### PR TITLE
feat(cli): theme packs (Forge + Atlas), header/footer config, hot-reload dev server, and OpenAPI rich pipeline

### DIFF
--- a/cli/docs/site-json-reference.md
+++ b/cli/docs/site-json-reference.md
@@ -1,0 +1,474 @@
+# site.json Reference
+
+`site.json` is the configuration file at the root of your Content_Folder. It controls the site title, navigation, theme, header, footer, sidebar, and more.
+
+## Minimal Example
+
+```json
+{
+  "title": "My Docs",
+  "description": "Documentation for My Project",
+  "nav": []
+}
+```
+
+Run `jolli dev .` in the folder containing this file to start a dev server.
+
+---
+
+## Top-Level Fields
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `title` | `string` | Yes | Site title. Displayed in the navbar logo and HTML `<title>`. |
+| `description` | `string` | Yes | HTML meta description. |
+| `nav` | `NavLink[]` | Yes | Legacy flat navbar links. Use `header` for dropdowns. |
+| `header` | `HeaderConfig` | No | Navbar with dropdown support. Overrides `nav` when set. |
+| `footer` | `FooterConfig` | No | Footer with columns, copyright, and social links. |
+| `sidebar` | `SidebarOverrides` | No | Custom sidebar labels and ordering per directory. |
+| `pathMappings` | `Record<string, string>` | No | Remap source folders to different content paths. |
+| `favicon` | `string` | No | Favicon URL. Deprecated; use `theme.favicon` instead. |
+| `theme` | `ThemeConfig` | No | Visual theme pack and branding options. |
+
+---
+
+## Navigation (`nav`)
+
+The simplest way to add links to the navbar. Each entry is a flat link with no dropdown support.
+
+```json
+{
+  "nav": [
+    { "label": "Guides", "href": "/guides" },
+    { "label": "API", "href": "/api" },
+    { "label": "GitHub", "href": "https://github.com/myorg/myproject" }
+  ]
+}
+```
+
+When `header` is also set, `header.items` takes precedence and `nav` is ignored.
+
+---
+
+## Header (`header`)
+
+Replaces `nav` with richer navbar items that support dropdowns.
+
+### Direct links only
+
+```json
+{
+  "header": {
+    "items": [
+      { "label": "Docs", "url": "/docs" },
+      { "label": "Pricing", "url": "https://example.com/pricing" }
+    ]
+  }
+}
+```
+
+### With dropdowns
+
+Each item can have nested `items` to render a dropdown menu:
+
+```json
+{
+  "header": {
+    "items": [
+      { "label": "Docs", "url": "/docs" },
+      { "label": "API Reference", "url": "/api" },
+      {
+        "label": "Resources",
+        "items": [
+          { "label": "Blog", "url": "https://blog.example.com" },
+          { "label": "Changelog", "url": "/changelog" },
+          { "label": "Status", "url": "https://status.example.com" }
+        ]
+      },
+      {
+        "label": "Community",
+        "items": [
+          { "label": "Discord", "url": "https://discord.gg/example" },
+          { "label": "GitHub Discussions", "url": "https://github.com/org/repo/discussions" }
+        ]
+      }
+    ]
+  }
+}
+```
+
+An item must have either `url` (direct link) or `items` (dropdown), not both.
+
+---
+
+## Footer (`footer`)
+
+Configures the site footer with copyright text, link columns, and social icons.
+
+### All footer fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `copyright` | `string` | Copyright text displayed at the bottom. |
+| `columns` | `FooterColumn[]` | Groups of links with a heading. |
+| `socialLinks` | `SocialLinks` | URLs for social platform icons. |
+
+### Social link platforms
+
+Supported platforms (rendered in this order): `github`, `twitter`, `discord`, `linkedin`, `youtube`. Unset platforms are skipped.
+
+### Example
+
+```json
+{
+  "footer": {
+    "copyright": "2026 Acme Inc. All rights reserved.",
+    "columns": [
+      {
+        "title": "Product",
+        "links": [
+          { "label": "Features", "url": "/features" },
+          { "label": "Pricing", "url": "/pricing" },
+          { "label": "Changelog", "url": "/changelog" }
+        ]
+      },
+      {
+        "title": "Developers",
+        "links": [
+          { "label": "Documentation", "url": "/docs" },
+          { "label": "API Reference", "url": "/api" },
+          { "label": "SDKs", "url": "/sdks" }
+        ]
+      },
+      {
+        "title": "Company",
+        "links": [
+          { "label": "About", "url": "/about" },
+          { "label": "Blog", "url": "https://blog.example.com" },
+          { "label": "Careers", "url": "/careers" }
+        ]
+      }
+    ],
+    "socialLinks": {
+      "github": "https://github.com/acme",
+      "twitter": "https://twitter.com/acme",
+      "discord": "https://discord.gg/acme",
+      "youtube": "https://youtube.com/@acme"
+    }
+  }
+}
+```
+
+When `footer` is omitted or empty, a bare default footer is rendered.
+
+---
+
+## Theme (`theme`)
+
+Controls the visual appearance of the generated site.
+
+### Theme fields
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `pack` | `"default"` \| `"forge"` \| `"atlas"` | `"default"` | Theme pack to use. |
+| `primaryHue` | `number` (0-360) | Pack default | Accent colour hue. Forge: 228 (indigo), Atlas: 200 (blue). |
+| `defaultTheme` | `"light"` \| `"dark"` \| `"system"` | Pack default | Initial colour scheme. Forge: `"light"`, Atlas: `"dark"`. |
+| `fontFamily` | `string` | Pack default | Body font. See font options below. |
+| `logoUrl` | `string` | None | Logo image URL (light mode). |
+| `logoUrlDark` | `string` | None | Logo image URL (dark mode). Falls back to `logoUrl`. |
+| `favicon` | `string` | None | Favicon URL. |
+
+### Theme packs
+
+**`default`** — Vanilla Nextra theme. No custom CSS. Best for quick starts.
+
+**`forge`** — Clean developer documentation style.
+- Sidebar-first layout with three-column desktop grid (sidebar | article | TOC)
+- Inter typography, hairline borders
+- Light mode by default
+- Default accent: indigo (hue 228)
+
+**`atlas`** — Editorial / handbook style.
+- Top-nav layout
+- Source Serif typography, airy spacing
+- Dark mode by default
+- Default accent: blue (hue 200)
+
+### Font options
+
+| Value | Font | Style |
+|-------|------|-------|
+| `"inter"` | Inter | Clean sans-serif (Forge default) |
+| `"space-grotesk"` | Space Grotesk | Geometric sans-serif |
+| `"ibm-plex"` | IBM Plex Sans | Technical sans-serif |
+| `"source-sans"` | Source Sans 3 | Neutral sans-serif |
+| `"source-serif"` | Source Serif 4 | Editorial serif (Atlas default) |
+
+---
+
+## Sidebar (`sidebar`)
+
+Overrides the auto-generated sidebar labels and ordering per directory.
+
+```json
+{
+  "sidebar": {
+    "/": {
+      "index": "Home",
+      "getting-started": "Getting Started",
+      "guides": "Guides"
+    },
+    "/guides": {
+      "quickstart": "Quick Start",
+      "advanced": "Advanced Usage"
+    }
+  }
+}
+```
+
+- Keys are directory paths (e.g. `"/"` for root, `"/guides"` for the guides folder).
+- Values are ordered maps of `{ slug: label }`.
+- Items are rendered in declaration order. Files not listed are appended alphabetically by Nextra.
+- Use an object value for external links or separators:
+
+```json
+{
+  "sidebar": {
+    "/": {
+      "index": "Home",
+      "---": { "type": "separator" },
+      "github": { "title": "GitHub", "href": "https://github.com/org/repo" }
+    }
+  }
+}
+```
+
+---
+
+## Path Mappings (`pathMappings`)
+
+Remaps source folder paths to different locations in the generated site. Useful when the sidebar structure should differ from the physical folder layout.
+
+```json
+{
+  "pathMappings": {
+    "sql": "pipelines/sql",
+    "api-docs": "reference/api"
+  }
+}
+```
+
+This maps `sql/` in your source folder to `pipelines/sql/` in the site content.
+
+---
+
+## Full Examples
+
+### Example 1: Minimal — just content, no customization
+
+```json
+{
+  "title": "My Project",
+  "description": "Project documentation",
+  "nav": []
+}
+```
+
+### Example 2: Default theme with header dropdowns and footer
+
+```json
+{
+  "title": "Acme Platform",
+  "description": "Acme Platform documentation",
+  "nav": [],
+  "header": {
+    "items": [
+      { "label": "Docs", "url": "/docs" },
+      { "label": "API", "url": "/api" },
+      {
+        "label": "Resources",
+        "items": [
+          { "label": "Blog", "url": "https://blog.acme.dev" },
+          { "label": "Changelog", "url": "/changelog" }
+        ]
+      }
+    ]
+  },
+  "footer": {
+    "copyright": "2026 Acme Inc.",
+    "columns": [
+      {
+        "title": "Product",
+        "links": [
+          { "label": "Features", "url": "/features" },
+          { "label": "Pricing", "url": "/pricing" }
+        ]
+      }
+    ],
+    "socialLinks": {
+      "github": "https://github.com/acme",
+      "discord": "https://discord.gg/acme"
+    }
+  }
+}
+```
+
+### Example 3: Forge theme with custom branding
+
+```json
+{
+  "title": "DevKit",
+  "description": "DevKit developer documentation",
+  "nav": [],
+  "theme": {
+    "pack": "forge",
+    "primaryHue": 160,
+    "defaultTheme": "light",
+    "fontFamily": "space-grotesk",
+    "logoUrl": "/images/logo.svg",
+    "logoUrlDark": "/images/logo-dark.svg",
+    "favicon": "/images/favicon.ico"
+  },
+  "header": {
+    "items": [
+      { "label": "Guides", "url": "/guides" },
+      { "label": "API Reference", "url": "/api" },
+      { "label": "GitHub", "url": "https://github.com/devkit/devkit" }
+    ]
+  },
+  "footer": {
+    "copyright": "2026 DevKit Labs",
+    "socialLinks": {
+      "github": "https://github.com/devkit",
+      "twitter": "https://twitter.com/devkit"
+    }
+  }
+}
+```
+
+### Example 4: Atlas theme for an editorial handbook
+
+```json
+{
+  "title": "Engineering Handbook",
+  "description": "Internal engineering handbook and style guide",
+  "nav": [],
+  "theme": {
+    "pack": "atlas",
+    "primaryHue": 220,
+    "defaultTheme": "dark",
+    "fontFamily": "source-serif",
+    "logoUrl": "/images/handbook-logo.svg"
+  },
+  "header": {
+    "items": [
+      { "label": "Principles", "url": "/principles" },
+      { "label": "Standards", "url": "/standards" },
+      {
+        "label": "Guides",
+        "items": [
+          { "label": "Code Review", "url": "/guides/code-review" },
+          { "label": "Testing", "url": "/guides/testing" },
+          { "label": "Deployment", "url": "/guides/deployment" }
+        ]
+      }
+    ]
+  },
+  "footer": {
+    "copyright": "Internal use only.",
+    "columns": [
+      {
+        "title": "Quick Links",
+        "links": [
+          { "label": "Onboarding", "url": "/onboarding" },
+          { "label": "Architecture", "url": "/architecture" },
+          { "label": "Runbooks", "url": "/runbooks" }
+        ]
+      }
+    ]
+  }
+}
+```
+
+### Example 5: Legacy format (backwards compatible)
+
+Older `site.json` files without `header`, `footer`, or `theme` still work:
+
+```json
+{
+  "title": "Old Docs",
+  "description": "Legacy documentation site",
+  "nav": [
+    { "label": "Home", "href": "/" },
+    { "label": "API", "href": "/api" }
+  ],
+  "favicon": "/favicon.ico",
+  "sidebar": {
+    "/": {
+      "index": "Welcome",
+      "getting-started": "Getting Started"
+    }
+  }
+}
+```
+
+### Example 6: OpenAPI specs with Forge theme and sidebar overrides
+
+```json
+{
+  "title": "Payment API",
+  "description": "Payment gateway API documentation",
+  "nav": [],
+  "theme": {
+    "pack": "forge",
+    "primaryHue": 145,
+    "fontFamily": "ibm-plex"
+  },
+  "header": {
+    "items": [
+      { "label": "Docs", "url": "/docs" },
+      { "label": "API Reference", "url": "/api-payments" },
+      {
+        "label": "SDKs",
+        "items": [
+          { "label": "Node.js", "url": "https://github.com/pay/node-sdk" },
+          { "label": "Python", "url": "https://github.com/pay/python-sdk" },
+          { "label": "Go", "url": "https://github.com/pay/go-sdk" }
+        ]
+      }
+    ]
+  },
+  "footer": {
+    "copyright": "2026 PayCo Inc.",
+    "columns": [
+      {
+        "title": "Resources",
+        "links": [
+          { "label": "Status Page", "url": "https://status.payco.dev" },
+          { "label": "Changelog", "url": "/changelog" }
+        ]
+      }
+    ],
+    "socialLinks": {
+      "github": "https://github.com/payco",
+      "linkedin": "https://linkedin.com/company/payco"
+    }
+  },
+  "sidebar": {
+    "/": {
+      "index": "Overview",
+      "getting-started": "Getting Started",
+      "authentication": "Authentication"
+    }
+  }
+}
+```
+
+Place your OpenAPI spec files (`.yaml`, `.json`) in the content folder. They are automatically detected, parsed, and rendered as interactive API reference pages.
+
+---
+
+## Security
+
+All URLs in `header`, `footer`, `nav`, and `theme` (logos, favicon) are sanitized. URLs using `javascript:`, `data:`, or `vbscript:` schemes are replaced with `"#"` to prevent script injection. Only `http(s):`, `mailto:`, `tel:`, relative paths, and fragment/query URLs are allowed.

--- a/cli/examples/README.md
+++ b/cli/examples/README.md
@@ -1,0 +1,27 @@
+# Examples
+
+Each folder is a self-contained Content_Folder you can run with `jolli dev`.
+
+## Running an Example
+
+```bash
+jolli dev cli/examples/<folder-name>
+```
+
+## Examples
+
+| Folder | What It Demonstrates |
+|--------|---------------------|
+| `minimal/` | Simplest possible site — just title, description, empty nav |
+| `nav-links/` | Legacy `nav` field with flat navbar links |
+| `header-dropdowns/` | `header.items` with direct links and dropdown menus |
+| `footer-config/` | Footer with copyright, link columns, and social icons |
+| `sidebar-overrides/` | Custom sidebar labels, ordering, separators, and external links |
+| `theme-forge/` | Forge theme pack with custom branding, header, footer, sidebar |
+| `theme-atlas/` | Atlas theme pack for an internal engineering handbook |
+| `openapi-spec/` | OpenAPI spec auto-detected and rendered as API reference pages |
+| `path-mappings/` | Remap source folder paths to different site URLs |
+
+## Reference
+
+See [site-json-reference.md](../docs/site-json-reference.md) for full documentation of all `site.json` fields.

--- a/cli/examples/footer-config/docs.md
+++ b/cli/examples/footer-config/docs.md
@@ -1,0 +1,3 @@
+# Documentation
+
+Welcome to the documentation.

--- a/cli/examples/footer-config/index.md
+++ b/cli/examples/footer-config/index.md
@@ -1,0 +1,19 @@
+# Footer Config Example
+
+This example demonstrates a fully configured footer with:
+
+- **Copyright text** — displayed at the bottom of the page
+- **Link columns** — Product, Developers, Company — each with a title and list of links
+- **Social links** — GitHub, Twitter, Discord, LinkedIn, YouTube icons rendered in canonical platform order
+
+Scroll to the bottom of the page to see the footer.
+
+## How It Works
+
+The `footer` block in `site.json` accepts three optional fields:
+
+- `copyright` — a string displayed as copyright text
+- `columns` — an array of `{ title, links }` objects
+- `socialLinks` — an object with platform names as keys and URLs as values
+
+When `footer` is omitted or all fields are empty, a bare default footer is rendered instead.

--- a/cli/examples/footer-config/site.json
+++ b/cli/examples/footer-config/site.json
@@ -1,0 +1,43 @@
+{
+  "title": "Footer Config Example",
+  "description": "Demonstrates footer with copyright, columns, and social links",
+  "nav": [
+    { "label": "Docs", "href": "/docs" }
+  ],
+  "footer": {
+    "copyright": "2026 Example Corp. All rights reserved.",
+    "columns": [
+      {
+        "title": "Product",
+        "links": [
+          { "label": "Features", "url": "/features" },
+          { "label": "Pricing", "url": "/pricing" },
+          { "label": "Changelog", "url": "/changelog" }
+        ]
+      },
+      {
+        "title": "Developers",
+        "links": [
+          { "label": "Documentation", "url": "/docs" },
+          { "label": "API Reference", "url": "/api" },
+          { "label": "SDKs", "url": "/sdks" }
+        ]
+      },
+      {
+        "title": "Company",
+        "links": [
+          { "label": "About", "url": "/about" },
+          { "label": "Blog", "url": "https://blog.example.com" },
+          { "label": "Careers", "url": "https://example.com/careers" }
+        ]
+      }
+    ],
+    "socialLinks": {
+      "github": "https://github.com/example",
+      "twitter": "https://twitter.com/example",
+      "discord": "https://discord.gg/example",
+      "linkedin": "https://linkedin.com/company/example",
+      "youtube": "https://youtube.com/@example"
+    }
+  }
+}

--- a/cli/examples/header-dropdowns/api.md
+++ b/cli/examples/header-dropdowns/api.md
@@ -1,0 +1,3 @@
+# API Reference
+
+This is the API reference page, linked from the header.

--- a/cli/examples/header-dropdowns/changelog.md
+++ b/cli/examples/header-dropdowns/changelog.md
@@ -1,0 +1,12 @@
+# Changelog
+
+## v1.2.0 — 2026-05-01
+- Added dropdown menus to header navigation
+- Improved footer layout with link columns
+
+## v1.1.0 — 2026-04-15
+- Added theme pack support (Forge, Atlas)
+- Added social links to footer
+
+## v1.0.0 — 2026-04-01
+- Initial release

--- a/cli/examples/header-dropdowns/docs.md
+++ b/cli/examples/header-dropdowns/docs.md
@@ -1,0 +1,3 @@
+# Documentation
+
+This is the docs page, linked from the header.

--- a/cli/examples/header-dropdowns/index.md
+++ b/cli/examples/header-dropdowns/index.md
@@ -1,0 +1,10 @@
+# Header Dropdowns Example
+
+This example uses `header.items` to create a navbar with both direct links and dropdown menus.
+
+- **Docs** and **API Reference** are direct links
+- **Resources** is a dropdown with Blog, Changelog, and Status Page
+- **Community** is a dropdown with Discord and GitHub Discussions
+- **Pricing** is a direct external link
+
+When `header` is set, it takes precedence over the legacy `nav` field.

--- a/cli/examples/header-dropdowns/site.json
+++ b/cli/examples/header-dropdowns/site.json
@@ -1,0 +1,27 @@
+{
+  "title": "Header Dropdowns Example",
+  "description": "Demonstrates header.items with dropdown menus",
+  "nav": [],
+  "header": {
+    "items": [
+      { "label": "Docs", "url": "/docs" },
+      { "label": "API Reference", "url": "/api" },
+      {
+        "label": "Resources",
+        "items": [
+          { "label": "Blog", "url": "https://blog.example.com" },
+          { "label": "Changelog", "url": "/changelog" },
+          { "label": "Status Page", "url": "https://status.example.com" }
+        ]
+      },
+      {
+        "label": "Community",
+        "items": [
+          { "label": "Discord", "url": "https://discord.gg/example" },
+          { "label": "GitHub Discussions", "url": "https://github.com/example/discussions" }
+        ]
+      },
+      { "label": "Pricing", "url": "https://example.com/pricing" }
+    ]
+  }
+}

--- a/cli/examples/minimal/index.md
+++ b/cli/examples/minimal/index.md
@@ -1,0 +1,13 @@
+# Welcome
+
+This is the simplest possible Jolli documentation site.
+
+Just a `site.json` with title, description, and an empty `nav` array — no theme, no header, no footer configuration needed.
+
+## Getting Started
+
+Run this example:
+
+```bash
+jolli dev cli/examples/minimal
+```

--- a/cli/examples/minimal/site.json
+++ b/cli/examples/minimal/site.json
@@ -1,0 +1,5 @@
+{
+  "title": "Minimal Docs",
+  "description": "The simplest possible Jolli site",
+  "nav": []
+}

--- a/cli/examples/nav-links/guides.md
+++ b/cli/examples/nav-links/guides.md
@@ -1,0 +1,3 @@
+# Guides
+
+This is the Guides page, linked from the navbar.

--- a/cli/examples/nav-links/index.md
+++ b/cli/examples/nav-links/index.md
@@ -1,0 +1,5 @@
+# Nav Links Example
+
+This example uses the `nav` field to add flat links to the navbar.
+
+The `nav` shorthand is the simplest way to add navigation — each entry becomes a link in the header bar. For dropdown menus, use `header.items` instead (see the `header-dropdowns` example).

--- a/cli/examples/nav-links/site.json
+++ b/cli/examples/nav-links/site.json
@@ -1,0 +1,9 @@
+{
+  "title": "Nav Links Example",
+  "description": "Demonstrates the legacy nav shorthand for flat navbar links",
+  "nav": [
+    { "label": "Home", "href": "/" },
+    { "label": "Guides", "href": "/guides" },
+    { "label": "GitHub", "href": "https://github.com/example/project" }
+  ]
+}

--- a/cli/examples/openapi-spec/index.md
+++ b/cli/examples/openapi-spec/index.md
@@ -1,0 +1,14 @@
+# Pet Store API Documentation
+
+Welcome to the Pet Store API docs. This example demonstrates how OpenAPI spec files are automatically detected and rendered as interactive API reference pages.
+
+## How It Works
+
+Place any `.yaml`, `.yml`, or `.json` file containing a valid OpenAPI spec in your content folder. Jolli automatically:
+
+1. Detects the file as an OpenAPI spec (by checking for `openapi` and `info` fields)
+2. Parses operations, parameters, request bodies, and responses
+3. Generates per-endpoint MDX pages with code samples (cURL, JS, TS, Python, Go)
+4. Renders an interactive Try It widget for each endpoint
+
+Check the **API Reference** link in the header to see the rendered spec.

--- a/cli/examples/openapi-spec/petstore.yaml
+++ b/cli/examples/openapi-spec/petstore.yaml
@@ -1,0 +1,164 @@
+openapi: "3.1.0"
+info:
+  title: Pet Store
+  version: "1.0.0"
+  description: A sample Pet Store API for demonstrating OpenAPI rendering.
+servers:
+  - url: https://petstore.example.com/v1
+    description: Production
+tags:
+  - name: Pets
+    description: Operations for managing pets
+  - name: Store
+    description: Store inventory and orders
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      summary: List all pets
+      description: Returns all pets in the store, with optional filtering by status.
+      tags:
+        - Pets
+      parameters:
+        - name: status
+          in: query
+          description: Filter by pet status
+          schema:
+            type: string
+            enum: [available, pending, sold]
+        - name: limit
+          in: query
+          description: Maximum number of results to return
+          schema:
+            type: integer
+            default: 20
+      responses:
+        "200":
+          description: A list of pets
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Pet"
+    post:
+      operationId: createPet
+      summary: Add a new pet
+      description: Adds a new pet to the store inventory.
+      tags:
+        - Pets
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/NewPet"
+            example:
+              name: "Rex"
+              species: "dog"
+              age: 3
+      responses:
+        "201":
+          description: Pet created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pet"
+  /pets/{petId}:
+    get:
+      operationId: getPet
+      summary: Get a pet by ID
+      tags:
+        - Pets
+      parameters:
+        - name: petId
+          in: path
+          required: true
+          description: The ID of the pet to retrieve
+          schema:
+            type: string
+      responses:
+        "200":
+          description: A single pet
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pet"
+        "404":
+          description: Pet not found
+    delete:
+      operationId: deletePet
+      summary: Delete a pet
+      tags:
+        - Pets
+      parameters:
+        - name: petId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "204":
+          description: Pet deleted
+        "404":
+          description: Pet not found
+  /store/inventory:
+    get:
+      operationId: getInventory
+      summary: Get store inventory
+      description: Returns the count of pets grouped by status.
+      tags:
+        - Store
+      responses:
+        "200":
+          description: Inventory counts
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  available:
+                    type: integer
+                  pending:
+                    type: integer
+                  sold:
+                    type: integer
+              example:
+                available: 12
+                pending: 3
+                sold: 45
+components:
+  schemas:
+    Pet:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        species:
+          type: string
+        age:
+          type: integer
+        status:
+          type: string
+          enum: [available, pending, sold]
+    NewPet:
+      type: object
+      required:
+        - name
+        - species
+      properties:
+        name:
+          type: string
+        species:
+          type: string
+        age:
+          type: integer
+  securitySchemes:
+    apiKey:
+      type: apiKey
+      in: header
+      name: X-API-Key
+security:
+  - apiKey: []

--- a/cli/examples/openapi-spec/site.json
+++ b/cli/examples/openapi-spec/site.json
@@ -1,0 +1,22 @@
+{
+  "title": "Pet Store API",
+  "description": "Demonstrates OpenAPI spec rendering with Forge theme",
+  "nav": [],
+  "theme": {
+    "pack": "forge",
+    "primaryHue": 265,
+    "fontFamily": "inter"
+  },
+  "header": {
+    "items": [
+      { "label": "Docs", "url": "/" },
+      { "label": "API Reference", "url": "/api-petstore" }
+    ]
+  },
+  "footer": {
+    "copyright": "2026 Pet Store Demo",
+    "socialLinks": {
+      "github": "https://github.com/example/petstore"
+    }
+  }
+}

--- a/cli/examples/path-mappings/api-docs/endpoints.md
+++ b/cli/examples/path-mappings/api-docs/endpoints.md
@@ -1,0 +1,11 @@
+# API Endpoints
+
+This page lives in `api-docs/endpoints.md` in the source folder but appears at `/reference/api/endpoints` in the generated site thanks to path mappings.
+
+## Available Endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/users` | List all users |
+| POST | `/users` | Create a user |
+| GET | `/users/{id}` | Get a user by ID |

--- a/cli/examples/path-mappings/guides.md
+++ b/cli/examples/path-mappings/guides.md
@@ -1,0 +1,3 @@
+# Guides
+
+User-facing guides and tutorials.

--- a/cli/examples/path-mappings/index.md
+++ b/cli/examples/path-mappings/index.md
@@ -1,0 +1,26 @@
+# Path Mappings Example
+
+This example demonstrates `pathMappings` — remapping source folder paths to different locations in the generated site.
+
+## What's Happening
+
+The source folder has:
+- `sql-docs/` — SQL reference documentation
+- `api-docs/` — API reference documentation
+
+But we want the site to show them under:
+- `reference/sql/`
+- `reference/api/`
+
+The `pathMappings` in `site.json` handles this:
+
+```json
+{
+  "pathMappings": {
+    "sql-docs": "reference/sql",
+    "api-docs": "reference/api"
+  }
+}
+```
+
+This is useful when your source folder structure doesn't match the URL hierarchy you want.

--- a/cli/examples/path-mappings/site.json
+++ b/cli/examples/path-mappings/site.json
@@ -1,0 +1,19 @@
+{
+  "title": "Path Mappings Example",
+  "description": "Demonstrates remapping source folders to different content paths",
+  "nav": [
+    { "label": "Guides", "href": "/guides" },
+    { "label": "API", "href": "/reference/api" }
+  ],
+  "pathMappings": {
+    "sql-docs": "reference/sql",
+    "api-docs": "reference/api"
+  },
+  "sidebar": {
+    "/": {
+      "index": "Home",
+      "guides": "Guides",
+      "reference": "Reference"
+    }
+  }
+}

--- a/cli/examples/path-mappings/sql-docs/overview.md
+++ b/cli/examples/path-mappings/sql-docs/overview.md
@@ -1,0 +1,10 @@
+# SQL Reference
+
+This page lives in `sql-docs/overview.md` in the source folder but appears at `/reference/sql/overview` in the generated site thanks to path mappings.
+
+## Supported Statements
+
+- `SELECT` — query data
+- `INSERT` — add rows
+- `UPDATE` — modify rows
+- `DELETE` — remove rows

--- a/cli/examples/sidebar-overrides/getting-started.md
+++ b/cli/examples/sidebar-overrides/getting-started.md
@@ -1,0 +1,20 @@
+# Getting Started
+
+Follow these steps to get up and running.
+
+## Prerequisites
+
+- Node.js 22.5 or later
+- A content folder with markdown files
+
+## Installation
+
+```bash
+npm install -g @jolli.ai/cli
+```
+
+## Your First Site
+
+```bash
+jolli dev .
+```

--- a/cli/examples/sidebar-overrides/guides/configuration.md
+++ b/cli/examples/sidebar-overrides/guides/configuration.md
@@ -1,0 +1,3 @@
+# Configuration
+
+Learn how to configure your site with `site.json`.

--- a/cli/examples/sidebar-overrides/guides/deployment.md
+++ b/cli/examples/sidebar-overrides/guides/deployment.md
@@ -1,0 +1,11 @@
+# Deployment
+
+Deploy your documentation site to production.
+
+## Static Export
+
+```bash
+jolli build .
+```
+
+The output is a static site you can host on any CDN (Vercel, Netlify, Cloudflare Pages, etc.).

--- a/cli/examples/sidebar-overrides/guides/quickstart.md
+++ b/cli/examples/sidebar-overrides/guides/quickstart.md
@@ -1,0 +1,3 @@
+# Quick Start
+
+Get a site running in under 5 minutes.

--- a/cli/examples/sidebar-overrides/index.md
+++ b/cli/examples/sidebar-overrides/index.md
@@ -1,0 +1,11 @@
+# Sidebar Overrides Example
+
+This example demonstrates custom sidebar configuration:
+
+- **Custom labels** — files are renamed in the sidebar (e.g. `getting-started` shows as "Getting Started")
+- **Custom ordering** — items appear in the order declared in `site.json`, not alphabetically
+- **Separators** — visual dividers between sidebar groups
+- **External links** — GitHub and Support links that open external URLs
+- **Per-directory overrides** — the `/guides` folder has its own sidebar order
+
+Check the left sidebar to see it in action.

--- a/cli/examples/sidebar-overrides/reference.md
+++ b/cli/examples/sidebar-overrides/reference.md
@@ -1,0 +1,3 @@
+# Reference
+
+API and configuration reference material.

--- a/cli/examples/sidebar-overrides/site.json
+++ b/cli/examples/sidebar-overrides/site.json
@@ -1,0 +1,22 @@
+{
+  "title": "Sidebar Overrides Example",
+  "description": "Demonstrates custom sidebar labels, ordering, separators, and external links",
+  "nav": [],
+  "sidebar": {
+    "/": {
+      "index": "Home",
+      "getting-started": "Getting Started",
+      "---": { "type": "separator" },
+      "guides": "Guides",
+      "reference": "Reference",
+      "---2": { "type": "separator" },
+      "github": { "title": "GitHub", "href": "https://github.com/example/project" },
+      "support": { "title": "Get Help", "href": "https://example.com/support" }
+    },
+    "/guides": {
+      "quickstart": "Quick Start",
+      "configuration": "Configuration",
+      "deployment": "Deployment"
+    }
+  }
+}

--- a/cli/examples/theme-atlas/architecture.md
+++ b/cli/examples/theme-atlas/architecture.md
@@ -1,0 +1,20 @@
+# Architecture
+
+High-level overview of our system architecture.
+
+## Services
+
+| Service | Language | Purpose |
+|---------|----------|---------|
+| API Gateway | TypeScript | Request routing, auth, rate limiting |
+| Core Service | TypeScript | Business logic, data processing |
+| Worker | Go | Background jobs, heavy computation |
+| Frontend | React | Web application |
+
+## Data Flow
+
+1. Client sends request to API Gateway
+2. Gateway authenticates and routes to Core Service
+3. Core Service processes synchronously or enqueues to Worker
+4. Worker processes asynchronously, writes results to database
+5. Client polls or receives webhook notification

--- a/cli/examples/theme-atlas/guides/code-review.md
+++ b/cli/examples/theme-atlas/guides/code-review.md
@@ -1,0 +1,17 @@
+# Code Review Guide
+
+How we review code at this company.
+
+## As an Author
+
+- Keep PRs small (under 400 lines when possible)
+- Write a clear PR description explaining *why*, not just *what*
+- Self-review before requesting others
+- Respond to every comment, even if just "Done"
+
+## As a Reviewer
+
+- Review within 24 hours of being assigned
+- Focus on correctness, security, and maintainability
+- Be kind — critique the code, not the person
+- Approve when the code is good enough, not when it's perfect

--- a/cli/examples/theme-atlas/guides/deployment.md
+++ b/cli/examples/theme-atlas/guides/deployment.md
@@ -1,0 +1,20 @@
+# Deployment Guide
+
+How we ship code to production.
+
+## Process
+
+1. Merge PR to `main`
+2. CI builds and runs tests
+3. Staging deploy happens automatically
+4. Verify on staging (smoke test + check monitoring)
+5. Promote to production via the deploy dashboard
+
+## Rollback
+
+If something goes wrong:
+
+1. Click "Rollback" on the deploy dashboard
+2. This deploys the previous known-good version
+3. Post in `#incidents` with a summary
+4. Investigate the root cause before re-deploying the fix

--- a/cli/examples/theme-atlas/guides/incident-response.md
+++ b/cli/examples/theme-atlas/guides/incident-response.md
@@ -1,0 +1,25 @@
+# Incident Response
+
+How we handle production incidents.
+
+## Severity Levels
+
+| Level | Criteria | Response Time |
+|-------|----------|---------------|
+| SEV-1 | Service down, data loss risk | 15 minutes |
+| SEV-2 | Major feature broken, workaround exists | 1 hour |
+| SEV-3 | Minor issue, low user impact | Next business day |
+
+## On-Call Expectations
+
+- Acknowledge pages within 5 minutes
+- Start investigating within 15 minutes
+- Post status updates every 30 minutes during SEV-1/2
+- Write a post-mortem within 48 hours for SEV-1/2
+
+## Post-Mortem Template
+
+1. **Summary** — what happened, impact, duration
+2. **Timeline** — key events with timestamps
+3. **Root cause** — why it happened
+4. **Action items** — what we'll do to prevent recurrence

--- a/cli/examples/theme-atlas/guides/testing.md
+++ b/cli/examples/theme-atlas/guides/testing.md
@@ -1,0 +1,22 @@
+# Testing Strategy
+
+Our approach to testing software.
+
+## Test Pyramid
+
+- **Unit tests** — fast, isolated, cover business logic (80% of tests)
+- **Integration tests** — verify components work together (15% of tests)
+- **End-to-end tests** — simulate real user flows (5% of tests)
+
+## What to Test
+
+- Every public function in a module
+- Error paths, not just happy paths
+- Edge cases: empty input, large input, null/undefined
+- Security boundaries: auth checks, input validation
+
+## What NOT to Test
+
+- Private implementation details
+- Third-party library behaviour
+- Trivial getters/setters

--- a/cli/examples/theme-atlas/index.md
+++ b/cli/examples/theme-atlas/index.md
@@ -1,0 +1,18 @@
+# Engineering Handbook
+
+Welcome to the engineering handbook. This is the single source of truth for how we build software.
+
+This example demonstrates the **Atlas** theme pack with:
+
+- Dark mode by default
+- Source Serif editorial font
+- Custom accent colour (blue, hue 220)
+- Header with dropdown menus (Guides, Tools)
+- Footer with internal quick links
+- Detailed sidebar with per-directory ordering
+
+## How to Use This Handbook
+
+1. **New engineers** — start with [Onboarding](/onboarding)
+2. **Day-to-day work** — refer to [Standards](/standards) and [Guides](/guides)
+3. **On-call** — jump to [Runbooks](/runbooks)

--- a/cli/examples/theme-atlas/onboarding.md
+++ b/cli/examples/theme-atlas/onboarding.md
@@ -1,0 +1,23 @@
+# Onboarding
+
+Welcome to the team! Here's how to get set up.
+
+## Day 1
+
+1. Set up your development environment (see DevOps wiki)
+2. Clone the monorepo
+3. Run `npm install` and `npm run build`
+4. Open your first PR (fix a typo, add yourself to the team page)
+
+## Week 1
+
+1. Read the [Principles](/principles) and [Standards](/standards)
+2. Shadow a code review
+3. Pair-program with your buddy on a small feature
+4. Attend the architecture walkthrough session
+
+## Month 1
+
+1. Own a small feature end-to-end
+2. Participate in on-call rotation (shadowing)
+3. Present a 5-minute tech talk on something you learned

--- a/cli/examples/theme-atlas/principles.md
+++ b/cli/examples/theme-atlas/principles.md
@@ -1,0 +1,23 @@
+# Engineering Principles
+
+These principles guide every technical decision we make.
+
+## 1. Ship Incrementally
+
+Break work into small, reviewable, deployable units. A feature behind a flag that ships today is better than a perfect feature that ships next month.
+
+## 2. Own What You Build
+
+The team that writes the code runs the service. You are the first responder when it breaks.
+
+## 3. Prefer Boring Technology
+
+Choose well-understood, battle-tested tools. Save your innovation tokens for the problems that are actually novel.
+
+## 4. Write for the Next Engineer
+
+Code is read far more often than it is written. Optimise for clarity over cleverness.
+
+## 5. Measure Everything
+
+If you can't measure it, you can't improve it. Every feature ships with metrics.

