### PR TITLE
Switch required checks to step-level skip via composite action

### DIFF
--- a/.github/actions/detect-relevant-paths/action.yaml
+++ b/.github/actions/detect-relevant-paths/action.yaml
@@ -1,0 +1,67 @@
+# Internal composite action used by required-check workflows.
+#
+# Computes whether the current event's diff touches any of the given path
+# globs. Lets a required check always run + report SUCCESS, with real
+# build steps gated on the `relevant` output — required + path-filter
+# would otherwise deadlock PRs that don't touch matching paths.
+
+name: Detect relevant paths
+description: Set relevant=true if any changed file matches any of the given globs.
+
+inputs:
+    globs:
+        description: |
+            Newline-separated list of case-style glob patterns. A changed
+            file matches if any pattern matches.
+        required: true
+
+outputs:
+    relevant:
+        description: '"true" if any changed file matched any glob, otherwise "false".'
+        value: ${{ steps.changes.outputs.relevant }}
+
+runs:
+    using: composite
+    steps:
+        -   id: changes
+            shell: bash
+            env:
+                EVENT: ${{ github.event_name }}
+                PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+                PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+                PUSH_BEFORE_SHA: ${{ github.event.before }}
+                PUSH_AFTER_SHA: ${{ github.event.after }}
+                GLOBS: ${{ inputs.globs }}
+            run: |
+                set -euo pipefail
+                cd "$GITHUB_WORKSPACE"
+
+                if [ "$EVENT" = "pull_request" ]; then
+                    base="$PR_BASE_SHA"
+                    head="$PR_HEAD_SHA"
+                else
+                    base="$PUSH_BEFORE_SHA"
+                    head="$PUSH_AFTER_SHA"
+                fi
+
+                # First push of a new branch / shallow fetch / unknown base: be conservative
+                if [ -z "$base" ] || [ "$base" = "0000000000000000000000000000000000000000" ] || ! git cat-file -e "$base" 2>/dev/null; then
+                    echo "relevant=true" >> "$GITHUB_OUTPUT"
+                    exit 0
+                fi
+
+                mapfile -t globs <<< "$GLOBS"
+
+                relevant=false
+                while IFS= read -r f; do
+                    [ -z "$f" ] && continue
+                    for glob in "${globs[@]}"; do
+                        [ -z "$glob" ] && continue
+                        # $glob unquoted on purpose — case patterns need word splitting
+                        case "$f" in
+                            $glob) relevant=true; break 2 ;;
+                        esac
+                    done
+                done <<< "$(git diff --name-only "$base" "$head")"
+
+                echo "relevant=$relevant" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/build-intellij.yaml
+++ b/.github/workflows/build-intellij.yaml
@@ -1,19 +1,15 @@
-name: Build & Test
+# Required by branch ruleset (context: build-intellij). See
+# build-vscode.yaml for the step-level skip rationale.
+name: CI - IntelliJ
 
 on:
   push:
-    branches: [main]
-    paths:
-      - "intellij/**"
-      - ".github/workflows/build-intellij.yaml"
+    branches: [main, "release/**"]
   pull_request:
-    branches: [main]
-    paths:
-      - "intellij/**"
-      - ".github/workflows/build-intellij.yaml"
+    branches: [main, "release/**"]
 
 jobs:
