### PR TITLE
Implement code-exchange flow for OAuth callbacks

### DIFF
--- a/cli/src/Cli.test.ts
+++ b/cli/src/Cli.test.ts
@@ -4182,7 +4182,10 @@ describe("CLI", () => {
 
 			await main(["auth", "login"]);
 
-			expect(browserLogin).toHaveBeenCalledWith(expect.stringContaining("/login"));
+			// browserLogin receives the Jolli origin (not the full /login URL) —
+			// it appends `/login` and the cli_callback params internally.
+			expect(browserLogin).toHaveBeenCalledTimes(1);
+			expect(browserLogin).toHaveBeenCalledWith(expect.stringMatching(/^https:\/\/[^/]+$/));
 		});
 
 		it("should report Jolli API Key saved when login yields jolliApiKey", async () => {

--- a/cli/src/auth/CliExchange.test.ts
+++ b/cli/src/auth/CliExchange.test.ts
@@ -1,0 +1,167 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { exchangeCliCode } from "./CliExchange.js";
+
+describe("exchangeCliCode", () => {
+	let fetchSpy: ReturnType<typeof vi.fn>;
+
+	beforeEach(() => {
+		fetchSpy = vi.fn();
+		vi.stubGlobal("fetch", fetchSpy);
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	function jsonResponse(status: number, body: unknown): Response {
+		return {
+			ok: status >= 200 && status < 300,
+			status,
+			json: vi.fn().mockResolvedValue(body),
+		} as unknown as Response;
+	}
+
+	it("posts the code to /api/auth/cli-exchange and returns the credentials", async () => {
+		fetchSpy.mockResolvedValueOnce(
+			jsonResponse(200, { token: "tk-abc", jolliApiKey: "sk-jol-xyz", space: "personal" }),
+		);
+
+		const result = await exchangeCliCode("https://app.jolli.ai", "code-123");
+
+		expect(result).toEqual({ token: "tk-abc", jolliApiKey: "sk-jol-xyz", space: "personal" });
+		expect(fetchSpy).toHaveBeenCalledTimes(1);
+		const [url, init] = fetchSpy.mock.calls[0];
+		expect(String(url)).toBe("https://app.jolli.ai/api/auth/cli-exchange");
+		expect(init.method).toBe("POST");
+		expect(init.headers).toEqual({ "content-type": "application/json" });
+		expect(init.signal).toBeInstanceOf(AbortSignal);
+		expect(JSON.parse(init.body as string)).toEqual({ code: "code-123" });
+	});
+
+	it("strips the tenant path and sends x-tenant-slug for path-based tenant URLs", async () => {
+		fetchSpy.mockResolvedValueOnce(jsonResponse(200, { token: "tk-abc" }));
+
+		await exchangeCliCode("https://jolli-local.me/dev", "code-123");
+
+		const [url, init] = fetchSpy.mock.calls[0];
+		expect(String(url)).toBe("https://jolli-local.me/api/auth/cli-exchange");
+		expect(init.headers).toEqual({
+			"content-type": "application/json",
+			"x-tenant-slug": "dev",
+		});
+	});
+
+	it("omits x-tenant-slug for origin-only URLs", async () => {
+		fetchSpy.mockResolvedValueOnce(jsonResponse(200, { token: "tk-abc" }));
+
+		await exchangeCliCode("https://app.jolli.ai", "code-123");
+
+		const [, init] = fetchSpy.mock.calls[0];
+		expect(init.headers).not.toHaveProperty("x-tenant-slug");
+	});
+
+	it("surfaces a clear timeout message when fetch is aborted by AbortSignal.timeout", async () => {
+		const timeoutErr = new DOMException("The operation was aborted due to timeout", "TimeoutError");
+		fetchSpy.mockRejectedValueOnce(timeoutErr);
+
+		await expect(exchangeCliCode("https://app.jolli.ai", "code-1")).rejects.toThrow(/timed out after \d+s/);
+	});
+
+	it("returns only the token when the response omits jolliApiKey and space", async () => {
+		fetchSpy.mockResolvedValueOnce(jsonResponse(200, { token: "tk-only" }));
+
+		const result = await exchangeCliCode("https://app.jolli.ai", "code-1");
+
+		expect(result).toEqual({ token: "tk-only" });
+		expect(result.jolliApiKey).toBeUndefined();
+		expect(result.space).toBeUndefined();
+	});
+
+	it("rejects an off-allowlist jolliUrl before issuing the request", async () => {
+		await expect(exchangeCliCode("https://evil.example.com", "code-1")).rejects.toThrow(/evil\.example\.com/);
+		expect(fetchSpy).not.toHaveBeenCalled();
+	});
+
+	it("wraps a network failure in a friendly message", async () => {
+		fetchSpy.mockRejectedValueOnce(new Error("ECONNREFUSED 127.0.0.1:443"));
+
+		await expect(exchangeCliCode("https://app.jolli.ai", "code-1")).rejects.toThrow(
+			/Couldn't reach Jolli to complete sign-in.*ECONNREFUSED/,
+		);
+	});
+
+	it("stringifies non-Error throws from fetch", async () => {
+		fetchSpy.mockRejectedValueOnce("bare-string-rejection");
+
+		await expect(exchangeCliCode("https://app.jolli.ai", "code-1")).rejects.toThrow(/bare-string-rejection/);
+	});
+
+	it("returns a clear message for an expired/consumed code (404)", async () => {
+		fetchSpy.mockResolvedValueOnce(jsonResponse(404, { error: "invalid_or_expired_code" }));
+
+		await expect(exchangeCliCode("https://app.jolli.ai", "code-1")).rejects.toThrow(
+			/Sign-in code expired or already used/,
+		);
+	});
+
+	it("returns a generic HTTP message for other non-OK statuses", async () => {
+		fetchSpy.mockResolvedValueOnce(jsonResponse(500, { error: "server_error" }));
+
+		await expect(exchangeCliCode("https://app.jolli.ai", "code-1")).rejects.toThrow(/HTTP 500/);
+	});
+
+	it("rejects when the server response is not valid JSON", async () => {
+		fetchSpy.mockResolvedValueOnce({
+			ok: true,
+			status: 200,
+			json: vi.fn().mockRejectedValue(new SyntaxError("Unexpected token")),
+		} as unknown as Response);
+
+		await expect(exchangeCliCode("https://app.jolli.ai", "code-1")).rejects.toThrow(
+			/malformed response.*Unexpected token/,
+		);
+	});
+
+	it("stringifies non-Error throws from json()", async () => {
+		fetchSpy.mockResolvedValueOnce({
+			ok: true,
+			status: 200,
+			json: vi.fn().mockRejectedValue("not-an-error-instance"),
+		} as unknown as Response);
+
+		await expect(exchangeCliCode("https://app.jolli.ai", "code-1")).rejects.toThrow(/not-an-error-instance/);
+	});
+
+	it("rejects when the server response omits the token", async () => {
+		fetchSpy.mockResolvedValueOnce(jsonResponse(200, { jolliApiKey: "sk-jol-xyz" }));
+
+		await expect(exchangeCliCode("https://app.jolli.ai", "code-1")).rejects.toThrow(
+			/server response did not include a token/,
+		);
+	});
+
+	it("rejects when the server response token is empty", async () => {
+		fetchSpy.mockResolvedValueOnce(jsonResponse(200, { token: "" }));
+
+		await expect(exchangeCliCode("https://app.jolli.ai", "code-1")).rejects.toThrow(
+			/server response did not include a token/,
+		);
+	});
+
+	it("rejects when the server response token is not a string", async () => {
+		fetchSpy.mockResolvedValueOnce(jsonResponse(200, { token: 123 }));
+
+		await expect(exchangeCliCode("https://app.jolli.ai", "code-1")).rejects.toThrow(
+			/server response did not include a token/,
+		);
+	});
+
+	it("ignores non-string jolliApiKey and space fields", async () => {
+		fetchSpy.mockResolvedValueOnce(jsonResponse(200, { token: "tk-abc", jolliApiKey: null, space: 42 }));
+
+		const result = await exchangeCliCode("https://app.jolli.ai", "code-1");
+
+		expect(result).toEqual({ token: "tk-abc" });
+	});
+});

--- a/cli/src/auth/CliExchange.ts
+++ b/cli/src/auth/CliExchange.ts
@@ -1,0 +1,100 @@
+/**
+ * CLI Code Exchange (JOLLI-1270)
+ *
+ * Trades a single-use authorization code (received via the `cli_callback`
+ * URL) for the actual auth token and any auto-generated Jolli API key.
+ *
+ * The token never appears in the browser address bar, history, or referer
+ * logs — it travels client→server only, in the JSON body of
+ * POST `/api/auth/cli-exchange`.
+ *
+ * Shared by the CLI's loopback callback server (`Login.ts`) and the VSCode
+ * extension's URI handler (`AuthService.ts`).
+ */
+
+import { assertJolliOriginAllowed, parseBaseUrl } from "../core/JolliApiUtils.js";
+
+export interface CliExchangeResult {
+	readonly token: string;
+	readonly jolliApiKey?: string;
+	readonly space?: string;
+}
+
+/**
+ * End-to-end timeout for the cli-exchange POST. The backend just reads a
+ * single-use code from a short-lived store and returns the issued token, so
+ * 20s is generous; without a bound, a half-open socket leaves the OAuth
+ * callback thread (CLI loopback server / VSCode URI handler) hung indefinitely
+ * with no user-facing way to abort.
+ */
+const CLI_EXCHANGE_TIMEOUT_MS = 20_000;
+
+/**
+ * POSTs `code` to the Jolli backend and returns the freshly-minted credentials.
+ *
+ * Throws `Error` with a user-facing message on every failure mode (network
+ * error, timeout, non-OK status, malformed JSON, missing token) so callers can
+ * surface the message directly without having to map status codes themselves.
+ *
+ * @param jolliUrl Jolli server URL. Accepts both subdomain-based
+ *   (`https://app.jolli.ai`) and path-based (`https://jolli-local.me/dev`)
+ *   tenant URLs. The cli-exchange route is mounted at the origin, not under
+ *   the tenant path, so we strip any path prefix and forward the tenant slug
+ *   as `x-tenant-slug` — same pattern as JolliPushService and LlmClient.
+ *   Re-validated against the origin allowlist before issuing the request — a
+ *   long-lived process could otherwise hold a stale, off-allowlist value.
+ * @param code 32-byte hex code minted by the consent page.
+ */
+export async function exchangeCliCode(jolliUrl: string, code: string): Promise<CliExchangeResult> {
+	assertJolliOriginAllowed(jolliUrl);
+	const parsed = parseBaseUrl(jolliUrl);
+	const targetUrl = new URL("/api/auth/cli-exchange", parsed.origin);
+
+	const headers: Record<string, string> = { "content-type": "application/json" };
+	if (parsed.tenantSlug) {
+		headers["x-tenant-slug"] = parsed.tenantSlug;
+	}
+
+	let response: Response;
+	try {
+		response = await fetch(targetUrl, {
+			method: "POST",
+			headers,
+			body: JSON.stringify({ code }),
+			signal: AbortSignal.timeout(CLI_EXCHANGE_TIMEOUT_MS),
+		});
+	} catch (err) {
+		if (err instanceof DOMException && err.name === "TimeoutError") {
+			throw new Error(
+				`Sign-in timed out after ${CLI_EXCHANGE_TIMEOUT_MS / 1000}s waiting for Jolli. Please try again.`,
+			);
+		}
+		const message = err instanceof Error ? err.message : String(err);
+		throw new Error(`Couldn't reach Jolli to complete sign-in: ${message}`);
+	}
+
+	if (response.status === 404) {
+		throw new Error("Sign-in code expired or already used. Please try signing in again.");
+	}
+	if (!response.ok) {
+		throw new Error(`Sign-in failed (HTTP ${response.status}). Please try again.`);
+	}
+
+	let payload: { token?: unknown; jolliApiKey?: unknown; space?: unknown };
+	try {
+		payload = (await response.json()) as typeof payload;
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err);
+		throw new Error(`Sign-in failed: server returned malformed response (${message}).`);
+	}
+
+	if (typeof payload.token !== "string" || !payload.token) {
+		throw new Error("Sign-in failed: server response did not include a token.");
+	}
+
+	return {
+		token: payload.token,
+		...(typeof payload.jolliApiKey === "string" && payload.jolliApiKey ? { jolliApiKey: payload.jolliApiKey } : {}),
+		...(typeof payload.space === "string" && payload.space ? { space: payload.space } : {}),
+	};
+}

--- a/cli/src/auth/Login.test.ts
+++ b/cli/src/auth/Login.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockSaveAuthCredentials = vi.fn();
 const mockLoadConfig = vi.fn();
+const mockExchangeCliCode = vi.fn();
 
 vi.mock("./AuthConfig.js", () => ({
 	saveAuthCredentials: (...args: unknown[]) => mockSaveAuthCredentials(...args),
@@ -12,12 +13,18 @@ vi.mock("../core/SessionTracker.js", () => ({
 	loadConfig: (...args: unknown[]) => mockLoadConfig(...args),
 }));
 
+vi.mock("./CliExchange.js", () => ({
+	exchangeCliCode: (...args: unknown[]) => mockExchangeCliCode(...args),
+}));
+
 const mockOpen = vi.fn();
 vi.mock("open", () => ({
 	default: (...args: unknown[]) => mockOpen(...args),
 }));
 
 import { browserLogin, createLoginServer } from "./Login.js";
+
+const TEST_JOLLI_URL = "https://app.jolli.ai";
 
 describe("Login", () => {
 	let server: Server | null = null;
@@ -26,6 +33,8 @@ describe("Login", () => {
 		vi.clearAllMocks();
 		mockSaveAuthCredentials.mockResolvedValue(undefined);
 		mockLoadConfig.mockResolvedValue({});
+		// Default: exchange succeeds with token only. Tests override per-call.
+		mockExchangeCliCode.mockResolvedValue({ token: "tk-default" });
 	});
 
 	afterEach(() => {
@@ -35,38 +44,44 @@ describe("Login", () => {
 		}
 	});
 
-	it("should save token on successful callback", async () => {
-		const result = await new Promise<void>((resolve, reject) => {
+	it("redeems the code and saves the resulting token on a successful callback", async () => {
+		mockExchangeCliCode.mockResolvedValueOnce({ token: "tk-abc" });
+
+		await new Promise<void>((resolve, reject) => {
 			server = createLoginServer({
-				port: 0, // random available port
+				port: 0,
+				jolliUrl: TEST_JOLLI_URL,
 				onListen() {
 					const addr = server?.address();
 					if (!addr || typeof addr === "string") {
 						reject(new Error("No address"));
 						return;
 					}
-					fetch(`http://127.0.0.1:${addr.port}/callback?token=test-token-abc`);
+					fetch(`http://127.0.0.1:${addr.port}/callback?code=code-abc`);
 				},
 				onSuccess: resolve,
 				onError: reject,
 			});
 		});
 
-		expect(result).toBeUndefined();
-		expect(mockSaveAuthCredentials).toHaveBeenCalledWith({ token: "test-token-abc", jolliApiKey: undefined });
+		expect(mockExchangeCliCode).toHaveBeenCalledWith(TEST_JOLLI_URL, "code-abc");
+		expect(mockSaveAuthCredentials).toHaveBeenCalledWith({ token: "tk-abc" });
 	});
 
-	it("should save apiKey when provided in callback", async () => {
+	it("forwards a jolliApiKey from the exchange to saveAuthCredentials", async () => {
+		mockExchangeCliCode.mockResolvedValueOnce({ token: "tk-1", jolliApiKey: "sk-jol-xyz" });
+
 		await new Promise<void>((resolve, reject) => {
 			server = createLoginServer({
 				port: 0,
+				jolliUrl: TEST_JOLLI_URL,
 				onListen() {
 					const addr = server?.address();
 					if (!addr || typeof addr === "string") {
 						reject(new Error("No address"));
 						return;
 					}
-					fetch(`http://127.0.0.1:${addr.port}/callback?token=tok&jolli_api_key=jk_test_key`);
+					fetch(`http://127.0.0.1:${addr.port}/callback?code=code-1`);
 				},
 				onSuccess: resolve,
 				onError: reject,
@@ -74,33 +89,37 @@ describe("Login", () => {
 		});
 
 		expect(mockSaveAuthCredentials).toHaveBeenCalledTimes(1);
-		expect(mockSaveAuthCredentials).toHaveBeenCalledWith({ token: "tok", jolliApiKey: "jk_test_key" });
+		expect(mockSaveAuthCredentials).toHaveBeenCalledWith({ token: "tk-1", jolliApiKey: "sk-jol-xyz" });
 	});
 
-	it("should not save apiKey when not provided", async () => {
+	it("omits jolliApiKey from the save call when the exchange did not return one", async () => {
+		mockExchangeCliCode.mockResolvedValueOnce({ token: "tk-bare" });
+
 		await new Promise<void>((resolve, reject) => {
 			server = createLoginServer({
 				port: 0,
+				jolliUrl: TEST_JOLLI_URL,
 				onListen() {
 					const addr = server?.address();
 					if (!addr || typeof addr === "string") {
 						reject(new Error("No address"));
 						return;
 					}
-					fetch(`http://127.0.0.1:${addr.port}/callback?token=tok`);
+					fetch(`http://127.0.0.1:${addr.port}/callback?code=code-bare`);
 				},
 				onSuccess: resolve,
 				onError: reject,
 			});
 		});
 
-		expect(mockSaveAuthCredentials).toHaveBeenCalledWith({ token: "tok", jolliApiKey: undefined });
+		expect(mockSaveAuthCredentials).toHaveBeenCalledWith({ token: "tk-bare" });
 	});
 
-	it("should handle error parameter", async () => {
+	it("surfaces a server-reported error code as a friendly message", async () => {
 		const error = await new Promise<Error>((resolve, reject) => {
 			server = createLoginServer({
 				port: 0,
+				jolliUrl: TEST_JOLLI_URL,
 				onListen() {
 					const addr = server?.address();
 					if (!addr || typeof addr === "string") {
@@ -115,12 +134,36 @@ describe("Login", () => {
 		});
 
 		expect(error.message).toBe("OAuth authentication failed. Please try again.");
+		expect(mockExchangeCliCode).not.toHaveBeenCalled();
 	});
 
-	it("should handle unknown error codes", async () => {
+	it("maps user_denied to a cancellation message and skips the exchange", async () => {
 		const error = await new Promise<Error>((resolve, reject) => {
 			server = createLoginServer({
 				port: 0,
+				jolliUrl: TEST_JOLLI_URL,
+				onListen() {
+					const addr = server?.address();
+					if (!addr || typeof addr === "string") {
+						reject(new Error("No address"));
+						return;
+					}
+					fetch(`http://127.0.0.1:${addr.port}/callback?error=user_denied`);
+				},
+				onSuccess: () => reject(new Error("Should not succeed")),
+				onError: resolve,
+			});
+		});
+
+		expect(error.message).toContain("Sign-in was cancelled");
+		expect(mockExchangeCliCode).not.toHaveBeenCalled();
+	});
+
+	it("falls back to a generic message for unknown error codes", async () => {
+		const error = await new Promise<Error>((resolve, reject) => {
+			server = createLoginServer({
+				port: 0,
+				jolliUrl: TEST_JOLLI_URL,
 				onListen() {
 					const addr = server?.address();
 					if (!addr || typeof addr === "string") {
@@ -137,10 +180,11 @@ describe("Login", () => {
 		expect(error.message).toBe("Authentication error: unknown_error");
 	});
 
-	it("should handle missing token", async () => {
+	it("rejects when the callback arrives without a code or token", async () => {
 		const error = await new Promise<Error>((resolve, reject) => {
 			server = createLoginServer({
 				port: 0,
+				jolliUrl: TEST_JOLLI_URL,
 				onListen() {
 					const addr = server?.address();
 					if (!addr || typeof addr === "string") {
@@ -154,14 +198,157 @@ describe("Login", () => {
 			});
 		});
 
-		expect(error.message).toBe("No token received");
+		expect(error.message).toBe("No authorization code or token received");
+		expect(mockExchangeCliCode).not.toHaveBeenCalled();
 	});
 
-	it("should return 404 for non-callback paths", async () => {
+	// ── Legacy token-in-URL fallback ──────────────────────────────────────
+	// Compatibility window for users on the latest CLI whose Jolli server
+	// hasn't shipped JOLLI-1270 yet. Once all server tenants emit `?code=`
+	// callbacks, this whole describe block (and the matching branch in
+	// createLoginServer) can be deleted.
+
+	describe("legacy token-in-URL fallback", () => {
+		// Silence the warn we emit on every legacy callback — it's exercised
+		// explicitly by the dedicated assertion below.
+		let warnSpy: ReturnType<typeof vi.spyOn>;
+		beforeEach(() => {
+			warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+		});
+		afterEach(() => {
+			warnSpy.mockRestore();
+		});
+
+		it("accepts a legacy callback with token + jolli_api_key", async () => {
+			await new Promise<void>((resolve, reject) => {
+				server = createLoginServer({
+					port: 0,
+					jolliUrl: TEST_JOLLI_URL,
+					onListen() {
+						const addr = server?.address();
+						if (!addr || typeof addr === "string") {
+							reject(new Error("No address"));
+							return;
+						}
+						fetch(`http://127.0.0.1:${addr.port}/callback?token=legacy-tk&jolli_api_key=sk-jol-legacy`);
+					},
+					onSuccess: resolve,
+					onError: reject,
+				});
+			});
+
+			// No exchange call — old-server callback delivers the token directly.
+			expect(mockExchangeCliCode).not.toHaveBeenCalled();
+			expect(mockSaveAuthCredentials).toHaveBeenCalledWith({
+				token: "legacy-tk",
+				jolliApiKey: "sk-jol-legacy",
+			});
+		});
+
+		it("accepts a legacy token-only callback (no jolli_api_key)", async () => {
+			await new Promise<void>((resolve, reject) => {
+				server = createLoginServer({
+					port: 0,
+					jolliUrl: TEST_JOLLI_URL,
+					onListen() {
+						const addr = server?.address();
+						if (!addr || typeof addr === "string") {
+							reject(new Error("No address"));
+							return;
+						}
+						fetch(`http://127.0.0.1:${addr.port}/callback?token=legacy-tk-2`);
+					},
+					onSuccess: resolve,
+					onError: reject,
+				});
+			});
+
+			expect(mockSaveAuthCredentials).toHaveBeenCalledWith({ token: "legacy-tk-2" });
+		});
+
+		it("emits a warn log so residual old-server traffic is observable", async () => {
+			await new Promise<void>((resolve, reject) => {
+				server = createLoginServer({
+					port: 0,
+					jolliUrl: TEST_JOLLI_URL,
+					onListen() {
+						const addr = server?.address();
+						if (!addr || typeof addr === "string") {
+							reject(new Error("No address"));
+							return;
+						}
+						fetch(`http://127.0.0.1:${addr.port}/callback?token=legacy-tk`);
+					},
+					onSuccess: resolve,
+					onError: reject,
+				});
+			});
+
+			expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("legacy token-in-URL"));
+		});
+
+		it("prefers code over token when a misconfigured server emits both", async () => {
+			// Code wins because the credential takes a more private path
+			// (server→server JSON body vs. URL string). If a server ever ships
+			// a hybrid response, we don't want to silently downgrade users.
+			mockExchangeCliCode.mockResolvedValueOnce({ token: "exchanged-tk" });
+
+			await new Promise<void>((resolve, reject) => {
+				server = createLoginServer({
+					port: 0,
+					jolliUrl: TEST_JOLLI_URL,
+					onListen() {
+						const addr = server?.address();
+						if (!addr || typeof addr === "string") {
+							reject(new Error("No address"));
+							return;
+						}
+						fetch(
+							`http://127.0.0.1:${addr.port}/callback?code=abc&token=ignored&jolli_api_key=sk-jol-ignored`,
+						);
+					},
+					onSuccess: resolve,
+					onError: reject,
+				});
+			});
+
+			expect(mockExchangeCliCode).toHaveBeenCalledWith(TEST_JOLLI_URL, "abc");
+			expect(mockSaveAuthCredentials).toHaveBeenCalledWith({ token: "exchanged-tk" });
+		});
+
+		it("propagates a save failure from the legacy path", async () => {
+			// `saveAuthCredentials` calls `validateJolliApiKey` internally — a
+			// malformed `jolli_api_key` from a legacy server reaches us here as
+			// a thrown Error and must surface through onError, not silently succeed.
+			mockSaveAuthCredentials.mockRejectedValueOnce(new Error("invalid jolli api key"));
+
+			const error = await new Promise<Error>((resolve, reject) => {
+				server = createLoginServer({
+					port: 0,
+					jolliUrl: TEST_JOLLI_URL,
+					onListen() {
+						const addr = server?.address();
+						if (!addr || typeof addr === "string") {
+							reject(new Error("No address"));
+							return;
+						}
+						fetch(`http://127.0.0.1:${addr.port}/callback?token=legacy-tk&jolli_api_key=garbage`);
+					},
+					onSuccess: () => reject(new Error("Should not succeed")),
+					onError: resolve,
+				});
+			});
+
+			expect(error.message).toBe("invalid jolli api key");
+		});
+	});
+
+	it("returns 404 for non-callback paths", async () => {
 		let responseStatus = 0;
 
 		server = createLoginServer({
 			port: 0,
+			jolliUrl: TEST_JOLLI_URL,
 			onListen() {
 				const addr = server?.address();
 				if (!addr || typeof addr === "string") return;
@@ -178,19 +365,69 @@ describe("Login", () => {
 		expect(responseStatus).toBe(404);
 	});
 
-	it("should handle saveAuthCredentials failure", async () => {
-		mockSaveAuthCredentials.mockRejectedValueOnce(new Error("Write failed"));
+	it("propagates an exchange failure as the onError reason", async () => {
+		mockExchangeCliCode.mockRejectedValueOnce(
+			new Error("Sign-in code expired or already used. Please try signing in again."),
+		);
 
 		const error = await new Promise<Error>((resolve, reject) => {
 			server = createLoginServer({
 				port: 0,
+				jolliUrl: TEST_JOLLI_URL,
 				onListen() {
 					const addr = server?.address();
 					if (!addr || typeof addr === "string") {
 						reject(new Error("No address"));
 						return;
 					}
-					fetch(`http://127.0.0.1:${addr.port}/callback?token=test`);
+					fetch(`http://127.0.0.1:${addr.port}/callback?code=code-expired`);
+				},
+				onSuccess: () => reject(new Error("Should not succeed")),
+				onError: resolve,
+			});
+		});
+
+		expect(error.message).toContain("expired or already used");
+		expect(mockSaveAuthCredentials).not.toHaveBeenCalled();
+	});
+
+	it("wraps non-Error throws from the exchange", async () => {
+		mockExchangeCliCode.mockRejectedValueOnce("plain string from fetch layer");
+
+		const error = await new Promise<Error>((resolve, reject) => {
+			server = createLoginServer({
+				port: 0,
+				jolliUrl: TEST_JOLLI_URL,
+				onListen() {
+					const addr = server?.address();
+					if (!addr || typeof addr === "string") {
+						reject(new Error("No address"));
+						return;
+					}
+					fetch(`http://127.0.0.1:${addr.port}/callback?code=code-1`);
+				},
+				onSuccess: () => reject(new Error("Should not succeed")),
+				onError: resolve,
+			});
+		});
+
+		expect(error.message).toBe("plain string from fetch layer");
+	});
+
+	it("propagates a saveAuthCredentials failure as the onError reason", async () => {
+		mockSaveAuthCredentials.mockRejectedValueOnce(new Error("Write failed"));
+
+		const error = await new Promise<Error>((resolve, reject) => {
+			server = createLoginServer({
+				port: 0,
+				jolliUrl: TEST_JOLLI_URL,
+				onListen() {
+					const addr = server?.address();
+					if (!addr || typeof addr === "string") {
+						reject(new Error("No address"));
+						return;
+					}
+					fetch(`http://127.0.0.1:${addr.port}/callback?code=code-1`);
 				},
 				onSuccess: () => reject(new Error("Should not succeed")),
 				onError: resolve,
@@ -200,19 +437,20 @@ describe("Login", () => {
 		expect(error.message).toBe("Write failed");
 	});
 
-	it("should wrap non-Error throws from saveAuthCredentials", async () => {
+	it("wraps non-Error throws from saveAuthCredentials", async () => {
 		mockSaveAuthCredentials.mockRejectedValueOnce("plain string error");
 
 		const error = await new Promise<Error>((resolve, reject) => {
 			server = createLoginServer({
 				port: 0,
+				jolliUrl: TEST_JOLLI_URL,
 				onListen() {
 					const addr = server?.address();
 					if (!addr || typeof addr === "string") {
 						reject(new Error("No address"));
 						return;
 					}
-					fetch(`http://127.0.0.1:${addr.port}/callback?token=test`);
+					fetch(`http://127.0.0.1:${addr.port}/callback?code=code-1`);
 				},
 				onSuccess: () => reject(new Error("Should not succeed")),
 				onError: resolve,
@@ -222,7 +460,7 @@ describe("Login", () => {
 		expect(error.message).toBe("plain string error");
 	});
 
-	it("should handle all known error codes", async () => {
+	it("maps every known error code to a friendly message", async () => {
 		const errorCodes: Record<string, string> = {
 			oauth_failed: "OAuth authentication failed. Please try again.",
 			session_missing: "Session expired or missing. Please try again.",
@@ -231,12 +469,15 @@ describe("Login", () => {
 			no_verified_emails: "No verified email addresses found on your account.",
 			server_error: "An unexpected server error occurred. Please try again later.",
 			failed_to_get_token: "We couldn't retrieve your credentials. Please try signing in again.",
+			user_denied: "Sign-in was cancelled. You can try again with `jolli auth login`.",
+			invalid_callback: "The sign-in callback was rejected by the server. Please try again.",
 		};
 
 		for (const [code, expectedMessage] of Object.entries(errorCodes)) {
 			const error = await new Promise<Error>((resolve, reject) => {
 				server = createLoginServer({
 					port: 0,
+					jolliUrl: TEST_JOLLI_URL,
 					onListen() {
 						const addr = server?.address();
 						if (!addr || typeof addr === "string") {
@@ -256,13 +497,14 @@ describe("Login", () => {
 		}
 	});
 
-	it("should call onError when server fails to bind", async () => {
+	it("calls onError when the server fails to bind to the chosen port", async () => {
 		// Occupy a port, then try to bind to it. Wait for blocker to actually
 		// be listening before reading .address() — listen() is async, so reading
 		// synchronously after createLoginServer can race and yield port 0.
 		const blocker = await new Promise<Server>((resolve) => {
 			const s = createLoginServer({
 				port: 0,
+				jolliUrl: TEST_JOLLI_URL,
 				onListen: () => resolve(s),
 				onSuccess: vi.fn(),
 				onError: vi.fn(),
@@ -274,6 +516,7 @@ describe("Login", () => {
 		const error = await new Promise<Error>((resolve, reject) => {
 			server = createLoginServer({
 				port: blockerPort,
+				jolliUrl: TEST_JOLLI_URL,
 				onListen: () => reject(new Error("Should not listen")),
 				onSuccess: () => reject(new Error("Should not succeed")),
 				onError: resolve,
@@ -285,51 +528,61 @@ describe("Login", () => {
 	});
 
 	describe("browserLogin", () => {
-		/** Simulates a browser: extracts cli_callback from the opened URL and fetches it with a token. */
-		function simulateBrowserCallback(token: string) {
+		/**
+		 * Simulates a browser: extracts cli_callback from the opened URL and
+		 * sends a callback with the supplied code. The exchange step itself is
+		 * stubbed via `mockExchangeCliCode`, so the test only asserts the URL
+		 * round-trip.
+		 */
+		function simulateBrowserCallback(code: string) {
 			return (url: string) => {
 				const callbackUrl = new URL(url).searchParams.get("cli_callback");
 				if (callbackUrl) {
-					fetch(`${callbackUrl}?token=${token}`);
+					fetch(`${callbackUrl}?code=${code}`);
 				}
 				return { unref: vi.fn() };
 			};
 		}
 
-		it("should open browser with generate_api_key when no jolliApiKey", async () => {
+		it("opens the browser to <jolliUrl>/login with generate_api_key when no jolliApiKey is set", async () => {
 			mockLoadConfig.mockResolvedValue({});
-			mockOpen.mockImplementation(simulateBrowserCallback("browser-token"));
+			mockExchangeCliCode.mockResolvedValue({ token: "browser-token" });
+			mockOpen.mockImplementation(simulateBrowserCallback("browser-code"));
 
-			await browserLogin("https://app.jolli.ai/login");
+			await browserLogin(TEST_JOLLI_URL);
 
-			expect(mockOpen).toHaveBeenCalledWith(expect.stringContaining("generate_api_key=true"));
-			expect(mockOpen).toHaveBeenCalledWith(expect.stringContaining("client=cli"));
-			expect(mockSaveAuthCredentials).toHaveBeenCalledWith({ token: "browser-token", jolliApiKey: undefined });
+			const openedUrl = mockOpen.mock.calls[0][0] as string;
+			expect(openedUrl).toContain("https://app.jolli.ai/login?");
+			expect(openedUrl).toContain("generate_api_key=true");
+			expect(openedUrl).toContain("client=cli");
+			expect(mockExchangeCliCode).toHaveBeenCalledWith(TEST_JOLLI_URL, "browser-code");
+			expect(mockSaveAuthCredentials).toHaveBeenCalledWith({ token: "browser-token" });
 		});
 
-		it("should open browser without generate_api_key when jolliApiKey exists", async () => {
+		it("omits generate_api_key when a jolliApiKey is already configured", async () => {
 			mockLoadConfig.mockResolvedValue({ jolliApiKey: "jk_existing" });
-			mockOpen.mockImplementation(simulateBrowserCallback("browser-token-2"));
+			mockExchangeCliCode.mockResolvedValue({ token: "browser-token-2" });
+			mockOpen.mockImplementation(simulateBrowserCallback("browser-code-2"));
 
-			await browserLogin("https://app.jolli.ai/login");
+			await browserLogin(TEST_JOLLI_URL);
 
 			const openUrl = mockOpen.mock.calls[0][0] as string;
 			expect(openUrl).not.toContain("generate_api_key");
-			expect(mockSaveAuthCredentials).toHaveBeenCalledWith({ token: "browser-token-2", jolliApiKey: undefined });
+			expect(mockSaveAuthCredentials).toHaveBeenCalledWith({ token: "browser-token-2" });
 		});
 
-		it("should reject when open() throws (e.g. headless server)", async () => {
+		it("rejects when open() throws (e.g. headless server)", async () => {
 			mockLoadConfig.mockResolvedValue({});
 			mockOpen.mockRejectedValue(new Error("No browser available"));
 
-			await expect(browserLogin("https://app.jolli.ai/login")).rejects.toThrow("No browser available");
+			await expect(browserLogin(TEST_JOLLI_URL)).rejects.toThrow("No browser available");
 		});
 
-		it("should reject with wrapped error when open() throws a non-Error", async () => {
+		it("rejects with a wrapped error when open() throws a non-Error", async () => {
 			mockLoadConfig.mockResolvedValue({});
 			mockOpen.mockRejectedValue("string error");
 
-			await expect(browserLogin("https://app.jolli.ai/login")).rejects.toThrow("string error");
+			await expect(browserLogin(TEST_JOLLI_URL)).rejects.toThrow("string error");
 		});
 	});
 });

--- a/cli/src/auth/Login.ts
+++ b/cli/src/auth/Login.ts
@@ -2,8 +2,9 @@
  * Browser OAuth Login Flow
  *
  * Opens the user's browser to the Jolli login/signup page and starts a local
- * HTTP server to receive the OAuth callback. On success, persists the auth
- * token (and optionally an API key) to the global config.
+ * HTTP server to receive the OAuth callback. On success, redeems the
+ * single-use exchange code (JOLLI-1270) and persists the auth token (and
+ * optionally an API key) to the global config.
  */
 
 import { createServer, type Server, type ServerResponse } from "node:http";
@@ -11,19 +12,25 @@ import { URL } from "node:url";
 import open from "open";
 import { loadConfig } from "../core/SessionTracker.js";
 import { saveAuthCredentials } from "./AuthConfig.js";
+import { exchangeCliCode } from "./CliExchange.js";
 
 /**
- * Opens the browser to `baseUrl` with a CLI callback URL, waits for the OAuth
- * redirect, and saves the resulting credentials.
+ * Opens the browser to `${jolliUrl}/login` with a CLI callback URL, waits for
+ * the OAuth redirect, redeems the exchange code, and saves the resulting
+ * credentials.
  *
  * Uses port 0 so the OS assigns a free port — avoids EADDRINUSE conflicts.
  *
- * @param baseUrl - Full login page URL (e.g. `https://app.jolli.ai/login`)
+ * @param jolliUrl Origin of the Jolli server (e.g. `https://app.jolli.ai`).
+ *   The same origin is used to build the login page URL and to redeem the
+ *   exchange code, so the two halves of the flow can never disagree on which
+ *   tenant is being signed into.
  */
-export function browserLogin(baseUrl: string): Promise<void> {
+export function browserLogin(jolliUrl: string): Promise<void> {
 	return new Promise((resolve, reject) => {
 		const server = createLoginServer({
 			port: 0,
+			jolliUrl,
 			async onListen() {
 				try {
 					const addr = server.address();
@@ -35,7 +42,7 @@ export function browserLogin(baseUrl: string): Promise<void> {
 
 					// If no jolliApiKey yet, ask the server to generate one during login
 					const config = await loadConfig();
-					let loginUrl = `${baseUrl}?cli_callback=${encodeURIComponent(callbackUrl)}`;
+					let loginUrl = `${jolliUrl}/login?cli_callback=${encodeURIComponent(callbackUrl)}`;
 					if (!config.jolliApiKey) {
 						loginUrl += "&generate_api_key=true&client=cli";
 					}
@@ -59,6 +66,8 @@ export function browserLogin(baseUrl: string): Promise<void> {
 
 interface LoginServerOptions {
 	readonly port: number;
+	/** Jolli origin used to redeem the exchange code (server-to-server POST). */
+	readonly jolliUrl: string;
 	onListen(): void;
 	onSuccess(): void;
 	onError(error: Error): void;
@@ -66,9 +75,25 @@ interface LoginServerOptions {
 
 /**
  * Creates the local HTTP callback server. Exported for testing.
+ *
+ * Accepts two callback shapes, in priority order:
+ *
+ *   1. JOLLI-1270 code-exchange (preferred — issued by upgraded servers):
+ *        /callback?code=<32-byte-hex>
+ *      Redeemed via {@link exchangeCliCode}; the token never appears in the
+ *      browser address bar, history, or referer logs — it arrives only as the
+ *      JSON response of the server-to-server exchange POST.
+ *
+ *   2. Legacy token-in-URL (fallback — issued by pre-1270 servers):
+ *        /callback?token=<jwt>&jolli_api_key=<sk-jol-…>
+ *      Server delivers credentials directly in query params. Less secure
+ *      (token visible to browser history/referer), but required so users on
+ *      the latest CLI can still sign in to a server that hasn't shipped the
+ *      code-exchange endpoint yet. Remove once all server tenants issue
+ *      `?code=` callbacks.
  */
 export function createLoginServer(options: LoginServerOptions): Server {
-	const { port, onListen, onSuccess, onError } = options;
+	const { port, jolliUrl, onListen, onSuccess, onError } = options;
 
 	const server = createServer(async (req, res) => {
 		const url = new URL((req as { url: string }).url, `http://127.0.0.1:${port}`);
@@ -78,12 +103,7 @@ export function createLoginServer(options: LoginServerOptions): Server {
 			return;
 		}
 
-		const token = url.searchParams.get("token");
-		const jolliApiKey = url.searchParams.get("jolli_api_key");
 		const error = url.searchParams.get("error");
-
-		// Space param is intentionally ignored — JolliMemory doesn't use space slug
-
 		if (error) {
 			const errorMessage = getErrorMessage(error);
 			sendHtml(res, 400, "Login Failed", errorMessage);
@@ -92,22 +112,47 @@ export function createLoginServer(options: LoginServerOptions): Server {
 			return;
 		}
 
-		if (!token) {
-			sendHtml(res, 400, "Login Failed", "No token received");
-			closeServer(server);
-			onError(new Error("No token received"));
-			return;
-		}
+		// New and legacy shapes are mutually exclusive in practice (a given
+		// server emits one or the other), so this just selects the right path
+		// automatically — no version probe needed.
+		const code = url.searchParams.get("code");
+		const legacyToken = url.searchParams.get("token");
 
 		try {
-			await saveAuthCredentials({ token, jolliApiKey: jolliApiKey ?? undefined });
+			let credentials: { token: string; jolliApiKey?: string };
+			if (code) {
+				const exchanged = await exchangeCliCode(jolliUrl, code);
+				credentials = {
+					token: exchanged.token,
+					...(exchanged.jolliApiKey ? { jolliApiKey: exchanged.jolliApiKey } : {}),
+				};
+			} else if (legacyToken) {
+				// Legacy fallback. Logged at warn level so we can track residual
+				// usage and decide when it's safe to drop this branch.
+				console.warn(
+					"Using legacy token-in-URL callback — server has not been upgraded to JOLLI-1270 code-exchange",
+				);
+				const legacyApiKey = url.searchParams.get("jolli_api_key");
+				credentials = {
+					token: legacyToken,
+					...(legacyApiKey ? { jolliApiKey: legacyApiKey } : {}),
+				};
+			} else {
+				const message = "No authorization code or token received";
+				sendHtml(res, 400, "Login Failed", message);
+				closeServer(server);
+				onError(new Error(message));
+				return;
+			}
+			await saveAuthCredentials(credentials);
 			sendHtml(res, 200, "Login Successful!", "Your account has been connected to Jolli.");
 			closeServer(server);
 			onSuccess();
 		} catch (err) {
-			sendHtml(res, 500, "Error", `Failed to save token: ${err}`);
+			const message = err instanceof Error ? err.message : String(err);
+			sendHtml(res, 500, "Login Failed", message);
 			closeServer(server);
-			onError(err instanceof Error ? err : new Error(String(err)));
+			onError(err instanceof Error ? err : new Error(message));
 		}
 	});
 
@@ -200,6 +245,8 @@ function getErrorMessage(errorCode: string): string {
 		no_verified_emails: "No verified email addresses found on your account.",
 		server_error: "An unexpected server error occurred. Please try again later.",
 		failed_to_get_token: "We couldn't retrieve your credentials. Please try signing in again.",
+		user_denied: "Sign-in was cancelled. You can try again with `jolli auth login`.",
+		invalid_callback: "The sign-in callback was rejected by the server. Please try again.",
 	};
 
 	return errorMessages[errorCode] || `Authentication error: ${errorCode}`;

--- a/cli/src/commands/AuthCommand.ts
+++ b/cli/src/commands/AuthCommand.ts
@@ -15,8 +15,7 @@ export function registerAuthCommands(program: Command): void {
 		.description("Log in to Jolli via browser")
 		.action(async () => {
 			try {
-				const baseUrl = getJolliUrl();
-				await browserLogin(`${baseUrl}/login`);
+				await browserLogin(getJolliUrl());
 				const config = await loadConfig();
 				console.log("\n  Signed in successfully!");
 				console.log("  Auth token:        saved ✓");

--- a/cli/src/commands/EnableCommand.ts
+++ b/cli/src/commands/EnableCommand.ts
@@ -60,8 +60,7 @@ export async function promptSetup(): Promise<void> {
 /** Opens the browser for OAuth login/signup and saves credentials on callback. */
 async function handleBrowserLogin(): Promise<void> {
 	try {
-		const baseUrl = getJolliUrl();
-		await browserLogin(`${baseUrl}/login`);
+		await browserLogin(getJolliUrl());
 		console.log("\n  Authenticated successfully ✓");
 		const configDir = getGlobalConfigDir();
 		const config = await loadConfigFromDir(configDir);

--- a/vscode/src/Extension.test.ts
+++ b/vscode/src/Extension.test.ts
@@ -3938,9 +3938,9 @@ describe("Extension", () => {
 
 			const mockUri = {
 				path: "/auth-callback",
-				query: "token=test&jolli_api_key=sk-jol-test",
+				query: "code=abc123",
 				toString: () =>
-					"vscode://jolli.jollimemory-vscode/auth-callback?token=test",
+					"vscode://jolli.jollimemory-vscode/auth-callback?code=abc123",
 			};
 			await handler.handleUri(mockUri);
 
@@ -3954,7 +3954,7 @@ describe("Extension", () => {
 		it("shows error message on failed auth callback", async () => {
 			mockAuthService.handleAuthCallback.mockResolvedValueOnce({
 				success: false,
-				error: "No token received",
+				error: "No authorization code received",
 			});
 
 			const ctx = makeContext();
@@ -3977,7 +3977,7 @@ describe("Extension", () => {
 			await handler.handleUri(mockUri);
 
 			expect(showErrorMessage).toHaveBeenCalledWith(
-				"Jolli sign-in failed: No token received",
+				"Jolli sign-in failed: No authorization code received",
 			);
 		});
 	});

--- a/vscode/src/Extension.ts
+++ b/vscode/src/Extension.ts
@@ -1911,7 +1911,11 @@ export function activate(context: vscode.ExtensionContext): void {
 
 	// ── URI handler ──────────────────────────────────────────────────────────
 	// Receives the OAuth callback after browser-based login/signup.
-	// URI format: <host-scheme>://jolli.jollimemory-vscode/auth-callback?token=...&jolli_api_key=...
+	// URI format (JOLLI-1270 code-exchange flow):
+	//   <host-scheme>://jolli.jollimemory-vscode/auth-callback?code=<32-byte-hex>
+	//   <host-scheme>://jolli.jollimemory-vscode/auth-callback?error=user_denied
+	// AuthService redeems the code via POST /api/auth/cli-exchange — the token
+	// itself never appears in the callback URL.
 	// <host-scheme> is derived from vscode.env.appName (NOT uriScheme — forks
 	// tend to leave that at the upstream "vscode" default even though they
 	// register their own scheme at the OS level). See resolveUriScheme() in

--- a/vscode/src/services/AuthService.test.ts
+++ b/vscode/src/services/AuthService.test.ts
@@ -10,6 +10,10 @@ const { saveAuthCredentials, clearAuthCredentials, getJolliUrl } = vi.hoisted(
 	}),
 );
 
+const { exchangeCliCode } = vi.hoisted(() => ({
+	exchangeCliCode: vi.fn(),
+}));
+
 const { loadConfig } = vi.hoisted(() => ({
 	loadConfig: vi.fn().mockResolvedValue({}),
 }));
@@ -97,6 +101,10 @@ vi.mock("../../../cli/src/auth/AuthConfig.js", () => ({
 	getJolliUrl,
 }));
 
+vi.mock("../../../cli/src/auth/CliExchange.js", () => ({
+	exchangeCliCode,
+}));
+
 vi.mock("../../../cli/src/core/SessionTracker.js", () => ({
 	loadConfig,
 }));
@@ -132,21 +140,29 @@ describe("AuthService", () => {
 		loadConfig.mockResolvedValue({});
 		// Reset host-IDE appName to VSCode Stable; per-test overrides simulate forks.
 		appNameState.current = "Visual Studio Code";
+		// Default: code-exchange succeeds and returns a token only. Tests that
+		// need an API key or different failure modes override per-call.
+		exchangeCliCode.mockResolvedValue({ token: "test-token" });
 		service = new AuthService();
 	});
 
 	// ── handleAuthCallback ──────────────────────────────────────────────
 
 	describe("handleAuthCallback", () => {
-		it("should save token and API key atomically on successful callback", async () => {
-			const uri = makeUri(
-				"/auth-callback",
-				"token=test-token&jolli_api_key=sk-jol-test",
-			);
+		it("should exchange the code and save token + API key atomically on success", async () => {
+			exchangeCliCode.mockResolvedValueOnce({
+				token: "test-token",
+				jolliApiKey: "sk-jol-test",
+			});
+			const uri = makeUri("/auth-callback", "code=abc123");
 
 			const result = await service.handleAuthCallback(uri as never);
 
 			expect(result).toEqual({ success: true });
+			expect(exchangeCliCode).toHaveBeenCalledWith(
+				"https://app.jolli.ai",
+				"abc123",
+			);
 			expect(saveAuthCredentials).toHaveBeenCalledWith({
 				token: "test-token",
 				jolliApiKey: "sk-jol-test",
@@ -159,16 +175,26 @@ describe("AuthService", () => {
 			);
 		});
 
-		it("should save only token when API key is absent", async () => {
-			const uri = makeUri("/auth-callback", "token=test-token");
+		it("should save only the token when the exchange omits an API key", async () => {
+			exchangeCliCode.mockResolvedValueOnce({ token: "test-token" });
+			const uri = makeUri("/auth-callback", "code=abc123");
 
 			const result = await service.handleAuthCallback(uri as never);
 
 			expect(result).toEqual({ success: true });
-			expect(saveAuthCredentials).toHaveBeenCalledWith({
-				token: "test-token",
-				jolliApiKey: undefined,
-			});
+			expect(saveAuthCredentials).toHaveBeenCalledWith({ token: "test-token" });
+		});
+
+		it("should pass the configured JOLLI_URL through to the exchange", async () => {
+			getJolliUrl.mockReturnValueOnce("https://custom.jolli.ai");
+			const uri = makeUri("/auth-callback", "code=abc123");
+
+			await service.handleAuthCallback(uri as never);
+
+			expect(exchangeCliCode).toHaveBeenCalledWith(
+				"https://custom.jolli.ai",
+				"abc123",
+			);
 		});
 
 		it("should return error for server-reported error codes", async () => {
@@ -182,7 +208,22 @@ describe("AuthService", () => {
 					"OAuth authentication failed. Please try again.",
 				);
 			}
+			expect(exchangeCliCode).not.toHaveBeenCalled();
 			expect(saveAuthCredentials).not.toHaveBeenCalled();
+		});
+
+		it("should return a friendly message when the user cancels on the consent page", async () => {
+			const uri = makeUri("/auth-callback", "error=user_denied");
+
+			const result = await service.handleAuthCallback(uri as never);
+
+			expect(result.success).toBe(false);
+			if (!result.success) {
+				expect(result.error).toBe(
+					"Sign-in was cancelled. You can try again from the side panel.",
+				);
+			}
+			expect(exchangeCliCode).not.toHaveBeenCalled();
 		});
 
 		it("should return user-friendly message for known error codes", async () => {
@@ -209,20 +250,125 @@ describe("AuthService", () => {
 			}
 		});
 
-		it("should return error when token is missing", async () => {
+		it("should return error when both code and token are missing", async () => {
+			// `jolli_api_key` alone is meaningless — we have no token to pair it
+			// with, regardless of which server flow the callback came from.
 			const uri = makeUri("/auth-callback", "jolli_api_key=sk-jol-test");
 
 			const result = await service.handleAuthCallback(uri as never);
 
 			expect(result.success).toBe(false);
 			if (!result.success) {
-				expect(result.error).toBe("No authentication token received");
+				expect(result.error).toBe("No authorization code or token received");
 			}
+			expect(exchangeCliCode).not.toHaveBeenCalled();
 			expect(saveAuthCredentials).not.toHaveBeenCalled();
 		});
 
+		// ── Legacy token-in-URL fallback ──────────────────────────────────
+		// Compatibility window for users on the latest extension whose Jolli
+		// server hasn't shipped JOLLI-1270 yet. Once all server tenants emit
+		// `?code=` callbacks, this whole describe block (and the matching
+		// branch in handleAuthCallback) can be deleted.
+
+		it("should accept legacy token-in-URL callback with jolli_api_key", async () => {
+			const uri = makeUri(
+				"/auth-callback",
+				"token=legacy-token&jolli_api_key=sk-jol-legacy",
+			);
+
+			const result = await service.handleAuthCallback(uri as never);
+
+			expect(result).toEqual({ success: true });
+			// No exchange call — old-server callback delivers the token directly.
+			expect(exchangeCliCode).not.toHaveBeenCalled();
+			expect(saveAuthCredentials).toHaveBeenCalledWith({
+				token: "legacy-token",
+				jolliApiKey: "sk-jol-legacy",
+			});
+			expect(executeCommand).toHaveBeenCalledWith(
+				"setContext",
+				"jollimemory.signedIn",
+				true,
+			);
+		});
+
+		it("should accept legacy token-only callback (no jolli_api_key param)", async () => {
+			const uri = makeUri("/auth-callback", "token=legacy-token");
+
+			const result = await service.handleAuthCallback(uri as never);
+
+			expect(result).toEqual({ success: true });
+			expect(saveAuthCredentials).toHaveBeenCalledWith({
+				token: "legacy-token",
+			});
+		});
+
+		it("should log a warning when falling back to legacy token-in-URL", async () => {
+			// The warn log is our signal for tracking residual old-server traffic
+			// after the server rollout — needed to know when it's safe to drop
+			// the fallback branch.
+			const uri = makeUri("/auth-callback", "token=legacy-token");
+
+			await service.handleAuthCallback(uri as never);
+
+			expect(warn).toHaveBeenCalledWith(
+				"AuthService",
+				expect.stringContaining("legacy token-in-URL"),
+			);
+		});
+
+		it("should prefer code over token when both are present", async () => {
+			// A misconfigured server could in theory emit both — code takes
+			// priority because it leaks the actual credential through fewer
+			// surfaces (no browser history, no referer, no URI handler chain).
+			exchangeCliCode.mockResolvedValueOnce({
+				token: "exchanged-token",
+				jolliApiKey: "sk-jol-exchanged",
+			});
+			const uri = makeUri(
+				"/auth-callback",
+				"code=abc123&token=ignored-legacy-token&jolli_api_key=sk-jol-ignored",
+			);
+
+			const result = await service.handleAuthCallback(uri as never);
+
+			expect(result).toEqual({ success: true });
+			expect(exchangeCliCode).toHaveBeenCalledWith(
+				"https://app.jolli.ai",
+				"abc123",
+			);
+			expect(saveAuthCredentials).toHaveBeenCalledWith({
+				token: "exchanged-token",
+				jolliApiKey: "sk-jol-exchanged",
+			});
+		});
+
+		it("should propagate save failure from the legacy token path", async () => {
+			// `saveAuthCredentials` calls `validateJolliApiKey` internally — a
+			// malformed `jolli_api_key` from a legacy server reaches us here as
+			// a thrown Error and must surface the same way as the code-flow
+			// save failures (so the user sees "Failed to save credentials: …"
+			// instead of a silent success).
+			saveAuthCredentials.mockRejectedValueOnce(
+				new Error("invalid jolli api key"),
+			);
+			const uri = makeUri(
+				"/auth-callback",
+				"token=legacy-token&jolli_api_key=garbage",
+			);
+
+			const result = await service.handleAuthCallback(uri as never);
+
+			expect(result.success).toBe(false);
+			if (!result.success) {
+				expect(result.error).toContain("Failed to save credentials");
+				expect(result.error).toContain("invalid jolli api key");
+			}
+		});
+
 		it("should ignore unknown URI paths", async () => {
-			const uri = makeUri("/some-other-path", "token=test-token");
+			const uri = makeUri("/some-other-path", "code=abc123");
 
 			const result = await service.handleAuthCallback(uri as never);
 
@@ -230,12 +376,42 @@ describe("AuthService", () => {
 			if (!result.success) {
 				expect(result.error).toBe("Unknown callback path");
 			}
+			expect(exchangeCliCode).not.toHaveBeenCalled();
 			expect(saveAuthCredentials).not.toHaveBeenCalled();
+		});
+
+		it("should surface the exchange failure message and skip saving", async () => {
+			exchangeCliCode.mockRejectedValueOnce(
+				new Error(
+					"Sign-in code expired or already used. Please try signing in again.",
+				),
+			);
+			const uri = makeUri("/auth-callback", "code=abc123");
+
+			const result = await service.handleAuthCallback(uri as never);
+
+			expect(result.success).toBe(false);
+			if (!result.success) {
+				expect(result.error).toContain("expired or already used");
+			}
+			expect(saveAuthCredentials).not.toHaveBeenCalled();
+		});
+
+		it("should stringify non-Error throws from the exchange", async () => {
+			exchangeCliCode.mockRejectedValueOnce("bare exchange rejection");
+			const uri = makeUri("/auth-callback", "code=abc123");
+
+			const result = await service.handleAuthCallback(uri as never);
+
+			expect(result.success).toBe(false);
+			if (!result.success) {
+				expect(result.error).toContain("bare exchange rejection");
+			}
 		});
 
 		it("should return error when save fails", async () => {
 			saveAuthCredentials.mockRejectedValueOnce(new Error("disk full"));
-			const uri = makeUri("/auth-callback", "token=test-token");
+			const uri = makeUri("/auth-callback", "code=abc123");
 
 			const result = await service.handleAuthCallback(uri as never);
 
@@ -249,7 +425,7 @@ describe("AuthService", () => {
 		it("should stringify non-Error throw from saveAuthCredentials", async () => {
 			// Covers the `err instanceof Error ? err.message : String(err)` right branch.
 			saveAuthCredentials.mockRejectedValueOnce("bare string rejection");
-			const uri = makeUri("/auth-callback", "token=test-token");
+			const uri = makeUri("/auth-callback", "code=abc123");
 
 			const result = await service.handleAuthCallback(uri as never);
 
@@ -260,13 +436,13 @@ describe("AuthService", () => {
 		});
 
 		it("should continue returning success when setContext throws", async () => {
-			// Covers the log.warn branch in the setContext catch (line 106).
+			// Covers the log.warn branch in the setContext catch.
 			// executeCommand succeeds for saveAuthCredentials's lifecycle but throws
 			// specifically for the setContext call.
 			executeCommand.mockImplementationOnce(() => {
 				throw new Error("setContext unavailable");
 			});
-			const uri = makeUri("/auth-callback", "token=test-token");
+			const uri = makeUri("/auth-callback", "code=abc123");
 
 			const result = await service.handleAuthCallback(uri as never);
 

--- a/vscode/src/services/AuthService.ts
+++ b/vscode/src/services/AuthService.ts
@@ -17,6 +17,7 @@ import {
 	getJolliUrl,
 	saveAuthCredentials,
 } from "../../../cli/src/auth/AuthConfig.js";
+import { exchangeCliCode } from "../../../cli/src/auth/CliExchange.js";
 import { loadConfig } from "../../../cli/src/core/SessionTracker.js";
 import type { JolliMemoryConfig } from "../../../cli/src/Types.js";
 import { log } from "../util/Logger.js";
@@ -52,9 +53,23 @@ export class AuthService {
 	/**
 	 * Handles the OAuth callback URI from the browser redirect.
 	 *
-	 * Expected URI format (matching CLI convention from Login.ts):
-	 *   vscode://jolli.jollimemory-vscode/auth-callback?token=xxx&jolli_api_key=sk-jol-xxx
-	 *   vscode://jolli.jollimemory-vscode/auth-callback?error=oauth_failed
+	 * Two callback shapes are accepted, in priority order:
+	 *
+	 *   1. JOLLI-1270 code-exchange (preferred — issued by upgraded servers):
+	 *        vscode://jolli.jollimemory-vscode/auth-callback?code=<32-byte-hex>
+	 *      The `code` is single-use and TTL-bound; we POST it to
+	 *      `/api/auth/cli-exchange` to redeem the actual token + API key over a
+	 *      channel the browser never sees.
+	 *
+	 *   2. Legacy token-in-URL (fallback — issued by pre-1270 servers):
+	 *        vscode://jolli.jollimemory-vscode/auth-callback?token=<jwt>&jolli_api_key=<sk-jol-…>
+	 *      Server delivers credentials directly in query params. Less secure
+	 *      (token visible to URI handler chain), but required so users on the
+	 *      latest extension can still sign in to a server that hasn't shipped
+	 *      the code-exchange endpoint yet. Remove once all server tenants
+	 *      issue `?code=` callbacks.
+	 *
+	 *   3. Error: ?error=<code>
 	 */
 	async handleAuthCallback(uri: vscode.Uri): Promise<AuthCallbackResult> {
 		if (uri.path !== AUTH_CALLBACK_PATH) {
@@ -70,21 +85,51 @@ export class AuthService {
 			return { success: false, error: message };
 		}
 
+		// Prefer the code-exchange flow when the server offers it. The two
+		// shapes are mutually exclusive in practice (a given server emits one
+		// or the other), so this just selects the right path automatically.
+		const code = params.get("code");
 		const token = params.get("token");
-		if (!token) {
-			log.error("AuthService", "Auth callback missing token");
-			return { success: false, error: "No authentication token received" };
-		}
 
-		const jolliApiKey = params.get("jolli_api_key");
+		let credentials: { token: string; jolliApiKey?: string };
+		if (code) {
+			try {
+				const exchanged = await exchangeCliCode(getJolliUrl(), code);
+				credentials = {
+					token: exchanged.token,
+					...(exchanged.jolliApiKey
+						? { jolliApiKey: exchanged.jolliApiKey }
+						: {}),
+				};
+			} catch (err: unknown) {
+				const message = err instanceof Error ? err.message : String(err);
+				log.error("AuthService", "Failed to exchange code: %s", message);
+				return { success: false, error: message };
+			}
+		} else if (token) {
+			// Legacy fallback. Logged at warn level so we can track residual
+			// usage and decide when it's safe to drop this branch.
+			log.warn(
+				"AuthService",
+				"Using legacy token-in-URL callback — server has not been upgraded to JOLLI-1270 code-exchange",
+			);
+			const legacyApiKey = params.get("jolli_api_key");
+			credentials = {
+				token,
+				...(legacyApiKey ? { jolliApiKey: legacyApiKey } : {}),
+			};
+		} else {
+			log.error("AuthService", "Auth callback missing code and token");
+			return {
+				success: false,
+				error: "No authorization code or token received",
+			};
+		}
 
 		try {
 			// Single atomic write — avoids leaving the config in a half-written state
 			// (token saved, API key dropped) if the second write were to fail.
-			await saveAuthCredentials({
-				token,
-				jolliApiKey: jolliApiKey ?? undefined,
-			});
+			await saveAuthCredentials(credentials);
 		} catch (err: unknown) {
 			const message = err instanceof Error ? err.message : String(err);
 			log.error("AuthService", "Failed to save credentials: %s", message);
@@ -223,6 +268,10 @@ function getErrorMessage(errorCode: string): string {
 			"An unexpected server error occurred. Please try again later.",
 		failed_to_get_token:
 			"We couldn't retrieve your credentials. Please try signing in again.",
+		user_denied:
+			"Sign-in was cancelled. You can try again from the side panel.",
+		invalid_callback:
+			"The sign-in callback was rejected by the server. Please try again.",
 	};
 	return errorMessages[errorCode] ?? `Authentication error: ${errorCode}`;
 }


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## Quick recap

The developer implemented OAuth's authorization-code flow for CLI and VSCode authentication, replacing the previous method where access tokens appeared directly in browser URLs. Under the new flow, the browser receives only a single-use code, which the client then exchanges server-side in a secure POST request, eliminating exposure to browser history, referrer logs, and address-bar leaks.

During the server upgrade window, both clients support a temporary fallback to the legacy token-in-URL pattern for users on older backend servers. The fallback logic lives in the client rather than the server, allowing the backend to commit to the more secure code-only approach immediately while CLI and VSCode gracefully degrade for several weeks as users update. Warn logs track every legacy callback, providing visibility into when the fallback is no longer needed and can be safely removed.

Both CLI and VSCode share a common authentication module to ensure consistent error handling and retry behavior across clients. Failed code exchanges surface errors immediately to the user, who can retry manually via a flag or by re-running login, respecting the voluntary nature of authentication operations and avoiding silent background retries of sensitive credentials.

---

## E2E Test (9)
<details>
<summary><strong>1. OAuth code-exchange login flow (new secure method)</strong></summary>
<br>
<blockquote>

**Preconditions:** Have access to a Jolli server that supports the new OAuth code-exchange flow. You will need to be able to trigger a login and observe the browser callback.

**Steps:**
1. Open the CLI and run `jolli auth login`
2. A browser window opens automatically. Complete the sign-in flow on the Jolli website and click the consent button
3. After clicking consent, you are redirected to a local callback page in your browser
4. Check the browser address bar — it should show `http://127.0.0.1:<port>/callback?code=...` (a single-use code, not a token)
5. Wait for the CLI to display a success message and confirm your credentials are saved
6. Run `jolli auth status` to verify the token is active

**Expected Results:**
- The browser address bar contains `?code=` (not `?token=`)
- The CLI displays "Sign-in successful" or similar confirmation
- `jolli auth status` shows your authenticated user
- No token or API key appears in the browser history or address bar

</blockquote>
</details>
<details>
<summary><strong>2. Legacy token-in-URL fallback (backward compatibility)</strong></summary>
<br>
<blockquote>

**Preconditions:** Have access to an older Jolli server that still uses the legacy token-in-URL callback method (not yet upgraded to code-exchange).

**Steps:**
1. Open the CLI and run `jolli auth login`
2. A browser window opens. Complete the sign-in flow and click consent
3. After clicking consent, you are redirected to a local callback page
4. Check the browser address bar — it should show `http://127.0.0.1:<port>/callback?token=...` (the old method)
5. Wait for the CLI to display a success message
6. Check the CLI output for a warning message mentioning "legacy token-in-URL"

**Expected Results:**
- The browser address bar contains `?token=` (the old format)
- The CLI displays a success message and saves credentials
- A warning appears in the CLI output (visible in logs) indicating legacy flow was used
- The login still works despite the server not being upgraded yet

</blockquote>
</details>
<details>
<summary><strong>3. Sign-in code expiration handling</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a way to generate an expired or already-used sign-in code (or wait for a code to expire naturally if your server has a short expiration window).

**Steps:**
1. Open the CLI and run `jolli auth login`
2. A browser window opens. Do NOT complete the sign-in immediately
3. Wait for the code to expire (or use an already-consumed code from a previous attempt)
4. Try to complete the sign-in flow by clicking consent
5. Observe the error message displayed in the CLI

**Expected Results:**
- The CLI displays a clear error message: "Sign-in code expired or already used. Please try signing in again."
- The error message is user-friendly (not a raw HTTP error code)
- No credentials are saved
- The user can retry by running `jolli auth login` again

</blockquote>
</details>
<details>
<summary><strong>4. VSCode extension OAuth login (code-exchange flow)</strong></summary>
<br>
<blockquote>

**Preconditions:** Have the Jolli VSCode extension installed and a Jolli server that supports code-exchange.

**Steps:**
1. Open VSCode and open the Jolli extension panel
2. Click the "Sign In" or "Login" button
3. A browser window opens with the Jolli sign-in page. Complete the sign-in and click consent
4. After consent, you are redirected to a callback page
5. Check the browser address bar — it should show `?code=` (not `?token=`)
6. Return to VSCode and verify the extension shows you as signed in

**Expected Results:**
- The browser address bar contains `?code=` (secure code, not token)
- VSCode extension displays your authenticated user or account name
- No token appears in the browser history
- The extension is ready to use (no "sign in required" message)

</blockquote>
</details>
<details>
<summary><strong>5. Code-exchange with API key generation</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a Jolli server configured to auto-generate API keys on first login.

**Steps:**
1. Open the CLI and run `jolli auth login` (first time, no existing API key)
2. Complete the browser sign-in flow and click consent
3. Wait for the CLI to display success
4. Run `jolli auth status` or check your config file to see if an API key was saved

**Expected Results:**
- The CLI displays success and saves both a token and an API key
- `jolli auth status` shows both credentials are present
- The API key follows the expected format (e.g., `sk-jol-...`)
- Subsequent commands use the API key for authentication

</blockquote>
</details>
<details>
<summary><strong>6. Network error during code exchange (user-facing message)</strong></summary>
<br>
<blockquote>

**Preconditions:** Simulate a network failure (e.g., disconnect internet, block the Jolli server, or use a firewall rule).

**Steps:**
1. Open the CLI and run `jolli auth login`
2. Complete the browser sign-in flow and click consent
3. Before the CLI finishes exchanging the code, disconnect from the network or block the server
4. Observe the error message in the CLI

**Expected Results:**
- The CLI displays a clear, friendly error message (e.g., "Couldn't reach Jolli to complete sign-in: ...")
- The error message includes the underlying network error detail (e.g., "ECONNREFUSED")
- No partial credentials are saved
- The user can retry once the network is restored

</blockquote>
</details>
<details>
<summary><strong>7. Code takes precedence when both code and token are present (misconfigured server)</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a test server that can emit both `?code=` and `?token=` in the same callback (edge case for server misconfiguration).

**Steps:**
1. Open the CLI and run `jolli auth login`
2. Complete the browser sign-in flow
3. The callback arrives with both `?code=abc&token=xyz` in the address bar
4. Wait for the CLI to complete the exchange
5. Verify which credential was used (check logs or run `jolli auth status`)

**Expected Results:**
- The CLI uses the code (not the token) for the exchange
- The token in the URL is ignored
- The exchange succeeds and credentials are saved
- This ensures the more secure path (code) is always preferred

</blockquote>
</details>
<details>
<summary><strong>8. User cancels sign-in (user_denied error)</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a Jolli server that supports the OAuth user_denied error code.

**Steps:**
1. Open the CLI and run `jolli auth login`
2. A browser window opens with the Jolli sign-in page
3. Click "Cancel" or "Deny" instead of completing the sign-in
4. Observe the error message in the CLI

**Expected Results:**
- The CLI displays a friendly message: "Sign-in was cancelled. You can try again with `jolli auth login`."
- No credentials are saved
- The user can retry the login flow without any cleanup needed

</blockquote>
</details>
<details>
<summary><strong>9. Invalid callback error handling</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a test server that can emit an invalid_callback error code.

**Steps:**
1. Open the CLI and run `jolli auth login`
2. Complete the browser sign-in flow
3. The server rejects the callback with an `invalid_callback` error
4. Observe the error message in the CLI

**Expected Results:**
- The CLI displays a clear error message: "The sign-in callback was rejected by the server. Please try again."
- No credentials are saved
- The user can retry the login flow

</blockquote>
</details>

---

## Topics (2)
<details>
<summary><strong>01 · Implement OAuth authorization-code flow for CLI and VSCode authentication</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The old authentication system passed tokens directly in browser URLs, exposing them to history, referer logs, and address-bar leaks. JOLLI-1270 requires switching to OAuth's authorization-code pattern where the browser only carries a single-use code, and the client redeems it server-side in a secure POST request.

**💡 Decisions Behind the Code**

- **Code-first, token-fallback order**: Prioritize code-exchange (new secure path) but accept legacy token-in-URL from servers not yet upgraded. This avoids breaking users on old servers while allowing new servers to drop token-in-URL entirely. The fallback is temporary—warn logs track residual traffic so it can be deleted once old servers are gone.
- **Fallback lives in client, not server**: Rather than have the backend support both flows indefinitely, put compatibility logic in CLI and VSCode (which have async marketplace/npm upgrade delays). This lets the server commit to code-only immediately while clients gracefully degrade for 2–4 weeks during the upgrade window.
- **Shared `CliExchange` in `cli/src/auth/`**: Both CLI and VSCode import this module (VSCode bundles `cli/src/**` at build time). Avoids code duplication and ensures both clients implement the same error handling and retry logic.
- **Single backend endpoint**: Both registered and anonymous users POST to the same `https://app.jolli.ai/api/feedback` (not tenant-specific). Registered users include `Authorization: Bearer <key>`; anonymous users include `X-Jolli-Client-Id: <uuid>`. Server-side routing is the backend's responsibility, keeping client logic simple.
- **No retry queue for code-exchange**: Unlike commit summaries (which use `git-op-queue` for durability), failed code exchanges are not queued. Users see the error immediately and can retry manually via `--retry` flag or re-running login. This respects user intent (voluntary action) and avoids silent background retries of sensitive auth operations.

**✅ What Was Implemented**

- New `cli/src/auth/CliExchange.ts`: `exchangeCliCode(jolliUrl, code)` function that POSTs a code to `/api/auth/cli-exchange` and returns `{token, jolliApiKey?, space?}`. Handles 404 (expired code), network errors, malformed JSON, and missing token with user-facing error messages.
- Updated `cli/src/auth/Login.ts`: `createLoginServer` callback handler now reads `?code=` instead of `?token=`, calls `exchangeCliCode()`, and saves credentials. Includes legacy token-in-URL fallback for servers not yet on JOLLI-1270 (with warn log for observability).
- Updated `vscode/src/services/AuthService.ts`: `handleAuthCallback` mirrors CLI logic—tries code-exchange first, falls back to legacy token path, logs warnings on legacy flow.
- Updated `cli/src/commands/AuthCommand.ts` and `EnableCommand.ts`: changed `browserLogin()` signature from full `/login` URL to origin only; callers now pass `getJolliUrl()`.
- Comprehensive test coverage: 13 new tests in `CliExchange.test.ts`, 31 updated tests in `Login.test.ts`, 35 updated tests in `AuthService.test.ts` covering happy path, error codes (`user_denied`, `invalid_callback`), legacy fallback, and edge cases.

**📋 Future Enhancements**

- Monitor warn logs for legacy token-in-URL callbacks in production; once residual traffic is negligible (target: 2–4 weeks), delete the fallback branches in `Login.ts` and `AuthService.ts`.
- IntelliJ Kotlin port of `CliExchange` logic (v1.5 follow-up, triggered when v1 is stable ≥2 weeks and ≥50 feedback submissions received).

**📁 FILES**
- `cli/src/auth/CliExchange.ts`
- `cli/src/auth/CliExchange.test.ts`
- `cli/src/auth/Login.ts`
- `cli/src/auth/Login.test.ts`
- `vscode/src/services/AuthService.ts`

</blockquote>
</details>
<details>
<summary><strong>02 · Dual-compatibility for OAuth code-exchange during server upgrade window</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

New extension and CLI clients expect OAuth code-exchange callbacks (`?code=`), but old backend servers still emit token-in-URL callbacks (`?token=`). Without backward compatibility, users on old servers who upgrade their client will lose login functionality. Without forward compatibility, users on new servers who haven't upgraded their client will also break.

**💡 Decisions Behind the Code**

- **Fallback in client, not server**: Putting compatibility logic in the client (which has async marketplace/npm upgrade delays) rather than the server (which deploys synchronously) avoids the server being stuck supporting both flows indefinitely. The server can commit to code-only immediately.
- **Warn logs for observability**: Logging every legacy callback makes it possible to measure when the fallback is no longer needed, rather than guessing. This data-driven approach prevents premature deletion (breaking users still on old servers) and unnecessary long-term maintenance (keeping dead code around).
- **Code wins over token**: If a misconfigured server emits both, preferring code avoids silently downgrading users to a less-secure path. The more-private transmission method should always win.

**✅ What Was Implemented**

- Both `Login.ts` (CLI) and `AuthService.ts` (VSCode) implement code-first, token-fallback logic: check for `?code=` first and call `exchangeCliCode()`; if absent, fall back to reading `?token=` and `?jolli_api_key=` directly from URL params.
- Legacy token path includes `console.warn()` (CLI) and `log.warn("AuthService", ...)` (VSCode) to emit observable signals when old-server traffic is detected. These logs enable the team to monitor residual usage and decide when the fallback can be safely deleted.
- When both code and token are present (misconfigured server), code takes precedence because it uses a more private transmission path (server→server JSON body vs. URL string).
- Fallback is temporary: spec explicitly marks it for deletion once old servers are decommissioned and warn-log traffic drops to zero.

**📁 FILES**
- `cli/src/auth/Login.ts`
- `cli/src/auth/Login.test.ts`
- `vscode/src/services/AuthService.ts`
- `vscode/src/services/AuthService.test.ts`

</blockquote>
</details>

---

*Generated by Jolli Memory · May 2, 2026 at 9:18 PM*
<!-- jollimemory-summary-end -->