--- a/cli/examples/theme-atlas/runbooks.md
+++ b/cli/examples/theme-atlas/runbooks.md
@@ -1,0 +1,19 @@
+# Runbooks
+
+Operational procedures for common incidents.
+
+## High Latency Alert
+
+1. Check Grafana dashboard for the affected service
+2. Look for recent deployments in the last 2 hours
+3. Check database connection pool usage
+4. If database is the bottleneck, check slow query log
+5. Escalate to the database team if queries are fine but connections are saturated
+
+## 5xx Spike
+
+1. Check error logs for the stack trace
+2. Identify if it's a single endpoint or system-wide
+3. If single endpoint: check recent PRs that touched that route
+4. If system-wide: check infrastructure (database, cache, external APIs)
+5. Roll back the most recent deployment if the cause isn't immediately clear

--- a/cli/examples/theme-atlas/site.json
+++ b/cli/examples/theme-atlas/site.json
@@ -1,0 +1,75 @@
+{
+  "title": "Engineering Handbook",
+  "description": "Internal engineering handbook and style guide — Atlas theme",
+  "nav": [],
+  "theme": {
+    "pack": "atlas",
+    "primaryHue": 220,
+    "defaultTheme": "dark",
+    "fontFamily": "source-serif",
+    "logoUrl": "https://placehold.co/140x32/3b82f6/white?text=Handbook"
+  },
+  "header": {
+    "items": [
+      { "label": "Principles", "url": "/principles" },
+      { "label": "Standards", "url": "/standards" },
+      {
+        "label": "Guides",
+        "items": [
+          { "label": "Code Review", "url": "/guides/code-review" },
+          { "label": "Testing Strategy", "url": "/guides/testing" },
+          { "label": "Deployment", "url": "/guides/deployment" },
+          { "label": "Incident Response", "url": "/guides/incident-response" }
+        ]
+      },
+      {
+        "label": "Tools",
+        "items": [
+          { "label": "CI/CD Dashboard", "url": "https://ci.internal.example.com" },
+          { "label": "Monitoring", "url": "https://grafana.internal.example.com" }
+        ]
+      }
+    ]
+  },
+  "footer": {
+    "copyright": "Internal use only. Do not distribute.",
+    "columns": [
+      {
+        "title": "Quick Links",
+        "links": [
+          { "label": "Onboarding", "url": "/onboarding" },
+          { "label": "Architecture", "url": "/architecture" },
+          { "label": "Runbooks", "url": "/runbooks" }
+        ]
+      },
+      {
+        "title": "Team Resources",
+        "links": [
+          { "label": "Engineering Blog", "url": "https://eng-blog.internal.example.com" },
+          { "label": "RFC Archive", "url": "https://rfcs.internal.example.com" },
+          { "label": "Design System", "url": "https://design.internal.example.com" }
+        ]
+      }
+    ],
+    "socialLinks": {
+      "github": "https://github.com/example-corp"
+    }
+  },
+  "sidebar": {
+    "/": {
+      "index": "Welcome",
+      "principles": "Principles",
+      "standards": "Standards",
+      "guides": "Guides",
+      "onboarding": "Onboarding",
+      "architecture": "Architecture",
+      "runbooks": "Runbooks"
+    },
+    "/guides": {
+      "code-review": "Code Review",
+      "testing": "Testing Strategy",
+      "deployment": "Deployment",
+      "incident-response": "Incident Response"
+    }
+  }
+}

--- a/cli/examples/theme-atlas/standards.md
+++ b/cli/examples/theme-atlas/standards.md
@@ -1,0 +1,21 @@
+# Engineering Standards
+
+Baseline expectations for all production code.
+
+## Code Style
+
+- TypeScript for all backend and frontend code
+- Biome for formatting and linting (tabs, 120 column limit)
+- No `any` types in production code
+
+## Testing
+
+- Unit tests for all business logic
+- Integration tests for API endpoints
+- Coverage thresholds enforced in CI
+
+## Code Review
+
+- Every PR requires at least one approval
+- Address all review comments before merging
+- Squash merge to keep a clean history

--- a/cli/examples/theme-forge/api.md
+++ b/cli/examples/theme-forge/api.md
@@ -1,0 +1,25 @@
+# API Reference
+
+The DevKit API is organized around REST. All endpoints accept JSON request bodies and return JSON responses.
+
+## Base URL
+
+```
+https://api.devkit.dev/v1
+```
+
+## Authentication
+
+Use your API key in the `Authorization` header:
+
+```
+Authorization: Bearer dk_live_xxx
+```
+
+## Endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | `/process` | Process a document |
+| GET | `/process/{id}` | Get processing result |
+| GET | `/usage` | Get current usage stats |

--- a/cli/examples/theme-forge/changelog.md
+++ b/cli/examples/theme-forge/changelog.md
@@ -1,0 +1,13 @@
+# Changelog
+
+## v2.0.0 — 2026-05-01
+- Redesigned API with streaming support
+- Added Go and Python SDKs
+- Breaking: removed legacy `/v0` endpoints
+
+## v1.5.0 — 2026-03-15
+- Added batch processing endpoint
+- Improved error messages with request IDs
+
+## v1.0.0 — 2026-01-10
+- Initial public release

--- a/cli/examples/theme-forge/guides.md
+++ b/cli/examples/theme-forge/guides.md
@@ -1,0 +1,25 @@
+# Guides
+
+Step-by-step guides for common tasks.
+
+## Quick Start
+
+```bash
+npm install devkit
+```
+
+```javascript
+import { DevKit } from 'devkit';
+
+const client = new DevKit({ apiKey: 'your-key' });
+const result = await client.process({ input: 'Hello' });
+console.log(result);
+```
+
+## Authentication
+
+All API requests require an API key passed in the `Authorization` header:
+
+```bash
+curl -H "Authorization: Bearer YOUR_API_KEY" https://api.devkit.dev/v1/process
+```

--- a/cli/examples/theme-forge/index.md
+++ b/cli/examples/theme-forge/index.md
@@ -1,0 +1,19 @@
+# DevKit Documentation
+
+Welcome to DevKit — a developer toolkit for building modern APIs.
+
+This example demonstrates the **Forge** theme pack with:
+
+- Custom accent colour (green, hue 160)
+- Space Grotesk font family
+- Light/dark logo variants
+- Header with dropdown (SDKs)
+- Footer with columns and social links
+- Sidebar with custom labels
+
+## Features
+
+- **Fast** — built on top of Nextra v4 with static export
+- **Searchable** — Pagefind indexes every page
+- **API Reference** — OpenAPI specs rendered as interactive pages
+- **Themeable** — customise accent colour, fonts, logos via `site.json`

--- a/cli/examples/theme-forge/site.json
+++ b/cli/examples/theme-forge/site.json
@@ -1,0 +1,62 @@
+{
+  "title": "DevKit",
+  "description": "DevKit developer documentation — Forge theme",
+  "nav": [],
+  "theme": {
+    "pack": "forge",
+    "primaryHue": 160,
+    "defaultTheme": "light",
+    "fontFamily": "space-grotesk",
+    "logoUrl": "https://placehold.co/120x32/22c55e/white?text=DevKit",
+    "logoUrlDark": "https://placehold.co/120x32/111827/22c55e?text=DevKit",
+    "favicon": "https://placehold.co/32x32/22c55e/white?text=D"
+  },
+  "header": {
+    "items": [
+      { "label": "Guides", "url": "/guides" },
+      { "label": "API Reference", "url": "/api" },
+      {
+        "label": "SDKs",
+        "items": [
+          { "label": "Node.js", "url": "https://github.com/devkit/node-sdk" },
+          { "label": "Python", "url": "https://github.com/devkit/python-sdk" },
+          { "label": "Go", "url": "https://github.com/devkit/go-sdk" }
+        ]
+      }
+    ]
+  },
+  "footer": {
+    "copyright": "2026 DevKit Labs. All rights reserved.",
+    "columns": [
+      {
+        "title": "Product",
+        "links": [
+          { "label": "Features", "url": "https://devkit.dev/features" },
+          { "label": "Pricing", "url": "https://devkit.dev/pricing" },
+          { "label": "Changelog", "url": "/changelog" }
+        ]
+      },
+      {
+        "title": "Resources",
+        "links": [
+          { "label": "Documentation", "url": "/" },
+          { "label": "API Reference", "url": "/api" },
+          { "label": "Blog", "url": "https://blog.devkit.dev" }
+        ]
+      }
+    ],
+    "socialLinks": {
+      "github": "https://github.com/devkit",
+      "twitter": "https://twitter.com/devkit",
+      "discord": "https://discord.gg/devkit"
+    }
+  },
+  "sidebar": {
+    "/": {
+      "index": "Overview",
+      "guides": "Guides",
+      "api": "API Reference",
+      "changelog": "Changelog"
+    }
+  }
+}

