### PR TITLE
Add PlanProgressEvaluator and wire plan progress into PostCommitHook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .jolli/
+.claude/settings.local.json

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/core/PlanProgressEvaluator.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/core/PlanProgressEvaluator.kt
@@ -1,0 +1,191 @@
+package ai.jolli.jollimemory.core
+
+import com.google.gson.Gson
+import com.google.gson.JsonObject
+
+/**
+ * PlanProgressEvaluator — Kotlin port of PlanProgressEvaluator.ts
+ *
+ * Pure, single-plan evaluator that calls the LLM to assess which plan steps
+ * moved forward in a commit. No registry access, no filesystem writes.
+ */
+object PlanProgressEvaluator {
+
+    private val log = JmLogger.create("PlanProgressEvaluator")
+    private val gson = Gson()
+    private const val MAX_TOKENS = 4096
+
+    private val VALID_STATUSES = setOf("completed", "in_progress", "not_started")
+
+    private val PLAN_PROGRESS_PROMPT = """You are JolliMemory, an AI development process documentation tool. Your task is to evaluate how much progress a developer made on a plan during a single coding session, based on the code diff, conversation summary topics, and the raw conversation transcript.
+
+## Plan (Markdown)
+{{planContent}}
+
+## Code Changes (git diff)
+```diff
+{{diff}}
+```
+
+## Conversation Summary Topics
+{{topics}}
+
+## Conversation Transcript
+{{conversation}}
+
+## Instructions
+
+Analyze the plan above and determine which steps moved forward in this session. You MUST:
+
+1. Produce a brief "summary" (1-2 sentences) of what the developer was working on overall in this session.
+2. For EVERY step in the plan, determine its status based on the diff:
+   - "completed" -- the diff fully implements this step
+   - "in_progress" -- the diff partially addresses this step
+   - "not_started" -- no evidence of progress on this step in the diff
+3. For steps that are "completed" or "in_progress", write a rationale-rich note:
+   - Cite specific decisions and trade-offs from the conversation topics (not just file names)
+   - Reference what triggered the work and any alternatives considered
+   - Scan the conversation transcript for human-flagged signals: things to revisit, questions to ask someone, concerns raised, deferred ideas -- and surface them in the relevant step note
+4. For steps that are "not_started", set note to null.
+
+## Output Format
+
+Return a single JSON object (no markdown fences, no explanation):
+
+{
+  "summary": "1-2 sentence summary of what the developer worked on",
+  "steps": [
+    { "id": "1", "description": "Step description from plan", "status": "completed", "note": "Rationale..." },
+    { "id": "2", "description": "Step description from plan", "status": "not_started", "note": null }
+  ]
+}
+
+## Rules
+1. Discover step IDs and descriptions directly from the plan markdown. Steps may be numbered (1, 2, 3), lettered (a, b, c), use headings (## Step 1), or checkboxes (- [ ]). Assign IDs in the order they appear.
+2. The diff is the PRIMARY evidence for status -- do not mark a step as "completed" unless the code changes clearly implement it.
+3. The topics and transcript provide CONTEXT for notes -- cite decisions, trade-offs, and reasoning that cannot be reconstructed from code alone.
+4. Keep notes concise (1-3 sentences each). Focus on the "why" and any flagged signals, not on restating what the code does.
+5. Return ONLY the JSON object. No surrounding text, no markdown fences."""
+
+    /** Renders topic summaries into a compact text block for the LLM prompt */
+    fun renderTopics(topics: List<TopicSummary>): String {
+        if (topics.isEmpty()) return "(no topics available)"
+
+        return topics.mapIndexed { i, t ->
+            val lines = mutableListOf(
+                "Topic ${i + 1}: ${t.title}",
+                "  Trigger: ${t.trigger}",
+                "  Decisions: ${t.decisions}",
+            )
+            if (!t.todo.isNullOrBlank()) lines.add("  Todo: ${t.todo}")
+            lines.joinToString("\n")
+        }.joinToString("\n\n")
+    }
+
+    /**
+     * Evaluates plan progress for a single plan against a commit's diff and conversation.
+     *
+     * Returns a partial PlanProgressArtifact (commit metadata fields are empty — caller fills them in),
+     * or null on any failure (fire-and-forget).
+     */
+    fun evaluatePlanProgress(
+        planMarkdown: String,
+        diff: String,
+        topics: List<TopicSummary>,
+        conversation: String,
+        apiKey: String,
+    ): PlanProgressArtifact? {
+        val topicsText = renderTopics(topics)
+
+        val prompt = PLAN_PROGRESS_PROMPT
+            .replace("{{planContent}}", planMarkdown)
+            .replace("{{diff}}", diff)
+            .replace("{{topics}}", topicsText)
+            .replace("{{conversation}}", conversation)
+
+        val model = Summarizer.resolveModelId("haiku")
+        val client = AnthropicClient(apiKey)
+
+        val startTime = System.currentTimeMillis()
+        val response = try {
+            client.createMessage(
+                model = model,
+                maxTokens = MAX_TOKENS,
+                temperature = 0.0,
+                messages = listOf(AnthropicClient.Message("user", prompt)),
+            )
+        } catch (e: Exception) {
+            log.warn("Plan progress LLM call failed: %s", e.message)
+            return null
+        }
+        val elapsed = System.currentTimeMillis() - startTime
+
+        val responseText = response.content.firstOrNull { it.type == "text" }?.text?.trim()
+        if (responseText.isNullOrEmpty()) {
+            log.warn("Plan progress LLM returned empty text")
+            return null
+        }
+
+        // Strip markdown code fences if present
+        var jsonText = responseText
+        val fenced = Regex("```(?:json)?\\s*([\\s\\S]*?)```").find(responseText)
+        if (fenced != null) {
+            jsonText = fenced.groupValues[1].trim()
+        }
+
+        // Parse JSON response
+        val parsed: JsonObject = try {
+            gson.fromJson(jsonText, JsonObject::class.java)
+        } catch (e: Exception) {
+            log.warn("Plan progress LLM returned invalid JSON: %s", responseText.take(200))
+            return null
+        }
+
+        // Validate structure
+        val summary = parsed.get("summary")?.takeIf { it.isJsonPrimitive }?.asString
+        val stepsArray = parsed.getAsJsonArray("steps")
+        if (summary == null || stepsArray == null) {
+            log.warn("Plan progress LLM response missing required fields (summary, steps)")
+            return null
+        }
+
+        // Validate and normalize steps
+        val steps = mutableListOf<PlanStep>()
+        for (element in stepsArray) {
+            if (!element.isJsonObject) continue
+            val stepObj = element.asJsonObject
+            val id = stepObj.get("id")?.takeIf { it.isJsonPrimitive }?.asString ?: continue
+            val description = stepObj.get("description")?.takeIf { it.isJsonPrimitive }?.asString ?: continue
+            val statusStr = stepObj.get("status")?.takeIf { it.isJsonPrimitive }?.asString ?: continue
+            val status = if (statusStr in VALID_STATUSES) {
+                PlanStepStatus.valueOf(statusStr)
+            } else {
+                PlanStepStatus.not_started
+            }
+            val note = stepObj.get("note")?.takeIf { it.isJsonPrimitive && !it.isJsonNull }?.asString
+
+            steps.add(PlanStep(id = id, description = description, status = status, note = note))
+        }
+
+        val llm = LlmCallMetadata(
+            model = response.model,
+            inputTokens = response.usage.inputTokens,
+            outputTokens = response.usage.outputTokens,
+            apiLatencyMs = elapsed,
+            stopReason = response.stopReason,
+        )
+
+        // Return partial result — commit metadata is filled in by the caller
+        return PlanProgressArtifact(
+            version = 1,
+            commitHash = "",
+            commitMessage = "",
+            commitDate = "",
+            planSlug = "",
+            originalSlug = "",
+            summary = summary,
+            steps = steps,
+            llm = llm,
+        )
+    }
+}

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/core/SummaryStore.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/core/SummaryStore.kt
@@ -132,7 +132,7 @@ class SummaryStore(private val cwd: String, private val git: GitOps) {
 
     // ── Write API ───────────────────────────────────────────────────────────
 
-    fun storeSummary(summary: CommitSummary, force: Boolean = false, transcript: StoredTranscript? = null) {
+    fun storeSummary(summary: CommitSummary, force: Boolean = false, transcript: StoredTranscript? = null, planProgress: List<PlanProgressArtifact>? = null) {
         val existingIndex = loadIndex()
         val entryMap = (existingIndex?.entries ?: emptyList()).associateBy { it.commitHash }.toMutableMap()
 
@@ -156,6 +156,11 @@ class SummaryStore(private val cwd: String, private val git: GitOps) {
         )
         if (transcript != null && transcript.sessions.isNotEmpty()) {
             files.add(FileWrite("transcripts/${summary.commitHash}.json", gson.toJson(transcript)))
+        }
+        if (!planProgress.isNullOrEmpty()) {
+            for (artifact in planProgress) {
+                files.add(FileWrite("plan-progress/${artifact.planSlug}.json", gson.toJson(artifact)))
+            }
         }
 
         writeFilesToBranch(files, "Add summary for ${summary.commitHash.take(8)}: ${summary.commitMessage.take(50)}")

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/core/Types.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/core/Types.kt
@@ -223,6 +223,32 @@ data class NoteReference(
     val jolliNoteDocId: Int? = null,
 )
 
+// ── Plan Progress types ────────────────────────────────────────────────────
+
+/** Status of a single step in a plan */
+enum class PlanStepStatus { completed, in_progress, not_started }
+
+/** A single step within a plan progress evaluation */
+data class PlanStep(
+    val id: String,
+    val description: String,
+    val status: PlanStepStatus,
+    val note: String? = null,
+)
+
+/** Result of evaluating plan progress against a commit */
+data class PlanProgressArtifact(
+    val version: Int = 1,
+    val commitHash: String,
+    val commitMessage: String,
+    val commitDate: String,
+    val planSlug: String,
+    val originalSlug: String,
+    val summary: String,
+    val steps: List<PlanStep>,
+    val llm: LlmCallMetadata,
+)
+
 /** Lightweight index entry for the summary index file */
 data class SummaryIndexEntry(
     val commitHash: String,

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/hooks/PostCommitHook.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/hooks/PostCommitHook.kt
@@ -2,6 +2,8 @@ package ai.jolli.jollimemory.hooks
 
 import ai.jolli.jollimemory.bridge.GitOps
 import ai.jolli.jollimemory.core.*
+import ai.jolli.jollimemory.services.PlanService
+import java.io.File
 import java.time.Instant
 
 /**
@@ -211,6 +213,53 @@ object PostCommitHook {
                 model = config.model,
             ))
 
+            // 8b. Detect uncommitted plans, archive, and evaluate progress
+            val planRefs = mutableListOf<PlanReference>()
+            val planProgressArtifacts = mutableListOf<PlanProgressArtifact>()
+
+            val uncommittedSlugs = detectUncommittedPlanSlugs(cwd)
+            if (uncommittedSlugs.isNotEmpty()) {
+                log.info("Detected %d uncommitted plan(s): %s", uncommittedSlugs.size, uncommittedSlugs.joinToString(", "))
+                val plansDir = File(System.getProperty("user.home"), ".claude/plans")
+                val topics: List<TopicSummary> = summaryResult.topics ?: emptyList()
+                val commitDate = Instant.parse(commitInfo.date).toString()
+
+                for (slug in uncommittedSlugs) {
+                    // Read plan markdown before archiving (retain for eval)
+                    val planFile = File(plansDir, "$slug.md")
+                    val planMarkdown = if (planFile.exists()) planFile.readText(Charsets.UTF_8) else null
+
+                    // Archive: renames slug to slug-hash in registry, stores plan on orphan branch
+                    val ref = PlanService.archivePlanForCommit(slug, commitInfo.hash, store, cwd)
+                    if (ref != null) {
+                        planRefs.add(ref)
+
+                        // Evaluate progress via Haiku LLM call
+                        if (planMarkdown != null) {
+                            val result = try {
+                                PlanProgressEvaluator.evaluatePlanProgress(
+                                    planMarkdown, diff, topics, conversation, apiKey,
+                                )
+                            } catch (e: Exception) {
+                                log.warn("Plan progress eval failed for %s: %s", slug, e.message)
+                                null
+                            }
+
+                            if (result != null) {
+                                planProgressArtifacts.add(result.copy(
+                                    commitHash = commitInfo.hash,
+                                    commitMessage = commitInfo.message,
+                                    commitDate = commitDate,
+                                    planSlug = ref.slug,
+                                    originalSlug = slug,
+                                ))
+                            }
+                        }
+                    }
+                }
+                log.info("Plan progress: evaluated %d/%d plan(s)", planProgressArtifacts.size, planRefs.size)
+            }
+
             // 9. Build and store CommitSummary
             val branch = git.getCurrentBranch() ?: "unknown"
             val commitType = detectCommitType()
@@ -230,6 +279,7 @@ object PostCommitHook {
                 stats = summaryResult.stats,
                 topics = summaryResult.topics,
                 ticketId = summaryResult.ticketId,
+                plans = planRefs.takeIf { it.isNotEmpty() },
             )
 
             // Store transcript data alongside summary
@@ -238,7 +288,7 @@ object PostCommitHook {
             }
             val storedTranscript = StoredTranscript(storedSessions)
 
-            store.storeSummary(summary, force = force, transcript = storedTranscript)
+            store.storeSummary(summary, force = force, transcript = storedTranscript, planProgress = planProgressArtifacts.takeIf { it.isNotEmpty() })
             log.info("=== PostCommitHook worker finished ===")
 
         } finally {
@@ -276,6 +326,15 @@ object PostCommitHook {
             reflogAction.startsWith("commit") -> CommitType.commit
             else -> CommitType.commit
         }
+    }
+
+    /** Returns slugs of plans in plans.json that are not yet committed and not ignored. */
+    private fun detectUncommittedPlanSlugs(cwd: String): Set<String> {
+        val registry = SessionTracker.loadPlansRegistry(cwd)
+        return registry.plans.entries
+            .filter { (_, entry) -> entry.commitHash == null && entry.ignored != true }
+            .map { (slug, _) -> slug }
+            .toSet()
     }
 
     private fun parseDiffStats(statOutput: String): DiffStats {


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## E2E Test (4)

### 1. Plan progress automatically evaluated after a commit

**Preconditions:** Have at least one active plan set up in JolliMemory (a plan that has not yet been committed and is not marked as ignored). Have a conversation session open with some topics recorded. Make sure the JolliMemory plugin is active and connected.

**Steps:**
1. Open your project in the IDE with the JolliMemory plugin active.
2. Make one or more code changes related to a step in your active plan.
3. Commit those changes using your normal git commit flow.
4. Wait for the JolliMemory post-commit process to finish (watch for the plugin's status indicator to settle).
5. Open the JolliMemory panel and navigate to the summary for the commit you just made.
6. Check whether the plan section shows each plan step with a status (completed, in progress, or not started) and a short note explaining what was done.

**Expected Results:**
- The commit summary should include a plan progress section listing every step from the active plan.
- Each step should show one of three statuses: completed, in progress, or not started.
- Steps marked completed or in progress should have a short note describing what was done and why, referencing decisions from the conversation.
- Steps with no evidence of progress should show "not started" with no note.

### 2. Plan progress artifact saved to storage after commit

**Preconditions:** Have at least one active, non-ignored plan in JolliMemory. Complete a commit so that the post-commit hook runs and plan progress is evaluated.

**Steps:**
1. Make a small code change and commit it while an active plan is present.
2. Wait for the JolliMemory post-commit process to complete.
3. Open the JolliMemory panel and look for the stored artifacts section or browse the commit's stored data.
4. Locate the plan progress entry for your active plan.
5. Open or expand the plan progress entry to view its contents.

**Expected Results:**
- A plan progress record should be saved and visible for the commit, identified by the plan's name.
- The record should contain the overall session summary, the list of steps with their statuses, and the commit details (hash, message, and date).
- The record should persist if you close and reopen the IDE or refresh the JolliMemory panel.

### 3. Multiple active plans each get their own progress evaluation

**Preconditions:** Have two or more active, non-ignored plans set up in JolliMemory before making a commit.

**Steps:**
1. With two or more active plans present, make a code change that touches work related to at least one of the plans.
2. Commit the changes using your normal git commit flow.
3. Wait for the JolliMemory post-commit process to finish.
4. Open the JolliMemory panel and view the commit summary.
5. Check that a separate plan progress entry exists for each active plan.

**Expected Results:**
- Each active plan should have its own separate progress entry in the commit summary.
- The steps and statuses in each entry should reflect that specific plan's content, not a combined or shared result.
- Plans whose steps were not touched by the commit should show all steps as "not started."

### 4. Ignored or already-committed plans are excluded from progress evaluation

**Preconditions:** Have one plan marked as ignored and one plan that was already committed in a previous session, alongside one new active plan.

**Steps:**
1. Make a code change and commit it while the ignored plan, the previously committed plan, and the new active plan are all present.
2. Wait for the JolliMemory post-commit process to finish.
3. Open the JolliMemory panel and view the plan progress section for this commit.

**Expected Results:**
- Only the new active plan should appear in the plan progress section.
- The ignored plan should not have a progress entry for this commit.
- The previously committed plan should not have a new progress entry for this commit.

---

## Summaries (2)

### 01 · Evaluate plan step progress automatically after each commit

**⚡ Why This Change**

After a commit is made, the team wanted JolliMemory to automatically assess which steps of an active plan were completed, partially addressed, or untouched — capturing that judgment while the context is fresh, without requiring manual input.

**💡 Decisions Behind the Code**

- **Partial result pattern**: The evaluator returns an artifact with empty commit metadata fields, which the caller fills in. This keeps the evaluator free of commit-context dependencies and easier to test in isolation.
- **Haiku model, fire-and-forget**: A lighter, faster model was chosen for this evaluation call, and failures are caught and logged rather than surfacing to the user — plan progress is valuable but not worth blocking or failing a commit hook.
- **Diff as primary evidence**: The LLM prompt explicitly instructs the model to treat the code diff as the authoritative signal for step status, with conversation topics used only for richer notes. This prevents the model from marking steps complete based on discussion alone.
- **Read markdown before archiving**: The plan file is read from disk before the archive step renames it, ensuring the evaluator always has the original content even if archiving mutates the slug.

**✅ What Was Implemented**

- Added `PlanProgressEvaluator` (new file) as a pure, stateless evaluator that sends plan markdown, the git diff, conversation topics, and the raw transcript to the Haiku LLM and parses the structured JSON response into typed step-level results.
- Added `PlanStep`, `PlanStepStatus`, and `PlanProgressArtifact` data types to `Types.kt`.
- Wired the evaluator into `PostCommitHook`: after archiving uncommitted plans, the hook reads each plan's markdown, calls the evaluator, fills in commit metadata on the partial result, and collects artifacts.
- Extended `SummaryStore.storeSummary` to accept a list of plan progress artifacts and write each to `plan-progress/<slug>.json` on the orphan branch.
- Added `detectUncommittedPlanSlugs` helper in `PostCommitHook` to filter the plans registry to only active, non-ignored plans.

### 02 · Store plan progress artifacts alongside commit summaries on orphan branch

**⚡ Why This Change**

Once plan progress was being evaluated, the results needed a persistent home — written to the same orphan branch as other JolliMemory artifacts so they could be retrieved later without polluting the working tree.

**💡 Decisions Behind the Code**

- **Co-located with existing artifact writes**: Reusing the existing batch file-write mechanism meant no new branch operations or locking concerns — plan progress lands atomically with the rest of the commit record.
- **Keyed by slug, not commit hash**: Files are named by plan slug rather than commit hash so the latest progress for a plan is always at a predictable path, making future reads straightforward without an index lookup.

**✅ What Was Implemented**

- Extended `SummaryStore.storeSummary` signature to accept an optional list of plan progress artifacts.
- Each artifact is serialized to JSON and queued as a file write at `plan-progress/<slug>.json` within the same atomic branch write that stores the commit summary and transcript.

---

*Generated by Jolli Memory · April 16, 2026 at 11:57 AM*
<!-- jollimemory-summary-end -->