### PR TITLE
Add BranchSummaryLoader and SummaryPrAggregateMarkdownBuilder for multi-commit PR support

### DIFF
--- a/vscode/src/Extension.test.ts
+++ b/vscode/src/Extension.test.ts
@@ -673,6 +673,7 @@ const {
 			setExtensionOutdated: vi.fn(),
 			setStatus: vi.fn(),
 			setMainBranch: vi.fn(),
+			getMainBranch: vi.fn(() => "main"),
 			setFilter: vi.fn().mockResolvedValue(undefined),
 			getFilter: vi.fn(() => ""),
 			loadMore: vi.fn().mockResolvedValue(undefined),
@@ -1425,6 +1426,8 @@ describe("Extension", () => {
 					summary,
 					expect.anything(),
 					"/test/workspace",
+					mockBridge,
+					expect.any(String),
 					"commit",
 				);
 			});
@@ -1468,6 +1471,8 @@ describe("Extension", () => {
 					summary,
 					expect.anything(),
 					"/test/workspace",
+					mockBridge,
+					expect.any(String),
 					"memory",
 				);
 			});
@@ -1484,6 +1489,8 @@ describe("Extension", () => {
 					summary,
 					expect.anything(),
 					"/test/workspace",
+					mockBridge,
+					expect.any(String),
 					"memory",
 				);
 			});

--- a/vscode/src/Extension.ts
+++ b/vscode/src/Extension.ts
@@ -1699,6 +1699,8 @@ export function activate(context: vscode.ExtensionContext): void {
 					summary,
 					context.extensionUri,
 					workspaceRoot,
+					bridge,
+					commitsStore.getMainBranch(),
 					"commit",
 				);
 			},
@@ -1724,6 +1726,8 @@ export function activate(context: vscode.ExtensionContext): void {
 					summary,
 					context.extensionUri,
 					workspaceRoot,
+					bridge,
+					commitsStore.getMainBranch(),
 					"memory",
 				);
 			},
@@ -1755,6 +1759,8 @@ export function activate(context: vscode.ExtensionContext): void {
 							summary,
 							context.extensionUri,
 							workspaceRoot,
+							bridge,
+							commitsStore.getMainBranch(),
 							"kb",
 						);
 						return;