--- a/cli/package.json
+++ b/cli/package.json
@@ -50,6 +50,7 @@
 	"dependencies": {
 		"@anthropic-ai/sdk": "^0.39.0",
 		"@mdx-js/mdx": "^3.1.1",
+		"chokidar": "^4.0.0",
 		"commander": "^13.1.0",
 		"open": "^11.0.0",
 		"yaml": "^2.6.1"

--- a/cli/src/Cli.test.ts
+++ b/cli/src/Cli.test.ts
@@ -3504,7 +3504,7 @@ describe("CLI", () => {
 		it("should auto-reinstall missing hooks when --fix is passed", async () => {
 			const { install } = await import("./install/Installer.js");
 			vi.mocked(install).mockClear();
-			vi.mocked(install).mockResolvedValueOnce({ success: true, message: "ok" });
+			vi.mocked(install).mockResolvedValueOnce({ success: true, message: "ok", warnings: [] });
 
 			await runDoctor(["doctor", "--fix"], { gitHookInstalled: false });
 
@@ -3533,7 +3533,7 @@ describe("CLI", () => {
 			// Simulate install failing — fixer contract is "throw on failure",
 			// so we make install resolve with success=false which the fixer
 			// converts to a thrown error.
-			vi.mocked(install).mockResolvedValueOnce({ success: false, message: "disk full" });
+			vi.mocked(install).mockResolvedValueOnce({ success: false, message: "disk full", warnings: [] });
 			process.exitCode = 0;
 
 			const output = (await runDoctor(["doctor", "--fix"], { gitHookInstalled: false })).join("\n");
@@ -3636,6 +3636,7 @@ describe("CLI", () => {
 						branch: "main",
 						commitMessage: "test",
 						commitDate: "2026-04-01T00:00:00.000Z",
+						generatedAt: "2026-04-01T00:00:00.000Z",
 					})),
 				});
 			} else {
@@ -4606,17 +4607,19 @@ describe("CLI", () => {
 				entries: [
 					{
 						commitHash: "aaa1111111111111111",
+						parentCommitHash: null,
 						branch: "main",
 						commitMessage: "standalone commit",
 						commitDate: "2026-04-01T00:00:00.000Z",
-						// No parentCommitHash — this is a root entry
+						generatedAt: "2026-04-01T00:00:00.000Z",
 					},
 					{
 						commitHash: "bbb2222222222222222",
+						parentCommitHash: null,
 						branch: "main",
 						commitMessage: "another standalone",
 						commitDate: "2026-04-02T00:00:00.000Z",
-						// No parentCommitHash
+						generatedAt: "2026-04-02T00:00:00.000Z",
 					},
 				],
 			});

--- a/cli/src/commands/StartCommand.test.ts
+++ b/cli/src/commands/StartCommand.test.ts
@@ -122,6 +122,11 @@ vi.mock("../site/PagefindRunner.js", () => ({
 	runPagefind: mockRunPagefind,
 }));
 
+const mockStartSourceWatcher = vi.hoisted(() => vi.fn());
+vi.mock("../site/SourceWatcher.js", () => ({
+	startSourceWatcher: mockStartSourceWatcher,
+}));
+
 // ─── Default mock values ──────────────────────────────────────────────────────
 
 const DEFAULT_SITE_JSON_RESULT = {
@@ -183,6 +188,7 @@ function setupSuccessfulRun(
 	mockRunNpmDev.mockResolvedValue({ success: true, output: "" });
 	mockRunPagefind.mockResolvedValue({ success: true, output: "Indexed 5 pages", pagesIndexed: 5 });
 	mockRunServe.mockResolvedValue({ success: true, output: "" });
+	mockStartSourceWatcher.mockReturnValue({ close: vi.fn().mockResolvedValue(undefined) });
 }
 
 // ─── Shared pipeline tests (apply to both start and dev) ─────────────────────
@@ -550,6 +556,84 @@ describe("jolli dev", () => {
 		await program.parseAsync(["dev", "/my-docs"], { from: "user" });
 
 		expect(process.exitCode).toBe(0);
+	});
+
+	// ── Source-folder hot reload ──────────────────────────────────────────────
+
+	it("starts a source-folder watcher rooted at the resolved sourceRoot", async () => {
+		setupSuccessfulRun();
+		const program = await makeProgram();
+		await program.parseAsync(["dev", "/my-docs"], { from: "user" });
+
+		expect(mockStartSourceWatcher).toHaveBeenCalledOnce();
+		const [watchedPath] = mockStartSourceWatcher.mock.calls[0] as [string, { onChange: () => Promise<void> }];
+		expect(watchedPath).toBe(resolve("/my-docs"));
+	});
+
+	it("closes the watcher when the dev server exits cleanly", async () => {
+		setupSuccessfulRun();
+		const closeMock = vi.fn().mockResolvedValue(undefined);
+		mockStartSourceWatcher.mockReturnValue({ close: closeMock });
+		const program = await makeProgram();
+		await program.parseAsync(["dev", "/my-docs"], { from: "user" });
+
+		expect(closeMock).toHaveBeenCalledOnce();
+	});
+
+	it("closes the watcher even when the dev server errors out", async () => {
+		setupSuccessfulRun();
+		mockRunNpmDev.mockResolvedValue({ success: false, output: "Dev error" });
+		const closeMock = vi.fn().mockResolvedValue(undefined);
+		mockStartSourceWatcher.mockReturnValue({ close: closeMock });
+		const program = await makeProgram();
+		await program.parseAsync(["dev", "/my-docs"], { from: "user" });
+
+		expect(process.exitCode).toBe(1);
+		expect(closeMock).toHaveBeenCalledOnce();
+	});
+
+	it("re-runs mirror + nav + openapi when the watcher fires onChange", async () => {
+		setupSuccessfulRun({ openapiFiles: ["api/spec.yaml"] });
+		const program = await makeProgram();
+		await program.parseAsync(["dev", "/my-docs"], { from: "user" });
+
+		// Initial pass already called the mirroring + render path once.
+		const initialMirrorCount = mockMirrorContent.mock.calls.length;
+		const initialRenderCount = mockRenderOpenApiSpecs.mock.calls.length;
+
+		// Trigger the captured onChange to simulate a file edit.
+		const [, options] = mockStartSourceWatcher.mock.calls[0] as [string, { onChange: () => Promise<void> }];
+		await options.onChange();
+
+		expect(mockMirrorContent.mock.calls.length).toBe(initialMirrorCount + 1);
+		expect(mockGenerateMetaFiles).toHaveBeenCalledTimes(2);
+		expect(mockRenderOpenApiSpecs.mock.calls.length).toBe(initialRenderCount + 1);
+	});
+
+	it("logs a synced-file count on each onChange", async () => {
+		setupSuccessfulRun({ markdownFiles: ["a.md", "b.md"], openapiFiles: ["api.yaml"] });
+		const program = await makeProgram();
+		await program.parseAsync(["dev", "/my-docs"], { from: "user" });
+
+		const [, options] = mockStartSourceWatcher.mock.calls[0] as [string, { onChange: () => Promise<void> }];
+		await options.onChange();
+
+		const output = consoleSpy.mock.calls.map((c: unknown[]) => c.join(" ")).join("\n");
+		expect(output).toMatch(/↻ Synced \d+ files/);
+	});
+
+	it("watcher onChange swallows a site.json read error and does NOT crash", async () => {
+		setupSuccessfulRun();
+		const program = await makeProgram();
+		await program.parseAsync(["dev", "/my-docs"], { from: "user" });
+
+		// Make the next site.json read fail; the dev process must keep running.
+		mockReadSiteJson.mockRejectedValueOnce(new Error("transient parse error"));
+		const [, options] = mockStartSourceWatcher.mock.calls[0] as [string, { onChange: () => Promise<void> }];
+		await expect(options.onChange()).resolves.toBeUndefined();
+
+		const errorOutput = consoleErrorSpy.mock.calls.map((c: unknown[]) => c.join(" ")).join("\n");
+		expect(errorOutput).toContain("transient parse error");
 	});
 });
 

--- a/cli/src/commands/StartCommand.ts
+++ b/cli/src/commands/StartCommand.ts
@@ -18,6 +18,7 @@ import { runPagefind } from "../site/PagefindRunner.js";
 import { resolveRenderer, type SiteRenderer } from "../site/renderer/index.js";
 import type { OpenApiSpecInput } from "../site/renderer/SiteRenderer.js";
 import { readSiteJson } from "../site/SiteJsonReader.js";
+import { startSourceWatcher } from "../site/SourceWatcher.js";
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -64,6 +65,60 @@ function buildOpenApiSpecInputs(mirrorResult: Awaited<ReturnType<typeof mirrorCo
 		inputs.push({ specName, sourceRelPath, pipeline: buildPipeline(doc) });
 	}
 	return inputs;
+}
+
+// ─── syncContent ─────────────────────────────────────────────────────────────
+
+/**
+ * Reads `site.json`, mirrors the source folder into `contentDir`, fixes the
+ * sidebar's index key if a file was renamed, regenerates navigation, and
+ * re-renders OpenAPI specs. Used by both the initial `prepareContent` and
+ * the dev-mode source watcher (which calls it on every settled change so
+ * `next dev`'s HMR sees the latest output).
+ *
+ * Side effects this function does NOT do — they're scaffolding-only and
+ * belong to `prepareContent`: `initProject`, clearing the public dir,
+ * resolving favicon, npm install.
+ */
+async function syncContent(
+	sourceRoot: string,
+	contentDir: string,
+	publicDir: string,
+	renderer: SiteRenderer,
+	opts: CmdOpts,
+): Promise<{ success: false } | { success: true; mirrorResult: Awaited<ReturnType<typeof mirrorContent>> }> {
+	let siteJsonResult: Awaited<ReturnType<typeof readSiteJson>>;
+	try {
+		siteJsonResult = await readSiteJson(sourceRoot, { migrate: opts.migrate });
+	} catch (err) {
+		console.error(`  Error: ${err instanceof Error ? err.message : String(err)}`);
+		return { success: false };
+	}
+
+	const mirrorResult = await mirrorContent(
+		sourceRoot,
+		contentDir,
+		siteJsonResult.config.pathMappings,
+		publicDir,
+		renderer.getContentRules(),
+	);
+
+	// Fix sidebar index key if a file was renamed during mirror.
+	const sidebar = siteJsonResult.config.sidebar;
+	if (mirrorResult.renamedToIndex && sidebar?.["/"]?.[mirrorResult.renamedToIndex]) {
+		const label = sidebar["/"][mirrorResult.renamedToIndex];
+		delete sidebar["/"][mirrorResult.renamedToIndex];
+		sidebar["/"] = { index: label, ...sidebar["/"] };
+	}
+
+	await renderer.generateNavigation(contentDir, sidebar);
+
+	if (mirrorResult.openapiFiles.length > 0) {
+		const specInputs = buildOpenApiSpecInputs(mirrorResult);
+		await renderer.renderOpenApiSpecs(contentDir, publicDir, specInputs);
+	}
+
+	return { success: true, mirrorResult };
 }
 
 // ─── prepareContent ──────────────────────────────────────────────────────────
@@ -122,15 +177,14 @@ async function prepareContent(
 	// Resolve favicon
 	await resolveFavicon(siteJsonResult.config.favicon, sourceRoot, publicDir);
 
-	// Mirror content
+	// Mirror + nav + render OpenAPI specs (shared with the dev watcher).
 	verbose("Mirroring content…", v);
-	const mirrorResult = await mirrorContent(
-		sourceRoot,
-		contentDir,
-		siteJsonResult.config.pathMappings,
-		publicDir,
-		renderer.getContentRules(),
-	);
+	const sync = await syncContent(sourceRoot, contentDir, publicDir, renderer, opts);
+	if (!sync.success) {
+		process.exitCode = 1;
+		return { success: false };
+	}
+	const { mirrorResult } = sync;
 
 	const total = mirrorResult.markdownFiles.length + mirrorResult.imageFiles.length + mirrorResult.openapiFiles.length;
 	const downgraded = mirrorResult.downgradedCount;
@@ -141,25 +195,7 @@ async function prepareContent(
 		console.warn("  ⚠ No markdown or OpenAPI files found. Producing an empty site.");
 	}
 
-	// Fix sidebar index key if file was renamed
-	const sidebar = siteJsonResult.config.sidebar;
-	if (mirrorResult.renamedToIndex && sidebar?.["/"]?.[mirrorResult.renamedToIndex]) {
-		const label = sidebar["/"][mirrorResult.renamedToIndex];
-		delete sidebar["/"][mirrorResult.renamedToIndex];
-		sidebar["/"] = { index: label, ...sidebar["/"] };
-	}
-
-	// Generate navigation
-	verbose("Generating navigation…", v);
-	await renderer.generateNavigation(contentDir, sidebar);
 	console.log("  ✓ Generated navigation");
-
-	// Render OpenAPI specs
-	if (mirrorResult.openapiFiles.length > 0) {
-		verbose("Rendering OpenAPI specs…", v);
-		const specInputs = buildOpenApiSpecInputs(mirrorResult);
-		await renderer.renderOpenApiSpecs(contentDir, publicDir, specInputs);
-	}
 
 	// Install dependencies
 	if (needsInstall(buildDir)) {
@@ -281,11 +317,34 @@ export function registerDevCommand(program: Command): void {
 			const result = await prepareContent(sourceRoot, buildDir, contentDir, publicDir, false, opts);
 			if (!result.success) return;
 
+			// Watch the source folder so edits trigger an incremental re-mirror
+			// + re-render of OpenAPI specs while the dev server is running.
+			// Next.js's HMR picks up the writes to <buildDir>/content/.
+			console.log("  Watching source folder for changes…");
+			const watcher = startSourceWatcher(sourceRoot, {
+				onChange: async () => {
+					const sync = await syncContent(sourceRoot, contentDir, publicDir, result.renderer, opts);
+					if (sync.success) {
+						const total =
+							sync.mirrorResult.markdownFiles.length +
+							sync.mirrorResult.imageFiles.length +
+							sync.mirrorResult.openapiFiles.length;
+						const ignored = sync.mirrorResult.ignoredFiles.length;
+						const suffix = ignored > 0 ? ` (${ignored} ignored)` : "";
+						console.log(`  ↻ Synced ${total} files${suffix}`);
+					}
+				},
+			});
+
 			console.log("");
-			const devResult = await result.renderer.runDev(buildDir, opts.verbose === true);
-			if (!devResult.success) {
-				if (devResult.output) console.error(devResult.output);
-				process.exitCode = 1;
+			try {
+				const devResult = await result.renderer.runDev(buildDir, opts.verbose === true);
+				if (!devResult.success) {
+					if (devResult.output) console.error(devResult.output);
+					process.exitCode = 1;
+				}
+			} finally {
+				await watcher.close();
 			}
 		});
 }

--- a/cli/src/core/SessionTracker.test.ts
+++ b/cli/src/core/SessionTracker.test.ts
@@ -660,8 +660,12 @@ describe("SessionTracker", () => {
 					"feature-auth": {
 						slug: "feature-auth",
 						title: "Auth plan",
-						path: "plans/feature-auth.md",
+						sourcePath: "plans/feature-auth.md",
+						addedAt: "2026-03-01T10:00:00Z",
 						updatedAt: "2026-03-01T10:00:00Z",
+						branch: "main",
+						commitHash: null,
+						editCount: 0,
 					},
 				},
 			};
@@ -677,8 +681,12 @@ describe("SessionTracker", () => {
 					"feature-auth": {
 						slug: "feature-auth",
 						title: "Auth plan",
-						path: "plans/feature-auth.md",
+						sourcePath: "plans/feature-auth.md",
+						addedAt: "2026-03-01T10:00:00Z",
 						updatedAt: "2026-03-01T10:00:00Z",
+						branch: "main",
+						commitHash: null,
+						editCount: 0,
 					},
 				},
 			};
@@ -707,8 +715,12 @@ describe("SessionTracker", () => {
 					"feature-auth": {
 						slug: "feature-auth",
 						title: "Auth plan",
-						path: "plans/feature-auth.md",
+						sourcePath: "plans/feature-auth.md",
+						addedAt: "2026-03-01T10:00:00Z",
 						updatedAt: "2026-03-01T10:00:00Z",
+						branch: "main",
+						commitHash: null,
+						editCount: 0,
 					},
 				},
 			};
@@ -728,8 +740,12 @@ describe("SessionTracker", () => {
 					"feature-auth": {
 						slug: "feature-auth",
 						title: "Auth plan",
-						path: "plans/feature-auth.md",
+						sourcePath: "plans/feature-auth.md",
+						addedAt: "2026-03-01T10:00:00Z",
 						updatedAt: "2026-03-01T10:00:00Z",
+						branch: "main",
+						commitHash: null,
+						editCount: 0,
 					},
 				},
 			};
@@ -747,8 +763,11 @@ describe("SessionTracker", () => {
 					"feature-auth": {
 						slug: "feature-auth",
 						title: "Auth plan",
-						path: "plans/feature-auth.md",
+						sourcePath: "plans/feature-auth.md",
+						addedAt: "2026-03-01T10:00:00Z",
 						updatedAt: "2026-03-01T10:00:00Z",
+						branch: "main",
+						editCount: 0,
 						commitHash: "abcdef1234567890",
 					},
 				},

--- a/cli/src/core/StorageFactory.test.ts
+++ b/cli/src/core/StorageFactory.test.ts
@@ -57,25 +57,31 @@ describe("StorageFactory", () => {
 		const storage = await createStorage("/project/path");
 
 		expect(DualWriteStorage).toHaveBeenCalledOnce();
-		expect((storage as Record<string, unknown>).type).toBe("dual-write");
+		expect((storage as unknown as Record<string, unknown>).type).toBe("dual-write");
 	});
 
 	it('returns OrphanBranchStorage when storageMode is "orphan"', async () => {
-		mockLoadConfig.mockResolvedValue({ storageMode: "orphan" });
+		// `storageMode` is read off the config via a cast in StorageFactory.ts;
+		// the type doesn't declare the field but the implementation tolerates it.
+		mockLoadConfig.mockResolvedValue({ storageMode: "orphan" } as unknown as Awaited<
+			ReturnType<typeof loadConfig>
+		>);
 
 		const storage = await createStorage("/project/path");
 
 		expect(OrphanBranchStorage).toHaveBeenCalledOnce();
-		expect((storage as Record<string, unknown>).type).toBe("orphan");
+		expect((storage as unknown as Record<string, unknown>).type).toBe("orphan");
 	});
 
 	it('returns FolderStorage when storageMode is "folder"', async () => {
-		mockLoadConfig.mockResolvedValue({ storageMode: "folder" });
+		mockLoadConfig.mockResolvedValue({ storageMode: "folder" } as unknown as Awaited<
+			ReturnType<typeof loadConfig>
+		>);
 
 		const storage = await createStorage("/project/path");
 
 		expect(FolderStorage).toHaveBeenCalledOnce();
-		expect((storage as Record<string, unknown>).type).toBe("folder");
+		expect((storage as unknown as Record<string, unknown>).type).toBe("folder");
 	});
 
 	it("falls back to DualWriteStorage with warning when loadConfig fails", async () => {
@@ -85,7 +91,7 @@ describe("StorageFactory", () => {
 		const storage = await createStorage("/project/path");
 
 		expect(DualWriteStorage).toHaveBeenCalledOnce();
-		expect((storage as Record<string, unknown>).type).toBe("dual-write");
+		expect((storage as unknown as Record<string, unknown>).type).toBe("dual-write");
 		// Verify that a warning was logged (our Logger writes to console.warn)
 		expect(warnSpy).toHaveBeenCalled();
 	});

--- a/cli/src/core/Summarizer.test.ts
+++ b/cli/src/core/Summarizer.test.ts
@@ -1,9 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { LlmCallResult } from "./LlmClient.js";
+import type { LlmCallOptions, LlmCallResult } from "./LlmClient.js";
 
-const mockCallLlm = vi.fn<() => Promise<LlmCallResult>>();
+const mockCallLlm = vi.fn<(options: LlmCallOptions) => Promise<LlmCallResult>>();
 vi.mock("./LlmClient.js", () => ({
-	callLlm: (...args: unknown[]) => mockCallLlm(...args),
+	callLlm: (options: LlmCallOptions) => mockCallLlm(options),
 }));
 
 vi.spyOn(console, "log").mockImplementation(() => {});
@@ -1437,7 +1437,7 @@ Test reordering
 			const result = await generateE2eTest({
 				commitMessage: "Fix bug",
 				topics: [{ title: "Fix", trigger: "Bug", response: "Fixed", decisions: "D" }],
-				diffSummary: "+1 -1",
+				diff: "+1 -1",
 				config: mockConfig,
 			});
 

--- a/cli/src/core/SummaryStore.test.ts
+++ b/cli/src/core/SummaryStore.test.ts
@@ -158,7 +158,6 @@ describe("SummaryStore", () => {
 						{
 							sessionId: "claude/session-1",
 							source: "claude",
-							startedAt: "2026-02-19T09:55:00Z",
 							entries: [],
 						},
 					],
@@ -608,9 +607,9 @@ describe("SummaryStore", () => {
 				],
 				e2eTestGuide: [
 					{
-						name: "checkout flow",
+						title: "checkout flow",
 						steps: ["open cart", "submit order"],
-						expectedResult: "order succeeds",
+						expectedResults: ["order succeeds"],
 					},
 				],
 			};
@@ -632,9 +631,9 @@ describe("SummaryStore", () => {
 			]);
 			expect(newSummaryContent.e2eTestGuide).toEqual([
 				{
-					name: "checkout flow",
+					title: "checkout flow",
 					steps: ["open cart", "submit order"],
-					expectedResult: "order succeeds",
+					expectedResults: ["order succeeds"],
 				},
 			]);
 			expect(newSummaryContent.children?.[0].plans).toBeUndefined();
@@ -2180,7 +2179,7 @@ describe("SummaryStore", () => {
 			generatedAt: "2026-01-01T00:00:05Z",
 			transcriptEntries: 0,
 			stats: { filesChanged: 0, insertions: 0, deletions: 0 },
-			topics: topics.map((t) => ({ title: t, detail: t, decisions: undefined })),
+			topics: topics.map((t) => ({ title: t, trigger: t, response: t, decisions: "" })),
 		});
 
 		it("preserves grandchild topics in v3 squash-of-squash scenario", () => {
@@ -2222,7 +2221,7 @@ describe("SummaryStore", () => {
 				generatedAt: "2026-01-01T00:00:05Z",
 				transcriptEntries: 0,
 				stats: { filesChanged: 0, insertions: 0, deletions: 0 },
-				topics: [{ title: "v4-topic", detail: "d", decisions: undefined }],
+				topics: [{ title: "v4-topic", trigger: "t", response: "r", decisions: "" }],
 			};
 
 			const sources = expandSourcesForConsolidation(v4Summary);
@@ -2245,7 +2244,7 @@ describe("SummaryStore", () => {
 				stats: { filesChanged: 0, insertions: 0, deletions: 0 },
 				ticketId: "PROJ-123",
 				recap: "The developer added drag-handle reordering.",
-				topics: [{ title: "x", detail: "d", decisions: undefined }],
+				topics: [{ title: "x", trigger: "t", response: "r", decisions: "" }],
 			};
 
 			const sources = expandSourcesForConsolidation(v4Summary);

--- a/cli/src/hooks/PostCommitHook.helpers.test.ts
+++ b/cli/src/hooks/PostCommitHook.helpers.test.ts
@@ -782,16 +782,13 @@ describe("PostCommitHook helpers", () => {
 
 	describe("buildStoredTranscript", () => {
 		it("falls back to the session transcript path when the session metadata is missing", () => {
-			const stored = __test__.buildStoredTranscript(
-				[
-					{
-						sessionId: "sess-1",
-						transcriptPath: "/tmp/from-transcript.jsonl",
-						entries: [{ role: "human", content: "hi" }],
-					},
-				],
-				[],
-			);
+			const stored = __test__.buildStoredTranscript([
+				{
+					sessionId: "sess-1",
+					transcriptPath: "/tmp/from-transcript.jsonl",
+					entries: [{ role: "human", content: "hi" }],
+				},
+			]);
 
 			expect(stored.sessions[0].transcriptPath).toBe("/tmp/from-transcript.jsonl");
 		});

--- a/cli/src/hooks/PostCommitHook.test.ts
+++ b/cli/src/hooks/PostCommitHook.test.ts
@@ -1424,10 +1424,10 @@ describe("queue-driven Worker", () => {
 
 			// Mock fs to allow reading the note file
 			vi.mocked(existsSync).mockImplementation((path) => path === noteSourcePath);
-			vi.mocked(readFileSync).mockImplementation((path) => {
-				if (path === noteSourcePath) return "# Test note content" as unknown as Buffer;
-				return "" as unknown as Buffer;
-			});
+			vi.mocked(readFileSync).mockImplementation(((path: unknown) => {
+				if (path === noteSourcePath) return "# Test note content";
+				return "";
+			}) as typeof readFileSync);
 
 			await runWorker("/test/project");
 
@@ -1979,7 +1979,7 @@ describe("queue-driven Worker", () => {
 			});
 			vi.mocked(getSummary).mockResolvedValue({
 				...createMockSummary("oldHash"),
-				e2eTestGuide: { scenarios: [{ title: "Test scenario", steps: ["step 1"], assertions: ["assert 1"] }] },
+				e2eTestGuide: [{ title: "Test scenario", steps: ["step 1"], expectedResults: ["assert 1"] }],
 			});
 			vi.mocked(loadConfig).mockResolvedValue({});
 			vi.mocked(loadAllSessions).mockResolvedValue([]);
@@ -1995,7 +1995,7 @@ describe("queue-driven Worker", () => {
 
 			expect(storeSummary).toHaveBeenCalledWith(
 				expect.objectContaining({
-					e2eTestGuide: expect.objectContaining({ scenarios: expect.any(Array) }),
+					e2eTestGuide: expect.any(Array),
 				}),
 				"/test/project",
 			);
@@ -2041,7 +2041,7 @@ describe("queue-driven Worker", () => {
 			//   2. detectUncommittedNoteIds → registry WITH ghost note (id added to set)
 			//   3. associateNotesWithCommit → registry WITHOUT that note (id missing → skip)
 			const registryWithNote = {
-				version: 1,
+				version: 1 as const,
 				plans: {},
 				notes: {
 					"ghost-note": {
@@ -2056,7 +2056,7 @@ describe("queue-driven Worker", () => {
 					},
 				},
 			};
-			const emptyRegistry = { version: 1, plans: {}, notes: {} };
+			const emptyRegistry = { version: 1 as const, plans: {}, notes: {} };
 
 			vi.mocked(loadPlansRegistry)
 				.mockResolvedValueOnce(emptyRegistry) // detectPlanSlugsFromRegistry
@@ -2091,10 +2091,10 @@ describe("queue-driven Worker", () => {
 				},
 			});
 			vi.mocked(existsSync).mockImplementation((path) => path === snippetPath);
-			vi.mocked(readFileSync).mockImplementation((path) => {
-				if (path === snippetPath) return "const x = 42;" as unknown as Buffer;
-				return "" as unknown as Buffer;
-			});
+			vi.mocked(readFileSync).mockImplementation(((path: unknown) => {
+				if (path === snippetPath) return "const x = 42;";
+				return "";
+			}) as typeof readFileSync);
 
 			await runWorker("/test/project");
 

--- a/cli/src/hooks/StopHook.test.ts
+++ b/cli/src/hooks/StopHook.test.ts
@@ -313,7 +313,9 @@ describe("StopHook — plan discovery", () => {
 		vi.mocked(loadPlansRegistry).mockResolvedValue({ version: 1, plans: {} });
 		// Default: files don't exist
 		vi.mocked(existsSync).mockReturnValue(false);
-		vi.mocked(readFileSync).mockReturnValue("# Plan Title\n\nContent" as unknown as Buffer);
+		vi.mocked(readFileSync).mockReturnValue(
+			"# Plan Title\n\nContent" as unknown as ReturnType<typeof readFileSync>,
+		);
 	});
 
 	afterEach(() => {
@@ -423,7 +425,7 @@ describe("StopHook — plan discovery", () => {
 
 	it("should fall back to the file name when the plan has no markdown heading", async () => {
 		vi.mocked(existsSync).mockReturnValueOnce(true).mockReturnValueOnce(true);
-		vi.mocked(readFileSync).mockReturnValueOnce("plain text only" as unknown as Buffer);
+		vi.mocked(readFileSync).mockReturnValueOnce("plain text only" as unknown as ReturnType<typeof readFileSync>);
 
 		mockTranscriptWithLines(['{"type":"tool_result","slug":"untitled-plan","content":"..."}']);
 

--- a/cli/src/install/Installer.test.ts
+++ b/cli/src/install/Installer.test.ts
@@ -1253,7 +1253,7 @@ describe("Installer", () => {
 
 		it("should exclude OpenCode sessions when openCodeEnabled is false", async () => {
 			const { isOpenCodeInstalled, scanOpenCodeSessions } = await import("../core/OpenCodeSessionDiscoverer.js");
-			const { saveConfig } = await import("../core/SessionTracker.js");
+			const { saveConfigScoped } = await import("../core/SessionTracker.js");
 			vi.mocked(isOpenCodeInstalled).mockResolvedValue(true);
 			vi.mocked(scanOpenCodeSessions).mockResolvedValue({
 				sessions: [
@@ -1266,8 +1266,7 @@ describe("Installer", () => {
 				],
 			});
 
-			const projectConfigDir = join(tempDir, ".jolli", "jollimemory");
-			await saveConfig({ openCodeEnabled: false }, undefined, projectConfigDir);
+			await saveConfigScoped({ openCodeEnabled: false }, emptyGlobalDir);
 			const status = await getStatus(tempDir);
 			expect(status.activeSessions).toBe(0);
 			expect(status.mostRecentSession).toBeNull();
@@ -1982,7 +1981,7 @@ describe("Installer", () => {
 			);
 
 			const status = await getStatus(tempDir);
-			expect(status.sessionsBySource.claude).toBe(1);
+			expect(status.sessionsBySource?.claude).toBe(1);
 		});
 
 		it("should compute mostRecentSession via reduce when multiple enabled sessions exist", async () => {

--- a/cli/src/site/NextraProjectWriter.test.ts
+++ b/cli/src/site/NextraProjectWriter.test.ts
@@ -227,6 +227,225 @@ describe("NextraProjectWriter.generateLayout", () => {
 		expect(result).toContain("'nextra-theme-docs/style.css'");
 		expect(result).toContain("'../styles/api.css'");
 	});
+
+	// ── theme.pack dispatcher (Phase 1) ──────────────────────────────────────
+
+	it("uses the default layout when theme.pack is unset", async () => {
+		const { generateLayout, generateDefaultLayout } = await import("./NextraProjectWriter.js");
+		expect(generateLayout(SAMPLE_CONFIG)).toBe(generateDefaultLayout(SAMPLE_CONFIG));
+	});
+
+	it("uses the default layout when theme.pack is explicitly 'default'", async () => {
+		const { generateLayout, generateDefaultLayout } = await import("./NextraProjectWriter.js");
+		const config = { ...SAMPLE_CONFIG, theme: { pack: "default" as const } };
+		expect(generateLayout(config)).toBe(generateDefaultLayout(SAMPLE_CONFIG));
+	});
+
+	it("forge pack returns the Forge layout (forge-sidebar-logo + forge.css import)", async () => {
+		const { generateLayout } = await import("./NextraProjectWriter.js");
+		const config = { ...SAMPLE_CONFIG, theme: { pack: "forge" as const } };
+		const result = generateLayout(config);
+		expect(result).toContain("forge-sidebar-logo");
+		expect(result).toContain("./themes/forge.css");
+	});
+
+	it("atlas pack returns the Atlas layout (atlas-navbar-logo + atlas.css import)", async () => {
+		const { generateLayout } = await import("./NextraProjectWriter.js");
+		const config = { ...SAMPLE_CONFIG, theme: { pack: "atlas" as const } };
+		const result = generateLayout(config);
+		expect(result).toContain("atlas-navbar-logo");
+		expect(result).toContain("./themes/atlas.css");
+	});
+
+	it("default layout passes through theme branding fields without crashing (no-op for now)", async () => {
+		const { generateLayout } = await import("./NextraProjectWriter.js");
+		const config = {
+			...SAMPLE_CONFIG,
+			theme: {
+				logoUrl: "/logo.svg",
+				logoUrlDark: "/logo-dark.svg",
+				favicon: "/favicon.ico",
+				primaryHue: 200,
+				defaultTheme: "dark" as const,
+				fontFamily: "inter" as const,
+			},
+		};
+		const result = generateLayout(config);
+		expect(result).toContain("My API Docs");
+		expect(result).toContain("nextra-theme-docs");
+	});
+
+	// ── header / footer (post-1392 schema) ────────────────────────────────────
+
+	it("renders header.items direct links the same way as legacy nav", async () => {
+		const { generateLayout } = await import("./NextraProjectWriter.js");
+		const result = generateLayout({
+			title: "T",
+			description: "D",
+			nav: [],
+			header: { items: [{ label: "Guides", url: "/guides" }] },
+		});
+		expect(result).toContain('<a href={"/guides"}');
+		expect(result).toContain('{"Guides"}');
+	});
+
+	it("prefers header.items over the legacy nav shorthand when both are set", async () => {
+		const { generateLayout } = await import("./NextraProjectWriter.js");
+		const result = generateLayout({
+			title: "T",
+			description: "D",
+			nav: [{ label: "FromNav", href: "/nav" }],
+			header: { items: [{ label: "FromHeader", url: "/header" }] },
+		});
+		expect(result).toContain("FromHeader");
+		expect(result).not.toContain("FromNav");
+	});
+
+	it("renders a <details> dropdown when a header item has sub-items", async () => {
+		const { generateLayout } = await import("./NextraProjectWriter.js");
+		const result = generateLayout({
+			title: "T",
+			description: "D",
+			nav: [],
+			header: {
+				items: [
+					{
+						label: "Resources",
+						items: [
+							{ label: "Blog", url: "/blog" },
+							{ label: "Changelog", url: "/changelog" },
+						],
+					},
+				],
+			},
+		});
+		expect(result).toContain("<details");
+		expect(result).toContain("<summary");
+		expect(result).toContain('{"Resources"}');
+		expect(result).toContain('{"Blog"}');
+		expect(result).toContain('{"Changelog"}');
+		expect(result).toContain('<a href={"/blog"}');
+	});
+
+	it("emits a bare <Footer /> when no footer config is provided (back-compat)", async () => {
+		const { generateLayout } = await import("./NextraProjectWriter.js");
+		const result = generateLayout(SAMPLE_CONFIG);
+		expect(result).toContain("footer={<Footer />}");
+	});
+
+	it("emits a bare <Footer /> when footer is set but has no rendering content", async () => {
+		const { generateLayout } = await import("./NextraProjectWriter.js");
+		const result = generateLayout({
+			title: "T",
+			description: "D",
+			nav: [],
+			footer: { columns: [], socialLinks: {} },
+		});
+		expect(result).toContain("footer={<Footer />}");
+	});
+
+	it("renders footer copyright text", async () => {
+		const { generateLayout } = await import("./NextraProjectWriter.js");
+		const result = generateLayout({
+			title: "T",
+			description: "D",
+			nav: [],
+			footer: { copyright: "2026 Acme Inc." },
+		});
+		expect(result).toContain("<Footer>");
+		expect(result).toContain('{"2026 Acme Inc."}');
+	});
+
+	it("renders footer columns with titles and links", async () => {
+		const { generateLayout } = await import("./NextraProjectWriter.js");
+		const result = generateLayout({
+			title: "T",
+			description: "D",
+			nav: [],
+			footer: {
+				columns: [
+					{
+						title: "Product",
+						links: [
+							{ label: "Pricing", url: "/pricing" },
+							{ label: "Docs", url: "/docs" },
+						],
+					},
+				],
+			},
+		});
+		expect(result).toContain('{"Product"}');
+		expect(result).toContain('{"Pricing"}');
+		expect(result).toContain('<a href={"/pricing"}');
+		expect(result).toContain('<a href={"/docs"}');
+	});
+
+	it("renders footer social links in canonical platform order, skipping unset ones", async () => {
+		const { generateLayout } = await import("./NextraProjectWriter.js");
+		const result = generateLayout({
+			title: "T",
+			description: "D",
+			nav: [],
+			footer: { socialLinks: { youtube: "https://yt.example", github: "https://gh.example" } },
+		});
+		// github appears before youtube in SOCIAL_PLATFORMS; verify ordering survived.
+		const ghIdx = result.indexOf("gh.example");
+		const ytIdx = result.indexOf("yt.example");
+		expect(ghIdx).toBeGreaterThan(-1);
+		expect(ytIdx).toBeGreaterThan(-1);
+		expect(ghIdx).toBeLessThan(ytIdx);
+		expect(result).toContain('aria-label={"github"}');
+		expect(result).toContain('aria-label={"youtube"}');
+		expect(result).not.toContain('aria-label={"twitter"}');
+	});
+
+	it("sanitizes javascript: URLs in header items to '#'", async () => {
+		const { generateLayout } = await import("./NextraProjectWriter.js");
+		const result = generateLayout({
+			title: "T",
+			description: "D",
+			nav: [],
+			header: { items: [{ label: "Bad", url: "javascript:alert(1)" }] },
+		});
+		expect(result).not.toContain("javascript:alert");
+		expect(result).toContain('<a href={"#"}');
+	});
+
+	it("sanitizes javascript: URLs in dropdown sub-items to '#'", async () => {
+		const { generateLayout } = await import("./NextraProjectWriter.js");
+		const result = generateLayout({
+			title: "T",
+			description: "D",
+			nav: [],
+			header: {
+				items: [
+					{
+						label: "Menu",
+						items: [{ label: "Bad", url: "JAVASCRIPT:alert(1)" }],
+					},
+				],
+			},
+		});
+		expect(result).not.toMatch(/javascript:alert/i);
+		expect(result).toContain('<a href={"#"}');
+	});
+
+	it("sanitizes javascript: URLs in footer column links and social links", async () => {
+		const { generateLayout } = await import("./NextraProjectWriter.js");
+		const result = generateLayout({
+			title: "T",
+			description: "D",
+			nav: [],
+			footer: {
+				columns: [{ title: "X", links: [{ label: "Bad", url: "javascript:alert(1)" }] }],
+				socialLinks: { github: "data:text/html,evil" },
+			},
+		});
+		expect(result).not.toContain("javascript:alert");
+		expect(result).not.toContain("data:text/html");
+		// Both unsafe URLs should have been replaced with "#".
+		expect(result.match(/<a href={"#"}/g)?.length).toBeGreaterThanOrEqual(2);
+	});
 });
 
 // ─── generateMdxComponents unit tests ────────────────────────────────────────
@@ -497,6 +716,102 @@ describe("NextraProjectWriter.initNextraProject", () => {
 		expect(content).toContain("nextra");
 		expect(content).toContain("export default");
 	});
+
+	// ── Forge pack: writes app/themes/forge.css ──────────────────────────────
+
+	it("writes app/themes/forge.css when theme.pack is 'forge'", async () => {
+		const { initNextraProject } = await import("./NextraProjectWriter.js");
+		const buildDir = join(tempDir, ".jolli-site");
+		const config = { ...SAMPLE_CONFIG, theme: { pack: "forge" as const } };
+
+		await initNextraProject(buildDir, config);
+
+		expect(existsSync(join(buildDir, "app", "themes", "forge.css"))).toBe(true);
+	});
+
+	it("does NOT write app/themes/forge.css for the default pack", async () => {
+		const { initNextraProject } = await import("./NextraProjectWriter.js");
+		const buildDir = join(tempDir, ".jolli-site");
+
+		await initNextraProject(buildDir, SAMPLE_CONFIG);
+
+		expect(existsSync(join(buildDir, "app", "themes", "forge.css"))).toBe(false);
+	});
+
+	it("forge.css reflects theme.primaryHue in the generated overrides", async () => {
+		const { initNextraProject } = await import("./NextraProjectWriter.js");
+		const buildDir = join(tempDir, ".jolli-site");
+		const config = { ...SAMPLE_CONFIG, theme: { pack: "forge" as const, primaryHue: 145 } };
+
+		await initNextraProject(buildDir, config);
+
+		const css = await readFile(join(buildDir, "app", "themes", "forge.css"), "utf-8");
+		expect(css).toContain("--nextra-primary-hue:        145");
+		expect(css).toContain("hsl(145");
+	});
+
+	it("forge.css reflects theme.fontFamily in the generated overrides", async () => {
+		const { initNextraProject } = await import("./NextraProjectWriter.js");
+		const buildDir = join(tempDir, ".jolli-site");
+		const config = {
+			...SAMPLE_CONFIG,
+			theme: { pack: "forge" as const, fontFamily: "ibm-plex" as const },
+		};
+
+		await initNextraProject(buildDir, config);
+
+		const css = await readFile(join(buildDir, "app", "themes", "forge.css"), "utf-8");
+		expect(css).toContain("--forge-font-family:");
+		expect(css).toContain("IBM Plex Sans");
+	});
+
+	// ── Atlas pack: writes app/themes/atlas.css ──────────────────────────────
+
+	it("writes app/themes/atlas.css when theme.pack is 'atlas'", async () => {
+		const { initNextraProject } = await import("./NextraProjectWriter.js");
+		const buildDir = join(tempDir, ".jolli-site");
+		const config = { ...SAMPLE_CONFIG, theme: { pack: "atlas" as const } };
+
+		await initNextraProject(buildDir, config);
+
+		expect(existsSync(join(buildDir, "app", "themes", "atlas.css"))).toBe(true);
+	});
+
+	it("does NOT write app/themes/atlas.css for the forge pack", async () => {
+		const { initNextraProject } = await import("./NextraProjectWriter.js");
+		const buildDir = join(tempDir, ".jolli-site");
+		const config = { ...SAMPLE_CONFIG, theme: { pack: "forge" as const } };
+
+		await initNextraProject(buildDir, config);
+
+		expect(existsSync(join(buildDir, "app", "themes", "atlas.css"))).toBe(false);
+	});
+
+	it("atlas.css uses Atlas's manifest hue (200) when primaryHue is unset", async () => {
+		const { initNextraProject } = await import("./NextraProjectWriter.js");
+		const buildDir = join(tempDir, ".jolli-site");
+		const config = { ...SAMPLE_CONFIG, theme: { pack: "atlas" as const } };
+
+		await initNextraProject(buildDir, config);
+
+		const css = await readFile(join(buildDir, "app", "themes", "atlas.css"), "utf-8");
+		expect(css).toContain("--nextra-primary-hue:        200");
+	});
+
+	it("atlas.css reflects theme.fontFamily in the generated overrides", async () => {
+		const { initNextraProject } = await import("./NextraProjectWriter.js");
+		const buildDir = join(tempDir, ".jolli-site");
+		const config = {
+			...SAMPLE_CONFIG,
+			theme: { pack: "atlas" as const, fontFamily: "source-sans" as const },
+		};
+
+		await initNextraProject(buildDir, config);
+
+		const css = await readFile(join(buildDir, "app", "themes", "atlas.css"), "utf-8");
+		expect(css).toContain("--atlas-font-family:");
+		expect(css).toContain("Source Sans 3");
+	});
 });
 
 // ─── Property-based tests ─────────────────────────────────────────────────────
@@ -576,8 +891,18 @@ describe("Property 5: site.json fields are preserved in generated Nextra config"
 		);
 	});
 
-	it("generateLayout always contains all nav item hrefs", async () => {
+	it("generateLayout always contains the sanitized form of every nav item href", async () => {
 		const { generateLayout } = await import("./NextraProjectWriter.js");
+
+		// sanitizeUrl trims whitespace and replaces non-safe schemes with "#".
+		// The output embeds each href via JSON.stringify(sanitizeUrl(href)).
+		function expectedHref(href: string): string {
+			const trimmed = href.trim();
+			if (trimmed === "" || /^(?:https?:|mailto:|tel:|[#?/]|\.\.?\/)/i.test(trimmed)) {
+				return JSON.stringify(trimmed);
+			}
+			return JSON.stringify("#");
+		}
 
 		fc.assert(
 			fc.property(
@@ -587,7 +912,7 @@ describe("Property 5: site.json fields are preserved in generated Nextra config"
 				(title, description, nav) => {
 					const config = { title, description, nav };
 					const result = generateLayout(config);
-					return nav.every(({ href }) => result.includes(href));
+					return nav.every(({ href }) => result.includes(expectedHref(href)));
 				},
 			),
 			{ numRuns: 100 },

--- a/cli/src/site/NextraProjectWriter.ts
+++ b/cli/src/site/NextraProjectWriter.ts
@@ -15,6 +15,19 @@
 import { existsSync } from "node:fs";
 import { mkdir, writeFile } from "node:fs/promises";
 import { join } from "node:path";
+import type { FooterConfig, HeaderConfig, HeaderItem, NavLink, ThemeConfig, ThemePack } from "./Types.js";
+import {
+	buildAtlasCss,
+	buildAtlasFontFamilyCssValue,
+	generateAtlasLayoutTsx,
+	resolveAtlasLayoutInput,
+} from "./themes/atlas/index.js";
+import {
+	buildForgeCss,
+	buildForgeFontFamilyCssValue,
+	generateForgeLayoutTsx,
+	resolveForgeLayoutInput,
+} from "./themes/forge/index.js";
 
 // ─── NextraProjectConfig ──────────────────────────────────────────────────────
 
@@ -25,7 +38,16 @@ import { join } from "node:path";
 export interface NextraProjectConfig {
 	title: string;
 	description: string;
-	nav: Array<{ label: string; href: string }>;
+	nav: NavLink[];
+	header?: HeaderConfig;
+	footer?: FooterConfig;
+	/**
+	 * Legacy top-level `favicon` URL. Deprecated alias for `theme.favicon`;
+	 * when both are set the top-level value wins so existing sites keep
+	 * working unchanged.
+	 */
+	favicon?: string;
+	theme?: ThemeConfig;
 }
 
 // ─── initNextraProject ────────────────────────────────────────────────────────
@@ -59,6 +81,29 @@ export async function initNextraProject(
 	await writeFile(join(buildDir, "app", "[[...mdxPath]]", "page.tsx"), generateCatchAllPage(), "utf-8");
 	await writeFile(join(buildDir, "mdx-components.tsx"), generateMdxComponents(), "utf-8");
 	await writeFile(join(buildDir, "tsconfig.json"), generateTsConfig(), "utf-8");
+
+	// Pack-specific stylesheet — only written when the user opts into a
+	// non-default pack. Each pack's layout imports its own CSS file, so the
+	// file has to land before `next dev` reads the layout module.
+	if (config.theme?.pack === "forge") {
+		await mkdir(join(buildDir, "app", "themes"), { recursive: true });
+		const primaryHue = config.theme.primaryHue ?? 228;
+		const fontFamily = config.theme.fontFamily ?? "inter";
+		const css = buildForgeCss({
+			accentHue: primaryHue,
+			fontFamily: buildForgeFontFamilyCssValue(fontFamily),
+		});
+		await writeFile(join(buildDir, "app", "themes", "forge.css"), css, "utf-8");
+	} else if (config.theme?.pack === "atlas") {
+		await mkdir(join(buildDir, "app", "themes"), { recursive: true });
+		const primaryHue = config.theme.primaryHue ?? 200;
+		const fontFamily = config.theme.fontFamily ?? "source-serif";
+		const css = buildAtlasCss({
+			accentHue: primaryHue,
+			fontFamily: buildAtlasFontFamilyCssValue(fontFamily),
+		});
+		await writeFile(join(buildDir, "app", "themes", "atlas.css"), css, "utf-8");
+	}
 
 	return { isNew };
 }
@@ -137,31 +182,168 @@ export default withNextra({${exportLines}
 `;
 }
 
-// ─── generateLayout ──────────────────────────────────────────────────────────
+// ─── generateLayout helpers ──────────────────────────────────────────────────
+
+/** Social platforms supported in the footer, in display order. */
+const SOCIAL_PLATFORMS = ["github", "twitter", "discord", "linkedin", "youtube"] as const;
 
 /**
- * Returns the contents of `app/layout.tsx` — the root layout for the Nextra v4
- * docs theme.
- *
- * Maps `title`, `description`, and `nav` from `site.json` into the Nextra
- * Layout, Navbar, and Footer components.
+ * Allow http(s), mailto, tel, fragments, query strings, and absolute or
+ * relative paths. Anything else (e.g. `javascript:`, `data:`, `vbscript:`)
+ * is replaced with `"#"` so a malicious site.json can't inject a script URL.
+ */
+function sanitizeUrl(url: string): string {
+	const trimmed = url.trim();
+	if (trimmed === "" || /^(?:https?:|mailto:|tel:|[#?/]|\.\.?\/)/i.test(trimmed)) {
+		return trimmed;
+	}
+	return "#";
+}
+
+/**
+ * Resolves the navbar's logical item list. `header.items` wins when set;
+ * otherwise the legacy flat `nav` is coerced into dropdown-less items so
+ * pre-`header` site.json files keep rendering unchanged.
+ */
+function resolveHeaderItems(config: NextraProjectConfig): HeaderItem[] {
+	if (config.header?.items && config.header.items.length > 0) {
+		return config.header.items;
+	}
+	return config.nav.map((n) => ({ label: n.label, url: n.href }));
+}
+
+/** Renders a single header item — either an `<a>` or a `<details>` dropdown. */
+function renderNavbarChild(item: HeaderItem): string {
+	const jsLabel = JSON.stringify(item.label);
+	if (item.items && item.items.length > 0) {
+		const subLinks = item.items
+			.map((sub) => {
+				const jsSubLabel = JSON.stringify(sub.label);
+				const jsSubHref = JSON.stringify(sanitizeUrl(sub.url));
+				return `              <a href={${jsSubHref}} style={{ display: 'block', padding: '0.25rem 0.75rem', whiteSpace: 'nowrap' }}>{${jsSubLabel}}</a>`;
+			})
+			.join("\n");
+		return [
+			`          <details style={{ marginLeft: '1rem', display: 'inline-block', position: 'relative' }}>`,
+			`            <summary style={{ cursor: 'pointer', listStyle: 'none' }}>{${jsLabel}}</summary>`,
+			`            <div style={{ position: 'absolute', top: '100%', left: 0, marginTop: '0.25rem', background: 'var(--nextra-bg, #fff)', border: '1px solid var(--nextra-border, #e5e7eb)', borderRadius: 4, padding: '0.25rem 0', minWidth: 160, zIndex: 10 }}>`,
+			subLinks,
+			`            </div>`,
+			`          </details>`,
+		].join("\n");
+	}
+	const jsHref = JSON.stringify(sanitizeUrl(item.url ?? "#"));
+	return `          <a href={${jsHref}} style={{ marginLeft: '1rem' }}>{${jsLabel}}</a>`;
+}
+
+/** Builds the inner JSX of `<Footer>`, or `""` when there's nothing to render. */
+function buildFooterBody(footer: FooterConfig | undefined): string {
+	if (!footer) return "";
+
+	const hasColumns = footer.columns && footer.columns.length > 0;
+	const hasCopyright = typeof footer.copyright === "string" && footer.copyright.length > 0;
+	const socials = footer.socialLinks;
+	const socialEntries = socials
+		? SOCIAL_PLATFORMS.filter((p) => typeof socials[p] === "string" && socials[p] !== "")
+		: [];
+	const hasSocial = socialEntries.length > 0;
+
+	if (!hasColumns && !hasCopyright && !hasSocial) return "";
+
+	const blocks: string[] = [];
+
+	if (hasColumns) {
+		const columnsJsx = (footer.columns ?? [])
+			.map((col) => {
+				const jsTitle = JSON.stringify(col.title);
+				const links = col.links
+					.map((link) => {
+						const jsLabel = JSON.stringify(link.label);
+						const jsHref = JSON.stringify(sanitizeUrl(link.url));
+						return `                <li><a href={${jsHref}}>{${jsLabel}}</a></li>`;
+					})
+					.join("\n");
+				return [
+					`            <div style={{ minWidth: 140 }}>`,
+					`              <h4 style={{ margin: '0 0 0.5rem', fontSize: '0.875rem', fontWeight: 600 }}>{${jsTitle}}</h4>`,
+					`              <ul style={{ listStyle: 'none', padding: 0, margin: 0 }}>`,
+					links,
+					`              </ul>`,
+					`            </div>`,
+				].join("\n");
+			})
+			.join("\n");
+		blocks.push(
+			`          <div style={{ display: 'flex', gap: '2rem', flexWrap: 'wrap', marginBottom: '1rem' }}>\n${columnsJsx}\n          </div>`,
+		);
+	}
+
+	if (hasCopyright || hasSocial) {
+		const bottom: string[] = [];
+		if (hasCopyright) {
+			const jsCopyright = JSON.stringify(footer.copyright);
+			bottom.push(`            <span>{${jsCopyright}}</span>`);
+		}
+		if (hasSocial && socials) {
+			const social = socialEntries
+				.map((p) => {
+					const jsHref = JSON.stringify(sanitizeUrl(socials[p] ?? ""));
+					const jsLabel = JSON.stringify(p);
+					return `              <a href={${jsHref}} aria-label={${jsLabel}}>{${jsLabel}}</a>`;
+				})
+				.join("\n");
+			bottom.push(`            <div style={{ display: 'flex', gap: '0.75rem' }}>\n${social}\n            </div>`);
+		}
+		blocks.push(
+			`          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', flexWrap: 'wrap', gap: '1rem' }}>\n${bottom.join("\n")}\n          </div>`,
+		);
+	}
+
+	return [`        <div style={{ width: '100%' }}>`, ...blocks, `        </div>`].join("\n");
+}
+
+// ─── generateLayout (dispatcher) ─────────────────────────────────────────────
+
+/**
+ * Returns the contents of `app/layout.tsx`. Dispatches to a pack-specific
+ * generator based on `config.theme?.pack`:
+ *   - `default` (or unset) → vanilla `nextra-theme-docs` with header/footer
+ *   - `forge` → Forge pack (clean dev docs)
+ *   - `atlas` → Atlas pack (editorial)
  */
 export function generateLayout(config: NextraProjectConfig): string {
-	const { title, description, nav } = config;
+	const pack: ThemePack = config.theme?.pack ?? "default";
+	switch (pack) {
+		case "forge":
+			return generateForgeLayout(config);
+		case "atlas":
+			return generateAtlasLayout(config);
+		default:
+			return generateDefaultLayout(config);
+	}
+}
+
+// ─── generateDefaultLayout ───────────────────────────────────────────────────
+
+/**
+ * Vanilla `nextra-theme-docs` layout with header dropdown and footer support.
+ * Maps `title`, `description`, `nav` / `header`, and `footer` from `site.json`
+ * into the Nextra Layout, Navbar, and Footer components. `nav` is the legacy
+ * flat shorthand; `header.items` (which supports per-item dropdowns) wins
+ * when set.
+ */
+export function generateDefaultLayout(config: NextraProjectConfig): string {
+	const { title, description } = config;
 
 	const jsTitle = JSON.stringify(title);
 	const jsDescription = JSON.stringify(description);
 
-	// Build navbar children from nav items (Navbar uses `children` for extra content).
-	const navLinks = nav
-		.map(({ label, href }) => {
-			const jsLabel = JSON.stringify(label);
-			const jsHref = JSON.stringify(href);
-			return `          <a href={${jsHref}} style={{ marginLeft: '1rem' }}>{${jsLabel}}</a>`;
-		})
-		.join("\n");
+	const headerItems = resolveHeaderItems(config);
+	const navLinks = headerItems.map(renderNavbarChild).join("\n");
+	const navbarChildren = headerItems.length > 0 ? `\n${navLinks}\n        ` : "";
 
-	const navbarChildren = nav.length > 0 ? `\n${navLinks}\n        ` : "";
+	const footerBody = buildFooterBody(config.footer);
+	const footerJsx = footerBody === "" ? `<Footer />` : `<Footer>\n${footerBody}\n      </Footer>`;
 
 	return `import { Footer, Layout, Navbar } from 'nextra-theme-docs'
 import { Head } from 'nextra/components'
@@ -184,7 +366,7 @@ export default async function RootLayout({ children }: { children: React.ReactNo
             <Navbar logo={<b>{${jsTitle}}</b>}>${navbarChildren}</Navbar>
           }
           pageMap={await getPageMap()}
-          footer={<Footer />}
+          footer={${footerJsx}}
         >
           {children}
         </Layout>
@@ -193,6 +375,46 @@ export default async function RootLayout({ children }: { children: React.ReactNo
   )
 }
 `;
+}
+
+// ─── generateForgeLayout ─────────────────────────────────────────────────────
+
+/**
+ * Forge pack layout — clean developer-docs visual style. The pack-specific
+ * stylesheet is written to `app/themes/forge.css` by `initNextraProject`.
+ * See `themes/forge/Layout.ts` for the template and the SaaS-port notes.
+ */
+export function generateForgeLayout(config: NextraProjectConfig): string {
+	const input = resolveForgeLayoutInput({
+		title: config.title,
+		description: config.description,
+		nav: config.nav,
+		header: config.header,
+		footer: config.footer,
+		theme: config.theme,
+		legacyFavicon: config.favicon,
+	});
+	return generateForgeLayoutTsx(input);
+}
+
+// ─── generateAtlasLayout ─────────────────────────────────────────────────────
+
+/**
+ * Atlas pack layout — editorial handbook visual style. The pack-specific
+ * stylesheet is written to `app/themes/atlas.css` by `initNextraProject`.
+ * See `themes/atlas/Layout.ts` for the template and the SaaS-port notes.
+ */
+export function generateAtlasLayout(config: NextraProjectConfig): string {
+	const input = resolveAtlasLayoutInput({
+		title: config.title,
+		description: config.description,
+		nav: config.nav,
+		header: config.header,
+		footer: config.footer,
+		theme: config.theme,
+		legacyFavicon: config.favicon,
+	});
+	return generateAtlasLayoutTsx(input);
 }
 
 // ─── generateNotFound ───────────────────────────────────────────────────────

--- a/cli/src/site/SourceWatcher.test.ts
+++ b/cli/src/site/SourceWatcher.test.ts
@@ -1,0 +1,267 @@
+/**
+ * Tests for SourceWatcher.
+ *
+ * The watcher is exercised against a stub `WatchFactory` that returns a
+ * thin `FSWatcher`-shaped EventEmitter — no real filesystem is touched.
+ */
+
+import { EventEmitter } from "node:events";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { startSourceWatcher, type WatchFactory } from "./SourceWatcher.js";
+
+// ─── Stub factory ──────────────────────────────────────────────────────────
+
+interface StubWatcher extends EventEmitter {
+	close(): Promise<void>;
+	closeMock: ReturnType<typeof vi.fn>;
+	options?: { ignoreInitial: boolean; ignored: string[] };
+	path?: string;
+}
+
+function makeStubFactory(): { factory: WatchFactory; getWatcher: () => StubWatcher } {
+	let captured: StubWatcher | null = null;
+
+	const factory: WatchFactory = (path, options) => {
+		const emitter = new EventEmitter() as StubWatcher;
+		emitter.path = path;
+		emitter.options = options;
+		const closeMock = vi.fn().mockResolvedValue(undefined);
+		emitter.closeMock = closeMock;
+		emitter.close = closeMock;
+		captured = emitter;
+		// Return as the chokidar FSWatcher type — the watcher only uses
+		// `on(name, cb)` and `close()`, both of which the stub provides.
+		// biome-ignore lint/suspicious/noExplicitAny: stub typed dynamically for the test surface
+		return emitter as any;
+	};
+
+	return {
+		factory,
+		getWatcher: () => {
+			if (!captured) {
+				throw new Error("watcher was never created");
+			}
+			return captured;
+		},
+	};
+}
+
+/** Yields control to the microtask queue once. */
+function tick(): Promise<void> {
+	return new Promise((resolve) => setImmediate(resolve));
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe("startSourceWatcher", () => {
+	beforeEach(() => {
+		// Only fake setTimeout / clearTimeout — leave setImmediate alone so
+		// our `tick()` microtask flush actually resolves.
+		vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("passes ignoreInitial=true and the built-in ignore globs to chokidar", () => {
+		const { factory, getWatcher } = makeStubFactory();
+		const onChange = vi.fn().mockResolvedValue(undefined);
+		const watcher = startSourceWatcher("/src", { onChange, watchFactory: factory });
+		const stub = getWatcher();
+
+		expect(stub.path).toBe("/src");
+		expect(stub.options?.ignoreInitial).toBe(true);
+		expect(stub.options?.ignored).toContain("**/.git/**");
+		expect(stub.options?.ignored).toContain("**/node_modules/**");
+		expect(stub.options?.ignored).toContain("**/.jolli-site/**");
+		expect(stub.options?.ignored).toContain("**/.next/**");
+
+		void watcher.close();
+	});
+
+	it("appends user-supplied ignore patterns after the built-ins", () => {
+		const { factory, getWatcher } = makeStubFactory();
+		const onChange = vi.fn().mockResolvedValue(undefined);
+		startSourceWatcher("/src", {
+			onChange,
+			watchFactory: factory,
+			ignored: ["**/secret/**"],
+		});
+		expect(getWatcher().options?.ignored).toContain("**/secret/**");
+	});
+
+	it("debounces a burst of events into a single onChange call", async () => {
+		const { factory, getWatcher } = makeStubFactory();
+		const onChange = vi.fn().mockResolvedValue(undefined);
+		startSourceWatcher("/src", { onChange, debounceMs: 50, watchFactory: factory });
+		const stub = getWatcher();
+
+		stub.emit("change", "/src/a.md");
+		stub.emit("change", "/src/b.md");
+		stub.emit("add", "/src/c.md");
+
+		expect(onChange).not.toHaveBeenCalled();
+
+		await vi.advanceTimersByTimeAsync(50);
+		await tick();
+
+		expect(onChange).toHaveBeenCalledTimes(1);
+	});
+
+	it("listens for add / change / unlink events", async () => {
+		const { factory, getWatcher } = makeStubFactory();
+		const onChange = vi.fn().mockResolvedValue(undefined);
+		startSourceWatcher("/src", { onChange, debounceMs: 10, watchFactory: factory });
+		const stub = getWatcher();
+
+		stub.emit("unlink", "/src/old.md");
+		await vi.advanceTimersByTimeAsync(10);
+		await tick();
+
+		expect(onChange).toHaveBeenCalledTimes(1);
+	});
+
+	it("coalesces events that arrive while onChange is in flight into a single follow-up sync", async () => {
+		const { factory, getWatcher } = makeStubFactory();
+		let resolveFirst: () => void = () => {};
+		const onChange = vi.fn();
+		onChange.mockImplementationOnce(
+			() =>
+				new Promise<void>((r) => {
+					resolveFirst = r;
+				}),
+		);
+		onChange.mockImplementation(() => Promise.resolve());
+		startSourceWatcher("/src", { onChange, debounceMs: 10, watchFactory: factory });
+		const stub = getWatcher();
+
+		stub.emit("change", "/src/a.md");
+		await vi.advanceTimersByTimeAsync(10);
+		await tick();
+
+		// First onChange is in flight (still pending). Fire two more events;
+		// they should coalesce into a single follow-up sync once the first
+		// one resolves.
+		stub.emit("change", "/src/b.md");
+		stub.emit("change", "/src/c.md");
+		await vi.advanceTimersByTimeAsync(10);
+		await tick();
+
+		// Still only one onChange running.
+		expect(onChange).toHaveBeenCalledTimes(1);
+
+		resolveFirst();
+		await tick();
+		await tick();
+
+		expect(onChange).toHaveBeenCalledTimes(2);
+	});
+
+	it("logs and continues when onChange throws", async () => {
+		const { factory, getWatcher } = makeStubFactory();
+		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+		const onChange = vi.fn().mockRejectedValueOnce(new Error("kaboom")).mockResolvedValueOnce(undefined);
+
+		startSourceWatcher("/src", { onChange, debounceMs: 10, watchFactory: factory });
+		const stub = getWatcher();
+
+		stub.emit("change", "/src/a.md");
+		await vi.advanceTimersByTimeAsync(10);
+		await tick();
+		await tick();
+
+		expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("kaboom"));
+
+		// A subsequent sync still runs — the watcher didn't unwind.
+		stub.emit("change", "/src/b.md");
+		await vi.advanceTimersByTimeAsync(10);
+		await tick();
+		await tick();
+
+		expect(onChange).toHaveBeenCalledTimes(2);
+		errorSpy.mockRestore();
+	});
+
+	it("formats non-Error throw values via String() in the log line", async () => {
+		const { factory, getWatcher } = makeStubFactory();
+		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+		const onChange = vi.fn().mockRejectedValueOnce("string-error").mockResolvedValue(undefined);
+
+		startSourceWatcher("/src", { onChange, debounceMs: 10, watchFactory: factory });
+		const stub = getWatcher();
+
+		stub.emit("change", "/src/a.md");
+		await vi.advanceTimersByTimeAsync(10);
+		await tick();
+		await tick();
+
+		expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("string-error"));
+		errorSpy.mockRestore();
+	});
+
+	it("close() awaits in-flight sync and shuts down chokidar", async () => {
+		const { factory, getWatcher } = makeStubFactory();
+		let resolveSync: () => void = () => {};
+		const onChange = vi.fn().mockImplementation(
+			() =>
+				new Promise<void>((r) => {
+					resolveSync = r;
+				}),
+		);
+
+		const watcher = startSourceWatcher("/src", { onChange, debounceMs: 10, watchFactory: factory });
+		const stub = getWatcher();
+
+		stub.emit("change", "/src/a.md");
+		await vi.advanceTimersByTimeAsync(10);
+		await tick();
+
+		// onChange is in flight; trigger close() — it should NOT resolve until
+		// the in-flight sync settles.
+		const closePromise = watcher.close();
+		let closed = false;
+		void closePromise.then(() => {
+			closed = true;
+		});
+		await tick();
+		expect(closed).toBe(false);
+
+		resolveSync();
+		await closePromise;
+
+		expect(stub.closeMock).toHaveBeenCalled();
+	});
+
+	it("close() also clears a pending debounce timer so no late sync fires", async () => {
+		const { factory, getWatcher } = makeStubFactory();
+		const onChange = vi.fn().mockResolvedValue(undefined);
+		const watcher = startSourceWatcher("/src", { onChange, debounceMs: 50, watchFactory: factory });
+		const stub = getWatcher();
+
+		stub.emit("change", "/src/a.md");
+		// Don't advance the timer — close() should clear it.
+		await watcher.close();
+		await vi.advanceTimersByTimeAsync(100);
+		await tick();
+
+		expect(onChange).not.toHaveBeenCalled();
+		expect(stub.closeMock).toHaveBeenCalled();
+	});
+
+	it("ignores events that fire after close()", async () => {
+		const { factory, getWatcher } = makeStubFactory();
+		const onChange = vi.fn().mockResolvedValue(undefined);
+		const watcher = startSourceWatcher("/src", { onChange, debounceMs: 10, watchFactory: factory });
+		const stub = getWatcher();
+
+		await watcher.close();
+
+		// Even if some belated emitter fires, no sync runs.
+		stub.emit("change", "/src/a.md");
+		await vi.advanceTimersByTimeAsync(50);
+		await tick();
+
+		expect(onChange).not.toHaveBeenCalled();
+	});
+});

--- a/cli/src/site/SourceWatcher.ts
+++ b/cli/src/site/SourceWatcher.ts
@@ -1,0 +1,129 @@
+/**
+ * SourceWatcher — debounced file-system watcher for `jolli dev` source-folder
+ * hot reload.
+ *
+ * Wraps `chokidar` with a small re-entrancy guard so rapid edits coalesce
+ * into a single re-sync rather than queueing a sync per event:
+ *
+ *   1. A change fires → the timer starts (or restarts).
+ *   2. After `debounceMs` of quiet, a re-sync runs.
+ *   3. If more changes arrive while a re-sync is in flight, a *single*
+ *      follow-up sync runs after the current one completes — events that
+ *      arrive during a sync are coalesced via a `dirty` flag.
+ *
+ * `onChange` errors are caught and logged so a failing re-sync (e.g. a
+ * temporarily malformed `site.json`) never crashes the running dev server.
+ */
+
+import { watch as chokidarWatch, type FSWatcher } from "chokidar";
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export interface SourceWatcherOptions {
+	/** Called after debounced FS event(s) settle. Errors are caught and logged. */
+	onChange: () => Promise<void>;
+	/** Debounce window in ms. Defaults to 100. */
+	debounceMs?: number;
+	/**
+	 * Glob patterns to ignore in addition to the built-in defaults
+	 * (`.git/`, `node_modules/`, `.jolli-site/`, `.next/`, `dist/`,
+	 * `build/`, `out/`).
+	 */
+	ignored?: string[];
+	/**
+	 * Optional override for the chokidar factory. Tests pass a stub so
+	 * they don't have to touch the real filesystem. Default: `chokidar.watch`.
+	 */
+	watchFactory?: WatchFactory;
+}
+
+export interface SourceWatcher {
+	/** Stops watching and waits for any in-flight re-sync to finish. */
+	close(): Promise<void>;
+}
+
+/** Factory signature matching `chokidar.watch`, narrowed to what we use. */
+export type WatchFactory = (path: string, options: { ignoreInitial: boolean; ignored: string[] }) => FSWatcher;
+
+// ─── Built-in ignore patterns ────────────────────────────────────────────────
+
+const BUILTIN_IGNORED = [
+	"**/.git/**",
+	"**/node_modules/**",
+	"**/.jolli-site/**",
+	"**/.next/**",
+	"**/dist/**",
+	"**/build/**",
+	"**/out/**",
+	"**/.DS_Store",
+	"**/*.swp",
+	"**/*~",
+];
+
+// ─── startSourceWatcher ─────────────────────────────────────────────────────
+
+/**
+ * Begins watching `sourceRoot` for `add` / `change` / `unlink` events. The
+ * returned handle stops the watcher and waits for any in-flight re-sync.
+ */
+export function startSourceWatcher(sourceRoot: string, opts: SourceWatcherOptions): SourceWatcher {
+	const debounceMs = opts.debounceMs ?? 100;
+	const factory = opts.watchFactory ?? chokidarWatch;
+	const ignored = [...BUILTIN_IGNORED, ...(opts.ignored ?? [])];
+
+	const watcher = factory(sourceRoot, { ignoreInitial: true, ignored });
+
+	let timer: ReturnType<typeof setTimeout> | null = null;
+	let dirty = false;
+	let running = false;
+	let closed = false;
+	let inFlight: Promise<void> = Promise.resolve();
+
+	// At most 2 iterations: the initial sync plus one follow-up if events
+	// arrived during the first sync. The debounce timer can only set `dirty`
+	// once between iterations, so unbounded looping is not possible.
+	const drain = async (): Promise<void> => {
+		while (dirty && !closed) {
+			dirty = false;
+			try {
+				await opts.onChange();
+			} catch (err) {
+				console.error(`  Error during incremental sync: ${err instanceof Error ? err.message : String(err)}`);
+			}
+		}
+		running = false;
+	};
+
+	const trigger = (): void => {
+		if (closed) {
+			return;
+		}
+		if (timer) {
+			clearTimeout(timer);
+		}
+		timer = setTimeout(() => {
+			timer = null;
+			dirty = true;
+			if (!running) {
+				running = true;
+				inFlight = drain();
+			}
+		}, debounceMs);
+	};
+
+	watcher.on("add", trigger);
+	watcher.on("change", trigger);
+	watcher.on("unlink", trigger);
+
+	return {
+		async close(): Promise<void> {
+			closed = true;
+			if (timer) {
+				clearTimeout(timer);
+				timer = null;
+			}
+			await inFlight;
+			await watcher.close();
+		},
+	};
+}

--- a/cli/src/site/StarterKit.test.ts
+++ b/cli/src/site/StarterKit.test.ts
@@ -119,6 +119,17 @@ describe("StarterKit.scaffoldProject", () => {
 		}
 	});
 
+	it("site.json defaults theme.pack to forge so new sites get the polished look out of the box", async () => {
+		const { scaffoldProject } = await import("./StarterKit.js");
+		const targetDir = join(tempBase, "my-docs");
+
+		await scaffoldProject(targetDir);
+
+		const raw = await readFile(join(targetDir, "site.json"), "utf-8");
+		const parsed = JSON.parse(raw) as { theme?: { pack?: unknown } };
+		expect(parsed.theme?.pack).toBe("forge");
+	});
+
 	// ── Markdown files (Requirement 1.4) ───────────────────────────────────
 
 	it("writes index.md at the root", async () => {

--- a/cli/src/site/StarterKit.ts
+++ b/cli/src/site/StarterKit.ts
@@ -26,6 +26,9 @@ const SITE_JSON = JSON.stringify(
 			{ label: "API Reference", href: "/api/openapi" },
 			{ label: "Guides", href: "/guides/introduction" },
 		],
+		// Forge — clean developer-docs visual style. Drop or change to
+		// `"default"` to render with vanilla `nextra-theme-docs` instead.
+		theme: { pack: "forge" },
 	},
 	null,
 	2,
@@ -81,7 +84,9 @@ All content lives in this folder. You can:
 
 ## Configuring the site
 
-Edit \`site.json\` to change the site title, description, and top navigation bar.
+Edit \`site.json\` to change the site title, description, top navigation bar,
+and visual theme. Available theme packs: \`"forge"\` (clean developer docs,
+default) or \`"default"\` (vanilla \`nextra-theme-docs\`).
 
 \`\`\`json
 {
@@ -89,7 +94,8 @@ Edit \`site.json\` to change the site title, description, and top navigation bar
   "description": "Documentation site powered by Jolli",
   "nav": [
     { "label": "Home", "href": "/" }
-  ]
+  ],
+  "theme": { "pack": "forge", "primaryHue": 228 }
 }
 \`\`\`
 `;

--- a/cli/src/site/Types.ts
+++ b/cli/src/site/Types.ts
@@ -9,10 +9,57 @@ import type { OpenApiDocument } from "./openapi/Types.js";
 /** File classification used by ContentMirror to categorize source files */
 export type FileType = "markdown" | "openapi" | "image" | "ignored";
 
-/** A navigation bar link entry in site.json */
+/** A navigation bar link entry in site.json (legacy flat shorthand for `header.items`). */
 export interface NavLink {
 	label: string;
 	href: string;
+}
+
+/**
+ * A simple labelled URL — used as a footer-column link, a header-dropdown
+ * sub-item, etc. Matches the SaaS `ExternalLink` shape (minus the editor-only
+ * `id` field, which the CLI doesn't need).
+ */
+export interface ExternalLink {
+	label: string;
+	url: string;
+}
+
+/**
+ * Header navbar item — direct link (`url`) OR dropdown (`items`),
+ * mutually exclusive. Matches the SaaS `HeaderNavItem` shape.
+ */
+export interface HeaderItem {
+	label: string;
+	url?: string;
+	items?: ExternalLink[];
+}
+
+/** Header navigation config in site.json. */
+export interface HeaderConfig {
+	items: HeaderItem[];
+}
+
+/** A footer column with a heading and a list of links. */
+export interface FooterColumn {
+	title: string;
+	links: ExternalLink[];
+}
+
+/** Social-icon URLs rendered alongside footer columns. */
+export interface SocialLinks {
+	github?: string;
+	twitter?: string;
+	discord?: string;
+	linkedin?: string;
+	youtube?: string;
+}
+
+/** Footer config in site.json. */
+export interface FooterConfig {
+	copyright?: string;
+	columns?: FooterColumn[];
+	socialLinks?: SocialLinks;
 }
 
 /**
@@ -43,15 +90,83 @@ export type SidebarOverrides = Record<string, Record<string, SidebarItemValue>>;
  */
 export type PathMappings = Record<string, string>;
 
+/**
+ * Visual theme pack — picks the layout/CSS shell.
+ *   - `default` — vanilla `nextra-theme-docs` (current behaviour, shipped before
+ *     theme packs existed). The fallback when `theme.pack` is unset.
+ *   - `forge` — clean developer-docs pack: light default, sidebar-first layout,
+ *     Inter typography, hairline borders. Mirrors the SaaS Forge pack post-1392.
+ *   - `atlas` — editorial pack: dark default, top-nav, serif headlines,
+ *     airy spacing, masthead footer. Mirrors the SaaS Atlas pack.
+ */
+export type ThemePack = "default" | "forge" | "atlas";
+
+/** Initial colour scheme for visitors. */
+export type DefaultThemeMode = "light" | "dark" | "system";
+
+/**
+ * Font families a pack can resolve via Google Fonts. Names match the SaaS
+ * `FontFamily` enum so a single site.json works in both surfaces.
+ */
+export type FontFamily = "inter" | "space-grotesk" | "ibm-plex" | "source-sans" | "source-serif";
+
+/**
+ * Visual theme block in site.json. Mirrors the customer-facing surface of
+ * the SaaS `SiteBranding` (post-1392), minus tenant-only fields (`siteName` —
+ * the CLI uses `title` at the top level instead, `customCss`, `legacyBranding`).
+ *
+ * All fields are optional; each pack's manifest supplies defaults (e.g. Forge
+ * defaults to `primaryHue: 228`, `defaultTheme: "light"`, `fontFamily: "inter"`).
+ */
+export interface ThemeConfig {
+	pack?: ThemePack;
+	/** Image URL for logo (light mode and fallback when `logoUrlDark` is unset). */
+	logoUrl?: string;
+	/** Optional dark-mode logo variant. The pack swaps when `.dark` is active. */
+	logoUrlDark?: string;
+	/**
+	 * Favicon URL. When the legacy top-level `favicon` field is also set, the
+	 * top-level value wins (deprecated alias kept for back-compat).
+	 */
+	favicon?: string;
+	/** Primary accent hue 0-360. Pack default applies when unset. */
+	primaryHue?: number;
+	/** Initial theme mode. Pack default applies when unset. */
+	defaultTheme?: DefaultThemeMode;
+	/** Body / heading font family. Pack default applies when unset. */
+	fontFamily?: FontFamily;
+}
+
 /** The parsed contents of site.json */
 export interface SiteJson {
 	title: string;
 	description: string;
+	/**
+	 * Flat navbar shorthand. When `header` is also present, `header.items`
+	 * wins; otherwise these entries are coerced into header dropdown-less
+	 * items at render time so existing CLI sites keep working unchanged.
+	 */
 	nav: NavLink[];
+	/**
+	 * Header navbar — supports per-item dropdowns. Mirrors the SaaS
+	 * `HeaderLinksConfig` shape so a single `site.json` works in both systems.
+	 */
+	header?: HeaderConfig;
+	/**
+	 * Site footer — copyright, columns of links, and social-icon URLs.
+	 * Mirrors the SaaS `FooterConfig` shape.
+	 */
+	footer?: FooterConfig;
 	sidebar?: SidebarOverrides;
 	pathMappings?: PathMappings;
+	/**
+	 * Deprecated: use `theme.favicon` instead. When both are set the
+	 * top-level value wins so existing sites keep working.
+	 */
 	favicon?: string;
 	renderer?: string;
+	/** Visual styling — see `ThemeConfig`. */
+	theme?: ThemeConfig;
 	[key: string]: unknown; // unknown fields are silently ignored
 }
 

--- a/cli/src/site/renderer/NextraRenderer.test.ts
+++ b/cli/src/site/renderer/NextraRenderer.test.ts
@@ -98,6 +98,59 @@ describe("NextraRenderer", () => {
 		}
 	});
 
+	it("api.css uses theme.primaryHue when set, regardless of pack", async () => {
+		const buildDir = await mkdtemp(join(tmpdir(), "jolli-nextra-hue-"));
+		try {
+			const config = {
+				title: "T",
+				description: "D",
+				nav: [],
+				theme: { pack: "forge" as const, primaryHue: 145 },
+			};
+			await new NextraRenderer().initProject(buildDir, config, { staticExport: true });
+			const css = await readFile(join(buildDir, "styles", "api.css"), "utf-8");
+			expect(css).toContain("hsl(145 84% 50%)");
+		} finally {
+			await rm(buildDir, { recursive: true, force: true });
+		}
+	});
+
+	it("api.css falls back to Forge's manifest hue (228) when pack is forge but primaryHue is unset", async () => {
+		const buildDir = await mkdtemp(join(tmpdir(), "jolli-nextra-forge-"));
+		try {
+			const config = { title: "T", description: "D", nav: [], theme: { pack: "forge" as const } };
+			await new NextraRenderer().initProject(buildDir, config, { staticExport: true });
+			const css = await readFile(join(buildDir, "styles", "api.css"), "utf-8");
+			expect(css).toContain("hsl(228 84% 50%)");
+		} finally {
+			await rm(buildDir, { recursive: true, force: true });
+		}
+	});
+
+	it("api.css falls back to Atlas's manifest hue (200) when pack is atlas but primaryHue is unset", async () => {
+		const buildDir = await mkdtemp(join(tmpdir(), "jolli-nextra-atlas-"));
+		try {
+			const config = { title: "T", description: "D", nav: [], theme: { pack: "atlas" as const } };
+			await new NextraRenderer().initProject(buildDir, config, { staticExport: true });
+			const css = await readFile(join(buildDir, "styles", "api.css"), "utf-8");
+			expect(css).toContain("hsl(200 84% 50%)");
+		} finally {
+			await rm(buildDir, { recursive: true, force: true });
+		}
+	});
+
+	it("api.css uses generateApiCss's internal default (220) when no theme is set", async () => {
+		const buildDir = await mkdtemp(join(tmpdir(), "jolli-nextra-default-"));
+		try {
+			const config = { title: "T", description: "D", nav: [] };
+			await new NextraRenderer().initProject(buildDir, config, { staticExport: true });
+			const css = await readFile(join(buildDir, "styles", "api.css"), "utf-8");
+			expect(css).toContain("hsl(220 84% 50%)");
+		} finally {
+			await rm(buildDir, { recursive: true, force: true });
+		}
+	});
+
 	it("getCacheDirs returns .next directory", () => {
 		expect(new NextraRenderer().getCacheDirs("/build")).toEqual(["/build/.next"]);
 	});

--- a/cli/src/site/renderer/NextraRenderer.ts
+++ b/cli/src/site/renderer/NextraRenderer.ts
@@ -29,6 +29,35 @@ const PROVIDED_COMPONENTS = new Set(["Fragment", "Callout", "Cards", "Card", "Fi
 
 const PAGE_COUNT_PATTERN = /Generating static pages.*?(\d+)\/(\d+)/s;
 
+/**
+ * Pack manifest defaults — kept in sync with `themes/<pack>/Manifest.ts`.
+ * Hardcoded here because importing the manifests from inside `renderer/`
+ * would invert the dependency direction (renderer should not depend on
+ * pack-specific modules; ApiCss is pack-agnostic).
+ */
+const FORGE_DEFAULT_HUE = 228;
+const ATLAS_DEFAULT_HUE = 200;
+
+/**
+ * Resolves the accent hue passed to `generateApiCss`. `theme.primaryHue`
+ * wins when set; otherwise we fall back to a pack-aware default so the
+ * API surface visually matches the pack the customer picked. Returning
+ * `undefined` lets `generateApiCss` apply its own internal default (220).
+ */
+function resolveApiAccentHue(config: SiteJson): number | undefined {
+	if (typeof config.theme?.primaryHue === "number") {
+		return config.theme.primaryHue;
+	}
+	switch (config.theme?.pack) {
+		case "forge":
+			return FORGE_DEFAULT_HUE;
+		case "atlas":
+			return ATLAS_DEFAULT_HUE;
+		default:
+			return undefined;
+	}
+}
+
 // ─── NextraRenderer ─────────────────────────────────────────────────────────
 
 export class NextraRenderer implements SiteRenderer {
@@ -46,7 +75,15 @@ export class NextraRenderer implements SiteRenderer {
 		// before any MDX shim does. Writing them once here also avoids
 		// rewriting nine files on every render-loop call. The API stylesheet
 		// is also scaffold — `app/layout.tsx` imports it unconditionally.
-		await this.writeFiles(buildDir, [...generateApiComponents(), generateApiCss()]);
+		//
+		// `accentHue` flows from `theme.primaryHue` so the API method/status
+		// pills match the rest of the pack. When the user picks Forge but
+		// doesn't override the hue, fall back to Forge's manifest default
+		// (228) so the API surface inherits the pack's identity instead of
+		// the unrelated `generateApiCss` fallback (220).
+		const accentHue = resolveApiAccentHue(config);
+		await this.writeFiles(buildDir, [...generateApiComponents(), generateApiCss({ accentHue })]);
+
 		return result;
 	}
 

--- a/cli/src/site/themes/atlas/Css.test.ts
+++ b/cli/src/site/themes/atlas/Css.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Tests for the Atlas stylesheet builder. Sanity-checks the static
+ * vendor + targeted assertions on the dynamic override generator.
+ */
+
+import { describe, expect, it } from "vitest";
+import { buildAtlasCss, buildAtlasOverrides } from "./Css.js";
+
+describe("buildAtlasOverrides", () => {
+	it("interpolates the accent hue into hsl() declarations", () => {
+		const result = buildAtlasOverrides({ accentHue: 145 });
+		expect(result).toContain("--nextra-primary-hue:        145");
+		expect(result).toContain("hsl(145 70% 56%)");
+	});
+
+	it("uses Atlas's saturation (70%) and lightness (56%) — distinct from Forge's 84%/61%", () => {
+		const result = buildAtlasOverrides({ accentHue: 200 });
+		expect(result).toContain("70% 56%");
+		expect(result).not.toContain("84% 61%");
+	});
+
+	it("emits dark-mode accent variants tuned for Atlas's default dark palette", () => {
+		const result = buildAtlasOverrides({ accentHue: 200 });
+		expect(result).toContain(".dark");
+		expect(result).toContain("hsl(200 70% 64%)"); // dark accent
+		expect(result).toContain("hsl(200 70% 12%)"); // dark accent-soft
+	});
+
+	it("emits a --atlas-font-family declaration when fontFamily is set", () => {
+		const result = buildAtlasOverrides({ accentHue: 200, fontFamily: "'Source Serif 4', serif" });
+		expect(result).toContain("--atlas-font-family: 'Source Serif 4', serif");
+	});
+
+	it("omits --atlas-font-family when fontFamily is undefined", () => {
+		const result = buildAtlasOverrides({ accentHue: 200 });
+		expect(result).not.toContain("--atlas-font-family:");
+	});
+});
+
+describe("buildAtlasCss", () => {
+	it("includes the base Atlas stylesheet sections", () => {
+		const result = buildAtlasCss({ accentHue: 200 });
+		expect(result).toContain("Atlas");
+		expect(result).toContain(".atlas-navbar-logo");
+		expect(result).toContain("nextra-sidebar");
+		expect(result).toContain("nextra-toc");
+	});
+
+	it("appends the override block after the base CSS so cascade gives overrides precedence", () => {
+		const result = buildAtlasCss({ accentHue: 145 });
+		const baseMarkerIdx = result.indexOf(".atlas-footer-social");
+		const overrideMarkerIdx = result.indexOf("Atlas theme overrides (generated)");
+		expect(baseMarkerIdx).toBeGreaterThan(-1);
+		expect(overrideMarkerIdx).toBeGreaterThan(baseMarkerIdx);
+	});
+
+	it("does NOT include the auth banner block (CLI-strip)", () => {
+		const result = buildAtlasCss({ accentHue: 200 });
+		expect(result).not.toContain(".jolli-auth-banner");
+	});
+});

--- a/cli/src/site/themes/atlas/Css.ts
+++ b/cli/src/site/themes/atlas/Css.ts
@@ -1,0 +1,1066 @@
+/**
+ * Atlas theme CSS — editorial handbook visual style.
+ *
+ * Top-nav layout, serif headlines (Source Serif 4), dark-default mode (warm
+ * cream when toggled to light), wider content column, airy spacing, masthead-
+ * style footer. Accent color used as ambient glow rather than solid fill.
+ *
+ * Vendored from the SaaS Atlas pack
+ * (`tools/nextra-generator/src/themes/atlas/styles/AtlasCss.ts` in jolli.ai/jolli)
+ * post-JOLLI-1392. The auth banner block has been stripped (CLI sites have no
+ * JWT auth) and the API-reference companion stylesheet is consumed via
+ * `styles/api.css` from the rich-renderer pipeline rather than appended here.
+ */
+
+const ATLAS_BASE_CSS = `/*
+ * Atlas Theme — editorial handbook
+ * Pack-internal decisions: serif headlines, dark default, top-nav, masthead footer.
+ *
+ * Source Serif 4 is loaded via a <link rel="stylesheet"> in app/layout.tsx
+ * (see Atlas Apply.ts) so the browser can fetch the font in parallel with the
+ * page HTML rather than waiting for this stylesheet to parse.
+ */
+
+:root {
+  --nextra-primary-hue: 200;
+  --nextra-primary-saturation: 70%;
+  --nextra-primary-lightness: 56%;
+  --nextra-bg: 250 250 247;
+  --nextra-navbar-height: 60px;
+
+  --atlas-accent:        hsl(200 70% 56%);
+  --atlas-accent-soft:   hsl(200 70% 95%);
+  --atlas-accent-glow:   hsla(200, 70%, 50%, 0.15);
+
+  --atlas-bg:            #fafaf7;
+  --atlas-bg-surface:    #ffffff;
+  --atlas-border:        #e7e5e0;
+  --atlas-border-soft:   #f1efea;
+  --atlas-text-strong:   #18181b;
+  --atlas-text:          #3f3f46;
+  --atlas-text-soft:     #71717a;
+  --atlas-text-faint:    #a1a1aa;
+
+  --atlas-headline-font: 'Source Serif 4', 'Iowan Old Style', Georgia, serif;
+}
+
+.dark {
+  --nextra-bg: 10 10 15;
+  --nextra-primary-lightness: 64%;
+
+  --atlas-accent:        hsl(200 70% 64%);
+  --atlas-accent-soft:   hsl(200 70% 12%);
+  --atlas-accent-glow:   hsla(200, 70%, 60%, 0.2);
+
+  --atlas-bg:            #0a0a0f;
+  --atlas-bg-surface:    #131318;
+  --atlas-border:        #27272a;
+  --atlas-border-soft:   #1c1c1f;
+  --atlas-text-strong:   #fafafa;
+  --atlas-text:          #d4d4d8;
+  --atlas-text-soft:     #a1a1aa;
+  --atlas-text-faint:    #71717a;
+}
+
+/* ═══════════════════════════════════════════════════════════════════════════
+   BASE
+   ═══════════════════════════════════════════════════════════════════════════ */
+
+html {
+  font-family: var(--atlas-font-family, 'Inter', ui-sans-serif, system-ui, sans-serif) !important;
+  -webkit-font-smoothing: antialiased;
+  letter-spacing: -0.005em;
+}
+
+body { background-color: var(--atlas-bg); }
+
+/* ═══════════════════════════════════════════════════════════════════════════
+   TOP NAVBAR — Atlas-specific (logo centered, slim height)
+   ═══════════════════════════════════════════════════════════════════════════ */
+
+.nextra-navbar-blur {
+  background-color: var(--atlas-bg) !important;
+  backdrop-filter: blur(8px) !important;
+  border-bottom: 1px solid var(--atlas-border-soft) !important;
+}
+
+/* Navbar inner width matches the sidebar (280) + article (820) + TOC (200) =
+   1300px so the header reads as the cap of the same column band instead of
+   visibly narrower than the content below it. */
+.nextra-navbar nav {
+  max-width: 1300px !important;
+  margin: 0 auto !important;
+  padding: 0 1.5rem !important;
+  height: var(--nextra-navbar-height) !important;
+}
+
+.atlas-navbar-logo {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-family: var(--atlas-headline-font);
+  font-size: 1.25rem;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  color: var(--atlas-text-strong);
+}
+.atlas-navbar-logo img {
+  flex-shrink: 0;
+  height: 28px;
+  width: auto;
+}
+
+.atlas-logo-dark { display: none !important; }
+.dark .atlas-logo-light { display: none !important; }
+.dark .atlas-logo-dark { display: inline-block !important; }
+
+/* ═══════════════════════════════════════════════════════════════════════════
+   SIDEBAR — Atlas treats the sidebar as a "handbook spine" rather than a
+   docs tree. Transparent surface, hairline right rule, looser line-height,
+   serif italic small-caps section headers, decimal-leading-zero numbering on
+   top-level folders, no chevron arrows. The intent is "engineering wiki"
+   not "Stripe SDK reference".
+   ═══════════════════════════════════════════════════════════════════════════ */
+
+aside.nextra-sidebar-container,
+aside.nextra-sidebar {
+  background: transparent !important;
+  border-right: 1px solid var(--atlas-border-soft) !important;
+  width: 280px !important;
+  scrollbar-width: thin !important;
+  scrollbar-color: var(--atlas-border) transparent !important;
+}
+aside.nextra-sidebar::-webkit-scrollbar,
+aside.nextra-sidebar-container::-webkit-scrollbar {
+  width: 6px;
+}
+aside.nextra-sidebar::-webkit-scrollbar-track,
+aside.nextra-sidebar-container::-webkit-scrollbar-track {
+  background: transparent;
+}
+aside.nextra-sidebar::-webkit-scrollbar-thumb,
+aside.nextra-sidebar-container::-webkit-scrollbar-thumb {
+  background: var(--atlas-border-soft);
+  border-radius: 3px;
+}
+aside.nextra-sidebar:hover::-webkit-scrollbar-thumb,
+aside.nextra-sidebar-container:hover::-webkit-scrollbar-thumb {
+  background: var(--atlas-border);
+}
+
+aside.nextra-sidebar > div,
+aside.nextra-sidebar-container > div {
+  padding-left: 0.75rem !important;
+  padding-right: 1.25rem !important;
+}
+
+/* Top-level folder/section headers — serif italic, sit as quiet "chapter
+   titles" with a faded hairline rule beneath them (print-book divider). */
+aside.nextra-sidebar > div > div > ul > li > button,
+aside.nextra-sidebar-container > div > div > ul > li > button {
+  font-family: var(--atlas-headline-font) !important;
+  font-style: italic !important;
+  font-size: 0.9375rem !important;
+  font-weight: 500 !important;
+  letter-spacing: 0.01em !important;
+  color: var(--atlas-text-strong) !important;
+  text-transform: none !important;
+  background: none !important;
+  border: none !important;
+  margin-top: 1.75rem !important;
+  margin-bottom: 0.5rem !important;
+  padding: 0.25rem 0.5rem 0.5rem !important;
+  width: 60% !important;
+  text-align: left !important;
+  cursor: pointer;
+  border-bottom: 1px solid var(--atlas-border-soft) !important;
+}
+
+/* Hide chevron arrows on the section tree only — collapse state is implied
+   by indent. Scoped to ul-button so the sidebar-footer theme toggle (also
+   a button + svg) is left intact. */
+aside.nextra-sidebar ul li > button > svg,
+aside.nextra-sidebar-container ul li > button > svg {
+  display: none !important;
+}
+
+/* Nested entries — quiet, looser line-height, larger indent */
+aside.nextra-sidebar li > div > ul,
+aside.nextra-sidebar-container li > div > ul {
+  margin-left: 1rem !important;
+  border-left: 1px solid var(--atlas-border-soft) !important;
+  padding-left: 0.25rem !important;
+}
+
+aside.nextra-sidebar li a,
+aside.nextra-sidebar-container li a {
+  position: relative !important;
+  font-size: 0.9375rem !important;
+  line-height: 1.7 !important;
+  color: var(--atlas-text-soft) !important;
+  padding: 0.3rem 0.5rem 0.3rem 1.25rem !important;
+  border-left: 3px solid transparent !important;
+  border-radius: 0 !important;
+  background: none !important;
+  transition: border-color 0.15s, color 0.15s, background 0.15s !important;
+}
+/* Quiet hyphen bullet before each entry — marginal-note feel */
+aside.nextra-sidebar li a::before,
+aside.nextra-sidebar-container li a::before {
+  content: "-";
+  position: absolute;
+  left: 0.5rem;
+  color: var(--atlas-text-faint);
+  font-weight: 400;
+}
+aside.nextra-sidebar li a:hover,
+aside.nextra-sidebar-container li a:hover {
+  color: var(--atlas-text-strong) !important;
+  border-left-color: var(--atlas-border) !important;
+  background: none !important;
+}
+aside.nextra-sidebar li.active > a,
+aside.nextra-sidebar-container li.active > a {
+  color: var(--atlas-accent) !important;
+  font-weight: 500 !important;
+  border-left-color: var(--atlas-accent) !important;
+  background: var(--atlas-accent-soft) !important;
+  box-shadow: none !important;
+}
+.dark aside.nextra-sidebar li.active > a,
+.dark aside.nextra-sidebar-container li.active > a {
+  background: transparent !important;
+  box-shadow: inset 4px 0 0 var(--atlas-accent), 0 0 12px var(--atlas-accent-glow) !important;
+  border-left-color: transparent !important;
+}
+
+/* Sidebar footer — holds Nextra's theme switch. Solid background so scrolled
+   sidebar content doesn't bleed through. Soft inset top shadow gives a quiet
+   scroll cue (content fading behind the footer). */
+.nextra-sidebar-footer {
+  border-top: 1px solid var(--atlas-border-soft) !important;
+  background: var(--atlas-bg) !important;
+  padding: 0.75rem 0.5rem !important;
+  box-shadow: 0 -8px 8px -8px rgba(0, 0, 0, 0.06) !important;
+}
+.dark .nextra-sidebar-footer {
+  box-shadow: 0 -8px 8px -8px rgba(0, 0, 0, 0.4) !important;
+}
+.nextra-sidebar-footer button {
+  font-size: 0.8125rem !important;
+  color: var(--atlas-text-soft) !important;
+  background: transparent !important;
+  border: 1px solid var(--atlas-border-soft) !important;
+  border-radius: 8px !important;
+  transition: border-color 0.15s, color 0.15s !important;
+}
+.nextra-sidebar-footer button:hover {
+  color: var(--atlas-text-strong) !important;
+  border-color: var(--atlas-border) !important;
+}
+
+/* ═══════════════════════════════════════════════════════════════════════════
+   MOBILE — below the md breakpoint (<768px) Nextra's persistent sidebar is
+   replaced by a hamburger-driven drawer (.nextra-mobile-nav). Our overrides:
+     - Hide the desktop collapse toggle (drawer is its own affordance)
+     - Force the persistent sidebar offscreen (defensive against our 280px
+       width override leaking in at narrow viewports)
+     - Tighten article padding so the reading column doesn't overflow
+     - Shrink the navbar logo so it fits next to the hamburger + theme toggle
+   ═══════════════════════════════════════════════════════════════════════════ */
+@media (max-width: 767px) {
+  /* Hide Nextra's collapse toggle on mobile — the hamburger drawer is the
+     sole nav affordance below md. */
+  button[title="Collapse sidebar"],
+  button[title="Expand sidebar"] {
+    display: none !important;
+  }
+  aside.nextra-sidebar,
+  aside.nextra-sidebar-container {
+    display: none !important;
+  }
+  article {
+    padding: 1.75rem 1.25rem 4rem !important;
+  }
+  article h1 {
+    font-size: 2rem !important;
+  }
+  article h2 {
+    font-size: 1.375rem !important;
+  }
+  .atlas-navbar-logo {
+    font-size: 1rem !important;
+  }
+  .nextra-navbar nav {
+    padding: 0 1rem !important;
+  }
+  /* Drawer styling — slides in from left, fills most of screen. We let
+     the drawer itself be the scroll container (overflow-y: auto on the
+     <aside>) so EVERY child is visible no matter how tall — the previous
+     attempt at flexing the first child as the scroll region clipped the
+     search input because flex-shrink kicked in before the input's own
+     padding cleared. Touch-scrolling momentum is preserved on iOS.
+
+     \`scroll-padding-top\` keeps Nextra's auto-scroll-to-active behavior
+     from pushing the search bar off the top: Nextra calls
+     \`scrollIntoView({ block: 'center' })\` on the active item when the
+     drawer mounts, and without this padding the drawer scrolled past
+     its own top edge, half-hiding the search input. */
+  .nextra-mobile-nav {
+    width: 320px !important;
+    max-width: 88vw !important;
+    background: var(--atlas-bg) !important;
+    border-right: 1px solid var(--atlas-border-soft) !important;
+    overflow-y: auto !important;
+    -webkit-overflow-scrolling: touch;
+    scroll-padding-top: calc(var(--nextra-navbar-height, 60px) + 0.5rem);
+  }
+  /* Comfortable inset for the directory list. Top padding has to clear
+     the fixed navbar manually — Nextra v4's default mobile drawer sits
+     at top:0 and does NOT pad for the navbar, so without this the first
+     directory item paints behind the navbar band. */
+  .nextra-mobile-nav > div:first-child {
+    padding: calc(var(--nextra-navbar-height) + 0.75rem) 0.875rem 1.5rem !important;
+  }
+  /* Hide the theme switch pinned at the bottom of the drawer. The
+     dark/light toggle is already in the navbar; duplicating it inside
+     the drawer added a full-width band that ate vertical space and
+     competed with the directory list for attention. */
+  .nextra-mobile-nav .nextra-sidebar-footer {
+    display: none !important;
+  }
+  /* Atlas mobile drawer: hide the top-level navbar entries (Documentation,
+     API Reference, customer-supplied header links) so the drawer is just
+     the active section's nav. The header items are still reachable from
+     the top navbar above the drawer. We match by href shape because Nextra
+     doesn't tag virtual nav-only items with an identifying attribute:
+       - href="/"        → __documentation
+       - href^="/api-"   → single-spec API Reference link, or wrapper-emitted
+                            top-level page-tab during API scope (visually
+                            redundant with the dropdown)
+       - href^="http"    → external customer header links (Support, Sign In, …)
+       - href^="mailto:" → external mailto header links
+     The folder-bound \`api-{spec}\` page-tab renders as a folder (<li> with
+     nested <ul>) and is excluded by the \`:not(:has(> div > ul))\` guard.
+     The "API Reference" multi-spec dropdown renders as <li> containing a
+     nested <ul> whose links go to /api-* — that's the dropdown filter. */
+  .nextra-mobile-nav > div > div > ul > li:has(> a[href="/"]),
+  .nextra-mobile-nav > div > div > ul > li:has(> a[href^="http"]):not(:has(> div > ul)),
+  .nextra-mobile-nav > div > div > ul > li:has(> a[href^="mailto:"]):not(:has(> div > ul)),
+  .nextra-mobile-nav > div > div > ul > li:has(> a[href^="/api-"]):not(:has(> div > ul)),
+  .nextra-mobile-nav > div > div > ul > li:has(> div > ul > li > a[href^="/api-"]),
+  .nextra-mobile-nav > div > div > ul > li:has(> div > ul > li > a[href^="http"]) {
+    display: none !important;
+  }
+  /* Footer columns stack on mobile */
+  .atlas-footer-columns {
+    flex-direction: column !important;
+    gap: 1.5rem !important;
+  }
+  footer {
+    padding: 2rem 1.25rem 3rem !important;
+  }
+}
+
+/* ═══════════════════════════════════════════════════════════════════════════
+   SIDEBAR COLLAPSE — hijacks Nextra's built-in toggle button (rendered in
+   the sidebar-footer next to the theme switch). Nextra flips the button's
+   title between "Collapse sidebar" and "Expand sidebar" — we use that as
+   the state signal:
+     - Collapsed: sidebar grid track + element width go to 0; the toggle
+       button itself escapes via position:fixed so it stays visible at
+       bottom-left of the viewport, just outside the article column.
+     - Expanded: everything renders normally.
+   ═══════════════════════════════════════════════════════════════════════════ */
+
+div:has(> aside.nextra-sidebar) {
+  transition: grid-template-columns 0.25s ease !important;
+}
+aside.nextra-sidebar,
+aside.nextra-sidebar-container {
+  transition: width 0.25s ease, opacity 0.2s ease, padding 0.2s ease;
+}
+article {
+  transition: max-width 0.25s ease;
+}
+
+/* Collapsed-state layout — driven by the toggle button's "Expand sidebar" title */
+div:has(> aside.nextra-sidebar:has(button[title="Expand sidebar"])) {
+  grid-template-columns: 0 1fr !important;
+}
+aside.nextra-sidebar:has(button[title="Expand sidebar"]),
+aside.nextra-sidebar-container:has(button[title="Expand sidebar"]) {
+  width: 0 !important;
+  min-width: 0 !important;
+  padding: 0 !important;
+  border-right: none !important;
+}
+/* Hide the rest of the footer (theme switch, etc.) when collapsed so they
+   don't ghost in. The toggle itself escapes the hide via position:fixed. */
+aside.nextra-sidebar:has(button[title="Expand sidebar"]) .nextra-sidebar-footer > *:not(button[title="Expand sidebar"]) {
+  opacity: 0 !important;
+  pointer-events: none !important;
+}
+body:has(button[title="Expand sidebar"]) article {
+  max-width: 980px !important;
+}
+
+/* Style Nextra's toggle button — same look in either state, prominent so the
+   user always knows where it is. Sits in the sidebar-footer when expanded. */
+button[title="Collapse sidebar"],
+button[title="Expand sidebar"] {
+  width: 28px !important;
+  height: 28px !important;
+  padding: 0 !important;
+  display: flex !important;
+  align-items: center !important;
+  justify-content: center !important;
+  border: 1px solid var(--atlas-border) !important;
+  border-radius: 6px !important;
+  background: var(--atlas-bg-surface) !important;
+  color: var(--atlas-text-strong) !important;
+  opacity: 1 !important;
+  cursor: pointer !important;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04) !important;
+  transition: background 0.15s, color 0.15s, border-color 0.15s, box-shadow 0.15s !important;
+}
+button[title="Collapse sidebar"]:hover,
+button[title="Expand sidebar"]:hover {
+  background: var(--atlas-bg) !important;
+  color: var(--atlas-accent) !important;
+  border-color: var(--atlas-accent) !important;
+  box-shadow: 0 0 0 3px var(--atlas-accent-glow) !important;
+}
+.dark button[title="Collapse sidebar"],
+.dark button[title="Expand sidebar"] {
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.4) !important;
+}
+
+/* Collapsed: float the toggle out of the now-zero-width sidebar so it stays
+   visible. Anchored at bottom-left of the viewport, just outside the article. */
+button[title="Expand sidebar"] {
+  position: fixed !important;
+  left: 12px !important;
+  bottom: 1rem !important;
+  z-index: 50 !important;
+}
+
+/* ═══════════════════════════════════════════════════════════════════════════
+   ARTICLE — wider reading column with sidebar present. Generous breathing
+   room, but no longer fights Nextra's three-column grid.
+   ═══════════════════════════════════════════════════════════════════════════ */
+
+article {
+  max-width: 820px !important;
+  padding: 2.5rem 2rem 5rem !important;
+  margin: 0 auto !important;
+  color: var(--atlas-text) !important;
+}
+
+article h1 {
+  font-family: var(--atlas-headline-font) !important;
+  font-size: 2.5rem !important;
+  font-weight: 600 !important;
+  letter-spacing: -0.005em !important;
+  line-height: 1.15 !important;
+  color: var(--atlas-text-strong) !important;
+  margin-top: 0 !important;
+  margin-bottom: 1.5rem !important;
+}
+
+article h1 + p {
+  font-size: 1.125rem !important;
+  color: var(--atlas-text-soft) !important;
+  line-height: 1.7 !important;
+  margin-bottom: 2.5rem !important;
+}
+
+article h2 {
+  font-family: var(--atlas-headline-font) !important;
+  font-size: 1.5rem !important;
+  font-weight: 600 !important;
+  letter-spacing: -0.005em !important;
+  line-height: 1.3 !important;
+  color: var(--atlas-text-strong) !important;
+  margin-top: 3rem !important;
+  margin-bottom: 0.875rem !important;
+  padding-bottom: 0 !important;
+  border-bottom: none !important;
+}
+article h2::before {
+  content: "-";
+  color: var(--atlas-text-faint);
+  font-weight: 400;
+  margin-right: 0.5rem;
+}
+
+article h3 {
+  font-family: var(--atlas-headline-font) !important;
+  font-size: 1.125rem !important;
+  font-weight: 600 !important;
+  color: var(--atlas-text-strong) !important;
+  margin-top: 2rem !important;
+  margin-bottom: 0.625rem !important;
+}
+
+article p {
+  font-size: 0.9375rem !important;
+  line-height: 1.8 !important;
+  color: var(--atlas-text) !important;
+  margin-bottom: 1.125rem !important;
+}
+
+article ul,
+article ol {
+  font-size: 0.9375rem !important;
+  line-height: 1.75 !important;
+}
+
+article a:not(.nextra-card) {
+  color: var(--atlas-accent) !important;
+  font-weight: 500 !important;
+  text-decoration: underline !important;
+  text-underline-offset: 3px !important;
+  text-decoration-thickness: 1px !important;
+}
+article a:not(.nextra-card):hover {
+  text-decoration-thickness: 2px !important;
+}
+
+/* User-authored markdown <hr> ('---') — quiet faded hairline rule. Auto-rendered
+   header separators get out of the way via tight margins. */
+article hr {
+  border: none !important;
+  height: 1px !important;
+  background: var(--atlas-border-soft) !important;
+  margin: 1.5rem auto !important;
+  max-width: 6rem !important;
+}
+
+article strong { color: var(--atlas-text-strong) !important; font-weight: 600 !important; }
+
+/* Code — full-bleed, soft surface, no gutter */
+article code:not(pre code) {
+  font-size: 0.8125em !important;
+  font-weight: 500 !important;
+  color: var(--atlas-text-strong) !important;
+  background: var(--atlas-border-soft) !important;
+  border-radius: 4px !important;
+  padding: 0.15em 0.4em !important;
+}
+
+/* Atlas code blocks — printed-listing style. No card border, no rounded
+   corners; instead the block extends past the article column by ~1rem each
+   side and is bookended by hairline rules above and below, so code reads
+   like a typeset listing in a print magazine rather than an inset card. */
+.nextra-code {
+  position: relative !important;
+  margin: 2rem -1rem !important;
+}
+.nextra-code pre, article pre {
+  font-size: 0.875rem !important;
+  line-height: 1.75 !important;
+  border-radius: 0 !important;
+  border: none !important;
+  border-top: 1px solid var(--atlas-border-soft) !important;
+  border-bottom: 1px solid var(--atlas-border-soft) !important;
+  padding: 1.25rem 1.5rem !important;
+  background: var(--atlas-bg-surface) !important;
+  margin: 0 !important;
+}
+
+/* Quiet copy button — italic small-caps "copy" tag, no surface treatment */
+.nextra-code button[title="Copy code"] {
+  top: 0.625rem !important;
+  right: 0.75rem !important;
+  padding: 0.25rem 0.4375rem !important;
+  background: transparent !important;
+  border: 1px solid var(--atlas-border-soft) !important;
+  border-radius: 4px !important;
+  color: var(--atlas-text-faint) !important;
+  opacity: 0.7 !important;
+  transition: opacity 0.15s, color 0.15s, border-color 0.15s !important;
+}
+.nextra-code:hover button[title="Copy code"] {
+  opacity: 1 !important;
+}
+.nextra-code button[title="Copy code"]:hover {
+  color: var(--atlas-accent) !important;
+  border-color: var(--atlas-accent) !important;
+}
+
+/* Cards with soft shadow (light) / glow (dark) */
+a.nextra-card {
+  border: 1px solid var(--atlas-border) !important;
+  border-radius: 12px !important;
+  background: var(--atlas-bg-surface) !important;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.04) !important;
+  transition: border-color 0.2s, box-shadow 0.2s !important;
+}
+a.nextra-card:hover {
+  border-color: var(--atlas-accent) !important;
+  box-shadow: 0 0 0 4px var(--atlas-accent-glow) !important;
+}
+.dark a.nextra-card {
+  box-shadow: none !important;
+}
+.dark a.nextra-card:hover {
+  box-shadow: 0 0 0 4px var(--atlas-accent-glow) !important;
+}
+
+/* ═══════════════════════════════════════════════════════════════════════════
+   TOC — tight, quiet "Contents" rail. Sticky behavior is owned by Nextra's
+   inner wrapper div, which already pins itself to var(--nextra-navbar-height).
+   We don't fight it from the outer nav — that creates a parent/child sticky
+   conflict that visually "shifts" the TOC down on scroll.
+   ═══════════════════════════════════════════════════════════════════════════ */
+
+.nextra-toc {
+  width: 200px !important;
+}
+
+.nextra-toc > div > p:first-child {
+  font-family: var(--atlas-headline-font) !important;
+  font-style: italic !important;
+  font-size: 0.8125rem !important;
+  font-weight: 500 !important;
+  letter-spacing: 0.02em !important;
+  color: var(--atlas-text-soft) !important;
+  padding: 1rem 1rem 0.5rem !important;
+  margin-bottom: 0.25rem !important;
+  border-bottom: 1px solid var(--atlas-border-soft) !important;
+}
+
+.nextra-toc ul li a {
+  font-size: 0.75rem !important;
+  line-height: 1.5 !important;
+  color: var(--atlas-text-faint) !important;
+  padding: 0.25rem 0.75rem !important;
+  border-left: 2px solid transparent !important;
+  transition: color 0.15s, border-color 0.15s !important;
+}
+.nextra-toc ul li a:hover {
+  color: var(--atlas-text-soft) !important;
+  border-left-color: var(--atlas-border) !important;
+}
+.nextra-toc ul li a.nextra-toc-active,
+.nextra-toc ul li a[data-active="true"] {
+  color: var(--atlas-text-strong) !important;
+  border-left-color: var(--atlas-accent) !important;
+}
+
+@media (max-width: 1279px) {
+  .nextra-toc { display: none !important; }
+}
+
+/* ═══════════════════════════════════════════════════════════════════════════
+   FOOTER — masthead style
+   ═══════════════════════════════════════════════════════════════════════════ */
+
+footer {
+  font-family: var(--atlas-headline-font) !important;
+  font-size: 0.875rem !important;
+  color: var(--atlas-text-soft) !important;
+  padding: 1.75rem 1.5rem 2rem !important;
+  border-top: 1px solid var(--atlas-border-soft) !important;
+  margin-top: 2rem !important;
+}
+footer > div:first-child {
+  margin-top: 0 !important;
+  padding-top: 0 !important;
+}
+
+footer .atlas-footer-masthead {
+  font-family: var(--atlas-headline-font);
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: var(--atlas-text-strong);
+  letter-spacing: -0.005em;
+  margin-bottom: 0.5rem;
+}
+
+footer .atlas-footer-copy {
+  font-family: 'Inter', sans-serif;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--atlas-text-faint);
+}
+
+/* ═══════════════════════════════════════════════════════════════════════════
+   ENTRY METADATA STRIP — date, reading time, type, rendered above h1 by
+   the AtlasWrapper when the page frontmatter carries a date field.
+   Establishes the "this is a dated entry" feel that distinguishes Atlas
+   from Forge's reference-doc stance.
+   ═══════════════════════════════════════════════════════════════════════════ */
+
+.atlas-entry-meta {
+  font-family: 'Inter', sans-serif;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--atlas-text-faint);
+  margin: 0 0 1rem 0;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.atlas-entry-date,
+.atlas-entry-type {
+  color: var(--atlas-text-soft);
+}
+
+.atlas-entry-sep {
+  color: var(--atlas-text-faint);
+}
+
+.atlas-entry-type {
+  text-transform: uppercase;
+}
+
+/* ═══════════════════════════════════════════════════════════════════════════
+   DIGEST CALLOUTS — <Outcome>, <Decision>, <ActionItem> render as styled
+   asides for capturing conversation summary structure. Each variant has its
+   own accent tint so a reader scanning a long entry can spot the structure
+   at a glance.
+   ═══════════════════════════════════════════════════════════════════════════ */
+
+.atlas-callout {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 1rem 1.25rem;
+  margin: 1.75rem 0;
+  border-radius: 12px;
+  border: 1px solid var(--atlas-border-soft);
+  background: var(--atlas-bg-surface);
+}
+
+.atlas-callout-head {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-family: var(--atlas-headline-font);
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--atlas-text-strong);
+}
+
+.atlas-callout-glyph {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.25rem;
+  height: 1.25rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  line-height: 1;
+}
+
+.atlas-callout-label {
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  font-size: 0.6875rem;
+}
+
+.atlas-callout-body {
+  font-family: 'Inter', sans-serif;
+  font-size: 0.9375rem;
+  line-height: 1.7;
+  color: var(--atlas-text);
+}
+.atlas-callout-body > *:first-child { margin-top: 0; }
+.atlas-callout-body > *:last-child { margin-bottom: 0; }
+
+/* Variant accents — each gets a tinted glyph background and left border. */
+.atlas-callout-outcome {
+  border-left: 3px solid hsl(150 50% 45%);
+}
+.atlas-callout-outcome .atlas-callout-glyph {
+  background: hsl(150 50% 92%);
+  color: hsl(150 60% 30%);
+}
+.dark .atlas-callout-outcome .atlas-callout-glyph {
+  background: hsl(150 50% 14%);
+  color: hsl(150 50% 70%);
+}
+
+.atlas-callout-decision {
+  border-left: 3px solid var(--atlas-accent);
+}
+.atlas-callout-decision .atlas-callout-glyph {
+  background: var(--atlas-accent-soft);
+  color: var(--atlas-accent);
+}
+
+.atlas-callout-action {
+  border-left: 3px solid hsl(35 80% 50%);
+}
+.atlas-callout-action .atlas-callout-glyph {
+  background: hsl(35 80% 92%);
+  color: hsl(35 70% 35%);
+}
+.dark .atlas-callout-action .atlas-callout-glyph {
+  background: hsl(35 60% 14%);
+  color: hsl(35 80% 70%);
+}
+
+/* ═══════════════════════════════════════════════════════════════════════════
+   PULL QUOTES — <Quote source="..."> for capturing dialogue snippets.
+   ═══════════════════════════════════════════════════════════════════════════ */
+
+.atlas-quote {
+  margin: 2rem 0;
+  padding: 0 0 0 1.5rem;
+  border-left: 3px solid var(--atlas-accent);
+}
+
+.atlas-quote blockquote {
+  margin: 0 !important;
+  padding: 0 !important;
+  font-family: var(--atlas-headline-font) !important;
+  font-style: italic !important;
+  font-size: 1.125rem !important;
+  line-height: 1.6 !important;
+  color: var(--atlas-text-strong) !important;
+}
+
+.atlas-quote figcaption {
+  margin-top: 0.625rem;
+  font-family: 'Inter', sans-serif;
+  font-size: 0.8125rem;
+  color: var(--atlas-text-soft);
+}
+
+/* ═══════════════════════════════════════════════════════════════════════════
+   ENTRY FEED — reverse-chronological list for index pages. Each row links
+   to a dated entry; sized to feel like a Substack-archive list, not docs
+   nav cards.
+   ═══════════════════════════════════════════════════════════════════════════ */
+
+.atlas-feed {
+  list-style: none !important;
+  margin: 2rem 0 !important;
+  padding: 0 !important;
+  border-top: 1px solid var(--atlas-border-soft);
+}
+
+.atlas-feed-item {
+  margin: 0 !important;
+  border-bottom: 1px solid var(--atlas-border-soft);
+}
+
+.atlas-feed-link {
+  display: block !important;
+  padding: 1.5rem 0 !important;
+  text-decoration: none !important;
+  transition: opacity 0.15s;
+}
+.atlas-feed-link:hover { opacity: 0.85; }
+
+.atlas-feed-meta {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  font-family: 'Inter', sans-serif;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--atlas-text-faint);
+  margin-bottom: 0.375rem;
+}
+
+.atlas-feed-title {
+  font-family: var(--atlas-headline-font) !important;
+  font-size: 1.375rem !important;
+  font-weight: 600 !important;
+  letter-spacing: -0.005em !important;
+  color: var(--atlas-text-strong) !important;
+  margin: 0 0 0.5rem 0 !important;
+}
+
+.atlas-feed-excerpt {
+  font-family: 'Inter', sans-serif;
+  font-size: 0.9375rem;
+  line-height: 1.65;
+  color: var(--atlas-text-soft);
+  margin: 0 !important;
+}
+
+.atlas-feed-empty {
+  color: var(--atlas-text-soft);
+  font-style: italic;
+}
+
+/* ═══════════════════════════════════════════════════════════════════════════
+   FOOTER (structured) — rendered when SiteBranding.footer is configured
+   Atlas keeps its masthead character; columns/social sit above the masthead.
+   ═══════════════════════════════════════════════════════════════════════════ */
+
+.atlas-footer {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 2.25rem;
+  padding: 0 0.5rem;
+}
+
+.atlas-footer-columns {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 2rem;
+}
+
+.atlas-footer-col h4 {
+  font-family: var(--atlas-headline-font) !important;
+  font-size: 0.875rem !important;
+  font-weight: 600 !important;
+  color: var(--atlas-text-strong) !important;
+  margin: 0 0 0.625rem 0 !important;
+}
+
+.atlas-footer-col ul {
+  list-style: none !important;
+  margin: 0 !important;
+  padding: 0 !important;
+  display: flex !important;
+  flex-direction: column !important;
+  gap: 0.375rem !important;
+}
+
+.atlas-footer-col a {
+  font-family: 'Inter', sans-serif !important;
+  font-size: 0.875rem !important;
+  color: var(--atlas-text-soft) !important;
+  text-decoration: none !important;
+}
+.atlas-footer-col a:hover {
+  color: var(--atlas-accent) !important;
+}
+
+.atlas-footer-bottom {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+  padding-top: 1.25rem;
+  border-top: 1px solid var(--atlas-border-soft);
+}
+
+.atlas-footer-social {
+  display: inline-flex;
+  align-items: center;
+  gap: 1rem;
+}
+.atlas-footer-social a {
+  font-family: 'Inter', sans-serif !important;
+  font-size: 0.75rem !important;
+  text-transform: uppercase !important;
+  letter-spacing: 0.06em !important;
+  color: var(--atlas-text-soft) !important;
+  text-decoration: none !important;
+}
+.atlas-footer-social a:hover {
+  color: var(--atlas-accent) !important;
+}
+
+/* ═══════════════════════════════════════════════════════════════════════════
+   SEARCH RESULTS DROPDOWN — Nextra portals the dropdown to body level. By
+   default it inherits the search input's width (clipping long result titles)
+   and stacks below the sidebar (whose left half then paints over the
+   dropdown). Match the portal element across the tailwind/headless-ui
+   variations Nextra has shipped, force a wider min-width, and use a z-index
+   high enough to beat any site chrome. position:relative is required for
+   z-index to take effect on otherwise position:static elements.
+   ═══════════════════════════════════════════════════════════════════════════ */
+
+.nextra-search ul,
+.nextra-search [role="listbox"],
+.nextra-search [role="dialog"],
+.nextra-search > div:not(:first-child),
+.nextra-search > p {
+  z-index: 9999 !important;
+  position: relative;
+}
+
+body > [class*="rounded-xl"][class*="shadow-xl"],
+body > [class*="rounded-lg"][class*="shadow-lg"],
+body > [class*="z-30"][class*="rounded"],
+body > [class*="z-50"][class*="rounded"],
+body > div[id^="headlessui-combobox"],
+body > div:has(> [role="listbox"]),
+body > [role="listbox"],
+body > [role="dialog"][aria-modal="true"]:has([role="listbox"]) {
+  position: relative !important;
+  z-index: 9999 !important;
+  min-width: 480px !important;
+  max-width: calc(100vw - 2rem) !important;
+}
+
+body > [class*="rounded-xl"][class*="shadow-xl"] li > a,
+body > [class*="rounded-lg"][class*="shadow-lg"] li > a,
+body > [class*="rounded-xl"] [role="option"],
+body > [class*="rounded-lg"] [role="option"],
+body > [role="listbox"] [role="option"],
+body > div:has(> [role="listbox"]) [role="option"] {
+  white-space: nowrap !important;
+  overflow: hidden !important;
+  text-overflow: ellipsis !important;
+}
+
+@media (max-width: 767px) {
+  body > [class*="rounded-xl"][class*="shadow-xl"],
+  body > [class*="rounded-lg"][class*="shadow-lg"],
+  body > [class*="z-30"][class*="rounded"],
+  body > [class*="z-50"][class*="rounded"],
+  body > div[id^="headlessui-combobox"],
+  body > div:has(> [role="listbox"]),
+  body > [role="listbox"] {
+    min-width: 0 !important;
+  }
+}
+
+`;
+
+export interface AtlasOverrideInput {
+	accentHue: number;
+	fontFamily?: string;
+}
+
+export function buildAtlasOverrides(input: AtlasOverrideInput): string {
+	const hue = input.accentHue;
+	const fontDecl = input.fontFamily ? `  --atlas-font-family: ${input.fontFamily};\n` : "";
+
+	return `
+/* ── Atlas theme overrides (generated) ──────────────────────────────────── */
+:root {
+${fontDecl}  --nextra-primary-hue:        ${hue};
+  --nextra-primary-saturation: 70%;
+  --nextra-primary-lightness:  56%;
+
+  --atlas-accent:      hsl(${hue} 70% 56%);
+  --atlas-accent-soft: hsl(${hue} 70% 95%);
+  --atlas-accent-glow: hsla(${hue}, 70%, 50%, 0.15);
+}
+
+.dark {
+  --nextra-primary-lightness: 64%;
+  --atlas-accent:      hsl(${hue} 70% 64%);
+  --atlas-accent-soft: hsl(${hue} 70% 12%);
+  --atlas-accent-glow: hsla(${hue}, 70%, 60%, 0.2);
+}
+`;
+}
+
+/**
+ * Build the complete Atlas stylesheet (base + customer overrides). The
+ * API-reference companion stylesheet that the SaaS appends here is left out
+ * — the CLI's rich-renderer writes `styles/api.css` separately and the
+ * layout imports it alongside `themes/atlas.css`.
+ */
+export function buildAtlasCss(input: AtlasOverrideInput): string {
+	return ATLAS_BASE_CSS + buildAtlasOverrides(input);
+}

--- a/cli/src/site/themes/atlas/Layout.test.ts
+++ b/cli/src/site/themes/atlas/Layout.test.ts
@@ -1,0 +1,317 @@
+/**
+ * Tests for the Atlas layout generator.
+ *
+ * Two surfaces:
+ *   - `resolveAtlasLayoutInput` — schema → AtlasLayoutInput resolution,
+ *     including manifest defaults (notably the dark / serif defaults that
+ *     differentiate Atlas from Forge) and the legacy top-level `favicon`
+ *     alias precedence.
+ *   - `generateAtlasLayoutTsx` — input → TSX string, covering the navbar
+ *     logo wrapper Atlas's CSS depends on, font/favicon link rendering,
+ *     logo slot variants, URL sanitization, and the `toc.title = "Contents"`
+ *     editorial detail.
+ */
+
+import { describe, expect, it } from "vitest";
+import { buildAtlasFontFamilyCssValue, generateAtlasLayoutTsx, resolveAtlasLayoutInput } from "./Layout.js";
+import { ATLAS_MANIFEST } from "./Manifest.js";
+
+const BASE_INPUT = {
+	title: "Acme Handbook",
+	description: "Editorial-style content site",
+	nav: [],
+	primaryHue: ATLAS_MANIFEST.defaults.primaryHue,
+	defaultTheme: ATLAS_MANIFEST.defaults.defaultTheme,
+	fontFamily: ATLAS_MANIFEST.defaults.fontFamily,
+};
+
+// ─── resolveAtlasLayoutInput ────────────────────────────────────────────────
+
+describe("resolveAtlasLayoutInput", () => {
+	it("applies Atlas manifest defaults when theme is undefined (dark + serif)", () => {
+		const result = resolveAtlasLayoutInput({
+			title: "T",
+			description: "D",
+			nav: [],
+			theme: undefined,
+			legacyFavicon: undefined,
+		});
+		expect(result.primaryHue).toBe(200);
+		expect(result.defaultTheme).toBe("dark");
+		expect(result.fontFamily).toBe("source-serif");
+	});
+
+	it("honors theme overrides over manifest defaults", () => {
+		const result = resolveAtlasLayoutInput({
+			title: "T",
+			description: "D",
+			nav: [],
+			theme: { primaryHue: 30, defaultTheme: "light", fontFamily: "ibm-plex" },
+			legacyFavicon: undefined,
+		});
+		expect(result.primaryHue).toBe(30);
+		expect(result.defaultTheme).toBe("light");
+		expect(result.fontFamily).toBe("ibm-plex");
+	});
+
+	it("legacy top-level favicon wins over theme.favicon (deprecated alias precedence)", () => {
+		const result = resolveAtlasLayoutInput({
+			title: "T",
+			description: "D",
+			nav: [],
+			theme: { favicon: "/theme.ico" },
+			legacyFavicon: "/legacy.ico",
+		});
+		expect(result.favicon).toBe("/legacy.ico");
+	});
+
+	it("resolves the CSS font-family value for a given FontFamily key", () => {
+		expect(buildAtlasFontFamilyCssValue("source-serif")).toContain("Source Serif 4");
+		expect(buildAtlasFontFamilyCssValue("inter")).toContain("Inter");
+	});
+
+	it("passes through header and footer config", () => {
+		const header = { items: [{ label: "Docs", url: "/docs" }] };
+		const footer = { copyright: "2026 Acme" };
+		const result = resolveAtlasLayoutInput({
+			title: "T",
+			description: "D",
+			nav: [],
+			header,
+			footer,
+			theme: undefined,
+			legacyFavicon: undefined,
+		});
+		expect(result.header).toBe(header);
+		expect(result.footer).toBe(footer);
+	});
+});
+
+// ─── generateAtlasLayoutTsx ─────────────────────────────────────────────────
+
+describe("generateAtlasLayoutTsx", () => {
+	it("imports the Atlas stylesheet and the shared API stylesheet", () => {
+		const result = generateAtlasLayoutTsx(BASE_INPUT);
+		expect(result).toContain("import './themes/atlas.css'");
+		expect(result).toContain("import '../styles/api.css'");
+	});
+
+	it("renders the Atlas navbar logo wrapper that the CSS depends on", () => {
+		const result = generateAtlasLayoutTsx(BASE_INPUT);
+		expect(result).toContain('className="atlas-navbar-logo"');
+	});
+
+	it("does NOT render a sidebar logo or sidebar-search wrapper (Atlas-specific layout)", () => {
+		const result = generateAtlasLayoutTsx(BASE_INPUT);
+		expect(result).not.toContain("atlas-sidebar-logo");
+		expect(result).not.toContain("atlas-sidebar-search");
+	});
+
+	it("uses Atlas's saturation (70) in <Head color>, not Forge's 84", () => {
+		const result = generateAtlasLayoutTsx({ ...BASE_INPUT, primaryHue: 145 });
+		expect(result).toContain("hue: 145, saturation: 70");
+		expect(result).not.toContain("saturation: 84");
+	});
+
+	it("passes toc={{ title: 'Contents' }} to <Layout> for Atlas's editorial label", () => {
+		const result = generateAtlasLayoutTsx(BASE_INPUT);
+		expect(result).toContain("toc={{ title: 'Contents' }}");
+	});
+
+	it("interpolates defaultTheme into <Layout nextThemes>", () => {
+		const result = generateAtlasLayoutTsx({ ...BASE_INPUT, defaultTheme: "system" });
+		expect(result).toContain('defaultTheme: "system"');
+	});
+
+	it("emits the Source Serif 4 Google Fonts <link> by default", () => {
+		const result = generateAtlasLayoutTsx(BASE_INPUT);
+		expect(result).toContain("fonts.googleapis.com/css2?family=Source+Serif+4");
+	});
+
+	it("renders a single light-mode <img> when only logoUrl is set (no dark swap)", () => {
+		const result = generateAtlasLayoutTsx({ ...BASE_INPUT, logoUrl: "/logo.svg" });
+		expect(result).toContain('<img src={"/logo.svg"} alt={"Acme Handbook"}');
+		expect(result).not.toContain("atlas-logo-dark");
+	});
+
+	it("renders paired light+dark <img>s with atlas-logo-light/dark classes when both set", () => {
+		const result = generateAtlasLayoutTsx({
+			...BASE_INPUT,
+			logoUrl: "/light.svg",
+			logoUrlDark: "/dark.svg",
+		});
+		expect(result).toContain('className="atlas-logo-light"');
+		expect(result).toContain('className="atlas-logo-dark"');
+	});
+
+	it("includes the favicon <link> when configured and omits it when not", () => {
+		expect(generateAtlasLayoutTsx(BASE_INPUT)).not.toContain('rel="icon"');
+		const withFavicon = generateAtlasLayoutTsx({ ...BASE_INPUT, favicon: "/favicon.ico" });
+		expect(withFavicon).toContain('<link rel="icon" href={"/favicon.ico"}');
+	});
+
+	it("sanitizes javascript: URLs in nav, favicon, and logoUrl to '#'", () => {
+		const navResult = generateAtlasLayoutTsx({
+			...BASE_INPUT,
+			nav: [{ label: "Bad", href: "javascript:alert(1)" }],
+		});
+		expect(navResult).not.toMatch(/javascript:alert/i);
+		expect(navResult).toContain('<a href={"#"}');
+
+		const favResult = generateAtlasLayoutTsx({ ...BASE_INPUT, favicon: "javascript:alert(1)" });
+		expect(favResult).not.toMatch(/javascript:alert/i);
+
+		const logoResult = generateAtlasLayoutTsx({ ...BASE_INPUT, logoUrl: "javascript:alert(1)" });
+		expect(logoResult).not.toMatch(/javascript:alert/i);
+		expect(logoResult).toContain('<img src={"#"}');
+	});
+
+	it("renders nav items as <a> children of <Navbar> (Atlas keeps the legacy nav shorthand support)", () => {
+		const result = generateAtlasLayoutTsx({
+			...BASE_INPUT,
+			nav: [{ label: "Guides", href: "/guides" }],
+		});
+		expect(result).toContain('href={"/guides"}');
+		expect(result).toContain('{"Guides"}');
+	});
+
+	// ── header.items support ─────────────────────────────────────────────────
+
+	it("prefers header.items over legacy nav when both are set", () => {
+		const result = generateAtlasLayoutTsx({
+			...BASE_INPUT,
+			nav: [{ label: "FromNav", href: "/nav" }],
+			header: { items: [{ label: "FromHeader", url: "/header" }] },
+		});
+		expect(result).toContain("FromHeader");
+		expect(result).not.toContain("FromNav");
+	});
+
+	it("renders a <details> dropdown when a header item has sub-items", () => {
+		const result = generateAtlasLayoutTsx({
+			...BASE_INPUT,
+			header: {
+				items: [
+					{
+						label: "Resources",
+						items: [
+							{ label: "Blog", url: "/blog" },
+							{ label: "Changelog", url: "/changelog" },
+						],
+					},
+				],
+			},
+		});
+		expect(result).toContain("<details");
+		expect(result).toContain("<summary");
+		expect(result).toContain('{"Resources"}');
+		expect(result).toContain('{"Blog"}');
+		expect(result).toContain('href={"/blog"}');
+	});
+
+	it("renders a direct link for header items without sub-items", () => {
+		const result = generateAtlasLayoutTsx({
+			...BASE_INPUT,
+			header: { items: [{ label: "Docs", url: "/docs" }] },
+		});
+		expect(result).toContain('href={"/docs"}');
+		expect(result).not.toContain("<details");
+	});
+
+	it("falls back to '#' for header items with no url and no sub-items", () => {
+		const result = generateAtlasLayoutTsx({
+			...BASE_INPUT,
+			header: { items: [{ label: "Empty" }] },
+		});
+		expect(result).toContain('href={"#"}');
+	});
+
+	it("sanitizes javascript: URLs in header dropdown sub-items", () => {
+		const result = generateAtlasLayoutTsx({
+			...BASE_INPUT,
+			header: {
+				items: [{ label: "Menu", items: [{ label: "Bad", url: "javascript:alert(1)" }] }],
+			},
+		});
+		expect(result).not.toMatch(/javascript:alert/i);
+		expect(result).toContain('href={"#"}');
+	});
+
+	it("falls back to legacy nav when header.items is empty", () => {
+		const result = generateAtlasLayoutTsx({
+			...BASE_INPUT,
+			nav: [{ label: "NavLink", href: "/nav" }],
+			header: { items: [] },
+		});
+		expect(result).toContain("NavLink");
+	});
+
+	// ── footer support ───────────────────────────────────────────────────────
+
+	it("renders default copyright footer when no footer config is set", () => {
+		const result = generateAtlasLayoutTsx(BASE_INPUT);
+		expect(result).toContain("<Footer>");
+		expect(result).toContain("new Date().getFullYear()");
+	});
+
+	it("renders footer copyright text", () => {
+		const result = generateAtlasLayoutTsx({
+			...BASE_INPUT,
+			footer: { copyright: "2026 Acme Inc." },
+		});
+		expect(result).toContain("<Footer>");
+		expect(result).toContain('{"2026 Acme Inc."}');
+	});
+
+	it("renders footer columns with titles and links", () => {
+		const result = generateAtlasLayoutTsx({
+			...BASE_INPUT,
+			footer: {
+				columns: [
+					{
+						title: "Product",
+						links: [
+							{ label: "Pricing", url: "/pricing" },
+							{ label: "Docs", url: "/docs" },
+						],
+					},
+				],
+			},
+		});
+		expect(result).toContain('{"Product"}');
+		expect(result).toContain('{"Pricing"}');
+		expect(result).toContain('href={"/pricing"}');
+	});
+
+	it("renders footer social links in canonical platform order", () => {
+		const result = generateAtlasLayoutTsx({
+			...BASE_INPUT,
+			footer: { socialLinks: { youtube: "https://yt.example", github: "https://gh.example" } },
+		});
+		const ghIdx = result.indexOf("gh.example");
+		const ytIdx = result.indexOf("yt.example");
+		expect(ghIdx).toBeGreaterThan(-1);
+		expect(ytIdx).toBeGreaterThan(-1);
+		expect(ghIdx).toBeLessThan(ytIdx);
+	});
+
+	it("renders default copyright footer when footer has no content", () => {
+		const result = generateAtlasLayoutTsx({
+			...BASE_INPUT,
+			footer: { columns: [], socialLinks: {} },
+		});
+		expect(result).toContain("new Date().getFullYear()");
+	});
+
+	it("sanitizes javascript: URLs in footer links and social links", () => {
+		const result = generateAtlasLayoutTsx({
+			...BASE_INPUT,
+			footer: {
+				columns: [{ title: "X", links: [{ label: "Bad", url: "javascript:alert(1)" }] }],
+				socialLinks: { github: "data:text/html,evil" },
+			},
+		});
+		expect(result).not.toContain("javascript:alert");
+		expect(result).not.toContain("data:text/html");
+	});
+});

--- a/cli/src/site/themes/atlas/Layout.ts
+++ b/cli/src/site/themes/atlas/Layout.ts
@@ -1,0 +1,363 @@
+/**
+ * Atlas layout generator — produces `app/layout.tsx` for sites that pick
+ * `theme.pack === "atlas"` in their `site.json`.
+ *
+ * Adapted from the SaaS Atlas layout
+ * (`tools/nextra-generator/src/themes/atlas/templates/Layout.ts` in
+ * jolli.ai/jolli) post-JOLLI-1392, with the same SaaS-only bits stripped
+ * as the Forge port (`ScopedNextraLayout`, auth banner, auth provider,
+ * `filterAuthFromPageMap`).
+ *
+ * Atlas differs from Forge layout-wise in a handful of places:
+ *   - logo lives only in the navbar (`.atlas-navbar-logo`) — no separate
+ *     sidebar logo wrapper
+ *   - no sidebar search block — Atlas uses Nextra's default navbar search
+ *   - `<Head color={{ saturation: 70 }}>` (vs Forge's 84)
+ *   - passes `toc={{ title: 'Contents' }}` to `<Layout>` so the TOC label
+ *     reads in Atlas's editorial voice
+ *
+ * Customer fields resolved from `theme.*` (with Atlas manifest defaults):
+ *   - `primaryHue`         → `<Head color={{ hue, saturation: 70 }}>`
+ *   - `defaultTheme`       → `<Layout nextThemes={{ defaultTheme }}>`
+ *                            (defaults to "dark")
+ *   - `fontFamily`         → Google Fonts `<link>` + `--atlas-font-family`
+ *                            (defaults to "source-serif")
+ *   - `logoUrl`/`Dark`     → `<img>` rendered in the navbar logo slot
+ *   - `favicon`            → `<link rel="icon">` (top-level `favicon` wins)
+ */
+
+import type {
+	DefaultThemeMode,
+	ExternalLink,
+	FontFamily,
+	FooterConfig,
+	HeaderConfig,
+	HeaderItem,
+	NavLink,
+} from "../../Types.js";
+import { ATLAS_MANIFEST } from "./Manifest.js";
+
+// ─── Font config ─────────────────────────────────────────────────────────────
+
+interface FontEntry {
+	url: string;
+	cssFamily: string;
+}
+
+/**
+ * Google Fonts URLs + CSS family values. Same shape as Forge's `FONT_CONFIG`
+ * (mirrors `FONT_CONFIG` from jolli-common). Duplicated here rather than
+ * factored out — sharing is a 30-line refactor for marginal value when
+ * there are only two packs; revisit if a third pack lands.
+ */
+const FONT_CONFIG: Record<FontFamily, FontEntry> = {
+	inter: {
+		url: "https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap",
+		cssFamily: "'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif",
+	},
+	"space-grotesk": {
+		url: "https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&display=swap",
+		cssFamily: "'Space Grotesk', -apple-system, sans-serif",
+	},
+	"ibm-plex": {
+		url: "https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&display=swap",
+		cssFamily: "'IBM Plex Sans', -apple-system, sans-serif",
+	},
+	"source-sans": {
+		url: "https://fonts.googleapis.com/css2?family=Source+Sans+3:wght@400;600;700&display=swap",
+		cssFamily: "'Source Sans 3', -apple-system, sans-serif",
+	},
+	"source-serif": {
+		url: "https://fonts.googleapis.com/css2?family=Source+Serif+4:opsz,wght@8..60,400;8..60,500;8..60,600;8..60,700&display=swap",
+		cssFamily: "'Source Serif 4', 'Iowan Old Style', Georgia, serif",
+	},
+};
+
+// ─── AtlasLayoutInput ────────────────────────────────────────────────────────
+
+export interface AtlasLayoutInput {
+	title: string;
+	description: string;
+	nav: NavLink[];
+	header?: HeaderConfig;
+	footer?: FooterConfig;
+	primaryHue: number;
+	defaultTheme: DefaultThemeMode;
+	fontFamily: FontFamily;
+	logoUrl?: string;
+	logoUrlDark?: string;
+	favicon?: string;
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/** See `themes/forge/Layout.ts` — same allow-list, same fail-closed default. */
+function sanitizeUrl(url: string): string {
+	const trimmed = url.trim();
+	if (trimmed === "" || /^(?:https?:|mailto:|tel:|[#?/]|\.\.?\/)/i.test(trimmed)) {
+		return trimmed;
+	}
+	return "#";
+}
+
+/**
+ * Logo slot markup for the Atlas navbar. JSX-expression attributes
+ * (`src={...}`, `alt={...}`) keep user-controlled title out of raw HTML
+ * attributes. Atlas only renders the logo in the navbar — there's no
+ * sidebar logo wrapper to populate.
+ *
+ * Returns `{ light, dark }`:
+ *   - No `logoUrl`             → both empty (text-only logo)
+ *   - `logoUrl` only           → single `<img>`, no dark swap
+ *   - `logoUrl` + `logoUrlDark` → paired imgs with `.atlas-logo-light` /
+ *                                 `.atlas-logo-dark`
+ */
+function buildLogoSlots(input: AtlasLayoutInput): { light: string; dark: string } {
+	if (!input.logoUrl) {
+		return { light: "", dark: "" };
+	}
+	const jsAlt = JSON.stringify(input.title);
+	const jsLightSrc = JSON.stringify(sanitizeUrl(input.logoUrl));
+	if (!input.logoUrlDark) {
+		return { light: `<img src={${jsLightSrc}} alt={${jsAlt}} />`, dark: "" };
+	}
+	const jsDarkSrc = JSON.stringify(sanitizeUrl(input.logoUrlDark));
+	return {
+		light: `<img src={${jsLightSrc}} alt={${jsAlt}} className="atlas-logo-light" />`,
+		dark: `<img src={${jsDarkSrc}} alt={${jsAlt}} className="atlas-logo-dark" />`,
+	};
+}
+
+/**
+ * Resolves the navbar's logical item list. `header.items` wins when set;
+ * otherwise legacy `nav` is coerced into dropdown-less items.
+ */
+function resolveHeaderItems(input: AtlasLayoutInput): HeaderItem[] {
+	if (input.header?.items && input.header.items.length > 0) {
+		return input.header.items;
+	}
+	return input.nav.map((n) => ({ label: n.label, url: n.href }));
+}
+
+/** Renders a single header item — either an `<a>` or a `<details>` dropdown. */
+function renderNavbarChild(item: HeaderItem): string {
+	const jsLabel = JSON.stringify(item.label);
+	if (item.items && item.items.length > 0) {
+		const subLinks = item.items
+			.map((sub: ExternalLink) => {
+				const jsSubLabel = JSON.stringify(sub.label);
+				const jsSubHref = JSON.stringify(sanitizeUrl(sub.url));
+				return `              <a href={${jsSubHref}} style={{ display: 'block', padding: '0.25rem 0.75rem', whiteSpace: 'nowrap' }}>{${jsSubLabel}}</a>`;
+			})
+			.join("\n");
+		return [
+			`          <details style={{ marginLeft: '1rem', display: 'inline-block', position: 'relative' }}>`,
+			`            <summary style={{ cursor: 'pointer', listStyle: 'none' }}>{${jsLabel}}</summary>`,
+			`            <div style={{ position: 'absolute', top: '100%', left: 0, marginTop: '0.25rem', background: 'var(--nextra-bg, #fff)', border: '1px solid var(--nextra-border, #e5e7eb)', borderRadius: 4, padding: '0.25rem 0', minWidth: 160, zIndex: 10 }}>`,
+			subLinks,
+			`            </div>`,
+			`          </details>`,
+		].join("\n");
+	}
+	const jsHref = JSON.stringify(sanitizeUrl(item.url ?? "#"));
+	return `          <a href={${jsHref}} style={{ marginLeft: '1rem' }}>{${jsLabel}}</a>`;
+}
+
+/** Social platforms supported in the footer, in display order. */
+const SOCIAL_PLATFORMS = ["github", "twitter", "discord", "linkedin", "youtube"] as const;
+
+/** Builds the inner JSX of `<Footer>`, or `""` when there's nothing to render. */
+function buildFooterBody(footer: FooterConfig | undefined): string {
+	if (!footer) return "";
+
+	const hasColumns = footer.columns && footer.columns.length > 0;
+	const hasCopyright = typeof footer.copyright === "string" && footer.copyright.length > 0;
+	const socials = footer.socialLinks;
+	const socialEntries = socials
+		? SOCIAL_PLATFORMS.filter((p) => typeof socials[p] === "string" && socials[p] !== "")
+		: [];
+	const hasSocial = socialEntries.length > 0;
+
+	if (!hasColumns && !hasCopyright && !hasSocial) return "";
+
+	const blocks: string[] = [];
+
+	if (hasColumns) {
+		const columnsJsx = (footer.columns ?? [])
+			.map((col) => {
+				const jsTitle = JSON.stringify(col.title);
+				const links = col.links
+					.map((link: ExternalLink) => {
+						const jsLabel = JSON.stringify(link.label);
+						const jsHref = JSON.stringify(sanitizeUrl(link.url));
+						return `                <li><a href={${jsHref}}>{${jsLabel}}</a></li>`;
+					})
+					.join("\n");
+				return [
+					`            <div style={{ minWidth: 140 }}>`,
+					`              <h4 style={{ margin: '0 0 0.5rem', fontSize: '0.875rem', fontWeight: 600 }}>{${jsTitle}}</h4>`,
+					`              <ul style={{ listStyle: 'none', padding: 0, margin: 0 }}>`,
+					links,
+					`              </ul>`,
+					`            </div>`,
+				].join("\n");
+			})
+			.join("\n");
+		blocks.push(
+			`          <div style={{ display: 'flex', gap: '2rem', flexWrap: 'wrap', marginBottom: '1rem' }}>\n${columnsJsx}\n          </div>`,
+		);
+	}
+
+	if (hasCopyright || hasSocial) {
+		const bottom: string[] = [];
+		if (hasCopyright) {
+			const jsCopyright = JSON.stringify(footer.copyright);
+			bottom.push(`            <span>{${jsCopyright}}</span>`);
+		}
+		if (hasSocial && socials) {
+			const social = socialEntries
+				.map((p) => {
+					const jsHref = JSON.stringify(sanitizeUrl(socials[p] ?? ""));
+					const jsLabel = JSON.stringify(p);
+					return `              <a href={${jsHref}} aria-label={${jsLabel}}>{${jsLabel}}</a>`;
+				})
+				.join("\n");
+			bottom.push(`            <div style={{ display: 'flex', gap: '0.75rem' }}>\n${social}\n            </div>`);
+		}
+		blocks.push(
+			`          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', flexWrap: 'wrap', gap: '1rem' }}>\n${bottom.join("\n")}\n          </div>`,
+		);
+	}
+
+	return [`        <div style={{ width: '100%' }}>`, ...blocks, `        </div>`].join("\n");
+}
+
+// ─── generateAtlasLayoutTsx ──────────────────────────────────────────────────
+
+/**
+ * Returns the full contents of `app/layout.tsx` for an Atlas-themed site.
+ * Caller is responsible for writing `app/themes/atlas.css` (which this
+ * layout imports) — see `initNextraProject` in `NextraProjectWriter`.
+ */
+export function generateAtlasLayoutTsx(input: AtlasLayoutInput): string {
+	const jsTitle = JSON.stringify(input.title);
+	const jsDescription = JSON.stringify(input.description);
+	const jsDefaultTheme = JSON.stringify(input.defaultTheme);
+
+	const font = FONT_CONFIG[input.fontFamily];
+	const fontLink = `<link rel="stylesheet" href={${JSON.stringify(font.url)}} />`;
+	const faviconLink = input.favicon ? `<link rel="icon" href={${JSON.stringify(sanitizeUrl(input.favicon))}} />` : "";
+
+	const logo = buildLogoSlots(input);
+	const logoMarkup = `${logo.light}${logo.dark}<span>{${jsTitle}}</span>`;
+
+	const headerItems = resolveHeaderItems(input);
+	const navLinks = headerItems.map(renderNavbarChild).join("\n");
+	const navbarChildren = headerItems.length > 0 ? `\n${navLinks}\n        ` : "";
+
+	const footerBody = buildFooterBody(input.footer);
+	const footerJsx =
+		footerBody === ""
+			? `<Footer>{new Date().getFullYear()} © {${jsTitle}}</Footer>`
+			: `<Footer>\n${footerBody}\n      </Footer>`;
+
+	return `import { Footer, Layout, Navbar } from 'nextra-theme-docs'
+import { Head } from 'nextra/components'
+import { getPageMap } from 'nextra/page-map'
+import 'nextra-theme-docs/style.css'
+import '../styles/api.css'
+import './themes/atlas.css'
+
+export const metadata = {
+  title: ${jsTitle},
+  description: ${jsDescription},
+}
+
+const SiteLogo = () => (
+  <span className="atlas-navbar-logo">
+    ${logoMarkup}
+  </span>
+)
+
+const navbar = <Navbar logo={<SiteLogo />}>${navbarChildren}</Navbar>
+const footer = ${footerJsx}
+
+export default async function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en" dir="ltr" suppressHydrationWarning>
+      <Head color={{ hue: ${input.primaryHue}, saturation: 70 }}>
+        ${fontLink}
+        ${faviconLink}
+      </Head>
+      <body>
+        <Layout
+          navbar={navbar}
+          pageMap={await getPageMap()}
+          footer={footer}
+          editLink={null}
+          feedback={{ content: null }}
+          toc={{ title: 'Contents' }}
+          darkMode={true}
+          nextThemes={{ defaultTheme: ${jsDefaultTheme} }}
+        >
+          {children}
+        </Layout>
+      </body>
+    </html>
+  )
+}
+`;
+}
+
+// ─── resolveAtlasLayoutInput ─────────────────────────────────────────────────
+
+/**
+ * Resolves the `AtlasLayoutInput` from a project config + `theme` block,
+ * applying Atlas manifest defaults for any unset customer field. Same
+ * legacy-favicon precedence rule as Forge: top-level `favicon` wins over
+ * `theme.favicon`.
+ */
+export function resolveAtlasLayoutInput(args: {
+	title: string;
+	description: string;
+	nav: NavLink[];
+	header?: HeaderConfig;
+	footer?: FooterConfig;
+	theme:
+		| {
+				primaryHue?: number;
+				defaultTheme?: DefaultThemeMode;
+				fontFamily?: FontFamily;
+				logoUrl?: string;
+				logoUrlDark?: string;
+				favicon?: string;
+		  }
+		| undefined;
+	legacyFavicon: string | undefined;
+}): AtlasLayoutInput {
+	const t = args.theme ?? {};
+	return {
+		title: args.title,
+		description: args.description,
+		nav: args.nav,
+		header: args.header,
+		footer: args.footer,
+		primaryHue: t.primaryHue ?? ATLAS_MANIFEST.defaults.primaryHue,
+		defaultTheme: t.defaultTheme ?? ATLAS_MANIFEST.defaults.defaultTheme,
+		fontFamily: t.fontFamily ?? ATLAS_MANIFEST.defaults.fontFamily,
+		logoUrl: t.logoUrl,
+		logoUrlDark: t.logoUrlDark,
+		favicon: args.legacyFavicon ?? t.favicon,
+	};
+}
+
+// ─── buildAtlasFontFamilyCssValue ────────────────────────────────────────────
+
+/**
+ * Resolves the CSS `font-family` value for a given `FontFamily` choice.
+ * Used by `NextraProjectWriter` to pass into `buildAtlasCss({ fontFamily })`
+ * so the generated CSS overrides match the `<link>`-loaded Google Font.
+ */
+export function buildAtlasFontFamilyCssValue(font: FontFamily): string {
+	return FONT_CONFIG[font].cssFamily;
+}

--- a/cli/src/site/themes/atlas/Manifest.ts
+++ b/cli/src/site/themes/atlas/Manifest.ts
@@ -1,0 +1,32 @@
+/**
+ * Atlas theme pack manifest — editorial handbook visual style.
+ *
+ * Designed to feel materially different from Forge so users have a real
+ * reason to pick. Top-nav layout (vs Forge's sidebar-dominant), serif
+ * headlines, dark-default mode, airy spacing, masthead-style footer.
+ *
+ * Mirrors `ATLAS_MANIFEST` from the SaaS Atlas pack
+ * (`tools/nextra-generator/src/themes/atlas/Manifest.ts` in jolli.ai/jolli)
+ * post-JOLLI-1392.
+ */
+
+import type { DefaultThemeMode, FontFamily } from "../../Types.js";
+
+export const ATLAS_MANIFEST = {
+	name: "atlas",
+	displayName: "Atlas",
+	tagline: "Editorial handbook",
+	defaults: {
+		/** Atlas leans cooler — neutral mid-blue when `theme.primaryHue` is unset. */
+		primaryHue: 200,
+		/** Editorial mood reads better at night; default dark, light is the warm cream variant. */
+		defaultTheme: "dark" as DefaultThemeMode,
+		/**
+		 * Default body font — Source Serif 4 is the most decisive visual signal vs
+		 * Forge. Customer can still override via `theme.fontFamily`.
+		 */
+		fontFamily: "source-serif" as FontFamily,
+	},
+} as const;
+
+export type AtlasManifest = typeof ATLAS_MANIFEST;

--- a/cli/src/site/themes/atlas/index.ts
+++ b/cli/src/site/themes/atlas/index.ts
@@ -1,0 +1,12 @@
+/**
+ * Atlas theme pack — public surface re-exports.
+ */
+
+export { type AtlasOverrideInput, buildAtlasCss, buildAtlasOverrides } from "./Css.js";
+export {
+	type AtlasLayoutInput,
+	buildAtlasFontFamilyCssValue,
+	generateAtlasLayoutTsx,
+	resolveAtlasLayoutInput,
+} from "./Layout.js";
+export { ATLAS_MANIFEST, type AtlasManifest } from "./Manifest.js";

--- a/cli/src/site/themes/forge/Css.test.ts
+++ b/cli/src/site/themes/forge/Css.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Tests for the Forge stylesheet builder.
+ *
+ * Forge CSS is mostly a vendored static block (~1300 lines) that we cover
+ * with sanity checks rather than line-by-line — the value-add of these
+ * tests is the dynamic override generator: hue interpolation, optional
+ * font-family declaration, and the cascade order (base + overrides).
+ */
+
+import { describe, expect, it } from "vitest";
+import { buildForgeCss, buildForgeOverrides } from "./Css.js";
+
+describe("buildForgeOverrides", () => {
+	it("interpolates the accent hue into hsl() declarations", () => {
+		const result = buildForgeOverrides({ accentHue: 145 });
+		expect(result).toContain("--nextra-primary-hue:        145");
+		expect(result).toContain("hsl(145 84% 61%)");
+	});
+
+	it("emits dark-mode accent variants derived from the same hue", () => {
+		const result = buildForgeOverrides({ accentHue: 200 });
+		expect(result).toContain(".dark");
+		expect(result).toContain("hsl(200 84% 68%)"); // dark accent
+		expect(result).toContain("hsl(200 84% 11%)"); // dark accent-soft
+	});
+
+	it("emits a --forge-font-family declaration when fontFamily is set", () => {
+		const result = buildForgeOverrides({ accentHue: 228, fontFamily: "'IBM Plex Sans', sans-serif" });
+		expect(result).toContain("--forge-font-family: 'IBM Plex Sans', sans-serif");
+	});
+
+	it("omits --forge-font-family when fontFamily is undefined", () => {
+		const result = buildForgeOverrides({ accentHue: 228 });
+		expect(result).not.toContain("--forge-font-family:");
+	});
+});
+
+describe("buildForgeCss", () => {
+	it("includes the base Forge stylesheet sections", () => {
+		const result = buildForgeCss({ accentHue: 228 });
+		expect(result).toContain("Forge Theme");
+		expect(result).toContain(".forge-sidebar-logo");
+		expect(result).toContain(".forge-sidebar-search");
+		expect(result).toContain(".nextra-navbar");
+		expect(result).toContain(".nextra-toc");
+	});
+
+	it("appends the override block after the base CSS so cascade gives overrides precedence", () => {
+		const result = buildForgeCss({ accentHue: 145 });
+		const baseMarkerIdx = result.indexOf(".forge-footer-social");
+		const overrideMarkerIdx = result.indexOf("Forge theme overrides (generated)");
+		expect(baseMarkerIdx).toBeGreaterThan(-1);
+		expect(overrideMarkerIdx).toBeGreaterThan(baseMarkerIdx);
+	});
+
+	it("does NOT include the auth banner block (CLI-strip)", () => {
+		const result = buildForgeCss({ accentHue: 228 });
+		expect(result).not.toContain(".jolli-auth-banner");
+	});
+});

--- a/cli/src/site/themes/forge/Css.ts
+++ b/cli/src/site/themes/forge/Css.ts
@@ -1,0 +1,1308 @@
+/**
+ * Forge theme CSS — clean developer-docs visual style.
+ *
+ * Sidebar-dominant layout, navbar reduced to search + theme switch, three-column
+ * desktop grid (sidebar | article | TOC), Inter typography, hairline borders.
+ *
+ * Pack-internal defaults are encoded in --forge-* and --header-/--nav-* CSS
+ * variables. The override block (built by `buildForgeOverrides`) is appended at
+ * the end of the file so customer accent + sidebar/header bg overrides take
+ * precedence via the cascade.
+ *
+ * Vendored from the SaaS Forge pack
+ * (`tools/nextra-generator/src/themes/forge/styles/ForgeCss.ts` in jolli.ai/jolli)
+ * post-JOLLI-1392. The auth banner block has been stripped (CLI sites don't
+ * have JWT auth) and the API-reference companion stylesheet (`buildApiCss`)
+ * is intentionally not appended yet — it lands in a follow-up commit so the
+ * OpenAPI page styling can be reviewed in isolation.
+ */
+
+/**
+ * Base Forge stylesheet. Keep in sync with the
+ * `forge-theme/forge.css` reference under Downloads.
+ */
+const FORGE_BASE_CSS = `/*
+ * Forge Theme
+ * To retheme: override the --header-* and --nav-* variables only.
+ * Everything else derives from those + the general palette.
+ */
+
+/* ═══════════════════════════════════════════════════════════════════════════
+   DESIGN TOKENS
+   ═══════════════════════════════════════════════════════════════════════════ */
+
+:root {
+  /* Nextra internals */
+  --nextra-primary-hue: 228;
+  --nextra-primary-saturation: 84%;
+  --nextra-primary-lightness: 61%;
+  --nextra-bg: 255 255 255;
+  --nextra-navbar-height: 54px;
+
+  /* ── Accent ─────────────────────────────────────────── */
+  --forge-accent:        hsl(228 84% 61%);
+  --forge-accent-soft:   hsl(228 84% 96%);
+  --forge-accent-border: hsl(228 84% 75%);
+
+  /* ── General palette ────────────────────────────────── */
+  --forge-bg:            #ffffff;
+  --forge-border:        #e5e7eb;
+  --forge-border-soft:   #f3f4f6;
+  --forge-text-strong:   #111827;
+  --forge-text:          #374151;
+  --forge-text-soft:     #6b7280;
+  --forge-text-faint:    #9ca3af;
+  --forge-hover-bg:      #f9fafb;
+
+  /* ── Header (navbar) ────────────────────────────────── */
+  --header-bg:             #ffffff;
+  --header-border:         #e5e7eb;
+  --header-logo-color:     #111827;
+  --header-search-bg:      #f3f4f6;
+  --header-search-border:  #e5e7eb;
+  --header-search-color:   #6b7280;
+  --header-kbd-bg:         #ffffff;
+  --header-kbd-color:      #9ca3af;
+
+  /* ── Left-hand nav (sidebar) ────────────────────────── */
+  --nav-bg:                #f3f4f6;
+  --nav-border:            #e5e7eb;
+  --nav-section-color:     #9ca3af;
+  --nav-item-color:        #4b5563;
+  --nav-item-hover-bg:     #e9ebee;
+  --nav-item-hover-color:  #111827;
+  --nav-active-bg:         #ffffff;
+  --nav-active-color:      hsl(228 84% 61%);
+  --nav-active-bar:        hsl(228 84% 61%);
+  --nav-footer-bg:         #eceef1;
+  --nav-footer-border:     #e5e7eb;
+  --nav-footer-color:      #6b7280;
+}
+
+.dark {
+  --nextra-bg: 10 10 15;
+  --nextra-primary-lightness: 68%;
+
+  --forge-accent-soft:   hsl(228 84% 11%);
+  --forge-accent-border: hsl(228 84% 40%);
+  --forge-bg:            rgb(10 10 15);
+  --forge-border:        #1f2937;
+  --forge-border-soft:   #111827;
+  --forge-text-strong:   #f9fafb;
+  --forge-text:          #d1d5db;
+  --forge-text-soft:     #9ca3af;
+  --forge-text-faint:    #6b7280;
+  --forge-hover-bg:      #111827;
+
+  --header-bg:             rgb(10 10 15);
+  --header-border:         #1f2937;
+  --header-logo-color:     #f9fafb;
+  --header-search-bg:      #111827;
+  --header-search-border:  #1f2937;
+  --header-search-color:   #9ca3af;
+  --header-kbd-bg:         #1f2937;
+  --header-kbd-color:      #4b5563;
+
+  --nav-bg:                #111827;
+  --nav-border:            #1f2937;
+  --nav-section-color:     #6b7280;
+  --nav-item-color:        #9ca3af;
+  --nav-item-hover-bg:     #111827;
+  --nav-item-hover-color:  #f9fafb;
+  --nav-active-bg:         hsl(228 84% 11%);
+  --nav-active-color:      hsl(228 84% 68%);
+  --nav-active-bar:        hsl(228 84% 68%);
+  --nav-footer-bg:         rgb(10 10 15);
+  --nav-footer-border:     #1f2937;
+  --nav-footer-color:      #6b7280;
+}
+
+/* ═══════════════════════════════════════════════════════════════════════════
+   BASE
+   ═══════════════════════════════════════════════════════════════════════════ */
+
+html {
+  font-family: var(--forge-font-family, 'Inter', ui-sans-serif, system-ui, sans-serif) !important;
+  font-feature-settings: 'cv02', 'cv03', 'cv04', 'cv11';
+  -webkit-font-smoothing: antialiased;
+  letter-spacing: -0.011em;
+}
+
+body { background-color: var(--forge-bg); }
+
+/* ═══════════════════════════════════════════════════════════════════════════
+   SIDEBAR LOGO — pinned to very top of sidebar column
+   ═══════════════════════════════════════════════════════════════════════════ */
+
+.forge-sidebar-logo {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 295px;
+  height: var(--nextra-navbar-height);
+  background: var(--nav-bg);
+  z-index: 36;
+  display: flex;
+  align-items: center;
+  padding: 0 1rem;
+  flex-shrink: 0;
+}
+
+.forge-sidebar-logo a {
+  display: flex;
+  align-items: center;
+  gap: 0.625rem;
+  font-size: 1.125rem;
+  font-weight: 700;
+  letter-spacing: -0.03em;
+  color: var(--nav-item-hover-color);
+  text-decoration: none;
+}
+.forge-sidebar-logo a img {
+  flex-shrink: 0;
+  height: 24px;
+  width: auto;
+}
+.forge-sidebar-logo a:hover { opacity: 0.75; }
+
+/* Light/dark logo swap — only fires when both variants are emitted. */
+img.forge-logo-dark { display: none !important; }
+.dark img.forge-logo-light { display: none !important; }
+.dark img.forge-logo-dark { display: inline-block !important; }
+
+@media (max-width: 767px) {
+  .forge-sidebar-logo { display: none; }
+}
+
+/* ═══════════════════════════════════════════════════════════════════════════
+   SIDEBAR SEARCH — pinned below the logo
+   ═══════════════════════════════════════════════════════════════════════════ */
+
+.forge-sidebar-search {
+  position: fixed;
+  top: var(--nextra-navbar-height);
+  left: 0;
+  width: 295px;
+  padding: 0.625rem 1rem;
+  background: var(--nav-bg);
+  z-index: 36;
+}
+
+.forge-sidebar-search .nextra-search input {
+  width: 100% !important;
+  background: var(--forge-bg) !important;
+  border: 1px solid var(--forge-border) !important;
+  border-radius: 0.5rem !important;
+  padding: 0.4375rem 0.75rem !important;
+  font-size: 0.8125rem !important;
+  font-family: inherit !important;
+  color: var(--forge-text-soft) !important;
+  transition: border-color 0.15s, box-shadow 0.15s !important;
+}
+.forge-sidebar-search .nextra-search input::placeholder {
+  color: var(--forge-text-faint) !important;
+}
+.forge-sidebar-search .nextra-search input:focus {
+  border-color: var(--forge-accent) !important;
+  box-shadow: 0 0 0 3px var(--forge-accent-soft) !important;
+  outline: none !important;
+  color: var(--forge-text-strong) !important;
+}
+.forge-sidebar-search .nextra-search kbd {
+  background: var(--forge-border-soft) !important;
+  border: 1px solid var(--forge-border) !important;
+  border-radius: 0.25rem !important;
+  color: var(--forge-text-faint) !important;
+  font-family: inherit !important;
+  font-size: 0.625rem !important;
+  box-shadow: none !important;
+  padding: 0 0.3rem !important;
+}
+.dark .forge-sidebar-search .nextra-search input {
+  background: var(--forge-border-soft) !important;
+}
+
+.nextra-sidebar > div:first-child {
+  padding-top: calc(var(--nextra-navbar-height) + 3.75rem) !important;
+}
+
+.nextra-search ul,
+.nextra-search [role="listbox"],
+.nextra-search [role="dialog"],
+.nextra-search > div:not(:first-child),
+.nextra-search > p {
+  z-index: 1000 !important;
+  position: relative;
+}
+
+/* Portal-rendered search dropdown sits at body level. The default width
+   inherits from the search input (~263px in the sidebar), which clips long
+   result titles, and the default z-index is below the fixed sidebar (35),
+   which paints over the dropdown's left half. We catch the portal element
+   across nextra-theme-docs class-name variations (Nextra has shipped a few
+   different combinations of tailwind utility classes) plus role-based
+   fallbacks so any of them gets the wider min-width and the high z-index.
+   position:relative is required because z-index has no effect on a
+   position:static element.
+
+   The :has rules use descendant matching (not direct-child) because Nextra
+   sometimes wraps the listbox in one or more layers of divs inside the
+   portal — newer combobox builds add an empty wrapper for transition
+   animations, which broke the previous direct-child > [role=listbox]
+   selector and let the sidebar paint over the popup. */
+body > [class*="rounded-xl"][class*="shadow-xl"],
+body > [class*="rounded-lg"][class*="shadow-lg"],
+body > [class*="z-30"][class*="rounded"],
+body > [class*="z-50"][class*="rounded"],
+body > div[id^="headlessui-combobox"],
+body > div[id^="headlessui"],
+body > [data-headlessui-state],
+body > div:has([role="listbox"]),
+body > div:has([role="dialog"]),
+body > [role="listbox"],
+body > [role="dialog"][aria-modal="true"]:has([role="listbox"]) {
+  position: relative !important;
+  z-index: 9999 !important;
+  min-width: 480px !important;
+  max-width: calc(100vw - 2rem) !important;
+}
+
+body > [class*="rounded-xl"][class*="shadow-xl"] li > a,
+body > [class*="rounded-lg"][class*="shadow-lg"] li > a,
+body > [class*="rounded-xl"] [role="option"],
+body > [class*="rounded-lg"] [role="option"],
+body > [role="listbox"] [role="option"],
+body > div:has(> [role="listbox"]) [role="option"] {
+  white-space: nowrap !important;
+  overflow: hidden !important;
+  text-overflow: ellipsis !important;
+}
+
+@media (max-width: 767px) {
+  .forge-sidebar-search { display: none; }
+  /* Search dropdown sizing on mobile. The desktop rules (above) hard-set
+     min-width: 480px so the popover doesn't clip long titles next to the
+     295px sidebar; on mobile that overflows the viewport, so we drop
+     min-width and pin both width and max-width to (100vw - 1rem) so the
+     dropdown fills the screen with a comfortable inset. max-height caps
+     the popover at 70vh so it never pushes the input offscreen — the
+     result list scrolls inside instead. */
+  body > [class*="rounded-xl"][class*="shadow-xl"],
+  body > [class*="rounded-lg"][class*="shadow-lg"],
+  body > [class*="z-30"][class*="rounded"],
+  body > [class*="z-50"][class*="rounded"],
+  body > div[id^="headlessui-combobox"],
+  body > div:has(> [role="listbox"]),
+  body > [role="listbox"] {
+    min-width: 0 !important;
+    width: calc(100vw - 1rem) !important;
+    max-width: calc(100vw - 1rem) !important;
+    max-height: 70vh !important;
+  }
+  /* Override the desktop nowrap+ellipsis (where rows fit comfortably in
+     the 480px popover): on mobile the rows must wrap so the page title
+     and breadcrumb don't collapse to a single ellipsized character. Bump
+     padding so each row hits a 44px+ tap target. */
+  body > [class*="rounded-xl"][class*="shadow-xl"] li > a,
+  body > [class*="rounded-lg"][class*="shadow-lg"] li > a,
+  body > [class*="rounded-xl"] [role="option"],
+  body > [class*="rounded-lg"] [role="option"],
+  body > [role="listbox"] [role="option"],
+  body > div:has(> [role="listbox"]) [role="option"] {
+    white-space: normal !important;
+    overflow: visible !important;
+    text-overflow: clip !important;
+    padding: 0.75rem 0.875rem !important;
+    min-height: 2.75rem !important;
+  }
+  /* Nextra v4 portals the search popover (.nextra-search-results) via
+     Headless UI Combobox + Floating UI. Floating UI anchors the popover
+     to the search input's top edge ('top end'); when the input sits near
+     the top of the mobile drawer, the available space above is just the
+     navbar height (~30px), which collapses the popover to one cramped
+     row. Sizing overrides alone can't fix this — the bigger popover
+     just extends further off-screen above the viewport.
+
+     Resolution: ignore Floating UI's anchor positioning on mobile and
+     force-render the popover as a fixed overlay below the navbar,
+     spanning most of the viewport. Visually disconnected from the input
+     but always usable. !important wins over Floating UI's frame-by-frame
+     inline style assignments because Floating UI doesn't set !important.
+
+     Top is set to (navbar + 6rem) so the popover starts below the
+     drawer's search input — the input lives at navbar-bottom + drawer
+     top-padding + input-height, which works out to ~5rem below the
+     navbar; the extra 1rem is breathing room so the popover isn't
+     visually jammed up against the input. Users can keep typing and
+     see results update without the popover masking the input. */
+  .nextra-search-results {
+    position: fixed !important;
+    top: calc(var(--nextra-navbar-height) + 6rem) !important;
+    left: 0.5rem !important;
+    right: 0.5rem !important;
+    bottom: 1rem !important;
+    width: auto !important;
+    max-width: none !important;
+    height: auto !important;
+    max-height: none !important;
+  }
+  .nextra-search-results [role="option"] {
+    padding: 0.75rem 0.875rem !important;
+    min-height: 2.75rem !important;
+  }
+}
+
+/* Nextra's "Skip to Content" accessibility anchor uses an x:sr-only
+   utility that gets overridden by our cascade-layer wrap, so it renders
+   as a giant visible link in the top-left. We don't surface keyboard-skip
+   navigation in the Jolli-generated layouts (the sidebar's first link is
+   already the primary entry point), so hide it outright. */
+.nextra-skip-nav,
+a[href="#nextra-skip-nav"] {
+  position: absolute !important;
+  width: 1px !important;
+  height: 1px !important;
+  padding: 0 !important;
+  margin: -1px !important;
+  overflow: hidden !important;
+  clip: rect(0, 0, 0, 0) !important;
+  white-space: nowrap !important;
+  border: 0 !important;
+  /* Even when focused, don't reveal — feature isn't surfaced in Forge. */
+  clip-path: inset(50%) !important;
+}
+
+/* ═══════════════════════════════════════════════════════════════════════════
+   HEADER / NAVBAR
+   ═══════════════════════════════════════════════════════════════════════════ */
+
+.nextra-navbar-blur {
+  background-color: var(--header-bg) !important;
+  backdrop-filter: none !important;
+  -webkit-backdrop-filter: none !important;
+  border-bottom: 1px solid var(--nav-bg) !important;
+}
+
+.nextra-navbar nav {
+  max-width: 100% !important;
+  padding-left: calc(295px + 1.5rem) !important;
+  padding-right: 1.5rem !important;
+  gap: 0 !important;
+}
+
+@media (max-width: 767px) {
+  .nextra-navbar nav {
+    padding-left: 1rem !important;
+    padding-right: 1rem !important;
+  }
+  /* Hide the navbar's page-tab strip (Documentation, API Reference, header
+     links). On mobile those entries live in the hamburger drawer — leaving
+     them in the top bar made it overflow into a wrapped row at any
+     viewport with more than two header items. The search wrapper, theme
+     switch, and hamburger stay visible because they're siblings of (not
+     inside) the nav-items div. */
+  .nextra-navbar nav > div:not(:has(.nextra-search)) {
+    display: none !important;
+  }
+}
+
+.nextra-navbar nav > a[href="/"] {
+  display: none !important;
+}
+
+@media (max-width: 767px) {
+  .nextra-navbar nav > a[href="/"] {
+    display: flex !important;
+    align-items: center !important;
+    margin-right: auto !important;
+  }
+}
+
+.forge-navbar-logo {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 1rem;
+  font-weight: 700;
+  letter-spacing: -0.03em;
+  color: var(--forge-text-strong);
+}
+.forge-navbar-logo img {
+  flex-shrink: 0;
+  height: 24px;
+  width: auto;
+}
+
+.nextra-navbar nav > div:not(:has(.nextra-search)) {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  overflow: visible;
+  /* Right-align the nav links inside this flex:1 container so they cluster
+     toward the search/theme controls instead of butting against the
+     sidebar's right edge. The search wrapper is a separate sibling div with
+     its own \`margin-left: auto\` (below), so it stays pinned rightmost
+     after the nav links. */
+  justify-content: flex-end;
+}
+
+/* Header links rendered from nav-* _meta.ts entries — give them comfortable
+   spacing and link-style treatment so they do not butt against each other or
+   look like raw text. */
+.nextra-navbar nav > div > a,
+.nextra-navbar nav > div > details {
+  padding: 0.375rem 0.625rem !important;
+  font-size: 0.8125rem !important;
+  font-weight: 500 !important;
+  color: var(--forge-text-soft) !important;
+  text-decoration: none !important;
+  border-radius: 0.375rem !important;
+  transition: background 0.12s, color 0.12s !important;
+  white-space: nowrap !important;
+}
+.nextra-navbar nav > div > a:hover,
+.nextra-navbar nav > div > details:hover {
+  background: var(--forge-hover-bg) !important;
+  color: var(--forge-text-strong) !important;
+}
+.nextra-navbar nav > div > details > summary {
+  cursor: pointer !important;
+  list-style: none !important;
+}
+
+.nextra-navbar .nextra-search { margin-left: auto; }
+.forge-sidebar-search .nextra-search { margin-left: 0; width: 100%; }
+
+/* Forge renders search twice: a sidebar block (forge-sidebar-search) for
+   desktop and Nextra's auto-rendered navbar search for mobile. Each viewport
+   shows exactly one — sidebar is hidden under 768px (line 277) and the
+   navbar copy is hidden at/above it here. Both are <Search/> from
+   nextra/components and trigger the same Cmd+K modal, so duplication
+   doesn't fork shortcut state. */
+@media (min-width: 768px) {
+  .nextra-navbar .nextra-search { display: none !important; }
+}
+
+.nextra-search input {
+  width: 13rem !important;
+  background: var(--header-search-bg) !important;
+  border: 1px solid var(--header-search-border) !important;
+  border-radius: 0.5rem !important;
+  padding: 0.375rem 0.75rem !important;
+  font-size: 0.8125rem !important;
+  font-family: inherit !important;
+  color: var(--header-search-color) !important;
+  transition: border-color 0.15s, box-shadow 0.15s, background 0.15s !important;
+}
+.nextra-search input::placeholder { color: var(--header-search-color) !important; }
+.nextra-search input:focus {
+  background: var(--forge-bg) !important;
+  border-color: var(--forge-accent) !important;
+  box-shadow: 0 0 0 3px var(--forge-accent-soft) !important;
+  outline: none !important;
+  color: var(--forge-text-strong) !important;
+}
+
+.nextra-search kbd {
+  background: var(--header-kbd-bg) !important;
+  border: 1px solid var(--header-search-border) !important;
+  border-radius: 0.25rem !important;
+  color: var(--header-kbd-color) !important;
+  font-family: inherit !important;
+  font-size: 0.625rem !important;
+  letter-spacing: 0.02em !important;
+  box-shadow: none !important;
+  padding: 0 0.3rem !important;
+}
+
+.nextra-hamburger {
+  color: var(--forge-text-soft) !important;
+  padding: 0.375rem !important;
+  border-radius: 0.375rem !important;
+}
+.nextra-hamburger:hover {
+  background: var(--forge-hover-bg) !important;
+  color: var(--forge-text-strong) !important;
+}
+
+/* ═══════════════════════════════════════════════════════════════════════════
+   MAIN LAYOUT — 5-col grid
+   col: [sidebar 295px] [1fr] [article 680px] [toc 220px] [1fr]
+   ═══════════════════════════════════════════════════════════════════════════ */
+
+div:has(> aside.nextra-sidebar) {
+  display: grid !important;
+  grid-template-columns: 295px 1fr 680px 220px 1fr !important;
+  max-width: 100% !important;
+  width: 100% !important;
+  margin: 0 !important;
+  align-items: start !important;
+}
+
+aside.nextra-sidebar { grid-column: 1 !important; grid-row: 1 !important; }
+article              { grid-column: 3 !important; grid-row: 1 !important; min-width: 0 !important; width: 100% !important; max-width: 100% !important; margin: 0 !important; }
+nav.nextra-toc       { grid-column: 4 !important; grid-row: 1 !important; width: 220px !important; order: unset !important; }
+
+@media (max-width: 1279px) {
+  div:has(> aside.nextra-sidebar) { grid-template-columns: 295px 1fr 680px 1fr !important; }
+  article { grid-column: 3 !important; }
+  nav.nextra-toc { display: none !important; }
+}
+
+@media (max-width: 900px) {
+  div:has(> aside.nextra-sidebar) { grid-template-columns: 295px 1fr !important; }
+  article { grid-column: 2 !important; }
+}
+
+@media (max-width: 767px) {
+  div:has(> aside.nextra-sidebar) { grid-template-columns: 1fr !important; }
+  aside.nextra-sidebar { display: none !important; }
+  article { grid-column: 1 !important; padding: 0 1.25rem 4rem !important; }
+}
+
+/* ═══════════════════════════════════════════════════════════════════════════
+   SIDEBAR / LEFT-HAND NAV
+   ═══════════════════════════════════════════════════════════════════════════ */
+
+.nextra-sidebar {
+  position: fixed !important;
+  top: 0 !important;
+  left: 0 !important;
+  width: 295px !important;
+  min-width: 295px !important;
+  height: 100dvh !important;
+  background: var(--nav-bg) !important;
+  border-right: none !important;
+  z-index: 35 !important;
+}
+
+div:has(> aside.nextra-sidebar)::before {
+  content: '';
+  display: block;
+  grid-column: 1;
+  grid-row: 1;
+  width: 295px;
+  pointer-events: none;
+}
+
+.nextra-sidebar > div:first-child {
+  padding: calc(var(--nextra-navbar-height) + 3.75rem) 1rem 1rem !important;
+}
+
+:is(.nextra-sidebar, .nextra-mobile-nav) > div > div > ul {
+  gap: 0 !important;
+  display: flex !important;
+  flex-direction: column !important;
+}
+
+:is(.nextra-sidebar, .nextra-mobile-nav) > div > div > ul > li > button {
+  font-size: 0.6875rem !important;
+  font-weight: 600 !important;
+  text-transform: uppercase !important;
+  letter-spacing: 0.08em !important;
+  color: var(--nav-section-color) !important;
+  background: none !important;
+  padding: 0.375rem 0.5rem 0.25rem 0.875rem !important;
+  margin-top: 1.5rem !important;
+  gap: 0 !important;
+  cursor: default !important;
+  pointer-events: none !important;
+  border-radius: 0 !important;
+}
+:is(.nextra-sidebar, .nextra-mobile-nav) > div > div > ul > li:first-of-type > button {
+  margin-top: 0.5rem !important;
+}
+:is(.nextra-sidebar, .nextra-mobile-nav) > div > div > ul > li > button > svg {
+  display: none !important;
+}
+
+:is(.nextra-sidebar, .nextra-mobile-nav) > div > div > ul > li.active > a,
+:is(.nextra-sidebar, .nextra-mobile-nav) > div > div > ul > li:not(.open) > a {
+  font-size: 0.8125rem !important;
+  padding: 0.3125rem 0.5rem 0.3125rem 0.875rem !important;
+  border-radius: 0.375rem !important;
+}
+
+:is(.nextra-sidebar, .nextra-mobile-nav) li > div > ul {
+  padding-left: 0.75rem !important;
+  margin-left: 0 !important;
+  padding-top: 0 !important;
+}
+:is(.nextra-sidebar, .nextra-mobile-nav) > div > div > ul > li > div > ul {
+  padding-left: 0 !important;
+}
+:is(.nextra-sidebar, .nextra-mobile-nav) li > div {
+  padding-top: 0 !important;
+}
+:is(.nextra-sidebar, .nextra-mobile-nav) li.open > a,
+:is(.nextra-sidebar, .nextra-mobile-nav) li.open > button {
+  padding-bottom: 0.5rem !important;
+}
+:is(.nextra-sidebar, .nextra-mobile-nav) li > div > ul::before {
+  display: none !important;
+  width: 0 !important;
+}
+
+:is(.nextra-sidebar, .nextra-mobile-nav) li > div > ul li > a,
+:is(.nextra-sidebar, .nextra-mobile-nav) li > div > ul li > button {
+  font-size: 0.8125rem !important;
+  font-weight: 500 !important;
+  color: var(--nav-item-color) !important;
+  padding: 0.3125rem 0.5rem 0.3125rem 0.875rem !important;
+  border-radius: 0.375rem !important;
+  background: none !important;
+  transition: background 0.1s, color 0.1s !important;
+  margin: 0 !important;
+  position: relative !important;
+  overflow: visible !important;
+}
+:is(.nextra-sidebar, .nextra-mobile-nav) li > div > ul li > a:hover,
+:is(.nextra-sidebar, .nextra-mobile-nav) li > div > ul li > button:hover {
+  background: var(--nav-item-hover-bg) !important;
+  color: var(--nav-item-hover-color) !important;
+}
+
+:is(.nextra-sidebar, .nextra-mobile-nav) li.active > a {
+  color: var(--nav-active-color) !important;
+  background: var(--nav-active-bg) !important;
+}
+:is(.nextra-sidebar, .nextra-mobile-nav) li.active > a::before {
+  content: '';
+  position: absolute;
+  left: -0.625rem;
+  top: 18%;
+  bottom: 18%;
+  width: 2px;
+  border-radius: 0 1px 1px 0;
+  background: var(--nav-active-bar);
+}
+
+.nextra-sidebar-footer { display: none !important; }
+
+.nextra-navbar .nextra-theme-switch { display: flex; align-items: center; }
+.nextra-navbar .nextra-theme-switch span { display: none !important; }
+.nextra-navbar .nextra-theme-switch button {
+  padding: 0.375rem !important;
+  border-radius: 0.375rem !important;
+  color: var(--forge-text-soft) !important;
+  background: none !important;
+  border: none !important;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  transition: background 0.1s, color 0.1s;
+}
+.nextra-navbar .nextra-theme-switch button:hover {
+  background: var(--forge-hover-bg) !important;
+  color: var(--forge-text-strong) !important;
+}
+
+/* Mobile drawer (Forge keeps header nav + section nav, both scrollable).
+   Nextra's MobileNav uses \`directories\` from \`normalizePages\` which
+   contains the visible navbar entries (Documentation, API Reference)
+   followed by the active section's items. We let both render so the
+   drawer is the single pane the user navigates with.
+
+   Scroll the whole drawer rather than flexing the first child as the
+   scroll region — the flex approach clipped the search input because
+   the search wrapper's natural height is taller than its flex basis,
+   and shrink kicked in before the input cleared its own padding. */
+.nextra-mobile-nav {
+  background: var(--nav-bg) !important;
+  overflow-y: auto !important;
+  -webkit-overflow-scrolling: touch;
+  /* \`scroll-padding-top\` tells the browser to treat the navbar-height
+     band as scroll padding. Nextra's MobileNav calls
+     \`scrollIntoView({ block: 'center' })\` on the active item when the
+     drawer mounts; without this padding the drawer can scroll past its
+     own top, hiding the search bar and the first nav items
+     ("Documentation"/spec name) above the navbar's bottom edge. */
+  scroll-padding-top: calc(var(--nextra-navbar-height, 54px) + 0.5rem);
+}
+/* Top padding clears the fixed navbar — without it the first nav item
+   (e.g. "Documentation") paints behind the navbar at top:0. The drawer
+   itself sits at top:0 by Nextra default, so the first child has to
+   account for the navbar band itself. */
+.nextra-mobile-nav > div:first-child {
+  padding: calc(var(--nextra-navbar-height) + 0.75rem) 1rem 1rem !important;
+}
+/* Top-level navbar links in the drawer: render as a distinct band above the
+   section items so the user can tell "site nav" from "page nav". The
+   sidebar's section headers (\`> ul > li > button\`) already get section
+   styling — page-tab links use \`<a>\` inside top-level \`<li>\` so we paint a
+   subtle hairline below the band. */
+.nextra-mobile-nav > div > div > ul > li:has(> a[href="/"]),
+.nextra-mobile-nav > div > div > ul > li:has(> a[href^="/api-"]):not(:has(> div > ul)),
+.nextra-mobile-nav > div > div > ul > li:has(> a[href^="http"]):not(:has(> div > ul)),
+.nextra-mobile-nav > div > div > ul > li:has(> a[href^="mailto:"]):not(:has(> div > ul)) {
+  font-weight: 500;
+}
+.nextra-mobile-nav > div > div > ul > li:has(> a[href="/"]) > a,
+.nextra-mobile-nav > div > div > ul > li:has(> a[href^="/api-"]):not(:has(> div > ul)) > a,
+.nextra-mobile-nav > div > div > ul > li:has(> a[href^="http"]):not(:has(> div > ul)) > a,
+.nextra-mobile-nav > div > div > ul > li:has(> a[href^="mailto:"]):not(:has(> div > ul)) > a {
+  font-size: 0.875rem !important;
+  color: var(--nav-item-hover-color) !important;
+  padding: 0.5rem 0.875rem !important;
+}
+/* Hide the theme switch in the mobile drawer footer. The dark/light
+   toggle is already in the navbar (top right) — duplicating it pinned
+   to the bottom of the drawer ate vertical space and added a
+   distracting full-width band that competed with the nav items. */
+.nextra-mobile-nav .nextra-sidebar-footer {
+  display: none !important;
+}
+
+/* ═══════════════════════════════════════════════════════════════════════════
+   TOC — right column
+   ═══════════════════════════════════════════════════════════════════════════ */
+
+.nextra-toc {
+  width: 220px !important;
+  min-width: 0 !important;
+  position: sticky !important;
+  top: var(--nextra-navbar-height) !important;
+  max-height: calc(100vh - var(--nextra-navbar-height)) !important;
+  overflow-y: auto !important;
+}
+
+.nextra-toc > div > p:first-child {
+  font-size: 0.6875rem !important;
+  font-weight: 600 !important;
+  text-transform: uppercase !important;
+  letter-spacing: 0.08em !important;
+  color: var(--forge-text-faint) !important;
+  padding: 1.5rem 1rem 0.5rem !important;
+}
+
+.nextra-toc ul { padding: 0.5rem 1rem 1rem !important; }
+.nextra-toc ul li { margin: 0 !important; }
+.nextra-toc ul li a {
+  font-size: 0.8125rem !important;
+  font-weight: 400 !important;
+  color: var(--forge-text-soft) !important;
+  padding: 0.3rem 0 !important;
+  display: block !important;
+  transition: color 0.12s !important;
+  line-height: 1.4 !important;
+}
+.nextra-toc ul li a:hover { color: var(--forge-accent) !important; }
+.nextra-toc ul li a[class*="font-semibold"] {
+  color: var(--forge-accent) !important;
+  font-weight: 500 !important;
+}
+
+.nextra-toc > div > div:last-child { display: none !important; }
+
+/* ═══════════════════════════════════════════════════════════════════════════
+   ARTICLE CONTENT
+   ═══════════════════════════════════════════════════════════════════════════ */
+
+article {
+  padding: 0 2.5rem 5rem !important;
+  color: var(--forge-text) !important;
+}
+
+.nextra-breadcrumb {
+  margin-top: 1.5rem !important;
+  margin-bottom: 0.375rem !important;
+  font-size: 0.75rem !important;
+  color: var(--forge-text-faint) !important;
+  gap: 0.375rem !important;
+}
+.nextra-breadcrumb span:last-child {
+  color: var(--forge-accent) !important;
+  font-weight: 500 !important;
+}
+
+article h1 {
+  font-size: 1.75rem !important;
+  font-weight: 700 !important;
+  letter-spacing: -0.035em !important;
+  line-height: 1.2 !important;
+  color: var(--forge-text-strong) !important;
+  margin-top: 0.25rem !important;
+  margin-bottom: 0.75rem !important;
+}
+article h1 + p {
+  font-size: 1rem !important;
+  color: var(--forge-text-soft) !important;
+  line-height: 1.65 !important;
+  margin-top: 0 !important;
+  margin-bottom: 1.5rem !important;
+}
+article h2 {
+  font-size: 1.1875rem !important;
+  font-weight: 600 !important;
+  letter-spacing: -0.025em !important;
+  line-height: 1.3 !important;
+  color: var(--forge-text-strong) !important;
+  margin-top: 2.25rem !important;
+  margin-bottom: 0.625rem !important;
+  padding-bottom: 0 !important;
+  border-bottom: none !important;
+}
+article h3 {
+  font-size: 1rem !important;
+  font-weight: 600 !important;
+  letter-spacing: -0.015em !important;
+  color: var(--forge-text-strong) !important;
+  margin-top: 1.75rem !important;
+  margin-bottom: 0.5rem !important;
+}
+article h4 {
+  font-size: 0.9375rem !important;
+  font-weight: 600 !important;
+  color: var(--forge-text-strong) !important;
+  margin-top: 1.25rem !important;
+}
+article p {
+  font-size: 0.9375rem !important;
+  line-height: 1.75 !important;
+  color: var(--forge-text) !important;
+}
+article a:not(.nextra-card) {
+  color: var(--forge-accent) !important;
+  font-weight: 500 !important;
+  text-decoration: none !important;
+}
+article a:not(.nextra-card):hover {
+  text-decoration: underline !important;
+  text-underline-offset: 2px !important;
+}
+article ul, article ol {
+  font-size: 0.9375rem !important;
+  line-height: 1.75 !important;
+  color: var(--forge-text) !important;
+}
+article hr { border-color: var(--forge-border) !important; margin: 2rem 0 !important; }
+article strong { color: var(--forge-text-strong) !important; font-weight: 600 !important; }
+
+/* Nextra 4 emits each <table> with \`display: block; overflow-x: auto\` so
+   it acts as its own horizontal scroll container. That display:block was
+   the source of the phantom band: with block layout the browser creates
+   an anonymous table box inside the <table> for the actual cell layout
+   and sizes the outer block independently — the rendered border hugs
+   the article column while the cells fill only the natural content
+   width. \`fit-content\` didn't reliably collapse the block in Chromium.
+   Reverting the table to a real CSS table (\`display: table\`) with
+   \`width: auto\` makes the cells size the box: the border now wraps the
+   cells exactly. The trade-off is losing horizontal scroll for tables
+   wider than the article column — content has to wrap inside cells
+   instead — which is fine for docs tables (the API-reference endpoint
+   tables are the wide-table case and they live inside their own grid). */
+article *:has(> table) {
+  max-width: 100% !important;
+}
+article table {
+  display: table !important;
+  width: auto !important;
+  max-width: 100% !important;
+  font-size: 0.875rem !important;
+  border-collapse: separate !important;
+  border-spacing: 0 !important;
+  border: 1px solid var(--forge-border) !important;
+  border-radius: 0.5rem !important;
+  margin: 1.5rem 0 !important;
+  table-layout: auto !important;
+  /* Cell text wraps instead of forcing horizontal scroll on the (now
+     non-scrollable) block. Long unbroken strings (URLs, identifiers)
+     still need word-break to avoid stretching the column past the
+     article width. */
+  word-break: break-word;
+}
+article thead tr th {
+  background: var(--forge-border-soft) !important;
+  color: var(--forge-text-soft) !important;
+  font-size: 0.6875rem !important;
+  font-weight: 600 !important;
+  text-transform: uppercase !important;
+  letter-spacing: 0.06em !important;
+  padding: 0.625rem 0.875rem !important;
+  border-bottom: 1px solid var(--forge-border) !important;
+  text-align: left !important;
+}
+.dark article thead tr th { background: #111827 !important; }
+article tbody tr td {
+  padding: 0.625rem 0.875rem !important;
+  color: var(--forge-text) !important;
+  border-bottom: 1px solid var(--forge-border) !important;
+  vertical-align: top !important;
+  font-size: 0.875rem !important;
+  line-height: 1.5 !important;
+}
+article tbody tr:last-child td { border-bottom: none !important; }
+article tbody tr:hover td { background: var(--forge-hover-bg) !important; }
+
+article code:not(pre code) {
+  font-size: 0.8125em !important;
+  font-weight: 500 !important;
+  color: hsl(228 84% 52%) !important;
+  background: var(--forge-accent-soft) !important;
+  border: 1px solid hsl(228 84% 88%) !important;
+  border-radius: 0.3rem !important;
+  padding: 0.1em 0.4em !important;
+}
+.dark article code:not(pre code) {
+  color: hsl(228 84% 72%) !important;
+  background: hsl(228 84% 10%) !important;
+  border-color: hsl(228 84% 20%) !important;
+}
+
+.nextra-code pre, article pre {
+  font-size: 0.8125rem !important;
+  line-height: 1.7 !important;
+  border-radius: 0.625rem !important;
+  border: 1.5px solid var(--forge-border) !important;
+  padding: 1rem 1.25rem !important;
+  background: #f8fafc !important;
+  overflow-x: auto;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.04) !important;
+}
+.dark .nextra-code pre, .dark article pre {
+  background: #0d1117 !important;
+  border-color: var(--forge-border) !important;
+  box-shadow: none !important;
+}
+
+/* Forge copy button — prominent chip in the top-right corner. Solid surface,
+   sharper edge than Nextra's default ghost button so it reads as a
+   first-class affordance rather than an afterthought. */
+.nextra-code {
+  position: relative !important;
+}
+.nextra-code button[title="Copy code"] {
+  top: 0.5rem !important;
+  right: 0.5rem !important;
+  padding: 0.3125rem 0.4375rem !important;
+  background: #ffffff !important;
+  border: 1px solid var(--forge-border) !important;
+  border-radius: 0.375rem !important;
+  color: var(--forge-text-soft) !important;
+  opacity: 0.85 !important;
+  transition: opacity 0.12s, color 0.12s, border-color 0.12s, background 0.12s !important;
+}
+.nextra-code:hover button[title="Copy code"] {
+  opacity: 1 !important;
+}
+.nextra-code button[title="Copy code"]:hover {
+  color: var(--forge-accent) !important;
+  border-color: var(--forge-accent) !important;
+}
+.dark .nextra-code button[title="Copy code"] {
+  background: #161b22 !important;
+}
+
+/* Forge keyboard chips — inset-shadow chip with monospace caption, mimicking
+   macOS shortcut hints. Reinforces the "developer reference" stance. */
+article kbd {
+  display: inline-block;
+  font-family: var(--font-mono, ui-monospace, 'SF Mono', Menlo, Consolas, monospace) !important;
+  font-size: 0.75rem !important;
+  font-weight: 500 !important;
+  line-height: 1 !important;
+  color: var(--forge-text-strong) !important;
+  background: #ffffff !important;
+  border: 1px solid var(--forge-border) !important;
+  border-radius: 0.3125rem !important;
+  padding: 0.1875rem 0.4375rem !important;
+  box-shadow: inset 0 -1.5px 0 var(--forge-border-soft), 0 1px 0 var(--forge-border-soft) !important;
+  vertical-align: 1px;
+}
+.dark article kbd {
+  color: var(--forge-text-strong) !important;
+  background: var(--forge-border-soft) !important;
+  border-color: var(--forge-border) !important;
+  box-shadow: inset 0 -1.5px 0 #000, 0 1px 0 #000 !important;
+}
+
+/* Forge definition lists — hanging-indent layout that reads like an API
+   reference or a glossary entry rather than a stacked list. */
+article dl {
+  display: grid !important;
+  grid-template-columns: 9rem 1fr !important;
+  column-gap: 1.5rem !important;
+  row-gap: 0.75rem !important;
+  margin: 1.5rem 0 !important;
+  padding: 1rem 1.25rem !important;
+  border: 1px solid var(--forge-border) !important;
+  border-radius: 0.5rem !important;
+  background: var(--forge-bg) !important;
+}
+article dt {
+  font-family: var(--font-mono, ui-monospace, 'SF Mono', Menlo, Consolas, monospace) !important;
+  font-size: 0.8125rem !important;
+  font-weight: 500 !important;
+  color: var(--forge-accent) !important;
+  align-self: start !important;
+  padding-top: 0.1875rem !important;
+}
+article dd {
+  margin: 0 !important;
+  font-size: 0.875rem !important;
+  line-height: 1.6 !important;
+  color: var(--forge-text) !important;
+}
+@media (max-width: 767px) {
+  article dl {
+    grid-template-columns: 1fr !important;
+    row-gap: 0.25rem !important;
+  }
+  article dd {
+    margin-bottom: 0.5rem !important;
+  }
+}
+
+.nextra-callout {
+  border-radius: 0.5rem !important;
+  padding: 0.875rem 1.125rem !important;
+  font-size: 0.875rem !important;
+  line-height: 1.6 !important;
+  margin: 1.25rem 0 !important;
+  border-width: 1px !important;
+}
+
+/* ═══════════════════════════════════════════════════════════════════════════
+   CARDS
+   ═══════════════════════════════════════════════════════════════════════════ */
+
+.nextra-cards { gap: 0.75rem !important; margin-top: 1.25rem !important; }
+
+a.nextra-card {
+  border: 1px solid var(--forge-border) !important;
+  border-radius: 0.625rem !important;
+  background: white !important;
+  box-shadow: none !important;
+  padding: 0 !important;
+  overflow: hidden !important;
+  transition: border-color 0.15s, box-shadow 0.15s !important;
+  display: flex !important;
+  flex-direction: column !important;
+  text-decoration: none !important;
+  position: relative;
+}
+.dark a.nextra-card { background: #0d1117 !important; border-color: var(--forge-border) !important; }
+
+a.nextra-card:hover {
+  border-color: var(--forge-accent-border) !important;
+  box-shadow: 0 0 0 3px var(--forge-accent-soft) !important;
+  background: white !important;
+}
+.dark a.nextra-card:hover { background: #0d1117 !important; }
+
+a.nextra-card > span {
+  padding: 1rem 1.125rem 0.875rem !important;
+  gap: 0 !important;
+  display: flex !important;
+  flex-direction: column !important;
+  padding-right: 2.25rem !important;
+}
+a.nextra-card > span > span {
+  font-size: 0.9rem !important;
+  font-weight: 600 !important;
+  color: var(--forge-text-strong) !important;
+  letter-spacing: -0.01em !important;
+  white-space: normal !important;
+  overflow: visible !important;
+  text-overflow: unset !important;
+}
+a.nextra-card::after {
+  content: '↗';
+  position: absolute;
+  top: 0.9rem;
+  right: 1rem;
+  font-size: 0.875rem;
+  line-height: 1;
+  color: var(--forge-text-faint);
+  transition: color 0.15s;
+  font-weight: 400;
+}
+a.nextra-card:hover::after { color: var(--forge-accent) !important; }
+
+/* ═══════════════════════════════════════════════════════════════════════════
+   PREV/NEXT + FOOTER
+   ═══════════════════════════════════════════════════════════════════════════ */
+
+article + div { border-top-color: var(--forge-border) !important; }
+article + div a { font-size: 0.875rem !important; color: var(--forge-text-soft) !important; font-weight: 500 !important; }
+article + div a:hover { color: var(--forge-accent) !important; }
+article > div[class*="text-end"] { font-size: 0.75rem !important; color: var(--forge-text-faint) !important; }
+
+body > div:last-of-type { background: var(--forge-bg) !important; }
+
+/* The footer must clear the 295px fixed sidebar AND align with the content
+   + TOC columns (680 + 220 = 900px) rather than spanning the full canvas to
+   the right of the sidebar. We size to 900px and offset by the sidebar plus
+   half the leftover horizontal space so the footer reads as a continuation
+   of the article column. The max() guard keeps the footer flush to the
+   sidebar's right edge on viewports too narrow to center. */
+footer {
+  font-size: 0.8125rem !important;
+  color: var(--forge-text-faint) !important;
+  padding: 2.5rem 0 3rem !important;
+  width: 900px !important;
+  max-width: calc(100vw - 295px - 2rem) !important;
+  margin-left: calc(295px + max((100vw - 295px - 900px) / 2, 0px)) !important;
+  margin-right: auto !important;
+  border-top: 1px solid var(--forge-border-soft) !important;
+}
+
+@media (max-width: 767px) {
+  footer {
+    width: auto !important;
+    margin-left: 0 !important;
+    max-width: 100vw !important;
+    padding: 2rem 1.25rem !important;
+  }
+}
+
+.nextra-border { border-color: var(--forge-border) !important; }
+
+/* ═══════════════════════════════════════════════════════════════════════════
+   MISC
+   ═══════════════════════════════════════════════════════════════════════════ */
+
+.subheading-anchor { opacity: 0; margin-left: 0.375rem; font-size: 0.75em; transition: opacity 0.15s; }
+*:hover > .subheading-anchor, .subheading-anchor:focus { opacity: 0.4; }
+
+::-webkit-scrollbar { width: 5px; height: 5px; }
+::-webkit-scrollbar-track { background: transparent; }
+::-webkit-scrollbar-thumb { background: #d1d5db; border-radius: 999px; }
+.dark ::-webkit-scrollbar-thumb { background: #374151; }
+
+/* ═══════════════════════════════════════════════════════════════════════════
+   FOOTER (structured) — rendered when SiteBranding.footer is configured
+   ═══════════════════════════════════════════════════════════════════════════ */
+
+.forge-footer {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+  padding: 0 0.5rem;
+}
+
+.forge-footer-columns {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 1.5rem;
+}
+
+.forge-footer-col h4 {
+  font-size: 0.6875rem !important;
+  font-weight: 600 !important;
+  text-transform: uppercase !important;
+  letter-spacing: 0.08em !important;
+  color: var(--forge-text-soft) !important;
+  margin: 0 0 0.5rem 0 !important;
+}
+
+.forge-footer-col ul {
+  list-style: none !important;
+  margin: 0 !important;
+  padding: 0 !important;
+  display: flex !important;
+  flex-direction: column !important;
+  gap: 0.25rem !important;
+}
+
+.forge-footer-col a {
+  font-size: 0.8125rem !important;
+  color: var(--forge-text-soft) !important;
+  text-decoration: none !important;
+}
+.forge-footer-col a:hover {
+  color: var(--forge-accent) !important;
+}
+
+.forge-footer-bottom {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--forge-border-soft);
+  font-size: 0.75rem;
+  color: var(--forge-text-faint);
+}
+
+.forge-footer-copyright,
+.forge-footer-powered {
+  font-size: 0.75rem;
+  color: var(--forge-text-faint);
+}
+
+.forge-footer-social {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.875rem;
+}
+.forge-footer-social a {
+  font-size: 0.75rem;
+  color: var(--forge-text-soft) !important;
+  text-decoration: none !important;
+}
+.forge-footer-social a:hover {
+  color: var(--forge-accent) !important;
+}
+`;
+
+/**
+ * Customer overrides for Forge accent + sidebar/header backgrounds.
+ * Appended after FORGE_BASE_CSS so the cascade gives the customer's
+ * `primaryHue` (and any future per-pack overrides) precedence.
+ */
+export interface ForgeOverrideInput {
+	/** Customer accent hue 0-360 (defaults to Forge's indigo 228). */
+	accentHue: number;
+	/** Customer font-family CSS value (defaults baked into base CSS if undefined). */
+	fontFamily?: string;
+}
+
+export function buildForgeOverrides(input: ForgeOverrideInput): string {
+	const hue = input.accentHue;
+	const accent = `hsl(${hue} 84% 61%)`;
+	const accentSoft = `hsl(${hue} 84% 96%)`;
+	const accentBorder = `hsl(${hue} 84% 75%)`;
+	const accentDark = `hsl(${hue} 84% 68%)`;
+	const accentDarkSoft = `hsl(${hue} 84% 11%)`;
+	const accentDarkBorder = `hsl(${hue} 84% 40%)`;
+	const fontDecl = input.fontFamily ? `  --forge-font-family: ${input.fontFamily};\n` : "";
+
+	return `
+/* ── Forge theme overrides (generated) ──────────────────────────────────── */
+:root {
+${fontDecl}  --nextra-primary-hue:        ${hue};
+  --nextra-primary-saturation: 84%;
+  --nextra-primary-lightness:  61%;
+
+  --forge-accent:        ${accent};
+  --forge-accent-soft:   ${accentSoft};
+  --forge-accent-border: ${accentBorder};
+
+  --nav-active-color: ${accent};
+  --nav-active-bar:   ${accent};
+}
+
+.dark {
+  --nextra-primary-lightness: 68%;
+
+  --forge-accent-soft:       ${accentDarkSoft};
+  --forge-accent-border:     ${accentDarkBorder};
+  --nav-active-color:        ${accentDark};
+  --nav-active-bar:          ${accentDark};
+}
+`;
+}
+
+/**
+ * Build the complete Forge stylesheet (base + customer overrides). The
+ * API-reference companion stylesheet that the SaaS appends here is left out
+ * for now; OpenAPI pages render with the default Nextra styling until the
+ * follow-up commit ports `ApiCss` over.
+ */
+export function buildForgeCss(input: ForgeOverrideInput): string {
+	return FORGE_BASE_CSS + buildForgeOverrides(input);
+}

--- a/cli/src/site/themes/forge/Layout.test.ts
+++ b/cli/src/site/themes/forge/Layout.test.ts
@@ -1,0 +1,363 @@
+/**
+ * Tests for the Forge layout generator.
+ *
+ * Two surfaces:
+ *   - `resolveForgeLayoutInput` — schema → ForgeLayoutInput resolution,
+ *     including manifest defaults and the legacy top-level `favicon` alias.
+ *   - `generateForgeLayoutTsx` — input → TSX string, covering the wrappers
+ *     the Forge CSS depends on, font/favicon link rendering, logo slots,
+ *     and URL sanitization.
+ */
+
+import { describe, expect, it } from "vitest";
+import { buildForgeFontFamilyCssValue, generateForgeLayoutTsx, resolveForgeLayoutInput } from "./Layout.js";
+import { FORGE_MANIFEST } from "./Manifest.js";
+
+const BASE_INPUT = {
+	title: "Acme Docs",
+	description: "API reference + guides",
+	nav: [],
+	primaryHue: FORGE_MANIFEST.defaults.primaryHue,
+	defaultTheme: FORGE_MANIFEST.defaults.defaultTheme,
+	fontFamily: FORGE_MANIFEST.defaults.fontFamily,
+};
+
+// ─── resolveForgeLayoutInput ────────────────────────────────────────────────
+
+describe("resolveForgeLayoutInput", () => {
+	it("applies Forge manifest defaults when theme is undefined", () => {
+		const result = resolveForgeLayoutInput({
+			title: "T",
+			description: "D",
+			nav: [],
+			theme: undefined,
+			legacyFavicon: undefined,
+		});
+		expect(result.primaryHue).toBe(FORGE_MANIFEST.defaults.primaryHue);
+		expect(result.defaultTheme).toBe(FORGE_MANIFEST.defaults.defaultTheme);
+		expect(result.fontFamily).toBe(FORGE_MANIFEST.defaults.fontFamily);
+	});
+
+	it("honors theme overrides over manifest defaults", () => {
+		const result = resolveForgeLayoutInput({
+			title: "T",
+			description: "D",
+			nav: [],
+			theme: { primaryHue: 200, defaultTheme: "dark", fontFamily: "source-serif" },
+			legacyFavicon: undefined,
+		});
+		expect(result.primaryHue).toBe(200);
+		expect(result.defaultTheme).toBe("dark");
+		expect(result.fontFamily).toBe("source-serif");
+	});
+
+	it("legacy top-level favicon wins over theme.favicon (deprecated alias precedence)", () => {
+		const result = resolveForgeLayoutInput({
+			title: "T",
+			description: "D",
+			nav: [],
+			theme: { favicon: "/theme.ico" },
+			legacyFavicon: "/legacy.ico",
+		});
+		expect(result.favicon).toBe("/legacy.ico");
+	});
+
+	it("falls back to theme.favicon when legacy top-level is unset", () => {
+		const result = resolveForgeLayoutInput({
+			title: "T",
+			description: "D",
+			nav: [],
+			theme: { favicon: "/theme.ico" },
+			legacyFavicon: undefined,
+		});
+		expect(result.favicon).toBe("/theme.ico");
+	});
+
+	it("resolves the CSS font-family value for a given FontFamily key", () => {
+		expect(buildForgeFontFamilyCssValue("inter")).toContain("Inter");
+		expect(buildForgeFontFamilyCssValue("source-serif")).toContain("Source Serif 4");
+	});
+
+	it("passes through header and footer config", () => {
+		const header = { items: [{ label: "Docs", url: "/docs" }] };
+		const footer = { copyright: "2026 Acme" };
+		const result = resolveForgeLayoutInput({
+			title: "T",
+			description: "D",
+			nav: [],
+			header,
+			footer,
+			theme: undefined,
+			legacyFavicon: undefined,
+		});
+		expect(result.header).toBe(header);
+		expect(result.footer).toBe(footer);
+	});
+});
+
+// ─── generateForgeLayoutTsx ─────────────────────────────────────────────────
+
+describe("generateForgeLayoutTsx", () => {
+	it("imports the Forge stylesheet at app/themes/forge.css", () => {
+		const result = generateForgeLayoutTsx(BASE_INPUT);
+		expect(result).toContain("import './themes/forge.css'");
+	});
+
+	it("imports the shared API stylesheet at ../styles/api.css", () => {
+		// Forge sites still need API styling for OpenAPI pages — same singleton
+		// stylesheet the default layout consumes, just tinted with Forge's hue
+		// at write time (see NextraRenderer.initProject).
+		const result = generateForgeLayoutTsx(BASE_INPUT);
+		expect(result).toContain("import '../styles/api.css'");
+	});
+
+	it("renders the Forge wrapper elements that the CSS depends on", () => {
+		const result = generateForgeLayoutTsx(BASE_INPUT);
+		expect(result).toContain('className="forge-sidebar-logo"');
+		expect(result).toContain('className="forge-sidebar-search"');
+		expect(result).toContain('className="forge-navbar-logo"');
+	});
+
+	it("includes the Nextra <Search /> component in the sidebar wrapper", () => {
+		const result = generateForgeLayoutTsx(BASE_INPUT);
+		expect(result).toContain("<Search ");
+	});
+
+	it("interpolates primaryHue into the <Head color> prop", () => {
+		const result = generateForgeLayoutTsx({ ...BASE_INPUT, primaryHue: 145 });
+		expect(result).toContain("hue: 145, saturation: 84");
+	});
+
+	it("interpolates defaultTheme into the <Layout nextThemes> prop", () => {
+		const result = generateForgeLayoutTsx({ ...BASE_INPUT, defaultTheme: "dark" });
+		expect(result).toContain('defaultTheme: "dark"');
+	});
+
+	it("emits the Google Fonts <link> for the chosen font family", () => {
+		const inter = generateForgeLayoutTsx({ ...BASE_INPUT, fontFamily: "inter" });
+		expect(inter).toContain("fonts.googleapis.com/css2?family=Inter");
+
+		const serif = generateForgeLayoutTsx({ ...BASE_INPUT, fontFamily: "source-serif" });
+		expect(serif).toContain("fonts.googleapis.com/css2?family=Source+Serif+4");
+	});
+
+	it("omits the favicon <link> when no favicon is configured", () => {
+		const result = generateForgeLayoutTsx(BASE_INPUT);
+		expect(result).not.toContain('rel="icon"');
+	});
+
+	it("includes the favicon <link> when configured", () => {
+		const result = generateForgeLayoutTsx({ ...BASE_INPUT, favicon: "/favicon.ico" });
+		expect(result).toContain('<link rel="icon" href={"/favicon.ico"}');
+	});
+
+	it("renders only the text logo span when no logoUrl is set", () => {
+		const result = generateForgeLayoutTsx(BASE_INPUT);
+		expect(result).not.toContain("<img ");
+		expect(result).toContain('<span>{"Acme Docs"}</span>');
+	});
+
+	it("renders a single light-mode <img> when only logoUrl is set", () => {
+		const result = generateForgeLayoutTsx({ ...BASE_INPUT, logoUrl: "/logo.svg" });
+		expect(result).toContain('<img src={"/logo.svg"} alt={"Acme Docs"}');
+		expect(result).not.toContain("forge-logo-dark");
+	});
+
+	it("renders paired light+dark <img>s with swap classes when both URLs are set", () => {
+		const result = generateForgeLayoutTsx({
+			...BASE_INPUT,
+			logoUrl: "/light.svg",
+			logoUrlDark: "/dark.svg",
+		});
+		expect(result).toContain('className="forge-logo-light"');
+		expect(result).toContain('className="forge-logo-dark"');
+		expect(result).toContain('<img src={"/light.svg"}');
+		expect(result).toContain('<img src={"/dark.svg"}');
+	});
+
+	it("renders nav items as <a> children of <Navbar> alongside <ThemeSwitch />", () => {
+		const result = generateForgeLayoutTsx({
+			...BASE_INPUT,
+			nav: [
+				{ label: "Guides", href: "/guides" },
+				{ label: "GitHub", href: "https://github.com/acme" },
+			],
+		});
+		expect(result).toContain('href={"/guides"}');
+		expect(result).toContain('{"Guides"}');
+		expect(result).toContain('href={"https://github.com/acme"}');
+		expect(result).toContain('{"GitHub"}');
+		expect(result).toContain("<ThemeSwitch />");
+	});
+
+	it("sanitizes javascript: URLs in nav hrefs to '#'", () => {
+		const result = generateForgeLayoutTsx({
+			...BASE_INPUT,
+			nav: [{ label: "Bad", href: "javascript:alert(1)" }],
+		});
+		expect(result).not.toMatch(/javascript:alert/i);
+		expect(result).toContain('<a href={"#"}');
+	});
+
+	it("sanitizes javascript: URLs in favicon to '#'", () => {
+		const result = generateForgeLayoutTsx({ ...BASE_INPUT, favicon: "javascript:alert(1)" });
+		expect(result).not.toMatch(/javascript:alert/i);
+		expect(result).toContain('<link rel="icon" href={"#"}');
+	});
+
+	it("sanitizes javascript: URLs in logoUrl to '#'", () => {
+		const result = generateForgeLayoutTsx({ ...BASE_INPUT, logoUrl: "javascript:alert(1)" });
+		expect(result).not.toMatch(/javascript:alert/i);
+		expect(result).toContain('<img src={"#"}');
+	});
+
+	it("title with embedded quotes survives JSON-stringification into the alt attribute", () => {
+		const result = generateForgeLayoutTsx({
+			...BASE_INPUT,
+			title: 'Acme "Tools"',
+			logoUrl: "/logo.svg",
+		});
+		expect(result).toContain('alt={"Acme \\"Tools\\""}');
+	});
+
+	// ── header.items support ─────────────────────────────────────────────────
+
+	it("prefers header.items over legacy nav when both are set", () => {
+		const result = generateForgeLayoutTsx({
+			...BASE_INPUT,
+			nav: [{ label: "FromNav", href: "/nav" }],
+			header: { items: [{ label: "FromHeader", url: "/header" }] },
+		});
+		expect(result).toContain("FromHeader");
+		expect(result).not.toContain("FromNav");
+	});
+
+	it("renders a <details> dropdown when a header item has sub-items", () => {
+		const result = generateForgeLayoutTsx({
+			...BASE_INPUT,
+			header: {
+				items: [
+					{
+						label: "Resources",
+						items: [
+							{ label: "Blog", url: "/blog" },
+							{ label: "Changelog", url: "/changelog" },
+						],
+					},
+				],
+			},
+		});
+		expect(result).toContain("<details");
+		expect(result).toContain("<summary");
+		expect(result).toContain('{"Resources"}');
+		expect(result).toContain('{"Blog"}');
+		expect(result).toContain('href={"/blog"}');
+	});
+
+	it("renders a direct link for header items without sub-items", () => {
+		const result = generateForgeLayoutTsx({
+			...BASE_INPUT,
+			header: { items: [{ label: "Docs", url: "/docs" }] },
+		});
+		expect(result).toContain('href={"/docs"}');
+		expect(result).toContain('{"Docs"}');
+		expect(result).not.toContain("<details");
+	});
+
+	it("falls back to '#' for header items with no url and no sub-items", () => {
+		const result = generateForgeLayoutTsx({
+			...BASE_INPUT,
+			header: { items: [{ label: "Empty" }] },
+		});
+		expect(result).toContain('href={"#"}');
+	});
+
+	it("sanitizes javascript: URLs in header dropdown sub-items", () => {
+		const result = generateForgeLayoutTsx({
+			...BASE_INPUT,
+			header: {
+				items: [{ label: "Menu", items: [{ label: "Bad", url: "javascript:alert(1)" }] }],
+			},
+		});
+		expect(result).not.toMatch(/javascript:alert/i);
+		expect(result).toContain('href={"#"}');
+	});
+
+	it("falls back to legacy nav when header.items is empty", () => {
+		const result = generateForgeLayoutTsx({
+			...BASE_INPUT,
+			nav: [{ label: "NavLink", href: "/nav" }],
+			header: { items: [] },
+		});
+		expect(result).toContain("NavLink");
+	});
+
+	// ── footer support ───────────────────────────────────────────────────────
+
+	it("renders default copyright footer when no footer config is set", () => {
+		const result = generateForgeLayoutTsx(BASE_INPUT);
+		expect(result).toContain("<Footer>");
+		expect(result).toContain("new Date().getFullYear()");
+	});
+
+	it("renders footer copyright text", () => {
+		const result = generateForgeLayoutTsx({
+			...BASE_INPUT,
+			footer: { copyright: "2026 Acme Inc." },
+		});
+		expect(result).toContain("<Footer>");
+		expect(result).toContain('{"2026 Acme Inc."}');
+	});
+
+	it("renders footer columns with titles and links", () => {
+		const result = generateForgeLayoutTsx({
+			...BASE_INPUT,
+			footer: {
+				columns: [
+					{
+						title: "Product",
+						links: [
+							{ label: "Pricing", url: "/pricing" },
+							{ label: "Docs", url: "/docs" },
+						],
+					},
+				],
+			},
+		});
+		expect(result).toContain('{"Product"}');
+		expect(result).toContain('{"Pricing"}');
+		expect(result).toContain('href={"/pricing"}');
+	});
+
+	it("renders footer social links in canonical platform order", () => {
+		const result = generateForgeLayoutTsx({
+			...BASE_INPUT,
+			footer: { socialLinks: { youtube: "https://yt.example", github: "https://gh.example" } },
+		});
+		const ghIdx = result.indexOf("gh.example");
+		const ytIdx = result.indexOf("yt.example");
+		expect(ghIdx).toBeGreaterThan(-1);
+		expect(ytIdx).toBeGreaterThan(-1);
+		expect(ghIdx).toBeLessThan(ytIdx);
+	});
+
+	it("renders default copyright footer when footer has no content", () => {
+		const result = generateForgeLayoutTsx({
+			...BASE_INPUT,
+			footer: { columns: [], socialLinks: {} },
+		});
+		expect(result).toContain("new Date().getFullYear()");
+	});
+
+	it("sanitizes javascript: URLs in footer links and social links", () => {
+		const result = generateForgeLayoutTsx({
+			...BASE_INPUT,
+			footer: {
+				columns: [{ title: "X", links: [{ label: "Bad", url: "javascript:alert(1)" }] }],
+				socialLinks: { github: "data:text/html,evil" },
+			},
+		});
+		expect(result).not.toContain("javascript:alert");
+		expect(result).not.toContain("data:text/html");
+	});
+});

--- a/cli/src/site/themes/forge/Layout.ts
+++ b/cli/src/site/themes/forge/Layout.ts
@@ -1,0 +1,380 @@
+/**
+ * Forge layout generator — produces `app/layout.tsx` for sites that pick
+ * `theme.pack === "forge"` in their `site.json`.
+ *
+ * Adapted from the SaaS Forge layout
+ * (`tools/nextra-generator/src/themes/forge/templates/Layout.ts` in
+ * jolli.ai/jolli) post-JOLLI-1392, with the SaaS-only bits stripped:
+ *
+ *   - `ScopedNextraLayout` → vanilla `<Layout>` from `nextra-theme-docs`
+ *   - `<AuthBanner>` / `<Auth0Provider>` slots removed (CLI sites are
+ *     not multi-tenant and don't gate on JWT auth)
+ *   - `filterAuthFromPageMap` removed (no `/auth` callback page)
+ *
+ * The Forge-specific wrapper elements (`.forge-sidebar-logo`,
+ * `.forge-sidebar-search`, `.forge-navbar-logo`) are preserved verbatim
+ * because Css.ts targets them.
+ *
+ * Customer fields resolved from `theme.*` (with Forge manifest defaults):
+ *   - `primaryHue`         → `<Head color={{ hue, saturation: 84 }}>`
+ *   - `defaultTheme`       → `<Layout nextThemes={{ defaultTheme }}>`
+ *   - `fontFamily`         → Google Fonts `<link>` + a CSS variable picked
+ *                            up by Css.ts via `--forge-font-family`
+ *   - `logoUrl`/`Dark`     → `<img>` tags rendered in both the navbar logo
+ *                            slot and the sidebar logo wrapper
+ *   - `favicon`            → `<link rel="icon">` (top-level `favicon` wins
+ *                            for back-compat; `theme.favicon` is the fallback)
+ */
+
+import type {
+	DefaultThemeMode,
+	ExternalLink,
+	FontFamily,
+	FooterConfig,
+	HeaderConfig,
+	HeaderItem,
+	NavLink,
+} from "../../Types.js";
+import { FORGE_MANIFEST } from "./Manifest.js";
+
+// ─── Font config ─────────────────────────────────────────────────────────────
+
+interface FontEntry {
+	url: string;
+	cssFamily: string;
+}
+
+/**
+ * Google Fonts URLs + CSS family values. Mirrors `FONT_CONFIG` from
+ * jolli-common so a single `theme.fontFamily` value renders identically in
+ * both surfaces.
+ */
+const FONT_CONFIG: Record<FontFamily, FontEntry> = {
+	inter: {
+		url: "https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap",
+		cssFamily: "'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif",
+	},
+	"space-grotesk": {
+		url: "https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&display=swap",
+		cssFamily: "'Space Grotesk', -apple-system, sans-serif",
+	},
+	"ibm-plex": {
+		url: "https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&display=swap",
+		cssFamily: "'IBM Plex Sans', -apple-system, sans-serif",
+	},
+	"source-sans": {
+		url: "https://fonts.googleapis.com/css2?family=Source+Sans+3:wght@400;600;700&display=swap",
+		cssFamily: "'Source Sans 3', -apple-system, sans-serif",
+	},
+	"source-serif": {
+		url: "https://fonts.googleapis.com/css2?family=Source+Serif+4:opsz,wght@8..60,400;8..60,500;8..60,600;8..60,700&display=swap",
+		cssFamily: "'Source Serif 4', 'Iowan Old Style', Georgia, serif",
+	},
+};
+
+// ─── ForgeLayoutInput ────────────────────────────────────────────────────────
+
+export interface ForgeLayoutInput {
+	title: string;
+	description: string;
+	nav: NavLink[];
+	header?: HeaderConfig;
+	footer?: FooterConfig;
+	primaryHue: number;
+	defaultTheme: DefaultThemeMode;
+	fontFamily: FontFamily;
+	logoUrl?: string;
+	logoUrlDark?: string;
+	favicon?: string;
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/**
+ * Allow http(s), mailto, tel, fragments, query strings, and relative paths.
+ * Anything else (`javascript:`, `data:`, `vbscript:`) is replaced with `"#"`
+ * so a malicious site.json can't smuggle a script URL into the layout.
+ */
+function sanitizeUrl(url: string): string {
+	const trimmed = url.trim();
+	if (trimmed === "" || /^(?:https?:|mailto:|tel:|[#?/]|\.\.?\/)/i.test(trimmed)) {
+		return trimmed;
+	}
+	return "#";
+}
+
+/**
+ * Logo slot markup used in both the navbar logo + sidebar logo positions.
+ * Each `<img>` uses JSX-expression attributes (`src={...}` / `alt={...}`)
+ * stamped from JSON-stringified values, so the user-controlled title is
+ * never spliced into a raw HTML attribute (no escape needed, no breakout
+ * surface).
+ *
+ * Returns `{ light, dark }`:
+ *   - No `logoUrl`            → both empty (text-only logo)
+ *   - `logoUrl` only          → single light-mode `<img>`, no dark swap
+ *   - `logoUrl` + `logoUrlDark` → paired imgs with `.forge-logo-light` /
+ *                                 `.forge-logo-dark`; CSS swaps based on `.dark`
+ */
+function buildLogoSlots(input: ForgeLayoutInput): { light: string; dark: string } {
+	if (!input.logoUrl) {
+		return { light: "", dark: "" };
+	}
+	const jsAlt = JSON.stringify(input.title);
+	const jsLightSrc = JSON.stringify(sanitizeUrl(input.logoUrl));
+	if (!input.logoUrlDark) {
+		return { light: `<img src={${jsLightSrc}} alt={${jsAlt}} />`, dark: "" };
+	}
+	const jsDarkSrc = JSON.stringify(sanitizeUrl(input.logoUrlDark));
+	return {
+		light: `<img src={${jsLightSrc}} alt={${jsAlt}} className="forge-logo-light" />`,
+		dark: `<img src={${jsDarkSrc}} alt={${jsAlt}} className="forge-logo-dark" />`,
+	};
+}
+
+/**
+ * Resolves the navbar's logical item list. `header.items` wins when set;
+ * otherwise legacy `nav` is coerced into dropdown-less items.
+ */
+function resolveHeaderItems(input: ForgeLayoutInput): HeaderItem[] {
+	if (input.header?.items && input.header.items.length > 0) {
+		return input.header.items;
+	}
+	return input.nav.map((n) => ({ label: n.label, url: n.href }));
+}
+
+/** Renders a single header item — either an `<a>` or a `<details>` dropdown. */
+function renderNavbarChild(item: HeaderItem): string {
+	const jsLabel = JSON.stringify(item.label);
+	if (item.items && item.items.length > 0) {
+		const subLinks = item.items
+			.map((sub: ExternalLink) => {
+				const jsSubLabel = JSON.stringify(sub.label);
+				const jsSubHref = JSON.stringify(sanitizeUrl(sub.url));
+				return `              <a href={${jsSubHref}} style={{ display: 'block', padding: '0.25rem 0.75rem', whiteSpace: 'nowrap' }}>{${jsSubLabel}}</a>`;
+			})
+			.join("\n");
+		return [
+			`          <details style={{ marginLeft: '1rem', display: 'inline-block', position: 'relative' }}>`,
+			`            <summary style={{ cursor: 'pointer', listStyle: 'none' }}>{${jsLabel}}</summary>`,
+			`            <div style={{ position: 'absolute', top: '100%', left: 0, marginTop: '0.25rem', background: 'var(--nextra-bg, #fff)', border: '1px solid var(--nextra-border, #e5e7eb)', borderRadius: 4, padding: '0.25rem 0', minWidth: 160, zIndex: 10 }}>`,
+			subLinks,
+			`            </div>`,
+			`          </details>`,
+		].join("\n");
+	}
+	const jsHref = JSON.stringify(sanitizeUrl(item.url ?? "#"));
+	return `          <a href={${jsHref}} style={{ marginLeft: '1rem' }}>{${jsLabel}}</a>`;
+}
+
+/** Social platforms supported in the footer, in display order. */
+const SOCIAL_PLATFORMS = ["github", "twitter", "discord", "linkedin", "youtube"] as const;
+
+/** Builds the inner JSX of `<Footer>`, or `""` when there's nothing to render. */
+function buildFooterBody(footer: FooterConfig | undefined): string {
+	if (!footer) return "";
+
+	const hasColumns = footer.columns && footer.columns.length > 0;
+	const hasCopyright = typeof footer.copyright === "string" && footer.copyright.length > 0;
+	const socials = footer.socialLinks;
+	const socialEntries = socials
+		? SOCIAL_PLATFORMS.filter((p) => typeof socials[p] === "string" && socials[p] !== "")
+		: [];
+	const hasSocial = socialEntries.length > 0;
+
+	if (!hasColumns && !hasCopyright && !hasSocial) return "";
+
+	const blocks: string[] = [];
+
+	if (hasColumns) {
+		const columnsJsx = (footer.columns ?? [])
+			.map((col) => {
+				const jsTitle = JSON.stringify(col.title);
+				const links = col.links
+					.map((link: ExternalLink) => {
+						const jsLabel = JSON.stringify(link.label);
+						const jsHref = JSON.stringify(sanitizeUrl(link.url));
+						return `                <li><a href={${jsHref}}>{${jsLabel}}</a></li>`;
+					})
+					.join("\n");
+				return [
+					`            <div style={{ minWidth: 140 }}>`,
+					`              <h4 style={{ margin: '0 0 0.5rem', fontSize: '0.875rem', fontWeight: 600 }}>{${jsTitle}}</h4>`,
+					`              <ul style={{ listStyle: 'none', padding: 0, margin: 0 }}>`,
+					links,
+					`              </ul>`,
+					`            </div>`,
+				].join("\n");
+			})
+			.join("\n");
+		blocks.push(
+			`          <div style={{ display: 'flex', gap: '2rem', flexWrap: 'wrap', marginBottom: '1rem' }}>\n${columnsJsx}\n          </div>`,
+		);
+	}
+
+	if (hasCopyright || hasSocial) {
+		const bottom: string[] = [];
+		if (hasCopyright) {
+			const jsCopyright = JSON.stringify(footer.copyright);
+			bottom.push(`            <span>{${jsCopyright}}</span>`);
+		}
+		if (hasSocial && socials) {
+			const social = socialEntries
+				.map((p) => {
+					const jsHref = JSON.stringify(sanitizeUrl(socials[p] ?? ""));
+					const jsLabel = JSON.stringify(p);
+					return `              <a href={${jsHref}} aria-label={${jsLabel}}>{${jsLabel}}</a>`;
+				})
+				.join("\n");
+			bottom.push(`            <div style={{ display: 'flex', gap: '0.75rem' }}>\n${social}\n            </div>`);
+		}
+		blocks.push(
+			`          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', flexWrap: 'wrap', gap: '1rem' }}>\n${bottom.join("\n")}\n          </div>`,
+		);
+	}
+
+	return [`        <div style={{ width: '100%' }}>`, ...blocks, `        </div>`].join("\n");
+}
+
+// ─── generateForgeLayoutTsx ──────────────────────────────────────────────────
+
+/**
+ * Returns the full contents of `app/layout.tsx` for a Forge-themed site.
+ * Caller is responsible for writing `app/themes/forge.css` (which this
+ * layout imports) — see `initNextraProject` in `NextraProjectWriter`.
+ */
+export function generateForgeLayoutTsx(input: ForgeLayoutInput): string {
+	const jsTitle = JSON.stringify(input.title);
+	const jsDescription = JSON.stringify(input.description);
+	const jsDefaultTheme = JSON.stringify(input.defaultTheme);
+
+	const font = FONT_CONFIG[input.fontFamily];
+	const fontLink = `<link rel="stylesheet" href={${JSON.stringify(font.url)}} />`;
+	const faviconLink = input.favicon ? `<link rel="icon" href={${JSON.stringify(sanitizeUrl(input.favicon))}} />` : "";
+
+	const logo = buildLogoSlots(input);
+	const logoMarkup = `${logo.light}${logo.dark}<span>{${jsTitle}}</span>`;
+
+	const headerItems = resolveHeaderItems(input);
+	const navLinks = headerItems.map(renderNavbarChild).join("\n");
+	const navbarChildren =
+		headerItems.length > 0 ? `\n${navLinks}\n          <ThemeSwitch />\n        ` : "<ThemeSwitch />";
+
+	const footerBody = buildFooterBody(input.footer);
+	const footerJsx =
+		footerBody === ""
+			? `<Footer>{new Date().getFullYear()} © {${jsTitle}}</Footer>`
+			: `<Footer>\n${footerBody}\n      </Footer>`;
+
+	return `import { Footer, Layout, Navbar, ThemeSwitch } from 'nextra-theme-docs'
+import { Head, Search } from 'nextra/components'
+import { getPageMap } from 'nextra/page-map'
+import 'nextra-theme-docs/style.css'
+import '../styles/api.css'
+import './themes/forge.css'
+
+export const metadata = {
+  title: ${jsTitle},
+  description: ${jsDescription},
+}
+
+const SiteLogo = () => (
+  <span className="forge-navbar-logo">
+    ${logoMarkup}
+  </span>
+)
+
+const navbar = <Navbar logo={<SiteLogo />}>${navbarChildren}</Navbar>
+const footer = ${footerJsx}
+
+export default async function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en" dir="ltr" suppressHydrationWarning>
+      <Head color={{ hue: ${input.primaryHue}, saturation: 84 }}>
+        ${fontLink}
+        ${faviconLink}
+      </Head>
+      <body>
+        <div className="forge-sidebar-logo">
+          <a href="/">
+            ${logoMarkup}
+          </a>
+        </div>
+
+        <div className="forge-sidebar-search">
+          <Search placeholder="Search…" />
+        </div>
+
+        <Layout
+          navbar={navbar}
+          pageMap={await getPageMap()}
+          footer={footer}
+          editLink={null}
+          feedback={{ content: null }}
+          darkMode={true}
+          nextThemes={{ defaultTheme: ${jsDefaultTheme} }}
+        >
+          {children}
+        </Layout>
+      </body>
+    </html>
+  )
+}
+`;
+}
+
+// ─── resolveForgeLayoutInput ─────────────────────────────────────────────────
+
+/**
+ * Resolves the `ForgeLayoutInput` from a project config + `theme` block,
+ * applying Forge manifest defaults for any unset customer field.
+ *
+ * `favicon` lookup follows the deprecated-alias rule: top-level `favicon`
+ * (passed in via `legacyFavicon`) wins when set; `theme.favicon` is the
+ * fallback. Drops back to `undefined` when neither is configured — the
+ * layout omits the `<link rel="icon">` tag in that case.
+ */
+export function resolveForgeLayoutInput(args: {
+	title: string;
+	description: string;
+	nav: NavLink[];
+	header?: HeaderConfig;
+	footer?: FooterConfig;
+	theme:
+		| {
+				primaryHue?: number;
+				defaultTheme?: DefaultThemeMode;
+				fontFamily?: FontFamily;
+				logoUrl?: string;
+				logoUrlDark?: string;
+				favicon?: string;
+		  }
+		| undefined;
+	legacyFavicon: string | undefined;
+}): ForgeLayoutInput {
+	const t = args.theme ?? {};
+	return {
+		title: args.title,
+		description: args.description,
+		nav: args.nav,
+		header: args.header,
+		footer: args.footer,
+		primaryHue: t.primaryHue ?? FORGE_MANIFEST.defaults.primaryHue,
+		defaultTheme: t.defaultTheme ?? FORGE_MANIFEST.defaults.defaultTheme,
+		fontFamily: t.fontFamily ?? FORGE_MANIFEST.defaults.fontFamily,
+		logoUrl: t.logoUrl,
+		logoUrlDark: t.logoUrlDark,
+		favicon: args.legacyFavicon ?? t.favicon,
+	};
+}
+
+// ─── buildForgeFontFamilyCssValue ────────────────────────────────────────────
+
+/**
+ * Resolves the CSS `font-family` value for a given `FontFamily` choice.
+ * Used by `NextraProjectWriter` to pass into `buildForgeCss({ fontFamily })`
+ * so the generated CSS overrides match the `<link>`-loaded Google Font.
+ */
+export function buildForgeFontFamilyCssValue(font: FontFamily): string {
+	return FONT_CONFIG[font].cssFamily;
+}

--- a/cli/src/site/themes/forge/Manifest.ts
+++ b/cli/src/site/themes/forge/Manifest.ts
@@ -1,0 +1,30 @@
+/**
+ * Forge theme pack manifest — declares the pack's identity and the defaults
+ * applied when a customer-overridable field on `theme` (in `site.json`) is
+ * absent.
+ *
+ * Mirrors `FORGE_MANIFEST` from the SaaS Forge pack
+ * (`tools/nextra-generator/src/themes/forge/Manifest.ts` in jolli.ai/jolli)
+ * post-JOLLI-1392. Customer fields the CLI doesn't surface yet (e.g.
+ * `requiredPackages` for SaaS deploy validation) are omitted — the CLI runs
+ * `npm install` against the same `nextra-theme-docs` deps the default pack
+ * already declares in `package.json`.
+ */
+
+import type { DefaultThemeMode, FontFamily } from "../../Types.js";
+
+export const FORGE_MANIFEST = {
+	name: "forge",
+	displayName: "Forge",
+	tagline: "Clean developer docs",
+	defaults: {
+		/** Default accent hue when `theme.primaryHue` is unset. */
+		primaryHue: 228,
+		/** Forge ships in light mode by default. */
+		defaultTheme: "light" as DefaultThemeMode,
+		/** Default body font when `theme.fontFamily` is unset. */
+		fontFamily: "inter" as FontFamily,
+	},
+} as const;
+
+export type ForgeManifest = typeof FORGE_MANIFEST;

--- a/cli/src/site/themes/forge/index.ts
+++ b/cli/src/site/themes/forge/index.ts
@@ -1,0 +1,12 @@
+/**
+ * Forge theme pack — public surface re-exports.
+ */
+
+export { buildForgeCss, buildForgeOverrides, type ForgeOverrideInput } from "./Css.js";
+export {
+	buildForgeFontFamilyCssValue,
+	type ForgeLayoutInput,
+	generateForgeLayoutTsx,
+	resolveForgeLayoutInput,
+} from "./Layout.js";
+export { FORGE_MANIFEST, type ForgeManifest } from "./Manifest.js";

--- a/cli/vite.config.ts
+++ b/cli/vite.config.ts
@@ -24,7 +24,7 @@ export default defineConfig({
 			formats: ["es"],
 		},
 		rollupOptions: {
-			external: ["@anthropic-ai/sdk", "@mdx-js/mdx", "commander", "open", "yaml", /^node:.*/],
+			external: ["@anthropic-ai/sdk", "@mdx-js/mdx", "chokidar", "commander", "open", "yaml", /^node:.*/],
 			output: {
 				chunkFileNames: "[name].js",
 			},

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
 			"dependencies": {
 				"@anthropic-ai/sdk": "^0.39.0",
 				"@mdx-js/mdx": "^3.1.1",
+				"chokidar": "^4.0.0",
 				"commander": "^13.1.0",
 				"open": "^11.0.0",
 				"yaml": "^2.6.1"
@@ -2755,6 +2756,21 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/fb55"
+			}
+		},
+		"node_modules/chokidar": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+			"integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+			"license": "MIT",
+			"dependencies": {
+				"readdirp": "^4.0.1"
+			},
+			"engines": {
+				"node": ">= 14.16.0"
+			},
+			"funding": {
+				"url": "https://paulmillr.com/funding/"
 			}
 		},
 		"node_modules/chownr": {
@@ -6184,6 +6200,19 @@
 			},
 			"engines": {
 				"node": ">= 6"
+			}
+		},
+		"node_modules/readdirp": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+			"integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 14.18.0"
+			},
+			"funding": {
+				"type": "individual",
+				"url": "https://paulmillr.com/funding/"
 			}
 		},
 		"node_modules/recma-build-jsx": {


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## E2E Test (6)
<details>
<summary><strong>1. OpenAPI reference pages render as full documentation</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a project with at least one OpenAPI spec file (YAML or JSON) configured in the site settings. Have the documentation site built and running locally.

**Steps:**
1. Open the documentation site in your browser.
2. Navigate to the API reference section using the sidebar.
3. Click on any endpoint listed in the sidebar (for example, a "GET /users" or "POST /orders" entry).
4. Check that the endpoint page shows a full description, request parameters, and example code snippets.
5. Scroll down to verify that response schemas and example values are displayed on the page.
6. Click on a different endpoint in the sidebar and confirm it also loads with full details.

**Expected Results:**
- Each endpoint should have its own dedicated page with a title, description, and parameter table.
- Code samples should appear for the endpoint showing how to call it.
- Response schemas should be visible with example values.
- No blank pages, broken layouts, or "Swagger UI" placeholder widgets should appear anywhere in the API reference section.

</blockquote>
</details>
<details>
<summary><strong>2. Hot-reload dev server picks up content changes automatically</strong></summary>
<br>
<blockquote>

**Preconditions:** Have the documentation project running in development mode (the local dev server should be active and the site visible in a browser).

**Steps:**
1. Open the documentation site in your browser and note the current text on any page.
2. Open the source content folder on your computer and edit one of the documentation files — for example, change a heading or add a sentence to a page.
3. Save the file.
4. Wait about 3–5 seconds, then look at the browser tab showing the documentation site.
5. Refresh the page in the browser.
6. Check that the change you made in step 2 is now visible on the page.

**Expected Results:**
- After saving the file and refreshing, the updated text should appear on the page without needing to restart the dev server.
- The terminal or console running the dev server should show a message similar to "↻ Synced" followed by a number of files.
- The dev server should remain running and stable after the file change — it should not crash or stop.

</blockquote>
</details>
<details>
<summary><strong>3. Forge theme displays configured header navigation with dropdowns</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a project using the Forge theme with header navigation items (including at least one dropdown menu group) defined in the site configuration file.

**Steps:**
1. Open the documentation site in your browser.
2. Look at the top navigation bar (header) of the site.
3. Confirm that the navigation links you configured appear in the header.
4. Click on a header item that is set up as a dropdown menu.
5. Check that a dropdown menu appears with the nested links listed inside it.
6. Click one of the dropdown links and verify it navigates to the correct page.

**Expected Results:**
- The header should show the navigation items exactly as configured, not a hardcoded default set.
- Clicking a dropdown item should reveal a menu with the nested entries you defined.
- Clicking a nested link should take you to the correct destination page.

</blockquote>
</details>
<details>
<summary><strong>4. Forge theme displays configured footer with copyright and columns</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a project using the Forge theme with a footer configured in the site settings, including copyright text, at least one column of links, and at least one social media link.

**Steps:**
1. Open the documentation site in your browser.
2. Scroll all the way to the bottom of any page.
3. Check that the footer shows the copyright text you configured.
4. Look for the footer columns and confirm the links inside them match what you set up.
5. Check that the social media icons or links appear in the footer.
6. Click one of the footer links to confirm it goes to the right destination.

**Expected Results:**
- The footer should display the custom copyright text, not a generic placeholder.
- Footer columns with their headings and links should appear as configured.
- Social links should be visible and clickable, leading to the correct URLs.

</blockquote>
</details>
<details>
<summary><strong>5. Atlas theme displays configured header and footer</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a project using the Atlas theme with header navigation items and a footer (including copyright text and at least one column) defined in the site configuration.

**Steps:**
1. Open the documentation site in your browser with the Atlas theme active.
2. Look at the top header and confirm the navigation items you configured are shown.
3. Click a header link to verify it navigates correctly.
4. Scroll to the bottom of the page.
5. Confirm the footer shows your configured copyright text and column links.

**Expected Results:**
- The Atlas theme header should show the custom navigation items, not hardcoded defaults.
- The footer should display the configured copyright text and link columns.
- All header and footer links should be functional and lead to the correct pages.

</blockquote>
</details>
<details>
<summary><strong>6. Forge and Atlas themes fall back gracefully when no header or footer is configured</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a project using either the Forge or Atlas theme with no header or footer settings defined in the site configuration (the relevant fields should be absent or empty).

**Steps:**
1. Open the documentation site in your browser.
2. Look at the top header area of the site.
3. Confirm that a default navigation bar is still displayed (the site should not show a blank or broken header).
4. Scroll to the bottom of the page.
5. Confirm that a default footer is still displayed with some copyright text (the footer area should not be blank or broken).

**Expected Results:**
- The header should show a sensible default navigation, not an empty or broken bar.
- The footer should show a default copyright message, not a blank space or error.
- The site should load and function normally without any visible errors.

</blockquote>
</details>

---

## Topics (4)
<details>
<summary><strong>01 · Framework-agnostic OpenAPI pipeline with renderer-specific emitter</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The previous OpenAPI implementation embedded a third-party Swagger UI component as a simple shim, which couldn't be customized and tied the whole rendering pipeline to a single framework. The team needed a proper pipeline that pre-renders everything as MDX and can be extended to other doc frameworks without duplicating parsing logic.

**💡 Decisions Behind the Code**

- **Split IR from emitter**: ~70% of the OpenAPI code (parsing, refs, code samples, schema synthesis) is reusable across frameworks; isolating it means a future Fumadocs or Docusaurus emitter only needs ~600 lines of new code rather than a full fork
- **Throw on collisions rather than silently drop**: both `(tag, operationId)` collisions in the parser and spec-name slug collisions in the command layer throw hard errors, because silently dropping an endpoint or spec would produce missing pages with no visible warning
- **Pre-render to MDX instead of embedding Swagger UI**: pre-rendering lets Nextra's Shiki pipeline highlight code samples and removes a heavy runtime dependency, at the cost of a more complex build step
- **`ContentMirror` caches the parsed AST**: parsing each spec once and stashing it in `MirrorResult.openapiDocs` avoids re-parsing on every hot-reload cycle

**✅ What Was Implemented**

- Introduced a two-layer architecture: a framework-agnostic IR layer (`cli/src/site/openapi/`) containing `SpecLoader`, `SpecParser`, `RefResolver`, `CodeSampleGenerator`, `SchemaExample`, `OpenApiPipeline`, `Slug`, `Escape`, `SpecName`, and `Types`
- Added a Nextra-specific emitter layer (`cli/src/site/renderer/nextra/`) with `OverviewPageEmitter`, `EndpointPageEmitter`, `EndpointDataEmitter`, `SidebarMetaEmitter`, `Components`, `ApiCss`, and `Paths`
- `buildPipeline` in `OpenApiPipeline.ts` serves as the single entry point; `parseFullSpec` walks paths in declaration order, follows `$ref` with RFC 6901 escapes, and throws on `(tag, operationId)` collisions
- `buildOpenApiSpecInputs` in `StartCommand.ts` bridges the two layers, deriving URL slugs from source filenames and throwing on slug collisions
- Removed `swagger-ui-react` from `NEXTRA_DEPENDENCIES`; added `yaml` and `chokidar` to CLI dependencies

**📋 Future Enhancements**

`SchemaExample` documents gaps: `$ref`, `oneOf`, `anyOf`, `allOf`, `enum`, `default`, and `nullable` are not honoured in example synthesis — these are known deferred improvements.

**📁 FILES**
- `cli/src/site/openapi/OpenApiPipeline.ts`
- `cli/src/site/openapi/SpecParser.ts`
- `cli/src/site/renderer/nextra/index.ts`
- `cli/src/commands/StartCommand.ts`
- `cli/src/site/renderer/SiteRenderer.ts`

</blockquote>
</details>
<details>
<summary><strong>02 · Hot-reload dev server with source-folder file watcher</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The dev server had no mechanism to detect changes in the source content folder and re-sync them into the build directory. Developers editing docs had to manually restart the server to see updates.

**💡 Decisions Behind the Code**

- **Shared `syncContent` function rather than duplicating logic**: the same mirror + nav + OpenAPI render sequence is needed both at startup and on each file change; extracting it prevents the two paths from drifting out of sync
- **Swallow watcher `onChange` errors instead of crashing**: a transient file-system or config error during a reload should not kill the long-running dev server; the error is logged so the developer is informed without losing their session
- **Close watcher in `finally`**: guarantees cleanup regardless of how the dev server exits, preventing orphaned file-system watchers

**✅ What Was Implemented**

- Added `startSourceWatcher` in `cli/src/site/SourceWatcher.js` (backed by `chokidar`) that watches the resolved source root and fires an `onChange` callback after changes settle
- Extracted `syncContent` in `StartCommand.ts` as a shared async function covering mirror → navigation → OpenAPI render; called on initial startup and on every watcher `onChange` event
- The watcher is started before `runDev` and closed in a `finally` block so it is always torn down whether the dev server exits cleanly or errors out
- `onChange` swallows errors from `readSiteJson` (logs them) so a transient config parse error does not crash the running dev process
- Logs a "↻ Synced N files" message on each successful reload cycle

**📁 FILES**
- `cli/src/site/SourceWatcher.ts`
- `cli/src/commands/StartCommand.ts`
- `cli/package.json`

</blockquote>
</details>
<details>
<summary><strong>03 · Theme packs Forge and Atlas with configurable header and footer</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The Forge and Atlas themes had no way to configure navigation headers with dropdown menus or footers with copyright text, columns, and social links. Users needed structured config options rather than hardcoded defaults.

**💡 Decisions Behind the Code**

- **Fallback to legacy defaults when config is absent**: existing sites with no header/footer config continue to work without any migration, preserving backward compatibility at zero cost

**✅ What Was Implemented**

- Extended both Forge and Atlas theme packs to read `header.items` (supporting nested dropdown entries) and a `footer` config block (copyright, columns, social links) from `site.json`
- Added graceful fallback to legacy nav and default copyright footer when no header/footer config is present
- Changes landed in commit `2041aa2` prior to the squash

**📁 FILES**
- `cli/src/site/renderer/nextra/Components.ts`

</blockquote>
</details>
<details>
<summary><strong>04 · Architecture documentation for the OpenAPI pipeline and site generation</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The new two-layer OpenAPI pipeline and its module boundaries were complex enough that future contributors (and future framework emitter authors) needed explicit guidance on what belongs in each layer and how to add a new docs framework.

**💡 Decisions Behind the Code**

- **Document the "must not" boundaries explicitly**: both layers have hard rules about what they must not import or assume; making these explicit in writing prevents accidental coupling as the codebase grows

**✅ What Was Implemented**

- Added a detailed "Site Generation: OpenAPI Reference Pipeline" section to `cli/DEVELOPMENT.md` including an ASCII file-flow diagram, a per-module table for both the IR and emitter layers, a rationale section for the IR/emitter split, and a step-by-step guide for adding a new docs framework
- Updated `CLAUDE.md` with a concise summary of the two-layer architecture, the `SiteRenderer.renderOpenApiSpecs` bridge, and a note that `swagger-ui-react` is removed

**📁 FILES**
- `cli/DEVELOPMENT.md`
- `CLAUDE.md`

</blockquote>
</details>

---

*Generated by Jolli Memory · May 5, 2026 at 11:20 PM*
<!-- jollimemory-summary-end -->