### PR TITLE
feat(cli): hot-reload source folder in jolli dev

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -50,6 +50,7 @@
 	"dependencies": {
 		"@anthropic-ai/sdk": "^0.39.0",
 		"@mdx-js/mdx": "^3.1.1",
+		"chokidar": "^4.0.0",
 		"commander": "^13.1.0",
 		"open": "^11.0.0"
 	},

--- a/cli/src/commands/StartCommand.test.ts
+++ b/cli/src/commands/StartCommand.test.ts
@@ -84,6 +84,11 @@ vi.mock("../site/PagefindRunner.js", () => ({
 	runPagefind: mockRunPagefind,
 }));
 
+const mockStartSourceWatcher = vi.hoisted(() => vi.fn());
+vi.mock("../site/SourceWatcher.js", () => ({
+	startSourceWatcher: mockStartSourceWatcher,
+}));
+
 // ─── Default mock values ──────────────────────────────────────────────────────
 
 const DEFAULT_SITE_JSON_RESULT = {
@@ -129,6 +134,7 @@ function setupSuccessfulRun(
 	mockRunNpmDev.mockResolvedValue({ success: true, output: "" });
 	mockRunPagefind.mockResolvedValue({ success: true, output: "Indexed 5 pages", pagesIndexed: 5 });
 	mockRunServe.mockResolvedValue({ success: true, output: "" });
+	mockStartSourceWatcher.mockReturnValue({ close: vi.fn().mockResolvedValue(undefined) });
 }
 
 // ─── Shared pipeline tests (apply to both start and dev) ─────────────────────
@@ -496,6 +502,84 @@ describe("jolli dev", () => {
 		await program.parseAsync(["dev", "/my-docs"], { from: "user" });
 
 		expect(process.exitCode).toBe(0);
+	});
+
+	// ── Source-folder hot reload ──────────────────────────────────────────────
+
+	it("starts a source-folder watcher rooted at the resolved sourceRoot", async () => {
+		setupSuccessfulRun();
+		const program = await makeProgram();
+		await program.parseAsync(["dev", "/my-docs"], { from: "user" });
+
+		expect(mockStartSourceWatcher).toHaveBeenCalledOnce();
+		const [watchedPath] = mockStartSourceWatcher.mock.calls[0] as [string, { onChange: () => Promise<void> }];
+		expect(watchedPath).toBe(resolve("/my-docs"));
+	});
+
+	it("closes the watcher when the dev server exits cleanly", async () => {
+		setupSuccessfulRun();
+		const closeMock = vi.fn().mockResolvedValue(undefined);
+		mockStartSourceWatcher.mockReturnValue({ close: closeMock });
+		const program = await makeProgram();
+		await program.parseAsync(["dev", "/my-docs"], { from: "user" });
+
+		expect(closeMock).toHaveBeenCalledOnce();
+	});
+
+	it("closes the watcher even when the dev server errors out", async () => {
+		setupSuccessfulRun();
+		mockRunNpmDev.mockResolvedValue({ success: false, output: "Dev error" });
+		const closeMock = vi.fn().mockResolvedValue(undefined);
+		mockStartSourceWatcher.mockReturnValue({ close: closeMock });
+		const program = await makeProgram();
+		await program.parseAsync(["dev", "/my-docs"], { from: "user" });
+
+		expect(process.exitCode).toBe(1);
+		expect(closeMock).toHaveBeenCalledOnce();
+	});
+
+	it("re-runs mirror + nav + openapi when the watcher fires onChange", async () => {
+		setupSuccessfulRun({ openapiFiles: ["api/spec.yaml"] });
+		const program = await makeProgram();
+		await program.parseAsync(["dev", "/my-docs"], { from: "user" });
+
+		// Initial pass already called the mirroring + render path once.
+		const initialMirrorCount = mockMirrorContent.mock.calls.length;
+		const initialRenderCount = mockRenderOpenApiFiles.mock.calls.length;
+
+		// Trigger the captured onChange to simulate a file edit.
+		const [, options] = mockStartSourceWatcher.mock.calls[0] as [string, { onChange: () => Promise<void> }];
+		await options.onChange();
+
+		expect(mockMirrorContent.mock.calls.length).toBe(initialMirrorCount + 1);
+		expect(mockGenerateMetaFiles).toHaveBeenCalledTimes(2);
+		expect(mockRenderOpenApiFiles.mock.calls.length).toBe(initialRenderCount + 1);
+	});
+
+	it("logs a synced-file count on each onChange", async () => {
+		setupSuccessfulRun({ markdownFiles: ["a.md", "b.md"], openapiFiles: ["api.yaml"] });
+		const program = await makeProgram();
+		await program.parseAsync(["dev", "/my-docs"], { from: "user" });
+
+		const [, options] = mockStartSourceWatcher.mock.calls[0] as [string, { onChange: () => Promise<void> }];
+		await options.onChange();
+
+		const output = consoleSpy.mock.calls.map((c: unknown[]) => c.join(" ")).join("\n");
+		expect(output).toMatch(/↻ Synced \d+ files/);
+	});
+
+	it("watcher onChange swallows a site.json read error and does NOT crash", async () => {
+		setupSuccessfulRun();
+		const program = await makeProgram();
+		await program.parseAsync(["dev", "/my-docs"], { from: "user" });
+
+		// Make the next site.json read fail; the dev process must keep running.
+		mockReadSiteJson.mockRejectedValueOnce(new Error("transient parse error"));
+		const [, options] = mockStartSourceWatcher.mock.calls[0] as [string, { onChange: () => Promise<void> }];
+		await expect(options.onChange()).resolves.toBeUndefined();
+
+		const errorOutput = consoleErrorSpy.mock.calls.map((c: unknown[]) => c.join(" ")).join("\n");
+		expect(errorOutput).toContain("transient parse error");
 	});
 });
 

