### PR TITLE
Add pre-squash state snapshot and auto-restore on failure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .jolli/
 .claude/settings.json
+.claude/settings.local.json
 .claude/skills/
 .gemini/

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/actions/SquashAction.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/actions/SquashAction.kt
@@ -130,6 +130,18 @@ class SquashAction : AnAction() {
                         ApplicationManager.getApplication().executeOnPooledThread {
                             indicator.text = "Squashing commits..."
 
+                            // Snapshot index and HEAD for safe restore on failure
+                            val originalIndexTree = git.writeTree()
+                            val originalHead = git.getHeadHash()
+                            if (originalIndexTree == null || originalHead == null) {
+                                ApplicationManager.getApplication().invokeLater {
+                                    Messages.showErrorDialog(project,
+                                        "Could not snapshot the current git state. Squash aborted to avoid data loss.",
+                                        "Jolli Memory")
+                                }
+                                return@executeOnPooledThread
+                            }
+
                             // Order oldest-first (matching VS Code SquashCommand behavior).
                             // getBranchCommits() and getSelectedCommits() return newest-first.
                             val orderedCommits = commits.reversed()
@@ -160,24 +172,27 @@ class SquashAction : AnAction() {
                             SessionTracker.savePluginSource(cwd)
                             SessionTracker.saveSquashPending(hashes, forkPoint, cwd)
 
-                            // Step 3: Soft reset to fork point (stages all changes)
-                            val resetResult = git.exec("reset", "--soft", forkPoint)
-                            log.info("git reset --soft %s → %s", forkPoint.take(8),
-                                if (resetResult != null) "ok" else "FAILED")
+                            try {
+                                // Step 3: Soft reset to fork point (stages all changes)
+                                val resetResult = git.exec("reset", "--soft", forkPoint)
+                                if (resetResult == null) throw RuntimeException("git reset --soft failed")
+                                log.info("git reset --soft %s → ok", forkPoint.take(8))
 
-                            // Step 4: Create the squash commit
-                            val commitResult = git.exec("commit", "-m", edited)
-                            if (commitResult == null) {
-                                log.error("git commit failed after reset --soft")
+                                // Step 4: Create the squash commit
+                                val commitResult = git.exec("commit", "-m", edited)
+                                if (commitResult == null) throw RuntimeException("git commit failed after reset")
+                                log.info("Squash commit created successfully")
+                            } catch (ex: Exception) {
+                                log.error("Squash failed, restoring state: %s", ex.message)
+                                git.exec("reset", "--soft", originalHead)
+                                git.readTree(originalIndexTree)
                                 ApplicationManager.getApplication().invokeLater {
                                     Messages.showErrorDialog(project,
-                                        "Squash failed: git commit returned an error after reset. " +
-                                            "Your changes are staged — you can commit manually.",
+                                        "Squash failed: ${ex.message}\n\nYour staging area and HEAD have been restored.",
                                         "Jolli Memory")
                                 }
                                 return@executeOnPooledThread
                             }
-                            log.info("Squash commit created successfully")
 
                             // Step 5: Optional force push (matching VS Code "Squash & Push")
                             if (shouldPush) {


### PR DESCRIPTION
# Add pre-squash state snapshot and auto-restore on failure

- **Commit:** `37b77f55dd40e5dbb6153abc0572624a1d99d1a6`
- **Branch:** `fix/auto-restore-staging`
- **Author:** Jordan
- **Date:** April 16, 2026 at 2:18 PM
- **Duration:** 1 day
- **Changes:** 2 files changed, +28 insertions, −12 deletions

---

## E2E Test (1)

### 1. Git state is restored automatically when squash fails midway

**Preconditions:** Have a local Git repository open in the JolliMemory plugin with at least 2 commits on the current branch that can be selected for squashing. Note the current commit history and any staged changes before starting.

**Steps:**
1. Open the JolliMemory panel and select 2 or more commits to squash.
2. When prompted, edit the commit message and confirm to begin the squash.
3. Simulate a failure during the squash (for example, by temporarily revoking write permissions on the repository folder, or by working with a reviewer who can trigger the failure condition in a test environment).
4. Wait for the error dialog to appear.
5. Check the error dialog message that is shown.
6. Open your Git history or source control panel and verify the repository state.

**Expected Results:**
- An error dialog appears with a message that includes "Your staging area and HEAD have been restored."
- The dialog does NOT say anything about "your changes are staged — you can commit manually."
- The Git history shows the original commits are still intact, exactly as they were before the squash was attempted.
- No unexpected staged changes appear in the source control panel — the working state matches what it was before the squash started.

---

## Summary (1)

### 01 · Auto-restore git state when squash operation fails midway `feature`

**⚡ Why This Change**

If the squash operation failed after the soft reset but before the new commit was created, the repository would be left in a broken intermediate state — staged changes with no commit — and the user would have to manually recover.

**💡 Decisions Behind the Code**

- **Snapshot before mutation**: Taking a snapshot of both HEAD and the index tree before any destructive git commands means recovery is deterministic — no guessing what state to return to, and no reliance on git's own undo mechanisms being available.
- **Abort early if snapshot fails**: If the snapshot itself cannot be taken, the operation is cancelled entirely rather than proceeding without a safety net, prioritising data safety over convenience.
- **Restore both HEAD and index**: Resetting only HEAD would leave the index out of sync; restoring both returns the working environment to exactly the pre-squash state, avoiding subtle follow-on issues for the user.
- **Try/catch over per-step null checks**: Wrapping the multi-step sequence in a single try/catch with a shared recovery block reduces branching and makes the failure path easier to reason about and maintain.

**✅ What Was Implemented**

- Before beginning the destructive steps, `SquashAction.kt` now captures a snapshot of both the current HEAD hash and the index tree (via `git.writeTree()` and `git.getHeadHash()`), aborting early if either cannot be read.
- The soft reset and commit steps are wrapped in a try/catch; on any failure, the code runs a soft reset back to the original HEAD and restores the index tree, then shows an updated error dialog telling the user their state has been restored.
- The error message was updated from "your changes are staged — commit manually" to "your staging area and HEAD have been restored," reflecting the new recovery guarantee.
- `settings.local.json` was added to `.gitignore`.

**📁 FILES**
- `intellij/src/main/kotlin/ai/jolli/jollimemory/actions/SquashAction.kt`
- `.gitignore`

---

*Generated by Jolli Memory · April 17, 2026 at 3:23 PM*