### PR TITLE
Add OAuth login flow with JolliAuthService, config store, and UI banners

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,8 @@ Thumbs.db
 .codex/
 .opencode/
 .DS_Store
+.idea/
+*.iml
 **/dist/
 **/coverage/
 **/node_modules/

--- a/intellij/build.gradle.kts
+++ b/intellij/build.gradle.kts
@@ -375,6 +375,17 @@ tasks {
         }
     }
 
+    // Workaround: IntelliJ Platform Gradle Plugin 2.5.0 fails to parse the Java
+    // version from the downloaded IDE runtime, producing "JavaLanguageVersion must
+    // be a positive integer, not ''". Explicitly set the JVM launcher for affected tasks.
+    withType<JavaExec> {
+        javaLauncher.set(
+            project.the<JavaToolchainService>().launcherFor {
+                languageVersion.set(JavaLanguageVersion.of(21))
+            }
+        )
+    }
+
     test {
         useJUnitPlatform()
     }

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/actions/CommitAIAction.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/actions/CommitAIAction.kt
@@ -59,9 +59,9 @@ class CommitAIAction : AnAction() {
         }
 
         val config = SessionTracker.loadConfig(cwd)
-        if (config.apiKey.isNullOrBlank()) {
+        if (config.apiKey.isNullOrBlank() && config.jolliApiKey.isNullOrBlank() && System.getenv("ANTHROPIC_API_KEY").isNullOrBlank()) {
             Messages.showErrorDialog(project,
-                "Anthropic API key not configured.\nSet it in the STATUS panel or Settings > Tools > Jolli Memory.",
+                "No LLM credentials available.\nSign in to Jolli or configure an Anthropic API key in Settings > Tools > Jolli Memory.",
                 "Jolli Memory")
             return
         }
@@ -116,13 +116,14 @@ class CommitAIAction : AnAction() {
                     val branch = git.getCurrentBranch() ?: "unknown"
 
                     // Step 5: Generate AI message
-                    indicator.text = "Calling Anthropic API..."
+                    indicator.text = "Generating AI commit message..."
                     val message = Summarizer.generateCommitMessage(CommitMessageParams(
                         stagedDiff = diff,
                         branch = branch,
                         stagedFiles = selectedPaths,
                         apiKey = config.apiKey,
                         model = config.model,
+                        jolliApiKey = config.jolliApiKey,
                     ))
 
                     // Step 6: Show dialog on EDT

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/actions/SquashAction.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/actions/SquashAction.kt
@@ -114,7 +114,7 @@ class SquashAction : AnAction() {
                     }
                     try {
                         log.info("Generating squash message via AI…")
-                        message = Summarizer.generateSquashMessage(commitData, ticketId, isFullSquash, config.apiKey, config.model)
+                        message = Summarizer.generateSquashMessage(commitData, ticketId, isFullSquash, config.apiKey, config.model, config.jolliApiKey)
                         log.info("Squash message generated: %s", message)
                     } catch (ex: Exception) {
                         log.error("Failed to generate squash message: %s", ex.message)

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/auth/JolliConfigStore.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/auth/JolliConfigStore.kt
@@ -1,0 +1,68 @@
+package ai.jolli.jollimemory.auth
+
+import ai.jolli.jollimemory.core.JolliMemoryConfig
+import ai.jolli.jollimemory.core.SessionTracker
+import com.google.gson.Gson
+import com.google.gson.GsonBuilder
+import java.nio.file.Files
+import java.nio.file.Path
+
+/**
+ * Read/write store for general Jolli config files under ~/.jolli/ (shared with CLI).
+ * Auth token and space are stored in ~/.jolli/jollimemory/config.json.
+ */
+object JolliConfigStore {
+
+    private val gson: Gson = GsonBuilder().setPrettyPrinting().create()
+
+    private fun jolliDir(): Path =
+        Path.of(System.getProperty("user.home"), ".jolli")
+
+    private fun spacePath(): Path = jolliDir().resolve("space.json")
+
+    private data class SpaceConfigFile(
+        val space: String? = null,
+    )
+
+    /** Load auth token from env var or ~/.jolli/jollimemory/config.json. */
+    fun loadAuthToken(): String? {
+        System.getenv("JOLLI_AUTH_TOKEN")?.takeIf { it.isNotBlank() }?.let { return it }
+
+        val config = SessionTracker.loadConfigFromDir(SessionTracker.getGlobalConfigDir())
+        return config.authToken?.takeIf { it.isNotBlank() }
+    }
+
+    /** Save auth token to ~/.jolli/jollimemory/config.json. */
+    fun saveAuthToken(token: String) {
+        val globalDir = SessionTracker.getGlobalConfigDir()
+        val existing = SessionTracker.loadConfigFromDir(globalDir)
+        SessionTracker.saveConfigToDir(existing.copy(authToken = token), globalDir)
+    }
+
+    /** Clear auth token from ~/.jolli/jollimemory/config.json. */
+    fun clearAuthToken() {
+        val globalDir = SessionTracker.getGlobalConfigDir()
+        val existing = SessionTracker.loadConfigFromDir(globalDir)
+        SessionTracker.saveConfigToDir(existing.copy(authToken = null), globalDir)
+    }
+
+    /** Load space from ~/.jolli/space.json. */
+    fun loadSpace(): String? {
+        val path = spacePath()
+        if (!Files.exists(path)) return null
+        return try {
+            val json = Files.readString(path)
+            gson.fromJson(json, SpaceConfigFile::class.java)?.space
+        } catch (_: Exception) {
+            null
+        }
+    }
+
+    /** Save space to ~/.jolli/space.json. */
+    fun saveSpace(space: String) {
+        val dir = jolliDir()
+        Files.createDirectories(dir)
+        val data = SpaceConfigFile(space = space)
+        Files.writeString(spacePath(), gson.toJson(data))
+    }
+}

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/auth/JolliUrlConfig.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/auth/JolliUrlConfig.kt
@@ -1,0 +1,17 @@
+package ai.jolli.jollimemory.auth
+
+/**
+ * Resolves the Jolli login URL.
+ * Priority: JOLLI_URL env var > jolli.url system property > default.
+ */
+// TODO: test comment for jollimemory summary verification
+object JolliUrlConfig {
+
+    private const val DEFAULT_URL = "https://jolli.ai"
+
+    fun getJolliUrl(): String {
+        return System.getenv("JOLLI_URL")?.takeIf { it.isNotBlank() }
+            ?: System.getProperty("jolli.url")?.takeIf { it.isNotBlank() }
+            ?: DEFAULT_URL
+    }
+}

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/bridge/GitOps.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/bridge/GitOps.kt
@@ -22,16 +22,50 @@ class GitOps(private val projectDir: String) {
      */
     private val shellPath: String by lazy {
         try {
-            val shell = System.getenv("SHELL") ?: "/bin/zsh"
-            val proc = ProcessBuilder(shell, "-l", "-c", "echo \$PATH")
+            if (System.getProperty("os.name").lowercase().contains("win")) {
+                resolveWindowsPath()
+            } else {
+                val shell = System.getenv("SHELL") ?: "/bin/zsh"
+                val proc = ProcessBuilder(shell, "-l", "-c", "echo \$PATH")
+                    .redirectErrorStream(true)
+                    .start()
+                val output = proc.inputStream.bufferedReader().use { it.readText().trim() }
+                proc.waitFor(5, TimeUnit.SECONDS)
+                if (output.isNotBlank()) output else System.getenv("PATH") ?: ""
+            }
+        } catch (_: Exception) {
+            System.getenv("PATH") ?: ""
+        }
+    }
+
+    /**
+     * On Windows, the system PATH usually has Git's cmd/ dir but not usr/bin/
+     * where tools like sed and awk live. Find the Git install root and append
+     * usr/bin so git hooks that need those tools work correctly.
+     */
+    private fun resolveWindowsPath(): String {
+        val basePath = System.getenv("PATH") ?: ""
+        try {
+            val proc = ProcessBuilder("where", "git")
                 .redirectErrorStream(true)
                 .start()
             val output = proc.inputStream.bufferedReader().use { it.readText().trim() }
             proc.waitFor(5, TimeUnit.SECONDS)
-            if (output.isNotBlank()) output else System.getenv("PATH") ?: ""
-        } catch (_: Exception) {
-            System.getenv("PATH") ?: ""
-        }
+
+            // Find Git install root from the first git.exe path
+            // e.g. "C:\Program Files\Git\cmd\git.exe" -> "C:\Program Files\Git"
+            val gitExePath = output.lines().firstOrNull { it.endsWith("git.exe") }
+            if (gitExePath != null) {
+                val gitRoot = File(gitExePath).parentFile?.parentFile
+                if (gitRoot != null) {
+                    val usrBin = File(gitRoot, "usr${File.separator}bin")
+                    if (usrBin.isDirectory) {
+                        return "$basePath${File.pathSeparator}${usrBin.absolutePath}"
+                    }
+                }
+            }
+        } catch (_: Exception) { }
+        return basePath
     }
 
     /**

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/core/LlmClient.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/core/LlmClient.kt
@@ -1,0 +1,110 @@
+package ai.jolli.jollimemory.core
+
+import ai.jolli.jollimemory.services.JolliApiClient
+
+/**
+ * LlmClient — Routes LLM calls between direct Anthropic API and Jolli proxy.
+ *
+ * Credential priority: Anthropic API key > ANTHROPIC_API_KEY env var > Jolli API key (proxy).
+ * Direct mode: caller provides a pre-built prompt, we call AnthropicClient.
+ * Proxy mode: we send action + params to Jolli backend which owns the prompt template.
+ */
+object LlmClient {
+
+    private val log = JmLogger.create("LlmClient")
+
+    enum class CredentialSource { ANTHROPIC_CONFIG, ANTHROPIC_ENV, JOLLI_PROXY }
+
+    data class LlmCallResult(
+        val text: String?,
+        val model: String?,
+        val inputTokens: Int,
+        val outputTokens: Int,
+        val apiLatencyMs: Long,
+        val stopReason: String?,
+    )
+
+    /**
+     * Determines which credential source to use.
+     * Returns null if no credentials are available.
+     */
+    fun resolveCredentialSource(apiKey: String?, jolliApiKey: String?): CredentialSource? {
+        if (!apiKey.isNullOrBlank()) return CredentialSource.ANTHROPIC_CONFIG
+        if (!System.getenv("ANTHROPIC_API_KEY").isNullOrBlank()) return CredentialSource.ANTHROPIC_ENV
+        if (!jolliApiKey.isNullOrBlank()) return CredentialSource.JOLLI_PROXY
+        return null
+    }
+
+    /**
+     * Makes an LLM call, routing to direct Anthropic or Jolli proxy based on available credentials.
+     *
+     * @param action Template key (e.g. "summarize:small", "commit-message") — used for proxy mode
+     * @param params Template params — used for proxy mode
+     * @param apiKey Anthropic API key for direct mode
+     * @param jolliApiKey Jolli API key for proxy mode
+     * @param model Model alias or full ID (direct mode only)
+     * @param maxTokens Max output tokens (direct mode only)
+     * @param prompt Pre-built prompt string (direct mode only)
+     */
+    fun callLlm(
+        action: String,
+        params: Map<String, String>,
+        apiKey: String?,
+        jolliApiKey: String?,
+        model: String?,
+        maxTokens: Int?,
+        prompt: String?,
+    ): LlmCallResult {
+        val source = resolveCredentialSource(apiKey, jolliApiKey)
+            ?: throw RuntimeException("No LLM credentials available. Sign in to Jolli or configure an Anthropic API key.")
+
+        log.info("LLM call: action=%s, source=%s", action, source)
+
+        return when (source) {
+            CredentialSource.ANTHROPIC_CONFIG -> callDirect(prompt!!, apiKey!!, model, maxTokens)
+            CredentialSource.ANTHROPIC_ENV -> callDirect(prompt!!, System.getenv("ANTHROPIC_API_KEY"), model, maxTokens)
+            CredentialSource.JOLLI_PROXY -> callProxy(jolliApiKey!!, action, params)
+        }
+    }
+
+    private fun callDirect(prompt: String, apiKey: String, model: String?, maxTokens: Int?): LlmCallResult {
+        val resolvedModel = Summarizer.resolveModelId(model)
+        val resolvedMaxTokens = maxTokens ?: 8192
+        val client = AnthropicClient(apiKey)
+        val startTime = System.currentTimeMillis()
+
+        val response = client.createMessage(
+            model = resolvedModel,
+            maxTokens = resolvedMaxTokens,
+            temperature = 0.0,
+            messages = listOf(AnthropicClient.Message("user", prompt)),
+        )
+
+        val elapsed = System.currentTimeMillis() - startTime
+        val text = response.content.firstOrNull { it.type == "text" }?.text?.trim()
+
+        return LlmCallResult(
+            text = text,
+            model = response.model,
+            inputTokens = response.usage.inputTokens,
+            outputTokens = response.usage.outputTokens,
+            apiLatencyMs = elapsed,
+            stopReason = response.stopReason,
+        )
+    }
+
+    private fun callProxy(jolliApiKey: String, action: String, params: Map<String, String>): LlmCallResult {
+        val startTime = System.currentTimeMillis()
+        val result = JolliApiClient.callLlmProxy(jolliApiKey, action, params)
+        val elapsed = System.currentTimeMillis() - startTime
+
+        return LlmCallResult(
+            text = result.text,
+            model = null,
+            inputTokens = result.inputTokens,
+            outputTokens = result.outputTokens,
+            apiLatencyMs = elapsed,
+            stopReason = null,
+        )
+    }
+}

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/core/PlanProgressEvaluator.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/core/PlanProgressEvaluator.kt
@@ -93,8 +93,9 @@ Return a single JSON object (no markdown fences, no explanation):
         diff: String,
         topics: List<TopicSummary>,
         conversation: String,
-        apiKey: String,
+        apiKey: String?,
         model: String? = null,
+        jolliApiKey: String? = null,
     ): PlanProgressEvalResult? {
         val topicsText = renderTopics(topics)
 
@@ -104,24 +105,29 @@ Return a single JSON object (no markdown fences, no explanation):
             .replace("{{topics}}", topicsText)
             .replace("{{conversation}}", conversation)
 
-        val resolvedModel = Summarizer.resolveModelId(model ?: "haiku")
-        val client = AnthropicClient(apiKey)
+        val proxyParams = mapOf(
+            "planContent" to planMarkdown,
+            "diff" to diff,
+            "topics" to topicsText,
+            "conversation" to conversation,
+        )
 
-        val startTime = System.currentTimeMillis()
-        val response = try {
-            client.createMessage(
-                model = resolvedModel,
+        val result = try {
+            LlmClient.callLlm(
+                action = "plan-progress",
+                params = proxyParams,
+                apiKey = apiKey,
+                jolliApiKey = jolliApiKey,
+                model = Summarizer.resolveModelId(model ?: "haiku"),
                 maxTokens = MAX_TOKENS,
-                temperature = 0.0,
-                messages = listOf(AnthropicClient.Message("user", prompt)),
+                prompt = prompt,
             )
         } catch (e: Exception) {
             log.warn("Plan progress LLM call failed: %s", e.message)
             return null
         }
-        val elapsed = System.currentTimeMillis() - startTime
 
-        val responseText = response.content.firstOrNull { it.type == "text" }?.text?.trim()
+        val responseText = result.text
         if (responseText.isNullOrEmpty()) {
             log.warn("Plan progress LLM returned empty text")
             return null
@@ -169,11 +175,11 @@ Return a single JSON object (no markdown fences, no explanation):
         }
 
         val llm = LlmCallMetadata(
-            model = response.model,
-            inputTokens = response.usage.inputTokens,
-            outputTokens = response.usage.outputTokens,
-            apiLatencyMs = elapsed,
-            stopReason = response.stopReason,
+            model = result.model ?: Summarizer.resolveModelId(model ?: "haiku"),
+            inputTokens = result.inputTokens,
+            outputTokens = result.outputTokens,
+            apiLatencyMs = result.apiLatencyMs,
+            stopReason = result.stopReason,
         )
 
         return PlanProgressEvalResult(

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/core/SessionTracker.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/core/SessionTracker.kt
@@ -173,6 +173,7 @@ object SessionTracker {
             maxTokens = update.maxTokens ?: existing.maxTokens,
             excludePatterns = update.excludePatterns ?: existing.excludePatterns,
             jolliApiKey = update.jolliApiKey ?: existing.jolliApiKey,
+            authToken = update.authToken ?: existing.authToken,
             claudeEnabled = update.claudeEnabled ?: existing.claudeEnabled,
             codexEnabled = update.codexEnabled ?: existing.codexEnabled,
             geminiEnabled = update.geminiEnabled ?: existing.geminiEnabled,

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/core/Summarizer.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/core/Summarizer.kt
@@ -43,6 +43,7 @@ object Summarizer {
         val conversationTurns: Int? = null,
         val apiKey: String? = null,
         val model: String? = null,
+        val jolliApiKey: String? = null,
     )
 
     /** Builds the full summarization prompt. */
@@ -114,39 +115,52 @@ major
 17. NEVER use ===TOPIC=== or ---FIELDNAME--- inside your content."""
     }
 
-    /** Generates a summary by calling the Anthropic API. */
+    /** Generates a summary by calling the LLM (direct Anthropic or Jolli proxy). */
     fun generateSummary(params: SummarizeParams): SummaryResult {
-        val model = resolveModelId(params.model)
-        val apiKey = params.apiKey ?: System.getenv("ANTHROPIC_API_KEY")
-            ?: throw RuntimeException("Anthropic API key not found")
-
         log.info("Generating summary for commit %s", params.commitInfo.hash.take(8))
-        val prompt = buildSummarizationPrompt(params.conversation, params.diff, params.commitInfo)
-        val client = AnthropicClient(apiKey)
-        val startTime = System.currentTimeMillis()
 
-        val response = client.createMessage(
-            model = model,
-            maxTokens = DEFAULT_MAX_TOKENS,
-            temperature = 0.0,
-            messages = listOf(AnthropicClient.Message("user", prompt)),
+        // Select template variant based on diff size (matches CLI logic)
+        val totalLines = params.diffStats.insertions + params.diffStats.deletions
+        val workSize = when {
+            totalLines <= 100 -> "small"
+            totalLines <= 500 -> "medium"
+            else -> "large"
+        }
+
+        val prompt = buildSummarizationPrompt(params.conversation, params.diff, params.commitInfo)
+        val proxyParams = mapOf(
+            "commitHash" to params.commitInfo.hash,
+            "commitMessage" to params.commitInfo.message,
+            "commitAuthor" to params.commitInfo.author,
+            "commitDate" to params.commitInfo.date,
+            "conversation" to params.conversation,
+            "diff" to params.diff,
         )
 
-        val elapsed = System.currentTimeMillis() - startTime
-        log.info("API response in %dms (in=%d, out=%d)", elapsed, response.usage.inputTokens, response.usage.outputTokens)
+        val result = LlmClient.callLlm(
+            action = "summarize:$workSize",
+            params = proxyParams,
+            apiKey = params.apiKey,
+            jolliApiKey = params.jolliApiKey,
+            model = resolveModelId(params.model),
+            maxTokens = DEFAULT_MAX_TOKENS,
+            prompt = prompt,
+        )
 
-        val responseText = response.content.firstOrNull { it.type == "text" }?.text?.trim()
+        log.info("API response in %dms (in=%d, out=%d)", result.apiLatencyMs, result.inputTokens, result.outputTokens)
+
+        val responseText = result.text
             ?: throw RuntimeException("No text content in API response")
 
         val parsed = parseSummaryResponse(responseText)
         log.info("Summary parsed: %d topic(s)", parsed.topics.size)
 
         val llm = LlmCallMetadata(
-            model = response.model,
-            inputTokens = response.usage.inputTokens,
-            outputTokens = response.usage.outputTokens,
-            apiLatencyMs = elapsed,
-            stopReason = response.stopReason,
+            model = result.model ?: resolveModelId(params.model),
+            inputTokens = result.inputTokens,
+            outputTokens = result.outputTokens,
+            apiLatencyMs = result.apiLatencyMs,
+            stopReason = result.stopReason,
         )
 
         return SummaryResult(
@@ -275,21 +289,25 @@ Rules:
     }
 
     fun generateCommitMessage(params: CommitMessageParams): String {
-        val model = resolveModelId(params.model)
-        val apiKey = params.apiKey ?: System.getenv("ANTHROPIC_API_KEY")
-            ?: throw RuntimeException("Anthropic API key not found")
-
         val prompt = buildCommitMessagePrompt(params)
-        val client = AnthropicClient(apiKey)
-
-        val response = client.createMessage(
-            model = model,
-            maxTokens = 256,
-            temperature = 0.0,
-            messages = listOf(AnthropicClient.Message("user", prompt)),
+        val fileList = params.stagedFiles.joinToString(", ").ifEmpty { "(none)" }
+        val proxyParams = mapOf(
+            "stagedDiff" to params.stagedDiff.ifEmpty { "(empty diff -- no staged changes)" },
+            "branch" to params.branch,
+            "fileList" to fileList,
         )
 
-        val text = response.content.firstOrNull { it.type == "text" }?.text?.trim()
+        val result = LlmClient.callLlm(
+            action = "commit-message",
+            params = proxyParams,
+            apiKey = params.apiKey,
+            jolliApiKey = params.jolliApiKey,
+            model = resolveModelId(params.model),
+            maxTokens = 256,
+            prompt = prompt,
+        )
+
+        val text = result.text
             ?: throw RuntimeException("No text content in API response")
 
         return text.trim('"', '\'')
@@ -304,6 +322,7 @@ Rules:
         val diff: String,
         val apiKey: String? = null,
         val model: String? = null,
+        val jolliApiKey: String? = null,
     )
 
     private val SCENARIO_DELIMITER_RE = Regex("^\\s*===SCENARIO===\\s*$", RegexOption.MULTILINE)
@@ -430,23 +449,33 @@ What the reviewer needs to have ready before testing (e.g. "Have a Space with 3+
         return scenarios
     }
 
-    /** Generates E2E test scenarios by calling the Anthropic API. */
+    /** Generates E2E test scenarios by calling the LLM (direct Anthropic or Jolli proxy). */
     fun generateE2eTest(params: E2eTestParams): List<E2eTestScenario> {
-        val model = resolveModelId(params.model)
-        val apiKey = params.apiKey ?: throw RuntimeException("API key required")
-
         log.info("Generating E2E test guide for: %s", params.commitMessage.take(60))
         val prompt = buildE2eTestPrompt(params.topics, params.commitMessage, params.diff)
-        val client = AnthropicClient(apiKey)
+        val maxScenarios = if (params.topics.size <= 3) 5 else 10
+        val topicsSummary = params.topics.mapIndexed { i, t ->
+            "### Topic ${i + 1}: ${t.title}\n- **Trigger:** ${t.trigger}\n- **Response:** ${t.response}"
+        }.joinToString("\n\n")
 
-        val response = client.createMessage(
-            model = model,
-            maxTokens = DEFAULT_MAX_TOKENS,
-            temperature = 0.0,
-            messages = listOf(AnthropicClient.Message("user", prompt)),
+        val proxyParams = mapOf(
+            "commitMessage" to params.commitMessage,
+            "topicsSummary" to topicsSummary,
+            "diff" to params.diff,
+            "maxScenarios" to maxScenarios.toString(),
         )
 
-        val text = response.content.firstOrNull { it.type == "text" }?.text?.trim()
+        val result = LlmClient.callLlm(
+            action = "e2e-test",
+            params = proxyParams,
+            apiKey = params.apiKey,
+            jolliApiKey = params.jolliApiKey,
+            model = resolveModelId(params.model),
+            maxTokens = DEFAULT_MAX_TOKENS,
+            prompt = prompt,
+        )
+
+        val text = result.text
             ?: throw RuntimeException("No text in response")
 
         log.info("E2E raw response length: %d chars, first 500: %s", text.length, text.take(500))
@@ -473,23 +502,22 @@ Rules:
 $content"""
     }
 
-    /** Translates a Markdown document to English using the Anthropic API. */
-    fun translateToEnglish(content: String, apiKey: String?, model: String?): String {
-        val resolvedModel = resolveModelId(model)
-        val resolvedKey = apiKey ?: throw RuntimeException("API key required")
-
+    /** Translates a Markdown document to English using the LLM (direct Anthropic or Jolli proxy). */
+    fun translateToEnglish(content: String, apiKey: String?, model: String?, jolliApiKey: String? = null): String {
         log.info("Translating plan to English (%d chars)", content.length)
         val prompt = buildTranslationPrompt(content)
-        val client = AnthropicClient(resolvedKey)
 
-        val response = client.createMessage(
-            model = resolvedModel,
+        val result = LlmClient.callLlm(
+            action = "translate",
+            params = mapOf("content" to content),
+            apiKey = apiKey,
+            jolliApiKey = jolliApiKey,
+            model = resolveModelId(model),
             maxTokens = DEFAULT_MAX_TOKENS,
-            temperature = 0.0,
-            messages = listOf(AnthropicClient.Message("user", prompt)),
+            prompt = prompt,
         )
 
-        return response.content.firstOrNull { it.type == "text" }?.text?.trim()
+        return result.text
             ?: throw RuntimeException("No text in translation response")
     }
 
@@ -502,11 +530,8 @@ $content"""
         isFullSquash: Boolean,
         apiKey: String?,
         model: String?,
+        jolliApiKey: String? = null,
     ): String {
-        val resolvedModel = resolveModelId(model)
-        val key = apiKey ?: System.getenv("ANTHROPIC_API_KEY")
-            ?: throw RuntimeException("Anthropic API key not found")
-
         val commitsBlock = commits.mapIndexed { i, (msg, topics) ->
             val topicLines = if (topics.isNotEmpty()) {
                 topics.joinToString("\n") { "   - ${it.title}\n     Why: ${it.trigger}" }
@@ -547,9 +572,23 @@ Rules:
    - No ticket: no prefix.
 6. Do NOT include multi-line bodies -- just the single subject line."""
 
-        val client = AnthropicClient(key)
-        val response = client.createMessage(resolvedModel, 256, 0.0, listOf(AnthropicClient.Message("user", prompt)))
-        return response.content.firstOrNull { it.type == "text" }?.text?.trim()?.trim('"', '\'')
+        val proxyParams = mapOf(
+            "ticketLine" to ticketLine,
+            "commitsBlock" to commitsBlock,
+            "scopeLine" to scopeLine,
+        )
+
+        val result = LlmClient.callLlm(
+            action = "squash-message",
+            params = proxyParams,
+            apiKey = apiKey,
+            jolliApiKey = jolliApiKey,
+            model = resolveModelId(model),
+            maxTokens = 256,
+            prompt = prompt,
+        )
+
+        return result.text?.trim('"', '\'')
             ?: throw RuntimeException("No text in response")
     }
 }

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/core/Types.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/core/Types.kt
@@ -284,6 +284,7 @@ data class JolliMemoryConfig(
     val maxTokens: Int? = null,
     val excludePatterns: List<String>? = null,
     val jolliApiKey: String? = null,
+    val authToken: String? = null,
     val claudeEnabled: Boolean? = null,
     val codexEnabled: Boolean? = null,
     val geminiEnabled: Boolean? = null,
@@ -324,6 +325,7 @@ data class CommitMessageParams(
     val stagedFiles: List<String>,
     val apiKey: String? = null,
     val model: String? = null,
+    val jolliApiKey: String? = null,
 )
 
 /** Result of enable/disable operations */

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/hooks/PostCommitHook.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/hooks/PostCommitHook.kt
@@ -195,10 +195,10 @@ object PostCommitHook {
             // 7. Build conversation context
             val conversation = TranscriptReader.buildMultiSessionContext(sessionTranscripts)
 
-            // 8. Generate summary via Anthropic API
+            // 8. Generate summary via LLM (direct Anthropic or Jolli proxy)
             val apiKey = config.apiKey ?: System.getenv("ANTHROPIC_API_KEY")
-            if (apiKey == null) {
-                log.warn("No API key configured — skipping summarization")
+            if (apiKey == null && config.jolliApiKey.isNullOrBlank()) {
+                log.warn("No LLM credentials configured — skipping summarization")
                 return
             }
 
@@ -211,6 +211,7 @@ object PostCommitHook {
                 conversationTurns = totalTurns,
                 apiKey = apiKey,
                 model = config.model,
+                jolliApiKey = config.jolliApiKey,
             ))
 
             // 8b. Detect uncommitted plans, archive, and evaluate progress
@@ -238,7 +239,7 @@ object PostCommitHook {
                         if (planMarkdown != null) {
                             val evalResult = try {
                                 PlanProgressEvaluator.evaluatePlanProgress(
-                                    planMarkdown, diff, topics, conversation, apiKey, config.model,
+                                    planMarkdown, diff, topics, conversation, apiKey, config.model, config.jolliApiKey,
                                 )
                             } catch (e: Exception) {
                                 log.warn("Plan progress eval failed for %s: %s", slug, e.message)

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/services/JolliApiClient.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/services/JolliApiClient.kt
@@ -1,5 +1,6 @@
 package ai.jolli.jollimemory.services
 
+import ai.jolli.jollimemory.auth.JolliConfigStore
 import ai.jolli.jollimemory.core.JmLogger
 import com.google.gson.Gson
 import java.net.URI
@@ -183,6 +184,82 @@ object JolliApiClient {
 
         if (statusCode != 200 && statusCode != 204) {
             throw RuntimeException("Delete failed with status $statusCode")
+        }
+    }
+
+    /**
+     * Resolves the effective bearer token for Jolli API calls.
+     * Priority: explicit Jolli API key > OAuth auth token from ~/.jolli/jollimemory/config.json.
+     */
+    fun resolveToken(jolliApiKey: String?): String? {
+        if (!jolliApiKey.isNullOrBlank()) return jolliApiKey
+        return JolliConfigStore.loadAuthToken()
+    }
+
+    // ── LLM Proxy ─────────────────────────────────────────────────────────
+
+    /** Response from the LLM proxy endpoint. */
+    data class LlmProxyResult(
+        val text: String?,
+        val inputTokens: Int,
+        val outputTokens: Int,
+    )
+
+    /** Payload sent to the LLM proxy endpoint. */
+    private data class LlmProxyPayload(
+        val action: String,
+        val params: Map<String, String>,
+    )
+
+    /**
+     * Calls the Jolli LLM proxy endpoint.
+     * The backend owns the prompt template — we just send the action key and params.
+     */
+    fun callLlmProxy(apiKey: String, action: String, params: Map<String, String>): LlmProxyResult {
+        val keyMeta = parseJolliApiKey(apiKey)
+        val resolvedBaseUrl = keyMeta?.u
+            ?: throw RuntimeException(
+                "Jolli site URL could not be determined from API key. " +
+                    "Please regenerate your Jolli API Key."
+            )
+
+        val parsed = parseBaseUrl(resolvedBaseUrl)
+        val targetUri = URI.create("${parsed.origin}/api/push/llm/complete")
+
+        val body = gson.toJson(LlmProxyPayload(action, params))
+        val requestBuilder = HttpRequest.newBuilder()
+            .uri(targetUri)
+            .header("Content-Type", "application/json")
+            .header("Authorization", "Bearer $apiKey")
+            .POST(HttpRequest.BodyPublishers.ofString(body))
+            .timeout(Duration.ofSeconds(120))
+
+        if (parsed.tenantSlug != null) {
+            requestBuilder.header("x-tenant-slug", parsed.tenantSlug)
+        }
+        if (keyMeta.o != null) {
+            requestBuilder.header("x-org-slug", keyMeta.o)
+        }
+
+        val response = client.send(requestBuilder.build(), HttpResponse.BodyHandlers.ofString())
+        val raw = response.body() ?: ""
+        val statusCode = response.statusCode()
+
+        if (statusCode !in 200..299) {
+            log.warn("LLM proxy error %d: %s", statusCode, raw.take(500))
+            throw RuntimeException("LLM proxy error (HTTP $statusCode): ${raw.take(200)}")
+        }
+
+        return try {
+            @Suppress("UNCHECKED_CAST")
+            val json = gson.fromJson(raw, Map::class.java) as Map<String, Any?>
+            LlmProxyResult(
+                text = json["text"] as? String,
+                inputTokens = (json["inputTokens"] as? Double)?.toInt() ?: 0,
+                outputTokens = (json["outputTokens"] as? Double)?.toInt() ?: 0,
+            )
+        } catch (_: Exception) {
+            throw RuntimeException("Invalid JSON from LLM proxy (HTTP $statusCode): ${raw.take(200)}")
         }
     }
 

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/services/JolliAuthService.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/services/JolliAuthService.kt
@@ -1,0 +1,233 @@
+package ai.jolli.jollimemory.services
+
+import ai.jolli.jollimemory.auth.JolliConfigStore
+import ai.jolli.jollimemory.auth.JolliUrlConfig
+import ai.jolli.jollimemory.core.JmLogger
+import ai.jolli.jollimemory.core.JolliMemoryConfig
+import ai.jolli.jollimemory.core.SessionTracker
+import com.intellij.ide.BrowserUtil
+import com.intellij.openapi.Disposable
+import com.sun.net.httpserver.HttpServer
+import java.net.InetSocketAddress
+import java.security.SecureRandom
+import java.util.concurrent.Executors
+import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.ScheduledFuture
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * OAuth login flow for Jolli — spins up a localhost callback server,
+ * opens the browser, and captures the token redirect.
+ */
+// TODO: test comment for jollimemory summary verification
+object JolliAuthService {
+
+    private val log = JmLogger.create("JolliAuthService")
+
+    private const val DEFAULT_LOGIN_TIMEOUT_SECONDS = 60L
+
+    @Volatile
+    private var server: HttpServer? = null
+
+    @Volatile
+    private var serverExecutor: java.util.concurrent.ExecutorService? = null
+
+    private val timeoutExecutor: ScheduledExecutorService =
+        Executors.newSingleThreadScheduledExecutor { r ->
+            Thread(r, "JolliAuth-timeout").apply { isDaemon = true }
+        }
+
+    @Volatile
+    private var timeoutTask: ScheduledFuture<*>? = null
+
+    private val completed = AtomicBoolean(false)
+
+    private val authListeners = java.util.concurrent.CopyOnWriteArrayList<() -> Unit>()
+
+    fun addAuthListener(listener: () -> Unit): Disposable {
+        authListeners.add(listener)
+        return Disposable { authListeners.remove(listener) }
+    }
+
+    private fun notifyAuthListeners() { authListeners.forEach { it() } }
+
+    fun isSignedIn(): Boolean = JolliConfigStore.loadAuthToken() != null
+
+    /**
+     * Start the OAuth login flow.
+     * Opens the browser to the Jolli login page with a localhost callback.
+     */
+    data class LoginResult(
+        val token: String,
+        val space: String? = null,
+        val jolliApiKey: String? = null,
+    )
+
+    fun login(
+        timeoutSeconds: Long = DEFAULT_LOGIN_TIMEOUT_SECONDS,
+        onSuccess: (result: LoginResult) -> Unit,
+        onError: (message: String) -> Unit,
+    ) {
+        // Shut down any previous server
+        shutdown()
+        completed.set(false)
+
+        try {
+            val httpServer = HttpServer.create(InetSocketAddress("127.0.0.1", 0), 0)
+            val executor = Executors.newSingleThreadExecutor()
+            httpServer.executor = executor
+            server = httpServer
+            serverExecutor = executor
+
+            val port = httpServer.address.port
+            val jolliUrl = JolliUrlConfig.getJolliUrl()
+            val stateBytes = ByteArray(16)
+            SecureRandom().nextBytes(stateBytes)
+            val state = stateBytes.joinToString("") { "%02x".format(it) }
+            val callbackUrl = "http://localhost:$port/callback?state=$state"
+            val encodedCallback = java.net.URLEncoder.encode(callbackUrl, Charsets.UTF_8)
+            val loginUrl = "$jolliUrl/login?cli_callback=$encodedCallback" +
+                "&generate_api_key=true&client=intellij"
+            log.info("Login URL: %s", loginUrl)
+
+            httpServer.createContext("/callback") { exchange ->
+                if (!completed.compareAndSet(false, true)) {
+                    try { sendHtml(exchange, errorHtml("Login already timed out — please try again."), 408) } catch (_: Exception) {}
+                    return@createContext
+                }
+                try {
+                    val query = exchange.requestURI.query ?: ""
+                    val params = parseQuery(query)
+                    log.info("Callback received — state expected=%s, received=%s", state, params["state"])
+
+                    val returnedState = params["state"]
+                    if (returnedState != state) {
+                        val html = errorHtml("Invalid login state — possible CSRF attack. Please try again.")
+                        sendHtml(exchange, html, 403)
+                        onError("Invalid login state. Please try again.")
+                        shutdown()
+                        return@createContext
+                    }
+
+                    val error = params["error"]
+                    if (error != null) {
+                        val message = getErrorMessage(error)
+                        val html = errorHtml(message)
+                        sendHtml(exchange, html, 400)
+                        onError(message)
+                    } else {
+                        val token = params["token"]
+                        val space = params["space"]
+                        val jolliApiKey = params["jolli_api_key"]
+
+                        if (token.isNullOrBlank()) {
+                            val html = errorHtml("No token received from server.")
+                            sendHtml(exchange, html, 400)
+                            onError("No token received from server.")
+                        } else {
+                            val globalDir = SessionTracker.getGlobalConfigDir()
+                            val existing = SessionTracker.loadConfigFromDir(globalDir)
+                            SessionTracker.saveConfigToDir(existing.copy(
+                                authToken = token,
+                                jolliApiKey = if (!jolliApiKey.isNullOrBlank()) jolliApiKey else existing.jolliApiKey,
+                            ), globalDir)
+                            if (!space.isNullOrBlank()) {
+                                JolliConfigStore.saveSpace(space)
+                            }
+
+                            val html = successHtml()
+                            sendHtml(exchange, html, 200)
+                            notifyAuthListeners()
+                            onSuccess(LoginResult(token, space, jolliApiKey))
+                        }
+                    }
+                } catch (e: Exception) {
+                    log.warn("Callback error: ${e.message}")
+                    try {
+                        sendHtml(exchange, errorHtml("Unexpected error: ${e.message}"), 500)
+                    } catch (_: Exception) { }
+                    onError("Callback error: ${e.message}")
+                } finally {
+                    shutdown()
+                }
+            }
+
+            httpServer.start()
+            log.info("OAuth callback server started on port $port")
+
+            timeoutTask = timeoutExecutor.schedule({
+                if (completed.compareAndSet(false, true)) {
+                    log.info("Login timed out after ${timeoutSeconds}s")
+                    shutdown()
+                    onError("Login timed out — please try again.")
+                }
+            }, timeoutSeconds, TimeUnit.SECONDS)
+
+            BrowserUtil.browse(loginUrl)
+        } catch (e: Exception) {
+            log.warn("Failed to start OAuth flow: ${e.message}")
+            shutdown()
+            onError("Failed to start login: ${e.message}")
+        }
+    }
+
+    fun signOut() {
+        val globalDir = SessionTracker.getGlobalConfigDir()
+        val existing = SessionTracker.loadConfigFromDir(globalDir)
+        SessionTracker.saveConfigToDir(existing.copy(authToken = null), globalDir)
+        notifyAuthListeners()
+    }
+
+    private fun shutdown() {
+        timeoutTask?.cancel(false)
+        timeoutTask = null
+        server?.stop(1)
+        server = null
+        serverExecutor?.shutdownNow()
+        serverExecutor = null
+    }
+
+    internal fun parseQuery(query: String): Map<String, String> {
+        if (query.isBlank()) return emptyMap()
+        return query.split("&").associate { param ->
+            val parts = param.split("=", limit = 2)
+            val key = java.net.URLDecoder.decode(parts[0], Charsets.UTF_8)
+            val value = if (parts.size > 1) java.net.URLDecoder.decode(parts[1], Charsets.UTF_8) else ""
+            key to value
+        }
+    }
+
+    internal fun getErrorMessage(code: String): String = when (code) {
+        "access_denied" -> "Access was denied. Please try again."
+        "invalid_request" -> "Invalid login request. Please try again."
+        "server_error" -> "Server error during login. Please try again later."
+        "temporarily_unavailable" -> "Service temporarily unavailable. Please try again later."
+        else -> "Login failed: $code"
+    }
+
+    private fun sendHtml(exchange: com.sun.net.httpserver.HttpExchange, html: String, statusCode: Int) {
+        val bytes = html.toByteArray(Charsets.UTF_8)
+        exchange.responseHeaders.add("Content-Type", "text/html; charset=utf-8")
+        exchange.sendResponseHeaders(statusCode, bytes.size.toLong())
+        exchange.responseBody.use { it.write(bytes) }
+    }
+
+    private fun successHtml(): String = """
+        <!DOCTYPE html>
+        <html><head><title>Jolli - Signed In</title>
+        <style>body{font-family:system-ui,sans-serif;display:flex;justify-content:center;align-items:center;height:100vh;margin:0;background:#f8f9fa}
+        .card{text-align:center;padding:2rem;border-radius:12px;background:white;box-shadow:0 2px 8px rgba(0,0,0,.1)}
+        h1{color:#22c55e;margin-bottom:.5rem}p{color:#6b7280}</style></head>
+        <body><div class="card"><h1>&#10003; Signed In</h1><p>You can close this tab and return to your IDE.</p></div></body></html>
+    """.trimIndent()
+
+    private fun errorHtml(message: String): String = """
+        <!DOCTYPE html>
+        <html><head><title>Jolli - Login Failed</title>
+        <style>body{font-family:system-ui,sans-serif;display:flex;justify-content:center;align-items:center;height:100vh;margin:0;background:#f8f9fa}
+        .card{text-align:center;padding:2rem;border-radius:12px;background:white;box-shadow:0 2px 8px rgba(0,0,0,.1)}
+        h1{color:#ef4444;margin-bottom:.5rem}p{color:#6b7280}</style></head>
+        <body><div class="card"><h1>&#10007; Login Failed</h1><p>${message.replace("<", "&lt;").replace(">", "&gt;")}</p></div></body></html>
+    """.trimIndent()
+}

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/settings/JolliMemoryConfigurable.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/settings/JolliMemoryConfigurable.kt
@@ -2,14 +2,17 @@ package ai.jolli.jollimemory.settings
 
 import ai.jolli.jollimemory.core.JolliMemoryConfig
 import ai.jolli.jollimemory.core.SessionTracker
+import ai.jolli.jollimemory.services.JolliAuthService
 import com.intellij.openapi.options.Configurable
 import com.intellij.openapi.project.Project
 import com.intellij.ui.components.JBLabel
 import com.intellij.ui.components.JBPasswordField
 import com.intellij.ui.components.JBTextField
 import com.intellij.util.ui.FormBuilder
+import javax.swing.JButton
 import javax.swing.JComponent
 import javax.swing.JPanel
+import javax.swing.SwingUtilities
 
 /**
  * Settings page for JolliMemory — IntelliJ Preferences > Tools > JolliMemory.
@@ -26,6 +29,9 @@ class JolliMemoryConfigurable(private val project: Project) : Configurable {
     private var apiKeyField: JBPasswordField? = null
     private var modelField: JBTextField? = null
     private var jolliApiKeyField: JBPasswordField? = null
+    private var jolliApiKeyLabel: JBLabel? = null
+    private var accountStatusLabel: JBLabel? = null
+    private var accountButton: JButton? = null
 
     private var savedApiKey: String? = null
     private var savedModel: String? = null
@@ -37,9 +43,13 @@ class JolliMemoryConfigurable(private val project: Project) : Configurable {
         apiKeyField = JBPasswordField()
         modelField = JBTextField()
         jolliApiKeyField = JBPasswordField()
+        jolliApiKeyLabel = JBLabel("Jolli API Key:")
+        accountStatusLabel = JBLabel()
+        accountButton = JButton()
 
-        // Load current values
+        // Load current values first so updateAccountUI can check the API key field
         loadFromConfig()
+        updateAccountUI()
 
         val privacyNotice = JBLabel(
             "<html>By providing an API key, you consent to sending code diffs and AI session " +
@@ -52,15 +62,63 @@ class JolliMemoryConfigurable(private val project: Project) : Configurable {
         return FormBuilder.createFormBuilder()
             .addComponent(privacyNotice)
             .addSeparator()
+            .addLabeledComponent(JBLabel("Account:"), accountPanel(), 1, false)
+            .addTooltip("Sign in with your Jolli account for Personal Space sync")
+            .addSeparator()
             .addLabeledComponent(JBLabel("Anthropic API Key:"), apiKeyField!!, 1, false)
             .addTooltip("Required for AI commit summaries. Get yours at console.anthropic.com")
             .addLabeledComponent(JBLabel("Model:"), modelField!!, 1, false)
             .addTooltip("Alias (haiku, sonnet, opus) or full model ID. Default: sonnet")
             .addSeparator()
-            .addLabeledComponent(JBLabel("Jolli API Key:"), jolliApiKeyField!!, 1, false)
-            .addTooltip("For pushing summaries to Jolli Space (sk-jol-...)")
+            .addLabeledComponent(jolliApiKeyLabel!!, jolliApiKeyField!!, 1, false)
+            .addTooltip("For pushing summaries to Jolli Space (sk-jol-...). Fallback if not signed in.")
             .addComponentFillVertically(JPanel(), 0)
             .panel
+    }
+
+    private fun accountPanel(): JPanel {
+        return JPanel(java.awt.FlowLayout(java.awt.FlowLayout.LEFT, 4, 0)).apply {
+            add(accountStatusLabel)
+            add(accountButton)
+        }
+    }
+
+    private fun updateAccountUI() {
+        if (JolliAuthService.isSignedIn()) {
+            accountStatusLabel?.text = "Signed in"
+            accountButton?.text = "Sign Out"
+            accountButton?.actionListeners?.forEach { accountButton?.removeActionListener(it) }
+            accountButton?.addActionListener {
+                JolliAuthService.signOut()
+                updateAccountUI()
+            }
+            jolliApiKeyLabel?.text = "Jolli API Key (optional — auto-managed via account):"
+            jolliApiKeyField?.toolTipText = "Optional. Your account key is used automatically. Enter a manual key here to override it."
+        } else {
+            accountStatusLabel?.text = "Not signed in"
+            accountButton?.text = "Sign In"
+            accountButton?.actionListeners?.forEach { accountButton?.removeActionListener(it) }
+            accountButton?.addActionListener {
+                accountButton?.isEnabled = false
+                accountButton?.text = "Signing in..."
+                JolliAuthService.login(
+                    onSuccess = { _ ->
+                        SwingUtilities.invokeLater {
+                            loadFromConfig()
+                            updateAccountUI()
+                        }
+                    },
+                    onError = { msg ->
+                        SwingUtilities.invokeLater {
+                            updateAccountUI()
+                            com.intellij.openapi.ui.Messages.showErrorDialog(msg, "Jolli Sign In")
+                        }
+                    },
+                )
+            }
+            jolliApiKeyLabel?.text = "Jolli API Key:"
+            jolliApiKeyField?.toolTipText = null
+        }
     }
 
     override fun isModified(): Boolean {
@@ -75,12 +133,14 @@ class JolliMemoryConfigurable(private val project: Project) : Configurable {
         val model = modelField?.text?.trim()?.ifBlank { null }
         val jolliApiKey = getJolliApiKeyFieldText().ifBlank { null }
 
-        val update = JolliMemoryConfig(
+        val globalDir = SessionTracker.getGlobalConfigDir()
+        val existing = SessionTracker.loadConfigFromDir(globalDir)
+        val merged = existing.copy(
             apiKey = apiKey,
             model = model,
             jolliApiKey = jolliApiKey,
         )
-        SessionTracker.saveConfig(update, cwd)
+        SessionTracker.saveConfigToDir(merged, globalDir)
 
         // Update saved values
         savedApiKey = apiKey ?: ""

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/JolliMemoryToolWindowFactory.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/JolliMemoryToolWindowFactory.kt
@@ -2,8 +2,9 @@ package ai.jolli.jollimemory.toolwindow
 
 import ai.jolli.jollimemory.JolliMemoryIcons
 import ai.jolli.jollimemory.actions.TogglePanelAction
- import ai.jolli.jollimemory.core.SessionTracker
+import ai.jolli.jollimemory.core.SessionTracker
 import ai.jolli.jollimemory.services.JolliApiClient
+import ai.jolli.jollimemory.services.JolliAuthService
 import ai.jolli.jollimemory.services.JolliMemoryService
 import com.intellij.openapi.actionSystem.DefaultActionGroup
 import com.intellij.openapi.project.DumbAware
@@ -209,8 +210,90 @@ class JolliMemoryToolWindowFactory : ToolWindowFactory, DumbAware {
         }
         toolWindow.setAdditionalGearActions(gearActions)
 
-        val content = ContentFactory.getInstance().createContent(accordionPanel, "", false).apply {
+        // Sign-in banner — shown at top of tool window when not signed in
+        val signInBanner = JPanel(BorderLayout()).apply {
+            border = JBUI.Borders.empty(10, 12)
+        }
+
+        // Signed-in status line — shown when signed in
+        val signedInBar = JPanel(java.awt.FlowLayout(java.awt.FlowLayout.LEFT, 8, 4)).apply {
+            add(JBLabel(JolliMemoryIcons.Check))
+            add(JBLabel("Signed in"))
+            add(javax.swing.JButton("Sign Out").apply {
+                putClientProperty("JButton.buttonType", "default")
+                addActionListener {
+                    JolliAuthService.signOut()
+                }
+            })
+        }
+
+        val syncSignInBanner: () -> Unit = {
+            val signedIn = JolliAuthService.isSignedIn()
+            signInBanner.isVisible = !signedIn
+            signedInBar.isVisible = signedIn
+        }
+
+        // Build banner contents (needs syncSignInBanner reference for the button callback)
+        val signInButton = javax.swing.JButton("Sign In").apply {
+            putClientProperty("JButton.buttonType", "default")
+            addActionListener {
+                isEnabled = false
+                text = "Signing in..."
+                JolliAuthService.login(
+                    onSuccess = { _ ->
+                        SwingUtilities.invokeLater {
+                            isEnabled = true
+                            text = "Sign In"
+                            syncSignInBanner()
+                        }
+                    },
+                    onError = { msg ->
+                        SwingUtilities.invokeLater {
+                            isEnabled = true
+                            text = "Sign In"
+                            com.intellij.notification.Notifications.Bus.notify(
+                                com.intellij.notification.Notification(
+                                    "JolliMemory",
+                                    "Sign In Failed",
+                                    msg,
+                                    com.intellij.notification.NotificationType.ERROR,
+                                )
+                            )
+                        }
+                    },
+                )
+            }
+        }
+        signInBanner.add(javax.swing.Box.createVerticalBox().apply {
+            add(JBLabel("<html><b>Sign up or Sign In to Jolli</b></html>"))
+            add(javax.swing.Box.createVerticalStrut(4))
+            add(JBLabel("<html><span style='color:gray'>Enable cloud sync, team collaboration, and LLM proxy</span></html>"))
+            add(javax.swing.Box.createVerticalStrut(8))
+            add(signInButton.apply {
+                alignmentX = java.awt.Component.LEFT_ALIGNMENT
+                maximumSize = java.awt.Dimension(Int.MAX_VALUE, preferredSize.height)
+            })
+            add(javax.swing.Box.createVerticalStrut(6))
+            add(JBLabel("<html><span style='color:gray; font-size:0.85em'>Or configure API keys in Settings &gt; Tools &gt; Jolli Memory</span></html>"))
+        }, BorderLayout.CENTER)
+
+        syncSignInBanner()
+        service.addStatusListener { SwingUtilities.invokeLater { syncSignInBanner() } }
+        val authListenerDisposable = JolliAuthService.addAuthListener { SwingUtilities.invokeLater { syncSignInBanner() } }
+
+        // Outer panel: banner at top, accordion fills the rest
+        val outerPanel = JPanel(BorderLayout()).apply {
+            val bannerWrapper = JPanel(BorderLayout()).apply {
+                add(signInBanner, BorderLayout.NORTH)
+                add(signedInBar, BorderLayout.SOUTH)
+            }
+            add(bannerWrapper, BorderLayout.NORTH)
+            add(accordionPanel, BorderLayout.CENTER)
+        }
+
+        val content = ContentFactory.getInstance().createContent(outerPanel, "", false).apply {
             setDisposer(Disposer.newDisposable("JolliMemoryToolWindowContent").also { parentDisposable ->
+                Disposer.register(parentDisposable, authListenerDisposable)
                 Disposer.register(parentDisposable, statusPanel)
                 Disposer.register(parentDisposable, plansPanel)
                 Disposer.register(parentDisposable, changesPanel)

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/SettingsDialog.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/SettingsDialog.kt
@@ -160,7 +160,10 @@ class SettingsDialog(
             .map { it.trim() }
             .filter { it.isNotEmpty() }
 
-        val config = JolliMemoryConfig(
+        // Always save to global config directory, preserving fields not managed by this dialog
+        val configDir = SessionTracker.getGlobalConfigDir()
+        val existing = SessionTracker.loadConfigFromDir(configDir)
+        val config = existing.copy(
             apiKey = resolvedApiKey.ifBlank { null },
             model = (modelCombo.selectedItem as String).let { if (it == "sonnet") null else it },
             maxTokens = maxTokens,
@@ -170,9 +173,6 @@ class SettingsDialog(
             geminiEnabled = geminiEnabledCheckbox.isSelected,
             excludePatterns = if (excludePatterns.isNotEmpty()) excludePatterns else null,
         )
-
-        // Always save to global config directory
-        val configDir = SessionTracker.getGlobalConfigDir()
         SessionTracker.saveConfigToDir(config, configDir)
 
         super.doOKAction()

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/StatusPanel.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/StatusPanel.kt
@@ -7,6 +7,7 @@ import ai.jolli.jollimemory.core.JolliMemoryConfig
 import ai.jolli.jollimemory.core.SessionTracker
 import ai.jolli.jollimemory.core.SummaryStore
 import ai.jolli.jollimemory.services.JolliApiClient
+import ai.jolli.jollimemory.services.JolliAuthService
 import ai.jolli.jollimemory.services.JolliMemoryService
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.application.ApplicationManager
@@ -180,7 +181,7 @@ class StatusPanel(
             tooltip = "$branchSummaryCount on current branch, ${status.summaryCount} total across all branches",
         ))
 
-        // 5. Jolli Site (from API key) — show site URL when configured, warning when not
+        // 5. Jolli Site (from API key) — show site URL when configured
         if (!config.jolliApiKey.isNullOrBlank()) {
             val meta = JolliApiClient.parseJolliApiKey(config.jolliApiKey!!)
             val siteUrl = meta?.u
@@ -192,14 +193,6 @@ class StatusPanel(
                     tooltip = "Resolved from Jolli API Key (tenant: ${meta.t})",
                 ))
             }
-        } else {
-            listModel.addElement(StatusRow(
-                icon = Icon.WARN,
-                label = "Jolli API Key",
-                description = "not configured — double-click to set",
-                tooltip = "Required for pushing memories to Jolli Space (embeds site URL)",
-                onClick = { openSettingsDialog() },
-            ))
         }
 
         // 6. Claude Integration — matches VS Code pushIntegrationItem() descriptions

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/SummaryPanel.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/SummaryPanel.kt
@@ -251,14 +251,15 @@ class SummaryPanel(
         val config = SessionTracker.loadConfig(cwd)
         if (config.jolliApiKey.isNullOrBlank()) {
             ApplicationManager.getApplication().invokeLater {
-                Messages.showWarningDialog(project, "Please configure your Jolli API Key first (STATUS panel).", "Missing API Key")
+                Messages.showWarningDialog(project, "Please sign in or configure a Jolli API Key in Settings > Tools > Jolli Memory.", "Missing API Key")
             }
             return
         }
 
         val keyMeta = JolliApiClient.parseJolliApiKey(config.jolliApiKey!!)
         val resolvedBaseUrl = keyMeta?.u
-        if (resolvedBaseUrl == null) {
+            ?: ai.jolli.jollimemory.auth.JolliUrlConfig.getJolliUrl()
+        if (resolvedBaseUrl.isBlank()) {
             ApplicationManager.getApplication().invokeLater {
                 Messages.showWarningDialog(project, "Jolli site URL could not be determined. Please regenerate your Jolli API Key.", "Invalid API Key")
             }
@@ -411,7 +412,7 @@ class SummaryPanel(
                 val scenarios = Summarizer.generateE2eTest(Summarizer.E2eTestParams(
                     topics = topics.map { it.topic.topic },
                     commitMessage = summary.commitMessage, diff = diff,
-                    apiKey = config.apiKey, model = config.model,
+                    apiKey = config.apiKey, model = config.model, jolliApiKey = config.jolliApiKey,
                 ))
 
                 val updatedSummary = summary.copy(e2eTestGuide = scenarios)
@@ -511,7 +512,7 @@ class SummaryPanel(
                 }
                 ApplicationManager.getApplication().invokeLater { postToWebview("planTranslating", mapOf("slug" to slug)) }
                 val config = SessionTracker.loadConfig(cwd)
-                val translated = Summarizer.translateToEnglish(content, config.apiKey, config.model)
+                val translated = Summarizer.translateToEnglish(content, config.apiKey, config.model, config.jolliApiKey)
                 store.writePlanToBranch(slug, translated, "Translate plan $slug to English")
                 syncPlanTitle(slug, translated)
                 planTranslateSet.remove(slug)

--- a/intellij/src/test/kotlin/ai/jolli/jollimemory/services/JolliAuthServiceTest.kt
+++ b/intellij/src/test/kotlin/ai/jolli/jollimemory/services/JolliAuthServiceTest.kt
@@ -1,0 +1,135 @@
+package ai.jolli.jollimemory.services
+
+import ai.jolli.jollimemory.core.JolliMemoryConfig
+import ai.jolli.jollimemory.core.SessionTracker
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.mockk.every
+import io.mockk.mockkObject
+import io.mockk.slot
+import io.mockk.unmockkObject
+import io.mockk.verify
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+
+class JolliAuthServiceTest {
+
+    // --- parseQuery tests ---
+
+    @Test
+    fun `parseQuery parses standard query string`() {
+        val result = JolliAuthService.parseQuery("token=abc&space=my-org&jolli_api_key=sk-123")
+        result["token"] shouldBe "abc"
+        result["space"] shouldBe "my-org"
+        result["jolli_api_key"] shouldBe "sk-123"
+    }
+
+    @Test
+    fun `parseQuery returns empty map for blank input`() {
+        JolliAuthService.parseQuery("") shouldBe emptyMap()
+        JolliAuthService.parseQuery("   ") shouldBe emptyMap()
+    }
+
+    @Test
+    fun `parseQuery handles URL-encoded values`() {
+        val result = JolliAuthService.parseQuery("callback=http%3A%2F%2Flocalhost%3A8080%2Fpath")
+        result["callback"] shouldBe "http://localhost:8080/path"
+    }
+
+    @Test
+    fun `parseQuery handles param with no value`() {
+        val result = JolliAuthService.parseQuery("token=abc&empty")
+        result["token"] shouldBe "abc"
+        result["empty"] shouldBe ""
+    }
+
+    @Test
+    fun `parseQuery last value wins for duplicate keys`() {
+        val result = JolliAuthService.parseQuery("key=first&key=second")
+        result["key"] shouldBe "second"
+    }
+
+    // --- getErrorMessage tests ---
+
+    @Test
+    fun `getErrorMessage returns message for known codes`() {
+        JolliAuthService.getErrorMessage("access_denied") shouldContain "denied"
+        JolliAuthService.getErrorMessage("invalid_request") shouldContain "Invalid"
+        JolliAuthService.getErrorMessage("server_error") shouldContain "Server error"
+        JolliAuthService.getErrorMessage("temporarily_unavailable") shouldContain "unavailable"
+    }
+
+    @Test
+    fun `getErrorMessage includes code for unknown errors`() {
+        val result = JolliAuthService.getErrorMessage("something_weird")
+        result shouldContain "something_weird"
+    }
+
+    // --- signOut tests ---
+
+    @AfterEach
+    fun tearDown() {
+        try { unmockkObject(SessionTracker) } catch (_: Exception) {}
+    }
+
+    @Test
+    fun `signOut clears authToken but preserves jolliApiKey`() {
+        mockkObject(SessionTracker)
+        every { SessionTracker.getGlobalConfigDir() } returns "/fake/global"
+        every { SessionTracker.loadConfigFromDir("/fake/global") } returns JolliMemoryConfig(
+            authToken = "old-token",
+            jolliApiKey = "sk-jol-keep-me",
+        )
+        val savedConfig = slot<JolliMemoryConfig>()
+        every { SessionTracker.saveConfigToDir(capture(savedConfig), "/fake/global") } returns Unit
+
+        JolliAuthService.signOut()
+
+        savedConfig.captured.authToken shouldBe null
+        savedConfig.captured.jolliApiKey shouldBe "sk-jol-keep-me"
+    }
+
+    @Test
+    fun `signOut notifies auth listeners`() {
+        mockkObject(SessionTracker)
+        every { SessionTracker.getGlobalConfigDir() } returns "/fake/global"
+        every { SessionTracker.loadConfigFromDir("/fake/global") } returns JolliMemoryConfig()
+        every { SessionTracker.saveConfigToDir(any(), any()) } returns Unit
+
+        var notified = false
+        val disposable = JolliAuthService.addAuthListener { notified = true }
+
+        JolliAuthService.signOut()
+
+        notified shouldBe true
+        disposable.dispose()
+    }
+
+    // --- login timeout test ---
+
+    @Test
+    fun `times out and fires onError when no callback arrives`() {
+        val latch = CountDownLatch(1)
+        val errorMessages = mutableListOf<String>()
+        val successCount = AtomicInteger(0)
+
+        JolliAuthService.login(
+            timeoutSeconds = 0L,
+            onSuccess = { successCount.incrementAndGet() },
+            onError = { msg ->
+                synchronized(errorMessages) { errorMessages += msg }
+                latch.countDown()
+            },
+        )
+
+        latch.await(5, TimeUnit.SECONDS) shouldBe true
+        successCount.get() shouldBe 0
+        synchronized(errorMessages) {
+            errorMessages.size shouldBe 1
+            errorMessages.single() shouldContain "timed out"
+        }
+    }
+}


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## E2E Test (8)
<details>
<summary><strong>1. Sign in to Jolli account from the tool window</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a valid Jolli account. Make sure you are currently signed out (no active session in the IDE).

**Steps:**
1. Open the Jolli Memory panel in the IDE (look for it in the side panel or bottom bar).
2. Check that a sign-in banner appears at the top of the panel.
3. Click the "Sign In" button in the banner.
4. Complete the login flow in the browser window that opens.
5. Return to the IDE and look at the Jolli Memory panel.

**Expected Results:**
- The sign-in banner disappears after a successful login.
- A status bar appears showing that you are signed in, along with a "Sign Out" button.

</blockquote>
</details>
<details>
<summary><strong>2. Sign out of Jolli account from the tool window</strong></summary>
<br>
<blockquote>

**Preconditions:** Be signed in to a Jolli account in the IDE.

**Steps:**
1. Open the Jolli Memory panel in the IDE.
2. Confirm the signed-in status bar is visible with a "Sign Out" button.
3. Click the "Sign Out" button.
4. Observe the panel.

**Expected Results:**
- The signed-in status bar disappears.
- The sign-in banner reappears at the top of the panel.

</blockquote>
</details>
<details>
<summary><strong>3. Sign in to Jolli account from the Settings page</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a valid Jolli account. Make sure you are currently signed out.

**Steps:**
1. Open Settings and navigate to Tools > Jolli Memory.
2. Find the Account section on the settings page.
3. Check that a "Sign In" button and a status label are visible.
4. Click the "Sign In" button and complete the login in the browser.
5. Return to the Settings page.

**Expected Results:**
- The status label updates to show you are signed in.
- The button changes to "Sign Out".
- The Jolli API Key field label updates to indicate the key is optional now that an account is active.

</blockquote>
</details>
<details>
<summary><strong>4. Sign out of Jolli account from the Settings page</strong></summary>
<br>
<blockquote>

**Preconditions:** Be signed in to a Jolli account in the IDE.

**Steps:**
1. Open Settings and navigate to Tools > Jolli Memory.
2. Find the Account section and confirm the "Sign Out" button is visible.
3. Click "Sign Out".
4. Observe the Account section.

**Expected Results:**
- The status label updates to show you are signed out.
- The button changes back to "Sign In".
- The Jolli API Key field label no longer shows the "optional" indicator.

</blockquote>
</details>
<details>
<summary><strong>5. Generate a commit message using a Jolli account (no Anthropic key)</strong></summary>
<br>
<blockquote>

**Preconditions:** Be signed in to a Jolli account. Ensure no Anthropic API key is set in Settings or as an environment variable. Have at least one file staged for commit in a Git repository.

**Steps:**
1. Stage a change in your project.
2. Open the commit dialog or trigger the AI commit message action.
3. Wait for the AI to generate a commit message.
4. Check the result.

**Expected Results:**
- The commit message is generated successfully without any error about a missing API key.
- The generated message appears in the commit message field.

</blockquote>
</details>
<details>
<summary><strong>6. Error shown when no credentials are available at commit time</strong></summary>
<br>
<blockquote>

**Preconditions:** Be signed out of Jolli. Ensure no Anthropic API key is configured in Settings and no environment variable is set. Have at least one file staged for commit.

**Steps:**
1. Stage a change in your project.
2. Trigger the AI commit message action.
3. Observe what happens.

**Expected Results:**
- An error dialog appears stating that no credentials are available.
- The message directs you to sign in to Jolli or configure an Anthropic API key in Settings.
- No commit message is generated.

</blockquote>
</details>
<details>
<summary><strong>7. OAuth login rejects a tampered or replayed callback (CSRF protection)</strong></summary>
<br>
<blockquote>

**Preconditions:** Be signed out of Jolli. Have a way to send a custom web request to localhost (e.g. a browser or a tool like Postman).

**Steps:**
1. Trigger the Sign In flow from the tool window or Settings page.
2. Before completing the login in the browser, manually open a new browser tab and try to visit the local callback URL with a made-up or blank state value in the address bar.
3. Observe the response in the browser tab.
4. Check whether the IDE shows a successful sign-in.

**Expected Results:**
- The manually crafted callback is rejected and the browser shows an error (such as a 403 or similar failure message).
- The IDE does not show a signed-in status — the sign-in banner remains visible.
- The local callback server shuts down after the failed attempt and does not remain open.

</blockquote>
</details>
<details>
<summary><strong>8. Settings save does not erase the stored auth token</strong></summary>
<br>
<blockquote>

**Preconditions:** Be signed in to a Jolli account so an auth token is stored.

**Steps:**
1. Open Settings and navigate to Tools > Jolli Memory.
2. Change any unrelated setting (for example, update the model selection or a text field).
3. Click OK or Apply to save.
4. Close and reopen Settings.
5. Check the Account section.

**Expected Results:**
- The account status still shows you are signed in after saving.
- The auth token has not been cleared by the save operation.

</blockquote>
</details>

---

## Topics (5)
<details>
<summary><strong>01 · OAuth login flow with CSRF state parameter protection</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The login callback accepted any GET request containing a token and wrote it straight to disk, with no verification that the callback came from the browser tab the plugin opened. Any local process or browser tab could silently sign the IDE into an attacker-controlled account, after which the plugin would push diffs and transcripts to attacker-owned storage.

**💡 Decisions Behind the Code**

- **State embedded in callback URL, not as a top-level login param**: The Jolli web app stores the entire `cli_callback` URL and appends `token=` to it on redirect, so a separate `state=` param on the login URL would be lost. Embedding state inside the callback URL ensures it survives the round-trip automatically.
- **Shutdown on mismatch, not just rejection**: Leaving the server open after a failed state check would keep the exposure window alive until timeout. Shutting down immediately closes the window as soon as an invalid request is detected.
- **`finally` block for shutdown**: An early `return` inside the callback handler would skip `shutdown()`, leaving the server running. The `finally` block guarantees cleanup regardless of which code path exits.

**✅ What Was Implemented**

- `JolliAuthService.kt` (new): full OAuth callback server — generates a 128-bit cryptographically random state token before opening the browser, embeds it in the callback URL (URL-encoded inside `cli_callback` so the web app forwards it back), and rejects any callback where the returned state doesn't match with a 403 response
- State mismatch and error paths both call `shutdown()` via a `finally` block so the server never stays open past a failed check
- 60-second timeout was already present; this change adds the state validation on top of it
- `JolliAuthServiceTest.kt` (new): verifies the timeout fires `onError` and never fires `onSuccess`

**📁 FILES**
- `intellij/src/main/kotlin/ai/jolli/jollimemory/services/JolliAuthService.kt`
- `intellij/src/test/kotlin/ai/jolli/jollimemory/services/JolliAuthServiceTest.kt`

</blockquote>
</details>
<details>
<summary><strong>02 · Jolli account sign-in UI in tool window and settings page</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

There was no way for users to sign in to their Jolli account from inside the IDE. Credentials had to be configured manually as raw API keys, with no guided flow and no visible account status.

**💡 Decisions Behind the Code**

- **Banner in tool window, not just Settings**: Placing the sign-in prompt where users already work (the tool window) makes it discoverable without requiring them to navigate to preferences first, improving adoption.
- **Auth listener pattern for UI sync**: Rather than polling or requiring manual refresh, `JolliAuthService` maintains a listener list so all UI surfaces update immediately when auth state changes, keeping the signed-in bar and banner in sync without coupling them directly.
- **Jolli API Key field kept but marked optional when signed in**: Removing the field entirely would break existing users who configured a key manually. Relabeling it as optional preserves backward compatibility while communicating the new preferred path.

**✅ What Was Implemented**

- `JolliMemoryToolWindowFactory.kt`: adds a sign-in banner at the top of the tool window (shown when signed out) and a signed-in status bar with a Sign Out button (shown when signed in); both toggle via `JolliAuthService.addAuthListener`
- `JolliMemoryConfigurable.kt`: adds an Account section to the Settings page with a dynamic Sign In / Sign Out button and status label; the Jolli API Key label updates to indicate it is optional when an account is active
- `StatusPanel.kt`: removes the warning row that appeared when no Jolli API key was configured, since sign-in is now the primary path
- `SummaryPanel.kt`: updates the missing-key warning message to direct users to sign in or use Settings

**📁 FILES**
- `intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/JolliMemoryToolWindowFactory.kt`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/settings/JolliMemoryConfigurable.kt`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/StatusPanel.kt`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/auth/JolliConfigStore.kt`

</blockquote>
</details>
<details>
<summary><strong>03 · LLM proxy routing layer to support Jolli-managed credentials</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

All LLM calls were hardwired to the Anthropic API and required users to supply their own API key. There was no way to route calls through the Jolli backend for users who sign in with an account instead of providing a key directly.

**💡 Decisions Behind the Code**

- **Proxy sends action key + params, not a pre-built prompt**: The Jolli backend owns the prompt templates in proxy mode, so the plugin only needs to send structured data. This lets the backend iterate on prompts without plugin releases, and avoids sending large prompt strings over the wire when the backend can construct them.
- **Anthropic key takes priority over proxy**: Users who already have a direct key configured get the same behavior as before; the proxy is only used as a fallback, minimising disruption to existing setups.
- **Single routing object rather than per-call branching**: Centralising the credential resolution and dispatch in one place makes the priority logic easy to audit and change, rather than duplicating it across five call sites.

**✅ What Was Implemented**

- `LlmClient.kt` (new): central routing object with `resolveCredentialSource` (priority: Anthropic config key > `ANTHROPIC_API_KEY` env var > Jolli proxy) and `callLlm` that dispatches to either direct Anthropic or `JolliApiClient.callLlmProxy`
- `JolliApiClient.kt`: adds `callLlmProxy` (POST to `/api/push/llm/complete` with action key + params) and `resolveToken` (prefers explicit key, falls back to stored OAuth token)
- `Summarizer.kt`: all five LLM call sites (`generateSummary`, `generateCommitMessage`, `generateE2eTest`, `translateToEnglish`, `generateSquashMessage`) refactored to go through `LlmClient.callLlm`; each now accepts an optional `jolliApiKey` param
- `PlanProgressEvaluator.kt`: same refactor applied
- `CommitAIAction.kt`, `SquashAction.kt`, `PostCommitHook.kt`: credential check and error messages updated to reflect that either an Anthropic key or a Jolli account is sufficient

**📁 FILES**
- `intellij/src/main/kotlin/ai/jolli/jollimemory/core/LlmClient.kt`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/services/JolliApiClient.kt`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/core/Summarizer.kt`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/core/PlanProgressEvaluator.kt`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/hooks/PostCommitHook.kt`

</blockquote>
</details>
<details>
<summary><strong>04 · Windows PATH fix to make git hooks find shell utilities</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

When IntelliJ runs a git commit, the JVM process that launches git hooks does not inherit the user's shell PATH. On Windows this means tools like `sed` — which live in Git's `usr/bin` directory — are not found, causing hook scripts to fail silently.

**💡 Decisions Behind the Code**

- **Locate Git root dynamically via `where git`**: Hard-coding a path like `C:\Program Files\Git` would break for users with non-standard install locations. Deriving the root from the actual `git.exe` location works regardless of where Git is installed.
- **Append rather than replace PATH**: Replacing the entire PATH would drop other entries the JVM inherited. Appending `usr/bin` is the minimal, safe change that adds only what is missing.

**✅ What Was Implemented**

`GitOps.kt`: added `resolveWindowsPath()` — on Windows, runs `where git` to locate `git.exe`, walks up two directory levels to the Git install root, checks for `usr/bin`, and appends it to the inherited `PATH` in the `ProcessBuilder` environment. The existing Unix path-resolution logic is unchanged.

**📁 FILES**
- `intellij/src/main/kotlin/ai/jolli/jollimemory/bridge/GitOps.kt`

</blockquote>
</details>
<details>
<summary><strong>05 · Global config store for auth token and space, shared with CLI</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The OAuth token received after sign-in needed a persistent home that both the IntelliJ plugin and the CLI tool could read, and the existing per-project config file was not the right place for account-level credentials.

**💡 Decisions Behind the Code**

- **Separate file for space (`space.json`) vs. token (`config.json`)**: The CLI already uses this layout, so matching it avoids a migration and lets both tools share state without coordination.
- **Merge-on-save in settings dialogs**: Previously, saving settings constructed a fresh config object, which would silently erase any fields the dialog didn't manage (including the new auth token). Switching to load-then-copy preserves all fields not explicitly changed by the user.

**✅ What Was Implemented**

- `JolliConfigStore.kt` (new): read/write helpers for `~/.jolli/jollimemory/config.json` (auth token) and `~/.jolli/space.json` (space name), both shared with the CLI
- `Types.kt`: added `authToken` field to `JolliMemoryConfig`
- `SessionTracker.kt`: `mergeConfig` now preserves `authToken` when merging partial updates
- `JolliMemoryConfigurable.kt` and `SettingsDialog.kt`: settings saves now load the existing global config and use `copy()` to merge changes, preventing unrelated fields (including `authToken`) from being wiped on save

**📁 FILES**
- `intellij/src/main/kotlin/ai/jolli/jollimemory/auth/JolliConfigStore.kt`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/core/Types.kt`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/settings/JolliMemoryConfigurable.kt`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/SettingsDialog.kt`

</blockquote>
</details>

---

*Generated by Jolli Memory · April 28, 2026 at 6:06 PM*
<!-- jollimemory-summary-end -->