-  build:
+  build-intellij:
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -21,26 +17,41 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
-      - name: Set up JDK 21
+      - id: changes
+        uses: ./.github/actions/detect-relevant-paths
+        with:
+          globs: |
+            intellij/*
+            .github/workflows/build-intellij.yaml
+
+      - if: steps.changes.outputs.relevant == 'true'
+        name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: 21
 
-      - name: Setup Gradle
+      - if: steps.changes.outputs.relevant == 'true'
+        name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
 
-      - name: Build plugin
+      - if: steps.changes.outputs.relevant == 'true'
+        name: Build plugin
         run: ./gradlew buildPlugin
 
-      - name: Run tests
+      - if: steps.changes.outputs.relevant == 'true'
+        name: Run tests
         run: ./gradlew test
 
-      - name: Run Plugin Verifier
+      - if: steps.changes.outputs.relevant == 'true'
+        name: Run Plugin Verifier
         run: ./gradlew verifyPlugin
 
-      - name: Upload plugin artifact
+      - if: steps.changes.outputs.relevant == 'true'
+        name: Upload plugin artifact
         uses: actions/upload-artifact@v4
         with:
           name: jollimemory-intellij

--- a/.github/workflows/build-vscode.yaml
+++ b/.github/workflows/build-vscode.yaml
@@ -3,40 +3,49 @@
 # Covers both `cli/` and `vscode/` because they share a root package.json
 # (npm workspaces) — touching one can break the other's install or build.
 
-name: Build & Test (CLI + VS Code)
+# Required by branch ruleset (contexts: build-vscode). The status check
+# context that ruleset matches is the job id, not the workflow name.
+#
+# The job always runs and reports a status — required + path-filter
+# would deadlock PRs that don't touch matching paths. Step-level `if:`
+# (not job-level) lets us skip real work while keeping the status SUCCESS
+# instead of `skipped`, which ruleset doesn't accept as passing.
+name: CI - CLI + VS Code
 
 on:
     push:
-        branches: [main]
-        paths:
-            - "cli/**"
-            - "vscode/**"
-            - "package.json"
-            - "package-lock.json"
-            - ".nvmrc"
-            - ".github/workflows/build-vscode.yaml"
+        branches: [main, "release/**"]
     pull_request:
-        branches: [main]
-        paths:
-            - "cli/**"
-            - "vscode/**"
-            - "package.json"
-            - "package-lock.json"
-            - ".nvmrc"
-            - ".github/workflows/build-vscode.yaml"
+        branches: [main, "release/**"]
 
 jobs:
-    build:
+    build-vscode:
         runs-on: ubuntu-24.04
         steps:
             -   uses: actions/checkout@v5
+                with:
+                    fetch-depth: 0
 
-            -   uses: actions/setup-node@v5
+            -   id: changes
+                uses: ./.github/actions/detect-relevant-paths
+                with:
+                    globs: |
+                        cli/*
+                        vscode/*
+                        package.json
+                        package-lock.json
+                        .nvmrc
+                        .github/workflows/build-vscode.yaml
+
+            -   if: steps.changes.outputs.relevant == 'true'
+                uses: actions/setup-node@v5
                 with:
                     node-version-file: .nvmrc
 
-            -   name: Install workspace dependencies
+            -   if: steps.changes.outputs.relevant == 'true'
+                name: Install workspace dependencies
                 run: npm ci
 
-            -   name: Build, lint, and test (CLI + VS Code)
+            -   if: steps.changes.outputs.relevant == 'true'
+                name: Build, lint, and test (CLI + VS Code)
                 run: npm run all


### PR DESCRIPTION
## Summary

- Required checks `build-vscode` / `build-intellij` deadlocked PRs that didn't match the workflows' `on.*.paths` filters — required + path-filter is the classic GitHub deadlock.
- Both workflows now always run and report a status; real build steps are gated by a step-level `if:` driven by a new internal composite action `.github/actions/detect-relevant-paths` that runs `git diff` against the event base.
- No third-party action — composite action lives in this repo.

## Naming & triggers

- Workflow `name:` set to `CI - CLI + VS Code` / `CI - IntelliJ` for friendlier CI list display; job ids stay `build-vscode` / `build-intellij` to match ruleset literals (ruleset matches `check_run.name` = job id, not workflow name).
- Push & PR triggers extended from `[main]` to `[main, "release/**"]` so hot-fix work against release branches goes through the same gates.

## Intentionally unchanged

- `publish-*.yaml` workflows.
- IntelliJ skip behavior — still only does a real build when `intellij/**` changes; now at step level instead of `on.*.paths`.
- Release branch ruleset (id `15767917`) — still has no required-check enforcement on release branches; can be added separately if desired.

## Test plan

- [ ] CI on this PR: both `build-vscode` and `build-intellij` checks run real steps (the PR touches both workflow files), producing two green checks.
- [ ] Pick any subsequent docs-only PR: expect both checks to start, skip all real work, and report SUCCESS.