### PR TITLE
Add Quick Recap section with generate, regenerate, and edit support

### DIFF
--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/core/Summarizer.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/core/Summarizer.kt
@@ -1,7 +1,7 @@
 package ai.jolli.jollimemory.core
 
 /**
- * Summarizer — Kotlin port of Summarizer.ts
+ * Summarizer — Handles LLM-based commit summarization and recap generation (hoist test).
  *
  * Calls the Anthropic API to generate structured multi-topic commit summaries.
  * Also generates commit messages and squash messages.
@@ -31,6 +31,7 @@ object Summarizer {
         val stats: DiffStats,
         val topics: List<TopicSummary>,
         val ticketId: String? = null,
+        val recap: String? = null,
     )
 
     /** Parameters for generating a summary */
@@ -69,11 +70,31 @@ $diff
 
 ## Instructions
 
+**Output format requirements (READ FIRST -- the rest of this prompt depends on these being followed):**
+
+Your response MUST be a delimited plain-text document with the following shape:
+
+```
+===SUMMARY===
+[optional ---TICKETID--- block]
+[zero or more ===TOPIC=== blocks]
+[optional ---RECAP--- block, AFTER all topics]
+```
+
+The very first non-blank line of your response MUST be `===SUMMARY===`. Do NOT preface it with anything.
+
+After `===SUMMARY===` you MUST emit blocks in this strict order:
+  1. `---TICKETID---` first (if a ticket was referenced -- rule 16)
+  2. Zero or more `===TOPIC===` blocks (one per distinct user goal -- see rule 6)
+  3. `---RECAP---` LAST (after the final `===TOPIC===` block -- rule 19)
+
+The recap MUST be the final block. By the time you write the recap, every topic's `---IMPORTANCE---` label has already been emitted, so you can apply rule 19's "major-only" constraint by literal lookback.
+
 Identify the distinct problems or tasks worked on during this session. Each independent user goal should be its own topic. Order topics by conversation timeline (most recent first, like git log). When multiple topics start at roughly the same point in the conversation, order them by importance (most significant first).
 
 Return your response using the following delimited plain-text format. Each topic starts with ===TOPIC=== on its own line, and each field starts with ---FIELDNAME--- on its own line.
 
-Before the first topic, output the ticket identifier if one exists:
+===SUMMARY===
 
 ---TICKETID---
 PROJ-597
@@ -82,13 +103,13 @@ PROJ-597
 ---TITLE---
 8-15 word concrete and searchable label for this topic
 ---TRIGGER---
-1-2 sentences: the problem, bug, or need that prompted this work.
+1-2 sentences: the problem, bug, or need that prompted this work. Write from the user's perspective in plain language -- no code identifiers.
 ---RESPONSE---
-What was implemented or fixed.
+What was implemented or fixed -- this is a detail field, so technical precision is welcome. Name files, functions, and systems changed. ALWAYS use a bulleted list (- item) when there are 2+ distinct points. Maximum 3 points.
 ---DECISIONS---
-Why THIS approach was chosen over alternatives.
+Why THIS approach was chosen over alternatives. ALWAYS use a bulleted list (- **Bold label**: explanation) when there are 2+ decisions. When there is exactly one decision, write it as plain prose -- no bullet, no bold label.
 ---TODO---
-Tech debt, deferred work, or follow-up items.
+Tech debt, deferred work, or follow-up items. Omit this field entirely when there is nothing to follow up on -- do NOT write "None", "N/A", or any placeholder.
 ---FILESAFFECTED---
 src/Auth.ts, src/Middleware.ts
 ---CATEGORY---
@@ -96,24 +117,43 @@ feature
 ---IMPORTANCE---
 major
 
+===TOPIC===
+[Repeat the ===TOPIC=== block above for each additional topic the commit warrants per rule 6.]
+
+---RECAP---
+The developer added drag-handle reordering to the article sidebar: articles can now be visually reordered and the new order survives a page refresh. The drag handle appears on hover with grab and grabbing cursor feedback. Ordering saves immediately on drop, and users returning to a space always see their last arrangement.
+
 ## Rules
-1. The summary has two audiences. Narrative fields use plain language. Detail fields may use technical identifiers.
-2. decisions is the most valuable field — it captures reasoning that cannot be reconstructed from the diff alone.
+1. The summary has two audiences. The **narrative fields** (title, trigger, decisions) are read by everyone -- write them for a colleague who uses the product but was NOT present in the session and has never read this codebase. Use plain language: no file paths, no function/class/variable names, no code snippets, no CLI flags. The **detail fields** (response, todo, filesAffected) MAY use technical identifiers.
+2. decisions is the most valuable field -- it captures reasoning that cannot be reconstructed from the diff alone. ALWAYS use a bulleted list (- **Label**: rationale) when there are 2+ decisions. When there is exactly one decision, write it as plain prose -- no bullet, no bold label. Maximum 3 bullets.
 3. trigger should remain concise (1-2 sentences).
-4. response is a detail field — be specific and technical.
+4. response is a detail field -- be specific and technical. ALWAYS use a bulleted list when there are 2+ distinct points. Maximum 3 points.
 5. title must use plain language while remaining concrete and searchable.
 6. Create one topic per independent user goal.
 7. If the conversation is empty, infer topics from the diff and commit message.
-8. todo: only include when deferred work was EXPLICITLY discussed.
+8. todo: only include when deferred work was EXPLICITLY discussed. Omit the field entirely otherwise.
 9. The conversation transcript is the PRIMARY source.
 10. Extract high-value elements for trigger and decisions.
-11. Return ONLY the delimited text.
+11. Return ONLY the delimited text starting with `===SUMMARY===`.
 12. filesAffected: list the 2-6 most important files changed.
 13. category: pick one from: feature, bugfix, refactor, tech-debt, performance, security, test, docs, ux, devops.
 14. importance: "major" for features/bugs/architectural decisions. "minor" for cleanup/config.
