### PR TITLE
Add privacy consent notice to settings page and use new icon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,36 @@
+# IDE
+.idea/
+*.iml
+*.ipr
+*.iws
+
+# Gradle
+.gradle/
+build/
+
+# Kotlin / Java artifacts
+*.class
+*.jar
+*.war
+*.ear
+
+# Re-include Gradle wrapper jar
+!**/gradle/wrapper/gradle-wrapper.jar
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Editor
+.vscode/
+*.swp
+*~
+
+# Environment
+.env
+.env.*
+
+# Jolli / Claude
 .jolli/
 .claude/
 .gemini/

--- a/intellij/build.gradle.kts
+++ b/intellij/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 }
 
 group = "ai.jolli"
-version = "0.97.8"
+version = "0.97.9"
 
 repositories {
     mavenCentral()
@@ -132,6 +132,13 @@ intellijPlatform {
             </p>
         """.trimIndent()
         changeNotes = """
+            <h3>0.97.9</h3>
+            <ul>
+                <li><b>Privacy consent notice</b> &mdash; display a privacy notice with link to
+                    privacy policy at the top of the Settings page, satisfying JetBrains Marketplace
+                    guideline 2.2 for explicit user consent before data processing</li>
+            </ul>
+
             <h3>0.97.8</h3>
             <ul>
                 <li><b>Fix scheduled-for-removal API</b> &mdash; replace <code>PluginId.findId()</code>

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/settings/JolliMemoryConfigurable.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/settings/JolliMemoryConfigurable.kt
@@ -41,7 +41,17 @@ class JolliMemoryConfigurable(private val project: Project) : Configurable {
         // Load current values
         loadFromConfig()
 
+        val privacyNotice = JBLabel(
+            "<html>By providing an API key, you consent to sending code diffs and AI session " +
+            "transcripts to third-party AI providers (e.g., Anthropic). " +
+            "<a href=\"https://github.com/Jolli-sample-repos/privacy/blob/main/privacy.md\">Privacy Policy</a></html>"
+        ).apply {
+            setCopyable(true)
+        }
+
         return FormBuilder.createFormBuilder()
+            .addComponent(privacyNotice)
+            .addSeparator()
             .addLabeledComponent(JBLabel("Anthropic API Key:"), apiKeyField!!, 1, false)
             .addTooltip("Required for AI commit summaries. Get yours at console.anthropic.com")
             .addLabeledComponent(JBLabel("Model:"), modelField!!, 1, false)

--- a/intellij/src/main/resources/META-INF/pluginIcon.svg
+++ b/intellij/src/main/resources/META-INF/pluginIcon.svg
@@ -1,4 +1,25 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 40 40" fill="none">
-  <rect x="4" y="12" width="24" height="20" rx="3" stroke="#6B7280" stroke-width="2" fill="#6B7280" fill-opacity="0.08" opacity="0.5"/>
-  <rect x="12" y="6" width="24" height="20" rx="3" stroke="#6B7280" stroke-width="2.5" fill="#6B7280" fill-opacity="0.08"/>
+<svg width="40" height="40" viewBox="0 0 61 56" xmlns="http://www.w3.org/2000/svg">
+  <g stroke="#D9D5F8" stroke-width="2.2" stroke-linecap="round" fill="none" opacity="0.95">
+    <!-- outer connections -->
+    <line x1="29.25" y1="6.88" x2="5.50" y2="25.67"/>
+    <line x1="29.25" y1="6.88" x2="50.05" y2="18.21"/>
+    <line x1="5.5" y1="25.67" x2="11.65" y2="49.42"/>
+    <line x1="11.65" y1="49.42" x2="53.70" y2="40.68"/>
+    <line x1="53.70" y1="40.68" x2="50.05" y2="18.21"/>
+
+    <!-- center connections -->
+    <line x1="29.05" y1="30.48" x2="29.25" y2="6.88"/>
+    <line x1="29.05" y1="30.48" x2="5.50" y2="25.67"/>
+    <line x1="29.05" y1="30.48" x2="50.05" y2="18.21"/>
+    <line x1="29.05" y1="30.48" x2="11.65" y2="49.42"/>
+    <line x1="29.05" y1="30.48" x2="53.70" y2="40.68"/>
+  </g>
+
+  <!-- nodes -->
+  <circle cx="29.25" cy="6.88" r="6.98" fill="#3C7BE6"/>
+  <circle cx="50.05" cy="18.21" r="5.53" fill="#11B4CF"/>
+  <circle cx="5.5" cy="25.67" r="5.17" fill="#5A9CF2"/>
+  <circle cx="53.70" cy="40.68" r="6.96" fill="#6A66F0"/>
+  <circle cx="11.65" cy="49.42" r="6.02" fill="#A788F2"/>
+  <circle cx="29.05" cy="30.48" r="7.82" fill="#7A3FF0"/>
 </svg>

--- a/intellij/src/main/resources/META-INF/pluginIcon_dark.svg
+++ b/intellij/src/main/resources/META-INF/pluginIcon_dark.svg
@@ -1,4 +1,28 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 40 40" fill="none">
-  <rect x="4" y="12" width="24" height="20" rx="3" stroke="#AFB8C1" stroke-width="2" fill="#AFB8C1" fill-opacity="0.08" opacity="0.5"/>
-  <rect x="12" y="6" width="24" height="20" rx="3" stroke="#AFB8C1" stroke-width="2.5" fill="#AFB8C1" fill-opacity="0.08"/>
+<svg width="40" height="40" viewBox="0 0 61 56" xmlns="http://www.w3.org/2000/svg">
+
+  <!-- Edges -->
+  <g stroke="#8F88D8" stroke-width="2.4" stroke-linecap="round" fill="none" opacity="0.9">
+    <!-- outer connections -->
+    <line x1="29.25" y1="6.88" x2="5.50" y2="25.67"/>
+    <line x1="29.25" y1="6.88" x2="50.05" y2="18.21"/>
+    <line x1="5.5" y1="25.67" x2="11.65" y2="49.42"/>
+    <line x1="11.65" y1="49.42" x2="53.70" y2="40.68"/>
+    <line x1="53.70" y1="40.68" x2="50.05" y2="18.21"/>
+
+    <!-- center connections -->
+    <line x1="29.05" y1="30.48" x2="29.25" y2="6.88"/>
+    <line x1="29.05" y1="30.48" x2="5.50" y2="25.67"/>
+    <line x1="29.05" y1="30.48" x2="50.05" y2="18.21"/>
+    <line x1="29.05" y1="30.48" x2="11.65" y2="49.42"/>
+    <line x1="29.05" y1="30.48" x2="53.70" y2="40.68"/>
+  </g>
+
+  <!-- nodes -->
+  <circle cx="29.25" cy="6.88" r="6.98" fill="#4C8CFF"/>
+  <circle cx="50.05" cy="18.21" r="5.53" fill="#20D4E8"/>
+  <circle cx="5.5" cy="25.67" r="5.17" fill="#6FB3FF"/>
+  <circle cx="53.70" cy="40.68" r="6.96" fill="#7B7BFF"/>
+  <circle cx="11.65" cy="49.42" r="6.02" fill="#C3A6FF"/>
+  <circle cx="29.05" cy="30.48" r="7.82" fill="#9B5CFF"/>
+
 </svg>

--- a/intellij/src/main/resources/icons/jollimemory.svg
+++ b/intellij/src/main/resources/icons/jollimemory.svg
@@ -1,4 +1,22 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 13 13" fill="none">
-  <rect x="0.5" y="3.5" width="9" height="7" rx="1.2" stroke="#6B7280" stroke-width="1" fill="#6B7280" fill-opacity="0.08" opacity="0.5"/>
-  <rect x="3.5" y="1.5" width="9" height="7" rx="1.2" stroke="#6B7280" stroke-width="1.2" fill="#6B7280" fill-opacity="0.08"/>
+<svg width="13" height="13" viewBox="0 0 61 56" xmlns="http://www.w3.org/2000/svg">
+  <g stroke="#D9D5F8" stroke-width="1.4" stroke-linecap="round" fill="none" opacity="0.95">
+    <line x1="29.25" y1="6.88" x2="5.50" y2="25.67"/>
+    <line x1="29.25" y1="6.88" x2="50.05" y2="18.21"/>
+    <line x1="5.5" y1="25.67" x2="11.65" y2="49.42"/>
+    <line x1="11.65" y1="49.42" x2="53.70" y2="40.68"/>
+    <line x1="53.70" y1="40.68" x2="50.05" y2="18.21"/>
+
+    <line x1="29.05" y1="30.48" x2="29.25" y2="6.88"/>
+    <line x1="29.05" y1="30.48" x2="5.50" y2="25.67"/>
+    <line x1="29.05" y1="30.48" x2="50.05" y2="18.21"/>
+    <line x1="29.05" y1="30.48" x2="11.65" y2="49.42"/>
+    <line x1="29.05" y1="30.48" x2="53.70" y2="40.68"/>
+  </g>
+
+  <circle cx="29.25" cy="6.88" r="5.5" fill="#3C7BE6"/>
+  <circle cx="50.05" cy="18.21" r="4.5" fill="#11B4CF"/>
+  <circle cx="5.5" cy="25.67" r="4.2" fill="#5A9CF2"/>
+  <circle cx="53.70" cy="40.68" r="5.5" fill="#6A66F0"/>
+  <circle cx="11.65" cy="49.42" r="4.8" fill="#A788F2"/>
+  <circle cx="29.05" cy="30.48" r="6.2" fill="#7A3FF0"/>
 </svg>

--- a/intellij/src/main/resources/icons/jollimemory_dark.svg
+++ b/intellij/src/main/resources/icons/jollimemory_dark.svg
@@ -1,4 +1,22 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 13 13" fill="none">
-  <rect x="0.5" y="3.5" width="9" height="7" rx="1.2" stroke="#AFB8C1" stroke-width="1" fill="#AFB8C1" fill-opacity="0.08" opacity="0.5"/>
-  <rect x="3.5" y="1.5" width="9" height="7" rx="1.2" stroke="#AFB8C1" stroke-width="1.2" fill="#AFB8C1" fill-opacity="0.08"/>
+<svg width="13" height="13" viewBox="0 0 61 56" xmlns="http://www.w3.org/2000/svg">
+  <g stroke="#8F88D8" stroke-width="1.5" stroke-linecap="round" fill="none" opacity="0.9">
+    <line x1="29.25" y1="6.88" x2="5.50" y2="25.67"/>
+    <line x1="29.25" y1="6.88" x2="50.05" y2="18.21"/>
+    <line x1="5.5" y1="25.67" x2="11.65" y2="49.42"/>
+    <line x1="11.65" y1="49.42" x2="53.70" y2="40.68"/>
+    <line x1="53.70" y1="40.68" x2="50.05" y2="18.21"/>
+
+    <line x1="29.05" y1="30.48" x2="29.25" y2="6.88"/>
+    <line x1="29.05" y1="30.48" x2="5.50" y2="25.67"/>
+    <line x1="29.05" y1="30.48" x2="50.05" y2="18.21"/>
+    <line x1="29.05" y1="30.48" x2="11.65" y2="49.42"/>
+    <line x1="29.05" y1="30.48" x2="53.70" y2="40.68"/>
+  </g>
+
+  <circle cx="29.25" cy="6.88" r="5.5" fill="#4C8CFF"/>
+  <circle cx="50.05" cy="18.21" r="4.5" fill="#20D4E8"/>
+  <circle cx="5.5" cy="25.67" r="4.2" fill="#6FB3FF"/>
+  <circle cx="53.70" cy="40.68" r="5.5" fill="#7B7BFF"/>
+  <circle cx="11.65" cy="49.42" r="4.8" fill="#C3A6FF"/>
+  <circle cx="29.05" cy="30.48" r="6.2" fill="#9B5CFF"/>
 </svg>


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## Jolli Memory


## E2E Test (1)

### 1. Privacy consent notice appears before API key entry

**Preconditions:** Have the JolliMemory plugin installed in IntelliJ IDEA

**Steps:**
1. Open IntelliJ IDEA and go to Settings (on Mac: IntelliJ IDEA → Settings, on Windows/Linux: File → Settings).
2. In the left sidebar, find and click on the JolliMemory section.
3. Look at the settings panel that appears on the right side of the screen.
4. Check that a privacy notice message is visible near the top of the panel, above the API key field.
5. Check that the notice mentions sending code diffs and AI session transcripts to third-party AI providers.
6. Check that there is a clickable "Privacy Policy" link in the notice, and that clicking it opens the privacy policy page in your browser.

**Expected Results:**
- A privacy notice message should appear at the top of the JolliMemory settings panel, before the API key input field.
- A horizontal dividing line should separate the privacy notice from the API key field below it.
- The notice should contain a working "Privacy Policy" link that opens a webpage when clicked.
- The API key field should only appear below the notice and divider, not above it.

---

## Summaries (3)

### 01 · Add privacy consent notice to settings page before API key entry

**⚡ Why This Change**

Users needed to be informed about data sharing before entering their API key, since the plugin sends code diffs and AI session transcripts to third-party providers like Anthropic.

**💡 Decisions Behind the Code**

- **Placement before the API key field**: Showing the notice above the input ensures users see the consent language before they can act, rather than after — this is the safer UX pattern for informed consent.
- **Inline HTML with a hyperlink**: Embedding the privacy policy link directly in the notice avoids requiring users to navigate elsewhere to find it, reducing friction while keeping the full policy accessible.
- **Copyable label**: Making the label copyable lets users save or share the notice text, which is a minor usability improvement with no meaningful downside.

**✅ What Was Implemented**

Added a privacy consent notice to the settings panel in `JolliMemoryConfigurable.kt`:
- Created a `JBLabel` with inline HTML explaining that providing an API key constitutes consent to sending code diffs and AI session transcripts to third-party AI providers
- Included a hyperlink to the hosted privacy policy document
- Enabled copyable mode on the label so users can copy the text
- Placed the notice above the API key field, separated by a horizontal divider, so it appears before the user can enter credentials

### 02 · Add Kotlin IntelliJ plugin .gitignore entries

**⚡ Why This Change**

The project lacked standard .gitignore coverage for a Kotlin IntelliJ plugin, risking IDE metadata, build artifacts, and sensitive files being committed.

**💡 Decisions Behind the Code**

The previous `.claude/settings.json` and `.claude/skills/` entries were collapsed into a single `.claude/` wildcard, accepting that any Claude-related files should be excluded rather than selectively ignoring sub-paths. The `gradle/wrapper/gradle-wrapper.jar` was explicitly un-ignored (negation rule) because it is conventionally committed so CI and fresh checkouts can bootstrap Gradle without a pre-installed version.

**✅ What Was Implemented**

Replaced the minimal 3-line `.gitignore` with a 34-line version covering: IDE files (`.idea/`, `*.iml`, `*.ipr`, `*.iws`), Gradle artifacts (`.gradle/`, `build/`, with `gradle-wrapper.jar` explicitly kept), Kotlin/Java build outputs (`*.class`, `*.jar`, `*.war`, `*.ear`), OS files (`.DS_Store`, `Thumbs.db`), editor files (`.vscode/`, `*.swp`, `*~`), environment files (`.env`, `.env.*`), and consolidated the existing Jolli/Claude tool directories (`.jolli/`, `.claude/`, `.gemini/`) into a single block.

### 03 · Bump version to 0.97.9 and add privacy consent changelog entry

**⚡ Why This Change**

The `intellij/build.gradle.kts` file remained in the working tree as a modified but uncommitted file after a prior commit, prompting the user to ask why it was still showing as changed.

**💡 Decisions Behind the Code**

The assistant clarified that the file was not a `.gitignore` oversight — it was a legitimate code change predating the session (shown as ` M` in the initial git status). Rather than amending the previous commit or ignoring the file, it was committed separately as its own atomic change, keeping the version bump and changelog co-located with the feature they describe.

**✅ What Was Implemented**

Committed `intellij/build.gradle.kts` with two changes: version string incremented from `0.97.8` to `0.97.9`, and a new `<h3>0.97.9</h3>` changelog block added to `changeNotes` describing the privacy consent notice feature (satisfying JetBrains Marketplace guideline 2.2 for explicit user consent before data processing).

---

*Generated by JolliMemory · April 21, 2026 at 2:59 PM*
<!-- jollimemory-summary-end -->