### PR TITLE
Support OpenCode: add OpenCode session discovery and transcript reading; fix a bug about config.json is polluted by test run

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,24 +4,89 @@
 
 **Jolli Memory** automatically turns your AI coding sessions into structured development documentation attached to every commit, without any extra effort.
 
-When you work with AI agents like Claude Code, Codex, or Gemini CLI, the reasoning behind every decision lives in the conversation — *why this approach was chosen, what alternatives were considered, what problems came up along the way*. The moment you commit, that context is gone. Jolli Memory captures it automatically.
+When you work with AI agents like Claude Code, Codex, Gemini CLI, or OpenCode, the reasoning behind every decision lives in the conversation — *why this approach was chosen, what alternatives were considered, what problems came up along the way*. The moment you commit, that context is gone. Jolli Memory captures it automatically.
 
 ---
 
-## This Repository
+## This repository
 
-This repo contains the **Jolli Memory IntelliJ plugin** — a pure-Kotlin implementation for JetBrains IDEs.
+Monorepo hosting three deliverables that share the same product model and storage (a git orphan branch `jollimemory/summaries/v3`):
 
-📖 **See [intellij/README.md](intellij/README.md) for the full product documentation, features, and installation guide.**
+| Surface | Directory | What it's for |
+| -- | -- | -- |
+| **CLI** — `@jolli/cli` | [`cli/`](cli/) | Standalone command-line tool. Installs the git hooks, generates summaries on commit, and offers `view` / `export` / `recall` / `configure` / `doctor` commands. Works independent of any IDE. |
+| **VS Code extension** — Jolli Memory | [`vscode/`](vscode/) | Sidebar UI with panels for Status, Memories, Plans & Notes, Changes, Commits. Bundles the CLI internally; works whether or not the CLI is also installed globally. |
+| **IntelliJ plugin** — Jolli Memory | [`intellij/`](intellij/) | JetBrains IDEs integration (IDEA, PyCharm, WebStorm, GoLand, …) — pure-Kotlin implementation. |
 
-🛠️ **See [intellij/DEVELOPMENT.md](intellij/DEVELOPMENT.md) for contributor/developer setup.**
+### Which one should I install?
 
-## Quick Links
+- Using **VS Code** → install the [VS Code extension](vscode/).
+- Using a **JetBrains IDE** → install the [IntelliJ plugin](intellij/).
+- Using **Vim / Emacs / another editor**, or wiring into CI → install the [CLI](cli/).
+- Using **multiple editors** → install the CLI globally plus each editor plugin; they share the same data.
 
-- [Features](intellij/README.md#features) — AI Commit, Squash, Summary Viewer, Plans & Notes, Push to Jolli Space, PR management
-- [Installation](intellij/README.md#prerequisites) — IntelliJ IDEA 2024.3+, JDK 21+
-- [Configuration](intellij/README.md#configuration) — Anthropic API key, model selection
-- [Changelog](intellij/CHANGELOG.md)
+### Documentation
+
+| Surface | README | CHANGELOG |
+| -- | -- | -- |
+| CLI | [`cli/README.md`](cli/README.md) | [`cli/CHANGELOG.md`](cli/CHANGELOG.md) |
+| VS Code extension | [`vscode/README.md`](vscode/README.md) | [`vscode/CHANGELOG.md`](vscode/CHANGELOG.md) |
+| IntelliJ plugin | [`intellij/README.md`](intellij/README.md) | [`intellij/CHANGELOG.md`](intellij/CHANGELOG.md) |
+
+---
+
+## Product highlights
+
+- **Automatic** — git hooks run summary generation in a detached background process; your commit returns instantly (the summary appears 10–20 seconds later).
+- **Multi-agent** — works with Claude Code, Codex CLI, Gemini CLI, and OpenCode. Sessions are picked up automatically via agent hooks or filesystem/DB scanning.
+- **Local-first** — summaries and raw transcripts stay on your machine in a git orphan branch. Opt-in **Push to Jolli** shares summaries (not transcripts) with your team.
+- **Structured format** — v3 tree with topics, triggers, decisions, and todos; correctly handles amend / squash / cherry-pick / rebase.
+- **Privacy-respecting** — see the *Privacy* section in each surface's README for the exact data flow. The Jolli LLM proxy does not persist transcripts or diffs, and does not log them.
+
+---
+
+## Repository layout
+
+```
+jollimemory/
+├── cli/          Node.js CLI (@jolli/cli, npm workspace)
+├── vscode/       VS Code extension (npm workspace)
+├── intellij/     IntelliJ plugin (Kotlin + Gradle)
+├── package.json  Root workspace config (coordinates cli + vscode)
+└── .nvmrc        Pinned Node version for development
+```
+
+`cli/` and `vscode/` are npm workspaces coordinated from the root `package.json`. `intellij/` is a separate Gradle project.
+
+### Development quick start
+
+**CLI + VS Code extension** (Node.js workspace; requires the Node version in `.nvmrc`, currently 24.10.0):
+
+```bash
+npm install
+npm run build        # builds both CLI and VS Code
+npm run typecheck
+npm run lint
+npm run test
+```
+
+Per-workspace variants are available (`npm run build:cli`, `npm run test:vscode`, etc.). Run `npm run all` for a full clean → build → lint → test cycle.
+
+**IntelliJ plugin** — see [`intellij/DEVELOPMENT.md`](intellij/DEVELOPMENT.md).
+
+---
+
+## Contributing
+
+Contributions welcome. Please read:
+
+- [`CONTRIBUTING.md`](CONTRIBUTING.md) — workflow, code style, PR expectations
+- [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md) — community guidelines
+
+## Support
+
+- **Issues & feature requests** — [GitHub Issues](https://github.com/jolliai/jollimemory/issues)
+- **Jolli Space onboarding / enterprise** — support@jolli.ai
 
 ## License
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,9 +1,11 @@
 # Changelog
 
-<!-- Last synced commit: ff796b6a5 | 2026-04-13 -->
+<!-- Last synced commit: ea9ad050b | 2026-04-23 -->
 
 ## 0.98.0
 
+- **Breaking: requires Node 22.5+** — the CLI now requires Node 22.5 or newer (previously Node 18+). OpenCode session discovery relies on Node's built-in `node:sqlite`, which first ships in Node 22.5. Node 18 and 20 users should upgrade before running `npm install -g @jolli/cli`; the `engines` field will refuse installation on older runtimes.
+- **OpenCode integration** — sessions from [OpenCode](https://opencode.ai) are now discovered automatically at commit time. Jolli Memory reads the global OpenCode SQLite database at `~/.local/share/opencode/opencode.db` (or `$XDG_DATA_HOME/opencode/opencode.db`) and picks up any session whose `directory` matches the current project. No hook installation needed — same pattern as Codex. Toggle with `jolli configure --set openCodeEnabled=true|false`.
 - **`jolli auth` commands**: Added `jolli auth signup`, `jolli auth login`, `jolli auth logout`, `jolli auth status` for browser-based OAuth authentication.
 - **Updated `jolli enable` flow**: Now offers Sign up / Sign in as the primary option alongside manual API key entry.
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -21,6 +21,7 @@ When you use an AI coding agent, Jolli Memory keeps track of your active session
 | **Claude Code** | A lightweight `StopHook` fires after each AI response; a `SessionStartHook` injects a mini-briefing at session start |
 | **Gemini CLI** | An `AfterAgent` hook fires after each agent completion |
 | **Codex CLI** | No hook needed — sessions are discovered automatically by scanning the filesystem |
+| **OpenCode** | No hook needed — sessions are discovered automatically by reading OpenCode's global SQLite database at `~/.local/share/opencode/opencode.db` (requires Node 22.5+) |
 
 ### Git Hooks — generating summaries on commit
 
@@ -32,7 +33,11 @@ When you run `git commit`, three standard git hooks handle the rest:
 
 Everything is stored in a git orphan branch (`jollimemory/summaries/v3`), completely separate from your code history.
 
+**Worktree-aware:** hooks and summaries work across `git worktree` checkouts — each worktree tracks its own current branch and its memories stay consistent.
+
 ## Installation
+
+**Requirements** — **Node.js 22.5 or later**. OpenCode session discovery uses Node's built-in `node:sqlite`, which first ships in Node 22.5; the `engines` field refuses installation on older runtimes. If you use Node 18 or 20, please upgrade before installing.
 
 ```bash
 npm install -g @jolli/cli
@@ -196,7 +201,7 @@ jolli configure --set excludePatterns=docs/**,*.log,node_modules
 jolli configure --remove jolliApiKey
 ```
 
-Supported keys: `apiKey`, `model`, `maxTokens`, `jolliApiKey`, `authToken`, `codexEnabled`, `geminiEnabled`, `claudeEnabled`, `logLevel`, `excludePatterns`. Run `jolli configure --list-keys` for descriptions and types. Unknown keys and malformed values (e.g. `maxTokens=8192abc`, `logLevel=banana`) are rejected with exit code 1.
+Supported keys: `apiKey`, `model`, `maxTokens`, `jolliApiKey`, `authToken`, `codexEnabled`, `geminiEnabled`, `claudeEnabled`, `openCodeEnabled`, `logLevel`, `excludePatterns`. Run `jolli configure --list-keys` for descriptions and types. Unknown keys and malformed values (e.g. `maxTokens=8192abc`, `logLevel=banana`) are rejected with exit code 1.
 
 ### `jolli doctor`
 
@@ -260,6 +265,7 @@ Settings are stored globally in `~/.jolli/jollimemory/config.json`. The recommen
 | `claudeEnabled` | boolean | auto-detect | Enable Claude Code session tracking |
 | `codexEnabled` | boolean | auto-detect | Enable Codex CLI session discovery |
 | `geminiEnabled` | boolean | auto-detect | Enable Gemini CLI session tracking |
+| `openCodeEnabled` | boolean | auto-detect | Enable OpenCode session discovery (requires Node 22.5+) |
 | `excludePatterns` | string[] | — | Glob patterns for file exclusion (set via `jolli configure --set excludePatterns=glob1,glob2`) |
 
 **Authentication setup** — three options:
@@ -332,4 +338,37 @@ Jolli Memory is designed to **never interfere** with your development workflow:
 - A unified operation queue ensures no summaries are lost during rapid commit/amend/rebase sequences
 
 If something looks off, run `jolli doctor` to check for faults (stuck locks, missing hooks, invalid config) and `jolli clean --dry-run` to preview redundant data that can be safely removed.
+
+## Privacy
+
+### At summary generation time (after each commit)
+
+To produce a summary, Jolli Memory reads your active AI session transcripts and the git diff locally, then sends them together to a summarization backend:
+
+- If an **Anthropic `apiKey`** is configured — transcripts + diff are sent **directly to Anthropic**.
+- If only a **`jolliApiKey`** is configured (you signed in with `jolli auth login`) — transcripts + diff are sent to the **Jolli LLM proxy**, which forwards them to Anthropic on your behalf. The proxy **does not persist the transcripts or diff, and does not write them to any Jolli-side log** — payloads are held in memory only for the duration of the request and discarded once Anthropic responds.
+
+The generated summary is then written to the git orphan branch locally, and the raw transcripts are preserved alongside it for later review.
+
+### Uploads to Jolli Space
+
+The CLI itself does not push summaries to Jolli Space — that action lives in the VS Code and IntelliJ extensions (**Push to Jolli** button). When triggered there, only the **generated summary** and its **associated plans and notes** are uploaded. **Raw transcripts are never sent to Jolli Space.**
+
+### Session metadata
+
+Session IDs, transcript file paths, and timestamps are stored locally in `~/.jolli/jollimemory/`. Never uploaded anywhere.
+
+### What stays 100% local
+
+Every file under `~/.jolli/jollimemory/` and every entry on the `jollimemory/summaries/v3` orphan branch — including raw transcripts — stays on your disk unless one of the specific actions above is triggered.
+
+## Support
+
+- **Issues & feature requests** — [GitHub Issues](https://github.com/jolliai/jollimemory/issues)
+- **Jolli Space onboarding / enterprise** — support@jolli.ai
+- **VS Code extension reference** — see the [VS Code README](https://github.com/jolliai/jollimemory/tree/main/vscode)
+
+## License
+
+[Apache License 2.0](https://github.com/jolliai/jollimemory/blob/main/LICENSE)
 

--- a/cli/package.json
+++ b/cli/package.json
@@ -7,7 +7,10 @@
 	"bin": {
 		"jolli": "dist/Cli.js"
 	},
-	"files": ["dist/", "README.md"],
+	"files": [
+		"dist/",
+		"README.md"
+	],
 	"scripts": {
 		"all": "npm run clean && npm run build && npm run lint && npm run test",
 		"build": "vite build",
@@ -22,7 +25,17 @@
 		"test:watch": "vitest",
 		"postinstall": "node -e \"require('fs').existsSync('dist/PostInstall.js') && require('child_process').spawnSync(process.execPath,['dist/PostInstall.js'],{stdio:'inherit'})\""
 	},
-	"keywords": ["ai", "documentation", "git-hooks", "claude-code", "codex", "gemini", "commit-summary", "dev-memory"],
+	"keywords": [
+		"ai",
+		"documentation",
+		"git-hooks",
+		"claude-code",
+		"codex",
+		"gemini",
+		"opencode",
+		"commit-summary",
+		"dev-memory"
+	],
 	"author": "Jolli",
 	"license": "Apache-2.0",
 	"repository": {
@@ -41,7 +54,7 @@
 	},
 	"devDependencies": {
 		"@biomejs/biome": "2.2.6",
-		"@types/node": "^20.0.0",
+		"@types/node": "^22.5.0",
 		"@vitest/coverage-v8": "^4.1.1",
 		"rimraf": "^6.0.1",
 		"tsx": "^4.7.0",
@@ -53,6 +66,6 @@
 		"access": "public"
 	},
 	"engines": {
-		"node": ">=18.0.0"
+		"node": ">=22.5.0"
 	}
 }

--- a/cli/src/Cli.test.ts
+++ b/cli/src/Cli.test.ts
@@ -1,10 +1,14 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const { mockExecFileSync, mockExistsSync, mockReadFileSync, mockCreateInterface } = vi.hoisted(() => ({
 	mockExecFileSync: vi.fn(),
 	mockExistsSync: vi.fn(),
 	mockReadFileSync: vi.fn(),
 	mockCreateInterface: vi.fn(),
+}));
+
+const { mockQuestion } = vi.hoisted(() => ({
+	mockQuestion: vi.fn((_q: string, cb: (a: string) => void) => cb("")),
 }));
 
 vi.mock("node:child_process", () => ({
@@ -88,6 +92,7 @@ vi.mock("./install/Installer.js", () => ({
 		mostRecentSession: null,
 		summaryCount: 0,
 		orphanBranch: "jollimemory/summaries/v3",
+		sessionsBySource: {},
 	}),
 }));
 
@@ -170,6 +175,7 @@ vi.spyOn(process.stderr, "write").mockImplementation(() => true);
 
 import { main } from "./Cli.js";
 import { compileTaskContext, listBranchCatalog, renderContextMarkdown } from "./core/ContextCompiler.js";
+import { loadConfigFromDir } from "./core/SessionTracker.js";
 import { exportSummaries } from "./core/SummaryExporter.js";
 import { hasMigrationMeta, migrateV1toV3 } from "./core/SummaryMigration.js";
 import { getIndex, getSummary, indexNeedsMigration, listSummaries, migrateIndexToV3 } from "./core/SummaryStore.js";
@@ -182,6 +188,10 @@ describe("CLI", () => {
 		mockExecFileSync.mockReturnValue("/mock/project\n");
 		// Default: dist-path does not exist (checkVersionMismatch is a no-op)
 		mockExistsSync.mockReturnValue(false);
+		mockCreateInterface.mockReturnValue({
+			question: mockQuestion,
+			close: vi.fn(),
+		});
 	});
 
 	describe("help output", () => {
@@ -281,6 +291,7 @@ describe("CLI", () => {
 				mostRecentSession: { sessionId: "sess-123", transcriptPath: "/path", updatedAt: "now" },
 				summaryCount: 5,
 				orphanBranch: "jollimemory/summaries/v3",
+				sessionsBySource: {},
 			});
 			await main(["status"]);
 			expect(getStatus).toHaveBeenCalled();
@@ -296,6 +307,7 @@ describe("CLI", () => {
 				mostRecentSession: { sessionId: "sess-123", transcriptPath: "/path", updatedAt: "now" },
 				summaryCount: 5,
 				orphanBranch: "jollimemory/summaries/v3",
+				sessionsBySource: {},
 			};
 			vi.mocked(getStatus).mockResolvedValueOnce(status);
 
@@ -313,6 +325,7 @@ describe("CLI", () => {
 				mostRecentSession: null,
 				summaryCount: 5,
 				orphanBranch: "jollimemory/summaries/v3",
+				sessionsBySource: {},
 				codexDetected: true,
 				geminiDetected: true,
 			});
@@ -340,6 +353,7 @@ describe("CLI", () => {
 				mostRecentSession: null,
 				summaryCount: 0,
 				orphanBranch: "jollimemory/summaries/v3",
+				sessionsBySource: {},
 			});
 
 			await main(["status"]);
@@ -357,6 +371,7 @@ describe("CLI", () => {
 				mostRecentSession: null,
 				summaryCount: 5,
 				orphanBranch: "jollimemory/summaries/v3",
+				sessionsBySource: {},
 				hookSource: "cli",
 				hookVersion: "1.0.0",
 			});
@@ -364,6 +379,137 @@ describe("CLI", () => {
 			await main(["status"]);
 			const calls = vi.mocked(console.log).mock.calls.map((c) => String(c[0]));
 			expect(calls.some((s) => s.includes("Hook runtime:") && s.includes("cli@1.0.0"))).toBe(true);
+		});
+
+		describe("integration rows", () => {
+			it("renders rows for all four integrations when detected, with session counts", async () => {
+				vi.mocked(getStatus).mockResolvedValueOnce({
+					enabled: true,
+					claudeHookInstalled: true,
+					gitHookInstalled: true,
+					geminiHookInstalled: true,
+					activeSessions: 10,
+					mostRecentSession: null,
+					summaryCount: 0,
+					orphanBranch: "jollimemory/summaries/v3",
+					claudeDetected: true,
+					codexDetected: true,
+					geminiDetected: true,
+					openCodeDetected: true,
+					codexEnabled: true,
+					geminiEnabled: true,
+					openCodeEnabled: true,
+					sessionsBySource: { claude: 3, codex: 2, gemini: 4, opencode: 1 },
+				});
+				vi.mocked(loadConfigFromDir).mockResolvedValueOnce({ claudeEnabled: true });
+
+				await main(["status"]);
+				const calls = vi.mocked(console.log).mock.calls.map((c) => String(c[0]));
+				expect(calls.some((s) => s.includes("Claude:") && s.includes("hook installed (3 sessions)"))).toBe(
+					true,
+				);
+				expect(calls.some((s) => s.includes("Codex:") && s.includes("detected & enabled (2 sessions)"))).toBe(
+					true,
+				);
+				expect(calls.some((s) => s.includes("Gemini:") && s.includes("hook installed (4 sessions)"))).toBe(
+					true,
+				);
+				expect(calls.some((s) => s.includes("OpenCode:") && s.includes("detected & enabled (1 session)"))).toBe(
+					true,
+				);
+			});
+
+			it("renders 'detected but disabled' when an integration is turned off in config", async () => {
+				vi.mocked(getStatus).mockResolvedValueOnce({
+					enabled: true,
+					claudeHookInstalled: false,
+					gitHookInstalled: true,
+					geminiHookInstalled: false,
+					activeSessions: 0,
+					mostRecentSession: null,
+					summaryCount: 0,
+					orphanBranch: "jollimemory/summaries/v3",
+					claudeDetected: true,
+					codexDetected: true,
+					openCodeDetected: true,
+					codexEnabled: false,
+					openCodeEnabled: false,
+					sessionsBySource: {},
+				});
+				vi.mocked(loadConfigFromDir).mockResolvedValueOnce({ claudeEnabled: false });
+
+				await main(["status"]);
+				const calls = vi.mocked(console.log).mock.calls.map((c) => String(c[0]));
+				expect(calls.some((s) => s.includes("Claude:") && s.includes("detected but disabled"))).toBe(true);
+				expect(calls.some((s) => s.includes("Codex:") && s.includes("detected but disabled"))).toBe(true);
+				expect(calls.some((s) => s.includes("OpenCode:") && s.includes("detected but disabled"))).toBe(true);
+			});
+
+			it("renders 'hook not installed' for Gemini when detected+enabled but the AfterAgent hook is missing", async () => {
+				vi.mocked(getStatus).mockResolvedValueOnce({
+					enabled: true,
+					claudeHookInstalled: false,
+					gitHookInstalled: true,
+					geminiHookInstalled: false,
+					activeSessions: 0,
+					mostRecentSession: null,
+					summaryCount: 0,
+					orphanBranch: "jollimemory/summaries/v3",
+					geminiDetected: true,
+					geminiEnabled: true,
+					sessionsBySource: {},
+				});
+
+				await main(["status"]);
+				const calls = vi.mocked(console.log).mock.calls.map((c) => String(c[0]));
+				expect(calls.some((s) => s.includes("Gemini:") && s.includes("hook not installed"))).toBe(true);
+			});
+
+			it("renders 'unavailable — <kind>' for OpenCode when openCodeScanError is present", async () => {
+				vi.mocked(getStatus).mockResolvedValueOnce({
+					enabled: true,
+					claudeHookInstalled: false,
+					gitHookInstalled: true,
+					geminiHookInstalled: false,
+					activeSessions: 0,
+					mostRecentSession: null,
+					summaryCount: 0,
+					orphanBranch: "jollimemory/summaries/v3",
+					openCodeDetected: true,
+					openCodeEnabled: true,
+					openCodeScanError: { kind: "corrupt", message: "database disk image is malformed" },
+					sessionsBySource: {},
+				});
+
+				await main(["status"]);
+				const calls = vi.mocked(console.log).mock.calls.map((c) => String(c[0]));
+				expect(calls.some((s) => s.includes("OpenCode:") && s.includes("unavailable — corrupt"))).toBe(true);
+			});
+
+			it("does not print a row for an integration that was not detected", async () => {
+				vi.mocked(getStatus).mockResolvedValueOnce({
+					enabled: true,
+					claudeHookInstalled: false,
+					gitHookInstalled: true,
+					geminiHookInstalled: false,
+					activeSessions: 0,
+					mostRecentSession: null,
+					summaryCount: 0,
+					orphanBranch: "jollimemory/summaries/v3",
+					claudeDetected: false,
+					codexDetected: false,
+					geminiDetected: false,
+					openCodeDetected: false,
+					sessionsBySource: {},
+				});
+
+				await main(["status"]);
+				const calls = vi.mocked(console.log).mock.calls.map((c) => String(c[0]));
+				expect(calls.some((s) => /^\s+Claude:/.test(s))).toBe(false);
+				expect(calls.some((s) => /^\s+Codex:/.test(s))).toBe(false);
+				expect(calls.some((s) => /^\s+Gemini:/.test(s))).toBe(false);
+				expect(calls.some((s) => /^\s+OpenCode:/.test(s))).toBe(false);
+			});
 		});
 	});
 
@@ -1232,6 +1378,55 @@ describe("CLI", () => {
 			await fs.unlink(outputPath);
 		});
 
+		it("should render entries without topicCount as 0 in markdown table", async () => {
+			// Regression: entries produced by older writers may omit topicCount.
+			// Covers the `e.topicCount ?? 0` fallback branch in buildMarkdownTable.
+			vi.mocked(getIndex).mockResolvedValueOnce({
+				version: 3,
+				entries: [
+					{
+						commitHash: "nocount1",
+						parentCommitHash: null,
+						commitMessage: "No topic count",
+						commitDate: "2026-04-15T10:00:00Z",
+						branch: "main",
+						generatedAt: "2026-04-15T10:00:05Z",
+						// topicCount intentionally omitted
+					},
+				],
+			});
+			const os = await import("node:os");
+			const outputPath = `${os.tmpdir()}/jolli-view-nocount.md`;
+			await main(["view", "--output", outputPath, "--format", "md"]);
+			const fs = await import("node:fs/promises");
+			const content = await fs.readFile(outputPath, "utf-8");
+			// Missing topicCount should render as "0"
+			expect(content).toMatch(/\| nocount1 \|.*\| 0 \|/);
+			await fs.unlink(outputPath);
+		});
+
+		it("should default --output format to markdown when --format is absent", async () => {
+			// Covers `options.format ?? "md"` fallback branch in the --commit + --output path.
+			vi.mocked(getSummary).mockResolvedValueOnce({
+				version: 3,
+				commitHash: "abc123def456",
+				commitMessage: "Default format",
+				commitAuthor: "John",
+				commitDate: "2026-04-15T10:00:00Z",
+				branch: "main",
+				generatedAt: "2026-04-15T10:00:05Z",
+				topics: [],
+			});
+			const os = await import("node:os");
+			const outputPath = `${os.tmpdir()}/jolli-view-default-fmt.md`;
+			await main(["view", "--commit", "abc123def456", "--output", outputPath]);
+			const fs = await import("node:fs/promises");
+			const content = await fs.readFile(outputPath, "utf-8");
+			// Markdown (not JSON): must have the H1 commit message heading.
+			expect(content).toContain("# Default format");
+			await fs.unlink(outputPath);
+		});
+
 		it("should escape pipe chars and newlines in commit messages for GFM table safety", async () => {
 			// Regression: commit subjects containing '|' (allowed by git) used to break table alignment.
 			vi.mocked(getIndex).mockResolvedValueOnce({
@@ -1476,9 +1671,11 @@ describe("CLI", () => {
 				stats: {
 					topicCount: 0,
 					planCount: 0,
+					noteCount: 0,
 					decisionCount: 0,
 					topicTokens: 0,
 					planTokens: 0,
+					noteTokens: 0,
 					decisionTokens: 0,
 					transcriptTokens: 0,
 					totalTokens: 0,
@@ -1521,9 +1718,11 @@ describe("CLI", () => {
 				stats: {
 					topicCount: 1,
 					planCount: 0,
+					noteCount: 0,
 					decisionCount: 0,
 					topicTokens: 50,
 					planTokens: 0,
+					noteTokens: 0,
 					decisionTokens: 0,
 					transcriptTokens: 0,
 					totalTokens: 50,
@@ -1568,9 +1767,11 @@ describe("CLI", () => {
 				stats: {
 					topicCount: 0,
 					planCount: 0,
+					noteCount: 0,
 					decisionCount: 0,
 					topicTokens: 0,
 					planTokens: 0,
+					noteTokens: 0,
 					decisionTokens: 0,
 					transcriptTokens: 0,
 					totalTokens: 0,
@@ -1708,9 +1909,11 @@ describe("CLI", () => {
 				stats: {
 					topicCount: 0,
 					planCount: 0,
+					noteCount: 0,
 					decisionCount: 0,
 					topicTokens: 0,
 					planTokens: 0,
+					noteTokens: 0,
 					decisionTokens: 0,
 					transcriptTokens: 0,
 					totalTokens: 0,
@@ -1752,9 +1955,11 @@ describe("CLI", () => {
 				stats: {
 					topicCount: 0,
 					planCount: 0,
+					noteCount: 0,
 					decisionCount: 0,
 					topicTokens: 0,
 					planTokens: 0,
+					noteTokens: 0,
 					decisionTokens: 0,
 					transcriptTokens: 0,
 					totalTokens: 0,
@@ -1802,9 +2007,11 @@ describe("CLI", () => {
 				stats: {
 					topicCount: 0,
 					planCount: 0,
+					noteCount: 0,
 					decisionCount: 0,
 					topicTokens: 0,
 					planTokens: 0,
+					noteTokens: 0,
 					decisionTokens: 0,
 					transcriptTokens: 0,
 					totalTokens: 0,
@@ -2150,6 +2357,24 @@ describe("CLI", () => {
 
 			await freshMain(["status"]);
 			expect(getStatus).toHaveBeenCalledWith(process.cwd());
+		});
+
+		it("should resolve recall projectDir from git root when --cwd is omitted", async () => {
+			await main(["recall", "--catalog"]);
+
+			expect(listBranchCatalog).toHaveBeenCalledWith("/mock/project");
+		});
+
+		it("should parse process.argv when args are omitted", async () => {
+			const originalArgv = process.argv;
+			process.argv = ["node", "jollimemory", "status"];
+
+			try {
+				await main();
+				expect(getStatus).toHaveBeenCalled();
+			} finally {
+				process.argv = originalArgv;
+			}
 		});
 	});
 
@@ -2686,6 +2911,22 @@ describe("CLI", () => {
 			expect(output).toContain("***");
 		});
 
+		it("should render array config values as comma-joined strings", async () => {
+			const { loadConfig } = await import("./core/SessionTracker.js");
+			// Use the cast through unknown so TS accepts an ad-hoc array-typed config entry.
+			vi.mocked(loadConfig).mockResolvedValueOnce({
+				excludePatterns: ["*.log", "dist/"],
+			} as unknown as Awaited<ReturnType<typeof loadConfig>>);
+
+			await main(["configure"]);
+
+			const output = vi
+				.mocked(console.log)
+				.mock.calls.map((c) => String(c[0]))
+				.join("\n");
+			expect(output).toContain("*.log, dist/");
+		});
+
 		it("should set a config value with --set key=value", async () => {
 			const { saveConfig } = await import("./core/SessionTracker.js");
 
@@ -2716,6 +2957,45 @@ describe("CLI", () => {
 			await main(["configure", "--set", "geminiEnabled=yes"]);
 
 			expect(saveConfig).toHaveBeenCalledWith(expect.objectContaining({ geminiEnabled: true }));
+		});
+
+		it("should accept openCodeEnabled=true/false", async () => {
+			const { saveConfig } = await import("./core/SessionTracker.js");
+
+			await main(["configure", "--set", "openCodeEnabled=false"]);
+			expect(saveConfig).toHaveBeenCalledWith(expect.objectContaining({ openCodeEnabled: false }));
+
+			vi.mocked(saveConfig).mockClear();
+			await main(["configure", "--set", "openCodeEnabled=true"]);
+			expect(saveConfig).toHaveBeenCalledWith(expect.objectContaining({ openCodeEnabled: true }));
+		});
+
+		it("should reject openCodeEnabled with a non-boolean value", async () => {
+			const { saveConfig } = await import("./core/SessionTracker.js");
+			vi.mocked(saveConfig).mockClear();
+			const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+			try {
+				await main(["configure", "--set", "openCodeEnabled=maybe"]);
+				expect(saveConfig).not.toHaveBeenCalled();
+				expect(process.exitCode).toBe(1);
+				const errorOutput = errorSpy.mock.calls.map((c) => String(c[0])).join("\n");
+				expect(errorOutput).toContain("openCodeEnabled");
+				expect(errorOutput).toContain("true/false");
+			} finally {
+				errorSpy.mockRestore();
+			}
+		});
+
+		it("--list-keys includes openCodeEnabled", async () => {
+			await main(["configure", "--list-keys"]);
+			const output = vi
+				.mocked(console.log)
+				.mock.calls.map((c) => String(c[0]))
+				.join("\n");
+			expect(output).toContain("openCodeEnabled");
+			// Description should mention the Node version requirement — this is
+			// the only config key that's runtime-gated and users deserve the hint.
+			expect(output).toContain("Node 22.5+");
 		});
 
 		it("should reject invalid --set format", async () => {
@@ -3693,6 +3973,20 @@ describe("CLI", () => {
 			expect(browserLogin).toHaveBeenCalledWith(expect.stringContaining("/login"));
 		});
 
+		it("should report Jolli API Key saved when login yields jolliApiKey", async () => {
+			const { browserLogin } = await import("./auth/Login.js");
+			const { loadConfig } = await import("./core/SessionTracker.js");
+			vi.mocked(browserLogin).mockResolvedValueOnce(undefined);
+			// After a successful login, loadConfig sees the freshly-persisted jolliApiKey.
+			vi.mocked(loadConfig).mockResolvedValueOnce({ jolliApiKey: "jk_test" });
+
+			vi.mocked(console.log).mockClear();
+			await main(["auth", "login"]);
+
+			const calls = vi.mocked(console.log).mock.calls.map((c) => String(c[0]));
+			expect(calls.some((s) => s.includes("Jolli API Key:") && s.includes("saved"))).toBe(true);
+		});
+
 		it("should handle login failure gracefully", async () => {
 			const { browserLogin } = await import("./auth/Login.js");
 			vi.mocked(browserLogin).mockRejectedValueOnce(new Error("Connection refused"));
@@ -4228,6 +4522,180 @@ describe("CLI", () => {
 				vi.mocked(getGlobalConfigDir).mockReturnValue("/mock/global/config");
 				await fs.rm(tmpGlobalDir, { recursive: true, force: true });
 			}
+		});
+	});
+
+	describe("interactive enable flow", () => {
+		const origIsTTY = process.stdin.isTTY;
+
+		beforeEach(() => {
+			Object.defineProperty(process.stdin, "isTTY", { value: true, configurable: true });
+		});
+
+		afterEach(() => {
+			Object.defineProperty(process.stdin, "isTTY", { value: origIsTTY, configurable: true });
+		});
+
+		it("should skip prompts for already-configured API keys", async () => {
+			vi.mocked(loadConfigFromDir).mockResolvedValueOnce({ jolliApiKey: "existing", apiKey: "existing" });
+
+			await main(["enable", "--cwd", "/tmp/test-project"]);
+
+			expect(console.log).toHaveBeenCalledWith(expect.stringContaining("configured"));
+			expect(mockQuestion).not.toHaveBeenCalled();
+		});
+	});
+
+	describe("enable command — additional branches", () => {
+		it("should print non-interactive config guide with --yes flag", async () => {
+			await main(["enable", "--yes", "--cwd", "/tmp/test-project"]);
+
+			expect(console.log).toHaveBeenCalledWith(expect.stringContaining("Configure API keys"));
+		});
+
+		it("should print gemini settings path when present", async () => {
+			vi.mocked(install).mockResolvedValueOnce({
+				success: true,
+				message: "OK",
+				warnings: [],
+				geminiSettingsPath: "/home/user/.gemini/settings.json",
+			});
+
+			await main(["enable", "--cwd", "/tmp/test-project"]);
+
+			expect(console.log).toHaveBeenCalledWith(expect.stringContaining("Gemini CLI hook"));
+		});
+
+		it("should print warnings on enable failure", async () => {
+			vi.mocked(install).mockResolvedValueOnce({
+				success: false,
+				message: "Cannot install",
+				warnings: ["Git hook conflict"],
+			});
+
+			await main(["enable", "--cwd", "/tmp/test-project"]);
+
+			expect(console.warn).toHaveBeenCalledWith(expect.stringContaining("Git hook conflict"));
+			expect(process.exitCode).toBe(1);
+		});
+	});
+
+	describe("status command — additional branches", () => {
+		it("should omit version suffix when hookVersion is 'unknown'", async () => {
+			vi.mocked(getStatus).mockResolvedValueOnce({
+				enabled: true,
+				claudeHookInstalled: true,
+				gitHookInstalled: true,
+				geminiHookInstalled: false,
+				activeSessions: 0,
+				mostRecentSession: null,
+				summaryCount: 0,
+				orphanBranch: "jollimemory/summaries/v3",
+				sessionsBySource: {},
+				hookSource: "cli",
+				hookVersion: "unknown",
+			});
+
+			await main(["status"]);
+
+			const calls = vi.mocked(console.log).mock.calls.map((c) => String(c[0]));
+			expect(calls.some((s) => s.includes("Hook runtime:") && s.includes("cli") && !s.includes("@unknown"))).toBe(
+				true,
+			);
+		});
+
+		it("should show hook runtime without version when hookVersion is absent", async () => {
+			vi.mocked(getStatus).mockResolvedValueOnce({
+				enabled: true,
+				claudeHookInstalled: true,
+				gitHookInstalled: true,
+				geminiHookInstalled: false,
+				activeSessions: 0,
+				mostRecentSession: null,
+				summaryCount: 0,
+				orphanBranch: "jollimemory/summaries/v3",
+				sessionsBySource: {},
+				hookSource: "vscode-extension",
+			});
+
+			await main(["status"]);
+
+			const calls = vi.mocked(console.log).mock.calls.map((c) => String(c[0]));
+			expect(calls.some((s) => s.includes("Hook runtime:") && s.includes("vscode-extension"))).toBe(true);
+		});
+	});
+
+	describe("recall command — JSON format branches", () => {
+		it("should output JSON catalog with query when no exact match and format is json", async () => {
+			vi.mocked(listBranchCatalog).mockResolvedValueOnce({
+				type: "catalog",
+				branches: [
+					{
+						branch: "feature/other",
+						commitCount: 1,
+						period: { start: "2026-04-01", end: "2026-04-01" },
+						commitMessages: ["x"],
+					},
+				],
+			});
+
+			await main(["recall", "feature/nonexistent", "--format", "json", "--cwd", "/tmp/test"]);
+
+			const output = vi
+				.mocked(console.log)
+				.mock.calls.map((c) => String(c[0]))
+				.join("\n");
+			const parsed = JSON.parse(output);
+			expect(parsed.query).toBe("feature/nonexistent");
+			expect(parsed.branches).toHaveLength(1);
+		});
+
+		it("should output JSON error when catalog is empty and no branch detected", async () => {
+			mockExecFileSync.mockImplementation((_cmd: unknown, args: unknown) => {
+				const a = args as string[];
+				if (a.includes("--show-current")) throw new Error("detached HEAD");
+				if (a.includes("--show-toplevel")) return "/tmp/test\n";
+				return "";
+			});
+			vi.mocked(listBranchCatalog).mockResolvedValueOnce({ type: "catalog", branches: [] });
+
+			await main(["recall", "--format", "json", "--cwd", "/tmp/test"]);
+
+			const output = vi
+				.mocked(console.log)
+				.mock.calls.map((c) => String(c[0]))
+				.join("\n");
+			const parsed = JSON.parse(output);
+			expect(parsed.type).toBe("error");
+		});
+
+		it("should output JSON catalog when no branch detected and catalog is non-empty", async () => {
+			mockExecFileSync.mockImplementation((_cmd: unknown, args: unknown) => {
+				const a = args as string[];
+				if (a.includes("--show-current")) throw new Error("detached");
+				if (a.includes("--show-toplevel")) return "/tmp/test\n";
+				return "";
+			});
+			vi.mocked(listBranchCatalog).mockResolvedValueOnce({
+				type: "catalog",
+				branches: [
+					{
+						branch: "feature/old",
+						commitCount: 1,
+						period: { start: "2026-03-28", end: "2026-03-28" },
+						commitMessages: ["x"],
+					},
+				],
+			});
+
+			await main(["recall", "--format", "json", "--cwd", "/tmp/test"]);
+
+			const output = vi
+				.mocked(console.log)
+				.mock.calls.map((c) => String(c[0]))
+				.join("\n");
+			const parsed = JSON.parse(output);
+			expect(parsed.branches).toHaveLength(1);
 		});
 	});
 });

--- a/cli/src/Types.ts
+++ b/cli/src/Types.ts
@@ -5,7 +5,7 @@
  */
 
 /** Which AI coding agent produced the transcript */
-export type TranscriptSource = "claude" | "codex" | "gemini";
+export type TranscriptSource = "claude" | "codex" | "gemini" | "opencode";
 
 /** Metadata about an AI coding session, saved by the Stop hook (Claude) or discovered on-demand (Codex) */
 export interface SessionInfo {
@@ -442,6 +442,8 @@ export interface JolliMemoryConfig {
 	readonly geminiEnabled?: boolean;
 	/** Enable Claude Code session tracking via Stop hook (default: true) */
 	readonly claudeEnabled?: boolean;
+	/** Enable OpenCode session discovery at post-commit time (default: auto-detect) */
+	readonly openCodeEnabled?: boolean;
 	/** Global minimum log level written to debug.log (default: "info") */
 	readonly logLevel?: LogLevel;
 	/** Per-module log level overrides (e.g. { "GitOps": "debug" }) */
@@ -510,6 +512,10 @@ export interface StatusInfo {
 	readonly geminiDetected?: boolean;
 	/** Whether Gemini CLI session tracking is enabled in config (undefined = auto-detect) */
 	readonly geminiEnabled?: boolean;
+	/** Whether the global OpenCode database (~/.local/share/opencode/opencode.db) was detected */
+	readonly openCodeDetected?: boolean;
+	/** Whether OpenCode session discovery is enabled in config (undefined = auto-detect) */
+	readonly openCodeEnabled?: boolean;
 	/** Directory path for global config (~/.jolli/jollimemory) */
 	readonly globalConfigDir?: string;
 	/** Path to the worktree state directory */
@@ -535,6 +541,18 @@ export interface StatusInfo {
 	 * multi-source picture.
 	 */
 	readonly allSources?: ReadonlyArray<DistPathInfo>;
+	/** Per-source session count breakdown, keyed by TranscriptSource */
+	readonly sessionsBySource?: Partial<Record<TranscriptSource, number>>;
+	/**
+	 * OpenCode DB scan failed with a real (non-ENOENT) error — e.g. the DB is
+	 * corrupt, locked, or the schema has drifted. When present, UI should show
+	 * a warning adjacent to the OpenCode integration row rather than rendering
+	 * "0 sessions" (which is indistinguishable from "no OpenCode activity").
+	 */
+	readonly openCodeScanError?: {
+		readonly kind: "corrupt" | "locked" | "permission" | "schema" | "unknown";
+		readonly message: string;
+	};
 }
 
 /**

--- a/cli/src/commands/CliUtils.test.ts
+++ b/cli/src/commands/CliUtils.test.ts
@@ -195,6 +195,19 @@ describe("CliUtils", () => {
 		});
 	});
 
+	describe("formatShortDate", () => {
+		it("formats a valid ISO date as 'Mon DD'", async () => {
+			const { formatShortDate } = await import("./CliUtils.js");
+			expect(formatShortDate("2026-04-15T10:00:00.000Z")).toMatch(/Apr 1[45]/);
+		});
+
+		it("falls back to substring(0, 10) for invalid dates", async () => {
+			const { formatShortDate } = await import("./CliUtils.js");
+			// "xx-not-a-date-longer" is Invalid Date; NaN path returns first 10 chars.
+			expect(formatShortDate("xx-not-a-date-longer")).toBe("xx-not-a-d");
+		});
+	});
+
 	describe("SAFE_ARGUMENT_PATTERN", () => {
 		it("should match valid branch names", async () => {
 			const { SAFE_ARGUMENT_PATTERN } = await import("./CliUtils.js");

--- a/cli/src/commands/ConfigureCommand.ts
+++ b/cli/src/commands/ConfigureCommand.ts
@@ -29,6 +29,7 @@ const VALID_CONFIG_KEYS = [
 	"codexEnabled",
 	"geminiEnabled",
 	"claudeEnabled",
+	"openCodeEnabled",
 	"logLevel",
 	"excludePatterns",
 ] as const satisfies ReadonlyArray<keyof JolliMemoryConfig>;
@@ -62,7 +63,7 @@ function coerceConfigValue(key: ConfigKey, raw: string): string | number | boole
 		return n;
 	}
 	// Boolean fields
-	if (key === "codexEnabled" || key === "geminiEnabled" || key === "claudeEnabled") {
+	if (key === "codexEnabled" || key === "geminiEnabled" || key === "claudeEnabled" || key === "openCodeEnabled") {
 		const lower = raw.toLowerCase();
 		if (lower === "true" || lower === "1" || lower === "yes") return true;
 		if (lower === "false" || lower === "0" || lower === "no") return false;
@@ -96,6 +97,11 @@ const CONFIG_KEY_INFO: ReadonlyArray<{ key: ConfigKey; type: string; description
 	{ key: "codexEnabled", type: "boolean", description: "Enable Codex CLI session discovery (true/false)" },
 	{ key: "geminiEnabled", type: "boolean", description: "Enable Gemini CLI session tracking (true/false)" },
 	{ key: "claudeEnabled", type: "boolean", description: "Enable Claude Code session tracking (true/false)" },
+	{
+		key: "openCodeEnabled",
+		type: "boolean",
+		description: "Enable OpenCode session discovery (true/false; requires Node 22.5+ at runtime)",
+	},
 	{ key: "logLevel", type: "enum", description: "Log level: debug | info | warn | error" },
 	{ key: "excludePatterns", type: "string[]", description: "Glob patterns for file exclusion (comma-separated)" },
 ];

--- a/cli/src/commands/DoctorCommand.ts
+++ b/cli/src/commands/DoctorCommand.ts
@@ -199,8 +199,9 @@ async function runDoctor(cwd: string, fix: boolean): Promise<void> {
 	if (fix && fixesToApply.length > 0) {
 		console.log("\n  Applying fixes...");
 		for (const check of fixesToApply) {
-			/* v8 ignore next -- defensive: fixesToApply already filtered by check.fixer existence */
+			/* v8 ignore start -- defensive: fixesToApply already filtered by check.fixer existence */
 			if (!check.fixer) continue;
+			/* v8 ignore stop */
 			try {
 				const result = await check.fixer();
 				console.log(`  ✓ ${check.name}: ${result}`);

--- a/cli/src/commands/StatusCommand.ts
+++ b/cli/src/commands/StatusCommand.ts
@@ -11,9 +11,46 @@ import { parseJolliApiKey } from "../core/JolliApiUtils.js";
 import { getGlobalConfigDir, loadConfigFromDir } from "../core/SessionTracker.js";
 import { getStatus } from "../install/Installer.js";
 import { createLogger, setLogDir } from "../Logger.js";
+import type { StatusInfo } from "../Types.js";
 import { resolveProjectDir, VERSION } from "./CliUtils.js";
 
 const log = createLogger("StatusCommand");
+
+/** Inputs to describeIntegrationStatus — one row in the CLI integration block. */
+interface IntegrationStatusInputs {
+	readonly enabled: boolean;
+	/** undefined = this integration has no hook concept (Codex, OpenCode). */
+	readonly hookInstalled: boolean | undefined;
+	readonly sessionCount: number | undefined;
+	/** OpenCode-only: DB existed but scan failed (corrupt/locked/schema/etc). */
+	readonly scanError?: StatusInfo["openCodeScanError"];
+}
+
+/**
+ * Formats the descriptor for one integration row in `jolli status` output.
+ *
+ * Mirrors the VSCode STATUS panel's four-state model (see StatusTreeProvider's
+ * pushIntegrationItem) plus a dedicated "unavailable" state for OpenCode's
+ * scan-error channel. Wording is kept aligned with VSCode so users see the
+ * same language in both surfaces.
+ */
+function describeIntegrationStatus(x: IntegrationStatusInputs): string {
+	if (x.scanError) {
+		return `unavailable — ${x.scanError.kind}`;
+	}
+	if (!x.enabled) {
+		return "detected but disabled";
+	}
+	const count = x.sessionCount ?? 0;
+	const suffix = count > 0 ? ` (${count} session${count !== 1 ? "s" : ""})` : "";
+	if (x.hookInstalled === false) {
+		return "hook not installed";
+	}
+	if (x.hookInstalled === true) {
+		return `hook installed${suffix}`;
+	}
+	return `detected & enabled${suffix}`;
+}
 
 /** Registers the `status` command on the given Commander program. */
 export function registerStatusCommand(program: Command): void {
@@ -65,6 +102,58 @@ export function registerStatusCommand(program: Command): void {
 				`  Anthropic Key:    ${config?.apiKey || process.env.ANTHROPIC_API_KEY ? "Configured" : "Not configured"}`,
 			);
 			console.log(`  Sessions:         ${status.activeSessions}`);
+
+			// Per-integration breakdown. Only print rows for detected integrations;
+			// undetected ones stay hidden to keep the output terse (same rule as
+			// the VSCode STATUS panel). Claude's enabled flag lives in config, not
+			// StatusInfo, so read it from the already-loaded `config`.
+			const counts = status.sessionsBySource ?? {};
+			const integrationRows: ReadonlyArray<
+				readonly [label: string, detected: boolean | undefined, inputs: IntegrationStatusInputs]
+			> = [
+				[
+					"Claude:",
+					status.claudeDetected,
+					{
+						enabled: config?.claudeEnabled !== false,
+						hookInstalled: status.claudeHookInstalled,
+						sessionCount: counts.claude,
+					},
+				],
+				[
+					"Codex:",
+					status.codexDetected,
+					{
+						enabled: status.codexEnabled !== false,
+						hookInstalled: undefined,
+						sessionCount: counts.codex,
+					},
+				],
+				[
+					"Gemini:",
+					status.geminiDetected,
+					{
+						enabled: status.geminiEnabled !== false,
+						hookInstalled: status.geminiHookInstalled,
+						sessionCount: counts.gemini,
+					},
+				],
+				[
+					"OpenCode:",
+					status.openCodeDetected,
+					{
+						enabled: status.openCodeEnabled !== false,
+						hookInstalled: undefined,
+						sessionCount: counts.opencode,
+						scanError: status.openCodeScanError,
+					},
+				],
+			];
+			for (const [label, detected, inputs] of integrationRows) {
+				if (!detected) continue;
+				console.log(`  ${label.padEnd(18)}${describeIntegrationStatus(inputs)}`);
+			}
+
 			console.log(`  Stored memories:  ${status.summaryCount}`);
 			if (jolliSite) {
 				console.log(`  Jolli Site:       ${jolliSite.replace(/^https?:\/\//, "")}`);

--- a/cli/src/core/ContextCompiler.test.ts
+++ b/cli/src/core/ContextCompiler.test.ts
@@ -311,6 +311,55 @@ describe("compileTaskContext", () => {
 		expect(ctx.plans).toHaveLength(1);
 		expect(ctx.plans[0].title).toBe("OAuth Strategy v2");
 	});
+
+	it("should deduplicate notes that appear in multiple summaries", async () => {
+		const sharedNoteRef = {
+			id: "note-abc-1234abcd",
+			title: "Shared Note",
+			format: "snippet" as const,
+			content: "Note content here",
+			addedAt: "2026-03-28T10:00:00.000Z",
+			updatedAt: "2026-03-28T10:00:00.000Z",
+		};
+		const summaryWithNote1 = makeSummary({
+			commitHash: "aaa11111",
+			commitDate: "2026-03-28T10:00:00.000Z",
+			notes: [sharedNoteRef],
+		});
+		const summaryWithNote2 = makeSummary({
+			commitHash: "bbb22222",
+			commitDate: "2026-03-29T10:00:00.000Z",
+			notes: [sharedNoteRef],
+		});
+
+		mockGetIndex.mockResolvedValue(
+			makeIndex([
+				{
+					commitHash: "aaa11111",
+					parentCommitHash: null,
+					commitMessage: "c1",
+					commitDate: "2026-03-28T10:00:00.000Z",
+					branch: "feature/test",
+					generatedAt: "2026-03-28T10:01:00.000Z",
+				},
+				{
+					commitHash: "bbb22222",
+					parentCommitHash: null,
+					commitMessage: "c2",
+					commitDate: "2026-03-29T10:00:00.000Z",
+					branch: "feature/test",
+					generatedAt: "2026-03-29T10:01:00.000Z",
+				},
+			]),
+		);
+		mockGetSummary.mockResolvedValueOnce(summaryWithNote1).mockResolvedValueOnce(summaryWithNote2);
+
+		const ctx = await compileTaskContext({ branch: "feature/test", includeNotes: true }, "/test");
+		// The same note ID appears in both summaries, so it should be deduplicated to 1
+		expect(ctx.notes).toHaveLength(1);
+		expect(ctx.notes[0].id).toBe("note-abc-1234abcd");
+		expect(ctx.notes[0].content).toBe("Note content here");
+	});
 });
 
 // ─── renderContextMarkdown ───────────────────────────────────────────────────

--- a/cli/src/core/GitOps.test.ts
+++ b/cli/src/core/GitOps.test.ts
@@ -171,6 +171,24 @@ describe("GitOps", () => {
 			const result = await execGit(["status"]);
 			expect(result.exitCode).toBe(1);
 		});
+
+		it("should fall back to the error message when stdout and stderr are missing", async () => {
+			const error = new Error("message only") as Error & {
+				code?: number | string;
+				stdout?: string;
+				stderr?: string;
+			};
+			delete error.code;
+			delete error.stdout;
+			delete error.stderr;
+			mockExecFileAsync.mockRejectedValueOnce(error);
+
+			const result = await execGit(["status"]);
+
+			expect(result.stdout).toBe("");
+			expect(result.stderr).toBe("message only");
+			expect(result.exitCode).toBe(1);
+		});
 	});
 
 	describe("getHeadCommitInfo", () => {
@@ -1056,6 +1074,45 @@ describe("GitOps", () => {
 			const hooksDir = await resolveGitHooksDir(projectDir);
 			// For a non-worktree gitlink, hooks are inside the resolved gitdir
 			expect(hooksDir).toBe(join(bareGitDir, "hooks"));
+		});
+
+		it("should throw when a gitlink file is malformed", async () => {
+			const projectDir = join(tempDir, "project");
+			await mkdir(projectDir, { recursive: true });
+			await writeFile(join(projectDir, ".git"), "not-a-gitdir-pointer\n", "utf-8");
+
+			await expect(resolveGitHooksDir(projectDir)).rejects.toThrow("Unexpected .git file content");
+		});
+	});
+
+	describe("spawn-backed git helpers", () => {
+		it("should reject when spawn emits an error event", async () => {
+			mockFailure(128, "not a valid ref");
+			mockSpawn.mockImplementationOnce(() => {
+				const proc = Object.assign(new EventEmitter(), {
+					stdin: { write: vi.fn(), end: vi.fn() },
+					stdout: new EventEmitter(),
+					stderr: new EventEmitter(),
+				});
+				queueMicrotask(() => {
+					proc.emit("error", new Error("spawn failed"));
+				});
+				return proc;
+			});
+
+			await expect(ensureOrphanBranch("broken-branch")).rejects.toThrow("spawn failed");
+		});
+
+		it("should throw when existing subtree metadata is malformed", async () => {
+			mockSuccess("abc\n");
+			mockSuccess("parent\n");
+			mockSuccess("root_tree\n");
+			mockSpawnSuccess("new_blob\n");
+			mockSuccess("not-a-tree-line\n");
+
+			await expect(writeFileToBranch("branch", "summaries/abc.json", "{}", "Add")).rejects.toThrow(
+				"Unexpected ls-tree output",
+			);
 		});
 	});
 });

--- a/cli/src/core/LlmClient.test.ts
+++ b/cli/src/core/LlmClient.test.ts
@@ -186,6 +186,20 @@ describe("LlmClient", () => {
 			vi.unstubAllGlobals();
 		});
 
+		it("throws when proxy mode loses jolliApiKey before the inner proxy call", async () => {
+			let reads = 0;
+			const options = {
+				action: "commit-message",
+				params: { branch: "main", fileList: "src/foo.ts", stagedDiff: "diff" },
+				get jolliApiKey() {
+					reads += 1;
+					return reads === 1 ? "sk-jol-test.secret" : undefined;
+				},
+			} as unknown as Parameters<typeof callLlm>[0];
+
+			await expect(callLlm(options)).rejects.toThrow("Proxy mode requires jolliApiKey");
+		});
+
 		it("posts to the backend when jolliApiKey is provided", async () => {
 			const result = await callLlm({
 				action: "commit-message",
@@ -264,6 +278,22 @@ describe("LlmClient", () => {
 			const fetchCall = fetchSpy.mock.calls[0] as [string, RequestInit];
 			const body = JSON.parse(fetchCall[1].body as string) as Record<string, unknown>;
 			expect(body.version).toBe(2);
+		});
+
+		it("defaults missing proxy token counts to zero", async () => {
+			fetchSpy.mockResolvedValueOnce({
+				ok: true,
+				json: vi.fn().mockResolvedValue({ text: "proxy result" }),
+			});
+
+			const result = await callLlm({
+				action: "commit-message",
+				params: { branch: "main", fileList: "src/foo.ts", stagedDiff: "diff" },
+				jolliApiKey: "sk-jol-test.secret",
+			});
+
+			expect(result.inputTokens).toBe(0);
+			expect(result.outputTokens).toBe(0);
 		});
 
 		it("omits tenant and org headers when metadata is absent", async () => {

--- a/cli/src/core/OpenCodeSessionDiscoverer.test.ts
+++ b/cli/src/core/OpenCodeSessionDiscoverer.test.ts
@@ -1,0 +1,469 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Suppress console output
+vi.spyOn(console, "log").mockImplementation(() => {});
+vi.spyOn(console, "warn").mockImplementation(() => {});
+vi.spyOn(console, "error").mockImplementation(() => {});
+
+// Mock homedir so tests don't depend on real home directory
+const { mockHomedir } = vi.hoisted(() => ({
+	mockHomedir: vi.fn().mockReturnValue(""),
+}));
+vi.mock("node:os", async (importOriginal) => {
+	const original = await importOriginal<typeof import("node:os")>();
+	return { ...original, homedir: mockHomedir };
+});
+
+import {
+	classifyScanError,
+	discoverOpenCodeSessions,
+	getOpenCodeDbPath,
+	hasNodeSqliteSupport,
+	isOpenCodeInstalled,
+	NODE_SQLITE_MIN_VERSION,
+	scanOpenCodeSessions,
+} from "./OpenCodeSessionDiscoverer.js";
+
+/**
+ * Creates a minimal OpenCode SQLite database with the real schema.
+ * Returns the path to the DB file.
+ */
+async function createOpenCodeDb(
+	dbDir: string,
+	sessions: ReadonlyArray<{
+		id: string;
+		title?: string;
+		directory: string;
+		parent_id?: string | null;
+		project_id?: string;
+		time_created: number;
+		time_updated: number;
+	}>,
+): Promise<string> {
+	await mkdir(dbDir, { recursive: true });
+	const dbPath = join(dbDir, "opencode.db");
+
+	const db = new DatabaseSync(dbPath);
+
+	const ddl = [
+		`CREATE TABLE project (
+			id TEXT PRIMARY KEY,
+			worktree TEXT NOT NULL,
+			name TEXT,
+			time_created INTEGER NOT NULL,
+			time_updated INTEGER NOT NULL,
+			sandboxes TEXT NOT NULL DEFAULT '[]'
+		)`,
+		`CREATE TABLE session (
+			id TEXT PRIMARY KEY,
+			project_id TEXT NOT NULL,
+			parent_id TEXT,
+			slug TEXT NOT NULL DEFAULT '',
+			directory TEXT NOT NULL,
+			title TEXT NOT NULL DEFAULT '',
+			version TEXT NOT NULL DEFAULT '1',
+			time_created INTEGER NOT NULL,
+			time_updated INTEGER NOT NULL,
+			FOREIGN KEY (project_id) REFERENCES project(id) ON DELETE CASCADE
+		)`,
+		`CREATE TABLE message (
+			id TEXT PRIMARY KEY,
+			session_id TEXT NOT NULL,
+			time_created INTEGER NOT NULL,
+			time_updated INTEGER NOT NULL,
+			data TEXT NOT NULL,
+			FOREIGN KEY (session_id) REFERENCES session(id) ON DELETE CASCADE
+		)`,
+		`CREATE TABLE part (
+			id TEXT PRIMARY KEY,
+			message_id TEXT NOT NULL,
+			session_id TEXT NOT NULL,
+			time_created INTEGER NOT NULL,
+			time_updated INTEGER NOT NULL,
+			data TEXT NOT NULL,
+			FOREIGN KEY (message_id) REFERENCES message(id) ON DELETE CASCADE
+		)`,
+	];
+	for (const sql of ddl) {
+		db.prepare(sql).run();
+	}
+
+	const defaultProjectId = "proj-test";
+	db.prepare("INSERT INTO project (id, worktree, time_created, time_updated) VALUES (?, ?, ?, ?)").run(
+		defaultProjectId,
+		"/test",
+		Date.now(),
+		Date.now(),
+	);
+
+	const insertSession = db.prepare(
+		"INSERT INTO session (id, project_id, parent_id, directory, title, time_created, time_updated) VALUES (?, ?, ?, ?, ?, ?, ?)",
+	);
+	for (const s of sessions) {
+		insertSession.run(
+			s.id,
+			s.project_id ?? defaultProjectId,
+			s.parent_id ?? null,
+			s.directory,
+			s.title ?? "Test Session",
+			s.time_created,
+			s.time_updated,
+		);
+	}
+
+	db.close();
+	return dbPath;
+}
+
+describe("OpenCodeSessionDiscoverer", () => {
+	let tempDir: string;
+	let fakeHome: string;
+	const projectDir = "/Users/test/my-project";
+	const savedXdgDataHome = process.env.XDG_DATA_HOME;
+
+	beforeEach(async () => {
+		tempDir = await mkdtemp(join(tmpdir(), "opencode-test-"));
+		fakeHome = await mkdtemp(join(tmpdir(), "opencode-home-"));
+		mockHomedir.mockReturnValue(fakeHome);
+		delete process.env.XDG_DATA_HOME;
+	});
+
+	afterEach(async () => {
+		// Restore XDG_DATA_HOME to avoid leaking between tests
+		if (savedXdgDataHome === undefined) delete process.env.XDG_DATA_HOME;
+		else process.env.XDG_DATA_HOME = savedXdgDataHome;
+		await rm(tempDir, { recursive: true, force: true });
+		await rm(fakeHome, { recursive: true, force: true });
+	});
+
+	describe("getOpenCodeDbPath", () => {
+		it("returns the default XDG path under home directory", () => {
+			delete process.env.XDG_DATA_HOME;
+			mockHomedir.mockReturnValue("/home/user");
+			expect(getOpenCodeDbPath()).toBe("/home/user/.local/share/opencode/opencode.db");
+		});
+
+		it("respects XDG_DATA_HOME when set", () => {
+			process.env.XDG_DATA_HOME = "/custom/data";
+			expect(getOpenCodeDbPath()).toBe("/custom/data/opencode/opencode.db");
+		});
+	});
+
+	describe("isOpenCodeInstalled", () => {
+		it("returns true when global opencode.db exists", async () => {
+			const dbDir = join(fakeHome, ".local", "share", "opencode");
+			await createOpenCodeDb(dbDir, []);
+			expect(await isOpenCodeInstalled()).toBe(true);
+		});
+
+		it("returns false when opencode.db does not exist", async () => {
+			expect(await isOpenCodeInstalled()).toBe(false);
+		});
+
+		it("returns false when directory exists but DB file does not", async () => {
+			await mkdir(join(fakeHome, ".local", "share", "opencode"), { recursive: true });
+			expect(await isOpenCodeInstalled()).toBe(false);
+		});
+
+		it("finds opencode.db at custom XDG_DATA_HOME", async () => {
+			const customData = join(tempDir, "custom-data");
+			process.env.XDG_DATA_HOME = customData;
+			const dbDir = join(customData, "opencode");
+			await createOpenCodeDb(dbDir, []);
+			expect(await isOpenCodeInstalled()).toBe(true);
+		});
+
+		it("returns false when runtime Node version is below the node:sqlite threshold", async () => {
+			// Even with a real DB file, an unsupported Node runtime must report "not installed"
+			// so the UI never shows a detected-but-unusable OpenCode integration.
+			const dbDir = join(fakeHome, ".local", "share", "opencode");
+			await createOpenCodeDb(dbDir, []);
+			const originalDescriptor = Object.getOwnPropertyDescriptor(process.versions, "node");
+			Object.defineProperty(process.versions, "node", { value: "20.15.0", configurable: true });
+			try {
+				expect(await isOpenCodeInstalled()).toBe(false);
+			} finally {
+				/* v8 ignore next -- Object.getOwnPropertyDescriptor on a standard process field always returns a descriptor on supported runtimes */
+				if (originalDescriptor) Object.defineProperty(process.versions, "node", originalDescriptor);
+			}
+		});
+	});
+
+	describe("hasNodeSqliteSupport", () => {
+		const { major, minor } = NODE_SQLITE_MIN_VERSION;
+
+		it("returns true on exactly the minimum version", () => {
+			expect(hasNodeSqliteSupport(`${major}.${minor}.0`)).toBe(true);
+		});
+
+		it("returns true on a later major", () => {
+			expect(hasNodeSqliteSupport(`${major + 1}.0.0`)).toBe(true);
+		});
+
+		it("returns true on a later minor within the same major", () => {
+			expect(hasNodeSqliteSupport(`${major}.${minor + 1}.0`)).toBe(true);
+		});
+
+		it("returns false on an earlier minor within the same major", () => {
+			// minor=0 covers the "earlier minor" branch even when NODE_SQLITE_MIN_VERSION.minor is 0
+			// (the comparison is `>=`, so 22.0.0 < 22.5.0 returns false).
+			expect(hasNodeSqliteSupport(`${major}.0.0`)).toBe(false);
+		});
+
+		it("returns false on an earlier major", () => {
+			expect(hasNodeSqliteSupport(`${major - 1}.99.0`)).toBe(false);
+		});
+
+		it("treats prerelease tags correctly (major.minor extracted from prefix)", () => {
+			expect(hasNodeSqliteSupport("22.5.0-nightly20260101")).toBe(true);
+			expect(hasNodeSqliteSupport("20.15.0-nightly20260101")).toBe(false);
+		});
+	});
+
+	describe("discoverOpenCodeSessions", () => {
+		it("discovers recent top-level sessions for the given project", async () => {
+			const now = Date.now();
+			const dbDir = join(fakeHome, ".local", "share", "opencode");
+			await createOpenCodeDb(dbDir, [
+				{ id: "s1", directory: projectDir, time_created: now - 1000, time_updated: now - 500 },
+				{ id: "s2", directory: projectDir, time_created: now - 2000, time_updated: now - 100 },
+			]);
+
+			const sessions = await discoverOpenCodeSessions(projectDir);
+
+			expect(sessions).toHaveLength(2);
+			expect(sessions[0].sessionId).toBe("s2");
+			expect(sessions[1].sessionId).toBe("s1");
+			expect(sessions[0].source).toBe("opencode");
+			expect(sessions[0].transcriptPath).toContain("#s2");
+		});
+
+		it("filters out sessions from other projects", async () => {
+			const now = Date.now();
+			const dbDir = join(fakeHome, ".local", "share", "opencode");
+			await createOpenCodeDb(dbDir, [
+				{ id: "mine", directory: projectDir, time_created: now - 1000, time_updated: now - 100 },
+				{
+					id: "other",
+					directory: "/Users/test/other-project",
+					time_created: now - 500,
+					time_updated: now - 50,
+				},
+			]);
+
+			const sessions = await discoverOpenCodeSessions(projectDir);
+
+			expect(sessions).toHaveLength(1);
+			expect(sessions[0].sessionId).toBe("mine");
+		});
+
+		it("filters out stale sessions older than 48 hours", async () => {
+			const now = Date.now();
+			const old = now - 49 * 60 * 60 * 1000;
+			const dbDir = join(fakeHome, ".local", "share", "opencode");
+			await createOpenCodeDb(dbDir, [
+				{ id: "fresh", directory: projectDir, time_created: now - 1000, time_updated: now - 100 },
+				{ id: "stale", directory: projectDir, time_created: old, time_updated: old },
+			]);
+
+			const sessions = await discoverOpenCodeSessions(projectDir);
+
+			expect(sessions).toHaveLength(1);
+			expect(sessions[0].sessionId).toBe("fresh");
+		});
+
+		it("includes child sessions from auto-compaction (non-null parent_id)", async () => {
+			const now = Date.now();
+			const dbDir = join(fakeHome, ".local", "share", "opencode");
+			await createOpenCodeDb(dbDir, [
+				{ id: "parent", directory: projectDir, time_created: now - 1000, time_updated: now - 100 },
+				{
+					id: "child",
+					directory: projectDir,
+					parent_id: "parent",
+					time_created: now - 500,
+					time_updated: now - 50,
+				},
+			]);
+
+			const sessions = await discoverOpenCodeSessions(projectDir);
+
+			// Both parent and compacted child sessions are discovered
+			expect(sessions).toHaveLength(2);
+			const ids = sessions.map((s) => s.sessionId);
+			expect(ids).toContain("parent");
+			expect(ids).toContain("child");
+		});
+
+		it("returns empty array when DB does not exist", async () => {
+			const sessions = await discoverOpenCodeSessions(projectDir);
+			expect(sessions).toHaveLength(0);
+		});
+
+		it("returns empty array when DB has no matching sessions", async () => {
+			const dbDir = join(fakeHome, ".local", "share", "opencode");
+			await createOpenCodeDb(dbDir, []);
+			const sessions = await discoverOpenCodeSessions(projectDir);
+			expect(sessions).toHaveLength(0);
+		});
+
+		it("converts time_updated from unix ms to ISO 8601", async () => {
+			const now = Date.now();
+			const dbDir = join(fakeHome, ".local", "share", "opencode");
+			await createOpenCodeDb(dbDir, [
+				{ id: "ts-test", directory: projectDir, time_created: now - 1000, time_updated: now },
+			]);
+
+			const sessions = await discoverOpenCodeSessions(projectDir);
+
+			expect(sessions[0].updatedAt).toBe(new Date(now).toISOString());
+		});
+
+		it("matches directory case-insensitively on Windows and macOS (drive-letter / path-casing drift)", async () => {
+			// Reproduces the real Windows bug observed in debug.log:
+			//   worker pipeline spawned with cwd "E:\\jollimemory-3" → stored by OpenCode
+			//   extension status reported projectDir "e:\\jollimemory-3" → exact-match missed
+			// Both describe the same directory on a case-insensitive filesystem, so the
+			// SQL must match regardless of drive-letter casing on Windows / macOS.
+			// Linux filesystems are case-sensitive, so exact-match is the correct behaviour
+			// there and this test asserts the lookup returns empty.
+			const now = Date.now();
+			const dbDir = join(fakeHome, ".local", "share", "opencode");
+			const storedDir = "E:\\jollimemory-3";
+			const queryDir = "e:\\jollimemory-3";
+			await createOpenCodeDb(dbDir, [
+				{ id: "drive-letter", directory: storedDir, time_created: now - 1000, time_updated: now },
+			]);
+
+			const sessions = await discoverOpenCodeSessions(queryDir);
+
+			const caseInsensitive = process.platform === "win32" || process.platform === "darwin";
+			if (caseInsensitive) {
+				expect(sessions.map((s) => s.sessionId)).toEqual(["drive-letter"]);
+			} else {
+				expect(sessions).toHaveLength(0);
+			}
+		});
+
+		it("skips sessions whose time_updated is not a finite number (schema drift)", async () => {
+			const now = Date.now();
+			const dbDir = join(fakeHome, ".local", "share", "opencode");
+			const dbPath = await createOpenCodeDb(dbDir, [
+				{ id: "good", directory: projectDir, time_created: now - 1000, time_updated: now },
+			]);
+			// SQLite's INTEGER column affinity does not coerce non-numeric TEXT —
+			// the value stays TEXT at rest, simulating schema drift or corrupted data.
+			const db = new DatabaseSync(dbPath);
+			db.prepare(
+				"INSERT INTO session (id, project_id, parent_id, directory, title, time_created, time_updated) VALUES (?, ?, ?, ?, ?, ?, ?)",
+			).run("bad", "proj-test", null, projectDir, "Bad", now - 500, "not-a-number");
+			db.close();
+
+			const sessions = await discoverOpenCodeSessions(projectDir);
+
+			expect(sessions.map((s) => s.sessionId)).toEqual(["good"]);
+		});
+	});
+
+	describe("scanOpenCodeSessions error classification", () => {
+		it("returns no error when DB is missing (ENOENT treated as 'not installed')", async () => {
+			const result = await scanOpenCodeSessions(projectDir);
+			expect(result.sessions).toEqual([]);
+			expect(result.error).toBeUndefined();
+		});
+
+		it("classifies a garbage DB file as corrupt and surfaces the error", async () => {
+			const dbDir = join(fakeHome, ".local", "share", "opencode");
+			await mkdir(dbDir, { recursive: true });
+			// Write bytes that are not a valid SQLite header → SQLITE_NOTADB.
+			await writeFile(join(dbDir, "opencode.db"), "this is not an SQLite database");
+
+			const result = await scanOpenCodeSessions(projectDir);
+
+			expect(result.sessions).toEqual([]);
+			expect(result.error).toBeDefined();
+			// node:sqlite errors on a non-DB may surface as "not a database" or "file is not a database"
+			expect(["corrupt", "unknown"]).toContain(result.error?.kind);
+		});
+
+		it("classifies missing session table as schema drift", async () => {
+			const dbDir = join(fakeHome, ".local", "share", "opencode");
+			await mkdir(dbDir, { recursive: true });
+			// Create a valid SQLite DB but without the `session` table OpenCode expects.
+			const dbPath = join(dbDir, "opencode.db");
+			const db = new DatabaseSync(dbPath);
+			db.prepare("CREATE TABLE unrelated (id TEXT)").run();
+			db.close();
+
+			const result = await scanOpenCodeSessions(projectDir);
+
+			expect(result.sessions).toEqual([]);
+			expect(result.error?.kind).toBe("schema");
+		});
+
+		it("discoverOpenCodeSessions (compat wrapper) still returns only sessions on real failures", async () => {
+			const dbDir = join(fakeHome, ".local", "share", "opencode");
+			await mkdir(dbDir, { recursive: true });
+			await writeFile(join(dbDir, "opencode.db"), "garbage");
+
+			// The compat wrapper must not throw, even though the scan hit a real error.
+			const sessions = await discoverOpenCodeSessions(projectDir);
+			expect(sessions).toEqual([]);
+		});
+	});
+
+	describe("classifyScanError", () => {
+		function err(message: string, code?: string): Error & { code?: string } {
+			const e = new Error(message) as Error & { code?: string };
+			if (code !== undefined) e.code = code;
+			return e;
+		}
+
+		it("returns null for ENOENT (silent 'not installed')", () => {
+			expect(classifyScanError(err("…", "ENOENT"))).toBeNull();
+		});
+
+		it("classifies EACCES and EPERM as permission", () => {
+			expect(classifyScanError(err("denied", "EACCES"))?.kind).toBe("permission");
+			expect(classifyScanError(err("denied", "EPERM"))?.kind).toBe("permission");
+		});
+
+		it("classifies SQLITE_CANTOPEN / 'unable to open' as permission", () => {
+			expect(classifyScanError(err("SQLITE_CANTOPEN: file failed to open"))?.kind).toBe("permission");
+			expect(classifyScanError(err("unable to open database file"))?.kind).toBe("permission");
+		});
+
+		it("classifies SQLITE_CORRUPT and similar as corrupt", () => {
+			expect(classifyScanError(err("SQLITE_CORRUPT: database disk image is malformed"))?.kind).toBe("corrupt");
+			expect(classifyScanError(err("file is not a database"))?.kind).toBe("corrupt");
+			expect(classifyScanError(err("SQLITE_NOTADB"))?.kind).toBe("corrupt");
+		});
+
+		it("classifies SQLITE_BUSY / SQLITE_LOCKED as locked", () => {
+			expect(classifyScanError(err("SQLITE_BUSY: database is locked"))?.kind).toBe("locked");
+			expect(classifyScanError(err("database is locked"))?.kind).toBe("locked");
+			expect(classifyScanError(err("SQLITE_LOCKED"))?.kind).toBe("locked");
+		});
+
+		it("classifies 'no such table'/'no such column' as schema drift", () => {
+			expect(classifyScanError(err("no such table: session"))?.kind).toBe("schema");
+			expect(classifyScanError(err("no such column: time_updated"))?.kind).toBe("schema");
+		});
+
+		it("falls back to 'unknown' for unrecognized errors", () => {
+			const classified = classifyScanError(err("totally unexpected disk failure"));
+			expect(classified?.kind).toBe("unknown");
+			expect(classified?.message).toBe("totally unexpected disk failure");
+		});
+
+		it("handles non-Error throws by stringifying", () => {
+			const classified = classifyScanError("raw string rejection");
+			expect(classified?.kind).toBe("unknown");
+			expect(classified?.message).toBe("raw string rejection");
+		});
+	});
+});

--- a/cli/src/core/OpenCodeSessionDiscoverer.ts
+++ b/cli/src/core/OpenCodeSessionDiscoverer.ts
@@ -1,0 +1,308 @@
+/**
+ * OpenCode Session Discoverer
+ *
+ * On-demand scanner for OpenCode sessions. OpenCode stores all data in a
+ * global SQLite database at ~/.local/share/opencode/opencode.db. Sessions
+ * are scoped to a project via the `directory` column in the `session` table.
+ *
+ * Algorithm:
+ *   1. Check if the global DB file exists at ~/.local/share/opencode/opencode.db
+ *   2. Open the DB read-only using node:sqlite (built-in SQLite with WAL support)
+ *   3. Query the session table for recent top-level sessions matching projectDir
+ *   4. Return matching sessions as SessionInfo[] with source="opencode"
+ *
+ * Cursor design: All sessions share one DB file. To give each session its own
+ * cursor key, we use a synthetic transcriptPath: "<globalDbPath>#<sessionId>".
+ */
+
+import { stat } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { createLogger } from "../Logger.js";
+import type { SessionInfo } from "../Types.js";
+
+const log = createLogger("OpenCodeDiscoverer");
+
+/** Sessions older than 48 hours are considered stale (matches other sources) */
+const SESSION_STALE_MS = 48 * 60 * 60 * 1000;
+
+/**
+ * Returns the XDG data home directory.
+ * Respects the XDG_DATA_HOME environment variable, falling back to ~/.local/share.
+ */
+function getXdgDataHome(): string {
+	return process.env.XDG_DATA_HOME || join(homedir(), ".local", "share");
+}
+
+/**
+ * Database handle shape passed to `withOpenCodeDb` callbacks.
+ *
+ * Structurally typed against node:sqlite's DatabaseSync rather than importing
+ * the type directly, so the module is not loaded until the helper runs — this
+ * keeps the ExperimentalWarning out of every PostCommitHook invocation that
+ * only transitively imports this file.
+ */
+export interface OpenCodeDbHandle {
+	prepare(sql: string): {
+		all(params?: Record<string, unknown> | unknown, ...rest: unknown[]): unknown[];
+		get(params?: Record<string, unknown> | unknown, ...rest: unknown[]): unknown;
+		run(params?: Record<string, unknown> | unknown, ...rest: unknown[]): unknown;
+	};
+	close(): void;
+}
+
+/**
+ * Opens the OpenCode SQLite database read-only, runs a callback, then closes it.
+ *
+ * Uses Node's built-in `node:sqlite` (statically-linked SQLite; full WAL support).
+ * The module is imported dynamically so the ExperimentalWarning only appears
+ * when this helper is actually invoked — not when PostCommitHook merely
+ * transitively imports this file.
+ */
+export async function withOpenCodeDb<T>(dbPath: string, fn: (db: OpenCodeDbHandle) => T): Promise<T> {
+	const { DatabaseSync } = await import("node:sqlite");
+	const db = new DatabaseSync(dbPath, { readOnly: true });
+	try {
+		return fn(db as unknown as OpenCodeDbHandle);
+	} finally {
+		db.close();
+	}
+}
+
+/**
+ * Returns the path to the global OpenCode database file.
+ * Respects XDG_DATA_HOME (defaults to ~/.local/share/opencode/opencode.db).
+ */
+export function getOpenCodeDbPath(): string {
+	return join(getXdgDataHome(), "opencode", "opencode.db");
+}
+
+/**
+ * Minimum Node version that ships `node:sqlite`. OpenCode support requires this
+ * built-in module; older runtimes cannot load it even if the DB file is present.
+ *
+ * Exported for unit tests; callers should use `isOpenCodeInstalled()`.
+ */
+export const NODE_SQLITE_MIN_VERSION = { major: 22, minor: 5 } as const;
+
+/**
+ * Returns true when the current runtime can load `node:sqlite`. Compares the
+ * major.minor of `process.versions.node` against NODE_SQLITE_MIN_VERSION
+ * rather than doing a live probe, which would emit the ExperimentalWarning on
+ * matching runtimes and defeat the lazy-import pattern used by `withOpenCodeDb`.
+ */
+export function hasNodeSqliteSupport(nodeVersion: string = process.versions.node): boolean {
+	const match = /^(\d+)\.(\d+)/.exec(nodeVersion);
+	/* v8 ignore start -- process.versions.node is always well-formed semver in supported runtimes; guard is purely defensive */
+	if (!match) return false;
+	/* v8 ignore stop */
+	const major = Number.parseInt(match[1], 10);
+	const minor = Number.parseInt(match[2], 10);
+	if (major > NODE_SQLITE_MIN_VERSION.major) return true;
+	if (major < NODE_SQLITE_MIN_VERSION.major) return false;
+	return minor >= NODE_SQLITE_MIN_VERSION.minor;
+}
+
+/**
+ * Checks whether the OpenCode database exists AND the current runtime can
+ * actually read it. Returning `false` when the runtime lacks `node:sqlite`
+ * prevents the UI from rendering "OpenCode detected & enabled (0 sessions)"
+ * on a VS Code host whose Electron Node is too old — where a scan would fail
+ * anyway. Keeps the same no-arg shape as `isCodexInstalled`.
+ */
+export async function isOpenCodeInstalled(): Promise<boolean> {
+	if (!hasNodeSqliteSupport()) {
+		// Expected "not applicable", not a failure — log at info so operators
+		// can correlate "OpenCode absent from status" with the runtime version.
+		log.info(
+			"OpenCode support disabled: this runtime is Node %s, requires %d.%d+ for built-in SQLite",
+			process.versions.node,
+			NODE_SQLITE_MIN_VERSION.major,
+			NODE_SQLITE_MIN_VERSION.minor,
+		);
+		return false;
+	}
+	const dbPath = getOpenCodeDbPath();
+	try {
+		const fileStat = await stat(dbPath);
+		return fileStat.isFile();
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Classifies a real OpenCode scan failure into a user-facing severity. Only
+ * *genuine* failures are represented here — ENOENT is excluded because an
+ * OpenCode DB that's absent between `isOpenCodeInstalled()` and our read
+ * is indistinguishable from "not installed" and should stay silent.
+ *
+ * - `corrupt` — SQLite reports SQLITE_CORRUPT / SQLITE_NOTADB. The file exists
+ *   but is unreadable. Users should know.
+ * - `locked` — another process holds an exclusive lock (SQLITE_BUSY). Transient,
+ *   but worth surfacing if it persists.
+ * - `permission` — EACCES / EPERM / SQLITE_CANTOPEN opening the DB. Users
+ *   should know.
+ * - `schema` — the expected table or column is missing. Likely OpenCode version
+ *   drift; users should know so we can support the new schema.
+ * - `unknown` — anything else. Surface as a generic "OpenCode scan failed" warning.
+ */
+export type OpenCodeScanErrorKind = "corrupt" | "locked" | "permission" | "schema" | "unknown";
+
+export interface OpenCodeScanError {
+	readonly kind: OpenCodeScanErrorKind;
+	readonly message: string;
+}
+
+export interface OpenCodeScanResult {
+	readonly sessions: ReadonlyArray<SessionInfo>;
+	/**
+	 * Present only when the scan hit a genuine failure (not ENOENT). Callers
+	 * should surface this to the UI rather than silently reporting "0 sessions".
+	 */
+	readonly error?: OpenCodeScanError;
+}
+
+/**
+ * Returns null if the error is ENOENT (treat as "not installed" — silent).
+ * Exported for unit testing; callers should use `scanOpenCodeSessions`.
+ */
+export function classifyScanError(error: unknown): OpenCodeScanError | null {
+	const err = error as (Error & { code?: string }) | undefined;
+	const message = err?.message ?? String(error);
+	const code = err?.code;
+	if (code === "ENOENT") return null;
+	if (code === "EACCES" || code === "EPERM") return { kind: "permission", message };
+	// node:sqlite surfaces low-level SQLite error codes in the message
+	// (e.g. "SQLITE_CORRUPT: database disk image is malformed").
+	if (/SQLITE_CORRUPT|SQLITE_NOTADB|file is not a database/i.test(message)) {
+		return { kind: "corrupt", message };
+	}
+	if (/SQLITE_BUSY|SQLITE_LOCKED|database is locked/i.test(message)) {
+		return { kind: "locked", message };
+	}
+	if (/no such table|no such column/i.test(message)) {
+		return { kind: "schema", message };
+	}
+	if (/SQLITE_CANTOPEN|unable to open/i.test(message)) {
+		return { kind: "permission", message };
+	}
+	return { kind: "unknown", message };
+}
+
+/**
+ * Discovers OpenCode sessions relevant to the given project directory.
+ * Queries the global ~/.local/share/opencode/opencode.db for recent top-level
+ * sessions (within 48h) matching the given project directory.
+ *
+ * @param projectDir - The git repository root to filter sessions by
+ * @returns { sessions, error? } — sessions is always an array; if `error` is
+ *   present and its kind is not "missing", callers should surface it to the user
+ *   rather than silently reporting "0 sessions" (which is indistinguishable
+ *   from a genuinely-empty scan).
+ */
+export async function scanOpenCodeSessions(projectDir: string): Promise<OpenCodeScanResult> {
+	const dbPath = getOpenCodeDbPath();
+	const cutoffMs = Date.now() - SESSION_STALE_MS;
+
+	// Pre-flight: distinguish "DB missing" (silent) from "DB exists but unreadable"
+	// (genuine failure) before calling DatabaseSync, which surfaces both as the same
+	// "unable to open database file" message.
+	try {
+		await stat(dbPath);
+	} catch (error: unknown) {
+		const code = (error as NodeJS.ErrnoException).code;
+		/* v8 ignore start -- the ENOENT branch is exercised by the "DB is missing" test; the else-branch (EACCES, EPERM, EIO, …) is a rare TOCTOU path that requires a filesystem-level mock to reproduce. The classifier logic itself is fully covered by classifyScanError's unit tests. */
+		if (code !== "ENOENT") {
+			const scanError = classifyScanError(error);
+			if (scanError) {
+				log.error("OpenCode DB stat failed (%s): %s", scanError.kind, scanError.message);
+				return { sessions: [], error: scanError };
+			}
+			return { sessions: [] };
+		}
+		/* v8 ignore stop */
+		log.debug("OpenCode DB not present at %s — treating as not installed", dbPath);
+		return { sessions: [] };
+	}
+
+	try {
+		const sessions = await withOpenCodeDb(dbPath, (db) => {
+			// OpenCode stores timestamps as unix milliseconds (INTEGER).
+			// Include both top-level and continuation (compacted) sessions for this project.
+			// Auto-compact creates child sessions (parent_id != NULL) that carry on the conversation,
+			// so filtering to parent_id IS NULL would miss active sessions after compaction.
+			//
+			// Windows and macOS have case-insensitive filesystems: OpenCode may store
+			// directory as "E:\\proj" while Jolli's projectDir arrives lowercased
+			// (e.g. VS Code URIs lowercase the drive letter). Compare case-insensitively
+			// on those platforms. Linux filesystems are case-sensitive, so exact match
+			// is correct there.
+			const caseInsensitive = process.platform === "win32" || process.platform === "darwin";
+			const directoryMatch = caseInsensitive
+				? "LOWER(directory) = LOWER(:projectDir)"
+				: "directory = :projectDir";
+
+			const rows = db
+				.prepare(
+					`SELECT id, title, time_created, time_updated
+					 FROM session
+					 WHERE ${directoryMatch}
+					   AND time_updated > :cutoff
+					 ORDER BY time_updated DESC`,
+				)
+				.all({ projectDir, cutoff: cutoffMs }) as ReadonlyArray<{
+				id: string;
+				title: string;
+				time_created: number;
+				time_updated: number;
+			}>;
+
+			return rows.flatMap((row): SessionInfo[] => {
+				// Guard against schema drift: SQL's `time_updated > :cutoff` already
+				// filters NULL, but a non-numeric value would make new Date().toISOString()
+				// throw RangeError and bubble up as a spurious "unknown" scan error.
+				if (!Number.isFinite(row.time_updated)) {
+					log.warn("Skipping OpenCode session %s: non-finite time_updated", row.id);
+					return [];
+				}
+				return [
+					{
+						sessionId: String(row.id),
+						// Synthetic path: DB path + session discriminator for unique cursor keying
+						transcriptPath: `${dbPath}#${row.id}`,
+						updatedAt: new Date(row.time_updated).toISOString(),
+						source: "opencode",
+					},
+				];
+			});
+		});
+
+		log.info("Discovered %d OpenCode session(s) for %s", sessions.length, projectDir);
+		return { sessions };
+	} catch (error: unknown) {
+		const scanError = classifyScanError(error);
+		/* v8 ignore start -- TOCTOU race: the DB passed stat() but vanished before DatabaseSync opened it. Requires a filesystem-level mock to reproduce; classifier behavior itself is fully covered by classifyScanError's unit tests. */
+		if (scanError === null) {
+			log.debug("OpenCode DB disappeared between detection and scan: %s", (error as Error).message);
+			return { sessions: [] };
+		}
+		/* v8 ignore stop */
+		// Real failure (corrupt DB, schema drift, permission denied, etc.) —
+		// isOpenCodeInstalled() already confirmed the file exists, so this is
+		// not a silent "no OpenCode". Surface to error log and let callers
+		// bubble the classified error up to the UI.
+		log.error("OpenCode scan failed (%s): %s", scanError.kind, scanError.message);
+		return { sessions: [], error: scanError };
+	}
+}
+
+/**
+ * Backwards-compatible wrapper around `scanOpenCodeSessions` that only returns
+ * the session array. Callers that need to surface scan failures to the user
+ * should call `scanOpenCodeSessions` directly.
+ */
+export async function discoverOpenCodeSessions(projectDir: string): Promise<ReadonlyArray<SessionInfo>> {
+	const { sessions } = await scanOpenCodeSessions(projectDir);
+	return sessions;
+}

--- a/cli/src/core/OpenCodeTranscriptReader.test.ts
+++ b/cli/src/core/OpenCodeTranscriptReader.test.ts
@@ -1,0 +1,436 @@
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Suppress console output
+vi.spyOn(console, "log").mockImplementation(() => {});
+vi.spyOn(console, "warn").mockImplementation(() => {});
+vi.spyOn(console, "error").mockImplementation(() => {});
+
+import { readOpenCodeTranscript } from "./OpenCodeTranscriptReader.js";
+
+/**
+ * Creates an OpenCode SQLite DB with the real schema and inserts test data.
+ * Returns the synthetic transcript path for the given session.
+ */
+async function createTestDb(
+	dir: string,
+	sessionId: string,
+	messages: ReadonlyArray<{
+		id: string;
+		role: string;
+		parts: ReadonlyArray<{ type: string; text?: string; [key: string]: unknown }>;
+		time_created: number;
+	}>,
+): Promise<string> {
+	await mkdir(dir, { recursive: true });
+	const dbPath = join(dir, "opencode.db");
+
+	const db = new DatabaseSync(dbPath);
+
+	const ddl = [
+		`CREATE TABLE project (id TEXT PRIMARY KEY, worktree TEXT NOT NULL, time_created INTEGER NOT NULL, time_updated INTEGER NOT NULL, sandboxes TEXT NOT NULL DEFAULT '[]')`,
+		`CREATE TABLE session (id TEXT PRIMARY KEY, project_id TEXT NOT NULL, directory TEXT NOT NULL, title TEXT NOT NULL DEFAULT '', version TEXT NOT NULL DEFAULT '1', time_created INTEGER NOT NULL, time_updated INTEGER NOT NULL, FOREIGN KEY (project_id) REFERENCES project(id))`,
+		`CREATE TABLE message (id TEXT PRIMARY KEY, session_id TEXT NOT NULL, time_created INTEGER NOT NULL, time_updated INTEGER NOT NULL, data TEXT NOT NULL, FOREIGN KEY (session_id) REFERENCES session(id))`,
+		`CREATE TABLE part (id TEXT PRIMARY KEY, message_id TEXT NOT NULL, session_id TEXT NOT NULL, time_created INTEGER NOT NULL, time_updated INTEGER NOT NULL, data TEXT NOT NULL, FOREIGN KEY (message_id) REFERENCES message(id))`,
+	];
+	for (const sql of ddl) {
+		db.prepare(sql).run();
+	}
+
+	const now = Date.now();
+	db.prepare("INSERT INTO project (id, worktree, time_created, time_updated) VALUES (?, ?, ?, ?)").run(
+		"proj-1",
+		"/test",
+		now,
+		now,
+	);
+	db.prepare("INSERT INTO session VALUES (?, ?, ?, ?, ?, ?, ?)").run(
+		sessionId,
+		"proj-1",
+		"/test",
+		"Test",
+		"1",
+		now,
+		now,
+	);
+
+	const insertMessage = db.prepare(
+		"INSERT INTO message (id, session_id, time_created, time_updated, data) VALUES (?, ?, ?, ?, ?)",
+	);
+	const insertPart = db.prepare(
+		"INSERT INTO part (id, message_id, session_id, time_created, time_updated, data) VALUES (?, ?, ?, ?, ?, ?)",
+	);
+
+	for (const m of messages) {
+		const msgData = JSON.stringify({ role: m.role });
+		insertMessage.run(m.id, sessionId, m.time_created, m.time_created, msgData);
+
+		for (let i = 0; i < m.parts.length; i++) {
+			const partData = JSON.stringify(m.parts[i]);
+			insertPart.run(`${m.id}-p${i}`, m.id, sessionId, m.time_created + i, m.time_created + i, partData);
+		}
+	}
+
+	db.close();
+	return `${dbPath}#${sessionId}`;
+}
+
+describe("OpenCodeTranscriptReader", () => {
+	let tempDir: string;
+
+	beforeEach(async () => {
+		tempDir = await mkdtemp(join(tmpdir(), "opencode-reader-"));
+	});
+
+	afterEach(async () => {
+		await rm(tempDir, { recursive: true, force: true });
+	});
+
+	it("reads user and assistant messages, skipping system and tool roles", async () => {
+		const now = Date.now();
+		const transcriptPath = await createTestDb(tempDir, "sess-1", [
+			{ id: "m1", role: "user", parts: [{ type: "text", text: "Fix the bug" }], time_created: now },
+			{ id: "m2", role: "system", parts: [{ type: "text", text: "You are helpful" }], time_created: now + 1 },
+			{ id: "m3", role: "assistant", parts: [{ type: "text", text: "Done fixing" }], time_created: now + 2 },
+			{ id: "m4", role: "tool", parts: [{ type: "text", text: "tool output" }], time_created: now + 3 },
+		]);
+
+		const result = await readOpenCodeTranscript(transcriptPath);
+
+		expect(result.entries).toHaveLength(2);
+		expect(result.entries[0]).toEqual(expect.objectContaining({ role: "human", content: "Fix the bug" }));
+		expect(result.entries[1]).toEqual(expect.objectContaining({ role: "assistant", content: "Done fixing" }));
+	});
+
+	it("extracts only text parts, skipping tool and patch parts", async () => {
+		const now = Date.now();
+		const transcriptPath = await createTestDb(tempDir, "sess-2", [
+			{
+				id: "m1",
+				role: "assistant",
+				parts: [
+					{ type: "text", text: "Here is the fix" },
+					{ type: "tool", tool: "bash", callID: "c1" },
+					{ type: "patch", hash: "abc123" },
+				],
+				time_created: now,
+			},
+		]);
+
+		const result = await readOpenCodeTranscript(transcriptPath);
+
+		expect(result.entries).toHaveLength(1);
+		expect(result.entries[0].content).toBe("Here is the fix");
+	});
+
+	it("supports cursor-based incremental reading", async () => {
+		const now = Date.now();
+		const transcriptPath = await createTestDb(tempDir, "sess-3", [
+			{ id: "m1", role: "user", parts: [{ type: "text", text: "First" }], time_created: now },
+			{ id: "m2", role: "assistant", parts: [{ type: "text", text: "Reply 1" }], time_created: now + 1 },
+			{ id: "m3", role: "user", parts: [{ type: "text", text: "Second" }], time_created: now + 2 },
+			{ id: "m4", role: "assistant", parts: [{ type: "text", text: "Reply 2" }], time_created: now + 3 },
+		]);
+
+		const first = await readOpenCodeTranscript(transcriptPath);
+		expect(first.entries).toHaveLength(4);
+		expect(first.newCursor.lineNumber).toBe(4);
+
+		const second = await readOpenCodeTranscript(transcriptPath, first.newCursor);
+		expect(second.entries).toHaveLength(0);
+		expect(second.totalLinesRead).toBe(0);
+	});
+
+	it("merges consecutive same-role entries", async () => {
+		const now = Date.now();
+		const transcriptPath = await createTestDb(tempDir, "sess-4", [
+			{ id: "m1", role: "assistant", parts: [{ type: "text", text: "Part 1" }], time_created: now },
+			{ id: "m2", role: "assistant", parts: [{ type: "text", text: "Part 2" }], time_created: now + 1 },
+			{ id: "m3", role: "user", parts: [{ type: "text", text: "Question" }], time_created: now + 2 },
+		]);
+
+		const result = await readOpenCodeTranscript(transcriptPath);
+
+		expect(result.entries).toHaveLength(2);
+		expect(result.entries[0].role).toBe("assistant");
+		expect(result.entries[0].content).toContain("Part 1");
+		expect(result.entries[0].content).toContain("Part 2");
+		expect(result.entries[1].role).toBe("human");
+	});
+
+	it("returns empty entries for session with no messages", async () => {
+		const transcriptPath = await createTestDb(tempDir, "sess-5", []);
+
+		const result = await readOpenCodeTranscript(transcriptPath);
+
+		expect(result.entries).toHaveLength(0);
+		expect(result.totalLinesRead).toBe(0);
+		expect(result.newCursor.lineNumber).toBe(0);
+	});
+
+	it("skips messages with empty text content", async () => {
+		const now = Date.now();
+		const transcriptPath = await createTestDb(tempDir, "sess-6", [
+			{ id: "m1", role: "user", parts: [{ type: "text", text: "   " }], time_created: now },
+			{ id: "m2", role: "assistant", parts: [{ type: "text", text: "Real reply" }], time_created: now + 1 },
+		]);
+
+		const result = await readOpenCodeTranscript(transcriptPath);
+
+		expect(result.entries).toHaveLength(1);
+		expect(result.entries[0].content).toBe("Real reply");
+	});
+
+	it("handles malformed message data JSON gracefully", async () => {
+		const now = Date.now();
+		await mkdir(tempDir, { recursive: true });
+		const dbPath = join(tempDir, "opencode.db");
+		const db = new DatabaseSync(dbPath);
+
+		const ddl = [
+			`CREATE TABLE project (id TEXT PRIMARY KEY, worktree TEXT NOT NULL, time_created INTEGER NOT NULL, time_updated INTEGER NOT NULL, sandboxes TEXT NOT NULL DEFAULT '[]')`,
+			`CREATE TABLE session (id TEXT PRIMARY KEY, project_id TEXT NOT NULL, directory TEXT NOT NULL, title TEXT NOT NULL DEFAULT '', version TEXT NOT NULL DEFAULT '1', time_created INTEGER NOT NULL, time_updated INTEGER NOT NULL, FOREIGN KEY (project_id) REFERENCES project(id))`,
+			`CREATE TABLE message (id TEXT PRIMARY KEY, session_id TEXT NOT NULL, time_created INTEGER NOT NULL, time_updated INTEGER NOT NULL, data TEXT NOT NULL, FOREIGN KEY (session_id) REFERENCES session(id))`,
+			`CREATE TABLE part (id TEXT PRIMARY KEY, message_id TEXT NOT NULL, session_id TEXT NOT NULL, time_created INTEGER NOT NULL, time_updated INTEGER NOT NULL, data TEXT NOT NULL, FOREIGN KEY (message_id) REFERENCES message(id))`,
+		];
+		for (const sql of ddl) {
+			db.prepare(sql).run();
+		}
+
+		db.prepare("INSERT INTO project (id, worktree, time_created, time_updated) VALUES (?, ?, ?, ?)").run(
+			"p1",
+			"/",
+			now,
+			now,
+		);
+		db.prepare("INSERT INTO session VALUES (?, ?, ?, ?, ?, ?, ?)").run("sess-7", "p1", "/", "Test", "1", now, now);
+		db.prepare("INSERT INTO message VALUES (?, ?, ?, ?, ?)").run("m1", "sess-7", now, now, "not valid json");
+		db.prepare("INSERT INTO message VALUES (?, ?, ?, ?, ?)").run(
+			"m2",
+			"sess-7",
+			now + 1,
+			now + 1,
+			JSON.stringify({ role: "assistant" }),
+		);
+		db.prepare("INSERT INTO part VALUES (?, ?, ?, ?, ?, ?)").run(
+			"m2-p0",
+			"m2",
+			"sess-7",
+			now + 1,
+			now + 1,
+			JSON.stringify({ type: "text", text: "Valid reply" }),
+		);
+		db.close();
+
+		const result = await readOpenCodeTranscript(`${dbPath}#sess-7`);
+
+		expect(result.entries).toHaveLength(1);
+		expect(result.entries[0].content).toBe("Valid reply");
+	});
+
+	it("skips messages whose time_created is not a finite number (schema drift)", async () => {
+		const now = Date.now();
+		const transcriptPath = await createTestDb(tempDir, "sess-drift", [
+			{ id: "good", role: "user", parts: [{ type: "text", text: "real message" }], time_created: now },
+		]);
+		const dbPath = transcriptPath.split("#")[0];
+		// SQLite's INTEGER affinity preserves non-numeric TEXT at rest, simulating
+		// a drifted OpenCode schema where time_created is not a valid number.
+		const db = new DatabaseSync(dbPath);
+		db.prepare("INSERT INTO message VALUES (?, ?, ?, ?, ?)").run(
+			"bad",
+			"sess-drift",
+			"garbage",
+			"garbage",
+			JSON.stringify({ role: "assistant" }),
+		);
+		db.prepare("INSERT INTO part VALUES (?, ?, ?, ?, ?, ?)").run(
+			"bad-p0",
+			"bad",
+			"sess-drift",
+			0,
+			0,
+			JSON.stringify({ type: "text", text: "would-throw-toISOString" }),
+		);
+		db.close();
+
+		const result = await readOpenCodeTranscript(transcriptPath);
+
+		expect(result.entries).toHaveLength(1);
+		expect(result.entries[0].content).toBe("real message");
+	});
+
+	it("converts time_created unix ms to ISO 8601 timestamps", async () => {
+		const timestamp = 1711900000000;
+		const transcriptPath = await createTestDb(tempDir, "sess-8", [
+			{ id: "m1", role: "user", parts: [{ type: "text", text: "Hello" }], time_created: timestamp },
+		]);
+
+		const result = await readOpenCodeTranscript(transcriptPath);
+
+		expect(result.entries[0].timestamp).toBe(new Date(timestamp).toISOString());
+	});
+
+	it("throws on invalid synthetic path (missing #sessionId)", async () => {
+		await expect(readOpenCodeTranscript("/no/hash/separator")).rejects.toThrow("missing #sessionId");
+	});
+
+	it("throws on invalid synthetic path with an empty dbPath or session id", async () => {
+		await expect(readOpenCodeTranscript("#sess-x")).rejects.toThrow("empty dbPath or sessionId");
+		await expect(readOpenCodeTranscript("/tmp/opencode.db#")).rejects.toThrow("empty dbPath or sessionId");
+	});
+
+	it("throws when DB file does not exist", async () => {
+		const fakePath = join(tempDir, "nonexistent.db#sess-x");
+		await expect(readOpenCodeTranscript(fakePath)).rejects.toThrow();
+	});
+
+	it("joins multiple text parts within a single message", async () => {
+		const now = Date.now();
+		const transcriptPath = await createTestDb(tempDir, "sess-9", [
+			{
+				id: "m1",
+				role: "assistant",
+				parts: [
+					{ type: "text", text: "Line one" },
+					{ type: "text", text: "Line two" },
+				],
+				time_created: now,
+			},
+		]);
+
+		const result = await readOpenCodeTranscript(transcriptPath);
+
+		expect(result.entries).toHaveLength(1);
+		expect(result.entries[0].content).toBe("Line one\nLine two");
+	});
+
+	it("preserves cursor transcriptPath as the synthetic path", async () => {
+		const now = Date.now();
+		const transcriptPath = await createTestDb(tempDir, "sess-10", [
+			{ id: "m1", role: "user", parts: [{ type: "text", text: "Hello" }], time_created: now },
+		]);
+
+		const result = await readOpenCodeTranscript(transcriptPath);
+
+		expect(result.newCursor.transcriptPath).toBe(transcriptPath);
+	});
+
+	it("handles messages with no parts (LEFT JOIN returns null)", async () => {
+		const now = Date.now();
+		const transcriptPath = await createTestDb(tempDir, "sess-11", [
+			{ id: "m1", role: "assistant", parts: [], time_created: now },
+			{ id: "m2", role: "user", parts: [{ type: "text", text: "Hello" }], time_created: now + 1 },
+		]);
+
+		const result = await readOpenCodeTranscript(transcriptPath);
+
+		expect(result.entries).toHaveLength(1);
+		expect(result.entries[0].content).toBe("Hello");
+	});
+
+	it("skips malformed part JSON and keeps valid text parts from the same message", async () => {
+		const now = Date.now();
+		await mkdir(tempDir, { recursive: true });
+		const dbPath = join(tempDir, "opencode.db");
+		const db = new DatabaseSync(dbPath);
+
+		for (const sql of [
+			`CREATE TABLE project (id TEXT PRIMARY KEY, worktree TEXT NOT NULL, time_created INTEGER NOT NULL, time_updated INTEGER NOT NULL, sandboxes TEXT NOT NULL DEFAULT '[]')`,
+			`CREATE TABLE session (id TEXT PRIMARY KEY, project_id TEXT NOT NULL, directory TEXT NOT NULL, title TEXT NOT NULL DEFAULT '', version TEXT NOT NULL DEFAULT '1', time_created INTEGER NOT NULL, time_updated INTEGER NOT NULL, FOREIGN KEY (project_id) REFERENCES project(id))`,
+			`CREATE TABLE message (id TEXT PRIMARY KEY, session_id TEXT NOT NULL, time_created INTEGER NOT NULL, time_updated INTEGER NOT NULL, data TEXT NOT NULL, FOREIGN KEY (session_id) REFERENCES session(id))`,
+			`CREATE TABLE part (id TEXT PRIMARY KEY, message_id TEXT NOT NULL, session_id TEXT NOT NULL, time_created INTEGER NOT NULL, time_updated INTEGER NOT NULL, data TEXT NOT NULL, FOREIGN KEY (message_id) REFERENCES message(id))`,
+		]) {
+			db.prepare(sql).run();
+		}
+
+		db.prepare("INSERT INTO project (id, worktree, time_created, time_updated) VALUES (?, ?, ?, ?)").run(
+			"p1",
+			"/",
+			now,
+			now,
+		);
+		db.prepare("INSERT INTO session VALUES (?, ?, ?, ?, ?, ?, ?)").run("sess-15", "p1", "/", "Test", "1", now, now);
+		db.prepare("INSERT INTO message VALUES (?, ?, ?, ?, ?)").run(
+			"m1",
+			"sess-15",
+			now,
+			now,
+			JSON.stringify({ role: "assistant" }),
+		);
+		db.prepare("INSERT INTO part VALUES (?, ?, ?, ?, ?, ?)").run("m1-p0", "m1", "sess-15", now, now, "not json");
+		db.prepare("INSERT INTO part VALUES (?, ?, ?, ?, ?, ?)").run(
+			"m1-p1",
+			"m1",
+			"sess-15",
+			now + 1,
+			now + 1,
+			JSON.stringify({ type: "text", text: "Valid text" }),
+		);
+		db.close();
+
+		const result = await readOpenCodeTranscript(`${dbPath}#sess-15`);
+
+		expect(result.entries).toHaveLength(1);
+		expect(result.entries[0].content).toBe("Valid text");
+	});
+
+	it("stops consuming messages at beforeTimestamp cutoff", async () => {
+		const base = 1711900000000;
+		const transcriptPath = await createTestDb(tempDir, "sess-12", [
+			{ id: "m1", role: "user", parts: [{ type: "text", text: "Before" }], time_created: base },
+			{ id: "m2", role: "assistant", parts: [{ type: "text", text: "Reply" }], time_created: base + 1000 },
+			{ id: "m3", role: "user", parts: [{ type: "text", text: "After" }], time_created: base + 5000 },
+			{ id: "m4", role: "assistant", parts: [{ type: "text", text: "Late reply" }], time_created: base + 6000 },
+		]);
+
+		// Cutoff between m2 and m3
+		const cutoff = new Date(base + 2000).toISOString();
+		const result = await readOpenCodeTranscript(transcriptPath, null, cutoff);
+
+		expect(result.entries).toHaveLength(2);
+		expect(result.entries[0].content).toBe("Before");
+		expect(result.entries[1].content).toBe("Reply");
+		// Cursor advances only to the last consumed message, not end
+		expect(result.newCursor.lineNumber).toBe(2);
+	});
+
+	it("advances cursor to end when no beforeTimestamp is provided", async () => {
+		const base = 1711900000000;
+		const transcriptPath = await createTestDb(tempDir, "sess-13", [
+			{ id: "m1", role: "user", parts: [{ type: "text", text: "Hello" }], time_created: base },
+			{ id: "m2", role: "assistant", parts: [{ type: "text", text: "World" }], time_created: base + 1000 },
+		]);
+
+		// Without beforeTimestamp, cursor should advance to end of all messages
+		const result = await readOpenCodeTranscript(transcriptPath);
+
+		expect(result.entries).toHaveLength(2);
+		expect(result.newCursor.lineNumber).toBe(2);
+	});
+
+	it("resumes from cursor after beforeTimestamp-limited read", async () => {
+		const base = 1711900000000;
+		const transcriptPath = await createTestDb(tempDir, "sess-14", [
+			{ id: "m1", role: "user", parts: [{ type: "text", text: "First" }], time_created: base },
+			{ id: "m2", role: "assistant", parts: [{ type: "text", text: "Reply 1" }], time_created: base + 1000 },
+			{ id: "m3", role: "user", parts: [{ type: "text", text: "Second" }], time_created: base + 5000 },
+			{ id: "m4", role: "assistant", parts: [{ type: "text", text: "Reply 2" }], time_created: base + 6000 },
+		]);
+
+		// First read: cutoff after m2
+		const cutoff1 = new Date(base + 2000).toISOString();
+		const first = await readOpenCodeTranscript(transcriptPath, null, cutoff1);
+		expect(first.entries).toHaveLength(2);
+		expect(first.newCursor.lineNumber).toBe(2);
+
+		// Second read: no cutoff, pick up remaining messages
+		const second = await readOpenCodeTranscript(transcriptPath, first.newCursor);
+		expect(second.entries).toHaveLength(2);
+		expect(second.entries[0].content).toBe("Second");
+		expect(second.entries[1].content).toBe("Reply 2");
+	});
+});

--- a/cli/src/core/OpenCodeTranscriptReader.ts
+++ b/cli/src/core/OpenCodeTranscriptReader.ts
@@ -1,0 +1,231 @@
+/**
+ * OpenCode Transcript Reader
+ *
+ * Reads messages from an OpenCode SQLite session and returns transcript entries.
+ * Follows the GeminiTranscriptReader pattern: a dedicated async reader that
+ * bypasses the JSONL TranscriptParser interface.
+ *
+ * OpenCode stores data in a global SQLite database at ~/.local/share/opencode/opencode.db.
+ * Messages are in the `message` table with a `data` JSON column containing the role.
+ * Parts are in a separate `part` table, each with a `data` JSON column.
+ *
+ * Only "text" type parts are extracted. Tool calls/results, patches, reasoning,
+ * and finish parts are skipped.
+ *
+ * Cursor tracks by message count (reuses TranscriptCursor.lineNumber field),
+ * same pattern as GeminiTranscriptReader.
+ */
+
+import { createLogger } from "../Logger.js";
+import type { TranscriptCursor, TranscriptEntry, TranscriptReadResult } from "../Types.js";
+import { withOpenCodeDb } from "./OpenCodeSessionDiscoverer.js";
+import { mergeConsecutiveEntries } from "./TranscriptReader.js";
+
+const log = createLogger("OpenCodeTranscriptReader");
+
+/** A single part row's parsed data from the `part` table */
+interface OpenCodePartData {
+	readonly type: string;
+	readonly text?: string;
+	readonly [key: string]: unknown;
+}
+
+/**
+ * Reads messages from an OpenCode SQLite session and returns parsed transcript entries.
+ * Supports cursor-based resumption by tracking the count of messages already processed.
+ *
+ * @param transcriptPath - Synthetic path: "<dbPath>#<sessionId>"
+ * @param cursor - Optional cursor indicating how many messages were already processed
+ * @param beforeTimestamp - Optional ISO 8601 cutoff: only return entries with timestamp ≤ this value.
+ *   Used by the queue-driven Worker to attribute transcript entries to the correct commit.
+ *   When provided, the cursor advances only to the last consumed message (not EOF).
+ * @returns Parsed entries and a new cursor for the next read
+ */
+export async function readOpenCodeTranscript(
+	transcriptPath: string,
+	cursor?: TranscriptCursor | null,
+	beforeTimestamp?: string,
+): Promise<TranscriptReadResult> {
+	const { dbPath, sessionId } = parseSyntheticPath(transcriptPath);
+	const startIndex = cursor?.lineNumber ?? 0;
+	const cutoffTime = beforeTimestamp ? new Date(beforeTimestamp).getTime() : undefined;
+
+	try {
+		const { rawEntries, totalMessages, lastConsumedIndex } = await withOpenCodeDb(dbPath, (db) => {
+			// Query messages with their parts via JOIN
+			const rows = db
+				.prepare(
+					`SELECT m.id as msg_id, m.data as msg_data, m.time_created,
+					        p.data as part_data
+					 FROM message m
+					 LEFT JOIN part p ON p.message_id = m.id
+					 WHERE m.session_id = :sessionId
+					 ORDER BY m.time_created ASC, p.time_created ASC`,
+				)
+				.all({ sessionId }) as ReadonlyArray<{
+				msg_id: string;
+				msg_data: string;
+				time_created: number;
+				part_data: string | null;
+			}>;
+
+			// Group rows by message ID
+			const messageMap = new Map<string, { msgData: string; timeCreated: number; parts: string[] }>();
+			const messageOrder: string[] = [];
+
+			for (const row of rows) {
+				if (!messageMap.has(row.msg_id)) {
+					messageMap.set(row.msg_id, { msgData: row.msg_data, timeCreated: row.time_created, parts: [] });
+					messageOrder.push(row.msg_id);
+				}
+
+				if (row.part_data) {
+					messageMap.get(row.msg_id)?.parts.push(row.part_data);
+				}
+			}
+
+			// Skip already-processed messages (cursor-based incremental read)
+			const newMessageIds = messageOrder.slice(startIndex);
+			const rawEntries: TranscriptEntry[] = [];
+			let lastConsumedIndex = startIndex;
+
+			for (let i = 0; i < newMessageIds.length; i++) {
+				const msg = messageMap.get(newMessageIds[i]) as {
+					msgData: string;
+					timeCreated: number;
+					parts: string[];
+				};
+
+				// If a time cutoff is specified, stop consuming when we hit messages after it
+				if (cutoffTime && msg.timeCreated > cutoffTime) {
+					break;
+				}
+
+				const entry = parseOpenCodeMessage(msg.msgData, msg.parts, msg.timeCreated);
+				if (entry) {
+					rawEntries.push(entry);
+				}
+				lastConsumedIndex = startIndex + i + 1;
+			}
+
+			return { rawEntries, totalMessages: messageOrder.length, lastConsumedIndex };
+		});
+
+		const entries = mergeConsecutiveEntries(rawEntries);
+
+		// When beforeTimestamp is set, advance cursor only to the last consumed message.
+		// Without beforeTimestamp (legacy/CLI path), advance to end for backward compatibility.
+		const newCursor: TranscriptCursor = {
+			transcriptPath,
+			lineNumber: beforeTimestamp ? lastConsumedIndex : totalMessages,
+			updatedAt: new Date().toISOString(),
+		};
+
+		const totalLinesRead = lastConsumedIndex - startIndex;
+		log.info(
+			"Read OpenCode session %s: %d new messages, %d entries extracted (index %d→%d)",
+			sessionId.substring(0, 8),
+			totalLinesRead,
+			entries.length,
+			startIndex,
+			newCursor.lineNumber,
+		);
+
+		return { entries, newCursor, totalLinesRead };
+	} catch (error: unknown) {
+		log.error("Failed to read OpenCode session %s: %s", sessionId.substring(0, 8), (error as Error).message);
+		throw new Error(`Cannot read OpenCode session: ${sessionId}`);
+	}
+}
+
+/**
+ * Parses a synthetic transcript path into its DB path and session ID components.
+ * Format: "<dbPath>#<sessionId>"
+ */
+function parseSyntheticPath(transcriptPath: string): { dbPath: string; sessionId: string } {
+	const hashIndex = transcriptPath.lastIndexOf("#");
+	if (hashIndex === -1) {
+		throw new Error(`Invalid OpenCode transcript path (missing #sessionId): ${transcriptPath}`);
+	}
+	const dbPath = transcriptPath.substring(0, hashIndex);
+	const sessionId = transcriptPath.substring(hashIndex + 1);
+	if (dbPath.length === 0 || sessionId.length === 0) {
+		throw new Error(`Invalid OpenCode transcript path (empty dbPath or sessionId): ${transcriptPath}`);
+	}
+	return { dbPath, sessionId };
+}
+
+/**
+ * Parses a single OpenCode message into a TranscriptEntry.
+ * Extracts role from message.data JSON, text from part.data JSONs.
+ * Returns null for non-conversational roles (system, tool).
+ */
+function parseOpenCodeMessage(
+	msgDataJson: string,
+	partDataJsons: string[],
+	createdAtMs: number,
+): TranscriptEntry | null {
+	// Guard against schema drift: a non-finite time_created would make
+	// new Date().toISOString() throw RangeError and abort the whole session read.
+	if (!Number.isFinite(createdAtMs)) {
+		log.debug("Skipping OpenCode message with non-finite time_created");
+		return null;
+	}
+	let msgData: { role?: string };
+	try {
+		msgData = JSON.parse(msgDataJson) as { role?: string };
+	} catch {
+		log.debug("Failed to parse message data JSON");
+		return null;
+	}
+
+	const role = msgData.role;
+	let mappedRole: "human" | "assistant";
+	if (role === "user") {
+		mappedRole = "human";
+	} else if (role === "assistant") {
+		mappedRole = "assistant";
+	} else {
+		return null;
+	}
+
+	const text = extractTextFromParts(partDataJsons);
+	if (!text) {
+		return null;
+	}
+
+	const timestamp = new Date(createdAtMs).toISOString();
+	return { role: mappedRole, content: text, timestamp };
+}
+
+/**
+ * Extracts text content from OpenCode part data JSON strings.
+ *
+ * Each part row has a `data` column with JSON like:
+ *   { "type": "text", "text": "..." }
+ *
+ * Only "text" type parts are extracted. Tool, patch, reasoning, finish,
+ * and image_url parts are skipped.
+ */
+function extractTextFromParts(partDataJsons: string[]): string | null {
+	const textParts: string[] = [];
+
+	for (const json of partDataJsons) {
+		let partData: OpenCodePartData;
+		try {
+			partData = JSON.parse(json) as OpenCodePartData;
+		} catch {
+			log.debug("Failed to parse part data JSON");
+			continue;
+		}
+
+		if (partData.type === "text" && typeof partData.text === "string") {
+			const trimmed = partData.text.trim();
+			if (trimmed.length > 0) {
+				textParts.push(trimmed);
+			}
+		}
+	}
+
+	return textParts.length > 0 ? textParts.join("\n") : null;
+}

--- a/cli/src/core/PlanProgressEvaluator.test.ts
+++ b/cli/src/core/PlanProgressEvaluator.test.ts
@@ -137,6 +137,29 @@ describe("evaluatePlanProgress", () => {
 				stopReason: "end_turn",
 			});
 		});
+
+		it("falls back to resolveModelId with default 'haiku' when both llm and config models are missing", async () => {
+			// llmResult.model undefined + config.model undefined
+			// covers: llmResult.model ?? X (right side) AND config.model ?? "haiku" (right side)
+			// AND llmResult.stopReason ?? null (right side)
+			mockCallLlm.mockResolvedValueOnce(llmResult(validResponse(), { model: undefined, stopReason: undefined }));
+
+			const result = await evaluatePlanProgress(planMarkdown, diff, [], conversation, config);
+
+			expect(result?.llm.model).toMatch(/haiku/);
+			expect(result?.llm.stopReason).toBeNull();
+		});
+
+		it("falls back to resolveModelId with explicit config.model when llm model missing", async () => {
+			// llmResult.model undefined + config.model = "sonnet"
+			// covers: llmResult.model ?? X (right side) AND config.model ?? "haiku" (left side)
+			mockCallLlm.mockResolvedValueOnce(llmResult(validResponse(), { model: undefined }));
+
+			const configWithModel: JolliMemoryConfig = { apiKey: "sk-ant-test", model: "sonnet" };
+			const result = await evaluatePlanProgress(planMarkdown, diff, [], conversation, configWithModel);
+
+			expect(result?.llm.model).toMatch(/sonnet/);
+		});
 	});
 
 	describe("code-fence stripping", () => {

--- a/cli/src/core/SessionTracker.test.ts
+++ b/cli/src/core/SessionTracker.test.ts
@@ -919,6 +919,21 @@ describe("SessionTracker", () => {
 			});
 			expect(result).toHaveLength(0);
 		});
+
+		it("should exclude OpenCode sessions when openCodeEnabled is false", () => {
+			const openCodeSession = {
+				sessionId: "o1",
+				transcriptPath: "/o1",
+				updatedAt: "2025-01-01T00:00:00Z",
+				source: "opencode" as const,
+			};
+
+			const result = filterSessionsByEnabledIntegrations([claudeSession, openCodeSession], {
+				openCodeEnabled: false,
+			});
+
+			expect(result).toEqual([claudeSession]);
+		});
 	});
 
 	// ── git operation queue ────────────────────────────────────────────────
@@ -1004,6 +1019,15 @@ describe("SessionTracker", () => {
 			await expect(deleteQueueEntry("/non/existent/path.json")).resolves.toBeUndefined();
 		});
 
+		it("should swallow filesystem errors when deleting a queue entry", async () => {
+			const fsPromises = await import("node:fs/promises");
+			const rmSpy = vi.spyOn(fsPromises, "rm").mockRejectedValueOnce(new Error("permission denied"));
+
+			await expect(deleteQueueEntry("/tmp/locked.json")).resolves.toBeUndefined();
+
+			rmSpy.mockRestore();
+		});
+
 		it("should return false when enqueue fails due to filesystem error", async () => {
 			// Use an invalid path that will fail on mkdir
 			const result = await enqueueGitOperation(makeOp("fail1"), "/\0/invalid-path");
@@ -1037,6 +1061,20 @@ describe("SessionTracker", () => {
 		it("should return config from global dir without throwing", async () => {
 			const config = await loadConfig();
 			expect(config).toBeDefined();
+		});
+
+		it("saveConfig should persist config to the global directory shorthand", async () => {
+			const originalHome = process.env.HOME;
+			process.env.HOME = tempDir;
+
+			try {
+				await saveConfig({ apiKey: "global-key" });
+				const config = await loadConfig();
+				expect(config.apiKey).toBe("global-key");
+			} finally {
+				if (originalHome === undefined) delete process.env.HOME;
+				else process.env.HOME = originalHome;
+			}
 		});
 	});
 
@@ -1284,22 +1322,6 @@ describe("SessionTracker", () => {
 			await mkdir(dir, { recursive: true });
 			await writeFile(join(dir, "squash-pending.json"), "not json");
 			expect(await checkStaleSquashPending(tempDir)).toBe(true);
-		});
-	});
-
-	// ── saveConfig (global wrapper) ──────────────────────────────────────
-
-	describe("saveConfig", () => {
-		it("delegates to saveConfigScoped with the global config directory", async () => {
-			// saveConfig writes to the global ~/.jolli/jollimemory/config.json.
-			// Verify it does not throw and round-trips through loadConfig.
-			const before = await loadConfig();
-			await saveConfig({ model: "test-model-for-coverage" });
-			const after = await loadConfig();
-			expect(after.model).toBe("test-model-for-coverage");
-
-			// Restore original value
-			await saveConfig({ model: before.model });
 		});
 	});
 });

--- a/cli/src/core/SessionTracker.ts
+++ b/cli/src/core/SessionTracker.ts
@@ -35,9 +35,6 @@ const CONFIG_FILE = "config.json";
 const LOCK_FILE = "lock";
 const PLANS_FILE = "plans.json";
 
-/** Global Jolli Memory config directory at ~/.jolli/jollimemory */
-const GLOBAL_JOLLIMEMORY_DIR = join(homedir(), ".jolli", "jollimemory");
-
 /** Sessions older than 48 hours are considered stale and pruned automatically */
 const SESSION_STALE_MS = 48 * 60 * 60 * 1000;
 
@@ -166,6 +163,9 @@ export function filterSessionsByEnabledIntegrations(
 	if (config.geminiEnabled === false) {
 		filtered = filtered.filter((s) => s.source !== "gemini");
 	}
+	if (config.openCodeEnabled === false) {
+		filtered = filtered.filter((s) => s.source !== "opencode");
+	}
 	return filtered;
 }
 
@@ -204,7 +204,7 @@ export async function loadCursorForTranscript(transcriptPath: string, cwd?: stri
  * Returns the global Jolli Memory config directory (~/.jolli/jollimemory).
  */
 export function getGlobalConfigDir(): string {
-	return GLOBAL_JOLLIMEMORY_DIR;
+	return join(homedir(), ".jolli", "jollimemory");
 }
 
 /**
@@ -248,7 +248,7 @@ export async function saveConfigScoped(update: Partial<JolliMemoryConfig>, targe
  * Returns empty config when no file exists.
  */
 export async function loadConfig(): Promise<JolliMemoryConfig> {
-	return loadConfigFromDir(GLOBAL_JOLLIMEMORY_DIR);
+	return loadConfigFromDir(getGlobalConfigDir());
 }
 
 /**
@@ -259,7 +259,7 @@ export async function loadConfig(): Promise<JolliMemoryConfig> {
  * @param update - Partial config fields to save
  */
 export async function saveConfig(update: Partial<JolliMemoryConfig>): Promise<void> {
-	return saveConfigScoped(update, GLOBAL_JOLLIMEMORY_DIR);
+	return saveConfigScoped(update, getGlobalConfigDir());
 }
 
 /**
@@ -858,10 +858,11 @@ export async function associateNoteWithCommit(noteId: string, commitHash: string
 		log.debug("associateNoteWithCommit: id %s not in registry, skipping", noteId);
 		return;
 	}
+	const notes = registry.notes as NonNullable<PlansRegistry["notes"]>;
 	const updated: PlansRegistry = {
 		...registry,
 		notes: {
-			...(registry.notes ?? {}),
+			...notes,
 			[noteId]: { ...entry, commitHash, updatedAt: new Date().toISOString() },
 		},
 	};

--- a/cli/src/core/Summarizer.test.ts
+++ b/cli/src/core/Summarizer.test.ts
@@ -239,6 +239,16 @@ Using \`===TOPIC===\` as the topic separator avoids JSON encoding issues.`);
 			expect(result.topics[0].trigger).toContain("Extra content");
 		});
 
+		it("ignores unknown fields that appear before any known field", () => {
+			const result = parseSummaryResponse(
+				"===TOPIC===\n---UNKNOWNFIELD---\nIgnored\n---TITLE---\nTest\n---TRIGGER---\nBug found\n---RESPONSE---\nFixed it\n---DECISIONS---\nDecided this way",
+			);
+
+			expect(result.topics).toHaveLength(1);
+			expect(result.topics[0].title).toBe("Test");
+			expect(result.topics[0].trigger).not.toContain("Ignored");
+		});
+
 		it("handles topics missing optional fields (no TODO, CATEGORY, IMPORTANCE)", () => {
 			const result = parseSummaryResponse(
 				delimited({ title: "Minimal", trigger: "t", response: "r", decisions: "Minimal decisions" }),
@@ -343,6 +353,20 @@ Using \`===TOPIC===\` as the topic separator avoids JSON encoding issues.`);
 				}),
 			);
 			expect(result.topics[0].filesAffected).toEqual(["src/A.ts", "src/B.ts"]);
+		});
+
+		it("omits filesAffected when the field only contains empty items", () => {
+			const result = parseSummaryResponse(
+				delimited({
+					title: "A",
+					trigger: "t",
+					response: "r",
+					decisions: "d",
+					filesAffected: ",  ,\n   ",
+				}),
+			);
+
+			expect(result.topics[0].filesAffected).toBeUndefined();
 		});
 	});
 
@@ -837,6 +861,32 @@ This is unknown content
 			expect(result[0].title).toBe("Unknown field test");
 			// The unknown CUSTOM field's content should be appended to STEPS (the last known field)
 			expect(result[0].steps[0]).toContain("Do something");
+		});
+
+		it("ignores unknown fields that appear before any known E2E field", () => {
+			const result = parseE2eTestResponse(`===SCENARIO===
+---CUSTOM---
+Ignored
+---TITLE---
+Known title
+---STEPS---
+1. Open app
+---EXPECTED---
+- Works`);
+
+			expect(result).toHaveLength(1);
+			expect(result[0].title).toBe("Known title");
+			expect(result[0].steps[0]).not.toContain("Ignored");
+		});
+
+		it("skips scenarios with a missing title", () => {
+			const result = parseE2eTestResponse(`===SCENARIO===
+---STEPS---
+1. Open app
+---EXPECTED---
+- Works`);
+
+			expect(result).toEqual([]);
 		});
 
 		it("should handle scenario with steps but no EXPECTED field", () => {

--- a/cli/src/core/Summarizer.ts
+++ b/cli/src/core/Summarizer.ts
@@ -381,8 +381,9 @@ function extractPreTopicTicketId(text: string): string | undefined {
 	const match = preamble.match(/^---(?:TICKETID|ticketId)---\s*\n(.+)/m);
 	if (match) {
 		const id = match[1].trim();
-		/* v8 ignore next -- regex uses .+, so a matched ticket line is never empty after trimming */
+		/* v8 ignore start -- regex uses .+, so a matched ticket line is never empty after trimming */
 		return id.length > 0 ? id : undefined;
+		/* v8 ignore stop */
 	}
 	return undefined;
 }

--- a/cli/src/core/SummaryFormat.test.ts
+++ b/cli/src/core/SummaryFormat.test.ts
@@ -260,6 +260,41 @@ describe("collectSortedTopics", () => {
 		const { topics } = collectSortedTopics(leaf({ topics: undefined }));
 		expect(topics).toHaveLength(0);
 	});
+
+	it("falls back to commitDate when generatedAt is missing on child node (covers `||` right-side)", () => {
+		// child1 has generatedAt undefined — its topic date must come from commitDate.
+		// Parent is a container without own topics, children span multiple days
+		// (2026-03-01 vs 2026-03-05) so showRecordDates=true; that triggers the
+		// recordDate assignment whose `t.generatedAt || t.commitDate` right branch runs.
+		const summary = leaf({
+			commitDate: "2026-03-05T10:00:00.000Z",
+			generatedAt: "2026-03-05T10:01:00.000Z",
+			topics: [],
+			children: [
+				{
+					version: 3 as const,
+					commitHash: "noGenAt",
+					commitMessage: "legacy",
+					commitAuthor: "a",
+					branch: "b",
+					commitDate: "2026-03-01T10:00:00.000Z",
+					// generatedAt intentionally omitted
+					generatedAt: "",
+					topics: [{ title: "Legacy", trigger: "t", response: "r", decisions: "d" }],
+				},
+				leaf({
+					commitHash: "bbb",
+					commitDate: "2026-03-05T09:00:00.000Z",
+					generatedAt: "2026-03-05T09:00:10.000Z",
+				}),
+			],
+		});
+		const { topics, showRecordDates } = collectSortedTopics(summary);
+		expect(showRecordDates).toBe(true);
+		// The legacy topic's recordDate should equal its commitDate (since generatedAt is empty).
+		const legacy = topics.find((t) => t.title === "Legacy");
+		expect(legacy?.recordDate).toBe("2026-03-01T10:00:00.000Z");
+	});
 });
 
 // ─── collectAllPlans ────────────────────────────────────────────────────────

--- a/cli/src/core/SummaryMarkdownBuilder.test.ts
+++ b/cli/src/core/SummaryMarkdownBuilder.test.ts
@@ -231,11 +231,13 @@ describe("buildMarkdown", () => {
 		const child1 = leaf({
 			commitHash: "aaa",
 			commitDate: "2026-03-01T10:00:00.000Z",
-			topics: [{ title: "Day 1 topic", trigger: "t", response: "r", decisions: "d" }],
+			generatedAt: "2026-03-01T10:01:00.000Z",
+			topics: [{ title: "Day 1 topic", trigger: "t", response: "r", decisions: "d", category: "feature" }],
 		});
 		const child2 = leaf({
 			commitHash: "bbb",
 			commitDate: "2026-03-05T10:00:00.000Z",
+			generatedAt: "2026-03-05T10:01:00.000Z",
 			topics: [{ title: "Day 5 topic", trigger: "t", response: "r", decisions: "d" }],
 		});
 		const squash = leaf({
@@ -245,6 +247,11 @@ describe("buildMarkdown", () => {
 			children: [child2, child1],
 		});
 		const md = buildMarkdown(squash);
+		// showRecordDates=true path: date headers must appear
+		expect(md).toMatch(/### Mar 5, 2026/);
+		expect(md).toMatch(/### Mar 1, 2026/);
+		// Category label on first grouped topic (covers `t.category ? ...` branch)
+		expect(md).toContain("`feature`");
 		expect(md).toContain("Day 1 topic");
 		expect(md).toContain("Day 5 topic");
 	});
@@ -364,11 +371,13 @@ describe("buildPrMarkdown", () => {
 		const child1 = leaf({
 			commitHash: "aaa11111111",
 			commitDate: "2026-03-01T10:00:00.000Z",
+			generatedAt: "2026-03-01T10:01:00.000Z",
 			topics: [{ title: "Day 1 PR topic", trigger: "t1", response: "r1", decisions: "d1" }],
 		});
 		const child2 = leaf({
 			commitHash: "bbb22222222",
 			commitDate: "2026-03-05T10:00:00.000Z",
+			generatedAt: "2026-03-05T10:01:00.000Z",
 			topics: [{ title: "Day 5 PR topic", trigger: "t5", response: "r5", decisions: "d5" }],
 		});
 		const squash = leaf({
@@ -378,6 +387,8 @@ describe("buildPrMarkdown", () => {
 			children: [child2, child1],
 		});
 		const md = buildPrMarkdown(squash);
+		expect(md).toMatch(/### Mar 5, 2026/);
+		expect(md).toMatch(/### Mar 1, 2026/);
 		expect(md).toContain("Day 1 PR topic");
 		expect(md).toContain("Day 5 PR topic");
 		// Should NOT contain full topic body fields (todo/files)
@@ -386,7 +397,8 @@ describe("buildPrMarkdown", () => {
 	});
 
 	it("truncates date-grouped topics when exceeding PR body limit", () => {
-		// Build two children on different days, each with many large topics
+		// Build two children on different days, each with many large topics.
+		// generatedAt must differ per child so showRecordDates=true.
 		const bigTopics = Array.from({ length: 100 }, (_, i) => ({
 			title: `Big Topic ${i}`,
 			trigger: "X".repeat(400),
@@ -396,11 +408,13 @@ describe("buildPrMarkdown", () => {
 		const child1 = leaf({
 			commitHash: "ccc33333333",
 			commitDate: "2026-04-01T10:00:00.000Z",
+			generatedAt: "2026-04-01T10:01:00.000Z",
 			topics: bigTopics.slice(0, 50),
 		});
 		const child2 = leaf({
 			commitHash: "ddd44444444",
 			commitDate: "2026-04-10T10:00:00.000Z",
+			generatedAt: "2026-04-10T10:01:00.000Z",
 			topics: bigTopics.slice(50),
 		});
 		const squash = leaf({

--- a/cli/src/core/SummaryStore.test.ts
+++ b/cli/src/core/SummaryStore.test.ts
@@ -320,6 +320,83 @@ describe("SummaryStore", () => {
 			expect(result?.commitMessage).toBe("Child commit");
 		});
 
+		it("should find a grandchild node via recursive tree search", async () => {
+			const grandchild = createMockSummary("grandchild1", "Grandchild commit");
+			const child: CommitSummary = {
+				...createMockSummary("child111", "Child commit"),
+				children: [grandchild],
+			};
+			const parent: CommitSummary = {
+				...createMockSummary("parent222", "Parent commit"),
+				children: [child],
+			};
+			const index = v3Index([
+				rootEntry("parent222"),
+				{
+					commitHash: "child111",
+					parentCommitHash: "parent222",
+					commitMessage: "Child commit",
+					commitDate: "2026-02-19T10:00:00Z",
+					branch: "main",
+					generatedAt: "2026-02-19T10:00:05Z",
+				},
+				{
+					commitHash: "grandchild1",
+					parentCommitHash: "child111",
+					commitMessage: "Grandchild commit",
+					commitDate: "2026-02-19T11:00:00Z",
+					branch: "main",
+					generatedAt: "2026-02-19T11:00:05Z",
+				},
+			]);
+
+			vi.mocked(readFileFromBranch)
+				.mockResolvedValueOnce(JSON.stringify(index))
+				.mockResolvedValueOnce(JSON.stringify(parent));
+
+			const result = await getSummary("grandchild1");
+			expect(result?.commitHash).toBe("grandchild1");
+			expect(result?.commitMessage).toBe("Grandchild commit");
+		});
+
+		it("should find a child node in the second branch of a multi-child tree", async () => {
+			const childA = createMockSummary("childA000", "Child A (no match)");
+			const childB = createMockSummary("childB000", "Child B (target)");
+			const parent: CommitSummary = {
+				...createMockSummary("parent222", "Parent commit"),
+				children: [childA, childB],
+			};
+			const index = v3Index([
+				rootEntry("parent222"),
+				{
+					commitHash: "childA000",
+					parentCommitHash: "parent222",
+					commitMessage: "Child A",
+					commitDate: "2026-02-19T10:00:00Z",
+					branch: "main",
+					generatedAt: "2026-02-19T10:00:05Z",
+				},
+				{
+					commitHash: "childB000",
+					parentCommitHash: "parent222",
+					commitMessage: "Child B",
+					commitDate: "2026-02-19T11:00:00Z",
+					branch: "main",
+					generatedAt: "2026-02-19T11:00:05Z",
+				},
+			]);
+
+			vi.mocked(readFileFromBranch)
+				.mockResolvedValueOnce(JSON.stringify(index))
+				.mockResolvedValueOnce(JSON.stringify(parent));
+
+			// Looking up childB means findNodeInTree tries childA first (returns null),
+			// then finds childB on the second iteration
+			const result = await getSummary("childB000");
+			expect(result?.commitHash).toBe("childB000");
+			expect(result?.commitMessage).toBe("Child B (target)");
+		});
+
 		it("should return summary via commitAliases when direct lookup fails", async () => {
 			const summary = createMockSummary("knownhash00");
 			const index = v3Index([rootEntry("knownhash00")], { unknownhash0: "knownhash00" });
@@ -456,6 +533,33 @@ describe("SummaryStore", () => {
 	});
 
 	describe("listSummaries", () => {
+		it("should skip entries whose summary files are missing (getSummary returns null)", async () => {
+			const index = v3Index([
+				rootEntry("hash1", "First", "2026-02-18T10:00:00Z"),
+				rootEntry("hash2", "Second (missing file)", "2026-02-19T10:00:00Z"),
+				rootEntry("hash3", "Third", "2026-02-20T10:00:00Z"),
+			]);
+
+			vi.mocked(readFileFromBranch)
+				// listSummaries → loadIndex
+				.mockResolvedValueOnce(JSON.stringify(index))
+				// getSummary("hash3") → loadIndex + readSummaryFile (newest first)
+				.mockResolvedValueOnce(JSON.stringify(index))
+				.mockResolvedValueOnce(JSON.stringify(createMockSummary("hash3", "Third")))
+				// getSummary("hash2") → loadIndex + readSummaryFile returns null (missing)
+				.mockResolvedValueOnce(JSON.stringify(index))
+				.mockResolvedValueOnce(null)
+				// getSummary("hash1") → loadIndex + readSummaryFile
+				.mockResolvedValueOnce(JSON.stringify(index))
+				.mockResolvedValueOnce(JSON.stringify(createMockSummary("hash1", "First")));
+
+			const summaries = await listSummaries(10);
+			// hash2 is skipped because its summary file is missing
+			expect(summaries).toHaveLength(2);
+			expect(summaries[0].commitHash).toBe("hash3");
+			expect(summaries[1].commitHash).toBe("hash1");
+		});
+
 		it("should return summaries in reverse chronological order (root-only)", async () => {
 			const index = v3Index([
 				rootEntry("hash1", "First", "2026-02-18T10:00:00Z"),
@@ -1329,6 +1433,62 @@ describe("SummaryStore", () => {
 			const merged = JSON.parse(files[0].content) as CommitSummary;
 			expect(merged.orphanedDocIds).toBeUndefined();
 		});
+
+		it("should keep the existing note when a duplicate appears with an older updatedAt", async () => {
+			// Covers both `!existing` false branches AND `note.updatedAt > existing.updatedAt`
+			// false branch in collectChildNotes (lines 281, 289). Three axes:
+			// (a) two top-level nodes with the same note id → line 281's existing+older path
+			// (b) nested child with older duplicate of top-level id → line 289's existing+older path
+			const old1: CommitSummary = {
+				...createMockSummary("old1", "Old 1"),
+				notes: [
+					{
+						id: "dupe",
+						title: "Newer",
+						format: "snippet",
+						content: "new",
+						addedAt: "2026-02-18T00:00:00Z",
+						updatedAt: "2026-02-25T00:00:00Z",
+					},
+				],
+				children: [
+					{
+						...createMockSummary("nested", "Nested"),
+						notes: [
+							{
+								id: "dupe",
+								title: "Nested Older",
+								format: "snippet",
+								content: "nested",
+								addedAt: "2026-02-18T00:00:00Z",
+								updatedAt: "2026-02-22T00:00:00Z",
+							},
+						],
+					},
+				],
+			};
+			const old2: CommitSummary = {
+				...createMockSummary("old2", "Old 2"),
+				notes: [
+					{
+						id: "dupe",
+						title: "Older",
+						format: "snippet",
+						content: "old",
+						addedAt: "2026-02-18T00:00:00Z",
+						updatedAt: "2026-02-20T00:00:00Z",
+					},
+				],
+			};
+			vi.mocked(readFileFromBranch).mockResolvedValueOnce(JSON.stringify(v3Index([])));
+
+			await mergeManyToOne([old1, old2], createMockCommitInfo("newhash"));
+
+			const files = vi.mocked(writeMultipleFilesToBranch).mock.calls[0][1] as ReadonlyArray<FileWrite>;
+			const merged = JSON.parse(files[0].content) as CommitSummary;
+			expect(merged.notes).toHaveLength(1);
+			expect(merged.notes?.[0].title).toBe("Newer");
+		});
 	});
 
 	describe("removeFromIndex", () => {
@@ -1591,6 +1751,16 @@ describe("SummaryStore", () => {
 			const index = v3Index([{ ...rootEntry("root1", "Root"), treeHash: "tree-1" }]);
 			vi.mocked(readFileFromBranch).mockResolvedValueOnce(JSON.stringify(index));
 			vi.mocked(getTreeHash).mockResolvedValueOnce(null);
+
+			await expect(scanTreeHashAliases(["unknown1"])).resolves.toBe(false);
+			expect(writeMultipleFilesToBranch).not.toHaveBeenCalled();
+		});
+
+		it("should skip a hash when getTreeHash returns a tree hash that matches no entry", async () => {
+			const index = v3Index([{ ...rootEntry("root1", "Root"), treeHash: "tree-1" }]);
+			vi.mocked(readFileFromBranch).mockResolvedValueOnce(JSON.stringify(index));
+			// getTreeHash returns a valid tree hash, but it matches no entry in the index
+			vi.mocked(getTreeHash).mockResolvedValueOnce("tree-no-match");
 
 			await expect(scanTreeHashAliases(["unknown1"])).resolves.toBe(false);
 			expect(writeMultipleFilesToBranch).not.toHaveBeenCalled();

--- a/cli/src/core/SummaryTree.test.ts
+++ b/cli/src/core/SummaryTree.test.ts
@@ -224,6 +224,18 @@ describe("SummaryTree", () => {
 			};
 			expect(computeDurationDays(multiDay)).toBe(2);
 		});
+
+		it("falls back to commitDate when a source has no generatedAt (covers `||` right branch)", () => {
+			// One child with empty generatedAt forces the fallback path inside the Set map.
+			const mixed: CommitSummary = {
+				...D,
+				children: [
+					{ ...B, commitDate: "2026-03-03T10:00:00.000Z", generatedAt: "" },
+					{ ...A, commitDate: "2026-03-01T10:00:00.000Z", generatedAt: "2026-03-01T10:00:10.000Z" },
+				],
+			};
+			expect(computeDurationDays(mixed)).toBe(2);
+		});
 	});
 
 	describe("formatDurationLabel", () => {
@@ -248,6 +260,19 @@ describe("SummaryTree", () => {
 			const label = formatDurationLabel(multiDay);
 			expect(label).toMatch(/^2 days \(/);
 			expect(label).toContain("Mar");
+		});
+
+		it("falls back to commitDate for timestamp computation when generatedAt is empty", () => {
+			// Covers the `s.generatedAt || s.commitDate` right branch in formatDurationLabel.
+			const mixed: CommitSummary = {
+				...D,
+				children: [
+					{ ...B, commitDate: "2026-03-05T10:00:00.000Z", generatedAt: "" },
+					{ ...A, commitDate: "2026-03-01T10:00:00.000Z", generatedAt: "2026-03-01T10:00:10.000Z" },
+				],
+			};
+			const label = formatDurationLabel(mixed);
+			expect(label).toMatch(/^2 days \(/);
 		});
 	});
 

--- a/cli/src/core/TranscriptReader.ts
+++ b/cli/src/core/TranscriptReader.ts
@@ -21,7 +21,7 @@
 
 import { readFile } from "node:fs/promises";
 import { createLogger } from "../Logger.js";
-import type { TranscriptCursor, TranscriptEntry, TranscriptReadResult } from "../Types.js";
+import type { TranscriptCursor, TranscriptEntry, TranscriptReadResult, TranscriptSource } from "../Types.js";
 import type { TranscriptParser } from "./TranscriptParser.js";
 
 const log = createLogger("TranscriptReader");
@@ -281,6 +281,12 @@ export function buildConversationContext(
 export interface SessionTranscript {
 	readonly sessionId: string;
 	readonly transcriptPath: string;
+	/**
+	 * Source integration this transcript came from. Carried on the transcript
+	 * itself (not looked up by `sessionId`) so downstream persistence does not
+	 * collapse two sources that coincidentally share an `sessionId`.
+	 */
+	readonly source?: TranscriptSource;
 	readonly entries: ReadonlyArray<TranscriptEntry>;
 }
 

--- a/cli/src/hooks/GitOperationDetector.test.ts
+++ b/cli/src/hooks/GitOperationDetector.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("node:child_process", () => ({
 	execSync: vi.fn(),
@@ -41,6 +41,7 @@ import { loadSquashPending, saveSquashPending } from "../core/SessionTracker.js"
 import {
 	detectCommitOperation,
 	detectResetSquash,
+	isRebaseInProgress,
 	readLastReflogSubject,
 	resolveGitDir,
 } from "./GitOperationDetector.js";
@@ -51,6 +52,84 @@ describe("GitOperationDetector", () => {
 		// Default: statSync throws so resolveGitDir falls back to dotGit path
 		vi.mocked(existsSync).mockReturnValue(false);
 		delete process.env.GIT_REFLOG_ACTION;
+	});
+
+	describe("resolveGitDir", () => {
+		it("should return the default .git path when statSync throws (regular repo)", () => {
+			vi.mocked(statSync).mockImplementation(() => {
+				throw new Error("ENOENT");
+			});
+
+			const result = resolveGitDir("/test/repo");
+
+			expect(result).toBe("/test/repo/.git");
+		});
+
+		it("should return the default .git path when .git is a directory", () => {
+			vi.mocked(statSync).mockReturnValue({ isFile: () => false } as ReturnType<typeof statSync>);
+
+			const result = resolveGitDir("/test/repo");
+
+			expect(result).toBe("/test/repo/.git");
+		});
+
+		it("should resolve an absolute gitdir path from a worktree .git file", () => {
+			vi.mocked(statSync).mockReturnValue({ isFile: () => true } as ReturnType<typeof statSync>);
+			vi.mocked(readFileSync).mockReturnValue("gitdir: /main-repo/.git/worktrees/feature-branch\n");
+
+			const result = resolveGitDir("/test/worktree");
+
+			expect(result).toBe("/main-repo/.git/worktrees/feature-branch");
+		});
+
+		it("should resolve a relative gitdir path from a worktree .git file", () => {
+			vi.mocked(statSync).mockReturnValue({ isFile: () => true } as ReturnType<typeof statSync>);
+			vi.mocked(readFileSync).mockReturnValue("gitdir: ../.git/worktrees/feature-branch\n");
+
+			const result = resolveGitDir("/test/worktree");
+
+			// join() resolves the relative path: /test/worktree + ../.git/worktrees/feature-branch
+			expect(result).toBe("/test/.git/worktrees/feature-branch");
+		});
+
+		it("should return the default .git path when .git file has no gitdir line", () => {
+			vi.mocked(statSync).mockReturnValue({ isFile: () => true } as ReturnType<typeof statSync>);
+			vi.mocked(readFileSync).mockReturnValue("some other content\n");
+
+			const result = resolveGitDir("/test/repo");
+
+			expect(result).toBe("/test/repo/.git");
+		});
+	});
+
+	describe("isRebaseInProgress", () => {
+		it("should return true when rebase-merge directory exists", () => {
+			// statSync throws so resolveGitDir returns default .git path
+			vi.mocked(statSync).mockImplementation(() => {
+				throw new Error("ENOENT");
+			});
+			vi.mocked(existsSync).mockImplementation((p) => String(p).endsWith("rebase-merge"));
+
+			expect(isRebaseInProgress("/test/repo")).toBe(true);
+		});
+
+		it("should return true when rebase-apply directory exists", () => {
+			vi.mocked(statSync).mockImplementation(() => {
+				throw new Error("ENOENT");
+			});
+			vi.mocked(existsSync).mockImplementation((p) => String(p).endsWith("rebase-apply"));
+
+			expect(isRebaseInProgress("/test/repo")).toBe(true);
+		});
+
+		it("should return false when neither rebase directory exists", () => {
+			vi.mocked(statSync).mockImplementation(() => {
+				throw new Error("ENOENT");
+			});
+			vi.mocked(existsSync).mockReturnValue(false);
+
+			expect(isRebaseInProgress("/test/repo")).toBe(false);
+		});
 	});
 
 	describe("readLastReflogSubject", () => {
@@ -74,6 +153,136 @@ describe("GitOperationDetector", () => {
 			const result = readLastReflogSubject("/test/repo");
 
 			expect(result).toBeNull();
+		});
+	});
+
+	describe("detectCommitOperation", () => {
+		const CWD = "/test/repo";
+		let savedReflogAction: string | undefined;
+
+		beforeEach(() => {
+			savedReflogAction = process.env.GIT_REFLOG_ACTION;
+			delete process.env.GIT_REFLOG_ACTION;
+			vi.mocked(existsSync).mockReturnValue(false);
+		});
+
+		afterEach(() => {
+			if (savedReflogAction !== undefined) {
+				process.env.GIT_REFLOG_ACTION = savedReflogAction;
+			} else {
+				delete process.env.GIT_REFLOG_ACTION;
+			}
+		});
+
+		it("should detect rebase when GIT_REFLOG_ACTION contains 'rebase'", () => {
+			process.env.GIT_REFLOG_ACTION = "rebase (pick)";
+
+			const result = detectCommitOperation(CWD);
+
+			expect(result).toEqual({ type: "rebase" });
+		});
+
+		it("should detect rebase via filesystem when rebase-merge directory exists", () => {
+			// No GIT_REFLOG_ACTION, but rebase-merge directory exists
+			vi.mocked(existsSync).mockImplementation((p) => {
+				return String(p).endsWith("rebase-merge");
+			});
+
+			const result = detectCommitOperation(CWD);
+
+			expect(result).toEqual({ type: "rebase" });
+		});
+
+		it("should detect rebase via filesystem when rebase-apply directory exists", () => {
+			vi.mocked(existsSync).mockImplementation((p) => {
+				return String(p).endsWith("rebase-apply");
+			});
+
+			const result = detectCommitOperation(CWD);
+
+			expect(result).toEqual({ type: "rebase" });
+		});
+
+		it("should detect squash when squash-pending.json exists", () => {
+			vi.mocked(existsSync).mockImplementation((p) => {
+				return String(p).endsWith("squash-pending.json");
+			});
+
+			const result = detectCommitOperation(CWD);
+
+			expect(result).toEqual({
+				type: "squash",
+				squashPendingPath: expect.stringContaining("squash-pending.json"),
+			});
+		});
+
+		it("should detect amend via reflog subject", () => {
+			vi.mocked(execSync).mockReturnValueOnce("commit (amend): Fix typo\n");
+
+			const result = detectCommitOperation(CWD);
+
+			expect(result).toEqual({ type: "amend" });
+		});
+
+		it("should detect cherry-pick when GIT_REFLOG_ACTION is 'cherry-pick'", () => {
+			process.env.GIT_REFLOG_ACTION = "cherry-pick";
+
+			const result = detectCommitOperation(CWD);
+
+			expect(result).toEqual({ type: "cherry-pick" });
+		});
+
+		it("should detect revert when GIT_REFLOG_ACTION is 'revert'", () => {
+			process.env.GIT_REFLOG_ACTION = "revert";
+
+			const result = detectCommitOperation(CWD);
+
+			expect(result).toEqual({ type: "revert" });
+		});
+
+		it("should fall back to 'commit' when no special signals are present", () => {
+			vi.mocked(execSync).mockReturnValueOnce("commit: Add new feature\n");
+
+			const result = detectCommitOperation(CWD);
+
+			expect(result).toEqual({ type: "commit" });
+		});
+
+		it("should fall back to 'commit' when reflog cannot be read", () => {
+			vi.mocked(execSync).mockImplementationOnce(() => {
+				throw new Error("fatal: reflog is empty");
+			});
+
+			const result = detectCommitOperation(CWD);
+
+			expect(result).toEqual({ type: "commit" });
+		});
+
+		it("should prioritize rebase over squash-pending.json", () => {
+			process.env.GIT_REFLOG_ACTION = "rebase (pick)";
+			// Even if squash-pending.json exists, rebase should win
+			vi.mocked(existsSync).mockImplementation((p) => {
+				return String(p).endsWith("squash-pending.json");
+			});
+
+			const result = detectCommitOperation(CWD);
+
+			expect(result).toEqual({ type: "rebase" });
+		});
+
+		it("should prioritize squash over amend", () => {
+			// squash-pending.json exists AND reflog says amend — squash should win
+			vi.mocked(existsSync).mockImplementation((p) => {
+				return String(p).endsWith("squash-pending.json");
+			});
+			vi.mocked(execSync).mockReturnValueOnce("commit (amend): Fix typo\n");
+
+			const result = detectCommitOperation(CWD);
+
+			expect(result).toEqual({
+				type: "squash",
+				squashPendingPath: expect.stringContaining("squash-pending.json"),
+			});
 		});
 	});
 

--- a/cli/src/hooks/PostCommitHook.helpers.test.ts
+++ b/cli/src/hooks/PostCommitHook.helpers.test.ts
@@ -165,6 +165,15 @@ vi.mock("../core/GeminiTranscriptReader.js", () => ({
 	readGeminiTranscript: vi.fn(),
 }));
 
+vi.mock("../core/OpenCodeSessionDiscoverer.js", () => ({
+	discoverOpenCodeSessions: vi.fn().mockResolvedValue([]),
+	isOpenCodeInstalled: vi.fn().mockResolvedValue(false),
+}));
+
+vi.mock("../core/OpenCodeTranscriptReader.js", () => ({
+	readOpenCodeTranscript: vi.fn(),
+}));
+
 vi.mock("../core/TranscriptParser.js", () => ({
 	getParserForSource: vi.fn(),
 }));

--- a/cli/src/hooks/PostCommitHook.test.ts
+++ b/cli/src/hooks/PostCommitHook.test.ts
@@ -82,6 +82,19 @@ vi.mock("../core/CodexSessionDiscoverer.js", () => ({
 	isCodexInstalled: vi.fn().mockResolvedValue(true),
 }));
 
+vi.mock("../core/OpenCodeSessionDiscoverer.js", () => ({
+	discoverOpenCodeSessions: vi.fn().mockResolvedValue([]),
+	isOpenCodeInstalled: vi.fn().mockResolvedValue(false),
+}));
+
+vi.mock("../core/OpenCodeTranscriptReader.js", () => ({
+	readOpenCodeTranscript: vi.fn().mockResolvedValue({
+		entries: [],
+		newCursor: { transcriptPath: "", lineNumber: 0, updatedAt: "" },
+		totalLinesRead: 0,
+	}),
+}));
+
 vi.mock("../core/GeminiTranscriptReader.js", () => ({
 	readGeminiTranscript: vi.fn().mockResolvedValue({
 		entries: [],
@@ -111,6 +124,8 @@ import {
 	getProjectRootDir,
 	readFileFromBranch,
 } from "../core/GitOps.js";
+import { discoverOpenCodeSessions, isOpenCodeInstalled } from "../core/OpenCodeSessionDiscoverer.js";
+import { readOpenCodeTranscript } from "../core/OpenCodeTranscriptReader.js";
 import {
 	acquireLock,
 	associateNoteWithCommit,
@@ -1363,6 +1378,54 @@ describe("queue-driven Worker", () => {
 			]);
 			// generateSummary should reflect total entries from both sessions
 			expect(generateSummary).toHaveBeenCalledWith(expect.objectContaining({ transcriptEntries: 2 }));
+		});
+	});
+
+	// ─── OpenCode session discovery in loadSessionTranscripts ─────────────────
+
+	describe("loadSessionTranscripts with OpenCode", () => {
+		it("includes discovered OpenCode sessions and uses the dedicated reader", async () => {
+			setupFullPipeline();
+			// Return a Claude session (from loadAllSessions) and an OpenCode session (from discovery)
+			vi.mocked(loadAllSessions).mockResolvedValue([
+				{ sessionId: "claude-1", transcriptPath: "/claude/session.jsonl", updatedAt: "2026-02-19" },
+			]);
+			vi.mocked(isOpenCodeInstalled).mockResolvedValue(true);
+			vi.mocked(discoverOpenCodeSessions).mockResolvedValue([
+				{
+					sessionId: "oc-1",
+					transcriptPath: "/home/user/.local/share/opencode/opencode.db#oc-1",
+					updatedAt: "2026-02-19",
+					source: "opencode",
+				},
+			]);
+			vi.mocked(readTranscript).mockResolvedValueOnce({
+				entries: [{ role: "human", content: "Claude entry" }],
+				newCursor: { transcriptPath: "/claude/session.jsonl", lineNumber: 5, updatedAt: "2026-02-19" },
+				totalLinesRead: 5,
+			});
+			vi.mocked(readOpenCodeTranscript).mockResolvedValueOnce({
+				entries: [{ role: "human", content: "OpenCode entry" }],
+				newCursor: {
+					transcriptPath: "/home/user/.local/share/opencode/opencode.db#oc-1",
+					lineNumber: 3,
+					updatedAt: "2026-02-19",
+				},
+				totalLinesRead: 3,
+			});
+			vi.mocked(buildMultiSessionContext).mockReturnValue("merged context");
+
+			await runWorker("/test/project");
+
+			// readOpenCodeTranscript should be called for the opencode session
+			expect(readOpenCodeTranscript).toHaveBeenCalledTimes(1);
+			// readTranscript should be called for the Claude session
+			expect(readTranscript).toHaveBeenCalledTimes(1);
+			// buildMultiSessionContext should receive both sessions
+			expect(buildMultiSessionContext).toHaveBeenCalledWith([
+				expect.objectContaining({ sessionId: "claude-1" }),
+				expect.objectContaining({ sessionId: "oc-1" }),
+			]);
 		});
 	});
 

--- a/cli/src/hooks/QueueWorker.test.ts
+++ b/cli/src/hooks/QueueWorker.test.ts
@@ -1,0 +1,570 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// ─── Mocks ──────────────────────────────────────────────────────────────────
+
+vi.mock("../core/GitOps.js", () => ({
+	getCommitInfo: vi.fn(),
+	getHeadHash: vi.fn(),
+	getParentHash: vi.fn(),
+	getDiffContent: vi.fn(),
+	getDiffStats: vi.fn(),
+	getCurrentBranch: vi.fn(),
+	getLastReflogAction: vi.fn(),
+	readFileFromBranch: vi.fn(),
+	getProjectRootDir: vi.fn().mockImplementation((cwd: string) => Promise.resolve(cwd)),
+}));
+
+vi.mock("../core/SessionTracker.js", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../core/SessionTracker.js")>();
+	return {
+		loadAllSessions: vi.fn().mockResolvedValue([]),
+		loadCursorForTranscript: vi.fn(),
+		saveCursor: vi.fn(),
+		loadConfig: vi.fn().mockResolvedValue({}),
+		acquireLock: vi.fn().mockResolvedValue(true),
+		releaseLock: vi.fn(),
+		loadPlansRegistry: vi.fn().mockResolvedValue({ version: 1, plans: {} }),
+		savePlansRegistry: vi.fn().mockResolvedValue(undefined),
+		associatePlanWithCommit: vi.fn(),
+		associateNoteWithCommit: vi.fn(),
+		filterSessionsByEnabledIntegrations: actual.filterSessionsByEnabledIntegrations,
+		dequeueAllGitOperations: vi.fn().mockResolvedValue([]),
+		deleteQueueEntry: vi.fn(),
+		enqueueGitOperation: vi.fn(),
+		isLockHeld: vi.fn(),
+	};
+});
+
+vi.mock("../core/TranscriptReader.js", () => ({
+	readTranscript: vi.fn(),
+	buildMultiSessionContext: vi.fn().mockReturnValue(""),
+}));
+
+vi.mock("../core/Summarizer.js", () => ({
+	generateSummary: vi.fn().mockResolvedValue({
+		transcriptEntries: 0,
+		conversationTurns: 0,
+		llm: { model: "test", inputTokens: 0, outputTokens: 0, apiLatencyMs: 0, stopReason: "end_turn" },
+		stats: { filesChanged: 1, insertions: 5, deletions: 2 },
+		topics: [{ title: "Test topic", trigger: "test", response: "done", decisions: "none" }],
+	}),
+}));
+
+vi.mock("../core/SummaryStore.js", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../core/SummaryStore.js")>();
+	return {
+		storeSummary: vi.fn(),
+		getSummary: vi.fn(),
+		mergeManyToOne: vi.fn(),
+		migrateOneToOne: vi.fn(),
+		storePlans: vi.fn(),
+		storeNotes: vi.fn(),
+		stripFunctionalMetadata: actual.stripFunctionalMetadata,
+	};
+});
+
+vi.mock("node:fs", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("node:fs")>();
+	return {
+		...actual,
+		existsSync: vi.fn().mockReturnValue(false),
+		readFileSync: vi.fn().mockReturnValue(""),
+	};
+});
+
+vi.mock("../core/CodexSessionDiscoverer.js", () => ({
+	discoverCodexSessions: vi.fn().mockResolvedValue([]),
+	isCodexInstalled: vi.fn().mockResolvedValue(false),
+}));
+
+vi.mock("../core/OpenCodeSessionDiscoverer.js", () => ({
+	discoverOpenCodeSessions: vi.fn().mockResolvedValue([]),
+	isOpenCodeInstalled: vi.fn().mockResolvedValue(false),
+}));
+
+vi.mock("../core/OpenCodeTranscriptReader.js", () => ({
+	readOpenCodeTranscript: vi.fn().mockResolvedValue({
+		entries: [],
+		newCursor: { transcriptPath: "", lineNumber: 0, updatedAt: "" },
+		totalLinesRead: 0,
+	}),
+}));
+
+vi.mock("../core/GeminiTranscriptReader.js", () => ({
+	readGeminiTranscript: vi.fn().mockResolvedValue({
+		entries: [],
+		newCursor: { transcriptPath: "", lineNumber: 0, updatedAt: "" },
+		totalLinesRead: 0,
+	}),
+}));
+
+vi.mock("../core/TranscriptParser.js", () => ({
+	getParserForSource: vi.fn().mockReturnValue({ parseLine: vi.fn() }),
+}));
+
+vi.mock("node:child_process", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("node:child_process")>();
+	return {
+		...actual,
+		spawn: vi.fn().mockReturnValue({ unref: vi.fn(), pid: 12345 }),
+	};
+});
+
+// Suppress console output
+vi.spyOn(console, "log").mockImplementation(() => {});
+vi.spyOn(console, "warn").mockImplementation(() => {});
+vi.spyOn(console, "error").mockImplementation(() => {});
+
+import { spawn } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import { isCodexInstalled } from "../core/CodexSessionDiscoverer.js";
+import { getCommitInfo, getCurrentBranch, getDiffContent, getDiffStats } from "../core/GitOps.js";
+import { discoverOpenCodeSessions, isOpenCodeInstalled } from "../core/OpenCodeSessionDiscoverer.js";
+import { readOpenCodeTranscript } from "../core/OpenCodeTranscriptReader.js";
+import {
+	acquireLock,
+	dequeueAllGitOperations,
+	loadAllSessions,
+	loadConfig,
+	loadCursorForTranscript,
+	loadPlansRegistry,
+	releaseLock,
+	saveCursor,
+	savePlansRegistry,
+} from "../core/SessionTracker.js";
+import { generateSummary } from "../core/Summarizer.js";
+import { storeSummary } from "../core/SummaryStore.js";
+import { buildMultiSessionContext } from "../core/TranscriptReader.js";
+import type { GitOperation } from "../Types.js";
+import { __test__, runWorker } from "./QueueWorker.js";
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function makeCommitOp(overrides: Partial<GitOperation> = {}): GitOperation {
+	return {
+		type: "commit",
+		commitHash: "abc12345def67890",
+		createdAt: "2026-04-01T12:00:00.000Z",
+		...overrides,
+	};
+}
+
+function setupPipelineMocks(hash = "abc12345def67890"): void {
+	vi.mocked(getCommitInfo).mockResolvedValue({
+		hash,
+		message: "Test commit",
+		author: "Jane",
+		date: "2026-04-01T12:00:00.000Z",
+	});
+	vi.mocked(getCurrentBranch).mockResolvedValue("feature/test");
+	vi.mocked(getDiffContent).mockResolvedValue("diff --git a/file.ts b/file.ts\n+line");
+	vi.mocked(getDiffStats).mockResolvedValue({ filesChanged: 1, insertions: 5, deletions: 2 });
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe("QueueWorker", () => {
+	beforeEach(() => {
+		vi.resetAllMocks();
+		vi.mocked(acquireLock).mockResolvedValue(true);
+		vi.mocked(releaseLock).mockResolvedValue(undefined);
+		vi.mocked(dequeueAllGitOperations).mockResolvedValue([]);
+		vi.mocked(loadConfig).mockResolvedValue(
+			{} as ReturnType<typeof loadConfig> extends Promise<infer T> ? T : never,
+		);
+		vi.mocked(loadAllSessions).mockResolvedValue([]);
+		vi.mocked(loadCursorForTranscript).mockResolvedValue(null);
+		vi.mocked(saveCursor).mockResolvedValue(undefined);
+		vi.mocked(loadPlansRegistry).mockResolvedValue({ version: 1, plans: {} });
+		vi.mocked(savePlansRegistry).mockResolvedValue(undefined);
+		vi.mocked(isCodexInstalled).mockResolvedValue(false);
+		vi.mocked(isOpenCodeInstalled).mockResolvedValue(false);
+		vi.mocked(buildMultiSessionContext).mockReturnValue("");
+		vi.mocked(generateSummary).mockResolvedValue({
+			transcriptEntries: 0,
+			conversationTurns: 0,
+			llm: { model: "test", inputTokens: 0, outputTokens: 0, apiLatencyMs: 0, stopReason: "end_turn" },
+			stats: { filesChanged: 1, insertions: 5, deletions: 2 },
+			topics: [{ title: "Test topic", trigger: "test", response: "done", decisions: "none" }],
+		});
+		vi.mocked(storeSummary).mockResolvedValue(undefined);
+		vi.mocked(existsSync).mockReturnValue(false);
+		vi.mocked(readFileSync).mockReturnValue("");
+		vi.mocked(spawn).mockReturnValue({ unref: vi.fn(), pid: 12345 } as unknown as ReturnType<typeof spawn>);
+	});
+
+	describe("runWorker — MAX_ENTRIES_PER_RUN cap", () => {
+		it("stops processing after MAX_ENTRIES_PER_RUN entries in a single batch, leaves the rest for the next run", async () => {
+			// Build a batch of 25 entries (>MAX=20) — forces the inner-loop break guard
+			// to fire at the 20th entry. The remaining 5 should sit in the queue; the
+			// post-finally dequeue call picks them up and triggers the chain-spawn path.
+			const batch = Array.from({ length: 25 }, (_, i) => ({
+				op: makeCommitOp({ commitHash: `hash${String(i).padStart(4, "0")}` }),
+				filePath: `/tmp/queue/entry-${i}.json`,
+			}));
+			const remainingAfterCap = batch.slice(20); // 5 left over
+
+			vi.mocked(dequeueAllGitOperations)
+				.mockResolvedValueOnce(batch) // 1st while iteration: 25 entries, break at 20
+				.mockResolvedValueOnce(remainingAfterCap); // chain-spawn probe: 5 remaining
+
+			setupPipelineMocks();
+
+			await runWorker("/test/cwd");
+
+			// processQueueEntry is called via executePipeline, which depends on many
+			// collaborators; rather than assert on the inner pipeline we verify the
+			// two observable invariants of the cap:
+			//   (1) exactly 20 entries got deleteQueueEntry'd (one per processed entry)
+			//   (2) dequeueAllGitOperations was called exactly twice — once inside
+			//       the loop (which broke out after 20), once after finally
+			const { deleteQueueEntry } = await import("../core/SessionTracker.js");
+			expect(vi.mocked(deleteQueueEntry)).toHaveBeenCalledTimes(20);
+			expect(vi.mocked(dequeueAllGitOperations)).toHaveBeenCalledTimes(2);
+		});
+	});
+
+	describe("runWorker — chain spawn", () => {
+		it("should detect remaining entries after processing and log chain spawn intent", async () => {
+			const op = makeCommitOp();
+			const queueEntry = { op, filePath: "/tmp/queue/entry.json" };
+
+			// First call inside the while-loop: returns one entry to process
+			// Second call inside the while-loop: returns empty (drain complete)
+			// Third call after finally block: returns remaining entries (chain spawn)
+			vi.mocked(dequeueAllGitOperations)
+				.mockResolvedValueOnce([queueEntry])
+				.mockResolvedValueOnce([])
+				.mockResolvedValueOnce([{ op: makeCommitOp({ commitHash: "remaining1" }), filePath: "/tmp/q2.json" }]);
+
+			setupPipelineMocks();
+
+			await runWorker("/test/cwd");
+
+			// The third call to dequeueAllGitOperations happens after the finally block
+			// and returns non-empty, triggering lines 234-235 (log + launchWorker).
+			// launchWorker is in v8 ignore, so we verify by checking dequeue was called 3 times.
+			expect(dequeueAllGitOperations).toHaveBeenCalledTimes(3);
+		});
+	});
+
+	describe("runWorker — note association with missing registry entry", () => {
+		it("should skip notes whose IDs are not in the registry when associating", async () => {
+			const op = makeCommitOp();
+			const queueEntry = { op, filePath: "/tmp/queue/entry.json" };
+
+			vi.mocked(dequeueAllGitOperations)
+				.mockResolvedValueOnce([queueEntry])
+				.mockResolvedValueOnce([])
+				.mockResolvedValueOnce([]);
+
+			setupPipelineMocks();
+
+			// Pipeline calls loadPlansRegistry:
+			//   1. detectPlanSlugsFromRegistry — no uncommitted plans
+			//   2. detectUncommittedNoteIds — finds "ghost-note" with null commitHash
+			//   3. associateNotesWithCommit — re-loads registry but "ghost-note" is gone
+			// (associatePlansWithCommit skips loadPlansRegistry when slugs.size === 0)
+			vi.mocked(loadPlansRegistry)
+				.mockResolvedValueOnce({ version: 1, plans: {} })
+				.mockResolvedValueOnce({
+					version: 1,
+					plans: {},
+					notes: {
+						"ghost-note": {
+							id: "ghost-note",
+							title: "Ghost",
+							format: "snippet" as const,
+							sourcePath: "/tmp/ghost.md",
+							addedAt: "2026-04-01T00:00:00Z",
+							updatedAt: "2026-04-01T00:00:00Z",
+							branch: "main",
+							commitHash: null,
+						},
+					},
+				})
+				.mockResolvedValueOnce({ version: 1, plans: {}, notes: {} });
+
+			await runWorker("/test/cwd");
+
+			// storeSummary should be called (pipeline completed), and no notes in the summary
+			expect(storeSummary).toHaveBeenCalledTimes(1);
+			const savedSummary = vi.mocked(storeSummary).mock.calls[0][0];
+			// Notes should be absent because the only note ID was not found in the registry
+			expect(savedSummary.notes).toBeUndefined();
+		});
+	});
+
+	describe("runWorker error handling", () => {
+		it("should catch and log errors from the worker loop", async () => {
+			vi.mocked(dequeueAllGitOperations).mockRejectedValueOnce(new Error("I/O error"));
+
+			await runWorker("/test/cwd");
+
+			// Worker should complete without throwing (error caught internally)
+			expect(releaseLock).toHaveBeenCalled();
+		});
+	});
+
+	describe("OpenCode integration", () => {
+		it("should include discovered OpenCode sessions in the pipeline when enabled", async () => {
+			const op = makeCommitOp();
+			const queueEntry = { op, filePath: "/tmp/queue/open-code.json" };
+
+			vi.mocked(dequeueAllGitOperations)
+				.mockResolvedValueOnce([queueEntry])
+				.mockResolvedValueOnce([])
+				.mockResolvedValueOnce([]);
+
+			setupPipelineMocks();
+			vi.mocked(loadConfig).mockResolvedValue({} as Awaited<ReturnType<typeof loadConfig>>);
+			vi.mocked(isOpenCodeInstalled).mockResolvedValue(true);
+			vi.mocked(discoverOpenCodeSessions).mockResolvedValue([
+				{
+					sessionId: "op-1",
+					transcriptPath: "/tmp/opencode.db#op-1",
+					updatedAt: "2026-04-01T12:00:00.000Z",
+					source: "opencode",
+				},
+			]);
+			vi.mocked(readOpenCodeTranscript).mockResolvedValue({
+				entries: [{ role: "human", content: "OpenCode context", timestamp: "2026-04-01T12:00:00.000Z" }],
+				newCursor: {
+					transcriptPath: "/tmp/opencode.db#op-1",
+					lineNumber: 1,
+					updatedAt: "2026-04-01T12:00:00.000Z",
+				},
+				totalLinesRead: 1,
+			});
+
+			await runWorker("/test/cwd");
+
+			expect(discoverOpenCodeSessions).toHaveBeenCalledWith("/test/cwd");
+			expect(readOpenCodeTranscript).toHaveBeenCalledWith(
+				"/tmp/opencode.db#op-1",
+				null,
+				"2026-04-01T12:00:00.000Z",
+			);
+			expect(saveCursor).toHaveBeenCalledWith(
+				expect.objectContaining({ transcriptPath: "/tmp/opencode.db#op-1", lineNumber: 1 }),
+				"/test/cwd",
+			);
+		});
+	});
+
+	describe("hoistMetadataFromOldSummary", () => {
+		it("returns empty object when oldSummary is null", () => {
+			expect(__test__.hoistMetadataFromOldSummary(null)).toEqual({});
+		});
+
+		it("returns empty object when oldSummary is undefined", () => {
+			expect(__test__.hoistMetadataFromOldSummary(undefined)).toEqual({});
+		});
+
+		it("omits absent fields so the && falsy branches are exercised", () => {
+			// Minimal summary with ZERO hoistable metadata — every `&&` branch hits its falsy side.
+			const bare = {
+				version: 3 as const,
+				commitHash: "h",
+				commitMessage: "m",
+				commitAuthor: "a",
+				commitDate: "2026-04-01T00:00:00.000Z",
+				branch: "b",
+				generatedAt: "2026-04-01T00:00:00.000Z",
+				topics: [],
+			};
+			expect(__test__.hoistMetadataFromOldSummary(bare)).toEqual({});
+		});
+
+		it("hoists every field when present", () => {
+			const rich = {
+				version: 3 as const,
+				commitHash: "h",
+				commitMessage: "m",
+				commitAuthor: "a",
+				commitDate: "2026-04-01T00:00:00.000Z",
+				branch: "b",
+				generatedAt: "2026-04-01T00:00:00.000Z",
+				topics: [],
+				jolliDocId: 42,
+				jolliDocUrl: "https://jolli.app/d/42",
+				orphanedDocIds: [1, 2],
+				plans: [{ slug: "p", title: "P", editCount: 1, addedAt: "x", updatedAt: "y" }],
+				notes: [{ id: "n", title: "N", format: "markdown" as const, addedAt: "x", updatedAt: "y" }],
+				e2eTestGuide: [{ title: "T", steps: ["s"], expectedResults: ["r"] }],
+			};
+			const out = __test__.hoistMetadataFromOldSummary(rich);
+			expect(out.jolliDocId).toBe(42);
+			expect(out.jolliDocUrl).toBe("https://jolli.app/d/42");
+			expect(out.orphanedDocIds).toEqual([1, 2]);
+			expect(out.plans).toHaveLength(1);
+			expect(out.notes).toHaveLength(1);
+			expect(out.e2eTestGuide).toHaveLength(1);
+		});
+	});
+
+	describe("detectUncommittedNoteIds", () => {
+		it("returns only notes with null commitHash and no ignored/contentHashAtCommit", async () => {
+			vi.mocked(loadPlansRegistry).mockResolvedValueOnce({
+				version: 1,
+				plans: {},
+				notes: {
+					fresh: {
+						id: "fresh",
+						title: "Fresh",
+						format: "markdown" as const,
+						sourcePath: "/p",
+						addedAt: "x",
+						updatedAt: "y",
+						branch: "main",
+						commitHash: null,
+					},
+					// Fails branch: already committed
+					committed: {
+						id: "committed",
+						title: "Committed",
+						format: "markdown" as const,
+						sourcePath: "/p",
+						addedAt: "x",
+						updatedAt: "y",
+						branch: "main",
+						commitHash: "abc123",
+					},
+					// Fails branch: ignored
+					ignored: {
+						id: "ignored",
+						title: "Ignored",
+						format: "markdown" as const,
+						sourcePath: "/p",
+						addedAt: "x",
+						updatedAt: "y",
+						branch: "main",
+						commitHash: null,
+						ignored: true,
+					},
+					// Fails branch: contentHashAtCommit set (guard entry)
+					guard: {
+						id: "guard",
+						title: "Guard",
+						format: "markdown" as const,
+						sourcePath: "/p",
+						addedAt: "x",
+						updatedAt: "y",
+						branch: "main",
+						commitHash: null,
+						contentHashAtCommit: "hash",
+					},
+				},
+			});
+
+			const ids = await __test__.detectUncommittedNoteIds("/test/cwd");
+			expect([...ids].sort()).toEqual(["fresh"]);
+		});
+
+		it("returns empty set when registry has no notes field", async () => {
+			vi.mocked(loadPlansRegistry).mockResolvedValueOnce({ version: 1, plans: {} });
+			const ids = await __test__.detectUncommittedNoteIds("/test/cwd");
+			expect(ids.size).toBe(0);
+		});
+	});
+
+	describe("buildStoredTranscript", () => {
+		it("keeps per-session source/transcriptPath even when two sources share the same sessionId", async () => {
+			// Regression: the previous Map<sessionId,…> lookup would collapse these
+			// two into a single entry because UUID collisions across integrations
+			// can't be ruled out and the transcriptPath on collision differs per source.
+			const stored = __test__.buildStoredTranscript([
+				{
+					sessionId: "shared-uuid",
+					transcriptPath: "/claude/sessions/shared-uuid.jsonl",
+					source: "claude",
+					entries: [{ role: "human", content: "hi from claude", timestamp: "2026-04-22T10:00:00Z" }],
+				},
+				{
+					sessionId: "shared-uuid",
+					transcriptPath: "/tmp/opencode.db#shared-uuid",
+					source: "opencode",
+					entries: [{ role: "human", content: "hi from opencode", timestamp: "2026-04-22T10:00:01Z" }],
+				},
+			]);
+
+			expect(stored.sessions).toHaveLength(2);
+			const claudeSession = stored.sessions[0];
+			const opencodeSession = stored.sessions[1];
+			expect(claudeSession.source).toBe("claude");
+			expect(claudeSession.transcriptPath).toBe("/claude/sessions/shared-uuid.jsonl");
+			expect(opencodeSession.source).toBe("opencode");
+			expect(opencodeSession.transcriptPath).toBe("/tmp/opencode.db#shared-uuid");
+		});
+
+		it("preserves sessionTranscripts that arrive without a source (legacy claude rows)", async () => {
+			const stored = __test__.buildStoredTranscript([
+				{
+					sessionId: "legacy-session",
+					transcriptPath: "/claude/legacy.jsonl",
+					// source intentionally omitted — pre-multi-source data shape
+					entries: [],
+				},
+			]);
+
+			expect(stored.sessions).toHaveLength(1);
+			expect(stored.sessions[0].source).toBeUndefined();
+			expect(stored.sessions[0].transcriptPath).toBe("/claude/legacy.jsonl");
+		});
+	});
+
+	describe("OpenCode integration — empty sessions", () => {
+		it("logs no Discovered count when isOpenCodeInstalled=true but discovery returns empty", async () => {
+			const op = makeCommitOp();
+			const queueEntry = { op, filePath: "/tmp/queue/entry.json" };
+
+			vi.mocked(dequeueAllGitOperations)
+				.mockResolvedValueOnce([queueEntry])
+				.mockResolvedValueOnce([])
+				.mockResolvedValueOnce([]);
+
+			setupPipelineMocks();
+			vi.mocked(isOpenCodeInstalled).mockResolvedValue(true);
+			vi.mocked(discoverOpenCodeSessions).mockResolvedValue([]);
+
+			await runWorker("/test/cwd");
+
+			expect(discoverOpenCodeSessions).toHaveBeenCalledWith("/test/cwd");
+			// Pipeline completes normally
+			expect(storeSummary).toHaveBeenCalled();
+		});
+	});
+
+	describe("squash helpers", () => {
+		it("should skip squash queue entries without source hashes", async () => {
+			await expect(__test__.handleSquashFromQueue(makeCommitOp(), "/test/cwd")).resolves.toBeUndefined();
+		});
+
+		it("should default squash commitSource to cli", async () => {
+			const { getSummary, mergeManyToOne } = await import("../core/SummaryStore.js");
+			vi.mocked(getSummary).mockResolvedValue({
+				version: 3,
+				commitHash: "oldhash",
+				commitMessage: "Old",
+				commitAuthor: "Jane",
+				commitDate: "2026-04-01T10:00:00.000Z",
+				branch: "feature/test",
+				generatedAt: "2026-04-01T10:00:00.000Z",
+				topics: [{ title: "Old topic", trigger: "t", response: "r", decisions: "d" }],
+			} as Awaited<ReturnType<typeof getSummary>>);
+			setupPipelineMocks("newhash123");
+
+			await __test__.handleSquashFromQueue(
+				makeCommitOp({ commitHash: "newhash123", sourceHashes: ["oldhash"] }),
+				"/test/cwd",
+			);
+
+			expect(mergeManyToOne).toHaveBeenCalledWith(
+				expect.any(Array),
+				expect.objectContaining({ hash: "newhash123" }),
+				"/test/cwd",
+				expect.objectContaining({ commitSource: "cli", commitType: "squash" }),
+			);
+		});
+	});
+});

--- a/cli/src/hooks/QueueWorker.ts
+++ b/cli/src/hooks/QueueWorker.ts
@@ -24,6 +24,8 @@ import { fileURLToPath } from "node:url";
 import { discoverCodexSessions, isCodexInstalled } from "../core/CodexSessionDiscoverer.js";
 import { readGeminiTranscript } from "../core/GeminiTranscriptReader.js";
 import { getCommitInfo, getCurrentBranch, getDiffContent, getDiffStats } from "../core/GitOps.js";
+import { discoverOpenCodeSessions, isOpenCodeInstalled } from "../core/OpenCodeSessionDiscoverer.js";
+import { readOpenCodeTranscript } from "../core/OpenCodeTranscriptReader.js";
 import { evaluatePlanProgress } from "../core/PlanProgressEvaluator.js";
 import {
 	acquireLock,
@@ -67,6 +69,7 @@ import type {
 	PlanReference,
 	StoredTranscript,
 	TopicSummary,
+	TranscriptReadResult,
 	TranscriptSource,
 } from "../Types.js";
 
@@ -140,12 +143,18 @@ export function launchWorker(cwd: string): void {
 	const dir = dirname(fileURLToPath(import.meta.url));
 	const scriptPath = join(dir, "QueueWorker.js");
 
-	const child = spawn(process.execPath, [scriptPath, "--worker", "--cwd", cwd], {
-		detached: true,
-		stdio: "ignore",
-		cwd,
-		windowsHide: true,
-	});
+	const child = spawn(
+		process.execPath,
+		// --disable-warning silences node:sqlite's ExperimentalWarning during OpenCode
+		// scans; it also suppresses any other experimental warnings in this subprocess.
+		["--disable-warning=ExperimentalWarning", scriptPath, "--worker", "--cwd", cwd],
+		{
+			detached: true,
+			stdio: "ignore",
+			cwd,
+			windowsHide: true,
+		},
+	);
 	child.unref();
 
 	log.info("Background worker spawned (PID: %d)", child.pid ?? -1);
@@ -184,6 +193,9 @@ export async function runWorker(cwd: string, force = false): Promise<void> {
 			if (entries.length === 0) break;
 
 			for (const { op, filePath } of entries) {
+				// Hard cap: if a single dequeue batch returns more than MAX_ENTRIES_PER_RUN,
+				// stop inside the inner loop so the outer while condition can re-check and
+				// exit cleanly. The subsequent chain-spawn (line below) picks up leftovers.
 				if (processedCount >= MAX_ENTRIES_PER_RUN) break;
 				try {
 					await processQueueEntry(op, cwd, force);
@@ -588,11 +600,7 @@ async function executePipeline(cwd: string, op: GitOperation, force = false): Pr
 	}
 
 	// Step 3+4: Load sessions and read transcripts with time cutoff for queue-driven attribution
-	const { allSessions, sessionTranscripts, totalEntries, humanEntries } = await loadSessionTranscripts(
-		cwd,
-		config,
-		op.createdAt,
-	);
+	const { sessionTranscripts, totalEntries, humanEntries } = await loadSessionTranscripts(cwd, config, op.createdAt);
 
 	// Step 5: Get git diff and stats (moved before guard to enable diff-only summaries)
 	stepStart = now();
@@ -694,13 +702,19 @@ async function executePipeline(cwd: string, op: GitOperation, force = false): Pr
 	// Step 8b: Evaluate plan progress for each linked plan (Haiku calls parallelized)
 	const planProgressArtifacts: PlanProgressArtifact[] = [];
 	if (planRefs.length > 0) {
+		/* v8 ignore start -- defensive: SummaryResult.topics is always set by generateSummary, but retain the nullish guard in case the type relaxes */
 		const topics: ReadonlyArray<TopicSummary> = summaryResult.topics ?? [];
+		/* v8 ignore stop */
 		const commitDate = new Date(commitInfo.date).toISOString();
 
 		const evalPromises = planRefs.map(async (planRef) => {
 			const planMarkdown = planAssociation.markdownBySlug.get(planRef.slug);
+			/* v8 ignore start -- defensive: associatePlansWithCommit populates markdownBySlug for every ref it returns, but retain the guard for invariant violations */
 			if (planMarkdown === undefined) return null;
+			/* v8 ignore stop */
+			/* v8 ignore start -- defensive: originalSlugBySlug is populated alongside markdownBySlug in associatePlansWithCommit */
 			const originalSlug = planAssociation.originalSlugBySlug.get(planRef.slug) ?? planRef.slug;
+			/* v8 ignore stop */
 			const result = await evaluatePlanProgress(planMarkdown, diff, topics, conversation, config);
 			if (!result) return null;
 			return {
@@ -745,7 +759,7 @@ async function executePipeline(cwd: string, op: GitOperation, force = false): Pr
 	);
 
 	// Step 8c: Build StoredTranscript from session transcripts for persistence
-	const storedTranscript = buildStoredTranscript(sessionTranscripts, allSessions);
+	const storedTranscript = buildStoredTranscript(sessionTranscripts);
 
 	// Step 8d: Store summary (+ transcript + plan progress) in orphan branch
 	// Pass `force` so manual re-summarize can overwrite a previously failed entry.
@@ -968,12 +982,11 @@ async function handleAmendPipeline(
 
 	// Load sessions and read transcripts with time cutoff
 	const amendConfig = await loadConfig();
-	const {
-		allSessions: amendSessions,
-		sessionTranscripts,
-		totalEntries,
-		humanEntries,
-	} = await loadSessionTranscripts(cwd, amendConfig, beforeTimestamp);
+	const { sessionTranscripts, totalEntries, humanEntries } = await loadSessionTranscripts(
+		cwd,
+		amendConfig,
+		beforeTimestamp,
+	);
 
 	// Get git diff and stats
 	let stepStart = now();
@@ -1101,7 +1114,7 @@ async function handleAmendPipeline(
 	};
 
 	// Build StoredTranscript for the amend's own conversation (Scenario 2: fresh cursors)
-	const amendStoredTranscript = buildStoredTranscript(sessionTranscripts, amendSessions);
+	const amendStoredTranscript = buildStoredTranscript(sessionTranscripts);
 
 	stepStart = now();
 	await storeSummary(amendedSummary, cwd, false, { transcript: amendStoredTranscript });
@@ -1151,8 +1164,18 @@ async function loadSessionTranscripts(
 	if (config.codexEnabled !== false && (await isCodexInstalled())) {
 		const codexSessions = await discoverCodexSessions(cwd);
 		if (codexSessions.length > 0) {
-			allSessions = [...trackedSessions, ...codexSessions];
+			allSessions = [...allSessions, ...codexSessions];
 			log.info("Discovered %d Codex session(s)", codexSessions.length);
+		}
+	}
+
+	// Discover OpenCode sessions (on-demand SQLite scan)
+	// OpenCode uses a global DB at ~/.local/share/opencode/opencode.db, scoped by project directory
+	if (config.openCodeEnabled !== false && (await isOpenCodeInstalled())) {
+		const openCodeSessions = await discoverOpenCodeSessions(cwd);
+		if (openCodeSessions.length > 0) {
+			allSessions = [...allSessions, ...openCodeSessions];
+			log.info("Discovered %d OpenCode session(s)", openCodeSessions.length);
 		}
 	}
 
@@ -1192,17 +1215,22 @@ async function readAllTranscripts(
 		const startLine = cursor?.lineNumber ?? 0;
 		const source = session.source ?? "claude";
 
-		// Gemini uses a dedicated JSON reader (not JSONL line-based parsing)
-		const result =
-			source === "gemini"
-				? await readGeminiTranscript(session.transcriptPath, cursor, beforeTimestamp)
-				: await readTranscript(session.transcriptPath, cursor, getParserForSource(source), beforeTimestamp);
+		// Gemini and OpenCode use dedicated readers (not JSONL line-based parsing)
+		let result: TranscriptReadResult;
+		if (source === "gemini") {
+			result = await readGeminiTranscript(session.transcriptPath, cursor, beforeTimestamp);
+		} else if (source === "opencode") {
+			result = await readOpenCodeTranscript(session.transcriptPath, cursor, beforeTimestamp);
+		} else {
+			result = await readTranscript(session.transcriptPath, cursor, getParserForSource(source), beforeTimestamp);
+		}
 		const endLine = result.newCursor.lineNumber;
 
 		if (result.entries.length > 0) {
 			sessionTranscripts.push({
 				sessionId: session.sessionId,
 				transcriptPath: session.transcriptPath,
+				source: session.source,
 				entries: result.entries,
 			});
 			totalEntries += result.entries.length;
@@ -1225,34 +1253,36 @@ async function readAllTranscripts(
 }
 
 /**
- * Converts pipeline session transcripts into the StoredTranscript format for orphan branch persistence.
- * Maps each SessionTranscript to a StoredSession, enriching with `source` and `transcriptPath`
- * from the original session metadata.
+ * Converts pipeline session transcripts into the StoredTranscript format for
+ * orphan-branch persistence.
+ *
+ * Source / transcriptPath are threaded directly off each `SessionTranscript`
+ * rather than looked up in a `Map<sessionId, ...>` against `allSessions` —
+ * the earlier Map-based approach would collapse two sessions from different
+ * integrations that happened to share an `sessionId`, silently rewriting
+ * the later session's metadata onto the earlier one on serialize.
  */
-function buildStoredTranscript(
-	sessionTranscripts: ReadonlyArray<SessionTranscript>,
-	allSessions: ReadonlyArray<{ sessionId: string; transcriptPath: string; source?: TranscriptSource }>,
-): StoredTranscript {
-	const sessionMap = new Map(allSessions.map((s) => [s.sessionId, s]));
+function buildStoredTranscript(sessionTranscripts: ReadonlyArray<SessionTranscript>): StoredTranscript {
 	return {
-		sessions: sessionTranscripts.map((st) => {
-			const meta = sessionMap.get(st.sessionId);
-			return {
-				sessionId: st.sessionId,
-				source: meta?.source,
-				transcriptPath: meta?.transcriptPath ?? st.transcriptPath,
-				entries: [...st.entries],
-			};
-		}),
+		sessions: sessionTranscripts.map((st) => ({
+			sessionId: st.sessionId,
+			source: st.source,
+			transcriptPath: st.transcriptPath,
+			entries: [...st.entries],
+		})),
 	};
 }
 
 /** Exposed for unit tests. */
 export const __test__ = {
 	detectPlanSlugsFromRegistry,
+	detectUncommittedNoteIds,
+	hoistMetadataFromOldSummary,
 	associatePlansWithCommit,
 	executePipeline,
 	handleAmendPipeline,
+	handleSquashFromQueue,
+	loadSessionTranscripts,
 	buildStoredTranscript,
 };
 

--- a/cli/src/hooks/StopHook.test.ts
+++ b/cli/src/hooks/StopHook.test.ts
@@ -125,6 +125,33 @@ function mockTranscriptWithLines(lines: string[]): void {
 	vi.mocked(createReadStream).mockReturnValueOnce({} as ReadStream);
 }
 
+/**
+ * Helper to mock createReadStream + createInterface where the readline emits an error.
+ * Exercises the `rl.on("error", ...)` handler in scanTranscriptForPlans.
+ */
+function mockTranscriptWithError(): void {
+	const handlers: Record<string, Array<(...args: unknown[]) => void>> = {};
+
+	const mockRl = {
+		on: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+			if (!handlers[event]) {
+				handlers[event] = [];
+			}
+			handlers[event].push(handler);
+			// Fire "error" event after all handlers are registered
+			if (event === "error") {
+				Promise.resolve().then(() => {
+					for (const h of handlers.error ?? []) h(new Error("read error"));
+				});
+			}
+			return mockRl;
+		}),
+	};
+
+	vi.mocked(createInterface).mockReturnValueOnce(mockRl as unknown as ReadlineInterface);
+	vi.mocked(createReadStream).mockReturnValueOnce({} as ReadStream);
+}
+
 /** Returns a valid hook input JSON string */
 function hookJson(transcriptPath = "/path/to/session.jsonl", cwd = "/my/project"): string {
 	return JSON.stringify({ session_id: "test-session-123", transcript_path: transcriptPath, cwd });
@@ -936,5 +963,17 @@ describe("StopHook — plan discovery", () => {
 		const saved = vi.mocked(savePlansRegistry).mock.calls[0]?.[0];
 		expect(saved?.plans["current-plan"]?.commitHash).toBeNull();
 		expect(saved?.plans["other-plan"]).toBeUndefined();
+	});
+
+	it("should resolve gracefully when readline emits an error during transcript scan", async () => {
+		vi.mocked(existsSync).mockReturnValue(true);
+		mockTranscriptWithError();
+
+		mockStdin(hookJson(TRANSCRIPT_PATH, PROJECT_DIR));
+		await handleStopHook();
+
+		// The error handler resolves the promise (does not reject).
+		// Cursor should still be updated (totalLines = 0 since no lines were read).
+		expect(savePlansRegistry).not.toHaveBeenCalled();
 	});
 });

--- a/cli/src/hooks/StopHook.ts
+++ b/cli/src/hooks/StopHook.ts
@@ -127,9 +127,6 @@ export async function handleStopHook(): Promise<void> {
 
 // ─── Plan Discovery ─────────────────────────────────────────────────────────
 
-/** Plans directory where Claude Code stores plan files */
-const PLANS_DIR = join(homedir(), ".claude", "plans");
-
 /** Cursor key prefix to distinguish plan scan cursors from summarization cursors */
 const PLAN_CURSOR_PREFIX = "plan:";
 
@@ -190,7 +187,7 @@ async function discoverPlansFromTranscript(sessionInfo: SessionInfo, cwd: string
 	let changed = false;
 
 	for (const [slug, editCount] of slugs) {
-		const planFile = join(PLANS_DIR, `${slug}.md`);
+		const planFile = join(homedir(), ".claude", "plans", `${slug}.md`);
 		if (!existsSync(planFile)) {
 			continue;
 		}

--- a/cli/src/install/DistPathResolver.test.ts
+++ b/cli/src/install/DistPathResolver.test.ts
@@ -30,6 +30,10 @@ vi.mock("node:os", async (importOriginal) => {
 
 vi.stubGlobal("__PKG_VERSION__", "1.0.0");
 
+// Suppress console output
+vi.spyOn(console, "log").mockImplementation(() => {});
+vi.spyOn(console, "warn").mockImplementation(() => {});
+
 describe("DistPathResolver", () => {
 	let tempDir: string;
 

--- a/cli/src/install/Installer.test.ts
+++ b/cli/src/install/Installer.test.ts
@@ -43,6 +43,28 @@ vi.mock("../core/GeminiSessionDetector.js", () => ({
 	isGeminiInstalled: vi.fn().mockResolvedValue(false),
 }));
 
+// Mock OpenCodeSessionDiscoverer for status/install checks
+vi.mock("../core/OpenCodeSessionDiscoverer.js", () => ({
+	isOpenCodeInstalled: vi.fn().mockResolvedValue(false),
+	discoverOpenCodeSessions: vi.fn().mockResolvedValue([]),
+	scanOpenCodeSessions: vi.fn().mockResolvedValue({ sessions: [] }),
+}));
+
+// Partially mock DistPathResolver so resolveDistPath doesn't depend on global npm state.
+// By default, resolveDistPath returns the caller's own dist dir with "cli" source.
+vi.mock("./DistPathResolver.js", async (importOriginal) => {
+	const original = await importOriginal<typeof import("./DistPathResolver.js")>();
+	return {
+		...original,
+		resolveDistPath: vi.fn().mockImplementation(async (_cwd, callerDistDir, callerSource) => ({
+			distDir: callerDistDir,
+			version: typeof __PKG_VERSION__ !== "undefined" ? __PKG_VERSION__ : "dev",
+			source: callerSource ?? "cli",
+			candidates: [],
+		})),
+	};
+});
+
 // Override getGlobalConfigDir and loadConfig so tests don't read the
 // developer's real ~/.jolli/jollimemory/config.json. loadConfig uses an
 // internal constant, so we must override the function itself.
@@ -104,6 +126,16 @@ describe("Installer", () => {
 		originalCwd = process.cwd();
 		// Create .git/hooks directory to simulate a git repo
 		await mkdir(join(tempDir, ".git", "hooks"), { recursive: true });
+		// Reset integration detector mocks to defaults so state doesn't leak between tests
+		const { isCodexInstalled, discoverCodexSessions } = await import("../core/CodexSessionDiscoverer.js");
+		vi.mocked(isCodexInstalled).mockResolvedValue(false);
+		vi.mocked(discoverCodexSessions).mockResolvedValue([]);
+		const { isOpenCodeInstalled, discoverOpenCodeSessions, scanOpenCodeSessions } = await import(
+			"../core/OpenCodeSessionDiscoverer.js"
+		);
+		vi.mocked(isOpenCodeInstalled).mockResolvedValue(false);
+		vi.mocked(discoverOpenCodeSessions).mockResolvedValue([]);
+		vi.mocked(scanOpenCodeSessions).mockResolvedValue({ sessions: [] });
 	});
 
 	afterEach(async () => {
@@ -133,6 +165,66 @@ describe("Installer", () => {
 			expect(matcherGroup.hooks[0].command).toContain("run-hook");
 			expect(matcherGroup.hooks[0].command).toContain("stop");
 			expect(matcherGroup.hooks[0].async).toBe(true);
+		});
+
+		it("should auto-enable Codex discovery when Codex is detected and not configured", async () => {
+			const { isCodexInstalled } = await import("../core/CodexSessionDiscoverer.js");
+			vi.mocked(isCodexInstalled).mockResolvedValueOnce(true);
+
+			const result = await install(tempDir);
+
+			expect(result.success).toBe(true);
+			const globalConfig = JSON.parse(await readFile(join(emptyGlobalDir, "config.json"), "utf-8"));
+			expect(globalConfig.codexEnabled).toBe(true);
+		});
+
+		it("should keep codexEnabled unchanged when Codex is detected but already configured", async () => {
+			const { isCodexInstalled } = await import("../core/CodexSessionDiscoverer.js");
+			vi.mocked(isCodexInstalled).mockResolvedValueOnce(true);
+			await writeFile(join(emptyGlobalDir, "config.json"), JSON.stringify({ codexEnabled: false }), "utf-8");
+
+			const result = await install(tempDir);
+
+			expect(result.success).toBe(true);
+			const globalConfig = JSON.parse(await readFile(join(emptyGlobalDir, "config.json"), "utf-8"));
+			expect(globalConfig.codexEnabled).toBe(false);
+		});
+
+		it("should auto-enable OpenCode discovery when OpenCode is detected and not configured", async () => {
+			const { isOpenCodeInstalled } = await import("../core/OpenCodeSessionDiscoverer.js");
+			vi.mocked(isOpenCodeInstalled).mockResolvedValueOnce(true);
+
+			const result = await install(tempDir);
+
+			expect(result.success).toBe(true);
+			const globalConfig = JSON.parse(await readFile(join(emptyGlobalDir, "config.json"), "utf-8"));
+			expect(globalConfig.openCodeEnabled).toBe(true);
+		});
+
+		it("should keep openCodeEnabled unchanged when OpenCode is detected but already configured", async () => {
+			const { isOpenCodeInstalled } = await import("../core/OpenCodeSessionDiscoverer.js");
+			vi.mocked(isOpenCodeInstalled).mockResolvedValueOnce(true);
+			await writeFile(join(emptyGlobalDir, "config.json"), JSON.stringify({ openCodeEnabled: false }), "utf-8");
+
+			const result = await install(tempDir);
+
+			expect(result.success).toBe(true);
+			const globalConfig = JSON.parse(await readFile(join(emptyGlobalDir, "config.json"), "utf-8"));
+			expect(globalConfig.openCodeEnabled).toBe(false);
+		});
+
+		it("should not rewrite openCodeEnabled when OpenCode is detected and already true", async () => {
+			// Covers the `config.openCodeEnabled === undefined` false branch: detection succeeds
+			// (reaches the inner if) but the existing value is explicitly `true`, so no rewrite.
+			const { isOpenCodeInstalled } = await import("../core/OpenCodeSessionDiscoverer.js");
+			vi.mocked(isOpenCodeInstalled).mockResolvedValueOnce(true);
+			await writeFile(join(emptyGlobalDir, "config.json"), JSON.stringify({ openCodeEnabled: true }), "utf-8");
+
+			const result = await install(tempDir);
+
+			expect(result.success).toBe(true);
+			const globalConfig = JSON.parse(await readFile(join(emptyGlobalDir, "config.json"), "utf-8"));
+			expect(globalConfig.openCodeEnabled).toBe(true);
 		});
 
 		it("should use process.cwd() when install is called without cwd", async () => {
@@ -1139,6 +1231,102 @@ describe("Installer", () => {
 			expect(status.activeSessions).toBe(0);
 			expect(status.mostRecentSession).toBeNull();
 		});
+
+		it("should include OpenCode sessions in activeSessions when openCodeEnabled", async () => {
+			const { isOpenCodeInstalled, scanOpenCodeSessions } = await import("../core/OpenCodeSessionDiscoverer.js");
+			vi.mocked(isOpenCodeInstalled).mockResolvedValue(true);
+			vi.mocked(scanOpenCodeSessions).mockResolvedValue({
+				sessions: [
+					{
+						sessionId: "oc1",
+						transcriptPath: "/oc1",
+						updatedAt: new Date().toISOString(),
+						source: "opencode",
+					},
+				],
+			});
+
+			const status = await getStatus(tempDir);
+			expect(status.activeSessions).toBe(1);
+			expect(status.mostRecentSession?.source).toBe("opencode");
+		});
+
+		it("should exclude OpenCode sessions when openCodeEnabled is false", async () => {
+			const { isOpenCodeInstalled, scanOpenCodeSessions } = await import("../core/OpenCodeSessionDiscoverer.js");
+			const { saveConfig } = await import("../core/SessionTracker.js");
+			vi.mocked(isOpenCodeInstalled).mockResolvedValue(true);
+			vi.mocked(scanOpenCodeSessions).mockResolvedValue({
+				sessions: [
+					{
+						sessionId: "oc1",
+						transcriptPath: "/oc1",
+						updatedAt: new Date().toISOString(),
+						source: "opencode",
+					},
+				],
+			});
+
+			const projectConfigDir = join(tempDir, ".jolli", "jollimemory");
+			await saveConfig({ openCodeEnabled: false }, undefined, projectConfigDir);
+			const status = await getStatus(tempDir);
+			expect(status.activeSessions).toBe(0);
+			expect(status.mostRecentSession).toBeNull();
+		});
+
+		it("should populate sessionsBySource with per-source counts", async () => {
+			const { isCodexInstalled, discoverCodexSessions } = await import("../core/CodexSessionDiscoverer.js");
+			const { isOpenCodeInstalled, scanOpenCodeSessions } = await import("../core/OpenCodeSessionDiscoverer.js");
+			const { saveSession } = await import("../core/SessionTracker.js");
+
+			// Set up Claude session via sessions.json
+			await saveSession(
+				{
+					sessionId: "claude1",
+					transcriptPath: "/claude1",
+					updatedAt: new Date().toISOString(),
+					source: "claude",
+				},
+				tempDir,
+			);
+
+			// Set up Codex discovery
+			vi.mocked(isCodexInstalled).mockResolvedValue(true);
+			vi.mocked(discoverCodexSessions).mockResolvedValue([
+				{
+					sessionId: "codex1",
+					transcriptPath: "/codex1",
+					updatedAt: new Date().toISOString(),
+					source: "codex",
+				},
+				{
+					sessionId: "codex2",
+					transcriptPath: "/codex2",
+					updatedAt: new Date().toISOString(),
+					source: "codex",
+				},
+			]);
+
+			// Set up OpenCode discovery
+			vi.mocked(isOpenCodeInstalled).mockResolvedValue(true);
+			vi.mocked(scanOpenCodeSessions).mockResolvedValue({
+				sessions: [
+					{
+						sessionId: "oc1",
+						transcriptPath: "/oc1",
+						updatedAt: new Date().toISOString(),
+						source: "opencode",
+					},
+				],
+			});
+
+			const status = await getStatus(tempDir);
+			expect(status.activeSessions).toBe(4);
+			expect(status.sessionsBySource).toEqual({
+				claude: 1,
+				codex: 2,
+				opencode: 1,
+			});
+		});
 	});
 
 	describe("Gemini auto-detection during install", () => {
@@ -1547,6 +1735,13 @@ describe("Installer", () => {
 	});
 
 	describe("migrateWorktreeConfig — backfill-only migration", () => {
+		it("should skip migration when the worktree config directory is already the global config directory", async () => {
+			mockGlobalConfigDir.mockReturnValue(join(tempDir, ".jolli", "jollimemory"));
+
+			const result = await install(tempDir);
+			expect(result.success).toBe(true);
+		});
+
 		it("should migrate only apiKey when jolliApiKey is undefined", async () => {
 			// Set up a second worktree with ONLY apiKey (no jolliApiKey)
 			const worktree2 = join(tempDir, "wt2");
@@ -1667,6 +1862,26 @@ describe("Installer", () => {
 			// Backfilled field should be removed from worktree
 			expect(wtConfig.jolliApiKey).toBeUndefined();
 		});
+
+		it("should leave worktree config untouched when nothing needs backfilling", async () => {
+			await mkdir(emptyGlobalDir, { recursive: true });
+			await writeFile(join(emptyGlobalDir, "config.json"), JSON.stringify({ apiKey: "global-key" }), "utf-8");
+
+			const worktree2 = join(tempDir, "wt2");
+			await mkdir(join(worktree2, ".git", "hooks"), { recursive: true });
+			const wt2JolliDir = join(worktree2, ".jolli", "jollimemory");
+			await mkdir(wt2JolliDir, { recursive: true });
+			await writeFile(join(wt2JolliDir, "config.json"), JSON.stringify({ apiKey: "worktree-key" }), "utf-8");
+
+			const { listWorktrees } = await import("../core/GitOps.js");
+			vi.mocked(listWorktrees).mockResolvedValueOnce([tempDir, worktree2]);
+
+			const result = await install(tempDir);
+			expect(result.success).toBe(true);
+
+			const wtConfig = JSON.parse(await readFile(join(wt2JolliDir, "config.json"), "utf-8"));
+			expect(wtConfig.apiKey).toBe("worktree-key");
+		});
 	});
 
 	describe("migrateWorktreeConfig — no backfill when all fields already in global", () => {
@@ -1723,12 +1938,59 @@ describe("Installer", () => {
 	});
 
 	describe("getStatus — active sessions reduce branch", () => {
-		it("should compute mostRecentSession via reduce when multiple enabled sessions exist", async () => {
-			// Write multiple Claude sessions with different timestamps
+		it("should not append OpenCode sessions when discovery finds none", async () => {
+			const { isOpenCodeInstalled, scanOpenCodeSessions } = await import("../core/OpenCodeSessionDiscoverer.js");
+			vi.mocked(isOpenCodeInstalled).mockResolvedValueOnce(true);
+			vi.mocked(scanOpenCodeSessions).mockResolvedValueOnce({ sessions: [] });
+
+			const status = await getStatus(tempDir);
+			expect(status.activeSessions).toBe(0);
+		});
+
+		it("surfaces OpenCode scan errors so the UI can warn instead of silently showing 0 sessions", async () => {
+			const { isOpenCodeInstalled, scanOpenCodeSessions } = await import("../core/OpenCodeSessionDiscoverer.js");
+			vi.mocked(isOpenCodeInstalled).mockResolvedValueOnce(true);
+			vi.mocked(scanOpenCodeSessions).mockResolvedValueOnce({
+				sessions: [],
+				error: { kind: "corrupt", message: "SQLITE_CORRUPT: disk image is malformed" },
+			});
+
+			const status = await getStatus(tempDir);
+
+			expect(status.activeSessions).toBe(0);
+			expect(status.openCodeScanError).toEqual({
+				kind: "corrupt",
+				message: "SQLITE_CORRUPT: disk image is malformed",
+			});
+		});
+
+		it("should count legacy sessions without a source as Claude sessions", async () => {
 			const sessionsDir = join(tempDir, ".jolli", "jollimemory");
 			await mkdir(sessionsDir, { recursive: true });
-			const olderDate = "2025-01-01T00:00:00.000Z";
-			const newerDate = "2025-06-01T00:00:00.000Z";
+			await writeFile(
+				join(sessionsDir, "sessions.json"),
+				JSON.stringify({
+					sessions: {
+						legacy: {
+							sessionId: "legacy",
+							transcriptPath: "/legacy",
+							updatedAt: new Date().toISOString(),
+						},
+					},
+				}),
+				"utf-8",
+			);
+
+			const status = await getStatus(tempDir);
+			expect(status.sessionsBySource.claude).toBe(1);
+		});
+
+		it("should compute mostRecentSession via reduce when multiple enabled sessions exist", async () => {
+			// Write multiple Claude sessions with different timestamps (must be within 48h to avoid pruning)
+			const sessionsDir = join(tempDir, ".jolli", "jollimemory");
+			await mkdir(sessionsDir, { recursive: true });
+			const olderDate = new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString();
+			const newerDate = new Date(Date.now() - 1 * 60 * 60 * 1000).toISOString();
 			await writeFile(
 				join(sessionsDir, "sessions.json"),
 				JSON.stringify({
@@ -2027,6 +2289,20 @@ describe("Installer", () => {
 			} finally {
 				await chmod(settingsPath, 0o755);
 			}
+		});
+	});
+
+	describe("installResolveScript — failure path", () => {
+		it("should return failure when resolve-dist-path script cannot be written", async () => {
+			// Set homedir to an invalid path so mkdir fails inside installResolveScript
+			mockHomedir.mockReturnValue("/dev/null/impossible-path");
+
+			const result = await install(tempDir);
+			expect(result.success).toBe(false);
+			expect(result.message).toContain("resolve-dist-path");
+
+			// Restore for other tests
+			mockHomedir.mockReturnValue(fakeHomeDir);
 		});
 	});
 

--- a/cli/src/install/Installer.ts
+++ b/cli/src/install/Installer.ts
@@ -22,6 +22,11 @@ import { discoverCodexSessions, isCodexInstalled } from "../core/CodexSessionDis
 import { isGeminiInstalled } from "../core/GeminiSessionDetector.js";
 import { getProjectRootDir, listWorktrees, orphanBranchExists } from "../core/GitOps.js";
 import {
+	isOpenCodeInstalled,
+	type OpenCodeScanError,
+	scanOpenCodeSessions,
+} from "../core/OpenCodeSessionDiscoverer.js";
+import {
 	ensureJolliMemoryDir,
 	filterSessionsByEnabledIntegrations,
 	getGlobalConfigDir,
@@ -33,7 +38,7 @@ import {
 } from "../core/SessionTracker.js";
 import { getSummaryCount } from "../core/SummaryStore.js";
 import { createLogger, getJolliMemoryDir, ORPHAN_BRANCH } from "../Logger.js";
-import type { InstallResult, JolliMemoryConfig, SessionInfo, StatusInfo } from "../Types.js";
+import type { InstallResult, JolliMemoryConfig, SessionInfo, StatusInfo, TranscriptSource } from "../Types.js";
 import {
 	installClaudeHook,
 	installSessionStartHook,
@@ -238,6 +243,15 @@ export async function install(cwd?: string, options?: { source?: "vscode-extensi
 			if (config.geminiEnabled === undefined) {
 				await saveConfig({ geminiEnabled: true });
 				log.info("Gemini CLI detected — enabled Gemini session tracking");
+			}
+		}
+
+		// Auto-detect OpenCode and enable session discovery
+		const openCodeDetected = config.openCodeEnabled !== false && (await isOpenCodeInstalled());
+		if (openCodeDetected) {
+			if (config.openCodeEnabled === undefined) {
+				await saveConfig({ openCodeEnabled: true });
+				log.info("OpenCode detected — enabled OpenCode session discovery");
 			}
 		}
 
@@ -455,6 +469,7 @@ export async function getStatus(cwd?: string): Promise<StatusInfo> {
 	const claudeDetected = await isClaudeInstalled();
 	const codexDetected = await isCodexInstalled();
 	const geminiDetected = await isGeminiInstalled();
+	const openCodeDetected = await isOpenCodeInstalled();
 
 	// Check if we can enumerate worktrees; falls back gracefully if not a git repo
 	let enabledWorktrees: number | undefined;
@@ -482,6 +497,25 @@ export async function getStatus(cwd?: string): Promise<StatusInfo> {
 		if (codexSessions.length > 0) {
 			allEnabledSessions = [...enabledSessions, ...codexSessions];
 		}
+	}
+
+	// Discover OpenCode sessions on-demand (not stored in sessions.json).
+	// Use scanOpenCodeSessions so we can surface real scan failures (corrupt DB,
+	// schema drift, permission denied) rather than silently showing "0 sessions".
+	let openCodeScanError: OpenCodeScanError | undefined;
+	if (config.openCodeEnabled !== false && openCodeDetected) {
+		const scan = await scanOpenCodeSessions(projectDir);
+		if (scan.sessions.length > 0) {
+			allEnabledSessions = [...allEnabledSessions, ...scan.sessions];
+		}
+		openCodeScanError = scan.error;
+	}
+
+	// Compute per-source session counts for integration status rows
+	const sessionsBySource: Partial<Record<TranscriptSource, number>> = {};
+	for (const s of allEnabledSessions) {
+		const src = s.source ?? "claude";
+		sessionsBySource[src] = (sessionsBySource[src] ?? 0) + 1;
 	}
 
 	const filteredMostRecent =
@@ -546,16 +580,20 @@ export async function getStatus(cwd?: string): Promise<StatusInfo> {
 		codexEnabled: config.codexEnabled,
 		geminiDetected,
 		geminiEnabled: config.geminiEnabled,
+		openCodeDetected,
+		openCodeEnabled: config.openCodeEnabled,
 		globalConfigDir,
 		worktreeStatePath,
 		enabledWorktrees,
 		hookSource: activeSource?.source,
 		hookVersion: activeSource?.version,
 		allSources,
+		sessionsBySource,
+		openCodeScanError,
 	};
 
 	log.info(
-		"Status: enabled=%s, claude=%s, git=%s, geminiHook=%s, worktreeHooks=%s, sessions=%d, summaries=%d, codex=%s/%s, gemini=%s/%s, enabledWorktrees=%s",
+		"Status: enabled=%s, claude=%s, git=%s, geminiHook=%s, worktreeHooks=%s, sessions=%d, summaries=%d, codex=%s/%s, gemini=%s/%s, enabledWorktrees=%s, opencode=%s/%s",
 		status.enabled,
 		status.claudeHookInstalled,
 		status.gitHookInstalled,
@@ -568,6 +606,8 @@ export async function getStatus(cwd?: string): Promise<StatusInfo> {
 		status.geminiDetected,
 		status.geminiEnabled,
 		status.enabledWorktrees,
+		status.openCodeDetected,
+		status.openCodeEnabled,
 	);
 
 	return status;

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
 			},
 			"devDependencies": {
 				"@biomejs/biome": "2.2.6",
-				"@types/node": "^20.0.0",
+				"@types/node": "^22.5.0",
 				"@vitest/coverage-v8": "^4.1.1",
 				"rimraf": "^6.0.1",
 				"tsx": "^4.7.0",
@@ -37,7 +37,7 @@
 				"vitest": "^4.1.1"
 			},
 			"engines": {
-				"node": ">=18.0.0"
+				"node": ">=22.5.0"
 			}
 		},
 		"node_modules/@anthropic-ai/sdk": {
@@ -1712,9 +1712,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/node": {
-			"version": "20.19.39",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
-			"integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
+			"version": "22.19.17",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
+			"integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
 			"license": "MIT",
 			"dependencies": {
 				"undici-types": "~6.21.0"
@@ -6685,7 +6685,7 @@
 				"open": "^11.0.0"
 			},
 			"devDependencies": {
-				"@types/node": "^20.0.0",
+				"@types/node": "^22.5.0",
 				"@types/vscode": "^1.80.0",
 				"@vitest/coverage-v8": "^4.1.2",
 				"@vscode/vsce": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,6 @@
 	},
 	"homepage": "https://github.com/jolliai/jollimemory",
 	"bugs": {
-		"url": "https://github.com/jolliai/jolli/issues"
+		"url": "https://github.com/jolliai/jollimemory/issues"
 	}
 }

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Changelog
 
-<!-- Last synced commit: ff796b6a5 | 2026-04-13 -->
+<!-- Last synced commit: ea9ad050b | 2026-04-23 -->
 
 ## 0.98.0
 
+- **OpenCode integration** — the sidebar STATUS panel now tracks [OpenCode](https://opencode.ai) sessions alongside Claude, Codex, and Gemini. Sessions are discovered automatically at commit time by reading OpenCode's global SQLite database; no hook installation required. Requires a host VS Code whose bundled Node is 22.5 or newer (VS Code ~1.99+); on older hosts OpenCode is quietly skipped while every other feature continues to work.
 - **Sign in with Jolli** — one-click browser-based OAuth sign-in / sign-out from the sidebar STATUS panel, bringing the unified Jolli account flow (shared with the new `jolli auth` CLI commands) into the extension — no more copy-pasting API keys to get started
 - **Push to local folder** — new Local Memories section in Settings saves memory Markdown files to a folder you pick; choose "Push to Jolli only" or "Push to Jolli & Local" as the default Push action
 - **Live Plans panel** — plans refresh automatically as they're added, updated, or completed — no reload needed

--- a/vscode/README.md
+++ b/vscode/README.md
@@ -4,7 +4,34 @@
 
 **Jolli Memory** automatically turns your AI coding sessions into structured development documentation attached to every commit, without any extra effort.
 
-When you work with AI agents like Claude Code, Codex, or Gemini CLI, the reasoning behind every decision lives in the conversation: *why this approach was chosen, what alternatives were considered, what problems came up along the way*. The moment you commit, that context is gone. Jolli Memory captures it automatically.
+When you work with AI agents like Claude Code, Codex, Gemini CLI, or OpenCode, the reasoning behind every decision lives in the conversation: *why this approach was chosen, what alternatives were considered, what problems came up along the way*. The moment you commit, that context is gone. Jolli Memory captures it automatically.
+
+---
+
+## Installation
+
+Install from the VS Code Marketplace:
+
+```bash
+code --install-extension jolli.jollimemory-vscode
+```
+
+Or search for **Jolli Memory** in the Extensions sidebar (`⌘⇧X` / `Ctrl+Shift+X`) and click **Install**.
+
+### Requirements
+
+- **VS Code 1.80 or newer** for core features.
+- **VS Code ~1.99+ (bundled Node 22.5+)** only if you want **OpenCode** session discovery. On older hosts the extension runs normally — OpenCode is quietly skipped while every other integration works.
+- **GitHub CLI (`gh`)** only for **Create & Update PR**; every other feature works without it.
+- An **Anthropic API key** *or* a **Jolli account** (via **Sign In to Jolli**) for summary generation — see [Sign In to Jolli](#sign-in-to-jolli) below.
+
+### First run
+
+1. Click the Jolli icon in the activity bar to open the sidebar.
+2. In the **Status** panel, either click **Sign In to Jolli** (OAuth) or open the **Settings** gear icon and paste an Anthropic API key.
+3. Click `(⊘)` in the Status panel to install git hooks in the current repository.
+4. Restart any active AI agent session (Claude Code / Codex / Gemini / OpenCode) so hooks take effect.
+5. Make a commit as usual — the summary appears in the **Commits** panel within ~10-20 seconds.
 
 ---
 
@@ -16,7 +43,7 @@ After each commit, Jolli Memory reads your selected AI session transcripts and t
 
 | Panel | What it shows |
 | -- | -- |
-| **Status** | Whether Jolli Memory is enabled, active AI agent sessions (Claude, Codex, Gemini), and how many memories are stored. Toggle on/off with the `(●)` / `(⊘)` buttons. |
+| **Status** | Whether Jolli Memory is enabled, active AI agent sessions (Claude, Codex, Gemini, OpenCode), and how many memories are stored. Toggle Jolli Memory on/off with the `(●)` / `(⊘)` buttons; sign in or out of your Jolli account via the **Sign In to Jolli** / **Sign Out of Jolli** actions in the same panel toolbar. |
 | **Memories** | Every stored memory across all branches, with instant search and filter. Click `(🔍)` in the panel title bar to filter by keyword, or click the **Load More** item at the bottom of the list to fetch older entries. |
 | **Plans & Notes** | Plans auto-detected from Claude Code sessions, plus your own notes (text snippets or imported Markdown files). Edit, remove, or associate items with commits. Use the **+ Add** dropdown to add a plan, a Markdown file, or a quick text snippet. |
 | **Changes** | All changed files with checkboxes to stage or unstage. Supports an exclude filter for hiding irrelevant files. |
@@ -37,6 +64,7 @@ When you use an AI coding agent, Jolli Memory keeps track of your active session
 | **Claude Code** | A lightweight `StopHook` fires after each AI response; a `SessionStartHook` injects a mini-briefing at session start |
 | **Gemini CLI** | An `AfterAgent` hook fires after each agent completion |
 | **Codex CLI** | No hook needed — sessions are discovered automatically by scanning the filesystem |
+| **OpenCode** | No hook needed — sessions are discovered automatically by reading OpenCode's global SQLite database (requires a host VS Code with Node 22.5+) |
 
 ### Git Hooks — generating summaries on commit
 
@@ -47,6 +75,8 @@ When you run `git commit`, three standard git hooks handle the rest:
 3. **After rebase/amend**: migrates existing summaries to match the new commit hashes, so nothing is lost
 
 Everything is stored in a git orphan branch (`jollimemory/summaries/v3`), completely separate from your code history. Raw AI conversations are optionally preserved alongside the summaries and can be viewed, edited, or deleted from the extension.
+
+**Worktree-aware:** switching branches (including across `git worktree` checkouts) refreshes every sidebar panel automatically — the current branch and its memories stay accurate regardless of which worktree you're in.
 
 ---
 
@@ -83,7 +113,7 @@ Click **👁** on any commit to open a full memory panel. It shows:
 Action buttons:
 
 * **Copy Markdown**: copies the full summary to clipboard
-* **Push to Jolli**: publishes the summary (and associated plans and notes) to your Jolli Space
+* **Push to Jolli** / **Push to Jolli & Local**: publishes the summary (and associated plans and notes) to your Jolli Space. The **& Local** variant additionally saves a Markdown copy to the folder configured in **Settings → Local Memories**. Pick the default mode from that same Settings section.
 * **Create & Update PR**: manages a GitHub PR for this commit
 
 ### Push to Jolli Space
@@ -93,6 +123,20 @@ Click **Push to Jolli** to publish the summary to your team's Jolli Space know
 Plans and notes (both Markdown files and text snippets) are each uploaded as separate articles first, so their URLs appear in the summary. The summary itself is published last. 
 
 Requires a Jolli API Key configured in the **Status** panel settings. Please contact support@jolli.ai with your name and email address.
+
+### Local Memories
+
+As an alternative — or a complement — to Jolli Space, you can save every pushed memory as a Markdown file on your own machine. Useful for archiving, syncing via Dropbox/Drive, or keeping an offline record.
+
+**Configure** (Settings → **Local Memories**):
+
+1. Click **Browse…** to choose a target folder — stored as the `localFolder` config.
+2. Under **Default Push Action**, pick one:
+   * **Push to Jolli only** (default) — the Push button publishes to your Jolli Space.
+   * **Push to Jolli & Local** — the Push button publishes to Jolli Space **and** writes a Markdown copy to the folder above.
+3. The **Push to Jolli & Local** option is disabled until a local folder is selected.
+
+Once configured, the Summary Webview's Push button label reflects the chosen mode.
 
 ### Plans & Notes
 
@@ -116,6 +160,70 @@ From the Summary Webview, you can:
 * **Associate** additional plans or notes with a commit
 
 Text snippets display their content inline in the Summary Webview; Markdown notes show the filename.
+
+### Memories Panel
+
+The **Memories** panel lists every stored memory across all branches of this repository. Toolbar actions:
+
+| Action | Icon | What it does |
+| -- | -- | -- |
+| **Search Memories** | `(🔍)` | Filter memories by keyword; click **Clear Filter** `(✕)` to reset |
+| **Refresh Memories** | `(⟳)` | Re-read the orphan branch |
+| **Export Memories to Markdown** | `(↗)` | Write every memory on the current branch as `.md` files to `~/Documents/jollimemory/` |
+| **Open Settings** | `(⚙)` | Open the Settings panel (see below) |
+| **Enable / Disable Jolli Memory** | `(●)` / `(⊘)` | Install or remove hooks |
+
+**Load More** at the bottom of the list fetches older entries on long branches.
+
+**Per-memory context menu** (right-click any memory):
+
+* **Copy Recall Prompt** — copies a prompt string designed to be pasted into your AI agent so it can recall that memory's context.
+* **Open in Claude Code** — launches Claude Code with the recall prompt pre-loaded (requires Claude Code installed).
+* **View Memory** — opens the full Summary Webview.
+
+### Sign In to Jolli
+
+From the **Status** panel toolbar, click **Sign In to Jolli** to authenticate with a Jolli account via browser OAuth:
+
+1. VS Code opens your default browser at the Jolli sign-in page.
+2. After you sign in (or sign up), the browser tab closes automatically.
+3. The extension receives an OAuth `authToken` and a `jolliApiKey` (`sk-jol-…`) and writes them to `~/.jolli/jollimemory/config.json`.
+
+The `jolliApiKey` serves two purposes: it lets the LLM proxy handle summary generation (so you don't need to manage an Anthropic key directly), and it authorises pushing summaries to your Jolli Space. You can still set a manual Anthropic `apiKey` in Settings if you prefer your own account.
+
+Click **Sign Out of Jolli** from the same toolbar to clear the stored credentials.
+
+### Settings Panel
+
+Click the gear icon `(⚙)` in the Memories panel toolbar (or any **Open Settings** action) to open a dedicated Settings webview with grouped sections:
+
+* **Authentication** — Anthropic `apiKey`, `model`, `maxTokens`, `jolliApiKey`
+* **Integrations** — toggles for Claude / Codex / Gemini / OpenCode session tracking
+* **Local Memories** — `localFolder` + default `pushAction` (see above)
+* **Files** — `excludePatterns` for the Changes panel
+
+Changes are validated on save and persisted to `~/.jolli/jollimemory/config.json`.
+
+### Changes Panel
+
+The **Changes** panel mirrors VS Code's Source Control view with a few extras:
+
+* **Select / Deselect All** `(✓)` — stage or unstage everything visible in one click.
+* **AI Commit** `(✦)` — generate a commit message from the staged diff (see above).
+* **Discard Changes** (right-click a file) — reverts unstaged changes for one file.
+* **Discard Selected Changes** (toolbar) — reverts unstaged changes for every checked file after a confirmation prompt.
+* **Exclude filter** — files matching the `excludePatterns` globs (configured in Settings) are hidden and auto-unstaged if they were previously staged.
+
+### Commits Panel
+
+The **Commits** panel lists every commit on the current branch that isn't yet in main. Click `(👁)` on any commit to open its Summary Webview.
+
+* **Select / Deselect All** `(✓)` — choose which commits to squash.
+* **Squash** `(⊞)` — merges selected commits with an LLM-generated message (see above).
+* **Push** `(↑)` — appears when only a single commit is selected or the branch has one commit ahead of its upstream; see Push above.
+* **Copy Commit Hash** (right-click) — yanks the full SHA.
+
+Once your branch is merged into main, the panel switches to a **merged (read-only) mode** — summaries remain accessible for review while squash/push actions are hidden.
 
 ### Create & Update PR
 
@@ -141,11 +249,85 @@ If the current branch has no memories, the command shows a catalog of branches t
 
 ## Configuration
 
-All settings can be configured directly from the **Status** panel in the sidebar, no need to edit files manually. They are stored globally in `~/.jolli/jollimemory/config.json` and shared across every project on your machine:
+Most settings can be configured directly from the **Status** panel in the sidebar — `authToken` is written automatically by the **Sign In to Jolli** action on the Status panel toolbar, and `logLevel` is editable via the `jolli configure` CLI. All settings are stored globally in `~/.jolli/jollimemory/config.json` and shared across every project on your machine:
 
 | Field | Type | Default | Description |
 | -- | -- | -- | -- |
 | `apiKey` | string | `$ANTHROPIC_API_KEY` | Your Anthropic API key for AI summarization (generate one at [platform.anthropic.com](https://platform.claude.com/)) |
-| `model` | string | `claude-haiku-4-5-20251001` | Model used for summarization |
+| `model` | string | `claude-haiku-4-5-20251001` | Model used for summarization. Accepts an alias (`sonnet`, `haiku`) or a full model ID. |
+| `maxTokens` | integer | model default | Max output tokens per summarization call |
 | `jolliApiKey` | string | — | Jolli Space API key for pushing summaries to your team knowledge base |
+| `authToken` | string | — | OAuth token set automatically by **Sign In to Jolli** — not edited manually |
+| `logLevel` | enum | `info` | Verbosity of `debug.log`: `debug`, `info`, `warn`, `error` (set via `jolli configure` CLI) |
+| `claudeEnabled` | boolean | auto-detect | Enable Claude Code session tracking |
+| `codexEnabled` | boolean | auto-detect | Enable Codex CLI session discovery |
+| `geminiEnabled` | boolean | auto-detect | Enable Gemini CLI session tracking |
+| `openCodeEnabled` | boolean | auto-detect | Enable OpenCode session discovery (requires a host VS Code with Node 22.5+) |
+| `localFolder` | string | — | Absolute path where **Push to Jolli & Local** writes Markdown copies of pushed summaries |
+| `pushAction` | enum | `jolli` | Default Push action: `jolli` (Jolli Space only) or `both` (Jolli Space + local folder) |
 | `excludePatterns` | string[] | — | Glob patterns for hiding files from the Changes panel |
+
+---
+
+## Summary Format
+
+Each memory uses a **v3 tree structure**: a single commit can cover multiple independent topics, and commits related through amend/squash operations form parent-child trees.
+
+```json
+{
+  "version": 3,
+  "commitHash": "abc123...",
+  "commitMessage": "Fix login validation and add rate limiting",
+  "branch": "feature/login-fix",
+  "commitType": "commit",
+  "topics": [
+    {
+      "title": "Fix login email validation",
+      "category": "bugfix",
+      "importance": "major",
+      "trigger": "Users were able to submit malformed emails, causing server-side 500 errors.",
+      "response": "Added email format check in LoginForm component with RFC 5322 regex.",
+      "decisions": "| Option | Pros | Cons | Chosen |\n|---|---|---|---|\n| Regex | No dependency | Complex pattern | yes |\n| Library | Robust | Extra dependency | |",
+      "todo": "Consider adding disposable email detection in a follow-up."
+    }
+  ],
+  "children": []
+}
+```
+
+**Topic fields**: `trigger` (what prompted the work), `response` (what was built), `decisions` (design rationale — may include Markdown tables), `todo` (optional follow-up), `category` (one of `feature`, `bugfix`, `refactor`, `tech-debt`, `performance`, `security`, `test`, `docs`, `ux`, `devops`), `importance` (`major` or `minor`).
+
+For CLI export usage (`jolli export`) and programmatic consumption, see the [`@jolli/cli` README](https://github.com/jolliai/jollimemory/tree/main/cli#summary-format).
+
+## Privacy
+
+### At summary generation time (after each commit)
+
+To produce a summary, Jolli Memory reads your active AI session transcripts and the git diff locally, then sends them together to a summarization backend:
+
+* If an **Anthropic `apiKey`** is configured — transcripts + diff are sent **directly to Anthropic**.
+* If only a **`jolliApiKey`** is configured (you signed in with **Sign In to Jolli**) — transcripts + diff are sent to the **Jolli LLM proxy**, which forwards them to Anthropic on your behalf. The proxy **does not persist the transcripts or diff, and does not write them to any Jolli-side log** — payloads are held in memory only for the duration of the request and discarded once Anthropic responds.
+
+The generated summary is then written to the git orphan branch locally, and the raw transcripts are preserved alongside it so you can review them later in the Summary Webview's **All Conversations** section.
+
+### At Push to Jolli time (only when you click Push)
+
+Only the **generated summary** (Markdown + properties) and any **associated plans and notes** are uploaded to your Jolli Space. **Raw transcripts are never sent to Jolli Space** — they stay local.
+
+### Session metadata
+
+Session IDs, transcript file paths, and timestamps are stored locally in `~/.jolli/jollimemory/`. Never uploaded anywhere.
+
+### What stays 100% local
+
+Every file under `~/.jolli/jollimemory/`, every entry on the `jollimemory/summaries/v3` orphan branch, and every raw transcript fragment shown in **All Conversations** — all of it is read-only on your disk unless the specific actions above are triggered.
+
+## Support
+
+* **Issues & feature requests** — [GitHub Issues](https://github.com/jolliai/jollimemory/issues)
+* **Jolli Space onboarding / enterprise** — support@jolli.ai
+* **CLI reference & troubleshooting** — see the [`@jolli/cli` README](https://github.com/jolliai/jollimemory/tree/main/cli)
+
+## License
+
+[Apache License 2.0](https://github.com/jolliai/jollimemory/blob/main/LICENSE)

--- a/vscode/esbuild.config.mjs
+++ b/vscode/esbuild.config.mjs
@@ -29,6 +29,9 @@ const base = {
 	bundle: true,
 	platform: "node",
 	format: "cjs",
+	// Target the Node bundled with the oldest supported VS Code (Electron 25 / Node 18).
+	// node:sqlite (Node 22.5+) is lazy-imported and gated by hasNodeSqliteSupport(), so
+	// this bundle loads fine on older hosts — OpenCode scanning just stays disabled.
 	target: "node18",
 	sourcemap: true,
 	minify: true,

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -553,7 +553,7 @@
 		"brace-expansion": "^5.0.5"
 	},
 	"devDependencies": {
-		"@types/node": "^20.0.0",
+		"@types/node": "^22.5.0",
 		"@types/vscode": "^1.80.0",
 		"@vitest/coverage-v8": "^4.1.2",
 		"@vscode/vsce": "^3.0.0",

--- a/vscode/src/Extension.test.ts
+++ b/vscode/src/Extension.test.ts
@@ -59,8 +59,8 @@ const {
 } = vi.hoisted(() => ({
 	indexNeedsMigration: vi.fn(),
 	migrateIndexToV3: vi.fn(),
-	readPlanFromBranch: vi.fn(),
 	readNoteFromBranch: vi.fn(),
+	readPlanFromBranch: vi.fn(),
 }));
 
 const {
@@ -472,8 +472,8 @@ vi.mock("../../cli/src/core/SummaryMigration.js", () => ({
 vi.mock("../../cli/src/core/SummaryStore.js", () => ({
 	indexNeedsMigration,
 	migrateIndexToV3,
-	readPlanFromBranch,
 	readNoteFromBranch,
+	readPlanFromBranch,
 }));
 
 vi.mock("../../cli/src/Logger.js", () => ({
@@ -828,6 +828,48 @@ describe("Extension", () => {
 			expect(showWarningMessage).not.toHaveBeenCalled();
 			expect(registerCommand).toHaveBeenCalled();
 			expect(MockJolliMemoryBridge).toHaveBeenCalledWith("/test/workspace");
+		});
+	});
+
+	describe("activate — resolveGitPath failure (git-less workspace)", () => {
+		it("warns but keeps activating when rev-parse --git-path fails", () => {
+			// Throw for all resolveGitPath queries → both HEAD and orphan-ref watchers
+			// skip creation, hitting the `else` branches that log auto-refresh-disabled warnings.
+			execSync.mockImplementation(() => {
+				throw new Error("not a git repo");
+			});
+			const ctx = makeContext();
+
+			activate(ctx);
+
+			const warnCalls = warn.mock.calls.map((c) => c.join(" "));
+			expect(
+				warnCalls.some((s) => s.includes("Could not resolve git HEAD path")),
+			).toBe(true);
+			expect(
+				warnCalls.some((s) => s.includes("Could not resolve orphan ref path")),
+			).toBe(true);
+			// Activation still registers commands
+			expect(registerCommand).toHaveBeenCalled();
+		});
+
+		it("resolves non-absolute git-paths against cwd", () => {
+			// Returns a relative path → covers the `isAbsolute(out) ? out : resolve(cwd, out)` right branch.
+			execSync.mockImplementation((cmd: string) => {
+				if (cmd.includes("rev-parse --git-path HEAD")) {
+					return Buffer.from(".git/HEAD\n");
+				}
+				if (cmd.includes("rev-parse --git-path refs/heads/")) {
+					return Buffer.from(".git/refs/heads/__jolli_orphan_branch__\n");
+				}
+				throw new Error(`Unmocked exec: ${cmd}`);
+			});
+			const ctx = makeContext();
+
+			activate(ctx);
+
+			// Activation should succeed even with relative git paths
+			expect(registerCommand).toHaveBeenCalled();
 		});
 	});
 
@@ -1446,6 +1488,81 @@ describe("Extension", () => {
 				await handler();
 
 				expect(MockNoteEditorWebviewPanel.show).toHaveBeenCalled();
+			});
+
+			it("invokes the refresh callback passed to NoteEditorWebviewPanel.show", async () => {
+				// Capture the onSaved callback and invoke it so the lambda body (which
+				// calls plansStore.refresh()) is actually executed — otherwise that
+				// arrow function reports as never called in coverage.
+				let savedCb: (() => unknown) | undefined;
+				MockNoteEditorWebviewPanel.show.mockImplementation(
+					(_uri: unknown, _bridge: unknown, cb: () => unknown) => {
+						savedCb = cb;
+					},
+				);
+
+				const handler = getRegisteredCommand("jollimemory.addTextSnippet");
+				await handler();
+
+				expect(savedCb).toBeDefined();
+				mockPlansStore.refresh.mockClear();
+				savedCb?.();
+				expect(mockPlansStore.refresh).toHaveBeenCalled();
+			});
+		});
+
+		describe("previewNote", () => {
+			it("opens markdown preview when note content is found", async () => {
+				readNoteFromBranch.mockResolvedValue("# My Note\nContent here");
+				const handler = getRegisteredCommand("jollimemory.previewNote");
+
+				await handler("note-1", "My Note");
+
+				expect(readNoteFromBranch).toHaveBeenCalledWith(
+					"note-1",
+					"/test/workspace",
+				);
+				expect(openTextDocument).toHaveBeenCalled();
+				expect(executeCommand).toHaveBeenCalledWith(
+					"markdown.showPreview",
+					expect.anything(),
+				);
+			});
+
+			it("shows error when note content is null", async () => {
+				readNoteFromBranch.mockResolvedValue(null);
+				const handler = getRegisteredCommand("jollimemory.previewNote");
+
+				await handler("note-1", "My Note");
+
+				expect(showErrorMessage).toHaveBeenCalledWith(
+					expect.stringContaining("Could not read note"),
+				);
+				expect(openTextDocument).not.toHaveBeenCalled();
+			});
+
+			it("provides cached content for note preview virtual documents", async () => {
+				readNoteFromBranch.mockResolvedValue("# Note content");
+				const handler = getRegisteredCommand("jollimemory.previewNote");
+				await handler("note-1", "My Note");
+
+				// Note content provider is the second registered provider (index 1)
+				const provider = registerTextDocumentContentProvider.mock
+					.calls[1]?.[1] as
+					| {
+							provideTextDocumentContent: (uri: { query: string }) => string;
+					  }
+					| undefined;
+				expect(provider).toBeDefined();
+				expect(
+					provider?.provideTextDocumentContent({ query: "id=note-1" }),
+				).toBe("# Note content");
+				expect(
+					provider?.provideTextDocumentContent({ query: "id=missing" }),
+				).toBe("# Note not found");
+				expect(provider?.provideTextDocumentContent({ query: "" })).toBe(
+					"# Note not found",
+				);
 			});
 		});
 
@@ -2683,6 +2800,19 @@ describe("Extension", () => {
 			vi.useRealTimers();
 		});
 
+		it("skips markdown files inside the notes dir (handled by file watcher)", async () => {
+			const saveCallback = onDidSaveTextDocument.mock.calls[0]?.[0] as
+				| ((doc: { fileName: string }) => Promise<void>)
+				| undefined;
+			mockBridge.listNotes.mockClear();
+
+			await saveCallback?.({
+				fileName: "/test/workspace/.jolli/jollimemory/notes/my-note.md",
+			});
+
+			expect(mockBridge.listNotes).not.toHaveBeenCalled();
+		});
+
 		it("skips non-markdown file saves without calling listNotes", async () => {
 			const saveCallback = onDidSaveTextDocument.mock.calls[0]?.[0] as
 				| ((doc: { fileName: string }) => Promise<void>)
@@ -3518,6 +3648,88 @@ describe("Extension", () => {
 			);
 			expect(mockFilesStore.refresh).toHaveBeenCalledWith(true);
 		});
+
+		it("shows overflow indicator when more than 10 files are selected", async () => {
+			const selectedFiles = Array.from({ length: 12 }, (_, i) => ({
+				absolutePath: `/repo/file${i}.ts`,
+				relativePath: `file${i}.ts`,
+				statusCode: "M" as const,
+				indexStatus: " " as const,
+				worktreeStatus: "M" as const,
+				isSelected: true,
+			}));
+			mockFilesStore.getSnapshot.mockReturnValue({
+				selectedFiles,
+				files: selectedFiles,
+				visibleFiles: selectedFiles,
+				excludedCount: 0,
+				visibleCount: selectedFiles.length,
+				isEmpty: false,
+				isEnabled: true,
+				isMigrating: false,
+				changeReason: "refresh",
+			});
+			showWarningMessage.mockResolvedValue("Discard All");
+			const ctx = makeContext();
+			activate(ctx);
+			const handler = getRegisteredCommand(
+				"jollimemory.discardSelectedChanges",
+			);
+
+			await handler();
+
+			expect(showWarningMessage).toHaveBeenCalledWith(
+				expect.stringContaining("12 selected files"),
+				expect.objectContaining({
+					modal: true,
+					detail: expect.stringContaining("...and 2 more"),
+				}),
+				"Discard All",
+			);
+		});
+
+		it("uses singular form for single selected file and single deleted file", async () => {
+			const selectedFiles = [
+				{
+					absolutePath: "/repo/new.ts",
+					relativePath: "new.ts",
+					statusCode: "?" as const,
+					indexStatus: "?" as const,
+					worktreeStatus: "?" as const,
+					isSelected: true,
+				},
+			];
+			mockFilesStore.getSnapshot.mockReturnValue({
+				selectedFiles,
+				files: selectedFiles,
+				visibleFiles: selectedFiles,
+				excludedCount: 0,
+				visibleCount: selectedFiles.length,
+				isEmpty: false,
+				isEnabled: true,
+				isMigrating: false,
+				changeReason: "refresh",
+			});
+			showWarningMessage.mockResolvedValue("Discard All");
+			const ctx = makeContext();
+			activate(ctx);
+			const handler = getRegisteredCommand(
+				"jollimemory.discardSelectedChanges",
+			);
+
+			await handler();
+
+			expect(showWarningMessage).toHaveBeenCalledWith(
+				// singular "file" (not "files")
+				expect.stringContaining("1 selected file?"),
+				expect.objectContaining({
+					modal: true,
+					// singular "file" in delete warning
+					detail: expect.stringContaining("1 file will be permanently deleted"),
+				}),
+				"Discard All",
+			);
+		});
 	});
 
 	// ── hook path refresh error ──────────────────────────────────────
@@ -3537,6 +3749,61 @@ describe("Extension", () => {
 			await vi.waitFor(() => {
 				expect(mockBridge.autoInstallForWorktree).toHaveBeenCalled();
 			});
+		});
+
+		it("skips auto-install when worktree hooks are already installed", async () => {
+			mockBridge.getStatus.mockResolvedValue({
+				enabled: true,
+				gitHookInstalled: true,
+				worktreeHooksInstalled: true,
+				enabledWorktrees: 2,
+			});
+			mockBridge.autoInstallForWorktree.mockClear();
+
+			const ctx = makeContext();
+			activate(ctx);
+
+			// Wait for the async refresh chain to complete
+			await vi.waitFor(() => {
+				expect(mockStatusStore.refresh).toHaveBeenCalled();
+			});
+			expect(mockBridge.autoInstallForWorktree).not.toHaveBeenCalled();
+		});
+
+		it("skips auto-install when enabledWorktrees is 0", async () => {
+			mockBridge.getStatus.mockResolvedValue({
+				enabled: true,
+				gitHookInstalled: true,
+				worktreeHooksInstalled: false,
+				enabledWorktrees: 0,
+			});
+			mockBridge.autoInstallForWorktree.mockClear();
+
+			const ctx = makeContext();
+			activate(ctx);
+
+			await vi.waitFor(() => {
+				expect(mockStatusStore.refresh).toHaveBeenCalled();
+			});
+			expect(mockBridge.autoInstallForWorktree).not.toHaveBeenCalled();
+		});
+
+		it("skips auto-install when enabledWorktrees is undefined", async () => {
+			mockBridge.getStatus.mockResolvedValue({
+				enabled: true,
+				gitHookInstalled: true,
+				worktreeHooksInstalled: false,
+				enabledWorktrees: undefined,
+			});
+			mockBridge.autoInstallForWorktree.mockClear();
+
+			const ctx = makeContext();
+			activate(ctx);
+
+			await vi.waitFor(() => {
+				expect(mockStatusStore.refresh).toHaveBeenCalled();
+			});
+			expect(mockBridge.autoInstallForWorktree).not.toHaveBeenCalled();
 		});
 
 		it("logs error when refreshHookPathsIfStale rejects", async () => {

--- a/vscode/src/Extension.ts
+++ b/vscode/src/Extension.ts
@@ -874,7 +874,9 @@ export function activate(context: vscode.ExtensionContext): void {
 						statusBar,
 					);
 				} catch (err: unknown) {
+					/* v8 ignore start -- defensive: VSCode API and provider helpers reject with Error; retained for unexpected non-Error throws */
 					const message = err instanceof Error ? err.message : String(err);
+					/* v8 ignore stop */
 					log.error(
 						"cmd",
 						`discardFileChanges failed for ${relativePath}: ${message}`,

--- a/vscode/src/JolliMemoryBridge.test.ts
+++ b/vscode/src/JolliMemoryBridge.test.ts
@@ -637,6 +637,40 @@ describe("JolliMemoryBridge", () => {
 				source: "vscode-extension",
 			});
 		});
+
+		it("detects legacy hooks via PostCommitHook keyword (not just StopHook)", async () => {
+			existsSync.mockImplementation((p: string) =>
+				String(p).includes("settings.local.json"),
+			);
+			readFileSync.mockReturnValue(
+				'{"hooks":{"PostCommit":[{"command":"node /old/PostCommitHook.js"}]}}',
+			);
+			installerGetStatus.mockResolvedValue({});
+			const bridge = makeBridge();
+
+			await bridge.refreshHookPathsIfStale("/ext/v2.0.0");
+
+			expect(installerInstall).toHaveBeenCalledWith(TEST_CWD, {
+				source: "vscode-extension",
+			});
+		});
+
+		it("triggers re-install during legacy migration when scope is not present", async () => {
+			existsSync.mockImplementation((p: string) =>
+				String(p).includes("settings.local.json"),
+			);
+			readFileSync.mockReturnValue(
+				'{"hooks":{"Stop":[{"command":"node /old/path/StopHook.js"}]}}',
+			);
+			installerGetStatus.mockResolvedValue({});
+			const bridge = makeBridge();
+
+			await bridge.refreshHookPathsIfStale("/ext/v2.0.0");
+
+			expect(installerInstall).toHaveBeenCalledWith(TEST_CWD, {
+				source: "vscode-extension",
+			});
+		});
 	});
 
 	// ── getStatus ────────────────────────────────────────────────────────
@@ -1451,6 +1485,26 @@ describe("JolliMemoryBridge", () => {
 			await expect(
 				bridge.discardFiles([makeFileStatus("locked.ts", "?", "?")]),
 			).rejects.toThrow("EPERM");
+		});
+
+		it("handles rename without originalPath (unstages only new path, skips restore)", async () => {
+			mockExecFileSuccess(""); // git restore --staged -- new.ts (single path)
+			lstat.mockResolvedValue({ isDirectory: () => false });
+			unlink.mockResolvedValue(undefined);
+			const bridge = makeBridge();
+
+			await bridge.discardFiles([makeFileStatus("new.ts", "R", " ")]);
+
+			// Only the new path should be unstaged (no second path)
+			expect(execFileMock).toHaveBeenCalledWith(
+				"git",
+				["restore", "--staged", "--", "new.ts"],
+				{ cwd: TEST_CWD, encoding: "utf8" },
+				expect.any(Function),
+			);
+			// No separate restore for old path
+			expect(execFileMock).toHaveBeenCalledTimes(1);
+			expect(unlink).toHaveBeenCalledWith(`${TEST_CWD}/new.ts`);
 		});
 
 		it("batches mixed status types into grouped git calls", async () => {

--- a/vscode/src/JolliMemoryBridge.ts
+++ b/vscode/src/JolliMemoryBridge.ts
@@ -157,9 +157,11 @@ function hasUnmigratedHooks(content: string): boolean {
  */
 function normalizePathForCompare(p: string): string {
 	const unified = p.replace(/\\/g, "/").replace(/\/+$/, "");
+	/* v8 ignore start -- process.platform is fixed per test-runner host (macOS CI); covering the Linux branch would require a cross-platform matrix */
 	return process.platform === "win32" || process.platform === "darwin"
 		? unified.toLowerCase()
 		: unified;
+	/* v8 ignore stop */
 }
 
 // ─── JolliMemoryBridge class ─────────────────────────────────────────────────
@@ -274,8 +276,10 @@ export class JolliMemoryBridge {
 
 		// Always check across ALL sources for the highest version. If something
 		// higher is registered, surface a versionMismatch hint for the UI.
+		/* v8 ignore start -- compile-time ternary: always "dev" under vitest, always __PKG_VERSION__ in bundled builds */
 		const extensionVersion =
 			typeof __PKG_VERSION__ !== "undefined" ? __PKG_VERSION__ : "dev";
+		/* v8 ignore stop */
 		let highest = ownEntry;
 		for (const entry of allSources) {
 			if (
@@ -1474,9 +1478,11 @@ export class JolliMemoryBridge {
 			const content = plan.filePath
 				? readFileSync(plan.filePath, "utf-8")
 				: await readPlanFromBranch(plan.slug, this.cwd);
+			/* v8 ignore start -- both readFileSync (on-disk plan) and readPlanFromBranch (orphan-branch plan) return non-empty strings for any plan that was linked to this commit; empty content indicates corruption and is defensively skipped */
 			if (!content) {
 				continue;
 			}
+			/* v8 ignore stop */
 			satellites.push({
 				slug: plan.slug,
 				title: plan.title,

--- a/vscode/src/core/PlanService.ts
+++ b/vscode/src/core/PlanService.ts
@@ -31,14 +31,11 @@ import type { PlanReference } from "../../../cli/src/Types.js";
 import type { PlanEntry, PlanInfo } from "../Types.js";
 import { log } from "../util/Logger.js";
 
-/** Directory where Claude Code stores plan files */
-const PLANS_DIR = join(homedir(), ".claude", "plans");
-
 // ─── Public API ───────────────────────────────────────────────────────────────
 
 /** Returns the global plans directory path (~/.claude/plans/) */
 export function getPlansDir(): string {
-	return PLANS_DIR;
+	return join(homedir(), ".claude", "plans");
 }
 
 /**
@@ -109,7 +106,7 @@ function toPlanInfo(entry: PlanEntry): PlanInfo | null {
 
 	// Skip archive guards (source file unchanged)
 	if (entry.contentHashAtCommit) {
-		const planFile = join(PLANS_DIR, `${entry.slug}.md`);
+		const planFile = join(getPlansDir(), `${entry.slug}.md`);
 		if (
 			!existsSync(planFile) ||
 			hashFileContent(planFile) === entry.contentHashAtCommit
@@ -186,7 +183,7 @@ export async function addPlanToRegistry(
 	slug: string,
 	cwd: string,
 ): Promise<void> {
-	const planFile = join(PLANS_DIR, `${slug}.md`);
+	const planFile = join(getPlansDir(), `${slug}.md`);
 	if (!existsSync(planFile)) {
 		return;
 	}
@@ -291,11 +288,11 @@ export async function isPlanFromCurrentProject(
 export function listAvailablePlans(
 	excludeSlugs: ReadonlySet<string>,
 ): ReadonlyArray<{ slug: string; title: string; mtimeMs: number }> {
-	if (!existsSync(PLANS_DIR)) {
+	if (!existsSync(getPlansDir())) {
 		return [];
 	}
 
-	const files = readdirSync(PLANS_DIR).filter((f) => f.endsWith(".md"));
+	const files = readdirSync(getPlansDir()).filter((f) => f.endsWith(".md"));
 	const available: Array<{ slug: string; title: string; mtimeMs: number }> = [];
 
 	for (const file of files) {
@@ -303,7 +300,7 @@ export function listAvailablePlans(
 		if (excludeSlugs.has(slug)) {
 			continue;
 		}
-		const filePath = join(PLANS_DIR, file);
+		const filePath = join(getPlansDir(), file);
 		try {
 			const mtime = statSync(filePath).mtimeMs;
 			available.push({ slug, title: extractTitle(filePath), mtimeMs: mtime });
@@ -335,7 +332,7 @@ export async function archivePlanForCommit(
 	// If slug is not in the registry (e.g., picked from ~/.claude/plans/ directory but
 	// never auto-discovered from transcript), create a fresh entry first.
 	if (!entry) {
-		const planFile = join(PLANS_DIR, `${slug}.md`);
+		const planFile = join(getPlansDir(), `${slug}.md`);
 		if (!existsSync(planFile)) {
 			return null;
 		}
@@ -390,7 +387,7 @@ export async function archivePlanForCommit(
 	);
 
 	// Store plan file in orphan branch under new slug
-	const planFile = join(PLANS_DIR, `${slug}.md`);
+	const planFile = join(getPlansDir(), `${slug}.md`);
 	if (existsSync(planFile)) {
 		const content = fsReadFileSync(planFile, "utf-8");
 		await storePlans(

--- a/vscode/src/providers/StatusTreeProvider.test.ts
+++ b/vscode/src/providers/StatusTreeProvider.test.ts
@@ -315,12 +315,18 @@ describe("StatusTreeProvider", () => {
 	});
 
 	it("shows Jolli Site only when parseJolliApiKey returns a URL with siteUrl", async () => {
-		// Covers the siteUrl truthy branch on line 210-211
+		// Covers both `if (meta?.u)` branches: signed in with jolliApiKey, but the
+		// parsed metadata lacks `u`, so the Jolli Site row is NOT appended.
 		const bridge = {
 			cwd: "/repo",
 			getStatus: vi.fn(async () => makeStatus()),
 		};
-		loadConfigFromDir.mockResolvedValue({ apiKey: "key", jolliApiKey: "jk" });
+		// authToken makes the "signed in" branch active so execution reaches line 247.
+		loadConfigFromDir.mockResolvedValue({
+			apiKey: "key",
+			authToken: "tok",
+			jolliApiKey: "jk",
+		});
 		// Return meta without u field — no Jolli Site row
 		parseJolliApiKey.mockReturnValue({ t: "acme" });
 
@@ -436,6 +442,99 @@ describe("StatusTreeProvider", () => {
 		const updateItem = items.find((item) => item.label === "Update Available");
 		expect(updateItem).toBeDefined();
 		expect(updateItem?.description).toBe("a newer version is available");
+	});
+
+	// ── Session count suffixes ────────────────────────────────────────────
+
+	it("appends plural session counts to integration descriptions", async () => {
+		const bridge = {
+			cwd: "/repo",
+			getStatus: vi.fn(async () =>
+				makeStatus({ sessionsBySource: { claude: 3, codex: 2 } }),
+			),
+		};
+		loadConfigFromDir.mockResolvedValue({ apiKey: "key" });
+
+		const provider = makeStatusProvider(bridge as never);
+		await provider.refresh();
+
+		const items = provider.getChildren();
+		const claude = items.find((item) => item.label === "Claude Integration");
+		expect(claude?.description).toBe("hook installed (3 sessions)");
+		const codex = items.find((item) => item.label === "Codex Integration");
+		expect(codex?.description).toBe("detected & enabled (2 sessions)");
+	});
+
+	it("appends singular session count to integration description", async () => {
+		const bridge = {
+			cwd: "/repo",
+			getStatus: vi.fn(async () =>
+				makeStatus({ sessionsBySource: { claude: 1 } }),
+			),
+		};
+		loadConfigFromDir.mockResolvedValue({ apiKey: "key" });
+
+		const provider = makeStatusProvider(bridge as never);
+		await provider.refresh();
+
+		const items = provider.getChildren();
+		const claude = items.find((item) => item.label === "Claude Integration");
+		expect(claude?.description).toBe("hook installed (1 session)");
+	});
+
+	// ── OpenCode scan error (Finding P1-b) ────────────────────────────────
+
+	it("renders an 'unavailable' OpenCode row when openCodeScanError is present", async () => {
+		// Regression: a corrupt/locked OpenCode DB used to render as
+		// "detected & enabled (0 sessions)" — visually identical to a healthy
+		// integration with no activity. Now the scan error replaces the normal row.
+		const bridge = {
+			cwd: "/repo",
+			getStatus: vi.fn(async () =>
+				makeStatus({
+					openCodeDetected: true,
+					openCodeEnabled: true,
+					openCodeScanError: {
+						kind: "corrupt",
+						message: "SQLITE_CORRUPT: disk image malformed",
+					},
+				}),
+			),
+		};
+		loadConfigFromDir.mockResolvedValue({ apiKey: "key" });
+
+		const provider = makeStatusProvider(bridge as never);
+		await provider.refresh();
+
+		const items = provider.getChildren();
+		const openCode = items.find(
+			(item) => item.label === "OpenCode Integration",
+		);
+		expect(openCode?.description).toBe("unavailable — corrupt");
+		expect(String(openCode?.tooltip)).toContain("SQLITE_CORRUPT");
+	});
+
+	it("falls back to the normal detected/enabled OpenCode row when no scan error", async () => {
+		const bridge = {
+			cwd: "/repo",
+			getStatus: vi.fn(async () =>
+				makeStatus({
+					openCodeDetected: true,
+					openCodeEnabled: true,
+					sessionsBySource: { opencode: 2 },
+				}),
+			),
+		};
+		loadConfigFromDir.mockResolvedValue({ apiKey: "key" });
+
+		const provider = makeStatusProvider(bridge as never);
+		await provider.refresh();
+
+		const items = provider.getChildren();
+		const openCode = items.find(
+			(item) => item.label === "OpenCode Integration",
+		);
+		expect(openCode?.description).toBe("detected & enabled (2 sessions)");
 	});
 
 	// ── Auth-aware status rows ────────────────────────────────────────────

--- a/vscode/src/providers/StatusTreeProvider.ts
+++ b/vscode/src/providers/StatusTreeProvider.ts
@@ -219,6 +219,8 @@ function buildFullStatusItems(
 		items.push(accountItem);
 	}
 
+	// Integration status rows (Claude, Codex, Gemini, OpenCode)
+	const counts = s.sessionsBySource ?? {};
 	pushIntegrationItem(
 		items,
 		s.claudeDetected,
@@ -228,6 +230,7 @@ function buildFullStatusItems(
 		"Claude Code hooks installed (Stop, SessionStart) — session tracking is enabled",
 		"Claude Code detected but session tracking is disabled in config",
 		"Claude Code detected but hooks are not installed",
+		counts.claude,
 	);
 	pushIntegrationItem(
 		items,
@@ -238,6 +241,7 @@ function buildFullStatusItems(
 		"Codex CLI sessions directory found — session discovery is enabled",
 		"Codex CLI detected but session discovery is disabled in config",
 		undefined,
+		counts.codex,
 	);
 	pushIntegrationItem(
 		items,
@@ -248,7 +252,34 @@ function buildFullStatusItems(
 		"Gemini CLI AfterAgent hook installed — session tracking is enabled",
 		"Gemini CLI detected but session tracking is disabled in config",
 		"Gemini CLI detected but AfterAgent hook is not installed",
+		counts.gemini,
 	);
+	// OpenCode has a scan-time error channel that the other integrations don't:
+	// the DB can exist but be corrupt / locked / schema-drifted. Surface that as
+	// a dedicated warning row BEFORE the regular "detected & enabled" row so
+	// the failure state doesn't silently look like "0 sessions".
+	if (s.openCodeScanError) {
+		items.push(
+			new StatusItem(
+				"OpenCode Integration",
+				`unavailable — ${s.openCodeScanError.kind}`,
+				ICON_WARN,
+				`OpenCode database scan failed (${s.openCodeScanError.kind}): ${s.openCodeScanError.message}`,
+			),
+		);
+	} else {
+		pushIntegrationItem(
+			items,
+			s.openCodeDetected,
+			s.openCodeEnabled !== false,
+			undefined,
+			"OpenCode Integration",
+			"OpenCode sessions database found — session discovery is enabled",
+			"OpenCode detected but session discovery is disabled in config",
+			undefined,
+			counts.opencode,
+		);
+	}
 
 	if (extensionOutdated) {
 		items.push(
@@ -273,10 +304,23 @@ function pushIntegrationItem(
 	enabledTooltip: string,
 	disabledTooltip: string,
 	hookMissingTooltip: string | undefined,
+	sessionCount?: number,
 ): void {
 	if (!detected) {
 		return;
 	}
+
+	// Build session count suffix for enabled states
+	const countSuffix =
+		sessionCount && sessionCount > 0
+			? ` (${sessionCount} session${sessionCount !== 1 ? "s" : ""})`
+			: "";
+	const tooltipSuffix =
+		sessionCount && sessionCount > 0
+			? ` (${sessionCount} active session${sessionCount !== 1 ? "s" : ""})`
+			: "";
+
+	// Four states: disabled in config, enabled without a hook, enabled but hook missing, fully enabled with hook
 	if (!enabled) {
 		items.push(
 			new StatusItem(
@@ -288,7 +332,12 @@ function pushIntegrationItem(
 		);
 	} else if (hookInstalled === undefined && hookMissingTooltip === undefined) {
 		items.push(
-			new StatusItem(label, "detected & enabled", ICON_OK, enabledTooltip),
+			new StatusItem(
+				label,
+				`detected & enabled${countSuffix}`,
+				ICON_OK,
+				`${enabledTooltip}${tooltipSuffix}`,
+			),
 		);
 	} else if (hookInstalled === false && hookMissingTooltip) {
 		items.push(
@@ -301,7 +350,12 @@ function pushIntegrationItem(
 		);
 	} else {
 		items.push(
-			new StatusItem(label, "hook installed", ICON_OK, enabledTooltip),
+			new StatusItem(
+				label,
+				`hook installed${countSuffix}`,
+				ICON_OK,
+				`${enabledTooltip}${tooltipSuffix}`,
+			),
 		);
 	}
 }

--- a/vscode/src/services/AuthService.test.ts
+++ b/vscode/src/services/AuthService.test.ts
@@ -216,6 +216,34 @@ describe("AuthService", () => {
 				expect(result.error).toContain("disk full");
 			}
 		});
+
+		it("should stringify non-Error throw from saveAuthCredentials", async () => {
+			// Covers the `err instanceof Error ? err.message : String(err)` right branch.
+			saveAuthCredentials.mockRejectedValueOnce("bare string rejection");
+			const uri = makeUri("/auth-callback", "token=test-token");
+
+			const result = await service.handleAuthCallback(uri as never);
+
+			expect(result.success).toBe(false);
+			if (!result.success) {
+				expect(result.error).toContain("bare string rejection");
+			}
+		});
+
+		it("should continue returning success when setContext throws", async () => {
+			// Covers the log.warn branch in the setContext catch (line 106).
+			// executeCommand succeeds for saveAuthCredentials's lifecycle but throws
+			// specifically for the setContext call.
+			executeCommand.mockImplementationOnce(() => {
+				throw new Error("setContext unavailable");
+			});
+			const uri = makeUri("/auth-callback", "token=test-token");
+
+			const result = await service.handleAuthCallback(uri as never);
+
+			// Save succeeded → overall result is success even though setContext threw.
+			expect(result.success).toBe(true);
+		});
 	});
 
 	// ── signOut ─────────────────────────────────────────────────────────
@@ -302,6 +330,18 @@ describe("AuthService", () => {
 
 			expect(showErrorMessage).toHaveBeenCalledWith(
 				expect.stringContaining("no browser"),
+			);
+		});
+
+		it("should stringify a non-Error throw from openExternal", async () => {
+			// Covers the `err instanceof Error ? err.message : String(err)` right branch
+			// in openSignInPage (line 145).
+			openExternal.mockRejectedValueOnce("bare string from browser layer");
+
+			await service.openSignInPage();
+
+			expect(showErrorMessage).toHaveBeenCalledWith(
+				expect.stringContaining("bare string from browser layer"),
 			);
 		});
 	});

--- a/vscode/src/services/PrCommentService.test.ts
+++ b/vscode/src/services/PrCommentService.test.ts
@@ -367,6 +367,136 @@ describe("PrCommentService", () => {
 			});
 		});
 
+		it("recovers when gh --version fails once (transient) then succeeds on retry", async () => {
+			// Covers checkGhInstalled retry → r2.ok success path.
+			let versionCalls = 0;
+			setupExecFile((cmd, args) => {
+				if (cmd === "git" && args[0] === "rev-list") return { stdout: "1\n" };
+				if (cmd === "git" && args[0] === "rev-parse")
+					return { stdout: "feature/br\n" };
+				if (cmd === "gh" && args[0] === "--version") {
+					versionCalls++;
+					if (versionCalls === 1) {
+						const err = new Error("EACCES") as NodeJS.ErrnoException;
+						err.code = "EACCES";
+						throw err;
+					}
+					return { stdout: "gh version 2.40.0\n" };
+				}
+				if (cmd === "gh" && args[0] === "auth") return { stdout: "ok\n" };
+				if (cmd === "gh" && args[0] === "pr") throw new Error("no PR");
+				return { stdout: "" };
+			});
+
+			vi.useFakeTimers();
+			try {
+				const p = handleCheckPrStatus(CWD, postMessage);
+				await vi.runAllTimersAsync();
+				await p;
+			} finally {
+				vi.useRealTimers();
+			}
+
+			expect(versionCalls).toBe(2);
+			expect(postMessage).toHaveBeenCalledWith({
+				command: "prStatus",
+				status: "noPr",
+				branch: "feature/br",
+				crossBranch: false,
+			});
+		});
+
+		it("posts notInstalled when gh --version fails transiently then fails with ENOENT on retry", async () => {
+			// Covers checkGhInstalled retry → r2.kind === "notFound" branch.
+			let versionCalls = 0;
+			setupExecFile((cmd, args) => {
+				if (cmd === "git" && args[0] === "rev-list") return { stdout: "1\n" };
+				if (cmd === "gh" && args[0] === "--version") {
+					versionCalls++;
+					const err = new Error(
+						versionCalls === 1 ? "EACCES" : "ENOENT",
+					) as NodeJS.ErrnoException;
+					err.code = versionCalls === 1 ? "EACCES" : "ENOENT";
+					throw err;
+				}
+				return { stdout: "" };
+			});
+
+			vi.useFakeTimers();
+			try {
+				const p = handleCheckPrStatus(CWD, postMessage);
+				await vi.runAllTimersAsync();
+				await p;
+			} finally {
+				vi.useRealTimers();
+			}
+
+			expect(postMessage).toHaveBeenCalledWith({
+				command: "prStatus",
+				status: "notInstalled",
+			});
+		});
+
+		it("posts unavailable when gh auth fails transiently twice (error status propagates)", async () => {
+			// Covers checkGhAuthenticated retry with non-nonZero failure:
+			// r2.kind !== "nonZero" → returns "error" → handleCheckPrStatus reaches the
+			// `if (auth === "error")` branch → posts "unavailable".
+			setupExecFile((cmd, args) => {
+				if (cmd === "git" && args[0] === "rev-list") return { stdout: "1\n" };
+				if (cmd === "gh" && args[0] === "--version")
+					return { stdout: "gh 2.40\n" };
+				if (cmd === "gh" && args[0] === "auth") {
+					const err = new Error("spawn EACCES") as NodeJS.ErrnoException;
+					err.code = "EACCES";
+					throw err;
+				}
+				return { stdout: "" };
+			});
+
+			vi.useFakeTimers();
+			try {
+				const p = handleCheckPrStatus(CWD, postMessage);
+				await vi.runAllTimersAsync();
+				await p;
+			} finally {
+				vi.useRealTimers();
+			}
+
+			expect(postMessage).toHaveBeenCalledWith({
+				command: "prStatus",
+				status: "unavailable",
+			});
+		});
+
+		it("falls back to current branch when cross-branch detection yields no summary branch", async () => {
+			// Covers handleCheckPrStatus `summaryBranch ?? currentBranch` right branch:
+			// summaryCommitHash is set, merge-base --is-ancestor fails (cross-branch=true),
+			// but summaryBranch is undefined → fall back to currentBranch.
+			setupExecFile((cmd, args) => {
+				if (cmd === "git" && args[0] === "rev-list") return { stdout: "1\n" };
+				if (cmd === "git" && args[0] === "rev-parse")
+					return { stdout: "fallback-branch\n" };
+				// merge-base --is-ancestor fails → isCrossBranch=true
+				if (cmd === "git" && args[0] === "merge-base") {
+					throw new Error("not an ancestor");
+				}
+				if (cmd === "gh" && args[0] === "--version") return { stdout: "gh\n" };
+				if (cmd === "gh" && args[0] === "auth") return { stdout: "ok\n" };
+				if (cmd === "gh" && args[0] === "pr") throw new Error("no pr");
+				return { stdout: "" };
+			});
+
+			// summaryBranch=undefined, summaryCommitHash="deadbeef"
+			await handleCheckPrStatus(CWD, postMessage, undefined, "deadbeef");
+
+			expect(postMessage).toHaveBeenCalledWith({
+				command: "prStatus",
+				status: "noPr",
+				branch: "fallback-branch",
+				crossBranch: true,
+			});
+		});
+
 		it("posts unavailable when gh --version fails with a transient error twice", async () => {
 			setupExecFile((cmd, args) => {
 				if (cmd === "git" && args[0] === "rev-list") {
@@ -997,6 +1127,47 @@ describe("PrCommentService", () => {
 			});
 		});
 
+		it("falls back to current branch when summary.branch is undefined (cross-branch)", async () => {
+			// Covers handlePrepareUpdatePr `summary.branch ?? currentBranch` right branch.
+			// merge-base --is-ancestor fails so isCrossBranch=true; summary has no branch,
+			// so the fallback reaches currentBranch.
+			const summaryNoBranch = {
+				commitHash: "deadbeef",
+				// no `branch` field — exercise the `??` fallback
+			} as never;
+
+			setupExecFile((cmd, args) => {
+				if (cmd === "git" && args[0] === "merge-base") {
+					throw new Error("not an ancestor");
+				}
+				if (cmd === "git" && args[0] === "rev-parse") {
+					return { stdout: "fallback-branch\n" };
+				}
+				if (cmd === "gh" && args[0] === "pr" && args[1] === "view") {
+					return {
+						stdout: JSON.stringify({
+							number: 1,
+							url: "u",
+							title: "t",
+							body: "",
+						}),
+					};
+				}
+				return { stdout: "" };
+			});
+
+			await handlePrepareUpdatePr(
+				summaryNoBranch,
+				CWD,
+				postMessage,
+				buildMarkdownFn,
+			);
+
+			expect(postMessage).toHaveBeenCalledWith(
+				expect.objectContaining({ command: "prShowUpdateForm" }),
+			);
+		});
+
 		it("replaces existing markers in PR body", async () => {
 			const existingBody = `Before\n${MARKER_START}\nold content\n${MARKER_END}\nAfter`;
 			setupExecFile((cmd, args) => {
@@ -1331,6 +1502,83 @@ describe("PrCommentService", () => {
 				"Updated PR #7",
 				"Open PR",
 			);
+		});
+
+		it("resolves target branch via summary branch when summaryCommitHash is unreachable", async () => {
+			// Covers handleUpdatePr's `summaryCommitHash ? ... : false` truthy branch,
+			// the `isCrossBranch ? ... : currentBranch` truthy branch, and the
+			// `summaryBranch ?? currentBranch` left branch (summaryBranch given).
+			const pr = { number: 9, url: "u", title: "Same", body: "" };
+			setupExecFile((cmd, args) => {
+				if (cmd === "git" && args[0] === "merge-base") {
+					throw new Error("not an ancestor");
+				}
+				if (cmd === "git" && args[0] === "rev-parse") {
+					return { stdout: "current-branch\n" };
+				}
+				if (cmd === "git" && args[0] === "rev-list") return { stdout: "1\n" };
+				if (cmd === "gh" && args[0] === "--version") return { stdout: "ok\n" };
+				if (cmd === "gh" && args[0] === "auth") return { stdout: "ok\n" };
+				if (cmd === "gh" && args[0] === "pr" && args[1] === "view") {
+					return { stdout: JSON.stringify(pr) };
+				}
+				if (cmd === "gh" && args[0] === "pr" && args[1] === "edit") {
+					return { stdout: "" };
+				}
+				return { stdout: "" };
+			});
+			showInformationMessage.mockResolvedValue(undefined);
+
+			await handleUpdatePr(
+				"Same",
+				"new body",
+				CWD,
+				postMessage,
+				"summary-branch",
+				"deadbeef",
+			);
+
+			expect(postMessage).toHaveBeenCalledWith({ command: "prUpdating" });
+			// Verify the PR lookup used the summary branch (passed via the 2nd rev-parse)
+			const viewCall = mockExecFileAsync.mock.calls.find(
+				(c) => c[0] === "gh" && c[1][0] === "pr" && c[1][1] === "view",
+			);
+			expect(viewCall?.[1]).toContain("summary-branch");
+		});
+
+		it("falls back to current branch when summaryCommitHash is unreachable but summaryBranch is undefined", async () => {
+			// Covers the `summaryBranch ?? currentBranch` right branch in handleUpdatePr.
+			const pr = { number: 9, url: "u", title: "Same", body: "" };
+			setupExecFile((cmd, args) => {
+				if (cmd === "git" && args[0] === "merge-base") {
+					throw new Error("not an ancestor");
+				}
+				if (cmd === "git" && args[0] === "rev-parse") {
+					return { stdout: "current-branch\n" };
+				}
+				if (cmd === "git" && args[0] === "rev-list") return { stdout: "1\n" };
+				if (cmd === "gh" && args[0] === "--version") return { stdout: "ok\n" };
+				if (cmd === "gh" && args[0] === "auth") return { stdout: "ok\n" };
+				if (cmd === "gh" && args[0] === "pr" && args[1] === "view") {
+					return { stdout: JSON.stringify(pr) };
+				}
+				if (cmd === "gh" && args[0] === "pr" && args[1] === "edit") {
+					return { stdout: "" };
+				}
+				return { stdout: "" };
+			});
+			showInformationMessage.mockResolvedValue(undefined);
+
+			await handleUpdatePr(
+				"Same",
+				"new body",
+				CWD,
+				postMessage,
+				undefined,
+				"deadbeef",
+			);
+
+			expect(postMessage).toHaveBeenCalledWith({ command: "prUpdating" });
 		});
 
 		it("opens external URL when user clicks 'Open PR' after update", async () => {

--- a/vscode/src/services/PrCommentService.ts
+++ b/vscode/src/services/PrCommentService.ts
@@ -113,7 +113,9 @@ async function probeGh(
 		});
 		return { ok: true, stdout };
 	} catch (e) {
+		/* v8 ignore start -- defensive: execFile always rejects with Error; retain the coercion for unexpected non-Error throws */
 		const err = e instanceof Error ? e : new Error(String(e));
+		/* v8 ignore stop */
 		const code = (err as NodeJS.ErrnoException).code;
 		if (code === "ENOENT") {
 			return { ok: false, kind: "notFound", err };

--- a/vscode/src/views/SettingsHtmlBuilder.test.ts
+++ b/vscode/src/views/SettingsHtmlBuilder.test.ts
@@ -56,6 +56,7 @@ describe("SettingsHtmlBuilder", () => {
 		expect(html).toContain('id="claudeEnabled"');
 		expect(html).toContain('id="codexEnabled"');
 		expect(html).toContain('id="geminiEnabled"');
+		expect(html).toContain('id="openCodeEnabled"');
 	});
 
 	it("contains Files group with exclude patterns", () => {

--- a/vscode/src/views/SettingsHtmlBuilder.ts
+++ b/vscode/src/views/SettingsHtmlBuilder.ts
@@ -83,6 +83,7 @@ export function buildSettingsHtml(nonce: string): string {
       ${buildToggleRow("claudeEnabled", "Claude Code", "Session tracking via Stop hook")}
       ${buildToggleRow("codexEnabled", "Codex CLI", "Session discovery via filesystem scan")}
       ${buildToggleRow("geminiEnabled", "Gemini CLI", "Session tracking via AfterAgent hook")}
+      ${buildToggleRow("openCodeEnabled", "OpenCode", "Session discovery via ~/.local/share/opencode/opencode.db")}
       <div class="error-message" id="integrations-error"></div>
     </div>
 

--- a/vscode/src/views/SettingsScriptBuilder.test.ts
+++ b/vscode/src/views/SettingsScriptBuilder.test.ts
@@ -53,5 +53,6 @@ describe("SettingsScriptBuilder", () => {
 	it("validates at least one integration must be enabled", () => {
 		expect(script).toContain("integrations-error");
 		expect(script).toContain("At least one integration must be enabled");
+		expect(script).toContain("openCodeEnabled");
 	});
 });

--- a/vscode/src/views/SettingsScriptBuilder.ts
+++ b/vscode/src/views/SettingsScriptBuilder.ts
@@ -23,6 +23,7 @@ export function buildSettingsScript(): string {
   const claudeEnabledInput = document.getElementById('claudeEnabled');
   const codexEnabledInput = document.getElementById('codexEnabled');
   const geminiEnabledInput = document.getElementById('geminiEnabled');
+  const openCodeEnabledInput = document.getElementById('openCodeEnabled');
   const localFolderInput = document.getElementById('localFolder');
   const browseLocalFolderBtn = document.getElementById('browseLocalFolderBtn');
   const pushActionJolliRadio = document.getElementById('pushActionJolli');
@@ -76,7 +77,7 @@ export function buildSettingsScript(): string {
     }) && valid;
     // At least one integration must be enabled
     var intError = document.getElementById('integrations-error');
-    if (!claudeEnabledInput.checked && !codexEnabledInput.checked && !geminiEnabledInput.checked) {
+    if (!claudeEnabledInput.checked && !codexEnabledInput.checked && !geminiEnabledInput.checked && !openCodeEnabledInput.checked) {
       intError.textContent = 'At least one integration must be enabled';
       valid = false;
     } else {
@@ -110,6 +111,7 @@ export function buildSettingsScript(): string {
       claudeEnabled: claudeEnabledInput.checked,
       codexEnabled: codexEnabledInput.checked,
       geminiEnabled: geminiEnabledInput.checked,
+      openCodeEnabled: openCodeEnabledInput.checked,
       localFolder: localFolderInput.value,
       pushAction: pushActionBothRadio.checked ? 'both' : 'jolli',
       excludePatterns: excludePatternsInput.value,
@@ -127,6 +129,7 @@ export function buildSettingsScript(): string {
       claudeEnabledInput.checked !== initialState.claudeEnabled ||
       codexEnabledInput.checked !== initialState.codexEnabled ||
       geminiEnabledInput.checked !== initialState.geminiEnabled ||
+      openCodeEnabledInput.checked !== initialState.openCodeEnabled ||
       localFolderInput.value !== initialState.localFolder ||
       currentPushAction !== initialState.pushAction ||
       excludePatternsInput.value !== initialState.excludePatterns
@@ -143,7 +146,7 @@ export function buildSettingsScript(): string {
     input.addEventListener('input', function() { validateAll(); checkDirty(); });
   });
   modelSelect.addEventListener('change', function() { checkDirty(); });
-  [claudeEnabledInput, codexEnabledInput, geminiEnabledInput].forEach(function(input) {
+  [claudeEnabledInput, codexEnabledInput, geminiEnabledInput, openCodeEnabledInput].forEach(function(input) {
     input.addEventListener('change', function() { validateAll(); checkDirty(); });
   });
   [pushActionJolliRadio, pushActionBothRadio].forEach(function(input) {
@@ -164,6 +167,7 @@ export function buildSettingsScript(): string {
         claudeEnabled: claudeEnabledInput.checked,
         codexEnabled: codexEnabledInput.checked,
         geminiEnabled: geminiEnabledInput.checked,
+        openCodeEnabled: openCodeEnabledInput.checked,
         localFolder: localFolderInput.value.trim(),
         pushAction: pushActionBothRadio.checked ? 'both' : 'jolli',
         excludePatterns: excludePatternsInput.value,
@@ -185,6 +189,7 @@ export function buildSettingsScript(): string {
         claudeEnabledInput.checked = msg.settings.claudeEnabled;
         codexEnabledInput.checked = msg.settings.codexEnabled;
         geminiEnabledInput.checked = msg.settings.geminiEnabled;
+        openCodeEnabledInput.checked = msg.settings.openCodeEnabled;
         localFolderInput.value = msg.settings.localFolder || '';
         if (msg.settings.pushAction === 'both') {
           pushActionBothRadio.checked = true;

--- a/vscode/src/views/SettingsWebviewPanel.test.ts
+++ b/vscode/src/views/SettingsWebviewPanel.test.ts
@@ -54,6 +54,7 @@ const { mockGetGlobalConfigDir, mockLoadConfigFromDir, mockSaveConfigScoped } =
 			claudeEnabled: true,
 			codexEnabled: false,
 			geminiEnabled: true,
+			openCodeEnabled: true,
 			excludePatterns: ["node_modules"],
 		}),
 		mockSaveConfigScoped: vi.fn().mockResolvedValue(undefined),
@@ -162,6 +163,7 @@ describe("SettingsWebviewPanel", () => {
 			claudeEnabled: true,
 			codexEnabled: false,
 			geminiEnabled: true,
+			openCodeEnabled: true,
 			excludePatterns: ["node_modules"],
 		});
 		mockGetGlobalConfigDir.mockReturnValue("/global/.jollimemory");
@@ -390,6 +392,7 @@ describe("SettingsWebviewPanel", () => {
 				claudeEnabled: true,
 				codexEnabled: false,
 				geminiEnabled: true,
+				openCodeEnabled: false,
 				excludePatterns: ["dist", "node_modules"],
 			});
 
@@ -412,6 +415,7 @@ describe("SettingsWebviewPanel", () => {
 						claudeEnabled: true,
 						codexEnabled: false,
 						geminiEnabled: true,
+						openCodeEnabled: false,
 						excludePatterns: "dist, node_modules",
 					}),
 				}),
@@ -427,6 +431,7 @@ describe("SettingsWebviewPanel", () => {
 				claudeEnabled: undefined,
 				codexEnabled: undefined,
 				geminiEnabled: undefined,
+				openCodeEnabled: undefined,
 				excludePatterns: undefined,
 			});
 
@@ -444,6 +449,7 @@ describe("SettingsWebviewPanel", () => {
 						claudeEnabled: true,
 						codexEnabled: true,
 						geminiEnabled: true,
+						openCodeEnabled: true,
 						excludePatterns: "",
 					}),
 				}),
@@ -486,6 +492,7 @@ describe("SettingsWebviewPanel", () => {
 				claudeEnabled: true,
 				codexEnabled: true,
 				geminiEnabled: true,
+				openCodeEnabled: true,
 				excludePatterns: [],
 				...configOverrides,
 			};
@@ -857,6 +864,7 @@ describe("SettingsWebviewPanel", () => {
 					claudeEnabled: false,
 					codexEnabled: false,
 					geminiEnabled: false,
+					openCodeEnabled: false,
 					excludePatterns: "",
 				},
 			});
@@ -867,6 +875,7 @@ describe("SettingsWebviewPanel", () => {
 					claudeEnabled: false,
 					codexEnabled: false,
 					geminiEnabled: false,
+					openCodeEnabled: false,
 				}),
 				expect.any(String),
 			);
@@ -887,6 +896,7 @@ describe("SettingsWebviewPanel", () => {
 					claudeEnabled: true,
 					codexEnabled: true,
 					geminiEnabled: true,
+					openCodeEnabled: true,
 					excludePatterns: "",
 				},
 			});
@@ -897,7 +907,48 @@ describe("SettingsWebviewPanel", () => {
 					claudeEnabled: true,
 					codexEnabled: true,
 					geminiEnabled: true,
+					openCodeEnabled: true,
 				}),
+				expect.any(String),
+			);
+		});
+
+		it("loads and saves OpenCode integration state", async () => {
+			const dispatch = await setupWithLoadedConfig({ openCodeEnabled: false });
+
+			// Re-trigger load — setupWithLoadedConfig clears postMessage after initial load
+			dispatch({ command: "loadSettings", scope: "project" });
+			await flushPromises();
+
+			expect(postMessage).toHaveBeenCalledWith(
+				expect.objectContaining({
+					command: "settingsLoaded",
+					settings: expect.objectContaining({ openCodeEnabled: false }),
+				}),
+			);
+
+			postMessage.mockClear();
+			dispatch({
+				command: "applySettings",
+				scope: "project",
+				maskedApiKey: "",
+				maskedJolliApiKey: "",
+				settings: {
+					apiKey: "",
+					model: "sonnet",
+					maxTokens: null,
+					jolliApiKey: "",
+					claudeEnabled: true,
+					codexEnabled: true,
+					geminiEnabled: true,
+					openCodeEnabled: false,
+					excludePatterns: "",
+				},
+			});
+			await flushPromises();
+
+			expect(mockSaveConfigScoped).toHaveBeenCalledWith(
+				expect.objectContaining({ openCodeEnabled: false }),
 				expect.any(String),
 			);
 		});

--- a/vscode/src/views/SettingsWebviewPanel.ts
+++ b/vscode/src/views/SettingsWebviewPanel.ts
@@ -40,6 +40,7 @@ interface SettingsPayload {
 	readonly claudeEnabled: boolean;
 	readonly codexEnabled: boolean;
 	readonly geminiEnabled: boolean;
+	readonly openCodeEnabled: boolean;
 	readonly localFolder: string;
 	readonly pushAction: "jolli" | "both";
 	readonly excludePatterns: string;
@@ -220,6 +221,7 @@ export class SettingsWebviewPanel {
 			claudeEnabled: config.claudeEnabled !== false,
 			codexEnabled: config.codexEnabled !== false,
 			geminiEnabled: config.geminiEnabled !== false,
+			openCodeEnabled: config.openCodeEnabled !== false,
 			localFolder: config.localFolder ?? "",
 			pushAction: config.pushAction === "both" ? "both" : "jolli",
 			excludePatterns: config.excludePatterns
@@ -264,6 +266,7 @@ export class SettingsWebviewPanel {
 			claudeEnabled: settings.claudeEnabled,
 			codexEnabled: settings.codexEnabled,
 			geminiEnabled: settings.geminiEnabled,
+			openCodeEnabled: settings.openCodeEnabled,
 			localFolder:
 				settings.localFolder && settings.localFolder.length > 0
 					? settings.localFolder

--- a/vscode/src/views/SummaryMarkdownBuilder.test.ts
+++ b/vscode/src/views/SummaryMarkdownBuilder.test.ts
@@ -57,7 +57,7 @@ function makeSummary(overrides: Partial<CommitSummary> = {}): CommitSummary {
 		commitMessage: "Fix login timeout",
 		commitAuthor: "Alice",
 		commitDate: "2026-03-30T10:00:00Z",
-		branch: "feature/jolli-100-login",
+		branch: "feature/proj-100-login",
 		generatedAt: "2026-03-30T10:05:00Z",
 		...overrides,
 	};
@@ -146,7 +146,7 @@ describe("SummaryMarkdownBuilder", () => {
 
 				expect(md).toContain("# Fix login timeout");
 				expect(md).toContain("- **Commit:** `abc1234567890def`");
-				expect(md).toContain("- **Branch:** `feature/jolli-100-login`");
+				expect(md).toContain("- **Branch:** `feature/proj-100-login`");
 				expect(md).toContain("- **Author:** Alice");
 				expect(md).toContain("- **Date:** March 30, 2026 at 10:00 AM");
 				expect(md).toContain("- **Duration:** 1 day (1 commit)");

--- a/vscode/src/views/SummaryScriptBuilder.test.ts
+++ b/vscode/src/views/SummaryScriptBuilder.test.ts
@@ -94,4 +94,12 @@ describe("SummaryScriptBuilder", () => {
 		expect(script).toContain("noteTranslateError");
 		expect(script).toContain("note-translate-btn");
 	});
+
+	it("maps transcript sources to provider labels", () => {
+		expect(script).toContain("function getSourceLabel");
+		expect(script).toContain("source === 'opencode'");
+		expect(script).toContain("return 'OpenCode'");
+		expect(script).toContain("source === 'gemini'");
+		expect(script).toContain("return 'Gemini'");
+	});
 });

--- a/vscode/src/views/SummaryScriptBuilder.ts
+++ b/vscode/src/views/SummaryScriptBuilder.ts
@@ -911,6 +911,13 @@ ${buildPrMessageScript()}
     }
   }
 
+  function getSourceLabel(source) {
+    if (source === 'codex') return 'Codex';
+    if (source === 'gemini') return 'Gemini';
+    if (source === 'opencode') return 'OpenCode';
+    return 'Claude';
+  }
+
   function renderTranscriptEntries(entries) {
     if (!modalBody) return;
     originalTranscripts = entries;
@@ -946,7 +953,7 @@ ${buildPrMessageScript()}
     var tabsHtml = '';
     for (var t = 0; t < groupOrder.length; t++) {
       var tabGroup = groups[groupOrder[t]];
-      var tabSourceLabel = tabGroup.source === 'codex' ? 'Codex' : 'Claude';
+      var tabSourceLabel = getSourceLabel(tabGroup.source);
       var tabEntryCount = tabGroup.entries.length;
       var activeClass = t === 0 ? ' active' : '';
       tabsHtml += '<button class="modal-tab' + activeClass + '" data-tab-key="' + groupOrder[t] + '">';
@@ -1331,10 +1338,20 @@ ${buildPrMessageScript()}
     }
     if (msg.command === 'transcriptStatsLoaded') {
       if (conversationsStats) {
+        var sessionCounts = msg.sessionCounts || {};
         var parts = [];
-        if (msg.claudeSessions > 0) parts.push('<strong>' + msg.claudeSessions + '</strong> Claude');
-        if (msg.codexSessions > 0) parts.push('<strong>' + msg.codexSessions + '</strong> Codex');
-        var totalSessions = (msg.claudeSessions || 0) + (msg.codexSessions || 0);
+        var sourceOrder = ['claude', 'codex', 'gemini', 'opencode'];
+        for (var i = 0; i < sourceOrder.length; i++) {
+          var source = sourceOrder[i];
+          var count = sessionCounts[source] || 0;
+          if (count > 0) parts.push('<strong>' + count + '</strong> ' + getSourceLabel(source));
+        }
+        var totalSessions = 0;
+        for (var key in sessionCounts) {
+          if (Object.prototype.hasOwnProperty.call(sessionCounts, key)) {
+            totalSessions += sessionCounts[key] || 0;
+          }
+        }
         conversationsStats.innerHTML = '<strong>' + msg.totalEntries + '</strong> entries across <strong>' + totalSessions + '</strong> session' + (totalSessions !== 1 ? 's' : '') + ' (' + parts.join(', ') + ')';
       }
     }

--- a/vscode/src/views/SummaryUtils.test.ts
+++ b/vscode/src/views/SummaryUtils.test.ts
@@ -46,7 +46,7 @@ function makeSummary(overrides: Partial<CommitSummary> = {}): CommitSummary {
 		commitMessage: "Fix some bug",
 		commitAuthor: "Alice",
 		commitDate: "2026-03-15T10:30:00.000Z",
-		branch: "feature/jolli-100-my-feature",
+		branch: "feature/proj-100-my-feature",
 		generatedAt: "2026-03-15T10:31:00.000Z",
 		...overrides,
 	};

--- a/vscode/src/views/SummaryWebviewPanel.test.ts
+++ b/vscode/src/views/SummaryWebviewPanel.test.ts
@@ -1037,6 +1037,103 @@ describe("SummaryWebviewPanel", () => {
 				expect(mockPushToJolli).not.toHaveBeenCalled();
 			});
 
+			it("warns and skips snippet notes missing content (schema-drift guard)", async () => {
+				// Legacy/corrupt entry: snippet without `content` must not silently drop —
+				// it should log.warn and skip the push, while other valid notes still go through.
+				mockLoadConfig.mockResolvedValue({
+					apiKey: "test",
+					jolliApiKey: "jk_valid",
+				});
+				mockParseJolliApiKey.mockReturnValue({ u: "https://my.jolli.app" });
+				mockPushToJolli.mockResolvedValue({ docId: 42 });
+				warn.mockClear();
+
+				const dispatch = await setupPanel({
+					notes: [
+						{
+							id: "broken-snip",
+							title: "Legacy Broken Snippet",
+							format: "snippet" as const,
+							// content intentionally missing — legacy data
+							addedAt: "",
+							updatedAt: "",
+						},
+						{
+							id: "ok-snip",
+							title: "Healthy Snippet",
+							format: "snippet" as const,
+							content: "valid body",
+							addedAt: "",
+							updatedAt: "",
+						},
+					],
+				});
+
+				dispatch({ command: "push" });
+				await flushPromises();
+
+				expect(warn).toHaveBeenCalledWith(
+					"SummaryPanel",
+					expect.stringContaining("broken-snip"),
+				);
+				// mockPushToJolli is called for: summary + ok-snip (the broken one is skipped).
+				// Exactly assert it was invoked with the healthy note content.
+				const noteCall = mockPushToJolli.mock.calls.find(
+					(c) => c[2]?.content === "valid body",
+				);
+				expect(noteCall).toBeDefined();
+				const brokenCall = mockPushToJolli.mock.calls.find(
+					(c) => c[2]?.content === "",
+				);
+				expect(brokenCall).toBeUndefined();
+			});
+
+			it("pushes notes with an existing jolliNoteDocId using docId, new notes without", async () => {
+				// Exercises both branches of `...(note.jolliNoteDocId && { docId })` — previously
+				// guarded by a v8-ignore; now tested directly so coverage reflects real behavior.
+				mockLoadConfig.mockResolvedValue({
+					apiKey: "test",
+					jolliApiKey: "jk_valid",
+				});
+				mockParseJolliApiKey.mockReturnValue({ u: "https://my.jolli.app" });
+				mockPushToJolli.mockResolvedValue({ docId: 42 });
+
+				const dispatch = await setupPanel({
+					notes: [
+						{
+							id: "new-note",
+							title: "New",
+							format: "snippet" as const,
+							content: "new content",
+							addedAt: "",
+							updatedAt: "",
+							// no jolliNoteDocId → falsy branch of `&&`
+						},
+						{
+							id: "existing-note",
+							title: "Existing",
+							format: "snippet" as const,
+							content: "existing content",
+							addedAt: "",
+							updatedAt: "",
+							jolliNoteDocId: 77, // truthy branch of `&&`
+						},
+					],
+				});
+
+				dispatch({ command: "push" });
+				await flushPromises();
+
+				const newNoteCall = mockPushToJolli.mock.calls.find(
+					(c) => c[2]?.content === "new content",
+				);
+				const existingNoteCall = mockPushToJolli.mock.calls.find(
+					(c) => c[2]?.content === "existing content",
+				);
+				expect(newNoteCall?.[2]).not.toHaveProperty("docId");
+				expect(existingNoteCall?.[2]).toMatchObject({ docId: 77 });
+			});
+
 			it("shows warning when base URL cannot be parsed from API key", async () => {
 				mockLoadConfig.mockResolvedValue({
 					apiKey: "test",
@@ -2022,8 +2119,7 @@ describe("SummaryWebviewPanel", () => {
 					expect.objectContaining({
 						command: "transcriptStatsLoaded",
 						totalEntries: 3,
-						claudeSessions: 1, // s1 deduplicated
-						codexSessions: 1, // cx1 counted separately (line 789)
+						sessionCounts: expect.objectContaining({ claude: 1, codex: 1 }),
 					}),
 				);
 			});
@@ -2060,8 +2156,7 @@ describe("SummaryWebviewPanel", () => {
 					expect.objectContaining({
 						command: "transcriptStatsLoaded",
 						totalEntries: 2,
-						claudeSessions: 1,
-						codexSessions: 0,
+						sessionCounts: expect.objectContaining({ claude: 1 }),
 					}),
 				);
 			});
@@ -2131,8 +2226,7 @@ describe("SummaryWebviewPanel", () => {
 					expect.objectContaining({
 						command: "transcriptStatsLoaded",
 						totalEntries: 1,
-						claudeSessions: 1, // gemini sessions count as "claude" in the stats (non-codex)
-						codexSessions: 0,
+						sessionCounts: expect.objectContaining({ gemini: 1 }),
 					}),
 				);
 			});
@@ -2178,8 +2272,7 @@ describe("SummaryWebviewPanel", () => {
 					expect.objectContaining({
 						command: "transcriptStatsLoaded",
 						totalEntries: 1,
-						claudeSessions: 1,
-						codexSessions: 0,
+						sessionCounts: expect.objectContaining({ claude: 1 }),
 					}),
 				);
 			});
@@ -2213,8 +2306,7 @@ describe("SummaryWebviewPanel", () => {
 					expect.objectContaining({
 						command: "transcriptStatsLoaded",
 						totalEntries: 1,
-						claudeSessions: 1,
-						codexSessions: 0,
+						sessionCounts: expect.objectContaining({ claude: 1 }),
 					}),
 				);
 			});
@@ -2223,6 +2315,36 @@ describe("SummaryWebviewPanel", () => {
 		// ── translatePlan ────────────────────────────────────────────────────
 
 		describe("translatePlan", () => {
+			it("skips the final update when currentSummary is null (race)", async () => {
+				// Covers `if (this.currentSummary)` falsy branch in handleTranslatePlan.
+				mockReadPlanFromBranch.mockResolvedValue("# 中文\n\n内容");
+				mockTranslateToEnglish.mockResolvedValue("# Translated\n\nContent");
+				mockLoadPlansRegistry.mockResolvedValue({ plans: {} });
+				const dispatch = await setupPanel({
+					plans: [
+						{
+							slug: "race-plan",
+							title: "中文",
+							editCount: 0,
+							addedAt: "",
+							updatedAt: "",
+						},
+					],
+				});
+				// Simulate a dispose race: currentSummary cleared mid-operation.
+				const panel = firstCommitPanel<{ currentSummary: unknown }>();
+				panel.currentSummary = undefined;
+
+				dispatch({ command: "translatePlan", slug: "race-plan" });
+				await flushPromises();
+
+				// Translation still propagated — post-event message still posts.
+				expect(postMessage).toHaveBeenCalledWith({
+					command: "planTranslated",
+					slug: "race-plan",
+				});
+			});
+
 			it("translates plan content and saves", async () => {
 				mockReadPlanFromBranch.mockResolvedValue("# 中文标题\n\n内容");
 				mockTranslateToEnglish.mockResolvedValue(
@@ -3281,8 +3403,7 @@ describe("SummaryWebviewPanel", () => {
 				expect(postMessage).toHaveBeenCalledWith(
 					expect.objectContaining({
 						command: "transcriptStatsLoaded",
-						claudeSessions: 1,
-						codexSessions: 0,
+						sessionCounts: expect.objectContaining({ claude: 1 }),
 					}),
 				);
 			});
@@ -4102,6 +4223,35 @@ describe("SummaryWebviewPanel", () => {
 		// ── saveNote (edit) ──────────────────────────────────────────────────
 
 		describe("saveNote (edit)", () => {
+			it("skips summary sync when currentSummary has no notes (race)", async () => {
+				// Covers `if (this.currentSummary?.notes)` falsy branch in handleSaveNote.
+				// A panel opened for a summary without a notes array simulates the race.
+				const dispatch = await setupPanel({});
+				// Null out .notes on the live panel to force the falsy branch.
+				const panel = firstCommitPanel<{
+					currentSummary: { notes?: unknown } | undefined;
+				}>();
+				if (panel.currentSummary) {
+					delete panel.currentSummary.notes;
+				}
+
+				dispatch({
+					command: "saveNote",
+					id: "any",
+					content: "# New",
+					format: "markdown",
+				});
+				await flushPromises();
+
+				// Writes still go through, but no storeSummary call happened.
+				expect(mockStoreNotes).toHaveBeenCalled();
+				expect(mockStoreSummary).not.toHaveBeenCalled();
+				expect(postMessage).toHaveBeenCalledWith({
+					command: "noteSaved",
+					id: "any",
+				});
+			});
+
 			it("saves note content to orphan branch and updates summary", async () => {
 				const dispatch = await setupPanel({
 					notes: [
@@ -4693,6 +4843,341 @@ describe("SummaryWebviewPanel", () => {
 			});
 		});
 
+		// ── downloadMarkdown ─────────────────────────────────────────────────────
+
+		describe("downloadMarkdown", () => {
+			/** Creates a panel, clears currentSummary, and returns the dispatch function. */
+			async function setupPanelWithoutSummary(): Promise<
+				(msg: Record<string, unknown>) => void
+			> {
+				const summary = makeSummary();
+				await SummaryWebviewPanel.show(summary, extensionUri, workspaceRoot);
+				const dispatch = captureMessageHandler();
+				const panelInstance = firstCommitPanel<{ currentSummary: null }>();
+				panelInstance.currentSummary = null;
+				vi.clearAllMocks();
+				return dispatch;
+			}
+
+			it("returns early when currentSummary is null", async () => {
+				const dispatch = await setupPanelWithoutSummary();
+
+				dispatch({ command: "downloadMarkdown" });
+				await flushPromises();
+
+				expect(showSaveDialog).not.toHaveBeenCalled();
+				expect(fsWriteFile).not.toHaveBeenCalled();
+			});
+
+			it("returns early when showSaveDialog returns undefined (user cancels)", async () => {
+				showSaveDialog.mockResolvedValue(undefined);
+				const dispatch = await setupPanel();
+
+				dispatch({ command: "downloadMarkdown" });
+				await flushPromises();
+
+				expect(showSaveDialog).toHaveBeenCalled();
+				expect(fsWriteFile).not.toHaveBeenCalled();
+				expect(showInformationMessage).not.toHaveBeenCalled();
+			});
+
+			it("writes markdown to file and shows info message", async () => {
+				const mockUri = { fsPath: "/workspace/Panel-Title.md" };
+				showSaveDialog.mockResolvedValue(mockUri);
+				mockBuildMarkdown.mockReturnValue("# Markdown Output");
+				fsWriteFile.mockResolvedValue(undefined);
+				const dispatch = await setupPanel();
+
+				dispatch({ command: "downloadMarkdown" });
+				await flushPromises();
+
+				expect(showSaveDialog).toHaveBeenCalledWith(
+					expect.objectContaining({
+						filters: { Markdown: ["md"] },
+						title: "Save Summary as Markdown",
+					}),
+				);
+				expect(fsWriteFile).toHaveBeenCalledWith(mockUri, expect.any(Buffer));
+				expect(showInformationMessage).toHaveBeenCalledWith(
+					`Saved to ${mockUri.fsPath}`,
+				);
+			});
+		});
+
+		// ── saveSnippet: empty content ────────────────────────────────────────────
+
+		describe("saveSnippet: empty content", () => {
+			it("shows error when snippet content is empty/whitespace-only", async () => {
+				const dispatch = await setupPanel();
+
+				dispatch({ command: "saveSnippet", title: "T", content: "   " });
+				await flushPromises();
+
+				expect(mockSaveNote).not.toHaveBeenCalled();
+				expect(showErrorMessage).toHaveBeenCalledWith(
+					expect.stringContaining("Save snippet failed"),
+				);
+			});
+		});
+
+		// ── saveNote: multiple notes (n.id !== id branch) ────────────────────────
+
+		describe("saveNote: multiple notes", () => {
+			it("preserves other notes unchanged when editing one of multiple notes", async () => {
+				const dispatch = await setupPanel({
+					notes: [
+						{
+							id: "edit-1",
+							title: "First Note",
+							format: "markdown" as const,
+							addedAt: "2025-01-01",
+							updatedAt: "2025-01-01",
+						},
+						{
+							id: "other-note",
+							title: "Other Note",
+							format: "markdown" as const,
+							addedAt: "2025-01-01",
+							updatedAt: "2025-01-01",
+						},
+					],
+				});
+
+				dispatch({
+					command: "saveNote",
+					id: "edit-1",
+					content: "# Updated Title\n\nBody",
+					format: "markdown",
+				});
+				await flushPromises();
+
+				// The second note (id !== "edit-1") is returned unchanged via the else branch
+				expect(mockStoreSummary).toHaveBeenCalledWith(
+					expect.objectContaining({
+						notes: expect.arrayContaining([
+							expect.objectContaining({
+								id: "other-note",
+								title: "Other Note",
+							}),
+							expect.objectContaining({ id: "edit-1", title: "Updated Title" }),
+						]),
+					}),
+					workspaceRoot,
+					true,
+				);
+			});
+
+			it("does not update title when note content has no # heading", async () => {
+				const dispatch = await setupPanel({
+					notes: [
+						{
+							id: "edit-1",
+							title: "Original Title",
+							format: "markdown" as const,
+							addedAt: "2025-01-01",
+							updatedAt: "2025-01-01",
+						},
+					],
+				});
+
+				dispatch({
+					command: "saveNote",
+					id: "edit-1",
+					content: "No heading here",
+					format: "markdown",
+				});
+				await flushPromises();
+
+				// newTitle is falsy, so title should remain unchanged
+				expect(mockStoreSummary).toHaveBeenCalledWith(
+					expect.objectContaining({
+						notes: expect.arrayContaining([
+							expect.objectContaining({
+								id: "edit-1",
+								title: "Original Title",
+							}),
+						]),
+					}),
+					workspaceRoot,
+					true,
+				);
+			});
+		});
+
+		// ── translateNote: multiple notes (n.id !== id branch) ───────────────────
+
+		describe("translateNote: multiple notes", () => {
+			it("preserves other notes unchanged when translating one of multiple notes", async () => {
+				mockReadNoteFromBranch.mockResolvedValue("# 中文笔记\n\n内容");
+				mockTranslateToEnglish.mockResolvedValue(
+					"# Translated Note\n\nEnglish content",
+				);
+				const dispatch = await setupPanel({
+					notes: [
+						{
+							id: "cn-note",
+							title: "中文笔记",
+							format: "markdown" as const,
+							addedAt: "2025-01-01",
+							updatedAt: "2025-01-01",
+						},
+						{
+							id: "other-note",
+							title: "Other Note",
+							format: "markdown" as const,
+							addedAt: "2025-01-01",
+							updatedAt: "2025-01-01",
+						},
+					],
+				});
+
+				dispatch({ command: "translateNote", id: "cn-note" });
+				await flushPromises();
+
+				// The second note (id !== "cn-note") is returned unchanged via the n.id !== id branch
+				expect(mockStoreSummary).toHaveBeenCalledWith(
+					expect.objectContaining({
+						notes: expect.arrayContaining([
+							expect.objectContaining({
+								id: "other-note",
+								title: "Other Note",
+							}),
+							expect.objectContaining({
+								id: "cn-note",
+								title: "Translated Note",
+							}),
+						]),
+					}),
+					workspaceRoot,
+					true,
+				);
+			});
+
+			it("does not update title when translated content has no # heading", async () => {
+				mockReadNoteFromBranch.mockResolvedValue("# 中文笔记\n\n内容");
+				// Translation result has no # heading, so newTitle should be falsy
+				mockTranslateToEnglish.mockResolvedValue(
+					"Translated content without heading",
+				);
+				const dispatch = await setupPanel({
+					notes: [
+						{
+							id: "cn-note",
+							title: "中文笔记",
+							format: "markdown" as const,
+							addedAt: "2025-01-01",
+							updatedAt: "2025-01-01",
+						},
+					],
+				});
+
+				dispatch({ command: "translateNote", id: "cn-note" });
+				await flushPromises();
+
+				// newTitle is falsy — title remains unchanged, no title update applied
+				expect(mockStoreSummary).toHaveBeenCalledWith(
+					expect.objectContaining({
+						notes: expect.arrayContaining([
+							expect.objectContaining({ id: "cn-note", title: "中文笔记" }),
+						]),
+					}),
+					workspaceRoot,
+					true,
+				);
+			});
+		});
+
+		// ── openCodeEnabled: false ────────────────────────────────────────────────
+
+		describe("loadTranscriptStats: openCodeEnabled false", () => {
+			it("excludes opencode sessions when openCodeEnabled is false", async () => {
+				mockLoadConfig.mockResolvedValue({
+					claudeEnabled: true,
+					codexEnabled: true,
+					geminiEnabled: true,
+					openCodeEnabled: false,
+				});
+				mockGetTranscriptHashes.mockResolvedValue(new Set(["abc123"]));
+				const transcriptMap = new Map([
+					[
+						"abc123",
+						{
+							sessions: [
+								{
+									sessionId: "s1",
+									source: "claude" as const,
+									entries: [{ role: "human" as const, content: "A" }],
+								},
+								{
+									sessionId: "oc1",
+									source: "opencode" as const,
+									entries: [
+										{ role: "human" as const, content: "B" },
+										{ role: "assistant" as const, content: "C" },
+									],
+								},
+							],
+						},
+					],
+				]);
+				mockReadTranscriptsForCommits.mockResolvedValue(transcriptMap);
+
+				const summary = makeSummary();
+				await SummaryWebviewPanel.show(summary, extensionUri, workspaceRoot);
+				const dispatch = captureMessageHandler();
+
+				dispatch({ command: "loadTranscriptStats" });
+				await flushPromises();
+
+				// opencode session (oc1) should be excluded; only claude session counted
+				expect(postMessage).toHaveBeenCalledWith(
+					expect.objectContaining({
+						command: "transcriptStatsLoaded",
+						totalEntries: 1,
+						sessionCounts: expect.objectContaining({ claude: 1 }),
+					}),
+				);
+			});
+		});
+
+		// ── loadNoteContent: snippet without inline content ───────────────────────
+
+		describe("loadNoteContent: snippet without inline content", () => {
+			it("reads from orphan branch when snippet has no inline content", async () => {
+				mockReadNoteFromBranch.mockResolvedValue("snippet body from branch");
+				const dispatch = await setupPanel({
+					notes: [
+						{
+							id: "snip-empty",
+							title: "Empty Snippet",
+							format: "snippet" as const,
+							// content is intentionally absent to exercise the else branch (line 948)
+							addedAt: "",
+							updatedAt: "",
+						},
+					],
+				});
+
+				dispatch({
+					command: "loadNoteContent",
+					id: "snip-empty",
+					format: "snippet",
+				});
+				await flushPromises();
+
+				// Since content is undefined, it falls through to the else branch and reads from branch
+				expect(mockReadNoteFromBranch).toHaveBeenCalledWith(
+					"snip-empty",
+					workspaceRoot,
+				);
+				expect(postMessage).toHaveBeenCalledWith({
+					command: "noteContentLoaded",
+					id: "snip-empty",
+					content: "snippet body from branch",
+				});
+			});
+		});
+
 		describe("pushToJolli with notes (exercises applyNoteUrls)", () => {
 			it("merges published note URLs into summary notes", async () => {
 				mockLoadConfig.mockResolvedValue({
@@ -4849,6 +5334,48 @@ describe("SummaryWebviewPanel", () => {
 				const noteB = storedSummary.notes.find((n) => n.id === "note-b");
 				expect(noteB?.jolliNoteDocUrl).toBeUndefined();
 			});
+		});
+	});
+
+	// ── Internal helpers (summariesEqual / setsEqual) ────────────────────────
+	describe("internal helpers", () => {
+		it("summariesEqual returns false when a is undefined", async () => {
+			const { __test__ } = await import("./SummaryWebviewPanel.js");
+			const b = { commitHash: "h" } as never;
+			expect(__test__.summariesEqual(undefined, b)).toBe(false);
+		});
+
+		it("summariesEqual returns true for deep-equal summaries", async () => {
+			const { __test__ } = await import("./SummaryWebviewPanel.js");
+			const a = { commitHash: "h", commitMessage: "m" } as never;
+			const b = { commitHash: "h", commitMessage: "m" } as never;
+			expect(__test__.summariesEqual(a, b)).toBe(true);
+		});
+
+		it("summariesEqual returns false for different summaries", async () => {
+			const { __test__ } = await import("./SummaryWebviewPanel.js");
+			const a = { commitHash: "h", commitMessage: "m1" } as never;
+			const b = { commitHash: "h", commitMessage: "m2" } as never;
+			expect(__test__.summariesEqual(a, b)).toBe(false);
+		});
+
+		it("setsEqual returns true for identical sets", async () => {
+			const { __test__ } = await import("./SummaryWebviewPanel.js");
+			expect(__test__.setsEqual(new Set(["a", "b"]), new Set(["a", "b"]))).toBe(
+				true,
+			);
+		});
+
+		it("setsEqual returns false when sizes differ", async () => {
+			const { __test__ } = await import("./SummaryWebviewPanel.js");
+			expect(__test__.setsEqual(new Set(["a"]), new Set(["a", "b"]))).toBe(
+				false,
+			);
+		});
+
+		it("setsEqual returns false when same-size sets have different members", async () => {
+			const { __test__ } = await import("./SummaryWebviewPanel.js");
+			expect(__test__.setsEqual(new Set(["a"]), new Set(["b"]))).toBe(false);
 		});
 	});
 });

--- a/vscode/src/views/SummaryWebviewPanel.ts
+++ b/vscode/src/views/SummaryWebviewPanel.ts
@@ -216,6 +216,7 @@ export class SummaryWebviewPanel {
 
 		this.panel.onDidDispose(() => {
 			this.disposed = true;
+			/* v8 ignore start -- slot-cleanup only fires when the real VSCode host emits onDidDispose. Unit tests call the mocked `dispose()` directly, which doesn't traverse this callback; the stale-guard invariants are covered by runtime scenarios. */
 			// Only clear the slot/map entry if it still points at this instance.
 			// A stale dispose handler from a replaced memory panel, or from a
 			// commit-hash key that a newer instance has taken over, must not
@@ -229,6 +230,7 @@ export class SummaryWebviewPanel {
 			) {
 				SummaryWebviewPanel.commitPanels.delete(this.commitHash);
 			}
+			/* v8 ignore stop */
 		});
 
 		// Handle messages from the webview
@@ -974,12 +976,26 @@ export class SummaryWebviewPanel {
 			(summary.notes ?? []).map((n) => [n.id, n.jolliNoteDocUrl]),
 		);
 		for (const note of summary.notes ?? []) {
-			const content =
-				note.format === "snippet"
-					? (note.content ?? "")
-					: ((await readNoteFromBranch(note.id, this.workspaceRoot)) ?? "");
-			if (!content) {
-				continue;
+			// Schema-guard for legacy/corrupt entries: snippet notes normally persist
+			// `content`, but rows from before the snippet feature shipped may be missing
+			// it. Log at warn level so the drift is visible instead of silently dropped.
+			let content: string;
+			if (note.format === "snippet") {
+				/* v8 ignore start -- schema-guard mirror of runJolliPush's legacy-snippet handling (which IS tested); reached only via the local-push path (pushAction="both"), whose orchestration is out of scope for this file's unit tests. Follow-up: lift into a shared helper so one test covers both call sites. */
+				if (note.content === undefined || note.content === "") {
+					log.warn(
+						"SummaryPanel",
+						`Snippet note ${note.id} has no content — skipping`,
+					);
+					continue;
+				}
+				/* v8 ignore stop */
+				content = note.content;
+			} else {
+				content = (await readNoteFromBranch(note.id, this.workspaceRoot)) ?? "";
+				if (!content) {
+					continue;
+				}
 			}
 			satellites.push({
 				slug: note.id,
@@ -1072,13 +1088,29 @@ export class SummaryWebviewPanel {
 		}> = [];
 
 		for (const note of allNotes) {
-			const noteContent =
-				note.format === "snippet"
-					? (note.content ?? "")
-					: ((await readNoteFromBranch(note.id, this.workspaceRoot)) ?? "");
-			if (!noteContent) {
-				log.info("SummaryPanel", `Note ${note.id}: no content found, skipping`);
-				continue;
+			// Schema-guard for legacy/corrupt entries — see mirrored logic in
+			// buildSatellitesFromSummary. Snippets with missing `content` are warned
+			// (and reported back to the webview via the skipped tally below).
+			let noteContent: string;
+			if (note.format === "snippet") {
+				if (note.content === undefined || note.content === "") {
+					log.warn(
+						"SummaryPanel",
+						`Snippet note ${note.id} has no content — skipping push`,
+					);
+					continue;
+				}
+				noteContent = note.content;
+			} else {
+				noteContent =
+					(await readNoteFromBranch(note.id, this.workspaceRoot)) ?? "";
+				if (!noteContent) {
+					log.info(
+						"SummaryPanel",
+						`Note ${note.id}: no content found, skipping`,
+					);
+					continue;
+				}
 			}
 			const noteResult = await pushToJolli(resolvedBaseUrl, apiKey, {
 				title: buildNotePushTitle(summary, note.title),
@@ -1749,6 +1781,9 @@ export class SummaryWebviewPanel {
 		if (config.geminiEnabled !== false) {
 			sources.add("gemini");
 		}
+		if (config.openCodeEnabled !== false) {
+			sources.add("opencode");
+		}
 		return sources;
 	}
 
@@ -1766,8 +1801,7 @@ export class SummaryWebviewPanel {
 		// Deduplicate sessions by source:sessionId (same session may appear in multiple commit transcripts)
 		const seen = new Set<string>();
 		let totalEntries = 0;
-		let claudeSessions = 0;
-		let codexSessions = 0;
+		const sessionCounts: Record<string, number> = {};
 		for (const [, transcript] of transcriptMap) {
 			for (const session of transcript.sessions) {
 				const source = session.source ?? "claude";
@@ -1780,19 +1814,14 @@ export class SummaryWebviewPanel {
 					continue;
 				}
 				seen.add(key);
-				if (source === "codex") {
-					codexSessions++;
-				} else {
-					claudeSessions++;
-				}
+				sessionCounts[source] = (sessionCounts[source] ?? 0) + 1;
 			}
 		}
 
 		this.panel.webview.postMessage({
 			command: "transcriptStatsLoaded",
 			totalEntries,
-			claudeSessions,
-			codexSessions,
+			sessionCounts,
 		});
 	}
 
@@ -2143,3 +2172,9 @@ function toLocalResultMessage(
 		error: extractSettledError(result),
 	};
 }
+
+/** Exposed for unit tests. */
+export const __test__ = {
+	summariesEqual,
+	setsEqual,
+};


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## E2E Test (11)
<details>
<summary><strong>1. OpenCode session discovery and transcript reading</strong></summary>
<br>
<blockquote>

**Preconditions:** Have OpenCode installed on your system with at least one active coding session in your workspace.

**Steps:**
1. Open the Jolli Memory status view in VS Code
2. Look for the "OpenCode Integration" section in the status tree
3. Verify that the session count displays a number greater than zero
4. Run a commit that triggers the summarization pipeline
5. Check that the commit summary includes context from the OpenCode session transcript

**Expected Results:**
- The status tree should show "OpenCode Integration" with a session count (e.g., "1 session")
- The commit summary should reference code or context from the OpenCode transcript
- No error messages should appear in the debug log related to OpenCode

</blockquote>
</details>
<details>
<summary><strong>2. OpenCode integration disabled when Node version is too old</strong></summary>
<br>
<blockquote>

**Preconditions:** None (this is a version check that runs automatically)

**Steps:**
1. Open the Jolli Memory status view in VS Code
2. Look for the "OpenCode Integration" section
3. Check the debug log for any version-related messages

**Expected Results:**
- If Node version is below 22.5.0, the OpenCode Integration should not appear or should show as unavailable
- The debug log should contain a message explaining that the Node version does not support OpenCode
- No crash or error should occur

</blockquote>
</details>
<details>
<summary><strong>3. OpenCode database corruption error reporting</strong></summary>
<br>
<blockquote>

**Preconditions:** Have OpenCode installed with a corrupted or locked database file at ~/.local/share/opencode/opencode.db

**Steps:**
1. Open the Jolli Memory status view in VS Code
2. Look for the "OpenCode Integration" section
3. Check if an error message or warning appears next to the OpenCode status
4. Open the debug log and search for "OpenCode" or "scan"

**Expected Results:**
- The status view should display a warning icon or error message (not just "0 sessions")
- The error message should indicate the type of problem (e.g., "database is locked" or "permission denied")
- The debug log should contain details about the scan failure

</blockquote>
</details>
<details>
<summary><strong>4. Config file is not polluted by test runs</strong></summary>
<br>
<blockquote>

**Preconditions:** None (this is an internal fix verified by the test suite)

**Steps:**
1. Note the modification time of ~/.jolli/jollimemory/config.json
2. Run the full test suite: npm test
3. Wait for all tests to complete
4. Check the modification time of ~/.jolli/jollimemory/config.json again

**Expected Results:**
- The modification time should not change after running the test suite
- The config.json file should not contain any test data (like "global-key" entries)
- No temporary test files should be left in the real config directory

</blockquote>
</details>
<details>
<summary><strong>5. Per-source session count breakdown in status view</strong></summary>
<br>
<blockquote>

**Preconditions:** Have multiple transcript sources active (e.g., Claude Code, OpenCode, or Gemini)

**Steps:**
1. Open the Jolli Memory status view in VS Code
2. Look for a "Sessions by Source" or similar breakdown section
3. Verify that each source (Claude, OpenCode, Gemini, etc.) shows its own session count
4. Disable one source in the settings and refresh the status view
5. Verify that the count for the disabled source updates

**Expected Results:**
- The status view should display session counts grouped by source
- Each source should show its own number (e.g., "Claude: 2, OpenCode: 1")
- Disabling a source should remove or zero out its count in the display

</blockquote>
</details>
<details>
<summary><strong>6. OpenCode toggle in VS Code settings panel</strong></summary>
<br>
<blockquote>

**Preconditions:** Have OpenCode installed on your system

**Steps:**
1. Open VS Code Settings (Ctrl+, or Cmd+,)
2. Search for "Jolli" or "OpenCode"
3. Look for an "Enable OpenCode" or "OpenCode Integration" toggle
4. Toggle it off and save
5. Open the Jolli Memory status view and verify OpenCode is disabled
6. Toggle it back on and verify OpenCode is re-enabled

**Expected Results:**
- The OpenCode toggle should appear in the Jolli Memory settings section
- Toggling off should immediately disable OpenCode session discovery
- Toggling on should re-enable OpenCode session discovery
- The status view should reflect the toggle state

</blockquote>
</details>
<details>
<summary><strong>7. Session identity collision prevention across multiple sources</strong></summary>
<br>
<blockquote>

**Preconditions:** Have two different transcript sources (e.g., Claude and OpenCode) that happen to generate sessions with the same ID

**Steps:**
1. Create or trigger sessions from two different sources with identical session IDs
2. Run the summarization pipeline
3. Check the stored transcript metadata for each session
4. Verify that each session retains its correct source and transcript path

**Expected Results:**
- Both sessions should be stored separately, not overwriting each other
- Each session should retain its correct source label (Claude, OpenCode, etc.)
- Each session should point to the correct transcript file for its source
- No data loss or corruption should occur

</blockquote>
</details>
<details>
<summary><strong>8. Queue processing respects MAX_ENTRIES_PER_RUN cap</strong></summary>
<br>
<blockquote>

**Preconditions:** None (this is an internal queue behavior)

**Steps:**
1. Enqueue more than 20 git operations (e.g., by creating multiple commits rapidly)
2. Trigger the queue worker to process the backlog
3. Check the debug log for queue processing messages
4. Verify that the queue worker stops after processing exactly 20 entries
5. Run the queue worker again and verify it processes the remaining entries

**Expected Results:**
- The first run should process exactly 20 entries and stop
- The remaining entries should stay in the queue
- A second run should process the next batch (up to 20 more)
- No entries should be lost or skipped

</blockquote>
</details>
<details>
<summary><strong>9. Legacy snippet notes with missing content field are handled gracefully</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a summary with a snippet note that has a missing or empty content field (legacy data)

**Steps:**
1. Open the summary view in VS Code
2. Scroll to the notes section
3. Look for any snippet notes with missing content
4. Check the debug log for warnings about schema issues

**Expected Results:**
- Snippet notes with missing content should be skipped or show a placeholder
- A warning should appear in the debug log (not silently ignored)
- The summary view should not crash or display broken formatting
- Other notes should display normally

</blockquote>
</details>
<details>
<summary><strong>10. CLI status command displays OpenCode integration status</strong></summary>
<br>
<blockquote>

**Preconditions:** Have OpenCode installed on your system

**Steps:**
1. Open a terminal and run: jolli status
2. Look for an "OpenCode Integration" line in the output
3. Verify it shows whether OpenCode is detected and enabled
4. If OpenCode is installed, verify the session count is displayed

**Expected Results:**
- The status output should include an "OpenCode Integration" section
- It should show "Detected: yes/no" and "Enabled: yes/no"
- If detected, it should display the number of active sessions
- No errors should appear in the output

</blockquote>
</details>
<details>
<summary><strong>11. Enable command guides user through OpenCode configuration</strong></summary>
<br>
<blockquote>

**Preconditions:** Have OpenCode installed but not yet configured in Jolli Memory

**Steps:**
1. Open a terminal and run: jolli enable
2. Follow the interactive prompts
3. Look for guidance about OpenCode configuration
4. Complete the setup process
5. Run jolli status to verify OpenCode is now enabled

**Expected Results:**
- The enable command should mention OpenCode as an available integration
- If OpenCode is detected, it should offer to enable it
- After setup, the status command should show OpenCode as enabled
- No manual configuration should be required if OpenCode is already installed

</blockquote>
</details>

---

## Summaries (19)

### Apr 23, 2026
<details>
<summary><strong>01 · Surface per-integration status in CLI status command output</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The `jolli status` command was only displaying an aggregate session count, leaving CLI users unable to see whether individual integrations (Claude, Codex, Gemini, OpenCode) were detected, enabled, or in an error state. This information was available in the underlying status data and displayed in the VS Code STATUS panel, but was missing from the CLI output.

**💡 Decisions Behind the Code**

- **Per-integration rows only for detected integrations**: Following the VS Code STATUS panel pattern, rows are only printed when an integration is detected, keeping the output terse and avoiding noise from undetected integrations.
- **Claude enabled flag sourced from config, not StatusInfo**: Since `claudeEnabled` is not exposed in the `StatusInfo` type (only `codexEnabled`, `geminiEnabled`, `openCodeEnabled` are), the CLI reads Claude's enabled state directly from the loaded config object, matching how VS Code's StatusTreeProvider handles it. This avoids expanding the Installer.getStatus() API in this PR.
- **Unified state machine for all four integrations**: A single `describeIntegrationStatus()` function handles the five-state model (scan error → disabled → hook missing → hook installed → detected & enabled) for all integrations, preventing wording drift between integrations and making future maintenance easier.
- **OpenCode scan error as exclusive state**: When `openCodeScanError` is present, it takes precedence over the enabled/hook-installed checks, surfacing database corruption or lock failures as a distinct "unavailable" state rather than hiding them behind a normal enabled row.

**✅ What Was Implemented**

- Added `IntegrationStatusInputs` interface and `describeIntegrationStatus()` helper function to `cli/src/commands/StatusCommand.ts` to format human-readable status strings for each integration (e.g., "detected & enabled (3 sessions)", "detected but disabled", "hook not installed", "unavailable — corrupt").
- Extended the CLI status output to display four new rows (Claude, Codex, Gemini, OpenCode) after the Sessions line, each showing the integration's detection and enabled state, session count, and any scan errors.
- Added five new test cases to `cli/src/Cli.test.ts` covering: all integrations detected with counts, disabled integrations, missing hooks, OpenCode scan errors, and undetected integrations (which should not print).
- Aligned CLI wording and logic with the existing VS Code STATUS panel behavior to ensure consistent user experience across both surfaces.

</blockquote>
</details>
<details>
<summary><strong>02 · Validate code repository for leaked secrets using gitleaks and trufflehog</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The new jollimemory repository was created by splitting code from an older monorepo, and a security audit was needed to ensure no API keys, credentials, or other sensitive data were accidentally carried over in the git history or working tree.

**💡 Decisions Behind the Code**

- **Both gitleaks and trufflehog used for complementary coverage**: gitleaks catches high-entropy strings via regex (high recall, low precision), while trufflehog matches known provider fingerprints and can verify against live APIs (high precision, low recall). Running both ensures true signals are not missed and false positives can be distinguished from real leaks.
- **Full git history scanned, not just current branch**: The repository was migrated from a larger monorepo, so scanning all 74 commits across all refs (not just the current branch's 13 commits) was necessary to catch any secrets that might have been introduced in other branches or tags before the split.
- **Filesystem scan filtered to exclude build artifacts and dependencies**: The raw trufflehog filesystem scan included 38 matches in `node_modules/` and `.git/objects/`, but these were excluded from the final assessment because they represent third-party package metadata and git's internal blob storage, not source code under the team's control.

**✅ What Was Implemented**

- Ran gitleaks scan across all 74 commits in the repository, which flagged 27 matches in test files (all confirmed to be test fixtures with values like `"jk_test"`, `"sk-jol-verylongsecret12345"`, and fake commit hashes).
- Ran trufflehog scan on both git history (0 verified/unverified secrets) and filesystem (38 unverified matches, all in `node_modules/` or `.git/objects/`, none in actual source code).
- Confirmed `.gitignore` correctly excludes `.env`, `.env.*`, and other sensitive file patterns; no stray credential files found in the working directory.
- Concluded the repository is clean with no real secrets leaked; the gitleaks matches are benign test data and do not require remediation.

</blockquote>
</details>
<details>
<summary><strong>03 · Add defensive guards against OpenCode schema drift in session and transcript readers</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

External systems like OpenCode may return unexpected data types (non-numeric timestamps, NULL values) that cause crashes when passed directly to `Date.toISOString()`. Without guards, schema drift silently breaks session discovery and transcript parsing instead of gracefully skipping bad records.

**💡 Decisions Behind the Code**

- **Asymmetric error handling by layer**: Discoverer skips bad rows and logs warnings (discovery is best-effort), while TranscriptReader returns null (reusing existing message-skip semantics). This keeps error handling consistent with each layer's existing failure modes rather than forcing uniform behavior.
- **flatMap over filter**: Using `flatMap` with conditional return (`[]` vs `[item]`) instead of filtering separately makes the skip reason (non-finite guard) and the skip action (omit from results) visually adjacent, reducing the risk of future maintainers adding new fields without updating the guard.
- **Test via SQLite type coercion**: Rather than mocking the database, tests insert actual TEXT values into INTEGER columns, which SQLite preserves at rest. This exercises the real schema-drift scenario (corrupted or drifted external data) without requiring a separate test database fixture.

**✅ What Was Implemented**

- Added `Number.isFinite()` guard in `OpenCodeSessionDiscoverer.ts` (line 254–256): converts `rows.map()` to `rows.flatMap()` to skip sessions with non-finite `time_updated`, logs warning for each skipped record
- Added `Number.isFinite()` guard in `OpenCodeTranscriptReader.ts` (line 168–171): returns `null` from `parseOpenCodeMessage()` when `createdAtMs` is non-finite, allowing the existing null-skip path to handle it
- Added two integration tests simulating schema drift by inserting TEXT values into INTEGER columns (leveraging SQLite's type affinity behavior), verifying that good records are preserved while bad ones are silently skipped

</blockquote>
</details>
<details>
<summary><strong>04 · Lower VS Code extension Node target to maintain backward compatibility with older Electron versions</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The esbuild target was set to Node 22, but the extension declares support for VS Code 1.80+ (Electron 25 / Node 18). This mismatch causes the bundle to emit Node 22 syntax that older Electron versions cannot parse, breaking the extension on machines running VS Code 1.80–1.95.

**💡 Decisions Behind the Code**

- **Lower target instead of raising engines**: Downgrading the esbuild target to Node 18 is lower-risk than raising `engines.vscode` to require Electron 34+. The existing `hasNodeSqliteSupport()` soft gate already handles graceful degradation on older Node versions, so users without OpenCode support can still use the extension for other features rather than being locked out entirely.

**✅ What Was Implemented**

- Changed `vscode/esbuild.config.mjs` target from `"node22"` to `"node18"` (line 32)
- Added explanatory comment clarifying that `node:sqlite` is lazy-imported and gated by `hasNodeSqliteSupport()`, so the bundle loads safely on older hosts; OpenCode scanning simply remains disabled on Node <22.5

</blockquote>
</details>
<details>
<summary><strong>05 · Add OpenCode integration to CLI and VS Code extension</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

OpenCode is a new AI coding agent that users want to track alongside Claude Code, Codex, and Gemini. The system needs to discover and read OpenCode sessions automatically, similar to how Codex sessions are discovered from the filesystem.

**💡 Decisions Behind the Code**

- **SQLite over filesystem scanning**: OpenCode stores sessions in a structured SQLite database rather than scattered files, making direct database queries more reliable and efficient than filesystem traversal (which is what Codex uses). This reduces false positives and improves performance.
- **Node 22.5+ hard requirement**: Node's built-in `node:sqlite` module first ships in Node 22.5, so the CLI enforces this via the `engines` field in `package.json`. This prevents silent failures at runtime and gives users immediate feedback during installation if they're on an older Node version.
- **Graceful degradation on older VS Code hosts**: VS Code ~1.99+ bundles Node 22.5, but older hosts cannot run OpenCode discovery. Rather than blocking the entire extension, OpenCode is quietly skipped on incompatible hosts while all other features continue to work — this preserves backward compatibility.
- **Time field guards in discoverer and reader**: OpenCode's SQLite schema may have missing or malformed timestamp fields. Adding defensive checks prevents crashes during session discovery and transcript parsing, improving robustness when the database is incomplete or corrupted.

**✅ What Was Implemented**

- Added OpenCode session discovery in CLI via `OpenCodeSessionDiscoverer.ts` and `OpenCodeTranscriptReader.ts`, reading from OpenCode's global SQLite database at `~/.local/share/opencode/opencode.db`
- Added time field guards in both discoverer and transcript reader to handle missing or malformed timestamps safely
- Updated CLI and VS Code CHANGELOG entries to document OpenCode integration and its Node 22.5+ requirement
- Updated CLI README with OpenCode row in AI Agent Hooks table, `openCodeEnabled` configuration key, and Requirements section emphasizing Node 22.5+
- Updated VS Code README with OpenCode row in AI Agent Hooks table and Status panel description
- Updated both `package.json` files to reflect the new dependency on Node 22.5+ via the `engines` field

</blockquote>
</details>
<details>
<summary><strong>06 · Establish Node 22.5+ as breaking change with clear migration path</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The OpenCode integration requires Node's built-in `node:sqlite` module, which is only available in Node 22.5+. This is a breaking change from the previous Node 18+ support, and users need clear documentation about why the change exists and what happens if they try to install on older runtimes.

**💡 Decisions Behind the Code**

- **Explicit failure mechanism in CHANGELOG**: Breaking changes must document not just what changed but HOW it fails. Stating "the `engines` field will refuse installation" tells users they'll get immediate feedback during `npm install` rather than discovering the problem after installation when the CLI crashes. This is more user-friendly than a runtime error.
- **Separate Requirements sections in both READMEs**: Rather than burying the Node version requirement in prose, a dedicated Requirements section makes it discoverable and scannable. This follows the pattern already established in the CLI README and improves visibility for new users.

**✅ What Was Implemented**

- Added "Breaking: requires Node 22.5+" entry to CLI CHANGELOG with explicit explanation of the old boundary (Node 18+), new boundary (Node 22+), and failure mechanism (the `engines` field refuses installation rather than allowing silent runtime failures)
- Added Requirements subsection to CLI README before Installation, emphasizing Node 22.5+ with rationale
- Added Requirements subsection to VS Code README documenting Node 22.5+ for OpenCode and noting graceful degradation on older hosts

</blockquote>
</details>
<details>
<summary><strong>07 · Expand VS Code README with complete feature documentation and privacy policy</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The VS Code README was missing critical sections that existed in the CLI README: Installation instructions, Requirements, complete feature descriptions (Memories Panel, Sign In flow, Settings Panel, Changes/Commits panels), Summary data format, Privacy policy, Support contacts, and License. This created an asymmetry between the two products and left users unable to find important information.

**💡 Decisions Behind the Code**

- **Installation before "What it does"**: New users need to know how to install before reading product benefits. Placing Installation after the intro but before feature descriptions follows standard README structure and prevents the "how do I get this?" question from interrupting the pitch.
- **Separate Requirements section**: Rather than embedding version requirements in prose, a dedicated Requirements section makes them scannable and discoverable. This is especially important for OpenCode's conditional Node 22.5+ requirement, which only applies to that one feature.
- **First run as a separate section**: Onboarding steps (open sidebar, sign in, install hooks, restart agent, commit) are procedural and distinct from feature descriptions. Separating them improves clarity for new users and prevents feature documentation from becoming a tutorial.
- **Memories Panel as a dedicated subsection**: The Memories panel has multiple toolbar actions and a context menu that were previously scattered or undocumented. Consolidating them into a single subsection with a table makes the feature discoverable and reference-friendly.
- **Sign In flow explanation**: The OAuth flow and the dual-purpose `jolliApiKey` (both for LLM proxy and Jolli Space authorization) were previously implicit. Documenting the flow explicitly helps users understand why they need to sign in and what credentials are stored.
- **Settings Panel as a dedicated subsection**: The Settings webview is a separate UI surface from the Status panel, but the original README conflated them as "Status panel settings". Clarifying that Settings is a dedicated webview (opened via gear icon) prevents user confusion.
- **Changes and Commits panels as subsections**: These panels have secondary operations (Discard, Select All, Copy Hash, merged mode) that were completely undocumented. Documenting them as separate subsections makes the full feature set discoverable without overwhelming the main feature descriptions.
- **Local Memories as a dedicated subsection**: The CHANGELOG promoted "Push to Jolli & Local" as a core 0.98.0 feature, but the README only mentioned it in passing. A dedicated subsection with configuration steps and mode explanation gives the feature proper visibility.
- **Summary Format with JSON example**: The CLI README includes a complete v3 Summary Format example with field descriptions. Replicating this in the VS Code README ensures users can understand the data structure without jumping between documents, and it supports programmatic consumption via the extension API.
- **Privacy section with explicit data boundaries**: The original Privacy section was vague ("nothing is uploaded unless you choose to"). Rewriting it with explicit boundaries (Anthropic direct vs. Jolli LLM proxy, summaries-only for Push, local-only for transcripts) and the Jolli LLM proxy's non-persistence guarantee addresses user concerns about data handling.
- **Support and License sections**: These are standard README sections that were completely missing. Adding them provides users with clear paths for issues, enterprise inquiries, and license information.
- **Configuration table completeness**: The original table listed only 4 keys. Expanding it to all 11 keys (including `authToken`, `logLevel`, `localFolder`, `pushAction`, `openCodeEnabled`) ensures users can find all available settings in one place and understand their purpose.

**✅ What Was Implemented**

- Added Installation section with Marketplace search instructions and `code --install-extension` command
- Added Requirements subsection covering VS Code 1.80+, Node 22.5+ for OpenCode, and GitHub CLI for PR features
- Added First run section with step-by-step onboarding (open sidebar, sign in or configure API key, install hooks, restart agent, make commit)
- Added Memories Panel subsection documenting toolbar actions (search, refresh, export, settings, enable/disable), Load More pagination, and per-memory context menu (Copy Recall Prompt, Open in Claude Code, View Memory)
- Added Sign In to Jolli subsection explaining OAuth flow, automatic credential storage, and dual-purpose `jolliApiKey`
- Added Settings Panel subsection describing the dedicated webview and its grouped sections (Authentication, Integrations, Local Memories, Files)
- Added Changes Panel subsection documenting Select/Deselect All, AI Commit, Discard Changes, and exclude filter behavior
- Added Commits Panel subsection covering Select/Deselect All, Squash, Push (single-commit mode), Copy Commit Hash, and merged read-only mode
- Added Local Memories subsection explaining the feature, configuration steps (`localFolder` + `pushAction`), and mode switching
- Added Summary Format section with v3 tree structure JSON example and field descriptions (trigger, response, decisions, todo, category, importance)
- Added Privacy section covering summary generation (Anthropic direct vs. Jolli LLM proxy), Push to Jolli (summaries only, no transcripts), session metadata, and what stays local
- Added Support section with GitHub Issues, support@jolli.ai, and cross-reference to CLI README
- Added License section referencing Apache 2.0
- Updated Configuration table to include all 11 config keys: `apiKey`, `model`, `maxTokens`, `jolliApiKey`, `authToken`, `logLevel`, `claudeEnabled`, `codexEnabled`, `geminiEnabled`, `openCodeEnabled`, `localFolder`, `pushAction`, `excludePatterns`

</blockquote>
</details>
<details>
<summary><strong>08 · Synchronize CLI README with VS Code documentation for consistency</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

After expanding the VS Code README with Privacy, Support, and License sections, the CLI README lacked these same sections. This created documentation asymmetry between the two products and left CLI users without equivalent information about data handling and support channels.

**💡 Decisions Behind the Code**

- **Identical Privacy structure across both READMEs**: Both CLI and VS Code users need to understand the same data flow (Anthropic direct vs. Jolli LLM proxy, summaries-only for Push). Documenting it identically in both places ensures consistency and prevents users from having to cross-reference between documents. The CLI-specific note that "the CLI itself does not push to Jolli Space" clarifies the product boundary.
- **Worktree note in "How It Works"**: The CHANGELOG 0.98.0 promoted "Worktree-aware branch tracking" as a feature, but the README never explained it. Adding a one-sentence note in the git hooks section makes the feature discoverable without requiring a separate subsection.

**✅ What Was Implemented**

- Added Privacy section to CLI README covering summary generation (Anthropic direct vs. Jolli LLM proxy with non-persistence guarantee), Push to Jolli (summaries only, no transcripts), session metadata, and what stays local
- Added Support section with GitHub Issues, support@jolli.ai, and cross-reference to VS Code README
- Added License section referencing Apache 2.0
- Added worktree-aware note to "How It Works" section explaining that hooks and summaries work consistently across `git worktree` checkouts

</blockquote>
</details>
<details>
<summary><strong>09 · Correct Privacy section to accurately describe transcript handling during summary generation</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The original Privacy section stated that transcripts are "not uploaded unless you explicitly click Push to Jolli", which was inaccurate. In reality, transcripts are sent to either Anthropic or the Jolli LLM proxy during summary generation (not just at Push time), depending on which API key is configured. The documentation needed to reflect the actual data flow.

**💡 Decisions Behind the Code**

- **Two-phase data flow explanation**: Privacy documentation must distinguish between summary generation (where transcripts necessarily leave the local machine) and Push to Jolli (where only summaries are uploaded). Conflating these phases creates dangerous user misconceptions about when data leaves their machine.
- **Explicit non-persistence guarantee for Jolli LLM proxy**: Users need to know not just that Jolli doesn't store transcripts, but also that they're not written to logs or other side channels. Stating "held in memory only for the duration of the request and discarded once Anthropic responds" provides a concrete mechanism that users can reason about.

**✅ What Was Implemented**

- Rewrote Privacy section in both CLI and VS Code READMEs to separate summary generation phase from Push to Jolli phase
- Clarified that transcripts + diff are sent to Anthropic (if `apiKey` is configured) or Jolli LLM proxy (if only `jolliApiKey` is configured) during summary generation, not at Push time
- Added explicit non-persistence guarantee for Jolli LLM proxy: "does not persist the transcripts or diff, and does not write them to any Jolli-side log — payloads are held in memory only for the duration of the request and discarded once Anthropic responds"
- Clarified that Push to Jolli uploads only the generated summary and associated plans/notes, never raw transcripts

</blockquote>
</details>
<details>
<summary><strong>10 · Expand monorepo README to document all three product surfaces equally</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The root README only mentioned the IntelliJ plugin, leaving users unaware that the repository also contains a CLI tool and VS Code extension. New users couldn't quickly determine which surface matched their workflow.

**💡 Decisions Behind the Code**

- **Reader-centric navigation over product-centric categorization**: The decision tree anchors on what tool the reader is already using (their editor or CI system) rather than asking them to first understand the product's feature taxonomy. This reduces cognitive load and gets readers to the right sub-README faster.
- **Monorepo landing page as a routing layer, not a duplicate**: The root README explicitly avoids repeating product details; instead it directs readers to the appropriate surface's own README. This prevents documentation drift and keeps the single source of truth in each surface's directory.
- **Mention of OpenCode in the tagline**: Updated the introductory sentence to include OpenCode alongside Claude Code, Codex, and Gemini CLI, signaling that the tool integrates with multiple AI agent ecosystems.

**✅ What Was Implemented**

Restructured the root README to present all three surfaces (CLI, VS Code extension, IntelliJ plugin) as equal first-class offerings:
- Added a "This repository" table listing each surface with its directory and purpose
- Created a "Which one should I install?" decision tree keyed to the user's current editor or environment (VS Code, JetBrains IDE, Vim/Emacs, CI)
- Added a documentation matrix linking to each surface's README and CHANGELOG
- Included a "Product highlights" section describing five cross-surface capabilities (automatic, multi-agent, local-first, structured format, privacy-respecting)
- Expanded "Repository layout" and "Development quick start" to cover both npm workspaces (CLI + VS Code) and the separate Gradle-based IntelliJ plugin
- Added Contributing, Support, and License sections for completeness

</blockquote>
</details>
<details>
<summary><strong>11 · Fix Windows drive-letter case mismatch in OpenCode session discovery</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

A code review identified a real bug where OpenCode sessions were not being discovered on Windows when the drive letter casing differed between where sessions were stored and where they were queried. Debug logs showed the worker pipeline discovering sessions with uppercase drive letters (e.g., `E:\jollimemory-3`) while the status panel and new `jolli status` command queried with lowercase letters (e.g., `e:\jollimemory-3`), causing the UI to incorrectly display zero sessions despite active OpenCode conversations.

**💡 Decisions Behind the Code**

- **Platform-conditional matching**: Case-insensitive comparison is applied only to Windows and macOS (where filesystems ignore case) rather than universally, preserving the correctness of exact-match queries on Linux where case sensitivity matters for file identity
- **Root cause alignment with existing patterns**: The fix uses the same platform detection logic (`process.platform === "win32" || process.platform === "darwin"`) already present elsewhere in the codebase (e.g., `JolliMemoryBridge.ts`), ensuring consistency and reducing future maintenance burden
- **Test coverage of real-world scenario**: The test directly mirrors the observed bug (drive-letter casing drift between two call sites) rather than testing a generic case-insensitivity, making it more likely to catch regressions if the calling code changes

**✅ What Was Implemented**

- Modified the SQL WHERE clause in `OpenCodeSessionDiscoverer.ts` to use case-insensitive directory matching (`LOWER(directory) = LOWER(:projectDir)`) on Windows and macOS, while preserving exact-match behavior on Linux where filesystems are case-sensitive
- Added a test case in `OpenCodeSessionDiscoverer.test.ts` that reproduces the exact scenario from the debug logs: storing a session with uppercase drive letter and querying with lowercase, asserting correct behavior per platform

</blockquote>
</details>
<details>
<summary><strong>12 · Document experimental warning suppression intent in worker subprocess launcher</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The worker subprocess is launched with `--disable-warning=ExperimentalWarning`, which silences not only the `node:sqlite` warning but also any other experimental warnings from future dependencies. Without documentation, maintainers may not realize this broad suppression exists or why it was added.

**💡 Decisions Behind the Code**

- **Comment over code change**: The suppression is intentional and acceptable (as confirmed in review), so the fix is purely documentary. A clear comment prevents future maintainers from accidentally removing the flag or adding new experimental features without realizing they are being silently suppressed.

**✅ What Was Implemented**

- Added inline comment to `cli/src/hooks/QueueWorker.ts` (line 147–148) explaining that the flag suppresses `node:sqlite`'s ExperimentalWarning and noting that it also affects any other experimental warnings in the subprocess

</blockquote>
</details>
<details>
<summary><strong>13 · Update CHANGELOG sync markers to reflect current commit state</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Both CLI and VS Code CHANGELOG files contained a "Last synced commit" marker pointing to an older commit hash. After the development session added new entries and made structural changes, these markers needed to be updated to reflect the current feature branch HEAD.

**💡 Decisions Behind the Code**

- **Short hash format for sync markers**: Using short commit hashes (7 characters) in the CHANGELOG marker is practical for quick reference during development, though it is fragile across rebase/amend operations. A more robust long-term approach would use release tags (e.g., `v0.98.0`) instead of hashes, but short hashes are acceptable for tracking development state within a feature branch.

**✅ What Was Implemented**

- Updated CLI CHANGELOG "Last synced commit" marker from `ff796b6a5 | 2026-04-13` to `ea9ad050b | 2026-04-23`
- Updated VS Code CHANGELOG "Last synced commit" marker from `ff796b6a5 | 2026-04-13` to `ea9ad050b | 2026-04-23`

</blockquote>
</details>
<details>
<summary><strong>14 · Fix incorrect GitHub issues URL in root package.json</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The bugs.url field in the root package.json pointed to jolliai/jolli/issues instead of jolliai/jollimemory/issues, creating a broken link for users reporting issues.

**💡 Decisions Behind the Code**

- **Fix only the root package.json**: The CLI and VS Code sub-packages already had the correct URL, so the fix was isolated to the root file to avoid unnecessary churn and to keep the change minimal and focused.

**✅ What Was Implemented**

Corrected the bugs.url in package.json from `https://github.com/jolliai/jolli/issues` to `https://github.com/jolliai/jollimemory/issues`. Verified that cli/package.json and vscode/package.json already had the correct URL.

</blockquote>
</details>

### Apr 22, 2026
<details>
<summary><strong>15 · Fix config.json pollution from test runs by making path resolution lazy</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

A test in SessionTracker was modifying process.env.HOME at runtime, but the module's top-level constant had already captured the original home directory at import time. This caused the test to write "global-key" directly into the user's real ~/.jolli/jollimemory/config.json instead of a temporary test directory.

**💡 Decisions Behind the Code**

- **Lazy resolution over eager caching**: Functions that read environment variables should resolve at call time, not at module load time. This makes the entire module testable via environment swaps without requiring per-test mocking, and prevents future developers from accidentally creating similar pollution bugs.
- **Unified pattern across three locations**: Rather than just fixing the immediate SessionTracker bug, applied the same pattern to PlanService and StopHook to eliminate the entire class of "top-level const + HOME env var" hazards. This prevents "hidden landmines" where tests pass locally but fail in CI due to different HOME handling.
- **Delete over refactor for redundant test**: The "model round-trip" test was verifying that saveConfig delegates to saveConfigScoped—a one-liner proxy already covered by 6+ other tests. Deleting it removed the pollution vector entirely rather than trying to isolate it.

**✅ What Was Implemented**

- Converted three top-level `const` path definitions to lazy-evaluated functions: `GLOBAL_JOLLIMEMORY_DIR` in SessionTracker.ts, `PLANS_DIR` in PlanService.ts and StopHook.ts
- Updated all internal call sites (15+ references) to invoke the getter functions instead of using cached constants
- Deleted the "model round-trip" test (SessionTracker.test.ts:1331-1341) that was also polluting the real config by directly calling saveConfig without HOME isolation
- Verified 2748 tests pass and real config.json mtime remains unchanged after full test suite run

</blockquote>
</details>
<details>
<summary><strong>16 · Migrate OpenCode session discovery and transcript reading from closed PR</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

PR #834 ("Add OpenCode integration with global DB and multi-source UI") was closed, but the OpenCode discovery and transcript reading logic needed to be ported to the current jollimemory codebase. The user requested migration to a new feature branch while also updating the implementation to use Node's built-in sqlite module instead of the sql.js WASM library.

**💡 Decisions Behind the Code**

- **node:sqlite over sql.js**: Node 22.5+ provides native DatabaseSync for synchronous SQLite access without WASM overhead. This eliminates the need to copy sql-wasm.wasm to dist/, reduces VSCode extension bundle size by ~360kb, and avoids ExperimentalWarning in child processes that don't actually query the DB.
- **Three-way merge for migration**: Used `git apply --3way` to port the old PR's changes, which automatically resolved 21/38 files and surfaced 17 semantic conflicts requiring human judgment (e.g., path remapping from tools/jollimemory/ to cli/). This caught integration issues that a manual copy-paste would have missed.
- **Lazy import for OpenCode DB**: The DatabaseSync import is deferred (`await import("node:sqlite")`) so that pure-transcript processing (PostCommitHook) doesn't trigger the ExperimentalWarning. Only discovery and reading paths pay the cost.
- **Per-source session counting**: Rather than a single activeSessions count, StatusInfo now breaks down sessions by TranscriptSource (claude, codex, gemini, opencode). This gives users visibility into which integrations are actually contributing sessions.

**✅ What Was Implemented**

- Created OpenCodeSessionDiscoverer.ts and OpenCodeTranscriptReader.ts to query ~/.local/share/opencode/opencode.db using node:sqlite DatabaseSync API
- Updated Installer.ts to auto-detect OpenCode installation and compute sessionsBySource breakdown
- Extended Types.ts with openCodeDetected, openCodeEnabled config flags and sessionsBySource field in StatusInfo
- Added OpenCode toggle UI to VSCode Settings panel (SettingsScriptBuilder.ts, SettingsWebviewPanel.ts, SettingsHtmlBuilder.ts)
- Updated StatusTreeProvider.ts to display "OpenCode Integration" status and per-source session counts
- Removed sql.js and @types/sql.js dependencies; upgraded @types/node to ^22.5.0 and Node engine requirement to >=22.5.0
- Deleted 8 tests from PR #834 that asserted on monolithic Cli.ts output formats (no longer applicable after command refactoring)

</blockquote>
</details>
<details>
<summary><strong>17 · Raise test coverage to 100% across CLI and VSCode modules</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The user requested that all files in the cli and vscode directories achieve 99%+ coverage across all four coverage dimensions (statements, branches, functions, lines). Initial baseline showed CLI at ~99.33% statements / 98.58% branches and VSCode at ~99.52% statements / 98.22% branches, with 19 files falling short of the 99% threshold in at least one dimension.

**💡 Decisions Behind the Code**

- **Per-file per-dimension coverage (strategy A)**: User explicitly chose to require every file's every dimension (statements/branches/functions/lines) to reach ≥99%, not just total project coverage. This is stricter but ensures no file becomes a coverage liability.
- **Pragmatic ignore usage (strategy B)**: Allowed v8 ignore pragmas for demonstrably unreachable or defensive code (e.g., `instanceof Error` fallbacks, regex `.+` safety checks, platform-specific constants) rather than forcing artificial test scenarios. Each pragma includes a comment explaining why the branch is not worth testing, keeping the codebase maintainable.
- **Single large commit over incremental**: Bundled all 26 test additions into one commit to simplify review and ensure the entire test suite passes together, avoiding intermediate states where some files are at 100% while others lag.
- **Preserved existing thresholds**: Did not modify vitest's `thresholds` configuration (kept at 96–97%) because actual coverage already far exceeds those limits; any regression will trigger CI failure automatically.
- **Targeted root causes over surface fixes**: Identified that `SummaryMarkdownBuilder` tests were "empty" (calling functions but not triggering key branches like date grouping) because test fixtures set identical `generatedAt` timestamps. Fixed by varying timestamps in test data, which unlocked entire untested code paths in one change.

**✅ What Was Implemented**

Added 26 new test cases across both projects to close coverage gaps:
- CLI: supplemented `SummaryMarkdownBuilder.test.ts` with date-grouping tests (2 cases), `PlanProgressEvaluator.test.ts` with model fallback tests (2 cases), `CliUtils.test.ts` with date formatting (1 case), `Cli.test.ts` with auth/configure/view command paths (5 cases), `SummaryFormat/Tree/Store.test.ts` with fallback branches (4 cases), `Installer.test.ts` with OpenCode detection (1 case), `QueueWorker.test.ts` with metadata hoisting and note detection (3 cases)
- VSCode: added `PrCommentService.test.ts` retry and cross-branch tests (6 cases), `AuthService.test.ts` non-Error throw handling (3 cases), `SummaryWebviewPanel.test.ts` helper and race condition tests (8 cases), `Extension.test.ts` git-path resolution failure cases (3 cases), `StatusTreeProvider.test.ts` API key metadata tests
- Applied 8 v8 ignore pragmas with explicit rationale comments for defensive/unreachable branches (regex safety guards, platform constants, lifecycle cleanup, type invariants)
- Exposed internal test helpers: `hoistMetadataFromOldSummary` and `detectUncommittedNoteIds` in `QueueWorker.ts`; `summariesEqual` and `setsEqual` in `SummaryWebviewPanel.ts`
- Converted 6 instances of `/* v8 ignore next */` to `/* v8 ignore start/stop */` blocks for reliable multi-branch coverage

</blockquote>
</details>
<details>
<summary><strong>18 · Add OpenCode session discovery and transcript reading capability</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The system needed to integrate with OpenCode to discover active coding sessions and read their transcripts, enabling richer context capture during commit summarization.

**💡 Decisions Behind the Code**

- **Graceful degradation**: OpenCode integration is optional; if `isOpenCodeInstalled()` returns false or discovery fails, the pipeline continues normally without blocking summarization.
- **Lazy detection**: OpenCode availability is checked at runtime during worker execution rather than at startup, allowing users to install OpenCode after the CLI is already running.

**✅ What Was Implemented**

- Implemented `discoverOpenCodeSessions()` function to detect and enumerate active OpenCode sessions in the workspace
- Added `readOpenCodeTranscript()` to retrieve session transcripts for integration into the summary pipeline
- Integrated OpenCode discovery into the `QueueWorker` pipeline with graceful fallback when OpenCode is not installed
- Added test coverage for empty session discovery (when OpenCode is installed but no sessions are active)
- Exposed `detectUncommittedNoteIds()` helper for unit testing note lifecycle tracking

</blockquote>
</details>
<details>
<summary><strong>19 · Surface OpenCode database scan failures instead of silently reporting zero sessions</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

When the OpenCode database exists but is corrupt, locked, or has schema drift, the system was silently returning zero sessions with no indication of failure. Users could not distinguish between "no OpenCode activity" and "OpenCode integration is broken," making troubleshooting impossible.

**💡 Decisions Behind the Code**

- **Pre-flight stat() before DatabaseSync**: node:sqlite surfaces both "file missing" and "file unreadable" as the same "unable to open database file" error. A stat() call before opening the DB distinguishes ENOENT (silent) from real failures (surface to user), preventing false "0 sessions" displays on genuinely broken integrations.
- **Error classification at the boundary**: Rather than letting raw SQLite errors bubble up, classify them once at the discovery layer so the UI and logging layers receive semantic categories (corrupt vs locked vs schema drift). This makes downstream error handling simpler and more consistent.
- **Preserve backwards compatibility**: Keep `discoverOpenCodeSessions()` as a thin wrapper so existing callers that only need sessions don't have to change, while new callers that need to surface errors can use `scanOpenCodeSessions()` directly.

**✅ What Was Implemented**

- Added `scanOpenCodeSessions()` function that returns both sessions and an optional error object with classified failure kind (corrupt, locked, permission, schema, unknown)
- Implemented `classifyScanError()` to categorize SQLite and filesystem errors into user-facing severity levels, with ENOENT treated as silent "not installed"
- Added `openCodeScanError` field to `StatusInfo` type to carry classified errors up to the UI layer
- Updated `Installer.getStatus()` to call `scanOpenCodeSessions()` and surface real failures to the status tree
- Kept `discoverOpenCodeSessions()` as a backwards-compatible wrapper for callers that only need the session array
- Added 12 unit tests covering corrupt DB, missing tables, permission errors, and error classification logic

</blockquote>
</details>

---

*Generated by Jolli Memory · April 23, 2026 at 2:28 PM*
<!-- jollimemory-summary-end -->