### PR TITLE
Fixes JOLLI-1376: Fix diff stat accuracy for amend and squash commits

### DIFF
--- a/cli/DEVELOPMENT.md
+++ b/cli/DEVELOPMENT.md
@@ -132,10 +132,35 @@ jolli status
 | [GeminiSessionDetector.ts](src/core/GeminiSessionDetector.ts) | Detects Gemini CLI installation |
 | [Summarizer.ts](src/core/Summarizer.ts) | Anthropic API calls for structured summary generation. Also exports `generateSquashMessage()` for the VSCode extension's squash flow |
 | [SummaryStore.ts](src/core/SummaryStore.ts) | Reads/writes summaries to the orphan branch (v3 tree format), merge/migrate operations |
-| [SummaryTree.ts](src/core/SummaryTree.ts) | Tree traversal utilities (aggregate stats/turns, collect source nodes) |
+| [SummaryTree.ts](src/core/SummaryTree.ts) | Tree traversal utilities (aggregate stats/turns, collect source nodes, `resolveDiffStats` display helper) |
 | [SummaryMigration.ts](src/core/SummaryMigration.ts) | v1→v3 migration logic for legacy orphan branch data |
 | [GitOperationDetector.ts](src/hooks/GitOperationDetector.ts) | Detects git operation type (commit, amend, squash, rebase, cherry-pick, revert) |
 | [Installer.ts](src/install/Installer.ts) | Installs/removes hooks in Claude Code, Gemini, and git |
+
+## Display-Layer Conventions
+
+### Reading diff stats — always use `resolveDiffStats`
+
+Any code that shows file/line diff numbers to a human (UI, Markdown, console, PR body, webview, AI briefing text) **MUST** read through `resolveDiffStats(node)` from [SummaryTree.ts](src/core/SummaryTree.ts).
+
+Do **NOT**:
+- Call `aggregateStats(node)` directly in display code — it recursively sums children, which over-counts files edited by multiple source commits in a squash.
+- Read `node.stats?.insertions` / `.deletions` / `.filesChanged` directly as display data — `stats` has different semantics per node type (delta for amend, absent for squash containers). It is kept as a legacy / old-plugin compat field, not for display.
+
+Do:
+- Call `resolveDiffStats(node)` — priority: persisted `node.diffStats` (new data) → `node.stats` on a leaf (legacy leaf) → recursive `aggregateStats` (legacy container fallback). The leaf/container branching prevents double-counting grandchildren on amend-over-squash trees.
+
+### Writing diff stats — `diffStats` is the persisted truth
+
+Every code path that constructs a `CommitSummary` writes `diffStats` from a fresh `git diff {hash}^..{hash}`:
+- [QueueWorker.executePipeline](src/hooks/QueueWorker.ts) — leaf commits
+- [QueueWorker.handleAmendPipeline](src/hooks/QueueWorker.ts) — amend (both the LLM branch and the message-only branch)
+- [SummaryStore.mergeManyToOne](src/core/SummaryStore.ts) — squash / merge-squash
+- [SummaryStore.migrateOneToOne](src/core/SummaryStore.ts) — rebase-pick
+
+`flattenSummaryTree()` prefers `node.diffStats` when writing the index entry, so `summaries/{hash}.json` and `index.json` are guaranteed consistent by construction and there is no redundant git call.
+
+`stats` stays untouched on new writes (keeps old plugin versions functional when they read new data).
 
 ## Unified Git Operation Queue
 

