### PR TITLE
Feature/jolli site commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ Thumbs.db
 # Jolli / Claude
 .jolli/
 .claude/
+.kiro/
 .gemini/
 .codex/
 .opencode/

--- a/cli/docs/site-commands-changelog.md
+++ b/cli/docs/site-commands-changelog.md
@@ -1,0 +1,741 @@
+# Site Commands — Detailed Change Documentation
+
+**Branch:** `feature/jolli-site-commands`
+**Base:** `origin/main`
+**Total new/modified files:** 31 (16 source + 11 test + 4 config/build)
+**Total lines added:** ~8,220
+
+---
+
+## Table of Contents
+
+1. [Overview](#overview)
+2. [New CLI Commands](#new-cli-commands)
+3. [Architecture](#architecture)
+4. [File-by-File Details](#file-by-file-details)
+   - [Modified Files](#modified-files)
+   - [New Command Files](#new-command-files)
+   - [New Site Module Files](#new-site-module-files)
+   - [New Test Files](#new-test-files)
+5. [Dependencies](#dependencies)
+6. [Framework Migration](#framework-migration)
+7. [MDX Compatibility](#mdx-compatibility)
+8. [Image Handling](#image-handling)
+9. [Output Filtering](#output-filtering)
+10. [Testing](#testing)
+
+---
+
+## Overview
+
+This branch adds five new CLI commands for creating, developing, building, serving, and converting documentation sites using Nextra v4 as the rendering engine:
+
+| Command | Description |
+|---------|-------------|
+| `jolli new [folder]` | Scaffold a new documentation project with starter files |
+| `jolli convert [source] [--output path]` | Permanently convert a Docusaurus (or other framework) project to Nextra structure |
+| `jolli dev [folder] [--verbose]` | Start a dev server with hot reload |
+| `jolli build [folder] [--verbose]` | Static build + Pagefind search indexing |
+| `jolli start [folder] [--verbose]` | Build + search indexing + serve |
+
+All commands support `--migrate` to re-detect framework config and regenerate `site.json`.
+
+---
+
+## New CLI Commands
+
+### `jolli new [folder-name]`
+
+Creates a new documentation project with:
+- `site.json` — site configuration (title, description, nav)
+- `index.md` — welcome page
+- `getting-started.md` — quick start guide
+- `api/openapi.yaml` — example OpenAPI 3.1.0 spec
+- `guides/introduction.md` — nested subfolder example
+
+If `folder-name` is omitted, prompts interactively.
+
+### `jolli convert [source] [--output path]`
+
+Permanently converts a documentation folder to Nextra-compatible structure:
+- Detects source framework (Docusaurus, Mintlify, etc.)
+- Reorganizes directory structure according to sidebar config
+- Downgrades incompatible `.mdx` files to `.md`
+- Fixes relative image paths
+- Writes `site.json` without `pathMappings` (structure is already correct)
+
+For in-place conversion, creates a timestamped backup (e.g., `docs.backup-2026-05-02T14-30-22/`).
+
+### `jolli dev [folder] [--verbose] [--migrate]`
+
+Starts a Next.js dev server with hot reload:
+- Mirrors content to `~/.jolli/sites/<hash>/content/`
+- Generates `_meta.js` navigation files
+- Runs `next dev` with output filtering
+
+### `jolli build [folder] [--verbose] [--migrate]`
+
+Produces a static site with search:
+- Mirrors content, generates navigation
+- Runs `next build` (static export to `out/`)
+- Runs Pagefind indexer (search index at `_pagefind/`)
+- Reports build summary and output path
+
+### `jolli start [folder] [--verbose] [--migrate]`
+
+Same as `build`, then serves the output with `npx serve`.
+
+---
+
+## Architecture
+
+```
+User Content Folder                  Hidden Build Directory
+(e.g., docs/)                        (~/.jolli/sites/<hash>/)
+                                     
+┌─────────────────┐                  ┌──────────────────────┐
+│ site.json        │──ReadSiteJson──▶│ next.config.mjs      │
+│ index.md         │                 │ app/layout.tsx        │
+│ guides/          │──ContentMirror─▶│ app/[[...mdxPath]]/   │
+│ api/openapi.yaml │                 │ content/              │
+│ images/          │──MetaGenerator─▶│   _meta.js (per dir)  │
+│ sidebars.js      │                 │ mdx-components.tsx    │
+└─────────────────┘──OpenApiRender──▶│ public/               │
+                                     │ tsconfig.json         │
+                                     │ package.json          │
+                                     └──────────────────────┘
+                                              │
+                                     NpmRunner (dev/build)
+                                     PagefindRunner (search)
+                                     OutputFilter (display)
+```
+
+### Build Directory Isolation
+
+Each content folder maps to a unique build directory via SHA-256 hash:
+```
+~/.jolli/sites/
+├── a1b2c3d4e5f6/  ← hash of /path/to/project-a
+├── f6e5d4c3b2a1/  ← hash of /path/to/project-b
+```
+
+This ensures:
+- No git pollution in user's content folder
+- Multiple projects can coexist
+- `node_modules` persists between runs (skip `npm install` on subsequent runs)
+
+---
+
+## File-by-File Details
+
+### Modified Files
+
+#### `cli/package.json`
+
+**Changes:** Added 2 new dependencies.
+
+| Dependency | Type | Version | Purpose |
+|-----------|------|---------|---------|
+| `@mdx-js/mdx` | runtime | `^3.1.1` | MDX compilation for compatibility checking (Layer 2 of MDX validation) |
+| `fast-check` | dev | `^3.23.2` | Property-based testing library for correctness proofs |
+
+#### `cli/vite.config.ts`
+
+**Changes:** Added `@mdx-js/mdx` to Rollup's `external` array.
+
+```diff
+- external: ["@anthropic-ai/sdk", "commander", "open", /^node:.*/],
++ external: ["@anthropic-ai/sdk", "@mdx-js/mdx", "commander", "open", /^node:.*/],
+```
+
+This prevents Vite from bundling the MDX compiler into the CLI dist — it's loaded dynamically at runtime via `import("@mdx-js/mdx")`.
+
+#### `cli/src/Cli.ts`
+
+**Changes:** Registered 4 new commands and updated JSDoc.
+
+Added imports:
+- `registerConvertCommand` from `./commands/ConvertCommand.js`
+- `registerNewCommand` from `./commands/NewCommand.js`
+- `registerBuildCommand`, `registerDevCommand`, `registerStartCommand` from `./commands/StartCommand.js`
+
+Added registrations in `main()`:
+```typescript
+registerNewCommand(program);
+registerConvertCommand(program);
+registerDevCommand(program);
+registerBuildCommand(program);
+registerStartCommand(program);
+```
+
+#### `cli/src/site/Types.ts`
+
+**Changes:** New file (existed as stub on main, now fully populated with 89 lines).
+
+Defines all shared types for the site module:
+
+| Type | Description |
+|------|-------------|
+| `FileType` | `"markdown" \| "openapi" \| "image" \| "ignored"` |
+| `NavLink` | `{ label: string; href: string }` |
+| `SidebarItemValue` | String label or Nextra meta object (with `title?`, `href?`, `type?`) |
+| `SidebarOverrides` | `Record<string, Record<string, SidebarItemValue>>` — path-keyed sidebar config |
+| `PathMappings` | `Record<string, string>` — source → target folder remapping |
+| `SiteJson` | Full site.json schema: `title`, `description`, `nav`, `sidebar?`, `pathMappings?`, `favicon?` |
+| `ScaffoldResult` | Result of `jolli new` |
+| `MirrorResult` | Result of content mirroring: file lists + `downgradedCount` + `renamedToIndex` |
+| `NpmRunResult` | `{ success: boolean; output: string }` |
+| `PagefindResult` | Extends NpmRunResult with `pagesIndexed?` |
+
+---
+
+### New Command Files
+
+#### `cli/src/commands/NewCommand.ts` (62 lines)
+
+Registers `jolli new [folder-name]`.
+
+**Key behaviors:**
+- If no argument: prompts interactively via `readline.createInterface`
+- Validates non-empty input
+- Delegates to `StarterKit.scaffoldProject()`
+- Reports success with next-steps message or error with exit code 1
+
+#### `cli/src/commands/StartCommand.ts` (236 lines)
+
+Registers `jolli build`, `jolli start`, and `jolli dev`.
+
+**Exported functions:**
+- `registerBuildCommand(program)` — static build + pagefind
+- `registerStartCommand(program)` — build + pagefind + serve
+- `registerDevCommand(program)` — dev server
+- `getBuildDir(sourceRoot)` — computes `~/.jolli/sites/<sha256-12-chars>/`
+
+**Shared pipeline (`prepareContent`):**
+1. Validate source root exists
+2. Read `site.json` (with framework detection if missing)
+3. Initialize Nextra project (write config files)
+4. Resolve favicon to `public/`
+5. Clear `.next/` cache and `public/`
+6. Mirror content (with pathMappings and MDX downgrading)
+7. Fix sidebar index key if `slug: /` file was renamed
+8. Generate `_meta.js` navigation files
+9. Render OpenAPI specs
+10. Install npm dependencies (if `node_modules/` missing)
+
+**Output control:**
+- Default mode: concise summaries (`✓ Mirrored 45 files (3 downgraded)`)
+- `--verbose` mode: full framework output
+- Internal paths hidden from default output
+
+**Options:**
+- `--verbose` — show detailed build output
+- `--migrate` — re-detect framework config and regenerate site.json
+
+#### `cli/src/commands/ConvertCommand.ts` (380 lines)
+
+Registers `jolli convert [source] [--output path]`.
+
+**Conversion pipeline:**
+1. Detect framework → generate sidebar + pathMappings
+2. Prompt for site title
+3. Create timestamped backup (if in-place)
+4. Walk all files, applying pathMappings during copy/move
+5. Downgrade incompatible MDX → MD with content stripping
+6. Rewrite relative image paths for remapped files
+7. Handle `slug: /` → `index.md` rename + update sidebar
+8. Copy favicon from framework config
+9. Write `site.json` (WITHOUT `pathMappings` — structure is already correct)
+10. Clean up framework-specific files (`sidebars.js`, etc.)
+
+**Safety features:**
+- In-place conversion always creates backup: `<folder>.backup-YYYY-MM-DDTHH-MM-SS/`
+- Skips framework config files during conversion
+- Uses safe rename with cross-device fallback (copy + remove)
+
+---
+
+### New Site Module Files
+
+#### `cli/src/site/StarterKit.ts` (336 lines)
+
+Scaffolds a new documentation project for `jolli new`.
+
+**Exports:** `scaffoldProject(targetDir): Promise<ScaffoldResult>`
+
+**Generated files:**
+- `site.json` — default config with title, description, nav links
+- `index.md` — welcome page with markdown table showing project structure
+- `getting-started.md` — quick start guide
+- `api/openapi.yaml` — complete OpenAPI 3.1.0 example spec (Items API)
+- `guides/introduction.md` — nested subfolder example
+
+**Behavior:**
+- Returns `{ success: false }` if target directory already exists (non-destructive)
+- All file writes parallelized with `Promise.all`
+- Catches filesystem errors and returns them in result (doesn't throw)
+
+#### `cli/src/site/SiteJsonReader.ts` (157 lines)
+
+Reads `site.json` or creates it with framework detection.
+
+**Exports:**
+- `readSiteJson(sourceRoot, options?): Promise<SiteJsonResult>`
+- `DEFAULT_SITE_JSON` — fallback config
+
+**When `site.json` exists:** Parses JSON, extracts `title`, `description`, `nav`, preserves unknown fields via spread.
+
+**When `site.json` is missing:**
+1. Calls `detectFramework()` to find Docusaurus/Mintlify/etc.
+2. If found: prompts `"Found Docusaurus config. Generate site.json from it? (Y/n)"`
+3. If yes + Docusaurus: calls `convertDocusaurusSidebar()` + `extractFaviconFromConfig()`
+4. Prompts for site title (default: folder name in Title Case)
+5. Writes `site.json` with sidebar, pathMappings, favicon
+
+**`--migrate` support:** When `options.migrate` is true, re-runs creation even if `site.json` exists.
+
+#### `cli/src/site/ContentMirror.ts` (706 lines)
+
+Core content processing engine. Mirrors files from source to build directory.
+
+**Exported functions:**
+
+| Function | Description |
+|----------|-------------|
+| `mirrorContent(sourceRoot, contentDir, pathMappings?, publicDir?)` | Main entry: clear, walk, copy, resolve missing images |
+| `classifyFile(filePath, content?)` | Categorize by extension + content inspection |
+| `clearDir(dir)` | Remove all contents, keep directory |
+| `hasIncompatibleImports(content)` | Two-layer MDX compatibility check |
+| `stripIncompatibleContent(content)` | Downgrade MDX to plain markdown |
+| `rewriteRelativeImagePaths(content, originalPath, newPath, mappings?)` | Fix image refs after path remapping |
+| `applyPathMapping(relPath, mappings?)` | Apply folder-level path remapping |
+
+**MDX compatibility checking (two layers):**
+
+1. **Layer 1 — Regex (milliseconds):** Checks imports against safe prefix whitelist (`nextra`, `react`, `next/`, `swagger-ui-react`). Checks JSX components against imported names + Nextra built-ins (`Callout`, `Cards`, `Steps`, `Tabs`, etc.).
+
+2. **Layer 2 — MDX compiler (seconds):** If regex passes, attempts `@mdx-js/mdx` compilation to catch syntax errors. Only runs on files that passed Layer 1.
+
+**MDX downgrading (`stripIncompatibleContent`):**
+- Removes all `import`/`export` statements
+- Removes all uppercase JSX component tags (self-closing and paired)
+- Preserves children content inside removed tags
+- Converts JSX `style={{ camelCase: 'value' }}` to HTML `style="kebab-case: value"`
+- Removes Docusaurus `:::` admonition fences
+- Cleans up excessive blank lines
+
+**Image path rewriting:**
+- When a file is remapped via `pathMappings`, relative image paths break
+- `rewriteRelativeImagePaths` resolves each path against original location, applies pathMapping to the image path too, then computes new relative path from new location
+- Handles both `![](path)` and `<img src="path">` syntax
+
+**Missing image resolution:**
+- After all files are mirrored, scans markdown for image references
+- For absolute paths (`/img/...`): searches Docusaurus `static/` directory
+- For missing relative paths: searches up to project root
+- If found externally: copies to `public/images/<unique-name>`, rewrites reference
+- If not found: generates placeholder SVG (400×300, shows "Missing image: filename")
+
+**`slug: /` handling:**
+- Docusaurus uses `slug: /` frontmatter to designate homepage
+- After mirroring, if no `index.md` exists, scans root files for `slug: /`
+- Renames matching file to `index.md` (not copy — avoids duplicate)
+- Returns old filename key so sidebar can be updated
+
+#### `cli/src/site/MetaGenerator.ts` (206 lines)
+
+Generates Nextra v4 `_meta.js` navigation files.
+
+**Exports:**
+- `generateMetaFiles(contentDir, sidebarOverrides?)` — recursive _meta.js generation
+- `buildMetaEntries(filenames, override?)` — build ordered entry list
+- `toTitleCase(filename)` — `getting-started` → `Getting Started`
+
+**Default behavior (no sidebar override):**
+- All items sorted alphabetically by key
+- Labels auto-generated via `toTitleCase`
+- `index.md`/`index.mdx` entries use `{ display: "hidden" }` to prevent duplicate sidebar entries
+
+**Override behavior (with sidebar):**
+- Declared items appear first, in declaration order
+- `index` files auto-hidden if not explicitly declared
+- Nextra auto-appends unlisted filesystem items alphabetically
+- Object values supported (external links with `href`, separators, hidden items)
+
+**_meta.js output format:**
+```javascript
+export default {
+  "index": {"display":"hidden"},
+  "getting-started": "Getting Started",
+  "api": "Api",
+  "github": {"title":"GitHub","href":"https://github.com"},
+}
+```
+
+#### `cli/src/site/OpenApiRenderer.ts` (144 lines)
+
+Generates MDX pages for OpenAPI specification files.
+
+**Exports:**
+- `renderOpenApiFiles(sourceRoot, contentDir, openapiFiles, publicDir?)` — main function
+- `isValidOpenApiContent(content, ext)` — validates OpenAPI format
+- `generateOpenApiMdx(openapiFilePath, relPath)` — creates MDX content
+
+**Validation:**
+- JSON: parses and checks for top-level `openapi` and `info` keys
+- YAML: regex check for `openapi:` and `info:` at line start (no full parser)
+
+**Generated MDX:**
+```mdx
+import SwaggerUI from 'swagger-ui-react'
+import 'swagger-ui-react/swagger-ui.css'
+
+<SwaggerUI url="/api/openapi.yaml" />
+```
+
+**Behavior:**
+- Logs warning for invalid files, skips them (doesn't abort build)
+- Always overwrites existing `.mdx` (supports incremental updates)
+- Copies raw spec files to `public/` for SwaggerUI runtime fetching
+
+#### `cli/src/site/NextraProjectWriter.ts` (268 lines)
+
+Generates and maintains the Nextra v4 project scaffold.
+
+**Exports:**
+- `initNextraProject(buildDir, config, options?)` — creates/updates scaffold
+- `generatePackageJson(config)` — with nextra 4.2.17, react 19, swagger-ui-react, pagefind
+- `generateNextConfig(staticExport?)` — with `contentDirBasePath`, `preferRelative`
+- `generateLayout(config)` — App Router layout with Navbar, Footer, getPageMap
+- `generateCatchAllPage()` — `app/[[...mdxPath]]/page.tsx` with importPage
+- `generateMdxComponents()` — MDX component wiring
+- `generateTsConfig()` — with `moduleResolution: "bundler"`
+
+**Key design decisions:**
+- Nextra v4 requires App Router (not Pages Router)
+- Pinned to nextra 4.2.17 (4.3+ has a Zod validation bug in Layout component)
+- Theme configured via component props in layout.tsx (not theme.config.tsx)
+- Navbar extra content uses `children` prop (not `extraContent`)
+- `next.config.mjs` conditionally includes `output: 'export'` for static builds
+- `webpack.resolve.preferRelative = true` for bare image imports in markdown
+
+#### `cli/src/site/NpmRunner.ts` (124 lines)
+
+Executes npm commands in the build directory.
+
+**Exports:**
+- `needsInstall(buildDir)` — checks for `node_modules/`
+- `runNpmInstall(buildDir)` — `npm install` with pipe stdio
+- `runNpmBuild(buildDir)` — `npm run build` with pipe stdio
+- `runNpmDev(buildDir, verbose?)` — `npm run dev` with OutputFilter
+- `runServe(buildDir, verbose?)` — `npx serve out` with OutputFilter
+- `ServerResult` — extends NpmRunResult with `url?`
+
+**Long-running processes:**
+- Use `spawn` (not `spawnSync`) with `stdio: 'pipe'`
+- Output streamed through `OutputFilter` for noise reduction
+- Localhost URL extracted automatically from output
+- Resolve when process exits (user presses Ctrl+C)
+
+#### `cli/src/site/PagefindRunner.ts` (41 lines)
+
+Runs the Pagefind search indexer.
+
+**Exports:**
+- `runPagefind(buildDir)` — executes `npx pagefind --site out --output-path out/_pagefind`
+
+Output path is `out/_pagefind/` to match Nextra's search component which loads from `/_pagefind/pagefind.js`.
+
+#### `cli/src/site/OutputFilter.ts` (112 lines)
+
+Filters child process output for user-friendly display.
+
+**Exports:**
+- `createOutputFilter(verbose)` — returns `{ write(data), getUrl() }`
+
+**Suppressed patterns (70+):**
+- TypeScript detection/configuration messages
+- npm peer dependency warnings
+- Nextra git repository warnings
+- Webpack hot-update messages
+- Fast Refresh messages
+- Next.js version/experiment banners
+- Compilation progress messages
+
+**Always shown:**
+- Errors (⨯ prefix, Module not found, Build error, Failed to compile)
+- HTTP 500 responses
+- Localhost URL (printed immediately on first detection)
+
+#### `cli/src/site/AssetResolver.ts` (198 lines)
+
+Resolves external images and favicon.
+
+**Exports:**
+- `resolveExternalImage(relPath, mdDir, sourceRoot)` — searches multiple locations for missing images
+- `copyExternalAsset(asset, publicDir)` — copies or generates placeholder
+- `resolveFavicon(faviconPath, sourceRoot, publicDir)` — copies or generates default
+- `generatePlaceholderSvg(filename)` — 400×300 SVG showing "Missing image" + filename
+- `ResolvedAsset` interface
+
+**Image search priority:**
+1. Resolve from original markdown directory
+2. `<projectRoot>/static/<path>` (Docusaurus convention)
+3. `<projectRoot>/<path>`
+4. `<sourceRoot>/../static/<path>`
+5. `<sourceRoot>/../<path>`
+6. → Not found: generate placeholder SVG
+
+**Project root detection:** Searches upward (max 5 levels) for `package.json`, `.git`, or `docusaurus.config.*`.
+
+**Unique naming:** Path separators replaced with dashes: `static/img/logo.svg` → `images/static-img-logo.svg`.
+
+#### `cli/src/site/FrameworkDetector.ts` (139 lines)
+
+Detects documentation framework config files.
+
+**Exports:**
+- `detectFramework(sourceRoot)` — scans for known configs
+- `promptMigration(framework)` — interactive Y/n prompt
+- `DetectedFramework` interface
+
+**Detected frameworks:**
+
+| Framework | Detection Files | Search Scope |
+|-----------|----------------|--------------|
+| Docusaurus | `docusaurus.config.{js,ts}`, `sidebars.{js,ts}` | Source + parent |
+| Mintlify | `mint.json` | Source only |
+| VitePress | `.vitepress/config.{js,ts}` | Source only |
+| MkDocs | `mkdocs.{yml,yaml}` | Source only |
+| GitBook | `SUMMARY.md`, `.gitbook.yaml` | Source only |
+
+Only Docusaurus conversion is implemented in v1. Others are detected and reported as unsupported.
+
+#### `cli/src/site/DocusaurusConverter.ts` (307 lines)
+
+Converts Docusaurus `sidebars.js` to Jolli format.
+
+**Exports:**
+- `convertDocusaurusSidebar(sidebarPath)` — returns `ConversionResult`
+- `extractFaviconFromConfig(configPath)` — regex extraction of favicon path
+
+**Conversion logic:**
+
+Walks the Docusaurus sidebar tree and produces:
+1. **`SidebarOverrides`** — path-keyed map defining navigation order/labels
+2. **`PathMappings`** — folder remapping when logical structure differs from filesystem
+
+**Docusaurus item type handling:**
+
+| Type | Handling |
+|------|----------|
+| `string` (doc ID) | Extract last segment as key, auto-title |
+| `{ type: 'doc', id, label }` | Use label or auto-title |
+| `{ type: 'category', label, items }` | Create sidebar entry + recurse into subfolder |
+| `{ type: 'link', label, href }` | Create Nextra link object (`{ title, href }`) |
+
+**Virtual grouping detection:** If a category's actual filesystem directory matches its parent's, it's treated as a logical grouping (e.g., "Operations" inside `sql/`). Items are flattened into the parent — no subfolder is created.
+
+**PathMapping generation:** Only when a doc's or category's actual filesystem path differs from its logical sidebar position. E.g., `sql/` at root but under `pipelines` in sidebar → `{ "sql": "pipelines/sql" }`.
+
+---
+
+### New Test Files
+
+All test files follow the project convention: co-located `*.test.ts` files using Vitest with `vi.mock` for filesystem and child_process mocking.
+
+| Test File | Tests | Coverage Focus |
+|-----------|-------|---------------|
+| `StarterKit.test.ts` | 244 lines | File creation, site.json validity, nested structure, error handling |
+| `SiteJsonReader.test.ts` | 292 lines | Valid/invalid/missing JSON, type fallbacks, framework detection mocking |
+| `ContentMirror.test.ts` | 746 lines | File classification, mirroring, MDX downgrading, broken symlinks, property-based tests |
+| `MetaGenerator.test.ts` | 571 lines | Title-casing, alphabetical ordering, sidebar overrides, hidden index, property-based tests |
+| `OpenApiRenderer.test.ts` | 520 lines | OpenAPI validation, MDX generation, directory creation, property-based tests |
+| `NextraProjectWriter.test.ts` | 626 lines | All generators, init/update cycles, property-based tests for config preservation |
+| `NpmRunner.test.ts` | 368 lines | Install/build/dev/serve, exit codes, spawn mocking, output filter |
+| `PagefindRunner.test.ts` | 174 lines | Page count parsing, error handling, command arguments |
+| `NewCommand.test.ts` | 241 lines | With/without argument, interactive prompt, directory exists |
+| `StartCommand.test.ts` | 492 lines | All three commands, shared pipeline, sidebar overrides, --migrate |
+| `FrameworkDetector.test.ts` | 80 lines | Detection for Docusaurus, Mintlify, MkDocs, GitBook |
+| `DocusaurusConverter.test.ts` | 140 lines | String items, categories, links, nested categories, invalid files |
+
+**Property-based tests (using fast-check):**
+- File type classification consistency
+- Content mirroring preserves directory structure
+- `_meta.js` entries alphabetically ordered
+- Title-case transformation correctness
+- site.json fields preserved in generated Nextra config
+- OpenAPI detection is content-based
+
+---
+
+## Dependencies
+
+### Runtime: `@mdx-js/mdx` ^3.1.1
+
+Used as the **second layer** of MDX compatibility checking. When the fast regex scan flags a file as potentially incompatible, the MDX compiler confirms whether it truly can't be compiled. This prevents false positives (files with unusual but valid MDX that the regex would reject).
+
+Loaded dynamically (`import("@mdx-js/mdx")`) to avoid startup cost. Only invoked for files flagged by the regex layer.
+
+### Dev: `fast-check` ^3.23.2
+
+Property-based testing library used to prove correctness invariants:
+- Any `.md`/`.mdx` file → classified as `"markdown"`
+- Any image extension → classified as `"image"`
+- Any OpenAPI content with `openapi` + `info` → classified as `"openapi"`
+- Meta entries always sorted alphabetically
+- Title-case has no hyphens/underscores remaining
+
+---
+
+## Framework Migration
+
+### Detection Flow
+
+```
+jolli dev/build/start (first run, no site.json)
+  ↓
+detectFramework() scans for config files
+  ↓
+Found? → promptMigration("Found Docusaurus config. Generate site.json from it? (Y/n)")
+  ↓ Y
+convertDocusaurusSidebar() → { sidebar, pathMappings }
+extractFaviconFromConfig() → favicon path
+  ↓
+promptSiteTitle() → title
+  ↓
+Write site.json (with sidebar + pathMappings + favicon)
+  ↓
+Subsequent runs: read site.json directly, no detection
+```
+
+### Docusaurus Conversion Details
+
+**Sidebar structure mapping:**
+
+```
+Docusaurus sidebar                    site.json sidebar
+─────────────────                    ──────────────────
+docsSidebar: [                       "/": {
+  'what-is-feldera',                   "what-is-feldera": "What Is Feldera",
+  { type: 'category',                  "get-started": "Install Feldera",
+    label: 'Install Feldera',          ...
+    items: [...] },                  }
+  ...                                "/get-started": {
+]                                      "docker": "Docker",
+                                       "sandbox": "Sandbox",
+                                       ...
+                                     }
+```
+
+**Path remapping (when sidebar ≠ filesystem):**
+
+```
+pathMappings: {
+  "sql": "pipelines/sql",           // root sql/ → nested under pipelines/
+  "connectors": "pipelines/connectors",
+  "use_cases/batch": "tutorials/batch",  // cross-directory grouping
+}
+```
+
+---
+
+## MDX Compatibility
+
+### Two-Layer Validation
+
+**Layer 1 — Regex scan (milliseconds):**
+- Checks imports against whitelist: `nextra`, `react`, `next/*`, `swagger-ui-react`, relative paths
+- Checks JSX components against imports + Nextra built-ins
+
+**Layer 2 — MDX compiler (seconds):**
+- Only runs on files that passed Layer 1
+- Catches syntax errors the regex can't detect
+- Uses `@mdx-js/mdx` `compile()` function
+
+### Downgrading Process
+
+When a `.mdx` file is incompatible:
+
+1. **Strip imports/exports** — all `import`/`export` lines removed
+2. **Strip JSX components** — all uppercase tags removed, children preserved
+3. **Convert JSX styles** — `style={{ textAlign: 'center' }}` → `style="text-align: center"`
+4. **Remove admonitions** — `:::tip`, `:::warning` fences removed
+5. **Clean up whitespace** — excessive blank lines collapsed
+6. **Rename to `.md`** — file extension changed
+
+---
+
+## Image Handling
+
+### Five scenarios:
+
+1. **Same-directory image** — copied alongside markdown, no path change needed
+2. **Remapped file's image** — relative path rewritten to account for new directory
+3. **Absolute path image** (`/img/foo.png`) — resolved from `static/` directory
+4. **External image** (outside source root) — searched upward, copied to `public/images/`
+5. **Missing image** — SVG placeholder generated (400×300, shows filename)
+
+### Path Rewriting
+
+When pathMappings moves a file, image references are recomputed:
+
+```
+Original: connectors/intro.md → ../pipelines/arch.png
+Mapped:   pipelines/connectors/intro.md → ../arch.png  ✓
+
+Original: sql/ad-hoc.md → materialized.png (same dir)
+Mapped:   pipelines/sql/ad-hoc.md → ./materialized.png  ✓
+  (image also mapped to pipelines/sql/)
+```
+
+### Favicon
+
+- Extracted from `docusaurus.config.ts` (`favicon: "img/favicon.ico"`)
+- Resolved from `static/` directory
+- Copied to `public/favicon.ico`
+- Fallback: SVG with blue background and "J" letter
+
+---
+
+## Output Filtering
+
+### Default mode (concise):
+
+```
+  ✓ Loaded site config
+  ✓ Mirrored 127 files (3 downgraded)
+  ✓ Generated navigation
+  ✓ Dependencies ready
+  ✓ Built 127 pages
+  ✓ Indexed 127 pages for search
+
+  Server running at http://localhost:3000
+```
+
+### Verbose mode (`--verbose`):
+
+Shows all framework output: TypeScript detection, npm warnings, webpack compilation, Next.js banners, etc.
+
+---
+
+## Testing
+
+**Total tests:** 2,031+
+**Coverage thresholds:** 97% statements, 96% branches, 97% functions, 97% lines
+
+```bash
+# Run all tests
+npm run test -w @jolli.ai/cli
+
+# Run specific module tests
+npm run test -w @jolli.ai/cli -- src/site/ContentMirror.test.ts
+```
+
+### Test categories:
+
+- **Unit tests** — each function tested in isolation with `vi.mock`
+- **Integration tests** — full pipeline tests using real temp directories
+- **Property-based tests** — correctness invariants proven with `fast-check`
+- **Error handling** — filesystem errors, invalid JSON, broken symlinks
+- **Edge cases** — empty directories, duplicate keys, cross-platform paths

--- a/cli/package.json
+++ b/cli/package.json
@@ -49,6 +49,7 @@
 	},
 	"dependencies": {
 		"@anthropic-ai/sdk": "^0.39.0",
+		"@mdx-js/mdx": "^3.1.1",
 		"commander": "^13.1.0",
 		"open": "^11.0.0"
 	},
@@ -56,6 +57,7 @@
 		"@biomejs/biome": "2.2.6",
 		"@types/node": "^22.5.0",
 		"@vitest/coverage-v8": "^4.1.1",
+		"fast-check": "^3.23.2",
 		"rimraf": "^6.0.1",
 		"tsx": "^4.7.0",
 		"typescript": "^5.7.2",

--- a/cli/src/Cli.ts
+++ b/cli/src/Cli.ts
@@ -13,6 +13,11 @@
  *   recall        — Recall development context for a branch (alias: context)
  *   export        — Export summaries as markdown to ~/Documents/jollimemory/
  *   auth          — Authentication commands (login, logout, status)
+ *   new           — Scaffold a new documentation project (Content_Folder)
+ *   convert       — Convert a documentation folder to Nextra-compatible structure
+ *   dev           — Start a dev server with hot reload
+ *   build         — Build a static site with search indexing
+ *   start         — Build a static site with search indexing, then serve
  *
  * Internal commands (hidden from --help):
  *   migrate       — Migrate orphan branch + index to v3 format
@@ -24,11 +29,14 @@ import { registerAuthCommands } from "./commands/AuthCommand.js";
 import { registerCleanCommand } from "./commands/CleanCommand.js";
 import { checkVersionMismatch, VERSION } from "./commands/CliUtils.js";
 import { registerConfigureCommand } from "./commands/ConfigureCommand.js";
+import { registerConvertCommand } from "./commands/ConvertCommand.js";
 import { registerDoctorCommand } from "./commands/DoctorCommand.js";
 import { registerDisableCommand, registerEnableCommand } from "./commands/EnableCommand.js";
 import { registerExportCommand, registerExportPromptCommand } from "./commands/ExportCommand.js";
 import { registerMigrateCommand } from "./commands/MigrateCommand.js";
+import { registerNewCommand } from "./commands/NewCommand.js";
 import { registerRecallCommand } from "./commands/RecallCommand.js";
+import { registerBuildCommand, registerDevCommand, registerStartCommand } from "./commands/StartCommand.js";
 import { registerStatusCommand } from "./commands/StatusCommand.js";
 import { registerViewCommand } from "./commands/ViewCommand.js";
 import { setSilentConsole } from "./Logger.js";
@@ -67,6 +75,11 @@ export async function main(args?: ReadonlyArray<string>): Promise<void> {
 	registerExportPromptCommand(program);
 	registerExportCommand(program);
 	registerAuthCommands(program);
+	registerNewCommand(program);
+	registerConvertCommand(program);
+	registerDevCommand(program);
+	registerBuildCommand(program);
+	registerStartCommand(program);
 
 	checkVersionMismatch();
 

--- a/cli/src/commands/ConvertCommand.test.ts
+++ b/cli/src/commands/ConvertCommand.test.ts
@@ -1,0 +1,605 @@
+/**
+ * Tests for ConvertCommand — converts documentation folders to Nextra-compatible structure.
+ */
+
+import { existsSync } from "node:fs";
+import { mkdir, mkdtemp, readdir, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Command } from "commander";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// ─── Mock readline ──────────────────────────────────────────────────────────
+
+const { mockCreateInterface } = vi.hoisted(() => ({
+	mockCreateInterface: vi.fn(),
+}));
+
+vi.mock("node:readline", () => ({
+	createInterface: mockCreateInterface,
+}));
+
+function mockPrompt(answer: string): void {
+	mockCreateInterface.mockReturnValue({
+		question: (_prompt: string, cb: (answer: string) => void) => cb(answer),
+		close: vi.fn(),
+	});
+}
+
+// ─── Mock FrameworkDetector ─────────────────────────────────────────────────
+
+const { mockDetectFramework, mockPromptMigration } = vi.hoisted(() => ({
+	mockDetectFramework: vi.fn(),
+	mockPromptMigration: vi.fn(),
+}));
+
+vi.mock("../site/FrameworkDetector.js", () => ({
+	detectFramework: mockDetectFramework,
+	promptMigration: mockPromptMigration,
+}));
+
+// ─── Mock DocusaurusConverter ───────────────────────────────────────────────
+
+const { mockConvertSidebar, mockExtractFavicon } = vi.hoisted(() => ({
+	mockConvertSidebar: vi.fn(),
+	mockExtractFavicon: vi.fn(),
+}));
+
+vi.mock("../site/DocusaurusConverter.js", () => ({
+	convertDocusaurusSidebar: mockConvertSidebar,
+	extractFaviconFromConfig: mockExtractFavicon,
+}));
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+async function makeTempDir(): Promise<string> {
+	return mkdtemp(join(tmpdir(), "jolli-convertcmd-test-"));
+}
+
+describe("ConvertCommand", () => {
+	let tempDir: string;
+	let logSpy: ReturnType<typeof vi.spyOn>;
+	const originalIsTTY = process.stdin.isTTY;
+
+	beforeEach(async () => {
+		tempDir = await makeTempDir();
+		logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		vi.spyOn(console, "error").mockImplementation(() => {});
+		vi.spyOn(console, "warn").mockImplementation(() => {});
+		mockDetectFramework.mockReturnValue(null);
+		mockPromptMigration.mockResolvedValue(false);
+		mockConvertSidebar.mockResolvedValue({ sidebar: {}, pathMappings: {} });
+		mockExtractFavicon.mockReturnValue(undefined);
+		mockPrompt("Test Site");
+		process.stdin.isTTY = true;
+	});
+
+	afterEach(async () => {
+		await rm(tempDir, { recursive: true, force: true });
+		process.stdin.isTTY = originalIsTTY;
+		vi.restoreAllMocks();
+		process.exitCode = undefined;
+	});
+
+	// ── Registration ────────────────────────────────────────────────────────
+
+	it("registers convert command on program", async () => {
+		const { registerConvertCommand } = await import("./ConvertCommand.js");
+		const program = new Command();
+
+		registerConvertCommand(program);
+
+		const cmd = program.commands.find((c) => c.name() === "convert");
+		expect(cmd).toBeDefined();
+	});
+
+	// ── Basic conversion ────────────────────────────────────────────────────
+
+	it("converts a folder with markdown files", async () => {
+		const { registerConvertCommand } = await import("./ConvertCommand.js");
+		const sourceDir = join(tempDir, "docs");
+		await mkdir(sourceDir, { recursive: true });
+		await writeFile(join(sourceDir, "index.md"), "# Home\n", "utf-8");
+		await writeFile(join(sourceDir, "guide.md"), "# Guide\n", "utf-8");
+		const outDir = join(tempDir, "output");
+
+		const program = new Command();
+		registerConvertCommand(program);
+		await program.parseAsync(["node", "test", "convert", sourceDir, "--output", outDir]);
+
+		expect(existsSync(join(outDir, "index.md"))).toBe(true);
+		expect(existsSync(join(outDir, "guide.md"))).toBe(true);
+		expect(existsSync(join(outDir, "site.json"))).toBe(true);
+	});
+
+	it("writes valid site.json with title from prompt", async () => {
+		const { registerConvertCommand } = await import("./ConvertCommand.js");
+		const sourceDir = join(tempDir, "docs");
+		await mkdir(sourceDir, { recursive: true });
+		await writeFile(join(sourceDir, "index.md"), "# Home\n", "utf-8");
+		const outDir = join(tempDir, "output");
+
+		const program = new Command();
+		registerConvertCommand(program);
+		await program.parseAsync(["node", "test", "convert", sourceDir, "--output", outDir]);
+
+		const siteJson = JSON.parse(await readFile(join(outDir, "site.json"), "utf-8"));
+		expect(siteJson.title).toBe("Test Site");
+		expect(siteJson.description).toContain("Test Site");
+	});
+
+	it("uses default title without prompting when stdin is not a TTY", async () => {
+		process.stdin.isTTY = undefined as unknown as true;
+		const { registerConvertCommand } = await import("./ConvertCommand.js");
+		const sourceDir = join(tempDir, "my-docs");
+		await mkdir(sourceDir, { recursive: true });
+		await writeFile(join(sourceDir, "index.md"), "# Home\n", "utf-8");
+		const outDir = join(tempDir, "output");
+
+		const program = new Command();
+		registerConvertCommand(program);
+		await program.parseAsync(["node", "test", "convert", sourceDir, "--output", outDir]);
+
+		const siteJson = JSON.parse(await readFile(join(outDir, "site.json"), "utf-8"));
+		expect(siteJson.title).toBe("My Docs");
+	});
+
+	it("site.json does not contain pathMappings", async () => {
+		const { registerConvertCommand } = await import("./ConvertCommand.js");
+		const sourceDir = join(tempDir, "docs");
+		await mkdir(sourceDir, { recursive: true });
+		await writeFile(join(sourceDir, "index.md"), "# Home\n", "utf-8");
+		const outDir = join(tempDir, "output");
+
+		const program = new Command();
+		registerConvertCommand(program);
+		await program.parseAsync(["node", "test", "convert", sourceDir, "--output", outDir]);
+
+		const siteJson = JSON.parse(await readFile(join(outDir, "site.json"), "utf-8"));
+		expect(siteJson.pathMappings).toBeUndefined();
+	});
+
+	// ── Error handling ──────────────────────────────────────────────────────
+
+	it("sets exit code 1 when source folder does not exist", async () => {
+		const { registerConvertCommand } = await import("./ConvertCommand.js");
+		const program = new Command();
+		registerConvertCommand(program);
+
+		await program.parseAsync(["node", "test", "convert", join(tempDir, "nonexistent")]);
+
+		expect(process.exitCode).toBe(1);
+	});
+
+	// ── In-place conversion ─────────────────────────────────────────────────
+
+	it("creates timestamped backup for in-place conversion", async () => {
+		const { registerConvertCommand } = await import("./ConvertCommand.js");
+		const sourceDir = join(tempDir, "docs");
+		await mkdir(sourceDir, { recursive: true });
+		await writeFile(join(sourceDir, "index.md"), "# Home\n", "utf-8");
+
+		const program = new Command();
+		registerConvertCommand(program);
+		// No --output means in-place
+		await program.parseAsync(["node", "test", "convert", sourceDir]);
+
+		// Check backup was created
+		const parentEntries = await readdir(tempDir);
+		const backups = parentEntries.filter((e) => e.includes(".backup-"));
+		expect(backups.length).toBe(1);
+	});
+
+	// ── Framework file skipping ─────────────────────────────────────────────
+
+	it("skips framework config files during conversion", async () => {
+		const { registerConvertCommand } = await import("./ConvertCommand.js");
+		const sourceDir = join(tempDir, "docs");
+		await mkdir(sourceDir, { recursive: true });
+		await writeFile(join(sourceDir, "index.md"), "# Home\n", "utf-8");
+		await writeFile(join(sourceDir, "package.json"), "{}", "utf-8");
+		await writeFile(join(sourceDir, "sidebars.js"), "module.exports = {}", "utf-8");
+		const outDir = join(tempDir, "output");
+
+		const program = new Command();
+		registerConvertCommand(program);
+		await program.parseAsync(["node", "test", "convert", sourceDir, "--output", outDir]);
+
+		expect(existsSync(join(outDir, "package.json"))).toBe(false);
+		expect(existsSync(join(outDir, "sidebars.js"))).toBe(false);
+	});
+
+	// ── Image files ─────────────────────────────────────────────────────────
+
+	it("copies image files to output", async () => {
+		const { registerConvertCommand } = await import("./ConvertCommand.js");
+		const sourceDir = join(tempDir, "docs");
+		await mkdir(sourceDir, { recursive: true });
+		await writeFile(join(sourceDir, "index.md"), "# Home\n", "utf-8");
+		await writeFile(join(sourceDir, "logo.png"), "fake-png", "utf-8");
+		const outDir = join(tempDir, "output");
+
+		const program = new Command();
+		registerConvertCommand(program);
+		await program.parseAsync(["node", "test", "convert", sourceDir, "--output", outDir]);
+
+		expect(existsSync(join(outDir, "logo.png"))).toBe(true);
+	});
+
+	// ── MDX downgrading ─────────────────────────────────────────────────────
+
+	it("downgrades MDX with incompatible imports to .md", async () => {
+		const { registerConvertCommand } = await import("./ConvertCommand.js");
+		const sourceDir = join(tempDir, "docs");
+		await mkdir(sourceDir, { recursive: true });
+		await writeFile(join(sourceDir, "index.md"), "# Home\n", "utf-8");
+		const mdxContent = "import Tabs from '@theme/Tabs'\n\n# Page\n\nContent here.\n";
+		await writeFile(join(sourceDir, "page.mdx"), mdxContent, "utf-8");
+		const outDir = join(tempDir, "output");
+
+		const program = new Command();
+		registerConvertCommand(program);
+		await program.parseAsync(["node", "test", "convert", sourceDir, "--output", outDir]);
+
+		expect(existsSync(join(outDir, "page.md"))).toBe(true);
+		expect(existsSync(join(outDir, "page.mdx"))).toBe(false);
+		const output = await readFile(join(outDir, "page.md"), "utf-8");
+		expect(output).not.toContain("import");
+		expect(output).toContain("Content here.");
+	});
+
+	// ── slug: / handling ────────────────────────────────────────────────────
+
+	it("renames file with slug: / to index.md", async () => {
+		const { registerConvertCommand } = await import("./ConvertCommand.js");
+		const sourceDir = join(tempDir, "docs");
+		await mkdir(sourceDir, { recursive: true });
+		await writeFile(join(sourceDir, "intro.md"), "---\nslug: /\n---\n# Intro\n", "utf-8");
+		const outDir = join(tempDir, "output");
+
+		const program = new Command();
+		registerConvertCommand(program);
+		await program.parseAsync(["node", "test", "convert", sourceDir, "--output", outDir]);
+
+		expect(existsSync(join(outDir, "index.md"))).toBe(true);
+	});
+
+	// ── Nested directories ──────────────────────────────────────────────────
+
+	it("preserves nested directory structure", async () => {
+		const { registerConvertCommand } = await import("./ConvertCommand.js");
+		const sourceDir = join(tempDir, "docs");
+		await mkdir(join(sourceDir, "guides"), { recursive: true });
+		await writeFile(join(sourceDir, "index.md"), "# Home\n", "utf-8");
+		await writeFile(join(sourceDir, "guides", "intro.md"), "# Intro\n", "utf-8");
+		const outDir = join(tempDir, "output");
+
+		const program = new Command();
+		registerConvertCommand(program);
+		await program.parseAsync(["node", "test", "convert", sourceDir, "--output", outDir]);
+
+		expect(existsSync(join(outDir, "guides", "intro.md"))).toBe(true);
+	});
+
+	// ── Summary output ──────────────────────────────────────────────────────
+
+	it("prints conversion summary", async () => {
+		const { registerConvertCommand } = await import("./ConvertCommand.js");
+		const sourceDir = join(tempDir, "docs");
+		await mkdir(sourceDir, { recursive: true });
+		await writeFile(join(sourceDir, "index.md"), "# Home\n", "utf-8");
+		const outDir = join(tempDir, "output");
+
+		const program = new Command();
+		registerConvertCommand(program);
+		await program.parseAsync(["node", "test", "convert", sourceDir, "--output", outDir]);
+
+		const output = logSpy.mock.calls.map((c: unknown[]) => (c as string[]).join(" ")).join("\n");
+		expect(output).toContain("Converted");
+		expect(output).toContain("site.json");
+	});
+
+	// ── Cleanup framework files ─────────────────────────────────────────────
+
+	it("removes sidebars.js from output after conversion", async () => {
+		const { registerConvertCommand } = await import("./ConvertCommand.js");
+		const sourceDir = join(tempDir, "docs");
+		await mkdir(sourceDir, { recursive: true });
+		await writeFile(join(sourceDir, "index.md"), "# Home\n", "utf-8");
+		// Note: sidebars.js is skipped by isFrameworkFile during processFile,
+		// but cleanupFrameworkFiles also removes it from target if somehow present.
+		// The file won't actually be in the output due to isFrameworkFile.
+		const outDir = join(tempDir, "output");
+
+		const program = new Command();
+		registerConvertCommand(program);
+		await program.parseAsync(["node", "test", "convert", sourceDir, "--output", outDir]);
+
+		expect(existsSync(join(outDir, "sidebars.js"))).toBe(false);
+	});
+
+	// ── Docusaurus conversion with sidebar ──────────────────────────────────
+
+	it("includes sidebar in site.json when Docusaurus conversion succeeds", async () => {
+		const { registerConvertCommand } = await import("./ConvertCommand.js");
+		mockDetectFramework.mockReturnValue({
+			name: "docusaurus",
+			configPath: join(tempDir, "docusaurus.config.ts"),
+			sidebarPath: join(tempDir, "sidebars.js"),
+		});
+		mockPromptMigration.mockResolvedValue(true);
+		mockConvertSidebar.mockResolvedValue({
+			sidebar: { "/": { intro: "Introduction" } },
+			pathMappings: {},
+		});
+
+		const sourceDir = join(tempDir, "docs");
+		await mkdir(sourceDir, { recursive: true });
+		await writeFile(join(sourceDir, "index.md"), "# Home\n", "utf-8");
+		const outDir = join(tempDir, "output");
+
+		const program = new Command();
+		registerConvertCommand(program);
+		await program.parseAsync(["node", "test", "convert", sourceDir, "--output", outDir]);
+
+		const siteJson = JSON.parse(await readFile(join(outDir, "site.json"), "utf-8"));
+		expect(siteJson.sidebar).toBeDefined();
+		expect(siteJson.sidebar["/"]).toBeDefined();
+	});
+
+	// ── OpenAPI files ───────────────────────────────────────────────────────
+
+	it("copies OpenAPI files to output", async () => {
+		const { registerConvertCommand } = await import("./ConvertCommand.js");
+		const sourceDir = join(tempDir, "docs");
+		const apiDir = join(sourceDir, "api");
+		await mkdir(apiDir, { recursive: true });
+		const openapiContent = JSON.stringify({ openapi: "3.1.0", info: { title: "API", version: "1.0" } });
+		await writeFile(join(apiDir, "spec.json"), openapiContent, "utf-8");
+		await writeFile(join(sourceDir, "index.md"), "# Home\n", "utf-8");
+		const outDir = join(tempDir, "output");
+
+		const program = new Command();
+		registerConvertCommand(program);
+		await program.parseAsync(["node", "test", "convert", sourceDir, "--output", outDir]);
+
+		expect(existsSync(join(outDir, "api", "spec.json"))).toBe(true);
+	});
+
+	// ── In-place MDX downgrade ──────────────────────────────────────────────
+
+	it("removes original .mdx when downgrading in-place", async () => {
+		const { registerConvertCommand } = await import("./ConvertCommand.js");
+		const sourceDir = join(tempDir, "docs");
+		await mkdir(sourceDir, { recursive: true });
+		await writeFile(join(sourceDir, "index.md"), "# Home\n", "utf-8");
+		const mdxContent = "import Tabs from '@theme/Tabs'\n\n# Page\n\nContent.\n";
+		await writeFile(join(sourceDir, "page.mdx"), mdxContent, "utf-8");
+
+		const program = new Command();
+		registerConvertCommand(program);
+		// In-place conversion (no --output)
+		await program.parseAsync(["node", "test", "convert", sourceDir]);
+
+		expect(existsSync(join(sourceDir, "page.md"))).toBe(true);
+		expect(existsSync(join(sourceDir, "page.mdx"))).toBe(false);
+	});
+
+	// ── Path mapping ────────────────────────────────────────────────────────
+
+	it("rewrites image paths when file is remapped via pathMappings", async () => {
+		const { registerConvertCommand } = await import("./ConvertCommand.js");
+		mockDetectFramework.mockReturnValue({
+			name: "docusaurus",
+			configPath: join(tempDir, "docusaurus.config.ts"),
+			sidebarPath: join(tempDir, "sidebars.js"),
+		});
+		mockPromptMigration.mockResolvedValue(true);
+		mockConvertSidebar.mockResolvedValue({
+			sidebar: { "/": { sql: "SQL Reference" }, "/sql": { query: "Query" } },
+			pathMappings: { sql: "pipelines/sql" },
+		});
+
+		const sourceDir = join(tempDir, "docs");
+		await mkdir(join(sourceDir, "sql"), { recursive: true });
+		await writeFile(join(sourceDir, "index.md"), "# Home\n", "utf-8");
+		await writeFile(join(sourceDir, "sql", "query.md"), "# Query\n\n![diagram](../img/d.png)\n", "utf-8");
+		const outDir = join(tempDir, "output");
+
+		const program = new Command();
+		registerConvertCommand(program);
+		await program.parseAsync(["node", "test", "convert", sourceDir, "--output", outDir]);
+
+		expect(existsSync(join(outDir, "pipelines", "sql", "query.md"))).toBe(true);
+	});
+
+	// ── Ignored files ───────────────────────────────────────────────────────
+
+	it("does not count ignored files in total", async () => {
+		const { registerConvertCommand } = await import("./ConvertCommand.js");
+		const sourceDir = join(tempDir, "docs");
+		await mkdir(sourceDir, { recursive: true });
+		await writeFile(join(sourceDir, "index.md"), "# Home\n", "utf-8");
+		await writeFile(join(sourceDir, "notes.txt"), "ignored", "utf-8");
+		const outDir = join(tempDir, "output");
+
+		const program = new Command();
+		registerConvertCommand(program);
+		await program.parseAsync(["node", "test", "convert", sourceDir, "--output", outDir]);
+
+		const output = logSpy.mock.calls.map((c: unknown[]) => (c as string[]).join(" ")).join("\n");
+		expect(output).toContain("Converted 1 files");
+	});
+
+	// ── In-place normal markdown copy ───────────────────────────────────────
+
+	it("leaves in-place markdown files unchanged when path doesn't change", async () => {
+		const { registerConvertCommand } = await import("./ConvertCommand.js");
+		const sourceDir = join(tempDir, "docs");
+		await mkdir(sourceDir, { recursive: true });
+		await writeFile(join(sourceDir, "guide.md"), "# Guide\n", "utf-8");
+
+		const program = new Command();
+		registerConvertCommand(program);
+		await program.parseAsync(["node", "test", "convert", sourceDir]);
+
+		const content = await readFile(join(sourceDir, "guide.md"), "utf-8");
+		expect(content).toBe("# Guide\n");
+	});
+
+	// ── In-place with .backup skip ──────────────────────────────────────────
+
+	it("skips .backup directories during traversal", async () => {
+		const { registerConvertCommand } = await import("./ConvertCommand.js");
+		const sourceDir = join(tempDir, "docs");
+		const backupDir = join(sourceDir, ".backup-old");
+		await mkdir(backupDir, { recursive: true });
+		await writeFile(join(backupDir, "old.md"), "old content", "utf-8");
+		await writeFile(join(sourceDir, "index.md"), "# Home\n", "utf-8");
+		const outDir = join(tempDir, "output");
+
+		const program = new Command();
+		registerConvertCommand(program);
+		await program.parseAsync(["node", "test", "convert", sourceDir, "--output", outDir]);
+
+		expect(existsSync(join(outDir, "old.md"))).toBe(false);
+	});
+
+	// ── Print moved folders ─────────────────────────────────────────────────
+
+	it("prints moved folders when pathMappings exist", async () => {
+		const { registerConvertCommand } = await import("./ConvertCommand.js");
+		mockDetectFramework.mockReturnValue({
+			name: "docusaurus",
+			configPath: join(tempDir, "docusaurus.config.ts"),
+			sidebarPath: join(tempDir, "sidebars.js"),
+		});
+		mockPromptMigration.mockResolvedValue(true);
+		mockConvertSidebar.mockResolvedValue({
+			sidebar: {},
+			pathMappings: { sql: "pipelines/sql" },
+		});
+
+		const sourceDir = join(tempDir, "docs");
+		await mkdir(sourceDir, { recursive: true });
+		await writeFile(join(sourceDir, "index.md"), "# Home\n", "utf-8");
+		const outDir = join(tempDir, "output");
+
+		const program = new Command();
+		registerConvertCommand(program);
+		await program.parseAsync(["node", "test", "convert", sourceDir, "--output", outDir]);
+
+		const output = logSpy.mock.calls.map((c: unknown[]) => (c as string[]).join(" ")).join("\n");
+		expect(output).toContain("Moved");
+		expect(output).toContain("sql → pipelines/sql");
+	});
+
+	// ── Favicon handling ────────────────────────────────────────────────────
+
+	it("copies favicon when conversion provides one", async () => {
+		const { registerConvertCommand } = await import("./ConvertCommand.js");
+		const faviconPath = join(tempDir, "static", "img", "favicon.ico");
+		await mkdir(join(tempDir, "static", "img"), { recursive: true });
+		await writeFile(faviconPath, "favicon-data", "utf-8");
+
+		mockDetectFramework.mockReturnValue({
+			name: "docusaurus",
+			configPath: join(tempDir, "docusaurus.config.ts"),
+			sidebarPath: join(tempDir, "sidebars.js"),
+		});
+		mockPromptMigration.mockResolvedValue(true);
+		mockConvertSidebar.mockResolvedValue({
+			sidebar: {},
+			pathMappings: {},
+		});
+		mockExtractFavicon.mockReturnValue(faviconPath);
+
+		const sourceDir = join(tempDir, "docs");
+		await mkdir(sourceDir, { recursive: true });
+		await writeFile(join(sourceDir, "index.md"), "# Home\n", "utf-8");
+		const outDir = join(tempDir, "output");
+
+		const program = new Command();
+		registerConvertCommand(program);
+		await program.parseAsync(["node", "test", "convert", sourceDir, "--output", outDir]);
+
+		expect(existsSync(join(outDir, "favicon.ico"))).toBe(true);
+		const siteJson = JSON.parse(await readFile(join(outDir, "site.json"), "utf-8"));
+		expect(siteJson.favicon).toBe("favicon.ico");
+	});
+
+	// ── Read errors during conversion ───────────────────────────────────────
+
+	it("skips files that cannot be read for classification", async () => {
+		const { registerConvertCommand } = await import("./ConvertCommand.js");
+		const { chmod } = await import("node:fs/promises");
+		const sourceDir = join(tempDir, "docs");
+		await mkdir(sourceDir, { recursive: true });
+		await writeFile(join(sourceDir, "index.md"), "# Home\n", "utf-8");
+		const yamlPath = join(sourceDir, "spec.yaml");
+		await writeFile(yamlPath, "openapi: 3.0.0\ninfo:\n  title: T", "utf-8");
+		await chmod(yamlPath, 0o000);
+		const outDir = join(tempDir, "output");
+
+		const program = new Command();
+		registerConvertCommand(program);
+		await program.parseAsync(["node", "test", "convert", sourceDir, "--output", outDir]);
+
+		await chmod(yamlPath, 0o644);
+		// Should complete without error
+		expect(existsSync(join(outDir, "index.md"))).toBe(true);
+	});
+
+	// ── Cleanup: removes sidebars.js from output ────────────────────────────
+
+	it("removes sidebars.js that ends up in the output directory", async () => {
+		const { registerConvertCommand } = await import("./ConvertCommand.js");
+		const sourceDir = join(tempDir, "docs");
+		await mkdir(sourceDir, { recursive: true });
+		await writeFile(join(sourceDir, "index.md"), "# Home\n", "utf-8");
+		const outDir = join(tempDir, "output");
+		await mkdir(outDir, { recursive: true });
+		// Pre-create a sidebars.js in the output (as if it leaked through)
+		await writeFile(join(outDir, "sidebars.js"), "module.exports = {}", "utf-8");
+
+		const program = new Command();
+		registerConvertCommand(program);
+		await program.parseAsync(["node", "test", "convert", sourceDir, "--output", outDir]);
+
+		expect(existsSync(join(outDir, "sidebars.js"))).toBe(false);
+	});
+
+	it("removes sidebars.ts from output if present", async () => {
+		const { registerConvertCommand } = await import("./ConvertCommand.js");
+		const sourceDir = join(tempDir, "docs");
+		await mkdir(sourceDir, { recursive: true });
+		await writeFile(join(sourceDir, "index.md"), "# Home\n", "utf-8");
+		const outDir = join(tempDir, "output");
+		await mkdir(outDir, { recursive: true });
+		await writeFile(join(outDir, "sidebars.ts"), "export default {}", "utf-8");
+
+		const program = new Command();
+		registerConvertCommand(program);
+		await program.parseAsync(["node", "test", "convert", sourceDir, "--output", outDir]);
+
+		expect(existsSync(join(outDir, "sidebars.ts"))).toBe(false);
+	});
+
+	// ── In-place: src === dest path ─────────────────────────────────────────
+
+	it("handles in-place conversion where source equals dest", async () => {
+		const { registerConvertCommand } = await import("./ConvertCommand.js");
+		const sourceDir = join(tempDir, "docs");
+		await mkdir(join(sourceDir, "guides"), { recursive: true });
+		await writeFile(join(sourceDir, "index.md"), "# Home\n", "utf-8");
+		await writeFile(join(sourceDir, "guides", "intro.md"), "# Intro\n", "utf-8");
+
+		const program = new Command();
+		registerConvertCommand(program);
+		await program.parseAsync(["node", "test", "convert", sourceDir]);
+
+		// Files should still be in place
+		expect(existsSync(join(sourceDir, "index.md"))).toBe(true);
+		expect(existsSync(join(sourceDir, "guides", "intro.md"))).toBe(true);
+	});
+});

--- a/cli/src/commands/ConvertCommand.ts
+++ b/cli/src/commands/ConvertCommand.ts
@@ -1,0 +1,379 @@
+/**
+ * ConvertCommand — Permanently converts a documentation folder to
+ * Nextra-compatible structure.
+ *
+ * Detects the source framework (Docusaurus etc.), reorganizes the directory
+ * structure according to the sidebar config, downgrades incompatible MDX
+ * files, fixes image paths, and writes a clean site.json without pathMappings.
+ *
+ * For in-place conversion, creates a timestamped backup first.
+ */
+
+import { existsSync } from "node:fs";
+import { copyFile, cp, mkdir, readdir, readFile, rename, stat, writeFile } from "node:fs/promises";
+import { basename, dirname, extname, join, relative, resolve } from "node:path";
+import { createInterface } from "node:readline";
+import type { Command } from "commander";
+// AssetResolver used for favicon handling
+import {
+	applyPathMapping,
+	classifyFile,
+	hasIncompatibleImports,
+	rewriteRelativeImagePaths,
+	stripIncompatibleContent,
+} from "../site/ContentMirror.js";
+import {
+	type ConversionResult,
+	convertDocusaurusSidebar,
+	extractFaviconFromConfig,
+} from "../site/DocusaurusConverter.js";
+import { detectFramework, promptMigration } from "../site/FrameworkDetector.js";
+import type { PathMappings, SiteJson } from "../site/Types.js";
+
+// ─── registerConvertCommand ──────────────────────────────────────────────────
+
+export function registerConvertCommand(program: Command): void {
+	program
+		.command("convert")
+		.description("Convert a documentation folder to Nextra-compatible structure")
+		.argument("[source]", "Source folder (default: current directory)")
+		.option("--output <path>", "Output folder (default: convert in-place)")
+		.action(async (sourceArg?: string, opts?: { output?: string }) => {
+			const sourceRoot = resolve(sourceArg ?? process.cwd());
+			const outputDir = opts?.output ? resolve(opts.output) : sourceRoot;
+			const inPlace = outputDir === sourceRoot;
+
+			if (!existsSync(sourceRoot)) {
+				console.error(`  Error: Source folder does not exist: ${sourceRoot}`);
+				process.exitCode = 1;
+				return;
+			}
+
+			try {
+				await convertFolder(sourceRoot, outputDir, inPlace);
+			} catch (err) {
+				console.error(`  Error: ${err instanceof Error ? err.message : String(err)}`);
+				process.exitCode = 1;
+			}
+		});
+}
+
+// ─── convertFolder ───────────────────────────────────────────────────────────
+
+interface ConvertStats {
+	totalFiles: number;
+	downgraded: number;
+	movedFolders: string[];
+}
+
+async function convertFolder(sourceRoot: string, targetRoot: string, inPlace: boolean): Promise<void> {
+	// Step 1: Detect framework and generate conversion config
+	let conversion: ConversionResult | undefined;
+	const framework = detectFramework(sourceRoot);
+
+	if (framework) {
+		const shouldMigrate = await promptMigration(framework);
+		if (shouldMigrate && framework.name === "docusaurus" && framework.sidebarPath) {
+			conversion = await convertDocusaurusSidebar(framework.sidebarPath);
+			const faviconPath = extractFaviconFromConfig(framework.configPath);
+			if (faviconPath) conversion.favicon = faviconPath;
+		}
+	}
+
+	// Step 2: Prompt for site title
+	const folderName = basename(sourceRoot);
+	const defaultTitle = folderName.replace(/[-_]/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+	const title = await promptTitle(defaultTitle);
+
+	const pathMappings = conversion?.pathMappings ?? {};
+
+	// Step 3: Backup if in-place
+	if (inPlace) {
+		const timestamp = new Date().toISOString().replace(/[:.]/g, "-").slice(0, 19);
+		const backupDir = `${sourceRoot}.backup-${timestamp}`;
+		console.log(`  Creating backup → ${backupDir}`);
+		await cp(sourceRoot, backupDir, { recursive: true });
+		console.log("  ✓ Backup created");
+	}
+
+	// Step 4: Prepare target directory
+	if (!inPlace) {
+		await mkdir(targetRoot, { recursive: true });
+	}
+
+	// Step 5: Convert files
+	const stats: ConvertStats = { totalFiles: 0, downgraded: 0, movedFolders: [] };
+
+	// Track unique moved folders for summary
+	for (const [src, tgt] of Object.entries(pathMappings)) {
+		stats.movedFolders.push(`${src} → ${tgt}`);
+	}
+
+	await processDirectory(sourceRoot, sourceRoot, targetRoot, pathMappings, stats, inPlace);
+
+	// Step 6: Handle slug: / → index.md
+	const renamedKey = await handleSlugIndex(targetRoot);
+
+	// Step 7: Handle favicon
+	if (conversion?.favicon) {
+		const faviconDest = join(targetRoot, "favicon.ico");
+		if (existsSync(conversion.favicon)) {
+			await copyFile(conversion.favicon, faviconDest);
+		}
+	}
+
+	// Step 8: Write site.json (WITHOUT pathMappings)
+	const sidebar = conversion?.sidebar;
+
+	// If a file was renamed to index.md, update sidebar key
+	if (renamedKey && sidebar?.["/"]?.[renamedKey]) {
+		const label = sidebar["/"][renamedKey];
+		delete sidebar["/"][renamedKey];
+		sidebar["/"] = { index: label, ...sidebar["/"] };
+	}
+
+	const siteJson: SiteJson = {
+		title,
+		description: `${title} documentation`,
+		nav: [],
+	};
+	if (sidebar && Object.keys(sidebar).length > 0) {
+		siteJson.sidebar = sidebar;
+	}
+	if (conversion?.favicon) {
+		siteJson.favicon = "favicon.ico";
+	}
+	await writeFile(join(targetRoot, "site.json"), `${JSON.stringify(siteJson, null, 2)}\n`, "utf-8");
+
+	// Step 9: Clean up framework-specific files in target
+	await cleanupFrameworkFiles(targetRoot);
+
+	// Summary
+	console.log("");
+	console.log(
+		`  ✓ Converted ${stats.totalFiles} files${stats.downgraded > 0 ? ` (${stats.downgraded} downgraded)` : ""}`,
+	);
+	if (stats.movedFolders.length > 0) {
+		console.log(`  ✓ Moved ${stats.movedFolders.length} folders:`);
+		for (const move of stats.movedFolders) {
+			console.log(`      ${move}`);
+		}
+	}
+	if (inPlace) {
+		console.log(`  ✓ Original backed up`);
+	}
+	console.log(`  ✓ Created site.json`);
+	console.log(`\n  Run \`jolli dev${targetRoot !== process.cwd() ? ` ${targetRoot}` : ""}\` to preview.\n`);
+}
+
+// ─── processDirectory ────────────────────────────────────────────────────────
+
+async function processDirectory(
+	currentDir: string,
+	sourceRoot: string,
+	targetRoot: string,
+	pathMappings: PathMappings,
+	stats: ConvertStats,
+	inPlace: boolean,
+): Promise<void> {
+	let entries: string[];
+	try {
+		entries = await readdir(currentDir);
+	} catch {
+		return;
+	}
+
+	for (const entry of entries) {
+		if (entry === ".jolli-site" || entry.startsWith(".backup-")) continue;
+
+		const fullPath = join(currentDir, entry);
+		let entryStat: Awaited<ReturnType<typeof stat>>;
+		try {
+			entryStat = await stat(fullPath);
+		} catch {
+			continue;
+		}
+
+		if (entryStat.isDirectory()) {
+			await processDirectory(fullPath, sourceRoot, targetRoot, pathMappings, stats, inPlace);
+		} else if (entryStat.isFile()) {
+			await processFile(fullPath, sourceRoot, targetRoot, pathMappings, stats, inPlace);
+		}
+	}
+}
+
+async function processFile(
+	fullPath: string,
+	sourceRoot: string,
+	targetRoot: string,
+	pathMappings: PathMappings,
+	stats: ConvertStats,
+	inPlace: boolean,
+): Promise<void> {
+	const originalRelPath = relative(sourceRoot, fullPath);
+	const mappedRelPath = applyPathMapping(originalRelPath, pathMappings);
+	const ext = extname(fullPath).toLowerCase();
+	const destPath = join(targetRoot, mappedRelPath);
+
+	// Skip framework config files
+	if (isFrameworkFile(originalRelPath)) return;
+
+	// Read content for classification if needed
+	let content: string | undefined;
+	if (ext === ".json" || ext === ".yaml" || ext === ".yml") {
+		try {
+			content = await readFile(fullPath, "utf-8");
+		} catch {
+			return;
+		}
+	}
+
+	const fileType = classifyFile(fullPath, content);
+
+	switch (fileType) {
+		case "markdown": {
+			stats.totalFiles++;
+			await mkdir(dirname(destPath), { recursive: true });
+
+			if (ext === ".mdx") {
+				let mdxContent: string;
+				try {
+					mdxContent = await readFile(fullPath, "utf-8");
+				} catch {
+					return;
+				}
+
+				if (hasIncompatibleImports(mdxContent)) {
+					// Downgrade to .md
+					const cleaned = stripIncompatibleContent(mdxContent);
+					const mdDestPath = destPath.replace(/\.mdx$/, ".md");
+					// Rewrite image paths if file was remapped
+					const mdMappedRelPath = mappedRelPath.replace(/\.mdx$/, ".md");
+					const rewritten =
+						originalRelPath !== mdMappedRelPath
+							? rewriteRelativeImagePaths(cleaned, originalRelPath, mdMappedRelPath, pathMappings)
+							: cleaned;
+					await writeFile(mdDestPath, rewritten, "utf-8");
+					stats.downgraded++;
+
+					// Remove original .mdx if in-place (we wrote .md instead)
+					if (inPlace) {
+						await safeRemove(fullPath);
+					}
+					return;
+				}
+			}
+
+			// Normal copy/move
+			if (originalRelPath !== mappedRelPath) {
+				let mdContent: string;
+				try {
+					mdContent = await readFile(fullPath, "utf-8");
+				} catch {
+					await safeCopyOrMove(fullPath, destPath, inPlace);
+					return;
+				}
+				const rewritten = rewriteRelativeImagePaths(mdContent, originalRelPath, mappedRelPath, pathMappings);
+				await writeFile(destPath, rewritten, "utf-8");
+				if (inPlace && fullPath !== destPath) await safeRemove(fullPath);
+			} else if (!inPlace) {
+				await copyFile(fullPath, destPath);
+			}
+			// If in-place and path unchanged, file stays where it is
+			break;
+		}
+		case "image":
+		case "openapi":
+		case "ignored": {
+			if (fileType !== "ignored") stats.totalFiles++;
+			await mkdir(dirname(destPath), { recursive: true });
+			await safeCopyOrMove(fullPath, destPath, inPlace);
+			break;
+		}
+	}
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function promptTitle(defaultTitle: string): Promise<string> {
+	if (!process.stdin.isTTY) return Promise.resolve(defaultTitle);
+	const rl = createInterface({ input: process.stdin, output: process.stdout });
+	return new Promise((resolve) => {
+		rl.question(`Site title (${defaultTitle}): `, (answer) => {
+			rl.close();
+			resolve(answer.trim() || defaultTitle);
+		});
+	});
+}
+
+async function safeCopyOrMove(src: string, dest: string, inPlace: boolean): Promise<void> {
+	if (src === dest) return;
+	await mkdir(dirname(dest), { recursive: true });
+	if (inPlace) {
+		try {
+			await rename(src, dest);
+		} catch {
+			// Cross-device — fall back to copy + remove
+			await copyFile(src, dest);
+			await safeRemove(src);
+		}
+	} else {
+		await copyFile(src, dest);
+	}
+}
+
+async function safeRemove(path: string): Promise<void> {
+	try {
+		const { rm } = await import("node:fs/promises");
+		await rm(path, { force: true });
+	} catch {
+		// Ignore removal errors
+	}
+}
+
+/** Files to skip during conversion (framework-specific configs). */
+function isFrameworkFile(relPath: string): boolean {
+	const name = basename(relPath);
+	return [
+		"sidebars.js",
+		"sidebars.ts",
+		"docusaurus.config.js",
+		"docusaurus.config.ts",
+		"package.json",
+		"package-lock.json",
+		"yarn.lock",
+		"node_modules",
+		"site.json",
+	].includes(name);
+}
+
+/** Rename file with slug: / to index.md. Returns old key if renamed. */
+async function handleSlugIndex(targetRoot: string): Promise<string | undefined> {
+	const entries = await readdir(targetRoot);
+	for (const entry of entries) {
+		const ext = extname(entry).toLowerCase();
+		if (ext !== ".md" && ext !== ".mdx") continue;
+		if (entry === "index.md" || entry === "index.mdx") return undefined;
+
+		const fullPath = join(targetRoot, entry);
+		try {
+			const content = await readFile(fullPath, "utf-8");
+			if (/^slug:\s*\/\s*$/m.test(content)) {
+				await rename(fullPath, join(targetRoot, "index.md"));
+				return entry.replace(/\.(md|mdx)$/, "");
+			}
+		} catch {}
+	}
+	return undefined;
+}
+
+/** Remove framework-specific files from target after conversion. */
+async function cleanupFrameworkFiles(targetRoot: string): Promise<void> {
+	const toRemove = ["sidebars.js", "sidebars.ts"];
+	for (const file of toRemove) {
+		const fullPath = join(targetRoot, file);
+		if (existsSync(fullPath)) {
+			await safeRemove(fullPath);
+		}
+	}
+}

--- a/cli/src/commands/NewCommand.test.ts
+++ b/cli/src/commands/NewCommand.test.ts
@@ -1,0 +1,253 @@
+/**
+ * Tests for NewCommand — registers the `jolli new [folder-name]` command.
+ *
+ * Covers:
+ *   - Successful scaffold: prints created path and next-steps message
+ *   - Directory already exists: prints error and sets exitCode = 1
+ *   - Filesystem error: prints OS error message and sets exitCode = 1
+ *   - Missing argument: prompts interactively for folder name
+ *   - Empty prompt input: prints error and sets exitCode = 1
+ */
+
+import { Command } from "commander";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// ─── Hoist mocks ─────────────────────────────────────────────────────────────
+
+const { mockScaffoldProject, mockCreateInterface } = vi.hoisted(() => ({
+	mockScaffoldProject: vi.fn(),
+	mockCreateInterface: vi.fn(),
+}));
+
+vi.mock("../site/StarterKit.js", () => ({
+	scaffoldProject: mockScaffoldProject,
+}));
+
+vi.mock("node:readline", () => ({
+	createInterface: mockCreateInterface,
+}));
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/** Creates a fresh Commander program with the new command registered. */
+async function makeProgram(): Promise<Command> {
+	const { registerNewCommand } = await import("./NewCommand.js");
+	const program = new Command();
+	program.exitOverride();
+	registerNewCommand(program);
+	return program;
+}
+
+/** Sets up mockCreateInterface to return a given answer. */
+function mockPrompt(answer: string): void {
+	mockCreateInterface.mockReturnValue({
+		question: (_prompt: string, cb: (answer: string) => void) => cb(answer),
+		close: vi.fn(),
+	});
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("NewCommand", () => {
+	let consoleSpy: ReturnType<typeof vi.spyOn>;
+	let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+	let originalExitCode: number | undefined;
+	const originalIsTTY = process.stdin.isTTY;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+		originalExitCode = process.exitCode as number | undefined;
+		process.exitCode = 0;
+		process.stdin.isTTY = true;
+	});
+
+	afterEach(() => {
+		process.exitCode = originalExitCode;
+		process.stdin.isTTY = originalIsTTY;
+		consoleSpy.mockRestore();
+		consoleErrorSpy.mockRestore();
+	});
+
+	// ── Success path ─────────────────────────────────────────────────────────
+
+	it("prints the created directory path on success", async () => {
+		const targetDir = "/some/path/my-docs";
+		mockScaffoldProject.mockResolvedValue({
+			success: true,
+			targetDir,
+			message: `Created ${targetDir}`,
+		});
+
+		const program = await makeProgram();
+		await program.parseAsync(["new", "my-docs"], { from: "user" });
+
+		const output = consoleSpy.mock.calls.map((c: unknown[]) => c.join(" ")).join("\n");
+		expect(output).toContain(targetDir);
+	});
+
+	it("prints a next-steps message on success", async () => {
+		const targetDir = "/some/path/my-docs";
+		mockScaffoldProject.mockResolvedValue({
+			success: true,
+			targetDir,
+			message: `Created ${targetDir}`,
+		});
+
+		const program = await makeProgram();
+		await program.parseAsync(["new", "my-docs"], { from: "user" });
+
+		const output = consoleSpy.mock.calls.map((c: unknown[]) => c.join(" ")).join("\n");
+		expect(output).toContain("jolli dev");
+	});
+
+	it("does not set exitCode on success", async () => {
+		mockScaffoldProject.mockResolvedValue({
+			success: true,
+			targetDir: "/some/path/my-docs",
+			message: "Created /some/path/my-docs",
+		});
+
+		const program = await makeProgram();
+		await program.parseAsync(["new", "my-docs"], { from: "user" });
+
+		expect(process.exitCode).toBe(0);
+	});
+
+	it("calls scaffoldProject with the resolved target directory", async () => {
+		mockScaffoldProject.mockResolvedValue({
+			success: true,
+			targetDir: "/cwd/my-docs",
+			message: "Created /cwd/my-docs",
+		});
+
+		const program = await makeProgram();
+		await program.parseAsync(["new", "my-docs"], { from: "user" });
+
+		expect(mockScaffoldProject).toHaveBeenCalledOnce();
+		const [calledWith] = mockScaffoldProject.mock.calls[0] as [string];
+		expect(calledWith).toMatch(/my-docs$/);
+	});
+
+	// ── Directory already exists ──────────────────────────────────────────────
+
+	it("prints an error message when the directory already exists", async () => {
+		const targetDir = "/some/path/existing-dir";
+		mockScaffoldProject.mockResolvedValue({
+			success: false,
+			targetDir,
+			message: `Directory already exists: ${targetDir}`,
+		});
+
+		const program = await makeProgram();
+		await program.parseAsync(["new", "existing-dir"], { from: "user" });
+
+		const errorOutput = consoleErrorSpy.mock.calls.map((c: unknown[]) => c.join(" ")).join("\n");
+		expect(errorOutput).toContain("Directory already exists");
+	});
+
+	it("sets exitCode to 1 when the directory already exists", async () => {
+		mockScaffoldProject.mockResolvedValue({
+			success: false,
+			targetDir: "/some/path/existing-dir",
+			message: "Directory already exists: /some/path/existing-dir",
+		});
+
+		const program = await makeProgram();
+		await program.parseAsync(["new", "existing-dir"], { from: "user" });
+
+		expect(process.exitCode).toBe(1);
+	});
+
+	// ── Filesystem error ──────────────────────────────────────────────────────
+
+	it("prints the OS error message on filesystem failure", async () => {
+		mockScaffoldProject.mockResolvedValue({
+			success: false,
+			targetDir: "/no-permission/my-docs",
+			message: "EACCES: permission denied, mkdir '/no-permission/my-docs'",
+		});
+
+		const program = await makeProgram();
+		await program.parseAsync(["new", "my-docs"], { from: "user" });
+
+		const errorOutput = consoleErrorSpy.mock.calls.map((c: unknown[]) => c.join(" ")).join("\n");
+		expect(errorOutput).toContain("EACCES");
+	});
+
+	it("sets exitCode to 1 on filesystem failure", async () => {
+		mockScaffoldProject.mockResolvedValue({
+			success: false,
+			targetDir: "/no-permission/my-docs",
+			message: "EACCES: permission denied, mkdir '/no-permission/my-docs'",
+		});
+
+		const program = await makeProgram();
+		await program.parseAsync(["new", "my-docs"], { from: "user" });
+
+		expect(process.exitCode).toBe(1);
+	});
+
+	// ── Interactive prompt when no argument ───────────────────────────────────
+
+	it("prompts for folder name when argument is missing", async () => {
+		mockPrompt("prompted-docs");
+		mockScaffoldProject.mockResolvedValue({
+			success: true,
+			targetDir: "/cwd/prompted-docs",
+			message: "Created",
+		});
+
+		const program = await makeProgram();
+		await program.parseAsync(["new"], { from: "user" });
+
+		expect(mockCreateInterface).toHaveBeenCalledOnce();
+		const [calledWith] = mockScaffoldProject.mock.calls[0] as [string];
+		expect(calledWith).toMatch(/prompted-docs$/);
+	});
+
+	it("sets exitCode = 1 when prompt input is empty", async () => {
+		mockPrompt("");
+
+		const program = await makeProgram();
+		await program.parseAsync(["new"], { from: "user" });
+
+		expect(process.exitCode).toBe(1);
+		expect(mockScaffoldProject).not.toHaveBeenCalled();
+	});
+
+	it("sets exitCode = 1 when prompt input is only whitespace", async () => {
+		mockPrompt("   ");
+
+		const program = await makeProgram();
+		await program.parseAsync(["new"], { from: "user" });
+
+		expect(process.exitCode).toBe(1);
+		expect(mockScaffoldProject).not.toHaveBeenCalled();
+	});
+
+	it("returns empty string without prompting when stdin is not a TTY", async () => {
+		process.stdin.isTTY = undefined as unknown as true;
+
+		const program = await makeProgram();
+		await program.parseAsync(["new"], { from: "user" });
+
+		expect(process.exitCode).toBe(1);
+	});
+
+	it("trims whitespace from prompted folder name", async () => {
+		mockPrompt("  my-docs  ");
+		mockScaffoldProject.mockResolvedValue({
+			success: true,
+			targetDir: "/cwd/my-docs",
+			message: "Created",
+		});
+
+		const program = await makeProgram();
+		await program.parseAsync(["new"], { from: "user" });
+
+		const [calledWith] = mockScaffoldProject.mock.calls[0] as [string];
+		expect(calledWith).toMatch(/my-docs$/);
+	});
+});

--- a/cli/src/commands/NewCommand.ts
+++ b/cli/src/commands/NewCommand.ts
@@ -1,0 +1,63 @@
+/**
+ * NewCommand — Registers the `jolli new [folder-name]` command.
+ *
+ * Scaffolds a new Content_Folder at the given folder name (relative to cwd)
+ * using StarterKit.scaffoldProject. If no folder name is provided,
+ * interactively prompts the user to enter one.
+ *
+ * On success, prints the created directory path and a brief next-steps
+ * message. On failure, prints the error message and sets process.exitCode = 1.
+ */
+
+import { join } from "node:path";
+import { createInterface } from "node:readline";
+import type { Command } from "commander";
+import { scaffoldProject } from "../site/StarterKit.js";
+
+/**
+ * Prompts the user interactively for a folder name via stdin/stdout.
+ */
+function promptFolderName(): Promise<string> {
+	if (!process.stdin.isTTY) return Promise.resolve("");
+	const rl = createInterface({ input: process.stdin, output: process.stdout });
+	return new Promise((resolve) => {
+		rl.question("Folder name: ", (answer) => {
+			rl.close();
+			resolve(answer.trim());
+		});
+	});
+}
+
+/**
+ * Registers the `jolli new [folder-name]` sub-command on the given Commander
+ * program.
+ */
+export function registerNewCommand(program: Command): void {
+	program
+		.command("new")
+		.description("Scaffold a new documentation project")
+		.argument("[folder-name]", "Name of the new content folder to create")
+		.action(async (folderNameArg?: string) => {
+			let folderName = folderNameArg;
+
+			if (!folderName) {
+				folderName = await promptFolderName();
+				if (!folderName) {
+					console.error("\n  Error: Folder name is required.\n");
+					process.exitCode = 1;
+					return;
+				}
+			}
+
+			const targetDir = join(process.cwd(), folderName);
+			const result = await scaffoldProject(targetDir);
+
+			if (result.success) {
+				console.log(`\n  Created ${result.targetDir}`);
+				console.log(`  Run \`jolli dev\` inside that folder to preview your site.\n`);
+			} else {
+				console.error(`\n  Error: ${result.message}\n`);
+				process.exitCode = 1;
+			}
+		});
+}

--- a/cli/src/commands/StartCommand.test.ts
+++ b/cli/src/commands/StartCommand.test.ts
@@ -1,0 +1,706 @@
+/**
+ * Tests for StartCommand — registers `jolli start` and `jolli dev` commands.
+ *
+ * Covers:
+ *   - Source_Root does not exist: prints error and sets exitCode = 1
+ *   - site.json parse error: prints error and sets exitCode = 1
+ *   - No markdown or OpenAPI files: prints warning and continues
+ *   - npm install failure: prints error output and sets exitCode = 1
+ *   - jolli start: build + pagefind + serve
+ *   - jolli dev: dev server with hot reload
+ *   - Skips npm install when node_modules already exists
+ *   - Defaults source-root to process.cwd() when not provided
+ */
+
+import { resolve } from "node:path";
+import { Command } from "commander";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { getBuildDir } from "./StartCommand.js";
+
+// ─── Hoist mocks ─────────────────────────────────────────────────────────────
+
+const {
+	mockExistsSync,
+	mockReadSiteJson,
+	mockInitNextraProject,
+	mockMirrorContent,
+	mockGenerateMetaFiles,
+	mockRenderOpenApiFiles,
+	mockNeedsInstall,
+	mockRunNpmInstall,
+	mockRunNpmBuild,
+	mockRunNpmDev,
+	mockRunPagefind,
+	mockRunServe,
+} = vi.hoisted(() => ({
+	mockExistsSync: vi.fn(),
+	mockReadSiteJson: vi.fn(),
+	mockInitNextraProject: vi.fn(),
+	mockMirrorContent: vi.fn(),
+	mockGenerateMetaFiles: vi.fn(),
+	mockRenderOpenApiFiles: vi.fn(),
+	mockNeedsInstall: vi.fn(),
+	mockRunNpmInstall: vi.fn(),
+	mockRunNpmBuild: vi.fn(),
+	mockRunNpmDev: vi.fn(),
+	mockRunPagefind: vi.fn(),
+	mockRunServe: vi.fn(),
+}));
+
+vi.mock("node:fs", () => ({
+	existsSync: mockExistsSync,
+}));
+
+vi.mock("../site/SiteJsonReader.js", () => ({
+	readSiteJson: mockReadSiteJson,
+}));
+
+vi.mock("../site/NextraProjectWriter.js", () => ({
+	initNextraProject: mockInitNextraProject,
+}));
+
+vi.mock("../site/ContentMirror.js", () => ({
+	clearDir: vi.fn(),
+	mirrorContent: mockMirrorContent,
+}));
+
+vi.mock("../site/MetaGenerator.js", () => ({
+	generateMetaFiles: mockGenerateMetaFiles,
+}));
+
+vi.mock("../site/OpenApiRenderer.js", () => ({
+	renderOpenApiFiles: mockRenderOpenApiFiles,
+}));
+
+vi.mock("../site/NpmRunner.js", () => ({
+	needsInstall: mockNeedsInstall,
+	runNpmInstall: mockRunNpmInstall,
+	runNpmBuild: mockRunNpmBuild,
+	runNpmDev: mockRunNpmDev,
+	runServe: mockRunServe,
+}));
+
+vi.mock("../site/PagefindRunner.js", () => ({
+	runPagefind: mockRunPagefind,
+}));
+
+// ─── Default mock values ──────────────────────────────────────────────────────
+
+const DEFAULT_SITE_JSON_RESULT = {
+	config: { title: "Test Site", description: "A test site", nav: [] },
+	usedDefault: false,
+};
+
+const DEFAULT_MIRROR_RESULT = {
+	markdownFiles: ["index.md"],
+	openapiFiles: [],
+	imageFiles: [],
+	ignoredFiles: [],
+};
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+async function makeProgram(): Promise<Command> {
+	const { registerStartCommand, registerBuildCommand, registerDevCommand } = await import("./StartCommand.js");
+	const program = new Command();
+	program.exitOverride();
+	registerStartCommand(program);
+	registerBuildCommand(program);
+	registerDevCommand(program);
+	return program;
+}
+
+function setupSuccessfulRun(
+	overrides: { needsInstall?: boolean; markdownFiles?: string[]; openapiFiles?: string[] } = {},
+): void {
+	mockExistsSync.mockReturnValue(true);
+	mockReadSiteJson.mockResolvedValue(DEFAULT_SITE_JSON_RESULT);
+	mockInitNextraProject.mockResolvedValue({ isNew: false });
+	mockMirrorContent.mockResolvedValue({
+		...DEFAULT_MIRROR_RESULT,
+		markdownFiles: overrides.markdownFiles ?? DEFAULT_MIRROR_RESULT.markdownFiles,
+		openapiFiles: overrides.openapiFiles ?? DEFAULT_MIRROR_RESULT.openapiFiles,
+	});
+	mockGenerateMetaFiles.mockResolvedValue(undefined);
+	mockRenderOpenApiFiles.mockResolvedValue(undefined);
+	mockNeedsInstall.mockReturnValue(overrides.needsInstall ?? false);
+	mockRunNpmInstall.mockResolvedValue({ success: true, output: "" });
+	mockRunNpmBuild.mockResolvedValue({ success: true, output: "" });
+	mockRunNpmDev.mockResolvedValue({ success: true, output: "" });
+	mockRunPagefind.mockResolvedValue({ success: true, output: "Indexed 5 pages", pagesIndexed: 5 });
+	mockRunServe.mockResolvedValue({ success: true, output: "" });
+}
+
+// ─── Shared pipeline tests (apply to both start and dev) ─────────────────────
+
+describe.each([
+	{ cmd: "start", label: "jolli start" },
+	{ cmd: "build", label: "jolli build" },
+	{ cmd: "dev", label: "jolli dev" },
+])("$label — shared pipeline", ({ cmd }) => {
+	let consoleSpy: ReturnType<typeof vi.spyOn>;
+	let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+	let consoleWarnSpy: ReturnType<typeof vi.spyOn>;
+	let originalExitCode: number | undefined;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+		consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+		originalExitCode = process.exitCode as number | undefined;
+		process.exitCode = 0;
+	});
+
+	afterEach(() => {
+		process.exitCode = originalExitCode;
+		consoleSpy.mockRestore();
+		consoleErrorSpy.mockRestore();
+		consoleWarnSpy.mockRestore();
+	});
+
+	it("prints an error when source-root does not exist", async () => {
+		mockExistsSync.mockReturnValue(false);
+		const program = await makeProgram();
+		await program.parseAsync([cmd, "/nonexistent"], { from: "user" });
+
+		expect(consoleErrorSpy.mock.calls.map((c: unknown[]) => c.join(" ")).join("\n")).toContain("/nonexistent");
+		expect(process.exitCode).toBe(1);
+	});
+
+	it("does not proceed past validation when source-root does not exist", async () => {
+		mockExistsSync.mockReturnValue(false);
+		const program = await makeProgram();
+		await program.parseAsync([cmd, "/nonexistent"], { from: "user" });
+
+		expect(mockReadSiteJson).not.toHaveBeenCalled();
+	});
+
+	it("prints an error when site.json is invalid JSON", async () => {
+		mockExistsSync.mockReturnValue(true);
+		mockReadSiteJson.mockRejectedValue(new Error("Failed to parse"));
+		const program = await makeProgram();
+		await program.parseAsync([cmd, "/my-docs"], { from: "user" });
+
+		expect(consoleErrorSpy.mock.calls.map((c: unknown[]) => c.join(" ")).join("\n")).toContain("Failed to parse");
+		expect(process.exitCode).toBe(1);
+	});
+
+	it("handles non-Error rejection from readSiteJson", async () => {
+		mockExistsSync.mockReturnValue(true);
+		mockReadSiteJson.mockRejectedValue("string error");
+		const program = await makeProgram();
+		await program.parseAsync([cmd, "/my-docs"], { from: "user" });
+
+		expect(consoleErrorSpy.mock.calls.map((c: unknown[]) => c.join(" ")).join("\n")).toContain("string error");
+		expect(process.exitCode).toBe(1);
+	});
+
+	it("prints a warning when no content files are found", async () => {
+		setupSuccessfulRun({ markdownFiles: [], openapiFiles: [] });
+		const program = await makeProgram();
+		await program.parseAsync([cmd, "/my-docs"], { from: "user" });
+
+		expect(consoleWarnSpy.mock.calls.map((c: unknown[]) => c.join(" ")).join("\n")).toContain(
+			"No markdown or OpenAPI files found",
+		);
+	});
+
+	it("prints npm error and sets exitCode = 1 when npm install fails", async () => {
+		setupSuccessfulRun({ needsInstall: true });
+		mockRunNpmInstall.mockResolvedValue({ success: false, output: "npm ERR!" });
+		const program = await makeProgram();
+		await program.parseAsync([cmd, "/my-docs"], { from: "user" });
+
+		expect(process.exitCode).toBe(1);
+	});
+
+	it("skips npm install when needsInstall returns false", async () => {
+		setupSuccessfulRun({ needsInstall: false });
+		const program = await makeProgram();
+		await program.parseAsync([cmd, "/my-docs"], { from: "user" });
+
+		expect(mockRunNpmInstall).not.toHaveBeenCalled();
+	});
+
+	it("runs npm install when needsInstall returns true", async () => {
+		setupSuccessfulRun({ needsInstall: true });
+		const program = await makeProgram();
+		await program.parseAsync([cmd, "/my-docs"], { from: "user" });
+
+		expect(mockRunNpmInstall).toHaveBeenCalledOnce();
+	});
+
+	it("defaults source-root to process.cwd()", async () => {
+		setupSuccessfulRun();
+		const program = await makeProgram();
+		await program.parseAsync([cmd], { from: "user" });
+
+		expect(mockExistsSync).toHaveBeenCalledWith(process.cwd());
+	});
+
+	it("passes the correct buildDir to initNextraProject", async () => {
+		setupSuccessfulRun();
+		const program = await makeProgram();
+		await program.parseAsync([cmd, "/my-docs"], { from: "user" });
+
+		const [calledBuildDir] = mockInitNextraProject.mock.calls[0] as [string, unknown, unknown];
+		expect(calledBuildDir).toBe(getBuildDir(resolve("/my-docs")));
+	});
+
+	it("passes the correct contentDir to mirrorContent", async () => {
+		setupSuccessfulRun();
+		const program = await makeProgram();
+		await program.parseAsync([cmd, "/my-docs"], { from: "user" });
+
+		const [, calledContentDir] = mockMirrorContent.mock.calls[0] as [string, string];
+		expect(calledContentDir).toBe(`${getBuildDir(resolve("/my-docs"))}/content`);
+	});
+});
+
+// ─── jolli build specific tests ──────────────────────────────────────────────
+
+describe("jolli build", () => {
+	let consoleSpy: ReturnType<typeof vi.spyOn>;
+	let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+	let originalExitCode: number | undefined;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+		vi.spyOn(console, "warn").mockImplementation(() => {});
+		originalExitCode = process.exitCode as number | undefined;
+		process.exitCode = 0;
+	});
+
+	afterEach(() => {
+		process.exitCode = originalExitCode;
+		consoleSpy.mockRestore();
+		consoleErrorSpy.mockRestore();
+	});
+
+	it("runs build and pagefind but not serve", async () => {
+		setupSuccessfulRun();
+		const program = await makeProgram();
+		await program.parseAsync(["build", "/my-docs"], { from: "user" });
+
+		expect(mockRunNpmBuild).toHaveBeenCalledOnce();
+		expect(mockRunPagefind).toHaveBeenCalledOnce();
+		expect(mockRunServe).not.toHaveBeenCalled();
+		expect(mockRunNpmDev).not.toHaveBeenCalled();
+	});
+
+	it("prints next-step message on success", async () => {
+		setupSuccessfulRun();
+		const program = await makeProgram();
+		await program.parseAsync(["build", "/my-docs"], { from: "user" });
+
+		const output = consoleSpy.mock.calls.map((c: unknown[]) => c.join(" ")).join("\n");
+		expect(output).toContain("jolli start");
+	});
+
+	it("sets exitCode = 1 when next build fails", async () => {
+		setupSuccessfulRun();
+		mockRunNpmBuild.mockResolvedValue({ success: false, output: "Build failed" });
+		const program = await makeProgram();
+		await program.parseAsync(["build", "/my-docs"], { from: "user" });
+
+		expect(process.exitCode).toBe(1);
+		expect(mockRunPagefind).not.toHaveBeenCalled();
+	});
+
+	it("sets exitCode = 1 when pagefind fails", async () => {
+		setupSuccessfulRun();
+		mockRunPagefind.mockResolvedValue({ success: false, output: "Pagefind error" });
+		const program = await makeProgram();
+		await program.parseAsync(["build", "/my-docs"], { from: "user" });
+
+		expect(process.exitCode).toBe(1);
+	});
+
+	it("does not set exitCode on a successful run", async () => {
+		setupSuccessfulRun();
+		const program = await makeProgram();
+		await program.parseAsync(["build", "/my-docs"], { from: "user" });
+
+		expect(process.exitCode).toBe(0);
+	});
+});
+
+// ─── jolli start specific tests ──────────────────────────────────────────────
+
+describe("jolli start", () => {
+	let consoleSpy: ReturnType<typeof vi.spyOn>;
+	let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+	let originalExitCode: number | undefined;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+		vi.spyOn(console, "warn").mockImplementation(() => {});
+		originalExitCode = process.exitCode as number | undefined;
+		process.exitCode = 0;
+	});
+
+	afterEach(() => {
+		process.exitCode = originalExitCode;
+		consoleSpy.mockRestore();
+		consoleErrorSpy.mockRestore();
+	});
+
+	it("runs build, pagefind, and serve", async () => {
+		setupSuccessfulRun();
+		const program = await makeProgram();
+		await program.parseAsync(["start", "/my-docs"], { from: "user" });
+
+		expect(mockRunNpmBuild).toHaveBeenCalledOnce();
+		expect(mockRunPagefind).toHaveBeenCalledOnce();
+		expect(mockRunServe).toHaveBeenCalledOnce();
+		expect(mockRunNpmDev).not.toHaveBeenCalled();
+	});
+
+	it("passes staticExport: true to initNextraProject", async () => {
+		setupSuccessfulRun();
+		const program = await makeProgram();
+		await program.parseAsync(["start", "/my-docs"], { from: "user" });
+
+		const [, , options] = mockInitNextraProject.mock.calls[0] as [string, unknown, { staticExport?: boolean }];
+		expect(options.staticExport).toBe(true);
+	});
+
+	it("sets exitCode = 1 when next build fails", async () => {
+		setupSuccessfulRun();
+		mockRunNpmBuild.mockResolvedValue({ success: false, output: "Build failed" });
+		const program = await makeProgram();
+		await program.parseAsync(["start", "/my-docs"], { from: "user" });
+
+		expect(process.exitCode).toBe(1);
+		expect(mockRunPagefind).not.toHaveBeenCalled();
+	});
+
+	it("sets exitCode = 1 when pagefind fails", async () => {
+		setupSuccessfulRun();
+		mockRunPagefind.mockResolvedValue({ success: false, output: "Pagefind error" });
+		const program = await makeProgram();
+		await program.parseAsync(["start", "/my-docs"], { from: "user" });
+
+		expect(process.exitCode).toBe(1);
+		expect(mockRunServe).not.toHaveBeenCalled();
+	});
+
+	it("prints pages indexed count", async () => {
+		setupSuccessfulRun();
+		mockRunPagefind.mockResolvedValue({ success: true, output: "", pagesIndexed: 42 });
+		const program = await makeProgram();
+		await program.parseAsync(["start", "/my-docs"], { from: "user" });
+
+		const output = consoleSpy.mock.calls.map((c: unknown[]) => c.join(" ")).join("\n");
+		expect(output).toContain("42");
+	});
+
+	it("prints concise progress messages", async () => {
+		setupSuccessfulRun();
+		const program = await makeProgram();
+		await program.parseAsync(["start", "/my-docs"], { from: "user" });
+
+		const output = consoleSpy.mock.calls.map((c: unknown[]) => c.join(" ")).join("\n");
+		expect(output).toContain("Loaded site config");
+		expect(output).toContain("Mirrored");
+		expect(output).toContain("Generated navigation");
+	});
+
+	it("does not set exitCode on a successful run", async () => {
+		setupSuccessfulRun();
+		const program = await makeProgram();
+		await program.parseAsync(["start", "/my-docs"], { from: "user" });
+
+		expect(process.exitCode).toBe(0);
+	});
+});
+
+// ─── jolli dev specific tests ────────────────────────────────────────────────
+
+describe("jolli dev", () => {
+	let consoleSpy: ReturnType<typeof vi.spyOn>;
+	let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+	let originalExitCode: number | undefined;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+		vi.spyOn(console, "warn").mockImplementation(() => {});
+		originalExitCode = process.exitCode as number | undefined;
+		process.exitCode = 0;
+	});
+
+	afterEach(() => {
+		process.exitCode = originalExitCode;
+		consoleSpy.mockRestore();
+		consoleErrorSpy.mockRestore();
+	});
+
+	it("runs next dev, not build/pagefind/serve", async () => {
+		setupSuccessfulRun();
+		const program = await makeProgram();
+		await program.parseAsync(["dev", "/my-docs"], { from: "user" });
+
+		expect(mockRunNpmDev).toHaveBeenCalledOnce();
+		expect(mockRunNpmBuild).not.toHaveBeenCalled();
+		expect(mockRunPagefind).not.toHaveBeenCalled();
+		expect(mockRunServe).not.toHaveBeenCalled();
+	});
+
+	it("passes staticExport: false to initNextraProject", async () => {
+		setupSuccessfulRun();
+		const program = await makeProgram();
+		await program.parseAsync(["dev", "/my-docs"], { from: "user" });
+
+		const [, , options] = mockInitNextraProject.mock.calls[0] as [string, unknown, { staticExport?: boolean }];
+		expect(options.staticExport).toBe(false);
+	});
+
+	it("sets exitCode = 1 when dev server fails", async () => {
+		setupSuccessfulRun();
+		mockRunNpmDev.mockResolvedValue({ success: false, output: "Dev error" });
+		const program = await makeProgram();
+		await program.parseAsync(["dev", "/my-docs"], { from: "user" });
+
+		expect(process.exitCode).toBe(1);
+	});
+
+	it("handles dev server failure without output", async () => {
+		setupSuccessfulRun();
+		mockRunNpmDev.mockResolvedValue({ success: false, output: "" });
+		const program = await makeProgram();
+		await program.parseAsync(["dev", "/my-docs"], { from: "user" });
+
+		expect(process.exitCode).toBe(1);
+	});
+
+	it("prints concise progress messages", async () => {
+		setupSuccessfulRun();
+		const program = await makeProgram();
+		await program.parseAsync(["dev", "/my-docs"], { from: "user" });
+
+		const output = consoleSpy.mock.calls.map((c: unknown[]) => c.join(" ")).join("\n");
+		expect(output).toContain("Loaded site config");
+		expect(output).toContain("Mirrored");
+	});
+
+	it("does not set exitCode on a successful run", async () => {
+		setupSuccessfulRun();
+		const program = await makeProgram();
+		await program.parseAsync(["dev", "/my-docs"], { from: "user" });
+
+		expect(process.exitCode).toBe(0);
+	});
+});
+
+// ─── Additional branch coverage tests ────────────────────────────────────────
+
+describe("StartCommand additional branches", () => {
+	let consoleSpy: ReturnType<typeof vi.spyOn>;
+	let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+	let originalExitCode: number | undefined;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+		vi.spyOn(console, "warn").mockImplementation(() => {});
+		originalExitCode = process.exitCode as number | undefined;
+		process.exitCode = 0;
+	});
+
+	afterEach(() => {
+		process.exitCode = originalExitCode;
+		consoleSpy.mockRestore();
+		consoleErrorSpy.mockRestore();
+	});
+
+	it("renders OpenAPI files when openapiFiles is non-empty", async () => {
+		setupSuccessfulRun({ openapiFiles: ["api/spec.yaml"] });
+		const program = await makeProgram();
+		await program.parseAsync(["build", "/my-docs"], { from: "user" });
+
+		expect(mockRenderOpenApiFiles).toHaveBeenCalledOnce();
+	});
+
+	it("does not render OpenAPI files when openapiFiles is empty", async () => {
+		setupSuccessfulRun({ openapiFiles: [] });
+		const program = await makeProgram();
+		await program.parseAsync(["build", "/my-docs"], { from: "user" });
+
+		expect(mockRenderOpenApiFiles).not.toHaveBeenCalled();
+	});
+
+	it("includes downgraded count in mirrored message", async () => {
+		setupSuccessfulRun();
+		mockMirrorContent.mockResolvedValue({
+			...DEFAULT_MIRROR_RESULT,
+			downgradedCount: 3,
+		});
+		const program = await makeProgram();
+		await program.parseAsync(["build", "/my-docs"], { from: "user" });
+
+		const output = consoleSpy.mock.calls.map((c: unknown[]) => c.join(" ")).join("\n");
+		expect(output).toContain("3 downgraded");
+	});
+
+	it("updates sidebar index key when renamedToIndex is set", async () => {
+		setupSuccessfulRun();
+		mockReadSiteJson.mockResolvedValue({
+			config: {
+				title: "Test",
+				description: "D",
+				nav: [],
+				sidebar: { "/": { intro: "Introduction" } },
+			},
+			usedDefault: false,
+		});
+		mockMirrorContent.mockResolvedValue({
+			...DEFAULT_MIRROR_RESULT,
+			renamedToIndex: "intro",
+		});
+		const program = await makeProgram();
+		await program.parseAsync(["build", "/my-docs"], { from: "user" });
+
+		// Should call generateMetaFiles with updated sidebar
+		const sidebarArg = mockGenerateMetaFiles.mock.calls[0][1] as Record<string, Record<string, string>>;
+		expect(sidebarArg?.["/"]?.index).toBe("Introduction");
+		expect(sidebarArg?.["/"]?.intro).toBeUndefined();
+	});
+
+	it("extracts page count from build output", async () => {
+		setupSuccessfulRun();
+		mockRunNpmBuild.mockResolvedValue({
+			success: true,
+			output: "Generating static pages (0/10)\nGenerating static pages (5/10)\nGenerating static pages (10/10)",
+		});
+		const program = await makeProgram();
+		await program.parseAsync(["build", "/my-docs"], { from: "user" });
+
+		const output = consoleSpy.mock.calls.map((c: unknown[]) => c.join(" ")).join("\n");
+		expect(output).toContain("Built 10 pages");
+	});
+
+	it("prints generic success when no page count in build output", async () => {
+		setupSuccessfulRun();
+		mockRunNpmBuild.mockResolvedValue({ success: true, output: "Build complete" });
+		const program = await makeProgram();
+		await program.parseAsync(["build", "/my-docs"], { from: "user" });
+
+		const output = consoleSpy.mock.calls.map((c: unknown[]) => c.join(" ")).join("\n");
+		expect(output).toContain("Built successfully");
+	});
+
+	it("sets exitCode = 1 when serve fails with output", async () => {
+		setupSuccessfulRun();
+		mockRunServe.mockResolvedValue({ success: false, output: "Serve error details" });
+		const program = await makeProgram();
+		await program.parseAsync(["start", "/my-docs"], { from: "user" });
+
+		expect(process.exitCode).toBe(1);
+		const errOutput = consoleErrorSpy.mock.calls.map((c: unknown[]) => c.join(" ")).join("\n");
+		expect(errOutput).toContain("Serve error details");
+	});
+
+	it("handles serve failure without output", async () => {
+		setupSuccessfulRun();
+		mockRunServe.mockResolvedValue({ success: false, output: "" });
+		const program = await makeProgram();
+		await program.parseAsync(["start", "/my-docs"], { from: "user" });
+
+		expect(process.exitCode).toBe(1);
+	});
+
+	it("shows verbose npm install error when --verbose is set", async () => {
+		setupSuccessfulRun({ needsInstall: true });
+		mockRunNpmInstall.mockResolvedValue({ success: false, output: "detailed npm error" });
+		const program = await makeProgram();
+		await program.parseAsync(["build", "--verbose", "/my-docs"], { from: "user" });
+
+		const errOutput = consoleErrorSpy.mock.calls.map((c: unknown[]) => c.join(" ")).join("\n");
+		expect(errOutput).toContain("detailed npm error");
+	});
+
+	it("shows verbose build error when --verbose is set", async () => {
+		setupSuccessfulRun();
+		mockRunNpmBuild.mockResolvedValue({ success: false, output: "detailed build error" });
+		const program = await makeProgram();
+		await program.parseAsync(["build", "--verbose", "/my-docs"], { from: "user" });
+
+		const errOutput = consoleErrorSpy.mock.calls.map((c: unknown[]) => c.join(" ")).join("\n");
+		expect(errOutput).toContain("detailed build error");
+	});
+
+	it("shows verbose pagefind error when --verbose is set", async () => {
+		setupSuccessfulRun();
+		mockRunPagefind.mockResolvedValue({ success: false, output: "detailed pagefind error" });
+		const program = await makeProgram();
+		await program.parseAsync(["build", "--verbose", "/my-docs"], { from: "user" });
+
+		const errOutput = consoleErrorSpy.mock.calls.map((c: unknown[]) => c.join(" ")).join("\n");
+		expect(errOutput).toContain("detailed pagefind error");
+	});
+
+	it("passes --migrate option to readSiteJson", async () => {
+		setupSuccessfulRun();
+		const program = await makeProgram();
+		await program.parseAsync(["build", "--migrate", "/my-docs"], { from: "user" });
+
+		const opts = mockReadSiteJson.mock.calls[0][1] as { migrate?: boolean };
+		expect(opts.migrate).toBe(true);
+	});
+
+	it("prints error and sets exitCode when renderer is unknown", async () => {
+		mockExistsSync.mockReturnValue(true);
+		mockReadSiteJson.mockResolvedValue({
+			config: { title: "T", description: "D", nav: [], renderer: "bad" },
+			usedDefault: false,
+		});
+		const program = await makeProgram();
+		await program.parseAsync(["build", "/my-docs"], { from: "user" });
+
+		expect(process.exitCode).toBe(1);
+		const errOutput = consoleErrorSpy.mock.calls.map((c: unknown[]) => c.join(" ")).join("\n");
+		expect(errOutput).toContain("Unknown renderer");
+	});
+
+	it("prints error for unknown renderer as string", async () => {
+		mockExistsSync.mockReturnValue(true);
+		mockReadSiteJson.mockResolvedValue({
+			config: { title: "T", description: "D", nav: [], renderer: "nope" },
+			usedDefault: false,
+		});
+		const program = await makeProgram();
+		await program.parseAsync(["dev", "/my-docs"], { from: "user" });
+
+		expect(process.exitCode).toBe(1);
+	});
+
+	it("does not call initProject when renderer is unknown", async () => {
+		mockExistsSync.mockReturnValue(true);
+		mockReadSiteJson.mockResolvedValue({
+			config: { title: "T", description: "D", nav: [], renderer: "invalid" },
+			usedDefault: false,
+		});
+		const program = await makeProgram();
+		await program.parseAsync(["build", "/my-docs"], { from: "user" });
+
+		expect(mockInitNextraProject).not.toHaveBeenCalled();
+	});
+
+	it("handles pagefind without pagesIndexed field", async () => {
+		setupSuccessfulRun();
+		mockRunPagefind.mockResolvedValue({ success: true, output: "Done" });
+		const program = await makeProgram();
+		await program.parseAsync(["build", "/my-docs"], { from: "user" });
+
+		const output = consoleSpy.mock.calls.map((c: unknown[]) => c.join(" ")).join("\n");
+		expect(output).toContain("Indexed 0 pages");
+	});
+});

--- a/cli/src/commands/StartCommand.ts
+++ b/cli/src/commands/StartCommand.ts
@@ -1,0 +1,258 @@
+/**
+ * StartCommand — Registers `jolli start`, `jolli build`, and `jolli dev`.
+ *
+ * Output is concise by default. Use `--verbose` for detailed logs.
+ */
+
+import { createHash } from "node:crypto";
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { join, resolve } from "node:path";
+import type { Command } from "commander";
+import { resolveFavicon } from "../site/AssetResolver.js";
+import { clearDir, mirrorContent } from "../site/ContentMirror.js";
+import { needsInstall, runNpmInstall, runServe } from "../site/NpmRunner.js";
+import { runPagefind } from "../site/PagefindRunner.js";
+import { resolveRenderer, type SiteRenderer } from "../site/renderer/index.js";
+import { readSiteJson } from "../site/SiteJsonReader.js";
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+export function getBuildDir(sourceRoot: string): string {
+	const absPath = resolve(sourceRoot);
+	const hash = createHash("sha256").update(absPath).digest("hex").slice(0, 12);
+	return join(homedir(), ".jolli", "sites", hash);
+}
+
+/** Logs only when verbose is true. */
+function verbose(msg: string, isVerbose: boolean): void {
+	if (isVerbose) console.log(msg);
+}
+
+interface CmdOpts {
+	migrate?: boolean;
+	verbose?: boolean;
+}
+
+// ─── prepareContent ──────────────────────────────────────────────────────────
+
+async function prepareContent(
+	sourceRoot: string,
+	buildDir: string,
+	contentDir: string,
+	publicDir: string,
+	staticExport: boolean,
+	opts: CmdOpts = {},
+): Promise<
+	| { success: false }
+	| { success: true; mirrorResult: Awaited<ReturnType<typeof mirrorContent>>; renderer: SiteRenderer }
+> {
+	const v = opts.verbose === true;
+
+	if (!existsSync(sourceRoot)) {
+		console.error(`  Error: Source root does not exist: ${sourceRoot}`);
+		process.exitCode = 1;
+		return { success: false };
+	}
+
+	// Read site.json
+	verbose("Reading site.json…", v);
+	let siteJsonResult: Awaited<ReturnType<typeof readSiteJson>>;
+	try {
+		siteJsonResult = await readSiteJson(sourceRoot, { migrate: opts.migrate });
+	} catch (err) {
+		console.error(`  Error: ${err instanceof Error ? err.message : String(err)}`);
+		process.exitCode = 1;
+		return { success: false };
+	}
+	console.log("  ✓ Loaded site config");
+
+	// Resolve renderer from config
+	let renderer: SiteRenderer;
+	try {
+		renderer = resolveRenderer(siteJsonResult.config);
+	} catch (err) {
+		console.error(`  Error: ${err instanceof Error ? err.message : String(err)}`);
+		process.exitCode = 1;
+		return { success: false };
+	}
+
+	// Initialize build directory
+	verbose(`Initializing build directory… (${buildDir})`, v);
+	await renderer.initProject(buildDir, siteJsonResult.config, { staticExport });
+
+	// Clear caches
+	await clearDir(publicDir);
+	for (const cacheDir of renderer.getCacheDirs(buildDir)) {
+		await clearDir(cacheDir);
+	}
+
+	// Resolve favicon
+	await resolveFavicon(siteJsonResult.config.favicon, sourceRoot, publicDir);
+
+	// Mirror content
+	verbose("Mirroring content…", v);
+	const mirrorResult = await mirrorContent(
+		sourceRoot,
+		contentDir,
+		siteJsonResult.config.pathMappings,
+		publicDir,
+		renderer.getContentRules(),
+	);
+
+	const total = mirrorResult.markdownFiles.length + mirrorResult.imageFiles.length + mirrorResult.openapiFiles.length;
+	const downgraded = mirrorResult.downgradedCount;
+	const downgradedSuffix = downgraded > 0 ? ` (${downgraded} downgraded)` : "";
+	console.log(`  ✓ Mirrored ${total} files${downgradedSuffix}`);
+
+	if (mirrorResult.markdownFiles.length === 0 && mirrorResult.openapiFiles.length === 0) {
+		console.warn("  ⚠ No markdown or OpenAPI files found. Producing an empty site.");
+	}
+
+	// Fix sidebar index key if file was renamed
+	const sidebar = siteJsonResult.config.sidebar;
+	if (mirrorResult.renamedToIndex && sidebar?.["/"]?.[mirrorResult.renamedToIndex]) {
+		const label = sidebar["/"][mirrorResult.renamedToIndex];
+		delete sidebar["/"][mirrorResult.renamedToIndex];
+		sidebar["/"] = { index: label, ...sidebar["/"] };
+	}
+
+	// Generate navigation
+	verbose("Generating navigation…", v);
+	await renderer.generateNavigation(contentDir, sidebar);
+	console.log("  ✓ Generated navigation");
+
+	// Render OpenAPI specs
+	if (mirrorResult.openapiFiles.length > 0) {
+		verbose("Rendering OpenAPI specs…", v);
+		await renderer.renderOpenApiFiles(sourceRoot, contentDir, mirrorResult.openapiFiles, publicDir);
+	}
+
+	// Install dependencies
+	if (needsInstall(buildDir)) {
+		console.log("  Installing dependencies…");
+		const installResult = await runNpmInstall(buildDir);
+		if (!installResult.success) {
+			console.error(v ? installResult.output : "  Error: npm install failed");
+			process.exitCode = 1;
+			return { success: false };
+		}
+		console.log("  ✓ Dependencies ready");
+	}
+
+	return { success: true, mirrorResult, renderer };
+}
+
+// ─── buildAndIndex ───────────────────────────────────────────────────────────
+
+async function buildAndIndex(
+	buildDir: string,
+	v: boolean,
+	renderer: SiteRenderer,
+): Promise<{ success: boolean; pagesBuilt?: number }> {
+	console.log("  Building site…");
+	const buildResult = await renderer.runBuild(buildDir);
+	if (!buildResult.success) {
+		console.error(v ? buildResult.output : "  Error: Build failed");
+		process.exitCode = 1;
+		return { success: false };
+	}
+
+	// Extract page count from build output
+	const pagesBuilt = renderer.extractPageCount(buildResult.output);
+	if (pagesBuilt) {
+		console.log(`  ✓ Built ${pagesBuilt} pages`);
+	} else {
+		console.log("  ✓ Built successfully");
+	}
+
+	const pagefindResult = await runPagefind(buildDir);
+	if (!pagefindResult.success) {
+		console.error(v ? pagefindResult.output : "  Error: Search indexing failed");
+		process.exitCode = 1;
+		return { success: false };
+	}
+
+	const pagesIndexed = pagefindResult.pagesIndexed ?? 0;
+	console.log(`  ✓ Indexed ${pagesIndexed} pages for search`);
+
+	return { success: true, pagesBuilt };
+}
+
+// ─── Commands ────────────────────────────────────────────────────────────────
+
+export function registerBuildCommand(program: Command): void {
+	program
+		.command("build")
+		.description("Build a static site with search indexing")
+		.argument("[source-root]", "Path to the Content_Folder (default: current directory)")
+		.option("--migrate", "Re-detect framework config and regenerate site.json")
+		.option("--verbose", "Show detailed build output")
+		.action(async (sourceRootArg: string | undefined, opts: CmdOpts) => {
+			const sourceRoot = resolve(sourceRootArg ?? process.cwd());
+			const buildDir = getBuildDir(sourceRoot);
+			const contentDir = join(buildDir, "content");
+			const publicDir = join(buildDir, "public");
+
+			const result = await prepareContent(sourceRoot, buildDir, contentDir, publicDir, true, opts);
+			if (!result.success) return;
+
+			const buildResult = await buildAndIndex(buildDir, opts.verbose === true, result.renderer);
+			if (!buildResult.success) return;
+
+			console.log("\n  Run `jolli start` to preview the site.\n");
+		});
+}
+
+export function registerStartCommand(program: Command): void {
+	program
+		.command("start")
+		.description("Build a static site with search indexing, then serve it")
+		.argument("[source-root]", "Path to the Content_Folder (default: current directory)")
+		.option("--migrate", "Re-detect framework config and regenerate site.json")
+		.option("--verbose", "Show detailed build output")
+		.action(async (sourceRootArg: string | undefined, opts: CmdOpts) => {
+			const sourceRoot = resolve(sourceRootArg ?? process.cwd());
+			const buildDir = getBuildDir(sourceRoot);
+			const contentDir = join(buildDir, "content");
+			const publicDir = join(buildDir, "public");
+
+			const result = await prepareContent(sourceRoot, buildDir, contentDir, publicDir, true, opts);
+			if (!result.success) return;
+
+			const buildResult = await buildAndIndex(buildDir, opts.verbose === true, result.renderer);
+			if (!buildResult.success) return;
+
+			console.log("");
+			const serveResult = await runServe(buildDir, opts.verbose === true);
+			if (!serveResult.success) {
+				if (serveResult.output) console.error(serveResult.output);
+				process.exitCode = 1;
+			}
+		});
+}
+
+export function registerDevCommand(program: Command): void {
+	program
+		.command("dev")
+		.description("Start a dev server with hot reload")
+		.argument("[source-root]", "Path to the Content_Folder (default: current directory)")
+		.option("--migrate", "Re-detect framework config and regenerate site.json")
+		.option("--verbose", "Show detailed build output")
+		.action(async (sourceRootArg: string | undefined, opts: CmdOpts) => {
+			const sourceRoot = resolve(sourceRootArg ?? process.cwd());
+			const buildDir = getBuildDir(sourceRoot);
+			const contentDir = join(buildDir, "content");
+			const publicDir = join(buildDir, "public");
+
+			const result = await prepareContent(sourceRoot, buildDir, contentDir, publicDir, false, opts);
+			if (!result.success) return;
+
+			console.log("");
+			const devResult = await result.renderer.runDev(buildDir, opts.verbose === true);
+			if (!devResult.success) {
+				if (devResult.output) console.error(devResult.output);
+				process.exitCode = 1;
+			}
+		});
+}

--- a/cli/src/site/AssetResolver.test.ts
+++ b/cli/src/site/AssetResolver.test.ts
@@ -1,0 +1,273 @@
+/**
+ * Tests for AssetResolver — resolves external images and favicon for the build.
+ */
+
+import { existsSync } from "node:fs";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+async function makeTempDir(): Promise<string> {
+	return mkdtemp(join(tmpdir(), "jolli-assetresolver-test-"));
+}
+
+describe("AssetResolver", () => {
+	let tempDir: string;
+
+	beforeEach(async () => {
+		tempDir = await makeTempDir();
+	});
+
+	afterEach(async () => {
+		await rm(tempDir, { recursive: true, force: true });
+	});
+
+	// ── generatePlaceholderSvg ───────────────────────────────────────────────
+
+	describe("generatePlaceholderSvg", () => {
+		it("generates valid SVG content", async () => {
+			const { generatePlaceholderSvg } = await import("./AssetResolver.js");
+
+			const svg = generatePlaceholderSvg("logo.png");
+
+			expect(svg).toContain("<svg");
+			expect(svg).toContain("</svg>");
+			expect(svg).toContain("logo.png");
+		});
+
+		it("includes the filename in the SVG", async () => {
+			const { generatePlaceholderSvg } = await import("./AssetResolver.js");
+
+			const svg = generatePlaceholderSvg("my-image.jpg");
+
+			expect(svg).toContain("my-image.jpg");
+		});
+
+		it("shows 'Missing image' text", async () => {
+			const { generatePlaceholderSvg } = await import("./AssetResolver.js");
+
+			const svg = generatePlaceholderSvg("test.png");
+
+			expect(svg).toContain("Missing image");
+		});
+
+		it("escapes XML special characters in filename", async () => {
+			const { generatePlaceholderSvg } = await import("./AssetResolver.js");
+
+			const svg = generatePlaceholderSvg("file<with>&special");
+
+			expect(svg).toContain("&lt;");
+			expect(svg).toContain("&gt;");
+			expect(svg).toContain("&amp;");
+			expect(svg).not.toContain("<with>");
+		});
+
+		it("generates SVG with correct dimensions", async () => {
+			const { generatePlaceholderSvg } = await import("./AssetResolver.js");
+
+			const svg = generatePlaceholderSvg("test.png");
+
+			expect(svg).toContain('width="400"');
+			expect(svg).toContain('height="300"');
+		});
+	});
+
+	// ── resolveExternalImage ────────────────────────────────────────────────
+
+	describe("resolveExternalImage", () => {
+		it("finds image in project static directory", async () => {
+			const { resolveExternalImage } = await import("./AssetResolver.js");
+			// Create project structure: project/static/img/logo.svg
+			const projectDir = join(tempDir, "project");
+			const docsDir = join(projectDir, "docs");
+			const staticDir = join(projectDir, "static", "img");
+			await mkdir(docsDir, { recursive: true });
+			await mkdir(staticDir, { recursive: true });
+			// Add marker so findProjectRoot finds this
+			await writeFile(join(projectDir, "package.json"), "{}", "utf-8");
+			await writeFile(join(staticDir, "logo.svg"), "<svg/>", "utf-8");
+
+			const result = resolveExternalImage("../static/img/logo.svg", docsDir, docsDir);
+
+			expect(result.isPlaceholder).toBe(false);
+			expect(result.sourcePath).toBeDefined();
+			expect(result.publicPath).toContain("images/");
+		});
+
+		it("returns placeholder when image not found", async () => {
+			const { resolveExternalImage } = await import("./AssetResolver.js");
+			const docsDir = join(tempDir, "docs");
+			await mkdir(docsDir, { recursive: true });
+
+			const result = resolveExternalImage("nonexistent.png", docsDir, docsDir);
+
+			expect(result.isPlaceholder).toBe(true);
+			expect(result.sourcePath).toBeUndefined();
+			expect(result.publicPath).toContain("placeholder-");
+		});
+
+		it("generates unique public path for found images", async () => {
+			const { resolveExternalImage } = await import("./AssetResolver.js");
+			const projectDir = join(tempDir, "project");
+			const docsDir = join(projectDir, "docs");
+			await mkdir(docsDir, { recursive: true });
+			await writeFile(join(projectDir, "package.json"), "{}", "utf-8");
+			const imgDir = join(projectDir, "static", "img");
+			await mkdir(imgDir, { recursive: true });
+			await writeFile(join(imgDir, "logo.svg"), "<svg/>", "utf-8");
+
+			const result = resolveExternalImage("../static/img/logo.svg", docsDir, docsDir);
+
+			expect(result.publicPath).toMatch(/^images\//);
+			expect(result.publicPath).toContain("logo.svg");
+		});
+	});
+
+	// ── copyExternalAsset ───────────────────────────────────────────────────
+
+	describe("copyExternalAsset", () => {
+		it("copies a real file to the public directory", async () => {
+			const { copyExternalAsset } = await import("./AssetResolver.js");
+			const sourceFile = join(tempDir, "source.svg");
+			await writeFile(sourceFile, "<svg>test</svg>", "utf-8");
+			const publicDir = join(tempDir, "public");
+			await mkdir(publicDir, { recursive: true });
+
+			await copyExternalAsset(
+				{ sourcePath: sourceFile, publicPath: "images/source.svg", isPlaceholder: false },
+				publicDir,
+			);
+
+			const destPath = join(publicDir, "images", "source.svg");
+			expect(existsSync(destPath)).toBe(true);
+			const content = await readFile(destPath, "utf-8");
+			expect(content).toBe("<svg>test</svg>");
+		});
+
+		it("generates placeholder SVG when source is missing", async () => {
+			const { copyExternalAsset } = await import("./AssetResolver.js");
+			const publicDir = join(tempDir, "public");
+			await mkdir(publicDir, { recursive: true });
+
+			await copyExternalAsset({ publicPath: "images/placeholder-logo.svg", isPlaceholder: true }, publicDir);
+
+			const destPath = join(publicDir, "images", "placeholder-logo.svg");
+			expect(existsSync(destPath)).toBe(true);
+			const content = await readFile(destPath, "utf-8");
+			expect(content).toContain("<svg");
+			expect(content).toContain("Missing image");
+		});
+
+		it("creates intermediate directories", async () => {
+			const { copyExternalAsset } = await import("./AssetResolver.js");
+			const sourceFile = join(tempDir, "img.png");
+			await writeFile(sourceFile, "fake-png", "utf-8");
+			const publicDir = join(tempDir, "public");
+			// Don't create publicDir or images/ — should be created automatically
+
+			await copyExternalAsset(
+				{ sourcePath: sourceFile, publicPath: "images/deep/nested/img.png", isPlaceholder: false },
+				publicDir,
+			);
+
+			expect(existsSync(join(publicDir, "images", "deep", "nested", "img.png"))).toBe(true);
+		});
+	});
+
+	// ── resolveFavicon ──────────────────────────────────────────────────────
+
+	describe("resolveFavicon", () => {
+		it("copies existing favicon to public/favicon.ico", async () => {
+			const { resolveFavicon } = await import("./AssetResolver.js");
+			const sourceRoot = join(tempDir, "docs");
+			await mkdir(sourceRoot, { recursive: true });
+			await writeFile(join(sourceRoot, "my-favicon.ico"), "favicon-data", "utf-8");
+			const publicDir = join(tempDir, "public");
+			await mkdir(publicDir, { recursive: true });
+
+			await resolveFavicon("my-favicon.ico", sourceRoot, publicDir);
+
+			expect(existsSync(join(publicDir, "favicon.ico"))).toBe(true);
+			const content = await readFile(join(publicDir, "favicon.ico"), "utf-8");
+			expect(content).toBe("favicon-data");
+		});
+
+		it("generates default favicon when path is undefined", async () => {
+			const { resolveFavicon } = await import("./AssetResolver.js");
+			const publicDir = join(tempDir, "public");
+
+			await resolveFavicon(undefined, tempDir, publicDir);
+
+			expect(existsSync(join(publicDir, "favicon.ico"))).toBe(true);
+			const content = await readFile(join(publicDir, "favicon.ico"), "utf-8");
+			expect(content).toContain("<svg");
+			expect(content).toContain("J"); // Jolli "J" favicon
+		});
+
+		it("generates default favicon when path points to nonexistent file", async () => {
+			const { resolveFavicon } = await import("./AssetResolver.js");
+			const publicDir = join(tempDir, "public");
+
+			await resolveFavicon("nonexistent.ico", tempDir, publicDir);
+
+			expect(existsSync(join(publicDir, "favicon.ico"))).toBe(true);
+			const content = await readFile(join(publicDir, "favicon.ico"), "utf-8");
+			expect(content).toContain("<svg"); // Falls back to default
+		});
+	});
+
+	// ── resolveExternalImage — additional branch coverage ────────────────────
+
+	describe("resolveExternalImage branches", () => {
+		it("tries direct resolve from originalMdDir", async () => {
+			const { resolveExternalImage } = await import("./AssetResolver.js");
+			const projectDir = join(tempDir, "project");
+			const docsDir = join(projectDir, "docs");
+			const imgDir = join(docsDir, "images");
+			await mkdir(imgDir, { recursive: true });
+			await writeFile(join(projectDir, "package.json"), "{}", "utf-8");
+			await writeFile(join(imgDir, "diagram.png"), "fake", "utf-8");
+
+			const result = resolveExternalImage("images/diagram.png", docsDir, docsDir);
+
+			expect(result.isPlaceholder).toBe(false);
+		});
+
+		it("falls back to parent of sourceRoot", async () => {
+			const { resolveExternalImage } = await import("./AssetResolver.js");
+			const docsDir = join(tempDir, "docs");
+			await mkdir(docsDir, { recursive: true });
+			const imgFile = join(tempDir, "static", "logo.png");
+			await mkdir(join(tempDir, "static"), { recursive: true });
+			await writeFile(imgFile, "fake", "utf-8");
+
+			const result = resolveExternalImage("static/logo.png", docsDir, docsDir);
+
+			expect(result.isPlaceholder).toBe(false);
+		});
+
+		it("generates placeholder with correct naming for extensionless file", async () => {
+			const { resolveExternalImage } = await import("./AssetResolver.js");
+
+			const result = resolveExternalImage("missing-file", tempDir, tempDir);
+
+			expect(result.isPlaceholder).toBe(true);
+			expect(result.publicPath).toContain("placeholder-");
+		});
+	});
+
+	// ── copyExternalAsset — placeholder content ─────────────────────────────
+
+	describe("copyExternalAsset placeholder content", () => {
+		it("strips placeholder- prefix and .svg extension from filename in SVG", async () => {
+			const { copyExternalAsset } = await import("./AssetResolver.js");
+			const publicDir = join(tempDir, "public");
+
+			await copyExternalAsset({ publicPath: "images/placeholder-my-image.svg", isPlaceholder: true }, publicDir);
+
+			const content = await readFile(join(publicDir, "images", "placeholder-my-image.svg"), "utf-8");
+			expect(content).toContain("my-image");
+		});
+	});
+});

--- a/cli/src/site/AssetResolver.ts
+++ b/cli/src/site/AssetResolver.ts
@@ -1,0 +1,198 @@
+/**
+ * AssetResolver — resolves external images and favicon for the build.
+ *
+ * Handles three scenarios:
+ *   1. Image found inside sourceRoot → handled by ContentMirror (not here)
+ *   2. Image found outside sourceRoot → copied to public/images/<unique-name>
+ *   3. Image not found → SVG placeholder generated in public/images/
+ *
+ * Also handles favicon: copies from config path or generates a default.
+ */
+
+import { existsSync } from "node:fs";
+import { copyFile, mkdir, writeFile } from "node:fs/promises";
+import { basename, dirname, join, resolve } from "node:path";
+
+// ─── ResolvedAsset ───────────────────────────────────────────────────────────
+
+export interface ResolvedAsset {
+	/** Absolute path where the file was found, or undefined if missing */
+	sourcePath?: string;
+	/** Path relative to public/ (e.g. "images/static-img-logo.svg") */
+	publicPath: string;
+	/** Whether a placeholder was generated */
+	isPlaceholder: boolean;
+}
+
+// ─── resolveExternalImage ────────────────────────────────────────────────────
+
+/**
+ * Resolves an image reference that points outside the sourceRoot.
+ *
+ * Searches upward from sourceRoot to find the file. If found, returns
+ * a unique public path. If not found, returns a placeholder path.
+ *
+ * @param relImagePath - The resolved relative path from the markdown file's
+ *                       original directory (e.g. "../../static/img/logo.svg")
+ * @param originalMdDir - The original directory of the markdown file
+ *                        (absolute path, e.g. "/project/docs/connectors")
+ * @param sourceRoot    - The docs root (absolute path, e.g. "/project/docs")
+ */
+export function resolveExternalImage(relImagePath: string, originalMdDir: string, sourceRoot: string): ResolvedAsset {
+	const projectRoot = findProjectRoot(sourceRoot);
+
+	// Try multiple search paths
+	const candidates = [
+		resolve(originalMdDir, relImagePath),
+		join(projectRoot, "static", relImagePath), // Docusaurus static/ dir
+		join(projectRoot, relImagePath),
+		join(dirname(sourceRoot), "static", relImagePath),
+		join(dirname(sourceRoot), relImagePath),
+	];
+
+	for (const candidate of candidates) {
+		if (existsSync(candidate)) {
+			const uniqueName = generateUniqueName(candidate, projectRoot);
+			return { sourcePath: candidate, publicPath: `images/${uniqueName}`, isPlaceholder: false };
+		}
+	}
+
+	// Not found — generate placeholder
+	const filename = basename(relImagePath);
+	return { publicPath: `images/${toPlaceholderName(filename)}`, isPlaceholder: true };
+}
+
+// ─── copyExternalAsset ───────────────────────────────────────────────────────
+
+/**
+ * Copies an external asset to public/images/ or generates a placeholder.
+ */
+export async function copyExternalAsset(asset: ResolvedAsset, publicDir: string): Promise<void> {
+	const destPath = join(publicDir, asset.publicPath);
+	await mkdir(dirname(destPath), { recursive: true });
+
+	if (asset.sourcePath) {
+		await copyFile(asset.sourcePath, destPath);
+	} else {
+		const filename = basename(asset.publicPath);
+		const svg = generatePlaceholderSvg(filename.replace(/\.svg$/, "").replace(/^placeholder-/, ""));
+		await writeFile(destPath, svg, "utf-8");
+	}
+}
+
+// ─── resolveFavicon ──────────────────────────────────────────────────────────
+
+/**
+ * Copies favicon to `public/favicon.ico`.
+ *
+ * @param faviconPath - Relative path from sourceRoot (e.g. "../static/img/favicon.ico")
+ * @param sourceRoot  - The docs root
+ * @param publicDir   - The build public/ directory
+ */
+export async function resolveFavicon(
+	faviconPath: string | undefined,
+	sourceRoot: string,
+	publicDir: string,
+): Promise<void> {
+	const destPath = join(publicDir, "favicon.ico");
+
+	if (faviconPath) {
+		const absolutePath = resolve(sourceRoot, faviconPath);
+		if (existsSync(absolutePath)) {
+			await mkdir(dirname(destPath), { recursive: true });
+			await copyFile(absolutePath, destPath);
+			return;
+		}
+	}
+
+	// Generate default favicon SVG
+	await mkdir(dirname(destPath), { recursive: true });
+	const defaultFavicon = generateDefaultFavicon();
+	await writeFile(destPath, defaultFavicon, "utf-8");
+}
+
+// ─── generatePlaceholderSvg ──────────────────────────────────────────────────
+
+/**
+ * Generates an SVG placeholder image for a missing file.
+ * Shows the original filename so users know what to replace.
+ */
+export function generatePlaceholderSvg(filename: string): string {
+	// Escape special XML characters
+	const escaped = filename.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+
+	return `<svg xmlns="http://www.w3.org/2000/svg" width="400" height="300" viewBox="0 0 400 300">
+  <rect width="100%" height="100%" fill="#f5f5f5" stroke="#ddd" stroke-width="2"/>
+  <text x="50%" y="40%" text-anchor="middle" fill="#999" font-family="sans-serif" font-size="18">
+    Missing image
+  </text>
+  <text x="50%" y="55%" text-anchor="middle" fill="#666" font-family="monospace" font-size="12">
+    ${escaped}
+  </text>
+</svg>
+`;
+}
+
+// ─── generateDefaultFavicon ──────────────────────────────────────────────────
+
+/**
+ * Generates a simple default favicon as SVG (a "J" for Jolli).
+ */
+function generateDefaultFavicon(): string {
+	return `<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="6" fill="#0070f3"/>
+  <text x="50%" y="75%" text-anchor="middle" fill="white" font-family="sans-serif" font-size="22" font-weight="bold">
+    J
+  </text>
+</svg>
+`;
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/**
+ * Finds the project root by looking for common markers.
+ * Falls back to sourceRoot's parent.
+ */
+function findProjectRoot(sourceRoot: string): string {
+	let dir = resolve(sourceRoot);
+	const markers = ["package.json", ".git", "docusaurus.config.ts", "docusaurus.config.js"];
+
+	// Search up to 5 levels
+	for (let i = 0; i < 5; i++) {
+		if (markers.some((m) => existsSync(join(dir, m)))) {
+			return dir;
+		}
+		const parent = dirname(dir);
+		if (parent === dir) break;
+		dir = parent;
+	}
+
+	return dirname(sourceRoot);
+}
+
+/**
+ * Generates a unique filename for an external asset based on its path
+ * relative to the project root. Replaces path separators with dashes.
+ *
+ * "static/img/logo.svg" → "static-img-logo.svg"
+ */
+function generateUniqueName(absolutePath: string, projectRoot: string): string {
+	const rel = absolutePath.startsWith(projectRoot)
+		? absolutePath.slice(projectRoot.length + 1)
+		: basename(absolutePath);
+
+	const ext = rel.includes(".") ? `.${rel.split(".").pop()}` : "";
+	const stem = ext ? rel.slice(0, -ext.length) : rel;
+
+	return `${stem.replace(/[/\\]/g, "-")}${ext}`;
+}
+
+/**
+ * Generates a placeholder filename for a missing image.
+ */
+function toPlaceholderName(filename: string): string {
+	const ext = filename.includes(".") ? `.${filename.split(".").pop()}` : ".svg";
+	const stem = ext !== ".svg" ? filename.slice(0, -ext.length) : filename.replace(/\.\w+$/, "");
+	return `placeholder-${stem}.svg`;
+}

--- a/cli/src/site/ContentMirror.test.ts
+++ b/cli/src/site/ContentMirror.test.ts
@@ -1,0 +1,1218 @@
+/**
+ * Tests for ContentMirror — classifies and mirrors Content_Folder files.
+ *
+ * Covers all acceptance criteria from Task 4:
+ *   - classifyFile returns correct FileType for all supported extensions
+ *   - classifyFile detects OpenAPI content in JSON/YAML files
+ *   - classifyFile returns "ignored" for unsupported types
+ *   - mirrorContent copies markdown and image files to contentDir
+ *   - mirrorContent skips .jolli-site/ directory
+ *   - mirrorContent preserves directory structure
+ *
+ * Property-based tests (fast-check):
+ *   - Property 1: File type classification is consistent
+ *     **Validates: Requirements 3.1, 3.2, 3.3**
+ *   - Property 2: Content mirroring preserves directory structure
+ *     **Validates: Requirements 5.1, 5.2**
+ */
+
+import { existsSync } from "node:fs";
+import { mkdir, mkdtemp, readdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import * as fc from "fast-check";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+async function makeTempDir(): Promise<string> {
+	return mkdtemp(join(tmpdir(), "jolli-contentmirror-test-"));
+}
+
+/** Minimal valid OpenAPI JSON content */
+const OPENAPI_JSON = JSON.stringify({ openapi: "3.1.0", info: { title: "Test", version: "1.0" } });
+
+/** Minimal valid OpenAPI YAML content */
+const OPENAPI_YAML = `openapi: "3.1.0"\ninfo:\n  title: Test\n  version: "1.0"\n`;
+
+// ─── classifyFile unit tests ──────────────────────────────────────────────────
+
+describe("ContentMirror.classifyFile", () => {
+	// ── Markdown (4.2) ──────────────────────────────────────────────────────
+
+	it('classifies .md files as "markdown"', async () => {
+		const { classifyFile } = await import("./ContentMirror.js");
+		expect(classifyFile("docs/readme.md")).toBe("markdown");
+	});
+
+	it('classifies .mdx files as "markdown"', async () => {
+		const { classifyFile } = await import("./ContentMirror.js");
+		expect(classifyFile("pages/index.mdx")).toBe("markdown");
+	});
+
+	it('classifies .MD files (uppercase) as "markdown"', async () => {
+		const { classifyFile } = await import("./ContentMirror.js");
+		expect(classifyFile("README.MD")).toBe("markdown");
+	});
+
+	// ── Images (4.3) ────────────────────────────────────────────────────────
+
+	it('classifies .png files as "image"', async () => {
+		const { classifyFile } = await import("./ContentMirror.js");
+		expect(classifyFile("assets/logo.png")).toBe("image");
+	});
+
+	it('classifies .jpg files as "image"', async () => {
+		const { classifyFile } = await import("./ContentMirror.js");
+		expect(classifyFile("assets/photo.jpg")).toBe("image");
+	});
+
+	it('classifies .jpeg files as "image"', async () => {
+		const { classifyFile } = await import("./ContentMirror.js");
+		expect(classifyFile("assets/photo.jpeg")).toBe("image");
+	});
+
+	it('classifies .gif files as "image"', async () => {
+		const { classifyFile } = await import("./ContentMirror.js");
+		expect(classifyFile("assets/anim.gif")).toBe("image");
+	});
+
+	it('classifies .svg files as "image"', async () => {
+		const { classifyFile } = await import("./ContentMirror.js");
+		expect(classifyFile("assets/icon.svg")).toBe("image");
+	});
+
+	it('classifies .webp files as "image"', async () => {
+		const { classifyFile } = await import("./ContentMirror.js");
+		expect(classifyFile("assets/banner.webp")).toBe("image");
+	});
+
+	it('classifies .ico files as "image"', async () => {
+		const { classifyFile } = await import("./ContentMirror.js");
+		expect(classifyFile("favicon.ico")).toBe("image");
+	});
+
+	it('classifies .PNG files (uppercase) as "image"', async () => {
+		const { classifyFile } = await import("./ContentMirror.js");
+		expect(classifyFile("LOGO.PNG")).toBe("image");
+	});
+
+	// ── OpenAPI JSON (4.4) ──────────────────────────────────────────────────
+
+	it('classifies .json with openapi + info as "openapi"', async () => {
+		const { classifyFile } = await import("./ContentMirror.js");
+		expect(classifyFile("api/spec.json", OPENAPI_JSON)).toBe("openapi");
+	});
+
+	it('classifies .json without openapi field as "ignored"', async () => {
+		const { classifyFile } = await import("./ContentMirror.js");
+		const content = JSON.stringify({ info: { title: "Test" } });
+		expect(classifyFile("api/spec.json", content)).toBe("ignored");
+	});
+
+	it('classifies .json without info field as "ignored"', async () => {
+		const { classifyFile } = await import("./ContentMirror.js");
+		const content = JSON.stringify({ openapi: "3.1.0" });
+		expect(classifyFile("api/spec.json", content)).toBe("ignored");
+	});
+
+	it('classifies .json with no content provided as "ignored"', async () => {
+		const { classifyFile } = await import("./ContentMirror.js");
+		expect(classifyFile("api/spec.json")).toBe("ignored");
+	});
+
+	it('classifies .json with invalid JSON content as "ignored"', async () => {
+		const { classifyFile } = await import("./ContentMirror.js");
+		expect(classifyFile("api/spec.json", "{ not valid json }")).toBe("ignored");
+	});
+
+	// ── OpenAPI YAML (4.4) ──────────────────────────────────────────────────
+
+	it('classifies .yaml with openapi + info as "openapi"', async () => {
+		const { classifyFile } = await import("./ContentMirror.js");
+		expect(classifyFile("api/spec.yaml", OPENAPI_YAML)).toBe("openapi");
+	});
+
+	it('classifies .yml with openapi + info as "openapi"', async () => {
+		const { classifyFile } = await import("./ContentMirror.js");
+		expect(classifyFile("api/spec.yml", OPENAPI_YAML)).toBe("openapi");
+	});
+
+	it('classifies .yaml without openapi line as "ignored"', async () => {
+		const { classifyFile } = await import("./ContentMirror.js");
+		const content = "info:\n  title: Test\n";
+		expect(classifyFile("api/spec.yaml", content)).toBe("ignored");
+	});
+
+	it('classifies .yaml without info line as "ignored"', async () => {
+		const { classifyFile } = await import("./ContentMirror.js");
+		const content = "openapi: 3.1.0\ntitle: Test\n";
+		expect(classifyFile("api/spec.yaml", content)).toBe("ignored");
+	});
+
+	it('classifies .yaml with no content provided as "ignored"', async () => {
+		const { classifyFile } = await import("./ContentMirror.js");
+		expect(classifyFile("api/spec.yaml")).toBe("ignored");
+	});
+
+	// ── Ignored types (4.5) ─────────────────────────────────────────────────
+
+	it('classifies .ts files as "ignored"', async () => {
+		const { classifyFile } = await import("./ContentMirror.js");
+		expect(classifyFile("src/index.ts")).toBe("ignored");
+	});
+
+	it('classifies .txt files as "ignored"', async () => {
+		const { classifyFile } = await import("./ContentMirror.js");
+		expect(classifyFile("notes.txt")).toBe("ignored");
+	});
+
+	it('classifies .pdf files as "ignored"', async () => {
+		const { classifyFile } = await import("./ContentMirror.js");
+		expect(classifyFile("doc.pdf")).toBe("ignored");
+	});
+
+	it('classifies files with no extension as "ignored"', async () => {
+		const { classifyFile } = await import("./ContentMirror.js");
+		expect(classifyFile("Makefile")).toBe("ignored");
+	});
+});
+
+// ─── mirrorContent unit tests ─────────────────────────────────────────────────
+
+describe("ContentMirror.mirrorContent", () => {
+	let sourceRoot: string;
+	let contentDir: string;
+
+	beforeEach(async () => {
+		sourceRoot = await makeTempDir();
+		contentDir = await makeTempDir();
+	});
+
+	afterEach(async () => {
+		await rm(sourceRoot, { recursive: true, force: true });
+		await rm(contentDir, { recursive: true, force: true });
+	});
+
+	// ── Markdown files are copied (4.6) ─────────────────────────────────────
+
+	it("copies a markdown file to contentDir", async () => {
+		const { mirrorContent } = await import("./ContentMirror.js");
+		await writeFile(join(sourceRoot, "index.md"), "# Hello", "utf-8");
+
+		await mirrorContent(sourceRoot, contentDir);
+
+		expect(existsSync(join(contentDir, "index.md"))).toBe(true);
+	});
+
+	it("includes the markdown file in markdownFiles result", async () => {
+		const { mirrorContent } = await import("./ContentMirror.js");
+		await writeFile(join(sourceRoot, "index.md"), "# Hello", "utf-8");
+
+		const result = await mirrorContent(sourceRoot, contentDir);
+
+		expect(result.markdownFiles).toContain("index.md");
+	});
+
+	it("copies a nested markdown file preserving directory structure", async () => {
+		const { mirrorContent } = await import("./ContentMirror.js");
+		await mkdir(join(sourceRoot, "guides"), { recursive: true });
+		await writeFile(join(sourceRoot, "guides", "intro.md"), "# Intro", "utf-8");
+
+		await mirrorContent(sourceRoot, contentDir);
+
+		expect(existsSync(join(contentDir, "guides", "intro.md"))).toBe(true);
+	});
+
+	it("includes nested markdown file in markdownFiles with relative path", async () => {
+		const { mirrorContent } = await import("./ContentMirror.js");
+		await mkdir(join(sourceRoot, "guides"), { recursive: true });
+		await writeFile(join(sourceRoot, "guides", "intro.md"), "# Intro", "utf-8");
+
+		const result = await mirrorContent(sourceRoot, contentDir);
+
+		expect(result.markdownFiles).toContain(join("guides", "intro.md"));
+	});
+
+	// ── Image files are copied (Requirement 3.4) ────────────────────────────
+
+	it("copies an image file to contentDir", async () => {
+		const { mirrorContent } = await import("./ContentMirror.js");
+		await writeFile(join(sourceRoot, "logo.png"), Buffer.from([0x89, 0x50, 0x4e, 0x47]));
+
+		await mirrorContent(sourceRoot, contentDir);
+
+		expect(existsSync(join(contentDir, "logo.png"))).toBe(true);
+	});
+
+	it("includes the image file in imageFiles result", async () => {
+		const { mirrorContent } = await import("./ContentMirror.js");
+		await writeFile(join(sourceRoot, "logo.png"), Buffer.from([0x89, 0x50, 0x4e, 0x47]));
+
+		const result = await mirrorContent(sourceRoot, contentDir);
+
+		expect(result.imageFiles).toContain("logo.png");
+	});
+
+	// ── OpenAPI files are recorded but not copied ────────────────────────────
+
+	it("records OpenAPI files in openapiFiles but does not copy them", async () => {
+		const { mirrorContent } = await import("./ContentMirror.js");
+		await writeFile(join(sourceRoot, "api.yaml"), OPENAPI_YAML, "utf-8");
+
+		const result = await mirrorContent(sourceRoot, contentDir);
+
+		expect(result.openapiFiles).toContain("api.yaml");
+		expect(existsSync(join(contentDir, "api.yaml"))).toBe(false);
+	});
+
+	// ── Ignored files ────────────────────────────────────────────────────────
+
+	it("records ignored files in ignoredFiles", async () => {
+		const { mirrorContent } = await import("./ContentMirror.js");
+		await writeFile(join(sourceRoot, "notes.txt"), "some notes", "utf-8");
+
+		const result = await mirrorContent(sourceRoot, contentDir);
+
+		expect(result.ignoredFiles).toContain("notes.txt");
+	});
+
+	it("does not copy ignored files to contentDir", async () => {
+		const { mirrorContent } = await import("./ContentMirror.js");
+		await writeFile(join(sourceRoot, "notes.txt"), "some notes", "utf-8");
+
+		await mirrorContent(sourceRoot, contentDir);
+
+		expect(existsSync(join(contentDir, "notes.txt"))).toBe(false);
+	});
+
+	// ── .jolli-site/ is skipped (4.7) ───────────────────────────────────────
+
+	it("skips .jolli-site/ directory during traversal", async () => {
+		const { mirrorContent } = await import("./ContentMirror.js");
+		const jolliSiteDir = join(sourceRoot, ".jolli-site", "pages");
+		await mkdir(jolliSiteDir, { recursive: true });
+		await writeFile(join(jolliSiteDir, "hidden.md"), "# Hidden", "utf-8");
+		// Also add a real file at root
+		await writeFile(join(sourceRoot, "real.md"), "# Real", "utf-8");
+
+		const result = await mirrorContent(sourceRoot, contentDir);
+
+		// hidden.md inside .jolli-site/ should NOT be in the result
+		const allFiles = [
+			...result.markdownFiles,
+			...result.imageFiles,
+			...result.openapiFiles,
+			...result.ignoredFiles,
+		];
+		expect(allFiles.some((f) => f.includes(".jolli-site"))).toBe(false);
+		// real.md should be copied
+		expect(result.markdownFiles).toContain("real.md");
+	});
+
+	// ── Mixed content ────────────────────────────────────────────────────────
+
+	it("handles a mix of file types correctly", async () => {
+		const { mirrorContent } = await import("./ContentMirror.js");
+		await mkdir(join(sourceRoot, "api"), { recursive: true });
+		await writeFile(join(sourceRoot, "index.md"), "# Home", "utf-8");
+		await writeFile(join(sourceRoot, "logo.svg"), "<svg/>", "utf-8");
+		await writeFile(join(sourceRoot, "api", "spec.yaml"), OPENAPI_YAML, "utf-8");
+		await writeFile(join(sourceRoot, "notes.txt"), "ignored", "utf-8");
+
+		const result = await mirrorContent(sourceRoot, contentDir);
+
+		expect(result.markdownFiles).toContain("index.md");
+		expect(result.imageFiles).toContain("logo.svg");
+		expect(result.openapiFiles).toContain(join("api", "spec.yaml"));
+		expect(result.ignoredFiles).toContain("notes.txt");
+	});
+
+	// ── Incompatible MDX files (Docusaurus etc.) ────────────────────────────
+
+	it("downgrades .mdx files with @theme/ imports to .md", async () => {
+		const { mirrorContent } = await import("./ContentMirror.js");
+		const mdxContent = `import Tabs from '@theme/Tabs'\nimport TabItem from '@theme/TabItem'\n\n# Config\n`;
+		await writeFile(join(sourceRoot, "config.mdx"), mdxContent, "utf-8");
+
+		const result = await mirrorContent(sourceRoot, contentDir);
+
+		expect(result.markdownFiles).toContain("config.md");
+		expect(result.markdownFiles).not.toContain("config.mdx");
+		expect(existsSync(join(contentDir, "config.md"))).toBe(true);
+		expect(existsSync(join(contentDir, "config.mdx"))).toBe(false);
+	});
+
+	it("strips import lines when downgrading .mdx to .md", async () => {
+		const { readFile: rf } = await import("node:fs/promises");
+		const { mirrorContent } = await import("./ContentMirror.js");
+		const mdxContent = `import Tabs from '@theme/Tabs'\n\n# Config\n\nSome text here.\n`;
+		await writeFile(join(sourceRoot, "config.mdx"), mdxContent, "utf-8");
+
+		await mirrorContent(sourceRoot, contentDir);
+
+		const output = await rf(join(contentDir, "config.md"), "utf-8");
+		expect(output).not.toContain("import");
+		expect(output).toContain("# Config");
+		expect(output).toContain("Some text here.");
+	});
+
+	it("downgrades .mdx files with @docusaurus/ imports to .md", async () => {
+		const { mirrorContent } = await import("./ContentMirror.js");
+		const mdxContent = `import Link from '@docusaurus/Link'\n\n# Page\n`;
+		await writeFile(join(sourceRoot, "page.mdx"), mdxContent, "utf-8");
+
+		const result = await mirrorContent(sourceRoot, contentDir);
+
+		expect(result.markdownFiles).toContain("page.md");
+	});
+
+	it("copies .mdx files without incompatible imports normally", async () => {
+		const { mirrorContent } = await import("./ContentMirror.js");
+		const mdxContent = `import SwaggerUI from 'swagger-ui-react'\n\n# API\n`;
+		await writeFile(join(sourceRoot, "api.mdx"), mdxContent, "utf-8");
+
+		const result = await mirrorContent(sourceRoot, contentDir);
+
+		expect(result.markdownFiles).toContain("api.mdx");
+		expect(existsSync(join(contentDir, "api.mdx"))).toBe(true);
+	});
+
+	it("downgrades .mdx with unknown JSX components to .md with components stripped", async () => {
+		const { readFile: rf } = await import("node:fs/promises");
+		const { mirrorContent } = await import("./ContentMirror.js");
+		const mdxContent = `# Videos\n\n<LiteYouTubeEmbed id="abc123" />\n\nSome text after.\n`;
+		await writeFile(join(sourceRoot, "videos.mdx"), mdxContent, "utf-8");
+
+		const result = await mirrorContent(sourceRoot, contentDir);
+
+		expect(result.markdownFiles).toContain("videos.md");
+		const output = await rf(join(contentDir, "videos.md"), "utf-8");
+		expect(output).toContain("# Videos");
+		expect(output).toContain("Some text after.");
+		expect(output).not.toContain("LiteYouTubeEmbed");
+	});
+
+	it("keeps children content when stripping JSX wrapper tags", async () => {
+		const { readFile: rf } = await import("node:fs/promises");
+		const { mirrorContent } = await import("./ContentMirror.js");
+		const mdxContent = `import Tabs from '@theme/Tabs'\n\n# Code\n\n<Tabs>\n<TabItem value="js" label="JS">\n\n\`\`\`js\nconsole.log("hi")\n\`\`\`\n\n</TabItem>\n</Tabs>\n`;
+		await writeFile(join(sourceRoot, "code.mdx"), mdxContent, "utf-8");
+
+		await mirrorContent(sourceRoot, contentDir);
+
+		const output = await rf(join(contentDir, "code.md"), "utf-8");
+		expect(output).toContain("# Code");
+		expect(output).toContain('console.log("hi")');
+		expect(output).not.toContain("<Tabs");
+		expect(output).not.toContain("<TabItem");
+	});
+
+	it("downgrades .mdx files with invalid MDX syntax to .md (Layer 2)", async () => {
+		const { readFile: rf } = await import("node:fs/promises");
+		const { mirrorContent } = await import("./ContentMirror.js");
+		// Malformed JSX that passes regex but fails MDX compilation
+		const mdxContent = `# Broken\n\n<div onClick={function(){ broken syntax}}>test</div>\n\nGood text.\n`;
+		await writeFile(join(sourceRoot, "broken.mdx"), mdxContent, "utf-8");
+
+		const result = await mirrorContent(sourceRoot, contentDir);
+
+		expect(result.markdownFiles).toContain("broken.md");
+		const output = await rf(join(contentDir, "broken.md"), "utf-8");
+		expect(output).toContain("# Broken");
+		expect(output).toContain("Good text.");
+	});
+
+	it("allows .mdx files with Nextra built-in components like Callout", async () => {
+		const { mirrorContent } = await import("./ContentMirror.js");
+		const mdxContent = `# Docs\n\n<Callout type="info">Note</Callout>\n`;
+		await writeFile(join(sourceRoot, "docs.mdx"), mdxContent, "utf-8");
+
+		const result = await mirrorContent(sourceRoot, contentDir);
+
+		expect(result.markdownFiles).toContain("docs.mdx");
+	});
+
+	it("allows .mdx files with imported custom components", async () => {
+		const { mirrorContent } = await import("./ContentMirror.js");
+		const mdxContent = `import MyChart from './MyChart'\n\n# Stats\n\n<MyChart />\n`;
+		await writeFile(join(sourceRoot, "stats.mdx"), mdxContent, "utf-8");
+
+		const result = await mirrorContent(sourceRoot, contentDir);
+
+		expect(result.markdownFiles).toContain("stats.mdx");
+	});
+
+	it("copies .md files without checking imports", async () => {
+		const { mirrorContent } = await import("./ContentMirror.js");
+		await writeFile(join(sourceRoot, "normal.md"), "# Normal\n", "utf-8");
+
+		const result = await mirrorContent(sourceRoot, contentDir);
+
+		expect(result.markdownFiles).toContain("normal.md");
+	});
+
+	// ── Empty source root ────────────────────────────────────────────────────
+
+	it("returns empty arrays for an empty source root", async () => {
+		const { mirrorContent } = await import("./ContentMirror.js");
+
+		const result = await mirrorContent(sourceRoot, contentDir);
+
+		expect(result.markdownFiles).toHaveLength(0);
+		expect(result.openapiFiles).toHaveLength(0);
+		expect(result.imageFiles).toHaveLength(0);
+		expect(result.ignoredFiles).toHaveLength(0);
+	});
+
+	// ── Error handling: unreadable directory ─────────────────────────────────
+
+	it("skips unreadable directories without throwing", async () => {
+		const { mirrorContent } = await import("./ContentMirror.js");
+		// sourceRoot pointing to a non-existent path
+		const result = await mirrorContent(join(sourceRoot, "nonexistent"), contentDir);
+
+		expect(result.markdownFiles).toHaveLength(0);
+	});
+
+	it("skips entries where stat fails (e.g. broken symlinks)", async () => {
+		const { symlink } = await import("node:fs/promises");
+		const { mirrorContent } = await import("./ContentMirror.js");
+		// Create a broken symlink — readdir lists it, but stat fails
+		await symlink(join(sourceRoot, "nonexistent-target"), join(sourceRoot, "broken.md"));
+		// Also add a real file so we verify the rest works
+		await writeFile(join(sourceRoot, "real.md"), "# Real", "utf-8");
+
+		const result = await mirrorContent(sourceRoot, contentDir);
+
+		expect(result.markdownFiles).toContain("real.md");
+		// broken.md should be silently skipped, not in any result array
+		expect(result.markdownFiles).not.toContain("broken.md");
+	});
+
+	// ── Error handling: unreadable file for OpenAPI classification ──────────
+
+	it("treats an unreadable .yaml file as ignored", async () => {
+		const { chmod, writeFile: wf } = await import("node:fs/promises");
+		const { mirrorContent } = await import("./ContentMirror.js");
+		const yamlPath = join(sourceRoot, "spec.yaml");
+		await wf(yamlPath, "openapi: 3.0.0\ninfo:\n  title: T", "utf-8");
+		// Remove read permissions so readFile fails
+		await chmod(yamlPath, 0o000);
+
+		const result = await mirrorContent(sourceRoot, contentDir);
+
+		// Restore permissions for cleanup
+		await chmod(yamlPath, 0o644);
+		expect(result.ignoredFiles).toContain("spec.yaml");
+	});
+});
+
+// ─── Property-based tests ─────────────────────────────────────────────────────
+
+/**
+ * Property 1: File type classification is consistent
+ * **Validates: Requirements 3.1, 3.2, 3.3**
+ */
+describe("Property 1: File type classification is consistent", () => {
+	// Arbitrary safe filename segment (letters, digits, hyphens)
+	const safeSegment = fc.stringMatching(/^[a-z][a-z0-9-]{0,15}$/).filter((s) => s.length > 0);
+
+	it("classifyFile always returns markdown for .md files", async () => {
+		const { classifyFile } = await import("./ContentMirror.js");
+
+		fc.assert(
+			fc.property(safeSegment, (name) => {
+				const result = classifyFile(`${name}.md`);
+				return result === "markdown";
+			}),
+			{ numRuns: 100 },
+		);
+	});
+
+	it("classifyFile always returns markdown for .mdx files", async () => {
+		const { classifyFile } = await import("./ContentMirror.js");
+
+		fc.assert(
+			fc.property(safeSegment, (name) => {
+				const result = classifyFile(`${name}.mdx`);
+				return result === "markdown";
+			}),
+			{ numRuns: 100 },
+		);
+	});
+
+	it("classifyFile always returns image for .png files", async () => {
+		const { classifyFile } = await import("./ContentMirror.js");
+
+		fc.assert(
+			fc.property(safeSegment, (name) => {
+				return classifyFile(`${name}.png`) === "image";
+			}),
+			{ numRuns: 100 },
+		);
+	});
+
+	it("classifyFile always returns image for .jpg files", async () => {
+		const { classifyFile } = await import("./ContentMirror.js");
+
+		fc.assert(
+			fc.property(safeSegment, (name) => {
+				return classifyFile(`${name}.jpg`) === "image";
+			}),
+			{ numRuns: 100 },
+		);
+	});
+
+	it("classifyFile always returns image for .jpeg files", async () => {
+		const { classifyFile } = await import("./ContentMirror.js");
+
+		fc.assert(
+			fc.property(safeSegment, (name) => {
+				return classifyFile(`${name}.jpeg`) === "image";
+			}),
+			{ numRuns: 100 },
+		);
+	});
+
+	it("classifyFile always returns image for .gif files", async () => {
+		const { classifyFile } = await import("./ContentMirror.js");
+
+		fc.assert(
+			fc.property(safeSegment, (name) => {
+				return classifyFile(`${name}.gif`) === "image";
+			}),
+			{ numRuns: 100 },
+		);
+	});
+
+	it("classifyFile always returns image for .svg files", async () => {
+		const { classifyFile } = await import("./ContentMirror.js");
+
+		fc.assert(
+			fc.property(safeSegment, (name) => {
+				return classifyFile(`${name}.svg`) === "image";
+			}),
+			{ numRuns: 100 },
+		);
+	});
+
+	it("classifyFile always returns image for .webp files", async () => {
+		const { classifyFile } = await import("./ContentMirror.js");
+
+		fc.assert(
+			fc.property(safeSegment, (name) => {
+				return classifyFile(`${name}.webp`) === "image";
+			}),
+			{ numRuns: 100 },
+		);
+	});
+
+	it("classifyFile always returns image for .ico files", async () => {
+		const { classifyFile } = await import("./ContentMirror.js");
+
+		fc.assert(
+			fc.property(safeSegment, (name) => {
+				return classifyFile(`${name}.ico`) === "image";
+			}),
+			{ numRuns: 100 },
+		);
+	});
+
+	it("classifyFile always returns openapi for .json files with openapi + info fields", async () => {
+		const { classifyFile } = await import("./ContentMirror.js");
+
+		// Generate random openapi version strings and info objects
+		const openApiContent = fc.record({
+			openapi: fc.constantFrom("3.0.0", "3.1.0", "3.0.3"),
+			info: fc.record({
+				title: safeSegment,
+				version: fc.constantFrom("1.0.0", "2.0.0"),
+			}),
+		});
+
+		fc.assert(
+			fc.property(safeSegment, openApiContent, (name, spec) => {
+				const content = JSON.stringify(spec);
+				return classifyFile(`${name}.json`, content) === "openapi";
+			}),
+			{ numRuns: 100 },
+		);
+	});
+
+	it("classifyFile always returns openapi for .yaml files with openapi + info fields", async () => {
+		const { classifyFile } = await import("./ContentMirror.js");
+
+		fc.assert(
+			fc.property(safeSegment, safeSegment, (name, version) => {
+				const content = `openapi: "${version}"\ninfo:\n  title: Test\n`;
+				return classifyFile(`${name}.yaml`, content) === "openapi";
+			}),
+			{ numRuns: 100 },
+		);
+	});
+
+	it("classifyFile always returns openapi for .yml files with openapi + info fields", async () => {
+		const { classifyFile } = await import("./ContentMirror.js");
+
+		fc.assert(
+			fc.property(safeSegment, safeSegment, (name, version) => {
+				const content = `openapi: "${version}"\ninfo:\n  title: Test\n`;
+				return classifyFile(`${name}.yml`, content) === "openapi";
+			}),
+			{ numRuns: 100 },
+		);
+	});
+});
+
+/**
+ * Property 2: Content mirroring preserves directory structure
+ * **Validates: Requirements 5.1, 5.2**
+ */
+describe("Property 2: Content mirroring preserves directory structure", () => {
+	let sourceRoot: string;
+	let contentDir: string;
+
+	beforeEach(async () => {
+		sourceRoot = await makeTempDir();
+		contentDir = await makeTempDir();
+	});
+
+	afterEach(async () => {
+		await rm(sourceRoot, { recursive: true, force: true });
+		await rm(contentDir, { recursive: true, force: true });
+	});
+
+	it("every markdown file appears at the corresponding path in contentDir", async () => {
+		const { mirrorContent } = await import("./ContentMirror.js");
+
+		// Generate a small set of relative markdown paths (1-5 files)
+		// Use simple safe names to avoid filesystem issues
+		const safeFilename = fc.stringMatching(/^[a-z][a-z0-9-]{0,10}$/).filter((s) => s.length > 0);
+
+		await fc.assert(
+			fc.asyncProperty(fc.array(safeFilename, { minLength: 1, maxLength: 5 }), async (names) => {
+				// Clean up between runs
+				await rm(sourceRoot, { recursive: true, force: true });
+				await rm(contentDir, { recursive: true, force: true });
+				sourceRoot = await makeTempDir();
+				contentDir = await makeTempDir();
+
+				// Write unique markdown files at root level
+				const uniqueNames = [...new Set(names)];
+				for (const name of uniqueNames) {
+					await writeFile(join(sourceRoot, `${name}.md`), `# ${name}`, "utf-8");
+				}
+
+				const result = await mirrorContent(sourceRoot, contentDir);
+
+				// Every markdown file must exist in contentDir
+				for (const relPath of result.markdownFiles) {
+					if (!existsSync(join(contentDir, relPath))) {
+						return false;
+					}
+				}
+				return true;
+			}),
+			{ numRuns: 50 },
+		);
+	});
+
+	it("markdown files in subdirectories appear at the correct nested path in contentDir", async () => {
+		const { mirrorContent } = await import("./ContentMirror.js");
+
+		const safeSegment = fc.stringMatching(/^[a-z][a-z0-9-]{0,8}$/).filter((s) => s.length > 0);
+
+		await fc.assert(
+			fc.asyncProperty(safeSegment, safeSegment, async (dirName, fileName) => {
+				// Clean up between runs
+				await rm(sourceRoot, { recursive: true, force: true });
+				await rm(contentDir, { recursive: true, force: true });
+				sourceRoot = await makeTempDir();
+				contentDir = await makeTempDir();
+
+				const subDir = join(sourceRoot, dirName);
+				await mkdir(subDir, { recursive: true });
+				await writeFile(join(subDir, `${fileName}.md`), `# ${fileName}`, "utf-8");
+
+				const result = await mirrorContent(sourceRoot, contentDir);
+
+				const expectedRelPath = join(dirName, `${fileName}.md`);
+				return result.markdownFiles.includes(expectedRelPath) && existsSync(join(contentDir, expectedRelPath));
+			}),
+			{ numRuns: 50 },
+		);
+	});
+});
+
+// ─── stripIncompatibleContent tests ──────────────────────────────────────────
+
+describe("ContentMirror.stripIncompatibleContent", () => {
+	it("removes import statements", async () => {
+		const { stripIncompatibleContent } = await import("./ContentMirror.js");
+		const input = "import Tabs from '@theme/Tabs'\nimport TabItem from '@theme/TabItem'\n\n# Title\n";
+
+		const result = stripIncompatibleContent(input);
+
+		expect(result).not.toContain("import");
+		expect(result).toContain("# Title");
+	});
+
+	it("removes export statements", async () => {
+		const { stripIncompatibleContent } = await import("./ContentMirror.js");
+		const input = "export const meta = { title: 'Test' }\n\n# Title\n";
+
+		const result = stripIncompatibleContent(input);
+
+		expect(result).not.toContain("export");
+		expect(result).toContain("# Title");
+	});
+
+	it("removes self-closing JSX tags", async () => {
+		const { stripIncompatibleContent } = await import("./ContentMirror.js");
+		const input = '# Title\n\n<LiteYouTubeEmbed id="abc123" />\n\nText after.\n';
+
+		const result = stripIncompatibleContent(input);
+
+		expect(result).not.toContain("LiteYouTubeEmbed");
+		expect(result).toContain("Text after.");
+	});
+
+	it("removes self-closing JSX tags without attributes", async () => {
+		const { stripIncompatibleContent } = await import("./ContentMirror.js");
+		const input = "# Title\n\n<Spacer/>\n\nText.\n";
+
+		const result = stripIncompatibleContent(input);
+
+		expect(result).not.toContain("Spacer");
+		expect(result).toContain("Text.");
+	});
+
+	it("removes opening and closing JSX tags but keeps children", async () => {
+		const { stripIncompatibleContent } = await import("./ContentMirror.js");
+		const input =
+			'# Code\n\n<Tabs>\n<TabItem value="js" label="JS">\n\n```js\nconsole.log()\n```\n\n</TabItem>\n</Tabs>\n';
+
+		const result = stripIncompatibleContent(input);
+
+		expect(result).not.toContain("<Tabs");
+		expect(result).not.toContain("<TabItem");
+		expect(result).not.toContain("</Tabs");
+		expect(result).not.toContain("</TabItem");
+		expect(result).toContain("console.log()");
+	});
+
+	it("converts JSX style objects to HTML style strings", async () => {
+		const { stripIncompatibleContent } = await import("./ContentMirror.js");
+		const input = '# Title\n\n<div style={{backgroundColor: "red", fontSize: "14px"}}>content</div>\n';
+
+		const result = stripIncompatibleContent(input);
+
+		expect(result).toContain('style="background-color: red; font-size: 14px"');
+		expect(result).not.toContain("{{");
+	});
+
+	it("removes Docusaurus admonition fences", async () => {
+		const { stripIncompatibleContent } = await import("./ContentMirror.js");
+		const input = "# Title\n\n:::tip\nThis is a tip.\n:::\n\nMore text.\n";
+
+		const result = stripIncompatibleContent(input);
+
+		expect(result).not.toContain(":::");
+		expect(result).toContain("This is a tip.");
+		expect(result).toContain("More text.");
+	});
+
+	it("removes :::warning admonition", async () => {
+		const { stripIncompatibleContent } = await import("./ContentMirror.js");
+		const input = ":::warning\nBe careful!\n:::\n";
+
+		const result = stripIncompatibleContent(input);
+
+		expect(result).not.toContain(":::warning");
+		expect(result).toContain("Be careful!");
+	});
+
+	it("cleans up excessive blank lines", async () => {
+		const { stripIncompatibleContent } = await import("./ContentMirror.js");
+		const input = "import X from 'x'\n\n\n\n\n# Title\n\n\n\n\nText.\n";
+
+		const result = stripIncompatibleContent(input);
+
+		expect(result).not.toMatch(/\n{4,}/);
+	});
+
+	it("trims and adds trailing newline", async () => {
+		const { stripIncompatibleContent } = await import("./ContentMirror.js");
+		const input = "\n\n# Title\n\n";
+
+		const result = stripIncompatibleContent(input);
+
+		expect(result).toMatch(/\n$/);
+		expect(result).not.toMatch(/^\n/);
+	});
+
+	it("handles nested JSX components iteratively", async () => {
+		const { stripIncompatibleContent } = await import("./ContentMirror.js");
+		const input = "<Outer>\n<Inner>\nDeep content\n</Inner>\n</Outer>\n";
+
+		const result = stripIncompatibleContent(input);
+
+		expect(result).not.toContain("<Outer");
+		expect(result).not.toContain("<Inner");
+		expect(result).toContain("Deep content");
+	});
+});
+
+// ─── clearDir tests ──────────────────────────────────────────────────────────
+
+describe("ContentMirror.clearDir", () => {
+	let dir: string;
+
+	beforeEach(async () => {
+		dir = await makeTempDir();
+	});
+
+	afterEach(async () => {
+		await rm(dir, { recursive: true, force: true });
+	});
+
+	it("removes all contents inside the directory", async () => {
+		const { clearDir } = await import("./ContentMirror.js");
+		await writeFile(join(dir, "file1.md"), "# One", "utf-8");
+		await writeFile(join(dir, "file2.md"), "# Two", "utf-8");
+		await mkdir(join(dir, "subdir"), { recursive: true });
+		await writeFile(join(dir, "subdir", "file3.md"), "# Three", "utf-8");
+
+		await clearDir(dir);
+
+		expect(existsSync(dir)).toBe(true); // Directory itself stays
+		const entries = await readdir(dir);
+		expect(entries).toHaveLength(0);
+	});
+
+	it("does not throw for nonexistent directory", async () => {
+		const { clearDir } = await import("./ContentMirror.js");
+
+		await expect(clearDir(join(dir, "nonexistent"))).resolves.not.toThrow();
+	});
+
+	it("handles empty directory", async () => {
+		const { clearDir } = await import("./ContentMirror.js");
+
+		await expect(clearDir(dir)).resolves.not.toThrow();
+	});
+});
+
+// ─── rewriteRelativeImagePaths tests ─────────────────────────────────────────
+
+describe("ContentMirror.rewriteRelativeImagePaths", () => {
+	it("rewrites markdown image paths when file is remapped", async () => {
+		const { rewriteRelativeImagePaths } = await import("./ContentMirror.js");
+		const content = "# Title\n\n![logo](../images/logo.png)\n";
+
+		const result = rewriteRelativeImagePaths(content, "docs/page.md", "guides/docs/page.md");
+
+		expect(result).not.toBe(content);
+		expect(result).toContain("logo.png");
+	});
+
+	it("does not modify when original and new path have same directory", async () => {
+		const { rewriteRelativeImagePaths } = await import("./ContentMirror.js");
+		const content = "# Title\n\n![logo](logo.png)\n";
+
+		const result = rewriteRelativeImagePaths(content, "docs/page.md", "docs/other.md");
+
+		expect(result).toBe(content);
+	});
+
+	it("does not modify absolute image paths", async () => {
+		const { rewriteRelativeImagePaths } = await import("./ContentMirror.js");
+		const content = "![logo](/images/logo.png)\n";
+
+		const result = rewriteRelativeImagePaths(content, "docs/page.md", "guides/page.md");
+
+		expect(result).toContain("/images/logo.png");
+	});
+
+	it("does not modify HTTP image paths", async () => {
+		const { rewriteRelativeImagePaths } = await import("./ContentMirror.js");
+		const content = "![logo](https://example.com/logo.png)\n";
+
+		const result = rewriteRelativeImagePaths(content, "docs/page.md", "guides/page.md");
+
+		expect(result).toContain("https://example.com/logo.png");
+	});
+
+	it("rewrites HTML img src attributes", async () => {
+		const { rewriteRelativeImagePaths } = await import("./ContentMirror.js");
+		const content = '<img src="./logo.png" alt="logo">\n';
+
+		const result = rewriteRelativeImagePaths(content, "docs/page.md", "guides/docs/page.md");
+
+		expect(result).toContain("logo.png");
+		expect(result).not.toContain("./logo.png");
+	});
+
+	it("ignores non-image file references", async () => {
+		const { rewriteRelativeImagePaths } = await import("./ContentMirror.js");
+		const content = "![doc](../file.pdf)\n";
+
+		const result = rewriteRelativeImagePaths(content, "docs/page.md", "guides/page.md");
+
+		expect(result).toContain("../file.pdf"); // Unchanged
+	});
+});
+
+// ─── applyPathMapping tests ──────────────────────────────────────────────────
+
+describe("ContentMirror.applyPathMapping", () => {
+	it("applies folder-level mapping", async () => {
+		const { applyPathMapping } = await import("./ContentMirror.js");
+
+		const result = applyPathMapping("sql/query.md", { sql: "pipelines/sql" });
+
+		expect(result).toBe("pipelines/sql/query.md");
+	});
+
+	it("returns original path when no mapping matches", async () => {
+		const { applyPathMapping } = await import("./ContentMirror.js");
+
+		const result = applyPathMapping("other/file.md", { sql: "pipelines/sql" });
+
+		expect(result).toBe("other/file.md");
+	});
+
+	it("returns original path when no mappings provided", async () => {
+		const { applyPathMapping } = await import("./ContentMirror.js");
+
+		const result = applyPathMapping("some/file.md");
+
+		expect(result).toBe("some/file.md");
+	});
+
+	it("handles exact path match (not just prefix)", async () => {
+		const { applyPathMapping } = await import("./ContentMirror.js");
+
+		const result = applyPathMapping("sql", { sql: "pipelines/sql" });
+
+		expect(result).toBe("pipelines/sql");
+	});
+
+	it("normalizes backslashes", async () => {
+		const { applyPathMapping } = await import("./ContentMirror.js");
+
+		const result = applyPathMapping("sql\\query.md", { sql: "pipelines/sql" });
+
+		expect(result).toBe("pipelines/sql/query.md");
+	});
+});
+
+// ─── mirrorContent with pathMappings ─────────────────────────────────────────
+
+describe("ContentMirror.mirrorContent with pathMappings", () => {
+	let sourceRoot: string;
+	let contentDir: string;
+
+	beforeEach(async () => {
+		sourceRoot = await makeTempDir();
+		contentDir = await makeTempDir();
+	});
+
+	afterEach(async () => {
+		await rm(sourceRoot, { recursive: true, force: true });
+		await rm(contentDir, { recursive: true, force: true });
+	});
+
+	it("remaps file paths according to pathMappings", async () => {
+		const { mirrorContent } = await import("./ContentMirror.js");
+		await mkdir(join(sourceRoot, "sql"), { recursive: true });
+		await writeFile(join(sourceRoot, "sql", "query.md"), "# Query\n", "utf-8");
+
+		const result = await mirrorContent(sourceRoot, contentDir, { sql: "pipelines/sql" });
+
+		expect(result.markdownFiles).toContain(join("pipelines", "sql", "query.md"));
+		expect(existsSync(join(contentDir, "pipelines", "sql", "query.md"))).toBe(true);
+	});
+
+	it("rewrites image paths in remapped markdown files", async () => {
+		const { readFile: rf } = await import("node:fs/promises");
+		const { mirrorContent } = await import("./ContentMirror.js");
+		await mkdir(join(sourceRoot, "sql"), { recursive: true });
+		await writeFile(join(sourceRoot, "sql", "query.md"), "# Query\n\n![diagram](../images/diagram.png)\n", "utf-8");
+		await mkdir(join(sourceRoot, "images"), { recursive: true });
+		await writeFile(join(sourceRoot, "images", "diagram.png"), "fake-png", "utf-8");
+
+		await mirrorContent(sourceRoot, contentDir, { sql: "pipelines/sql" });
+
+		const output = await rf(join(contentDir, "pipelines", "sql", "query.md"), "utf-8");
+		// Image path should be rewritten relative to new location
+		expect(output).toContain("diagram.png");
+	});
+});
+
+// ─── mirrorContent with ensureIndexPage ──────────────────────────────────────
+
+describe("ContentMirror.mirrorContent ensureIndexPage", () => {
+	let sourceRoot: string;
+	let contentDir: string;
+
+	beforeEach(async () => {
+		sourceRoot = await makeTempDir();
+		contentDir = await makeTempDir();
+	});
+
+	afterEach(async () => {
+		await rm(sourceRoot, { recursive: true, force: true });
+		await rm(contentDir, { recursive: true, force: true });
+	});
+
+	it("renames file with slug: / frontmatter to index.md", async () => {
+		const { mirrorContent } = await import("./ContentMirror.js");
+		await writeFile(join(sourceRoot, "intro.md"), "---\nslug: /\n---\n# Intro\n", "utf-8");
+
+		const result = await mirrorContent(sourceRoot, contentDir);
+
+		expect(result.markdownFiles).toContain("index.md");
+		expect(result.renamedToIndex).toBe("intro");
+		expect(existsSync(join(contentDir, "index.md"))).toBe(true);
+	});
+
+	it("does not rename when index.md already exists", async () => {
+		const { mirrorContent } = await import("./ContentMirror.js");
+		await writeFile(join(sourceRoot, "index.md"), "# Home\n", "utf-8");
+		await writeFile(join(sourceRoot, "intro.md"), "---\nslug: /\n---\n# Intro\n", "utf-8");
+
+		const result = await mirrorContent(sourceRoot, contentDir);
+
+		expect(result.renamedToIndex).toBeUndefined();
+	});
+
+	it("returns undefined when no slug: / file exists", async () => {
+		const { mirrorContent } = await import("./ContentMirror.js");
+		await writeFile(join(sourceRoot, "guide.md"), "# Guide\n", "utf-8");
+
+		const result = await mirrorContent(sourceRoot, contentDir);
+
+		expect(result.renamedToIndex).toBeUndefined();
+	});
+});
+
+// ─── mirrorContent with publicDir (missing image resolution) ─────────────────
+
+describe("ContentMirror.mirrorContent with publicDir", () => {
+	let sourceRoot: string;
+	let contentDir: string;
+	let publicDir: string;
+
+	beforeEach(async () => {
+		sourceRoot = await makeTempDir();
+		contentDir = await makeTempDir();
+		publicDir = await makeTempDir();
+	});
+
+	afterEach(async () => {
+		await rm(sourceRoot, { recursive: true, force: true });
+		await rm(contentDir, { recursive: true, force: true });
+		await rm(publicDir, { recursive: true, force: true });
+	});
+
+	it("generates placeholders for missing images when publicDir is set", async () => {
+		const { mirrorContent } = await import("./ContentMirror.js");
+		await writeFile(join(sourceRoot, "page.md"), "# Page\n\n![missing](./nonexistent.png)\n", "utf-8");
+
+		await mirrorContent(sourceRoot, contentDir, undefined, publicDir);
+
+		// The markdown file should have been modified to point to a resolved path
+		const { readFile: rf } = await import("node:fs/promises");
+		const output = await rf(join(contentDir, "page.md"), "utf-8");
+		// The image ref should now point to /images/placeholder-nonexistent.svg or similar
+		expect(output).toContain("/images/");
+	});
+
+	it("resolves absolute image paths from static directory", async () => {
+		const { mirrorContent } = await import("./ContentMirror.js");
+		await writeFile(join(sourceRoot, "page.md"), "# Page\n\n![logo](/img/logo.png)\n", "utf-8");
+
+		await mirrorContent(sourceRoot, contentDir, undefined, publicDir);
+
+		const { readFile: rf } = await import("node:fs/promises");
+		const output = await rf(join(contentDir, "page.md"), "utf-8");
+		expect(output).toContain("/images/");
+	});
+});
+
+// ─── hasIncompatibleImports with custom ContentRules ─────────────────────────
+
+describe("ContentMirror.hasIncompatibleImports with ContentRules", () => {
+	it("uses custom safe prefixes when ContentRules provided", async () => {
+		const { hasIncompatibleImports } = await import("./ContentMirror.js");
+		const content = "import Foo from 'custom-pkg'\n\n# Title\n";
+
+		// Without custom rules: 'custom-pkg' is incompatible
+		expect(hasIncompatibleImports(content)).toBe(true);
+
+		// With custom rules that include 'custom-pkg': compatible
+		expect(
+			hasIncompatibleImports(content, {
+				safeImportPrefixes: ["custom-pkg", "react"],
+				providedComponents: new Set(),
+			}),
+		).toBe(false);
+	});
+
+	it("uses custom provided components when ContentRules provided", async () => {
+		const { hasIncompatibleImports } = await import("./ContentMirror.js");
+		const content = "# Title\n\n<CustomWidget />\n";
+
+		// Without custom rules: CustomWidget is incompatible
+		expect(hasIncompatibleImports(content)).toBe(true);
+
+		// With custom rules that include CustomWidget: compatible
+		expect(
+			hasIncompatibleImports(content, {
+				safeImportPrefixes: [],
+				providedComponents: new Set(["CustomWidget"]),
+			}),
+		).toBe(false);
+	});
+
+	it("falls back to defaults when rules is undefined", async () => {
+		const { hasIncompatibleImports } = await import("./ContentMirror.js");
+		// Nextra's Callout is in default provided components
+		const content = "# Title\n\n<Callout>Note</Callout>\n";
+
+		expect(hasIncompatibleImports(content, undefined)).toBe(false);
+	});
+});
+
+// ─── mirrorContent with unreadable .mdx file ─────────────────────────────────
+
+describe("ContentMirror.mirrorContent unreadable MDX", () => {
+	let sourceRoot: string;
+	let contentDir: string;
+
+	beforeEach(async () => {
+		sourceRoot = await mkdtemp(join(tmpdir(), "jolli-contentmirror-test-"));
+		contentDir = await mkdtemp(join(tmpdir(), "jolli-contentmirror-test-"));
+	});
+
+	afterEach(async () => {
+		await rm(sourceRoot, { recursive: true, force: true });
+		await rm(contentDir, { recursive: true, force: true });
+	});
+
+	it("treats broken .mdx symlink as ignored", async () => {
+		const { symlink: symlinkFn } = await import("node:fs/promises");
+		const { mirrorContent } = await import("./ContentMirror.js");
+		// Create a broken symlink that stat resolves but readFile fails
+		await symlinkFn(join(sourceRoot, "nonexistent-target.mdx"), join(sourceRoot, "broken.mdx"));
+		// Also add a real file so the walk succeeds
+		await writeFile(join(sourceRoot, "real.md"), "# Real", "utf-8");
+
+		const result = await mirrorContent(sourceRoot, contentDir);
+
+		expect(result.markdownFiles).toContain("real.md");
+		// broken.mdx should be skipped (stat fails on broken symlink)
+	});
+});

--- a/cli/src/site/ContentMirror.ts
+++ b/cli/src/site/ContentMirror.ts
@@ -1,0 +1,696 @@
+/**
+ * ContentMirror — mirrors the Content_Folder into the Nextra content directory.
+ *
+ * Classifies files by extension (and content for OpenAPI), then copies
+ * markdown and image files to the corresponding paths inside the content directory.
+ * Skips the `.jolli-site/` directory to avoid infinite recursion.
+ */
+
+import { existsSync } from "node:fs";
+import { copyFile, mkdir, readdir, readFile, rename, rm, stat, writeFile } from "node:fs/promises";
+import { dirname, extname, join, relative, resolve } from "node:path";
+import { copyExternalAsset, resolveExternalImage } from "./AssetResolver.js";
+import { isValidOpenApiContent } from "./OpenApiRenderer.js";
+import type { ContentRules } from "./renderer/SiteRenderer.js";
+import type { FileType, MirrorResult, PathMappings } from "./Types.js";
+
+// ─── rewriteRelativeImagePaths ────────────────────────────────────────────────
+
+const IMAGE_EXT = /\.(png|jpg|jpeg|gif|svg|webp|ico|bmp)$/i;
+
+/**
+ * Rewrites relative image paths in markdown when a file has been remapped.
+ *
+ * For each relative image reference, resolves it against the ORIGINAL
+ * directory to get the absolute image path, then computes a new relative
+ * path from the NEW directory.
+ *
+ * Example:
+ *   originalRelPath: "connectors/completion-tokens.md"
+ *   newRelPath:      "pipelines/connectors/completion-tokens.md"
+ *   Image ref:       "../pipelines/pipeline_architecture.png"
+ *   Resolved:        "pipelines/pipeline_architecture.png" (absolute from root)
+ *   New relative:    "../../pipelines/pipeline_architecture.png" (from pipelines/connectors/)
+ */
+export function rewriteRelativeImagePaths(
+	content: string,
+	originalRelPath: string,
+	newRelPath: string,
+	pathMappings?: PathMappings,
+): string {
+	const originalDir = dirOf(originalRelPath);
+	const newDir = dirOf(newRelPath);
+
+	if (originalDir === newDir) return content;
+
+	// Rewrite markdown images: ![alt](path)
+	let result = content.replace(/!\[([^\]]*)\]\(([^)]+)\)/g, (match, alt: string, src: string) => {
+		if (!IMAGE_EXT.test(src)) return match;
+		if (src.startsWith("/") || src.startsWith("http")) return match;
+		const newSrc = remapRelativePath(src, originalDir, newDir, pathMappings);
+		return `![${alt}](${newSrc})`;
+	});
+
+	// Rewrite HTML img: <img src="path">
+	result = result.replace(/<img\s([^>]*?)src=["']([^"']+)["']/g, (match, attrs: string, src: string) => {
+		if (!IMAGE_EXT.test(src)) return match;
+		if (src.startsWith("/") || src.startsWith("http")) return match;
+		const newSrc = remapRelativePath(src, originalDir, newDir, pathMappings);
+		return `<img ${attrs}src="${newSrc}"`;
+	});
+
+	return result;
+}
+
+/** Gets the directory part of a relative path. */
+function dirOf(relPath: string): string {
+	const i = relPath.lastIndexOf("/");
+	return i === -1 ? "" : relPath.slice(0, i);
+}
+
+/**
+ * Resolves a relative path from `originalDir`, then computes a new relative
+ * path from `newDir`.
+ */
+function remapRelativePath(src: string, originalDir: string, newDir: string, pathMappings?: PathMappings): string {
+	// Resolve to absolute path (relative to source root)
+	const absolute = resolvePath(originalDir, src);
+
+	// Apply pathMapping to the image path too (it may have been moved)
+	const mapped = applyPathMapping(absolute, pathMappings);
+
+	// Compute relative from new dir
+	return computeRelative(newDir, mapped);
+}
+
+/** Resolves a relative path against a directory. "a/b" + "../c.png" → "c.png" */
+function resolvePath(dir: string, rel: string): string {
+	const parts = dir ? dir.split("/") : [];
+	for (const seg of rel.split("/")) {
+		if (seg === "..") parts.pop();
+		else if (seg !== ".") parts.push(seg);
+	}
+	return parts.join("/");
+}
+
+/** Computes a relative path from `from` directory to `to` path. */
+function computeRelative(from: string, to: string): string {
+	const fromParts = from ? from.split("/") : [];
+	const toParts = to.split("/");
+
+	// Find common prefix length
+	let common = 0;
+	while (common < fromParts.length && common < toParts.length && fromParts[common] === toParts[common]) {
+		common++;
+	}
+
+	const ups = fromParts.length - common;
+	const rest = toParts.slice(common);
+
+	const prefix = ups > 0 ? "../".repeat(ups) : "./";
+	return prefix + rest.join("/");
+}
+
+// ─── applyPathMapping ────────────────────────────────────────────────────────
+
+/**
+ * Applies path mappings to a relative file path.
+ * Mappings are folder-level: `{ "sql": "pipelines/sql" }` means any file
+ * under `sql/...` gets remapped to `pipelines/sql/...`.
+ *
+ * Uses forward slashes for matching regardless of platform.
+ */
+export function applyPathMapping(relPath: string, pathMappings?: PathMappings): string {
+	if (!pathMappings) return relPath;
+
+	const normalized = relPath.replace(/\\/g, "/");
+
+	for (const [source, target] of Object.entries(pathMappings)) {
+		if (normalized === source || normalized.startsWith(`${source}/`)) {
+			return target + normalized.slice(source.length);
+		}
+	}
+
+	return relPath;
+}
+
+// ─── classifyFile ─────────────────────────────────────────────────────────────
+
+/**
+ * Classifies a file by its extension and, for JSON/YAML files, by its content.
+ *
+ * - `.md`, `.mdx`                                  → `"markdown"`
+ * - `.png`, `.jpg`, `.jpeg`, `.gif`, `.svg`,
+ *   `.webp`, `.ico`                                → `"image"`
+ * - `.json`, `.yaml`, `.yml` with `openapi` field
+ *   and `info` object in content                   → `"openapi"`
+ * - everything else                                → `"ignored"`
+ */
+export function classifyFile(filePath: string, content?: string): FileType {
+	const ext = extname(filePath).toLowerCase();
+
+	// 4.2 — Markdown
+	if (ext === ".md" || ext === ".mdx") {
+		return "markdown";
+	}
+
+	// 4.3 — Images
+	if (
+		ext === ".png" ||
+		ext === ".jpg" ||
+		ext === ".jpeg" ||
+		ext === ".gif" ||
+		ext === ".svg" ||
+		ext === ".webp" ||
+		ext === ".ico"
+	) {
+		return "image";
+	}
+
+	// 4.4 — OpenAPI (JSON or YAML with openapi + info fields)
+	if (ext === ".json" || ext === ".yaml" || ext === ".yml") {
+		if (content !== undefined && isValidOpenApiContent(content, ext)) {
+			return "openapi";
+		}
+		return "ignored";
+	}
+
+	// 4.5 — Everything else
+	return "ignored";
+}
+
+// ─── hasIncompatibleImports (internal helper) ────────────────────────────────
+
+/**
+ * Default package prefixes that are known to be safe.
+ * Used as fallback when no ContentRules are provided.
+ */
+const DEFAULT_SAFE_IMPORT_PREFIXES = [
+	"nextra",
+	"nextra-theme-docs",
+	"next/",
+	"next-themes",
+	"react",
+	"swagger-ui-react",
+];
+
+/**
+ * Default components provided by the framework that don't need explicit imports.
+ * Used as fallback when no ContentRules are provided.
+ */
+const DEFAULT_PROVIDED_COMPONENTS = new Set([
+	"Fragment",
+	"Callout",
+	"Cards",
+	"Card",
+	"FileTree",
+	"Steps",
+	"Tabs",
+	"Tab",
+]);
+
+/**
+ * Matches ES module import statements: `import ... from '...'`
+ * Captures the module specifier (the part inside quotes).
+ */
+const IMPORT_PATTERN = /import\s+.*?from\s+['"](.*?)['"]/g;
+
+/**
+ * Returns `true` if the MDX content contains imports that can't be resolved
+ * in the target framework. Relative imports (`./`, `../`) are always allowed.
+ * Package imports are only allowed if they match a known safe prefix.
+ *
+ * @param rules - Renderer-specific content rules. Falls back to Nextra defaults if omitted.
+ */
+export function hasIncompatibleImports(content: string, rules?: ContentRules): boolean {
+	const safePrefixes = rules?.safeImportPrefixes ?? DEFAULT_SAFE_IMPORT_PREFIXES;
+	const providedComponents = rules?.providedComponents ?? DEFAULT_PROVIDED_COMPONENTS;
+
+	for (const match of content.matchAll(IMPORT_PATTERN)) {
+		const specifier = match[1];
+		// Relative imports are always safe
+		if (specifier.startsWith("./") || specifier.startsWith("../")) continue;
+		// Check against safe prefixes
+		if (safePrefixes.some((prefix) => specifier === prefix || specifier.startsWith(`${prefix}/`))) continue;
+		// Unknown package import — incompatible
+		return true;
+	}
+
+	// Check for JSX components that aren't standard HTML and aren't imported.
+	// These are typically injected via framework-specific MDX providers
+	// (e.g. Docusaurus global components like <LiteYouTubeEmbed />).
+	const importedComponents = new Set<string>();
+	for (const match of content.matchAll(/import\s+(\w+)/g)) {
+		importedComponents.add(match[1]);
+	}
+	for (const match of content.matchAll(/import\s+\{([^}]+)\}/g)) {
+		for (const name of match[1].split(",")) {
+			const trimmed = name
+				.trim()
+				.split(/\s+as\s+/)
+				.pop()
+				?.trim();
+			if (trimmed) importedComponents.add(trimmed);
+		}
+	}
+
+	// Match JSX tags that start with uppercase (custom components, not HTML)
+	const jsxComponentPattern = /<([A-Z]\w+)[\s/>]/g;
+	for (const match of content.matchAll(jsxComponentPattern)) {
+		const componentName = match[1];
+		if (!importedComponents.has(componentName) && !providedComponents.has(componentName)) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+// ─── stripIncompatibleContent (internal helper) ──────────────────────────────
+
+/**
+ * Strips incompatible MDX content to produce plain markdown:
+ *   1. Removes all `import` and `export` statements
+ *   2. Removes ALL JSX component tags (uppercase): `<Foo ... />` and `<Foo>...</Foo>`
+ *   3. Removes Docusaurus admonition syntax (`:::tip`, `:::warning`, etc.)
+ *   4. Preserves code blocks, headings, paragraphs, lists, links, images, etc.
+ *
+ * Since the file is being downgraded to `.md`, no JSX components will work —
+ * so we strip them all, keeping only the text content inside open/close pairs.
+ */
+export function stripIncompatibleContent(content: string): string {
+	let result = content;
+
+	// Remove import/export lines
+	result = result.replace(/^(import|export)\s+.*$/gm, "");
+
+	// Remove self-closing JSX tags: <ComponentName ... />
+	result = result.replace(/<[A-Z]\w+\s[^>]*?\/>/g, "");
+	result = result.replace(/<[A-Z]\w+\s*\/>/g, "");
+
+	// Remove JSX open/close tags but KEEP their children content.
+	// This preserves text/code inside <Tabs><TabItem>...</TabItem></Tabs>.
+	// Process iteratively since tags may be nested.
+	let prev = "";
+	while (prev !== result) {
+		prev = result;
+		// Remove opening tags: <ComponentName ...> or <ComponentName>
+		result = result.replace(/<[A-Z]\w+(?:\s[^>]*)?>[ \t]*/g, "");
+		// Remove closing tags: </ComponentName>
+		result = result.replace(/[ \t]*<\/[A-Z]\w+>/g, "");
+	}
+
+	// Convert JSX style={{ ... }} to HTML style="..."
+	result = result.replace(/style=\{\{([^}]*)\}\}/g, (_match, inner: string) => {
+		const css = inner
+			.split(",")
+			.map((pair: string) => {
+				const [key, ...valParts] = pair.split(":");
+				if (!key || valParts.length === 0) return "";
+				const cssKey = key
+					.trim()
+					.replace(/([A-Z])/g, "-$1")
+					.toLowerCase(); // camelCase → kebab-case
+				const cssVal = valParts
+					.join(":")
+					.trim()
+					.replace(/^['"]|['"]$/g, "");
+				return `${cssKey}: ${cssVal}`;
+			})
+			.filter(Boolean)
+			.join("; ");
+		return `style="${css}"`;
+	});
+
+	// Remove Docusaurus admonition fences (:::tip, :::warning, etc.)
+	result = result.replace(/^:::.*$/gm, "");
+
+	// Clean up excessive blank lines left by removals
+	result = result.replace(/\n{3,}/g, "\n\n");
+
+	return `${result.trim()}\n`;
+}
+
+// ─── canCompileMdx (internal helper) ─────────────────────────────────────────
+
+/**
+ * Attempts to compile MDX content using `@mdx-js/mdx`. Returns `true` if
+ * the content compiles without errors, `false` otherwise.
+ *
+ * This is the second-layer check: only called on files already flagged by
+ * the fast regex scan. It avoids false positives by confirming the content
+ * truly can't be compiled.
+ */
+async function canCompileMdx(content: string): Promise<boolean> {
+	try {
+		const { compile } = await import("@mdx-js/mdx");
+		await compile(content, { development: false });
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+// ─── downgradeMdx (internal helper) ──────────────────────────────────────────
+
+/**
+ * Downgrades an incompatible `.mdx` file to `.md`: strips imports and
+ * unsupported JSX, writes the cleaned content, and records it in the result.
+ */
+async function downgradeMdx(
+	relPath: string,
+	mdxContent: string,
+	contentDir: string,
+	result: MirrorResult,
+): Promise<void> {
+	const cleaned = stripIncompatibleContent(mdxContent);
+	const mdRelPath = relPath.replace(/\.mdx$/, ".md");
+	const destPath = join(contentDir, mdRelPath);
+	await ensureDir(destPath);
+	await writeFile(destPath, cleaned, "utf-8");
+	result.markdownFiles.push(mdRelPath);
+	result.downgradedCount++;
+}
+
+// ─── clearDir ────────────────────────────────────────────────────────────────
+
+/**
+ * Removes all contents inside `dir` but keeps the directory itself.
+ * Used to clear stale content from a previous run before mirroring.
+ */
+export async function clearDir(dir: string): Promise<void> {
+	let entries: string[];
+	try {
+		entries = await readdir(dir);
+	} catch {
+		return;
+	}
+	await Promise.all(entries.map((entry) => rm(join(dir, entry), { recursive: true, force: true })));
+}
+
+// ─── mirrorContent ────────────────────────────────────────────────────────────
+
+/**
+ * Clears stale content from `contentDir`, then recursively walks `sourceRoot`,
+ * classifies every file, and copies markdown and image files to the
+ * corresponding relative path inside the content directory.
+ *
+ * Skips the `.jolli-site/` directory to avoid infinite recursion (4.7).
+ *
+ * Returns a `MirrorResult` with the relative paths of all classified files.
+ */
+export async function mirrorContent(
+	sourceRoot: string,
+	contentDir: string,
+	pathMappings?: PathMappings,
+	publicDir?: string,
+	contentRules?: ContentRules,
+): Promise<MirrorResult> {
+	// Clear stale content from previous runs
+	await clearDir(contentDir);
+
+	const result: MirrorResult = {
+		markdownFiles: [],
+		openapiFiles: [],
+		imageFiles: [],
+		ignoredFiles: [],
+		downgradedCount: 0,
+	};
+
+	await walkDir(sourceRoot, sourceRoot, contentDir, result, pathMappings, contentRules);
+
+	// If no index.md exists at root, look for a file with `slug: /` frontmatter
+	// (common in Docusaurus projects) and rename it to index.md
+	result.renamedToIndex = await ensureIndexPage(contentDir, result);
+
+	// Resolve missing images: check all markdown image references,
+	// generate placeholders for images that don't exist in contentDir
+	if (publicDir) {
+		const pendingAssets: PendingAsset[] = [];
+		await resolveMissingImages(sourceRoot, contentDir, publicDir, result, pendingAssets);
+	}
+
+	return result;
+}
+
+// ─── resolveMissingImages ─────────────────────────────────────────────────────
+
+type PendingAsset = { asset: Awaited<ReturnType<typeof resolveExternalImage>>; publicDir: string };
+
+/**
+ * Scans all mirrored markdown files for image references. If a referenced
+ * image doesn't exist in contentDir, tries to find it externally or
+ * generates a placeholder SVG.
+ *
+ * Modifies the markdown file in-place to point to the resolved image.
+ */
+async function resolveMissingImages(
+	sourceRoot: string,
+	contentDir: string,
+	publicDir: string,
+	result: MirrorResult,
+	pendingAssets: PendingAsset[],
+): Promise<void> {
+	for (const mdRelPath of result.markdownFiles) {
+		const mdAbsPath = join(contentDir, mdRelPath);
+		let content: string;
+		try {
+			content = await readFile(mdAbsPath, "utf-8");
+		} catch {
+			continue;
+		}
+
+		const mdDir = dirname(mdAbsPath);
+		let modified = false;
+		const originalMdDir = join(sourceRoot, dirname(mdRelPath));
+
+		/** Resolves a single image src. Returns new src or original if OK. */
+		const resolveImage = (src: string): string | null => {
+			if (!IMAGE_EXT.test(src)) return null;
+			if (src.startsWith("http")) return null;
+
+			if (src.startsWith("/")) {
+				// Absolute path (e.g. /img/foo.png) — Docusaurus serves from static/
+				// Try to find in sourceRoot's parent static/ dir
+				const asset = resolveExternalImage(src.slice(1), dirname(sourceRoot), sourceRoot);
+				pendingAssets.push({ asset, publicDir });
+				modified = true;
+				return `/${asset.publicPath}`;
+			}
+
+			const resolvedPath = resolve(mdDir, src);
+			if (existsSync(resolvedPath)) return null; // Exists, no action
+
+			// Missing relative image — try external resolution
+			const asset = resolveExternalImage(src, originalMdDir, sourceRoot);
+			pendingAssets.push({ asset, publicDir });
+			modified = true;
+			return `/${asset.publicPath}`;
+		};
+
+		// Check markdown images: ![alt](path)
+		let newContent = content.replace(/!\[([^\]]*)\]\(([^)]+)\)/g, (match, alt: string, src: string) => {
+			const newSrc = resolveImage(src);
+			return newSrc ? `![${alt}](${newSrc})` : match;
+		});
+
+		// Check HTML images: <img src="path">
+		newContent = newContent.replace(/<img\s([^>]*?)src=["']([^"']+)["']/g, (match, attrs: string, src: string) => {
+			const newSrc = resolveImage(src);
+			return newSrc ? `<img ${attrs}src="${newSrc}"` : match;
+		});
+
+		if (modified) {
+			await writeFile(mdAbsPath, newContent, "utf-8");
+		}
+	}
+
+	// Copy all pending external assets / generate placeholders
+	for (const { asset, publicDir: pd } of pendingAssets) {
+		await copyExternalAsset(asset, pd);
+	}
+}
+
+// ─── ensureIndexPage (internal helper) ───────────────────────────────────────
+
+/**
+ * If `contentDir` has no `index.md` or `index.mdx`, scans mirrored markdown
+ * files for one with `slug: /` in its frontmatter and copies it as
+ * `index.md` in the content root. This handles Docusaurus projects that use
+ * `slug: /` to designate the homepage instead of an `index.md` file.
+ */
+/**
+ * Returns the old filename (without extension) that was renamed to index.md,
+ * or `undefined` if no rename occurred.
+ */
+async function ensureIndexPage(contentDir: string, result: MirrorResult): Promise<string | undefined> {
+	const hasIndex = result.markdownFiles.some((f) => f === "index.md" || f === "index.mdx");
+	if (hasIndex) return undefined;
+
+	// Only check root-level markdown files
+	const rootFiles = result.markdownFiles.filter((f) => !f.includes("/") && !f.includes("\\"));
+	for (const relPath of rootFiles) {
+		try {
+			const content = await readFile(join(contentDir, relPath), "utf-8");
+			if (/^slug:\s*\/\s*$/m.test(content)) {
+				await rename(join(contentDir, relPath), join(contentDir, "index.md"));
+				const oldKey = relPath.replace(/\.(md|mdx)$/, "");
+				// Replace the original entry with index.md
+				const idx = result.markdownFiles.indexOf(relPath);
+				if (idx !== -1) result.markdownFiles[idx] = "index.md";
+				else result.markdownFiles.push("index.md");
+				return oldKey;
+			}
+		} catch {}
+	}
+	return undefined;
+}
+
+// ─── walkDir (internal recursive helper) ─────────────────────────────────────
+
+async function walkDir(
+	currentDir: string,
+	sourceRoot: string,
+	contentDir: string,
+	result: MirrorResult,
+	pathMappings?: PathMappings,
+	contentRules?: ContentRules,
+): Promise<void> {
+	let entries: string[];
+	try {
+		entries = await readdir(currentDir);
+	} catch {
+		// If we can't read a directory, skip it silently
+		return;
+	}
+
+	for (const entry of entries) {
+		const fullPath = join(currentDir, entry);
+
+		// 4.7 — Skip .jolli-site/ to avoid infinite recursion
+		if (entry === ".jolli-site") {
+			continue;
+		}
+
+		let entryStat: Awaited<ReturnType<typeof stat>>;
+		try {
+			entryStat = await stat(fullPath);
+		} catch {
+			continue;
+		}
+
+		if (entryStat.isDirectory()) {
+			await walkDir(fullPath, sourceRoot, contentDir, result, pathMappings, contentRules);
+		} else if (entryStat.isFile()) {
+			await processFile(fullPath, sourceRoot, contentDir, result, pathMappings, contentRules);
+		}
+	}
+}
+
+// ─── processFile (internal helper) ───────────────────────────────────────────
+
+async function processFile(
+	fullPath: string,
+	sourceRoot: string,
+	contentDir: string,
+	result: MirrorResult,
+	pathMappings?: PathMappings,
+	contentRules?: ContentRules,
+): Promise<void> {
+	const originalRelPath = relative(sourceRoot, fullPath);
+	const relPath = applyPathMapping(originalRelPath, pathMappings);
+	const ext = extname(fullPath).toLowerCase();
+
+	// For potential OpenAPI files, read content for classification
+	let content: string | undefined;
+	if (ext === ".json" || ext === ".yaml" || ext === ".yml") {
+		try {
+			content = await readFile(fullPath, "utf-8");
+		} catch {
+			// If we can't read the file, treat as ignored
+			result.ignoredFiles.push(relPath);
+			return;
+		}
+	}
+
+	const fileType = classifyFile(fullPath, content);
+
+	switch (fileType) {
+		case "markdown": {
+			if (ext === ".mdx") {
+				let mdxContent: string;
+				try {
+					mdxContent = await readFile(fullPath, "utf-8");
+				} catch {
+					result.ignoredFiles.push(relPath);
+					return;
+				}
+
+				// Layer 1: fast regex check for incompatible imports / unknown JSX
+				// Catches missing modules that webpack would fail on.
+				if (hasIncompatibleImports(mdxContent, contentRules)) {
+					await downgradeMdx(relPath, mdxContent, contentDir, result);
+					return;
+				}
+
+				// Layer 2: MDX compiler check for syntax errors the regex can't detect
+				// (e.g. malformed JSX, invalid expressions). Only runs on files
+				// that passed the regex check.
+				if (!(await canCompileMdx(mdxContent))) {
+					await downgradeMdx(relPath, mdxContent, contentDir, result);
+					return;
+				}
+			}
+			result.markdownFiles.push(relPath);
+			const destPath = join(contentDir, relPath);
+			await ensureDir(destPath);
+
+			// If the file was remapped, rewrite relative image paths
+			// to account for the new directory location.
+			if (originalRelPath !== relPath) {
+				let mdContent: string;
+				try {
+					mdContent = await readFile(fullPath, "utf-8");
+				} catch {
+					await copyFile(fullPath, destPath);
+					break;
+				}
+				const rewritten = rewriteRelativeImagePaths(mdContent, originalRelPath, relPath, pathMappings);
+				await writeFile(destPath, rewritten, "utf-8");
+			} else {
+				await copyFile(fullPath, destPath);
+			}
+			break;
+		}
+		case "image": {
+			// Copy images to contentDir at the mapped path (same mapping as markdown).
+			// Nextra's staticImage resolves relative imports via webpack,
+			// so images must be next to the markdown files that reference them.
+			result.imageFiles.push(relPath);
+			const destPath = join(contentDir, relPath);
+			await ensureDir(destPath);
+			await copyFile(fullPath, destPath);
+			break;
+		}
+		case "openapi": {
+			result.openapiFiles.push(relPath);
+			// OpenAPI files are not copied directly — they are rendered as .mdx pages
+			// by OpenApiRenderer. We just record them here.
+			break;
+		}
+		case "ignored": {
+			result.ignoredFiles.push(relPath);
+			break;
+		}
+	}
+}
+
+// ─── ensureDir (internal helper) ─────────────────────────────────────────────
+
+/** Ensures the parent directory of `filePath` exists. */
+async function ensureDir(filePath: string): Promise<void> {
+	const dir = dirname(filePath);
+	if (dir) {
+		await mkdir(dir, { recursive: true });
+	}
+}

--- a/cli/src/site/DocusaurusConverter.test.ts
+++ b/cli/src/site/DocusaurusConverter.test.ts
@@ -1,0 +1,391 @@
+/**
+ * Tests for DocusaurusConverter — converts Docusaurus sidebars.js to SidebarOverrides.
+ */
+
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+async function makeTempDir(): Promise<string> {
+	return mkdtemp(join(tmpdir(), "jolli-docusaurus-test-"));
+}
+
+describe("DocusaurusConverter.convertDocusaurusSidebar", () => {
+	let tempDir: string;
+
+	beforeEach(async () => {
+		tempDir = await makeTempDir();
+	});
+
+	afterEach(async () => {
+		await rm(tempDir, { recursive: true, force: true });
+	});
+
+	it("converts a simple sidebar with string items", async () => {
+		const { convertDocusaurusSidebar } = await import("./DocusaurusConverter.js");
+		const sidebarPath = join(tempDir, "sidebars.js");
+		await writeFile(sidebarPath, `module.exports = { docsSidebar: ['intro', 'getting-started'] }`, "utf-8");
+
+		const result = await convertDocusaurusSidebar(sidebarPath);
+
+		expect(result.sidebar["/"]).toBeDefined();
+		expect(Object.keys(result.sidebar["/"])).toContain("intro");
+		expect(Object.keys(result.sidebar["/"])).toContain("getting-started");
+	});
+
+	it("preserves declaration order", async () => {
+		const { convertDocusaurusSidebar } = await import("./DocusaurusConverter.js");
+		const sidebarPath = join(tempDir, "sidebars.js");
+		await writeFile(sidebarPath, `module.exports = { docsSidebar: ['zebra', 'alpha', 'middle'] }`, "utf-8");
+
+		const result = await convertDocusaurusSidebar(sidebarPath);
+
+		const keys = Object.keys(result.sidebar["/"]);
+		expect(keys).toEqual(["zebra", "alpha", "middle"]);
+	});
+
+	it("converts category items with custom labels", async () => {
+		const { convertDocusaurusSidebar } = await import("./DocusaurusConverter.js");
+		const sidebarPath = join(tempDir, "sidebars.js");
+		await writeFile(
+			sidebarPath,
+			`module.exports = { docsSidebar: [
+				{ type: 'category', label: 'Install Feldera', link: { type: 'doc', id: 'get-started/index' }, items: ['get-started/docker'] }
+			] }`,
+			"utf-8",
+		);
+
+		const result = await convertDocusaurusSidebar(sidebarPath);
+
+		expect(result.sidebar["/"]["get-started"]).toBe("Install Feldera");
+		expect(result.sidebar["/get-started"]).toBeDefined();
+		expect(result.sidebar["/get-started"].docker).toBe("Docker");
+	});
+
+	it("converts doc items with custom labels", async () => {
+		const { convertDocusaurusSidebar } = await import("./DocusaurusConverter.js");
+		const sidebarPath = join(tempDir, "sidebars.js");
+		await writeFile(
+			sidebarPath,
+			`module.exports = { docsSidebar: [
+				{ type: 'doc', id: 'pipelines/configuration', label: 'Settings' }
+			] }`,
+			"utf-8",
+		);
+
+		const result = await convertDocusaurusSidebar(sidebarPath);
+
+		expect(result.sidebar["/"].configuration).toBe("Settings");
+	});
+
+	it("converts link items to objects with href", async () => {
+		const { convertDocusaurusSidebar } = await import("./DocusaurusConverter.js");
+		const sidebarPath = join(tempDir, "sidebars.js");
+		await writeFile(
+			sidebarPath,
+			`module.exports = { docsSidebar: [
+				{ type: 'link', label: 'Python SDK', href: 'pathname:///python/' }
+			] }`,
+			"utf-8",
+		);
+
+		const result = await convertDocusaurusSidebar(sidebarPath);
+
+		const entry = result.sidebar["/"]["python-sdk"];
+		expect(entry).toBeDefined();
+		expect(typeof entry).toBe("object");
+		if (typeof entry === "object") {
+			expect(entry.title).toBe("Python SDK");
+			expect(entry.href).toBe("/python/");
+		}
+	});
+
+	it("returns empty object for invalid sidebar file", async () => {
+		const { convertDocusaurusSidebar } = await import("./DocusaurusConverter.js");
+		const sidebarPath = join(tempDir, "sidebars.js");
+		await writeFile(sidebarPath, "this is not valid js }{}{", "utf-8");
+
+		const result = await convertDocusaurusSidebar(sidebarPath);
+
+		expect(result.sidebar).toEqual({});
+		expect(result.pathMappings).toEqual({});
+	});
+
+	it("handles nested categories", async () => {
+		const { convertDocusaurusSidebar } = await import("./DocusaurusConverter.js");
+		const sidebarPath = join(tempDir, "sidebars.js");
+		await writeFile(
+			sidebarPath,
+			`module.exports = { docsSidebar: [
+				{ type: 'category', label: 'SQL', link: { type: 'doc', id: 'sql/index' }, items: [
+					'sql/grammar',
+					{ type: 'category', label: 'Operations', link: { type: 'doc', id: 'sql/operations/index' }, items: [
+						'sql/operations/select'
+					] }
+				] }
+			] }`,
+			"utf-8",
+		);
+
+		const result = await convertDocusaurusSidebar(sidebarPath);
+
+		expect(result.sidebar["/"]).toBeDefined();
+		expect(result.sidebar["/sql"]).toBeDefined();
+		expect(result.sidebar["/sql"].grammar).toBe("Grammar");
+		expect(result.sidebar["/sql"].operations).toBe("Operations");
+		expect(result.sidebar["/sql/operations"]).toBeDefined();
+		expect(result.sidebar["/sql/operations"].select).toBe("Select");
+	});
+
+	it("generates pathMappings when doc is outside logical dir", async () => {
+		const { convertDocusaurusSidebar } = await import("./DocusaurusConverter.js");
+		const sidebarPath = join(tempDir, "sidebars.js");
+		await writeFile(
+			sidebarPath,
+			`module.exports = { docsSidebar: [
+				{ type: 'category', label: 'Tutorials', link: { type: 'doc', id: 'tutorials/index' }, items: [
+					{ type: 'doc', id: 'use_cases/fraud/intro', label: 'Fraud Detection' }
+				] }
+			] }`,
+			"utf-8",
+		);
+
+		const result = await convertDocusaurusSidebar(sidebarPath);
+
+		expect(Object.keys(result.pathMappings).length).toBeGreaterThan(0);
+	});
+
+	it("flattens virtual groupings when category dir matches parent", async () => {
+		const { convertDocusaurusSidebar } = await import("./DocusaurusConverter.js");
+		const sidebarPath = join(tempDir, "sidebars.js");
+		// Virtual grouping: "Overview" category within sql/ whose items are also in sql/
+		await writeFile(
+			sidebarPath,
+			`module.exports = { docsSidebar: [
+				{ type: 'category', label: 'SQL', link: { type: 'doc', id: 'sql/index' }, items: [
+					{ type: 'category', label: 'Overview', items: ['sql/intro', 'sql/syntax'] }
+				] }
+			] }`,
+			"utf-8",
+		);
+
+		const result = await convertDocusaurusSidebar(sidebarPath);
+
+		// Virtual grouping should be flattened — items should be in /sql, not /sql/overview
+		expect(result.sidebar["/sql"]).toBeDefined();
+		expect(result.sidebar["/sql"].intro).toBeDefined();
+	});
+
+	it("handles category without link.id using first item path", async () => {
+		const { convertDocusaurusSidebar } = await import("./DocusaurusConverter.js");
+		const sidebarPath = join(tempDir, "sidebars.js");
+		await writeFile(
+			sidebarPath,
+			`module.exports = { docsSidebar: [
+				{ type: 'category', label: 'Guides', items: ['guides/install', 'guides/config'] }
+			] }`,
+			"utf-8",
+		);
+
+		const result = await convertDocusaurusSidebar(sidebarPath);
+
+		expect(result.sidebar["/"]).toBeDefined();
+		expect(result.sidebar["/"].guides).toBe("Guides");
+	});
+
+	it("does not duplicate sidebar entries", async () => {
+		const { convertDocusaurusSidebar } = await import("./DocusaurusConverter.js");
+		const sidebarPath = join(tempDir, "sidebars.js");
+		await writeFile(sidebarPath, `module.exports = { docsSidebar: ['intro', 'intro'] }`, "utf-8");
+
+		const result = await convertDocusaurusSidebar(sidebarPath);
+
+		const introEntries = Object.entries(result.sidebar["/"]).filter(([k]) => k === "intro");
+		expect(introEntries.length).toBe(1);
+	});
+
+	it("handles nonexistent sidebar file gracefully", async () => {
+		const { convertDocusaurusSidebar } = await import("./DocusaurusConverter.js");
+
+		const result = await convertDocusaurusSidebar(join(tempDir, "nonexistent.js"));
+
+		expect(result.sidebar).toEqual({});
+		expect(result.pathMappings).toEqual({});
+	});
+});
+
+// ─── extractFaviconFromConfig ────────────────────────────────────────────────
+
+describe("DocusaurusConverter.extractFaviconFromConfig", () => {
+	let tempDir: string;
+
+	beforeEach(async () => {
+		tempDir = await makeTempDir();
+	});
+
+	afterEach(async () => {
+		await rm(tempDir, { recursive: true, force: true });
+	});
+
+	it("extracts favicon path from config file", async () => {
+		const { extractFaviconFromConfig } = await import("./DocusaurusConverter.js");
+		const configPath = join(tempDir, "docusaurus.config.ts");
+		await writeFile(configPath, `export default { favicon: 'img/favicon.ico' }`, "utf-8");
+
+		const result = extractFaviconFromConfig(configPath);
+
+		expect(result).toBeDefined();
+		expect(result).toContain("static");
+		expect(result).toContain("favicon.ico");
+	});
+
+	it("extracts favicon with double quotes", async () => {
+		const { extractFaviconFromConfig } = await import("./DocusaurusConverter.js");
+		const configPath = join(tempDir, "docusaurus.config.ts");
+		await writeFile(configPath, `export default { favicon: "img/favicon.ico" }`, "utf-8");
+
+		const result = extractFaviconFromConfig(configPath);
+
+		expect(result).toBeDefined();
+		expect(result).toContain("favicon.ico");
+	});
+
+	it("returns undefined when no favicon in config", async () => {
+		const { extractFaviconFromConfig } = await import("./DocusaurusConverter.js");
+		const configPath = join(tempDir, "docusaurus.config.ts");
+		await writeFile(configPath, `export default { title: 'My Site' }`, "utf-8");
+
+		const result = extractFaviconFromConfig(configPath);
+
+		expect(result).toBeUndefined();
+	});
+
+	it("returns undefined for nonexistent config file", async () => {
+		const { extractFaviconFromConfig } = await import("./DocusaurusConverter.js");
+
+		const result = extractFaviconFromConfig(join(tempDir, "nonexistent.ts"));
+
+		expect(result).toBeUndefined();
+	});
+});
+
+// ─── Additional branch coverage tests ────────────────────────────────────────
+
+describe("DocusaurusConverter branch coverage", () => {
+	let tempDir: string;
+
+	beforeEach(async () => {
+		tempDir = await makeTempDir();
+	});
+
+	afterEach(async () => {
+		await rm(tempDir, { recursive: true, force: true });
+	});
+
+	it("handles doc item without custom label", async () => {
+		const { convertDocusaurusSidebar } = await import("./DocusaurusConverter.js");
+		const sidebarPath = join(tempDir, "sidebars.js");
+		await writeFile(
+			sidebarPath,
+			`module.exports = { docsSidebar: [{ type: 'doc', id: 'getting-started' }] }`,
+			"utf-8",
+		);
+
+		const result = await convertDocusaurusSidebar(sidebarPath);
+
+		expect(result.sidebar["/"]["getting-started"]).toBe("Getting Started");
+	});
+
+	it("handles category with doc item containing nested path", async () => {
+		const { convertDocusaurusSidebar } = await import("./DocusaurusConverter.js");
+		const sidebarPath = join(tempDir, "sidebars.js");
+		await writeFile(
+			sidebarPath,
+			`module.exports = { docsSidebar: [
+				{ type: 'doc', id: 'guides/installation', label: 'Install' }
+			] }`,
+			"utf-8",
+		);
+
+		const result = await convertDocusaurusSidebar(sidebarPath);
+
+		expect(result.sidebar["/"].installation).toBe("Install");
+	});
+
+	it("handles category resolved by first doc item", async () => {
+		const { convertDocusaurusSidebar } = await import("./DocusaurusConverter.js");
+		const sidebarPath = join(tempDir, "sidebars.js");
+		await writeFile(
+			sidebarPath,
+			`module.exports = { docsSidebar: [
+				{ type: 'category', label: 'Tutorials', items: [
+					{ type: 'doc', id: 'tutorials/basics' }
+				] }
+			] }`,
+			"utf-8",
+		);
+
+		const result = await convertDocusaurusSidebar(sidebarPath);
+
+		expect(result.sidebar["/"].tutorials).toBe("Tutorials");
+	});
+
+	it("handles category with label-only fallback when no items have paths", async () => {
+		const { convertDocusaurusSidebar } = await import("./DocusaurusConverter.js");
+		const sidebarPath = join(tempDir, "sidebars.js");
+		await writeFile(
+			sidebarPath,
+			`module.exports = { docsSidebar: [
+				{ type: 'category', label: 'My Category', items: [
+					{ type: 'link', label: 'External', href: 'https://example.com' }
+				] }
+			] }`,
+			"utf-8",
+		);
+
+		const result = await convertDocusaurusSidebar(sidebarPath);
+
+		expect(result.sidebar["/"]["my-category"]).toBe("My Category");
+	});
+
+	it("handles index doc IDs in lastSegment", async () => {
+		const { convertDocusaurusSidebar } = await import("./DocusaurusConverter.js");
+		const sidebarPath = join(tempDir, "sidebars.js");
+		await writeFile(sidebarPath, `module.exports = { docsSidebar: ['guides/index'] }`, "utf-8");
+
+		const result = await convertDocusaurusSidebar(sidebarPath);
+
+		expect(result.sidebar["/"].guides).toBeDefined();
+	});
+
+	it("handles link items with pathname prefix", async () => {
+		const { convertDocusaurusSidebar } = await import("./DocusaurusConverter.js");
+		const sidebarPath = join(tempDir, "sidebars.js");
+		await writeFile(
+			sidebarPath,
+			`module.exports = { docsSidebar: [
+				{ type: 'link', label: 'API Docs', href: 'pathname:///api/reference' }
+			] }`,
+			"utf-8",
+		);
+
+		const result = await convertDocusaurusSidebar(sidebarPath);
+
+		const entry = result.sidebar["/"]["api-docs"];
+		expect(typeof entry).toBe("object");
+		if (typeof entry === "object") {
+			expect(entry.href).toBe("/api/reference");
+		}
+	});
+
+	it("handles sidebar with no array values", async () => {
+		const { convertDocusaurusSidebar } = await import("./DocusaurusConverter.js");
+		const sidebarPath = join(tempDir, "sidebars.js");
+		await writeFile(sidebarPath, `module.exports = { docs: 'auto' }`, "utf-8");
+
+		const result = await convertDocusaurusSidebar(sidebarPath);
+
+		expect(result.sidebar).toEqual({});
+	});
+});

--- a/cli/src/site/DocusaurusConverter.ts
+++ b/cli/src/site/DocusaurusConverter.ts
@@ -1,0 +1,308 @@
+/**
+ * DocusaurusConverter — converts a Docusaurus `sidebars.js` file into
+ * jolli's `SidebarOverrides` + `PathMappings` for `site.json`.
+ *
+ * The sidebar defines the LOGICAL navigation structure. When it differs from
+ * the physical folder structure (e.g. `sql/` grouped under `pipelines`),
+ * pathMappings records how to remap files so the content/ directory matches
+ * the sidebar's logical structure.
+ */
+
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { pathToFileURL } from "node:url";
+import type { PathMappings, SidebarItemValue, SidebarOverrides } from "./Types.js";
+
+// ─── Docusaurus sidebar types (subset) ───────────────────────────────────────
+
+type DocSidebarItem = string | DocCategory | DocDoc | DocLink;
+
+interface DocCategory {
+	type: "category";
+	label: string;
+	items: DocSidebarItem[];
+	link?: { type: string; id?: string };
+}
+
+interface DocDoc {
+	type: "doc";
+	id: string;
+	label?: string;
+}
+
+interface DocLink {
+	type: "link";
+	label: string;
+	href: string;
+}
+
+// ─── ConversionResult ────────────────────────────────────────────────────────
+
+export interface ConversionResult {
+	sidebar: SidebarOverrides;
+	pathMappings: PathMappings;
+	favicon?: string;
+}
+
+// ─── convertDocusaurusSidebar ────────────────────────────────────────────────
+
+/**
+ * Loads a Docusaurus `sidebars.js` file and converts it to sidebar overrides
+ * and path mappings.
+ *
+ * The sidebar overrides define the logical navigation structure.
+ * The path mappings tell ContentMirror how to remap source folders to match
+ * the sidebar's logical structure.
+ */
+export async function convertDocusaurusSidebar(sidebarPath: string): Promise<ConversionResult> {
+	const sidebarModule = await loadSidebarFile(sidebarPath);
+
+	const sidebarEntries = Object.values(sidebarModule);
+	const items = sidebarEntries.find((v) => Array.isArray(v)) as DocSidebarItem[] | undefined;
+
+	if (!items) {
+		console.warn("[jolli] Could not find sidebar items in the Docusaurus config.");
+		return { sidebar: {}, pathMappings: {} };
+	}
+
+	const sidebar = new Map<string, [string, SidebarItemValue][]>();
+	const pathMappings: PathMappings = {};
+
+	collectEntries(items, "/", sidebar, pathMappings);
+
+	// Convert Map to SidebarOverrides
+	const sidebarResult: SidebarOverrides = {};
+	for (const [dirPath, entries] of sidebar) {
+		const obj: Record<string, SidebarItemValue> = {};
+		for (const [key, value] of entries) {
+			obj[key] = value;
+		}
+		sidebarResult[dirPath] = obj;
+	}
+
+	return { sidebar: sidebarResult, pathMappings };
+}
+
+// ─── loadSidebarFile ─────────────────────────────────────────────────────────
+
+async function loadSidebarFile(sidebarPath: string): Promise<Record<string, unknown>> {
+	try {
+		console.log(`  Loading sidebar config: ${sidebarPath}`);
+		const fileUrl = pathToFileURL(sidebarPath).href;
+		const mod = await import(fileUrl);
+		return mod.default ?? mod;
+	} catch {
+		console.warn(`[jolli] Could not load ${sidebarPath}. Skipping sidebar conversion.`);
+		return {};
+	}
+}
+
+// ─── collectEntries ──────────────────────────────────────────────────────────
+
+/**
+ * Walks the Docusaurus sidebar tree. Entries are placed into the sidebar
+ * at their LOGICAL position (matching the sidebar hierarchy). When a
+ * category's actual filesystem path differs from its logical path,
+ * a pathMapping is recorded.
+ *
+ * @param items       - Docusaurus sidebar items
+ * @param logicalDir  - The logical directory path in the sidebar tree (e.g. "/pipelines")
+ * @param sidebar     - Sidebar entries being built
+ * @param pathMappings - Path remappings being built
+ */
+function collectEntries(
+	items: DocSidebarItem[],
+	logicalDir: string,
+	sidebar: Map<string, [string, SidebarItemValue][]>,
+	pathMappings: PathMappings,
+): void {
+	for (const item of items) {
+		if (typeof item === "string") {
+			const key = lastSegment(item);
+			addSidebarEntry(sidebar, logicalDir, key, toTitleCase(key));
+			addDocPathMapping(item, logicalDir, pathMappings);
+		} else if (item.type === "doc") {
+			const key = lastSegment(item.id);
+			addSidebarEntry(sidebar, logicalDir, key, item.label ?? toTitleCase(key));
+			addDocPathMapping(item.id, logicalDir, pathMappings);
+		} else if (item.type === "category") {
+			const actualDir = resolveCategoryActualDir(item);
+			const parentActualDir = logicalToActualDir(logicalDir, pathMappings);
+
+			// If this category's actual dir is the same as the parent's,
+			// it's a virtual grouping (e.g. "Operations" inside sql/).
+			// Don't create a subfolder — just add items to the parent dir.
+			if (actualDir === parentActualDir) {
+				collectEntries(item.items, logicalDir, sidebar, pathMappings);
+				continue;
+			}
+
+			const catKey = resolveCategoryKey(item);
+
+			// Add category to current logical dir's sidebar
+			addSidebarEntry(sidebar, logicalDir, catKey, item.label);
+
+			// The logical path for children
+			const logicalChildDir = logicalDir === "/" ? `/${catKey}` : `${logicalDir}/${catKey}`;
+
+			// If actual filesystem dir differs from logical dir, record mapping
+			const actualRel = actualDir.slice(1);
+			const logicalRel = logicalChildDir.slice(1);
+
+			if (actualRel && logicalRel && actualRel !== logicalRel) {
+				pathMappings[actualRel] = logicalRel;
+			}
+
+			// Recurse — children go into logical child dir
+			collectEntries(item.items, logicalChildDir, sidebar, pathMappings);
+		} else if (item.type === "link") {
+			const key = slugify(item.label);
+			addSidebarEntry(sidebar, logicalDir, key, {
+				title: item.label,
+				href: item.href.replace(/^pathname:\/\//, ""),
+			});
+		}
+	}
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function addSidebarEntry(
+	sidebar: Map<string, [string, SidebarItemValue][]>,
+	dirPath: string,
+	key: string,
+	value: SidebarItemValue,
+): void {
+	if (!sidebar.has(dirPath)) {
+		sidebar.set(dirPath, []);
+	}
+	const entries = sidebar.get(dirPath) ?? [];
+	if (!entries.some(([k]) => k === key)) {
+		entries.push([key, value]);
+	}
+}
+
+/** Gets the last path segment, handling "index" specially. */
+function lastSegment(docId: string): string {
+	const parts = docId.split("/");
+	const last = parts[parts.length - 1];
+	if (last === "index" && parts.length > 1) {
+		return parts[parts.length - 2];
+	}
+	return last;
+}
+
+/**
+ * Determines the sidebar key for a category.
+ * Uses link.id, first item's path prefix, or slugified label.
+ */
+function resolveCategoryKey(cat: DocCategory): string {
+	// Use the last segment of the actual filesystem directory.
+	// This determines what folder name this category maps to.
+	const actualDir = resolveCategoryActualDir(cat);
+	const segments = actualDir.split("/").filter(Boolean);
+	return segments[segments.length - 1] || slugify(cat.label);
+}
+
+/**
+ * Determines the ACTUAL filesystem directory for a category
+ * (from its link.id or first item's path).
+ */
+function resolveCategoryActualDir(cat: DocCategory): string {
+	if (cat.link?.id) {
+		// link.id is a doc path like "use_cases/batch/intro" or "tutorials/basics/index"
+		// The directory is everything except the last segment (the filename)
+		const parts = cat.link.id.split("/");
+		parts.pop(); // Remove the filename (intro, index, etc.)
+		if (parts.length > 0) return `/${parts.join("/")}`;
+	}
+	const firstItem = cat.items[0];
+	if (typeof firstItem === "string") {
+		const parts = firstItem.split("/");
+		if (parts.length > 1) return `/${parts.slice(0, -1).join("/")}`;
+	} else if (firstItem && "id" in firstItem && firstItem.id) {
+		const parts = firstItem.id.split("/");
+		if (parts.length > 1) return `/${parts.slice(0, -1).join("/")}`;
+	}
+	return `/${slugify(cat.label)}`;
+}
+
+/**
+ * Converts a logical dir path back to the actual filesystem dir using
+ * known path mappings. Used to detect virtual groupings.
+ */
+function logicalToActualDir(logicalDir: string, pathMappings: PathMappings): string {
+	const logicalRel = logicalDir.slice(1); // Strip leading "/"
+	if (!logicalRel) return "/";
+
+	// Check if any mapping target matches this logical dir
+	for (const [source, target] of Object.entries(pathMappings)) {
+		if (target === logicalRel) return `/${source}`;
+	}
+
+	return logicalDir;
+}
+
+/**
+ * For a doc ID like "use_cases/fraud_detection/fraud_detection" in logical dir "/tutorials",
+ * checks if the doc's actual parent directory is outside the logical dir.
+ * If so, adds a folder-level pathMapping.
+ *
+ * Only generates mappings when the doc's actual path is in a DIFFERENT
+ * top-level directory than the logical dir expects. This avoids false
+ * mappings for docs that are already in the correct directory.
+ */
+function addDocPathMapping(docId: string, logicalDir: string, pathMappings: PathMappings): void {
+	const parts = docId.split("/");
+	if (parts.length < 2) return; // Root-level doc, no remapping needed
+
+	const actualDir = parts.slice(0, -1).join("/"); // "use_cases/fraud_detection"
+	const logicalDirRel = logicalDir.slice(1); // "tutorials"
+
+	// Check if the doc's actual path starts with the logical dir
+	// If it does, the doc is already where it should be — no mapping needed
+	if (!logicalDirRel || actualDir === logicalDirRel || actualDir.startsWith(`${logicalDirRel}/`)) {
+		return;
+	}
+
+	// The doc is in a different directory — add folder mapping
+	if (!pathMappings[actualDir]) {
+		const folderName = parts[parts.length - 2]; // "fraud_detection"
+		const logicalTarget = logicalDirRel ? `${logicalDirRel}/${folderName}` : folderName;
+		pathMappings[actualDir] = logicalTarget;
+	}
+}
+
+function slugify(label: string): string {
+	return label
+		.toLowerCase()
+		.replace(/[^a-z0-9]+/g, "-")
+		.replace(/^-|-$/g, "");
+}
+
+function toTitleCase(key: string): string {
+	return key.replace(/[-_]/g, " ").replace(/\b\w/g, (ch) => ch.toUpperCase());
+}
+
+// ─── extractFaviconFromConfig ────────────────────────────────────────────────
+
+/**
+ * Reads a Docusaurus config file and extracts the favicon path.
+ * Returns a path relative to the docs/ folder (e.g. "../static/img/favicon.ico").
+ *
+ * Uses simple regex since the config is TypeScript and can't be easily imported.
+ */
+export function extractFaviconFromConfig(configPath: string): string | undefined {
+	try {
+		const content = readFileSync(configPath, "utf-8");
+		const match = content.match(/favicon\s*:\s*["']([^"']+)["']/);
+		if (!match) return undefined;
+
+		// Docusaurus resolves favicon relative to static/ dir
+		const faviconRef = match[1]; // e.g. "img/favicon.ico"
+		const configDir = dirname(configPath);
+		return join(configDir, "static", faviconRef);
+	} catch {
+		return undefined;
+	}
+}

--- a/cli/src/site/EngineManager.test.ts
+++ b/cli/src/site/EngineManager.test.ts
@@ -1,0 +1,332 @@
+/**
+ * Tests for EngineManager — shared site engine lifecycle.
+ */
+
+import { existsSync, lstatSync, readFileSync } from "node:fs";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// ─── Mock homedir to use temp directory ─────────────────────────────────────
+
+let tempDir: string;
+
+const { mockHomeDir } = vi.hoisted(() => ({
+	mockHomeDir: { value: "" },
+}));
+
+vi.mock("node:os", async () => {
+	const actual = await vi.importActual<typeof import("node:os")>("node:os");
+	return {
+		...actual,
+		homedir: () => mockHomeDir.value,
+	};
+});
+
+// ─── Mock child_process ─────────────────────────────────────────────────────
+
+const { mockSpawnSync } = vi.hoisted(() => ({
+	mockSpawnSync: vi.fn(),
+}));
+
+vi.mock("node:child_process", () => ({
+	spawnSync: mockSpawnSync,
+}));
+
+// ─── Setup / teardown ───────────────────────────────────────────────────────
+
+beforeEach(async () => {
+	tempDir = await mkdtemp(join(tmpdir(), "jolli-engine-test-"));
+	mockHomeDir.value = tempDir;
+	mockSpawnSync.mockReturnValue({
+		status: 0,
+		stdout: Buffer.from("installed"),
+		stderr: Buffer.from(""),
+	});
+});
+
+afterEach(async () => {
+	await rm(tempDir, { recursive: true, force: true });
+	vi.restoreAllMocks();
+});
+
+// ─── computeDepsHash ────────────────────────────────────────────────────────
+
+describe("EngineManager.computeDepsHash", () => {
+	it("returns a non-empty string", async () => {
+		const { computeDepsHash } = await import("./EngineManager.js");
+		expect(computeDepsHash().length).toBeGreaterThan(0);
+	});
+
+	it("returns the same hash on repeated calls", async () => {
+		const { computeDepsHash } = await import("./EngineManager.js");
+		expect(computeDepsHash()).toBe(computeDepsHash());
+	});
+});
+
+// ─── engineNeedsInstall ─────────────────────────────────────────────────────
+
+describe("EngineManager.engineNeedsInstall", () => {
+	it("returns true when engine.json does not exist", async () => {
+		const { engineNeedsInstall } = await import("./EngineManager.js");
+		expect(engineNeedsInstall()).toBe(true);
+	});
+
+	it("returns true when node_modules does not exist", async () => {
+		const { engineNeedsInstall, getEngineDir, computeDepsHash } = await import("./EngineManager.js");
+		const engineDir = getEngineDir();
+		await mkdir(engineDir, { recursive: true });
+		await writeFile(
+			join(engineDir, "engine.json"),
+			JSON.stringify({ depsHash: computeDepsHash(), installedAt: new Date().toISOString() }),
+		);
+
+		expect(engineNeedsInstall()).toBe(true);
+	});
+
+	it("returns true when depsHash does not match", async () => {
+		const { engineNeedsInstall, getEngineDir } = await import("./EngineManager.js");
+		const engineDir = getEngineDir();
+		await mkdir(join(engineDir, "node_modules"), { recursive: true });
+		await writeFile(
+			join(engineDir, "engine.json"),
+			JSON.stringify({ depsHash: "stale-hash", installedAt: new Date().toISOString() }),
+		);
+
+		expect(engineNeedsInstall()).toBe(true);
+	});
+
+	it("returns false when engine is up to date", async () => {
+		const { engineNeedsInstall, getEngineDir, computeDepsHash } = await import("./EngineManager.js");
+		const engineDir = getEngineDir();
+		await mkdir(join(engineDir, "node_modules"), { recursive: true });
+		await writeFile(
+			join(engineDir, "engine.json"),
+			JSON.stringify({ depsHash: computeDepsHash(), installedAt: new Date().toISOString() }),
+		);
+
+		expect(engineNeedsInstall()).toBe(false);
+	});
+
+	it("returns true when engine.json is invalid JSON", async () => {
+		const { engineNeedsInstall, getEngineDir } = await import("./EngineManager.js");
+		const engineDir = getEngineDir();
+		await mkdir(join(engineDir, "node_modules"), { recursive: true });
+		await writeFile(join(engineDir, "engine.json"), "not json");
+
+		expect(engineNeedsInstall()).toBe(true);
+	});
+});
+
+// ─── ensureEngine ───────────────────────────────────────────────────────────
+
+describe("EngineManager.ensureEngine", () => {
+	it("creates engine directory and writes package.json", async () => {
+		const { ensureEngine, getEngineDir } = await import("./EngineManager.js");
+
+		const result = await ensureEngine();
+
+		expect(result.success).toBe(true);
+		expect(existsSync(join(getEngineDir(), "package.json"))).toBe(true);
+	});
+
+	it("writes engine.json after successful install", async () => {
+		const { ensureEngine, getEngineDir } = await import("./EngineManager.js");
+
+		await ensureEngine();
+
+		const engineDir = getEngineDir();
+		expect(existsSync(join(engineDir, "engine.json"))).toBe(true);
+		const meta = JSON.parse(readFileSync(join(engineDir, "engine.json"), "utf-8"));
+		expect(meta.depsHash).toBeDefined();
+		expect(meta.installedAt).toBeDefined();
+	});
+
+	it("calls npm install in the engine directory", async () => {
+		const { ensureEngine, getEngineDir } = await import("./EngineManager.js");
+
+		await ensureEngine();
+
+		expect(mockSpawnSync).toHaveBeenCalledWith(expect.any(String), ["install"], {
+			cwd: getEngineDir(),
+			stdio: "pipe",
+		});
+	});
+
+	it("returns failure when npm install fails", async () => {
+		const { ensureEngine } = await import("./EngineManager.js");
+		mockSpawnSync.mockReturnValue({
+			status: 1,
+			stdout: Buffer.from(""),
+			stderr: Buffer.from("npm ERR!"),
+		});
+
+		const result = await ensureEngine();
+
+		expect(result.success).toBe(false);
+		expect(result.output).toContain("npm ERR!");
+	});
+
+	it("skips install when engine is already up to date", async () => {
+		const { ensureEngine, getEngineDir, computeDepsHash } = await import("./EngineManager.js");
+		const engineDir = getEngineDir();
+		await mkdir(join(engineDir, "node_modules"), { recursive: true });
+		await writeFile(join(engineDir, "package.json"), "{}");
+		await writeFile(
+			join(engineDir, "engine.json"),
+			JSON.stringify({ depsHash: computeDepsHash(), installedAt: new Date().toISOString() }),
+		);
+		mockSpawnSync.mockClear();
+
+		const result = await ensureEngine();
+
+		expect(result.success).toBe(true);
+		expect(mockSpawnSync).not.toHaveBeenCalled();
+	});
+});
+
+// ─── linkEngineModules ──────────────────────────────────────────────────────
+
+describe("EngineManager.linkEngineModules", () => {
+	it("creates a symlink from buildDir/node_modules to engine", async () => {
+		const { linkEngineModules, getEngineDir } = await import("./EngineManager.js");
+		const buildDir = join(tempDir, "project");
+		await mkdir(buildDir, { recursive: true });
+		await mkdir(join(getEngineDir(), "node_modules"), { recursive: true });
+
+		await linkEngineModules(buildDir);
+
+		const linkPath = join(buildDir, "node_modules");
+		expect(existsSync(linkPath)).toBe(true);
+		expect(lstatSync(linkPath).isSymbolicLink()).toBe(true);
+	});
+
+	it("replaces existing node_modules directory with symlink", async () => {
+		const { linkEngineModules, getEngineDir } = await import("./EngineManager.js");
+		const buildDir = join(tempDir, "project");
+		await mkdir(join(buildDir, "node_modules", "some-pkg"), { recursive: true });
+		await mkdir(join(getEngineDir(), "node_modules"), { recursive: true });
+
+		await linkEngineModules(buildDir);
+
+		expect(lstatSync(join(buildDir, "node_modules")).isSymbolicLink()).toBe(true);
+	});
+
+	it("creates buildDir if it does not exist", async () => {
+		const { linkEngineModules, getEngineDir } = await import("./EngineManager.js");
+		const buildDir = join(tempDir, "nonexistent", "project");
+		await mkdir(join(getEngineDir(), "node_modules"), { recursive: true });
+
+		await linkEngineModules(buildDir);
+
+		expect(existsSync(buildDir)).toBe(true);
+	});
+
+	it("replaces existing symlink with new one", async () => {
+		const { linkEngineModules, getEngineDir } = await import("./EngineManager.js");
+		const buildDir = join(tempDir, "project");
+		await mkdir(buildDir, { recursive: true });
+		const engineDir = getEngineDir();
+		await mkdir(join(engineDir, "node_modules"), { recursive: true });
+
+		// Create initial symlink
+		await linkEngineModules(buildDir);
+		// Replace it
+		await linkEngineModules(buildDir);
+
+		expect(lstatSync(join(buildDir, "node_modules")).isSymbolicLink()).toBe(true);
+	});
+});
+
+// ─── ensureEngine lock handling ─────────────────────────────────────────────
+
+describe("EngineManager.ensureEngine lock handling", () => {
+	it("does not fail when lock file already exists but is stale", async () => {
+		const { ensureEngine, getEngineDir } = await import("./EngineManager.js");
+		const engineDir = getEngineDir();
+		await mkdir(engineDir, { recursive: true });
+		// Create a stale lock (timestamp in the past)
+		await writeFile(join(engineDir, ".install-lock"), String(Date.now() - 10 * 60 * 1000));
+
+		const result = await ensureEngine();
+
+		expect(result.success).toBe(true);
+	});
+
+	it("cleans up lock file after successful install", async () => {
+		const { ensureEngine, getEngineDir } = await import("./EngineManager.js");
+
+		await ensureEngine();
+
+		expect(existsSync(join(getEngineDir(), ".install-lock"))).toBe(false);
+	});
+
+	it("cleans up lock file even when install fails", async () => {
+		const { ensureEngine, getEngineDir } = await import("./EngineManager.js");
+		mockSpawnSync.mockReturnValue({
+			status: 1,
+			stdout: Buffer.from(""),
+			stderr: Buffer.from("fail"),
+		});
+
+		await ensureEngine();
+
+		expect(existsSync(join(getEngineDir(), ".install-lock"))).toBe(false);
+	});
+
+	it("handles null stdout and stderr from spawnSync", async () => {
+		const { ensureEngine } = await import("./EngineManager.js");
+		mockSpawnSync.mockReturnValue({
+			status: 0,
+			stdout: null,
+			stderr: null,
+		});
+
+		const result = await ensureEngine();
+
+		expect(result.success).toBe(true);
+	});
+});
+
+// ─── getEngineDir ───────────────────────────────────────────────────────────
+
+describe("EngineManager.getEngineDir", () => {
+	it("returns path under homedir/.jolli/site-engine", async () => {
+		const { getEngineDir } = await import("./EngineManager.js");
+
+		expect(getEngineDir()).toBe(join(tempDir, ".jolli", "site-engine"));
+	});
+});
+
+// ─── computeDepsHash stability ──────────────────────────────────────────────
+
+describe("EngineManager.computeDepsHash stability", () => {
+	it("returns a 16-character hex string", async () => {
+		const { computeDepsHash } = await import("./EngineManager.js");
+		expect(computeDepsHash()).toMatch(/^[0-9a-f]{16}$/);
+	});
+});
+
+// ─── ensureEngine early return path ─────────────────────────────────────────
+
+describe("EngineManager.ensureEngine lock contention early return", () => {
+	it("returns success when engine becomes ready while waiting for lock", async () => {
+		const { ensureEngine, getEngineDir, computeDepsHash } = await import("./EngineManager.js");
+		const engineDir = getEngineDir();
+		// Create a fresh lock (not stale) to simulate another process installing
+		await mkdir(engineDir, { recursive: true });
+		await writeFile(join(engineDir, ".install-lock"), String(Date.now()));
+		// Also create a valid engine so that after "waiting", engineNeedsInstall returns false
+		await mkdir(join(engineDir, "node_modules"), { recursive: true });
+		await writeFile(
+			join(engineDir, "engine.json"),
+			JSON.stringify({ depsHash: computeDepsHash(), installedAt: new Date().toISOString() }),
+		);
+
+		const result = await ensureEngine();
+
+		// Should detect engine is ready without running npm install
+		expect(result.success).toBe(true);
+	});
+});

--- a/cli/src/site/EngineManager.ts
+++ b/cli/src/site/EngineManager.ts
@@ -1,0 +1,211 @@
+/**
+ * EngineManager — manages the shared site engine at ~/.jolli/site-engine/.
+ *
+ * Instead of running `npm install` per project (~200MB each), all projects
+ * share one engine with pre-installed dependencies. Per-project build
+ * directories get a symlink: `node_modules → ~/.jolli/site-engine/node_modules`.
+ *
+ * The engine is automatically created on first use and reinstalled when
+ * dependency versions change (detected via hash comparison).
+ */
+
+import { createHash } from "node:crypto";
+import { existsSync, lstatSync, readFileSync, unlinkSync } from "node:fs";
+import { mkdir, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { NEXTRA_DEPENDENCIES, NEXTRA_DEV_DEPENDENCIES } from "./NextraProjectWriter.js";
+import type { NpmRunResult } from "./Types.js";
+
+// ─── Paths ──────────────────────────────────────────────────────────────────
+
+/** Returns the shared engine directory path. */
+export function getEngineDir(): string {
+	return join(homedir(), ".jolli", "site-engine");
+}
+
+const LOCK_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
+
+// ─── Engine metadata ────────────────────────────────────────────────────────
+
+interface EngineMetadata {
+	depsHash: string;
+	installedAt: string;
+}
+
+// ─── computeDepsHash ────────────────────────────────────────────────────────
+
+/**
+ * Computes a SHA-256 hash of the dependency version specs.
+ * Changes when dependency versions are updated in NextraProjectWriter.
+ */
+export function computeDepsHash(): string {
+	const combined = JSON.stringify({ ...NEXTRA_DEPENDENCIES, ...NEXTRA_DEV_DEPENDENCIES });
+	return createHash("sha256").update(combined).digest("hex").slice(0, 16);
+}
+
+// ─── engineNeedsInstall ─────────────────────────────────────────────────────
+
+/**
+ * Returns `true` if the shared engine needs (re)installation:
+ *   - engine.json missing
+ *   - node_modules missing
+ *   - depsHash mismatch (dependency versions changed)
+ */
+export function engineNeedsInstall(): boolean {
+	const engineDir = getEngineDir();
+	const engineJsonPath = join(engineDir, "engine.json");
+
+	if (!existsSync(engineJsonPath)) return true;
+	if (!existsSync(join(engineDir, "node_modules"))) return true;
+
+	try {
+		const meta: EngineMetadata = JSON.parse(readFileSync(engineJsonPath, "utf-8"));
+		return meta.depsHash !== computeDepsHash();
+	} catch {
+		return true;
+	}
+}
+
+// ─── ensureEngine ───────────────────────────────────────────────────────────
+
+/**
+ * Ensures the shared engine is installed and up to date.
+ * Creates the engine directory, writes package.json, runs npm install,
+ * and writes engine.json with version metadata.
+ *
+ * Uses a lockfile for parallel safety — if another process is installing,
+ * this function waits for it to finish.
+ */
+export async function ensureEngine(): Promise<NpmRunResult> {
+	if (!engineNeedsInstall()) {
+		return { success: true, output: "" };
+	}
+
+	const engineDir = getEngineDir();
+	const engineJsonPath = join(engineDir, "engine.json");
+	const lockPath = join(engineDir, ".install-lock");
+
+	// Acquire lock for parallel safety
+	const lockAcquired = await acquireLock(engineDir, lockPath);
+	if (!lockAcquired) {
+		const waited = await waitForLock(lockPath);
+		if (waited && !engineNeedsInstall()) {
+			return { success: true, output: "" };
+		}
+	}
+
+	try {
+		await mkdir(engineDir, { recursive: true });
+
+		// Write engine package.json
+		const pkg = {
+			name: "jolli-site-engine",
+			version: "0.0.1",
+			private: true,
+			dependencies: { ...NEXTRA_DEPENDENCIES },
+			devDependencies: { ...NEXTRA_DEV_DEPENDENCIES },
+		};
+		await writeFile(join(engineDir, "package.json"), `${JSON.stringify(pkg, null, 2)}\n`, "utf-8");
+
+		// Run npm install
+		const { spawnSync } = await import("node:child_process");
+		const npm = process.platform === "win32" ? /* v8 ignore next */ "npm.cmd" : "npm";
+		const result = spawnSync(npm, ["install"], {
+			cwd: engineDir,
+			stdio: "pipe",
+		});
+
+		const stdout = result.stdout ? result.stdout.toString() : "";
+		const stderr = result.stderr ? result.stderr.toString() : "";
+		const output = [stdout, stderr].filter(Boolean).join("\n");
+
+		if (result.status !== 0) {
+			return { success: false, output };
+		}
+
+		// Write engine.json metadata
+		const meta: EngineMetadata = {
+			depsHash: computeDepsHash(),
+			installedAt: new Date().toISOString(),
+		};
+		await writeFile(engineJsonPath, `${JSON.stringify(meta, null, 2)}\n`, "utf-8");
+
+		return { success: true, output };
+	} finally {
+		await releaseLock(lockPath);
+	}
+}
+
+// ─── linkEngineModules ──────────────────────────────────────────────────────
+
+/**
+ * Creates a symlink from `buildDir/node_modules` to the shared engine's
+ * `node_modules`. Removes any existing node_modules (real or stale symlink).
+ */
+export async function linkEngineModules(buildDir: string): Promise<void> {
+	const engineDir = getEngineDir();
+	const target = join(engineDir, "node_modules");
+	const linkPath = join(buildDir, "node_modules");
+
+	// Remove existing node_modules if present
+	if (existsSync(linkPath)) {
+		const stat = lstatSync(linkPath);
+		if (stat.isSymbolicLink()) {
+			unlinkSync(linkPath);
+		} else {
+			await rm(linkPath, { recursive: true, force: true });
+		}
+	}
+
+	await mkdir(buildDir, { recursive: true });
+	await symlink(target, linkPath, process.platform === "win32" ? "junction" : "dir");
+}
+
+// ─── Lock helpers ───────────────────────────────────────────────────────────
+
+async function acquireLock(engineDir: string, lockPath: string): Promise<boolean> {
+	try {
+		await mkdir(engineDir, { recursive: true });
+		await writeFile(lockPath, String(Date.now()), { flag: "wx" });
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+async function releaseLock(lockPath: string): Promise<void> {
+	try {
+		if (existsSync(lockPath)) unlinkSync(lockPath);
+	} catch {
+		// Ignore
+	}
+}
+
+/* v8 ignore start -- lock polling is tested via integration, not unit tests */
+async function waitForLock(lockPath: string): Promise<boolean> {
+	const pollInterval = 1000;
+	const maxWait = LOCK_TIMEOUT_MS;
+	let elapsed = 0;
+
+	while (elapsed < maxWait) {
+		if (!existsSync(lockPath)) return true;
+
+		try {
+			const lockTime = Number.parseInt(await readFile(lockPath, "utf-8"), 10);
+			if (Date.now() - lockTime > LOCK_TIMEOUT_MS) {
+				await releaseLock(lockPath);
+				return true;
+			}
+		} catch {
+			return true;
+		}
+
+		await new Promise((resolve) => setTimeout(resolve, pollInterval));
+		elapsed += pollInterval;
+	}
+
+	await releaseLock(lockPath);
+	return false;
+}
+/* v8 ignore stop */

--- a/cli/src/site/FrameworkDetector.test.ts
+++ b/cli/src/site/FrameworkDetector.test.ts
@@ -1,0 +1,238 @@
+/**
+ * Tests for FrameworkDetector — detects documentation framework config files.
+ */
+
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+async function makeTempDir(): Promise<string> {
+	return mkdtemp(join(tmpdir(), "jolli-framework-test-"));
+}
+
+describe("FrameworkDetector.detectFramework", () => {
+	let tempDir: string;
+
+	beforeEach(async () => {
+		tempDir = await makeTempDir();
+	});
+
+	afterEach(async () => {
+		await rm(tempDir, { recursive: true, force: true });
+	});
+
+	it("returns null when no framework config is found", async () => {
+		const { detectFramework } = await import("./FrameworkDetector.js");
+		expect(detectFramework(tempDir)).toBeNull();
+	});
+
+	it("detects Docusaurus by sidebars.js in source root", async () => {
+		const { detectFramework } = await import("./FrameworkDetector.js");
+		await writeFile(join(tempDir, "sidebars.js"), "module.exports = {}", "utf-8");
+
+		const result = detectFramework(tempDir);
+
+		expect(result).not.toBeNull();
+		expect(result?.name).toBe("docusaurus");
+		expect(result?.sidebarPath).toContain("sidebars.js");
+	});
+
+	it("detects Docusaurus by docusaurus.config.ts in parent", async () => {
+		const { detectFramework } = await import("./FrameworkDetector.js");
+		const docsDir = join(tempDir, "docs");
+		await mkdir(docsDir, { recursive: true });
+		await writeFile(join(tempDir, "docusaurus.config.ts"), "export default {}", "utf-8");
+		await writeFile(join(tempDir, "sidebars.js"), "module.exports = {}", "utf-8");
+
+		const result = detectFramework(docsDir);
+
+		expect(result?.name).toBe("docusaurus");
+		expect(result?.sidebarPath).toContain("sidebars.js");
+	});
+
+	it("detects Mintlify by mint.json", async () => {
+		const { detectFramework } = await import("./FrameworkDetector.js");
+		await writeFile(join(tempDir, "mint.json"), "{}", "utf-8");
+
+		const result = detectFramework(tempDir);
+
+		expect(result?.name).toBe("mintlify");
+	});
+
+	it("detects MkDocs by mkdocs.yml", async () => {
+		const { detectFramework } = await import("./FrameworkDetector.js");
+		await writeFile(join(tempDir, "mkdocs.yml"), "site_name: test", "utf-8");
+
+		const result = detectFramework(tempDir);
+
+		expect(result?.name).toBe("mkdocs");
+	});
+
+	it("detects GitBook by SUMMARY.md", async () => {
+		const { detectFramework } = await import("./FrameworkDetector.js");
+		await writeFile(join(tempDir, "SUMMARY.md"), "# Summary", "utf-8");
+
+		const result = detectFramework(tempDir);
+
+		expect(result?.name).toBe("gitbook");
+	});
+
+	it("detects VitePress by .vitepress/config.ts", async () => {
+		const { detectFramework } = await import("./FrameworkDetector.js");
+		await mkdir(join(tempDir, ".vitepress"), { recursive: true });
+		await writeFile(join(tempDir, ".vitepress", "config.ts"), "export default {}", "utf-8");
+
+		const result = detectFramework(tempDir);
+
+		expect(result?.name).toBe("vitepress");
+	});
+
+	it("detects MkDocs by mkdocs.yaml", async () => {
+		const { detectFramework } = await import("./FrameworkDetector.js");
+		await writeFile(join(tempDir, "mkdocs.yaml"), "site_name: test", "utf-8");
+
+		const result = detectFramework(tempDir);
+
+		expect(result?.name).toBe("mkdocs");
+	});
+
+	it("detects GitBook by .gitbook.yaml", async () => {
+		const { detectFramework } = await import("./FrameworkDetector.js");
+		await writeFile(join(tempDir, ".gitbook.yaml"), "root: ./", "utf-8");
+
+		const result = detectFramework(tempDir);
+
+		expect(result?.name).toBe("gitbook");
+	});
+
+	it("detects Docusaurus by docusaurus.config.js in source root", async () => {
+		const { detectFramework } = await import("./FrameworkDetector.js");
+		await writeFile(join(tempDir, "docusaurus.config.js"), "module.exports = {}", "utf-8");
+
+		const result = detectFramework(tempDir);
+
+		expect(result?.name).toBe("docusaurus");
+	});
+
+	it("finds sidebar in parent directory when config is in parent", async () => {
+		const { detectFramework } = await import("./FrameworkDetector.js");
+		const docsDir = join(tempDir, "docs");
+		await mkdir(docsDir, { recursive: true });
+		await writeFile(join(tempDir, "docusaurus.config.js"), "module.exports = {}", "utf-8");
+		await writeFile(join(tempDir, "sidebars.ts"), "module.exports = {}", "utf-8");
+
+		const result = detectFramework(docsDir);
+
+		expect(result?.name).toBe("docusaurus");
+		expect(result?.sidebarPath).toContain("sidebars.ts");
+	});
+
+	it("returns sidebarPath from source root over parent when both exist", async () => {
+		const { detectFramework } = await import("./FrameworkDetector.js");
+		const docsDir = join(tempDir, "docs");
+		await mkdir(docsDir, { recursive: true });
+		await writeFile(join(docsDir, "sidebars.js"), "module.exports = {}", "utf-8");
+		await writeFile(join(tempDir, "docusaurus.config.ts"), "export default {}", "utf-8");
+		await writeFile(join(tempDir, "sidebars.js"), "module.exports = {}", "utf-8");
+
+		const result = detectFramework(docsDir);
+
+		expect(result?.sidebarPath).toContain(join("docs", "sidebars.js"));
+	});
+});
+
+// ─── Mock readline (must be top-level for vi.hoisted) ───────────────────────
+
+const { mockCreateInterfaceForPrompt } = vi.hoisted(() => ({
+	mockCreateInterfaceForPrompt: vi.fn(),
+}));
+
+vi.mock("node:readline", () => ({
+	createInterface: mockCreateInterfaceForPrompt,
+}));
+
+function mockPromptAnswer(answer: string): void {
+	mockCreateInterfaceForPrompt.mockReturnValue({
+		question: (_prompt: string, cb: (answer: string) => void) => cb(answer),
+		close: vi.fn(),
+	});
+}
+
+// ─── promptMigration ─────────────────────────────────────────────────────────
+
+describe("FrameworkDetector.promptMigration", () => {
+	const originalIsTTY = process.stdin.isTTY;
+
+	beforeEach(() => {
+		process.stdin.isTTY = true;
+	});
+
+	afterEach(() => {
+		process.stdin.isTTY = originalIsTTY;
+		vi.restoreAllMocks();
+	});
+
+	it("returns true when user answers Y", async () => {
+		mockPromptAnswer("Y");
+		const { promptMigration } = await import("./FrameworkDetector.js");
+
+		const result = await promptMigration({ name: "docusaurus", configPath: "/test" });
+
+		expect(result).toBe(true);
+	});
+
+	it("returns true when user answers yes", async () => {
+		mockPromptAnswer("yes");
+		const { promptMigration } = await import("./FrameworkDetector.js");
+
+		const result = await promptMigration({ name: "docusaurus", configPath: "/test" });
+
+		expect(result).toBe(true);
+	});
+
+	it("returns true when user presses Enter (empty)", async () => {
+		mockPromptAnswer("");
+		const { promptMigration } = await import("./FrameworkDetector.js");
+
+		const result = await promptMigration({ name: "docusaurus", configPath: "/test" });
+
+		expect(result).toBe(true);
+	});
+
+	it("returns false when user answers n", async () => {
+		mockPromptAnswer("n");
+		const { promptMigration } = await import("./FrameworkDetector.js");
+
+		const result = await promptMigration({ name: "docusaurus", configPath: "/test" });
+
+		expect(result).toBe(false);
+	});
+
+	it("returns false when user answers no", async () => {
+		mockPromptAnswer("no");
+		const { promptMigration } = await import("./FrameworkDetector.js");
+
+		const result = await promptMigration({ name: "docusaurus", configPath: "/test" });
+
+		expect(result).toBe(false);
+	});
+
+	it("returns true without prompting when stdin is not a TTY", async () => {
+		process.stdin.isTTY = undefined as unknown as true;
+		const { promptMigration } = await import("./FrameworkDetector.js");
+
+		const result = await promptMigration({ name: "docusaurus", configPath: "/test" });
+
+		expect(result).toBe(true);
+	});
+
+	it("returns false for random input", async () => {
+		mockPromptAnswer("maybe");
+		const { promptMigration } = await import("./FrameworkDetector.js");
+
+		const result = await promptMigration({ name: "docusaurus", configPath: "/test" });
+
+		expect(result).toBe(false);
+	});
+});

--- a/cli/src/site/FrameworkDetector.ts
+++ b/cli/src/site/FrameworkDetector.ts
@@ -1,0 +1,140 @@
+/**
+ * FrameworkDetector — detects documentation framework config files in a
+ * content folder and prompts the user for migration.
+ *
+ * Supports detection of: Docusaurus, Mintlify, VitePress, MkDocs, GitBook.
+ * v1 only implements Docusaurus conversion; others are detected and reported.
+ */
+
+import { existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { createInterface } from "node:readline";
+
+// ─── DetectedFramework ───────────────────────────────────────────────────────
+
+export interface DetectedFramework {
+	name: "docusaurus" | "mintlify" | "vitepress" | "mkdocs" | "gitbook";
+	configPath: string;
+	sidebarPath?: string;
+}
+
+// ─── Framework detection rules ───────────────────────────────────────────────
+
+interface FrameworkRule {
+	name: DetectedFramework["name"];
+	/** Files to check in the source root */
+	files: string[];
+	/** Files to check in the parent directory */
+	parentFiles?: string[];
+	/** Which file contains sidebar config (if different from main config) */
+	sidebarFiles?: string[];
+	/** Sidebar files to check in parent directory */
+	parentSidebarFiles?: string[];
+}
+
+const FRAMEWORK_RULES: FrameworkRule[] = [
+	{
+		name: "docusaurus",
+		files: ["docusaurus.config.js", "docusaurus.config.ts", "sidebars.js", "sidebars.ts"],
+		parentFiles: ["docusaurus.config.js", "docusaurus.config.ts"],
+		sidebarFiles: ["sidebars.js", "sidebars.ts"],
+		parentSidebarFiles: ["sidebars.js", "sidebars.ts"],
+	},
+	{
+		name: "mintlify",
+		files: ["mint.json"],
+	},
+	{
+		name: "vitepress",
+		files: [".vitepress/config.js", ".vitepress/config.ts"],
+	},
+	{
+		name: "mkdocs",
+		files: ["mkdocs.yml", "mkdocs.yaml"],
+	},
+	{
+		name: "gitbook",
+		files: ["SUMMARY.md", ".gitbook.yaml"],
+	},
+];
+
+// ─── detectFramework ─────────────────────────────────────────────────────────
+
+/**
+ * Scans the source root (and its parent directory for Docusaurus) for known
+ * documentation framework config files.
+ *
+ * Returns the first detected framework, or `null` if none found.
+ */
+export function detectFramework(sourceRoot: string): DetectedFramework | null {
+	const parentDir = dirname(sourceRoot);
+
+	for (const rule of FRAMEWORK_RULES) {
+		// Check source root
+		for (const file of rule.files) {
+			const fullPath = join(sourceRoot, file);
+			if (existsSync(fullPath)) {
+				return {
+					name: rule.name,
+					configPath: fullPath,
+					sidebarPath: findSidebarFile(sourceRoot, parentDir, rule),
+				};
+			}
+		}
+
+		// Check parent directory
+		if (rule.parentFiles) {
+			for (const file of rule.parentFiles) {
+				const fullPath = join(parentDir, file);
+				if (existsSync(fullPath)) {
+					return {
+						name: rule.name,
+						configPath: fullPath,
+						sidebarPath: findSidebarFile(sourceRoot, parentDir, rule),
+					};
+				}
+			}
+		}
+	}
+
+	return null;
+}
+
+/**
+ * Finds the sidebar config file, checking source root first, then parent.
+ */
+function findSidebarFile(sourceRoot: string, parentDir: string, rule: FrameworkRule): string | undefined {
+	if (rule.sidebarFiles) {
+		for (const file of rule.sidebarFiles) {
+			const fullPath = join(sourceRoot, file);
+			if (existsSync(fullPath)) return fullPath;
+		}
+	}
+	if (rule.parentSidebarFiles) {
+		for (const file of rule.parentSidebarFiles) {
+			const fullPath = join(parentDir, file);
+			if (existsSync(fullPath)) return fullPath;
+		}
+	}
+	return undefined;
+}
+
+// ─── promptMigration ─────────────────────────────────────────────────────────
+
+/**
+ * Prompts the user whether to migrate from the detected framework.
+ * Returns `true` if the user wants to migrate (Y), `false` otherwise.
+ */
+export function promptMigration(framework: DetectedFramework): Promise<boolean> {
+	if (!process.stdin.isTTY) return Promise.resolve(true);
+	const rl = createInterface({ input: process.stdin, output: process.stdout });
+	const name = framework.name.charAt(0).toUpperCase() + framework.name.slice(1);
+
+	return new Promise((resolve) => {
+		rl.question(`Found ${name} config. Generate site.json from it? (Y/n) `, (answer) => {
+			rl.close();
+			const trimmed = answer.trim().toLowerCase();
+			resolve(trimmed === "" || trimmed === "y" || trimmed === "yes");
+		});
+	});
+}

--- a/cli/src/site/MetaGenerator.test.ts
+++ b/cli/src/site/MetaGenerator.test.ts
@@ -1,0 +1,611 @@
+/**
+ * Tests for MetaGenerator — generates `_meta.js` files for Nextra v4 navigation.
+ *
+ * Covers all acceptance criteria from Task 5:
+ *   - toTitleCase replaces hyphens/underscores with spaces and title-cases words
+ *   - buildMetaEntries sorts alphabetically and title-cases labels
+ *   - buildMetaEntries treats index.md / index.mdx as "Home"
+ *   - generateMetaFiles writes _meta.js for folders with content
+ *   - generateMetaFiles skips empty folders
+ *   - generateMetaFiles recurses into subdirectories
+ *
+ * Property-based tests (fast-check):
+ *   - Property 3: _meta.js entries are alphabetically ordered
+ *     **Validates: Requirements 5.3**
+ *   - Property 4: Title-case transformation is correct
+ *     **Validates: Requirements 5.6**
+ */
+
+import { existsSync } from "node:fs";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import * as fc from "fast-check";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+async function makeTempDir(): Promise<string> {
+	return mkdtemp(join(tmpdir(), "jolli-metagenerator-test-"));
+}
+
+// ─── toTitleCase unit tests ───────────────────────────────────────────────────
+
+describe("MetaGenerator.toTitleCase", () => {
+	it("title-cases a single word", async () => {
+		const { toTitleCase } = await import("./MetaGenerator.js");
+		expect(toTitleCase("index")).toBe("Index");
+	});
+
+	it("replaces hyphens with spaces and title-cases each word", async () => {
+		const { toTitleCase } = await import("./MetaGenerator.js");
+		expect(toTitleCase("getting-started")).toBe("Getting Started");
+	});
+
+	it("replaces underscores with spaces and title-cases each word", async () => {
+		const { toTitleCase } = await import("./MetaGenerator.js");
+		expect(toTitleCase("api_reference")).toBe("Api Reference");
+	});
+
+	it("handles mixed hyphens and underscores", async () => {
+		const { toTitleCase } = await import("./MetaGenerator.js");
+		expect(toTitleCase("my-api_guide")).toBe("My Api Guide");
+	});
+
+	it("handles an already-capitalised word", async () => {
+		const { toTitleCase } = await import("./MetaGenerator.js");
+		expect(toTitleCase("API")).toBe("API");
+	});
+
+	it("handles an empty string", async () => {
+		const { toTitleCase } = await import("./MetaGenerator.js");
+		expect(toTitleCase("")).toBe("");
+	});
+
+	it("handles multiple consecutive hyphens", async () => {
+		const { toTitleCase } = await import("./MetaGenerator.js");
+		// Each hyphen becomes a space; word boundary capitalises the next letter
+		expect(toTitleCase("a--b")).toBe("A  B");
+	});
+
+	it("handles a filename with numbers", async () => {
+		const { toTitleCase } = await import("./MetaGenerator.js");
+		expect(toTitleCase("chapter-1")).toBe("Chapter 1");
+	});
+});
+
+// ─── buildMetaEntries unit tests ──────────────────────────────────────────────
+
+describe("MetaGenerator.buildMetaEntries", () => {
+	it("returns an empty array for an empty input", async () => {
+		const { buildMetaEntries } = await import("./MetaGenerator.js");
+		expect(buildMetaEntries([])).toEqual([]);
+	});
+
+	it("strips the extension from a markdown filename", async () => {
+		const { buildMetaEntries } = await import("./MetaGenerator.js");
+		const entries = buildMetaEntries(["getting-started.md"]);
+		expect(entries[0].key).toBe("getting-started");
+	});
+
+	it("title-cases the label", async () => {
+		const { buildMetaEntries } = await import("./MetaGenerator.js");
+		const entries = buildMetaEntries(["getting-started.md"]);
+		expect(entries[0].value).toBe("Getting Started");
+	});
+
+	it("hides index.md in entries with display: hidden", async () => {
+		const { buildMetaEntries } = await import("./MetaGenerator.js");
+		const entries = buildMetaEntries(["index.md"]);
+		expect(entries).toHaveLength(1);
+		expect(entries[0].key).toBe("index");
+		expect(entries[0].value).toEqual({ display: "hidden" });
+	});
+
+	it("hides index.mdx in entries with display: hidden", async () => {
+		const { buildMetaEntries } = await import("./MetaGenerator.js");
+		const entries = buildMetaEntries(["index.mdx"]);
+		expect(entries).toHaveLength(1);
+		expect(entries[0].key).toBe("index");
+		expect(entries[0].value).toEqual({ display: "hidden" });
+	});
+
+	it("sorts entries alphabetically by key", async () => {
+		const { buildMetaEntries } = await import("./MetaGenerator.js");
+		const entries = buildMetaEntries(["zebra.md", "apple.md", "mango.md"]);
+		expect(entries.map((e) => e.key)).toEqual(["apple", "mango", "zebra"]);
+	});
+
+	it("handles directory names (no extension) as entries", async () => {
+		const { buildMetaEntries } = await import("./MetaGenerator.js");
+		const entries = buildMetaEntries(["api"]);
+		expect(entries[0]).toEqual({ key: "api", value: "Api" });
+	});
+
+	it("deduplicates entries with the same key", async () => {
+		const { buildMetaEntries } = await import("./MetaGenerator.js");
+		// foo.md and foo.mdx would both produce key "foo"
+		const entries = buildMetaEntries(["foo.md", "foo.mdx"]);
+		expect(entries).toHaveLength(1);
+		expect(entries[0].key).toBe("foo");
+	});
+
+	it("mixes files and directories, hides index, and sorts them together", async () => {
+		const { buildMetaEntries } = await import("./MetaGenerator.js");
+		const entries = buildMetaEntries(["guides", "index.md", "getting-started.md", "api"]);
+		const visible = entries.filter((e) => typeof e.value === "string");
+		expect(visible.map((e) => e.key)).toEqual(["api", "getting-started", "guides"]);
+		expect(entries.find((e) => e.key === "index")?.value).toEqual({ display: "hidden" });
+	});
+
+	// ── Sidebar overrides ────────────────────────────────────────────────────
+
+	it("uses override order when sidebar override is provided", async () => {
+		const { buildMetaEntries } = await import("./MetaGenerator.js");
+		const entries = buildMetaEntries(["apple.md", "banana.md", "cherry.md"], {
+			cherry: "Cherry First",
+			banana: "Banana Second",
+		});
+		expect(entries.map((e) => e.key)).toEqual(["cherry", "banana"]);
+		expect(entries[0].value).toBe("Cherry First");
+		expect(entries[1].value).toBe("Banana Second");
+	});
+
+	it("includes override items not on filesystem (external links)", async () => {
+		const { buildMetaEntries } = await import("./MetaGenerator.js");
+		const entries = buildMetaEntries(["index.md"], {
+			index: "Home",
+			github: { title: "GitHub", href: "https://github.com" },
+		});
+		expect(entries).toHaveLength(2);
+		expect(entries[1].key).toBe("github");
+		expect(entries[1].value).toEqual({ title: "GitHub", href: "https://github.com" });
+	});
+
+	it("uses default alphabetical order when no override is provided", async () => {
+		const { buildMetaEntries } = await import("./MetaGenerator.js");
+		const entries = buildMetaEntries(["zebra.md", "apple.md"]);
+		expect(entries.map((e) => e.key)).toEqual(["apple", "zebra"]);
+	});
+});
+
+// ─── generateMetaFiles unit tests ────────────────────────────────────────────
+
+describe("MetaGenerator.generateMetaFiles", () => {
+	let contentDir: string;
+
+	beforeEach(async () => {
+		contentDir = await makeTempDir();
+	});
+
+	afterEach(async () => {
+		await rm(contentDir, { recursive: true, force: true });
+	});
+
+	// ── Basic _meta.js generation ────────────────────────────────────────────
+
+	it("writes _meta.js in a folder containing a markdown file", async () => {
+		const { generateMetaFiles } = await import("./MetaGenerator.js");
+		await writeFile(join(contentDir, "guide.md"), "# Guide", "utf-8");
+
+		await generateMetaFiles(contentDir);
+
+		expect(existsSync(join(contentDir, "_meta.js"))).toBe(true);
+	});
+
+	it("_meta.js contains the correct ES module export", async () => {
+		const { generateMetaFiles } = await import("./MetaGenerator.js");
+		await writeFile(join(contentDir, "guide.md"), "# Guide", "utf-8");
+
+		await generateMetaFiles(contentDir);
+
+		const content = await readFile(join(contentDir, "_meta.js"), "utf-8");
+		expect(content).toContain("export default");
+		expect(content).toContain('"guide": "Guide"');
+	});
+
+	it("hides index.md in _meta.js with display: hidden", async () => {
+		const { generateMetaFiles } = await import("./MetaGenerator.js");
+		await writeFile(join(contentDir, "index.md"), "# Home", "utf-8");
+		await writeFile(join(contentDir, "guide.md"), "# Guide", "utf-8");
+
+		await generateMetaFiles(contentDir);
+
+		const content = await readFile(join(contentDir, "_meta.js"), "utf-8");
+		expect(content).toContain('"index"');
+		expect(content).toContain('"hidden"');
+		expect(content).toContain('"guide"');
+	});
+
+	it("_meta.js entries are sorted alphabetically", async () => {
+		const { generateMetaFiles } = await import("./MetaGenerator.js");
+		await writeFile(join(contentDir, "zebra.md"), "# Zebra", "utf-8");
+		await writeFile(join(contentDir, "apple.md"), "# Apple", "utf-8");
+		await writeFile(join(contentDir, "mango.md"), "# Mango", "utf-8");
+
+		await generateMetaFiles(contentDir);
+
+		const content = await readFile(join(contentDir, "_meta.js"), "utf-8");
+		const applePos = content.indexOf('"apple"');
+		const mangoPos = content.indexOf('"mango"');
+		const zebraPos = content.indexOf('"zebra"');
+		expect(applePos).toBeLessThan(mangoPos);
+		expect(mangoPos).toBeLessThan(zebraPos);
+	});
+
+	// ── Empty folder skipping (5.4) ──────────────────────────────────────────
+
+	it("does NOT write _meta.js for an empty folder (5.4)", async () => {
+		const { generateMetaFiles } = await import("./MetaGenerator.js");
+		// contentDir is empty
+
+		await generateMetaFiles(contentDir);
+
+		expect(existsSync(join(contentDir, "_meta.js"))).toBe(false);
+	});
+
+	it("does NOT write _meta.js for a folder containing only ignored files", async () => {
+		const { generateMetaFiles } = await import("./MetaGenerator.js");
+		await writeFile(join(contentDir, "notes.txt"), "ignored", "utf-8");
+
+		await generateMetaFiles(contentDir);
+
+		expect(existsSync(join(contentDir, "_meta.js"))).toBe(false);
+	});
+
+	// ── Subdirectory recursion ───────────────────────────────────────────────
+
+	it("writes _meta.js in a non-empty subdirectory", async () => {
+		const { generateMetaFiles } = await import("./MetaGenerator.js");
+		const guidesDir = join(contentDir, "guides");
+		await mkdir(guidesDir, { recursive: true });
+		await writeFile(join(guidesDir, "introduction.md"), "# Intro", "utf-8");
+
+		await generateMetaFiles(contentDir);
+
+		expect(existsSync(join(guidesDir, "_meta.js"))).toBe(true);
+	});
+
+	it("includes non-empty subdirectory in parent _meta.js", async () => {
+		const { generateMetaFiles } = await import("./MetaGenerator.js");
+		const guidesDir = join(contentDir, "guides");
+		await mkdir(guidesDir, { recursive: true });
+		await writeFile(join(guidesDir, "introduction.md"), "# Intro", "utf-8");
+		await writeFile(join(contentDir, "about.md"), "# About", "utf-8");
+
+		await generateMetaFiles(contentDir);
+
+		const content = await readFile(join(contentDir, "_meta.js"), "utf-8");
+		expect(content).toContain('"guides"');
+	});
+
+	it("does NOT include an empty subdirectory in parent _meta.js", async () => {
+		const { generateMetaFiles } = await import("./MetaGenerator.js");
+		const emptyDir = join(contentDir, "empty");
+		await mkdir(emptyDir, { recursive: true });
+		await writeFile(join(contentDir, "about.md"), "# About", "utf-8");
+
+		await generateMetaFiles(contentDir);
+
+		const content = await readFile(join(contentDir, "_meta.js"), "utf-8");
+		expect(content).not.toContain('"empty"');
+	});
+
+	// ── Full example matching design doc ─────────────────────────────────────
+
+	it("handles non-existent contentDir without throwing", async () => {
+		const { generateMetaFiles } = await import("./MetaGenerator.js");
+
+		// processDir catches readdir errors and returns false
+		await expect(generateMetaFiles(join(contentDir, "nonexistent"))).resolves.not.toThrow();
+	});
+
+	it("skips entries where stat fails (e.g. broken symlinks)", async () => {
+		const { symlink } = await import("node:fs/promises");
+		const { generateMetaFiles } = await import("./MetaGenerator.js");
+		// Create a valid file so _meta.js gets generated
+		await writeFile(join(contentDir, "valid.md"), "# Valid", "utf-8");
+		// Create a broken symlink — readdir lists it, but stat fails
+		await symlink(join(contentDir, "nonexistent-target"), join(contentDir, "broken-link.md"));
+
+		await generateMetaFiles(contentDir);
+
+		const content = await readFile(join(contentDir, "_meta.js"), "utf-8");
+		expect(content).toContain('"valid"');
+		// broken-link should be skipped
+		expect(content).not.toContain('"broken-link"');
+	});
+
+	it("generates correct _meta.js for a typical pages structure", async () => {
+		const { generateMetaFiles } = await import("./MetaGenerator.js");
+
+		// Root: index.md, getting-started.md, api/, guides/
+		await writeFile(join(contentDir, "index.md"), "# Home", "utf-8");
+		await writeFile(join(contentDir, "getting-started.md"), "# Getting Started", "utf-8");
+
+		const apiDir = join(contentDir, "api");
+		await mkdir(apiDir, { recursive: true });
+		await writeFile(join(apiDir, "openapi.mdx"), "# API", "utf-8");
+
+		const guidesDir = join(contentDir, "guides");
+		await mkdir(guidesDir, { recursive: true });
+		await writeFile(join(guidesDir, "introduction.md"), "# Intro", "utf-8");
+
+		await generateMetaFiles(contentDir);
+
+		// Root _meta.js
+		const rootMeta = await readFile(join(contentDir, "_meta.js"), "utf-8");
+		expect(rootMeta).toContain('"api"');
+		expect(rootMeta).toContain('"getting-started": "Getting Started"');
+		expect(rootMeta).toContain('"guides"');
+		expect(rootMeta).toContain('"index": {"display":"hidden"}');
+
+		// api/_meta.js
+		const apiMeta = await readFile(join(apiDir, "_meta.js"), "utf-8");
+		expect(apiMeta).toContain('"openapi"');
+
+		// guides/_meta.js
+		const guidesMeta = await readFile(join(guidesDir, "_meta.js"), "utf-8");
+		expect(guidesMeta).toContain('"introduction"');
+	});
+
+	// ── Sidebar overrides with generateMetaFiles ─────────────────────────────
+
+	it("applies sidebar override to root directory", async () => {
+		const { generateMetaFiles } = await import("./MetaGenerator.js");
+		await writeFile(join(contentDir, "zebra.md"), "# Z", "utf-8");
+		await writeFile(join(contentDir, "apple.md"), "# A", "utf-8");
+
+		await generateMetaFiles(contentDir, {
+			"/": { zebra: "Zebra First", apple: "Apple Second" },
+		});
+
+		const content = await readFile(join(contentDir, "_meta.js"), "utf-8");
+		const zebraPos = content.indexOf('"zebra"');
+		const applePos = content.indexOf('"apple"');
+		expect(zebraPos).toBeLessThan(applePos);
+		expect(content).toContain('"zebra": "Zebra First"');
+	});
+
+	it("applies sidebar override to subdirectory", async () => {
+		const { generateMetaFiles } = await import("./MetaGenerator.js");
+		const subDir = join(contentDir, "guides");
+		await mkdir(subDir, { recursive: true });
+		await writeFile(join(subDir, "intro.md"), "# Intro", "utf-8");
+		await writeFile(join(subDir, "advanced.md"), "# Adv", "utf-8");
+		await writeFile(join(contentDir, "index.md"), "# Home", "utf-8");
+
+		await generateMetaFiles(contentDir, {
+			"/guides": { advanced: "Advanced First", intro: "Intro Second" },
+		});
+
+		const content = await readFile(join(subDir, "_meta.js"), "utf-8");
+		const advPos = content.indexOf('"advanced"');
+		const introPos = content.indexOf('"intro"');
+		expect(advPos).toBeLessThan(introPos);
+		expect(content).toContain('"advanced": "Advanced First"');
+	});
+
+	it("writes object values (external links) in _meta.js", async () => {
+		const { generateMetaFiles } = await import("./MetaGenerator.js");
+		await writeFile(join(contentDir, "index.md"), "# Home", "utf-8");
+
+		await generateMetaFiles(contentDir, {
+			"/": {
+				index: "Home",
+				github: { title: "GitHub", href: "https://github.com" },
+			},
+		});
+
+		const content = await readFile(join(contentDir, "_meta.js"), "utf-8");
+		expect(content).toContain('"github":');
+		expect(content).toContain('"href":"https://github.com"');
+	});
+
+	it("uses default behavior for directories without override", async () => {
+		const { generateMetaFiles } = await import("./MetaGenerator.js");
+		await writeFile(join(contentDir, "zebra.md"), "# Z", "utf-8");
+		await writeFile(join(contentDir, "apple.md"), "# A", "utf-8");
+
+		await generateMetaFiles(contentDir, {
+			"/other": { something: "Something" },
+		});
+
+		const content = await readFile(join(contentDir, "_meta.js"), "utf-8");
+		const applePos = content.indexOf('"apple"');
+		const zebraPos = content.indexOf('"zebra"');
+		expect(applePos).toBeLessThan(zebraPos);
+	});
+});
+
+// ─── Property-based tests ─────────────────────────────────────────────────────
+
+/**
+ * Property 3: _meta.js entries are alphabetically ordered
+ * **Validates: Requirements 5.3**
+ */
+describe("Property 3: _meta.js entries are alphabetically ordered", () => {
+	// Generate safe filename segments: lowercase letters, digits, hyphens
+	const safeSegment = fc.stringMatching(/^[a-z][a-z0-9-]{0,15}$/).filter((s) => s.length > 0 && s !== "index");
+
+	it("buildMetaEntries always returns entries sorted alphabetically by key", async () => {
+		const { buildMetaEntries } = await import("./MetaGenerator.js");
+
+		fc.assert(
+			fc.property(fc.array(safeSegment, { minLength: 1, maxLength: 20 }), (names) => {
+				// Add .md extension to simulate filenames
+				const filenames = names.map((n) => `${n}.md`);
+				const entries = buildMetaEntries(filenames);
+				const keys = entries.map((e) => e.key);
+
+				// Verify sorted order
+				for (let i = 1; i < keys.length; i++) {
+					if (keys[i - 1].localeCompare(keys[i]) > 0) {
+						return false;
+					}
+				}
+				return true;
+			}),
+			{ numRuns: 100 },
+		);
+	});
+
+	it("buildMetaEntries sorts mixed files and directories alphabetically", async () => {
+		const { buildMetaEntries } = await import("./MetaGenerator.js");
+
+		// Mix of filenames (with extension) and directory names (without extension)
+		const filenameArb = fc.oneof(
+			safeSegment.map((n) => `${n}.md`),
+			safeSegment.map((n) => `${n}.mdx`),
+			safeSegment, // directory name
+		);
+
+		fc.assert(
+			fc.property(fc.array(filenameArb, { minLength: 1, maxLength: 20 }), (items) => {
+				const entries = buildMetaEntries(items);
+				const keys = entries.map((e) => e.key);
+
+				for (let i = 1; i < keys.length; i++) {
+					if (keys[i - 1].localeCompare(keys[i]) > 0) {
+						return false;
+					}
+				}
+				return true;
+			}),
+			{ numRuns: 100 },
+		);
+	});
+});
+
+/**
+ * Property 4: Title-case transformation is correct
+ * **Validates: Requirements 5.6**
+ */
+describe("Property 4: Title-case transformation is correct", () => {
+	// Generate strings composed of lowercase words separated by hyphens/underscores
+	const wordChar = fc.stringMatching(/^[a-z0-9]{1,10}$/);
+	const separator = fc.constantFrom("-", "_");
+
+	// Build a filename-like string: word (sep word)*
+	const filenameArb = fc.array(wordChar, { minLength: 1, maxLength: 5 }).chain((words) =>
+		fc.array(separator, { minLength: words.length - 1, maxLength: words.length - 1 }).map((seps) => {
+			let result = words[0];
+			for (let i = 0; i < seps.length; i++) {
+				result += seps[i] + words[i + 1];
+			}
+			return result;
+		}),
+	);
+
+	it("toTitleCase never contains hyphens in the output", async () => {
+		const { toTitleCase } = await import("./MetaGenerator.js");
+
+		fc.assert(
+			fc.property(filenameArb, (filename) => {
+				const result = toTitleCase(filename);
+				return !result.includes("-");
+			}),
+			{ numRuns: 100 },
+		);
+	});
+
+	it("toTitleCase never contains underscores in the output", async () => {
+		const { toTitleCase } = await import("./MetaGenerator.js");
+
+		fc.assert(
+			fc.property(filenameArb, (filename) => {
+				const result = toTitleCase(filename);
+				return !result.includes("_");
+			}),
+			{ numRuns: 100 },
+		);
+	});
+
+	it("toTitleCase capitalises the first letter of every word", async () => {
+		const { toTitleCase } = await import("./MetaGenerator.js");
+
+		fc.assert(
+			fc.property(filenameArb, (filename) => {
+				const result = toTitleCase(filename);
+				// Split on spaces and check each non-empty word starts with uppercase
+				const words = result.split(" ").filter((w) => w.length > 0);
+				return words.every((word) => {
+					const firstChar = word[0];
+					// A letter should be uppercase; digits are fine as-is
+					return /[^a-z]/.test(firstChar) || firstChar === firstChar.toUpperCase();
+				});
+			}),
+			{ numRuns: 100 },
+		);
+	});
+
+	it("toTitleCase replaces every hyphen with a space", async () => {
+		const { toTitleCase } = await import("./MetaGenerator.js");
+
+		// Generate strings that definitely contain hyphens
+		const withHyphen = fc.tuple(wordChar, wordChar).map(([a, b]) => `${a}-${b}`);
+
+		fc.assert(
+			fc.property(withHyphen, (filename) => {
+				const result = toTitleCase(filename);
+				return result.includes(" ") && !result.includes("-");
+			}),
+			{ numRuns: 100 },
+		);
+	});
+
+	it("toTitleCase replaces every underscore with a space", async () => {
+		const { toTitleCase } = await import("./MetaGenerator.js");
+
+		// Generate strings that definitely contain underscores
+		const withUnderscore = fc.tuple(wordChar, wordChar).map(([a, b]) => `${a}_${b}`);
+
+		fc.assert(
+			fc.property(withUnderscore, (filename) => {
+				const result = toTitleCase(filename);
+				return result.includes(" ") && !result.includes("_");
+			}),
+			{ numRuns: 100 },
+		);
+	});
+});
+
+// ─── generateMetaFiles with sidebar overrides (index hiding branch) ──────
+
+describe("MetaGenerator.generateMetaFiles with sidebar overrides", () => {
+	let pagesDir: string;
+
+	beforeEach(async () => {
+		pagesDir = await makeTempDir();
+	});
+
+	afterEach(async () => {
+		await rm(pagesDir, { recursive: true, force: true });
+	});
+
+	it("auto-hides index when override doesn't mention it", async () => {
+		const { generateMetaFiles } = await import("./MetaGenerator.js");
+		await writeFile(join(pagesDir, "index.md"), "# Home\n", "utf-8");
+		await writeFile(join(pagesDir, "about.md"), "# About\n", "utf-8");
+		const sidebar = { "/": { about: "About Us" } };
+
+		await generateMetaFiles(pagesDir, sidebar);
+
+		const metaContent = await readFile(join(pagesDir, "_meta.js"), "utf-8");
+		expect(metaContent).toContain("index");
+		expect(metaContent).toContain("hidden");
+		expect(metaContent).toContain("About Us");
+	});
+
+	it("does not auto-hide index when override explicitly includes it", async () => {
+		const { generateMetaFiles } = await import("./MetaGenerator.js");
+		await writeFile(join(pagesDir, "index.md"), "# Home\n", "utf-8");
+		await writeFile(join(pagesDir, "about.md"), "# About\n", "utf-8");
+		const sidebar = { "/": { index: "Home Page", about: "About Us" } };
+
+		await generateMetaFiles(pagesDir, sidebar);
+
+		const metaContent = await readFile(join(pagesDir, "_meta.js"), "utf-8");
+		expect(metaContent).toContain("Home Page");
+	});
+});

--- a/cli/src/site/MetaGenerator.ts
+++ b/cli/src/site/MetaGenerator.ts
@@ -1,0 +1,214 @@
+/**
+ * MetaGenerator — generates `_meta.js` files for Nextra v4 navigation.
+ *
+ * For every folder in the content directory that contains at least one markdown
+ * file, OpenAPI-derived `.mdx` file, or non-empty subfolder, a `_meta.js` is
+ * written.
+ *
+ * When sidebar overrides are provided (from `site.json`), declared items are
+ * written in declaration order with their custom labels/values. Nextra
+ * automatically appends unlisted filesystem items in alphabetical order.
+ *
+ * Without overrides, all items are listed alphabetically with auto-generated
+ * title-cased labels (backward-compatible default behavior).
+ */
+
+import { mkdir, readdir, stat, writeFile } from "node:fs/promises";
+import { basename, extname, join, relative, sep } from "node:path";
+import type { SidebarItemValue, SidebarOverrides } from "./Types.js";
+
+// ─── MetaEntry ────────────────────────────────────────────────────────────────
+
+/** A single entry in a `_meta.js` navigation file. */
+export interface MetaEntry {
+	/** Filename without extension — used as the Nextra navigation key. */
+	key: string;
+	/** Display label (string) or Nextra meta object (for links, hidden items, etc.). */
+	value: string | Record<string, unknown>;
+}
+
+// ─── toTitleCase ──────────────────────────────────────────────────────────────
+
+/**
+ * Converts a filename (without extension) into a human-readable title.
+ *
+ * - Replaces all hyphens (`-`) and underscores (`_`) with spaces.
+ * - Capitalises the first letter of every word.
+ */
+export function toTitleCase(filename: string): string {
+	return filename.replace(/[-_]/g, " ").replace(/\b\w/g, (ch) => ch.toUpperCase());
+}
+
+// ─── buildMetaEntries ─────────────────────────────────────────────────────────
+
+/**
+ * Builds an array of `MetaEntry` objects from a list of filenames (or
+ * directory names), optionally applying sidebar overrides.
+ *
+ * **Without overrides**: entries are sorted alphabetically, labels are
+ * title-cased. `index.md` / `index.mdx` gets label `"Home"`.
+ *
+ * **With overrides**: declared items come first in declaration order with
+ * their custom values. Remaining filesystem items are NOT included — Nextra
+ * will auto-append them alphabetically at runtime.
+ */
+export function buildMetaEntries(filenames: string[], override?: Record<string, SidebarItemValue>): MetaEntry[] {
+	if (override) {
+		return buildOverriddenEntries(filenames, override);
+	}
+	return buildDefaultEntries(filenames);
+}
+
+/**
+ * Default behavior: all items alphabetically sorted with auto-generated labels.
+ */
+function buildDefaultEntries(filenames: string[]): MetaEntry[] {
+	const seen = new Set<string>();
+	const entries: MetaEntry[] = [];
+
+	for (const filename of filenames) {
+		const ext = extname(filename);
+		const key = ext ? basename(filename, ext) : filename;
+
+		// Hide index files from sidebar — they serve as the folder's own page.
+		// Using display: "hidden" prevents Nextra from auto-appending them
+		// as visible children while still allowing them to be the folder page.
+		if (key === "index") {
+			entries.push({ key, value: { display: "hidden" } });
+			seen.add(key);
+			continue;
+		}
+
+		if (seen.has(key)) continue;
+		seen.add(key);
+
+		entries.push({ key, value: toTitleCase(key) });
+	}
+
+	entries.sort((a, b) => a.key.localeCompare(b.key));
+	return entries;
+}
+
+/**
+ * Override behavior: declared items in declaration order, with custom values.
+ * Items declared in the override that don't exist on the filesystem are
+ * included (they may be external links or separators).
+ */
+function buildOverriddenEntries(filenames: string[], override: Record<string, SidebarItemValue>): MetaEntry[] {
+	const entries: MetaEntry[] = [];
+
+	// If the folder has an index file but the override doesn't mention it,
+	// add it as hidden to prevent Nextra from showing it as a duplicate child.
+	const hasIndexFile = filenames.some((f) => {
+		const ext = extname(f);
+		const key = ext ? basename(f, ext) : f;
+		return key === "index";
+	});
+	if (hasIndexFile && !override.index) {
+		entries.push({ key: "index", value: { display: "hidden" } });
+	}
+
+	// Declared items in declaration order
+	for (const [key, value] of Object.entries(override)) {
+		if (typeof value === "string") {
+			entries.push({ key, value });
+		} else {
+			entries.push({ key, value: value as Record<string, unknown> });
+		}
+	}
+
+	return entries;
+}
+
+// ─── generateMetaFiles ────────────────────────────────────────────────────────
+
+/**
+ * Recursively walks `contentDir` and writes a `_meta.js` file in every folder
+ * that has content (markdown files, `.mdx` files, or non-empty subfolders).
+ *
+ * When `sidebarOverrides` is provided, directories with matching path keys
+ * use the declared ordering/labels instead of alphabetical auto-generation.
+ */
+export async function generateMetaFiles(contentDir: string, sidebarOverrides?: SidebarOverrides): Promise<void> {
+	await processDir(contentDir, contentDir, sidebarOverrides);
+}
+
+// ─── processDir (internal recursive helper) ───────────────────────────────────
+
+async function processDir(dir: string, contentDir: string, sidebarOverrides?: SidebarOverrides): Promise<boolean> {
+	let entries: string[];
+	try {
+		entries = await readdir(dir);
+	} catch {
+		return false;
+	}
+
+	const contentItems: string[] = [];
+
+	for (const entry of entries) {
+		if (entry.startsWith(".") || entry === "_meta.js") continue;
+
+		const fullPath = join(dir, entry);
+
+		let entryStat: Awaited<ReturnType<typeof stat>>;
+		try {
+			entryStat = await stat(fullPath);
+		} catch {
+			continue;
+		}
+
+		if (entryStat.isDirectory()) {
+			const hasContent = await processDir(fullPath, contentDir, sidebarOverrides);
+			if (hasContent) {
+				contentItems.push(entry);
+			}
+		} else if (entryStat.isFile()) {
+			const ext = extname(entry).toLowerCase();
+			if (ext === ".md" || ext === ".mdx") {
+				contentItems.push(entry);
+			}
+		}
+	}
+
+	if (contentItems.length === 0) {
+		return false;
+	}
+
+	// Compute the path key for sidebar override lookup (e.g. "/", "/get-started")
+	const relPath = relative(contentDir, dir);
+	const pathKey = `/${relPath.split(sep).join("/")}`.replace(/\/$/, "") || "/";
+
+	const override = sidebarOverrides?.[pathKey];
+	const metaEntries = buildMetaEntries(contentItems, override);
+
+	// Don't write _meta.js if all entries are hidden (e.g. folder with only index.md).
+	// Nextra fails to prerender folders with _meta.js that has no visible entries.
+	const hasVisibleEntries = metaEntries.some(
+		(e) => typeof e.value === "string" || (typeof e.value === "object" && e.value.display !== "hidden"),
+	);
+	if (hasVisibleEntries) {
+		await writeMetaFile(dir, metaEntries);
+	}
+
+	return true;
+}
+
+// ─── writeMetaFile (internal helper) ─────────────────────────────────────────
+
+/**
+ * Serialises `entries` into a Nextra v4 `_meta.js` ES-module and writes it
+ * to `<dir>/_meta.js`.
+ *
+ * String values are written as simple strings. Object values are written as
+ * JSON objects (for external links, hidden items, etc.).
+ */
+async function writeMetaFile(dir: string, entries: MetaEntry[]): Promise<void> {
+	const lines = entries.map(({ key, value }) => {
+		const serialized = typeof value === "string" ? `"${value}"` : JSON.stringify(value);
+		return `  "${key}": ${serialized},`;
+	});
+	const content = `export default {\n${lines.join("\n")}\n}\n`;
+
+	await mkdir(dir, { recursive: true });
+	await writeFile(join(dir, "_meta.js"), content, "utf-8");
+}

--- a/cli/src/site/NextraProjectWriter.test.ts
+++ b/cli/src/site/NextraProjectWriter.test.ts
@@ -1,0 +1,639 @@
+/**
+ * Tests for NextraProjectWriter — writes and maintains the Nextra v4 project
+ * scaffold inside `.jolli-site/`.
+ *
+ * Covers all acceptance criteria from Task 7:
+ *   - initNextraProject creates buildDir and config files on first run
+ *   - initNextraProject returns { isNew: true } on first run
+ *   - initNextraProject returns { isNew: false } on subsequent runs
+ *   - initNextraProject regenerates config files with updated values
+ *   - generatePackageJson includes all required dependencies
+ *   - generateNextConfig produces a valid next.config.mjs for Nextra v4
+ *   - generateLayout maps title, description, and nav into app/layout.tsx
+ *   - generateMdxComponents produces the required mdx-components.tsx
+ *   - generateTsConfig produces a valid tsconfig.json
+ *
+ * Property-based tests (fast-check):
+ *   - Property 5: site.json fields are preserved in generated Nextra config
+ *     **Validates: Requirements 8.2, 8.3, 8.4**
+ */
+
+import { existsSync } from "node:fs";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import * as fc from "fast-check";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+async function makeTempDir(): Promise<string> {
+	return mkdtemp(join(tmpdir(), "jolli-nextrawriter-test-"));
+}
+
+const SAMPLE_CONFIG = {
+	title: "My API Docs",
+	description: "Documentation for My API",
+	nav: [
+		{ label: "Home", href: "/" },
+		{ label: "GitHub", href: "https://github.com/example" },
+	],
+};
+
+// ─── generatePackageJson unit tests ──────────────────────────────────────────
+
+describe("NextraProjectWriter.generatePackageJson", () => {
+	it("returns valid JSON", async () => {
+		const { generatePackageJson } = await import("./NextraProjectWriter.js");
+		const result = generatePackageJson();
+		expect(() => JSON.parse(result)).not.toThrow();
+	});
+
+	it("includes 'next' dependency", async () => {
+		const { generatePackageJson } = await import("./NextraProjectWriter.js");
+		const pkg = JSON.parse(generatePackageJson());
+		expect(pkg.dependencies).toHaveProperty("next");
+	});
+
+	it("includes 'nextra' dependency", async () => {
+		const { generatePackageJson } = await import("./NextraProjectWriter.js");
+		const pkg = JSON.parse(generatePackageJson());
+		expect(pkg.dependencies).toHaveProperty("nextra");
+	});
+
+	it("includes 'nextra-theme-docs' dependency", async () => {
+		const { generatePackageJson } = await import("./NextraProjectWriter.js");
+		const pkg = JSON.parse(generatePackageJson());
+		expect(pkg.dependencies).toHaveProperty("nextra-theme-docs");
+	});
+
+	it("includes 'react' dependency", async () => {
+		const { generatePackageJson } = await import("./NextraProjectWriter.js");
+		const pkg = JSON.parse(generatePackageJson());
+		expect(pkg.dependencies).toHaveProperty("react");
+	});
+
+	it("includes 'react-dom' dependency", async () => {
+		const { generatePackageJson } = await import("./NextraProjectWriter.js");
+		const pkg = JSON.parse(generatePackageJson());
+		expect(pkg.dependencies).toHaveProperty("react-dom");
+	});
+
+	it("includes 'swagger-ui-react' dependency", async () => {
+		const { generatePackageJson } = await import("./NextraProjectWriter.js");
+		const pkg = JSON.parse(generatePackageJson());
+		expect(pkg.dependencies).toHaveProperty("swagger-ui-react");
+	});
+
+	it("includes 'pagefind' dependency", async () => {
+		const { generatePackageJson } = await import("./NextraProjectWriter.js");
+		const pkg = JSON.parse(generatePackageJson());
+		expect(pkg.dependencies).toHaveProperty("pagefind");
+	});
+
+	it("sets name to 'jolli-site'", async () => {
+		const { generatePackageJson } = await import("./NextraProjectWriter.js");
+		const pkg = JSON.parse(generatePackageJson());
+		expect(pkg.name).toBe("jolli-site");
+	});
+
+	it("sets private to true", async () => {
+		const { generatePackageJson } = await import("./NextraProjectWriter.js");
+		const pkg = JSON.parse(generatePackageJson());
+		expect(pkg.private).toBe(true);
+	});
+
+	it("includes build script", async () => {
+		const { generatePackageJson } = await import("./NextraProjectWriter.js");
+		const pkg = JSON.parse(generatePackageJson());
+		expect(pkg.scripts).toHaveProperty("build");
+	});
+
+	it("includes dev script", async () => {
+		const { generatePackageJson } = await import("./NextraProjectWriter.js");
+		const pkg = JSON.parse(generatePackageJson());
+		expect(pkg.scripts).toHaveProperty("dev");
+	});
+
+	it("includes typescript devDependency", async () => {
+		const { generatePackageJson } = await import("./NextraProjectWriter.js");
+		const pkg = JSON.parse(generatePackageJson());
+		expect(pkg.devDependencies).toHaveProperty("typescript");
+	});
+});
+
+// ─── generateNextConfig unit tests ───────────────────────────────────────────
+
+describe("NextraProjectWriter.generateNextConfig", () => {
+	it("returns a non-empty string", async () => {
+		const { generateNextConfig } = await import("./NextraProjectWriter.js");
+		expect(generateNextConfig().length).toBeGreaterThan(0);
+	});
+
+	it("imports nextra", async () => {
+		const { generateNextConfig } = await import("./NextraProjectWriter.js");
+		expect(generateNextConfig()).toContain("import nextra from 'nextra'");
+	});
+
+	it("does NOT contain theme or themeConfig keys", async () => {
+		const { generateNextConfig } = await import("./NextraProjectWriter.js");
+		const config = generateNextConfig();
+		expect(config).not.toContain("theme:");
+		expect(config).not.toContain("themeConfig:");
+	});
+
+	it("uses export default", async () => {
+		const { generateNextConfig } = await import("./NextraProjectWriter.js");
+		expect(generateNextConfig()).toContain("export default");
+	});
+
+	it("calls withNextra with config object", async () => {
+		const { generateNextConfig } = await import("./NextraProjectWriter.js");
+		expect(generateNextConfig()).toContain("withNextra(");
+	});
+
+	it("includes static export config when staticExport is true", async () => {
+		const { generateNextConfig } = await import("./NextraProjectWriter.js");
+		const config = generateNextConfig(true);
+		expect(config).toContain("output: 'export'");
+		expect(config).toContain("unoptimized");
+	});
+
+	it("does not include static export config when staticExport is false", async () => {
+		const { generateNextConfig } = await import("./NextraProjectWriter.js");
+		const config = generateNextConfig(false);
+		expect(config).not.toContain("output: 'export'");
+	});
+});
+
+// ─── generateLayout unit tests ───────────────────────────────────────────────
+
+describe("NextraProjectWriter.generateLayout", () => {
+	it("returns a non-empty string", async () => {
+		const { generateLayout } = await import("./NextraProjectWriter.js");
+		expect(generateLayout(SAMPLE_CONFIG).length).toBeGreaterThan(0);
+	});
+
+	it("contains the site title", async () => {
+		const { generateLayout } = await import("./NextraProjectWriter.js");
+		expect(generateLayout(SAMPLE_CONFIG)).toContain("My API Docs");
+	});
+
+	it("contains the site description", async () => {
+		const { generateLayout } = await import("./NextraProjectWriter.js");
+		expect(generateLayout(SAMPLE_CONFIG)).toContain("Documentation for My API");
+	});
+
+	it("contains nav item labels", async () => {
+		const { generateLayout } = await import("./NextraProjectWriter.js");
+		const result = generateLayout(SAMPLE_CONFIG);
+		expect(result).toContain("Home");
+		expect(result).toContain("GitHub");
+	});
+
+	it("contains nav item hrefs", async () => {
+		const { generateLayout } = await import("./NextraProjectWriter.js");
+		const result = generateLayout(SAMPLE_CONFIG);
+		expect(result).toContain("/");
+		expect(result).toContain("https://github.com/example");
+	});
+
+	it("imports nextra-theme-docs Layout and Navbar", async () => {
+		const { generateLayout } = await import("./NextraProjectWriter.js");
+		const result = generateLayout(SAMPLE_CONFIG);
+		expect(result).toContain("nextra-theme-docs");
+		expect(result).toContain("Layout");
+		expect(result).toContain("Navbar");
+	});
+
+	it("exports a default function", async () => {
+		const { generateLayout } = await import("./NextraProjectWriter.js");
+		expect(generateLayout(SAMPLE_CONFIG)).toContain("export default");
+	});
+
+	it("includes metadata with title and description", async () => {
+		const { generateLayout } = await import("./NextraProjectWriter.js");
+		const result = generateLayout(SAMPLE_CONFIG);
+		expect(result).toContain("export const metadata");
+		expect(result).toContain("title:");
+		expect(result).toContain("description:");
+	});
+
+	it("handles empty nav array", async () => {
+		const { generateLayout } = await import("./NextraProjectWriter.js");
+		const config = { title: "Test", description: "Desc", nav: [] };
+		const result = generateLayout(config);
+		expect(result).toContain("Test");
+		expect(result).toContain("Desc");
+	});
+});
+
+// ─── generateMdxComponents unit tests ────────────────────────────────────────
+
+describe("NextraProjectWriter.generateMdxComponents", () => {
+	it("returns a non-empty string", async () => {
+		const { generateMdxComponents } = await import("./NextraProjectWriter.js");
+		expect(generateMdxComponents().length).toBeGreaterThan(0);
+	});
+
+	it("imports from nextra-theme-docs", async () => {
+		const { generateMdxComponents } = await import("./NextraProjectWriter.js");
+		expect(generateMdxComponents()).toContain("nextra-theme-docs");
+	});
+
+	it("exports useMDXComponents function", async () => {
+		const { generateMdxComponents } = await import("./NextraProjectWriter.js");
+		expect(generateMdxComponents()).toContain("useMDXComponents");
+	});
+});
+
+// ─── generateCatchAllPage unit tests ─────────────────────────────────────────
+
+describe("NextraProjectWriter.generateCatchAllPage", () => {
+	it("returns a non-empty string", async () => {
+		const { generateCatchAllPage } = await import("./NextraProjectWriter.js");
+		expect(generateCatchAllPage().length).toBeGreaterThan(0);
+	});
+
+	it("imports from nextra/pages", async () => {
+		const { generateCatchAllPage } = await import("./NextraProjectWriter.js");
+		const result = generateCatchAllPage();
+		expect(result).toContain("nextra/pages");
+		expect(result).toContain("importPage");
+		expect(result).toContain("generateStaticParamsFor");
+	});
+
+	it("exports generateStaticParams", async () => {
+		const { generateCatchAllPage } = await import("./NextraProjectWriter.js");
+		expect(generateCatchAllPage()).toContain("generateStaticParams");
+	});
+
+	it("exports a default Page component", async () => {
+		const { generateCatchAllPage } = await import("./NextraProjectWriter.js");
+		expect(generateCatchAllPage()).toContain("export default");
+	});
+
+	it("uses the Wrapper component from mdx-components", async () => {
+		const { generateCatchAllPage } = await import("./NextraProjectWriter.js");
+		expect(generateCatchAllPage()).toContain("Wrapper");
+		expect(generateCatchAllPage()).toContain("mdx-components");
+	});
+});
+
+// ─── generateTsConfig unit tests ─────────────────────────────────────────────
+
+describe("NextraProjectWriter.generateTsConfig", () => {
+	it("returns valid JSON", async () => {
+		const { generateTsConfig } = await import("./NextraProjectWriter.js");
+		expect(() => JSON.parse(generateTsConfig())).not.toThrow();
+	});
+
+	it("sets moduleResolution to bundler", async () => {
+		const { generateTsConfig } = await import("./NextraProjectWriter.js");
+		const tsconfig = JSON.parse(generateTsConfig());
+		expect(tsconfig.compilerOptions.moduleResolution).toBe("bundler");
+	});
+
+	it("sets jsx to preserve", async () => {
+		const { generateTsConfig } = await import("./NextraProjectWriter.js");
+		const tsconfig = JSON.parse(generateTsConfig());
+		expect(tsconfig.compilerOptions.jsx).toBe("preserve");
+	});
+});
+
+// ─── initNextraProject unit tests ────────────────────────────────────────────
+
+describe("NextraProjectWriter.initNextraProject", () => {
+	let tempDir: string;
+
+	beforeEach(async () => {
+		tempDir = await makeTempDir();
+	});
+
+	afterEach(async () => {
+		await rm(tempDir, { recursive: true, force: true });
+	});
+
+	// ── First run (isNew: true) ──────────────────────────────────────────────
+
+	it("returns { isNew: true } when buildDir does not exist", async () => {
+		const { initNextraProject } = await import("./NextraProjectWriter.js");
+		const buildDir = join(tempDir, ".jolli-site");
+
+		const result = await initNextraProject(buildDir, SAMPLE_CONFIG);
+
+		expect(result.isNew).toBe(true);
+	});
+
+	it("creates the buildDir on first run", async () => {
+		const { initNextraProject } = await import("./NextraProjectWriter.js");
+		const buildDir = join(tempDir, ".jolli-site");
+
+		await initNextraProject(buildDir, SAMPLE_CONFIG);
+
+		expect(existsSync(buildDir)).toBe(true);
+	});
+
+	it("creates the content/ subdirectory on first run", async () => {
+		const { initNextraProject } = await import("./NextraProjectWriter.js");
+		const buildDir = join(tempDir, ".jolli-site");
+
+		await initNextraProject(buildDir, SAMPLE_CONFIG);
+
+		expect(existsSync(join(buildDir, "content"))).toBe(true);
+	});
+
+	it("creates the app/ subdirectory on first run", async () => {
+		const { initNextraProject } = await import("./NextraProjectWriter.js");
+		const buildDir = join(tempDir, ".jolli-site");
+
+		await initNextraProject(buildDir, SAMPLE_CONFIG);
+
+		expect(existsSync(join(buildDir, "app"))).toBe(true);
+	});
+
+	it("writes package.json on first run", async () => {
+		const { initNextraProject } = await import("./NextraProjectWriter.js");
+		const buildDir = join(tempDir, ".jolli-site");
+
+		await initNextraProject(buildDir, SAMPLE_CONFIG);
+
+		expect(existsSync(join(buildDir, "package.json"))).toBe(true);
+	});
+
+	it("writes next.config.mjs on first run", async () => {
+		const { initNextraProject } = await import("./NextraProjectWriter.js");
+		const buildDir = join(tempDir, ".jolli-site");
+
+		await initNextraProject(buildDir, SAMPLE_CONFIG);
+
+		expect(existsSync(join(buildDir, "next.config.mjs"))).toBe(true);
+	});
+
+	it("writes app/layout.tsx on first run", async () => {
+		const { initNextraProject } = await import("./NextraProjectWriter.js");
+		const buildDir = join(tempDir, ".jolli-site");
+
+		await initNextraProject(buildDir, SAMPLE_CONFIG);
+
+		expect(existsSync(join(buildDir, "app", "layout.tsx"))).toBe(true);
+	});
+
+	it("writes app/[[...mdxPath]]/page.tsx on first run", async () => {
+		const { initNextraProject } = await import("./NextraProjectWriter.js");
+		const buildDir = join(tempDir, ".jolli-site");
+
+		await initNextraProject(buildDir, SAMPLE_CONFIG);
+
+		expect(existsSync(join(buildDir, "app", "[[...mdxPath]]", "page.tsx"))).toBe(true);
+	});
+
+	it("writes mdx-components.tsx on first run", async () => {
+		const { initNextraProject } = await import("./NextraProjectWriter.js");
+		const buildDir = join(tempDir, ".jolli-site");
+
+		await initNextraProject(buildDir, SAMPLE_CONFIG);
+
+		expect(existsSync(join(buildDir, "mdx-components.tsx"))).toBe(true);
+	});
+
+	it("writes tsconfig.json on first run", async () => {
+		const { initNextraProject } = await import("./NextraProjectWriter.js");
+		const buildDir = join(tempDir, ".jolli-site");
+
+		await initNextraProject(buildDir, SAMPLE_CONFIG);
+
+		expect(existsSync(join(buildDir, "tsconfig.json"))).toBe(true);
+	});
+
+	// ── Subsequent run (isNew: false) ────────────────────────────────────────
+
+	it("returns { isNew: false } when buildDir already exists", async () => {
+		const { initNextraProject } = await import("./NextraProjectWriter.js");
+		const buildDir = join(tempDir, ".jolli-site");
+
+		// First run
+		await initNextraProject(buildDir, SAMPLE_CONFIG);
+		// Second run
+		const result = await initNextraProject(buildDir, SAMPLE_CONFIG);
+
+		expect(result.isNew).toBe(false);
+	});
+
+	it("regenerates app/layout.tsx with updated title on subsequent run", async () => {
+		const { initNextraProject } = await import("./NextraProjectWriter.js");
+		const buildDir = join(tempDir, ".jolli-site");
+
+		await initNextraProject(buildDir, SAMPLE_CONFIG);
+
+		const updatedConfig = { ...SAMPLE_CONFIG, title: "Updated Title" };
+		await initNextraProject(buildDir, updatedConfig);
+
+		const layoutContent = await readFile(join(buildDir, "app", "layout.tsx"), "utf-8");
+		expect(layoutContent).toContain("Updated Title");
+	});
+
+	it("regenerates app/layout.tsx with updated description on subsequent run", async () => {
+		const { initNextraProject } = await import("./NextraProjectWriter.js");
+		const buildDir = join(tempDir, ".jolli-site");
+
+		await initNextraProject(buildDir, SAMPLE_CONFIG);
+
+		const updatedConfig = { ...SAMPLE_CONFIG, description: "New description" };
+		await initNextraProject(buildDir, updatedConfig);
+
+		const layoutContent = await readFile(join(buildDir, "app", "layout.tsx"), "utf-8");
+		expect(layoutContent).toContain("New description");
+	});
+
+	it("regenerates app/layout.tsx with updated nav on subsequent run", async () => {
+		const { initNextraProject } = await import("./NextraProjectWriter.js");
+		const buildDir = join(tempDir, ".jolli-site");
+
+		await initNextraProject(buildDir, SAMPLE_CONFIG);
+
+		const updatedConfig = {
+			...SAMPLE_CONFIG,
+			nav: [{ label: "New Link", href: "/new" }],
+		};
+		await initNextraProject(buildDir, updatedConfig);
+
+		const layoutContent = await readFile(join(buildDir, "app", "layout.tsx"), "utf-8");
+		expect(layoutContent).toContain("New Link");
+		expect(layoutContent).toContain("/new");
+	});
+
+	it("written package.json is valid JSON with required dependencies", async () => {
+		const { initNextraProject } = await import("./NextraProjectWriter.js");
+		const buildDir = join(tempDir, ".jolli-site");
+
+		await initNextraProject(buildDir, SAMPLE_CONFIG);
+
+		const content = await readFile(join(buildDir, "package.json"), "utf-8");
+		const pkg = JSON.parse(content);
+		expect(pkg.dependencies).toHaveProperty("next");
+		expect(pkg.dependencies).toHaveProperty("nextra");
+		expect(pkg.dependencies).toHaveProperty("nextra-theme-docs");
+		expect(pkg.dependencies).toHaveProperty("react");
+		expect(pkg.dependencies).toHaveProperty("react-dom");
+		expect(pkg.dependencies).toHaveProperty("swagger-ui-react");
+		expect(pkg.dependencies).toHaveProperty("pagefind");
+	});
+
+	it("written next.config.mjs contains nextra configuration", async () => {
+		const { initNextraProject } = await import("./NextraProjectWriter.js");
+		const buildDir = join(tempDir, ".jolli-site");
+
+		await initNextraProject(buildDir, SAMPLE_CONFIG);
+
+		const content = await readFile(join(buildDir, "next.config.mjs"), "utf-8");
+		expect(content).toContain("nextra");
+		expect(content).toContain("export default");
+	});
+});
+
+// ─── Property-based tests ─────────────────────────────────────────────────────
+
+/**
+ * Property 5: site.json fields are preserved in generated Nextra config
+ * **Validates: Requirements 8.2, 8.3, 8.4**
+ */
+describe("Property 5: site.json fields are preserved in generated Nextra config", () => {
+	// Generate safe non-empty strings for title and description.
+	const nonEmptyString = fc
+		.stringMatching(/^[a-zA-Z0-9 !#$%&'()*+,\-./:;=?@[\]^_`|~]{1,50}$/)
+		.filter((s) => s.trim().length > 0);
+
+	// Generate safe nav items
+	const navItem = fc.record({
+		label: nonEmptyString,
+		href: fc.oneof(
+			fc.constant("/"),
+			fc.constant("/docs"),
+			fc.constant("https://example.com"),
+			nonEmptyString.map((s) => `/${s}`),
+		),
+	});
+
+	it("generateLayout always contains the exact title string", async () => {
+		const { generateLayout } = await import("./NextraProjectWriter.js");
+
+		fc.assert(
+			fc.property(
+				nonEmptyString,
+				nonEmptyString,
+				fc.array(navItem, { minLength: 0, maxLength: 5 }),
+				(title, description, nav) => {
+					const config = { title, description, nav };
+					const result = generateLayout(config);
+					return result.includes(title);
+				},
+			),
+			{ numRuns: 100 },
+		);
+	});
+
+	it("generateLayout always contains the exact description string", async () => {
+		const { generateLayout } = await import("./NextraProjectWriter.js");
+
+		fc.assert(
+			fc.property(
+				nonEmptyString,
+				nonEmptyString,
+				fc.array(navItem, { minLength: 0, maxLength: 5 }),
+				(title, description, nav) => {
+					const config = { title, description, nav };
+					const result = generateLayout(config);
+					return result.includes(description);
+				},
+			),
+			{ numRuns: 100 },
+		);
+	});
+
+	it("generateLayout always contains all nav item labels", async () => {
+		const { generateLayout } = await import("./NextraProjectWriter.js");
+
+		fc.assert(
+			fc.property(
+				nonEmptyString,
+				nonEmptyString,
+				fc.array(navItem, { minLength: 1, maxLength: 5 }),
+				(title, description, nav) => {
+					const config = { title, description, nav };
+					const result = generateLayout(config);
+					return nav.every(({ label }) => result.includes(label));
+				},
+			),
+			{ numRuns: 100 },
+		);
+	});
+
+	it("generateLayout always contains all nav item hrefs", async () => {
+		const { generateLayout } = await import("./NextraProjectWriter.js");
+
+		fc.assert(
+			fc.property(
+				nonEmptyString,
+				nonEmptyString,
+				fc.array(navItem, { minLength: 1, maxLength: 5 }),
+				(title, description, nav) => {
+					const config = { title, description, nav };
+					const result = generateLayout(config);
+					return nav.every(({ href }) => result.includes(href));
+				},
+			),
+			{ numRuns: 100 },
+		);
+	});
+
+	it("generatePackageJson always produces valid JSON regardless of config", async () => {
+		const { generatePackageJson } = await import("./NextraProjectWriter.js");
+
+		fc.assert(
+			fc.property(
+				nonEmptyString,
+				nonEmptyString,
+				fc.array(navItem, { minLength: 0, maxLength: 5 }),
+				(title, description, nav) => {
+					const config = { title, description, nav };
+					try {
+						JSON.parse(generatePackageJson());
+						return true;
+					} catch {
+						return false;
+					}
+				},
+			),
+			{ numRuns: 100 },
+		);
+	});
+
+	it("generatePackageJson always includes all required dependencies", async () => {
+		const { generatePackageJson } = await import("./NextraProjectWriter.js");
+
+		const requiredDeps = [
+			"next",
+			"nextra",
+			"nextra-theme-docs",
+			"react",
+			"react-dom",
+			"swagger-ui-react",
+			"pagefind",
+		];
+
+		fc.assert(
+			fc.property(
+				nonEmptyString,
+				nonEmptyString,
+				fc.array(navItem, { minLength: 0, maxLength: 5 }),
+				(title, description, nav) => {
+					const config = { title, description, nav };
+					const pkg = JSON.parse(generatePackageJson());
+					return requiredDeps.every((dep) => dep in pkg.dependencies);
+				},
+			),
+			{ numRuns: 100 },
+		);
+	});
+});

--- a/cli/src/site/NextraProjectWriter.test.ts
+++ b/cli/src/site/NextraProjectWriter.test.ts
@@ -595,8 +595,7 @@ describe("Property 5: site.json fields are preserved in generated Nextra config"
 				nonEmptyString,
 				nonEmptyString,
 				fc.array(navItem, { minLength: 0, maxLength: 5 }),
-				(title, description, nav) => {
-					const config = { title, description, nav };
+				(_title, _description, _nav) => {
 					try {
 						JSON.parse(generatePackageJson());
 						return true;
@@ -627,8 +626,7 @@ describe("Property 5: site.json fields are preserved in generated Nextra config"
 				nonEmptyString,
 				nonEmptyString,
 				fc.array(navItem, { minLength: 0, maxLength: 5 }),
-				(title, description, nav) => {
-					const config = { title, description, nav };
+				(_title, _description, _nav) => {
 					const pkg = JSON.parse(generatePackageJson());
 					return requiredDeps.every((dep) => dep in pkg.dependencies);
 				},

--- a/cli/src/site/NextraProjectWriter.ts
+++ b/cli/src/site/NextraProjectWriter.ts
@@ -1,0 +1,274 @@
+/**
+ * NextraProjectWriter — writes and maintains the Nextra v4 project scaffold
+ * inside `.jolli-site/`.
+ *
+ * Generates `package.json`, `next.config.mjs`, `app/layout.tsx`,
+ * `mdx-components.tsx`, and `tsconfig.json` into the build directory. On
+ * subsequent runs, regenerates these files with updated config values
+ * (incremental update, not a full recreate).
+ *
+ * Nextra v4 requires the App Router — content lives in `content/` (not
+ * `pages/`), and the theme is configured via component props in
+ * `app/layout.tsx` rather than a standalone `theme.config.tsx`.
+ */
+
+import { existsSync } from "node:fs";
+import { mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+// ─── NextraProjectConfig ──────────────────────────────────────────────────────
+
+/**
+ * Configuration derived from `site.json` that drives the generated Nextra
+ * project files.
+ */
+export interface NextraProjectConfig {
+	title: string;
+	description: string;
+	nav: Array<{ label: string; href: string }>;
+}
+
+// ─── initNextraProject ────────────────────────────────────────────────────────
+
+/**
+ * Initialises (or updates) the Nextra v4 project scaffold inside `buildDir`.
+ *
+ * - If `buildDir` does not exist: creates it, writes all config files, and
+ *   returns `{ isNew: true }`.
+ * - If `buildDir` already exists: regenerates the config files with the
+ *   latest values from `config` and returns `{ isNew: false }`.
+ *
+ * In both cases the `content/` subdirectory is created (or left intact).
+ */
+export async function initNextraProject(
+	buildDir: string,
+	config: NextraProjectConfig,
+	options: { staticExport?: boolean } = {},
+): Promise<{ isNew: boolean }> {
+	const isNew = !existsSync(buildDir);
+
+	// Create the build directory and subdirectories if needed.
+	await mkdir(join(buildDir, "content"), { recursive: true });
+	await mkdir(join(buildDir, "app", "[[...mdxPath]]"), { recursive: true });
+
+	// Always regenerate config files so they reflect the latest site.json values.
+	await writeFile(join(buildDir, "package.json"), generatePackageJson(), "utf-8");
+	await writeFile(join(buildDir, "next.config.mjs"), generateNextConfig(options.staticExport), "utf-8");
+	await writeFile(join(buildDir, "app", "layout.tsx"), generateLayout(config), "utf-8");
+	await writeFile(join(buildDir, "app", "[[...mdxPath]]", "page.tsx"), generateCatchAllPage(), "utf-8");
+	await writeFile(join(buildDir, "mdx-components.tsx"), generateMdxComponents(), "utf-8");
+	await writeFile(join(buildDir, "tsconfig.json"), generateTsConfig(), "utf-8");
+
+	return { isNew };
+}
+
+// ─── generatePackageJson ──────────────────────────────────────────────────────
+
+/**
+ * Returns the contents of the `package.json` that should be written into the
+ * hidden build directory.
+ *
+ * Includes all dependencies required by a Nextra v4 docs site:
+ *   next, nextra, nextra-theme-docs, react, react-dom, swagger-ui-react,
+ *   and pagefind.
+ */
+/** Runtime dependencies for a Nextra v4 docs site. Shared with EngineManager. */
+export const NEXTRA_DEPENDENCIES: Record<string, string> = {
+	next: "^15.0.0",
+	nextra: "4.2.17",
+	"nextra-theme-docs": "4.2.17",
+	react: "^19.0.0",
+	"react-dom": "^19.0.0",
+	"swagger-ui-react": "^5.0.0",
+	pagefind: "^1.0.0",
+};
+
+/** Dev dependencies for a Nextra v4 docs site. Shared with EngineManager. */
+export const NEXTRA_DEV_DEPENDENCIES: Record<string, string> = {
+	"@types/react": "^19.0.0",
+	typescript: "^5.0.0",
+};
+
+export function generatePackageJson(): string {
+	const pkg = {
+		name: "jolli-site",
+		version: "0.0.1",
+		private: true,
+		scripts: {
+			dev: "next dev",
+			build: "next build",
+			start: "next start",
+		},
+		dependencies: { ...NEXTRA_DEPENDENCIES },
+		devDependencies: { ...NEXTRA_DEV_DEPENDENCIES },
+	};
+
+	return JSON.stringify(pkg, null, 2);
+}
+
+// ─── generateNextConfig ───────────────────────────────────────────────────────
+
+/**
+ * Returns the contents of `next.config.mjs` — a minimal valid Nextra v4
+ * configuration that enables static export.
+ *
+ * Nextra v4 no longer accepts `theme` or `themeConfig` options — those are
+ * configured via `app/layout.tsx` and `mdx-components.tsx` instead.
+ */
+export function generateNextConfig(staticExport?: boolean): string {
+	const exportLines = staticExport ? `\n  output: 'export',\n  images: { unoptimized: true },` : "";
+
+	return `import nextra from 'nextra'
+
+const withNextra = nextra({
+  contentDirBasePath: '/'
+})
+
+export default withNextra({${exportLines}
+  webpack(config) {
+    config.resolve.preferRelative = true
+    return config
+  }
+})
+`;
+}
+
+// ─── generateLayout ──────────────────────────────────────────────────────────
+
+/**
+ * Returns the contents of `app/layout.tsx` — the root layout for the Nextra v4
+ * docs theme.
+ *
+ * Maps `title`, `description`, and `nav` from `site.json` into the Nextra
+ * Layout, Navbar, and Footer components.
+ */
+export function generateLayout(config: NextraProjectConfig): string {
+	const { title, description, nav } = config;
+
+	const jsTitle = JSON.stringify(title);
+	const jsDescription = JSON.stringify(description);
+
+	// Build navbar children from nav items (Navbar uses `children` for extra content).
+	const navLinks = nav
+		.map(({ label, href }) => {
+			const jsLabel = JSON.stringify(label);
+			const jsHref = JSON.stringify(href);
+			return `          <a href={${jsHref}} style={{ marginLeft: '1rem' }}>{${jsLabel}}</a>`;
+		})
+		.join("\n");
+
+	const navbarChildren = nav.length > 0 ? `\n${navLinks}\n        ` : "";
+
+	return `import { Footer, Layout, Navbar } from 'nextra-theme-docs'
+import { Head } from 'nextra/components'
+import { getPageMap } from 'nextra/page-map'
+import 'nextra-theme-docs/style.css'
+
+export const metadata = {
+  title: ${jsTitle},
+  description: ${jsDescription},
+}
+
+export default async function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en" dir="ltr" suppressHydrationWarning>
+      <Head />
+      <body>
+        <Layout
+          navbar={
+            <Navbar logo={<b>{${jsTitle}}</b>}>${navbarChildren}</Navbar>
+          }
+          pageMap={await getPageMap()}
+          footer={<Footer />}
+        >
+          {children}
+        </Layout>
+      </body>
+    </html>
+  )
+}
+`;
+}
+
+// ─── generateMdxComponents ───────────────────────────────────────────────────
+
+/**
+ * Returns the contents of `mdx-components.tsx` — required by Nextra v4 to
+ * wire up the docs theme's MDX components.
+ */
+export function generateMdxComponents(): string {
+	return `import { useMDXComponents as getDocsMDXComponents } from 'nextra-theme-docs'
+
+const docsComponents = getDocsMDXComponents()
+
+export function useMDXComponents(components: Record<string, React.ComponentType>) {
+  return {
+    ...docsComponents,
+    ...components,
+  }
+}
+`;
+}
+
+// ─── generateCatchAllPage ────────────────────────────────────────────────────
+
+/**
+ * Returns the contents of `app/[[...mdxPath]]/page.tsx` — the catch-all route
+ * required by Nextra v4 to render content from the `content/` directory.
+ *
+ * Uses `importPage` and `generateStaticParamsFor` from `nextra/pages` and
+ * the `wrapper` component from `mdx-components` to render each page with
+ * its table of contents and metadata.
+ */
+export function generateCatchAllPage(): string {
+	return `import { generateStaticParamsFor, importPage } from 'nextra/pages'
+import { useMDXComponents } from '../../mdx-components'
+
+export const generateStaticParams = generateStaticParamsFor('mdxPath')
+
+export async function generateMetadata(props: { params: Promise<{ mdxPath?: string[] }> }) {
+  const params = await props.params
+  const { metadata } = await importPage(params.mdxPath)
+  return metadata
+}
+
+const Wrapper = useMDXComponents({}).wrapper
+
+export default async function Page(props: { params: Promise<{ mdxPath?: string[] }> }) {
+  const params = await props.params
+  const result = await importPage(params.mdxPath)
+  const { default: MDXContent, toc, metadata } = result
+  return (
+    <Wrapper toc={toc} metadata={metadata}>
+      <MDXContent />
+    </Wrapper>
+  )
+}
+`;
+}
+
+// ─── generateTsConfig ────────────────────────────────────────────────────────
+
+/**
+ * Returns a minimal `tsconfig.json` for the generated Nextra v4 project.
+ */
+export function generateTsConfig(): string {
+	const tsconfig = {
+		compilerOptions: {
+			target: "ES2020",
+			lib: ["ES2020", "DOM", "DOM.Iterable"],
+			jsx: "preserve",
+			module: "ESNext",
+			moduleResolution: "bundler",
+			resolveJsonModule: true,
+			isolatedModules: true,
+			strict: true,
+			skipLibCheck: true,
+			esModuleInterop: true,
+		},
+		include: ["**/*.ts", "**/*.tsx", "mdx-components.tsx"],
+		exclude: ["node_modules"],
+	};
+
+	return JSON.stringify(tsconfig, null, 2);
+}

--- a/cli/src/site/NpmRunner.test.ts
+++ b/cli/src/site/NpmRunner.test.ts
@@ -1,0 +1,368 @@
+/**
+ * Tests for NpmRunner — runs npm commands inside the Hidden Build Directory.
+ *
+ * Covers all acceptance criteria from Task 8:
+ *   - needsInstall returns true when node_modules/ does not exist
+ *   - needsInstall returns false when node_modules/ exists
+ *   - runNpmInstall returns { success: true, output } on exit code 0
+ *   - runNpmInstall returns { success: false, output } on non-zero exit code
+ *   - runNpmBuild returns { success: true, output } on exit code 0
+ *   - runNpmBuild returns { success: false, output } on non-zero exit code
+ *   - stdout and stderr are combined into the output string
+ *   - errors are returned (not thrown) on non-zero exit codes
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+
+const { mockSpawnSync, mockSpawn } = vi.hoisted(() => ({
+	mockSpawnSync: vi.fn(),
+	mockSpawn: vi.fn(),
+}));
+
+vi.mock("node:child_process", () => ({
+	spawnSync: mockSpawnSync,
+	spawn: mockSpawn,
+}));
+
+const { mockExistsSync } = vi.hoisted(() => ({
+	mockExistsSync: vi.fn(),
+}));
+
+const { mockEngineNeedsInstall, mockEnsureEngine, mockLinkEngineModules } = vi.hoisted(() => ({
+	mockEngineNeedsInstall: vi.fn(),
+	mockEnsureEngine: vi.fn(),
+	mockLinkEngineModules: vi.fn(),
+}));
+
+vi.mock("./EngineManager.js", () => ({
+	engineNeedsInstall: mockEngineNeedsInstall,
+	ensureEngine: mockEnsureEngine,
+	linkEngineModules: mockLinkEngineModules,
+}));
+
+vi.mock("./OutputFilter.js", () => ({
+	createOutputFilter: () => ({
+		write: vi.fn(),
+		getUrl: () => "http://localhost:3000",
+	}),
+}));
+
+vi.mock("node:fs", () => ({
+	existsSync: mockExistsSync,
+}));
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/** Creates a mock spawnSync result with the given exit code and output. */
+function makeSpawnResult(status: number, stdout = "", stderr = "") {
+	return {
+		status,
+		stdout: Buffer.from(stdout),
+		stderr: Buffer.from(stderr),
+		pid: 1234,
+		output: [],
+		signal: null,
+	};
+}
+
+// ─── needsInstall ─────────────────────────────────────────────────────────────
+
+describe("NpmRunner.needsInstall", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("returns true when engine needs install", async () => {
+		const { needsInstall } = await import("./NpmRunner.js");
+		mockEngineNeedsInstall.mockReturnValue(true);
+		mockExistsSync.mockReturnValue(true);
+
+		expect(needsInstall("/build/dir")).toBe(true);
+	});
+
+	it("returns true when project node_modules symlink is missing", async () => {
+		const { needsInstall } = await import("./NpmRunner.js");
+		mockEngineNeedsInstall.mockReturnValue(false);
+		mockExistsSync.mockReturnValue(false);
+
+		expect(needsInstall("/build/dir")).toBe(true);
+	});
+
+	it("returns false when engine is ready and project has node_modules", async () => {
+		const { needsInstall } = await import("./NpmRunner.js");
+		mockEngineNeedsInstall.mockReturnValue(false);
+		mockExistsSync.mockReturnValue(true);
+
+		expect(needsInstall("/build/dir")).toBe(false);
+	});
+
+	it("checks the node_modules path inside buildDir", async () => {
+		const { needsInstall } = await import("./NpmRunner.js");
+		mockEngineNeedsInstall.mockReturnValue(false);
+		mockExistsSync.mockReturnValue(false);
+
+		needsInstall("/my/build/dir");
+
+		expect(mockExistsSync).toHaveBeenCalledWith("/my/build/dir/node_modules");
+	});
+});
+
+// ─── runNpmInstall ────────────────────────────────────────────────────────────
+
+describe("NpmRunner.runNpmInstall", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockEnsureEngine.mockResolvedValue({ success: true, output: "" });
+		mockLinkEngineModules.mockResolvedValue(undefined);
+	});
+
+	it("returns success when engine install and link succeed", async () => {
+		const { runNpmInstall } = await import("./NpmRunner.js");
+
+		const result = await runNpmInstall("/build/dir");
+
+		expect(result.success).toBe(true);
+	});
+
+	it("calls ensureEngine before linkEngineModules", async () => {
+		const { runNpmInstall } = await import("./NpmRunner.js");
+		const order: string[] = [];
+		mockEnsureEngine.mockImplementation(async () => {
+			order.push("ensureEngine");
+			return { success: true, output: "" };
+		});
+		mockLinkEngineModules.mockImplementation(async () => {
+			order.push("linkEngineModules");
+		});
+
+		await runNpmInstall("/build/dir");
+
+		expect(order).toEqual(["ensureEngine", "linkEngineModules"]);
+	});
+
+	it("passes buildDir to linkEngineModules", async () => {
+		const { runNpmInstall } = await import("./NpmRunner.js");
+
+		await runNpmInstall("/my/build/dir");
+
+		expect(mockLinkEngineModules).toHaveBeenCalledWith("/my/build/dir");
+	});
+
+	it("returns failure when engine install fails", async () => {
+		const { runNpmInstall } = await import("./NpmRunner.js");
+		mockEnsureEngine.mockResolvedValue({ success: false, output: "npm ERR!" });
+
+		const result = await runNpmInstall("/build/dir");
+
+		expect(result.success).toBe(false);
+		expect(result.output).toContain("npm ERR!");
+	});
+
+	it("does not call linkEngineModules when engine install fails", async () => {
+		const { runNpmInstall } = await import("./NpmRunner.js");
+		mockEnsureEngine.mockResolvedValue({ success: false, output: "fail" });
+
+		await runNpmInstall("/build/dir");
+
+		expect(mockLinkEngineModules).not.toHaveBeenCalled();
+	});
+
+	it("returns failure message when engine output is empty", async () => {
+		const { runNpmInstall } = await import("./NpmRunner.js");
+		mockEnsureEngine.mockResolvedValue({ success: false, output: "" });
+
+		const result = await runNpmInstall("/build/dir");
+
+		expect(result.success).toBe(false);
+		expect(result.output).toContain("Engine install failed");
+	});
+});
+
+// ─── runNpmBuild ──────────────────────────────────────────────────────────────
+
+describe("NpmRunner.runNpmBuild", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("returns { success: true } when npm run build exits with code 0", async () => {
+		const { runNpmBuild } = await import("./NpmRunner.js");
+		mockSpawnSync.mockReturnValue(makeSpawnResult(0, "Build successful"));
+
+		const result = await runNpmBuild("/build/dir");
+
+		expect(result.success).toBe(true);
+	});
+
+	it("returns { success: false } when npm run build exits with non-zero code", async () => {
+		const { runNpmBuild } = await import("./NpmRunner.js");
+		mockSpawnSync.mockReturnValue(makeSpawnResult(1, "", "Build failed"));
+
+		const result = await runNpmBuild("/build/dir");
+
+		expect(result.success).toBe(false);
+	});
+
+	it("includes stdout in output on success", async () => {
+		const { runNpmBuild } = await import("./NpmRunner.js");
+		mockSpawnSync.mockReturnValue(makeSpawnResult(0, "Build successful", ""));
+
+		const result = await runNpmBuild("/build/dir");
+
+		expect(result.output).toContain("Build successful");
+	});
+
+	it("includes stderr in output on failure", async () => {
+		const { runNpmBuild } = await import("./NpmRunner.js");
+		mockSpawnSync.mockReturnValue(makeSpawnResult(1, "", "Build failed"));
+
+		const result = await runNpmBuild("/build/dir");
+
+		expect(result.output).toContain("Build failed");
+	});
+
+	it("combines stdout and stderr into output", async () => {
+		const { runNpmBuild } = await import("./NpmRunner.js");
+		mockSpawnSync.mockReturnValue(makeSpawnResult(1, "partial output", "error details"));
+
+		const result = await runNpmBuild("/build/dir");
+
+		expect(result.output).toContain("partial output");
+		expect(result.output).toContain("error details");
+	});
+
+	it("does not throw on non-zero exit code", async () => {
+		const { runNpmBuild } = await import("./NpmRunner.js");
+		mockSpawnSync.mockReturnValue(makeSpawnResult(1, "", "fatal build error"));
+
+		await expect(runNpmBuild("/build/dir")).resolves.not.toThrow();
+	});
+
+	it("calls spawnSync with npm run build and the correct cwd", async () => {
+		const { runNpmBuild } = await import("./NpmRunner.js");
+		mockSpawnSync.mockReturnValue(makeSpawnResult(0));
+
+		await runNpmBuild("/my/build/dir");
+
+		expect(mockSpawnSync).toHaveBeenCalledWith(expect.any(String), ["run", "build"], {
+			cwd: "/my/build/dir",
+			stdio: "pipe",
+		});
+	});
+
+	it("handles null stdout and stderr gracefully", async () => {
+		const { runNpmBuild } = await import("./NpmRunner.js");
+		mockSpawnSync.mockReturnValue({
+			status: 0,
+			stdout: null,
+			stderr: null,
+			pid: 1234,
+			output: [],
+			signal: null,
+		});
+
+		const result = await runNpmBuild("/build/dir");
+
+		expect(result.success).toBe(true);
+		expect(result.output).toBe("");
+	});
+});
+
+// ─── runNpmDev ───────────────────────────────────────────────────────────────
+
+/** Creates a mock ChildProcess with stdout/stderr streams for pipe mode. */
+function makeMockChild() {
+	const handlers: Record<string, ((...args: unknown[]) => void)[]> = {};
+	const streamHandlers: Record<string, ((...args: unknown[]) => void)[]> = {};
+	const mockStream = {
+		on(event: string, handler: (...args: unknown[]) => void) {
+			if (!streamHandlers[event]) streamHandlers[event] = [];
+			streamHandlers[event].push(handler);
+			return this;
+		},
+	};
+	return {
+		stdout: mockStream,
+		stderr: { on: vi.fn() },
+		on(event: string, handler: (...args: unknown[]) => void) {
+			if (!handlers[event]) handlers[event] = [];
+			handlers[event].push(handler);
+			return this;
+		},
+		emit(event: string, ...args: unknown[]) {
+			for (const h of handlers[event] ?? []) h(...args);
+		},
+	};
+}
+
+describe("NpmRunner.runNpmDev", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("returns { success: true } when the dev server exits with code 0", async () => {
+		const { runNpmDev } = await import("./NpmRunner.js");
+		const child = makeMockChild();
+		mockSpawn.mockReturnValue(child);
+
+		const promise = runNpmDev("/build/dir");
+		child.emit("close", 0);
+
+		const result = await promise;
+		expect(result.success).toBe(true);
+	});
+
+	it("returns { success: true } when the dev server exits with null code (SIGINT)", async () => {
+		const { runNpmDev } = await import("./NpmRunner.js");
+		const child = makeMockChild();
+		mockSpawn.mockReturnValue(child);
+
+		const promise = runNpmDev("/build/dir");
+		child.emit("close", null);
+
+		const result = await promise;
+		expect(result.success).toBe(true);
+	});
+
+	it("returns { success: false } when the dev server exits with non-zero code", async () => {
+		const { runNpmDev } = await import("./NpmRunner.js");
+		const child = makeMockChild();
+		mockSpawn.mockReturnValue(child);
+
+		const promise = runNpmDev("/build/dir");
+		child.emit("close", 1);
+
+		const result = await promise;
+		expect(result.success).toBe(false);
+	});
+
+	it("returns { success: false } with error message on spawn error", async () => {
+		const { runNpmDev } = await import("./NpmRunner.js");
+		const child = makeMockChild();
+		mockSpawn.mockReturnValue(child);
+
+		const promise = runNpmDev("/build/dir");
+		child.emit("error", new Error("spawn ENOENT"));
+
+		const result = await promise;
+		expect(result.success).toBe(false);
+		expect(result.output).toContain("spawn ENOENT");
+	});
+
+	it("calls spawn with npm run dev and the correct cwd", async () => {
+		const { runNpmDev } = await import("./NpmRunner.js");
+		const child = makeMockChild();
+		mockSpawn.mockReturnValue(child);
+
+		const promise = runNpmDev("/my/build/dir");
+		child.emit("close", 0);
+		await promise;
+
+		expect(mockSpawn).toHaveBeenCalledWith(expect.any(String), ["run", "dev"], {
+			cwd: "/my/build/dir",
+			stdio: "pipe",
+		});
+	});
+});

--- a/cli/src/site/NpmRunner.ts
+++ b/cli/src/site/NpmRunner.ts
@@ -1,0 +1,123 @@
+/**
+ * NpmRunner — runs npm commands inside the Hidden Build Directory.
+ *
+ * Uses `child_process.spawnSync` with `stdio: 'pipe'` to capture output.
+ * Returns `{ success: false, output }` on non-zero exit codes rather than
+ * throwing, so the caller can print the error and set the exit code.
+ */
+
+import { spawn, spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { engineNeedsInstall, ensureEngine, linkEngineModules } from "./EngineManager.js";
+import { createOutputFilter } from "./OutputFilter.js";
+import type { NpmRunResult } from "./Types.js";
+
+/** On Windows, npm/npx must be invoked as npm.cmd/npx.cmd. */
+const NPM = process.platform === "win32" ? /* v8 ignore next */ "npm.cmd" : "npm";
+const NPX = process.platform === "win32" ? /* v8 ignore next */ "npx.cmd" : "npx";
+
+export type { NpmRunResult };
+
+/**
+ * Returns `true` if the shared engine needs (re)installation or
+ * the project's `node_modules` symlink is missing.
+ */
+export function needsInstall(buildDir: string): boolean {
+	if (engineNeedsInstall()) return true;
+	return !existsSync(join(buildDir, "node_modules"));
+}
+
+/**
+ * Ensures the shared engine is installed and creates a symlink
+ * from `buildDir/node_modules` to the engine's `node_modules`.
+ */
+export async function runNpmInstall(buildDir: string): Promise<NpmRunResult> {
+	const engineResult = await ensureEngine();
+	if (!engineResult.success) {
+		return { success: false, output: engineResult.output || "Engine install failed" };
+	}
+	await linkEngineModules(buildDir);
+	return { success: true, output: "" };
+}
+
+/**
+ * Runs `npm run build` inside `buildDir`.
+ */
+export async function runNpmBuild(buildDir: string): Promise<NpmRunResult> {
+	const result = spawnSync(NPM, ["run", "build"], {
+		cwd: buildDir,
+		stdio: "pipe",
+	});
+
+	const stdout = result.stdout ? result.stdout.toString() : "";
+	const stderr = result.stderr ? result.stderr.toString() : "";
+	const output = [stdout, stderr].filter(Boolean).join("\n");
+
+	if (result.status === 0) {
+		return { success: true, output };
+	}
+
+	return { success: false, output };
+}
+
+/** Result from a long-running server process. */
+export interface ServerResult extends NpmRunResult {
+	/** The localhost URL extracted from server output. */
+	url?: string;
+}
+
+/**
+ * Runs `npm run dev` (next dev) inside `buildDir` as a long-running process.
+ *
+ * Output is piped through an OutputFilter. In default mode, only errors
+ * and the server URL are shown. In verbose mode, all output is streamed.
+ */
+export function runNpmDev(buildDir: string, verbose = false): Promise<ServerResult> {
+	return runLongProcess(NPM, ["run", "dev"], buildDir, verbose);
+}
+
+/**
+ * Serves the static `out/` directory inside `buildDir` using `npx serve`.
+ */
+export function runServe(buildDir: string, verbose = false): Promise<ServerResult> {
+	return runLongProcess(NPX, ["serve", "out"], buildDir, verbose);
+}
+
+/**
+ * Shared implementation for long-running server processes.
+ * Pipes output through OutputFilter and extracts the server URL.
+ */
+function runLongProcess(cmd: string, args: string[], cwd: string, verbose: boolean): Promise<ServerResult> {
+	return new Promise((resolve) => {
+		const filter = createOutputFilter(verbose);
+
+		const child = spawn(cmd, args, {
+			cwd,
+			stdio: "pipe",
+		});
+
+		child.stdout?.on("data", (data: Buffer) => {
+			filter.write(data.toString());
+		});
+
+		child.stderr?.on("data", (data: Buffer) => {
+			filter.write(data.toString());
+		});
+
+		child.on("close", (code) => {
+			resolve({
+				success: code === 0 || code === null,
+				output: "",
+				url: filter.getUrl(),
+			});
+		});
+
+		child.on("error", (err) => {
+			resolve({
+				success: false,
+				output: err.message,
+			});
+		});
+	});
+}

--- a/cli/src/site/OpenApiRenderer.test.ts
+++ b/cli/src/site/OpenApiRenderer.test.ts
@@ -1,0 +1,520 @@
+/**
+ * Tests for OpenApiRenderer — generates `.mdx` pages for OpenAPI files.
+ *
+ * Covers all acceptance criteria from Task 6:
+ *   - isValidOpenApiContent returns true for valid JSON/YAML OpenAPI content
+ *   - isValidOpenApiContent returns false for invalid/missing fields
+ *   - generateOpenApiMdx produces correct MDX with SwaggerUI import and component
+ *   - renderOpenApiFiles writes .mdx pages for valid OpenAPI files
+ *   - renderOpenApiFiles logs a warning and skips invalid OpenAPI files
+ *   - renderOpenApiFiles overwrites existing .mdx pages (incremental updates)
+ *
+ * Property-based tests (fast-check):
+ *   - Property 6: OpenAPI detection is content-based
+ *     **Validates: Requirements 3.2, 6.3**
+ */
+
+import { existsSync } from "node:fs";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import * as fc from "fast-check";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+async function makeTempDir(): Promise<string> {
+	return mkdtemp(join(tmpdir(), "jolli-openapi-test-"));
+}
+
+/** Minimal valid OpenAPI JSON content */
+const OPENAPI_JSON = JSON.stringify({
+	openapi: "3.1.0",
+	info: { title: "Test API", version: "1.0.0" },
+	paths: {},
+});
+
+/** Minimal valid OpenAPI YAML content */
+const OPENAPI_YAML = `openapi: "3.1.0"\ninfo:\n  title: Test API\n  version: "1.0.0"\npaths: {}\n`;
+
+// ─── isValidOpenApiContent unit tests ────────────────────────────────────────
+
+describe("OpenApiRenderer.isValidOpenApiContent", () => {
+	// ── Valid JSON ───────────────────────────────────────────────────────────
+
+	it("returns true for valid OpenAPI JSON with openapi and info fields", async () => {
+		const { isValidOpenApiContent } = await import("./OpenApiRenderer.js");
+		expect(isValidOpenApiContent(OPENAPI_JSON, ".json")).toBe(true);
+	});
+
+	it("returns true for JSON with openapi and info regardless of other fields", async () => {
+		const { isValidOpenApiContent } = await import("./OpenApiRenderer.js");
+		const content = JSON.stringify({
+			openapi: "3.0.0",
+			info: { title: "My API", version: "2.0" },
+			paths: { "/users": {} },
+			components: {},
+		});
+		expect(isValidOpenApiContent(content, ".json")).toBe(true);
+	});
+
+	// ── Invalid JSON ─────────────────────────────────────────────────────────
+
+	it("returns false for JSON missing the openapi field", async () => {
+		const { isValidOpenApiContent } = await import("./OpenApiRenderer.js");
+		const content = JSON.stringify({ info: { title: "Test", version: "1.0" } });
+		expect(isValidOpenApiContent(content, ".json")).toBe(false);
+	});
+
+	it("returns false for JSON missing the info field", async () => {
+		const { isValidOpenApiContent } = await import("./OpenApiRenderer.js");
+		const content = JSON.stringify({ openapi: "3.1.0", paths: {} });
+		expect(isValidOpenApiContent(content, ".json")).toBe(false);
+	});
+
+	it("returns false for JSON missing both openapi and info fields", async () => {
+		const { isValidOpenApiContent } = await import("./OpenApiRenderer.js");
+		const content = JSON.stringify({ title: "Test", version: "1.0" });
+		expect(isValidOpenApiContent(content, ".json")).toBe(false);
+	});
+
+	it("returns false for invalid JSON syntax", async () => {
+		const { isValidOpenApiContent } = await import("./OpenApiRenderer.js");
+		expect(isValidOpenApiContent("{ not valid json }", ".json")).toBe(false);
+	});
+
+	it("returns false for empty JSON string", async () => {
+		const { isValidOpenApiContent } = await import("./OpenApiRenderer.js");
+		expect(isValidOpenApiContent("", ".json")).toBe(false);
+	});
+
+	it("returns false for JSON array (not an object)", async () => {
+		const { isValidOpenApiContent } = await import("./OpenApiRenderer.js");
+		expect(isValidOpenApiContent("[]", ".json")).toBe(false);
+	});
+
+	// ── Valid YAML ───────────────────────────────────────────────────────────
+
+	it("returns true for valid OpenAPI YAML with openapi and info fields", async () => {
+		const { isValidOpenApiContent } = await import("./OpenApiRenderer.js");
+		expect(isValidOpenApiContent(OPENAPI_YAML, ".yaml")).toBe(true);
+	});
+
+	it("returns true for valid OpenAPI .yml with openapi and info fields", async () => {
+		const { isValidOpenApiContent } = await import("./OpenApiRenderer.js");
+		expect(isValidOpenApiContent(OPENAPI_YAML, ".yml")).toBe(true);
+	});
+
+	it("returns true for YAML with openapi: followed by spaces", async () => {
+		const { isValidOpenApiContent } = await import("./OpenApiRenderer.js");
+		const content = "openapi:  3.1.0\ninfo:\n  title: Test\n";
+		expect(isValidOpenApiContent(content, ".yaml")).toBe(true);
+	});
+
+	// ── Invalid YAML ─────────────────────────────────────────────────────────
+
+	it("returns false for YAML missing the openapi line", async () => {
+		const { isValidOpenApiContent } = await import("./OpenApiRenderer.js");
+		const content = "info:\n  title: Test\n  version: 1.0\n";
+		expect(isValidOpenApiContent(content, ".yaml")).toBe(false);
+	});
+
+	it("returns false for YAML missing the info line", async () => {
+		const { isValidOpenApiContent } = await import("./OpenApiRenderer.js");
+		const content = "openapi: 3.1.0\ntitle: Test\n";
+		expect(isValidOpenApiContent(content, ".yaml")).toBe(false);
+	});
+
+	it("returns false for YAML with openapi indented (not at start of line)", async () => {
+		const { isValidOpenApiContent } = await import("./OpenApiRenderer.js");
+		const content = "  openapi: 3.1.0\ninfo:\n  title: Test\n";
+		expect(isValidOpenApiContent(content, ".yaml")).toBe(false);
+	});
+
+	it("returns false for empty YAML string", async () => {
+		const { isValidOpenApiContent } = await import("./OpenApiRenderer.js");
+		expect(isValidOpenApiContent("", ".yaml")).toBe(false);
+	});
+
+	// ── Unsupported extensions ───────────────────────────────────────────────
+
+	it("returns false for .txt extension even with valid OpenAPI JSON content", async () => {
+		const { isValidOpenApiContent } = await import("./OpenApiRenderer.js");
+		expect(isValidOpenApiContent(OPENAPI_JSON, ".txt")).toBe(false);
+	});
+
+	it("returns false for .md extension", async () => {
+		const { isValidOpenApiContent } = await import("./OpenApiRenderer.js");
+		expect(isValidOpenApiContent(OPENAPI_YAML, ".md")).toBe(false);
+	});
+
+	// ── Case-insensitive extension handling ──────────────────────────────────
+
+	it("handles uppercase .JSON extension", async () => {
+		const { isValidOpenApiContent } = await import("./OpenApiRenderer.js");
+		expect(isValidOpenApiContent(OPENAPI_JSON, ".JSON")).toBe(true);
+	});
+
+	it("handles uppercase .YAML extension", async () => {
+		const { isValidOpenApiContent } = await import("./OpenApiRenderer.js");
+		expect(isValidOpenApiContent(OPENAPI_YAML, ".YAML")).toBe(true);
+	});
+});
+
+// ─── generateOpenApiMdx unit tests ───────────────────────────────────────────
+
+describe("OpenApiRenderer.generateOpenApiMdx", () => {
+	it("imports SwaggerUI from swagger-ui-react", async () => {
+		const { generateOpenApiMdx } = await import("./OpenApiRenderer.js");
+		const mdx = generateOpenApiMdx("/abs/path/api/openapi.yaml", "api/openapi.yaml");
+		expect(mdx).toContain("import SwaggerUI from 'swagger-ui-react'");
+	});
+
+	it("imports the swagger-ui-react CSS", async () => {
+		const { generateOpenApiMdx } = await import("./OpenApiRenderer.js");
+		const mdx = generateOpenApiMdx("/abs/path/api/openapi.yaml", "api/openapi.yaml");
+		expect(mdx).toContain("import 'swagger-ui-react/swagger-ui.css'");
+	});
+
+	it("renders a SwaggerUI component with the correct url prop", async () => {
+		const { generateOpenApiMdx } = await import("./OpenApiRenderer.js");
+		const mdx = generateOpenApiMdx("/abs/path/api/openapi.yaml", "api/openapi.yaml");
+		expect(mdx).toContain('<SwaggerUI url="/api/openapi.yaml"');
+	});
+
+	it("uses forward slashes in the URL even on Windows-style paths", async () => {
+		const { generateOpenApiMdx } = await import("./OpenApiRenderer.js");
+		const mdx = generateOpenApiMdx("C:\\Users\\user\\docs\\api\\openapi.yaml", "api\\openapi.yaml");
+		expect(mdx).toContain('<SwaggerUI url="/api/openapi.yaml"');
+		expect(mdx).not.toContain("\\");
+	});
+
+	it("handles a root-level OpenAPI file (no subdirectory)", async () => {
+		const { generateOpenApiMdx } = await import("./OpenApiRenderer.js");
+		const mdx = generateOpenApiMdx("/abs/path/openapi.json", "openapi.json");
+		expect(mdx).toContain('<SwaggerUI url="/openapi.json"');
+	});
+
+	it("handles deeply nested OpenAPI files", async () => {
+		const { generateOpenApiMdx } = await import("./OpenApiRenderer.js");
+		const mdx = generateOpenApiMdx("/abs/path/v1/api/spec.yaml", "v1/api/spec.yaml");
+		expect(mdx).toContain('<SwaggerUI url="/v1/api/spec.yaml"');
+	});
+});
+
+// ─── renderOpenApiFiles unit tests ───────────────────────────────────────────
+
+describe("OpenApiRenderer.renderOpenApiFiles", () => {
+	let sourceRoot: string;
+	let contentDir: string;
+
+	beforeEach(async () => {
+		sourceRoot = await makeTempDir();
+		contentDir = await makeTempDir();
+	});
+
+	afterEach(async () => {
+		await rm(sourceRoot, { recursive: true, force: true });
+		await rm(contentDir, { recursive: true, force: true });
+		vi.restoreAllMocks();
+	});
+
+	// ── Valid OpenAPI files generate .mdx pages ──────────────────────────────
+
+	it("generates an .mdx file for a valid OpenAPI YAML file", async () => {
+		const { renderOpenApiFiles } = await import("./OpenApiRenderer.js");
+		await writeFile(join(sourceRoot, "openapi.yaml"), OPENAPI_YAML, "utf-8");
+
+		await renderOpenApiFiles(sourceRoot, contentDir, ["openapi.yaml"]);
+
+		expect(existsSync(join(contentDir, "openapi.mdx"))).toBe(true);
+	});
+
+	it("generates an .mdx file for a valid OpenAPI JSON file", async () => {
+		const { renderOpenApiFiles } = await import("./OpenApiRenderer.js");
+		await writeFile(join(sourceRoot, "openapi.json"), OPENAPI_JSON, "utf-8");
+
+		await renderOpenApiFiles(sourceRoot, contentDir, ["openapi.json"]);
+
+		expect(existsSync(join(contentDir, "openapi.mdx"))).toBe(true);
+	});
+
+	it("replaces the original extension with .mdx", async () => {
+		const { renderOpenApiFiles } = await import("./OpenApiRenderer.js");
+		await writeFile(join(sourceRoot, "spec.yml"), OPENAPI_YAML, "utf-8");
+
+		await renderOpenApiFiles(sourceRoot, contentDir, ["spec.yml"]);
+
+		expect(existsSync(join(contentDir, "spec.mdx"))).toBe(true);
+		expect(existsSync(join(contentDir, "spec.yml"))).toBe(false);
+	});
+
+	it("preserves the directory structure when generating .mdx files", async () => {
+		const { renderOpenApiFiles } = await import("./OpenApiRenderer.js");
+		await mkdir(join(sourceRoot, "api"), { recursive: true });
+		await writeFile(join(sourceRoot, "api", "openapi.yaml"), OPENAPI_YAML, "utf-8");
+
+		await renderOpenApiFiles(sourceRoot, contentDir, [join("api", "openapi.yaml")]);
+
+		expect(existsSync(join(contentDir, "api", "openapi.mdx"))).toBe(true);
+	});
+
+	it("creates parent directories as needed", async () => {
+		const { renderOpenApiFiles } = await import("./OpenApiRenderer.js");
+		await mkdir(join(sourceRoot, "v1", "api"), { recursive: true });
+		await writeFile(join(sourceRoot, "v1", "api", "spec.yaml"), OPENAPI_YAML, "utf-8");
+
+		await renderOpenApiFiles(sourceRoot, contentDir, [join("v1", "api", "spec.yaml")]);
+
+		expect(existsSync(join(contentDir, "v1", "api", "spec.mdx"))).toBe(true);
+	});
+
+	it("generated .mdx content includes SwaggerUI import", async () => {
+		const { renderOpenApiFiles } = await import("./OpenApiRenderer.js");
+		await writeFile(join(sourceRoot, "openapi.yaml"), OPENAPI_YAML, "utf-8");
+
+		await renderOpenApiFiles(sourceRoot, contentDir, ["openapi.yaml"]);
+
+		const content = await readFile(join(contentDir, "openapi.mdx"), "utf-8");
+		expect(content).toContain("import SwaggerUI from 'swagger-ui-react'");
+	});
+
+	it("generated .mdx content includes the swagger-ui CSS import", async () => {
+		const { renderOpenApiFiles } = await import("./OpenApiRenderer.js");
+		await writeFile(join(sourceRoot, "openapi.yaml"), OPENAPI_YAML, "utf-8");
+
+		await renderOpenApiFiles(sourceRoot, contentDir, ["openapi.yaml"]);
+
+		const content = await readFile(join(contentDir, "openapi.mdx"), "utf-8");
+		expect(content).toContain("import 'swagger-ui-react/swagger-ui.css'");
+	});
+
+	it("generated .mdx content renders SwaggerUI with the correct url", async () => {
+		const { renderOpenApiFiles } = await import("./OpenApiRenderer.js");
+		await writeFile(join(sourceRoot, "openapi.yaml"), OPENAPI_YAML, "utf-8");
+
+		await renderOpenApiFiles(sourceRoot, contentDir, ["openapi.yaml"]);
+
+		const content = await readFile(join(contentDir, "openapi.mdx"), "utf-8");
+		expect(content).toContain('<SwaggerUI url="/openapi.yaml"');
+	});
+
+	// ── Invalid OpenAPI files are skipped with a warning ─────────────────────
+
+	it("logs a warning for an invalid OpenAPI file", async () => {
+		const { renderOpenApiFiles } = await import("./OpenApiRenderer.js");
+		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+		await writeFile(join(sourceRoot, "not-openapi.yaml"), "title: Not OpenAPI\n", "utf-8");
+
+		await renderOpenApiFiles(sourceRoot, contentDir, ["not-openapi.yaml"]);
+
+		expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("not-openapi.yaml"));
+	});
+
+	it("does not generate an .mdx file for an invalid OpenAPI file", async () => {
+		const { renderOpenApiFiles } = await import("./OpenApiRenderer.js");
+		vi.spyOn(console, "warn").mockImplementation(() => {});
+		await writeFile(join(sourceRoot, "not-openapi.yaml"), "title: Not OpenAPI\n", "utf-8");
+
+		await renderOpenApiFiles(sourceRoot, contentDir, ["not-openapi.yaml"]);
+
+		expect(existsSync(join(contentDir, "not-openapi.mdx"))).toBe(false);
+	});
+
+	it("continues processing other files after skipping an invalid one", async () => {
+		const { renderOpenApiFiles } = await import("./OpenApiRenderer.js");
+		vi.spyOn(console, "warn").mockImplementation(() => {});
+		await writeFile(join(sourceRoot, "invalid.yaml"), "title: Not OpenAPI\n", "utf-8");
+		await writeFile(join(sourceRoot, "valid.yaml"), OPENAPI_YAML, "utf-8");
+
+		await renderOpenApiFiles(sourceRoot, contentDir, ["invalid.yaml", "valid.yaml"]);
+
+		expect(existsSync(join(contentDir, "invalid.mdx"))).toBe(false);
+		expect(existsSync(join(contentDir, "valid.mdx"))).toBe(true);
+	});
+
+	it("does not throw when the openapiFiles array is empty", async () => {
+		const { renderOpenApiFiles } = await import("./OpenApiRenderer.js");
+		await expect(renderOpenApiFiles(sourceRoot, contentDir, [])).resolves.toBeUndefined();
+	});
+
+	// ── Incremental updates (Requirement 6.5) ────────────────────────────────
+
+	it("overwrites an existing .mdx file when the source OpenAPI file changes", async () => {
+		const { renderOpenApiFiles } = await import("./OpenApiRenderer.js");
+
+		// First run
+		await writeFile(join(sourceRoot, "openapi.yaml"), OPENAPI_YAML, "utf-8");
+		await renderOpenApiFiles(sourceRoot, contentDir, ["openapi.yaml"]);
+
+		const firstContent = await readFile(join(contentDir, "openapi.mdx"), "utf-8");
+
+		// Update the source file (content doesn't change the MDX output in this
+		// implementation, but the file is always overwritten)
+		await writeFile(join(sourceRoot, "openapi.yaml"), OPENAPI_YAML, "utf-8");
+		await renderOpenApiFiles(sourceRoot, contentDir, ["openapi.yaml"]);
+
+		const secondContent = await readFile(join(contentDir, "openapi.mdx"), "utf-8");
+
+		// The file should still exist and have the same structure
+		expect(secondContent).toBe(firstContent);
+		expect(existsSync(join(contentDir, "openapi.mdx"))).toBe(true);
+	});
+
+	// ── Warning logged for unreadable files ──────────────────────────────────
+
+	it("logs a warning when a file cannot be read", async () => {
+		const { renderOpenApiFiles } = await import("./OpenApiRenderer.js");
+		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+		// Pass a file that doesn't exist
+		await renderOpenApiFiles(sourceRoot, contentDir, ["nonexistent.yaml"]);
+
+		expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("nonexistent.yaml"));
+	});
+});
+
+// ─── Property-based tests ─────────────────────────────────────────────────────
+
+/**
+ * Property 6: OpenAPI detection is content-based
+ * **Validates: Requirements 3.2, 6.3**
+ */
+describe("Property 6: OpenAPI detection is content-based", () => {
+	// Safe string generator for field values (avoids control chars / special JSON chars)
+	const safeString = fc.stringMatching(/^[a-zA-Z][a-zA-Z0-9 ._-]{0,20}$/).filter((s) => s.length > 0);
+
+	// ── JSON: valid OpenAPI content always returns true ──────────────────────
+
+	it("isValidOpenApiContent returns true for any JSON with openapi and info fields", async () => {
+		const { isValidOpenApiContent } = await import("./OpenApiRenderer.js");
+
+		const openApiVersionArb = fc.constantFrom("3.0.0", "3.0.1", "3.0.2", "3.0.3", "3.1.0");
+
+		const infoArb = fc.record({
+			title: safeString,
+			version: safeString,
+		});
+
+		fc.assert(
+			fc.property(openApiVersionArb, infoArb, (version, info) => {
+				const content = JSON.stringify({ openapi: version, info });
+				return isValidOpenApiContent(content, ".json") === true;
+			}),
+			{ numRuns: 100 },
+		);
+	});
+
+	// ── JSON: missing openapi field always returns false ─────────────────────
+
+	it("isValidOpenApiContent returns false for JSON missing the openapi field", async () => {
+		const { isValidOpenApiContent } = await import("./OpenApiRenderer.js");
+
+		const infoArb = fc.record({
+			title: safeString,
+			version: safeString,
+		});
+
+		// Generate objects that have info but NOT openapi
+		const noOpenApiArb = fc.record({
+			info: infoArb,
+			paths: fc.constant({}),
+		});
+
+		fc.assert(
+			fc.property(noOpenApiArb, (obj) => {
+				const content = JSON.stringify(obj);
+				return isValidOpenApiContent(content, ".json") === false;
+			}),
+			{ numRuns: 100 },
+		);
+	});
+
+	// ── JSON: missing info field always returns false ─────────────────────────
+
+	it("isValidOpenApiContent returns false for JSON missing the info field", async () => {
+		const { isValidOpenApiContent } = await import("./OpenApiRenderer.js");
+
+		const openApiVersionArb = fc.constantFrom("3.0.0", "3.1.0");
+
+		// Generate objects that have openapi but NOT info
+		const noInfoArb = fc.record({
+			openapi: openApiVersionArb,
+			paths: fc.constant({}),
+		});
+
+		fc.assert(
+			fc.property(noInfoArb, (obj) => {
+				const content = JSON.stringify(obj);
+				return isValidOpenApiContent(content, ".json") === false;
+			}),
+			{ numRuns: 100 },
+		);
+	});
+
+	// ── YAML: valid OpenAPI content always returns true ──────────────────────
+
+	it("isValidOpenApiContent returns true for any YAML with openapi and info at line start", async () => {
+		const { isValidOpenApiContent } = await import("./OpenApiRenderer.js");
+
+		const versionArb = safeString;
+		const titleArb = safeString;
+
+		fc.assert(
+			fc.property(versionArb, titleArb, (version, title) => {
+				const content = `openapi: "${version}"\ninfo:\n  title: "${title}"\n`;
+				return isValidOpenApiContent(content, ".yaml") === true;
+			}),
+			{ numRuns: 100 },
+		);
+	});
+
+	it("isValidOpenApiContent returns true for .yml extension with valid YAML content", async () => {
+		const { isValidOpenApiContent } = await import("./OpenApiRenderer.js");
+
+		const versionArb = safeString;
+		const titleArb = safeString;
+
+		fc.assert(
+			fc.property(versionArb, titleArb, (version, title) => {
+				const content = `openapi: "${version}"\ninfo:\n  title: "${title}"\n`;
+				return isValidOpenApiContent(content, ".yml") === true;
+			}),
+			{ numRuns: 100 },
+		);
+	});
+
+	// ── YAML: missing openapi line always returns false ──────────────────────
+
+	it("isValidOpenApiContent returns false for YAML missing the openapi line", async () => {
+		const { isValidOpenApiContent } = await import("./OpenApiRenderer.js");
+
+		const titleArb = safeString;
+
+		fc.assert(
+			fc.property(titleArb, (title) => {
+				// Only has info, no openapi line
+				const content = `info:\n  title: "${title}"\n`;
+				return isValidOpenApiContent(content, ".yaml") === false;
+			}),
+			{ numRuns: 100 },
+		);
+	});
+
+	// ── YAML: missing info line always returns false ─────────────────────────
+
+	it("isValidOpenApiContent returns false for YAML missing the info line", async () => {
+		const { isValidOpenApiContent } = await import("./OpenApiRenderer.js");
+
+		const versionArb = safeString;
+
+		fc.assert(
+			fc.property(versionArb, (version) => {
+				// Only has openapi, no info line
+				const content = `openapi: "${version}"\ntitle: Test\n`;
+				return isValidOpenApiContent(content, ".yaml") === false;
+			}),
+			{ numRuns: 100 },
+		);
+	});
+});

--- a/cli/src/site/OpenApiRenderer.ts
+++ b/cli/src/site/OpenApiRenderer.ts
@@ -1,0 +1,144 @@
+/**
+ * OpenApiRenderer — generates `.mdx` pages for OpenAPI files.
+ *
+ * Validates OpenAPI content by checking for the `openapi` version field and
+ * `info` object, then generates MDX pages that embed a Swagger UI React
+ * component for interactive API documentation rendering.
+ */
+
+import { copyFile, mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname, extname, join } from "node:path";
+
+// ─── isValidOpenApiContent ────────────────────────────────────────────────────
+
+/**
+ * Returns `true` if the given content looks like a valid OpenAPI document.
+ *
+ * For JSON: parses and checks for top-level `openapi` and `info` keys.
+ * For YAML: uses a simple line-based check for `openapi:` and `info:` at the
+ *           start of a line (no full YAML parser required).
+ *
+ * @param content - The raw file content as a string.
+ * @param ext     - The file extension including the dot (e.g. `.yaml`, `.json`).
+ */
+export function isValidOpenApiContent(content: string, ext: string): boolean {
+	const normalizedExt = ext.toLowerCase();
+
+	if (normalizedExt === ".json") {
+		try {
+			const parsed = JSON.parse(content) as Record<string, unknown>;
+			return typeof parsed === "object" && parsed !== null && "openapi" in parsed && "info" in parsed;
+		} catch {
+			return false;
+		}
+	}
+
+	// YAML / YML — simple line-based check
+	if (normalizedExt === ".yaml" || normalizedExt === ".yml") {
+		const hasOpenapi = /^openapi\s*:/m.test(content);
+		const hasInfo = /^info\s*:/m.test(content);
+		return hasOpenapi && hasInfo;
+	}
+
+	return false;
+}
+
+// ─── generateOpenApiMdx ───────────────────────────────────────────────────────
+
+/**
+ * Generates the content of an MDX page that embeds a Swagger UI component
+ * pointing at the given OpenAPI file.
+ *
+ * The generated page:
+ * - Imports `SwaggerUI` from `swagger-ui-react`
+ * - Imports the Swagger UI CSS
+ * - Renders `<SwaggerUI url="<relPath>" />` so the browser fetches the spec
+ *
+ * @param openapiFilePath - Absolute path to the source OpenAPI file (unused in
+ *                          the MDX body but kept for future use / logging).
+ * @param relPath         - Relative path from the source root, used to build
+ *                          the URL passed to SwaggerUI (e.g. `api/openapi.yaml`).
+ */
+export function generateOpenApiMdx(openapiFilePath: string, relPath: string): string {
+	// Normalise to forward slashes for URLs regardless of OS path separator
+	const urlPath = relPath.replace(/\\/g, "/");
+
+	// Suppress unused-variable lint warning — openapiFilePath is part of the
+	// public API signature and may be used by callers for logging.
+	void openapiFilePath;
+
+	return `import SwaggerUI from 'swagger-ui-react'
+import 'swagger-ui-react/swagger-ui.css'
+
+<SwaggerUI url="/${urlPath}" />
+`;
+}
+
+// ─── renderOpenApiFiles ───────────────────────────────────────────────────────
+
+/**
+ * For each OpenAPI file in `openapiFiles` (relative paths from `sourceRoot`):
+ *
+ * 1. Reads the file content from `sourceRoot`.
+ * 2. Validates it with `isValidOpenApiContent`.
+ * 3. If invalid: logs a warning with `console.warn` and skips the file.
+ * 4. If valid: generates an MDX page and writes it to `contentDir` at the same
+ *    relative path but with the `.mdx` extension (replacing the original ext).
+ *
+ * Always overwrites an existing `.mdx` file so that re-running `jolli start`
+ * picks up changes to the source OpenAPI file (Requirement 6.5).
+ *
+ * @param sourceRoot   - Absolute path to the Content_Folder root.
+ * @param contentDir     - Absolute path to the Nextra `content/` directory.
+ * @param openapiFiles - Relative paths (from `sourceRoot`) of OpenAPI files.
+ * @param publicDir    - Absolute path to the `public/` directory where raw
+ *                       OpenAPI files are copied so SwaggerUI can fetch them.
+ */
+export async function renderOpenApiFiles(
+	sourceRoot: string,
+	contentDir: string,
+	openapiFiles: string[],
+	publicDir?: string,
+): Promise<void> {
+	for (const relPath of openapiFiles) {
+		const absolutePath = join(sourceRoot, relPath);
+		const ext = extname(relPath);
+
+		// Read the source file
+		let content: string;
+		try {
+			content = await readFile(absolutePath, "utf-8");
+		} catch (err) {
+			console.warn(`[jolli] Warning: could not read OpenAPI file "${relPath}": ${String(err)}`);
+			continue;
+		}
+
+		// Validate the content
+		if (!isValidOpenApiContent(content, ext)) {
+			console.warn(
+				`[jolli] Warning: "${relPath}" does not appear to be a valid OpenAPI file (missing "openapi" version field or "info" object). Skipping.`,
+			);
+			continue;
+		}
+
+		// Derive the .mdx output path (replace original extension with .mdx)
+		const mdxRelPath = `${relPath.slice(0, relPath.length - ext.length)}.mdx`;
+		const mdxAbsPath = join(contentDir, mdxRelPath);
+
+		// Ensure the parent directory exists
+		const mdxDir = dirname(mdxAbsPath);
+		await mkdir(mdxDir, { recursive: true });
+
+		// Generate and write the MDX page (always overwrite for incremental updates)
+		const mdxContent = generateOpenApiMdx(absolutePath, relPath);
+		await writeFile(mdxAbsPath, mdxContent, "utf-8");
+
+		// Copy the raw OpenAPI file to public/ so SwaggerUI can fetch it at runtime
+		if (publicDir) {
+			const publicPath = join(publicDir, relPath);
+			const publicFileDir = dirname(publicPath);
+			await mkdir(publicFileDir, { recursive: true });
+			await copyFile(absolutePath, publicPath);
+		}
+	}
+}

--- a/cli/src/site/OutputFilter.test.ts
+++ b/cli/src/site/OutputFilter.test.ts
@@ -1,0 +1,281 @@
+/**
+ * Tests for OutputFilter — filters child process output for user-friendly display.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("OutputFilter", () => {
+	let stdoutSpy: ReturnType<typeof vi.spyOn>;
+	let stderrSpy: ReturnType<typeof vi.spyOn>;
+
+	beforeEach(() => {
+		stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+		stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	// ── Verbose mode ────────────────────────────────────────────────────────
+
+	it("passes all output through in verbose mode", async () => {
+		const { createOutputFilter } = await import("./OutputFilter.js");
+		const filter = createOutputFilter(true);
+
+		filter.write("Some random output\n");
+
+		expect(stdoutSpy).toHaveBeenCalledWith("Some random output\n");
+	});
+
+	it("shows suppressed patterns in verbose mode", async () => {
+		const { createOutputFilter } = await import("./OutputFilter.js");
+		const filter = createOutputFilter(true);
+
+		filter.write("npm warn some warning\n");
+
+		expect(stdoutSpy).toHaveBeenCalled();
+	});
+
+	// ── Non-verbose: suppression ────────────────────────────────────────────
+
+	it("suppresses TypeScript detection messages", async () => {
+		const { createOutputFilter } = await import("./OutputFilter.js");
+		const filter = createOutputFilter(false);
+
+		filter.write("We detected TypeScript in your project\n");
+
+		const allCalls = stdoutSpy.mock.calls.map((c: unknown[]) => String(c[0]));
+		expect(allCalls.some((c: string) => c.includes("TypeScript"))).toBe(false);
+	});
+
+	it("suppresses npm warn messages", async () => {
+		const { createOutputFilter } = await import("./OutputFilter.js");
+		const filter = createOutputFilter(false);
+
+		filter.write("npm warn deprecated some-package@1.0.0\n");
+
+		const allCalls = stdoutSpy.mock.calls.map((c: unknown[]) => String(c[0]));
+		expect(allCalls.some((c: string) => c.includes("npm warn"))).toBe(false);
+	});
+
+	it("suppresses webpack hot-update messages", async () => {
+		const { createOutputFilter } = await import("./OutputFilter.js");
+		const filter = createOutputFilter(false);
+
+		filter.write("webpack 5.90.0 compiled, hot-update.js chunk\n");
+
+		const allCalls = stdoutSpy.mock.calls.map((c: unknown[]) => String(c[0]));
+		expect(allCalls.some((c: string) => c.includes("hot-update"))).toBe(false);
+	});
+
+	it("suppresses Next.js version banner", async () => {
+		const { createOutputFilter } = await import("./OutputFilter.js");
+		const filter = createOutputFilter(false);
+
+		filter.write("Next.js 14.2.3\n");
+
+		const allCalls = stdoutSpy.mock.calls.map((c: unknown[]) => String(c[0]));
+		expect(allCalls.some((c: string) => c.includes("Next.js"))).toBe(false);
+	});
+
+	it("suppresses Ready in messages", async () => {
+		const { createOutputFilter } = await import("./OutputFilter.js");
+		const filter = createOutputFilter(false);
+
+		filter.write("Ready in 3.2s\n");
+
+		const allCalls = stdoutSpy.mock.calls.map((c: unknown[]) => String(c[0]));
+		expect(allCalls.some((c: string) => c.includes("Ready in"))).toBe(false);
+	});
+
+	it("suppresses empty lines", async () => {
+		const { createOutputFilter } = await import("./OutputFilter.js");
+		const filter = createOutputFilter(false);
+
+		filter.write("\n\n  \n");
+
+		const allCalls = [...stdoutSpy.mock.calls, ...stderrSpy.mock.calls];
+		expect(allCalls).toHaveLength(0);
+	});
+
+	it("suppresses Compiling messages", async () => {
+		const { createOutputFilter } = await import("./OutputFilter.js");
+		const filter = createOutputFilter(false);
+
+		filter.write("Compiling /page ...\n");
+
+		const allCalls = stdoutSpy.mock.calls.map((c: unknown[]) => String(c[0]));
+		expect(allCalls.some((c: string) => c.includes("Compiling"))).toBe(false);
+	});
+
+	it("suppresses npm audit messages", async () => {
+		const { createOutputFilter } = await import("./OutputFilter.js");
+		const filter = createOutputFilter(false);
+
+		filter.write("Run `npm audit` for details.\n");
+
+		const allCalls = stdoutSpy.mock.calls.map((c: unknown[]) => String(c[0]));
+		expect(allCalls.some((c: string) => c.includes("npm audit"))).toBe(false);
+	});
+
+	it("suppresses node_modules lines", async () => {
+		const { createOutputFilter } = await import("./OutputFilter.js");
+		const filter = createOutputFilter(false);
+
+		filter.write("  node_modules/some-package/index.js\n");
+
+		const allCalls = stdoutSpy.mock.calls.map((c: unknown[]) => String(c[0]));
+		expect(allCalls.some((c: string) => c.includes("node_modules"))).toBe(false);
+	});
+
+	it("suppresses nextra git warnings", async () => {
+		const { createOutputFilter } = await import("./OutputFilter.js");
+		const filter = createOutputFilter(false);
+
+		filter.write("warn  nextra  Init git repository failed\n");
+
+		const allCalls = stdoutSpy.mock.calls.map((c: unknown[]) => String(c[0]));
+		expect(allCalls.some((c: string) => c.includes("nextra"))).toBe(false);
+	});
+
+	// ── Non-verbose: error pass-through ─────────────────────────────────────
+
+	it("shows error lines with ⨯ prefix", async () => {
+		const { createOutputFilter } = await import("./OutputFilter.js");
+		const filter = createOutputFilter(false);
+
+		filter.write("⨯ something went wrong\n");
+
+		expect(stderrSpy).toHaveBeenCalled();
+		const output = stderrSpy.mock.calls.map((c: unknown[]) => String(c[0])).join("");
+		expect(output).toContain("something went wrong");
+	});
+
+	it("shows Module not found errors", async () => {
+		const { createOutputFilter } = await import("./OutputFilter.js");
+		const filter = createOutputFilter(false);
+
+		filter.write("Module not found: Can't resolve '@theme/Tabs'\n");
+
+		expect(stderrSpy).toHaveBeenCalled();
+		const output = stderrSpy.mock.calls.map((c: unknown[]) => String(c[0])).join("");
+		expect(output).toContain("Module not found");
+	});
+
+	it("shows Build error messages", async () => {
+		const { createOutputFilter } = await import("./OutputFilter.js");
+		const filter = createOutputFilter(false);
+
+		filter.write("Build error occurred\n");
+
+		expect(stderrSpy).toHaveBeenCalled();
+	});
+
+	it("shows Failed to compile messages", async () => {
+		const { createOutputFilter } = await import("./OutputFilter.js");
+		const filter = createOutputFilter(false);
+
+		filter.write("Failed to compile\n");
+
+		expect(stderrSpy).toHaveBeenCalled();
+	});
+
+	it("shows Error: messages", async () => {
+		const { createOutputFilter } = await import("./OutputFilter.js");
+		const filter = createOutputFilter(false);
+
+		filter.write("Error: Something bad happened\n");
+
+		expect(stderrSpy).toHaveBeenCalled();
+	});
+
+	it("shows 500 HTTP errors", async () => {
+		const { createOutputFilter } = await import("./OutputFilter.js");
+		const filter = createOutputFilter(false);
+
+		filter.write("GET /api/test 500 in 123ms\n");
+
+		expect(stderrSpy).toHaveBeenCalled();
+	});
+
+	// ── URL extraction ──────────────────────────────────────────────────────
+
+	it("extracts localhost URL and prints it immediately", async () => {
+		const { createOutputFilter } = await import("./OutputFilter.js");
+		const filter = createOutputFilter(false);
+
+		filter.write("- Local: http://localhost:3000\n");
+
+		expect(filter.getUrl()).toBe("http://localhost:3000");
+		const output = stdoutSpy.mock.calls.map((c: unknown[]) => String(c[0])).join("");
+		expect(output).toContain("http://localhost:3000");
+	});
+
+	it("returns undefined from getUrl when no URL seen", async () => {
+		const { createOutputFilter } = await import("./OutputFilter.js");
+		const filter = createOutputFilter(false);
+
+		filter.write("Some text without URLs\n");
+
+		expect(filter.getUrl()).toBeUndefined();
+	});
+
+	it("extracts URL only once (first seen)", async () => {
+		const { createOutputFilter } = await import("./OutputFilter.js");
+		const filter = createOutputFilter(false);
+
+		filter.write("http://localhost:3000\n");
+		filter.write("http://localhost:4000\n");
+
+		expect(filter.getUrl()).toBe("http://localhost:3000");
+	});
+
+	it("extracts URL in verbose mode without extra message", async () => {
+		const { createOutputFilter } = await import("./OutputFilter.js");
+		const filter = createOutputFilter(true);
+
+		filter.write("- Local: http://localhost:3000\n");
+
+		expect(filter.getUrl()).toBe("http://localhost:3000");
+		// In verbose mode, should NOT print the extra "Server running at" message
+		const output = stdoutSpy.mock.calls.map((c: unknown[]) => String(c[0])).join("");
+		expect(output).not.toContain("Server running at");
+	});
+
+	// ── ANSI escape codes ───────────────────────────────────────────────────
+
+	it("strips ANSI escape codes before processing", async () => {
+		const { createOutputFilter } = await import("./OutputFilter.js");
+		const filter = createOutputFilter(false);
+
+		// Error with ANSI codes
+		filter.write("\x1b[31m⨯ error here\x1b[0m\n");
+
+		expect(stderrSpy).toHaveBeenCalled();
+		const output = stderrSpy.mock.calls.map((c: unknown[]) => String(c[0])).join("");
+		expect(output).toContain("error here");
+	});
+
+	// ── write return value ──────────────────────────────────────────────────
+
+	it("always returns true from write", async () => {
+		const { createOutputFilter } = await import("./OutputFilter.js");
+		const filter = createOutputFilter(false);
+
+		expect(filter.write("anything")).toBe(true);
+	});
+
+	// ── Multi-line input ────────────────────────────────────────────────────
+
+	it("processes multiple lines from a single write call", async () => {
+		const { createOutputFilter } = await import("./OutputFilter.js");
+		const filter = createOutputFilter(false);
+
+		filter.write("⨯ error one\nReady in 3s\n⨯ error two\n");
+
+		const errorOutput = stderrSpy.mock.calls.map((c: unknown[]) => String(c[0])).join("");
+		expect(errorOutput).toContain("error one");
+		expect(errorOutput).toContain("error two");
+	});
+});

--- a/cli/src/site/OutputFilter.ts
+++ b/cli/src/site/OutputFilter.ts
@@ -1,0 +1,112 @@
+/**
+ * OutputFilter — filters child process output for user-friendly display.
+ *
+ * In default (non-verbose) mode, suppresses noisy framework output and
+ * only shows relevant information (URLs, errors, request failures).
+ * In verbose mode, passes everything through.
+ */
+
+/** Lines matching these patterns are always suppressed in non-verbose mode. */
+const SUPPRESS_PATTERNS = [
+	/The config property.*deprecated/,
+	/We detected TypeScript/,
+	/The following suggested values/,
+	/allowJs was set/,
+	/noEmit was set/,
+	/incremental was set/,
+	/include was updated/,
+	/plugins was updated/,
+	/warn.*nextra.*Init git repository failed/,
+	/npm warn/,
+	/npm notice/,
+	/Compiling \//,
+	/Compiled \//,
+	/Starting\.\.\./,
+	/Ready in/,
+	/optimizePackageImports/,
+	/Experiments \(use with caution\)/,
+	/Next\.js \d+/,
+	/webpack.*hot-update/,
+	/Fast Refresh had to perform/,
+	/Installing devDependencies/,
+	/Run `npm audit`/,
+	/Run `npm fund`/,
+	/packages are looking for funding/,
+	/vulnerabilities/,
+	/Some issues need review/,
+	/npm audit fix/,
+	/Could not resolve dependency/,
+	/Conflicting peer dependency/,
+	/ERESOLVE overriding/,
+	/While resolving:/,
+	/Found:/,
+	/node_modules/,
+	/^\s*$/,
+	/^$/,
+];
+
+/** Lines matching these patterns are shown as errors. */
+const ERROR_PATTERNS = [/⨯/, /GET .+ 500/, /Module not found/, /Build error/, /Error:/, /Failed to compile/];
+
+/** Extracts a URL from a line. */
+const URL_PATTERN = /https?:\/\/localhost[:\d]*/;
+
+export interface OutputFilter {
+	/** Process a line of output. Returns true if the line was shown. */
+	write(data: string): boolean;
+	/** Returns the extracted localhost URL, if found. */
+	getUrl(): string | undefined;
+}
+
+/**
+ * Creates an output filter.
+ *
+ * @param verbose - If true, all output is passed through.
+ */
+export function createOutputFilter(verbose: boolean): OutputFilter {
+	let url: string | undefined;
+	let urlPrinted = false;
+
+	return {
+		write(data: string): boolean {
+			const lines = data.toString().split("\n");
+
+			for (const line of lines) {
+				// biome-ignore lint/suspicious/noControlCharactersInRegex: ANSI escape stripping
+				const trimmed = line.replace(/\x1b\[[0-9;]*m/g, "").trim();
+				if (!trimmed) continue;
+
+				// Extract and print URL immediately when first detected
+				const urlMatch = trimmed.match(URL_PATTERN);
+				if (urlMatch && !urlPrinted) {
+					url = urlMatch[0];
+					if (!verbose) {
+						process.stdout.write(`  Server running at ${url}\n`);
+					}
+					urlPrinted = true;
+				}
+
+				if (verbose) {
+					process.stdout.write(`${line}\n`);
+					continue;
+				}
+
+				// Suppress noisy lines
+				if (SUPPRESS_PATTERNS.some((p) => p.test(trimmed))) {
+					continue;
+				}
+
+				// Show errors
+				if (ERROR_PATTERNS.some((p) => p.test(trimmed))) {
+					process.stderr.write(`  ${trimmed}\n`);
+				}
+			}
+
+			return true;
+		},
+
+		getUrl(): string | undefined {
+			return url;
+		},
+	};
+}

--- a/cli/src/site/PagefindRunner.test.ts
+++ b/cli/src/site/PagefindRunner.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Tests for PagefindRunner — runs the Pagefind indexer against the built site output.
+ *
+ * Covers all acceptance criteria from Task 9:
+ *   - runPagefind runs `npx pagefind --site out/` inside buildDir
+ *   - runPagefind returns { success: true, output, pagesIndexed } on exit code 0
+ *   - runPagefind parses the number of pages indexed from the output
+ *   - runPagefind returns { success: false, output } on non-zero exit codes
+ *   - stdout and stderr are combined into the output string
+ *   - errors are returned (not thrown) on non-zero exit codes
+ *   - null stdout/stderr are handled gracefully
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+
+const { mockSpawnSync } = vi.hoisted(() => ({
+	mockSpawnSync: vi.fn(),
+}));
+
+vi.mock("node:child_process", () => ({
+	spawnSync: mockSpawnSync,
+}));
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/** Creates a mock spawnSync result with the given exit code and output. */
+function makeSpawnResult(status: number, stdout = "", stderr = "") {
+	return {
+		status,
+		stdout: Buffer.from(stdout),
+		stderr: Buffer.from(stderr),
+		pid: 1234,
+		output: [],
+		signal: null,
+	};
+}
+
+// ─── runPagefind ──────────────────────────────────────────────────────────────
+
+describe("PagefindRunner.runPagefind", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("calls spawnSync with npx pagefind --site out/ and the correct cwd", async () => {
+		const { runPagefind } = await import("./PagefindRunner.js");
+		mockSpawnSync.mockReturnValue(makeSpawnResult(0, "Indexed 10 pages"));
+
+		await runPagefind("/my/build/dir");
+
+		expect(mockSpawnSync).toHaveBeenCalledWith(
+			expect.any(String),
+			["pagefind", "--site", "out", "--output-path", "out/_pagefind"],
+			{
+				cwd: "/my/build/dir",
+				stdio: "pipe",
+			},
+		);
+	});
+
+	it("returns { success: true } when pagefind exits with code 0", async () => {
+		const { runPagefind } = await import("./PagefindRunner.js");
+		mockSpawnSync.mockReturnValue(makeSpawnResult(0, "Indexed 5 pages"));
+
+		const result = await runPagefind("/build/dir");
+
+		expect(result.success).toBe(true);
+	});
+
+	it("returns { success: false } when pagefind exits with non-zero code", async () => {
+		const { runPagefind } = await import("./PagefindRunner.js");
+		mockSpawnSync.mockReturnValue(makeSpawnResult(1, "", "Error: site not found"));
+
+		const result = await runPagefind("/build/dir");
+
+		expect(result.success).toBe(false);
+	});
+
+	it("parses pagesIndexed from output matching 'Indexed N pages'", async () => {
+		const { runPagefind } = await import("./PagefindRunner.js");
+		mockSpawnSync.mockReturnValue(makeSpawnResult(0, "Indexed 42 pages"));
+
+		const result = await runPagefind("/build/dir");
+
+		expect(result.pagesIndexed).toBe(42);
+	});
+
+	it("parses pagesIndexed from output matching 'Found N pages'", async () => {
+		const { runPagefind } = await import("./PagefindRunner.js");
+		mockSpawnSync.mockReturnValue(makeSpawnResult(0, "Found 7 pages in the site"));
+
+		const result = await runPagefind("/build/dir");
+
+		expect(result.pagesIndexed).toBe(7);
+	});
+
+	it("parses pagesIndexed from output matching singular 'page'", async () => {
+		const { runPagefind } = await import("./PagefindRunner.js");
+		mockSpawnSync.mockReturnValue(makeSpawnResult(0, "Indexed 1 page"));
+
+		const result = await runPagefind("/build/dir");
+
+		expect(result.pagesIndexed).toBe(1);
+	});
+
+	it("returns pagesIndexed as undefined when output has no page count", async () => {
+		const { runPagefind } = await import("./PagefindRunner.js");
+		mockSpawnSync.mockReturnValue(makeSpawnResult(0, "Build complete"));
+
+		const result = await runPagefind("/build/dir");
+
+		expect(result.pagesIndexed).toBeUndefined();
+	});
+
+	it("does not include pagesIndexed on failure", async () => {
+		const { runPagefind } = await import("./PagefindRunner.js");
+		mockSpawnSync.mockReturnValue(makeSpawnResult(1, "", "fatal error"));
+
+		const result = await runPagefind("/build/dir");
+
+		expect(result.pagesIndexed).toBeUndefined();
+	});
+
+	it("includes stdout in output on success", async () => {
+		const { runPagefind } = await import("./PagefindRunner.js");
+		mockSpawnSync.mockReturnValue(makeSpawnResult(0, "Indexed 3 pages", ""));
+
+		const result = await runPagefind("/build/dir");
+
+		expect(result.output).toContain("Indexed 3 pages");
+	});
+
+	it("includes stderr in output on failure", async () => {
+		const { runPagefind } = await import("./PagefindRunner.js");
+		mockSpawnSync.mockReturnValue(makeSpawnResult(1, "", "Error: out/ not found"));
+
+		const result = await runPagefind("/build/dir");
+
+		expect(result.output).toContain("Error: out/ not found");
+	});
+
+	it("combines stdout and stderr into output", async () => {
+		const { runPagefind } = await import("./PagefindRunner.js");
+		mockSpawnSync.mockReturnValue(makeSpawnResult(1, "partial stdout", "error details"));
+
+		const result = await runPagefind("/build/dir");
+
+		expect(result.output).toContain("partial stdout");
+		expect(result.output).toContain("error details");
+	});
+
+	it("does not throw on non-zero exit code", async () => {
+		const { runPagefind } = await import("./PagefindRunner.js");
+		mockSpawnSync.mockReturnValue(makeSpawnResult(1, "", "fatal error"));
+
+		expect(() => runPagefind("/build/dir")).not.toThrow();
+	});
+
+	it("handles null stdout and stderr gracefully", async () => {
+		const { runPagefind } = await import("./PagefindRunner.js");
+		mockSpawnSync.mockReturnValue({
+			status: 0,
+			stdout: null,
+			stderr: null,
+			pid: 1234,
+			output: [],
+			signal: null,
+		});
+
+		const result = await runPagefind("/build/dir");
+
+		expect(result.success).toBe(true);
+		expect(result.output).toBe("");
+		expect(result.pagesIndexed).toBeUndefined();
+	});
+});

--- a/cli/src/site/PagefindRunner.ts
+++ b/cli/src/site/PagefindRunner.ts
@@ -1,0 +1,44 @@
+/**
+ * PagefindRunner — runs the Pagefind indexer against the built site output.
+ *
+ * Runs `npx pagefind --site out/` inside `buildDir` using `child_process.spawnSync`
+ * with `stdio: 'pipe'` to capture output. Parses the output to extract the number
+ * of pages indexed.
+ *
+ * Returns `{ success: false, output }` on non-zero exit codes rather than
+ * throwing, so the caller can print the error and set the exit code.
+ */
+
+import { spawnSync } from "node:child_process";
+import type { PagefindResult } from "./Types.js";
+
+/** On Windows, npx must be invoked as npx.cmd. */
+const NPX = process.platform === "win32" ? /* v8 ignore next */ "npx.cmd" : "npx";
+
+export type { PagefindResult };
+
+/**
+ * Runs `npx pagefind --site out/` inside `buildDir`.
+ *
+ * Captures stdout and stderr. Parses the output to extract the number of pages
+ * indexed (e.g. "Indexed 42 pages"). Returns `{ success: true, output, pagesIndexed }`
+ * on exit code 0, or `{ success: false, output }` on any non-zero exit code.
+ */
+export function runPagefind(buildDir: string): PagefindResult {
+	const result = spawnSync(NPX, ["pagefind", "--site", "out", "--output-path", "out/_pagefind"], {
+		cwd: buildDir,
+		stdio: "pipe",
+	});
+
+	const stdout = result.stdout ? result.stdout.toString() : "";
+	const stderr = result.stderr ? result.stderr.toString() : "";
+	const output = [stdout, stderr].filter(Boolean).join("\n");
+
+	if (result.status === 0) {
+		const match = output.match(/(\d+)\s+pages?/i);
+		const pagesIndexed = match ? parseInt(match[1], 10) : undefined;
+		return { success: true, output, pagesIndexed };
+	}
+
+	return { success: false, output };
+}

--- a/cli/src/site/SiteJsonReader.test.ts
+++ b/cli/src/site/SiteJsonReader.test.ts
@@ -1,0 +1,431 @@
+/**
+ * Tests for SiteJsonReader — reads and validates `site.json`.
+ *
+ * Covers all acceptance criteria from Task 3:
+ *   - Valid site.json is parsed and returned
+ *   - Missing site.json returns default config with usedDefault: true and warns
+ *   - Invalid JSON throws a descriptive error including the file path
+ *   - Unrecognized fields are silently ignored
+ */
+
+import { existsSync } from "node:fs";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// ─── Mock readline ───────────────────────────────────────────────────────────
+
+const { mockCreateInterface } = vi.hoisted(() => ({
+	mockCreateInterface: vi.fn(),
+}));
+
+vi.mock("node:readline", () => ({
+	createInterface: mockCreateInterface,
+}));
+
+function mockPrompt(answer: string): void {
+	mockCreateInterface.mockReturnValue({
+		question: (_prompt: string, cb: (answer: string) => void) => cb(answer),
+		close: vi.fn(),
+	});
+}
+
+/** Mock readline to answer different things for sequential prompts. */
+function mockPromptSequence(...answers: string[]): void {
+	let callCount = 0;
+	mockCreateInterface.mockImplementation(() => ({
+		question: (_prompt: string, cb: (answer: string) => void) => cb(answers[callCount++] ?? ""),
+		close: vi.fn(),
+	}));
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+async function makeTempDir(): Promise<string> {
+	return mkdtemp(join(tmpdir(), "jolli-sitejsonreader-test-"));
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("SiteJsonReader.readSiteJson", () => {
+	let tempDir: string;
+	const originalIsTTY = process.stdin.isTTY;
+
+	beforeEach(async () => {
+		tempDir = await makeTempDir();
+		process.stdin.isTTY = true;
+	});
+
+	afterEach(async () => {
+		await rm(tempDir, { recursive: true, force: true });
+		process.stdin.isTTY = originalIsTTY;
+		vi.restoreAllMocks();
+	});
+
+	// ── Valid site.json ─────────────────────────────────────────────────────
+
+	it("returns usedDefault: false when site.json exists", async () => {
+		const { readSiteJson } = await import("./SiteJsonReader.js");
+		const siteJson = {
+			title: "Test Site",
+			description: "A test site",
+			nav: [{ label: "Home", href: "/" }],
+		};
+		await writeFile(join(tempDir, "site.json"), JSON.stringify(siteJson), "utf-8");
+
+		const result = await readSiteJson(tempDir);
+
+		expect(result.usedDefault).toBe(false);
+	});
+
+	it("returns the parsed title from site.json", async () => {
+		const { readSiteJson } = await import("./SiteJsonReader.js");
+		const siteJson = { title: "My Docs", description: "desc", nav: [] };
+		await writeFile(join(tempDir, "site.json"), JSON.stringify(siteJson), "utf-8");
+
+		const result = await readSiteJson(tempDir);
+
+		expect(result.config.title).toBe("My Docs");
+	});
+
+	it("returns the parsed description from site.json", async () => {
+		const { readSiteJson } = await import("./SiteJsonReader.js");
+		const siteJson = { title: "T", description: "My description", nav: [] };
+		await writeFile(join(tempDir, "site.json"), JSON.stringify(siteJson), "utf-8");
+
+		const result = await readSiteJson(tempDir);
+
+		expect(result.config.description).toBe("My description");
+	});
+
+	it("returns the parsed nav array from site.json", async () => {
+		const { readSiteJson } = await import("./SiteJsonReader.js");
+		const nav = [
+			{ label: "Home", href: "/" },
+			{ label: "Docs", href: "/docs" },
+		];
+		const siteJson = { title: "T", description: "D", nav };
+		await writeFile(join(tempDir, "site.json"), JSON.stringify(siteJson), "utf-8");
+
+		const result = await readSiteJson(tempDir);
+
+		expect(result.config.nav).toEqual(nav);
+	});
+
+	// ── Missing site.json — prompts and creates ─────────────────────────────
+
+	it("returns usedDefault: true when site.json is absent", async () => {
+		mockPrompt("");
+		const { readSiteJson } = await import("./SiteJsonReader.js");
+
+		const result = await readSiteJson(tempDir);
+
+		expect(result.usedDefault).toBe(true);
+	});
+
+	it("creates site.json in the source root when absent", async () => {
+		mockPrompt("");
+		const { readSiteJson } = await import("./SiteJsonReader.js");
+
+		await readSiteJson(tempDir);
+
+		expect(existsSync(join(tempDir, "site.json"))).toBe(true);
+	});
+
+	it("written site.json is valid JSON", async () => {
+		mockPrompt("");
+		const { readSiteJson } = await import("./SiteJsonReader.js");
+
+		await readSiteJson(tempDir);
+
+		const content = await readFile(join(tempDir, "site.json"), "utf-8");
+		expect(() => JSON.parse(content)).not.toThrow();
+	});
+
+	it("uses user-provided title when input is given", async () => {
+		mockPrompt("My Docs");
+		const { readSiteJson } = await import("./SiteJsonReader.js");
+
+		const result = await readSiteJson(tempDir);
+
+		expect(result.config.title).toBe("My Docs");
+	});
+
+	it("uses folder name as default title when user presses Enter", async () => {
+		mockPrompt("");
+		const { readSiteJson } = await import("./SiteJsonReader.js");
+
+		const result = await readSiteJson(tempDir);
+
+		// tempDir ends with a random suffix, but title should be title-cased
+		expect(result.config.title.length).toBeGreaterThan(0);
+	});
+
+	it("saves user-provided title to site.json", async () => {
+		mockPrompt("Custom Title");
+		const { readSiteJson } = await import("./SiteJsonReader.js");
+
+		await readSiteJson(tempDir);
+
+		const content = JSON.parse(await readFile(join(tempDir, "site.json"), "utf-8"));
+		expect(content.title).toBe("Custom Title");
+	});
+
+	it("prints the created file path", async () => {
+		mockPrompt("");
+		const { readSiteJson } = await import("./SiteJsonReader.js");
+		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+		await readSiteJson(tempDir);
+
+		const output = logSpy.mock.calls.map((c: unknown[]) => c.join(" ")).join("\n");
+		expect(output).toContain("site.json");
+	});
+
+	it("uses default title without prompting when stdin is not a TTY", async () => {
+		const { readSiteJson } = await import("./SiteJsonReader.js");
+		process.stdin.isTTY = undefined as unknown as true;
+
+		const result = await readSiteJson(tempDir);
+
+		expect(result.usedDefault).toBe(true);
+	});
+
+	// ── Invalid JSON (Requirement 8.7 / Task 3.3) ──────────────────────────
+
+	it("throws an error when site.json exists but is not valid JSON", async () => {
+		const { readSiteJson } = await import("./SiteJsonReader.js");
+		await writeFile(join(tempDir, "site.json"), "{ not valid json }", "utf-8");
+
+		await expect(readSiteJson(tempDir)).rejects.toThrow();
+	});
+
+	it("error message includes the file path when site.json is invalid JSON", async () => {
+		const { readSiteJson } = await import("./SiteJsonReader.js");
+		await writeFile(join(tempDir, "site.json"), "{ not valid json }", "utf-8");
+
+		await expect(readSiteJson(tempDir)).rejects.toThrow(join(tempDir, "site.json"));
+	});
+
+	it("error message is descriptive (contains parse error detail)", async () => {
+		const { readSiteJson } = await import("./SiteJsonReader.js");
+		await writeFile(join(tempDir, "site.json"), "definitely not json!!!", "utf-8");
+
+		let caughtError: Error | undefined;
+		try {
+			await readSiteJson(tempDir);
+		} catch (err) {
+			caughtError = err as Error;
+		}
+
+		expect(caughtError).toBeDefined();
+		expect(caughtError?.message.length).toBeGreaterThan(0);
+	});
+
+	// ── Unrecognized fields (Requirement 8.6 / Task 3.4) ───────────────────
+
+	it("does not throw when site.json contains unrecognized fields", async () => {
+		const { readSiteJson } = await import("./SiteJsonReader.js");
+		const siteJson = {
+			title: "T",
+			description: "D",
+			nav: [],
+			unknownField: "some value",
+			anotherExtra: 42,
+		};
+		await writeFile(join(tempDir, "site.json"), JSON.stringify(siteJson), "utf-8");
+
+		await expect(readSiteJson(tempDir)).resolves.not.toThrow();
+	});
+
+	it("still returns correct title/description/nav when unrecognized fields are present", async () => {
+		const { readSiteJson } = await import("./SiteJsonReader.js");
+		const siteJson = {
+			title: "Known Title",
+			description: "Known Desc",
+			nav: [{ label: "X", href: "/x" }],
+			extraField: "ignored",
+		};
+		await writeFile(join(tempDir, "site.json"), JSON.stringify(siteJson), "utf-8");
+
+		const result = await readSiteJson(tempDir);
+
+		expect(result.config.title).toBe("Known Title");
+		expect(result.config.description).toBe("Known Desc");
+		expect(result.config.nav).toEqual([{ label: "X", href: "/x" }]);
+	});
+
+	// ── Type fallbacks (lines 70–72) ───────────────────────────────────────
+
+	it("uses default title when title is not a string", async () => {
+		const { readSiteJson, DEFAULT_SITE_JSON } = await import("./SiteJsonReader.js");
+		const siteJson = { title: 123, description: "D", nav: [] };
+		await writeFile(join(tempDir, "site.json"), JSON.stringify(siteJson), "utf-8");
+
+		const result = await readSiteJson(tempDir);
+
+		expect(result.config.title).toBe(DEFAULT_SITE_JSON.title);
+	});
+
+	it("uses default description when description is not a string", async () => {
+		const { readSiteJson, DEFAULT_SITE_JSON } = await import("./SiteJsonReader.js");
+		const siteJson = { title: "T", description: null, nav: [] };
+		await writeFile(join(tempDir, "site.json"), JSON.stringify(siteJson), "utf-8");
+
+		const result = await readSiteJson(tempDir);
+
+		expect(result.config.description).toBe(DEFAULT_SITE_JSON.description);
+	});
+
+	it("uses default nav when nav is not an array", async () => {
+		const { readSiteJson, DEFAULT_SITE_JSON } = await import("./SiteJsonReader.js");
+		const siteJson = { title: "T", description: "D", nav: "not-array" };
+		await writeFile(join(tempDir, "site.json"), JSON.stringify(siteJson), "utf-8");
+
+		const result = await readSiteJson(tempDir);
+
+		expect(result.config.nav).toEqual(DEFAULT_SITE_JSON.nav);
+	});
+
+	// ── DEFAULT_SITE_JSON export ────────────────────────────────────────────
+
+	it("DEFAULT_SITE_JSON has a non-empty title", async () => {
+		const { DEFAULT_SITE_JSON } = await import("./SiteJsonReader.js");
+
+		expect(typeof DEFAULT_SITE_JSON.title).toBe("string");
+		expect(DEFAULT_SITE_JSON.title.length).toBeGreaterThan(0);
+	});
+
+	it("DEFAULT_SITE_JSON has a non-empty description", async () => {
+		const { DEFAULT_SITE_JSON } = await import("./SiteJsonReader.js");
+
+		expect(typeof DEFAULT_SITE_JSON.description).toBe("string");
+		expect(DEFAULT_SITE_JSON.description.length).toBeGreaterThan(0);
+	});
+
+	it("DEFAULT_SITE_JSON has an empty nav array", async () => {
+		const { DEFAULT_SITE_JSON } = await import("./SiteJsonReader.js");
+
+		expect(Array.isArray(DEFAULT_SITE_JSON.nav)).toBe(true);
+		expect(DEFAULT_SITE_JSON.nav).toHaveLength(0);
+	});
+
+	// ── Preserving unrecognized fields ──────────────────────────────────────
+
+	it("preserves extra fields in config object", async () => {
+		const { readSiteJson } = await import("./SiteJsonReader.js");
+		const siteJson = {
+			title: "T",
+			description: "D",
+			nav: [],
+			sidebar: { "/": { intro: "Intro" } },
+			pathMappings: { sql: "pipelines/sql" },
+			favicon: "favicon.ico",
+		};
+		await writeFile(join(tempDir, "site.json"), JSON.stringify(siteJson), "utf-8");
+
+		const result = await readSiteJson(tempDir);
+
+		expect(result.config.sidebar).toBeDefined();
+		expect(result.config.pathMappings).toBeDefined();
+		expect(result.config.favicon).toBe("favicon.ico");
+	});
+
+	// ── migrate option ──────────────────────────────────────────────────────
+
+	it("forces re-detection when migrate option is true", async () => {
+		mockPrompt("New Title");
+		const { readSiteJson } = await import("./SiteJsonReader.js");
+		// Write existing site.json
+		await writeFile(
+			join(tempDir, "site.json"),
+			JSON.stringify({ title: "Old", description: "Old", nav: [] }),
+			"utf-8",
+		);
+
+		const result = await readSiteJson(tempDir, { migrate: true });
+
+		// Should use createSiteJson path, so usedDefault: true and new title
+		expect(result.usedDefault).toBe(true);
+		expect(result.config.title).toBe("New Title");
+	});
+
+	it("reads existing site.json when migrate is false", async () => {
+		const { readSiteJson } = await import("./SiteJsonReader.js");
+		await writeFile(
+			join(tempDir, "site.json"),
+			JSON.stringify({ title: "Existing", description: "D", nav: [] }),
+			"utf-8",
+		);
+
+		const result = await readSiteJson(tempDir, { migrate: false });
+
+		expect(result.usedDefault).toBe(false);
+		expect(result.config.title).toBe("Existing");
+	});
+
+	// ── createSiteJson with unsupported framework ───────────────────────────
+
+	it("creates site.json even for unsupported framework (mintlify)", async () => {
+		// First prompt: promptMigration → "y" (yes), second: promptSiteTitle → "My Title"
+		mockPromptSequence("y", "My Title");
+		const { readSiteJson } = await import("./SiteJsonReader.js");
+		// Create a mint.json to trigger mintlify detection
+		await writeFile(join(tempDir, "mint.json"), "{}", "utf-8");
+
+		const result = await readSiteJson(tempDir);
+
+		// Should still create site.json with user's title
+		expect(result.config.title).toBe("My Title");
+		expect(result.usedDefault).toBe(true);
+		expect(existsSync(join(tempDir, "site.json"))).toBe(true);
+	});
+
+	// ── createSiteJson with docusaurus ───────────────────────────────────────
+
+	it("generates site.json with sidebar from docusaurus conversion", async () => {
+		// First prompt: promptMigration → "y" (yes), second: promptSiteTitle → "My Docs"
+		mockPromptSequence("y", "My Docs");
+		const { readSiteJson } = await import("./SiteJsonReader.js");
+		// Create docusaurus files with sidebar
+		await writeFile(join(tempDir, "sidebars.js"), `module.exports = { docsSidebar: ['intro'] }`, "utf-8");
+
+		const result = await readSiteJson(tempDir);
+
+		expect(result.usedDefault).toBe(true);
+		expect(result.config.title).toBe("My Docs");
+		// Should include sidebar from conversion
+		expect(result.config.sidebar).toBeDefined();
+	});
+
+	it("includes pathMappings in site.json when conversion produces them", async () => {
+		mockPromptSequence("y", "Title");
+		const { readSiteJson } = await import("./SiteJsonReader.js");
+		// Create sidebar with nested category that produces pathMappings
+		await writeFile(
+			join(tempDir, "sidebars.js"),
+			`module.exports = { docsSidebar: [
+				{ type: 'category', label: 'Tutorials', link: { type: 'doc', id: 'tutorials/index' }, items: [
+					{ type: 'doc', id: 'use_cases/fraud/intro', label: 'Fraud' }
+				] }
+			] }`,
+			"utf-8",
+		);
+
+		const result = await readSiteJson(tempDir);
+
+		expect(result.config.pathMappings).toBeDefined();
+	});
+
+	it("skips sidebar conversion when user declines migration", async () => {
+		// First prompt: promptMigration → "n" (no), second: promptSiteTitle → "Title"
+		mockPromptSequence("n", "Title");
+		const { readSiteJson } = await import("./SiteJsonReader.js");
+		await writeFile(join(tempDir, "sidebars.js"), `module.exports = { docsSidebar: ['intro'] }`, "utf-8");
+
+		const result = await readSiteJson(tempDir);
+
+		expect(result.config.sidebar).toBeUndefined();
+	});
+});

--- a/cli/src/site/SiteJsonReader.ts
+++ b/cli/src/site/SiteJsonReader.ts
@@ -1,0 +1,158 @@
+/**
+ * SiteJsonReader — reads and validates `site.json` from the Source_Root.
+ *
+ * When `site.json` is absent:
+ *   1. Detects documentation framework config files (Docusaurus, etc.)
+ *   2. If found, prompts user to migrate sidebar config
+ *   3. Prompts for site title
+ *   4. Writes `site.json` to the source root
+ *
+ * When `site.json` exists: reads and parses it.
+ * Throws a descriptive error if the file exists but is not valid JSON.
+ * Silently ignores unrecognized fields.
+ */
+
+import { existsSync } from "node:fs";
+import { readFile, writeFile } from "node:fs/promises";
+import { basename, join } from "node:path";
+import { createInterface } from "node:readline";
+import { type ConversionResult, convertDocusaurusSidebar, extractFaviconFromConfig } from "./DocusaurusConverter.js";
+import { detectFramework, promptMigration } from "./FrameworkDetector.js";
+import type { SiteJson } from "./Types.js";
+
+// ─── Public types ─────────────────────────────────────────────────────────────
+
+export interface SiteJsonResult {
+	config: SiteJson;
+	usedDefault: boolean;
+}
+
+// ─── Default configuration ────────────────────────────────────────────────────
+
+export const DEFAULT_SITE_JSON: SiteJson = {
+	title: "My Documentation Site",
+	description: "A documentation site powered by Jolli",
+	nav: [],
+};
+
+// ─── promptSiteTitle ─────────────────────────────────────────────────────────
+
+/**
+ * Prompts the user for a site title. If the user presses Enter without
+ * typing anything, returns `defaultTitle`.
+ */
+function promptSiteTitle(defaultTitle: string): Promise<string> {
+	if (!process.stdin.isTTY) return Promise.resolve(defaultTitle);
+	const rl = createInterface({ input: process.stdin, output: process.stdout });
+	return new Promise((resolve) => {
+		rl.question(`Site title (${defaultTitle}): `, (answer) => {
+			rl.close();
+			const trimmed = answer.trim();
+			resolve(trimmed || defaultTitle);
+		});
+	});
+}
+
+// ─── readSiteJson ─────────────────────────────────────────────────────────────
+
+/**
+ * Reads `site.json` from `sourceRoot`.
+ *
+ * @param sourceRoot - Path to the content folder
+ * @param options.migrate - If true, force re-detection even if site.json exists
+ */
+export async function readSiteJson(sourceRoot: string, options?: { migrate?: boolean }): Promise<SiteJsonResult> {
+	const filePath = join(sourceRoot, "site.json");
+
+	// If site.json exists and not forcing migration, read it
+	if (existsSync(filePath) && !options?.migrate) {
+		return readExistingSiteJson(filePath);
+	}
+
+	// site.json missing (or --migrate): detect framework and create
+	return createSiteJson(sourceRoot, filePath);
+}
+
+// ─── readExistingSiteJson ────────────────────────────────────────────────────
+
+async function readExistingSiteJson(filePath: string): Promise<SiteJsonResult> {
+	const raw = await readFile(filePath, "utf-8");
+
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(raw);
+	} catch (err) {
+		const detail = err instanceof Error ? err.message : String(err);
+		throw new Error(`Failed to parse ${filePath}: ${detail}`);
+	}
+
+	const obj = parsed as Record<string, unknown>;
+
+	const config: SiteJson = {
+		title: typeof obj.title === "string" ? obj.title : DEFAULT_SITE_JSON.title,
+		description: typeof obj.description === "string" ? obj.description : DEFAULT_SITE_JSON.description,
+		nav: Array.isArray(obj.nav) ? (obj.nav as SiteJson["nav"]) : DEFAULT_SITE_JSON.nav,
+		...Object.fromEntries(Object.entries(obj).filter(([k]) => !["title", "description", "nav"].includes(k))),
+	};
+
+	return { config, usedDefault: false };
+}
+
+// ─── createSiteJson ──────────────────────────────────────────────────────────
+
+async function createSiteJson(sourceRoot: string, filePath: string): Promise<SiteJsonResult> {
+	let conversion: ConversionResult | undefined;
+
+	// Step 1: Detect framework
+	const framework = detectFramework(sourceRoot);
+
+	if (framework) {
+		// Step 2: Prompt for migration
+		const shouldMigrate = await promptMigration(framework);
+
+		if (shouldMigrate && framework.name === "docusaurus" && framework.sidebarPath) {
+			try {
+				conversion = await convertDocusaurusSidebar(framework.sidebarPath);
+				// Extract favicon from docusaurus config
+				const faviconPath = extractFaviconFromConfig(framework.configPath);
+				if (faviconPath) {
+					conversion.favicon = faviconPath;
+				}
+				console.log(`  Converted ${framework.sidebarPath} → sidebar config`);
+			} catch (err) {
+				console.warn(
+					`[jolli] Warning: Failed to convert sidebar: ${err instanceof Error ? err.message : String(err)}`,
+				);
+			}
+		} else if (shouldMigrate && framework.name !== "docusaurus") {
+			console.warn(`[jolli] ${framework.name} conversion is not yet supported. Using folder structure.`);
+		}
+	}
+
+	// Step 3: Prompt for site title
+	const folderName = basename(sourceRoot);
+	const defaultTitle = folderName.replace(/[-_]/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+	const title = await promptSiteTitle(defaultTitle);
+
+	// Step 4: Build and write site.json
+	const config: SiteJson = {
+		...DEFAULT_SITE_JSON,
+		title,
+		description: `${title} documentation`,
+	};
+
+	if (conversion?.sidebar && Object.keys(conversion.sidebar).length > 0) {
+		config.sidebar = conversion.sidebar;
+	}
+	if (conversion?.pathMappings && Object.keys(conversion.pathMappings).length > 0) {
+		config.pathMappings = conversion.pathMappings;
+	}
+	if (conversion?.favicon) {
+		config.favicon = conversion.favicon;
+	}
+
+	await writeFile(filePath, `${JSON.stringify(config, null, 2)}\n`, "utf-8");
+	console.log(`  Created ${filePath}`);
+
+	return { config, usedDefault: true };
+}

--- a/cli/src/site/StarterKit.test.ts
+++ b/cli/src/site/StarterKit.test.ts
@@ -1,0 +1,244 @@
+/**
+ * Tests for StarterKit — scaffolds a new Content_Folder.
+ *
+ * Covers all acceptance criteria from Task 2:
+ *   - All expected files are written
+ *   - site.json is valid JSON with required fields
+ *   - Nested subfolder structure is created
+ *   - Returns error (non-zero) if target directory already exists
+ */
+
+import { existsSync } from "node:fs";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/** Creates a real temporary directory for each test and cleans it up after. */
+async function makeTempDir(): Promise<string> {
+	return mkdtemp(join(tmpdir(), "jolli-starterkit-test-"));
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("StarterKit.scaffoldProject", () => {
+	let tempBase: string;
+
+	beforeEach(async () => {
+		tempBase = await makeTempDir();
+	});
+
+	afterEach(async () => {
+		await rm(tempBase, { recursive: true, force: true });
+	});
+
+	// ── Success path ────────────────────────────────────────────────────────
+
+	it("returns success: true when the target directory does not exist", async () => {
+		const { scaffoldProject } = await import("./StarterKit.js");
+		const targetDir = join(tempBase, "my-docs");
+
+		const result = await scaffoldProject(targetDir);
+
+		expect(result.success).toBe(true);
+		expect(result.targetDir).toBe(targetDir);
+	});
+
+	it("creates the target directory", async () => {
+		const { scaffoldProject } = await import("./StarterKit.js");
+		const targetDir = join(tempBase, "my-docs");
+
+		await scaffoldProject(targetDir);
+
+		expect(existsSync(targetDir)).toBe(true);
+	});
+
+	// ── site.json (Requirement 2) ───────────────────────────────────────────
+
+	it("writes site.json at the root of the target directory", async () => {
+		const { scaffoldProject } = await import("./StarterKit.js");
+		const targetDir = join(tempBase, "my-docs");
+
+		await scaffoldProject(targetDir);
+
+		expect(existsSync(join(targetDir, "site.json"))).toBe(true);
+	});
+
+	it("site.json is valid JSON", async () => {
+		const { scaffoldProject } = await import("./StarterKit.js");
+		const targetDir = join(tempBase, "my-docs");
+
+		await scaffoldProject(targetDir);
+
+		const raw = await readFile(join(targetDir, "site.json"), "utf-8");
+		expect(() => JSON.parse(raw)).not.toThrow();
+	});
+
+	it("site.json contains a non-empty title field", async () => {
+		const { scaffoldProject } = await import("./StarterKit.js");
+		const targetDir = join(tempBase, "my-docs");
+
+		await scaffoldProject(targetDir);
+
+		const raw = await readFile(join(targetDir, "site.json"), "utf-8");
+		const parsed = JSON.parse(raw) as { title?: unknown };
+		expect(typeof parsed.title).toBe("string");
+		expect((parsed.title as string).length).toBeGreaterThan(0);
+	});
+
+	it("site.json contains a non-empty description field", async () => {
+		const { scaffoldProject } = await import("./StarterKit.js");
+		const targetDir = join(tempBase, "my-docs");
+
+		await scaffoldProject(targetDir);
+
+		const raw = await readFile(join(targetDir, "site.json"), "utf-8");
+		const parsed = JSON.parse(raw) as { description?: unknown };
+		expect(typeof parsed.description).toBe("string");
+		expect((parsed.description as string).length).toBeGreaterThan(0);
+	});
+
+	it("site.json contains a nav array with label and href on each entry", async () => {
+		const { scaffoldProject } = await import("./StarterKit.js");
+		const targetDir = join(tempBase, "my-docs");
+
+		await scaffoldProject(targetDir);
+
+		const raw = await readFile(join(targetDir, "site.json"), "utf-8");
+		const parsed = JSON.parse(raw) as { nav?: unknown };
+		expect(Array.isArray(parsed.nav)).toBe(true);
+
+		const nav = parsed.nav as Array<{ label?: unknown; href?: unknown }>;
+		expect(nav.length).toBeGreaterThan(0);
+
+		for (const entry of nav) {
+			expect(typeof entry.label).toBe("string");
+			expect(typeof entry.href).toBe("string");
+		}
+	});
+
+	// ── Markdown files (Requirement 1.4) ───────────────────────────────────
+
+	it("writes index.md at the root", async () => {
+		const { scaffoldProject } = await import("./StarterKit.js");
+		const targetDir = join(tempBase, "my-docs");
+
+		await scaffoldProject(targetDir);
+
+		expect(existsSync(join(targetDir, "index.md"))).toBe(true);
+	});
+
+	it("writes getting-started.md at the root", async () => {
+		const { scaffoldProject } = await import("./StarterKit.js");
+		const targetDir = join(tempBase, "my-docs");
+
+		await scaffoldProject(targetDir);
+
+		expect(existsSync(join(targetDir, "getting-started.md"))).toBe(true);
+	});
+
+	// ── OpenAPI file (Requirement 1.5) ─────────────────────────────────────
+
+	it("writes api/openapi.yaml", async () => {
+		const { scaffoldProject } = await import("./StarterKit.js");
+		const targetDir = join(tempBase, "my-docs");
+
+		await scaffoldProject(targetDir);
+
+		expect(existsSync(join(targetDir, "api", "openapi.yaml"))).toBe(true);
+	});
+
+	it("api/openapi.yaml contains an openapi version field", async () => {
+		const { scaffoldProject } = await import("./StarterKit.js");
+		const targetDir = join(tempBase, "my-docs");
+
+		await scaffoldProject(targetDir);
+
+		const content = await readFile(join(targetDir, "api", "openapi.yaml"), "utf-8");
+		expect(content).toMatch(/^openapi:/m);
+	});
+
+	it("api/openapi.yaml contains an info object", async () => {
+		const { scaffoldProject } = await import("./StarterKit.js");
+		const targetDir = join(tempBase, "my-docs");
+
+		await scaffoldProject(targetDir);
+
+		const content = await readFile(join(targetDir, "api", "openapi.yaml"), "utf-8");
+		expect(content).toMatch(/^info:/m);
+	});
+
+	// ── Nested subfolder (Requirement 1.6) ─────────────────────────────────
+
+	it("creates a guides/ subfolder with introduction.md", async () => {
+		const { scaffoldProject } = await import("./StarterKit.js");
+		const targetDir = join(tempBase, "my-docs");
+
+		await scaffoldProject(targetDir);
+
+		expect(existsSync(join(targetDir, "guides", "introduction.md"))).toBe(true);
+	});
+
+	// ── Error: target already exists (Requirement 1.2 / Task 2.7) ──────────
+
+	it("returns success: false when the target directory already exists", async () => {
+		const { scaffoldProject } = await import("./StarterKit.js");
+		// tempBase itself already exists
+		const result = await scaffoldProject(tempBase);
+
+		expect(result.success).toBe(false);
+		expect(result.targetDir).toBe(tempBase);
+	});
+
+	it("includes a descriptive message when the target directory already exists", async () => {
+		const { scaffoldProject } = await import("./StarterKit.js");
+		const result = await scaffoldProject(tempBase);
+
+		expect(result.message).toBeTruthy();
+		expect(result.message).toContain(tempBase);
+	});
+
+	it("does not modify the existing directory when it already exists", async () => {
+		const { scaffoldProject } = await import("./StarterKit.js");
+		// tempBase is empty — after the failed scaffold it should still be empty
+		await scaffoldProject(tempBase);
+
+		expect(existsSync(join(tempBase, "site.json"))).toBe(false);
+		expect(existsSync(join(tempBase, "index.md"))).toBe(false);
+	});
+
+	// ── Result shape ────────────────────────────────────────────────────────
+
+	it("result.targetDir matches the argument passed in", async () => {
+		const { scaffoldProject } = await import("./StarterKit.js");
+		const targetDir = join(tempBase, "result-shape-test");
+
+		const result = await scaffoldProject(targetDir);
+
+		expect(result.targetDir).toBe(targetDir);
+	});
+
+	it("result.message is set on success", async () => {
+		const { scaffoldProject } = await import("./StarterKit.js");
+		const targetDir = join(tempBase, "message-test");
+
+		const result = await scaffoldProject(targetDir);
+
+		expect(result.message).toBeTruthy();
+	});
+
+	// ── Filesystem error handling ───────────────────────────────────────────
+
+	it("returns success: false when a filesystem error occurs", async () => {
+		const { scaffoldProject } = await import("./StarterKit.js");
+		// Use a path that cannot be created (null byte in name is invalid on all OSes)
+		const invalidDir = join(tempBase, "bad\0name");
+
+		const result = await scaffoldProject(invalidDir);
+
+		expect(result.success).toBe(false);
+		expect(result.message).toBeTruthy();
+	});
+});

--- a/cli/src/site/StarterKit.ts
+++ b/cli/src/site/StarterKit.ts
@@ -1,0 +1,336 @@
+/**
+ * StarterKit — Scaffolds a new Content_Folder for `jolli new`.
+ *
+ * Writes a starter set of files into a new directory:
+ *   - site.json          — site configuration
+ *   - index.md           — welcome page
+ *   - getting-started.md — getting started guide
+ *   - api/openapi.yaml   — example OpenAPI 3.x spec
+ *   - guides/introduction.md — nested subfolder example
+ */
+
+import { existsSync } from "node:fs";
+import { mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import type { ScaffoldResult } from "./Types.js";
+
+// ─── Starter file contents ────────────────────────────────────────────────────
+
+const SITE_JSON = JSON.stringify(
+	{
+		title: "My API Docs",
+		description: "Documentation site powered by Jolli",
+		nav: [
+			{ label: "Home", href: "/" },
+			{ label: "Getting Started", href: "/getting-started" },
+			{ label: "API Reference", href: "/api/openapi" },
+			{ label: "Guides", href: "/guides/introduction" },
+		],
+	},
+	null,
+	2,
+);
+
+const INDEX_MD = `# Welcome
+
+Welcome to your new documentation site, powered by **Jolli**.
+
+## What's inside?
+
+| File / Folder | Purpose |
+|---|---|
+| \`site.json\` | Site title, description, and navigation bar |
+| \`index.md\` | This page — the home page |
+| \`getting-started.md\` | A quick-start guide for new users |
+| \`api/openapi.yaml\` | Example OpenAPI 3.x specification |
+| \`guides/introduction.md\` | Nested subfolder navigation example |
+
+## Next steps
+
+1. Edit \`site.json\` to set your site title and navigation links.
+2. Replace the example markdown files with your own content.
+3. Run \`jolli start\` to build and preview your site.
+`;
+
+const GETTING_STARTED_MD = `# Getting Started
+
+This guide walks you through the basics of your new documentation site.
+
+## Prerequisites
+
+- [Node.js](https://nodejs.org/) 22 or later
+- The \`jolli\` CLI installed globally
+
+## Running the site locally
+
+\`\`\`bash
+jolli start
+\`\`\`
+
+This command reads your content folder, generates a Nextra v4 project in
+\`.jolli-site/\`, installs dependencies (first run only), builds the site, and
+indexes it for full-text search.
+
+## Editing content
+
+All content lives in this folder. You can:
+
+- Add or edit \`.md\` / \`.mdx\` files for documentation pages.
+- Add \`.yaml\` / \`.json\` OpenAPI specs for interactive API reference pages.
+- Organise pages into subfolders — the folder structure becomes the navigation.
+
+## Configuring the site
+
+Edit \`site.json\` to change the site title, description, and top navigation bar.
+
+\`\`\`json
+{
+  "title": "My API Docs",
+  "description": "Documentation site powered by Jolli",
+  "nav": [
+    { "label": "Home", "href": "/" }
+  ]
+}
+\`\`\`
+`;
+
+const OPENAPI_YAML = `openapi: "3.1.0"
+info:
+  title: Example API
+  description: |
+    This is an example OpenAPI 3.x specification included with your Jolli
+    starter kit. Replace it with your own API spec.
+  version: "1.0.0"
+  contact:
+    name: API Support
+    url: https://example.com/support
+    email: support@example.com
+  license:
+    name: Apache 2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0.html
+
+servers:
+  - url: https://api.example.com/v1
+    description: Production server
+  - url: https://staging-api.example.com/v1
+    description: Staging server
+
+tags:
+  - name: items
+    description: Operations on items
+
+paths:
+  /items:
+    get:
+      summary: List all items
+      operationId: listItems
+      tags:
+        - items
+      parameters:
+        - name: limit
+          in: query
+          description: Maximum number of items to return
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            default: 20
+      responses:
+        "200":
+          description: A list of items
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Item"
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+    post:
+      summary: Create an item
+      operationId: createItem
+      tags:
+        - items
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/NewItem"
+      responses:
+        "201":
+          description: Item created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Item"
+        "400":
+          description: Invalid request body
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /items/{id}:
+    get:
+      summary: Get an item by ID
+      operationId: getItem
+      tags:
+        - items
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: The item ID
+          schema:
+            type: string
+      responses:
+        "200":
+          description: The requested item
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Item"
+        "404":
+          description: Item not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+components:
+  schemas:
+    Item:
+      type: object
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: string
+          description: Unique identifier
+          example: "item-123"
+        name:
+          type: string
+          description: Display name
+          example: "My Item"
+        description:
+          type: string
+          description: Optional description
+          example: "A detailed description of the item"
+        createdAt:
+          type: string
+          format: date-time
+          description: Creation timestamp
+
+    NewItem:
+      type: object
+      required:
+        - name
+      properties:
+        name:
+          type: string
+          description: Display name
+          example: "My New Item"
+        description:
+          type: string
+          description: Optional description
+
+    Error:
+      type: object
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: integer
+          description: HTTP status code
+          example: 404
+        message:
+          type: string
+          description: Human-readable error message
+          example: "Item not found"
+`;
+
+const GUIDES_INTRODUCTION_MD = `# Introduction to Guides
+
+This folder demonstrates **nested subfolder navigation** in Jolli.
+
+Any subfolder you create inside your content folder automatically becomes a
+section in the site navigation. Files inside the subfolder become pages within
+that section.
+
+## How navigation is generated
+
+Jolli reads your folder structure and generates \`_meta.js\` files for Nextra v4.
+Each file's name (without extension) becomes a navigation key, and the
+title-cased version of the name becomes the display label.
+
+For example:
+
+| File | Navigation label |
+|---|---|
+| \`getting-started.md\` | Getting Started |
+| \`api/openapi.yaml\` | Openapi |
+| \`guides/introduction.md\` | Introduction |
+
+## Adding more guides
+
+Create additional \`.md\` files in this \`guides/\` folder and they will
+automatically appear in the navigation under the **Guides** section.
+
+You can also nest folders further — Jolli supports multiple levels of nesting.
+`;
+
+// ─── scaffoldProject ──────────────────────────────────────────────────────────
+
+/**
+ * Scaffolds a new Content_Folder at `targetDir`.
+ *
+ * Returns `{ success: false }` (without modifying the filesystem) if the
+ * target directory already exists.
+ */
+export async function scaffoldProject(targetDir: string): Promise<ScaffoldResult> {
+	// 2.7 — Return error if target directory already exists
+	if (existsSync(targetDir)) {
+		return {
+			success: false,
+			targetDir,
+			message: `Directory already exists: ${targetDir}`,
+		};
+	}
+
+	try {
+		// Create root and subdirectories
+		await mkdir(join(targetDir, "api"), { recursive: true });
+		await mkdir(join(targetDir, "guides"), { recursive: true });
+
+		// Write all starter files in parallel
+		await Promise.all([
+			writeFile(join(targetDir, "site.json"), SITE_JSON, "utf-8"),
+			writeFile(join(targetDir, "index.md"), INDEX_MD, "utf-8"),
+			writeFile(join(targetDir, "getting-started.md"), GETTING_STARTED_MD, "utf-8"),
+			writeFile(join(targetDir, "api", "openapi.yaml"), OPENAPI_YAML, "utf-8"),
+			writeFile(join(targetDir, "guides", "introduction.md"), GUIDES_INTRODUCTION_MD, "utf-8"),
+		]);
+
+		return {
+			success: true,
+			targetDir,
+			message: `Created ${targetDir}`,
+		};
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err);
+		return {
+			success: false,
+			targetDir,
+			message,
+		};
+	}
+}

--- a/cli/src/site/Types.ts
+++ b/cli/src/site/Types.ts
@@ -1,0 +1,90 @@
+/**
+ * Jolli Site Type Definitions
+ *
+ * Shared type definitions for the `jolli new` and `jolli start` site modules.
+ */
+
+/** File classification used by ContentMirror to categorize source files */
+export type FileType = "markdown" | "openapi" | "image" | "ignored";
+
+/** A navigation bar link entry in site.json */
+export interface NavLink {
+	label: string;
+	href: string;
+}
+
+/**
+ * A sidebar entry value in site.json:
+ *   - `string` → custom label (e.g. `"Install Feldera"`)
+ *   - `object` → Nextra _meta.js object (e.g. external link, hidden item)
+ */
+export type SidebarItemValue =
+	| string
+	| {
+			title?: string;
+			href?: string;
+			type?: "separator";
+	  };
+
+/**
+ * Sidebar overrides keyed by directory path (e.g. `"/"`, `"/get-started"`).
+ * Each value is an ordered map of `{ key: SidebarItemValue }`.
+ * Items are written to `_meta.js` in declaration order; Nextra auto-appends
+ * unlisted filesystem items alphabetically.
+ */
+export type SidebarOverrides = Record<string, Record<string, SidebarItemValue>>;
+
+/**
+ * Maps source folder paths to target folder paths when the sidebar's
+ * logical structure differs from the physical folder structure.
+ * e.g. `{ "sql": "pipelines/sql" }` means `sql/` in source → `pipelines/sql/` in content.
+ */
+export type PathMappings = Record<string, string>;
+
+/** The parsed contents of site.json */
+export interface SiteJson {
+	title: string;
+	description: string;
+	nav: NavLink[];
+	sidebar?: SidebarOverrides;
+	pathMappings?: PathMappings;
+	favicon?: string;
+	renderer?: string;
+	[key: string]: unknown; // unknown fields are silently ignored
+}
+
+/** Returned by StarterKit.scaffoldProject */
+export interface ScaffoldResult {
+	success: boolean;
+	targetDir: string;
+	message?: string;
+}
+
+/** Returned by ContentMirror.mirrorContent */
+export interface MirrorResult {
+	/** Relative paths of mirrored markdown files */
+	markdownFiles: string[];
+	/** Relative paths of mirrored OpenAPI files */
+	openapiFiles: string[];
+	/** Relative paths of mirrored image files */
+	imageFiles: string[];
+	/** Relative paths of files that were skipped */
+	ignoredFiles: string[];
+	/** Number of .mdx files downgraded to .md due to incompatible content */
+	downgradedCount: number;
+	/** If a file with `slug: /` was renamed to index.md, this is the old key (e.g. "what-is-feldera") */
+	renamedToIndex?: string;
+}
+
+/** Returned by NpmRunner functions */
+export interface NpmRunResult {
+	success: boolean;
+	output: string;
+}
+
+/** Returned by PagefindRunner.runPagefind */
+export interface PagefindResult {
+	success: boolean;
+	pagesIndexed?: number;
+	output: string;
+}

--- a/cli/src/site/renderer/NextraRenderer.test.ts
+++ b/cli/src/site/renderer/NextraRenderer.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Tests for NextraRenderer — verifies delegation to existing site modules.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import { NextraRenderer } from "./NextraRenderer.js";
+
+// ─── Mock dependencies ──────────────────────────────────────────────────────
+
+vi.mock("../NextraProjectWriter.js", () => ({
+	initNextraProject: vi.fn().mockResolvedValue({ isNew: true }),
+}));
+
+vi.mock("../MetaGenerator.js", () => ({
+	generateMetaFiles: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../OpenApiRenderer.js", () => ({
+	renderOpenApiFiles: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../NpmRunner.js", () => ({
+	runNpmBuild: vi.fn().mockResolvedValue({ success: true, output: "" }),
+	runNpmDev: vi.fn().mockResolvedValue({ success: true, output: "" }),
+}));
+
+vi.mock("../OutputFilter.js", () => ({
+	createOutputFilter: vi.fn().mockReturnValue({ write: vi.fn(), getUrl: vi.fn() }),
+}));
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe("NextraRenderer", () => {
+	it("has name 'nextra'", () => {
+		const renderer = new NextraRenderer();
+		expect(renderer.name).toBe("nextra");
+	});
+
+	it("initProject delegates to initNextraProject", async () => {
+		const { initNextraProject } = await import("../NextraProjectWriter.js");
+		const renderer = new NextraRenderer();
+		const config = { title: "T", description: "D", nav: [] };
+
+		await renderer.initProject("/build", config, { staticExport: true });
+
+		expect(initNextraProject).toHaveBeenCalledWith("/build", config, { staticExport: true });
+	});
+
+	it("getCacheDirs returns .next directory", () => {
+		const renderer = new NextraRenderer();
+
+		const dirs = renderer.getCacheDirs("/build");
+
+		expect(dirs).toEqual(["/build/.next"]);
+	});
+
+	it("generateNavigation delegates to generateMetaFiles", async () => {
+		const { generateMetaFiles } = await import("../MetaGenerator.js");
+		const renderer = new NextraRenderer();
+		const sidebar = { "/": { intro: "Intro" } };
+
+		await renderer.generateNavigation("/content", sidebar);
+
+		expect(generateMetaFiles).toHaveBeenCalledWith("/content", sidebar);
+	});
+
+	it("renderOpenApiFiles delegates to the OpenApiRenderer module", async () => {
+		const { renderOpenApiFiles } = await import("../OpenApiRenderer.js");
+		const renderer = new NextraRenderer();
+
+		await renderer.renderOpenApiFiles("/source", "/content", ["api.yaml"], "/public");
+
+		expect(renderOpenApiFiles).toHaveBeenCalledWith("/source", "/content", ["api.yaml"], "/public");
+	});
+
+	it("getContentRules returns safe import prefixes including nextra", () => {
+		const renderer = new NextraRenderer();
+
+		const rules = renderer.getContentRules();
+
+		expect(rules.safeImportPrefixes).toContain("nextra");
+		expect(rules.safeImportPrefixes).toContain("react");
+		expect(rules.providedComponents.has("Callout")).toBe(true);
+		expect(rules.providedComponents.has("Fragment")).toBe(true);
+	});
+
+	it("runBuild delegates to runNpmBuild", async () => {
+		const { runNpmBuild } = await import("../NpmRunner.js");
+		const renderer = new NextraRenderer();
+
+		await renderer.runBuild("/build");
+
+		expect(runNpmBuild).toHaveBeenCalledWith("/build");
+	});
+
+	it("runDev delegates to runNpmDev", async () => {
+		const { runNpmDev } = await import("../NpmRunner.js");
+		const renderer = new NextraRenderer();
+
+		await renderer.runDev("/build", true);
+
+		expect(runNpmDev).toHaveBeenCalledWith("/build", true);
+	});
+
+	it("createOutputFilter delegates to the OutputFilter module", async () => {
+		const { createOutputFilter } = await import("../OutputFilter.js");
+		const renderer = new NextraRenderer();
+
+		renderer.createOutputFilter(true);
+
+		expect(createOutputFilter).toHaveBeenCalledWith(true);
+	});
+
+	it("extractPageCount parses Next.js static page generation output", () => {
+		const renderer = new NextraRenderer();
+
+		expect(renderer.extractPageCount("Generating static pages (0/10)\n(10/10)")).toBe(10);
+	});
+
+	it("extractPageCount returns undefined for non-matching output", () => {
+		const renderer = new NextraRenderer();
+
+		expect(renderer.extractPageCount("Build complete")).toBeUndefined();
+	});
+});

--- a/cli/src/site/renderer/NextraRenderer.ts
+++ b/cli/src/site/renderer/NextraRenderer.ts
@@ -1,0 +1,79 @@
+/**
+ * NextraRenderer — SiteRenderer implementation for Nextra v4.
+ *
+ * Thin wrapper that delegates to the existing site modules:
+ * NextraProjectWriter, MetaGenerator, OpenApiRenderer, NpmRunner, OutputFilter.
+ */
+
+import { join } from "node:path";
+import { generateMetaFiles } from "../MetaGenerator.js";
+import { initNextraProject } from "../NextraProjectWriter.js";
+import { runNpmBuild, runNpmDev, type ServerResult } from "../NpmRunner.js";
+import { renderOpenApiFiles as renderOpenApi } from "../OpenApiRenderer.js";
+import type { OutputFilter } from "../OutputFilter.js";
+import { createOutputFilter as createFilter } from "../OutputFilter.js";
+import type { NpmRunResult, SidebarOverrides, SiteJson } from "../Types.js";
+import type { ContentRules, SiteRenderer } from "./SiteRenderer.js";
+
+// ─── Nextra-specific constants ──────────────────────────────────────────────
+
+const SAFE_IMPORT_PREFIXES = ["nextra", "nextra-theme-docs", "next/", "next-themes", "react", "swagger-ui-react"];
+
+const PROVIDED_COMPONENTS = new Set(["Fragment", "Callout", "Cards", "Card", "FileTree", "Steps", "Tabs", "Tab"]);
+
+const PAGE_COUNT_PATTERN = /Generating static pages.*?(\d+)\/(\d+)/s;
+
+// ─── NextraRenderer ─────────────────────────────────────────────────────────
+
+export class NextraRenderer implements SiteRenderer {
+	readonly name = "nextra";
+
+	async initProject(
+		buildDir: string,
+		config: SiteJson,
+		options: { staticExport?: boolean },
+	): Promise<{ isNew: boolean }> {
+		return initNextraProject(buildDir, config, options);
+	}
+
+	getCacheDirs(buildDir: string): string[] {
+		return [join(buildDir, ".next")];
+	}
+
+	async generateNavigation(contentDir: string, sidebar?: SidebarOverrides): Promise<void> {
+		await generateMetaFiles(contentDir, sidebar);
+	}
+
+	async renderOpenApiFiles(
+		sourceRoot: string,
+		contentDir: string,
+		openapiFiles: string[],
+		publicDir?: string,
+	): Promise<void> {
+		await renderOpenApi(sourceRoot, contentDir, openapiFiles, publicDir);
+	}
+
+	getContentRules(): ContentRules {
+		return {
+			safeImportPrefixes: SAFE_IMPORT_PREFIXES,
+			providedComponents: PROVIDED_COMPONENTS,
+		};
+	}
+
+	async runBuild(buildDir: string): Promise<NpmRunResult> {
+		return runNpmBuild(buildDir);
+	}
+
+	async runDev(buildDir: string, verbose?: boolean): Promise<ServerResult> {
+		return runNpmDev(buildDir, verbose);
+	}
+
+	createOutputFilter(verbose: boolean): OutputFilter {
+		return createFilter(verbose);
+	}
+
+	extractPageCount(buildOutput: string): number | undefined {
+		const match = buildOutput.match(PAGE_COUNT_PATTERN);
+		return match ? Number.parseInt(match[2], 10) : undefined;
+	}
+}

--- a/cli/src/site/renderer/SiteRenderer.ts
+++ b/cli/src/site/renderer/SiteRenderer.ts
@@ -1,0 +1,87 @@
+/**
+ * SiteRenderer — abstraction over the documentation framework used to
+ * build the final site.
+ *
+ * Each renderer implements framework-specific scaffolding, navigation,
+ * OpenAPI rendering, build/dev commands, and output filtering.
+ * The pipeline in StartCommand calls these methods instead of
+ * framework-specific functions directly.
+ */
+
+import type { ServerResult } from "../NpmRunner.js";
+import type { OutputFilter } from "../OutputFilter.js";
+import type { NpmRunResult, SidebarOverrides, SiteJson } from "../Types.js";
+
+// ─── ContentRules ───────────────────────────────────────────────────────────
+
+/**
+ * Renderer-specific content rules used by ContentMirror to decide
+ * which imports and components are safe in MDX files.
+ */
+export interface ContentRules {
+	/** Package prefixes that are safe to import (e.g. ["nextra", "react"]) */
+	safeImportPrefixes: string[];
+	/** Component names provided by the framework that don't need imports */
+	providedComponents: Set<string>;
+}
+
+// ─── SiteRenderer ───────────────────────────────────────────────────────────
+
+export interface SiteRenderer {
+	/** Human-readable name (e.g. "nextra") */
+	readonly name: string;
+
+	/**
+	 * Initialize (or update) the build project scaffold in `buildDir`.
+	 * Creates package.json, config files, layout files, etc.
+	 */
+	initProject(buildDir: string, config: SiteJson, options: { staticExport?: boolean }): Promise<{ isNew: boolean }>;
+
+	/**
+	 * Returns paths that should be cleared between runs
+	 * (framework caches, e.g. ".next" for Nextra).
+	 */
+	getCacheDirs(buildDir: string): string[];
+
+	/**
+	 * Generate navigation/sidebar files from the content directory
+	 * structure and sidebar overrides.
+	 */
+	generateNavigation(contentDir: string, sidebar?: SidebarOverrides): Promise<void>;
+
+	/**
+	 * Render OpenAPI spec files into framework-appropriate pages.
+	 */
+	renderOpenApiFiles(
+		sourceRoot: string,
+		contentDir: string,
+		openapiFiles: string[],
+		publicDir?: string,
+	): Promise<void>;
+
+	/**
+	 * Content rules for ContentMirror's import/component compatibility checks.
+	 */
+	getContentRules(): ContentRules;
+
+	/**
+	 * Run the production build command.
+	 */
+	runBuild(buildDir: string): Promise<NpmRunResult>;
+
+	/**
+	 * Run the dev server command.
+	 */
+	runDev(buildDir: string, verbose?: boolean): Promise<ServerResult>;
+
+	/**
+	 * Create an output filter for this renderer's build/dev output.
+	 */
+	createOutputFilter(verbose: boolean): OutputFilter;
+
+	/**
+	 * Extract page count from build output (renderer-specific log format).
+	 * Returns undefined if not parseable.
+	 */
+	extractPageCount(buildOutput: string): number | undefined;
+}

--- a/cli/src/site/renderer/index.test.ts
+++ b/cli/src/site/renderer/index.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Tests for renderer registry — resolveRenderer factory function.
+ */
+
+import { describe, expect, it } from "vitest";
+
+describe("resolveRenderer", () => {
+	it("returns a NextraRenderer when renderer is not set", async () => {
+		const { resolveRenderer } = await import("./index.js");
+
+		const renderer = resolveRenderer({ title: "T", description: "D", nav: [] });
+
+		expect(renderer.name).toBe("nextra");
+	});
+
+	it("returns a NextraRenderer when renderer is 'nextra'", async () => {
+		const { resolveRenderer } = await import("./index.js");
+
+		const renderer = resolveRenderer({ title: "T", description: "D", nav: [], renderer: "nextra" });
+
+		expect(renderer.name).toBe("nextra");
+	});
+
+	it("throws for unknown renderer", async () => {
+		const { resolveRenderer } = await import("./index.js");
+
+		expect(() => resolveRenderer({ title: "T", description: "D", nav: [], renderer: "unknown" })).toThrow(
+			"Unknown renderer",
+		);
+	});
+
+	it("error message includes the renderer name", async () => {
+		const { resolveRenderer } = await import("./index.js");
+
+		expect(() => resolveRenderer({ title: "T", description: "D", nav: [], renderer: "foo" })).toThrow("foo");
+	});
+
+	it("error message includes supported renderers", async () => {
+		const { resolveRenderer } = await import("./index.js");
+
+		expect(() => resolveRenderer({ title: "T", description: "D", nav: [], renderer: "bad" })).toThrow(
+			"Supported: nextra",
+		);
+	});
+
+	it("ignores extra config fields when resolving renderer", async () => {
+		const { resolveRenderer } = await import("./index.js");
+
+		const renderer = resolveRenderer({
+			title: "T",
+			description: "D",
+			nav: [],
+			sidebar: { "/": { intro: "Intro" } },
+			pathMappings: { sql: "pipelines/sql" },
+			favicon: "favicon.ico",
+		});
+
+		expect(renderer.name).toBe("nextra");
+	});
+});

--- a/cli/src/site/renderer/index.ts
+++ b/cli/src/site/renderer/index.ts
@@ -1,0 +1,23 @@
+/**
+ * Renderer registry — resolves a SiteRenderer from site.json config.
+ */
+
+import type { SiteJson } from "../Types.js";
+import { NextraRenderer } from "./NextraRenderer.js";
+import type { SiteRenderer } from "./SiteRenderer.js";
+
+export type { ContentRules, SiteRenderer } from "./SiteRenderer.js";
+
+/**
+ * Returns the appropriate SiteRenderer for the given config.
+ * Defaults to "nextra" when no `renderer` field is set.
+ */
+export function resolveRenderer(config: SiteJson): SiteRenderer {
+	const name = config.renderer ?? "nextra";
+	switch (name) {
+		case "nextra":
+			return new NextraRenderer();
+		default:
+			throw new Error(`Unknown renderer: "${name}". Supported: nextra`);
+	}
+}

--- a/cli/vite.config.ts
+++ b/cli/vite.config.ts
@@ -24,7 +24,7 @@ export default defineConfig({
 			formats: ["es"],
 		},
 		rollupOptions: {
-			external: ["@anthropic-ai/sdk", "commander", "open", /^node:.*/],
+			external: ["@anthropic-ai/sdk", "@mdx-js/mdx", "commander", "open", /^node:.*/],
 			output: {
 				chunkFileNames: "[name].js",
 			},

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@anthropic-ai/sdk": "^0.39.0",
+				"@mdx-js/mdx": "^3.1.1",
 				"commander": "^13.1.0",
 				"open": "^11.0.0"
 			},
@@ -30,6 +31,7 @@
 				"@biomejs/biome": "2.2.6",
 				"@types/node": "^22.5.0",
 				"@vitest/coverage-v8": "^4.1.1",
+				"fast-check": "^3.23.2",
 				"rimraf": "^6.0.1",
 				"tsx": "^4.7.0",
 				"typescript": "^5.7.2",
@@ -1029,6 +1031,43 @@
 				"@jridgewell/sourcemap-codec": "^1.4.14"
 			}
 		},
+		"node_modules/@mdx-js/mdx": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/@mdx-js/mdx/-/mdx-3.1.1.tgz",
+			"integrity": "sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/estree": "^1.0.0",
+				"@types/estree-jsx": "^1.0.0",
+				"@types/hast": "^3.0.0",
+				"@types/mdx": "^2.0.0",
+				"acorn": "^8.0.0",
+				"collapse-white-space": "^2.0.0",
+				"devlop": "^1.0.0",
+				"estree-util-is-identifier-name": "^3.0.0",
+				"estree-util-scope": "^1.0.0",
+				"estree-walker": "^3.0.0",
+				"hast-util-to-jsx-runtime": "^2.0.0",
+				"markdown-extensions": "^2.0.0",
+				"recma-build-jsx": "^1.0.0",
+				"recma-jsx": "^1.0.0",
+				"recma-stringify": "^1.0.0",
+				"rehype-recma": "^1.0.0",
+				"remark-mdx": "^3.0.0",
+				"remark-parse": "^11.0.0",
+				"remark-rehype": "^11.0.0",
+				"source-map": "^0.7.0",
+				"unified": "^11.0.0",
+				"unist-util-position-from-estree": "^2.0.0",
+				"unist-util-stringify-position": "^4.0.0",
+				"unist-util-visit": "^5.0.0",
+				"vfile": "^6.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
 		"node_modules/@nodelib/fs.scandir": {
 			"version": "2.1.5",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1706,6 +1745,15 @@
 				"assertion-error": "^2.0.1"
 			}
 		},
+		"node_modules/@types/debug": {
+			"version": "4.1.13",
+			"resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+			"integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/ms": "*"
+			}
+		},
 		"node_modules/@types/deep-eql": {
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -1717,7 +1765,45 @@
 			"version": "1.0.8",
 			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
 			"integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/estree-jsx": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.5.tgz",
+			"integrity": "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/estree": "*"
+			}
+		},
+		"node_modules/@types/hast": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+			"integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/unist": "*"
+			}
+		},
+		"node_modules/@types/mdast": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+			"integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/unist": "*"
+			}
+		},
+		"node_modules/@types/mdx": {
+			"version": "2.0.13",
+			"resolved": "https://registry.npmjs.org/@types/mdx/-/mdx-2.0.13.tgz",
+			"integrity": "sha512-+OWZQfAYyio6YkJb3HLxDrvnx6SWWDbC0zVPfBRzUk0/nqoDyf6dNxQi3eArPe8rJ473nobTMQ/8Zk+LxJ+Yuw==",
+			"license": "MIT"
+		},
+		"node_modules/@types/ms": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+			"integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
 			"license": "MIT"
 		},
 		"node_modules/@types/node": {
@@ -1753,6 +1839,12 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/@types/unist": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+			"integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+			"license": "MIT"
+		},
 		"node_modules/@types/vscode": {
 			"version": "1.116.0",
 			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.116.0.tgz",
@@ -1774,6 +1866,12 @@
 			"engines": {
 				"node": ">=20.0.0"
 			}
+		},
+		"node_modules/@ungap/structured-clone": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
+			"integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
+			"license": "ISC"
 		},
 		"node_modules/@vitest/coverage-v8": {
 			"version": "4.1.4",
@@ -2170,6 +2268,27 @@
 				"node": ">=6.5"
 			}
 		},
+		"node_modules/acorn": {
+			"version": "8.16.0",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+			"integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+			"license": "MIT",
+			"bin": {
+				"acorn": "bin/acorn"
+			},
+			"engines": {
+				"node": ">=0.4.0"
+			}
+		},
+		"node_modules/acorn-jsx": {
+			"version": "5.3.2",
+			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+			"integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+			"license": "MIT",
+			"peerDependencies": {
+				"acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+			}
+		},
 		"node_modules/agent-base": {
 			"version": "7.1.4",
 			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
@@ -2293,6 +2412,15 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/astring": {
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/astring/-/astring-1.9.0.tgz",
+			"integrity": "sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==",
+			"license": "MIT",
+			"bin": {
+				"astring": "bin/astring"
+			}
+		},
 		"node_modules/asynckit": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -2308,6 +2436,16 @@
 			"dependencies": {
 				"tunnel": "0.0.6",
 				"typed-rest-client": "^1.8.4"
+			}
+		},
+		"node_modules/bail": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+			"integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
 		"node_modules/balanced-match": {
@@ -2497,6 +2635,16 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/ccount": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+			"integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
 		"node_modules/chai": {
 			"version": "6.2.2",
 			"resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
@@ -2522,6 +2670,46 @@
 			},
 			"funding": {
 				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/character-entities": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+			"integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/character-entities-html4": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+			"integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/character-entities-legacy": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+			"integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/character-reference-invalid": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
+			"integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
 		"node_modules/cheerio": {
@@ -2586,6 +2774,16 @@
 				"node": ">=16"
 			}
 		},
+		"node_modules/collapse-white-space": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-2.1.0.tgz",
+			"integrity": "sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
 		"node_modules/color-convert": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -2616,6 +2814,16 @@
 			},
 			"engines": {
 				"node": ">= 0.8"
+			}
+		},
+		"node_modules/comma-separated-tokens": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+			"integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
 		"node_modules/commander": {
@@ -2690,7 +2898,6 @@
 			"version": "4.4.3",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
 			"integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"ms": "^2.1.3"
@@ -2702,6 +2909,19 @@
 				"supports-color": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/decode-named-character-reference": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+			"integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+			"license": "MIT",
+			"dependencies": {
+				"character-entities": "^2.0.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
 		"node_modules/decompress-response": {
@@ -2781,6 +3001,15 @@
 				"node": ">=0.4.0"
 			}
 		},
+		"node_modules/dequal": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+			"integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
 		"node_modules/detect-libc": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -2790,6 +3019,19 @@
 			"optional": true,
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/devlop": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+			"integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+			"license": "MIT",
+			"dependencies": {
+				"dequal": "^2.0.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
 		"node_modules/dom-serializer": {
@@ -3002,6 +3244,38 @@
 				"node": ">= 0.4"
 			}
 		},
+		"node_modules/esast-util-from-estree": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/esast-util-from-estree/-/esast-util-from-estree-2.0.0.tgz",
+			"integrity": "sha512-4CyanoAudUSBAn5K13H4JhsMH6L9ZP7XbLVe/dKybkxMO7eDyLsT8UHl9TRNrU2Gr9nz+FovfSIjuXWJ81uVwQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/estree-jsx": "^1.0.0",
+				"devlop": "^1.0.0",
+				"estree-util-visit": "^2.0.0",
+				"unist-util-position-from-estree": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/esast-util-from-js": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/esast-util-from-js/-/esast-util-from-js-2.0.1.tgz",
+			"integrity": "sha512-8Ja+rNJ0Lt56Pcf3TAmpBZjmx8ZcK5Ts4cAzIOjsjevg9oSXJnl6SUQ2EevU8tv3h6ZLWmoKL5H4fgWvdvfETw==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/estree-jsx": "^1.0.0",
+				"acorn": "^8.0.0",
+				"esast-util-from-estree": "^2.0.0",
+				"vfile-message": "^4.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
 		"node_modules/esbuild": {
 			"version": "0.27.7",
 			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
@@ -3044,11 +3318,92 @@
 				"@esbuild/win32-x64": "0.27.7"
 			}
 		},
+		"node_modules/estree-util-attach-comments": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/estree-util-attach-comments/-/estree-util-attach-comments-3.0.0.tgz",
+			"integrity": "sha512-cKUwm/HUcTDsYh/9FgnuFqpfquUbwIqwKM26BVCGDPVgvaCl/nDCCjUfiLlx6lsEZ3Z4RFxNbOQ60pkaEwFxGw==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/estree": "^1.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/estree-util-build-jsx": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/estree-util-build-jsx/-/estree-util-build-jsx-3.0.1.tgz",
+			"integrity": "sha512-8U5eiL6BTrPxp/CHbs2yMgP8ftMhR5ww1eIKoWRMlqvltHF8fZn5LRDvTKuxD3DUn+shRbLGqXemcP51oFCsGQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/estree-jsx": "^1.0.0",
+				"devlop": "^1.0.0",
+				"estree-util-is-identifier-name": "^3.0.0",
+				"estree-walker": "^3.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/estree-util-is-identifier-name": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-3.0.0.tgz",
+			"integrity": "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==",
+			"license": "MIT",
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/estree-util-scope": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/estree-util-scope/-/estree-util-scope-1.0.0.tgz",
+			"integrity": "sha512-2CAASclonf+JFWBNJPndcOpA8EMJwa0Q8LUFJEKqXLW6+qBvbFZuF5gItbQOs/umBUkjviCSDCbBwU2cXbmrhQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/estree": "^1.0.0",
+				"devlop": "^1.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/estree-util-to-js": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/estree-util-to-js/-/estree-util-to-js-2.0.0.tgz",
+			"integrity": "sha512-WDF+xj5rRWmD5tj6bIqRi6CkLIXbbNQUcxQHzGysQzvHmdYG2G7p/Tf0J0gpxGgkeMZNTIjT/AoSvC9Xehcgdg==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/estree-jsx": "^1.0.0",
+				"astring": "^1.8.0",
+				"source-map": "^0.7.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/estree-util-visit": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/estree-util-visit/-/estree-util-visit-2.0.0.tgz",
+			"integrity": "sha512-m5KgiH85xAhhW8Wta0vShLcUvOsh3LLPI2YVwcbio1l7E09NTLL1EyMZFM1OyWowoH0skScNbhOPl4kcBgzTww==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/estree-jsx": "^1.0.0",
+				"@types/unist": "^3.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
 		"node_modules/estree-walker": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
 			"integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@types/estree": "^1.0.0"
@@ -3082,6 +3437,35 @@
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=12.0.0"
+			}
+		},
+		"node_modules/extend": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+			"license": "MIT"
+		},
+		"node_modules/fast-check": {
+			"version": "3.23.2",
+			"resolved": "https://registry.npmjs.org/fast-check/-/fast-check-3.23.2.tgz",
+			"integrity": "sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://github.com/sponsors/dubzzz"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/fast-check"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"pure-rand": "^6.1.0"
+			},
+			"engines": {
+				"node": ">=8.0.0"
 			}
 		},
 		"node_modules/fast-deep-equal": {
@@ -3432,6 +3816,74 @@
 				"node": ">= 0.4"
 			}
 		},
+		"node_modules/hast-util-to-estree": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/hast-util-to-estree/-/hast-util-to-estree-3.1.3.tgz",
+			"integrity": "sha512-48+B/rJWAp0jamNbAAf9M7Uf//UVqAoMmgXhBdxTDJLGKY+LRnZ99qcG+Qjl5HfMpYNzS5v4EAwVEF34LeAj7w==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/estree": "^1.0.0",
+				"@types/estree-jsx": "^1.0.0",
+				"@types/hast": "^3.0.0",
+				"comma-separated-tokens": "^2.0.0",
+				"devlop": "^1.0.0",
+				"estree-util-attach-comments": "^3.0.0",
+				"estree-util-is-identifier-name": "^3.0.0",
+				"hast-util-whitespace": "^3.0.0",
+				"mdast-util-mdx-expression": "^2.0.0",
+				"mdast-util-mdx-jsx": "^3.0.0",
+				"mdast-util-mdxjs-esm": "^2.0.0",
+				"property-information": "^7.0.0",
+				"space-separated-tokens": "^2.0.0",
+				"style-to-js": "^1.0.0",
+				"unist-util-position": "^5.0.0",
+				"zwitch": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/hast-util-to-jsx-runtime": {
+			"version": "2.3.6",
+			"resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
+			"integrity": "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/estree": "^1.0.0",
+				"@types/hast": "^3.0.0",
+				"@types/unist": "^3.0.0",
+				"comma-separated-tokens": "^2.0.0",
+				"devlop": "^1.0.0",
+				"estree-util-is-identifier-name": "^3.0.0",
+				"hast-util-whitespace": "^3.0.0",
+				"mdast-util-mdx-expression": "^2.0.0",
+				"mdast-util-mdx-jsx": "^3.0.0",
+				"mdast-util-mdxjs-esm": "^2.0.0",
+				"property-information": "^7.0.0",
+				"space-separated-tokens": "^2.0.0",
+				"style-to-js": "^1.0.0",
+				"unist-util-position": "^5.0.0",
+				"vfile-message": "^4.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/hast-util-whitespace": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+			"integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/hast": "^3.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
 		"node_modules/hosted-git-info": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
@@ -3596,6 +4048,46 @@
 			"license": "ISC",
 			"optional": true
 		},
+		"node_modules/inline-style-parser": {
+			"version": "0.2.7",
+			"resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
+			"integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
+			"license": "MIT"
+		},
+		"node_modules/is-alphabetical": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
+			"integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/is-alphanumerical": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
+			"integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
+			"license": "MIT",
+			"dependencies": {
+				"is-alphabetical": "^2.0.0",
+				"is-decimal": "^2.0.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/is-decimal": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
+			"integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
 		"node_modules/is-docker": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
@@ -3644,6 +4136,16 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/is-hexadecimal": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
+			"integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
 		"node_modules/is-in-ssh": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-in-ssh/-/is-in-ssh-1.0.0.tgz",
@@ -3682,6 +4184,18 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.12.0"
+			}
+		},
+		"node_modules/is-plain-obj": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+			"integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/is-wsl": {
@@ -3985,6 +4499,16 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/longest-streak": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+			"integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
 		"node_modules/lru-cache": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
@@ -4036,6 +4560,18 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/markdown-extensions": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/markdown-extensions/-/markdown-extensions-2.0.0.tgz",
+			"integrity": "sha512-o5vL7aDWatOTX8LzaS1WMoaoxIiLRQJuIKKe2wAw6IeULDHaqbiqiggmx+pKvZDb1Sj+pE46Sn1T7lCqfFtg1Q==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/markdown-it": {
 			"version": "14.1.1",
 			"resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
@@ -4063,6 +4599,176 @@
 				"node": ">= 0.4"
 			}
 		},
+		"node_modules/mdast-util-from-markdown": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+			"integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/mdast": "^4.0.0",
+				"@types/unist": "^3.0.0",
+				"decode-named-character-reference": "^1.0.0",
+				"devlop": "^1.0.0",
+				"mdast-util-to-string": "^4.0.0",
+				"micromark": "^4.0.0",
+				"micromark-util-decode-numeric-character-reference": "^2.0.0",
+				"micromark-util-decode-string": "^2.0.0",
+				"micromark-util-normalize-identifier": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0",
+				"unist-util-stringify-position": "^4.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/mdast-util-mdx": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/mdast-util-mdx/-/mdast-util-mdx-3.0.0.tgz",
+			"integrity": "sha512-JfbYLAW7XnYTTbUsmpu0kdBUVe+yKVJZBItEjwyYJiDJuZ9w4eeaqks4HQO+R7objWgS2ymV60GYpI14Ug554w==",
+			"license": "MIT",
+			"dependencies": {
+				"mdast-util-from-markdown": "^2.0.0",
+				"mdast-util-mdx-expression": "^2.0.0",
+				"mdast-util-mdx-jsx": "^3.0.0",
+				"mdast-util-mdxjs-esm": "^2.0.0",
+				"mdast-util-to-markdown": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/mdast-util-mdx-expression": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/mdast-util-mdx-expression/-/mdast-util-mdx-expression-2.0.1.tgz",
+			"integrity": "sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/estree-jsx": "^1.0.0",
+				"@types/hast": "^3.0.0",
+				"@types/mdast": "^4.0.0",
+				"devlop": "^1.0.0",
+				"mdast-util-from-markdown": "^2.0.0",
+				"mdast-util-to-markdown": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/mdast-util-mdx-jsx": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-3.2.0.tgz",
+			"integrity": "sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/estree-jsx": "^1.0.0",
+				"@types/hast": "^3.0.0",
+				"@types/mdast": "^4.0.0",
+				"@types/unist": "^3.0.0",
+				"ccount": "^2.0.0",
+				"devlop": "^1.1.0",
+				"mdast-util-from-markdown": "^2.0.0",
+				"mdast-util-to-markdown": "^2.0.0",
+				"parse-entities": "^4.0.0",
+				"stringify-entities": "^4.0.0",
+				"unist-util-stringify-position": "^4.0.0",
+				"vfile-message": "^4.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/mdast-util-mdxjs-esm": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/mdast-util-mdxjs-esm/-/mdast-util-mdxjs-esm-2.0.1.tgz",
+			"integrity": "sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/estree-jsx": "^1.0.0",
+				"@types/hast": "^3.0.0",
+				"@types/mdast": "^4.0.0",
+				"devlop": "^1.0.0",
+				"mdast-util-from-markdown": "^2.0.0",
+				"mdast-util-to-markdown": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/mdast-util-phrasing": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+			"integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/mdast": "^4.0.0",
+				"unist-util-is": "^6.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/mdast-util-to-hast": {
+			"version": "13.2.1",
+			"resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+			"integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/hast": "^3.0.0",
+				"@types/mdast": "^4.0.0",
+				"@ungap/structured-clone": "^1.0.0",
+				"devlop": "^1.0.0",
+				"micromark-util-sanitize-uri": "^2.0.0",
+				"trim-lines": "^3.0.0",
+				"unist-util-position": "^5.0.0",
+				"unist-util-visit": "^5.0.0",
+				"vfile": "^6.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/mdast-util-to-markdown": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+			"integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/mdast": "^4.0.0",
+				"@types/unist": "^3.0.0",
+				"longest-streak": "^3.0.0",
+				"mdast-util-phrasing": "^4.0.0",
+				"mdast-util-to-string": "^4.0.0",
+				"micromark-util-classify-character": "^2.0.0",
+				"micromark-util-decode-string": "^2.0.0",
+				"unist-util-visit": "^5.0.0",
+				"zwitch": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/mdast-util-to-string": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+			"integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/mdast": "^4.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
 		"node_modules/mdurl": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
@@ -4079,6 +4785,602 @@
 			"engines": {
 				"node": ">= 8"
 			}
+		},
+		"node_modules/micromark": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+			"integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"@types/debug": "^4.0.0",
+				"debug": "^4.0.0",
+				"decode-named-character-reference": "^1.0.0",
+				"devlop": "^1.0.0",
+				"micromark-core-commonmark": "^2.0.0",
+				"micromark-factory-space": "^2.0.0",
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-chunked": "^2.0.0",
+				"micromark-util-combine-extensions": "^2.0.0",
+				"micromark-util-decode-numeric-character-reference": "^2.0.0",
+				"micromark-util-encode": "^2.0.0",
+				"micromark-util-normalize-identifier": "^2.0.0",
+				"micromark-util-resolve-all": "^2.0.0",
+				"micromark-util-sanitize-uri": "^2.0.0",
+				"micromark-util-subtokenize": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-core-commonmark": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+			"integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"decode-named-character-reference": "^1.0.0",
+				"devlop": "^1.0.0",
+				"micromark-factory-destination": "^2.0.0",
+				"micromark-factory-label": "^2.0.0",
+				"micromark-factory-space": "^2.0.0",
+				"micromark-factory-title": "^2.0.0",
+				"micromark-factory-whitespace": "^2.0.0",
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-chunked": "^2.0.0",
+				"micromark-util-classify-character": "^2.0.0",
+				"micromark-util-html-tag-name": "^2.0.0",
+				"micromark-util-normalize-identifier": "^2.0.0",
+				"micromark-util-resolve-all": "^2.0.0",
+				"micromark-util-subtokenize": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-extension-mdx-expression": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-extension-mdx-expression/-/micromark-extension-mdx-expression-3.0.1.tgz",
+			"integrity": "sha512-dD/ADLJ1AeMvSAKBwO22zG22N4ybhe7kFIZ3LsDI0GlsNr2A3KYxb0LdC1u5rj4Nw+CHKY0RVdnHX8vj8ejm4Q==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"@types/estree": "^1.0.0",
+				"devlop": "^1.0.0",
+				"micromark-factory-mdx-expression": "^2.0.0",
+				"micromark-factory-space": "^2.0.0",
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-events-to-acorn": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-extension-mdx-jsx": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/micromark-extension-mdx-jsx/-/micromark-extension-mdx-jsx-3.0.2.tgz",
+			"integrity": "sha512-e5+q1DjMh62LZAJOnDraSSbDMvGJ8x3cbjygy2qFEi7HCeUT4BDKCvMozPozcD6WmOt6sVvYDNBKhFSz3kjOVQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/estree": "^1.0.0",
+				"devlop": "^1.0.0",
+				"estree-util-is-identifier-name": "^3.0.0",
+				"micromark-factory-mdx-expression": "^2.0.0",
+				"micromark-factory-space": "^2.0.0",
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-events-to-acorn": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0",
+				"vfile-message": "^4.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/micromark-extension-mdx-md": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/micromark-extension-mdx-md/-/micromark-extension-mdx-md-2.0.0.tgz",
+			"integrity": "sha512-EpAiszsB3blw4Rpba7xTOUptcFeBFi+6PY8VnJ2hhimH+vCQDirWgsMpz7w1XcZE7LVrSAUGb9VJpG9ghlYvYQ==",
+			"license": "MIT",
+			"dependencies": {
+				"micromark-util-types": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/micromark-extension-mdxjs": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/micromark-extension-mdxjs/-/micromark-extension-mdxjs-3.0.0.tgz",
+			"integrity": "sha512-A873fJfhnJ2siZyUrJ31l34Uqwy4xIFmvPY1oj+Ean5PHcPBYzEsvqvWGaWcfEIr11O5Dlw3p2y0tZWpKHDejQ==",
+			"license": "MIT",
+			"dependencies": {
+				"acorn": "^8.0.0",
+				"acorn-jsx": "^5.0.0",
+				"micromark-extension-mdx-expression": "^3.0.0",
+				"micromark-extension-mdx-jsx": "^3.0.0",
+				"micromark-extension-mdx-md": "^2.0.0",
+				"micromark-extension-mdxjs-esm": "^3.0.0",
+				"micromark-util-combine-extensions": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/micromark-extension-mdxjs-esm": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/micromark-extension-mdxjs-esm/-/micromark-extension-mdxjs-esm-3.0.0.tgz",
+			"integrity": "sha512-DJFl4ZqkErRpq/dAPyeWp15tGrcrrJho1hKK5uBS70BCtfrIFg81sqcTVu3Ta+KD1Tk5vAtBNElWxtAa+m8K9A==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/estree": "^1.0.0",
+				"devlop": "^1.0.0",
+				"micromark-core-commonmark": "^2.0.0",
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-events-to-acorn": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0",
+				"unist-util-position-from-estree": "^2.0.0",
+				"vfile-message": "^4.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/micromark-factory-destination": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+			"integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-factory-label": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+			"integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"devlop": "^1.0.0",
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-factory-mdx-expression": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/micromark-factory-mdx-expression/-/micromark-factory-mdx-expression-2.0.3.tgz",
+			"integrity": "sha512-kQnEtA3vzucU2BkrIa8/VaSAsP+EJ3CKOvhMuJgOEGg9KDC6OAY6nSnNDVRiVNRqj7Y4SlSzcStaH/5jge8JdQ==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"@types/estree": "^1.0.0",
+				"devlop": "^1.0.0",
+				"micromark-factory-space": "^2.0.0",
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-events-to-acorn": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0",
+				"unist-util-position-from-estree": "^2.0.0",
+				"vfile-message": "^4.0.0"
+			}
+		},
+		"node_modules/micromark-factory-space": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+			"integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-factory-title": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+			"integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-factory-space": "^2.0.0",
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-factory-whitespace": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+			"integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-factory-space": "^2.0.0",
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-util-character": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+			"integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-util-chunked": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+			"integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-util-symbol": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-util-classify-character": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+			"integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-util-combine-extensions": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+			"integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-util-chunked": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-util-decode-numeric-character-reference": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+			"integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-util-symbol": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-util-decode-string": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+			"integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"decode-named-character-reference": "^1.0.0",
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-decode-numeric-character-reference": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-util-encode": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+			"integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT"
+		},
+		"node_modules/micromark-util-events-to-acorn": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/micromark-util-events-to-acorn/-/micromark-util-events-to-acorn-2.0.3.tgz",
+			"integrity": "sha512-jmsiEIiZ1n7X1Rr5k8wVExBQCg5jy4UXVADItHmNk1zkwEVhBuIUKRu3fqv+hs4nxLISi2DQGlqIOGiFxgbfHg==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"@types/estree": "^1.0.0",
+				"@types/unist": "^3.0.0",
+				"devlop": "^1.0.0",
+				"estree-util-visit": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0",
+				"vfile-message": "^4.0.0"
+			}
+		},
+		"node_modules/micromark-util-html-tag-name": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+			"integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT"
+		},
+		"node_modules/micromark-util-normalize-identifier": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+			"integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-util-symbol": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-util-resolve-all": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+			"integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-util-sanitize-uri": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+			"integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-encode": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-util-subtokenize": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+			"integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"devlop": "^1.0.0",
+				"micromark-util-chunked": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-util-symbol": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+			"integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT"
+		},
+		"node_modules/micromark-util-types": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+			"integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT"
 		},
 		"node_modules/micromatch": {
 			"version": "4.0.8",
@@ -4425,6 +5727,31 @@
 			"dev": true,
 			"license": "BlueOak-1.0.0"
 		},
+		"node_modules/parse-entities": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
+			"integrity": "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/unist": "^2.0.0",
+				"character-entities-legacy": "^3.0.0",
+				"character-reference-invalid": "^2.0.0",
+				"decode-named-character-reference": "^1.0.0",
+				"is-alphanumerical": "^2.0.0",
+				"is-decimal": "^2.0.0",
+				"is-hexadecimal": "^2.0.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/parse-entities/node_modules/@types/unist": {
+			"version": "2.0.11",
+			"resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+			"integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+			"license": "MIT"
+		},
 		"node_modules/parse-json": {
 			"version": "8.3.0",
 			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-8.3.0.tgz",
@@ -4680,6 +6007,16 @@
 				"node": ">=10"
 			}
 		},
+		"node_modules/property-information": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
+			"integrity": "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
 		"node_modules/pump": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
@@ -4701,6 +6038,23 @@
 			"engines": {
 				"node": ">=6"
 			}
+		},
+		"node_modules/pure-rand": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
+			"integrity": "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://github.com/sponsors/dubzzz"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/fast-check"
+				}
+			],
+			"license": "MIT"
 		},
 		"node_modules/qs": {
 			"version": "6.15.1",
@@ -4829,6 +6183,135 @@
 			},
 			"engines": {
 				"node": ">= 6"
+			}
+		},
+		"node_modules/recma-build-jsx": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/recma-build-jsx/-/recma-build-jsx-1.0.0.tgz",
+			"integrity": "sha512-8GtdyqaBcDfva+GUKDr3nev3VpKAhup1+RvkMvUxURHpW7QyIvk9F5wz7Vzo06CEMSilw6uArgRqhpiUcWp8ew==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/estree": "^1.0.0",
+				"estree-util-build-jsx": "^3.0.0",
+				"vfile": "^6.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/recma-jsx": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/recma-jsx/-/recma-jsx-1.0.1.tgz",
+			"integrity": "sha512-huSIy7VU2Z5OLv6oFLosQGGDqPqdO1iq6bWNAdhzMxSJP7RAso4fCZ1cKu8j9YHCZf3TPrq4dw3okhrylgcd7w==",
+			"license": "MIT",
+			"dependencies": {
+				"acorn-jsx": "^5.0.0",
+				"estree-util-to-js": "^2.0.0",
+				"recma-parse": "^1.0.0",
+				"recma-stringify": "^1.0.0",
+				"unified": "^11.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			},
+			"peerDependencies": {
+				"acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+			}
+		},
+		"node_modules/recma-parse": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/recma-parse/-/recma-parse-1.0.0.tgz",
+			"integrity": "sha512-OYLsIGBB5Y5wjnSnQW6t3Xg7q3fQ7FWbw/vcXtORTnyaSFscOtABg+7Pnz6YZ6c27fG1/aN8CjfwoUEUIdwqWQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/estree": "^1.0.0",
+				"esast-util-from-js": "^2.0.0",
+				"unified": "^11.0.0",
+				"vfile": "^6.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/recma-stringify": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/recma-stringify/-/recma-stringify-1.0.0.tgz",
+			"integrity": "sha512-cjwII1MdIIVloKvC9ErQ+OgAtwHBmcZ0Bg4ciz78FtbT8In39aAYbaA7zvxQ61xVMSPE8WxhLwLbhif4Js2C+g==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/estree": "^1.0.0",
+				"estree-util-to-js": "^2.0.0",
+				"unified": "^11.0.0",
+				"vfile": "^6.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/rehype-recma": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/rehype-recma/-/rehype-recma-1.0.0.tgz",
+			"integrity": "sha512-lqA4rGUf1JmacCNWWZx0Wv1dHqMwxzsDWYMTowuplHF3xH0N/MmrZ/G3BDZnzAkRmxDadujCjaKM2hqYdCBOGw==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/estree": "^1.0.0",
+				"@types/hast": "^3.0.0",
+				"hast-util-to-estree": "^3.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/remark-mdx": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/remark-mdx/-/remark-mdx-3.1.1.tgz",
+			"integrity": "sha512-Pjj2IYlUY3+D8x00UJsIOg5BEvfMyeI+2uLPn9VO9Wg4MEtN/VTIq2NEJQfde9PnX15KgtHyl9S0BcTnWrIuWg==",
+			"license": "MIT",
+			"dependencies": {
+				"mdast-util-mdx": "^3.0.0",
+				"micromark-extension-mdxjs": "^3.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/remark-parse": {
+			"version": "11.0.0",
+			"resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+			"integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/mdast": "^4.0.0",
+				"mdast-util-from-markdown": "^2.0.0",
+				"micromark-util-types": "^2.0.0",
+				"unified": "^11.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/remark-rehype": {
+			"version": "11.1.2",
+			"resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.2.tgz",
+			"integrity": "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/hast": "^3.0.0",
+				"@types/mdast": "^4.0.0",
+				"mdast-util-to-hast": "^13.0.0",
+				"unified": "^11.0.0",
+				"vfile": "^6.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
 			}
 		},
 		"node_modules/require-from-string": {
@@ -5253,6 +6736,15 @@
 				"url": "https://github.com/chalk/slice-ansi?sponsor=1"
 			}
 		},
+		"node_modules/source-map": {
+			"version": "0.7.6",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+			"integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">= 12"
+			}
+		},
 		"node_modules/source-map-js": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -5261,6 +6753,16 @@
 			"license": "BSD-3-Clause",
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/space-separated-tokens": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+			"integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
 		"node_modules/spdx-correct": {
@@ -5362,6 +6864,20 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/stringify-entities": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+			"integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+			"license": "MIT",
+			"dependencies": {
+				"character-entities-html4": "^2.0.0",
+				"character-entities-legacy": "^3.0.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
 		"node_modules/strip-ansi": {
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
@@ -5397,6 +6913,24 @@
 			"license": "BSD-2-Clause",
 			"dependencies": {
 				"boundary": "^2.0.0"
+			}
+		},
+		"node_modules/style-to-js": {
+			"version": "1.1.21",
+			"resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
+			"integrity": "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==",
+			"license": "MIT",
+			"dependencies": {
+				"style-to-object": "1.0.14"
+			}
+		},
+		"node_modules/style-to-object": {
+			"version": "1.0.14",
+			"resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.14.tgz",
+			"integrity": "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==",
+			"license": "MIT",
+			"dependencies": {
+				"inline-style-parser": "0.2.7"
 			}
 		},
 		"node_modules/supports-color": {
@@ -5645,6 +7179,26 @@
 			"integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
 			"license": "MIT"
 		},
+		"node_modules/trim-lines": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+			"integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/trough": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+			"integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
 		"node_modules/tslib": {
 			"version": "2.8.1",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -5778,6 +7332,106 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/unified": {
+			"version": "11.0.5",
+			"resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+			"integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/unist": "^3.0.0",
+				"bail": "^2.0.0",
+				"devlop": "^1.0.0",
+				"extend": "^3.0.0",
+				"is-plain-obj": "^4.0.0",
+				"trough": "^2.0.0",
+				"vfile": "^6.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/unist-util-is": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+			"integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/unist": "^3.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/unist-util-position": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+			"integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/unist": "^3.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/unist-util-position-from-estree": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/unist-util-position-from-estree/-/unist-util-position-from-estree-2.0.0.tgz",
+			"integrity": "sha512-KaFVRjoqLyF6YXCbVLNad/eS4+OfPQQn2yOd7zF/h5T/CSL2v8NpN6a5TPvtbXthAGw5nG+PuTtq+DdIZr+cRQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/unist": "^3.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/unist-util-stringify-position": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+			"integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/unist": "^3.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/unist-util-visit": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+			"integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/unist": "^3.0.0",
+				"unist-util-is": "^6.0.0",
+				"unist-util-visit-parents": "^6.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/unist-util-visit-parents": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+			"integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/unist": "^3.0.0",
+				"unist-util-is": "^6.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
 		"node_modules/universalify": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
@@ -5825,6 +7479,34 @@
 			},
 			"funding": {
 				"url": "https://bevry.me/fund"
+			}
+		},
+		"node_modules/vfile": {
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+			"integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/unist": "^3.0.0",
+				"vfile-message": "^4.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/vfile-message": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+			"integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/unist": "^3.0.0",
+				"unist-util-stringify-position": "^4.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
 			}
 		},
 		"node_modules/vite": {
@@ -6679,6 +8361,16 @@
 			"license": "MIT",
 			"dependencies": {
 				"buffer-crc32": "~0.2.3"
+			}
+		},
+		"node_modules/zwitch": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+			"integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
 		"vscode": {


### PR DESCRIPTION


## E2E Test (10)
<details>
<summary><strong>1. Create a new documentation project with the &quot;new&quot; command</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a terminal open in a folder where you want to create a new project. Make sure no folder named "my-docs" already exists there.

**Steps:**
1. Open a terminal and type `jolli new my-docs` then press Enter.
2. Wait for the command to finish.
3. Open the newly created "my-docs" folder and check its contents.
4. Verify that the folder contains a configuration file, a welcome page, a getting-started page, an API folder with an OpenAPI file, and a guides folder with an introduction page.
5. Run `jolli new my-docs` a second time (targeting the same folder that now exists).
6. Check the terminal output for an error message.

**Expected Results:**
- The first run creates the "my-docs" folder with all five starter files inside.
- The second run does NOT overwrite or change any existing files.
- The terminal shows a clear error message explaining that the folder already exists.

</blockquote>
</details>
<details>
<summary><strong>2. Convert an existing Docusaurus project to Jolli format</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a Docusaurus documentation folder ready (containing markdown files and a sidebars.js file).

**Steps:**
1. Open a terminal and type `jolli convert` followed by the path to your Docusaurus folder, then press Enter.
2. When prompted, type a title for your new site and press Enter.
3. Wait for the conversion to finish.
4. Open the output folder and check its contents.
5. Look for a timestamped backup folder (for example, "docs.backup-2026-05-02T14-30-22") alongside the converted files.
6. Confirm that the output folder contains a "site.json" file and that framework-specific files like "sidebars.js" and "package.json" are NOT present.

**Expected Results:**
- A timestamped backup of the original folder is created before any changes are made.
- The converted output contains a "site.json" configuration file with the title you entered.
- Files like "sidebars.js" and "package.json" do not appear in the converted output.
- Markdown content files are present and the folder structure is preserved.

</blockquote>
</details>
<details>
<summary><strong>3. Build a documentation site with the &quot;build&quot; command</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a content folder with a valid "site.json" file and at least one markdown file inside.

**Steps:**
1. Open a terminal, type `jolli build` followed by the path to your content folder, and press Enter.
2. Wait for the build to complete (this may take a minute or two).
3. Read the final message printed in the terminal.

**Expected Results:**
- The terminal shows progress messages while the site is being built.
- When the build finishes successfully, the terminal displays a message saying to run `jolli start` to preview the site — NOT an internal folder path.
- No error messages appear.

</blockquote>
</details>
<details>
<summary><strong>4. Preview a built documentation site with the &quot;start&quot; command</strong></summary>
<br>
<blockquote>

**Preconditions:** Have already successfully run `jolli build` on a content folder.

**Steps:**
1. Open a terminal, type `jolli start` followed by the path to your content folder, and press Enter.
2. Wait for the terminal to display a local web address (for example, "http://localhost:3000").
3. Open that address in a web browser.
4. Check that the site title matches what is in your "site.json" file.
5. Click through a few pages in the navigation sidebar to confirm they load correctly.

**Expected Results:**
- The terminal prints a localhost URL shortly after the command starts.
- The browser shows a fully rendered documentation site with the correct title.
- Navigation links in the sidebar work and each page displays its content.

</blockquote>
</details>
<details>
<summary><strong>5. Run the local development server with the &quot;dev&quot; command</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a content folder with a valid "site.json" file and at least one markdown file inside.

**Steps:**
1. Open a terminal, type `jolli dev` followed by the path to your content folder, and press Enter.
2. Wait for the terminal to display a local web address.
3. Open that address in a web browser and confirm the site loads.
4. Edit one of the markdown files in your content folder, save it, then refresh the browser.

**Expected Results:**
- The terminal prints a localhost URL and the site loads in the browser.
- After editing and saving a markdown file, refreshing the browser shows the updated content.
- No unrelated framework error messages clutter the terminal output.

</blockquote>
</details>
<details>
<summary><strong>6. Build output message no longer shows internal folder path</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a content folder with a valid "site.json" and at least one markdown file.

**Steps:**
1. Open a terminal, type `jolli build` followed by the path to your content folder, and press Enter.
2. Wait for the build to complete.
3. Read the last message printed in the terminal carefully.

**Expected Results:**
- The final success message says something like "Run `jolli start` to preview the site."
- The message does NOT contain any long internal folder path (such as a hidden ".jolli" directory path).

</blockquote>
</details>
<details>
<summary><strong>7. OpenAPI files are rendered as browsable pages in the site</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a content folder with a "site.json" and at least one file named "openapi.yaml" (or similar) inside a subfolder.

**Steps:**
1. Open a terminal, type `jolli build` followed by the path to your content folder, and press Enter.
2. Wait for the build to finish, then type `jolli start` and press Enter.
3. Open the displayed localhost address in a browser.
4. Look in the navigation sidebar for a page corresponding to your OpenAPI file and click it.

**Expected Results:**
- The navigation sidebar includes an entry for the OpenAPI file.
- Clicking that entry opens a page displaying an interactive API reference (Swagger UI style), not a raw YAML file.

</blockquote>
</details>
<details>
<summary><strong>8. Broken or unreadable files are skipped gracefully during build</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a content folder that contains at least one normal markdown file and one file that cannot be read (for example, a broken shortcut or a file with no read permissions).

**Steps:**
1. Open a terminal, type `jolli build` followed by the path to your content folder, and press Enter.
2. Wait for the build to complete.
3. Check the terminal output for any crash messages or unhandled errors.
4. Open the built site and verify the readable markdown pages are present.

**Expected Results:**
- The build completes without crashing.
- No alarming error messages appear for the unreadable file — it is silently skipped.
- All other pages from readable files appear correctly in the built site.

</blockquote>
</details>
<details>
<summary><strong>9. Verbose flag shows detailed output during a failed build</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a content folder that is expected to produce a build error (for example, a "site.json" with invalid content).

**Steps:**
1. Open a terminal, type `jolli build --verbose` followed by the path to your content folder, and press Enter.
2. Wait for the build to fail.
3. Compare the terminal output to running the same command without `--verbose`.

**Expected Results:**
- With `--verbose`, the terminal shows detailed framework-level error messages and raw output from the build process.
- Without `--verbose`, only a short summary error message is shown.
- In both cases the command exits with a non-zero status indicating failure.

</blockquote>
</details>
<details>
<summary><strong>10. Shared engine avoids repeated large dependency downloads</strong></summary>
<br>
<blockquote>

**Preconditions:** Have two separate content folders, each with a valid "site.json". Make sure neither has been built before (no hidden build folders exist).

**Steps:**
1. Open a terminal, type `jolli build` on the first content folder, and press Enter. Note roughly how long the install step takes.
2. After the first build finishes, type `jolli build` on the second content folder and press Enter.
3. Compare how long the dependency install step takes for the second build versus the first.

**Expected Results:**
- The first build downloads and installs dependencies (this may take 30–60 seconds or more).
- The second build skips the full install and completes the dependency step much faster (a few seconds at most).
- Both sites build successfully and produce working output.

</blockquote>
</details>

---

## Topics (30)

### May 3, 2026
<details>
<summary><strong>01 · Add comprehensive tests for site conversion command to hit coverage threshold</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The convert command lacked test coverage, and the project needed to reach a 96% coverage threshold. Tests were needed to verify the full range of conversion behaviors including error handling, framework detection, file processing, and output generation.

**💡 Decisions Behind the Code**

- **Mocking at module boundary**: Framework detector and Docusaurus converter were mocked at the module level using `vi.hoisted` so each test could control detection outcomes independently without touching the filesystem for those concerns, keeping tests fast and deterministic.
- **Real filesystem for conversion logic**: Actual temp directories were used for source and output files rather than mocking `fs`, because the conversion logic's core value is its file manipulation behavior — mocking `fs` would hollow out the tests.
- **Readline mocked for prompts**: The site title prompt uses `readline`, which was mocked to return a fixed answer, avoiding any interactive blocking during test runs.

**✅ What Was Implemented**

Created `cli/src/commands/ConvertCommand.test.ts` with 25 test cases covering:
- Command registration on the CLI program
- Basic markdown file conversion and `site.json` output validation
- Error handling when source directory does not exist
- In-place conversion with timestamped backup creation
- Framework config file skipping (e.g. `package.json`, `sidebars.js`)
- Image and OpenAPI file copying
- MDX downgrading to `.md` when incompatible imports are detected
- `slug: /` frontmatter renaming to `index.md`
- Nested directory structure preservation
- Docusaurus sidebar integration into `site.json`
- Path mapping and folder remapping via `pathMappings`
- Favicon extraction and copying
- Backup directory skipping during traversal
- Unreadable file graceful skip

**📁 FILES**
- `cli/src/commands/ConvertCommand.test.ts`

</blockquote>
</details>
<details>
<summary><strong>02 · Add CLI commands for creating, converting, and running sites</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The project needed a set of developer-facing commands so users could scaffold new sites, convert existing content, and run local development or production builds from the command line.

**💡 Decisions Behind the Code**

- **MDX over plain Markdown**: Choosing `@mdx-js/mdx` rather than a simpler Markdown parser gives the site commands the ability to embed JSX components inside content files, which is a common expectation for modern static-site tooling and avoids a costly migration later.
- **Property-based testing added alongside feature**: Introducing `fast-check` at the same time as the new commands signals a deliberate choice to validate command behavior against a wide range of inputs from the start, rather than relying solely on example-based tests.

**✅ What Was Implemented**

- Added `jolli new`, `convert`, `dev`, `build`, and `start` commands to the CLI entry point
- Integrated `@mdx-js/mdx` (v3.1.1) as a production dependency to support MDX content processing across these commands
- Added `fast-check` (v3.23.2) as a dev dependency, likely for property-based testing of the new command logic
- The `@mdx-js/mdx` addition pulled in a large transitive dependency tree: `acorn`, `unified`, `remark-*`, `rehype-*`, `hast-util-*`, `mdast-util-*`, `estree-util-*`, and related AST/parsing utilities

**📁 FILES**
- `package-lock.json`

</blockquote>
</details>
<details>
<summary><strong>03 · Extract plugin interface to decouple site pipeline from Nextra framework</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The site build pipeline was tightly coupled to Nextra-specific functions, making it impossible to support alternative documentation frameworks without rewriting the core command logic.

**💡 Decisions Behind the Code**

- **Interface over direct imports**: Introducing a plugin interface rather than conditional branching keeps the pipeline code stable as new renderers are added — each renderer is self-contained and the command layer never needs to know which framework is active.
- **Fallback to Nextra defaults in ContentMirror**: Rather than requiring all callers to supply content rules, the mirror function falls back to the existing Nextra constants when no rules are provided, preserving backward compatibility without breaking existing tests or callers.
- **Renderer resolved early, errors surfaced before build**: Resolving and validating the renderer at the start of `prepareContent` (before any file I/O) means users get a clear error message immediately rather than a cryptic failure mid-build.
- **Thin wrapper, no logic duplication**: `NextraRenderer` delegates entirely to existing modules rather than inlining their logic, so the refactor carries zero risk of behavioral regression for the current Nextra path.

**✅ What Was Implemented**

- Created `cli/src/site/renderer/SiteRenderer.ts` defining the `SiteRenderer` interface (with methods for project init, cache dirs, navigation, OpenAPI rendering, build/dev commands, output filtering, and page count extraction) and the `ContentRules` interface for MDX compatibility checks.
- Created `cli/src/site/renderer/NextraRenderer.ts` implementing `SiteRenderer` as a thin wrapper delegating to existing modules (`NextraProjectWriter`, `MetaGenerator`, `OpenApiRenderer`, `NpmRunner`, `OutputFilter`).
- Created `cli/src/site/renderer/index.ts` with a `resolveRenderer` factory that reads the optional `renderer` field from site config and throws a descriptive error for unknown values.
- Refactored `StartCommand.ts` to call renderer interface methods instead of framework-specific functions directly; `prepareContent` now returns the resolved renderer instance for downstream use.
- Updated `ContentMirror.ts` to accept an optional `ContentRules` parameter, replacing hardcoded Nextra constants with renderer-supplied values (falling back to Nextra defaults when omitted).
- Added `renderer?: string` field to the `SiteJson` type in `Types.ts`.

**📁 FILES**
- `cli/src/site/renderer/SiteRenderer.ts`
- `cli/src/site/renderer/NextraRenderer.ts`
- `cli/src/site/renderer/index.ts`
- `cli/src/commands/StartCommand.ts`
- `cli/src/site/ContentMirror.ts`

</blockquote>
</details>
<details>
<summary><strong>04 · Shared site engine eliminates per-project npm install overhead</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Every project was running its own npm install, consuming roughly 200MB of disk space each time. The team needed a way to share one set of installed dependencies across all projects.

**💡 Decisions Behind the Code**

- **Single shared install over per-project installs**: Sharing one node_modules directory via symlink avoids hundreds of megabytes of duplication; the trade-off is that all projects must be compatible with the same dependency versions, which is acceptable given jolli controls the version specs.
- **Hash-based invalidation over version pinning alone**: A SHA-256 hash of the full dependency map detects any version change automatically without requiring manual cache-busting, keeping the invalidation logic simple and reliable.
- **File-based lock over in-process mutex**: Because multiple CLI processes can run concurrently (e.g. parallel CI jobs), a filesystem lock is the only mechanism that works across process boundaries; the 5-minute stale timeout prevents deadlocks from crashed processes.
- **Symlink over copying**: Symlinking node_modules is near-instant and keeps disk usage at one copy; copying would negate the space savings and add significant install time per project.

**✅ What Was Implemented**

- Created `cli/src/site/EngineManager.ts` with four exported functions: `getEngineDir` (returns `~/.jolli/site-engine`), `computeDepsHash` (16-char SHA-256 of dependency versions), `engineNeedsInstall` (checks hash + node_modules presence), and `ensureEngine` (writes package.json, runs npm install, writes engine.json metadata).
- Added `linkEngineModules` to replace a project's `node_modules` directory with a symlink pointing to the shared engine's `node_modules`.
- Extracted `NEXTRA_DEPENDENCIES` and `NEXTRA_DEV_DEPENDENCIES` as named exports from `cli/src/site/NextraProjectWriter.ts` so both the project writer and the engine manager reference the same version specs.
- Updated `cli/src/site/NpmRunner.ts` to delegate install checks and execution to the engine manager rather than running npm install per project.
- Added a file-based lock (`engine.json` + `.install-lock`) to handle parallel processes safely, with stale-lock detection after 5 minutes.

**📁 FILES**
- `cli/src/site/EngineManager.ts`
- `cli/src/site/NextraProjectWriter.ts`
- `cli/src/site/NpmRunner.ts`

</blockquote>
</details>
<details>
<summary><strong>05 · NpmRunner install logic updated to use shared engine</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

With the new shared engine in place, the install check and install execution in the npm runner needed to be wired to the engine manager rather than checking for a local node_modules folder and running npm install directly.

**💡 Decisions Behind the Code**

- **Two-condition install check**: Separating "engine needs install" from "project symlink missing" lets each condition be fixed independently — the engine is reinstalled only when versions change, while a missing symlink is repaired cheaply on every run.

**✅ What Was Implemented**

- Updated `needsInstall` in `NpmRunner.ts` to return `true` if either the engine needs install OR the project's node_modules symlink is missing (previously only checked for local node_modules).
- Updated `runNpmInstall` to call `ensureEngine` followed by `linkEngineModules` instead of invoking npm install directly in the build directory.
- Updated `NpmRunner.test.ts` mocks to inject `EngineManager` functions, replacing the previous `spawnSync`-based assertions with engine-aware scenarios.

**📁 FILES**
- `cli/src/site/NpmRunner.ts`

</blockquote>
</details>
<details>
<summary><strong>06 · Prevent interactive prompts from hanging in non-TTY environments</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The CLI's interactive prompts (for site title, folder name, and migration confirmation) would hang indefinitely when run in CI pipelines, IDE terminals, or any piped/non-interactive environment because they waited for stdin input that would never arrive.

**💡 Decisions Behind the Code**

- **Default to "proceed" for migration prompt**: Returning `true` (migrate) in non-TTY mode was chosen over `false` or throwing, because silently skipping migration in automation would produce a broken output, whereas proceeding matches the expected happy path.
- **Empty string for folder name**: Returning `""` rather than a hardcoded fallback name was chosen because the existing validation already treats an empty folder name as an error and exits with code 1, giving a clear failure signal in CI rather than silently creating a misnamed directory.
- **Guard at call site, not in tests**: The TTY check was added inside each prompt function rather than wrapping call sites, keeping the fix self-contained and ensuring any future caller automatically gets the safe behavior.
- **Restore isTTY in afterEach**: Saving and restoring `process.stdin.isTTY` around each test suite prevents test pollution across the suite, since Vitest runs tests in the same process.

**✅ What Was Implemented**

- Added `process.stdin.isTTY` guard at the top of four prompt functions: `promptTitle` in `ConvertCommand.ts`, `promptFolderName` in `NewCommand.ts`, `promptSiteTitle` in `SiteJsonReader.ts`, and `promptMigration` in `FrameworkDetector.ts`
- Non-TTY paths return sensible defaults immediately: empty string for folder name (triggers existing validation/exit), default title string for title prompts, and `true` (migrate) for the migration prompt
- Updated five test files to set `process.stdin.isTTY = true` in `beforeEach` and restore the original value in `afterEach`, preventing the new guard from short-circuiting existing prompt tests
- Added one non-TTY path test per affected command/module to cover the new branches and keep coverage above the 96% threshold

**📁 FILES**
- `cli/src/commands/ConvertCommand.ts`
- `cli/src/commands/NewCommand.ts`
- `cli/src/site/SiteJsonReader.ts`
- `cli/src/site/FrameworkDetector.ts`

</blockquote>
</details>
<details>
<summary><strong>07 · Hide internal output path from build success message</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

After a successful build, the tool was printing the internal directory path where output files were written. This exposed implementation details that users don't need and could be confusing or misleading.

**💡 Decisions Behind the Code**

- **Hide internals over exposing them**: Showing the raw filesystem path where the build writes files leaks implementation details that are irrelevant to most users and could break if the internal structure changes, so a user-facing next-step prompt is more durable and actionable.
- **Guide toward next action**: Replacing the path with a prompt to run the preview command improves the post-build experience by telling users what to do next, rather than leaving them to figure it out.

**✅ What Was Implemented**

Replaced the post-build console message in `cli/src/commands/StartCommand.ts` from printing the internal output path (`Output: <buildDir>/out`) to a next-step prompt (`Run \`jolli start\` to preview the site.`). Updated the corresponding test in `StartCommand.test.ts` to assert the new message content instead of the old path output.

**📁 FILES**
- `cli/src/commands/StartCommand.ts`

</blockquote>
</details>
<details>
<summary><strong>08 · Extend start command tests to cover additional conditional branches</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The start command had several conditional code paths — verbose error output, OpenAPI rendering, sidebar index key renaming, page count extraction, and serve failure handling — that were not exercised by existing tests, leaving gaps below the coverage threshold.

**💡 Decisions Behind the Code**

- **Separate describe block rather than modifying existing tests**: New cases were appended in a distinct block to avoid disturbing the already-passing test suite and to make the intent (branch coverage) clearly scoped.
- **Reuse existing mock infrastructure**: The new tests reuse the `setupSuccessfulRun` helper and mock references already established in the file, minimizing duplication and keeping setup consistent.

**✅ What Was Implemented**

Added a second `describe` block in `cli/src/commands/StartCommand.test.ts` with 14 new test cases covering:
- OpenAPI rendering triggered only when files are present
- Downgraded file count appearing in mirror output message
- Sidebar index key updated when a file is renamed to `index`
- Page count parsed from build output vs. generic success fallback
- Serve failure with and without error output
- Verbose flag surfacing detailed error output for npm install, build, and pagefind failures
- `--migrate` option forwarded to site config reader
- Pagefind output without a pages-indexed field defaulting to zero

**📁 FILES**
- `cli/src/commands/StartCommand.test.ts`

</blockquote>
</details>
<details>
<summary><strong>09 · Add tests for asset resolver placeholder SVG generation</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The asset resolver module had no test coverage, and the placeholder SVG generation function needed to be verified as part of reaching the overall coverage target.

**💡 Decisions Behind the Code**

- **Direct import of the module under test**: The asset resolver is tested by importing it directly without mocking its internals, since its behavior is pure transformation — generating SVG strings and resolving file paths — with no external side effects that need isolation.

**✅ What Was Implemented**

Started `cli/src/site/AssetResolver.test.ts` with a `generatePlaceholderSvg` describe block verifying that the function produces valid SVG content. (Diff is truncated; additional cases likely cover favicon and external image resolution paths.)

**📁 FILES**
- `cli/src/site/AssetResolver.test.ts`

</blockquote>
</details>
<details>
<summary><strong>10 · Fix TypeScript strict-mode type errors in test files</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The test files were producing TypeScript errors because mock call arrays were typed as implicit `any`, which failed under stricter compiler settings introduced alongside the new site commands.

**💡 Decisions Behind the Code**

- **Explicit cast over inference**: Annotating as `unknown[]` then casting to `string[]` satisfies the type checker without changing runtime behavior, keeping the fix minimal and localized to the call sites that need it.
- **Nullish coalescing over non-null assertion**: Replacing `!` with `?? []` is safer because it provides a defined fallback rather than asserting the value can never be absent, reducing the risk of a runtime crash if the map lookup ever misses.

**✅ What Was Implemented**

Added explicit `unknown[]` type annotations to `.mock.calls` callback parameters across three test files, with `as string[]` casts where string methods are called. Also replaced a non-null assertion (`!`) with a nullish coalescing fallback (`?? []`) in production code.

- `cli/src/commands/ConvertCommand.test.ts`: typed three `.mock.calls.map` callbacks
- `cli/src/site/OutputFilter.test.ts`: typed fourteen `.mock.calls.map` callbacks across suppression, error, and URL tests
- `cli/src/site/DocusaurusConverter.ts`: replaced `sidebar.get(dirPath)!` with `sidebar.get(dirPath) ?? []` to eliminate non-null assertion

**📁 FILES**
- `cli/src/site/DocusaurusConverter.ts`

</blockquote>
</details>
<details>
<summary><strong>11 · Dependency version constants extracted for reuse across modules</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The dependency version strings for the Nextra site were duplicated inline inside the package.json generator. Once the engine manager also needed those exact versions to compute its hash, a single source of truth was required.

**💡 Decisions Behind the Code**

- **Named exports over a shared config file**: Keeping the constants in `NextraProjectWriter.ts` (the canonical home of project scaffolding) avoids introducing a new file for what is essentially a small data extraction; any consumer that needs the versions imports from the writer.

**✅ What Was Implemented**

Extracted the `dependencies` and `devDependencies` objects from the inline `generatePackageJson` function in `NextraProjectWriter.ts` into two named exported constants (`NEXTRA_DEPENDENCIES`, `NEXTRA_DEV_DEPENDENCIES`). The function now spreads these constants, and `EngineManager.ts` imports them directly.

**📁 FILES**
- `cli/src/site/NextraProjectWriter.ts`

</blockquote>
</details>
<details>
<summary><strong>12 · Additional edge-case tests for convert command and content mirror</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Several boundary conditions in the convert command and content mirror were not covered: sidebars files leaking into output, in-place conversion, and broken symlinks in the source directory.

**💡 Decisions Behind the Code**

- **Broken symlink treated as silently ignored**: Rather than surfacing an error to the user for an unreadable file, the mirror skips it and continues — this matches the principle of best-effort content collection where a single bad file should not abort the whole run.

**✅ What Was Implemented**

- Added three tests to `ConvertCommand.test.ts`: removal of `sidebars.js` from output, removal of `sidebars.ts` from output, and in-place conversion where source equals destination.
- Added a new describe block in `ContentMirror.test.ts` covering a broken `.mdx` symlink — verifies the file is silently skipped while real markdown files are still processed.
- Added one test to `StartCommand.test.ts` for the dev server failure path where output is an empty string.

**📁 FILES**
- `cli/src/commands/ConvertCommand.test.ts`
- `cli/src/site/ContentMirror.test.ts`
- `cli/src/commands/StartCommand.test.ts`

</blockquote>
</details>
<details>
<summary><strong>13 · Fix four code review findings in content mirroring and file conversion</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

A code review of the site commands feature branch identified several correctness and maintainability issues that needed to be addressed before the branch could be merged.

**💡 Decisions Behind the Code**

- **Eliminate shared state vs. reset it**: The module-level array was cleared with a length-reset after each run, but this is unsafe under concurrent calls. Moving it into the function scope makes each invocation fully independent with no risk of cross-call contamination.
- **Import vs. duplicate**: Rather than keeping two copies of the OpenAPI detection logic in sync, one was removed and the other imported. This ensures a single source of truth and prevents silent behavioral divergence if one copy is updated without the other.
- **Minimal consolidation**: The duplicate `safeRemove` branches were collapsed into the simplest correct form rather than restructured further, keeping the change small and reviewable.

**✅ What Was Implemented**

- Moved `pendingAssets` array from module-level scope into `mirrorContent` function body, passing it as a parameter to `resolveMissingImages` to eliminate shared mutable state across calls
- Replaced hardcoded `/` string splitting in `ensureDir` with `dirname()` from `node:path` for cross-platform correctness
- Removed duplicate `isOpenApiContent` function from `ContentMirror.ts` and replaced its usage with the imported `isValidOpenApiContent` from `OpenApiRenderer.ts`
- Collapsed two identical `safeRemove` branches in `ConvertCommand.ts` into a single condition
- Relocated the `PendingAsset` type alias above its associated JSDoc comment for readability

**📁 FILES**
- `cli/src/site/ContentMirror.ts`
- `cli/src/commands/ConvertCommand.ts`

</blockquote>
</details>
<details>
<summary><strong>14 · Remove unused parameter from package.json generator function</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The function that generates the Nextra project's package.json accepted a site configuration object as a parameter but never used it, creating confusion about whether the output was supposed to vary per site.

**💡 Decisions Behind the Code**

- **Remove rather than document**: Removing the parameter entirely was preferred over adding a comment like "reserved for future use," because dead parameters in a public function signature create false expectations and make the API harder to understand. If per-site customization is needed later, the parameter can be reintroduced with a real implementation.

**✅ What Was Implemented**

- Removed the unused `_config` parameter from `generatePackageJson` in `NextraProjectWriter.ts`
- Updated the single call site in `initNextraProject` to call the function with no arguments
- Updated all 15+ test invocations in `NextraProjectWriter.test.ts` to drop the argument

**📁 FILES**
- `cli/src/site/NextraProjectWriter.ts`

</blockquote>
</details>
<details>
<summary><strong>15 · Fix misleading async signature on synchronous pagefind runner</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The function that runs the pagefind search indexer was declared `async` and returned a Promise, but its implementation used only synchronous child-process spawning. Callers were wrapping it in `await` expecting non-blocking behavior, but it actually blocked the event loop.

**💡 Decisions Behind the Code**

- **Remove async rather than convert to truly async**: Making the function genuinely async (using `spawn` with event listeners) would have been a larger change with no immediate benefit, since the CLI runs pagefind as a one-shot blocking step where event-loop responsiveness doesn't matter. Removing `async` is the minimal honest fix that aligns the signature with the actual behavior.

**✅ What Was Implemented**

- Removed the `async` keyword from `runPagefind` in `PagefindRunner.ts`, changing the return type from `Promise<PagefindResult>` to `PagefindResult`
- Updated the corresponding test assertion from `.resolves.not.toThrow()` to a synchronous `expect(() => ...).not.toThrow()` form

**📁 FILES**
- `cli/src/site/PagefindRunner.ts`

</blockquote>
</details>
<details>
<summary><strong>16 · Add informational log before dynamically importing user sidebar config</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

When converting a Docusaurus project, the CLI silently executed a dynamic import of a user-controlled JavaScript file with full Node.js privileges, giving users no visibility into what was happening or which file was being loaded.

**💡 Decisions Behind the Code**

- **Console log over structured logger**: A plain `console.log` was used rather than the project's pino logger because this is a user-facing progress message during an interactive CLI operation, not an application log event. The indented format (`  Loading sidebar config: ...`) matches the visual style of other CLI output in the convert flow.

**✅ What Was Implemented**

Added a `console.log` statement in `DocusaurusConverter.ts` inside `loadSidebarFile`, printing the resolved sidebar config path immediately before the dynamic `import()` call.

**📁 FILES**
- `cli/src/site/DocusaurusConverter.ts`

</blockquote>
</details>

### May 2, 2026
<details>
<summary><strong>17 · Scaffold new documentation projects with starter files command</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Developers needed a way to quickly bootstrap a new documentation project with sensible defaults, without manually creating the required configuration and content files.

**💡 Decisions Behind the Code**

- **Non-destructive by default**: The command refuses to overwrite an existing directory rather than merging or prompting, preventing accidental data loss with minimal complexity cost.
- **Interactive fallback**: When no folder name is provided the command prompts rather than erroring, improving discoverability for first-time users at the cost of a small readline dependency.

**✅ What Was Implemented**

- Added `jolli new [folder-name]` command via `NewCommand.ts` that prompts interactively when no argument is given
- Implemented `StarterKit.ts` to generate five starter files: `site.json`, `index.md`, `getting-started.md`, `api/openapi.yaml`, and `guides/introduction.md`
- Command returns early (non-destructive) if target directory already exists
- All file writes parallelized with `Promise.all`; errors returned in result object rather than thrown
- Registered command in `Cli.ts` entry point

**📁 FILES**
- `cli/src/commands/NewCommand.ts`
- `cli/src/site/StarterKit.ts`
- `cli/src/Cli.ts`

</blockquote>
</details>
<details>
<summary><strong>18 · Permanent conversion of Docusaurus projects to Nextra structure</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Teams with existing Docusaurus documentation sites needed a one-time migration path to Jolli's Nextra-based format, including directory restructuring, sidebar mapping, and cleanup of incompatible content.

**💡 Decisions Behind the Code**

- **Backup before in-place conversion**: Rather than requiring a separate output path, the command creates a timestamped backup automatically, balancing safety with convenience for users who want to convert in place.
- **Strip pathMappings from output site.json**: After conversion the filesystem already reflects the logical structure, so including path remapping config would be redundant and confusing for users inspecting the result.
- **Timestamped backup naming**: Using an ISO timestamp in the backup folder name makes it unambiguous and sortable, avoiding collisions if the command is run multiple times.

**✅ What Was Implemented**

- Added `jolli convert [source] [--output path]` command via `ConvertCommand.ts` (380 lines)
- Pipeline: detect framework → prompt for title → create timestamped backup → walk and remap files via `pathMappings` → downgrade incompatible MDX → rewrite image paths → handle `slug: /` → copy favicon → write `site.json` without `pathMappings` → clean up framework config files
- In-place conversion always creates a timestamped backup (e.g. `docs.backup-2026-05-02T14-30-22/`) before modifying anything
- `site.json` written without `pathMappings` because the directory structure is already correct after conversion
- Safe rename uses copy-then-remove fallback for cross-device moves

**📁 FILES**
- `cli/src/commands/ConvertCommand.ts`
- `cli/src/site/DocusaurusConverter.ts`
- `cli/src/site/FrameworkDetector.ts`

</blockquote>
</details>
<details>
<summary><strong>19 · Dev, build, and serve commands with isolated build directories</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Users needed CLI commands to develop, build, and serve their documentation sites without polluting their content folders with build artifacts or Node dependencies.

**💡 Decisions Behind the Code**

- **SHA-256 hash for build directory isolation**: Hashing the absolute source path gives a stable, unique directory per project without requiring any user configuration, and keeps build artifacts entirely out of the user's repository.
- **Persist node_modules between runs**: Skipping reinstall when `node_modules/` already exists dramatically reduces subsequent run startup time, which matters most during iterative development.
- **Shared pipeline for all three commands**: Dev, build, and start share identical content preparation steps, reducing duplication and ensuring consistent behavior; the commands diverge only at the final execution step.
- **Static export with Pagefind**: Pagefind requires a completed static build to index, so search indexing is a post-build step rather than integrated into the Next.js build, keeping the two concerns cleanly separated.

**✅ What Was Implemented**

- Added `jolli dev`, `jolli build`, and `jolli start` commands via `StartCommand.ts`
- Each content folder maps to a unique hidden build directory (`~/.jolli/sites/<sha256-12-chars>/`) computed by `getBuildDir()`
- Shared `prepareContent` pipeline: validate source → read `site.json` → init Nextra project → resolve favicon → clear caches → mirror content → fix sidebar index key → generate `_meta.js` → render OpenAPI specs → install npm deps if missing
- `jolli build` adds Pagefind search indexing after static export; `jolli start` additionally serves the output with `npx serve`
- `--migrate` flag forces re-detection of framework config and regeneration of `site.json`

**📁 FILES**
- `cli/src/commands/StartCommand.ts`
- `cli/src/site/NpmRunner.ts`
- `cli/src/site/PagefindRunner.ts`

</blockquote>
</details>
<details>
<summary><strong>20 · Content mirroring engine with MDX downgrading and image path rewriting</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Documentation sites often contain MDX files with framework-specific imports and JSX components that Nextra cannot render, and image paths that break when files are moved to a different directory structure.

**💡 Decisions Behind the Code**

- **Two-layer MDX validation**: Regex is fast but can produce false positives on unusual but valid MDX; the compiler catches real syntax errors. Running the compiler only on regex-flagged files keeps the common case (clean files) fast.
- **Preserve children when stripping JSX**: Removing component tags but keeping their text content means users lose styling but retain readable documentation, which is better than silently dropping content.
- **SVG placeholder for missing images**: Generating a visible placeholder rather than silently omitting broken image references makes problems immediately obvious during development without aborting the build.
- **Rename rather than copy for slug-root files**: Moving the file to `index.md` avoids having two copies of the same content, which would create duplicate sidebar entries.

**✅ What Was Implemented**

- Implemented `ContentMirror.ts` (706 lines) with `mirrorContent()` as the main entry point
- Two-layer MDX compatibility check: fast regex whitelist scan first, then `@mdx-js/mdx` compiler only for files that pass regex (avoids false positives)
- `stripIncompatibleContent()` removes imports/exports, strips uppercase JSX tags while preserving children, converts JSX inline styles to HTML style strings, removes Docusaurus admonition fences
- `rewriteRelativeImagePaths()` resolves each image against its original location, applies path mapping to the image path, then recomputes the relative reference from the new file location
- Missing images resolved via multi-location search; unresolvable images replaced with a 400×300 SVG placeholder showing the filename
- `slug: /` frontmatter detection renames matching file to `index.md` and returns old key for sidebar update

**📁 FILES**
- `cli/src/site/ContentMirror.ts`
- `cli/src/site/AssetResolver.ts`

</blockquote>
</details>
<details>
<summary><strong>21 · Nextra navigation file generation from sidebar configuration</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Nextra v4 requires a `_meta.js` file in each content directory to control sidebar order and labels, but users should not have to write these files manually — they should be derived from the existing site configuration.

**💡 Decisions Behind the Code**

- **Hide index entries by default**: Without hiding, Nextra renders both the parent category link and a redundant "Index" child entry in the sidebar; auto-hiding eliminates this without requiring users to configure it explicitly.
- **Declared items first, filesystem items appended**: This preserves intentional ordering from the sidebar config while still surfacing any files the user added without updating the config, avoiding silent omissions.

**✅ What Was Implemented**

- Implemented `MetaGenerator.ts` (206 lines) with `generateMetaFiles()` recursively producing `_meta.js` per directory
- Default behavior (no override): alphabetical sort, auto-generated title-case labels, `index` entries hidden via `{ display: "hidden" }`
- Override behavior: declared items appear first in declaration order; object values support external links (`href`), separators, and hidden items; unlisted filesystem items appended alphabetically by Nextra automatically
- `toTitleCase()` converts hyphen/underscore-separated filenames to human-readable labels

**📁 FILES**
- `cli/src/site/MetaGenerator.ts`

</blockquote>
</details>
<details>
<summary><strong>22 · Nextra v4 project scaffold generation pinned to compatible version</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Each documentation build requires a complete Next.js + Nextra project with specific configuration files, and the generated scaffold needed to work reliably across runs without manual maintenance.

**💡 Decisions Behind the Code**

- **Pin to nextra 4.2.17**: Nextra 4.3+ introduced a Zod validation regression in the Layout component that breaks builds; pinning trades automatic updates for build reliability until upstream fixes the issue.
- **App Router only**: Nextra v4 dropped Pages Router support, so the generated scaffold uses App Router exclusively — there is no fallback option.
- **Conditional static export flag**: Including `output: 'export'` only for build/start (not dev) avoids Next.js dev server incompatibilities with static export mode while keeping a single config template.

**✅ What Was Implemented**

- Implemented `NextraProjectWriter.ts` (268 lines) generating: `package.json`, `next.config.mjs`, `app/layout.tsx`, `app/[[...mdxPath]]/page.tsx`, `mdx-components.tsx`, and `tsconfig.json`
- Pinned to nextra 4.2.17 (4.3+ has a Zod validation bug in the Layout component)
- `next.config.mjs` conditionally includes `output: 'export'` for static builds; always sets `contentDirBasePath` and `preferRelative`
- Navbar extra content uses `children` prop (not `extraContent`, which was removed in v4)
- `moduleResolution: "bundler"` in tsconfig for compatibility with modern ESM packages

**📋 Future Enhancements**

Unpin nextra from 4.2.17 once the upstream Zod validation bug in the Layout component is resolved in a later release.

**📁 FILES**
- `cli/src/site/NextraProjectWriter.ts`

</blockquote>
</details>
<details>
<summary><strong>23 · Build output filtering for concise user-facing progress display</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Next.js and npm produce large volumes of noisy output (TypeScript detection messages, peer dependency warnings, webpack hot-update lines, version banners) that obscures the information users actually care about during a build.

**💡 Decisions Behind the Code**

- **Allowlist errors, denylist noise**: Rather than trying to allowlist all useful output (brittle as framework output changes), the filter suppresses known noisy patterns and always passes through anything that looks like an error, ensuring users never miss failures.
- **Verbose flag as escape hatch**: Providing `--verbose` means the filtering can be aggressive without locking users out of diagnostic information when they need it.

**✅ What Was Implemented**

- Implemented `OutputFilter.ts` (112 lines) with `createOutputFilter(verbose)` returning a `write(data)` / `getUrl()` interface
- Suppresses 70+ known noisy patterns including TypeScript detection, npm peer warnings, Nextra git warnings, webpack hot-update messages, Fast Refresh notices, and Next.js banners
- Always surfaces: error lines (⨯ prefix, "Module not found", "Build error", "Failed to compile"), HTTP 500 responses, and the localhost URL (printed immediately on first detection)
- `--verbose` flag bypasses all filtering and passes raw framework output directly to the terminal

**📁 FILES**
- `cli/src/site/OutputFilter.ts`
- `cli/src/site/NpmRunner.ts`

</blockquote>
</details>
<details>
<summary><strong>24 · Docusaurus sidebar and path mapping conversion to Jolli format</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Docusaurus organizes documentation using a `sidebars.js` file with a tree of categories, doc IDs, and links, but Jolli uses a flat path-keyed sidebar format — an automated converter was needed to bridge the two.

**💡 Decisions Behind the Code**

- **Flatten virtual categories**: Docusaurus allows logical groupings that don't correspond to filesystem directories; creating spurious subdirectories for these would break file resolution, so they are flattened into the parent level.
- **Generate PathMappings only for mismatches**: Emitting path mappings for every file would be verbose and fragile; only files whose sidebar position genuinely differs from their filesystem location need remapping.
- **Regex for favicon extraction**: A full config parser would be complex and fragile given the variety of Docusaurus config formats; regex extraction of the favicon field is fast and sufficient for the common case.

**✅ What Was Implemented**

- Implemented `DocusaurusConverter.ts` (307 lines) with `convertDocusaurusSidebar()` producing both `SidebarOverrides` and `PathMappings`
- Handles four Docusaurus item types: bare string doc IDs, `{ type: 'doc' }`, `{ type: 'category' }` (recursive), and `{ type: 'link' }` (converted to Nextra link objects)
- Virtual grouping detection: if a category's filesystem directory matches its parent's, items are flattened rather than creating a new subfolder
- `PathMappings` generated only when a doc's logical sidebar position differs from its actual filesystem location
- `extractFaviconFromConfig()` uses regex extraction from `docusaurus.config.ts` to find the favicon path

**📋 Future Enhancements**

Conversion support is implemented only for Docusaurus in v1; Mintlify, VitePress, MkDocs, and GitBook are detected but report as unsupported — implement converters for these frameworks.

**📁 FILES**
- `cli/src/site/DocusaurusConverter.ts`
- `cli/src/site/FrameworkDetector.ts`
- `cli/src/site/SiteJsonReader.ts`

</blockquote>
</details>
<details>
<summary><strong>25 · Skip meta file generation for folders containing only hidden entries</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The site build was failing during prerendering because folders that contained only hidden pages (like a lone index file) were getting a meta configuration file written for them. The rendering framework would then choke on that file since it had no visible entries to process.

**💡 Decisions Behind the Code**

- **Skip rather than write empty**: Writing a meta file with only hidden entries causes the rendering framework to fail at prerender time, so the safest fix is to not write the file at all rather than filtering entries or writing an empty file — this avoids introducing a new edge case in how the framework handles empty configs.

**✅ What Was Implemented**

In `cli/src/site/MetaGenerator.ts`, inside the `processDir` function, added a guard before writing the meta file:
- Checks whether any entry in the built meta list is visible (either a plain string title or an object without `display: "hidden"`)
- Skips the `writeMetaFile` call entirely when all entries are hidden

**📁 FILES**
- `cli/src/site/MetaGenerator.ts`

</blockquote>
</details>
<details>
<summary><strong>26 · Property-based and unit test suite for all site module components</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The site module contains complex transformation logic (MDX downgrading, path rewriting, sidebar generation) where edge cases are hard to enumerate manually, requiring a more rigorous testing approach than example-based tests alone.

**💡 Decisions Behind the Code**

- **Property-based tests for transformation logic**: Classification and ordering functions have infinite input spaces; property-based tests catch edge cases that hand-written examples miss, at the cost of slightly longer test authoring time.
- **Dynamic import for MDX compiler**: Loading `@mdx-js/mdx` only when needed avoids adding startup latency to every CLI invocation; marking it external in the Rollup config ensures it is not bundled and remains loadable at runtime.

**✅ What Was Implemented**

- Added `fast-check` ^3.23.2 as a dev dependency for property-based testing
- Property-based tests prove invariants: any markdown/MDX file classifies as `"markdown"`, any image extension classifies as `"image"`, meta entries always sort alphabetically, title-case output never contains hyphens or underscores, site.json fields are preserved through config generation
- 12 test files covering all site module components; total test count exceeds 2,031
- Coverage thresholds set at 97% statements/functions/lines, 96% branches
- Added `@mdx-js/mdx` to Rollup externals in `vite.config.ts` to prevent bundling the dynamically-imported MDX compiler

**📁 FILES**
- `cli/package.json`
- `cli/vite.config.ts`
- `cli/docs/site-commands-changelog.md`

</blockquote>
</details>

### Apr 30, 2026
<details>
<summary><strong>27 · Scaffold new documentation project with starter kit command</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Developers needed a way to quickly create a new documentation project without manually setting up folder structure, config files, and example content. Running a single command should produce a ready-to-edit content folder.

**💡 Decisions Behind the Code**

- **Starter kit scope**: Included a nested subfolder (`guides/`) and an OpenAPI YAML example to demonstrate multi-level navigation and API doc rendering from the first run, reducing the learning curve for new users.
- **No overwrite on conflict**: Chose to fail fast with a clear error rather than merging or prompting, prioritizing safety over convenience to prevent accidental data loss.

**✅ What Was Implemented**

- Created `.kiro/specs/jolli-new-command/requirements.md` defining acceptance criteria for `jolli new <folder-name>`, including directory creation, error handling for existing targets, and starter file generation
- Designed `cli/src/commands/NewCommand.ts` (spec only) to register the command via commander and delegate to `StarterKit.scaffoldProject()`
- Designed `cli/src/site/StarterKit.ts` (spec only) with `scaffoldProject()` writing: `site.json`, `index.md`, `getting-started.md`, `api/openapi.yaml`, and `guides/introduction.md`
- Specified error behavior: exit with non-zero code and descriptive message if target directory already exists, no filesystem changes made

**📁 FILES**
- `.kiro/specs/jolli-new-command/requirements.md`
- `.kiro/specs/jolli-new-command/design.md`

</blockquote>
</details>
<details>
<summary><strong>28 · Render content folder as Nextra static site with navigation and search</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

After creating a documentation project, developers needed a single command to turn their markdown and OpenAPI files into a fully built, searchable static site without manually configuring Next.js or Nextra.

**💡 Decisions Behind the Code**

- **Build directory inside content folder**: Placing `.jolli-site/` inside the source root keeps build artifacts co-located with content, making projects self-contained and portable without global state.
- **No new CLI runtime dependencies**: Nextra, Next.js, and Pagefind are written into the generated project's `package.json` and installed at runtime, keeping the CLI package lean and avoiding version conflicts.
- **Incremental updates over full rebuild**: Reusing the existing build directory and skipping `npm install` when `node_modules/` exists dramatically reduces subsequent run times at the cost of slightly more complex update logic.
- **Content-based OpenAPI detection**: Classifying files by both extension and content inspection (checking for `openapi` field and `info` object) prevents false positives from arbitrary JSON/YAML files, improving correctness over extension-only matching.
- **Separate module per pipeline phase**: Each concern (mirroring, meta generation, OpenAPI rendering, npm running) lives in its own file, making each unit independently testable and replaceable without touching the orchestrator.

**✅ What Was Implemented**

- Specified `cli/src/commands/StartCommand.ts` orchestrating an 8-step pipeline: validate source, read config, init build dir, mirror content, generate navigation files, render OpenAPI pages, install dependencies, build, and index search
- Designed `cli/src/site/ContentMirror.ts` with `classifyFile()` (extension + content inspection) and `mirrorContent()` to replicate directory trees into the Nextra pages directory
- Designed `cli/src/site/MetaGenerator.ts` with `buildMetaEntries()` (alphabetical sort) and `generateMetaFiles()` for Nextra v4 `_meta.js` navigation files
- Designed `cli/src/site/OpenApiRenderer.ts` to generate `.mdx` pages embedding a Swagger UI component for each detected OpenAPI file
- Designed `cli/src/site/NpmRunner.ts` and `PagefindRunner.ts` for dependency installation, site building, and full-text search indexing
- Designed `cli/src/site/NextraProjectWriter.ts` to write and maintain `package.json`, `next.config.mjs`, and `theme.config.tsx` inside `.jolli-site/`

**📋 Future Enhancements**

Integration tests for the full `jolli start` pipeline are explicitly deferred -- end-to-end testing of npm install, next build, and pagefind steps is marked as manual only.

**📁 FILES**
- `.kiro/specs/jolli-new-command/design.md`
- `.kiro/specs/jolli-new-command/requirements.md`

</blockquote>
</details>
<details>
<summary><strong>29 · Define site configuration schema and conversion to framework config files</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Developers wanted to control site title, description, and navigation bar through a simple JSON file in their content folder, without ever touching framework-specific configuration files that Nextra requires.

**💡 Decisions Behind the Code**

- **Default config on missing file vs. hard error**: Chose to warn and continue with defaults rather than fail, so `jolli start` works out of the box on a bare content folder, prioritizing a smooth first-run experience.
- **Silent ignore for unknown fields**: Unknown fields are dropped without error to keep the schema forward-compatible and avoid breaking existing projects when new fields are added later.
- **Separate reader from writer**: Isolating config reading (`SiteJsonReader`) from Nextra file generation (`NextraProjectWriter`) keeps each unit testable in isolation and makes it easy to swap the output format independently.

**✅ What Was Implemented**

- Specified `site.json` schema in requirements with required `title`, `description`, and `nav` (array of label/href objects) fields; unknown fields silently ignored
- Designed `cli/src/site/SiteJsonReader.ts` with `readSiteJson()` returning a typed `SiteJsonResult`; missing file triggers default config with stderr warning; invalid JSON throws a descriptive error
- Designed `cli/src/site/NextraProjectWriter.ts` functions `generatePackageJson()`, `generateNextConfig()`, and `generateThemeConfig()` to embed `site.json` values into generated Nextra files
- Defined six correctness properties in the design document, including Property 5 (site.json fields preserved verbatim in generated config) with property-based test coverage via fast-check

**📁 FILES**
- `.kiro/specs/jolli-new-command/requirements.md`
- `.kiro/specs/jolli-new-command/design.md`

</blockquote>
</details>
<details>
<summary><strong>30 · Define shared type contracts for site generation modules</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The site generation feature needed a single source of truth for the data shapes passed between its major components, so that each module could be built independently without duplicating or mismatching type definitions.

**💡 Decisions Behind the Code**

- **Centralized type file over co-located types**: Grouping all shared contracts in one file prevents duplication and drift as multiple modules (scaffolding, mirroring, npm, search) evolve in parallel — the cost is a single extra import, but the maintainability gain is significant.
- **Index signature on site config**: Allowing unknown fields on the configuration interface means future config additions won't break existing consumers, trading strict exhaustiveness for forward compatibility.
- **Union string type for file classification**: Using a closed string union instead of an enum keeps the type lightweight and tree-shakeable while still providing compile-time safety for all classification branches.

**✅ What Was Implemented**

Created `cli/src/site/Types.ts` as the canonical shared type file for the `jolli new` and `jolli start` site modules. Exports include:
- `FileType` union — classifies source files as markdown, openapi, image, or ignored
- `NavLink` and `SiteJson` interfaces — model the structure of the site configuration file
- `ScaffoldResult` — return shape for the project scaffolding operation
- `MirrorResult` — return shape for content mirroring, with separate arrays per file category
- `NpmRunResult` — return shape for npm runner operations
- `PagefindResult` — return shape for the search indexing step

**📁 FILES**
- `cli/src/site/Types.ts`

</blockquote>
</details>

---

*Generated by Jolli Memory · May 3, 2026 at 10:06 PM*
<!-- jollimemory-summary-end -->