--- a/cli/src/commands/StartCommand.ts
+++ b/cli/src/commands/StartCommand.ts
@@ -15,6 +15,7 @@ import { needsInstall, runNpmInstall, runServe } from "../site/NpmRunner.js";
 import { runPagefind } from "../site/PagefindRunner.js";
 import { resolveRenderer, type SiteRenderer } from "../site/renderer/index.js";
 import { readSiteJson } from "../site/SiteJsonReader.js";
+import { startSourceWatcher } from "../site/SourceWatcher.js";
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -32,6 +33,59 @@ function verbose(msg: string, isVerbose: boolean): void {
 interface CmdOpts {
 	migrate?: boolean;
 	verbose?: boolean;
+}
+
+// ─── syncContent ─────────────────────────────────────────────────────────────
+
+/**
+ * Reads `site.json`, mirrors the source folder into `contentDir`, fixes the
+ * sidebar's index key if a file was renamed, regenerates navigation, and
+ * re-renders OpenAPI specs. Used by both the initial `prepareContent` and
+ * the dev-mode source watcher (which calls it on every settled change so
+ * `next dev`'s HMR sees the latest output).
+ *
+ * Side effects this function does NOT do — they're scaffolding-only and
+ * belong to `prepareContent`: `initProject`, clearing the public dir,
+ * resolving favicon, npm install.
+ */
+async function syncContent(
+	sourceRoot: string,
+	contentDir: string,
+	publicDir: string,
+	renderer: SiteRenderer,
+	opts: CmdOpts,
+): Promise<{ success: false } | { success: true; mirrorResult: Awaited<ReturnType<typeof mirrorContent>> }> {
+	let siteJsonResult: Awaited<ReturnType<typeof readSiteJson>>;
+	try {
+		siteJsonResult = await readSiteJson(sourceRoot, { migrate: opts.migrate });
+	} catch (err) {
+		console.error(`  Error: ${err instanceof Error ? err.message : String(err)}`);
+		return { success: false };
+	}
+
+	const mirrorResult = await mirrorContent(
+		sourceRoot,
+		contentDir,
+		siteJsonResult.config.pathMappings,
+		publicDir,
+		renderer.getContentRules(),
+	);
+
+	// Fix sidebar index key if a file was renamed during mirror.
+	const sidebar = siteJsonResult.config.sidebar;
+	if (mirrorResult.renamedToIndex && sidebar?.["/"]?.[mirrorResult.renamedToIndex]) {
+		const label = sidebar["/"][mirrorResult.renamedToIndex];
+		delete sidebar["/"][mirrorResult.renamedToIndex];
+		sidebar["/"] = { index: label, ...sidebar["/"] };
+	}
+
+	await renderer.generateNavigation(contentDir, sidebar);
+
+	if (mirrorResult.openapiFiles.length > 0) {
+		await renderer.renderOpenApiFiles(sourceRoot, contentDir, mirrorResult.openapiFiles, publicDir);
+	}
+
+	return { success: true, mirrorResult };
 }
 
 // ─── prepareContent ──────────────────────────────────────────────────────────
@@ -90,15 +144,14 @@ async function prepareContent(
 	// Resolve favicon
 	await resolveFavicon(siteJsonResult.config.favicon, sourceRoot, publicDir);
 
-	// Mirror content
+	// Mirror + nav + render OpenAPI specs (shared with the dev watcher).
 	verbose("Mirroring content…", v);
-	const mirrorResult = await mirrorContent(
-		sourceRoot,
-		contentDir,
-		siteJsonResult.config.pathMappings,
-		publicDir,
-		renderer.getContentRules(),
-	);
+	const sync = await syncContent(sourceRoot, contentDir, publicDir, renderer, opts);
+	if (!sync.success) {
+		process.exitCode = 1;
+		return { success: false };
+	}
+	const { mirrorResult } = sync;
 
 	const total = mirrorResult.markdownFiles.length + mirrorResult.imageFiles.length + mirrorResult.openapiFiles.length;
 	const downgraded = mirrorResult.downgradedCount;
@@ -109,24 +162,7 @@ async function prepareContent(
 		console.warn("  ⚠ No markdown or OpenAPI files found. Producing an empty site.");
 	}
 
-	// Fix sidebar index key if file was renamed
-	const sidebar = siteJsonResult.config.sidebar;
-	if (mirrorResult.renamedToIndex && sidebar?.["/"]?.[mirrorResult.renamedToIndex]) {
-		const label = sidebar["/"][mirrorResult.renamedToIndex];
-		delete sidebar["/"][mirrorResult.renamedToIndex];
-		sidebar["/"] = { index: label, ...sidebar["/"] };
-	}
-
-	// Generate navigation
-	verbose("Generating navigation…", v);
-	await renderer.generateNavigation(contentDir, sidebar);
 	console.log("  ✓ Generated navigation");
-
-	// Render OpenAPI specs
-	if (mirrorResult.openapiFiles.length > 0) {
-		verbose("Rendering OpenAPI specs…", v);
-		await renderer.renderOpenApiFiles(sourceRoot, contentDir, mirrorResult.openapiFiles, publicDir);
-	}
 
 	// Install dependencies
 	if (needsInstall(buildDir)) {
@@ -248,11 +284,34 @@ export function registerDevCommand(program: Command): void {
 			const result = await prepareContent(sourceRoot, buildDir, contentDir, publicDir, false, opts);
 			if (!result.success) return;
 
+			// Watch the source folder so edits trigger an incremental re-mirror
+			// + re-render of OpenAPI specs while the dev server is running.
+			// Next.js's HMR picks up the writes to <buildDir>/content/.
+			console.log("  Watching source folder for changes…");
+			const watcher = startSourceWatcher(sourceRoot, {
+				onChange: async () => {
+					const sync = await syncContent(sourceRoot, contentDir, publicDir, result.renderer, opts);
+					if (sync.success) {
+						const total =
+							sync.mirrorResult.markdownFiles.length +
+							sync.mirrorResult.imageFiles.length +
+							sync.mirrorResult.openapiFiles.length;
+						const ignored = sync.mirrorResult.ignoredFiles.length;
+						const suffix = ignored > 0 ? ` (${ignored} ignored)` : "";
+						console.log(`  ↻ Synced ${total} files${suffix}`);
+					}
+				},
+			});
+
 			console.log("");
-			const devResult = await result.renderer.runDev(buildDir, opts.verbose === true);
-			if (!devResult.success) {
-				if (devResult.output) console.error(devResult.output);
-				process.exitCode = 1;
+			try {
+				const devResult = await result.renderer.runDev(buildDir, opts.verbose === true);
+				if (!devResult.success) {
+					if (devResult.output) console.error(devResult.output);
+					process.exitCode = 1;
+				}
+			} finally {
+				await watcher.close();
 			}
 		});
 }

--- a/cli/src/site/SourceWatcher.test.ts
+++ b/cli/src/site/SourceWatcher.test.ts
@@ -1,0 +1,267 @@
+/**
+ * Tests for SourceWatcher.
+ *
+ * The watcher is exercised against a stub `WatchFactory` that returns a
+ * thin `FSWatcher`-shaped EventEmitter — no real filesystem is touched.
+ */
+
+import { EventEmitter } from "node:events";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { startSourceWatcher, type WatchFactory } from "./SourceWatcher.js";
+
+// ─── Stub factory ──────────────────────────────────────────────────────────
+
+interface StubWatcher extends EventEmitter {
+	close(): Promise<void>;
+	closeMock: ReturnType<typeof vi.fn>;
+	options?: { ignoreInitial: boolean; ignored: string[] };
+	path?: string;
+}
+
+function makeStubFactory(): { factory: WatchFactory; getWatcher: () => StubWatcher } {
+	let captured: StubWatcher | null = null;
+
+	const factory: WatchFactory = (path, options) => {
+		const emitter = new EventEmitter() as StubWatcher;
+		emitter.path = path;
+		emitter.options = options;
+		const closeMock = vi.fn().mockResolvedValue(undefined);
+		emitter.closeMock = closeMock;
+		emitter.close = closeMock;
+		captured = emitter;
+		// Return as the chokidar FSWatcher type — the watcher only uses
+		// `on(name, cb)` and `close()`, both of which the stub provides.
+		// biome-ignore lint/suspicious/noExplicitAny: stub typed dynamically for the test surface
+		return emitter as any;
+	};
+
+	return {
+		factory,
+		getWatcher: () => {
+			if (!captured) {
+				throw new Error("watcher was never created");
+			}
+			return captured;
+		},
+	};
+}
+
+/** Yields control to the microtask queue once. */
+function tick(): Promise<void> {
+	return new Promise((resolve) => setImmediate(resolve));
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe("startSourceWatcher", () => {
+	beforeEach(() => {
+		// Only fake setTimeout / clearTimeout — leave setImmediate alone so
+		// our `tick()` microtask flush actually resolves.
+		vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("passes ignoreInitial=true and the built-in ignore globs to chokidar", () => {
+		const { factory, getWatcher } = makeStubFactory();
+		const onChange = vi.fn().mockResolvedValue(undefined);
+		const watcher = startSourceWatcher("/src", { onChange, watchFactory: factory });
+		const stub = getWatcher();
+
+		expect(stub.path).toBe("/src");
+		expect(stub.options?.ignoreInitial).toBe(true);
+		expect(stub.options?.ignored).toContain("**/.git/**");
+		expect(stub.options?.ignored).toContain("**/node_modules/**");
+		expect(stub.options?.ignored).toContain("**/.jolli-site/**");
+		expect(stub.options?.ignored).toContain("**/.next/**");
+
+		void watcher.close();
+	});
+
+	it("appends user-supplied ignore patterns after the built-ins", () => {
+		const { factory, getWatcher } = makeStubFactory();
+		const onChange = vi.fn().mockResolvedValue(undefined);
+		startSourceWatcher("/src", {
+			onChange,
+			watchFactory: factory,
+			ignored: ["**/secret/**"],
+		});
+		expect(getWatcher().options?.ignored).toContain("**/secret/**");
+	});
+
+	it("debounces a burst of events into a single onChange call", async () => {
+		const { factory, getWatcher } = makeStubFactory();
+		const onChange = vi.fn().mockResolvedValue(undefined);
+		startSourceWatcher("/src", { onChange, debounceMs: 50, watchFactory: factory });
+		const stub = getWatcher();
+
+		stub.emit("change", "/src/a.md");
+		stub.emit("change", "/src/b.md");
+		stub.emit("add", "/src/c.md");
+
+		expect(onChange).not.toHaveBeenCalled();
+
+		await vi.advanceTimersByTimeAsync(50);
+		await tick();
+
+		expect(onChange).toHaveBeenCalledTimes(1);
+	});
+
+	it("listens for add / change / unlink events", async () => {
+		const { factory, getWatcher } = makeStubFactory();
+		const onChange = vi.fn().mockResolvedValue(undefined);
+		startSourceWatcher("/src", { onChange, debounceMs: 10, watchFactory: factory });
+		const stub = getWatcher();
+
+		stub.emit("unlink", "/src/old.md");
+		await vi.advanceTimersByTimeAsync(10);
+		await tick();
+
+		expect(onChange).toHaveBeenCalledTimes(1);
+	});
+
+	it("coalesces events that arrive while onChange is in flight into a single follow-up sync", async () => {
+		const { factory, getWatcher } = makeStubFactory();
+		let resolveFirst: () => void = () => {};
+		const onChange = vi.fn();
+		onChange.mockImplementationOnce(
+			() =>
+				new Promise<void>((r) => {
+					resolveFirst = r;
+				}),
+		);
+		onChange.mockImplementation(() => Promise.resolve());
+		startSourceWatcher("/src", { onChange, debounceMs: 10, watchFactory: factory });
+		const stub = getWatcher();
+
+		stub.emit("change", "/src/a.md");
+		await vi.advanceTimersByTimeAsync(10);
+		await tick();
+
+		// First onChange is in flight (still pending). Fire two more events;
+		// they should coalesce into a single follow-up sync once the first
+		// one resolves.
+		stub.emit("change", "/src/b.md");
+		stub.emit("change", "/src/c.md");
+		await vi.advanceTimersByTimeAsync(10);
+		await tick();
+
+		// Still only one onChange running.
+		expect(onChange).toHaveBeenCalledTimes(1);
+
+		resolveFirst();
+		await tick();
+		await tick();
+
+		expect(onChange).toHaveBeenCalledTimes(2);
+	});
+
+	it("logs and continues when onChange throws", async () => {
+		const { factory, getWatcher } = makeStubFactory();
+		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+		const onChange = vi.fn().mockRejectedValueOnce(new Error("kaboom")).mockResolvedValueOnce(undefined);
+
+		startSourceWatcher("/src", { onChange, debounceMs: 10, watchFactory: factory });
+		const stub = getWatcher();
+
+		stub.emit("change", "/src/a.md");
+		await vi.advanceTimersByTimeAsync(10);
+		await tick();
+		await tick();
+
+		expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("kaboom"));
+
+		// A subsequent sync still runs — the watcher didn't unwind.
+		stub.emit("change", "/src/b.md");
+		await vi.advanceTimersByTimeAsync(10);
+		await tick();
+		await tick();
+
+		expect(onChange).toHaveBeenCalledTimes(2);
+		errorSpy.mockRestore();
+	});
+
+	it("formats non-Error throw values via String() in the log line", async () => {
+		const { factory, getWatcher } = makeStubFactory();
+		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+		const onChange = vi.fn().mockRejectedValueOnce("string-error").mockResolvedValue(undefined);
+
+		startSourceWatcher("/src", { onChange, debounceMs: 10, watchFactory: factory });
+		const stub = getWatcher();
+
+		stub.emit("change", "/src/a.md");
+		await vi.advanceTimersByTimeAsync(10);
+		await tick();
+		await tick();
+
+		expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("string-error"));
+		errorSpy.mockRestore();
+	});
+
+	it("close() awaits in-flight sync and shuts down chokidar", async () => {
+		const { factory, getWatcher } = makeStubFactory();
+		let resolveSync: () => void = () => {};
+		const onChange = vi.fn().mockImplementation(
+			() =>
+				new Promise<void>((r) => {
+					resolveSync = r;
+				}),
+		);
+
+		const watcher = startSourceWatcher("/src", { onChange, debounceMs: 10, watchFactory: factory });
+		const stub = getWatcher();
+
+		stub.emit("change", "/src/a.md");
+		await vi.advanceTimersByTimeAsync(10);
+		await tick();
+
+		// onChange is in flight; trigger close() — it should NOT resolve until
+		// the in-flight sync settles.
+		const closePromise = watcher.close();
+		let closed = false;
+		void closePromise.then(() => {
+			closed = true;
+		});
+		await tick();
+		expect(closed).toBe(false);
+
+		resolveSync();
+		await closePromise;
+
+		expect(stub.closeMock).toHaveBeenCalled();
+	});
+
+	it("close() also clears a pending debounce timer so no late sync fires", async () => {
+		const { factory, getWatcher } = makeStubFactory();
+		const onChange = vi.fn().mockResolvedValue(undefined);
+		const watcher = startSourceWatcher("/src", { onChange, debounceMs: 50, watchFactory: factory });
+		const stub = getWatcher();
+
+		stub.emit("change", "/src/a.md");
+		// Don't advance the timer — close() should clear it.
+		await watcher.close();
+		await vi.advanceTimersByTimeAsync(100);
+		await tick();
+
+		expect(onChange).not.toHaveBeenCalled();
+		expect(stub.closeMock).toHaveBeenCalled();
+	});
+
+	it("ignores events that fire after close()", async () => {
+		const { factory, getWatcher } = makeStubFactory();
+		const onChange = vi.fn().mockResolvedValue(undefined);
+		const watcher = startSourceWatcher("/src", { onChange, debounceMs: 10, watchFactory: factory });
+		const stub = getWatcher();
+
+		await watcher.close();
+
+		// Even if some belated emitter fires, no sync runs.
+		stub.emit("change", "/src/a.md");
+		await vi.advanceTimersByTimeAsync(50);
+		await tick();
+
+		expect(onChange).not.toHaveBeenCalled();
+	});
+});

--- a/cli/src/site/SourceWatcher.ts
+++ b/cli/src/site/SourceWatcher.ts
@@ -1,0 +1,129 @@
+/**
+ * SourceWatcher — debounced file-system watcher for `jolli dev` source-folder
+ * hot reload.
+ *
+ * Wraps `chokidar` with a small re-entrancy guard so rapid edits coalesce
+ * into a single re-sync rather than queueing a sync per event:
+ *
+ *   1. A change fires → the timer starts (or restarts).
+ *   2. After `debounceMs` of quiet, a re-sync runs.
+ *   3. If more changes arrive while a re-sync is in flight, a *single*
+ *      follow-up sync runs after the current one completes — events that
+ *      arrive during a sync are coalesced via a `dirty` flag.
+ *
+ * `onChange` errors are caught and logged so a failing re-sync (e.g. a
+ * temporarily malformed `site.json`) never crashes the running dev server.
+ */
+
+import { watch as chokidarWatch, type FSWatcher } from "chokidar";
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export interface SourceWatcherOptions {
+	/** Called after debounced FS event(s) settle. Errors are caught and logged. */
+	onChange: () => Promise<void>;
+	/** Debounce window in ms. Defaults to 100. */
+	debounceMs?: number;
+	/**
+	 * Glob patterns to ignore in addition to the built-in defaults
+	 * (`.git/`, `node_modules/`, `.jolli-site/`, `.next/`, `dist/`,
+	 * `build/`, `out/`).
+	 */
+	ignored?: string[];
+	/**
+	 * Optional override for the chokidar factory. Tests pass a stub so
+	 * they don't have to touch the real filesystem. Default: `chokidar.watch`.
+	 */
+	watchFactory?: WatchFactory;
+}
+
+export interface SourceWatcher {
+	/** Stops watching and waits for any in-flight re-sync to finish. */
+	close(): Promise<void>;
+}
+
+/** Factory signature matching `chokidar.watch`, narrowed to what we use. */
+export type WatchFactory = (path: string, options: { ignoreInitial: boolean; ignored: string[] }) => FSWatcher;
+
+// ─── Built-in ignore patterns ────────────────────────────────────────────────
+
+const BUILTIN_IGNORED = [
+	"**/.git/**",
+	"**/node_modules/**",
+	"**/.jolli-site/**",
+	"**/.next/**",
+	"**/dist/**",
+	"**/build/**",
+	"**/out/**",
+	"**/.DS_Store",
+	"**/*.swp",
+	"**/*~",
+];
+
+// ─── startSourceWatcher ─────────────────────────────────────────────────────
+
+/**
+ * Begins watching `sourceRoot` for `add` / `change` / `unlink` events. The
+ * returned handle stops the watcher and waits for any in-flight re-sync.
+ */
+export function startSourceWatcher(sourceRoot: string, opts: SourceWatcherOptions): SourceWatcher {
+	const debounceMs = opts.debounceMs ?? 100;
+	const factory = opts.watchFactory ?? chokidarWatch;
+	const ignored = [...BUILTIN_IGNORED, ...(opts.ignored ?? [])];
+
+	const watcher = factory(sourceRoot, { ignoreInitial: true, ignored });
+
+	let timer: ReturnType<typeof setTimeout> | null = null;
+	let dirty = false;
+	let running = false;
+	let closed = false;
+	let inFlight: Promise<void> = Promise.resolve();
+
+	// At most 2 iterations: the initial sync plus one follow-up if events
+	// arrived during the first sync. The debounce timer can only set `dirty`
+	// once between iterations, so unbounded looping is not possible.
+	const drain = async (): Promise<void> => {
+		while (dirty && !closed) {
+			dirty = false;
+			try {
+				await opts.onChange();
+			} catch (err) {
+				console.error(`  Error during incremental sync: ${err instanceof Error ? err.message : String(err)}`);
+			}
+		}
+		running = false;
+	};
+
+	const trigger = (): void => {
+		if (closed) {
+			return;
+		}
+		if (timer) {
+			clearTimeout(timer);
+		}
+		timer = setTimeout(() => {
+			timer = null;
+			dirty = true;
+			if (!running) {
+				running = true;
+				inFlight = drain();
+			}
+		}, debounceMs);
+	};
+
+	watcher.on("add", trigger);
+	watcher.on("change", trigger);
+	watcher.on("unlink", trigger);
+
+	return {
+		async close(): Promise<void> {
+			closed = true;
+			if (timer) {
+				clearTimeout(timer);
+				timer = null;
+			}
+			await inFlight;
+			await watcher.close();
+		},
+	};
+}

--- a/cli/vite.config.ts
+++ b/cli/vite.config.ts
@@ -24,7 +24,7 @@ export default defineConfig({
 			formats: ["es"],
 		},
 		rollupOptions: {
-			external: ["@anthropic-ai/sdk", "@mdx-js/mdx", "commander", "open", /^node:.*/],
+			external: ["@anthropic-ai/sdk", "@mdx-js/mdx", "chokidar", "commander", "open", /^node:.*/],
 			output: {
 				chunkFileNames: "[name].js",
 			},

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
 			"dependencies": {
 				"@anthropic-ai/sdk": "^0.39.0",
 				"@mdx-js/mdx": "^3.1.1",
+				"chokidar": "^4.0.0",
 				"commander": "^13.1.0",
 				"open": "^11.0.0"
 			},
@@ -2754,6 +2755,21 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/fb55"
+			}
+		},
+		"node_modules/chokidar": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+			"integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+			"license": "MIT",
+			"dependencies": {
+				"readdirp": "^4.0.1"
+			},
+			"engines": {
+				"node": ">= 14.16.0"
+			},
+			"funding": {
+				"url": "https://paulmillr.com/funding/"
 			}
 		},
 		"node_modules/chownr": {
@@ -6183,6 +6199,19 @@
 			},
 			"engines": {
 				"node": ">= 6"
+			}
+		},
+		"node_modules/readdirp": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+			"integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 14.18.0"
+			},
+			"funding": {
+				"type": "individual",
+				"url": "https://paulmillr.com/funding/"
 			}
 		},
 		"node_modules/recma-build-jsx": {


### PR DESCRIPTION
Add a debounced chokidar file watcher to `jolli dev` that re-mirrors the source Content_Folder into the build directory on every settled change, so Next.js HMR picks up edits without a restart.

The watcher coalesces rapid events via a dirty flag and re-entrancy guard, logs sync counts (including ignored files), and catches errors so a transient site.json parse failure never crashes the dev server.

<!-- jollimemory-summary-start -->


## E2E Test (4)
<details>
<summary><strong>1. Hot reload triggers re-sync when a source file is edited</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a docs source folder with at least one markdown file ready. Make sure the jolli CLI is installed from this branch.

**Steps:**
1. Open a terminal and run the dev command pointing at your docs folder (e.g. "jolli dev ./my-docs").
2. Wait for the terminal to show the "Watching source folder for changes…" message and for the dev server to start.
3. Open one of the markdown files in your docs folder in any text editor and add a new line of text, then save the file.
4. Switch back to the terminal and wait a moment (about 1–2 seconds).
5. Check the terminal output for a sync confirmation message.

**Expected Results:**
- The terminal should display a line like "↻ Synced 3 files" shortly after the file is saved, without restarting the dev server.
- The dev server should continue running normally — no crash or restart message should appear.

</blockquote>
</details>
<details>
<summary><strong>2. Ignored-file count appears in sync message when editor temp files are present</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a docs source folder ready and the jolli CLI running in dev mode (see previous scenario). Your text editor must create temporary/swap files on save (common editors like Vim create ".swp" files; macOS may create ".DS_Store" files).

**Steps:**
1. Run the dev command pointing at your docs folder: "jolli dev ./my-docs".
2. Wait for the "Watching source folder for changes…" message and the dev server to start.
3. Edit and save a markdown file using an editor that creates swap or temp files (e.g. Vim, which creates a ".swp" file alongside the real file).
4. Watch the terminal output after saving.

**Expected Results:**
- The sync message should show the number of real files synced AND a note about ignored files in parentheses, for example: "↻ Synced 2 files (1 ignored)".
- If no temp files were created, the message should show only "↻ Synced 2 files" with no parenthetical — the ignored count should not appear when it is zero.

</blockquote>
</details>
<details>
<summary><strong>3. Watcher shuts down cleanly when the dev server stops</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a docs source folder ready and the jolli CLI installed from this branch.

**Steps:**
1. Open a terminal and run "jolli dev ./my-docs".
2. Wait for the dev server to start and the "Watching source folder for changes…" message to appear.
3. Press Ctrl+C in the terminal to stop the dev server.
4. After the process exits, edit and save a file in the docs folder.
5. Wait 3–5 seconds and check the terminal.

**Expected Results:**
- The terminal process should exit cleanly with no error messages about the watcher.
- After stopping, saving a file should produce no further output in the terminal — the watcher should be fully shut down.

</blockquote>
</details>
<details>
<summary><strong>4. Dev server continues running after a temporary file-read error</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a docs source folder with a valid "site.json" configuration file ready.

**Steps:**
1. Run "jolli dev ./my-docs" and wait for the dev server to start.
2. While the server is running, briefly rename or temporarily corrupt the "site.json" file in your docs folder (for example, rename it to "site.json.bak"), then immediately save a markdown file to trigger a sync.
3. Wait 2–3 seconds and check the terminal output.
4. Restore "site.json" to its original name and save a markdown file again.
5. Wait 2–3 seconds and check the terminal output again.

**Expected Results:**
- After step 2, the terminal should show an error message describing the problem (e.g. mentioning the missing or unreadable config), but the dev server should keep running — no crash or exit.
- After step 4, the terminal should show a normal "↻ Synced X files" message, confirming the watcher recovered automatically.

</blockquote>
</details>

---

## Topic (1)
<details>
<summary><strong>01 · Address code review suggestions for hot-reload file watcher</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

A code review of the hot-reload feature surfaced several improvement suggestions that the user wanted implemented before merging: better ignore patterns for editor temp files, clearer logging when files are skipped, and a comment explaining a subtle loop bound.

**💡 Decisions Behind the Code**

- **Ignored file patterns**: Common editor temp files and OS metadata files were added to the static ignore list rather than making the list user-configurable, keeping the feature zero-config for the common case while eliminating the most frequent sources of spurious re-syncs.
- **Ignored count in log**: The suffix is only appended when the ignored count is greater than zero, avoiding noise in the typical case while surfacing the information exactly when it would be confusing to the user.
- **Loop comment over refactor**: The drain loop was left structurally unchanged; a comment was added instead of rewriting the loop, because the logic is correct and the only concern was future-reader confusion about the iteration bound.

**✅ What Was Implemented**

- `SourceWatcher.ts`: Added `.DS_Store`, `*.swp`, and `*~` to the built-in chokidar ignore list to prevent unnecessary re-syncs from editor artifacts and macOS metadata files.
- `SourceWatcher.ts`: Added a comment above the `drain` loop explaining that it is bounded to at most 2 iterations because the debounce timer can only set the dirty flag once between iterations.
- `StartCommand.ts`: Extended the sync log line to include an ignored-file count when non-zero (e.g. `↻ Synced 5 files (2 ignored)`), so users understand why a file they added may not appear in the count.

**📁 FILES**
- `cli/src/site/SourceWatcher.ts`
- `cli/src/commands/StartCommand.ts`

</blockquote>
</details>

---

*Generated by Jolli Memory · May 5, 2026 at 3:29 PM*
<!-- jollimemory-summary-end -->