--- a/cli/src/Types.ts
+++ b/cli/src/Types.ts
@@ -202,8 +202,39 @@ export interface CommitSummary {
 	readonly conversationTurns?: number;
 	/** LLM call metadata; absent for squash/merge containers (no API call made) */
 	readonly llm?: LlmCallMetadata;
-	/** Diff statistics for this node's own changes */
+	/**
+	 * Legacy field: "this node's own LLM-processed diff".
+	 *
+	 * Semantics vary by node type — this is WHY display code cannot read it directly:
+	 *   - Leaf commits            → git diff {hash}^..{hash} (correct)
+	 *   - amend roots             → may be delta (oldHash..newHash) when diffOverride used,
+	 *                               or the full amended diff (HEAD~1..HEAD) otherwise
+	 *   - squash / rebase-pick roots → absent (containers have no own stats)
+	 *
+	 * Kept for:
+	 *   (a) backward compat with older plugin versions that only know this field
+	 *   (b) historical amend delta info (not user-facing but retained for completeness)
+	 *   (c) v3 fallback when `diffStats` is absent on legacy data
+	 *
+	 * New code should prefer `diffStats`. Display code MUST use resolveDiffStats(node)
+	 * — never read this field directly as display data.
+	 */
 	readonly stats?: DiffStats;
+	/**
+	 * Real `git diff {commitHash}^..{commitHash} --shortstat` result.
+	 *
+	 * Semantics: "this commit's actual diff against its parent". Identical meaning for
+	 * every node type (leaf / amend root / squash root / rebase-pick root / nested
+	 * container). Written at construction time by:
+	 *   - executePipeline         (leaf)
+	 *   - handleAmendPipeline     (both the LLM branch and the message-only branch)
+	 *   - mergeManyToOne          (squash / merge-squash root)
+	 *   - migrateOneToOne         (rebase-pick root)
+	 *
+	 * Display code reads via resolveDiffStats(), which falls back to `stats` /
+	 * aggregateStats() for v3 legacy data that predates this field.
+	 */
+	readonly diffStats?: DiffStats;
 	/** AI-generated topics for this node's own changes */
 	readonly topics?: ReadonlyArray<TopicSummary>;
 	/**

--- a/cli/src/commands/ViewCommand.ts
+++ b/cli/src/commands/ViewCommand.ts
@@ -14,7 +14,7 @@ import { type Command, Option } from "commander";
 import { getDisplayDate } from "../core/SummaryFormat.js";
 import { buildMarkdown } from "../core/SummaryMarkdownBuilder.js";
 import { getIndex, getSummary } from "../core/SummaryStore.js";
-import { aggregateStats, aggregateTurns, collectAllTopics, formatDurationLabel } from "../core/SummaryTree.js";
+import { aggregateTurns, collectAllTopics, formatDurationLabel, resolveDiffStats } from "../core/SummaryTree.js";
 import { createLogger, setLogDir } from "../Logger.js";
 import type { CommitSummary, SummaryIndexEntry, TopicSummary } from "../Types.js";
 import { formatShortDate, parsePositiveInt, resolveProjectDir } from "./CliUtils.js";
@@ -129,7 +129,7 @@ function printSummary(summary: CommitSummary): void {
 	console.log(`  Date:    ${getDisplayDate(summary)}`);
 	console.log(`  Duration: ${formatDurationLabel(summary)}`);
 
-	const stats = aggregateStats(summary);
+	const stats = resolveDiffStats(summary);
 	const statsStr = `${stats.filesChanged} files, +${stats.insertions} -${stats.deletions}`;
 	console.log(`  Changes: ${statsStr}`);
 

--- a/cli/src/core/ContextCompiler.ts
+++ b/cli/src/core/ContextCompiler.ts
@@ -11,7 +11,7 @@ import { createLogger } from "../Logger.js";
 import type { CommitSummary, SummaryIndexEntry } from "../Types.js";
 import { getDisplayDate } from "./SummaryFormat.js";
 import { getIndex, getSummary, readNoteFromBranch, readPlanFromBranch } from "./SummaryStore.js";
-import { aggregateStats, collectAllTopics } from "./SummaryTree.js";
+import { collectAllTopics, resolveDiffStats } from "./SummaryTree.js";
 
 const log = createLogger("ContextCompiler");
 
@@ -311,12 +311,17 @@ export async function compileTaskContext(options: ContextOptions, cwd?: string):
 		}
 	}
 
-	// Step 7: Aggregate stats
+	// Step 7: Aggregate stats.
+	// Horizontal (cross-commit) sum: each summary contributes its own real diff; sum
+	// gives the total work for the branch. Uses resolveDiffStats() so each commit's
+	// contribution is the persisted real `git diff` (new data) or the best available
+	// fallback (legacy). This is different from vertical (tree) recursion, which is
+	// what we eliminated — the outer sum here is the correct semantics.
 	let totalFilesChanged = 0;
 	let totalInsertions = 0;
 	let totalDeletions = 0;
 	for (const summary of summaries) {
-		const stats = aggregateStats(summary);
+		const stats = resolveDiffStats(summary);
 		totalFilesChanged += stats.filesChanged;
 		totalInsertions += stats.insertions;
 		totalDeletions += stats.deletions;
@@ -483,7 +488,7 @@ export function renderContextMarkdown(ctx: CompiledContext, tokenBudget?: number
 
 function renderSummarySection(summary: CommitSummary, index?: number): string {
 	const lines: string[] = [];
-	const stats = aggregateStats(summary);
+	const stats = resolveDiffStats(summary);
 	const prefix = index !== undefined ? `${index}. ` : "";
 
 	lines.push(

--- a/cli/src/core/SummaryMarkdownBuilder.test.ts
+++ b/cli/src/core/SummaryMarkdownBuilder.test.ts
@@ -227,6 +227,89 @@ describe("buildMarkdown", () => {
 		expect(md).not.toContain("1 files");
 	});
 
+	it("reads from diffStats (new data) rather than aggregating children — fixes squash over-count", () => {
+		// Squash root with diffStats set (new data). Children have their own stats,
+		// which if aggregated would yield filesChanged=4 (2+2). The real git diff
+		// says filesChanged=1. The display must show 1.
+		const squashRoot: CommitSummary = {
+			...leaf(),
+			stats: undefined,
+			diffStats: { filesChanged: 1, insertions: 42, deletions: 5 },
+			topics: undefined,
+			children: [
+				leaf({
+					commitHash: "child1",
+					stats: { filesChanged: 2, insertions: 20, deletions: 2 },
+					topics: [{ title: "c1", trigger: "t", response: "r", decisions: "d" }],
+				}),
+				leaf({
+					commitHash: "child2",
+					stats: { filesChanged: 2, insertions: 22, deletions: 3 },
+					topics: [{ title: "c2", trigger: "t", response: "r", decisions: "d" }],
+				}),
+			],
+		};
+		const md = buildMarkdown(squashRoot);
+		expect(md).toContain("1 file changed, +42 insertions");
+		expect(md).not.toContain("4 files");
+	});
+
+	it("falls back to aggregate for legacy squash root (no diffStats, no stats, has children)", () => {
+		// Mimics a v3 squash root on disk today: no diffStats anywhere, no stats on
+		// the container. resolveDiffStats must walk children — same as today's
+		// aggregateStats — so the rendered number is pixel-identical to today.
+		const legacySquashRoot: CommitSummary = {
+			...leaf(),
+			stats: undefined,
+			diffStats: undefined,
+			topics: undefined,
+			children: [
+				leaf({
+					commitHash: "child1",
+					stats: { filesChanged: 2, insertions: 20, deletions: 2 },
+					topics: [{ title: "c1", trigger: "t", response: "r", decisions: "d" }],
+				}),
+				leaf({
+					commitHash: "child2",
+					stats: { filesChanged: 2, insertions: 22, deletions: 3 },
+					topics: [{ title: "c2", trigger: "t", response: "r", decisions: "d" }],
+				}),
+			],
+		};
+		const md = buildMarkdown(legacySquashRoot);
+		// Aggregate: 2 + 2 = 4 files, 20 + 22 = 42 insertions, 2 + 3 = 5 deletions
+		expect(md).toContain("4 files changed, +42 insertions, −5 deletions");
+	});
+
+	it("Source Commits section uses each child's real diff via resolveDiffStats", () => {
+		const squashRoot: CommitSummary = {
+			...leaf(),
+			stats: undefined,
+			diffStats: { filesChanged: 2, insertions: 30, deletions: 4 },
+			topics: undefined,
+			children: [
+				leaf({
+					commitHash: "childAAA",
+					commitMessage: "first",
+					commitDate: "2026-03-02T10:00:00.000Z",
+					stats: { filesChanged: 1, insertions: 7, deletions: 1 },
+					topics: [{ title: "c1", trigger: "t", response: "r", decisions: "d" }],
+				}),
+				leaf({
+					commitHash: "childBBB",
+					commitMessage: "second",
+					commitDate: "2026-03-03T10:00:00.000Z",
+					stats: { filesChanged: 1, insertions: 23, deletions: 3 },
+					topics: [{ title: "c2", trigger: "t", response: "r", decisions: "d" }],
+				}),
+			],
+		};
+		const md = buildMarkdown(squashRoot);
+		// Each child row renders its own real diff, not aggregated
+		expect(md).toContain("+7 ");
+		expect(md).toContain("+23 ");
+	});
+
 	it("renders date-grouped topics for multi-day squash", () => {
 		const child1 = leaf({
 			commitHash: "aaa",

--- a/cli/src/core/SummaryMarkdownBuilder.ts
+++ b/cli/src/core/SummaryMarkdownBuilder.ts
@@ -16,7 +16,7 @@ import {
 	padIndex,
 	type TopicWithDate,
 } from "./SummaryFormat.js";
-import { aggregateStats, aggregateTurns, formatDurationLabel } from "./SummaryTree.js";
+import { aggregateTurns, formatDurationLabel, resolveDiffStats } from "./SummaryTree.js";
 
 /**
  * Builds a Markdown string from a CommitSummary for clipboard export.
@@ -74,11 +74,11 @@ export function buildPrMarkdown(summary: CommitSummary): string {
 
 /** Appends the commit properties header (H1, metadata list, separator). */
 function pushPropertiesSection(lines: Array<string>, summary: CommitSummary): void {
-	const aggStats = aggregateStats(summary);
-	const totalFiles = aggStats.filesChanged;
+	const displayStats = resolveDiffStats(summary);
+	const totalFiles = displayStats.filesChanged;
 	const totalTurns = aggregateTurns(summary);
 
-	const filesLabel = `${totalFiles} file${totalFiles !== 1 ? "s" : ""} changed, +${aggStats.insertions} insertions, \u2212${aggStats.deletions} deletions`;
+	const filesLabel = `${totalFiles} file${totalFiles !== 1 ? "s" : ""} changed, +${displayStats.insertions} insertions, \u2212${displayStats.deletions} deletions`;
 	const dateLabel = formatFullDate(getDisplayDate(summary));
 
 	lines.push(
@@ -157,11 +157,10 @@ function pushSourceCommitsSection(lines: Array<string>, sourceNodes: ReadonlyArr
 	}
 	lines.push("", `## Source Commits (${sourceNodes.length})`);
 	for (const node of sourceNodes) {
-		const ins = node.stats?.insertions ?? 0;
-		const del = node.stats?.deletions ?? 0;
+		const nodeStats = resolveDiffStats(node);
 		const turnsMd = node.conversationTurns ? ` · ${node.conversationTurns} turns` : "";
 		lines.push(
-			`- \`${node.commitHash.substring(0, 8)}\` ${node.commitMessage}  _(+${ins} \u2212${del}${turnsMd} · ${formatDate(getDisplayDate(node))})_`,
+			`- \`${node.commitHash.substring(0, 8)}\` ${node.commitMessage}  _(+${nodeStats.insertions} \u2212${nodeStats.deletions}${turnsMd} · ${formatDate(getDisplayDate(node))})_`,
 		);
 	}
 	lines.push("", "---");

--- a/cli/src/core/SummaryStore.test.ts
+++ b/cli/src/core/SummaryStore.test.ts
@@ -706,6 +706,8 @@ describe("SummaryStore", () => {
 			expect(newSummaryContent.commitType).toBe("rebase");
 			expect(newSummaryContent.topics).toBeUndefined();
 			expect(newSummaryContent.stats).toBeUndefined();
+			// diffStats is populated from git diff (persisted for display layer — no recursive aggregation needed)
+			expect(newSummaryContent.diffStats).toEqual({ filesChanged: 1, insertions: 5, deletions: 2 });
 			// Old summary preserved as the sole child — old hash is never lost
 			expect(newSummaryContent.children).toHaveLength(1);
 			expect(newSummaryContent.children?.[0].commitHash).toBe(oldHash);
@@ -883,6 +885,18 @@ describe("SummaryStore", () => {
 			expect(hashes).toContain(newHash);
 			expect(hashes).toContain("oldhash");
 		});
+
+		it("falls back to zero diffStats when git diff fails on the new rebase-pick root", async () => {
+			vi.mocked(getDiffStats).mockRejectedValueOnce(new Error("git diff failed"));
+			vi.mocked(readFileFromBranch).mockResolvedValueOnce(null);
+
+			const newHash = "newhash0000000000000002";
+			await migrateOneToOne(createMockSummary("oldhash"), createMockCommitInfo(newHash));
+
+			const files = vi.mocked(writeMultipleFilesToBranch).mock.calls[0][1] as ReadonlyArray<FileWrite>;
+			const migrated = JSON.parse(files[0].content) as CommitSummary;
+			expect(migrated.diffStats).toEqual({ filesChanged: 0, insertions: 0, deletions: 0 });
+		});
 	});
 
 	describe("mergeManyToOne", () => {
@@ -932,10 +946,15 @@ describe("SummaryStore", () => {
 			expect(mergedContent.children?.[1].commitHash).toBe(oldHash1);
 			expect(mergedContent.children?.[1].topics).toHaveLength(1);
 
-			// Pure container: no own topics/stats/llm
+			// Pure container: no own topics/stats/llm (stats = the node's own LLM-processed
+			// diff; a pure squash root has none since no LLM runs on it).
 			expect(mergedContent.topics).toBeUndefined();
 			expect(mergedContent.stats).toBeUndefined();
 			expect(mergedContent.llm).toBeUndefined();
+			// diffStats IS populated — it's the real `git diff {squashHash}^..{squashHash}`
+			// computed at merge time, so the display layer never needs to recursively
+			// aggregate children (which over-counts files edited by multiple sources).
+			expect(mergedContent.diffStats).toEqual({ filesChanged: 1, insertions: 5, deletions: 2 });
 
 			// Index: all three hashes present; old hashes are now children of new hash
 			const newIndexContent = JSON.parse(files[1].content) as SummaryIndex;
@@ -1488,6 +1507,57 @@ describe("SummaryStore", () => {
 			const merged = JSON.parse(files[0].content) as CommitSummary;
 			expect(merged.notes).toHaveLength(1);
 			expect(merged.notes?.[0].title).toBe("Newer");
+		});
+
+		it("stores diffStats from git --shortstat even when child .stats would over-count", async () => {
+			// Scenario: 3 source commits all edit the SAME file. Recursive aggregation
+			// (today's aggregateStats) would report filesChanged=3 because each child
+			// has its own stats{filesChanged:1}. The real git diff of the squash commit,
+			// however, is filesChanged=1 (one distinct file on disk). Our persisted
+			// diffStats reflects the real number — not the inflated aggregate.
+
+			// Override default getDiffStats for this test: real squash diff = 1 file.
+			vi.mocked(getDiffStats).mockResolvedValueOnce({
+				filesChanged: 1,
+				insertions: 42,
+				deletions: 5,
+			});
+
+			const makeSourceWithStats = (hash: string, insertions: number): CommitSummary => ({
+				...createMockSummary(hash),
+				stats: { filesChanged: 1, insertions, deletions: 1 },
+			});
+
+			const old1 = makeSourceWithStats("abc1", 10);
+			const old2 = makeSourceWithStats("abc2", 20);
+			const old3 = makeSourceWithStats("abc3", 15);
+
+			vi.mocked(readFileFromBranch).mockResolvedValueOnce(null);
+			await mergeManyToOne([old1, old2, old3], createMockCommitInfo("squash1"));
+
+			const files = vi.mocked(writeMultipleFilesToBranch).mock.calls[0][1] as ReadonlyArray<FileWrite>;
+			const merged = JSON.parse(files[0].content) as CommitSummary;
+
+			// Real diff wins: 1 file changed, NOT 3 (which children.stats summed would give)
+			expect(merged.diffStats).toEqual({ filesChanged: 1, insertions: 42, deletions: 5 });
+			// Sanity: children retain their original per-commit stats unchanged
+			expect(merged.children?.[0].stats?.filesChanged).toBe(1);
+			expect(merged.children?.[1].stats?.filesChanged).toBe(1);
+			expect(merged.children?.[2].stats?.filesChanged).toBe(1);
+		});
+
+		it("falls back to zero diffStats when git diff fails (e.g. first commit)", async () => {
+			vi.mocked(getDiffStats).mockRejectedValueOnce(new Error("git diff failed"));
+
+			vi.mocked(readFileFromBranch).mockResolvedValueOnce(null);
+			await mergeManyToOne(
+				[createMockSummary("old1"), createMockSummary("old2")],
+				createMockCommitInfo("newhash"),
+			);
+
+			const files = vi.mocked(writeMultipleFilesToBranch).mock.calls[0][1] as ReadonlyArray<FileWrite>;
+			const merged = JSON.parse(files[0].content) as CommitSummary;
+			expect(merged.diffStats).toEqual({ filesChanged: 0, insertions: 0, deletions: 0 });
 		});
 	});
 
@@ -2152,6 +2222,35 @@ describe("SummaryStore", () => {
 			expect(indexContent.entries[0].diffStats).toEqual({ filesChanged: 10, insertions: 100, deletions: 50 });
 			// getDiffStats should NOT be called — reused from existing entry
 			expect(getDiffStats).not.toHaveBeenCalled();
+		});
+
+		it("should prefer node.diffStats over index and skip git call (new-data path)", async () => {
+			// CommitSummary carries its own persisted diffStats (written by the pipeline).
+			// flattenSummaryTree must prefer it — this guarantees summary.json and
+			// index.json carry the same value by construction AND avoids a redundant
+			// git call. Priority: node.diffStats > existing entry > fresh git diff.
+			const summary: CommitSummary = {
+				...createMockSummary("newdata"),
+				diffStats: { filesChanged: 7, insertions: 77, deletions: 17 },
+			};
+			// Existing index has stale diffStats — should be ignored
+			const staleEntry: SummaryIndexEntry = {
+				...rootEntry("newdata", "Stale"),
+				diffStats: { filesChanged: 99, insertions: 999, deletions: 999 },
+			};
+			vi.mocked(readFileFromBranch).mockResolvedValueOnce(JSON.stringify(v3Index([staleEntry])));
+
+			await storeSummary(summary, undefined, true);
+
+			const files = vi.mocked(writeMultipleFilesToBranch).mock.calls[0][1] as ReadonlyArray<FileWrite>;
+			const indexContent = JSON.parse(files[1].content) as SummaryIndex;
+			// Index entry reflects node.diffStats, not the stale value nor a fresh git diff
+			expect(indexContent.entries[0].diffStats).toEqual({ filesChanged: 7, insertions: 77, deletions: 17 });
+			// No redundant git call when the node already carries the answer
+			expect(getDiffStats).not.toHaveBeenCalled();
+			// summary.json on disk reflects the same value — single source of truth
+			const summaryContent = JSON.parse(files[0].content) as CommitSummary;
+			expect(summaryContent.diffStats).toEqual({ filesChanged: 7, insertions: 77, deletions: 17 });
 		});
 	});
 

--- a/cli/src/core/SummaryStore.ts
+++ b/cli/src/core/SummaryStore.ts
@@ -168,6 +168,14 @@ export async function migrateOneToOne(
 	// - orphanedDocIds: memory article IDs pending cleanup on next push
 	const strippedOld = stripFunctionalMetadata(oldSummary);
 	const docUrl = oldSummary.jolliDocUrl;
+
+	// Compute the real `git diff {newHash}^..{newHash}` for the persisted `diffStats`
+	// field. Rebase-pick preserves the diff of the commit, but the new hash has a
+	// different parent so we recompute to be safe.
+	const migratedDiffStats: DiffStats = await getDiffStats(`${newCommitInfo.hash}^`, newCommitInfo.hash, cwd).catch(
+		(): DiffStats => ({ filesChanged: 0, insertions: 0, deletions: 0 }),
+	);
+
 	const newSummary: CommitSummary = {
 		version: 3,
 		commitHash: newCommitInfo.hash,
@@ -183,6 +191,7 @@ export async function migrateOneToOne(
 		...(oldSummary.plans && { plans: oldSummary.plans }),
 		...(oldSummary.notes && { notes: oldSummary.notes }),
 		...(oldSummary.e2eTestGuide && { e2eTestGuide: oldSummary.e2eTestGuide }),
+		diffStats: migratedDiffStats,
 		children: [strippedOld],
 	};
 
@@ -403,6 +412,14 @@ export async function mergeManyToOne(
 	const allOrphanedDocIds = [...jolliMeta.orphanedDocIds, ...inheritedOrphanIds];
 	const strippedChildren = children.map(stripFunctionalMetadata);
 
+	// Compute the real `git diff {squashHash}^..{squashHash}` for the persisted
+	// `diffStats` field. This is what the display layer reads — eliminates the need
+	// for the recursive children aggregation that previously over-counted files
+	// modified by multiple source commits.
+	const mergedDiffStats: DiffStats = await getDiffStats(`${newCommitInfo.hash}^`, newCommitInfo.hash, cwd).catch(
+		(): DiffStats => ({ filesChanged: 0, insertions: 0, deletions: 0 }),
+	);
+
 	const mergedSummary: CommitSummary = {
 		version: 3,
 		commitHash: newCommitInfo.hash,
@@ -418,6 +435,7 @@ export async function mergeManyToOne(
 		...(hoistedNotes.length > 0 && { notes: hoistedNotes }),
 		...(jolliMeta.winner && { jolliDocId: jolliMeta.winner.jolliDocId, jolliDocUrl: jolliMeta.winner.jolliDocUrl }),
 		...(allOrphanedDocIds.length > 0 && { orphanedDocIds: allOrphanedDocIds }),
+		diffStats: mergedDiffStats,
 		children: strippedChildren,
 	};
 
@@ -938,17 +956,26 @@ async function flattenSummaryTree(
 	const isRoot = parentCommitHash === null;
 
 	// For root entries, compute display-level metadata (topicCount + diffStats).
-	// diffStats are reused from the existing entry when available (commit hash unchanged
-	// means diff unchanged — e.g. WebView topic edits via storeSummary(force=true)).
+	// Source of truth for diffStats, in preference order:
+	//   1. node.diffStats — persisted by the construction pipeline (executePipeline /
+	//      handleAmendPipeline / mergeManyToOne / migrateOneToOne) from a fresh
+	//      `git diff`. Reusing it here avoids a redundant git call AND guarantees
+	//      that summaries/{hash}.json and index.json carry the same value by construction.
+	//   2. existing entry — commit hash unchanged means diff unchanged (e.g. WebView
+	//      topic edit via storeSummary(force=true) on a legacy v3 summary that has
+	//      no diffStats on the node).
+	//   3. fresh `git diff` — legacy v3 path where neither the node nor the index
+	//      entry carries diffStats yet. Returns zeros on first-commit (no parent).
 	let rootFields: { readonly topicCount: number; readonly diffStats: DiffStats } | undefined;
 	if (isRoot) {
+		const nodeDiffStats = node.diffStats;
 		const existingDiffStats = existingEntryMap?.get(node.commitHash)?.diffStats;
 		let diffStats: DiffStats;
-		if (existingDiffStats) {
+		if (nodeDiffStats) {
+			diffStats = nodeDiffStats;
+		} else if (existingDiffStats) {
 			diffStats = existingDiffStats;
 		} else {
-			// getDiffStats returns zeroes when git diff fails (e.g. first commit with no parent),
-			// because execGit internally catches all errors and returns empty stdout.
 			diffStats = await getDiffStats(`${node.commitHash}^`, node.commitHash, cwd);
 		}
 		rootFields = { topicCount: countTopics(node), diffStats };

--- a/cli/src/core/SummaryTree.test.ts
+++ b/cli/src/core/SummaryTree.test.ts
@@ -10,6 +10,7 @@ import {
 	deleteTopicInTree,
 	formatDurationLabel,
 	isLeafNode,
+	resolveDiffStats,
 	updateTopicInTree,
 } from "./SummaryTree.js";
 
@@ -356,6 +357,79 @@ describe("SummaryTree", () => {
 			expect(result).not.toBeNull();
 			expect(result?.consumed).toBe(3);
 			expect(result?.result).toBe(D);
+		});
+	});
+
+	describe("resolveDiffStats", () => {
+		it("returns diffStats when present (new-data path) — ignores stats and children", () => {
+			const node: CommitSummary = {
+				...A,
+				diffStats: { filesChanged: 99, insertions: 999, deletions: 9 },
+				stats: { filesChanged: 1, insertions: 1, deletions: 1 },
+				children: [B],
+			};
+			expect(resolveDiffStats(node)).toEqual({ filesChanged: 99, insertions: 999, deletions: 9 });
+		});
+
+		it("returns node.stats for a leaf (no children, no diffStats)", () => {
+			// A is a leaf with stats but no diffStats
+			expect(resolveDiffStats(A)).toEqual({ filesChanged: 3, insertions: 120, deletions: 5 });
+		});
+
+		it("returns zeros for a leaf with neither diffStats nor stats", () => {
+			const empty: CommitSummary = { ...A, stats: undefined };
+			expect(resolveDiffStats(empty)).toEqual({ filesChanged: 0, insertions: 0, deletions: 0 });
+		});
+
+		it("treats undefined children and [] children both as leaf", () => {
+			const withEmptyChildren: CommitSummary = { ...A, children: [] };
+			expect(resolveDiffStats(withEmptyChildren)).toEqual({ filesChanged: 3, insertions: 120, deletions: 5 });
+		});
+
+		it("aggregates across tree for a container (legacy squash root: no diffStats, no stats, has children)", () => {
+			// D is a pure container with children [B, C] where C in turn has child A.
+			// Matches today's aggregateStats behavior exactly.
+			const viaHelper = resolveDiffStats(D);
+			const viaAggregate = aggregateStats(D);
+			expect(viaHelper).toEqual(viaAggregate);
+			// Sanity: the sum matches aggregateStats's own test expectation
+			expect(viaHelper).toEqual({ filesChanged: 6, insertions: 203, deletions: 10 });
+		});
+
+		it("aggregates for a legacy amend root (stats is delta, has children)", () => {
+			// Legacy amend: stats = delta (small), children carry pre-amend full stats.
+			// Today's display is aggregateStats(amend) = delta + children.stats. Must
+			// stay identical under resolveDiffStats for backward compatibility.
+			const legacyAmend: CommitSummary = {
+				...C, // C already has stats (delta-ish) + children [A]
+			};
+			expect(resolveDiffStats(legacyAmend)).toEqual(aggregateStats(legacyAmend));
+			expect(resolveDiffStats(legacyAmend)).toEqual({ filesChanged: 4, insertions: 123, deletions: 8 });
+		});
+
+		it("aggregates for a legacy nested container (no diffStats anywhere, no root stats, has children)", () => {
+			// Pure nested container: mimics an old squash/rebase-pick root viewed via getSummary.
+			const nested: CommitSummary = {
+				...D,
+				stats: undefined,
+				diffStats: undefined,
+				children: [B, C], // reuse same sub-tree
+			};
+			expect(resolveDiffStats(nested)).toEqual(aggregateStats(nested));
+		});
+
+		it("returns diffStats even when children are present (new container root)", () => {
+			const newSquashRoot: CommitSummary = {
+				...D,
+				diffStats: { filesChanged: 2, insertions: 40, deletions: 20 },
+				// No stats (container), children still present
+				children: [B, C],
+			};
+			expect(resolveDiffStats(newSquashRoot)).toEqual({
+				filesChanged: 2,
+				insertions: 40,
+				deletions: 20,
+			});
 		});
 	});
 });

--- a/cli/src/core/SummaryTree.ts
+++ b/cli/src/core/SummaryTree.ts
@@ -42,6 +42,11 @@ export function collectAllTopics(node: CommitSummary): ReadonlyArray<TopicWithDa
 /**
  * Recursively aggregates diff statistics across the entire tree.
  * Pure function — does not mutate the original node.
+ *
+ * NOTE: Display code must NOT call this directly. Use resolveDiffStats() instead,
+ * which prefers the persisted `diffStats` field and only falls back here for v3
+ * legacy data. This function is retained as the fallback implementation and for
+ * internal use (e.g. SessionStartHook's branch-level aggregation).
  */
 export function aggregateStats(node: CommitSummary): DiffStats {
 	const s = node.stats;
@@ -55,6 +60,33 @@ export function aggregateStats(node: CommitSummary): DiffStats {
 		deletions += cs.deletions;
 	}
 	return { filesChanged, insertions, deletions };
+}
+
+/**
+ * Single source of truth for display code's diff stats.
+ *
+ * Decision tree:
+ *   1. node.diffStats present                → return it (new data, authoritative).
+ *   2. node is a LEAF (no children)          → return node.stats ?? zeros.
+ *      Leaves always have a well-defined `stats` = this commit's own diff.
+ *   3. node is a CONTAINER (has children)    → return aggregateStats(node).
+ *      Rationale: on legacy container roots, `stats` may be:
+ *        - absent (squash / rebase-pick roots)  → must aggregate
+ *        - a delta diff (amend root, Scenario 1) → mixing delta with
+ *          children.stats (the pre-amend full diff) is exactly what today's
+ *          aggregateStats() does. Preserving aggregate keeps the display
+ *          pixel-identical to today for legacy amend data.
+ *
+ * Display code MUST use this helper. Never call aggregateStats() directly, and
+ * never read node.stats as a display field.
+ */
+export function resolveDiffStats(node: CommitSummary): DiffStats {
+	if (node.diffStats) return node.diffStats;
+	const hasChildren = (node.children?.length ?? 0) > 0;
+	if (!hasChildren) {
+		return node.stats ?? { filesChanged: 0, insertions: 0, deletions: 0 };
+	}
+	return aggregateStats(node);
 }
 
 /** Recursively sums conversationTurns across the entire tree. */

--- a/cli/src/hooks/PostCommitHook.test.ts
+++ b/cli/src/hooks/PostCommitHook.test.ts
@@ -757,6 +757,12 @@ describe("queue-driven Worker", () => {
 		expect(getCommitInfo).toHaveBeenCalledWith("abc123", "/test/project");
 		expect(generateSummary).toHaveBeenCalled();
 		expect(deleteQueueEntry).toHaveBeenCalledWith(DEFAULT_COMMIT_OP.filePath);
+		// Leaf commits persist diffStats on the CommitSummary equal to the actual
+		// `git diff {hash}^..{hash}` result (mocked to {2, 10, 5} in setupFullPipeline).
+		// For leaves this value equals `stats`, but diffStats is the canonical
+		// field the display layer reads via resolveDiffStats.
+		const summaryArg = vi.mocked(storeSummary).mock.calls[0][0] as CommitSummary;
+		expect(summaryArg.diffStats).toEqual({ filesChanged: 2, insertions: 10, deletions: 5 });
 	});
 
 	it("exits gracefully when queue is empty", async () => {
@@ -1199,6 +1205,31 @@ describe("queue-driven Worker", () => {
 				false,
 				expect.anything(),
 			);
+			// The amend root carries diffStats so the display layer can read the
+			// real integer `git diff {newHash}^..{newHash}` instead of aggregating
+			// delta + children.stats (today's over-counting behavior).
+			const summaryArg = vi.mocked(storeSummary).mock.calls[0][0] as CommitSummary;
+			expect(summaryArg.diffStats).toBeDefined();
+		});
+
+		it("amend diffStats is the full commit diff (Scenario 1 second getDiffStats call)", async () => {
+			setupAmendPipeline({ hasOldSummary: true });
+			// Override getDiffStats to distinguish the two production calls:
+			// 1st call = delta (fromRef=oldHash, toRef=newHash) — used by the LLM
+			// 2nd call = full commit diff (newHash^..newHash) — persisted as diffStats
+			vi.mocked(getDiffStats)
+				.mockResolvedValueOnce({ filesChanged: 1, insertions: 3, deletions: 1 }) // delta
+				.mockResolvedValueOnce({ filesChanged: 5, insertions: 120, deletions: 40 }); // full
+
+			await runWorker("/test/project");
+
+			const summaryArg = vi.mocked(storeSummary).mock.calls[0][0] as CommitSummary;
+			// `diffStats` is the full commit diff for display — sourced from the
+			// 2nd getDiffStats call inserted by this refactor.
+			expect(summaryArg.diffStats).toEqual({ filesChanged: 5, insertions: 120, deletions: 40 });
+			// `stats` is whatever the LLM's SummaryResult carried (mock provides a
+			// fixed 2/10/5 via createMockResult). It is NOT the diffStats.
+			expect(summaryArg.stats).not.toEqual(summaryArg.diffStats);
 		});
 
 		it("creates fresh leaf node when no old summary exists", async () => {
@@ -1215,6 +1246,13 @@ describe("queue-driven Worker", () => {
 
 		it("skips LLM but migrates index for message-only amend (no diff, no transcript)", async () => {
 			setupAmendPipeline({ hasOldSummary: true, hasTranscript: false, hasDiff: false });
+			// Second getDiffStats call (for `{newHash}^..{newHash}` integral) returns
+			// a non-zero number — the full commit has a diff even though the message-only
+			// amend DELTA is empty. This is the key correctness invariant the plan
+			// calls out for the message-only branch.
+			vi.mocked(getDiffStats)
+				.mockResolvedValueOnce({ filesChanged: 0, insertions: 0, deletions: 0 }) // delta = empty
+				.mockResolvedValueOnce({ filesChanged: 3, insertions: 70, deletions: 15 }); // integral
 
 			await runWorker("/test/project");
 
@@ -1229,6 +1267,14 @@ describe("queue-driven Worker", () => {
 				}),
 				"/test/project",
 			);
+			// The message-only amend ALSO writes diffStats (the full commit diff) on
+			// the migrated summary, so display code doesn't fall back to recursive
+			// aggregation of children. This was previously missed — see plan.
+			const summaryArg = vi.mocked(storeSummary).mock.calls[0][0] as CommitSummary;
+			expect(summaryArg.diffStats).toEqual({ filesChanged: 3, insertions: 70, deletions: 15 });
+			// `stats` field stays undefined on the migrated summary (this path never
+			// ran an LLM and had no local `stats` value to assign).
+			expect(summaryArg.stats).toBeUndefined();
 		});
 	});
 

--- a/cli/src/hooks/QueueWorker.ts
+++ b/cli/src/hooks/QueueWorker.ts
@@ -735,7 +735,8 @@ async function executePipeline(cwd: string, op: GitOperation, force = false): Pr
 		log.info("Plan progress: evaluated %d/%d plan(s)", planProgressArtifacts.length, planRefs.length);
 	}
 
-	// Build the CommitSummary leaf node with top-level fields from the API result
+	// Build the CommitSummary leaf node with top-level fields from the API result.
+	// For a leaf, diffStats === stats (both are `git diff {hash}^..{hash}`).
 	const summary: CommitSummary = {
 		version: 3,
 		commitHash: commitInfo.hash,
@@ -747,6 +748,7 @@ async function executePipeline(cwd: string, op: GitOperation, force = false): Pr
 		commitType,
 		commitSource,
 		...summaryResult,
+		diffStats,
 		...(planRefs.length > 0 ? { plans: planRefs } : {}),
 		...(noteRefs.length > 0 ? { notes: noteRefs } : {}),
 	};
@@ -1018,6 +1020,17 @@ async function handleAmendPipeline(
 		formatElapsed(stepStart),
 	);
 
+	// Compute the amend commit's FULL diff (git diff {newHash}^..{newHash}) for the
+	// persisted `diffStats` field. In Scenario 1 (diffOverride = oldHash..newHash) the
+	// `diffStats` local above is the DELTA, not the full commit diff. In Scenario 2
+	// (default HEAD~1..HEAD, equals newHash^..newHash at amend time) the two are equal
+	// and we skip the extra git call.
+	const amendFullDiffStats: DiffStats = diffOverride
+		? await getDiffStats(`${commitInfo.hash}^`, commitInfo.hash, cwd).catch(
+				(): DiffStats => ({ filesChanged: 0, insertions: 0, deletions: 0 }),
+			)
+		: diffStats;
+
 	// Guard: skip LLM generation if no transcript entries AND no file changes.
 	// However, we MUST still migrate the index even when skipping — a message-only amend
 	// changes the commit hash and the old hash must be replaced in the index.
@@ -1041,6 +1054,7 @@ async function handleAmendPipeline(
 				...(metadata?.commitType && { commitType: metadata.commitType }),
 				...(metadata?.commitSource && { commitSource: metadata.commitSource }),
 				...hoistMetadataFromOldSummary(oldSummary),
+				diffStats: amendFullDiffStats,
 				children: [strippedOld],
 			};
 			await storeSummary(migratedSummary, cwd);
@@ -1109,6 +1123,10 @@ async function handleAmendPipeline(
 		...(metadata?.commitType && { commitType: metadata.commitType }),
 		...(metadata?.commitSource && { commitSource: metadata.commitSource }),
 		...summaryResult,
+		// `summaryResult.stats` is what the LLM processed — in Scenario 1 that's
+		// the amend delta, not the full commit diff. `diffStats` is a separate
+		// field that always records the full commit diff for display purposes.
+		diffStats: amendFullDiffStats,
 		...hoistMetadataFromOldSummary(oldSummary),
 		...(strippedOld && { children: [strippedOld] }),
 	};

--- a/vscode/src/views/SummaryHtmlBuilder.test.ts
+++ b/vscode/src/views/SummaryHtmlBuilder.test.ts
@@ -2,17 +2,29 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // ─── Hoisted mocks ──────────────────────────────────────────────────────────
 
-const { aggregateStats, aggregateTurns, formatDurationLabel } = vi.hoisted(
-	() => ({
-		aggregateStats: vi.fn(() => ({
-			insertions: 10,
-			deletions: 5,
-			filesChanged: 3,
-		})),
-		aggregateTurns: vi.fn(() => 0),
-		formatDurationLabel: vi.fn(() => "2 hours"),
+const {
+	aggregateStats,
+	aggregateTurns,
+	formatDurationLabel,
+	resolveDiffStats,
+} = vi.hoisted(() => ({
+	aggregateStats: vi.fn(() => ({
+		insertions: 10,
+		deletions: 5,
+		filesChanged: 3,
+	})),
+	aggregateTurns: vi.fn(() => 0),
+	formatDurationLabel: vi.fn(() => "2 hours"),
+	// resolveDiffStats: new canonical display-stats helper.
+	// Default impl mirrors the real helper's fallback: node.diffStats →
+	// node.stats → zeros. Source-commit rows with stats-less leaves render
+	// as +0 −0, matching the old production behavior.
+	resolveDiffStats: vi.fn((node: { diffStats?: unknown; stats?: unknown }) => {
+		if (node.diffStats) return node.diffStats;
+		if (node.stats) return node.stats;
+		return { insertions: 0, deletions: 0, filesChanged: 0 };
 	}),
-);
+}));
 
 const { buildPrSectionHtml } = vi.hoisted(() => ({
 	buildPrSectionHtml: vi.fn(() => ""),
@@ -67,6 +79,7 @@ vi.mock("../../../cli/src/core/SummaryTree.js", () => ({
 	aggregateStats,
 	aggregateTurns,
 	formatDurationLabel,
+	resolveDiffStats,
 }));
 
 vi.mock("../services/PrCommentService.js", () => ({
@@ -182,6 +195,14 @@ describe("SummaryHtmlBuilder", () => {
 			deletions: 5,
 			filesChanged: 3,
 		});
+		// Re-install the per-node default impl (clearAllMocks above cleared it).
+		resolveDiffStats.mockImplementation(
+			(node: { diffStats?: unknown; stats?: unknown }) => {
+				if (node.diffStats) return node.diffStats as object;
+				if (node.stats) return node.stats as object;
+				return { insertions: 0, deletions: 0, filesChanged: 0 };
+			},
+		);
 		aggregateTurns.mockReturnValue(0);
 		formatDurationLabel.mockReturnValue("2 hours");
 		buildPrSectionHtml.mockReturnValue("");
@@ -723,7 +744,7 @@ describe("SummaryHtmlBuilder", () => {
 		});
 
 		it("header shows correct singular/plural for file changes", () => {
-			aggregateStats.mockReturnValue({
+			resolveDiffStats.mockReturnValue({
 				insertions: 1,
 				deletions: 1,
 				filesChanged: 1,
@@ -735,7 +756,7 @@ describe("SummaryHtmlBuilder", () => {
 		});
 
 		it("header shows correct plural for multiple file changes", () => {
-			aggregateStats.mockReturnValue({
+			resolveDiffStats.mockReturnValue({
 				insertions: 10,
 				deletions: 5,
 				filesChanged: 3,

--- a/vscode/src/views/SummaryHtmlBuilder.ts
+++ b/vscode/src/views/SummaryHtmlBuilder.ts
@@ -7,9 +7,9 @@
  */
 
 import {
-	aggregateStats,
 	aggregateTurns,
 	formatDurationLabel,
+	resolveDiffStats,
 } from "../../../cli/src/core/SummaryTree.js";
 import type {
 	CommitSummary,
@@ -69,7 +69,7 @@ export function buildHtml(
 		sourceNodes,
 		showRecordDates,
 	} = collectSortedTopics(summary);
-	const stats = aggregateStats(summary);
+	const stats = resolveDiffStats(summary);
 	const totalInsertions = stats.insertions;
 	const totalDeletions = stats.deletions;
 	const totalFiles = stats.filesChanged;
@@ -553,12 +553,11 @@ function renderCommitRow(node: CommitSummary): string {
 	const turnsSuffix = turns
 		? ` &middot; <span class="stat-turns">${turns} turn${turns !== 1 ? "s" : ""}</span>`
 		: "";
-	const ins = node.stats?.insertions ?? 0;
-	const del = node.stats?.deletions ?? 0;
+	const nodeStats = resolveDiffStats(node);
 	return `<div class="commit-row">
   <span class="hash">${escHtml(node.commitHash.substring(0, 8))}</span>
   <span class="commit-msg">${escHtml(node.commitMessage)}</span>
-  <span class="commit-meta"><span class="stat-add">+${ins}</span> <span class="stat-del">\u2212${del}</span>${turnsSuffix} &middot; ${formatDate(getDisplayDate(node))}</span>
+  <span class="commit-meta"><span class="stat-add">+${nodeStats.insertions}</span> <span class="stat-del">\u2212${nodeStats.deletions}</span>${turnsSuffix} &middot; ${formatDate(getDisplayDate(node))}</span>
 </div>`;
 }
 

--- a/vscode/src/views/SummaryMarkdownBuilder.test.ts
+++ b/vscode/src/views/SummaryMarkdownBuilder.test.ts
@@ -14,6 +14,10 @@ const mocks = vi.hoisted(() => ({
 	aggregateStats: vi.fn(),
 	aggregateTurns: vi.fn(),
 	formatDurationLabel: vi.fn(),
+	// resolveDiffStats: new helper that prefers node.diffStats (new data) and
+	// falls back to aggregateStats (legacy path). Tests that previously set up
+	// aggregateStats return values keep working without change.
+	resolveDiffStats: vi.fn(),
 	collectSortedTopics: vi.fn(),
 	formatDate: vi.fn(),
 	formatFullDate: vi.fn(),
@@ -29,6 +33,7 @@ vi.mock("../../../cli/src/core/SummaryTree.js", () => ({
 	aggregateStats: mocks.aggregateStats,
 	aggregateTurns: mocks.aggregateTurns,
 	formatDurationLabel: mocks.formatDurationLabel,
+	resolveDiffStats: mocks.resolveDiffStats,
 }));
 
 // Mock the core SummaryFormat module (used by the core SummaryMarkdownBuilder)
@@ -60,6 +65,9 @@ function makeSummary(overrides: Partial<CommitSummary> = {}): CommitSummary {
 		commitDate: "2026-03-30T10:00:00Z",
 		branch: "feature/proj-100-login",
 		generatedAt: "2026-03-30T10:05:00Z",
+		// Default stats match commonSetup's aggregateStats return value, so the
+		// resolveDiffStats mock can read node.stats directly for the header case.
+		stats: { filesChanged: 3, insertions: 50, deletions: 10 },
 		...overrides,
 	};
 }
@@ -98,6 +106,15 @@ function setupDefaults(
 		filesChanged: 3,
 		insertions: 50,
 		deletions: 10,
+	});
+	// resolveDiffStats is the new canonical display-stats helper. Mirrors the
+	// real implementation's fallback: node.diffStats → node.stats → zeros.
+	// Leaves without stats render as +0 −0, matching the old production code
+	// path (which read `node.stats?.insertions ?? 0` directly).
+	mocks.resolveDiffStats.mockImplementation((node: CommitSummary) => {
+		if (node.diffStats) return node.diffStats;
+		if (node.stats) return node.stats;
+		return { filesChanged: 0, insertions: 0, deletions: 0 };
 	});
 	mocks.aggregateTurns.mockReturnValue(5);
 	mocks.formatDurationLabel.mockReturnValue("1 day (1 commit)");
@@ -160,6 +177,11 @@ describe("SummaryMarkdownBuilder", () => {
 				const summary = makeSummary();
 				setupDefaults(summary);
 				mocks.aggregateStats.mockReturnValue({
+					filesChanged: 1,
+					insertions: 5,
+					deletions: 0,
+				});
+				mocks.resolveDiffStats.mockReturnValue({
 					filesChanged: 1,
 					insertions: 5,
 					deletions: 0,
@@ -514,9 +536,12 @@ describe("SummaryMarkdownBuilder", () => {
 
 			it("handles source node without stats", () => {
 				const summary = makeSummary();
+				// Explicitly clear the default stats so the child is truly stats-less \u2014
+				// mirrors legacy data where a leaf's stats field was never written.
 				const child = makeSummary({
 					commitHash: "ccc3333300000000",
 					commitMessage: "No stats",
+					stats: undefined,
 				});
 				setupDefaults(summary, [makeTopic()], [child, child]);
 

--- a/vscode/src/views/SummaryMarkdownBuilder.ts
+++ b/vscode/src/views/SummaryMarkdownBuilder.ts
@@ -12,9 +12,9 @@
  */
 
 import {
-	aggregateStats,
 	aggregateTurns,
 	formatDurationLabel,
+	resolveDiffStats,
 } from "../../../cli/src/core/SummaryTree.js";
 import type { CommitSummary, E2eTestScenario } from "../../../cli/src/Types.js";
 import {
@@ -62,11 +62,11 @@ function pushPropertiesSection(
 	lines: Array<string>,
 	summary: CommitSummary,
 ): void {
-	const aggStats = aggregateStats(summary);
-	const totalFiles = aggStats.filesChanged;
+	const displayStats = resolveDiffStats(summary);
+	const totalFiles = displayStats.filesChanged;
 	const totalTurns = aggregateTurns(summary);
 
-	const filesLabel = `${totalFiles} file${totalFiles !== 1 ? "s" : ""} changed, +${aggStats.insertions} insertions, −${aggStats.deletions} deletions`;
+	const filesLabel = `${totalFiles} file${totalFiles !== 1 ? "s" : ""} changed, +${displayStats.insertions} insertions, −${displayStats.deletions} deletions`;
 	const dateLabel = formatFullDate(getDisplayDate(summary));
 
 	lines.push(
@@ -167,13 +167,12 @@ function pushSourceCommitsSection(
 	}
 	lines.push("", `## Source Commits (${sourceNodes.length})`);
 	for (const node of sourceNodes) {
-		const ins = node.stats?.insertions ?? 0;
-		const del = node.stats?.deletions ?? 0;
+		const nodeStats = resolveDiffStats(node);
 		const turnsMd = node.conversationTurns
 			? ` · ${node.conversationTurns} turns`
 			: "";
 		lines.push(
-			`- \`${node.commitHash.substring(0, 8)}\` ${node.commitMessage}  _(+${ins} −${del}${turnsMd} · ${formatDate(getDisplayDate(node))})_`,
+			`- \`${node.commitHash.substring(0, 8)}\` ${node.commitMessage}  _(+${nodeStats.insertions} −${nodeStats.deletions}${turnsMd} · ${formatDate(getDisplayDate(node))})_`,
 		);
 	}
 	lines.push("", "---");

--- a/vscode/src/views/SummaryPrMarkdownBuilder.test.ts
+++ b/vscode/src/views/SummaryPrMarkdownBuilder.test.ts
@@ -14,6 +14,7 @@ const mocks = vi.hoisted(() => ({
 	aggregateStats: vi.fn(),
 	aggregateTurns: vi.fn(),
 	formatDurationLabel: vi.fn(),
+	resolveDiffStats: vi.fn(),
 	collectSortedTopics: vi.fn(),
 	formatDate: vi.fn(),
 	formatFullDate: vi.fn(),
@@ -29,6 +30,7 @@ vi.mock("../../../cli/src/core/SummaryTree.js", () => ({
 	aggregateStats: mocks.aggregateStats,
 	aggregateTurns: mocks.aggregateTurns,
 	formatDurationLabel: mocks.formatDurationLabel,
+	resolveDiffStats: mocks.resolveDiffStats,
 }));
 
 // Mock the core SummaryFormat module (used by the core SummaryMarkdownBuilder)
@@ -58,6 +60,8 @@ function makeSummary(overrides: Partial<CommitSummary> = {}): CommitSummary {
 		commitDate: "2026-03-30T10:00:00Z",
 		branch: "feature/proj-100-login",
 		generatedAt: "2026-03-30T10:05:00Z",
+		// Default stats so resolveDiffStats mock reads a sensible value on the header call.
+		stats: { filesChanged: 3, insertions: 50, deletions: 10 },
 		...overrides,
 	};
 }
@@ -96,6 +100,11 @@ function setupDefaults(
 		filesChanged: 3,
 		insertions: 50,
 		deletions: 10,
+	});
+	mocks.resolveDiffStats.mockImplementation((node: CommitSummary) => {
+		if (node.diffStats) return node.diffStats;
+		if (node.stats) return node.stats;
+		return { filesChanged: 0, insertions: 0, deletions: 0 };
 	});
 	mocks.aggregateTurns.mockReturnValue(5);
 	mocks.formatDurationLabel.mockReturnValue("1 day (1 commit)");


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## E2E Test (4)
<details>
<summary><strong>1. Squash commit shows correct file count (not inflated sum of source commits)</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a repository where you have performed a squash commit that combined multiple commits, where at least two of those source commits edited the same file.

**Steps:**
1. Open the Jolli Memory panel or run the view command for the squash commit.
2. Look at the "Changes" or diff stats line that shows files changed, insertions, and deletions.
3. Note the number of files changed displayed.
4. Compare that number to the actual number of distinct files changed in the squash commit (you can verify this in your git client).

**Expected Results:**
- The files changed count should match the real number of distinct files in the squash commit's diff.
- The count should NOT be inflated by adding up each source commit's file count separately (for example, if two source commits both edited the same file, the display should show 1 file changed, not 2).

</blockquote>
</details>
<details>
<summary><strong>2. Squash commit diff stats in exported Markdown match the real git diff</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a repository with a squash commit where multiple source commits touched overlapping files.

**Steps:**
1. Open the Jolli Memory panel for the squash commit.
2. Export or copy the summary as Markdown (use the "Copy as Markdown" or export button).
3. Open the copied Markdown and find the header section showing files changed, insertions, and deletions.
4. Check that the file count matches the actual number of distinct files changed in the squash commit.

**Expected Results:**
- The Markdown header should show the correct file count from the real squash diff (e.g. "1 file changed, +42 insertions, −5 deletions").
- It should NOT show an inflated count that adds up all source commits' individual file counts.

</blockquote>
</details>
<details>
<summary><strong>3. Source Commits section in Markdown shows each child commit's own diff stats</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a repository with a squash commit that has two or more source commits, each with their own insertions and deletions.

**Steps:**
1. Open the Jolli Memory panel for the squash commit.
2. Export or copy the summary as Markdown.
3. Scroll to the "Source Commits" section in the Markdown output.
4. Check the insertion and deletion numbers listed next to each individual source commit.

**Expected Results:**
- Each source commit row should show its own individual insertion and deletion counts (for example, "+7" for one commit and "+23" for another).
- The numbers should reflect each commit's own changes, not a combined or aggregated total.

</blockquote>
</details>
<details>
<summary><strong>4. Legacy squash commits (created before this update) still display stats without errors</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a repository with older squash commit summaries that were created before this update (they will not have the new "diffStats" field stored).

**Steps:**
1. Open the Jolli Memory panel or run the view command for an older squash commit.
2. Look at the diff stats line showing files changed, insertions, and deletions.
3. Check that numbers are displayed and the panel loads without any error message.

**Expected Results:**
- The diff stats should still display a number (falling back to summing the source commits' stats, as before).
- No error message or blank/zero stats should appear just because the commit predates this update.
- The panel or CLI output should load normally.

</blockquote>
</details>

---

## Summaries (4)
<details>
<summary><strong>01 · Fix diff stat display for amend and squash commits</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Amend and squash commits were showing incorrect file change counts in all display surfaces (CLI, VSCode panel, markdown exports). The root cause was that the display layer recursively summed stats across child commits, which over-counts files touched by multiple source commits and misrepresents amend deltas as full commit diffs.

**💡 Decisions Behind the Code**

- **Persist vs. inject at runtime**: Storing `diffStats` on disk (rather than computing it at read time or injecting it as a transient field) was chosen because runtime injection would leak through the many WebView read-modify-write paths and the CLI JSON output, requiring permanent defensive stripping at every write site.
- **Keep legacy `stats` field**: Deleting `stats` would break older plugin versions that only know that field, and would silently show zero counts for all existing history. Keeping it as a fallback costs nothing and preserves amend delta history.
- **Leaf vs. container branching in the helper**: Legacy amend roots store a delta in `stats`, not a full diff. Routing containers through `aggregateStats()` (delta + children) keeps the displayed number pixel-identical to today for all pre-existing data, avoiding a silent behavior change on historical records.
- **Rejected runtime-injection approach (Plan A)**: An earlier design injected a transient `displayStats` field into the in-memory object. This was abandoned after review identified 16+ WebView write-back paths and CLI JSON output that would all need explicit stripping — a permanent maintenance burden with no type-system enforcement.

**✅ What Was Implemented**

- Added `diffStats` as a new persisted field on `CommitSummary` (alongside the legacy `stats` field, which is retained for backward compatibility)
- Added `resolveDiffStats()` helper in `SummaryTree.ts` with a three-branch decision tree: prefer `diffStats` → leaf fallback to `stats` → container fallback to `aggregateStats()`
- Populated `diffStats` at all five construction sites: leaf commits (`executePipeline`), both amend branches in `handleAmendPipeline` (LLM path and message-only path), squash roots (`mergeManyToOne`), and rebase-pick roots (`migrateOneToOne`)
- Replaced all six display-layer `aggregateStats()` call sites with `resolveDiffStats()`: `SummaryMarkdownBuilder`, `SummaryHtmlBuilder` (VSCode), `ContextCompiler`, `ViewCommand`, and the Source Commits drill-down rows in both markdown builders
- Added 15 new passing tests covering the over-count scenario, legacy fallback pixel-parity, amend delta vs. full-diff distinction, and error fallback to zero stats

</blockquote>
</details>
<details>
<summary><strong>02 · Test pollution overwrites real API key on Windows during test runs</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

After running the test suite on Windows, the developer's real Anthropic API key was silently replaced with the placeholder value `global-key`, causing all LLM-dependent features to fail with a 401 authentication error. The bug had been partially fixed twice before but the specific test responsible was missed each time.

**💡 Decisions Behind the Code**

- **Mock `os.homedir()` rather than set environment variables**: Setting environment variables to redirect the home directory is not cross-platform. Mocking the OS module directly (as other tests in the repo already do) is the only reliable approach on Windows.
- **Separate PR recommended**: The fix is unrelated to the diff display work in progress, so mixing it into the same branch would obscure the change history. A dedicated branch was suggested.

**✅ What Was Implemented**

Identified root cause: a test in `SessionTracker.test.ts` redirects the home directory by setting the `HOME` environment variable, which Node's `os.homedir()` ignores on Windows (it reads `USERPROFILE` instead). As a result the test writes to the real user config file instead of the temp directory. The fix was discussed but not implemented in this session — the immediate workaround was to manually restore the real API key in the config file.

</blockquote>
</details>
<details>
<summary><strong>03 · Fix diff stats priority order to eliminate redundant git calls and data inconsistency</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

A code review found that the function responsible for writing the summary index was ignoring already-computed diff stats stored on the summary node itself, instead falling back to stale index data or making a fresh git call. This could cause the per-commit summary file and the index file to hold different diff stat values, and wasted a git invocation on every write.

**💡 Decisions Behind the Code**

- **Priority order**: Pipeline-computed stats are placed first because they are the freshest and most authoritative value — they come from the same git call that produced the summary file, so reusing them guarantees the two storage locations are consistent by construction rather than by coincidence.
- **Preserve existing-entry fallback**: Dropping the index-reuse fallback entirely would break the WebView topic-edit path, where a summary is force-written without re-running the pipeline and the node carries no `diffStats`. Keeping it as level 2 maintains backward compatibility at no cost.
- **Strengthen test assertion rather than just add a new test**: The leaf-commit test was the only write path with a weak "exists" assertion; upgrading it to an exact value check closes the coverage gap identified in the review and makes the test suite uniformly strict across all five write paths.
- **Document in DEVELOPMENT.md rather than only in code comments**: The invariant spans multiple files and is easy to violate silently; a dedicated conventions section gives future contributors a single place to check before touching display or write code.

**✅ What Was Implemented**

- `SummaryStore.ts` `flattenSummaryTree()`: rewrote the diff stats resolution to a three-level priority — (1) `node.diffStats` from the construction pipeline, (2) existing index entry (legacy WebView force-write path), (3) fresh `git diff` call (legacy v3 fallback). Previously levels 1 and 2 were swapped, so pipeline-computed stats were ignored.
- `SummaryStore.test.ts`: added a new test asserting that when `node.diffStats` is present, the index entry reflects that value, the stale index value is ignored, `getDiffStats` is not called, and both the summary JSON and index JSON carry the same value.
- `PostCommitHook.test.ts`: upgraded the leaf-commit assertion from `toBeDefined()` to `toEqual({ filesChanged: 2, insertions: 10, deletions: 5 })`, matching the mock's actual return value and aligning with the stronger assertions already present on amend/squash/rebase paths.
- `DEVELOPMENT.md`: updated the Core Modules table entry for the tree utility file and added a new "Display-Layer Conventions" section documenting the three-level priority, the five write points, and the prohibition on calling the aggregation helper or reading raw stats fields directly in display code.

</blockquote>
</details>
<details>
<summary><strong>04 · Design exploration: three competing approaches for fixing diff display</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Before any code was written, the team needed to settle on an architecture for the fix. Three distinct approaches were proposed and debated across multiple review cycles, with each round of feedback revealing new problems with the leading candidate.

**💡 Decisions Behind the Code**

- **Persistence over runtime injection**: Any field that exists only in memory but passes through write-back paths will eventually leak to disk. Making the field a first-class persisted field removes the entire category of leak risk without requiring ongoing vigilance.
- **Backward compatibility over clean slate**: Deleting the old field would have been simpler but would silently break all existing history for users who had not yet upgraded both CLI and plugin simultaneously. Keeping the old field as a fallback costs one extra branch in the helper.
- **Honest documentation scope**: Early plan drafts over-promised that "all nodes will have `diffStats` after this change." Review correctly identified that nodes wrapped as children by later operations are never backfilled. The final plan explicitly scopes the guarantee to newly constructed roots only.

**✅ What Was Implemented**

- Plan A (runtime injection): inject a transient `displayStats` field into the in-memory summary object at read time; rejected after review found 16+ WebView write-back paths and CLI JSON output would silently persist the field to disk
- Plan B (explicit parameter threading): pass display stats as a separate argument to every renderer function; rejected as mechanically large (~20-25 changes) with no advantage over Plan D once the leak problem was understood
- Plan D (persist new field, keep old field): add `diffStats` as a proper persisted field written at construction time; chosen because it eliminates all leak risk by design, requires no defensive stripping, and is naturally backward-compatible
- The design document (`docs/refactor-display-diff-stats.md`) went through four full rewrites and six rounds of structured review before implementation began

</blockquote>
</details>

---

*Generated by Jolli Memory · April 24, 2026 at 2:10 PM*
<!-- jollimemory-summary-end -->