### PR TITLE
Add jolli.cloud to allowed origins allowlist and error messages

### DIFF
--- a/cli/src/core/JolliApiUtils.test.ts
+++ b/cli/src/core/JolliApiUtils.test.ts
@@ -108,6 +108,14 @@ describe("JolliApiUtils", () => {
 			expect(() => assertJolliOriginAllowed("https://tenant.jolli.dev")).not.toThrow();
 		});
 
+		it("accepts https://admin.jolli.cloud", () => {
+			expect(() => assertJolliOriginAllowed("https://admin.jolli.cloud")).not.toThrow();
+		});
+
+		it("accepts apex https://jolli.cloud", () => {
+			expect(() => assertJolliOriginAllowed("https://jolli.cloud")).not.toThrow();
+		});
+
 		it("accepts https://jolli-local.me for local development", () => {
 			expect(() => assertJolliOriginAllowed("https://jolli-local.me")).not.toThrow();
 		});

--- a/cli/src/core/JolliApiUtils.ts
+++ b/cli/src/core/JolliApiUtils.ts
@@ -99,7 +99,7 @@ export function validateJolliApiKey(key: string): void {
 	assertJolliOriginAllowed(meta.u);
 }
 
-const ALLOWED_JOLLI_HOSTS = ["jolli.ai", "jolli.dev", "jolli-local.me"];
+const ALLOWED_JOLLI_HOSTS = ["jolli.ai", "jolli.dev", "jolli.cloud", "jolli-local.me"];
 
 /**
  * Rejects origins that are not on the Jolli allowlist. Called from the
@@ -128,6 +128,6 @@ export function assertJolliOriginAllowed(origin: string): void {
 		return;
 	}
 	throw new Error(
-		`Rejected Jolli origin "${url.origin}". Only https://*.jolli.ai, https://*.jolli.dev, and https://*.jolli-local.me are permitted.`,
+		`Rejected Jolli origin "${url.origin}". Only https://*.jolli.ai, https://*.jolli.dev, https://*.jolli.cloud, and https://*.jolli-local.me are permitted.`,
 	);
 }

--- a/vscode/src/views/SettingsScriptBuilder.test.ts
+++ b/vscode/src/views/SettingsScriptBuilder.test.ts
@@ -41,6 +41,13 @@ describe("SettingsScriptBuilder", () => {
 		expect(script).toContain("sk-jol-");
 	});
 
+	it("includes all Jolli hosts in the allowlist", () => {
+		expect(script).toContain("'jolli.ai'");
+		expect(script).toContain("'jolli.dev'");
+		expect(script).toContain("'jolli.cloud'");
+		expect(script).toContain("'jolli-local.me'");
+	});
+
 	it("contains dirty tracking logic", () => {
 		expect(script).toContain("isDirty");
 	});

--- a/vscode/src/views/SettingsScriptBuilder.ts
+++ b/vscode/src/views/SettingsScriptBuilder.ts
@@ -41,7 +41,7 @@ export function buildSettingsScript(): string {
   let hasErrors = false;
 
   // ── Validation ──
-  var ALLOWED_JOLLI_HOSTS = ['jolli.ai', 'jolli.dev', 'jolli-local.me'];
+  var ALLOWED_JOLLI_HOSTS = ['jolli.ai', 'jolli.dev', 'jolli.cloud', 'jolli-local.me'];
 
   function decodeBase64url(seg) {
     try {
@@ -87,7 +87,7 @@ export function buildSettingsScript(): string {
         var meta = JSON.parse(json);
         if (typeof meta.t === 'string' && typeof meta.u === 'string') {
           if (!checkJolliOriginAllowed(meta.u)) {
-            return 'Origin ' + meta.u + ' is not on the Jolli allowlist (only *.jolli.ai, *.jolli.dev, *.jolli-local.me).';
+            return 'Origin ' + meta.u + ' is not on the Jolli allowlist (only *.jolli.ai, *.jolli.dev, *.jolli.cloud, *.jolli-local.me).';
           }
           return '';
         }


### PR DESCRIPTION
# Add jolli.cloud to allowed origins allowlist and error messages
---

## E2E Test (4)

### 1. jolli.cloud API key accepted in VS Code settings

**Preconditions:** Have a valid Jolli API key that was issued from a jolli.cloud domain (for example, one whose embedded URL contains "jolli.cloud").

**Steps:**
1. Open VS Code and navigate to the Jolli extension settings panel.
2. Paste your jolli.cloud API key into the API key field.
3. Click Save (or the equivalent confirm button).
4. Check whether any error or warning message appears beneath the field.

**Expected Results:**
- No error or rejection message appears.
- The settings panel accepts the key and saves successfully, the same way a jolli.ai or jolli.dev key would.

### 2. jolli.cloud API key accepted in the CLI

**Preconditions:** Have a valid Jolli API key issued from a jolli.cloud domain and access to a terminal with the Jolli CLI installed.

**Steps:**
1. Open a terminal window.
2. Run the Jolli CLI login or configure command and enter your jolli.cloud API key when prompted.
3. Confirm the entry and wait for the CLI to respond.
4. Check the output message shown in the terminal.

**Expected Results:**
- The CLI accepts the key without printing any rejection or "not permitted" error.
- The command completes successfully, just as it would with a jolli.ai or jolli.dev key.

### 3. Rejection error message lists jolli.cloud for invalid keys in VS Code

**Preconditions:** Have an API key from a domain that is NOT on the allowlist (for example, one containing "example.com").

**Steps:**
1. Open VS Code and navigate to the Jolli extension settings panel.
2. Paste the invalid (non-Jolli-domain) API key into the API key field.
3. Click Save or confirm the entry.
4. Read the error message that appears.

**Expected Results:**
- An error message appears explaining the key was rejected.
- The message lists "*.jolli.cloud" alongside "*.jolli.ai", "*.jolli.dev", and "*.jolli-local.me" as the permitted domains.

### 4. Rejection error message lists jolli.cloud for invalid keys in the CLI

**Preconditions:** Have an API key from a domain that is NOT on the allowlist (for example, one containing "example.com") and access to a terminal with the Jolli CLI installed.

**Steps:**
1. Open a terminal window.
2. Run the Jolli CLI login or configure command and enter the invalid API key when prompted.
3. Confirm the entry and wait for the CLI to respond.
4. Read the error message printed in the terminal.

**Expected Results:**
- The CLI prints a rejection error message.
- The message includes "https://*.jolli.cloud" alongside the other permitted domains (https://*.jolli.ai, https://*.jolli.dev, https://*.jolli-local.me).

---

## Topic (1)

### 01 · Add jolli.cloud domain to origin allowlist across CLI and VS Code plugin `security`

**⚡ Why This Change**

The origin allowlist rejected valid requests from jolli.cloud, blocking users on that domain from authenticating or saving settings. Both the CLI and the VS Code extension webview needed updating since they maintain separate copies of the allowlist.

**💡 Decisions Behind the Code**

- **Two separate copies, not one**: The VS Code webview runs in a browser context and cannot import Node modules, so it must carry its own inline copy of the allowlist. Both copies must be kept in sync manually — this is a known maintenance burden acknowledged in the conversation.
- **Smoke test for the webview copy**: Because the webview's validation logic cannot be exercised in a Node test environment (it depends on the browser `URL` API), the test only asserts that the host strings are present in the generated script. This is weaker than the CLI's behavioral tests but is the best achievable coverage for that layer.

**✅ What Was Implemented**

- `cli/src/core/JolliApiUtils.ts`: added `"jolli.cloud"` to `ALLOWED_JOLLI_HOSTS` array; updated error message to include `https://*.jolli.cloud`
- `vscode/src/views/SettingsScriptBuilder.ts`: added `'jolli.cloud'` to the inline webview copy of `ALLOWED_JOLLI_HOSTS`; updated the user-facing error string to include `*.jolli.cloud`
- `cli/src/core/JolliApiUtils.test.ts`: added two new test cases covering apex `https://jolli.cloud` and subdomain `https://admin.jolli.cloud`
- `vscode/src/views/SettingsScriptBuilder.test.ts`: added a smoke-test assertion that all four allowed hosts appear in the generated webview script

**📁 FILES**
- `cli/src/core/JolliApiUtils.ts`
- `vscode/src/views/SettingsScriptBuilder.ts`

---