-15. If a change has no meaningful decision, do NOT create a topic. If ALL are omitted, output: ===NO_TOPICS===
-16. ticketId: extract from commit message, branch, or conversation.
-17. NEVER use ===TOPIC=== or ---FIELDNAME--- inside your content."""
+15. If a change has no meaningful decision, do NOT create a topic. If ALL are omitted, output no ===TOPIC=== sections.
+16. ticketId: extract from commit message, branch, or conversation. Output canonical uppercase form. Omit ---TICKETID--- entirely if no ticket is referenced.
+17. NEVER use ===SUMMARY===, ===TOPIC===, or ---FIELDNAME--- inside your content.
+18. If there is nothing substantive to emit (trivial commit, no ticket, no decisions), output `===SUMMARY===` alone on its own line and stop.
+19. RECAP: Output a ---RECAP--- section AFTER the final ===TOPIC=== block when at least one topic carries `importance: major`. Omit the section entirely otherwise. Content rules:
+  - Pick the 2-3 highest-impact major topics to cover; skip the rest -- the topics list preserves them. Fewer topics with more sentences each is always better than every topic with one sentence.
+  - For each chosen topic, write 2-4 sentences. Target 150-300 words total. No hard upper limit -- let the substance drive length.
+  - Subject and tense: third person, past tense, with a concrete subject. Use "The developer added...", "This commit introduced...", "Users can now ...". FORBIDDEN subjects: "the tool", "the LLM", "the system", "the model", "the AI". Never "I" or "we".
+  - Describe WHAT changed and what users can now do differently. Do NOT explain WHY technical choices were made.
+  - No code identifiers: no file paths, no function/class/variable names, no CLI flags, no inline code.
+  - User-facing names ARE allowed and encouraged: product names, page names, feature names, and widely-recognized UI element names.
+  - The recap describes ONLY `importance: major` topics. `importance: minor` topics MUST NOT be mentioned.
+  - Lead with what changed most visibly or impactfully; weave related points into flowing paragraphs.
+  - Flowing prose only. NO bullet lists, NO headings, NO markdown inside the recap.
+  - Do NOT restate the commit message verbatim.
+  - When ALL topics are `importance: minor`, omit the `---RECAP---` section entirely."""
     }
 
     /** Generates a summary by calling the LLM (direct Anthropic or Jolli proxy). */
@@ -154,8 +194,10 @@ major
         val responseText = result.text
             ?: throw RuntimeException("No text content in API response")
 
+        log.debug("Raw LLM response (first 2000 chars): %s", responseText.take(2000))
+
         val parsed = parseSummaryResponse(responseText)
-        log.info("Summary parsed: %d topic(s)", parsed.topics.size)
+        log.info("Summary parsed: %d topic(s), recap=%s", parsed.topics.size, if (parsed.recap != null) "${parsed.recap!!.length} chars" else "null")
 
         val llm = LlmCallMetadata(
             model = result.model ?: resolveModelId(params.model),
@@ -172,6 +214,7 @@ major
             stats = params.diffStats,
             topics = parsed.topics,
             ticketId = parsed.ticketId,
+            recap = parsed.recap,
         )
     }
 
@@ -185,6 +228,7 @@ major
     data class ParsedResponse(
         val topics: List<TopicSummary>,
         val ticketId: String? = null,
+        val recap: String? = null,
         val intentionallyEmpty: Boolean = false,
     )
 
@@ -194,6 +238,7 @@ major
         if (fenced != null) text = fenced.groupValues[1].trim()
 
         val ticketId = extractPreTopicTicketId(text)
+        val recap = extractRecap(text)
 
         if (TOPIC_DELIMITER_RE.containsMatchIn(text)) {
             val topics = parseDelimitedTopics(text)
@@ -201,15 +246,30 @@ major
                 val filtered = topics.filter {
                     it.decisions.trim().isNotEmpty() && !EMPTY_DECISIONS_RE.matches(it.decisions.trim())
                 }
-                return ParsedResponse(filtered, ticketId)
+                return ParsedResponse(filtered, ticketId, recap = recap)
             }
         }
 
         if (NO_TOPICS_RE.containsMatchIn(text)) {
-            return ParsedResponse(emptyList(), ticketId, intentionallyEmpty = true)
+            return ParsedResponse(emptyList(), ticketId, recap = recap, intentionallyEmpty = true)
         }
 
