### PR TITLE
Rename repository from jollimemory to jolliai across all configs and docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
 blank_issues_enabled: false
 contact_links:
   - name: 💬 Questions & Discussions
-    url: https://github.com/jolliai/jollimemory/discussions
+    url: https://github.com/jolliai/jolliai/discussions
     about: Ask questions or share ideas
   - name: 🔐 Security Vulnerabilities
-    url: https://github.com/jolliai/jollimemory/security/advisories/new
+    url: https://github.com/jolliai/jolliai/security/advisories/new
     about: Report security issues privately (do not file public issues)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,8 +15,8 @@ This is an npm workspaces monorepo containing the CLI (`cli/`) and the VS Code e
 
 ```bash
 # Clone your fork
-git clone https://github.com/<your-username>/jollimemory.git
-cd jollimemory
+git clone https://github.com/<your-username>/jolliai.git
+cd jolliai
 
 # Install dependencies for all workspaces
 npm ci

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Contributions welcome. Please read:
 
 ## Support
 
-- **Issues & feature requests** — [GitHub Issues](https://github.com/jolliai/jollimemory/issues)
+- **Issues & feature requests** — [GitHub Issues](https://github.com/jolliai/jolliai/issues)
 - **Jolli Space onboarding / enterprise** — support@jolli.ai
 
 ## License

--- a/cli/README.md
+++ b/cli/README.md
@@ -364,11 +364,11 @@ Every file under `~/.jolli/jollimemory/` and every entry on the `jollimemory/sum
 
 ## Support
 
-- **Issues & feature requests** — [GitHub Issues](https://github.com/jolliai/jollimemory/issues)
+- **Issues & feature requests** — [GitHub Issues](https://github.com/jolliai/jolliai/issues)
 - **Jolli Space onboarding / enterprise** — support@jolli.ai
-- **VS Code extension reference** — see the [VS Code README](https://github.com/jolliai/jollimemory/tree/main/vscode)
+- **VS Code extension reference** — see the [VS Code README](https://github.com/jolliai/jolliai/tree/main/vscode)
 
 ## License
 
-[Apache License 2.0](https://github.com/jolliai/jollimemory/blob/main/LICENSE)
+[Apache License 2.0](https://github.com/jolliai/jolliai/blob/main/LICENSE)
 

--- a/cli/package.json
+++ b/cli/package.json
@@ -40,12 +40,12 @@
 	"license": "Apache-2.0",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/jolliai/jollimemory",
+		"url": "https://github.com/jolliai/jolliai",
 		"directory": "cli"
 	},
-	"homepage": "https://github.com/jolliai/jollimemory/tree/main/cli#readme",
+	"homepage": "https://github.com/jolliai/jolliai/tree/main/cli#readme",
 	"bugs": {
-		"url": "https://github.com/jolliai/jollimemory/issues"
+		"url": "https://github.com/jolliai/jolliai/issues"
 	},
 	"dependencies": {
 		"@anthropic-ai/sdk": "^0.39.0",

--- a/package.json
+++ b/package.json
@@ -31,10 +31,10 @@
 	"license": "Apache-2.0",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/jolliai/jollimemory"
+		"url": "https://github.com/jolliai/jolliai"
 	},
-	"homepage": "https://github.com/jolliai/jollimemory",
+	"homepage": "https://github.com/jolliai/jolliai",
 	"bugs": {
-		"url": "https://github.com/jolliai/jollimemory/issues"
+		"url": "https://github.com/jolliai/jolliai/issues"
 	}
 }

--- a/vscode/README.md
+++ b/vscode/README.md
@@ -297,7 +297,7 @@ Each memory uses a **v3 tree structure**: a single commit can cover multiple ind
 
 **Topic fields**: `trigger` (what prompted the work), `response` (what was built), `decisions` (design rationale — may include Markdown tables), `todo` (optional follow-up), `category` (one of `feature`, `bugfix`, `refactor`, `tech-debt`, `performance`, `security`, `test`, `docs`, `ux`, `devops`), `importance` (`major` or `minor`).
 
-For CLI export usage (`jolli export`) and programmatic consumption, see the [`@jolli.ai/cli` README](https://github.com/jolliai/jollimemory/tree/main/cli#summary-format).
+For CLI export usage (`jolli export`) and programmatic consumption, see the [`@jolli.ai/cli` README](https://github.com/jolliai/jolliai/tree/main/cli#summary-format).
 
 ## Privacy
 
@@ -324,10 +324,10 @@ Every file under `~/.jolli/jollimemory/`, every entry on the `jollimemory/summar
 
 ## Support
 
-* **Issues & feature requests** — [GitHub Issues](https://github.com/jolliai/jollimemory/issues)
+* **Issues & feature requests** — [GitHub Issues](https://github.com/jolliai/jolliai/issues)
 * **Jolli Space onboarding / enterprise** — support@jolli.ai
-* **CLI reference & troubleshooting** — see the [`@jolli.ai/cli` README](https://github.com/jolliai/jollimemory/tree/main/cli)
+* **CLI reference & troubleshooting** — see the [`@jolli.ai/cli` README](https://github.com/jolliai/jolliai/tree/main/cli)
 
 ## License
 
-[Apache License 2.0](https://github.com/jolliai/jollimemory/blob/main/LICENSE)
+[Apache License 2.0](https://github.com/jolliai/jolliai/blob/main/LICENSE)

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -6,13 +6,13 @@
 	"publisher": "jolli",
 	"license": "Apache-2.0",
 	"icon": "assets/icon.png",
-	"homepage": "https://github.com/jolliai/jollimemory/tree/main/vscode#readme",
+	"homepage": "https://github.com/jolliai/jolliai/tree/main/vscode#readme",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/jolliai/jollimemory"
+		"url": "https://github.com/jolliai/jolliai"
 	},
 	"bugs": {
-		"url": "https://github.com/jolliai/jollimemory/issues"
+		"url": "https://github.com/jolliai/jolliai/issues"
 	},
 	"keywords": [
 		"ai",


### PR DESCRIPTION
## Summary

Renames the GitHub repository slug from `jolliai/jollimemory` to `jolliai/jolliai` across all configs and docs. URL-only rename — no code, runtime, or product contract changes.

**Updated:**
- Package metadata (`repository.url`, `homepage`, `bugs.url`) in root, `cli/`, and `vscode/` `package.json`
- GitHub links in `README.md`, `cli/README.md`, `vscode/README.md`, `CONTRIBUTING.md` (clone instructions)
- `.github/ISSUE_TEMPLATE/config.yml` Discussions and Security advisories links

**Intentionally unchanged** (these are runtime data contracts, not repo identifiers):
- `~/.jolli/jollimemory/` — user data directory path
- `jollimemory/summaries/*` — summary git refspec
- `@jolli.ai/cli` — published npm package name

GitHub's automatic 301 from the old slug keeps existing clones/links working; this PR just removes the redirect dependency.

## Test plan

- [ ] `npm ci` succeeds at repo root
- [ ] `npm run all` passes
- [ ] Spot-check rendered links in `README.md` and `cli/README.md` resolve to `jolliai/jolliai`
- [ ] Verify `.github/ISSUE_TEMPLATE/config.yml` renders correctly on the "New issue" page after merge
