### PR TITLE
Block actions while worker is busy and batch file staging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .jolli/
 .claude/settings.json
+.claude/settings.local.json
 .claude/skills/
 .gemini/

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/actions/CommitAIAction.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/actions/CommitAIAction.kt
@@ -278,7 +278,10 @@ class CommitAIAction : AnAction() {
     }
 
     override fun update(e: AnActionEvent) {
-        val status = e.project?.getService(JolliMemoryService::class.java)?.getStatus()
-        e.presentation.isEnabled = status != null && status.enabled
+        val service = e.project?.getService(JolliMemoryService::class.java)
+        val status = service?.getStatus()
+        val cwd = service?.mainRepoRoot ?: e.project?.basePath
+        val workerBusy = cwd != null && SessionTracker.isWorkerBusy(cwd)
+        e.presentation.isEnabled = status != null && status.enabled && !workerBusy
     }
 }

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/actions/PushAction.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/actions/PushAction.kt
@@ -1,5 +1,6 @@
 package ai.jolli.jollimemory.actions
 
+import ai.jolli.jollimemory.core.SessionTracker
 import ai.jolli.jollimemory.services.JolliMemoryService
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
@@ -17,7 +18,15 @@ class PushAction : AnAction() {
     override fun actionPerformed(e: AnActionEvent) {
         val project = e.project ?: return
         val service = project.getService(JolliMemoryService::class.java)
+        val cwd = service.mainRepoRoot ?: project.basePath ?: return
         val git = service.getGitOps() ?: return
+
+        if (SessionTracker.isWorkerBusy(cwd)) {
+            Messages.showWarningDialog(project,
+                "AI summary is being generated. Please wait a moment.",
+                "Jolli Memory")
+            return
+        }
 
         ProgressManager.getInstance().run(object : Task.Backgroundable(project, "Jolli Memory: Pushing...", false) {
             override fun run(indicator: ProgressIndicator) {
@@ -49,7 +58,10 @@ class PushAction : AnAction() {
     }
 
     override fun update(e: AnActionEvent) {
-        val status = e.project?.getService(JolliMemoryService::class.java)?.getStatus()
-        e.presentation.isEnabled = status != null && status.enabled
+        val service = e.project?.getService(JolliMemoryService::class.java)
+        val status = service?.getStatus()
+        val cwd = service?.mainRepoRoot ?: e.project?.basePath
+        val workerBusy = cwd != null && SessionTracker.isWorkerBusy(cwd)
+        e.presentation.isEnabled = status != null && status.enabled && !workerBusy
     }
 }

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/actions/SquashAction.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/actions/SquashAction.kt
@@ -48,6 +48,14 @@ class SquashAction : AnAction() {
         val service = project.getService(JolliMemoryService::class.java)
         val git = service.getGitOps() ?: return
         val cwd = service.mainRepoRoot ?: project.basePath ?: return
+
+        if (SessionTracker.isWorkerBusy(cwd)) {
+            Messages.showWarningDialog(project,
+                "AI summary is being generated. Please wait a moment.",
+                "Jolli Memory")
+            return
+        }
+
         val config = SessionTracker.loadConfig(cwd)
 
         // Get selected commits from CommitsPanel if available, otherwise use all branch commits
@@ -215,8 +223,11 @@ class SquashAction : AnAction() {
     }
 
     override fun update(e: AnActionEvent) {
-        val status = e.project?.getService(JolliMemoryService::class.java)?.getStatus()
-        e.presentation.isEnabled = status != null && status.enabled
+        val service = e.project?.getService(JolliMemoryService::class.java)
+        val status = service?.getStatus()
+        val cwd = service?.mainRepoRoot ?: e.project?.basePath
+        val workerBusy = cwd != null && SessionTracker.isWorkerBusy(cwd)
+        e.presentation.isEnabled = status != null && status.enabled && !workerBusy
     }
 }
 

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/bridge/GitOps.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/bridge/GitOps.kt
@@ -188,18 +188,16 @@ class GitOps(private val projectDir: String) {
         return output.lines().filter { it.isNotBlank() }
     }
 
-    /** Stages one or more files. */
+    /** Stages one or more files in a single git command. */
     fun stageFiles(paths: List<String>) {
-        for (path in paths) {
-            exec("add", path)
-        }
+        if (paths.isEmpty()) return
+        exec(*( listOf("add", "--") + paths ).toTypedArray())
     }
 
-    /** Unstages one or more tracked files. */
+    /** Unstages one or more tracked files in a single git command. */
     fun unstageFiles(paths: List<String>) {
-        for (path in paths) {
-            exec("restore", "--staged", path)
-        }
+        if (paths.isEmpty()) return
+        exec(*( listOf("restore", "--staged", "--") + paths ).toTypedArray())
     }
 
     /**


### PR DESCRIPTION
# Block actions while worker is busy and batch file staging args

- **Commit:** `5bcb4b1f419765893c4f03152ad6a4939dc8f118`
- **Branch:** `fix/block-actions-batch-file-staging`
- **Author:** Jordan
- **Date:** April 16, 2026 at 1:55 PM
- **Duration:** 1 day
- **Changes:** 5 files changed, +39 insertions, −14 deletions

---

## E2E Test (3)

### 1. Buttons disabled while AI summary is generating

**Preconditions:** Have a Git repository open in the IDE with the Jolli Memory plugin active and at least one staged file ready to commit.

**Steps:**
1. Stage one or more files so the Commit, Push, and Squash buttons are normally enabled.
2. Trigger an AI summary generation (for example, by opening the Jolli Memory panel so the background worker starts processing).
3. While the summary is still being generated, look at the Commit, Push, and Squash action buttons in the toolbar or menu.
4. Verify that all three buttons appear greyed out and cannot be clicked during generation.
5. Wait for the AI summary to finish generating.
6. Verify that the Commit, Push, and Squash buttons become active and clickable again.

**Expected Results:**
- While the AI worker is running, the Commit, Push, and Squash buttons should be visually disabled (greyed out) and unresponsive to clicks.
- Once the AI summary finishes, all three buttons should return to their normal enabled state.

### 2. Warning dialog when triggering Push or Squash while AI is busy

**Preconditions:** Have a Git repository open with the Jolli Memory plugin active and an AI summary generation in progress.

**Steps:**
1. While the AI summary is actively being generated in the background, attempt to trigger the Push action (for example, via the right-click context menu or keyboard shortcut if the button is briefly enabled).
2. Verify that a warning dialog appears instead of the push proceeding.
3. Close the dialog and attempt to trigger the Squash action the same way.
4. Verify that the same warning dialog appears for Squash as well.

**Expected Results:**
- A dialog box titled "Jolli Memory" should appear with the message "AI summary is being generated. Please wait a moment."
- Neither the push nor the squash operation should start while the warning is shown.
- Dismissing the dialog should return the user to the normal IDE view without any git operation having run.

### 3. Staging multiple files at once

**Preconditions:** Have a Git repository open with at least 5 unstaged modified files.

**Steps:**
1. Open the Jolli Memory panel and navigate to the file list showing unstaged changes.
2. Select all 5 or more unstaged files at once.
3. Click the button to stage the selected files.
4. Verify that all selected files move to the staged section immediately.
5. Repeat the test by selecting all staged files and clicking unstage, then verify all files move back to the unstaged section at once.

**Expected Results:**
- All selected files should move to the staged area in one smooth action with no noticeable delay or file-by-file flickering.
- After unstaging, all files should return to the unstaged area together.
- The final staged and unstaged counts in the panel should match the number of files moved.

---

## Summaries (2)

### 01 · Disable UI actions while AI summary generation is in progress `ux`

**⚡ Why This Change**

Users could trigger commit, push, or squash actions while the AI worker was still generating a summary in the background, potentially causing conflicts or inconsistent state.

**💡 Decisions Behind the Code**

- **Two-layer protection**: The `update()` method disables the button visually, but a runtime guard was also added inside `actionPerformed()` as a safety net in case the action is invoked programmatically or the UI state is stale. This trades a small amount of extra code for stronger correctness guarantees.
- **Fallback path resolution**: The repo root is resolved from the service's `mainRepoRoot` first, falling back to the project base path, so the busy check works even before the service is fully initialized without crashing.

**✅ What Was Implemented**

- Added worker-busy checks to the `update()` method of all three action classes (`CommitAIAction`, `PushAction`, `SquashAction`), disabling the UI button when the worker is active for the current repo.
- Added runtime guards at the top of `actionPerformed()` in `PushAction` and `SquashAction` that show a warning dialog if the user somehow triggers the action while the worker is busy.
- Both checks resolve the working directory via `mainRepoRoot` with a fallback to `project.basePath`.

**📁 FILES**
- `intellij/src/main/kotlin/ai/jolli/jollimemory/actions/CommitAIAction.kt`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/actions/PushAction.kt`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/actions/SquashAction.kt`

### 02 · Batch file staging and unstaging into single git commands `performance`

**⚡ Why This Change**

File staging and unstaging were issuing one git process per file, which is inefficient when many files are involved at once.

**💡 Decisions Behind the Code**

- **Single process call over a loop**: Spawning one process per file has meaningful overhead at scale; batching all paths into one command reduces that to a constant cost regardless of file count. The `--` separator was added to safely handle filenames that could be mistaken for flags.
- **Empty-list guard**: Calling git with no file arguments would be an error or a no-op with unintended side effects, so an early return was added to keep behavior predictable without relying on git's own argument validation.

**✅ What Was Implemented**

- `stageFiles` in `GitOps` now calls `git add -- <file1> <file2> ...` in a single process invocation instead of looping.
- `unstageFiles` similarly calls `git restore --staged -- <file1> <file2> ...` in a single invocation.
- Both methods now short-circuit and return immediately when the input list is empty.

**📁 FILES**
- `intellij/src/main/kotlin/ai/jolli/jollimemory/bridge/GitOps.kt`

---

*Generated by Jolli Memory · April 17, 2026 at 3:23 PM*