### PR TITLE
Mock homedir() in SessionTracker tests to prevent config pollution

### DIFF
--- a/cli/src/core/SessionTracker.test.ts
+++ b/cli/src/core/SessionTracker.test.ts
@@ -15,6 +15,24 @@ vi.mock("node:fs/promises", async (importOriginal) => {
 	};
 });
 
+// Redirect homedir() so the global-config tests don't pollute the developer's
+// real ~/.jolli/jollimemory/config.json. Default passes through to the real
+// homedir(); individual tests opt into redirection via mockHomedir.mockReturnValue().
+// Cross-platform: works on Windows too, where process.env.HOME is ignored by homedir().
+const { mockHomedir, realHomedir } = vi.hoisted(() => ({
+	mockHomedir: vi.fn<typeof import("node:os").homedir>(),
+	realHomedir: { current: null as typeof import("node:os").homedir | null },
+}));
+vi.mock("node:os", async (importOriginal) => {
+	const original = await importOriginal<typeof import("node:os")>();
+	realHomedir.current = original.homedir;
+	mockHomedir.mockImplementation(original.homedir);
+	return {
+		...original,
+		homedir: mockHomedir,
+	};
+});
+
 // Suppress console output
 vi.spyOn(console, "log").mockImplementation(() => {});
 vi.spyOn(console, "warn").mockImplementation(() => {});
@@ -1058,23 +1076,23 @@ describe("SessionTracker", () => {
 	// ── loadConfig (global shorthand) ────────────────────────────────────
 
 	describe("loadConfig", () => {
+		beforeEach(() => {
+			mockHomedir.mockReturnValue(tempDir);
+		});
+
+		afterEach(() => {
+			if (realHomedir.current) mockHomedir.mockImplementation(realHomedir.current);
+		});
+
 		it("should return config from global dir without throwing", async () => {
 			const config = await loadConfig();
 			expect(config).toBeDefined();
 		});
 
 		it("saveConfig should persist config to the global directory shorthand", async () => {
-			const originalHome = process.env.HOME;
-			process.env.HOME = tempDir;
-
-			try {
-				await saveConfig({ apiKey: "global-key" });
-				const config = await loadConfig();
-				expect(config.apiKey).toBe("global-key");
-			} finally {
-				if (originalHome === undefined) delete process.env.HOME;
-				else process.env.HOME = originalHome;
-			}
+			await saveConfig({ apiKey: "global-key" });
+			const config = await loadConfig();
+			expect(config.apiKey).toBe("global-key");
 		});
 	});
 


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## Topic (1)
<details>
<summary><strong>01 · Mock homedir() in SessionTracker tests to prevent config file pollution on Windows</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The test suite was overwriting developers' real `~/.jolli/jollimemory/config.json` with test data on Windows machines. The existing test used `process.env.HOME` to redirect file writes, but this environment variable is ignored by Node's `homedir()` function on Windows (which reads `USERPROFILE` instead), causing the mock to fail silently and pollute the actual config file.

**💡 Decisions Behind the Code**

- **Direct OS module mocking over environment variable manipulation**: Mocking at the `node:os` module boundary is cross-platform (works on Windows, macOS, and Linux) and does not depend on platform-specific environment variable semantics, whereas `process.env.HOME` is ignored by `homedir()` on Windows.
- **Describe-scoped `beforeEach/afterEach` over global `restoreMocks: true`**: A global `restoreMocks: true` configuration would require migrating 18 test files that rely on factory-once `mockImplementation` setup, creating unacceptable blast radius; a localized `afterEach` in this describe block keeps the fix isolated and safe.
- **Hoisted factory pattern with passthrough default**: Storing `realHomedir.current` and defaulting `mockHomedir.mockImplementation(original.homedir)` ensures that other describe blocks continue to use the real `homedir()` without modification, preventing unintended side effects on unrelated tests.

**✅ What Was Implemented**

- Added a `node:os` module mock in `SessionTracker.test.ts` that intercepts `homedir()` calls and redirects them to a temporary test directory
- Implemented a hoisted mock factory pattern (`mockHomedir` + `realHomedir.current`) that defaults to passing through the real `homedir()` implementation but allows individual test suites to override it
- Replaced the `process.env.HOME` manipulation in the `describe("loadConfig")` block with a `beforeEach/afterEach` pair that uses `mockHomedir.mockReturnValue(tempDir)` to redirect file operations
- Removed the try/finally cleanup logic for environment variables, relying instead on the existing `afterEach` hook that cleans up the temp directory and the new `afterEach` that restores the mock implementation

**📁 FILES**
- `cli/src/core/SessionTracker.test.ts`

</blockquote>
</details>

---

*Generated by Jolli Memory · April 24, 2026 at 2:13 PM*
<!-- jollimemory-summary-end -->