### PR TITLE
Refactor E2E webview with per-scenario editing and fix stale PR form

### DIFF
--- a/vscode/src/services/PrCommentService.test.ts
+++ b/vscode/src/services/PrCommentService.test.ts
@@ -162,26 +162,8 @@ describe("PrCommentService", () => {
 	// ─── buildPrSectionHtml ─────────────────────────────────────────────────
 
 	describe("buildPrSectionHtml", () => {
-		it("returns HTML with escaped title and body in data attributes", () => {
-			const html = buildPrSectionHtml('Fix "bug" & <tag>', "## Summary\nDone");
-			expect(html).toContain(
-				'data-title="Fix &quot;bug&quot; &amp; &lt;tag&gt;"',
-			);
-			// Markers are HTML-escaped inside the data attribute
-			const escapedMarkerStart = MARKER_START.replace(/</g, "&lt;").replace(
-				/>/g,
-				"&gt;",
-			);
-			const escapedMarkerEnd = MARKER_END.replace(/</g, "&lt;").replace(
-				/>/g,
-				"&gt;",
-			);
-			expect(html).toContain(`data-body="${escapedMarkerStart}`);
-			expect(html).toContain(escapedMarkerEnd);
-		});
-
 		it("includes the PR section structure with status text and form", () => {
-			const html = buildPrSectionHtml("Title", "Body");
+			const html = buildPrSectionHtml();
 			expect(html).toContain('id="prSection"');
 			expect(html).toContain('id="prStatusText"');
 			expect(html).toContain('id="prForm"');
@@ -189,6 +171,8 @@ describe("PrCommentService", () => {
 			expect(html).toContain('id="prBodyInput"');
 			expect(html).toContain('id="prFormSubmit"');
 			expect(html).toContain("Pull Request");
+			expect(html).not.toContain("data-title");
+			expect(html).not.toContain("data-body");
 		});
 	});
 

--- a/vscode/src/services/PrCommentService.ts
+++ b/vscode/src/services/PrCommentService.ts
@@ -28,15 +28,6 @@ const TAG = "PrSection";
 
 // ─── HTML helper ─────────────────────────────────────────────────────────────
 
-/** Escapes a string for use inside an HTML attribute value. */
-function escAttr(s: string): string {
-	return s
-		.replace(/&/g, "&amp;")
-		.replace(/"/g, "&quot;")
-		.replace(/</g, "&lt;")
-		.replace(/>/g, "&gt;");
-}
-
 // ─── Marker constants ────────────────────────────────────────────────────────
 
 const MARKER_START = "<!-- jollimemory-summary-start -->";
@@ -47,7 +38,7 @@ const MARKER_PATTERN =
 // ─── Marker helpers ──────────────────────────────────────────────────────────
 
 /** Wraps markdown content with start/end markers. */
-function wrapWithMarkers(markdown: string): string {
+export function wrapWithMarkers(markdown: string): string {
 	return `${MARKER_START}\n${markdown}\n${MARKER_END}`;
 }
 
@@ -722,13 +713,7 @@ export async function handleUpdatePr(
 const PR_ICON = `<svg class="pr-icon" width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path d="M7.177 3.073L9.573.677A.25.25 0 0110 .854v4.792a.25.25 0 01-.427.177L7.177 3.427a.25.25 0 010-.354zM3.75 2.5a.75.75 0 100 1.5.75.75 0 000-1.5zm-2.25.75a2.25 2.25 0 113 2.122v5.256a2.251 2.251 0 11-1.5 0V5.372A2.25 2.25 0 011.5 3.25zM11 2.5h-1V4h1a1 1 0 011 1v5.628a2.251 2.251 0 101.5 0V5A2.5 2.5 0 0011 2.5zm1 10.25a.75.75 0 111.5 0 .75.75 0 01-1.5 0zM3.75 12a.75.75 0 100 1.5.75.75 0 000-1.5z"/></svg>`;
 
 /** Returns the initial HTML for the PR section (loading state). */
-export function buildPrSectionHtml(
-	commitMessage: string,
-	summaryMarkdown: string,
-): string {
-	// Encode pre-fill values as data attributes for the Create PR form
-	const escapedTitle = escAttr(commitMessage);
-	const escapedBody = escAttr(wrapWithMarkers(summaryMarkdown));
+export function buildPrSectionHtml(): string {
 	return `
 <div class="section" id="prSection">
   <div class="section-header">
@@ -737,7 +722,7 @@ export function buildPrSectionHtml(
   <p class="pr-status-text" id="prStatusText">Checking PR status...</p>
   <div class="pr-link-row pr-hidden" id="prLinkRow"></div>
   <div class="pr-actions pr-hidden" id="prActions"></div>
-  <div class="pr-form pr-hidden" id="prForm" data-title="${escapedTitle}" data-body="${escapedBody}">
+  <div class="pr-form pr-hidden" id="prForm">
     <label class="pr-form-label">Title</label>
     <input type="text" class="pr-form-input" id="prTitleInput" />
     <label class="pr-form-label">Body</label>
@@ -948,18 +933,12 @@ export function buildPrMessageScript(): string {
           btn.textContent = 'Create PR';
           prActions.appendChild(btn);
           prShow(prActions);
-          // Bind Create PR button
+          // Bind Create PR button — request fresh body from backend so that
+          // content generated after the webview opened (e.g. E2E test) is included.
           btn.addEventListener('click', function() {
-            prHide(prStatusText);
-            prHide(prLinkRow);
-            prHide(prActions);
-            prShow(prForm);
-            prForm.dataset.mode = 'create';
-            prFormSubmit.textContent = 'Submit PR';
-            // Pre-fill form — values set via data attributes on prForm
-            prTitleInput.value = prForm.dataset.title || '';
-            prBodyInput.value = prForm.dataset.body || '';
-            prTitleInput.focus();
+            btn.disabled = true;
+            btn.textContent = 'Loading...';
+            vscode.postMessage({ command: 'prepareCreatePr' });
           });
         }
       } else if (s === 'ready') {
@@ -988,6 +967,23 @@ export function buildPrMessageScript(): string {
           vscode.postMessage({ command: 'prepareUpdatePr' });
         });
       }
+    }
+
+    // ── PR show create form ──
+    if (msg.command === 'prShowCreateForm') {
+      prHide(prStatusText);
+      prHide(prLinkRow);
+      var createBtn = document.getElementById('createPrBtn');
+      if (createBtn) { createBtn.textContent = 'Create PR'; createBtn.disabled = false; }
+      prHide(prActions);
+      prShow(prForm);
+      prForm.dataset.mode = 'create';
+      prFormSubmit.textContent = 'Submit PR';
+      prFormSubmit.disabled = false;
+      prFormCancel.disabled = false;
+      prTitleInput.value = msg.title || '';
+      prBodyInput.value = msg.body || '';
+      prTitleInput.focus();
     }
 
     // ── PR show update form ──

--- a/vscode/src/views/SummaryCssBuilder.ts
+++ b/vscode/src/views/SummaryCssBuilder.ts
@@ -247,14 +247,20 @@ export function buildCss(): string {
     padding-left: 2px;
   }
   .plan-remove-btn:hover { color: var(--vscode-errorForeground, #f44); }
-  .plan-translate-btn.translating {
+  .plan-translate-btn.translating,
+  .note-translate-btn.translating {
     opacity: 0.5;
     cursor: wait;
-    animation: pulse 1.2s ease-in-out infinite;
+    animation: spin 1s linear infinite;
   }
-  @keyframes pulse {
-    0%, 100% { opacity: 0.5; }
-    50% { opacity: 0.2; }
+  @keyframes spin {
+    from { transform: rotate(0deg); }
+    to { transform: rotate(360deg); }
+  }
+  .topic-action-btn.generating {
+    opacity: 0.5;
+    cursor: wait;
+    animation: spin 1s linear infinite;
   }
   .plan-title-link {
     color: var(--vscode-foreground);
@@ -403,8 +409,8 @@ export function buildCss(): string {
   .e2e-scenario .callout.preconditions .callout-label { color: var(--callout-trigger-label); }
   .e2e-scenario .callout.steps { background: var(--callout-response-bg); }
   .e2e-scenario .callout.steps .callout-label { color: var(--callout-response-label); }
-  .e2e-scenario .callout.expected { background: var(--callout-decisions-bg); }
-  .e2e-scenario .callout.expected .callout-label { color: var(--callout-decisions-label); }
+  .e2e-scenario .callout.expectedResults { background: var(--callout-decisions-bg); }
+  .e2e-scenario .callout.expectedResults .callout-label { color: var(--callout-decisions-label); }
   .e2e-scenario .callout ol {
     margin: 0; padding-left: 1.4em;
   }
@@ -413,26 +419,6 @@ export function buildCss(): string {
   }
   .e2e-scenario .callout li {
     margin-bottom: 4px; line-height: 1.45;
-  }
-  .e2e-edit-area {
-    width: 100%;
-    min-height: 200px;
-    font-family: var(--vscode-editor-font-family, monospace);
-    font-size: 0.9em;
-    line-height: 1.5;
-    background: var(--vscode-input-background);
-    color: var(--vscode-input-foreground);
-    border: 1px solid var(--vscode-input-border, #444);
-    border-radius: 4px;
-    padding: 10px;
-    resize: vertical;
-    box-sizing: border-box;
-  }
-  .e2e-edit-actions {
-    display: flex;
-    gap: 8px;
-    margin-top: 8px;
-    justify-content: flex-end;
   }
 
   /* ── Quick recap edit mode (mirrors e2e-edit-area) ── */

--- a/vscode/src/views/SummaryHtmlBuilder.test.ts
+++ b/vscode/src/views/SummaryHtmlBuilder.test.ts
@@ -34,10 +34,6 @@ const { buildCss } = vi.hoisted(() => ({
 	buildCss: vi.fn(() => "/* css */"),
 }));
 
-const { buildPrMarkdown } = vi.hoisted(() => ({
-	buildPrMarkdown: vi.fn(() => "pr markdown"),
-}));
-
 const { buildScript } = vi.hoisted(() => ({
 	buildScript: vi.fn(() => "// script"),
 }));
@@ -85,10 +81,6 @@ vi.mock("../services/PrCommentService.js", () => ({
 
 vi.mock("./SummaryCssBuilder.js", () => ({
 	buildCss,
-}));
-
-vi.mock("./SummaryPrMarkdownBuilder.js", () => ({
-	buildPrMarkdown,
 }));
 
 vi.mock("./SummaryScriptBuilder.js", () => ({
@@ -204,7 +196,6 @@ describe("SummaryHtmlBuilder", () => {
 		formatDurationLabel.mockReturnValue("2 hours");
 		buildPrSectionHtml.mockReturnValue("");
 		buildCss.mockReturnValue("/* css */");
-		buildPrMarkdown.mockReturnValue("pr markdown");
 		buildScript.mockReturnValue("// script");
 		collectSortedTopics.mockReturnValue({
 			topics: [],
@@ -613,12 +604,17 @@ describe("SummaryHtmlBuilder", () => {
 			expect(html).toContain("Generate");
 		});
 
-		it("E2E test section with scenarios shows edit/regen/delete buttons", () => {
+		it("E2E test section with scenarios shows section toolbar (collapse-all + regen + delete)", () => {
 			const scenarios = [makeScenario()];
 			const html = buildHtml(makeSummary({ e2eTestGuide: scenarios }));
-			expect(html).toContain("editE2eBtn");
+			// Section toolbar: collapse-all + regen + delete (no bulk-edit anymore).
+			expect(html).toContain("toggleAllE2eBtn");
 			expect(html).toContain("regenE2eBtn");
 			expect(html).toContain("deleteE2eBtn");
+			expect(html).not.toContain("editE2eBtn");
+			// Per-scenario actions live on the scenario row.
+			expect(html).toContain("e2e-edit-btn");
+			expect(html).toContain("e2e-delete-btn");
 		});
 
 		it("source commits section not shown for single source", () => {
@@ -774,12 +770,9 @@ describe("SummaryHtmlBuilder", () => {
 			expect(html).toContain("pushJolliBtn");
 		});
 
-		it("calls buildPrSectionHtml with commit message and PR markdown", () => {
+		it("calls buildPrSectionHtml with no arguments", () => {
 			buildHtml(makeSummary({ commitMessage: "test msg" }));
-			expect(buildPrSectionHtml).toHaveBeenCalledWith(
-				"test msg",
-				"pr markdown",
-			);
+			expect(buildPrSectionHtml).toHaveBeenCalledWith();
 		});
 
 		it("includes hash copy button with full hash in data attribute", () => {
@@ -899,13 +892,50 @@ describe("SummaryHtmlBuilder", () => {
 			expect(html).toContain(`<span class="section-count">2</span>`);
 		});
 
-		it("shows edit/regen/delete buttons when scenarios exist", () => {
+		it("shows section toolbar (collapse-all + regen + delete) when scenarios exist", () => {
 			const html = buildE2eTestSection(
 				makeSummary({ e2eTestGuide: [makeScenario()] }),
 			);
-			expect(html).toContain("editE2eBtn");
+			expect(html).toContain("toggleAllE2eBtn");
 			expect(html).toContain("regenE2eBtn");
 			expect(html).toContain("deleteE2eBtn");
+			expect(html).not.toContain("editE2eBtn");
+		});
+
+		it("renders per-scenario edit/delete buttons with scenario index", () => {
+			const html = buildE2eTestSection(
+				makeSummary({
+					e2eTestGuide: [
+						makeScenario({ title: "A" }),
+						makeScenario({ title: "B" }),
+					],
+				}),
+			);
+			// Each scenario gets its own edit/delete with data-scenario-index.
+			expect(html).toContain('e2e-edit-btn" data-scenario-index="0"');
+			expect(html).toContain('e2e-delete-btn" data-scenario-index="0"');
+			expect(html).toContain('e2e-edit-btn" data-scenario-index="1"');
+			expect(html).toContain('e2e-delete-btn" data-scenario-index="1"');
+		});
+
+		it("embeds scenario data on the toggle as data-scenario JSON", () => {
+			const html = buildE2eTestSection(
+				makeSummary({
+					e2eTestGuide: [
+						makeScenario({
+							title: "Edit me",
+							preconditions: "ready",
+							steps: ["one", "two"],
+							expectedResults: ["pass"],
+						}),
+					],
+				}),
+			);
+			// data-scenario carries title + preconditions + newline-joined arrays
+			// so the inline edit form can populate textareas without an extra round-trip.
+			expect(html).toContain("data-scenario=");
+			expect(html).toContain("Edit me");
+			expect(html).toContain("ready");
 		});
 
 		it("renders preconditions block when preconditions are set", () => {

--- a/vscode/src/views/SummaryHtmlBuilder.ts
+++ b/vscode/src/views/SummaryHtmlBuilder.ts
@@ -20,7 +20,6 @@ import type {
 } from "../../../cli/src/Types.js";
 import { buildPrSectionHtml } from "../services/PrCommentService.js";
 import { buildCss } from "./SummaryCssBuilder.js";
-import { buildPrMarkdown } from "./SummaryPrMarkdownBuilder.js";
 import { buildScript } from "./SummaryScriptBuilder.js";
 import {
 	collectSortedTopics,
@@ -96,7 +95,7 @@ ${buildAllConversationsSection(transcriptHashSet)}
 ${buildHeader(summary, totalFiles, totalInsertions, totalDeletions, pushAction)}
 <hr class="separator" />
 ${buildRecapSection(summary.recap)}
-${buildPrSectionHtml(summary.commitMessage, buildPrMarkdown(summary))}
+${buildPrSectionHtml()}
 ${buildPlansAndNotesSection(summary.plans, summary.notes, planTranslateSet, noteTranslateSet)}
 ${buildE2eTestSection(summary)}
 ${buildSourceCommits(sourceNodes)}
@@ -435,8 +434,8 @@ export function buildE2eTestSection(summary: CommitSummary): string {
   <div class="section-header">
     <div class="section-title">\uD83E\uDDEA E2E Test <span class="section-count">${scenarios.length}</span></div>
     <span class="topic-actions">
-      <button class="topic-action-btn" id="editE2eBtn" title="Edit">\u270E</button>
-      <button class="topic-action-btn" id="regenE2eBtn" title="Regenerate">\uD83D\uDD04</button>
+      <button class="toggle-all-btn" id="toggleAllE2eBtn" title="Expand / Collapse all scenarios">Collapse All</button>
+      <button class="topic-action-btn" id="regenE2eBtn" title="Regenerate">&#x21BB;</button>
       <button class="topic-action-btn" id="deleteE2eBtn" title="Delete">\uD83D\uDDD1</button>
     </span>
   </div>
@@ -445,8 +444,13 @@ export function buildE2eTestSection(summary: CommitSummary): string {
 <hr class="separator" />`;
 }
 
-/** Renders a single E2E test scenario as a collapsible toggle. */
-function renderE2eScenario(s: E2eTestScenario, index: number): string {
+/**
+ * Renders a single E2E test scenario as a collapsible toggle.
+ *
+ * Exported so the webview-panel handler can re-render just one scenario
+ * row after a per-scenario edit (mirrors the topic pattern of `renderTopic`).
+ */
+export function renderE2eScenario(s: E2eTestScenario, index: number): string {
 	const preconditionsHtml = s.preconditions
 		? `<div class="callout preconditions">
       <div class="callout-body">
@@ -464,12 +468,25 @@ function renderE2eScenario(s: E2eTestScenario, index: number): string {
 		.map((r) => `<li>${escHtml(r)}</li>`)
 		.join("\n        ");
 
+	// Embed raw scenario data for inline edit mode (mirrors topic pattern).
+	// Arrays joined by newlines so edit textareas can use one-item-per-line.
+	const scenarioData = JSON.stringify({
+		title: s.title,
+		preconditions: s.preconditions ?? "",
+		steps: s.steps.join("\n"),
+		expectedResults: s.expectedResults.join("\n"),
+	});
+
 	return `
-<div class="toggle e2e-scenario" id="e2e-scenario-${index}">
+<div class="toggle e2e-scenario" id="e2e-scenario-${index}" data-scenario='${escAttr(scenarioData)}'>
   <div class="toggle-header">
     <span class="arrow">\u25BC</span>
     <span class="toggle-num">${padIndex(index)}</span>
     <span class="toggle-title">${escHtml(s.title)}</span>
+    <span class="topic-actions">
+      <button class="topic-action-btn e2e-edit-btn" data-scenario-index="${index}" title="Edit scenario">\u270E</button>
+      <button class="topic-action-btn e2e-delete-btn" data-scenario-index="${index}" title="Delete scenario">\uD83D\uDDD1</button>
+    </span>
   </div>
   <div class="toggle-content">
     ${preconditionsHtml}
@@ -479,7 +496,7 @@ function renderE2eScenario(s: E2eTestScenario, index: number): string {
         <div class="callout-text"><ol>${stepsHtml}</ol></div>
       </div>
     </div>
-    <div class="callout expected">
+    <div class="callout expectedResults">
       <div class="callout-body">
         <div class="callout-label">\u2705 Expected Results</div>
         <div class="callout-text"><ul>${expectedHtml}</ul></div>

--- a/vscode/src/views/SummaryScriptBuilder.test.ts
+++ b/vscode/src/views/SummaryScriptBuilder.test.ts
@@ -17,6 +17,14 @@ describe("SummaryScriptBuilder", () => {
 		expect(script.length).toBeGreaterThan(0);
 	});
 
+	it("produces parseable JavaScript (catches syntax errors at build time)", () => {
+		// Try to parse the script via Function constructor — throws on syntax errors.
+		// This catches issues like backticks inside template literals, unbalanced
+		// braces, or stray template-literal delimiters that would otherwise only
+		// surface at webview runtime.
+		expect(() => new Function(script)).not.toThrow();
+	});
+
 	it("contains vscode API initialization", () => {
 		expect(script).toContain("acquireVsCodeApi");
 	});
@@ -74,7 +82,18 @@ describe("SummaryScriptBuilder", () => {
 
 	it("contains E2E test handlers", () => {
 		expect(script).toContain("e2eTestSection");
-		expect(script).toContain("e2e-editing");
+		// New section-level toolbar handler (Collapse-All for E2E).
+		expect(script).toContain("toggleAllE2eBtn");
+		// Per-scenario inline edit/delete handlers.
+		expect(script).toContain("e2e-edit-btn");
+		expect(script).toContain("e2e-delete-btn");
+		expect(script).toContain("enterE2eEditMode");
+		expect(script).toContain("editE2eScenario");
+		expect(script).toContain("deleteE2eScenario");
+		// Surgical per-scenario replacement message.
+		expect(script).toContain("e2eScenarioUpdated");
+		// Bulk-markdown-edit removed; no e2e-editing class anymore.
+		expect(script).not.toContain("e2e-editing");
 	});
 
 	it("contains message event listener", () => {

--- a/vscode/src/views/SummaryScriptBuilder.ts
+++ b/vscode/src/views/SummaryScriptBuilder.ts
@@ -189,12 +189,14 @@ ${buildPrMessageScript()}
     }
   });
 
-  // Toggle All: expand / collapse all memories
+  // Toggle All: expand / collapse all topic toggles and timeline groups.
+  // Scoped to topics — explicitly excludes .e2e-scenario so the E2E section
+  // has its own independent #toggleAllE2eBtn.
   var allCollapsed = false;
   var toggleAllBtn = document.getElementById('toggleAllBtn');
   if (toggleAllBtn) {
     toggleAllBtn.addEventListener('click', function() {
-      var items = document.querySelectorAll('.toggle');
+      var items = document.querySelectorAll('.toggle:not(.e2e-scenario), .timeline-group');
       allCollapsed = !allCollapsed;
       items.forEach(function(t) {
         if (allCollapsed) {
@@ -382,135 +384,79 @@ ${buildPrMessageScript()}
   }
 
   // ── E2E Test Guide ────────────────────────────────────────────────────
+  // Mirrors the Topics pattern: each scenario is a .toggle.e2e-scenario
+  // with its own edit/delete buttons; the section header has a Collapse-All
+  // button. Inline edit replaces title (in header) and content fields with
+  // textareas; Save posts editE2eScenario, Cancel restores cached HTML.
   // E2E scenario toggle is handled by the generic .toggle-header handler above.
 
-  // Generate / Regenerate button
-  var genE2eBtn = document.getElementById('generateE2eBtn');
-  var regenE2eBtn = document.getElementById('regenE2eBtn');
-  function handleGenerateE2e(btn) {
-    if (!btn) return;
-    btn.addEventListener('click', function() {
+  var E2E_EDIT_FIELDS = [
+    { key: 'preconditions',   label: '📋 Preconditions', placeholder: '' },
+    { key: 'steps',           label: '👣 Steps',          placeholder: 'One step per line' },
+    { key: 'expectedResults', label: '✅ Expected Results',     placeholder: 'One result per line' }
+  ];
+
+  function attachE2eHandlers(root) {
+    if (!root) return;
+
+    // Generate / Regenerate (placeholder + section header buttons share command).
+    var genBtn = root.querySelector('#generateE2eBtn');
+    if (genBtn) genBtn.addEventListener('click', function() {
       vscode.postMessage({ command: 'generateE2eTest' });
     });
-  }
-  handleGenerateE2e(genE2eBtn);
-  handleGenerateE2e(regenE2eBtn);
+    var regenBtn = root.querySelector('#regenE2eBtn');
+    if (regenBtn) regenBtn.addEventListener('click', function() {
+      vscode.postMessage({ command: 'generateE2eTest' });
+    });
 
-  // Delete E2E button
-  function attachDeleteE2eHandler(btn) {
-    if (!btn) return;
-    btn.addEventListener('click', function(e) {
+    // Section-level Delete (deletes the whole guide).
+    var sectionDelBtn = root.querySelector('#deleteE2eBtn');
+    if (sectionDelBtn) sectionDelBtn.addEventListener('click', function(e) {
       e.stopPropagation();
       vscode.postMessage({ command: 'deleteE2eTest' });
     });
-  }
-  attachDeleteE2eHandler(document.getElementById('deleteE2eBtn'));
 
-  // Edit E2E button — switch to Markdown textarea editing
-  function attachEditE2eHandler(btn) {
-    if (!btn) return;
-    btn.addEventListener('click', function(e) {
-      e.stopPropagation();
+    // Collapse-All for E2E (scoped to the e2e section only).
+    var toggleAllBtn = root.querySelector('#toggleAllE2eBtn');
+    if (toggleAllBtn) toggleAllBtn.addEventListener('click', function() {
       var section = document.getElementById('e2eTestSection');
-      if (!section || section.classList.contains('e2e-editing')) return;
-      section.classList.add('e2e-editing');
+      if (!section) return;
+      var scenarios = section.querySelectorAll('.toggle.e2e-scenario');
+      var allCollapsed = scenarios.length > 0 && Array.prototype.every.call(scenarios, function(s) {
+        return s.classList.contains('collapsed');
+      });
+      var collapseNext = !allCollapsed;
+      scenarios.forEach(function(s) {
+        if (collapseNext) { s.classList.add('collapsed'); }
+        else { s.classList.remove('collapsed'); }
+      });
+      toggleAllBtn.textContent = collapseNext ? 'Expand All' : 'Collapse All';
+    });
 
-      // Collect existing scenarios from DOM into Markdown text
-      var scenarios = section.querySelectorAll('.e2e-scenario');
-      var md = '';
-      scenarios.forEach(function(sc, i) {
-        var title = sc.querySelector('.toggle-title');
-        var precond = sc.querySelector('.callout.preconditions .callout-text');
-        var stepsOl = sc.querySelector('.callout.steps ol');
-        var expectedUl = sc.querySelector('.callout.expected ul');
-        if (i > 0) md += '\\n';
-        md += '### ' + (title ? title.textContent : 'Scenario') + '\\n';
-        if (precond && precond.textContent.trim()) {
-          md += '**Preconditions:** ' + precond.textContent.trim() + '\\n';
-        }
-        md += '**Steps:**\\n';
-        if (stepsOl) {
-          var items = stepsOl.querySelectorAll('li');
-          items.forEach(function(li, j) {
-            md += (j + 1) + '. ' + li.textContent + '\\n';
-          });
-        }
-        md += '**Expected:**\\n';
-        if (expectedUl) {
-          var items = expectedUl.querySelectorAll('li');
-          items.forEach(function(li) {
-            md += '- ' + li.textContent + '\\n';
-          });
+    // Per-scenario Delete.
+    root.querySelectorAll('.e2e-delete-btn').forEach(function(btn) {
+      btn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        var idx = parseInt(btn.dataset.scenarioIndex, 10);
+        var scenarioEl = document.getElementById('e2e-scenario-' + idx);
+        var titleEl = scenarioEl ? scenarioEl.querySelector('.toggle-title') : null;
+        var title = titleEl ? titleEl.textContent : '';
+        vscode.postMessage({ command: 'deleteE2eScenario', index: idx, title: title });
+      });
+    });
+
+    // Per-scenario Edit.
+    root.querySelectorAll('.e2e-edit-btn').forEach(function(btn) {
+      btn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        var idx = parseInt(btn.dataset.scenarioIndex, 10);
+        var toggle = document.getElementById('e2e-scenario-' + idx);
+        if (toggle && !toggle.classList.contains('editing')) {
+          enterE2eEditMode(toggle, idx);
         }
       });
-
-      // Save original content for cancel
-      section._originalE2eHtml = section.innerHTML;
-
-      // Replace section content with textarea + buttons (keep header)
-      var header = section.querySelector('.section-header');
-      section.innerHTML = '';
-      if (header) section.appendChild(header);
-
-      var ta = document.createElement('textarea');
-      ta.className = 'e2e-edit-area';
-      ta.value = md;
-      section.appendChild(ta);
-
-      var actions = document.createElement('div');
-      actions.className = 'e2e-edit-actions';
-      var cancelBtn = document.createElement('button');
-      cancelBtn.className = 'action-btn';
-      cancelBtn.textContent = 'Cancel';
-      var saveBtn = document.createElement('button');
-      saveBtn.className = 'action-btn primary';
-      saveBtn.textContent = 'Save';
-      actions.appendChild(cancelBtn);
-      actions.appendChild(saveBtn);
-      section.appendChild(actions);
-
-      // Auto-resize textarea
-      ta.style.height = ta.scrollHeight + 'px';
-      ta.addEventListener('input', function() {
-        ta.style.height = 'auto';
-        ta.style.height = ta.scrollHeight + 'px';
-      });
-      ta.focus();
-
-      // Cancel
-      cancelBtn.addEventListener('click', function() {
-        section.innerHTML = section._originalE2eHtml;
-        section.classList.remove('e2e-editing');
-        delete section._originalE2eHtml;
-        // Re-attach E2E handlers
-        reattachE2eHandlers();
-      });
-
-      // Save — parse Markdown back into scenarios
-      saveBtn.addEventListener('click', function() {
-        var text = ta.value;
-        var parsed = parseE2eMarkdown(text);
-        if (parsed.length === 0) {
-          ta.style.borderColor = 'var(--vscode-inputValidation-errorBorder, #f44)';
-          return;
-        }
-        saveBtn.textContent = 'Saving...';
-        saveBtn.disabled = true;
-        cancelBtn.disabled = true;
-        vscode.postMessage({ command: 'editE2eTest', scenarios: parsed });
-      });
-
-      // ESC to cancel
-      section._e2eEscHandler = function(ev) {
-        if (ev.key === 'Escape') {
-          ev.preventDefault();
-          cancelBtn.click();
-        }
-      };
-      document.addEventListener('keydown', section._e2eEscHandler);
     });
   }
-  attachEditE2eHandler(document.getElementById('editE2eBtn'));
 
   // ── Recap edit handler ─────────────────────────────────────────────────
   function attachEditRecapHandler() {
@@ -595,43 +541,125 @@ ${buildPrMessageScript()}
   }
   attachEditRecapHandler();
 
-  /** Parses Markdown text back into E2eTestScenario[] for the save handler. */
-  function parseE2eMarkdown(text) {
-    var scenarios = [];
-    var blocks = text.split(/^###\\s+/m).filter(function(b) { return b.trim().length > 0; });
-    for (var i = 0; i < blocks.length; i++) {
-      var block = blocks[i];
-      var lines = block.split('\\n');
-      var title = lines[0].trim();
-      var preconditions = '';
-      var steps = [];
-      var expected = [];
-      var mode = '';
-      for (var j = 1; j < lines.length; j++) {
-        var line = lines[j];
-        if (/^\\*\\*Preconditions:\\*\\*/.test(line)) {
-          preconditions = line.replace(/^\\*\\*Preconditions:\\*\\*\\s*/, '').trim();
-          mode = '';
-          continue;
-        }
-        if (/^\\*\\*Steps:\\*\\*/.test(line)) { mode = 'steps'; continue; }
-        if (/^\\*\\*Expected:\\*\\*/.test(line)) { mode = 'expected'; continue; }
-        var trimmed = line.trim();
-        if (!trimmed) continue;
-        if (mode === 'steps') {
-          steps.push(trimmed.replace(/^\\d+\\.\\s*/, ''));
-        } else if (mode === 'expected') {
-          expected.push(trimmed.replace(/^[-*]\\s+/, ''));
-        }
-      }
-      if (title && steps.length > 0) {
-        var sc = { title: title, steps: steps, expectedResults: expected };
-        if (preconditions) sc.preconditions = preconditions;
-        scenarios.push(sc);
-      }
+  function enterE2eEditMode(toggle, scenarioIndex) {
+    var data = JSON.parse(toggle.dataset.scenario || '{}');
+    toggle.classList.add('editing');
+    toggle.classList.remove('collapsed');
+
+    // Replace title span with input in the header (mirrors topic pattern).
+    var header = toggle.querySelector('.toggle-header');
+    var titleSpan = header.querySelector('.toggle-title');
+    toggle._originalTitleHtml = titleSpan.outerHTML;
+    var titleInput = document.createElement('input');
+    titleInput.className = 'edit-title-input';
+    titleInput.dataset.editField = 'title';
+    titleInput.value = data.title || '';
+    titleInput.style.pointerEvents = 'auto';
+    titleInput.addEventListener('click', function(e) { e.stopPropagation(); });
+    titleSpan.replaceWith(titleInput);
+
+    var content = toggle.querySelector('.toggle-content');
+    toggle._originalHtml = content.innerHTML;
+
+    var html = '';
+    for (var i = 0; i < E2E_EDIT_FIELDS.length; i++) {
+      var f = E2E_EDIT_FIELDS[i];
+      var val = data[f.key] || '';
+      html += '<div class="callout ' + f.key + '">' +
+        '<div class="callout-body">' +
+        '<div class="callout-label">' + f.label + '</div>' +
+        '<textarea class="edit-textarea" data-edit-field="' + f.key + '"' +
+        (f.placeholder ? ' placeholder="' + f.placeholder + '"' : '') +
+        '>' +
+        val.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;') +
+        '</textarea></div></div>';
     }
-    return scenarios;
+
+    html += '<div class="edit-actions">' +
+      '<button class="edit-cancel-btn">Cancel</button>' +
+      '<button class="edit-save-btn">Save</button></div>';
+
+    content.innerHTML = html;
+
+    content.querySelectorAll('.edit-textarea').forEach(function(ta) {
+      autoResize(ta);
+      ta.addEventListener('input', function() { autoResize(ta); });
+    });
+
+    content.querySelector('.edit-cancel-btn').addEventListener('click', function() {
+      exitE2eEditMode(toggle);
+    });
+
+    var saveBtn = content.querySelector('.edit-save-btn');
+    saveBtn.addEventListener('click', function() {
+      var updates = {};
+      var titleEl = toggle.querySelector('[data-edit-field="title"]');
+      updates.title = titleEl ? titleEl.value : '';
+      content.querySelectorAll('[data-edit-field]').forEach(function(el) {
+        var field = el.dataset.editField;
+        var value = el.value;
+        if (field === 'steps' || field === 'expectedResults') {
+          updates[field] = value.split('\\n').map(function(s) { return s.trim(); }).filter(function(s) { return s.length > 0; });
+        } else if (field === 'preconditions') {
+          updates[field] = value.trim(); // empty string signals clear to backend
+        }
+      });
+      // Validation: title required.
+      if (!updates.title || !updates.title.trim()) {
+        var ti = toggle.querySelector('[data-edit-field="title"]');
+        if (ti) {
+          ti.focus();
+          ti.style.borderColor = 'var(--vscode-inputValidation-errorBorder, #f44)';
+        }
+        return;
+      }
+      // Validation: at least one step required.
+      if (!updates.steps || updates.steps.length === 0) {
+        var stepsEl = content.querySelector('[data-edit-field="steps"]');
+        if (stepsEl) {
+          stepsEl.focus();
+          stepsEl.style.borderColor = 'var(--vscode-inputValidation-errorBorder, #f44)';
+        }
+        return;
+      }
+      saveBtn.textContent = 'Saving...';
+      saveBtn.disabled = true;
+      content.querySelector('.edit-cancel-btn').disabled = true;
+      vscode.postMessage({ command: 'editE2eScenario', index: scenarioIndex, updates: updates });
+    });
+
+    toggle._escHandler = function(e) {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        e.stopPropagation();
+        exitE2eEditMode(toggle);
+      }
+    };
+    document.addEventListener('keydown', toggle._escHandler);
   }
+
+  function exitE2eEditMode(toggle) {
+    if (toggle._escHandler) {
+      document.removeEventListener('keydown', toggle._escHandler);
+      delete toggle._escHandler;
+    }
+    toggle.classList.remove('editing');
+    var titleInput = toggle.querySelector('.edit-title-input');
+    if (titleInput && toggle._originalTitleHtml) {
+      var temp = document.createElement('div');
+      temp.innerHTML = toggle._originalTitleHtml;
+      titleInput.replaceWith(temp.firstChild);
+      delete toggle._originalTitleHtml;
+    }
+    var content = toggle.querySelector('.toggle-content');
+    if (toggle._originalHtml) {
+      content.innerHTML = toggle._originalHtml;
+      delete toggle._originalHtml;
+      attachCollapsibleHandlers(toggle);
+    }
+  }
+
+  attachE2eHandlers(document);
 
   // Handle E2E status messages from the extension
   window.addEventListener('message', function(event) {
@@ -639,71 +667,79 @@ ${buildPrMessageScript()}
     if (msg.command === 'e2eTestGenerating') {
       var btn = document.getElementById('generateE2eBtn') || document.getElementById('regenE2eBtn');
       if (btn) {
-        btn.textContent = 'Generating...';
+        if (btn.id === 'regenE2eBtn') {
+          btn.classList.add('generating');
+          btn.title = 'Generating...';
+        } else {
+          btn.textContent = 'Generating...';
+        }
         btn.disabled = true;
       }
     } else if (msg.command === 'e2eTestUpdated' && msg.html) {
+      // Whole-section replacement (used by Generate, section-level Delete,
+      // and per-scenario Delete since indices shift after removal).
       var section = document.getElementById('e2eTestSection');
       if (section) {
-        // Clean up ESC handler if in edit mode
-        if (section._e2eEscHandler) {
-          document.removeEventListener('keydown', section._e2eEscHandler);
-          delete section._e2eEscHandler;
-        }
-        section.classList.remove('e2e-editing');
-        // Replace entire section with server-rendered HTML (includes the outer section div + hr)
+        // Clean up any ESC handlers from scenarios currently in edit mode
+        // before the DOM nodes are discarded.
+        section.querySelectorAll('.e2e-scenario.editing').forEach(function(t) {
+          if (t._escHandler) {
+            document.removeEventListener('keydown', t._escHandler);
+          }
+        });
         var wrapper = document.createElement('div');
         wrapper.innerHTML = msg.html;
-        // The HTML contains the section div and an hr — extract the section
         var newSection = wrapper.querySelector('#e2eTestSection');
         if (newSection) {
-          // Also get the separator hr following the section
           var hr = section.nextElementSibling;
           section.replaceWith(newSection);
-          // Replace the old hr with the new one from rendered HTML
           var newHr = wrapper.querySelector('hr.separator');
           if (newHr && hr && hr.tagName === 'HR') {
             hr.replaceWith(newHr);
           } else if (newHr && !hr) {
             newSection.insertAdjacentElement('afterend', newHr);
           }
-          reattachE2eHandlers();
+          attachE2eHandlers(newSection);
         }
+      }
+    } else if (msg.command === 'e2eScenarioUpdated' && typeof msg.scenarioIndex === 'number' && msg.html) {
+      // Surgical per-scenario replacement preserves collapsed state of other scenarios.
+      var oldToggle = document.getElementById('e2e-scenario-' + msg.scenarioIndex);
+      if (oldToggle) {
+        if (oldToggle._escHandler) {
+          document.removeEventListener('keydown', oldToggle._escHandler);
+        }
+        var wasCollapsed = oldToggle.classList.contains('collapsed');
+        var wrapper = document.createElement('div');
+        wrapper.innerHTML = msg.html;
+        var newToggle = wrapper.firstElementChild;
+        if (newToggle) {
+          oldToggle.replaceWith(newToggle);
+          if (wasCollapsed) { newToggle.classList.add('collapsed'); }
+          attachE2eHandlers(newToggle);
+        }
+      }
+    } else if (msg.command === 'e2eScenarioUpdateError') {
+      // Re-enable save/cancel so the user can retry.
+      var editing = document.querySelector('.e2e-scenario.editing');
+      if (editing) {
+        var saveBtn = editing.querySelector('.edit-save-btn');
+        var cancelBtn = editing.querySelector('.edit-cancel-btn');
+        if (saveBtn) { saveBtn.textContent = 'Save'; saveBtn.disabled = false; }
+        if (cancelBtn) { cancelBtn.disabled = false; }
       }
     } else if (msg.command === 'e2eTestError') {
       var btn = document.getElementById('generateE2eBtn') || document.getElementById('regenE2eBtn');
       if (btn) {
-        btn.textContent = btn.id === 'generateE2eBtn' ? 'Generate' : '\\uD83D\\uDD04';
+        if (btn.id === 'regenE2eBtn') {
+          btn.classList.remove('generating');
+          btn.title = 'Regenerate';
+        } else {
+          btn.textContent = 'Generate';
+        }
         btn.disabled = false;
       }
-      // If in edit mode, re-enable buttons
-      var section = document.getElementById('e2eTestSection');
-      if (section && section.classList.contains('e2e-editing')) {
-        var saveBtn = section.querySelector('.action-btn.primary');
-        var cancelBtn = section.querySelector('.action-btn:not(.primary)');
-        if (saveBtn) { saveBtn.textContent = 'Save'; saveBtn.disabled = false; }
-        if (cancelBtn) { cancelBtn.disabled = false; }
-      }
     }
-
-  /** Re-attaches E2E button event handlers after DOM replacement. */
-  function reattachE2eHandlers() {
-    var section = document.getElementById('e2eTestSection');
-    if (!section) return;
-    // Re-attach toggle collapse (new DOM elements lack the global handler)
-    section.querySelectorAll('.toggle-header').forEach(function(header) {
-      header.addEventListener('click', function(e) {
-        if (e.target.closest('.topic-actions')) { return; }
-        header.parentElement.classList.toggle('collapsed');
-      });
-    });
-    // Re-attach generate/regen
-    handleGenerateE2e(document.getElementById('generateE2eBtn'));
-    handleGenerateE2e(document.getElementById('regenE2eBtn'));
-    // Re-attach edit and delete buttons
-    attachEditE2eHandler(document.getElementById('editE2eBtn'));
-    attachDeleteE2eHandler(document.getElementById('deleteE2eBtn'));
-  }
 
   // ── Plan inline edit messages ──
   if (msg.command === 'planContentLoaded' && msg.slug && msg.content !== undefined) {

--- a/vscode/src/views/SummaryWebviewPanel.handlePush.test.ts
+++ b/vscode/src/views/SummaryWebviewPanel.handlePush.test.ts
@@ -280,18 +280,23 @@ vi.mock("../util/Logger.js", () => ({
 	log: { info, warn, error: logError },
 }));
 
-const { mockBuildHtml, mockBuildE2eTestSection, mockRenderTopic } = vi.hoisted(
-	() => ({
-		mockBuildHtml: vi.fn().mockReturnValue("<html>mock</html>"),
-		mockBuildE2eTestSection: vi.fn().mockReturnValue("<div>e2e</div>"),
-		mockRenderTopic: vi.fn().mockReturnValue("<div>topic</div>"),
-	}),
-);
+const {
+	mockBuildHtml,
+	mockBuildE2eTestSection,
+	mockRenderTopic,
+	mockRenderE2eScenario,
+} = vi.hoisted(() => ({
+	mockBuildHtml: vi.fn().mockReturnValue("<html>mock</html>"),
+	mockBuildE2eTestSection: vi.fn().mockReturnValue("<div>e2e</div>"),
+	mockRenderTopic: vi.fn().mockReturnValue("<div>topic</div>"),
+	mockRenderE2eScenario: vi.fn().mockReturnValue("<div>scenario</div>"),
+}));
 
 vi.mock("./SummaryHtmlBuilder.js", () => ({
 	buildHtml: mockBuildHtml,
 	buildE2eTestSection: mockBuildE2eTestSection,
 	renderTopic: mockRenderTopic,
+	renderE2eScenario: mockRenderE2eScenario,
 }));
 
 const { mockBuildMarkdown, mockBuildPrMarkdown } = vi.hoisted(() => ({

--- a/vscode/src/views/SummaryWebviewPanel.test.ts
+++ b/vscode/src/views/SummaryWebviewPanel.test.ts
@@ -274,6 +274,7 @@ vi.mock("../services/PrCommentService.js", () => ({
 	handleCreatePr: mockHandleCreatePr,
 	handlePrepareUpdatePr: mockHandlePrepareUpdatePr,
 	handleUpdatePr: mockHandleUpdatePr,
+	wrapWithMarkers: (s: string) => `[MARKERS]${s}[/MARKERS]`,
 }));
 
 vi.mock("../util/Logger.js", () => ({
@@ -285,11 +286,13 @@ const {
 	mockBuildE2eTestSection,
 	mockBuildRecapSection,
 	mockRenderTopic,
+	mockRenderE2eScenario,
 } = vi.hoisted(() => ({
 	mockBuildHtml: vi.fn().mockReturnValue("<html>mock</html>"),
 	mockBuildE2eTestSection: vi.fn().mockReturnValue("<div>e2e</div>"),
 	mockBuildRecapSection: vi.fn().mockReturnValue("<div>recap</div>"),
 	mockRenderTopic: vi.fn().mockReturnValue("<div>topic</div>"),
+	mockRenderE2eScenario: vi.fn().mockReturnValue("<div>scenario</div>"),
 }));
 
 vi.mock("./SummaryHtmlBuilder.js", () => ({
@@ -297,6 +300,7 @@ vi.mock("./SummaryHtmlBuilder.js", () => ({
 	buildE2eTestSection: mockBuildE2eTestSection,
 	buildRecapSection: mockBuildRecapSection,
 	renderTopic: mockRenderTopic,
+	renderE2eScenario: mockRenderE2eScenario,
 }));
 
 const { mockBuildMarkdown, mockBuildPrMarkdown } = vi.hoisted(() => ({
@@ -1670,6 +1674,245 @@ describe("SummaryWebviewPanel", () => {
 			});
 		});
 
+		// ── editE2eScenario ──────────────────────────────────────────────────
+
+		describe("editE2eScenario", () => {
+			it("merges updates into the scenario at index, persists, and posts e2eScenarioUpdated", async () => {
+				const original = {
+					title: "Old",
+					preconditions: "before",
+					steps: ["s1"],
+					expectedResults: ["r1"],
+				};
+				mockRenderE2eScenario.mockReturnValue("<div>row 0</div>");
+				const dispatch = await setupPanel({ e2eTestGuide: [original] });
+
+				dispatch({
+					command: "editE2eScenario",
+					index: 0,
+					updates: { title: "New", steps: ["a", "b"] },
+				});
+				await flushPromises();
+
+				expect(mockStoreSummary).toHaveBeenCalledWith(
+					expect.objectContaining({
+						e2eTestGuide: [
+							{
+								title: "New",
+								preconditions: "before",
+								steps: ["a", "b"],
+								expectedResults: ["r1"],
+							},
+						],
+					}),
+					workspaceRoot,
+					true,
+				);
+				expect(postMessage).toHaveBeenCalledWith({
+					command: "e2eScenarioUpdated",
+					scenarioIndex: 0,
+					html: "<div>row 0</div>",
+				});
+			});
+
+			it("clears preconditions when updates omits or empties the field", async () => {
+				const original = {
+					title: "T",
+					preconditions: "old",
+					steps: ["s"],
+					expectedResults: ["r"],
+				};
+				const dispatch = await setupPanel({ e2eTestGuide: [original] });
+
+				// Empty string → backend should drop the field.
+				dispatch({
+					command: "editE2eScenario",
+					index: 0,
+					updates: { title: "T", preconditions: "" },
+				});
+				await flushPromises();
+
+				const stored = mockStoreSummary.mock.calls[0][0] as {
+					e2eTestGuide: ReadonlyArray<{ preconditions?: string }>;
+				};
+				expect(stored.e2eTestGuide[0].preconditions).toBeUndefined();
+			});
+
+			it("preserves original preconditions when updates does not mention the field", async () => {
+				const original = {
+					title: "T",
+					preconditions: "keep me",
+					steps: ["s"],
+					expectedResults: ["r"],
+				};
+				const dispatch = await setupPanel({ e2eTestGuide: [original] });
+
+				dispatch({
+					command: "editE2eScenario",
+					index: 0,
+					updates: { title: "renamed" },
+				});
+				await flushPromises();
+
+				const stored = mockStoreSummary.mock.calls[0][0] as {
+					e2eTestGuide: ReadonlyArray<{ preconditions?: string }>;
+				};
+				expect(stored.e2eTestGuide[0].preconditions).toBe("keep me");
+			});
+
+			it("returns early when summary is not loaded", async () => {
+				const dispatch = await setupPanel();
+				// no e2eTestGuide on default summary
+
+				dispatch({
+					command: "editE2eScenario",
+					index: 0,
+					updates: { title: "x" },
+				});
+				await flushPromises();
+
+				expect(mockStoreSummary).not.toHaveBeenCalled();
+			});
+
+			it("returns early when index is out of range", async () => {
+				const dispatch = await setupPanel({
+					e2eTestGuide: [
+						{ title: "only", steps: ["s"], expectedResults: ["r"] },
+					],
+				});
+
+				dispatch({
+					command: "editE2eScenario",
+					index: 5,
+					updates: { title: "x" },
+				});
+				await flushPromises();
+
+				expect(mockStoreSummary).not.toHaveBeenCalled();
+			});
+
+			it("only mutates the targeted scenario in a multi-scenario guide", async () => {
+				const a = { title: "A", steps: ["a"], expectedResults: ["ra"] };
+				const b = { title: "B", steps: ["b"], expectedResults: ["rb"] };
+				const c = { title: "C", steps: ["c"], expectedResults: ["rc"] };
+				const dispatch = await setupPanel({ e2eTestGuide: [a, b, c] });
+
+				dispatch({
+					command: "editE2eScenario",
+					index: 1,
+					updates: { title: "B-edited" },
+				});
+				await flushPromises();
+
+				const stored = mockStoreSummary.mock.calls[0][0] as {
+					e2eTestGuide: ReadonlyArray<{ title: string }>;
+				};
+				expect(stored.e2eTestGuide.map((s) => s.title)).toEqual([
+					"A",
+					"B-edited",
+					"C",
+				]);
+			});
+
+			it("treats explicit preconditions: undefined the same as empty string (clears)", async () => {
+				const original = {
+					title: "T",
+					preconditions: "old",
+					steps: ["s"],
+					expectedResults: ["r"],
+				};
+				const dispatch = await setupPanel({ e2eTestGuide: [original] });
+
+				dispatch({
+					command: "editE2eScenario",
+					index: 0,
+					updates: { title: "T", preconditions: undefined },
+				});
+				await flushPromises();
+
+				const stored = mockStoreSummary.mock.calls[0][0] as {
+					e2eTestGuide: ReadonlyArray<{ preconditions?: string }>;
+				};
+				expect(stored.e2eTestGuide[0].preconditions).toBeUndefined();
+			});
+		});
+
+		// ── deleteE2eScenario ────────────────────────────────────────────────
+
+		describe("deleteE2eScenario", () => {
+			it("removes the scenario at index after confirmation, posts e2eTestUpdated", async () => {
+				showWarningMessage.mockResolvedValue("Delete");
+				const a = { title: "A", steps: ["s"], expectedResults: ["r"] };
+				const b = { title: "B", steps: ["s"], expectedResults: ["r"] };
+				const dispatch = await setupPanel({ e2eTestGuide: [a, b] });
+
+				dispatch({ command: "deleteE2eScenario", index: 0, title: "A" });
+				await flushPromises();
+
+				expect(mockStoreSummary).toHaveBeenCalledWith(
+					expect.objectContaining({ e2eTestGuide: [b] }),
+					workspaceRoot,
+					true,
+				);
+				expect(postMessage).toHaveBeenCalledWith(
+					expect.objectContaining({ command: "e2eTestUpdated" }),
+				);
+			});
+
+			it("sets e2eTestGuide to undefined when removing the last scenario", async () => {
+				showWarningMessage.mockResolvedValue("Delete");
+				const dispatch = await setupPanel({
+					e2eTestGuide: [
+						{ title: "only", steps: ["s"], expectedResults: ["r"] },
+					],
+				});
+
+				dispatch({ command: "deleteE2eScenario", index: 0 });
+				await flushPromises();
+
+				expect(mockStoreSummary).toHaveBeenCalledWith(
+					expect.objectContaining({ e2eTestGuide: undefined }),
+					workspaceRoot,
+					true,
+				);
+			});
+
+			it("does nothing when user cancels", async () => {
+				showWarningMessage.mockResolvedValue(undefined);
+				const dispatch = await setupPanel({
+					e2eTestGuide: [{ title: "T", steps: ["s"], expectedResults: ["r"] }],
+				});
+
+				dispatch({ command: "deleteE2eScenario", index: 0 });
+				await flushPromises();
+
+				expect(mockStoreSummary).not.toHaveBeenCalled();
+			});
+
+			it("returns early when summary is not loaded", async () => {
+				const dispatch = await setupPanel();
+				// default summary has no e2eTestGuide
+
+				dispatch({ command: "deleteE2eScenario", index: 0 });
+				await flushPromises();
+
+				expect(showWarningMessage).not.toHaveBeenCalled();
+				expect(mockStoreSummary).not.toHaveBeenCalled();
+			});
+
+			it("returns early when index is out of range", async () => {
+				const dispatch = await setupPanel({
+					e2eTestGuide: [{ title: "T", steps: ["s"], expectedResults: ["r"] }],
+				});
+
+				dispatch({ command: "deleteE2eScenario", index: 99 });
+				await flushPromises();
+
+				expect(showWarningMessage).not.toHaveBeenCalled();
+				expect(mockStoreSummary).not.toHaveBeenCalled();
+			});
+		});
+
 		// ── loadPlanContent ──────────────────────────────────────────────────
 
 		describe("loadPlanContent", () => {
@@ -2060,6 +2303,43 @@ describe("SummaryWebviewPanel", () => {
 				await flushPromises();
 
 				expect(postMessage).toHaveBeenCalledWith({ command: "prCreating" });
+			});
+		});
+
+		describe("prepareCreatePr", () => {
+			it("posts prShowCreateForm with wrapped body and commit message title", async () => {
+				mockBuildPrMarkdown.mockReturnValue("# fresh body");
+				const dispatch = await setupPanel({ commitMessage: "feat: add thing" });
+
+				dispatch({ command: "prepareCreatePr" });
+				await flushPromises();
+
+				expect(mockBuildPrMarkdown).toHaveBeenCalledWith(
+					expect.objectContaining({ commitHash: "abc123" }),
+				);
+				expect(postMessage).toHaveBeenCalledWith({
+					command: "prShowCreateForm",
+					body: "[MARKERS]# fresh body[/MARKERS]",
+					title: "feat: add thing",
+				});
+			});
+
+			it("does nothing when no summary is loaded", async () => {
+				await SummaryWebviewPanel.show(
+					makeSummary(),
+					extensionUri,
+					workspaceRoot,
+				);
+				const dispatch = captureMessageHandler();
+				firstCommitPanel<{ currentSummary: null }>().currentSummary = null;
+				vi.clearAllMocks();
+
+				dispatch({ command: "prepareCreatePr" });
+				await flushPromises();
+
+				expect(postMessage).not.toHaveBeenCalledWith(
+					expect.objectContaining({ command: "prShowCreateForm" }),
+				);
 			});
 		});
 

--- a/vscode/src/views/SummaryWebviewPanel.ts
+++ b/vscode/src/views/SummaryWebviewPanel.ts
@@ -73,6 +73,7 @@ import {
 	handleCreatePr,
 	handlePrepareUpdatePr,
 	handleUpdatePr,
+	wrapWithMarkers,
 } from "../services/PrCommentService.js";
 import { log } from "../util/Logger.js";
 import { loadGlobalConfig } from "../util/WorkspaceUtils.js";
@@ -80,6 +81,7 @@ import {
 	buildE2eTestSection,
 	buildHtml,
 	buildRecapSection,
+	renderE2eScenario,
 	renderTopic,
 } from "./SummaryHtmlBuilder.js";
 import { buildMarkdown } from "./SummaryMarkdownBuilder.js";
@@ -112,6 +114,12 @@ type WebviewMessage =
 	| { command: "generateE2eTest" }
 	| { command: "editE2eTest"; scenarios: Array<E2eTestScenario> }
 	| { command: "deleteE2eTest" }
+	| {
+			command: "editE2eScenario";
+			index: number;
+			updates: Partial<E2eTestScenario>;
+	  }
+	| { command: "deleteE2eScenario"; index: number; title?: string }
 	| { command: "editPlan"; slug: string; committed?: boolean }
 	| { command: "loadPlanContent"; slug: string }
 	| { command: "savePlan"; slug: string; content: string }
@@ -126,6 +134,7 @@ type WebviewMessage =
 	| { command: "translateNote"; id: string }
 	| { command: "removeNote"; id: string; title: string }
 	| { command: "checkPrStatus" }
+	| { command: "prepareCreatePr" }
 	| { command: "createPr"; title: string; body: string }
 	| { command: "prepareUpdatePr" }
 	| { command: "updatePr"; title: string; body: string }
@@ -315,6 +324,21 @@ export class SummaryWebviewPanel {
 			case "deleteE2eTest":
 				this.catchAndShow(this.handleDeleteE2eTest(), "Delete failed");
 				break;
+			case "editE2eScenario":
+				this.catchAndShow(
+					this.handleEditE2eScenario(message.index, message.updates),
+					"E2E scenario save failed",
+					{
+						command: "e2eScenarioUpdateError",
+					},
+				);
+				break;
+			case "deleteE2eScenario":
+				this.catchAndShow(
+					this.handleDeleteE2eScenario(message.index, message.title),
+					"Delete scenario failed",
+				);
+				break;
 			case "editPlan":
 				void vscode.commands.executeCommand(
 					"jollimemory.editPlan",
@@ -430,6 +454,17 @@ export class SummaryWebviewPanel {
 					),
 					"Create PR failed",
 				);
+				break;
+			case "prepareCreatePr":
+				if (this.currentSummary) {
+					const body = wrapWithMarkers(buildPrMarkdown(this.currentSummary));
+					const title = this.currentSummary.commitMessage;
+					void this.panel.webview.postMessage({
+						command: "prShowCreateForm",
+						body,
+						title,
+					});
+				}
 				break;
 			case "prepareUpdatePr":
 				if (this.currentSummary) {
@@ -1281,7 +1316,14 @@ export class SummaryWebviewPanel {
 		this.panel.webview.postMessage({ command: "e2eTestUpdated", html });
 	}
 
-	/** Saves edited E2E test scenarios from the webview. */
+	/**
+	 * Saves edited E2E test scenarios from the webview (bulk replace).
+	 *
+	 * @deprecated Replaced by per-scenario `handleEditE2eScenario` /
+	 * `handleDeleteE2eScenario`. Kept as a defensive fallback in case any
+	 * external caller still posts `editE2eTest`; current webview UI no
+	 * longer triggers this command.
+	 */
 	private async handleEditE2eTest(
 		scenarios: Array<E2eTestScenario>,
 	): Promise<void> {
@@ -1293,6 +1335,111 @@ export class SummaryWebviewPanel {
 		const updatedSummary: CommitSummary = {
 			...summary,
 			e2eTestGuide: scenarios,
+		};
+		await storeSummary(updatedSummary, this.workspaceRoot, true);
+		this.currentSummary = updatedSummary;
+
+		const html = buildE2eTestSection(updatedSummary);
+		this.panel.webview.postMessage({ command: "e2eTestUpdated", html });
+	}
+
+	/**
+	 * Updates a single E2E scenario at the given index. Sends back a
+	 * rendered scenario row via `e2eScenarioUpdated` so the webview can
+	 * replace just that row, preserving collapsed state on other scenarios.
+	 */
+	private async handleEditE2eScenario(
+		index: number,
+		updates: Partial<E2eTestScenario>,
+	): Promise<void> {
+		const summary = this.currentSummary;
+		if (!summary || !summary.e2eTestGuide) {
+			return;
+		}
+		if (index < 0 || index >= summary.e2eTestGuide.length) {
+			log.warn(
+				"SummaryWebviewPanel",
+				"editE2eScenario: index out of range",
+				index,
+			);
+			return;
+		}
+
+		const oldScenario = summary.e2eTestGuide[index];
+		const merged: E2eTestScenario = {
+			...oldScenario,
+			...updates,
+			// Preserve required-array shape: caller may omit unchanged arrays.
+			steps: updates.steps ?? oldScenario.steps,
+			expectedResults: updates.expectedResults ?? oldScenario.expectedResults,
+		};
+		// Honor caller's intent to clear preconditions: empty/undefined value
+		// in updates means drop the field. Omitting the key keeps the old
+		// value (already handled by the spread above).
+		if (
+			"preconditions" in updates &&
+			(updates.preconditions === undefined || updates.preconditions === "")
+		) {
+			delete (merged as { preconditions?: string }).preconditions;
+		}
+
+		const newScenarios = summary.e2eTestGuide.map((s, i) =>
+			i === index ? merged : s,
+		);
+		const updatedSummary: CommitSummary = {
+			...summary,
+			e2eTestGuide: newScenarios,
+		};
+		await storeSummary(updatedSummary, this.workspaceRoot, true);
+		this.currentSummary = updatedSummary;
+
+		const html = renderE2eScenario(merged, index);
+		this.panel.webview.postMessage({
+			command: "e2eScenarioUpdated",
+			scenarioIndex: index,
+			html,
+		});
+	}
+
+	/**
+	 * Deletes a single E2E scenario at the given index. Since indices shift
+	 * after removal, sends back a full re-rendered section via
+	 * `e2eTestUpdated` (the existing whole-section replacement path).
+	 *
+	 * If the deletion empties the guide, `e2eTestGuide` is set to undefined
+	 * so the webview falls back to the "no scenarios" placeholder.
+	 */
+	private async handleDeleteE2eScenario(
+		index: number,
+		title?: string,
+	): Promise<void> {
+		const summary = this.currentSummary;
+		if (!summary || !summary.e2eTestGuide) {
+			return;
+		}
+		if (index < 0 || index >= summary.e2eTestGuide.length) {
+			log.warn(
+				"SummaryWebviewPanel",
+				"deleteE2eScenario: index out of range",
+				index,
+			);
+			return;
+		}
+
+		const scenarioTitle = title ?? summary.e2eTestGuide[index].title;
+		const choice = await vscode.window.showWarningMessage(
+			`Delete scenario "${scenarioTitle}"?`,
+			{ modal: true, detail: "This cannot be undone." },
+			"Delete",
+		);
+		if (choice !== "Delete") {
+			return;
+		}
+
+		const remaining = summary.e2eTestGuide.filter((_, i) => i !== index);
+		const updatedSummary: CommitSummary = {
+			...summary,
+			e2eTestGuide: remaining.length > 0 ? remaining : undefined,
 		};
 		await storeSummary(updatedSummary, this.workspaceRoot, true);
 		this.currentSummary = updatedSummary;


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## Quick recap

The E2E Test Guide section of the JolliMemory VSCode extension was refactored to match the interaction pattern already established by the Topics section. Previously, all E2E test scenarios could only be edited as a single bulk text block; after this work, each scenario behaves as an independent item — it can be collapsed, edited inline with per-field inputs, or deleted on its own without affecting any other scenario. The section toolbar was updated to replace the old bulk-edit button with a dedicated Collapse All button alongside the existing Regenerate and Delete controls.

Two bugs discovered during the refactor were fixed before the work was complete. Every button in the webview had become entirely unresponsive after the initial implementation — a silent script parsing failure caused by a malformed escape sequence that prevented all event handlers from registering. The fix was a one-character correction, and a new automated check was added so that any future error of this kind is caught at build time rather than discovered at runtime. A separate issue caused the Expected Results section to lose its background color when a scenario entered edit mode; this was traced to a mismatch between the class names used by the static renderer and the edit mode generator, and all three affected layers were updated to use a single consistent name.

A more impactful bug was also addressed in the "Create PR" flow. The form that lets users open a pull request was pre-populated at page load time and never updated to reflect content generated during the session — so clicking "Create PR" immediately after producing an E2E test would silently omit that test from the PR body. The fix removes the pre-computed cached values entirely. Now, when the user clicks "Create PR," the extension reads the current summary state at that moment and computes the PR body fresh before sending it to the form, ensuring the form always reflects exactly what the summary contains regardless of what was generated or edited during the session.

---

## E2E Test (4)
<details>
<summary><strong>1. Per-scenario edit button opens inline edit form</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a commit summary open in the webview that already has at least one E2E test scenario generated.

**Steps:**
1. Open the webview panel and scroll down to the "E2E Test" section.
2. Locate a scenario row and click the small pencil (✎) icon button on the right side of that scenario's header.
3. Check that the scenario expands and its title becomes a text input field.
4. Check that the content area now shows text boxes for Preconditions, Steps, and Expected Results, each pre-filled with the existing scenario data.
5. Change the title and edit one of the text boxes, then click "Save".
6. Check that the scenario row updates to show the new content without affecting any other scenarios on the page.

**Expected Results:**
- Clicking the pencil icon on a single scenario opens an inline edit form only for that scenario.
- All other scenarios remain unchanged and interactive.
- After saving, the updated scenario displays the new title and field values immediately.
- No full-page reload or section replacement occurs.

</blockquote>
</details>
<details>
<summary><strong>2. Per-scenario delete button removes only that scenario</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a commit summary open in the webview with at least two E2E test scenarios generated.

**Steps:**
1. Scroll to the "E2E Test" section and note the titles of all scenarios listed.
2. Click the trash (🗑) icon button on the second scenario's header row.
3. Confirm the deletion if a confirmation prompt appears.
4. Check the E2E Test section after the action completes.

**Expected Results:**
- Only the scenario whose delete button was clicked is removed.
- All remaining scenarios are still visible and their edit/delete buttons still work.
- The scenario count in the section header decreases by one.

</blockquote>
</details>
<details>
<summary><strong>3. Collapse All / Expand All button in E2E section header</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a commit summary open in the webview with at least two E2E test scenarios generated and at least one expanded.

**Steps:**
1. Scroll to the "E2E Test" section and confirm at least one scenario is expanded (content visible).
2. Click the "Collapse All" button in the E2E section header toolbar.
3. Check all scenario rows in the E2E section.
4. Click the button again (it should now read "Expand All").
5. Check all scenario rows again.
6. Scroll to the Topics section and verify its collapse/expand state was not affected.

**Expected Results:**
- After clicking "Collapse All", every E2E scenario row collapses so only its title header is visible, and the button label changes to "Expand All".
- After clicking "Expand All", every E2E scenario row expands again, and the button label returns to "Collapse All".
- Topics in the main Topics section are completely unaffected by this button.

</blockquote>
</details>
<details>
<summary><strong>4. All buttons remain responsive after the webview loads (silent syntax error fix)</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a commit summary open in the webview with topics, an E2E test section, and a timeline visible.

**Steps:**
1. Open the webview panel and wait for it to fully load.
2. Click the pencil (✎) edit button on any topic in the Topics section.
3. Click "Cancel" to close it, then click the "Collapse All" button in the Topics section header.
4. Click the "Collapse All" button in the E2E Test section header.
5. Click the regenerate (🔄) button in the E2E Test section header.

**Expected Results:**
- Every button responds immediately to clicks with no silent failures.
- The topic edit form opens and closes correctly.
- Both Collapse All buttons collapse their respective sections.
- The regenerate button triggers the generation flow (spinner or loading state appears).

</blockquote>
</details>

---

## Topics (4)
<details>
<summary><strong>01 · PR creation form now fetches fresh content instead of showing stale cached data</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

After generating an E2E test in the webview, clicking "Create PR" immediately afterward showed a PR body that was missing the newly generated content. The form was pre-populated at page load time and never updated to reflect anything produced during the session.

**💡 Decisions Behind the Code**

- **On-demand computation over cached DOM attributes**: The original design stored the PR title and body in hidden HTML attributes at page render time, meaning any content generated after the page opened was invisible to the form. Computing the body fresh at the moment the user clicks "Create PR" removes this entire category of staleness bug without requiring any cache-invalidation logic.
- **Lightweight backend round-trip over frontend-only recalculation**: The developer initially considered mirroring the "Edit PR" flow, which fetches the already-published PR body from GitHub before showing the form. The user correctly identified that "Create PR" has no published PR to fetch, so the chosen approach sends a message to the backend purely to access the current in-memory summary — no network I/O involved, just a synchronous read of state that already exists in memory.
- **Remove the cache entirely rather than patch it**: Rather than refreshing the cached attributes whenever new content arrived (e.g., after an E2E test was generated), the team chose to eliminate the cache altogether. A cache that must be manually invalidated on every summary change is fragile by design; computing on demand is simpler, always accurate, and removes the failure mode permanently.

**✅ What Was Implemented**

- In `PrCommentService.ts`, the "Create PR" button click handler was changed from reading pre-stored hidden attribute values to sending a message to the backend requesting fresh form data. A new `prShowCreateForm` message handler was added on the frontend to receive the computed title and body and populate the form only after the backend responds.
- In `SummaryWebviewPanel.ts`, a new `prepareCreatePr` message case was added. When triggered, it computes the PR body against the current in-memory summary state and posts it back to the webview as `prShowCreateForm`, so the form always reflects exactly what the summary contains at the moment the user opens it.
- `wrapWithMarkers` was exported from `PrCommentService.ts` so the panel handler could call it directly, keeping the marker-wrapping logic in one place rather than duplicating it.
- The pre-computed hidden data attributes on the form element were removed entirely, eliminating the cache that had to be manually invalidated whenever any part of the summary changed.

**📁 FILES**
- `vscode/src/services/PrCommentService.ts`
- `vscode/src/views/SummaryWebviewPanel.ts`
- `vscode/src/views/SummaryHtmlBuilder.ts`

</blockquote>
</details>
<details>
<summary><strong>02 · E2E test scenarios refactored to support per-scenario inline editing and deletion</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The E2E Test Guide section only allowed bulk editing of all scenarios at once as a single raw text block, which was inconsistent with the Topics section where each item could be individually edited, deleted, and collapsed. The developer wanted to bring the two sections into alignment.

**💡 Decisions Behind the Code**

- **Remove bulk editing entirely rather than keeping both modes**: Keeping a section-level bulk text editor alongside per-scenario inline editing would have created two overlapping ways to do the same thing, increasing cognitive load and button clutter. Since the Regenerate button already provides a way to wholesale replace all scenarios via the language model, the bulk editor was judged redundant and removed, leaving the toolbar clean with only Collapse All, Regenerate, and Delete.
- **Surgical per-scenario DOM replacement on save**: When a single scenario is saved, only that scenario's DOM node is swapped out rather than re-rendering the entire section. This preserves the collapsed or expanded state of all other scenarios, which would be lost in a full section replacement. The trade-off is slightly more complex message handling, but the user experience benefit of not disrupting unrelated scenarios was considered worth it.
- **One-item-per-line textarea convention for array fields**: Steps and expected results are multi-item lists, but building a dynamic add/remove UI for individual list items would have added significant complexity. Joining items with newlines and splitting on save keeps the edit form simple while remaining readable, matching the same convention already used for the files-affected field in Topics.

**✅ What Was Implemented**

- `SummaryHtmlBuilder.ts` was updated to export the single-scenario render function and embed each scenario's structured data as a JSON attribute on its DOM element, enabling the edit form to populate without a network round-trip. The section toolbar was changed to replace the bulk-edit button with a Collapse All button, and each scenario row gained its own edit and delete icon buttons.
- `SummaryScriptBuilder.ts` had roughly 150 lines of bulk Markdown editing logic removed and replaced with `attachE2eHandlers`, `enterE2eEditMode`, and `exitE2eEditMode` functions that mirror the Topics pattern — title editing in the header, per-field textareas in the content area, Save/Cancel at the bottom, ESC to cancel, and surgical per-scenario DOM replacement on save.
- `SummaryWebviewPanel.ts` gained two new message handlers: one that merges per-field updates onto the stored scenario (with explicit semantics for clearing the optional preconditions field), and one that confirms before deleting a single scenario and clears the entire guide when the last scenario is removed.

**📋 Future Enhancements**

- The detached ESC listener leak when a section-level delete or regenerate fires while a scenario is in edit mode was identified as a low-probability edge case. A partial fix was applied for the whole-section replacement path, but the scenario-level replacement path remains a follow-up.

**📁 FILES**
- `vscode/src/views/SummaryHtmlBuilder.ts`
- `vscode/src/views/SummaryScriptBuilder.ts`
- `vscode/src/views/SummaryWebviewPanel.ts`
- `vscode/src/views/SummaryCssBuilder.ts`

</blockquote>
</details>
<details>
<summary><strong>03 · Silent webview script syntax error caused all button interactions to stop working</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

After the initial E2E per-scenario editing implementation was deployed, every button in the webview was completely unresponsive — clicks on edit, delete, collapse, and regenerate all did nothing. The problem produced no visible error in tests or build output.

**💡 Decisions Behind the Code**

Adding a parse-time syntax check as a regression test was chosen because the webview script is generated as a string at build time and only parsed by the browser engine at runtime, meaning ordinary TypeScript compilation cannot catch JavaScript syntax errors inside it. Wrapping the generated output in a JavaScript function constructor call inside a unit test creates a build-time safety net that catches this entire class of error going forward, at essentially zero maintenance cost.

**✅ What Was Implemented**

A Python script used during development wrote a newline escape sequence that TypeScript interpreted as a literal newline character inside a template literal, producing a JavaScript string literal split across two lines in the generated output. This made the entire webview script unparseable at runtime, silently preventing all event handlers from registering. The fix was a one-character change to the escape sequence. A new test was also added that parses the full generated script through the JavaScript engine at build time, so any future syntax error of this kind will be caught before deployment rather than at runtime.

**📁 FILES**
- `vscode/src/views/SummaryScriptBuilder.ts`

</blockquote>
</details>
<details>
<summary><strong>04 · Edit mode lost background color on Expected Results callout due to CSS class mismatch</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

When a user entered inline edit mode on an E2E scenario, the Expected Results section lost its colored background, making it visually indistinguishable from the surrounding content.

**💡 Decisions Behind the Code**

- **Field key as the canonical CSS class name**: Rather than maintaining a separate display-oriented class name for the callout alongside the field key used in edit mode, aligning both to the field key eliminates the category of mismatch that caused this bug. It also makes the relationship between data and presentation self-documenting, so future additions of new fields are less likely to produce the same inconsistency.

**✅ What Was Implemented**

- The static HTML renderer used one CSS class name for the Expected Results callout while the edit mode JavaScript generated a different class name derived from the data field key. The CSS rules only matched the static name, so the background was absent in edit mode. All three — the static renderer, the CSS rules, and the edit mode generator — were updated to use the field key name consistently, resolving the mismatch.
- The Topics section Collapse All button was also found to be collapsing E2E scenario elements unintentionally; its selector was narrowed to explicitly exclude E2E scenario elements.

**📁 FILES**
- `vscode/src/views/SummaryCssBuilder.ts`
- `vscode/src/views/SummaryHtmlBuilder.ts`
- `vscode/src/views/SummaryScriptBuilder.ts`

</blockquote>
</details>

---

*Generated by Jolli Memory · April 29, 2026 at 3:48 PM*
<!-- jollimemory-summary-end -->