### PR TITLE
Improve recap quality, add regeneration, and deduplicate prompt rules

### DIFF
--- a/cli/src/core/PromptTemplates.test.ts
+++ b/cli/src/core/PromptTemplates.test.ts
@@ -33,6 +33,7 @@ describe("PromptTemplates", () => {
 			"commit-message",
 			"squash-message",
 			"e2e-test",
+			"recap",
 			"plan-progress",
 			"translate",
 		]);
@@ -75,6 +76,42 @@ describe("PromptTemplates", () => {
 		expect(summarize).toContain("</diff>");
 	});
 
+	it("SUMMARIZE prompt places RECAP block AFTER topic blocks in the output spec and example", () => {
+		// Phase 3: recap was moved from "before first topic" to "after final topic"
+		// so the LLM can apply the major-only rule by literal lookback at the
+		// IMPORTANCE labels it just emitted, rather than by speculation.
+		const summarize = TEMPLATES.get("summarize")?.template ?? "";
+		expect(summarize).toContain("[optional ---RECAP--- block, AFTER all topics]");
+		expect(summarize).toContain("`---RECAP---` LAST");
+		// In the rendered example, the ---RECAP--- block must appear AFTER the
+		// final ===TOPIC=== example block. Clip to just the example section
+		// (between "### Output Example" and the start of "## Rules") so rule
+		// text doesn't pollute the substring search.
+		const exampleStart = summarize.indexOf("### Output Example");
+		const rulesStart = summarize.indexOf("## Rules", exampleStart);
+		expect(exampleStart).toBeGreaterThan(0);
+		expect(rulesStart).toBeGreaterThan(exampleStart);
+		const exampleSection = summarize.slice(exampleStart, rulesStart);
+		const lastTopicIdx = exampleSection.lastIndexOf("===TOPIC===");
+		const recapIdx = exampleSection.indexOf("---RECAP---");
+		expect(lastTopicIdx).toBeGreaterThan(0);
+		expect(recapIdx).toBeGreaterThan(lastTopicIdx);
+	});
+
+	it("SUMMARIZE rule 19 narrows the recap to importance:major topics only", () => {
+		const summarize = TEMPLATES.get("summarize")?.template ?? "";
+		// New wording — recap is the major-work narrative; minor topics are
+		// excluded entirely (not even a trailing sentence).
+		expect(summarize).toContain("describes ONLY `importance: major` topics");
+		expect(summarize).toContain("MUST NOT be mentioned in the recap");
+		// All-minor commit -> omit recap entirely
+		expect(summarize).toContain("When ALL topics are `importance: minor`, omit");
+		// The old "smaller changes get a brief mention at the end" line MUST be
+		// gone — leaving it in alongside the new rule would send a contradictory
+		// soft signal that LLM might trust over the new hard signal.
+		expect(summarize).not.toContain("Smaller changes get a brief mention at the end");
+	});
+
 	it("SUMMARIZE prompt ends with a Begin-response sentinel", () => {
 		const summarize = TEMPLATES.get("summarize")?.template ?? "";
 		expect(summarize).toContain("## Begin response now");
@@ -92,6 +129,32 @@ describe("PromptTemplates", () => {
 		const identifyIdx = squash.indexOf("First, identify the distinct user goals");
 		expect(preambleIdx).toBeGreaterThan(0);
 		expect(identifyIdx).toBeGreaterThan(preambleIdx);
+	});
+
+	it("SQUASH_CONSOLIDATE prompt places RECAP block AFTER topic blocks", () => {
+		const squash = TEMPLATES.get("squash-consolidate")?.template ?? "";
+		expect(squash).toContain("[optional ---RECAP--- block, AFTER all topics]");
+		expect(squash).toContain("`---RECAP---` LAST");
+		const exampleStart = squash.indexOf("### Output Example");
+		const rulesStart = squash.indexOf("## Rules", exampleStart);
+		expect(exampleStart).toBeGreaterThan(0);
+		expect(rulesStart).toBeGreaterThan(exampleStart);
+		const exampleSection = squash.slice(exampleStart, rulesStart);
+		const lastTopicIdx = exampleSection.lastIndexOf("===TOPIC===");
+		const recapIdx = exampleSection.indexOf("---RECAP---");
+		expect(lastTopicIdx).toBeGreaterThan(0);
+		expect(recapIdx).toBeGreaterThan(lastTopicIdx);
+	});
+
+	it("SQUASH_CONSOLIDATE rule 1 narrows the recap to importance:major topics + forbids verbatim source-recap copy", () => {
+		const squash = TEMPLATES.get("squash-consolidate")?.template ?? "";
+		expect(squash).toContain("describes ONLY `importance: major` topics");
+		expect(squash).toContain("MUST NOT be mentioned in the recap");
+		expect(squash).toContain("When ALL post-merge topics are `importance: minor`");
+		// Defense against the byte-identical-recap-copy failure mode observed
+		// on commit 1bb408e (LLM copied src1's 1544-char recap verbatim).
+		expect(squash).toContain("Do NOT copy verbatim from any single source recap");
+		expect(squash).not.toContain("smaller changes get a brief trailing mention");
 	});
 
 	it("SQUASH_CONSOLIDATE prompt ends with a Begin-response sentinel", () => {
@@ -232,6 +295,56 @@ describe("PromptTemplates", () => {
 		const squash = TEMPLATES.get("squash-consolidate")?.template ?? "";
 		expect(squash).toContain("17. Trigger field on merged topics");
 		expect(squash).toContain("18. Topic ordering");
+	});
+
+	describe("RECAP standalone template", () => {
+		it("is registered at version 1", () => {
+			expect(TEMPLATES.get("recap")?.version).toBe(1);
+			expect(TEMPLATES.get("recap")?.action).toBe("recap");
+		});
+
+		it("declares exactly the expected placeholders", () => {
+			const recap = TEMPLATES.get("recap")?.template ?? "";
+			const placeholders = new Set<string>();
+			for (const match of recap.matchAll(/\{\{\s*(\w+)\s*\}\}/g)) {
+				placeholders.add(match[1]);
+			}
+			expect(placeholders).toEqual(new Set(["commitMessage", "topicsSummary"]));
+		});
+
+		it("wraps inputs in XML tags so transcript content cannot mimic the output spec", () => {
+			const recap = TEMPLATES.get("recap")?.template ?? "";
+			expect(recap).toContain("<commit-message>");
+			expect(recap).toContain("</commit-message>");
+			expect(recap).toContain("<topics>");
+			expect(recap).toContain("</topics>");
+		});
+
+		it("instructs the LLM to emit a leading ---RECAP--- marker and forbids prose preface", () => {
+			const recap = TEMPLATES.get("recap")?.template ?? "";
+			expect(recap).toContain("---RECAP---");
+			expect(recap).toContain("Output ONLY the `---RECAP---` marker");
+		});
+
+		it("carries the major-only / 2-3 topics / 150-300 words rule", () => {
+			const recap = TEMPLATES.get("recap")?.template ?? "";
+			expect(recap).toContain("2-3 highest-impact topics");
+			expect(recap).toContain("150-300 words");
+		});
+
+		it("forbids WHY in recap (decisions field owns rationale)", () => {
+			const recap = TEMPLATES.get("recap")?.template ?? "";
+			expect(recap).toContain("Do NOT explain WHY");
+		});
+
+		it("renders cleanly with the standard input set (no leftover placeholders)", () => {
+			const recap = TEMPLATES.get("recap")?.template ?? "";
+			const filled = fillTemplate(recap, {
+				commitMessage: "Add drag handle",
+				topicsSummary: "### Topic 1: Reorder\n- **Trigger:** ...\n- **Decisions:** ...",
+			});
+			expect(filled).not.toContain("{{");
+		});
 	});
 
 	it("each entry exposes action / version / template fields", () => {

--- a/cli/src/core/PromptTemplates.ts
+++ b/cli/src/core/PromptTemplates.ts
@@ -46,6 +46,112 @@ export function findUnfilledPlaceholders(
 	return [...missing];
 }
 
+// -- Shared recap content rules ----------------------------------------------
+
+/**
+ * The five language/style rules that govern recap writing across all three
+ * recap-producing templates: SUMMARIZE rule 19 (per-commit), SQUASH_CONSOLIDATE
+ * rule 1 (squash consolidation), and RECAP (standalone regenerate). Extracted
+ * because all three previously carried near-byte-identical copies and any
+ * tightening (e.g. adding the causal-connectives signal) had to be applied in
+ * three places, with high drift risk over time.
+ *
+ * Formatted with leading 2-space indentation so it splices directly into the
+ * bulleted recap-rules section of each template. The subject example is
+ * deliberately generic ("This commit (or batch of commits)...") so the same
+ * text works for both single-commit and squash recaps.
+ */
+const RECAP_LANGUAGE_RULES = `  - Subject and tense: third person, past tense, with a concrete subject. Use "The developer added...", "This commit (or batch of commits) introduced...", "The login page now ...", or "Users can now ...". FORBIDDEN subjects: "the tool", "the LLM", "the system", "the model", "the AI" -- never anthropomorphize the generator. Never "I" or "we".
+  - Describe WHAT changed and what users can now do differently. Do NOT explain WHY technical choices were made -- that belongs in the decisions field. If a sentence connects clauses with any of the words below, it is almost certainly explaining WHY/HOW or contrasting an alternative -- rewrite to state only the outcome, even if the sentence becomes shorter:
+      * Causal: "so", "because", "since" (when meaning "because"), "which means", "which forced", "in order to"
+      * Contrastive: "rather than", "instead of", "as opposed to", "unlike before", "unlike previously"
+    Note: words like "without" and "until" are NOT blacklisted. They are fine when they describe a neutral spatial / contextual fact ("without leaving the page", "until the result satisfies the user"). They become a problem only when they implicitly criticise an old path ("...there was no way to fix it without re-running the entire flow from scratch") -- which is already covered by the broader rule "do not describe before-vs-after in the recap".
+  - No code identifiers: no file paths, no function/class/variable names, no CLI flags, no inline code. Also forbidden: any internal field name or section label from this prompt or the data model (e.g. "decisions field", "topic count", "importance label", "recap block", "word ceiling", "trailing mention"). Also forbidden: references to how the generator works internally ("before labeling", "after parsing", "the tool decides", "marked as major"). The test: a colleague who uses the product but has never seen this codebase or this prompt should understand every sentence.
+  - User-facing names ARE allowed and encouraged: product names, page names ("the login page"), feature names ("article reordering"), and widely-recognized UI element names ("the sidebar", "the Settings panel").
+  - Meta-commits (changes to internal rules, prompts, configuration, or generation behavior the user does not directly interact with): describe the user-VISIBLE consequence -- what the user will see in future output or product behavior -- NOT the internal rule that changed. Translate mechanism statements like "the recap is now generated after the topic list" into user-facing outcomes like "future commit summaries will read more clearly: each recap covers fewer topics in greater depth". If you cannot identify a visible consequence for the user, this change may not warrant a recap at all.
+  - Paragraph balance: when the recap has multiple paragraphs, each paragraph MUST contain at least 2 sentences. Single-sentence paragraphs alongside longer ones produce a fragmented finish -- expand the short one with concrete detail, or merge it into an adjacent paragraph. (A whole-recap-of-one-sentence is still fine for trivial single-change commits.)
+  - Self-check (mandatory): before finalizing your output, mentally scan each sentence of your draft recap for the forbidden connectives listed above. For every match, rewrite that sentence to state only the visible outcome and drop the comparison/causation clause entirely. The lost information either belongs in the decisions field or should not be in the recap at all. If you have not done this scan, your output is not ready.`;
+
+/**
+ * Anti-patterns block: BAD/GOOD recap examples with brief annotations.
+ * Shared across all three templates and placed at the end of each template's
+ * recap-rules section. Indented to match the surrounding bulleted structure.
+ */
+const RECAP_ANTI_PATTERNS = `  Recap anti-patterns (do NOT write like this):
+  - BAD: "The way the tool selects topics was overhauled, so it can look back at what was already marked as major rather than guessing ahead."
+    Why bad: subject "the tool" anthropomorphizes the generator; "so" + "rather than" are causal connectives explaining WHY/HOW; "marked as major" is implementation-level vocabulary.
+  - BAD: "The recap block was moved after the topics, which means the LLM no longer needs to anticipate the importance label."
+    Why bad: "the LLM" forbidden subject; "the recap block" / "importance label" are internal field names; "which means" explains mechanism.
+  - GOOD: "Future commit summaries will be easier to read: each recap now focuses on the two or three most impactful changes and explains them in real depth. Single-line summaries of every topic are gone. Routine cleanup work no longer appears in the recap at all."
+    Why good: subject is the user-visible artefact ("future commit summaries"); describes WHAT the user will see; no internal vocabulary; no forbidden causal/contrastive connectives.`;
+
+// -- Shared output-format building blocks -------------------------------------
+
+/**
+ * The format-spec preamble shared verbatim by SUMMARIZE and SQUASH_CONSOLIDATE:
+ * the "Output format requirements" header, the "MUST be a delimited..." line,
+ * and the fenced shape diagram. Extracted because this block is the format
+ * contract most likely to be tightened (e.g. adding a new top-level marker)
+ * across both prompts at once, with high drift risk if duplicated.
+ */
+const OUTPUT_FORMAT_SHAPE = `**Output format requirements (READ FIRST -- the rest of this prompt depends on these being followed):**
+
+Your response MUST be a delimited plain-text document with the following shape:
+
+\`\`\`
+===SUMMARY===
+[optional ---TICKETID--- block]
+[zero or more ===TOPIC=== blocks]
+[optional ---RECAP--- block, AFTER all topics]
+\`\`\``;
+
+/**
+ * Output-Example TOPIC block skeleton with caller-supplied RESPONSE and
+ * DECISIONS bodies. The other six fields (TITLE / TRIGGER / TODO /
+ * FILESAFFECTED / CATEGORY / IMPORTANCE) are byte-identical between
+ * SUMMARIZE and SQUASH_CONSOLIDATE; only RESPONSE and DECISIONS diverge in
+ * cap (3 vs 5 bullets) and source-of-insight wording, so they're injected.
+ */
+function buildTopicExample(responseBody: string, decisionsBody: string): string {
+	return `===TOPIC===
+---TITLE---
+8-15 word concrete and searchable label for this topic
+---TRIGGER---
+1-2 sentences: the problem, bug, or need that prompted this work. Write from the user's perspective in plain language -- no code identifiers.
+---RESPONSE---
+${responseBody}
+---DECISIONS---
+${decisionsBody}
+---TODO---
+Tech debt, deferred work, or follow-up items. Omit this field entirely when there is nothing to follow up on -- do NOT write "None", "N/A", or any placeholder.
+---FILESAFFECTED---
+src/Auth.ts, src/Middleware.ts
+---CATEGORY---
+feature
+---IMPORTANCE---
+major`;
+}
+
+/**
+ * The two opening bullets of the recap content rules: topic-count selection
+ * and per-topic length / total-word target. Used by SUMMARIZE rule 19,
+ * SQUASH_CONSOLIDATE rule 1, and the standalone RECAP template. The standalone
+ * RECAP runs without a topic-list output, so it omits the "major" qualifier
+ * and the "topics list preserves them" reassurance (there is no topics list
+ * to preserve anything).
+ */
+function buildRecapHighImpactRule(opts: {
+	topicRange: string;
+	majorQualifier: boolean;
+	preserveNote: boolean;
+	wordTarget: string;
+}): string {
+	const major = opts.majorQualifier ? " major" : "";
+	const preserve = opts.preserveNote ? " -- the topics list preserves them" : "";
+	return `  - Pick the ${opts.topicRange} highest-impact${major} topics to cover; skip the rest${preserve}. Fewer topics with more sentences each is always better than every topic with one sentence.
+  - For each chosen topic, write 2-4 sentences. Target ${opts.wordTarget} words total. No hard upper limit -- let the substance drive length.`;
+}
+
 // -- Summarize template -------------------------------------------------------
 
 /**
@@ -53,7 +159,7 @@ export function findUnfilledPlaceholders(
  * a three-bucket rule (rule 6) inside the prompt itself, letting the LLM gauge
  * the diff scope and choose the appropriate range. We previously had three
  * separate templates (summarize:small/medium/large) plus a `{{topicGuidance}}`
- * placeholder filled by the CLI's diff-size bucketing — both designs were
+ * placeholder filled by the CLI's diff-size bucketing -- both designs were
  * abandoned because they leaked CLI implementation details into the prompt
  * contract and risked silent failure if any caller forgot to fill the field.
  */
@@ -78,23 +184,16 @@ Date: {{commitDate}}
 
 ## Instructions
 
-**Output format requirements (READ FIRST -- the rest of this prompt depends on these being followed):**
-
-Your response MUST be a delimited plain-text document with the following shape:
-
-\`\`\`
-===SUMMARY===
-[optional ---TICKETID--- block]
-[optional ---RECAP--- block]
-[zero or more ===TOPIC=== blocks]
-\`\`\`
+${OUTPUT_FORMAT_SHAPE}
 
 The very first non-blank line of your response MUST be \`===SUMMARY===\`. This is a fixed sentinel that marks the start of your output. Do NOT preface it with anything: no markdown headers (\`#\`, \`##\`, \`###\`, \`####\`), no markdown tables, no code fences (\`\`\`), no prose ("Here is the summary...", "## Summary"). If your response does not start with \`===SUMMARY===\` it will be rejected.
 
-After \`===SUMMARY===\` you MAY emit, in order:
-  - \`---TICKETID---\` if a ticket was referenced (rule 17)
-  - \`---RECAP---\` with a single-paragraph "Quick recap" of the commit's main work (rule 19)
-  - Zero or more \`===TOPIC===\` blocks (one per distinct user goal -- see rule 6 for count)
+After \`===SUMMARY===\` you MUST emit blocks in this strict order:
+  1. \`---TICKETID---\` first (if a ticket was referenced -- rule 17)
+  2. Zero or more \`===TOPIC===\` blocks (one per distinct user goal -- see rule 6 for count)
+  3. \`---RECAP---\` LAST (after the final \`===TOPIC===\` block -- rule 19)
+
+The recap MUST be the final block. This ordering is intentional: by the time you write the recap, every topic's \`---IMPORTANCE---\` label has already been emitted to your own output, so you can apply rule 19's "major-only" constraint by literal lookback at what you just wrote rather than by speculation.
 
 If there is nothing substantive to emit per rule 16 (trivial commit, no ticket, no substantive decisions), output \`===SUMMARY===\` alone on its own line and stop. Do NOT write prose explanations or placeholder sentinels.
 
@@ -110,33 +209,20 @@ Each topic starts with \`===TOPIC===\` on its own line, and each field starts wi
 ---TICKETID---
 PROJ-123
 
----RECAP---
-The developer added drag-handle reordering to the article sidebar with full backend persistence: articles can now be visually reordered and the new order survives a page refresh. The drag handle's styling matches the sidebar's existing icon set with grab/grabbing cursor feedback, and unit tests cover the underlying sort helper.
-
-===TOPIC===
----TITLE---
-8-15 word concrete and searchable label for this topic
----TRIGGER---
-1-2 sentences: the problem, bug, or need that prompted this work. Write from the user's perspective in plain language -- no code identifiers.
----RESPONSE---
-What was implemented or fixed -- this is a detail field, so technical precision is welcome. Name files, functions, and systems changed. ALWAYS use a bulleted list (- item) when there are 2+ distinct points. Use 2-4 sentences per point -- enough to specify what changed, not pad. A single sentence is fine for trivial single-point changes. Maximum 3 points. If the commit has more than 3 substantive changes, pick the 3 with highest impact (architectural changes, user-visible behavior changes, changes to load-bearing systems) -- do NOT merge unrelated changes into one point just to fit more in. Lower-impact changes you don't pick simply don't appear; that's the intended trade-off.
----DECISIONS---
-Why THIS approach was chosen over alternatives. ALWAYS use a bulleted list (- **Bold label**: explanation) when there are 2+ decisions -- each bullet is one decision with its rationale. Prioritize insights from the conversation: alternatives considered, constraints, trade-offs. Explain in plain language using impact dimensions (speed, safety, complexity, UX, maintainability) -- no code identifiers. Write so a teammate unfamiliar with this codebase area can follow. Use 2-4 sentences per bullet -- enough to explain the trade-off, not pad. Maximum 3 bullets. If the commit has more than 3 substantive decisions, pick the 3 with highest impact (architectural choices, user-visible behavior changes, decisions that constrain future work) -- do NOT merge unrelated decisions into one bullet just to fit more in. Lower-impact decisions you don't pick simply don't appear; that's the intended trade-off.
----TODO---
-Tech debt, deferred work, or follow-up items. Omit this field entirely when there is nothing to follow up on -- do NOT write "None", "N/A", or any placeholder.
----FILESAFFECTED---
-src/Auth.ts, src/Middleware.ts
----CATEGORY---
-feature
----IMPORTANCE---
-major
+${buildTopicExample(
+	"What was implemented or fixed -- this is a detail field, so technical precision is welcome. Name files, functions, and systems changed. ALWAYS use a bulleted list (- item) when there are 2+ distinct points. Use 2-4 sentences per point -- enough to specify what changed, not pad. A single sentence is fine for trivial single-point changes. Maximum 3 points. If the commit has more than 3 substantive changes, pick the 3 with highest impact (architectural changes, user-visible behavior changes, changes to load-bearing systems) -- do NOT merge unrelated changes into one point just to fit more in. Lower-impact changes you don't pick simply don't appear; that's the intended trade-off.",
+	"Why THIS approach was chosen over alternatives. ALWAYS use a bulleted list (- **Bold label**: explanation) when there are 2+ decisions -- each bullet is one decision with its rationale. When there is exactly one decision, write it as plain prose -- no bullet, no bold label. One decision is fine; one bullet is a formatting error. Prioritize insights from the conversation: alternatives considered, constraints, trade-offs. Explain in plain language using impact dimensions (speed, safety, complexity, UX, maintainability) -- no code identifiers. Write so a teammate unfamiliar with this codebase area can follow. Use 2-4 sentences per bullet -- enough to explain the trade-off, not pad. Maximum 3 bullets. If the commit has more than 3 substantive decisions, pick the 3 with highest impact (architectural choices, user-visible behavior changes, decisions that constrain future work) -- do NOT merge unrelated decisions into one bullet just to fit more in. Lower-impact decisions you don't pick simply don't appear; that's the intended trade-off.",
+)}
 
 ===TOPIC===
 [Repeat the ===TOPIC=== block above for each additional topic the commit warrants per rule 6's count guidance. The example shows ONE block for brevity -- do not let that anchor your output to a single topic when the diff covers multiple goals.]
 
+---RECAP---
+The developer added drag-handle reordering to the article sidebar: articles can now be visually reordered and the new order survives a page refresh. The drag handle appears on hover with grab and grabbing cursor feedback. Ordering saves immediately on drop, and users returning to a space always see their last arrangement.
+
 ## Rules
-1. The summary has two audiences. The **narrative fields** (title, trigger, decisions) are read by everyone -- write them for a developer who was NOT present in the session. Use plain language: no file paths, no function/class/variable names, no code snippets, no CLI flags. The **detail fields** (response, todo, filesAffected) are collapsed by default and read on-demand -- they MAY use technical identifiers (file names, function names, specific APIs) to describe implementation precisely.
-2. decisions is the most valuable field -- it captures reasoning that cannot be reconstructed from the diff alone. ALWAYS use a bulleted list (- **Label**: rationale) when there are 2+ decisions. Express each in terms of IMPACT and TRADE-OFFS, not code architecture. Use 2-4 sentences per bullet to actually explain the trade-off (depth over breadth). A single prose sentence is acceptable only when there is exactly one decision. Maximum 3 bullets. If there are more than 3 substantive decisions, pick the 3 with highest impact -- do NOT merge unrelated decisions into one bullet just to fit more in. Lower-impact decisions you don't pick simply don't appear; that's the intended trade-off.
+1. The summary has two audiences. The **narrative fields** (title, trigger, decisions) are read by everyone -- write them for a colleague who uses the product but was NOT present in the session and has never read this codebase. Use plain language: no file paths, no function/class/variable names, no code snippets, no CLI flags, and no implementation-level terms that only make sense if you have seen the code (e.g. internal algorithm names, internal protocol names, framework-specific concepts). The test: a product manager or designer should understand every sentence in these fields without needing an explanation. The **detail fields** (response, todo, filesAffected) are collapsed by default and read on-demand -- they MAY use technical identifiers (file names, function names, specific APIs) to describe implementation precisely.
+2. decisions is the most valuable field -- it captures reasoning that cannot be reconstructed from the diff alone. ALWAYS use a bulleted list (- **Label**: rationale) when there are 2+ decisions. When there is exactly one decision, write it as plain prose -- no bullet, no bold label. One decision is fine; one bullet is a formatting error. Express each in terms of IMPACT and TRADE-OFFS, not code architecture. Use 2-4 sentences per bullet to actually explain the trade-off (depth over breadth). Maximum 3 bullets. If there are more than 3 substantive decisions, pick the 3 with highest impact -- do NOT merge unrelated decisions into one bullet just to fit more in. Lower-impact decisions you don't pick simply don't appear; that's the intended trade-off.
 3. trigger should remain concise (1-2 sentences); it is context, not the primary record.
 4. response is a detail field -- be specific and technical. Name the files, functions, or systems changed. ALWAYS use a bulleted list (- item) when there are 2 or more distinct points. Use 2-4 sentences per point to specify what changed (depth over breadth). A single prose sentence is acceptable only for trivial single-point changes. Maximum 3 points. If there are more than 3 substantive changes, pick the 3 with highest impact -- do NOT merge unrelated changes into one point just to fit more in. Lower-impact changes you don't pick simply don't appear; that's the intended trade-off.
 5. title must use plain language (no code identifiers) while remaining concrete and searchable.
@@ -157,15 +243,18 @@ major
 16. If a change has no meaningful decision behind it (e.g. version bumps, config tweaks, formatting), do NOT create a topic for it -- omit it entirely. Every topic MUST have a substantive decisions field. Never write "No design decisions recorded" or similar placeholders. If rule 16 causes ALL topics to be omitted (the entire commit has no substantive decisions), simply emit no ===TOPIC=== sections. Other top-level sections (such as ---TICKETID--- if a ticket exists, and ---RECAP--- if that field is part of your output format) remain governed by their own rules and may still appear. If there is nothing to emit at all (no ticket, no recap, no topics), output \`===SUMMARY===\` alone on its own line and stop. Do NOT write any prose explanation or placeholder sentinel.
 17. ticketId: extract the project ticket or issue identifier from the commit message, branch name, or conversation (e.g. "PROJ-123", "FEAT-456", "#789"). Output the canonical uppercase form (e.g. "proj-123" -> "PROJ-123"). If no ticket is referenced anywhere, omit the ---TICKETID--- field entirely.
 18. NEVER use the literal strings ===SUMMARY===, ===TOPIC===, or ---FIELDNAME--- (e.g. ---TITLE---, ---RESPONSE---, ---RECAP---, ---TICKETID---) inside your content. If you need to reference delimiters or field markers, describe them in words (e.g. "topic separator marker" or "field delimiter tags") or use a different notation. The format-level markers that structure your response are required and not subject to this restriction.
-19. RECAP: Output a ---RECAP--- section before the first ===TOPIC=== if there is substantive work to narrate. Omit the section entirely otherwise -- do NOT invent content for trivial commits. Content rules:
-  - 3-8 sentences. Target 80-160 words. Favor substantive coverage over terse bullets.
-  - Plain English, third person, past tense. Use "The developer added..." / "This commit introduced..." -- never "I" or "we".
-  - No code identifiers: no file paths, no function/class/variable names, no CLI flags, no inline code.
-  - User-facing names ARE allowed and encouraged: product names, page names ("the login page"), feature names ("article reordering"), and widely-recognized UI element names ("the sidebar", "the Settings panel"). The test is whether a non-technical reader using the product would recognize the term.
-  - Lead with the most impactful change. Smaller changes get a brief mention at the end.
+19. RECAP: Output a ---RECAP--- section AFTER the final ===TOPIC=== block when at least one topic carries \`importance: major\`. Omit the section entirely otherwise -- do NOT invent content for trivial commits, and do NOT write a recap when every topic is \`importance: minor\`. Content rules:
+${buildRecapHighImpactRule({ topicRange: "2-3", majorQualifier: true, preserveNote: true, wordTarget: "150-300" })}
+${RECAP_LANGUAGE_RULES}
+  - The recap describes ONLY \`importance: major\` topics. \`importance: minor\` topics (routine formatting, config tweaks, version bumps, doc-only changes) MUST NOT be mentioned in the recap, not even briefly -- they are preserved as standalone topics for audit; the recap is the major-work narrative only.
+  - Lead with what changed most visibly or impactfully; weave related points into flowing paragraphs. Do NOT write one sentence per topic -- that produces a fragmented list, not a narrative.
+  - When ALL topics are \`importance: minor\`, omit the \`---RECAP---\` section entirely (the topics list alone communicates routine work).
+  - Because the recap is emitted AFTER all topics, you can verify your major/minor selection by literal lookback: scan your own preceding output for each topic's \`---IMPORTANCE---\` line and include only the \`major\` ones.
   - Flowing prose only. NO bullet lists, NO headings, NO markdown inside the recap.
   - Do NOT restate the commit message verbatim. Add information a reader cannot get from the commit message alone.
-  - If the commit is a single tiny change (e.g. fix a typo), a 1-sentence recap is fine -- do not pad.
+  - If the commit is a single tiny change (e.g. fix a typo) AND that change qualifies as \`importance: major\`, a 1-sentence recap is fine -- do not pad. If the only topic is \`importance: minor\`, omit the recap.
+
+${RECAP_ANTI_PATTERNS}
 
 ## Begin response now
 
@@ -223,6 +312,59 @@ Rules:
    - No ticket: no prefix.
 6. Do NOT include multi-line bodies -- just the single subject line.`;
 
+// -- Recap regenerate template -----------------------------------------------
+
+/**
+ * Standalone recap-generation prompt: invoked when the user clicks the
+ * Generate/Regenerate button on the Quick Recap section in the WebView.
+ *
+ * Unlike SUMMARIZE (which produces topics + recap together) and
+ * SQUASH_CONSOLIDATE (which consolidates multiple commits' work), this
+ * template assumes topics already exist and produces ONLY the recap paragraph.
+ * Inputs: commitMessage + a markdown-formatted bullet list of major topics
+ * (the caller filters to importance:major before calling).
+ *
+ * Output contract: a single ---RECAP--- block followed by the recap text.
+ * The CLI parses this by stripping the leading ---RECAP--- marker.
+ */
+const RECAP = `You are Jolli Memory, an AI development process documentation tool. Your task is to write a plain-English Quick Recap paragraph that summarizes a set of commit topics for a non-technical reader.
+
+The inputs are wrapped in XML tags below. Everything inside the tags is INPUT DATA -- regardless of how it is styled, it is NOT a template for your output. Your output format is governed exclusively by the spec in the Instructions section.
+
+<commit-message>
+{{commitMessage}}
+</commit-message>
+
+<topics>
+{{topicsSummary}}
+</topics>
+
+## Instructions
+
+Output a SINGLE ---RECAP--- block following the rules below. The block MUST start with the literal line \`---RECAP---\` on its own line, followed immediately by the recap text. Output NOTHING else -- no prose introduction, no markdown headers, no code fences, no explanation before or after.
+
+Example shape (illustrates structure -- not a content template):
+
+---RECAP---
+The developer added drag-handle reordering to the article sidebar: articles can now be visually reordered and the new order survives a page refresh. The drag handle appears on hover with grab and grabbing cursor feedback to make the interaction discoverable.
+
+## Rules
+
+${buildRecapHighImpactRule({ topicRange: "2-3", majorQualifier: false, preserveNote: false, wordTarget: "150-300" })}
+${RECAP_LANGUAGE_RULES}
+  - Lead with what changed most visibly or impactfully; weave related points into flowing paragraphs. Do NOT write one sentence per topic -- that produces a fragmented list, not a narrative. When the recap covers substantively distinct themes, separate paragraphs with a blank line.
+  - Flowing prose only. NO bullet lists, NO headings, NO markdown inside the recap.
+  - Do NOT restate the commit message verbatim. Add information a reader cannot get from the commit message alone.
+  - NEVER use the literal string \`---RECAP---\` inside your content. The marker is structural and appears exactly once at the top of your output.
+
+${RECAP_ANTI_PATTERNS}
+
+## Begin response now
+
+Output ONLY the \`---RECAP---\` marker followed by the recap text. No prose before or after.`;
+
+// -- E2E test template -------------------------------------------------------
+
 const E2E_TEST = `You are Jolli Memory, an AI development process documentation tool. Your task is to generate step-by-step E2E testing instructions for PR reviewers who need to manually verify this commit's changes.
 
 ## Commit Message
@@ -260,7 +402,7 @@ What the reviewer needs to have ready before testing (e.g. "Have a Space with 3+
 - The item should move to the new position
 
 ## Rules
-1. Write for a NON-TECHNICAL person -- no code, no file paths, no API names, no developer jargon.
+1. Write for a NON-TECHNICAL person -- no code, no file paths, no API names, no developer jargon. Assume the reviewer has never used or seen this feature before: describe what to open, where to navigate, and what to look for as if explaining to someone testing the product for the first time.
 2. Use everyday verbs: "open", "click", "type", "check", "scroll", "wait", "refresh".
 3. Steps must be SPECIFIC and ACTIONABLE -- not "test the feature" but "type 'hello' in the search box and press Enter".
 4. Expected results must be VERIFIABLE -- not "should work correctly" but "the page should display 3 search results".
@@ -375,23 +517,16 @@ The source commits below are presented in chronological order: Commit 1 is the o
 
 ## Instructions
 
-**Output format requirements (READ FIRST -- the rest of this prompt depends on these being followed):**
-
-Your response MUST be a delimited plain-text document with the following shape:
-
-\`\`\`
-===SUMMARY===
-[optional ---TICKETID--- block]
-[optional ---RECAP--- block]
-[zero or more ===TOPIC=== blocks]
-\`\`\`
+${OUTPUT_FORMAT_SHAPE}
 
 The very first non-blank line of your response MUST be \`===SUMMARY===\`. This is a fixed sentinel that marks the start of your output. Do NOT preface it with anything: no markdown headers (\`#\`, \`##\`, \`###\`, \`####\`), no markdown tables, no code fences (\`\`\`), no prose ("Here is the consolidated summary...", "## Squash Summary"). If your response does not start with \`===SUMMARY===\` it will be rejected.
 
-After \`===SUMMARY===\` you MAY emit, in order:
-  - \`---TICKETID---\` if a ticket was referenced
-  - \`---RECAP---\` with the consolidated recap paragraph
-  - Zero or more \`===TOPIC===\` blocks (one per consolidated user goal -- see rule 11 for count)
+After \`===SUMMARY===\` you MUST emit blocks in this strict order:
+  1. \`---TICKETID---\` first (if a ticket was referenced)
+  2. Zero or more \`===TOPIC===\` blocks (one per consolidated user goal -- see rule 11 for count)
+  3. \`---RECAP---\` LAST, after the final \`===TOPIC===\` block (rule 1)
+
+The recap MUST be the final block. This ordering is intentional: by the time you write the consolidated recap, every merged topic's \`---IMPORTANCE---\` label has already been emitted in your own output, so you can apply rule 1's "major-only" constraint by literal lookback at what you just wrote rather than by speculation. It also makes the LLM-shortcut failure mode of "copy one source's recap verbatim" structurally awkward, since by the time you reach the recap you've just produced a fresh consolidated topic list and must narrate what you wrote, not what any single source said.
 
 If every source topic is trivial and there is nothing substantive to emit (per rule 15), output \`===SUMMARY===\` alone on its own line and stop.
 
@@ -407,43 +542,35 @@ Then emit your response in the delimited plain-text format below. Each topic sta
 ---TICKETID---
 PROJ-123
 
----RECAP---
-The developer added drag-handle reordering to the article sidebar with full backend persistence: articles can now be visually reordered and the new order survives a page refresh. The drag handle's styling matches the sidebar's existing icon set with grab/grabbing cursor feedback, and unit tests cover the underlying sort helper to lock down ordering invariants.
-
-===TOPIC===
----TITLE---
-8-15 word concrete and searchable label for this topic
----TRIGGER---
-1-2 sentences: the problem, bug, or need that prompted this work. Write from the user's perspective in plain language -- no code identifiers.
----RESPONSE---
-What was implemented or fixed. This is a detail field, so technical precision is welcome. Name files, functions, and systems changed. ALWAYS use a bulleted list (- item) when there are 2+ distinct points. Use 2-4 sentences per point -- enough to specify what changed, not pad. A single sentence is fine for trivial single-point changes. Cap and selection are governed by rule 6's bullet-count guidance (squash-consolidate raises the per-topic cap to 5 vs the summarize prompt's 3, since consolidation aggregates work from multiple commits).
----DECISIONS---
-Why THIS approach was chosen over alternatives. ALWAYS use a bulleted list (- **Bold label**: explanation) when there are 2+ decisions -- each bullet is one decision with its rationale. Prioritize insights carried over from the source topics: alternatives considered, constraints, trade-offs. Explain in plain language using impact dimensions (speed, safety, complexity, UX, maintainability) -- no code identifiers. Use 2-4 sentences per bullet -- enough to explain the trade-off, not pad. Cap and selection are governed by rule 6's bullet-count guidance (max 5 per topic; pick the highest-impact decisions when consolidating yields more).
----TODO---
-Tech debt, deferred work, or follow-up items. Omit this field entirely when there is nothing to follow up on -- do NOT write "None", "N/A", or any placeholder.
----FILESAFFECTED---
-src/Auth.ts, src/Middleware.ts
----CATEGORY---
-feature
----IMPORTANCE---
-major
+${buildTopicExample(
+	"What was implemented or fixed. This is a detail field, so technical precision is welcome. Name files, functions, and systems changed. ALWAYS use a bulleted list (- item) when there are 2+ distinct points. Use 2-4 sentences per point -- enough to specify what changed, not pad. A single sentence is fine for trivial single-point changes. Cap and selection are governed by rule 6's bullet-count guidance (squash-consolidate raises the per-topic cap to 5 vs the summarize prompt's 3, since consolidation aggregates work from multiple commits).",
+	"Why THIS approach was chosen over alternatives. ALWAYS use a bulleted list (- **Bold label**: explanation) when there are 2+ decisions -- each bullet is one decision with its rationale. Prioritize insights carried over from the source topics: alternatives considered, constraints, trade-offs. Explain in plain language using impact dimensions (speed, safety, complexity, UX, maintainability) -- no code identifiers. Use 2-4 sentences per bullet -- enough to explain the trade-off, not pad. Cap and selection are governed by rule 6's bullet-count guidance (max 5 per topic; pick the highest-impact decisions when consolidating yields more).",
+)}
 
 ===TOPIC===
 [Repeat the full ===TOPIC=== block above for each independent or merged topic the consolidation produces. Squashes spanning diverse work commonly emit 5-15 topics -- see rule 11 for sizing. The example shows ONE block for brevity; do not let that anchor your output to a single topic.]
 
+---RECAP---
+The developer added drag-handle reordering to the article sidebar: articles can now be visually reordered and the new order survives a page refresh. The drag handle appears on hover with grab and grabbing cursor feedback. Ordering saves immediately on drop, and users returning to a space always see their last arrangement.
+
+A new confirmation step was added before destructive actions in the settings panel. Clicking "Delete Space" or "Archive" now presents a confirmation dialog. Accidental data loss is much less likely, and both actions share the same pattern across the panel.
+
 ## Rules
 
-1. RECAP: Output a ---RECAP--- section before the first ===TOPIC=== if there is substantive work to narrate across the squashed commits. Omit the section entirely otherwise -- do NOT invent content. Content rules:
-  - 3-8 sentences. Target 80-160 words. A squash typically warrants the higher end of this range since it covers more ground than a single commit.
-  - Plain English, third person, past tense. "The developer added...", "This batch of commits...". Never "I" or "we".
-  - No code identifiers: no file paths, no function/class/variable names, no CLI flags, no inline code.
-  - User-facing names ARE allowed and encouraged: product names, page names, feature names, and widely-recognized UI element names (e.g., "the article sidebar", "the Settings panel", "article reordering"). The test is whether a non-technical reader using the product would recognize the term.
+1. RECAP: Output a ---RECAP--- section AFTER the final ===TOPIC=== block when at least one consolidated topic carries \`importance: major\`. Omit the section entirely otherwise -- do NOT invent content, and do NOT write a recap when every consolidated topic is \`importance: minor\`. Content rules:
+${buildRecapHighImpactRule({ topicRange: "3-5", majorQualifier: true, preserveNote: true, wordTarget: "200-400" })}
+${RECAP_LANGUAGE_RULES}
+  - The consolidated recap describes ONLY \`importance: major\` topics. \`importance: minor\` topics (routine formatting, config tweaks, version bumps, doc-only changes) MUST NOT be mentioned in the recap, not even briefly -- they survive in the topics list; the recap is reserved for major-work narrative.
+  - Lead with what changed most visibly or impactfully; weave related points into flowing paragraphs. Do NOT write one sentence per topic -- that produces a fragmented list, not a narrative.
+  - When ALL post-merge topics are \`importance: minor\`, omit the \`---RECAP---\` section entirely (the topics list alone communicates routine work).
+  - Because the recap is emitted AFTER all topics, you can verify your major/minor selection by literal lookback: scan your own preceding output for each topic's \`---IMPORTANCE---\` line and include only the \`major\` ones. Do NOT copy verbatim from any single source recap; the consolidated recap MUST be a fresh synthesis driven by the \`major\` topics you just emitted, not by which input recap looked most comprehensive.
   - Deduplicate iterations: describe the FINAL state only, not the iteration history. If an earlier recap says a button was added and a later recap says it was renamed with a confirmation dialog, the consolidated recap describes the button in its final form.
   - When source iteration represents a substantive technical evolution (algorithm change, library swap, scope pivot), do NOT describe the path here -- that belongs in DECISIONS per rule 6's evolution sub-rule. RECAP is for final-state user-facing prose; the X-over-Y trade-off path lives in the structured decisions field.
   - Describe net effects (subject to rule 4's evidence requirement).
-  - Lead with impact. Most significant accomplishment first; smaller changes get a brief trailing mention if worth including.
   - Flowing prose only. NO bullet lists, NO headings, NO markdown.
   - Do NOT restate the squash commit message verbatim. Add information a reader cannot get from the commit message alone.
+
+${RECAP_ANTI_PATTERNS}
 
 2. Consolidate topics about the same feature or user goal. If commit A introduced feature X and commit B later changed how feature X works, produce ONE topic that describes feature X in its final state. Describe the outcome, not the iteration history.
 
@@ -465,7 +592,7 @@ major
 6. Decisions are the highest-value field. When merging topics, combine their decisions into one bulleted list with the most important trade-offs:
   - Deduplicate overlapping points; prefer the richer phrasing; never paraphrase away specifics like "chose X over Y because Z".
   - When source topics document an EVOLUTION of approach (e.g. an earlier commit used A, a later commit switched to B), preserve it as ONE bullet that captures both the final choice and the path: "**B over A**: tried A first, hit constraint X, switched to B which avoids X while preserving Y." This is more informative than either source's bullet alone, and avoids the failure mode of either dropping the earlier rationale or emitting two contradictory bullets.
-  - Maximum 5 bullets per topic (note: this is intentionally higher than the 3-bullet cap in the summarize prompt -- squash aggregates decisions from multiple commits). Pick the 5 with highest impact and drop the rest -- lower-impact decisions you don't pick simply don't appear, that's the intended trade-off. Use 2-4 sentences per bullet to actually explain the trade-off (depth over breadth); a single prose sentence is acceptable only when there is exactly one decision.
+  - Maximum 5 bullets per topic (note: this is intentionally higher than the 3-bullet cap in the summarize prompt -- squash aggregates decisions from multiple commits). Pick the 5 with highest impact and drop the rest -- lower-impact decisions you don't pick simply don't appear, that's the intended trade-off. Use 2-4 sentences per bullet to actually explain the trade-off (depth over breadth). When there is exactly one decision, write it as plain prose -- no bullet, no bold label. One decision is fine; one bullet is a formatting error.
 
 7. Todo handling on merge:
    - If a source topic's todo was addressed by a later commit in this squash (under rule 4's evidence standard), DROP that todo.
@@ -476,7 +603,7 @@ major
 
 9. category and importance: when merging, pick the highest-importance ("major" beats "minor") and the category that best reflects the consolidated work (prefer the later commit's category on ties).
 
-10. The narrative fields (title, trigger, decisions) are read by everyone -- write them in plain language: no file paths, no function/class/variable names, no code snippets, no CLI flags. The detail fields (response, todo, filesAffected) MAY use technical identifiers.
+10. The narrative fields (title, trigger, decisions) are read by everyone -- write them for a colleague who uses the product but has never read this codebase. Use plain language: no file paths, no function/class/variable names, no code snippets, no CLI flags, and no implementation-level terms that only make sense if you have seen the code. The test: a product manager or designer should understand every sentence in these fields without needing an explanation. The detail fields (response, todo, filesAffected) MAY use technical identifiers.
 
 11. Topic count is determined by what survives consolidation, NOT by an arbitrary range. The upper bound is the union of distinct source topics after rules 2-4 merge duplicates and drop superseded work. Every independent topic from sources MUST be carried forward (per rule 5) -- do not drop independent topics just to keep the count small. There is no artificial cap; squashes spanning diverse work may produce 10+ topics if sources warrant it. The only floor is rule 15: if every source topic is trivial, zero topics is correct.
 
@@ -489,7 +616,7 @@ major
 
 14. ticketId: extract from the squash commit message or any source topic's context. If multiple tickets appear, prefer the one on the squash commit message. Output canonical uppercase form. Omit the field entirely if no ticket is referenced.
 
-15. Return ONLY the delimited text starting with the \`===SUMMARY===\` sentinel. No JSON, no markdown fences, no prose before or after. If every source topic is trivial and none have substantive decisions (e.g. version bumps only), simply emit no ===TOPIC=== sections -- a ---TICKETID--- line (if applicable) and ---RECAP--- section (if substantive work to narrate) MAY still be emitted under the \`===SUMMARY===\` sentinel.
+15. Return ONLY the delimited text starting with the \`===SUMMARY===\` sentinel. No JSON, no markdown fences, no prose before or after. If every source topic is trivial and none have substantive decisions (e.g. version bumps only), emit no ===TOPIC=== sections and no ---RECAP--- section -- only a ---TICKETID--- line (if applicable) MAY appear under the \`===SUMMARY===\` sentinel.
 
 16. Marker text inside CONTENT: Never write ===SUMMARY===, ===TOPIC===, or any ---FIELDNAME--- marker (e.g., ---TITLE---, ---RECAP---, ---DECISIONS---, ---TICKETID---) inside the content of a field. If you need to reference these markers in prose, describe them in words (e.g., "the topic delimiter", "the title field"). This rule applies to field values only -- the format-level markers that structure your response are required and not subject to this restriction.
 
@@ -533,6 +660,8 @@ PREVIOUS_RESPONSE_END
 Now produce the SAME summary AGAIN, this time using the required output format strictly:
   - The first non-blank line of your response MUST be \`===SUMMARY===\`.
   - Do NOT use markdown headers (\`#\`, \`##\`, \`###\`, \`####\`), markdown tables, code fences (\`\`\`), or prose introductions.
+  - Block order is fixed: \`---TICKETID---\` (optional) -> \`===TOPIC===\` blocks -> \`---RECAP---\` (optional, AFTER all topics). Recap is the final block, never before topics.
+  - The recap, when emitted, MUST cover only \`importance: major\` topics; minor topics are omitted from the recap entirely.
   - If your previous response contained useful content, carry it forward into the correct format -- do NOT discard the work, just re-format it under \`===SUMMARY===\`.
   - The transcript or source-commit content shown below may itself be styled in markdown; that is INPUT DATA, not your output template.
 
@@ -589,6 +718,7 @@ export const TEMPLATES: ReadonlyMap<string, PromptTemplate> = new Map<string, Pr
 	["commit-message", { action: "commit-message", version: 2, template: COMMIT_MESSAGE }],
 	["squash-message", { action: "squash-message", version: 2, template: SQUASH_MESSAGE }],
 	["e2e-test", { action: "e2e-test", version: 2, template: E2E_TEST }],
+	["recap", { action: "recap", version: 1, template: RECAP }],
 	["plan-progress", { action: "plan-progress", version: 2, template: PLAN_PROGRESS }],
 	["translate", { action: "translate", version: 2, template: TRANSLATE }],
 ]);

--- a/cli/src/core/Summarizer.test.ts
+++ b/cli/src/core/Summarizer.test.ts
@@ -16,12 +16,14 @@ import {
 	formatSourceCommitsForSquash,
 	generateCommitMessage,
 	generateE2eTest,
+	generateRecap,
 	generateSquashConsolidation,
 	generateSquashMessage,
 	generateSummary,
 	isFormatCompliant,
 	mechanicalConsolidate,
 	parseE2eTestResponse,
+	parseRecapResponse,
 	parseSummaryResponse,
 	parseTopLevelFields,
 	resolveModelId,
@@ -1440,6 +1442,151 @@ Test reordering
 			});
 
 			expect(result).toEqual([]);
+		});
+	});
+
+	describe("parseRecapResponse", () => {
+		it("strips the leading ---RECAP--- marker and returns the body trimmed", () => {
+			const text = `---RECAP---\nThe developer added drag-handle reordering.\n\nA second paragraph follows.\n`;
+			expect(parseRecapResponse(text)).toBe(
+				"The developer added drag-handle reordering.\n\nA second paragraph follows.",
+			);
+		});
+
+		it("returns empty string for empty input", () => {
+			expect(parseRecapResponse("")).toBe("");
+			expect(parseRecapResponse("   \n\t  ")).toBe("");
+		});
+
+		it("falls back to whole text when the marker is missing", () => {
+			// Defensive against LLMs that occasionally drop the leading marker.
+			expect(parseRecapResponse("The developer added X.")).toBe("The developer added X.");
+		});
+
+		it("strips an echoed closing ---RECAP--- marker if the model wraps the body", () => {
+			const text = `---RECAP---\nA recap paragraph.\n---RECAP---\n`;
+			expect(parseRecapResponse(text)).toBe("A recap paragraph.");
+		});
+
+		it("handles surrounding whitespace before the marker", () => {
+			const text = `\n\n   \n---RECAP---\nText after whitespace.\n`;
+			expect(parseRecapResponse(text)).toBe("Text after whitespace.");
+		});
+	});
+
+	describe("generateRecap", () => {
+		it("returns the parsed recap and skips the diff in the LLM payload", async () => {
+			mockCallLlm.mockResolvedValueOnce(
+				summaryLlmResult("---RECAP---\nThe developer reorganised the article sidebar."),
+			);
+
+			const recap = await generateRecap({
+				topics: mockTopics,
+				commitMessage: "Refactor sidebar",
+				config: mockConfig,
+			});
+
+			expect(recap).toBe("The developer reorganised the article sidebar.");
+			expect(mockCallLlm).toHaveBeenCalledWith(
+				expect.objectContaining({
+					action: "recap",
+					params: expect.objectContaining({
+						commitMessage: "Refactor sidebar",
+						topicsSummary: expect.stringContaining("Add drag-to-reorder for articles"),
+					}),
+				}),
+			);
+			const calls = mockCallLlm.mock.calls as unknown as ReadonlyArray<[{ params: Record<string, unknown> }]>;
+			// Recap re-generation deliberately does NOT pass the diff (token-saving;
+			// recap is a narrative over already-extracted topics, not fresh code analysis).
+			expect(calls[0][0].params).not.toHaveProperty("diff");
+		});
+
+		it("formats topicsSummary using narrative fields only (no response field leakage)", async () => {
+			mockCallLlm.mockResolvedValueOnce(summaryLlmResult("---RECAP---\nx"));
+
+			await generateRecap({
+				topics: mockTopics,
+				commitMessage: "msg",
+				config: mockConfig,
+			});
+
+			const calls = mockCallLlm.mock.calls as unknown as ReadonlyArray<[{ params: Record<string, string> }]>;
+			const summary = calls[0][0].params.topicsSummary;
+			// Title, Trigger, Decisions are present (narrative).
+			expect(summary).toContain("Add drag-to-reorder for articles");
+			expect(summary).toContain("**Trigger:** Users wanted to reorder articles");
+			expect(summary).toContain("**Decisions:** Used a simple swap algorithm");
+			// Response is implementation-detail and must not appear.
+			expect(summary).not.toContain("Implemented drag-and-drop reordering via the chat agent");
+		});
+
+		it("filters out minor topics before sending to the LLM", async () => {
+			mockCallLlm.mockResolvedValueOnce(summaryLlmResult("---RECAP---\ny"));
+
+			await generateRecap({
+				topics: [
+					{
+						title: "Major change",
+						trigger: "t",
+						response: "r",
+						decisions: "d",
+						importance: "major",
+					},
+					{
+						title: "Tiny tweak",
+						trigger: "t",
+						response: "r",
+						decisions: "d",
+						importance: "minor",
+					},
+				],
+				commitMessage: "Mixed",
+				config: mockConfig,
+			});
+
+			const calls = mockCallLlm.mock.calls as unknown as ReadonlyArray<[{ params: Record<string, string> }]>;
+			const summary = calls[0][0].params.topicsSummary;
+			expect(summary).toContain("Major change");
+			expect(summary).not.toContain("Tiny tweak");
+		});
+
+		it("returns empty string and skips the LLM call when every topic is minor", async () => {
+			const result = await generateRecap({
+				topics: [
+					{ title: "x", trigger: "t", response: "r", decisions: "d", importance: "minor" },
+					{ title: "y", trigger: "t", response: "r", decisions: "d", importance: "minor" },
+				],
+				commitMessage: "Trivia only",
+				config: mockConfig,
+			});
+
+			expect(result).toBe("");
+			expect(mockCallLlm).not.toHaveBeenCalled();
+		});
+
+		it("returns empty string when the LLM produces no text", async () => {
+			mockCallLlm.mockResolvedValueOnce(summaryLlmResult("", { text: null as unknown as string }));
+
+			const result = await generateRecap({
+				topics: mockTopics,
+				commitMessage: "msg",
+				config: mockConfig,
+			});
+
+			expect(result).toBe("");
+		});
+
+		it("uses the configured model alias", async () => {
+			mockCallLlm.mockResolvedValueOnce(summaryLlmResult("---RECAP---\ntext"));
+
+			await generateRecap({
+				topics: mockTopics,
+				commitMessage: "msg",
+				config: { model: "haiku" },
+			});
+
+			expect(mockCallLlm).toHaveBeenCalledWith(expect.objectContaining({ model: "claude-haiku-4-5-20251001" }));
 		});
 	});
 

--- a/cli/src/core/Summarizer.ts
+++ b/cli/src/core/Summarizer.ts
@@ -910,6 +910,88 @@ export async function generateE2eTest(params: E2eTestParams): Promise<ReadonlyAr
 	return scenarios;
 }
 
+// --- Recap regeneration ------------------------------------------------------
+
+/** Parameters for the standalone recap regeneration call. */
+export interface RecapParams {
+	readonly topics: ReadonlyArray<TopicSummary>;
+	readonly commitMessage: string;
+	/** LLM credentials and model selection loaded by the caller. */
+	readonly config: LlmConfig;
+}
+
+/**
+ * Extracts the recap text from a `RECAP` template response.
+ *
+ * The expected output starts with a `---RECAP---` marker on its own line
+ * followed by the recap paragraph(s). This function:
+ *   1. Finds the marker and returns everything after it (trimmed).
+ *   2. Falls back to the whole response if the marker is missing -- some LLMs
+ *      occasionally drop the leading delimiter when the rest of the prompt
+ *      has been internalised. Treating that as the recap text is safer than
+ *      returning empty (the caller can still display whatever was generated).
+ *   3. Strips a trailing `---RECAP---` if the model echoes it at the bottom
+ *      (defensive against the model wrapping the content in a closing tag).
+ */
+export function parseRecapResponse(text: string): string {
+	const trimmed = text.trim();
+	if (!trimmed) return "";
+
+	const markerRe = /^\s*---RECAP---\s*$/m;
+	const match = markerRe.exec(trimmed);
+	const body = match ? trimmed.slice(match.index + match[0].length) : trimmed;
+
+	// Drop any echoed closing marker so we don't render it as content.
+	return body.replace(/^\s*---RECAP---\s*$/m, "").trim();
+}
+
+/**
+ * Generates a single Quick Recap paragraph for an existing commit summary.
+ *
+ * Topics are filtered to `importance: major` (legacy topics without the field
+ * are included) before being formatted as the prompt's `topicsSummary` input.
+ * Returns an empty string when no major topics exist -- the caller decides
+ * whether to keep or clear an existing recap in that case.
+ *
+ * Unlike `generateE2eTest`, this call does NOT take the diff: the recap is a
+ * narrative over already-extracted topics, not a fresh analysis of code.
+ * Keeping the diff out of the input also keeps token cost low for an action
+ * users may invoke repeatedly until the wording feels right.
+ */
+export async function generateRecap(params: RecapParams): Promise<string> {
+	log.info("Regenerating recap for: %s", params.commitMessage.substring(0, 60));
+
+	const { config } = params;
+	const majorTopics = params.topics.filter((t) => t.importance !== "minor");
+	if (majorTopics.length === 0) {
+		log.info("Recap regenerate: no major topics -- returning empty recap");
+		return "";
+	}
+
+	// The narrative fields (title, trigger, decisions) are what the recap is
+	// built from; response is a detail field and would push the LLM toward
+	// implementation-level prose, which the recap rules explicitly forbid.
+	const topicsSummary = majorTopics
+		.map((t, i) => `### Topic ${i + 1}: ${t.title}\n- **Trigger:** ${t.trigger}\n- **Decisions:** ${t.decisions}`)
+		.join("\n\n");
+
+	const llmResult = await callLlm({
+		action: "recap",
+		params: {
+			commitMessage: params.commitMessage,
+			topicsSummary,
+		},
+		maxTokens: DEFAULT_MAX_TOKENS,
+		apiKey: config.apiKey,
+		model: resolveModelId(config.model),
+		jolliApiKey: config.jolliApiKey,
+	});
+
+	const recap = parseRecapResponse(llmResult.text ?? "");
+	log.info("Recap regenerate: produced %d chars from %d major topic(s)", recap.length, majorTopics.length);
+	return recap;
+}
+
 // --- Translation --------------------------------------------------------------
 
 /** Parameters for the translateToEnglish function. */

--- a/cli/src/core/SummaryStore.test.ts
+++ b/cli/src/core/SummaryStore.test.ts
@@ -2229,5 +2229,124 @@ describe("SummaryStore", () => {
 			expect(sources[0]?.commitHash).toBe("v4abc");
 			expect(sources[0]?.topics.map((t) => t.title)).toEqual(["v4-topic"]);
 		});
+
+		it("carries ticketId and recap from v4 unified-hoist root onto the source", () => {
+			const v4Summary: CommitSummary = {
+				version: 4,
+				commitHash: "v4withMeta",
+				commitMessage: "Squash with meta",
+				commitAuthor: "Dev",
+				commitDate: "2026-01-01T00:00:00Z",
+				branch: "main",
+				generatedAt: "2026-01-01T00:00:05Z",
+				transcriptEntries: 0,
+				stats: { filesChanged: 0, insertions: 0, deletions: 0 },
+				ticketId: "PROJ-123",
+				recap: "The developer added drag-handle reordering.",
+				topics: [{ title: "x", detail: "d", decisions: undefined }],
+			};
+
+			const sources = expandSourcesForConsolidation(v4Summary);
+
+			expect(sources).toHaveLength(1);
+			expect(sources[0]?.ticketId).toBe("PROJ-123");
+			expect(sources[0]?.recap).toBe("The developer added drag-handle reordering.");
+		});
+
+		it("carries ticketId and recap from v3 children onto each source", () => {
+			const child1: CommitSummary = {
+				...leaf("c1", ["t1"]),
+				ticketId: "FEAT-1",
+				recap: "Recap for child 1.",
+			};
+			const child2: CommitSummary = {
+				...leaf("c2", ["t2"]),
+				// Intentionally no ticketId / recap to exercise the falsy branch
+				// of the conditional spreads on lines 458 / 460.
+			};
+			const root: CommitSummary = {
+				...leaf("root", []),
+				children: [child1, child2],
+			};
+
+			const sources = expandSourcesForConsolidation(root);
+
+			expect(sources).toHaveLength(2);
+			expect(sources.find((s) => s.commitHash === "c1")?.ticketId).toBe("FEAT-1");
+			expect(sources.find((s) => s.commitHash === "c1")?.recap).toBe("Recap for child 1.");
+			expect(sources.find((s) => s.commitHash === "c2")?.ticketId).toBeUndefined();
+			expect(sources.find((s) => s.commitHash === "c2")?.recap).toBeUndefined();
+		});
+
+		it("appends a legacy v3 amend root carrying its own topics + recap + ticketId as an extra source", () => {
+			// v3 amend pattern: the root commit has children (from prior commits) AND
+			// its own delta topics/recap/ticketId left behind by the amend operation.
+			// Without this branch, the root delta would be silently dropped during squash.
+			const child: CommitSummary = leaf("child", ["child-topic"]);
+			const amendRoot: CommitSummary = {
+				...leaf("amend-root", ["root-delta-topic"]),
+				ticketId: "AMEND-9",
+				recap: "Recap left on the amend root.",
+				children: [child],
+			};
+
+			const sources = expandSourcesForConsolidation(amendRoot);
+
+			expect(sources).toHaveLength(2);
+			const rootSource = sources.find((s) => s.commitHash === "amend-root");
+			expect(rootSource).toBeDefined();
+			expect(rootSource?.ticketId).toBe("AMEND-9");
+			expect(rootSource?.recap).toBe("Recap left on the amend root.");
+			expect(rootSource?.topics.map((t) => t.title)).toEqual(["root-delta-topic"]);
+		});
+
+		it("appends a legacy v3 amend root with only recap (no ticketId, no own topics) so the recap survives", () => {
+			// Edge case: rootHasOwnData triggers when topics OR recap is present.
+			// Without recap on the amend root and no own topics, the branch should
+			// NOT trigger and the source list should match children only.
+			const child: CommitSummary = leaf("child", ["child-topic"]);
+			const recapOnlyRoot: CommitSummary = {
+				...leaf("recap-only-root", []),
+				recap: "Only a recap here.",
+				children: [child],
+			};
+
+			const sources = expandSourcesForConsolidation(recapOnlyRoot);
+
+			expect(sources).toHaveLength(2);
+			const rootSource = sources.find((s) => s.commitHash === "recap-only-root");
+			expect(rootSource?.recap).toBe("Only a recap here.");
+			expect(rootSource?.ticketId).toBeUndefined();
+		});
+
+		it("handles a legacy v3 amend root where topics is undefined (not [])", () => {
+			// rootHasOwnData uses optional chaining `oldSummary.topics?.length`
+			// which yields undefined when topics is not set; the `?? 0` fallback
+			// then gates on recap. The legacy carry-over also relies on
+			// `topics: oldSummary.topics ?? []` to materialise the empty array.
+			// This test exercises both nullish-coalesce branches.
+			const child: CommitSummary = leaf("child", ["child-topic"]);
+			const noTopicsRoot: CommitSummary = {
+				version: 3,
+				commitHash: "no-topics-root",
+				commitMessage: "Amend with only recap",
+				commitAuthor: "Dev",
+				commitDate: "2026-01-01T00:00:00Z",
+				branch: "main",
+				generatedAt: "2026-01-01T00:00:05Z",
+				transcriptEntries: 0,
+				stats: { filesChanged: 0, insertions: 0, deletions: 0 },
+				// Intentionally omit `topics` -- exercises optional-chain undefined
+				recap: "Recap on a topic-less root.",
+				children: [child],
+			};
+
+			const sources = expandSourcesForConsolidation(noTopicsRoot);
+
+			expect(sources).toHaveLength(2);
+			const rootSource = sources.find((s) => s.commitHash === "no-topics-root");
+			expect(rootSource?.topics).toEqual([]);
+			expect(rootSource?.recap).toBe("Recap on a topic-less root.");
+		});
 	});
 });

--- a/vscode/src/views/SummaryCssBuilder.ts
+++ b/vscode/src/views/SummaryCssBuilder.ts
@@ -397,8 +397,9 @@ export function buildCss(): string {
     display: none;
   }
 
-  /* ── E2E Test Guide ── */
-  .e2e-placeholder {
+  /* ── Empty-state placeholder text (E2E Test Guide, Quick recap, Plans & Notes) ── */
+  .e2e-placeholder,
+  .recap-placeholder {
     color: var(--vscode-descriptionForeground);
     font-size: 0.92em;
     line-height: 1.5;

--- a/vscode/src/views/SummaryHtmlBuilder.test.ts
+++ b/vscode/src/views/SummaryHtmlBuilder.test.ts
@@ -800,21 +800,34 @@ describe("SummaryHtmlBuilder", () => {
 	// ─── buildRecapSection ───────────────────────────────────────────────────
 
 	describe("buildRecapSection", () => {
-		it("returns empty string when recap is undefined", () => {
-			expect(buildRecapSection(undefined)).toBe("");
+		it("renders State 1 (placeholder + Generate button) when recap is undefined", () => {
+			const html = buildRecapSection(undefined);
+			expect(html).toContain('id="recapSection"');
+			expect(html).toContain('id="generateRecapBtn"');
+			expect(html).toContain("Quick recap");
+			expect(html).toContain("recap-placeholder");
+			// State 1 has no Edit / Regenerate / data-raw / recap-body
+			expect(html).not.toContain('id="editRecapBtn"');
+			expect(html).not.toContain('id="regenerateRecapBtn"');
+			expect(html).not.toContain("data-raw=");
+			expect(html).not.toContain("recap-body");
 		});
 
-		it("returns empty string when recap is whitespace-only", () => {
-			expect(buildRecapSection("   \n  \t  ")).toBe("");
+		it("renders State 1 when recap is whitespace-only (treated as empty)", () => {
+			const html = buildRecapSection("   \n  \t  ");
+			expect(html).toContain('id="generateRecapBtn"');
+			expect(html).not.toContain('id="editRecapBtn"');
 		});
 
-		it("renders the section with edit button and trailing separator", () => {
+		it("renders State 2 (recap body with Edit + Regenerate buttons) when recap is present", () => {
 			const html = buildRecapSection("This commit added a recap field.");
 			expect(html).toContain('id="recapSection"');
 			expect(html).toContain("Quick recap");
 			expect(html).toContain('id="editRecapBtn"');
+			expect(html).toContain('id="regenerateRecapBtn"');
 			expect(html).toContain('class="recap-body"');
 			expect(html).toContain("This commit added a recap field.");
+			expect(html).not.toContain('id="generateRecapBtn"');
 			expect(html.trimEnd().endsWith('<hr class="separator" />')).toBe(true);
 		});
 
@@ -823,6 +836,19 @@ describe("SummaryHtmlBuilder", () => {
 			// data-raw uses escAttr (mocked to identity here), the body uses escHtml.
 			// The point of the assertion is that data-raw exists and carries the value.
 			expect(html).toContain('data-raw="Recap with <html> & special chars"');
+		});
+
+		it("splits multi-paragraph recaps on blank lines into separate <p> elements", () => {
+			const html = buildRecapSection("First paragraph.\n\nSecond paragraph.");
+			// Two <p> tags inside the body, each holding one paragraph
+			expect(html).toContain("<p>First paragraph.</p>");
+			expect(html).toContain("<p>Second paragraph.</p>");
+		});
+
+		it("collapses 3+ consecutive newlines to a single paragraph break", () => {
+			const html = buildRecapSection("A.\n\n\n\nB.");
+			expect(html).toContain("<p>A.</p>");
+			expect(html).toContain("<p>B.</p>");
 		});
 	});
 
@@ -839,10 +865,14 @@ describe("SummaryHtmlBuilder", () => {
 			expect(recapIdx).toBeLessThan(prIdx);
 		});
 
-		it("omits the recap section entirely when summary has no recap", () => {
+		it("renders the State 1 placeholder when summary has no recap (so Generate button is reachable)", () => {
 			const html = buildHtml(makeSummary({ recap: undefined }));
-			expect(html).not.toContain("recapSection");
-			expect(html).not.toContain("editRecapBtn");
+			// recapSection is always present now; what differs between states is
+			// which buttons appear and whether recap-body / data-raw exist.
+			expect(html).toContain('id="recapSection"');
+			expect(html).toContain('id="generateRecapBtn"');
+			expect(html).not.toContain('id="editRecapBtn"');
+			expect(html).not.toContain('id="regenerateRecapBtn"');
 		});
 	});
 

--- a/vscode/src/views/SummaryHtmlBuilder.ts
+++ b/vscode/src/views/SummaryHtmlBuilder.ts
@@ -271,30 +271,54 @@ function buildHeader(
 // ─── Quick recap section ────────────────────────────────────────────────────
 
 /**
- * Builds the Quick recap section. Returns an empty string when no recap is
- * present so the surrounding template doesn't render an empty wrapper.
+ * Builds the Quick recap section.
  *
- * Reuses the same `.section` / `.section-header` shell as the topics block so
- * the visual rhythm of the page is unchanged. The recap body is wrapped in
- * `.recap-body` for callout-style styling defined in SummaryCssBuilder.
+ * Two states:
+ *   1. No recap: render a placeholder + Generate button so the user can
+ *      trigger a one-shot recap LLM call without re-running the full summarize.
+ *   2. With recap: render the recap body (split on blank lines into paragraphs)
+ *      plus Edit and Regenerate buttons.
  *
- * Includes an inline edit button (consistent with E2E section's pencil-icon
- * pattern). Click toggles `.recap-editing` state which the SummaryScriptBuilder
- * handles by replacing the body with a textarea + Save/Cancel buttons. The
- * raw recap text is stashed in `data-raw` so the editor restores the unescaped
- * source rather than the HTML-escaped display version.
+ * The raw recap text is stashed in `data-raw` so the inline editor restores
+ * the unescaped source rather than the HTML-escaped display version.
+ *
+ * Paragraph splitting on `\n\n` is defensive: the LLM may emit one or several
+ * paragraphs depending on how many topics it weaves in, and HTML collapses
+ * whitespace by default so a textual blank line would otherwise disappear.
  */
 export function buildRecapSection(recap: string | undefined): string {
 	const trimmed = recap?.trim();
-	if (!trimmed) return "";
+
+	if (!trimmed) {
+		// State 1: no recap yet. Always show the Generate button. If the commit
+		// has no `importance: major` topics, the handler short-circuits and
+		// surfaces a toast instead of producing an empty recap; storage stays
+		// untouched in that case so existing recaps are never destroyed.
+		return `
+<div class="section recap-section" id="recapSection">
+  <div class="section-header">
+    <div class="section-title">&#x1F4D6; Quick recap</div>
+  </div>
+  <p class="recap-placeholder">Generate a recap that highlights the major work in this commit.</p>
+  <button class="action-btn" id="generateRecapBtn">&#x2728; Generate</button>
+</div>
+<hr class="separator" />`;
+	}
+
+	// State 2: recap exists. Render body + Edit/Regenerate buttons.
+	const bodyHtml = trimmed
+		.split(/\n\n+/)
+		.map((p) => `<p>${escHtml(p.trim())}</p>`)
+		.join("");
 	return `<div class="section recap-section" id="recapSection" data-raw="${escAttr(trimmed)}">
   <div class="section-header">
     <div class="section-title">&#x1F4D6; Quick recap</div>
     <span class="topic-actions">
       <button class="topic-action-btn" id="editRecapBtn" title="Edit recap">✎</button>
+      <button class="topic-action-btn" id="regenerateRecapBtn" title="Regenerate">&#x21BB;</button>
     </span>
   </div>
-  <div class="recap-body">${escHtml(trimmed)}</div>
+  <div class="recap-body">${bodyHtml}</div>
 </div>
 <hr class="separator" />`;
 }

--- a/vscode/src/views/SummaryScriptBuilder.test.ts
+++ b/vscode/src/views/SummaryScriptBuilder.test.ts
@@ -34,6 +34,24 @@ describe("SummaryScriptBuilder", () => {
 		expect(script).toContain("classList.toggle");
 	});
 
+	it("toggle-header binding is idempotent and reused by E2E re-render path", () => {
+		// E2E section is replaced wholesale on e2eTestUpdated / e2eScenarioUpdated;
+		// new headers must get the click handler too. Guarded by a `_toggleAttached`
+		// marker so both the page-level pass and attachE2eHandlers can call the
+		// shared helper without double-binding.
+		expect(script).toContain("function attachToggleHeader");
+		expect(script).toContain("_toggleAttached");
+		// The shared helper is invoked by attachE2eHandlers on its root parameter.
+		// We assert the call exists inside the function body by locating it after
+		// the function definition.
+		const e2eHandlerStart = script.indexOf("function attachE2eHandlers");
+		expect(e2eHandlerStart).toBeGreaterThan(0);
+		const e2eHandlerSection = script.slice(e2eHandlerStart);
+		expect(e2eHandlerSection).toContain(
+			"querySelectorAll('.toggle-header').forEach(attachToggleHeader)",
+		);
+	});
+
 	it("contains hash copy functionality", () => {
 		expect(script).toContain(".hash-copy");
 		expect(script).toContain("navigator.clipboard.writeText");

--- a/vscode/src/views/SummaryScriptBuilder.ts
+++ b/vscode/src/views/SummaryScriptBuilder.ts
@@ -18,13 +18,17 @@ export function buildScript(): string {
 	return `
   const vscode = acquireVsCodeApi();
 
-  // Toggle expand/collapse for individual memory sections (skip clicks on action buttons)
-  document.querySelectorAll('.toggle-header').forEach(function(header) {
+  // Toggle expand/collapse for individual memory sections (skip clicks on action buttons).
+  // Idempotent so attachE2eHandlers can safely revisit headers after section replacement.
+  function attachToggleHeader(header) {
+    if (header._toggleAttached) { return; }
+    header._toggleAttached = true;
     header.addEventListener('click', function(e) {
       if (e.target.closest('.topic-actions')) { return; }
       header.parentElement.classList.toggle('collapsed');
     });
-  });
+  }
+  document.querySelectorAll('.toggle-header').forEach(attachToggleHeader);
 
   // Hash copy button: copy full commit hash to clipboard inline
   document.querySelectorAll('.hash-copy').forEach(function(btn) {
@@ -156,7 +160,7 @@ ${buildPrMessageScript()}
       }
     }
 
-    // ── Recap edit status ──
+    // ── Recap edit / generate status ──
     if (msg.command === 'recapUpdated' && msg.html) {
       // Server re-renders the whole recap section so we get the canonical HTML
       // (handles the empty-recap → section-removed case automatically too).
@@ -175,16 +179,36 @@ ${buildPrMessageScript()}
           var nodes = Array.prototype.slice.call(recapWrap.childNodes).filter(function(n) { return n.nodeType === 1; });
           if (oldSep && oldSep.tagName === 'HR') oldSep.remove();
           oldRecap.replaceWith.apply(oldRecap, nodes);
+          // Reattach BOTH handlers: edit (state-2 only) and generate/regen
+          // (state-1 has only Generate button, state-2 has only Regenerate).
+          // Both attach functions internally null-check the buttons so calling
+          // them in either state is safe.
           attachEditRecapHandler();
+          attachGenerateRecapHandler();
         }
       }
     } else if (msg.command === 'recapUpdateError') {
+      // Edit-mode failure — restore Save/Cancel button state.
       var editingRecap = document.querySelector('.recap-section.recap-editing');
       if (editingRecap) {
         var rSave = editingRecap.querySelector('.recap-edit-actions .primary');
         var rCancel = editingRecap.querySelector('.recap-edit-actions .action-btn');
         if (rSave) { rSave.textContent = 'Save'; rSave.disabled = false; }
         if (rCancel) { rCancel.disabled = false; }
+      }
+      // Generate-mode failure — restore button labels and clear the
+      // .generating spinning state on the regen icon. The section is
+      // never simultaneously editing and generating, so this is independent.
+      var genBtn2 = document.getElementById('generateRecapBtn');
+      var regenBtn2 = document.getElementById('regenerateRecapBtn');
+      if (genBtn2) {
+        genBtn2.textContent = '\\u2728 Generate';
+        genBtn2.disabled = false;
+      }
+      if (regenBtn2) {
+        regenBtn2.classList.remove('generating');
+        regenBtn2.title = 'Regenerate';
+        regenBtn2.disabled = false;
       }
     }
   });
@@ -399,6 +423,10 @@ ${buildPrMessageScript()}
   function attachE2eHandlers(root) {
     if (!root) return;
 
+    // Re-bind toggle-header click on freshly-rendered scenarios — the page-level
+    // attach pass runs once on script load and misses elements inserted later.
+    root.querySelectorAll('.toggle-header').forEach(attachToggleHeader);
+
     // Generate / Regenerate (placeholder + section header buttons share command).
     var genBtn = root.querySelector('#generateE2eBtn');
     if (genBtn) genBtn.addEventListener('click', function() {
@@ -540,6 +568,48 @@ ${buildPrMessageScript()}
     document.addEventListener('keydown', section._recapEscHandler);
   }
   attachEditRecapHandler();
+
+  // ── Recap generate / regenerate handler ────────────────────────────────
+  // Both buttons post the same 'generateRecap' command; the extension
+  // decides whether this is a first-time generate or a regenerate based on
+  // whether summary.recap is already set. Loading state is reflected on
+  // whichever button is in the DOM.
+  function attachGenerateRecapHandler() {
+    var ids = ['generateRecapBtn', 'regenerateRecapBtn'];
+    ids.forEach(function(id) {
+      var btn = document.getElementById(id);
+      if (!btn) return;
+      btn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        vscode.postMessage({ command: 'generateRecap' });
+      });
+    });
+  }
+  attachGenerateRecapHandler();
+
+  // Recap status messages — generation flow only. The 'recapUpdated' /
+  // 'recapUpdateError' messages are handled in the top-level message
+  // listener above and reused here; we only add the generating-loading
+  // state here so the button reflects in-flight work.
+  // Mirrors the E2E regenerate UX: regen icon button gets the .generating
+  // class (spinning animation + opacity dim + wait cursor); the larger
+  // Generate text button just changes its label to "Generating...".
+  window.addEventListener('message', function(event) {
+    var msg = event.data;
+    if (msg.command === 'recapGenerating') {
+      var genBtn = document.getElementById('generateRecapBtn');
+      var regenBtn = document.getElementById('regenerateRecapBtn');
+      if (genBtn) {
+        genBtn.textContent = 'Generating...';
+        genBtn.disabled = true;
+      }
+      if (regenBtn) {
+        regenBtn.classList.add('generating');
+        regenBtn.title = 'Generating...';
+        regenBtn.disabled = true;
+      }
+    }
+  });
 
   function enterE2eEditMode(toggle, scenarioIndex) {
     var data = JSON.parse(toggle.dataset.scenario || '{}');
@@ -735,7 +805,7 @@ ${buildPrMessageScript()}
           btn.classList.remove('generating');
           btn.title = 'Regenerate';
         } else {
-          btn.textContent = 'Generate';
+          btn.textContent = '\\u2728 Generate';
         }
         btn.disabled = false;
       }

--- a/vscode/src/views/SummaryWebviewPanel.test.ts
+++ b/vscode/src/views/SummaryWebviewPanel.test.ts
@@ -111,15 +111,18 @@ vi.mock("../util/WorkspaceUtils.js", () => ({
 	loadGlobalConfig: mockLoadConfig,
 }));
 
-const { mockGenerateE2eTest, mockTranslateToEnglish } = vi.hoisted(() => ({
-	mockGenerateE2eTest: vi.fn().mockResolvedValue([]),
-	mockTranslateToEnglish: vi
-		.fn()
-		.mockResolvedValue("# Translated Plan\n\nEnglish content"),
-}));
+const { mockGenerateE2eTest, mockGenerateRecap, mockTranslateToEnglish } =
+	vi.hoisted(() => ({
+		mockGenerateE2eTest: vi.fn().mockResolvedValue([]),
+		mockGenerateRecap: vi.fn().mockResolvedValue(""),
+		mockTranslateToEnglish: vi
+			.fn()
+			.mockResolvedValue("# Translated Plan\n\nEnglish content"),
+	}));
 
 vi.mock("../../../cli/src/core/Summarizer.js", () => ({
 	generateE2eTest: mockGenerateE2eTest,
+	generateRecap: mockGenerateRecap,
 	translateToEnglish: mockTranslateToEnglish,
 }));
 
@@ -1460,6 +1463,67 @@ describe("SummaryWebviewPanel", () => {
 			});
 		});
 
+		// ── generateRecap ────────────────────────────────────────────────────
+
+		describe("generateRecap", () => {
+			it("stores the new recap and posts recapUpdated when generation succeeds", async () => {
+				mockGenerateRecap.mockResolvedValueOnce("  Generated recap.  ");
+				mockBuildRecapSection.mockReturnValue('<div id="recapSection">x</div>');
+				const dispatch = await setupPanel();
+
+				dispatch({ command: "generateRecap" });
+				await flushPromises();
+
+				expect(postMessage).toHaveBeenCalledWith({
+					command: "recapGenerating",
+				});
+				expect(mockStoreSummary).toHaveBeenCalledWith(
+					expect.objectContaining({ recap: "Generated recap." }),
+					workspaceRoot,
+					true,
+				);
+				expect(postMessage).toHaveBeenCalledWith({
+					command: "recapUpdated",
+					html: '<div id="recapSection">x</div>',
+				});
+			});
+
+			it("preserves existing recap and shows toast when generation returns empty", async () => {
+				// Empty result happens when the commit has no major topics. The
+				// handler must not destroy a previously stored recap.
+				mockGenerateRecap.mockResolvedValueOnce("");
+				const dispatch = await setupPanel({ recap: "Existing recap." });
+
+				dispatch({ command: "generateRecap" });
+				await flushPromises();
+
+				expect(mockStoreSummary).not.toHaveBeenCalled();
+				expect(showInformationMessage).toHaveBeenCalledWith(
+					expect.stringContaining("nothing to recap"),
+				);
+				expect(postMessage).toHaveBeenCalledWith({
+					command: "recapUpdateError",
+				});
+				expect(postMessage).not.toHaveBeenCalledWith(
+					expect.objectContaining({ command: "recapUpdated" }),
+				);
+			});
+
+			it("treats whitespace-only generation as empty (no store, toast surfaced)", async () => {
+				mockGenerateRecap.mockResolvedValueOnce("   \n\t  ");
+				const dispatch = await setupPanel();
+
+				dispatch({ command: "generateRecap" });
+				await flushPromises();
+
+				expect(mockStoreSummary).not.toHaveBeenCalled();
+				expect(showInformationMessage).toHaveBeenCalled();
+				expect(postMessage).toHaveBeenCalledWith({
+					command: "recapUpdateError",
+				});
+			});
+		});
+
 		// ── editRecap ────────────────────────────────────────────────────────
 
 		describe("editRecap", () => {
@@ -1615,6 +1679,32 @@ describe("SummaryWebviewPanel", () => {
 				// Should still call generateE2eTest with empty diff
 				expect(mockGenerateE2eTest).toHaveBeenCalledWith(
 					expect.objectContaining({ diff: "" }),
+				);
+			});
+
+			it("preserves existing guide and shows toast when generation returns no scenarios", async () => {
+				// Empty array happens when the commit has no major (testable) topics.
+				// The handler must not overwrite an existing guide with [].
+				const existingGuide = [
+					{
+						title: "Existing scenario",
+						steps: ["Step 1"],
+						expectedResults: ["Result 1"],
+					},
+				];
+				mockGenerateE2eTest.mockResolvedValueOnce([]);
+				const dispatch = await setupPanel({ e2eTestGuide: existingGuide });
+
+				dispatch({ command: "generateE2eTest" });
+				await flushPromises();
+
+				expect(mockStoreSummary).not.toHaveBeenCalled();
+				expect(showInformationMessage).toHaveBeenCalledWith(
+					expect.stringContaining("nothing to test"),
+				);
+				expect(postMessage).toHaveBeenCalledWith({ command: "e2eTestError" });
+				expect(postMessage).not.toHaveBeenCalledWith(
+					expect.objectContaining({ command: "e2eTestUpdated" }),
 				);
 			});
 		});

--- a/vscode/src/views/SummaryWebviewPanel.ts
+++ b/vscode/src/views/SummaryWebviewPanel.ts
@@ -26,6 +26,7 @@ import {
 } from "../../../cli/src/core/SessionTracker.js";
 import {
 	generateE2eTest,
+	generateRecap,
 	translateToEnglish,
 } from "../../../cli/src/core/Summarizer.js";
 import {
@@ -146,7 +147,8 @@ type WebviewMessage =
 			entries: ReadonlyArray<TranscriptEntryUpdate>;
 	  }
 	| { command: "deleteAllTranscripts" }
-	| { command: "editRecap"; recap: string };
+	| { command: "editRecap"; recap: string }
+	| { command: "generateRecap" };
 
 /** Entry data sent back from the webview on Save All. */
 interface TranscriptEntryUpdate {
@@ -289,6 +291,15 @@ export class SummaryWebviewPanel {
 				this.catchAndShow(
 					this.handleEditRecap(message.recap ?? ""),
 					"Recap save failed",
+					{
+						command: "recapUpdateError",
+					},
+				);
+				break;
+			case "generateRecap":
+				this.catchAndShow(
+					this.handleGenerateRecap(),
+					"Recap generation failed",
 					{
 						command: "recapUpdateError",
 					},
@@ -1236,6 +1247,57 @@ export class SummaryWebviewPanel {
 		});
 	}
 
+	/**
+	 * Generates (or regenerates) the Quick Recap paragraph via a standalone
+	 * LLM call against the existing topics. The diff is intentionally NOT
+	 * included -- the recap is a narrative over already-extracted topics, not a
+	 * fresh code analysis, and skipping the diff keeps token cost low for an
+	 * action users may invoke repeatedly until the wording feels right.
+	 *
+	 * If the commit has no major topics, generateRecap returns an empty string
+	 * and the section re-renders into its placeholder (state-1) form. The
+	 * webview's recapUpdated handler treats the new HTML as canonical, so the
+	 * Generate button reappears automatically without extra signalling.
+	 */
+	private async handleGenerateRecap(): Promise<void> {
+		const summary = this.currentSummary;
+		if (!summary) {
+			return;
+		}
+
+		this.panel.webview.postMessage({ command: "recapGenerating" });
+
+		const { topics } = collectSortedTopics(summary);
+		const config = await loadGlobalConfig();
+		const recap = await generateRecap({
+			topics,
+			commitMessage: summary.commitMessage,
+			config,
+		});
+
+		const trimmed = recap.trim();
+		// Empty result means generateRecap short-circuited because the commit has
+		// no `importance: major` topics. Surface a toast and exit without
+		// touching storage so an existing recap (legacy summaries, or summaries
+		// where the user just demoted every topic) is never silently destroyed.
+		if (!trimmed) {
+			vscode.window.showInformationMessage(
+				"No major topics in this commit, so there's nothing to recap.",
+			);
+			this.panel.webview.postMessage({ command: "recapUpdateError" });
+			return;
+		}
+
+		const updated: CommitSummary = { ...summary, recap: trimmed };
+		await storeSummary(updated, this.workspaceRoot, true);
+		this.currentSummary = updated;
+
+		this.panel.webview.postMessage({
+			command: "recapUpdated",
+			html: buildRecapSection(updated.recap),
+		});
+	}
+
 	/** Handles deleting a memory at the given global index (with confirmation). */
 	private async handleDeleteTopic(
 		topicIndex: number,
@@ -1303,6 +1365,18 @@ export class SummaryWebviewPanel {
 			diff,
 			config,
 		});
+
+		// Empty result means generateE2eTest short-circuited because the commit
+		// has no testable major topics (no topics at all, or every topic is
+		// `importance: minor`). Surface a toast and exit without touching
+		// storage so a previously generated guide is never silently overwritten.
+		if (scenarios.length === 0) {
+			vscode.window.showInformationMessage(
+				"No major topics in this commit, so there's nothing to test.",
+			);
+			this.panel.webview.postMessage({ command: "e2eTestError" });
+			return;
+		}
 
 		const updatedSummary: CommitSummary = {
 			...summary,


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## Quick recap

Users can now generate or refresh the Quick Recap directly from the commit summary panel. A Generate button appears whenever a recap is absent, and a Regenerate button is available once one exists — recovering from a poor or missing recap no longer requires restarting the entire summarisation flow.

Future commit summaries will also read more clearly. Recaps now focus on two or three of the most significant changes and give each one two to four sentences of real explanation, replacing the previous style of one-line coverage spread thinly across every topic. Routine or minor work no longer appears in the recap at all. When a recap naturally spans multiple topics, paragraph breaks are now preserved in the panel display.

Clicking section headers in the end-to-end test panel now correctly expands and collapses those sections, consistent with the Collapse All button that was already working.

---

## E2E Test (4)
<details>
<summary><strong>1. Generate recap when none exists</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a commit that has been summarised but does not yet have a Quick Recap visible in the commit summary panel.

**Steps:**
1. Open the commit summary panel for a commit that shows no Quick Recap.
2. Locate the placeholder area where the recap would normally appear.
3. Click the "Generate" button shown in that area.
4. Wait for the button to show a spinning or loading state.
5. Verify that the loading animation stops and a recap paragraph appears in place of the placeholder.

**Expected Results:**
- While generating, the Generate button should appear visually active (rotating icon, reduced opacity, or wait cursor).
- After generation completes, the placeholder disappears and one or more paragraphs of recap text are shown.
- An "Edit" button and a "Regenerate" button (showing ↻) appear alongside the recap text.

</blockquote>
</details>
<details>
<summary><strong>2. Regenerate an existing recap</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a commit summary panel open that already displays a Quick Recap with visible text.

**Steps:**
1. In the commit summary panel, locate the Quick Recap section showing existing recap text.
2. Click the "↻ Regenerate" button next to the recap.
3. Watch the button while the recap refreshes.
4. Verify the recap area updates with new content once the loading state ends.

**Expected Results:**
- The Regenerate button should show a rotation animation, reduced opacity, and a wait cursor while the new recap is being generated.
- After generation completes, the recap text updates (it may differ from the previous version).
- The Edit and Regenerate buttons remain visible after the new recap appears.

</blockquote>
</details>
<details>
<summary><strong>3. Multi-paragraph recap displays with visible separation</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a commit whose recap contains two or more distinct paragraphs (a longer commit covering multiple topics works best).

**Steps:**
1. Open the commit summary panel for a commit that has a multi-paragraph Quick Recap.
2. Read through the recap section.
3. Verify that each paragraph is visually separated from the next.

**Expected Results:**
- Each paragraph of the recap should appear as its own block with a visible gap between paragraphs.
- The text should NOT run together as one unbroken wall of text.
- Single-paragraph recaps on other commits should be unaffected and display normally.

</blockquote>
</details>
<details>
<summary><strong>4. Recap covers only major topics, not minor ones</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a commit that contains at least one major topic and at least one minor topic (such as a formatting fix or config tweak) visible in the topics list.

**Steps:**
1. Open the commit summary panel and review the topics list to identify which topics are marked as major and which are minor.
2. Read the Quick Recap section.
3. Check whether the minor topic's subject matter appears anywhere in the recap text.

**Expected Results:**
- The recap should describe only the major topics from the commit.
- The minor topic (for example, a formatting or configuration change) should not be mentioned anywhere in the recap, not even briefly at the end.
- If every topic in the commit is minor, the recap section should be absent entirely — no placeholder, no empty block.

</blockquote>
</details>

---

## Topics (11)
<details>
<summary><strong>01 · E2E test section headers now correctly toggle collapse on click</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Clicking on a header row in the E2E test section had no effect — the section would not expand or collapse. The "Collapse All" button at the top still worked, making the inconsistency confusing.

**💡 Decisions Behind the Code**

An idempotency guard was added to the attachment helper rather than simply re-running a raw query loop each time. Without the guard, headers that survived a partial re-render could accumulate duplicate listeners, causing each click to fire the toggle multiple times. The guard keeps the fix safe to call repeatedly with no behavioral side effects, which matters because the handler is invoked on every update message.

**✅ What Was Implemented**

- The root cause was identified in `SummaryScriptBuilder.ts`: the global click listener for collapsible headers was attached once at script load time, but the E2E section replaces its entire DOM subtree when test data updates arrive, leaving newly inserted header elements without listeners.
- The fix extracted the per-header attachment logic into a reusable `attachToggleHeader` function with an idempotency guard (`_toggleAttached` flag on the element), then called it inside `attachE2eHandlers` so freshly rendered E2E scenario headers are wired up immediately after each DOM replacement.

**📁 FILES**
- `vscode/src/views/SummaryScriptBuilder.ts`

</blockquote>
</details>
<details>
<summary><strong>02 · On-demand recap generation and regeneration added to the commit summary panel</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Users had no way to generate or refresh the Quick Recap from the webview after a commit was summarised. If the initial recap was poor quality or missing, there was no recovery path short of re-running the full summarisation flow.

**💡 Decisions Behind the Code**

- **No diff in the recap LLM call**: The recap is a narrative over already-extracted topics, not a fresh code analysis. Excluding the diff keeps token cost low for an action users may invoke repeatedly, and avoids pushing the model toward implementation-level prose that the recap rules explicitly forbid.
- **Narrative fields only sent to the model**: Only title, trigger, and decisions are sent — the response field is excluded. The response field is an implementation-detail field that would pull the model toward code-level language, which contradicts the recap's plain-English, user-facing requirement.
- **Always render the recap section**: Even when no recap exists, the section is rendered with a Generate button rather than being omitted entirely. This makes the affordance discoverable without requiring users to know the feature exists, and mirrors the pattern used for the E2E test section.
- **Reuse existing generating CSS class**: Aligning to the `.generating` class already defined for the E2E section keeps the visual behaviour identical with zero new CSS. Inventing a recap-specific variant would have created divergence requiring later reconciliation.

**✅ What Was Implemented**

- Added a standalone RECAP prompt template in `PromptTemplates.ts` that takes only the commit message and major topics as inputs — no diff — and emits a single delimited recap block. The template carries the full recap ruleset (major-only, 2-3 topics, 150-300 words, user-facing prose, no rationale reasoning).
- Added `generateRecap()` and `parseRecapResponse()` to `Summarizer.ts`. `generateRecap` filters topics to major-only before calling the LLM, formats only the narrative fields (title, trigger, decisions — not response), and returns an empty string when no major topics exist. `parseRecapResponse` handles three defensive cases: missing marker (falls back to whole text), echoed closing marker (stripped), and empty input.
- Updated `SummaryHtmlBuilder.ts` to render two states for the recap section: State 1 (no recap) shows a placeholder and a Generate button; State 2 (recap present) shows the recap body split into paragraphs plus Edit and Regenerate buttons.
- Added `handleGenerateRecap()` and routing in `SummaryWebviewPanel.ts`, and `attachGenerateRecapHandler` with loading state management in `SummaryScriptBuilder.ts`. The Regenerate button uses the `&#x21BB;` (↻) character with a "Regenerate" tooltip, and applies the existing `.generating` CSS class during the loading state (rotation animation, reduced opacity, wait cursor) rather than only toggling the disabled attribute.

**📁 FILES**
- `cli/src/core/PromptTemplates.ts`
- `cli/src/core/Summarizer.ts`
- `vscode/src/views/SummaryHtmlBuilder.ts`
- `vscode/src/views/SummaryScriptBuilder.ts`
- `vscode/src/views/SummaryWebviewPanel.ts`

</blockquote>
</details>
<details>
<summary><strong>03 · Recap ordering fixed so major-only content rule is structurally enforced</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The recap was being generated before the topics list, meaning the model had to decide which topics were major or minor before it had written out any importance labels — a structural problem that made the major-only rule probabilistic rather than reliable.

**💡 Decisions Behind the Code**

- **Structural ordering over prompt-level instruction**: Moving the recap to after the topics converts the major-only rule from a forward-planning requirement into a lookback requirement — the model reads labels it just emitted rather than anticipating labels it hasn't written yet. This is a structural guarantee rather than a probabilistic one, and it costs nothing in parser changes because the parser already accepted the recap in any position.
- **Hard exclusion over trailing mention**: Allowing minor topics to appear as a single trailing sentence was considered and rejected. It still consumed word budget on minor work, created ambiguity about what counted as "worth mentioning," and blurred the recap's role as a major-work narrative. A clean exclusion makes the recap's purpose unambiguous and easier to test mechanically.
- **Verbatim-copy prohibition added to squash prompt**: After observing a specific failure where the model copied a 1,544-character source recap unchanged into the squash output, an explicit rule was added forbidding verbatim reproduction of any single source recap. The structural fix reduces the temptation, but the explicit prohibition adds a second layer of defense.

**✅ What Was Implemented**

- In `PromptTemplates.ts`, the output format spec for both the summarize and squash-consolidate prompts was updated to require the recap block to appear after all topic blocks rather than before the first one. The rationale is embedded in the spec itself: by the time the model writes the recap, every topic's importance label is already in its own output and can be referenced directly.
- Rule 19 (summarize) and rule 1 (squash-consolidate) were rewritten to enforce a major-only recap policy: minor topics must not appear in the recap at all, not even as a trailing sentence. When every topic is minor, the recap section is omitted entirely. The old "smaller changes get a brief mention at the end" wording was removed.
- The squash-consolidate rule gained an explicit prohibition against copying any single source recap verbatim, targeting the failure mode where the model reproduced the first source's recap byte-for-byte instead of synthesizing across all sources.
- The output examples in both prompts were updated to show the recap block at the bottom, after the topic blocks.
- Four new tests were added to `PromptTemplates.test.ts` pinning the recap-after-topics ordering and the major-only wording for both prompt variants.

**📁 FILES**
- `cli/src/core/PromptTemplates.ts`
- `cli/src/core/PromptTemplates.test.ts`

</blockquote>
</details>
<details>
<summary><strong>04 · Recap word-count and topic-selection rules restructured for depth over breadth</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Generated recaps were covering every topic with one or two sentences each, producing a fragmented list that read like a table of contents rather than a narrative. A rule requiring all major topics to be covered within a tight word-count ceiling forced the model to allocate only a sentence per topic regardless of how many topics there were.

**💡 Decisions Behind the Code**

Removing the hard upper word limit was the key change. The previous ceiling forced the model into a coverage-over-depth trade-off where it would mention every topic briefly rather than explain any topic well. Replacing it with a topic-count ceiling (2-3 topics) and a per-topic sentence floor (2-4 sentences) inverts the trade-off: the model must choose what to leave out rather than how to compress everything in, which produces prose that actually explains what changed rather than listing that changes occurred.

**✅ What Was Implemented**

Rule 19 in the summarize prompt and rule 1 in the squash-consolidate prompt were rewritten to replace the "cover all major topics, 80-160 words" constraint with a "pick the 2-3 highest-impact topics, 2-4 sentences each, 150-300 words target with no hard upper limit" structure. The squash variant allows 3-5 topics and targets 200-400 words. Both variants explicitly prohibit the one-sentence-per-topic pattern and require weaving chosen topics into flowing paragraphs.

**📁 FILES**
- `cli/src/core/PromptTemplates.ts`

</blockquote>
</details>
<details>
<summary><strong>05 · Prompt readability rules strengthened for human-facing narrative fields</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Generated summaries were written in a way that assumed the reader already knew what the feature was, used implementation-level terminology, and explained technical rationale rather than describing what changed from a user's perspective.

**💡 Decisions Behind the Code**

- **Audience redefinition over style guidance**: Changing the stated audience from "a developer not present" to "a colleague who uses the product but has never read the codebase" shifts the model's frame of reference from technical peer to product-aware non-engineer. This produces more accessible language without requiring the model to simplify content — it still knows what the feature does, but it describes it in terms of what the user experiences rather than how the code works.
- **Explicit prohibition over soft guidance**: Adding a hard "MUST NOT explain WHY" rule to the recap content rules is stronger than the previous implicit expectation. The decisions field already exists for rationale; making the recap's scope explicit prevents the model from filling word budget with technical justification when it should be describing outcomes.

**✅ What Was Implemented**

- Rule 1 in the summarize prompt was updated to replace "a developer who was NOT present" with "a colleague who uses the product but has never read this codebase," and added an explicit test: a product manager or designer should understand every sentence without needing an explanation. Implementation-level terms that only make sense after reading the code were explicitly prohibited alongside the existing ban on file paths and variable names.
- Rule 19's recap content rules were updated to require describing what changed and what users can now do differently, and to explicitly prohibit explaining why technical choices were made (that belongs in the decisions field). The same plain-language test was added to the recap rules.
- The end-to-end test prompt's rule 1 was updated to instruct the model to assume the reviewer has never used or seen the feature before, and to describe navigation and expected results as if explaining to someone testing the product for the first time.

**📁 FILES**
- `cli/src/core/PromptTemplates.ts`

</blockquote>
</details>
<details>
<summary><strong>06 · Recap multi-paragraph rendering fixed in the commit summary panel</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The recap field sometimes contains paragraph breaks that the model inserts naturally when covering multiple topics, but the panel was rendering the raw text into a single HTML element without converting those breaks into actual paragraph separators, so the visual separation was lost.

**💡 Decisions Behind the Code**

Double-newline paragraph breaks in the recap are a natural model behavior rather than a guaranteed prompt-enforced contract, so the UI handles them defensively regardless of whether the model produces one paragraph or several. Enforcing paragraph structure through the prompt was considered but rejected because it could cause the model to insert blank lines even in single-topic recaps where no separation is needed.

**✅ What Was Implemented**

In the WebView panel's recap section builder, the recap text is now split on double newlines before rendering. Each resulting segment is wrapped in its own paragraph element, so multi-paragraph recaps display with visible separation. Single-paragraph recaps produce a single paragraph element and are unaffected.

**📁 FILES**
- `vscode/src/webview/WebviewPanelManager.ts`

</blockquote>
</details>
<details>
<summary><strong>07 · Single-decision formatting rule clarified to prohibit lone bullet points</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The decisions field was frequently rendered as a single-item bullet list when there was only one decision, which looked visually awkward and was inconsistent with the intent that bullet lists signal multiple parallel items.

**💡 Decisions Behind the Code**

The earlier draft of this rule used the phrase "A lone bullet is always wrong," which risked being read as discouraging single-decision entries altogether. The final wording explicitly separates the two concerns — one decision as content is encouraged when there is genuinely only one thing to say, but the bullet format is the error — so the model is not nudged toward inventing a second decision just to justify list formatting.

**✅ What Was Implemented**

In `PromptTemplates.ts`, the decisions field description in the output example, rule 2, and the inline field spec were all updated to state that a single decision must be written as plain prose with no bullet and no bold label. The phrasing "One decision is fine; one bullet is a formatting error" was used to separate the content question (having one decision is acceptable) from the formatting question (rendering it as a bullet is not).

**📁 FILES**
- `cli/src/core/PromptTemplates.ts`

</blockquote>
</details>
<details>
<summary><strong>08 · Recap prompt rules deduplicated into shared constants across all prompt templates</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Three prompt templates each carried near-identical copies of the recap content rules, the output-format preamble, and the topic-field skeleton, meaning any future tightening of these rules had to be applied in three places with high risk of drift.

**💡 Decisions Behind the Code**

- **Parameterize only the diverging fields**: RESPONSE and DECISIONS bodies are injected into `buildTopicExample` rather than making the entire skeleton a template string with many parameters. The six shared fields are hardcoded inside the function, keeping the signature narrow and making the shared structure visually obvious at the call site.
- **Function over constant for the recap high-impact rule**: `buildRecapHighImpactRule` is a function rather than a constant because the three call sites differ in four independent dimensions. A constant would require either duplication or a complex substitution scheme; a typed options object keeps each call site self-documenting.
- **Scope limited to three highest-value blocks**: Nine categories of duplication were identified. Only the three with the highest line-count-times-drift-risk were addressed — output-format preamble, topic skeleton, and recap opening bullets — matching an explicit preference for a single high-value cleanup round rather than exhaustive deduplication.

**✅ What Was Implemented**

- Extracted `OUTPUT_FORMAT_SHAPE` constant holding the "Output format requirements" header, the "MUST be a delimited..." line, and the fenced shape diagram; replaced the two duplicate copies in SUMMARIZE and SQUASH_CONSOLIDATE with a single interpolation.
- Extracted `buildTopicExample(responseBody, decisionsBody)` function to generate the example topic block skeleton. The six byte-identical fields are hardcoded; only RESPONSE and DECISIONS are injected as parameters since they differ in bullet cap and source-of-insight wording between templates.
- Extracted `buildRecapHighImpactRule({ topicRange, majorQualifier, preserveNote, wordTarget })` function to generate the two opening recap content bullets. Used by SUMMARIZE rule 19, SQUASH_CONSOLIDATE rule 1, and the standalone RECAP template, with parameters controlling range ("2-3" vs "3-5"), whether the "major" qualifier appears, whether the topics-list reassurance appears, and the word target ("150-300" vs "200-400").
- Cleaned up four example-text violations in the process: removed `so` / `without needing to re-sort` from the SUMMARIZE output example, removed `rather than acting immediately, reducing accidental data loss` from the SQUASH_CONSOLIDATE output example, and removed `because they cover fewer topics` from the meta-commit example in `RECAP_LANGUAGE_RULES` — all cases where the prompt's own examples contradicted its own rules.

**📁 FILES**
- `cli/src/core/PromptTemplates.ts`

</blockquote>
</details>
<details>
<summary><strong>09 · Squash recap verbatim-copy failure diagnosed and addressed after two commits merged</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

After merging two commits into a single squash entry, the resulting recap was byte-for-byte identical to the first source commit's recap, meaning the second source's content was completely absent from the narrative.

**💡 Decisions Behind the Code**

The team decided not to add a parser-level byte-identical detection check at this time, on the basis that one observed instance is insufficient to justify a defensive layer. The structural fix of moving the recap after the topics (which makes verbatim copying structurally awkward) and the explicit prompt prohibition against copying source recaps were judged sufficient as a first response, with the option to add parser-level detection if the pattern recurs.

**✅ What Was Implemented**

- The merged commit data was inspected by comparing the squash output against both source files. The topics list was confirmed to be correctly synthesized (11 + 2 sources merged to 12 topics, with one genuine duplicate collapsed). The recap was confirmed to be a verbatim copy of the first source's 1,544-character recap.
- The root cause was identified as model behavior rather than a code defect: the formatting pipeline correctly passed both source recaps to the model, but the model chose to reproduce the first source's recap unchanged rather than synthesize across both.
- Structural and prompt-level fixes were applied in `PromptTemplates.ts` as part of the broader recap ordering and verbatim-copy prohibition work.

**📁 FILES**
- `cli/src/core/Summarizer.ts`
- `cli/src/core/PromptTemplates.ts`

</blockquote>
</details>
<details>
<summary><strong>10 · Recap regeneration plan document and prompt quality analysis created</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The team needed a written record of the on-demand recap regeneration design and a structured analysis of why an early generated recap performed poorly, to guide iterative prompt improvement.

**💡 Decisions Behind the Code**

- **Document-first, code-second for prompt iteration**: Rather than immediately patching the prompt, the analysis was written up as a living document so each iteration's input and output could be compared side by side. This makes the improvement process reproducible and auditable rather than a one-shot guess.
- **Root cause identified as missing meta-commit guidance**: The prompt performed well on ordinary commits but had no rule for commits whose user-visible effect is a change to future output rather than a direct product change. The five proposed improvements target this gap specifically rather than making broad changes that could regress ordinary commits.

**✅ What Was Implemented**

- Created `e:/jm-docs/124. PLAN - Recap 按需重新生成功能.md` describing the design for on-demand recap regeneration. The design mirrors the existing end-to-end test regeneration pattern: a dedicated LLM call that takes the existing major topics as input and returns only a new recap paragraph, without re-running the full summarisation pipeline. The plan specifies that the call should receive narrative fields from existing topics (title, trigger, decisions) rather than the raw diff.
- Created `e:/jm-docs/125. 实验 - Recap Prompt 迭代优化过程.md` documenting the first generated recap in full, a structured violation analysis against the prompt rules, root-cause identification (meta-commit with no dedicated guidance), and five prioritised prompt improvement suggestions. The document includes placeholder sections for subsequent regeneration rounds to track improvement across iterations.

**📋 Future Enhancements**

- Apply the five prioritised prompt improvements from the quality analysis document and evaluate output across subsequent regeneration rounds.

**📁 FILES**
- `cli/src/core/PromptTemplates.ts`

</blockquote>
</details>
<details>
<summary><strong>11 · Linear issue created for on-demand recap regeneration gap</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The team needed a tracked issue in Linear capturing the problem that users could not regenerate the Quick Recap from the webview, without including implementation details in the issue description.

**💡 Decisions Behind the Code**

Problem-only framing was used deliberately — the issue describes the gap without proposing a solution, keeping the Linear ticket as a problem statement rather than a pre-decided implementation ticket.

**✅ What Was Implemented**

Created Linear issue JOLLI-1400 "Quick Recap can't be regenerated on-demand from the webview" describing three problem dimensions: stale recap after topic edits, no retry path for poor output, and no user affordance. An explicit out-of-scope list was included. The plan file referenced in the request was not found on disk; the issue was derived from the branch's code changes instead.

**📁 FILES**
- `cli/src/core/PromptTemplates.ts`

</blockquote>
</details>

---

*Generated by Jolli Memory · April 30, 2026 at 5:16 PM*
<!-- jollimemory-summary-end -->