--- a/vscode/src/Types.ts
+++ b/vscode/src/Types.ts
@@ -125,8 +125,8 @@ export interface PlansRegistry {
 // Re-export core note types to avoid duplication
 export type { NoteEntry, NoteFormat } from "../../cli/src/Types.js";
 
-// Import for use in NoteInfo below
-import type { NoteFormat } from "../../cli/src/Types.js";
+// Import for use in PlansRegistry / NoteInfo above and below
+import type { NoteEntry, NoteFormat } from "../../cli/src/Types.js";
 
 /** Display-level note metadata for the VSCode tree view */
 export interface NoteInfo {

--- a/vscode/src/commands/PushCommand.test.ts
+++ b/vscode/src/commands/PushCommand.test.ts
@@ -111,7 +111,9 @@ describe("PushCommand", () => {
 		expect(deps.bridge.pushCurrentBranch).not.toHaveBeenCalled();
 	});
 
-	it("warns when the branch is not in single-commit mode", async () => {
+	it("pushes successfully when branch has multiple commits (multi-commit support)", async () => {
+		// Multi-commit branches no longer trigger a warning — push proceeds the
+		// same way as for single-commit branches (`git push origin HEAD`).
 		const deps = makeDeps([makeCommit(), makeCommit({ hash: "bbbb" })]);
 		const command = new PushCommand(
 			deps.bridge as never,
@@ -124,9 +126,61 @@ describe("PushCommand", () => {
 
 		await command.execute();
 
-		expect(showWarningMessage).toHaveBeenCalledWith(
-			"Jolli Memory: Push mode is available only when this branch has exactly 1 commit.",
+		expect(deps.bridge.pushCurrentBranch).toHaveBeenCalled();
+		expect(showInformationMessage).toHaveBeenCalledWith(
+			"Jolli Memory: Successfully pushed the current branch.",
 		);
+		expect(showWarningMessage).not.toHaveBeenCalledWith(
+			expect.stringContaining("exactly 1 commit"),
+		);
+	});
+
+	it("warns and aborts when branch has zero commits ahead of base", async () => {
+		// Removed the !== 1 gate but kept an explicit empty-branch guard, since
+		// the command can be invoked from the command palette / keyboard binding
+		// in a state the sidebar UI hides.
+		const deps = makeDeps([]);
+		const command = new PushCommand(
+			deps.bridge as never,
+			deps.commitsStore as never,
+			deps.filesStore as never,
+			deps.statusStore as never,
+			deps.statusBar as never,
+			"/repo",
+		);
+
+		await command.execute();
+
+		expect(showWarningMessage).toHaveBeenCalledWith(
+			"Jolli Memory: No commits to push on the current branch.",
+		);
+		expect(deps.bridge.pushCurrentBranch).not.toHaveBeenCalled();
+	});
+
+	it("force-push warning shows commit count when branch has > 1 commits", async () => {
+		const deps = makeDeps([
+			makeCommit({ hash: "aaaa", isPushed: true, message: "head msg" }),
+			makeCommit({ hash: "bbbb" }),
+			makeCommit({ hash: "cccc" }),
+		]);
+		showWarningMessage.mockResolvedValueOnce("Force Push (--force-with-lease)");
+		const command = new PushCommand(
+			deps.bridge as never,
+			deps.commitsStore as never,
+			deps.filesStore as never,
+			deps.statusStore as never,
+			deps.statusBar as never,
+			"/repo",
+		);
+
+		await command.execute();
+
+		expect(showWarningMessage).toHaveBeenCalledWith(
+			expect.stringContaining("HEAD (3 commits)"),
+			expect.objectContaining({ modal: true }),
+			"Force Push (--force-with-lease)",
+		);
+		expect(deps.bridge.forcePush).toHaveBeenCalled();
 	});
 
 	it("pushes normally and refreshes all providers", async () => {

--- a/vscode/src/commands/PushCommand.ts
+++ b/vscode/src/commands/PushCommand.ts
@@ -1,11 +1,14 @@
 /**
  * PushCommand
  *
- * Handles single-commit branch submission from the Branch Commits panel.
+ * Handles branch submission from the Branch Commits panel. Supports any
+ * commit count >= 1 — multi-commit branches push exactly the same way as
+ * single-commit ones (`git push origin HEAD`); the difference is purely the
+ * force-push warning copy.
  *
  * Flow:
- * 1. Validate the branch has exactly one commit in history view.
- * 2. If the commit is already pushed, ask for force-push confirmation first.
+ * 1. Reject empty branches (no commits ahead of base) with a warning.
+ * 2. If the HEAD commit is already on remote, ask for force-push confirmation.
  * 3. Otherwise try normal push; on non-fast-forward rejection, offer force push.
  * 4. Refresh panels and status bar after success.
  */
@@ -42,29 +45,33 @@ export class PushCommand {
 		}
 
 		const commits = this.commitsStore.getSnapshot().commits;
-		if (commits.length !== 1) {
-			log.warn(
+		if (commits.length === 0) {
+			log.info(
 				"push",
-				`pushBranch only supports single-commit mode, got ${commits.length}`,
+				"pushBranch invoked with empty branch — nothing to push",
 			);
 			vscode.window.showWarningMessage(
-				"Jolli Memory: Push mode is available only when this branch has exactly 1 commit.",
+				"Jolli Memory: No commits to push on the current branch.",
 			);
 			return;
 		}
 
-		const onlyCommit = commits[0];
+		// commits is newest-first (per JolliMemoryBridge.listBranchCommits), so
+		// commits[0] is HEAD. The "is HEAD on remote" check covers both single
+		// and multi commit branches uniformly: if HEAD is already pushed, any
+		// further push that lands a different HEAD is a history rewrite.
+		const headCommit = commits[0];
 		let resultLabel: "pushed" | "force-pushed" = "pushed";
 
 		try {
-			if (onlyCommit.isPushed) {
+			if (headCommit.isPushed) {
 				log.info(
 					"push",
-					"Single commit already pushed — asking for force-push confirmation",
+					`HEAD already pushed (${commits.length} commit(s) on branch) — asking for force-push confirmation`,
 				);
 				const confirmed = await this.showForcePushWarning(
-					onlyCommit,
-					"This commit is already on remote. Force push will rewrite remote branch history.",
+					commits,
+					"HEAD is already on remote. Force push will rewrite remote branch history.",
 				);
 				if (!confirmed) {
 					log.info("push", "Force-push confirmation cancelled");
@@ -84,7 +91,7 @@ export class PushCommand {
 						"Normal push rejected (non-fast-forward) — offering force push",
 					);
 					const confirmed = await this.showForcePushWarning(
-						onlyCommit,
+						commits,
 						"Remote branch has diverged. Force push will overwrite remote history.",
 					);
 					if (!confirmed) {
@@ -108,15 +115,25 @@ export class PushCommand {
 		await this.refreshAll();
 	}
 
+	/**
+	 * Shows a modal force-push confirmation dialog.
+	 *
+	 * Single-commit branches show "Commit: <hash> <msg>"; multi-commit branches
+	 * show "HEAD (N commits): <hash> <msg>" so the user can see at a glance how
+	 * many commits the force-push will replace on the remote.
+	 */
 	private async showForcePushWarning(
-		commit: BranchCommit,
+		commits: ReadonlyArray<BranchCommit>,
 		reason: string,
 	): Promise<boolean> {
+		const head = commits[0];
+		const headLabel =
+			commits.length === 1 ? "Commit" : `HEAD (${commits.length} commits)`;
 		const answer = await vscode.window.showWarningMessage(
 			[
 				"This operation may rewrite remote history.",
 				"",
-				`Commit: ${commit.shortHash} ${commit.message.substring(0, 80)}`,
+				`${headLabel}: ${head.shortHash} ${head.message.substring(0, 80)}`,
 				"",
 				reason,
 				"This may affect collaborators on the same branch.",

--- a/vscode/src/providers/PlansTreeProvider.test.ts
+++ b/vscode/src/providers/PlansTreeProvider.test.ts
@@ -99,7 +99,14 @@ function makePlansProvider(bridge: unknown) {
 		getTreeItem: provider.getTreeItem.bind(provider),
 		getChildren: provider.getChildren.bind(provider),
 		serialize: (
-			provider as unknown as { serialize: () => unknown }
+			provider as unknown as {
+				serialize: () => ReadonlyArray<{
+					id?: string;
+					label?: string;
+					iconKey?: string;
+					iconColor?: string;
+				}>;
+			}
 		).serialize?.bind(provider),
 		onDidChangeTreeData: provider.onDidChangeTreeData,
 		dispose: () => provider.dispose(),
@@ -380,7 +387,9 @@ describe("PlansTreeProvider", () => {
 			label: expect.any(String),
 		});
 		// Check that icon colors are preserved for committed items
-		const committedItem = out?.find((item) => item.label.includes("abcdef12"));
+		const committedItem = out?.find((item) =>
+			(item.label ?? "").includes("abcdef12"),
+		);
 		if (committedItem) {
 			expect(committedItem.iconKey).toBe("lock");
 			expect(committedItem.iconColor).toBe("charts.green");

--- a/vscode/src/services/PrCommentService.test.ts
+++ b/vscode/src/services/PrCommentService.test.ts
@@ -151,11 +151,12 @@ const MARKER_END = "<!-- jollimemory-summary-end -->";
 // ─── Tests ──────────────────────────────────────────────────────────────────
 
 describe("PrCommentService", () => {
-	let postMessage: ReturnType<typeof vi.fn>;
+	let postMessage: ReturnType<typeof vi.fn> &
+		((msg: Record<string, unknown>) => void);
 
 	beforeEach(() => {
 		vi.clearAllMocks();
-		postMessage = vi.fn();
+		postMessage = vi.fn() as typeof postMessage;
 		setupTmpFile();
 	});
 
@@ -236,23 +237,46 @@ describe("PrCommentService", () => {
 	// ─── handleCheckPrStatus ────────────────────────────────────────────────
 
 	describe("handleCheckPrStatus", () => {
-		it("posts multipleCommits status when branch has more than 1 commit", async () => {
+		it("proceeds past the (now removed) commit-count gate regardless of multi-commit branches", async () => {
+			// Multi-commit branches no longer trigger a "multipleCommits" status —
+			// the gate was removed when multi-commit PRs became supported.
+			// This test asserts the gate is gone: with `gh` available + a PR found,
+			// status becomes 'ready' even though git history shows multiple commits.
 			setupExecFile((cmd, args) => {
-				if (cmd === "git" && args[0] === "symbolic-ref") {
-					return { stdout: "origin/main\n" };
+				if (cmd === "git" && args[0] === "rev-parse") {
+					return { stdout: "feature/multi\n" };
 				}
-				if (cmd === "git" && args[0] === "rev-list") {
-					return { stdout: "3\n" };
+				if (cmd === "gh" && args[0] === "--version") {
+					return { stdout: "gh version 2.40.0\n" };
+				}
+				if (cmd === "gh" && args[0] === "auth") {
+					return { stdout: "Logged in\n" };
+				}
+				if (cmd === "gh" && args[0] === "pr") {
+					const prData = {
+						number: 42,
+						url: "https://github.com/example/repo/pull/42",
+						title: "Multi-commit PR",
+						body: "",
+					};
+					return { stdout: JSON.stringify(prData) };
 				}
 				return { stdout: "" };
 			});
 
 			await handleCheckPrStatus(CWD, postMessage);
 
+			expect(postMessage).not.toHaveBeenCalledWith(
+				expect.objectContaining({ status: "multipleCommits" }),
+			);
 			expect(postMessage).toHaveBeenCalledWith({
 				command: "prStatus",
-				status: "multipleCommits",
-				count: 3,
+				status: "ready",
+				pr: {
+					number: 42,
+					url: "https://github.com/example/repo/pull/42",
+					title: "Multi-commit PR",
+				},
 			});
 		});
 
@@ -286,7 +310,14 @@ describe("PrCommentService", () => {
 					return { stdout: "gh version 2.40.0\n" };
 				}
 				if (cmd === "gh" && args[0] === "auth") {
-					const err = new Error("not logged in") as NodeJS.ErrnoException;
+					// execFile sets numeric exit codes on the error object; production
+					// `probeGh` uses `typeof code === "number"` to detect the
+					// non-zero-exit case (despite the Node.js TS typing claiming
+					// `code: string | undefined`). Cast through `unknown` so we can
+					// simulate the runtime shape the production code actually checks.
+					const err = new Error("not logged in") as unknown as {
+						code: number;
+					} & Error;
 					err.code = 1;
 					throw err;
 				}
@@ -323,9 +354,9 @@ describe("PrCommentService", () => {
 				if (cmd === "gh" && args[0] === "auth") {
 					authCalls++;
 					if (authCalls === 1) {
-						const err = new Error(
-							"credential manager locked",
-						) as NodeJS.ErrnoException;
+						const err = new Error("credential manager locked") as unknown as {
+							code: number;
+						} & Error;
 						err.code = 1;
 						throw err;
 					}
@@ -676,28 +707,6 @@ describe("PrCommentService", () => {
 			expect(logError).toHaveBeenCalled();
 		});
 
-		it("treats non-numeric rev-list output as 0 commits (|| 0 fallback)", async () => {
-			setupExecFile((cmd, args) => {
-				if (cmd === "git" && args[0] === "rev-list") {
-					// Returns non-numeric output — parseInt returns NaN, || 0 kicks in
-					return { stdout: "not-a-number\n" };
-				}
-				if (cmd === "gh" && args[0] === "--version") {
-					throw new Error("no gh");
-				}
-				return { stdout: "" };
-			});
-
-			await handleCheckPrStatus(CWD, postMessage);
-
-			// NaN || 0 → 0 commits, which is <= 1, so continues to gh check
-			// gh is not available → unavailable
-			expect(postMessage).toHaveBeenCalledWith({
-				command: "prStatus",
-				status: "unavailable",
-			});
-		});
-
 		it("coerces non-Error to string in outer catch (line 217)", async () => {
 			setupExecFile((cmd, args) => {
 				if (cmd === "git" && args[0] === "rev-list") {
@@ -725,44 +734,6 @@ describe("PrCommentService", () => {
 			expect(logError).toHaveBeenCalledWith(
 				expect.any(String),
 				expect.stringContaining("string error from git"),
-			);
-		});
-
-		it("treats unresolved upstream baseline as 0 commits and continues (no origin/HEAD)", async () => {
-			const prData = {
-				number: 7,
-				url: "https://pr/7",
-				title: "My PR",
-				body: "",
-			};
-			setupExecFile((cmd, args) => {
-				if (cmd === "git" && args[0] === "symbolic-ref") {
-					// Healthy repo without a pinned origin/HEAD — e.g. no origin remote,
-					// or fresh clone before first fetch. symbolic-ref exits non-zero.
-					throw new Error(
-						"fatal: ref refs/remotes/origin/HEAD is not a symbolic ref",
-					);
-				}
-				if (cmd === "git" && args[0] === "rev-parse") {
-					return { stdout: "feature/test\n" };
-				}
-				if (cmd === "gh" && args[0] === "--version") {
-					return { stdout: "gh version 2.40.0\n" };
-				}
-				if (cmd === "gh" && args[0] === "auth") {
-					return { stdout: "ok\n" };
-				}
-				if (cmd === "gh" && args[0] === "pr") {
-					return { stdout: JSON.stringify(prData) };
-				}
-				return { stdout: "" };
-			});
-
-			await handleCheckPrStatus(CWD, postMessage);
-
-			// baseline unresolved → 0 commits, no multipleCommits gate, flow continues.
-			expect(postMessage).toHaveBeenCalledWith(
-				expect.objectContaining({ command: "prStatus", status: "ready" }),
 			);
 		});
 
@@ -829,30 +800,6 @@ describe("PrCommentService", () => {
 			expect(postMessage).not.toHaveBeenCalledWith(
 				expect.objectContaining({ status: "multipleCommits" }),
 			);
-		});
-
-		it("keeps commit count check when branch matches current branch", async () => {
-			setupExecFile((cmd, args) => {
-				if (cmd === "git" && args[0] === "symbolic-ref") {
-					return { stdout: "origin/main\n" };
-				}
-				if (cmd === "git" && args[0] === "rev-list") {
-					return { stdout: "3\n" };
-				}
-				if (cmd === "git" && args[0] === "rev-parse") {
-					return { stdout: "feature/current\n" };
-				}
-				return { stdout: "" };
-			});
-
-			// Pass branch that matches current — should still show multipleCommits
-			await handleCheckPrStatus(CWD, postMessage, "feature/current");
-
-			expect(postMessage).toHaveBeenCalledWith({
-				command: "prStatus",
-				status: "multipleCommits",
-				count: 3,
-			});
 		});
 
 		it("uses provided branch in noPr status message with crossBranch flag", async () => {
@@ -1070,101 +1017,6 @@ describe("PrCommentService", () => {
 				expect.objectContaining({ status: "noPr", branch: "feature/br" }),
 			);
 		});
-
-		it("stays silent when upstream baseline cannot be resolved — healthy repos without origin/HEAD must not spam logs", async () => {
-			setupExecFile((cmd, args) => {
-				if (cmd === "git" && args[0] === "symbolic-ref") {
-					// No origin/HEAD pinned — common in repos with no `origin`, fresh
-					// clones, or detached setups. Previously this caused a warn on
-					// every PR panel open for any repo using master/trunk; now it
-					// should be completely silent.
-					throw new Error(
-						"fatal: ref refs/remotes/origin/HEAD is not a symbolic ref",
-					);
-				}
-				if (cmd === "git" && args[0] === "rev-parse")
-					return { stdout: "feature/br\n" };
-				if (cmd === "gh" && args[0] === "--version")
-					return { stdout: "gh 2.40\n" };
-				if (cmd === "gh" && args[0] === "auth") return { stdout: "ok\n" };
-				if (cmd === "gh" && args[0] === "pr") throw new Error("no pr");
-				return { stdout: "" };
-			});
-
-			await handleCheckPrStatus(CWD, postMessage);
-
-			// Silent: no commit-count log at all when baseline is unresolved.
-			// (The unrelated `gh pr` stub still trips a warn from findPrForBranch,
-			// so assert narrowly: nothing about rev-list.)
-			expect(warn).not.toHaveBeenCalledWith(
-				expect.any(String),
-				expect.stringContaining("rev-list"),
-			);
-			expect(debug).not.toHaveBeenCalledWith(
-				expect.any(String),
-				expect.stringContaining("rev-list"),
-			);
-			// Flow continues — commit count treated as 0 means no multipleCommits gate.
-			expect(postMessage).not.toHaveBeenCalledWith(
-				expect.objectContaining({ status: "multipleCommits" }),
-			);
-		});
-
-		it("resolves the actual upstream default branch (origin/master etc.), not hardcoded origin/main", async () => {
-			// Verifies the root-cause fix: squash gate works in master-based repos.
-			setupExecFile((cmd, args) => {
-				if (cmd === "git" && args[0] === "symbolic-ref") {
-					return { stdout: "origin/master\n" };
-				}
-				if (cmd === "git" && args[0] === "rev-list") {
-					// Executed only if the command uses origin/master..HEAD — otherwise
-					// the production bug (hardcoded origin/main) would reach this stub
-					// with different args and we would never see count=5 in postMessage.
-					expect(args).toEqual(["rev-list", "--count", "origin/master..HEAD"]);
-					return { stdout: "5\n" };
-				}
-				if (cmd === "git" && args[0] === "rev-parse")
-					return { stdout: "feature/br\n" };
-				return { stdout: "" };
-			});
-
-			await handleCheckPrStatus(CWD, postMessage);
-
-			expect(postMessage).toHaveBeenCalledWith({
-				command: "prStatus",
-				status: "multipleCommits",
-				count: 5,
-			});
-		});
-
-		it("warns when rev-list fails after the upstream baseline was resolved — that is a real repo problem, not a config mismatch", async () => {
-			setupExecFile((cmd, args) => {
-				if (cmd === "git" && args[0] === "symbolic-ref") {
-					return { stdout: "origin/master\n" };
-				}
-				if (cmd === "git" && args[0] === "rev-list") {
-					// Baseline resolved but rev-list still broke — e.g. permission,
-					// corruption. Worth a warn so debug.log has a trail.
-					throw new Error("fatal: bad object origin/master");
-				}
-				if (cmd === "git" && args[0] === "rev-parse")
-					return { stdout: "feature/br\n" };
-				if (cmd === "gh" && args[0] === "--version")
-					return { stdout: "gh 2.40\n" };
-				if (cmd === "gh" && args[0] === "auth") return { stdout: "ok\n" };
-				if (cmd === "gh" && args[0] === "pr") throw new Error("no pr");
-				return { stdout: "" };
-			});
-
-			await handleCheckPrStatus(CWD, postMessage);
-
-			expect(warn).toHaveBeenCalledWith(
-				expect.any(String),
-				expect.stringMatching(
-					/git rev-list --count origin\/master\.\.HEAD failed.*bad object/s,
-				),
-			);
-		});
 	});
 
 	// ─── handleCreatePr ─────────────────────────────────────────────────────
@@ -1316,12 +1168,13 @@ describe("PrCommentService", () => {
 	// ─── handlePrepareUpdatePr ──────────────────────────────────────────────
 
 	describe("handlePrepareUpdatePr", () => {
-		const summary = {
-			message: "fix: bug",
-			files: [],
-			branch: "feature/test-branch",
-		} as never;
-		const buildMarkdownFn = vi.fn(() => "## Summary\nFixed a bug");
+		// New signature: caller pre-builds the markdown and passes the branch +
+		// commit hash separately. The function is now PR-lookup + marker-merge
+		// only — single-summary vs aggregated rendering happens upstream in
+		// SummaryWebviewPanel before the call.
+		const SUMMARY_BRANCH = "feature/test-branch";
+		const SUMMARY_HASH = "deadbeef";
+		const MARKDOWN = "## Summary\nFixed a bug";
 
 		it("posts prShowUpdateForm with merged body when PR exists", async () => {
 			const existingBody = "Old description";
@@ -1342,9 +1195,14 @@ describe("PrCommentService", () => {
 				return { stdout: "" };
 			});
 
-			await handlePrepareUpdatePr(summary, CWD, postMessage, buildMarkdownFn);
+			await handlePrepareUpdatePr(
+				SUMMARY_BRANCH,
+				SUMMARY_HASH,
+				MARKDOWN,
+				CWD,
+				postMessage,
+			);
 
-			expect(buildMarkdownFn).toHaveBeenCalledWith(summary);
 			expect(postMessage).toHaveBeenCalledWith({
 				command: "prShowUpdateForm",
 				title: "PR Title",
@@ -1352,15 +1210,10 @@ describe("PrCommentService", () => {
 			});
 		});
 
-		it("falls back to current branch when summary.branch is undefined (cross-branch)", async () => {
-			// Covers handlePrepareUpdatePr `summary.branch ?? currentBranch` right branch.
-			// merge-base --is-ancestor fails so isCrossBranch=true; summary has no branch,
-			// so the fallback reaches currentBranch.
-			const summaryNoBranch = {
-				commitHash: "deadbeef",
-				// no `branch` field — exercise the `??` fallback
-			} as never;
-
+		it("falls back to current branch when summaryBranch is undefined under cross-branch", async () => {
+			// Covers `summaryBranch ?? currentBranch` fallback. With a commit hash
+			// that fails merge-base --is-ancestor → isCrossBranch=true; with no
+			// summaryBranch passed, target falls through to currentBranch.
 			setupExecFile((cmd, args) => {
 				if (cmd === "git" && args[0] === "merge-base") {
 					throw new Error("not an ancestor");
@@ -1382,10 +1235,43 @@ describe("PrCommentService", () => {
 			});
 
 			await handlePrepareUpdatePr(
-				summaryNoBranch,
+				undefined,
+				SUMMARY_HASH,
+				MARKDOWN,
 				CWD,
 				postMessage,
-				buildMarkdownFn,
+			);
+
+			expect(postMessage).toHaveBeenCalledWith(
+				expect.objectContaining({ command: "prShowUpdateForm" }),
+			);
+		});
+
+		it("treats undefined commitHash as not cross-branch (uses current branch)", async () => {
+			// When summaryCommitHash is undefined the cross-branch probe is skipped.
+			setupExecFile((cmd, args) => {
+				if (cmd === "git" && args[0] === "rev-parse") {
+					return { stdout: "feature/test-branch\n" };
+				}
+				if (cmd === "gh" && args[0] === "pr" && args[1] === "view") {
+					return {
+						stdout: JSON.stringify({
+							number: 5,
+							url: "u",
+							title: "t",
+							body: "",
+						}),
+					};
+				}
+				return { stdout: "" };
+			});
+
+			await handlePrepareUpdatePr(
+				SUMMARY_BRANCH,
+				undefined,
+				MARKDOWN,
+				CWD,
+				postMessage,
 			);
 
 			expect(postMessage).toHaveBeenCalledWith(
@@ -1412,7 +1298,13 @@ describe("PrCommentService", () => {
 				return { stdout: "" };
 			});
 
-			await handlePrepareUpdatePr(summary, CWD, postMessage, buildMarkdownFn);
+			await handlePrepareUpdatePr(
+				SUMMARY_BRANCH,
+				SUMMARY_HASH,
+				MARKDOWN,
+				CWD,
+				postMessage,
+			);
 
 			const call = postMessage.mock.calls[0][0];
 			expect(call.body).toContain("Before\n");
@@ -1430,7 +1322,13 @@ describe("PrCommentService", () => {
 				throw new Error("no PR");
 			});
 
-			await handlePrepareUpdatePr(summary, CWD, postMessage, buildMarkdownFn);
+			await handlePrepareUpdatePr(
+				SUMMARY_BRANCH,
+				SUMMARY_HASH,
+				MARKDOWN,
+				CWD,
+				postMessage,
+			);
 
 			expect(showWarningMessage).toHaveBeenCalledWith(
 				"No pull request found for branch feature/test-branch.",
@@ -1438,33 +1336,24 @@ describe("PrCommentService", () => {
 			expect(postMessage).not.toHaveBeenCalled();
 		});
 
-		it("shows error on unexpected failure", async () => {
-			// Return a valid PR first, but make buildMarkdownFn throw
+		it("shows error and logs when an unexpected error is thrown", async () => {
 			setupExecFile((cmd, args) => {
 				if (cmd === "git" && args[0] === "rev-parse") {
-					return { stdout: "feature/test-branch\n" };
-				}
-				if (cmd === "gh" && args[0] === "pr" && args[1] === "view") {
-					return {
-						stdout: JSON.stringify({
-							number: 10,
-							url: "https://url",
-							title: "T",
-							body: "body",
-						}),
-					};
+					throw new Error("git rev-parse exploded");
 				}
 				return { stdout: "" };
 			});
 
-			const throwingBuildFn = vi.fn(() => {
-				throw new Error("markdown generation failed");
-			});
-
-			await handlePrepareUpdatePr(summary, CWD, postMessage, throwingBuildFn);
+			await handlePrepareUpdatePr(
+				SUMMARY_BRANCH,
+				SUMMARY_HASH,
+				MARKDOWN,
+				CWD,
+				postMessage,
+			);
 
 			expect(showErrorMessage).toHaveBeenCalledWith(
-				expect.stringContaining("markdown generation failed"),
+				expect.stringContaining("git rev-parse exploded"),
 			);
 			expect(logError).toHaveBeenCalled();
 		});
@@ -1472,26 +1361,18 @@ describe("PrCommentService", () => {
 		it("coerces non-Error thrown to string in error message", async () => {
 			setupExecFile((cmd, args) => {
 				if (cmd === "git" && args[0] === "rev-parse") {
-					return { stdout: "feature/test-branch\n" };
-				}
-				if (cmd === "gh" && args[0] === "pr" && args[1] === "view") {
-					return {
-						stdout: JSON.stringify({
-							number: 10,
-							url: "https://url",
-							title: "T",
-							body: "body",
-						}),
-					};
+					throw "plain string error";
 				}
 				return { stdout: "" };
 			});
 
-			const throwingBuildFn = vi.fn(() => {
-				throw "plain string error";
-			});
-
-			await handlePrepareUpdatePr(summary, CWD, postMessage, throwingBuildFn);
+			await handlePrepareUpdatePr(
+				SUMMARY_BRANCH,
+				SUMMARY_HASH,
+				MARKDOWN,
+				CWD,
+				postMessage,
+			);
 
 			expect(showErrorMessage).toHaveBeenCalledWith(
 				expect.stringContaining("plain string error"),
@@ -1517,7 +1398,13 @@ describe("PrCommentService", () => {
 				return { stdout: "" };
 			});
 
-			await handlePrepareUpdatePr(summary, CWD, postMessage, buildMarkdownFn);
+			await handlePrepareUpdatePr(
+				SUMMARY_BRANCH,
+				SUMMARY_HASH,
+				MARKDOWN,
+				CWD,
+				postMessage,
+			);
 
 			const call = postMessage.mock.calls[0][0];
 			expect(call.body).toBe(

--- a/vscode/src/services/PrCommentService.ts
+++ b/vscode/src/services/PrCommentService.ts
@@ -19,7 +19,6 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { promisify } from "node:util";
 import * as vscode from "vscode";
-import type { CommitSummary } from "../../../cli/src/Types.js";
 import { log } from "../util/Logger.js";
 
 const execFileAsync = promisify(execFile);
@@ -205,60 +204,6 @@ async function execGit(args: Array<string>, cwd: string): Promise<string> {
 	return stdout;
 }
 
-/**
- * Resolves the upstream default branch (what `origin/HEAD` points to), e.g.
- * `"origin/main"`, `"origin/master"`, `"origin/trunk"`. Returns `undefined`
- * when the ref is not set — common and healthy in repos without an `origin`
- * remote, in fresh clones before the first fetch, in detached states, or when
- * `origin/HEAD` was never pinned. Undefined is an expected outcome, not an
- * error: callers should treat it as "no baseline in this repo".
- */
-async function resolveUpstreamBaseline(
-	cwd: string,
-): Promise<string | undefined> {
-	try {
-		const raw = await execGit(
-			["symbolic-ref", "--short", "refs/remotes/origin/HEAD"],
-			cwd,
-		);
-		const trimmed = raw.trim();
-		return trimmed.length > 0 ? trimmed : undefined;
-	} catch {
-		return undefined;
-	}
-}
-
-/**
- * Returns the number of commits on the current branch that are ahead of the
- * upstream default branch. Used only to gate the "multiple commits — please
- * squash" UI, so 0 means "don't gate" — a safe fallback whenever the baseline
- * cannot be determined or the count cannot be computed.
- */
-async function getCommitCount(cwd: string): Promise<number> {
-	const baseline = await resolveUpstreamBaseline(cwd);
-	if (!baseline) {
-		// No upstream baseline in this repo — squash gate does not apply.
-		// Silent: this is the normal state for many healthy setups (no
-		// `origin`, fresh clone, detached HEAD), not a condition to warn about.
-		return 0;
-	}
-	try {
-		const raw = await execGit(
-			["rev-list", "--count", `${baseline}..HEAD`],
-			cwd,
-		);
-		return Number.parseInt(raw.trim(), 10) || 0;
-	} catch (err) {
-		// Baseline resolved but rev-list failed — unusual (e.g. corrupted
-		// repo, permissions). Worth a warn so debug.log has a trail.
-		log.warn(
-			TAG,
-			`git rev-list --count ${baseline}..HEAD failed: ${(err as Error).message}`,
-		);
-		return 0;
-	}
-}
-
 /** Returns the current branch name. */
 async function getCurrentBranch(cwd: string): Promise<string> {
 	const raw = await execGit(["rev-parse", "--abbrev-ref", "HEAD"], cwd);
@@ -293,7 +238,7 @@ async function getCurrentBranch(cwd: string): Promise<string> {
  * HEAD, 1 when it is not, and other codes on internal errors — in all
  * failure modes we conservatively return false.
  */
-async function isCommitReachableFromHead(
+export async function isCommitReachableFromHead(
 	cwd: string,
 	commitHash: string,
 ): Promise<boolean> {
@@ -454,19 +399,6 @@ export async function handleCheckPrStatus(
 			? (summaryBranch ?? currentBranch)
 			: currentBranch;
 
-		// Commit-count check: only relevant for the current working branch.
-		if (!isCrossBranch) {
-			const commitCount = await getCommitCount(cwd);
-			if (commitCount > 1) {
-				postMessage({
-					command: "prStatus",
-					status: "multipleCommits",
-					count: commitCount,
-				});
-				return;
-			}
-		}
-
 		// Check gh availability — distinguish "not installed" (definitive) from
 		// transient spawn errors so the user gets an actionable message.
 		const availability = await checkGhInstalled(cwd);
@@ -588,29 +520,32 @@ export async function handleCreatePr(
 
 /**
  * Prepares the Update PR form by fetching the current PR data,
- * replacing the marker region with the latest summary, and sending
- * the pre-filled title + body to the webview.
+ * replacing the marker region with the caller-provided markdown, and
+ * sending the pre-filled title + body to the webview.
  *
- * The branch is read directly from `summary.branch` — no separate parameter
- * needed, avoiding drift between the summary object and a loose branch arg.
+ * The caller is responsible for assembling `markdown` (single-summary or
+ * branch-aggregated) and for cross-branch detection — so this function
+ * only handles the GitHub-side lookup + marker replacement, keeping its
+ * single-responsibility scope. See `SummaryWebviewPanel.handlePrepareUpdatePr`.
+ *
+ * `summaryBranch` / `summaryCommitHash` are passed through to mirror the
+ * branch-resolution logic in `handleCheckPrStatus` (cross-branch falls back
+ * to `summaryBranch`; normal case uses the current branch).
  */
 export async function handlePrepareUpdatePr(
-	summary: CommitSummary,
+	summaryBranch: string | undefined,
+	summaryCommitHash: string | undefined,
+	markdown: string,
 	cwd: string,
 	postMessage: PostMessageFn,
-	buildMarkdownFn: (s: CommitSummary) => string,
 ): Promise<void> {
 	try {
-		// Same lookup strategy as handleCheckPrStatus — see the Cross-branch
-		// section above. Normal case: use current branch so the pre-filled
-		// edit form targets the PR that was just created.
-		const isCrossBranch = !(await isCommitReachableFromHead(
-			cwd,
-			summary.commitHash,
-		));
+		const isCrossBranch = summaryCommitHash
+			? !(await isCommitReachableFromHead(cwd, summaryCommitHash))
+			: false;
 		const currentBranch = await getCurrentBranch(cwd);
 		const targetBranch = isCrossBranch
-			? (summary.branch ?? currentBranch)
+			? (summaryBranch ?? currentBranch)
 			: currentBranch;
 		const pr = await findPrForBranch(cwd, targetBranch);
 		if (!pr) {
@@ -620,7 +555,6 @@ export async function handlePrepareUpdatePr(
 			return;
 		}
 
-		const markdown = buildMarkdownFn(summary);
 		const newBody = replaceSummaryInBody(pr.body || "", markdown);
 
 		postMessage({
@@ -878,12 +812,7 @@ export function buildPrMessageScript(): string {
       prCurrentState = s;
       prHide(prForm);
 
-      if (s === 'multipleCommits') {
-        prStatusText.textContent = 'Branch has ' + msg.count + ' commits. Please squash into a single commit before creating or updating a PR.';
-        prShow(prStatusText);
-        prHide(prLinkRow);
-        prHide(prActions);
-      } else if (s === 'notInstalled') {
+      if (s === 'notInstalled') {
         prStatusText.textContent = 'GitHub CLI (gh) is not installed. Install it from https://cli.github.com/ and reload the window.';
         prShow(prStatusText);
         prHide(prLinkRow);

--- a/vscode/src/stores/CommitsStore.ts
+++ b/vscode/src/stores/CommitsStore.ts
@@ -80,6 +80,19 @@ export class CommitsStore extends BaseStore<
 		this.rebuildSnapshot("mainBranch");
 	}
 
+	/**
+	 * Returns the configured main branch name (default `"main"`).
+	 *
+	 * Public read access for callers that need the same baseline the store
+	 * uses for `bridge.listBranchCommits` — e.g. `SummaryWebviewPanel` when
+	 * loading branch summaries to assemble a multi-commit PR body. Kept as a
+	 * getter (rather than exposing the field) so a future `setMainBranch`
+	 * caller wiring config-driven values doesn't change the read API.
+	 */
+	getMainBranch(): string {
+		return this.mainBranch;
+	}
+
 	// ── Reads ─────────────────────────────────────────────────────────────────
 
 	/** File list for a commit (promise-cached to dedupe concurrent expands). */

--- a/vscode/src/views/BranchSummaryLoader.test.ts
+++ b/vscode/src/views/BranchSummaryLoader.test.ts
@@ -1,0 +1,234 @@
+import { describe, expect, it, vi } from "vitest";
+import type { CommitSummary } from "../../../cli/src/Types.js";
+import type { JolliMemoryBridge } from "../JolliMemoryBridge.js";
+import type { BranchCommit, BranchCommitsResult } from "../Types.js";
+
+// Logger imports `vscode`; mock both to keep the loader test pure-Node.
+const { warn } = vi.hoisted(() => ({ warn: vi.fn() }));
+vi.mock("vscode", () => ({}));
+vi.mock("../util/Logger.js", () => ({
+	log: { warn, info: vi.fn(), debug: vi.fn(), error: vi.fn() },
+}));
+
+import { loadBranchSummaries } from "./BranchSummaryLoader.js";
+
+function makeCommit(hash: string, message = `msg-${hash}`): BranchCommit {
+	return {
+		hash,
+		shortHash: hash.substring(0, 7),
+		message,
+		author: "tester",
+		authorEmail: "t@t",
+		date: "2026-05-06T00:00:00Z",
+		shortDate: "05-06",
+		topicCount: 0,
+		insertions: 0,
+		deletions: 0,
+		filesChanged: 0,
+		isPushed: false,
+		hasSummary: true,
+	};
+}
+
+function makeSummary(hash: string, message?: string): CommitSummary {
+	return {
+		commitHash: hash,
+		commitMessage: message ?? `summary-of-${hash}`,
+		commitAuthor: "tester",
+		commitAuthorEmail: "t@t",
+		commitDate: "2026-05-06T00:00:00Z",
+		branch: "feature/x",
+	} as unknown as CommitSummary;
+}
+
+interface MockBridgeOptions {
+	commits: ReadonlyArray<BranchCommit>;
+	summaryByHash: Record<string, CommitSummary | null>;
+}
+
+function makeBridge(opts: MockBridgeOptions): JolliMemoryBridge {
+	const result: BranchCommitsResult = {
+		commits: opts.commits,
+		isMerged: false,
+	};
+	const listBranchCommits = vi.fn().mockResolvedValue(result);
+	const getSummary = vi.fn(async (hash: string) => {
+		return opts.summaryByHash[hash] ?? null;
+	});
+	return {
+		listBranchCommits,
+		getSummary,
+	} as unknown as JolliMemoryBridge;
+}
+
+describe("loadBranchSummaries", () => {
+	it("returns all summaries chronologically (oldest first) when every commit is summarized", async () => {
+		// listBranchCommits emits newest-first: [C, B, A]
+		const bridge = makeBridge({
+			commits: [makeCommit("CCCC"), makeCommit("BBBB"), makeCommit("AAAA")],
+			summaryByHash: {
+				CCCC: makeSummary("CCCC"),
+				BBBB: makeSummary("BBBB"),
+				AAAA: makeSummary("AAAA"),
+			},
+		});
+
+		const result = await loadBranchSummaries(bridge, "main");
+
+		expect(result.missingCount).toBe(0);
+		expect(result.summaries.map((s) => s.commitHash)).toEqual([
+			"AAAA",
+			"BBBB",
+			"CCCC",
+		]);
+	});
+
+	it("counts and skips commits without a recorded summary", async () => {
+		// 5 commits newest-first; B and D return null
+		const bridge = makeBridge({
+			commits: [
+				makeCommit("EEEE"),
+				makeCommit("DDDD"),
+				makeCommit("CCCC"),
+				makeCommit("BBBB"),
+				makeCommit("AAAA"),
+			],
+			summaryByHash: {
+				EEEE: makeSummary("EEEE"),
+				DDDD: null,
+				CCCC: makeSummary("CCCC"),
+				BBBB: null,
+				AAAA: makeSummary("AAAA"),
+			},
+		});
+
+		const result = await loadBranchSummaries(bridge, "main");
+
+		expect(result.missingCount).toBe(2);
+		expect(result.summaries.map((s) => s.commitHash)).toEqual([
+			"AAAA",
+			"CCCC",
+			"EEEE",
+		]);
+	});
+
+	it("counts every commit as missing when none has a summary", async () => {
+		const bridge = makeBridge({
+			commits: [makeCommit("BBBB"), makeCommit("AAAA")],
+			summaryByHash: { BBBB: null, AAAA: null },
+		});
+
+		const result = await loadBranchSummaries(bridge, "main");
+
+		expect(result.summaries).toEqual([]);
+		expect(result.missingCount).toBe(2);
+	});
+
+	it("returns empty result when the branch has no commits ahead of base", async () => {
+		const bridge = makeBridge({
+			commits: [],
+			summaryByHash: {},
+		});
+
+		const result = await loadBranchSummaries(bridge, "main");
+
+		expect(result).toEqual({ summaries: [], missingCount: 0 });
+	});
+
+	it("calls bridge.getSummary (not the CLI directly) — verified by mock invocation", async () => {
+		const summaryAaaa = makeSummary("AAAA");
+		const bridge = makeBridge({
+			commits: [makeCommit("AAAA")],
+			summaryByHash: { AAAA: summaryAaaa },
+		});
+
+		await loadBranchSummaries(bridge, "main");
+
+		// listBranchCommits called once with mainBranch arg
+		expect(bridge.listBranchCommits).toHaveBeenCalledTimes(1);
+		expect(bridge.listBranchCommits).toHaveBeenCalledWith("main");
+		// getSummary called per commit hash, going through the bridge wrapper
+		expect(bridge.getSummary).toHaveBeenCalledTimes(1);
+		expect(bridge.getSummary).toHaveBeenCalledWith("AAAA");
+	});
+
+	it("coerces non-Error rejection reasons to string when warn-logging", async () => {
+		// `r.reason instanceof Error` is the false branch when getSummary rejects
+		// with a plain string / number / object — the loader has to coerce.
+		const bridge = {
+			listBranchCommits: vi.fn().mockResolvedValue({
+				commits: [makeCommit("AAAA")],
+				isMerged: false,
+			}),
+			getSummary: vi.fn(async () => {
+				throw "plain-string-reason"; // not an Error instance
+			}),
+		} as unknown as JolliMemoryBridge;
+
+		const result = await loadBranchSummaries(bridge, "main");
+
+		expect(result.missingCount).toBe(1);
+		expect(warn).toHaveBeenCalledWith(
+			expect.any(String),
+			expect.stringContaining("plain-string-reason"),
+		);
+	});
+
+	it("counts a rejected getSummary as missing (Promise.allSettled, not Promise.all)", async () => {
+		// If the loader used Promise.all, one rejection would reject the whole
+		// load and freeze the WebView's "Loading..." button. allSettled lets
+		// transient `bridge.getSummary` failures (corrupt orphan ref, git flake)
+		// degrade gracefully into "missing" entries with a warn-log breadcrumb.
+		const bridge = {
+			listBranchCommits: vi.fn().mockResolvedValue({
+				commits: [makeCommit("BBBB"), makeCommit("AAAA")],
+				isMerged: false,
+			}),
+			getSummary: vi.fn(async (hash: string) => {
+				if (hash === "BBBB") {
+					throw new Error("simulated transient git failure");
+				}
+				return makeSummary(hash);
+			}),
+		} as unknown as JolliMemoryBridge;
+
+		const result = await loadBranchSummaries(bridge, "main");
+
+		expect(result.missingCount).toBe(1);
+		expect(result.summaries.map((s) => s.commitHash)).toEqual(["AAAA"]);
+		expect(warn).toHaveBeenCalledWith(
+			expect.any(String),
+			expect.stringContaining("simulated transient git failure"),
+		);
+	});
+
+	it("preserves chronological order even when getSummary resolves out of order", async () => {
+		// Make getSummary resolve in reverse order to prove the loader reorders
+		// based on the listBranchCommits sequence, not the resolution sequence.
+		let resolveD!: (s: CommitSummary | null) => void;
+		const dPromise = new Promise<CommitSummary | null>((r) => {
+			resolveD = r;
+		});
+		const bridge = {
+			listBranchCommits: vi.fn().mockResolvedValue({
+				commits: [makeCommit("DDDD"), makeCommit("CCCC"), makeCommit("AAAA")],
+				isMerged: false,
+			}),
+			getSummary: vi.fn(async (hash: string) => {
+				if (hash === "DDDD") return dPromise;
+				return makeSummary(hash);
+			}),
+		} as unknown as JolliMemoryBridge;
+
+		const promise = loadBranchSummaries(bridge, "main");
+		// Resolve DDDD last
+		setTimeout(() => resolveD(makeSummary("DDDD")), 0);
+		const result = await promise;
+
+		expect(result.summaries.map((s) => s.commitHash)).toEqual([
+			"AAAA",
+			"CCCC",
+			"DDDD",
+		]);
+	});
+});

--- a/vscode/src/views/BranchSummaryLoader.ts
+++ b/vscode/src/views/BranchSummaryLoader.ts
@@ -1,0 +1,65 @@
+/**
+ * BranchSummaryLoader
+ *
+ * Enumerates `CommitSummary` objects for `base..HEAD` in chronological
+ * (oldest-first) order via `bridge.getSummary(hash)`, so the lookup passes
+ * through the bridge's lazy `StorageProvider` instead of the CLI's
+ * standalone `getSummary` (which would bypass storage-backend selection).
+ */
+
+import type { CommitSummary } from "../../../cli/src/Types.js";
+import type { JolliMemoryBridge } from "../JolliMemoryBridge.js";
+import { log } from "../util/Logger.js";
+
+const TAG = "BranchSummaryLoader";
+
+export interface BranchSummariesResult {
+	/** Summaries on `base..HEAD`, ordered chronologically (oldest first; HEAD last). */
+	readonly summaries: ReadonlyArray<CommitSummary>;
+	/** Number of commits on the branch with no recorded summary (skipped). */
+	readonly missingCount: number;
+}
+
+/**
+ * `Promise.allSettled` so a transient `bridge.getSummary` failure (corrupt
+ * orphan ref, `git show` flake) degrades to a "missing" entry with a warn
+ * log instead of rejecting the whole load and freezing the WebView's
+ * "Loading..." button.
+ */
+export async function loadBranchSummaries(
+	bridge: JolliMemoryBridge,
+	mainBranch: string,
+): Promise<BranchSummariesResult> {
+	const { commits } = await bridge.listBranchCommits(mainBranch);
+	if (commits.length === 0) {
+		return { summaries: [], missingCount: 0 };
+	}
+
+	// listBranchCommits returns newest-first; reverse for chronological order
+	// so the body reads as a story (first commit at the top).
+	const chronological = commits.slice().reverse();
+	const settled = await Promise.allSettled(
+		chronological.map((c) => bridge.getSummary(c.hash)),
+	);
+
+	const summaries: Array<CommitSummary> = [];
+	let missingCount = 0;
+	for (let i = 0; i < settled.length; i++) {
+		const r = settled[i];
+		if (r.status === "fulfilled" && r.value) {
+			summaries.push(r.value);
+			continue;
+		}
+		if (r.status === "rejected") {
+			const reason =
+				r.reason instanceof Error ? r.reason.message : String(r.reason);
+			log.warn(
+				TAG,
+				`getSummary failed for ${chronological[i].hash.substring(0, 7)}: ${reason}`,
+			);
+		}
+		missingCount++;
+	}
+
+	return { summaries, missingCount };
+}

--- a/vscode/src/views/SettingsWebviewPanel.test.ts
+++ b/vscode/src/views/SettingsWebviewPanel.test.ts
@@ -1326,8 +1326,7 @@ describe("SettingsWebviewPanel", () => {
 
 			expect(logError).toHaveBeenCalledWith(
 				"SettingsPanel",
-				"Failed to sync Claude hook for %s: %s",
-				"/workspace",
+				"Failed to sync Claude hook for /workspace",
 				expect.any(Error),
 			);
 			expect(mockInstallGeminiHook).toHaveBeenCalledWith("/workspace");
@@ -1362,8 +1361,7 @@ describe("SettingsWebviewPanel", () => {
 
 			expect(logError).toHaveBeenCalledWith(
 				"SettingsPanel",
-				"Failed to sync Claude hook for %s: %s",
-				"/workspace",
+				"Failed to sync Claude hook for /workspace",
 				expect.any(Error),
 			);
 			expect(mockInstallGeminiHook).toHaveBeenCalledWith("/workspace");
@@ -1397,8 +1395,7 @@ describe("SettingsWebviewPanel", () => {
 
 			expect(logError).toHaveBeenCalledWith(
 				"SettingsPanel",
-				"Failed to sync Gemini hook for %s: %s",
-				"/workspace",
+				"Failed to sync Gemini hook for /workspace",
 				expect.any(Error),
 			);
 			expect(mockInstallClaudeHook).toHaveBeenCalledWith("/workspace");
@@ -1432,8 +1429,7 @@ describe("SettingsWebviewPanel", () => {
 
 			expect(logError).toHaveBeenCalledWith(
 				"SettingsPanel",
-				"Failed to sync Gemini hook for %s: %s",
-				"/workspace",
+				"Failed to sync Gemini hook for /workspace",
 				expect.any(Error),
 			);
 			expect(mockInstallClaudeHook).toHaveBeenCalledWith("/workspace");

--- a/vscode/src/views/SettingsWebviewPanel.ts
+++ b/vscode/src/views/SettingsWebviewPanel.ts
@@ -381,12 +381,7 @@ export class SettingsWebviewPanel {
 					await removeClaudeHook(wt);
 				}
 			} catch (err: unknown) {
-				log.error(
-					"SettingsPanel",
-					"Failed to sync Claude hook for %s: %s",
-					wt,
-					err,
-				);
+				log.error("SettingsPanel", `Failed to sync Claude hook for ${wt}`, err);
 				failures.push({ integration: "Claude", worktree: wt, cause: err });
 			}
 
@@ -397,12 +392,7 @@ export class SettingsWebviewPanel {
 					await removeGeminiHook(wt);
 				}
 			} catch (err: unknown) {
-				log.error(
-					"SettingsPanel",
-					"Failed to sync Gemini hook for %s: %s",
-					wt,
-					err,
-				);
+				log.error("SettingsPanel", `Failed to sync Gemini hook for ${wt}`, err);
 				failures.push({ integration: "Gemini", worktree: wt, cause: err });
 			}
 		}

--- a/vscode/src/views/SidebarScriptBuilder.test.ts
+++ b/vscode/src/views/SidebarScriptBuilder.test.ts
@@ -654,6 +654,20 @@ describe("SidebarScriptBuilder", () => {
 			expect(js).toMatch(/iconButton\('commits-push-branch',/);
 		});
 
+		it("multi mode toolbar includes pushBranch alongside select-all and squash", () => {
+			// Multi-commit branches now support push directly (no squash precondition).
+			// Assert the multi branch in the rendered JS contains all three button ids.
+			const js = buildSidebarScript();
+			const multiMatch = js.match(
+				/if \(m === 'multi'\)[\s\S]*?return \[([\s\S]*?)\];/,
+			);
+			expect(multiMatch).not.toBeNull();
+			const multiArr = multiMatch?.[1] ?? "";
+			expect(multiArr).toMatch(/iconButton\('commits-select-all',/);
+			expect(multiArr).toMatch(/iconButton\('commits-squash',/);
+			expect(multiArr).toMatch(/iconButton\('commits-push-branch',/);
+		});
+
 		it("uses codicons matching package.json contributes (check-all / git-merge / cloud-upload)", () => {
 			const js = buildSidebarScript();
 			// `[,)]` accepts either a closing paren (no opts arg) or a comma

--- a/vscode/src/views/SidebarScriptBuilder.ts
+++ b/vscode/src/views/SidebarScriptBuilder.ts
@@ -1384,12 +1384,16 @@ export function buildSidebarScript(): string {
         // button below that threshold; it auto-re-enables when the user picks
         // a 2nd commit because branch:commitsData triggers renderBranch which
         // rebuilds these section actions with a fresh selectedCount.
+        // Push Branch is also exposed in multi mode now that PushCommand
+        // supports any commit count >= 1 — squashing remains a user choice,
+        // not a precondition.
         const selectedCount = branchData.commits.filter(function(c) {
           return !!c.isSelected;
         }).length;
         return [
           iconButton('commits-select-all', 'Select/Deselect All Commits', 'check-all'),
           iconButton('commits-squash',     'Squash Selected',             'git-merge', { disabled: selectedCount < 2 }),
+          iconButton('commits-push-branch', 'Push Branch',                'cloud-upload'),
         ];
       }
       if (m === 'single') {

--- a/vscode/src/views/SidebarWebviewProvider.test.ts
+++ b/vscode/src/views/SidebarWebviewProvider.test.ts
@@ -1222,10 +1222,7 @@ describe("SidebarWebviewProvider", () => {
 				detached: false,
 			}),
 			extensionUri: mockExtensionUri as unknown as never,
-			historyProvider: historyProvider as unknown as {
-				serialize(): Promise<ReadonlyArray<unknown>>;
-				onDidChangeTreeData: (cb: () => void) => { dispose: () => void };
-			},
+			historyProvider: historyProvider as never,
 		});
 		provider.resolveWebviewView(view as unknown as never);
 		view.webview.triggerMessage({ type: "ready" });

--- a/vscode/src/views/SummaryHtmlBuilder.test.ts
+++ b/vscode/src/views/SummaryHtmlBuilder.test.ts
@@ -49,10 +49,15 @@ const {
 	renderCalloutText,
 	timeAgo,
 } = vi.hoisted(() => ({
-	collectSortedTopics: vi.fn(() => ({
-		topics: [],
-		sourceNodes: [],
-	})),
+	collectSortedTopics: vi.fn(
+		(): {
+			topics: Array<unknown>;
+			sourceNodes: Array<unknown>;
+		} => ({
+			topics: [],
+			sourceNodes: [],
+		}),
+	),
 	escAttr: vi.fn((s: string) => s),
 	escHtml: vi.fn((s: string) => s),
 	formatDate: vi.fn(() => "Jan 1, 2026"),

--- a/vscode/src/views/SummaryMarkdownBuilder.test.ts
+++ b/vscode/src/views/SummaryMarkdownBuilder.test.ts
@@ -80,7 +80,6 @@ function makeTopic(overrides: Partial<TopicWithDate> = {}): TopicWithDate {
 		todo: "Add metrics for retry counts.",
 		filesAffected: ["src/auth/Login.ts", "src/auth/Retry.ts"],
 		category: "bugfix",
-		recordDate: "2026-03-30T10:00:00Z",
 		importance: "major",
 		commitDate: "2026-03-30T10:00:00Z",
 		treeIndex: 0,

--- a/vscode/src/views/SummaryPrAggregateMarkdownBuilder.test.ts
+++ b/vscode/src/views/SummaryPrAggregateMarkdownBuilder.test.ts
@@ -1,0 +1,684 @@
+/**
+ * SummaryPrAggregateMarkdownBuilder tests
+ *
+ * Builds aggregated PR markdown for multi-summary branches. Uses the real
+ * single-summary helpers (`SummaryPrMarkdownBuilder`, `SummaryMarkdownBuilder`)
+ * — only the core SummaryFormat helpers (`collectSortedTopics`, `padIndex`,
+ * `formatFullDate`, `getDisplayDate`) are mocked, matching the pattern used
+ * by `SummaryPrMarkdownBuilder.test.ts`.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type {
+	CommitSummary,
+	E2eTestScenario,
+	NoteReference,
+	PlanReference,
+	TopicSummary,
+} from "../../../cli/src/Types.js";
+
+const mocks = vi.hoisted(() => ({
+	collectSortedTopics: vi.fn(),
+	formatFullDate: vi.fn(() => "2026-05-06 00:00:00 UTC"),
+	getDisplayDate: vi.fn(
+		(e: { generatedAt?: string; commitDate: string }) =>
+			e.generatedAt || e.commitDate,
+	),
+	padIndex: vi.fn((i: number) => String(i + 1).padStart(2, "0")),
+	formatDate: vi.fn(),
+	aggregateStats: vi.fn(),
+	aggregateTurns: vi.fn(),
+	formatDurationLabel: vi.fn(),
+	resolveDiffStats: vi.fn(),
+}));
+
+vi.mock("../../../cli/src/core/SummaryFormat.js", () => ({
+	collectSortedTopics: mocks.collectSortedTopics,
+	formatFullDate: mocks.formatFullDate,
+	getDisplayDate: mocks.getDisplayDate,
+	padIndex: mocks.padIndex,
+	formatDate: mocks.formatDate,
+}));
+
+vi.mock("../../../cli/src/core/SummaryTree.js", () => ({
+	aggregateStats: mocks.aggregateStats,
+	aggregateTurns: mocks.aggregateTurns,
+	formatDurationLabel: mocks.formatDurationLabel,
+	resolveDiffStats: mocks.resolveDiffStats,
+}));
+
+import { buildAggregatedPrMarkdown } from "./SummaryPrAggregateMarkdownBuilder.js";
+
+// ─── Fixtures ──────────────────────────────────────────────────────────────
+
+interface SummaryOpts {
+	hash: string;
+	message?: string;
+	recap?: string;
+	jolliDocUrl?: string;
+	plans?: ReadonlyArray<PlanReference>;
+	notes?: ReadonlyArray<NoteReference>;
+	e2eTestGuide?: ReadonlyArray<E2eTestScenario>;
+	topics?: ReadonlyArray<TopicSummary>;
+}
+
+function makeSummary(opts: SummaryOpts): CommitSummary {
+	return {
+		version: 3,
+		commitHash: opts.hash,
+		commitMessage: opts.message ?? `commit-${opts.hash.substring(0, 7)}`,
+		commitAuthor: "tester",
+		commitDate: "2026-05-06T00:00:00Z",
+		generatedAt: "2026-05-06T00:00:00Z",
+		branch: "feature/x",
+		stats: { filesChanged: 1, insertions: 1, deletions: 0 },
+		recap: opts.recap,
+		jolliDocUrl: opts.jolliDocUrl,
+		plans: opts.plans,
+		notes: opts.notes,
+		e2eTestGuide: opts.e2eTestGuide,
+		topics: opts.topics,
+	} as unknown as CommitSummary;
+}
+
+function makeTopic(overrides: Partial<TopicSummary> = {}): TopicSummary {
+	return {
+		title: "Topic title",
+		trigger: "Trigger text",
+		response: "Response text",
+		decisions: "Decisions text",
+		todo: "Todo text",
+		filesAffected: ["src/file.ts"],
+		category: "feature",
+		importance: "major",
+		...overrides,
+	};
+}
+
+function makeScenario(
+	overrides: Partial<E2eTestScenario> = {},
+): E2eTestScenario {
+	return {
+		title: "Scenario title",
+		preconditions: "Preconditions text",
+		steps: ["Step one", "Step two"],
+		expectedResults: ["Expect one"],
+		...overrides,
+	};
+}
+
+beforeEach(() => {
+	// Default: no topics in any summary unless test overrides.
+	mocks.collectSortedTopics.mockReturnValue({ topics: [], sourceNodes: [] });
+});
+
+afterEach(() => {
+	vi.clearAllMocks();
+});
+
+// ─── Tests ─────────────────────────────────────────────────────────────────
+
+describe("buildAggregatedPrMarkdown", () => {
+	it("throws when summaries.length < 2 (precondition for caller routing)", () => {
+		expect(() =>
+			buildAggregatedPrMarkdown([makeSummary({ hash: "AAAA1234" })], 0),
+		).toThrow(/summaries.length >= 2/);
+		expect(() => buildAggregatedPrMarkdown([], 0)).toThrow(
+			/summaries.length >= 2/,
+		);
+	});
+
+	it("renders top directory header as (M) when missingCount === 0", () => {
+		const summaries = [
+			makeSummary({ hash: "AAAA1234", message: "feat: add X" }),
+			makeSummary({ hash: "BBBB5678", message: "fix: handle Y" }),
+		];
+		const md = buildAggregatedPrMarkdown(summaries, 0);
+		expect(md).toContain("## Commits in this PR (2)");
+		expect(md).not.toContain("of");
+		expect(md).toMatch(/1\. feat: add X \(`AAAA123`\)/);
+		expect(md).toMatch(/2\. fix: handle Y \(`BBBB567`\)/);
+	});
+
+	it("renders top directory header as (M of N) when missingCount > 0", () => {
+		const summaries = [
+			makeSummary({ hash: "AAAA1234" }),
+			makeSummary({ hash: "BBBB5678" }),
+			makeSummary({ hash: "CCCC9012" }),
+		];
+		const md = buildAggregatedPrMarkdown(summaries, 2);
+		expect(md).toContain("## Commits in this PR (3 of 5)");
+		expect(md).toContain("> Note: 2 commit(s) without summary were skipped.");
+	});
+
+	it("appends [Memory](url) link when jolliDocUrl is set; omits otherwise", () => {
+		const summaries = [
+			makeSummary({
+				hash: "AAAA1234",
+				message: "with url",
+				jolliDocUrl: "https://jolli.example/articles?doc=1",
+			}),
+			makeSummary({ hash: "BBBB5678", message: "no url" }),
+		];
+		const md = buildAggregatedPrMarkdown(summaries, 0);
+		expect(md).toContain(
+			"1. with url (`AAAA123`) — [Memory](https://jolli.example/articles?doc=1)",
+		);
+		expect(md).toContain("2. no url (`BBBB567`)");
+		// No spurious — [Memory]( on the no-url line.
+		expect(md).not.toMatch(/no url \(`BBBB567`\) — \[Memory\]/);
+	});
+
+	it("dedupes plans across commits using jolliPlanDocUrl ?? slug:<slug>", () => {
+		// Same plan referenced by two commits; one entry has URL, one doesn't.
+		// Both should dedupe via the slug fallback because URL key differs.
+		const planA1: PlanReference = {
+			slug: "feature-a",
+			title: "Feature A",
+			editCount: 3,
+			addedAt: "2026-05-01T00:00:00Z",
+			updatedAt: "2026-05-02T00:00:00Z",
+			jolliPlanDocUrl: "https://jolli.example/articles?doc=10",
+		};
+		// Note: A2 has the SAME slug+URL → duplicates by URL.
+		const planA2: PlanReference = { ...planA1 };
+		// planB is a separate plan entirely.
+		const planB: PlanReference = {
+			slug: "feature-b",
+			title: "Feature B",
+			editCount: 1,
+			addedAt: "2026-05-03T00:00:00Z",
+			updatedAt: "2026-05-03T00:00:00Z",
+		};
+		const summaries = [
+			makeSummary({ hash: "AAAA1234", plans: [planA1, planB] }),
+			makeSummary({ hash: "BBBB5678", plans: [planA2] }),
+		];
+		const md = buildAggregatedPrMarkdown(summaries, 0);
+		// Plans & Notes header includes total count = 2 (deduped)
+		expect(md).toContain("## Plans & Notes (2)");
+		// Only one entry per dedup key
+		expect(md.match(/Feature A/g)?.length).toBe(1);
+		expect(md.match(/Feature B/g)?.length).toBe(1);
+	});
+
+	it("dedupes plans by slug when neither has a URL", () => {
+		const draftA1: PlanReference = {
+			slug: "draft-x",
+			title: "Draft X",
+			editCount: 1,
+			addedAt: "2026-05-01T00:00:00Z",
+			updatedAt: "2026-05-01T00:00:00Z",
+		};
+		const draftA2: PlanReference = { ...draftA1, editCount: 2 }; // same slug, no URL
+		const summaries = [
+			makeSummary({ hash: "AAAA1234", plans: [draftA1] }),
+			makeSummary({ hash: "BBBB5678", plans: [draftA2] }),
+		];
+		const md = buildAggregatedPrMarkdown(summaries, 0);
+		expect(md.match(/Draft X/g)?.length).toBe(1);
+	});
+
+	it("dedupes notes by jolliNoteDocUrl ?? id:<id>", () => {
+		const noteA1: NoteReference = {
+			id: "note-1",
+			title: "Note 1",
+			format: "markdown",
+			addedAt: "2026-05-01T00:00:00Z",
+			updatedAt: "2026-05-01T00:00:00Z",
+			jolliNoteDocUrl: "https://jolli.example/articles?doc=20",
+		};
+		const noteA2: NoteReference = { ...noteA1 }; // same URL → dedup
+		const noteB: NoteReference = {
+			id: "note-2",
+			title: "Note 2",
+			format: "markdown",
+			addedAt: "2026-05-01T00:00:00Z",
+			updatedAt: "2026-05-01T00:00:00Z",
+		};
+		const summaries = [
+			makeSummary({ hash: "AAAA1234", notes: [noteA1, noteB] }),
+			makeSummary({ hash: "BBBB5678", notes: [noteA2] }),
+		];
+		const md = buildAggregatedPrMarkdown(summaries, 0);
+		expect(md.match(/Note 1/g)?.length).toBe(1);
+		expect(md.match(/Note 2/g)?.length).toBe(1);
+	});
+
+	it("emits Quick recap blocks only for commits with non-empty recap, header carries the (N) count", () => {
+		const summaries = [
+			makeSummary({
+				hash: "AAAA1234",
+				message: "first",
+				recap: "First recap content.",
+			}),
+			makeSummary({ hash: "BBBB5678", message: "second" }), // no recap
+			makeSummary({
+				hash: "CCCC9012",
+				message: "third",
+				recap: "Third recap content.",
+			}),
+		];
+		const md = buildAggregatedPrMarkdown(summaries, 0);
+		// Header matches single-summary "## Quick recap" + (N) count style.
+		expect(md).toContain("## Quick recap (2)");
+		expect(md).not.toContain("## Per-Commit Recap");
+		expect(md).toContain("### Commit 1 of 3: first (`AAAA123`)");
+		expect(md).toContain("First recap content.");
+		expect(md).not.toContain("### Commit 2 of 3:");
+		expect(md).toContain("### Commit 3 of 3: third (`CCCC901`)");
+		expect(md).toContain("Third recap content.");
+	});
+
+	it("omits Quick recap section entirely when no commit has a recap", () => {
+		const summaries = [
+			makeSummary({ hash: "AAAA1234" }),
+			makeSummary({ hash: "BBBB5678" }),
+		];
+		const md = buildAggregatedPrMarkdown(summaries, 0);
+		expect(md).not.toContain("## Quick recap");
+		expect(md).not.toContain("## Per-Commit Recap");
+	});
+
+	it("flattens E2E scenarios across commits with [shortHash] prefix", () => {
+		const summaries = [
+			makeSummary({
+				hash: "AAAA1234",
+				e2eTestGuide: [
+					makeScenario({ title: "Login flow" }),
+					makeScenario({ title: "Logout flow" }),
+				],
+			}),
+			makeSummary({
+				hash: "BBBB5678",
+				e2eTestGuide: [makeScenario({ title: "Session expiry" })],
+			}),
+		];
+		const md = buildAggregatedPrMarkdown(summaries, 0);
+		expect(md).toContain("## E2E Test (3)");
+		expect(md).toContain("1. [AAAA123] Login flow");
+		expect(md).toContain("2. [AAAA123] Logout flow");
+		expect(md).toContain("3. [BBBB567] Session expiry");
+	});
+
+	it("omits E2E section when no commit has scenarios", () => {
+		const summaries = [
+			makeSummary({ hash: "AAAA1234" }),
+			makeSummary({ hash: "BBBB5678" }),
+		];
+		const md = buildAggregatedPrMarkdown(summaries, 0);
+		expect(md).not.toContain("## E2E Test");
+	});
+
+	it("flattens topics across commits with [shortHash] prefix using padIndex", () => {
+		const sA = makeSummary({ hash: "AAAA1234" });
+		const sB = makeSummary({ hash: "BBBB5678" });
+		// collectSortedTopics is mocked: return per-summary topics in insertion order
+		mocks.collectSortedTopics.mockImplementation((s: CommitSummary) => {
+			if (s.commitHash === "AAAA1234") {
+				return {
+					topics: [makeTopic({ title: "T-A1" }), makeTopic({ title: "T-A2" })],
+					sourceNodes: [],
+				};
+			}
+			return {
+				topics: [makeTopic({ title: "T-B1" })],
+				sourceNodes: [],
+			};
+		});
+		const md = buildAggregatedPrMarkdown([sA, sB], 0);
+		expect(md).toContain("## Topics (3)");
+		// padIndex mock returns 01, 02, 03
+		expect(md).toContain("01 · [AAAA123] T-A1");
+		expect(md).toContain("02 · [AAAA123] T-A2");
+		expect(md).toContain("03 · [BBBB567] T-B1");
+	});
+
+	it("uses 'Topic' (singular) header when exactly 1 topic across all commits", () => {
+		mocks.collectSortedTopics.mockImplementation((s: CommitSummary) => {
+			if (s.commitHash === "AAAA1234") {
+				return {
+					topics: [makeTopic({ title: "Only topic" })],
+					sourceNodes: [],
+				};
+			}
+			return { topics: [], sourceNodes: [] };
+		});
+		const md = buildAggregatedPrMarkdown(
+			[makeSummary({ hash: "AAAA1234" }), makeSummary({ hash: "BBBB5678" })],
+			0,
+		);
+		expect(md).toContain("## Topic (1)");
+		expect(md).not.toContain("## Topics");
+	});
+
+	it("preserves intra-commit topic order under chronological commit order", () => {
+		mocks.collectSortedTopics.mockImplementation((s: CommitSummary) => {
+			if (s.commitHash === "AAAA1234") {
+				return {
+					topics: [makeTopic({ title: "T-1" }), makeTopic({ title: "T-2" })],
+					sourceNodes: [],
+				};
+			}
+			return {
+				topics: [makeTopic({ title: "T-3" }), makeTopic({ title: "T-4" })],
+				sourceNodes: [],
+			};
+		});
+		const md = buildAggregatedPrMarkdown(
+			[makeSummary({ hash: "AAAA1234" }), makeSummary({ hash: "BBBB5678" })],
+			0,
+		);
+		const idxT1 = md.indexOf("T-1");
+		const idxT2 = md.indexOf("T-2");
+		const idxT3 = md.indexOf("T-3");
+		const idxT4 = md.indexOf("T-4");
+		expect(idxT1).toBeLessThan(idxT2);
+		expect(idxT2).toBeLessThan(idxT3);
+		expect(idxT3).toBeLessThan(idxT4);
+	});
+
+	it("appends missing-summary footnote only when missingCount > 0", () => {
+		const summaries = [
+			makeSummary({ hash: "AAAA1234" }),
+			makeSummary({ hash: "BBBB5678" }),
+		];
+		expect(buildAggregatedPrMarkdown(summaries, 0)).not.toContain(
+			"without summary were skipped",
+		);
+		expect(buildAggregatedPrMarkdown(summaries, 1)).toContain(
+			"> Note: 1 commit(s) without summary were skipped.",
+		);
+		expect(buildAggregatedPrMarkdown(summaries, 4)).toContain(
+			"> Note: 4 commit(s) without summary were skipped.",
+		);
+	});
+
+	it("truncates Topics at 65K and emits an omitted footnote", () => {
+		// Build many large topics to force truncation
+		const bigText = "x".repeat(2500);
+		const bigTopics = Array.from({ length: 40 }, (_, i) =>
+			makeTopic({
+				title: `T-${i}`,
+				trigger: bigText,
+				response: bigText,
+				decisions: bigText,
+			}),
+		);
+		mocks.collectSortedTopics.mockImplementation((s: CommitSummary) => {
+			if (s.commitHash === "AAAA1234") {
+				return { topics: bigTopics, sourceNodes: [] };
+			}
+			return { topics: [], sourceNodes: [] };
+		});
+		const md = buildAggregatedPrMarkdown(
+			[makeSummary({ hash: "AAAA1234" }), makeSummary({ hash: "BBBB5678" })],
+			0,
+		);
+		expect(md).toMatch(
+			/> ⚠️ \d+ more topics? omitted due to GitHub PR body size limit\./,
+		);
+		expect(md.length).toBeLessThan(65_500);
+	});
+
+	it("truncates E2E at 60K and emits an omitted footnote", () => {
+		const bigText = "y".repeat(3000);
+		const bigScenarios = Array.from({ length: 30 }, (_, i) =>
+			makeScenario({
+				title: `Sc-${i}`,
+				preconditions: bigText,
+				steps: [bigText, bigText],
+				expectedResults: [bigText],
+			}),
+		);
+		const summaries = [
+			makeSummary({ hash: "AAAA1234", e2eTestGuide: bigScenarios }),
+			makeSummary({ hash: "BBBB5678" }),
+		];
+		const md = buildAggregatedPrMarkdown(summaries, 0);
+		expect(md).toMatch(
+			/> ⚠️ \d+ more scenarios? omitted due to GitHub PR body size limit\./,
+		);
+	});
+
+	it("truncates Per-Commit Recap at 50K and emits an omitted footnote", () => {
+		const bigRecap = "z".repeat(20000);
+		// 5 commits, each with a 20K recap → triggers the 50K soft limit.
+		const summaries = Array.from({ length: 5 }, (_, i) =>
+			makeSummary({
+				hash: `AAAA${String(i).padStart(4, "0")}`,
+				message: `commit-${i}`,
+				recap: bigRecap,
+			}),
+		);
+		const md = buildAggregatedPrMarkdown(summaries, 0);
+		expect(md).toMatch(
+			/> ⚠️ \d+ more commits?'? recap omitted due to GitHub PR body size limit\./,
+		);
+	});
+
+	it("uses singular possessive 'commit's' when exactly one recap is omitted", () => {
+		// Two small recaps fit, then one giant recap pushes past the 50K Recap
+		// soft-limit alone — exactly 1 truncated.
+		const summaries = [
+			makeSummary({ hash: "AAAA1234", recap: "small recap A" }),
+			makeSummary({ hash: "BBBB5678", recap: "small recap B" }),
+			makeSummary({ hash: "CCCC9012", recap: "z".repeat(60000) }),
+		];
+		const md = buildAggregatedPrMarkdown(summaries, 0);
+		expect(md).toContain("1 more commit's recap omitted");
+		// Make sure it's not the plural form.
+		expect(md).not.toMatch(/[02-9] more commits' recap omitted/);
+	});
+
+	it("uses plural possessive 'commits'' when 2+ recaps are omitted", () => {
+		// First recap (~40K) fits; the next two (45K each) push past the 50K
+		// Recap soft-limit, so both are omitted.
+		const summaries = [
+			makeSummary({ hash: "AAAA1234", recap: "z".repeat(40000) }),
+			makeSummary({ hash: "BBBB5678", recap: "z".repeat(45000) }),
+			makeSummary({ hash: "CCCC9012", recap: "z".repeat(45000) }),
+		];
+		const md = buildAggregatedPrMarkdown(summaries, 0);
+		expect(md).toMatch(/2 more commits' recap omitted/);
+		// And none of the singular form should appear.
+		expect(md).not.toContain("commit's recap omitted");
+	});
+
+	it("does not produce adjacent '---' separators when Topics is absent", () => {
+		// Recap + E2E present, Topics absent. Earlier impl emitted trailing '---'
+		// in both Recap and E2E, then footer added another '---', causing
+		// '---\n\n---' adjacency. Layout fix: only footer emits the final rule.
+		const summaries = [
+			makeSummary({
+				hash: "AAAA1234",
+				recap: "first recap",
+				e2eTestGuide: [makeScenario({ title: "S1" })],
+			}),
+			makeSummary({
+				hash: "BBBB5678",
+				recap: "second recap",
+				e2eTestGuide: [makeScenario({ title: "S2" })],
+			}),
+		];
+		const md = buildAggregatedPrMarkdown(summaries, 0);
+		expect(md).not.toMatch(/---\s*\n\s*---/);
+	});
+
+	it("never exceeds GitHub's 65536-char body limit even with markers + missing footnote + maxed sections", () => {
+		// Pile content into all three truncating sections + missingCount > 0
+		// to stress-test the 64500 internal budget against the 65536 hard cap.
+		const bigText = "x".repeat(2500);
+		const bigTopics = Array.from({ length: 60 }, (_, i) =>
+			makeTopic({
+				title: `T-${i}`,
+				trigger: bigText,
+				response: bigText,
+				decisions: bigText,
+			}),
+		);
+		const bigScenarios = Array.from({ length: 30 }, (_, i) =>
+			makeScenario({
+				title: `Sc-${i}`,
+				preconditions: bigText,
+				steps: [bigText, bigText],
+				expectedResults: [bigText],
+			}),
+		);
+		const bigRecap = "z".repeat(15000);
+		mocks.collectSortedTopics.mockImplementation((s: CommitSummary) => {
+			if (s.commitHash === "AAAA1234")
+				return { topics: bigTopics, sourceNodes: [] };
+			return { topics: [], sourceNodes: [] };
+		});
+		const summaries = [
+			makeSummary({
+				hash: "AAAA1234",
+				recap: bigRecap,
+				e2eTestGuide: bigScenarios,
+			}),
+			makeSummary({ hash: "BBBB5678", recap: bigRecap }),
+			makeSummary({ hash: "CCCC9012", recap: bigRecap }),
+		];
+		const md = buildAggregatedPrMarkdown(summaries, 4);
+		// Simulate caller wrapping with markers (adds ~80 chars).
+		const wrapped = `<!-- jollimemory-summary-start -->\n${md}\n<!-- jollimemory-summary-end -->`;
+		expect(wrapped.length).toBeLessThanOrEqual(65536);
+	});
+
+	it("strips backticks from commit messages in the directory header (no triple-backtick injection)", () => {
+		const summaries = [
+			makeSummary({
+				hash: "AAAA1234",
+				message: "fix `foo` and `bar`", // contains backticks
+			}),
+			makeSummary({ hash: "BBBB5678", message: "ok" }),
+		];
+		const md = buildAggregatedPrMarkdown(summaries, 0);
+		// No raw backtick from the message should land in the directory line —
+		// the only backticks on directory lines come from the (`shortHash`)
+		// inline code-span. Verify there's no triple-backtick anywhere.
+		expect(md).not.toContain("```");
+		// And the message text retains the words minus the offending characters.
+		expect(md).toContain("fix foo and bar");
+	});
+
+	it("renders an E2E scenario without preconditions (omits the **Preconditions:** line)", () => {
+		const summaries = [
+			makeSummary({
+				hash: "AAAA1234",
+				e2eTestGuide: [
+					{
+						title: "No-precondition scenario",
+						steps: ["Step 1"],
+						expectedResults: ["Expected"],
+					},
+				],
+			}),
+			makeSummary({ hash: "BBBB5678" }),
+		];
+		const md = buildAggregatedPrMarkdown(summaries, 0);
+		expect(md).toContain("No-precondition scenario");
+		// E2E body should not include the Preconditions header when not provided.
+		// (Other scenarios across other tests do include it.)
+		const e2eBlockMatch = md.match(
+			/\[AAAA123\] No-precondition scenario[\s\S]*?<\/details>/,
+		);
+		expect(e2eBlockMatch).not.toBeNull();
+		expect(e2eBlockMatch?.[0]).not.toContain("**Preconditions:**");
+	});
+
+	it("uses singular 'scenario' (no plural 's') when exactly 1 E2E scenario is omitted", () => {
+		// One small scenario fits; one giant scenario overflows the 60K budget
+		// alone. omitted == 1 deterministically.
+		const tiny = makeScenario({ title: "Tiny" });
+		const giant = makeScenario({
+			title: "Giant",
+			preconditions: "z".repeat(50000),
+			steps: ["z".repeat(20000)],
+			expectedResults: ["z".repeat(20000)],
+		});
+		const summaries = [
+			makeSummary({ hash: "AAAA1234", e2eTestGuide: [tiny, giant] }),
+			makeSummary({ hash: "BBBB5678" }),
+		];
+		const md = buildAggregatedPrMarkdown(summaries, 0);
+		expect(md).toContain("1 more scenario omitted");
+		expect(md).not.toContain("scenarios omitted");
+	});
+
+	it("uses singular 'topic' (no plural 's') when exactly 1 topic is omitted", () => {
+		// One small topic fits; one giant topic overflows alone → omitted=1.
+		const smallTopic = makeTopic({ title: "Tiny" });
+		const giantTrigger = "x".repeat(70000); // alone > PR_BODY_LIMIT
+		const giantTopic = makeTopic({
+			title: "Giant",
+			trigger: giantTrigger,
+			response: giantTrigger,
+			decisions: giantTrigger,
+		});
+		mocks.collectSortedTopics.mockImplementation((s: CommitSummary) => {
+			if (s.commitHash === "AAAA1234") {
+				return { topics: [smallTopic, giantTopic], sourceNodes: [] };
+			}
+			return { topics: [], sourceNodes: [] };
+		});
+		const md = buildAggregatedPrMarkdown(
+			[makeSummary({ hash: "AAAA1234" }), makeSummary({ hash: "BBBB5678" })],
+			0,
+		);
+		expect(md).toContain("1 more topic omitted");
+		expect(md).not.toContain("topics omitted");
+	});
+
+	it("does not strip backticks from non-directory sections (recap rendering preserves them)", () => {
+		const summaries = [
+			makeSummary({
+				hash: "AAAA1234",
+				message: "ok msg",
+				recap: "Use the `foo()` API to bar.",
+			}),
+			makeSummary({ hash: "BBBB5678", message: "ok msg2" }),
+		];
+		const md = buildAggregatedPrMarkdown(summaries, 0);
+		expect(md).toContain("Use the `foo()` API to bar.");
+	});
+
+	it("ends with the standard footer", () => {
+		const md = buildAggregatedPrMarkdown(
+			[makeSummary({ hash: "AAAA1234" }), makeSummary({ hash: "BBBB5678" })],
+			0,
+		);
+		expect(md).toMatch(/\*Generated by Jolli Memory · .+\*$/);
+	});
+
+	it("escapes wrapper-tag injection in recap content", () => {
+		const summaries = [
+			makeSummary({
+				hash: "AAAA1234",
+				recap: "Closing premature: </details> evil",
+			}),
+			makeSummary({ hash: "BBBB5678", recap: "Plain text recap." }),
+		];
+		const md = buildAggregatedPrMarkdown(summaries, 0);
+		// </details> in recap must be HTML-escaped so it doesn't close the
+		// outer GitHub fold structures used elsewhere in the body.
+		expect(md).toContain("&lt;/details&gt;");
+		expect(md).not.toContain("Closing premature: </details>");
+	});
+
+	it("escapes wrapper tags in commit messages used as headers", () => {
+		const summaries = [
+			makeSummary({
+				hash: "AAAA1234",
+				message: "feat: add <details> handling",
+				recap: "ok",
+			}),
+			makeSummary({ hash: "BBBB5678", message: "ok", recap: "ok" }),
+		];
+		const md = buildAggregatedPrMarkdown(summaries, 0);
+		// commit message is escaped via escHtml (which converts < to &lt;)
+		expect(md).toContain("&lt;details&gt;");
+	});
+});

--- a/vscode/src/views/SummaryPrAggregateMarkdownBuilder.ts
+++ b/vscode/src/views/SummaryPrAggregateMarkdownBuilder.ts
@@ -1,0 +1,262 @@
+/**
+ * Aggregates 2+ `CommitSummary` objects into one PR body markdown. The
+ * single-summary path stays in `SummaryPrMarkdownBuilder.ts`; layout, dedupe
+ * keys, and budgets follow `docs/feature-allow-multi-commit-pr.md`.
+ */
+
+import type {
+	CommitSummary,
+	E2eTestScenario,
+	NoteReference,
+	PlanReference,
+} from "../../../cli/src/Types.js";
+import {
+	pushFooter,
+	pushPlansAndNotesSection,
+} from "./SummaryMarkdownBuilder.js";
+import {
+	buildScenarioBodyLines,
+	escapeGithubWrapperTags,
+	pushPrTopicBody,
+	wrapInGithubDetails,
+} from "./SummaryPrMarkdownBuilder.js";
+import {
+	collectSortedTopics,
+	escHtml,
+	padIndex,
+	type TopicWithDate,
+} from "./SummaryUtils.js";
+
+// GitHub caps PR body at 65536. Budgets ~1000 chars for footer, missing
+// footnote, marker envelope (added by `wrapWithMarkers` in caller), and
+// per-section omitted-footnotes — keeping wrapped output safely below cap.
+const PR_BODY_LIMIT = 64500;
+const RECAP_SOFT_LIMIT = 50000;
+const E2E_SOFT_LIMIT = 60000;
+
+interface AggregatedScenario extends E2eTestScenario {
+	readonly sourceShortHash: string;
+}
+
+interface AggregatedTopic extends TopicWithDate {
+	readonly sourceShortHash: string;
+}
+
+export function buildAggregatedPrMarkdown(
+	summaries: ReadonlyArray<CommitSummary>,
+	missingCount: number,
+): string {
+	if (summaries.length < 2) {
+		throw new Error(
+			`buildAggregatedPrMarkdown requires summaries.length >= 2; got ${summaries.length}`,
+		);
+	}
+
+	const lines: Array<string> = [];
+	const currentLength = (): number => lines.join("\n").length;
+	const totalCount = summaries.length + missingCount;
+
+	pushCommitsDirectory(lines, summaries, totalCount, missingCount);
+	pushMergedPlansAndNotes(lines, summaries);
+	pushPerCommitRecap(lines, summaries, currentLength);
+	pushAggregatedE2eSection(lines, summaries, currentLength);
+	pushAggregatedTopicsSection(lines, summaries, currentLength);
+	pushMissingFootnote(lines, missingCount);
+	pushFooter(lines);
+
+	return lines.join("\n");
+}
+
+// ─── Section builders (file-local) ─────────────────────────────────────────
+
+function pushCommitsDirectory(
+	lines: Array<string>,
+	summaries: ReadonlyArray<CommitSummary>,
+	totalCount: number,
+	missingCount: number,
+): void {
+	const header =
+		missingCount > 0
+			? `## Commits in this PR (${summaries.length} of ${totalCount})`
+			: `## Commits in this PR (${summaries.length})`;
+	lines.push(header, "");
+	for (let i = 0; i < summaries.length; i++) {
+		const s = summaries[i];
+		const shortHash = s.commitHash.substring(0, 7);
+		const memoryLink = s.jolliDocUrl ? ` — [Memory](${s.jolliDocUrl})` : "";
+		// Strip backticks: escHtml doesn't escape them, and they would
+		// collide with the inline `${shortHash}` code-span on the same line.
+		const safeMessage = escHtml(s.commitMessage).replace(/`/g, "");
+		lines.push(`${i + 1}. ${safeMessage} (\`${shortHash}\`)${memoryLink}`);
+	}
+}
+
+// Dedupe key: URL when published, else `slug:`/`id:` prefix so unpublished
+// entries with the same slug/id still collapse to one row. Prefix avoids
+// accidental collision with URL strings.
+function pushMergedPlansAndNotes(
+	lines: Array<string>,
+	summaries: ReadonlyArray<CommitSummary>,
+): void {
+	const planSeen = new Set<string>();
+	const noteSeen = new Set<string>();
+	const mergedPlans: Array<PlanReference> = [];
+	const mergedNotes: Array<NoteReference> = [];
+
+	for (const s of summaries) {
+		for (const p of s.plans ?? []) {
+			const key = p.jolliPlanDocUrl ?? `slug:${p.slug}`;
+			if (!planSeen.has(key)) {
+				planSeen.add(key);
+				mergedPlans.push(p);
+			}
+		}
+		for (const n of s.notes ?? []) {
+			const key = n.jolliNoteDocUrl ?? `id:${n.id}`;
+			if (!noteSeen.has(key)) {
+				noteSeen.add(key);
+				mergedNotes.push(n);
+			}
+		}
+	}
+
+	if (mergedPlans.length === 0 && mergedNotes.length === 0) return;
+
+	pushPlansAndNotesSection(lines, {
+		plans: mergedPlans,
+		notes: mergedNotes,
+	} as unknown as CommitSummary);
+}
+
+function pushPerCommitRecap(
+	lines: Array<string>,
+	summaries: ReadonlyArray<CommitSummary>,
+	currentLength: () => number,
+): void {
+	const withRecapCount = summaries.filter((s) => s.recap?.trim()).length;
+	if (withRecapCount === 0) return;
+
+	// Header matches the single-summary `## Quick recap` (in
+	// `SummaryMarkdownBuilder.pushRecapSection`) plus the `(N)` count style
+	// used by every other aggregate section (Commits / E2E / Topics).
+	lines.push("", `## Quick recap (${withRecapCount})`);
+
+	let truncated = false;
+	let truncatedCount = 0;
+	for (let i = 0; i < summaries.length; i++) {
+		const s = summaries[i];
+		const recap = s.recap?.trim();
+		if (!recap) continue;
+		if (truncated) {
+			truncatedCount++;
+			continue;
+		}
+		const shortHash = s.commitHash.substring(0, 7);
+		const safeMessage = escHtml(s.commitMessage).replace(/`/g, "");
+		const block = [
+			"",
+			`### Commit ${i + 1} of ${summaries.length}: ${safeMessage} (\`${shortHash}\`)`,
+			"",
+			escapeGithubWrapperTags(recap),
+		];
+		if (currentLength() + block.join("\n").length > RECAP_SOFT_LIMIT) {
+			truncated = true;
+			truncatedCount++;
+			continue;
+		}
+		lines.push(...block);
+	}
+	if (truncatedCount > 0) {
+		const possessive = truncatedCount === 1 ? "commit's" : "commits'";
+		lines.push(
+			"",
+			`> ⚠️ ${truncatedCount} more ${possessive} recap omitted due to GitHub PR body size limit.`,
+		);
+	}
+}
+
+function pushAggregatedE2eSection(
+	lines: Array<string>,
+	summaries: ReadonlyArray<CommitSummary>,
+	currentLength: () => number,
+): void {
+	const all: Array<AggregatedScenario> = [];
+	for (const s of summaries) {
+		const shortHash = s.commitHash.substring(0, 7);
+		for (const sc of s.e2eTestGuide ?? []) {
+			all.push({ ...sc, sourceShortHash: shortHash });
+		}
+	}
+	if (all.length === 0) return;
+
+	lines.push("", `## E2E Test (${all.length})`);
+
+	let included = 0;
+	for (let i = 0; i < all.length; i++) {
+		const sc = all[i];
+		const summaryContent = `<strong>${i + 1}. [${sc.sourceShortHash}] ${escHtml(sc.title)}</strong>`;
+		const wrapped = wrapInGithubDetails(
+			summaryContent,
+			buildScenarioBodyLines(sc),
+		);
+		if (currentLength() + wrapped.join("\n").length > E2E_SOFT_LIMIT) {
+			break;
+		}
+		lines.push(...wrapped);
+		included++;
+	}
+	const omitted = all.length - included;
+	if (omitted > 0) {
+		lines.push(
+			"",
+			`> ⚠️ ${omitted} more scenario${omitted !== 1 ? "s" : ""} omitted due to GitHub PR body size limit.`,
+		);
+	}
+}
+
+function pushAggregatedTopicsSection(
+	lines: Array<string>,
+	summaries: ReadonlyArray<CommitSummary>,
+	currentLength: () => number,
+): void {
+	const all: Array<AggregatedTopic> = [];
+	for (const s of summaries) {
+		const shortHash = s.commitHash.substring(0, 7);
+		const { topics } = collectSortedTopics(s);
+		for (const t of topics) {
+			all.push({ ...t, sourceShortHash: shortHash });
+		}
+	}
+	if (all.length === 0) return;
+
+	lines.push("", `## ${all.length === 1 ? "Topic" : "Topics"} (${all.length})`);
+
+	let included = 0;
+	for (let i = 0; i < all.length; i++) {
+		const t = all[i];
+		const summaryContent = `<strong>${padIndex(i)} · [${t.sourceShortHash}] ${escHtml(t.title)}</strong>`;
+		const body: Array<string> = [];
+		pushPrTopicBody(body, t);
+		const wrapped = wrapInGithubDetails(summaryContent, body);
+		if (currentLength() + wrapped.join("\n").length > PR_BODY_LIMIT) {
+			break;
+		}
+		lines.push(...wrapped);
+		included++;
+	}
+	const omitted = all.length - included;
+	if (omitted > 0) {
+		lines.push(
+			"",
+			`> ⚠️ ${omitted} more topic${omitted !== 1 ? "s" : ""} omitted due to GitHub PR body size limit.`,
+		);
+	}
+}
+
+function pushMissingFootnote(lines: Array<string>, missingCount: number): void {
+	if (missingCount <= 0) return;
+	lines.push(
+		"",
+		`> Note: ${missingCount} commit(s) without summary were skipped.`,
+	);
+}

--- a/vscode/src/views/SummaryPrMarkdownBuilder.test.ts
+++ b/vscode/src/views/SummaryPrMarkdownBuilder.test.ts
@@ -74,7 +74,6 @@ function makeTopic(overrides: Partial<TopicWithDate> = {}): TopicWithDate {
 		todo: "Add metrics for retry counts.",
 		filesAffected: ["src/auth/Login.ts", "src/auth/Retry.ts"],
 		category: "bugfix",
-		recordDate: "2026-03-30T10:00:00Z",
 		importance: "major",
 		commitDate: "2026-03-30T10:00:00Z",
 		treeIndex: 0,

--- a/vscode/src/views/SummaryPrMarkdownBuilder.ts
+++ b/vscode/src/views/SummaryPrMarkdownBuilder.ts
@@ -12,6 +12,11 @@
  * (`pushPlansAndNotesSection`, `pushRecapSection`, `pushFooter`) imported
  * from that file so recap, plans, and footer rendering stays identical
  * between clipboard and PR output.
+ *
+ * The four file-local helpers `wrapInGithubDetails`, `escapeGithubWrapperTags`,
+ * `pushPrE2eTestSection`, and `pushPrTopicBody` are exported so the
+ * branch-aggregating builder (`SummaryPrAggregateMarkdownBuilder`) can reuse
+ * the same fold/escape/render conventions across multi-commit PR bodies.
  */
 
 import type { CommitSummary, E2eTestScenario } from "../../../cli/src/Types.js";
@@ -83,7 +88,7 @@ export function buildPrMarkdown(summary: CommitSummary): string {
  * `<blockquote>` and the first body block is preserved (needed by GFM to
  * switch from HTML mode to markdown parsing inside the blockquote).
  */
-function wrapInGithubDetails(
+export function wrapInGithubDetails(
 	summaryContent: string,
 	bodyLines: Array<string>,
 ): Array<string> {
@@ -114,7 +119,7 @@ function wrapInGithubDetails(
  * NOTE: Only applied to generated content inside buildPrMarkdown. User-edited
  * textarea content is NOT re-sanitized on submit (by design).
  */
-function escapeGithubWrapperTags(text: string): string {
+export function escapeGithubWrapperTags(text: string): string {
 	return text
 		.replace(/<details\b[^>]*>/gi, (m) => `&lt;${m.slice(1, -1)}&gt;`)
 		.replace(/<\/details\s*>/gi, "&lt;/details&gt;")
@@ -125,11 +130,30 @@ function escapeGithubWrapperTags(text: string): string {
 // ─── PR body section builders (file-local) ─────────────────────────────────
 
 /**
- * Appends the E2E test guide section for PR markdown. Each scenario is
- * wrapped in a `<details>` block with its title in `<summary>`, and all
- * user-provided fields are sanitized against wrapper-tag injection.
+ * Builds the inner body lines (preconditions / steps / expected results) of
+ * a PR e2e scenario. Shared between single-summary and branch-aggregated
+ * renderers — keep both call sites' output byte-identical.
  */
-function pushPrE2eTestSection(
+export function buildScenarioBodyLines(s: E2eTestScenario): Array<string> {
+	const out: Array<string> = [];
+	if (s.preconditions) {
+		out.push(
+			"",
+			`**Preconditions:** ${escapeGithubWrapperTags(s.preconditions)}`,
+		);
+	}
+	out.push("", "**Steps:**");
+	for (let j = 0; j < s.steps.length; j++) {
+		out.push(`${j + 1}. ${escapeGithubWrapperTags(s.steps[j])}`);
+	}
+	out.push("", "**Expected Results:**");
+	for (const r of s.expectedResults) {
+		out.push(`- ${escapeGithubWrapperTags(r)}`);
+	}
+	return out;
+}
+
+export function pushPrE2eTestSection(
 	lines: Array<string>,
 	e2eTestGuide: ReadonlyArray<E2eTestScenario> | undefined,
 ): void {
@@ -140,22 +164,9 @@ function pushPrE2eTestSection(
 	for (let i = 0; i < e2eTestGuide.length; i++) {
 		const s = e2eTestGuide[i];
 		const summaryContent = `<strong>${i + 1}. ${escHtml(s.title)}</strong>`;
-		const bodyOnly: Array<string> = [];
-		if (s.preconditions) {
-			bodyOnly.push(
-				"",
-				`**Preconditions:** ${escapeGithubWrapperTags(s.preconditions)}`,
-			);
-		}
-		bodyOnly.push("", "**Steps:**");
-		for (let j = 0; j < s.steps.length; j++) {
-			bodyOnly.push(`${j + 1}. ${escapeGithubWrapperTags(s.steps[j])}`);
-		}
-		bodyOnly.push("", "**Expected Results:**");
-		for (const r of s.expectedResults) {
-			bodyOnly.push(`- ${escapeGithubWrapperTags(r)}`);
-		}
-		lines.push(...wrapInGithubDetails(summaryContent, bodyOnly));
+		lines.push(
+			...wrapInGithubDetails(summaryContent, buildScenarioBodyLines(s)),
+		);
 	}
 	lines.push("", "---");
 }
@@ -169,7 +180,7 @@ function pushPrE2eTestSection(
  * injection. File paths are wrapped in backticks (code span) where HTML
  * is not parsed, so `filesAffected` entries need no escape.
  */
-function pushPrTopicBody(out: Array<string>, t: TopicWithDate): void {
+export function pushPrTopicBody(out: Array<string>, t: TopicWithDate): void {
 	out.push(
 		"",
 		`**⚡ Why This Change**`,

--- a/vscode/src/views/SummaryWebviewPanel.handlePush.test.ts
+++ b/vscode/src/views/SummaryWebviewPanel.handlePush.test.ts
@@ -446,9 +446,22 @@ async function setupPanel(
 	overrides?: Partial<CommitSummary>,
 ): Promise<(msg: Record<string, unknown>) => void> {
 	const summary = makeSummary(overrides);
-	await SummaryWebviewPanel.show(summary, extensionUri, workspaceRoot);
+	await SummaryWebviewPanel.show(
+		summary,
+		extensionUri,
+		workspaceRoot,
+		stubBridge,
+		"main",
+	);
 	return captureMessageHandler();
 }
+
+// Bridge stub used only to satisfy the panel ctor signature; handlePush tests
+// don't exercise branch-summary loading, so the stub's methods stay unused.
+const stubBridge = {
+	listBranchCommits: vi.fn(),
+	getSummary: vi.fn(),
+} as unknown as import("../JolliMemoryBridge.js").JolliMemoryBridge;
 
 // ── Tests ────────────────────────────────────────────────────────────────────
 

--- a/vscode/src/views/SummaryWebviewPanel.test.ts
+++ b/vscode/src/views/SummaryWebviewPanel.test.ts
@@ -304,11 +304,14 @@ const {
 	mockHandleCreatePr,
 	mockHandlePrepareUpdatePr,
 	mockHandleUpdatePr,
+	mockIsCommitReachableFromHead,
 } = vi.hoisted(() => ({
 	mockHandleCheckPrStatus: vi.fn().mockResolvedValue(undefined),
 	mockHandleCreatePr: vi.fn().mockResolvedValue(undefined),
 	mockHandlePrepareUpdatePr: vi.fn().mockResolvedValue(undefined),
 	mockHandleUpdatePr: vi.fn().mockResolvedValue(undefined),
+	// Default: commit IS reachable from HEAD (i.e., NOT cross-branch).
+	mockIsCommitReachableFromHead: vi.fn().mockResolvedValue(true),
 }));
 
 vi.mock("../services/PrCommentService.js", () => ({
@@ -316,7 +319,35 @@ vi.mock("../services/PrCommentService.js", () => ({
 	handleCreatePr: mockHandleCreatePr,
 	handlePrepareUpdatePr: mockHandlePrepareUpdatePr,
 	handleUpdatePr: mockHandleUpdatePr,
+	isCommitReachableFromHead: mockIsCommitReachableFromHead,
 	wrapWithMarkers: (s: string) => `[MARKERS]${s}[/MARKERS]`,
+}));
+
+const { mockIsWorkerBusy } = vi.hoisted(() => ({
+	mockIsWorkerBusy: vi.fn().mockResolvedValue(false),
+}));
+
+vi.mock("../util/LockUtils.js", () => ({
+	isWorkerBusy: mockIsWorkerBusy,
+}));
+
+const { mockLoadBranchSummaries } = vi.hoisted(() => ({
+	// Default: empty branch summaries → routes through single-summary path.
+	mockLoadBranchSummaries: vi
+		.fn()
+		.mockResolvedValue({ summaries: [], missingCount: 0, totalCount: 0 }),
+}));
+
+vi.mock("./BranchSummaryLoader.js", () => ({
+	loadBranchSummaries: mockLoadBranchSummaries,
+}));
+
+const { mockBuildAggregatedPrMarkdown } = vi.hoisted(() => ({
+	mockBuildAggregatedPrMarkdown: vi.fn().mockReturnValue("# Aggregated body"),
+}));
+
+vi.mock("./SummaryPrAggregateMarkdownBuilder.js", () => ({
+	buildAggregatedPrMarkdown: mockBuildAggregatedPrMarkdown,
 }));
 
 vi.mock("../util/Logger.js", () => ({
@@ -428,6 +459,13 @@ function makeSummary(overrides?: Partial<CommitSummary>): CommitSummary {
 
 const extensionUri = { fsPath: "/ext", toString: () => "/ext" } as never;
 const workspaceRoot = "/workspace";
+// Bridge stub used to satisfy the panel ctor signature; tests in this file
+// don't exercise branch-summary loading. Methods stay unused.
+const stubBridge = {
+	listBranchCommits: vi.fn(),
+	getSummary: vi.fn(),
+} as unknown as import("../JolliMemoryBridge.js").JolliMemoryBridge;
+const mainBranch = "main";
 
 /**
  * Captures the onDidReceiveMessage callback registered by the panel constructor,
@@ -486,7 +524,13 @@ describe("SummaryWebviewPanel", () => {
 	describe("show()", () => {
 		it("creates a new webview panel when none exists (commit slot by default)", async () => {
 			const summary = makeSummary();
-			await SummaryWebviewPanel.show(summary, extensionUri, workspaceRoot);
+			await SummaryWebviewPanel.show(
+				summary,
+				extensionUri,
+				workspaceRoot,
+				stubBridge,
+				mainBranch,
+			);
 
 			expect(createWebviewPanel).toHaveBeenCalledWith(
 				"jollimemory.summary.commit",
@@ -505,6 +549,8 @@ describe("SummaryWebviewPanel", () => {
 				summary,
 				extensionUri,
 				workspaceRoot,
+				stubBridge,
+				mainBranch,
 				"memory",
 			);
 
@@ -527,6 +573,8 @@ describe("SummaryWebviewPanel", () => {
 				summary1,
 				extensionUri,
 				workspaceRoot,
+				stubBridge,
+				mainBranch,
 				"commit",
 			);
 			const commitPanelDispose =
@@ -536,6 +584,8 @@ describe("SummaryWebviewPanel", () => {
 				summary2,
 				extensionUri,
 				workspaceRoot,
+				stubBridge,
+				mainBranch,
 				"memory",
 			);
 
@@ -546,7 +596,13 @@ describe("SummaryWebviewPanel", () => {
 		it("sets panel title from buildPanelTitle", async () => {
 			mockBuildPanelTitle.mockReturnValue("Custom Title");
 			const summary = makeSummary();
-			await SummaryWebviewPanel.show(summary, extensionUri, workspaceRoot);
+			await SummaryWebviewPanel.show(
+				summary,
+				extensionUri,
+				workspaceRoot,
+				stubBridge,
+				mainBranch,
+			);
 
 			const panel = createWebviewPanel.mock.results[0].value;
 			expect(panel.title).toBe("Custom Title");
@@ -555,7 +611,13 @@ describe("SummaryWebviewPanel", () => {
 		it("sets HTML content from buildHtml", async () => {
 			mockBuildHtml.mockReturnValue("<html>test content</html>");
 			const summary = makeSummary();
-			await SummaryWebviewPanel.show(summary, extensionUri, workspaceRoot);
+			await SummaryWebviewPanel.show(
+				summary,
+				extensionUri,
+				workspaceRoot,
+				stubBridge,
+				mainBranch,
+			);
 
 			const panel = createWebviewPanel.mock.results[0].value;
 			expect(panel.webview.html).toBe("<html>test content</html>");
@@ -573,7 +635,13 @@ describe("SummaryWebviewPanel", () => {
 
 		it("dispose handler removes the commit panel from the per-hash map", async () => {
 			const summary = makeSummary();
-			await SummaryWebviewPanel.show(summary, extensionUri, workspaceRoot);
+			await SummaryWebviewPanel.show(
+				summary,
+				extensionUri,
+				workspaceRoot,
+				stubBridge,
+				mainBranch,
+			);
 
 			expect(onDidDispose).toHaveBeenCalled();
 			const disposeCallback = onDidDispose.mock.calls[0][0] as () => void;
@@ -581,7 +649,13 @@ describe("SummaryWebviewPanel", () => {
 
 			// After dispose, a new call to show() for the same commit should
 			// create a new panel (instead of revealing the now-disposed one).
-			await SummaryWebviewPanel.show(summary, extensionUri, workspaceRoot);
+			await SummaryWebviewPanel.show(
+				summary,
+				extensionUri,
+				workspaceRoot,
+				stubBridge,
+				mainBranch,
+			);
 			expect(createWebviewPanel).toHaveBeenCalledTimes(2);
 		});
 
@@ -589,10 +663,22 @@ describe("SummaryWebviewPanel", () => {
 			const summary1 = makeSummary({ commitHash: "aaa" });
 			const summary2 = makeSummary({ commitHash: "bbb" });
 
-			await SummaryWebviewPanel.show(summary1, extensionUri, workspaceRoot);
+			await SummaryWebviewPanel.show(
+				summary1,
+				extensionUri,
+				workspaceRoot,
+				stubBridge,
+				mainBranch,
+			);
 			const firstPanelDispose =
 				createWebviewPanel.mock.results[0].value.dispose;
-			await SummaryWebviewPanel.show(summary2, extensionUri, workspaceRoot);
+			await SummaryWebviewPanel.show(
+				summary2,
+				extensionUri,
+				workspaceRoot,
+				stubBridge,
+				mainBranch,
+			);
 
 			expect(createWebviewPanel).toHaveBeenCalledTimes(2);
 			expect(firstPanelDispose).not.toHaveBeenCalled();
@@ -601,9 +687,21 @@ describe("SummaryWebviewPanel", () => {
 		it("commit slot: reveals the existing panel when the same commit is shown again", async () => {
 			const summary = makeSummary({ commitHash: "aaa" });
 
-			await SummaryWebviewPanel.show(summary, extensionUri, workspaceRoot);
+			await SummaryWebviewPanel.show(
+				summary,
+				extensionUri,
+				workspaceRoot,
+				stubBridge,
+				mainBranch,
+			);
 			reveal.mockClear();
-			await SummaryWebviewPanel.show(summary, extensionUri, workspaceRoot);
+			await SummaryWebviewPanel.show(
+				summary,
+				extensionUri,
+				workspaceRoot,
+				stubBridge,
+				mainBranch,
+			);
 
 			expect(createWebviewPanel).toHaveBeenCalledTimes(1);
 			// reveal() with undefined viewColumn keeps the panel in its current column
@@ -614,11 +712,23 @@ describe("SummaryWebviewPanel", () => {
 		it("commit slot: skips webview re-render when summary + config + orphan state all unchanged", async () => {
 			const summary = makeSummary({ commitHash: "aaa" });
 
-			await SummaryWebviewPanel.show(summary, extensionUri, workspaceRoot);
+			await SummaryWebviewPanel.show(
+				summary,
+				extensionUri,
+				workspaceRoot,
+				stubBridge,
+				mainBranch,
+			);
 			mockGetTranscriptHashes.mockClear();
 			mockBuildHtml.mockClear();
 
-			await SummaryWebviewPanel.show(summary, extensionUri, workspaceRoot);
+			await SummaryWebviewPanel.show(
+				summary,
+				extensionUri,
+				workspaceRoot,
+				stubBridge,
+				mainBranch,
+			);
 
 			// Refreshes always run (they're cheap reads that cover orphan-branch
 			// state which can change without a summary JSON change). But when all
@@ -637,7 +747,13 @@ describe("SummaryWebviewPanel", () => {
 				model: "m",
 				pushAction: "jolli",
 			});
-			await SummaryWebviewPanel.show(summary, extensionUri, workspaceRoot);
+			await SummaryWebviewPanel.show(
+				summary,
+				extensionUri,
+				workspaceRoot,
+				stubBridge,
+				mainBranch,
+			);
 			mockBuildHtml.mockClear();
 
 			mockLoadConfig.mockResolvedValueOnce({
@@ -645,7 +761,13 @@ describe("SummaryWebviewPanel", () => {
 				model: "m",
 				pushAction: "both",
 			});
-			await SummaryWebviewPanel.show(summary, extensionUri, workspaceRoot);
+			await SummaryWebviewPanel.show(
+				summary,
+				extensionUri,
+				workspaceRoot,
+				stubBridge,
+				mainBranch,
+			);
 
 			expect(mockBuildHtml).toHaveBeenCalledWith(
 				summary,
@@ -657,13 +779,25 @@ describe("SummaryWebviewPanel", () => {
 			const summary = makeSummary({ commitHash: "aaa" });
 
 			mockGetTranscriptHashes.mockResolvedValueOnce(new Set<string>());
-			await SummaryWebviewPanel.show(summary, extensionUri, workspaceRoot);
+			await SummaryWebviewPanel.show(
+				summary,
+				extensionUri,
+				workspaceRoot,
+				stubBridge,
+				mainBranch,
+			);
 			mockBuildHtml.mockClear();
 
 			// Background session added a transcript for this commit — summary JSON
 			// is identical, but the orphan-branch state changed.
 			mockGetTranscriptHashes.mockResolvedValueOnce(new Set(["aaa"]));
-			await SummaryWebviewPanel.show(summary, extensionUri, workspaceRoot);
+			await SummaryWebviewPanel.show(
+				summary,
+				extensionUri,
+				workspaceRoot,
+				stubBridge,
+				mainBranch,
+			);
 
 			expect(mockBuildHtml).toHaveBeenCalledWith(
 				summary,
@@ -675,11 +809,23 @@ describe("SummaryWebviewPanel", () => {
 			const summary1 = makeSummary({ commitHash: "aaa", commitMessage: "v1" });
 			const summary2 = makeSummary({ commitHash: "aaa", commitMessage: "v2" });
 
-			await SummaryWebviewPanel.show(summary1, extensionUri, workspaceRoot);
+			await SummaryWebviewPanel.show(
+				summary1,
+				extensionUri,
+				workspaceRoot,
+				stubBridge,
+				mainBranch,
+			);
 			mockGetTranscriptHashes.mockClear();
 			mockBuildHtml.mockClear();
 
-			await SummaryWebviewPanel.show(summary2, extensionUri, workspaceRoot);
+			await SummaryWebviewPanel.show(
+				summary2,
+				extensionUri,
+				workspaceRoot,
+				stubBridge,
+				mainBranch,
+			);
 
 			// Content differs → refresh + update runs on the existing panel.
 			expect(createWebviewPanel).toHaveBeenCalledTimes(1);
@@ -695,6 +841,8 @@ describe("SummaryWebviewPanel", () => {
 				summary1,
 				extensionUri,
 				workspaceRoot,
+				stubBridge,
+				mainBranch,
 				"memory",
 			);
 			const firstPanelDispose =
@@ -703,6 +851,8 @@ describe("SummaryWebviewPanel", () => {
 				summary2,
 				extensionUri,
 				workspaceRoot,
+				stubBridge,
+				mainBranch,
 				"memory",
 			);
 
@@ -719,8 +869,20 @@ describe("SummaryWebviewPanel", () => {
 				.mockReturnValueOnce("<html>first</html>")
 				.mockReturnValueOnce("<html>second</html>");
 
-			await SummaryWebviewPanel.show(summary1, extensionUri, workspaceRoot);
-			await SummaryWebviewPanel.show(summary2, extensionUri, workspaceRoot);
+			await SummaryWebviewPanel.show(
+				summary1,
+				extensionUri,
+				workspaceRoot,
+				stubBridge,
+				mainBranch,
+			);
+			await SummaryWebviewPanel.show(
+				summary2,
+				extensionUri,
+				workspaceRoot,
+				stubBridge,
+				mainBranch,
+			);
 
 			const secondPanel = createWebviewPanel.mock.results[1].value;
 			expect(secondPanel.webview.html).toBe("<html>second</html>");
@@ -732,6 +894,8 @@ describe("SummaryWebviewPanel", () => {
 				summary,
 				extensionUri,
 				workspaceRoot,
+				stubBridge,
+				mainBranch,
 				"memory",
 			);
 
@@ -771,7 +935,13 @@ describe("SummaryWebviewPanel", () => {
 					}),
 				],
 			});
-			await SummaryWebviewPanel.show(summary, extensionUri, workspaceRoot);
+			await SummaryWebviewPanel.show(
+				summary,
+				extensionUri,
+				workspaceRoot,
+				stubBridge,
+				mainBranch,
+			);
 
 			// buildHtml should receive all 3 hashes (root + child + grandchild) intersected with file hashes
 			expect(mockBuildHtml).toHaveBeenCalledWith(
@@ -789,7 +959,13 @@ describe("SummaryWebviewPanel", () => {
 		it("populates transcriptHashSet from orphan branch", async () => {
 			mockGetTranscriptHashes.mockResolvedValue(new Set(["abc123", "def456"]));
 			const summary = makeSummary({ commitHash: "abc123" });
-			await SummaryWebviewPanel.show(summary, extensionUri, workspaceRoot);
+			await SummaryWebviewPanel.show(
+				summary,
+				extensionUri,
+				workspaceRoot,
+				stubBridge,
+				mainBranch,
+			);
 
 			// buildHtml should receive the intersection of tree hashes and file hashes
 			expect(mockBuildHtml).toHaveBeenCalledWith(
@@ -823,7 +999,13 @@ describe("SummaryWebviewPanel", () => {
 					},
 				],
 			});
-			await SummaryWebviewPanel.show(summary, extensionUri, workspaceRoot);
+			await SummaryWebviewPanel.show(
+				summary,
+				extensionUri,
+				workspaceRoot,
+				stubBridge,
+				mainBranch,
+			);
 
 			// plan-1 has CJK title, plan-2 does not and readPlanFromBranch returns null
 			expect(mockBuildHtml).toHaveBeenCalledWith(
@@ -851,7 +1033,13 @@ describe("SummaryWebviewPanel", () => {
 					},
 				],
 			});
-			await SummaryWebviewPanel.show(summary, extensionUri, workspaceRoot);
+			await SummaryWebviewPanel.show(
+				summary,
+				extensionUri,
+				workspaceRoot,
+				stubBridge,
+				mainBranch,
+			);
 
 			expect(mockBuildHtml).toHaveBeenCalledWith(
 				summary,
@@ -884,7 +1072,13 @@ describe("SummaryWebviewPanel", () => {
 					},
 				],
 			});
-			await SummaryWebviewPanel.show(summary, extensionUri, workspaceRoot);
+			await SummaryWebviewPanel.show(
+				summary,
+				extensionUri,
+				workspaceRoot,
+				stubBridge,
+				mainBranch,
+			);
 
 			// cn-note has CJK title, en-note does not
 			expect(mockBuildHtml).toHaveBeenCalledWith(
@@ -912,7 +1106,13 @@ describe("SummaryWebviewPanel", () => {
 					},
 				],
 			});
-			await SummaryWebviewPanel.show(summary, extensionUri, workspaceRoot);
+			await SummaryWebviewPanel.show(
+				summary,
+				extensionUri,
+				workspaceRoot,
+				stubBridge,
+				mainBranch,
+			);
 
 			expect(mockBuildHtml).toHaveBeenCalledWith(
 				summary,
@@ -939,7 +1139,13 @@ describe("SummaryWebviewPanel", () => {
 					},
 				],
 			});
-			await SummaryWebviewPanel.show(summary, extensionUri, workspaceRoot);
+			await SummaryWebviewPanel.show(
+				summary,
+				extensionUri,
+				workspaceRoot,
+				stubBridge,
+				mainBranch,
+			);
 
 			expect(mockBuildHtml).toHaveBeenCalledWith(
 				summary,
@@ -966,7 +1172,13 @@ describe("SummaryWebviewPanel", () => {
 					},
 				],
 			});
-			await SummaryWebviewPanel.show(summary, extensionUri, workspaceRoot);
+			await SummaryWebviewPanel.show(
+				summary,
+				extensionUri,
+				workspaceRoot,
+				stubBridge,
+				mainBranch,
+			);
 
 			// noteTranslateSet should be empty since read failed
 			expect(mockBuildHtml).toHaveBeenCalledWith(
@@ -990,7 +1202,13 @@ describe("SummaryWebviewPanel", () => {
 			overrides?: Partial<CommitSummary>,
 		): Promise<(msg: Record<string, unknown>) => void> {
 			const summary = makeSummary(overrides);
-			await SummaryWebviewPanel.show(summary, extensionUri, workspaceRoot);
+			await SummaryWebviewPanel.show(
+				summary,
+				extensionUri,
+				workspaceRoot,
+				stubBridge,
+				mainBranch,
+			);
 			return captureMessageHandler();
 		}
 
@@ -1416,7 +1634,13 @@ describe("SummaryWebviewPanel", () => {
 
 			it("returns early when currentSummary is null (handlePushToJolli guard)", async () => {
 				const summary = makeSummary();
-				await SummaryWebviewPanel.show(summary, extensionUri, workspaceRoot);
+				await SummaryWebviewPanel.show(
+					summary,
+					extensionUri,
+					workspaceRoot,
+					stubBridge,
+					mainBranch,
+				);
 				const dispatch = captureMessageHandler();
 				// Clear the summary from the internal state to exercise lines 329-332
 				const panelInstance = firstCommitPanel<{ currentSummary: null }>();
@@ -2439,7 +2663,10 @@ describe("SummaryWebviewPanel", () => {
 		});
 
 		describe("prepareCreatePr", () => {
-			it("posts prShowCreateForm with wrapped body and commit message title", async () => {
+			it("posts prShowCreateForm with wrapped body and commit message title (single-summary path)", async () => {
+				// Default branch state: 0 summaries → caller falls back to
+				// buildPrMarkdown(currentSummary). missingCount=0 means no footnote
+				// is appended, so the body is byte-identical to today.
 				mockBuildPrMarkdown.mockReturnValue("# fresh body");
 				const dispatch = await setupPanel({ commitMessage: "feat: add thing" });
 
@@ -2456,11 +2683,101 @@ describe("SummaryWebviewPanel", () => {
 				});
 			});
 
+			it("uses aggregated body and HEAD commit message title when branch has 2+ summaries", async () => {
+				const sA = makeSummary({
+					commitHash: "AAAA1234",
+					commitMessage: "first commit",
+				});
+				const sB = makeSummary({
+					commitHash: "BBBB5678",
+					commitMessage: "head commit",
+				});
+				mockLoadBranchSummaries.mockResolvedValueOnce({
+					summaries: [sA, sB],
+					missingCount: 0,
+					totalCount: 2,
+				});
+				mockBuildAggregatedPrMarkdown.mockReturnValueOnce("# aggregated");
+				const dispatch = await setupPanel({ commitMessage: "viewer commit" });
+
+				dispatch({ command: "prepareCreatePr" });
+				await flushPromises();
+
+				expect(mockBuildAggregatedPrMarkdown).toHaveBeenCalledWith([sA, sB], 0);
+				expect(postMessage).toHaveBeenCalledWith({
+					command: "prShowCreateForm",
+					body: "[MARKERS]# aggregated[/MARKERS]",
+					title: "head commit",
+				});
+			});
+
+			it("appends missing-summary footnote when summaries.length <= 1 but missingCount > 0", async () => {
+				mockLoadBranchSummaries.mockResolvedValueOnce({
+					summaries: [],
+					missingCount: 3,
+					totalCount: 3,
+				});
+				mockBuildPrMarkdown.mockReturnValueOnce("# only body");
+				const dispatch = await setupPanel({ commitMessage: "lone msg" });
+
+				dispatch({ command: "prepareCreatePr" });
+				await flushPromises();
+
+				const call = postMessage.mock.calls.find(
+					(c) => (c[0] as { command?: string }).command === "prShowCreateForm",
+				);
+				expect(call).toBeDefined();
+				const body = (call?.[0] as { body: string }).body;
+				expect(body).toContain("# only body");
+				expect(body).toContain(
+					"> Note: 3 commit(s) without summary were skipped.",
+				);
+			});
+
+			it("uses single-summary path on cross-branch (commit not reachable from HEAD)", async () => {
+				mockIsCommitReachableFromHead.mockResolvedValueOnce(false);
+				mockBuildPrMarkdown.mockReturnValueOnce("# cross body");
+				const dispatch = await setupPanel({ commitMessage: "cross msg" });
+
+				dispatch({ command: "prepareCreatePr" });
+				await flushPromises();
+
+				// Cross-branch must NOT call loadBranchSummaries.
+				expect(mockLoadBranchSummaries).not.toHaveBeenCalled();
+				expect(mockBuildAggregatedPrMarkdown).not.toHaveBeenCalled();
+				expect(postMessage).toHaveBeenCalledWith({
+					command: "prShowCreateForm",
+					body: "[MARKERS]# cross body[/MARKERS]",
+					title: "cross msg",
+				});
+			});
+
+			it("worker-busy: shows warning + re-runs handleCheckPrStatus to reset the button", async () => {
+				mockIsWorkerBusy.mockResolvedValueOnce(true);
+				const dispatch = await setupPanel();
+
+				dispatch({ command: "prepareCreatePr" });
+				await flushPromises();
+
+				expect(showWarningMessage).toHaveBeenCalledWith(
+					expect.stringContaining("AI summary is being generated"),
+				);
+				// Status check is invoked so the webview rebuilds the section,
+				// which replaces the click-time "Loading..." button with a fresh one.
+				expect(mockHandleCheckPrStatus).toHaveBeenCalled();
+				// No prShowCreateForm should be posted.
+				expect(postMessage).not.toHaveBeenCalledWith(
+					expect.objectContaining({ command: "prShowCreateForm" }),
+				);
+			});
+
 			it("does nothing when no summary is loaded", async () => {
 				await SummaryWebviewPanel.show(
 					makeSummary(),
 					extensionUri,
 					workspaceRoot,
+					stubBridge,
+					mainBranch,
 				);
 				const dispatch = captureMessageHandler();
 				firstCommitPanel<{ currentSummary: null }>().currentSummary = null;
@@ -2476,28 +2793,89 @@ describe("SummaryWebviewPanel", () => {
 		});
 
 		describe("prepareUpdatePr", () => {
-			it("delegates to handlePrepareUpdatePr with current summary", async () => {
+			it("delegates to handlePrepareUpdatePr with single-summary markdown when branch has <= 1 summary", async () => {
+				mockBuildPrMarkdown.mockReturnValueOnce("# update body");
 				const dispatch = await setupPanel();
 
 				dispatch({ command: "prepareUpdatePr" });
 				await flushPromises();
 
 				expect(mockHandlePrepareUpdatePr).toHaveBeenCalledWith(
-					expect.objectContaining({ commitHash: "abc123" }),
+					"feature/test",
+					"abc123",
+					"# update body",
 					workspaceRoot,
 					expect.any(Function),
-					mockBuildPrMarkdown,
 				);
 			});
 
+			it("delegates with aggregated markdown when branch has 2+ summaries", async () => {
+				const sA = makeSummary({ commitHash: "AAAA1234" });
+				const sB = makeSummary({ commitHash: "BBBB5678" });
+				mockLoadBranchSummaries.mockResolvedValueOnce({
+					summaries: [sA, sB],
+					missingCount: 0,
+					totalCount: 2,
+				});
+				mockBuildAggregatedPrMarkdown.mockReturnValueOnce(
+					"# aggregated update",
+				);
+				const dispatch = await setupPanel();
+
+				dispatch({ command: "prepareUpdatePr" });
+				await flushPromises();
+
+				expect(mockBuildAggregatedPrMarkdown).toHaveBeenCalledWith([sA, sB], 0);
+				expect(mockHandlePrepareUpdatePr).toHaveBeenCalledWith(
+					"feature/test",
+					"abc123",
+					"# aggregated update",
+					workspaceRoot,
+					expect.any(Function),
+				);
+			});
+
+			it("appends missing-summary footnote on the single-summary fallback when missingCount > 0", async () => {
+				mockLoadBranchSummaries.mockResolvedValueOnce({
+					summaries: [],
+					missingCount: 4,
+					totalCount: 4,
+				});
+				mockBuildPrMarkdown.mockReturnValueOnce("# update body");
+				const dispatch = await setupPanel();
+
+				dispatch({ command: "prepareUpdatePr" });
+				await flushPromises();
+
+				const md = mockHandlePrepareUpdatePr.mock.calls[0][2];
+				expect(md).toContain("# update body");
+				expect(md).toContain(
+					"> Note: 4 commit(s) without summary were skipped.",
+				);
+			});
+
+			it("worker-busy: shows warning + re-runs handleCheckPrStatus to reset the button", async () => {
+				mockIsWorkerBusy.mockResolvedValueOnce(true);
+				const dispatch = await setupPanel();
+
+				dispatch({ command: "prepareUpdatePr" });
+				await flushPromises();
+
+				expect(showWarningMessage).toHaveBeenCalledWith(
+					expect.stringContaining("AI summary is being generated"),
+				);
+				expect(mockHandleCheckPrStatus).toHaveBeenCalled();
+				expect(mockHandlePrepareUpdatePr).not.toHaveBeenCalled();
+			});
+
 			it("forwards postMessage callback to the webview panel", async () => {
-				// Make handlePrepareUpdatePr invoke the callback to exercise the lambda on line 210
 				mockHandlePrepareUpdatePr.mockImplementationOnce(
 					(
-						_summary: unknown,
+						_branch: string,
+						_hash: string,
+						_md: string,
 						_cwd: string,
 						pm: (msg: Record<string, unknown>) => void,
-						_buildPr: unknown,
 					) => Promise.resolve(pm({ command: "prDataLoaded" })),
 				);
 				const dispatch = await setupPanel();
@@ -2587,7 +2965,13 @@ describe("SummaryWebviewPanel", () => {
 				mockReadTranscriptsForCommits.mockResolvedValue(transcriptMap);
 
 				const summary = makeSummary();
-				await SummaryWebviewPanel.show(summary, extensionUri, workspaceRoot);
+				await SummaryWebviewPanel.show(
+					summary,
+					extensionUri,
+					workspaceRoot,
+					stubBridge,
+					mainBranch,
+				);
 				const dispatch = captureMessageHandler();
 
 				dispatch({ command: "loadTranscriptStats" });
@@ -2658,7 +3042,13 @@ describe("SummaryWebviewPanel", () => {
 				mockReadTranscriptsForCommits.mockResolvedValue(transcriptMap);
 
 				const summary = makeSummary();
-				await SummaryWebviewPanel.show(summary, extensionUri, workspaceRoot);
+				await SummaryWebviewPanel.show(
+					summary,
+					extensionUri,
+					workspaceRoot,
+					stubBridge,
+					mainBranch,
+				);
 				const dispatch = captureMessageHandler();
 
 				dispatch({ command: "loadTranscriptStats" });
@@ -2727,7 +3117,13 @@ describe("SummaryWebviewPanel", () => {
 				mockReadTranscriptsForCommits.mockResolvedValue(transcriptMap);
 
 				const summary = makeSummary();
-				await SummaryWebviewPanel.show(summary, extensionUri, workspaceRoot);
+				await SummaryWebviewPanel.show(
+					summary,
+					extensionUri,
+					workspaceRoot,
+					stubBridge,
+					mainBranch,
+				);
 				const dispatch = captureMessageHandler();
 
 				dispatch({ command: "loadTranscriptStats" });
@@ -2773,7 +3169,13 @@ describe("SummaryWebviewPanel", () => {
 				mockReadTranscriptsForCommits.mockResolvedValue(transcriptMap);
 
 				const summary = makeSummary();
-				await SummaryWebviewPanel.show(summary, extensionUri, workspaceRoot);
+				await SummaryWebviewPanel.show(
+					summary,
+					extensionUri,
+					workspaceRoot,
+					stubBridge,
+					mainBranch,
+				);
 				const dispatch = captureMessageHandler();
 
 				dispatch({ command: "loadTranscriptStats" });
@@ -2808,7 +3210,13 @@ describe("SummaryWebviewPanel", () => {
 				mockReadTranscriptsForCommits.mockResolvedValue(transcriptMap);
 
 				const summary = makeSummary();
-				await SummaryWebviewPanel.show(summary, extensionUri, workspaceRoot);
+				await SummaryWebviewPanel.show(
+					summary,
+					extensionUri,
+					workspaceRoot,
+					stubBridge,
+					mainBranch,
+				);
 				const dispatch = captureMessageHandler();
 
 				dispatch({ command: "loadTranscriptStats" });
@@ -2960,7 +3368,13 @@ describe("SummaryWebviewPanel", () => {
 				// Create a panel, then clear the internal currentSummary to exercise
 				// the `if (!summary) { return; }` guard on line 807-809.
 				const summary = makeSummary();
-				await SummaryWebviewPanel.show(summary, extensionUri, workspaceRoot);
+				await SummaryWebviewPanel.show(
+					summary,
+					extensionUri,
+					workspaceRoot,
+					stubBridge,
+					mainBranch,
+				);
 				const dispatch = captureMessageHandler();
 				// Clear the summary from the internal state
 				const panelInstance = firstCommitPanel<{ currentSummary: null }>();
@@ -3022,7 +3436,13 @@ describe("SummaryWebviewPanel", () => {
 				mockReadTranscriptsForCommits.mockResolvedValue(transcriptMap);
 
 				const summary = makeSummary();
-				await SummaryWebviewPanel.show(summary, extensionUri, workspaceRoot);
+				await SummaryWebviewPanel.show(
+					summary,
+					extensionUri,
+					workspaceRoot,
+					stubBridge,
+					mainBranch,
+				);
 				const dispatch = captureMessageHandler();
 
 				dispatch({ command: "loadAllTranscripts" });
@@ -3072,7 +3492,13 @@ describe("SummaryWebviewPanel", () => {
 				]);
 				mockReadTranscriptsForCommits.mockResolvedValue(transcriptMap);
 				const summary = makeSummary();
-				await SummaryWebviewPanel.show(summary, extensionUri, workspaceRoot);
+				await SummaryWebviewPanel.show(
+					summary,
+					extensionUri,
+					workspaceRoot,
+					stubBridge,
+					mainBranch,
+				);
 				const dispatch = captureMessageHandler();
 
 				dispatch({ command: "loadAllTranscripts" });
@@ -3122,7 +3548,13 @@ describe("SummaryWebviewPanel", () => {
 				]);
 				mockReadTranscriptsForCommits.mockResolvedValue(transcriptMap);
 				const summary = makeSummary();
-				await SummaryWebviewPanel.show(summary, extensionUri, workspaceRoot);
+				await SummaryWebviewPanel.show(
+					summary,
+					extensionUri,
+					workspaceRoot,
+					stubBridge,
+					mainBranch,
+				);
 				const dispatch = captureMessageHandler();
 
 				dispatch({ command: "loadAllTranscripts" });
@@ -3165,7 +3597,13 @@ describe("SummaryWebviewPanel", () => {
 					]),
 				);
 				const summary = makeSummary();
-				await SummaryWebviewPanel.show(summary, extensionUri, workspaceRoot);
+				await SummaryWebviewPanel.show(
+					summary,
+					extensionUri,
+					workspaceRoot,
+					stubBridge,
+					mainBranch,
+				);
 				const dispatch = captureMessageHandler();
 
 				dispatch({
@@ -3216,7 +3654,13 @@ describe("SummaryWebviewPanel", () => {
 					]),
 				);
 				const summary = makeSummary();
-				await SummaryWebviewPanel.show(summary, extensionUri, workspaceRoot);
+				await SummaryWebviewPanel.show(
+					summary,
+					extensionUri,
+					workspaceRoot,
+					stubBridge,
+					mainBranch,
+				);
 				const dispatch = captureMessageHandler();
 
 				dispatch({
@@ -3286,7 +3730,13 @@ describe("SummaryWebviewPanel", () => {
 				const summary = makeSummary({
 					children: [makeSummary({ commitHash: "def456" })],
 				});
-				await SummaryWebviewPanel.show(summary, extensionUri, workspaceRoot);
+				await SummaryWebviewPanel.show(
+					summary,
+					extensionUri,
+					workspaceRoot,
+					stubBridge,
+					mainBranch,
+				);
 				const dispatch = captureMessageHandler();
 
 				// Send entries only for abc123 — def456 has no entries so should be deleted
@@ -3320,7 +3770,13 @@ describe("SummaryWebviewPanel", () => {
 			it("deletes all transcript files for current summary", async () => {
 				mockGetTranscriptHashes.mockResolvedValue(new Set(["abc123"]));
 				const summary = makeSummary();
-				await SummaryWebviewPanel.show(summary, extensionUri, workspaceRoot);
+				await SummaryWebviewPanel.show(
+					summary,
+					extensionUri,
+					workspaceRoot,
+					stubBridge,
+					mainBranch,
+				);
 				const dispatch = captureMessageHandler();
 
 				dispatch({ command: "deleteAllTranscripts" });
@@ -3349,7 +3805,13 @@ describe("SummaryWebviewPanel", () => {
 			it("skips refresh when currentSummary is null during delete", async () => {
 				mockGetTranscriptHashes.mockResolvedValue(new Set(["abc123"]));
 				const summary = makeSummary();
-				await SummaryWebviewPanel.show(summary, extensionUri, workspaceRoot);
+				await SummaryWebviewPanel.show(
+					summary,
+					extensionUri,
+					workspaceRoot,
+					stubBridge,
+					mainBranch,
+				);
 				// Clear the summary after showing the panel
 				const panelInstance = firstCommitPanel<{ currentSummary: null }>();
 				panelInstance.currentSummary = null;
@@ -3409,7 +3871,13 @@ describe("SummaryWebviewPanel", () => {
 				(msg: Record<string, unknown>) => void
 			> {
 				const summary = makeSummary();
-				await SummaryWebviewPanel.show(summary, extensionUri, workspaceRoot);
+				await SummaryWebviewPanel.show(
+					summary,
+					extensionUri,
+					workspaceRoot,
+					stubBridge,
+					mainBranch,
+				);
 				const dispatch = captureMessageHandler();
 				const panelInstance = firstCommitPanel<{ currentSummary: null }>();
 				panelInstance.currentSummary = null;
@@ -3537,7 +4005,13 @@ describe("SummaryWebviewPanel", () => {
 				// The dispatch-level guard `if (this.currentSummary)` prevents handlePush
 				// from being called at all when the summary is cleared.
 				const summary = makeSummary();
-				await SummaryWebviewPanel.show(summary, extensionUri, workspaceRoot);
+				await SummaryWebviewPanel.show(
+					summary,
+					extensionUri,
+					workspaceRoot,
+					stubBridge,
+					mainBranch,
+				);
 				const panelInstance = firstCommitPanel<{ currentSummary: null }>();
 				panelInstance.currentSummary = null;
 				mockLoadConfig.mockClear();
@@ -3821,7 +4295,13 @@ describe("SummaryWebviewPanel", () => {
 			it("sets transcriptHashSet to empty on error", async () => {
 				mockGetTranscriptHashes.mockRejectedValue(new Error("git error"));
 				const summary = makeSummary();
-				await SummaryWebviewPanel.show(summary, extensionUri, workspaceRoot);
+				await SummaryWebviewPanel.show(
+					summary,
+					extensionUri,
+					workspaceRoot,
+					stubBridge,
+					mainBranch,
+				);
 
 				// buildHtml should have been called with an empty set
 				expect(mockBuildHtml).toHaveBeenCalledWith(
@@ -3839,7 +4319,13 @@ describe("SummaryWebviewPanel", () => {
 			it("handles non-Error rejection via String()", async () => {
 				mockGetTranscriptHashes.mockRejectedValue("string git error");
 				const summary = makeSummary();
-				await SummaryWebviewPanel.show(summary, extensionUri, workspaceRoot);
+				await SummaryWebviewPanel.show(
+					summary,
+					extensionUri,
+					workspaceRoot,
+					stubBridge,
+					mainBranch,
+				);
 
 				expect(warn).toHaveBeenCalledWith(
 					expect.stringContaining("Failed to load transcript hashes"),
@@ -3868,7 +4354,13 @@ describe("SummaryWebviewPanel", () => {
 						},
 					],
 				});
-				await SummaryWebviewPanel.show(summary, extensionUri, workspaceRoot);
+				await SummaryWebviewPanel.show(
+					summary,
+					extensionUri,
+					workspaceRoot,
+					stubBridge,
+					mainBranch,
+				);
 
 				// plan should NOT be in planTranslateSet because read failed
 				expect(mockBuildHtml).toHaveBeenCalledWith(
@@ -3906,7 +4398,13 @@ describe("SummaryWebviewPanel", () => {
 				mockReadTranscriptsForCommits.mockResolvedValue(transcriptMap);
 
 				const summary = makeSummary();
-				await SummaryWebviewPanel.show(summary, extensionUri, workspaceRoot);
+				await SummaryWebviewPanel.show(
+					summary,
+					extensionUri,
+					workspaceRoot,
+					stubBridge,
+					mainBranch,
+				);
 				const dispatch = captureMessageHandler();
 
 				dispatch({ command: "loadTranscriptStats" });
@@ -4074,7 +4572,13 @@ describe("SummaryWebviewPanel", () => {
 				);
 
 				const summary = makeSummary();
-				await SummaryWebviewPanel.show(summary, extensionUri, workspaceRoot);
+				await SummaryWebviewPanel.show(
+					summary,
+					extensionUri,
+					workspaceRoot,
+					stubBridge,
+					mainBranch,
+				);
 				const dispatch = captureMessageHandler();
 
 				dispatch({ command: "loadTranscriptStats" });
@@ -4091,7 +4595,13 @@ describe("SummaryWebviewPanel", () => {
 				mockReadTranscriptsForCommits.mockRejectedValue("string rejection");
 
 				const summary = makeSummary();
-				await SummaryWebviewPanel.show(summary, extensionUri, workspaceRoot);
+				await SummaryWebviewPanel.show(
+					summary,
+					extensionUri,
+					workspaceRoot,
+					stubBridge,
+					mainBranch,
+				);
 				const dispatch = captureMessageHandler();
 
 				dispatch({ command: "loadTranscriptStats" });
@@ -4132,7 +4642,13 @@ describe("SummaryWebviewPanel", () => {
 					]),
 				);
 				const summary = makeSummary();
-				await SummaryWebviewPanel.show(summary, extensionUri, workspaceRoot);
+				await SummaryWebviewPanel.show(
+					summary,
+					extensionUri,
+					workspaceRoot,
+					stubBridge,
+					mainBranch,
+				);
 				const dispatch = captureMessageHandler();
 
 				dispatch({
@@ -4243,7 +4759,13 @@ describe("SummaryWebviewPanel", () => {
 				]);
 				mockReadTranscriptsForCommits.mockResolvedValue(transcriptMap);
 				const summary = makeSummary();
-				await SummaryWebviewPanel.show(summary, extensionUri, workspaceRoot);
+				await SummaryWebviewPanel.show(
+					summary,
+					extensionUri,
+					workspaceRoot,
+					stubBridge,
+					mainBranch,
+				);
 				const dispatch = captureMessageHandler();
 
 				dispatch({ command: "loadAllTranscripts" });
@@ -4284,7 +4806,13 @@ describe("SummaryWebviewPanel", () => {
 					]),
 				);
 				const summary = makeSummary();
-				await SummaryWebviewPanel.show(summary, extensionUri, workspaceRoot);
+				await SummaryWebviewPanel.show(
+					summary,
+					extensionUri,
+					workspaceRoot,
+					stubBridge,
+					mainBranch,
+				);
 				const dispatch = captureMessageHandler();
 
 				dispatch({
@@ -4482,7 +5010,13 @@ describe("SummaryWebviewPanel", () => {
 
 			it("returns early when currentSummary is null", async () => {
 				const summary = makeSummary();
-				await SummaryWebviewPanel.show(summary, extensionUri, workspaceRoot);
+				await SummaryWebviewPanel.show(
+					summary,
+					extensionUri,
+					workspaceRoot,
+					stubBridge,
+					mainBranch,
+				);
 				const dispatch = captureMessageHandler();
 				const panelInstance = firstCommitPanel<{ currentSummary: null }>();
 				panelInstance.currentSummary = null;
@@ -5363,7 +5897,13 @@ describe("SummaryWebviewPanel", () => {
 				(msg: Record<string, unknown>) => void
 			> {
 				const summary = makeSummary();
-				await SummaryWebviewPanel.show(summary, extensionUri, workspaceRoot);
+				await SummaryWebviewPanel.show(
+					summary,
+					extensionUri,
+					workspaceRoot,
+					stubBridge,
+					mainBranch,
+				);
 				const dispatch = captureMessageHandler();
 				const panelInstance = firstCommitPanel<{ currentSummary: null }>();
 				panelInstance.currentSummary = null;
@@ -5635,7 +6175,13 @@ describe("SummaryWebviewPanel", () => {
 				mockReadTranscriptsForCommits.mockResolvedValue(transcriptMap);
 
 				const summary = makeSummary();
-				await SummaryWebviewPanel.show(summary, extensionUri, workspaceRoot);
+				await SummaryWebviewPanel.show(
+					summary,
+					extensionUri,
+					workspaceRoot,
+					stubBridge,
+					mainBranch,
+				);
 				const dispatch = captureMessageHandler();
 
 				dispatch({ command: "loadTranscriptStats" });

--- a/vscode/src/views/SummaryWebviewPanel.ts
+++ b/vscode/src/views/SummaryWebviewPanel.ts
@@ -62,6 +62,7 @@ import {
 	listAvailablePlans,
 	unassociatePlanFromCommit,
 } from "../core/PlanService.js";
+import type { JolliMemoryBridge } from "../JolliMemoryBridge.js";
 import {
 	BindingRequiredError,
 	deleteFromJolli,
@@ -74,15 +75,18 @@ import {
 	handleCreatePr,
 	handlePrepareUpdatePr,
 	handleUpdatePr,
+	isCommitReachableFromHead,
 	wrapWithMarkers,
 } from "../services/PrCommentService.js";
 import {
 	deriveRepoNameFromUrl,
 	getCanonicalRepoUrl,
 } from "../util/GitRemoteUtils.js";
+import { isWorkerBusy } from "../util/LockUtils.js";
 import { log } from "../util/Logger.js";
 import { loadGlobalConfig } from "../util/WorkspaceUtils.js";
 import { BindingChooserWebviewPanel } from "./BindingChooserWebviewPanel.js";
+import { loadBranchSummaries } from "./BranchSummaryLoader.js";
 import {
 	buildE2eTestSection,
 	buildHtml,
@@ -91,6 +95,7 @@ import {
 	renderTopic,
 } from "./SummaryHtmlBuilder.js";
 import { buildMarkdown } from "./SummaryMarkdownBuilder.js";
+import { buildAggregatedPrMarkdown } from "./SummaryPrAggregateMarkdownBuilder.js";
 import { buildPrMarkdown } from "./SummaryPrMarkdownBuilder.js";
 import {
 	buildBranchRelativePath,
@@ -170,6 +175,25 @@ interface TranscriptEntryUpdate {
 /** Source of the panel — determines which static slot it occupies. */
 export type SummaryPanelSource = "memory" | "commit" | "kb";
 
+// Single source of truth for Create/Update PR body assembly. Aggregates
+// when the branch has 2+ summaries; otherwise falls back to single-summary
+// `buildPrMarkdown` and (when missingCount > 0) appends a "K skipped"
+// footnote so partial-coverage branches don't render as misleading
+// single-commit PRs.
+function buildPrBodyMarkdown(
+	currentSummary: CommitSummary,
+	summaries: ReadonlyArray<CommitSummary>,
+	missingCount: number,
+	isCrossBranch: boolean,
+): string {
+	if (!isCrossBranch && summaries.length >= 2) {
+		return buildAggregatedPrMarkdown(summaries, missingCount);
+	}
+	const base = buildPrMarkdown(currentSummary);
+	if (missingCount <= 0) return base;
+	return `${base}\n\n> Note: ${missingCount} commit(s) without summary were skipped.`;
+}
+
 export class SummaryWebviewPanel {
 	/**
 	 * Single slot for panels opened from the Memories tree. Clicking another
@@ -210,16 +234,25 @@ export class SummaryWebviewPanel {
 	 */
 	private disposed = false;
 
+	private readonly bridge: JolliMemoryBridge;
+	// Snapshot of `CommitsStore.getMainBranch()` at panel creation. Revisit
+	// when `setMainBranch` is wired to a UI control (today there is no caller).
+	private readonly mainBranch: string;
+
 	private constructor(
 		extensionUri: vscode.Uri,
 		workspaceRoot: string,
 		source: SummaryPanelSource,
 		commitHash: string,
+		bridge: JolliMemoryBridge,
+		mainBranch: string,
 	) {
 		this.extensionUri = extensionUri;
 		this.workspaceRoot = workspaceRoot;
 		this.source = source;
 		this.commitHash = commitHash;
+		this.bridge = bridge;
+		this.mainBranch = mainBranch;
 		// Distinct viewType per source keeps the two panels independently identified by VSCode.
 		const viewType =
 			source === "memory"
@@ -476,24 +509,13 @@ export class SummaryWebviewPanel {
 				break;
 			case "prepareCreatePr":
 				if (this.currentSummary) {
-					const body = wrapWithMarkers(buildPrMarkdown(this.currentSummary));
-					const title = this.currentSummary.commitMessage;
-					void this.panel.webview.postMessage({
-						command: "prShowCreateForm",
-						body,
-						title,
-					});
+					this.catchAndShow(this.handlePrepareCreatePr(), "Prepare PR failed");
 				}
 				break;
 			case "prepareUpdatePr":
 				if (this.currentSummary) {
 					this.catchAndShow(
-						handlePrepareUpdatePr(
-							this.currentSummary,
-							this.workspaceRoot,
-							(msg) => this.panel.webview.postMessage(msg),
-							buildPrMarkdown,
-						),
+						this.handlePrepareUpdatePr(),
 						"Load PR data failed",
 					);
 				}
@@ -581,6 +603,8 @@ export class SummaryWebviewPanel {
 		summary: CommitSummary,
 		extensionUri: vscode.Uri,
 		workspaceRoot: string,
+		bridge: JolliMemoryBridge,
+		mainBranch: string,
 		source: SummaryPanelSource = "commit",
 	): Promise<void> {
 		const config = await loadGlobalConfig();
@@ -634,6 +658,8 @@ export class SummaryWebviewPanel {
 			workspaceRoot,
 			source,
 			summary.commitHash,
+			bridge,
+			mainBranch,
 		);
 		instance.pushAction = pushAction;
 		if (source === "memory") {
@@ -771,6 +797,106 @@ export class SummaryWebviewPanel {
 		const markdown = buildMarkdown(summary);
 		await vscode.workspace.fs.writeFile(uri, Buffer.from(markdown, "utf-8"));
 		vscode.window.showInformationMessage(`Saved to ${uri.fsPath}`);
+	}
+
+	private async handlePrepareCreatePr(): Promise<void> {
+		// biome-ignore lint/style/noNonNullAssertion: dispatch guard ensures currentSummary is set
+		const summary = this.currentSummary!;
+		const postMessage = (msg: Record<string, unknown>): void => {
+			this.panel.webview.postMessage(msg);
+		};
+
+		if (await this.handleWorkerBusyOrContinue(summary, postMessage)) {
+			return;
+		}
+
+		const { isCrossBranch, summaries, missingCount } =
+			await this.resolveBranchContext(summary);
+		const markdown = buildPrBodyMarkdown(
+			summary,
+			summaries,
+			missingCount,
+			isCrossBranch,
+		);
+		const useAggregate = !isCrossBranch && summaries.length >= 2;
+		const title = useAggregate
+			? summaries[summaries.length - 1].commitMessage
+			: summary.commitMessage;
+		postMessage({
+			command: "prShowCreateForm",
+			body: wrapWithMarkers(markdown),
+			title,
+		});
+	}
+
+	private async handlePrepareUpdatePr(): Promise<void> {
+		// biome-ignore lint/style/noNonNullAssertion: dispatch guard ensures currentSummary is set
+		const summary = this.currentSummary!;
+		const postMessage = (msg: Record<string, unknown>): void => {
+			this.panel.webview.postMessage(msg);
+		};
+
+		if (await this.handleWorkerBusyOrContinue(summary, postMessage)) {
+			return;
+		}
+
+		const { isCrossBranch, summaries, missingCount } =
+			await this.resolveBranchContext(summary);
+		const markdown = buildPrBodyMarkdown(
+			summary,
+			summaries,
+			missingCount,
+			isCrossBranch,
+		);
+
+		await handlePrepareUpdatePr(
+			summary.branch,
+			summary.commitHash,
+			markdown,
+			this.workspaceRoot,
+			postMessage,
+		);
+	}
+
+	// Returns true when worker is busy: shows the toast and re-runs the
+	// status check so the click-time "Loading..." button gets rebuilt.
+	private async handleWorkerBusyOrContinue(
+		summary: CommitSummary,
+		postMessage: (msg: Record<string, unknown>) => void,
+	): Promise<boolean> {
+		if (!(await isWorkerBusy(this.workspaceRoot))) {
+			return false;
+		}
+		vscode.window.showWarningMessage(
+			"Jolli Memory: AI summary is being generated. Please wait a moment.",
+		);
+		await handleCheckPrStatus(
+			this.workspaceRoot,
+			postMessage,
+			summary.branch,
+			summary.commitHash,
+		);
+		return true;
+	}
+
+	private async resolveBranchContext(summary: CommitSummary): Promise<{
+		isCrossBranch: boolean;
+		summaries: ReadonlyArray<CommitSummary>;
+		missingCount: number;
+	}> {
+		const isCrossBranch = !(await isCommitReachableFromHead(
+			this.workspaceRoot,
+			summary.commitHash,
+		));
+		if (isCrossBranch) {
+			return { isCrossBranch: true, summaries: [], missingCount: 0 };
+		}
+		const result = await loadBranchSummaries(this.bridge, this.mainBranch);
+		return {
+			isCrossBranch: false,
+			summaries: result.summaries,
+			missingCount: result.missingCount,
+		};
 	}
 
 	/**
@@ -1894,7 +2020,7 @@ export class SummaryWebviewPanel {
 				if (n.id !== id) {
 					return n;
 				}
-				const updates: Partial<NoteReference> = {};
+				const updates: { title?: string; content?: string } = {};
 				if (newTitle) {
 					updates.title = newTitle;
 				}
@@ -2044,7 +2170,7 @@ export class SummaryWebviewPanel {
 				if (n.id !== id) {
 					return n;
 				}
-				const updates: Partial<NoteReference> = {};
+				const updates: { title?: string; content?: string } = {};
 				if (newTitle) {
 					updates.title = newTitle;
 				}


### PR DESCRIPTION
<!-- jollimemory-summary-start -->
## Commits in this PR (2)

1. feat: Support multi-commit PRs with aggregated branch summaries (`4f1c7ea`)
2. Add BranchSummaryLoader and SummaryPrAggregateMarkdownBuilder for multi-commit PR support (`19b7fcf`)

## Quick recap (2)

### Commit 1 of 2: feat: Support multi-commit PRs with aggregated branch summaries (`4f1c7ea`)

The extension's pull request workflow was rebuilt to support branches with any number of commits. Previously, attempting to create or update a pull request on a branch with more than one commit was blocked outright. Now the extension reads all available commit summaries from the branch, assembles them into a single structured pull request body, and submits or updates the pull request in one operation. The body organizes content into a commit directory at the top, individual recap sections per commit, a flat list of end-to-end test scenarios tagged with their source commit, a deduplicated plans-and-notes section, and a merged topics list — each section capped at its own size limit to stay within GitHub's constraints. Branches with exactly one summarized commit and no missing summaries produce output identical to the previous behavior, preserving the existing experience for users who have not changed their workflow.

The push command received a parallel update: it now accepts any non-empty branch and shows the commit count in the force-push confirmation dialog when more than one commit would be affected. The "Push Branch" button also became visible in the multi-commit sidebar view, giving users a direct path to push without switching modes. Dependency injection was added to the panel layer so the new aggregation logic can access the storage bridge and the repository's main branch name at the point where summaries are loaded.

### Commit 2 of 2: Add BranchSummaryLoader and SummaryPrAggregateMarkdownBuilder for multi-commit PR support (`19b7fcf`)

Two new capabilities were added to support pull requests that span multiple commits. A branch summary loader now fetches per-commit summaries in chronological order, counting any commits whose summary is unavailable rather than failing the entire operation. Transient lookup failures are logged and treated as missing entries, keeping the PR view responsive even when individual git operations encounter errors.

An aggregated PR markdown builder combines the summaries from all commits on a branch into a single, structured PR body. It produces a directory of commits at the top, merges plans and notes from across commits without duplication, and assembles topics, E2E test scenarios, and per-commit recaps into clearly labelled sections. Each of the three large content sections enforces its own size budget and emits a visible warning when content is trimmed, ensuring the final output always fits within GitHub's PR body character limit regardless of how many commits the branch contains. All four sections of the PR body now share the same heading style, with a count of items in parentheses, giving the output a consistent visual structure throughout.

## E2E Test (4)
<details>
<summary><strong>1. [4f1c7ea] Multi-commit branch: creating a pull request</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a Git repository open in VS Code with the Jolli Memory extension installed. Make sure the current branch has at least two commits that are not yet on the remote (you can verify this by checking the Branch Commits panel — it should list two or more commits).

**Steps:**
1. Open the Jolli Memory sidebar panel in VS Code.
2. Navigate to the Branch Commits section and confirm you can see two or more commits listed.
3. Click the "Create Pull Request" button (or equivalent action) in the panel.
4. Wait for the pull request preparation screen to appear.
5. Check that a pull request body has been generated and is shown in the form — it should contain content from all commits on the branch, not just one.
6. Confirm there is no error message or warning saying the branch has "too many commits" or that only single-commit branches are supported.

**Expected Results:**
- The pull request creation form opens successfully without any blocking warning about commit count.
- The generated pull request body includes a summary that covers all commits on the branch (look for multiple sections or a commit directory at the top of the body).
- No "multiple commits" error or restriction message appears anywhere in the panel.

</blockquote>
</details>
<details>
<summary><strong>2. [19b7fcf] Multi-commit PR shows a directory of all commits with short hashes</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a branch with at least 2 commits, each with a saved Jolli Memory summary. Open the pull request view for that branch.

**Steps:**
1. Open the Jolli Memory panel and navigate to the pull request view for a branch that has 2 or more commits.
2. Click the button to generate or refresh the PR description.
3. Scroll to the top of the generated PR body.
4. Check that a "Commits in this PR (2)" heading appears, followed by a numbered list of commit messages.
5. Verify that each list item shows the commit message and a short 7-character code in backticks, for example: `AAAA123`.
6. Confirm the total count in the heading matches the number of commits shown in the list.

**Expected Results:**
- A "Commits in this PR (N)" heading is visible at the top of the PR body, where N equals the number of commits on the branch.
- Each commit appears as a numbered list item with its message and short hash in parentheses.
- No extra or duplicate entries appear in the list.

</blockquote>
</details>
<details>
<summary><strong>3. [19b7fcf] E2E test scenarios from all commits are combined into one numbered list with commit labels</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a branch with at least 2 commits, each containing at least one E2E test scenario in its summary.

**Steps:**
1. Open the Jolli Memory panel and navigate to the pull request view for the branch.
2. Click the button to generate or refresh the PR description.
3. Scroll to the "E2E Test" section of the generated PR body.
4. Check that scenarios from all commits appear together in a single numbered list.
5. Verify that each scenario title is prefixed with a short commit identifier in square brackets, for example "[AAAA123] Login flow".

**Expected Results:**
- A single "E2E Test (N)" section appears, where N is the total number of scenarios across all commits.
- Every scenario is numbered sequentially starting from 1.
- Each scenario title is prefixed with the short hash of the commit it came from, in square brackets.

</blockquote>
</details>
<details>
<summary><strong>4. [19b7fcf] Per-commit recap blocks appear only for commits that have recap text, and the section is absent when none do</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a branch with at least 3 commits: some with recap text in their summary and at least one without.

**Steps:**
1. Open the Jolli Memory panel and navigate to the pull request view for the branch.
2. Click the button to generate or refresh the PR description.
3. Scroll to the "Per-Commit Recap" section of the generated PR body.
4. Check that only commits with recap text have a sub-heading and recap content.
5. Confirm that commits without recap text do not appear in this section at all.
6. Now test with a branch where no commit has recap text: regenerate the PR body and verify the "Per-Commit Recap" section does not appear anywhere.

**Expected Results:**
- The "Per-Commit Recap" section lists only the commits that have recap content, each under a heading like "Commit 1 of 3: message (`shortHash`)".
- Commits without recap text are silently skipped — no empty heading or blank block appears for them.
- When no commit on the branch has recap text, the entire "Per-Commit Recap" section is absent from the PR body.

</blockquote>
</details>

## Topics (7)
<details>
<summary><strong>01 · [4f1c7ea] Remove single-commit restriction so branches with multiple commits can create pull requests</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The extension blocked users from creating or updating a pull request whenever a branch contained more than one commit. Since a pull request on GitHub always represents an entire branch — not a single commit — this restriction was incorrect and prevented normal multi-commit development workflows.

**💡 Decisions Behind the Code**

- **Aggregate the whole branch rather than use the current commit's summary alone**: A pull request on GitHub always contains every commit on the branch, so a PR description that only reflected one commit would mislead reviewers. Aggregating all summaries into a single structured body gives reviewers a complete picture and makes repeated "Update PR" calls produce the same output regardless of which commit's panel triggered the action.
- **Single-commit branches bypass the aggregation path entirely**: When a branch has exactly one summarized commit and no missing summaries, the output is byte-for-byte identical to the previous single-commit renderer. This preserves existing behavior for the common case and avoids any regression risk for users who have not changed their workflow.
- **Worker-busy state resets the button by re-running the status check**: When the AI summary worker is still running at the moment a user clicks "Create PR" or "Update PR", the button is already in a loading state. Rather than introducing a new cancel message, the handler re-triggers the existing PR status check, which rebuilds the PR section and naturally restores the button to its default state.

**✅ What Was Implemented**

- Removed the commit-count gate from `PrCommentService.ts` along with the helper functions (`getCommitCount`, `resolveUpstreamBaseline`) that powered it. The `handlePrepareUpdatePr` function signature was updated to accept a pre-built markdown string, branch name, and commit hash separately, moving rendering responsibility upstream to the panel layer. The `multipleCommits` webview status and its associated JavaScript branch in the PR section builder were also deleted.
- Added `BranchSummaryLoader.ts`, a new module that enumerates all commit summaries on the current branch by calling the bridge's storage-aware lookup for each commit hash. It uses `Promise.allSettled` so a single failed lookup does not abort the entire load, and returns both the found summaries and a count of commits with no summary.
- Added `SummaryPrAggregateMarkdownBuilder.ts`, which assembles a pull request body from multiple commit summaries. The output groups content into a commit directory at the top, per-commit recap sections, a flat list of end-to-end test scenarios with short-hash prefixes, a deduplicated plans-and-notes section, and a merged topics list — each section with its own size budget to keep the total body within GitHub's limits.

**📋 Future Enhancements**

Pre-existing TypeScript type errors in unrelated files (Extension.ts, JolliMemoryBridge.ts, several test files) and CLI test failures on Windows path separators remain unresolved. These existed before this branch and are tracked separately.

**📁 FILES**
- `vscode/src/services/PrCommentService.ts`
- `vscode/src/views/BranchSummaryLoader.ts`
- `vscode/src/views/SummaryPrAggregateMarkdownBuilder.ts`
- `vscode/src/views/SummaryWebviewPanel.ts`
- `vscode/src/commands/PushCommand.ts`

</blockquote>
</details>
<details>
<summary><strong>02 · [4f1c7ea] Push command updated to support multi-commit branches with improved force-push messaging</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The push command previously rejected any branch that did not have exactly one commit, which meant users with multi-commit branches could not push from the panel at all. Removing that restriction also required updating the force-push confirmation dialog to accurately reflect how many commits would be affected.

**💡 Decisions Behind the Code**

- **Guard on zero commits rather than non-one commits**: The original guard was written when only single-commit branches were supported, so `!== 1` happened to catch both the empty-branch case and the multi-commit case. Splitting these into separate conditions makes the intent explicit: empty branches are always rejected, multi-commit branches are now valid.
- **Show commit count in the force-push dialog**: A force-push on a multi-commit branch rewrites more remote history than a single-commit one, so the confirmation message was updated to surface the count. This gives users enough information to make an informed decision without requiring them to check the panel separately.

**✅ What Was Implemented**

- Replaced the `commits.length !== 1` rejection in `PushCommand.ts` with a `commits.length === 0` guard that warns and exits only for genuinely empty branches. This preserves protection against pushing when there is nothing to push while allowing any non-empty branch through.
- Updated `showForcePushWarning` to accept the full commits array. The dialog now shows "Commit: hash message" for single-commit branches and "HEAD (N commits): hash message" for multi-commit branches, giving users a clear count of what the force-push will replace on the remote.

**📁 FILES**
- `vscode/src/commands/PushCommand.ts`

</blockquote>
</details>
<details>
<summary><strong>03 · [4f1c7ea] Panel dependency injection: bridge and main branch name passed in at creation time</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The new aggregation logic needed access to the storage bridge and the name of the repository's main branch, but the panel was created without either. Without these, the panel could not load branch summaries or determine which commits were ahead of the base branch.

**💡 Decisions Behind the Code**

- **Snapshot the main branch name as a plain string rather than holding a live reference**: The main branch name is effectively constant for the lifetime of a panel session. Passing a snapshot at construction time keeps the panel's dependencies simple and avoids coupling it to the store's internal state. If the branch name ever becomes dynamic, the panel can be rebuilt at that point.
- **Add a public getter to the store rather than routing through the bridge**: The main branch name lives in the commits store, not in the bridge. Inventing a bridge accessor for data the bridge does not own would have misrepresented the architecture. A minimal getter on the store exposes only what is needed.

**✅ What Was Implemented**

- Extended the `SummaryWebviewPanel` constructor and its static `show` method to accept a bridge reference and a main-branch name string. All three call sites in `Extension.ts` were updated to pass these values, sourcing the branch name from a new `getMainBranch()` getter added to `CommitsStore`.
- Added `handlePrepareCreatePr` and `handlePrepareUpdatePr` as private async methods on the panel, replacing inline `await` expressions that would have caused a compile error inside the synchronous message dispatcher. The dispatcher now delegates to these methods via the existing error-catching helper.

**📁 FILES**
- `vscode/src/views/SummaryWebviewPanel.ts`
- `vscode/src/stores/CommitsStore.ts`
- `vscode/src/Extension.ts`

</blockquote>
</details>
<details>
<summary><strong>04 · [4f1c7ea] Sidebar push button exposed in multi-commit view mode</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Users working on branches with multiple commits had no way to push the branch from the sidebar panel because the "Push Branch" button was only rendered in single-commit mode.

**💡 Decisions Behind the Code**

Exposing the button in multi-commit mode is consistent with the broader change that removed the single-commit restriction from the push command itself. Hiding it would have left users with no discoverable path to push a multi-commit branch from the panel.

**✅ What Was Implemented**

Added the Push Branch button to the multi-commit toolbar in `SidebarScriptBuilder.ts` so it appears regardless of how many commits the branch contains.

**📁 FILES**
- `vscode/src/views/SidebarScriptBuilder.ts`

</blockquote>
</details>
<details>
<summary><strong>05 · [4f1c7ea] Design document written and iteratively refined before implementation began</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The team needed a shared, reviewable plan before touching production code, covering the aggregation strategy, edge cases, and the exact sequence of implementation steps.

**💡 Decisions Behind the Code**

- **Aggregate content by type rather than repeating the full summary block per commit**: Grouping all recaps together, all test scenarios together, and all topics together makes the pull request body easier to scan than N identical-structure blocks stacked vertically. End-to-end scenarios and topics are discrete list items that read naturally when merged; recaps are prose and must stay per-commit to preserve narrative coherence.
- **Use the bridge's storage-aware lookup rather than calling the underlying library directly**: The bridge maintains a configured storage backend that may differ from the library's default. Bypassing it would have caused summaries to be read from the wrong location in non-default storage configurations, a subtle correctness bug that would only surface in specific setups.

**✅ What Was Implemented**

Created `docs/feature-allow-multi-commit-pr.md` capturing the full design: aggregation layout (commit directory, per-commit recaps, flat end-to-end scenarios, merged topics), size budgets for each section, routing rules for single-commit and missing-summary edge cases, dependency injection requirements, and a seven-step implementation sequence. The document went through two rounds of automated review that caught six and five issues respectively, each round followed by targeted corrections before any code was written.

**📁 FILES**
- `docs/feature-allow-multi-commit-pr.md`

</blockquote>
</details>
<details>
<summary><strong>06 · [19b7fcf] Load all commit summaries for a branch in chronological order</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The PR view needed to display summaries for every commit on a branch, not just the most recent one. A reliable way to fetch all per-commit summaries in the correct order was required, with graceful handling of missing or failing lookups.

**💡 Decisions Behind the Code**

- **Routing through the bridge instead of the CLI directly**: Calling the bridge's summary lookup rather than the CLI's standalone function ensures the lookup passes through the bridge's lazy storage-provider selection. Bypassing the bridge would silently ignore the user's configured storage backend, producing incorrect results for non-default setups.
- **`Promise.allSettled` over `Promise.all`**: A single transient git failure would reject the entire load with `Promise.all`, leaving the PR view stuck on "Loading…" with no recovery path. `allSettled` lets each failure degrade independently into a missing-count increment and a warn log, keeping the rest of the summaries usable.
- **Chronological reordering at load time**: The commit enumeration API returns commits newest-first (matching git log conventions), but the PR body reads as a story from oldest to newest. Reversing once at the loader boundary keeps all downstream consumers free of ordering concerns and makes the intent explicit at the point where the data enters the pipeline.

**✅ What Was Implemented**

- Created `vscode/src/views/BranchSummaryLoader.ts` exporting `loadBranchSummaries`, which calls `bridge.listBranchCommits` to enumerate commits on `base..HEAD`, reverses the newest-first list into chronological order, then fans out to `bridge.getSummary` for each hash using `Promise.allSettled`.
- The result shape (`BranchSummariesResult`) carries the ordered `summaries` array and a `missingCount` integer for commits whose summary was absent or whose fetch failed. Failed fetches are warn-logged with the short hash and error message rather than surfaced as exceptions.

**📁 FILES**
- `vscode/src/views/BranchSummaryLoader.ts`

</blockquote>
</details>
<details>
<summary><strong>07 · [19b7fcf] Build aggregated PR markdown body for multi-commit branches</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

When a branch contains more than one commit, the existing single-commit PR markdown builder was insufficient. A new builder was needed to merge topics, plans, notes, E2E scenarios, and per-commit recaps from multiple summaries into one coherent PR body that fits within GitHub's character limit.

**💡 Decisions Behind the Code**

- **Independent per-section size budgets**: Assigning separate character budgets to Topics, E2E, and Recap rather than a single shared pool means that one unusually large section cannot silently crowd out the others. Each section truncates independently and emits its own footnote, giving reviewers a clear signal about what was cut and from which area.
- **Deduplication by URL with slug/id fallback**: Plans and notes can be referenced by multiple commits in the same branch. Using the canonical document URL as the dedup key (falling back to a prefixed slug or id when no URL exists) avoids duplicates regardless of whether the references carry URLs, without requiring a deep equality comparison of the full reference objects.
- **Precondition guard requiring at least two summaries**: The function throws immediately when called with fewer than two summaries, enforcing that callers route single-commit branches to the existing single-summary builder. This keeps the aggregate builder's logic clean and prevents subtle rendering differences from appearing silently for single-commit PRs.
- **Uniform "Quick recap (N)" heading over a distinct label**: Reusing the existing heading pattern already established by the Commits, E2E, and Topics sections keeps all four PR body sections visually and semantically uniform. Introducing a distinct label for the per-commit block would have required readers to learn a separate naming convention for functionally the same kind of content.

**✅ What Was Implemented**

- Created `vscode/src/views/SummaryPrAggregateMarkdownBuilder.ts` exporting `buildAggregatedPrMarkdown`, which accepts an ordered array of commit summary objects and a missing count. It renders a directory header listing each commit with its short hash and optional memory link, then aggregates plans, notes, E2E scenarios, topics, and per-commit recaps into labelled sections.
- Plans and notes are deduplicated across commits using the canonical document URL (falling back to a prefixed slug or id when no URL exists) as keys, so the same plan or note referenced by multiple commits appears only once.
- Each of the three large sections — Topics (65 K), E2E (60 K), and Quick Recap (50 K) — has an independent soft-limit budget; content that exceeds the budget is truncated and replaced with a visible `⚠️ N more … omitted` footnote, keeping the total output within GitHub's 65 536-character PR body limit.
- The per-commit recap section header uses the `## Quick recap (N)` pattern, where N is the count of commits with a non-empty recap, matching the heading style of the other PR body sections.

**📁 FILES**
- `vscode/src/views/SummaryPrAggregateMarkdownBuilder.ts`

</blockquote>
</details>

---

*Generated by Jolli Memory · May 6, 2026 at 5:32 PM*
<!-- jollimemory-summary-end -->