### PR TITLE
Support sign-in for VSCode forks by deriving URI scheme from appName

### DIFF
--- a/vscode/src/Extension.ts
+++ b/vscode/src/Extension.ts
@@ -1272,7 +1272,12 @@ export function activate(context: vscode.ExtensionContext): void {
 
 	// ── URI handler ──────────────────────────────────────────────────────────
 	// Receives the OAuth callback after browser-based login/signup.
-	// URI format: vscode://jolli.jollimemory-vscode/auth-callback?token=...&jolli_api_key=...
+	// URI format: <host-scheme>://jolli.jollimemory-vscode/auth-callback?token=...&jolli_api_key=...
+	// <host-scheme> is derived from vscode.env.appName (NOT uriScheme — forks
+	// tend to leave that at the upstream "vscode" default even though they
+	// register their own scheme at the OS level). See resolveUriScheme() in
+	// AuthService.ts for the mapping. This handler runs regardless of which
+	// scheme the OS dispatched — registerUriHandler covers every scheme.
 	context.subscriptions.push(
 		vscode.window.registerUriHandler({
 			async handleUri(uri: vscode.Uri) {

--- a/vscode/src/services/AuthService.test.ts
+++ b/vscode/src/services/AuthService.test.ts
@@ -14,38 +14,57 @@ const { loadConfig } = vi.hoisted(() => ({
 	loadConfig: vi.fn().mockResolvedValue({}),
 }));
 
-const { executeCommand, openExternal, showErrorMessage, Uri, uriParse } =
-	vi.hoisted(() => {
-		const executeCommand = vi.fn().mockResolvedValue(undefined);
-		const showErrorMessage = vi.fn();
-		const openExternal = vi.fn().mockResolvedValue(true);
+const {
+	executeCommand,
+	openExternal,
+	showErrorMessage,
+	Uri,
+	uriParse,
+	appNameState,
+} = vi.hoisted(() => {
+	const executeCommand = vi.fn().mockResolvedValue(undefined);
+	const showErrorMessage = vi.fn();
+	const openExternal = vi.fn().mockResolvedValue(true);
+	// Mutable holder so individual tests can swap the host IDE (e.g. set to
+	// `"Cursor"` to simulate running inside Cursor) and verify AuthService's
+	// scheme resolution adapts. The `vi.mock` factory below reads it via a
+	// getter so runtime mutation is honored — the factory itself only
+	// executes once.
+	const appNameState = { current: "Visual Studio Code" };
 
-		// Minimal Uri shape — AuthService only reads path/query, so full URI semantics
-		// aren't required. Enough to stand in for vscode.Uri in tests.
-		interface FakeUri {
-			readonly scheme: string;
-			readonly authority: string;
-			readonly path: string;
-			readonly query: string;
-			readonly fragment: string;
-		}
+	// Minimal Uri shape — AuthService only reads path/query, so full URI semantics
+	// aren't required. Enough to stand in for vscode.Uri in tests.
+	interface FakeUri {
+		readonly scheme: string;
+		readonly authority: string;
+		readonly path: string;
+		readonly query: string;
+		readonly fragment: string;
+	}
 
-		// `parse` is a vi.fn so tests can assert on the exact string that was parsed
-		// (this is the login URL AuthService hands to openExternal).
-		const uriParse = vi.fn((value: string): FakeUri => {
-			const url = new URL(value);
-			return {
-				scheme: url.protocol.replace(":", ""),
-				authority: url.hostname,
-				path: url.pathname,
-				query: url.search.replace("?", ""),
-				fragment: url.hash.replace("#", ""),
-			};
-		});
-		const Uri = { parse: uriParse };
-
-		return { executeCommand, openExternal, showErrorMessage, Uri, uriParse };
+	// `parse` is a vi.fn so tests can assert on the exact string that was parsed
+	// (this is the login URL AuthService hands to openExternal).
+	const uriParse = vi.fn((value: string): FakeUri => {
+		const url = new URL(value);
+		return {
+			scheme: url.protocol.replace(":", ""),
+			authority: url.hostname,
+			path: url.pathname,
+			query: url.search.replace("?", ""),
+			fragment: url.hash.replace("#", ""),
+		};
 	});
+	const Uri = { parse: uriParse };
+
+	return {
+		executeCommand,
+		openExternal,
+		showErrorMessage,
+		Uri,
+		uriParse,
+		appNameState,
+	};
+});
 
 const {
 	info,
@@ -59,7 +78,15 @@ const {
 
 vi.mock("vscode", () => ({
 	commands: { executeCommand },
-	env: { openExternal },
+	env: {
+		openExternal,
+		// Getter so tests can mutate `appNameState.current` at runtime
+		// (the factory itself only executes once). `appName` is the signal
+		// AuthService uses to derive the OS-registered URI scheme.
+		get appName() {
+			return appNameState.current;
+		},
+	},
 	window: { showErrorMessage },
 	Uri,
 }));
@@ -103,6 +130,8 @@ describe("AuthService", () => {
 		vi.clearAllMocks();
 		// Default: no jolliApiKey configured — sign-in should request key generation.
 		loadConfig.mockResolvedValue({});
+		// Reset host-IDE appName to VSCode Stable; per-test overrides simulate forks.
+		appNameState.current = "Visual Studio Code";
 		service = new AuthService();
 	});
 
@@ -343,6 +372,58 @@ describe("AuthService", () => {
 			expect(showErrorMessage).toHaveBeenCalledWith(
 				expect.stringContaining("bare string from browser layer"),
 			);
+		});
+
+		// Each VSCode fork rebrands `vscode.env.appName` (product.json nameLong)
+		// while often leaving `vscode.env.uriScheme` at the upstream default
+		// "vscode". AuthService therefore derives the callback scheme from
+		// appName — these mappings must stay in sync with Jolli's cli_callback
+		// allowlist. If a new fork shows up, add a row here AND to
+		// resolveUriScheme() in AuthService.ts AND to the server-side allowlist.
+		describe.each([
+			["Visual Studio Code", "vscode"],
+			["Visual Studio Code - Insiders", "vscode-insiders"],
+			["VSCodium", "vscodium"],
+			["Cursor", "cursor"],
+			["Windsurf", "windsurf"],
+			["Kiro", "kiro"],
+			["Antigravity", "antigravity"],
+		])("with host appName=%s", (appName, expectedScheme) => {
+			it(`constructs the callback URI with the ${expectedScheme} scheme`, async () => {
+				appNameState.current = appName;
+
+				await service.openSignInPage();
+
+				expect(uriParse).toHaveBeenCalledTimes(1);
+				const parsed = uriParse.mock.calls[0]?.[0] ?? "";
+
+				// Decoding the full cli_callback value guards against false
+				// positives from `client=vscode` (which also contains "vscode"
+				// but is unrelated to the callback scheme).
+				const match = parsed.match(/cli_callback=([^&]+)/);
+				expect(match).not.toBeNull();
+				const decoded = decodeURIComponent(match?.[1] ?? "");
+				expect(decoded).toBe(
+					`${expectedScheme}://jolli.jollimemory-vscode/auth-callback`,
+				);
+			});
+		});
+
+		it("should fall back to vscode:// for an unrecognized host appName", async () => {
+			// Safety net for forks resolveUriScheme() doesn't know about yet:
+			// we route to "vscode" so at least the VSCode-family install on the
+			// machine catches the callback (better than a scheme that nothing
+			// on the OS is registered to handle). The user can then add the new
+			// fork to the mapping.
+			appNameState.current = "Some Brand New Fork";
+
+			await service.openSignInPage();
+
+			expect(uriParse).toHaveBeenCalledTimes(1);
+			const parsed = uriParse.mock.calls[0]?.[0] ?? "";
+			const match = parsed.match(/cli_callback=([^&]+)/);
+			const decoded = decodeURIComponent(match?.[1] ?? "");
+			expect(decoded).toBe("vscode://jolli.jollimemory-vscode/auth-callback");
 		});
 	});
 

--- a/vscode/src/services/AuthService.ts
+++ b/vscode/src/services/AuthService.ts
@@ -124,7 +124,13 @@ export class AuthService {
 
 	/** Opens the browser to the Jolli login page with a VSCode callback URI. */
 	async openSignInPage(): Promise<void> {
-		const callbackUri = `vscode://${EXTENSION_ID}${AUTH_CALLBACK_PATH}`;
+		// Derive the callback scheme from the host IDE. `vscode.env.uriScheme`
+		// is unreliable here — most forks inherit upstream's "vscode" default
+		// for that API even though they register their own scheme at the OS
+		// level. `appName` is consistently rebranded (forks surface it in window
+		// titles and About dialogs), so it's the stable signal — see
+		// resolveUriScheme() at the bottom of this file.
+		const callbackUri = `${resolveUriScheme()}://${EXTENSION_ID}${AUTH_CALLBACK_PATH}`;
 		// Only ask the server to issue a fresh Jolli API key when the user has
 		// none configured — otherwise sign-in would overwrite a manually
 		// configured key (and a subsequent sign-out would then delete it).
@@ -163,6 +169,32 @@ export class AuthService {
 			this.isSignedIn(config),
 		);
 	}
+}
+
+/**
+ * Resolves the OS-registered URI scheme for the host IDE.
+ *
+ * `vscode.env.uriScheme` returns "vscode" in most forks (Cursor, Windsurf,
+ * Kiro, Antigravity, …) because forks inherit upstream VSCode's default for
+ * that API without overriding it. The OS-level scheme registration, however,
+ * is usually correct — so we detect the host via `appName` (which forks
+ * consistently rebrand) and return the scheme the OS has registered.
+ *
+ * Unknown forks fall through to "vscode". If such a fork did register its
+ * own scheme, sign-in will fail over to VSCode Stable; add a new branch here
+ * and a corresponding entry to Jolli's cli_callback allowlist to fix it.
+ */
+function resolveUriScheme(): string {
+	const appName = vscode.env.appName.toLowerCase();
+	if (appName.includes("cursor")) return "cursor";
+	if (appName.includes("windsurf")) return "windsurf";
+	if (appName.includes("vscodium")) return "vscodium";
+	if (appName.includes("kiro")) return "kiro";
+	if (appName.includes("antigravity")) return "antigravity";
+	// Check "insiders" last: it coexists with "visual studio code" in the
+	// VSCode Insiders appName, and we want the more specific match to win.
+	if (appName.includes("insiders")) return "vscode-insiders";
+	return "vscode";
 }
 
 /** Maps server-returned error codes to user-friendly messages. Mirrors Login.ts. */


### PR DESCRIPTION
Support sign-in for VSCode forks like Cursor, Windsurf, Kiro, Antigravity, VSCodium, etc.

<!-- jollimemory-summary-start -->

## E2E Test (4)
<details>
<summary><strong>1. Sign in to Jolli from Cursor IDE</strong></summary>
<br>
<blockquote>

**Steps:**
1. Open Cursor IDE and open the Jolli extension
2. Click the "Sign In" button
3. Wait for your browser to open to the Jolli login page
4. Complete the login process in your browser
5. Verify that you are redirected back to Cursor (not Visual Studio Code) and the sign-in completes successfully in the extension

**Expected Results:**
- The browser should redirect to a URL starting with `cursor://` (not `vscode://`)
- The extension should recognize the callback and display a success message
- Your account should appear as signed in within the Cursor extension

</blockquote>
</details>
<details>
<summary><strong>2. Sign in to Jolli from Windsurf IDE</strong></summary>
<br>
<blockquote>

**Steps:**
1. Open Windsurf IDE and open the Jolli extension
2. Click the "Sign In" button
3. Wait for your browser to open to the Jolli login page
4. Complete the login process in your browser
5. Verify that you are redirected back to Windsurf (not Visual Studio Code) and the sign-in completes successfully in the extension

**Expected Results:**
- The browser should redirect to a URL starting with `windsurf://` (not `vscode://`)
- The extension should recognize the callback and display a success message
- Your account should appear as signed in within the Windsurf extension

</blockquote>
</details>
<details>
<summary><strong>3. Sign in to Jolli from VSCode Insiders</strong></summary>
<br>
<blockquote>

**Steps:**
1. Open Visual Studio Code - Insiders and open the Jolli extension
2. Click the "Sign In" button
3. Wait for your browser to open to the Jolli login page
4. Complete the login process in your browser
5. Verify that you are redirected back to VSCode Insiders and the sign-in completes successfully in the extension

**Expected Results:**
- The browser should redirect to a URL starting with `vscode-insiders://` (not `vscode://`)
- The extension should recognize the callback and display a success message
- Your account should appear as signed in within the VSCode Insiders extension

</blockquote>
</details>
<details>
<summary><strong>4. Sign in to Jolli from standard Visual Studio Code</strong></summary>
<br>
<blockquote>

**Steps:**
1. Open Visual Studio Code (stable) and open the Jolli extension
2. Click the "Sign In" button
3. Wait for your browser to open to the Jolli login page
4. Complete the login process in your browser
5. Verify that you are redirected back to Visual Studio Code and the sign-in completes successfully in the extension

**Expected Results:**
- The browser should redirect to a URL starting with `vscode://`
- The extension should recognize the callback and display a success message
- Your account should appear as signed in within the Visual Studio Code extension

</blockquote>
</details>

---

## Topics (3)
<details>
<summary><strong>01 · Support sign-in for VSCode forks by deriving URI scheme from appName</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

VSCode forks like Cursor, Windsurf, Kiro, and Antigravity all hardcode the callback URI scheme to `vscode://`, causing OAuth callbacks to be routed to VSCode Stable instead of the IDE the user is actually using, breaking sign-in in those forks.

**💡 Decisions Behind the Code**

- **appName over uriScheme**: `vscode.env.uriScheme` returns "vscode" in most forks because they inherit upstream's default without overriding it, even though they register their own scheme at the OS level. `appName` is consistently rebranded by forks (appears in window titles and About dialogs), making it the reliable signal for scheme detection.
- **Substring matching over exact equality**: Used `.includes("cursor")` rather than exact string comparison to tolerate future appName variations (e.g., "Cursor Pro") while remaining safe for the current 7 known forks whose names don't overlap.
- **Fallback to vscode for unknown forks**: Unknown forks default to "vscode" so at least VSCode Stable on the machine can catch the callback, providing graceful degradation rather than a completely unhandled scheme.
- **Test isolation via hoisted mutable state**: Used vitest's hoisted factory pattern with a mutable `appNameState` object and getter to allow per-test scheme switching without duplicating the entire mock setup, keeping tests DRY while enabling parametrized fork simulation.

**✅ What Was Implemented**

- Modified `vscode/src/services/AuthService.ts:127` to replace hardcoded `vscode://` with dynamic `${resolveUriScheme()}://`
- Added `resolveUriScheme()` function that maps `vscode.env.appName` to the correct OS-registered URI scheme for each fork (cursor, windsurf, kiro, antigravity, vscodium, vscode-insiders, vscode)
- Updated `vscode/src/Extension.ts:1275` comment to explain that the URI handler receives callbacks via the dynamically-resolved scheme, not the unreliable `vscode.env.uriScheme` API
- Rewrote `vscode/src/services/AuthService.test.ts` to mock `vscode.env.appName` as a mutable hoisted state, added 7-fork parametrized test cases, and added fallback test for unknown forks

**📋 Future Enhancements**

Kiro and Antigravity require runtime verification that their `vscode.env.appName` values actually contain "kiro" and "antigravity" respectively; if they use different branding, the mapping in `resolveUriScheme()` must be updated and the server-side allowlist adjusted accordingly.

**📁 FILES**
- `vscode/src/services/AuthService.ts`
- `vscode/src/services/AuthService.test.ts`
- `vscode/src/Extension.ts`

</blockquote>
</details>
<details>
<summary><strong>02 · Add server-side URI scheme allowlist to prevent open redirect in OAuth callback</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The Jolli login backend had no validation on the `cli_callback` parameter, allowing any URL to be used as an OAuth redirect target — a classic open redirect vulnerability that could leak authentication tokens to attacker-controlled domains.

**💡 Decisions Behind the Code**

- **Enumerated allowlist (strategy A) over regex or fallback**: Explicit enumeration of known IDE schemes is safest for a security boundary (login endpoint), avoids future attack surface from overly-permissive patterns, and requires only occasional maintenance as new forks emerge.
- **Validation before token issuance**: Placed the check before `getCliToken()` to prevent token generation for disallowed callbacks, ensuring audit logs and rate limits don't record attempts to exfiltrate credentials.
- **Localhost allowlist for CLI**: Mirrored the CLI's own `http://127.0.0.1:PORT/callback` pattern (IETF BCP 212 standard for OAuth native apps) to support both VSCode extension and CLI login flows from the same backend.

**✅ What Was Implemented**

- Added `isAllowedCliCallback()` helper function in `frontend/src/contexts/NavigationContext.tsx` that validates callback URLs against an explicit allowlist
- Allowlist includes IDE URI schemes (vscode, cursor, kiro, windsurf, antigravity, code-oss, vscodium, trae) and localhost HTTP callbacks for CLI (127.0.0.1, localhost, [::1] on any ephemeral port)
- Integrated validation into `handleCliCallback()` before token issuance, rejecting disallowed callbacks with a 400 error
- Added two regression tests: one verifying external domains are rejected, one verifying kiro:// scheme is accepted

**📁 FILES**
- `frontend/src/contexts/NavigationContext.tsx`
- `frontend/src/contexts/NavigationContext.test.tsx`

</blockquote>
</details>
<details>
<summary><strong>03 · Coordinate client and server deployment order for fork sign-in support</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The URI scheme fix requires changes in two repositories (jollimemory extension and jolli backend) that must be deployed in a specific order to avoid breaking existing functionality during the transition window.

**💡 Decisions Behind the Code**

- **Server-first deployment**: Deploying the allowlist before the client change ensures old clients (still sending vscode://) don't break, and new clients (sending cursor://, kiro://, etc.) are immediately accepted. Reverse order would create a window where new clients send schemes the old server rejects.

**✅ What Was Implemented**

Established deployment sequence: jolli backend (server-side allowlist) deploys first, then jollimemory extension (client-side scheme resolution) deploys second. This ordering ensures backward compatibility during the transition — old clients sending `vscode://` callbacks remain accepted by the new allowlist, while new clients sending fork-specific schemes work correctly once the allowlist is in place.

**📁 FILES**
- `(coordination only; no single-repo change)`

</blockquote>
</details>

---

*Generated by Jolli Memory · April 25, 2026 at 8:11 AM*
<!-- jollimemory-summary-end -->