### PR TITLE
Deduplicate in-flight git queries in CommitsPanel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .jolli/
 .claude/settings.json
+.claude/settings.local.json
 .claude/skills/
 .gemini/

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/CommitsPanel.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/CommitsPanel.kt
@@ -18,6 +18,8 @@ import com.intellij.util.ui.JBUI
 import git4idea.repo.GitRepository
 import git4idea.repo.GitRepositoryChangeListener
 import java.awt.BorderLayout
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.ConcurrentHashMap
 import java.awt.Color
 import java.awt.Component
 import java.awt.Cursor
@@ -77,8 +79,9 @@ class CommitsPanel(
     )
     private val checkedHashes = mutableSetOf<String>()
     private var commits: List<CommitSummaryBrief> = emptyList()
-    /** Cache of files per commit hash — avoids re-running git for expanded commits. */
-    private val fileCache = mutableMapOf<String, List<CommitFileInfo>>()
+    /** Cache of files per commit hash — avoids re-running git for expanded commits.
+     *  Stores a CompletableFuture so that concurrent expands share the same in-flight request. */
+    private val fileCache = ConcurrentHashMap<String, CompletableFuture<List<CommitFileInfo>>>()
     /** Per-commit UI state for expand/collapse and checkbox management. */
     private val commitRowStates = mutableMapOf<String, CommitRowState>()
     /** True when the branch is fully merged into main (read-only history view). */
@@ -381,7 +384,7 @@ class CommitsPanel(
         listPanel.repaint()
     }
 
-    /** Lazily loads commit files on first expansion. */
+    /** Lazily loads commit files on first expansion, deduplicating in-flight git queries. */
     private fun loadCommitFiles(hash: String) {
         val state = commitRowStates[hash] ?: return
 
@@ -394,24 +397,36 @@ class CommitsPanel(
         })
         state.fileContainer.revalidate()
 
-        ApplicationManager.getApplication().executeOnPooledThread {
-            val files = fileCache.getOrPut(hash) { service.listCommitFiles(hash) }
+        // If a future already exists for this hash, reuse it (dedup in-flight requests).
+        // computeIfAbsent is atomic on ConcurrentHashMap, so only one thread creates the future.
+        val future = fileCache.computeIfAbsent(hash) {
+            CompletableFuture.supplyAsync(
+                { service.listCommitFiles(hash) },
+                { cmd -> ApplicationManager.getApplication().executeOnPooledThread(cmd) },
+            )
+        }
+
+        future.whenComplete { files, error ->
+            if (error != null) {
+                fileCache.remove(hash)
+            }
             SwingUtilities.invokeLater {
                 val currentState = commitRowStates[hash] ?: return@invokeLater
                 currentState.fileContainer.removeAll()
 
-                if (files.isEmpty()) {
-                    currentState.fileContainer.add(JLabel("(no files)").apply {
+                val result = files ?: emptyList()
+                if (result.isEmpty()) {
+                    currentState.fileContainer.add(JLabel(if (error != null) "(failed to load)" else "(no files)").apply {
                         foreground = Color.GRAY
                         border = JBUI.Borders.empty(2, 28)
                         alignmentX = Component.LEFT_ALIGNMENT
                     })
                 } else {
-                    for (file in files) {
+                    for (file in result) {
                         currentState.fileContainer.add(createFileRow(hash, file))
                     }
                 }
-                currentState.filesLoaded = true
+                currentState.filesLoaded = error == null
                 currentState.fileContainer.revalidate()
                 currentState.fileContainer.repaint()
             }


### PR DESCRIPTION
# Deduplicate in-flight git queries in CommitsPanel file cache

- **Commit:** `61689cfb840e1e1762b9221b491b25e179ed008b`
- **Branch:** `fix/deduplicate-git-queries`
- **Author:** Jordan
- **Date:** April 16, 2026 at 3:04 PM
- **Duration:** 1 day
- **Changes:** 2 files changed, +25 insertions, −9 deletions

---

## E2E Test (2)

### 1. No duplicate loading when expanding a commit twice quickly

**Preconditions:** Have the JolliMemory plugin open in IntelliJ with a Git repository that has at least one commit with changed files visible in the Commits panel.

**Steps:**
1. Open the Commits panel in the JolliMemory tool window.
2. Find any commit entry in the list and click to expand it — then immediately click to collapse it and expand it again as fast as possible (within about one second).
3. Wait a moment for the file list to finish loading.
4. Check that the expanded commit shows its list of changed files normally, with no duplicate file entries and no blank or broken section.
5. Collapse and re-expand the same commit a second time and verify the files appear instantly without reloading.

**Expected Results:**
- Each file changed in that commit appears exactly once in the expanded view — no duplicates.
- The file list loads correctly and displays normally after the rapid double-expand.
- On the second expand (after collapsing), the files reappear immediately from the cache with no delay.

### 2. Error state shown when a commit's files fail to load

**Preconditions:** Have the JolliMemory plugin open in IntelliJ. To simulate a failure, temporarily disconnect from the repository or use a commit hash that cannot be resolved (for example, by testing in an environment where git commands are blocked).

**Steps:**
1. Open the Commits panel in the JolliMemory tool window.
2. Click to expand a commit whose files cannot be loaded (due to a git error or network issue).
3. Wait a few seconds for the loading attempt to complete.
4. Check what message appears inside the expanded commit row.
5. Collapse the commit, then expand it again to confirm it retries the load rather than staying stuck.

**Expected Results:**
- The expanded commit row displays a grey "(failed to load)" message instead of a file list.
- After collapsing and re-expanding, the panel attempts to load the files again (it does not permanently cache the failure).

---

## Summary (1)

### 01 · Prevent duplicate git queries when expanding the same commit twice quickly `bugfix`

**⚡ Why This Change**

When a user rapidly expanded the same commit entry, or two expansions triggered close together, the panel would fire multiple git queries for the same commit hash — wasting resources and potentially causing race conditions in the UI.

**💡 Decisions Behind the Code**

- **Atomic deduplication over locking**: Using `ConcurrentHashMap.computeIfAbsent` makes the "check-then-create" step atomic without explicit locks, keeping the code simple and avoiding deadlock risk.
- **Cache the future, not the result**: Storing the future rather than the finished list means concurrent callers can attach callbacks to the same in-flight operation rather than each launching their own, which is the core fix for the race.
- **Evict on failure**: Removing the cache entry when a query fails lets the user retry by collapsing and re-expanding, rather than permanently caching a broken state — a safer default for a tool window.

**✅ What Was Implemented**

- Changed `fileCache` in `CommitsPanel` from a plain mutable map holding results to a `ConcurrentHashMap` holding `CompletableFuture` values, so the cache entry is created atomically before the work completes.
- Used `computeIfAbsent` to guarantee only one future is created per hash even under concurrent access; subsequent callers reuse the same in-flight future.
- Replaced the manual `executeOnPooledThread` + result assignment pattern with `CompletableFuture.supplyAsync`, using `executeOnPooledThread` as the executor.
- Added error handling in the `whenComplete` callback: removes the cache entry on failure (so a retry is possible), shows a "(failed to load)" label in the UI, and marks `filesLoaded` as false so the state stays consistent.

**📁 FILES**
- `intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/CommitsPanel.kt`

---

*Generated by Jolli Memory · April 17, 2026 at 3:24 PM*