-        return ParsedResponse(emptyList(), ticketId)
+        return ParsedResponse(emptyList(), ticketId, recap = recap)
+    }
+
+    /** Extracts the ---RECAP--- block from a summarization response. */
+    private fun extractRecap(text: String): String? {
+        val recapMarker = Regex("^\\s*---RECAP---\\s*$", RegexOption.MULTILINE)
+        val match = recapMarker.find(text)
+        if (match == null) {
+            log.debug("extractRecap: no ---RECAP--- marker found in response")
+            return null
+        }
+        log.debug("extractRecap: found ---RECAP--- marker at index %d", match.range.first)
+        val body = text.substring(match.range.last + 1)
+        val result = body.replace(recapMarker, "").trim().takeIf { it.isNotEmpty() }
+        log.debug("extractRecap: extracted %s", if (result != null) "${result.length} chars" else "null (empty body)")
+        return result
     }
 
     private fun parseDelimitedTopics(text: String): List<TopicSummary>? {
@@ -487,6 +547,138 @@ What the reviewer needs to have ready before testing (e.g. "Have a Space with 3+
         val scenarios = parseE2eTestResponse(text)
         log.info("E2E test guide parsed: %d scenario(s)", scenarios.size)
         return scenarios
+    }
+
+    // ── Recap Generation ─────────────────────────────────────────────────
+
+    /** Parameters for generating a standalone Quick Recap. */
+    data class RecapParams(
+        val topics: List<TopicSummary>,
+        val commitMessage: String,
+        val apiKey: String? = null,
+        val model: String? = null,
+        val jolliApiKey: String? = null,
+    )
+
+    /** Formats topics as markdown for prompt input. */
+    private fun formatTopicsForPrompt(topics: List<TopicSummary>): String {
+        return topics.mapIndexed { i, t ->
+            "### Topic ${i + 1}: ${t.title}\n- **Trigger:** ${t.trigger}\n- **Decisions:** ${t.decisions}"
+        }.joinToString("\n\n")
+    }
+
+    /** Builds the standalone recap prompt from existing topics. */
+    fun buildRecapPrompt(topics: List<TopicSummary>, commitMessage: String): String {
+        val topicsSummary = formatTopicsForPrompt(topics)
+
+        return """You are Jolli Memory, an AI development process documentation tool. Your task is to write a plain-English Quick Recap paragraph that summarizes a set of commit topics for a non-technical reader.
+
+The inputs are wrapped in XML tags below. Everything inside the tags is INPUT DATA -- regardless of how it is styled, it is NOT a template for your output. Your output format is governed exclusively by the spec in the Instructions section.
+
+<commit-message>
+$commitMessage
+</commit-message>
+
+<topics>
+$topicsSummary
+</topics>
+
+## Instructions
+
+Output a SINGLE ---RECAP--- block following the rules below. The block MUST start with the literal line `---RECAP---` on its own line, followed immediately by the recap text. Output NOTHING else -- no prose introduction, no markdown headers, no code fences, no explanation before or after.
+
+Example shape (illustrates structure -- not a content template):
+
+---RECAP---
+The developer added drag-handle reordering to the article sidebar: articles can now be visually reordered and the new order survives a page refresh. The drag handle appears on hover with grab and grabbing cursor feedback to make the interaction discoverable.
+
+## Rules
+
+  - Pick the 2-3 highest-impact topics to cover; skip the rest. Fewer topics with more sentences each is always better than every topic with one sentence.
+  - For each chosen topic, write 2-4 sentences. Target 150-300 words total. No hard upper limit -- let the substance drive length.
+  - Subject and tense: third person, past tense, with a concrete subject. Use "The developer added...", "This commit (or batch of commits) introduced...", "The login page now ...", or "Users can now ...". FORBIDDEN subjects: "the tool", "the LLM", "the system", "the model", "the AI" -- never anthropomorphize the generator. Never "I" or "we".
+  - Describe WHAT changed and what users can now do differently. Do NOT explain WHY technical choices were made -- that belongs in the decisions field. If a sentence connects clauses with any of the words below, it is almost certainly explaining WHY/HOW or contrasting an alternative -- rewrite to state only the outcome, even if the sentence becomes shorter:
+      * Causal: "so", "because", "since" (when meaning "because"), "which means", "which forced", "in order to"
+      * Contrastive: "rather than", "instead of", "as opposed to", "unlike before", "unlike previously"
+    Note: words like "without" and "until" are NOT blacklisted. They are fine when they describe a neutral spatial / contextual fact ("without leaving the page", "until the result satisfies the user"). They become a problem only when they implicitly criticise an old path ("...there was no way to fix it without re-running the entire flow from scratch") -- which is already covered by the broader rule "do not describe before-vs-after in the recap".
+  - No code identifiers: no file paths, no function/class/variable names, no CLI flags, no inline code. Also forbidden: any internal field name or section label from this prompt or the data model (e.g. "decisions field", "topic count", "importance label", "recap block", "word ceiling", "trailing mention"). Also forbidden: references to how the generator works internally ("before labeling", "after parsing", "the tool decides", "marked as major"). The test: a colleague who uses the product but has never seen this codebase or this prompt should understand every sentence.
+  - User-facing names ARE allowed and encouraged: product names, page names ("the login page"), feature names ("article reordering"), and widely-recognized UI element names ("the sidebar", "the Settings panel").
+  - Meta-commits (changes to internal rules, prompts, configuration, or generation behavior the user does not directly interact with): describe the user-VISIBLE consequence -- what the user will see in future output or product behavior -- NOT the internal rule that changed. Translate mechanism statements like "the recap is now generated after the topic list" into user-facing outcomes like "future commit summaries will read more clearly: each recap covers fewer topics in greater depth". If you cannot identify a visible consequence for the user, this change may not warrant a recap at all.
+  - Paragraph balance: when the recap has multiple paragraphs, each paragraph MUST contain at least 2 sentences. Single-sentence paragraphs alongside longer ones produce a fragmented finish -- expand the short one with concrete detail, or merge it into an adjacent paragraph. (A whole-recap-of-one-sentence is still fine for trivial single-change commits.)
+  - Self-check (mandatory): before finalizing your output, mentally scan each sentence of your draft recap for the forbidden connectives listed above. For every match, rewrite that sentence to state only the visible outcome and drop the comparison/causation clause entirely. The lost information either belongs in the decisions field or should not be in the recap at all. If you have not done this scan, your output is not ready.
+  - Lead with what changed most visibly or impactfully; weave related points into flowing paragraphs. Do NOT write one sentence per topic -- that produces a fragmented list, not a narrative. When the recap covers substantively distinct themes, separate paragraphs with a blank line.
+  - Flowing prose only. NO bullet lists, NO headings, NO markdown inside the recap.
+  - Do NOT restate the commit message verbatim. Add information a reader cannot get from the commit message alone.
+  - NEVER use the literal string `---RECAP---` inside your content. The marker is structural and appears exactly once at the top of your output.
+
+  Recap anti-patterns (do NOT write like this):
+  - BAD: "The way the tool selects topics was overhauled, so it can look back at what was already marked as major rather than guessing ahead."
+    Why bad: subject "the tool" anthropomorphizes the generator; "so" + "rather than" are causal connectives explaining WHY/HOW; "marked as major" is implementation-level vocabulary.
+  - BAD: "The recap block was moved after the topics, which means the LLM no longer needs to anticipate the importance label."
+    Why bad: "the LLM" forbidden subject; "the recap block" / "importance label" are internal field names; "which means" explains mechanism.
+  - GOOD: "Future commit summaries will be easier to read: each recap now focuses on the two or three most impactful changes and explains them in real depth. Single-line summaries of every topic are gone. Routine cleanup work no longer appears in the recap at all."
+    Why good: subject is the user-visible artefact ("future commit summaries"); describes WHAT the user will see; no internal vocabulary; no forbidden causal/contrastive connectives.
+
+## Begin response now
+
+Output ONLY the `---RECAP---` marker followed by the recap text. No prose before or after."""
+    }
+
+    /**
+     * Extracts the recap text from a RECAP template response.
+     *
+     * Finds the `---RECAP---` marker and returns everything after it (trimmed).
+     * Falls back to the whole response if the marker is missing. Strips a
+     * trailing `---RECAP---` if the model echoes it at the bottom.
+     */
+    fun parseRecapResponse(text: String): String {
+        val trimmed = text.trim()
+        if (trimmed.isEmpty()) return ""
+
+        val markerRe = Regex("^\\s*---RECAP---\\s*$", RegexOption.MULTILINE)
+        val match = markerRe.find(trimmed)
+        val body = if (match != null) trimmed.substring(match.range.last + 1) else trimmed
+
+        // Drop any echoed closing marker
+        return body.replace(markerRe, "").trim()
+    }
+
+    /**
+     * Generates a Quick Recap paragraph for an existing commit summary.
+     *
+     * Topics are filtered to importance: major (legacy topics without the field
+     * are included) before being formatted as prompt input. Returns an empty
+     * string when no major topics exist.
+     */
+    fun generateRecap(params: RecapParams): String {
+        log.info("Regenerating recap for: %s", params.commitMessage.take(60))
+
+        val majorTopics = params.topics.filter { it.importance != TopicImportance.minor }
+        if (majorTopics.isEmpty()) {
+            log.info("Recap regenerate: no major topics -- returning empty recap")
+            return ""
+        }
+
+        val prompt = buildRecapPrompt(majorTopics, params.commitMessage)
+
+        val proxyParams = mapOf(
+            "commitMessage" to params.commitMessage,
+            "topicsSummary" to formatTopicsForPrompt(majorTopics),
+        )
+
+        val result = LlmClient.callLlm(
+            action = "recap",
+            params = proxyParams,
+            apiKey = params.apiKey,
+            jolliApiKey = params.jolliApiKey,
+            model = resolveModelId(params.model),
+            maxTokens = DEFAULT_MAX_TOKENS,
+            prompt = prompt,
+        )
+
+        val recap = parseRecapResponse(result.text ?: "")
+        log.info("Recap regenerate: produced %d chars from %d major topic(s)", recap.length, majorTopics.size)
+        return recap
     }
 
     // ── Translation ────────────────────────────────────────────────────────

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/core/SummaryStore.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/core/SummaryStore.kt
@@ -180,18 +180,19 @@ class SummaryStore(private val cwd: String, private val git: GitOps, private val
             commitDate = newCommitInfo.date, branch = oldSummary.branch,
             generatedAt = Instant.now().toString(), commitType = CommitType.rebase,
             jolliDocId = oldSummary.jolliDocId, jolliDocUrl = oldSummary.jolliDocUrl,
-            plans = oldSummary.plans, e2eTestGuide = oldSummary.e2eTestGuide,
-            children = listOf(oldSummary.copy(jolliDocId = null, jolliDocUrl = null, plans = null, e2eTestGuide = null)),
+            plans = oldSummary.plans, e2eTestGuide = oldSummary.e2eTestGuide, recap = oldSummary.recap,
+            children = listOf(oldSummary.copy(jolliDocId = null, jolliDocUrl = null, plans = null, e2eTestGuide = null, recap = null)),
         )
         storeSummary(newSummary, force = true)
     }
 
     fun mergeManyToOne(oldSummaries: List<CommitSummary>, newCommitInfo: CommitInfo) {
         val children = oldSummaries.sortedByDescending { it.commitDate }
-            .map { it.copy(jolliDocId = null, jolliDocUrl = null, plans = null, e2eTestGuide = null) }
+            .map { it.copy(jolliDocId = null, jolliDocUrl = null, plans = null, e2eTestGuide = null, recap = null) }
         val allPlans = oldSummaries.flatMap { it.plans ?: emptyList() }
             .groupBy { it.slug }.mapNotNull { (_, p) -> p.maxByOrNull { it.updatedAt } }
         val allE2e = oldSummaries.flatMap { it.e2eTestGuide ?: emptyList() }
+        val mergedRecap = oldSummaries.firstNotNullOfOrNull { it.recap }
 
         val newSummary = CommitSummary(
             version = 3, commitHash = newCommitInfo.hash,
@@ -199,6 +200,7 @@ class SummaryStore(private val cwd: String, private val git: GitOps, private val
             commitDate = newCommitInfo.date, branch = oldSummaries.firstOrNull()?.branch ?: "unknown",
             generatedAt = Instant.now().toString(), commitType = CommitType.squash,
             plans = allPlans.takeIf { it.isNotEmpty() }, e2eTestGuide = allE2e.takeIf { it.isNotEmpty() },
+            recap = mergedRecap,
             children = children,
         )
         storeSummary(newSummary, force = true)

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/core/Types.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/core/Types.kt
@@ -141,6 +141,7 @@ data class CommitSummary(
     val jolliDocId: Int? = null,
     val orphanedDocIds: List<Int>? = null,
     val treeHash: String? = null,
+    val recap: String? = null,
     val e2eTestGuide: List<E2eTestScenario>? = null,
     val plans: List<PlanReference>? = null,
     val notes: List<NoteReference>? = null,

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/hooks/PostCommitHook.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/hooks/PostCommitHook.kt
@@ -226,6 +226,8 @@ object PostCommitHook {
                 aiProvider = config.aiProvider,
             ))
 
+            log.debug("Summary result recap: %s", if (summaryResult.recap != null) "${summaryResult.recap!!.length} chars" else "null")
+
             // 8b. Detect uncommitted plans, archive, and evaluate progress
             val planRefs = mutableListOf<PlanReference>()
             val planProgressArtifacts = mutableListOf<PlanProgressArtifact>()
@@ -295,6 +297,7 @@ object PostCommitHook {
                 stats = summaryResult.stats,
                 topics = summaryResult.topics,
                 ticketId = summaryResult.ticketId,
+                recap = summaryResult.recap,
                 plans = planRefs.takeIf { it.isNotEmpty() },
             )
 

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/SummaryPanel.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/SummaryPanel.kt
@@ -233,6 +233,8 @@ class SummaryPanel(
                 "loadAllTranscripts" -> handleLoadAllTranscripts()
                 "saveAllTranscripts" -> handleSaveAllTranscripts(json.getAsJsonArray("entries"))
                 "deleteAllTranscripts" -> handleDeleteAllTranscripts()
+                "generateRecap" -> handleGenerateRecap()
+                "editRecap" -> handleEditRecap(json.get("recap").asString)
                 else -> LOG.debug("Unknown webview command: $command")
             }
         } catch (e: Exception) {
@@ -460,6 +462,60 @@ class SummaryPanel(
                 currentSummary = updatedSummary
                 val html = SummaryHtmlBuilder.buildE2eTestSection(updatedSummary)
                 ApplicationManager.getApplication().invokeLater { postToWebview("e2eTestUpdated", mapOf("html" to html)) }
+            }
+        }
+    }
+
+    private fun handleGenerateRecap() {
+        postToWebview("recapGenerating")
+        ApplicationManager.getApplication().executeOnPooledThread {
+            try {
+                val summary = currentSummary
+                val config = SessionTracker.loadConfig(cwd)
+                val (topics) = SummaryUtils.collectSortedTopics(summary)
+
+                val recap = Summarizer.generateRecap(Summarizer.RecapParams(
+                    topics = topics.map { it.topic.topic },
+                    commitMessage = summary.commitMessage,
+                    apiKey = config.apiKey, model = config.model, jolliApiKey = config.jolliApiKey,
+                ))
+
+                val trimmed = recap.trim()
+                if (trimmed.isEmpty()) {
+                    ApplicationManager.getApplication().invokeLater {
+                        postToWebview("recapUpdateError")
+                        Messages.showInfoMessage(project, "No major topics in this commit, so there's nothing to recap.", "Recap")
+                    }
+                    return@executeOnPooledThread
+                }
+
+                val updatedSummary = summary.copy(recap = trimmed)
+                store.storeSummary(updatedSummary, force = true)
+                currentSummary = updatedSummary
+                val html = SummaryHtmlBuilder.buildRecapSection(updatedSummary)
+                ApplicationManager.getApplication().invokeLater { postToWebview("recapUpdated", mapOf("html" to html)) }
+            } catch (e: Exception) {
+                ApplicationManager.getApplication().invokeLater {
+                    postToWebview("recapUpdateError", mapOf("message" to (e.message ?: "Generation failed")))
+                    Messages.showErrorDialog(project, "Recap generation failed: ${e.message}", "Error")
+                }
+            }
+        }
+    }
+
+    private fun handleEditRecap(recap: String) {
+        ApplicationManager.getApplication().executeOnPooledThread {
+            try {
+                val updatedSummary = currentSummary.copy(recap = recap.ifEmpty { null })
+                store.storeSummary(updatedSummary, force = true)
+                currentSummary = updatedSummary
+                val html = SummaryHtmlBuilder.buildRecapSection(updatedSummary)
+                ApplicationManager.getApplication().invokeLater { postToWebview("recapUpdated", mapOf("html" to html)) }
+            } catch (e: Exception) {
+                ApplicationManager.getApplication().invokeLater {
+                    postToWebview("recapUpdateError", mapOf("message" to (e.message ?: "Save failed")))
+                    Messages.showErrorDialog(project, "Recap save failed: ${e.message}", "Error")
+                }
             }
         }
     }

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/views/SummaryCssBuilder.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/views/SummaryCssBuilder.kt
@@ -206,12 +206,49 @@ $rootVars
     display: none;
   }
 
