### PR TITLE
Fix AI Commit stageFiles for paths missing from worktree

### DIFF
--- a/vscode/src/JolliMemoryBridge.integration.test.ts
+++ b/vscode/src/JolliMemoryBridge.integration.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Real-git integration tests for JolliMemoryBridge.stageFiles().
+ *
+ * Unlike JolliMemoryBridge.test.ts, this file does NOT mock
+ * node:child_process or node:fs. Each test creates a throwaway git
+ * repo in the OS temp dir, exercises the bridge against it, and
+ * verifies the resulting index state via `git status --porcelain`.
+ *
+ * Purpose: end-to-end regression cover for JOLLI-1326. The unit tests
+ * prove the partition logic in isolation; these tests prove the
+ * partition's *design* matches real git's pathspec semantics.
+ */
+
+import { execSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Stub out the only vscode-runtime dependency transitively pulled in by
+// the bridge. Everything else (node:child_process, node:fs, git on PATH)
+// is left real so we exercise the actual stageFiles → execFile → git pipeline.
+vi.mock("vscode", () => ({}));
+vi.mock("./util/Logger.js", () => ({
+	log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+import { JolliMemoryBridge } from "./JolliMemoryBridge.js";
+
+let repoDir: string;
+
+beforeEach(() => {
+	repoDir = mkdtempSync(join(tmpdir(), "jolli-1326-"));
+	execSync("git init -q", { cwd: repoDir });
+	// Deterministic identity so commits succeed even in sandboxed env.
+	execSync('git -c commit.gpgsign=false config user.email "test@example.com"', {
+		cwd: repoDir,
+	});
+	execSync('git config user.name "Test"', { cwd: repoDir });
+	execSync('git commit --allow-empty -qm "init"', { cwd: repoDir });
+});
+
+afterEach(() => {
+	rmSync(repoDir, { recursive: true, force: true });
+});
+
+function gitStatus(): string {
+	return execSync("git status --short", {
+		cwd: repoDir,
+		encoding: "utf8",
+	}).trim();
+}
+
+describe("stageFiles() — real git integration", () => {
+	it("allowMissing stages the deletion for the JOLLI-1326 bug state", async () => {
+		// Bug state: path was tracked, then `git rm --cached` removed it
+		// from the index, then the worktree copy was deleted. Running
+		// `git add -- foo.ts` in this state produces the exact error
+		// reported in the Linear ticket.
+		writeFileSync(join(repoDir, "foo.ts"), "v1");
+		execSync('git add foo.ts && git commit -qm "track foo"', { cwd: repoDir });
+		execSync("git rm --cached -q foo.ts", { cwd: repoDir });
+		rmSync(join(repoDir, "foo.ts"));
+		expect(gitStatus()).toBe("D  foo.ts");
+
+		// Sanity: raw `git add` would reject this path (locks our bug premise).
+		expect(() =>
+			execSync("git add -- foo.ts", { cwd: repoDir, stdio: "pipe" }),
+		).toThrow(/did not match any files/);
+
+		const bridge = new JolliMemoryBridge(repoDir);
+		await bridge.stageFiles(["foo.ts"], { allowMissing: true });
+
+		// Deletion remains staged; no error bubbled up.
+		expect(gitStatus()).toBe("D  foo.ts");
+	});
+
+	it("default mode rejects the same bug state (preserves restore-path warning)", async () => {
+		writeFileSync(join(repoDir, "bar.ts"), "v1");
+		execSync('git add bar.ts && git commit -qm "track bar"', { cwd: repoDir });
+		execSync("git rm --cached -q bar.ts", { cwd: repoDir });
+		rmSync(join(repoDir, "bar.ts"));
+
+		const bridge = new JolliMemoryBridge(repoDir);
+		await expect(bridge.stageFiles(["bar.ts"])).rejects.toThrow(
+			/did not match any files/,
+		);
+		// Index unchanged — caller's try/catch takes over.
+		expect(gitStatus()).toBe("D  bar.ts");
+	});
+
+	it("allowMissing stages a real deletion for a tracked-then-removed file", async () => {
+		// Positive control: the common case still works.
+		writeFileSync(join(repoDir, "existing.ts"), "v1");
+		execSync('git add existing.ts && git commit -qm "track"', { cwd: repoDir });
+		rmSync(join(repoDir, "existing.ts"));
+
+		const bridge = new JolliMemoryBridge(repoDir);
+		await bridge.stageFiles(["existing.ts"], { allowMissing: true });
+
+		expect(gitStatus()).toBe("D  existing.ts");
+	});
+
+	it("allowMissing stages a new file addition", async () => {
+		// Positive control: adding a new file via allowMissing still works.
+		writeFileSync(join(repoDir, "new.ts"), "content");
+
+		const bridge = new JolliMemoryBridge(repoDir);
+		await bridge.stageFiles(["new.ts"], { allowMissing: true });
+
+		expect(gitStatus()).toBe("A  new.ts");
+	});
+
+	it("allowMissing partitions a mixed selection correctly", async () => {
+		// Setup: `present.ts` on disk; `gone.ts` in the bug state.
+		writeFileSync(join(repoDir, "gone.ts"), "v1");
+		execSync('git add gone.ts && git commit -qm "track gone"', {
+			cwd: repoDir,
+		});
+		execSync("git rm --cached -q gone.ts", { cwd: repoDir });
+		rmSync(join(repoDir, "gone.ts"));
+		writeFileSync(join(repoDir, "present.ts"), "new");
+
+		const bridge = new JolliMemoryBridge(repoDir);
+		await bridge.stageFiles(["present.ts", "gone.ts"], { allowMissing: true });
+
+		const status = gitStatus().split("\n").sort().join("\n");
+		expect(status).toBe("A  present.ts\nD  gone.ts");
+	});
+});
+
+describe("getStagedFilePaths() — real git integration (NUL-separated, unicode)", () => {
+	it("returns unicode paths verbatim without octal quoting", async () => {
+		// Regression lock for the bundled 3.1 fix. Without `-z`, git would
+		// emit `"fo\303\266.ts"` for this filename.
+		writeFileSync(join(repoDir, "foö.ts"), "x");
+		execSync("git add foö.ts", { cwd: repoDir });
+
+		const bridge = new JolliMemoryBridge(repoDir);
+		const staged = await bridge.getStagedFilePaths();
+
+		expect(staged).toEqual(["foö.ts"]);
+	});
+});

--- a/vscode/src/JolliMemoryBridge.test.ts
+++ b/vscode/src/JolliMemoryBridge.test.ts
@@ -95,8 +95,9 @@ const { info, warn, error, debug } = vi.hoisted(() => ({
 	debug: vi.fn(),
 }));
 
-const { existsSync, readFileSync } = vi.hoisted(() => ({
+const { existsSync, lstatSync, readFileSync } = vi.hoisted(() => ({
 	existsSync: vi.fn(),
+	lstatSync: vi.fn(),
 	readFileSync: vi.fn(),
 }));
 
@@ -234,6 +235,7 @@ vi.mock("node:child_process", () => ({
 
 vi.mock("node:fs", () => ({
 	existsSync,
+	lstatSync,
 	readFileSync,
 }));
 
@@ -920,24 +922,19 @@ describe("JolliMemoryBridge", () => {
 
 	// ── stageFile / stageFiles ───────────────────────────────────────────
 
-	describe("stageFiles() — single file", () => {
-		it("runs git add for the given path", async () => {
-			mockExecFileSuccess("");
-			const bridge = makeBridge();
+	// Helper: a Stats-like sentinel. `lstatSync(..., { throwIfNoEntry: false })`
+	// returns a real `fs.Stats` for any filesystem entry (including dangling
+	// symlinks); tests only care that the return is !== undefined.
+	const STATS_PRESENT = {} as unknown as ReturnType<typeof lstatSync>;
 
-			await bridge.stageFiles(["src/main.ts"]);
+	describe("stageFiles() — default mode (restore semantics)", () => {
+		// Default mode (no opts) is what CommitCommand.ts:200 and
+		// SquashCommand.ts:205 use to reinstate pre-flow staging. Contract:
+		// "just run git add and let it fail loudly" so the rejection surfaces
+		// the existing "previously-staged files could not be re-staged"
+		// warning.
 
-			expect(execFileMock).toHaveBeenCalledWith(
-				"git",
-				["add", "--", "src/main.ts"],
-				{ cwd: TEST_CWD, encoding: "utf8" },
-				expect.any(Function),
-			);
-		});
-	});
-
-	describe("stageFiles()", () => {
-		it("runs git add with multiple paths", async () => {
+		it("runs plain git add with all paths and no existence check", async () => {
 			mockExecFileSuccess("");
 			const bridge = makeBridge();
 
@@ -949,6 +946,21 @@ describe("JolliMemoryBridge", () => {
 				{ cwd: TEST_CWD, encoding: "utf8" },
 				expect.any(Function),
 			);
+			expect(execFileMock).toHaveBeenCalledTimes(1);
+			// No fs lookups in default mode — contract lock for restore callers.
+			expect(lstatSync).not.toHaveBeenCalled();
+			expect(existsSync).not.toHaveBeenCalled();
+		});
+
+		it("propagates git add rejection unchanged (preserves restore warning)", async () => {
+			mockExecFileError(
+				"fatal: pathspec 'ignored-and-gone.ts' did not match any files",
+			);
+			const bridge = makeBridge();
+
+			await expect(bridge.stageFiles(["ignored-and-gone.ts"])).rejects.toThrow(
+				/did not match any files/,
+			);
 		});
 
 		it("does nothing when paths array is empty", async () => {
@@ -957,6 +969,166 @@ describe("JolliMemoryBridge", () => {
 			await bridge.stageFiles([]);
 
 			expect(execFileMock).not.toHaveBeenCalled();
+		});
+	});
+
+	describe("stageFiles() — allowMissing mode (AI-commit selection)", () => {
+		it("runs git add with multiple paths when all exist", async () => {
+			lstatSync.mockReturnValue(STATS_PRESENT);
+			mockExecFileSuccess("");
+			const bridge = makeBridge();
+
+			await bridge.stageFiles(["a.ts", "b.ts"], { allowMissing: true });
+
+			expect(execFileMock).toHaveBeenCalledWith(
+				"git",
+				["add", "--", "a.ts", "b.ts"],
+				{ cwd: TEST_CWD, encoding: "utf8" },
+				expect.any(Function),
+			);
+			expect(execFileMock).toHaveBeenCalledTimes(1);
+		});
+
+		it("runs git rm --cached --ignore-unmatch when all paths are missing", async () => {
+			lstatSync.mockReturnValue(undefined);
+			mockExecFileSuccess("");
+			const bridge = makeBridge();
+
+			await bridge.stageFiles(["a.ts", "b.ts"], { allowMissing: true });
+
+			expect(execFileMock).toHaveBeenCalledWith(
+				"git",
+				["rm", "--cached", "--ignore-unmatch", "--", "a.ts", "b.ts"],
+				{ cwd: TEST_CWD, encoding: "utf8" },
+				expect.any(Function),
+			);
+			expect(execFileMock).toHaveBeenCalledTimes(1);
+		});
+
+		it("partitions mixed paths and runs git add before git rm --cached", async () => {
+			lstatSync.mockImplementation((p: string) =>
+				p === join(TEST_CWD, "a.ts") ? STATS_PRESENT : undefined,
+			);
+			mockExecFileSuccess(""); // for git add
+			mockExecFileSuccess(""); // for git rm --cached
+			const bridge = makeBridge();
+
+			await bridge.stageFiles(["a.ts", "b.ts"], { allowMissing: true });
+
+			expect(execFileMock).toHaveBeenNthCalledWith(
+				1,
+				"git",
+				["add", "--", "a.ts"],
+				{ cwd: TEST_CWD, encoding: "utf8" },
+				expect.any(Function),
+			);
+			expect(execFileMock).toHaveBeenNthCalledWith(
+				2,
+				"git",
+				["rm", "--cached", "--ignore-unmatch", "--", "b.ts"],
+				{ cwd: TEST_CWD, encoding: "utf8" },
+				expect.any(Function),
+			);
+		});
+
+		it("routes the reported JOLLI-1326 scenario (gitignored + deleted) to git rm --cached", async () => {
+			// Selection contains a path that `git add` would reject because it
+			// is gitignored and deleted from the worktree — simulated here by
+			// lstatSync returning undefined for that path. The partition logic
+			// must route it to `git rm --cached`, not `git add`.
+			lstatSync.mockImplementation((p: string) =>
+				p === join(TEST_CWD, "ignored-and-gone.ts") ? undefined : STATS_PRESENT,
+			);
+			mockExecFileSuccess(""); // git add for the healthy path
+			mockExecFileSuccess(""); // git rm --cached for the problem path
+			const bridge = makeBridge();
+
+			await expect(
+				bridge.stageFiles(["healthy.ts", "ignored-and-gone.ts"], {
+					allowMissing: true,
+				}),
+			).resolves.toBeUndefined();
+
+			expect(execFileMock).toHaveBeenNthCalledWith(
+				1,
+				"git",
+				["add", "--", "healthy.ts"],
+				{ cwd: TEST_CWD, encoding: "utf8" },
+				expect.any(Function),
+			);
+			expect(execFileMock).toHaveBeenNthCalledWith(
+				2,
+				"git",
+				["rm", "--cached", "--ignore-unmatch", "--", "ignored-and-gone.ts"],
+				{ cwd: TEST_CWD, encoding: "utf8" },
+				expect.any(Function),
+			);
+		});
+
+		it("routes a dangling symlink to git add, not git rm --cached", async () => {
+			// Regression lock for P2: fs.existsSync follows symlinks and returns
+			// false for a dangling link. lstatSync, which we use, returns a
+			// Stats object for any fs entry (including dangling links) —
+			// matching what `git add` actually accepts.
+			lstatSync.mockReturnValue(STATS_PRESENT);
+			mockExecFileSuccess("");
+			const bridge = makeBridge();
+
+			await bridge.stageFiles(["dangling-link"], { allowMissing: true });
+
+			expect(execFileMock).toHaveBeenCalledWith(
+				"git",
+				["add", "--", "dangling-link"],
+				{ cwd: TEST_CWD, encoding: "utf8" },
+				expect.any(Function),
+			);
+			expect(execFileMock).toHaveBeenCalledTimes(1);
+		});
+
+		it("calls lstatSync with join(cwd, path) and throwIfNoEntry: false", async () => {
+			lstatSync.mockReturnValue(STATS_PRESENT);
+			mockExecFileSuccess("");
+			const bridge = makeBridge();
+
+			await bridge.stageFiles(["src/main.ts"], { allowMissing: true });
+
+			expect(lstatSync).toHaveBeenCalledWith(join(TEST_CWD, "src/main.ts"), {
+				throwIfNoEntry: false,
+			});
+		});
+
+		it("propagates git add rejection and does not invoke git rm --cached", async () => {
+			lstatSync.mockReturnValue(STATS_PRESENT);
+			mockExecFileError("add failed");
+			const bridge = makeBridge();
+
+			await expect(
+				bridge.stageFiles(["a.ts"], { allowMissing: true }),
+			).rejects.toThrow("add failed");
+			expect(execFileMock).toHaveBeenCalledTimes(1);
+		});
+
+		it("propagates git rm --cached rejection even though git add already succeeded", async () => {
+			lstatSync.mockImplementation((p: string) =>
+				p === join(TEST_CWD, "a.ts") ? STATS_PRESENT : undefined,
+			);
+			mockExecFileSuccess(""); // git add succeeds
+			mockExecFileError("rm failed"); // git rm --cached rejects
+			const bridge = makeBridge();
+
+			await expect(
+				bridge.stageFiles(["a.ts", "b.ts"], { allowMissing: true }),
+			).rejects.toThrow("rm failed");
+			expect(execFileMock).toHaveBeenCalledTimes(2);
+		});
+
+		it("does nothing when paths array is empty", async () => {
+			const bridge = makeBridge();
+
+			await bridge.stageFiles([], { allowMissing: true });
+
+			expect(execFileMock).not.toHaveBeenCalled();
+			expect(lstatSync).not.toHaveBeenCalled();
 		});
 	});
 
@@ -1328,8 +1500,8 @@ describe("JolliMemoryBridge", () => {
 			mockExecFileSuccess("diff --cached output\n");
 			// 2) getCurrentBranch (tryExecGit for rev-parse --abbrev-ref HEAD)
 			mockExecFileSuccess("feature/test\n");
-			// 3) getStagedFilePaths (tryExecGit for diff --cached --name-only)
-			mockExecFileSuccess("src/a.ts\nsrc/b.ts\n");
+			// 3) getStagedFilePaths (tryExecGit for diff --cached -z --name-only)
+			mockExecFileSuccess("src/a.ts\0src/b.ts\0");
 			generateCommitMessage.mockResolvedValue("feat: add feature");
 
 			const bridge = makeBridge();
@@ -1859,13 +2031,42 @@ describe("JolliMemoryBridge", () => {
 	});
 
 	describe("getStagedFilePaths()", () => {
-		it("splits lines and filters blanks", async () => {
-			mockExecFileSuccess("src/a.ts\n\nsrc/b.ts\n");
+		it("splits NUL-separated output and filters the trailing empty entry", async () => {
+			// Real git -z output has a trailing NUL after every record, so the
+			// mock includes it.
+			mockExecFileSuccess("src/a.ts\0src/b.ts\0");
 			const bridge = makeBridge();
 
 			const paths = await bridge.getStagedFilePaths();
 
 			expect(paths).toEqual(["src/a.ts", "src/b.ts"]);
+			expect(execFileMock).toHaveBeenCalledWith(
+				"git",
+				["diff", "--cached", "-z", "--name-only"],
+				{ cwd: TEST_CWD, encoding: "utf8" },
+				expect.any(Function),
+			);
+		});
+
+		it("returns unicode paths verbatim (no octal quoting)", async () => {
+			// Regression lock for the JOLLI-1326 bundled fix: without `-z`, git
+			// would emit `"fo\303\266.ts"` for this filename, which later breaks
+			// the re-stage round-trip.
+			mockExecFileSuccess("foö.ts\0");
+			const bridge = makeBridge();
+
+			const paths = await bridge.getStagedFilePaths();
+
+			expect(paths).toEqual(["foö.ts"]);
+		});
+
+		it("returns an empty array when no files are staged", async () => {
+			mockExecFileSuccess("");
+			const bridge = makeBridge();
+
+			const paths = await bridge.getStagedFilePaths();
+
+			expect(paths).toEqual([]);
 		});
 	});
 

--- a/vscode/src/JolliMemoryBridge.ts
+++ b/vscode/src/JolliMemoryBridge.ts
@@ -11,7 +11,7 @@
  */
 
 import { execFile } from "node:child_process";
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, lstatSync, readFileSync } from "node:fs";
 import { lstat, rm, unlink } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
@@ -465,12 +465,68 @@ export class JolliMemoryBridge {
 		return files;
 	}
 
-	/** Stages multiple files in a single git add invocation to avoid index.lock contention. */
-	async stageFiles(relativePaths: Array<string>): Promise<void> {
+	/**
+	 * Stages multiple files.
+	 *
+	 * Default mode (no `allowMissing`): plain `git add --`. If any path
+	 * is unreachable (missing from worktree AND not in the index), git
+	 * fails with "pathspec did not match any files" and the rejection
+	 * surfaces to the caller — this is what the restore-previously-
+	 * staged flow (`CommitCommand.ts:200` / `SquashCommand.ts:205`)
+	 * relies on to warn the user that a prior staging state could not
+	 * be reinstated.
+	 *
+	 * `allowMissing: true` (AI-commit selection path): partition paths
+	 * by on-disk existence. Present paths go through `git add`; absent
+	 * paths go through `git rm --cached --ignore-unmatch`. This covers
+	 * the deletion flavours that `git add` refuses (gitignored +
+	 * deleted, sparse-excluded, skip-worktree, staged-add-then-deleted,
+	 * post-`git rm --cached` deletions, and the status-vs-commit race).
+	 * See JOLLI-1326 for the full rationale.
+	 *
+	 * The existence check is `lstatSync(..., { throwIfNoEntry: false })`
+	 * rather than `existsSync` — the latter dereferences symlinks and
+	 * would misclassify a dangling symlink as absent, even though git
+	 * stages dangling symlinks normally (it uses `lstat` internally).
+	 *
+	 * Invocations are sequential to preserve index.lock safety; errors
+	 * propagate unchanged so the caller's `restoreIndex()` path can
+	 * recover.
+	 */
+	async stageFiles(
+		relativePaths: Array<string>,
+		opts: { allowMissing?: boolean } = {},
+	): Promise<void> {
 		if (relativePaths.length === 0) {
 			return;
 		}
-		await execGit(["add", "--", ...relativePaths], this.cwd);
+
+		if (!opts.allowMissing) {
+			await execGit(["add", "--", ...relativePaths], this.cwd);
+			return;
+		}
+
+		const existing: Array<string> = [];
+		const missing: Array<string> = [];
+		for (const p of relativePaths) {
+			if (
+				lstatSync(join(this.cwd, p), { throwIfNoEntry: false }) !== undefined
+			) {
+				existing.push(p);
+			} else {
+				missing.push(p);
+			}
+		}
+
+		if (existing.length > 0) {
+			await execGit(["add", "--", ...existing], this.cwd);
+		}
+		if (missing.length > 0) {
+			await execGit(
+				["rm", "--cached", "--ignore-unmatch", "--", ...missing],
+				this.cwd,
+			);
+		}
 	}
 
 	/** Unstages multiple files in a single git restore invocation to avoid index.lock contention. */
@@ -1267,13 +1323,19 @@ export class JolliMemoryBridge {
 
 	// ── Private helpers ───────────────────────────────────────────────────
 
-	/** Returns file paths currently staged in the git index (git diff --cached --name-only). */
+	/**
+	 * Returns file paths currently staged in the git index.
+	 *
+	 * Uses `-z` (NUL-separated) so paths are output verbatim — no quoting of
+	 * unicode or control chars. Matches `listFiles()` so paths produced here
+	 * flow cleanly through `stageFiles()`'s `existsSync`-based partition.
+	 */
 	async getStagedFilePaths(): Promise<Array<string>> {
 		const output = await tryExecGit(
-			["diff", "--cached", "--name-only"],
+			["diff", "--cached", "-z", "--name-only"],
 			this.cwd,
 		);
-		return output.split("\n").filter(Boolean);
+		return output.split("\0").filter(Boolean);
 	}
 
 	/**

--- a/vscode/src/commands/CommitCommand.test.ts
+++ b/vscode/src/commands/CommitCommand.test.ts
@@ -843,11 +843,18 @@ describe("CommitCommand", () => {
 		await command.execute();
 
 		expect(deps.bridge.commit).toHaveBeenCalledWith("feat: generated");
-		// stageFiles is called multiple times: once for index prep, once for re-stage before commit,
-		// and once for re-staging remaining previously-staged files
+		// stageFiles is called three times: (1) index prep, (2) re-stage
+		// before commit, (3) re-stage previously-staged remainder.
+		//
+		// Contract (JOLLI-1326 P1): the first two — the user-selection path —
+		// must opt in to missing-file tolerance with { allowMissing: true }.
+		// The third — the restore path — must NOT pass opts; it relies on
+		// `git add`'s loud failure to trigger the re-stage warning.
 		const stageFilesCalls = deps.bridge.stageFiles.mock.calls;
-		const lastCall = stageFilesCalls[stageFilesCalls.length - 1];
-		expect(lastCall).toEqual([["extra.ts"]]);
+		expect(stageFilesCalls).toHaveLength(3);
+		expect(stageFilesCalls[0]).toEqual([["a.ts"], { allowMissing: true }]);
+		expect(stageFilesCalls[1]).toEqual([["a.ts"], { allowMissing: true }]);
+		expect(stageFilesCalls[2]).toEqual([["extra.ts"]]);
 	});
 
 	it("warns when re-staging previously-staged files fails after commit", async () => {

--- a/vscode/src/commands/CommitCommand.ts
+++ b/vscode/src/commands/CommitCommand.ts
@@ -118,7 +118,7 @@ export class CommitCommand {
 			return;
 		}
 		try {
-			await this.bridge.stageFiles(selectedPaths);
+			await this.bridge.stageFiles(selectedPaths, { allowMissing: true });
 			if (unselectedTrackedPaths.length > 0) {
 				await this.bridge.unstageFiles(unselectedTrackedPaths);
 			}
@@ -172,7 +172,7 @@ export class CommitCommand {
 		// Step 5: Re-stage selected files to capture any edits made during message
 		// generation or QuickPick review, then execute the selected action.
 		try {
-			await this.bridge.stageFiles(selectedPaths);
+			await this.bridge.stageFiles(selectedPaths, { allowMissing: true });
 			log.info(
 				"commit",
 				`Re-staged ${selectedPaths.length} file(s) before commit`,


### PR DESCRIPTION
<!-- jollimemory-summary-start -->


## E2E Test (2)

### 1. AI Commit succeeds when selection includes a deleted or gitignored file

**Preconditions:** Have a git repository open in the extension where at least one file has been deleted from disk but is still tracked by git (for example, a file that was previously committed and then removed from the folder, or a file that is both tracked and listed in .gitignore).

**Steps:**
1. Open the Jolli Memory panel in VS Code.
2. Start the AI Commit flow by clicking the "AI Commit" button.
3. When the file selection list appears, check the box next to the deleted or gitignored file alongside at least one normal, existing file.
4. Confirm the selection and let the commit flow proceed.
5. Check whether the commit completes successfully or shows an error.
6. Open the git log or Source Control panel to verify the commit was recorded.

**Expected Results:**
- The AI Commit flow should complete without any fatal git error message.
- The commit should appear in the git history.
- The deleted file should be recorded as removed in the commit, and the existing file should be recorded as added or modified — no "pathspec did not match" or similar error should appear.

### 2. AI Commit handles a file with special characters or accented letters in its name

**Preconditions:** Have a git repository open where at least one staged or modified file has a name containing accented letters or non-English characters (for example, a file named with an umlaut or accent, like "résumé.txt" or "über.ts").

**Steps:**
1. Open the Jolli Memory panel in VS Code.
2. Start the AI Commit flow by clicking the "AI Commit" button.
3. When the file selection list appears, check the box next to the file with the special-character name.
4. Confirm the selection and let the commit flow proceed.
5. Check whether the commit completes successfully.
6. Open the git log or Source Control panel and verify the file name is shown correctly, without any garbled characters or backslash codes.

**Expected Results:**
- The AI Commit flow should complete without errors.
- The file name in the commit history should display the accented or special characters exactly as they appear in the folder — not as a series of backslashes and numbers (for example, it should show "résumé.txt", not "\303\251sum\303\251.txt").

---

## Summaries (6)

### 01 · Fix AI Commit failure when staging deleted or gitignored files

**⚡ Why This Change**

The AI Commit flow would abort with a fatal git error whenever the user's selection included a file that had been deleted from disk — for example, a file that was both tracked and matched by a gitignore rule. Because all selected paths were passed to a single git staging command, one bad path killed the entire commit.

**💡 Decisions Behind the Code**

- **Partition by on-disk existence, not git status code**: Git status codes like "D" are unreliable — they collapse edge cases such as staged-add-then-deleted, sparse checkout exclusions, and skip-worktree flags. The on-disk check matches the exact precondition that makes `git add` fail, covering all triggers with one discriminator.
- **Use `git rm --cached --ignore-unmatch` for missing paths**: The `--cached` flag avoids touching the worktree, and `--ignore-unmatch` silently tolerates paths not in the index (races, phantom entries). This bypasses gitignore consultation entirely, which is the correct behavior for staging a deletion.
- **Bundle the NUL-separator fix in the same PR**: Without it, the partition fix would silently drop specially-named files during the re-stage round-trip — changing the failure mode from a loud error to silent data loss. The fix is small and the two changes are semantically coupled.
- **Sequential git invocations, not parallel**: Preserves the existing index-lock safety guarantee that the original batched approach was designed around. Error from either call propagates unchanged so the caller's restore path can recover.
- **Reject force-adding ignored files that exist on disk**: Routing present-but-ignored files through `git add --force` would weaken gitignore as a safety net. Deferred until a user explicitly needs it.

**✅ What Was Implemented**

- `stageFiles()` in `JolliMemoryBridge.ts`: replaced single `git add` call with a partition loop — paths that exist on disk go to `git add`, paths missing from disk go to `git rm --cached --ignore-unmatch`
- `getStagedFilePaths()` in `JolliMemoryBridge.ts`: switched from newline-separated to NUL-separated (`-z`) git output and updated the split/filter accordingly, so unicode and special-character filenames are returned verbatim instead of octal-quoted
- Added 8 new unit tests for `stageFiles()` covering: all-existing, all-missing, mixed partition, absolute-path resolution guard, and error propagation for both git invocations
- Added 3 new unit tests for `getStagedFilePaths()` covering: NUL-separated output with trailing NUL, unicode path round-trip, and empty output
- Updated existing tests to set `existsSync` mock explicitly so partitioning is deterministic

### 02 · Fix staging failure when selected files are missing from disk

**⚡ Why This Change**

When using the AI Commit feature, staging would fail with a "pathspec did not match any files" error if the commit selection included files that had been deleted from disk — for example, gitignored-then-deleted files, sparse-excluded paths, or files deleted after being staged.

**💡 Decisions Behind the Code**

- **Split by existence rather than catching errors**: Proactively checking whether each path exists on disk and routing it to the correct git command avoids a fragile try/catch approach that would be harder to reason about and could silently swallow unrelated errors.
- **Use `--ignore-unmatch` on removal**: Passing this flag means the removal command succeeds even if a path has already been cleaned up, making the operation idempotent and safe to retry without extra guard logic.
- **NUL-separated output for path parsing**: Switching to NUL delimiters instead of newlines is a low-risk, high-correctness change — it eliminates an entire class of encoding bugs for unusual filenames without affecting the happy path.

**✅ What Was Implemented**

- Partitioned `stageFiles` inputs by on-disk existence: paths present on disk are passed to `git add`, while missing paths are passed to `git rm --cached --ignore-unmatch` instead.
- Switched `getStagedFilePaths` to use NUL-separated output so file paths containing unicode or control characters survive the re-stage round-trip without being mangled by octal quoting.



### 03 · Restore accidentally deleted root monorepo package.json file

**⚡ Why This Change**

The root package.json was unintentionally deleted from the repository in a previous commit. The developer noticed the file was missing and needed it restored to re-establish the monorepo workspace configuration.

**💡 Decisions Behind the Code**

- **Standalone commit over amend**: A new commit was chosen instead of amending the prior history-rewriting commit, because the deletion commit may have already been pushed — amending would require a force push and risk disrupting collaborators.
- **Recovery from git history over backup file**: The file was restored from the git object store (an earlier commit) rather than from the `package.bak.json` backup, because both were confirmed byte-identical and the git-sourced version is the authoritative record.

**✅ What Was Implemented**

- Restored `package.json` to the repo root by recovering the file from an earlier git commit, confirmed byte-identical to the pre-deletion version
- The restored file defines the npm workspaces monorepo structure (`cli`, `vscode`), aggregated scripts for build, typecheck, lint, test, and clean across both workspaces, and standard package metadata (license, repository, bugs URL)
- Committed as a standalone restore commit rather than amending history

---

*Generated by Jolli Memory · April 22, 2026 at 2:06 PM*
<!-- jollimemory-summary-end -->