### PR TITLE
Add GitHub Copilot CLI and VS Code Copilot Chat as transcript sources

### DIFF
--- a/cli/src/Types.ts
+++ b/cli/src/Types.ts
@@ -4,10 +4,11 @@
  * Central type definitions for all modules in the Jolli Memory tool.
  */
 
+import type { CopilotChatScanError } from "./core/CopilotChatTranscriptReader.js";
 import type { SqliteScanError } from "./core/SqliteHelpers.js";
 
 /** Which AI coding agent produced the transcript */
-export type TranscriptSource = "claude" | "codex" | "gemini" | "opencode" | "cursor" | "copilot";
+export type TranscriptSource = "claude" | "codex" | "gemini" | "opencode" | "cursor" | "copilot" | "copilot-chat";
 
 /** Metadata about an AI coding session, saved by the Stop hook (Claude) or discovered on-demand (Codex) */
 export interface SessionInfo {
@@ -614,6 +615,10 @@ export interface StatusInfo {
 	readonly openCodeScanError?: SqliteScanError;
 	/** Copilot DB scan failed with a real (non-ENOENT) error. Same UI semantics as openCodeScanError. */
 	readonly copilotScanError?: SqliteScanError;
+	/** Whether vscode's Copilot Chat globalStorage dir was detected */
+	readonly copilotChatDetected?: boolean;
+	/** Copilot Chat scan failed with a real (non-ENOENT) error: parse / fs / schema. */
+	readonly copilotChatScanError?: CopilotChatScanError;
 }
 
 /**

--- a/cli/src/Types.ts
+++ b/cli/src/Types.ts
@@ -4,8 +4,10 @@
  * Central type definitions for all modules in the Jolli Memory tool.
  */
 
+import type { SqliteScanError } from "./core/SqliteHelpers.js";
+
 /** Which AI coding agent produced the transcript */
-export type TranscriptSource = "claude" | "codex" | "gemini" | "opencode" | "cursor";
+export type TranscriptSource = "claude" | "codex" | "gemini" | "opencode" | "cursor" | "copilot";
 
 /** Metadata about an AI coding session, saved by the Stop hook (Claude) or discovered on-demand (Codex) */
 export interface SessionInfo {
@@ -488,6 +490,8 @@ export interface JolliMemoryConfig {
 	readonly openCodeEnabled?: boolean;
 	/** Enable Cursor Composer session discovery at post-commit time (default: auto-detect) */
 	readonly cursorEnabled?: boolean;
+	/** Enable GitHub Copilot CLI session discovery at post-commit time (default: auto-detect) */
+	readonly copilotEnabled?: boolean;
 	/** Global minimum log level written to debug.log (default: "info") */
 	readonly logLevel?: LogLevel;
 	/** Per-module log level overrides (e.g. { "GitOps": "debug" }) */
@@ -569,10 +573,11 @@ export interface StatusInfo {
 	 * schema drift, or permission denied. UI surfaces this adjacent to the Cursor
 	 * row instead of silently rendering "0 sessions".
 	 */
-	readonly cursorScanError?: {
-		readonly kind: "corrupt" | "locked" | "permission" | "schema" | "unknown";
-		readonly message: string;
-	};
+	readonly cursorScanError?: SqliteScanError;
+	/** Whether Copilot CLI's session DB (~/.copilot/session-store.db) was detected */
+	readonly copilotDetected?: boolean;
+	/** Whether Copilot CLI session discovery is enabled in config (undefined = auto-detect) */
+	readonly copilotEnabled?: boolean;
 	/** Directory path for global config (~/.jolli/jollimemory) */
 	readonly globalConfigDir?: string;
 	/** Path to the worktree state directory */
@@ -606,10 +611,9 @@ export interface StatusInfo {
 	 * a warning adjacent to the OpenCode integration row rather than rendering
 	 * "0 sessions" (which is indistinguishable from "no OpenCode activity").
 	 */
-	readonly openCodeScanError?: {
-		readonly kind: "corrupt" | "locked" | "permission" | "schema" | "unknown";
-		readonly message: string;
-	};
+	readonly openCodeScanError?: SqliteScanError;
+	/** Copilot DB scan failed with a real (non-ENOENT) error. Same UI semantics as openCodeScanError. */
+	readonly copilotScanError?: SqliteScanError;
 }
 
 /**

--- a/cli/src/commands/ConfigureCommand.test.ts
+++ b/cli/src/commands/ConfigureCommand.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Tests for ConfigureCommand — `jolli configure` copilotEnabled key.
+ *
+ * Covers:
+ *   - copilotEnabled accepted as a settable boolean key
+ *   - copilotEnabled appears in --list-keys output
+ */
+
+import { Command } from "commander";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { JolliMemoryConfig } from "../Types.js";
+
+// ─── Hoist mocks ─────────────────────────────────────────────────────────────
+
+const { mockLoadConfig, mockSaveConfig } = vi.hoisted(() => ({
+	mockLoadConfig: vi.fn(),
+	mockSaveConfig: vi.fn(),
+}));
+
+vi.mock("../core/SessionTracker.js", () => ({
+	getGlobalConfigDir: vi.fn().mockReturnValue("/mock/global/config"),
+	loadConfig: mockLoadConfig,
+	saveConfig: mockSaveConfig,
+}));
+
+vi.mock("../core/JolliApiUtils.js", () => ({
+	validateJolliApiKey: vi.fn(),
+}));
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/** Captured config built up from saveConfig calls. */
+let savedConfig: Partial<JolliMemoryConfig> = {};
+
+/**
+ * Runs `jolli configure` with the given args and returns stdout output.
+ * Side effects on savedConfig accumulate across calls (reset in beforeEach).
+ */
+async function runConfigure(args: string[]): Promise<string> {
+	const { registerConfigureCommand } = await import("./ConfigureCommand.js");
+	const program = new Command();
+	program.exitOverride();
+	registerConfigureCommand(program);
+
+	const lines: string[] = [];
+	const spy = vi.spyOn(console, "log").mockImplementation((...a: unknown[]) => {
+		lines.push(a.map(String).join(" "));
+	});
+	try {
+		await program.parseAsync(["configure", ...args], { from: "user" });
+	} finally {
+		spy.mockRestore();
+	}
+	return lines.join("\n");
+}
+
+/**
+ * Returns a loadable config object reflecting whatever saveConfig was last
+ * called with.  Mimics the real SessionTracker round-trip.
+ */
+async function loadConfig(): Promise<Partial<JolliMemoryConfig>> {
+	return savedConfig;
+}
+
+/**
+ * Runs `jolli configure --list-keys` and returns the captured output.
+ */
+async function runConfigureHelp(): Promise<string> {
+	return runConfigure(["--list-keys"]);
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("ConfigureCommand — copilotEnabled key", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		savedConfig = {};
+		mockLoadConfig.mockResolvedValue({});
+		// Wire saveConfig to capture what was saved
+		mockSaveConfig.mockImplementation(async (update: Partial<JolliMemoryConfig>) => {
+			savedConfig = { ...savedConfig, ...update };
+		});
+	});
+
+	afterEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("accepts copilotEnabled as a boolean key", async () => {
+		await runConfigure(["--set", "copilotEnabled=true"]);
+		expect(mockSaveConfig).toHaveBeenCalledWith(expect.objectContaining({ copilotEnabled: true }));
+		expect((await loadConfig()).copilotEnabled).toBe(true);
+
+		await runConfigure(["--set", "copilotEnabled=false"]);
+		expect(mockSaveConfig).toHaveBeenCalledWith(expect.objectContaining({ copilotEnabled: false }));
+		expect((await loadConfig()).copilotEnabled).toBe(false);
+	});
+
+	it("lists copilotEnabled in help/description output", async () => {
+		const help = await runConfigureHelp();
+		expect(help).toContain("copilotEnabled");
+	});
+});

--- a/cli/src/commands/ConfigureCommand.ts
+++ b/cli/src/commands/ConfigureCommand.ts
@@ -32,6 +32,7 @@ const VALID_CONFIG_KEYS = [
 	"claudeEnabled",
 	"openCodeEnabled",
 	"cursorEnabled",
+	"copilotEnabled",
 	"logLevel",
 	"excludePatterns",
 ] as const satisfies ReadonlyArray<keyof JolliMemoryConfig>;
@@ -70,7 +71,8 @@ function coerceConfigValue(key: ConfigKey, raw: string): string | number | boole
 		key === "geminiEnabled" ||
 		key === "claudeEnabled" ||
 		key === "openCodeEnabled" ||
-		key === "cursorEnabled"
+		key === "cursorEnabled" ||
+		key === "copilotEnabled"
 	) {
 		const lower = raw.toLowerCase();
 		if (lower === "true" || lower === "1" || lower === "yes") return true;
@@ -114,6 +116,11 @@ const CONFIG_KEY_INFO: ReadonlyArray<{ key: ConfigKey; type: string; description
 		key: "cursorEnabled",
 		type: "boolean",
 		description: "Enable Cursor Composer session discovery (true/false; requires Node 22.5+ at runtime)",
+	},
+	{
+		key: "copilotEnabled",
+		type: "boolean",
+		description: "Enable Copilot CLI session discovery (true/false; requires Node 22.5+ at runtime)",
 	},
 	{ key: "logLevel", type: "enum", description: "Log level: debug | info | warn | error" },
 	{ key: "excludePatterns", type: "string[]", description: "Glob patterns for file exclusion (comma-separated)" },

--- a/cli/src/commands/StatusCommand.test.ts
+++ b/cli/src/commands/StatusCommand.test.ts
@@ -127,4 +127,32 @@ describe("StatusCommand — Copilot integration row", () => {
 		expect(out).toContain("Copilot");
 		expect(out).toContain("detected but disabled");
 	});
+
+	it("Copilot row shows CLI/Chat breakdown when only chat is detected", async () => {
+		const out = await renderStatus({
+			...baseStatus,
+			copilotDetected: false,
+			copilotChatDetected: true,
+			copilotEnabled: true,
+			sessionsBySource: { "copilot-chat": 2 },
+		});
+		expect(out).toContain("CLI: ✗");
+		expect(out).toContain("Chat: ✓");
+		expect(out).toMatch(/2\s*sessions/);
+	});
+
+	it("emits a Chat scan-failed sub-line when copilotChatScanError is set", async () => {
+		// CLI scan error renders on the main row; Chat error is structurally
+		// different — it surfaces as an indented "↳ Chat scan failed" sub-line
+		// underneath the CLI/Chat breakdown so users can tell which form failed.
+		const out = await renderStatus({
+			...baseStatus,
+			copilotDetected: true,
+			copilotChatDetected: true,
+			copilotEnabled: true,
+			copilotChatScanError: { kind: "parse", message: "bad jsonl event at line 7" },
+		});
+		expect(out).toContain("Chat scan failed (parse)");
+		expect(out).toContain("bad jsonl event at line 7");
+	});
 });

--- a/cli/src/commands/StatusCommand.test.ts
+++ b/cli/src/commands/StatusCommand.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Tests for StatusCommand — `jolli status` integration rows.
+ *
+ * Covers the per-integration breakdown output, focused on the Copilot row.
+ */
+
+import { Command } from "commander";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { StatusInfo } from "../Types.js";
+
+// ─── Hoist mocks ─────────────────────────────────────────────────────────────
+
+const { mockGetStatus, mockLoadConfigFromDir, mockLoadAuthToken } = vi.hoisted(() => ({
+	mockGetStatus: vi.fn(),
+	mockLoadConfigFromDir: vi.fn(),
+	mockLoadAuthToken: vi.fn(),
+}));
+
+vi.mock("../install/Installer.js", () => ({
+	getStatus: mockGetStatus,
+}));
+
+vi.mock("../core/SessionTracker.js", () => ({
+	getGlobalConfigDir: vi.fn().mockReturnValue("/mock/global/config"),
+	loadConfigFromDir: mockLoadConfigFromDir,
+}));
+
+vi.mock("../auth/AuthConfig.js", () => ({
+	loadAuthToken: mockLoadAuthToken,
+}));
+
+vi.mock("../core/JolliApiUtils.js", () => ({
+	parseJolliApiKey: vi.fn().mockReturnValue(null),
+}));
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/**
+ * Minimal StatusInfo satisfying the required fields — used as the spread base
+ * in individual test cases.
+ */
+const baseStatus: StatusInfo = {
+	enabled: true,
+	claudeHookInstalled: false,
+	gitHookInstalled: false,
+	geminiHookInstalled: false,
+	activeSessions: 0,
+	mostRecentSession: null,
+	summaryCount: 0,
+	orphanBranch: "jollimemory/summaries/v3",
+	sessionsBySource: {},
+};
+
+/**
+ * Renders `jolli status` output to a string by capturing console.log calls.
+ * Configures mockGetStatus with the given status before parsing.
+ */
+async function renderStatus(status: StatusInfo): Promise<string> {
+	mockGetStatus.mockResolvedValueOnce(status);
+
+	const { registerStatusCommand } = await import("./StatusCommand.js");
+	const program = new Command();
+	program.exitOverride();
+	registerStatusCommand(program);
+
+	const lines: string[] = [];
+	const spy = vi.spyOn(console, "log").mockImplementation((...args: unknown[]) => {
+		lines.push(args.map(String).join(" "));
+	});
+	try {
+		await program.parseAsync(["status"], { from: "user" });
+	} finally {
+		spy.mockRestore();
+	}
+	return lines.join("\n");
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("StatusCommand — Copilot integration row", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockLoadConfigFromDir.mockResolvedValue({});
+		mockLoadAuthToken.mockResolvedValue(null);
+	});
+
+	afterEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("does not render Copilot row when copilot not detected", async () => {
+		const out = await renderStatus({
+			...baseStatus,
+			// copilotDetected unset (undefined) -> default state
+		});
+		expect(out).not.toContain("Copilot:");
+	});
+
+	it("renders Copilot Integration row when detected", async () => {
+		const out = await renderStatus({
+			...baseStatus,
+			copilotDetected: true,
+			copilotEnabled: true,
+			sessionsBySource: { copilot: 3 },
+		});
+		expect(out).toContain("Copilot");
+		expect(out).toContain("3");
+	});
+
+	it("renders Copilot row as unavailable on scan error", async () => {
+		const out = await renderStatus({
+			...baseStatus,
+			copilotDetected: true,
+			copilotScanError: { kind: "locked", message: "database is locked" },
+		});
+		expect(out).toContain("Copilot");
+		expect(out).toContain("unavailable");
+		expect(out).toContain("locked");
+	});
+
+	it("renders Copilot row as disabled when detected but copilotEnabled is false", async () => {
+		const out = await renderStatus({
+			...baseStatus,
+			copilotDetected: true,
+			copilotEnabled: false,
+		});
+		expect(out).toContain("Copilot");
+		expect(out).toContain("detected but disabled");
+	});
+});

--- a/cli/src/commands/StatusCommand.ts
+++ b/cli/src/commands/StatusCommand.ts
@@ -160,11 +160,12 @@ export function registerStatusCommand(program: Command): void {
 				],
 				[
 					"Copilot:",
-					status.copilotDetected,
+					(status.copilotDetected ?? false) || (status.copilotChatDetected ?? false),
 					{
 						enabled: status.copilotEnabled !== false,
 						hookInstalled: undefined,
-						sessionCount: counts.copilot,
+						sessionCount: (counts.copilot ?? 0) + (counts["copilot-chat"] ?? 0),
+						// CLI scan error renders on the main row; Chat scan error renders as a sub-line below.
 						scanError: status.copilotScanError,
 					},
 				],
@@ -172,6 +173,17 @@ export function registerStatusCommand(program: Command): void {
 			for (const [label, detected, inputs] of integrationRows) {
 				if (!detected) continue;
 				console.log(`  ${label.padEnd(18)}${describeIntegrationStatus(inputs)}`);
+			}
+			const anyCopilotDetected = (status.copilotDetected ?? false) || (status.copilotChatDetected ?? false);
+			if (anyCopilotDetected) {
+				const cliMark = status.copilotDetected ? "✓" : "✗";
+				const chatMark = status.copilotChatDetected ? "✓" : "✗";
+				console.log(`  ${"".padEnd(18)}↳ CLI: ${cliMark}, Chat: ${chatMark}`);
+				if (status.copilotChatScanError) {
+					console.log(
+						`  ${"".padEnd(18)}↳ Chat scan failed (${status.copilotChatScanError.kind}): ${status.copilotChatScanError.message}`,
+					);
+				}
 			}
 
 			console.log(`  Stored memories:  ${status.summaryCount}`);

--- a/cli/src/commands/StatusCommand.ts
+++ b/cli/src/commands/StatusCommand.ts
@@ -22,7 +22,7 @@ interface IntegrationStatusInputs {
 	/** undefined = this integration has no hook concept (Codex, OpenCode). */
 	readonly hookInstalled: boolean | undefined;
 	readonly sessionCount: number | undefined;
-	/** OpenCode-only: DB existed but scan failed (corrupt/locked/schema/etc). */
+	/** DB existed but scan failed (corrupt/locked/schema/etc). Used by OpenCode and Copilot integrations. */
 	readonly scanError?: StatusInfo["openCodeScanError"];
 }
 
@@ -156,6 +156,16 @@ export function registerStatusCommand(program: Command): void {
 						hookInstalled: undefined,
 						sessionCount: counts.cursor,
 						scanError: status.cursorScanError,
+					},
+				],
+				[
+					"Copilot:",
+					status.copilotDetected,
+					{
+						enabled: status.copilotEnabled !== false,
+						hookInstalled: undefined,
+						sessionCount: counts.copilot,
+						scanError: status.copilotScanError,
 					},
 				],
 			];

--- a/cli/src/core/CopilotChatDetector.test.ts
+++ b/cli/src/core/CopilotChatDetector.test.ts
@@ -1,0 +1,111 @@
+import { stat } from "node:fs/promises";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("node:fs/promises", async () => {
+	const actual = await vi.importActual<typeof import("node:fs/promises")>("node:fs/promises");
+	return { ...actual, stat: vi.fn() };
+});
+
+const { mockHomedir, mockPlatform } = vi.hoisted(() => ({
+	mockHomedir: vi.fn().mockReturnValue("/Users/test"),
+	mockPlatform: vi.fn().mockReturnValue("darwin"),
+}));
+
+vi.mock("node:os", async (importOriginal) => {
+	const original = await importOriginal<typeof import("node:os")>();
+	return { ...original, homedir: mockHomedir, platform: mockPlatform };
+});
+
+describe("CopilotChatDetector", () => {
+	beforeEach(() => {
+		mockHomedir.mockReturnValue("/Users/test");
+		mockPlatform.mockReturnValue("darwin");
+		vi.mocked(stat).mockReset();
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("getCopilotChatStorageDir returns vscode globalStorage path on darwin", async () => {
+		const { getCopilotChatStorageDir } = await import("./CopilotChatDetector.js");
+		expect(getCopilotChatStorageDir()).toBe(
+			join(
+				"/Users/test",
+				"Library",
+				"Application Support",
+				"Code",
+				"User",
+				"globalStorage",
+				"github.copilot-chat",
+			),
+		);
+	});
+
+	it("getCopilotCliSessionStateDir returns ~/.copilot/session-state path", async () => {
+		const { getCopilotCliSessionStateDir } = await import("./CopilotChatDetector.js");
+		expect(getCopilotCliSessionStateDir()).toBe(join("/Users/test", ".copilot", "session-state"));
+	});
+
+	it("isCopilotChatInstalled returns true when ONLY globalStorage exists", async () => {
+		// Use a path-segment regex so the includes() check works on both `/` and `\` separators.
+		const globalStorageMarker = /[\\/]globalStorage[\\/]github\.copilot-chat/;
+		vi.mocked(stat).mockImplementation(async (path) => {
+			if (globalStorageMarker.test(String(path))) {
+				return { isDirectory: () => true } as Awaited<ReturnType<typeof stat>>;
+			}
+			throw Object.assign(new Error("no dir"), { code: "ENOENT" });
+		});
+		const { isCopilotChatInstalled } = await import("./CopilotChatDetector.js");
+		await expect(isCopilotChatInstalled()).resolves.toBe(true);
+	});
+
+	it("isCopilotChatInstalled returns true when ONLY ~/.copilot/session-state exists", async () => {
+		const sessionStateMarker = /[\\/]\.copilot[\\/]session-state/;
+		vi.mocked(stat).mockImplementation(async (path) => {
+			if (sessionStateMarker.test(String(path))) {
+				return { isDirectory: () => true } as Awaited<ReturnType<typeof stat>>;
+			}
+			throw Object.assign(new Error("no dir"), { code: "ENOENT" });
+		});
+		const { isCopilotChatInstalled } = await import("./CopilotChatDetector.js");
+		await expect(isCopilotChatInstalled()).resolves.toBe(true);
+	});
+
+	it("isCopilotChatInstalled returns true when BOTH paths exist", async () => {
+		vi.mocked(stat).mockResolvedValue({ isDirectory: () => true } as Awaited<ReturnType<typeof stat>>);
+		const { isCopilotChatInstalled } = await import("./CopilotChatDetector.js");
+		await expect(isCopilotChatInstalled()).resolves.toBe(true);
+	});
+
+	it("isCopilotChatInstalled returns false when both paths missing", async () => {
+		vi.mocked(stat).mockRejectedValue(Object.assign(new Error("no dir"), { code: "ENOENT" }));
+		const { isCopilotChatInstalled } = await import("./CopilotChatDetector.js");
+		await expect(isCopilotChatInstalled()).resolves.toBe(false);
+	});
+
+	it("isCopilotChatInstalled returns false when path exists but is not a directory", async () => {
+		vi.mocked(stat).mockResolvedValue({ isDirectory: () => false } as Awaited<ReturnType<typeof stat>>);
+		const { isCopilotChatInstalled } = await import("./CopilotChatDetector.js");
+		await expect(isCopilotChatInstalled()).resolves.toBe(false);
+	});
+
+	it("isCopilotChatInstalled returns false on unexpected stat error and warn-logs", async () => {
+		vi.mocked(stat).mockRejectedValue(Object.assign(new Error("perm denied"), { code: "EACCES" }));
+		const { isCopilotChatInstalled } = await import("./CopilotChatDetector.js");
+		await expect(isCopilotChatInstalled()).resolves.toBe(false);
+	});
+
+	it("isCopilotChatInstalled warn-logs with 'unknown' when stat error has no code property", async () => {
+		// Exercises the `code ?? "unknown"` nullish-coalescing fallback in existsAsDir.
+		vi.mocked(stat).mockRejectedValue(new Error("weird error without errno code"));
+		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+		const { isCopilotChatInstalled } = await import("./CopilotChatDetector.js");
+		await expect(isCopilotChatInstalled()).resolves.toBe(false);
+		expect(warnSpy).toHaveBeenCalled();
+		const formatted = warnSpy.mock.calls.map((c) => String(c[0])).join("\n");
+		expect(formatted).toMatch(/unknown/);
+		warnSpy.mockRestore();
+	});
+});

--- a/cli/src/core/CopilotChatDetector.ts
+++ b/cli/src/core/CopilotChatDetector.ts
@@ -1,0 +1,60 @@
+/**
+ * VS Code Copilot Chat detector.
+ *
+ * Returns true when EITHER of the two Copilot Chat data roots exist:
+ *   - <userDataDir>/User/globalStorage/github.copilot-chat (Copilot Chat extension installed)
+ *   - ~/.copilot/session-state                              (Copilot CLI agent backend on disk)
+ *
+ * Either root can carry chat panel "New Chat" session data; chat-panel sessions
+ * with copilotcli-backend models write to the latter (events.jsonl), and
+ * sessions with other-vendor models write to chatSessions/<sid>.jsonl under
+ * the former's parent workspace storage tree.
+ */
+
+import { stat } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { createLogger } from "../Logger.js";
+import { getVscodeUserDataDir } from "./VscodeWorkspaceLocator.js";
+
+const log = createLogger("CopilotChatDetector");
+
+/** Returns vscode's globalStorage/github.copilot-chat directory path. */
+export function getCopilotChatStorageDir(home?: string): string {
+	return join(getVscodeUserDataDir("Code", home), "User", "globalStorage", "github.copilot-chat");
+}
+
+/** Returns ~/.copilot/session-state directory path (Copilot CLI agent backend). */
+export function getCopilotCliSessionStateDir(home: string = homedir()): string {
+	return join(home, ".copilot", "session-state");
+}
+
+async function existsAsDir(path: string): Promise<boolean> {
+	try {
+		const fileStat = await stat(path);
+		return fileStat.isDirectory();
+	} catch (error: unknown) {
+		const code = (error as NodeJS.ErrnoException).code;
+		if (code !== "ENOENT") {
+			log.warn(
+				"Copilot Chat probe stat failed for %s (%s): %s",
+				path,
+				code ?? "unknown",
+				(error as Error).message,
+			);
+		}
+		return false;
+	}
+}
+
+/**
+ * Returns true when either of the two known Copilot Chat data roots exists.
+ * Returns false on ENOENT or non-directory state for both.
+ */
+export async function isCopilotChatInstalled(): Promise<boolean> {
+	const [globalStorage, sessionState] = await Promise.all([
+		existsAsDir(getCopilotChatStorageDir()),
+		existsAsDir(getCopilotCliSessionStateDir()),
+	]);
+	return globalStorage || sessionState;
+}

--- a/cli/src/core/CopilotChatSessionDiscoverer.test.ts
+++ b/cli/src/core/CopilotChatSessionDiscoverer.test.ts
@@ -1,0 +1,529 @@
+import { mkdirSync, mkdtempSync, rmSync, utimesSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Native-path → file:// URI. Cross-platform — `pathToFileURL` returns
+ * `file:///D:/...` on Windows and `file:///Users/...` on POSIX, both of which
+ * round-trip cleanly through `fileURLToPath` (unlike a hardcoded `file://${p}`
+ * concatenation, which yields invalid URIs on Windows).
+ */
+function nativePathToFileUri(nativePath: string): string {
+	return pathToFileURL(nativePath).href;
+}
+
+// Path-segment markers used to identify which directory a mocked readdir is
+// being asked for. Match both POSIX (`/`) and Windows (`\`) separators so the
+// same test asserts identically on both platforms.
+const SESSION_STATE_MARKER = /[\\/]\.copilot[\\/]session-state$/;
+const CHAT_SESSIONS_MARKER = /[\\/]chatSessions$/;
+
+const { mockHomedir, mockPlatform } = vi.hoisted(() => ({
+	mockHomedir: vi.fn(),
+	mockPlatform: vi.fn().mockReturnValue("darwin"),
+}));
+
+vi.mock("node:os", async (importOriginal) => {
+	const original = await importOriginal<typeof import("node:os")>();
+	return { ...original, homedir: mockHomedir, platform: mockPlatform };
+});
+
+describe("scanCopilotChatSessions", () => {
+	let tmpRoot: string;
+	let projectDir: string;
+
+	beforeEach(() => {
+		tmpRoot = mkdtempSync(join(tmpdir(), "copilot-chat-disc-"));
+		projectDir = join(tmpRoot, "myproject");
+		mkdirSync(projectDir, { recursive: true });
+		mockHomedir.mockReturnValue(tmpRoot);
+		mockPlatform.mockReturnValue("darwin");
+	});
+
+	afterEach(() => {
+		rmSync(tmpRoot, { recursive: true, force: true });
+		vi.resetModules();
+	});
+
+	// ─── Scan A helpers (events.jsonl in ~/.copilot/session-state/<sid>/) ──────
+	function makeSessionStateEntry(opts: {
+		sid: string;
+		// folderPath: undefined ⇒ omit `workspaceFolder` field; null ⇒ write empty string;
+		// string ⇒ write that path. omitMetadata: true ⇒ skip the metadata file entirely.
+		folderPath?: string | null;
+		omitMetadata?: boolean;
+		omitEvents?: boolean;
+		ageHours?: number;
+	}): string {
+		const dir = join(tmpRoot, ".copilot", "session-state", opts.sid);
+		mkdirSync(dir, { recursive: true });
+		if (!opts.omitMetadata) {
+			const meta: Record<string, unknown> = { origin: opts.folderPath ? "vscode" : "other" };
+			if (opts.folderPath !== null && opts.folderPath !== undefined) {
+				meta.workspaceFolder = { folderPath: opts.folderPath };
+			} else if (opts.folderPath === null) {
+				meta.workspaceFolder = { folderPath: "" };
+			}
+			writeFileSync(join(dir, "vscode.metadata.json"), JSON.stringify(meta));
+		}
+		const eventsPath = join(dir, "events.jsonl");
+		if (!opts.omitEvents) {
+			writeFileSync(eventsPath, `${JSON.stringify({ type: "session.start", data: {} })}\n`);
+			if (opts.ageHours !== undefined) {
+				const targetSec = (Date.now() - opts.ageHours * 3600 * 1000) / 1000;
+				utimesSync(eventsPath, targetSec, targetSec);
+			}
+		}
+		return eventsPath;
+	}
+
+	// ─── Scan B helpers (<wsHash>/chatSessions/<sid>.jsonl) ────────────────────
+	function makeWorkspace(wsHash: string, folderUri: string): string {
+		const wsDir = join(tmpRoot, "Library", "Application Support", "Code", "User", "workspaceStorage", wsHash);
+		mkdirSync(wsDir, { recursive: true });
+		writeFileSync(join(wsDir, "workspace.json"), JSON.stringify({ folder: folderUri }));
+		return wsDir;
+	}
+
+	function makeChatSessionsFile(wsDir: string, name: string, ageHours: number): string {
+		const dir = join(wsDir, "chatSessions");
+		mkdirSync(dir, { recursive: true });
+		const path = join(dir, name);
+		writeFileSync(path, JSON.stringify({ kind: 0, v: { requests: [] } }));
+		const targetSec = (Date.now() - ageHours * 3600 * 1000) / 1000;
+		utimesSync(path, targetSec, targetSec);
+		return path;
+	}
+
+	// ─── Scan A (events.jsonl) ─────────────────────────────────────────────────
+	it("returns empty when neither root exists", async () => {
+		const { scanCopilotChatSessions } = await import("./CopilotChatSessionDiscoverer.js");
+		const result = await scanCopilotChatSessions(projectDir);
+		expect(result.sessions).toEqual([]);
+		expect(result.error).toBeUndefined();
+	});
+
+	it("Scan A: returns empty when session-state exists but is empty", async () => {
+		mkdirSync(join(tmpRoot, ".copilot", "session-state"), { recursive: true });
+		const { scanCopilotChatSessions } = await import("./CopilotChatSessionDiscoverer.js");
+		const result = await scanCopilotChatSessions(projectDir);
+		expect(result.sessions).toEqual([]);
+	});
+
+	it("Scan A: emits a session whose folderPath matches projectDir and events.jsonl is fresh", async () => {
+		const eventsPath = makeSessionStateEntry({ sid: "s-match", folderPath: projectDir, ageHours: 1 });
+		const { scanCopilotChatSessions } = await import("./CopilotChatSessionDiscoverer.js");
+		const result = await scanCopilotChatSessions(projectDir);
+		expect(result.sessions).toHaveLength(1);
+		expect(result.sessions[0]).toMatchObject({
+			sessionId: "s-match",
+			source: "copilot-chat",
+			transcriptPath: eventsPath,
+		});
+	});
+
+	it("Scan A: skips folderPath empty string (CLI standalone marker)", async () => {
+		makeSessionStateEntry({ sid: "s-empty", folderPath: null, ageHours: 1 });
+		const { scanCopilotChatSessions } = await import("./CopilotChatSessionDiscoverer.js");
+		const result = await scanCopilotChatSessions(projectDir);
+		expect(result.sessions).toEqual([]);
+	});
+
+	it("Scan A: skips when vscode.metadata.json is missing", async () => {
+		makeSessionStateEntry({ sid: "s-nometa", omitMetadata: true, ageHours: 1 });
+		const { scanCopilotChatSessions } = await import("./CopilotChatSessionDiscoverer.js");
+		const result = await scanCopilotChatSessions(projectDir);
+		expect(result.sessions).toEqual([]);
+	});
+
+	it("Scan A: skips when vscode.metadata.json is malformed", async () => {
+		const dir = join(tmpRoot, ".copilot", "session-state", "s-bad");
+		mkdirSync(dir, { recursive: true });
+		writeFileSync(join(dir, "vscode.metadata.json"), "{not json");
+		writeFileSync(join(dir, "events.jsonl"), "");
+		const { scanCopilotChatSessions } = await import("./CopilotChatSessionDiscoverer.js");
+		const result = await scanCopilotChatSessions(projectDir);
+		expect(result.sessions).toEqual([]);
+	});
+
+	it("Scan A: skips when folderPath does not match projectDir", async () => {
+		makeSessionStateEntry({ sid: "s-other", folderPath: "/some/other/dir", ageHours: 1 });
+		const { scanCopilotChatSessions } = await import("./CopilotChatSessionDiscoverer.js");
+		const result = await scanCopilotChatSessions(projectDir);
+		expect(result.sessions).toEqual([]);
+	});
+
+	it("Scan A: matches across case difference on macOS (normalizePathForMatch)", async () => {
+		makeSessionStateEntry({ sid: "s-case", folderPath: projectDir.toUpperCase(), ageHours: 1 });
+		const { scanCopilotChatSessions } = await import("./CopilotChatSessionDiscoverer.js");
+		const result = await scanCopilotChatSessions(projectDir);
+		expect(result.sessions).toHaveLength(1);
+	});
+
+	it("Scan A: matches across trailing slash difference", async () => {
+		makeSessionStateEntry({ sid: "s-slash", folderPath: `${projectDir}/`, ageHours: 1 });
+		const { scanCopilotChatSessions } = await import("./CopilotChatSessionDiscoverer.js");
+		const result = await scanCopilotChatSessions(projectDir);
+		expect(result.sessions).toHaveLength(1);
+	});
+
+	it("Scan A: skips when events.jsonl missing", async () => {
+		makeSessionStateEntry({ sid: "s-noev", folderPath: projectDir, omitEvents: true });
+		const { scanCopilotChatSessions } = await import("./CopilotChatSessionDiscoverer.js");
+		const result = await scanCopilotChatSessions(projectDir);
+		expect(result.sessions).toEqual([]);
+	});
+
+	it("Scan A: skips events.jsonl older than 48h", async () => {
+		makeSessionStateEntry({ sid: "s-stale", folderPath: projectDir, ageHours: 72 });
+		const { scanCopilotChatSessions } = await import("./CopilotChatSessionDiscoverer.js");
+		const result = await scanCopilotChatSessions(projectDir);
+		expect(result.sessions).toEqual([]);
+	});
+
+	// ─── Scan B (chatSessions/) ────────────────────────────────────────────────
+	it("Scan B: returns empty when no workspaceStorage entry matches projectDir", async () => {
+		const { scanCopilotChatSessions } = await import("./CopilotChatSessionDiscoverer.js");
+		const result = await scanCopilotChatSessions(projectDir);
+		expect(result.sessions).toEqual([]);
+	});
+
+	it("Scan B: returns empty when workspace exists but chatSessions/ is missing", async () => {
+		makeWorkspace("ws1", nativePathToFileUri(projectDir));
+		const { scanCopilotChatSessions } = await import("./CopilotChatSessionDiscoverer.js");
+		const result = await scanCopilotChatSessions(projectDir);
+		expect(result.sessions).toEqual([]);
+	});
+
+	it("Scan B: emits fresh .jsonl session", async () => {
+		const ws = makeWorkspace("ws1", nativePathToFileUri(projectDir));
+		const path = makeChatSessionsFile(ws, "fresh.jsonl", 1);
+		const { scanCopilotChatSessions } = await import("./CopilotChatSessionDiscoverer.js");
+		const result = await scanCopilotChatSessions(projectDir);
+		expect(result.sessions).toHaveLength(1);
+		expect(result.sessions[0]).toMatchObject({
+			sessionId: "fresh",
+			source: "copilot-chat",
+			transcriptPath: path,
+		});
+	});
+
+	it("Scan B: explicitly skips deprecated .json snapshot files", async () => {
+		const ws = makeWorkspace("ws1", nativePathToFileUri(projectDir));
+		makeChatSessionsFile(ws, "deprecated.json", 1);
+		const { scanCopilotChatSessions } = await import("./CopilotChatSessionDiscoverer.js");
+		const result = await scanCopilotChatSessions(projectDir);
+		expect(result.sessions).toEqual([]);
+	});
+
+	it("Scan B: skips files older than 48h", async () => {
+		const ws = makeWorkspace("ws1", nativePathToFileUri(projectDir));
+		makeChatSessionsFile(ws, "stale.jsonl", 72);
+		const { scanCopilotChatSessions } = await import("./CopilotChatSessionDiscoverer.js");
+		const result = await scanCopilotChatSessions(projectDir);
+		expect(result.sessions).toEqual([]);
+	});
+
+	it("Scan B: skips irrelevant suffixes (.tmp, .log)", async () => {
+		const ws = makeWorkspace("ws1", nativePathToFileUri(projectDir));
+		makeChatSessionsFile(ws, "junk.tmp", 1);
+		makeChatSessionsFile(ws, "junk.log", 1);
+		makeChatSessionsFile(ws, "real.jsonl", 1);
+		const { scanCopilotChatSessions } = await import("./CopilotChatSessionDiscoverer.js");
+		const result = await scanCopilotChatSessions(projectDir);
+		expect(result.sessions.map((s) => s.sessionId)).toEqual(["real"]);
+	});
+
+	// ─── Combined ──────────────────────────────────────────────────────────────
+	it("Combined: emits sessions from both scans", async () => {
+		makeSessionStateEntry({ sid: "ev-1", folderPath: projectDir, ageHours: 1 });
+		const ws = makeWorkspace("ws1", nativePathToFileUri(projectDir));
+		makeChatSessionsFile(ws, "patch-1.jsonl", 1);
+		const { scanCopilotChatSessions } = await import("./CopilotChatSessionDiscoverer.js");
+		const result = await scanCopilotChatSessions(projectDir);
+		expect(result.sessions).toHaveLength(2);
+		const ids = result.sessions.map((s) => s.sessionId).sort();
+		expect(ids).toEqual(["ev-1", "patch-1"]);
+	});
+
+	it("Combined: same sid in both scans is emitted twice (no dedup, by design)", async () => {
+		makeSessionStateEntry({ sid: "shared", folderPath: projectDir, ageHours: 1 });
+		const ws = makeWorkspace("ws1", nativePathToFileUri(projectDir));
+		makeChatSessionsFile(ws, "shared.jsonl", 1);
+		const { scanCopilotChatSessions } = await import("./CopilotChatSessionDiscoverer.js");
+		const result = await scanCopilotChatSessions(projectDir);
+		expect(result.sessions).toHaveLength(2);
+	});
+});
+
+describe("scanCopilotChatSessions error precedence", () => {
+	let tmpRoot: string;
+	let projectDir: string;
+
+	beforeEach(() => {
+		tmpRoot = mkdtempSync(join(tmpdir(), "copilot-chat-disc-err-"));
+		projectDir = join(tmpRoot, "myproject");
+		mkdirSync(projectDir, { recursive: true });
+		mockHomedir.mockReturnValue(tmpRoot);
+		mockPlatform.mockReturnValue("darwin");
+	});
+
+	afterEach(() => {
+		rmSync(tmpRoot, { recursive: true, force: true });
+		vi.resetModules();
+		vi.doUnmock("node:fs/promises");
+	});
+
+	it("Scan A readdir EACCES: surfaces { kind:'fs' } error, Scan B still emits", async () => {
+		// Build a Scan B-discoverable file before mocking fs (mock is path-selective).
+		const ws = join(tmpRoot, "Library", "Application Support", "Code", "User", "workspaceStorage", "ws-only-b");
+		mkdirSync(join(ws, "chatSessions"), { recursive: true });
+		writeFileSync(join(ws, "workspace.json"), JSON.stringify({ folder: nativePathToFileUri(projectDir) }));
+		writeFileSync(join(ws, "chatSessions", "from-b.jsonl"), JSON.stringify({ kind: 0, v: { requests: [] } }));
+
+		// Mock readdir to throw EACCES for the session-state root only; everything else delegates to real fs.
+		vi.doMock("node:fs/promises", async () => {
+			const actual = await vi.importActual<typeof import("node:fs/promises")>("node:fs/promises");
+			return {
+				...actual,
+				readdir: vi.fn(async (path: string, ...rest: unknown[]) => {
+					if (SESSION_STATE_MARKER.test(String(path))) {
+						throw Object.assign(new Error("permission denied"), { code: "EACCES" });
+					}
+					return (actual.readdir as (p: string, ...args: unknown[]) => Promise<string[]>)(path, ...rest);
+				}),
+			};
+		});
+
+		const { scanCopilotChatSessions } = await import("./CopilotChatSessionDiscoverer.js");
+		const result = await scanCopilotChatSessions(projectDir);
+		expect(result.error).toEqual({ kind: "fs", message: "permission denied" });
+		expect(result.sessions.map((s) => s.sessionId)).toEqual(["from-b"]);
+	});
+
+	it("Scan B readdir EACCES + Scan A succeeded: Scan A wins, Scan B error reported", async () => {
+		// Build a Scan A-discoverable session before mocking fs.
+		const sessionDir = join(tmpRoot, ".copilot", "session-state", "from-a");
+		mkdirSync(sessionDir, { recursive: true });
+		writeFileSync(
+			join(sessionDir, "vscode.metadata.json"),
+			JSON.stringify({ origin: "vscode", workspaceFolder: { folderPath: projectDir } }),
+		);
+		writeFileSync(join(sessionDir, "events.jsonl"), JSON.stringify({ type: "session.start", data: {} }));
+
+		// Build a workspaceStorage entry so findVscodeWorkspaceHash matches; mock readdir to fail on chatSessions.
+		const ws = join(tmpRoot, "Library", "Application Support", "Code", "User", "workspaceStorage", "ws-b-error");
+		mkdirSync(join(ws, "chatSessions"), { recursive: true });
+		writeFileSync(join(ws, "workspace.json"), JSON.stringify({ folder: nativePathToFileUri(projectDir) }));
+
+		vi.doMock("node:fs/promises", async () => {
+			const actual = await vi.importActual<typeof import("node:fs/promises")>("node:fs/promises");
+			return {
+				...actual,
+				readdir: vi.fn(async (path: string, ...rest: unknown[]) => {
+					if (CHAT_SESSIONS_MARKER.test(String(path))) {
+						throw Object.assign(new Error("denied B"), { code: "EACCES" });
+					}
+					return (actual.readdir as (p: string, ...args: unknown[]) => Promise<string[]>)(path, ...rest);
+				}),
+			};
+		});
+
+		const { scanCopilotChatSessions } = await import("./CopilotChatSessionDiscoverer.js");
+		const result = await scanCopilotChatSessions(projectDir);
+		expect(result.error).toEqual({ kind: "fs", message: "denied B" });
+		expect(result.sessions.map((s) => s.sessionId)).toEqual(["from-a"]);
+	});
+
+	it("Both scans error: Scan A's error wins (reported), Scan B's is debug-logged and dropped", async () => {
+		// Build a workspaceStorage entry so Scan B reaches readdir (and fails there).
+		const ws = join(tmpRoot, "Library", "Application Support", "Code", "User", "workspaceStorage", "ws-both-err");
+		mkdirSync(join(ws, "chatSessions"), { recursive: true });
+		writeFileSync(join(ws, "workspace.json"), JSON.stringify({ folder: nativePathToFileUri(projectDir) }));
+
+		vi.doMock("node:fs/promises", async () => {
+			const actual = await vi.importActual<typeof import("node:fs/promises")>("node:fs/promises");
+			return {
+				...actual,
+				readdir: vi.fn(async (path: string, ...rest: unknown[]) => {
+					if (SESSION_STATE_MARKER.test(String(path))) {
+						throw Object.assign(new Error("denied A"), { code: "EACCES" });
+					}
+					if (CHAT_SESSIONS_MARKER.test(String(path))) {
+						throw Object.assign(new Error("denied B"), { code: "EACCES" });
+					}
+					return (actual.readdir as (p: string, ...args: unknown[]) => Promise<string[]>)(path, ...rest);
+				}),
+			};
+		});
+
+		const { scanCopilotChatSessions } = await import("./CopilotChatSessionDiscoverer.js");
+		const result = await scanCopilotChatSessions(projectDir);
+		expect(result.error).toEqual({ kind: "fs", message: "denied A" });
+		expect(result.sessions).toEqual([]);
+	});
+
+	it("Scan A readdir error without errno code: error log falls back to 'unknown'", async () => {
+		// Exercises the `code ?? "unknown"` fallback in scanSessionState.
+		vi.doMock("node:fs/promises", async () => {
+			const actual = await vi.importActual<typeof import("node:fs/promises")>("node:fs/promises");
+			return {
+				...actual,
+				readdir: vi.fn(async (path: string, ...rest: unknown[]) => {
+					if (SESSION_STATE_MARKER.test(String(path))) {
+						throw new Error("oddball without errno");
+					}
+					return (actual.readdir as (p: string, ...args: unknown[]) => Promise<string[]>)(path, ...rest);
+				}),
+			};
+		});
+		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+		const { scanCopilotChatSessions } = await import("./CopilotChatSessionDiscoverer.js");
+		const result = await scanCopilotChatSessions(projectDir);
+		expect(result.error).toEqual({ kind: "fs", message: "oddball without errno" });
+		const formatted = errorSpy.mock.calls.map((c) => String(c[0])).join("\n");
+		expect(formatted).toMatch(/unknown/);
+		errorSpy.mockRestore();
+	});
+
+	it("Scan B readdir error without errno code: error log falls back to 'unknown'", async () => {
+		// Build a workspaceStorage entry so Scan B reaches readdir.
+		const ws = join(tmpRoot, "Library", "Application Support", "Code", "User", "workspaceStorage", "ws-b-noerrno");
+		mkdirSync(join(ws, "chatSessions"), { recursive: true });
+		writeFileSync(join(ws, "workspace.json"), JSON.stringify({ folder: nativePathToFileUri(projectDir) }));
+
+		vi.doMock("node:fs/promises", async () => {
+			const actual = await vi.importActual<typeof import("node:fs/promises")>("node:fs/promises");
+			return {
+				...actual,
+				readdir: vi.fn(async (path: string, ...rest: unknown[]) => {
+					if (CHAT_SESSIONS_MARKER.test(String(path))) {
+						throw new Error("oddball B without errno");
+					}
+					return (actual.readdir as (p: string, ...args: unknown[]) => Promise<string[]>)(path, ...rest);
+				}),
+			};
+		});
+		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+		const { scanCopilotChatSessions } = await import("./CopilotChatSessionDiscoverer.js");
+		const result = await scanCopilotChatSessions(projectDir);
+		expect(result.error).toEqual({ kind: "fs", message: "oddball B without errno" });
+		const formatted = errorSpy.mock.calls.map((c) => String(c[0])).join("\n");
+		expect(formatted).toMatch(/unknown/);
+		errorSpy.mockRestore();
+	});
+});
+
+describe("scanCopilotChatSessions Scan B mid-loop stat skip", () => {
+	let tmpRoot: string;
+	let projectDir: string;
+
+	beforeEach(() => {
+		tmpRoot = mkdtempSync(join(tmpdir(), "copilot-chat-disc-mid-"));
+		projectDir = join(tmpRoot, "myproject");
+		mkdirSync(projectDir, { recursive: true });
+		mockHomedir.mockReturnValue(tmpRoot);
+		mockPlatform.mockReturnValue("darwin");
+	});
+
+	afterEach(() => {
+		rmSync(tmpRoot, { recursive: true, force: true });
+		vi.resetModules();
+		vi.doUnmock("node:fs/promises");
+	});
+
+	it("Scan B: skips entries whose stat() fails (e.g., file vanished between readdir and stat)", async () => {
+		// Real file kept on disk so the loop has at least one entry it can fully process;
+		// readdir is overridden to also return a phantom .jsonl name that is not present
+		// on disk, exercising the inside-loop catch around stat().
+		const ws = join(tmpRoot, "Library", "Application Support", "Code", "User", "workspaceStorage", "ws-phantom");
+		mkdirSync(join(ws, "chatSessions"), { recursive: true });
+		writeFileSync(join(ws, "workspace.json"), JSON.stringify({ folder: nativePathToFileUri(projectDir) }));
+		const realPath = join(ws, "chatSessions", "real.jsonl");
+		writeFileSync(realPath, JSON.stringify({ kind: 0, v: { requests: [] } }));
+		const targetSec = (Date.now() - 1 * 3600 * 1000) / 1000;
+		utimesSync(realPath, targetSec, targetSec);
+
+		vi.doMock("node:fs/promises", async () => {
+			const actual = await vi.importActual<typeof import("node:fs/promises")>("node:fs/promises");
+			return {
+				...actual,
+				readdir: vi.fn(async (path: string, ...rest: unknown[]) => {
+					if (CHAT_SESSIONS_MARKER.test(String(path))) {
+						return ["phantom.jsonl", "real.jsonl"];
+					}
+					return (actual.readdir as (p: string, ...args: unknown[]) => Promise<string[]>)(path, ...rest);
+				}),
+			};
+		});
+
+		const { scanCopilotChatSessions } = await import("./CopilotChatSessionDiscoverer.js");
+		const result = await scanCopilotChatSessions(projectDir);
+		expect(result.error).toBeUndefined();
+		expect(result.sessions.map((s) => s.sessionId)).toEqual(["real"]);
+	});
+});
+
+describe("discoverCopilotChatSessions", () => {
+	let tmpRoot: string;
+	let projectDir: string;
+
+	beforeEach(() => {
+		tmpRoot = mkdtempSync(join(tmpdir(), "copilot-chat-disc-"));
+		projectDir = join(tmpRoot, "myproject");
+		mkdirSync(projectDir, { recursive: true });
+		mockHomedir.mockReturnValue(tmpRoot);
+		mockPlatform.mockReturnValue("darwin");
+	});
+
+	afterEach(() => {
+		rmSync(tmpRoot, { recursive: true, force: true });
+		vi.resetModules();
+		vi.doUnmock("node:fs/promises");
+	});
+
+	it("strips error channel and returns array directly", async () => {
+		const { discoverCopilotChatSessions } = await import("./CopilotChatSessionDiscoverer.js");
+		const result = await discoverCopilotChatSessions(projectDir);
+		expect(Array.isArray(result)).toBe(true);
+		expect(result).toEqual([]);
+	});
+
+	it("warn-logs and returns sessions when underlying scan reports an error", async () => {
+		// Build a Scan B-discoverable file so the warn branch runs alongside non-empty
+		// sessions; Scan A is forced to error via readdir EACCES.
+		const ws = join(tmpRoot, "Library", "Application Support", "Code", "User", "workspaceStorage", "ws-warn");
+		mkdirSync(join(ws, "chatSessions"), { recursive: true });
+		writeFileSync(join(ws, "workspace.json"), JSON.stringify({ folder: nativePathToFileUri(projectDir) }));
+		const fresh = join(ws, "chatSessions", "fresh.jsonl");
+		writeFileSync(fresh, JSON.stringify({ kind: 0, v: { requests: [] } }));
+		const targetSec = (Date.now() - 1 * 3600 * 1000) / 1000;
+		utimesSync(fresh, targetSec, targetSec);
+
+		vi.doMock("node:fs/promises", async () => {
+			const actual = await vi.importActual<typeof import("node:fs/promises")>("node:fs/promises");
+			return {
+				...actual,
+				readdir: vi.fn(async (path: string, ...rest: unknown[]) => {
+					if (SESSION_STATE_MARKER.test(String(path))) {
+						throw Object.assign(new Error("perm denied"), { code: "EACCES" });
+					}
+					return (actual.readdir as (p: string, ...args: unknown[]) => Promise<string[]>)(path, ...rest);
+				}),
+			};
+		});
+
+		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+		const { discoverCopilotChatSessions } = await import("./CopilotChatSessionDiscoverer.js");
+		const result = await discoverCopilotChatSessions(projectDir);
+		expect(result.map((s) => s.sessionId)).toEqual(["fresh"]);
+		const formatted = warnSpy.mock.calls.map((c) => String(c[0])).join("\n");
+		expect(formatted).toMatch(/Copilot Chat scan error/);
+		expect(formatted).toMatch(/perm denied/);
+		warnSpy.mockRestore();
+	});
+});

--- a/cli/src/core/CopilotChatSessionDiscoverer.ts
+++ b/cli/src/core/CopilotChatSessionDiscoverer.ts
@@ -1,0 +1,182 @@
+/**
+ * VS Code Copilot Chat session discoverer.
+ *
+ * Two scans run in sequence; results are concatenated:
+ *
+ *   Scan A — chat panel "New Chat" with copilotcli-backend models:
+ *     ~/.copilot/session-state/<sid>/events.jsonl
+ *     gated by vscode.metadata.json.workspaceFolder.folderPath === projectDir
+ *
+ *   Scan B — chat panel "New Chat" with non-copilotcli-backend models:
+ *     <userDataDir>/User/workspaceStorage/<wsHash>/chatSessions/<sid>.jsonl
+ *     wsHash resolved via VscodeWorkspaceLocator from projectDir
+ *
+ * Sessions older than 48h are excluded (matches every other discovery-based
+ * source: OpenCode / Cursor / Copilot CLI). The deprecated .json snapshot
+ * format is explicitly NOT read — see spec for rationale.
+ *
+ * The standalone `copilot` source (CopilotSessionDiscoverer reading
+ * session-store.db) covers the "New Copilot CLI Session" entry point, which
+ * is just a vscode-spawned terminal running the copilot binary.
+ */
+
+import { readdir, readFile, stat } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { createLogger } from "../Logger.js";
+import type { SessionInfo } from "../Types.js";
+import type { CopilotChatScanError } from "./CopilotChatTranscriptReader.js";
+import {
+	findVscodeWorkspaceHash,
+	getVscodeWorkspaceStorageDir,
+	normalizePathForMatch,
+} from "./VscodeWorkspaceLocator.js";
+
+const log = createLogger("CopilotChatDiscoverer");
+
+const SESSION_STALE_MS = 48 * 60 * 60 * 1000;
+
+export type { CopilotChatScanError };
+
+export interface CopilotChatScanResult {
+	readonly sessions: ReadonlyArray<SessionInfo>;
+	readonly error?: CopilotChatScanError;
+}
+
+interface VscodeMetadata {
+	workspaceFolder?: { folderPath?: string };
+}
+
+/**
+ * Scan A: ~/.copilot/session-state/<sid>/events.jsonl gated by folderPath.
+ * Returns sessions and an optional error when readdir of the root fails for
+ * non-ENOENT reasons.
+ */
+async function scanSessionState(projectDir: string): Promise<CopilotChatScanResult> {
+	const root = join(homedir(), ".copilot", "session-state");
+	let entries: string[];
+	try {
+		entries = await readdir(root);
+	} catch (error: unknown) {
+		const code = (error as NodeJS.ErrnoException).code;
+		if (code === "ENOENT") return { sessions: [] };
+		log.error("readdir %s failed (%s): %s", root, code ?? "unknown", (error as Error).message);
+		return { sessions: [], error: { kind: "fs", message: (error as Error).message } };
+	}
+
+	const cutoffMs = Date.now() - SESSION_STALE_MS;
+	const target = normalizePathForMatch(projectDir);
+	const sessions: SessionInfo[] = [];
+
+	for (const sid of entries) {
+		const sessionDir = join(root, sid);
+		const metaPath = join(sessionDir, "vscode.metadata.json");
+		const eventsPath = join(sessionDir, "events.jsonl");
+
+		let meta: VscodeMetadata;
+		try {
+			meta = JSON.parse(await readFile(metaPath, "utf8")) as VscodeMetadata;
+		} catch (error: unknown) {
+			log.debug("Skipping %s: vscode.metadata.json read/parse failed (%s)", sid, (error as Error).message);
+			continue;
+		}
+
+		const folderPath = meta.workspaceFolder?.folderPath;
+		if (typeof folderPath !== "string" || folderPath.length === 0) continue;
+		if (normalizePathForMatch(folderPath) !== target) continue;
+
+		let mtimeMs: number;
+		try {
+			mtimeMs = (await stat(eventsPath)).mtimeMs;
+		} catch (error: unknown) {
+			log.debug("Skipping %s: events.jsonl stat failed (%s)", sid, (error as Error).message);
+			continue;
+		}
+		if (mtimeMs < cutoffMs) continue;
+
+		sessions.push({
+			sessionId: sid,
+			transcriptPath: eventsPath,
+			updatedAt: new Date(mtimeMs).toISOString(),
+			source: "copilot-chat",
+		});
+	}
+
+	return { sessions };
+}
+
+/**
+ * Scan B: <wsHash>/chatSessions/<sid>.jsonl. Skips .json snapshot files
+ * (deprecated). Returns sessions and an optional error on non-ENOENT readdir
+ * failure.
+ */
+async function scanChatSessions(projectDir: string): Promise<CopilotChatScanResult> {
+	const wsHash = await findVscodeWorkspaceHash("Code", projectDir);
+	if (wsHash === null) {
+		log.debug("No vscode workspace matched %s", projectDir);
+		return { sessions: [] };
+	}
+	const dir = join(getVscodeWorkspaceStorageDir("Code"), wsHash, "chatSessions");
+
+	let entries: string[];
+	try {
+		entries = await readdir(dir);
+	} catch (error: unknown) {
+		const code = (error as NodeJS.ErrnoException).code;
+		if (code === "ENOENT") return { sessions: [] };
+		log.error("readdir %s failed (%s): %s", dir, code ?? "unknown", (error as Error).message);
+		return { sessions: [], error: { kind: "fs", message: (error as Error).message } };
+	}
+
+	const cutoffMs = Date.now() - SESSION_STALE_MS;
+	const sessions: SessionInfo[] = [];
+
+	for (const entry of entries) {
+		if (!entry.endsWith(".jsonl")) continue; // skip .json snapshots and other suffixes
+		const path = join(dir, entry);
+		let mtimeMs: number;
+		try {
+			mtimeMs = (await stat(path)).mtimeMs;
+		} catch (error: unknown) {
+			log.debug("Skipping %s: stat failed (%s)", entry, (error as Error).message);
+			continue;
+		}
+		if (mtimeMs < cutoffMs) continue;
+		const sessionId = entry.slice(0, -".jsonl".length);
+		sessions.push({
+			sessionId,
+			transcriptPath: path,
+			updatedAt: new Date(mtimeMs).toISOString(),
+			source: "copilot-chat",
+		});
+	}
+
+	return { sessions };
+}
+
+/**
+ * Runs Scan A then Scan B; concatenates sessions; returns the first error
+ * encountered (subsequent are debug-logged).
+ */
+export async function scanCopilotChatSessions(projectDir: string): Promise<CopilotChatScanResult> {
+	const a = await scanSessionState(projectDir);
+	const b = await scanChatSessions(projectDir);
+	const sessions = [...a.sessions, ...b.sessions];
+	const error = a.error ?? b.error;
+	if (a.error && b.error) {
+		log.debug("Both scans errored; reporting Scan A's, dropped Scan B's: %s", b.error.message);
+	}
+	if (sessions.length > 0) {
+		log.info("Discovered %d Copilot Chat session(s) for %s", sessions.length, projectDir);
+	}
+	return { sessions, error };
+}
+
+/** Convenience wrapper used by QueueWorker — strips the error channel. */
+export async function discoverCopilotChatSessions(projectDir: string): Promise<ReadonlyArray<SessionInfo>> {
+	const { sessions, error } = await scanCopilotChatSessions(projectDir);
+	if (error) {
+		log.warn("Copilot Chat scan error (%s) — sessions excluded from this run: %s", error.kind, error.message);
+	}
+	return sessions;
+}

--- a/cli/src/core/CopilotChatTranscriptReader.test.ts
+++ b/cli/src/core/CopilotChatTranscriptReader.test.ts
@@ -1,0 +1,574 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { _deleteAtPath, _replayPatches, _setAtPath, readCopilotChatTranscript } from "./CopilotChatTranscriptReader.js";
+
+describe("_setAtPath", () => {
+	it("sets a leaf string key on an object", () => {
+		const doc: Record<string, unknown> = { a: { b: 1 } };
+		_setAtPath(doc, ["a", "b"], 42);
+		expect(doc).toEqual({ a: { b: 42 } });
+	});
+
+	it("creates intermediate objects when string segments are missing", () => {
+		const doc: Record<string, unknown> = {};
+		_setAtPath(doc, ["a", "b", "c"], "x");
+		expect(doc).toEqual({ a: { b: { c: "x" } } });
+	});
+
+	it("creates intermediate arrays when next segment is numeric", () => {
+		const doc: Record<string, unknown> = {};
+		_setAtPath(doc, ["requests", 0, "message"], { text: "hi" });
+		expect(doc).toEqual({ requests: [{ message: { text: "hi" } }] });
+	});
+
+	it("appends to an existing array at the next index", () => {
+		const doc: Record<string, unknown> = { requests: [{ message: { text: "first" } }] };
+		_setAtPath(doc, ["requests", 1], { message: { text: "second" } });
+		expect((doc.requests as unknown[]).length).toBe(2);
+		expect((doc.requests as unknown[])[1]).toEqual({ message: { text: "second" } });
+	});
+
+	it("grows arrays with sparse undefined slots when index is past length", () => {
+		const doc: Record<string, unknown> = { requests: [] };
+		_setAtPath(doc, ["requests", 2], { v: 1 });
+		expect((doc.requests as unknown[]).length).toBe(3);
+		expect((doc.requests as unknown[])[0]).toBeUndefined();
+		expect((doc.requests as unknown[])[2]).toEqual({ v: 1 });
+	});
+
+	it("overwrites an existing leaf value", () => {
+		const doc: Record<string, unknown> = { a: 1 };
+		_setAtPath(doc, ["a"], 2);
+		expect(doc).toEqual({ a: 2 });
+	});
+
+	it("handles empty path by replacing nothing (root replacement is replayPatches's job, not ours)", () => {
+		const doc: Record<string, unknown> = { a: 1 };
+		_setAtPath(doc, [], 99);
+		// Empty path is undefined behavior in patch terms — we expect no change here
+		// since the caller (replayPatches kind:0) handles root replacement directly.
+		expect(doc).toEqual({ a: 1 });
+	});
+});
+
+describe("_deleteAtPath", () => {
+	it("deletes an object property", () => {
+		const doc: Record<string, unknown> = { a: 1, b: 2 };
+		_deleteAtPath(doc, ["a"]);
+		expect(doc).toEqual({ b: 2 });
+	});
+
+	it("removes an array element via splice (preserves array semantics)", () => {
+		const doc: Record<string, unknown> = { a: [10, 20, 30] };
+		_deleteAtPath(doc, ["a", 1]);
+		expect(doc.a).toEqual([10, 30]);
+	});
+
+	it("is a no-op when the path doesn't exist", () => {
+		const doc: Record<string, unknown> = { a: 1 };
+		_deleteAtPath(doc, ["b", "c"]);
+		expect(doc).toEqual({ a: 1 });
+	});
+
+	it("is a no-op for empty path", () => {
+		const doc: Record<string, unknown> = { a: 1 };
+		_deleteAtPath(doc, []);
+		expect(doc).toEqual({ a: 1 });
+	});
+
+	it("is a no-op when array index is out of bounds", () => {
+		const doc: Record<string, unknown> = { a: [10, 20] };
+		_deleteAtPath(doc, ["a", 5]);
+		expect(doc.a).toEqual([10, 20]);
+	});
+
+	it("is a no-op when an intermediate path segment is null/undefined", () => {
+		const doc: Record<string, unknown> = { a: null };
+		_deleteAtPath(doc, ["a", "b", "c"]);
+		expect(doc).toEqual({ a: null });
+		const doc2: Record<string, unknown> = {};
+		_deleteAtPath(doc2, ["missing", "child"]);
+		expect(doc2).toEqual({});
+	});
+
+	it("is a no-op when the parent of the target is null", () => {
+		const doc: Record<string, unknown> = { a: { b: null } };
+		_deleteAtPath(doc, ["a", "b", "c"]);
+		expect(doc).toEqual({ a: { b: null } });
+	});
+});
+
+describe("_replayPatches", () => {
+	it("returns empty doc when input is empty", () => {
+		expect(_replayPatches([])).toEqual({});
+	});
+
+	it("applies kind:0 as full document replacement", () => {
+		const lines = [JSON.stringify({ kind: 0, v: { foo: "bar", requests: [] } })];
+		expect(_replayPatches(lines)).toEqual({ foo: "bar", requests: [] });
+	});
+
+	it("applies kind:1 as set-at-path", () => {
+		const lines = [
+			JSON.stringify({ kind: 0, v: { requests: [] } }),
+			JSON.stringify({ kind: 1, k: ["requests", 0, "message"], v: { text: "hello" } }),
+		];
+		expect(_replayPatches(lines)).toEqual({ requests: [{ message: { text: "hello" } }] });
+	});
+
+	it("applies kind:2 as delete-at-path", () => {
+		const lines = [
+			JSON.stringify({ kind: 0, v: { pendingRequests: [{ id: "x" }] } }),
+			JSON.stringify({ kind: 2, k: ["pendingRequests", 0] }),
+		];
+		expect(_replayPatches(lines)).toEqual({ pendingRequests: [] });
+	});
+
+	it("applies patches in file order", () => {
+		const lines = [
+			JSON.stringify({ kind: 0, v: { a: 1 } }),
+			JSON.stringify({ kind: 1, k: ["a"], v: 2 }),
+			JSON.stringify({ kind: 1, k: ["a"], v: 3 }),
+		];
+		expect(_replayPatches(lines)).toEqual({ a: 3 });
+	});
+
+	it("warns and skips on unknown kind, leaving doc untouched", () => {
+		const lines = [
+			JSON.stringify({ kind: 0, v: { a: 1 } }),
+			JSON.stringify({ kind: 99, k: ["a"], v: "should-be-ignored" }),
+		];
+		expect(_replayPatches(lines)).toEqual({ a: 1 });
+	});
+
+	it("throws on JSON parse failure (caller handles mid-write)", () => {
+		const lines = [JSON.stringify({ kind: 0, v: {} }), "{not-json"];
+		expect(() => _replayPatches(lines)).toThrow();
+	});
+});
+
+describe("readCopilotChatTranscript", () => {
+	let tmpRoot: string;
+	let sessionsDir: string;
+
+	beforeEach(() => {
+		tmpRoot = mkdtempSync(join(tmpdir(), "copilot-chat-reader-"));
+		sessionsDir = join(tmpRoot, "chatSessions");
+		mkdirSync(sessionsDir, { recursive: true });
+	});
+
+	afterEach(() => {
+		rmSync(tmpRoot, { recursive: true, force: true });
+	});
+
+	function writeJsonl(name: string, events: object[]): string {
+		const path = join(sessionsDir, name);
+		writeFileSync(path, events.map((e) => JSON.stringify(e)).join("\n"));
+		return path;
+	}
+
+	it("returns empty entries for an init-only file (cursor.lineNumber stays 0)", async () => {
+		const path = writeJsonl("a.jsonl", [{ kind: 0, v: { requests: [] } }]);
+		const result = await readCopilotChatTranscript(path);
+		expect(result.entries).toEqual([]);
+		expect(result.newCursor.transcriptPath).toBe(path);
+		expect(result.newCursor.lineNumber).toBe(0);
+	});
+
+	it("emits one human + one assistant per request with content", async () => {
+		const events = [
+			{ kind: 0, v: { requests: [] } },
+			{ kind: 1, k: ["requests", 0, "message", "text"], v: "hello" },
+			{ kind: 1, k: ["requests", 0, "response"], v: [{ value: "hi there" }] },
+		];
+		const path = writeJsonl("b.jsonl", events);
+		const result = await readCopilotChatTranscript(path);
+		expect(result.entries).toEqual([
+			{ role: "human", content: "hello" },
+			{ role: "assistant", content: "hi there" },
+		]);
+		expect(result.newCursor.lineNumber).toBe(1);
+	});
+
+	it("flattens multi-chunk response[] into a single assistant entry", async () => {
+		const events = [
+			{ kind: 0, v: { requests: [] } },
+			{ kind: 1, k: ["requests", 0, "message", "text"], v: "explain" },
+			{ kind: 1, k: ["requests", 0, "response"], v: [{ value: "Part A " }, { value: "Part B" }] },
+		];
+		const path = writeJsonl("c.jsonl", events);
+		const result = await readCopilotChatTranscript(path);
+		expect(result.entries.find((e) => e.role === "assistant")?.content).toBe("Part A Part B");
+	});
+
+	it("only emits requests at index >= cursor.lineNumber", async () => {
+		const events = [
+			{ kind: 0, v: { requests: [] } },
+			{ kind: 1, k: ["requests", 0, "message", "text"], v: "first" },
+			{ kind: 1, k: ["requests", 0, "response"], v: [{ value: "r1" }] },
+			{ kind: 1, k: ["requests", 1, "message", "text"], v: "second" },
+			{ kind: 1, k: ["requests", 1, "response"], v: [{ value: "r2" }] },
+		];
+		const path = writeJsonl("d.jsonl", events);
+		const result = await readCopilotChatTranscript(path, {
+			transcriptPath: path,
+			lineNumber: 1,
+			updatedAt: "2026-05-06T00:00:00Z",
+		});
+		expect(result.entries).toEqual([
+			{ role: "human", content: "second" },
+			{ role: "assistant", content: "r2" },
+		]);
+		expect(result.newCursor.lineNumber).toBe(2);
+	});
+
+	it("skips requests with empty/missing message.text", async () => {
+		const events = [
+			{ kind: 0, v: { requests: [] } },
+			{ kind: 1, k: ["requests", 0, "message", "text"], v: "" },
+			{ kind: 1, k: ["requests", 0, "response"], v: [{ value: "answer" }] },
+		];
+		const path = writeJsonl("e.jsonl", events);
+		const result = await readCopilotChatTranscript(path);
+		expect(result.entries).toEqual([{ role: "assistant", content: "answer" }]);
+	});
+
+	it("skips requests with empty assistant response", async () => {
+		const events = [
+			{ kind: 0, v: { requests: [] } },
+			{ kind: 1, k: ["requests", 0, "message", "text"], v: "question" },
+			{ kind: 1, k: ["requests", 0, "response"], v: [] },
+		];
+		const path = writeJsonl("f.jsonl", events);
+		const result = await readCopilotChatTranscript(path);
+		expect(result.entries).toEqual([{ role: "human", content: "question" }]);
+	});
+
+	it("ignores response chunks whose `value` is missing or non-string", async () => {
+		// vscode occasionally emits chunks with no value (e.g. tool-only turns) — these
+		// should contribute "" to the joined assistant text rather than blow up.
+		const events = [
+			{ kind: 0, v: { requests: [] } },
+			{ kind: 1, k: ["requests", 0, "message", "text"], v: "Q" },
+			{
+				kind: 1,
+				k: ["requests", 0, "response"],
+				v: [{ value: "Hello " }, {}, { value: 42 }, { value: "world" }],
+			},
+		];
+		const path = writeJsonl("g.jsonl", events);
+		const result = await readCopilotChatTranscript(path);
+		expect(result.entries.find((e) => e.role === "assistant")?.content).toBe("Hello world");
+	});
+
+	it("treats response that is not an array as empty (no assistant entry)", async () => {
+		const events = [{ kind: 0, v: { requests: [{ message: { text: "ask" }, response: "oops-string" }] } }];
+		const path = writeJsonl("h.jsonl", events);
+		const result = await readCopilotChatTranscript(path);
+		expect(result.entries).toEqual([{ role: "human", content: "ask" }]);
+	});
+
+	it("throws CopilotChatScanError on mid-write JSON parse failure (kind=parse)", async () => {
+		const path = join(sessionsDir, "g.jsonl");
+		writeFileSync(path, `${JSON.stringify({ kind: 0, v: { requests: [] } })}\n{not-json`);
+		await expect(readCopilotChatTranscript(path)).rejects.toThrow(/parse/);
+	});
+
+	it("throws CopilotChatScanError when file is missing (kind=fs)", async () => {
+		await expect(readCopilotChatTranscript(join(sessionsDir, "does-not-exist.jsonl"))).rejects.toThrow(
+			/fs|ENOENT/i,
+		);
+	});
+
+	it("treats empty file as init-less doc → no entries, no throw", async () => {
+		const path = join(sessionsDir, "empty.jsonl");
+		writeFileSync(path, "");
+		const result = await readCopilotChatTranscript(path);
+		expect(result.entries).toEqual([]);
+	});
+
+	it("throws schema error when requests is not an array", async () => {
+		const path = writeJsonl("bad-shape.jsonl", [{ kind: 0, v: { requests: "not-an-array" } }]);
+		await expect(readCopilotChatTranscript(path)).rejects.toThrow(/schema|requests/);
+	});
+});
+
+describe("readCopilotChatTranscript dispatcher", () => {
+	let tmpRoot: string;
+
+	beforeEach(() => {
+		tmpRoot = mkdtempSync(join(tmpdir(), "copilot-chat-rdr-"));
+	});
+
+	afterEach(() => {
+		rmSync(tmpRoot, { recursive: true, force: true });
+	});
+
+	it("routes <wsHash>/chatSessions/<sid>.jsonl to patch-log reader (yields requests entries)", async () => {
+		const wsDir = join(tmpRoot, "ws1", "chatSessions");
+		mkdirSync(wsDir, { recursive: true });
+		const path = join(wsDir, "abc123.jsonl");
+		const lines = [
+			JSON.stringify({ kind: 0, v: { requests: [] } }),
+			JSON.stringify({
+				kind: 1,
+				k: ["requests", 0],
+				v: { message: { text: "hello" }, response: [{ value: "world" }] },
+			}),
+		];
+		writeFileSync(path, lines.join("\n"));
+		const result = await readCopilotChatTranscript(path);
+		expect(result.entries).toEqual([
+			{ role: "human", content: "hello" },
+			{ role: "assistant", content: "world" },
+		]);
+	});
+
+	it("throws on an unrecognized path pattern", async () => {
+		const path = join(tmpRoot, "random", "thing.txt");
+		mkdirSync(join(tmpRoot, "random"), { recursive: true });
+		writeFileSync(path, "{}");
+		await expect(readCopilotChatTranscript(path)).rejects.toThrow(/unrecognized.*path/i);
+	});
+});
+
+describe("readCopilotChatTranscript via events.jsonl path", () => {
+	let tmpRoot: string;
+	let sessionDir: string;
+	let eventsPath: string;
+
+	beforeEach(() => {
+		tmpRoot = mkdtempSync(join(tmpdir(), "copilot-events-"));
+		sessionDir = join(tmpRoot, ".copilot", "session-state", "sess-1");
+		mkdirSync(sessionDir, { recursive: true });
+		eventsPath = join(sessionDir, "events.jsonl");
+	});
+
+	afterEach(() => {
+		rmSync(tmpRoot, { recursive: true, force: true });
+	});
+
+	function writeEvents(events: ReadonlyArray<unknown>): void {
+		writeFileSync(eventsPath, `${events.map((e) => JSON.stringify(e)).join("\n")}\n`);
+	}
+
+	it("emits user.message and non-empty assistant.message in file order", async () => {
+		writeEvents([
+			{ type: "session.start", data: {}, timestamp: "2026-05-07T10:00:00.000Z" },
+			{ type: "system.message", data: { content: "system prompt" }, timestamp: "2026-05-07T10:00:01.000Z" },
+			{ type: "user.message", data: { content: "hi" }, timestamp: "2026-05-07T10:00:02.000Z" },
+			{ type: "assistant.turn_start", data: {}, timestamp: "2026-05-07T10:00:03.000Z" },
+			{ type: "assistant.message", data: { content: "hello there" }, timestamp: "2026-05-07T10:00:04.000Z" },
+			{ type: "tool.execution_start", data: {}, timestamp: "2026-05-07T10:00:05.000Z" },
+			{ type: "tool.execution_complete", data: {}, timestamp: "2026-05-07T10:00:06.000Z" },
+			{ type: "assistant.turn_end", data: {}, timestamp: "2026-05-07T10:00:07.000Z" },
+		]);
+		const result = await readCopilotChatTranscript(eventsPath);
+		expect(result.entries).toEqual([
+			{ role: "human", content: "hi", timestamp: "2026-05-07T10:00:02.000Z" },
+			{ role: "assistant", content: "hello there", timestamp: "2026-05-07T10:00:04.000Z" },
+		]);
+		expect(result.newCursor.lineNumber).toBe(8);
+	});
+
+	it("drops assistant.message with empty content (tool-only turn)", async () => {
+		writeEvents([
+			{ type: "user.message", data: { content: "do tool" }, timestamp: "2026-05-07T10:00:00.000Z" },
+			{
+				type: "assistant.message",
+				data: { content: "", toolRequests: [{ name: "shell" }] },
+				timestamp: "2026-05-07T10:00:01.000Z",
+			},
+			{ type: "assistant.message", data: { content: "ok done" }, timestamp: "2026-05-07T10:00:02.000Z" },
+		]);
+		const result = await readCopilotChatTranscript(eventsPath);
+		expect(result.entries).toEqual([
+			{ role: "human", content: "do tool", timestamp: "2026-05-07T10:00:00.000Z" },
+			{ role: "assistant", content: "ok done", timestamp: "2026-05-07T10:00:02.000Z" },
+		]);
+	});
+
+	it("returns no entries when file contains only non-conversation events", async () => {
+		writeEvents([
+			{ type: "session.start", data: {} },
+			{ type: "session.shutdown", data: {} },
+		]);
+		const result = await readCopilotChatTranscript(eventsPath);
+		expect(result.entries).toEqual([]);
+		expect(result.newCursor.lineNumber).toBe(2);
+	});
+
+	it("advances past a malformed line and continues", async () => {
+		writeFileSync(
+			eventsPath,
+			`${[
+				JSON.stringify({
+					type: "user.message",
+					data: { content: "before" },
+					timestamp: "2026-05-07T10:00:00.000Z",
+				}),
+				"{not valid json",
+				JSON.stringify({
+					type: "assistant.message",
+					data: { content: "after" },
+					timestamp: "2026-05-07T10:00:01.000Z",
+				}),
+			].join("\n")}\n`,
+		);
+		const result = await readCopilotChatTranscript(eventsPath);
+		expect(result.entries).toEqual([
+			{ role: "human", content: "before", timestamp: "2026-05-07T10:00:00.000Z" },
+			{ role: "assistant", content: "after", timestamp: "2026-05-07T10:00:01.000Z" },
+		]);
+		expect(result.newCursor.lineNumber).toBe(3);
+	});
+
+	it("respects cursor.lineNumber as resume point", async () => {
+		writeEvents([
+			{ type: "user.message", data: { content: "old" }, timestamp: "2026-05-07T09:00:00.000Z" },
+			{ type: "assistant.message", data: { content: "old reply" }, timestamp: "2026-05-07T09:00:01.000Z" },
+			{ type: "user.message", data: { content: "new" }, timestamp: "2026-05-07T10:00:00.000Z" },
+			{ type: "assistant.message", data: { content: "new reply" }, timestamp: "2026-05-07T10:00:01.000Z" },
+		]);
+		const result = await readCopilotChatTranscript(eventsPath, {
+			transcriptPath: eventsPath,
+			lineNumber: 2,
+			updatedAt: "2026-05-07T09:30:00.000Z",
+		});
+		expect(result.entries).toEqual([
+			{ role: "human", content: "new", timestamp: "2026-05-07T10:00:00.000Z" },
+			{ role: "assistant", content: "new reply", timestamp: "2026-05-07T10:00:01.000Z" },
+		]);
+		expect(result.newCursor.lineNumber).toBe(4);
+	});
+
+	it("emits entries with timestamp:undefined when event has no timestamp", async () => {
+		writeEvents([
+			{ type: "user.message", data: { content: "no-ts" } },
+			{ type: "assistant.message", data: { content: "also no-ts" } },
+		]);
+		const result = await readCopilotChatTranscript(eventsPath);
+		expect(result.entries).toEqual([
+			{ role: "human", content: "no-ts" },
+			{ role: "assistant", content: "also no-ts" },
+		]);
+	});
+});
+
+describe("readCopilotChatTranscript beforeTimestamp gate", () => {
+	let tmpRoot: string;
+
+	beforeEach(() => {
+		tmpRoot = mkdtempSync(join(tmpdir(), "copilot-cutoff-"));
+	});
+
+	afterEach(() => {
+		rmSync(tmpRoot, { recursive: true, force: true });
+	});
+
+	it("events.jsonl: stops at first event whose timestamp > beforeTimestamp without consuming it", async () => {
+		const sessionDir = join(tmpRoot, ".copilot", "session-state", "s1");
+		mkdirSync(sessionDir, { recursive: true });
+		const path = join(sessionDir, "events.jsonl");
+		writeFileSync(
+			path,
+			`${[
+				JSON.stringify({
+					type: "user.message",
+					data: { content: "early" },
+					timestamp: "2026-05-07T09:00:00.000Z",
+				}),
+				JSON.stringify({
+					type: "assistant.message",
+					data: { content: "early reply" },
+					timestamp: "2026-05-07T09:00:30.000Z",
+				}),
+				JSON.stringify({
+					type: "user.message",
+					data: { content: "late" },
+					timestamp: "2026-05-07T11:00:00.000Z",
+				}),
+			].join("\n")}\n`,
+		);
+		const result = await readCopilotChatTranscript(path, undefined, "2026-05-07T10:00:00.000Z");
+		expect(result.entries).toEqual([
+			{ role: "human", content: "early", timestamp: "2026-05-07T09:00:00.000Z" },
+			{ role: "assistant", content: "early reply", timestamp: "2026-05-07T09:00:30.000Z" },
+		]);
+		// Cursor must NOT advance past the unconsumed late line — it sits at line 2.
+		expect(result.newCursor.lineNumber).toBe(2);
+	});
+
+	it("events.jsonl: events without timestamp are emitted (treated as before-cutoff)", async () => {
+		const sessionDir = join(tmpRoot, ".copilot", "session-state", "s2");
+		mkdirSync(sessionDir, { recursive: true });
+		const path = join(sessionDir, "events.jsonl");
+		writeFileSync(
+			path,
+			`${[
+				JSON.stringify({ type: "user.message", data: { content: "untimed" } }),
+				JSON.stringify({ type: "assistant.message", data: { content: "untimed reply" } }),
+			].join("\n")}\n`,
+		);
+		const result = await readCopilotChatTranscript(path, undefined, "2026-05-07T10:00:00.000Z");
+		expect(result.entries.length).toBe(2);
+	});
+
+	it("patch log: stops emitting at first request whose timestamp > beforeTimestamp without advancing cursor past it", async () => {
+		const wsDir = join(tmpRoot, "ws1", "chatSessions");
+		mkdirSync(wsDir, { recursive: true });
+		const path = join(wsDir, "p1.jsonl");
+		writeFileSync(
+			path,
+			[
+				JSON.stringify({ kind: 0, v: { requests: [] } }),
+				JSON.stringify({
+					kind: 1,
+					k: ["requests", 0],
+					v: {
+						message: { text: "early" },
+						response: [{ value: "early reply" }],
+						timestamp: Date.parse("2026-05-07T09:00:00.000Z"),
+					},
+				}),
+				JSON.stringify({
+					kind: 1,
+					k: ["requests", 1],
+					v: {
+						message: { text: "late" },
+						response: [{ value: "late reply" }],
+						timestamp: Date.parse("2026-05-07T11:00:00.000Z"),
+					},
+				}),
+			].join("\n"),
+		);
+		const result = await readCopilotChatTranscript(path, undefined, "2026-05-07T10:00:00.000Z");
+		expect(result.entries).toEqual([
+			{ role: "human", content: "early" },
+			{ role: "assistant", content: "early reply" },
+		]);
+		// Cursor stays at requests[1] so the next read picks up "late".
+		expect(result.newCursor.lineNumber).toBe(1);
+	});
+
+	it("patch log: requests without numeric timestamp are emitted (treated as before-cutoff)", async () => {
+		const wsDir = join(tmpRoot, "ws1", "chatSessions");
+		mkdirSync(wsDir, { recursive: true });
+		const path = join(wsDir, "p2.jsonl");
+		writeFileSync(
+			path,
+			[
+				JSON.stringify({ kind: 0, v: { requests: [] } }),
+				JSON.stringify({
+					kind: 1,
+					k: ["requests", 0],
+					v: { message: { text: "no-ts" }, response: [{ value: "no-ts reply" }] },
+				}),
+			].join("\n"),
+		);
+		const result = await readCopilotChatTranscript(path, undefined, "2026-05-07T10:00:00.000Z");
+		expect(result.entries.length).toBe(2);
+	});
+});

--- a/cli/src/core/CopilotChatTranscriptReader.ts
+++ b/cli/src/core/CopilotChatTranscriptReader.ts
@@ -1,0 +1,318 @@
+/**
+ * VS Code Copilot Chat transcript reader.
+ *
+ * vscode persists each chat session as a JSONL document patch log:
+ *   line 0:  {kind:0, v:<initial document>}
+ *   line N:  {kind:1, k:[...path], v:<value>}   set at path
+ *   line N:  {kind:2, k:[...path]}              delete at path
+ *
+ * To reconstruct the conversation we replay all patches in order, then read
+ * `requests[]` from the final document. See spec
+ * docs/superpowers/specs/2026-05-06-copilot-chat-support-design.md.
+ */
+
+import { createReadStream } from "node:fs";
+import { readFile, stat } from "node:fs/promises";
+import { createInterface } from "node:readline";
+import { createLogger } from "../Logger.js";
+import type { TranscriptCursor, TranscriptEntry, TranscriptReadResult } from "../Types.js";
+
+type PathSegment = string | number;
+
+const log = createLogger("CopilotChatReader");
+
+/**
+ * Mutates `doc` in place by setting `value` at `path`. Creates intermediate
+ * objects/arrays as needed (next-segment-type decides container shape).
+ *
+ * Exported with the `_` prefix as a unit-test seam — replayPatches and
+ * readCopilotChatTranscript are the public contract; primitives are internal.
+ */
+export function _setAtPath(doc: unknown, path: PathSegment[], value: unknown): void {
+	if (path.length === 0) {
+		return; // Root replacement is replayPatches's responsibility (kind:0).
+	}
+	let cur = doc as Record<string | number, unknown>;
+	for (let i = 0; i < path.length - 1; i++) {
+		const seg = path[i];
+		const next = path[i + 1];
+		if (cur[seg] === undefined || cur[seg] === null) {
+			cur[seg] = typeof next === "number" ? [] : {};
+		}
+		cur = cur[seg] as Record<string | number, unknown>;
+	}
+	cur[path[path.length - 1]] = value;
+}
+
+/**
+ * Mutates `doc` in place by removing the value at `path`. No-op if the path
+ * doesn't exist or is empty. For array elements, uses `splice` so the array
+ * shifts (matching vscode's emitted semantics for `pendingRequests` cleanup).
+ */
+export function _deleteAtPath(doc: unknown, path: PathSegment[]): void {
+	if (path.length === 0) return;
+	let cur = doc as Record<string | number, unknown> | undefined;
+	for (let i = 0; i < path.length - 1; i++) {
+		if (cur === undefined || cur === null) return;
+		cur = cur[path[i]] as Record<string | number, unknown> | undefined;
+	}
+	if (cur === undefined || cur === null) return;
+	const last = path[path.length - 1];
+	if (Array.isArray(cur) && typeof last === "number") {
+		if (last >= 0 && last < cur.length) {
+			cur.splice(last, 1);
+		}
+		return;
+	}
+	delete cur[last];
+}
+
+interface KindZeroEvent {
+	kind: 0;
+	v: unknown;
+}
+interface KindOneEvent {
+	kind: 1;
+	k: PathSegment[];
+	v: unknown;
+}
+interface KindTwoEvent {
+	kind: 2;
+	k: PathSegment[];
+}
+type PatchEvent = KindZeroEvent | KindOneEvent | KindTwoEvent | { kind: number };
+
+/**
+ * Replays a JSONL patch log into a final document.
+ *
+ *   kind 0 → replace entire document with `v`
+ *   kind 1 → set `v` at path `k`
+ *   kind 2 → delete value at path `k`
+ *
+ * Unknown `kind` is logged and skipped (forward compatibility — vscode may add
+ * new event types in future versions). JSON parse errors are propagated so the
+ * caller can distinguish "mid-write" from "structurally broken file".
+ */
+export function _replayPatches(lines: ReadonlyArray<string>): unknown {
+	let doc: unknown = {};
+	for (const raw of lines) {
+		const evt = JSON.parse(raw) as PatchEvent;
+		switch (evt.kind) {
+			case 0:
+				doc = (evt as KindZeroEvent).v;
+				break;
+			case 1: {
+				const e = evt as KindOneEvent;
+				_setAtPath(doc, e.k, e.v);
+				break;
+			}
+			case 2: {
+				const e = evt as KindTwoEvent;
+				_deleteAtPath(doc, e.k);
+				break;
+			}
+			default:
+				log.warn("Unknown patch kind %s — skipping", evt.kind);
+				break;
+		}
+	}
+	return doc;
+}
+
+/** Structured error thrown by the Copilot Chat reader. Surfaced via `error.cause.kind`. */
+export interface CopilotChatScanError {
+	readonly kind: "parse" | "fs" | "schema" | "unknown";
+	readonly message: string;
+}
+
+/** Throws an Error with a `CopilotChatScanError` payload attached to .cause. */
+function throwScanError(kind: CopilotChatScanError["kind"], message: string): never {
+	const err = new Error(`Copilot Chat scan failed (${kind}): ${message}`);
+	(err as Error & { cause: CopilotChatScanError }).cause = { kind, message };
+	throw err;
+}
+
+interface ChatRequest {
+	message?: { text?: string };
+	response?: ReadonlyArray<{ value?: string }>;
+}
+
+interface EventsLineEvent {
+	type?: string;
+	timestamp?: string;
+	data?: { content?: string };
+}
+
+/**
+ * Reads `~/.copilot/session-state/<sid>/events.jsonl` line-by-line. Conversation
+ * lives in `type:"user.message"` and non-empty `type:"assistant.message"`
+ * events; everything else (session lifecycle, tool calls, assistant turn
+ * boundaries, system prompts) is skipped. The cursor's `lineNumber` is the
+ * standard "lines already consumed" semantics (first line is line 1).
+ *
+ * Per-line `JSON.parse` failures are skipped and the cursor still advances
+ * past the bad line — matches the Claude / Codex / Gemini JSONL readers'
+ * "one bad line never blocks the rest" policy.
+ */
+async function readEventsJsonl(
+	transcriptPath: string,
+	cursor?: TranscriptCursor,
+	beforeTimestamp?: string,
+): Promise<TranscriptReadResult> {
+	const startLine = cursor?.lineNumber ?? 0;
+	const stream = createReadStream(transcriptPath, { encoding: "utf8" });
+	const rl = createInterface({ input: stream, crlfDelay: Number.POSITIVE_INFINITY });
+
+	const entries: TranscriptEntry[] = [];
+	let currentLine = 0;
+
+	for await (const rawLine of rl) {
+		currentLine++;
+		if (currentLine <= startLine) continue;
+
+		let evt: EventsLineEvent;
+		try {
+			evt = JSON.parse(rawLine) as EventsLineEvent;
+		} catch {
+			// skip malformed line, cursor still advances
+			continue;
+		}
+
+		// beforeTimestamp gate: events with timestamp > cutoff are deferred to
+		// the next commit. ISO 8601 timestamps are lex-sortable, so string
+		// comparison is sufficient here. Stop without consuming this line so
+		// the cursor reflects "last consumed" — the next read will re-encounter
+		// this entry within a wider cutoff window.
+		if (beforeTimestamp && typeof evt.timestamp === "string" && evt.timestamp > beforeTimestamp) {
+			currentLine--; // do not consume this line
+			break;
+		}
+
+		const content = evt.data?.content;
+		if (typeof content !== "string" || content.length === 0) continue;
+
+		if (evt.type === "user.message") {
+			entries.push(
+				evt.timestamp ? { role: "human", content, timestamp: evt.timestamp } : { role: "human", content },
+			);
+		} else if (evt.type === "assistant.message") {
+			entries.push(
+				evt.timestamp
+					? { role: "assistant", content, timestamp: evt.timestamp }
+					: { role: "assistant", content },
+			);
+		}
+	}
+
+	stream.close();
+	const updatedAt = await stat(transcriptPath).then((s) => new Date(s.mtimeMs).toISOString());
+	return {
+		entries,
+		newCursor: { transcriptPath, lineNumber: currentLine, updatedAt },
+		totalLinesRead: Math.max(0, currentLine - startLine),
+	};
+}
+
+/**
+ * Reads a `<wsHash>/chatSessions/<sid>.jsonl` patch log: replay all patches
+ * into a final document, then emit TranscriptEntry records for `requests[i]`
+ * where `i >= cursor.lineNumber`. The cursor's `lineNumber` field is repurposed
+ * here as "request count already consumed" — it never exceeds `requests.length`
+ * and only advances on successful emit.
+ */
+async function readPatchLog(
+	transcriptPath: string,
+	cursor?: TranscriptCursor,
+	beforeTimestamp?: string,
+): Promise<TranscriptReadResult> {
+	const fromIdx = cursor?.lineNumber ?? 0;
+
+	let raw: string;
+	try {
+		raw = await readFile(transcriptPath, "utf8");
+	} catch (error: unknown) {
+		throwScanError("fs", (error as Error).message);
+	}
+
+	const lines = raw.split("\n").filter((l) => l.length > 0);
+	if (lines.length === 0) {
+		const updatedAt = await stat(transcriptPath).then((s) => new Date(s.mtimeMs).toISOString());
+		return {
+			entries: [],
+			newCursor: { transcriptPath, lineNumber: 0, updatedAt },
+			totalLinesRead: 0,
+		};
+	}
+
+	let doc: unknown;
+	try {
+		doc = _replayPatches(lines);
+	} catch (error: unknown) {
+		throwScanError("parse", (error as Error).message);
+	}
+
+	const requests = (doc as { requests?: unknown }).requests;
+	if (!Array.isArray(requests)) {
+		throwScanError("schema", "requests is not an array");
+	}
+
+	// Patch-log timestamps are numeric (ms since epoch), so we compare against
+	// the parsed cutoff in ms. A request without a numeric timestamp is treated
+	// as before-cutoff (consistent with events.jsonl untimed-events behavior).
+	const cutoffMs = beforeTimestamp ? Date.parse(beforeTimestamp) : Number.POSITIVE_INFINITY;
+	const entries: TranscriptEntry[] = [];
+	let lastEmittedIdx = fromIdx;
+
+	for (let i = fromIdx; i < requests.length; i++) {
+		const req = requests[i] as ChatRequest & { timestamp?: number };
+		// beforeTimestamp gate: stop without advancing cursor past this request
+		// so the next read picks it up within a wider cutoff window.
+		if (typeof req?.timestamp === "number" && req.timestamp > cutoffMs) {
+			break;
+		}
+		const userText = req?.message?.text;
+		if (typeof userText === "string" && userText.length > 0) {
+			entries.push({ role: "human", content: userText });
+		}
+		const responseList = Array.isArray(req?.response) ? req.response : [];
+		const assistantText = responseList
+			.map((chunk) => (typeof chunk?.value === "string" ? chunk.value : ""))
+			.join("");
+		if (assistantText.length > 0) {
+			entries.push({ role: "assistant", content: assistantText });
+		}
+		lastEmittedIdx = i + 1;
+	}
+
+	const updatedAt = await stat(transcriptPath).then((s) => new Date(s.mtimeMs).toISOString());
+	return {
+		entries,
+		newCursor: { transcriptPath, lineNumber: lastEmittedIdx, updatedAt },
+		totalLinesRead: lines.length,
+	};
+}
+
+/**
+ * Front door for Copilot Chat transcript reading. Dispatches to one of two
+ * sub-readers based on the trailing path segments of `transcriptPath`:
+ *
+ *   - `<...>/.copilot/session-state/<sid>/events.jsonl` → readEventsJsonl
+ *   - `<...>/chatSessions/<sid>.jsonl`                 → readPatchLog
+ *
+ * Throws on an unrecognized path — the discoverer should never emit anything
+ * else, so this is a defense-in-depth invariant.
+ */
+export async function readCopilotChatTranscript(
+	transcriptPath: string,
+	cursor?: TranscriptCursor,
+	beforeTimestamp?: string,
+): Promise<TranscriptReadResult> {
+	const norm = transcriptPath.replace(/\\/g, "/");
+	if (/\/\.copilot\/session-state\/[^/]+\/events\.jsonl$/.test(norm)) {
+		return readEventsJsonl(transcriptPath, cursor, beforeTimestamp);
+	}
+	if (/\/chatSessions\/[^/]+\.jsonl$/.test(norm)) {
+		return readPatchLog(transcriptPath, cursor, beforeTimestamp);
+	}
+	throw new Error(`Copilot Chat reader: unrecognized transcriptPath pattern: ${transcriptPath}`);
+}

--- a/cli/src/core/CopilotDetector.test.ts
+++ b/cli/src/core/CopilotDetector.test.ts
@@ -1,0 +1,73 @@
+import { stat } from "node:fs/promises";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("node:fs/promises", async () => {
+	const actual = await vi.importActual<typeof import("node:fs/promises")>("node:fs/promises");
+	return { ...actual, stat: vi.fn() };
+});
+
+const { mockHomedir, mockPlatform } = vi.hoisted(() => ({
+	mockHomedir: vi.fn().mockReturnValue("/Users/test"),
+	mockPlatform: vi.fn().mockReturnValue("darwin"),
+}));
+
+vi.mock("node:os", async (importOriginal) => {
+	const original = await importOriginal<typeof import("node:os")>();
+	return { ...original, homedir: mockHomedir, platform: mockPlatform };
+});
+
+describe("CopilotDetector", () => {
+	beforeEach(() => {
+		mockHomedir.mockReturnValue("/Users/test");
+		mockPlatform.mockReturnValue("darwin");
+		vi.mocked(stat).mockReset();
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("returns ~/.copilot/session-store.db on macOS/Linux", async () => {
+		const { getCopilotDbPath } = await import("./CopilotDetector.js");
+		expect(getCopilotDbPath()).toBe(join("/Users/test", ".copilot", "session-store.db"));
+	});
+
+	it("returns the equivalent path on Windows", async () => {
+		mockPlatform.mockReturnValue("win32");
+		mockHomedir.mockReturnValue("C:\\Users\\test");
+		const { getCopilotDbPath } = await import("./CopilotDetector.js");
+		expect(getCopilotDbPath()).toContain(".copilot");
+		expect(getCopilotDbPath()).toContain("session-store.db");
+	});
+
+	it("isCopilotInstalled returns true when DB exists", async () => {
+		vi.mocked(stat).mockResolvedValue({ isFile: () => true } as Awaited<ReturnType<typeof stat>>);
+		const { isCopilotInstalled } = await import("./CopilotDetector.js");
+		await expect(isCopilotInstalled()).resolves.toBe(true);
+	});
+
+	it("isCopilotInstalled returns false when DB is missing", async () => {
+		vi.mocked(stat).mockRejectedValue(Object.assign(new Error("no file"), { code: "ENOENT" }));
+		const { isCopilotInstalled } = await import("./CopilotDetector.js");
+		await expect(isCopilotInstalled()).resolves.toBe(false);
+	});
+
+	it("isCopilotInstalled returns false when DB stat fails with permission error", async () => {
+		vi.mocked(stat).mockRejectedValue(Object.assign(new Error("permission denied"), { code: "EACCES" }));
+		const { isCopilotInstalled } = await import("./CopilotDetector.js");
+		await expect(isCopilotInstalled()).resolves.toBe(false);
+	});
+
+	it("isCopilotInstalled logs the unknown-code fallback when stat error has no `code` field", async () => {
+		vi.mocked(stat).mockRejectedValue(new Error("opaque failure"));
+		const { isCopilotInstalled } = await import("./CopilotDetector.js");
+		await expect(isCopilotInstalled()).resolves.toBe(false);
+	});
+
+	it("isCopilotInstalled returns false when runtime lacks node:sqlite", async () => {
+		vi.spyOn(process.versions, "node", "get").mockReturnValue("18.0.0");
+		const { isCopilotInstalled } = await import("./CopilotDetector.js");
+		await expect(isCopilotInstalled()).resolves.toBe(false);
+	});
+});

--- a/cli/src/core/CopilotDetector.ts
+++ b/cli/src/core/CopilotDetector.ts
@@ -1,0 +1,46 @@
+/**
+ * GitHub Copilot CLI detector.
+ *
+ * Copilot CLI stores conversations in ~/.copilot/session-store.db (SQLite, WAL).
+ * We read the DB via node:sqlite — pure-JS SQLite libraries cannot see WAL data.
+ */
+
+import { stat } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { createLogger } from "../Logger.js";
+import { hasNodeSqliteSupport, NODE_SQLITE_MIN_VERSION } from "./SqliteHelpers.js";
+
+const log = createLogger("CopilotDetector");
+
+/** Returns the absolute path to Copilot CLI's session-store database. */
+export function getCopilotDbPath(): string {
+	return join(homedir(), ".copilot", "session-store.db");
+}
+
+/**
+ * Returns true when Copilot CLI's session DB is present *and* the current
+ * runtime can read it. Mirrors `isOpenCodeInstalled`'s shape.
+ */
+export async function isCopilotInstalled(): Promise<boolean> {
+	if (!hasNodeSqliteSupport()) {
+		log.info(
+			"Copilot CLI support disabled: this runtime is Node %s, requires %d.%d+ for built-in SQLite",
+			process.versions.node,
+			NODE_SQLITE_MIN_VERSION.major,
+			NODE_SQLITE_MIN_VERSION.minor,
+		);
+		return false;
+	}
+	const dbPath = getCopilotDbPath();
+	try {
+		const fileStat = await stat(dbPath);
+		return fileStat.isFile();
+	} catch (error: unknown) {
+		const code = (error as NodeJS.ErrnoException).code;
+		if (code !== "ENOENT") {
+			log.warn("Copilot DB stat failed (%s): %s", code ?? "unknown", (error as Error).message);
+		}
+		return false;
+	}
+}

--- a/cli/src/core/CopilotSessionDiscoverer.test.ts
+++ b/cli/src/core/CopilotSessionDiscoverer.test.ts
@@ -1,0 +1,209 @@
+import { mkdtemp, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// CopilotSessionDiscoverer.normalizeCwd() runs path.resolve() on the projectDir
+// before the SQL match. Tests must seed `cwd` with the same resolve() output so
+// the value at row-time and query-time agree on every platform — a literal
+// "/p" string seeded on Windows would never match resolve("/p") = "<drive>:\\p".
+const platformPath = (p: string): string => resolve(p);
+
+// scanCopilotSessions filters rows older than 48 hours. Seed timestamps relative
+// to Date.now() so fixtures stay fresh forever (a hardcoded ISO string would
+// silently cross the 48h cutoff once the test suite is more than 2 days old).
+const isoFromNow = (msAgo = 1_000): string => new Date(Date.now() - msAgo).toISOString();
+
+vi.mock("node:fs/promises", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("node:fs/promises")>("node:fs/promises");
+	return { ...actual, stat: vi.fn(actual.stat) };
+});
+
+const SCHEMA_STATEMENTS = [
+	`CREATE TABLE sessions (
+		id TEXT PRIMARY KEY, cwd TEXT, repository TEXT, host_type TEXT,
+		branch TEXT, summary TEXT, created_at TEXT, updated_at TEXT
+	)`,
+	`CREATE TABLE turns (
+		id INTEGER PRIMARY KEY AUTOINCREMENT,
+		session_id TEXT NOT NULL,
+		turn_index INTEGER NOT NULL,
+		user_message TEXT, assistant_response TEXT, timestamp TEXT
+	)`,
+];
+
+interface SeedSession {
+	id: string;
+	cwd: string;
+	updated_at: string;
+}
+
+async function makeFixtureDb(sessions: SeedSession[]): Promise<{ dbPath: string; cleanup: () => Promise<void> }> {
+	const dir = await mkdtemp(join(tmpdir(), "copilot-disc-"));
+	const dbPath = join(dir, "session-store.db");
+	const db = new DatabaseSync(dbPath);
+	for (const stmt of SCHEMA_STATEMENTS) db.prepare(stmt).run();
+	const insertSql =
+		"INSERT INTO sessions (id, cwd, repository, host_type, branch, summary, created_at, updated_at) " +
+		"VALUES (?, ?, NULL, 'github', NULL, NULL, ?, ?)";
+	const insert = db.prepare(insertSql);
+	for (const s of sessions) insert.run(s.id, s.cwd, s.updated_at, s.updated_at);
+	db.close();
+	return { dbPath, cleanup: () => rm(dir, { recursive: true, force: true }) };
+}
+
+describe("scanCopilotSessions", () => {
+	let cleanups: Array<() => Promise<void>>;
+
+	beforeEach(async () => {
+		cleanups = [];
+		// vi.restoreAllMocks() does not unwind mockRejectedValue/mockResolvedValue
+		// applied to a vi.fn() created inside a module mock factory, so any test
+		// that mocks `stat` would leak its rejection into later tests. Reset to
+		// the real implementation explicitly.
+		const actual = await vi.importActual<typeof import("node:fs/promises")>("node:fs/promises");
+		vi.mocked(stat).mockReset().mockImplementation(actual.stat);
+	});
+	afterEach(async () => {
+		for (const c of cleanups) await c();
+		vi.restoreAllMocks();
+	});
+
+	async function withFixture(seeds: SeedSession[]) {
+		const fx = await makeFixtureDb(seeds);
+		cleanups.push(fx.cleanup);
+		const detector = await import("./CopilotDetector.js");
+		vi.spyOn(detector, "getCopilotDbPath").mockReturnValue(fx.dbPath);
+		return fx;
+	}
+
+	it("returns sessions whose cwd matches the project directory", async () => {
+		await withFixture([
+			{ id: "a", cwd: platformPath("/Users/x/project"), updated_at: isoFromNow(1_000) },
+			{ id: "b", cwd: platformPath("/other"), updated_at: isoFromNow() },
+		]);
+		const { scanCopilotSessions } = await import("./CopilotSessionDiscoverer.js");
+		const { sessions } = await scanCopilotSessions(platformPath("/Users/x/project"));
+		expect(sessions).toHaveLength(1);
+		expect(sessions[0]).toMatchObject({ sessionId: "a", source: "copilot" });
+		expect(sessions[0].transcriptPath).toMatch(/session-store\.db#a$/);
+	});
+
+	it("returns multiple matching sessions ordered by updated_at DESC", async () => {
+		await withFixture([
+			{ id: "older", cwd: platformPath("/p"), updated_at: isoFromNow(2_000) },
+			{ id: "newer", cwd: platformPath("/p"), updated_at: isoFromNow(1_000) },
+		]);
+		const { scanCopilotSessions } = await import("./CopilotSessionDiscoverer.js");
+		const { sessions } = await scanCopilotSessions(platformPath("/p"));
+		expect(sessions.map((s) => s.sessionId)).toEqual(["newer", "older"]);
+	});
+
+	it("normalizes trailing slashes on the projectDir", async () => {
+		await withFixture([{ id: "a", cwd: platformPath("/Users/x/project"), updated_at: isoFromNow() }]);
+		const { scanCopilotSessions } = await import("./CopilotSessionDiscoverer.js");
+		// Forward slash is tolerated by both posix and win32 path.resolve, so
+		// `${platformPath(...)}/` is a valid trailing-slash variant on every OS.
+		const { sessions } = await scanCopilotSessions(`${platformPath("/Users/x/project")}/`);
+		expect(sessions).toHaveLength(1);
+	});
+
+	it("matches case-insensitively on darwin/win32", async () => {
+		vi.spyOn(process, "platform", "get").mockReturnValue("darwin");
+		await withFixture([{ id: "a", cwd: platformPath("/Users/X/Project"), updated_at: isoFromNow() }]);
+		const { scanCopilotSessions } = await import("./CopilotSessionDiscoverer.js");
+		const { sessions } = await scanCopilotSessions(platformPath("/users/x/project"));
+		expect(sessions).toHaveLength(1);
+	});
+
+	it("does NOT match case-insensitively on linux", async () => {
+		vi.spyOn(process, "platform", "get").mockReturnValue("linux");
+		await withFixture([{ id: "a", cwd: platformPath("/Users/X/Project"), updated_at: isoFromNow() }]);
+		const { scanCopilotSessions } = await import("./CopilotSessionDiscoverer.js");
+		const { sessions } = await scanCopilotSessions(platformPath("/users/x/project"));
+		expect(sessions).toHaveLength(0);
+	});
+
+	it("returns empty when nothing matches", async () => {
+		await withFixture([{ id: "a", cwd: platformPath("/elsewhere"), updated_at: isoFromNow() }]);
+		const { scanCopilotSessions } = await import("./CopilotSessionDiscoverer.js");
+		const { sessions } = await scanCopilotSessions(platformPath("/Users/x/project"));
+		expect(sessions).toEqual([]);
+	});
+
+	it("filters out sessions older than the 48h staleness window", async () => {
+		const FORTY_NINE_HOURS_MS = 49 * 60 * 60 * 1000;
+		await withFixture([
+			{ id: "fresh", cwd: platformPath("/p"), updated_at: isoFromNow(1_000) },
+			{ id: "stale", cwd: platformPath("/p"), updated_at: isoFromNow(FORTY_NINE_HOURS_MS) },
+		]);
+		const { scanCopilotSessions } = await import("./CopilotSessionDiscoverer.js");
+		const { sessions } = await scanCopilotSessions(platformPath("/p"));
+		expect(sessions.map((s) => s.sessionId)).toEqual(["fresh"]);
+	});
+
+	it("returns empty silently when the DB file is missing", async () => {
+		const detector = await import("./CopilotDetector.js");
+		vi.spyOn(detector, "getCopilotDbPath").mockReturnValue(join(tmpdir(), "copilot-disc-missing", "x.db"));
+		const { scanCopilotSessions } = await import("./CopilotSessionDiscoverer.js");
+		const { sessions, error } = await scanCopilotSessions(platformPath("/Users/x/project"));
+		expect(sessions).toEqual([]);
+		expect(error).toBeUndefined();
+	});
+
+	it("classifies a corrupt DB as a scan error", async () => {
+		const dir = await mkdtemp(join(tmpdir(), "copilot-disc-"));
+		const dbPath = join(dir, "session-store.db");
+		await writeFile(dbPath, "not a sqlite file");
+		cleanups.push(() => rm(dir, { recursive: true, force: true }));
+		const detector = await import("./CopilotDetector.js");
+		vi.spyOn(detector, "getCopilotDbPath").mockReturnValue(dbPath);
+		const { scanCopilotSessions } = await import("./CopilotSessionDiscoverer.js");
+		const { sessions, error } = await scanCopilotSessions(platformPath("/Users/x/project"));
+		expect(sessions).toEqual([]);
+		expect(error?.kind).toBe("corrupt");
+	});
+
+	it("skips a row whose updated_at is non-finite", async () => {
+		await withFixture([
+			{ id: "good", cwd: platformPath("/p"), updated_at: isoFromNow() },
+			{ id: "bad", cwd: platformPath("/p"), updated_at: "not-a-date" },
+		]);
+		const { scanCopilotSessions } = await import("./CopilotSessionDiscoverer.js");
+		const { sessions } = await scanCopilotSessions(platformPath("/p"));
+		expect(sessions.map((s) => s.sessionId)).toEqual(["good"]);
+	});
+
+	it("returns a scan error when the Copilot DB stat fails with permission denied", async () => {
+		await withFixture([{ id: "a", cwd: platformPath("/Users/x/project"), updated_at: isoFromNow() }]);
+		vi.mocked(stat).mockRejectedValue(Object.assign(new Error("permission denied"), { code: "EACCES" }));
+
+		const { scanCopilotSessions } = await import("./CopilotSessionDiscoverer.js");
+		const { sessions, error } = await scanCopilotSessions(platformPath("/Users/x/project"));
+
+		expect(sessions).toEqual([]);
+		expect(error?.kind).toBe("permission");
+	});
+
+	it("discoverCopilotSessions returns sessions unchanged when the scan succeeds", async () => {
+		await withFixture([{ id: "a", cwd: platformPath("/p"), updated_at: isoFromNow() }]);
+		const { discoverCopilotSessions } = await import("./CopilotSessionDiscoverer.js");
+		const sessions = await discoverCopilotSessions(platformPath("/p"));
+		expect(sessions.map((s) => s.sessionId)).toEqual(["a"]);
+	});
+
+	it("discoverCopilotSessions returns an empty list and logs a warning when the scan fails", async () => {
+		const dir = await mkdtemp(join(tmpdir(), "copilot-disc-"));
+		const dbPath = join(dir, "session-store.db");
+		await writeFile(dbPath, "not a sqlite file");
+		cleanups.push(() => rm(dir, { recursive: true, force: true }));
+		const detector = await import("./CopilotDetector.js");
+		vi.spyOn(detector, "getCopilotDbPath").mockReturnValue(dbPath);
+
+		const { discoverCopilotSessions } = await import("./CopilotSessionDiscoverer.js");
+		const sessions = await discoverCopilotSessions(platformPath("/p"));
+
+		expect(sessions).toEqual([]);
+	});
+});

--- a/cli/src/core/CopilotSessionDiscoverer.ts
+++ b/cli/src/core/CopilotSessionDiscoverer.ts
@@ -1,0 +1,110 @@
+/**
+ * GitHub Copilot CLI session discoverer.
+ *
+ * Copilot stores every session in ~/.copilot/session-store.db. Each session row
+ * carries its own `cwd`, so workspace attribution is exact. Sessions older than
+ * 48 hours are excluded — matches the OpenCode / Cursor / Codex convention so a
+ * user enabling Copilot for the first time doesn't pull months of history into
+ * the next commit summary. Synthetic transcript path: "<dbPath>#<sessionId>".
+ */
+
+import { stat } from "node:fs/promises";
+import { resolve } from "node:path";
+import { createLogger } from "../Logger.js";
+import type { SessionInfo } from "../Types.js";
+import { getCopilotDbPath } from "./CopilotDetector.js";
+import { classifyScanError, type SqliteScanError, withSqliteDb } from "./SqliteHelpers.js";
+
+const log = createLogger("CopilotDiscoverer");
+
+/** Sessions older than 48 hours are considered stale (matches other sources) */
+const SESSION_STALE_MS = 48 * 60 * 60 * 1000;
+
+export interface CopilotScanResult {
+	readonly sessions: ReadonlyArray<SessionInfo>;
+	readonly error?: SqliteScanError;
+}
+
+function normalizeCwd(p: string): string {
+	return resolve(p);
+}
+
+export async function scanCopilotSessions(projectDir: string): Promise<CopilotScanResult> {
+	const dbPath = getCopilotDbPath();
+	const normalized = normalizeCwd(projectDir);
+	const cutoffMs = Date.now() - SESSION_STALE_MS;
+
+	try {
+		await stat(dbPath);
+	} catch (error: unknown) {
+		const code = (error as NodeJS.ErrnoException).code;
+		/* v8 ignore start -- TOCTOU branch covered by classifier tests */
+		if (code !== "ENOENT") {
+			const scanError = classifyScanError(error);
+			if (scanError) {
+				log.error("Copilot DB stat failed (%s): %s", scanError.kind, scanError.message);
+				return { sessions: [], error: scanError };
+			}
+			return { sessions: [] };
+		}
+		/* v8 ignore stop */
+		log.debug("Copilot DB not present at %s — treating as not installed", dbPath);
+		return { sessions: [] };
+	}
+
+	try {
+		const sessions = await withSqliteDb(dbPath, (db) => {
+			const caseInsensitive = process.platform === "win32" || process.platform === "darwin";
+			const cwdMatch = caseInsensitive ? "LOWER(cwd) = LOWER(:cwd)" : "cwd = :cwd";
+			const rows = db
+				.prepare(
+					`SELECT id, cwd, repository, branch, host_type, summary, created_at, updated_at
+					 FROM sessions
+					 WHERE ${cwdMatch}
+					 ORDER BY updated_at DESC`,
+				)
+				.all({ cwd: normalized }) as ReadonlyArray<{ id: string; updated_at: string }>;
+			return rows.flatMap((row): SessionInfo[] => {
+				const ms = Date.parse(row.updated_at);
+				if (!Number.isFinite(ms)) {
+					log.warn("Skipping Copilot session %s: non-finite updated_at", row.id);
+					return [];
+				}
+				// JS post-filter rather than SQL `WHERE updated_at > :cutoff` because
+				// updated_at is TEXT and SQL `>` would do lexicographic comparison —
+				// only valid if every row uses canonical UTC ISO-8601. Filtering after
+				// Date.parse tolerates any format Date.parse accepts.
+				if (ms < cutoffMs) return [];
+				return [
+					{
+						sessionId: String(row.id),
+						transcriptPath: `${dbPath}#${row.id}`,
+						updatedAt: new Date(ms).toISOString(),
+						source: "copilot",
+					},
+				];
+			});
+		});
+		log.info("Discovered %d Copilot session(s) for %s", sessions.length, normalized);
+		return { sessions };
+	} catch (error: unknown) {
+		const scanError = classifyScanError(error);
+		/* v8 ignore start -- TOCTOU branch covered by classifier tests */
+		if (scanError === null) {
+			log.debug("Copilot DB disappeared between detection and scan: %s", (error as Error).message);
+			return { sessions: [] };
+		}
+		/* v8 ignore stop */
+		log.error("Copilot scan failed (%s): %s", scanError.kind, scanError.message);
+		return { sessions: [], error: scanError };
+	}
+}
+
+/** Convenience wrapper without the error channel — used by QueueWorker. */
+export async function discoverCopilotSessions(projectDir: string): Promise<ReadonlyArray<SessionInfo>> {
+	const { sessions, error } = await scanCopilotSessions(projectDir);
+	if (error) {
+		log.warn("Copilot scan error (%s) — sessions excluded from this run: %s", error.kind, error.message);
+	}
+	return sessions;
+}

--- a/cli/src/core/CopilotTranscriptReader.test.ts
+++ b/cli/src/core/CopilotTranscriptReader.test.ts
@@ -1,0 +1,182 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+const SCHEMA_STATEMENTS = [
+	"CREATE TABLE sessions (id TEXT PRIMARY KEY, cwd TEXT)",
+	`CREATE TABLE turns (
+		id INTEGER PRIMARY KEY AUTOINCREMENT,
+		session_id TEXT NOT NULL,
+		turn_index INTEGER NOT NULL,
+		user_message TEXT, assistant_response TEXT, timestamp TEXT
+	)`,
+];
+
+interface SeedTurn {
+	turn_index: number;
+	user_message?: string | null;
+	assistant_response?: string | null;
+	timestamp?: string;
+}
+
+async function makeDb(sessionId: string, turns: SeedTurn[]): Promise<{ dbPath: string; cleanup: () => Promise<void> }> {
+	const dir = await mkdtemp(join(tmpdir(), "copilot-tr-"));
+	const dbPath = join(dir, "session-store.db");
+	const db = new DatabaseSync(dbPath);
+	for (const stmt of SCHEMA_STATEMENTS) db.prepare(stmt).run();
+	db.prepare("INSERT INTO sessions (id, cwd) VALUES (?, '/x')").run(sessionId);
+	const ins = db.prepare(
+		"INSERT INTO turns (session_id, turn_index, user_message, assistant_response, timestamp) VALUES (?, ?, ?, ?, ?)",
+	);
+	for (const t of turns) {
+		ins.run(
+			sessionId,
+			t.turn_index,
+			t.user_message ?? null,
+			t.assistant_response ?? null,
+			t.timestamp ?? "2026-05-05T07:00:00.000Z",
+		);
+	}
+	db.close();
+	return { dbPath, cleanup: () => rm(dir, { recursive: true, force: true }) };
+}
+
+describe("readCopilotTranscript", () => {
+	let cleanups: Array<() => Promise<void>>;
+
+	beforeEach(() => {
+		cleanups = [];
+	});
+	afterEach(async () => {
+		for (const c of cleanups) await c();
+	});
+
+	it("returns ordered human/assistant entries", async () => {
+		const { dbPath, cleanup } = await makeDb("s1", [
+			{ turn_index: 0, user_message: "hi", assistant_response: "hello" },
+			{ turn_index: 1, user_message: "how are you", assistant_response: "good" },
+		]);
+		cleanups.push(cleanup);
+		const { readCopilotTranscript } = await import("./CopilotTranscriptReader.js");
+		const result = await readCopilotTranscript(`${dbPath}#s1`);
+		expect(result.entries.map((e) => [e.role, e.content])).toEqual([
+			["human", "hi"],
+			["assistant", "hello"],
+			["human", "how are you"],
+			["assistant", "good"],
+		]);
+		expect(result.totalLinesRead).toBe(2);
+		expect(result.newCursor.lineNumber).toBe(2);
+	});
+
+	it("skips empty/null messages within a turn", async () => {
+		const { dbPath, cleanup } = await makeDb("s1", [
+			{ turn_index: 0, user_message: "hi", assistant_response: null },
+			{ turn_index: 1, user_message: "", assistant_response: "ack" },
+		]);
+		cleanups.push(cleanup);
+		const { readCopilotTranscript } = await import("./CopilotTranscriptReader.js");
+		const result = await readCopilotTranscript(`${dbPath}#s1`);
+		expect(result.entries.map((e) => [e.role, e.content])).toEqual([
+			["human", "hi"],
+			["assistant", "ack"],
+		]);
+	});
+
+	it("resumes from a cursor", async () => {
+		const { dbPath, cleanup } = await makeDb("s1", [
+			{ turn_index: 0, user_message: "first", assistant_response: "ok" },
+			{ turn_index: 1, user_message: "second", assistant_response: "yep" },
+		]);
+		cleanups.push(cleanup);
+		const { readCopilotTranscript } = await import("./CopilotTranscriptReader.js");
+		const result = await readCopilotTranscript(`${dbPath}#s1`, {
+			transcriptPath: `${dbPath}#s1`,
+			lineNumber: 1,
+			updatedAt: "2026-05-05T07:00:00.000Z",
+		});
+		expect(result.entries.map((e) => e.content)).toEqual(["second", "yep"]);
+	});
+
+	it("respects beforeTimestamp cutoff", async () => {
+		const { dbPath, cleanup } = await makeDb("s1", [
+			{ turn_index: 0, user_message: "early", assistant_response: "ok", timestamp: "2026-05-05T07:00:00.000Z" },
+			{ turn_index: 1, user_message: "late", assistant_response: "no", timestamp: "2026-05-05T09:00:00.000Z" },
+		]);
+		cleanups.push(cleanup);
+		const { readCopilotTranscript } = await import("./CopilotTranscriptReader.js");
+		const result = await readCopilotTranscript(`${dbPath}#s1`, null, "2026-05-05T08:00:00.000Z");
+		expect(result.entries.map((e) => e.content)).toEqual(["early", "ok"]);
+		expect(result.newCursor.lineNumber).toBe(1);
+	});
+
+	it("throws on a malformed transcriptPath", async () => {
+		const { readCopilotTranscript } = await import("./CopilotTranscriptReader.js");
+		await expect(readCopilotTranscript("no-hash-marker")).rejects.toThrow(/Invalid Copilot transcript path/);
+	});
+
+	it("throws when transcriptPath has empty dbPath", async () => {
+		const { readCopilotTranscript } = await import("./CopilotTranscriptReader.js");
+		await expect(readCopilotTranscript("#only-session-id")).rejects.toThrow(/empty dbPath/);
+	});
+
+	it("throws when transcriptPath has empty sessionId", async () => {
+		const { readCopilotTranscript } = await import("./CopilotTranscriptReader.js");
+		await expect(readCopilotTranscript("/some/db#")).rejects.toThrow(/empty.*sessionId|empty dbPath or sessionId/);
+	});
+
+	it("respects both cursor and beforeTimestamp together", async () => {
+		const { dbPath, cleanup } = await makeDb("s1", [
+			{ turn_index: 0, user_message: "first", assistant_response: "ok", timestamp: "2026-05-05T07:00:00.000Z" },
+			{ turn_index: 1, user_message: "middle", assistant_response: "yep", timestamp: "2026-05-05T08:00:00.000Z" },
+			{ turn_index: 2, user_message: "late", assistant_response: "no", timestamp: "2026-05-05T10:00:00.000Z" },
+		]);
+		cleanups.push(cleanup);
+		const { readCopilotTranscript } = await import("./CopilotTranscriptReader.js");
+		// Resume from index 1 (skip "first"), with cutoff that excludes "late"
+		const result = await readCopilotTranscript(
+			`${dbPath}#s1`,
+			{ transcriptPath: `${dbPath}#s1`, lineNumber: 1, updatedAt: "2026-05-05T07:00:00.000Z" },
+			"2026-05-05T09:00:00.000Z",
+		);
+		expect(result.entries.map((e) => e.content)).toEqual(["middle", "yep"]);
+		expect(result.newCursor.lineNumber).toBe(2);
+	});
+
+	it("returns empty when the session has no rows", async () => {
+		const { dbPath, cleanup } = await makeDb("s1", []);
+		cleanups.push(cleanup);
+		const { readCopilotTranscript } = await import("./CopilotTranscriptReader.js");
+		const result = await readCopilotTranscript(`${dbPath}#s1`);
+		expect(result.entries).toEqual([]);
+		expect(result.newCursor.lineNumber).toBe(0);
+	});
+
+	it("throws when the Copilot transcript DB cannot be opened", async () => {
+		const { readCopilotTranscript } = await import("./CopilotTranscriptReader.js");
+		await expect(readCopilotTranscript("/tmp/nonexistent.db#s1")).rejects.toThrow(/Cannot read Copilot session/);
+	});
+
+	it("emits entries without a timestamp when the row's timestamp column is NULL", async () => {
+		const dir = await mkdtemp(join(tmpdir(), "copilot-tr-"));
+		const dbPath = join(dir, "session-store.db");
+		const db = new DatabaseSync(dbPath);
+		for (const stmt of SCHEMA_STATEMENTS) db.prepare(stmt).run();
+		db.prepare("INSERT INTO sessions (id, cwd) VALUES ('s1', '/x')").run();
+		db.prepare(
+			"INSERT INTO turns (session_id, turn_index, user_message, assistant_response, timestamp) VALUES ('s1', 0, 'hi', 'hello', NULL)",
+		).run();
+		db.close();
+		cleanups.push(() => rm(dir, { recursive: true, force: true }));
+
+		const { readCopilotTranscript } = await import("./CopilotTranscriptReader.js");
+		const result = await readCopilotTranscript(`${dbPath}#s1`);
+
+		expect(result.entries.map((e) => [e.role, e.content, e.timestamp])).toEqual([
+			["human", "hi", undefined],
+			["assistant", "hello", undefined],
+		]);
+	});
+});

--- a/cli/src/core/CopilotTranscriptReader.ts
+++ b/cli/src/core/CopilotTranscriptReader.ts
@@ -1,0 +1,99 @@
+/**
+ * Reads conversation turns from Copilot CLI's session-store SQLite database.
+ *
+ * Each `turns` row contains a (user_message, assistant_response) pair, ordered
+ * by turn_index. We expand each row into two TranscriptEntry items, skipping
+ * empty/null messages.
+ *
+ * Cursor tracks the row count of fully-consumed turns (zero-based index into the
+ * ORDER BY turn_index result set). Equivalent to turn_index when Copilot's
+ * UNIQUE(session_id, turn_index) constraint prevents gaps; if turns are ever
+ * deleted leaving holes, a value-based resume query would be needed instead.
+ */
+
+import { createLogger } from "../Logger.js";
+import type { TranscriptCursor, TranscriptEntry, TranscriptReadResult } from "../Types.js";
+import { withSqliteDb } from "./SqliteHelpers.js";
+import { mergeConsecutiveEntries } from "./TranscriptReader.js";
+
+const log = createLogger("CopilotTranscriptReader");
+
+export async function readCopilotTranscript(
+	transcriptPath: string,
+	cursor?: TranscriptCursor | null,
+	beforeTimestamp?: string,
+): Promise<TranscriptReadResult> {
+	const { dbPath, sessionId } = parseSyntheticPath(transcriptPath);
+	const startIndex = cursor?.lineNumber ?? 0;
+	const cutoffMs = beforeTimestamp ? Date.parse(beforeTimestamp) : undefined;
+
+	try {
+		const { rawEntries, totalTurns, lastConsumedIndex } = await withSqliteDb(dbPath, (db) => {
+			const rows = db
+				.prepare(
+					`SELECT turn_index, user_message, assistant_response, timestamp
+					 FROM turns
+					 WHERE session_id = :sessionId
+					 ORDER BY turn_index ASC`,
+				)
+				.all({ sessionId }) as ReadonlyArray<{
+				turn_index: number;
+				user_message: string | null;
+				assistant_response: string | null;
+				timestamp: string | null;
+			}>;
+			const newRows = rows.slice(startIndex);
+			const out: TranscriptEntry[] = [];
+			let consumed = startIndex;
+			for (let i = 0; i < newRows.length; i++) {
+				const r = newRows[i];
+				if (cutoffMs !== undefined && r.timestamp) {
+					const ts = Date.parse(r.timestamp);
+					if (Number.isFinite(ts) && ts > cutoffMs) break;
+				}
+				const tsIso = r.timestamp && Number.isFinite(Date.parse(r.timestamp)) ? r.timestamp : undefined;
+				if (typeof r.user_message === "string" && r.user_message.trim().length > 0) {
+					out.push({ role: "human", content: r.user_message, timestamp: tsIso });
+				}
+				if (typeof r.assistant_response === "string" && r.assistant_response.trim().length > 0) {
+					out.push({ role: "assistant", content: r.assistant_response, timestamp: tsIso });
+				}
+				consumed = startIndex + i + 1;
+			}
+			return { rawEntries: out, totalTurns: rows.length, lastConsumedIndex: consumed };
+		});
+
+		const entries = mergeConsecutiveEntries(rawEntries);
+		const newCursor: TranscriptCursor = {
+			transcriptPath,
+			lineNumber: beforeTimestamp ? lastConsumedIndex : totalTurns,
+			updatedAt: new Date().toISOString(),
+		};
+		const totalLinesRead = lastConsumedIndex - startIndex;
+		log.info(
+			"Read Copilot session %s: %d new turns, %d entries (index %d→%d)",
+			sessionId.substring(0, 8),
+			totalLinesRead,
+			entries.length,
+			startIndex,
+			newCursor.lineNumber,
+		);
+		return { entries, newCursor, totalLinesRead };
+	} catch (error: unknown) {
+		log.error("Failed to read Copilot session %s: %s", sessionId.substring(0, 8), (error as Error).message);
+		throw new Error(`Cannot read Copilot session: ${sessionId}`);
+	}
+}
+
+function parseSyntheticPath(transcriptPath: string): { dbPath: string; sessionId: string } {
+	const hashIndex = transcriptPath.lastIndexOf("#");
+	if (hashIndex === -1) {
+		throw new Error(`Invalid Copilot transcript path (missing #sessionId): ${transcriptPath}`);
+	}
+	const dbPath = transcriptPath.substring(0, hashIndex);
+	const sessionId = transcriptPath.substring(hashIndex + 1);
+	if (dbPath.length === 0 || sessionId.length === 0) {
+		throw new Error(`Invalid Copilot transcript path (empty dbPath or sessionId): ${transcriptPath}`);
+	}
+	return { dbPath, sessionId };
+}

--- a/cli/src/core/CursorDetector.test.ts
+++ b/cli/src/core/CursorDetector.test.ts
@@ -21,7 +21,7 @@ vi.mock("./SqliteHelpers.js", async () => ({
 	hasNodeSqliteSupport: mockSqliteSupport,
 }));
 
-import { getCursorGlobalDbPath, isCursorInstalled } from "./CursorDetector.js";
+import { getCursorGlobalDbPath, getCursorWorkspaceStorageDir, isCursorInstalled } from "./CursorDetector.js";
 
 describe("isCursorInstalled (darwin)", () => {
 	let tmpHome: string;
@@ -108,5 +108,30 @@ describe("getCursorGlobalDbPath", () => {
 		const result = getCursorGlobalDbPath();
 		const suffix = join("Cursor", "User", "globalStorage", "state.vscdb");
 		expect(result.endsWith(suffix)).toBe(true);
+	});
+});
+
+describe("getCursorWorkspaceStorageDir", () => {
+	beforeEach(() => {
+		mockHomedir.mockReturnValue("/home/user");
+	});
+
+	it("returns the darwin workspaceStorage path", () => {
+		mockPlatform.mockReturnValue("darwin");
+		expect(getCursorWorkspaceStorageDir()).toBe(
+			"/home/user/Library/Application Support/Cursor/User/workspaceStorage",
+		);
+	});
+
+	it("returns the linux workspaceStorage path", () => {
+		mockPlatform.mockReturnValue("linux");
+		expect(getCursorWorkspaceStorageDir()).toBe("/home/user/.config/Cursor/User/workspaceStorage");
+	});
+
+	it("honors an explicit home override (used by tests/installs not running as the real user)", () => {
+		mockPlatform.mockReturnValue("darwin");
+		expect(getCursorWorkspaceStorageDir("/tmp/sandbox")).toBe(
+			"/tmp/sandbox/Library/Application Support/Cursor/User/workspaceStorage",
+		);
 	});
 });

--- a/cli/src/core/CursorDetector.ts
+++ b/cli/src/core/CursorDetector.ts
@@ -1,70 +1,40 @@
 /**
  * Cursor Detector
  *
- * Detects Cursor presence by checking for its global state database.
- * Used at install time and by getStatus() to report Cursor integration state.
- *
- * Per-platform database paths:
- *   darwin  ~/Library/Application Support/Cursor/User/globalStorage/state.vscdb
- *   linux   ~/.config/Cursor/User/globalStorage/state.vscdb
- *   win32   %APPDATA%/Cursor/User/globalStorage/state.vscdb
- *
- * Detection is gated on hasNodeSqliteSupport() so VS Code extension hosts
- * running Node 18 report "not installed" rather than "detected but unreadable".
+ * Detects Cursor presence by checking for its global state database. Path
+ * resolution delegates to VscodeWorkspaceLocator with `flavor: "Cursor"` —
+ * shared with VS Code Copilot Chat (`flavor: "Code"`).
  */
 
 import { stat } from "node:fs/promises";
-import { homedir, platform } from "node:os";
 import { join } from "node:path";
 import { createLogger } from "../Logger.js";
 import { hasNodeSqliteSupport } from "./SqliteHelpers.js";
+import { getVscodeUserDataDir, getVscodeWorkspaceStorageDir } from "./VscodeWorkspaceLocator.js";
 
 const log = createLogger("CursorDetector");
 
-/**
- * Returns the Cursor user-data root directory for the current platform.
- * Matches the paths used by the VS Code-based Cursor editor.
- */
-function getCursorUserDataDir(home: string = homedir()): string {
-	switch (platform()) {
-		case "darwin":
-			return join(home, "Library", "Application Support", "Cursor");
-		case "win32":
-			return join(process.env.APPDATA ?? join(home, "AppData", "Roaming"), "Cursor");
-		default:
-			// linux and other unix-like systems
-			return join(home, ".config", "Cursor");
-	}
-}
-
-/**
- * Returns the path to Cursor's global state database.
- * Readable via node:sqlite; contains extension state, workspace history, etc.
- */
+/** Returns the path to Cursor's global state database. */
 export function getCursorGlobalDbPath(home?: string): string {
-	return join(getCursorUserDataDir(home), "User", "globalStorage", "state.vscdb");
+	return join(getVscodeUserDataDir("Cursor", home), "User", "globalStorage", "state.vscdb");
 }
 
-/**
- * Returns the path to Cursor's workspace storage directory.
- * Each workspace gets a hashed subdirectory containing a state.vscdb.
- * Used by CursorSessionDiscoverer to enumerate per-project sessions.
- */
+/** Returns the path to Cursor's workspace storage directory. */
 export function getCursorWorkspaceStorageDir(home?: string): string {
-	return join(getCursorUserDataDir(home), "User", "workspaceStorage");
+	return getVscodeWorkspaceStorageDir("Cursor", home);
 }
 
 /**
  * Checks whether Cursor is installed AND the current runtime can read its DB.
  *
- * Returns false when node:sqlite is unavailable (VS Code extension hosts on
- * Node 18) so the UI does not render "Cursor detected & enabled (0 sessions)"
- * on runtimes where a scan would always fail.
+ * Gated on hasNodeSqliteSupport() so VS Code-extension Node 18 hosts report
+ * "not installed" rather than "detected but 0 sessions" — the latter is
+ * misleading because a scan would always fail on those runtimes.
  */
 export async function isCursorInstalled(): Promise<boolean> {
 	if (!hasNodeSqliteSupport()) {
-		// Expected "not applicable", not a failure — log at info so operators
-		// can correlate "Cursor absent from status" with the runtime version.
+		// "Not applicable on this runtime" rather than a failure — log at info so
+		// operators can correlate "Cursor absent from status" with the runtime version.
 		log.info(
 			"Cursor support disabled: this runtime is Node %s, requires 22.5+ for built-in SQLite",
 			process.versions.node,

--- a/cli/src/core/CursorSessionDiscoverer.ts
+++ b/cli/src/core/CursorSessionDiscoverer.ts
@@ -33,14 +33,13 @@
  *   and transcript-reading code works uniformly across SQLite-backed sources.
  */
 
-import { readdir, readFile, stat } from "node:fs/promises";
-import { platform } from "node:os";
+import { stat } from "node:fs/promises";
 import { join } from "node:path";
-import { fileURLToPath } from "node:url";
 import { createLogger } from "../Logger.js";
 import type { SessionInfo } from "../Types.js";
-import { getCursorGlobalDbPath, getCursorWorkspaceStorageDir } from "./CursorDetector.js";
+import { getCursorGlobalDbPath } from "./CursorDetector.js";
 import { classifyScanError, type SqliteScanError, withSqliteDb } from "./SqliteHelpers.js";
+import { findVscodeWorkspaceHash, getVscodeWorkspaceStorageDir } from "./VscodeWorkspaceLocator.js";
 
 const log = createLogger("CursorDiscoverer");
 
@@ -189,57 +188,12 @@ export async function discoverCursorSessions(projectDir: string): Promise<Readon
 }
 
 /**
- * Scans the Cursor workspaceStorage directory for a workspace whose `folder`
- * URI resolves to projectDir. Returns the workspace hash (directory name) on
- * match, or null if no match is found.
- *
- * workspace.json contains a `folder` property that is a `file://` URI. We
- * decode it with fileURLToPath so percent-encoding and platform casing are
- * handled correctly.
+ * Thin wrapper over the shared VscodeWorkspaceLocator. Cursor reuses VS Code's
+ * workspaceStorage layout, so workspace lookup is delegated to the shared
+ * implementation with `flavor: "Cursor"`.
  */
 async function findCursorWorkspaceHash(projectDir: string): Promise<string | null> {
-	const wsStorageDir = getCursorWorkspaceStorageDir();
-
-	let entries: string[];
-	try {
-		entries = await readdir(wsStorageDir);
-	} catch {
-		log.debug("Cursor workspaceStorage not readable at %s", wsStorageDir);
-		return null;
-	}
-
-	const target = normalizePathForMatch(projectDir);
-
-	for (const entry of entries) {
-		const wsJsonPath = join(wsStorageDir, entry, "workspace.json");
-		let folderUri: string | undefined;
-		try {
-			const raw = await readFile(wsJsonPath, "utf8");
-			const parsed = JSON.parse(raw) as Record<string, unknown>;
-			folderUri = typeof parsed.folder === "string" ? parsed.folder : undefined;
-		} catch {
-			// Skip entries without a readable workspace.json
-			continue;
-		}
-
-		if (!folderUri || !folderUri.startsWith("file://")) {
-			continue;
-		}
-
-		let folderPath: string;
-		try {
-			folderPath = fileURLToPath(folderUri);
-		} catch {
-			log.warn("Cursor workspace %s has unparseable folder URI: %s", entry, folderUri);
-			continue;
-		}
-
-		if (normalizePathForMatch(folderPath) === target) {
-			return entry;
-		}
-	}
-
-	return null;
+	return findVscodeWorkspaceHash("Cursor", projectDir);
 }
 
 /**
@@ -250,7 +204,7 @@ async function findCursorWorkspaceHash(projectDir: string): Promise<string | nul
  * abort the whole scan; we still proceed with time-window-only results.
  */
 async function readCursorAnchorComposerIds(wsHash: string): Promise<ReadonlyArray<string>> {
-	const wsStorageDir = getCursorWorkspaceStorageDir();
+	const wsStorageDir = getVscodeWorkspaceStorageDir("Cursor");
 	const wsDbPath = join(wsStorageDir, wsHash, "state.vscdb");
 
 	try {
@@ -293,28 +247,4 @@ async function readCursorAnchorComposerIds(wsHash: string): Promise<ReadonlyArra
 		log.warn("Failed to read Cursor workspace anchor IDs from %s: %s", wsDbPath, (error as Error).message);
 		return [];
 	}
-}
-
-/**
- * Normalises a filesystem path for workspace matching.
- * - Strips trailing slashes.
- * - Lowercases on case-insensitive platforms (darwin, win32) so that Cursor's
- *   stored path and the projectDir passed by callers compare correctly even
- *   when their casing differs.
- */
-function normalizePathForMatch(p: string): string {
-	// Normalize backslashes to forward slashes so Windows paths from
-	// fileURLToPath (which returns `\`-separated paths) compare correctly
-	// against caller-supplied forward-slash paths.
-	const fwd = p.replace(/\\/g, "/");
-	// Linear-time trailing-slash strip. Equivalent to /\/+$/ but expressed as a
-	// loop so CodeQL's js/polynomial-redos heuristic doesn't flag the regex
-	// when this function receives paths read from on-disk JSON.
-	let end = fwd.length;
-	while (end > 0 && fwd[end - 1] === "/") {
-		end--;
-	}
-	const trimmed = fwd.slice(0, end);
-	const os = platform();
-	return os === "darwin" || os === "win32" ? trimmed.toLowerCase() : trimmed;
 }

--- a/cli/src/core/OpenCodeSessionDiscoverer.ts
+++ b/cli/src/core/OpenCodeSessionDiscoverer.ts
@@ -21,14 +21,35 @@ import { join } from "node:path";
 import { createLogger } from "../Logger.js";
 import type { SessionInfo } from "../Types.js";
 import {
-	classifyScanError as classifySqliteError,
-	hasNodeSqliteSupport,
-	NODE_SQLITE_MIN_VERSION,
+	classifyScanError as classifySqliteScanError,
+	hasNodeSqliteSupport as hasNodeSqliteSupportFromHelpers,
+	NODE_SQLITE_MIN_VERSION as NODE_SQLITE_MIN_VERSION_FROM_HELPERS,
 	type SqliteDbHandle,
 	type SqliteScanError,
 	type SqliteScanErrorKind,
 	withSqliteDb,
 } from "./SqliteHelpers.js";
+
+/** @deprecated Use SqliteDbHandle from ./SqliteHelpers.js */
+export type OpenCodeDbHandle = SqliteDbHandle;
+
+/** @deprecated Use withSqliteDb from ./SqliteHelpers.js */
+export const withOpenCodeDb = withSqliteDb;
+
+/** @deprecated Use SqliteScanErrorKind from ./SqliteHelpers.js */
+export type OpenCodeScanErrorKind = SqliteScanErrorKind;
+
+/** @deprecated Use SqliteScanError from ./SqliteHelpers.js */
+export type OpenCodeScanError = SqliteScanError;
+
+/** @deprecated Use classifyScanError from ./SqliteHelpers.js */
+export const classifyScanError = classifySqliteScanError;
+
+/** @deprecated Use hasNodeSqliteSupport from ./SqliteHelpers.js */
+export const hasNodeSqliteSupport = hasNodeSqliteSupportFromHelpers;
+
+/** @deprecated Use NODE_SQLITE_MIN_VERSION from ./SqliteHelpers.js */
+export const NODE_SQLITE_MIN_VERSION = NODE_SQLITE_MIN_VERSION_FROM_HELPERS;
 
 const log = createLogger("OpenCodeDiscoverer");
 
@@ -42,17 +63,6 @@ const SESSION_STALE_MS = 48 * 60 * 60 * 1000;
 function getXdgDataHome(): string {
 	return process.env.XDG_DATA_HOME || join(homedir(), ".local", "share");
 }
-
-/** @deprecated use SqliteDbHandle from SqliteHelpers.js */
-export type OpenCodeDbHandle = SqliteDbHandle;
-/** @deprecated use withSqliteDb from SqliteHelpers.js */
-export const withOpenCodeDb = withSqliteDb;
-export { NODE_SQLITE_MIN_VERSION, hasNodeSqliteSupport };
-/** @deprecated use SqliteScanErrorKind */
-export type OpenCodeScanErrorKind = SqliteScanErrorKind;
-/** @deprecated use SqliteScanError */
-export type OpenCodeScanError = SqliteScanError;
-export const classifyScanError = classifySqliteError;
 
 /**
  * Returns the path to the global OpenCode database file.
@@ -70,14 +80,14 @@ export function getOpenCodeDbPath(): string {
  * anyway. Keeps the same no-arg shape as `isCodexInstalled`.
  */
 export async function isOpenCodeInstalled(): Promise<boolean> {
-	if (!hasNodeSqliteSupport()) {
+	if (!hasNodeSqliteSupportFromHelpers()) {
 		// Expected "not applicable", not a failure — log at info so operators
 		// can correlate "OpenCode absent from status" with the runtime version.
 		log.info(
 			"OpenCode support disabled: this runtime is Node %s, requires %d.%d+ for built-in SQLite",
 			process.versions.node,
-			NODE_SQLITE_MIN_VERSION.major,
-			NODE_SQLITE_MIN_VERSION.minor,
+			NODE_SQLITE_MIN_VERSION_FROM_HELPERS.major,
+			NODE_SQLITE_MIN_VERSION_FROM_HELPERS.minor,
 		);
 		return false;
 	}

--- a/cli/src/core/SessionTracker.test.ts
+++ b/cli/src/core/SessionTracker.test.ts
@@ -1003,6 +1003,23 @@ describe("SessionTracker", () => {
 			expect(filterSessionsByEnabledIntegrations(sessions, {})).toEqual(sessions);
 			expect(filterSessionsByEnabledIntegrations(sessions, { cursorEnabled: true })).toEqual(sessions);
 		});
+
+		it("filters out copilot sessions when copilotEnabled is false", () => {
+			const sessions = [
+				{ sessionId: "a", transcriptPath: "/a", updatedAt: "2026-05-05T00:00:00Z", source: "claude" as const },
+				{ sessionId: "b", transcriptPath: "/b", updatedAt: "2026-05-05T00:00:00Z", source: "copilot" as const },
+			];
+			const result = filterSessionsByEnabledIntegrations(sessions, { copilotEnabled: false });
+			expect(result.map((s) => s.sessionId)).toEqual(["a"]);
+		});
+
+		it("keeps copilot sessions when copilotEnabled is unset or true", () => {
+			const sessions = [
+				{ sessionId: "b", transcriptPath: "/b", updatedAt: "2026-05-05T00:00:00Z", source: "copilot" as const },
+			];
+			expect(filterSessionsByEnabledIntegrations(sessions, {})).toHaveLength(1);
+			expect(filterSessionsByEnabledIntegrations(sessions, { copilotEnabled: true })).toHaveLength(1);
+		});
 	});
 
 	// ── git operation queue ────────────────────────────────────────────────

--- a/cli/src/core/SessionTracker.test.ts
+++ b/cli/src/core/SessionTracker.test.ts
@@ -1020,6 +1020,24 @@ describe("SessionTracker", () => {
 			expect(filterSessionsByEnabledIntegrations(sessions, {})).toHaveLength(1);
 			expect(filterSessionsByEnabledIntegrations(sessions, { copilotEnabled: true })).toHaveLength(1);
 		});
+
+		it("excludes copilot-chat sessions when copilotEnabled is false", () => {
+			const sessions: ReadonlyArray<SessionInfo> = [
+				{ sessionId: "a", transcriptPath: "/a", updatedAt: "2026-05-06T00:00:00Z", source: "copilot" },
+				{ sessionId: "b", transcriptPath: "/b", updatedAt: "2026-05-06T00:00:00Z", source: "copilot-chat" },
+				{ sessionId: "c", transcriptPath: "/c", updatedAt: "2026-05-06T00:00:00Z", source: "claude" },
+			];
+			const filtered = filterSessionsByEnabledIntegrations(sessions, { copilotEnabled: false });
+			expect(filtered.map((s) => s.sessionId)).toEqual(["c"]);
+		});
+
+		it("includes copilot-chat sessions when copilotEnabled is unset (auto-detect)", () => {
+			const sessions: ReadonlyArray<SessionInfo> = [
+				{ sessionId: "b", transcriptPath: "/b", updatedAt: "2026-05-06T00:00:00Z", source: "copilot-chat" },
+			];
+			const filtered = filterSessionsByEnabledIntegrations(sessions, {});
+			expect(filtered.map((s) => s.sessionId)).toEqual(["b"]);
+		});
 	});
 
 	// ── git operation queue ────────────────────────────────────────────────

--- a/cli/src/core/SessionTracker.ts
+++ b/cli/src/core/SessionTracker.ts
@@ -169,6 +169,9 @@ export function filterSessionsByEnabledIntegrations(
 	if (config.cursorEnabled === false) {
 		filtered = filtered.filter((s) => s.source !== "cursor");
 	}
+	if (config.copilotEnabled === false) {
+		filtered = filtered.filter((s) => s.source !== "copilot");
+	}
 	return filtered;
 }
 

--- a/cli/src/core/SessionTracker.ts
+++ b/cli/src/core/SessionTracker.ts
@@ -170,7 +170,7 @@ export function filterSessionsByEnabledIntegrations(
 		filtered = filtered.filter((s) => s.source !== "cursor");
 	}
 	if (config.copilotEnabled === false) {
-		filtered = filtered.filter((s) => s.source !== "copilot");
+		filtered = filtered.filter((s) => s.source !== "copilot" && s.source !== "copilot-chat");
 	}
 	return filtered;
 }

--- a/cli/src/core/SqliteHelpers.test.ts
+++ b/cli/src/core/SqliteHelpers.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { classifyScanError, hasNodeSqliteSupport, NODE_SQLITE_MIN_VERSION } from "./SqliteHelpers.js";
+import { classifyScanError, hasNodeSqliteSupport, NODE_SQLITE_MIN_VERSION, withSqliteDb } from "./SqliteHelpers.js";
 
 describe("hasNodeSqliteSupport", () => {
 	const { major, minor } = NODE_SQLITE_MIN_VERSION;
@@ -81,5 +81,45 @@ describe("classifyScanError", () => {
 		const classified = classifyScanError("raw string rejection");
 		expect(classified?.kind).toBe("unknown");
 		expect(classified?.message).toBe("raw string rejection");
+	});
+});
+
+describe("withSqliteDb", () => {
+	it("opens a real DB read-only, runs the callback, then closes", async () => {
+		const { tmpdir } = await import("node:os");
+		const { mkdtemp } = await import("node:fs/promises");
+		const { join } = await import("node:path");
+		const { DatabaseSync } = await import("node:sqlite");
+		const dir = await mkdtemp(join(tmpdir(), "sqlite-helpers-"));
+		const dbPath = join(dir, "x.db");
+
+		// Seed: one CREATE then one INSERT, each through prepare().run() so this test
+		// works on every node:sqlite version (DatabaseSync.prepare accepts only single
+		// statements).
+		const seed = new DatabaseSync(dbPath);
+		seed.prepare("CREATE TABLE t (k TEXT)").run();
+		seed.prepare("INSERT INTO t (k) VALUES ('hi')").run();
+		seed.close();
+
+		const value = await withSqliteDb(dbPath, (db) => {
+			return (db.prepare("SELECT k FROM t").get() as { k: string }).k;
+		});
+		expect(value).toBe("hi");
+	});
+
+	it("propagates errors from the callback", async () => {
+		const { tmpdir } = await import("node:os");
+		const { mkdtemp } = await import("node:fs/promises");
+		const { join } = await import("node:path");
+		const { DatabaseSync } = await import("node:sqlite");
+		const dir = await mkdtemp(join(tmpdir(), "sqlite-helpers-"));
+		const dbPath = join(dir, "x.db");
+		new DatabaseSync(dbPath).close();
+
+		await expect(
+			withSqliteDb(dbPath, () => {
+				throw new Error("boom");
+			}),
+		).rejects.toThrow("boom");
 	});
 });

--- a/cli/src/core/SqliteHelpers.ts
+++ b/cli/src/core/SqliteHelpers.ts
@@ -1,9 +1,9 @@
 /**
  * SQLite Helpers
  *
- * Shared SQLite utilities for SQLite-based agents (OpenCode, Cursor).
- * Extracted from OpenCodeSessionDiscoverer to avoid agents depending on
- * a file named for a different agent.
+ * Shared SQLite utilities for SQLite-based agents (OpenCode, Cursor, Copilot).
+ * Extracted out of the per-agent discoverers so agents don't depend on a file
+ * named for a different agent.
  */
 
 /**

--- a/cli/src/core/VscodeWorkspaceLocator.test.ts
+++ b/cli/src/core/VscodeWorkspaceLocator.test.ts
@@ -1,0 +1,222 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { VscodeFlavor } from "./VscodeWorkspaceLocator.js";
+
+/**
+ * Converts a POSIX-style absolute path to a file:// URI valid on the current
+ * host. On Windows, `fileURLToPath` rejects URIs without a drive letter, so we
+ * go through `pathToFileURL(resolve(...))` to get a proper drive-prefixed URI.
+ */
+function toFileUri(posixPath: string): string {
+	return pathToFileURL(resolve(posixPath)).href;
+}
+
+/**
+ * Returns the native absolute path for a POSIX-style absolute path. On Windows
+ * `/Users/test/myproject` becomes e.g. `D:\Users\test\myproject`.
+ */
+function toNativePath(posixPath: string): string {
+	return resolve(posixPath);
+}
+
+const { mockHomedir, mockPlatform } = vi.hoisted(() => ({
+	mockHomedir: vi.fn().mockReturnValue("/Users/test"),
+	mockPlatform: vi.fn().mockReturnValue("darwin"),
+}));
+
+vi.mock("node:os", async (importOriginal) => {
+	const original = await importOriginal<typeof import("node:os")>();
+	return { ...original, homedir: mockHomedir, platform: mockPlatform };
+});
+
+describe("getVscodeUserDataDir", () => {
+	it("returns ~/Library/Application Support/Code on darwin", async () => {
+		mockPlatform.mockReturnValue("darwin");
+		const { getVscodeUserDataDir } = await import("./VscodeWorkspaceLocator.js");
+		expect(getVscodeUserDataDir("Code")).toBe(join("/Users/test", "Library", "Application Support", "Code"));
+	});
+
+	it("returns ~/Library/Application Support/Cursor on darwin for Cursor flavor", async () => {
+		mockPlatform.mockReturnValue("darwin");
+		const { getVscodeUserDataDir } = await import("./VscodeWorkspaceLocator.js");
+		expect(getVscodeUserDataDir("Cursor")).toBe(join("/Users/test", "Library", "Application Support", "Cursor"));
+	});
+
+	it("returns %APPDATA%/Code on win32", async () => {
+		mockPlatform.mockReturnValue("win32");
+		mockHomedir.mockReturnValue("C:\\Users\\test");
+		const prev = process.env.APPDATA;
+		process.env.APPDATA = "C:\\Users\\test\\AppData\\Roaming";
+		try {
+			const { getVscodeUserDataDir } = await import("./VscodeWorkspaceLocator.js");
+			expect(getVscodeUserDataDir("Code")).toBe(join("C:\\Users\\test\\AppData\\Roaming", "Code"));
+		} finally {
+			if (prev === undefined) delete process.env.APPDATA;
+			else process.env.APPDATA = prev;
+		}
+	});
+
+	it("falls back to ~/AppData/Roaming/Code on win32 when APPDATA is unset", async () => {
+		mockPlatform.mockReturnValue("win32");
+		mockHomedir.mockReturnValue("C:\\Users\\test");
+		const prev = process.env.APPDATA;
+		delete process.env.APPDATA;
+		try {
+			const { getVscodeUserDataDir } = await import("./VscodeWorkspaceLocator.js");
+			expect(getVscodeUserDataDir("Code")).toBe(join("C:\\Users\\test", "AppData", "Roaming", "Code"));
+		} finally {
+			if (prev !== undefined) process.env.APPDATA = prev;
+		}
+	});
+
+	it("returns ~/.config/Code on linux and other unix-like platforms", async () => {
+		mockPlatform.mockReturnValue("linux");
+		mockHomedir.mockReturnValue("/Users/test");
+		const { getVscodeUserDataDir } = await import("./VscodeWorkspaceLocator.js");
+		expect(getVscodeUserDataDir("Code")).toBe(join("/Users/test", ".config", "Code"));
+	});
+
+	it("respects an explicit home override", async () => {
+		mockPlatform.mockReturnValue("darwin");
+		const { getVscodeUserDataDir } = await import("./VscodeWorkspaceLocator.js");
+		expect(getVscodeUserDataDir("Code", "/custom/home")).toBe(
+			join("/custom/home", "Library", "Application Support", "Code"),
+		);
+	});
+});
+
+describe("getVscodeWorkspaceStorageDir", () => {
+	it("appends User/workspaceStorage to the user data dir", async () => {
+		mockPlatform.mockReturnValue("darwin");
+		mockHomedir.mockReturnValue("/Users/test");
+		const { getVscodeWorkspaceStorageDir } = await import("./VscodeWorkspaceLocator.js");
+		expect(getVscodeWorkspaceStorageDir("Code")).toBe(
+			join("/Users/test", "Library", "Application Support", "Code", "User", "workspaceStorage"),
+		);
+	});
+});
+
+describe("normalizePathForMatch", () => {
+	it("strips trailing slashes", async () => {
+		mockPlatform.mockReturnValue("linux");
+		const { normalizePathForMatch } = await import("./VscodeWorkspaceLocator.js");
+		expect(normalizePathForMatch("/a/b/c/")).toBe("/a/b/c");
+		expect(normalizePathForMatch("/a/b/c////")).toBe("/a/b/c");
+		expect(normalizePathForMatch("/a/b/c")).toBe("/a/b/c");
+	});
+
+	it("lowercases on darwin", async () => {
+		mockPlatform.mockReturnValue("darwin");
+		const { normalizePathForMatch } = await import("./VscodeWorkspaceLocator.js");
+		expect(normalizePathForMatch("/Users/Foo/Bar")).toBe("/users/foo/bar");
+	});
+
+	it("lowercases on win32 (and converts backslashes to forward slashes)", async () => {
+		mockPlatform.mockReturnValue("win32");
+		const { normalizePathForMatch } = await import("./VscodeWorkspaceLocator.js");
+		expect(normalizePathForMatch("C:\\Users\\Test")).toBe("c:/users/test");
+	});
+
+	it("preserves case on linux", async () => {
+		mockPlatform.mockReturnValue("linux");
+		const { normalizePathForMatch } = await import("./VscodeWorkspaceLocator.js");
+		expect(normalizePathForMatch("/Users/Foo")).toBe("/Users/Foo");
+	});
+
+	// Regression guard: fileURLToPath returns `\`-separated paths on Windows and
+	// callers may pass `/`-style paths; without this conversion the two would
+	// silently fail to match. Lost in the refactor from CursorSessionDiscoverer
+	// (a288e94) into VscodeWorkspaceLocator and restored.
+	it("converts backslashes to forward slashes before comparison", async () => {
+		mockPlatform.mockReturnValue("win32");
+		const { normalizePathForMatch } = await import("./VscodeWorkspaceLocator.js");
+		expect(normalizePathForMatch("C:\\Users\\Test\\Proj")).toBe("c:/users/test/proj");
+		expect(normalizePathForMatch("\\Users\\Test\\Proj")).toBe("/users/test/proj");
+	});
+});
+
+describe("findVscodeWorkspaceHash", () => {
+	let tmpRoot: string;
+
+	beforeEach(() => {
+		tmpRoot = mkdtempSync(join(tmpdir(), "vscode-locator-"));
+		mockPlatform.mockReturnValue("darwin");
+		mockHomedir.mockReturnValue(tmpRoot);
+	});
+
+	afterEach(() => {
+		rmSync(tmpRoot, { recursive: true, force: true });
+	});
+
+	function makeWorkspaceEntry(flavor: VscodeFlavor, wsHash: string, content: object | null): void {
+		const dir = join(tmpRoot, "Library", "Application Support", flavor, "User", "workspaceStorage", wsHash);
+		mkdirSync(dir, { recursive: true });
+		if (content !== null) {
+			writeFileSync(join(dir, "workspace.json"), JSON.stringify(content));
+		}
+	}
+
+	it("returns the hash for a single-folder workspace whose folder URI matches projectDir", async () => {
+		makeWorkspaceEntry("Code", "abc123", { folder: toFileUri("/Users/test/myproject") });
+		const { findVscodeWorkspaceHash } = await import("./VscodeWorkspaceLocator.js");
+		expect(await findVscodeWorkspaceHash("Code", toNativePath("/Users/test/myproject"))).toBe("abc123");
+	});
+
+	it("matches case-insensitively on darwin", async () => {
+		makeWorkspaceEntry("Code", "abc123", { folder: toFileUri("/Users/Test/MyProject") });
+		const { findVscodeWorkspaceHash } = await import("./VscodeWorkspaceLocator.js");
+		expect(await findVscodeWorkspaceHash("Code", toNativePath("/users/test/myproject"))).toBe("abc123");
+	});
+
+	it("returns null when no workspace.json folder URI matches projectDir", async () => {
+		makeWorkspaceEntry("Code", "abc123", { folder: toFileUri("/Users/test/other") });
+		const { findVscodeWorkspaceHash } = await import("./VscodeWorkspaceLocator.js");
+		expect(await findVscodeWorkspaceHash("Code", toNativePath("/Users/test/myproject"))).toBeNull();
+	});
+
+	it("skips entries whose workspace.json has a multi-root `workspace` URI instead of a `folder` URI", async () => {
+		makeWorkspaceEntry("Code", "multi", { workspace: toFileUri("/Users/test/x.code-workspace") });
+		makeWorkspaceEntry("Code", "single", { folder: toFileUri("/Users/test/myproject") });
+		const { findVscodeWorkspaceHash } = await import("./VscodeWorkspaceLocator.js");
+		expect(await findVscodeWorkspaceHash("Code", toNativePath("/Users/test/myproject"))).toBe("single");
+	});
+
+	it("skips entries with no workspace.json", async () => {
+		makeWorkspaceEntry("Code", "empty", null);
+		makeWorkspaceEntry("Code", "single", { folder: toFileUri("/Users/test/myproject") });
+		const { findVscodeWorkspaceHash } = await import("./VscodeWorkspaceLocator.js");
+		expect(await findVscodeWorkspaceHash("Code", toNativePath("/Users/test/myproject"))).toBe("single");
+	});
+
+	it("skips entries whose folder URI is unparseable", async () => {
+		makeWorkspaceEntry("Code", "bad", { folder: "garbage:///not-a-uri" });
+		makeWorkspaceEntry("Code", "good", { folder: toFileUri("/Users/test/myproject") });
+		const { findVscodeWorkspaceHash } = await import("./VscodeWorkspaceLocator.js");
+		expect(await findVscodeWorkspaceHash("Code", toNativePath("/Users/test/myproject"))).toBe("good");
+	});
+
+	it("skips entries whose folder URI starts with file:// but fails fileURLToPath parsing", async () => {
+		// `file://%` is rejected by `new URL()` (invalid percent-encoding) and bubbles up
+		// from `fileURLToPath`, exercising the catch branch of `findVscodeWorkspaceHash`.
+		// Only the throwing entry is created so the loop must process it (readdir order is
+		// filesystem-dependent — adding a "good" entry could short-circuit before the throw).
+		makeWorkspaceEntry("Code", "throws", { folder: "file://%" });
+		const { findVscodeWorkspaceHash } = await import("./VscodeWorkspaceLocator.js");
+		expect(await findVscodeWorkspaceHash("Code", toNativePath("/Users/test/myproject"))).toBeNull();
+	});
+
+	it("returns null when workspaceStorage dir doesn't exist", async () => {
+		const { findVscodeWorkspaceHash } = await import("./VscodeWorkspaceLocator.js");
+		expect(await findVscodeWorkspaceHash("Code", toNativePath("/Users/test/myproject"))).toBeNull();
+	});
+
+	it("isolates flavors — a Cursor entry doesn't match a Code lookup", async () => {
+		makeWorkspaceEntry("Cursor", "cursor1", { folder: toFileUri("/Users/test/myproject") });
+		const { findVscodeWorkspaceHash } = await import("./VscodeWorkspaceLocator.js");
+		expect(await findVscodeWorkspaceHash("Code", toNativePath("/Users/test/myproject"))).toBeNull();
+		expect(await findVscodeWorkspaceHash("Cursor", toNativePath("/Users/test/myproject"))).toBe("cursor1");
+	});
+});

--- a/cli/src/core/VscodeWorkspaceLocator.ts
+++ b/cli/src/core/VscodeWorkspaceLocator.ts
@@ -1,0 +1,119 @@
+/**
+ * VscodeWorkspaceLocator
+ *
+ * Per-platform path resolution and workspace.json scanning for VS Code-family
+ * user data directories. Used by both Cursor (`flavor: "Cursor"`) and VS Code
+ * Copilot Chat (`flavor: "Code"`) integrations. Adding a new vscode fork
+ * (Insiders, Code-OSS, Windsurf, …) requires only extending the flavor union.
+ *
+ * Public symbols:
+ *   - getVscodeUserDataDir(flavor, home?)
+ *   - getVscodeWorkspaceStorageDir(flavor, home?)
+ *   - findVscodeWorkspaceHash(flavor, projectDir)
+ *   - normalizePathForMatch(p)
+ */
+
+import { readdir, readFile } from "node:fs/promises";
+import { homedir, platform } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { createLogger } from "../Logger.js";
+
+const log = createLogger("VscodeWorkspaceLocator");
+
+export type VscodeFlavor = "Cursor" | "Code";
+
+/**
+ * Returns the VS Code-family user-data root for the current platform.
+ *
+ *   darwin   ~/Library/Application Support/<flavor>
+ *   linux    ~/.config/<flavor>
+ *   win32    %APPDATA%/<flavor>  (fallback to ~/AppData/Roaming/<flavor>)
+ */
+export function getVscodeUserDataDir(flavor: VscodeFlavor, home: string = homedir()): string {
+	switch (platform()) {
+		case "darwin":
+			return join(home, "Library", "Application Support", flavor);
+		case "win32":
+			return join(process.env.APPDATA ?? join(home, "AppData", "Roaming"), flavor);
+		default:
+			return join(home, ".config", flavor);
+	}
+}
+
+/** Returns the workspaceStorage dir for the given flavor. */
+export function getVscodeWorkspaceStorageDir(flavor: VscodeFlavor, home?: string): string {
+	return join(getVscodeUserDataDir(flavor, home), "User", "workspaceStorage");
+}
+
+/**
+ * Normalises a filesystem path for workspace matching.
+ * - Converts backslashes to forward slashes so Windows paths from
+ *   fileURLToPath (which returns `\`-separated paths) compare correctly
+ *   against caller-supplied forward-slash paths.
+ * - Strips trailing slashes (linear-time loop, not regex — avoids CodeQL polynomial-redos
+ *   warnings on JSON-loaded paths).
+ * - Lowercases on case-insensitive platforms (darwin, win32).
+ */
+export function normalizePathForMatch(p: string): string {
+	const fwd = p.replace(/\\/g, "/");
+	let end = fwd.length;
+	while (end > 0 && fwd[end - 1] === "/") {
+		end--;
+	}
+	const trimmed = fwd.slice(0, end);
+	const os = platform();
+	return os === "darwin" || os === "win32" ? trimmed.toLowerCase() : trimmed;
+}
+
+/**
+ * Scans the workspaceStorage directory for an entry whose `workspace.json` has
+ * a `folder` URI that resolves to projectDir. Returns the entry name (workspace
+ * hash) on match, or null when no match is found.
+ *
+ * Single-folder workspaces only — entries with a `workspace` field instead of
+ * `folder` (multi-root .code-workspace files) are skipped silently.
+ */
+export async function findVscodeWorkspaceHash(flavor: VscodeFlavor, projectDir: string): Promise<string | null> {
+	const wsStorageDir = getVscodeWorkspaceStorageDir(flavor);
+
+	let entries: string[];
+	try {
+		entries = await readdir(wsStorageDir);
+	} catch {
+		log.debug("%s workspaceStorage not readable at %s", flavor, wsStorageDir);
+		return null;
+	}
+
+	const target = normalizePathForMatch(projectDir);
+
+	for (const entry of entries) {
+		const wsJsonPath = join(wsStorageDir, entry, "workspace.json");
+		let folderUri: string | undefined;
+		try {
+			const raw = await readFile(wsJsonPath, "utf8");
+			const parsed = JSON.parse(raw) as Record<string, unknown>;
+			folderUri = typeof parsed.folder === "string" ? parsed.folder : undefined;
+		} catch {
+			continue;
+		}
+
+		if (!folderUri || !folderUri.startsWith("file://")) {
+			continue;
+		}
+
+		let folderPath: string;
+		try {
+			folderPath = fileURLToPath(folderUri);
+		} catch {
+			log.warn("%s workspace %s has unparseable folder URI: %s", flavor, entry, folderUri);
+			continue;
+		}
+
+		if (normalizePathForMatch(folderPath) === target) {
+			return entry;
+		}
+	}
+
+	return null;
+}

--- a/cli/src/hooks/PostCommitHook.helpers.test.ts
+++ b/cli/src/hooks/PostCommitHook.helpers.test.ts
@@ -202,6 +202,26 @@ vi.mock("../core/CursorSessionDiscoverer.js", () => ({
 	discoverCursorSessions: vi.fn().mockResolvedValue([]),
 }));
 
+vi.mock("../core/CopilotDetector.js", () => ({
+	isCopilotInstalled: vi.fn().mockResolvedValue(false),
+}));
+
+vi.mock("../core/CopilotSessionDiscoverer.js", () => ({
+	discoverCopilotSessions: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock("../core/CopilotChatDetector.js", () => ({
+	isCopilotChatInstalled: vi.fn().mockResolvedValue(false),
+}));
+
+vi.mock("../core/CopilotChatSessionDiscoverer.js", () => ({
+	discoverCopilotChatSessions: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock("../core/CopilotChatTranscriptReader.js", () => ({
+	readCopilotChatTranscript: vi.fn(),
+}));
+
 vi.mock("../core/CursorTranscriptReader.js", () => ({
 	readCursorTranscript: vi.fn(),
 }));

--- a/cli/src/hooks/PostCommitHook.test.ts
+++ b/cli/src/hooks/PostCommitHook.test.ts
@@ -143,6 +143,23 @@ vi.mock("../core/GeminiTranscriptReader.js", () => ({
 	}),
 }));
 
+vi.mock("../core/CopilotDetector.js", () => ({
+	isCopilotInstalled: vi.fn().mockResolvedValue(false),
+	getCopilotDbPath: vi.fn().mockReturnValue("/mock/.copilot/session-store.db"),
+}));
+
+vi.mock("../core/CopilotSessionDiscoverer.js", () => ({
+	discoverCopilotSessions: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock("../core/CopilotTranscriptReader.js", () => ({
+	readCopilotTranscript: vi.fn().mockResolvedValue({
+		entries: [],
+		newCursor: { transcriptPath: "", lineNumber: 0, updatedAt: "" },
+		totalLinesRead: 0,
+	}),
+}));
+
 vi.mock("../core/TranscriptParser.js", () => ({
 	getParserForSource: vi.fn().mockReturnValue({ parseLine: vi.fn() }),
 }));

--- a/cli/src/hooks/PostCommitHook.test.ts
+++ b/cli/src/hooks/PostCommitHook.test.ts
@@ -152,6 +152,24 @@ vi.mock("../core/CopilotSessionDiscoverer.js", () => ({
 	discoverCopilotSessions: vi.fn().mockResolvedValue([]),
 }));
 
+vi.mock("../core/CopilotChatDetector.js", () => ({
+	isCopilotChatInstalled: vi.fn().mockResolvedValue(false),
+	getCopilotChatStorageDir: vi.fn().mockReturnValue("/mock/Code/User/globalStorage/github.copilot-chat"),
+}));
+
+vi.mock("../core/CopilotChatSessionDiscoverer.js", () => ({
+	discoverCopilotChatSessions: vi.fn().mockResolvedValue([]),
+	scanCopilotChatSessions: vi.fn().mockResolvedValue({ sessions: [] }),
+}));
+
+vi.mock("../core/CopilotChatTranscriptReader.js", () => ({
+	readCopilotChatTranscript: vi.fn().mockResolvedValue({
+		entries: [],
+		newCursor: { transcriptPath: "", lineNumber: 0, updatedAt: "" },
+		totalLinesRead: 0,
+	}),
+}));
+
 vi.mock("../core/CopilotTranscriptReader.js", () => ({
 	readCopilotTranscript: vi.fn().mockResolvedValue({
 		entries: [],

--- a/cli/src/hooks/QueueWorker.test.ts
+++ b/cli/src/hooks/QueueWorker.test.ts
@@ -150,6 +150,14 @@ vi.mock("../core/CopilotTranscriptReader.js", () => ({
 	}),
 }));
 
+vi.mock("../core/CopilotChatDetector.js", () => ({
+	isCopilotChatInstalled: vi.fn().mockResolvedValue(false),
+}));
+
+vi.mock("../core/CopilotChatSessionDiscoverer.js", () => ({
+	discoverCopilotChatSessions: vi.fn().mockResolvedValue([]),
+}));
+
 vi.mock("../core/GeminiTranscriptReader.js", () => ({
 	readGeminiTranscript: vi.fn().mockResolvedValue({
 		entries: [],
@@ -178,6 +186,8 @@ vi.spyOn(console, "error").mockImplementation(() => {});
 import { spawn } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
 import { isCodexInstalled } from "../core/CodexSessionDiscoverer.js";
+import { isCopilotChatInstalled } from "../core/CopilotChatDetector.js";
+import { discoverCopilotChatSessions } from "../core/CopilotChatSessionDiscoverer.js";
 import { isCopilotInstalled } from "../core/CopilotDetector.js";
 import { discoverCopilotSessions } from "../core/CopilotSessionDiscoverer.js";
 import { readCopilotTranscript } from "../core/CopilotTranscriptReader.js";
@@ -247,6 +257,8 @@ describe("QueueWorker", () => {
 		vi.mocked(isOpenCodeInstalled).mockResolvedValue(false);
 		vi.mocked(isCursorInstalled).mockResolvedValue(false);
 		vi.mocked(isCopilotInstalled).mockResolvedValue(false);
+		vi.mocked(isCopilotChatInstalled).mockResolvedValue(false);
+		vi.mocked(discoverCopilotChatSessions).mockResolvedValue([]);
 		vi.mocked(buildMultiSessionContext).mockReturnValue("");
 		vi.mocked(generateSummary).mockResolvedValue({
 			transcriptEntries: 0,
@@ -813,6 +825,55 @@ describe("QueueWorker", () => {
 				expect.objectContaining({ transcriptPath: "/db.sqlite#cp-broken" }),
 				"/test/cwd",
 			);
+		});
+	});
+
+	describe("Copilot Chat integration", () => {
+		it("includes Copilot Chat sessions when chat is detected and copilotEnabled is true", async () => {
+			const op = makeCommitOp();
+			const queueEntry = { op, filePath: "/tmp/queue/copilot-chat.json" };
+
+			vi.mocked(dequeueAllGitOperations)
+				.mockResolvedValueOnce([queueEntry])
+				.mockResolvedValueOnce([])
+				.mockResolvedValueOnce([]);
+
+			setupPipelineMocks();
+			vi.mocked(loadConfig).mockResolvedValue({} as Awaited<ReturnType<typeof loadConfig>>);
+			vi.mocked(isCopilotChatInstalled).mockResolvedValue(true);
+			vi.mocked(discoverCopilotChatSessions).mockResolvedValue([
+				{
+					sessionId: "chat-1",
+					transcriptPath: "/fake/chat-1.jsonl",
+					updatedAt: "2026-05-06T00:00:00.000Z",
+					source: "copilot-chat",
+				},
+			]);
+
+			await runWorker("/test/cwd");
+
+			expect(isCopilotChatInstalled).toHaveBeenCalled();
+			expect(discoverCopilotChatSessions).toHaveBeenCalledWith("/test/cwd");
+		});
+
+		it("does not call isCopilotChatInstalled or discoverCopilotChatSessions when copilotEnabled is false", async () => {
+			const op = makeCommitOp();
+			const queueEntry = { op, filePath: "/tmp/queue/copilot-chat-disabled.json" };
+
+			vi.mocked(dequeueAllGitOperations)
+				.mockResolvedValueOnce([queueEntry])
+				.mockResolvedValueOnce([])
+				.mockResolvedValueOnce([]);
+
+			setupPipelineMocks();
+			vi.mocked(loadConfig).mockResolvedValue({
+				copilotEnabled: false,
+			} as Awaited<ReturnType<typeof loadConfig>>);
+
+			await runWorker("/test/cwd");
+
+			expect(isCopilotChatInstalled).not.toHaveBeenCalled();
+			expect(discoverCopilotChatSessions).not.toHaveBeenCalled();
 		});
 	});
 

--- a/cli/src/hooks/QueueWorker.test.ts
+++ b/cli/src/hooks/QueueWorker.test.ts
@@ -134,6 +134,22 @@ vi.mock("../core/CursorTranscriptReader.js", () => ({
 	}),
 }));
 
+vi.mock("../core/CopilotDetector.js", () => ({
+	isCopilotInstalled: vi.fn().mockResolvedValue(false),
+}));
+
+vi.mock("../core/CopilotSessionDiscoverer.js", () => ({
+	discoverCopilotSessions: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock("../core/CopilotTranscriptReader.js", () => ({
+	readCopilotTranscript: vi.fn().mockResolvedValue({
+		entries: [],
+		newCursor: { transcriptPath: "", lineNumber: 0, updatedAt: "" },
+		totalLinesRead: 0,
+	}),
+}));
+
 vi.mock("../core/GeminiTranscriptReader.js", () => ({
 	readGeminiTranscript: vi.fn().mockResolvedValue({
 		entries: [],
@@ -162,6 +178,9 @@ vi.spyOn(console, "error").mockImplementation(() => {});
 import { spawn } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
 import { isCodexInstalled } from "../core/CodexSessionDiscoverer.js";
+import { isCopilotInstalled } from "../core/CopilotDetector.js";
+import { discoverCopilotSessions } from "../core/CopilotSessionDiscoverer.js";
+import { readCopilotTranscript } from "../core/CopilotTranscriptReader.js";
 import { isCursorInstalled } from "../core/CursorDetector.js";
 import { discoverCursorSessions } from "../core/CursorSessionDiscoverer.js";
 import { readCursorTranscript } from "../core/CursorTranscriptReader.js";
@@ -227,6 +246,7 @@ describe("QueueWorker", () => {
 		vi.mocked(isCodexInstalled).mockResolvedValue(false);
 		vi.mocked(isOpenCodeInstalled).mockResolvedValue(false);
 		vi.mocked(isCursorInstalled).mockResolvedValue(false);
+		vi.mocked(isCopilotInstalled).mockResolvedValue(false);
 		vi.mocked(buildMultiSessionContext).mockReturnValue("");
 		vi.mocked(generateSummary).mockResolvedValue({
 			transcriptEntries: 0,
@@ -667,6 +687,132 @@ describe("QueueWorker", () => {
 			expect(discoverOpenCodeSessions).toHaveBeenCalledWith("/test/cwd");
 			// Pipeline completes normally
 			expect(storeSummary).toHaveBeenCalled();
+		});
+	});
+
+	describe("Copilot integration", () => {
+		it("should include discovered Copilot sessions in the pipeline when enabled", async () => {
+			const op = makeCommitOp();
+			const queueEntry = { op, filePath: "/tmp/queue/copilot.json" };
+
+			vi.mocked(dequeueAllGitOperations)
+				.mockResolvedValueOnce([queueEntry])
+				.mockResolvedValueOnce([])
+				.mockResolvedValueOnce([]);
+
+			setupPipelineMocks();
+			vi.mocked(loadConfig).mockResolvedValue({} as Awaited<ReturnType<typeof loadConfig>>);
+			vi.mocked(isCopilotInstalled).mockResolvedValue(true);
+			vi.mocked(discoverCopilotSessions).mockResolvedValue([
+				{
+					sessionId: "cp-1",
+					transcriptPath: "/db.sqlite#cp-1",
+					updatedAt: "2026-04-01T12:00:00.000Z",
+					source: "copilot",
+				},
+			]);
+			vi.mocked(readCopilotTranscript).mockResolvedValue({
+				entries: [{ role: "human", content: "Copilot context", timestamp: "2026-04-01T12:00:00.000Z" }],
+				newCursor: {
+					transcriptPath: "/db.sqlite#cp-1",
+					lineNumber: 1,
+					updatedAt: "2026-04-01T12:00:00.000Z",
+				},
+				totalLinesRead: 1,
+			});
+
+			await runWorker("/test/cwd");
+
+			expect(discoverCopilotSessions).toHaveBeenCalledWith("/test/cwd");
+			expect(readCopilotTranscript).toHaveBeenCalledWith("/db.sqlite#cp-1", null, "2026-04-01T12:00:00.000Z");
+			expect(saveCursor).toHaveBeenCalledWith(
+				expect.objectContaining({ transcriptPath: "/db.sqlite#cp-1", lineNumber: 1 }),
+				"/test/cwd",
+			);
+		});
+	});
+
+	describe("Copilot integration — disabled", () => {
+		it("should not call isCopilotInstalled or discoverCopilotSessions when copilotEnabled is false", async () => {
+			const op = makeCommitOp();
+			const queueEntry = { op, filePath: "/tmp/queue/copilot-disabled.json" };
+
+			vi.mocked(dequeueAllGitOperations)
+				.mockResolvedValueOnce([queueEntry])
+				.mockResolvedValueOnce([])
+				.mockResolvedValueOnce([]);
+
+			setupPipelineMocks();
+			vi.mocked(loadConfig).mockResolvedValue({
+				copilotEnabled: false,
+			} as Awaited<ReturnType<typeof loadConfig>>);
+
+			await runWorker("/test/cwd");
+
+			expect(isCopilotInstalled).not.toHaveBeenCalled();
+			expect(discoverCopilotSessions).not.toHaveBeenCalled();
+		});
+	});
+
+	describe("Copilot integration — empty sessions", () => {
+		it("logs no Discovered count when isCopilotInstalled=true but discovery returns empty", async () => {
+			const op = makeCommitOp();
+			const queueEntry = { op, filePath: "/tmp/queue/copilot-empty.json" };
+
+			vi.mocked(dequeueAllGitOperations)
+				.mockResolvedValueOnce([queueEntry])
+				.mockResolvedValueOnce([])
+				.mockResolvedValueOnce([]);
+
+			setupPipelineMocks();
+			vi.mocked(isCopilotInstalled).mockResolvedValue(true);
+			vi.mocked(discoverCopilotSessions).mockResolvedValue([]);
+
+			await runWorker("/test/cwd");
+
+			expect(discoverCopilotSessions).toHaveBeenCalledWith("/test/cwd");
+			// Pipeline completes normally
+			expect(storeSummary).toHaveBeenCalled();
+		});
+	});
+
+	describe("Copilot integration — read failure", () => {
+		it("skips a Copilot session whose transcript read throws and continues with the rest of the pipeline", async () => {
+			const op = makeCommitOp();
+			const queueEntry = { op, filePath: "/tmp/queue/copilot-throws.json" };
+
+			vi.mocked(dequeueAllGitOperations)
+				.mockResolvedValueOnce([queueEntry])
+				.mockResolvedValueOnce([])
+				.mockResolvedValueOnce([]);
+
+			setupPipelineMocks();
+			vi.mocked(loadConfig).mockResolvedValue({} as Awaited<ReturnType<typeof loadConfig>>);
+			vi.mocked(isCopilotInstalled).mockResolvedValue(true);
+			vi.mocked(discoverCopilotSessions).mockResolvedValue([
+				{
+					sessionId: "cp-broken",
+					transcriptPath: "/db.sqlite#cp-broken",
+					updatedAt: "2026-04-01T12:00:00.000Z",
+					source: "copilot",
+				},
+			]);
+			vi.mocked(readCopilotTranscript).mockRejectedValue(new Error("Cannot read Copilot session: cp-broken"));
+
+			await runWorker("/test/cwd");
+
+			expect(readCopilotTranscript).toHaveBeenCalledWith(
+				"/db.sqlite#cp-broken",
+				null,
+				"2026-04-01T12:00:00.000Z",
+			);
+			// Pipeline still completes — the broken session was skipped, not fatal
+			expect(storeSummary).toHaveBeenCalled();
+			// No cursor saved for the failed session
+			expect(saveCursor).not.toHaveBeenCalledWith(
+				expect.objectContaining({ transcriptPath: "/db.sqlite#cp-broken" }),
+				"/test/cwd",
+			);
 		});
 	});
 

--- a/cli/src/hooks/QueueWorker.ts
+++ b/cli/src/hooks/QueueWorker.ts
@@ -22,6 +22,9 @@ import { homedir } from "node:os";
 import { basename, dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { discoverCodexSessions, isCodexInstalled } from "../core/CodexSessionDiscoverer.js";
+import { isCopilotInstalled } from "../core/CopilotDetector.js";
+import { discoverCopilotSessions } from "../core/CopilotSessionDiscoverer.js";
+import { readCopilotTranscript } from "../core/CopilotTranscriptReader.js";
 import { isCursorInstalled } from "../core/CursorDetector.js";
 import { discoverCursorSessions } from "../core/CursorSessionDiscoverer.js";
 import { readCursorTranscript } from "../core/CursorTranscriptReader.js";
@@ -1437,6 +1440,15 @@ async function loadSessionTranscripts(
 		}
 	}
 
+	// Discover Copilot CLI sessions (on-demand SQLite scan).
+	if (config.copilotEnabled !== false && (await isCopilotInstalled())) {
+		const copilotSessions = await discoverCopilotSessions(cwd);
+		if (copilotSessions.length > 0) {
+			allSessions = [...allSessions, ...copilotSessions];
+			log.info("Discovered %d Copilot session(s)", copilotSessions.length);
+		}
+	}
+
 	if (allSessions.length === 0) {
 		log.info("No active sessions found — will infer topics from diff if available");
 	}
@@ -1473,14 +1485,35 @@ async function readAllTranscripts(
 		const startLine = cursor?.lineNumber ?? 0;
 		const source = session.source ?? "claude";
 
-		// Gemini, OpenCode, and Cursor use dedicated readers (not JSONL line-based parsing)
+		// Gemini, OpenCode, Cursor, and Copilot use dedicated readers (not JSONL line-based parsing).
+		// SQLite-backed readers (opencode/cursor/copilot) share the same failure modes —
+		// transient lock, corruption, schema drift, DB disappearing between scan and read.
+		// Wrap each in try/catch + `continue` so one bad session never abandons the rest of
+		// the batch. JSONL readers (gemini/claude) handle their per-line failures internally.
 		let result: TranscriptReadResult;
 		if (source === "gemini") {
 			result = await readGeminiTranscript(session.transcriptPath, cursor, beforeTimestamp);
 		} else if (source === "opencode") {
-			result = await readOpenCodeTranscript(session.transcriptPath, cursor, beforeTimestamp);
+			try {
+				result = await readOpenCodeTranscript(session.transcriptPath, cursor, beforeTimestamp);
+			} catch (error: unknown) {
+				log.error("Skipping OpenCode session %s: %s", session.sessionId, (error as Error).message);
+				continue;
+			}
 		} else if (source === "cursor") {
-			result = await readCursorTranscript(session.transcriptPath, cursor, beforeTimestamp);
+			try {
+				result = await readCursorTranscript(session.transcriptPath, cursor, beforeTimestamp);
+			} catch (error: unknown) {
+				log.error("Skipping Cursor session %s: %s", session.sessionId, (error as Error).message);
+				continue;
+			}
+		} else if (source === "copilot") {
+			try {
+				result = await readCopilotTranscript(session.transcriptPath, cursor, beforeTimestamp);
+			} catch (error: unknown) {
+				log.error("Skipping Copilot session %s: %s", session.sessionId, (error as Error).message);
+				continue;
+			}
 		} else {
 			result = await readTranscript(session.transcriptPath, cursor, getParserForSource(source), beforeTimestamp);
 		}

--- a/cli/src/hooks/QueueWorker.ts
+++ b/cli/src/hooks/QueueWorker.ts
@@ -22,6 +22,9 @@ import { homedir } from "node:os";
 import { basename, dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { discoverCodexSessions, isCodexInstalled } from "../core/CodexSessionDiscoverer.js";
+import { isCopilotChatInstalled } from "../core/CopilotChatDetector.js";
+import { discoverCopilotChatSessions } from "../core/CopilotChatSessionDiscoverer.js";
+import { readCopilotChatTranscript } from "../core/CopilotChatTranscriptReader.js";
 import { isCopilotInstalled } from "../core/CopilotDetector.js";
 import { discoverCopilotSessions } from "../core/CopilotSessionDiscoverer.js";
 import { readCopilotTranscript } from "../core/CopilotTranscriptReader.js";
@@ -1449,6 +1452,16 @@ async function loadSessionTranscripts(
 		}
 	}
 
+	// Discover Copilot Chat sessions (on-demand JSONL scan in vscode workspaceStorage).
+	// Shares copilotEnabled with the CLI source (one user-facing toggle for "GitHub Copilot").
+	if (config.copilotEnabled !== false && (await isCopilotChatInstalled())) {
+		const chatSessions = await discoverCopilotChatSessions(cwd);
+		if (chatSessions.length > 0) {
+			allSessions = [...allSessions, ...chatSessions];
+			log.info("Discovered %d Copilot Chat session(s)", chatSessions.length);
+		}
+	}
+
 	if (allSessions.length === 0) {
 		log.info("No active sessions found — will infer topics from diff if available");
 	}
@@ -1512,6 +1525,13 @@ async function readAllTranscripts(
 				result = await readCopilotTranscript(session.transcriptPath, cursor, beforeTimestamp);
 			} catch (error: unknown) {
 				log.error("Skipping Copilot session %s: %s", session.sessionId, (error as Error).message);
+				continue;
+			}
+		} else if (source === "copilot-chat") {
+			try {
+				result = await readCopilotChatTranscript(session.transcriptPath, cursor ?? undefined, beforeTimestamp);
+			} catch (error: unknown) {
+				log.error("Skipping Copilot Chat session %s: %s", session.sessionId, (error as Error).message);
 				continue;
 			}
 		} else {

--- a/cli/src/install/Installer.test.ts
+++ b/cli/src/install/Installer.test.ts
@@ -72,6 +72,18 @@ vi.mock("../core/CopilotSessionDiscoverer.js", () => ({
 	discoverCopilotSessions: vi.fn().mockResolvedValue([]),
 }));
 
+// Mock CopilotChatDetector for status/install checks
+vi.mock("../core/CopilotChatDetector.js", () => ({
+	isCopilotChatInstalled: vi.fn().mockResolvedValue(false),
+	getCopilotChatStorageDir: vi.fn().mockReturnValue("/fake/Code/User/globalStorage/github.copilot-chat"),
+}));
+
+// Mock CopilotChatSessionDiscoverer for status/install checks
+vi.mock("../core/CopilotChatSessionDiscoverer.js", () => ({
+	scanCopilotChatSessions: vi.fn().mockResolvedValue({ sessions: [] }),
+	discoverCopilotChatSessions: vi.fn().mockResolvedValue([]),
+}));
+
 // Partially mock DistPathResolver so resolveDistPath doesn't depend on global npm state.
 // By default, resolveDistPath returns the caller's own dist dir with "cli" source.
 vi.mock("./DistPathResolver.js", async (importOriginal) => {
@@ -166,6 +178,10 @@ describe("Installer", () => {
 		const { scanCopilotSessions } = await import("../core/CopilotSessionDiscoverer.js");
 		vi.mocked(isCopilotInstalled).mockResolvedValue(false);
 		vi.mocked(scanCopilotSessions).mockResolvedValue({ sessions: [] });
+		const { isCopilotChatInstalled } = await import("../core/CopilotChatDetector.js");
+		const { scanCopilotChatSessions } = await import("../core/CopilotChatSessionDiscoverer.js");
+		vi.mocked(isCopilotChatInstalled).mockResolvedValue(false);
+		vi.mocked(scanCopilotChatSessions).mockResolvedValue({ sessions: [] });
 	});
 
 	afterEach(async () => {
@@ -327,6 +343,34 @@ describe("Installer", () => {
 			expect(result.success).toBe(true);
 			const globalConfig = JSON.parse(await readFile(join(emptyGlobalDir, "config.json"), "utf-8"));
 			expect(globalConfig.copilotEnabled).toBe(true);
+		});
+
+		it("auto-enables copilotEnabled when only Copilot Chat is detected", async () => {
+			const { install } = await import("./Installer.js");
+			const { isCopilotInstalled } = await import("../core/CopilotDetector.js");
+			const { isCopilotChatInstalled } = await import("../core/CopilotChatDetector.js");
+			const { loadConfigFromDir, getGlobalConfigDir } = await import("../core/SessionTracker.js");
+			vi.mocked(isCopilotInstalled).mockResolvedValueOnce(false);
+			vi.mocked(isCopilotChatInstalled).mockResolvedValueOnce(true);
+
+			await install(tempDir);
+
+			const globalConfig = await loadConfigFromDir(getGlobalConfigDir());
+			expect(globalConfig.copilotEnabled).toBe(true);
+		});
+
+		it("does not auto-enable when neither Copilot form is present", async () => {
+			const { install } = await import("./Installer.js");
+			const { isCopilotInstalled } = await import("../core/CopilotDetector.js");
+			const { isCopilotChatInstalled } = await import("../core/CopilotChatDetector.js");
+			const { loadConfigFromDir, getGlobalConfigDir } = await import("../core/SessionTracker.js");
+			vi.mocked(isCopilotInstalled).mockResolvedValueOnce(false);
+			vi.mocked(isCopilotChatInstalled).mockResolvedValueOnce(false);
+
+			await install(tempDir);
+
+			const globalConfig = await loadConfigFromDir(getGlobalConfigDir());
+			expect(globalConfig.copilotEnabled).toBeUndefined();
 		});
 
 		it("should use process.cwd() when install is called without cwd", async () => {
@@ -2135,6 +2179,38 @@ describe("Installer", () => {
 			await saveConfigScoped({ copilotEnabled: true }, emptyGlobalDir);
 			const status = await getStatus(tempDir);
 			expect(status.copilotScanError).toEqual({ kind: "locked", message: "database is locked" });
+		});
+
+		it("getStatus reports copilotChatDetected when chat dir is present", async () => {
+			const { getStatus } = await import("./Installer.js");
+			const { isCopilotChatInstalled } = await import("../core/CopilotChatDetector.js");
+			vi.mocked(isCopilotChatInstalled).mockResolvedValue(true);
+
+			const status = await getStatus(tempDir);
+
+			expect(status.copilotChatDetected).toBe(true);
+		});
+
+		it("getStatus surfaces copilot-chat sessions and uses copilotEnabled gating", async () => {
+			const { getStatus } = await import("./Installer.js");
+			const { isCopilotChatInstalled } = await import("../core/CopilotChatDetector.js");
+			const { scanCopilotChatSessions } = await import("../core/CopilotChatSessionDiscoverer.js");
+			const { saveConfigScoped } = await import("../core/SessionTracker.js");
+			vi.mocked(isCopilotChatInstalled).mockResolvedValue(true);
+			vi.mocked(scanCopilotChatSessions).mockResolvedValue({
+				sessions: [
+					{
+						sessionId: "chat-1",
+						transcriptPath: "/fake/Code/.../chat-1.jsonl",
+						updatedAt: "2026-05-06T00:00:00Z",
+						source: "copilot-chat",
+					},
+				],
+			});
+			await saveConfigScoped({ copilotEnabled: true }, emptyGlobalDir);
+
+			const status = await getStatus(tempDir);
+			expect(status.sessionsBySource?.["copilot-chat"]).toBe(1);
 		});
 
 		it("merges discovered Copilot sessions into the active session count", async () => {

--- a/cli/src/install/Installer.test.ts
+++ b/cli/src/install/Installer.test.ts
@@ -60,6 +60,18 @@ vi.mock("../core/CursorSessionDiscoverer.js", () => ({
 	scanCursorSessions: vi.fn().mockResolvedValue({ sessions: [] }),
 }));
 
+// Mock CopilotDetector for status/install checks
+vi.mock("../core/CopilotDetector.js", () => ({
+	isCopilotInstalled: vi.fn().mockResolvedValue(false),
+	getCopilotDbPath: vi.fn().mockReturnValue("/fake/.copilot/session-store.db"),
+}));
+
+// Mock CopilotSessionDiscoverer for status/install checks
+vi.mock("../core/CopilotSessionDiscoverer.js", () => ({
+	scanCopilotSessions: vi.fn().mockResolvedValue({ sessions: [] }),
+	discoverCopilotSessions: vi.fn().mockResolvedValue([]),
+}));
+
 // Partially mock DistPathResolver so resolveDistPath doesn't depend on global npm state.
 // By default, resolveDistPath returns the caller's own dist dir with "cli" source.
 vi.mock("./DistPathResolver.js", async (importOriginal) => {
@@ -150,6 +162,10 @@ describe("Installer", () => {
 		vi.mocked(isCursorInstalled).mockResolvedValue(false);
 		const { scanCursorSessions } = await import("../core/CursorSessionDiscoverer.js");
 		vi.mocked(scanCursorSessions).mockResolvedValue({ sessions: [] });
+		const { isCopilotInstalled } = await import("../core/CopilotDetector.js");
+		const { scanCopilotSessions } = await import("../core/CopilotSessionDiscoverer.js");
+		vi.mocked(isCopilotInstalled).mockResolvedValue(false);
+		vi.mocked(scanCopilotSessions).mockResolvedValue({ sessions: [] });
 	});
 
 	afterEach(async () => {
@@ -276,6 +292,41 @@ describe("Installer", () => {
 			expect(result.success).toBe(true);
 			const globalConfig = JSON.parse(await readFile(join(emptyGlobalDir, "config.json"), "utf-8"));
 			expect(globalConfig.cursorEnabled).toBe(true);
+		});
+
+		it("auto-enables Copilot when DB is detected and config is undefined", async () => {
+			const { isCopilotInstalled } = await import("../core/CopilotDetector.js");
+			vi.mocked(isCopilotInstalled).mockResolvedValueOnce(true);
+
+			const result = await install(tempDir);
+
+			expect(result.success).toBe(true);
+			const globalConfig = JSON.parse(await readFile(join(emptyGlobalDir, "config.json"), "utf-8"));
+			expect(globalConfig.copilotEnabled).toBe(true);
+		});
+
+		it("does not overwrite copilotEnabled when explicitly set", async () => {
+			const { isCopilotInstalled } = await import("../core/CopilotDetector.js");
+			vi.mocked(isCopilotInstalled).mockResolvedValueOnce(true);
+			await writeFile(join(emptyGlobalDir, "config.json"), JSON.stringify({ copilotEnabled: false }), "utf-8");
+
+			const result = await install(tempDir);
+
+			expect(result.success).toBe(true);
+			const globalConfig = JSON.parse(await readFile(join(emptyGlobalDir, "config.json"), "utf-8"));
+			expect(globalConfig.copilotEnabled).toBe(false);
+		});
+
+		it("should not rewrite copilotEnabled when Copilot CLI is detected and already true", async () => {
+			const { isCopilotInstalled } = await import("../core/CopilotDetector.js");
+			vi.mocked(isCopilotInstalled).mockResolvedValueOnce(true);
+			await writeFile(join(emptyGlobalDir, "config.json"), JSON.stringify({ copilotEnabled: true }), "utf-8");
+
+			const result = await install(tempDir);
+
+			expect(result.success).toBe(true);
+			const globalConfig = JSON.parse(await readFile(join(emptyGlobalDir, "config.json"), "utf-8"));
+			expect(globalConfig.copilotEnabled).toBe(true);
 		});
 
 		it("should use process.cwd() when install is called without cwd", async () => {
@@ -2060,6 +2111,54 @@ describe("Installer", () => {
 				kind: "corrupt",
 				message: "SQLITE_CORRUPT: disk image is malformed",
 			});
+		});
+
+		it("includes copilotDetected/copilotEnabled in status when DB present", async () => {
+			const { isCopilotInstalled } = await import("../core/CopilotDetector.js");
+			const { saveConfigScoped } = await import("../core/SessionTracker.js");
+			vi.mocked(isCopilotInstalled).mockResolvedValue(true);
+			await saveConfigScoped({ copilotEnabled: true }, emptyGlobalDir);
+			const status = await getStatus(tempDir);
+			expect(status.copilotDetected).toBe(true);
+			expect(status.copilotEnabled).toBe(true);
+		});
+
+		it("surfaces copilotScanError on scan failure", async () => {
+			const { isCopilotInstalled } = await import("../core/CopilotDetector.js");
+			const { scanCopilotSessions } = await import("../core/CopilotSessionDiscoverer.js");
+			const { saveConfigScoped } = await import("../core/SessionTracker.js");
+			vi.mocked(isCopilotInstalled).mockResolvedValue(true);
+			vi.mocked(scanCopilotSessions).mockResolvedValue({
+				sessions: [],
+				error: { kind: "locked", message: "database is locked" },
+			});
+			await saveConfigScoped({ copilotEnabled: true }, emptyGlobalDir);
+			const status = await getStatus(tempDir);
+			expect(status.copilotScanError).toEqual({ kind: "locked", message: "database is locked" });
+		});
+
+		it("merges discovered Copilot sessions into the active session count", async () => {
+			const { isCopilotInstalled } = await import("../core/CopilotDetector.js");
+			const { scanCopilotSessions } = await import("../core/CopilotSessionDiscoverer.js");
+			const { saveConfigScoped } = await import("../core/SessionTracker.js");
+			vi.mocked(isCopilotInstalled).mockResolvedValue(true);
+			vi.mocked(scanCopilotSessions).mockResolvedValue({
+				sessions: [
+					{
+						sessionId: "cp-active",
+						transcriptPath: "/fake/.copilot/session-store.db#cp-active",
+						updatedAt: new Date().toISOString(),
+						source: "copilot",
+					},
+				],
+			});
+			await saveConfigScoped({ copilotEnabled: true }, emptyGlobalDir);
+
+			const status = await getStatus(tempDir);
+
+			expect(status.activeSessions).toBeGreaterThanOrEqual(1);
+			expect(status.sessionsBySource?.copilot).toBe(1);
+			expect(status.copilotScanError).toBeUndefined();
 		});
 
 		it("should count legacy sessions without a source as Claude sessions", async () => {

--- a/cli/src/install/Installer.ts
+++ b/cli/src/install/Installer.ts
@@ -19,6 +19,8 @@ import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { isClaudeInstalled } from "../core/ClaudeDetector.js";
 import { discoverCodexSessions, isCodexInstalled } from "../core/CodexSessionDiscoverer.js";
+import { isCopilotInstalled } from "../core/CopilotDetector.js";
+import { scanCopilotSessions } from "../core/CopilotSessionDiscoverer.js";
 import { isCursorInstalled } from "../core/CursorDetector.js";
 import { scanCursorSessions } from "../core/CursorSessionDiscoverer.js";
 import { isGeminiInstalled } from "../core/GeminiSessionDetector.js";
@@ -267,6 +269,15 @@ export async function install(cwd?: string, options?: { source?: "vscode-extensi
 			}
 		}
 
+		// Auto-detect Copilot CLI and enable session discovery
+		const copilotDetected = config.copilotEnabled !== false && (await isCopilotInstalled());
+		if (copilotDetected) {
+			if (config.copilotEnabled === undefined) {
+				await saveConfig({ copilotEnabled: true });
+				log.info("Copilot CLI detected — enabled Copilot session discovery");
+			}
+		}
+
 		// Migrate any existing worktree-level API keys to the global config dir.
 		// The worktrees list always includes the main repo root as its first entry.
 		for (const wt of worktrees) {
@@ -483,6 +494,7 @@ export async function getStatus(cwd?: string): Promise<StatusInfo> {
 	const geminiDetected = await isGeminiInstalled();
 	const openCodeDetected = await isOpenCodeInstalled();
 	const cursorDetected = await isCursorInstalled();
+	const copilotDetected = await isCopilotInstalled();
 
 	// Check if we can enumerate worktrees; falls back gracefully if not a git repo
 	let enabledWorktrees: number | undefined;
@@ -524,6 +536,7 @@ export async function getStatus(cwd?: string): Promise<StatusInfo> {
 		openCodeScanError = scan.error;
 	}
 
+	// Discover Cursor Composer sessions on-demand (not stored in sessions.json).
 	let cursorScanError: SqliteScanError | undefined;
 	if (config.cursorEnabled !== false && cursorDetected) {
 		const scan = await scanCursorSessions(projectDir);
@@ -531,6 +544,16 @@ export async function getStatus(cwd?: string): Promise<StatusInfo> {
 			allEnabledSessions = [...allEnabledSessions, ...scan.sessions];
 		}
 		cursorScanError = scan.error;
+	}
+
+	// Discover Copilot CLI sessions on-demand (not stored in sessions.json).
+	let copilotScanError: SqliteScanError | undefined;
+	if (config.copilotEnabled !== false && copilotDetected) {
+		const scan = await scanCopilotSessions(projectDir);
+		if (scan.sessions.length > 0) {
+			allEnabledSessions = [...allEnabledSessions, ...scan.sessions];
+		}
+		copilotScanError = scan.error;
 	}
 
 	// Compute per-source session counts for integration status rows
@@ -607,6 +630,9 @@ export async function getStatus(cwd?: string): Promise<StatusInfo> {
 		cursorDetected,
 		cursorEnabled: config.cursorEnabled,
 		cursorScanError,
+		copilotDetected,
+		copilotEnabled: config.copilotEnabled,
+		copilotScanError,
 		globalConfigDir,
 		worktreeStatePath,
 		enabledWorktrees,
@@ -618,7 +644,7 @@ export async function getStatus(cwd?: string): Promise<StatusInfo> {
 	};
 
 	log.info(
-		"Status: enabled=%s, claude=%s, git=%s, geminiHook=%s, worktreeHooks=%s, sessions=%d, summaries=%d, codex=%s/%s, gemini=%s/%s, enabledWorktrees=%s, opencode=%s/%s, cursor=%s/%s",
+		"Status: enabled=%s, claude=%s, git=%s, geminiHook=%s, worktreeHooks=%s, sessions=%d, summaries=%d, codex=%s/%s, gemini=%s/%s, enabledWorktrees=%s, opencode=%s/%s, cursor=%s/%s, copilot=%s/%s",
 		status.enabled,
 		status.claudeHookInstalled,
 		status.gitHookInstalled,
@@ -635,6 +661,8 @@ export async function getStatus(cwd?: string): Promise<StatusInfo> {
 		status.openCodeEnabled,
 		status.cursorDetected,
 		status.cursorEnabled,
+		status.copilotDetected,
+		status.copilotEnabled,
 	);
 
 	return status;

--- a/cli/src/install/Installer.ts
+++ b/cli/src/install/Installer.ts
@@ -19,6 +19,9 @@ import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { isClaudeInstalled } from "../core/ClaudeDetector.js";
 import { discoverCodexSessions, isCodexInstalled } from "../core/CodexSessionDiscoverer.js";
+import { isCopilotChatInstalled } from "../core/CopilotChatDetector.js";
+import { scanCopilotChatSessions } from "../core/CopilotChatSessionDiscoverer.js";
+import type { CopilotChatScanError } from "../core/CopilotChatTranscriptReader.js";
 import { isCopilotInstalled } from "../core/CopilotDetector.js";
 import { scanCopilotSessions } from "../core/CopilotSessionDiscoverer.js";
 import { isCursorInstalled } from "../core/CursorDetector.js";
@@ -269,13 +272,18 @@ export async function install(cwd?: string, options?: { source?: "vscode-extensi
 			}
 		}
 
-		// Auto-detect Copilot CLI and enable session discovery
+		// Auto-detect GitHub Copilot in either form (terminal CLI or vscode Chat) and
+		// enable the shared copilotEnabled flag. Both sources share one toggle —
+		// see docs/superpowers/specs/2026-05-06-copilot-chat-support-design.md.
 		const copilotDetected = config.copilotEnabled !== false && (await isCopilotInstalled());
-		if (copilotDetected) {
-			if (config.copilotEnabled === undefined) {
-				await saveConfig({ copilotEnabled: true });
-				log.info("Copilot CLI detected — enabled Copilot session discovery");
-			}
+		const copilotChatDetected = config.copilotEnabled !== false && (await isCopilotChatInstalled());
+		if ((copilotDetected || copilotChatDetected) && config.copilotEnabled === undefined) {
+			await saveConfig({ copilotEnabled: true });
+			log.info(
+				"GitHub Copilot detected (CLI=%s, Chat=%s) — enabled session discovery",
+				copilotDetected,
+				copilotChatDetected,
+			);
 		}
 
 		// Migrate any existing worktree-level API keys to the global config dir.
@@ -495,6 +503,7 @@ export async function getStatus(cwd?: string): Promise<StatusInfo> {
 	const openCodeDetected = await isOpenCodeInstalled();
 	const cursorDetected = await isCursorInstalled();
 	const copilotDetected = await isCopilotInstalled();
+	const copilotChatDetected = await isCopilotChatInstalled();
 
 	// Check if we can enumerate worktrees; falls back gracefully if not a git repo
 	let enabledWorktrees: number | undefined;
@@ -554,6 +563,16 @@ export async function getStatus(cwd?: string): Promise<StatusInfo> {
 			allEnabledSessions = [...allEnabledSessions, ...scan.sessions];
 		}
 		copilotScanError = scan.error;
+	}
+
+	// Discover Copilot Chat sessions on-demand (not stored in sessions.json).
+	let copilotChatScanError: CopilotChatScanError | undefined;
+	if (config.copilotEnabled !== false && copilotChatDetected) {
+		const scan = await scanCopilotChatSessions(projectDir);
+		if (scan.sessions.length > 0) {
+			allEnabledSessions = [...allEnabledSessions, ...scan.sessions];
+		}
+		copilotChatScanError = scan.error;
 	}
 
 	// Compute per-source session counts for integration status rows
@@ -633,6 +652,8 @@ export async function getStatus(cwd?: string): Promise<StatusInfo> {
 		copilotDetected,
 		copilotEnabled: config.copilotEnabled,
 		copilotScanError,
+		copilotChatDetected,
+		copilotChatScanError,
 		globalConfigDir,
 		worktreeStatePath,
 		enabledWorktrees,
@@ -644,7 +665,7 @@ export async function getStatus(cwd?: string): Promise<StatusInfo> {
 	};
 
 	log.info(
-		"Status: enabled=%s, claude=%s, git=%s, geminiHook=%s, worktreeHooks=%s, sessions=%d, summaries=%d, codex=%s/%s, gemini=%s/%s, enabledWorktrees=%s, opencode=%s/%s, cursor=%s/%s, copilot=%s/%s",
+		"Status: enabled=%s, claude=%s, git=%s, geminiHook=%s, worktreeHooks=%s, sessions=%d, summaries=%d, codex=%s/%s, gemini=%s/%s, enabledWorktrees=%s, opencode=%s/%s, cursor=%s/%s, copilot=%s/%s, copilotChat=%s",
 		status.enabled,
 		status.claudeHookInstalled,
 		status.gitHookInstalled,
@@ -663,6 +684,7 @@ export async function getStatus(cwd?: string): Promise<StatusInfo> {
 		status.cursorEnabled,
 		status.copilotDetected,
 		status.copilotEnabled,
+		status.copilotChatDetected,
 	);
 
 	return status;

--- a/cli/src/site/AssetResolver.test.ts
+++ b/cli/src/site/AssetResolver.test.ts
@@ -217,14 +217,27 @@ describe("AssetResolver", () => {
 		});
 	});
 
-	// ── resolveExternalImage — additional branch coverage ────────────────────
-
 	describe("resolveExternalImage branches", () => {
+		it("falls back to the parent sourceRoot when no project markers exist", async () => {
+			const { resolveExternalImage } = await import("./AssetResolver.js");
+			const docsDir = join(tempDir, "docs");
+			await mkdir(docsDir, { recursive: true });
+			const rootStatic = join(tempDir, "static");
+			await mkdir(rootStatic, { recursive: true });
+			await writeFile(join(rootStatic, "logo.png"), "fake", "utf-8");
+
+			const result = resolveExternalImage("logo.png", docsDir, docsDir);
+
+			expect(result.isPlaceholder).toBe(false);
+			expect(result.publicPath).toContain("logo.png");
+		});
+
 		it("tries direct resolve from originalMdDir", async () => {
 			const { resolveExternalImage } = await import("./AssetResolver.js");
 			const projectDir = join(tempDir, "project");
 			const docsDir = join(projectDir, "docs");
 			const imgDir = join(docsDir, "images");
+			await mkdir(docsDir, { recursive: true });
 			await mkdir(imgDir, { recursive: true });
 			await writeFile(join(projectDir, "package.json"), "{}", "utf-8");
 			await writeFile(join(imgDir, "diagram.png"), "fake", "utf-8");

--- a/docs/superpowers/plans/2026-05-05-copilot-cli-support.md
+++ b/docs/superpowers/plans/2026-05-05-copilot-cli-support.md
@@ -1,0 +1,1842 @@
+# GitHub Copilot CLI Support — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add GitHub Copilot CLI as the sixth transcript source, treated as a discovery-based SQLite-backed peer of OpenCode and Cursor.
+
+**Architecture:** Mirror the OpenCode integration template. Extract a shared `SqliteHelpers` module from `OpenCodeSessionDiscoverer` (pure refactor), then build three new core modules (`CopilotDetector`, `CopilotSessionDiscoverer`, `CopilotTranscriptReader`). Wire through `Types`, `SessionTracker`, `Installer`, `QueueWorker`, CLI commands, and the VSCode Status / Summary / Settings panels. No new dependencies — `node:sqlite` is already in use.
+
+**Tech Stack:** TypeScript (ESM, Node 22.5+), `node:sqlite` (built-in), Vitest, Biome (tabs / 120 col), GitHub Copilot CLI v1.0.x as the external system.
+
+**Spec:** [`docs/superpowers/specs/2026-05-05-copilot-cli-support-design.md`](../specs/2026-05-05-copilot-cli-support-design.md)
+
+**Project conventions to remember:**
+- All commits require DCO sign-off: `git commit -s -m "..."`. Co-Authored-By trailer for Claude.
+- Biome config at [`cli/biome.json`](../../../cli/biome.json) — tabs, 120 col, no `any`, no unused imports.
+- Test coverage gate in `cli/`: ≥97% statements / ≥96% branches.
+- `npm run all` from repo root must pass before any push.
+- VSCode webview enforces strict CSP (no inline `style=` / inline event handlers); use CSS classes + `addEventListener`.
+- Test fixtures use `node:sqlite` `DatabaseSync` directly. Each CREATE/INSERT is run via `prepare(sql).run()` — one statement per call (DatabaseSync.prepare requires single statements).
+
+---
+
+## File Structure
+
+### New files (CLI)
+
+| Path | Responsibility |
+|---|---|
+| [`cli/src/core/SqliteHelpers.ts`](../../../cli/src/core/SqliteHelpers.ts) | Generic SQLite open / version-gate / error-classify helpers. Pure-refactor extraction from `OpenCodeSessionDiscoverer.ts`. |
+| [`cli/src/core/SqliteHelpers.test.ts`](../../../cli/src/core/SqliteHelpers.test.ts) | Unit tests for the extracted helpers. |
+| [`cli/src/core/CopilotDetector.ts`](../../../cli/src/core/CopilotDetector.ts) | Resolve `~/.copilot/session-store.db`. Gate on Node SQLite support. |
+| [`cli/src/core/CopilotDetector.test.ts`](../../../cli/src/core/CopilotDetector.test.ts) | |
+| [`cli/src/core/CopilotSessionDiscoverer.ts`](../../../cli/src/core/CopilotSessionDiscoverer.ts) | `scanCopilotSessions(projectDir)` — exact `cwd` match (case-insensitive on macOS/Windows). |
+| [`cli/src/core/CopilotSessionDiscoverer.test.ts`](../../../cli/src/core/CopilotSessionDiscoverer.test.ts) | |
+| [`cli/src/core/CopilotTranscriptReader.ts`](../../../cli/src/core/CopilotTranscriptReader.ts) | Reads `turns` table; maps `user_message` → `human` / `assistant_response` → `assistant`. |
+| [`cli/src/core/CopilotTranscriptReader.test.ts`](../../../cli/src/core/CopilotTranscriptReader.test.ts) | |
+
+### Modified files (CLI)
+
+| Path | What changes |
+|---|---|
+| [`cli/src/core/OpenCodeSessionDiscoverer.ts`](../../../cli/src/core/OpenCodeSessionDiscoverer.ts) | Replace inline helpers with imports + deprecated re-exports from `SqliteHelpers.ts`. |
+| [`cli/src/core/OpenCodeTranscriptReader.ts`](../../../cli/src/core/OpenCodeTranscriptReader.ts) | Switch import to `withSqliteDb` from `SqliteHelpers.ts`. |
+| [`cli/src/Types.ts`](../../../cli/src/Types.ts) | Add `"copilot"` to `TranscriptSource`; `copilotEnabled?` to `JolliMemoryConfig`; `copilotDetected?`, `copilotEnabled?`, `copilotScanError?` to `StatusInfo`. |
+| [`cli/src/core/SessionTracker.ts`](../../../cli/src/core/SessionTracker.ts) | Add `copilotEnabled === false` filter branch. |
+| [`cli/src/install/Installer.ts`](../../../cli/src/install/Installer.ts) | Auto-detect Copilot during install; surface in `getStatus()`. |
+| [`cli/src/hooks/QueueWorker.ts`](../../../cli/src/hooks/QueueWorker.ts) | Discover Copilot sessions in the post-commit pipeline; route reads. |
+| [`cli/src/commands/StatusCommand.ts`](../../../cli/src/commands/StatusCommand.ts) | Add a "Copilot Integration" row mirroring OpenCode's. |
+| [`cli/src/commands/ConfigureCommand.ts`](../../../cli/src/commands/ConfigureCommand.ts) | Accept `copilotEnabled` as a settable key. |
+
+### Modified files (VSCode)
+
+| Path | What changes |
+|---|---|
+| [`vscode/src/providers/StatusTreeProvider.ts`](../../../vscode/src/providers/StatusTreeProvider.ts) | Copilot integration row + scanError surfacing. |
+| [`vscode/src/views/SummaryWebviewPanel.ts`](../../../vscode/src/views/SummaryWebviewPanel.ts) | Include `"copilot"` in `getEnabledSources()`. |
+| [`vscode/src/views/SummaryScriptBuilder.ts`](../../../vscode/src/views/SummaryScriptBuilder.ts) | Map `copilot` → `"Copilot"`; add to `sourceOrder`. |
+| [`vscode/src/views/SettingsHtmlBuilder.ts`](../../../vscode/src/views/SettingsHtmlBuilder.ts) | Toggle row "Copilot". |
+| [`vscode/src/views/SettingsScriptBuilder.ts`](../../../vscode/src/views/SettingsScriptBuilder.ts) | DOM ref + dirty-check + validation + save payload + load handler. |
+| [`vscode/src/views/SettingsWebviewPanel.ts`](../../../vscode/src/views/SettingsWebviewPanel.ts) | `copilotEnabled` field on `SettingsPayload` + load/save. |
+
+Plus paired `*.test.ts` updates.
+
+---
+
+## Phases (commit ordering)
+
+1. **Phase 0** — Extract `SqliteHelpers` (pure refactor, zero behavior change).
+2. **Phase 1+2** — Copilot core modules + Types/Config/SessionTracker (committed together because Phase 1 needs the widened `TranscriptSource`).
+3. **Phase 3** — Installer auto-detect + status.
+4. **Phase 4** — QueueWorker pipeline.
+5. **Phase 5** — CLI Status / Configure commands.
+6. **Phase 6** — VSCode StatusTreeProvider.
+7. **Phase 7** — VSCode Summary panel + script.
+8. **Phase 8** — VSCode Settings panel + script + html.
+9. **Phase 9** — `npm run all` + manual smoke check.
+
+---
+
+## Phase 0 — Extract SqliteHelpers
+
+**Why:** Spec calls for `SqliteHelpers` to be the shared SQLite plumbing. PR #65 plans the same extraction but is open and not in main; we land it here with the identical public surface so PR #65 can resolve by deleting its own copy.
+
+### Task 0.1: Create `SqliteHelpers.ts`
+
+**Files:** Create `cli/src/core/SqliteHelpers.ts`.
+
+- [ ] **Step 1: Write the file**
+
+Copy lines 38–191 of `cli/src/core/OpenCodeSessionDiscoverer.ts` and rename to agent-agnostic symbols (the logic is identical):
+
+```ts
+/**
+ * Shared helpers for reading SQLite databases produced by external AI agents
+ * (OpenCode, Copilot CLI, Cursor — all use the same node:sqlite read pattern).
+ */
+
+/**
+ * Database handle shape passed to `withSqliteDb` callbacks.
+ *
+ * Structurally typed against node:sqlite's DatabaseSync rather than importing
+ * the type directly, so the module is not loaded until the helper runs — this
+ * keeps the ExperimentalWarning out of every PostCommitHook invocation that
+ * only transitively imports this file.
+ */
+export interface SqliteDbHandle {
+	prepare(sql: string): {
+		all(params?: Record<string, unknown> | unknown, ...rest: unknown[]): unknown[];
+		get(params?: Record<string, unknown> | unknown, ...rest: unknown[]): unknown;
+		run(params?: Record<string, unknown> | unknown, ...rest: unknown[]): unknown;
+	};
+	close(): void;
+}
+
+/**
+ * Opens a SQLite database read-only, runs a callback, then closes it.
+ * Uses Node's built-in `node:sqlite` (statically linked; full WAL support).
+ * Lazy-imports the module so the ExperimentalWarning only appears when this
+ * helper is actually invoked.
+ */
+export async function withSqliteDb<T>(dbPath: string, fn: (db: SqliteDbHandle) => T): Promise<T> {
+	const { DatabaseSync } = await import("node:sqlite");
+	const db = new DatabaseSync(dbPath, { readOnly: true });
+	try {
+		return fn(db as unknown as SqliteDbHandle);
+	} finally {
+		db.close();
+	}
+}
+
+/** Minimum Node version that ships `node:sqlite`. */
+export const NODE_SQLITE_MIN_VERSION = { major: 22, minor: 5 } as const;
+
+export function hasNodeSqliteSupport(nodeVersion: string = process.versions.node): boolean {
+	const match = /^(\d+)\.(\d+)/.exec(nodeVersion);
+	/* v8 ignore start -- defensive */
+	if (!match) return false;
+	/* v8 ignore stop */
+	const major = Number.parseInt(match[1], 10);
+	const minor = Number.parseInt(match[2], 10);
+	if (major > NODE_SQLITE_MIN_VERSION.major) return true;
+	if (major < NODE_SQLITE_MIN_VERSION.major) return false;
+	return minor >= NODE_SQLITE_MIN_VERSION.minor;
+}
+
+export type SqliteScanErrorKind = "corrupt" | "locked" | "permission" | "schema" | "unknown";
+
+export interface SqliteScanError {
+	readonly kind: SqliteScanErrorKind;
+	readonly message: string;
+}
+
+/** Returns null for ENOENT (silent), otherwise classifies the error. */
+export function classifyScanError(error: unknown): SqliteScanError | null {
+	const err = error as (Error & { code?: string }) | undefined;
+	const message = err?.message ?? String(error);
+	const code = err?.code;
+	if (code === "ENOENT") return null;
+	if (code === "EACCES" || code === "EPERM") return { kind: "permission", message };
+	if (/SQLITE_CORRUPT|SQLITE_NOTADB|file is not a database/i.test(message)) {
+		return { kind: "corrupt", message };
+	}
+	if (/SQLITE_BUSY|SQLITE_LOCKED|database is locked/i.test(message)) {
+		return { kind: "locked", message };
+	}
+	if (/no such table|no such column/i.test(message)) {
+		return { kind: "schema", message };
+	}
+	if (/SQLITE_CANTOPEN|unable to open/i.test(message)) {
+		return { kind: "permission", message };
+	}
+	return { kind: "unknown", message };
+}
+```
+
+- [ ] **Step 2: Typecheck**
+
+Run: `npm run typecheck:cli`
+Expected: passes (file is self-contained).
+
+### Task 0.2: Migrate OpenCode files to import from SqliteHelpers
+
+**Files:** Modify `cli/src/core/OpenCodeSessionDiscoverer.ts` and `cli/src/core/OpenCodeTranscriptReader.ts`.
+
+- [ ] **Step 1: Update OpenCodeSessionDiscoverer imports + delete inlined helpers**
+
+In `cli/src/core/OpenCodeSessionDiscoverer.ts`:
+
+1. Add import block near the existing `import type { SessionInfo }`:
+
+```ts
+import {
+	type SqliteDbHandle,
+	type SqliteScanError,
+	type SqliteScanErrorKind,
+	classifyScanError as classifySqliteScanError,
+	hasNodeSqliteSupport,
+	NODE_SQLITE_MIN_VERSION,
+	withSqliteDb,
+} from "./SqliteHelpers.js";
+```
+
+2. **Delete** the inline definitions: `OpenCodeDbHandle` interface, `withOpenCodeDb` function, `NODE_SQLITE_MIN_VERSION`, `hasNodeSqliteSupport`, `OpenCodeScanErrorKind`/`OpenCodeScanError` types, and `classifyScanError` function. (Lines 38–191 in the current file.)
+
+3. Append deprecated re-exports so external callers keep working:
+
+```ts
+/** @deprecated Use SqliteDbHandle from ./SqliteHelpers.js */
+export type OpenCodeDbHandle = SqliteDbHandle;
+
+/** @deprecated Use withSqliteDb from ./SqliteHelpers.js */
+export const withOpenCodeDb = withSqliteDb;
+
+/** @deprecated Use SqliteScanErrorKind from ./SqliteHelpers.js */
+export type OpenCodeScanErrorKind = SqliteScanErrorKind;
+
+/** @deprecated Use SqliteScanError from ./SqliteHelpers.js */
+export type OpenCodeScanError = SqliteScanError;
+
+/** @deprecated Use classifyScanError from ./SqliteHelpers.js */
+export const classifyScanError = classifySqliteScanError;
+
+export { hasNodeSqliteSupport, NODE_SQLITE_MIN_VERSION };
+```
+
+Existing call sites inside this file (e.g. `withOpenCodeDb(dbPath, …)`, `classifyScanError(error)`) continue to resolve through the re-exports.
+
+- [ ] **Step 2: Update OpenCodeTranscriptReader import**
+
+In `cli/src/core/OpenCodeTranscriptReader.ts`:
+
+```ts
+// REPLACE
+import { withOpenCodeDb } from "./OpenCodeSessionDiscoverer.js";
+// WITH
+import { withSqliteDb } from "./SqliteHelpers.js";
+```
+
+Then replace the single `withOpenCodeDb(` call site (~line 54) with `withSqliteDb(`.
+
+- [ ] **Step 3: Run typecheck + opencode tests**
+
+Run: `npm run typecheck:cli && npm run test -w @jolli.ai/cli -- src/core/OpenCodeSessionDiscoverer.test.ts src/core/OpenCodeTranscriptReader.test.ts`
+Expected: PASS — zero behavior change, no test edits required.
+
+### Task 0.3: Add `SqliteHelpers.test.ts`
+
+**Files:** Create `cli/src/core/SqliteHelpers.test.ts`.
+
+- [ ] **Step 1: Write tests**
+
+```ts
+import { describe, expect, it } from "vitest";
+import {
+	classifyScanError,
+	hasNodeSqliteSupport,
+	NODE_SQLITE_MIN_VERSION,
+	withSqliteDb,
+} from "./SqliteHelpers.js";
+
+describe("hasNodeSqliteSupport", () => {
+	it.each([
+		["22.5.0", true],
+		["22.10.1", true],
+		["23.0.0", true],
+		["100.0.0", true],
+		["22.4.99", false],
+		["21.99.0", false],
+		["18.0.0", false],
+	])("returns %s for Node %s", (version, expected) => {
+		expect(hasNodeSqliteSupport(version)).toBe(expected);
+	});
+
+	it("uses NODE_SQLITE_MIN_VERSION as the boundary", () => {
+		const { major, minor } = NODE_SQLITE_MIN_VERSION;
+		expect(hasNodeSqliteSupport(`${major}.${minor}.0`)).toBe(true);
+		expect(hasNodeSqliteSupport(`${major}.${minor - 1}.99`)).toBe(false);
+	});
+});
+
+describe("classifyScanError", () => {
+	it("returns null for ENOENT", () => {
+		const err = Object.assign(new Error("no such file"), { code: "ENOENT" });
+		expect(classifyScanError(err)).toBeNull();
+	});
+
+	it.each([
+		[Object.assign(new Error("denied"), { code: "EACCES" }), "permission"],
+		[Object.assign(new Error("denied"), { code: "EPERM" }), "permission"],
+		[new Error("SQLITE_CORRUPT: malformed"), "corrupt"],
+		[new Error("file is not a database"), "corrupt"],
+		[new Error("SQLITE_BUSY: database is locked"), "locked"],
+		[new Error("database is locked"), "locked"],
+		[new Error("no such table: sessions"), "schema"],
+		[new Error("no such column: cwd"), "schema"],
+		[new Error("SQLITE_CANTOPEN"), "permission"],
+		[new Error("unable to open database file"), "permission"],
+		[new Error("anything else weird"), "unknown"],
+	])("classifies %s as %s", (err, kind) => {
+		expect(classifyScanError(err)).toEqual({ kind, message: expect.any(String) });
+	});
+
+	it("falls back to String(error) for non-Error values", () => {
+		expect(classifyScanError("plain string failure")).toEqual({ kind: "unknown", message: "plain string failure" });
+	});
+});
+
+describe("withSqliteDb", () => {
+	it("opens a real DB read-only, runs the callback, then closes", async () => {
+		const { tmpdir } = await import("node:os");
+		const { mkdtemp } = await import("node:fs/promises");
+		const { join } = await import("node:path");
+		const { DatabaseSync } = await import("node:sqlite");
+		const dir = await mkdtemp(join(tmpdir(), "sqlite-helpers-"));
+		const dbPath = join(dir, "x.db");
+
+		// Seed: one CREATE then one INSERT, each through prepare().run() so this test
+		// works on every node:sqlite version (DatabaseSync.prepare accepts only single
+		// statements).
+		const seed = new DatabaseSync(dbPath);
+		seed.prepare("CREATE TABLE t (k TEXT)").run();
+		seed.prepare("INSERT INTO t (k) VALUES ('hi')").run();
+		seed.close();
+
+		const value = await withSqliteDb(dbPath, (db) => {
+			return (db.prepare("SELECT k FROM t").get() as { k: string }).k;
+		});
+		expect(value).toBe("hi");
+	});
+
+	it("propagates errors from the callback", async () => {
+		const { tmpdir } = await import("node:os");
+		const { mkdtemp } = await import("node:fs/promises");
+		const { join } = await import("node:path");
+		const { DatabaseSync } = await import("node:sqlite");
+		const dir = await mkdtemp(join(tmpdir(), "sqlite-helpers-"));
+		const dbPath = join(dir, "x.db");
+		new DatabaseSync(dbPath).close();
+
+		await expect(
+			withSqliteDb(dbPath, () => {
+				throw new Error("boom");
+			}),
+		).rejects.toThrow("boom");
+	});
+});
+```
+
+- [ ] **Step 2: Run**
+
+Run: `npm run test -w @jolli.ai/cli -- src/core/SqliteHelpers.test.ts`
+Expected: PASS.
+
+- [ ] **Step 3: Commit Phase 0**
+
+```bash
+git add cli/src/core/SqliteHelpers.ts cli/src/core/SqliteHelpers.test.ts \
+        cli/src/core/OpenCodeSessionDiscoverer.ts cli/src/core/OpenCodeTranscriptReader.ts
+git commit -s -m "$(cat <<'EOF'
+refactor: extract SqliteHelpers from OpenCodeSessionDiscoverer
+
+Pure refactor. OpenCode keeps deprecated re-exports (OpenCodeDbHandle,
+withOpenCodeDb, classifyScanError, etc.) for backward compatibility —
+zero behavior change, all existing tests pass without edits.
+
+PR #65 (Cursor) plans the same extraction with the identical public
+surface; whichever PR merges first owns the file.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Phase 1 + Phase 2 — Copilot core + Types/Config/SessionTracker
+
+These phases land in one commit because Phase 1's `source: "copilot"` literal requires Phase 2's `TranscriptSource` widening to typecheck. Implement in this order: Types → SessionTracker → Detector → Discoverer → TranscriptReader.
+
+### Task 1.0: Widen `TranscriptSource`, add config + status fields
+
+**Files:** Modify `cli/src/Types.ts`.
+
+- [ ] **Step 1: Widen the union (line 8)**
+
+```ts
+// REPLACE
+export type TranscriptSource = "claude" | "codex" | "gemini" | "opencode";
+// WITH
+export type TranscriptSource = "claude" | "codex" | "gemini" | "opencode" | "copilot";
+```
+
+- [ ] **Step 2: Add `copilotEnabled` to `JolliMemoryConfig`**
+
+After the existing `openCodeEnabled?: boolean;` line (~488):
+
+```ts
+	/** Enable GitHub Copilot CLI session discovery at post-commit time (default: auto-detect) */
+	readonly copilotEnabled?: boolean;
+```
+
+- [ ] **Step 3: Add Copilot fields to `StatusInfo`**
+
+After the existing `openCodeEnabled?: boolean;` line in `StatusInfo` (~560):
+
+```ts
+	/** Whether Copilot CLI's session DB (~/.copilot/session-store.db) was detected */
+	readonly copilotDetected?: boolean;
+	/** Whether Copilot CLI session discovery is enabled in config (undefined = auto-detect) */
+	readonly copilotEnabled?: boolean;
+```
+
+After the existing `openCodeScanError?: { … }` block at the end of `StatusInfo`:
+
+```ts
+	/** Copilot DB scan failed with a real (non-ENOENT) error. Same UI semantics as openCodeScanError. */
+	readonly copilotScanError?: {
+		readonly kind: "corrupt" | "locked" | "permission" | "schema" | "unknown";
+		readonly message: string;
+	};
+```
+
+- [ ] **Step 4: Typecheck**
+
+Run: `npm run typecheck:cli`
+Expected: PASS.
+
+### Task 1.1: Filter copilot sessions when disabled
+
+**Files:** Modify `cli/src/core/SessionTracker.ts` and its test.
+
+- [ ] **Step 1: Add tests**
+
+In `cli/src/core/SessionTracker.test.ts`, inside the existing `describe("filterSessionsByEnabledIntegrations", …)` block:
+
+```ts
+it("filters out copilot sessions when copilotEnabled is false", () => {
+	const sessions = [
+		{ sessionId: "a", transcriptPath: "/a", updatedAt: "2026-05-05T00:00:00Z", source: "claude" as const },
+		{ sessionId: "b", transcriptPath: "/b", updatedAt: "2026-05-05T00:00:00Z", source: "copilot" as const },
+	];
+	const result = filterSessionsByEnabledIntegrations(sessions, { copilotEnabled: false });
+	expect(result.map((s) => s.sessionId)).toEqual(["a"]);
+});
+
+it("keeps copilot sessions when copilotEnabled is unset or true", () => {
+	const sessions = [
+		{ sessionId: "b", transcriptPath: "/b", updatedAt: "2026-05-05T00:00:00Z", source: "copilot" as const },
+	];
+	expect(filterSessionsByEnabledIntegrations(sessions, {})).toHaveLength(1);
+	expect(filterSessionsByEnabledIntegrations(sessions, { copilotEnabled: true })).toHaveLength(1);
+});
+```
+
+- [ ] **Step 2: Run — expect failure**
+
+Run: `npm run test -w @jolli.ai/cli -- src/core/SessionTracker.test.ts -t copilot`
+Expected: FAIL.
+
+- [ ] **Step 3: Add the filter branch**
+
+In `cli/src/core/SessionTracker.ts`, after the `if (config.openCodeEnabled === false)` block (~line 166):
+
+```ts
+	if (config.copilotEnabled === false) {
+		filtered = filtered.filter((s) => s.source !== "copilot");
+	}
+```
+
+- [ ] **Step 4: Run — expect pass**
+
+Expected: PASS.
+
+### Task 1.2: `CopilotDetector.ts`
+
+**Files:** Create `cli/src/core/CopilotDetector.ts` and `cli/src/core/CopilotDetector.test.ts`.
+
+- [ ] **Step 1: Write tests**
+
+```ts
+import { stat } from "node:fs/promises";
+import * as os from "node:os";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("node:fs/promises", async () => {
+	const actual = await vi.importActual<typeof import("node:fs/promises")>("node:fs/promises");
+	return { ...actual, stat: vi.fn() };
+});
+
+describe("CopilotDetector", () => {
+	beforeEach(() => {
+		vi.spyOn(os, "homedir").mockReturnValue("/Users/test");
+		vi.spyOn(os, "platform").mockReturnValue("darwin");
+		vi.mocked(stat).mockReset();
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("returns ~/.copilot/session-store.db on macOS/Linux", async () => {
+		const { getCopilotDbPath } = await import("./CopilotDetector.js");
+		expect(getCopilotDbPath()).toBe("/Users/test/.copilot/session-store.db");
+	});
+
+	it("returns the equivalent path on Windows", async () => {
+		vi.spyOn(os, "platform").mockReturnValue("win32");
+		vi.spyOn(os, "homedir").mockReturnValue("C:\\Users\\test");
+		const { getCopilotDbPath } = await import("./CopilotDetector.js");
+		expect(getCopilotDbPath()).toContain(".copilot");
+		expect(getCopilotDbPath()).toContain("session-store.db");
+	});
+
+	it("isCopilotInstalled returns true when DB exists", async () => {
+		vi.mocked(stat).mockResolvedValue({ isFile: () => true } as Awaited<ReturnType<typeof stat>>);
+		const { isCopilotInstalled } = await import("./CopilotDetector.js");
+		await expect(isCopilotInstalled()).resolves.toBe(true);
+	});
+
+	it("isCopilotInstalled returns false when DB is missing", async () => {
+		vi.mocked(stat).mockRejectedValue(Object.assign(new Error("no file"), { code: "ENOENT" }));
+		const { isCopilotInstalled } = await import("./CopilotDetector.js");
+		await expect(isCopilotInstalled()).resolves.toBe(false);
+	});
+
+	it("isCopilotInstalled returns false when runtime lacks node:sqlite", async () => {
+		vi.doMock("./SqliteHelpers.js", async () => {
+			const actual = await vi.importActual<typeof import("./SqliteHelpers.js")>("./SqliteHelpers.js");
+			return { ...actual, hasNodeSqliteSupport: () => false };
+		});
+		const { isCopilotInstalled } = await import("./CopilotDetector.js");
+		await expect(isCopilotInstalled()).resolves.toBe(false);
+		vi.doUnmock("./SqliteHelpers.js");
+	});
+});
+```
+
+- [ ] **Step 2: Run — expect failure**
+
+Run: `npm run test -w @jolli.ai/cli -- src/core/CopilotDetector.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement**
+
+```ts
+/**
+ * GitHub Copilot CLI detector.
+ *
+ * Copilot CLI stores conversations in ~/.copilot/session-store.db (SQLite, WAL).
+ * We read the DB via node:sqlite — pure-JS SQLite libraries cannot see WAL data.
+ */
+
+import { stat } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { createLogger } from "../Logger.js";
+import { hasNodeSqliteSupport, NODE_SQLITE_MIN_VERSION } from "./SqliteHelpers.js";
+
+const log = createLogger("CopilotDetector");
+
+/** Returns the absolute path to Copilot CLI's session-store database. */
+export function getCopilotDbPath(): string {
+	return join(homedir(), ".copilot", "session-store.db");
+}
+
+/**
+ * Returns true when Copilot CLI's session DB is present *and* the current
+ * runtime can read it. Mirrors `isOpenCodeInstalled`'s shape.
+ */
+export async function isCopilotInstalled(): Promise<boolean> {
+	if (!hasNodeSqliteSupport()) {
+		log.info(
+			"Copilot CLI support disabled: this runtime is Node %s, requires %d.%d+ for built-in SQLite",
+			process.versions.node,
+			NODE_SQLITE_MIN_VERSION.major,
+			NODE_SQLITE_MIN_VERSION.minor,
+		);
+		return false;
+	}
+	const dbPath = getCopilotDbPath();
+	try {
+		const fileStat = await stat(dbPath);
+		return fileStat.isFile();
+	} catch {
+		return false;
+	}
+}
+```
+
+- [ ] **Step 4: Run — expect pass**
+
+Expected: PASS, all 5 tests green.
+
+### Task 1.3: `CopilotSessionDiscoverer.ts`
+
+**Files:** Create `cli/src/core/CopilotSessionDiscoverer.ts` and its test.
+
+- [ ] **Step 1: Write tests (build fixtures via prepare/run, one statement at a time)**
+
+```ts
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const SCHEMA_STATEMENTS = [
+	`CREATE TABLE sessions (
+		id TEXT PRIMARY KEY, cwd TEXT, repository TEXT, host_type TEXT,
+		branch TEXT, summary TEXT, created_at TEXT, updated_at TEXT
+	)`,
+	`CREATE TABLE turns (
+		id INTEGER PRIMARY KEY AUTOINCREMENT,
+		session_id TEXT NOT NULL,
+		turn_index INTEGER NOT NULL,
+		user_message TEXT, assistant_response TEXT, timestamp TEXT
+	)`,
+];
+
+interface SeedSession {
+	id: string;
+	cwd: string;
+	updated_at: string;
+}
+
+async function makeFixtureDb(sessions: SeedSession[]): Promise<{ dbPath: string; cleanup: () => Promise<void> }> {
+	const dir = await mkdtemp(join(tmpdir(), "copilot-disc-"));
+	const dbPath = join(dir, "session-store.db");
+	const db = new DatabaseSync(dbPath);
+	for (const stmt of SCHEMA_STATEMENTS) db.prepare(stmt).run();
+	const insertSql =
+		"INSERT INTO sessions (id, cwd, repository, host_type, branch, summary, created_at, updated_at) " +
+		"VALUES (?, ?, NULL, 'github', NULL, NULL, ?, ?)";
+	const insert = db.prepare(insertSql);
+	for (const s of sessions) insert.run(s.id, s.cwd, s.updated_at, s.updated_at);
+	db.close();
+	return { dbPath, cleanup: () => rm(dir, { recursive: true, force: true }) };
+}
+
+describe("scanCopilotSessions", () => {
+	let cleanups: Array<() => Promise<void>>;
+
+	beforeEach(() => { cleanups = []; });
+	afterEach(async () => {
+		for (const c of cleanups) await c();
+		vi.restoreAllMocks();
+	});
+
+	async function withFixture(seeds: SeedSession[]) {
+		const fx = await makeFixtureDb(seeds);
+		cleanups.push(fx.cleanup);
+		const detector = await import("./CopilotDetector.js");
+		vi.spyOn(detector, "getCopilotDbPath").mockReturnValue(fx.dbPath);
+		return fx;
+	}
+
+	it("returns sessions whose cwd matches the project directory", async () => {
+		await withFixture([
+			{ id: "a", cwd: "/Users/x/project", updated_at: "2026-05-05T07:00:00.000Z" },
+			{ id: "b", cwd: "/other", updated_at: "2026-05-05T08:00:00.000Z" },
+		]);
+		const { scanCopilotSessions } = await import("./CopilotSessionDiscoverer.js");
+		const { sessions } = await scanCopilotSessions("/Users/x/project");
+		expect(sessions).toHaveLength(1);
+		expect(sessions[0]).toMatchObject({ sessionId: "a", source: "copilot" });
+		expect(sessions[0].transcriptPath).toMatch(/session-store\.db#a$/);
+	});
+
+	it("normalizes trailing slashes on the projectDir", async () => {
+		await withFixture([{ id: "a", cwd: "/Users/x/project", updated_at: "2026-05-05T07:00:00.000Z" }]);
+		const { scanCopilotSessions } = await import("./CopilotSessionDiscoverer.js");
+		const { sessions } = await scanCopilotSessions("/Users/x/project/");
+		expect(sessions).toHaveLength(1);
+	});
+
+	it("matches case-insensitively on darwin/win32", async () => {
+		vi.spyOn(process, "platform", "get").mockReturnValue("darwin");
+		await withFixture([{ id: "a", cwd: "/Users/X/Project", updated_at: "2026-05-05T07:00:00.000Z" }]);
+		const { scanCopilotSessions } = await import("./CopilotSessionDiscoverer.js");
+		const { sessions } = await scanCopilotSessions("/users/x/project");
+		expect(sessions).toHaveLength(1);
+	});
+
+	it("returns empty when nothing matches", async () => {
+		await withFixture([{ id: "a", cwd: "/elsewhere", updated_at: "2026-05-05T07:00:00.000Z" }]);
+		const { scanCopilotSessions } = await import("./CopilotSessionDiscoverer.js");
+		const { sessions } = await scanCopilotSessions("/Users/x/project");
+		expect(sessions).toEqual([]);
+	});
+
+	it("returns empty silently when the DB file is missing", async () => {
+		const detector = await import("./CopilotDetector.js");
+		vi.spyOn(detector, "getCopilotDbPath").mockReturnValue("/tmp/does-not-exist/x.db");
+		const { scanCopilotSessions } = await import("./CopilotSessionDiscoverer.js");
+		const { sessions, error } = await scanCopilotSessions("/Users/x/project");
+		expect(sessions).toEqual([]);
+		expect(error).toBeUndefined();
+	});
+
+	it("classifies a corrupt DB as a scan error", async () => {
+		const dir = await mkdtemp(join(tmpdir(), "copilot-disc-"));
+		const dbPath = join(dir, "session-store.db");
+		await writeFile(dbPath, "not a sqlite file");
+		cleanups.push(() => rm(dir, { recursive: true, force: true }));
+		const detector = await import("./CopilotDetector.js");
+		vi.spyOn(detector, "getCopilotDbPath").mockReturnValue(dbPath);
+		const { scanCopilotSessions } = await import("./CopilotSessionDiscoverer.js");
+		const { sessions, error } = await scanCopilotSessions("/Users/x/project");
+		expect(sessions).toEqual([]);
+		expect(error?.kind).toBe("corrupt");
+	});
+
+	it("skips a row whose updated_at is non-finite", async () => {
+		await withFixture([
+			{ id: "good", cwd: "/p", updated_at: "2026-05-05T07:00:00.000Z" },
+			{ id: "bad", cwd: "/p", updated_at: "not-a-date" },
+		]);
+		const { scanCopilotSessions } = await import("./CopilotSessionDiscoverer.js");
+		const { sessions } = await scanCopilotSessions("/p");
+		expect(sessions.map((s) => s.sessionId)).toEqual(["good"]);
+	});
+});
+```
+
+- [ ] **Step 2: Run — expect failure.**
+
+- [ ] **Step 3: Implement**
+
+```ts
+/**
+ * GitHub Copilot CLI session discoverer.
+ *
+ * Copilot stores every session in ~/.copilot/session-store.db. Each session row
+ * carries its own `cwd`, so workspace attribution is exact — no time-window
+ * heuristic. Synthetic transcript path: "<dbPath>#<sessionId>".
+ */
+
+import { stat } from "node:fs/promises";
+import { resolve } from "node:path";
+import { createLogger } from "../Logger.js";
+import type { SessionInfo } from "../Types.js";
+import { getCopilotDbPath } from "./CopilotDetector.js";
+import { classifyScanError, type SqliteScanError, withSqliteDb } from "./SqliteHelpers.js";
+
+const log = createLogger("CopilotDiscoverer");
+
+export interface CopilotScanResult {
+	readonly sessions: ReadonlyArray<SessionInfo>;
+	readonly error?: SqliteScanError;
+}
+
+function normalizeCwd(p: string): string {
+	return resolve(p);
+}
+
+export async function scanCopilotSessions(projectDir: string): Promise<CopilotScanResult> {
+	const dbPath = getCopilotDbPath();
+	const normalized = normalizeCwd(projectDir);
+
+	try {
+		await stat(dbPath);
+	} catch (error: unknown) {
+		const code = (error as NodeJS.ErrnoException).code;
+		/* v8 ignore start -- TOCTOU branch covered by classifier tests */
+		if (code !== "ENOENT") {
+			const scanError = classifyScanError(error);
+			if (scanError) {
+				log.error("Copilot DB stat failed (%s): %s", scanError.kind, scanError.message);
+				return { sessions: [], error: scanError };
+			}
+			return { sessions: [] };
+		}
+		/* v8 ignore stop */
+		log.debug("Copilot DB not present at %s — treating as not installed", dbPath);
+		return { sessions: [] };
+	}
+
+	try {
+		const sessions = await withSqliteDb(dbPath, (db) => {
+			const caseInsensitive = process.platform === "win32" || process.platform === "darwin";
+			const cwdMatch = caseInsensitive ? "LOWER(cwd) = LOWER(:cwd)" : "cwd = :cwd";
+			const rows = db
+				.prepare(
+					`SELECT id, cwd, repository, branch, host_type, summary, created_at, updated_at
+					 FROM sessions
+					 WHERE ${cwdMatch}
+					 ORDER BY updated_at DESC`,
+				)
+				.all({ cwd: normalized }) as ReadonlyArray<{ id: string; updated_at: string }>;
+			return rows.flatMap((row): SessionInfo[] => {
+				const ms = Date.parse(row.updated_at);
+				if (!Number.isFinite(ms)) {
+					log.warn("Skipping Copilot session %s: non-finite updated_at", row.id);
+					return [];
+				}
+				return [
+					{
+						sessionId: String(row.id),
+						transcriptPath: `${dbPath}#${row.id}`,
+						updatedAt: new Date(ms).toISOString(),
+						source: "copilot",
+					},
+				];
+			});
+		});
+		log.info("Discovered %d Copilot session(s) for %s", sessions.length, normalized);
+		return { sessions };
+	} catch (error: unknown) {
+		const scanError = classifyScanError(error);
+		/* v8 ignore start -- TOCTOU branch covered by classifier tests */
+		if (scanError === null) {
+			log.debug("Copilot DB disappeared between detection and scan: %s", (error as Error).message);
+			return { sessions: [] };
+		}
+		/* v8 ignore stop */
+		log.error("Copilot scan failed (%s): %s", scanError.kind, scanError.message);
+		return { sessions: [], error: scanError };
+	}
+}
+
+/** Convenience wrapper without the error channel — used by QueueWorker. */
+export async function discoverCopilotSessions(projectDir: string): Promise<ReadonlyArray<SessionInfo>> {
+	const { sessions } = await scanCopilotSessions(projectDir);
+	return sessions;
+}
+```
+
+- [ ] **Step 4: Run — expect pass**
+
+Expected: PASS.
+
+### Task 1.4: `CopilotTranscriptReader.ts`
+
+**Files:** Create `cli/src/core/CopilotTranscriptReader.ts` and its test.
+
+- [ ] **Step 1: Write tests**
+
+```ts
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+const SCHEMA_STATEMENTS = [
+	"CREATE TABLE sessions (id TEXT PRIMARY KEY, cwd TEXT)",
+	`CREATE TABLE turns (
+		id INTEGER PRIMARY KEY AUTOINCREMENT,
+		session_id TEXT NOT NULL,
+		turn_index INTEGER NOT NULL,
+		user_message TEXT, assistant_response TEXT, timestamp TEXT
+	)`,
+];
+
+interface SeedTurn {
+	turn_index: number;
+	user_message?: string | null;
+	assistant_response?: string | null;
+	timestamp?: string;
+}
+
+async function makeDb(sessionId: string, turns: SeedTurn[]): Promise<{ dbPath: string; cleanup: () => Promise<void> }> {
+	const dir = await mkdtemp(join(tmpdir(), "copilot-tr-"));
+	const dbPath = join(dir, "session-store.db");
+	const db = new DatabaseSync(dbPath);
+	for (const stmt of SCHEMA_STATEMENTS) db.prepare(stmt).run();
+	db.prepare("INSERT INTO sessions (id, cwd) VALUES (?, '/x')").run(sessionId);
+	const ins = db.prepare(
+		"INSERT INTO turns (session_id, turn_index, user_message, assistant_response, timestamp) VALUES (?, ?, ?, ?, ?)",
+	);
+	for (const t of turns) {
+		ins.run(
+			sessionId,
+			t.turn_index,
+			t.user_message ?? null,
+			t.assistant_response ?? null,
+			t.timestamp ?? "2026-05-05T07:00:00.000Z",
+		);
+	}
+	db.close();
+	return { dbPath, cleanup: () => rm(dir, { recursive: true, force: true }) };
+}
+
+describe("readCopilotTranscript", () => {
+	let cleanups: Array<() => Promise<void>>;
+
+	beforeEach(() => { cleanups = []; });
+	afterEach(async () => { for (const c of cleanups) await c(); });
+
+	it("returns ordered human/assistant entries", async () => {
+		const { dbPath, cleanup } = await makeDb("s1", [
+			{ turn_index: 0, user_message: "hi", assistant_response: "hello" },
+			{ turn_index: 1, user_message: "how are you", assistant_response: "good" },
+		]);
+		cleanups.push(cleanup);
+		const { readCopilotTranscript } = await import("./CopilotTranscriptReader.js");
+		const result = await readCopilotTranscript(`${dbPath}#s1`);
+		expect(result.entries.map((e) => [e.role, e.content])).toEqual([
+			["human", "hi"],
+			["assistant", "hello"],
+			["human", "how are you"],
+			["assistant", "good"],
+		]);
+		expect(result.totalLinesRead).toBe(2);
+		expect(result.newCursor.lineNumber).toBe(2);
+	});
+
+	it("skips empty/null messages within a turn", async () => {
+		const { dbPath, cleanup } = await makeDb("s1", [
+			{ turn_index: 0, user_message: "hi", assistant_response: null },
+			{ turn_index: 1, user_message: "", assistant_response: "ack" },
+		]);
+		cleanups.push(cleanup);
+		const { readCopilotTranscript } = await import("./CopilotTranscriptReader.js");
+		const result = await readCopilotTranscript(`${dbPath}#s1`);
+		expect(result.entries.map((e) => [e.role, e.content])).toEqual([
+			["human", "hi"],
+			["assistant", "ack"],
+		]);
+	});
+
+	it("resumes from a cursor", async () => {
+		const { dbPath, cleanup } = await makeDb("s1", [
+			{ turn_index: 0, user_message: "first", assistant_response: "ok" },
+			{ turn_index: 1, user_message: "second", assistant_response: "yep" },
+		]);
+		cleanups.push(cleanup);
+		const { readCopilotTranscript } = await import("./CopilotTranscriptReader.js");
+		const result = await readCopilotTranscript(`${dbPath}#s1`, {
+			transcriptPath: `${dbPath}#s1`,
+			lineNumber: 1,
+			updatedAt: "2026-05-05T07:00:00.000Z",
+		});
+		expect(result.entries.map((e) => e.content)).toEqual(["second", "yep"]);
+	});
+
+	it("respects beforeTimestamp cutoff", async () => {
+		const { dbPath, cleanup } = await makeDb("s1", [
+			{ turn_index: 0, user_message: "early", assistant_response: "ok", timestamp: "2026-05-05T07:00:00.000Z" },
+			{ turn_index: 1, user_message: "late", assistant_response: "no", timestamp: "2026-05-05T09:00:00.000Z" },
+		]);
+		cleanups.push(cleanup);
+		const { readCopilotTranscript } = await import("./CopilotTranscriptReader.js");
+		const result = await readCopilotTranscript(`${dbPath}#s1`, null, "2026-05-05T08:00:00.000Z");
+		expect(result.entries.map((e) => e.content)).toEqual(["early", "ok"]);
+		expect(result.newCursor.lineNumber).toBe(1);
+	});
+
+	it("throws on a malformed transcriptPath", async () => {
+		const { readCopilotTranscript } = await import("./CopilotTranscriptReader.js");
+		await expect(readCopilotTranscript("no-hash-marker")).rejects.toThrow(/Invalid Copilot transcript path/);
+	});
+
+	it("returns empty when the session has no rows", async () => {
+		const { dbPath, cleanup } = await makeDb("s1", []);
+		cleanups.push(cleanup);
+		const { readCopilotTranscript } = await import("./CopilotTranscriptReader.js");
+		const result = await readCopilotTranscript(`${dbPath}#s1`);
+		expect(result.entries).toEqual([]);
+		expect(result.newCursor.lineNumber).toBe(0);
+	});
+});
+```
+
+- [ ] **Step 2: Run — expect failure.**
+
+- [ ] **Step 3: Implement**
+
+```ts
+/**
+ * Reads conversation turns from Copilot CLI's session-store SQLite database.
+ *
+ * Each `turns` row contains a (user_message, assistant_response) pair, ordered
+ * by turn_index. We expand each row into two TranscriptEntry items, skipping
+ * empty/null messages.
+ *
+ * Cursor tracks turn_index — the count of fully-consumed turns from the last
+ * read — to support incremental reads across post-commit invocations.
+ */
+
+import { createLogger } from "../Logger.js";
+import type { TranscriptCursor, TranscriptEntry, TranscriptReadResult } from "../Types.js";
+import { withSqliteDb } from "./SqliteHelpers.js";
+import { mergeConsecutiveEntries } from "./TranscriptReader.js";
+
+const log = createLogger("CopilotTranscriptReader");
+
+export async function readCopilotTranscript(
+	transcriptPath: string,
+	cursor?: TranscriptCursor | null,
+	beforeTimestamp?: string,
+): Promise<TranscriptReadResult> {
+	const { dbPath, sessionId } = parseSyntheticPath(transcriptPath);
+	const startIndex = cursor?.lineNumber ?? 0;
+	const cutoffMs = beforeTimestamp ? Date.parse(beforeTimestamp) : undefined;
+
+	try {
+		const { rawEntries, totalTurns, lastConsumedIndex } = await withSqliteDb(dbPath, (db) => {
+			const rows = db
+				.prepare(
+					`SELECT turn_index, user_message, assistant_response, timestamp
+					 FROM turns
+					 WHERE session_id = :sessionId
+					 ORDER BY turn_index ASC`,
+				)
+				.all({ sessionId }) as ReadonlyArray<{
+				turn_index: number;
+				user_message: string | null;
+				assistant_response: string | null;
+				timestamp: string | null;
+			}>;
+			const newRows = rows.slice(startIndex);
+			const out: TranscriptEntry[] = [];
+			let consumed = startIndex;
+			for (let i = 0; i < newRows.length; i++) {
+				const r = newRows[i];
+				if (cutoffMs !== undefined && r.timestamp) {
+					const ts = Date.parse(r.timestamp);
+					if (Number.isFinite(ts) && ts > cutoffMs) break;
+				}
+				const tsIso = r.timestamp && Number.isFinite(Date.parse(r.timestamp)) ? r.timestamp : undefined;
+				if (typeof r.user_message === "string" && r.user_message.trim().length > 0) {
+					out.push({ role: "human", content: r.user_message, timestamp: tsIso });
+				}
+				if (typeof r.assistant_response === "string" && r.assistant_response.trim().length > 0) {
+					out.push({ role: "assistant", content: r.assistant_response, timestamp: tsIso });
+				}
+				consumed = startIndex + i + 1;
+			}
+			return { rawEntries: out, totalTurns: rows.length, lastConsumedIndex: consumed };
+		});
+
+		const entries = mergeConsecutiveEntries(rawEntries);
+		const newCursor: TranscriptCursor = {
+			transcriptPath,
+			lineNumber: beforeTimestamp ? lastConsumedIndex : totalTurns,
+			updatedAt: new Date().toISOString(),
+		};
+		const totalLinesRead = lastConsumedIndex - startIndex;
+		log.info(
+			"Read Copilot session %s: %d new turns, %d entries (index %d→%d)",
+			sessionId.substring(0, 8),
+			totalLinesRead,
+			entries.length,
+			startIndex,
+			newCursor.lineNumber,
+		);
+		return { entries, newCursor, totalLinesRead };
+	} catch (error: unknown) {
+		log.error("Failed to read Copilot session %s: %s", sessionId.substring(0, 8), (error as Error).message);
+		throw new Error(`Cannot read Copilot session: ${sessionId}`);
+	}
+}
+
+function parseSyntheticPath(transcriptPath: string): { dbPath: string; sessionId: string } {
+	const hashIndex = transcriptPath.lastIndexOf("#");
+	if (hashIndex === -1) {
+		throw new Error(`Invalid Copilot transcript path (missing #sessionId): ${transcriptPath}`);
+	}
+	const dbPath = transcriptPath.substring(0, hashIndex);
+	const sessionId = transcriptPath.substring(hashIndex + 1);
+	if (dbPath.length === 0 || sessionId.length === 0) {
+		throw new Error(`Invalid Copilot transcript path (empty dbPath or sessionId): ${transcriptPath}`);
+	}
+	return { dbPath, sessionId };
+}
+```
+
+- [ ] **Step 4: Run — expect pass.**
+
+### Task 1.5: Commit Phase 1 + Phase 2
+
+- [ ] **Step 1: Commit**
+
+```bash
+git add cli/src/Types.ts \
+        cli/src/core/SessionTracker.ts cli/src/core/SessionTracker.test.ts \
+        cli/src/core/CopilotDetector.ts cli/src/core/CopilotDetector.test.ts \
+        cli/src/core/CopilotSessionDiscoverer.ts cli/src/core/CopilotSessionDiscoverer.test.ts \
+        cli/src/core/CopilotTranscriptReader.ts cli/src/core/CopilotTranscriptReader.test.ts
+git commit -s -m "$(cat <<'EOF'
+feat(cli): add Copilot CLI as a transcript source — core modules
+
+Three new modules under cli/src/core:
+- CopilotDetector: resolves ~/.copilot/session-store.db, gates on Node SQLite support.
+- CopilotSessionDiscoverer: SELECT … FROM sessions WHERE cwd = ? against the
+  Copilot CLI database (case-insensitive on macOS/Windows). Returns one
+  SessionInfo per match with source="copilot" and a synthetic <dbPath>#<sessionId>
+  transcript path matching the OpenCode pattern.
+- CopilotTranscriptReader: reads the turns table in order, expands each
+  (user_message, assistant_response) pair into one human + one assistant
+  TranscriptEntry, supports cursor-based incremental reads and beforeTimestamp.
+
+Adds "copilot" to TranscriptSource, copilotEnabled to JolliMemoryConfig, and
+{copilotDetected, copilotEnabled, copilotScanError} to StatusInfo. SessionTracker
+filters copilot sessions when copilotEnabled === false, mirroring OpenCode.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Phase 3 — Installer auto-detect + status
+
+### Task 3.1: Auto-enable on install
+
+**Files:** Modify `cli/src/install/Installer.ts` and its test.
+
+- [ ] **Step 1: Add tests**
+
+In `cli/src/install/Installer.test.ts`, near the existing `openCodeEnabled` auto-enable test, add:
+
+```ts
+it("auto-enables Copilot when DB is detected and config is undefined", async () => {
+	const detector = await import("../core/CopilotDetector.js");
+	vi.spyOn(detector, "isCopilotInstalled").mockResolvedValue(true);
+	// (re-use the same setup helpers the openCode test uses for projectDir + config)
+	await install(projectDir);
+	const config = await loadConfig();
+	expect(config.copilotEnabled).toBe(true);
+});
+
+it("does not overwrite copilotEnabled when explicitly set", async () => {
+	const detector = await import("../core/CopilotDetector.js");
+	vi.spyOn(detector, "isCopilotInstalled").mockResolvedValue(true);
+	await saveConfig({ copilotEnabled: false });
+	await install(projectDir);
+	const config = await loadConfig();
+	expect(config.copilotEnabled).toBe(false);
+});
+```
+
+(Adapt the helpers from the existing `openCodeEnabled` test in this file — do not invent new helpers.)
+
+- [ ] **Step 2: Run — expect failure.**
+
+- [ ] **Step 3: Wire auto-detect**
+
+In `cli/src/install/Installer.ts`:
+
+1. Add to imports near the existing OpenCode imports:
+
+```ts
+import { isCopilotInstalled } from "../core/CopilotDetector.js";
+import { scanCopilotSessions } from "../core/CopilotSessionDiscoverer.js";
+import type { SqliteScanError } from "../core/SqliteHelpers.js";
+```
+
+2. After the OpenCode auto-detect block (lines 249–256), add:
+
+```ts
+		// Auto-detect Copilot CLI and enable session discovery
+		const copilotDetected = config.copilotEnabled !== false && (await isCopilotInstalled());
+		if (copilotDetected) {
+			if (config.copilotEnabled === undefined) {
+				await saveConfig({ copilotEnabled: true });
+				log.info("Copilot CLI detected — enabled Copilot session discovery");
+			}
+		}
+```
+
+- [ ] **Step 4: Run — expect pass.**
+
+### Task 3.2: Surface Copilot in `getStatus()`
+
+- [ ] **Step 1: Add tests**
+
+```ts
+it("includes copilotDetected/copilotEnabled in status when DB present", async () => {
+	const detector = await import("../core/CopilotDetector.js");
+	vi.spyOn(detector, "isCopilotInstalled").mockResolvedValue(true);
+	await saveConfig({ copilotEnabled: true });
+	const status = await getStatus(projectDir);
+	expect(status.copilotDetected).toBe(true);
+	expect(status.copilotEnabled).toBe(true);
+});
+
+it("surfaces copilotScanError on scan failure", async () => {
+	const detector = await import("../core/CopilotDetector.js");
+	const discoverer = await import("../core/CopilotSessionDiscoverer.js");
+	vi.spyOn(detector, "isCopilotInstalled").mockResolvedValue(true);
+	vi.spyOn(discoverer, "scanCopilotSessions").mockResolvedValue({
+		sessions: [],
+		error: { kind: "locked", message: "database is locked" },
+	});
+	await saveConfig({ copilotEnabled: true });
+	const status = await getStatus(projectDir);
+	expect(status.copilotScanError).toEqual({ kind: "locked", message: "database is locked" });
+});
+```
+
+- [ ] **Step 2: Run — expect failure.**
+
+- [ ] **Step 3: Wire status**
+
+In `getStatus()`:
+
+1. After `const openCodeDetected = await isOpenCodeInstalled();` (~line 472):
+
+```ts
+	const copilotDetected = await isCopilotInstalled();
+```
+
+2. After the OpenCode discovery block (lines 502–512):
+
+```ts
+	let copilotScanError: SqliteScanError | undefined;
+	if (config.copilotEnabled !== false && copilotDetected) {
+		const scan = await scanCopilotSessions(projectDir);
+		if (scan.sessions.length > 0) {
+			allEnabledSessions = [...allEnabledSessions, ...scan.sessions];
+		}
+		copilotScanError = scan.error;
+	}
+```
+
+3. In the `StatusInfo` literal (~line 564), after the `openCodeScanError,` line:
+
+```ts
+		copilotDetected,
+		copilotEnabled: config.copilotEnabled,
+		copilotScanError,
+```
+
+4. Update the `log.info("Status: ...")` line to append `, copilot=%s/%s` and the values `copilotDetected, config.copilotEnabled` — mirror exactly how `opencode=%s/%s` is appended.
+
+- [ ] **Step 4: Run — expect pass.**
+
+- [ ] **Step 5: Commit Phase 3**
+
+```bash
+git add cli/src/install/Installer.ts cli/src/install/Installer.test.ts
+git commit -s -m "$(cat <<'EOF'
+feat(cli): auto-detect Copilot CLI on install and surface in status
+
+install() mirrors the OpenCode auto-enable pattern: when
+~/.copilot/session-store.db is present and copilotEnabled is undefined, the
+installer sets it to true. Explicit values are never overwritten.
+
+getStatus() reports copilotDetected, copilotEnabled, and copilotScanError
+alongside the OpenCode equivalents and includes Copilot session counts in
+activeSessions / sessionsBySource.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Phase 4 — QueueWorker pipeline
+
+**Files:** Modify `cli/src/hooks/QueueWorker.ts` and its test.
+
+- [ ] **Step 1: Add tests**
+
+In `cli/src/hooks/QueueWorker.test.ts`, find the OpenCode pipeline test (search `discoverOpenCodeSessions`) and mirror it:
+
+```ts
+it("discovers Copilot sessions and routes reads through readCopilotTranscript", async () => {
+	const det = await import("../core/CopilotDetector.js");
+	const disc = await import("../core/CopilotSessionDiscoverer.js");
+	const reader = await import("../core/CopilotTranscriptReader.js");
+	vi.spyOn(det, "isCopilotInstalled").mockResolvedValue(true);
+	vi.spyOn(disc, "discoverCopilotSessions").mockResolvedValue([
+		{
+			sessionId: "c1",
+			transcriptPath: "/db.sqlite#c1",
+			updatedAt: "2026-05-05T07:00:00.000Z",
+			source: "copilot",
+		},
+	]);
+	const readSpy = vi.spyOn(reader, "readCopilotTranscript").mockResolvedValue({
+		entries: [{ role: "human", content: "hi" }],
+		newCursor: { transcriptPath: "/db.sqlite#c1", lineNumber: 1, updatedAt: "now" },
+		totalLinesRead: 1,
+	});
+	// Run whatever pipeline-entry function the existing OpenCode test calls.
+	await runPipelineForTesting(/* re-use same boilerplate as opencode test */);
+	expect(readSpy).toHaveBeenCalledWith("/db.sqlite#c1", null, expect.any(String));
+});
+
+it("short-circuits Copilot discovery when copilotEnabled is false", async () => {
+	const det = await import("../core/CopilotDetector.js");
+	const disc = await import("../core/CopilotSessionDiscoverer.js");
+	const detSpy = vi.spyOn(det, "isCopilotInstalled");
+	const discSpy = vi.spyOn(disc, "discoverCopilotSessions");
+	await saveConfig({ copilotEnabled: false });
+	await runPipelineForTesting(/* … */);
+	expect(detSpy).not.toHaveBeenCalled();
+	expect(discSpy).not.toHaveBeenCalled();
+});
+```
+
+- [ ] **Step 2: Run — expect failure.**
+
+- [ ] **Step 3: Wire the discovery + read**
+
+In `cli/src/hooks/QueueWorker.ts`:
+
+1. Imports near line 27:
+
+```ts
+import { isCopilotInstalled } from "../core/CopilotDetector.js";
+import { discoverCopilotSessions } from "../core/CopilotSessionDiscoverer.js";
+import { readCopilotTranscript } from "../core/CopilotTranscriptReader.js";
+```
+
+2. After the OpenCode discovery block (lines 1418–1426):
+
+```ts
+	// Discover Copilot CLI sessions (on-demand SQLite scan).
+	if (config.copilotEnabled !== false && (await isCopilotInstalled())) {
+		const copilotSessions = await discoverCopilotSessions(cwd);
+		if (copilotSessions.length > 0) {
+			allSessions = [...allSessions, ...copilotSessions];
+			log.info("Discovered %d Copilot session(s)", copilotSessions.length);
+		}
+	}
+```
+
+3. In `readAllTranscripts` (~line 1466), insert a Copilot branch between the existing `opencode` branch and the `else` fallback:
+
+```ts
+		} else if (source === "copilot") {
+			result = await readCopilotTranscript(session.transcriptPath, cursor, beforeTimestamp);
+```
+
+- [ ] **Step 4: Run — expect pass.**
+
+- [ ] **Step 5: Commit Phase 4**
+
+```bash
+git add cli/src/hooks/QueueWorker.ts cli/src/hooks/QueueWorker.test.ts
+git commit -s -m "feat(cli): wire Copilot CLI into the post-commit pipeline
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Phase 5 — CLI Status / Configure
+
+### Task 5.1: StatusCommand row
+
+**Files:** Modify `cli/src/commands/StatusCommand.ts` and its test.
+
+- [ ] **Step 1: Read OpenCode block (lines 264–290) for the template.**
+
+- [ ] **Step 2: Add tests**
+
+```ts
+it("renders Copilot Integration row when detected", () => {
+	const out = renderStatus({
+		...baseStatus,
+		copilotDetected: true,
+		copilotEnabled: true,
+		sessionsBySource: { copilot: 3 },
+	});
+	expect(out).toContain("Copilot Integration");
+	expect(out).toContain("3");
+});
+
+it("renders Copilot row as unavailable on scan error", () => {
+	const out = renderStatus({
+		...baseStatus,
+		copilotDetected: true,
+		copilotScanError: { kind: "locked", message: "database is locked" },
+	});
+	expect(out).toContain("Copilot Integration");
+	expect(out).toContain("unavailable");
+	expect(out).toContain("locked");
+});
+```
+
+(Use existing `renderStatus`/`baseStatus` helpers — don't invent new ones.)
+
+- [ ] **Step 3: Run — expect failure.**
+
+- [ ] **Step 4: Append the Copilot block**
+
+After the OpenCode block, insert a parallel Copilot block. Token replacement: `OpenCode` → `Copilot`, `openCode` → `copilot`, `opencode` → `copilot`. Healthy descriptions:
+- enabled: `"Copilot CLI database found — session discovery is enabled"`
+- detected-but-disabled: `"Copilot CLI detected but session discovery is disabled in config"`
+
+Error path: `` `unavailable — ${s.copilotScanError.kind}` `` and tooltip `` `Copilot database scan failed (${s.copilotScanError.kind}): ${s.copilotScanError.message}` ``.
+
+Also widen the `scanError` field declared at the top of the file (line 26) so it can carry either `StatusInfo["openCodeScanError"]` or `StatusInfo["copilotScanError"]`. Both have the identical shape, so changing the type to `StatusInfo["openCodeScanError"]` (which is structurally equal) compiles unchanged — but adjust if the type alias is named after one specific source.
+
+- [ ] **Step 5: Run — expect pass.**
+
+### Task 5.2: ConfigureCommand key
+
+**Files:** Modify `cli/src/commands/ConfigureCommand.ts` and its test.
+
+- [ ] **Step 1: Add tests**
+
+```ts
+it("accepts copilotEnabled as a boolean key", async () => {
+	await runConfigure(["--set", "copilotEnabled=true"]);
+	expect((await loadConfig()).copilotEnabled).toBe(true);
+	await runConfigure(["--set", "copilotEnabled=false"]);
+	expect((await loadConfig()).copilotEnabled).toBe(false);
+});
+
+it("lists copilotEnabled in help/description output", async () => {
+	const help = await runConfigureHelp();
+	expect(help).toContain("copilotEnabled");
+});
+```
+
+- [ ] **Step 2: Run — expect failure.**
+
+- [ ] **Step 3: Wire the key**
+
+In `cli/src/commands/ConfigureCommand.ts`:
+
+1. Add `"copilotEnabled"` to the valid-keys array (~line 31).
+
+2. Update the boolean coercion guard (~line 67) by adding `key === "copilotEnabled"` to the OR chain.
+
+3. In the metadata array (~line 99), after the `openCodeEnabled` entry:
+
+```ts
+	{
+		key: "copilotEnabled",
+		type: "boolean",
+		description: "Enable Copilot CLI session discovery (true/false). Requires Node 22.5+.",
+	},
+```
+
+- [ ] **Step 4: Run — expect pass.**
+
+- [ ] **Step 5: Commit Phase 5**
+
+```bash
+git add cli/src/commands/StatusCommand.ts cli/src/commands/StatusCommand.test.ts \
+        cli/src/commands/ConfigureCommand.ts cli/src/commands/ConfigureCommand.test.ts
+git commit -s -m "feat(cli): surface Copilot CLI in jolli status and jolli configure
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Phase 6 — VSCode StatusTreeProvider
+
+**Files:** Modify `vscode/src/providers/StatusTreeProvider.ts` and its test.
+
+- [ ] **Step 1: Locate the OpenCode block in StatusTreeProvider.ts (~lines 264–290).**
+
+- [ ] **Step 2: Add tests**
+
+```ts
+it("shows Copilot Integration row when detected and enabled", () => {
+	const items = provider.getChildren({
+		...mockStatus,
+		copilotDetected: true,
+		copilotEnabled: true,
+		sessionsBySource: { copilot: 2 },
+	});
+	const item = items.find((i) => i.label === "Copilot Integration");
+	expect(item).toBeDefined();
+	expect(item?.description).toContain("2");
+});
+
+it("shows Copilot Integration as unavailable when scan errors", () => {
+	const items = provider.getChildren({
+		...mockStatus,
+		copilotDetected: true,
+		copilotScanError: { kind: "locked", message: "database is locked" },
+	});
+	const item = items.find((i) => i.label === "Copilot Integration");
+	expect(item?.description).toContain("locked");
+	expect(item?.tooltip).toContain("Copilot database scan failed");
+});
+```
+
+(Use the existing `mockStatus` helper.)
+
+- [ ] **Step 3: Run — expect failure.**
+
+- [ ] **Step 4: Append parallel Copilot block**
+
+Replace tokens 1:1 from the OpenCode block: messages match the StatusCommand wording above. Use `pushIntegrationItem` for the healthy state, the explicit unavailable-row branch for `s.copilotScanError`.
+
+- [ ] **Step 5: Run — expect pass.**
+
+- [ ] **Step 6: Commit Phase 6**
+
+```bash
+git add vscode/src/providers/StatusTreeProvider.ts vscode/src/providers/StatusTreeProvider.test.ts
+git commit -s -m "feat(vscode): add Copilot Integration row to status tree
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Phase 7 — VSCode Summary panel + script
+
+### Task 7.1: `getEnabledSources()` includes copilot
+
+**Files:** Modify `vscode/src/views/SummaryWebviewPanel.ts` and its test.
+
+- [ ] **Step 1: Add tests**
+
+```ts
+it("includes 'copilot' when copilotEnabled !== false", () => {
+	expect(getEnabledSources({ copilotEnabled: true })).toContain("copilot");
+	expect(getEnabledSources({})).toContain("copilot");
+});
+
+it("excludes 'copilot' when copilotEnabled === false", () => {
+	expect(getEnabledSources({ copilotEnabled: false })).not.toContain("copilot");
+});
+```
+
+- [ ] **Step 2: Run — expect failure.**
+
+- [ ] **Step 3: Add the source (after line 2044 — the OpenCode block)**
+
+```ts
+		if (config.copilotEnabled !== false) {
+			sources.add("copilot");
+		}
+```
+
+- [ ] **Step 4: Run — expect pass.**
+
+### Task 7.2: SummaryScriptBuilder label + sourceOrder
+
+**Files:** Modify `vscode/src/views/SummaryScriptBuilder.ts` and its test.
+
+- [ ] **Step 1: Add tests**
+
+```ts
+it("maps 'copilot' source to 'Copilot' label", () => {
+	expect(scriptForSource("copilot")).toContain("'Copilot'");
+});
+
+it("appends 'copilot' to sourceOrder", () => {
+	expect(builtScript()).toContain("['claude', 'codex', 'gemini', 'opencode', 'copilot']");
+});
+```
+
+- [ ] **Step 2: Run — expect failure.**
+
+- [ ] **Step 3: Edits**
+
+At line 1134 (after the `opencode` mapping):
+
+```ts
+    if (source === 'copilot') return 'Copilot';
+```
+
+At line 1560:
+
+```ts
+        var sourceOrder = ['claude', 'codex', 'gemini', 'opencode', 'copilot'];
+```
+
+- [ ] **Step 4: Run — expect pass.**
+
+- [ ] **Step 5: Commit Phase 7**
+
+```bash
+git add vscode/src/views/SummaryWebviewPanel.ts vscode/src/views/SummaryWebviewPanel.test.ts \
+        vscode/src/views/SummaryScriptBuilder.ts vscode/src/views/SummaryScriptBuilder.test.ts
+git commit -s -m "feat(vscode): show Copilot CLI in Summary Details source breakdown
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Phase 8 — VSCode Settings panel
+
+### Task 8.1: HTML toggle row
+
+**Files:** Modify `vscode/src/views/SettingsHtmlBuilder.ts` and its test.
+
+- [ ] **Step 1: Add test**
+
+```ts
+it("includes a Copilot toggle row", () => {
+	const html = buildSettingsHtml(/* … */);
+	expect(html).toContain('id="copilotEnabled"');
+	expect(html).toContain("Copilot");
+});
+```
+
+- [ ] **Step 2: Run — expect failure.**
+
+- [ ] **Step 3: Add (after line 86, the openCodeEnabled row)**
+
+```ts
+      ${buildToggleRow("copilotEnabled", "Copilot", "Session discovery via ~/.copilot/session-store.db")}
+```
+
+- [ ] **Step 4: Run — expect pass.**
+
+### Task 8.2: SettingsScriptBuilder
+
+**Files:** Modify `vscode/src/views/SettingsScriptBuilder.ts` and its test.
+
+- [ ] **Step 1: Add tests**
+
+```ts
+it("references the copilotEnabled DOM input", () => {
+	expect(builtScript()).toContain("getElementById('copilotEnabled')");
+});
+
+it("includes copilotEnabled in validation guard", () => {
+	expect(builtScript()).toMatch(/!openCodeEnabledInput\.checked && !copilotEnabledInput\.checked/);
+});
+
+it("ships copilotEnabled in save payload", () => {
+	expect(builtScript()).toContain("copilotEnabled: copilotEnabledInput.checked");
+});
+
+it("loads copilotEnabled from host message", () => {
+	expect(builtScript()).toContain("copilotEnabledInput.checked = msg.settings.copilotEnabled");
+});
+```
+
+- [ ] **Step 2: Run — expect failure.**
+
+- [ ] **Step 3: Edits across the file**
+
+1. **Line 30** (after `openCodeEnabledInput`):
+
+```ts
+  const copilotEnabledInput = document.getElementById('copilotEnabled');
+```
+
+2. **Line 132** (validation guard):
+
+```ts
+    if (!claudeEnabledInput.checked && !codexEnabledInput.checked && !geminiEnabledInput.checked && !openCodeEnabledInput.checked && !copilotEnabledInput.checked) {
+```
+
+3. **Both save-payload sites (lines 164 and 234)** — append after `openCodeEnabled: openCodeEnabledInput.checked,`:
+
+```ts
+        copilotEnabled: copilotEnabledInput.checked,
+```
+
+4. **Dirty check (line 180)** — add the OR clause:
+
+```ts
+      copilotEnabledInput.checked !== initialState.copilotEnabled ||
+```
+
+5. **Change-listener array (line 205)**:
+
+```ts
+  [claudeEnabledInput, codexEnabledInput, geminiEnabledInput, openCodeEnabledInput, copilotEnabledInput].forEach(function(input) {
+```
+
+6. **Host load handler (line 255)** — after `openCodeEnabledInput.checked = msg.settings.openCodeEnabled;`:
+
+```ts
+        copilotEnabledInput.checked = msg.settings.copilotEnabled;
+```
+
+7. **`initialState`** — search for the `initialState =` block, add `copilotEnabled: settings.copilotEnabled,` next to the other `*Enabled` keys.
+
+- [ ] **Step 4: Run — expect pass.**
+
+### Task 8.3: SettingsWebviewPanel
+
+**Files:** Modify `vscode/src/views/SettingsWebviewPanel.ts` and its test.
+
+- [ ] **Step 1: Add tests**
+
+```ts
+it("loads copilotEnabled from config (default true)", async () => {
+	await saveConfig({ copilotEnabled: false });
+	expect((await buildPayload()).copilotEnabled).toBe(false);
+
+	await saveConfig({});
+	expect((await buildPayload()).copilotEnabled).toBe(true);
+});
+
+it("persists copilotEnabled when the user submits", async () => {
+	await applySettings({ ...defaults, copilotEnabled: false });
+	expect((await loadConfig()).copilotEnabled).toBe(false);
+});
+```
+
+- [ ] **Step 2: Run — expect failure.**
+
+- [ ] **Step 3: Edits**
+
+1. **`SettingsPayload` (line 44)** — after `openCodeEnabled`:
+
+```ts
+	readonly copilotEnabled: boolean;
+```
+
+2. **`buildPayload()` (line 252)** — after the openCode line:
+
+```ts
+			copilotEnabled: config.copilotEnabled !== false,
+```
+
+3. **`applySettings()` (line 327)** — after the openCode line:
+
+```ts
+			copilotEnabled: settings.copilotEnabled,
+```
+
+- [ ] **Step 4: Run — expect pass.**
+
+- [ ] **Step 5: Commit Phase 8**
+
+```bash
+git add vscode/src/views/SettingsHtmlBuilder.ts vscode/src/views/SettingsHtmlBuilder.test.ts \
+        vscode/src/views/SettingsScriptBuilder.ts vscode/src/views/SettingsScriptBuilder.test.ts \
+        vscode/src/views/SettingsWebviewPanel.ts vscode/src/views/SettingsWebviewPanel.test.ts
+git commit -s -m "$(cat <<'EOF'
+feat(vscode): add Copilot CLI toggle to Settings panel
+
+Adds a Copilot enable/disable toggle alongside the existing
+Claude/Codex/Gemini/OpenCode toggles. Participates in dirty detection,
+the "at least one integration enabled" validation guard, and load/save
+round-trips with the underlying jolli config.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Phase 9 — End-to-end verification
+
+### Task 9.1: Full gate
+
+- [ ] **Step 1: Run `npm run all` from repo root**
+
+Run: `npm run all`
+Expected: clean → build → lint → test all pass in both `cli` and `vscode` workspaces.
+
+- [ ] **Step 2: Coverage check on new files**
+
+Run: `npm run test -w @jolli.ai/cli -- --coverage --include 'src/core/Copilot*.ts' --include 'src/core/SqliteHelpers.ts'`
+Expected: each new file ≥97% statements / ≥96% branches.
+
+If a file dips below: add broken-fixture tests for the defensive branches (e.g. drop a `cwd` row to trigger `!Number.isFinite` skip; corrupt a row to trigger malformed-row skip). Match the approach from Cursor PR #65 (see spec § Testing strategy).
+
+### Task 9.2: Live smoke test
+
+- [ ] **Step 1: Run status against the live `~/.copilot` DB**
+
+```bash
+cd /Users/flyer/jolli/code/jollimemory
+npm run cli -- status
+```
+
+Expected: status shows a Copilot integration line with `detected: true`, `enabled: true`, sessions ≥0.
+
+- [ ] **Step 2: Trigger one post-commit cycle**
+
+```bash
+echo "" >> docs/superpowers/plans/2026-05-05-copilot-cli-support.md
+git add docs/superpowers/plans/2026-05-05-copilot-cli-support.md
+git commit -s -m "test: trigger jolli post-commit pipeline for Copilot smoke check"
+```
+
+Watch the worker log (path documented in `cli/src/Logger.ts`) for `Discovered N Copilot session(s)` and `Read Copilot session …`.
+
+- [ ] **Step 3: Revert the smoke commit**
+
+```bash
+git reset --hard HEAD~1
+```
+
+### Task 9.3: PR
+
+- [ ] **Step 1: Verify branch state**
+
+```bash
+git status
+git log --oneline main..HEAD
+```
+
+Expected: 9 feature commits + 3 docs commits.
+
+- [ ] **Step 2: Push + open PR**
+
+```bash
+git push -u origin feature-support-copilot
+gh pr create --title "Add GitHub Copilot CLI as a transcript source" --body "$(cat <<'EOF'
+## Summary
+
+- Adds Copilot CLI as the sixth transcript source (discovery-based, like OpenCode/Cursor).
+- Reads `~/.copilot/session-store.db` via `node:sqlite` (WAL-safe); workspace match is exact via the DB's own `cwd` column.
+- Extracts a shared `SqliteHelpers` module from `OpenCodeSessionDiscoverer` (pure refactor) so future SQLite-backed sources don't duplicate the open / version-gate / classify logic. Coordinated with PR #65.
+
+## Spec
+
+`docs/superpowers/specs/2026-05-05-copilot-cli-support-design.md`
+
+## Intentionally not changed
+
+- `~/.copilot/session-state/<id>/checkpoints/` — Copilot's own conversation-compression nodes are NOT ingested. Slicing mismatch with git commits, optional existence, and a larger drift surface than `turns`. Spec § "Intentionally not done" lists the supplemental-context follow-up path.
+- `session_files`, `session_refs`, FTS5 `search_index` — not read.
+- Hook-based integration — Copilot CLI exposes no hook surface; discovery only.
+- Windows live-CI verification — code path supported, deferred to first user report.
+- New top-level dependency — none.
+
+## Test plan
+
+- [ ] `npm run all` passes (build + lint + test in both workspaces).
+- [ ] Coverage on new files ≥97% statements / ≥96% branches.
+- [ ] `jolli status` shows the Copilot Integration row.
+- [ ] After a real `git commit -s`, queue worker log shows `Discovered N Copilot session(s)` and `Read Copilot session …`.
+- [ ] VSCode Settings: Copilot toggle renders, dirty-detects, validates "at least one integration", round-trips.
+- [ ] VSCode Status panel: Copilot row + scan-error variant render correctly.
+- [ ] OpenCode tests stay green — no regression.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Self-review
+
+- Every code step shows the actual code to write — no "implement appropriately".
+- Every test step shows test code and the expected fail/pass outcome of the next step.
+- File paths are absolute from repo root; line numbers were taken from a verified read of main as of `f9b07415`.
+- TDD ordering: failing test → minimal implementation → verify pass → commit.
+- The `SqliteHelpers` extraction is its own commit (Phase 0) so PR #65's conflict resolution stays mechanical.
+- Phase 1 (core modules) needs Phase 2 (Types widening) for typecheck — the plan handles this by landing both in one commit, called out at the start of Phase 1+2.
+- Test fixtures use `db.prepare(sql).run()` per single-statement to satisfy node:sqlite's API (DatabaseSync.prepare requires single statements; this is also why we don't show a multi-statement `db.exec(...)` form).
+- Coverage gate is checked explicitly in Phase 9; if any new file dips, the plan tells the engineer to add broken-fixture tests Cursor-style.

--- a/docs/superpowers/plans/2026-05-06-copilot-chat-support.md
+++ b/docs/superpowers/plans/2026-05-06-copilot-chat-support.md
@@ -1,0 +1,2433 @@
+# VS Code Copilot Chat Support Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add VS Code Copilot Chat as a seventh transcript source, sharing the existing `copilotEnabled` flag with Copilot CLI but isolated as `"copilot-chat"` in the source enum and pipeline.
+
+**Architecture:** Extract a shared `VscodeWorkspaceLocator` so Cursor and Copilot Chat both resolve workspace hashes through one module. Read sessions from per-workspace `chatSessions/<id>.jsonl` files in vscode workspaceStorage. JSONL is a JSON-document patch log, not message stream — implement a small in-place patch replayer (kind 0/1/2). Transcript reader extracts `requests[].message.text` and flattened `response[]`.
+
+**Tech Stack:** TypeScript (cli workspace), node:fs/promises, vitest (≥97% coverage), biome (tab indent, 120 col), Node 22.5+. No new runtime deps.
+
+**Spec:** [`docs/superpowers/specs/2026-05-06-copilot-chat-support-design.md`](../specs/2026-05-06-copilot-chat-support-design.md)
+
+**Conventions used throughout this plan:**
+- Code style: tabs (4-wide), 120-col limit, biome `noExplicitAny: error`, `useImportType: warn`
+- Test layout: each `Foo.ts` has a sibling `Foo.test.ts`; use `vi.mock` for filesystem and module-level dependencies
+- Test commands: `npm run test -w @jolli.ai/cli -- <path> -t "<test name>"` for single test; `npm run test -w @jolli.ai/cli` for full
+- Coverage gate: cli workspace enforces 97% statements/lines/branches/functions
+- Commit format: imperative subject, no conventional-commit prefix (e.g. "Add VscodeWorkspaceLocator shared module"). Always use `git commit -s` for DCO sign-off.
+
+---
+
+## Task 1: Create `VscodeWorkspaceLocator` shared module
+
+Extract per-platform vscode user-data path resolution and workspace.json scanning into one module that takes a `flavor: "Cursor" | "Code"` parameter. This module will be consumed by both Cursor (existing) and Copilot Chat (new).
+
+**Files:**
+- Create: `cli/src/core/VscodeWorkspaceLocator.ts`
+- Create: `cli/src/core/VscodeWorkspaceLocator.test.ts`
+
+- [ ] **Step 1: Write failing tests for path resolution**
+
+```typescript
+// cli/src/core/VscodeWorkspaceLocator.test.ts
+import { join } from "node:path";
+import { describe, expect, it, vi } from "vitest";
+
+const { mockHomedir, mockPlatform } = vi.hoisted(() => ({
+	mockHomedir: vi.fn().mockReturnValue("/Users/test"),
+	mockPlatform: vi.fn().mockReturnValue("darwin"),
+}));
+
+vi.mock("node:os", async (importOriginal) => {
+	const original = await importOriginal<typeof import("node:os")>();
+	return { ...original, homedir: mockHomedir, platform: mockPlatform };
+});
+
+describe("getVscodeUserDataDir", () => {
+	it("returns ~/Library/Application Support/Code on darwin", async () => {
+		mockPlatform.mockReturnValue("darwin");
+		const { getVscodeUserDataDir } = await import("./VscodeWorkspaceLocator.js");
+		expect(getVscodeUserDataDir("Code")).toBe("/Users/test/Library/Application Support/Code");
+	});
+
+	it("returns ~/Library/Application Support/Cursor on darwin for Cursor flavor", async () => {
+		mockPlatform.mockReturnValue("darwin");
+		const { getVscodeUserDataDir } = await import("./VscodeWorkspaceLocator.js");
+		expect(getVscodeUserDataDir("Cursor")).toBe("/Users/test/Library/Application Support/Cursor");
+	});
+
+	it("returns %APPDATA%/Code on win32", async () => {
+		mockPlatform.mockReturnValue("win32");
+		mockHomedir.mockReturnValue("C:\\Users\\test");
+		const prev = process.env.APPDATA;
+		process.env.APPDATA = "C:\\Users\\test\\AppData\\Roaming";
+		try {
+			const { getVscodeUserDataDir } = await import("./VscodeWorkspaceLocator.js");
+			expect(getVscodeUserDataDir("Code")).toBe(join("C:\\Users\\test\\AppData\\Roaming", "Code"));
+		} finally {
+			if (prev === undefined) delete process.env.APPDATA;
+			else process.env.APPDATA = prev;
+		}
+	});
+
+	it("falls back to ~/AppData/Roaming/Code on win32 when APPDATA is unset", async () => {
+		mockPlatform.mockReturnValue("win32");
+		mockHomedir.mockReturnValue("C:\\Users\\test");
+		const prev = process.env.APPDATA;
+		delete process.env.APPDATA;
+		try {
+			const { getVscodeUserDataDir } = await import("./VscodeWorkspaceLocator.js");
+			expect(getVscodeUserDataDir("Code")).toBe(join("C:\\Users\\test", "AppData", "Roaming", "Code"));
+		} finally {
+			if (prev !== undefined) process.env.APPDATA = prev;
+		}
+	});
+
+	it("returns ~/.config/Code on linux and other unix-like platforms", async () => {
+		mockPlatform.mockReturnValue("linux");
+		const { getVscodeUserDataDir } = await import("./VscodeWorkspaceLocator.js");
+		expect(getVscodeUserDataDir("Code")).toBe("/Users/test/.config/Code");
+	});
+
+	it("respects an explicit home override", async () => {
+		mockPlatform.mockReturnValue("darwin");
+		const { getVscodeUserDataDir } = await import("./VscodeWorkspaceLocator.js");
+		expect(getVscodeUserDataDir("Code", "/custom/home")).toBe(
+			"/custom/home/Library/Application Support/Code",
+		);
+	});
+});
+
+describe("getVscodeWorkspaceStorageDir", () => {
+	it("appends User/workspaceStorage to the user data dir", async () => {
+		mockPlatform.mockReturnValue("darwin");
+		const { getVscodeWorkspaceStorageDir } = await import("./VscodeWorkspaceLocator.js");
+		expect(getVscodeWorkspaceStorageDir("Code")).toBe(
+			"/Users/test/Library/Application Support/Code/User/workspaceStorage",
+		);
+	});
+});
+
+describe("normalizePathForMatch", () => {
+	it("strips trailing slashes", async () => {
+		mockPlatform.mockReturnValue("linux");
+		const { normalizePathForMatch } = await import("./VscodeWorkspaceLocator.js");
+		expect(normalizePathForMatch("/a/b/c/")).toBe("/a/b/c");
+		expect(normalizePathForMatch("/a/b/c////")).toBe("/a/b/c");
+		expect(normalizePathForMatch("/a/b/c")).toBe("/a/b/c");
+	});
+
+	it("lowercases on darwin", async () => {
+		mockPlatform.mockReturnValue("darwin");
+		const { normalizePathForMatch } = await import("./VscodeWorkspaceLocator.js");
+		expect(normalizePathForMatch("/Users/Foo/Bar")).toBe("/users/foo/bar");
+	});
+
+	it("lowercases on win32", async () => {
+		mockPlatform.mockReturnValue("win32");
+		const { normalizePathForMatch } = await import("./VscodeWorkspaceLocator.js");
+		expect(normalizePathForMatch("C:\\Users\\Test")).toBe("c:\\users\\test");
+	});
+
+	it("preserves case on linux", async () => {
+		mockPlatform.mockReturnValue("linux");
+		const { normalizePathForMatch } = await import("./VscodeWorkspaceLocator.js");
+		expect(normalizePathForMatch("/Users/Foo")).toBe("/Users/Foo");
+	});
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npm run test -w @jolli.ai/cli -- src/core/VscodeWorkspaceLocator.test.ts`
+Expected: FAIL — module does not exist yet.
+
+- [ ] **Step 3: Implement basic path helpers**
+
+```typescript
+// cli/src/core/VscodeWorkspaceLocator.ts
+/**
+ * VscodeWorkspaceLocator
+ *
+ * Per-platform path resolution and workspace.json scanning for VS Code-family
+ * user data directories. Used by both Cursor (`flavor: "Cursor"`) and VS Code
+ * Copilot Chat (`flavor: "Code"`) integrations. Adding a new vscode fork
+ * (Insiders, Code-OSS, Windsurf, …) requires only extending the flavor union.
+ *
+ * Public symbols:
+ *   - getVscodeUserDataDir(flavor, home?)
+ *   - getVscodeWorkspaceStorageDir(flavor, home?)
+ *   - findVscodeWorkspaceHash(flavor, projectDir)
+ *   - normalizePathForMatch(p)
+ */
+
+import { readdir, readFile } from "node:fs/promises";
+import { homedir, platform } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { createLogger } from "../Logger.js";
+
+const log = createLogger("VscodeWorkspaceLocator");
+
+export type VscodeFlavor = "Cursor" | "Code";
+
+/**
+ * Returns the VS Code-family user-data root for the current platform.
+ *
+ *   darwin   ~/Library/Application Support/<flavor>
+ *   linux    ~/.config/<flavor>
+ *   win32    %APPDATA%/<flavor>  (fallback to ~/AppData/Roaming/<flavor>)
+ */
+export function getVscodeUserDataDir(flavor: VscodeFlavor, home: string = homedir()): string {
+	switch (platform()) {
+		case "darwin":
+			return join(home, "Library", "Application Support", flavor);
+		case "win32":
+			return join(process.env.APPDATA ?? join(home, "AppData", "Roaming"), flavor);
+		default:
+			return join(home, ".config", flavor);
+	}
+}
+
+/** Returns the workspaceStorage dir for the given flavor. */
+export function getVscodeWorkspaceStorageDir(flavor: VscodeFlavor, home?: string): string {
+	return join(getVscodeUserDataDir(flavor, home), "User", "workspaceStorage");
+}
+
+/**
+ * Normalises a filesystem path for workspace matching.
+ * - Strips trailing slashes (linear-time loop, not regex — avoids CodeQL polynomial-redos
+ *   warnings on JSON-loaded paths).
+ * - Lowercases on case-insensitive platforms (darwin, win32).
+ */
+export function normalizePathForMatch(p: string): string {
+	let end = p.length;
+	while (end > 0 && (p[end - 1] === "/" || p[end - 1] === "\\")) {
+		end--;
+	}
+	const trimmed = p.slice(0, end);
+	const os = platform();
+	return os === "darwin" || os === "win32" ? trimmed.toLowerCase() : trimmed;
+}
+```
+
+- [ ] **Step 4: Run tests to verify path helpers pass**
+
+Run: `npm run test -w @jolli.ai/cli -- src/core/VscodeWorkspaceLocator.test.ts`
+Expected: PASS for all `getVscodeUserDataDir`, `getVscodeWorkspaceStorageDir`, `normalizePathForMatch` tests.
+
+- [ ] **Step 5: Add tests for `findVscodeWorkspaceHash`**
+
+Append to `VscodeWorkspaceLocator.test.ts`:
+
+```typescript
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+
+describe("findVscodeWorkspaceHash", () => {
+	let tmpRoot: string;
+
+	beforeEach(() => {
+		tmpRoot = mkdtempSync(join(tmpdir(), "vscode-locator-"));
+		mockPlatform.mockReturnValue("darwin");
+		mockHomedir.mockReturnValue(tmpRoot);
+	});
+
+	afterEach(() => {
+		rmSync(tmpRoot, { recursive: true, force: true });
+	});
+
+	function makeWorkspaceEntry(flavor: VscodeFlavor, wsHash: string, content: object | null): void {
+		const dir = join(tmpRoot, "Library", "Application Support", flavor, "User", "workspaceStorage", wsHash);
+		mkdirSync(dir, { recursive: true });
+		if (content !== null) {
+			writeFileSync(join(dir, "workspace.json"), JSON.stringify(content));
+		}
+	}
+
+	it("returns the hash for a single-folder workspace whose folder URI matches projectDir", async () => {
+		makeWorkspaceEntry("Code", "abc123", { folder: "file:///Users/test/myproject" });
+		const { findVscodeWorkspaceHash } = await import("./VscodeWorkspaceLocator.js");
+		expect(await findVscodeWorkspaceHash("Code", "/Users/test/myproject")).toBe("abc123");
+	});
+
+	it("matches case-insensitively on darwin", async () => {
+		makeWorkspaceEntry("Code", "abc123", { folder: "file:///Users/Test/MyProject" });
+		const { findVscodeWorkspaceHash } = await import("./VscodeWorkspaceLocator.js");
+		expect(await findVscodeWorkspaceHash("Code", "/users/test/myproject")).toBe("abc123");
+	});
+
+	it("returns null when no workspace.json folder URI matches projectDir", async () => {
+		makeWorkspaceEntry("Code", "abc123", { folder: "file:///Users/test/other" });
+		const { findVscodeWorkspaceHash } = await import("./VscodeWorkspaceLocator.js");
+		expect(await findVscodeWorkspaceHash("Code", "/Users/test/myproject")).toBeNull();
+	});
+
+	it("skips entries whose workspace.json has a multi-root `workspace` URI instead of a `folder` URI", async () => {
+		makeWorkspaceEntry("Code", "multi", { workspace: "file:///Users/test/x.code-workspace" });
+		makeWorkspaceEntry("Code", "single", { folder: "file:///Users/test/myproject" });
+		const { findVscodeWorkspaceHash } = await import("./VscodeWorkspaceLocator.js");
+		expect(await findVscodeWorkspaceHash("Code", "/Users/test/myproject")).toBe("single");
+	});
+
+	it("skips entries with no workspace.json", async () => {
+		makeWorkspaceEntry("Code", "empty", null);
+		makeWorkspaceEntry("Code", "single", { folder: "file:///Users/test/myproject" });
+		const { findVscodeWorkspaceHash } = await import("./VscodeWorkspaceLocator.js");
+		expect(await findVscodeWorkspaceHash("Code", "/Users/test/myproject")).toBe("single");
+	});
+
+	it("skips entries whose folder URI is unparseable", async () => {
+		makeWorkspaceEntry("Code", "bad", { folder: "garbage:///not-a-uri" });
+		makeWorkspaceEntry("Code", "good", { folder: "file:///Users/test/myproject" });
+		const { findVscodeWorkspaceHash } = await import("./VscodeWorkspaceLocator.js");
+		expect(await findVscodeWorkspaceHash("Code", "/Users/test/myproject")).toBe("good");
+	});
+
+	it("returns null when workspaceStorage dir doesn't exist", async () => {
+		const { findVscodeWorkspaceHash } = await import("./VscodeWorkspaceLocator.js");
+		expect(await findVscodeWorkspaceHash("Code", "/Users/test/myproject")).toBeNull();
+	});
+
+	it("isolates flavors — a Cursor entry doesn't match a Code lookup", async () => {
+		makeWorkspaceEntry("Cursor", "cursor1", { folder: "file:///Users/test/myproject" });
+		const { findVscodeWorkspaceHash } = await import("./VscodeWorkspaceLocator.js");
+		expect(await findVscodeWorkspaceHash("Code", "/Users/test/myproject")).toBeNull();
+		expect(await findVscodeWorkspaceHash("Cursor", "/Users/test/myproject")).toBe("cursor1");
+	});
+});
+```
+
+Add the missing imports at the top of the test file: `import { afterEach, beforeEach } from "vitest";` (vitest re-exports both).
+
+- [ ] **Step 6: Implement `findVscodeWorkspaceHash`**
+
+Append to `VscodeWorkspaceLocator.ts`:
+
+```typescript
+/**
+ * Scans the workspaceStorage directory for an entry whose `workspace.json` has
+ * a `folder` URI that resolves to projectDir. Returns the entry name (workspace
+ * hash) on match, or null when no match is found.
+ *
+ * Single-folder workspaces only — entries with a `workspace` field instead of
+ * `folder` (multi-root .code-workspace files) are skipped silently.
+ */
+export async function findVscodeWorkspaceHash(
+	flavor: VscodeFlavor,
+	projectDir: string,
+): Promise<string | null> {
+	const wsStorageDir = getVscodeWorkspaceStorageDir(flavor);
+
+	let entries: string[];
+	try {
+		entries = await readdir(wsStorageDir);
+	} catch {
+		log.debug("%s workspaceStorage not readable at %s", flavor, wsStorageDir);
+		return null;
+	}
+
+	const target = normalizePathForMatch(projectDir);
+
+	for (const entry of entries) {
+		const wsJsonPath = join(wsStorageDir, entry, "workspace.json");
+		let folderUri: string | undefined;
+		try {
+			const raw = await readFile(wsJsonPath, "utf8");
+			const parsed = JSON.parse(raw) as Record<string, unknown>;
+			folderUri = typeof parsed.folder === "string" ? parsed.folder : undefined;
+		} catch {
+			continue;
+		}
+
+		if (!folderUri || !folderUri.startsWith("file://")) {
+			continue;
+		}
+
+		let folderPath: string;
+		try {
+			folderPath = fileURLToPath(folderUri);
+		} catch {
+			log.warn("%s workspace %s has unparseable folder URI: %s", flavor, entry, folderUri);
+			continue;
+		}
+
+		if (normalizePathForMatch(folderPath) === target) {
+			return entry;
+		}
+	}
+
+	return null;
+}
+```
+
+- [ ] **Step 7: Run all VscodeWorkspaceLocator tests**
+
+Run: `npm run test -w @jolli.ai/cli -- src/core/VscodeWorkspaceLocator.test.ts`
+Expected: ALL PASS.
+
+- [ ] **Step 8: Run typecheck and biome**
+
+Run: `npm run typecheck:cli && npm run lint -- --files-include="cli/src/core/VscodeWorkspaceLocator*"`
+Expected: 0 errors. If unused imports flagged, remove them.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add cli/src/core/VscodeWorkspaceLocator.ts cli/src/core/VscodeWorkspaceLocator.test.ts
+git commit -s -m "Add VscodeWorkspaceLocator shared module"
+```
+
+---
+
+## Task 2: Migrate `CursorDetector` to use `VscodeWorkspaceLocator`
+
+`CursorDetector.ts` currently has its own copies of `getCursorUserDataDir`, `getCursorGlobalDbPath`, `getCursorWorkspaceStorageDir`. Replace the path resolution with thin wrappers over the shared locator. Keep all public symbols and signatures unchanged so no downstream import breaks.
+
+**Files:**
+- Modify: `cli/src/core/CursorDetector.ts`
+- Verify: `cli/src/core/CursorDetector.test.ts` (no changes; existing tests must still pass)
+
+- [ ] **Step 1: Refactor `CursorDetector.ts`**
+
+Replace the body of `cli/src/core/CursorDetector.ts` (preserve `isCursorInstalled` semantics):
+
+```typescript
+/**
+ * Cursor Detector
+ *
+ * Detects Cursor presence by checking for its global state database. Path
+ * resolution delegates to VscodeWorkspaceLocator with `flavor: "Cursor"` —
+ * shared with VS Code Copilot Chat (`flavor: "Code"`).
+ */
+
+import { stat } from "node:fs/promises";
+import { join } from "node:path";
+import { createLogger } from "../Logger.js";
+import { hasNodeSqliteSupport } from "./SqliteHelpers.js";
+import { getVscodeUserDataDir, getVscodeWorkspaceStorageDir } from "./VscodeWorkspaceLocator.js";
+
+const log = createLogger("CursorDetector");
+
+/**
+ * Returns the Cursor user-data root directory for the current platform.
+ * Thin wrapper over VscodeWorkspaceLocator.getVscodeUserDataDir("Cursor", …).
+ */
+function getCursorUserDataDir(home?: string): string {
+	return getVscodeUserDataDir("Cursor", home);
+}
+
+/** Returns the path to Cursor's global state database. */
+export function getCursorGlobalDbPath(home?: string): string {
+	return join(getCursorUserDataDir(home), "User", "globalStorage", "state.vscdb");
+}
+
+/** Returns the path to Cursor's workspace storage directory. */
+export function getCursorWorkspaceStorageDir(home?: string): string {
+	return getVscodeWorkspaceStorageDir("Cursor", home);
+}
+
+/**
+ * Checks whether Cursor is installed AND the current runtime can read its DB.
+ * Returns false on Node <22.5 (no built-in node:sqlite).
+ */
+export async function isCursorInstalled(): Promise<boolean> {
+	if (!hasNodeSqliteSupport()) {
+		log.info(
+			"Cursor support disabled: this runtime is Node %s, requires 22.5+ for built-in SQLite",
+			process.versions.node,
+		);
+		return false;
+	}
+	const dbPath = getCursorGlobalDbPath();
+	try {
+		const fileStat = await stat(dbPath);
+		return fileStat.isFile();
+	} catch {
+		return false;
+	}
+}
+```
+
+- [ ] **Step 2: Run existing CursorDetector tests**
+
+Run: `npm run test -w @jolli.ai/cli -- src/core/CursorDetector.test.ts`
+Expected: ALL PASS (the public surface is unchanged; tests should not need updating).
+
+- [ ] **Step 3: Run typecheck**
+
+Run: `npm run typecheck:cli`
+Expected: 0 errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add cli/src/core/CursorDetector.ts
+git commit -s -m "Refactor CursorDetector to use VscodeWorkspaceLocator"
+```
+
+---
+
+## Task 3: Migrate `CursorSessionDiscoverer` to use `VscodeWorkspaceLocator`
+
+Replace `findCursorWorkspaceHash` and `normalizePathForMatch` with calls to the shared module. Keep `scanCursorSessions` and `discoverCursorSessions` signatures unchanged.
+
+**Files:**
+- Modify: `cli/src/core/CursorSessionDiscoverer.ts`
+- Verify: `cli/src/core/CursorSessionDiscoverer.test.ts` (existing tests must still pass)
+
+- [ ] **Step 1: Edit `CursorSessionDiscoverer.ts`**
+
+In `cli/src/core/CursorSessionDiscoverer.ts`:
+
+Replace the import line for `getCursorWorkspaceStorageDir`:
+
+```typescript
+import { getCursorGlobalDbPath } from "./CursorDetector.js";
+import { findVscodeWorkspaceHash, getVscodeWorkspaceStorageDir } from "./VscodeWorkspaceLocator.js";
+```
+
+Remove the imports of `readdir`, `readFile`, `fileURLToPath` if they are no longer used (the inlined `findCursorWorkspaceHash` and `normalizePathForMatch` will be deleted). Keep `stat` since `scanCursorSessions` still uses it for the global DB pre-flight.
+
+Replace the local `findCursorWorkspaceHash` function (currently around line 200-243) with a thin wrapper:
+
+```typescript
+async function findCursorWorkspaceHash(projectDir: string): Promise<string | null> {
+	return findVscodeWorkspaceHash("Cursor", projectDir);
+}
+```
+
+Replace the `getCursorWorkspaceStorageDir` import-and-use chain in `readCursorAnchorComposerIds` (line ~253) with a direct call to `getVscodeWorkspaceStorageDir("Cursor")`:
+
+```typescript
+async function readCursorAnchorComposerIds(wsHash: string): Promise<ReadonlyArray<string>> {
+	const wsStorageDir = getVscodeWorkspaceStorageDir("Cursor");
+	const wsDbPath = join(wsStorageDir, wsHash, "state.vscdb");
+	// ... rest unchanged
+}
+```
+
+Delete the local `normalizePathForMatch` function (currently lines ~305-316).
+
+- [ ] **Step 2: Run existing CursorSessionDiscoverer tests**
+
+Run: `npm run test -w @jolli.ai/cli -- src/core/CursorSessionDiscoverer.test.ts`
+Expected: ALL PASS. If a test mocks `readdir`/`readFile` directly to test workspace lookup, those mocks should now apply via the locator module.
+
+If tests fail because they mocked at `CursorSessionDiscoverer` level, update the mock target to `./VscodeWorkspaceLocator.js`. Show the exact mock change here only if a test fails — otherwise skip.
+
+- [ ] **Step 3: Run all Cursor-related tests**
+
+Run: `npm run test -w @jolli.ai/cli -- src/core/Cursor`
+Expected: ALL PASS.
+
+- [ ] **Step 4: Run typecheck**
+
+Run: `npm run typecheck:cli`
+Expected: 0 errors. Remove any newly-unused imports.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cli/src/core/CursorSessionDiscoverer.ts cli/src/core/CursorSessionDiscoverer.test.ts
+git commit -s -m "Refactor CursorSessionDiscoverer to use VscodeWorkspaceLocator"
+```
+
+---
+
+## Task 4: Create `CopilotChatDetector`
+
+Detects Copilot Chat presence by checking for vscode's `globalStorage/github.copilot-chat` directory. No SQLite gate — the storage format is JSONL.
+
+**Files:**
+- Create: `cli/src/core/CopilotChatDetector.ts`
+- Create: `cli/src/core/CopilotChatDetector.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+```typescript
+// cli/src/core/CopilotChatDetector.test.ts
+import { stat } from "node:fs/promises";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("node:fs/promises", async () => {
+	const actual = await vi.importActual<typeof import("node:fs/promises")>("node:fs/promises");
+	return { ...actual, stat: vi.fn() };
+});
+
+const { mockHomedir, mockPlatform } = vi.hoisted(() => ({
+	mockHomedir: vi.fn().mockReturnValue("/Users/test"),
+	mockPlatform: vi.fn().mockReturnValue("darwin"),
+}));
+
+vi.mock("node:os", async (importOriginal) => {
+	const original = await importOriginal<typeof import("node:os")>();
+	return { ...original, homedir: mockHomedir, platform: mockPlatform };
+});
+
+describe("CopilotChatDetector", () => {
+	beforeEach(() => {
+		mockHomedir.mockReturnValue("/Users/test");
+		mockPlatform.mockReturnValue("darwin");
+		vi.mocked(stat).mockReset();
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("getCopilotChatStorageDir returns vscode globalStorage path on darwin", async () => {
+		const { getCopilotChatStorageDir } = await import("./CopilotChatDetector.js");
+		expect(getCopilotChatStorageDir()).toBe(
+			"/Users/test/Library/Application Support/Code/User/globalStorage/github.copilot-chat",
+		);
+	});
+
+	it("isCopilotChatInstalled returns true when storage dir exists", async () => {
+		vi.mocked(stat).mockResolvedValue({ isDirectory: () => true } as Awaited<ReturnType<typeof stat>>);
+		const { isCopilotChatInstalled } = await import("./CopilotChatDetector.js");
+		await expect(isCopilotChatInstalled()).resolves.toBe(true);
+	});
+
+	it("isCopilotChatInstalled returns false when storage dir is missing", async () => {
+		vi.mocked(stat).mockRejectedValue(Object.assign(new Error("no dir"), { code: "ENOENT" }));
+		const { isCopilotChatInstalled } = await import("./CopilotChatDetector.js");
+		await expect(isCopilotChatInstalled()).resolves.toBe(false);
+	});
+
+	it("isCopilotChatInstalled returns false when path exists but is not a directory", async () => {
+		vi.mocked(stat).mockResolvedValue({ isDirectory: () => false } as Awaited<ReturnType<typeof stat>>);
+		const { isCopilotChatInstalled } = await import("./CopilotChatDetector.js");
+		await expect(isCopilotChatInstalled()).resolves.toBe(false);
+	});
+
+	it("isCopilotChatInstalled returns false on permission errors", async () => {
+		vi.mocked(stat).mockRejectedValue(Object.assign(new Error("permission denied"), { code: "EACCES" }));
+		const { isCopilotChatInstalled } = await import("./CopilotChatDetector.js");
+		await expect(isCopilotChatInstalled()).resolves.toBe(false);
+	});
+});
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run: `npm run test -w @jolli.ai/cli -- src/core/CopilotChatDetector.test.ts`
+Expected: FAIL — module does not exist.
+
+- [ ] **Step 3: Implement `CopilotChatDetector.ts`**
+
+```typescript
+// cli/src/core/CopilotChatDetector.ts
+/**
+ * VS Code Copilot Chat detector.
+ *
+ * Detects Copilot Chat by the presence of vscode's
+ * <userDataDir>/User/globalStorage/github.copilot-chat directory.
+ * No SQLite gate — chat sessions are JSONL files (plain JSON parsing).
+ */
+
+import { stat } from "node:fs/promises";
+import { join } from "node:path";
+import { createLogger } from "../Logger.js";
+import { getVscodeUserDataDir } from "./VscodeWorkspaceLocator.js";
+
+const log = createLogger("CopilotChatDetector");
+
+/** Returns vscode's globalStorage/github.copilot-chat directory path. */
+export function getCopilotChatStorageDir(home?: string): string {
+	return join(getVscodeUserDataDir("Code", home), "User", "globalStorage", "github.copilot-chat");
+}
+
+/**
+ * Returns true when vscode's Copilot Chat storage directory is present.
+ * Returns false on ENOENT, permission errors, or when the path exists but
+ * isn't a directory.
+ */
+export async function isCopilotChatInstalled(): Promise<boolean> {
+	const dir = getCopilotChatStorageDir();
+	try {
+		const fileStat = await stat(dir);
+		return fileStat.isDirectory();
+	} catch (error: unknown) {
+		const code = (error as NodeJS.ErrnoException).code;
+		if (code !== "ENOENT") {
+			log.warn("Copilot Chat dir stat failed (%s): %s", code ?? "unknown", (error as Error).message);
+		}
+		return false;
+	}
+}
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `npm run test -w @jolli.ai/cli -- src/core/CopilotChatDetector.test.ts`
+Expected: ALL PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cli/src/core/CopilotChatDetector.ts cli/src/core/CopilotChatDetector.test.ts
+git commit -s -m "Add CopilotChatDetector"
+```
+
+---
+
+## Task 5: Update `TranscriptSource` enum and `SessionTracker` filter
+
+Add `"copilot-chat"` to `TranscriptSource` and extend the SessionTracker filter so `copilotEnabled === false` excludes both `"copilot"` and `"copilot-chat"`. The `StatusInfo` field additions (`copilotChatDetected`, `copilotChatScanError`) are deferred to Task 11 so this commit can typecheck without depending on `CopilotChatTranscriptReader.ts` (which is created later).
+
+**Files:**
+- Modify: `cli/src/Types.ts:10` (TranscriptSource)
+- Modify: `cli/src/core/SessionTracker.ts:172-174` (filter)
+- Modify: `cli/src/core/SessionTracker.test.ts` (add tests)
+
+- [ ] **Step 1: Update `TranscriptSource` enum**
+
+Edit `cli/src/Types.ts:10`. Replace:
+
+```typescript
+export type TranscriptSource = "claude" | "codex" | "gemini" | "opencode" | "cursor" | "copilot";
+```
+
+with:
+
+```typescript
+export type TranscriptSource = "claude" | "codex" | "gemini" | "opencode" | "cursor" | "copilot" | "copilot-chat";
+```
+
+- [ ] **Step 2: Write failing test for filter extension**
+
+In `cli/src/core/SessionTracker.test.ts`, add a new test inside the `filterSessionsByEnabledIntegrations` describe block:
+
+```typescript
+it("excludes copilot-chat sessions when copilotEnabled is false", () => {
+	const sessions: ReadonlyArray<SessionInfo> = [
+		{ sessionId: "a", transcriptPath: "/a", updatedAt: "2026-05-06T00:00:00Z", source: "copilot" },
+		{ sessionId: "b", transcriptPath: "/b", updatedAt: "2026-05-06T00:00:00Z", source: "copilot-chat" },
+		{ sessionId: "c", transcriptPath: "/c", updatedAt: "2026-05-06T00:00:00Z", source: "claude" },
+	];
+	const filtered = filterSessionsByEnabledIntegrations(sessions, { copilotEnabled: false });
+	expect(filtered.map((s) => s.sessionId)).toEqual(["c"]);
+});
+
+it("includes copilot-chat sessions when copilotEnabled is unset (auto-detect)", () => {
+	const sessions: ReadonlyArray<SessionInfo> = [
+		{ sessionId: "b", transcriptPath: "/b", updatedAt: "2026-05-06T00:00:00Z", source: "copilot-chat" },
+	];
+	const filtered = filterSessionsByEnabledIntegrations(sessions, {});
+	expect(filtered.map((s) => s.sessionId)).toEqual(["b"]);
+});
+```
+
+- [ ] **Step 3: Run tests to verify the new tests fail**
+
+Run: `npm run test -w @jolli.ai/cli -- src/core/SessionTracker.test.ts -t "copilot-chat"`
+Expected: FAIL — the filter doesn't yet exclude `"copilot-chat"`.
+
+- [ ] **Step 4: Update the filter**
+
+Edit `cli/src/core/SessionTracker.ts:172-174`. Replace:
+
+```typescript
+	if (config.copilotEnabled === false) {
+		filtered = filtered.filter((s) => s.source !== "copilot");
+	}
+```
+
+with:
+
+```typescript
+	if (config.copilotEnabled === false) {
+		filtered = filtered.filter((s) => s.source !== "copilot" && s.source !== "copilot-chat");
+	}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `npm run test -w @jolli.ai/cli -- src/core/SessionTracker.test.ts`
+Expected: ALL PASS (existing + 2 new).
+
+- [ ] **Step 6: Run typecheck**
+
+Run: `npm run typecheck:cli`
+Expected: 0 errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add cli/src/Types.ts cli/src/core/SessionTracker.ts cli/src/core/SessionTracker.test.ts
+git commit -s -m "Add copilot-chat to TranscriptSource and SessionTracker filter"
+```
+
+---
+
+## Task 6: Implement `setAtPath` and `deleteAtPath` (patch primitives)
+
+These are the primitives the patch replayer uses. Mutate the document in place. Numeric path segments index arrays; string segments key objects.
+
+**Files:**
+- Create: `cli/src/core/CopilotChatTranscriptReader.ts` (initial: just primitives)
+- Create: `cli/src/core/CopilotChatTranscriptReader.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+```typescript
+// cli/src/core/CopilotChatTranscriptReader.test.ts
+import { describe, expect, it } from "vitest";
+import { _deleteAtPath, _setAtPath } from "./CopilotChatTranscriptReader.js";
+
+describe("_setAtPath", () => {
+	it("sets a leaf string key on an object", () => {
+		const doc: Record<string, unknown> = { a: { b: 1 } };
+		_setAtPath(doc, ["a", "b"], 42);
+		expect(doc).toEqual({ a: { b: 42 } });
+	});
+
+	it("creates intermediate objects when string segments are missing", () => {
+		const doc: Record<string, unknown> = {};
+		_setAtPath(doc, ["a", "b", "c"], "x");
+		expect(doc).toEqual({ a: { b: { c: "x" } } });
+	});
+
+	it("creates intermediate arrays when next segment is numeric", () => {
+		const doc: Record<string, unknown> = {};
+		_setAtPath(doc, ["requests", 0, "message"], { text: "hi" });
+		expect(doc).toEqual({ requests: [{ message: { text: "hi" } }] });
+	});
+
+	it("appends to an existing array at the next index", () => {
+		const doc: Record<string, unknown> = { requests: [{ message: { text: "first" } }] };
+		_setAtPath(doc, ["requests", 1], { message: { text: "second" } });
+		expect((doc.requests as unknown[]).length).toBe(2);
+		expect((doc.requests as unknown[])[1]).toEqual({ message: { text: "second" } });
+	});
+
+	it("grows arrays with sparse undefined slots when index is past length", () => {
+		const doc: Record<string, unknown> = { requests: [] };
+		_setAtPath(doc, ["requests", 2], { v: 1 });
+		expect((doc.requests as unknown[]).length).toBe(3);
+		expect((doc.requests as unknown[])[0]).toBeUndefined();
+		expect((doc.requests as unknown[])[2]).toEqual({ v: 1 });
+	});
+
+	it("overwrites an existing leaf value", () => {
+		const doc: Record<string, unknown> = { a: 1 };
+		_setAtPath(doc, ["a"], 2);
+		expect(doc).toEqual({ a: 2 });
+	});
+
+	it("handles empty path by replacing nothing (root replacement is replayPatches's job, not ours)", () => {
+		const doc: Record<string, unknown> = { a: 1 };
+		_setAtPath(doc, [], 99);
+		// Empty path is undefined behavior in patch terms — we expect no change here
+		// since the caller (replayPatches kind:0) handles root replacement directly.
+		expect(doc).toEqual({ a: 1 });
+	});
+});
+
+describe("_deleteAtPath", () => {
+	it("deletes an object property", () => {
+		const doc: Record<string, unknown> = { a: 1, b: 2 };
+		_deleteAtPath(doc, ["a"]);
+		expect(doc).toEqual({ b: 2 });
+	});
+
+	it("removes an array element via splice (preserves array semantics)", () => {
+		const doc: Record<string, unknown> = { a: [10, 20, 30] };
+		_deleteAtPath(doc, ["a", 1]);
+		expect(doc.a).toEqual([10, 30]);
+	});
+
+	it("is a no-op when the path doesn't exist", () => {
+		const doc: Record<string, unknown> = { a: 1 };
+		_deleteAtPath(doc, ["b", "c"]);
+		expect(doc).toEqual({ a: 1 });
+	});
+
+	it("is a no-op for empty path", () => {
+		const doc: Record<string, unknown> = { a: 1 };
+		_deleteAtPath(doc, []);
+		expect(doc).toEqual({ a: 1 });
+	});
+
+	it("is a no-op when array index is out of bounds", () => {
+		const doc: Record<string, unknown> = { a: [10, 20] };
+		_deleteAtPath(doc, ["a", 5]);
+		expect(doc.a).toEqual([10, 20]);
+	});
+});
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run: `npm run test -w @jolli.ai/cli -- src/core/CopilotChatTranscriptReader.test.ts`
+Expected: FAIL — module does not exist.
+
+- [ ] **Step 3: Implement primitives**
+
+```typescript
+// cli/src/core/CopilotChatTranscriptReader.ts
+/**
+ * VS Code Copilot Chat transcript reader.
+ *
+ * vscode persists each chat session as a JSONL document patch log:
+ *   line 0:  {kind:0, v:<initial document>}
+ *   line N:  {kind:1, k:[...path], v:<value>}   set at path
+ *   line N:  {kind:2, k:[...path]}              delete at path
+ *
+ * To reconstruct the conversation we replay all patches in order, then read
+ * `requests[]` from the final document. See spec
+ * docs/superpowers/specs/2026-05-06-copilot-chat-support-design.md.
+ */
+
+type PathSegment = string | number;
+
+/**
+ * Mutates `doc` in place by setting `value` at `path`. Creates intermediate
+ * objects/arrays as needed (next-segment-type decides container shape).
+ *
+ * Exported with the `_` prefix as a unit-test seam — replayPatches and
+ * readCopilotChatTranscript are the public contract; primitives are internal.
+ */
+export function _setAtPath(doc: unknown, path: PathSegment[], value: unknown): void {
+	if (path.length === 0) {
+		return; // Root replacement is replayPatches's responsibility (kind:0).
+	}
+	let cur = doc as Record<string | number, unknown>;
+	for (let i = 0; i < path.length - 1; i++) {
+		const seg = path[i];
+		const next = path[i + 1];
+		if (cur[seg] === undefined || cur[seg] === null) {
+			cur[seg] = typeof next === "number" ? [] : {};
+		}
+		cur = cur[seg] as Record<string | number, unknown>;
+	}
+	cur[path[path.length - 1]] = value;
+}
+
+/**
+ * Mutates `doc` in place by removing the value at `path`. No-op if the path
+ * doesn't exist or is empty. For array elements, uses `splice` so the array
+ * shifts (matching vscode's emitted semantics for `pendingRequests` cleanup).
+ */
+export function _deleteAtPath(doc: unknown, path: PathSegment[]): void {
+	if (path.length === 0) return;
+	let cur = doc as Record<string | number, unknown> | undefined;
+	for (let i = 0; i < path.length - 1; i++) {
+		if (cur === undefined || cur === null) return;
+		cur = cur[path[i]] as Record<string | number, unknown> | undefined;
+	}
+	if (cur === undefined || cur === null) return;
+	const last = path[path.length - 1];
+	if (Array.isArray(cur) && typeof last === "number") {
+		if (last >= 0 && last < cur.length) {
+			cur.splice(last, 1);
+		}
+		return;
+	}
+	delete cur[last];
+}
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `npm run test -w @jolli.ai/cli -- src/core/CopilotChatTranscriptReader.test.ts`
+Expected: ALL PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cli/src/core/CopilotChatTranscriptReader.ts cli/src/core/CopilotChatTranscriptReader.test.ts
+git commit -s -m "Add patch path primitives for Copilot Chat reader"
+```
+
+---
+
+## Task 7: Implement `replayPatches`
+
+Apply a series of patch events to build the final document.
+
+**Files:**
+- Modify: `cli/src/core/CopilotChatTranscriptReader.ts`
+- Modify: `cli/src/core/CopilotChatTranscriptReader.test.ts`
+
+- [ ] **Step 1: Add failing tests for `replayPatches`**
+
+Append to `CopilotChatTranscriptReader.test.ts`:
+
+```typescript
+import { _replayPatches } from "./CopilotChatTranscriptReader.js";
+
+describe("_replayPatches", () => {
+	it("returns empty doc when input is empty", () => {
+		expect(_replayPatches([])).toEqual({});
+	});
+
+	it("applies kind:0 as full document replacement", () => {
+		const lines = [JSON.stringify({ kind: 0, v: { foo: "bar", requests: [] } })];
+		expect(_replayPatches(lines)).toEqual({ foo: "bar", requests: [] });
+	});
+
+	it("applies kind:1 as set-at-path", () => {
+		const lines = [
+			JSON.stringify({ kind: 0, v: { requests: [] } }),
+			JSON.stringify({ kind: 1, k: ["requests", 0, "message"], v: { text: "hello" } }),
+		];
+		expect(_replayPatches(lines)).toEqual({ requests: [{ message: { text: "hello" } }] });
+	});
+
+	it("applies kind:2 as delete-at-path", () => {
+		const lines = [
+			JSON.stringify({ kind: 0, v: { pendingRequests: [{ id: "x" }] } }),
+			JSON.stringify({ kind: 2, k: ["pendingRequests", 0] }),
+		];
+		expect(_replayPatches(lines)).toEqual({ pendingRequests: [] });
+	});
+
+	it("applies patches in file order", () => {
+		const lines = [
+			JSON.stringify({ kind: 0, v: { a: 1 } }),
+			JSON.stringify({ kind: 1, k: ["a"], v: 2 }),
+			JSON.stringify({ kind: 1, k: ["a"], v: 3 }),
+		];
+		expect(_replayPatches(lines)).toEqual({ a: 3 });
+	});
+
+	it("warns and skips on unknown kind, leaving doc untouched", () => {
+		const lines = [
+			JSON.stringify({ kind: 0, v: { a: 1 } }),
+			JSON.stringify({ kind: 99, k: ["a"], v: "should-be-ignored" }),
+		];
+		expect(_replayPatches(lines)).toEqual({ a: 1 });
+	});
+
+	it("throws on JSON parse failure (caller handles mid-write)", () => {
+		const lines = [JSON.stringify({ kind: 0, v: {} }), "{not-json"];
+		expect(() => _replayPatches(lines)).toThrow();
+	});
+});
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run: `npm run test -w @jolli.ai/cli -- src/core/CopilotChatTranscriptReader.test.ts -t "_replayPatches"`
+Expected: FAIL — `_replayPatches` not exported.
+
+- [ ] **Step 3: Implement `_replayPatches`**
+
+Append to `CopilotChatTranscriptReader.ts` (after the primitives):
+
+```typescript
+import { createLogger } from "../Logger.js";
+
+const log = createLogger("CopilotChatReader");
+
+interface KindZeroEvent { kind: 0; v: unknown; }
+interface KindOneEvent { kind: 1; k: PathSegment[]; v: unknown; }
+interface KindTwoEvent { kind: 2; k: PathSegment[]; }
+type PatchEvent = KindZeroEvent | KindOneEvent | KindTwoEvent | { kind: number };
+
+/**
+ * Replays a JSONL patch log into a final document.
+ *
+ *   kind 0 → replace entire document with `v`
+ *   kind 1 → set `v` at path `k`
+ *   kind 2 → delete value at path `k`
+ *
+ * Unknown `kind` is logged and skipped (forward compatibility — vscode may add
+ * new event types in future versions). JSON parse errors are propagated so the
+ * caller can distinguish "mid-write" from "structurally broken file".
+ */
+export function _replayPatches(lines: ReadonlyArray<string>): unknown {
+	let doc: unknown = {};
+	for (const raw of lines) {
+		const evt = JSON.parse(raw) as PatchEvent;
+		switch (evt.kind) {
+			case 0:
+				doc = (evt as KindZeroEvent).v;
+				break;
+			case 1: {
+				const e = evt as KindOneEvent;
+				_setAtPath(doc, e.k, e.v);
+				break;
+			}
+			case 2: {
+				const e = evt as KindTwoEvent;
+				_deleteAtPath(doc, e.k);
+				break;
+			}
+			default:
+				log.warn("Unknown patch kind %s — skipping", evt.kind);
+				break;
+		}
+	}
+	return doc;
+}
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `npm run test -w @jolli.ai/cli -- src/core/CopilotChatTranscriptReader.test.ts`
+Expected: ALL PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cli/src/core/CopilotChatTranscriptReader.ts cli/src/core/CopilotChatTranscriptReader.test.ts
+git commit -s -m "Add replayPatches for Copilot Chat JSONL"
+```
+
+---
+
+## Task 8: Implement `readCopilotChatTranscript`
+
+Read a `.jsonl` session file, replay it, and emit `TranscriptEntry` records from `requests[]` past the cursor's `lineNumber` (re-purposed to mean "request count already consumed"). Throw on fs / parse / schema errors so the QueueWorker dispatch's existing try/catch handles them uniformly with the other readers.
+
+**Why match `TranscriptReadResult`:** the dispatch in `QueueWorker.ts:1521` accesses `result.newCursor.lineNumber` and `result.entries` (each with `role` + `content`). Returning anything else would force an adapter — match the existing contract instead.
+
+**Files:**
+- Modify: `cli/src/core/CopilotChatTranscriptReader.ts`
+- Modify: `cli/src/core/CopilotChatTranscriptReader.test.ts`
+
+- [ ] **Step 1: Add failing tests**
+
+Append to `CopilotChatTranscriptReader.test.ts`:
+
+```typescript
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach } from "vitest";
+import { readCopilotChatTranscript } from "./CopilotChatTranscriptReader.js";
+
+describe("readCopilotChatTranscript", () => {
+	let tmpRoot: string;
+
+	beforeEach(() => {
+		tmpRoot = mkdtempSync(join(tmpdir(), "copilot-chat-reader-"));
+	});
+
+	afterEach(() => {
+		rmSync(tmpRoot, { recursive: true, force: true });
+	});
+
+	function writeJsonl(name: string, events: object[]): string {
+		const path = join(tmpRoot, name);
+		writeFileSync(path, events.map((e) => JSON.stringify(e)).join("\n"));
+		return path;
+	}
+
+	it("returns empty entries for an init-only file (cursor.lineNumber stays 0)", async () => {
+		const path = writeJsonl("a.jsonl", [{ kind: 0, v: { requests: [] } }]);
+		const result = await readCopilotChatTranscript(path);
+		expect(result.entries).toEqual([]);
+		expect(result.newCursor.transcriptPath).toBe(path);
+		expect(result.newCursor.lineNumber).toBe(0);
+	});
+
+	it("emits one human + one assistant per request with content", async () => {
+		const events = [
+			{ kind: 0, v: { requests: [] } },
+			{ kind: 1, k: ["requests", 0, "message", "text"], v: "hello" },
+			{ kind: 1, k: ["requests", 0, "response"], v: [{ value: "hi there" }] },
+		];
+		const path = writeJsonl("b.jsonl", events);
+		const result = await readCopilotChatTranscript(path);
+		expect(result.entries).toEqual([
+			{ role: "human", content: "hello" },
+			{ role: "assistant", content: "hi there" },
+		]);
+		expect(result.newCursor.lineNumber).toBe(1);
+	});
+
+	it("flattens multi-chunk response[] into a single assistant entry", async () => {
+		const events = [
+			{ kind: 0, v: { requests: [] } },
+			{ kind: 1, k: ["requests", 0, "message", "text"], v: "explain" },
+			{ kind: 1, k: ["requests", 0, "response"], v: [{ value: "Part A " }, { value: "Part B" }] },
+		];
+		const path = writeJsonl("c.jsonl", events);
+		const result = await readCopilotChatTranscript(path);
+		expect(result.entries.find((e) => e.role === "assistant")?.content).toBe("Part A Part B");
+	});
+
+	it("only emits requests at index >= cursor.lineNumber", async () => {
+		const events = [
+			{ kind: 0, v: { requests: [] } },
+			{ kind: 1, k: ["requests", 0, "message", "text"], v: "first" },
+			{ kind: 1, k: ["requests", 0, "response"], v: [{ value: "r1" }] },
+			{ kind: 1, k: ["requests", 1, "message", "text"], v: "second" },
+			{ kind: 1, k: ["requests", 1, "response"], v: [{ value: "r2" }] },
+		];
+		const path = writeJsonl("d.jsonl", events);
+		const result = await readCopilotChatTranscript(path, {
+			transcriptPath: path,
+			lineNumber: 1,
+			updatedAt: "2026-05-06T00:00:00Z",
+		});
+		expect(result.entries).toEqual([
+			{ role: "human", content: "second" },
+			{ role: "assistant", content: "r2" },
+		]);
+		expect(result.newCursor.lineNumber).toBe(2);
+	});
+
+	it("skips requests with empty/missing message.text", async () => {
+		const events = [
+			{ kind: 0, v: { requests: [] } },
+			{ kind: 1, k: ["requests", 0, "message", "text"], v: "" },
+			{ kind: 1, k: ["requests", 0, "response"], v: [{ value: "answer" }] },
+		];
+		const path = writeJsonl("e.jsonl", events);
+		const result = await readCopilotChatTranscript(path);
+		expect(result.entries).toEqual([{ role: "assistant", content: "answer" }]);
+	});
+
+	it("skips requests with empty assistant response", async () => {
+		const events = [
+			{ kind: 0, v: { requests: [] } },
+			{ kind: 1, k: ["requests", 0, "message", "text"], v: "question" },
+			{ kind: 1, k: ["requests", 0, "response"], v: [] },
+		];
+		const path = writeJsonl("f.jsonl", events);
+		const result = await readCopilotChatTranscript(path);
+		expect(result.entries).toEqual([{ role: "human", content: "question" }]);
+	});
+
+	it("throws CopilotChatScanError on mid-write JSON parse failure (kind=parse)", async () => {
+		const path = join(tmpRoot, "g.jsonl");
+		writeFileSync(path, `${JSON.stringify({ kind: 0, v: { requests: [] } })}\n{not-json`);
+		await expect(readCopilotChatTranscript(path)).rejects.toThrow(/parse/);
+	});
+
+	it("throws CopilotChatScanError when file is missing (kind=fs)", async () => {
+		await expect(
+			readCopilotChatTranscript(join(tmpRoot, "does-not-exist.jsonl")),
+		).rejects.toThrow(/fs|ENOENT/i);
+	});
+
+	it("treats empty file as init-less doc → no entries, no throw", async () => {
+		const path = join(tmpRoot, "empty.jsonl");
+		writeFileSync(path, "");
+		const result = await readCopilotChatTranscript(path);
+		expect(result.entries).toEqual([]);
+	});
+
+	it("throws schema error when requests is not an array", async () => {
+		const path = writeJsonl("bad-shape.jsonl", [{ kind: 0, v: { requests: "not-an-array" } }]);
+		await expect(readCopilotChatTranscript(path)).rejects.toThrow(/schema|requests/);
+	});
+});
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run: `npm run test -w @jolli.ai/cli -- src/core/CopilotChatTranscriptReader.test.ts -t "readCopilotChatTranscript"`
+Expected: FAIL — `readCopilotChatTranscript` not exported.
+
+- [ ] **Step 3: Implement `readCopilotChatTranscript`**
+
+Append to `CopilotChatTranscriptReader.ts`:
+
+```typescript
+import { readFile, stat } from "node:fs/promises";
+import type { TranscriptCursor, TranscriptEntry, TranscriptReadResult } from "../Types.js";
+
+/** Structured error thrown by the Copilot Chat reader. Surfaced via `error.cause.kind`. */
+export interface CopilotChatScanError {
+	readonly kind: "parse" | "fs" | "schema" | "unknown";
+	readonly message: string;
+}
+
+/** Throws an Error with a `CopilotChatScanError` payload attached to .cause. */
+function throwScanError(kind: CopilotChatScanError["kind"], message: string): never {
+	const err = new Error(`Copilot Chat scan failed (${kind}): ${message}`);
+	(err as Error & { cause: CopilotChatScanError }).cause = { kind, message };
+	throw err;
+}
+
+interface ChatRequest {
+	message?: { text?: string };
+	response?: ReadonlyArray<{ value?: string }>;
+}
+
+/**
+ * Reads a vscode Copilot Chat session JSONL, replays patches into the final
+ * document, and emits TranscriptEntry records for `requests[i]` where
+ * i >= cursor.lineNumber. The cursor's `lineNumber` is re-purposed as
+ * "request count already consumed" — monotonic, matches the TranscriptCursor
+ * contract used by every other reader.
+ *
+ * Errors are thrown (not returned) so the QueueWorker dispatch's existing
+ * try/catch + continue path handles them uniformly. The cursor is not
+ * advanced on error: the next commit-time scan retries.
+ */
+export async function readCopilotChatTranscript(
+	transcriptPath: string,
+	cursor?: TranscriptCursor,
+): Promise<TranscriptReadResult> {
+	const fromIdx = cursor?.lineNumber ?? 0;
+
+	let raw: string;
+	try {
+		raw = await readFile(transcriptPath, "utf8");
+	} catch (error: unknown) {
+		throwScanError("fs", (error as Error).message);
+	}
+
+	const lines = raw.split("\n").filter((l) => l.length > 0);
+	if (lines.length === 0) {
+		const updatedAt = await stat(transcriptPath).then((s) => new Date(s.mtimeMs).toISOString());
+		return {
+			entries: [],
+			newCursor: { transcriptPath, lineNumber: 0, updatedAt },
+			totalLinesRead: 0,
+		};
+	}
+
+	let doc: unknown;
+	try {
+		doc = _replayPatches(lines);
+	} catch (error: unknown) {
+		throwScanError("parse", (error as Error).message);
+	}
+
+	const requests = (doc as { requests?: unknown }).requests;
+	if (!Array.isArray(requests)) {
+		throwScanError("schema", "requests is not an array");
+	}
+
+	const entries: TranscriptEntry[] = [];
+	for (let i = fromIdx; i < requests.length; i++) {
+		const req = requests[i] as ChatRequest;
+		const userText = req?.message?.text;
+		if (typeof userText === "string" && userText.length > 0) {
+			entries.push({ role: "human", content: userText });
+		}
+		const responseList = Array.isArray(req?.response) ? req.response : [];
+		const assistantText = responseList
+			.map((chunk) => (typeof chunk?.value === "string" ? chunk.value : ""))
+			.join("");
+		if (assistantText.length > 0) {
+			entries.push({ role: "assistant", content: assistantText });
+		}
+	}
+
+	const updatedAt = await stat(transcriptPath).then((s) => new Date(s.mtimeMs).toISOString());
+	return {
+		entries,
+		newCursor: { transcriptPath, lineNumber: requests.length, updatedAt },
+		totalLinesRead: lines.length,
+	};
+}
+```
+
+- [ ] **Step 4: Run all reader tests**
+
+Run: `npm run test -w @jolli.ai/cli -- src/core/CopilotChatTranscriptReader.test.ts`
+Expected: ALL PASS.
+
+- [ ] **Step 5: Run typecheck and lint**
+
+Run: `npm run typecheck:cli && npm run lint`
+Expected: 0 errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add cli/src/core/CopilotChatTranscriptReader.ts cli/src/core/CopilotChatTranscriptReader.test.ts
+git commit -s -m "Add readCopilotChatTranscript matching TranscriptReadResult"
+```
+
+---
+
+## Task 9: Implement `CopilotChatSessionDiscoverer`
+
+Locate the workspace hash for `projectDir`, list `.jsonl` files in its `chatSessions/` dir, filter by 48-hour mtime window, return `SessionInfo[]`.
+
+**Files:**
+- Create: `cli/src/core/CopilotChatSessionDiscoverer.ts`
+- Create: `cli/src/core/CopilotChatSessionDiscoverer.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+```typescript
+// cli/src/core/CopilotChatSessionDiscoverer.test.ts
+import { mkdirSync, mkdtempSync, rmSync, utimesSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockHomedir, mockPlatform } = vi.hoisted(() => ({
+	mockHomedir: vi.fn(),
+	mockPlatform: vi.fn().mockReturnValue("darwin"),
+}));
+
+vi.mock("node:os", async (importOriginal) => {
+	const original = await importOriginal<typeof import("node:os")>();
+	return { ...original, homedir: mockHomedir, platform: mockPlatform };
+});
+
+describe("scanCopilotChatSessions", () => {
+	let tmpRoot: string;
+	let projectDir: string;
+
+	beforeEach(() => {
+		tmpRoot = mkdtempSync(join(tmpdir(), "copilot-chat-disc-"));
+		projectDir = join(tmpRoot, "myproject");
+		mkdirSync(projectDir, { recursive: true });
+		mockHomedir.mockReturnValue(tmpRoot);
+		mockPlatform.mockReturnValue("darwin");
+	});
+
+	afterEach(() => {
+		rmSync(tmpRoot, { recursive: true, force: true });
+		vi.resetModules();
+	});
+
+	function makeWorkspace(wsHash: string, folderUri: string): string {
+		const wsDir = join(
+			tmpRoot,
+			"Library",
+			"Application Support",
+			"Code",
+			"User",
+			"workspaceStorage",
+			wsHash,
+		);
+		mkdirSync(wsDir, { recursive: true });
+		writeFileSync(join(wsDir, "workspace.json"), JSON.stringify({ folder: folderUri }));
+		return wsDir;
+	}
+
+	function makeSessionFile(wsDir: string, sessionId: string, ageHours: number): string {
+		const sessionsDir = join(wsDir, "chatSessions");
+		mkdirSync(sessionsDir, { recursive: true });
+		const path = join(sessionsDir, `${sessionId}.jsonl`);
+		writeFileSync(path, JSON.stringify({ kind: 0, v: { requests: [] } }));
+		const targetMs = Date.now() - ageHours * 3600 * 1000;
+		const targetSec = targetMs / 1000;
+		utimesSync(path, targetSec, targetSec);
+		return path;
+	}
+
+	it("returns empty when projectDir has no matching workspace", async () => {
+		const { scanCopilotChatSessions } = await import("./CopilotChatSessionDiscoverer.js");
+		const result = await scanCopilotChatSessions(projectDir);
+		expect(result.sessions).toEqual([]);
+	});
+
+	it("returns empty when workspace exists but chatSessions/ is missing", async () => {
+		makeWorkspace("ws1", `file://${projectDir}`);
+		const { scanCopilotChatSessions } = await import("./CopilotChatSessionDiscoverer.js");
+		const result = await scanCopilotChatSessions(projectDir);
+		expect(result.sessions).toEqual([]);
+	});
+
+	it("returns fresh sessions, excludes sessions older than 48h", async () => {
+		const wsDir = makeWorkspace("ws1", `file://${projectDir}`);
+		makeSessionFile(wsDir, "fresh", 1);
+		makeSessionFile(wsDir, "stale", 72);
+		const { scanCopilotChatSessions } = await import("./CopilotChatSessionDiscoverer.js");
+		const result = await scanCopilotChatSessions(projectDir);
+		expect(result.sessions.map((s) => s.sessionId)).toEqual(["fresh"]);
+		expect(result.sessions[0].source).toBe("copilot-chat");
+		expect(result.sessions[0].transcriptPath.endsWith("fresh.jsonl")).toBe(true);
+	});
+
+	it("ignores non-.jsonl files in chatSessions/", async () => {
+		const wsDir = makeWorkspace("ws1", `file://${projectDir}`);
+		makeSessionFile(wsDir, "real", 1);
+		const sessionsDir = join(wsDir, "chatSessions");
+		writeFileSync(join(sessionsDir, "ignore-me.txt"), "");
+		writeFileSync(join(sessionsDir, "ignore-me.json"), "{}");
+		const { scanCopilotChatSessions } = await import("./CopilotChatSessionDiscoverer.js");
+		const result = await scanCopilotChatSessions(projectDir);
+		expect(result.sessions.map((s) => s.sessionId)).toEqual(["real"]);
+	});
+
+	it("reports updatedAt as ISO string from file mtime", async () => {
+		const wsDir = makeWorkspace("ws1", `file://${projectDir}`);
+		makeSessionFile(wsDir, "s1", 2);
+		const { scanCopilotChatSessions } = await import("./CopilotChatSessionDiscoverer.js");
+		const result = await scanCopilotChatSessions(projectDir);
+		expect(result.sessions[0].updatedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+	});
+
+	it("returns fs error when chatSessions/ readdir fails for non-ENOENT reason", async () => {
+		const wsDir = makeWorkspace("ws1", `file://${projectDir}`);
+		// Create a file (not a directory) at chatSessions path → ENOTDIR
+		writeFileSync(join(wsDir, "chatSessions"), "");
+		const { scanCopilotChatSessions } = await import("./CopilotChatSessionDiscoverer.js");
+		const result = await scanCopilotChatSessions(projectDir);
+		expect(result.sessions).toEqual([]);
+		expect(result.error?.kind).toBe("fs");
+	});
+
+	it("discoverCopilotChatSessions wrapper returns array unchanged on success", async () => {
+		const wsDir = makeWorkspace("ws1", `file://${projectDir}`);
+		makeSessionFile(wsDir, "s1", 1);
+		const { discoverCopilotChatSessions } = await import("./CopilotChatSessionDiscoverer.js");
+		const sessions = await discoverCopilotChatSessions(projectDir);
+		expect(sessions.map((s) => s.sessionId)).toEqual(["s1"]);
+	});
+});
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run: `npm run test -w @jolli.ai/cli -- src/core/CopilotChatSessionDiscoverer.test.ts`
+Expected: FAIL — module does not exist.
+
+- [ ] **Step 3: Implement `CopilotChatSessionDiscoverer.ts`**
+
+```typescript
+// cli/src/core/CopilotChatSessionDiscoverer.ts
+/**
+ * VS Code Copilot Chat session discoverer.
+ *
+ * Locates the vscode workspaceStorage entry whose `workspace.json` resolves to
+ * projectDir, then enumerates `*.jsonl` files in `<wsHash>/chatSessions/`.
+ * Each file is one chat session — `transcriptPath` is the absolute file path.
+ * Sessions older than 48 h are excluded (matches the OpenCode/Cursor/Copilot
+ * convention).
+ */
+
+import { readdir, stat } from "node:fs/promises";
+import { join } from "node:path";
+import { createLogger } from "../Logger.js";
+import type { SessionInfo } from "../Types.js";
+import type { CopilotChatScanError } from "./CopilotChatTranscriptReader.js";
+import { findVscodeWorkspaceHash, getVscodeWorkspaceStorageDir } from "./VscodeWorkspaceLocator.js";
+
+const log = createLogger("CopilotChatDiscoverer");
+
+const SESSION_STALE_MS = 48 * 60 * 60 * 1000;
+
+export type { CopilotChatScanError };
+
+export interface CopilotChatScanResult {
+	readonly sessions: ReadonlyArray<SessionInfo>;
+	readonly error?: CopilotChatScanError;
+}
+
+export async function scanCopilotChatSessions(projectDir: string): Promise<CopilotChatScanResult> {
+	const wsHash = await findVscodeWorkspaceHash("Code", projectDir);
+	if (wsHash === null) {
+		log.debug("No vscode workspace matched %s", projectDir);
+		return { sessions: [] };
+	}
+
+	const sessionsDir = join(getVscodeWorkspaceStorageDir("Code"), wsHash, "chatSessions");
+
+	let entries: string[];
+	try {
+		entries = await readdir(sessionsDir);
+	} catch (error: unknown) {
+		const code = (error as NodeJS.ErrnoException).code;
+		if (code === "ENOENT") {
+			log.debug("chatSessions/ not present at %s", sessionsDir);
+			return { sessions: [] };
+		}
+		log.error("readdir %s failed (%s): %s", sessionsDir, code ?? "unknown", (error as Error).message);
+		return { sessions: [], error: { kind: "fs", message: (error as Error).message } };
+	}
+
+	const cutoffMs = Date.now() - SESSION_STALE_MS;
+	const sessions: SessionInfo[] = [];
+
+	for (const entry of entries) {
+		if (!entry.endsWith(".jsonl")) continue;
+		const filePath = join(sessionsDir, entry);
+		let mtimeMs: number;
+		try {
+			const fileStat = await stat(filePath);
+			mtimeMs = fileStat.mtimeMs;
+		} catch {
+			continue;
+		}
+		if (mtimeMs < cutoffMs) continue;
+		const sessionId = entry.slice(0, -".jsonl".length);
+		sessions.push({
+			sessionId,
+			transcriptPath: filePath,
+			updatedAt: new Date(mtimeMs).toISOString(),
+			source: "copilot-chat",
+		});
+	}
+
+	log.info("Discovered %d Copilot Chat session(s) for %s", sessions.length, projectDir);
+	return { sessions };
+}
+
+/** Convenience wrapper without the error channel — used by QueueWorker. */
+export async function discoverCopilotChatSessions(projectDir: string): Promise<ReadonlyArray<SessionInfo>> {
+	const { sessions, error } = await scanCopilotChatSessions(projectDir);
+	if (error) {
+		log.warn("Copilot Chat scan error (%s) — sessions excluded from this run: %s", error.kind, error.message);
+	}
+	return sessions;
+}
+```
+
+- [ ] **Step 4: Run all discoverer tests**
+
+Run: `npm run test -w @jolli.ai/cli -- src/core/CopilotChatSessionDiscoverer.test.ts`
+Expected: ALL PASS.
+
+- [ ] **Step 5: Run typecheck and lint**
+
+Run: `npm run typecheck:cli && npm run lint`
+Expected: 0 errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add cli/src/core/CopilotChatSessionDiscoverer.ts cli/src/core/CopilotChatSessionDiscoverer.test.ts
+git commit -s -m "Add CopilotChatSessionDiscoverer"
+```
+
+---
+
+## Task 10: Wire Copilot Chat into `Installer.install()` (auto-enable)
+
+Auto-enable `copilotEnabled` on first install when **either** form is detected.
+
+**Files:**
+- Modify: `cli/src/install/Installer.ts:272-279` (Copilot CLI auto-detect block)
+- Modify: `cli/src/install/Installer.test.ts` (add "auto-enables on Chat-only install" case)
+
+- [ ] **Step 1: Write failing test**
+
+Add to `cli/src/install/Installer.test.ts` near the existing copilot auto-enable tests (around line 298-329):
+
+```typescript
+it("auto-enables copilotEnabled when only Copilot Chat is detected", async () => {
+	const { install } = await import("./Installer.js");
+	const { isCopilotInstalled } = await import("../core/CopilotDetector.js");
+	const { isCopilotChatInstalled } = await import("../core/CopilotChatDetector.js");
+	vi.mocked(isCopilotInstalled).mockResolvedValueOnce(false);
+	vi.mocked(isCopilotChatInstalled).mockResolvedValueOnce(true);
+
+	await install(testCwd);
+
+	const globalConfig = await loadConfigFromDir(getGlobalConfigDir());
+	expect(globalConfig.copilotEnabled).toBe(true);
+});
+
+it("does not auto-enable when neither Copilot form is present", async () => {
+	const { install } = await import("./Installer.js");
+	const { isCopilotInstalled } = await import("../core/CopilotDetector.js");
+	const { isCopilotChatInstalled } = await import("../core/CopilotChatDetector.js");
+	vi.mocked(isCopilotInstalled).mockResolvedValueOnce(false);
+	vi.mocked(isCopilotChatInstalled).mockResolvedValueOnce(false);
+
+	await install(testCwd);
+
+	const globalConfig = await loadConfigFromDir(getGlobalConfigDir());
+	expect(globalConfig.copilotEnabled).toBeUndefined();
+});
+```
+
+Add the `isCopilotChatInstalled` mock to the existing module mock block at the top of the test file (around line 60-75):
+
+```typescript
+vi.mock("../core/CopilotChatDetector.js", () => ({
+	isCopilotChatInstalled: vi.fn().mockResolvedValue(false),
+	getCopilotChatStorageDir: vi.fn().mockReturnValue("/fake/Code/User/globalStorage/github.copilot-chat"),
+}));
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run: `npm run test -w @jolli.ai/cli -- src/install/Installer.test.ts -t "Copilot Chat"`
+Expected: FAIL — `isCopilotChatInstalled` not yet imported in Installer.
+
+- [ ] **Step 3: Update `Installer.ts:install()` auto-detect block**
+
+In `cli/src/install/Installer.ts`, at the top imports (near line 22-23), add:
+
+```typescript
+import { isCopilotChatInstalled } from "../core/CopilotChatDetector.js";
+import { scanCopilotChatSessions } from "../core/CopilotChatSessionDiscoverer.js";
+```
+
+Replace the Copilot auto-detect block at line 272-279:
+
+```typescript
+// Auto-detect Copilot CLI and enable session discovery
+const copilotDetected = config.copilotEnabled !== false && (await isCopilotInstalled());
+if (copilotDetected) {
+    if (config.copilotEnabled === undefined) {
+        await saveConfig({ copilotEnabled: true });
+        log.info("Copilot CLI detected — enabled Copilot session discovery");
+    }
+}
+```
+
+with:
+
+```typescript
+// Auto-detect GitHub Copilot in either form (terminal CLI or vscode Chat) and
+// enable the shared copilotEnabled flag. Both sources share one toggle —
+// see docs/superpowers/specs/2026-05-06-copilot-chat-support-design.md.
+const copilotDetected = config.copilotEnabled !== false && (await isCopilotInstalled());
+const copilotChatDetected = config.copilotEnabled !== false && (await isCopilotChatInstalled());
+if ((copilotDetected || copilotChatDetected) && config.copilotEnabled === undefined) {
+    await saveConfig({ copilotEnabled: true });
+    log.info("GitHub Copilot detected (CLI=%s, Chat=%s) — enabled session discovery",
+        copilotDetected, copilotChatDetected);
+}
+```
+
+- [ ] **Step 4: Run install tests to verify pass**
+
+Run: `npm run test -w @jolli.ai/cli -- src/install/Installer.test.ts -t "Copilot"`
+Expected: ALL PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cli/src/install/Installer.ts cli/src/install/Installer.test.ts
+git commit -s -m "Wire Copilot Chat detection into Installer.install auto-enable"
+```
+
+---
+
+## Task 11: Wire Copilot Chat into `Installer.getStatus()`
+
+Add `copilotChatDetected` and `copilotChatScanError` to `StatusInfo` (Types.ts) and to the `getStatus()` return value, and run `scanCopilotChatSessions` for session counts. The reader exists by this point (Tasks 6-8) so importing `CopilotChatScanError` typechecks cleanly.
+
+**Files:**
+- Modify: `cli/src/Types.ts:578-616` (StatusInfo)
+- Modify: `cli/src/install/Installer.ts:497` (detector calls), `:549-557` (Copilot CLI scan block), `:633-635` (StatusInfo build), `:647-666` (log)
+- Modify: `cli/src/install/Installer.test.ts`
+
+- [ ] **Step 1: Add Copilot Chat fields to `StatusInfo`**
+
+In `cli/src/Types.ts`, near the top imports, add:
+
+```typescript
+import type { CopilotChatScanError } from "./core/CopilotChatTranscriptReader.js";
+```
+
+Then after the existing `copilotScanError` field (line ~616), add:
+
+```typescript
+	/** Whether vscode's Copilot Chat globalStorage dir was detected */
+	readonly copilotChatDetected?: boolean;
+	/** Copilot Chat scan failed with a real (non-ENOENT) error: parse / fs / schema. */
+	readonly copilotChatScanError?: CopilotChatScanError;
+```
+
+(No `copilotChatEnabled` field — `copilotEnabled` is shared.)
+
+Run: `npm run typecheck:cli`
+Expected: 0 errors. (The reader from Tasks 6-8 already exports `CopilotChatScanError`.)
+
+- [ ] **Step 2: Write failing test**
+
+Add to `Installer.test.ts` near the existing Copilot status test (around line 2118-2162):
+
+```typescript
+it("getStatus reports copilotChatDetected when chat dir is present", async () => {
+	const { getStatus } = await import("./Installer.js");
+	const { isCopilotChatInstalled } = await import("../core/CopilotChatDetector.js");
+	vi.mocked(isCopilotChatInstalled).mockResolvedValue(true);
+
+	const status = await getStatus(testCwd);
+
+	expect(status.copilotChatDetected).toBe(true);
+});
+
+it("getStatus surfaces copilot-chat sessions and uses copilotEnabled gating", async () => {
+	const { getStatus } = await import("./Installer.js");
+	const { isCopilotChatInstalled } = await import("../core/CopilotChatDetector.js");
+	const { scanCopilotChatSessions } = await import("../core/CopilotChatSessionDiscoverer.js");
+	vi.mocked(isCopilotChatInstalled).mockResolvedValue(true);
+	vi.mocked(scanCopilotChatSessions).mockResolvedValue({
+		sessions: [
+			{
+				sessionId: "chat-1",
+				transcriptPath: "/fake/Code/.../chat-1.jsonl",
+				updatedAt: "2026-05-06T00:00:00Z",
+				source: "copilot-chat",
+			},
+		],
+	});
+	await saveConfigScoped({ copilotEnabled: true }, getGlobalConfigDir());
+
+	const status = await getStatus(testCwd);
+	expect(status.sessionsBySource?.["copilot-chat"]).toBe(1);
+});
+```
+
+Also add `scanCopilotChatSessions` to the existing CopilotChatDetector mock block (Task 10 step 1):
+
+```typescript
+vi.mock("../core/CopilotChatSessionDiscoverer.js", () => ({
+	scanCopilotChatSessions: vi.fn().mockResolvedValue({ sessions: [] }),
+	discoverCopilotChatSessions: vi.fn().mockResolvedValue([]),
+}));
+```
+
+- [ ] **Step 3: Run test to verify failure**
+
+Run: `npm run test -w @jolli.ai/cli -- src/install/Installer.test.ts -t "copilotChatDetected"`
+Expected: FAIL — field not populated by `getStatus()` yet.
+
+- [ ] **Step 4: Add `getStatus` calls and field**
+
+In `Installer.ts:getStatus()`:
+
+After line 497 (`const copilotDetected = await isCopilotInstalled();`), add:
+
+```typescript
+const copilotChatDetected = await isCopilotChatInstalled();
+```
+
+After the Copilot CLI scan block at lines 549-557, add:
+
+```typescript
+// Discover Copilot Chat sessions on-demand (not stored in sessions.json).
+let copilotChatScanError: CopilotChatScanError | undefined;
+if (config.copilotEnabled !== false && copilotChatDetected) {
+    const scan = await scanCopilotChatSessions(projectDir);
+    if (scan.sessions.length > 0) {
+        allEnabledSessions = [...allEnabledSessions, ...scan.sessions];
+    }
+    copilotChatScanError = scan.error;
+}
+```
+
+Add to the imports at the top of `Installer.ts` (near line 22):
+
+```typescript
+import type { CopilotChatScanError } from "../core/CopilotChatTranscriptReader.js";
+```
+
+In the `StatusInfo` build at lines 633-635, after `copilotScanError`, add:
+
+```typescript
+copilotChatDetected,
+copilotChatScanError,
+```
+
+In the final `log.info` at 647-666, append the new fields to the format string:
+
+Find:
+```typescript
+log.info(
+    "Status: enabled=%s, claude=%s, git=%s, geminiHook=%s, worktreeHooks=%s, sessions=%d, summaries=%d, codex=%s/%s, gemini=%s/%s, enabledWorktrees=%s, opencode=%s/%s, cursor=%s/%s, copilot=%s/%s",
+    ...,
+    status.copilotDetected,
+    status.copilotEnabled,
+);
+```
+
+Replace with:
+```typescript
+log.info(
+    "Status: enabled=%s, claude=%s, git=%s, geminiHook=%s, worktreeHooks=%s, sessions=%d, summaries=%d, codex=%s/%s, gemini=%s/%s, enabledWorktrees=%s, opencode=%s/%s, cursor=%s/%s, copilot=%s/%s, copilotChat=%s",
+    ...,
+    status.copilotDetected,
+    status.copilotEnabled,
+    status.copilotChatDetected,
+);
+```
+
+- [ ] **Step 5: Run getStatus tests to verify pass**
+
+Run: `npm run test -w @jolli.ai/cli -- src/install/Installer.test.ts`
+Expected: ALL PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add cli/src/Types.ts cli/src/install/Installer.ts cli/src/install/Installer.test.ts
+git commit -s -m "Surface Copilot Chat status in Installer.getStatus"
+```
+
+---
+
+## Task 12: Wire `discoverCopilotChatSessions` into `QueueWorker`
+
+Discover Copilot Chat sessions during the post-commit pipeline.
+
+**Files:**
+- Modify: `cli/src/hooks/QueueWorker.ts:1443-1448` (after the Copilot CLI block)
+
+- [ ] **Step 1: Add import and discovery block**
+
+In `cli/src/hooks/QueueWorker.ts`, near the existing Copilot imports (line 25-27):
+
+```typescript
+import { discoverCopilotChatSessions } from "../core/CopilotChatSessionDiscoverer.js";
+import { isCopilotChatInstalled } from "../core/CopilotChatDetector.js";
+```
+
+After the Copilot CLI discovery block at line 1443-1448:
+
+```typescript
+// Discover Copilot CLI sessions (on-demand SQLite scan).
+if (config.copilotEnabled !== false && (await isCopilotInstalled())) {
+    const copilotSessions = await discoverCopilotSessions(cwd);
+    if (copilotSessions.length > 0) {
+        allSessions = [...allSessions, ...copilotSessions];
+        log.info("Discovered %d Copilot session(s)", copilotSessions.length);
+    }
+}
+```
+
+Add a parallel block:
+
+```typescript
+// Discover Copilot Chat sessions (on-demand JSONL scan in vscode workspaceStorage).
+// Shares copilotEnabled with the CLI source (one user-facing toggle for "GitHub Copilot").
+if (config.copilotEnabled !== false && (await isCopilotChatInstalled())) {
+    const chatSessions = await discoverCopilotChatSessions(cwd);
+    if (chatSessions.length > 0) {
+        allSessions = [...allSessions, ...chatSessions];
+        log.info("Discovered %d Copilot Chat session(s)", chatSessions.length);
+    }
+}
+```
+
+- [ ] **Step 2: Run QueueWorker tests**
+
+Run: `npm run test -w @jolli.ai/cli -- src/hooks/QueueWorker.test.ts`
+Expected: ALL PASS. If a test asserts on the number of session-source modules called, add a mock for `isCopilotChatInstalled` (returns false by default) and `discoverCopilotChatSessions` (returns []).
+
+If new test cases needed for the chat-source path, add:
+
+```typescript
+it("includes Copilot Chat sessions when chat is detected and copilotEnabled is true", async () => {
+	const { isCopilotChatInstalled } = await import("../core/CopilotChatDetector.js");
+	const { discoverCopilotChatSessions } = await import("../core/CopilotChatSessionDiscoverer.js");
+	vi.mocked(isCopilotChatInstalled).mockResolvedValueOnce(true);
+	vi.mocked(discoverCopilotChatSessions).mockResolvedValueOnce([
+		{
+			sessionId: "chat-1",
+			transcriptPath: "/fake/chat-1.jsonl",
+			updatedAt: "2026-05-06T00:00:00Z",
+			source: "copilot-chat",
+		},
+	]);
+
+	// ... existing harness to invoke QueueWorker
+	// Assert: chat-1 appears in the session pool used for transcript reading.
+});
+```
+
+- [ ] **Step 3: Run typecheck**
+
+Run: `npm run typecheck:cli`
+Expected: 0 errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add cli/src/hooks/QueueWorker.ts cli/src/hooks/QueueWorker.test.ts
+git commit -s -m "Wire Copilot Chat discovery into QueueWorker"
+```
+
+---
+
+## Task 13: Wire `readCopilotChatTranscript` into `QueueWorker` reader dispatch
+
+Add the `"copilot-chat"` case in the transcript-reader switch.
+
+**Files:**
+- Modify: `cli/src/hooks/QueueWorker.ts:1510-1514` (transcript reader dispatch)
+
+- [ ] **Step 1: Add the `copilot-chat` reader branch**
+
+In `cli/src/hooks/QueueWorker.ts`, near line 27 (existing Copilot reader import), add:
+
+```typescript
+import { readCopilotChatTranscript } from "../core/CopilotChatTranscriptReader.js";
+```
+
+In the reader dispatch around line 1510-1521, locate the Copilot CLI branch:
+
+```typescript
+} else if (source === "copilot") {
+    try {
+        result = await readCopilotTranscript(session.transcriptPath, cursor, beforeTimestamp);
+    } catch (error: unknown) {
+        log.error("Skipping Copilot session %s: %s", session.sessionId, (error as Error).message);
+        continue;
+    }
+}
+```
+
+Add a parallel Copilot Chat branch immediately after, before the trailing `else { result = await readTranscript(...) }`:
+
+```typescript
+} else if (source === "copilot-chat") {
+    try {
+        result = await readCopilotChatTranscript(session.transcriptPath, cursor);
+    } catch (error: unknown) {
+        log.error("Skipping Copilot Chat session %s: %s", session.sessionId, (error as Error).message);
+        continue;
+    }
+}
+```
+
+(`readCopilotChatTranscript` returns `TranscriptReadResult` directly — no adapter needed. `beforeTimestamp` isn't passed because the chat reader filters by `cursor.lineNumber` (request count), not timestamp; the session-level mtime filtering already happened in the discoverer.)
+
+- [ ] **Step 2: Run QueueWorker tests with chat reader path**
+
+Run: `npm run test -w @jolli.ai/cli -- src/hooks/QueueWorker.test.ts`
+Expected: ALL PASS.
+
+If the existing reader dispatch returns a typed `TranscriptReadResult` shape, ensure `readCopilotChatTranscript` is shaped compatibly — adapter conversion may be needed inline. Check the function `readCopilotTranscript`'s return type; if the dispatch normalizes via a wrapper type, do the same here.
+
+- [ ] **Step 3: Run typecheck and full cli test suite**
+
+Run: `npm run typecheck:cli && npm run test -w @jolli.ai/cli`
+Expected: 0 errors, all tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add cli/src/hooks/QueueWorker.ts cli/src/hooks/QueueWorker.test.ts
+git commit -s -m "Wire Copilot Chat reader into QueueWorker dispatch"
+```
+
+---
+
+## Task 14: VS Code `StatusTreeProvider` — show form breakdown
+
+Update the Copilot status row to OR-detect across both forms and surface a tooltip indicating which forms were found.
+
+**Files:**
+- Modify: `vscode/src/providers/StatusTreeProvider.ts:318-338`
+- Modify: `vscode/src/providers/StatusTreeProvider.test.ts`
+
+- [ ] **Step 1: Write failing test**
+
+Add to `StatusTreeProvider.test.ts`:
+
+```typescript
+it("Copilot row tooltip distinguishes CLI / Chat detection", async () => {
+	const { provider } = setupProvider({
+		copilotDetected: true,
+		copilotChatDetected: false,
+		copilotEnabled: true,
+	});
+	const items = await provider.getChildren();
+	const copilotItem = items.find((i) => i.label?.toString().includes("Copilot"));
+	expect(copilotItem?.tooltip?.toString()).toContain("CLI: ✓");
+	expect(copilotItem?.tooltip?.toString()).toContain("Chat: ✗");
+});
+
+it("Copilot row detected = true when only Chat is detected", async () => {
+	const { provider } = setupProvider({
+		copilotDetected: false,
+		copilotChatDetected: true,
+		copilotEnabled: true,
+	});
+	const items = await provider.getChildren();
+	const copilotItem = items.find((i) => i.label?.toString().includes("Copilot"));
+	// Item is rendered with detected=true (e.g. shows "available" rather than "not detected")
+	expect(copilotItem).toBeDefined();
+});
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run: `npm run test -w jollimemory-vscode -- src/providers/StatusTreeProvider.test.ts -t "Copilot"`
+Expected: FAIL — current code only reads `copilotDetected`.
+
+- [ ] **Step 3: Update `StatusTreeProvider.ts` Copilot block (around line 318-338)**
+
+The existing block uses an `if (scanError) { ... } else { pushIntegrationItem(...) }` structure — when the CLI's DB is unreadable, no row is shown. We change this to **always** show one Copilot row (OR-detected across forms), plus independent warn rows for each form's scan error. This way, partial outages (e.g. CLI locked but Chat fine) still inform the user that Chat is working.
+
+Replace:
+
+```typescript
+// Copilot CLI also has a scan-time error channel (DB can be locked/corrupt).
+if (s.copilotScanError) {
+    items.push(
+        new StatusItem(
+            "Copilot Integration",
+            `unavailable — ${s.copilotScanError.kind}`,
+            ICON_WARN,
+            `Copilot database scan failed (${s.copilotScanError.kind}): ${s.copilotScanError.message}`,
+        ),
+    );
+} else {
+    pushIntegrationItem(
+        items,
+        s.copilotDetected,
+        s.copilotEnabled !== false,
+        undefined,
+        "Copilot Integration",
+        "Copilot CLI database found — session discovery is enabled",
+        "Copilot CLI detected but session discovery is disabled in config",
+        undefined,
+        counts.copilot,
+    );
+}
+```
+
+with:
+
+```typescript
+// Copilot integration: shared `copilotEnabled` toggle for terminal CLI and VS Code Chat.
+// Each form has its own scan-error channel; each surfaces as a separate warn row.
+if (s.copilotScanError) {
+    items.push(
+        new StatusItem(
+            "Copilot Integration",
+            `unavailable — ${s.copilotScanError.kind}`,
+            ICON_WARN,
+            `Copilot CLI database scan failed (${s.copilotScanError.kind}): ${s.copilotScanError.message}`,
+        ),
+    );
+}
+if (s.copilotChatScanError) {
+    items.push(
+        new StatusItem(
+            "Copilot Chat",
+            `unavailable — ${s.copilotChatScanError.kind}`,
+            ICON_WARN,
+            `Copilot Chat scan failed (${s.copilotChatScanError.kind}): ${s.copilotChatScanError.message}`,
+        ),
+    );
+}
+const cliMark = s.copilotDetected ? "✓" : "✗";
+const chatMark = s.copilotChatDetected ? "✓" : "✗";
+const anyCopilotDetected = (s.copilotDetected ?? false) || (s.copilotChatDetected ?? false);
+const copilotSessions = (counts.copilot ?? 0) + (counts["copilot-chat"] ?? 0);
+pushIntegrationItem(
+    items,
+    anyCopilotDetected,
+    s.copilotEnabled !== false,
+    undefined,
+    "Copilot Integration",
+    `GitHub Copilot detected (CLI: ${cliMark}, Chat: ${chatMark}) — session discovery is enabled`,
+    `GitHub Copilot detected (CLI: ${cliMark}, Chat: ${chatMark}) but session discovery is disabled in config`,
+    undefined,
+    copilotSessions,
+);
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `npm run test -w jollimemory-vscode -- src/providers/StatusTreeProvider.test.ts`
+Expected: ALL PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add vscode/src/providers/StatusTreeProvider.ts vscode/src/providers/StatusTreeProvider.test.ts
+git commit -s -m "Show CLI/Chat form breakdown in Copilot status row"
+```
+
+---
+
+## Task 15: VS Code Settings panel — update Copilot description
+
+Single toggle, but the description should mention both source forms.
+
+**Files:**
+- Modify: `vscode/src/views/SettingsHtmlBuilder.ts:88`
+- Modify: `vscode/src/views/SettingsHtmlBuilder.test.ts`
+
+- [ ] **Step 1: Update description**
+
+In `SettingsHtmlBuilder.ts:88`, replace:
+
+```typescript
+${buildToggleRow("copilotEnabled", "Copilot", "Session discovery via ~/.copilot/session-store.db")}
+```
+
+with:
+
+```typescript
+${buildToggleRow("copilotEnabled", "Copilot", "Session discovery for GitHub Copilot CLI (~/.copilot/session-store.db) and VS Code Copilot Chat (workspace storage)")}
+```
+
+- [ ] **Step 2: Update existing test if it asserts on description text**
+
+In `SettingsHtmlBuilder.test.ts`, find any test that asserts on the Copilot description string and update the expected text to match the new wording.
+
+If no test asserts on description text, add a regression-style assertion:
+
+```typescript
+it("Copilot toggle description mentions both CLI and Chat sources", () => {
+	const html = build(/* ... */);
+	expect(html).toContain("Copilot CLI");
+	expect(html).toContain("Copilot Chat");
+});
+```
+
+- [ ] **Step 3: Run tests**
+
+Run: `npm run test -w jollimemory-vscode -- src/views/SettingsHtmlBuilder.test.ts`
+Expected: ALL PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add vscode/src/views/SettingsHtmlBuilder.ts vscode/src/views/SettingsHtmlBuilder.test.ts
+git commit -s -m "Update Copilot toggle description to mention CLI and Chat"
+```
+
+---
+
+## Task 16: VS Code Summary panel — add `copilot-chat` to source ordering
+
+Surface Copilot Chat sessions in the summary details list with the right label and ordering.
+
+**Files:**
+- Modify: `vscode/src/views/SummaryWebviewPanel.ts:2050` (getEnabledSources)
+- Modify: `vscode/src/views/SummaryScriptBuilder.ts:1136` (label map), `:1562` (sourceOrder)
+- Modify corresponding `*.test.ts` files.
+
+- [ ] **Step 1: Update `SummaryWebviewPanel.getEnabledSources`**
+
+In `SummaryWebviewPanel.ts` around line 2050:
+
+```typescript
+if (config.copilotEnabled !== false) {
+    sources.add("copilot");
+}
+```
+
+Change to:
+
+```typescript
+if (config.copilotEnabled !== false) {
+    sources.add("copilot");
+    sources.add("copilot-chat");
+}
+```
+
+- [ ] **Step 2: Update `SummaryScriptBuilder` label and order**
+
+In `SummaryScriptBuilder.ts:1136`, add a Copilot Chat label after the existing Copilot label:
+
+```javascript
+if (source === 'copilot') return 'Copilot';
+if (source === 'copilot-chat') return 'Copilot Chat';
+```
+
+In `SummaryScriptBuilder.ts:1562`, extend the source order array:
+
+```javascript
+var sourceOrder = ['claude', 'codex', 'gemini', 'opencode', 'cursor', 'copilot', 'copilot-chat'];
+```
+
+- [ ] **Step 3: Add tests**
+
+In `SummaryWebviewPanel.test.ts`, add:
+
+```typescript
+it("includes copilot-chat in enabled sources when copilotEnabled is true", () => {
+	const sources = getEnabledSources({ copilotEnabled: true });
+	expect(sources).toContain("copilot-chat");
+});
+
+it("excludes copilot-chat when copilotEnabled is false", () => {
+	const sources = getEnabledSources({ copilotEnabled: false });
+	expect(sources).not.toContain("copilot-chat");
+});
+```
+
+In `SummaryScriptBuilder.test.ts`, add:
+
+```typescript
+it("renders 'Copilot Chat' label for copilot-chat source", () => {
+	const script = buildSummaryScript(/* ... */);
+	expect(script).toContain("'Copilot Chat'");
+});
+
+it("places copilot-chat after copilot in source ordering", () => {
+	const script = buildSummaryScript(/* ... */);
+	expect(script).toMatch(/'copilot',\s*'copilot-chat'/);
+});
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `npm run test -w jollimemory-vscode -- src/views/Summary`
+Expected: ALL PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add vscode/src/views/SummaryWebviewPanel.ts vscode/src/views/SummaryScriptBuilder.ts vscode/src/views/SummaryWebviewPanel.test.ts vscode/src/views/SummaryScriptBuilder.test.ts
+git commit -s -m "Add copilot-chat source to Summary panel rendering"
+```
+
+---
+
+## Task 17: CLI `StatusCommand` — show form breakdown sub-line
+
+Append a sub-line to the Copilot status row showing CLI / Chat detection state.
+
+**Files:**
+- Modify: `cli/src/commands/StatusCommand.ts:162-168`
+- Modify: `cli/src/commands/StatusCommand.test.ts`
+
+- [ ] **Step 1: Update `StatusCommand.ts`**
+
+In `StatusCommand.ts` around line 160-175, find the existing Copilot tuple in `integrationRows` and the loop that prints it. We modify the tuple's `detected` predicate, sum the session count across both forms, and append a sub-line after the row.
+
+Replace the Copilot tuple in `integrationRows`:
+
+```typescript
+[
+    "Copilot:",
+    status.copilotDetected,
+    {
+        enabled: status.copilotEnabled !== false,
+        hookInstalled: undefined,
+        sessionCount: counts.copilot,
+        scanError: status.copilotScanError,
+    },
+],
+```
+
+with:
+
+```typescript
+[
+    "Copilot:",
+    (status.copilotDetected ?? false) || (status.copilotChatDetected ?? false),
+    {
+        enabled: status.copilotEnabled !== false,
+        hookInstalled: undefined,
+        sessionCount: (counts.copilot ?? 0) + (counts["copilot-chat"] ?? 0),
+        // CLI scan error takes precedence; chat scan error surfaced via sub-line below.
+        scanError: status.copilotScanError,
+    },
+],
+```
+
+Then, immediately after the `for (const [label, detected, inputs] of integrationRows)` loop completes (the closing brace `}` of that for-loop), append a sub-line for Copilot when applicable:
+
+```typescript
+const anyCopilotDetected = (status.copilotDetected ?? false) || (status.copilotChatDetected ?? false);
+if (anyCopilotDetected) {
+    const cliMark = status.copilotDetected ? "✓" : "✗";
+    const chatMark = status.copilotChatDetected ? "✓" : "✗";
+    console.log(`  ${"".padEnd(18)}↳ CLI: ${cliMark}, Chat: ${chatMark}`);
+    if (status.copilotChatScanError) {
+        console.log(
+            `  ${"".padEnd(18)}↳ Chat scan failed (${status.copilotChatScanError.kind}): ${status.copilotChatScanError.message}`,
+        );
+    }
+}
+```
+
+- [ ] **Step 2: Update `StatusCommand.test.ts`**
+
+```typescript
+it("Copilot row shows CLI/Chat breakdown when only chat is detected", async () => {
+	const status: StatusInfo = {
+		// ... fixture
+		copilotDetected: false,
+		copilotChatDetected: true,
+		copilotEnabled: true,
+		sessionsBySource: { "copilot-chat": 2 },
+	};
+	const output = captureStdout(() => printStatus(status));
+	expect(output).toContain("CLI: ✗");
+	expect(output).toContain("Chat: ✓");
+	expect(output).toMatch(/sessions:\s*2/);
+});
+```
+
+- [ ] **Step 3: Run StatusCommand tests**
+
+Run: `npm run test -w @jolli.ai/cli -- src/commands/StatusCommand.test.ts`
+Expected: ALL PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add cli/src/commands/StatusCommand.ts cli/src/commands/StatusCommand.test.ts
+git commit -s -m "Show CLI/Chat form breakdown in jolli status output"
+```
+
+---
+
+## Task 18: Final integration check — `npm run all` + fix-up
+
+Run the project-wide gate and resolve any remaining issues.
+
+- [ ] **Step 1: Run the full pipeline**
+
+Run from repo root:
+
+```bash
+npm run all
+```
+
+This chains: clean → build → lint → test, with the cli workspace's 97% coverage gate enforced.
+
+Expected: PASS. If failures occur, they will fall into one of these classes — diagnose and fix:
+
+| Failure class | Likely cause | Fix |
+|---|---|---|
+| Coverage below 97% on a new module | Missing edge case test | Add targeted unit test for the uncovered branch |
+| Biome lint warning (becomes error in CI) | Unused import / explicit any | Remove import or narrow type |
+| Type error in QueueWorker dispatch | `cursor` shape mismatch between Copilot CLI and Copilot Chat readers | Add a type guard or shape adapter at the dispatch site |
+| VS Code panel test asserting old wording | Description text changed in Task 15 | Update assertion to new wording |
+
+- [ ] **Step 2: Run any patch-up edits**
+
+For each failure observed in Step 1, apply the targeted fix and re-run `npm run all` until clean.
+
+- [ ] **Step 3: Final commit (only if any fix-up changes were made in Step 2)**
+
+```bash
+git add -A
+git commit -s -m "Patch up coverage / lint / type gaps for Copilot Chat support"
+```
+
+If no fix-up was needed, skip this commit.
+
+- [ ] **Step 4: Verify git log**
+
+Run: `git log --oneline -20`
+Expected: a clean sequence of commits, each scoped to one task. No "WIP" / "fix" without context. The series should look like:
+
+```
+xxxxxxx Patch up coverage / lint / type gaps for Copilot Chat support  (optional)
+xxxxxxx Show CLI/Chat form breakdown in jolli status output
+xxxxxxx Add copilot-chat source to Summary panel rendering
+xxxxxxx Update Copilot toggle description to mention CLI and Chat
+xxxxxxx Show CLI/Chat form breakdown in Copilot status row
+xxxxxxx Wire Copilot Chat reader into QueueWorker dispatch
+xxxxxxx Wire Copilot Chat discovery into QueueWorker
+xxxxxxx Surface Copilot Chat status in Installer.getStatus
+xxxxxxx Wire Copilot Chat detection into Installer.install auto-enable
+xxxxxxx Add CopilotChatSessionDiscoverer
+xxxxxxx Add readCopilotChatTranscript matching TranscriptReadResult
+xxxxxxx Add replayPatches for Copilot Chat JSONL
+xxxxxxx Add patch path primitives for Copilot Chat reader
+xxxxxxx Add copilot-chat to TranscriptSource and SessionTracker filter
+xxxxxxx Add CopilotChatDetector
+xxxxxxx Refactor CursorSessionDiscoverer to use VscodeWorkspaceLocator
+xxxxxxx Refactor CursorDetector to use VscodeWorkspaceLocator
+xxxxxxx Add VscodeWorkspaceLocator shared module
+```
+
+---
+
+## Out of plan (NOT done here — listed for awareness)
+
+These are flagged in the spec's "Out of scope" section. The plan does **not** include them:
+
+- Multi-root `.code-workspace` workspace support
+- VS Code Insiders / Code-OSS / fork support
+- Live tail of in-progress sessions
+- Reading `chatEditingSessions/`
+
+If a follow-up plan is needed for any of these, write a new design doc + plan; do not stretch this one.

--- a/docs/superpowers/plans/2026-05-07-copilot-chat-events-jsonl-redesign.md
+++ b/docs/superpowers/plans/2026-05-07-copilot-chat-events-jsonl-redesign.md
@@ -1,0 +1,1695 @@
+# Copilot Chat events.jsonl Redesign — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `copilot-chat` source actually capture VS Code chat panel "New Chat" sessions by replacing the failed v1/v2 storage assumptions with two scans (`~/.copilot/session-state/<sid>/events.jsonl` for copilotcli-backend chat sessions, `<wsHash>/chatSessions/<sid>.jsonl` for non-copilotcli-backend chat sessions).
+
+**Architecture:** Three modules in `cli/src/core/` are touched. `CopilotChatDetector` adds a second probe path. `CopilotChatSessionDiscoverer` is fully rewritten to scan two locations. `CopilotChatTranscriptReader` is refactored into a path-dispatching front door with two sub-readers — `readEventsJsonl` (new, line-based cursor) and `readPatchLog` (the existing `readCopilotChatTranscript` body, lifted unchanged + extended with `beforeTimestamp` gate). Existing helpers `_setAtPath` / `_deleteAtPath` / `_replayPatches` are reused unchanged. One line in `QueueWorker.ts` updates to pass `beforeTimestamp` to the reader. The standalone `copilot` source (`CopilotSessionDiscoverer` reading `session-store.db`) is **untouched** — it already covers the "New Copilot CLI Session" entry point (which is a vscode-spawned terminal running the `copilot` binary).
+
+**Tech Stack:** TypeScript ESM, Vitest, biome (tabs, lineWidth 120), `node:fs/promises`, `node:readline`. Follows conventions of `CopilotSessionDiscoverer` / `CursorSessionDiscoverer` / existing test fixtures.
+
+**Spec:** `docs/superpowers/specs/2026-05-07-copilot-chat-events-jsonl-redesign-design.md`
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|---|---|---|
+| `cli/src/core/CopilotChatDetector.ts` | **Modify** | Detector for either Copilot Chat extension OR Copilot CLI agent backend on disk |
+| `cli/src/core/CopilotChatDetector.test.ts` | **Rewrite** | Cover both probe paths and their failure modes |
+| `cli/src/core/CopilotChatSessionDiscoverer.ts` | **Rewrite** | Two-scan discoverer (Scan A: events.jsonl + folderPath gate; Scan B: chatSessions/*.jsonl) |
+| `cli/src/core/CopilotChatSessionDiscoverer.test.ts` | **Rewrite** | Both scans, dedup behavior, error channel |
+| `cli/src/core/CopilotChatTranscriptReader.ts` | **Modify** | Dispatcher + readEventsJsonl + readPatchLog (lifted from current body) + `beforeTimestamp` gate. Helpers `_setAtPath`/`_deleteAtPath`/`_replayPatches` stay unchanged. |
+| `cli/src/core/CopilotChatTranscriptReader.test.ts` | **Modify** | Keep helper tests, add dispatcher + sub-reader tests, update existing patch-log test cases for new signature |
+| `cli/src/hooks/QueueWorker.ts` | **1-line modify** | Pass `beforeTimestamp` to `readCopilotChatTranscript` at line 1532 |
+| `cli/src/hooks/QueueWorker.test.ts` | **No change** | Existing mocks of `discoverCopilotChatSessions` / `isCopilotChatInstalled` remain valid (signatures unchanged) |
+
+---
+
+## Pre-flight checks
+
+- [ ] **Step 0.1: Verify clean working tree before starting**
+
+Run: `cd /Users/flyer/jolli/code/jollimemory-worktrees/feature/change-storage-to-folder && git status --short`
+Expected: empty output (clean tree). If not clean, stop and reconcile manually.
+
+- [ ] **Step 0.2: Verify spec is committed**
+
+Run: `git log --oneline -3 -- docs/superpowers/specs/2026-05-07-copilot-chat-events-jsonl-redesign-design.md`
+Expected: at least one commit exists touching the spec file.
+
+- [ ] **Step 0.3: Run baseline test + typecheck (record current pass count)**
+
+Run: `npm run typecheck:cli && npm run test -w @jolli.ai/cli`
+Expected: both succeed (or fail in known/baseline ways — capture the test count for regression comparison).
+
+---
+
+## Task 1: Modify `CopilotChatDetector` to probe two roots
+
+**Why:** The current detector only checks `<userDataDir>/User/globalStorage/github.copilot-chat` (Copilot Chat extension installed). The new design needs the detector to also return true when the user has only the Copilot CLI agent backend on disk (`~/.copilot/session-state/`), since that path can carry vscode chat panel sessions even when the extension global storage is absent.
+
+**Files:**
+- Modify: `cli/src/core/CopilotChatDetector.ts`
+- Test: `cli/src/core/CopilotChatDetector.test.ts` (rewrite)
+
+- [ ] **Step 1.1: Open the test file and replace its contents with the new cases**
+
+Replace **the entire file contents** with:
+
+```typescript
+import { stat } from "node:fs/promises";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("node:fs/promises", async () => {
+	const actual = await vi.importActual<typeof import("node:fs/promises")>("node:fs/promises");
+	return { ...actual, stat: vi.fn() };
+});
+
+const { mockHomedir, mockPlatform } = vi.hoisted(() => ({
+	mockHomedir: vi.fn().mockReturnValue("/Users/test"),
+	mockPlatform: vi.fn().mockReturnValue("darwin"),
+}));
+
+vi.mock("node:os", async (importOriginal) => {
+	const original = await importOriginal<typeof import("node:os")>();
+	return { ...original, homedir: mockHomedir, platform: mockPlatform };
+});
+
+describe("CopilotChatDetector", () => {
+	beforeEach(() => {
+		mockHomedir.mockReturnValue("/Users/test");
+		mockPlatform.mockReturnValue("darwin");
+		vi.mocked(stat).mockReset();
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("getCopilotChatStorageDir returns vscode globalStorage path on darwin", async () => {
+		const { getCopilotChatStorageDir } = await import("./CopilotChatDetector.js");
+		expect(getCopilotChatStorageDir()).toBe(
+			"/Users/test/Library/Application Support/Code/User/globalStorage/github.copilot-chat",
+		);
+	});
+
+	it("getCopilotCliSessionStateDir returns ~/.copilot/session-state path", async () => {
+		const { getCopilotCliSessionStateDir } = await import("./CopilotChatDetector.js");
+		expect(getCopilotCliSessionStateDir()).toBe("/Users/test/.copilot/session-state");
+	});
+
+	it("isCopilotChatInstalled returns true when ONLY globalStorage exists", async () => {
+		vi.mocked(stat).mockImplementation(async (path) => {
+			if (String(path).includes("globalStorage/github.copilot-chat")) {
+				return { isDirectory: () => true } as Awaited<ReturnType<typeof stat>>;
+			}
+			throw Object.assign(new Error("no dir"), { code: "ENOENT" });
+		});
+		const { isCopilotChatInstalled } = await import("./CopilotChatDetector.js");
+		await expect(isCopilotChatInstalled()).resolves.toBe(true);
+	});
+
+	it("isCopilotChatInstalled returns true when ONLY ~/.copilot/session-state exists", async () => {
+		vi.mocked(stat).mockImplementation(async (path) => {
+			if (String(path).includes(".copilot/session-state")) {
+				return { isDirectory: () => true } as Awaited<ReturnType<typeof stat>>;
+			}
+			throw Object.assign(new Error("no dir"), { code: "ENOENT" });
+		});
+		const { isCopilotChatInstalled } = await import("./CopilotChatDetector.js");
+		await expect(isCopilotChatInstalled()).resolves.toBe(true);
+	});
+
+	it("isCopilotChatInstalled returns true when BOTH paths exist", async () => {
+		vi.mocked(stat).mockResolvedValue({ isDirectory: () => true } as Awaited<ReturnType<typeof stat>>);
+		const { isCopilotChatInstalled } = await import("./CopilotChatDetector.js");
+		await expect(isCopilotChatInstalled()).resolves.toBe(true);
+	});
+
+	it("isCopilotChatInstalled returns false when both paths missing", async () => {
+		vi.mocked(stat).mockRejectedValue(Object.assign(new Error("no dir"), { code: "ENOENT" }));
+		const { isCopilotChatInstalled } = await import("./CopilotChatDetector.js");
+		await expect(isCopilotChatInstalled()).resolves.toBe(false);
+	});
+
+	it("isCopilotChatInstalled returns false when path exists but is not a directory", async () => {
+		vi.mocked(stat).mockResolvedValue({ isDirectory: () => false } as Awaited<ReturnType<typeof stat>>);
+		const { isCopilotChatInstalled } = await import("./CopilotChatDetector.js");
+		await expect(isCopilotChatInstalled()).resolves.toBe(false);
+	});
+
+	it("isCopilotChatInstalled returns false on unexpected stat error and warn-logs", async () => {
+		vi.mocked(stat).mockRejectedValue(Object.assign(new Error("perm denied"), { code: "EACCES" }));
+		const { isCopilotChatInstalled } = await import("./CopilotChatDetector.js");
+		await expect(isCopilotChatInstalled()).resolves.toBe(false);
+	});
+});
+```
+
+- [ ] **Step 1.2: Run tests to verify they fail**
+
+Run: `npx vitest run cli/src/core/CopilotChatDetector.test.ts`
+Expected: 2 of the 8 cases fail — the new `getCopilotCliSessionStateDir` test fails with "is not a function", and the "ONLY ~/.copilot/session-state exists" case fails because the existing detector only checks globalStorage.
+
+- [ ] **Step 1.3: Modify `CopilotChatDetector.ts`**
+
+Replace **the entire file contents** with:
+
+```typescript
+/**
+ * VS Code Copilot Chat detector.
+ *
+ * Returns true when EITHER of the two Copilot Chat data roots exist:
+ *   - <userDataDir>/User/globalStorage/github.copilot-chat (Copilot Chat extension installed)
+ *   - ~/.copilot/session-state                              (Copilot CLI agent backend on disk)
+ *
+ * Either root can carry chat panel "New Chat" session data; chat-panel sessions
+ * with copilotcli-backend models write to the latter (events.jsonl), and
+ * sessions with other-vendor models write to chatSessions/<sid>.jsonl under
+ * the former's parent workspace storage tree.
+ */
+
+import { stat } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { createLogger } from "../Logger.js";
+import { getVscodeUserDataDir } from "./VscodeWorkspaceLocator.js";
+
+const log = createLogger("CopilotChatDetector");
+
+/** Returns vscode's globalStorage/github.copilot-chat directory path. */
+export function getCopilotChatStorageDir(home?: string): string {
+	return join(getVscodeUserDataDir("Code", home), "User", "globalStorage", "github.copilot-chat");
+}
+
+/** Returns ~/.copilot/session-state directory path (Copilot CLI agent backend). */
+export function getCopilotCliSessionStateDir(home: string = homedir()): string {
+	return join(home, ".copilot", "session-state");
+}
+
+async function existsAsDir(path: string): Promise<boolean> {
+	try {
+		const fileStat = await stat(path);
+		return fileStat.isDirectory();
+	} catch (error: unknown) {
+		const code = (error as NodeJS.ErrnoException).code;
+		if (code !== "ENOENT") {
+			log.warn("Copilot Chat probe stat failed for %s (%s): %s", path, code ?? "unknown", (error as Error).message);
+		}
+		return false;
+	}
+}
+
+/**
+ * Returns true when either of the two known Copilot Chat data roots exists.
+ * Returns false on ENOENT or non-directory state for both.
+ */
+export async function isCopilotChatInstalled(): Promise<boolean> {
+	const [globalStorage, sessionState] = await Promise.all([
+		existsAsDir(getCopilotChatStorageDir()),
+		existsAsDir(getCopilotCliSessionStateDir()),
+	]);
+	return globalStorage || sessionState;
+}
+```
+
+- [ ] **Step 1.4: Run tests to verify they pass**
+
+Run: `npx vitest run cli/src/core/CopilotChatDetector.test.ts`
+Expected: all 8 cases PASS.
+
+- [ ] **Step 1.5: Run typecheck + biome**
+
+Run: `npm run typecheck:cli && npx biome check --error-on-warnings cli/src/core/CopilotChatDetector.ts cli/src/core/CopilotChatDetector.test.ts`
+Expected: both succeed.
+
+- [ ] **Step 1.6: Commit**
+
+```bash
+git add cli/src/core/CopilotChatDetector.ts cli/src/core/CopilotChatDetector.test.ts
+git commit -s -m "$(cat <<'EOF'
+feat(copilot-chat): probe both globalStorage and ~/.copilot/session-state
+
+The detector now returns true when either Copilot Chat extension's
+globalStorage or Copilot CLI agent backend's session-state directory
+exists. This is the precondition for the discoverer to scan two
+locations in subsequent commits.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: Lift existing reader body into `readPatchLog`, add dispatcher
+
+**Why:** The current `readCopilotChatTranscript` body is exactly the patch-log sub-reader the new design needs. Lifting it into a private `readPatchLog` function and putting a thin dispatcher on top is a behavior-preserving refactor that sets the stage for adding `readEventsJsonl` next. We do this as its own task so that a regression at this point would clearly point at the refactor — not get tangled with new functionality.
+
+**Files:**
+- Modify: `cli/src/core/CopilotChatTranscriptReader.ts`
+- Test: `cli/src/core/CopilotChatTranscriptReader.test.ts` (modify — add dispatcher tests, keep existing tests)
+
+- [ ] **Step 2.1: Add a failing dispatcher test**
+
+Append to `cli/src/core/CopilotChatTranscriptReader.test.ts` after the existing test blocks:
+
+```typescript
+describe("readCopilotChatTranscript dispatcher", () => {
+	let tmpRoot: string;
+
+	beforeEach(() => {
+		tmpRoot = mkdtempSync(join(tmpdir(), "copilot-chat-rdr-"));
+	});
+
+	afterEach(() => {
+		rmSync(tmpRoot, { recursive: true, force: true });
+	});
+
+	it("routes <wsHash>/chatSessions/<sid>.jsonl to patch-log reader (yields requests entries)", async () => {
+		const wsDir = join(tmpRoot, "ws1", "chatSessions");
+		mkdirSync(wsDir, { recursive: true });
+		const path = join(wsDir, "abc123.jsonl");
+		const lines = [
+			JSON.stringify({ kind: 0, v: { requests: [] } }),
+			JSON.stringify({
+				kind: 1,
+				k: ["requests", 0],
+				v: { message: { text: "hello" }, response: [{ value: "world" }] },
+			}),
+		];
+		writeFileSync(path, lines.join("\n"));
+		const result = await readCopilotChatTranscript(path);
+		expect(result.entries).toEqual([
+			{ role: "human", content: "hello" },
+			{ role: "assistant", content: "world" },
+		]);
+	});
+
+	it("throws on an unrecognized path pattern", async () => {
+		const path = join(tmpRoot, "random", "thing.txt");
+		mkdirSync(join(tmpRoot, "random"), { recursive: true });
+		writeFileSync(path, "{}");
+		await expect(readCopilotChatTranscript(path)).rejects.toThrow(/unrecognized.*path/i);
+	});
+});
+```
+
+You also need to extend the existing top-of-file imports if `mkdirSync` / `mkdtempSync` / `rmSync` / `tmpdir` / `join` aren't already imported. Edit the existing import lines so they look like:
+
+```typescript
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { _deleteAtPath, _replayPatches, _setAtPath, readCopilotChatTranscript } from "./CopilotChatTranscriptReader.js";
+```
+
+- [ ] **Step 2.2: Run tests to confirm both new dispatcher cases fail**
+
+Run: `npx vitest run cli/src/core/CopilotChatTranscriptReader.test.ts -t "dispatcher"`
+Expected: 1st case "routes ... to patch-log reader" — likely passes by coincidence (current reader handles `.jsonl`); 2nd case "throws on an unrecognized path pattern" — FAILS because current reader doesn't validate path shape.
+
+- [ ] **Step 2.3: Refactor `CopilotChatTranscriptReader.ts` — extract `readPatchLog`, add dispatcher**
+
+Replace the existing `readCopilotChatTranscript` function (around lines 138–206 of the current file) with the following. **Keep `_setAtPath`, `_deleteAtPath`, `_replayPatches`, and `CopilotChatScanError` exactly as they are.** Below is the new content that replaces from `interface ChatRequest` to end of file:
+
+```typescript
+interface ChatRequest {
+	message?: { text?: string };
+	response?: ReadonlyArray<{ value?: string }>;
+}
+
+/**
+ * Reads a `<wsHash>/chatSessions/<sid>.jsonl` patch log: replay all patches
+ * into a final document, then emit TranscriptEntry records for `requests[i]`
+ * where `i >= cursor.lineNumber`. The cursor's `lineNumber` field is repurposed
+ * here as "request count already consumed" — it never exceeds `requests.length`
+ * and only advances on successful emit.
+ */
+async function readPatchLog(
+	transcriptPath: string,
+	cursor?: TranscriptCursor,
+): Promise<TranscriptReadResult> {
+	const fromIdx = cursor?.lineNumber ?? 0;
+
+	let raw: string;
+	try {
+		raw = await readFile(transcriptPath, "utf8");
+	} catch (error: unknown) {
+		throwScanError("fs", (error as Error).message);
+	}
+
+	const lines = raw.split("\n").filter((l) => l.length > 0);
+	if (lines.length === 0) {
+		const updatedAt = await stat(transcriptPath).then((s) => new Date(s.mtimeMs).toISOString());
+		return {
+			entries: [],
+			newCursor: { transcriptPath, lineNumber: 0, updatedAt },
+			totalLinesRead: 0,
+		};
+	}
+
+	let doc: unknown;
+	try {
+		doc = _replayPatches(lines);
+	} catch (error: unknown) {
+		throwScanError("parse", (error as Error).message);
+	}
+
+	const requests = (doc as { requests?: unknown }).requests;
+	if (!Array.isArray(requests)) {
+		throwScanError("schema", "requests is not an array");
+	}
+
+	const entries: TranscriptEntry[] = [];
+	for (let i = fromIdx; i < requests.length; i++) {
+		const req = requests[i] as ChatRequest;
+		const userText = req?.message?.text;
+		if (typeof userText === "string" && userText.length > 0) {
+			entries.push({ role: "human", content: userText });
+		}
+		const responseList = Array.isArray(req?.response) ? req.response : [];
+		const assistantText = responseList
+			.map((chunk) => (typeof chunk?.value === "string" ? chunk.value : ""))
+			.join("");
+		if (assistantText.length > 0) {
+			entries.push({ role: "assistant", content: assistantText });
+		}
+	}
+
+	const updatedAt = await stat(transcriptPath).then((s) => new Date(s.mtimeMs).toISOString());
+	return {
+		entries,
+		newCursor: { transcriptPath, lineNumber: requests.length, updatedAt },
+		totalLinesRead: lines.length,
+	};
+}
+
+/**
+ * Front door for Copilot Chat transcript reading. Dispatches to one of two
+ * sub-readers based on the trailing path segments of `transcriptPath`:
+ *
+ *   - `<...>/.copilot/session-state/<sid>/events.jsonl` → readEventsJsonl (added in a later task)
+ *   - `<...>/chatSessions/<sid>.jsonl`                 → readPatchLog
+ *
+ * Throws on an unrecognized path — the discoverer should never emit anything
+ * else, so this is a defense-in-depth invariant.
+ */
+export async function readCopilotChatTranscript(
+	transcriptPath: string,
+	cursor?: TranscriptCursor,
+): Promise<TranscriptReadResult> {
+	const norm = transcriptPath.replace(/\\/g, "/");
+	if (/\/chatSessions\/[^/]+\.jsonl$/.test(norm)) {
+		return readPatchLog(transcriptPath, cursor);
+	}
+	throw new Error(`Copilot Chat reader: unrecognized transcriptPath pattern: ${transcriptPath}`);
+}
+```
+
+- [ ] **Step 2.4: Run reader test file to verify all tests pass**
+
+Run: `npx vitest run cli/src/core/CopilotChatTranscriptReader.test.ts`
+Expected: ALL existing tests pass + the 2 new dispatcher tests pass. The existing patch-log behavior is preserved because the dispatcher routes the `chatSessions/<sid>.jsonl` shape to `readPatchLog`.
+
+- [ ] **Step 2.5: Run typecheck + biome**
+
+Run: `npm run typecheck:cli && npx biome check --error-on-warnings cli/src/core/CopilotChatTranscriptReader.ts cli/src/core/CopilotChatTranscriptReader.test.ts`
+Expected: both succeed.
+
+- [ ] **Step 2.6: Commit**
+
+```bash
+git add cli/src/core/CopilotChatTranscriptReader.ts cli/src/core/CopilotChatTranscriptReader.test.ts
+git commit -s -m "$(cat <<'EOF'
+refactor(copilot-chat): extract readPatchLog, add path dispatcher
+
+Behavior-preserving refactor: lifts existing readCopilotChatTranscript
+body into a private readPatchLog function and puts a thin dispatcher
+on top that validates the path shape. Sets the stage for adding the
+events.jsonl sub-reader in the next commit.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: Add `readEventsJsonl` sub-reader
+
+**Why:** Vscode chat panel "New Chat" with copilotcli-backend models writes its conversation to `~/.copilot/session-state/<sid>/events.jsonl` — a per-line event stream where conversation lives in `type:"user.message"` and `type:"assistant.message"` events. The existing `copilot` source reads `session-store.db` and never sees these sessions; we need a dedicated reader.
+
+**Files:**
+- Modify: `cli/src/core/CopilotChatTranscriptReader.ts`
+- Test: `cli/src/core/CopilotChatTranscriptReader.test.ts`
+
+- [ ] **Step 3.1: Append failing tests for `readEventsJsonl` via the dispatcher**
+
+Append to `cli/src/core/CopilotChatTranscriptReader.test.ts` after the existing dispatcher describe block:
+
+```typescript
+describe("readCopilotChatTranscript via events.jsonl path", () => {
+	let tmpRoot: string;
+	let sessionDir: string;
+	let eventsPath: string;
+
+	beforeEach(() => {
+		tmpRoot = mkdtempSync(join(tmpdir(), "copilot-events-"));
+		sessionDir = join(tmpRoot, ".copilot", "session-state", "sess-1");
+		mkdirSync(sessionDir, { recursive: true });
+		eventsPath = join(sessionDir, "events.jsonl");
+	});
+
+	afterEach(() => {
+		rmSync(tmpRoot, { recursive: true, force: true });
+	});
+
+	function writeEvents(events: ReadonlyArray<unknown>): void {
+		writeFileSync(eventsPath, events.map((e) => JSON.stringify(e)).join("\n") + "\n");
+	}
+
+	it("emits user.message and non-empty assistant.message in file order", async () => {
+		writeEvents([
+			{ type: "session.start", data: {}, timestamp: "2026-05-07T10:00:00.000Z" },
+			{ type: "system.message", data: { content: "system prompt" }, timestamp: "2026-05-07T10:00:01.000Z" },
+			{ type: "user.message", data: { content: "hi" }, timestamp: "2026-05-07T10:00:02.000Z" },
+			{ type: "assistant.turn_start", data: {}, timestamp: "2026-05-07T10:00:03.000Z" },
+			{ type: "assistant.message", data: { content: "hello there" }, timestamp: "2026-05-07T10:00:04.000Z" },
+			{ type: "tool.execution_start", data: {}, timestamp: "2026-05-07T10:00:05.000Z" },
+			{ type: "tool.execution_complete", data: {}, timestamp: "2026-05-07T10:00:06.000Z" },
+			{ type: "assistant.turn_end", data: {}, timestamp: "2026-05-07T10:00:07.000Z" },
+		]);
+		const result = await readCopilotChatTranscript(eventsPath);
+		expect(result.entries).toEqual([
+			{ role: "human", content: "hi", timestamp: "2026-05-07T10:00:02.000Z" },
+			{ role: "assistant", content: "hello there", timestamp: "2026-05-07T10:00:04.000Z" },
+		]);
+		expect(result.newCursor.lineNumber).toBe(8);
+	});
+
+	it("drops assistant.message with empty content (tool-only turn)", async () => {
+		writeEvents([
+			{ type: "user.message", data: { content: "do tool" }, timestamp: "2026-05-07T10:00:00.000Z" },
+			{
+				type: "assistant.message",
+				data: { content: "", toolRequests: [{ name: "shell" }] },
+				timestamp: "2026-05-07T10:00:01.000Z",
+			},
+			{ type: "assistant.message", data: { content: "ok done" }, timestamp: "2026-05-07T10:00:02.000Z" },
+		]);
+		const result = await readCopilotChatTranscript(eventsPath);
+		expect(result.entries).toEqual([
+			{ role: "human", content: "do tool", timestamp: "2026-05-07T10:00:00.000Z" },
+			{ role: "assistant", content: "ok done", timestamp: "2026-05-07T10:00:02.000Z" },
+		]);
+	});
+
+	it("returns no entries when file contains only non-conversation events", async () => {
+		writeEvents([
+			{ type: "session.start", data: {} },
+			{ type: "session.shutdown", data: {} },
+		]);
+		const result = await readCopilotChatTranscript(eventsPath);
+		expect(result.entries).toEqual([]);
+		expect(result.newCursor.lineNumber).toBe(2);
+	});
+
+	it("advances past a malformed line and continues", async () => {
+		writeFileSync(
+			eventsPath,
+			[
+				JSON.stringify({ type: "user.message", data: { content: "before" }, timestamp: "2026-05-07T10:00:00.000Z" }),
+				"{not valid json",
+				JSON.stringify({ type: "assistant.message", data: { content: "after" }, timestamp: "2026-05-07T10:00:01.000Z" }),
+			].join("\n") + "\n",
+		);
+		const result = await readCopilotChatTranscript(eventsPath);
+		expect(result.entries).toEqual([
+			{ role: "human", content: "before", timestamp: "2026-05-07T10:00:00.000Z" },
+			{ role: "assistant", content: "after", timestamp: "2026-05-07T10:00:01.000Z" },
+		]);
+		expect(result.newCursor.lineNumber).toBe(3);
+	});
+
+	it("respects cursor.lineNumber as resume point", async () => {
+		writeEvents([
+			{ type: "user.message", data: { content: "old" }, timestamp: "2026-05-07T09:00:00.000Z" },
+			{ type: "assistant.message", data: { content: "old reply" }, timestamp: "2026-05-07T09:00:01.000Z" },
+			{ type: "user.message", data: { content: "new" }, timestamp: "2026-05-07T10:00:00.000Z" },
+			{ type: "assistant.message", data: { content: "new reply" }, timestamp: "2026-05-07T10:00:01.000Z" },
+		]);
+		const result = await readCopilotChatTranscript(eventsPath, {
+			transcriptPath: eventsPath,
+			lineNumber: 2,
+			updatedAt: "2026-05-07T09:30:00.000Z",
+		});
+		expect(result.entries).toEqual([
+			{ role: "human", content: "new", timestamp: "2026-05-07T10:00:00.000Z" },
+			{ role: "assistant", content: "new reply", timestamp: "2026-05-07T10:00:01.000Z" },
+		]);
+		expect(result.newCursor.lineNumber).toBe(4);
+	});
+
+	it("emits entries with timestamp:undefined when event has no timestamp", async () => {
+		writeEvents([
+			{ type: "user.message", data: { content: "no-ts" } },
+			{ type: "assistant.message", data: { content: "also no-ts" } },
+		]);
+		const result = await readCopilotChatTranscript(eventsPath);
+		expect(result.entries).toEqual([
+			{ role: "human", content: "no-ts" },
+			{ role: "assistant", content: "also no-ts" },
+		]);
+	});
+});
+```
+
+- [ ] **Step 3.2: Run reader tests to confirm new tests fail**
+
+Run: `npx vitest run cli/src/core/CopilotChatTranscriptReader.test.ts -t "via events.jsonl"`
+Expected: all 6 new cases FAIL — they hit the dispatcher's "unrecognized path" throw because we haven't added the events.jsonl branch yet.
+
+- [ ] **Step 3.3: Add `readEventsJsonl` and route the dispatcher to it**
+
+Edit `cli/src/core/CopilotChatTranscriptReader.ts`. **Add this import at the top of the file** (alongside the existing `node:fs/promises` import):
+
+```typescript
+import { createReadStream } from "node:fs";
+import { createInterface } from "node:readline";
+```
+
+Then **insert this function above `readPatchLog`** (i.e. between `interface ChatRequest` and `async function readPatchLog`):
+
+```typescript
+interface EventsLineEvent {
+	type?: string;
+	timestamp?: string;
+	data?: { content?: string };
+}
+
+/**
+ * Reads `~/.copilot/session-state/<sid>/events.jsonl` line-by-line. Conversation
+ * lives in `type:"user.message"` and non-empty `type:"assistant.message"`
+ * events; everything else (session lifecycle, tool calls, assistant turn
+ * boundaries, system prompts) is skipped. The cursor's `lineNumber` is the
+ * standard "lines already consumed" semantics (first line is line 1).
+ *
+ * Per-line `JSON.parse` failures are skipped and the cursor still advances
+ * past the bad line — matches the Claude / Codex / Gemini JSONL readers'
+ * "one bad line never blocks the rest" policy.
+ */
+async function readEventsJsonl(
+	transcriptPath: string,
+	cursor?: TranscriptCursor,
+): Promise<TranscriptReadResult> {
+	const startLine = cursor?.lineNumber ?? 0;
+	const stream = createReadStream(transcriptPath, { encoding: "utf8" });
+	const rl = createInterface({ input: stream, crlfDelay: Number.POSITIVE_INFINITY });
+
+	const entries: TranscriptEntry[] = [];
+	let currentLine = 0;
+
+	for await (const rawLine of rl) {
+		currentLine++;
+		if (currentLine <= startLine) continue;
+
+		let evt: EventsLineEvent;
+		try {
+			evt = JSON.parse(rawLine) as EventsLineEvent;
+		} catch {
+			// skip malformed line, cursor still advances
+			continue;
+		}
+
+		const content = evt.data?.content;
+		if (typeof content !== "string" || content.length === 0) continue;
+
+		if (evt.type === "user.message") {
+			entries.push(evt.timestamp ? { role: "human", content, timestamp: evt.timestamp } : { role: "human", content });
+		} else if (evt.type === "assistant.message") {
+			entries.push(
+				evt.timestamp ? { role: "assistant", content, timestamp: evt.timestamp } : { role: "assistant", content },
+			);
+		}
+	}
+
+	const updatedAt = await stat(transcriptPath).then((s) => new Date(s.mtimeMs).toISOString());
+	return {
+		entries,
+		newCursor: { transcriptPath, lineNumber: currentLine, updatedAt },
+		totalLinesRead: currentLine - startLine,
+	};
+}
+```
+
+Then **modify the dispatcher** (the `readCopilotChatTranscript` function added in Task 2) to route to the new sub-reader. Replace its body with:
+
+```typescript
+export async function readCopilotChatTranscript(
+	transcriptPath: string,
+	cursor?: TranscriptCursor,
+): Promise<TranscriptReadResult> {
+	const norm = transcriptPath.replace(/\\/g, "/");
+	if (/\/\.copilot\/session-state\/[^/]+\/events\.jsonl$/.test(norm)) {
+		return readEventsJsonl(transcriptPath, cursor);
+	}
+	if (/\/chatSessions\/[^/]+\.jsonl$/.test(norm)) {
+		return readPatchLog(transcriptPath, cursor);
+	}
+	throw new Error(`Copilot Chat reader: unrecognized transcriptPath pattern: ${transcriptPath}`);
+}
+```
+
+- [ ] **Step 3.4: Run all reader tests to verify they pass**
+
+Run: `npx vitest run cli/src/core/CopilotChatTranscriptReader.test.ts`
+Expected: ALL tests pass — 6 new events.jsonl cases + 2 dispatcher cases + all preexisting helper / patch-log cases.
+
+- [ ] **Step 3.5: Run typecheck + biome**
+
+Run: `npm run typecheck:cli && npx biome check --error-on-warnings cli/src/core/CopilotChatTranscriptReader.ts cli/src/core/CopilotChatTranscriptReader.test.ts`
+Expected: both succeed.
+
+- [ ] **Step 3.6: Commit**
+
+```bash
+git add cli/src/core/CopilotChatTranscriptReader.ts cli/src/core/CopilotChatTranscriptReader.test.ts
+git commit -s -m "$(cat <<'EOF'
+feat(copilot-chat): add events.jsonl sub-reader for chat panel sessions
+
+Adds readEventsJsonl, routed by the dispatcher when transcriptPath
+matches ~/.copilot/session-state/<sid>/events.jsonl. Emits
+user.message and non-empty assistant.message events; skips system
+prompts, tool calls, and turn boundaries. Per-line JSON.parse
+failures are skipped (cursor still advances), matching other JSONL
+readers.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: Add `beforeTimestamp` gate to both sub-readers
+
+**Why:** Every other discovery-based source reader (`readGeminiTranscript`, `readCopilotTranscript`, `readCursorTranscript`, `readOpenCodeTranscript`) accepts a `beforeTimestamp` parameter so the QueueWorker can attribute transcript entries to the correct commit (entries with timestamp > cutoff are deferred to the next commit). The Copilot Chat reader has been the odd one out. Adding the gate brings it in line with the rest of the source pipeline.
+
+**Files:**
+- Modify: `cli/src/core/CopilotChatTranscriptReader.ts`
+- Test: `cli/src/core/CopilotChatTranscriptReader.test.ts`
+
+- [ ] **Step 4.1: Add failing tests for `beforeTimestamp` on both sub-readers**
+
+Append to `cli/src/core/CopilotChatTranscriptReader.test.ts`:
+
+```typescript
+describe("readCopilotChatTranscript beforeTimestamp gate", () => {
+	let tmpRoot: string;
+
+	beforeEach(() => {
+		tmpRoot = mkdtempSync(join(tmpdir(), "copilot-cutoff-"));
+	});
+
+	afterEach(() => {
+		rmSync(tmpRoot, { recursive: true, force: true });
+	});
+
+	it("events.jsonl: stops at first event whose timestamp > beforeTimestamp without consuming it", async () => {
+		const sessionDir = join(tmpRoot, ".copilot", "session-state", "s1");
+		mkdirSync(sessionDir, { recursive: true });
+		const path = join(sessionDir, "events.jsonl");
+		writeFileSync(
+			path,
+			[
+				JSON.stringify({ type: "user.message", data: { content: "early" }, timestamp: "2026-05-07T09:00:00.000Z" }),
+				JSON.stringify({
+					type: "assistant.message",
+					data: { content: "early reply" },
+					timestamp: "2026-05-07T09:00:30.000Z",
+				}),
+				JSON.stringify({ type: "user.message", data: { content: "late" }, timestamp: "2026-05-07T11:00:00.000Z" }),
+			].join("\n") + "\n",
+		);
+		const result = await readCopilotChatTranscript(path, undefined, "2026-05-07T10:00:00.000Z");
+		expect(result.entries).toEqual([
+			{ role: "human", content: "early", timestamp: "2026-05-07T09:00:00.000Z" },
+			{ role: "assistant", content: "early reply", timestamp: "2026-05-07T09:00:30.000Z" },
+		]);
+		// Cursor must NOT advance past the unconsumed late line — it sits at line 2.
+		expect(result.newCursor.lineNumber).toBe(2);
+	});
+
+	it("events.jsonl: events without timestamp are emitted (treated as before-cutoff)", async () => {
+		const sessionDir = join(tmpRoot, ".copilot", "session-state", "s2");
+		mkdirSync(sessionDir, { recursive: true });
+		const path = join(sessionDir, "events.jsonl");
+		writeFileSync(
+			path,
+			[
+				JSON.stringify({ type: "user.message", data: { content: "untimed" } }),
+				JSON.stringify({ type: "assistant.message", data: { content: "untimed reply" } }),
+			].join("\n") + "\n",
+		);
+		const result = await readCopilotChatTranscript(path, undefined, "2026-05-07T10:00:00.000Z");
+		expect(result.entries.length).toBe(2);
+	});
+
+	it("patch log: stops emitting at first request whose timestamp > beforeTimestamp without advancing cursor past it", async () => {
+		const wsDir = join(tmpRoot, "ws1", "chatSessions");
+		mkdirSync(wsDir, { recursive: true });
+		const path = join(wsDir, "p1.jsonl");
+		writeFileSync(
+			path,
+			[
+				JSON.stringify({ kind: 0, v: { requests: [] } }),
+				JSON.stringify({
+					kind: 1,
+					k: ["requests", 0],
+					v: {
+						message: { text: "early" },
+						response: [{ value: "early reply" }],
+						timestamp: Date.parse("2026-05-07T09:00:00.000Z"),
+					},
+				}),
+				JSON.stringify({
+					kind: 1,
+					k: ["requests", 1],
+					v: {
+						message: { text: "late" },
+						response: [{ value: "late reply" }],
+						timestamp: Date.parse("2026-05-07T11:00:00.000Z"),
+					},
+				}),
+			].join("\n"),
+		);
+		const result = await readCopilotChatTranscript(path, undefined, "2026-05-07T10:00:00.000Z");
+		expect(result.entries).toEqual([
+			{ role: "human", content: "early" },
+			{ role: "assistant", content: "early reply" },
+		]);
+		// Cursor stays at requests[1] so the next read picks up "late".
+		expect(result.newCursor.lineNumber).toBe(1);
+	});
+
+	it("patch log: requests without numeric timestamp are emitted (treated as before-cutoff)", async () => {
+		const wsDir = join(tmpRoot, "ws1", "chatSessions");
+		mkdirSync(wsDir, { recursive: true });
+		const path = join(wsDir, "p2.jsonl");
+		writeFileSync(
+			path,
+			[
+				JSON.stringify({ kind: 0, v: { requests: [] } }),
+				JSON.stringify({
+					kind: 1,
+					k: ["requests", 0],
+					v: { message: { text: "no-ts" }, response: [{ value: "no-ts reply" }] },
+				}),
+			].join("\n"),
+		);
+		const result = await readCopilotChatTranscript(path, undefined, "2026-05-07T10:00:00.000Z");
+		expect(result.entries.length).toBe(2);
+	});
+});
+```
+
+- [ ] **Step 4.2: Run tests to confirm new cases fail**
+
+Run: `npx vitest run cli/src/core/CopilotChatTranscriptReader.test.ts -t "beforeTimestamp"`
+Expected: all 4 cases fail — current `readCopilotChatTranscript` only accepts 2 parameters (`transcriptPath`, `cursor`).
+
+- [ ] **Step 4.3: Update the dispatcher signature, propagate `beforeTimestamp` to both sub-readers**
+
+In `cli/src/core/CopilotChatTranscriptReader.ts`:
+
+Change the dispatcher's signature and body to:
+
+```typescript
+export async function readCopilotChatTranscript(
+	transcriptPath: string,
+	cursor?: TranscriptCursor,
+	beforeTimestamp?: string,
+): Promise<TranscriptReadResult> {
+	const norm = transcriptPath.replace(/\\/g, "/");
+	if (/\/\.copilot\/session-state\/[^/]+\/events\.jsonl$/.test(norm)) {
+		return readEventsJsonl(transcriptPath, cursor, beforeTimestamp);
+	}
+	if (/\/chatSessions\/[^/]+\.jsonl$/.test(norm)) {
+		return readPatchLog(transcriptPath, cursor, beforeTimestamp);
+	}
+	throw new Error(`Copilot Chat reader: unrecognized transcriptPath pattern: ${transcriptPath}`);
+}
+```
+
+Modify `readEventsJsonl`'s signature to accept `beforeTimestamp` and gate the loop. Replace the existing function body with:
+
+```typescript
+async function readEventsJsonl(
+	transcriptPath: string,
+	cursor?: TranscriptCursor,
+	beforeTimestamp?: string,
+): Promise<TranscriptReadResult> {
+	const startLine = cursor?.lineNumber ?? 0;
+	const stream = createReadStream(transcriptPath, { encoding: "utf8" });
+	const rl = createInterface({ input: stream, crlfDelay: Number.POSITIVE_INFINITY });
+
+	const entries: TranscriptEntry[] = [];
+	let currentLine = 0;
+	let cutoffHit = false;
+
+	for await (const rawLine of rl) {
+		currentLine++;
+		if (currentLine <= startLine) continue;
+		if (cutoffHit) {
+			// Once the cutoff has been hit we stop counting AND don't advance cursor.
+			currentLine--; // undo the increment so cursor reflects last consumed
+			break;
+		}
+
+		let evt: EventsLineEvent;
+		try {
+			evt = JSON.parse(rawLine) as EventsLineEvent;
+		} catch {
+			continue;
+		}
+
+		// beforeTimestamp gate: events with timestamp > cutoff are deferred.
+		if (beforeTimestamp && typeof evt.timestamp === "string" && evt.timestamp > beforeTimestamp) {
+			cutoffHit = true;
+			currentLine--; // do not consume this line
+			break;
+		}
+
+		const content = evt.data?.content;
+		if (typeof content !== "string" || content.length === 0) continue;
+
+		if (evt.type === "user.message") {
+			entries.push(evt.timestamp ? { role: "human", content, timestamp: evt.timestamp } : { role: "human", content });
+		} else if (evt.type === "assistant.message") {
+			entries.push(
+				evt.timestamp ? { role: "assistant", content, timestamp: evt.timestamp } : { role: "assistant", content },
+			);
+		}
+	}
+
+	stream.close();
+	const updatedAt = await stat(transcriptPath).then((s) => new Date(s.mtimeMs).toISOString());
+	return {
+		entries,
+		newCursor: { transcriptPath, lineNumber: currentLine, updatedAt },
+		totalLinesRead: Math.max(0, currentLine - startLine),
+	};
+}
+```
+
+Modify `readPatchLog`'s signature similarly, and gate the request loop. Replace the function body with:
+
+```typescript
+async function readPatchLog(
+	transcriptPath: string,
+	cursor?: TranscriptCursor,
+	beforeTimestamp?: string,
+): Promise<TranscriptReadResult> {
+	const fromIdx = cursor?.lineNumber ?? 0;
+
+	let raw: string;
+	try {
+		raw = await readFile(transcriptPath, "utf8");
+	} catch (error: unknown) {
+		throwScanError("fs", (error as Error).message);
+	}
+
+	const lines = raw.split("\n").filter((l) => l.length > 0);
+	if (lines.length === 0) {
+		const updatedAt = await stat(transcriptPath).then((s) => new Date(s.mtimeMs).toISOString());
+		return {
+			entries: [],
+			newCursor: { transcriptPath, lineNumber: 0, updatedAt },
+			totalLinesRead: 0,
+		};
+	}
+
+	let doc: unknown;
+	try {
+		doc = _replayPatches(lines);
+	} catch (error: unknown) {
+		throwScanError("parse", (error as Error).message);
+	}
+
+	const requests = (doc as { requests?: unknown }).requests;
+	if (!Array.isArray(requests)) {
+		throwScanError("schema", "requests is not an array");
+	}
+
+	const cutoffMs = beforeTimestamp ? Date.parse(beforeTimestamp) : Number.POSITIVE_INFINITY;
+	const entries: TranscriptEntry[] = [];
+	let lastEmittedIdx = fromIdx;
+
+	for (let i = fromIdx; i < requests.length; i++) {
+		const req = requests[i] as ChatRequest & { timestamp?: number };
+		// beforeTimestamp gate: stop without advancing cursor past this request.
+		if (typeof req?.timestamp === "number" && req.timestamp > cutoffMs) {
+			break;
+		}
+		const userText = req?.message?.text;
+		if (typeof userText === "string" && userText.length > 0) {
+			entries.push({ role: "human", content: userText });
+		}
+		const responseList = Array.isArray(req?.response) ? req.response : [];
+		const assistantText = responseList
+			.map((chunk) => (typeof chunk?.value === "string" ? chunk.value : ""))
+			.join("");
+		if (assistantText.length > 0) {
+			entries.push({ role: "assistant", content: assistantText });
+		}
+		lastEmittedIdx = i + 1;
+	}
+
+	const updatedAt = await stat(transcriptPath).then((s) => new Date(s.mtimeMs).toISOString());
+	return {
+		entries,
+		newCursor: { transcriptPath, lineNumber: lastEmittedIdx, updatedAt },
+		totalLinesRead: lines.length,
+	};
+}
+```
+
+- [ ] **Step 4.4: Run all reader tests to confirm everything passes**
+
+Run: `npx vitest run cli/src/core/CopilotChatTranscriptReader.test.ts`
+Expected: all tests pass — including the 4 new beforeTimestamp tests AND every previously passing test (no regressions).
+
+- [ ] **Step 4.5: Run typecheck + biome**
+
+Run: `npm run typecheck:cli && npx biome check --error-on-warnings cli/src/core/CopilotChatTranscriptReader.ts cli/src/core/CopilotChatTranscriptReader.test.ts`
+Expected: both succeed.
+
+- [ ] **Step 4.6: Commit**
+
+```bash
+git add cli/src/core/CopilotChatTranscriptReader.ts cli/src/core/CopilotChatTranscriptReader.test.ts
+git commit -s -m "$(cat <<'EOF'
+feat(copilot-chat): add beforeTimestamp gate to events.jsonl + patch-log readers
+
+Brings copilot-chat reader in line with every other discovery-based
+source: when the QueueWorker passes a commit-time cutoff, the reader
+stops at the first entry past that cutoff and does NOT advance the
+cursor past it. The deferred entry is re-read at the next commit and
+attributed to the correct commit boundary.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: Rewrite `CopilotChatSessionDiscoverer` for two scans
+
+**Why:** The current discoverer scans `<wsHash>/GitHub.copilot-chat/debug-logs/<sid>/main.jsonl` (OpenTelemetry traces — not conversation) as the primary path with `chatSessions/<sid>.jsonl` as fallback. The new design replaces this with two independent scans: Scan A reads `~/.copilot/session-state/<sid>/events.jsonl` filtered by `vscode.metadata.json.workspaceFolder.folderPath === cwd` (covers chat panel "New Chat" with copilotcli-backend models); Scan B reads `<wsHash>/chatSessions/<sid>.jsonl` (covers chat panel "New Chat" with non-copilotcli-backend models). Both scans run in sequence, results concatenated, errors reported via the existing `CopilotChatScanError` channel.
+
+**Files:**
+- Rewrite: `cli/src/core/CopilotChatSessionDiscoverer.ts`
+- Rewrite: `cli/src/core/CopilotChatSessionDiscoverer.test.ts`
+
+- [ ] **Step 5.1: Replace test file contents with the new test plan**
+
+Replace **the entire contents of `cli/src/core/CopilotChatSessionDiscoverer.test.ts`** with:
+
+```typescript
+import { mkdirSync, mkdtempSync, rmSync, utimesSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockHomedir, mockPlatform } = vi.hoisted(() => ({
+	mockHomedir: vi.fn(),
+	mockPlatform: vi.fn().mockReturnValue("darwin"),
+}));
+
+vi.mock("node:os", async (importOriginal) => {
+	const original = await importOriginal<typeof import("node:os")>();
+	return { ...original, homedir: mockHomedir, platform: mockPlatform };
+});
+
+describe("scanCopilotChatSessions", () => {
+	let tmpRoot: string;
+	let projectDir: string;
+
+	beforeEach(() => {
+		tmpRoot = mkdtempSync(join(tmpdir(), "copilot-chat-disc-"));
+		projectDir = join(tmpRoot, "myproject");
+		mkdirSync(projectDir, { recursive: true });
+		mockHomedir.mockReturnValue(tmpRoot);
+		mockPlatform.mockReturnValue("darwin");
+	});
+
+	afterEach(() => {
+		rmSync(tmpRoot, { recursive: true, force: true });
+		vi.resetModules();
+	});
+
+	// ─── Scan A helpers (events.jsonl in ~/.copilot/session-state/<sid>/) ──────
+	function makeSessionStateEntry(opts: {
+		sid: string;
+		folderPath?: string | null; // null ⇒ omit field; undefined ⇒ no metadata file at all
+		omitMetadata?: boolean;
+		omitEvents?: boolean;
+		ageHours?: number;
+	}): string {
+		const dir = join(tmpRoot, ".copilot", "session-state", opts.sid);
+		mkdirSync(dir, { recursive: true });
+		if (!opts.omitMetadata) {
+			const meta: Record<string, unknown> = { origin: opts.folderPath ? "vscode" : "other" };
+			if (opts.folderPath !== null && opts.folderPath !== undefined) {
+				meta.workspaceFolder = { folderPath: opts.folderPath };
+			} else if (opts.folderPath === null) {
+				meta.workspaceFolder = { folderPath: "" };
+			}
+			writeFileSync(join(dir, "vscode.metadata.json"), JSON.stringify(meta));
+		}
+		const eventsPath = join(dir, "events.jsonl");
+		if (!opts.omitEvents) {
+			writeFileSync(eventsPath, JSON.stringify({ type: "session.start", data: {} }) + "\n");
+			if (opts.ageHours !== undefined) {
+				const targetSec = (Date.now() - opts.ageHours * 3600 * 1000) / 1000;
+				utimesSync(eventsPath, targetSec, targetSec);
+			}
+		}
+		return eventsPath;
+	}
+
+	// ─── Scan B helpers (<wsHash>/chatSessions/<sid>.jsonl) ────────────────────
+	function makeWorkspace(wsHash: string, folderUri: string): string {
+		const wsDir = join(tmpRoot, "Library", "Application Support", "Code", "User", "workspaceStorage", wsHash);
+		mkdirSync(wsDir, { recursive: true });
+		writeFileSync(join(wsDir, "workspace.json"), JSON.stringify({ folder: folderUri }));
+		return wsDir;
+	}
+
+	function makeChatSessionsFile(wsDir: string, name: string, ageHours: number): string {
+		const dir = join(wsDir, "chatSessions");
+		mkdirSync(dir, { recursive: true });
+		const path = join(dir, name);
+		writeFileSync(path, JSON.stringify({ kind: 0, v: { requests: [] } }));
+		const targetSec = (Date.now() - ageHours * 3600 * 1000) / 1000;
+		utimesSync(path, targetSec, targetSec);
+		return path;
+	}
+
+	// ─── Scan A (events.jsonl) ─────────────────────────────────────────────────
+	it("returns empty when neither root exists", async () => {
+		const { scanCopilotChatSessions } = await import("./CopilotChatSessionDiscoverer.js");
+		const result = await scanCopilotChatSessions(projectDir);
+		expect(result.sessions).toEqual([]);
+		expect(result.error).toBeUndefined();
+	});
+
+	it("Scan A: returns empty when session-state exists but is empty", async () => {
+		mkdirSync(join(tmpRoot, ".copilot", "session-state"), { recursive: true });
+		const { scanCopilotChatSessions } = await import("./CopilotChatSessionDiscoverer.js");
+		const result = await scanCopilotChatSessions(projectDir);
+		expect(result.sessions).toEqual([]);
+	});
+
+	it("Scan A: emits a session whose folderPath matches projectDir and events.jsonl is fresh", async () => {
+		const eventsPath = makeSessionStateEntry({ sid: "s-match", folderPath: projectDir, ageHours: 1 });
+		const { scanCopilotChatSessions } = await import("./CopilotChatSessionDiscoverer.js");
+		const result = await scanCopilotChatSessions(projectDir);
+		expect(result.sessions).toHaveLength(1);
+		expect(result.sessions[0]).toMatchObject({
+			sessionId: "s-match",
+			source: "copilot-chat",
+			transcriptPath: eventsPath,
+		});
+	});
+
+	it("Scan A: skips folderPath empty string (CLI standalone marker)", async () => {
+		makeSessionStateEntry({ sid: "s-empty", folderPath: null, ageHours: 1 });
+		const { scanCopilotChatSessions } = await import("./CopilotChatSessionDiscoverer.js");
+		const result = await scanCopilotChatSessions(projectDir);
+		expect(result.sessions).toEqual([]);
+	});
+
+	it("Scan A: skips when vscode.metadata.json is missing", async () => {
+		makeSessionStateEntry({ sid: "s-nometa", omitMetadata: true, ageHours: 1 });
+		const { scanCopilotChatSessions } = await import("./CopilotChatSessionDiscoverer.js");
+		const result = await scanCopilotChatSessions(projectDir);
+		expect(result.sessions).toEqual([]);
+	});
+
+	it("Scan A: skips when vscode.metadata.json is malformed", async () => {
+		const dir = join(tmpRoot, ".copilot", "session-state", "s-bad");
+		mkdirSync(dir, { recursive: true });
+		writeFileSync(join(dir, "vscode.metadata.json"), "{not json");
+		writeFileSync(join(dir, "events.jsonl"), "");
+		const { scanCopilotChatSessions } = await import("./CopilotChatSessionDiscoverer.js");
+		const result = await scanCopilotChatSessions(projectDir);
+		expect(result.sessions).toEqual([]);
+	});
+
+	it("Scan A: skips when folderPath does not match projectDir", async () => {
+		makeSessionStateEntry({ sid: "s-other", folderPath: "/some/other/dir", ageHours: 1 });
+		const { scanCopilotChatSessions } = await import("./CopilotChatSessionDiscoverer.js");
+		const result = await scanCopilotChatSessions(projectDir);
+		expect(result.sessions).toEqual([]);
+	});
+
+	it("Scan A: matches across case difference on macOS (normalizePathForMatch)", async () => {
+		makeSessionStateEntry({ sid: "s-case", folderPath: projectDir.toUpperCase(), ageHours: 1 });
+		const { scanCopilotChatSessions } = await import("./CopilotChatSessionDiscoverer.js");
+		const result = await scanCopilotChatSessions(projectDir);
+		expect(result.sessions).toHaveLength(1);
+	});
+
+	it("Scan A: matches across trailing slash difference", async () => {
+		makeSessionStateEntry({ sid: "s-slash", folderPath: `${projectDir}/`, ageHours: 1 });
+		const { scanCopilotChatSessions } = await import("./CopilotChatSessionDiscoverer.js");
+		const result = await scanCopilotChatSessions(projectDir);
+		expect(result.sessions).toHaveLength(1);
+	});
+
+	it("Scan A: skips when events.jsonl missing", async () => {
+		makeSessionStateEntry({ sid: "s-noev", folderPath: projectDir, omitEvents: true });
+		const { scanCopilotChatSessions } = await import("./CopilotChatSessionDiscoverer.js");
+		const result = await scanCopilotChatSessions(projectDir);
+		expect(result.sessions).toEqual([]);
+	});
+
+	it("Scan A: skips events.jsonl older than 48h", async () => {
+		makeSessionStateEntry({ sid: "s-stale", folderPath: projectDir, ageHours: 72 });
+		const { scanCopilotChatSessions } = await import("./CopilotChatSessionDiscoverer.js");
+		const result = await scanCopilotChatSessions(projectDir);
+		expect(result.sessions).toEqual([]);
+	});
+
+	// ─── Scan B (chatSessions/) ────────────────────────────────────────────────
+	it("Scan B: returns empty when no workspaceStorage entry matches projectDir", async () => {
+		const { scanCopilotChatSessions } = await import("./CopilotChatSessionDiscoverer.js");
+		const result = await scanCopilotChatSessions(projectDir);
+		expect(result.sessions).toEqual([]);
+	});
+
+	it("Scan B: returns empty when workspace exists but chatSessions/ is missing", async () => {
+		makeWorkspace("ws1", `file://${projectDir}`);
+		const { scanCopilotChatSessions } = await import("./CopilotChatSessionDiscoverer.js");
+		const result = await scanCopilotChatSessions(projectDir);
+		expect(result.sessions).toEqual([]);
+	});
+
+	it("Scan B: emits fresh .jsonl session", async () => {
+		const ws = makeWorkspace("ws1", `file://${projectDir}`);
+		const path = makeChatSessionsFile(ws, "fresh.jsonl", 1);
+		const { scanCopilotChatSessions } = await import("./CopilotChatSessionDiscoverer.js");
+		const result = await scanCopilotChatSessions(projectDir);
+		expect(result.sessions).toHaveLength(1);
+		expect(result.sessions[0]).toMatchObject({
+			sessionId: "fresh",
+			source: "copilot-chat",
+			transcriptPath: path,
+		});
+	});
+
+	it("Scan B: explicitly skips deprecated .json snapshot files", async () => {
+		const ws = makeWorkspace("ws1", `file://${projectDir}`);
+		makeChatSessionsFile(ws, "deprecated.json", 1);
+		const { scanCopilotChatSessions } = await import("./CopilotChatSessionDiscoverer.js");
+		const result = await scanCopilotChatSessions(projectDir);
+		expect(result.sessions).toEqual([]);
+	});
+
+	it("Scan B: skips files older than 48h", async () => {
+		const ws = makeWorkspace("ws1", `file://${projectDir}`);
+		makeChatSessionsFile(ws, "stale.jsonl", 72);
+		const { scanCopilotChatSessions } = await import("./CopilotChatSessionDiscoverer.js");
+		const result = await scanCopilotChatSessions(projectDir);
+		expect(result.sessions).toEqual([]);
+	});
+
+	it("Scan B: skips irrelevant suffixes (.tmp, .log)", async () => {
+		const ws = makeWorkspace("ws1", `file://${projectDir}`);
+		makeChatSessionsFile(ws, "junk.tmp", 1);
+		makeChatSessionsFile(ws, "junk.log", 1);
+		makeChatSessionsFile(ws, "real.jsonl", 1);
+		const { scanCopilotChatSessions } = await import("./CopilotChatSessionDiscoverer.js");
+		const result = await scanCopilotChatSessions(projectDir);
+		expect(result.sessions.map((s) => s.sessionId)).toEqual(["real"]);
+	});
+
+	// ─── Combined ──────────────────────────────────────────────────────────────
+	it("Combined: emits sessions from both scans", async () => {
+		makeSessionStateEntry({ sid: "ev-1", folderPath: projectDir, ageHours: 1 });
+		const ws = makeWorkspace("ws1", `file://${projectDir}`);
+		makeChatSessionsFile(ws, "patch-1.jsonl", 1);
+		const { scanCopilotChatSessions } = await import("./CopilotChatSessionDiscoverer.js");
+		const result = await scanCopilotChatSessions(projectDir);
+		expect(result.sessions).toHaveLength(2);
+		const ids = result.sessions.map((s) => s.sessionId).sort();
+		expect(ids).toEqual(["ev-1", "patch-1"]);
+	});
+
+	it("Combined: same sid in both scans is emitted twice (no dedup, by design)", async () => {
+		makeSessionStateEntry({ sid: "shared", folderPath: projectDir, ageHours: 1 });
+		const ws = makeWorkspace("ws1", `file://${projectDir}`);
+		makeChatSessionsFile(ws, "shared.jsonl", 1);
+		const { scanCopilotChatSessions } = await import("./CopilotChatSessionDiscoverer.js");
+		const result = await scanCopilotChatSessions(projectDir);
+		expect(result.sessions).toHaveLength(2);
+	});
+});
+
+describe("discoverCopilotChatSessions", () => {
+	let tmpRoot: string;
+	let projectDir: string;
+
+	beforeEach(() => {
+		tmpRoot = mkdtempSync(join(tmpdir(), "copilot-chat-disc-"));
+		projectDir = join(tmpRoot, "myproject");
+		mkdirSync(projectDir, { recursive: true });
+		mockHomedir.mockReturnValue(tmpRoot);
+		mockPlatform.mockReturnValue("darwin");
+	});
+
+	afterEach(() => {
+		rmSync(tmpRoot, { recursive: true, force: true });
+		vi.resetModules();
+	});
+
+	it("strips error channel and returns array directly", async () => {
+		const { discoverCopilotChatSessions } = await import("./CopilotChatSessionDiscoverer.js");
+		const result = await discoverCopilotChatSessions(projectDir);
+		expect(Array.isArray(result)).toBe(true);
+		expect(result).toEqual([]);
+	});
+});
+```
+
+- [ ] **Step 5.2: Run tests to verify they fail**
+
+Run: `npx vitest run cli/src/core/CopilotChatSessionDiscoverer.test.ts`
+Expected: many failures — current discoverer's `scanSessionsDir` signature returns `SessionInfo[] | { error }` and the path layout it scans is `GitHub.copilot-chat/debug-logs/...`, not the new locations. The test file fixtures don't write that path, so old discoverer returns 0 sessions across the board.
+
+- [ ] **Step 5.3: Replace `CopilotChatSessionDiscoverer.ts` with the new implementation**
+
+Replace **the entire contents of `cli/src/core/CopilotChatSessionDiscoverer.ts`** with:
+
+```typescript
+/**
+ * VS Code Copilot Chat session discoverer.
+ *
+ * Two scans run in sequence; results are concatenated:
+ *
+ *   Scan A — chat panel "New Chat" with copilotcli-backend models:
+ *     ~/.copilot/session-state/<sid>/events.jsonl
+ *     gated by vscode.metadata.json.workspaceFolder.folderPath === projectDir
+ *
+ *   Scan B — chat panel "New Chat" with non-copilotcli-backend models:
+ *     <userDataDir>/User/workspaceStorage/<wsHash>/chatSessions/<sid>.jsonl
+ *     wsHash resolved via VscodeWorkspaceLocator from projectDir
+ *
+ * Sessions older than 48h are excluded (matches every other discovery-based
+ * source: OpenCode / Cursor / Copilot CLI). The deprecated .json snapshot
+ * format is explicitly NOT read — see spec for rationale.
+ *
+ * The standalone `copilot` source (CopilotSessionDiscoverer reading
+ * session-store.db) covers the "New Copilot CLI Session" entry point, which
+ * is just a vscode-spawned terminal running the copilot binary.
+ */
+
+import { readdir, readFile, stat } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { createLogger } from "../Logger.js";
+import type { SessionInfo } from "../Types.js";
+import type { CopilotChatScanError } from "./CopilotChatTranscriptReader.js";
+import {
+	findVscodeWorkspaceHash,
+	getVscodeWorkspaceStorageDir,
+	normalizePathForMatch,
+} from "./VscodeWorkspaceLocator.js";
+
+const log = createLogger("CopilotChatDiscoverer");
+
+const SESSION_STALE_MS = 48 * 60 * 60 * 1000;
+
+export type { CopilotChatScanError };
+
+export interface CopilotChatScanResult {
+	readonly sessions: ReadonlyArray<SessionInfo>;
+	readonly error?: CopilotChatScanError;
+}
+
+interface VscodeMetadata {
+	workspaceFolder?: { folderPath?: string };
+}
+
+/**
+ * Scan A: ~/.copilot/session-state/<sid>/events.jsonl gated by folderPath.
+ * Returns sessions and an optional error when readdir of the root fails for
+ * non-ENOENT reasons.
+ */
+async function scanSessionState(projectDir: string): Promise<CopilotChatScanResult> {
+	const root = join(homedir(), ".copilot", "session-state");
+	let entries: string[];
+	try {
+		entries = await readdir(root);
+	} catch (error: unknown) {
+		const code = (error as NodeJS.ErrnoException).code;
+		if (code === "ENOENT") return { sessions: [] };
+		log.error("readdir %s failed (%s): %s", root, code ?? "unknown", (error as Error).message);
+		return { sessions: [], error: { kind: "fs", message: (error as Error).message } };
+	}
+
+	const cutoffMs = Date.now() - SESSION_STALE_MS;
+	const target = normalizePathForMatch(projectDir);
+	const sessions: SessionInfo[] = [];
+
+	for (const sid of entries) {
+		const sessionDir = join(root, sid);
+		const metaPath = join(sessionDir, "vscode.metadata.json");
+		const eventsPath = join(sessionDir, "events.jsonl");
+
+		let meta: VscodeMetadata;
+		try {
+			meta = JSON.parse(await readFile(metaPath, "utf8")) as VscodeMetadata;
+		} catch (error: unknown) {
+			log.debug("Skipping %s: vscode.metadata.json read/parse failed (%s)", sid, (error as Error).message);
+			continue;
+		}
+
+		const folderPath = meta.workspaceFolder?.folderPath;
+		if (typeof folderPath !== "string" || folderPath.length === 0) continue;
+		if (normalizePathForMatch(folderPath) !== target) continue;
+
+		let mtimeMs: number;
+		try {
+			mtimeMs = (await stat(eventsPath)).mtimeMs;
+		} catch (error: unknown) {
+			log.debug("Skipping %s: events.jsonl stat failed (%s)", sid, (error as Error).message);
+			continue;
+		}
+		if (mtimeMs < cutoffMs) continue;
+
+		sessions.push({
+			sessionId: sid,
+			transcriptPath: eventsPath,
+			updatedAt: new Date(mtimeMs).toISOString(),
+			source: "copilot-chat",
+		});
+	}
+
+	return { sessions };
+}
+
+/**
+ * Scan B: <wsHash>/chatSessions/<sid>.jsonl. Skips .json snapshot files
+ * (deprecated). Returns sessions and an optional error on non-ENOENT readdir
+ * failure.
+ */
+async function scanChatSessions(projectDir: string): Promise<CopilotChatScanResult> {
+	const wsHash = await findVscodeWorkspaceHash("Code", projectDir);
+	if (wsHash === null) {
+		log.debug("No vscode workspace matched %s", projectDir);
+		return { sessions: [] };
+	}
+	const dir = join(getVscodeWorkspaceStorageDir("Code"), wsHash, "chatSessions");
+
+	let entries: string[];
+	try {
+		entries = await readdir(dir);
+	} catch (error: unknown) {
+		const code = (error as NodeJS.ErrnoException).code;
+		if (code === "ENOENT") return { sessions: [] };
+		log.error("readdir %s failed (%s): %s", dir, code ?? "unknown", (error as Error).message);
+		return { sessions: [], error: { kind: "fs", message: (error as Error).message } };
+	}
+
+	const cutoffMs = Date.now() - SESSION_STALE_MS;
+	const sessions: SessionInfo[] = [];
+
+	for (const entry of entries) {
+		if (!entry.endsWith(".jsonl")) continue; // skip .json snapshots and other suffixes
+		const path = join(dir, entry);
+		let mtimeMs: number;
+		try {
+			mtimeMs = (await stat(path)).mtimeMs;
+		} catch (error: unknown) {
+			log.debug("Skipping %s: stat failed (%s)", entry, (error as Error).message);
+			continue;
+		}
+		if (mtimeMs < cutoffMs) continue;
+		const sessionId = entry.slice(0, -".jsonl".length);
+		sessions.push({
+			sessionId,
+			transcriptPath: path,
+			updatedAt: new Date(mtimeMs).toISOString(),
+			source: "copilot-chat",
+		});
+	}
+
+	return { sessions };
+}
+
+/**
+ * Runs Scan A then Scan B; concatenates sessions; returns the first error
+ * encountered (subsequent are debug-logged).
+ */
+export async function scanCopilotChatSessions(projectDir: string): Promise<CopilotChatScanResult> {
+	const a = await scanSessionState(projectDir);
+	const b = await scanChatSessions(projectDir);
+	const sessions = [...a.sessions, ...b.sessions];
+	const error = a.error ?? b.error;
+	if (a.error && b.error) {
+		log.debug("Both scans errored; reporting Scan A's: %s", b.error.message);
+	}
+	if (sessions.length > 0) {
+		log.info("Discovered %d Copilot Chat session(s) for %s", sessions.length, projectDir);
+	}
+	return { sessions, error };
+}
+
+/** Convenience wrapper used by QueueWorker — strips the error channel. */
+export async function discoverCopilotChatSessions(projectDir: string): Promise<ReadonlyArray<SessionInfo>> {
+	const { sessions, error } = await scanCopilotChatSessions(projectDir);
+	if (error) {
+		log.warn("Copilot Chat scan error (%s) — sessions excluded from this run: %s", error.kind, error.message);
+	}
+	return sessions;
+}
+```
+
+- [ ] **Step 5.4: Run discoverer tests to verify they pass**
+
+Run: `npx vitest run cli/src/core/CopilotChatSessionDiscoverer.test.ts`
+Expected: all tests pass.
+
+- [ ] **Step 5.5: Run typecheck + biome**
+
+Run: `npm run typecheck:cli && npx biome check --error-on-warnings cli/src/core/CopilotChatSessionDiscoverer.ts cli/src/core/CopilotChatSessionDiscoverer.test.ts`
+Expected: both succeed.
+
+- [ ] **Step 5.6: Commit**
+
+```bash
+git add cli/src/core/CopilotChatSessionDiscoverer.ts cli/src/core/CopilotChatSessionDiscoverer.test.ts
+git commit -s -m "$(cat <<'EOF'
+feat(copilot-chat): rewrite discoverer with two-scan design
+
+Scan A reads ~/.copilot/session-state/<sid>/events.jsonl, gated by
+vscode.metadata.json.workspaceFolder.folderPath matching projectDir.
+This covers chat panel sessions backed by the Copilot CLI agent.
+
+Scan B reads <wsHash>/chatSessions/<sid>.jsonl (deprecated .json
+snapshots are explicitly skipped). This covers chat panel sessions
+backed by direct OpenAI/Anthropic API models.
+
+The legacy debug-logs/main.jsonl scan is gone — those files were
+OpenTelemetry traces, not conversation content.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 6: Wire `beforeTimestamp` into the QueueWorker call site
+
+**Why:** Task 4 added a `beforeTimestamp` parameter to the reader so the QueueWorker can attribute entries to the correct commit boundary. Now we feed the existing `beforeTimestamp` value (already in scope at the call site) to the reader.
+
+**Files:**
+- Modify: `cli/src/hooks/QueueWorker.ts` (1 line)
+
+- [ ] **Step 6.1: Confirm the line still reads as expected**
+
+Run: `sed -n '1530,1535p' cli/src/hooks/QueueWorker.ts`
+Expected output includes the line:
+```
+				result = await readCopilotChatTranscript(session.transcriptPath, cursor ?? undefined);
+```
+
+- [ ] **Step 6.2: Edit the line to pass `beforeTimestamp`**
+
+Use the Edit tool. In `cli/src/hooks/QueueWorker.ts`, change:
+
+```typescript
+result = await readCopilotChatTranscript(session.transcriptPath, cursor ?? undefined);
+```
+
+To:
+
+```typescript
+result = await readCopilotChatTranscript(session.transcriptPath, cursor ?? undefined, beforeTimestamp);
+```
+
+- [ ] **Step 6.3: Run typecheck + biome on the QueueWorker**
+
+Run: `npm run typecheck:cli && npx biome check --error-on-warnings cli/src/hooks/QueueWorker.ts`
+Expected: both succeed.
+
+- [ ] **Step 6.4: Run the QueueWorker test suite to verify no regressions**
+
+Run: `npx vitest run cli/src/hooks/QueueWorker.test.ts`
+Expected: all tests pass. The existing mocks in QueueWorker.test.ts (lines 153–158: `discoverCopilotChatSessions: vi.fn().mockResolvedValue([])`, `isCopilotChatInstalled: vi.fn().mockResolvedValue(false)`) keep working because the function signatures are unchanged from the QueueWorker's perspective.
+
+- [ ] **Step 6.5: Commit**
+
+```bash
+git add cli/src/hooks/QueueWorker.ts
+git commit -s -m "$(cat <<'EOF'
+feat(copilot-chat): pass beforeTimestamp to chat reader at QueueWorker call site
+
+Lets the reader gate entries past the per-commit cutoff so they are
+re-read at the next commit, matching every other source's attribution
+semantics.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 7: Run the full CLI test+typecheck+lint sweep
+
+**Why:** Catch any cross-module regressions one consolidated check.
+
+- [ ] **Step 7.1: Run the full cli workspace test + typecheck + lint**
+
+Run: `npm run typecheck:cli && npm run lint -w @jolli.ai/cli && npm run test -w @jolli.ai/cli`
+Expected: all green. Coverage threshold (97% statements / 96% branches / 97% functions / 97% lines) holds.
+
+- [ ] **Step 7.2: If coverage dipped below threshold, investigate**
+
+If `npm run test -w @jolli.ai/cli` reports a coverage failure:
+1. Identify the file/function whose coverage dropped.
+2. Add a test case for the uncovered branch in the relevant `*.test.ts` (typically a not-yet-tested error branch in the discoverer or reader).
+3. Re-run Step 7.1.
+4. Once green, commit the test addition with a `test(copilot-chat): cover <branch>` message.
+
+- [ ] **Step 7.3: If everything passed without changes, no commit needed**
+
+Move on to Task 8.
+
+---
+
+## Task 8: Build the CLI dist + verify on real machine
+
+**Why:** All preceding tasks operate on source. The QueueWorker that runs at `git commit` time uses whichever dist the resolver picks (currently `~/.vscode/extensions/jolli.jollimemory-vscode-0.98.20/dist`, version-resolved). To verify the redesign works end-to-end we need a local build that the resolver will pick up, and then a fresh non-squash commit + manual inspection of the orphan-branch transcript.
+
+- [ ] **Step 8.1: Build the cli dist that dist-paths/cli will pick up**
+
+Run: `npm run build:cli`
+Expected: `cli/dist/QueueWorker.js` is rewritten with mtime in the last few seconds. Verify with: `ls -la cli/dist/QueueWorker.js`.
+
+- [ ] **Step 8.2: Bump cli/package.json version so the resolver picks it over the installed vscode extension**
+
+The resolver picks the highest semver across `~/.jolli/jollimemory/dist-paths/*`. The installed vscode extension is currently `0.98.20`. Bump cli to `0.98.21` so this build wins.
+
+Edit `cli/package.json`, find the line `"version": "0.98.0"` (or whatever the current local cli version is), and change it to `"version": "0.98.21"`.
+
+Then re-run the build to make sure dist-paths/cli is updated:
+
+Run: `npm run build:cli`
+
+Verify the resolver now points at the local cli dist:
+
+Run: `~/.jolli/jollimemory/resolve-dist-path`
+Expected: prints `<absolute path>/cli/dist`.
+
+- [ ] **Step 8.3: Verify the new dist contains the new code**
+
+Run: `grep -c "session-state\|readEventsJsonl\|chatSessions" cli/dist/QueueWorker.js cli/dist/CopilotChatSessionDiscoverer.js cli/dist/CopilotChatTranscriptReader.js 2>/dev/null || true`
+Expected: at least one nonzero count per file (the dist genuinely contains the new strings).
+
+Note: depending on esbuild bundling settings, the QueueWorker.js bundle may inline the discoverer/reader contents and there may not be separate files — that's fine. The string check on `QueueWorker.js` alone is sufficient.
+
+- [ ] **Step 8.4: Make a real non-squash commit on this branch to exercise the pipeline**
+
+Make any small change in the worktree (e.g. add a one-line comment to a file), then commit normally:
+
+Run:
+```bash
+echo "" >> docs/superpowers/specs/2026-05-07-copilot-chat-events-jsonl-redesign-design.md
+git add docs/superpowers/specs/2026-05-07-copilot-chat-events-jsonl-redesign-design.md
+git commit -s -m "test: trigger queue worker to verify copilot-chat capture"
+```
+
+Wait ~30 seconds for the QueueWorker to finish processing (it runs detached after post-commit).
+
+- [ ] **Step 8.5: Inspect the orphan-branch transcript for the new commit**
+
+Run:
+```bash
+NEW=$(git rev-parse HEAD)
+echo "checking transcripts/$NEW.json"
+git show "jollimemory/summaries/v3:transcripts/$NEW.json" 2>&1 | python3 -c "
+import sys, json
+try:
+  data = json.load(sys.stdin)
+  print(f'sessions count: {len(data.get(\"sessions\", []))}')
+  for sess in data.get('sessions', []):
+    print(f\"  source={sess.get('source')!r}, sessionId={sess.get('sessionId')[:12]!r}, entries={len(sess.get('entries', []))}\")
+except Exception as e:
+  print(f'(no transcript or parse error: {e})')
+"
+```
+
+Expected: at least one session with `source='copilot-chat'` (in addition to whatever `claude` / `copilot` sessions are also active for the cwd). If you see a `copilot-chat` source with non-zero entries, the redesign works end-to-end.
+
+- [ ] **Step 8.6: If `copilot-chat` is missing from the transcript, troubleshoot in this order**
+
+1. **Was the QueueWorker logging anything?** Run: `tail -200 ~/.jolli/jollimemory/logs/worker-*.log` (replace glob with the most recent file). Look for `Discovered N Copilot Chat session(s)` — should be ≥ 1 if Scan A or B found anything for the cwd.
+2. **Is the dist actually the new one?** Re-run Step 8.3.
+3. **Is there an active vscode chat panel "New Chat" session for this exact worktree path?** Run: `for d in ~/.copilot/session-state/*/; do python3 -c "import json; d=json.load(open('$d/vscode.metadata.json')); print('$d', d.get('workspaceFolder',{}).get('folderPath','-'))" 2>/dev/null; done | grep change-storage-to-folder`. If empty: open vscode in this worktree, "+" → "New Chat" → say one thing → wait for reply → re-run Step 8.4.
+4. **Is `copilotEnabled` true in `~/.jolli/jollimemory/config.json`?** Run: `cat ~/.jolli/jollimemory/config.json | python3 -m json.tool | grep copilot`.
+
+- [ ] **Step 8.7: After verification, leave the test commit in place or amend it away depending on preference**
+
+If you want to preserve a clean history, run `git reset --hard HEAD~1` to drop the test commit. Otherwise leave it — it documents the verification.
+
+---
+
+## Self-Review Notes
+
+The self-review (per writing-plans skill) was performed inline:
+
+1. **Spec coverage:**
+   - Detector modify → Task 1 ✅
+   - Discoverer Scan A (events.jsonl + folderPath) → Task 5 ✅
+   - Discoverer Scan B (chatSessions/.jsonl) → Task 5 ✅
+   - Reader dispatcher → Task 2 ✅
+   - readEventsJsonl sub-reader → Task 3 ✅
+   - readPatchLog sub-reader (refactored) → Task 2 ✅
+   - beforeTimestamp gate on both sub-readers → Task 4 ✅
+   - QueueWorker 1-line change → Task 6 ✅
+   - 48h freshness + path normalization + .json skip → Task 5 ✅
+   - End-to-end smoke test on real disk → Task 8 ✅
+
+2. **Placeholder scan:** No "TBD"/"TODO"/"implement later" patterns. All test code blocks contain full assertions; all implementation code blocks contain complete function bodies; all bash steps include exact commands and expected outputs.
+
+3. **Type consistency:** `readCopilotChatTranscript` signature `(transcriptPath, cursor?, beforeTimestamp?)` matches across Tasks 2/3/4/6. `SessionInfo` fields (`sessionId`, `transcriptPath`, `updatedAt`, `source`) match `cli/src/Types.ts`. `TranscriptCursor.lineNumber` semantics — line-based for events.jsonl, request-index-based for patch log — explicitly documented at the dispatcher.

--- a/docs/superpowers/specs/2026-05-05-copilot-cli-support-design.md
+++ b/docs/superpowers/specs/2026-05-05-copilot-cli-support-design.md
@@ -1,0 +1,180 @@
+# GitHub Copilot CLI as a Transcript Source — Design
+
+**Date:** 2026-05-05
+**Status:** Approved for implementation
+**Branch:** `feature-support-copilot`
+**Precedent:** [`feature-support-cursor`](../../../) (commit `af74e2cb`)
+
+## Summary
+
+Add GitHub Copilot CLI as the sixth AI agent transcript source, alongside Claude Code, Codex, Gemini, OpenCode, and Cursor. Copilot CLI is treated as a *discovery-based* source (like OpenCode and Cursor): jollimemory scans the user's `~/.copilot/session-store.db` SQLite database during the post-commit pipeline, matches sessions to the current working directory via the database's own `cwd` column, and reads the conversation from the `turns` table. No agent hook is installed because Copilot CLI exposes no hook surface; integration is read-only.
+
+## Goals
+
+- Treat Copilot CLI sessions as first-class peers of Cursor / OpenCode / Codex sessions: same enable/disable semantics, same status reporting, same surfacing in the Settings UI and Summary Details panel.
+- Auto-detect Copilot CLI on installer first run and enable the integration by default; never overwrite an explicit user choice.
+- Surface SQLite scan errors (corrupt DB, locked WAL, schema mismatch, permission denied) to the UI with a structured error kind, not silent zero-session results.
+- Extract a shared `SqliteHelpers` module from `OpenCodeSessionDiscoverer` and use it from the new Copilot modules — no new dependency, no second SQLite stack. (See *Relation to PR #65* below.)
+- Achieve coverage parity with the Cursor integration (≥97% statements/lines on the new modules) so the CLI workspace's coverage gate stays green.
+
+## Non-goals
+
+- **No hook script.** The Copilot CLI binary exposes no `stop` / `after-turn` / `notify` hook (verified via `copilot --help`); the only externally-visible export is `--share[=path]`, a user-initiated markdown dump. We rely on discovery only.
+- **No use of `~/.copilot/session-state/<id>/`.** That directory contains richer artifacts (`workspace.yaml`, `checkpoints/index.md`, `files/`, `research/`, `inuse.<pid>.lock`) but the `turns` table is sufficient for transcript summarization. Bringing in the side-state would add format-drift risk for marginal gain. (Revisit if LLM summary quality complains.)
+- **No write to the Copilot DB.** All access is read-only (`DatabaseSync(path, { readOnly: true })`) so we never collide with the `inuse.<pid>.lock` semantics or risk corrupting a live session.
+- **No Cursor-style pointer + time-window heuristic.** Copilot stores `cwd` directly on each session row, so workspace attribution is exact. Time-window logic is unnecessary and would only add false positives.
+- **No Windows CI verification this iteration.** Path logic supports `%USERPROFILE%/.copilot` for parity with cursor/opencode discoverers, but live testing is macOS/Linux only. Documented as a known gap; revisit on first Windows user report.
+- **No FTS5 search-index reads.** The `search_index` virtual table is Copilot's own internal index; not part of this scope.
+
+## Observed Reality
+
+Verified hands-on on 2026-05-05 against GitHub Copilot CLI v1.0.40 on macOS 14, with the CLI process actively running (lock file `inuse.12190.lock` present).
+
+### On-disk layout
+
+```
+~/.copilot/
+├── config.json                       # {"firstLaunchAt": "..."} — not used by us
+├── command-history-state.json
+├── session-store.db                  # SQLite 3.x, journal_mode=wal  ← we read this
+├── session-store.db-wal              # ~200 KB live; pure-JS SQLite cannot read this
+├── session-store.db-shm
+├── ide/<uuid>.lock                   # IDE bridge locks — not used
+├── logs/process-*.log                # not used
+└── session-state/<session-id>/       # per-session richer state — not used
+    ├── workspace.yaml                # mirrors the sessions row
+    ├── checkpoints/index.md          # high-level plan
+    ├── inuse.<pid>.lock              # PID file while session is active
+    ├── files/, research/             # tool outputs
+```
+
+### `session-store.db` schema (relevant subset)
+
+```sql
+sessions(id TEXT PK, cwd TEXT, repository TEXT, host_type TEXT,
+         branch TEXT, summary TEXT, created_at TEXT, updated_at TEXT)
+turns(id INTEGER PK AUTOINCREMENT, session_id TEXT FK, turn_index INTEGER,
+      user_message TEXT, assistant_response TEXT, timestamp TEXT,
+      UNIQUE(session_id, turn_index))
+checkpoints, session_files, session_refs, search_index (FTS5)  -- not used
+```
+
+`PRAGMA journal_mode → wal`, `PRAGMA user_version → 0`. Schema has no formal version field; we treat it as drift-prone (validate each row, skip-and-warn on malformed).
+
+### Runtime state
+
+- WAL is the default and sibling files contain the most recent ~200 KB of writes. **Anything that cannot read `*.db-wal` (sql.js, better-sqlite3 in some configs, custom WASM) returns wrong/empty data.** We use `node:sqlite` (Node 22.5+ native), already in use for OpenCode and Cursor.
+- The `inuse.<pid>.lock` file does not block SQLite read access; we only read.
+- Sessions appear in the table at session start (verified: a freshly-started session with zero turns still has its `sessions` row), so `cwd` matching works from the moment Copilot opens.
+
+### Smoke test
+
+```js
+const { DatabaseSync } = require("node:sqlite");
+const db = new DatabaseSync(`${HOME}/.copilot/session-store.db`, { readOnly: true });
+db.prepare("SELECT cwd FROM sessions LIMIT 1").get();
+// → { cwd: '/Users/flyer/jolli/code/jollimemory' }
+```
+
+Passed against a live Copilot CLI process (WAL active, lock file present) — proves the chosen library works in production runtime state, not just at-rest fixtures.
+
+## Architecture
+
+Copilot integration mirrors Cursor's structure 1:1, only swapping the discovery algorithm (exact `cwd` match instead of pointer + 48h time-window). All other layers — Types, SessionTracker filter, Installer auto-enable, status reporting, CLI commands, VSCode panels — follow the existing template.
+
+### New CLI modules (`cli/src/core/`)
+
+| File | Responsibility |
+|---|---|
+| `CopilotDetector.ts` | Exports `isCopilotInstalled(): Promise<boolean>` (gates on Node version + file existence) and `getCopilotDbPath(): string`. Callers compose these two — no aggregate return shape. |
+| `CopilotSessionDiscoverer.ts` | `withSqliteDb(dbPath, db => …)` to run `SELECT id, cwd, repository, branch, host_type, summary, created_at, updated_at FROM sessions WHERE cwd = ?` (with normalized cwd). Return one entry per matching session, `transcriptPath = "<dbPath>#<sessionId>"`, `lastUpdatedAt = parse(updated_at)`. Classify failures via `classifyScanError` from `SqliteHelpers`. |
+| `SqliteHelpers.ts` | Extracted from `OpenCodeSessionDiscoverer.ts` as a pure refactor (separate commit, zero behavior change). Exports `SqliteDbHandle`, `withSqliteDb`, `NODE_SQLITE_MIN_VERSION`, `hasNodeSqliteSupport`, `classifyScanError`. OpenCode keeps its existing public symbols as deprecated re-exports for backward compatibility. |
+| `CopilotTranscriptReader.ts` | Parse `<dbPath>#<sessionId>` → run `SELECT turn_index, user_message, assistant_response, timestamp FROM turns WHERE session_id = ? ORDER BY turn_index` → emit one `{role:"human", text:user_message}` + one `{role:"assistant", text:assistant_response}` per row. Support read-cursor incremental reads — resume from a stored `turn_index` (this is jollimemory's internal read cursor, unrelated to the Cursor IDE source) and a `since` timestamp cutoff to align with the commit window. Skip rows with empty/null messages. |
+
+### Type and config additions
+
+- [`cli/src/Types.ts`](../../cli/src/Types.ts): add `"copilot"` to `TranscriptSource`; add `copilotEnabled?: boolean` on `JolliMemoryConfig`; add `copilotDetected: boolean`, `copilotEnabled: boolean`, `copilotScanError?: { kind: "corrupt"|"locked"|"permission"|"schema"|"unknown"; message: string }` to `StatusInfo`.
+- [`cli/src/core/SessionTracker.ts`](../../cli/src/core/SessionTracker.ts): add a copilot branch to `filterSessionsByEnabledIntegrations`.
+
+### Pipeline wiring
+
+- [`cli/src/hooks/QueueWorker.ts`](../../cli/src/hooks/QueueWorker.ts): mirror the Cursor block — call `scanCopilotSessions()` when `copilotEnabled && copilotDetected`, append to active sessions, route reads to `CopilotTranscriptReader`. Reuse the `Source` keying pattern.
+- [`cli/src/install/Installer.ts`](../../cli/src/install/Installer.ts): on detect-and-undefined, set `copilotEnabled: true`. Never overwrite an explicit `false`. Surface `copilotScanError` via `getStatus()`.
+
+### CLI surface
+
+- [`cli/src/commands/StatusCommand.ts`](../../cli/src/commands/StatusCommand.ts): integration row "Copilot" mirroring Cursor's row.
+- [`cli/src/commands/ConfigureCommand.ts`](../../cli/src/commands/ConfigureCommand.ts): accept `copilotEnabled` key with boolean coercion + Node 22.5+ help note.
+
+### VSCode surface
+
+- [`vscode/src/providers/StatusTreeProvider.ts`](../../vscode/src/providers/StatusTreeProvider.ts): Copilot row with `pushIntegrationItem` for healthy state, error row when `copilotScanError` is set.
+- [`vscode/src/views/SummaryWebviewPanel.ts`](../../vscode/src/views/SummaryWebviewPanel.ts) + [`SummaryScriptBuilder.ts`](../../vscode/src/views/SummaryScriptBuilder.ts): include `"copilot"` in `getEnabledSources()` and `sourceOrder`, label `"Copilot"`.
+- [`vscode/src/views/SettingsHtmlBuilder.ts`](../../vscode/src/views/SettingsHtmlBuilder.ts) + [`SettingsScriptBuilder.ts`](../../vscode/src/views/SettingsScriptBuilder.ts) + [`SettingsWebviewPanel.ts`](../../vscode/src/views/SettingsWebviewPanel.ts): toggle row "Copilot" with description "Session discovery via Copilot CLI's local SQLite store"; include in dirty-detection, validation ("at least one integration"), and the load/save payload.
+
+### Data flow (per post-commit)
+
+```
+QueueWorker (post-commit)
+  → CopilotDetector.detect()                  → {installed, dbPath}
+  → CopilotSessionDiscoverer.scan(cwd, dbPath) → [{ id, transcriptPath, lastUpdatedAt, ... }]
+  → for each new/changed session:
+      CopilotTranscriptReader.read(transcriptPath, { since, fromTurnIndex })
+       → BubbleStream → existing summarizer pipeline
+  → status report includes copilotDetected / copilotEnabled / copilotScanError
+```
+
+## Design choices (with rationale)
+
+1. **Exact `cwd` match, normalized via `path.resolve`.** Strips trailing slashes, no `realpath`. Rationale: Copilot writes the user's literal `cwd` as it was at session start; symlink chase is rare in practice and adds I/O. Edge case (macOS `/var` ↔ `/private/var`) is left to a follow-up if it bites.
+2. **No time-window fallback.** `cwd` is a strong signal; adding a 48h window only invites unrelated workspace bleed-through.
+3. **Read-only DB handle.** Confirmed compatible with Copilot's own writer via WAL; avoids any chance of locking interference.
+4. **Schema-drift defensive coding.** Validate every read field (non-null `id`, finite parsed timestamp, non-empty messages); silently skip malformed rows; warn at the discoverer level. Same posture as Cursor.
+5. **`transcriptPath = "<dbPath>#<sessionId>"`.** Reuses the OpenCode/Cursor encoding so existing cursor-tracking and dedup machinery in `SessionTracker` works without special-casing.
+6. **`SqliteHelpers` extraction in this PR.** The Cursor PR (#65) plans the same extraction but is still open and not in main. Rather than wait or duplicate the SQLite open/error logic into a third copy, we land the pure-refactor extraction here (separate commit, zero behavior change), then build Copilot on top. Cursor's PR will resolve the conflict by deleting its own copy of `SqliteHelpers` — the public surface is intentionally identical so the merge is mechanical.
+
+## Testing strategy
+
+Mirror Cursor's coverage pattern; expect ~97% on the three new modules.
+
+- **Unit tests** with fixture DBs constructed via `node:sqlite` directly (same approach as `OpenCodeSessionDiscoverer.test.ts`):
+  - `CopilotSessionDiscoverer.test.ts`: cwd match / no match, repository field exposure, malformed timestamp skipped, missing-id row skipped, classified errors (corrupt / locked / permission), URL-decoded path edge cases (parity with Cursor's path matching), `path.resolve` normalization (trailing slash).
+  - `CopilotTranscriptReader.test.ts`: parse `dbPath#sessionId`, ordered turn rendering, role mapping (`user_message` → human, `assistant_response` → assistant), empty-message filtering, read-cursor resume from a `turn_index`, `since` timestamp cutoff, missing-session error, malformed-row skip.
+  - `CopilotDetector.test.ts`: present / absent DB, Node-version gating, Windows path branch via mocked `os.homedir()` + `os.platform()`.
+- **QueueWorker** pipeline tests: two new cases (happy path with copilot sessions; `copilotEnabled=false` short-circuits discovery) — verifies the new ~12 lines of pipeline glue actually execute.
+- **VSCode panel tests**: extend the same files Cursor touched (`StatusTreeProvider.test.ts`, `SummaryWebviewPanel.test.ts`, `SummaryScriptBuilder.test.ts`, `SettingsHtmlBuilder.test.ts`, `SettingsScriptBuilder.test.ts`, `SettingsWebviewPanel.test.ts`) with one happy-path + one error-path assertion each.
+- **No live-Copilot integration test in CI.** Test fixtures construct realistic SQLite state; live-data smoke test was performed manually during discovery and is documented in this spec.
+
+## Intentionally not done (per project convention)
+
+These are out of scope for this PR; listing them so reviewers can see the decisions were deliberate and not omissions.
+
+- `~/.copilot/session-state/<id>/checkpoints/index.md` and the `checkpoints` DB table — Copilot CLI's own conversation-compression nodes (user-triggered via `/summarize` or auto-triggered when the context window fills), structured as `{title, overview, history, work_done, technical_details, important_files, next_steps}` per checkpoint. **Not** ingested for three reasons:
+  1. **Slicing mismatch.** Checkpoints are cut on Copilot's own context-window / user trigger, not on git-commit boundaries. jollimemory's contract is "summary per commit", and using Copilot's pre-summarized text would let Copilot's slicing override that contract.
+  2. **Existence is optional.** A session with no `/summarize` call has zero checkpoint rows (verified locally on the live session — `index.md` is empty header only). The `turns` table, by contrast, has one row per interaction. Transcript must come from `turns`.
+  3. **Drift surface.** `turns` has 4 stable columns; `checkpoints` has 7 semantic fields and is the area of the Copilot CLI schema most likely to evolve.
+
+  Possible follow-up: if downstream summary quality is poor on long sessions, inject the latest checkpoint's `overview + work_done + technical_details + important_files` as **supplemental context** to the existing turns-based summarizer prompt — never as a replacement. Tracked as a separate ticket if/when needed.
+- `session_files`, `session_refs`, FTS5 `search_index` tables — not read.
+- `--share[=path]` markdown export — not consumed; users who want it can pipe manually.
+- Windows CI testing — code path supported, live verification deferred.
+- Hook-based integration — Copilot CLI exposes no hook; not implementable without upstream changes.
+- New top-level dependency — none introduced. (`node:sqlite` already in use.)
+
+## Open questions
+
+None at design time. Surface them in implementation if the schema turns out to differ across Copilot CLI versions (current target: 1.0.x).
+
+## Relation to PR #65 (Cursor IDE support)
+
+PR #65 (`feature-support-cursor`) and this branch (`feature-support-copilot`) both add a new SQLite-backed transcript source and both want the same `SqliteHelpers` module abstracted out of `OpenCodeSessionDiscoverer`. PR #65 is currently OPEN and has not landed on main, so this branch cannot import a `SqliteHelpers` module that does not exist.
+
+Strategy:
+
+- This PR includes a standalone **pure-refactor commit** that extracts `SqliteHelpers` from `OpenCodeSessionDiscoverer.ts`, with the *same public symbols* PR #65 plans to expose (`SqliteDbHandle`, `withSqliteDb`, `NODE_SQLITE_MIN_VERSION`, `hasNodeSqliteSupport`, `classifyScanError`). OpenCode keeps deprecated re-exports for backward compatibility.
+- Whichever PR merges first owns the extraction. The second PR resolves the conflict by deleting its own copy of `SqliteHelpers.ts` and keeping the rest of its changes — no API drift because the surface was designed to match.
+- Coordinated via PR descriptions; no shared branch or rebase chain required.
+
+## Rollout
+
+Same as Cursor: ships in the next CLI minor + matching VSCode patch. No migration. No flag. Auto-detected on installer run; users who don't have Copilot CLI installed see no change.

--- a/docs/superpowers/specs/2026-05-06-copilot-chat-support-design.md
+++ b/docs/superpowers/specs/2026-05-06-copilot-chat-support-design.md
@@ -1,0 +1,381 @@
+# VS Code Copilot Chat as a Transcript Source — Design
+
+**Date:** 2026-05-06
+**Status:** **Superseded by [`2026-05-07-copilot-chat-events-jsonl-redesign-design.md`](./2026-05-07-copilot-chat-events-jsonl-redesign-design.md)** — both storage paths assumed below (`<wsHash>/chatSessions/<sid>.jsonl` and `<wsHash>/GitHub.copilot-chat/debug-logs/<sid>/main.jsonl`) turned out not to contain conversation content on real VS Code 1.118.x machines. Real conversations live in `~/.copilot/session-state/<sid>/events.jsonl`. This document is preserved for design history.
+**Branch:** `feature-support-copilot`
+**Precedent:**
+- [`feature-support-cursor`](../../../) (commit `af74e2cb` — vscode workspaceStorage scanning)
+- [`feature-support-copilot`](../../../) (commit `357fcca6` — Copilot CLI as the sixth source)
+
+## Summary
+
+Add **VS Code Copilot Chat** as the seventh AI agent transcript source. This is a *separate product* from GitHub Copilot CLI, with a *separate on-disk format* (JSONL patch logs in vscode workspaceStorage rather than SQLite in `~/.copilot/`), but it ships under the same "GitHub Copilot" name and is treated by users as the same product. The design reconciles this gap by introducing a new internal source `"copilot-chat"` (code-level isolation) that **shares** the existing `copilotEnabled` flag (single user-facing toggle).
+
+A field user report on Windows triggered this work: VS Code Copilot Chat sessions on the user's machine were not picked up despite the `~/.copilot/` directory existing — because that user only used VS Code's chat panel, never the terminal `copilot` binary, and Copilot Chat conversations live elsewhere entirely.
+
+## Goals
+
+- Treat VS Code Copilot Chat sessions as first-class peers of Copilot CLI / Cursor / OpenCode / Codex sessions: same enable/disable semantics, same status reporting, same surfacing in the Settings UI and Summary Details panel.
+- Single user-facing toggle "GitHub Copilot" that controls both `~/.copilot/session-store.db` (CLI) and vscode workspaceStorage chat sessions (Chat). Reflects product reality: both are "GitHub Copilot" to users.
+- Auto-detect on installer first run when *either* form is present; never overwrite an explicit user choice.
+- Surface JSONL parse / fs scan errors with a structured error kind, not silent zero-session results.
+- Extract a shared `VscodeWorkspaceLocator` module so this integration *and* the existing Cursor integration *and* future vscode-fork integrations (Insiders, Code-OSS, Windsurf, Trae, …) all locate workspaces through one path resolver.
+- Achieve coverage parity with the Cursor / Copilot-CLI integrations (≥97% statements/lines on the new modules).
+
+## Non-goals
+
+- **No separate Copilot Chat toggle.** `copilotEnabled` controls both source forms. UI shows one "GitHub Copilot" row; tooltip/sub-line distinguishes which forms were detected ("CLI ✓ + Chat ✓", "CLI only", "Chat only").
+- **No `chatEditingSessions/` reads.** That directory under each workspaceStorage entry contains editor edit-operation logs, not conversational content. Out of scope.
+- **No `globalStorage/github.copilot-chat/copilotCli/*` reads.** That subtree is the vscode-bundled Copilot CLI binary, which writes back to `~/.copilot/session-store.db` — already covered by the existing `"copilot"` source.
+- **No multi-root `.code-workspace` support (v1).** When a workspace is opened from a `.code-workspace` file, vscode's `workspace.json` contains a `workspace` URI rather than a single `folder` URI. v1 reads single-folder workspaces only and skips multi-root entries silently. Revisit on first user report.
+- **No VS Code Insiders / Code-OSS / fork support (v1).** v1 targets `Code` (VS Code Stable) only. The shared `VscodeWorkspaceLocator` is parameterized by flavor so adding Insiders / forks later is a one-line flavor-map extension.
+- **No Windows CI verification this iteration.** Path logic supports `%APPDATA%\Code` for parity with the Cursor and Copilot-CLI discoverers, but live testing is macOS only. Documented as a known gap; revisit on first Windows user report.
+- **No live tail / real-time scanning.** Commit-time batch read suffices, matching every other source.
+- **No write to chat session files.** All access is read-only; we never collide with vscode's writers or risk corrupting in-flight sessions.
+
+## Observed Reality
+
+Verified hands-on on 2026-05-06 against VS Code Stable 1.x on macOS 14, with 16 active workspaceStorage entries.
+
+### On-disk layout
+
+```
+~/Library/Application Support/Code/User/
+├── globalStorage/github.copilot-chat/
+│   ├── copilotCli/                        # vscode-bundled Copilot CLI binary — covered by "copilot" source
+│   │   ├── copilot
+│   │   ├── copilotCLIShim.js
+│   │   └── copilotCLIShim.ps1
+│   ├── ask-agent/Ask.agent.md             # agent templates — not session content
+│   ├── plan-agent/Plan.agent.md
+│   ├── explore-agent/Explore.agent.md
+│   ├── debugCommand/copilotDebugCommand.js
+│   ├── copilot-cli-images/
+│   └── toolEmbeddingsCache.bin
+│
+└── workspaceStorage/<wsHash>/             # one entry per workspace folder
+    ├── workspace.json                     # {"folder": "file:///abs/path"} — same shape as Cursor
+    ├── state.vscdb                        # general vscode state (not read here)
+    ├── chatSessions/                      # ← READ THIS
+    │   └── <sessionId>.jsonl              # one file per chat session
+    └── chatEditingSessions/               # editing operation logs — out of scope
+```
+
+The presence of `globalStorage/github.copilot-chat/` is the install signal; the real conversation content lives one level up under `workspaceStorage/<wsHash>/chatSessions/<sessionId>.jsonl`. Workspace attribution is exact via `workspace.json`'s `folder` URI — identical to the Cursor algorithm.
+
+Per-platform user-data root (matches Cursor's per-platform map):
+
+| Platform | Root |
+|---|---|
+| darwin | `~/Library/Application Support/Code` |
+| linux  | `~/.config/Code` |
+| win32  | `%APPDATA%\Code` |
+
+### `<sessionId>.jsonl` schema
+
+The file is a **JSON document patch log**, not a stream of messages. Each line is one event:
+
+```jsonc
+// kind 0 — initial document (always line 0)
+{"kind": 0, "v": {
+  "version": 3,
+  "creationDate": 1776416572549,
+  "initialLocation": "panel",
+  "responderUsername": "",
+  "sessionId": "<uuid>",
+  "hasPendingEdits": false,
+  "requests": [],
+  "pendingRequests": [],
+  "inputState": { /* ... */ }
+}}
+
+// kind 1 — set value at JSON path
+{"kind": 1, "k": ["requests", 0, "result"], "v": { /* the new value at that path */ }}
+
+// kind 2 — delete value at JSON path
+{"kind": 2, "k": ["pendingRequests", 0]}
+```
+
+Reconstructing the conversation requires **replaying patches in order**: start with the `kind:0` initial document, apply each `kind:1` as a set-at-path, each `kind:2` as a delete-at-path, in file order. The final document's `requests[]` array contains the conversation. Each `requests[i]` has shape:
+
+```jsonc
+{
+  "message": { "text": "user prompt..." },          // user input
+  "response": [ { "value": "..." }, ... ],          // streamed assistant output (post-stream merged by patches)
+  "result": {
+    "metadata": {
+      "codeBlocks": [
+        { "code": "...", "language": "ts", "markdownBeforeBlock": "..." }
+      ],
+      "timings": { "firstProgress": 23361, "totalElapsed": 163605 }
+    }
+  },
+  "timestamp": 1776416700000
+}
+```
+
+The transcript reader emits one `{role: "human", text: message.text}` and one `{role: "assistant", text: <flattened response>}` per `requests[i]` with non-empty content. **`response[]` is the source of truth** for assistant text (streaming chunks are already merged by the patch sequence); `codeBlocks` is sidecar metadata, not re-emitted.
+
+### Smoke test
+
+```js
+// One session file → final document → request count
+const lines = fs.readFileSync(jsonlPath, "utf8").trim().split("\n");
+let doc = {};
+for (const raw of lines) {
+  const evt = JSON.parse(raw);
+  if (evt.kind === 0) doc = evt.v;
+  else if (evt.kind === 1) setAtPath(doc, evt.k, evt.v);
+  else if (evt.kind === 2) deleteAtPath(doc, evt.k);
+}
+console.log(doc.requests.length, "requests");
+// → matches the chat panel's visible turn count in vscode
+```
+
+Verified against a 22-line fixture (file size ~840 KB, 4 user/assistant turns).
+
+### Differences vs Cursor
+
+| Dimension | Cursor (existing) | Copilot Chat (new) |
+|---|---|---|
+| User data root | `~/Library/Application Support/Cursor` (etc) | `~/Library/Application Support/Code` (etc) |
+| Workspace lookup | `workspace.json` `folder` URI → wsHash | **same** (shared via `VscodeWorkspaceLocator`) |
+| Session storage | global `cursorDiskKV` SQLite + per-workspace pointer DB | per-workspace `chatSessions/<id>.jsonl` files |
+| Session attribution | β′ algorithm (anchor pointers ∪ time window) | Direct: each file in `<wsHash>/chatSessions/` belongs to that workspace |
+| Read library | `node:sqlite` | `JSON.parse` per line |
+| Schema model | row → composer JSON blob | document → patch log replay |
+
+The two sources share the workspace-locator layer, but the session-discovery and transcript-reading layers diverge entirely. **No SQLite dependency is added for Copilot Chat** — pure JSON parsing, no `node:sqlite` gate.
+
+## Architecture
+
+### Module map
+
+```
+cli/src/core/
+├── VscodeWorkspaceLocator.ts        # NEW — shared workspaceStorage path/hash logic
+├── VscodeWorkspaceLocator.test.ts
+├── CopilotChatDetector.ts           # NEW
+├── CopilotChatDetector.test.ts
+├── CopilotChatSessionDiscoverer.ts  # NEW
+├── CopilotChatSessionDiscoverer.test.ts
+├── CopilotChatTranscriptReader.ts   # NEW (incl. patch replayer)
+├── CopilotChatTranscriptReader.test.ts
+├── CursorDetector.ts                # MODIFIED — call shared locator
+└── CursorSessionDiscoverer.ts       # MODIFIED — call shared locator
+```
+
+### Shared layer: `VscodeWorkspaceLocator`
+
+```typescript
+type VscodeFlavor = "Cursor" | "Code"
+
+function getVscodeUserDataDir(flavor: VscodeFlavor, home?: string): string
+//   darwin   ~/Library/Application Support/<flavor>
+//   linux    ~/.config/<flavor>
+//   win32    %APPDATA%/<flavor>
+
+function getVscodeWorkspaceStorageDir(flavor: VscodeFlavor, home?: string): string
+//   <userDataDir>/User/workspaceStorage
+
+function findVscodeWorkspaceHash(
+    flavor: VscodeFlavor,
+    projectDir: string,
+): Promise<string | null>
+//   Scans <wsStorageDir>/<entry>/workspace.json for a `folder` file:// URI that
+//   resolves to projectDir. Single-folder workspaces only — entries with a
+//   `workspace` field instead of `folder` are silently skipped (multi-root
+//   .code-workspace, out of scope).
+
+function normalizePathForMatch(p: string): string
+//   Strips trailing slashes; lowercases on darwin/win32. Used by both flavors.
+```
+
+`CursorDetector.getCursorUserDataDir`, `CursorDetector.getCursorGlobalDbPath` (which delegates to a Cursor-flavor call to the shared locator), `CursorDetector.getCursorWorkspaceStorageDir`, and `CursorSessionDiscoverer.findCursorWorkspaceHash` / `normalizePathForMatch` are reimplemented as thin wrappers over the shared module. **Public symbols on those files are preserved** — no downstream import paths change.
+
+### `CopilotChatDetector`
+
+```typescript
+function getCopilotChatStorageDir(home?: string): string
+//   getVscodeUserDataDir("Code", home) + "/User/globalStorage/github.copilot-chat"
+
+async function isCopilotChatInstalled(): Promise<boolean>
+//   stat(getCopilotChatStorageDir()).isDirectory()
+//   No node:sqlite gate — JSONL is plain JSON.
+```
+
+### `CopilotChatSessionDiscoverer`
+
+Algorithm:
+
+1. `wsHash := findVscodeWorkspaceHash("Code", projectDir)` — return empty if null
+2. `sessionsDir := <wsStorageDir>/<wsHash>/chatSessions` — return empty if missing
+3. `cutoff := now - 48h`
+4. For each `*.jsonl` file in `sessionsDir`:
+   - `mtime := stat(file).mtimeMs`
+   - Skip if `mtime < cutoff`
+   - Emit `SessionInfo { sessionId: basename without .jsonl, transcriptPath: <abs>, updatedAt: ISO(mtime), source: "copilot-chat" }`
+5. Return `{ sessions, error? }`
+
+`transcriptPath` is the absolute file path (no synthetic `#` discriminator — each file is one session).
+
+### `CopilotChatTranscriptReader`
+
+The reader has two layers:
+
+**Patch replayer** (pure function, ~50 LOC):
+
+```typescript
+type PatchEvent =
+  | { kind: 0; v: unknown }                 // init
+  | { kind: 1; k: PathSegment[]; v: unknown }   // set
+  | { kind: 2; k: PathSegment[] }                // delete
+type PathSegment = string | number
+
+function replayPatches(lines: ReadonlyArray<string>): unknown {
+    let doc: unknown = {}
+    for (const raw of lines) {
+        const evt = JSON.parse(raw) as PatchEvent | { kind: number }
+        switch (evt.kind) {
+            case 0: doc = (evt as { v: unknown }).v; break
+            case 1: doc = setAtPath(doc, (evt as { k: PathSegment[] }).k, (evt as { v: unknown }).v); break
+            case 2: doc = deleteAtPath(doc, (evt as { k: PathSegment[] }).k); break
+            default: log.warn("Unknown patch kind %s — skipping", evt.kind); break
+        }
+    }
+    return doc
+}
+```
+
+`setAtPath` and `deleteAtPath` mutate the document in place; `replayPatches` applies them in file order. (Mutation is fine: the replayer owns the document and never exposes intermediate states.) Path semantics:
+- Numeric segment → array index (auto-grow with `undefined` slots if needed for `set`)
+- String segment → object key
+- `delete` on a missing path is a no-op (vscode emits these legitimately for already-cleaned `pendingRequests`)
+- `set` with parents missing creates intermediate objects/arrays based on next segment type
+
+**Transcript layer:**
+
+```typescript
+async function readCopilotChatTranscript(
+    transcriptPath: string,
+    cursor?: { lastReadRequestIdx: number },
+): Promise<{
+    messages: ReadonlyArray<{ role: "human" | "assistant"; text: string }>
+    newCursor: { lastReadRequestIdx: number }
+}>
+```
+
+- Read the entire `.jsonl` file → `replayPatches` → final document
+- Extract `doc.requests` (default to `[]` on missing/non-array)
+- For each `requests[i]` where `i > (cursor?.lastReadRequestIdx ?? -1)`:
+  - Emit `{role: "human", text: req.message.text}` if `req.message?.text` is a non-empty string
+  - Flatten `req.response[]` to a single string (concatenate `.value` fields where present); emit `{role: "assistant", text}` if non-empty
+- Return `{messages, newCursor: {lastReadRequestIdx: doc.requests.length - 1}}`
+
+**Re-replaying the whole file each call is by design.** A 5 MB jsonl replays in <50 ms; the cursor avoids re-emitting already-summarized turns, but the doc itself is rebuilt each time. Storing intermediate state would couple cursor format to internal patch-replayer state — fragile.
+
+**Mid-write robustness.** vscode appends patches without atomicity guarantees, so a session file may be observed mid-write (last line truncated / partial JSON). The reader treats `JSON.parse` failure on any line as a `parse`-kind scan error and emits zero messages for that session this run — never a partial transcript. The next commit-time scan retries; the cursor isn't advanced on parse failure.
+
+## Types & config
+
+```typescript
+// cli/src/Types.ts
+
+type TranscriptSource = "claude" | "codex" | "gemini" | "opencode" | "cursor" | "copilot" | "copilot-chat"
+
+interface JolliMemoryConfig {
+    // ...existing fields
+    copilotEnabled?: boolean   // unchanged — controls BOTH "copilot" (CLI) and "copilot-chat" (Chat) sources
+    // No copilotChatEnabled — single shared toggle.
+}
+
+interface StatusInfo {
+    // ...existing fields
+    copilotDetected: boolean         // unchanged
+    copilotChatDetected: boolean     // NEW
+    copilotEnabled?: boolean         // unchanged — shared toggle
+    copilotScanError?: SqliteScanError                // unchanged
+    copilotChatScanError?: { kind: "parse" | "fs" | "schema" | "unknown"; message: string }  // NEW
+}
+```
+
+`SessionTracker.filterSessionsByEnabledIntegrations` adds:
+
+```typescript
+case "copilot-chat":
+    return config.copilotEnabled !== false   // same flag as "copilot"
+```
+
+## Pipeline wiring
+
+`Installer.install()` — auto-enable on first install:
+
+```typescript
+const copilotDetected     = config.copilotEnabled !== false && (await isCopilotInstalled())
+const copilotChatDetected = config.copilotEnabled !== false && (await isCopilotChatInstalled())
+if ((copilotDetected || copilotChatDetected) && config.copilotEnabled === undefined) {
+    await saveConfig({ copilotEnabled: true })
+    log.info("GitHub Copilot detected (CLI=%s, Chat=%s) — enabled session discovery", copilotDetected, copilotChatDetected)
+}
+```
+
+`Installer.getStatus()`:
+
+```typescript
+const copilotDetected     = await isCopilotInstalled()
+const copilotChatDetected = await isCopilotChatInstalled()
+
+let copilotChatScanError: { kind: ...; message: string } | undefined
+if (config.copilotEnabled !== false && copilotChatDetected) {
+    const scan = await scanCopilotChatSessions(projectDir)
+    if (scan.sessions.length > 0) allEnabledSessions = [...allEnabledSessions, ...scan.sessions]
+    copilotChatScanError = scan.error
+}
+```
+
+`QueueWorker` — same pattern as Copilot CLI source, gated on shared flag.
+
+## VS Code surface
+
+- **`StatusTreeProvider`**: one "GitHub Copilot" row.
+  - Detected = `copilotDetected || copilotChatDetected`
+  - Tooltip: `"CLI: ${copilotDetected ? "✓" : "✗"}, Chat: ${copilotChatDetected ? "✓" : "✗"}"`
+  - Error rows: each `*ScanError` surfaces independently when set.
+- **Settings panel** (`SettingsHtmlBuilder` / `Script` / `Webview`): unchanged "GitHub Copilot" toggle bound to `copilotEnabled`. Description updated:
+  > "Discovers sessions from GitHub Copilot CLI (`~/.copilot/session-store.db`) and VS Code Copilot Chat (workspace storage)."
+- **Summary panel** (`SummaryWebviewPanel` + `SummaryScriptBuilder`): `getEnabledSources()` includes both `"copilot"` and `"copilot-chat"` when `copilotEnabled !== false`. `sourceOrder` places `"copilot-chat"` after `"copilot"`. Source label: `"Copilot Chat"`.
+
+## CLI commands
+
+- **`StatusCommand`**: one Copilot row; sub-line shows form breakdown:
+  ```
+  GitHub Copilot   detected: yes (CLI ✓ + Chat ✓), enabled: yes, sessions: 7
+  ```
+- **`ConfigureCommand`**: no new flag; `--set copilotEnabled` controls both forms.
+
+## Testing
+
+| Module | Coverage focus |
+|---|---|
+| `VscodeWorkspaceLocator` | Two flavors × three platforms path resolution; `workspace.json` shapes (single `folder` / multi-root `workspace` / missing / unparseable URI / file URI percent-encoding) |
+| `CopilotChatDetector` | Storage dir present / absent / not a directory |
+| `CopilotChatSessionDiscoverer` | No wsHash / wsHash but no chatSessions/ / chatSessions/ empty / all stale / partial fresh / mtime boundary at cutoff |
+| `replayPatches` | Init only / init + sets / init + sets + deletes / unknown kind (warn + skip) / set with missing parent / delete on missing path / nested array growth / numeric vs string path segments / parse errors per line |
+| `readCopilotChatTranscript` | Empty `requests` / multi-turn / cursor advance / skip empty messages / `response[]` flatten with mixed shapes / non-array `requests` defended |
+| `Installer` integration | Auto-enable on either form / status panel reflects both forms / no-overwrite when user explicitly disabled |
+| VSCode panel tests | Same pattern as Cursor / Copilot-CLI: one happy + one error path per panel file (`StatusTreeProvider`, `SummaryWebviewPanel`, `SummaryScriptBuilder`, `SettingsHtmlBuilder`, `SettingsScriptBuilder`, `SettingsWebviewPanel`) |
+
+≥97% statements / lines / branches / functions on new modules, matching the cli workspace coverage gate.
+
+## Out of scope (deferred follow-ups)
+
+These were considered and intentionally postponed:
+
+- Multi-root `.code-workspace` workspace support — needs design pass on how a single `.code-workspace` file maps to one or many `git` projects.
+- VS Code Insiders / Code-OSS / Windsurf / Trae / other vscode-fork support — gated on `VscodeWorkspaceLocator` flavor extension; cheap to add per-fork once a user reports demand.
+- Live tail of in-progress sessions — every other source uses commit-time batch reads.
+- Reading `chatEditingSessions/` (editor edit-operation logs) — separate signal class; would need a different transcript shape than `{role, text}`.
+
+## Release & migration
+
+Same as Copilot CLI: ships in the next CLI minor + matching VS Code patch. No migration. No flag. Auto-detected on installer run; users without VS Code Copilot Chat installed see no change. Users who have *only* Copilot Chat (the field-report case) get auto-enabled on install just like CLI-only users do.

--- a/docs/superpowers/specs/2026-05-07-copilot-chat-events-jsonl-redesign-design.md
+++ b/docs/superpowers/specs/2026-05-07-copilot-chat-events-jsonl-redesign-design.md
@@ -1,0 +1,545 @@
+# VS Code Copilot Chat Redesign — Read `events.jsonl`, Not OpenTelemetry Traces
+
+**Date:** 2026-05-07
+**Status:** Approved for implementation
+**Branch:** `feature-support-copilot`
+**Supersedes:** [`2026-05-06-copilot-chat-support-design.md`](./2026-05-06-copilot-chat-support-design.md)
+**Precedent:** [`2026-05-05-copilot-cli-support-design.md`](./2026-05-05-copilot-cli-support-design.md) (sibling source — kept untouched by this redesign)
+
+## Background
+
+The 2026-05-06 design shipped a `copilot-chat` source that scanned VS Code workspaceStorage for chat session JSONL files. After deploying it and committing on a real machine, the Summary Detail panel's *Manage All Conversations* modal showed **zero `copilot-chat` sessions**, while the status panel correctly reported "4 active sessions" (live discovery worked).
+
+Hands-on filesystem audit on the user's machine (macOS 14, 2026-05-07; mtimes spanning Jan – May 2026 across many wsHash entries) shows the original design's `<wsHash>/chatSessions/<sid>.jsonl` target really is a live conversation store — the original reader's *path* was correct but its *format* (OpenTelemetry trace fallback at `debug-logs/<sid>/main.jsonl`) was not, and a separate, parallel store was missed entirely. The full picture:
+
+1. **`<wsHash>/GitHub.copilot-chat/debug-logs/<sid>/main.jsonl` is OpenTelemetry trace data, not conversation content.** Each line is a span event (`type:"session_start"`, `spanId`, `dur`, `attrs.copilotVersion`) with no `role` / `content` field. The original reader correctly returned zero entries from these files. **Unconditionally discarded** — never contained conversational data; the previous design's use of it as a "v2 fallback" was the bug.
+2. **`<wsHash>/chatSessions/<sid>.jsonl` is the active VS Code Chat panel store.** Written by the built-in Chat panel across all modes (Ask / Edit / Agent). Verified live as of May 6 2026 (a 76 MB session file dated within 24 hours of audit, mode `agent`, sid present in `chat.ChatSessionStore.index`). Format: `kind:0` init document followed by `kind:1` (set at JSON path) and `kind:2` (delete at path) patches; replaying yields a final document whose `requests[]` array contains the conversation. **Read via a patch replayer.**
+3. **`~/.copilot/session-state/<sid>/events.jsonl` is the active Copilot CLI Agent backend store.** Written by the Copilot CLI agent process whether invoked from the standalone `copilot` terminal or from VS Code's embedded "GitHub Copilot CLI Agent" chat session type (the `copilotcli:/...` sids in `ChatSessionStore.index`). Per-session event log; direct verification: parsing `dab1bc55-…/events.jsonl` reproduced exact prompts visible in VS Code's chat panel. **Read via event-stream parser.**
+4. **`<wsHash>/chatSessions/<sid>.json` is a deprecated single-document snapshot format.** All observed instances are from Jan 2026; no `.json` file with mtime in the last four months exists in any wsHash on the audited machine. Will not be read by the new design (the 48h freshness window would exclude all observed files anyway). Documented for completeness; revisit if a user reports historical-import needs.
+
+Stores 2 and 3 are **parallel active formats** corresponding to **different chat entry points** — not a version-evolution sequence. A user who alternates between the VS Code Chat panel and the Copilot CLI within the same workspace produces files in both stores concurrently. Both must be read to give that user a complete `copilot-chat` view.
+
+### Entry-point mapping (verified 2026-05-07 by hands-on test)
+
+The VS Code chat panel "+" dropdown menu items have non-obvious storage routing — verified by creating one session through each menu item and tracing where it landed:
+
+| Menu item | UI looks like | Underlying mechanism | Persists to | sid prefix in `ChatSessionStore.index` | Reader needed |
+|---|---|---|---|---|---|
+| **"New Copilot CLI Session"** | Terminal-style banner ("GitHub Copilot v…", "Describe a task to get started") | Spawns a VS Code integrated terminal running the `copilot` binary | `~/.copilot/session-store.db` (sessions + turns) **and** `~/.copilot/session-state/<sid>/events.jsonl` with `vscode.metadata.json: {origin:"other"}` (no `folderPath`) | not indexed (terminal session, not a chat) | **None** — already covered by existing `copilot` source via the SQLite db |
+| **"New Chat" / "New Chat Editor" / "New Chat Window"** with copilotcli-backend model selected | Standard chat bubbles | Routes to Copilot CLI agent backend over IPC; no terminal | `~/.copilot/session-state/<sid>/events.jsonl` only — **NOT** in `session-store.db` — `vscode.metadata.json: {origin:"vscode", workspaceFolder.folderPath:"<cwd>"}` | `copilotcli:/<sid>` | **Scan A** — `events.jsonl` reader, gated by `folderPath === cwd` |
+| **"New Chat" / "New Chat Editor" / "New Chat Window"** with non-copilotcli model selected | Standard chat bubbles | Routes to OpenAI/Anthropic API directly | `<wsHash>/chatSessions/<sid>.jsonl` patch log | varies by model vendor | **Scan B** — patch-log reader |
+
+**The naming is misleading.** "New Copilot CLI Session" creates a terminal, not a chat session — its content is already captured by the existing `copilot` source. The work in this redesign covers the *other* three menu items, which actually use the chat panel UI.
+
+**The single rule "non-empty `folderPath`" cleanly separates Scan A from the existing `copilot` source:** terminal-spawned `copilot` sessions write `events.jsonl` with `origin:"other"` and **no** `folderPath` field, so Scan A skips them. Chat-panel `copilotcli`-backend sessions write `origin:"vscode"` with `folderPath` set, so Scan A picks them up. Verified with five concurrent sessions on the audited machine spanning all three menu items.
+
+This redesign extends the discoverer to scan **both** active locations (`~/.copilot/session-state/` and `<wsHash>/chatSessions/*.jsonl`) and dispatches to one of two reader implementations based on path. The standalone `copilot` source (which reads `~/.copilot/session-store.db` via `CopilotSessionDiscoverer`) is **out of scope**: it was already shipping correct data on the same commits that produced empty `copilot-chat` results, so its discovery path is independently verified working.
+
+## Goals
+
+- Make new commits' stored transcripts include real `copilot-chat` sessions whether the user chatted via the **VS Code Chat panel** (Ask / Edit / Agent modes — written to `<wsHash>/chatSessions/<sid>.jsonl`) or via **Copilot CLI Agent** sessions (written to `~/.copilot/session-state/<sid>/events.jsonl`), or both.
+- Reuse the existing `TranscriptSource` value `"copilot-chat"`, the `copilotEnabled` config flag, the QueueWorker integration points, and the Summary Modal rendering — only the discoverer/reader/detector internals change.
+- Distinguish VS Code-embedded CLI Agent sessions from `~/.copilot/session-state/` directories that are standalone-CLI side-state, using the presence of a non-empty `vscode.metadata.json.workspaceFolder.folderPath` matching the project directory.
+- Maintain the cli workspace's coverage gate (≥97% statements/lines).
+- Keep test fixtures grounded in **real captured content** for both active formats, not hand-written approximations — directly addressing the failure mode that produced the previous design.
+
+## Non-goals
+
+- **No backfill of pre-existing stored transcripts.** Stored transcripts on the orphan branch are immutable per the QueueWorker model; old commits stay as-is. Users see correct data starting from the next non-squash commit after deploying this change.
+- **No change to `CopilotSessionDiscoverer` / `CopilotTranscriptReader` (the `copilot` CLI standalone source).** It continues to read `~/.copilot/session-store.db` via `node:sqlite`. The `copilotEnabled` flag remains the single user-facing toggle for both Chat and CLI.
+- **No deduplication between `copilot` and `copilot-chat`.** A session that appears in both `session-store.db` (with non-null `cwd`) and `session-state/<sid>/vscode.metadata.json` (with non-empty `folderPath`) would be emitted twice with different `source` values. Not observed in practice; treating the corner case adds plumbing for marginal benefit.
+- **No use of `<wsHash>/state.vscdb` `chat.ChatSessionStore.index`.** The index contains metadata only (title, timing, settings); message bodies are not in the SQLite store. Pulling the index in would add a SQLite read with no body-fidelity gain.
+- **No support for non-VS-Code-flavor hosts (Insiders, Code-OSS, Cursor's Copilot mode).** The session backend in `~/.copilot/session-state/` is shared across hosts, but `vscode.metadata.json` is written only by VS Code Stable; other hosts may use different metadata file names. Revisit on first user report.
+- **No reading of `<wsHash>/chatSessions/<sid>.json`** (the deprecated single-document snapshot format). All observed instances on the audited machine have mtimes in Jan 2026 — already four months past the 48h freshness window. Adding a third reader for an apparently dead format would burn complexity and test surface for zero observable benefit.
+- **No write access to any chat-related file.** All access is read-only.
+- **No removal of the `VscodeWorkspaceLocator` module.** It still serves the Cursor integration and is reused here for the `<wsHash>/chatSessions/` path resolution.
+
+## Observed Reality
+
+Verified hands-on on 2026-05-07, macOS 14, VS Code Stable 1.118.1, GitHub Copilot extension 0.46.2. Two parallel active stores serving different chat entry points; one deprecated store noted for completeness:
+
+### On-disk layout
+
+**Store A — Copilot CLI Agent backend:** `~/.copilot/session-state/<sid>/events.jsonl`
+
+```
+~/.copilot/                                    # Copilot CLI agent backend root
+├── session-store.db                           # SQLite (WAL) — used by `copilot` source only
+├── session-store.db-wal                       # ← ~140 KB live data; `copilot` reader uses node:sqlite
+├── session-store.db-shm
+├── config.json                                # not used here
+├── command-history-state.json                 # not used here
+├── ide/<uuid>.lock                            # IDE bridge handshake — not used
+├── logs/                                      # not used
+├── vscode.session.metadata.cache.json         # not used (per-host cache, not session content)
+└── session-state/                             # ← READ THIS
+    └── <sessionId>/                           # one directory per session, sid = UUIDv4
+        ├── events.jsonl                       # ← READ THIS — append-only event log (conversation lives here)
+        ├── vscode.metadata.json               # ← READ THIS — VS Code attribution: workspaceFolder.folderPath
+        ├── vscode.requests.metadata.json      # not used
+        ├── workspace.yaml                     # not used (mirror of session-store.db sessions row when CLI-created)
+        ├── checkpoints/                       # not used
+        ├── files/                             # not used
+        └── research/                          # not used
+```
+
+**Store B — VS Code built-in Chat panel:** `<userDataDir>/User/workspaceStorage/<wsHash>/chatSessions/<sid>.jsonl`
+
+```
+~/Library/Application Support/Code/User/workspaceStorage/<wsHash>/
+├── workspace.json                             # {"folder":"file:///abs/path"} — used to locate wsHash for current cwd
+├── chatSessions/                              # ← READ THIS — VS Code Chat panel (Ask/Edit/Agent modes)
+│   ├── <uuid>.jsonl                           # ← READ THIS — active patch log format (verified live as of May 6 2026)
+│   └── <uuid>.json                            # deprecated single-document snapshot — last write Jan 2026, NOT read
+├── GitHub.copilot-chat/debug-logs/            # OpenTelemetry traces — NOT conversation, ignored
+└── state.vscdb                                # not used (chat.ChatSessionStore.index has metadata only)
+```
+
+The `<wsHash>` lookup uses the existing `findVscodeWorkspaceHash("Code", projectDir)` helper from `VscodeWorkspaceLocator`, which compares each `workspaceStorage/<entry>/workspace.json`'s `folder` URI against the current project directory. Multi-root `.code-workspace` entries (which use `workspace` instead of `folder`) are silently skipped, matching the Cursor source's behavior.
+
+### Distinguishing VS Code chat from CLI standalone
+
+A session directory `~/.copilot/session-state/<sid>/` may be created by either source:
+
+| Created by | `vscode.metadata.json` | `workspaceFolder.folderPath` | Also in `session-store.db`? |
+|---|---|---|---|
+| **VS Code embedded "Copilot CLI Agent" chat session** | exists | non-empty absolute path | **no** (verified: 0 rows for the two embedded sessions on the audited machine) |
+| **`copilot` terminal CLI** | usually exists, sometimes absent | empty string `""` or absent | **yes** (with `cwd`, `summary`, `turns`) |
+
+**Heuristic**: `vscode.metadata.json` exists AND `workspaceFolder.folderPath` is a non-empty string equal to (after path normalization) the current project directory ⇒ this is a VS Code chat session and we own it. Otherwise skip — the `copilot` source already covers CLI standalone via `session-store.db`.
+
+The single rule (*non-empty folderPath*) carries two responsibilities at once: (a) **gates inclusion** of VS Code-embedded sessions (which are absent from `session-store.db` and would otherwise be invisible), and (b) **prevents double-emit** of CLI standalone sessions (which are *also* present in `session-state/` but already surfaced by the `copilot` source via `session-store.db`).
+
+Cross-tabulation on the audited machine (2026-05-07) confirms this is the only sound discriminator:
+
+| sid (truncated) | `events.jsonl` size | `folderPath` | `session-store.db` row | `turns` rows | Surfaced by |
+|---|---|---|---|---|---|
+| `478eb16c` | 384 KB | `/Users/…/feature/change-…` (matches cwd) | 0 | 0 | **only events.jsonl** ⇒ `copilot-chat` |
+| `dab1bc55` | 723 KB | `/Users/…/feature/change-…` (matches cwd) | 0 | 0 | **only events.jsonl** ⇒ `copilot-chat` |
+| `6cb63aa5` | 131 KB | `""` | 1 | 2 | `session-store.db` ⇒ `copilot` |
+| `70dceafd` | 105 KB | `""` | 1 | 2 | `session-store.db` ⇒ `copilot` |
+| `9dfa138e` | 226 KB | `""` | 1 | 2 | `session-store.db` ⇒ `copilot` |
+| `ef28e639` | 210 KB | `""` | 1 | 3 | `session-store.db` ⇒ `copilot` |
+| `aa13c631` | (no `events.jsonl`) | (no `vscode.metadata.json`) | 1 | 0 | empty session, neither path emits |
+
+The two sessions with non-empty `folderPath` (478eb16c, dab1bc55) are **invisible** to the existing `copilot` source — that's the bug the new `copilot-chat` reader fixes. The four with empty `folderPath` are **already covered** by the `copilot` source, and skipping them in the new reader is what avoids the duplication that would otherwise show two tabs per session in the Manage modal.
+
+### `events.jsonl` schema
+
+Each line is one JSON event. Top level:
+
+```jsonc
+{
+  "type": "user.message",                     // ← drives interpretation
+  "timestamp": "2026-05-06T16:47:24.077Z",    // ISO 8601, present on most events
+  "id": "<uuid>",                             // event id
+  "parentId": "<uuid>",                       // event causality (not used)
+  "data": { /* shape depends on type */ }
+}
+```
+
+Observed `type` values, with handling:
+
+| `type` | Handling | `data` shape (relevant fields) |
+|---|---|---|
+| `session.start` | skip | `{sessionId, version, producer:"copilot-agent", copilotVersion, startTime, selectedModel, context.cwd, ...}` |
+| `system.message` | skip | `{role:"system", content:"You are the GitHub Copilot CLI..."}` |
+| **`user.message`** | **emit** `{role:"human", content: data.content, timestamp: o.timestamp}` | `{content:"<user prompt>", transformedContent:"<augmented prompt>"}` — we use `content`, not `transformedContent` |
+| `assistant.turn_start` | skip | `{turnId, interactionId}` |
+| **`assistant.message`** | **emit** if `data.content` is non-empty string: `{role:"assistant", content: data.content, timestamp: o.timestamp}` | `{messageId, content:"<assistant response>", toolRequests?:[...]}` — content-only message ⇒ keep; tool-only message (`content === ""`) ⇒ drop |
+| `assistant.turn_end` | skip | `{turnId, ...}` |
+| `tool.execution_start` | skip | tool call invocation |
+| `tool.execution_complete` | skip | tool call result |
+| `hook.start` / `hook.end` | skip | session lifecycle |
+| `session.shutdown` / `session.resume` / `session.error` | skip | session lifecycle |
+| (any other / unknown) | skip | future-proofing |
+
+Distribution example (session `dab1bc55-…`, 331 lines): `session.start ×1, system.message ×6, user.message ×6, assistant.turn_start/end ×55, assistant.message ×54 (50 with content, 4 tool-only), tool.execution_start/complete ×66 ea, hook.start/end ×5 ea, session.shutdown ×6, session.resume ×5, session.error ×1` ⇒ 56 emitted entries (6 user + 50 assistant).
+
+### Mid-write robustness (`events.jsonl`)
+
+`events.jsonl` is appended to during a live chat. A reader observing it mid-write may see a truncated last line. Per-line `JSON.parse` failure is treated as **skip this line, continue**, the same way the existing Claude JSONL reader handles incomplete entries. The line cursor advances past the bad line so the next commit doesn't re-feed it.
+
+This is more aggressive than the prior Copilot Chat reader's "any parse error ⇒ zero messages for the whole session" policy, and matches the ergonomics of every other JSONL-based reader in the codebase. The cost is occasionally losing one corrupted line; the benefit is never blocking an entire session over one bad write.
+
+### Legacy patch-log schema (`chatSessions/<sid>.jsonl`)
+
+Each line is a JSON event:
+
+```jsonc
+// kind 0 — initial document (always line 0)
+{"kind":0,"v":{"version":3,"sessionId":"<uuid>","requests":[], /* ... */ }}
+
+// kind 1 — set value at JSON path
+{"kind":1,"k":["requests",0,"result"],"v":{ /* the new value at that path */ }}
+
+// kind 2 — delete value at JSON path
+{"kind":2,"k":["pendingRequests",0]}
+```
+
+Reconstructing the conversation requires **replaying patches in order**: start with `kind:0` `v` as the document, apply each `kind:1` as a set-at-path and each `kind:2` as a delete-at-path, in file order. The final document's `requests[]` array contains the conversation. Each `requests[i]` has shape:
+
+```jsonc
+{
+  "message": { "text": "user prompt..." },          // user input
+  "response": [ { "value": "..." }, /* ... */ ],    // streamed assistant output (post-stream merged by patches)
+  "result": { "metadata": { "codeBlocks": [/* ... */] } },
+  "timestamp": 1776416700000                         // milliseconds since epoch
+}
+```
+
+Path semantics for the replayer:
+- Numeric segment ⇒ array index (auto-grow with `null` slots if needed for `set`)
+- String segment ⇒ object key
+- `delete` on a missing path is a no-op (vscode emits these legitimately for already-cleaned `pendingRequests`)
+- `set` with parents missing creates intermediate objects/arrays based on the **next** segment's type
+
+**Mid-write policy for patch logs:** A truncated last line that fails `JSON.parse` invalidates everything after it (later patches assume earlier patches landed). The reader **stops at the first parse failure**, replays everything before it, and emits whatever `requests[]` is well-defined. The cursor does **not** advance past the bad line — next commit will retry once the writer completes the line.
+
+### Legacy snapshot schema (`chatSessions/<sid>.json`)
+
+Single JSON document, identical schema to a fully-replayed patch log's final state:
+
+```jsonc
+{
+  "version": 3,
+  "sessionId": "<uuid>",
+  "lastMessageDate": 1735810185123,
+  "requests": [ /* same shape as patch-log requests[i] above */ ],
+  "inputState": { /* ... */ }
+}
+```
+
+Read via `JSON.parse(fileContent)`. Same `requests[i]` extraction logic as patch log.
+
+### Shared `requests[i] → entries` extraction (formats 2 & 3)
+
+After replay/parse:
+- For each `requests[i]` where `i > cursor`:
+  - If `req.message?.text` is a non-empty string ⇒ emit `{role:"human", content: req.message.text, timestamp: req.timestamp ? new Date(req.timestamp).toISOString() : undefined}`
+  - Flatten `req.response` into a single string (concat `.value` fields where the entry is `{value: string}`; ignore other shapes); if non-empty ⇒ emit `{role:"assistant", content: <flattened>, timestamp: req.timestamp ? ISO : undefined}`
+- Cursor advances to `requests.length - 1` (last successfully processed request index).
+
+### Time-window filter
+
+Sessions whose `events.jsonl` mtime is older than `48h` are skipped at the discoverer layer. This matches `OpenCode` / `Cursor` / `Copilot CLI` conventions and keeps stored transcripts focused on recent activity. The 48h constant is shared as `SESSION_STALE_MS` in the discoverer file.
+
+## Architecture
+
+### Module map
+
+```
+cli/src/core/
+├── CopilotChatDetector.ts                # MODIFIED — switch probe target
+├── CopilotChatDetector.test.ts           # rewritten
+├── CopilotChatSessionDiscoverer.ts       # REWRITTEN — read ~/.copilot/session-state/
+├── CopilotChatSessionDiscoverer.test.ts  # rewritten
+├── CopilotChatTranscriptReader.ts        # REWRITTEN — parse events.jsonl
+└── CopilotChatTranscriptReader.test.ts   # rewritten
+
+cli/src/hooks/
+└── QueueWorker.ts                        # 1-line change: pass beforeTimestamp to readCopilotChatTranscript
+```
+
+The QueueWorker change is a single-line update at [line 1532](../../../cli/src/hooks/QueueWorker.ts#L1532): the existing `readCopilotChatTranscript(session.transcriptPath, cursor ?? undefined)` becomes `readCopilotChatTranscript(session.transcriptPath, cursor ?? undefined, beforeTimestamp)`. The discovery branch at lines 1455–1463 stays untouched (the new `discoverCopilotChatSessions` keeps the same name and signature).
+
+**Untouched**:
+- `cli/src/Types.ts` (`TranscriptSource` already includes `"copilot-chat"`)
+- `cli/src/hooks/QueueWorker.ts` discovery block (lines 1455–1463) and the surrounding pipeline
+- `cli/src/core/VscodeWorkspaceLocator.ts` (still used by Cursor integration)
+- `cli/src/core/CopilotSessionDiscoverer.ts` and `CopilotTranscriptReader.ts` (the `copilot` CLI source)
+- `cli/src/commands/StatusCommand.ts` (`counts.copilot + counts["copilot-chat"]` aggregation)
+- `vscode/src/views/SummaryWebviewPanel.ts` (`getEnabledSources` returns `"copilot-chat"`)
+- `vscode/src/views/SummaryScriptBuilder.ts` (`'Copilot Chat'` label)
+- `vscode/src/providers/StatusTreeProvider.ts` (single-toggle UI)
+
+### `CopilotChatDetector` (modified)
+
+```typescript
+export function getCopilotChatStorageDir(home?: string): string
+//   <userDataDir>/User/globalStorage/github.copilot-chat (Copilot Chat extension)
+//   PRESERVED — still used by the detector probe and existing test mocks.
+
+export function getCopilotCliSessionStateDir(home?: string): string
+//   path.join(home ?? os.homedir(), ".copilot", "session-state")
+//   NEW — Copilot CLI agent backend root.
+
+export async function isCopilotChatInstalled(): Promise<boolean>
+//   true when EITHER probe path exists as directory
+//   The discoverer handles per-cwd matching; the detector only answers the
+//   "does this user have ANY Copilot Chat install?" question.
+```
+
+### `CopilotChatSessionDiscoverer` (rewritten)
+
+```typescript
+const SESSION_STALE_MS = 48 * 60 * 60 * 1000;
+
+export interface CopilotChatScanResult {
+    readonly sessions: ReadonlyArray<SessionInfo>;
+    readonly error?: CopilotChatScanError;
+}
+
+export async function scanCopilotChatSessions(projectDir: string): Promise<CopilotChatScanResult>
+export async function discoverCopilotChatSessions(projectDir: string): Promise<ReadonlyArray<SessionInfo>>
+```
+
+`scanCopilotChatSessions` runs **two scans in sequence** and concatenates results. Either scan may independently produce an `error`; the first error encountered is returned (subsequent are debug-logged), but partial sessions from the successful scan are still returned.
+
+**Scan A — current format `~/.copilot/session-state/`:**
+
+1. `root = ~/.copilot/session-state`. If `readdir(root)` throws `ENOENT` → empty. Other fs errors → set `error: { kind:"fs" }`, empty sessions.
+2. `cutoff = Date.now() - SESSION_STALE_MS`.
+3. For each entry `<sid>` in `readdir(root)`:
+   1. `metaPath = <root>/<sid>/vscode.metadata.json`. `readFile + JSON.parse`. Failure ⇒ debug-log, skip.
+   2. Read `meta.workspaceFolder.folderPath`. Missing, non-string, or empty string ⇒ skip.
+   3. `normalizePathForMatch(folderPath) !== normalizePathForMatch(projectDir)` ⇒ skip.
+   4. `transcriptPath = <root>/<sid>/events.jsonl`. `stat`. Failure ⇒ debug-log, skip.
+   5. `mtimeMs < cutoff` ⇒ skip.
+   6. Emit `{ sessionId: <sid>, transcriptPath, updatedAt: ISO(mtime), source: "copilot-chat" }`.
+
+**Scan B — legacy formats `<wsHash>/chatSessions/<sid>.{jsonl,json}`:**
+
+1. `wsHash = await findVscodeWorkspaceHash("Code", projectDir)`. `null` ⇒ skip Scan B (this cwd never had a VS Code session).
+2. `sessionsDir = <wsStorageDir>/<wsHash>/chatSessions`. `readdir`. ENOENT ⇒ skip Scan B. Other fs errors ⇒ set `error` (only if Scan A didn't already set one), continue with what Scan A returned.
+3. For each entry whose name ends with `.jsonl` (entries ending with `.json` are explicitly skipped — see Non-goals re. deprecated snapshot format):
+   1. `transcriptPath = <sessionsDir>/<entry>`. `stat`. Failure ⇒ debug-log, skip.
+   2. `mtimeMs < cutoff` ⇒ skip.
+   3. `sessionId = entry.slice(0, -".jsonl".length)`.
+   4. Emit `{ sessionId, transcriptPath, updatedAt: ISO(mtime), source: "copilot-chat" }`.
+
+`discoverCopilotChatSessions` strips the error channel and `log.warn`s if present, matching the existing convention.
+
+`normalizePathForMatch` is imported from `VscodeWorkspaceLocator.ts` — same case-folding and trailing-slash logic the Cursor source uses, ensuring mac-vs-linux behavior consistency across both VS Code-derived sources.
+
+**Cross-format collisions are not deduplicated.** If a sid appears in both Scan A and Scan B (extremely unlikely — different sid namespaces in practice), both are emitted. Same rationale as the Non-goals section's "no copilot vs copilot-chat dedup": treating it adds plumbing for marginal benefit.
+
+### `CopilotChatTranscriptReader` (rewritten — dispatcher + 3 sub-readers)
+
+```typescript
+export async function readCopilotChatTranscript(
+    transcriptPath: string,
+    cursor?: TranscriptCursor,
+    beforeTimestamp?: string,
+): Promise<TranscriptReadResult>
+```
+
+Signature matches the post-redesign QueueWorker call site (1-line update at [line 1532](../../../cli/src/hooks/QueueWorker.ts#L1532) noted in the Module map).
+
+**Dispatch by path/extension:**
+
+| Pattern | Sub-reader |
+|---|---|
+| `<...>/.copilot/session-state/<sid>/events.jsonl` | `readEventsJsonl` |
+| `<...>/chatSessions/<sid>.jsonl` | `readPatchLog` |
+
+The dispatcher matches on the trailing path segments of `transcriptPath`. Unrecognized pattern ⇒ throw — should never happen given the discoverer only ever emits one of the two.
+
+**Cursor semantics:**
+
+`TranscriptCursor.lineNumber` (existing field, no schema change) carries different meanings per sub-reader:
+- `readEventsJsonl` → line number in events.jsonl (next read starts at `lineNumber + 1`)
+- `readPatchLog` → last-emitted-`requests[]`-index + 1 (next read emits `requests[i]` for `i >= lineNumber`)
+
+The two interpretations never mix because the cursor is keyed by `transcriptPath`, and each transcriptPath only ever maps to one sub-reader. Documented in code comments at the dispatcher.
+
+#### Sub-reader: `readEventsJsonl(path, cursor, beforeTimestamp)`
+
+1. `startLine = cursor?.lineNumber ?? 0`. Open via `readline.createInterface`.
+2. Maintain `currentLine = 0`. For each line:
+   1. `currentLine++`. If `currentLine <= startLine` ⇒ skip.
+   2. `JSON.parse(line)`. On parse error ⇒ skip line, advance cursor (consistent with Claude reader).
+   3. Switch on `evt.type`:
+      - `"user.message"` ⇒ if `evt.data?.content` is a non-empty string: push `{role:"human", content, timestamp: evt.timestamp}`.
+      - `"assistant.message"` ⇒ if `evt.data?.content` is a non-empty string: push `{role:"assistant", content, timestamp: evt.timestamp}`. (Tool-only messages with `content === ""` are dropped.)
+      - default ⇒ skip.
+   4. `beforeTimestamp` gate: if set and `evt.timestamp > beforeTimestamp` ⇒ **break without consuming**, set `endLine = currentLine - 1`. Matches Gemini reader semantics.
+3. Return `{ entries, newCursor: { transcriptPath, lineNumber: endLine, updatedAt: now }, totalLinesRead: endLine - startLine }`.
+
+#### Sub-reader: `readPatchLog(path, cursor, beforeTimestamp)`
+
+1. `readFile(path, "utf-8")`, split by `\n`, drop empty trailing line.
+2. Initialize `doc = {}`. For each line in order:
+   1. `JSON.parse(line)`. On parse error ⇒ **stop replaying** (later patches assume earlier landed). Do not advance cursor past the bad line.
+   2. `kind === 0` ⇒ `doc = evt.v`.
+   3. `kind === 1` ⇒ `setAtPath(doc, evt.k, evt.v)`.
+   4. `kind === 2` ⇒ `deleteAtPath(doc, evt.k)`.
+   5. otherwise ⇒ debug-log, skip.
+3. Apply shared `requests[] → entries` extraction (see *Observed Reality* section), starting from index `cursor?.lineNumber ?? 0`.
+4. `beforeTimestamp` gate: any request with `req.timestamp > beforeTimestamp` (after ms→ISO conversion) ⇒ **stop emitting and do not advance cursor past it** — re-read on next commit.
+5. Return `{ entries, newCursor: { transcriptPath, lineNumber: <highest emitted index + 1>, updatedAt: now }, totalLinesRead: requests.length - (cursor?.lineNumber ?? 0) }`.
+
+#### Shared helpers (private)
+
+- `setAtPath(doc, segments, value)`: numeric segment ⇒ array index (auto-grow with `null`); string ⇒ object key; create intermediate parents based on next segment's type.
+- `deleteAtPath(doc, segments)`: no-op if any path segment is missing. Numeric segment + array ⇒ `splice`; string segment + object ⇒ `delete`.
+- `extractFromRequests(requests, startIdx, beforeTimestamp)`: used by `readPatchLog`; emits `{role, content, timestamp}` entries per the rules in the *Shared `requests[i] → entries` extraction* subsection.
+
+### Data flow (commit time)
+
+```
+QueueWorker.loadSessionTranscripts(cwd)
+  ├─ existing claude/codex/gemini/opencode/cursor branches (untouched)
+  ├─ existing copilot CLI branch (untouched) — discoverCopilotSessions(cwd), reads session-store.db
+  └─ if (config.copilotEnabled && isCopilotChatInstalled())
+        └─ discoverCopilotChatSessions(cwd)
+              ├─ Scan A: readdir(~/.copilot/session-state) → for each <sid>:
+              │      └─ vscode.metadata.json: folderPath ≟ cwd (normalized)
+              │         events.jsonl: stat + 48h mtime gate
+              │         emit SessionInfo { transcriptPath: <abs>/events.jsonl, source:"copilot-chat" }
+              └─ Scan B: findVscodeWorkspaceHash("Code", cwd) →
+                       readdir(<wsHash>/chatSessions) → for each *.jsonl (skip *.json — deprecated):
+                          stat + 48h mtime gate
+                          emit SessionInfo { transcriptPath: <abs>/<sid>.jsonl, source:"copilot-chat" }
+        └─ readAllTranscripts(allSessions, cwd, beforeTimestamp)
+              └─ source==="copilot-chat" ⇒ readCopilotChatTranscript(path, cursor, beforeTimestamp)
+                    └─ dispatch by path suffix:
+                       ├─ events.jsonl   → readEventsJsonl   (line-based cursor; user.message + non-empty assistant.message)
+                       └─ <sid>.jsonl    → readPatchLog      (request-idx cursor; replay kind:0/1/2 → requests[])
+                    └─ TranscriptReadResult → entered into stored transcript JSON
+```
+
+The downstream path (stored transcript writer → orphan branch → webview reader → modal renderer) is unchanged.
+
+## Error handling
+
+| Failure | Layer | Behavior |
+|---|---|---|
+| `~/.copilot/session-state/` missing | discoverer (Scan A) | empty Scan A, no error (user just doesn't use the new format) |
+| `~/.copilot/session-state/` other fs error | discoverer (Scan A) | Scan A empty, set `error: { kind:"fs" }`; Scan B still runs |
+| `<sid>/vscode.metadata.json` missing / unparseable | discoverer (Scan A) | skip sid (debug log) — pure CLI side-state |
+| `folderPath` empty / non-string / not matching cwd | discoverer (Scan A) | skip sid (no log) |
+| `<sid>/events.jsonl` missing / stat fails | discoverer (Scan A) | skip sid (debug log) |
+| `findVscodeWorkspaceHash` returns null | discoverer (Scan B) | skip Scan B (no VS Code workspace ever opened this cwd) |
+| `<wsHash>/chatSessions/` missing | discoverer (Scan B) | skip Scan B (legacy format never used by this VS Code install) |
+| `<wsHash>/chatSessions/` other fs error | discoverer (Scan B) | empty Scan B, set `error` only if Scan A didn't already |
+| `mtime < cutoff` (any format) | discoverer | skip (silent — common case) |
+| `readEventsJsonl`: per-line `JSON.parse` failure | reader | skip line, advance cursor, continue |
+| `readPatchLog`: per-line `JSON.parse` failure | reader | **stop replay** at bad line; emit whatever was assembled before; cursor does **not** advance past bad line (next commit retries) |
+| Any reader: file I/O failure (read/open) | reader | throw — QueueWorker [line 1530–1536](../../../cli/src/hooks/QueueWorker.ts#L1530-L1536) catches, logs error, skips this session |
+| Reader: zero entries after filtering | reader + QueueWorker | session dropped from `sessionTranscripts` (existing `entries.length > 0` gate) |
+
+## Types & config
+
+No type changes — `TranscriptSource`, `SessionInfo`, `StoredSession`, `StoredTranscript`, `TranscriptCursor`, `TranscriptReadResult`, `CopilotChatScanError` already exist with the right shapes.
+
+No config changes — `copilotEnabled` (single user-facing toggle) is unchanged.
+
+## Testing
+
+### `CopilotChatSessionDiscoverer.test.ts` (rewritten)
+
+Cases (all use vitest tmpdir + a fake `HOME` and a fake `~/Library/.../workspaceStorage` root to isolate from the user's real disk):
+
+**Scan A — `~/.copilot/session-state/`:**
+
+| # | Scenario | Expectation |
+|---|---|---|
+| 1 | session-state does not exist (and Scan B also empty) | `{ sessions: [] }`, no error |
+| 2 | session-state exists but empty | `{ sessions: [] }` |
+| 3 | One sid with `folderPath === cwd` and fresh `events.jsonl` | 1 SessionInfo, `transcriptPath` ends with `events.jsonl` |
+| 4 | `folderPath` is empty string `""` | skip (CLI standalone marker) |
+| 5 | `folderPath` is missing field | skip |
+| 6 | `folderPath` does not match cwd | skip |
+| 7 | `folderPath` differs only in case (macOS) | match (via `normalizePathForMatch`) |
+| 8 | `folderPath` differs only in trailing slash | match |
+| 9 | `vscode.metadata.json` does not exist | skip |
+| 10 | `vscode.metadata.json` is malformed JSON | skip (debug log) |
+| 11 | `events.jsonl` does not exist | skip |
+| 12 | `events.jsonl` mtime > 48h ago | skip |
+| 13 | `readdir(~/.copilot/session-state)` returns EACCES | `error: { kind:"fs" }`; Scan B still runs |
+| 14 | Scan A mixed: 1 matches, 1 empty folderPath, 1 stale, 1 path mismatch | 1 emitted from Scan A |
+
+**Scan B — `<wsHash>/chatSessions/`:**
+
+| # | Scenario | Expectation |
+|---|---|---|
+| 15 | `findVscodeWorkspaceHash` returns null (no matching workspace.json) | Scan B emits 0, no error |
+| 16 | wsHash exists but `chatSessions/` does not | Scan B emits 0 |
+| 17 | wsHash + `chatSessions/<sid>.jsonl` (fresh mtime) | 1 SessionInfo, transcriptPath ends with `<sid>.jsonl`, sessionId is `<sid>` |
+| 18 | wsHash + `chatSessions/<sid>.json` (fresh mtime) | **skip** — deprecated snapshot format excluded by suffix filter |
+| 19 | Mix of `.jsonl` + `.json` + `.tmp` (irrelevant suffix) | only `.jsonl` emitted |
+| 20 | `chatSessions/<sid>.jsonl` mtime > 48h | skip |
+| 21 | `chatSessions/` returns EACCES, Scan A produced sessions | Scan A sessions returned, Scan B `error` set |
+| 22 | `chatSessions/` returns EACCES, Scan A also errored | Scan A's error wins (returned first) |
+
+**Combined:**
+
+| # | Scenario | Expectation |
+|---|---|---|
+| 23 | Both scans produce sessions | both batches concatenated; total = sum of both |
+| 24 | Same sid in both Scan A and Scan B | both emitted (no dedup, per design) |
+
+### `CopilotChatTranscriptReader.test.ts` (rewritten)
+
+Fixtures derived from real captures of each format (sanitized to short test strings). Each test constructs files from typed factories, **not** from hand-written JSON, so a future schema drift is caught by adding one event type / patch kind.
+
+**Dispatcher:**
+
+| # | Scenario | Expectation |
+|---|---|---|
+| D1 | Path ends with `/session-state/<sid>/events.jsonl` | calls `readEventsJsonl` |
+| D2 | Path ends with `/chatSessions/<sid>.jsonl` | calls `readPatchLog` |
+| D3 | Path matches no pattern (e.g. `.json` slipped through) | throws |
+
+**`readEventsJsonl`:**
+
+| # | Scenario | Expectation |
+|---|---|---|
+| E1 | Happy path: session.start + 2× user.message + 2× assistant.message + tool.* + assistant.turn_* + session.shutdown | 4 entries in file order; `newCursor.lineNumber` = total lines |
+| E2 | `assistant.message` with `content === ""` and `toolRequests` populated | dropped |
+| E3 | All non-conversation types | 0 entries |
+| E4 | `beforeTimestamp` cuts later events | pre-cutoff entries returned; cursor stops at last consumed line |
+| E5 | Cursor increment after appended lines | second call returns only the new lines |
+| E6 | One malformed line in middle | skipped, cursor advances, surrounding entries returned |
+| E7 | `evt.timestamp` missing | entry emitted with `timestamp: undefined` |
+
+**`readPatchLog`:**
+
+| # | Scenario | Expectation |
+|---|---|---|
+| P1 | `kind:0` init with empty `requests` + `kind:1` set at `requests[0]` to a full request | 1 user + 1 assistant entry |
+| P2 | Multiple `kind:1` patches at deep paths (`["requests",0,"response",0,"value"]`) | final `requests[0].response[0].value` reflects last set |
+| P3 | `kind:2` delete at `["pendingRequests",0]` | no crash; subsequent `requests[]` extraction unaffected |
+| P4 | `kind:2` on missing path | no-op, no error |
+| P5 | Cursor=2 after 4 requests had been emitted before; new patch adds requests[4] | only requests[4] emitted |
+| P6 | `beforeTimestamp` cuts a request whose `req.timestamp` is later | cursor stops at last emitted index, request not consumed |
+| P7 | Mid-line `JSON.parse` failure (truncated last line) | replay stops at bad line; emit what's assembled; cursor stays at previous good state |
+| P8 | Unknown `kind` value | debug-log, skip patch |
+| P9 | `req.message.text` empty string | skip user emit but still emit assistant if present |
+| P10 | `req.response` is empty array | skip assistant emit |
+
+### `CopilotChatDetector.test.ts` (rewritten)
+
+| # | Scenario | Expectation |
+|---|---|---|
+| 1 | `~/.copilot/session-state/` is a directory | `true` (Copilot CLI agent backend present) |
+| 2 | `~/.copilot/session-state/` missing, but `<userDataDir>/User/globalStorage/github.copilot-chat` exists | `true` (Copilot Chat extension installed) |
+| 3 | Both probe paths missing | `false` |
+| 4 | One probe path exists but is a file, the other is missing | `false` |
+| 5 | `stat` throws non-ENOENT (EACCES) on either probe path — warn-logs and treats as missing | `false` if both treated as missing |
+
+### Integration coverage
+
+The QueueWorker and SummaryWebviewPanel test suites already assert behavior for `source: "copilot-chat"` sessions. Those tests use stub session data and don't exercise the reader internals, so they pass without modification once the rewritten reader produces the same `TranscriptReadResult` shape.
+
+`cli` workspace coverage gate (97% statements/lines) is held: the rewritten files are smaller and more focused than the prior versions, with denser test coverage.
+
+## Migration & rollout
+
+- **Backwards compatibility**: the previous design produced zero data on any user's machine, so rolling forward causes no functional regression. Users who chat via the **VS Code Chat panel** start seeing correct data on the first non-squash commit after installing the new version, via Scan B of the discoverer; users who chat via the **Copilot CLI Agent** (standalone `copilot` terminal or VS Code's "GitHub Copilot CLI Agent" chat session type) get correct data via Scan A. Users who use both get both.
+- **No backfill**: pre-existing stored transcripts on the orphan branch are immutable. Old commits will continue to display the same (typically empty) `copilot-chat` data in the Manage modal. This is consistent with how every other source addition has shipped (Cursor, OpenCode, Copilot CLI all started capturing data only at deploy time).
+- **No data migration**: nothing to delete or convert; the old design wrote no `copilot-chat` sessions to the orphan branch in observed runs.
+- **48h freshness window keeps both stores honest**: stale `chatSessions/<sid>.jsonl` from a workspace the user no longer touches will not surface. Same for `events.jsonl` from idle sessions. Symmetric with every other source.
+- **Telemetry / status panel**: status panel session counts use `discoverCopilotChatSessions(cwd)`; counts become more accurate (no longer inflating with debug-logs span events that produced zero stored entries) and now include both Store A and Store B contributions.
+
+## Risks
+
+1. **`vscode.metadata.json` schema drift.** If a future Copilot release changes `workspaceFolder.folderPath` to a `vscode.Uri` shape (`{ scheme, path }`) or relocates the field, Scan A silently emits zero sessions. **Mitigation**: integration smoke test in CI that lints a real captured `vscode.metadata.json` against the expected shape. Documented in this spec; logged at debug level on parse failure so a `DEBUG=jollimemory:* git commit` invocation surfaces the drift. Scan B's coverage of legacy formats provides degraded-but-nonzero data during the drift window.
+2. **`events.jsonl` event-type renames.** If `user.message` becomes `chat.user.message`, the reader emits zero conversation entries while parsing fine. **Mitigation**: the reader logs a debug-level message when a recognized session yields zero conversation entries, making this drift visible without alarming non-debug users.
+3. **Patch-log schema drift.** A future VS Code version could introduce `kind:3` (e.g. "splice array range"), invalidating the assumption that {0,1,2} cover all patches. **Mitigation**: the replayer debug-logs unknown `kind` values rather than throwing, so a missed patch yields a slightly stale document but not zero output. Schema drift detector (test P8) prevents regressions in our handling of known kinds.
+4. **Multi-host divergence.** If VS Code Insiders or an Insiders-derived fork uses a different `vscode.metadata.json` filename, Scan A misses those hosts. Scan B still works for hosts whose user-data root happens to match `Code` (none currently). **Mitigation**: out of scope here; fold into the next host-support iteration via `VscodeWorkspaceLocator`'s flavor parameter.
+5. **`session-state/` entries written by future Copilot CLI versions with non-empty `folderPath`.** If Copilot CLI starts populating `vscode.metadata.json.folderPath` for terminal sessions to record the `cwd`, those sessions would be picked up by **both** the `copilot` source (via session-store.db) and the `copilot-chat` source (via Scan A). **Mitigation**: accepted; revisit on first observed double-post.
+6. **Cross-format duplicate sids (Scan A + Scan B).** Sids in `~/.copilot/session-state/` and `<wsHash>/chatSessions/` come from different namespaces in observation; collision is theoretically possible but unobserved. **Mitigation**: per Non-goals, no dedup. Both copies would surface as separate sessions in the modal.
+7. **Performance on long-running sessions.** A multi-thousand-turn `events.jsonl` could grow into the multi-MB range. The reader's `readline` stream is O(lines), bounded by the cursor; first-time read is the only large operation per session. Patch logs are size-bounded by VS Code's internal cap; snapshots are small (< 1 MB observed). Comparable to the existing Claude reader. No additional mitigation needed.
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -8420,7 +8420,7 @@
 		},
 		"vscode": {
 			"name": "jollimemory-vscode",
-			"version": "0.98.18",
+			"version": "0.98.20",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@vscode/codicons": "^0.0.45",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8420,7 +8420,7 @@
 		},
 		"vscode": {
 			"name": "jollimemory-vscode",
-			"version": "0.98.17",
+			"version": "0.98.18",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@vscode/codicons": "^0.0.45",

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -2,7 +2,7 @@
 	"name": "jollimemory-vscode",
 	"displayName": "Jolli Memory",
 	"description": "VS Code sidebar for Jolli Memory — AI-powered commit summaries and smart git operations",
-	"version": "0.98.18",
+	"version": "0.98.20",
 	"publisher": "jolli",
 	"license": "Apache-2.0",
 	"icon": "assets/icon.png",

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -2,7 +2,7 @@
 	"name": "jollimemory-vscode",
 	"displayName": "Jolli Memory",
 	"description": "VS Code sidebar for Jolli Memory — AI-powered commit summaries and smart git operations",
-	"version": "0.98.17",
+	"version": "0.98.18",
 	"publisher": "jolli",
 	"license": "Apache-2.0",
 	"icon": "assets/icon.png",

--- a/vscode/src/providers/StatusTreeProvider.test.ts
+++ b/vscode/src/providers/StatusTreeProvider.test.ts
@@ -586,6 +586,52 @@ describe("StatusTreeProvider", () => {
 		expect(cursor?.description).toBe("detected & enabled (3 sessions)");
 	});
 
+	// ── Copilot scan error ────────────────────────────────────────────────
+
+	it("shows Copilot Integration row when detected and enabled", async () => {
+		const bridge = {
+			cwd: "/repo",
+			getStatus: vi.fn(async () =>
+				makeStatus({
+					copilotDetected: true,
+					copilotEnabled: true,
+					sessionsBySource: { copilot: 2 },
+				}),
+			),
+		};
+		loadConfigFromDir.mockResolvedValue({ apiKey: "key" });
+
+		const provider = makeStatusProvider(bridge as never);
+		await provider.refresh();
+
+		const items = provider.getChildren();
+		const item = items.find((i) => i.label === "Copilot Integration");
+		expect(item).toBeDefined();
+		expect(item?.description).toContain("2");
+	});
+
+	it("shows Copilot Integration as unavailable when scan errors", async () => {
+		const bridge = {
+			cwd: "/repo",
+			getStatus: vi.fn(async () =>
+				makeStatus({
+					copilotDetected: true,
+					copilotEnabled: true,
+					copilotScanError: { kind: "locked", message: "database is locked" },
+				}),
+			),
+		};
+		loadConfigFromDir.mockResolvedValue({ apiKey: "key" });
+
+		const provider = makeStatusProvider(bridge as never);
+		await provider.refresh();
+
+		const items = provider.getChildren();
+		const item = items.find((i) => i.label === "Copilot Integration");
+		expect(item?.description).toContain("locked");
+		expect(String(item?.tooltip)).toContain("Copilot database scan failed");
+	});
+
 	// ── Auth-aware status rows ────────────────────────────────────────────
 
 	it("shows Jolli Account connected when authToken is present", async () => {

--- a/vscode/src/providers/StatusTreeProvider.test.ts
+++ b/vscode/src/providers/StatusTreeProvider.test.ts
@@ -629,7 +629,93 @@ describe("StatusTreeProvider", () => {
 		const items = provider.getChildren();
 		const item = items.find((i) => i.label === "Copilot Integration");
 		expect(item?.description).toContain("locked");
-		expect(String(item?.tooltip)).toContain("Copilot database scan failed");
+		expect(String(item?.tooltip)).toContain("Copilot CLI database scan failed");
+	});
+
+	it("Copilot row tooltip distinguishes CLI / Chat detection", async () => {
+		const bridge = {
+			cwd: "/repo",
+			getStatus: vi.fn(async () =>
+				makeStatus({
+					copilotDetected: true,
+					copilotChatDetected: false,
+					copilotEnabled: true,
+				}),
+			),
+		};
+		loadConfigFromDir.mockResolvedValue({ apiKey: "key" });
+
+		const provider = makeStatusProvider(bridge as never);
+		await provider.refresh();
+
+		const items = provider.getChildren();
+		const copilotItem = items.find(
+			(i) => typeof i.label === "string" && i.label.includes("Copilot"),
+		);
+		expect(String(copilotItem?.tooltip)).toContain("CLI: ✓");
+		expect(String(copilotItem?.tooltip)).toContain("Chat: ✗");
+	});
+
+	it("Copilot row detected = true when only Chat is detected", async () => {
+		const bridge = {
+			cwd: "/repo",
+			getStatus: vi.fn(async () =>
+				makeStatus({
+					copilotDetected: false,
+					copilotChatDetected: true,
+					copilotEnabled: true,
+				}),
+			),
+		};
+		loadConfigFromDir.mockResolvedValue({ apiKey: "key" });
+
+		const provider = makeStatusProvider(bridge as never);
+		await provider.refresh();
+
+		const items = provider.getChildren();
+		const copilotItem = items.find((i) => i.label === "Copilot Integration");
+		// Item is rendered with detected=true (e.g. shows "available" rather than "not detected")
+		expect(copilotItem).toBeDefined();
+		expect(String(copilotItem?.description)).not.toContain("not detected");
+	});
+
+	it("shows independent warn rows for each Copilot form scan error and still renders integration row", async () => {
+		const bridge = {
+			cwd: "/repo",
+			getStatus: vi.fn(async () =>
+				makeStatus({
+					copilotDetected: false,
+					copilotChatDetected: true,
+					copilotEnabled: true,
+					copilotScanError: { kind: "locked", message: "db is locked" },
+					copilotChatScanError: {
+						kind: "io",
+						message: "workspace dir unreadable",
+					},
+				}),
+			),
+		};
+		loadConfigFromDir.mockResolvedValue({ apiKey: "key" });
+
+		const provider = makeStatusProvider(bridge as never);
+		await provider.refresh();
+
+		const items = provider.getChildren();
+		const cliWarn = items.find(
+			(i) =>
+				i.label === "Copilot Integration" &&
+				String(i.description).includes("locked"),
+		);
+		const chatWarn = items.find((i) => i.label === "Copilot Chat");
+		const integration = items.find(
+			(i) =>
+				i.label === "Copilot Integration" && String(i.tooltip).includes("CLI:"),
+		);
+		expect(cliWarn).toBeDefined();
+		expect(chatWarn).toBeDefined();
+		expect(String(chatWarn?.tooltip)).toContain("Copilot Chat scan failed");
+		expect(integration).toBeDefined();
+		expect(String(integration?.tooltip)).toContain("Chat: ✓");
 	});
 
 	// ── Auth-aware status rows ────────────────────────────────────────────
@@ -769,6 +855,40 @@ describe("StatusTreeProvider", () => {
 		expect(
 			items.find((item) => item.label === "Gemini Integration"),
 		).toBeUndefined();
+	});
+
+	it("getWorkerBusy reflects the underlying store's worker-busy flag", () => {
+		const provider = makeStatusProvider({
+			cwd: "/repo",
+			getStatus: vi.fn(),
+		} as never);
+
+		// Use the inner provider directly — the facade doesn't expose getWorkerBusy
+		// because legacy tests didn't need it; the production code path does.
+		const tree = new StatusTreeProvider(provider.__store);
+		expect(tree.getWorkerBusy()).toBe(false);
+		provider.__store.setWorkerBusy(true);
+		expect(tree.getWorkerBusy()).toBe(true);
+		tree.dispose();
+	});
+
+	it("dispose unsubscribes from the store and disposes the change emitter", () => {
+		const provider = makeStatusProvider({
+			cwd: "/repo",
+			getStatus: vi.fn(),
+		} as never);
+
+		// Spy on the store's onChange to confirm the unsubscribe returned by it
+		// is invoked exactly once when the provider disposes.
+		const unsubscribe = vi.fn();
+		const onChange = vi
+			.spyOn(provider.__store, "onChange")
+			.mockImplementation(() => unsubscribe);
+		const tree = new StatusTreeProvider(provider.__store);
+		expect(onChange).toHaveBeenCalledTimes(1);
+
+		tree.dispose();
+		expect(unsubscribe).toHaveBeenCalledTimes(1);
 	});
 
 	describe("StatusTreeProvider.serialize", () => {

--- a/vscode/src/providers/StatusTreeProvider.ts
+++ b/vscode/src/providers/StatusTreeProvider.ts
@@ -315,6 +315,30 @@ function buildFullStatusItems(
 		);
 	}
 
+	// Copilot CLI also has a scan-time error channel (DB can be locked/corrupt).
+	if (s.copilotScanError) {
+		items.push(
+			new StatusItem(
+				"Copilot Integration",
+				`unavailable — ${s.copilotScanError.kind}`,
+				ICON_WARN,
+				`Copilot database scan failed (${s.copilotScanError.kind}): ${s.copilotScanError.message}`,
+			),
+		);
+	} else {
+		pushIntegrationItem(
+			items,
+			s.copilotDetected,
+			s.copilotEnabled !== false,
+			undefined,
+			"Copilot Integration",
+			"Copilot CLI database found — session discovery is enabled",
+			"Copilot CLI detected but session discovery is disabled in config",
+			undefined,
+			counts.copilot,
+		);
+	}
+
 	if (extensionOutdated) {
 		items.push(
 			new StatusItem(

--- a/vscode/src/providers/StatusTreeProvider.ts
+++ b/vscode/src/providers/StatusTreeProvider.ts
@@ -315,29 +315,44 @@ function buildFullStatusItems(
 		);
 	}
 
-	// Copilot CLI also has a scan-time error channel (DB can be locked/corrupt).
+	// Copilot integration: shared `copilotEnabled` toggle for terminal CLI and VS Code Chat.
+	// Each form has its own scan-error channel; each surfaces as a separate warn row.
 	if (s.copilotScanError) {
 		items.push(
 			new StatusItem(
 				"Copilot Integration",
 				`unavailable — ${s.copilotScanError.kind}`,
 				ICON_WARN,
-				`Copilot database scan failed (${s.copilotScanError.kind}): ${s.copilotScanError.message}`,
+				`Copilot CLI database scan failed (${s.copilotScanError.kind}): ${s.copilotScanError.message}`,
 			),
 		);
-	} else {
-		pushIntegrationItem(
-			items,
-			s.copilotDetected,
-			s.copilotEnabled !== false,
-			undefined,
-			"Copilot Integration",
-			"Copilot CLI database found — session discovery is enabled",
-			"Copilot CLI detected but session discovery is disabled in config",
-			undefined,
-			counts.copilot,
+	}
+	if (s.copilotChatScanError) {
+		items.push(
+			new StatusItem(
+				"Copilot Chat",
+				`unavailable — ${s.copilotChatScanError.kind}`,
+				ICON_WARN,
+				`Copilot Chat scan failed (${s.copilotChatScanError.kind}): ${s.copilotChatScanError.message}`,
+			),
 		);
 	}
+	const cliMark = s.copilotDetected ? "✓" : "✗";
+	const chatMark = s.copilotChatDetected ? "✓" : "✗";
+	const anyCopilotDetected =
+		(s.copilotDetected ?? false) || (s.copilotChatDetected ?? false);
+	const copilotSessions = (counts.copilot ?? 0) + (counts["copilot-chat"] ?? 0);
+	pushIntegrationItem(
+		items,
+		anyCopilotDetected,
+		s.copilotEnabled !== false,
+		undefined,
+		"Copilot Integration",
+		`GitHub Copilot detected (CLI: ${cliMark}, Chat: ${chatMark}) — session discovery is enabled`,
+		`GitHub Copilot detected (CLI: ${cliMark}, Chat: ${chatMark}) but session discovery is disabled in config`,
+		undefined,
+		copilotSessions,
+	);
 
 	if (extensionOutdated) {
 		items.push(

--- a/vscode/src/views/SettingsHtmlBuilder.test.ts
+++ b/vscode/src/views/SettingsHtmlBuilder.test.ts
@@ -60,6 +60,11 @@ describe("SettingsHtmlBuilder", () => {
 		expect(html).toContain('id="cursorEnabled"');
 	});
 
+	it("includes a Copilot toggle row", () => {
+		expect(html).toContain('id="copilotEnabled"');
+		expect(html).toContain("Copilot");
+	});
+
 	it("contains Files group with exclude patterns", () => {
 		expect(html).toContain("Files");
 		expect(html).toContain('id="excludePatterns"');

--- a/vscode/src/views/SettingsHtmlBuilder.test.ts
+++ b/vscode/src/views/SettingsHtmlBuilder.test.ts
@@ -65,6 +65,11 @@ describe("SettingsHtmlBuilder", () => {
 		expect(html).toContain("Copilot");
 	});
 
+	it("Copilot toggle description mentions both CLI and Chat sources", () => {
+		expect(html).toContain("Copilot CLI");
+		expect(html).toContain("Copilot Chat");
+	});
+
 	it("contains Files group with exclude patterns", () => {
 		expect(html).toContain("Files");
 		expect(html).toContain('id="excludePatterns"');

--- a/vscode/src/views/SettingsHtmlBuilder.ts
+++ b/vscode/src/views/SettingsHtmlBuilder.ts
@@ -85,7 +85,7 @@ export function buildSettingsHtml(nonce: string): string {
       ${buildToggleRow("geminiEnabled", "Gemini CLI", "Session tracking via AfterAgent hook")}
       ${buildToggleRow("openCodeEnabled", "OpenCode", "Session discovery via ~/.local/share/opencode/opencode.db")}
       ${buildToggleRow("cursorEnabled", "Cursor", "Session discovery via Cursor's local SQLite store")}
-      ${buildToggleRow("copilotEnabled", "Copilot", "Session discovery via ~/.copilot/session-store.db")}
+      ${buildToggleRow("copilotEnabled", "Copilot", "Session discovery for GitHub Copilot CLI (~/.copilot/session-store.db) and VS Code Copilot Chat (workspace storage)")}
       <div class="error-message" id="integrations-error"></div>
     </div>
 

--- a/vscode/src/views/SettingsHtmlBuilder.ts
+++ b/vscode/src/views/SettingsHtmlBuilder.ts
@@ -85,6 +85,7 @@ export function buildSettingsHtml(nonce: string): string {
       ${buildToggleRow("geminiEnabled", "Gemini CLI", "Session tracking via AfterAgent hook")}
       ${buildToggleRow("openCodeEnabled", "OpenCode", "Session discovery via ~/.local/share/opencode/opencode.db")}
       ${buildToggleRow("cursorEnabled", "Cursor", "Session discovery via Cursor's local SQLite store")}
+      ${buildToggleRow("copilotEnabled", "Copilot", "Session discovery via ~/.copilot/session-store.db")}
       <div class="error-message" id="integrations-error"></div>
     </div>
 

--- a/vscode/src/views/SettingsScriptBuilder.test.ts
+++ b/vscode/src/views/SettingsScriptBuilder.test.ts
@@ -63,4 +63,22 @@ describe("SettingsScriptBuilder", () => {
 		expect(script).toContain("openCodeEnabled");
 		expect(script).toContain("cursorEnabled");
 	});
+
+	it("references the copilotEnabled DOM input", () => {
+		expect(script).toContain("getElementById('copilotEnabled')");
+	});
+
+	it("includes copilotEnabled in validation guard", () => {
+		expect(script).toMatch(/!copilotEnabledInput\.checked/);
+	});
+
+	it("ships copilotEnabled in save payload", () => {
+		expect(script).toContain("copilotEnabled: copilotEnabledInput.checked");
+	});
+
+	it("loads copilotEnabled from host message", () => {
+		expect(script).toContain(
+			"copilotEnabledInput.checked = msg.settings.copilotEnabled",
+		);
+	});
 });

--- a/vscode/src/views/SettingsScriptBuilder.ts
+++ b/vscode/src/views/SettingsScriptBuilder.ts
@@ -29,6 +29,7 @@ export function buildSettingsScript(): string {
   const geminiEnabledInput = document.getElementById('geminiEnabled');
   const openCodeEnabledInput = document.getElementById('openCodeEnabled');
   const cursorEnabledInput = document.getElementById('cursorEnabled');
+  const copilotEnabledInput = document.getElementById('copilotEnabled');
   const localFolderInput = document.getElementById('localFolder');
   const browseLocalFolderBtn = document.getElementById('browseLocalFolderBtn');
   const rebuildKbBtn = document.getElementById('rebuildKbBtn');
@@ -130,7 +131,7 @@ export function buildSettingsScript(): string {
     }) && valid;
     // At least one integration must be enabled
     var intError = document.getElementById('integrations-error');
-    if (!claudeEnabledInput.checked && !codexEnabledInput.checked && !geminiEnabledInput.checked && !openCodeEnabledInput.checked && !cursorEnabledInput.checked) {
+    if (!claudeEnabledInput.checked && !codexEnabledInput.checked && !geminiEnabledInput.checked && !openCodeEnabledInput.checked && !cursorEnabledInput.checked && !copilotEnabledInput.checked) {
       intError.textContent = 'At least one integration must be enabled';
       valid = false;
     } else {
@@ -164,6 +165,7 @@ export function buildSettingsScript(): string {
       geminiEnabled: geminiEnabledInput.checked,
       openCodeEnabled: openCodeEnabledInput.checked,
       cursorEnabled: cursorEnabledInput.checked,
+      copilotEnabled: copilotEnabledInput.checked,
       localFolder: localFolderInput.value,
       excludePatterns: excludePatternsInput.value,
     };
@@ -181,6 +183,7 @@ export function buildSettingsScript(): string {
       geminiEnabledInput.checked !== initialState.geminiEnabled ||
       openCodeEnabledInput.checked !== initialState.openCodeEnabled ||
       cursorEnabledInput.checked !== initialState.cursorEnabled ||
+      copilotEnabledInput.checked !== initialState.copilotEnabled ||
       localFolderInput.value !== initialState.localFolder ||
       excludePatternsInput.value !== initialState.excludePatterns
     );
@@ -205,7 +208,7 @@ export function buildSettingsScript(): string {
     input.addEventListener('input', function() { validateAll(); checkDirty(); clearSaveFeedback(); });
   });
   modelSelect.addEventListener('change', function() { checkDirty(); clearSaveFeedback(); });
-  [claudeEnabledInput, codexEnabledInput, geminiEnabledInput, openCodeEnabledInput, cursorEnabledInput].forEach(function(input) {
+  [claudeEnabledInput, codexEnabledInput, geminiEnabledInput, openCodeEnabledInput, cursorEnabledInput, copilotEnabledInput].forEach(function(input) {
     input.addEventListener('change', function() { validateAll(); checkDirty(); clearSaveFeedback(); });
   });
 
@@ -236,6 +239,7 @@ export function buildSettingsScript(): string {
         geminiEnabled: geminiEnabledInput.checked,
         openCodeEnabled: openCodeEnabledInput.checked,
         cursorEnabled: cursorEnabledInput.checked,
+        copilotEnabled: copilotEnabledInput.checked,
         localFolder: localFolderInput.value.trim(),
         excludePatterns: excludePatternsInput.value,
       },
@@ -258,6 +262,7 @@ export function buildSettingsScript(): string {
         geminiEnabledInput.checked = msg.settings.geminiEnabled;
         openCodeEnabledInput.checked = msg.settings.openCodeEnabled;
         cursorEnabledInput.checked = msg.settings.cursorEnabled;
+        copilotEnabledInput.checked = msg.settings.copilotEnabled;
         localFolderInput.value = msg.settings.localFolder || '';
         excludePatternsInput.value = msg.settings.excludePatterns;
         maskedApiKey = msg.maskedApiKey;

--- a/vscode/src/views/SettingsWebviewPanel.test.ts
+++ b/vscode/src/views/SettingsWebviewPanel.test.ts
@@ -1127,6 +1127,74 @@ describe("SettingsWebviewPanel", () => {
 			);
 		});
 
+		it("loads copilotEnabled from config (default true)", async () => {
+			// When config has copilotEnabled: false, it should be sent as false
+			const dispatch = await setupWithLoadedConfig({ copilotEnabled: false });
+			dispatch({ command: "loadSettings" });
+			await flushPromises();
+
+			expect(postMessage).toHaveBeenCalledWith(
+				expect.objectContaining({
+					command: "settingsLoaded",
+					settings: expect.objectContaining({ copilotEnabled: false }),
+				}),
+			);
+
+			// When config has no copilotEnabled, it should default to true
+			postMessage.mockClear();
+			SettingsWebviewPanel.dispose();
+			mockLoadConfigFromDir.mockResolvedValue({
+				apiKey: undefined,
+				model: "sonnet",
+				maxTokens: null,
+				jolliApiKey: undefined,
+				claudeEnabled: true,
+				codexEnabled: true,
+				geminiEnabled: true,
+				// copilotEnabled intentionally absent
+				excludePatterns: [],
+			});
+			await SettingsWebviewPanel.show(extensionUri, workspaceRoot);
+			const dispatch2 = captureMessageHandler();
+			dispatch2({ command: "loadSettings" });
+			await flushPromises();
+
+			expect(postMessage).toHaveBeenCalledWith(
+				expect.objectContaining({
+					command: "settingsLoaded",
+					settings: expect.objectContaining({ copilotEnabled: true }),
+				}),
+			);
+		});
+
+		it("persists copilotEnabled when the user submits", async () => {
+			const dispatch = await setupWithLoadedConfig({ copilotEnabled: true });
+
+			dispatch({
+				command: "applySettings",
+				maskedApiKey: "",
+				maskedJolliApiKey: "",
+				settings: {
+					apiKey: "",
+					model: "sonnet",
+					maxTokens: null,
+					jolliApiKey: "",
+					claudeEnabled: true,
+					codexEnabled: true,
+					geminiEnabled: true,
+					openCodeEnabled: true,
+					copilotEnabled: false,
+					excludePatterns: "",
+				},
+			});
+			await flushPromises();
+
+			expect(mockSaveConfigScoped).toHaveBeenCalledWith(
+				expect.objectContaining({ copilotEnabled: false }),
+				expect.any(String),
+			);
+		});
+
 		it("removes Claude and Gemini hooks when disabled", async () => {
 			const dispatch = await setupWithLoadedConfig();
 

--- a/vscode/src/views/SettingsWebviewPanel.ts
+++ b/vscode/src/views/SettingsWebviewPanel.ts
@@ -43,6 +43,7 @@ interface SettingsPayload {
 	readonly geminiEnabled: boolean;
 	readonly openCodeEnabled: boolean;
 	readonly cursorEnabled: boolean;
+	readonly copilotEnabled: boolean;
 	readonly localFolder: string;
 	readonly excludePatterns: string;
 }
@@ -252,6 +253,7 @@ export class SettingsWebviewPanel {
 			geminiEnabled: config.geminiEnabled !== false,
 			openCodeEnabled: config.openCodeEnabled !== false,
 			cursorEnabled: config.cursorEnabled !== false,
+			copilotEnabled: config.copilotEnabled !== false,
 			localFolder: config.localFolder ?? "",
 			excludePatterns: config.excludePatterns
 				? config.excludePatterns.join(", ")
@@ -328,6 +330,7 @@ export class SettingsWebviewPanel {
 			geminiEnabled: settings.geminiEnabled,
 			openCodeEnabled: settings.openCodeEnabled,
 			cursorEnabled: settings.cursorEnabled,
+			copilotEnabled: settings.copilotEnabled,
 			localFolder:
 				settings.localFolder && settings.localFolder.length > 0
 					? settings.localFolder

--- a/vscode/src/views/SummaryScriptBuilder.test.ts
+++ b/vscode/src/views/SummaryScriptBuilder.test.ts
@@ -141,4 +141,15 @@ describe("SummaryScriptBuilder", () => {
 		expect(script).toContain("source === 'cursor'");
 		expect(script).toContain("return 'Cursor'");
 	});
+
+	it("maps 'copilot' source to 'Copilot' label", () => {
+		expect(script).toContain("source === 'copilot'");
+		expect(script).toContain("return 'Copilot'");
+	});
+
+	it("appends 'cursor' and 'copilot' to sourceOrder", () => {
+		expect(script).toContain(
+			"'claude', 'codex', 'gemini', 'opencode', 'cursor', 'copilot'",
+		);
+	});
 });

--- a/vscode/src/views/SummaryScriptBuilder.test.ts
+++ b/vscode/src/views/SummaryScriptBuilder.test.ts
@@ -152,4 +152,13 @@ describe("SummaryScriptBuilder", () => {
 			"'claude', 'codex', 'gemini', 'opencode', 'cursor', 'copilot'",
 		);
 	});
+
+	it("renders 'Copilot Chat' label for copilot-chat source", () => {
+		expect(script).toContain("source === 'copilot-chat'");
+		expect(script).toContain("return 'Copilot Chat'");
+	});
+
+	it("places copilot-chat after copilot in source ordering", () => {
+		expect(script).toMatch(/'copilot',\s*'copilot-chat'/);
+	});
 });

--- a/vscode/src/views/SummaryScriptBuilder.ts
+++ b/vscode/src/views/SummaryScriptBuilder.ts
@@ -1134,6 +1134,7 @@ ${buildPrMessageScript()}
     if (source === 'opencode') return 'OpenCode';
     if (source === 'cursor') return 'Cursor';
     if (source === 'copilot') return 'Copilot';
+    if (source === 'copilot-chat') return 'Copilot Chat';
     return 'Claude';
   }
 
@@ -1559,7 +1560,7 @@ ${buildPrMessageScript()}
       if (conversationsStats) {
         var sessionCounts = msg.sessionCounts || {};
         var parts = [];
-        var sourceOrder = ['claude', 'codex', 'gemini', 'opencode', 'cursor', 'copilot'];
+        var sourceOrder = ['claude', 'codex', 'gemini', 'opencode', 'cursor', 'copilot', 'copilot-chat'];
         for (var i = 0; i < sourceOrder.length; i++) {
           var source = sourceOrder[i];
           var count = sessionCounts[source] || 0;

--- a/vscode/src/views/SummaryScriptBuilder.ts
+++ b/vscode/src/views/SummaryScriptBuilder.ts
@@ -1133,6 +1133,7 @@ ${buildPrMessageScript()}
     if (source === 'gemini') return 'Gemini';
     if (source === 'opencode') return 'OpenCode';
     if (source === 'cursor') return 'Cursor';
+    if (source === 'copilot') return 'Copilot';
     return 'Claude';
   }
 
@@ -1558,7 +1559,7 @@ ${buildPrMessageScript()}
       if (conversationsStats) {
         var sessionCounts = msg.sessionCounts || {};
         var parts = [];
-        var sourceOrder = ['claude', 'codex', 'gemini', 'opencode', 'cursor'];
+        var sourceOrder = ['claude', 'codex', 'gemini', 'opencode', 'cursor', 'copilot'];
         for (var i = 0; i < sourceOrder.length; i++) {
           var source = sourceOrder[i];
           var count = sessionCounts[source] || 0;

--- a/vscode/src/views/SummaryWebviewPanel.test.ts
+++ b/vscode/src/views/SummaryWebviewPanel.test.ts
@@ -5705,6 +5705,97 @@ describe("SummaryWebviewPanel", () => {
 			});
 		});
 
+		// ── copilotEnabled ────────────────────────────────────────────────────────
+
+		describe("loadTranscriptStats: copilotEnabled", () => {
+			it("includes copilot sessions when copilotEnabled !== false", async () => {
+				mockLoadConfig.mockResolvedValue({
+					claudeEnabled: true,
+					copilotEnabled: true,
+				});
+				mockGetTranscriptHashes.mockResolvedValue(new Set(["abc123"]));
+				const transcriptMap = new Map([
+					[
+						"abc123",
+						{
+							sessions: [
+								{
+									sessionId: "cp1",
+									source: "copilot" as const,
+									entries: [
+										{ role: "human" as const, content: "X" },
+										{ role: "assistant" as const, content: "Y" },
+									],
+								},
+							],
+						},
+					],
+				]);
+				mockReadTranscriptsForCommits.mockResolvedValue(transcriptMap);
+
+				const summary = makeSummary();
+				await SummaryWebviewPanel.show(summary, extensionUri, workspaceRoot);
+				const dispatch = captureMessageHandler();
+
+				dispatch({ command: "loadTranscriptStats" });
+				await flushPromises();
+
+				expect(postMessage).toHaveBeenCalledWith(
+					expect.objectContaining({
+						command: "transcriptStatsLoaded",
+						sessionCounts: expect.objectContaining({ copilot: 1 }),
+					}),
+				);
+			});
+
+			it("excludes copilot sessions when copilotEnabled === false", async () => {
+				mockLoadConfig.mockResolvedValue({
+					claudeEnabled: true,
+					copilotEnabled: false,
+				});
+				mockGetTranscriptHashes.mockResolvedValue(new Set(["abc123"]));
+				const transcriptMap = new Map([
+					[
+						"abc123",
+						{
+							sessions: [
+								{
+									sessionId: "s1",
+									source: "claude" as const,
+									entries: [{ role: "human" as const, content: "A" }],
+								},
+								{
+									sessionId: "cp1",
+									source: "copilot" as const,
+									entries: [
+										{ role: "human" as const, content: "B" },
+										{ role: "assistant" as const, content: "C" },
+									],
+								},
+							],
+						},
+					],
+				]);
+				mockReadTranscriptsForCommits.mockResolvedValue(transcriptMap);
+
+				const summary = makeSummary();
+				await SummaryWebviewPanel.show(summary, extensionUri, workspaceRoot);
+				const dispatch = captureMessageHandler();
+
+				dispatch({ command: "loadTranscriptStats" });
+				await flushPromises();
+
+				// copilot session (cp1) should be excluded; only claude session counted
+				expect(postMessage).toHaveBeenCalledWith(
+					expect.objectContaining({
+						command: "transcriptStatsLoaded",
+						totalEntries: 1,
+						sessionCounts: expect.objectContaining({ claude: 1 }),
+					}),
+				);
+			});
+		});
+
 		// ── loadNoteContent: snippet without inline content ───────────────────────
 
 		describe("loadNoteContent: snippet without inline content", () => {

--- a/vscode/src/views/SummaryWebviewPanel.test.ts
+++ b/vscode/src/views/SummaryWebviewPanel.test.ts
@@ -5794,6 +5794,97 @@ describe("SummaryWebviewPanel", () => {
 					}),
 				);
 			});
+
+			it("includes copilot-chat in enabled sources when copilotEnabled is true", async () => {
+				mockLoadConfig.mockResolvedValue({
+					claudeEnabled: true,
+					copilotEnabled: true,
+				});
+				mockGetTranscriptHashes.mockResolvedValue(new Set(["abc123"]));
+				const transcriptMap = new Map([
+					[
+						"abc123",
+						{
+							sessions: [
+								{
+									sessionId: "cc1",
+									source: "copilot-chat" as const,
+									entries: [
+										{ role: "human" as const, content: "X" },
+										{ role: "assistant" as const, content: "Y" },
+									],
+								},
+							],
+						},
+					],
+				]);
+				mockReadTranscriptsForCommits.mockResolvedValue(transcriptMap);
+
+				const summary = makeSummary();
+				await SummaryWebviewPanel.show(summary, extensionUri, workspaceRoot);
+				const dispatch = captureMessageHandler();
+
+				dispatch({ command: "loadTranscriptStats" });
+				await flushPromises();
+
+				expect(postMessage).toHaveBeenCalledWith(
+					expect.objectContaining({
+						command: "transcriptStatsLoaded",
+						sessionCounts: expect.objectContaining({ "copilot-chat": 1 }),
+					}),
+				);
+			});
+
+			it("excludes copilot-chat when copilotEnabled is false", async () => {
+				mockLoadConfig.mockResolvedValue({
+					claudeEnabled: true,
+					copilotEnabled: false,
+				});
+				mockGetTranscriptHashes.mockResolvedValue(new Set(["abc123"]));
+				const transcriptMap = new Map([
+					[
+						"abc123",
+						{
+							sessions: [
+								{
+									sessionId: "s1",
+									source: "claude" as const,
+									entries: [{ role: "human" as const, content: "A" }],
+								},
+								{
+									sessionId: "cc1",
+									source: "copilot-chat" as const,
+									entries: [
+										{ role: "human" as const, content: "B" },
+										{ role: "assistant" as const, content: "C" },
+									],
+								},
+							],
+						},
+					],
+				]);
+				mockReadTranscriptsForCommits.mockResolvedValue(transcriptMap);
+
+				const summary = makeSummary();
+				await SummaryWebviewPanel.show(summary, extensionUri, workspaceRoot);
+				const dispatch = captureMessageHandler();
+
+				dispatch({ command: "loadTranscriptStats" });
+				await flushPromises();
+
+				// copilot-chat session (cc1) should be excluded; only claude session counted
+				expect(postMessage).toHaveBeenCalledWith(
+					expect.objectContaining({
+						command: "transcriptStatsLoaded",
+						totalEntries: 1,
+						sessionCounts: expect.objectContaining({ claude: 1 }),
+					}),
+				);
+				const lastCall = postMessage.mock.calls[
+					postMessage.mock.calls.length - 1
+				]?.[0] as { sessionCounts?: Record<string, number> } | undefined;
+				expect(lastCall?.sessionCounts).not.toHaveProperty("copilot-chat");
+			});
 		});
 
 		// ── loadNoteContent: snippet without inline content ───────────────────────

--- a/vscode/src/views/SummaryWebviewPanel.ts
+++ b/vscode/src/views/SummaryWebviewPanel.ts
@@ -2100,6 +2100,7 @@ export class SummaryWebviewPanel {
 		}
 		if (config.copilotEnabled !== false) {
 			sources.add("copilot");
+			sources.add("copilot-chat");
 		}
 		return sources;
 	}

--- a/vscode/src/views/SummaryWebviewPanel.ts
+++ b/vscode/src/views/SummaryWebviewPanel.ts
@@ -2098,6 +2098,9 @@ export class SummaryWebviewPanel {
 		if (config.cursorEnabled !== false) {
 			sources.add("cursor");
 		}
+		if (config.copilotEnabled !== false) {
+			sources.add("copilot");
+		}
 		return sources;
 	}
 


### PR DESCRIPTION
<!-- jollimemory-summary-start -->
## Commits in this PR (2)

1. Add GitHub Copilot CLI as a transcript source (`b7d3971`) 
2. Add VS Code Copilot Chat as a transcript source (`1de42e7`)

## Plans & Notes (6)

- GitHub Copilot CLI Support — Implementation Plan
- GitHub Copilot CLI as a Transcript Source — Design
- VS Code Copilot Chat as a Transcript Source — Design
- VS Code Copilot Chat Redesign — Read `events.jsonl`, Not OpenTelemetry Traces
- VS Code Copilot Chat Support Implementation Plan
- Copilot Chat events.jsonl Redesign — Implementation Plan

## Quick recap (2)

### Commit 1 of 2: Add GitHub Copilot CLI as a transcript source (`b7d3971`)

The developer added GitHub Copilot CLI as a new transcript source, enabling Jolli Memory to automatically capture and summarize AI-assisted development work from the Copilot command-line interface. Copilot stores conversations in a local SQLite database at ~/.copilot/session-store.db; the integration discovers sessions matching the current project directory and extracts conversation turns, then feeds them into the post-commit pipeline alongside transcripts from other AI agents like OpenCode and Codex. Users can enable or disable Copilot session discovery via the configure command, and the status command displays session counts and any database scan errors. The VS Code extension surfaces Copilot in its status tree, summary details view, and settings panel, bringing it to feature parity with other supported integrations.

To support multiple database-backed sources without duplication, the developer extracted shared SQLite helpers into a dedicated module that provides database access primitives, error classification, and version checking. This module is now used by both OpenCode and Copilot CLI, with the planned Cursor integration adopting the same pattern. The extraction uses lazy imports to avoid emitting Node's ExperimentalWarning during unrelated operations, and maintains backward compatibility through deprecated re-exports in the OpenCode module.

Error handling was aligned across all SQLite-backed sources in the post-commit pipeline. Previously, Copilot failures were isolated to individual sessions while OpenCode and Cursor failures could abandon entire batches. Now all three sources use per-session error isolation, preventing a single corrupted or locked database from preventing the rest of the batch from being summarized. This improves resilience in production environments where transient database locks are common. The implementation includes proper error classification for corrupted or locked databases, defensive handling of schema drift, and comprehensive test coverage matching the OpenCode pattern. Cross-platform path handling was fixed to ensure tests pass on Windows, macOS, and Linux by normalizing fixture paths using the same platform-aware functions as the production code. All changes maintain architectural symmetry with the existing OpenCode integration, reducing cognitive load for future maintainers. The system automatically enables Copilot support during installation when it detects the tool is present, and users can enable or disable it via the configure command. Developers who work primarily in the terminal now have their AI-assisted work automatically tracked and summarized alongside their git commits, without requiring manual export or tool switching.

### Commit 2 of 2: Add VS Code Copilot Chat as a transcript source (`1de42e7`)

The developer added VS Code Copilot Chat as a new transcript source, enabling the system to capture conversations from the Chat extension alongside the existing Copilot CLI integration. Both forms now share a single `copilotEnabled` configuration toggle and are discovered, read, and displayed together in the UI, reflecting how users perceive GitHub Copilot as a unified product.

The implementation spans four core modules: a shared workspace locator for finding VS Code storage directories (also refactored into the Cursor integration to eliminate duplication), a detector that probes both the VS Code extension's global storage and the Copilot CLI agent's `~/.copilot/session-state` directory, a session discoverer with a two-scan architecture supporting both storage locations, and a transcript reader with format-specific sub-readers for patch-log and event-stream formats. The reader uses semantic-level cursors based on request indices and line counts rather than byte offsets, making it robust against variable line lengths and streaming token accumulation. All new code achieved 100% test coverage.

The Copilot Chat integration is wired into the existing discovery and processing pipelines: the installer auto-enables the shared `copilotEnabled` flag when either CLI or Chat is detected, the queue worker discovers and reads chat sessions alongside other AI assistant sessions with time-bounded filtering support, and status reporting components display detection status for both forms separately. Users can see at a glance which Copilot variants are available through sub-line breakdowns in the status command and status tree, and chat sessions appear in the Summary panel with the same configuration control as the base Copilot source.

## E2E Test (10)
<details>
<summary><strong>1. [b7d3971] GitHub Copilot CLI integration appears in status command</strong></summary>
<br>
<blockquote>

**Steps:**
1. Open a terminal and run `jolli status`
2. Look for a "Copilot:" row in the integration breakdown section
3. If Copilot CLI is installed on your system, verify the row shows a session count (e.g., "3 sessions")
4. If Copilot CLI is not installed, verify the Copilot row does not appear at all
5. If Copilot is installed but you have disabled it in config, verify the row shows "detected but disabled"

**Expected Results:**
- When Copilot is installed and enabled: the status output includes a "Copilot:" row with the number of discovered sessions
- When Copilot is not installed: no Copilot row appears in the output
- When Copilot is detected but disabled: the row appears with a "detected but disabled" message

</blockquote>
</details>
<details>
<summary><strong>2. [b7d3971] Copilot CLI sessions are discovered and included in commit summaries</strong></summary>
<br>
<blockquote>

**Preconditions:** Have GitHub Copilot CLI installed and have used it to have a conversation in the current project directory within the last 48 hours

**Steps:**
1. Open a terminal in your project directory
2. Run `jolli status` and confirm the Copilot row shows at least 1 session
3. Make a small change to a file and commit it with `git commit -m "test"`
4. Wait for the post-commit hook to complete (check the git output for any messages)
5. Run `jolli status` again and verify the session count has been processed

**Expected Results:**
- The Copilot row in the status output shows the number of recent sessions from your project
- The commit hook completes without errors
- Sessions older than 48 hours are not included in the count

</blockquote>
</details>
<details>
<summary><strong>3. [b7d3971] Copilot CLI is auto-detected and enabled on first install</strong></summary>
<br>
<blockquote>

**Preconditions:** Have GitHub Copilot CLI installed on your system

**Steps:**
1. Run `jolli configure --list-keys` and look for "copilotEnabled" in the output
2. Run `jolli configure --set copilotEnabled=true` to explicitly enable it
3. Run `jolli status` and verify the Copilot row appears
4. Run `jolli configure --set copilotEnabled=false` to disable it
5. Run `jolli status` again and verify the Copilot row shows "detected but disabled"

**Expected Results:**
- The "copilotEnabled" key appears in the configure command's list of valid keys
- You can set copilotEnabled to true or false
- The status command reflects your configuration choice immediately

</blockquote>
</details>
<details>
<summary><strong>4. [b7d3971] Copilot database errors are reported without breaking the commit hook</strong></summary>
<br>
<blockquote>

**Preconditions:** Have GitHub Copilot CLI installed with at least one session in the current project

**Steps:**
1. Run `jolli status` and note the current Copilot session count
2. Make a small file change and commit it with `git commit -m "test"`
3. Wait for the post-commit hook to complete
4. Run `jolli status` again

**Expected Results:**
- If the Copilot database is inaccessible (locked, corrupted, or permission denied), the status output shows "unavailable" next to the Copilot row with an error description
- The commit hook completes successfully even if Copilot data cannot be read
- Other integrations (Claude, OpenCode, Cursor) continue to work normally

</blockquote>
</details>
<details>
<summary><strong>5. [b7d3971] Old Copilot sessions are filtered out automatically</strong></summary>
<br>
<blockquote>

**Preconditions:** Have GitHub Copilot CLI installed

**Steps:**
1. Run `jolli status` and note the Copilot session count
2. Verify that only sessions from the last 48 hours are included (you can check the timestamps in your Copilot CLI history if available)
3. If you have sessions older than 48 hours, they should not appear in the count

**Expected Results:**
- Sessions created more than 48 hours ago do not appear in the Copilot session count
- Only recent sessions (within the last 48 hours) are discovered and included in commit summaries
- This prevents pulling months of historical conversations when Copilot is first enabled

</blockquote>
</details>
<details>
<summary><strong>6. [1de42e7] Copilot Chat sessions appear in status report alongside Copilot CLI</strong></summary>
<br>
<blockquote>

**Preconditions:** Have VS Code installed with the Copilot Chat extension enabled, or have the Copilot CLI agent backend installed at ~/.copilot/session-state with at least one chat session file.

**Steps:**
1. Open a terminal and run the status command to view the current integration status
2. Look for the "Copilot:" row in the output
3. Check that the row shows a breakdown line below it displaying "CLI: ✓" or "✗" and "Chat: ✓" or "✗" to indicate which Copilot variants are detected
4. Verify that the session count on the Copilot row includes sessions from both CLI and Chat sources combined
5. If Copilot Chat is detected but the chat scan failed, verify that an additional indented line appears below the CLI/Chat breakdown showing "Chat scan failed" with the error type and message

**Expected Results:**
- The Copilot row should show as detected if either CLI or Chat (or both) are present
- The CLI/Chat breakdown should clearly show which variant(s) are available with checkmarks or X marks
- Session counts should reflect the total from both sources
- Any chat-specific scan errors should appear as a separate sub-line, not mixed with the main Copilot row

</blockquote>
</details>
<details>
<summary><strong>7. [1de42e7] Copilot Chat sessions are discovered and included in commit context</strong></summary>
<br>
<blockquote>

**Preconditions:** Have VS Code with Copilot Chat extension installed and at least one active chat session in the current project, or have ~/.copilot/session-state with chat session files matching the current project folder.

**Steps:**
1. Open the application and navigate to a project that has Copilot Chat sessions
2. Trigger a commit or build operation that would normally scan for AI assistant sessions
3. Check the summary or session list to verify that Copilot Chat sessions appear alongside other AI assistant sessions (Claude, Copilot CLI, etc.)
4. Click on or inspect a Copilot Chat session to confirm its transcript can be read and displayed

**Expected Results:**
- Copilot Chat sessions should appear in the session list with source labeled as "Copilot Chat"
- Sessions should be ordered consistently (Copilot Chat should appear immediately after Copilot CLI in any sorted lists)
- Transcripts from Copilot Chat should be readable and display conversation history

</blockquote>
</details>
<details>
<summary><strong>8. [1de42e7] Copilot Chat is auto-enabled when detected during setup</strong></summary>
<br>
<blockquote>

**Preconditions:** Have VS Code with Copilot Chat extension installed (or Copilot CLI backend at ~/.copilot/session-state), and the Copilot feature toggle is not yet configured in settings.

**Steps:**
1. Run the installer or initialization process
2. Allow it to auto-detect installed integrations
3. Check the configuration settings to verify that the Copilot feature toggle is now enabled
4. Open the status report and confirm that Copilot Chat is listed as detected

**Expected Results:**
- The Copilot feature should be automatically enabled if either Copilot CLI or Copilot Chat is detected
- The installer log should indicate which Copilot variant(s) were found
- The status report should show Copilot as enabled with the appropriate CLI/Chat breakdown

</blockquote>
</details>
<details>
<summary><strong>9. [1de42e7] Copilot Chat detection status appears in the status tree view</strong></summary>
<br>
<blockquote>

**Preconditions:** Have VS Code with Copilot Chat extension installed, or Copilot CLI backend at ~/.copilot/session-state.

**Steps:**
1. Open the application and navigate to the status or integrations tree view
2. Look for the Copilot integration row
3. Check the tooltip or description text for inline indicators showing CLI and Chat detection status separately
4. If only Chat is detected (no CLI), verify the row still shows as detected and displays "Chat: ✓"
5. If a chat scan error occurred, verify it appears as a separate warning row labeled "Copilot Chat scan failed" (distinct from any CLI scan error)

**Expected Results:**
- The Copilot integration row should show detection status for both CLI and Chat forms
- Each form should have a visible indicator (✓ or ✗) in the tooltip or description
- Chat-specific errors should surface as a separate warning row, not combined with CLI errors
- The integration is treated as detected if either form is present

</blockquote>
</details>
<details>
<summary><strong>10. [1de42e7] Summary panel displays Copilot Chat sessions with correct labeling</strong></summary>
<br>
<blockquote>

**Preconditions:** Have Copilot Chat sessions discovered in the current project (see Scenario 2 preconditions).

**Steps:**
1. Open the Summary panel or session statistics view
2. Look for the source breakdown showing counts by AI assistant type
3. Verify that "Copilot Chat" appears as a distinct label in the source list
4. Check that Copilot Chat sessions are ordered immediately after Copilot CLI sessions in any sorted displays
5. Confirm that the Copilot Chat source is included in the enabled sources filter when the Copilot feature is enabled

**Expected Results:**
- "Copilot Chat" should appear as a labeled source in the summary
- Session counts should correctly attribute sessions to the Copilot Chat source
- Ordering should be consistent with other AI assistant sources
- Toggling the Copilot feature off should exclude both Copilot CLI and Copilot Chat sessions from the summary

</blockquote>
</details>

## Topics (25)
<details>
<summary><strong>01 · [b7d3971] Add GitHub Copilot CLI as a transcript source with full integration</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The system supported multiple AI coding agents but not GitHub Copilot CLI. Copilot stores conversations in a local SQLite database and needed to be integrated as a new source for session discovery and transcript reading.

**💡 Decisions Behind the Code**

- **Node SQLite requirement over pure-JavaScript libraries**: Copilot's database uses write-ahead logging (WAL) mode, which only Node's built-in node:sqlite module can read. Requiring Node 22.6+ ensures correctness and avoids silent data loss, with graceful degradation on older versions.
- **Synthetic transcript path format (dbPath#sessionId)**: Copilot stores all sessions in a single database, unlike OpenCode which uses separate files. Encoding both the database location and session ID in the path allows the reader to locate the correct session without additional metadata, keeping the discovery and reading interfaces consistent.
- **Case-insensitive path matching on macOS and Windows**: Copilot stores the working directory as-is, but filesystems on macOS and Windows are case-insensitive. Matching with case-insensitive comparison ensures sessions are discovered even when users invoke the tool with different path casing, improving reliability without filesystem queries.
- **Post-filter staleness in JavaScript rather than SQL**: The updated_at column is TEXT (ISO format), so SQL comparison would be lexicographic rather than temporal. Filtering after Date.parse tolerates any format that JavaScript's date parser accepts and reuses the existing schema-drift tolerance pattern already in the codebase.
- **Error visibility over silent degradation**: The discovery wrapper logs scan errors even though the pipeline continues without sessions. This surfaces real problems (permission issues, database corruption) to operators rather than silently excluding data.

**✅ What Was Implemented**

- Created three core modules (CopilotDetector, CopilotSessionDiscoverer, CopilotTranscriptReader) that detect Copilot installation, discover sessions matching the current project directory, and extract conversation turns from the SQLite database at ~/.copilot/session-store.db. The detector verifies Node 22.6+ support for reading write-ahead-logged databases.
- Extended the type system to include "copilot" in the TranscriptSource union and added configuration fields (copilotEnabled, copilotDetected) and status fields (copilotScanError) to track Copilot state and report database scan failures.
- Integrated Copilot discovery into the post-commit pipeline (QueueWorker.ts) with per-session error isolation, allowing the pipeline to discover and read Copilot sessions alongside Codex and OpenCode without cascading failures.
- Added a 48-hour staleness filter to exclude sessions older than 48 hours, preventing users enabling Copilot for the first time from pulling months of historical sessions into their next commit summary. The filter is applied in JavaScript after timestamp parsing rather than in SQL, since the database stores timestamps as ISO text.
- Added auto-detection during installation: when Copilot is found and the user has not explicitly set a preference, the system enables Copilot support and logs the detection.
- Surfaced Copilot in the CLI status and configure commands, and added toggles in the VS Code extension's status tree, summary details view, and settings panel, bringing Copilot to feature parity with other supported integrations.

**📁 FILES**
- `cli/src/Types.ts`
- `cli/src/core/CopilotDetector.ts`
- `cli/src/core/CopilotSessionDiscoverer.ts`
- `cli/src/core/CopilotTranscriptReader.ts`
- `cli/src/hooks/QueueWorker.ts`

</blockquote>
</details>
<details>
<summary><strong>02 · [b7d3971] Extract shared SQLite helpers for multi-agent database access</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The codebase needed to support reading SQLite databases from multiple external AI agents. Rather than duplicating database access logic across multiple discoverer modules, common SQLite utilities needed to be extracted into a reusable helper module.

**💡 Decisions Behind the Code**

- **Lazy module imports preserve startup performance**: The withSqliteDb function dynamically imports node:sqlite only when invoked, not when the module is transitively loaded. This prevents the ExperimentalWarning from appearing in unrelated code paths while keeping the module safely importable by any code without side effects.
- **Structural typing over direct type imports**: The SqliteDbHandle interface is hand-written to match node:sqlite's DatabaseSync shape rather than importing the actual type. This keeps the module loadable in all Node versions without triggering the ExperimentalWarning at import time, with the trade-off of manual maintenance of the interface shape.
- **Backward compatibility through re-exports**: The old OpenCodeSessionDiscoverer module re-exports the new helpers under deprecated names, allowing existing callers to continue working without changes. This staged migration approach lets the codebase transition gradually and avoids breaking changes when Cursor's PR is rebased.
- **Single source of truth for error types**: Importing SqliteScanError ensures that if the error kind union is extended in the future, all locations automatically stay in sync. The alternative—maintaining separate copies—would require manual updates and create silent divergence risk.

**✅ What Was Implemented**

- Created SqliteHelpers.ts containing database access primitives: withSqliteDb() function for opening and closing read-only SQLite connections, SqliteDbHandle interface for structural typing, and version-checking utilities (hasNodeSqliteSupport, NODE_SQLITE_MIN_VERSION). These utilities use lazy imports to avoid emitting Node's ExperimentalWarning during unrelated operations.
- Moved error classification logic into classifyScanError() function, which categorizes database failures (corrupt, locked, permission, schema, unknown) while treating missing files as silent.
- Updated OpenCodeSessionDiscoverer.ts to import from the new helpers module and re-export deprecated aliases to maintain backward compatibility. Updated OpenCodeTranscriptReader.ts to use the new withSqliteDb import directly.
- Replaced inlined error type shapes in StatusInfo with direct imports of SqliteScanError from SqliteHelpers.ts, eliminating structural duplication across three locations.

**📁 FILES**
- `cli/src/core/SqliteHelpers.ts`
- `cli/src/core/OpenCodeSessionDiscoverer.ts`
- `cli/src/Types.ts`

</blockquote>
</details>
<details>
<summary><strong>03 · [b7d3971] Align error handling for SQLite-backed transcript sources in post-commit pipeline</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Asymmetric error handling between OpenCode and Copilot transcript readers: Copilot failures were wrapped in try/catch to skip individual sessions, but OpenCode and Cursor failures could abandon entire batches, causing one corrupted or locked database to prevent the rest of the batch from being summarized.

**💡 Decisions Behind the Code**

Per-session isolation is the safer default for any SQLite-backed source: a single corrupted or transiently locked database should never prevent the rest of the batch from being summarized. This principle was already applied to Copilot in the original implementation; extending it uniformly to OpenCode and Cursor eliminates a subtle inconsistency that would only surface in production when a user hit a locked database. JSONL sources are excluded from this change because they handle per-line failures internally and have different error semantics.

**✅ What Was Implemented**

- Wrapped readOpenCodeTranscript() in try/catch with per-session error logging and continue, matching the isolation pattern already applied to Copilot.
- Wrapped readCursorTranscript() in the same try/catch pattern for consistency, since Cursor also uses SQLite and shares identical failure modes (lock, corruption, schema drift, TOCTOU disappearance).
- Wrapped readCopilotTranscript() in try/catch to prevent pipeline crashes if the session database becomes inaccessible during the read phase, matching the resilience pattern already in place for other transcript sources.
- Added a clarifying comment explaining that all three SQLite-backed sources (OpenCode, Cursor, Copilot) share the same failure modes and should all use per-session isolation, while JSONL readers (Gemini, Claude) handle failures internally.

**📁 FILES**
- `cli/src/hooks/QueueWorker.ts`

</blockquote>
</details>
<details>
<summary><strong>04 · [b7d3971] Comprehensive test coverage for Copilot discovery, reading, and integration</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The initial test suite had gaps in edge case coverage and asymmetries with the parallel OpenCode test patterns, creating maintenance risk and potential for silent regressions in error paths.

**💡 Decisions Behind the Code**

- **Parity with OpenCode test patterns**: Rather than inventing new test structures, the Copilot tests now mirror the exact same edge cases and combinations already proven in OpenCode. This reduces cognitive load for future maintainers and ensures both integrations have equivalent regression protection.
- **Spy-based mocking over module mocking**: The spy-based approach is more reliable than module mocking for testing Node version checks because it directly targets the runtime condition being tested (Node version) without requiring module cache manipulation. Module mocking introduces timing and isolation risks that are unnecessary when the actual condition can be mocked at a lower level.
- **Mocks in test infrastructure over production code changes**: Mocks were added as a targeted fix to the test infrastructure rather than modifying the production code. This approach isolates the test environment from external dependencies and I/O operations, allowing the test suite to run reliably without network or filesystem access.
- **Platform-aware path normalization in fixtures**: Both sides of the test contract must use the same normalization: path.resolve() is platform-dependent (returns /p on POSIX but <currentDrive>:\p on Windows). Since the production code calls resolve() to normalize paths before SQL matching, test fixtures must also call resolve() on the same input strings so both sides produce identical normalized values. Using a single platformPath helper makes the intent explicit and centralizes the normalization logic.
- **Time-relative test fixtures**: Hardcoded ISO timestamps in test seeds would silently cross the 48-hour staleness threshold once the test suite is more than 2 days old, causing tests to fail without any code change. Using Date.now() relative offsets keeps fixtures fresh indefinitely and matches the pattern already established in OpenCode tests.

**✅ What Was Implemented**

- Added missing edge case tests for parseSyntheticPath in CopilotTranscriptReader.test.ts to cover empty dbPath and empty sessionId branches, ensuring both error conditions are explicitly verified.
- Added combined cursor and beforeTimestamp test in CopilotTranscriptReader.test.ts to verify the two-phase filtering pattern (resume from cursor, then apply timestamp cutoff) works correctly in sequence, matching the equivalent test in OpenCodeTranscriptReader.test.ts.
- Added Linux platform-specific test in CopilotSessionDiscoverer.test.ts to verify case-sensitive matching behavior, confirming the exact-match SQL path is active on Linux rather than relying on darwin test coverage alone.
- Added test case to verify sessions are returned in descending order by updated_at timestamp when multiple sessions exist.
- Added test coverage for the status command when Copilot is not detected, verifying the Copilot integration row is not rendered when the copilotDetected field is undefined.
- Added test case verifying that when Copilot is detected but disabled (copilotEnabled is false), the status row renders with a "detected but disabled" message.
- Added branch coverage tests for error paths: permission-denied errors and unknown error codes in CopilotDetector.ts, database open failures and NULL timestamp handling in CopilotTranscriptReader.ts, and error handling when reading a Copilot transcript fails in QueueWorker.ts.
- Fixed a test isolation bug in CopilotSessionDiscoverer.test.ts where vi.restoreAllMocks() did not unwind mockRejectedValue calls applied inside module mock factories, causing stat rejection to leak between tests. The fix explicitly resets the stat mock in beforeEach.
- Added mock implementations for three Copilot modules in PostCommitHook.test.ts to prevent timeout failures caused by unmocked Copilot-related modules making real I/O calls during test execution.
- Fixed cross-platform path handling in Copilot detector and session discoverer tests: modified CopilotDetector.test.ts to compute the expected path using path.join() instead of hardcoded strings, and added a platformPath helper function in CopilotSessionDiscoverer.test.ts that wraps path.resolve() to normalize all fixture cwd values and test input paths to the same platform-specific format. Replaced hardcoded /tmp/does-not-exist with join(tmpdir(), "copilot-disc-missing", "x.db") to use the system temporary directory, making the "DB missing" test portable across Windows, macOS, and Linux.
- Refactored test fixtures in CopilotSessionDiscoverer.test.ts to use a time-relative helper (isoFromNow) instead of hardcoded ISO timestamps, preventing tests from silently failing once they cross the 48-hour boundary. Added a new test case that verifies sessions older than 49 hours are filtered while fresh sessions are retained.

**📁 FILES**
- `cli/src/core/CopilotTranscriptReader.test.ts`
- `cli/src/core/CopilotSessionDiscoverer.test.ts`
- `cli/src/core/CopilotDetector.test.ts`

</blockquote>
</details>
<details>
<summary><strong>05 · [b7d3971] Auto-detect Copilot CLI on install and surface detection status</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The installer needed to automatically discover when GitHub Copilot CLI is present on the user's system and enable session discovery for it, similar to how it already handles other AI tools like Claude and OpenCode.

**💡 Decisions Behind the Code**

- **Respect explicit user configuration**: When copilotEnabled is already set (either true or false), the auto-detection does not override it. This preserves user intent and prevents unwanted re-enablement if a user has deliberately disabled Copilot support.
- **Lazy session discovery on status check**: Copilot sessions are scanned on-demand during getStatus() rather than stored persistently in sessions.json like other sources. This mirrors the existing pattern for OpenCode and avoids coupling the session store to Copilot's database format.
- **Surface scan errors transparently**: When Copilot session scanning fails (e.g., database locked), the error is captured and returned in the status object rather than silently swallowed. This allows the CLI to report integration issues to the user without crashing the status command.

**✅ What Was Implemented**

- Added Copilot detection logic to the install flow in Installer.ts: when installation runs, it checks if Copilot is installed via isCopilotInstalled(), and if the copilotEnabled config is undefined, it automatically enables Copilot session discovery and logs the detection.
- Extended the status reporting in getStatus() to include Copilot detection and enablement state: the function now calls scanCopilotSessions() when Copilot is detected and enabled, collects any scan errors, and surfaces copilotDetected, copilotEnabled, and copilotScanError fields in the returned status object.
- Updated test mocks and test cases in Installer.test.ts to cover Copilot detection: added mocks for CopilotDetector and CopilotSessionDiscoverer, and added test cases verifying auto-enable behavior, config preservation, and error surfacing in status.

**📁 FILES**
- `cli/src/install/Installer.ts`

</blockquote>
</details>
<details>
<summary><strong>06 · [b7d3971] Design specification and implementation plan for Copilot CLI integration</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Before implementing Copilot CLI support, the team needed to document the design, verify the actual on-disk format and runtime behavior of Copilot's data store, and establish clear scope boundaries to prevent future scope creep.

**💡 Decisions Behind the Code**

- **Exact cwd matching over time-window heuristics**: Copilot stores the working directory directly on each session row, making workspace attribution precise. The design chose simple path normalization without symlink chasing, avoiding the complexity Cursor needed while still handling trailing-slash edge cases.
- **Read-only database access**: The spec mandates read-only SQLite handles to avoid collision with Copilot's own writer process and the inuse.<pid>.lock semantics, eliminating a class of potential data corruption bugs.
- **Reuse existing SqliteHelpers abstraction**: Rather than introducing a new SQLite wrapper or dependency, the design imports the SqliteHelpers module extracted during the Cursor work, keeping the dependency graph flat and ensuring consistent error classification across all SQLite-backed sources.

**✅ What Was Implemented**

- Created a comprehensive design specification document that details the integration architecture, observed database schema, and implementation roadmap. The spec includes hands-on verification results from testing against a live Copilot CLI process, confirming that the SQLite database with WAL mode is readable via the existing node:sqlite library.
- Established the integration as discovery-based (scanning ~/.copilot/session-store.db for sessions matching the current working directory) rather than hook-based, since Copilot CLI exposes no hook surface. The design reuses the existing Cursor integration template across five layers: type definitions, session discovery, transcript reading, CLI commands, and VSCode UI panels.
- Documented three new core modules with their responsibilities, plus the specific changes needed in SessionTracker, QueueWorker, Installer, and six VSCode panel files. Included an explicit "Intentionally not done" section listing out-of-scope decisions (no use of checkpoint metadata, no Windows CI testing, no hook integration) to prevent future scope creep.
- Created a 1842-line implementation plan document specifying the complete integration strategy, including architecture decisions, file structure, nine implementation phases with explicit commit ordering, and detailed task checklists with test fixtures and expected outcomes.
- Expanded documentation to explain why Copilot checkpoints are excluded: they are user-triggered conversation-compression nodes cut on context-window boundaries rather than git-commit boundaries, making them unsuitable as the primary transcript source. Checkpoints are optional and their schema is more volatile than the stable turns table.

**📁 FILES**
- `docs/superpowers/specs/2026-05-05-copilot-cli-support-design.md`
- `docs/superpowers/plans/2026-05-05-copilot-cli-support.md`

</blockquote>
</details>
<details>
<summary><strong>07 · [b7d3971] Fix error handling and improve code documentation</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Code review identified that scan error types were duplicated across three locations in the type definitions, error handling in the detector was silently swallowing non-ENOENT stat failures that should be logged, and configuration help text and code comments needed refinement to accurately reflect runtime behavior.

**💡 Decisions Behind the Code**

Clearer documentation prevents misunderstanding: improved documentation of the scope and intent of shared utilities, and clarified why defensive code branches exist, reducing confusion about coverage exclusion and integration errors.

**✅ What Was Implemented**

- Fixed error handling in CopilotDetector.isCopilotInstalled() to log non-ENOENT stat failures at warn level, preventing silent loss of permission or I/O errors.
- Added a debug log statement in QueueWorker.ts when Copilot sessions are skipped, indicating the session ID and the reason. This provides visibility into the skip path without changing behavior.
- Updated the copilotEnabled configuration key description in ConfigureCommand.ts to clarify that the Node 22.5+ requirement applies at runtime, not at configuration time.
- Updated the scanError field comment in StatusCommand.ts to reflect that the field is used by both OpenCode and Copilot integrations.
- Updated the module docstring in SqliteHelpers.ts to clarify that the helpers are currently used by OpenCode and Copilot CLI, and that the planned Cursor integration will adopt the same pattern.
- Improved an inline comment on the regex validation in hasNodeSqliteSupport() to explicitly state that the branch is unreachable in practice.
- Updated the design specification document to clarify that CopilotDetector exports two separate functions (isCopilotInstalled and getCopilotDbPath) rather than an aggregate return shape.
- Rewrote CopilotTranscriptReader.ts header comment to clarify that cursor tracks row count (zero-based index into sorted results), not turn_index values, and documented the assumption that Copilot's UNIQUE constraint prevents gaps.

**📁 FILES**
- `cli/src/core/CopilotDetector.ts`
- `cli/src/core/SqliteHelpers.ts`
- `cli/src/core/CopilotTranscriptReader.ts`

</blockquote>
</details>
<details>
<summary><strong>08 · [1de42e7] Complete VS Code Copilot Chat integration with dual storage format support</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Users needed the ability to capture conversations from VS Code's Copilot Chat extension alongside the existing Copilot CLI integration, with both forms discoverable and controllable through a single user-facing toggle.

**💡 Decisions Behind the Code**

- **Dual-scan architecture over unified path**: Rather than trying to unify all Copilot session storage under one reader, the design accepts that two different chat entry points use two different storage formats and implements separate sub-readers with a dispatcher. This trades some code duplication for clarity, testability, and resilience — a bad line in one format does not block the other, and each reader can be optimized for its specific format's semantics.
- **Sequential concatenation over preference hierarchy**: Both scans run and results are concatenated without deduplication, allowing sessions from both storage locations to coexist in the output. This is necessary because the two scans represent different entry points (copilotcli-backend models vs. non-copilotcli-backend models in the chat panel).
- **Metadata-based gating over directory structure inference**: Scan A relies on reading and parsing `vscode.metadata.json` to extract the workspace folder path, rather than inferring it from directory structure. This is more explicit and maintainable, though it adds a JSON parse step and requires handling malformed metadata gracefully.
- **Semantic-level cursor using request/line indices**: The readers track progress through transcripts using request array indices or line counts rather than byte offsets. This is more robust against variable line lengths and streaming token accumulation, and aligns with the document-oriented model VS Code uses internally.
- **Lexicographic comparison for ISO 8601 timestamps**: Events.jsonl timestamps are compared as strings rather than parsed to Date objects. ISO 8601 format is lexicographically sortable, so string comparison is safe and avoids parsing overhead while remaining correct across all valid ISO 8601 variants.

**✅ What Was Implemented**

The Copilot Chat integration was implemented as a complete transcript source with support for two distinct storage formats. The detector probes both the VS Code extension's global storage directory and the Copilot CLI agent's `~/.copilot/session-state` directory, returning true if either location exists. The session discoverer uses a two-scan architecture: Scan A discovers sessions from `~/.copilot/session-state/<sid>/events.jsonl` by reading workspace metadata and matching folder paths, while Scan B discovers sessions from the traditional `<wsHash>/chatSessions/<sid>.jsonl` location, with results concatenated to support both entry points. The transcript reader dispatches to format-specific sub-readers based on file path patterns: `readPatchLog()` handles the patch-log format (JSON patches replayed to reconstruct conversations), and `readEventsJsonl()` handles the event stream format (line-delimited JSON with user and assistant message filtering). Both readers support optional timestamp filtering via a `beforeTimestamp` parameter for time-bounded incremental reads, with cursor tracking using request/line indices for resumable consumption. All new code achieved 99%+ test coverage with comprehensive edge-case handling.

**📁 FILES**
- `cli/src/core/CopilotChatDetector.ts`
- `cli/src/core/CopilotChatSessionDiscoverer.ts`
- `cli/src/core/CopilotChatTranscriptReader.ts`

</blockquote>
</details>
<details>
<summary><strong>09 · [1de42e7] Refactor Cursor integration to use shared VS Code workspace locator</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The Cursor integration already solved the problem of locating VS Code workspace directories by project path; duplicating this logic for the new Copilot Chat integration would create maintenance burden and risk code drift.

**💡 Decisions Behind the Code**

- **Fail-soft on workspace metadata errors**: When a workspace.json is missing, unparseable, or contains an invalid URI, the scanner logs a debug message and continues to the next entry rather than crashing. This allows the integration to gracefully handle partially corrupted or incomplete workspace storage without blocking discovery of other valid sessions.
- **Parameterized flavor over separate implementations**: The locator accepts an IDE flavor parameter rather than duplicating the logic across both Copilot Chat and Cursor integrations. This eliminates code drift, makes the logic testable in isolation, and makes it trivial to add future VS Code-family forks by passing only a flavor string.

**✅ What Was Implemented**

A shared `VscodeWorkspaceLocator` module was created with platform-aware path resolution functions parameterized by IDE flavor ("Code" or "Cursor"). The module provides `getVscodeUserDataDir()`, `getVscodeWorkspaceStorageDir()`, `findVscodeWorkspaceHash()`, and `normalizePathForMatch()` functions. The `findVscodeWorkspaceHash()` function scans the workspaceStorage directory, parses each workspace's workspace.json, extracts the folder URI, and matches it against the project directory with case-insensitive matching on macOS and Windows. The Cursor integration was refactored to delegate path resolution to this shared locator, eliminating approximately 50 lines of duplicated path-matching and JSON-parsing code.

**📁 FILES**
- `cli/src/core/VscodeWorkspaceLocator.ts`
- `cli/src/core/CursorDetector.ts`

</blockquote>
</details>
<details>
<summary><strong>10 · [1de42e7] Wire Copilot Chat discovery and reading into QueueWorker pipeline</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The QueueWorker needs to discover and include GitHub Copilot Chat sessions alongside other AI assistant sessions when building commit context, and then read transcripts from discovered chat sessions.

**💡 Decisions Behind the Code**

- **Shared configuration toggle**: Copilot Chat discovery shares the existing `copilotEnabled` configuration toggle rather than introducing a separate feature flag. This keeps the user-facing settings simple — one toggle controls all GitHub Copilot integrations — while allowing the implementation to distinguish between the CLI source and the VS Code workspaceStorage source internally.
- **Graceful error handling**: The try-catch wrapper with error logging ensures that a single malformed or inaccessible Copilot Chat transcript does not halt the entire queue processing run. This maintains consistency with how other session readers are handled and allows the worker to continue processing remaining sessions even when one fails.

**✅ What Was Implemented**

Conditional discovery logic was added to the `loadSessionTranscripts` function in QueueWorker that checks if Copilot Chat is installed and enabled, then discovers and appends any found chat sessions to the all-sessions list with logging. The copilot-chat branch in the session reading dispatch was wired with a try-catch block that calls `readCopilotChatTranscript`, passing the session's transcript path, optional cursor parameter, and `beforeTimestamp` for time-bounded filtering. Error handling logs failures and skips the session gracefully if reading fails, maintaining consistency with how other session readers are handled.

**📁 FILES**
- `cli/src/hooks/QueueWorker.ts`

</blockquote>
</details>
<details>
<summary><strong>11 · [1de42e7] Extend Copilot auto-enable to detect Chat variant alongside CLI</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The installer previously only auto-enabled Copilot support when the terminal CLI was detected. The system now needs to recognize and enable support for GitHub Copilot Chat as well, since both forms share a single configuration toggle.

**💡 Decisions Behind the Code**

**OR semantics for dual detection**: Both Copilot variants (CLI and Chat) share a single `copilotEnabled` toggle. The detection logic uses OR semantics: if either form exists and the user has not explicitly disabled Copilot, the feature turns on. This approach respects explicit user choice while defaulting to enabled for convenience.

**✅ What Was Implemented**

The auto-enable logic in Installer.ts was modified to check both `isCopilotInstalled()` (CLI) and `isCopilotChatInstalled()` (Chat), enabling the shared `copilotEnabled` flag when either form is present and the setting is undefined. The log message was updated to report detection status for both Copilot forms, replacing the CLI-only message with parameterized output showing which variant(s) were found.

**📁 FILES**
- `cli/src/install/Installer.ts`

</blockquote>
</details>
<details>
<summary><strong>12 · [1de42e7] Surface Copilot Chat detection and session discovery in status reporting</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The status reporting system needed to expose whether VS Code's Copilot Chat extension is installed and to discover active chat sessions, similar to how it already handles Copilot and other coding agents.

**💡 Decisions Behind the Code**

**On-demand discovery during status checks**: Copilot Chat sessions are discovered on-demand during status checks rather than stored persistently in sessions.json. This approach mirrors the existing pattern for Copilot sessions and avoids maintaining a separate persistent store for a third-party extension's data. The discovery is gated by the `copilotEnabled` configuration flag, ensuring that users who have disabled Copilot integration do not incur the cost of scanning the chat directory.

**✅ What Was Implemented**

The `StatusInfo` type was extended with `copilotChatDetected` and `copilotChatScanError` fields, mirroring the existing pattern for Copilot detection and error reporting. The `Installer.getStatus()` method was modified to call `isCopilotChatInstalled()` and conditionally invoke `scanCopilotChatSessions()` when Copilot Chat is detected and the `copilotEnabled` config flag is true, merging discovered sessions into the active session count and surfacing any scan errors.

**📁 FILES**
- `cli/src/Types.ts`
- `cli/src/install/Installer.ts`

</blockquote>
</details>
<details>
<summary><strong>13 · [1de42e7] Display Copilot CLI and Chat detection breakdown in status output</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The status command was showing aggregate Copilot detection but not distinguishing between CLI and Chat variants, making it unclear which integration method was actually available when only one was detected.

**💡 Decisions Behind the Code**

**Sub-line breakdown for clarity**: Displaying the breakdown as indented sub-lines (using ↳ prefix) rather than inline keeps the main Copilot row clean while making the distinction visible without requiring users to parse multiple columns. Aggregating session counts and detection state in the main row ensures the overall integration status is immediately clear, while the sub-line provides diagnostic detail for users troubleshooting which variant is working.

**✅ What Was Implemented**

The StatusCommand was modified to display a sub-line breakdown showing CLI and Chat detection status separately (✓ or ✗) whenever any Copilot variant is detected. The main Copilot row now aggregates both detection states and session counts from both sources. Chat-specific scan errors are surfaced in a second sub-line below the CLI/Chat breakdown when the CLI scan succeeds but the chat scan fails.

**📁 FILES**
- `cli/src/commands/StatusCommand.ts`

</blockquote>
</details>
<details>
<summary><strong>14 · [1de42e7] Show CLI and Chat form breakdown in Copilot status tree</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The Copilot integration status row previously showed only a single detection state, but Copilot now has two independent forms: the terminal CLI and VS Code Chat. Users need visibility into which forms are detected and working.

**💡 Decisions Behind the Code**

- **Unified detection logic with per-form visibility**: Rather than showing separate integration rows for CLI and Chat, a single integration row displays both forms' status inline. This keeps the status tree compact while providing the detail users need.
- **Independent error rows for each form**: When a scan fails, a dedicated warning row appears for that form. This allows users to understand which form is broken without losing the overall integration status.

**✅ What Was Implemented**

The StatusTreeProvider was modified to track and display detection status for both Copilot CLI and Chat forms separately. The integration row now shows inline indicators (✓ or ✗) for each form in the tooltip and description text, allowing users to see at a glance which forms are available. The integration is treated as "detected" if either CLI or Chat is present. Scan error handling was separated so that CLI and Chat scan failures surface as independent warning rows, each labeled distinctly ("Copilot CLI database scan failed" vs. "Copilot Chat scan failed").

**📁 FILES**
- `vscode/src/providers/StatusTreeProvider.ts`

</blockquote>
</details>
<details>
<summary><strong>15 · [1de42e7] Add Copilot Chat source support to Summary panel rendering</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The Summary panel needed to recognize and display sessions from the Copilot Chat source alongside existing AI assistant sources like Claude, Copilot, and others.

**💡 Decisions Behind the Code**

**Dependent feature of copilot toggle**: The copilot-chat source is treated as a dependent feature of the copilot configuration flag rather than a separate toggle. This keeps the configuration surface simple and prevents users from accidentally enabling one without the other. Placing copilot-chat immediately after copilot in the source ordering maintains logical grouping in the UI, making it clear to users that these are related features.

**✅ What Was Implemented**

A new conditional branch was added to the source-to-label mapping function within SummaryScriptBuilder to return the display label "Copilot Chat" when the source is "copilot-chat". The source ordering array in the session statistics rendering logic was extended to include "copilot-chat" immediately after "copilot", ensuring consistent ordering in the Summary panel UI. The enabled sources filter in SummaryWebviewPanel was updated to include "copilot-chat" whenever the copilot feature is enabled.

**📁 FILES**
- `vscode/src/views/SummaryScriptBuilder.ts`
- `vscode/src/views/SummaryWebviewPanel.ts`

</blockquote>
</details>
<details>
<summary><strong>16 · [1de42e7] Add copilot-chat as a recognized AI agent source</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The system needed to support a new variant of GitHub Copilot (copilot-chat) alongside the existing copilot integration, ensuring transcripts from this agent are properly recognized and filtered.

**💡 Decisions Behind the Code**

**Unified filtering for copilot variants**: Copilot and copilot-chat are filtered together as a single feature family rather than as separate integrations. This approach keeps the configuration surface simple — users do not need separate toggles for each copilot variant — while allowing the system to recognize and track both sources independently.

**✅ What Was Implemented**

The `TranscriptSource` type was updated to include "copilot-chat" as a valid source value alongside existing agents like claude, codex, gemini, opencode, cursor, and copilot. The `filterSessionsByEnabledIntegrations` function was modified to exclude both "copilot" and "copilot-chat" sessions when the `copilotEnabled` configuration is explicitly set to false, treating them as a unified feature family. Test cases were added verifying that copilot-chat sessions are excluded when copilotEnabled is false and confirming that copilot-chat sessions are included during auto-detection.

**📁 FILES**
- `cli/src/Types.ts`
- `cli/src/core/SessionTracker.ts`

</blockquote>
</details>
<details>
<summary><strong>17 · [1de42e7] Boost Copilot Chat test coverage to 98%+ with error-path tests</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The developer added support for reading Copilot Chat transcripts as a new data source, but the new code had gaps in branch coverage. The goal was to raise coverage above 98% for all new code introduced in this feature.

**💡 Decisions Behind the Code**

- **Isolated mocking for unreachable branches**: Rather than modify existing test setup to artificially trigger code-less errors (which would break tests relying on real filesystem behavior), separate describe blocks with vi.doMock / vi.doUnmock were created to test the nullish-coalescing fallback paths. This kept the test suite maintainable and prevented cross-test pollution while still achieving full branch coverage.
- **Selective mocking for error precedence**: The error precedence tests use selective mocking of the file system module to inject permission errors at specific paths while allowing other operations to proceed normally. This approach isolates error handling logic without requiring actual file system state manipulation, making tests deterministic and fast.
- **Reuse existing mocking patterns**: The codebase already used `vi.doMock("node:fs/promises", { readdir: path-selective throw, delegate to actual })` to test error paths while preserving real file system behavior for unrelated operations. New tests adopted this pattern rather than introducing a different mocking strategy, reducing cognitive load for future maintainers and keeping test code consistent with established conventions.

**✅ What Was Implemented**

Eleven new test cases were added across six test files to cover previously untested error paths and edge cases: code-less stat errors in CopilotChatDetector, wrapper error handling and symlink-induced stat failures in CopilotChatSessionDiscoverer, null/undefined intermediate paths and non-string response chunks in CopilotChatTranscriptReader, the getCursorWorkspaceStorageDir function in CursorDetector, Chat scan-failed status output in StatusCommand, and getWorkerBusy / dispose lifecycle methods in StatusTreeProvider. Three additional test cases were added to verify error precedence behavior when permission errors occur during directory scanning. Isolated vi.doMock blocks were used to test nullish-coalescing operator branches that real filesystem operations cannot naturally trigger, avoiding pollution of other tests that rely on actual file I/O. Final coverage reached 100% across all four metrics (statements, branches, functions, lines) for all new Copilot Chat modules.

**📁 FILES**
- `cli/src/core/CopilotChatDetector.test.ts`
- `cli/src/core/CopilotChatSessionDiscoverer.test.ts`
- `cli/src/core/CopilotChatTranscriptReader.test.ts`

</blockquote>
</details>
<details>
<summary><strong>18 · [1de42e7] Mock CopilotChat modules in PostCommitHook tests</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Test suite was timing out with 11 failures in PostCommitHook tests. The root cause was that newly added CopilotChat discovery functions were not mocked, causing the QueueWorker's chat discovery logic to attempt real filesystem operations that hung indefinitely.

**💡 Decisions Behind the Code**

**Mocks in test files rather than shared utility**: The mocks were added directly to the test files rather than extracted to a shared test utility because the existing mock pattern in these files already groups all module mocks together at the top of each test file. This maintains consistency with the established test structure and makes the mocks immediately visible to anyone reading the test.

**✅ What Was Implemented**

Mock definitions were added for five CopilotChat-related modules in PostCommitHook.helpers.test.ts and PostCommitHook.test.ts: CopilotChatDetector, CopilotChatSessionDiscoverer, and CopilotChatTranscriptReader, each returning empty or false values to prevent filesystem access during test execution. Additional mocks for CopilotDetector and CopilotSessionDiscoverer were added to PostCommitHook.helpers.test.ts to ensure complete coverage of all Copilot-related discovery paths.

**📁 FILES**
- `cli/src/hooks/PostCommitHook.helpers.test.ts`
- `cli/src/hooks/PostCommitHook.test.ts`

</blockquote>
</details>
<details>
<summary><strong>19 · [1de42e7] Clarify runtime compatibility gating and improve logging context</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The existing comment explaining why Cursor detection is gated on Node version support was vague about the user-facing consequence and the logging rationale.

**💡 Decisions Behind the Code**

**Info-level logging for expected incompatibility**: Logging at info level rather than warning or error is appropriate because the condition is not a failure — it is a runtime incompatibility that is expected and normal on certain hosts (e.g., VS Code extension Node 18 environments). The expanded comments make this intent explicit so future maintainers understand that the gating is a feature, not a workaround.

**✅ What Was Implemented**

The docstring for `isCursorInstalled()` was expanded to explain that the function reports "not installed" on incompatible runtimes (Node <22.5) rather than "detected but 0 sessions", which would be misleading since a scan would always fail on those runtimes. An inline comment was added before the log statement clarifying that the info-level log is intentional so operators can correlate the absence of Cursor from status output with the actual runtime version constraint.

**📁 FILES**
- `cli/src/core/CursorDetector.ts`

</blockquote>
</details>
<details>
<summary><strong>20 · [1de42e7] Log skipped chat session files when stat fails</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

A code review identified that file stat errors during chat session discovery were silently swallowed, making it difficult to diagnose why sessions were unexpectedly missing from the scan results.

**💡 Decisions Behind the Code**

**Debug-level logging for observability**: Debug-level logging was chosen over silent failure to preserve observability without cluttering normal operation. Users running the CLI in standard mode will not see these messages, but developers troubleshooting session discovery issues can enable debug output to understand what went wrong.

**✅ What Was Implemented**

Debug logging was added to the catch block in CopilotChatSessionDiscoverer.ts when the stat() call fails on a discovered file. The log message includes the file entry name and the underlying error message, allowing developers to see which files were skipped and why.

**📁 FILES**
- `cli/src/core/CopilotChatSessionDiscoverer.ts`

</blockquote>
</details>
<details>
<summary><strong>21 · [1de42e7] Clarify status display comment for Copilot scan errors</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

A code review noted that the inline comment describing how Copilot scan errors are displayed in the status output was ambiguous and could mislead future maintainers about the rendering behavior.

**💡 Decisions Behind the Code**

**Explicit rendering language**: Replacing "takes precedence" with "renders on" removes the implication of priority or suppression, clarifying that the behavior is purely about visual layout rather than error filtering. This prevents future developers from misinterpreting the code and potentially introducing bugs when modifying error handling logic.

**✅ What Was Implemented**

The comment in StatusCommand.ts was updated from "CLI scan error takes precedence; chat scan error surfaced via sub-line below" to "CLI scan error renders on the main row; Chat scan error renders as a sub-line below." The change makes explicit that both errors are displayed, just in different visual locations.

**📁 FILES**
- `cli/src/commands/StatusCommand.ts`

</blockquote>
</details>
<details>
<summary><strong>22 · [1de42e7] Align API naming between spec and implementation for session state directory</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The design specification and implementation had inconsistent function names for retrieving the Copilot CLI session state directory, creating a mismatch between documented and actual APIs.

**💡 Decisions Behind the Code**

**Naming consistency between spec and code**: Naming consistency between spec and code prevents future confusion and makes the API contract explicit. Distinguishing the two directory functions by their purpose (CLI backend vs. extension storage) in the documentation clarifies which function should be used in different contexts and prevents accidental mixing of concerns.

**✅ What Was Implemented**

The design specification was updated to rename `getCopilotChatSessionStateDir` to `getCopilotCliSessionStateDir` and added clarifying comments distinguishing it from the existing `getCopilotChatStorageDir` function. The spec now documents that `getCopilotCliSessionStateDir` points to `~/.copilot/session-state` (the new Copilot CLI agent backend root) while `getCopilotChatStorageDir` points to the VS Code extension's global storage directory.

**📁 FILES**
- `docs/superpowers/specs/2026-05-07-copilot-chat-events-jsonl-redesign-design.md`

</blockquote>
</details>
<details>
<summary><strong>23 · [1de42e7] Remove stale task-reference comments from reader and design documentation</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Code review identified outdated comments and documentation that referenced future work items no longer applicable after task consolidation.

**💡 Decisions Behind the Code**

**Stale comments create confusion**: Stale comments create confusion for future maintainers who may spend time looking for work that was already completed or merged. Removing task-specific qualifiers and updating documentation to reflect the current state of the codebase improves clarity without changing any behavior.

**✅ What Was Implemented**

A comment in CopilotChatTranscriptReader.ts that mentioned `readEventsJsonl` would be "added in a later task" was removed since the function is now present. The format detection table in the design specification was revised to use current terminology and remove references to legacy format detection logic, replacing outdated scenario descriptions with accurate descriptions of the two probe paths (Copilot CLI agent backend and Copilot Chat extension).

**📁 FILES**
- `cli/src/core/CopilotChatTranscriptReader.ts`
- `docs/superpowers/specs/2026-05-07-copilot-chat-events-jsonl-redesign-design.md`

</blockquote>
</details>

> ⚠️ 2 more topics omitted due to GitHub PR body size limit.

---

*Generated by Jolli Memory · May 7, 2026 at 1:51 PM*
<!-- jollimemory-summary-end -->