### PR TITLE
Add Cursor IDE as transcript source

### DIFF
--- a/cli/src/Cli.test.ts
+++ b/cli/src/Cli.test.ts
@@ -386,7 +386,7 @@ describe("CLI", () => {
 		});
 
 		describe("integration rows", () => {
-			it("renders rows for all four integrations when detected, with session counts", async () => {
+			it("renders rows for all five integrations when detected, with session counts", async () => {
 				vi.mocked(getStatus).mockResolvedValueOnce({
 					enabled: true,
 					claudeHookInstalled: true,
@@ -400,10 +400,12 @@ describe("CLI", () => {
 					codexDetected: true,
 					geminiDetected: true,
 					openCodeDetected: true,
+					cursorDetected: true,
 					codexEnabled: true,
 					geminiEnabled: true,
 					openCodeEnabled: true,
-					sessionsBySource: { claude: 3, codex: 2, gemini: 4, opencode: 1 },
+					cursorEnabled: true,
+					sessionsBySource: { claude: 3, codex: 2, gemini: 4, opencode: 1, cursor: 5 },
 				});
 				vi.mocked(loadConfigFromDir).mockResolvedValueOnce({ claudeEnabled: true });
 
@@ -421,6 +423,9 @@ describe("CLI", () => {
 				expect(calls.some((s) => s.includes("OpenCode:") && s.includes("detected & enabled (1 session)"))).toBe(
 					true,
 				);
+				expect(calls.some((s) => s.includes("Cursor:") && s.includes("detected & enabled (5 sessions)"))).toBe(
+					true,
+				);
 			});
 
 			it("renders 'detected but disabled' when an integration is turned off in config", async () => {
@@ -436,8 +441,10 @@ describe("CLI", () => {
 					claudeDetected: true,
 					codexDetected: true,
 					openCodeDetected: true,
+					cursorDetected: true,
 					codexEnabled: false,
 					openCodeEnabled: false,
+					cursorEnabled: false,
 					sessionsBySource: {},
 				});
 				vi.mocked(loadConfigFromDir).mockResolvedValueOnce({ claudeEnabled: false });
@@ -447,6 +454,7 @@ describe("CLI", () => {
 				expect(calls.some((s) => s.includes("Claude:") && s.includes("detected but disabled"))).toBe(true);
 				expect(calls.some((s) => s.includes("Codex:") && s.includes("detected but disabled"))).toBe(true);
 				expect(calls.some((s) => s.includes("OpenCode:") && s.includes("detected but disabled"))).toBe(true);
+				expect(calls.some((s) => s.includes("Cursor:") && s.includes("detected but disabled"))).toBe(true);
 			});
 
 			it("renders 'hook not installed' for Gemini when detected+enabled but the AfterAgent hook is missing", async () => {
@@ -490,6 +498,27 @@ describe("CLI", () => {
 				expect(calls.some((s) => s.includes("OpenCode:") && s.includes("unavailable — corrupt"))).toBe(true);
 			});
 
+			it("renders 'unavailable — <kind>' for Cursor when cursorScanError is present", async () => {
+				vi.mocked(getStatus).mockResolvedValueOnce({
+					enabled: true,
+					claudeHookInstalled: false,
+					gitHookInstalled: true,
+					geminiHookInstalled: false,
+					activeSessions: 0,
+					mostRecentSession: null,
+					summaryCount: 0,
+					orphanBranch: "jollimemory/summaries/v3",
+					cursorDetected: true,
+					cursorEnabled: true,
+					cursorScanError: { kind: "locked", message: "database is locked" },
+					sessionsBySource: {},
+				});
+
+				await main(["status"]);
+				const calls = vi.mocked(console.log).mock.calls.map((c) => String(c[0]));
+				expect(calls.some((s) => s.includes("Cursor:") && s.includes("unavailable — locked"))).toBe(true);
+			});
+
 			it("does not print a row for an integration that was not detected", async () => {
 				vi.mocked(getStatus).mockResolvedValueOnce({
 					enabled: true,
@@ -504,6 +533,7 @@ describe("CLI", () => {
 					codexDetected: false,
 					geminiDetected: false,
 					openCodeDetected: false,
+					cursorDetected: false,
 					sessionsBySource: {},
 				});
 
@@ -513,6 +543,7 @@ describe("CLI", () => {
 				expect(calls.some((s) => /^\s+Codex:/.test(s))).toBe(false);
 				expect(calls.some((s) => /^\s+Gemini:/.test(s))).toBe(false);
 				expect(calls.some((s) => /^\s+OpenCode:/.test(s))).toBe(false);
+				expect(calls.some((s) => /^\s+Cursor:/.test(s))).toBe(false);
 			});
 		});
 	});
@@ -3136,6 +3167,44 @@ describe("CLI", () => {
 			expect(output).toContain("openCodeEnabled");
 			// Description should mention the Node version requirement — this is
 			// the only config key that's runtime-gated and users deserve the hint.
+			expect(output).toContain("Node 22.5+");
+		});
+
+		it("should accept cursorEnabled=true/false", async () => {
+			const { saveConfig } = await import("./core/SessionTracker.js");
+
+			await main(["configure", "--set", "cursorEnabled=false"]);
+			expect(saveConfig).toHaveBeenCalledWith(expect.objectContaining({ cursorEnabled: false }));
+
+			vi.mocked(saveConfig).mockClear();
+			await main(["configure", "--set", "cursorEnabled=true"]);
+			expect(saveConfig).toHaveBeenCalledWith(expect.objectContaining({ cursorEnabled: true }));
+		});
+
+		it("should reject cursorEnabled with a non-boolean value", async () => {
+			const { saveConfig } = await import("./core/SessionTracker.js");
+			vi.mocked(saveConfig).mockClear();
+			const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+			try {
+				await main(["configure", "--set", "cursorEnabled=maybe"]);
+				expect(saveConfig).not.toHaveBeenCalled();
+				expect(process.exitCode).toBe(1);
+				const errorOutput = errorSpy.mock.calls.map((c) => String(c[0])).join("\n");
+				expect(errorOutput).toContain("cursorEnabled");
+				expect(errorOutput).toContain("true/false");
+			} finally {
+				errorSpy.mockRestore();
+			}
+		});
+
+		it("--list-keys includes cursorEnabled", async () => {
+			await main(["configure", "--list-keys"]);
+			const output = vi
+				.mocked(console.log)
+				.mock.calls.map((c) => String(c[0]))
+				.join("\n");
+			expect(output).toContain("cursorEnabled");
+			// Description should mention the Node version requirement.
 			expect(output).toContain("Node 22.5+");
 		});
 

--- a/cli/src/Types.ts
+++ b/cli/src/Types.ts
@@ -5,7 +5,7 @@
  */
 
 /** Which AI coding agent produced the transcript */
-export type TranscriptSource = "claude" | "codex" | "gemini" | "opencode";
+export type TranscriptSource = "claude" | "codex" | "gemini" | "opencode" | "cursor";
 
 /** Metadata about an AI coding session, saved by the Stop hook (Claude) or discovered on-demand (Codex) */
 export interface SessionInfo {
@@ -486,6 +486,8 @@ export interface JolliMemoryConfig {
 	readonly claudeEnabled?: boolean;
 	/** Enable OpenCode session discovery at post-commit time (default: auto-detect) */
 	readonly openCodeEnabled?: boolean;
+	/** Enable Cursor Composer session discovery at post-commit time (default: auto-detect) */
+	readonly cursorEnabled?: boolean;
 	/** Global minimum log level written to debug.log (default: "info") */
 	readonly logLevel?: LogLevel;
 	/** Per-module log level overrides (e.g. { "GitOps": "debug" }) */
@@ -558,6 +560,19 @@ export interface StatusInfo {
 	readonly openCodeDetected?: boolean;
 	/** Whether OpenCode session discovery is enabled in config (undefined = auto-detect) */
 	readonly openCodeEnabled?: boolean;
+	/** Whether Cursor data dir was detected (Cursor.app + state.vscdb + node:sqlite) */
+	readonly cursorDetected?: boolean;
+	/** Whether Cursor session discovery is enabled in config (undefined = auto-detect) */
+	readonly cursorEnabled?: boolean;
+	/**
+	 * Cursor DB scan failed with a real (non-ENOENT) error — corrupt, locked,
+	 * schema drift, or permission denied. UI surfaces this adjacent to the Cursor
+	 * row instead of silently rendering "0 sessions".
+	 */
+	readonly cursorScanError?: {
+		readonly kind: "corrupt" | "locked" | "permission" | "schema" | "unknown";
+		readonly message: string;
+	};
 	/** Directory path for global config (~/.jolli/jollimemory) */
 	readonly globalConfigDir?: string;
 	/** Path to the worktree state directory */

--- a/cli/src/commands/ConfigureCommand.ts
+++ b/cli/src/commands/ConfigureCommand.ts
@@ -31,6 +31,7 @@ const VALID_CONFIG_KEYS = [
 	"geminiEnabled",
 	"claudeEnabled",
 	"openCodeEnabled",
+	"cursorEnabled",
 	"logLevel",
 	"excludePatterns",
 ] as const satisfies ReadonlyArray<keyof JolliMemoryConfig>;
@@ -64,7 +65,13 @@ function coerceConfigValue(key: ConfigKey, raw: string): string | number | boole
 		return n;
 	}
 	// Boolean fields
-	if (key === "codexEnabled" || key === "geminiEnabled" || key === "claudeEnabled" || key === "openCodeEnabled") {
+	if (
+		key === "codexEnabled" ||
+		key === "geminiEnabled" ||
+		key === "claudeEnabled" ||
+		key === "openCodeEnabled" ||
+		key === "cursorEnabled"
+	) {
 		const lower = raw.toLowerCase();
 		if (lower === "true" || lower === "1" || lower === "yes") return true;
 		if (lower === "false" || lower === "0" || lower === "no") return false;
@@ -102,6 +109,11 @@ const CONFIG_KEY_INFO: ReadonlyArray<{ key: ConfigKey; type: string; description
 		key: "openCodeEnabled",
 		type: "boolean",
 		description: "Enable OpenCode session discovery (true/false; requires Node 22.5+ at runtime)",
+	},
+	{
+		key: "cursorEnabled",
+		type: "boolean",
+		description: "Enable Cursor Composer session discovery (true/false; requires Node 22.5+ at runtime)",
 	},
 	{ key: "logLevel", type: "enum", description: "Log level: debug | info | warn | error" },
 	{ key: "excludePatterns", type: "string[]", description: "Glob patterns for file exclusion (comma-separated)" },

--- a/cli/src/commands/StatusCommand.ts
+++ b/cli/src/commands/StatusCommand.ts
@@ -148,6 +148,16 @@ export function registerStatusCommand(program: Command): void {
 						scanError: status.openCodeScanError,
 					},
 				],
+				[
+					"Cursor:",
+					status.cursorDetected,
+					{
+						enabled: status.cursorEnabled !== false,
+						hookInstalled: undefined,
+						sessionCount: counts.cursor,
+						scanError: status.cursorScanError,
+					},
+				],
 			];
 			for (const [label, detected, inputs] of integrationRows) {
 				if (!detected) continue;

--- a/cli/src/core/CursorDetector.test.ts
+++ b/cli/src/core/CursorDetector.test.ts
@@ -1,0 +1,109 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.spyOn(console, "log").mockImplementation(() => {});
+
+const { mockHomedir, mockPlatform } = vi.hoisted(() => ({
+	mockHomedir: vi.fn().mockReturnValue(""),
+	mockPlatform: vi.fn().mockReturnValue("darwin"),
+}));
+vi.mock("node:os", async (importOriginal) => {
+	const original = await importOriginal<typeof import("node:os")>();
+	return { ...original, homedir: mockHomedir, platform: mockPlatform };
+});
+
+const { mockSqliteSupport } = vi.hoisted(() => ({
+	mockSqliteSupport: vi.fn().mockReturnValue(true),
+}));
+vi.mock("./SqliteHelpers.js", async () => ({
+	hasNodeSqliteSupport: mockSqliteSupport,
+}));
+
+import { getCursorGlobalDbPath, isCursorInstalled } from "./CursorDetector.js";
+
+describe("isCursorInstalled (darwin)", () => {
+	let tmpHome: string;
+
+	beforeEach(async () => {
+		tmpHome = await mkdtemp(join(tmpdir(), "cursor-detector-"));
+		mockHomedir.mockReturnValue(tmpHome);
+		mockPlatform.mockReturnValue("darwin");
+		mockSqliteSupport.mockReturnValue(true);
+	});
+
+	afterEach(async () => {
+		await rm(tmpHome, { recursive: true, force: true });
+	});
+
+	it("returns false when neither app nor data dir exists", async () => {
+		expect(await isCursorInstalled()).toBe(false);
+	});
+
+	it("returns false when data db does not exist", async () => {
+		await mkdir(join(tmpHome, "Library/Application Support/Cursor/User/globalStorage"), { recursive: true });
+		expect(await isCursorInstalled()).toBe(false);
+	});
+
+	it("returns true when data db exists and Node has SQLite support", async () => {
+		const globalDir = join(tmpHome, "Library/Application Support/Cursor/User/globalStorage");
+		await mkdir(globalDir, { recursive: true });
+		await writeFile(join(globalDir, "state.vscdb"), "stub");
+		expect(await isCursorInstalled()).toBe(true);
+	});
+
+	it("returns false when Node lacks SQLite support, even if data exists", async () => {
+		const globalDir = join(tmpHome, "Library/Application Support/Cursor/User/globalStorage");
+		await mkdir(globalDir, { recursive: true });
+		await writeFile(join(globalDir, "state.vscdb"), "stub");
+		mockSqliteSupport.mockReturnValue(false);
+		expect(await isCursorInstalled()).toBe(false);
+	});
+});
+
+describe("isCursorInstalled (linux)", () => {
+	let tmpHome: string;
+
+	beforeEach(async () => {
+		tmpHome = await mkdtemp(join(tmpdir(), "cursor-detector-"));
+		mockHomedir.mockReturnValue(tmpHome);
+		mockPlatform.mockReturnValue("linux");
+		mockSqliteSupport.mockReturnValue(true);
+	});
+
+	afterEach(async () => {
+		await rm(tmpHome, { recursive: true, force: true });
+	});
+
+	it("uses ~/.config/Cursor on linux", async () => {
+		const globalDir = join(tmpHome, ".config/Cursor/User/globalStorage");
+		await mkdir(globalDir, { recursive: true });
+		await writeFile(join(globalDir, "state.vscdb"), "stub");
+		expect(await isCursorInstalled()).toBe(true);
+	});
+});
+
+describe("getCursorGlobalDbPath", () => {
+	beforeEach(() => {
+		mockHomedir.mockReturnValue("/home/user");
+	});
+
+	it("returns the darwin path", () => {
+		mockPlatform.mockReturnValue("darwin");
+		expect(getCursorGlobalDbPath()).toBe(
+			"/home/user/Library/Application Support/Cursor/User/globalStorage/state.vscdb",
+		);
+	});
+
+	it("returns the linux path", () => {
+		mockPlatform.mockReturnValue("linux");
+		expect(getCursorGlobalDbPath()).toBe("/home/user/.config/Cursor/User/globalStorage/state.vscdb");
+	});
+
+	it("returns a Cursor-rooted path on win32", () => {
+		mockPlatform.mockReturnValue("win32");
+		const path = getCursorGlobalDbPath();
+		expect(path.endsWith("Cursor/User/globalStorage/state.vscdb")).toBe(true);
+	});
+});

--- a/cli/src/core/CursorDetector.ts
+++ b/cli/src/core/CursorDetector.ts
@@ -1,0 +1,81 @@
+/**
+ * Cursor Detector
+ *
+ * Detects Cursor presence by checking for its global state database.
+ * Used at install time and by getStatus() to report Cursor integration state.
+ *
+ * Per-platform database paths:
+ *   darwin  ~/Library/Application Support/Cursor/User/globalStorage/state.vscdb
+ *   linux   ~/.config/Cursor/User/globalStorage/state.vscdb
+ *   win32   %APPDATA%/Cursor/User/globalStorage/state.vscdb
+ *
+ * Detection is gated on hasNodeSqliteSupport() so VS Code extension hosts
+ * running Node 18 report "not installed" rather than "detected but unreadable".
+ */
+
+import { stat } from "node:fs/promises";
+import { homedir, platform } from "node:os";
+import { join } from "node:path";
+import { createLogger } from "../Logger.js";
+import { hasNodeSqliteSupport } from "./SqliteHelpers.js";
+
+const log = createLogger("CursorDetector");
+
+/**
+ * Returns the Cursor user-data root directory for the current platform.
+ * Matches the paths used by the VS Code-based Cursor editor.
+ */
+function getCursorUserDataDir(home: string = homedir()): string {
+	switch (platform()) {
+		case "darwin":
+			return join(home, "Library", "Application Support", "Cursor");
+		case "win32":
+			return join(process.env.APPDATA ?? join(home, "AppData", "Roaming"), "Cursor");
+		default:
+			// linux and other unix-like systems
+			return join(home, ".config", "Cursor");
+	}
+}
+
+/**
+ * Returns the path to Cursor's global state database.
+ * Readable via node:sqlite; contains extension state, workspace history, etc.
+ */
+export function getCursorGlobalDbPath(home?: string): string {
+	return join(getCursorUserDataDir(home), "User", "globalStorage", "state.vscdb");
+}
+
+/**
+ * Returns the path to Cursor's workspace storage directory.
+ * Each workspace gets a hashed subdirectory containing a state.vscdb.
+ * Used by CursorSessionDiscoverer to enumerate per-project sessions.
+ */
+export function getCursorWorkspaceStorageDir(home?: string): string {
+	return join(getCursorUserDataDir(home), "User", "workspaceStorage");
+}
+
+/**
+ * Checks whether Cursor is installed AND the current runtime can read its DB.
+ *
+ * Returns false when node:sqlite is unavailable (VS Code extension hosts on
+ * Node 18) so the UI does not render "Cursor detected & enabled (0 sessions)"
+ * on runtimes where a scan would always fail.
+ */
+export async function isCursorInstalled(): Promise<boolean> {
+	if (!hasNodeSqliteSupport()) {
+		// Expected "not applicable", not a failure — log at info so operators
+		// can correlate "Cursor absent from status" with the runtime version.
+		log.info(
+			"Cursor support disabled: this runtime is Node %s, requires 22.5+ for built-in SQLite",
+			process.versions.node,
+		);
+		return false;
+	}
+	const dbPath = getCursorGlobalDbPath();
+	try {
+		const fileStat = await stat(dbPath);
+		return fileStat.isFile();
+	} catch {
+		return false;
+	}
+}

--- a/cli/src/core/CursorSessionDiscoverer.test.ts
+++ b/cli/src/core/CursorSessionDiscoverer.test.ts
@@ -1,0 +1,613 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.spyOn(console, "log").mockImplementation(() => {});
+vi.spyOn(console, "warn").mockImplementation(() => {});
+vi.spyOn(console, "error").mockImplementation(() => {});
+
+const { mockHomedir, mockPlatform } = vi.hoisted(() => ({
+	mockHomedir: vi.fn().mockReturnValue(""),
+	mockPlatform: vi.fn().mockReturnValue("darwin"),
+}));
+vi.mock("node:os", async (importOriginal) => {
+	const original = await importOriginal<typeof import("node:os")>();
+	return { ...original, homedir: mockHomedir, platform: mockPlatform };
+});
+
+import { discoverCursorSessions, scanCursorSessions } from "./CursorSessionDiscoverer.js";
+
+const CURSOR_DDL = [
+	`CREATE TABLE ItemTable (key TEXT UNIQUE ON CONFLICT REPLACE, value BLOB)`,
+	`CREATE TABLE cursorDiskKV (key TEXT UNIQUE ON CONFLICT REPLACE, value BLOB)`,
+];
+
+interface ComposerFixture {
+	composerId: string;
+	name?: string;
+	createdAtMs: number;
+	lastUpdatedAtMs: number;
+	bubbleHeaders?: ReadonlyArray<{ bubbleId: string; type: number }>;
+}
+
+function createCursorGlobalDb(dbPath: string, composers: ReadonlyArray<ComposerFixture>): void {
+	const db = new DatabaseSync(dbPath);
+	for (const sql of CURSOR_DDL) db.prepare(sql).run();
+	for (const c of composers) {
+		const value = JSON.stringify({
+			_v: 16,
+			composerId: c.composerId,
+			name: c.name ?? "Untitled",
+			createdAt: c.createdAtMs,
+			lastUpdatedAt: c.lastUpdatedAtMs,
+			fullConversationHeadersOnly: (c.bubbleHeaders ?? []).map((h) => ({ ...h, grouping: null })),
+			status: "completed",
+			unifiedMode: "agent",
+		});
+		db.prepare("INSERT INTO cursorDiskKV (key, value) VALUES (?, ?)").run(`composerData:${c.composerId}`, value);
+	}
+	db.close();
+}
+
+function createCursorWorkspaceDb(
+	dbPath: string,
+	pointers: { lastFocusedComposerIds?: string[]; selectedComposerIds?: string[] } | null,
+): void {
+	const db = new DatabaseSync(dbPath);
+	for (const sql of CURSOR_DDL) db.prepare(sql).run();
+	if (pointers) {
+		const value = JSON.stringify({
+			lastFocusedComposerIds: pointers.lastFocusedComposerIds ?? [],
+			selectedComposerIds: pointers.selectedComposerIds ?? [],
+			hasMigratedComposerData: true,
+			hasMigratedMultipleComposers: true,
+		});
+		db.prepare("INSERT INTO ItemTable (key, value) VALUES (?, ?)").run("composer.composerData", value);
+	}
+	db.close();
+}
+
+async function setupCursorHome(
+	tmpHome: string,
+	opts: {
+		globalComposers: ReadonlyArray<ComposerFixture>;
+		workspaces: ReadonlyArray<{
+			folder: string;
+			pointers: { lastFocusedComposerIds?: string[]; selectedComposerIds?: string[] } | null;
+		}>;
+	},
+): Promise<void> {
+	const userDir = join(tmpHome, "Library/Application Support/Cursor/User");
+	await mkdir(join(userDir, "globalStorage"), { recursive: true });
+	createCursorGlobalDb(join(userDir, "globalStorage", "state.vscdb"), opts.globalComposers);
+
+	let i = 0;
+	for (const ws of opts.workspaces) {
+		const wsHash = `ws-${String(i).padStart(8, "0")}`;
+		const wsDir = join(userDir, "workspaceStorage", wsHash);
+		await mkdir(wsDir, { recursive: true });
+		await writeFile(join(wsDir, "workspace.json"), JSON.stringify({ folder: ws.folder }));
+		createCursorWorkspaceDb(join(wsDir, "state.vscdb"), ws.pointers);
+		i++;
+	}
+}
+
+describe("discoverCursorSessions", () => {
+	let tmpHome: string;
+
+	beforeEach(async () => {
+		tmpHome = await mkdtemp(join(tmpdir(), "cursor-disc-"));
+		mockHomedir.mockReturnValue(tmpHome);
+		mockPlatform.mockReturnValue("darwin");
+	});
+
+	afterEach(async () => {
+		await rm(tmpHome, { recursive: true, force: true });
+	});
+
+	it("returns [] when projectDir does not match any workspace", async () => {
+		await setupCursorHome(tmpHome, { globalComposers: [], workspaces: [] });
+		const sessions = await discoverCursorSessions("/Users/flyer/jolli/code/somewhere");
+		expect(sessions).toEqual([]);
+	});
+
+	it("returns the anchor composer when workspace pointer is set, even outside time window", async () => {
+		const ancientTs = Date.now() - 365 * 24 * 60 * 60 * 1000;
+		await setupCursorHome(tmpHome, {
+			globalComposers: [{ composerId: "anchor-1", createdAtMs: ancientTs, lastUpdatedAtMs: ancientTs }],
+			workspaces: [
+				{
+					folder: "file:///Users/flyer/work/proj-a",
+					pointers: { lastFocusedComposerIds: ["anchor-1"] },
+				},
+			],
+		});
+
+		const sessions = await discoverCursorSessions("/Users/flyer/work/proj-a");
+		expect(sessions).toHaveLength(1);
+		expect(sessions[0]).toMatchObject({ sessionId: "anchor-1", source: "cursor" });
+		expect(sessions[0].transcriptPath).toContain("#anchor-1");
+	});
+
+	it("includes time-window composers in addition to anchors, deduped", async () => {
+		const fresh = Date.now() - 60 * 1000;
+		const stale = Date.now() - 100 * 60 * 60 * 1000;
+		await setupCursorHome(tmpHome, {
+			globalComposers: [
+				{ composerId: "anchor-1", createdAtMs: fresh, lastUpdatedAtMs: fresh },
+				{ composerId: "fresh-2", createdAtMs: fresh, lastUpdatedAtMs: fresh },
+				{ composerId: "stale-3", createdAtMs: stale, lastUpdatedAtMs: stale },
+			],
+			workspaces: [
+				{
+					folder: "file:///Users/flyer/work/proj-a",
+					pointers: { lastFocusedComposerIds: ["anchor-1"] },
+				},
+			],
+		});
+
+		const sessions = await discoverCursorSessions("/Users/flyer/work/proj-a");
+		const ids = sessions.map((s) => s.sessionId).sort();
+		expect(ids).toEqual(["anchor-1", "fresh-2"]);
+	});
+
+	it("URL-decodes file:// folder paths and matches case-insensitively on darwin", async () => {
+		await setupCursorHome(tmpHome, {
+			globalComposers: [{ composerId: "c-1", createdAtMs: Date.now(), lastUpdatedAtMs: Date.now() }],
+			workspaces: [
+				{
+					folder: "file:///Users/Flyer/Code%20Folder/Proj",
+					pointers: { lastFocusedComposerIds: ["c-1"] },
+				},
+			],
+		});
+
+		const sessions = await discoverCursorSessions("/users/flyer/code folder/proj");
+		expect(sessions).toHaveLength(1);
+	});
+
+	it("returns empty when no anchor and no fresh composers, even if workspace matches", async () => {
+		const stale = Date.now() - 100 * 60 * 60 * 1000;
+		await setupCursorHome(tmpHome, {
+			globalComposers: [{ composerId: "stale-1", createdAtMs: stale, lastUpdatedAtMs: stale }],
+			workspaces: [
+				{
+					folder: "file:///Users/flyer/work/proj-a",
+					pointers: null,
+				},
+			],
+		});
+
+		const sessions = await discoverCursorSessions("/Users/flyer/work/proj-a");
+		expect(sessions).toEqual([]);
+	});
+
+	it("skips composerData rows with malformed JSON without crashing", async () => {
+		// Set up a normal workspace + global DB with one good and one bad composer row
+		const userDir = join(tmpHome, "Library/Application Support/Cursor/User");
+		await mkdir(join(userDir, "globalStorage"), { recursive: true });
+		await mkdir(join(userDir, "workspaceStorage", "ws-00000000"), { recursive: true });
+		await writeFile(
+			join(userDir, "workspaceStorage", "ws-00000000", "workspace.json"),
+			JSON.stringify({ folder: "file:///Users/flyer/work/proj-a" }),
+		);
+
+		// Workspace DB with anchor pointing to good-1
+		const wsDbPath = join(userDir, "workspaceStorage", "ws-00000000", "state.vscdb");
+		const wsDb = new DatabaseSync(wsDbPath);
+		for (const sql of CURSOR_DDL) wsDb.prepare(sql).run();
+		wsDb.prepare("INSERT INTO ItemTable (key, value) VALUES (?, ?)").run(
+			"composer.composerData",
+			JSON.stringify({ lastFocusedComposerIds: ["good-1"] }),
+		);
+		wsDb.close();
+
+		// Global DB with one good composer + one row of garbage JSON
+		const globalDbPath = join(userDir, "globalStorage", "state.vscdb");
+		const globalDb = new DatabaseSync(globalDbPath);
+		for (const sql of CURSOR_DDL) globalDb.prepare(sql).run();
+		globalDb
+			.prepare("INSERT INTO cursorDiskKV (key, value) VALUES (?, ?)")
+			.run("composerData:good-1", JSON.stringify({ composerId: "good-1", lastUpdatedAt: Date.now() }));
+		globalDb
+			.prepare("INSERT INTO cursorDiskKV (key, value) VALUES (?, ?)")
+			.run("composerData:bad-2", "this is not json");
+		globalDb.close();
+
+		const sessions = await discoverCursorSessions("/Users/flyer/work/proj-a");
+		expect(sessions.map((s) => s.sessionId)).toEqual(["good-1"]);
+	});
+
+	it("skips composerData rows with missing or non-string composerId", async () => {
+		const userDir = join(tmpHome, "Library/Application Support/Cursor/User");
+		await mkdir(join(userDir, "globalStorage"), { recursive: true });
+		await mkdir(join(userDir, "workspaceStorage", "ws-00000000"), { recursive: true });
+		await writeFile(
+			join(userDir, "workspaceStorage", "ws-00000000", "workspace.json"),
+			JSON.stringify({ folder: "file:///Users/flyer/work/proj-a" }),
+		);
+
+		const wsDbPath = join(userDir, "workspaceStorage", "ws-00000000", "state.vscdb");
+		const wsDb = new DatabaseSync(wsDbPath);
+		for (const sql of CURSOR_DDL) wsDb.prepare(sql).run();
+		wsDb.close();
+
+		const globalDbPath = join(userDir, "globalStorage", "state.vscdb");
+		const globalDb = new DatabaseSync(globalDbPath);
+		for (const sql of CURSOR_DDL) globalDb.prepare(sql).run();
+		// Row with no composerId field
+		globalDb
+			.prepare("INSERT INTO cursorDiskKV (key, value) VALUES (?, ?)")
+			.run("composerData:c-1", JSON.stringify({ lastUpdatedAt: Date.now() }));
+		// Row with non-string composerId
+		globalDb
+			.prepare("INSERT INTO cursorDiskKV (key, value) VALUES (?, ?)")
+			.run("composerData:c-2", JSON.stringify({ composerId: 12345, lastUpdatedAt: Date.now() }));
+		globalDb.close();
+
+		const sessions = await discoverCursorSessions("/Users/flyer/work/proj-a");
+		expect(sessions).toEqual([]);
+	});
+
+	it("skips composerData rows with non-finite lastUpdatedAt (anchor and non-anchor)", async () => {
+		const userDir = join(tmpHome, "Library/Application Support/Cursor/User");
+		await mkdir(join(userDir, "globalStorage"), { recursive: true });
+		await mkdir(join(userDir, "workspaceStorage", "ws-00000000"), { recursive: true });
+		await writeFile(
+			join(userDir, "workspaceStorage", "ws-00000000", "workspace.json"),
+			JSON.stringify({ folder: "file:///Users/flyer/work/proj-a" }),
+		);
+
+		const wsDbPath = join(userDir, "workspaceStorage", "ws-00000000", "state.vscdb");
+		const wsDb = new DatabaseSync(wsDbPath);
+		for (const sql of CURSOR_DDL) wsDb.prepare(sql).run();
+		wsDb.prepare("INSERT INTO ItemTable (key, value) VALUES (?, ?)").run(
+			"composer.composerData",
+			JSON.stringify({ lastFocusedComposerIds: ["anchor-bad"] }),
+		);
+		wsDb.close();
+
+		const globalDbPath = join(userDir, "globalStorage", "state.vscdb");
+		const globalDb = new DatabaseSync(globalDbPath);
+		for (const sql of CURSOR_DDL) globalDb.prepare(sql).run();
+		// Anchor composer with null lastUpdatedAt
+		globalDb
+			.prepare("INSERT INTO cursorDiskKV (key, value) VALUES (?, ?)")
+			.run("composerData:anchor-bad", JSON.stringify({ composerId: "anchor-bad", lastUpdatedAt: null }));
+		// Non-anchor composer with null lastUpdatedAt
+		globalDb
+			.prepare("INSERT INTO cursorDiskKV (key, value) VALUES (?, ?)")
+			.run("composerData:other-bad", JSON.stringify({ composerId: "other-bad", lastUpdatedAt: null }));
+		globalDb.close();
+
+		const sessions = await discoverCursorSessions("/Users/flyer/work/proj-a");
+		expect(sessions).toEqual([]);
+	});
+
+	it("skips workspaces whose folder URI is not file://", async () => {
+		const userDir = join(tmpHome, "Library/Application Support/Cursor/User");
+		await mkdir(join(userDir, "globalStorage"), { recursive: true });
+		createCursorGlobalDb(join(userDir, "globalStorage", "state.vscdb"), [
+			{ composerId: "c-1", createdAtMs: Date.now(), lastUpdatedAtMs: Date.now() },
+		]);
+
+		// Workspace with a remote URI (vscode-remote://...) — should not match a local path
+		const wsDir = join(userDir, "workspaceStorage", "ws-00000000");
+		await mkdir(wsDir, { recursive: true });
+		await writeFile(
+			join(wsDir, "workspace.json"),
+			JSON.stringify({ folder: "vscode-remote://ssh-remote+host/Users/flyer/work/proj-a" }),
+		);
+		createCursorWorkspaceDb(join(wsDir, "state.vscdb"), { lastFocusedComposerIds: ["c-1"] });
+
+		const sessions = await discoverCursorSessions("/Users/flyer/work/proj-a");
+		expect(sessions).toEqual([]);
+	});
+
+	it("returns empty when workspace composer.composerData has malformed JSON", async () => {
+		const userDir = join(tmpHome, "Library/Application Support/Cursor/User");
+		await mkdir(join(userDir, "globalStorage"), { recursive: true });
+		createCursorGlobalDb(join(userDir, "globalStorage", "state.vscdb"), [
+			{ composerId: "c-1", createdAtMs: Date.now(), lastUpdatedAtMs: Date.now() - 100 * 60 * 60 * 1000 }, // outside window
+		]);
+
+		const wsDir = join(userDir, "workspaceStorage", "ws-00000000");
+		await mkdir(wsDir, { recursive: true });
+		await writeFile(join(wsDir, "workspace.json"), JSON.stringify({ folder: "file:///Users/flyer/work/proj-a" }));
+
+		// Workspace DB has the composer.composerData key but with garbage JSON
+		const wsDb = new DatabaseSync(join(wsDir, "state.vscdb"));
+		for (const sql of CURSOR_DDL) wsDb.prepare(sql).run();
+		wsDb.prepare("INSERT INTO ItemTable (key, value) VALUES (?, ?)").run(
+			"composer.composerData",
+			"{not valid json",
+		);
+		wsDb.close();
+
+		// No anchors should be extracted; the stale composer is outside the time window;
+		// overall result is empty without the read crashing.
+		const sessions = await discoverCursorSessions("/Users/flyer/work/proj-a");
+		expect(sessions).toEqual([]);
+	});
+
+	it("uses selectedComposerIds as anchor when lastFocusedComposerIds is absent", async () => {
+		const ancientTs = Date.now() - 365 * 24 * 60 * 60 * 1000;
+		await setupCursorHome(tmpHome, {
+			globalComposers: [{ composerId: "selected-1", createdAtMs: ancientTs, lastUpdatedAtMs: ancientTs }],
+			workspaces: [
+				{
+					folder: "file:///Users/flyer/work/proj-a",
+					pointers: null, // creates the DB with tables but no composer.composerData row
+				},
+			],
+		});
+
+		// Insert composer.composerData with only selectedComposerIds (no lastFocusedComposerIds key)
+		// into the already-created workspace DB.
+		const wsDbPath = join(
+			tmpHome,
+			"Library/Application Support/Cursor/User",
+			"workspaceStorage",
+			"ws-00000000",
+			"state.vscdb",
+		);
+		const wsDb = new DatabaseSync(wsDbPath);
+		wsDb.prepare("INSERT INTO ItemTable (key, value) VALUES (?, ?)").run(
+			"composer.composerData",
+			JSON.stringify({ selectedComposerIds: ["selected-1"] }),
+		);
+		wsDb.close();
+
+		const sessions = await discoverCursorSessions("/Users/flyer/work/proj-a");
+		expect(sessions).toHaveLength(1);
+		expect(sessions[0].sessionId).toBe("selected-1");
+	});
+
+	it("skips workspaces whose folder URI cannot be parsed by fileURLToPath", async () => {
+		// fileURLToPath throws ERR_INVALID_FILE_URL_HOST when a `file://` URI
+		// has a non-empty host on POSIX. The bad workspace must be skipped
+		// without aborting the scan; the good workspace right after must still
+		// match and resolve its anchor composer.
+		const userDir = join(tmpHome, "Library/Application Support/Cursor/User");
+		await mkdir(join(userDir, "globalStorage"), { recursive: true });
+		createCursorGlobalDb(join(userDir, "globalStorage", "state.vscdb"), [
+			{ composerId: "c-1", createdAtMs: Date.now(), lastUpdatedAtMs: Date.now() },
+		]);
+
+		// Bad workspace: `file://hostname/path` — fileURLToPath rejects this on POSIX.
+		const badWsDir = join(userDir, "workspaceStorage", "ws-00000000");
+		await mkdir(badWsDir, { recursive: true });
+		await writeFile(
+			join(badWsDir, "workspace.json"),
+			JSON.stringify({ folder: "file://nonempty.host/Users/flyer/work/proj-a" }),
+		);
+		createCursorWorkspaceDb(join(badWsDir, "state.vscdb"), null);
+
+		// Good workspace right after — confirms the loop continued past the bad one.
+		const goodWsDir = join(userDir, "workspaceStorage", "ws-00000001");
+		await mkdir(goodWsDir, { recursive: true });
+		await writeFile(
+			join(goodWsDir, "workspace.json"),
+			JSON.stringify({ folder: "file:///Users/flyer/work/proj-a" }),
+		);
+		createCursorWorkspaceDb(join(goodWsDir, "state.vscdb"), { lastFocusedComposerIds: ["c-1"] });
+
+		const sessions = await discoverCursorSessions("/Users/flyer/work/proj-a");
+		expect(sessions).toHaveLength(1);
+		expect(sessions[0].sessionId).toBe("c-1");
+	});
+
+	it("returns time-window-only sessions when workspace state.vscdb is missing", async () => {
+		// Workspace folder matches but its state.vscdb file does not exist —
+		// readCursorAnchorComposerIds must swallow the stat() ENOENT and return [].
+		// The scan should still surface fresh composers from the global DB.
+		const fresh = Date.now() - 60 * 1000;
+		const userDir = join(tmpHome, "Library/Application Support/Cursor/User");
+		await mkdir(join(userDir, "globalStorage"), { recursive: true });
+		createCursorGlobalDb(join(userDir, "globalStorage", "state.vscdb"), [
+			{ composerId: "fresh-1", createdAtMs: fresh, lastUpdatedAtMs: fresh },
+		]);
+
+		const wsDir = join(userDir, "workspaceStorage", "ws-00000000");
+		await mkdir(wsDir, { recursive: true });
+		await writeFile(join(wsDir, "workspace.json"), JSON.stringify({ folder: "file:///Users/flyer/work/proj-a" }));
+		// Intentionally do NOT create wsDir/state.vscdb
+
+		const sessions = await discoverCursorSessions("/Users/flyer/work/proj-a");
+		expect(sessions.map((s) => s.sessionId)).toEqual(["fresh-1"]);
+	});
+
+	it("returns [] when the global state.vscdb file is missing (ENOENT)", async () => {
+		// workspaceStorage exists and matches projectDir, but globalStorage/state.vscdb
+		// is absent — this is a "Cursor not yet booted" / fresh-install scenario.
+		// scanCursorSessions must short-circuit silently with no error surface.
+		const userDir = join(tmpHome, "Library/Application Support/Cursor/User");
+		await mkdir(join(userDir, "globalStorage"), { recursive: true });
+		// Intentionally do NOT create globalStorage/state.vscdb
+
+		const wsDir = join(userDir, "workspaceStorage", "ws-00000000");
+		await mkdir(wsDir, { recursive: true });
+		await writeFile(join(wsDir, "workspace.json"), JSON.stringify({ folder: "file:///Users/flyer/work/proj-a" }));
+
+		const result = await scanCursorSessions("/Users/flyer/work/proj-a");
+		expect(result).toEqual({ sessions: [] });
+	});
+
+	it("skips workspace.json files that are unreadable or not valid JSON", async () => {
+		// readFile throws (file missing) for ws-0; JSON.parse throws for ws-1.
+		// Both cases fall through to the generic catch and `continue` — the loop
+		// must keep going and find the good workspace at ws-2.
+		const userDir = join(tmpHome, "Library/Application Support/Cursor/User");
+		await mkdir(join(userDir, "globalStorage"), { recursive: true });
+		createCursorGlobalDb(join(userDir, "globalStorage", "state.vscdb"), [
+			{ composerId: "c-1", createdAtMs: Date.now(), lastUpdatedAtMs: Date.now() },
+		]);
+
+		// ws-0: directory exists but workspace.json does not
+		await mkdir(join(userDir, "workspaceStorage", "ws-00000000"), { recursive: true });
+
+		// ws-1: workspace.json exists but is not valid JSON
+		const ws1 = join(userDir, "workspaceStorage", "ws-00000001");
+		await mkdir(ws1, { recursive: true });
+		await writeFile(join(ws1, "workspace.json"), "{ this is not json");
+
+		// ws-2: good
+		const ws2 = join(userDir, "workspaceStorage", "ws-00000002");
+		await mkdir(ws2, { recursive: true });
+		await writeFile(join(ws2, "workspace.json"), JSON.stringify({ folder: "file:///Users/flyer/work/proj-a" }));
+		createCursorWorkspaceDb(join(ws2, "state.vscdb"), { lastFocusedComposerIds: ["c-1"] });
+
+		const sessions = await discoverCursorSessions("/Users/flyer/work/proj-a");
+		expect(sessions.map((s) => s.sessionId)).toEqual(["c-1"]);
+	});
+
+	it("skips workspace.json whose `folder` field is not a string", async () => {
+		// Schema-drift / corruption guard: if `folder` is missing or a non-string
+		// value, folderUri stays undefined and the workspace is skipped at
+		// `!folderUri` rather than reaching fileURLToPath.
+		const userDir = join(tmpHome, "Library/Application Support/Cursor/User");
+		await mkdir(join(userDir, "globalStorage"), { recursive: true });
+		createCursorGlobalDb(join(userDir, "globalStorage", "state.vscdb"), [
+			{ composerId: "c-1", createdAtMs: Date.now(), lastUpdatedAtMs: Date.now() },
+		]);
+
+		const wsDir = join(userDir, "workspaceStorage", "ws-00000000");
+		await mkdir(wsDir, { recursive: true });
+		// folder is a number, not a string
+		await writeFile(join(wsDir, "workspace.json"), JSON.stringify({ folder: 12345 }));
+
+		const sessions = await discoverCursorSessions("/Users/flyer/work/proj-a");
+		expect(sessions).toEqual([]);
+	});
+
+	it("walks past non-matching workspaces before finding the matching one", async () => {
+		// Multiple workspaces, only the second one matches the target. This
+		// exercises the "folderPath !== target" falsy branch at the equality check
+		// — without it, the first workspace's truthy match would short-circuit.
+		const userDir = join(tmpHome, "Library/Application Support/Cursor/User");
+		await mkdir(join(userDir, "globalStorage"), { recursive: true });
+		createCursorGlobalDb(join(userDir, "globalStorage", "state.vscdb"), [
+			{ composerId: "c-1", createdAtMs: Date.now(), lastUpdatedAtMs: Date.now() },
+		]);
+
+		// Non-matching workspace
+		const ws0 = join(userDir, "workspaceStorage", "ws-00000000");
+		await mkdir(ws0, { recursive: true });
+		await writeFile(join(ws0, "workspace.json"), JSON.stringify({ folder: "file:///Users/flyer/work/other-proj" }));
+		createCursorWorkspaceDb(join(ws0, "state.vscdb"), null);
+
+		// Matching workspace
+		const ws1 = join(userDir, "workspaceStorage", "ws-00000001");
+		await mkdir(ws1, { recursive: true });
+		await writeFile(join(ws1, "workspace.json"), JSON.stringify({ folder: "file:///Users/flyer/work/proj-a" }));
+		createCursorWorkspaceDb(join(ws1, "state.vscdb"), { lastFocusedComposerIds: ["c-1"] });
+
+		const sessions = await discoverCursorSessions("/Users/flyer/work/proj-a");
+		expect(sessions.map((s) => s.sessionId)).toEqual(["c-1"]);
+	});
+
+	it("dedupes composers that appear under multiple keys with the same composerId", async () => {
+		// Defensive dedupe path: two distinct rows in cursorDiskKV where the
+		// embedded composerId collides. The second occurrence must be filtered
+		// out via the seenIds Set rather than producing a duplicate session.
+		const fresh = Date.now() - 60 * 1000;
+		const userDir = join(tmpHome, "Library/Application Support/Cursor/User");
+		await mkdir(join(userDir, "globalStorage"), { recursive: true });
+
+		const globalDbPath = join(userDir, "globalStorage", "state.vscdb");
+		const globalDb = new DatabaseSync(globalDbPath);
+		for (const sql of CURSOR_DDL) globalDb.prepare(sql).run();
+		// Two distinct keys, but both point at composerId="dup-1".
+		globalDb
+			.prepare("INSERT INTO cursorDiskKV (key, value) VALUES (?, ?)")
+			.run("composerData:dup-1", JSON.stringify({ composerId: "dup-1", lastUpdatedAt: fresh }));
+		globalDb
+			.prepare("INSERT INTO cursorDiskKV (key, value) VALUES (?, ?)")
+			.run("composerData:dup-1-alt", JSON.stringify({ composerId: "dup-1", lastUpdatedAt: fresh }));
+		globalDb.close();
+
+		const wsDir = join(userDir, "workspaceStorage", "ws-00000000");
+		await mkdir(wsDir, { recursive: true });
+		await writeFile(join(wsDir, "workspace.json"), JSON.stringify({ folder: "file:///Users/flyer/work/proj-a" }));
+		createCursorWorkspaceDb(join(wsDir, "state.vscdb"), null);
+
+		const sessions = await discoverCursorSessions("/Users/flyer/work/proj-a");
+		expect(sessions.map((s) => s.sessionId)).toEqual(["dup-1"]);
+	});
+
+	it("normalizes paths case-insensitively on win32", async () => {
+		// Covers the win32 leg of the `darwin || win32` short-circuit in
+		// normalizePathForMatch. Cursor on Windows reads from %APPDATA%/Cursor;
+		// we point APPDATA at tmpHome so the fixture is discoverable.
+		// Folder URI uses POSIX form because fileURLToPath runs on the real
+		// host (darwin) and would reject a Windows drive-letter URL — the
+		// platform mock only steers our own normalization path.
+		const prevAppData = process.env.APPDATA;
+		process.env.APPDATA = join(tmpHome, "Roaming");
+		try {
+			mockPlatform.mockReturnValue("win32");
+			const userDir = join(process.env.APPDATA, "Cursor", "User");
+			await mkdir(join(userDir, "globalStorage"), { recursive: true });
+			createCursorGlobalDb(join(userDir, "globalStorage", "state.vscdb"), [
+				{ composerId: "c-1", createdAtMs: Date.now(), lastUpdatedAtMs: Date.now() },
+			]);
+			const wsDir = join(userDir, "workspaceStorage", "ws-00000000");
+			await mkdir(wsDir, { recursive: true });
+			await writeFile(
+				join(wsDir, "workspace.json"),
+				JSON.stringify({ folder: "file:///Users/Flyer/Code%20Folder/Proj" }),
+			);
+			createCursorWorkspaceDb(join(wsDir, "state.vscdb"), { lastFocusedComposerIds: ["c-1"] });
+
+			// Lowercased target should match the original-cased stored path
+			// because the win32 normalize branch lowercases both sides.
+			const sessions = await discoverCursorSessions("/users/flyer/code folder/proj");
+			expect(sessions).toHaveLength(1);
+		} finally {
+			if (prevAppData === undefined) delete process.env.APPDATA;
+			else process.env.APPDATA = prevAppData;
+		}
+	});
+
+	it("preserves casing on linux (case-sensitive filesystem)", async () => {
+		// On linux, normalizePathForMatch does NOT lowercase — a casing mismatch
+		// must NOT resolve to a workspace match. Linux reads from ~/.config/Cursor.
+		mockPlatform.mockReturnValue("linux");
+		const userDir = join(tmpHome, ".config", "Cursor", "User");
+		await mkdir(join(userDir, "globalStorage"), { recursive: true });
+		createCursorGlobalDb(join(userDir, "globalStorage", "state.vscdb"), [
+			{ composerId: "c-1", createdAtMs: Date.now(), lastUpdatedAtMs: Date.now() },
+		]);
+		const wsDir = join(userDir, "workspaceStorage", "ws-00000000");
+		await mkdir(wsDir, { recursive: true });
+		await writeFile(join(wsDir, "workspace.json"), JSON.stringify({ folder: "file:///home/flyer/Work/Proj" }));
+		createCursorWorkspaceDb(join(wsDir, "state.vscdb"), { lastFocusedComposerIds: ["c-1"] });
+
+		// Lowercased target must NOT match the original-cased stored path on linux.
+		const sessions = await discoverCursorSessions("/home/flyer/work/proj");
+		expect(sessions).toEqual([]);
+
+		// Same-case target DOES match — confirms the linux branch was reached
+		// rather than the lookup short-circuiting on a missing workspace dir.
+		const sessions2 = await discoverCursorSessions("/home/flyer/Work/Proj");
+		expect(sessions2).toHaveLength(1);
+	});
+
+	it("surfaces a corrupt-DB error via scanCursorSessions", async () => {
+		const userDir = join(tmpHome, "Library/Application Support/Cursor/User");
+		await mkdir(join(userDir, "globalStorage"), { recursive: true });
+		await writeFile(join(userDir, "globalStorage", "state.vscdb"), "this is not a sqlite file");
+
+		const wsDir = join(userDir, "workspaceStorage", "ws-00000000");
+		await mkdir(wsDir, { recursive: true });
+		await writeFile(join(wsDir, "workspace.json"), JSON.stringify({ folder: "file:///Users/flyer/work/proj-a" }));
+		await writeFile(join(wsDir, "state.vscdb"), "garbage too");
+
+		const result = await scanCursorSessions("/Users/flyer/work/proj-a");
+		expect(result.sessions).toEqual([]);
+		expect(result.error).toBeDefined();
+		expect(["corrupt", "permission", "unknown"]).toContain(result.error?.kind);
+	});
+});

--- a/cli/src/core/CursorSessionDiscoverer.ts
+++ b/cli/src/core/CursorSessionDiscoverer.ts
@@ -1,0 +1,316 @@
+/**
+ * Cursor Session Discoverer
+ *
+ * On-demand scanner for Cursor Composer sessions. Cursor stores all Composer
+ * transcripts in a *global* SQLite at:
+ *   ~/Library/Application Support/Cursor/User/globalStorage/state.vscdb  (macOS)
+ *   ~/.config/Cursor/User/globalStorage/state.vscdb                      (Linux)
+ *   %APPDATA%/Cursor/User/globalStorage/state.vscdb                      (Windows)
+ *
+ * Rows in the `cursorDiskKV` table are JSON BLOBs keyed by:
+ *   composerData:<composerId>        — full composer metadata + bubble headers
+ *   bubbleId:<composerId>:<bubbleId> — individual message blobs (not read here)
+ *
+ * There is NO authoritative "this composer belongs to this workspace" pointer in
+ * the global DB. Per-workspace `state.vscdb` files (under
+ * User/workspaceStorage/<wsHash>/) DO contain a `composer.composerData` row in
+ * their `ItemTable` with `lastFocusedComposerIds` and `selectedComposerIds`.
+ *
+ * β′ Attribution Algorithm (4 steps):
+ *   1. Workspace lookup — scan each <wsHash>/workspace.json for a `folder` URI
+ *      that resolves to projectDir. Stop at the first match; return its <wsHash>.
+ *   2. Anchor extraction — read <wsHash>/state.vscdb and union the two pointer
+ *      arrays into an anchor set. These composers are always included, even if
+ *      their lastUpdatedAt is older than the 48 h window.
+ *   3. Time-window scan — open the global cursorDiskKV and include every
+ *      composerData row whose `lastUpdatedAt` is within the last 48 h.
+ *   4. Union + dedupe — merge anchors and window composers; each composer ID
+ *      appears at most once in the result.
+ *
+ * Synthetic transcript path:
+ *   "<globalDbPath>#<composerId>"
+ *   Matches OpenCode's pattern (<dbPath>#<sessionId>) so downstream cursor-keying
+ *   and transcript-reading code works uniformly across SQLite-backed sources.
+ */
+
+import { readdir, readFile, stat } from "node:fs/promises";
+import { platform } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { createLogger } from "../Logger.js";
+import type { SessionInfo } from "../Types.js";
+import { getCursorGlobalDbPath, getCursorWorkspaceStorageDir } from "./CursorDetector.js";
+import { classifyScanError, type SqliteScanError, withSqliteDb } from "./SqliteHelpers.js";
+
+const log = createLogger("CursorDiscoverer");
+
+/** Sessions older than 48 hours are considered stale (matches other sources) */
+const SESSION_STALE_MS = 48 * 60 * 60 * 1000;
+
+export interface CursorScanResult {
+	readonly sessions: ReadonlyArray<SessionInfo>;
+	/**
+	 * Present only when the scan hit a genuine failure (not ENOENT). Callers
+	 * should surface this to the UI rather than silently reporting "0 sessions".
+	 */
+	readonly error?: SqliteScanError;
+}
+
+/**
+ * Discovers Cursor Composer sessions relevant to the given project directory.
+ *
+ * Uses the β′ algorithm: workspace pointer IDs (always included) union with
+ * composers updated within the last 48 h (time window), deduped.
+ *
+ * @param projectDir - The git repository root to filter sessions by
+ * @returns { sessions, error? } — sessions is always an array; if `error` is
+ *   present, callers should surface it to the user rather than silently reporting
+ *   "0 sessions" (which is indistinguishable from a genuinely-empty scan).
+ */
+export async function scanCursorSessions(projectDir: string): Promise<CursorScanResult> {
+	const globalDbPath = getCursorGlobalDbPath();
+
+	// Step 1: Workspace lookup — find which workspace hash corresponds to projectDir.
+	const wsHash = await findCursorWorkspaceHash(projectDir);
+	if (wsHash === null) {
+		log.debug("No Cursor workspace found matching %s", projectDir);
+		return { sessions: [] };
+	}
+
+	// Pre-flight: distinguish "global DB missing" (silent) from "DB unreadable" (genuine failure)
+	// before calling DatabaseSync, which surfaces both as the same error message.
+	try {
+		await stat(globalDbPath);
+	} catch (error: unknown) {
+		const code = (error as NodeJS.ErrnoException).code;
+		/* v8 ignore start -- ENOENT branch tested by "does not match" test; the else-branch (EACCES, EPERM, EIO, …) is a rare TOCTOU path requiring a filesystem-level mock. The classifier logic itself is fully covered by classifyScanError's unit tests. */
+		if (code !== "ENOENT") {
+			const scanError = classifyScanError(error);
+			if (scanError) {
+				log.error("Cursor global DB stat failed (%s): %s", scanError.kind, scanError.message);
+				return { sessions: [], error: scanError };
+			}
+			return { sessions: [] };
+		}
+		/* v8 ignore stop */
+		log.debug("Cursor global DB not present at %s — treating as not installed", globalDbPath);
+		return { sessions: [] };
+	}
+
+	// Step 2: Anchor extraction — read the per-workspace composer pointer IDs.
+	const anchorIds = await readCursorAnchorComposerIds(wsHash);
+	const anchorSet = new Set(anchorIds);
+
+	// Step 3: Time-window scan — compute cutoff and open the global DB.
+	const cutoffMs = Date.now() - SESSION_STALE_MS;
+
+	try {
+		const out: SessionInfo[] = [];
+		const seenIds = new Set<string>();
+
+		await withSqliteDb(globalDbPath, (db) => {
+			const rows = db
+				.prepare("SELECT key, value FROM cursorDiskKV WHERE key LIKE 'composerData:%'")
+				.all() as ReadonlyArray<{ key: string; value: string }>;
+
+			for (const row of rows) {
+				let parsed: Record<string, unknown>;
+				try {
+					parsed = JSON.parse(row.value) as Record<string, unknown>;
+				} catch {
+					log.warn("Skipping Cursor composer row %s: invalid JSON", row.key);
+					continue;
+				}
+
+				const composerId = typeof parsed.composerId === "string" ? parsed.composerId : null;
+				if (composerId === null) {
+					log.warn("Skipping Cursor composer row %s: missing composerId", row.key);
+					continue;
+				}
+
+				const lastUpdatedAt = parsed.lastUpdatedAt;
+
+				// Guard against schema drift: non-numeric timestamps.
+				if (typeof lastUpdatedAt !== "number" || !Number.isFinite(lastUpdatedAt)) {
+					// Only warn if this composer is an anchor — otherwise silently skip.
+					if (anchorSet.has(composerId)) {
+						log.warn("Skipping Cursor composer %s: non-finite lastUpdatedAt", composerId);
+					}
+					continue;
+				}
+
+				const inAnchor = anchorSet.has(composerId);
+				const inWindow = lastUpdatedAt >= cutoffMs;
+
+				// Step 4: Union — include if in anchor set OR within time window.
+				if (!inAnchor && !inWindow) {
+					continue;
+				}
+
+				// Dedupe: each composerId appears at most once.
+				if (seenIds.has(composerId)) {
+					continue;
+				}
+				seenIds.add(composerId);
+
+				out.push({
+					sessionId: composerId,
+					// Synthetic path: global DB path + composer discriminator (matches OpenCode pattern)
+					transcriptPath: `${globalDbPath}#${composerId}`,
+					updatedAt: new Date(lastUpdatedAt).toISOString(),
+					source: "cursor",
+				});
+			}
+		});
+
+		log.info("Discovered %d Cursor session(s) for %s", out.length, projectDir);
+		return { sessions: out };
+	} catch (error: unknown) {
+		const scanError = classifyScanError(error);
+		/* v8 ignore start -- TOCTOU race: the DB passed stat() but vanished or became unreadable before DatabaseSync opened it. Requires a filesystem-level mock; classifier behavior is covered by classifyScanError unit tests. */
+		if (scanError === null) {
+			log.debug("Cursor global DB disappeared between detection and scan: %s", (error as Error).message);
+			return { sessions: [] };
+		}
+		/* v8 ignore stop */
+		log.error("Cursor scan failed (%s): %s", scanError.kind, scanError.message);
+		return { sessions: [], error: scanError };
+	}
+}
+
+/**
+ * Backwards-compatible wrapper around `scanCursorSessions` that only returns
+ * the session array. Callers that need to surface scan failures to the user
+ * should call `scanCursorSessions` directly.
+ */
+export async function discoverCursorSessions(projectDir: string): Promise<ReadonlyArray<SessionInfo>> {
+	const { sessions } = await scanCursorSessions(projectDir);
+	return sessions;
+}
+
+/**
+ * Scans the Cursor workspaceStorage directory for a workspace whose `folder`
+ * URI resolves to projectDir. Returns the workspace hash (directory name) on
+ * match, or null if no match is found.
+ *
+ * workspace.json contains a `folder` property that is a `file://` URI. We
+ * decode it with fileURLToPath so percent-encoding and platform casing are
+ * handled correctly.
+ */
+async function findCursorWorkspaceHash(projectDir: string): Promise<string | null> {
+	const wsStorageDir = getCursorWorkspaceStorageDir();
+
+	let entries: string[];
+	try {
+		entries = await readdir(wsStorageDir);
+	} catch {
+		log.debug("Cursor workspaceStorage not readable at %s", wsStorageDir);
+		return null;
+	}
+
+	const target = normalizePathForMatch(projectDir);
+
+	for (const entry of entries) {
+		const wsJsonPath = join(wsStorageDir, entry, "workspace.json");
+		let folderUri: string | undefined;
+		try {
+			const raw = await readFile(wsJsonPath, "utf8");
+			const parsed = JSON.parse(raw) as Record<string, unknown>;
+			folderUri = typeof parsed.folder === "string" ? parsed.folder : undefined;
+		} catch {
+			// Skip entries without a readable workspace.json
+			continue;
+		}
+
+		if (!folderUri || !folderUri.startsWith("file://")) {
+			continue;
+		}
+
+		let folderPath: string;
+		try {
+			folderPath = fileURLToPath(folderUri);
+		} catch {
+			log.warn("Cursor workspace %s has unparseable folder URI: %s", entry, folderUri);
+			continue;
+		}
+
+		if (normalizePathForMatch(folderPath) === target) {
+			return entry;
+		}
+	}
+
+	return null;
+}
+
+/**
+ * Reads the per-workspace state.vscdb for a given workspace hash and extracts
+ * the anchor composer IDs from the `composer.composerData` row.
+ *
+ * Returns an empty array (never throws) — a workspace-level failure does NOT
+ * abort the whole scan; we still proceed with time-window-only results.
+ */
+async function readCursorAnchorComposerIds(wsHash: string): Promise<ReadonlyArray<string>> {
+	const wsStorageDir = getCursorWorkspaceStorageDir();
+	const wsDbPath = join(wsStorageDir, wsHash, "state.vscdb");
+
+	try {
+		await stat(wsDbPath);
+	} catch {
+		log.debug("Cursor workspace DB not found at %s — skipping anchor extraction", wsDbPath);
+		return [];
+	}
+
+	try {
+		return await withSqliteDb(wsDbPath, (db) => {
+			const row = db.prepare("SELECT value FROM ItemTable WHERE key = 'composer.composerData' LIMIT 1").get() as
+				| { value: string }
+				| undefined;
+
+			if (!row) {
+				return [];
+			}
+
+			let parsed: Record<string, unknown>;
+			try {
+				parsed = JSON.parse(row.value) as Record<string, unknown>;
+			} catch {
+				log.warn("Cursor workspace %s composer.composerData is not valid JSON", wsHash);
+				return [];
+			}
+
+			const lastFocused = Array.isArray(parsed.lastFocusedComposerIds)
+				? (parsed.lastFocusedComposerIds as unknown[]).filter((id): id is string => typeof id === "string")
+				: [];
+			const selected = Array.isArray(parsed.selectedComposerIds)
+				? (parsed.selectedComposerIds as unknown[]).filter((id): id is string => typeof id === "string")
+				: [];
+
+			// Union of the two pointer arrays, deduped
+			const union = new Set([...lastFocused, ...selected]);
+			return Array.from(union);
+		});
+	} catch (error: unknown) {
+		log.warn("Failed to read Cursor workspace anchor IDs from %s: %s", wsDbPath, (error as Error).message);
+		return [];
+	}
+}
+
+/**
+ * Normalises a filesystem path for workspace matching.
+ * - Strips trailing slashes.
+ * - Lowercases on case-insensitive platforms (darwin, win32) so that Cursor's
+ *   stored path and the projectDir passed by callers compare correctly even
+ *   when their casing differs.
+ */
+function normalizePathForMatch(p: string): string {
+	// Linear-time trailing-slash strip. Equivalent to /\/+$/ but expressed as a
+	// loop so CodeQL's js/polynomial-redos heuristic doesn't flag the regex
+	// when this function receives paths read from on-disk JSON.
+	let end = p.length;
+	while (end > 0 && p[end - 1] === "/") {
+		end--;
+	}
+	const trimmed = p.slice(0, end);
+	const os = platform();
+	return os === "darwin" || os === "win32" ? trimmed.toLowerCase() : trimmed;
+}

--- a/cli/src/core/CursorTranscriptReader.test.ts
+++ b/cli/src/core/CursorTranscriptReader.test.ts
@@ -1,0 +1,345 @@
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.spyOn(console, "log").mockImplementation(() => {});
+vi.spyOn(console, "warn").mockImplementation(() => {});
+
+import { readCursorTranscript } from "./CursorTranscriptReader.js";
+
+const CURSOR_DDL = [
+	`CREATE TABLE ItemTable (key TEXT UNIQUE ON CONFLICT REPLACE, value BLOB)`,
+	`CREATE TABLE cursorDiskKV (key TEXT UNIQUE ON CONFLICT REPLACE, value BLOB)`,
+];
+
+interface BubbleFixture {
+	bubbleId: string;
+	type: 1 | 2;
+	text: string;
+	createdAt: string;
+}
+
+function createCursorTranscriptDb(dbPath: string, composerId: string, bubbles: ReadonlyArray<BubbleFixture>): void {
+	const db = new DatabaseSync(dbPath);
+	for (const sql of CURSOR_DDL) db.prepare(sql).run();
+
+	const composerData = JSON.stringify({
+		_v: 16,
+		composerId,
+		name: "Test composer",
+		createdAt: Date.now(),
+		lastUpdatedAt: Date.now(),
+		fullConversationHeadersOnly: bubbles.map((b) => ({ bubbleId: b.bubbleId, type: b.type, grouping: null })),
+		status: "completed",
+		unifiedMode: "agent",
+	});
+	db.prepare("INSERT INTO cursorDiskKV (key, value) VALUES (?, ?)").run(`composerData:${composerId}`, composerData);
+
+	for (const b of bubbles) {
+		const bubbleData = JSON.stringify({
+			_v: 3,
+			bubbleId: b.bubbleId,
+			type: b.type,
+			text: b.text,
+			createdAt: b.createdAt,
+		});
+		db.prepare("INSERT INTO cursorDiskKV (key, value) VALUES (?, ?)").run(
+			`bubbleId:${composerId}:${b.bubbleId}`,
+			bubbleData,
+		);
+	}
+	db.close();
+}
+
+describe("readCursorTranscript", () => {
+	let tmpDir: string;
+	let dbPath: string;
+	const composerId = "11111111-2222-3333-4444-555555555555";
+
+	beforeEach(async () => {
+		tmpDir = await mkdtemp(join(tmpdir(), "cursor-tr-"));
+		await mkdir(tmpDir, { recursive: true });
+		dbPath = join(tmpDir, "state.vscdb");
+	});
+
+	afterEach(async () => {
+		await rm(tmpDir, { recursive: true, force: true });
+	});
+
+	it("rejects malformed synthetic paths", async () => {
+		await expect(readCursorTranscript("/no/hash/in/path")).rejects.toThrow(/missing #composerId/);
+		await expect(readCursorTranscript("#only-id")).rejects.toThrow(/empty/);
+		await expect(readCursorTranscript("/path#")).rejects.toThrow(/empty/);
+	});
+
+	it("returns ordered user/assistant entries with type→role mapping", async () => {
+		createCursorTranscriptDb(dbPath, composerId, [
+			{ bubbleId: "b1", type: 1, text: "what is 2 + 2?", createdAt: "2026-05-03T10:00:00.000Z" },
+			{ bubbleId: "b2", type: 2, text: "2 + 2 = 4.", createdAt: "2026-05-03T10:00:01.000Z" },
+			{ bubbleId: "b3", type: 1, text: "thanks", createdAt: "2026-05-03T10:00:02.000Z" },
+		]);
+
+		const result = await readCursorTranscript(`${dbPath}#${composerId}`);
+
+		expect(result.entries).toEqual([
+			{ role: "human", content: "what is 2 + 2?", timestamp: "2026-05-03T10:00:00.000Z" },
+			{ role: "assistant", content: "2 + 2 = 4.", timestamp: "2026-05-03T10:00:01.000Z" },
+			{ role: "human", content: "thanks", timestamp: "2026-05-03T10:00:02.000Z" },
+		]);
+		expect(result.newCursor.lineNumber).toBe(3);
+		expect(result.totalLinesRead).toBe(3);
+	});
+
+	it("merges consecutive same-role entries", async () => {
+		createCursorTranscriptDb(dbPath, composerId, [
+			{ bubbleId: "b1", type: 2, text: "Looking at the file...", createdAt: "2026-05-03T10:00:00.000Z" },
+			{ bubbleId: "b2", type: 2, text: "I see the issue.", createdAt: "2026-05-03T10:00:01.000Z" },
+			{ bubbleId: "b3", type: 1, text: "what is it?", createdAt: "2026-05-03T10:00:02.000Z" },
+		]);
+
+		const result = await readCursorTranscript(`${dbPath}#${composerId}`);
+		expect(result.entries).toHaveLength(2);
+		expect(result.entries[0].role).toBe("assistant");
+		expect(result.entries[0].content).toBe("Looking at the file...\n\nI see the issue.");
+		expect(result.entries[1].role).toBe("human");
+	});
+
+	it("skips bubbles with empty text", async () => {
+		createCursorTranscriptDb(dbPath, composerId, [
+			{ bubbleId: "b1", type: 1, text: "hi", createdAt: "2026-05-03T10:00:00.000Z" },
+			{ bubbleId: "b2", type: 2, text: "", createdAt: "2026-05-03T10:00:01.000Z" },
+			{ bubbleId: "b3", type: 1, text: "ping", createdAt: "2026-05-03T10:00:02.000Z" },
+		]);
+
+		const result = await readCursorTranscript(`${dbPath}#${composerId}`);
+		expect(result.entries.map((e) => e.role)).toEqual(["human"]);
+	});
+
+	it("skips bubbles whose type does not map to a role", async () => {
+		createCursorTranscriptDb(dbPath, composerId, [
+			{ bubbleId: "b1", type: 1, text: "hi", createdAt: "2026-05-03T10:00:00.000Z" },
+			{ bubbleId: "b2", type: 99 as unknown as 1, text: "system noise", createdAt: "2026-05-03T10:00:01.000Z" },
+		]);
+		const result = await readCursorTranscript(`${dbPath}#${composerId}`);
+		expect(result.entries).toHaveLength(1);
+		expect(result.entries[0].role).toBe("human");
+	});
+
+	it("skips already-read bubbles when given a cursor", async () => {
+		createCursorTranscriptDb(dbPath, composerId, [
+			{ bubbleId: "b1", type: 1, text: "first", createdAt: "2026-05-03T10:00:00.000Z" },
+			{ bubbleId: "b2", type: 2, text: "second", createdAt: "2026-05-03T10:00:01.000Z" },
+			{ bubbleId: "b3", type: 1, text: "third", createdAt: "2026-05-03T10:00:02.000Z" },
+		]);
+
+		const result = await readCursorTranscript(`${dbPath}#${composerId}`, {
+			transcriptPath: `${dbPath}#${composerId}`,
+			lineNumber: 2,
+			updatedAt: "2026-05-03T10:00:01.000Z",
+		});
+		expect(result.entries).toEqual([{ role: "human", content: "third", timestamp: "2026-05-03T10:00:02.000Z" }]);
+		expect(result.newCursor.lineNumber).toBe(3);
+	});
+
+	it("respects beforeTimestamp cutoff and advances cursor only to last consumed", async () => {
+		createCursorTranscriptDb(dbPath, composerId, [
+			{ bubbleId: "b1", type: 1, text: "first", createdAt: "2026-05-03T10:00:00.000Z" },
+			{ bubbleId: "b2", type: 2, text: "second", createdAt: "2026-05-03T10:00:01.000Z" },
+			{ bubbleId: "b3", type: 1, text: "after-cutoff", createdAt: "2026-05-03T10:00:05.000Z" },
+		]);
+
+		const result = await readCursorTranscript(`${dbPath}#${composerId}`, null, "2026-05-03T10:00:01.500Z");
+		expect(result.entries.map((e) => e.content)).toEqual(["first", "second"]);
+		expect(result.newCursor.lineNumber).toBe(2);
+	});
+
+	it("falls back to header.type and empty text when bubble row omits those fields", async () => {
+		// Cursor bubble rows can omit `type` and `text` — the reader must fall
+		// back to the header's type and treat missing/empty text as a skip.
+		// This exercises the `bubble.type ?? header.type` and `(bubble.text ?? "").trim()`
+		// nullish branches that fully-populated fixtures don't reach.
+		const db = new DatabaseSync(dbPath);
+		for (const sql of CURSOR_DDL) db.prepare(sql).run();
+		const composerData = JSON.stringify({
+			composerId,
+			fullConversationHeadersOnly: [
+				{ bubbleId: "b1", type: 1, grouping: null }, // header carries the type
+				{ bubbleId: "b2", type: 1, grouping: null }, // header carries the type
+			],
+		});
+		db.prepare("INSERT INTO cursorDiskKV (key, value) VALUES (?, ?)").run(
+			`composerData:${composerId}`,
+			composerData,
+		);
+		// b1 has no `type` field → falls back to header.type=1; no `text` field → "" → skipped
+		db.prepare("INSERT INTO cursorDiskKV (key, value) VALUES (?, ?)").run(
+			`bubbleId:${composerId}:b1`,
+			JSON.stringify({ bubbleId: "b1", createdAt: "2026-05-03T10:00:00.000Z" }),
+		);
+		// b2 has no `type` field but has text → falls back to header.type=1, role=human
+		db.prepare("INSERT INTO cursorDiskKV (key, value) VALUES (?, ?)").run(
+			`bubbleId:${composerId}:b2`,
+			JSON.stringify({ bubbleId: "b2", text: "fallback works", createdAt: "2026-05-03T10:00:01.000Z" }),
+		);
+		db.close();
+
+		const result = await readCursorTranscript(`${dbPath}#${composerId}`);
+		expect(result.entries).toEqual([
+			{ role: "human", content: "fallback works", timestamp: "2026-05-03T10:00:01.000Z" },
+		]);
+	});
+
+	it("treats composerData with no fullConversationHeadersOnly field as empty", async () => {
+		// Schema-drift guard: if Cursor renames or drops fullConversationHeadersOnly,
+		// the reader must coerce to [] rather than crash. Covers the `?? []` branch.
+		const db = new DatabaseSync(dbPath);
+		for (const sql of CURSOR_DDL) db.prepare(sql).run();
+		db.prepare("INSERT INTO cursorDiskKV (key, value) VALUES (?, ?)").run(
+			`composerData:${composerId}`,
+			JSON.stringify({ composerId }), // no fullConversationHeadersOnly
+		);
+		db.close();
+
+		const result = await readCursorTranscript(`${dbPath}#${composerId}`);
+		expect(result.entries).toEqual([]);
+		expect(result.newCursor.lineNumber).toBe(0);
+	});
+
+	it("skips bubbles whose type cannot be inferred (header.type also missing)", async () => {
+		// Both bubble.type and header.type missing — type stays undefined, so
+		// the role lookup short-circuits to undefined and the bubble is skipped.
+		// Covers the `type !== undefined ? ... : undefined` falsy branch.
+		const db = new DatabaseSync(dbPath);
+		for (const sql of CURSOR_DDL) db.prepare(sql).run();
+		db.prepare("INSERT INTO cursorDiskKV (key, value) VALUES (?, ?)").run(
+			`composerData:${composerId}`,
+			JSON.stringify({
+				composerId,
+				fullConversationHeadersOnly: [{ bubbleId: "b1", grouping: null }], // no type
+			}),
+		);
+		db.prepare("INSERT INTO cursorDiskKV (key, value) VALUES (?, ?)").run(
+			`bubbleId:${composerId}:b1`,
+			JSON.stringify({ bubbleId: "b1", text: "untyped", createdAt: "2026-05-03T10:00:00.000Z" }),
+			// no type field on the bubble either
+		);
+		db.close();
+
+		const result = await readCursorTranscript(`${dbPath}#${composerId}`);
+		expect(result.entries).toEqual([]);
+	});
+
+	it("throws a friendly error when the composer is not in the DB", async () => {
+		createCursorTranscriptDb(dbPath, composerId, []);
+		await expect(readCursorTranscript(`${dbPath}#missing-id`)).rejects.toThrow(/Cannot read Cursor session/);
+	});
+
+	it("throws a friendly error when composerData row exists but is not valid JSON", async () => {
+		const db = new DatabaseSync(dbPath);
+		for (const sql of CURSOR_DDL) db.prepare(sql).run();
+		// Row present (so the "not found" branch is skipped) but value is garbage —
+		// JSON.parse throws, and the inner catch at L92-93 rewrites to a typed error
+		// which the outer catch then surfaces as the user-facing "Cannot read..." message.
+		db.prepare("INSERT INTO cursorDiskKV (key, value) VALUES (?, ?)").run(
+			`composerData:${composerId}`,
+			"{not valid json",
+		);
+		db.close();
+
+		await expect(readCursorTranscript(`${dbPath}#${composerId}`)).rejects.toThrow(/Cannot read Cursor session/);
+	});
+
+	it("skips bubbles whose row is missing from the DB without crashing", async () => {
+		// Build the composer header listing 3 bubbles, but only insert 2 of them
+		const db = new DatabaseSync(dbPath);
+		for (const sql of CURSOR_DDL) db.prepare(sql).run();
+		const composerData = JSON.stringify({
+			_v: 16,
+			composerId,
+			name: "Test composer",
+			createdAt: Date.now(),
+			lastUpdatedAt: Date.now(),
+			fullConversationHeadersOnly: [
+				{ bubbleId: "b1", type: 1, grouping: null },
+				{ bubbleId: "b2-missing", type: 2, grouping: null },
+				{ bubbleId: "b3", type: 1, grouping: null },
+			],
+			status: "completed",
+			unifiedMode: "agent",
+		});
+		db.prepare("INSERT INTO cursorDiskKV (key, value) VALUES (?, ?)").run(
+			`composerData:${composerId}`,
+			composerData,
+		);
+		// Insert b1 and b3 but NOT b2-missing
+		for (const b of [
+			{ bubbleId: "b1", type: 1, text: "first", createdAt: "2026-05-03T10:00:00.000Z" },
+			{ bubbleId: "b3", type: 1, text: "third", createdAt: "2026-05-03T10:00:02.000Z" },
+		]) {
+			db.prepare("INSERT INTO cursorDiskKV (key, value) VALUES (?, ?)").run(
+				`bubbleId:${composerId}:${b.bubbleId}`,
+				JSON.stringify({
+					_v: 3,
+					bubbleId: b.bubbleId,
+					type: b.type,
+					text: b.text,
+					createdAt: b.createdAt,
+				}),
+			);
+		}
+		db.close();
+
+		const result = await readCursorTranscript(`${dbPath}#${composerId}`);
+		// The two consecutive "human" entries get merged into one (b2 missing was skipped);
+		// cursor advances past all 3 header positions.
+		expect(result.entries).toEqual([
+			{ role: "human", content: "first\n\nthird", timestamp: "2026-05-03T10:00:00.000Z" },
+		]);
+		expect(result.newCursor.lineNumber).toBe(3);
+	});
+
+	it("skips bubbles whose row JSON is malformed", async () => {
+		const db = new DatabaseSync(dbPath);
+		for (const sql of CURSOR_DDL) db.prepare(sql).run();
+		const composerData = JSON.stringify({
+			_v: 16,
+			composerId,
+			name: "Test composer",
+			createdAt: Date.now(),
+			lastUpdatedAt: Date.now(),
+			fullConversationHeadersOnly: [
+				{ bubbleId: "b1", type: 1, grouping: null },
+				{ bubbleId: "b2-bad", type: 2, grouping: null },
+				{ bubbleId: "b3", type: 1, grouping: null },
+			],
+			status: "completed",
+			unifiedMode: "agent",
+		});
+		db.prepare("INSERT INTO cursorDiskKV (key, value) VALUES (?, ?)").run(
+			`composerData:${composerId}`,
+			composerData,
+		);
+		db.prepare("INSERT INTO cursorDiskKV (key, value) VALUES (?, ?)").run(
+			`bubbleId:${composerId}:b1`,
+			JSON.stringify({ _v: 3, bubbleId: "b1", type: 1, text: "first", createdAt: "2026-05-03T10:00:00.000Z" }),
+		);
+		// b2-bad row has unparseable JSON
+		db.prepare("INSERT INTO cursorDiskKV (key, value) VALUES (?, ?)").run(
+			`bubbleId:${composerId}:b2-bad`,
+			"{not valid json",
+		);
+		db.prepare("INSERT INTO cursorDiskKV (key, value) VALUES (?, ?)").run(
+			`bubbleId:${composerId}:b3`,
+			JSON.stringify({ _v: 3, bubbleId: "b3", type: 1, text: "third", createdAt: "2026-05-03T10:00:02.000Z" }),
+		);
+		db.close();
+
+		const result = await readCursorTranscript(`${dbPath}#${composerId}`);
+		expect(result.entries).toEqual([
+			{ role: "human", content: "first\n\nthird", timestamp: "2026-05-03T10:00:00.000Z" },
+		]);
+		expect(result.newCursor.lineNumber).toBe(3);
+	});
+});

--- a/cli/src/core/CursorTranscriptReader.ts
+++ b/cli/src/core/CursorTranscriptReader.ts
@@ -1,0 +1,192 @@
+/**
+ * Cursor Transcript Reader
+ *
+ * Reads Composer conversation messages from Cursor's global SQLite database
+ * (state.vscdb) and returns transcript entries.
+ *
+ * Storage layout:
+ *   - Table: `cursorDiskKV` with `key TEXT` and `value BLOB` columns.
+ *   - `composerData:<composerId>` — JSON containing `fullConversationHeadersOnly`,
+ *     an ordered list of `{ bubbleId, type }` objects representing the conversation
+ *     message index.
+ *   - `bubbleId:<composerId>:<bubbleId>` — JSON with the full bubble data:
+ *     `{ type, text, createdAt, ... }`.
+ *
+ * Bubble type → role mapping (empirically confirmed on real Cursor installs):
+ *   1 → "human"   (user messages)
+ *   2 → "assistant" (Cursor AI responses)
+ *   other → skipped (system messages, tool calls, etc.)
+ *
+ * Cursor reuses `TranscriptCursor.lineNumber` to track bubble index, matching
+ * the pattern used by OpenCodeTranscriptReader and GeminiTranscriptReader.
+ */
+
+import { createLogger } from "../Logger.js";
+import type { TranscriptCursor, TranscriptEntry, TranscriptReadResult } from "../Types.js";
+import { withSqliteDb } from "./SqliteHelpers.js";
+import { mergeConsecutiveEntries } from "./TranscriptReader.js";
+
+const log = createLogger("CursorTranscriptReader");
+
+/**
+ * Maps Cursor bubble.type numeric values to transcript roles.
+ * Centralized constant — update here when Cursor adds new bubble types.
+ *
+ *   1 → "human"     (user messages in the Composer chat)
+ *   2 → "assistant" (AI-generated responses)
+ */
+const BUBBLE_TYPE_TO_ROLE: Readonly<Record<number, "human" | "assistant">> = {
+	1: "human",
+	2: "assistant",
+};
+
+interface ConversationHeader {
+	readonly bubbleId: string;
+	readonly type?: number;
+}
+
+interface ComposerDataRow {
+	readonly fullConversationHeadersOnly?: ReadonlyArray<ConversationHeader>;
+}
+
+interface BubbleRow {
+	readonly type?: number;
+	readonly text?: string;
+	readonly createdAt?: string;
+}
+
+/**
+ * Reads messages from a Cursor Composer session and returns parsed transcript entries.
+ * Supports cursor-based resumption by tracking the count of bubbles already processed.
+ *
+ * @param transcriptPath - Synthetic path: "<dbPath>#<composerId>"
+ * @param cursor - Optional cursor indicating how many bubbles were already processed
+ * @param beforeTimestamp - Optional ISO 8601 cutoff: only return entries with timestamp ≤ this value.
+ *   Used by the queue-driven Worker to attribute transcript entries to the correct commit.
+ *   When provided, the cursor advances only to the last consumed bubble (not EOF).
+ * @returns Parsed entries and a new cursor for the next read
+ */
+export async function readCursorTranscript(
+	transcriptPath: string,
+	cursor?: TranscriptCursor | null,
+	beforeTimestamp?: string,
+): Promise<TranscriptReadResult> {
+	const { dbPath, composerId } = parseSyntheticPath(transcriptPath);
+	const startIndex = cursor?.lineNumber ?? 0;
+	const cutoffTime = beforeTimestamp ? Date.parse(beforeTimestamp) : undefined;
+
+	try {
+		const { rawEntries, totalBubbles, lastConsumedIndex } = await withSqliteDb(dbPath, (db) => {
+			// Load the composer index — fullConversationHeadersOnly is an ordered list of bubbles
+			const composerRow = db
+				.prepare("SELECT value FROM cursorDiskKV WHERE key = ? LIMIT 1")
+				.get(`composerData:${composerId}`) as { value: string } | undefined;
+
+			if (!composerRow) {
+				throw new Error(`Composer ${composerId} not found in database`);
+			}
+
+			let composer: ComposerDataRow;
+			try {
+				composer = JSON.parse(composerRow.value) as ComposerDataRow;
+			} catch {
+				throw new Error(`Failed to parse composerData JSON for ${composerId}`);
+			}
+
+			const headers: ReadonlyArray<ConversationHeader> = composer.fullConversationHeadersOnly ?? [];
+
+			// Skip already-processed bubbles (cursor-based incremental read)
+			const newHeaders = headers.slice(startIndex);
+			const rawEntries: TranscriptEntry[] = [];
+			let lastConsumedIndex = startIndex;
+
+			for (let i = 0; i < newHeaders.length; i++) {
+				const header = newHeaders[i];
+
+				// Load the full bubble data for this header
+				const bubbleRow = db
+					.prepare("SELECT value FROM cursorDiskKV WHERE key = ? LIMIT 1")
+					.get(`bubbleId:${composerId}:${header.bubbleId}`) as { value: string } | undefined;
+
+				if (!bubbleRow) {
+					// Bubble missing from DB — advance index but produce no entry
+					lastConsumedIndex = startIndex + i + 1;
+					continue;
+				}
+
+				let bubble: BubbleRow;
+				try {
+					bubble = JSON.parse(bubbleRow.value) as BubbleRow;
+				} catch {
+					log.debug("Failed to parse bubble JSON for %s:%s", composerId, header.bubbleId);
+					lastConsumedIndex = startIndex + i + 1;
+					continue;
+				}
+
+				const timestamp = bubble.createdAt;
+
+				// If a time cutoff is specified, stop consuming when we hit bubbles after it
+				if (cutoffTime !== undefined && timestamp !== undefined) {
+					const bubbleTime = Date.parse(timestamp);
+					if (Number.isFinite(bubbleTime) && bubbleTime > cutoffTime) {
+						break;
+					}
+				}
+
+				const type = bubble.type ?? header.type;
+				const role = type !== undefined ? BUBBLE_TYPE_TO_ROLE[type] : undefined;
+				const text = (bubble.text ?? "").trim();
+
+				if (role !== undefined && text.length > 0) {
+					rawEntries.push({ role, content: text, timestamp });
+				}
+
+				lastConsumedIndex = startIndex + i + 1;
+			}
+
+			return { rawEntries, totalBubbles: headers.length, lastConsumedIndex };
+		});
+
+		const entries = mergeConsecutiveEntries(rawEntries);
+
+		// When beforeTimestamp is set, advance cursor only to the last consumed bubble.
+		// Without beforeTimestamp (legacy/CLI path), advance to end for backward compatibility.
+		const newCursor: TranscriptCursor = {
+			transcriptPath,
+			lineNumber: beforeTimestamp ? lastConsumedIndex : totalBubbles,
+			updatedAt: new Date().toISOString(),
+		};
+
+		const totalLinesRead = lastConsumedIndex - startIndex;
+		log.info(
+			"Read Cursor session %s: %d new bubbles, %d entries extracted (index %d→%d)",
+			composerId.substring(0, 8),
+			totalLinesRead,
+			entries.length,
+			startIndex,
+			newCursor.lineNumber,
+		);
+
+		return { entries, newCursor, totalLinesRead };
+	} catch (error: unknown) {
+		log.error("Failed to read Cursor session %s: %s", composerId.substring(0, 8), (error as Error).message);
+		throw new Error(`Cannot read Cursor session: ${composerId}`);
+	}
+}
+
+/**
+ * Parses a synthetic transcript path into its DB path and composer ID components.
+ * Format: "<dbPath>#<composerId>"
+ */
+function parseSyntheticPath(transcriptPath: string): { dbPath: string; composerId: string } {
+	const hashIndex = transcriptPath.lastIndexOf("#");
+	if (hashIndex === -1) {
+		throw new Error(`Invalid Cursor transcript path (missing #composerId): ${transcriptPath}`);
+	}
+	const dbPath = transcriptPath.substring(0, hashIndex);
+	const composerId = transcriptPath.substring(hashIndex + 1);
+	if (dbPath.length === 0 || composerId.length === 0) {
+		throw new Error(`Invalid Cursor transcript path (empty dbPath or composerId): ${transcriptPath}`);
+	}
+	return { dbPath, composerId };
+}

--- a/cli/src/core/OpenCodeSessionDiscoverer.test.ts
+++ b/cli/src/core/OpenCodeSessionDiscoverer.test.ts
@@ -10,21 +10,19 @@ vi.spyOn(console, "warn").mockImplementation(() => {});
 vi.spyOn(console, "error").mockImplementation(() => {});
 
 // Mock homedir so tests don't depend on real home directory
-const { mockHomedir } = vi.hoisted(() => ({
+const { mockHomedir, mockPlatform } = vi.hoisted(() => ({
 	mockHomedir: vi.fn().mockReturnValue(""),
+	mockPlatform: vi.fn().mockReturnValue("darwin"),
 }));
 vi.mock("node:os", async (importOriginal) => {
 	const original = await importOriginal<typeof import("node:os")>();
-	return { ...original, homedir: mockHomedir };
+	return { ...original, homedir: mockHomedir, platform: mockPlatform };
 });
 
 import {
-	classifyScanError,
 	discoverOpenCodeSessions,
 	getOpenCodeDbPath,
-	hasNodeSqliteSupport,
 	isOpenCodeInstalled,
-	NODE_SQLITE_MIN_VERSION,
 	scanOpenCodeSessions,
 } from "./OpenCodeSessionDiscoverer.js";
 
@@ -193,37 +191,6 @@ describe("OpenCodeSessionDiscoverer", () => {
 		});
 	});
 
-	describe("hasNodeSqliteSupport", () => {
-		const { major, minor } = NODE_SQLITE_MIN_VERSION;
-
-		it("returns true on exactly the minimum version", () => {
-			expect(hasNodeSqliteSupport(`${major}.${minor}.0`)).toBe(true);
-		});
-
-		it("returns true on a later major", () => {
-			expect(hasNodeSqliteSupport(`${major + 1}.0.0`)).toBe(true);
-		});
-
-		it("returns true on a later minor within the same major", () => {
-			expect(hasNodeSqliteSupport(`${major}.${minor + 1}.0`)).toBe(true);
-		});
-
-		it("returns false on an earlier minor within the same major", () => {
-			// minor=0 covers the "earlier minor" branch even when NODE_SQLITE_MIN_VERSION.minor is 0
-			// (the comparison is `>=`, so 22.0.0 < 22.5.0 returns false).
-			expect(hasNodeSqliteSupport(`${major}.0.0`)).toBe(false);
-		});
-
-		it("returns false on an earlier major", () => {
-			expect(hasNodeSqliteSupport(`${major - 1}.99.0`)).toBe(false);
-		});
-
-		it("treats prerelease tags correctly (major.minor extracted from prefix)", () => {
-			expect(hasNodeSqliteSupport("22.5.0-nightly20260101")).toBe(true);
-			expect(hasNodeSqliteSupport("20.15.0-nightly20260101")).toBe(false);
-		});
-	});
-
 	describe("discoverOpenCodeSessions", () => {
 		it("discovers recent top-level sessions for the given project", async () => {
 			const now = Date.now();
@@ -323,30 +290,47 @@ describe("OpenCodeSessionDiscoverer", () => {
 			expect(sessions[0].updatedAt).toBe(new Date(now).toISOString());
 		});
 
-		it("matches directory case-insensitively on Windows and macOS (drive-letter / path-casing drift)", async () => {
-			// Reproduces the real Windows bug observed in debug.log:
-			//   worker pipeline spawned with cwd "E:\\jollimemory-3" → stored by OpenCode
-			//   extension status reported projectDir "e:\\jollimemory-3" → exact-match missed
-			// Both describe the same directory on a case-insensitive filesystem, so the
-			// SQL must match regardless of drive-letter casing on Windows / macOS.
-			// Linux filesystems are case-sensitive, so exact-match is the correct behaviour
-			// there and this test asserts the lookup returns empty.
+		it.each(["darwin", "win32"] as const)(
+			"matches directory case-insensitively on %s (drive-letter / path-casing drift)",
+			async (osName) => {
+				// Reproduces the real Windows bug observed in debug.log:
+				//   worker pipeline spawned with cwd "E:\\jollimemory-3" → stored by OpenCode
+				//   extension status reported projectDir "e:\\jollimemory-3" → exact-match missed
+				// Both describe the same directory on a case-insensitive filesystem, so the
+				// SQL must match regardless of drive-letter casing on Windows / macOS.
+				// Linux's case-sensitive behaviour is asserted by the next test.
+				mockPlatform.mockReturnValue(osName);
+				const now = Date.now();
+				const dbDir = join(fakeHome, ".local", "share", "opencode");
+				const storedDir = "E:\\jollimemory-3";
+				const queryDir = "e:\\jollimemory-3";
+				await createOpenCodeDb(dbDir, [
+					{ id: "drive-letter", directory: storedDir, time_created: now - 1000, time_updated: now },
+				]);
+
+				const sessions = await discoverOpenCodeSessions(queryDir);
+
+				expect(sessions.map((s) => s.sessionId)).toEqual(["drive-letter"]);
+			},
+		);
+
+		it("matches directory exactly (case-sensitive) on linux", async () => {
+			// Linux filesystems are case-sensitive, so a casing mismatch must NOT
+			// resolve to the same session. This exercises the `directory = :projectDir`
+			// branch of the case-insensitive ternary that darwin/win32 hosts skip.
+			mockPlatform.mockReturnValue("linux");
 			const now = Date.now();
 			const dbDir = join(fakeHome, ".local", "share", "opencode");
-			const storedDir = "E:\\jollimemory-3";
-			const queryDir = "e:\\jollimemory-3";
+			const storedDir = "/home/flyer/Project";
 			await createOpenCodeDb(dbDir, [
-				{ id: "drive-letter", directory: storedDir, time_created: now - 1000, time_updated: now },
+				{ id: "exact-1", directory: storedDir, time_created: now - 1000, time_updated: now },
 			]);
 
-			const sessions = await discoverOpenCodeSessions(queryDir);
-
-			const caseInsensitive = process.platform === "win32" || process.platform === "darwin";
-			if (caseInsensitive) {
-				expect(sessions.map((s) => s.sessionId)).toEqual(["drive-letter"]);
-			} else {
-				expect(sessions).toHaveLength(0);
-			}
+			// Lowercased query MUST NOT match the original-cased stored directory.
+			expect(await discoverOpenCodeSessions("/home/flyer/project")).toHaveLength(0);
+			// Same-cased query DOES match — confirms the linux branch was reached.
+			const sessions = await discoverOpenCodeSessions("/home/flyer/Project");
+			expect(sessions.map((s) => s.sessionId)).toEqual(["exact-1"]);
 		});
 
 		it("skips sessions whose time_updated is not a finite number (schema drift)", async () => {
@@ -413,57 +397,6 @@ describe("OpenCodeSessionDiscoverer", () => {
 			// The compat wrapper must not throw, even though the scan hit a real error.
 			const sessions = await discoverOpenCodeSessions(projectDir);
 			expect(sessions).toEqual([]);
-		});
-	});
-
-	describe("classifyScanError", () => {
-		function err(message: string, code?: string): Error & { code?: string } {
-			const e = new Error(message) as Error & { code?: string };
-			if (code !== undefined) e.code = code;
-			return e;
-		}
-
-		it("returns null for ENOENT (silent 'not installed')", () => {
-			expect(classifyScanError(err("…", "ENOENT"))).toBeNull();
-		});
-
-		it("classifies EACCES and EPERM as permission", () => {
-			expect(classifyScanError(err("denied", "EACCES"))?.kind).toBe("permission");
-			expect(classifyScanError(err("denied", "EPERM"))?.kind).toBe("permission");
-		});
-
-		it("classifies SQLITE_CANTOPEN / 'unable to open' as permission", () => {
-			expect(classifyScanError(err("SQLITE_CANTOPEN: file failed to open"))?.kind).toBe("permission");
-			expect(classifyScanError(err("unable to open database file"))?.kind).toBe("permission");
-		});
-
-		it("classifies SQLITE_CORRUPT and similar as corrupt", () => {
-			expect(classifyScanError(err("SQLITE_CORRUPT: database disk image is malformed"))?.kind).toBe("corrupt");
-			expect(classifyScanError(err("file is not a database"))?.kind).toBe("corrupt");
-			expect(classifyScanError(err("SQLITE_NOTADB"))?.kind).toBe("corrupt");
-		});
-
-		it("classifies SQLITE_BUSY / SQLITE_LOCKED as locked", () => {
-			expect(classifyScanError(err("SQLITE_BUSY: database is locked"))?.kind).toBe("locked");
-			expect(classifyScanError(err("database is locked"))?.kind).toBe("locked");
-			expect(classifyScanError(err("SQLITE_LOCKED"))?.kind).toBe("locked");
-		});
-
-		it("classifies 'no such table'/'no such column' as schema drift", () => {
-			expect(classifyScanError(err("no such table: session"))?.kind).toBe("schema");
-			expect(classifyScanError(err("no such column: time_updated"))?.kind).toBe("schema");
-		});
-
-		it("falls back to 'unknown' for unrecognized errors", () => {
-			const classified = classifyScanError(err("totally unexpected disk failure"));
-			expect(classified?.kind).toBe("unknown");
-			expect(classified?.message).toBe("totally unexpected disk failure");
-		});
-
-		it("handles non-Error throws by stringifying", () => {
-			const classified = classifyScanError("raw string rejection");
-			expect(classified?.kind).toBe("unknown");
-			expect(classified?.message).toBe("raw string rejection");
 		});
 	});
 });

--- a/cli/src/core/OpenCodeSessionDiscoverer.ts
+++ b/cli/src/core/OpenCodeSessionDiscoverer.ts
@@ -16,10 +16,19 @@
  */
 
 import { stat } from "node:fs/promises";
-import { homedir } from "node:os";
+import { homedir, platform } from "node:os";
 import { join } from "node:path";
 import { createLogger } from "../Logger.js";
 import type { SessionInfo } from "../Types.js";
+import {
+	classifyScanError as classifySqliteError,
+	hasNodeSqliteSupport,
+	NODE_SQLITE_MIN_VERSION,
+	type SqliteDbHandle,
+	type SqliteScanError,
+	type SqliteScanErrorKind,
+	withSqliteDb,
+} from "./SqliteHelpers.js";
 
 const log = createLogger("OpenCodeDiscoverer");
 
@@ -34,40 +43,16 @@ function getXdgDataHome(): string {
 	return process.env.XDG_DATA_HOME || join(homedir(), ".local", "share");
 }
 
-/**
- * Database handle shape passed to `withOpenCodeDb` callbacks.
- *
- * Structurally typed against node:sqlite's DatabaseSync rather than importing
- * the type directly, so the module is not loaded until the helper runs — this
- * keeps the ExperimentalWarning out of every PostCommitHook invocation that
- * only transitively imports this file.
- */
-export interface OpenCodeDbHandle {
-	prepare(sql: string): {
-		all(params?: Record<string, unknown> | unknown, ...rest: unknown[]): unknown[];
-		get(params?: Record<string, unknown> | unknown, ...rest: unknown[]): unknown;
-		run(params?: Record<string, unknown> | unknown, ...rest: unknown[]): unknown;
-	};
-	close(): void;
-}
-
-/**
- * Opens the OpenCode SQLite database read-only, runs a callback, then closes it.
- *
- * Uses Node's built-in `node:sqlite` (statically-linked SQLite; full WAL support).
- * The module is imported dynamically so the ExperimentalWarning only appears
- * when this helper is actually invoked — not when PostCommitHook merely
- * transitively imports this file.
- */
-export async function withOpenCodeDb<T>(dbPath: string, fn: (db: OpenCodeDbHandle) => T): Promise<T> {
-	const { DatabaseSync } = await import("node:sqlite");
-	const db = new DatabaseSync(dbPath, { readOnly: true });
-	try {
-		return fn(db as unknown as OpenCodeDbHandle);
-	} finally {
-		db.close();
-	}
-}
+/** @deprecated use SqliteDbHandle from SqliteHelpers.js */
+export type OpenCodeDbHandle = SqliteDbHandle;
+/** @deprecated use withSqliteDb from SqliteHelpers.js */
+export const withOpenCodeDb = withSqliteDb;
+export { NODE_SQLITE_MIN_VERSION, hasNodeSqliteSupport };
+/** @deprecated use SqliteScanErrorKind */
+export type OpenCodeScanErrorKind = SqliteScanErrorKind;
+/** @deprecated use SqliteScanError */
+export type OpenCodeScanError = SqliteScanError;
+export const classifyScanError = classifySqliteError;
 
 /**
  * Returns the path to the global OpenCode database file.
@@ -75,32 +60,6 @@ export async function withOpenCodeDb<T>(dbPath: string, fn: (db: OpenCodeDbHandl
  */
 export function getOpenCodeDbPath(): string {
 	return join(getXdgDataHome(), "opencode", "opencode.db");
-}
-
-/**
- * Minimum Node version that ships `node:sqlite`. OpenCode support requires this
- * built-in module; older runtimes cannot load it even if the DB file is present.
- *
- * Exported for unit tests; callers should use `isOpenCodeInstalled()`.
- */
-export const NODE_SQLITE_MIN_VERSION = { major: 22, minor: 5 } as const;
-
-/**
- * Returns true when the current runtime can load `node:sqlite`. Compares the
- * major.minor of `process.versions.node` against NODE_SQLITE_MIN_VERSION
- * rather than doing a live probe, which would emit the ExperimentalWarning on
- * matching runtimes and defeat the lazy-import pattern used by `withOpenCodeDb`.
- */
-export function hasNodeSqliteSupport(nodeVersion: string = process.versions.node): boolean {
-	const match = /^(\d+)\.(\d+)/.exec(nodeVersion);
-	/* v8 ignore start -- process.versions.node is always well-formed semver in supported runtimes; guard is purely defensive */
-	if (!match) return false;
-	/* v8 ignore stop */
-	const major = Number.parseInt(match[1], 10);
-	const minor = Number.parseInt(match[2], 10);
-	if (major > NODE_SQLITE_MIN_VERSION.major) return true;
-	if (major < NODE_SQLITE_MIN_VERSION.major) return false;
-	return minor >= NODE_SQLITE_MIN_VERSION.minor;
 }
 
 /**
@@ -131,29 +90,6 @@ export async function isOpenCodeInstalled(): Promise<boolean> {
 	}
 }
 
-/**
- * Classifies a real OpenCode scan failure into a user-facing severity. Only
- * *genuine* failures are represented here — ENOENT is excluded because an
- * OpenCode DB that's absent between `isOpenCodeInstalled()` and our read
- * is indistinguishable from "not installed" and should stay silent.
- *
- * - `corrupt` — SQLite reports SQLITE_CORRUPT / SQLITE_NOTADB. The file exists
- *   but is unreadable. Users should know.
- * - `locked` — another process holds an exclusive lock (SQLITE_BUSY). Transient,
- *   but worth surfacing if it persists.
- * - `permission` — EACCES / EPERM / SQLITE_CANTOPEN opening the DB. Users
- *   should know.
- * - `schema` — the expected table or column is missing. Likely OpenCode version
- *   drift; users should know so we can support the new schema.
- * - `unknown` — anything else. Surface as a generic "OpenCode scan failed" warning.
- */
-export type OpenCodeScanErrorKind = "corrupt" | "locked" | "permission" | "schema" | "unknown";
-
-export interface OpenCodeScanError {
-	readonly kind: OpenCodeScanErrorKind;
-	readonly message: string;
-}
-
 export interface OpenCodeScanResult {
 	readonly sessions: ReadonlyArray<SessionInfo>;
 	/**
@@ -161,33 +97,6 @@ export interface OpenCodeScanResult {
 	 * should surface this to the UI rather than silently reporting "0 sessions".
 	 */
 	readonly error?: OpenCodeScanError;
-}
-
-/**
- * Returns null if the error is ENOENT (treat as "not installed" — silent).
- * Exported for unit testing; callers should use `scanOpenCodeSessions`.
- */
-export function classifyScanError(error: unknown): OpenCodeScanError | null {
-	const err = error as (Error & { code?: string }) | undefined;
-	const message = err?.message ?? String(error);
-	const code = err?.code;
-	if (code === "ENOENT") return null;
-	if (code === "EACCES" || code === "EPERM") return { kind: "permission", message };
-	// node:sqlite surfaces low-level SQLite error codes in the message
-	// (e.g. "SQLITE_CORRUPT: database disk image is malformed").
-	if (/SQLITE_CORRUPT|SQLITE_NOTADB|file is not a database/i.test(message)) {
-		return { kind: "corrupt", message };
-	}
-	if (/SQLITE_BUSY|SQLITE_LOCKED|database is locked/i.test(message)) {
-		return { kind: "locked", message };
-	}
-	if (/no such table|no such column/i.test(message)) {
-		return { kind: "schema", message };
-	}
-	if (/SQLITE_CANTOPEN|unable to open/i.test(message)) {
-		return { kind: "permission", message };
-	}
-	return { kind: "unknown", message };
 }
 
 /**
@@ -227,7 +136,7 @@ export async function scanOpenCodeSessions(projectDir: string): Promise<OpenCode
 	}
 
 	try {
-		const sessions = await withOpenCodeDb(dbPath, (db) => {
+		const sessions = await withSqliteDb(dbPath, (db) => {
 			// OpenCode stores timestamps as unix milliseconds (INTEGER).
 			// Include both top-level and continuation (compacted) sessions for this project.
 			// Auto-compact creates child sessions (parent_id != NULL) that carry on the conversation,
@@ -238,7 +147,8 @@ export async function scanOpenCodeSessions(projectDir: string): Promise<OpenCode
 			// (e.g. VS Code URIs lowercase the drive letter). Compare case-insensitively
 			// on those platforms. Linux filesystems are case-sensitive, so exact match
 			// is correct there.
-			const caseInsensitive = process.platform === "win32" || process.platform === "darwin";
+			const os = platform();
+			const caseInsensitive = os === "win32" || os === "darwin";
 			const directoryMatch = caseInsensitive
 				? "LOWER(directory) = LOWER(:projectDir)"
 				: "directory = :projectDir";

--- a/cli/src/core/OpenCodeTranscriptReader.ts
+++ b/cli/src/core/OpenCodeTranscriptReader.ts
@@ -18,7 +18,7 @@
 
 import { createLogger } from "../Logger.js";
 import type { TranscriptCursor, TranscriptEntry, TranscriptReadResult } from "../Types.js";
-import { withOpenCodeDb } from "./OpenCodeSessionDiscoverer.js";
+import { withSqliteDb } from "./SqliteHelpers.js";
 import { mergeConsecutiveEntries } from "./TranscriptReader.js";
 
 const log = createLogger("OpenCodeTranscriptReader");
@@ -51,7 +51,7 @@ export async function readOpenCodeTranscript(
 	const cutoffTime = beforeTimestamp ? new Date(beforeTimestamp).getTime() : undefined;
 
 	try {
-		const { rawEntries, totalMessages, lastConsumedIndex } = await withOpenCodeDb(dbPath, (db) => {
+		const { rawEntries, totalMessages, lastConsumedIndex } = await withSqliteDb(dbPath, (db) => {
 			// Query messages with their parts via JOIN
 			const rows = db
 				.prepare(

--- a/cli/src/core/SessionTracker.test.ts
+++ b/cli/src/core/SessionTracker.test.ts
@@ -952,6 +952,38 @@ describe("SessionTracker", () => {
 
 			expect(result).toEqual([claudeSession]);
 		});
+
+		it("filters out cursor sessions when cursorEnabled === false", () => {
+			const sessions: SessionInfo[] = [
+				{
+					sessionId: "claude-1",
+					transcriptPath: "/c.jsonl",
+					updatedAt: "2026-05-03T00:00:00Z",
+					source: "claude",
+				},
+				{
+					sessionId: "cursor-1",
+					transcriptPath: "/db.vscdb#abc",
+					updatedAt: "2026-05-03T00:00:00Z",
+					source: "cursor",
+				},
+			];
+			const result = filterSessionsByEnabledIntegrations(sessions, { cursorEnabled: false });
+			expect(result).toEqual([sessions[0]]);
+		});
+
+		it("retains cursor sessions when cursorEnabled is undefined or true", () => {
+			const sessions: SessionInfo[] = [
+				{
+					sessionId: "cursor-1",
+					transcriptPath: "/db.vscdb#abc",
+					updatedAt: "2026-05-03T00:00:00Z",
+					source: "cursor",
+				},
+			];
+			expect(filterSessionsByEnabledIntegrations(sessions, {})).toEqual(sessions);
+			expect(filterSessionsByEnabledIntegrations(sessions, { cursorEnabled: true })).toEqual(sessions);
+		});
 	});
 
 	// ── git operation queue ────────────────────────────────────────────────

--- a/cli/src/core/SessionTracker.ts
+++ b/cli/src/core/SessionTracker.ts
@@ -166,6 +166,9 @@ export function filterSessionsByEnabledIntegrations(
 	if (config.openCodeEnabled === false) {
 		filtered = filtered.filter((s) => s.source !== "opencode");
 	}
+	if (config.cursorEnabled === false) {
+		filtered = filtered.filter((s) => s.source !== "cursor");
+	}
 	return filtered;
 }
 

--- a/cli/src/core/SqliteHelpers.test.ts
+++ b/cli/src/core/SqliteHelpers.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+
+import { classifyScanError, hasNodeSqliteSupport, NODE_SQLITE_MIN_VERSION } from "./SqliteHelpers.js";
+
+describe("hasNodeSqliteSupport", () => {
+	const { major, minor } = NODE_SQLITE_MIN_VERSION;
+
+	it("returns true on exactly the minimum version", () => {
+		expect(hasNodeSqliteSupport(`${major}.${minor}.0`)).toBe(true);
+	});
+
+	it("returns true on a later major", () => {
+		expect(hasNodeSqliteSupport(`${major + 1}.0.0`)).toBe(true);
+	});
+
+	it("returns true on a later minor within the same major", () => {
+		expect(hasNodeSqliteSupport(`${major}.${minor + 1}.0`)).toBe(true);
+	});
+
+	it("returns false on an earlier minor within the same major", () => {
+		// minor=0 covers the "earlier minor" branch even when NODE_SQLITE_MIN_VERSION.minor is 0
+		// (the comparison is `>=`, so 22.0.0 < 22.5.0 returns false).
+		expect(hasNodeSqliteSupport(`${major}.0.0`)).toBe(false);
+	});
+
+	it("returns false on an earlier major", () => {
+		expect(hasNodeSqliteSupport(`${major - 1}.99.0`)).toBe(false);
+	});
+
+	it("treats prerelease tags correctly (major.minor extracted from prefix)", () => {
+		expect(hasNodeSqliteSupport("22.5.0-nightly20260101")).toBe(true);
+		expect(hasNodeSqliteSupport("20.15.0-nightly20260101")).toBe(false);
+	});
+});
+
+describe("classifyScanError", () => {
+	function err(message: string, code?: string): Error & { code?: string } {
+		const e = new Error(message) as Error & { code?: string };
+		if (code !== undefined) e.code = code;
+		return e;
+	}
+
+	it("returns null for ENOENT (silent 'not installed')", () => {
+		expect(classifyScanError(err("…", "ENOENT"))).toBeNull();
+	});
+
+	it("classifies EACCES and EPERM as permission", () => {
+		expect(classifyScanError(err("denied", "EACCES"))?.kind).toBe("permission");
+		expect(classifyScanError(err("denied", "EPERM"))?.kind).toBe("permission");
+	});
+
+	it("classifies SQLITE_CANTOPEN / 'unable to open' as permission", () => {
+		expect(classifyScanError(err("SQLITE_CANTOPEN: file failed to open"))?.kind).toBe("permission");
+		expect(classifyScanError(err("unable to open database file"))?.kind).toBe("permission");
+	});
+
+	it("classifies SQLITE_CORRUPT and similar as corrupt", () => {
+		expect(classifyScanError(err("SQLITE_CORRUPT: database disk image is malformed"))?.kind).toBe("corrupt");
+		expect(classifyScanError(err("file is not a database"))?.kind).toBe("corrupt");
+		expect(classifyScanError(err("SQLITE_NOTADB"))?.kind).toBe("corrupt");
+	});
+
+	it("classifies SQLITE_BUSY / SQLITE_LOCKED as locked", () => {
+		expect(classifyScanError(err("SQLITE_BUSY: database is locked"))?.kind).toBe("locked");
+		expect(classifyScanError(err("database is locked"))?.kind).toBe("locked");
+		expect(classifyScanError(err("SQLITE_LOCKED"))?.kind).toBe("locked");
+	});
+
+	it("classifies 'no such table'/'no such column' as schema drift", () => {
+		expect(classifyScanError(err("no such table: session"))?.kind).toBe("schema");
+		expect(classifyScanError(err("no such column: time_updated"))?.kind).toBe("schema");
+	});
+
+	it("falls back to 'unknown' for unrecognized errors", () => {
+		const classified = classifyScanError(err("totally unexpected disk failure"));
+		expect(classified?.kind).toBe("unknown");
+		expect(classified?.message).toBe("totally unexpected disk failure");
+	});
+
+	it("handles non-Error throws by stringifying", () => {
+		const classified = classifyScanError("raw string rejection");
+		expect(classified?.kind).toBe("unknown");
+		expect(classified?.message).toBe("raw string rejection");
+	});
+});

--- a/cli/src/core/SqliteHelpers.ts
+++ b/cli/src/core/SqliteHelpers.ts
@@ -1,0 +1,120 @@
+/**
+ * SQLite Helpers
+ *
+ * Shared SQLite utilities for SQLite-based agents (OpenCode, Cursor).
+ * Extracted from OpenCodeSessionDiscoverer to avoid agents depending on
+ * a file named for a different agent.
+ */
+
+/**
+ * Database handle shape passed to `withSqliteDb` callbacks.
+ *
+ * Structurally typed against node:sqlite's DatabaseSync rather than importing
+ * the type directly, so the module is not loaded until the helper runs — this
+ * keeps the ExperimentalWarning out of every PostCommitHook invocation that
+ * only transitively imports this file.
+ */
+export interface SqliteDbHandle {
+	prepare(sql: string): {
+		all(params?: Record<string, unknown> | unknown, ...rest: unknown[]): unknown[];
+		get(params?: Record<string, unknown> | unknown, ...rest: unknown[]): unknown;
+		run(params?: Record<string, unknown> | unknown, ...rest: unknown[]): unknown;
+	};
+	close(): void;
+}
+
+/**
+ * Opens a SQLite database read-only, runs a callback, then closes it.
+ *
+ * Uses Node's built-in `node:sqlite` (statically-linked SQLite; full WAL support).
+ * The module is imported dynamically so the ExperimentalWarning only appears
+ * when this helper is actually invoked — not when PostCommitHook merely
+ * transitively imports this file.
+ */
+export async function withSqliteDb<T>(dbPath: string, fn: (db: SqliteDbHandle) => T): Promise<T> {
+	const { DatabaseSync } = await import("node:sqlite");
+	const db = new DatabaseSync(dbPath, { readOnly: true });
+	try {
+		return fn(db as unknown as SqliteDbHandle);
+	} finally {
+		db.close();
+	}
+}
+
+/**
+ * Minimum Node version that ships `node:sqlite`. SQLite-based agent support
+ * requires this built-in module; older runtimes cannot load it even if the DB
+ * file is present.
+ *
+ * Exported for unit tests; callers should use the agent-specific `isInstalled`
+ * helper.
+ */
+export const NODE_SQLITE_MIN_VERSION = { major: 22, minor: 5 } as const;
+
+/**
+ * Returns true when the current runtime can load `node:sqlite`. Compares the
+ * major.minor of `process.versions.node` against NODE_SQLITE_MIN_VERSION
+ * rather than doing a live probe, which would emit the ExperimentalWarning on
+ * matching runtimes and defeat the lazy-import pattern used by `withSqliteDb`.
+ */
+export function hasNodeSqliteSupport(nodeVersion: string = process.versions.node): boolean {
+	const match = /^(\d+)\.(\d+)/.exec(nodeVersion);
+	/* v8 ignore start -- process.versions.node is always well-formed semver in supported runtimes; guard is purely defensive */
+	if (!match) return false;
+	/* v8 ignore stop */
+	const major = Number.parseInt(match[1], 10);
+	const minor = Number.parseInt(match[2], 10);
+	if (major > NODE_SQLITE_MIN_VERSION.major) return true;
+	if (major < NODE_SQLITE_MIN_VERSION.major) return false;
+	return minor >= NODE_SQLITE_MIN_VERSION.minor;
+}
+
+/**
+ * Classifies a real SQLite scan failure into a user-facing severity. Only
+ * *genuine* failures are represented here — ENOENT is excluded because a
+ * DB that's absent between the install-check and the read is indistinguishable
+ * from "not installed" and should stay silent.
+ *
+ * - `corrupt` — SQLite reports SQLITE_CORRUPT / SQLITE_NOTADB. The file exists
+ *   but is unreadable. Users should know.
+ * - `locked` — another process holds an exclusive lock (SQLITE_BUSY). Transient,
+ *   but worth surfacing if it persists.
+ * - `permission` — EACCES / EPERM / SQLITE_CANTOPEN opening the DB. Users
+ *   should know.
+ * - `schema` — the expected table or column is missing. Likely agent version
+ *   drift; users should know so we can support the new schema.
+ * - `unknown` — anything else. Surface as a generic scan-failed warning.
+ */
+export type SqliteScanErrorKind = "corrupt" | "locked" | "permission" | "schema" | "unknown";
+
+export interface SqliteScanError {
+	readonly kind: SqliteScanErrorKind;
+	readonly message: string;
+}
+
+/**
+ * Returns null if the error is ENOENT (treat as "not installed" — silent).
+ * Exported for unit testing; callers should use the agent-specific scan helper.
+ */
+export function classifyScanError(error: unknown): SqliteScanError | null {
+	const err = error as (Error & { code?: string }) | undefined;
+	const message = err?.message ?? String(error);
+	const code = err?.code;
+	if (code === "ENOENT") return null;
+	if (code === "EACCES" || code === "EPERM") return { kind: "permission", message };
+	// node:sqlite surfaces low-level SQLite error codes in the message
+	// (e.g. "SQLITE_CORRUPT: database disk image is malformed").
+	if (/SQLITE_CORRUPT|SQLITE_NOTADB|file is not a database/i.test(message)) {
+		return { kind: "corrupt", message };
+	}
+	if (/SQLITE_BUSY|SQLITE_LOCKED|database is locked/i.test(message)) {
+		return { kind: "locked", message };
+	}
+	if (/no such table|no such column/i.test(message)) {
+		return { kind: "schema", message };
+	}
+	if (/SQLITE_CANTOPEN|unable to open/i.test(message)) {
+		return { kind: "permission", message };
+	}
+	return { kind: "unknown", message };
+}

--- a/cli/src/hooks/PostCommitHook.helpers.test.ts
+++ b/cli/src/hooks/PostCommitHook.helpers.test.ts
@@ -194,6 +194,18 @@ vi.mock("../core/OpenCodeTranscriptReader.js", () => ({
 	readOpenCodeTranscript: vi.fn(),
 }));
 
+vi.mock("../core/CursorDetector.js", () => ({
+	isCursorInstalled: vi.fn().mockResolvedValue(false),
+}));
+
+vi.mock("../core/CursorSessionDiscoverer.js", () => ({
+	discoverCursorSessions: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock("../core/CursorTranscriptReader.js", () => ({
+	readCursorTranscript: vi.fn(),
+}));
+
 vi.mock("../core/TranscriptParser.js", () => ({
 	getParserForSource: vi.fn(),
 }));

--- a/cli/src/hooks/PostCommitHook.test.ts
+++ b/cli/src/hooks/PostCommitHook.test.ts
@@ -119,6 +119,22 @@ vi.mock("../core/OpenCodeTranscriptReader.js", () => ({
 	}),
 }));
 
+vi.mock("../core/CursorDetector.js", () => ({
+	isCursorInstalled: vi.fn().mockResolvedValue(false),
+}));
+
+vi.mock("../core/CursorSessionDiscoverer.js", () => ({
+	discoverCursorSessions: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock("../core/CursorTranscriptReader.js", () => ({
+	readCursorTranscript: vi.fn().mockResolvedValue({
+		entries: [],
+		newCursor: { transcriptPath: "", lineNumber: 0, updatedAt: "" },
+		totalLinesRead: 0,
+	}),
+}));
+
 vi.mock("../core/GeminiTranscriptReader.js", () => ({
 	readGeminiTranscript: vi.fn().mockResolvedValue({
 		entries: [],

--- a/cli/src/hooks/QueueWorker.test.ts
+++ b/cli/src/hooks/QueueWorker.test.ts
@@ -118,6 +118,22 @@ vi.mock("../core/OpenCodeTranscriptReader.js", () => ({
 	}),
 }));
 
+vi.mock("../core/CursorSessionDiscoverer.js", () => ({
+	discoverCursorSessions: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock("../core/CursorDetector.js", () => ({
+	isCursorInstalled: vi.fn().mockResolvedValue(false),
+}));
+
+vi.mock("../core/CursorTranscriptReader.js", () => ({
+	readCursorTranscript: vi.fn().mockResolvedValue({
+		entries: [],
+		newCursor: { transcriptPath: "", lineNumber: 0, updatedAt: "" },
+		totalLinesRead: 0,
+	}),
+}));
+
 vi.mock("../core/GeminiTranscriptReader.js", () => ({
 	readGeminiTranscript: vi.fn().mockResolvedValue({
 		entries: [],
@@ -146,6 +162,9 @@ vi.spyOn(console, "error").mockImplementation(() => {});
 import { spawn } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
 import { isCodexInstalled } from "../core/CodexSessionDiscoverer.js";
+import { isCursorInstalled } from "../core/CursorDetector.js";
+import { discoverCursorSessions } from "../core/CursorSessionDiscoverer.js";
+import { readCursorTranscript } from "../core/CursorTranscriptReader.js";
 import { getCommitInfo, getCurrentBranch, getDiffContent, getDiffStats } from "../core/GitOps.js";
 import { discoverOpenCodeSessions, isOpenCodeInstalled } from "../core/OpenCodeSessionDiscoverer.js";
 import { readOpenCodeTranscript } from "../core/OpenCodeTranscriptReader.js";
@@ -207,6 +226,7 @@ describe("QueueWorker", () => {
 		vi.mocked(savePlansRegistry).mockResolvedValue(undefined);
 		vi.mocked(isCodexInstalled).mockResolvedValue(false);
 		vi.mocked(isOpenCodeInstalled).mockResolvedValue(false);
+		vi.mocked(isCursorInstalled).mockResolvedValue(false);
 		vi.mocked(buildMultiSessionContext).mockReturnValue("");
 		vi.mocked(generateSummary).mockResolvedValue({
 			transcriptEntries: 0,
@@ -331,6 +351,93 @@ describe("QueueWorker", () => {
 
 			// Worker should complete without throwing (error caught internally)
 			expect(releaseLock).toHaveBeenCalled();
+		});
+	});
+
+	describe("Cursor integration", () => {
+		it("should include discovered Cursor sessions in the pipeline when enabled", async () => {
+			const op = makeCommitOp();
+			const queueEntry = { op, filePath: "/tmp/queue/cursor.json" };
+
+			vi.mocked(dequeueAllGitOperations)
+				.mockResolvedValueOnce([queueEntry])
+				.mockResolvedValueOnce([])
+				.mockResolvedValueOnce([]);
+
+			setupPipelineMocks();
+			vi.mocked(loadConfig).mockResolvedValue({} as Awaited<ReturnType<typeof loadConfig>>);
+			vi.mocked(isCursorInstalled).mockResolvedValue(true);
+			vi.mocked(discoverCursorSessions).mockResolvedValue([
+				{
+					sessionId: "cur-1",
+					transcriptPath: "/tmp/cursor.vscdb#cur-1",
+					updatedAt: "2026-04-01T12:00:00.000Z",
+					source: "cursor",
+				},
+			]);
+			vi.mocked(readCursorTranscript).mockResolvedValue({
+				entries: [{ role: "human", content: "Cursor context", timestamp: "2026-04-01T12:00:00.000Z" }],
+				newCursor: {
+					transcriptPath: "/tmp/cursor.vscdb#cur-1",
+					lineNumber: 1,
+					updatedAt: "2026-04-01T12:00:00.000Z",
+				},
+				totalLinesRead: 1,
+			});
+
+			await runWorker("/test/cwd");
+
+			expect(discoverCursorSessions).toHaveBeenCalledWith("/test/cwd");
+			expect(readCursorTranscript).toHaveBeenCalledWith(
+				"/tmp/cursor.vscdb#cur-1",
+				null,
+				"2026-04-01T12:00:00.000Z",
+			);
+			expect(saveCursor).toHaveBeenCalledWith(
+				expect.objectContaining({ transcriptPath: "/tmp/cursor.vscdb#cur-1", lineNumber: 1 }),
+				"/test/cwd",
+			);
+		});
+
+		it("skips discovery when cursorEnabled is explicitly false", async () => {
+			const op = makeCommitOp();
+			const queueEntry = { op, filePath: "/tmp/queue/cursor-disabled.json" };
+
+			vi.mocked(dequeueAllGitOperations)
+				.mockResolvedValueOnce([queueEntry])
+				.mockResolvedValueOnce([])
+				.mockResolvedValueOnce([]);
+
+			setupPipelineMocks();
+			vi.mocked(loadConfig).mockResolvedValue({ cursorEnabled: false } as Awaited<ReturnType<typeof loadConfig>>);
+			vi.mocked(isCursorInstalled).mockResolvedValue(true);
+
+			await runWorker("/test/cwd");
+
+			// cursorEnabled=false short-circuits before isCursorInstalled is consulted
+			expect(isCursorInstalled).not.toHaveBeenCalled();
+			expect(discoverCursorSessions).not.toHaveBeenCalled();
+		});
+	});
+
+	describe("Cursor integration — empty sessions", () => {
+		it("logs no Discovered count when isCursorInstalled=true but discovery returns empty", async () => {
+			const op = makeCommitOp();
+			const queueEntry = { op, filePath: "/tmp/queue/cursor-empty.json" };
+
+			vi.mocked(dequeueAllGitOperations)
+				.mockResolvedValueOnce([queueEntry])
+				.mockResolvedValueOnce([])
+				.mockResolvedValueOnce([]);
+
+			setupPipelineMocks();
+			vi.mocked(isCursorInstalled).mockResolvedValue(true);
+			vi.mocked(discoverCursorSessions).mockResolvedValue([]);
+
+			await runWorker("/test/cwd");
+
+			expect(discoverCursorSessions).toHaveBeenCalledWith("/test/cwd");
+			expect(storeSummary).toHaveBeenCalled();
 		});
 	});
 

--- a/cli/src/hooks/QueueWorker.ts
+++ b/cli/src/hooks/QueueWorker.ts
@@ -22,6 +22,9 @@ import { homedir } from "node:os";
 import { basename, dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { discoverCodexSessions, isCodexInstalled } from "../core/CodexSessionDiscoverer.js";
+import { isCursorInstalled } from "../core/CursorDetector.js";
+import { discoverCursorSessions } from "../core/CursorSessionDiscoverer.js";
+import { readCursorTranscript } from "../core/CursorTranscriptReader.js";
 import { readGeminiTranscript } from "../core/GeminiTranscriptReader.js";
 import { getCommitInfo, getCurrentBranch, getDiffContent, getDiffStats } from "../core/GitOps.js";
 import { discoverOpenCodeSessions, isOpenCodeInstalled } from "../core/OpenCodeSessionDiscoverer.js";
@@ -1425,6 +1428,15 @@ async function loadSessionTranscripts(
 		}
 	}
 
+	// Discover Cursor Composer sessions (on-demand SQLite scan from globalStorage)
+	if (config.cursorEnabled !== false && (await isCursorInstalled())) {
+		const cursorSessions = await discoverCursorSessions(cwd);
+		if (cursorSessions.length > 0) {
+			allSessions = [...allSessions, ...cursorSessions];
+			log.info("Discovered %d Cursor session(s)", cursorSessions.length);
+		}
+	}
+
 	if (allSessions.length === 0) {
 		log.info("No active sessions found — will infer topics from diff if available");
 	}
@@ -1461,12 +1473,14 @@ async function readAllTranscripts(
 		const startLine = cursor?.lineNumber ?? 0;
 		const source = session.source ?? "claude";
 
-		// Gemini and OpenCode use dedicated readers (not JSONL line-based parsing)
+		// Gemini, OpenCode, and Cursor use dedicated readers (not JSONL line-based parsing)
 		let result: TranscriptReadResult;
 		if (source === "gemini") {
 			result = await readGeminiTranscript(session.transcriptPath, cursor, beforeTimestamp);
 		} else if (source === "opencode") {
 			result = await readOpenCodeTranscript(session.transcriptPath, cursor, beforeTimestamp);
+		} else if (source === "cursor") {
+			result = await readCursorTranscript(session.transcriptPath, cursor, beforeTimestamp);
 		} else {
 			result = await readTranscript(session.transcriptPath, cursor, getParserForSource(source), beforeTimestamp);
 		}

--- a/cli/src/install/Installer.test.ts
+++ b/cli/src/install/Installer.test.ts
@@ -50,6 +50,16 @@ vi.mock("../core/OpenCodeSessionDiscoverer.js", () => ({
 	scanOpenCodeSessions: vi.fn().mockResolvedValue({ sessions: [] }),
 }));
 
+// Mock CursorDetector for status/install checks
+vi.mock("../core/CursorDetector.js", () => ({
+	isCursorInstalled: vi.fn().mockResolvedValue(false),
+}));
+
+// Mock CursorSessionDiscoverer for status/install checks
+vi.mock("../core/CursorSessionDiscoverer.js", () => ({
+	scanCursorSessions: vi.fn().mockResolvedValue({ sessions: [] }),
+}));
+
 // Partially mock DistPathResolver so resolveDistPath doesn't depend on global npm state.
 // By default, resolveDistPath returns the caller's own dist dir with "cli" source.
 vi.mock("./DistPathResolver.js", async (importOriginal) => {
@@ -136,6 +146,10 @@ describe("Installer", () => {
 		vi.mocked(isOpenCodeInstalled).mockResolvedValue(false);
 		vi.mocked(discoverOpenCodeSessions).mockResolvedValue([]);
 		vi.mocked(scanOpenCodeSessions).mockResolvedValue({ sessions: [] });
+		const { isCursorInstalled } = await import("../core/CursorDetector.js");
+		vi.mocked(isCursorInstalled).mockResolvedValue(false);
+		const { scanCursorSessions } = await import("../core/CursorSessionDiscoverer.js");
+		vi.mocked(scanCursorSessions).mockResolvedValue({ sessions: [] });
 	});
 
 	afterEach(async () => {
@@ -225,6 +239,43 @@ describe("Installer", () => {
 			expect(result.success).toBe(true);
 			const globalConfig = JSON.parse(await readFile(join(emptyGlobalDir, "config.json"), "utf-8"));
 			expect(globalConfig.openCodeEnabled).toBe(true);
+		});
+
+		it("should auto-enable Cursor discovery when Cursor is detected and not configured", async () => {
+			const { isCursorInstalled } = await import("../core/CursorDetector.js");
+			vi.mocked(isCursorInstalled).mockResolvedValueOnce(true);
+
+			const result = await install(tempDir);
+
+			expect(result.success).toBe(true);
+			const globalConfig = JSON.parse(await readFile(join(emptyGlobalDir, "config.json"), "utf-8"));
+			expect(globalConfig.cursorEnabled).toBe(true);
+		});
+
+		it("should keep cursorEnabled unchanged when Cursor is detected but already configured", async () => {
+			const { isCursorInstalled } = await import("../core/CursorDetector.js");
+			vi.mocked(isCursorInstalled).mockResolvedValueOnce(true);
+			await writeFile(join(emptyGlobalDir, "config.json"), JSON.stringify({ cursorEnabled: false }), "utf-8");
+
+			const result = await install(tempDir);
+
+			expect(result.success).toBe(true);
+			const globalConfig = JSON.parse(await readFile(join(emptyGlobalDir, "config.json"), "utf-8"));
+			expect(globalConfig.cursorEnabled).toBe(false);
+		});
+
+		it("should not rewrite cursorEnabled when Cursor is detected and already true", async () => {
+			// Covers the `config.cursorEnabled === undefined` false branch: detection succeeds
+			// (reaches the inner if) but the existing value is explicitly `true`, so no rewrite.
+			const { isCursorInstalled } = await import("../core/CursorDetector.js");
+			vi.mocked(isCursorInstalled).mockResolvedValueOnce(true);
+			await writeFile(join(emptyGlobalDir, "config.json"), JSON.stringify({ cursorEnabled: true }), "utf-8");
+
+			const result = await install(tempDir);
+
+			expect(result.success).toBe(true);
+			const globalConfig = JSON.parse(await readFile(join(emptyGlobalDir, "config.json"), "utf-8"));
+			expect(globalConfig.cursorEnabled).toBe(true);
 		});
 
 		it("should use process.cwd() when install is called without cwd", async () => {
@@ -1959,6 +2010,54 @@ describe("Installer", () => {
 
 			expect(status.activeSessions).toBe(0);
 			expect(status.openCodeScanError).toEqual({
+				kind: "corrupt",
+				message: "SQLITE_CORRUPT: disk image is malformed",
+			});
+		});
+
+		it("should not append Cursor sessions when discovery finds none", async () => {
+			const { isCursorInstalled } = await import("../core/CursorDetector.js");
+			const { scanCursorSessions } = await import("../core/CursorSessionDiscoverer.js");
+			vi.mocked(isCursorInstalled).mockResolvedValueOnce(true);
+			vi.mocked(scanCursorSessions).mockResolvedValueOnce({ sessions: [] });
+
+			const status = await getStatus(tempDir);
+			expect(status.activeSessions).toBe(0);
+		});
+
+		it("should include Cursor sessions in activeSessions when cursorEnabled", async () => {
+			const { isCursorInstalled } = await import("../core/CursorDetector.js");
+			const { scanCursorSessions } = await import("../core/CursorSessionDiscoverer.js");
+			vi.mocked(isCursorInstalled).mockResolvedValue(true);
+			vi.mocked(scanCursorSessions).mockResolvedValue({
+				sessions: [
+					{
+						sessionId: "cursor1",
+						transcriptPath: "/cursor1",
+						updatedAt: new Date().toISOString(),
+						source: "cursor",
+					},
+				],
+			});
+
+			const status = await getStatus(tempDir);
+			expect(status.activeSessions).toBe(1);
+			expect(status.mostRecentSession?.source).toBe("cursor");
+		});
+
+		it("surfaces Cursor scan errors so the UI can warn instead of silently showing 0 sessions", async () => {
+			const { isCursorInstalled } = await import("../core/CursorDetector.js");
+			const { scanCursorSessions } = await import("../core/CursorSessionDiscoverer.js");
+			vi.mocked(isCursorInstalled).mockResolvedValueOnce(true);
+			vi.mocked(scanCursorSessions).mockResolvedValueOnce({
+				sessions: [],
+				error: { kind: "corrupt", message: "SQLITE_CORRUPT: disk image is malformed" },
+			});
+
+			const status = await getStatus(tempDir);
+
+			expect(status.activeSessions).toBe(0);
+			expect(status.cursorScanError).toEqual({
 				kind: "corrupt",
 				message: "SQLITE_CORRUPT: disk image is malformed",
 			});

--- a/cli/src/install/Installer.ts
+++ b/cli/src/install/Installer.ts
@@ -19,6 +19,8 @@ import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { isClaudeInstalled } from "../core/ClaudeDetector.js";
 import { discoverCodexSessions, isCodexInstalled } from "../core/CodexSessionDiscoverer.js";
+import { isCursorInstalled } from "../core/CursorDetector.js";
+import { scanCursorSessions } from "../core/CursorSessionDiscoverer.js";
 import { isGeminiInstalled } from "../core/GeminiSessionDetector.js";
 import { getProjectRootDir, listWorktrees, orphanBranchExists } from "../core/GitOps.js";
 import {
@@ -36,6 +38,7 @@ import {
 	saveConfig,
 	saveConfigScoped,
 } from "../core/SessionTracker.js";
+import type { SqliteScanError } from "../core/SqliteHelpers.js";
 import { getSummaryCount } from "../core/SummaryStore.js";
 import { createLogger, getJolliMemoryDir, ORPHAN_BRANCH } from "../Logger.js";
 import type { InstallResult, JolliMemoryConfig, SessionInfo, StatusInfo, TranscriptSource } from "../Types.js";
@@ -255,6 +258,15 @@ export async function install(cwd?: string, options?: { source?: "vscode-extensi
 			}
 		}
 
+		// Auto-detect Cursor and enable Composer session discovery
+		const cursorDetected = config.cursorEnabled !== false && (await isCursorInstalled());
+		if (cursorDetected) {
+			if (config.cursorEnabled === undefined) {
+				await saveConfig({ cursorEnabled: true });
+				log.info("Cursor detected — enabled Cursor Composer session discovery");
+			}
+		}
+
 		// Migrate any existing worktree-level API keys to the global config dir.
 		// The worktrees list always includes the main repo root as its first entry.
 		for (const wt of worktrees) {
@@ -470,6 +482,7 @@ export async function getStatus(cwd?: string): Promise<StatusInfo> {
 	const codexDetected = await isCodexInstalled();
 	const geminiDetected = await isGeminiInstalled();
 	const openCodeDetected = await isOpenCodeInstalled();
+	const cursorDetected = await isCursorInstalled();
 
 	// Check if we can enumerate worktrees; falls back gracefully if not a git repo
 	let enabledWorktrees: number | undefined;
@@ -509,6 +522,15 @@ export async function getStatus(cwd?: string): Promise<StatusInfo> {
 			allEnabledSessions = [...allEnabledSessions, ...scan.sessions];
 		}
 		openCodeScanError = scan.error;
+	}
+
+	let cursorScanError: SqliteScanError | undefined;
+	if (config.cursorEnabled !== false && cursorDetected) {
+		const scan = await scanCursorSessions(projectDir);
+		if (scan.sessions.length > 0) {
+			allEnabledSessions = [...allEnabledSessions, ...scan.sessions];
+		}
+		cursorScanError = scan.error;
 	}
 
 	// Compute per-source session counts for integration status rows
@@ -582,6 +604,9 @@ export async function getStatus(cwd?: string): Promise<StatusInfo> {
 		geminiEnabled: config.geminiEnabled,
 		openCodeDetected,
 		openCodeEnabled: config.openCodeEnabled,
+		cursorDetected,
+		cursorEnabled: config.cursorEnabled,
+		cursorScanError,
 		globalConfigDir,
 		worktreeStatePath,
 		enabledWorktrees,
@@ -593,7 +618,7 @@ export async function getStatus(cwd?: string): Promise<StatusInfo> {
 	};
 
 	log.info(
-		"Status: enabled=%s, claude=%s, git=%s, geminiHook=%s, worktreeHooks=%s, sessions=%d, summaries=%d, codex=%s/%s, gemini=%s/%s, enabledWorktrees=%s, opencode=%s/%s",
+		"Status: enabled=%s, claude=%s, git=%s, geminiHook=%s, worktreeHooks=%s, sessions=%d, summaries=%d, codex=%s/%s, gemini=%s/%s, enabledWorktrees=%s, opencode=%s/%s, cursor=%s/%s",
 		status.enabled,
 		status.claudeHookInstalled,
 		status.gitHookInstalled,
@@ -608,6 +633,8 @@ export async function getStatus(cwd?: string): Promise<StatusInfo> {
 		status.enabledWorktrees,
 		status.openCodeDetected,
 		status.openCodeEnabled,
+		status.cursorDetected,
+		status.cursorEnabled,
 	);
 
 	return status;

--- a/docs/superpowers/plans/2026-05-03-cursor-support.md
+++ b/docs/superpowers/plans/2026-05-03-cursor-support.md
@@ -1,0 +1,1608 @@
+# Cursor Support Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add Cursor (the IDE) as a fifth `TranscriptSource`. The CLI discovers Cursor Composer transcripts on every commit by scanning Cursor's local SQLite (`globalStorage/state.vscdb` `cursorDiskKV` table) using a "β′" attribution algorithm — workspace pointer + 48 h time window. No hooks, no Cursor-side files, no VS Code extension changes.
+
+**Architecture:** Mirrors the OpenCode pattern (passive SQLite discovery, no hook). Three new files in `cli/src/core/` (`CursorDetector.ts`, `CursorSessionDiscoverer.ts`, `CursorTranscriptReader.ts`) and one shared refactor (`SqliteHelpers.ts` extracted from OpenCode). Wired into `Installer.ts`, `QueueWorker.ts`, `StatusCommand.ts`, `ConfigureCommand.ts`, and `SessionTracker.ts`. See [`docs/superpowers/specs/2026-05-03-cursor-support-design.md`](../specs/2026-05-03-cursor-support-design.md).
+
+**Tech Stack:** TypeScript 5, Node 22.5+ (`node:sqlite` built-in), Vitest, Biome (tabs, 120-col), npm workspaces. The implementation lives in the `cli/` workspace only.
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|---|---|---|
+| `cli/src/core/SqliteHelpers.ts` | **Create** | `withSqliteDb`, `hasNodeSqliteSupport`, `NODE_SQLITE_MIN_VERSION`, `classifyScanError`, `SqliteScanError`, `SqliteScanErrorKind`. Extracted from OpenCode. |
+| `cli/src/core/SqliteHelpers.test.ts` | **Create** | Unit tests for `classifyScanError` and `hasNodeSqliteSupport`. |
+| `cli/src/core/OpenCodeSessionDiscoverer.ts` | **Modify** | Import from `SqliteHelpers.ts` (replace 4 inlined definitions). Re-export under old names for one minor version of compat. |
+| `cli/src/core/OpenCodeTranscriptReader.ts` | **Modify** | Switch import from `withOpenCodeDb` to `withSqliteDb` (1 line). |
+| `cli/src/core/OpenCodeSessionDiscoverer.test.ts` | **Modify** | Update import paths. Tests for `classifyScanError`/`hasNodeSqliteSupport` migrate to `SqliteHelpers.test.ts`. |
+| `cli/src/Types.ts` | **Modify** | Add `"cursor"` to `TranscriptSource` union; add `cursorEnabled` to `JolliMemoryConfig`; add `cursorDetected`, `cursorEnabled`, `cursorScanError` to `StatusInfo`. |
+| `cli/src/core/SessionTracker.ts` | **Modify** | `filterSessionsByEnabledIntegrations`: add cursor branch. |
+| `cli/src/core/SessionTracker.test.ts` | **Modify** | Add a cursor-disabled filtering test. |
+| `cli/src/core/CursorDetector.ts` | **Create** | `isCursorInstalled()`: checks app bundle, db file, and `hasNodeSqliteSupport()`. Platform-aware paths. |
+| `cli/src/core/CursorDetector.test.ts` | **Create** | Tests for installed/not-installed across platforms. |
+| `cli/src/core/CursorSessionDiscoverer.ts` | **Create** | β′ algorithm: workspace lookup → anchor pointers → time-window union. Exports `discoverCursorSessions`, `scanCursorSessions`, `getCursorGlobalDbPath`. |
+| `cli/src/core/CursorSessionDiscoverer.test.ts` | **Create** | Unit tests with real fixture SQLite databases. |
+| `cli/src/core/CursorTranscriptReader.ts` | **Create** | `readCursorTranscript(path, cursor?, beforeTimestamp?)`. Reads composerData → bubbleId rows, maps `bubble.type` to role. |
+| `cli/src/core/CursorTranscriptReader.test.ts` | **Create** | Unit tests for ordering, type→role mapping, cursor resume, beforeTimestamp. |
+| `cli/src/hooks/QueueWorker.ts` | **Modify** | `loadSessionTranscripts` discoverer fan-out + `readAllTranscripts` source dispatch. |
+| `cli/src/install/Installer.ts` | **Modify** | Auto-detect cursor at install time + populate `cursorDetected`/`cursorEnabled`/`cursorScanError` in `getStatus`. |
+| `cli/src/commands/StatusCommand.ts` | **Modify** | Add Cursor integration row. |
+| `cli/src/commands/ConfigureCommand.ts` | **Modify** | Add `cursorEnabled` to `VALID_CONFIG_KEYS` and the boolean coerce branch. |
+
+---
+
+## Pre-flight
+
+- [ ] **Verify branch and clean state**
+
+```bash
+cd /Users/flyer/jolli/code/jollimemory
+git status --short
+git branch --show-current
+```
+
+Expected: branch is `feature-support-cursor`, working tree clean.
+
+- [ ] **Confirm baseline tests pass before starting**
+
+```bash
+npm run test -w @jolli.ai/cli
+```
+
+Expected: all tests pass. (Coverage threshold may be at the threshold — that's the baseline we maintain.)
+
+---
+
+## Task 1: Extract `SqliteHelpers.ts` (pure refactor)
+
+**Files:**
+- Create: `cli/src/core/SqliteHelpers.ts`
+- Create: `cli/src/core/SqliteHelpers.test.ts`
+- Modify: `cli/src/core/OpenCodeSessionDiscoverer.ts`
+- Modify: `cli/src/core/OpenCodeTranscriptReader.ts`
+- Modify: `cli/src/core/OpenCodeSessionDiscoverer.test.ts`
+
+**Why this is first:** Cursor will reuse the SQLite helpers OpenCode already has, but they are currently named `withOpenCodeDb` / `OpenCodeScanError`. Extract before adding a second caller — otherwise we either duplicate or end up with cursor importing from a file named for a different agent.
+
+- [ ] **Step 1: Create `SqliteHelpers.ts` with the renamed shared helpers**
+
+Create a new file `cli/src/core/SqliteHelpers.ts`. Its content has four sections:
+
+1. A module docstring noting it was extracted from OpenCode for shared SQLite agents (currently OpenCode and Cursor).
+2. The `SqliteDbHandle` interface — structurally typed against `node:sqlite`'s `DatabaseSync` (do not import the type; reference the same shape with `prepare`, `close` methods).
+3. The async `withSqliteDb<T>(dbPath: string, fn: (db: SqliteDbHandle) => T): Promise<T>` function — dynamically `await import("node:sqlite")`, open `new DatabaseSync(dbPath, { readOnly: true })`, run `fn`, close in `finally`.
+4. `NODE_SQLITE_MIN_VERSION = { major: 22, minor: 5 } as const` and `hasNodeSqliteSupport(nodeVersion?: string): boolean` — parse the `M.m` of `process.versions.node` (or the override) and compare.
+5. `SqliteScanErrorKind` union (`"corrupt" | "locked" | "permission" | "schema" | "unknown"`), `SqliteScanError` interface, and `classifyScanError(error: unknown): SqliteScanError | null` — the regex/code matchers from the existing OpenCode helper, returning `null` on `ENOENT`.
+
+The simplest way to author this is to **copy the existing definitions verbatim from `cli/src/core/OpenCodeSessionDiscoverer.ts`** (the four matching exports plus their docstrings) and rename them in the new file:
+
+| Old (in OpenCode) | New (in SqliteHelpers) |
+|---|---|
+| `OpenCodeDbHandle` | `SqliteDbHandle` |
+| `withOpenCodeDb` | `withSqliteDb` |
+| `OpenCodeScanErrorKind` | `SqliteScanErrorKind` |
+| `OpenCodeScanError` | `SqliteScanError` |
+| `hasNodeSqliteSupport` | unchanged |
+| `NODE_SQLITE_MIN_VERSION` | unchanged |
+| `classifyScanError` | unchanged |
+
+Adjust the docstrings to refer to "SQLite-based agents (OpenCode, Cursor)" instead of "OpenCode".
+
+- [ ] **Step 2: Create `SqliteHelpers.test.ts` (migrate the tests for these symbols)**
+
+Find the existing tests in `cli/src/core/OpenCodeSessionDiscoverer.test.ts` for `classifyScanError` and `hasNodeSqliteSupport` (search the file for those names — they are top-level `describe(...)` blocks). Copy each `describe` block into a new `cli/src/core/SqliteHelpers.test.ts` file, replacing the import statement so it pulls from `./SqliteHelpers.js` instead of `./OpenCodeSessionDiscoverer.js`.
+
+The test bodies stay identical: ENOENT → null, EACCES/EPERM → permission, SQLITE_CORRUPT/SQLITE_NOTADB → corrupt, SQLITE_BUSY/SQLITE_LOCKED → locked, "no such table"/"no such column" → schema, anything else → unknown; and the Node-version semver comparison cases (`22.5.0` true, `22.4.0` false, `18.20.4` false, etc.).
+
+- [ ] **Step 3: Update `OpenCodeSessionDiscoverer.ts` to import from `SqliteHelpers.ts`**
+
+Open `cli/src/core/OpenCodeSessionDiscoverer.ts`. At the top of the file, add:
+
+```ts
+import {
+	classifyScanError as classifySqliteError,
+	hasNodeSqliteSupport,
+	NODE_SQLITE_MIN_VERSION,
+	type SqliteDbHandle,
+	type SqliteScanError,
+	type SqliteScanErrorKind,
+	withSqliteDb,
+} from "./SqliteHelpers.js";
+```
+
+Then **delete** the original definitions of `OpenCodeDbHandle`, `withOpenCodeDb`, `NODE_SQLITE_MIN_VERSION`, `hasNodeSqliteSupport`, `OpenCodeScanErrorKind`, `OpenCodeScanError`, and `classifyScanError` from this file. In their place, add backwards-compat re-exports so callers that import the old names still work for one minor:
+
+```ts
+/** @deprecated use SqliteDbHandle from SqliteHelpers.js */
+export type OpenCodeDbHandle = SqliteDbHandle;
+/** @deprecated use withSqliteDb from SqliteHelpers.js */
+export const withOpenCodeDb = withSqliteDb;
+export { NODE_SQLITE_MIN_VERSION, hasNodeSqliteSupport };
+/** @deprecated use SqliteScanErrorKind */
+export type OpenCodeScanErrorKind = SqliteScanErrorKind;
+/** @deprecated use SqliteScanError */
+export type OpenCodeScanError = SqliteScanError;
+export const classifyScanError = classifySqliteError;
+```
+
+Inside the file, replace internal call sites using `withOpenCodeDb(...)` with `withSqliteDb(...)`, and any `OpenCodeDbHandle` annotations with `SqliteDbHandle`. The OpenCode-specific exports (`getOpenCodeDbPath`, `isOpenCodeInstalled`, `OpenCodeScanResult`, `scanOpenCodeSessions`, `discoverOpenCodeSessions`) stay in this file.
+
+- [ ] **Step 4: Update `OpenCodeTranscriptReader.ts` to import `withSqliteDb`**
+
+Open `cli/src/core/OpenCodeTranscriptReader.ts`. Find the line:
+
+```ts
+import { withOpenCodeDb } from "./OpenCodeSessionDiscoverer.js";
+```
+
+Replace with:
+
+```ts
+import { withSqliteDb } from "./SqliteHelpers.js";
+```
+
+Then in the function body, replace the call site `withOpenCodeDb(...)` with `withSqliteDb(...)`.
+
+- [ ] **Step 5: Update `OpenCodeSessionDiscoverer.test.ts`**
+
+Open `cli/src/core/OpenCodeSessionDiscoverer.test.ts`. Remove `classifyScanError`, `hasNodeSqliteSupport`, and `NODE_SQLITE_MIN_VERSION` from the imports list, and remove the corresponding `describe(...)` blocks (they have moved to `SqliteHelpers.test.ts`). Keep imports for `discoverOpenCodeSessions`, `getOpenCodeDbPath`, `isOpenCodeInstalled`, and `scanOpenCodeSessions`.
+
+- [ ] **Step 6: Run the lint, typecheck, and test trio**
+
+```bash
+npm run typecheck -w @jolli.ai/cli
+npm run lint -w @jolli.ai/cli
+npm run test -w @jolli.ai/cli
+```
+
+Expected: all green. The OpenCode test suite still passes, the new `SqliteHelpers.test.ts` passes, and coverage threshold (97% statements) holds.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add cli/src/core/SqliteHelpers.ts cli/src/core/SqliteHelpers.test.ts \
+        cli/src/core/OpenCodeSessionDiscoverer.ts cli/src/core/OpenCodeTranscriptReader.ts \
+        cli/src/core/OpenCodeSessionDiscoverer.test.ts
+git commit -s -m "Extract SqliteHelpers from OpenCodeSessionDiscoverer
+
+Pulls withSqliteDb / hasNodeSqliteSupport / classifyScanError into a
+neutral file before adding Cursor as a second SQLite-based source.
+OpenCode keeps its old export names as @deprecated re-exports for
+backwards compatibility within this minor."
+```
+
+---
+
+## Task 2: Add `cursor` to `TranscriptSource` + config / status types
+
+**Files:**
+- Modify: `cli/src/Types.ts`
+- Modify: `cli/src/core/SessionTracker.ts`
+- Modify: `cli/src/core/SessionTracker.test.ts`
+
+- [ ] **Step 1: Extend `TranscriptSource` and add config / status fields in `Types.ts`**
+
+Open `cli/src/Types.ts`. Make these three edits:
+
+**Edit 1:** find the `TranscriptSource` definition (around line 8) and add `"cursor"`:
+
+```ts
+export type TranscriptSource = "claude" | "codex" | "gemini" | "opencode" | "cursor";
+```
+
+**Edit 2:** in `JolliMemoryConfig` (after the `openCodeEnabled` field), add:
+
+```ts
+	/** Enable Cursor Composer session discovery at post-commit time (default: auto-detect) */
+	readonly cursorEnabled?: boolean;
+```
+
+**Edit 3:** in `StatusInfo` (after the `openCodeEnabled` field, just before `globalConfigDir`), add:
+
+```ts
+	/** Whether Cursor data dir was detected (Cursor.app + state.vscdb + node:sqlite) */
+	readonly cursorDetected?: boolean;
+	/** Whether Cursor session discovery is enabled in config (undefined = auto-detect) */
+	readonly cursorEnabled?: boolean;
+	/**
+	 * Cursor DB scan failed with a real (non-ENOENT) error — corrupt, locked,
+	 * schema drift, or permission denied. UI surfaces this adjacent to the Cursor
+	 * row instead of silently rendering "0 sessions".
+	 */
+	readonly cursorScanError?: {
+		readonly kind: "corrupt" | "locked" | "permission" | "schema" | "unknown";
+		readonly message: string;
+	};
+```
+
+- [ ] **Step 2: Write failing test for cursor branch of `filterSessionsByEnabledIntegrations`**
+
+Open `cli/src/core/SessionTracker.test.ts`. Find the existing `filterSessionsByEnabledIntegrations` describe block and add these tests:
+
+```ts
+it("filters out cursor sessions when cursorEnabled === false", () => {
+	const sessions: SessionInfo[] = [
+		{ sessionId: "claude-1", transcriptPath: "/c.jsonl", updatedAt: "2026-05-03T00:00:00Z", source: "claude" },
+		{ sessionId: "cursor-1", transcriptPath: "/db.vscdb#abc", updatedAt: "2026-05-03T00:00:00Z", source: "cursor" },
+	];
+	const result = filterSessionsByEnabledIntegrations(sessions, { cursorEnabled: false });
+	expect(result).toEqual([sessions[0]]);
+});
+
+it("retains cursor sessions when cursorEnabled is undefined or true", () => {
+	const sessions: SessionInfo[] = [
+		{ sessionId: "cursor-1", transcriptPath: "/db.vscdb#abc", updatedAt: "2026-05-03T00:00:00Z", source: "cursor" },
+	];
+	expect(filterSessionsByEnabledIntegrations(sessions, {})).toEqual(sessions);
+	expect(filterSessionsByEnabledIntegrations(sessions, { cursorEnabled: true })).toEqual(sessions);
+});
+```
+
+- [ ] **Step 3: Run the new tests to confirm they fail**
+
+```bash
+npm run test -w @jolli.ai/cli -- src/core/SessionTracker.test.ts -t "filters out cursor"
+```
+
+Expected: FAIL — the cursor sessions are not filtered (current code has no cursor branch).
+
+- [ ] **Step 4: Add cursor branch to `filterSessionsByEnabledIntegrations`**
+
+Open `cli/src/core/SessionTracker.ts`. Find the function and add a cursor branch right after the `openCodeEnabled` check (around line 167):
+
+```ts
+	if (config.openCodeEnabled === false) {
+		filtered = filtered.filter((s) => s.source !== "opencode");
+	}
+	if (config.cursorEnabled === false) {
+		filtered = filtered.filter((s) => s.source !== "cursor");
+	}
+	return filtered;
+```
+
+- [ ] **Step 5: Re-run tests**
+
+```bash
+npm run test -w @jolli.ai/cli -- src/core/SessionTracker.test.ts
+npm run typecheck -w @jolli.ai/cli
+npm run lint -w @jolli.ai/cli
+```
+
+Expected: all pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add cli/src/Types.ts cli/src/core/SessionTracker.ts cli/src/core/SessionTracker.test.ts
+git commit -s -m "Add cursor literal to TranscriptSource and config types
+
+Threads the new cursor source through TranscriptSource, JolliMemoryConfig
+(cursorEnabled), StatusInfo (cursorDetected, cursorEnabled, cursorScanError),
+and the filter in SessionTracker. No runtime call sites yet — those follow
+in subsequent tasks."
+```
+
+---
+
+## Task 3: `CursorDetector.ts`
+
+**Files:**
+- Create: `cli/src/core/CursorDetector.ts`
+- Create: `cli/src/core/CursorDetector.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `cli/src/core/CursorDetector.test.ts`:
+
+```ts
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.spyOn(console, "log").mockImplementation(() => {});
+
+const { mockHomedir, mockPlatform } = vi.hoisted(() => ({
+	mockHomedir: vi.fn().mockReturnValue(""),
+	mockPlatform: vi.fn().mockReturnValue("darwin"),
+}));
+vi.mock("node:os", async (importOriginal) => {
+	const original = await importOriginal<typeof import("node:os")>();
+	return { ...original, homedir: mockHomedir, platform: mockPlatform };
+});
+
+const { mockSqliteSupport } = vi.hoisted(() => ({
+	mockSqliteSupport: vi.fn().mockReturnValue(true),
+}));
+vi.mock("./SqliteHelpers.js", async () => ({
+	hasNodeSqliteSupport: mockSqliteSupport,
+}));
+
+import { getCursorGlobalDbPath, isCursorInstalled } from "./CursorDetector.js";
+
+describe("isCursorInstalled (darwin)", () => {
+	let tmpHome: string;
+
+	beforeEach(async () => {
+		tmpHome = await mkdtemp(join(tmpdir(), "cursor-detector-"));
+		mockHomedir.mockReturnValue(tmpHome);
+		mockPlatform.mockReturnValue("darwin");
+		mockSqliteSupport.mockReturnValue(true);
+	});
+
+	afterEach(async () => {
+		await rm(tmpHome, { recursive: true, force: true });
+	});
+
+	it("returns false when neither app nor data dir exists", async () => {
+		expect(await isCursorInstalled()).toBe(false);
+	});
+
+	it("returns false when data db does not exist", async () => {
+		await mkdir(join(tmpHome, "Library/Application Support/Cursor/User/globalStorage"), { recursive: true });
+		expect(await isCursorInstalled()).toBe(false);
+	});
+
+	it("returns true when data db exists and Node has SQLite support", async () => {
+		const globalDir = join(tmpHome, "Library/Application Support/Cursor/User/globalStorage");
+		await mkdir(globalDir, { recursive: true });
+		await writeFile(join(globalDir, "state.vscdb"), "stub");
+		expect(await isCursorInstalled()).toBe(true);
+	});
+
+	it("returns false when Node lacks SQLite support, even if data exists", async () => {
+		const globalDir = join(tmpHome, "Library/Application Support/Cursor/User/globalStorage");
+		await mkdir(globalDir, { recursive: true });
+		await writeFile(join(globalDir, "state.vscdb"), "stub");
+		mockSqliteSupport.mockReturnValue(false);
+		expect(await isCursorInstalled()).toBe(false);
+	});
+});
+
+describe("isCursorInstalled (linux)", () => {
+	let tmpHome: string;
+
+	beforeEach(async () => {
+		tmpHome = await mkdtemp(join(tmpdir(), "cursor-detector-"));
+		mockHomedir.mockReturnValue(tmpHome);
+		mockPlatform.mockReturnValue("linux");
+		mockSqliteSupport.mockReturnValue(true);
+	});
+
+	afterEach(async () => {
+		await rm(tmpHome, { recursive: true, force: true });
+	});
+
+	it("uses ~/.config/Cursor on linux", async () => {
+		const globalDir = join(tmpHome, ".config/Cursor/User/globalStorage");
+		await mkdir(globalDir, { recursive: true });
+		await writeFile(join(globalDir, "state.vscdb"), "stub");
+		expect(await isCursorInstalled()).toBe(true);
+	});
+});
+
+describe("getCursorGlobalDbPath", () => {
+	beforeEach(() => {
+		mockHomedir.mockReturnValue("/home/user");
+	});
+
+	it("returns the darwin path", () => {
+		mockPlatform.mockReturnValue("darwin");
+		expect(getCursorGlobalDbPath()).toBe(
+			"/home/user/Library/Application Support/Cursor/User/globalStorage/state.vscdb",
+		);
+	});
+
+	it("returns the linux path", () => {
+		mockPlatform.mockReturnValue("linux");
+		expect(getCursorGlobalDbPath()).toBe("/home/user/.config/Cursor/User/globalStorage/state.vscdb");
+	});
+
+	it("returns a Cursor-rooted path on win32", () => {
+		mockPlatform.mockReturnValue("win32");
+		const path = getCursorGlobalDbPath();
+		expect(path.endsWith("Cursor/User/globalStorage/state.vscdb")).toBe(true);
+	});
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+npm run test -w @jolli.ai/cli -- src/core/CursorDetector.test.ts
+```
+
+Expected: FAIL with "Cannot find module './CursorDetector.js'".
+
+- [ ] **Step 3: Implement `CursorDetector.ts`**
+
+Create `cli/src/core/CursorDetector.ts` with:
+
+1. A module docstring noting platform paths:
+   - darwin: `~/Library/Application Support/Cursor/User/globalStorage/state.vscdb`
+   - linux: `~/.config/Cursor/User/globalStorage/state.vscdb`
+   - win32: `%APPDATA%/Cursor/User/globalStorage/state.vscdb`
+2. Imports: `stat` from `node:fs/promises`, `homedir`, `platform` from `node:os`, `join` from `node:path`, `createLogger` from `../Logger.js`, `hasNodeSqliteSupport` from `./SqliteHelpers.js`.
+3. A private `getCursorUserDataDir(home = homedir())` that branches on `platform()`:
+   - `darwin` → `join(home, "Library", "Application Support", "Cursor")`
+   - `win32` → `join(process.env.APPDATA ?? join(home, "AppData", "Roaming"), "Cursor")`
+   - else (linux/unix) → `join(home, ".config", "Cursor")`
+4. Exported `getCursorGlobalDbPath(home?)` returning `join(getCursorUserDataDir(home), "User", "globalStorage", "state.vscdb")`.
+5. Exported `getCursorWorkspaceStorageDir(home?)` returning `join(getCursorUserDataDir(home), "User", "workspaceStorage")`.
+6. Exported async `isCursorInstalled()`:
+   - First, if `!hasNodeSqliteSupport()`: log and return `false`.
+   - Then `stat(getCursorGlobalDbPath())`; on success return `fileStat.isFile()`; on any error return `false`.
+
+The implementation closely mirrors `cli/src/core/ClaudeDetector.ts` and the `isOpenCodeInstalled` pattern in `cli/src/core/OpenCodeSessionDiscoverer.ts` — refer to those for exact prose style.
+
+- [ ] **Step 4: Re-run the tests**
+
+```bash
+npm run test -w @jolli.ai/cli -- src/core/CursorDetector.test.ts
+npm run typecheck -w @jolli.ai/cli
+npm run lint -w @jolli.ai/cli
+```
+
+Expected: all green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cli/src/core/CursorDetector.ts cli/src/core/CursorDetector.test.ts
+git commit -s -m "Add CursorDetector (one-shot installation probe)
+
+Checks Cursor's global state.vscdb across darwin/linux/win32 and gates
+on hasNodeSqliteSupport() so VS Code-host runtimes (Node 18) report
+'not installed' rather than 'detected but unreadable'."
+```
+
+---
+
+## Task 4: `CursorSessionDiscoverer.ts` (β′ algorithm)
+
+**Files:**
+- Create: `cli/src/core/CursorSessionDiscoverer.ts`
+- Create: `cli/src/core/CursorSessionDiscoverer.test.ts`
+
+This task is the heart of the integration. β′ algorithm: workspace lookup → anchor pointers → time-window union. We build it bottom-up: helpers first, public API last.
+
+**Reference:** `cli/src/core/OpenCodeSessionDiscoverer.ts` for the overall structure (pre-flight stat, withSqliteDb, scan-result with optional error).
+
+- [ ] **Step 1: Write the fixture-builder + first failing test**
+
+Create `cli/src/core/CursorSessionDiscoverer.test.ts`. Begin with the fixture helpers and the first test (workspace not found):
+
+```ts
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.spyOn(console, "log").mockImplementation(() => {});
+vi.spyOn(console, "warn").mockImplementation(() => {});
+vi.spyOn(console, "error").mockImplementation(() => {});
+
+const { mockHomedir, mockPlatform } = vi.hoisted(() => ({
+	mockHomedir: vi.fn().mockReturnValue(""),
+	mockPlatform: vi.fn().mockReturnValue("darwin"),
+}));
+vi.mock("node:os", async (importOriginal) => {
+	const original = await importOriginal<typeof import("node:os")>();
+	return { ...original, homedir: mockHomedir, platform: mockPlatform };
+});
+
+import { discoverCursorSessions, scanCursorSessions } from "./CursorSessionDiscoverer.js";
+
+const CURSOR_DDL = [
+	`CREATE TABLE ItemTable (key TEXT UNIQUE ON CONFLICT REPLACE, value BLOB)`,
+	`CREATE TABLE cursorDiskKV (key TEXT UNIQUE ON CONFLICT REPLACE, value BLOB)`,
+];
+
+interface ComposerFixture {
+	composerId: string;
+	name?: string;
+	createdAtMs: number;
+	lastUpdatedAtMs: number;
+	bubbleHeaders?: ReadonlyArray<{ bubbleId: string; type: number }>;
+}
+
+function createCursorGlobalDb(dbPath: string, composers: ReadonlyArray<ComposerFixture>): void {
+	const db = new DatabaseSync(dbPath);
+	for (const sql of CURSOR_DDL) db.prepare(sql).run();
+	for (const c of composers) {
+		const value = JSON.stringify({
+			_v: 16,
+			composerId: c.composerId,
+			name: c.name ?? "Untitled",
+			createdAt: c.createdAtMs,
+			lastUpdatedAt: c.lastUpdatedAtMs,
+			fullConversationHeadersOnly: (c.bubbleHeaders ?? []).map((h) => ({ ...h, grouping: null })),
+			status: "completed",
+			unifiedMode: "agent",
+		});
+		db.prepare("INSERT INTO cursorDiskKV (key, value) VALUES (?, ?)").run(`composerData:${c.composerId}`, value);
+	}
+	db.close();
+}
+
+function createCursorWorkspaceDb(
+	dbPath: string,
+	pointers: { lastFocusedComposerIds?: string[]; selectedComposerIds?: string[] } | null,
+): void {
+	const db = new DatabaseSync(dbPath);
+	for (const sql of CURSOR_DDL) db.prepare(sql).run();
+	if (pointers) {
+		const value = JSON.stringify({
+			lastFocusedComposerIds: pointers.lastFocusedComposerIds ?? [],
+			selectedComposerIds: pointers.selectedComposerIds ?? [],
+			hasMigratedComposerData: true,
+			hasMigratedMultipleComposers: true,
+		});
+		db.prepare("INSERT INTO ItemTable (key, value) VALUES (?, ?)").run("composer.composerData", value);
+	}
+	db.close();
+}
+
+async function setupCursorHome(
+	tmpHome: string,
+	opts: {
+		globalComposers: ReadonlyArray<ComposerFixture>;
+		workspaces: ReadonlyArray<{
+			folder: string;
+			pointers: { lastFocusedComposerIds?: string[]; selectedComposerIds?: string[] } | null;
+		}>;
+	},
+): Promise<void> {
+	const userDir = join(tmpHome, "Library/Application Support/Cursor/User");
+	await mkdir(join(userDir, "globalStorage"), { recursive: true });
+	createCursorGlobalDb(join(userDir, "globalStorage", "state.vscdb"), opts.globalComposers);
+
+	let i = 0;
+	for (const ws of opts.workspaces) {
+		const wsHash = `ws-${String(i).padStart(8, "0")}`;
+		const wsDir = join(userDir, "workspaceStorage", wsHash);
+		await mkdir(wsDir, { recursive: true });
+		await writeFile(join(wsDir, "workspace.json"), JSON.stringify({ folder: ws.folder }));
+		createCursorWorkspaceDb(join(wsDir, "state.vscdb"), ws.pointers);
+		i++;
+	}
+}
+
+describe("discoverCursorSessions", () => {
+	let tmpHome: string;
+
+	beforeEach(async () => {
+		tmpHome = await mkdtemp(join(tmpdir(), "cursor-disc-"));
+		mockHomedir.mockReturnValue(tmpHome);
+		mockPlatform.mockReturnValue("darwin");
+	});
+
+	afterEach(async () => {
+		await rm(tmpHome, { recursive: true, force: true });
+	});
+
+	it("returns [] when projectDir does not match any workspace", async () => {
+		await setupCursorHome(tmpHome, { globalComposers: [], workspaces: [] });
+		const sessions = await discoverCursorSessions("/Users/flyer/jolli/code/somewhere");
+		expect(sessions).toEqual([]);
+	});
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+```bash
+npm run test -w @jolli.ai/cli -- src/core/CursorSessionDiscoverer.test.ts
+```
+
+Expected: FAIL — `Cannot find module './CursorSessionDiscoverer.js'`.
+
+- [ ] **Step 3: Implement `CursorSessionDiscoverer.ts`**
+
+Create `cli/src/core/CursorSessionDiscoverer.ts`. Structure:
+
+**Module docstring** — explain the storage layout (global vs per-workspace), the β′ algorithm (4 steps), and the synthetic transcript path format `<globalDbPath>#<composerId>`.
+
+**Imports:**
+
+```ts
+import { readFile, readdir, stat } from "node:fs/promises";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { createLogger } from "../Logger.js";
+import type { SessionInfo } from "../Types.js";
+import { getCursorGlobalDbPath, getCursorWorkspaceStorageDir } from "./CursorDetector.js";
+import { classifyScanError, type SqliteScanError, withSqliteDb } from "./SqliteHelpers.js";
+```
+
+**Constants:**
+
+```ts
+const log = createLogger("CursorDiscoverer");
+const SESSION_STALE_MS = 48 * 60 * 60 * 1000;
+```
+
+**Public types:**
+
+```ts
+export interface CursorScanResult {
+	readonly sessions: ReadonlyArray<SessionInfo>;
+	readonly error?: SqliteScanError;
+}
+```
+
+**Public API — `scanCursorSessions(projectDir)`** (the workhorse). Algorithm:
+
+1. Call `findCursorWorkspaceHash(projectDir)`. If no match, return `{ sessions: [] }`.
+2. `stat(globalDbPath)` to pre-flight; on `ENOENT`, return `{ sessions: [] }`; on other errors, classify and return with error.
+3. Call `readCursorAnchorComposerIds(wsHash)` → `Set<string>` of anchor IDs.
+4. Compute `cutoffMs = Date.now() - SESSION_STALE_MS`.
+5. Open the global db with `withSqliteDb`. SELECT `key, value FROM cursorDiskKV WHERE key LIKE 'composerData:%'`. For each row:
+   - Parse JSON. Extract `composerId` and `lastUpdatedAt`.
+   - Compute `inAnchor = anchorSet.has(composerId)` and `inWindow = lastUpdatedAt >= cutoffMs`.
+   - Skip if neither.
+   - Skip rows with non-finite `lastUpdatedAt` (with warn log).
+   - Otherwise push a `SessionInfo`:
+     - `sessionId: composerId`
+     - `transcriptPath: <globalDbPath>#<composerId>` (synthetic — same pattern as OpenCode)
+     - `updatedAt: new Date(lastUpdatedAt).toISOString()`
+     - `source: "cursor"`
+   - Add to seenIds set to dedupe.
+6. Return `{ sessions: out }`.
+7. On any thrown error, call `classifyScanError`. Null → return `{ sessions: [] }` (TOCTOU); else log and return `{ sessions: [], error }`.
+
+**Public API — `discoverCursorSessions(projectDir)`** — thin wrapper returning just `result.sessions`.
+
+**Internal helper — `findCursorWorkspaceHash(projectDir)`:**
+
+1. Read directory entries of `getCursorWorkspaceStorageDir()`. On error return `null`.
+2. Compute `target = normalizePathForMatch(projectDir)`.
+3. For each entry, read `<entry>/workspace.json`. Parse JSON, extract `folder` URI. Skip if missing or not `file://`.
+4. Convert URI to absolute path with `fileURLToPath(folderUri)`.
+5. If `normalizePathForMatch(folderPath) === target`, return `entry`.
+6. Return `null` if nothing matches.
+
+**Internal helper — `readCursorAnchorComposerIds(wsHash)`:**
+
+1. Path = `<workspaceStorageDir>/<wsHash>/state.vscdb`. `stat()` first; on error return `[]`.
+2. Open with `withSqliteDb`. SELECT `value FROM ItemTable WHERE key = 'composer.composerData' LIMIT 1`. If absent, return `[]`.
+3. Parse JSON. Union of `lastFocusedComposerIds` and `selectedComposerIds`. Return as array.
+4. On any thrown error, log warn and return `[]`.
+
+**Internal helper — `normalizePathForMatch(p)`:**
+
+```ts
+function normalizePathForMatch(p: string): string {
+	const trimmed = p.replace(/\/+$/, "");
+	return process.platform === "darwin" || process.platform === "win32" ? trimmed.toLowerCase() : trimmed;
+}
+```
+
+- [ ] **Step 4: Re-run the first test**
+
+```bash
+npm run test -w @jolli.ai/cli -- src/core/CursorSessionDiscoverer.test.ts -t "does not match any workspace"
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Add the remaining test cases**
+
+Append to `CursorSessionDiscoverer.test.ts` inside the existing `describe("discoverCursorSessions", ...)`:
+
+```ts
+	it("returns the anchor composer when workspace pointer is set, even outside time window", async () => {
+		const ancientTs = Date.now() - 365 * 24 * 60 * 60 * 1000;
+		await setupCursorHome(tmpHome, {
+			globalComposers: [
+				{ composerId: "anchor-1", createdAtMs: ancientTs, lastUpdatedAtMs: ancientTs },
+			],
+			workspaces: [
+				{
+					folder: "file:///Users/flyer/work/proj-a",
+					pointers: { lastFocusedComposerIds: ["anchor-1"] },
+				},
+			],
+		});
+
+		const sessions = await discoverCursorSessions("/Users/flyer/work/proj-a");
+		expect(sessions).toHaveLength(1);
+		expect(sessions[0]).toMatchObject({ sessionId: "anchor-1", source: "cursor" });
+		expect(sessions[0].transcriptPath).toContain("#anchor-1");
+	});
+
+	it("includes time-window composers in addition to anchors, deduped", async () => {
+		const fresh = Date.now() - 60 * 1000;
+		const stale = Date.now() - 100 * 60 * 60 * 1000;
+		await setupCursorHome(tmpHome, {
+			globalComposers: [
+				{ composerId: "anchor-1", createdAtMs: fresh, lastUpdatedAtMs: fresh },
+				{ composerId: "fresh-2", createdAtMs: fresh, lastUpdatedAtMs: fresh },
+				{ composerId: "stale-3", createdAtMs: stale, lastUpdatedAtMs: stale },
+			],
+			workspaces: [
+				{
+					folder: "file:///Users/flyer/work/proj-a",
+					pointers: { lastFocusedComposerIds: ["anchor-1"] },
+				},
+			],
+		});
+
+		const sessions = await discoverCursorSessions("/Users/flyer/work/proj-a");
+		const ids = sessions.map((s) => s.sessionId).sort();
+		expect(ids).toEqual(["anchor-1", "fresh-2"]);
+	});
+
+	it("URL-decodes file:// folder paths and matches case-insensitively on darwin", async () => {
+		await setupCursorHome(tmpHome, {
+			globalComposers: [{ composerId: "c-1", createdAtMs: Date.now(), lastUpdatedAtMs: Date.now() }],
+			workspaces: [
+				{
+					folder: "file:///Users/Flyer/Code%20Folder/Proj",
+					pointers: { lastFocusedComposerIds: ["c-1"] },
+				},
+			],
+		});
+
+		const sessions = await discoverCursorSessions("/users/flyer/code folder/proj");
+		expect(sessions).toHaveLength(1);
+	});
+
+	it("returns empty when no anchor and no fresh composers, even if workspace matches", async () => {
+		const stale = Date.now() - 100 * 60 * 60 * 1000;
+		await setupCursorHome(tmpHome, {
+			globalComposers: [{ composerId: "stale-1", createdAtMs: stale, lastUpdatedAtMs: stale }],
+			workspaces: [
+				{
+					folder: "file:///Users/flyer/work/proj-a",
+					pointers: null,
+				},
+			],
+		});
+
+		const sessions = await discoverCursorSessions("/Users/flyer/work/proj-a");
+		expect(sessions).toEqual([]);
+	});
+
+	it("surfaces a corrupt-DB error via scanCursorSessions", async () => {
+		const userDir = join(tmpHome, "Library/Application Support/Cursor/User");
+		await mkdir(join(userDir, "globalStorage"), { recursive: true });
+		await writeFile(join(userDir, "globalStorage", "state.vscdb"), "this is not a sqlite file");
+
+		const wsDir = join(userDir, "workspaceStorage", "ws-00000000");
+		await mkdir(wsDir, { recursive: true });
+		await writeFile(join(wsDir, "workspace.json"), JSON.stringify({ folder: "file:///Users/flyer/work/proj-a" }));
+		await writeFile(join(wsDir, "state.vscdb"), "garbage too");
+
+		const result = await scanCursorSessions("/Users/flyer/work/proj-a");
+		expect(result.sessions).toEqual([]);
+		if (result.error) {
+			expect(["corrupt", "permission", "unknown"]).toContain(result.error.kind);
+		}
+	});
+```
+
+- [ ] **Step 6: Run the full discoverer test suite**
+
+```bash
+npm run test -w @jolli.ai/cli -- src/core/CursorSessionDiscoverer.test.ts
+npm run typecheck -w @jolli.ai/cli
+npm run lint -w @jolli.ai/cli
+```
+
+Expected: all green. If any test fails, read the failure and fix the implementation — do not weaken the test.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add cli/src/core/CursorSessionDiscoverer.ts cli/src/core/CursorSessionDiscoverer.test.ts
+git commit -s -m "Add CursorSessionDiscoverer with β' attribution
+
+Implements the workspace pointer + 48h time window union from the
+Cursor support spec. Workspace lookup goes through workspace.json's
+folder URI; anchor IDs come from each workspace's composer.composerData;
+time-window IDs come from the global cursorDiskKV table. Synthetic
+transcript path uses the OpenCode pattern (<dbPath>#<composerId>)."
+```
+
+---
+
+## Task 5: `CursorTranscriptReader.ts`
+
+**Files:**
+- Create: `cli/src/core/CursorTranscriptReader.ts`
+- Create: `cli/src/core/CursorTranscriptReader.test.ts`
+
+The reader takes a synthetic path `<globalDbPath>#<composerId>` and produces `TranscriptEntry[]` by:
+1. Reading `composerData:<composerId>` to get the ordered `fullConversationHeadersOnly` list of bubbleIds.
+2. Reading each `bubbleId:<composerId>:<bubbleId>` row, mapping `bubble.type` to role, and using `bubble.text` as content.
+3. Supporting cursor-based resumption (skip already-consumed bubbles) and `beforeTimestamp` cutoff.
+
+**Bubble type → role mapping:** Empirically `1 → human`, `2 → assistant`. The spec mandates a fixture-based confirmation in Step 5 below.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `cli/src/core/CursorTranscriptReader.test.ts`:
+
+```ts
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.spyOn(console, "log").mockImplementation(() => {});
+vi.spyOn(console, "warn").mockImplementation(() => {});
+
+import { readCursorTranscript } from "./CursorTranscriptReader.js";
+
+const CURSOR_DDL = [
+	`CREATE TABLE ItemTable (key TEXT UNIQUE ON CONFLICT REPLACE, value BLOB)`,
+	`CREATE TABLE cursorDiskKV (key TEXT UNIQUE ON CONFLICT REPLACE, value BLOB)`,
+];
+
+interface BubbleFixture {
+	bubbleId: string;
+	type: 1 | 2;
+	text: string;
+	createdAt: string;
+}
+
+function createCursorTranscriptDb(
+	dbPath: string,
+	composerId: string,
+	bubbles: ReadonlyArray<BubbleFixture>,
+): void {
+	const db = new DatabaseSync(dbPath);
+	for (const sql of CURSOR_DDL) db.prepare(sql).run();
+
+	const composerData = JSON.stringify({
+		_v: 16,
+		composerId,
+		name: "Test composer",
+		createdAt: Date.now(),
+		lastUpdatedAt: Date.now(),
+		fullConversationHeadersOnly: bubbles.map((b) => ({ bubbleId: b.bubbleId, type: b.type, grouping: null })),
+		status: "completed",
+		unifiedMode: "agent",
+	});
+	db.prepare("INSERT INTO cursorDiskKV (key, value) VALUES (?, ?)").run(
+		`composerData:${composerId}`,
+		composerData,
+	);
+
+	for (const b of bubbles) {
+		const bubbleData = JSON.stringify({
+			_v: 3,
+			bubbleId: b.bubbleId,
+			type: b.type,
+			text: b.text,
+			createdAt: b.createdAt,
+		});
+		db.prepare("INSERT INTO cursorDiskKV (key, value) VALUES (?, ?)").run(
+			`bubbleId:${composerId}:${b.bubbleId}`,
+			bubbleData,
+		);
+	}
+	db.close();
+}
+
+describe("readCursorTranscript", () => {
+	let tmpDir: string;
+	let dbPath: string;
+	const composerId = "11111111-2222-3333-4444-555555555555";
+
+	beforeEach(async () => {
+		tmpDir = await mkdtemp(join(tmpdir(), "cursor-tr-"));
+		await mkdir(tmpDir, { recursive: true });
+		dbPath = join(tmpDir, "state.vscdb");
+	});
+
+	afterEach(async () => {
+		await rm(tmpDir, { recursive: true, force: true });
+	});
+
+	it("rejects malformed synthetic paths", async () => {
+		await expect(readCursorTranscript("/no/hash/in/path")).rejects.toThrow(/missing #composerId/);
+		await expect(readCursorTranscript("#only-id")).rejects.toThrow(/empty/);
+		await expect(readCursorTranscript("/path#")).rejects.toThrow(/empty/);
+	});
+
+	it("returns ordered user/assistant entries with type→role mapping", async () => {
+		createCursorTranscriptDb(dbPath, composerId, [
+			{ bubbleId: "b1", type: 1, text: "what is 2 + 2?", createdAt: "2026-05-03T10:00:00.000Z" },
+			{ bubbleId: "b2", type: 2, text: "2 + 2 = 4.", createdAt: "2026-05-03T10:00:01.000Z" },
+			{ bubbleId: "b3", type: 1, text: "thanks", createdAt: "2026-05-03T10:00:02.000Z" },
+		]);
+
+		const result = await readCursorTranscript(`${dbPath}#${composerId}`);
+
+		expect(result.entries).toEqual([
+			{ role: "human", content: "what is 2 + 2?", timestamp: "2026-05-03T10:00:00.000Z" },
+			{ role: "assistant", content: "2 + 2 = 4.", timestamp: "2026-05-03T10:00:01.000Z" },
+			{ role: "human", content: "thanks", timestamp: "2026-05-03T10:00:02.000Z" },
+		]);
+		expect(result.newCursor.lineNumber).toBe(3);
+		expect(result.totalLinesRead).toBe(3);
+	});
+
+	it("merges consecutive same-role entries", async () => {
+		createCursorTranscriptDb(dbPath, composerId, [
+			{ bubbleId: "b1", type: 2, text: "Looking at the file...", createdAt: "2026-05-03T10:00:00.000Z" },
+			{ bubbleId: "b2", type: 2, text: "I see the issue.", createdAt: "2026-05-03T10:00:01.000Z" },
+			{ bubbleId: "b3", type: 1, text: "what is it?", createdAt: "2026-05-03T10:00:02.000Z" },
+		]);
+
+		const result = await readCursorTranscript(`${dbPath}#${composerId}`);
+		expect(result.entries).toHaveLength(2);
+		expect(result.entries[0].role).toBe("assistant");
+		expect(result.entries[0].content).toBe("Looking at the file...\n\nI see the issue.");
+		expect(result.entries[1].role).toBe("human");
+	});
+
+	it("skips bubbles with empty text", async () => {
+		createCursorTranscriptDb(dbPath, composerId, [
+			{ bubbleId: "b1", type: 1, text: "hi", createdAt: "2026-05-03T10:00:00.000Z" },
+			{ bubbleId: "b2", type: 2, text: "", createdAt: "2026-05-03T10:00:01.000Z" },
+			{ bubbleId: "b3", type: 1, text: "ping", createdAt: "2026-05-03T10:00:02.000Z" },
+		]);
+
+		const result = await readCursorTranscript(`${dbPath}#${composerId}`);
+		expect(result.entries.map((e) => e.role)).toEqual(["human"]);
+	});
+
+	it("skips bubbles whose type does not map to a role", async () => {
+		createCursorTranscriptDb(dbPath, composerId, [
+			{ bubbleId: "b1", type: 1, text: "hi", createdAt: "2026-05-03T10:00:00.000Z" },
+			{ bubbleId: "b2", type: 99 as unknown as 1, text: "system noise", createdAt: "2026-05-03T10:00:01.000Z" },
+		]);
+		const result = await readCursorTranscript(`${dbPath}#${composerId}`);
+		expect(result.entries).toHaveLength(1);
+		expect(result.entries[0].role).toBe("human");
+	});
+
+	it("skips already-read bubbles when given a cursor", async () => {
+		createCursorTranscriptDb(dbPath, composerId, [
+			{ bubbleId: "b1", type: 1, text: "first", createdAt: "2026-05-03T10:00:00.000Z" },
+			{ bubbleId: "b2", type: 2, text: "second", createdAt: "2026-05-03T10:00:01.000Z" },
+			{ bubbleId: "b3", type: 1, text: "third", createdAt: "2026-05-03T10:00:02.000Z" },
+		]);
+
+		const result = await readCursorTranscript(`${dbPath}#${composerId}`, {
+			transcriptPath: `${dbPath}#${composerId}`,
+			lineNumber: 2,
+			updatedAt: "2026-05-03T10:00:01.000Z",
+		});
+		expect(result.entries).toEqual([
+			{ role: "human", content: "third", timestamp: "2026-05-03T10:00:02.000Z" },
+		]);
+		expect(result.newCursor.lineNumber).toBe(3);
+	});
+
+	it("respects beforeTimestamp cutoff and advances cursor only to last consumed", async () => {
+		createCursorTranscriptDb(dbPath, composerId, [
+			{ bubbleId: "b1", type: 1, text: "first", createdAt: "2026-05-03T10:00:00.000Z" },
+			{ bubbleId: "b2", type: 2, text: "second", createdAt: "2026-05-03T10:00:01.000Z" },
+			{ bubbleId: "b3", type: 1, text: "after-cutoff", createdAt: "2026-05-03T10:00:05.000Z" },
+		]);
+
+		const result = await readCursorTranscript(
+			`${dbPath}#${composerId}`,
+			null,
+			"2026-05-03T10:00:01.500Z",
+		);
+		expect(result.entries.map((e) => e.content)).toEqual(["first", "second"]);
+		expect(result.newCursor.lineNumber).toBe(2);
+	});
+
+	it("throws a friendly error when the composer is not in the DB", async () => {
+		createCursorTranscriptDb(dbPath, composerId, []);
+		await expect(readCursorTranscript(`${dbPath}#missing-id`)).rejects.toThrow(/Cannot read Cursor session/);
+	});
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+```bash
+npm run test -w @jolli.ai/cli -- src/core/CursorTranscriptReader.test.ts
+```
+
+Expected: FAIL with "Cannot find module './CursorTranscriptReader.js'".
+
+- [ ] **Step 3: Implement `CursorTranscriptReader.ts`**
+
+Create `cli/src/core/CursorTranscriptReader.ts`. Structure:
+
+**Module docstring** describing the storage layout, the `bubble.type` mapping (1=human, 2=assistant, others skipped), and that the cursor reuses `lineNumber` to track bubble index (same pattern as `OpenCodeTranscriptReader`).
+
+**Imports:**
+
+```ts
+import { createLogger } from "../Logger.js";
+import type { TranscriptCursor, TranscriptEntry, TranscriptReadResult } from "../Types.js";
+import { withSqliteDb } from "./SqliteHelpers.js";
+import { mergeConsecutiveEntries } from "./TranscriptReader.js";
+```
+
+**Constants and types:**
+
+```ts
+const log = createLogger("CursorTranscriptReader");
+
+const BUBBLE_TYPE_TO_ROLE: Readonly<Record<number, "human" | "assistant">> = {
+	1: "human",
+	2: "assistant",
+};
+
+interface ConversationHeader {
+	readonly bubbleId: string;
+	readonly type?: number;
+}
+
+interface ComposerDataRow {
+	readonly fullConversationHeadersOnly?: ReadonlyArray<ConversationHeader>;
+}
+
+interface BubbleRow {
+	readonly type?: number;
+	readonly text?: string;
+	readonly createdAt?: string;
+}
+```
+
+**Public function — `readCursorTranscript(transcriptPath, cursor?, beforeTimestamp?)`:**
+
+1. `parseSyntheticPath(transcriptPath)` → `{ dbPath, composerId }`. (Throw on missing/empty `#`.)
+2. `startIndex = cursor?.lineNumber ?? 0`.
+3. `cutoffTime = beforeTimestamp ? Date.parse(beforeTimestamp) : undefined`.
+4. Open the db with `withSqliteDb`. Inside the callback:
+   - SELECT `value FROM cursorDiskKV WHERE key = 'composerData:<id>' LIMIT 1`. Throw `Composer ${composerId} not found in database` if missing.
+   - Parse JSON into `ComposerDataRow`. Throw on parse failure.
+   - `headers = composer.fullConversationHeadersOnly ?? []`.
+   - Slice `headers` from `startIndex` onwards.
+   - For each header in the slice:
+     - SELECT the matching `bubbleId:<id>:<bubbleId>` row. Skip if missing (advance index but no entry).
+     - Parse JSON → `BubbleRow`. Skip if parse fails.
+     - `type = bubble.type ?? header.type`. `role = BUBBLE_TYPE_TO_ROLE[type]`. `text = (bubble.text ?? "").trim()`. `timestamp = bubble.createdAt`.
+     - If `cutoffTime` set and `timestamp` parses to a number after the cutoff, **break** the loop (do not advance index past this point).
+     - If `role` is defined and `text.length > 0`, push `{ role, content: text, timestamp }`.
+     - Advance `lastConsumedIndex = startIndex + i + 1`.
+   - Return `{ rawEntries, totalBubbles: headers.length, lastConsumedIndex }`.
+5. Outside the callback, `entries = mergeConsecutiveEntries(rawEntries)`.
+6. Build `newCursor`: `lineNumber = beforeTimestamp ? lastConsumedIndex : totalBubbles`.
+7. Return `{ entries, newCursor, totalLinesRead: lastConsumedIndex - startIndex }`.
+8. On any thrown error, log and rethrow as `Error("Cannot read Cursor session: " + composerId)`.
+
+**Internal helper — `parseSyntheticPath(transcriptPath)`:**
+
+- `hashIndex = transcriptPath.lastIndexOf("#")`. Throw if `-1` with "missing #composerId".
+- `dbPath = substring(0, hashIndex)`, `composerId = substring(hashIndex + 1)`.
+- Throw if either is empty (separate "empty" message).
+
+- [ ] **Step 4: Re-run the reader test suite**
+
+```bash
+npm run test -w @jolli.ai/cli -- src/core/CursorTranscriptReader.test.ts
+npm run typecheck -w @jolli.ai/cli
+npm run lint -w @jolli.ai/cli
+```
+
+Expected: all green.
+
+- [ ] **Step 5: Real-Cursor smoke verification (manual, before commit)**
+
+The plan author confirmed `type:1=user, type:2=assistant` empirically during the design phase. Verify this still holds in your local Cursor before merging:
+
+1. In Cursor, open any project and start a new Composer chat.
+2. Send one user message ("hello").
+3. Wait for the assistant reply.
+4. From a terminal:
+
+```bash
+sqlite3 "$HOME/Library/Application Support/Cursor/User/globalStorage/state.vscdb" \
+  "SELECT key, json_extract(value, '\$.type'), substr(json_extract(value, '\$.text'), 1, 40) \
+   FROM cursorDiskKV WHERE key LIKE 'bubbleId:%' ORDER BY rowid DESC LIMIT 4;"
+```
+
+Expected: rows where the user's "hello" has `type=1` and the assistant's reply has `type=2`. If reversed or different, update `BUBBLE_TYPE_TO_ROLE` in `CursorTranscriptReader.ts` and re-run unit tests before committing.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add cli/src/core/CursorTranscriptReader.ts cli/src/core/CursorTranscriptReader.test.ts
+git commit -s -m "Add CursorTranscriptReader
+
+Reads composerData -> fullConversationHeadersOnly index, then per-bubble
+rows from cursorDiskKV. Maps bubble.type 1 -> human, 2 -> assistant;
+unknown types skipped. Supports cursor-based resume and beforeTimestamp
+cutoff (matches OpenCodeTranscriptReader semantics)."
+```
+
+---
+
+## Task 6: Wire `QueueWorker` discoverer fan-out + reader dispatch
+
+**Files:**
+- Modify: `cli/src/hooks/QueueWorker.ts`
+
+The Worker has two relevant points:
+- `loadSessionTranscripts` — discovers sessions from each enabled source.
+- `readAllTranscripts` — dispatches to the right reader based on `session.source`.
+
+- [ ] **Step 1: Add the imports**
+
+At the top of `cli/src/hooks/QueueWorker.ts`, add (next to the OpenCode imports):
+
+```ts
+import { isCursorInstalled } from "../core/CursorDetector.js";
+import { discoverCursorSessions } from "../core/CursorSessionDiscoverer.js";
+import { readCursorTranscript } from "../core/CursorTranscriptReader.js";
+```
+
+- [ ] **Step 2: Add cursor discovery to `loadSessionTranscripts`**
+
+Find the existing OpenCode discovery block in `loadSessionTranscripts` (around line 1418-1426):
+
+```ts
+	// Discover OpenCode sessions (on-demand SQLite scan)
+	if (config.openCodeEnabled !== false && (await isOpenCodeInstalled())) {
+		const openCodeSessions = await discoverOpenCodeSessions(cwd);
+		if (openCodeSessions.length > 0) {
+			allSessions = [...allSessions, ...openCodeSessions];
+			log.info("Discovered %d OpenCode session(s)", openCodeSessions.length);
+		}
+	}
+```
+
+Add a parallel cursor block immediately after:
+
+```ts
+	// Discover Cursor Composer sessions (on-demand SQLite scan from globalStorage)
+	if (config.cursorEnabled !== false && (await isCursorInstalled())) {
+		const cursorSessions = await discoverCursorSessions(cwd);
+		if (cursorSessions.length > 0) {
+			allSessions = [...allSessions, ...cursorSessions];
+			log.info("Discovered %d Cursor session(s)", cursorSessions.length);
+		}
+	}
+```
+
+- [ ] **Step 3: Add the cursor branch to `readAllTranscripts` dispatch**
+
+In the same file, find the dispatch block in `readAllTranscripts` (around line 1466-1472):
+
+```ts
+		if (source === "gemini") {
+			result = await readGeminiTranscript(session.transcriptPath, cursor, beforeTimestamp);
+		} else if (source === "opencode") {
+			result = await readOpenCodeTranscript(session.transcriptPath, cursor, beforeTimestamp);
+		} else {
+			result = await readTranscript(session.transcriptPath, cursor, getParserForSource(source), beforeTimestamp);
+		}
+```
+
+Replace with:
+
+```ts
+		if (source === "gemini") {
+			result = await readGeminiTranscript(session.transcriptPath, cursor, beforeTimestamp);
+		} else if (source === "opencode") {
+			result = await readOpenCodeTranscript(session.transcriptPath, cursor, beforeTimestamp);
+		} else if (source === "cursor") {
+			result = await readCursorTranscript(session.transcriptPath, cursor, beforeTimestamp);
+		} else {
+			result = await readTranscript(session.transcriptPath, cursor, getParserForSource(source), beforeTimestamp);
+		}
+```
+
+- [ ] **Step 4: Run typecheck + lint + existing QueueWorker tests**
+
+```bash
+npm run typecheck -w @jolli.ai/cli
+npm run lint -w @jolli.ai/cli
+npm run test -w @jolli.ai/cli -- src/hooks/QueueWorker.test.ts
+```
+
+Expected: all green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cli/src/hooks/QueueWorker.ts
+git commit -s -m "Wire Cursor discovery and reader into QueueWorker
+
+loadSessionTranscripts now invokes discoverCursorSessions when
+cursorEnabled !== false and Cursor is installed. readAllTranscripts
+dispatches source==='cursor' to readCursorTranscript."
+```
+
+---
+
+## Task 7: Wire `Installer.ts` (auto-detect + status fields)
+
+**Files:**
+- Modify: `cli/src/install/Installer.ts`
+
+Three small edits: auto-enable on install, populate `getStatus` fields, and update the status log line.
+
+- [ ] **Step 1: Add imports**
+
+At the top of `cli/src/install/Installer.ts`, add (next to the OpenCode imports):
+
+```ts
+import { isCursorInstalled } from "../core/CursorDetector.js";
+import { scanCursorSessions } from "../core/CursorSessionDiscoverer.js";
+import type { SqliteScanError } from "../core/SqliteHelpers.js";
+```
+
+- [ ] **Step 2: Auto-detect cursor at install time**
+
+Find the OpenCode auto-detect block in the `install()` function (around line 250-256):
+
+```ts
+	// Auto-detect OpenCode and enable session discovery
+	const openCodeDetected = config.openCodeEnabled !== false && (await isOpenCodeInstalled());
+	if (openCodeDetected) {
+		if (config.openCodeEnabled === undefined) {
+			await saveConfig({ openCodeEnabled: true });
+			log.info("OpenCode detected — enabled OpenCode session discovery");
+		}
+	}
+```
+
+Add the cursor block immediately after:
+
+```ts
+	// Auto-detect Cursor and enable Composer session discovery
+	const cursorDetected = config.cursorEnabled !== false && (await isCursorInstalled());
+	if (cursorDetected) {
+		if (config.cursorEnabled === undefined) {
+			await saveConfig({ cursorEnabled: true });
+			log.info("Cursor detected — enabled Cursor Composer session discovery");
+		}
+	}
+```
+
+- [ ] **Step 3: Populate `cursor*` fields in `getStatus`**
+
+Find the OpenCode block in `getStatus()` (around line 472):
+
+```ts
+	const openCodeDetected = await isOpenCodeInstalled();
+```
+
+Add immediately after:
+
+```ts
+	const cursorDetected = await isCursorInstalled();
+```
+
+Find the OpenCode discovery block (around line 502-512):
+
+```ts
+	let openCodeScanError: OpenCodeScanError | undefined;
+	if (config.openCodeEnabled !== false && openCodeDetected) {
+		const scan = await scanOpenCodeSessions(projectDir);
+		if (scan.sessions.length > 0) {
+			allEnabledSessions = [...allEnabledSessions, ...scan.sessions];
+		}
+		openCodeScanError = scan.error;
+	}
+```
+
+Add the cursor analog immediately after:
+
+```ts
+	let cursorScanError: SqliteScanError | undefined;
+	if (config.cursorEnabled !== false && cursorDetected) {
+		const scan = await scanCursorSessions(projectDir);
+		if (scan.sessions.length > 0) {
+			allEnabledSessions = [...allEnabledSessions, ...scan.sessions];
+		}
+		cursorScanError = scan.error;
+	}
+```
+
+Find the `status: StatusInfo = {...}` literal (around line 564-593). After `openCodeEnabled: config.openCodeEnabled,` add:
+
+```ts
+		cursorDetected,
+		cursorEnabled: config.cursorEnabled,
+		cursorScanError,
+```
+
+(Place these next to the openCodeScanError field at the end of the literal.)
+
+Lastly update the `log.info(...)` status line near the end of `getStatus()`. Replace the format string:
+
+```ts
+		"Status: enabled=%s, claude=%s, git=%s, geminiHook=%s, worktreeHooks=%s, sessions=%d, summaries=%d, codex=%s/%s, gemini=%s/%s, enabledWorktrees=%s, opencode=%s/%s",
+```
+
+With:
+
+```ts
+		"Status: enabled=%s, claude=%s, git=%s, geminiHook=%s, worktreeHooks=%s, sessions=%d, summaries=%d, codex=%s/%s, gemini=%s/%s, enabledWorktrees=%s, opencode=%s/%s, cursor=%s/%s",
+```
+
+And add at the end of the argument list (after `status.openCodeEnabled,`):
+
+```ts
+		status.cursorDetected,
+		status.cursorEnabled,
+```
+
+- [ ] **Step 4: Run typecheck + lint + existing Installer tests**
+
+```bash
+npm run typecheck -w @jolli.ai/cli
+npm run lint -w @jolli.ai/cli
+npm run test -w @jolli.ai/cli -- src/install/Installer.test.ts
+```
+
+Expected: all green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cli/src/install/Installer.ts
+git commit -s -m "Wire Cursor auto-detect and status fields in Installer
+
+install() now auto-enables cursorEnabled when Cursor is detected and
+config has not explicitly set it. getStatus() populates cursorDetected,
+cursorEnabled, and cursorScanError, mirroring the OpenCode treatment."
+```
+
+---
+
+## Task 8: Wire CLI surfaces (`StatusCommand`, `ConfigureCommand`)
+
+**Files:**
+- Modify: `cli/src/commands/StatusCommand.ts`
+- Modify: `cli/src/commands/ConfigureCommand.ts`
+
+- [ ] **Step 1: Add Cursor row to StatusCommand `integrationRows`**
+
+Open `cli/src/commands/StatusCommand.ts`. Find the `integrationRows` array (around line 110-150). Add a new entry after the OpenCode entry:
+
+```ts
+				[
+					"Cursor:",
+					status.cursorDetected,
+					{
+						enabled: status.cursorEnabled !== false,
+						hookInstalled: undefined,
+						sessionCount: counts.cursor,
+						scanError: status.cursorScanError,
+					},
+				],
+```
+
+The row format mirrors OpenCode exactly: no hook (undefined), session count from per-source breakdown, and surface the scan error if any.
+
+- [ ] **Step 2: Add `cursorEnabled` to ConfigureCommand**
+
+Open `cli/src/commands/ConfigureCommand.ts`.
+
+**Edit 1:** in `VALID_CONFIG_KEYS` (around line 24-36), add `"cursorEnabled"` after `"openCodeEnabled"`:
+
+```ts
+const VALID_CONFIG_KEYS = [
+	"apiKey",
+	"model",
+	"maxTokens",
+	"jolliApiKey",
+	"authToken",
+	"codexEnabled",
+	"geminiEnabled",
+	"claudeEnabled",
+	"openCodeEnabled",
+	"cursorEnabled",
+	"logLevel",
+	"excludePatterns",
+] as const satisfies ReadonlyArray<keyof JolliMemoryConfig>;
+```
+
+**Edit 2:** in `coerceConfigValue` (around line 67), include `cursorEnabled` in the boolean branch:
+
+```ts
+	if (
+		key === "codexEnabled" ||
+		key === "geminiEnabled" ||
+		key === "claudeEnabled" ||
+		key === "openCodeEnabled" ||
+		key === "cursorEnabled"
+	) {
+		const lower = raw.toLowerCase();
+		if (lower === "true" || lower === "1" || lower === "yes") return true;
+		if (lower === "false" || lower === "0" || lower === "no") return false;
+		throw new Error(`${key} must be true/false (got: ${raw})`);
+	}
+```
+
+**Edit 3:** in `CONFIG_KEY_INFO` (around line 92-108), add a description after `openCodeEnabled`:
+
+```ts
+	{
+		key: "cursorEnabled",
+		type: "boolean",
+		description: "Enable Cursor Composer session discovery (true/false; requires Node 22.5+ at runtime)",
+	},
+```
+
+- [ ] **Step 3: Run all CLI checks**
+
+```bash
+npm run typecheck -w @jolli.ai/cli
+npm run lint -w @jolli.ai/cli
+npm run test -w @jolli.ai/cli
+```
+
+Expected: all green, including coverage threshold.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add cli/src/commands/StatusCommand.ts cli/src/commands/ConfigureCommand.ts
+git commit -s -m "Surface cursor in 'jolli status' and 'jolli configure'
+
+StatusCommand renders a Cursor integration row with the same shape as
+OpenCode (no hook, session count, scan error). ConfigureCommand accepts
+'cursorEnabled' as a boolean key."
+```
+
+---
+
+## Task 9: End-to-end smoke verification (manual)
+
+**Goal:** Confirm a real Cursor Composer conversation produces a Cursor-attributed session in a freshly-generated commit summary.
+
+This task does not modify code — it validates the full pipeline on the implementer's local machine. It must pass before merging.
+
+- [ ] **Step 1: Build the CLI from this branch and link globally**
+
+```bash
+cd cli
+npm run build
+npm install -g .
+cd ..
+```
+
+- [ ] **Step 2: Set up a sandbox repo and enable jollimemory**
+
+```bash
+mkdir -p /tmp/cursor-smoke && cd /tmp/cursor-smoke
+git init
+git commit --allow-empty -m "init" -s
+jolli enable
+jolli status
+```
+
+Expected `jolli status` output should include a `Cursor:` row reporting "detected" and a session count (likely 0 if you have not used Cursor in this directory yet).
+
+- [ ] **Step 3: Open the sandbox in Cursor and have a Composer conversation**
+
+1. `open -a Cursor /tmp/cursor-smoke` (macOS).
+2. Open a new Composer chat. Send: "create a file hello.txt that says hello world".
+3. Let Cursor's agent create the file.
+4. Save changes (if Cursor stages them, accept).
+
+- [ ] **Step 4: Make a commit and verify cursor is attributed**
+
+```bash
+cd /tmp/cursor-smoke
+git add .
+git commit -m "feat: add hello.txt" -s
+sleep 10
+jolli status
+HEAD_HASH=$(git rev-parse HEAD)
+git show "jollimemory/summaries/v3:summaries/${HEAD_HASH}.json" | jq '.children // .' | head -50
+```
+
+Expected:
+
+- `jolli status` shows a non-zero count in the `Cursor:` row.
+- The summary JSON contains a `sessions` entry whose `source` is `"cursor"`.
+
+- [ ] **Step 5: Cleanup**
+
+```bash
+cd ~ && rm -rf /tmp/cursor-smoke
+npm uninstall -g @jolli.ai/cli
+```
+
+- [ ] **Step 6: If everything passes, this task is complete — no commit (no code change).**
+
+If anything fails, treat it as a real bug: open a new branch off `feature-support-cursor`, fix, and re-run from Step 4.
+
+---
+
+## Final Sweep
+
+- [ ] **Run the full repo check from root**
+
+```bash
+cd /Users/flyer/jolli/code/jollimemory
+npm run all
+```
+
+Expected: clean → build → lint → test all green across both `cli/` and `vscode/`. If `vscode/` tests break, double-check that `cli/src/Types.ts` still type-checks under both CLI and VSCode tsconfigs (the VSCode bundler inlines `cli/src/**`).
+
+- [ ] **Verify the diff is bounded to the planned files**
+
+```bash
+git diff --stat main..HEAD
+```
+
+Expected: changes confined to the file list at the top of this plan. No incidental edits.
+
+- [ ] **Push and open the PR**
+
+```bash
+git push -u origin feature-support-cursor
+gh pr create --title "Add Cursor IDE support" --body "$(cat <<'PRBODY'
+## Summary
+
+Adds Cursor (the Anysphere VS Code fork) as a fifth TranscriptSource. The CLI now discovers Cursor Composer transcripts at post-commit time by scanning Cursor's local SQLite (~/Library/Application Support/Cursor/User/globalStorage/state.vscdb), using a workspace-pointer + 48 h time-window attribution algorithm.
+
+Mirrors the OpenCode integration pattern: passive scan, no hook, no Cursor-side files. Setup-time auto-detect via isCursorInstalled(), with `jolli status` and `jolli configure cursorEnabled` exposing the toggle.
+
+## Intentionally unchanged
+
+- vscode/: no marketplace, host-detection, or engines.vscode work.
+- intellij/: no Kotlin port of the discoverer.
+- The jollimemory/summaries/v3 orphan branch format.
+- ~/.jolli/jollimemory/ runtime state shape (no new files).
+- No Cursor-side hook installed (Cursor exposes no hook protocol).
+- chatSessions/*.jsonl: verified empty of conversation content during exploration.
+
+## Test plan
+
+- [ ] npm run all from repo root passes
+- [ ] cli/ coverage stays at 97% statements / 96% branches / 97% funcs / 97% lines
+- [ ] Smoke test in Task 9 of the plan passed locally:
+  - real Cursor Composer conversation -> commit -> cursor-attributed session in the summary tree
+
+## Spec & plan
+
+- Spec: docs/superpowers/specs/2026-05-03-cursor-support-design.md
+- Plan: docs/superpowers/plans/2026-05-03-cursor-support.md
+PRBODY
+)"
+```
+
+---
+
+## Self-Review Notes
+
+**Spec coverage check:**
+
+- §3.2 (new files) → covered by Tasks 3, 4, 5.
+- §3.3 (β′ algorithm) → Task 4.
+- §3.4 (transcript reading) → Task 5.
+- §3.5 (type extensions) → Task 2.
+- §3.6 (wiring: SessionTracker, QueueWorker, Installer, StatusCommand) → Tasks 2, 6, 7, 8.
+- §4 (setup integration) → Task 7.
+- §5 (error handling) → Tasks 1 (helpers) and 4 (error surfacing).
+- §6.1 (unit tests) → embedded in each task.
+- §6.2 (bubble.type confirmation) → Task 5 step 5.
+- §7.4 (`SqliteHelpers.ts` extraction) → Task 1.
+- §8 (implementation order) → mirrored by tasks 1–9.
+- §9 (intentionally unchanged) → reflected in PR body.
+
+**Type / signature consistency check:**
+
+- `withSqliteDb<T>(dbPath, fn): Promise<T>` — defined Task 1, used in Task 4 and Task 5.
+- `SqliteScanError.kind` literal — defined Task 1, used in Task 7 status field. The `Types.ts` field (Task 2) duplicates the literal union by design (per spec §3.5).
+- `discoverCursorSessions(projectDir): Promise<ReadonlyArray<SessionInfo>>` — defined Task 4, used Task 6.
+- `readCursorTranscript(path, cursor?, beforeTimestamp?): Promise<TranscriptReadResult>` — defined Task 5, used Task 6.
+- Synthetic transcript path format `<dbPath>#<composerId>` — produced in Task 4, parsed in Task 5.
+
+**No-placeholder check:** every step contains the code or command an implementer needs; no "TBD" / "TODO" / "fill in details" anywhere.
+

--- a/docs/superpowers/specs/2026-05-03-cursor-support-design.md
+++ b/docs/superpowers/specs/2026-05-03-cursor-support-design.md
@@ -1,0 +1,334 @@
+# Cursor Support — Design
+
+**Date:** 2026-05-03
+**Branch:** `feature-support-cursor`
+**Scope:** Add Cursor (the IDE) as a fifth `TranscriptSource`. Mirrors the OpenCode integration pattern: passive discovery from a global SQLite database, no hooks, no Cursor-side configuration. Setup-time detection with a status hint to the user.
+
+---
+
+## 1. Goals & non-goals
+
+### Goals
+
+- jollimemory's git-driven summary pipeline (`PostCommitHook` → `QueueWorker`) treats Cursor Composer conversations the same as Claude Code / Codex / OpenCode / Gemini transcripts: discovered, attributed to a commit, parsed to `TranscriptEntry[]`, and folded into the LLM summarization context.
+- `jolli setup` and `jolli status` detect Cursor's presence and surface "Cursor → enabled" without requiring any Cursor-side config or restart.
+
+### Non-goals
+
+- VS Code extension–layer adaptation (e.g. `engines.vscode` widening, marketplace publishing to Cursor's registry, host-detection in webviews). Cursor is a VS Code fork — packaging, marketplace, and IDE host concerns are deferred. `vscode/` is **not** modified.
+- A Cursor-side hook or extension installed inside Cursor itself. Cursor exposes no public hook protocol; we do not work around this with synthetic injection.
+- Mid-conversation streaming. Like Codex/OpenCode, Cursor is scanned at git events (post-commit), not in real time.
+- Indexing of Cursor's `agentKv:blob:*` rows (file-snapshot blobs not used by transcript display).
+
+---
+
+## 2. What we know about Cursor's storage
+
+Verified by hands-on inspection of `~/Library/Application Support/Cursor/` on the current machine (5 workspaces, 12 composers).
+
+### 2.1 Files & databases
+
+| Path | Role |
+|---|---|
+| `/Applications/Cursor.app` | Application bundle (used for installation detection) |
+| `~/Library/Application Support/Cursor/User/globalStorage/state.vscdb` | Global SQLite (`ItemTable`, `cursorDiskKV`). **Holds all transcript data.** |
+| `~/Library/Application Support/Cursor/User/workspaceStorage/<wsHash>/workspace.json` | `{"folder": "file:///abs/path"}` — the bridge from a folder path to its workspace hash |
+| `~/Library/Application Support/Cursor/User/workspaceStorage/<wsHash>/state.vscdb` | Per-workspace SQLite (`ItemTable`, `cursorDiskKV`). Holds workspace UI state and a **pointer** to the most recently used composer. |
+| `…/chatSessions/*.jsonl` | **Ignored.** VS Code-native `Chat` panel state, contains no Cursor Composer transcript content (verified empty `requests: []`). |
+
+Linux equivalent path: `~/.config/Cursor/User/...`. Windows: `%APPDATA%/Cursor/User/...`. The implementation uses platform-aware path resolution.
+
+### 2.2 The `cursorDiskKV` table layout
+
+The global SQLite's `cursorDiskKV` table holds Cursor-specific KV rows. Three relevant key shapes:
+
+| Key shape | Count (sample) | Purpose | Used? |
+|---|---|---|---|
+| `composerData:<composerId>` | 12 | Composer session header — name, timestamps, `fullConversationHeadersOnly` (ordered bubble index), unifiedMode (`agent`/`ask`/`edit`), modelConfig | **Yes** |
+| `bubbleId:<composerId>:<bubbleId>` | 18 | Single message — `text`, `richText`, `type` (1 = user, 2 = assistant — to be confirmed; see §6.2), `createdAt` (ISO), `modelInfo`, `tokenCount` | **Yes** |
+| `checkpointId:<composerId>:<id>` | 7 | File-state snapshot reference (constant 142 B) | No |
+| `agentKv:blob:<sha256>` | 50 | Binary attachments | No |
+
+A composer is the unit jollimemory will treat as a "session." It groups N bubbles in a parent-child tree via `composerData.fullConversationHeadersOnly` (ordered list of `{bubbleId, type, grouping}`).
+
+### 2.3 The workspace ↔ composer relationship
+
+Composers are **stored globally**, not per-workspace. The on-disk schema does not reify a strong workspace→composers relation. Investigation findings:
+
+- `composerData.trackedGitRepos` exists but is **empty** in observed rows.
+- `composerData.workspaceUris` exists but is also empty.
+- `globalStorage.ItemTable.backgroundComposer.windowBcMapping` is keyed by *window ID*, not by workspace, and lists only currently-running background composers (empty in the steady state).
+- The per-workspace `state.vscdb`'s `ItemTable.composer.composerData` value contains only `selectedComposerIds` and `lastFocusedComposerIds` — these are precise pointers from Cursor itself, but only to the most recent / currently selected composer, not the full history.
+
+**Conclusion**: There is no on-disk authoritative mapping from "workspace" to "all composers ever used in that workspace." The β′ algorithm in §3.3 makes the best of what is available.
+
+---
+
+## 3. Architecture
+
+### 3.1 Component map
+
+```
+                                            ┌──────────────────────────────┐
+                                            │  CursorDetector              │
+                                            │  (one-shot install probe)    │
+                                            └──────────────┬───────────────┘
+                                                           │
+              consulted by                                 │ used by
+                ┌────────────────────────┐                 ▼
+                │  Installer.ts (setup)  │       ┌─────────────────────────┐
+                └────────────────────────┘       │   `jolli status` /      │
+                                                 │    StatusInfo.cursor*   │
+                                                 └─────────────────────────┘
+
+    ┌─────────────────────┐                                ┌────────────────────────┐
+    │  QueueWorker.ts     │ ───── on every commit ───►    │ CursorSessionDiscoverer │
+    │  (post-commit)      │                                │ (β′: pointer + window) │
+    └─────────────────────┘                                └─────────────┬──────────┘
+                                                                         │ SessionInfo[]
+                                                                         ▼
+                                                          ┌──────────────────────────┐
+                                                          │ CursorTranscriptReader   │
+                                                          │ (composerId → entries)   │
+                                                          └─────────────┬────────────┘
+                                                                        │ TranscriptEntry[]
+                                                                        ▼
+                                                          (existing) Summarizer pipeline
+```
+
+No new hooks. No new state files. No changes to the orphan-branch storage format.
+
+### 3.2 New files
+
+| File | Approx. size | Mirrors |
+|---|---|---|
+| `cli/src/core/CursorDetector.ts` | ~30 LoC | `ClaudeDetector.ts` |
+| `cli/src/core/CursorDetector.test.ts` | tests | — |
+| `cli/src/core/CursorSessionDiscoverer.ts` | ~250 LoC | `OpenCodeSessionDiscoverer.ts` |
+| `cli/src/core/CursorSessionDiscoverer.test.ts` | tests | `OpenCodeSessionDiscoverer.test.ts` |
+| `cli/src/core/CursorTranscriptReader.ts` | ~150 LoC | `OpenCodeTranscriptReader.ts` |
+| `cli/src/core/CursorTranscriptReader.test.ts` | tests | `OpenCodeTranscriptReader.test.ts` |
+
+### 3.3 The β′ session-attribution algorithm
+
+The discoverer's job is to answer: *given a `projectDir` and a time-window cutoff, which composers contain conversation that should be folded into the next commit summary?*
+
+```
+Input: projectDir (absolute path), staleCutoffMs (now − 48h, matches other sources)
+
+Step 1  Find the workspace hash for this projectDir.
+        - Iterate workspaceStorage/*/workspace.json
+        - Parse `folder` URI; URL-decode; strip `file://`
+        - Match (case-insensitive on darwin/win32) against projectDir
+        - If no match → return [] (project never opened in Cursor)
+
+Step 2  Read pointers from per-workspace state.vscdb.
+        - ItemTable.composer.composerData → { lastFocusedComposerIds, selectedComposerIds }
+        - Take union of both lists; this is the "anchor set"
+
+Step 3  Read time-window candidates from global state.vscdb.
+        - SELECT key, value FROM cursorDiskKV WHERE key LIKE 'composerData:%'
+        - For each row, parse value, keep those with lastUpdatedAt ≥ staleCutoffMs
+        - This is the "window set"
+
+Step 4  Final composerId set = anchorSet ∪ windowSet.
+        - Anchor set guarantees recall for the focused workspace.
+        - Window set catches background composers and worktree-multiplexed cases
+          (user opens the same composer across multiple windows).
+
+Step 5  Map each composerId to a SessionInfo:
+        - sessionId       = composerId
+        - transcriptPath  = `${globalDbPath}#${composerId}` (synthetic, like OpenCode)
+        - updatedAt       = composerData.lastUpdatedAt (ISO)
+        - source          = "cursor"
+```
+
+**Acknowledged false-positive**: a composer used in workspace A but updated within the time window of an unrelated commit in workspace B will be picked up. This is intentional — the LLM summarizer can naturally ignore unrelated content; under-recall is harder to recover from than over-recall.
+
+### 3.4 Transcript reading
+
+`CursorTranscriptReader.readCursorTranscript(transcriptPath, cursor?, beforeTimestamp?)`:
+
+```
+1. Parse synthetic path "<dbPath>#<composerId>".
+2. Open globalStorage/state.vscdb read-only.
+3. Read composerData:<composerId> → fullConversationHeadersOnly = ordered bubbleIds.
+4. Read bubbleId:<composerId>:<bubbleId> rows in that order.
+5. For each bubble:
+     - Map bubble.type → "human" | "assistant"  (1=human, 2=assistant; see §6.2)
+     - Take bubble.text (fall back to empty string if absent — `richText` parsing
+       is a Phase-2 enhancement, see §7.2)
+     - Use bubble.createdAt (ISO) as timestamp
+     - Skip non-conversational types and empty bodies
+6. Apply mergeConsecutiveEntries (shared with TranscriptReader / OpenCodeTranscriptReader).
+7. Cursor advances by index into the bubble list (mirrors OpenCode's pattern).
+8. Apply beforeTimestamp cutoff if provided (drop entries strictly after).
+```
+
+Cursor reads use the same `withOpenCodeDb`-style pattern: dynamically import `node:sqlite`, open read-only, run a callback, close. We **introduce a small refactor** in `OpenCodeSessionDiscoverer.ts` to extract `withSqliteDb(dbPath, fn)` and `hasNodeSqliteSupport()` into a shared helper file (`cli/src/core/SqliteHelpers.ts`) so Cursor uses them too. This is a *targeted improvement* that serves the current goal and the existing OpenCode caller is rewritten to use the shared helper. (See §7.4 for justification.)
+
+### 3.5 Type-system extensions
+
+In `cli/src/Types.ts`:
+
+```ts
+export type TranscriptSource = "claude" | "codex" | "gemini" | "opencode" | "cursor";
+
+export interface JolliMemoryConfig {
+    // … existing fields …
+    /** Enable Cursor Composer session discovery at post-commit time (default: auto-detect) */
+    readonly cursorEnabled?: boolean;
+}
+
+export interface StatusInfo {
+    // … existing fields …
+    /** Whether Cursor data dir was detected */
+    readonly cursorDetected?: boolean;
+    /** Whether Cursor session discovery is enabled in config (undefined = auto-detect) */
+    readonly cursorEnabled?: boolean;
+    /** Cursor DB scan failed (corrupt, locked, schema drift, etc.) */
+    readonly cursorScanError?: { readonly kind: "corrupt" | "locked" | "permission" | "schema" | "unknown"; readonly message: string };
+}
+```
+
+Note: the existing `openCodeScanError.kind` literal type is duplicated rather than extracted, because the design decision is to mirror OpenCode's exact shape for consistency. If both fields end up needing identical shapes for a third source, an extraction is warranted then.
+
+### 3.6 Wiring
+
+Three integration points need to know about cursor:
+
+| Module | Change |
+|---|---|
+| `cli/src/core/SessionTracker.ts` `filterSessionsByEnabledIntegrations` | Add `if (config.cursorEnabled === false) filtered = filtered.filter(s => s.source !== "cursor")`. |
+| `cli/src/hooks/QueueWorker.ts` (the discoverer fan-out) | Add a call to `discoverCursorSessions(projectDir)` alongside the existing OpenCode/Codex calls; concatenate results. |
+| `cli/src/install/Installer.ts` | After `isCursorInstalled()` returns true, emit a one-line console hint: `"✓ Detected Cursor — Composer sessions will be auto-collected from local SQLite"`. Set `config.cursorEnabled = true` if not yet set. |
+| `cli/src/commands/StatusCommand.ts` (or equivalent — wherever `getStatus` is built) | Populate `cursorDetected`, `cursorEnabled`, `cursorScanError`, and an extra entry in `sessionsBySource`. |
+
+---
+
+## 4. Setup-time integration (Q3 = consistent with Codex/OpenCode)
+
+The first time the user runs `jolli setup`, `jolli enable`, or `jolli install` in a repo:
+
+1. `Installer.ts` calls `isCursorInstalled()` (checks `/Applications/Cursor.app` on darwin, `~/.config/Cursor` on linux, etc., **and** `globalStorage/state.vscdb` reachable, **and** `hasNodeSqliteSupport()` true).
+2. If detected, log: `"✓ Detected Cursor — Composer sessions will be auto-collected from local SQLite"`. Persist `cursorEnabled: true` in `config.json` (only on first detection — subsequent runs respect a user-set `false`).
+3. Nothing else: no hook installation, no Cursor-side files written, no restart prompted.
+
+`jolli disable` (if present) sets `cursorEnabled: false`. `jolli status` shows the enable/detect flags consistently with OpenCode rows.
+
+---
+
+## 5. Error handling
+
+Same classification scheme as OpenCode (`OpenCodeScanError.kind`):
+
+| Kind | Trigger | Surfacing |
+|---|---|---|
+| `corrupt` | `SQLITE_CORRUPT` / `SQLITE_NOTADB` | UI warning row |
+| `locked` | `SQLITE_BUSY` / `SQLITE_LOCKED` (Cursor app holding write lock) | UI warning row, transient |
+| `permission` | `EACCES` / `EPERM` / `SQLITE_CANTOPEN` | UI warning row |
+| `schema` | `no such table` / `no such column` (Cursor version drift) | UI warning row, signal to update jollimemory |
+| `unknown` | Anything else | UI warning row |
+
+ENOENT (DB file absent) is **not** a scan error — it is treated as "Cursor not installed/never opened" and is silent.
+
+`hasNodeSqliteSupport()` returning false (e.g. VS Code extension running on bundled Node 18) → `isCursorInstalled()` returns false; cursor support is disabled silently for that runtime.
+
+---
+
+## 6. Testing strategy
+
+### 6.1 Unit tests (vitest, in-repo)
+
+- `CursorDetector.test.ts` — mock `stat()` for `Cursor.app` and `state.vscdb`; verify `isCursorInstalled()` returns true only when both exist and `hasNodeSqliteSupport()` is true.
+- `CursorSessionDiscoverer.test.ts` — fixture SQLite databases (created in test setup with `node:sqlite`):
+    - empty global DB → `[]`
+    - global DB with composerData rows but no matching workspace → `[]` (β′ Step 1 fails)
+    - global DB + workspace.json + per-workspace `composer.composerData` pointer → returns anchor composer
+    - time-window expansion includes additional composers with `lastUpdatedAt` in window
+    - duplicates between anchor set and window set are deduped
+    - case-insensitive workspace folder match on darwin/win32
+    - URL-decoding of `file://` URIs (paths with spaces, unicode)
+    - SQLITE_CORRUPT / EACCES → `OpenCodeScanError` returned (no exception escapes)
+- `CursorTranscriptReader.test.ts` —
+    - synthetic path parsing (missing `#`, empty parts, → throws)
+    - bubble ordering follows `fullConversationHeadersOnly`
+    - empty `text` skipped
+    - cursor resumption (skip already-read bubbles)
+    - `beforeTimestamp` cutoff respected
+    - bubble.type → human/assistant mapping (see §6.2 for fixture sourcing)
+
+### 6.2 The bubble.type ↔ role mapping
+
+Empirical assumption: `type: 1` = user, `type: 2` = assistant. **This must be confirmed during implementation** by:
+1. Creating fixture composer with one user message and one assistant message via real Cursor.
+2. Reading the resulting `bubbleId:*` rows.
+3. Asserting the mapping.
+
+If the mapping is reversed or richer (e.g. tool-result bubbles get a third type), the reader's mapping table is the only place that changes. The single source of truth lives in `CursorTranscriptReader.ts` as a small constant map; tests pin it.
+
+### 6.3 Coverage budget
+
+Same threshold as the rest of `cli/src/` (97% statements, 96% branches, 97% functions, 97% lines per `cli/vite.config.ts`). New code should not regress totals.
+
+---
+
+## 7. Open issues, risks, and explicitly deferred work
+
+### 7.1 Risk: Cursor schema drift
+
+Cursor is closed-source and ships frequently. `cursorDiskKV` schema is undocumented. If a future Cursor release renames `composerData` keys or restructures `fullConversationHeadersOnly`, the discoverer/reader silently produces empty transcripts. Mitigation:
+
+- Surface `kind: "schema"` errors loudly in `jolli status`.
+- Pin a tiny structural smoke-test fixture (a tarred minimal `state.vscdb`) committed to the repo, regenerated when known-good Cursor versions are tested.
+
+### 7.2 `richText` is unused — Phase 2
+
+Cursor stores message content twice: `text` (plain) and `richText` (ProseMirror JSON). The `text` field is sufficient for v1. If `text` is ever empty when `richText` is non-empty (e.g. a code-block-only message), the bubble is dropped. **Phase 2** would add a minimal ProseMirror walker; estimated +50 LoC.
+
+### 7.3 Risk: workspace match miss
+
+If the user opens a project in Cursor via a symlinked path or a dev-container path, `workspace.json.folder` will not equal `process.cwd()`. The β′ algorithm degrades to "no anchor, time-window only" — still functional, slightly less precise. Documented; not addressed in v1.
+
+### 7.4 Refactor: `SqliteHelpers.ts` extraction
+
+`OpenCodeSessionDiscoverer.ts` exports `withOpenCodeDb`, `hasNodeSqliteSupport`, `NODE_SQLITE_MIN_VERSION`, and `classifyScanError` — all of which are **not OpenCode-specific**. With Cursor as a second SQLite-based source, these belong in a shared file:
+
+- New file: `cli/src/core/SqliteHelpers.ts` containing `withSqliteDb`, `hasNodeSqliteSupport`, `NODE_SQLITE_MIN_VERSION`, and `classifyScanError` (renamed from OpenCode-specific names).
+- `OpenCodeSessionDiscoverer.ts` imports from the new file instead of defining them.
+- `CursorSessionDiscoverer.ts` imports from the new file from day one.
+
+This is in scope because it directly serves the current goal — without it, the same logic would be duplicated. Tests for `classifyScanError` move to `SqliteHelpers.test.ts`.
+
+### 7.5 Out of scope
+
+- `node:sqlite` is Node 22.5+. The VS Code extension bundles Node 18 (per `CLAUDE.md`). On that runtime, cursor support is disabled the same way OpenCode currently is — `hasNodeSqliteSupport()` returns false, `isCursorInstalled()` returns false, no UI surface.
+- `intellij/` plugin: no change. The IntelliJ port writes to the same orphan branch + `~/.jolli/jollimemory/` state, but it has its own session-discovery surface (none for OpenCode/Cursor today; adding parity is a separate workstream).
+
+---
+
+## 8. Implementation order
+
+Suggested sequence for the implementation plan that follows this spec:
+
+1. Extract `SqliteHelpers.ts` from `OpenCodeSessionDiscoverer.ts`. Confirm `npm run all` still green. **Pure refactor commit.**
+2. Add `TranscriptSource` literal `"cursor"` and config/status fields to `Types.ts`. Wire `filterSessionsByEnabledIntegrations`. Type-only commit, tests should still pass.
+3. Implement `CursorDetector.ts` + tests.
+4. Implement `CursorSessionDiscoverer.ts` (β′ algorithm) + tests.
+5. Implement `CursorTranscriptReader.ts` + tests. **Confirm `bubble.type` → role mapping using a real Cursor fixture before merging.**
+6. Wire `QueueWorker.ts` discoverer fan-out and `Installer.ts` setup hint.
+7. Update `getStatus` / `StatusCommand` to surface `cursorDetected` / `cursorEnabled` / `cursorScanError`.
+8. End-to-end smoke test on the implementer's own Cursor: real composer in `feature-support-cursor` workspace → make a commit → verify the resulting summary references the Cursor conversation content.
+
+---
+
+## 9. Things this PR will explicitly **not** touch
+
+(Per the user's "intentionally unchanged" PR-summary norm.)
+
+- `vscode/` — no marketplace, host detection, or `engines.vscode` work.
+- `intellij/` — no Kotlin port of the discoverer.
+- The `jollimemory/summaries/v3` orphan branch format.
+- `~/.jolli/jollimemory/` runtime state shape (no new files, no cursor-specific subdirectory).
+- `cli/src/install/ClaudeHookInstaller.ts`, `GeminiHookInstaller.ts`, `GitHookInstaller.ts` — no Cursor-side hook because Cursor exposes no hook protocol.
+- `chatSessions/*.jsonl` reading — verified empty of conversation content.

--- a/package-lock.json
+++ b/package-lock.json
@@ -8391,7 +8391,7 @@
 		},
 		"vscode": {
 			"name": "jollimemory-vscode",
-			"version": "0.98.16",
+			"version": "0.98.17",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@vscode/codicons": "^0.0.45",

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -2,7 +2,7 @@
 	"name": "jollimemory-vscode",
 	"displayName": "Jolli Memory",
 	"description": "VS Code sidebar for Jolli Memory — AI-powered commit summaries and smart git operations",
-	"version": "0.98.16",
+	"version": "0.98.17",
 	"publisher": "jolli",
 	"license": "Apache-2.0",
 	"icon": "assets/icon.png",

--- a/vscode/src/providers/StatusTreeProvider.test.ts
+++ b/vscode/src/providers/StatusTreeProvider.test.ts
@@ -538,6 +538,54 @@ describe("StatusTreeProvider", () => {
 		expect(openCode?.description).toBe("detected & enabled (2 sessions)");
 	});
 
+	// ── Cursor scan error / healthy row ───────────────────────────────────
+
+	it("renders an 'unavailable' Cursor row when cursorScanError is present", async () => {
+		const bridge = {
+			cwd: "/repo",
+			getStatus: vi.fn(async () =>
+				makeStatus({
+					cursorDetected: true,
+					cursorEnabled: true,
+					cursorScanError: {
+						kind: "locked",
+						message: "database is locked",
+					},
+				}),
+			),
+		};
+		loadConfigFromDir.mockResolvedValue({ apiKey: "key" });
+
+		const provider = makeStatusProvider(bridge as never);
+		await provider.refresh();
+
+		const items = provider.getChildren();
+		const cursor = items.find((item) => item.label === "Cursor Integration");
+		expect(cursor?.description).toBe("unavailable — locked");
+		expect(String(cursor?.tooltip)).toContain("database is locked");
+	});
+
+	it("falls back to the normal detected/enabled Cursor row when no scan error", async () => {
+		const bridge = {
+			cwd: "/repo",
+			getStatus: vi.fn(async () =>
+				makeStatus({
+					cursorDetected: true,
+					cursorEnabled: true,
+					sessionsBySource: { cursor: 3 },
+				}),
+			),
+		};
+		loadConfigFromDir.mockResolvedValue({ apiKey: "key" });
+
+		const provider = makeStatusProvider(bridge as never);
+		await provider.refresh();
+
+		const items = provider.getChildren();
+		const cursor = items.find((item) => item.label === "Cursor Integration");
+		expect(cursor?.description).toBe("detected & enabled (3 sessions)");
+	});
+
 	// ── Auth-aware status rows ────────────────────────────────────────────
 
 	it("shows Jolli Account connected when authToken is present", async () => {

--- a/vscode/src/providers/StatusTreeProvider.ts
+++ b/vscode/src/providers/StatusTreeProvider.ts
@@ -230,7 +230,7 @@ function buildFullStatusItems(
 		items.push(accountItem);
 	}
 
-	// Integration status rows (Claude, Codex, Gemini, OpenCode)
+	// Integration status rows (Claude, Codex, Gemini, OpenCode, Cursor)
 	const counts = s.sessionsBySource ?? {};
 	pushIntegrationItem(
 		items,
@@ -289,6 +289,29 @@ function buildFullStatusItems(
 			"OpenCode detected but session discovery is disabled in config",
 			undefined,
 			counts.opencode,
+		);
+	}
+	// Cursor: Composer sessions via global SQLite (no agent hook — scan errors surface like OpenCode).
+	if (s.cursorScanError) {
+		items.push(
+			new StatusItem(
+				"Cursor Integration",
+				`unavailable — ${s.cursorScanError.kind}`,
+				ICON_WARN,
+				`Cursor database scan failed (${s.cursorScanError.kind}): ${s.cursorScanError.message}`,
+			),
+		);
+	} else {
+		pushIntegrationItem(
+			items,
+			s.cursorDetected,
+			s.cursorEnabled !== false,
+			undefined,
+			"Cursor Integration",
+			"Cursor Composer store found — session discovery is enabled",
+			"Cursor detected but session discovery is disabled in config",
+			undefined,
+			counts.cursor,
 		);
 	}
 

--- a/vscode/src/views/SettingsHtmlBuilder.test.ts
+++ b/vscode/src/views/SettingsHtmlBuilder.test.ts
@@ -57,6 +57,7 @@ describe("SettingsHtmlBuilder", () => {
 		expect(html).toContain('id="codexEnabled"');
 		expect(html).toContain('id="geminiEnabled"');
 		expect(html).toContain('id="openCodeEnabled"');
+		expect(html).toContain('id="cursorEnabled"');
 	});
 
 	it("contains Files group with exclude patterns", () => {

--- a/vscode/src/views/SettingsHtmlBuilder.ts
+++ b/vscode/src/views/SettingsHtmlBuilder.ts
@@ -84,6 +84,7 @@ export function buildSettingsHtml(nonce: string): string {
       ${buildToggleRow("codexEnabled", "Codex CLI", "Session discovery via filesystem scan")}
       ${buildToggleRow("geminiEnabled", "Gemini CLI", "Session tracking via AfterAgent hook")}
       ${buildToggleRow("openCodeEnabled", "OpenCode", "Session discovery via ~/.local/share/opencode/opencode.db")}
+      ${buildToggleRow("cursorEnabled", "Cursor", "Session discovery via Cursor's local SQLite store")}
       <div class="error-message" id="integrations-error"></div>
     </div>
 

--- a/vscode/src/views/SettingsScriptBuilder.test.ts
+++ b/vscode/src/views/SettingsScriptBuilder.test.ts
@@ -61,5 +61,6 @@ describe("SettingsScriptBuilder", () => {
 		expect(script).toContain("integrations-error");
 		expect(script).toContain("At least one integration must be enabled");
 		expect(script).toContain("openCodeEnabled");
+		expect(script).toContain("cursorEnabled");
 	});
 });

--- a/vscode/src/views/SettingsScriptBuilder.ts
+++ b/vscode/src/views/SettingsScriptBuilder.ts
@@ -28,6 +28,7 @@ export function buildSettingsScript(): string {
   const codexEnabledInput = document.getElementById('codexEnabled');
   const geminiEnabledInput = document.getElementById('geminiEnabled');
   const openCodeEnabledInput = document.getElementById('openCodeEnabled');
+  const cursorEnabledInput = document.getElementById('cursorEnabled');
   const localFolderInput = document.getElementById('localFolder');
   const browseLocalFolderBtn = document.getElementById('browseLocalFolderBtn');
   const rebuildKbBtn = document.getElementById('rebuildKbBtn');
@@ -129,7 +130,7 @@ export function buildSettingsScript(): string {
     }) && valid;
     // At least one integration must be enabled
     var intError = document.getElementById('integrations-error');
-    if (!claudeEnabledInput.checked && !codexEnabledInput.checked && !geminiEnabledInput.checked && !openCodeEnabledInput.checked) {
+    if (!claudeEnabledInput.checked && !codexEnabledInput.checked && !geminiEnabledInput.checked && !openCodeEnabledInput.checked && !cursorEnabledInput.checked) {
       intError.textContent = 'At least one integration must be enabled';
       valid = false;
     } else {
@@ -162,6 +163,7 @@ export function buildSettingsScript(): string {
       codexEnabled: codexEnabledInput.checked,
       geminiEnabled: geminiEnabledInput.checked,
       openCodeEnabled: openCodeEnabledInput.checked,
+      cursorEnabled: cursorEnabledInput.checked,
       localFolder: localFolderInput.value,
       excludePatterns: excludePatternsInput.value,
     };
@@ -178,6 +180,7 @@ export function buildSettingsScript(): string {
       codexEnabledInput.checked !== initialState.codexEnabled ||
       geminiEnabledInput.checked !== initialState.geminiEnabled ||
       openCodeEnabledInput.checked !== initialState.openCodeEnabled ||
+      cursorEnabledInput.checked !== initialState.cursorEnabled ||
       localFolderInput.value !== initialState.localFolder ||
       excludePatternsInput.value !== initialState.excludePatterns
     );
@@ -202,7 +205,7 @@ export function buildSettingsScript(): string {
     input.addEventListener('input', function() { validateAll(); checkDirty(); clearSaveFeedback(); });
   });
   modelSelect.addEventListener('change', function() { checkDirty(); clearSaveFeedback(); });
-  [claudeEnabledInput, codexEnabledInput, geminiEnabledInput, openCodeEnabledInput].forEach(function(input) {
+  [claudeEnabledInput, codexEnabledInput, geminiEnabledInput, openCodeEnabledInput, cursorEnabledInput].forEach(function(input) {
     input.addEventListener('change', function() { validateAll(); checkDirty(); clearSaveFeedback(); });
   });
 
@@ -232,6 +235,7 @@ export function buildSettingsScript(): string {
         codexEnabled: codexEnabledInput.checked,
         geminiEnabled: geminiEnabledInput.checked,
         openCodeEnabled: openCodeEnabledInput.checked,
+        cursorEnabled: cursorEnabledInput.checked,
         localFolder: localFolderInput.value.trim(),
         excludePatterns: excludePatternsInput.value,
       },
@@ -253,6 +257,7 @@ export function buildSettingsScript(): string {
         codexEnabledInput.checked = msg.settings.codexEnabled;
         geminiEnabledInput.checked = msg.settings.geminiEnabled;
         openCodeEnabledInput.checked = msg.settings.openCodeEnabled;
+        cursorEnabledInput.checked = msg.settings.cursorEnabled;
         localFolderInput.value = msg.settings.localFolder || '';
         excludePatternsInput.value = msg.settings.excludePatterns;
         maskedApiKey = msg.maskedApiKey;

--- a/vscode/src/views/SettingsWebviewPanel.test.ts
+++ b/vscode/src/views/SettingsWebviewPanel.test.ts
@@ -994,6 +994,7 @@ describe("SettingsWebviewPanel", () => {
 					codexEnabled: false,
 					geminiEnabled: false,
 					openCodeEnabled: false,
+					cursorEnabled: false,
 					excludePatterns: "",
 				},
 			});
@@ -1005,6 +1006,7 @@ describe("SettingsWebviewPanel", () => {
 					codexEnabled: false,
 					geminiEnabled: false,
 					openCodeEnabled: false,
+					cursorEnabled: false,
 				}),
 				expect.any(String),
 			);
@@ -1026,6 +1028,7 @@ describe("SettingsWebviewPanel", () => {
 					codexEnabled: true,
 					geminiEnabled: true,
 					openCodeEnabled: true,
+					cursorEnabled: true,
 					excludePatterns: "",
 				},
 			});
@@ -1037,6 +1040,7 @@ describe("SettingsWebviewPanel", () => {
 					codexEnabled: true,
 					geminiEnabled: true,
 					openCodeEnabled: true,
+					cursorEnabled: true,
 				}),
 				expect.any(String),
 			);
@@ -1071,6 +1075,7 @@ describe("SettingsWebviewPanel", () => {
 					codexEnabled: true,
 					geminiEnabled: true,
 					openCodeEnabled: false,
+					cursorEnabled: true,
 					excludePatterns: "",
 				},
 			});
@@ -1078,6 +1083,46 @@ describe("SettingsWebviewPanel", () => {
 
 			expect(mockSaveConfigScoped).toHaveBeenCalledWith(
 				expect.objectContaining({ openCodeEnabled: false }),
+				expect.any(String),
+			);
+		});
+
+		it("loads and saves Cursor integration state", async () => {
+			const dispatch = await setupWithLoadedConfig({ cursorEnabled: false });
+
+			dispatch({ command: "loadSettings", scope: "project" });
+			await flushPromises();
+
+			expect(postMessage).toHaveBeenCalledWith(
+				expect.objectContaining({
+					command: "settingsLoaded",
+					settings: expect.objectContaining({ cursorEnabled: false }),
+				}),
+			);
+
+			postMessage.mockClear();
+			dispatch({
+				command: "applySettings",
+				scope: "project",
+				maskedApiKey: "",
+				maskedJolliApiKey: "",
+				settings: {
+					apiKey: "",
+					model: "sonnet",
+					maxTokens: null,
+					jolliApiKey: "",
+					claudeEnabled: true,
+					codexEnabled: true,
+					geminiEnabled: true,
+					openCodeEnabled: true,
+					cursorEnabled: false,
+					excludePatterns: "",
+				},
+			});
+			await flushPromises();
+
+			expect(mockSaveConfigScoped).toHaveBeenCalledWith(
+				expect.objectContaining({ cursorEnabled: false }),
 				expect.any(String),
 			);
 		});

--- a/vscode/src/views/SettingsWebviewPanel.ts
+++ b/vscode/src/views/SettingsWebviewPanel.ts
@@ -42,6 +42,7 @@ interface SettingsPayload {
 	readonly codexEnabled: boolean;
 	readonly geminiEnabled: boolean;
 	readonly openCodeEnabled: boolean;
+	readonly cursorEnabled: boolean;
 	readonly localFolder: string;
 	readonly excludePatterns: string;
 }
@@ -250,6 +251,7 @@ export class SettingsWebviewPanel {
 			codexEnabled: config.codexEnabled !== false,
 			geminiEnabled: config.geminiEnabled !== false,
 			openCodeEnabled: config.openCodeEnabled !== false,
+			cursorEnabled: config.cursorEnabled !== false,
 			localFolder: config.localFolder ?? "",
 			excludePatterns: config.excludePatterns
 				? config.excludePatterns.join(", ")
@@ -325,6 +327,7 @@ export class SettingsWebviewPanel {
 			codexEnabled: settings.codexEnabled,
 			geminiEnabled: settings.geminiEnabled,
 			openCodeEnabled: settings.openCodeEnabled,
+			cursorEnabled: settings.cursorEnabled,
 			localFolder:
 				settings.localFolder && settings.localFolder.length > 0
 					? settings.localFolder

--- a/vscode/src/views/SummaryScriptBuilder.test.ts
+++ b/vscode/src/views/SummaryScriptBuilder.test.ts
@@ -138,5 +138,7 @@ describe("SummaryScriptBuilder", () => {
 		expect(script).toContain("return 'OpenCode'");
 		expect(script).toContain("source === 'gemini'");
 		expect(script).toContain("return 'Gemini'");
+		expect(script).toContain("source === 'cursor'");
+		expect(script).toContain("return 'Cursor'");
 	});
 });

--- a/vscode/src/views/SummaryScriptBuilder.ts
+++ b/vscode/src/views/SummaryScriptBuilder.ts
@@ -1132,6 +1132,7 @@ ${buildPrMessageScript()}
     if (source === 'codex') return 'Codex';
     if (source === 'gemini') return 'Gemini';
     if (source === 'opencode') return 'OpenCode';
+    if (source === 'cursor') return 'Cursor';
     return 'Claude';
   }
 
@@ -1557,7 +1558,7 @@ ${buildPrMessageScript()}
       if (conversationsStats) {
         var sessionCounts = msg.sessionCounts || {};
         var parts = [];
-        var sourceOrder = ['claude', 'codex', 'gemini', 'opencode'];
+        var sourceOrder = ['claude', 'codex', 'gemini', 'opencode', 'cursor'];
         for (var i = 0; i < sourceOrder.length; i++) {
           var source = sourceOrder[i];
           var count = sessionCounts[source] || 0;

--- a/vscode/src/views/SummaryWebviewPanel.test.ts
+++ b/vscode/src/views/SummaryWebviewPanel.test.ts
@@ -2560,6 +2560,40 @@ describe("SummaryWebviewPanel", () => {
 				);
 			});
 
+			it("counts cursor sessions in transcript stats when cursor integration is enabled", async () => {
+				mockGetTranscriptHashes.mockResolvedValue(new Set(["abc123"]));
+				const transcriptMap = new Map([
+					[
+						"abc123",
+						{
+							sessions: [
+								{
+									sessionId: "cur1",
+									source: "cursor" as const,
+									entries: [{ role: "human" as const, content: "hi" }],
+								},
+							],
+						},
+					],
+				]);
+				mockReadTranscriptsForCommits.mockResolvedValue(transcriptMap);
+
+				const summary = makeSummary();
+				await SummaryWebviewPanel.show(summary, extensionUri, workspaceRoot);
+				const dispatch = captureMessageHandler();
+
+				dispatch({ command: "loadTranscriptStats" });
+				await flushPromises();
+
+				expect(postMessage).toHaveBeenCalledWith(
+					expect.objectContaining({
+						command: "transcriptStatsLoaded",
+						totalEntries: 1,
+						sessionCounts: expect.objectContaining({ cursor: 1 }),
+					}),
+				);
+			});
+
 			it("loads transcript metadata and sends stats to webview", async () => {
 				mockGetTranscriptHashes.mockResolvedValue(new Set(["abc123"]));
 				const transcriptMap = new Map([
@@ -5566,6 +5600,59 @@ describe("SummaryWebviewPanel", () => {
 				await flushPromises();
 
 				// opencode session (oc1) should be excluded; only claude session counted
+				expect(postMessage).toHaveBeenCalledWith(
+					expect.objectContaining({
+						command: "transcriptStatsLoaded",
+						totalEntries: 1,
+						sessionCounts: expect.objectContaining({ claude: 1 }),
+					}),
+				);
+			});
+		});
+
+		// ── cursorEnabled: false ────────────────────────────────────────────────
+
+		describe("loadTranscriptStats: cursorEnabled false", () => {
+			it("excludes cursor sessions when cursorEnabled is false", async () => {
+				mockLoadConfig.mockResolvedValue({
+					claudeEnabled: true,
+					codexEnabled: true,
+					geminiEnabled: true,
+					openCodeEnabled: true,
+					cursorEnabled: false,
+				});
+				mockGetTranscriptHashes.mockResolvedValue(new Set(["abc123"]));
+				const transcriptMap = new Map([
+					[
+						"abc123",
+						{
+							sessions: [
+								{
+									sessionId: "s1",
+									source: "claude" as const,
+									entries: [{ role: "human" as const, content: "A" }],
+								},
+								{
+									sessionId: "cur1",
+									source: "cursor" as const,
+									entries: [
+										{ role: "human" as const, content: "B" },
+										{ role: "assistant" as const, content: "C" },
+									],
+								},
+							],
+						},
+					],
+				]);
+				mockReadTranscriptsForCommits.mockResolvedValue(transcriptMap);
+
+				const summary = makeSummary();
+				await SummaryWebviewPanel.show(summary, extensionUri, workspaceRoot);
+				const dispatch = captureMessageHandler();
+
+				dispatch({ command: "loadTranscriptStats" });
+				await flushPromises();
+
 				expect(postMessage).toHaveBeenCalledWith(
 					expect.objectContaining({
 						command: "transcriptStatsLoaded",

--- a/vscode/src/views/SummaryWebviewPanel.ts
+++ b/vscode/src/views/SummaryWebviewPanel.ts
@@ -2044,6 +2044,9 @@ export class SummaryWebviewPanel {
 		if (config.openCodeEnabled !== false) {
 			sources.add("opencode");
 		}
+		if (config.cursorEnabled !== false) {
+			sources.add("cursor");
+		}
 		return sources;
 	}
 


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## Quick recap

The developer added Cursor IDE as a fifth transcript source, enabling the tool to capture and summarize conversations from Cursor's Composer agent alongside Claude, Codex, Gemini, and OpenCode. Cursor workspaces are discovered using a pointer + time-window algorithm that anchors to the workspace's most recently focused composer and expands to include any composers updated within 48 hours, then reads transcript data directly from Cursor's global SQLite database. The implementation handles schema drift defensively, validating each field and silently skipping invalid entries rather than crashing when Cursor updates its storage format.

Cursor integration follows the established patterns for other AI agents: users can enable or disable Cursor session discovery via configuration, detection state and session counts appear in the status and configure CLI commands, and database scan errors surface with appropriate context in both the CLI and VS Code extension status panels. The integration is now visible throughout the extension, including the Manage All Conversations feature on the Summary Details page, where Cursor sessions are counted and displayed alongside other transcript sources. A shared SQLite utility module was extracted to support both OpenCode and Cursor, establishing a pattern for future database-backed transcript sources and reducing duplication across integrations. Comprehensive test coverage validates the discovery and reading logic against realistic Cursor database schemas, including defensive paths for malformed or missing data, ensuring the implementation is robust as the underlying database schema evolves.

---

## E2E Test (8)
<details>
<summary><strong>1. Cursor IDE appears in status command output</strong></summary>
<br>
<blockquote>

**Steps:**
1. Open a terminal and run the command: `jolli status`
2. Look at the integration status table that appears
3. Verify that a row labeled "Cursor:" is displayed alongside Claude, Codex, Gemini, and OpenCode rows
4. If Cursor is installed on your machine, the row should show "detected & enabled" with a session count
5. If Cursor is not installed, the row should not appear at all

**Expected Results:**
- The status output includes a "Cursor:" row when Cursor is detected
- The row displays the detection state (detected/not detected) and enabled status
- Session count is shown if any Cursor Composer sessions were found
- If a database error occurs, the row shows "unavailable — [error type]" instead of a session count

</blockquote>
</details>
<details>
<summary><strong>2. Cursor toggle appears in Settings page</strong></summary>
<br>
<blockquote>

**Steps:**
1. Open the VS Code extension and navigate to the Settings page
2. Scroll down to the integration toggles section
3. Look for a toggle labeled "Cursor" with the description "Session discovery via Cursor's local SQLite store"
4. Toggle the Cursor switch on and off
5. Close and reopen the Settings page to verify the toggle state persists

**Expected Results:**
- A "Cursor" toggle appears alongside toggles for Claude, Codex, Gemini, and OpenCode
- The toggle can be switched on and off without errors
- The toggle state is saved and restored when the Settings page is reopened
- At least one integration toggle must remain enabled (validation prevents disabling all integrations)

</blockquote>
</details>
<details>
<summary><strong>3. Cursor sessions appear in Manage All Conversations</strong></summary>
<br>
<blockquote>

**Steps:**
1. Open the VS Code extension and navigate to the Summary Details / Manage All Conversations page
2. Ensure the Cursor toggle is enabled in Settings
3. Look at the conversation statistics displayed on the page
4. Verify that a "Cursor" row or count appears in the source breakdown
5. Toggle Cursor off in Settings, then refresh the page
6. Verify that the Cursor count disappears from the statistics

**Expected Results:**
- When Cursor is enabled, the conversation statistics include a "Cursor" source with a session count
- When Cursor is disabled, the Cursor source is excluded from the statistics
- The count accurately reflects the number of Cursor Composer sessions discovered

</blockquote>
</details>
<details>
<summary><strong>4. Cursor integration status displays in VS Code status panel</strong></summary>
<br>
<blockquote>

**Steps:**
1. Open the VS Code extension and look at the status panel (tree view on the left sidebar)
2. Locate the "Integrations" section
3. Look for a "Cursor Integration" row
4. If Cursor is installed and enabled, it should show "Detected & enabled" with a session count
5. If a database error occurred during scanning, the row should show an error state with a tooltip

**Expected Results:**
- A "Cursor Integration" row appears in the status panel
- When healthy, it displays detection and enabled status with session count
- When a database error occurs (e.g., locked database), it shows "Unavailable" with the error type in a tooltip
- The row does not appear if Cursor is not detected

</blockquote>
</details>
<details>
<summary><strong>5. Configure command accepts cursorEnabled setting</strong></summary>
<br>
<blockquote>

**Steps:**
1. Open a terminal and run: `jolli configure --list-keys`
2. Verify that "cursorEnabled" appears in the list of valid configuration keys
3. Run: `jolli configure --set cursorEnabled=true`
4. Verify the command succeeds without error
5. Run: `jolli configure --set cursorEnabled=false`
6. Verify the command succeeds and the setting is updated

**Expected Results:**
- The `--list-keys` output includes "cursorEnabled" with a description mentioning Node 22.5+ requirement
- Setting `cursorEnabled=true` or `cursorEnabled=false` succeeds
- Invalid values (e.g., `cursorEnabled=maybe`) are rejected with a clear error message

</blockquote>
</details>
<details>
<summary><strong>6. Cursor auto-detection on first install</strong></summary>
<br>
<blockquote>

**Steps:**
1. Ensure Cursor IDE is installed on your machine
2. Run the Jolli Memory installer for the first time (or reset the global config)
3. After installation completes, run: `jolli status`
4. Check the Cursor row in the integration status table
5. Verify that Cursor shows "detected & enabled" automatically

**Expected Results:**
- If Cursor is installed, the installer automatically enables Cursor session discovery
- The status command shows Cursor as "detected & enabled" without manual configuration
- If Cursor is not installed, no Cursor row appears in the status output

</blockquote>
</details>
<details>
<summary><strong>7. Cursor database errors surface in UI</strong></summary>
<br>
<blockquote>

**Steps:**
1. Open the VS Code extension and navigate to Settings
2. Enable Cursor integration
3. Simulate a database error by corrupting or locking the Cursor database file (or wait for a real lock condition)
4. Run the status command or refresh the extension status panel
5. Look for error reporting in the Cursor row

**Expected Results:**
- When a database scan error occurs, the Cursor row displays "unavailable — [error kind]" (e.g., "unavailable — locked")
- The error kind and full message are visible in a tooltip or status details
- The error does not crash the application or prevent other integrations from being scanned

</blockquote>
</details>
<details>
<summary><strong>8. Cursor sessions flow through to commit summary</strong></summary>
<br>
<blockquote>

**Steps:**
1. Ensure Cursor is installed and enabled
2. Create a Cursor Composer conversation in your project
3. Make a commit in a repository where Jolli Memory is installed
4. Check the commit message or summary to verify Cursor sessions are included
5. Disable Cursor in Settings and make another commit
6. Verify that Cursor sessions no longer appear in the summary

**Expected Results:**
- When Cursor is enabled, Cursor Composer sessions are discovered and included in the commit summary
- When Cursor is disabled, Cursor sessions are excluded from the summary
- Sessions from other integrations (Claude, Codex, etc.) are unaffected by the Cursor toggle

</blockquote>
</details>

---

## Topics (9)
<details>
<summary><strong>01 · Cursor IDE support as fifth transcript source with pointer + time-window attribution</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The team needed to add Cursor (a VS Code fork with its own AI Composer agent) as a new transcript source alongside Claude, Codex, Gemini, and OpenCode. Cursor's Composer conversations were not being captured by the existing discovery pipeline.

**💡 Decisions Behind the Code**

- **Pointer + time-window over pure time-window**: Cursor stores composers globally without a strong workspace→composers mapping on disk. The algorithm uses Cursor's own UI state (`lastFocusedComposerIds` and `selectedComposerIds`) as an anchor to guarantee the focused composer is always captured, then extends with a 48-hour time window to catch background or multiplexed cases. This avoids false negatives (missing the composer the user was actually working in) while accepting some false positives (unrelated composers updated in the same window), which the LLM summarizer naturally filters.
- **SQLite as the single source of truth**: Cursor's `chatSessions/*.jsonl` files are empty UI state placeholders; the real transcript data lives in the global `state.vscdb` under `cursorDiskKV`. This required hands-on verification of the actual database schema before committing to the design, avoiding a costly rework if the assumption had been wrong.
- **Synthetic transcript path matching OpenCode pattern**: The transcriptPath is constructed as `<globalDbPath>#<composerId>` to match OpenCode's existing pattern, allowing downstream cursor-keying and transcript-reading code to work uniformly across SQLite-backed sources without special-casing Cursor.
- **Schema-drift defensive coding**: Cursor's internal data structures (workspace metadata, composer records, transcript bubbles) are not formally versioned. The code explicitly validates each field (checking for non-finite timestamps, missing text, malformed JSON) and silently skips invalid entries or warns at the discoverer level. This prevents crashes when Cursor updates its storage format and makes the integration resilient to real-world data corruption.

**✅ What Was Implemented**

- Created `CursorDetector.ts` to detect Cursor installation by checking for the global SQLite database at platform-specific paths (macOS: `~/Library/Application Support/Cursor`, Linux: `~/.config/Cursor`, Windows: `%APPDATA%/Cursor`), with a runtime gate to prevent false positives on Node versions that lack SQLite support.
- Implemented `CursorSessionDiscoverer.ts` using a pointer + time-window attribution algorithm: workspace lookup finds the workspace hash matching the project directory, anchor extraction reads per-workspace pointers to always-included composers, time-window scan includes composers updated within 48 hours, and union with deduplication combines results. Workspace-level failures gracefully degrade to time-window-only results rather than aborting the scan.
- Implemented `CursorTranscriptReader.ts` to parse Cursor's `cursorDiskKV` SQLite table: reads `composerData:<composerId>` to get the ordered bubble index, then reads `bubbleId:<composerId>:<bubbleId>` rows in sequence, mapping bubble types (1 = user, 2 = assistant) to human/assistant roles and extracting plain-text message content. Supports cursor-based incremental reads and timestamp cutoffs for commit-window alignment.
- Wired Cursor discovery and reading into `QueueWorker.ts` alongside existing Gemini and OpenCode integrations, following the established pattern for editor-based transcript sources.

**📁 FILES**
- `cli/src/core/CursorDetector.ts`
- `cli/src/core/CursorSessionDiscoverer.ts`
- `cli/src/core/CursorTranscriptReader.ts`
- `cli/src/hooks/QueueWorker.ts`

</blockquote>
</details>
<details>
<summary><strong>02 · Extract shared SQLite utilities for reuse across transcript sources</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Both OpenCode and Cursor integrations needed to query SQLite databases (VS Code's workspace storage and Cursor's internal state). Rather than duplicate the database-opening and error-handling logic, the code was refactored to share a common utility module.

**💡 Decisions Behind the Code**

The deprecated aliases in `OpenCodeSessionDiscoverer` preserve backward compatibility so existing code continues to work without immediate refactoring, while new code and other agents can import directly from `SqliteHelpers`. This staged migration approach avoids a breaking change and allows callers to adopt the new names at their own pace. Placing the pure-refactor extraction as a standalone commit (before any new agent features) makes code review simpler — reviewers see zero behavioral change in this commit, and all subsequent feature commits can safely reference the new `SqliteHelpers` module without introducing hidden dependencies or naming conflicts.

**✅ What Was Implemented**

- Created a new `SqliteHelpers.ts` module containing the generic SQLite abstractions: `SqliteDbHandle` interface, `withSqliteDb` function for read-only database access, `NODE_SQLITE_MIN_VERSION` constant, `hasNodeSqliteSupport` version checker, and `classifyScanError` error classifier. All functions and types are now agent-agnostic and reusable.
- Updated `OpenCodeSessionDiscoverer.ts` to import and re-export these utilities as deprecated aliases (OpenCodeDbHandle → SqliteDbHandle, withOpenCodeDb → withSqliteDb, etc.), preserving backward compatibility for existing callers while directing them toward the new canonical names.
- Updated `OpenCodeTranscriptReader.ts` to import `withSqliteDb` directly from `SqliteHelpers` instead of from `OpenCodeSessionDiscoverer`, establishing the new import pattern for SQLite-dependent code.

**📁 FILES**
- `cli/src/core/SqliteHelpers.ts`
- `cli/src/core/OpenCodeSessionDiscoverer.ts`

</blockquote>
</details>
<details>
<summary><strong>03 · Add cursor literal and configuration support to session tracking</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The codebase needed to recognize and track sessions from Cursor Composer alongside existing integrations, with user-configurable enable/disable behavior and structured error reporting.

**💡 Decisions Behind the Code**

The cursor integration follows the established pattern for other AI agents (Claude, OpenCode, etc.) rather than introducing a new configuration or filtering mechanism. This consistency reduces cognitive load for users and maintainers, as the enable/disable behavior, status reporting, and session filtering all mirror existing integrations. The `cursorScanError` field includes a structured kind enum ("corrupt", "locked", "permission", "schema", "unknown") to allow the UI to surface database scan failures with appropriate context, rather than silently rendering zero sessions when the database is inaccessible or corrupted.

**✅ What Was Implemented**

- Added "cursor" as a new literal value to the `TranscriptSource` type in `Types.ts`, expanding the union of recognized AI agent sources.
- Extended `JolliMemoryConfig` interface with a `cursorEnabled` boolean flag to allow users to enable or disable Cursor session discovery at post-commit time, matching the pattern used for other integrations.
- Expanded `StatusInfo` interface with three new fields: `cursorDetected` (boolean indicating whether Cursor data directory was found), `cursorEnabled` (boolean reflecting config state), and `cursorScanError` (structured error object capturing database scan failures with kind and message).
- Updated `filterSessionsByEnabledIntegrations` function in `SessionTracker.ts` to filter out cursor sessions when `cursorEnabled` is explicitly set to false, consistent with behavior for other integrations.

**📁 FILES**
- `cli/src/Types.ts`
- `cli/src/core/SessionTracker.ts`

</blockquote>
</details>
<details>
<summary><strong>04 · Wire Cursor auto-detection and status reporting in Installer</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The Installer module needed to detect when Cursor is installed and automatically enable Cursor Composer session discovery, mirroring the existing behavior for OpenCode. Additionally, the status reporting system needed to surface Cursor sessions and scan errors alongside other editor integrations.

**💡 Decisions Behind the Code**

- **Preserve existing configuration over auto-detection**: when Cursor is detected but `cursorEnabled` is already set (to either true or false), the installer does not overwrite it. This respects user intent and prevents unexpected re-enabling of a deliberately disabled integration, while still auto-enabling only on first detection when the setting is undefined.
- **Surface scan errors to the UI rather than silently failing**: the status object now includes a `cursorScanError` field so the UI can warn users about database corruption or other scan failures instead of showing zero sessions and leaving the user confused about whether Cursor sessions actually exist.

**✅ What Was Implemented**

- Added Cursor auto-detection during installation: when Cursor is detected and not yet configured, the installer automatically enables Cursor session discovery by setting `cursorEnabled: true` in the global config. If the setting already exists (true or false), it is left unchanged.
- Extended status reporting to include Cursor detection state, enabled flag, and scan errors: the `getStatus()` function now calls `scanCursorSessions()` when Cursor is enabled and detected, appends discovered sessions to the active session list, and surfaces any SQLite scan errors (e.g., corrupt database) to the UI.

**📁 FILES**
- `cli/src/install/Installer.ts`

</blockquote>
</details>
<details>
<summary><strong>05 · Surface Cursor in status and configure CLI commands</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The Cursor code editor integration needed to be surfaced in the CLI's status and configuration commands, alongside existing integrations like Claude, Codex, Gemini, and OpenCode.

**💡 Decisions Behind the Code**

The Cursor integration was implemented using the exact same structure and patterns already established for OpenCode, rather than introducing a new pattern. This minimizes cognitive load for maintainers and ensures consistent user experience across all integrations. The integration respects the same Node 22.5+ runtime requirement as OpenCode, keeping version constraints aligned across similar features.

**✅ What Was Implemented**

- Updated `StatusCommand.ts` to include a Cursor row in the integration status table, displaying detection state, enabled status, session count, and any scan errors using the same pattern as other integrations.
- Extended `ConfigureCommand.ts` to accept `cursorEnabled` as a valid configuration key, with boolean coercion logic and help text describing it as a Node 22.5+ feature.

**📁 FILES**
- `cli/src/commands/StatusCommand.ts`
- `cli/src/commands/ConfigureCommand.ts`

</blockquote>
</details>
<details>
<summary><strong>06 · Add Cursor Integration status display to VS Code extension status panel</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The status panel in the VS Code extension needed to display Cursor Integration information alongside other integrations like OpenCode and Gemini, including detection status, enablement state, and any database scan errors.

**💡 Decisions Behind the Code**

The implementation follows the existing OpenCode pattern for handling scan errors rather than inventing a new pattern. This ensures consistency in how the status panel presents integration health across different sources and makes the UI predictable for users. Scan errors surface as unavailable rows with warning icons and detailed tooltips, preventing them from being misinterpreted as zero sessions. The normal path uses the shared `pushIntegrationItem` helper to render detected/enabled states with optional session counts, keeping the code DRY and maintainable.

**✅ What Was Implemented**

- Modified `StatusTreeProvider.ts` to add a Cursor Integration row in the status panel that mirrors the OpenCode pattern: when a database scan error occurs, it displays an unavailable state with the error kind and full error message in the tooltip; when healthy, it shows detected/enabled status with session counts from `sessionsBySource.cursor`.
- Added two test cases in `StatusTreeProvider.test.ts` covering the error path (scan failure with locked database) and the healthy path (normal detected and enabled state with session count).

**📁 FILES**
- `vscode/src/providers/StatusTreeProvider.ts`

</blockquote>
</details>
<details>
<summary><strong>07 · Add Cursor IDE as a transcript source in Summary Details</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The Manage All Conversations feature on the Summary Details page was not counting or displaying Cursor IDE sessions, even though Cursor integration was already supported elsewhere in the extension.

**💡 Decisions Behind the Code**

Cursor was integrated into the same configuration-driven enable/disable pattern already used for Claude, Codex, Gemini, and OpenCode. This approach maintains consistency across all transcript sources and ensures that users who disable Cursor session discovery in settings will see it automatically excluded from conversation statistics, just like other integrations. The source ordering places Cursor last in the display list, preserving the existing visual hierarchy while adding it as a peer to other sources.

**✅ What Was Implemented**

- Updated `getEnabledSources()` in `SummaryWebviewPanel.ts` to include `"cursor"` when the Cursor integration is enabled, matching the behavior of other transcript sources like Claude and Codex.
- Extended `SummaryScriptBuilder.ts` to map the `cursor` source to the display label `"Cursor"` and added it to the `sourceOrder` array so conversation statistics display Cursor counts alongside other sources.
- Added test coverage in both `SummaryWebviewPanel.test.ts` and `SummaryScriptBuilder.test.ts` to verify that Cursor sessions are counted when enabled and excluded when `cursorEnabled: false`.

**📁 FILES**
- `vscode/src/views/SummaryWebviewPanel.ts`
- `vscode/src/views/SummaryScriptBuilder.ts`

</blockquote>
</details>
<details>
<summary><strong>08 · Add Cursor IDE enable/disable toggle to Settings page</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The Settings page in the VS Code extension had toggles for other transcript sources (Claude, Codex, Gemini, OpenCode) but was missing one for Cursor, even though Cursor support had already been added to the CLI and backend logic.

**💡 Decisions Behind the Code**

- **Cursor as a "discovery" source, not a hook-based integration**: Cursor was treated the same as OpenCode and Codex (scan-based discovery) rather than Claude and Gemini (which require agent hooks). This meant the toggle only needed to be added to the Settings UI and payload, not to the `syncHooks` function that installs/removes hooks. This kept the change focused and avoided unnecessary complexity in hook management.
- **Webview dual-definition pattern**: The toggle had to be defined in two places—the host-side `SettingsPayload` interface and the webview-side script builder's initialState—to satisfy both TypeScript type checking and the dirty-change detection mechanism. Skipping either would cause either type errors or the Apply button to not light up when users toggled Cursor. This is a structural constraint of the webview isolation model.
- **Validation includes Cursor in "at least one integration" check**: The validation logic was updated to require Cursor (along with Claude, Codex, Gemini, and OpenCode) to prevent users from disabling all integrations. This ensures the feature remains usable and prevents a confusing state where no transcript sources are active.

**✅ What Was Implemented**

- Added a new toggle row for Cursor in `SettingsHtmlBuilder.ts` alongside the existing integration toggles, with the label "Cursor" and description "Session discovery via Cursor's local SQLite store".
- Wired up the webview-side logic in `SettingsScriptBuilder.ts` to track the Cursor toggle state: added DOM element reference, included it in the dirty-change detection, validation logic (ensuring at least one integration remains enabled), and the settings payload sent to the host.
- Added the `cursorEnabled` field to the `SettingsPayload` interface in `SettingsWebviewPanel.ts` and implemented load/save logic to read the setting from config and persist user changes back to storage.
- Added assertions in test files (`SettingsHtmlBuilder.test.ts`, `SettingsScriptBuilder.test.ts`, `SettingsWebviewPanel.test.ts`) to verify the Cursor toggle is present in the HTML, included in validation logic, and correctly loaded and saved across settings operations.

**📁 FILES**
- `vscode/src/views/SettingsHtmlBuilder.ts`
- `vscode/src/views/SettingsScriptBuilder.ts`
- `vscode/src/views/SettingsWebviewPanel.ts`

</blockquote>
</details>
<details>
<summary><strong>09 · Comprehensive test coverage for Cursor session discovery and transcript reading</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The new Cursor session discovery and transcript reading modules needed test coverage to verify correct behavior across workspace matching, anchor extraction, time-window filtering, error handling, and schema-drift scenarios.

**💡 Decisions Behind the Code**

- **Fixture-driven testing with realistic SQLite schemas**: ensures the discovery and reading logic is validated against actual Cursor database structure rather than mocks, reducing the risk of schema drift breaking the scanner in production. The test suite exercises both the happy path (matching workspace, readable databases) and failure modes (missing files, corrupt JSON, unreadable databases) to verify graceful degradation.
- **Nullish-coalescing branch coverage required "broken fixture" tests rather than happy-path tests**: The Cursor schema includes optional fields (type, text, fullConversationHeadersOnly) that default to fallback values via `??` operators. Standard test fixtures populate all fields, so these fallback branches never execute. The solution was to write tests with deliberately incomplete JSON payloads (missing type, missing text, missing the entire header array) to force the reader to exercise the defensive code paths. This approach is more maintainable than trying to mock partial parse results.
- **Platform-specific path matching needed consistent mocking across both Cursor and OpenCode discoverers**: Both files had mixed usage of `process.platform` and `os.platform()`, making it impossible to mock platform behavior uniformly in tests. Standardizing on `os.platform()` (which is already imported and mocked in the test suite) eliminated the inconsistency and allowed tests to verify case-sensitive matching on Linux and case-insensitive matching on Windows/macOS without platform-specific test skips.
- **QueueWorker pipeline tests required explicit Cursor mocks to avoid false coverage**: The QueueWorker file has 16 new lines of Cursor-specific logic (discovery and transcript reading), but without dedicated test cases that set `isCursorInstalled=true` and return non-empty session arrays, those lines remained unreachable. Adding two focused tests (one for the happy path with sessions, one for the empty-sessions edge case) ensured the new code was exercised without inflating the test suite with redundant integration scenarios.

**✅ What Was Implemented**

- Added `CursorSessionDiscoverer.test.ts` with test cases covering: no matching workspace (returns empty), anchor composer always included even if ancient, time-window composers included alongside anchors with deduplication, URL decoding and case-insensitive path matching on macOS, empty result when no anchor and no fresh composers despite workspace match, corrupt database error surfacing, malformed JSON in composer rows, missing or non-string composerId field, non-finite lastUpdatedAt timestamps, non-file:// workspace folder URIs, and fallback to selectedComposerIds when lastFocusedComposerIds is absent.
- Added `CursorTranscriptReader.test.ts` with test cases covering: path parsing, type-to-role mapping, consecutive message merging, empty text filtering, cursor-based incremental reads, timestamp cutoff behavior, error handling for missing composers, skipping bubbles whose row is missing from the database, and skipping bubbles whose row JSON is malformed.
- Test fixtures include `createCursorGlobalDb()` and `createCursorWorkspaceDb()` to construct realistic SQLite state with composer metadata and workspace pointers, and `setupCursorHome()` to orchestrate a complete Cursor home directory structure with multiple workspaces.
- Added 230 lines of edge-case tests to `CursorSessionDiscoverer.test.ts` and 91 lines to `CursorTranscriptReader.test.ts` covering nullish coalescing fallbacks, missing schema fields, and JSON parse failures to achieve 98% coverage across all metrics (statement, branch, function, line).
- Added 107 lines of test cases to `QueueWorker.test.ts` covering the Cursor discovery and transcript-reading pipeline: one test verifies that discovered sessions flow through to the summary generation step, another confirms that the cursorEnabled config flag properly short-circuits discovery, and a third validates that empty discovery results are handled gracefully without errors.

**📁 FILES**
- `cli/src/core/CursorSessionDiscoverer.test.ts`
- `cli/src/core/CursorTranscriptReader.test.ts`
- `cli/src/core/OpenCodeSessionDiscoverer.test.ts`

</blockquote>
</details>

---

*Generated by Jolli Memory · May 5, 2026 at 11:27 AM*
<!-- jollimemory-summary-end -->