### PR TITLE
feat(cli): add header dropdowns + footer config to site.json

### DIFF
--- a/cli/src/site/NextraProjectWriter.test.ts
+++ b/cli/src/site/NextraProjectWriter.test.ts
@@ -226,6 +226,178 @@ describe("NextraProjectWriter.generateLayout", () => {
 		expect(result).toContain("Test");
 		expect(result).toContain("Desc");
 	});
+
+	// ── header / footer (post-1392 schema) ────────────────────────────────────
+
+	it("renders header.items direct links the same way as legacy nav", async () => {
+		const { generateLayout } = await import("./NextraProjectWriter.js");
+		const result = generateLayout({
+			title: "T",
+			description: "D",
+			nav: [],
+			header: { items: [{ label: "Guides", url: "/guides" }] },
+		});
+		expect(result).toContain('<a href={"/guides"}');
+		expect(result).toContain('{"Guides"}');
+	});
+
+	it("prefers header.items over the legacy nav shorthand when both are set", async () => {
+		const { generateLayout } = await import("./NextraProjectWriter.js");
+		const result = generateLayout({
+			title: "T",
+			description: "D",
+			nav: [{ label: "FromNav", href: "/nav" }],
+			header: { items: [{ label: "FromHeader", url: "/header" }] },
+		});
+		expect(result).toContain("FromHeader");
+		expect(result).not.toContain("FromNav");
+	});
+
+	it("renders a <details> dropdown when a header item has sub-items", async () => {
+		const { generateLayout } = await import("./NextraProjectWriter.js");
+		const result = generateLayout({
+			title: "T",
+			description: "D",
+			nav: [],
+			header: {
+				items: [
+					{
+						label: "Resources",
+						items: [
+							{ label: "Blog", url: "/blog" },
+							{ label: "Changelog", url: "/changelog" },
+						],
+					},
+				],
+			},
+		});
+		expect(result).toContain("<details");
+		expect(result).toContain("<summary");
+		expect(result).toContain('{"Resources"}');
+		expect(result).toContain('{"Blog"}');
+		expect(result).toContain('{"Changelog"}');
+		expect(result).toContain('<a href={"/blog"}');
+	});
+
+	it("emits a bare <Footer /> when no footer config is provided (back-compat)", async () => {
+		const { generateLayout } = await import("./NextraProjectWriter.js");
+		const result = generateLayout(SAMPLE_CONFIG);
+		expect(result).toContain("footer={<Footer />}");
+	});
+
+	it("emits a bare <Footer /> when footer is set but has no rendering content", async () => {
+		const { generateLayout } = await import("./NextraProjectWriter.js");
+		const result = generateLayout({
+			title: "T",
+			description: "D",
+			nav: [],
+			footer: { columns: [], socialLinks: {} },
+		});
+		expect(result).toContain("footer={<Footer />}");
+	});
+
+	it("renders footer copyright text", async () => {
+		const { generateLayout } = await import("./NextraProjectWriter.js");
+		const result = generateLayout({
+			title: "T",
+			description: "D",
+			nav: [],
+			footer: { copyright: "2026 Acme Inc." },
+		});
+		expect(result).toContain("<Footer>");
+		expect(result).toContain('{"2026 Acme Inc."}');
+	});
+
+	it("renders footer columns with titles and links", async () => {
+		const { generateLayout } = await import("./NextraProjectWriter.js");
+		const result = generateLayout({
+			title: "T",
+			description: "D",
+			nav: [],
+			footer: {
+				columns: [
+					{
+						title: "Product",
+						links: [
+							{ label: "Pricing", url: "/pricing" },
+							{ label: "Docs", url: "/docs" },
+						],
+					},
+				],
+			},
+		});
+		expect(result).toContain('{"Product"}');
+		expect(result).toContain('{"Pricing"}');
+		expect(result).toContain('<a href={"/pricing"}');
+		expect(result).toContain('<a href={"/docs"}');
+	});
+
+	it("renders footer social links in canonical platform order, skipping unset ones", async () => {
+		const { generateLayout } = await import("./NextraProjectWriter.js");
+		const result = generateLayout({
+			title: "T",
+			description: "D",
+			nav: [],
+			footer: { socialLinks: { youtube: "https://yt.example", github: "https://gh.example" } },
+		});
+		// github appears before youtube in SOCIAL_PLATFORMS; verify ordering survived.
+		const ghIdx = result.indexOf("gh.example");
+		const ytIdx = result.indexOf("yt.example");
+		expect(ghIdx).toBeGreaterThan(-1);
+		expect(ytIdx).toBeGreaterThan(-1);
+		expect(ghIdx).toBeLessThan(ytIdx);
+		expect(result).toContain('aria-label={"github"}');
+		expect(result).toContain('aria-label={"youtube"}');
+		expect(result).not.toContain('aria-label={"twitter"}');
+	});
+
+	it("sanitizes javascript: URLs in header items to '#'", async () => {
+		const { generateLayout } = await import("./NextraProjectWriter.js");
+		const result = generateLayout({
+			title: "T",
+			description: "D",
+			nav: [],
+			header: { items: [{ label: "Bad", url: "javascript:alert(1)" }] },
+		});
+		expect(result).not.toContain("javascript:alert");
+		expect(result).toContain('<a href={"#"}');
+	});
+
+	it("sanitizes javascript: URLs in dropdown sub-items to '#'", async () => {
+		const { generateLayout } = await import("./NextraProjectWriter.js");
+		const result = generateLayout({
+			title: "T",
+			description: "D",
+			nav: [],
+			header: {
+				items: [
+					{
+						label: "Menu",
+						items: [{ label: "Bad", url: "JAVASCRIPT:alert(1)" }],
+					},
+				],
+			},
+		});
+		expect(result).not.toMatch(/javascript:alert/i);
+		expect(result).toContain('<a href={"#"}');
+	});
+
+	it("sanitizes javascript: URLs in footer column links and social links", async () => {
+		const { generateLayout } = await import("./NextraProjectWriter.js");
+		const result = generateLayout({
+			title: "T",
+			description: "D",
+			nav: [],
+			footer: {
+				columns: [{ title: "X", links: [{ label: "Bad", url: "javascript:alert(1)" }] }],
+				socialLinks: { github: "data:text/html,evil" },
+			},
+		});
+		expect(result).not.toContain("javascript:alert");
+		expect(result).not.toContain("data:text/html");
+		// Both unsafe URLs should have been replaced with "#".
+		expect(result.match(/<a href={"#"}/g)?.length).toBeGreaterThanOrEqual(2);
+	});
 });
 
 // ─── generateMdxComponents unit tests ────────────────────────────────────────
