### PR TITLE
Log PR errors in PrCommentService with debug/warn granularity

### DIFF
--- a/cli/src/core/OpenCodeSessionDiscoverer.test.ts
+++ b/cli/src/core/OpenCodeSessionDiscoverer.test.ts
@@ -144,12 +144,12 @@ describe("OpenCodeSessionDiscoverer", () => {
 		it("returns the default XDG path under home directory", () => {
 			delete process.env.XDG_DATA_HOME;
 			mockHomedir.mockReturnValue("/home/user");
-			expect(getOpenCodeDbPath()).toBe("/home/user/.local/share/opencode/opencode.db");
+			expect(getOpenCodeDbPath()).toBe(join("/home/user", ".local/share/opencode/opencode.db"));
 		});
 
 		it("respects XDG_DATA_HOME when set", () => {
 			process.env.XDG_DATA_HOME = "/custom/data";
-			expect(getOpenCodeDbPath()).toBe("/custom/data/opencode/opencode.db");
+			expect(getOpenCodeDbPath()).toBe(join("/custom/data", "opencode/opencode.db"));
 		});
 	});
 

--- a/cli/src/hooks/GitOperationDetector.test.ts
+++ b/cli/src/hooks/GitOperationDetector.test.ts
@@ -36,6 +36,7 @@ vi.spyOn(console, "error").mockImplementation(() => {});
 
 import { execSync } from "node:child_process";
 import { existsSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
 import { getCommitRange, getHeadHash, getLastReflogAction, isAncestor, readOrigHead } from "../core/GitOps.js";
 import { loadSquashPending, saveSquashPending } from "../core/SessionTracker.js";
 import {
@@ -62,7 +63,8 @@ describe("GitOperationDetector", () => {
 
 			const result = resolveGitDir("/test/repo");
 
-			expect(result).toBe("/test/repo/.git");
+			// path.join uses native separators — keep the assertion platform-agnostic
+			expect(result).toBe(join("/test/repo", ".git"));
 		});
 
 		it("should return the default .git path when .git is a directory", () => {
@@ -70,7 +72,7 @@ describe("GitOperationDetector", () => {
 
 			const result = resolveGitDir("/test/repo");
 
-			expect(result).toBe("/test/repo/.git");
+			expect(result).toBe(join("/test/repo", ".git"));
 		});
 
 		it("should resolve an absolute gitdir path from a worktree .git file", () => {
@@ -89,7 +91,7 @@ describe("GitOperationDetector", () => {
 			const result = resolveGitDir("/test/worktree");
 
 			// join() resolves the relative path: /test/worktree + ../.git/worktrees/feature-branch
-			expect(result).toBe("/test/.git/worktrees/feature-branch");
+			expect(result).toBe(join("/test/worktree", "../.git/worktrees/feature-branch"));
 		});
 
 		it("should return the default .git path when .git file has no gitdir line", () => {
@@ -98,7 +100,7 @@ describe("GitOperationDetector", () => {
 
 			const result = resolveGitDir("/test/repo");
 
-			expect(result).toBe("/test/repo/.git");
+			expect(result).toBe(join("/test/repo", ".git"));
 		});
 	});
 

--- a/cli/src/install/Installer.test.ts
+++ b/cli/src/install/Installer.test.ts
@@ -2294,8 +2294,13 @@ describe("Installer", () => {
 
 	describe("installResolveScript — failure path", () => {
 		it("should return failure when resolve-dist-path script cannot be written", async () => {
-			// Set homedir to an invalid path so mkdir fails inside installResolveScript
-			mockHomedir.mockReturnValue("/dev/null/impossible-path");
+			// Cross-platform: drop a regular file and point homedir at a path whose
+			// parent segment is that file. mkdir (even recursive) fails with ENOTDIR
+			// when any parent in the chain is not a directory. Using `/dev/null/...`
+			// only fails on POSIX — Windows happily creates it as a normal subtree.
+			const blockingFile = join(tempDir, "blocker-file");
+			await writeFile(blockingFile, "not a directory");
+			mockHomedir.mockReturnValue(join(blockingFile, "home-under-file"));
 
 			const result = await install(tempDir);
 			expect(result.success).toBe(false);

--- a/vscode/src/services/PrCommentService.test.ts
+++ b/vscode/src/services/PrCommentService.test.ts
@@ -27,10 +27,12 @@ const { tmpdirMock } = vi.hoisted(() => ({
 }));
 
 const {
+	debug,
 	info,
 	warn,
 	error: logError,
 } = vi.hoisted(() => ({
+	debug: vi.fn(),
 	info: vi.fn(),
 	warn: vi.fn(),
 	error: vi.fn(),
@@ -88,7 +90,7 @@ vi.mock("node:os", () => ({
 }));
 
 vi.mock("../util/Logger.js", () => ({
-	log: { info, warn, error: logError },
+	log: { debug, info, warn, error: logError },
 }));
 
 // ─── Import under test ──────────────────────────────────────────────────────
@@ -252,6 +254,9 @@ describe("PrCommentService", () => {
 	describe("handleCheckPrStatus", () => {
 		it("posts multipleCommits status when branch has more than 1 commit", async () => {
 			setupExecFile((cmd, args) => {
+				if (cmd === "git" && args[0] === "symbolic-ref") {
+					return { stdout: "origin/main\n" };
+				}
 				if (cmd === "git" && args[0] === "rev-list") {
 					return { stdout: "3\n" };
 				}
@@ -739,7 +744,7 @@ describe("PrCommentService", () => {
 			);
 		});
 
-		it("treats getCommitCount failure as 0 commits and continues", async () => {
+		it("treats unresolved upstream baseline as 0 commits and continues (no origin/HEAD)", async () => {
 			const prData = {
 				number: 7,
 				url: "https://pr/7",
@@ -747,11 +752,15 @@ describe("PrCommentService", () => {
 				body: "",
 			};
 			setupExecFile((cmd, args) => {
+				if (cmd === "git" && args[0] === "symbolic-ref") {
+					// Healthy repo without a pinned origin/HEAD — e.g. no origin remote,
+					// or fresh clone before first fetch. symbolic-ref exits non-zero.
+					throw new Error(
+						"fatal: ref refs/remotes/origin/HEAD is not a symbolic ref",
+					);
+				}
 				if (cmd === "git" && args[0] === "rev-parse") {
 					return { stdout: "feature/test\n" };
-				}
-				if (cmd === "git" && args[0] === "rev-list") {
-					throw new Error("origin/main not found");
 				}
 				if (cmd === "gh" && args[0] === "--version") {
 					return { stdout: "gh version 2.40.0\n" };
@@ -767,7 +776,7 @@ describe("PrCommentService", () => {
 
 			await handleCheckPrStatus(CWD, postMessage);
 
-			// getCommitCount caught → 0, so no "multipleCommits", continues to PR check
+			// baseline unresolved → 0 commits, no multipleCommits gate, flow continues.
 			expect(postMessage).toHaveBeenCalledWith(
 				expect.objectContaining({ command: "prStatus", status: "ready" }),
 			);
@@ -840,6 +849,9 @@ describe("PrCommentService", () => {
 
 		it("keeps commit count check when branch matches current branch", async () => {
 			setupExecFile((cmd, args) => {
+				if (cmd === "git" && args[0] === "symbolic-ref") {
+					return { stdout: "origin/main\n" };
+				}
 				if (cmd === "git" && args[0] === "rev-list") {
 					return { stdout: "3\n" };
 				}
@@ -939,6 +951,235 @@ describe("PrCommentService", () => {
 				branch: "feature/new-name",
 				crossBranch: false,
 			});
+		});
+
+		// ── debug.log observability (non-goal: UI folding stays the same) ─────
+
+		/**
+		 * Builds an execFile router stub where `gh pr view` (or a custom gh call)
+		 * can be programmed. All the prereq probes (`git rev-list`, `git rev-parse`,
+		 * `gh --version`, `gh auth status`) return success so the flow reaches
+		 * `findPrForBranch`. `ghPrHandler` controls what `gh pr ...` does.
+		 */
+		function setupHappyProbesWithPrHandler(
+			ghPrHandler: () => { stdout: string },
+		): void {
+			setupExecFile((cmd, args) => {
+				if (cmd === "git" && args[0] === "symbolic-ref")
+					return { stdout: "origin/main\n" };
+				if (cmd === "git" && args[0] === "rev-list") return { stdout: "1\n" };
+				if (cmd === "git" && args[0] === "rev-parse")
+					return { stdout: "feature/br\n" };
+				if (cmd === "gh" && args[0] === "--version")
+					return { stdout: "gh 2.40\n" };
+				if (cmd === "gh" && args[0] === "auth") return { stdout: "ok\n" };
+				if (cmd === "gh" && args[0] === "pr") return ghPrHandler();
+				return { stdout: "" };
+			});
+		}
+
+		/** Builds an Error with `code` and `stderr` attached, mimicking child_process execFile rejection shape. */
+		function ghError(opts: {
+			message: string;
+			code?: string | number;
+			stderr?: string;
+		}): Error {
+			const err = new Error(opts.message) as Error & {
+				code?: string | number;
+				stderr?: string;
+			};
+			if (opts.code !== undefined) err.code = opts.code;
+			if (opts.stderr !== undefined) err.stderr = opts.stderr;
+			return err;
+		}
+
+		it("does not emit warn/debug on the happy path (baseline)", async () => {
+			setupHappyProbesWithPrHandler(() => ({
+				stdout: JSON.stringify({
+					number: 7,
+					url: "https://pr/7",
+					title: "t",
+					body: "b",
+				}),
+			}));
+
+			await handleCheckPrStatus(CWD, postMessage);
+
+			expect(warn).not.toHaveBeenCalled();
+			expect(debug).not.toHaveBeenCalled();
+		});
+
+		it("logs at debug when gh pr view stderr indicates 'no pull requests found'", async () => {
+			setupHappyProbesWithPrHandler(() => {
+				throw ghError({
+					message: "gh: exit 1",
+					code: 1,
+					stderr: "no pull requests found for branch feature/br\n",
+				});
+			});
+
+			await handleCheckPrStatus(CWD, postMessage);
+
+			expect(debug).toHaveBeenCalledWith(
+				expect.any(String),
+				expect.stringContaining("No PR for branch feature/br"),
+			);
+			expect(warn).not.toHaveBeenCalled();
+			// UI folding unchanged — see plan non-goal
+			expect(postMessage).toHaveBeenCalledWith(
+				expect.objectContaining({ status: "noPr", branch: "feature/br" }),
+			);
+		});
+
+		it("logs at warn when gh pr view fails with a non-expected stderr (e.g. auth/ratelimit)", async () => {
+			setupHappyProbesWithPrHandler(() => {
+				throw ghError({
+					message: "gh: exit 1",
+					code: 1,
+					stderr: "authentication required: please run gh auth login\n",
+				});
+			});
+
+			await handleCheckPrStatus(CWD, postMessage);
+
+			expect(warn).toHaveBeenCalledWith(
+				expect.any(String),
+				expect.stringMatching(
+					/gh pr view failed for branch feature\/br.*code=1.*stderr:.*authentication required/s,
+				),
+			);
+			expect(debug).not.toHaveBeenCalled();
+			expect(postMessage).toHaveBeenCalledWith(
+				expect.objectContaining({ status: "noPr", branch: "feature/br" }),
+			);
+		});
+
+		it("logs at warn with code=ENOENT when gh binary is missing for the pr view call", async () => {
+			// Note: pre-check `gh --version` succeeds in this stub; we only fail
+			// the `gh pr view` call, to exercise tryExecGh's ENOENT branch
+			// specifically (rather than checkGhInstalled's).
+			setupHappyProbesWithPrHandler(() => {
+				throw ghError({ message: "spawn gh ENOENT", code: "ENOENT" });
+			});
+
+			await handleCheckPrStatus(CWD, postMessage);
+
+			expect(warn).toHaveBeenCalledWith(
+				expect.any(String),
+				expect.stringContaining("code=ENOENT"),
+			);
+		});
+
+		it("logs at warn with Raw length when gh pr view returns unparseable JSON", async () => {
+			setupHappyProbesWithPrHandler(() => ({
+				stdout: "not-json-{{{",
+			}));
+
+			await handleCheckPrStatus(CWD, postMessage);
+
+			expect(warn).toHaveBeenCalledWith(
+				expect.any(String),
+				expect.stringMatching(/unparseable JSON.*Raw length: \d+/s),
+			);
+			// UI folding unchanged
+			expect(postMessage).toHaveBeenCalledWith(
+				expect.objectContaining({ status: "noPr", branch: "feature/br" }),
+			);
+		});
+
+		it("stays silent when upstream baseline cannot be resolved — healthy repos without origin/HEAD must not spam logs", async () => {
+			setupExecFile((cmd, args) => {
+				if (cmd === "git" && args[0] === "symbolic-ref") {
+					// No origin/HEAD pinned — common in repos with no `origin`, fresh
+					// clones, or detached setups. Previously this caused a warn on
+					// every PR panel open for any repo using master/trunk; now it
+					// should be completely silent.
+					throw new Error(
+						"fatal: ref refs/remotes/origin/HEAD is not a symbolic ref",
+					);
+				}
+				if (cmd === "git" && args[0] === "rev-parse")
+					return { stdout: "feature/br\n" };
+				if (cmd === "gh" && args[0] === "--version")
+					return { stdout: "gh 2.40\n" };
+				if (cmd === "gh" && args[0] === "auth") return { stdout: "ok\n" };
+				if (cmd === "gh" && args[0] === "pr") throw new Error("no pr");
+				return { stdout: "" };
+			});
+
+			await handleCheckPrStatus(CWD, postMessage);
+
+			// Silent: no commit-count log at all when baseline is unresolved.
+			// (The unrelated `gh pr` stub still trips a warn from findPrForBranch,
+			// so assert narrowly: nothing about rev-list.)
+			expect(warn).not.toHaveBeenCalledWith(
+				expect.any(String),
+				expect.stringContaining("rev-list"),
+			);
+			expect(debug).not.toHaveBeenCalledWith(
+				expect.any(String),
+				expect.stringContaining("rev-list"),
+			);
+			// Flow continues — commit count treated as 0 means no multipleCommits gate.
+			expect(postMessage).not.toHaveBeenCalledWith(
+				expect.objectContaining({ status: "multipleCommits" }),
+			);
+		});
+
+		it("resolves the actual upstream default branch (origin/master etc.), not hardcoded origin/main", async () => {
+			// Verifies the root-cause fix: squash gate works in master-based repos.
+			setupExecFile((cmd, args) => {
+				if (cmd === "git" && args[0] === "symbolic-ref") {
+					return { stdout: "origin/master\n" };
+				}
+				if (cmd === "git" && args[0] === "rev-list") {
+					// Executed only if the command uses origin/master..HEAD — otherwise
+					// the production bug (hardcoded origin/main) would reach this stub
+					// with different args and we would never see count=5 in postMessage.
+					expect(args).toEqual(["rev-list", "--count", "origin/master..HEAD"]);
+					return { stdout: "5\n" };
+				}
+				if (cmd === "git" && args[0] === "rev-parse")
+					return { stdout: "feature/br\n" };
+				return { stdout: "" };
+			});
+
+			await handleCheckPrStatus(CWD, postMessage);
+
+			expect(postMessage).toHaveBeenCalledWith({
+				command: "prStatus",
+				status: "multipleCommits",
+				count: 5,
+			});
+		});
+
+		it("warns when rev-list fails after the upstream baseline was resolved — that is a real repo problem, not a config mismatch", async () => {
+			setupExecFile((cmd, args) => {
+				if (cmd === "git" && args[0] === "symbolic-ref") {
+					return { stdout: "origin/master\n" };
+				}
+				if (cmd === "git" && args[0] === "rev-list") {
+					// Baseline resolved but rev-list still broke — e.g. permission,
+					// corruption. Worth a warn so debug.log has a trail.
+					throw new Error("fatal: bad object origin/master");
+				}
+				if (cmd === "git" && args[0] === "rev-parse")
+					return { stdout: "feature/br\n" };
+				if (cmd === "gh" && args[0] === "--version")
+					return { stdout: "gh 2.40\n" };
+				if (cmd === "gh" && args[0] === "auth") return { stdout: "ok\n" };
+				if (cmd === "gh" && args[0] === "pr") throw new Error("no pr");
+				return { stdout: "" };
+			});
+
+			await handleCheckPrStatus(CWD, postMessage);
+
+			expect(warn).toHaveBeenCalledWith(
+				expect.any(String),
+				expect.stringMatching(
+					/git rev-list --count origin\/master\.\.HEAD failed.*bad object/s,
+				),
+			);
 		});
 	});
 

--- a/vscode/src/services/PrCommentService.ts
+++ b/vscode/src/services/PrCommentService.ts
@@ -71,15 +71,31 @@ async function execGh(args: Array<string>, cwd: string): Promise<string> {
 	return stdout;
 }
 
-/** Runs a gh command, returning stdout or `undefined` on failure. */
+/** Result of a non-throwing gh invocation. */
+type GhCmdResult =
+	| { ok: true; stdout: string }
+	| { ok: false; code?: string | number; err: Error; stderr?: string };
+
+/**
+ * Runs a gh command. Returns a discriminated result — never throws, never
+ * returns undefined. Callers decide how to log based on the failure shape
+ * (e.g. stderr containing "no pull requests found" is expected and should
+ * be debug; anything else is warn).
+ */
 async function tryExecGh(
 	args: Array<string>,
 	cwd: string,
-): Promise<string | undefined> {
+): Promise<GhCmdResult> {
 	try {
-		return await execGh(args, cwd);
-	} catch {
-		return;
+		const stdout = await execGh(args, cwd);
+		return { ok: true, stdout };
+	} catch (e) {
+		const err = e instanceof Error ? e : new Error(String(e));
+		const code = (err as NodeJS.ErrnoException).code;
+		// execFile failure: child_process attaches stderr to the error (when
+		// within maxBuffer). Missing otherwise — callers must handle undefined.
+		const stderr = (err as { stderr?: string }).stderr;
+		return { ok: false, code, err, stderr };
 	}
 }
 
@@ -198,15 +214,56 @@ async function execGit(args: Array<string>, cwd: string): Promise<string> {
 	return stdout;
 }
 
-/** Returns the number of commits on the current branch relative to origin/main. */
-async function getCommitCount(cwd: string): Promise<number> {
+/**
+ * Resolves the upstream default branch (what `origin/HEAD` points to), e.g.
+ * `"origin/main"`, `"origin/master"`, `"origin/trunk"`. Returns `undefined`
+ * when the ref is not set — common and healthy in repos without an `origin`
+ * remote, in fresh clones before the first fetch, in detached states, or when
+ * `origin/HEAD` was never pinned. Undefined is an expected outcome, not an
+ * error: callers should treat it as "no baseline in this repo".
+ */
+async function resolveUpstreamBaseline(
+	cwd: string,
+): Promise<string | undefined> {
 	try {
 		const raw = await execGit(
-			["rev-list", "--count", "origin/main..HEAD"],
+			["symbolic-ref", "--short", "refs/remotes/origin/HEAD"],
+			cwd,
+		);
+		const trimmed = raw.trim();
+		return trimmed.length > 0 ? trimmed : undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+/**
+ * Returns the number of commits on the current branch that are ahead of the
+ * upstream default branch. Used only to gate the "multiple commits — please
+ * squash" UI, so 0 means "don't gate" — a safe fallback whenever the baseline
+ * cannot be determined or the count cannot be computed.
+ */
+async function getCommitCount(cwd: string): Promise<number> {
+	const baseline = await resolveUpstreamBaseline(cwd);
+	if (!baseline) {
+		// No upstream baseline in this repo — squash gate does not apply.
+		// Silent: this is the normal state for many healthy setups (no
+		// `origin`, fresh clone, detached HEAD), not a condition to warn about.
+		return 0;
+	}
+	try {
+		const raw = await execGit(
+			["rev-list", "--count", `${baseline}..HEAD`],
 			cwd,
 		);
 		return Number.parseInt(raw.trim(), 10) || 0;
-	} catch {
+	} catch (err) {
+		// Baseline resolved but rev-list failed — unusual (e.g. corrupted
+		// repo, permissions). Worth a warn so debug.log has a trail.
+		log.warn(
+			TAG,
+			`git rev-list --count ${baseline}..HEAD failed: ${(err as Error).message}`,
+		);
 		return 0;
 	}
 }
@@ -283,14 +340,36 @@ async function findPrForBranch(
 	branch: string,
 ): Promise<PrInfo | undefined> {
 	const args = ["pr", "view", "--json", "number,url,title,body", "--", branch];
-	const raw = await tryExecGh(args, cwd);
-	if (!raw) {
+	const result = await tryExecGh(args, cwd);
+
+	if (!result.ok) {
+		const stderr = result.stderr ?? "";
+		// "no pull requests found" is the expected miss path — keep it at
+		// debug to avoid noise on every WebView open. Anything else (auth,
+		// rate limit, network, repo config, non-zero exits) is a real
+		// failure and deserves warn so it shows at default log level.
+		const isExpectedNoPr = /no pull requests? found/i.test(stderr);
+		if (isExpectedNoPr) {
+			log.debug(TAG, `No PR for branch ${branch}`);
+		} else {
+			log.warn(
+				TAG,
+				`gh pr view failed for branch ${branch} (code=${result.code}): ${result.err.message}${
+					stderr ? ` | stderr: ${stderr.trim()}` : ""
+				}`,
+			);
+		}
 		return;
 	}
+
 	try {
-		const parsed = JSON.parse(raw) as PrInfo;
+		const parsed = JSON.parse(result.stdout) as PrInfo;
 		return parsed.number ? parsed : undefined;
-	} catch {
+	} catch (err) {
+		log.warn(
+			TAG,
+			`gh pr view returned unparseable JSON for branch ${branch}: ${(err as Error).message}. Raw length: ${result.stdout.length}`,
+		);
 		return;
 	}
 }


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## Summaries (3)

### 01 · Add structured error logging for silent PR lookup failures

**⚡ Why This Change**

When the PR status check or commit count query failed silently, nothing was written to the debug log. Users and developers had no way to distinguish "PR genuinely doesn't exist" from "the lookup failed due to an auth problem, rate limit, network issue, or misconfigured remote."

**💡 Decisions Behind the Code**

- **Discriminated union over simple logging patch**: Returning a structured result from `tryExecGh` lets each call site decide log severity based on failure semantics, rather than applying a blanket level — this avoids both over-logging (noise) and under-logging (missed real errors).
- **Debug for expected miss, warn for everything else**: "No PR found" is a normal outcome on every WebView open; logging it at warn would pollute logs for all users. Real failures (auth, network, rate limit) are unexpected and must be visible at the default log level.
- **UI folding intentionally left unchanged**: Fixing the debug log was the scoped goal; changing how the UI presents different failure modes was explicitly declared a non-goal to keep the change small and avoid touching handler return paths.
- **Test via public handler, not private functions**: `tryExecGh` and `findPrForBranch` are module-private; testing through the public handler avoids exporting internals and simultaneously validates that the log behavior and UI message are consistent end-to-end.

**✅ What Was Implemented**

- Replaced `tryExecGh`'s return type from `string | undefined` to a discriminated union (`GhCmdResult`) carrying the error object, exit code, and stderr — never throws, never silently drops failure context
- In `findPrForBranch`: stderr matching "no pull requests found" routes to `log.debug` (expected miss, low noise); all other failures route to `log.warn` with code and full stderr; unparseable JSON also routes to `log.warn` with raw length
- In `getCommitCount`: replaced silent `return 0` with `log.warn` recording the full error message
- Added `debug: vi.fn()` to the hoisted Logger mock in the test file
- Added 6 new test cases under a "debug.log observability" section, all exercising the public `handleCheckPrStatus` handler indirectly to avoid testing private functions

### 02 · Fix cross-platform test failures caused by hardcoded path separators

**⚡ Why This Change**

Seven CLI tests were failing on Windows because test assertions used hardcoded POSIX-style path strings, and one test relied on a Linux-specific device path to simulate a filesystem error. These failures blocked the full test suite from passing.

**💡 Decisions Behind the Code**

- **Path assertion strategy**: Using `path.join()` to build expected values rather than hardcoding strings means the test adapts to the OS at runtime, avoiding a separate set of Windows-specific assertions while keeping the test intent clear.
- **Filesystem error simulation**: The `/dev/null` trick was replaced with a "file-as-parent-directory" approach because it is the only reliable cross-platform way to force `mkdir` to fail — any OS will reject creating a directory whose parent path segment is a regular file (ENOTDIR), whereas `/dev/null` behaves as a device on Linux but as a normal path on Windows.

**✅ What Was Implemented**

- `GitOperationDetector.test.ts`: replaced four hardcoded POSIX path string assertions with `path.join()`-constructed equivalents so expected values use the native OS separator
- `OpenCodeSessionDiscoverer.test.ts`: same treatment for two path assertions involving home directory and XDG data paths
- `Installer.test.ts`: replaced the `/dev/null/impossible-path` trick (POSIX-only) with a cross-platform approach — writes a real file to a temp directory, then points the home directory mock at a subdirectory of that file, causing `mkdir` to fail with `ENOTDIR` on any OS

### 03 · Fix lint failures caused by Windows line-ending conversion on checkout

**⚡ Why This Change**

Running the linter reported 54 errors in the CLI workspace and 31 in the VS Code workspace. These turned out to be entirely caused by Windows automatically converting line endings to CRLF on checkout, while the project's linter requires LF.

**💡 Decisions Behind the Code**

- **Format-in-place rather than reconfigure git**: Reformatting the working tree with the existing formatter was the safest minimal fix — it produced zero content changes and left the repository history untouched. Changing git's `autocrlf` setting was explicitly ruled out because the project's `CLAUDE.md` prohibits modifying git config.
- **No `.gitattributes` change**: The repository already declared `eol=lf` in `.gitattributes`; the root cause was a local developer setting overriding it. A project-level fix would require every Windows contributor to adjust their git config, which was noted as a remaining risk but deferred.

**✅ What Was Implemented**

- Ran `biome format --write` across both workspaces to convert all working-tree files back to LF
- No actual code content changed — `git diff` produced empty output because the repository already stored files with LF endings
- Ran `git add .` to refresh git's stat cache and bring the working tree to a clean state

---

*Generated by Jolli Memory · April 24, 2026 at 2:38 PM*
<!-- jollimemory-summary-end -->