-  /* ── E2E Test Guide ── */
-  .e2e-placeholder {
+  /* ── Empty-state placeholder text (E2E Test Guide, Quick recap) ── */
+  .e2e-placeholder,
+  .recap-placeholder {
     color: var(--description-fg);
     font-size: 0.92em;
     line-height: 1.5;
     margin: 4px 0 12px;
+  }
+
+  /* ── Quick Recap ── */
+  .recap-body p {
+    margin: 0 0 8px;
+    line-height: 1.6;
+  }
+  .recap-body p:last-child {
+    margin-bottom: 0;
+  }
+  .recap-edit-area {
+    width: 100%;
+    min-height: 120px;
+    font-family: $MONO_FONT_FAMILY;
+    font-size: 0.92em;
+    padding: 8px 10px;
+    border: 1px solid var(--input-border);
+    border-radius: 4px;
+    background: var(--input-bg);
+    color: var(--fg);
+    resize: vertical;
+    box-sizing: border-box;
+    line-height: 1.5;
+  }
+  .recap-edit-area:focus {
+    outline: none;
+    border-color: var(--focus-border);
+  }
+  .recap-edit-actions {
+    display: flex;
+    gap: 8px;
+    margin-top: 8px;
+  }
+  .recap-section.recap-editing .recap-body,
+  .recap-section.recap-editing .topic-actions {
+    display: none;
   }
   .e2e-scenario .callout.preconditions { background: var(--callout-trigger-bg); }
   .e2e-scenario .callout.preconditions .callout-label { color: var(--callout-trigger-label); }

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/views/SummaryHtmlBuilder.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/views/SummaryHtmlBuilder.kt
@@ -78,6 +78,7 @@ ${buildHeader(summary, totalFiles, totalInsertions, totalDeletions)}
 <hr class="separator" />
 ${buildPrSection(summary)}
 ${buildPlansSection(summary.plans, planTranslateSet)}
+${buildRecapSection(summary)}
 ${buildE2eTestSection(summary)}
 ${buildSourceCommits(sourceNodes)}
 <div class="section">
@@ -129,6 +130,41 @@ ${if (bridgeScript.isNotEmpty()) "<script>$bridgeScript</script>" else ""}
     </span>
   </div>
   $scenariosHtml
+</div>
+<hr class="separator" />"""
+    }
+
+    // ── Quick Recap Section (public for in-place update) ───────────────────
+
+    /** Renders the Quick Recap section HTML (for in-place update). */
+    fun buildRecapSection(summary: CommitSummary): String {
+        val trimmed = summary.recap?.trim()
+
+        if (trimmed.isNullOrEmpty()) {
+            return """
+<div class="section recap-section" id="recapSection">
+  <div class="section-header">
+    <div class="section-title">&#x1F4D6; Quick recap</div>
+  </div>
+  <p class="recap-placeholder">Generate a recap that highlights the major work in this commit.</p>
+  <button class="action-btn" id="generateRecapBtn">&#x2728; Generate</button>
+</div>
+<hr class="separator" />"""
+        }
+
+        val bodyHtml = trimmed.split(Regex("\n\n+"))
+            .joinToString("") { "<p>${escHtml(it.trim())}</p>" }
+
+        return """
+<div class="section recap-section" id="recapSection" data-raw="${escAttr(trimmed)}">
+  <div class="section-header">
+    <div class="section-title">&#x1F4D6; Quick recap</div>
+    <span class="topic-actions">
+      <button class="topic-action-btn" id="editRecapBtn" title="Edit recap">&#x270E;</button>
+      <button class="topic-action-btn" id="regenerateRecapBtn" title="Regenerate">&#x21BB;</button>
+    </span>
+  </div>
+  <div class="recap-body">$bodyHtml</div>
 </div>
 <hr class="separator" />"""
     }

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/views/SummaryMarkdownBuilder.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/views/SummaryMarkdownBuilder.kt
@@ -34,6 +34,7 @@ object SummaryMarkdownBuilder {
 
         pushPropertiesSection(lines, summary)
         pushPlansSection(lines, summary, includeEditInfo = true)
+        pushRecapSection(lines, summary)
         pushE2eTestSection(lines, summary.e2eTestGuide)
         pushSourceCommitsSection(lines, sourceNodes)
         pushTopicsSection(lines, allTopics, showRecordDates, ::pushTopicBody)
@@ -130,6 +131,13 @@ object SummaryMarkdownBuilder {
             val noteUrl = note.jolliNoteDocUrl
             lines.add(if (noteUrl != null) "- [${note.title}]($noteUrl)" else "- ${note.title}")
         }
+    }
+
+    /** Appends the Quick Recap section if present. */
+    private fun pushRecapSection(lines: MutableList<String>, summary: CommitSummary) {
+        val recap = summary.recap?.trim()
+        if (recap.isNullOrEmpty()) return
+        lines.addAll(listOf("", "## Quick recap", "", recap, "", "---"))
     }
 
     /** Appends the E2E test guide section (shared between clipboard and PR markdown). */

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/views/SummaryPrMarkdownBuilder.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/views/SummaryPrMarkdownBuilder.kt
@@ -44,11 +44,19 @@ object SummaryPrMarkdownBuilder {
         }
 
         SummaryMarkdownBuilder.pushPlansAndNotesSection(lines, summary)
+        pushPrRecapSection(lines, summary)
         pushPrE2eTestSection(lines, summary.e2eTestGuide)
         pushPrTopicsSection(lines, allTopics)
         SummaryMarkdownBuilder.pushFooter(lines)
 
         return lines.joinToString("\n")
+    }
+
+    /** Appends the Quick Recap section for PR markdown if present. */
+    private fun pushPrRecapSection(lines: MutableList<String>, summary: CommitSummary) {
+        val recap = summary.recap?.trim()
+        if (recap.isNullOrEmpty()) return
+        lines.addAll(listOf("", "## Quick recap", "", recap, "", "---"))
     }
 
     // ── GitHub folding helpers ──────────────────────────────────────────────

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/views/SummaryScriptBuilder.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/views/SummaryScriptBuilder.kt
@@ -558,7 +558,91 @@ ${buildPrMessageScript()}
     return scenarios;
   }
 
-  // Handle E2E status messages from the IDE
+  // ── Quick Recap ──
+
+  // Generate / Regenerate button
+  function attachGenerateRecapHandler() {
+    var ids = ['generateRecapBtn', 'regenerateRecapBtn'];
+    ids.forEach(function(id) {
+      var btn = document.getElementById(id);
+      if (!btn) return;
+      btn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        jmSend({ command: 'generateRecap' });
+      });
+    });
+  }
+  attachGenerateRecapHandler();
+
+  // Edit recap button — switch to textarea editing
+  function attachEditRecapHandler() {
+    var btn = document.getElementById('editRecapBtn');
+    if (!btn) return;
+    btn.addEventListener('click', function(e) {
+      e.stopPropagation();
+      var section = document.getElementById('recapSection');
+      if (!section || section.classList.contains('recap-editing')) return;
+      section.classList.add('recap-editing');
+
+      var raw = section.getAttribute('data-raw') || '';
+      section._originalRecapHtml = section.innerHTML;
+
+      var header = section.querySelector('.section-header');
+      section.innerHTML = '';
+      if (header) section.appendChild(header);
+
+      var ta = document.createElement('textarea');
+      ta.className = 'recap-edit-area';
+      ta.value = raw;
+      section.appendChild(ta);
+
+      var actions = document.createElement('div');
+      actions.className = 'recap-edit-actions';
+      var cancelBtn = document.createElement('button');
+      cancelBtn.className = 'action-btn';
+      cancelBtn.textContent = 'Cancel';
+      var saveBtn = document.createElement('button');
+      saveBtn.className = 'action-btn primary';
+      saveBtn.textContent = 'Save';
+      actions.appendChild(cancelBtn);
+      actions.appendChild(saveBtn);
+      section.appendChild(actions);
+
+      ta.style.height = ta.scrollHeight + 'px';
+      ta.addEventListener('input', function() {
+        ta.style.height = 'auto';
+        ta.style.height = ta.scrollHeight + 'px';
+      });
+      ta.focus();
+
+      cancelBtn.addEventListener('click', function() {
+        section.innerHTML = section._originalRecapHtml;
+        section.classList.remove('recap-editing');
+        delete section._originalRecapHtml;
+        attachEditRecapHandler();
+        attachGenerateRecapHandler();
+      });
+
+      saveBtn.addEventListener('click', function() {
+        var text = ta.value.trim();
+        saveBtn.textContent = 'Saving...';
+        saveBtn.disabled = true;
+        cancelBtn.disabled = true;
+        jmSend({ command: 'editRecap', recap: text });
+      });
+
+      section._recapEscHandler = function(ev) {
+        if (ev.key === 'Escape') {
+          ev.preventDefault();
+          cancelBtn.click();
+        }
+      };
+      document.addEventListener('keydown', section._recapEscHandler);
+    });
+  }
+  attachEditRecapHandler();
+
+  // Handle E2E + Recap status messages from the IDE
   window.addEventListener('jollimemory', function(e) {
     var msg = e.detail;
     if (msg.command === 'e2eTestGenerating') {
@@ -628,6 +712,83 @@ ${buildPrMessageScript()}
     // Re-attach edit and delete buttons
     attachEditE2eHandler(document.getElementById('editE2eBtn'));
     attachDeleteE2eHandler(document.getElementById('deleteE2eBtn'));
+  }
+
+  // ── Recap status messages ──
+  if (msg.command === 'recapGenerating') {
+    var genRecapBtn = document.getElementById('generateRecapBtn');
+    var regenRecapBtn = document.getElementById('regenerateRecapBtn');
+    if (genRecapBtn) {
+      genRecapBtn.textContent = 'Generating...';
+      genRecapBtn.disabled = true;
+    }
+    if (regenRecapBtn) {
+      regenRecapBtn.classList.add('generating');
+      regenRecapBtn.title = 'Generating...';
+      regenRecapBtn.disabled = true;
+    }
+    var recapBody = document.querySelector('.recap-body');
+    if (recapBody) {
+      recapBody.style.opacity = '0.5';
+      var spinner = document.createElement('p');
+      spinner.className = 'recap-generating-indicator';
+      spinner.textContent = 'Regenerating recap...';
+      spinner.style.fontStyle = 'italic';
+      spinner.style.opacity = '0.7';
+      spinner.style.marginTop = '8px';
+      recapBody.parentElement.appendChild(spinner);
+    }
+  } else if (msg.command === 'recapUpdated' && msg.html) {
+    var recapSection = document.getElementById('recapSection');
+    if (recapSection) {
+      if (recapSection._recapEscHandler) {
+        document.removeEventListener('keydown', recapSection._recapEscHandler);
+        delete recapSection._recapEscHandler;
+      }
+      recapSection.classList.remove('recap-editing');
+      var recapWrap = document.createElement('div');
+      recapWrap.innerHTML = msg.html;
+      var newRecap = recapWrap.querySelector('#recapSection');
+      if (newRecap) {
+        var recapHr = recapSection.nextElementSibling;
+        recapSection.replaceWith(newRecap);
+        var newRecapHr = recapWrap.querySelector('hr.separator');
+        if (newRecapHr && recapHr && recapHr.tagName === 'HR') {
+          recapHr.replaceWith(newRecapHr);
+        } else if (newRecapHr && !recapHr) {
+          newRecap.insertAdjacentElement('afterend', newRecapHr);
+        }
+        attachEditRecapHandler();
+        attachGenerateRecapHandler();
+      }
+    }
+  } else if (msg.command === 'recapUpdateError') {
+    var genRecapBtn2 = document.getElementById('generateRecapBtn');
+    var regenRecapBtn2 = document.getElementById('regenerateRecapBtn');
+    if (genRecapBtn2) {
+      genRecapBtn2.textContent = '\u2728 Generate';
+      genRecapBtn2.disabled = false;
+    }
+    if (regenRecapBtn2) {
+      regenRecapBtn2.classList.remove('generating');
+      regenRecapBtn2.title = 'Regenerate';
+      regenRecapBtn2.disabled = false;
+    }
+    var recapBodyErr = document.querySelector('.recap-body');
+    if (recapBodyErr) {
+      recapBodyErr.style.opacity = '1';
+    }
+    var spinnerErr = document.querySelector('.recap-generating-indicator');
+    if (spinnerErr) {
+      spinnerErr.remove();
+    }
+    var editingRecap = document.querySelector('.recap-section.recap-editing');
+    if (editingRecap) {
+      var rSave = editingRecap.querySelector('.action-btn.primary');
+      var rCancel = editingRecap.querySelector('.action-btn:not(.primary)');
+      if (rSave) { rSave.textContent = 'Save'; rSave.disabled = false; }
+      if (rCancel) { rCancel.disabled = false; }
+    }
   }
 
   // ── Plan inline edit messages ──


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## E2E Test (5)
<details>
<summary><strong>1. Generate a Quick Recap for the first time</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a commit summary open in the JolliMemory panel that contains at least one major topic (a feature or bug fix, not just cleanup).

**Steps:**
1. Open the JolliMemory tool window and navigate to a commit summary that does not yet have a Quick Recap section.
2. Locate the Quick Recap area at the bottom of the summary panel.
3. Click the "Generate" button in the Quick Recap section.
4. Wait for the loading indicator to appear while the recap is being generated.
5. Verify that the loading indicator disappears and a paragraph of plain-English text appears in the Quick Recap section.
6. Close and reopen the summary panel, then verify the recap text is still present.

**Expected Results:**
- A loading spinner or indicator appears immediately after clicking "Generate".
- A flowing paragraph of plain English appears in the Quick Recap section — no bullet points, no headings, no code identifiers.
- The recap text describes what changed in the commit in plain language a non-technical reader could understand.
- After reopening the panel, the same recap text is still displayed, confirming it was saved.

</blockquote>
</details>
<details>
<summary><strong>2. Regenerate an existing Quick Recap</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a commit summary open that already has a Quick Recap paragraph visible.

**Steps:**
1. Open the JolliMemory tool window and navigate to a commit summary that already shows a Quick Recap paragraph.
2. Note the current recap text so you can compare it after regeneration.
3. Click the "Regenerate" button in the Quick Recap section.
4. Wait for the loading indicator to appear and then disappear.
5. Verify that a new recap paragraph appears in place of the old one.

**Expected Results:**
- A loading indicator appears while the new recap is being generated.
- The Quick Recap section updates with new text once generation completes.
- The panel does not show an error message.
- The new recap is saved — refreshing or reopening the panel still shows the updated text.

</blockquote>
</details>
<details>
<summary><strong>3. Edit and save a Quick Recap manually</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a commit summary open that already has a Quick Recap paragraph visible.

**Steps:**
1. Open the JolliMemory tool window and navigate to a commit summary that shows a Quick Recap paragraph.
2. Click the "Edit" button in the Quick Recap section.
3. Verify that the recap text becomes editable (a text input or editable area appears).
4. Clear the existing text and type a short custom sentence, for example: "This is my custom recap."
5. Click the "Save" button.
6. Verify that the Quick Recap section now displays your custom sentence, and reopen the panel to confirm it persisted.

**Expected Results:**
- Clicking "Edit" makes the recap text editable.
- After saving, the Quick Recap section displays the exact text that was typed.
- No error message appears.
- Reopening the panel shows the saved custom text, confirming it was stored correctly.

</blockquote>
</details>
<details>
<summary><strong>4. Cancel an in-progress recap edit</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a commit summary open that already has a Quick Recap paragraph visible.

**Steps:**
1. Open the JolliMemory tool window and navigate to a commit summary that shows a Quick Recap paragraph.
2. Note the current recap text.
3. Click the "Edit" button to enter edit mode.
4. Change the text to something different, for example: "Temporary text I do not want to save."
5. Click the "Cancel" button without saving.
6. Verify that the Quick Recap section reverts to the original text.

**Expected Results:**
- Clicking "Cancel" exits edit mode without saving the changes.
- The Quick Recap section displays the original recap text, not the modified version.
- No error message appears.

</blockquote>
</details>
<details>
<summary><strong>5. Generate recap on a commit with only minor topics shows an informational message</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a commit summary open whose topics are all minor (cleanup, config, or documentation changes only — no features or bug fixes).

**Steps:**
1. Open the JolliMemory tool window and navigate to a commit summary that contains only minor topics.
2. Locate the Quick Recap section and click the "Generate" button.
3. Wait for the loading indicator to finish.
4. Verify that no recap paragraph is added and that an informational message appears explaining why.

**Expected Results:**
- A loading indicator appears briefly after clicking "Generate".
- No recap text is inserted into the Quick Recap section.
- An informational dialog or notice appears stating that there are no major topics to recap (or similar plain-language explanation).
- The panel does not show a generic error — the message should be friendly and explanatory.

</blockquote>
</details>

---

## Topics (2)
<details>
<summary><strong>01 · Quick Recap section with generate, regenerate, and edit support</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Commit summaries lacked a plain-English narrative that non-technical readers could quickly scan. There was no way to produce or update a high-level recap paragraph from within the summary panel.

**💡 Decisions Behind the Code**

- **Standalone generation endpoint**: A dedicated `generateRecap` LLM call (separate from the main summarization prompt) was added so users can generate or regenerate a recap at any time after a commit, rather than only at commit time. This keeps the recap opt-in and re-generatable without re-running the full summary.
- **Major-topics filter**: Only topics marked `importance: major` are passed to the recap prompt, keeping the recap focused on high-impact work and preventing minor cleanup from diluting the narrative.
- **In-place HTML swap**: On `recapUpdated`, the script replaces only the recap section DOM node rather than reloading the full panel, matching the existing pattern used for topic edits.

**✅ What Was Implemented**

- Added `recap` field to `CommitSummary` and `SummaryResult`; wired through `PostCommitHook`, `SummaryStore` (rebase and squash merge paths), and `Summarizer.generateSummary`.
- Added `Summarizer.generateRecap`, `buildRecapPrompt`, and `parseRecapResponse` for standalone LLM-driven recap generation; `SummaryPanel` gained `handleGenerateRecap` and `handleEditRecap` handlers responding to `generateRecap` and `editRecap` webview commands.
- `SummaryHtmlBuilder.buildRecapSection`, `SummaryMarkdownBuilder.pushRecapSection`, and `SummaryPrMarkdownBuilder.pushPrRecapSection` render the recap in the panel, clipboard markdown, and PR markdown respectively; `SummaryScriptBuilder` adds generate, regenerate, edit, cancel, save, and loading-state JS.

**📁 FILES**
- `intellij/src/main/kotlin/ai/jolli/jollimemory/core/Summarizer.kt`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/core/Types.kt`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/SummaryPanel.kt`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/views/SummaryHtmlBuilder.kt`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/views/SummaryScriptBuilder.kt`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/core/SummaryStore.kt`

</blockquote>
</details>
<details>
<summary><strong>02 · Summarization prompt overhauled with stricter output format and recap rules</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The existing summarization prompt lacked explicit ordering constraints and detailed rules for the recap block, leading to inconsistent LLM output structure. Field-level guidance for trigger, response, decisions, and todo was also too loose.

**💡 Decisions Behind the Code**

- **Recap placed last in prompt**: The recap block is required after all topic blocks so the model can perform a literal lookback on emitted importance labels when deciding which topics to include, rather than having to anticipate them.
- **Narrative vs. detail field split**: Rules explicitly separate narrative fields (plain language, no code identifiers) from detail fields (technical precision welcome), giving the model clear per-field audience guidance instead of a single blanket instruction.

**✅ What Was Implemented**

- Rewrote the prompt in `Summarizer.kt` to mandate `===SUMMARY===` as the first line, enforce strict block ordering (ticket → topics → recap), and add 19 numbered rules covering field formatting, audience, forbidden subjects, and recap content constraints.
- Added `extractRecap` to parse the `---RECAP---` block out of summarization responses and populate `ParsedResponse.recap`.

**📁 FILES**
- `intellij/src/main/kotlin/ai/jolli/jollimemory/core/Summarizer.kt`

</blockquote>
</details>

---

*Generated by Jolli Memory · May 5, 2026 at 4:34 PM*
<!-- jollimemory-summary-end -->