@@ -569,8 +741,18 @@ describe("Property 5: site.json fields are preserved in generated Nextra config"
 		);
 	});
 
-	it("generateLayout always contains all nav item hrefs", async () => {
+	it("generateLayout always contains the sanitized form of every nav item href", async () => {
 		const { generateLayout } = await import("./NextraProjectWriter.js");
+
+		// sanitizeUrl trims whitespace and replaces non-safe schemes with "#".
+		// The output embeds each href via JSON.stringify(sanitizeUrl(href)).
+		function expectedHref(href: string): string {
+			const trimmed = href.trim();
+			if (trimmed === "" || /^(?:https?:|mailto:|tel:|[#?/]|\.\.?\/)/i.test(trimmed)) {
+				return JSON.stringify(trimmed);
+			}
+			return JSON.stringify("#");
+		}
 
 		fc.assert(
 			fc.property(
@@ -580,7 +762,7 @@ describe("Property 5: site.json fields are preserved in generated Nextra config"
 				(title, description, nav) => {
 					const config = { title, description, nav };
 					const result = generateLayout(config);
-					return nav.every(({ href }) => result.includes(href));
+					return nav.every(({ href }) => result.includes(expectedHref(href)));
 				},
 			),
 			{ numRuns: 100 },

--- a/cli/src/site/NextraProjectWriter.ts
+++ b/cli/src/site/NextraProjectWriter.ts
@@ -15,6 +15,7 @@
 import { existsSync } from "node:fs";
 import { mkdir, writeFile } from "node:fs/promises";
 import { join } from "node:path";
+import type { FooterConfig, HeaderConfig, HeaderItem, NavLink } from "./Types.js";
 
 // ─── NextraProjectConfig ──────────────────────────────────────────────────────
 
@@ -25,7 +26,9 @@ import { join } from "node:path";
 export interface NextraProjectConfig {
 	title: string;
 	description: string;
-	nav: Array<{ label: string; href: string }>;
+	nav: NavLink[];
+	header?: HeaderConfig;
+	footer?: FooterConfig;
 }
 
 // ─── initNextraProject ────────────────────────────────────────────────────────
@@ -133,31 +136,149 @@ export default withNextra({${exportLines}
 `;
 }
 
+// ─── generateLayout helpers ──────────────────────────────────────────────────
+
+/** Social platforms supported in the footer, in display order. */
+const SOCIAL_PLATFORMS = ["github", "twitter", "discord", "linkedin", "youtube"] as const;
+
+/**
+ * Allow http(s), mailto, tel, fragments, query strings, and absolute or
+ * relative paths. Anything else (e.g. `javascript:`, `data:`, `vbscript:`)
+ * is replaced with `"#"` so a malicious site.json can't inject a script URL.
+ */
+function sanitizeUrl(url: string): string {
+	const trimmed = url.trim();
+	if (trimmed === "" || /^(?:https?:|mailto:|tel:|[#?/]|\.\.?\/)/i.test(trimmed)) {
+		return trimmed;
+	}
+	return "#";
+}
+
+/**
+ * Resolves the navbar's logical item list. `header.items` wins when set;
+ * otherwise the legacy flat `nav` is coerced into dropdown-less items so
+ * pre-`header` site.json files keep rendering unchanged.
+ */
+function resolveHeaderItems(config: NextraProjectConfig): HeaderItem[] {
+	if (config.header?.items && config.header.items.length > 0) {
+		return config.header.items;
+	}
+	return config.nav.map((n) => ({ label: n.label, url: n.href }));
+}
+
+/** Renders a single header item — either an `<a>` or a `<details>` dropdown. */
+function renderNavbarChild(item: HeaderItem): string {
+	const jsLabel = JSON.stringify(item.label);
+	if (item.items && item.items.length > 0) {
+		const subLinks = item.items
+			.map((sub) => {
+				const jsSubLabel = JSON.stringify(sub.label);
+				const jsSubHref = JSON.stringify(sanitizeUrl(sub.url));
+				return `              <a href={${jsSubHref}} style={{ display: 'block', padding: '0.25rem 0.75rem', whiteSpace: 'nowrap' }}>{${jsSubLabel}}</a>`;
+			})
+			.join("\n");
+		return [
+			`          <details style={{ marginLeft: '1rem', display: 'inline-block', position: 'relative' }}>`,
+			`            <summary style={{ cursor: 'pointer', listStyle: 'none' }}>{${jsLabel}}</summary>`,
+			`            <div style={{ position: 'absolute', top: '100%', left: 0, marginTop: '0.25rem', background: 'var(--nextra-bg, #fff)', border: '1px solid var(--nextra-border, #e5e7eb)', borderRadius: 4, padding: '0.25rem 0', minWidth: 160, zIndex: 10 }}>`,
+			subLinks,
+			`            </div>`,
+			`          </details>`,
+		].join("\n");
+	}
+	const jsHref = JSON.stringify(sanitizeUrl(item.url ?? "#"));
+	return `          <a href={${jsHref}} style={{ marginLeft: '1rem' }}>{${jsLabel}}</a>`;
+}
+
+/** Builds the inner JSX of `<Footer>`, or `""` when there's nothing to render. */
+function buildFooterBody(footer: FooterConfig | undefined): string {
+	if (!footer) return "";
+
+	const hasColumns = footer.columns && footer.columns.length > 0;
+	const hasCopyright = typeof footer.copyright === "string" && footer.copyright.length > 0;
+	const socials = footer.socialLinks;
+	const socialEntries = socials
+		? SOCIAL_PLATFORMS.filter((p) => typeof socials[p] === "string" && socials[p] !== "")
+		: [];
+	const hasSocial = socialEntries.length > 0;
+
+	if (!hasColumns && !hasCopyright && !hasSocial) return "";
+
+	const blocks: string[] = [];
+
+	if (hasColumns) {
+		const columnsJsx = (footer.columns ?? [])
+			.map((col) => {
+				const jsTitle = JSON.stringify(col.title);
+				const links = col.links
+					.map((link) => {
+						const jsLabel = JSON.stringify(link.label);
+						const jsHref = JSON.stringify(sanitizeUrl(link.url));
+						return `                <li><a href={${jsHref}}>{${jsLabel}}</a></li>`;
+					})
+					.join("\n");
+				return [
+					`            <div style={{ minWidth: 140 }}>`,
+					`              <h4 style={{ margin: '0 0 0.5rem', fontSize: '0.875rem', fontWeight: 600 }}>{${jsTitle}}</h4>`,
+					`              <ul style={{ listStyle: 'none', padding: 0, margin: 0 }}>`,
+					links,
+					`              </ul>`,
+					`            </div>`,
+				].join("\n");
+			})
+			.join("\n");
+		blocks.push(
+			`          <div style={{ display: 'flex', gap: '2rem', flexWrap: 'wrap', marginBottom: '1rem' }}>\n${columnsJsx}\n          </div>`,
+		);
+	}
+
+	if (hasCopyright || hasSocial) {
+		const bottom: string[] = [];
+		if (hasCopyright) {
+			const jsCopyright = JSON.stringify(footer.copyright);
+			bottom.push(`            <span>{${jsCopyright}}</span>`);
+		}
+		if (hasSocial && socials) {
+			const social = socialEntries
+				.map((p) => {
+					const jsHref = JSON.stringify(sanitizeUrl(socials[p] ?? ""));
+					const jsLabel = JSON.stringify(p);
+					return `              <a href={${jsHref}} aria-label={${jsLabel}}>{${jsLabel}}</a>`;
+				})
+				.join("\n");
+			bottom.push(`            <div style={{ display: 'flex', gap: '0.75rem' }}>\n${social}\n            </div>`);
+		}
+		blocks.push(
+			`          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', flexWrap: 'wrap', gap: '1rem' }}>\n${bottom.join("\n")}\n          </div>`,
+		);
+	}
+
+	return [`        <div style={{ width: '100%' }}>`, ...blocks, `        </div>`].join("\n");
+}
+
 // ─── generateLayout ──────────────────────────────────────────────────────────
 
 /**
  * Returns the contents of `app/layout.tsx` — the root layout for the Nextra v4
  * docs theme.
  *
- * Maps `title`, `description`, and `nav` from `site.json` into the Nextra
- * Layout, Navbar, and Footer components.
+ * Maps `title`, `description`, `nav` / `header`, and `footer` from `site.json`
+ * into the Nextra Layout, Navbar, and Footer components. `nav` is the legacy
+ * flat shorthand; `header.items` (which supports per-item dropdowns) wins
+ * when set.
  */
 export function generateLayout(config: NextraProjectConfig): string {
-	const { title, description, nav } = config;
+	const { title, description } = config;
 
 	const jsTitle = JSON.stringify(title);
 	const jsDescription = JSON.stringify(description);
 
-	// Build navbar children from nav items (Navbar uses `children` for extra content).
-	const navLinks = nav
-		.map(({ label, href }) => {
-			const jsLabel = JSON.stringify(label);
-			const jsHref = JSON.stringify(href);
-			return `          <a href={${jsHref}} style={{ marginLeft: '1rem' }}>{${jsLabel}}</a>`;
-		})
-		.join("\n");
+	const headerItems = resolveHeaderItems(config);
+	const navLinks = headerItems.map(renderNavbarChild).join("\n");
+	const navbarChildren = headerItems.length > 0 ? `\n${navLinks}\n        ` : "";
 
-	const navbarChildren = nav.length > 0 ? `\n${navLinks}\n        ` : "";
+	const footerBody = buildFooterBody(config.footer);
+	const footerJsx = footerBody === "" ? `<Footer />` : `<Footer>\n${footerBody}\n      </Footer>`;
 
 	return `import { Footer, Layout, Navbar } from 'nextra-theme-docs'
 import { Head } from 'nextra/components'
@@ -179,7 +300,7 @@ export default async function RootLayout({ children }: { children: React.ReactNo
             <Navbar logo={<b>{${jsTitle}}</b>}>${navbarChildren}</Navbar>
           }
           pageMap={await getPageMap()}
-          footer={<Footer />}
+          footer={${footerJsx}}
         >
           {children}
         </Layout>

--- a/cli/src/site/Types.ts
+++ b/cli/src/site/Types.ts
@@ -7,10 +7,57 @@
 /** File classification used by ContentMirror to categorize source files */
 export type FileType = "markdown" | "openapi" | "image" | "ignored";
 
-/** A navigation bar link entry in site.json */
+/** A navigation bar link entry in site.json (legacy flat shorthand for `header.items`). */
 export interface NavLink {
 	label: string;
 	href: string;
+}
+
+/**
+ * A simple labelled URL — used as a footer-column link, a header-dropdown
+ * sub-item, etc. Matches the SaaS `ExternalLink` shape (minus the editor-only
+ * `id` field, which the CLI doesn't need).
+ */
+export interface ExternalLink {
+	label: string;
+	url: string;
+}
+
+/**
+ * Header navbar item — direct link (`url`) OR dropdown (`items`),
+ * mutually exclusive. Matches the SaaS `HeaderNavItem` shape.
+ */
+export interface HeaderItem {
+	label: string;
+	url?: string;
+	items?: ExternalLink[];
+}
+
+/** Header navigation config in site.json. */
+export interface HeaderConfig {
+	items: HeaderItem[];
+}
+
+/** A footer column with a heading and a list of links. */
+export interface FooterColumn {
+	title: string;
+	links: ExternalLink[];
+}
+
+/** Social-icon URLs rendered alongside footer columns. */
+export interface SocialLinks {
+	github?: string;
+	twitter?: string;
+	discord?: string;
+	linkedin?: string;
+	youtube?: string;
+}
+
+/** Footer config in site.json. */
+export interface FooterConfig {
+	copyright?: string;
+	columns?: FooterColumn[];
+	socialLinks?: SocialLinks;
 }
 
 /**
@@ -45,7 +92,22 @@ export type PathMappings = Record<string, string>;
 export interface SiteJson {
 	title: string;
 	description: string;
+	/**
+	 * Flat navbar shorthand. When `header` is also present, `header.items`
+	 * wins; otherwise these entries are coerced into header dropdown-less
+	 * items at render time so existing CLI sites keep working unchanged.
+	 */
 	nav: NavLink[];
+	/**
+	 * Header navbar — supports per-item dropdowns. Mirrors the SaaS
+	 * `HeaderLinksConfig` shape so a single `site.json` works in both systems.
+	 */
+	header?: HeaderConfig;
+	/**
+	 * Site footer — copyright, columns of links, and social-icon URLs.
+	 * Mirrors the SaaS `FooterConfig` shape.
+	 */
+	footer?: FooterConfig;
 	sidebar?: SidebarOverrides;
 	pathMappings?: PathMappings;
 	favicon?: string;


### PR DESCRIPTION
## Summary

Extend the Nextra site scaffold to support richer header navigation and a configurable footer, matching the SaaS platform's `site.json` schema so a single config works in both systems.

- **Header**: `header.items` supports per-item `<details>` dropdowns alongside direct links. Legacy flat `nav` is coerced into the new schema for backwards compat.
- **Footer**: `footer` supports `copyright`, `columns` (title + links), and `socialLinks` (rendered in canonical platform order: github, twitter, discord, linkedin, youtube).
- **Security**: All URLs from `site.json` are sanitized via an allowlist regex — `javascript:`, `data:`, `vbscript:` are replaced with `"#"`.

## Changes

- `Types.ts` — New types: `ExternalLink`, `HeaderItem`, `HeaderConfig`, `FooterColumn`, `SocialLinks`, `FooterConfig`. Added `header?` and `footer?` to `SiteJson`.
- `NextraProjectWriter.ts` — `sanitizeUrl()`, `resolveHeaderItems()`, `renderNavbarChild()`, `buildFooterBody()` helpers. Updated `generateLayout()` to use them.
- `NextraProjectWriter.test.ts` — 12 new tests covering header links, dropdowns, footer columns, social links, and XSS sanitization in all URL positions.

## Testing

- [x] 73/73 unit tests pass (including property-based tests)
- [x] Biome lint clean
- [x] Manually tested with `jolli dev` — header dropdowns and footer render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)