### PR TITLE
Fix API key origin exfiltration via assertJolliOriginAllowed allowlist

### DIFF
--- a/cli/src/Cli.test.ts
+++ b/cli/src/Cli.test.ts
@@ -45,9 +45,13 @@ vi.mock("./core/SessionTracker.js", () => ({
 	deleteSquashPending: vi.fn().mockResolvedValue(undefined),
 }));
 
-vi.mock("./core/JolliApiUtils.js", () => ({
-	parseJolliApiKey: vi.fn().mockReturnValue(null),
-}));
+vi.mock("./core/JolliApiUtils.js", async () => {
+	const actual = await vi.importActual<typeof import("./core/JolliApiUtils.js")>("./core/JolliApiUtils.js");
+	return {
+		...actual,
+		parseJolliApiKey: vi.fn().mockReturnValue(null),
+	};
+});
 
 vi.mock("./install/DistPathResolver.js", () => ({
 	compareSemver: (a: string, b: string) => {
@@ -2512,8 +2516,11 @@ describe("CLI", () => {
 
 		it("should save API keys and print confirmation when keys are entered interactively", async () => {
 			const { saveConfigScoped } = await import("./core/SessionTracker.js");
+			// Construct an on-allowlist key so the new validateJolliApiKey gate passes.
+			const goodMeta = { t: "tenant1", u: "https://tenant1.jolli.ai" };
+			const goodJolliKey = `sk-jol-${Buffer.from(JSON.stringify(goodMeta)).toString("base64url")}.secret`;
 			// Choose "2" (manual Jolli API key), enter key, then enter Anthropic key
-			mockUserInput("2", "jk_test_key_123", "sk-ant-test-key");
+			mockUserInput("2", goodJolliKey, "sk-ant-test-key");
 			mockExistsSync.mockReturnValue(false);
 			Object.defineProperty(process.stdin, "isTTY", { value: true, configurable: true });
 
@@ -2647,8 +2654,11 @@ describe("CLI", () => {
 
 		it("should show empty line when keys are saved after manual entry", async () => {
 			const { loadConfigFromDir } = await import("./core/SessionTracker.js");
+			// Construct an on-allowlist key so the new validateJolliApiKey gate passes.
+			const goodMeta = { t: "tenant1", u: "https://tenant1.jolli.ai" };
+			const goodJolliKey = `sk-jol-${Buffer.from(JSON.stringify(goodMeta)).toString("base64url")}.secret`;
 			// Choose "2" (manual), enter Jolli key, enter Anthropic key
-			mockUserInput("2", "jk_test", "sk-ant-test");
+			mockUserInput("2", goodJolliKey, "sk-ant-test");
 			mockExistsSync.mockReturnValue(false);
 			Object.defineProperty(process.stdin, "isTTY", { value: true, configurable: true });
 			// Mock the 3 calls to loadConfigFromDir:
@@ -2657,8 +2667,8 @@ describe("CLI", () => {
 			// 3. final state check in promptAnthropicKey (has both keys)
 			vi.mocked(loadConfigFromDir)
 				.mockResolvedValueOnce({})
-				.mockResolvedValueOnce({ jolliApiKey: "jk_test" })
-				.mockResolvedValueOnce({ jolliApiKey: "jk_test", apiKey: "sk-ant-test" });
+				.mockResolvedValueOnce({ jolliApiKey: goodJolliKey })
+				.mockResolvedValueOnce({ jolliApiKey: goodJolliKey, apiKey: "sk-ant-test" });
 
 			try {
 				await main(["enable"]);
@@ -3107,6 +3117,75 @@ describe("CLI", () => {
 			expect(saveConfig).toHaveBeenCalledWith(
 				expect.objectContaining({ excludePatterns: ["*.log", "dist/**", "node_modules"] }),
 			);
+		});
+
+		it("should reject a jolliApiKey whose embedded origin is off the allowlist", async () => {
+			const { saveConfig } = await import("./core/SessionTracker.js");
+			vi.mocked(saveConfig).mockClear();
+
+			// Build a real key whose embedded meta decodes to an off-allowlist origin —
+			// mocking parseJolliApiKey wouldn't work here because validateJolliApiKey
+			// calls into the same module (vi.mock doesn't intercept intra-module refs).
+			const evilMeta = { t: "x", u: "https://evil.com" };
+			const encoded = Buffer.from(JSON.stringify(evilMeta)).toString("base64url");
+			const evilKey = `sk-jol-${encoded}.secretbytes`;
+
+			const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+			try {
+				await main(["configure", "--set", `jolliApiKey=${evilKey}`]);
+				expect(saveConfig).not.toHaveBeenCalled();
+				expect(process.exitCode).toBe(1);
+				const errorOutput = errorSpy.mock.calls.map((c) => String(c[0])).join("\n");
+				expect(errorOutput).toContain("evil.com");
+			} finally {
+				errorSpy.mockRestore();
+			}
+		});
+
+		it("should accept a jolliApiKey whose embedded origin is on the allowlist", async () => {
+			const { saveConfig } = await import("./core/SessionTracker.js");
+			vi.mocked(saveConfig).mockClear();
+
+			const goodMeta = { t: "tenant1", u: "https://tenant1.jolli.ai" };
+			const encoded = Buffer.from(JSON.stringify(goodMeta)).toString("base64url");
+			const goodKey = `sk-jol-${encoded}.secretbytes`;
+
+			await main(["configure", "--set", `jolliApiKey=${goodKey}`]);
+
+			expect(saveConfig).toHaveBeenCalledWith(expect.objectContaining({ jolliApiKey: goodKey }));
+		});
+
+		it("should reject a jolliApiKey that cannot be decoded (legacy no-meta shape)", async () => {
+			const { saveConfig } = await import("./core/SessionTracker.js");
+			vi.mocked(saveConfig).mockClear();
+			// Default parseJolliApiKey mock returns null.
+
+			const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+			try {
+				await main(["configure", "--set", "jolliApiKey=sk-jol-legacyhex32chars"]);
+				expect(saveConfig).not.toHaveBeenCalled();
+				expect(process.exitCode).toBe(1);
+				const errorOutput = errorSpy.mock.calls.map((c) => String(c[0])).join("\n");
+				expect(errorOutput).toContain("cannot be decoded");
+			} finally {
+				errorSpy.mockRestore();
+			}
+		});
+
+		it("should reject a jolliApiKey that does not start with sk-jol-", async () => {
+			const { saveConfig } = await import("./core/SessionTracker.js");
+			vi.mocked(saveConfig).mockClear();
+
+			const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+			try {
+				await main(["configure", "--set", "jolliApiKey=sf-jol-garbage"]);
+				expect(saveConfig).not.toHaveBeenCalled();
+				expect(process.exitCode).toBe(1);
+				const errorOutput = errorSpy.mock.calls.map((c) => String(c[0])).join("\n");
+				expect(errorOutput).toContain("cannot be decoded");
+			} finally {
+				errorSpy.mockRestore();
+			}
 		});
 
 		it("should list all config keys with --list-keys", async () => {

--- a/cli/src/auth/AuthConfig.test.ts
+++ b/cli/src/auth/AuthConfig.test.ts
@@ -36,6 +36,21 @@ describe("AuthConfig", () => {
 			process.env.JOLLI_URL = "   ";
 			expect(getJolliUrl()).toBe("https://app.jolli.ai");
 		});
+
+		it("should accept a staging jolli.dev host with trailing slash stripped", () => {
+			process.env.JOLLI_URL = "https://staging.jolli.dev/";
+			expect(getJolliUrl()).toBe("https://staging.jolli.dev");
+		});
+
+		it("should throw when JOLLI_URL points off the allowlist", () => {
+			process.env.JOLLI_URL = "https://evil.com";
+			expect(() => getJolliUrl()).toThrow(/evil\.com/);
+		});
+
+		it("should throw when JOLLI_URL uses http scheme", () => {
+			process.env.JOLLI_URL = "http://app.jolli.ai";
+			expect(() => getJolliUrl()).toThrow(/Rejected/);
+		});
 	});
 
 	describe("saveAuthToken", () => {
@@ -83,11 +98,20 @@ describe("AuthConfig", () => {
 	});
 
 	describe("saveAuthCredentials", () => {
+		/** Builds a valid new-format sk-jol key whose embedded meta is the given object. */
+		function buildNewFormatKey(meta: Record<string, unknown>): string {
+			const encoded = Buffer.from(JSON.stringify(meta)).toString("base64url");
+			return `sk-jol-${encoded}.secretbytes`;
+		}
+
+		// Valid new-format key: meta is {t:"tenant",u:"https://tenant.jolli.ai"} base64url-encoded.
+		const VALID_KEY = "sk-jol-eyJ0IjoidGVuYW50IiwidSI6Imh0dHBzOi8vdGVuYW50LmpvbGxpLmFpIn0.secret";
+
 		it("should save both authToken and jolliApiKey in a single saveConfig call", async () => {
 			mockSaveConfig.mockResolvedValue(undefined);
-			await saveAuthCredentials({ token: "tk-abc", jolliApiKey: "sk-jol-xyz" });
+			await saveAuthCredentials({ token: "tk-abc", jolliApiKey: VALID_KEY });
 			expect(mockSaveConfig).toHaveBeenCalledTimes(1);
-			expect(mockSaveConfig).toHaveBeenCalledWith({ authToken: "tk-abc", jolliApiKey: "sk-jol-xyz" });
+			expect(mockSaveConfig).toHaveBeenCalledWith({ authToken: "tk-abc", jolliApiKey: VALID_KEY });
 		});
 
 		it("should omit jolliApiKey from the write when not provided", async () => {
@@ -100,6 +124,40 @@ describe("AuthConfig", () => {
 			mockSaveConfig.mockResolvedValue(undefined);
 			await saveAuthCredentials({ token: "tk-abc", jolliApiKey: undefined });
 			expect(mockSaveConfig).toHaveBeenCalledWith({ authToken: "tk-abc" });
+		});
+
+		it("should persist a new-format key whose embedded origin is on the allowlist", async () => {
+			mockSaveConfig.mockResolvedValue(undefined);
+			const key = buildNewFormatKey({ t: "tenant1", u: "https://tenant1.jolli.ai" });
+			await saveAuthCredentials({ token: "tk-abc", jolliApiKey: key });
+			expect(mockSaveConfig).toHaveBeenCalledWith({ authToken: "tk-abc", jolliApiKey: key });
+		});
+
+		it("should reject a new-format key whose embedded origin is off the allowlist", async () => {
+			const key = buildNewFormatKey({ t: "x", u: "https://evil.com" });
+			await expect(saveAuthCredentials({ token: "tk-abc", jolliApiKey: key })).rejects.toThrow(/evil\.com/);
+			expect(mockSaveConfig).not.toHaveBeenCalled();
+		});
+
+		it("should reject a key that cannot be decoded (wrong prefix)", async () => {
+			await expect(saveAuthCredentials({ token: "tk-abc", jolliApiKey: "sf-jol-garbage" })).rejects.toThrow(
+				/cannot be decoded/,
+			);
+			expect(mockSaveConfig).not.toHaveBeenCalled();
+		});
+
+		it("should reject a legacy-shape key with no embedded meta", async () => {
+			await expect(
+				saveAuthCredentials({ token: "tk-abc", jolliApiKey: "sk-jol-legacyhex32chars" }),
+			).rejects.toThrow(/cannot be decoded/);
+			expect(mockSaveConfig).not.toHaveBeenCalled();
+		});
+
+		it("should reject a key with non-ASCII characters (e.g. pasted garbage)", async () => {
+			await expect(
+				saveAuthCredentials({ token: "tk-abc", jolliApiKey: "sk-jol-windows大大大大" }),
+			).rejects.toThrow(/cannot be decoded/);
+			expect(mockSaveConfig).not.toHaveBeenCalled();
 		});
 	});
 });

--- a/cli/src/auth/AuthConfig.ts
+++ b/cli/src/auth/AuthConfig.ts
@@ -5,13 +5,21 @@
  * Tokens are stored in ~/.jolli/jollimemory/config.json alongside other config fields.
  */
 
+import { assertJolliOriginAllowed, validateJolliApiKey } from "../core/JolliApiUtils.js";
 import { loadConfig, saveConfig } from "../core/SessionTracker.js";
 
 const DEFAULT_JOLLI_URL = "https://app.jolli.ai";
 
-/** Returns the Jolli server URL. Checks JOLLI_URL env var, then falls back to default. Strips trailing slashes. */
+/**
+ * Returns the Jolli server URL. Checks JOLLI_URL env var, then falls back to default.
+ * Strips trailing slashes and enforces the Jolli origin allowlist — a
+ * socially-engineered `JOLLI_URL=https://evil.com` would otherwise send the
+ * user's OAuth credentials to the attacker before any API key is involved.
+ */
 export function getJolliUrl(): string {
-	return (process.env.JOLLI_URL?.trim() || DEFAULT_JOLLI_URL).replace(/\/+$/, "");
+	const url = (process.env.JOLLI_URL?.trim() || DEFAULT_JOLLI_URL).replace(/\/+$/, "");
+	assertJolliOriginAllowed(url);
+	return url;
 }
 
 /** Saves the OAuth auth token to global config. */
@@ -31,6 +39,7 @@ export async function saveAuthCredentials(credentials: {
 }): Promise<void> {
 	const update: { authToken: string; jolliApiKey?: string } = { authToken: credentials.token };
 	if (credentials.jolliApiKey) {
+		validateJolliApiKey(credentials.jolliApiKey);
 		update.jolliApiKey = credentials.jolliApiKey;
 	}
 	await saveConfig(update);

--- a/cli/src/commands/ConfigureCommand.ts
+++ b/cli/src/commands/ConfigureCommand.ts
@@ -7,6 +7,7 @@
 
 import { join } from "node:path";
 import type { Command } from "commander";
+import { validateJolliApiKey } from "../core/JolliApiUtils.js";
 import { getGlobalConfigDir, loadConfig, saveConfig } from "../core/SessionTracker.js";
 import { createLogger } from "../Logger.js";
 import type { JolliMemoryConfig, LogLevel } from "../Types.js";
@@ -163,6 +164,17 @@ export function registerConfigureCommand(program: Command): void {
 						console.error(`\n  Error: ${(err as Error).message}\n`);
 						process.exitCode = 1;
 						return;
+					}
+					// Reject unrecognized shapes and keys whose embedded `.u` points off
+					// the allowlist before we touch disk. Matches saveAuthCredentials.
+					if (key === "jolliApiKey" && typeof update[key] === "string") {
+						try {
+							validateJolliApiKey(update[key] as string);
+						} catch (err) {
+							console.error(`\n  Error: ${(err as Error).message}\n`);
+							process.exitCode = 1;
+							return;
+						}
 					}
 				}
 

--- a/cli/src/commands/EnableCommand.ts
+++ b/cli/src/commands/EnableCommand.ts
@@ -9,6 +9,7 @@ import { join } from "node:path";
 import type { Command } from "commander";
 import { getJolliUrl } from "../auth/AuthConfig.js";
 import { browserLogin } from "../auth/Login.js";
+import { validateJolliApiKey } from "../core/JolliApiUtils.js";
 import { getGlobalConfigDir, loadConfigFromDir, saveConfigScoped } from "../core/SessionTracker.js";
 import { install, uninstall } from "../install/Installer.js";
 import { createLogger, setLogDir } from "../Logger.js";
@@ -80,6 +81,13 @@ async function handleManualApiKey(configDir: string): Promise<void> {
 
 	const key = await promptText("  Jolli API Key (press Enter to skip): ");
 	if (key) {
+		try {
+			validateJolliApiKey(key);
+		} catch (err) {
+			console.error(`\n  Error: ${(err as Error).message}\n`);
+			process.exitCode = 1;
+			return;
+		}
 		await saveConfigScoped({ jolliApiKey: key } as Partial<JolliMemoryConfig>, configDir);
 		console.log("  Jolli API Key:     saved ✓");
 		console.log(`\n  Configuration saved to ${join(configDir, "config.json")}`);

--- a/cli/src/core/JolliApiUtils.test.ts
+++ b/cli/src/core/JolliApiUtils.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { parseBaseUrl, parseJolliApiKey } from "./JolliApiUtils";
+import { assertJolliOriginAllowed, parseBaseUrl, parseJolliApiKey } from "./JolliApiUtils";
 
 describe("JolliApiUtils", () => {
 	describe("parseBaseUrl", () => {
 		it("should parse origin from simple URL", () => {
-			const result = parseBaseUrl("https://jolli.app");
-			expect(result.origin).toBe("https://jolli.app");
+			const result = parseBaseUrl("https://jolli.dev");
+			expect(result.origin).toBe("https://jolli.dev");
 			expect(result.tenantSlug).toBeUndefined();
 		});
 
@@ -27,7 +27,7 @@ describe("JolliApiUtils", () => {
 		});
 
 		it("should handle URL with only root path", () => {
-			const result = parseBaseUrl("https://jolli.app/");
+			const result = parseBaseUrl("https://jolli.dev/");
 			expect(result.tenantSlug).toBeUndefined();
 		});
 	});
@@ -42,19 +42,19 @@ describe("JolliApiUtils", () => {
 		});
 
 		it("should parse valid new-format key", () => {
-			const meta = { t: "tenant1", u: "https://tenant1.jolli.app" };
+			const meta = { t: "tenant1", u: "https://tenant1.jolli.dev" };
 			const encoded = Buffer.from(JSON.stringify(meta)).toString("base64url");
 			const key = `sk-jol-${encoded}.randomsecretbytes`;
 			const result = parseJolliApiKey(key);
-			expect(result).toEqual({ t: "tenant1", u: "https://tenant1.jolli.app" });
+			expect(result).toEqual({ t: "tenant1", u: "https://tenant1.jolli.dev" });
 		});
 
 		it("should parse key with org slug", () => {
-			const meta = { t: "tenant1", u: "https://tenant1.jolli.app", o: "engineering" };
+			const meta = { t: "tenant1", u: "https://tenant1.jolli.dev", o: "engineering" };
 			const encoded = Buffer.from(JSON.stringify(meta)).toString("base64url");
 			const key = `sk-jol-${encoded}.randomsecretbytes`;
 			const result = parseJolliApiKey(key);
-			expect(result).toEqual({ t: "tenant1", u: "https://tenant1.jolli.app", o: "engineering" });
+			expect(result).toEqual({ t: "tenant1", u: "https://tenant1.jolli.dev", o: "engineering" });
 		});
 
 		it("should return null for invalid base64 in key", () => {
@@ -69,6 +69,79 @@ describe("JolliApiUtils", () => {
 
 		it("should return null for empty key", () => {
 			expect(parseJolliApiKey("")).toBeNull();
+		});
+
+		it("should parse JWT-shape key (meta in segment 1)", () => {
+			// sk-jol-<header>.<payload>.<sig> — the actual meta lives in the
+			// middle segment, not the first.
+			const header = Buffer.from(JSON.stringify({ alg: "HS256", typ: "JWT" })).toString("base64url");
+			const payload = Buffer.from(
+				JSON.stringify({ t: "tenant1", u: "https://tenant1.jolli.dev", o: "eng" }),
+			).toString("base64url");
+			const sig = "signatureBytesHere";
+			const key = `sk-jol-${header}.${payload}.${sig}`;
+			expect(parseJolliApiKey(key)).toEqual({
+				t: "tenant1",
+				u: "https://tenant1.jolli.dev",
+				o: "eng",
+			});
+		});
+
+		it("should return null when no JWT segment carries t/u fields", () => {
+			const header = Buffer.from(JSON.stringify({ alg: "HS256", typ: "JWT" })).toString("base64url");
+			const payload = Buffer.from(JSON.stringify({ sub: "someone", iat: 1 })).toString("base64url");
+			const sig = "signatureBytesHere";
+			expect(parseJolliApiKey(`sk-jol-${header}.${payload}.${sig}`)).toBeNull();
+		});
+	});
+
+	describe("assertJolliOriginAllowed", () => {
+		it("accepts https://app.jolli.ai", () => {
+			expect(() => assertJolliOriginAllowed("https://app.jolli.ai")).not.toThrow();
+		});
+
+		it("accepts apex https://jolli.ai", () => {
+			expect(() => assertJolliOriginAllowed("https://jolli.ai")).not.toThrow();
+		});
+
+		it("accepts https://tenant.jolli.dev", () => {
+			expect(() => assertJolliOriginAllowed("https://tenant.jolli.dev")).not.toThrow();
+		});
+
+		it("accepts https://jolli-local.me for local development", () => {
+			expect(() => assertJolliOriginAllowed("https://jolli-local.me")).not.toThrow();
+		});
+
+		it("accepts https://sub.jolli-local.me subdomain", () => {
+			expect(() => assertJolliOriginAllowed("https://sub.jolli-local.me")).not.toThrow();
+		});
+
+		it("accepts https with non-default port on allowed host", () => {
+			expect(() => assertJolliOriginAllowed("https://app.jolli.ai:8443")).not.toThrow();
+		});
+
+		it("rejects https://evil.com with origin in the error", () => {
+			expect(() => assertJolliOriginAllowed("https://evil.com")).toThrow(/evil\.com/);
+		});
+
+		it("rejects suffix-boundary host https://evil-jolli.ai", () => {
+			expect(() => assertJolliOriginAllowed("https://evil-jolli.ai")).toThrow(/Rejected/);
+		});
+
+		it("rejects suffix-extended host https://app.jolli.ai.evil.com", () => {
+			expect(() => assertJolliOriginAllowed("https://app.jolli.ai.evil.com")).toThrow(/Rejected/);
+		});
+
+		it("rejects http scheme on allowed host", () => {
+			expect(() => assertJolliOriginAllowed("http://app.jolli.ai")).toThrow(/Rejected/);
+		});
+
+		it("rejects unparseable input", () => {
+			expect(() => assertJolliOriginAllowed("not-a-url")).toThrow(/unparseable/);
+		});
+
+		it("rejects credentials-in-url disguising attacker host", () => {
+			expect(() => assertJolliOriginAllowed("https://app.jolli.ai@evil.com")).toThrow(/evil\.com/);
 		});
 	});
 });

--- a/cli/src/core/JolliApiUtils.ts
+++ b/cli/src/core/JolliApiUtils.ts
@@ -17,7 +17,7 @@ export interface ParsedBaseUrl {
 export interface JolliApiKeyMeta {
 	/** Tenant identifier */
 	readonly t: string;
-	/** Site base URL (e.g. "https://example.jolli.app") */
+	/** Site base URL (e.g. "https://example.jolli.dev") */
 	readonly u: string;
 	/** Organization slug (optional) */
 	readonly o?: string;
@@ -41,25 +41,93 @@ export function parseBaseUrl(baseUrl: string): ParsedBaseUrl {
 
 /**
  * Parses a Jolli API key (sk-jol-...) and extracts its metadata.
- * Returns null if the key format is invalid.
+ * Returns null for old-format (no-dot) keys and for unrecognized shapes.
+ *
+ * Scans every `.`-separated segment after the `sk-jol-` prefix and returns
+ * the first one that base64url-decodes to a JSON object containing string
+ * `t` and `u` fields. This covers:
+ *   - Format A (1 dot):   `sk-jol-<metaB64>.<secretB64>` — meta in segment 0
+ *   - Format B (JWT, 2 dots): `sk-jol-<headerB64>.<payloadB64>.<sigB64>` — meta in segment 1
+ *
+ * Scanning (rather than fixing on a specific segment index) means the allowlist
+ * check in `assertJolliOriginAllowed` runs for both formats — a key whose
+ * claimed `u` is off-allowlist is rejected regardless of which segment carries it.
  */
 export function parseJolliApiKey(key: string): JolliApiKeyMeta | null {
 	if (!key.startsWith("sk-jol-")) {
 		return null;
 	}
 	const rest = key.slice("sk-jol-".length);
-	const dotIndex = rest.indexOf(".");
-	if (dotIndex === -1) {
+	if (!rest.includes(".")) {
+		// Old format: `sk-jol-<32 hex chars>` — no embedded meta.
 		return null;
 	}
-	try {
-		const metaJson = Buffer.from(rest.slice(0, dotIndex), "base64url").toString("utf-8");
-		const meta = JSON.parse(metaJson) as Record<string, unknown>;
-		if (typeof meta.t === "string" && typeof meta.u === "string") {
-			return { t: meta.t, u: meta.u, ...(typeof meta.o === "string" ? { o: meta.o } : {}) };
+	for (const segment of rest.split(".")) {
+		try {
+			const json = Buffer.from(segment, "base64url").toString("utf-8");
+			const meta = JSON.parse(json) as Record<string, unknown>;
+			if (typeof meta.t === "string" && typeof meta.u === "string") {
+				return {
+					t: meta.t,
+					u: meta.u,
+					...(typeof meta.o === "string" ? { o: meta.o } : {}),
+				};
+			}
+		} catch {
+			// Segment isn't valid base64url JSON — try the next one.
 		}
-		return null;
-	} catch {
-		return null;
 	}
+	return null;
+}
+
+/**
+ * Rejects any Jolli API key we cannot decode, and any whose embedded `.u`
+ * claim points off the allowlist. Called from every save path (OAuth callback,
+ * settings UI, `configure --set`).
+ *
+ * Two checks, both enforced:
+ *   1. `parseJolliApiKey(key)` must return meta with `t` and `u` strings —
+ *      anything we can't decode (wrong prefix, non-base64url chars, no dot,
+ *      legacy-only shape, garbage) is refused.
+ *   2. `assertJolliOriginAllowed(meta.u)` must pass.
+ */
+export function validateJolliApiKey(key: string): void {
+	const meta = parseJolliApiKey(key);
+	if (!meta) {
+		throw new Error("Rejected Jolli API key: cannot be decoded. Paste the key exactly as issued by Jolli.");
+	}
+	assertJolliOriginAllowed(meta.u);
+}
+
+const ALLOWED_JOLLI_HOSTS = ["jolli.ai", "jolli.dev", "jolli-local.me"];
+
+/**
+ * Rejects origins that are not on the Jolli allowlist. Called from the
+ * settings save path (and the `JOLLI_URL` env-var resolver) so a crafted key
+ * or a socially-engineered env var is refused before it can be persisted or
+ * used as an OAuth target.
+ *
+ * Not intended for the network boundary — by the time a saved config is
+ * loaded for a request, the save-time check has already screened it, and
+ * adding another layer there is just "defense against scenarios that can't
+ * happen".
+ */
+export function assertJolliOriginAllowed(origin: string): void {
+	let url: URL;
+	try {
+		url = new URL(origin);
+	} catch {
+		throw new Error(`Rejected Jolli origin (unparseable): ${origin}`);
+	}
+	const host = url.hostname.toLowerCase();
+	const ok =
+		url.protocol === "https:" &&
+		host !== "" &&
+		ALLOWED_JOLLI_HOSTS.some((h) => host === h || host.endsWith(`.${h}`));
+	if (ok) {
+		return;
+	}
+	throw new Error(
+		`Rejected Jolli origin "${url.origin}". Only https://*.jolli.ai, https://*.jolli.dev, and https://*.jolli-local.me are permitted.`,
+	);
 }

--- a/vscode/src/services/AuthService.ts
+++ b/vscode/src/services/AuthService.ts
@@ -131,7 +131,20 @@ export class AuthService {
 		// Mirrors the CLI's browserLogin() behaviour in Login.ts.
 		const { jolliApiKey } = await loadConfig();
 		const generateKeyParam = jolliApiKey ? "" : "&generate_api_key=true";
-		const loginUrl = `${getJolliUrl()}/login?cli_callback=${encodeURIComponent(callbackUri)}${generateKeyParam}&client=vscode`;
+		// `getJolliUrl()` throws if `JOLLI_URL` env var points off the
+		// allowlist — catch it here so an attacker-pointed env var surfaces as
+		// a friendly error dialog instead of an unhandled command exception.
+		let loginUrl: string;
+		try {
+			loginUrl = `${getJolliUrl()}/login?cli_callback=${encodeURIComponent(callbackUri)}${generateKeyParam}&client=vscode`;
+		} catch (err: unknown) {
+			const message = err instanceof Error ? err.message : String(err);
+			log.error("AuthService", "getJolliUrl rejected: %s", message);
+			vscode.window.showErrorMessage(
+				`Cannot sign in: ${message} Unset JOLLI_URL (or set it to a trusted Jolli host) and retry.`,
+			);
+			return;
+		}
 		log.info("AuthService", "Opening browser for sign-in");
 		try {
 			const opened = await vscode.env.openExternal(vscode.Uri.parse(loginUrl));

--- a/vscode/src/services/JolliPushService.test.ts
+++ b/vscode/src/services/JolliPushService.test.ts
@@ -198,6 +198,9 @@ describe("parseJolliApiKey", () => {
 	});
 });
 
+// assertJolliOriginAllowed is owned by cli/src/core/JolliApiUtils.ts and
+// covered by cli/src/core/JolliApiUtils.test.ts — no duplicate here.
+
 describe("pushToJolli", () => {
 	beforeEach(() => {
 		vi.resetAllMocks();
@@ -391,11 +394,7 @@ describe("pushToJolli", () => {
 			},
 		);
 
-		await pushToJolli(
-			"https://jolli-local.me/test1/",
-			OLD_KEY,
-			DEFAULT_PAYLOAD,
-		);
+		await pushToJolli("https://jolli.ai/test1/", OLD_KEY, DEFAULT_PAYLOAD);
 
 		const callArgs = mockHttpsRequest.mock.calls[0] as [
 			unknown,
@@ -725,7 +724,7 @@ describe("deleteFromJolli", () => {
 			},
 		);
 
-		await deleteFromJolli("https://jolli-local.me/test1/", OLD_KEY, 42);
+		await deleteFromJolli("https://jolli.ai/test1/", OLD_KEY, 42);
 
 		const callArgs = mockHttpsRequest.mock.calls[0] as [
 			{ headers: Record<string, string> },
@@ -759,48 +758,6 @@ describe("deleteFromJolli", () => {
 			{ headers: Record<string, string> },
 		];
 		expect(callArgs[0].headers["x-org-slug"]).toBe("org1");
-	});
-
-	it("uses http.request for HTTP URL", async () => {
-		const mockReq = createMockRequest();
-		const mockRes: MockIncomingMessage = {
-			statusCode: 204,
-			on: vi.fn(),
-			resume: vi.fn(),
-		};
-
-		mockHttpRequest.mockImplementation(
-			(_opts: unknown, cb: (res: MockIncomingMessage) => void) => {
-				cb(mockRes);
-				return mockReq;
-			},
-		);
-
-		await deleteFromJolli("http://localhost:7034", OLD_KEY, 42);
-		expect(mockHttpRequest).toHaveBeenCalledOnce();
-		expect(mockHttpsRequest).not.toHaveBeenCalled();
-	});
-
-	it("defaults port to 80 for HTTP URL without explicit port", async () => {
-		const mockReq = createMockRequest();
-		const mockRes: MockIncomingMessage = {
-			statusCode: 204,
-			on: vi.fn(),
-			resume: vi.fn(),
-		};
-
-		mockHttpRequest.mockImplementation(
-			(_opts: unknown, cb: (res: MockIncomingMessage) => void) => {
-				cb(mockRes);
-				return mockReq;
-			},
-		);
-
-		await deleteFromJolli("http://localhost", OLD_KEY, 42);
-		expect(mockHttpRequest).toHaveBeenCalledOnce();
-
-		const callArgs = mockHttpRequest.mock.calls[0] as [{ port: number }];
-		expect(callArgs[0].port).toBe(80);
 	});
 
 	it("constructs the correct delete path with docId", async () => {

--- a/vscode/src/services/JolliPushService.ts
+++ b/vscode/src/services/JolliPushService.ts
@@ -15,6 +15,18 @@
 
 import { request as httpRequest } from "node:http";
 import { request as httpsRequest } from "node:https";
+// JolliPushService reads the key's embedded tenant/org metadata to route
+// requests — it does NOT enforce the origin allowlist. Allowlist validation
+// belongs to save-time paths (SettingsWebviewPanel.handleApplySettings,
+// AuthService.handleAuthCallback via CLI saveAuthCredentials). Those callers
+// import `validateJolliApiKey` directly from cli/src/core/JolliApiUtils.js.
+import {
+	type JolliApiKeyMeta,
+	parseBaseUrl,
+	parseJolliApiKey,
+} from "../../../cli/src/core/JolliApiUtils.js";
+
+export { parseJolliApiKey, type JolliApiKeyMeta };
 
 /** Thrown when the server rejects the request due to outdated plugin version (HTTP 426). */
 export class PluginOutdatedError extends Error {
@@ -44,84 +56,6 @@ export interface JolliPushResult {
 	readonly docId: number;
 	readonly jrn: string;
 	readonly created: boolean;
-}
-
-/**
- * Parsed base URL with optional tenant slug extracted from the path.
- *
- * Path-based: "https://jolli-local.me/test1/" → origin "https://jolli-local.me", tenantSlug "test1"
- * Subdomain:  "https://test1.jolli.ai"       → origin "https://test1.jolli.ai", tenantSlug undefined
- */
-interface ParsedBaseUrl {
-	/** The origin without any path prefix (e.g. "https://jolli-local.me") */
-	readonly origin: string;
-	/** Tenant slug extracted from the first path segment, if present */
-	readonly tenantSlug: string | undefined;
-}
-
-/**
- * Extracts the origin and optional tenant slug from a Jolli base URL.
- * If the URL has a non-empty path (e.g. "/test1/"), the first segment is the tenant slug.
- */
-function parseBaseUrl(baseUrl: string): ParsedBaseUrl {
-	const url = new URL(baseUrl);
-	// Strip leading/trailing slashes and extract first segment
-	const pathSegments = url.pathname
-		.replace(/^\/+|\/+$/g, "")
-		.split("/")
-		.filter(Boolean);
-	return {
-		origin: url.origin,
-		tenantSlug: pathSegments.length > 0 ? pathSegments[0] : undefined,
-	};
-}
-
-/**
- * Metadata embedded in a new-format Jolli API key.
- * - `t`: tenant slug (used as x-tenant-slug header for path-based tenants)
- * - `u`: full base URL (e.g., "https://ibm.jolli.ai" or "https://jolli.ai/ibm")
- * - `o`: org slug (used as x-org-slug header for multi-org routing; absent in old keys)
- */
-export interface JolliApiKeyMeta {
-	readonly t: string;
-	readonly u: string;
-	readonly o?: string;
-}
-
-/**
- * Parses the tenant metadata embedded in a new-format Jolli API key.
- *
- * New format: sk-jol-{base64url(JSON meta)}.{base64url(32 random bytes)}
- * Old format: sk-jol-{32 hex chars} — returns null
- *
- * @param key - Jolli API key string
- * @returns Parsed metadata, or null if the key uses the old format or cannot be decoded
- */
-export function parseJolliApiKey(key: string): JolliApiKeyMeta | null {
-	if (!key.startsWith("sk-jol-")) {
-		return null;
-	}
-	const rest = key.slice("sk-jol-".length);
-	const dotIndex = rest.indexOf(".");
-	if (dotIndex === -1) {
-		return null;
-	}
-	try {
-		const metaJson = Buffer.from(rest.slice(0, dotIndex), "base64url").toString(
-			"utf-8",
-		);
-		const meta = JSON.parse(metaJson) as Record<string, unknown>;
-		if (typeof meta.t === "string" && typeof meta.u === "string") {
-			return {
-				t: meta.t,
-				u: meta.u,
-				...(typeof meta.o === "string" ? { o: meta.o } : {}),
-			};
-		}
-		return null;
-	} catch {
-		return null;
-	}
 }
 
 /**

--- a/vscode/src/views/SettingsCssBuilder.ts
+++ b/vscode/src/views/SettingsCssBuilder.ts
@@ -242,7 +242,12 @@ export function buildSettingsCss(): string {
     margin-right: 12px;
     opacity: 0;
     transition: opacity 0.3s;
+    max-width: 480px;
   }
   .save-feedback.visible { opacity: 1; }
+  .save-feedback.error {
+    color: var(--vscode-errorForeground);
+    font-weight: 600;
+  }
   `;
 }

--- a/vscode/src/views/SettingsScriptBuilder.ts
+++ b/vscode/src/views/SettingsScriptBuilder.ts
@@ -41,6 +41,61 @@ export function buildSettingsScript(): string {
   let hasErrors = false;
 
   // ── Validation ──
+  var ALLOWED_JOLLI_HOSTS = ['jolli.ai', 'jolli.dev', 'jolli-local.me'];
+
+  function decodeBase64url(seg) {
+    try {
+      var b64 = seg.replace(/-/g, '+').replace(/_/g, '/');
+      var pad = b64.length % 4;
+      if (pad === 2) b64 += '==';
+      else if (pad === 3) b64 += '=';
+      else if (pad === 1) return null;
+      return atob(b64);
+    } catch (e) { return null; }
+  }
+
+  function checkJolliOriginAllowed(origin) {
+    try {
+      var u = new URL(origin);
+      var host = u.hostname.toLowerCase();
+      if (u.protocol !== 'https:' || !host) return false;
+      for (var i = 0; i < ALLOWED_JOLLI_HOSTS.length; i++) {
+        var h = ALLOWED_JOLLI_HOSTS[i];
+        if (host === h || host.slice(-(h.length + 1)) === '.' + h) return true;
+      }
+      return false;
+    } catch (e) { return false; }
+  }
+
+  // Inline port of cli/src/core/JolliApiUtils.ts validateJolliApiKey — this
+  // runs in the webview's browser context so it can't just import the Node
+  // module. Keep in lockstep with the CLI version (and the Kotlin port in
+  // intellij/.../JolliApiClient.kt). Runs on every keystroke for inline red
+  // feedback; the server-side check in handleApplySettings is authoritative.
+  function validateJolliApiKeyRule(v) {
+    if (v.length === 0 || v === maskedJolliApiKey) return '';
+    if (!v.startsWith('sk-jol-')) return 'Key cannot be decoded. Paste the key exactly as issued by Jolli.';
+    var rest = v.slice('sk-jol-'.length);
+    if (rest.indexOf('.') < 0) {
+      return 'Key cannot be decoded. Paste the key exactly as issued by Jolli.';
+    }
+    var segments = rest.split('.');
+    for (var i = 0; i < segments.length; i++) {
+      var json = decodeBase64url(segments[i]);
+      if (json === null) continue;
+      try {
+        var meta = JSON.parse(json);
+        if (typeof meta.t === 'string' && typeof meta.u === 'string') {
+          if (!checkJolliOriginAllowed(meta.u)) {
+            return 'Origin ' + meta.u + ' is not on the Jolli allowlist (only *.jolli.ai, *.jolli.dev, *.jolli-local.me).';
+          }
+          return '';
+        }
+      } catch (e) { /* try next segment */ }
+    }
+    return 'Key cannot be decoded. Paste the key exactly as issued by Jolli.';
+  }
+
   function validateField(input, errorId, rule) {
     var errorEl = document.getElementById(errorId);
     var value = input.value.trim();
@@ -64,13 +119,7 @@ export function buildSettingsScript(): string {
       }
       return '';
     }) && valid;
-    valid = validateField(jolliApiKeyInput, 'jolliApiKey-error', function(v) {
-      if (v.length > 0 && v !== maskedJolliApiKey) {
-        if (!v.startsWith('sk-jol-')) return 'Must start with sk-jol-';
-        if (v.length < 20) return 'Key looks incomplete';
-      }
-      return '';
-    }) && valid;
+    valid = validateField(jolliApiKeyInput, 'jolliApiKey-error', validateJolliApiKeyRule) && valid;
     valid = validateField(maxTokensInput, 'maxTokens-error', function(v) {
       if (v.length > 0 && (isNaN(Number(v)) || Number(v) < 1 || !Number.isInteger(Number(v)))) return 'Must be a positive integer';
       return '';
@@ -138,24 +187,44 @@ export function buildSettingsScript(): string {
   }
 
   function updateApplyBtn() {
+    // Gate on both "nothing to save" and "has client-side errors". The click
+    // handler also re-runs validateAll() and surfaces a saveFeedback message
+    // if a validation error slips through (e.g. programmatic value change),
+    // so the user gets explicit feedback rather than a swallowed click.
     applyBtn.disabled = !isDirty || hasErrors;
+  }
+
+  function clearSaveFeedback() {
+    saveFeedback.classList.remove('visible');
+    saveFeedback.classList.remove('error');
   }
 
   // ── Event listeners for all inputs ──
   [apiKeyInput, jolliApiKeyInput, maxTokensInput, excludePatternsInput].forEach(function(input) {
-    input.addEventListener('input', function() { validateAll(); checkDirty(); });
+    input.addEventListener('input', function() { validateAll(); checkDirty(); clearSaveFeedback(); });
   });
-  modelSelect.addEventListener('change', function() { checkDirty(); });
+  modelSelect.addEventListener('change', function() { checkDirty(); clearSaveFeedback(); });
   [claudeEnabledInput, codexEnabledInput, geminiEnabledInput, openCodeEnabledInput].forEach(function(input) {
-    input.addEventListener('change', function() { validateAll(); checkDirty(); });
+    input.addEventListener('change', function() { validateAll(); checkDirty(); clearSaveFeedback(); });
   });
   [pushActionJolliRadio, pushActionBothRadio].forEach(function(input) {
-    input.addEventListener('change', function() { checkDirty(); });
+    input.addEventListener('change', function() { checkDirty(); clearSaveFeedback(); });
   });
 
   // ── Apply Changes ──
   applyBtn.addEventListener('click', function() {
     if (applyBtn.disabled) return;
+    // Final client-side pass so inline errors stay in sync even if a field was
+    // changed programmatically or before any input event had a chance to fire.
+    // Server-side validation runs regardless, but this gives the user the
+    // inline red-text field marker immediately.
+    validateAll();
+    if (hasErrors) {
+      saveFeedback.textContent = 'Please fix the highlighted fields before saving';
+      saveFeedback.classList.add('error');
+      saveFeedback.classList.add('visible');
+      return;
+    }
     var maxVal = maxTokensInput.value.trim();
     vscode.postMessage({
       command: 'applySettings',
@@ -213,16 +282,17 @@ export function buildSettingsScript(): string {
         break;
       case 'settingsSaved':
         saveFeedback.textContent = 'Settings saved';
+        saveFeedback.classList.remove('error');
         saveFeedback.classList.add('visible');
         setTimeout(function() { saveFeedback.classList.remove('visible'); }, 2000);
         captureInitialState();
         break;
       case 'settingsError':
+        // Persistent red banner — stays until the user edits a field (handled
+        // by the input listeners above, which clear it via clearSaveFeedback).
         saveFeedback.textContent = msg.message;
+        saveFeedback.classList.add('error');
         saveFeedback.classList.add('visible');
-        setTimeout(function() {
-          saveFeedback.classList.remove('visible');
-        }, 3000);
         break;
     }
   });

--- a/vscode/src/views/SettingsWebviewPanel.test.ts
+++ b/vscode/src/views/SettingsWebviewPanel.test.ts
@@ -388,7 +388,8 @@ describe("SettingsWebviewPanel", () => {
 				apiKey: "sk-ant-api03-abcdefghijklmnopqrstuvwxyz1234",
 				model: "claude-3-5",
 				maxTokens: 4096,
-				jolliApiKey: "jolli-key-12345678901234",
+				jolliApiKey:
+					"sk-jol-eyJ0IjoidGVuYW50IiwidSI6Imh0dHBzOi8vdGVuYW50LmpvbGxpLmFpIn0.secret",
 				claudeEnabled: true,
 				codexEnabled: false,
 				geminiEnabled: true,
@@ -488,7 +489,8 @@ describe("SettingsWebviewPanel", () => {
 				apiKey: "sk-ant-api03-abcdefghijklmnopqrstuvwxyz1234",
 				model: "sonnet",
 				maxTokens: null,
-				jolliApiKey: "jolli-key-12345678901234",
+				jolliApiKey:
+					"sk-jol-eyJ0IjoidGVuYW50IiwidSI6Imh0dHBzOi8vdGVuYW50LmpvbGxpLmFpIn0.secret",
 				claudeEnabled: true,
 				codexEnabled: true,
 				geminiEnabled: true,
@@ -566,7 +568,8 @@ describe("SettingsWebviewPanel", () => {
 		});
 
 		it("preserves original jolli API key when masked value is unchanged", async () => {
-			const jolliKey = "jolli-key-12345678901234";
+			const jolliKey =
+				"sk-jol-eyJ0IjoidGVuYW50IiwidSI6Imh0dHBzOi8vdGVuYW50LmpvbGxpLmFpIn0.secret";
 			const dispatch = await setupWithLoadedConfig({ jolliApiKey: jolliKey });
 
 			const maskedJolliKey = `${jolliKey.substring(0, 12)}****${jolliKey.substring(jolliKey.length - 4)}`;
@@ -595,11 +598,13 @@ describe("SettingsWebviewPanel", () => {
 		});
 
 		it("uses new jolli API key when user changes it from the masked value", async () => {
-			const jolliKey = "jolli-key-12345678901234";
+			const jolliKey =
+				"sk-jol-eyJ0IjoidGVuYW50IiwidSI6Imh0dHBzOi8vdGVuYW50LmpvbGxpLmFpIn0.secret";
 			const dispatch = await setupWithLoadedConfig({ jolliApiKey: jolliKey });
 
 			const maskedJolliKey = `${jolliKey.substring(0, 12)}****${jolliKey.substring(jolliKey.length - 4)}`;
-			const newJolliKey = "jolli-key-new-9876543210";
+			const newJolliKey =
+				"sk-jol-eyJ0IjoidGVuYW50MiIsInUiOiJodHRwczovL3RlbmFudDIuam9sbGkuYWkifQ.secret";
 
 			dispatch({
 				command: "applySettings",
@@ -762,6 +767,130 @@ describe("SettingsWebviewPanel", () => {
 			expect(postMessage).toHaveBeenCalledWith({ command: "settingsSaved" });
 			expect(onSaved).toHaveBeenCalled();
 			expect(info).toHaveBeenCalledWith("SettingsPanel", "Settings saved");
+		});
+
+		it("rejects a Jolli API key that cannot be decoded (wrong prefix), without saving", async () => {
+			const dispatch = await setupWithLoadedConfig();
+
+			dispatch({
+				command: "applySettings",
+				maskedApiKey: "",
+				maskedJolliApiKey: "",
+				settings: {
+					apiKey: "",
+					model: "sonnet",
+					maxTokens: null,
+					jolliApiKey: "sf-jol-garbage",
+					claudeEnabled: true,
+					codexEnabled: true,
+					geminiEnabled: true,
+					excludePatterns: "",
+				},
+			});
+			await flushPromises();
+
+			expect(mockSaveConfigScoped).not.toHaveBeenCalled();
+			expect(postMessage).toHaveBeenCalledWith(
+				expect.objectContaining({
+					command: "settingsError",
+					message: expect.stringMatching(/cannot be decoded/),
+				}),
+			);
+		});
+
+		it("rejects a Jolli API key with no embedded meta (legacy-only shape), without saving", async () => {
+			const dispatch = await setupWithLoadedConfig();
+
+			dispatch({
+				command: "applySettings",
+				maskedApiKey: "",
+				maskedJolliApiKey: "",
+				settings: {
+					apiKey: "",
+					model: "sonnet",
+					maxTokens: null,
+					jolliApiKey: "sk-jol-legacyhex32chars",
+					claudeEnabled: true,
+					codexEnabled: true,
+					geminiEnabled: true,
+					excludePatterns: "",
+				},
+			});
+			await flushPromises();
+
+			expect(mockSaveConfigScoped).not.toHaveBeenCalled();
+			expect(postMessage).toHaveBeenCalledWith(
+				expect.objectContaining({
+					command: "settingsError",
+					message: expect.stringMatching(/cannot be decoded/),
+				}),
+			);
+		});
+
+		it("rejects a Jolli API key whose embedded origin is off the allowlist, without saving", async () => {
+			const dispatch = await setupWithLoadedConfig();
+			// Build a key whose decoded meta.u points off the allowlist
+			const badMeta = { t: "x", u: "https://evil.com" };
+			const encoded = Buffer.from(JSON.stringify(badMeta)).toString(
+				"base64url",
+			);
+			const badKey = `sk-jol-${encoded}.secret`;
+
+			dispatch({
+				command: "applySettings",
+				maskedApiKey: "",
+				maskedJolliApiKey: "",
+				settings: {
+					apiKey: "",
+					model: "sonnet",
+					maxTokens: null,
+					jolliApiKey: badKey,
+					claudeEnabled: true,
+					codexEnabled: true,
+					geminiEnabled: true,
+					excludePatterns: "",
+				},
+			});
+			await flushPromises();
+
+			expect(mockSaveConfigScoped).not.toHaveBeenCalled();
+			expect(postMessage).toHaveBeenCalledWith(
+				expect.objectContaining({
+					command: "settingsError",
+					message: expect.stringMatching(/evil\.com/),
+				}),
+			);
+		});
+
+		it("accepts a Jolli API key whose embedded origin is on the allowlist", async () => {
+			const dispatch = await setupWithLoadedConfig();
+			const goodMeta = { t: "tenant1", u: "https://tenant1.jolli.ai" };
+			const encoded = Buffer.from(JSON.stringify(goodMeta)).toString(
+				"base64url",
+			);
+			const goodKey = `sk-jol-${encoded}.secret`;
+
+			dispatch({
+				command: "applySettings",
+				maskedApiKey: "",
+				maskedJolliApiKey: "",
+				settings: {
+					apiKey: "",
+					model: "sonnet",
+					maxTokens: null,
+					jolliApiKey: goodKey,
+					claudeEnabled: true,
+					codexEnabled: true,
+					geminiEnabled: true,
+					excludePatterns: "",
+				},
+			});
+			await flushPromises();
+
+			expect(mockSaveConfigScoped).toHaveBeenCalledWith(
+				expect.objectContaining({ jolliApiKey: goodKey }),
+				expect.any(String),
+			);
 		});
 
 		it("posts settingsError when save fails", async () => {
@@ -1282,7 +1411,8 @@ describe("SettingsWebviewPanel", () => {
 				apiKey: "sk-ant-api03-abcdefghijklmnopqrstuvwxyz1234",
 				model: "sonnet",
 				maxTokens: null,
-				jolliApiKey: "jolli-key-12345678901234",
+				jolliApiKey:
+					"sk-jol-eyJ0IjoidGVuYW50IiwidSI6Imh0dHBzOi8vdGVuYW50LmpvbGxpLmFpIn0.secret",
 				claudeEnabled: true,
 				codexEnabled: true,
 				geminiEnabled: true,

--- a/vscode/src/views/SettingsWebviewPanel.ts
+++ b/vscode/src/views/SettingsWebviewPanel.ts
@@ -16,6 +16,7 @@ import {
 	getProjectRootDir,
 	listWorktrees,
 } from "../../../cli/src/core/GitOps.js";
+import { validateJolliApiKey } from "../../../cli/src/core/JolliApiUtils.js";
 import {
 	getGlobalConfigDir,
 	loadConfigFromDir,
@@ -235,6 +236,22 @@ export class SettingsWebviewPanel {
 			maskedApiKey,
 			maskedJolliApiKey,
 		});
+
+		// Surface invalid-but-saved Jolli API keys as soon as Settings opens.
+		// The webview only sees the masked form, so without this the user can't
+		// tell a malformed key is sitting in config until they try to save.
+		if (this.fullJolliApiKey.length > 0) {
+			try {
+				validateJolliApiKey(this.fullJolliApiKey);
+			} catch (err) {
+				const message =
+					err instanceof Error ? err.message : "Invalid Jolli API Key on file";
+				log.warn("SettingsPanel", `Saved Jolli API key is invalid: ${message}`);
+				this.postError(
+					`${message} (the key currently on disk is invalid — paste a new one and click Apply)`,
+				);
+			}
+		}
 	}
 
 	/** Saves settings, resolving masked API keys back to full values. */
@@ -250,6 +267,21 @@ export class SettingsWebviewPanel {
 			settings.jolliApiKey === sentMaskedJolliApiKey
 				? this.fullJolliApiKey
 				: settings.jolliApiKey;
+
+		// Reject unrecognized key shapes and keys whose embedded `.u` points off
+		// the allowlist before we touch disk or sync hooks. Surface the specific
+		// error inline so the user knows which field is wrong.
+		if (resolvedJolliApiKey.length > 0) {
+			try {
+				validateJolliApiKey(resolvedJolliApiKey);
+			} catch (err) {
+				const message =
+					err instanceof Error ? err.message : "Invalid Jolli API Key";
+				log.error("SettingsPanel", `Save rejected: ${message}`);
+				this.postError(message);
+				return;
+			}
+		}
 
 		// Parse exclude patterns from comma-separated string
 		const excludePatterns = settings.excludePatterns


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## E2E Test (10)
<details>
<summary><strong>1. Reject malicious API key pointing to untrusted server</strong></summary>
<br>
<blockquote>

**Preconditions:** Have the VS Code extension installed and the Jolli Memory settings panel open.

**Steps:**
1. Open the Jolli Memory settings panel in VS Code.
2. In the API key field, paste a key that begins with "sk-jol-" but contains a server address pointing to a non-Jolli website (for example, a key your team lead confirms is crafted to point to "evil.com").
3. Click the Apply button.
4. Check whether the key was saved by closing and reopening the settings panel.

**Expected Results:**
- A red error message appears immediately, mentioning the untrusted server address.
- The key is NOT saved — reopening the settings panel does not show the new key.

</blockquote>
</details>
<details>
<summary><strong>2. Reject malicious API key at CLI save time</strong></summary>
<br>
<blockquote>

**Preconditions:** Have the Jolli CLI installed and access to a terminal.

**Steps:**
1. Open a terminal.
2. Run the configure command to set the API key, using a key that your team lead confirms embeds a non-Jolli server address (for example, one pointing to "evil.com").
3. Check the terminal output.
4. Run the configure command again with the list option to confirm what key is currently saved.

**Expected Results:**
- The terminal displays an error message containing the untrusted server address (e.g. "evil.com").
- The command exits with an error status.
- The previously saved key remains unchanged — the bad key was never written to disk.

</blockquote>
</details>
<details>
<summary><strong>3. Accept a valid API key on the allowlist</strong></summary>
<br>
<blockquote>

**Preconditions:** Have the Jolli CLI installed and a valid API key issued by Jolli (one whose server address ends in jolli.ai, jolli.dev, or jolli-local.me).

**Steps:**
1. Open a terminal.
2. Run the configure command to set the API key using your valid Jolli-issued key.
3. Check the terminal output.
4. Run the configure command with the list option to confirm the key was saved.

**Expected Results:**
- No error message appears.
- The command completes successfully.
- The saved key matches the one you entered.

</blockquote>
</details>
<details>
<summary><strong>4. Block sign-in when JOLLI_URL environment variable points to untrusted server</strong></summary>
<br>
<blockquote>

**Preconditions:** Have the VS Code extension installed. Set the JOLLI_URL environment variable in your shell to "https://evil.com" before launching VS Code from that shell.

**Steps:**
1. Launch VS Code from the terminal where JOLLI_URL is set to "https://evil.com".
2. Open the Jolli Memory extension.
3. Click the Sign In button.
4. Observe what happens instead of a browser window opening.

**Expected Results:**
- No browser window opens.
- A VS Code error dialog appears with a message explaining that the server address is not trusted and instructing you to unset or correct the JOLLI_URL setting.

</blockquote>
</details>
<details>
<summary><strong>5. VS Code settings panel shows inline validation error immediately while typing</strong></summary>
<br>
<blockquote>

**Preconditions:** Have the VS Code extension installed and the Jolli Memory settings panel open.

**Steps:**
1. Open the Jolli Memory settings panel in VS Code.
2. Click into the API key field and type a clearly invalid value such as "not-a-real-key".
3. Without clicking Apply, observe the panel.
4. Now clear the field and type a valid Jolli-issued key.
5. Observe the panel again.

**Expected Results:**
- After typing the invalid key, a red error banner appears immediately (without clicking Apply) explaining the key cannot be decoded.
- After typing a valid key, the red error banner disappears.
- The Apply button remains clickable in both cases (it is not silently disabled).

</blockquote>
</details>
<details>
<summary><strong>6. Settings panel shows error banner on open when saved key is already invalid</strong></summary>
<br>
<blockquote>

**Preconditions:** Have the VS Code extension installed. The currently saved API key must be one that is now considered invalid (for example, an old-format key with no embedded server address).

**Steps:**
1. Open the Jolli Memory settings panel in VS Code without making any changes.
2. Observe the panel immediately after it loads.

**Expected Results:**
- A red error banner is visible as soon as the panel opens, indicating the currently saved key is invalid.
- The banner persists until you edit the API key field.

</blockquote>
</details>
<details>
<summary><strong>7. Reject API key that cannot be decoded (wrong format or prefix)</strong></summary>
<br>
<blockquote>

**Preconditions:** Have the Jolli CLI installed and access to a terminal.

**Steps:**
1. Open a terminal.
2. Run the configure command to set the API key, using the value "sf-jol-garbage" (note the wrong prefix "sf" instead of "sk").
3. Check the terminal output.

**Expected Results:**
- The terminal displays an error message saying the key cannot be decoded.
- The command exits with an error status.
- No key is saved.

</blockquote>
</details>
<details>
<summary><strong>8. Block CLI sign-in when JOLLI_URL environment variable uses untrusted server</strong></summary>
<br>
<blockquote>

**Preconditions:** Have the Jolli CLI installed. Set the JOLLI_URL environment variable in your terminal to "https://evil.com".

**Steps:**
1. In the terminal where JOLLI_URL is set to "https://evil.com", run the Jolli login command.
2. Observe the terminal output.

**Expected Results:**
- No browser window opens for sign-in.
- The terminal displays an error message mentioning "evil.com" or indicating the server address is not permitted.
- The command exits with an error status.

</blockquote>
</details>
<details>
<summary><strong>9. Reject API key with HTTP (non-secure) server address</strong></summary>
<br>
<blockquote>

**Preconditions:** Have the VS Code extension installed and the Jolli Memory settings panel open.

**Steps:**
1. Open the Jolli Memory settings panel in VS Code.
2. In the API key field, paste a key that your team lead confirms embeds a server address starting with "http://" (not "https://") pointing to a Jolli host.
3. Click the Apply button.
4. Observe the error message.

**Expected Results:**
- A red error message appears indicating the key was rejected.
- The key is not saved.

</blockquote>
</details>
<details>
<summary><strong>10. Accept JWT-shaped API key with valid server address in middle segment</strong></summary>
<br>
<blockquote>

**Preconditions:** Have the Jolli CLI installed. Obtain a JWT-format API key from your Jolli administrator (a key with three dot-separated parts where the server address is embedded in the middle section, pointing to a trusted Jolli host).

**Steps:**
1. Open a terminal.
2. Run the configure command to set the API key using the JWT-format key provided by your administrator.
3. Check the terminal output.
4. Run the configure command with the list option to confirm the key was saved.

**Expected Results:**
- No error message appears.
- The command completes successfully.
- The saved key matches the JWT-format key you entered.

</blockquote>
</details>

---

## Topics (11)
<details>
<summary><strong>01 · Block API key origin exfiltration via trusted domain allowlist</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

All three Jolli Memory clients (CLI, VS Code, IntelliJ) blindly trusted the destination URL embedded in API key metadata without any verification. An attacker could craft a key pointing to their own server and share it as a "team key," causing all subsequent requests — including code diffs, conversation transcripts, and the bearer token itself — to be silently forwarded to the attacker before any backend validation occurred.

**💡 Decisions Behind the Code**

- **No cryptographic signing**: The fix scope was explicitly limited to an allowlist — HMAC/public-key verification of the metadata segment was considered and ruled out by the user as out of scope for this change.
- **Hardcoded allowlist, no env-var override**: An environment-variable escape hatch was initially drafted but then removed at the user's direction to keep the security boundary unconditional and tamper-resistant.
- **`jolli-local.me` included in production allowlist**: Rather than a debug-build flag or env-var override (both considered), the local dev domain was added directly to the allowlist. The risk is low because the domain only resolves via hosts-file mapping in practice, and it avoids any conditional-compilation complexity.
- **Fail before network call**: The guard is placed before any HTTP client is invoked so that neither the request body nor the bearer token ever leaves the process when the origin is rejected.
- **Promise-reject wrapping in VS Code**: The existing push/delete functions return Promises but the guard throws synchronously; wrapping in `try/catch → Promise.reject` keeps the public API contract consistent with the rest of the error-handling surface.

**✅ What Was Implemented**

- Added `assertJolliOriginAllowed()` to CLI (`JolliApiUtils.ts`), VS Code (`JolliPushService.ts`), and IntelliJ (`JolliApiClient.kt`) — identical logic in all three: HTTPS-only, hostname must equal or be a subdomain of an allowlisted domain
- Allowlist hardcoded to `jolli.ai`, `jolli.dev`, and `jolli-local.me` (see domain decision below)
- CLI: guard called in `callProxy()` before any fetch; throws synchronously
- VS Code: guard wrapped in `try/catch → Promise.reject()` in both `pushToJolli()` and `deleteFromJolli()` to preserve promise-based call semantics
- IntelliJ: guard called at the top of both `pushToJolli()` and `deleteFromJolli()` before HTTP client is invoked
- Tests added in all three clients covering accepted hosts, suffix-boundary bypass attempts, HTTP scheme rejection, credential-in-URL disguise, and unparseable input

**📁 FILES**
- `cli/src/core/JolliApiUtils.ts`
- `cli/src/core/LlmClient.ts`
- `vscode/src/services/JolliPushService.ts`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/services/JolliApiClient.kt`

</blockquote>
</details>
<details>
<summary><strong>02 · API key validation moved from network call time to save time</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The origin allowlist check was only enforced when a network request was made, meaning a malicious API key could be saved silently and the user would only see an error much later — far from the point where they pasted the key.

**💡 Decisions Behind the Code**

- **Save-time as the only gate**: The threat model is a phishing key pasted into the UI; the save path is the single entry point. Keeping a second check at request time would be defending against a scenario that cannot happen after save-time validation is in place, violating YAGNI.
- **Belt-and-suspenders retained for non-UI paths**: The save-time check covers all UI entry points, but `JOLLI_URL` env-var and `configure --set` are CLI-only paths that bypass the UI, so they each received their own explicit validation call rather than relying on a shared wrapper.
- **`ConfigurationException` in IntelliJ**: The IDE's `Configurable.apply()` contract allows throwing this exception to display a native red error bar — chosen over a custom dialog because it integrates with the existing settings UI pattern at zero extra cost.

**✅ What Was Implemented**

- Introduced `validateJolliApiKey` in CLI utilities: calls `parseJolliApiKey` then `assertJolliOriginAllowed`, throwing on either failure
- Wired save-time validation into all four CLI save paths: OAuth callback (`saveAuthCredentials`), `configure --set jolliApiKey`, and the `JOLLI_URL` env-var resolver (`getJolliUrl`)
- Wired save-time validation into VSCode settings webview (`handleApplySettings`) and IntelliJ settings dialog (`JolliMemoryConfigurable.apply`, surfacing as `ConfigurationException` for IDE red-bar display)
- Removed the now-redundant request-time `assertJolliOriginAllowed` calls from `LlmClient`, `JolliPushService` (push and delete), and `JolliApiClient` (push and delete)
- Removed dead `node:http` import and `isHttps`/`requestFn` branching from `JolliPushService` since HTTPS is now the only reachable path

**📋 Future Enhancements**

- IntelliJ: a dedicated `JolliMemoryConfigurableTest` was deferred because it requires mocking `Project`/`JolliMemoryService` infrastructure disproportionate to the three-line change; the underlying `assertJolliOriginAllowed` logic is already covered by `JolliApiClientTest`.

**📁 FILES**
- `cli/src/core/JolliApiUtils.ts`
- `cli/src/auth/AuthConfig.ts`
- `cli/src/commands/ConfigureCommand.ts`
- `vscode/src/services/JolliPushService.ts`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/settings/JolliMemoryConfigurable.kt`

</blockquote>
</details>
<details>
<summary><strong>03 · API key parser extended to handle JWT-signed key format</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

A user pasted a real JWT-shaped API key (three dot-separated segments where the metadata is in the middle segment, not the first) and the allowlist check was silently skipped — the key was saved without any validation.

**💡 Decisions Behind the Code**

- **Scan all segments instead of fixing on index zero**: The old code assumed metadata was always the first segment. JWT format places a header in segment zero and the payload in segment one. Scanning is the minimal change that handles both formats without needing to know the format upfront.
- **First-match wins, silently skip non-JSON segments**: A segment that fails base64url decoding or JSON parsing is not an error — it is expected for JWT headers and HMAC signatures. Continuing to the next segment keeps the logic format-agnostic.

**✅ What Was Implemented**

- Rewrote `parseJolliApiKey` in all three clients (CLI, VSCode, IntelliJ) to scan every dot-separated segment rather than assuming metadata is always in segment zero
- The first segment that base64url-decodes to a JSON object with string `t` and `u` fields is accepted as the metadata, covering both the plain two-segment format and the JWT three-segment format
- Added two new test cases: JWT-shape key with valid metadata extracted from segment 1; JWT-shape key with no segment carrying `t`/`u` returns null

**📁 FILES**
- `cli/src/core/JolliApiUtils.ts`
- `vscode/src/services/JolliPushService.ts`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/services/JolliApiClient.kt`

</blockquote>
</details>
<details>
<summary><strong>04 · JOLLI_URL environment variable validated against origin allowlist on read</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

A reviewer noted that validating the API key's embedded origin at save time is not sufficient: an attacker who tricks a user into setting the server URL environment variable to a malicious host can steal OAuth credentials before any API key is involved, because the browser is opened to that URL during login.

**💡 Decisions Behind the Code**

- **Fix at the source function rather than each call site**: `getJolliUrl` is the single place where the environment variable is read and normalized. Enforcing the allowlist there means every caller — CLI login, VSCode auth service, any future caller — is protected automatically without per-call-site changes.
- **No separate IntelliJ change needed**: IntelliJ is a JVM plugin that does not share the Node module and has no equivalent environment variable override; all its configuration goes through the settings dialog which already has save-time validation.

**✅ What Was Implemented**

- Added `assertJolliOriginAllowed` call inside `getJolliUrl` in `AuthConfig.ts`, immediately after stripping trailing slashes and before returning the URL
- Because VSCode's extension host inherits the user's shell environment and imports `getJolliUrl` from the same CLI module, this single change protects both the CLI login flow and the VSCode sign-in command
- Updated design document to correct the earlier incorrect claim that VSCode had no equivalent env-var override

**📁 FILES**
- `cli/src/auth/AuthConfig.ts`

</blockquote>
</details>
<details>
<summary><strong>05 · VSCode settings webview shows validation errors immediately on input</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Users reported that pasting an invalid API key into the VSCode settings panel produced no visible feedback — the Apply button was silently disabled or errors only appeared after clicking Apply, making it unclear why nothing was happening.

**💡 Decisions Behind the Code**

- **Always allow Apply click, show error on submit**: Silently disabling the button left users with no explanation. Allowing the click and showing a clear error message is more informative and consistent with how other form validation works.
- **Load-time server push for existing invalid keys**: The webview cannot validate the stored key because it only receives a masked version. Pushing a validation result from the server at load time was the only way to surface problems with keys that were saved before validation was added.
- **Persistent error over auto-dismiss**: A 3-second toast is easy to miss. Security-relevant errors (wrong origin, undecipherable key) should stay visible until the user takes action.

**✅ What Was Implemented**

- Added client-side `validateJolliApiKeyRule` function to the webview script that runs on every keystroke, covering both the decode check and the allowlist check
- Changed Apply button disable logic: button is only disabled when the form is not dirty, not when it has errors — errors are shown as a persistent red banner instead of silently blocking the button
- Added load-time validation: when the settings panel opens, the server validates the raw key currently on disk and pushes an error banner to the webview if it is invalid, since the webview only sees the masked display value
- Error messages are styled with `var(--vscode-errorForeground)` and persist until the user edits a field, replacing the previous 3-second auto-dismiss behavior

**📁 FILES**
- `vscode/src/views/SettingsWebviewPanel.ts`
- `vscode/src/views/SettingsScriptBuilder.ts`
- `vscode/src/views/SettingsCssBuilder.ts`

</blockquote>
</details>

<details>
<summary><strong>07 · Remove out-of-scope HTTP transport cleanup from the security fix commit</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

During review, the user noticed that the HTTP/HTTPS transport dispatch logic had been silently removed from the push service as a side effect of the allowlist work — a cleanup that was never part of the agreed security fix scope.

**💡 Decisions Behind the Code**

- **Strict scope discipline**: The HTTP removal was bundled into a security commit under the reasoning that the allowlist would block HTTP anyway, but the user correctly identified this as a separate concern that should travel in its own change — mixing transport cleanup with a security fix obscures both.
- **Restore over redesign**: Rather than arguing for keeping the simplified HTTPS-only path, the decision was to faithfully restore the original behavior, preserving the existing test contract and avoiding unintended behavioral changes in a security-sensitive commit.

**✅ What Was Implemented**

Restored the HTTP/HTTPS dual-transport behavior that had been incorrectly removed:
- `JolliPushService.ts`: re-added `node:http` import, restored `isHttps` flag and `requestFn` dispatch in both `pushToJolli` and `deleteFromJolli`; restored `deleteFromJolli` to use explicit options object with `port: isHttps ? 443 : 80` fallback
- `JolliPushService.test.ts`: re-added `node:http` mock, restored deleted HTTP-path tests including the `http.request` usage test and port-80 default test; added one new HTTP URL test for `pushToJolli`
- Updated module comment to reflect that both HTTP and HTTPS are supported

**📁 FILES**
- `vscode/src/services/JolliPushService.ts`
- `vscode/src/services/JolliPushService.test.ts`

</blockquote>
</details>
<details>
<summary><strong>08 · Fix unhandled error when environment variable points to untrusted host during sign-in</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

A code review audit of all call sites for the newly-throwing URL getter found that the VSCode sign-in flow called it outside any error handler — meaning a malicious or misconfigured environment variable would crash the sign-in command with an ugly unhandled exception instead of a user-friendly message.

**💡 Decisions Behind the Code**

- **Catch at the call site, not globally**: Wrapping only this specific call (rather than a blanket handler) gives the most precise error message and avoids masking unrelated failures elsewhere in the sign-in flow.
- **User-facing message over silent failure**: The original code would have surfaced a raw exception through the command bus; the fix converts it to a friendly dialog, which also resolves the reviewer's nit about error messages not distinguishing between a bad environment variable and a bad stored URL.

**✅ What Was Implemented**

Wrapped the `getJolliUrl()` call in `AuthService.openSignInPage` with a dedicated try/catch block. On failure, logs the error and shows a VSCode error dialog with an actionable message telling the user to unset the environment variable or point it to a trusted host.

**📁 FILES**
- `vscode/src/services/AuthService.ts`

</blockquote>
</details>
<details>
<summary><strong>09 · API key validation rule simplified to decode-plus-allowlist only</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Early iterations of the save-time validator accumulated several weak format checks (prefix, minimum length, character set) that were redundant and produced confusing error messages. The user pointed out that only two things actually matter: whether the key can be decoded and whether its embedded origin is on the allowlist.

**💡 Decisions Behind the Code**

- **Two checks only, no intermediate format rules**: Prefix, length, and character-set checks were all proxies for "can we decode this key." Replacing them with the actual decode attempt is both simpler and more accurate — it rejects exactly the keys that would fail in practice, with no false positives or gaps.
- **Client-side and server-side rules kept in sync**: The webview runs its own copy of the validation logic for instant inline feedback. Keeping both copies at the same two-rule level prevents the confusing situation where the UI shows no error but the server rejects on save.

**✅ What Was Implemented**

- Removed standalone prefix, length, and character-set checks from `validateJolliApiKey` in all three clients
- Final rule is exactly two checks: `parseJolliApiKey` must return metadata (covers all malformed shapes including wrong prefix, non-ASCII characters, and undecipherable content), then `assertJolliOriginAllowed` must pass on the extracted origin
- Updated VSCode webview client-side validation rule (`validateJolliApiKeyRule`) to match the same two-check logic so inline field errors are consistent with server-side rejection

**📁 FILES**
- `cli/src/core/JolliApiUtils.ts`
- `vscode/src/services/JolliPushService.ts`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/services/JolliApiClient.kt`

</blockquote>
</details>
<details>
<summary><strong>10 · Consolidate duplicate allowlist validator into single canonical source</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

A code review flagged that the origin allowlist and validator function were duplicated across four locations, creating a maintainability risk on a security-critical constant — if the allowlist needed updating, all copies would need to change in sync.

**💡 Decisions Behind the Code**

- **Collapse two of four copies, not all four**: The Kotlin and webview-bundled JS copies are language/runtime-isolated and cannot share source, so only the two TypeScript copies were merged. The remaining two received cross-reference comments to make drift visible.
- **CLI as canonical source**: The CLI module was chosen as the single source of truth because VSCode already imported other utilities from it, making the dependency natural and avoiding a new abstraction layer.
- **Re-export for backward compatibility**: Rather than updating every downstream import site, `JolliPushService.ts` re-exports the CLI's functions so existing callers don't break.

**✅ What Was Implemented**

- `JolliPushService.ts`: removed its own copy of `parseJolliApiKey`, `validateJolliApiKey`, `assertJolliOriginAllowed`, `parseBaseUrl`, and related types; replaced with imports from `cli/src/core/JolliApiUtils.js`; re-exports `parseJolliApiKey` and `JolliApiKeyMeta` for downstream consumers
- `SettingsWebviewPanel.ts`: updated import of `validateJolliApiKey` to come directly from `cli/src/core/JolliApiUtils.js` instead of `JolliPushService.ts`
- `SettingsScriptBuilder.ts`: updated comment to explicitly name the CLI file as canonical and cross-reference the Kotlin port
- `JolliPushService.test.ts`: removed duplicate `assertJolliOriginAllowed` test suite with a comment pointing to the CLI test file as the authoritative coverage location

**📁 FILES**
- `vscode/src/services/JolliPushService.ts`
- `vscode/src/views/SettingsWebviewPanel.ts`
- `vscode/src/views/SettingsScriptBuilder.ts`

</blockquote>
</details>
<details>
<summary><strong>11 · Remove debug markers accidentally left in webview script</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

A code review identified a ship-blocking issue: a debug build tag and a console log statement had been left in the webview script from development iteration, adding noise to the production bundle with no runtime purpose.

**💡 Decisions Behind the Code**

- **Remove entirely rather than guard**: The build tag served only as a cache-busting debug aid during development; it has no runtime value and no consumer, so deletion was the correct fix rather than wrapping it in a debug flag.

**✅ What Was Implemented**

Removed two lines from `SettingsScriptBuilder.ts`: the `window.__jolliSettingsBuild` global assignment and the accompanying `console.log` statement that printed the build tag on every webview load.

**📁 FILES**
- `vscode/src/views/SettingsScriptBuilder.ts`

</blockquote>
</details>

---

*Generated by Jolli Memory · April 25, 2026 at 12:10 AM*
<!-- jollimemory-summary-end -->