### PR TITLE
fix: Windows compatibility for test suite and npm spawn

### DIFF
--- a/cli/src/Cli.ts
+++ b/cli/src/Cli.ts
@@ -24,7 +24,7 @@
  *   export-prompt — Print prompt templates to stdout
  */
 
-import { Command } from "commander";
+import { Command, Help } from "commander";
 import { registerAuthCommands } from "./commands/AuthCommand.js";
 import { registerCleanCommand } from "./commands/CleanCommand.js";
 import { checkVersionMismatch, VERSION } from "./commands/CliUtils.js";
@@ -52,15 +52,123 @@ export async function main(args?: ReadonlyArray<string>): Promise<void> {
 	setSilentConsole(true);
 
 	const program = new Command();
-	program.name("jolli").description("AI development process auto-documentation tool").version(VERSION);
+	program
+		.name("jolli")
+		.description("Auto-document AI development sessions and generate documentation sites")
+		.version(VERSION);
 
 	// Hide internal commands (migrate, export-prompt) from --help output.
 	// They remain fully functional when invoked directly.
 	const HIDDEN_COMMANDS = new Set(["migrate", "export-prompt"]);
+
+	// Group visible commands into two product surfaces in --help output.
+	const MEMORY_COMMAND_NAMES = new Set([
+		"enable",
+		"disable",
+		"status",
+		"configure",
+		"clean",
+		"doctor",
+		"view",
+		"recall",
+		"export",
+		"auth",
+	]);
+	const SITE_COMMAND_NAMES = new Set(["new", "convert", "dev", "build", "start"]);
+
+	const MEMORY_DESCRIPTION =
+		"Auto-documents your AI-assisted development. Lightweight git and AI-agent\nhooks turn each commit into a structured summary (intent, decisions,\nprogress) stored on a git orphan branch, so you can recall context across\nbranches, machines, and teammates.";
+
+	const SITE_DESCRIPTION =
+		"Generates a docs site from a content folder of Markdown/MDX and OpenAPI\nspecs. Scaffold a new project, build a static site with full-text search,\nor run a hot-reload dev server while you write.";
+
+	const formatGroupedHelp = (cmd: Command, helper: Help): string => {
+		// Grouping by Memory/Site only makes sense at the root program. For
+		// subcommand help (e.g. `jolli auth --help`), defer to Commander's
+		// default formatter — visibleCommands is still applied so hidden
+		// commands stay filtered.
+		if (cmd.parent !== null) {
+			return Help.prototype.formatHelp.call(helper, cmd, helper);
+		}
+
+		const itemIndent = "  ";
+		const visibleCmds = helper.visibleCommands(cmd);
+		const visibleOpts = helper.visibleOptions(cmd);
+
+		// Compute a single column width across all rendered terms so options and
+		// both command groups line up consistently.
+		const allTerms = [
+			...visibleOpts.map((o) => helper.optionTerm(o)),
+			...visibleCmds.map((c) => helper.subcommandTerm(c)),
+		];
+		const termWidth = allTerms.reduce((max, t) => Math.max(max, t.length), 0);
+
+		const formatRow = (term: string, description: string): string =>
+			helper.formatItem(term, termWidth, description, helper);
+
+		const renderSectionDescription = (text: string): string =>
+			text
+				.split("\n")
+				.map((line) => `${itemIndent}${line}`)
+				.join("\n");
+
+		const memoryCmds = visibleCmds.filter((c) => MEMORY_COMMAND_NAMES.has(c.name()));
+		const siteCmds = visibleCmds.filter((c) => SITE_COMMAND_NAMES.has(c.name()));
+		const otherCmds = visibleCmds.filter(
+			(c) => !MEMORY_COMMAND_NAMES.has(c.name()) && !SITE_COMMAND_NAMES.has(c.name()),
+		);
+
+		const lines: string[] = [];
+		lines.push(`Usage: ${helper.commandUsage(cmd)}`, "");
+
+		const description = helper.commandDescription(cmd);
+		if (description) lines.push(description, "");
+
+		if (visibleOpts.length > 0) {
+			lines.push("Options:");
+			for (const opt of visibleOpts) {
+				lines.push(formatRow(helper.optionTerm(opt), helper.optionDescription(opt)));
+			}
+			lines.push("");
+		}
+
+		if (memoryCmds.length > 0) {
+			lines.push("Jolli Memory — Auto-document AI development sessions");
+			lines.push(renderSectionDescription(MEMORY_DESCRIPTION), "");
+			lines.push("Commands:");
+			for (const c of memoryCmds) {
+				lines.push(formatRow(helper.subcommandTerm(c), helper.subcommandDescription(c)));
+			}
+			lines.push("");
+		}
+
+		if (siteCmds.length > 0) {
+			lines.push("Jolli Site — Generate a docs site from your content folder");
+			lines.push(renderSectionDescription(SITE_DESCRIPTION), "");
+			lines.push("Commands:");
+			for (const c of siteCmds) {
+				lines.push(formatRow(helper.subcommandTerm(c), helper.subcommandDescription(c)));
+			}
+			lines.push("");
+		}
+
+		if (otherCmds.length > 0) {
+			lines.push("Other commands:");
+			for (const c of otherCmds) {
+				lines.push(formatRow(helper.subcommandTerm(c), helper.subcommandDescription(c)));
+			}
+			lines.push("");
+		}
+
+		lines.push("Run `jolli <command> --help` for command-specific options.");
+		return `${lines.join("\n")}\n`;
+	};
+
 	program.configureHelp({
 		visibleCommands(cmd) {
 			return cmd.commands.filter((c) => !HIDDEN_COMMANDS.has(c.name()));
 		},
+		formatHelp: formatGroupedHelp,
 	});
 
 	registerEnableCommand(program);

--- a/cli/src/commands/AuthCommand.ts
+++ b/cli/src/commands/AuthCommand.ts
@@ -9,10 +9,14 @@ import { browserLogin } from "../auth/Login.js";
 import { loadConfig } from "../core/SessionTracker.js";
 
 export function registerAuthCommands(program: Command): void {
-	const auth = program.command("auth").description("Authentication commands");
+	const auth = program
+		.command("auth")
+		.description("Sign in to Jolli to generate AI summaries without an Anthropic API key");
 
 	auth.command("login")
-		.description("Log in to Jolli via browser")
+		.description(
+			"Log in via browser and save a Jolli API Key — for users with claude.ai access but no Anthropic API key, this key is what powers AI summary generation",
+		)
 		.action(async () => {
 			try {
 				await browserLogin(getJolliUrl());
@@ -31,7 +35,7 @@ export function registerAuthCommands(program: Command): void {
 		});
 
 	auth.command("logout")
-		.description("Clear stored auth credentials")
+		.description("Clear the stored Jolli auth token and Jolli API Key (Anthropic API key, if any, is preserved)")
 		.action(async () => {
 			await clearAuthCredentials();
 			const config = await loadConfig();
@@ -47,7 +51,7 @@ export function registerAuthCommands(program: Command): void {
 		});
 
 	auth.command("status")
-		.description("Show current authentication state")
+		.description("Show whether you're signed in and whether a Jolli API Key is configured")
 		.action(async () => {
 			const token = await loadAuthToken();
 			const config = await loadConfig();

--- a/cli/src/commands/StartCommand.test.ts
+++ b/cli/src/commands/StartCommand.test.ts
@@ -12,7 +12,7 @@
  *   - Defaults source-root to process.cwd() when not provided
  */
 
-import { resolve } from "node:path";
+import { join, resolve } from "node:path";
 import { Command } from "commander";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { getBuildDir } from "./StartCommand.js";
@@ -224,7 +224,9 @@ describe.each([
 		const program = await makeProgram();
 		await program.parseAsync([cmd, "/nonexistent"], { from: "user" });
 
-		expect(consoleErrorSpy.mock.calls.map((c: unknown[]) => c.join(" ")).join("\n")).toContain("/nonexistent");
+		expect(consoleErrorSpy.mock.calls.map((c: unknown[]) => c.join(" ")).join("\n")).toContain(
+			resolve("/nonexistent"),
+		);
 		expect(process.exitCode).toBe(1);
 	});
 
@@ -314,7 +316,7 @@ describe.each([
 		await program.parseAsync([cmd, "/my-docs"], { from: "user" });
 
 		const [, calledContentDir] = mockMirrorContent.mock.calls[0] as [string, string];
-		expect(calledContentDir).toBe(`${getBuildDir(resolve("/my-docs"))}/content`);
+		expect(calledContentDir).toBe(join(getBuildDir(resolve("/my-docs")), "content"));
 	});
 });
 

--- a/cli/src/core/CursorDetector.test.ts
+++ b/cli/src/core/CursorDetector.test.ts
@@ -92,18 +92,21 @@ describe("getCursorGlobalDbPath", () => {
 	it("returns the darwin path", () => {
 		mockPlatform.mockReturnValue("darwin");
 		expect(getCursorGlobalDbPath()).toBe(
-			"/home/user/Library/Application Support/Cursor/User/globalStorage/state.vscdb",
+			join("/home/user", "Library", "Application Support", "Cursor", "User", "globalStorage", "state.vscdb"),
 		);
 	});
 
 	it("returns the linux path", () => {
 		mockPlatform.mockReturnValue("linux");
-		expect(getCursorGlobalDbPath()).toBe("/home/user/.config/Cursor/User/globalStorage/state.vscdb");
+		expect(getCursorGlobalDbPath()).toBe(
+			join("/home/user", ".config", "Cursor", "User", "globalStorage", "state.vscdb"),
+		);
 	});
 
 	it("returns a Cursor-rooted path on win32", () => {
 		mockPlatform.mockReturnValue("win32");
-		const path = getCursorGlobalDbPath();
-		expect(path.endsWith("Cursor/User/globalStorage/state.vscdb")).toBe(true);
+		const result = getCursorGlobalDbPath();
+		const suffix = join("Cursor", "User", "globalStorage", "state.vscdb");
+		expect(result.endsWith(suffix)).toBe(true);
 	});
 });

--- a/cli/src/core/CursorSessionDiscoverer.test.ts
+++ b/cli/src/core/CursorSessionDiscoverer.test.ts
@@ -1,8 +1,26 @@
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 import { DatabaseSync } from "node:sqlite";
+import { pathToFileURL } from "node:url";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Converts a POSIX-style absolute path to a file:// URI that is valid on the
+ * current host. On Windows, `fileURLToPath` rejects URIs without a drive
+ * letter, so we go through `pathToFileURL(resolve(...))` to get a proper URI.
+ */
+function toFileUri(posixPath: string): string {
+	return pathToFileURL(resolve(posixPath)).href;
+}
+
+/**
+ * Returns the native absolute path for a POSIX-style absolute path.
+ * On Windows `/Users/flyer/work` becomes e.g. `D:\Users\flyer\work`.
+ */
+function toNativePath(posixPath: string): string {
+	return resolve(posixPath);
+}
 
 vi.spyOn(console, "log").mockImplementation(() => {});
 vi.spyOn(console, "warn").mockImplementation(() => {});
@@ -109,7 +127,7 @@ describe("discoverCursorSessions", () => {
 
 	it("returns [] when projectDir does not match any workspace", async () => {
 		await setupCursorHome(tmpHome, { globalComposers: [], workspaces: [] });
-		const sessions = await discoverCursorSessions("/Users/flyer/jolli/code/somewhere");
+		const sessions = await discoverCursorSessions(toNativePath("/Users/flyer/jolli/code/somewhere"));
 		expect(sessions).toEqual([]);
 	});
 
@@ -119,13 +137,13 @@ describe("discoverCursorSessions", () => {
 			globalComposers: [{ composerId: "anchor-1", createdAtMs: ancientTs, lastUpdatedAtMs: ancientTs }],
 			workspaces: [
 				{
-					folder: "file:///Users/flyer/work/proj-a",
+					folder: toFileUri("/Users/flyer/work/proj-a"),
 					pointers: { lastFocusedComposerIds: ["anchor-1"] },
 				},
 			],
 		});
 
-		const sessions = await discoverCursorSessions("/Users/flyer/work/proj-a");
+		const sessions = await discoverCursorSessions(toNativePath("/Users/flyer/work/proj-a"));
 		expect(sessions).toHaveLength(1);
 		expect(sessions[0]).toMatchObject({ sessionId: "anchor-1", source: "cursor" });
 		expect(sessions[0].transcriptPath).toContain("#anchor-1");
@@ -142,13 +160,13 @@ describe("discoverCursorSessions", () => {
 			],
 			workspaces: [
 				{
-					folder: "file:///Users/flyer/work/proj-a",
+					folder: toFileUri("/Users/flyer/work/proj-a"),
 					pointers: { lastFocusedComposerIds: ["anchor-1"] },
 				},
 			],
 		});
 
-		const sessions = await discoverCursorSessions("/Users/flyer/work/proj-a");
+		const sessions = await discoverCursorSessions(toNativePath("/Users/flyer/work/proj-a"));
 		const ids = sessions.map((s) => s.sessionId).sort();
 		expect(ids).toEqual(["anchor-1", "fresh-2"]);
 	});
@@ -158,13 +176,13 @@ describe("discoverCursorSessions", () => {
 			globalComposers: [{ composerId: "c-1", createdAtMs: Date.now(), lastUpdatedAtMs: Date.now() }],
 			workspaces: [
 				{
-					folder: "file:///Users/Flyer/Code%20Folder/Proj",
+					folder: toFileUri("/Users/Flyer/Code Folder/Proj"),
 					pointers: { lastFocusedComposerIds: ["c-1"] },
 				},
 			],
 		});
 
-		const sessions = await discoverCursorSessions("/users/flyer/code folder/proj");
+		const sessions = await discoverCursorSessions(toNativePath("/users/flyer/code folder/proj"));
 		expect(sessions).toHaveLength(1);
 	});
 
@@ -174,13 +192,13 @@ describe("discoverCursorSessions", () => {
 			globalComposers: [{ composerId: "stale-1", createdAtMs: stale, lastUpdatedAtMs: stale }],
 			workspaces: [
 				{
-					folder: "file:///Users/flyer/work/proj-a",
+					folder: toFileUri("/Users/flyer/work/proj-a"),
 					pointers: null,
 				},
 			],
 		});
 
-		const sessions = await discoverCursorSessions("/Users/flyer/work/proj-a");
+		const sessions = await discoverCursorSessions(toNativePath("/Users/flyer/work/proj-a"));
 		expect(sessions).toEqual([]);
 	});
 
@@ -191,7 +209,7 @@ describe("discoverCursorSessions", () => {
 		await mkdir(join(userDir, "workspaceStorage", "ws-00000000"), { recursive: true });
 		await writeFile(
 			join(userDir, "workspaceStorage", "ws-00000000", "workspace.json"),
-			JSON.stringify({ folder: "file:///Users/flyer/work/proj-a" }),
+			JSON.stringify({ folder: toFileUri("/Users/flyer/work/proj-a") }),
 		);
 
 		// Workspace DB with anchor pointing to good-1
@@ -216,7 +234,7 @@ describe("discoverCursorSessions", () => {
 			.run("composerData:bad-2", "this is not json");
 		globalDb.close();
 
-		const sessions = await discoverCursorSessions("/Users/flyer/work/proj-a");
+		const sessions = await discoverCursorSessions(toNativePath("/Users/flyer/work/proj-a"));
 		expect(sessions.map((s) => s.sessionId)).toEqual(["good-1"]);
 	});
 
@@ -226,7 +244,7 @@ describe("discoverCursorSessions", () => {
 		await mkdir(join(userDir, "workspaceStorage", "ws-00000000"), { recursive: true });
 		await writeFile(
 			join(userDir, "workspaceStorage", "ws-00000000", "workspace.json"),
-			JSON.stringify({ folder: "file:///Users/flyer/work/proj-a" }),
+			JSON.stringify({ folder: toFileUri("/Users/flyer/work/proj-a") }),
 		);
 
 		const wsDbPath = join(userDir, "workspaceStorage", "ws-00000000", "state.vscdb");
@@ -247,7 +265,7 @@ describe("discoverCursorSessions", () => {
 			.run("composerData:c-2", JSON.stringify({ composerId: 12345, lastUpdatedAt: Date.now() }));
 		globalDb.close();
 
-		const sessions = await discoverCursorSessions("/Users/flyer/work/proj-a");
+		const sessions = await discoverCursorSessions(toNativePath("/Users/flyer/work/proj-a"));
 		expect(sessions).toEqual([]);
 	});
 
@@ -257,7 +275,7 @@ describe("discoverCursorSessions", () => {
 		await mkdir(join(userDir, "workspaceStorage", "ws-00000000"), { recursive: true });
 		await writeFile(
 			join(userDir, "workspaceStorage", "ws-00000000", "workspace.json"),
-			JSON.stringify({ folder: "file:///Users/flyer/work/proj-a" }),
+			JSON.stringify({ folder: toFileUri("/Users/flyer/work/proj-a") }),
 		);
 
 		const wsDbPath = join(userDir, "workspaceStorage", "ws-00000000", "state.vscdb");
@@ -282,7 +300,7 @@ describe("discoverCursorSessions", () => {
 			.run("composerData:other-bad", JSON.stringify({ composerId: "other-bad", lastUpdatedAt: null }));
 		globalDb.close();
 
-		const sessions = await discoverCursorSessions("/Users/flyer/work/proj-a");
+		const sessions = await discoverCursorSessions(toNativePath("/Users/flyer/work/proj-a"));
 		expect(sessions).toEqual([]);
 	});
 
@@ -302,7 +320,7 @@ describe("discoverCursorSessions", () => {
 		);
 		createCursorWorkspaceDb(join(wsDir, "state.vscdb"), { lastFocusedComposerIds: ["c-1"] });
 
-		const sessions = await discoverCursorSessions("/Users/flyer/work/proj-a");
+		const sessions = await discoverCursorSessions(toNativePath("/Users/flyer/work/proj-a"));
 		expect(sessions).toEqual([]);
 	});
 
@@ -315,7 +333,10 @@ describe("discoverCursorSessions", () => {
 
 		const wsDir = join(userDir, "workspaceStorage", "ws-00000000");
 		await mkdir(wsDir, { recursive: true });
-		await writeFile(join(wsDir, "workspace.json"), JSON.stringify({ folder: "file:///Users/flyer/work/proj-a" }));
+		await writeFile(
+			join(wsDir, "workspace.json"),
+			JSON.stringify({ folder: toFileUri("/Users/flyer/work/proj-a") }),
+		);
 
 		// Workspace DB has the composer.composerData key but with garbage JSON
 		const wsDb = new DatabaseSync(join(wsDir, "state.vscdb"));
@@ -328,7 +349,7 @@ describe("discoverCursorSessions", () => {
 
 		// No anchors should be extracted; the stale composer is outside the time window;
 		// overall result is empty without the read crashing.
-		const sessions = await discoverCursorSessions("/Users/flyer/work/proj-a");
+		const sessions = await discoverCursorSessions(toNativePath("/Users/flyer/work/proj-a"));
 		expect(sessions).toEqual([]);
 	});
 
@@ -338,7 +359,7 @@ describe("discoverCursorSessions", () => {
 			globalComposers: [{ composerId: "selected-1", createdAtMs: ancientTs, lastUpdatedAtMs: ancientTs }],
 			workspaces: [
 				{
-					folder: "file:///Users/flyer/work/proj-a",
+					folder: toFileUri("/Users/flyer/work/proj-a"),
 					pointers: null, // creates the DB with tables but no composer.composerData row
 				},
 			],
@@ -360,7 +381,7 @@ describe("discoverCursorSessions", () => {
 		);
 		wsDb.close();
 
-		const sessions = await discoverCursorSessions("/Users/flyer/work/proj-a");
+		const sessions = await discoverCursorSessions(toNativePath("/Users/flyer/work/proj-a"));
 		expect(sessions).toHaveLength(1);
 		expect(sessions[0].sessionId).toBe("selected-1");
 	});
@@ -390,11 +411,11 @@ describe("discoverCursorSessions", () => {
 		await mkdir(goodWsDir, { recursive: true });
 		await writeFile(
 			join(goodWsDir, "workspace.json"),
-			JSON.stringify({ folder: "file:///Users/flyer/work/proj-a" }),
+			JSON.stringify({ folder: toFileUri("/Users/flyer/work/proj-a") }),
 		);
 		createCursorWorkspaceDb(join(goodWsDir, "state.vscdb"), { lastFocusedComposerIds: ["c-1"] });
 
-		const sessions = await discoverCursorSessions("/Users/flyer/work/proj-a");
+		const sessions = await discoverCursorSessions(toNativePath("/Users/flyer/work/proj-a"));
 		expect(sessions).toHaveLength(1);
 		expect(sessions[0].sessionId).toBe("c-1");
 	});
@@ -412,10 +433,13 @@ describe("discoverCursorSessions", () => {
 
 		const wsDir = join(userDir, "workspaceStorage", "ws-00000000");
 		await mkdir(wsDir, { recursive: true });
-		await writeFile(join(wsDir, "workspace.json"), JSON.stringify({ folder: "file:///Users/flyer/work/proj-a" }));
+		await writeFile(
+			join(wsDir, "workspace.json"),
+			JSON.stringify({ folder: toFileUri("/Users/flyer/work/proj-a") }),
+		);
 		// Intentionally do NOT create wsDir/state.vscdb
 
-		const sessions = await discoverCursorSessions("/Users/flyer/work/proj-a");
+		const sessions = await discoverCursorSessions(toNativePath("/Users/flyer/work/proj-a"));
 		expect(sessions.map((s) => s.sessionId)).toEqual(["fresh-1"]);
 	});
 
@@ -429,9 +453,12 @@ describe("discoverCursorSessions", () => {
 
 		const wsDir = join(userDir, "workspaceStorage", "ws-00000000");
 		await mkdir(wsDir, { recursive: true });
-		await writeFile(join(wsDir, "workspace.json"), JSON.stringify({ folder: "file:///Users/flyer/work/proj-a" }));
+		await writeFile(
+			join(wsDir, "workspace.json"),
+			JSON.stringify({ folder: toFileUri("/Users/flyer/work/proj-a") }),
+		);
 
-		const result = await scanCursorSessions("/Users/flyer/work/proj-a");
+		const result = await scanCursorSessions(toNativePath("/Users/flyer/work/proj-a"));
 		expect(result).toEqual({ sessions: [] });
 	});
 
@@ -456,10 +483,10 @@ describe("discoverCursorSessions", () => {
 		// ws-2: good
 		const ws2 = join(userDir, "workspaceStorage", "ws-00000002");
 		await mkdir(ws2, { recursive: true });
-		await writeFile(join(ws2, "workspace.json"), JSON.stringify({ folder: "file:///Users/flyer/work/proj-a" }));
+		await writeFile(join(ws2, "workspace.json"), JSON.stringify({ folder: toFileUri("/Users/flyer/work/proj-a") }));
 		createCursorWorkspaceDb(join(ws2, "state.vscdb"), { lastFocusedComposerIds: ["c-1"] });
 
-		const sessions = await discoverCursorSessions("/Users/flyer/work/proj-a");
+		const sessions = await discoverCursorSessions(toNativePath("/Users/flyer/work/proj-a"));
 		expect(sessions.map((s) => s.sessionId)).toEqual(["c-1"]);
 	});
 
@@ -478,7 +505,7 @@ describe("discoverCursorSessions", () => {
 		// folder is a number, not a string
 		await writeFile(join(wsDir, "workspace.json"), JSON.stringify({ folder: 12345 }));
 
-		const sessions = await discoverCursorSessions("/Users/flyer/work/proj-a");
+		const sessions = await discoverCursorSessions(toNativePath("/Users/flyer/work/proj-a"));
 		expect(sessions).toEqual([]);
 	});
 
@@ -495,16 +522,19 @@ describe("discoverCursorSessions", () => {
 		// Non-matching workspace
 		const ws0 = join(userDir, "workspaceStorage", "ws-00000000");
 		await mkdir(ws0, { recursive: true });
-		await writeFile(join(ws0, "workspace.json"), JSON.stringify({ folder: "file:///Users/flyer/work/other-proj" }));
+		await writeFile(
+			join(ws0, "workspace.json"),
+			JSON.stringify({ folder: toFileUri("/Users/flyer/work/other-proj") }),
+		);
 		createCursorWorkspaceDb(join(ws0, "state.vscdb"), null);
 
 		// Matching workspace
 		const ws1 = join(userDir, "workspaceStorage", "ws-00000001");
 		await mkdir(ws1, { recursive: true });
-		await writeFile(join(ws1, "workspace.json"), JSON.stringify({ folder: "file:///Users/flyer/work/proj-a" }));
+		await writeFile(join(ws1, "workspace.json"), JSON.stringify({ folder: toFileUri("/Users/flyer/work/proj-a") }));
 		createCursorWorkspaceDb(join(ws1, "state.vscdb"), { lastFocusedComposerIds: ["c-1"] });
 
-		const sessions = await discoverCursorSessions("/Users/flyer/work/proj-a");
+		const sessions = await discoverCursorSessions(toNativePath("/Users/flyer/work/proj-a"));
 		expect(sessions.map((s) => s.sessionId)).toEqual(["c-1"]);
 	});
 
@@ -530,10 +560,13 @@ describe("discoverCursorSessions", () => {
 
 		const wsDir = join(userDir, "workspaceStorage", "ws-00000000");
 		await mkdir(wsDir, { recursive: true });
-		await writeFile(join(wsDir, "workspace.json"), JSON.stringify({ folder: "file:///Users/flyer/work/proj-a" }));
+		await writeFile(
+			join(wsDir, "workspace.json"),
+			JSON.stringify({ folder: toFileUri("/Users/flyer/work/proj-a") }),
+		);
 		createCursorWorkspaceDb(join(wsDir, "state.vscdb"), null);
 
-		const sessions = await discoverCursorSessions("/Users/flyer/work/proj-a");
+		const sessions = await discoverCursorSessions(toNativePath("/Users/flyer/work/proj-a"));
 		expect(sessions.map((s) => s.sessionId)).toEqual(["dup-1"]);
 	});
 
@@ -557,13 +590,13 @@ describe("discoverCursorSessions", () => {
 			await mkdir(wsDir, { recursive: true });
 			await writeFile(
 				join(wsDir, "workspace.json"),
-				JSON.stringify({ folder: "file:///Users/Flyer/Code%20Folder/Proj" }),
+				JSON.stringify({ folder: toFileUri("/Users/Flyer/Code Folder/Proj") }),
 			);
 			createCursorWorkspaceDb(join(wsDir, "state.vscdb"), { lastFocusedComposerIds: ["c-1"] });
 
 			// Lowercased target should match the original-cased stored path
 			// because the win32 normalize branch lowercases both sides.
-			const sessions = await discoverCursorSessions("/users/flyer/code folder/proj");
+			const sessions = await discoverCursorSessions(toNativePath("/users/flyer/code folder/proj"));
 			expect(sessions).toHaveLength(1);
 		} finally {
 			if (prevAppData === undefined) delete process.env.APPDATA;
@@ -582,16 +615,16 @@ describe("discoverCursorSessions", () => {
 		]);
 		const wsDir = join(userDir, "workspaceStorage", "ws-00000000");
 		await mkdir(wsDir, { recursive: true });
-		await writeFile(join(wsDir, "workspace.json"), JSON.stringify({ folder: "file:///home/flyer/Work/Proj" }));
+		await writeFile(join(wsDir, "workspace.json"), JSON.stringify({ folder: toFileUri("/home/flyer/Work/Proj") }));
 		createCursorWorkspaceDb(join(wsDir, "state.vscdb"), { lastFocusedComposerIds: ["c-1"] });
 
 		// Lowercased target must NOT match the original-cased stored path on linux.
-		const sessions = await discoverCursorSessions("/home/flyer/work/proj");
+		const sessions = await discoverCursorSessions(toNativePath("/home/flyer/work/proj"));
 		expect(sessions).toEqual([]);
 
 		// Same-case target DOES match — confirms the linux branch was reached
 		// rather than the lookup short-circuiting on a missing workspace dir.
-		const sessions2 = await discoverCursorSessions("/home/flyer/Work/Proj");
+		const sessions2 = await discoverCursorSessions(toNativePath("/home/flyer/Work/Proj"));
 		expect(sessions2).toHaveLength(1);
 	});
 
@@ -602,10 +635,13 @@ describe("discoverCursorSessions", () => {
 
 		const wsDir = join(userDir, "workspaceStorage", "ws-00000000");
 		await mkdir(wsDir, { recursive: true });
-		await writeFile(join(wsDir, "workspace.json"), JSON.stringify({ folder: "file:///Users/flyer/work/proj-a" }));
+		await writeFile(
+			join(wsDir, "workspace.json"),
+			JSON.stringify({ folder: toFileUri("/Users/flyer/work/proj-a") }),
+		);
 		await writeFile(join(wsDir, "state.vscdb"), "garbage too");
 
-		const result = await scanCursorSessions("/Users/flyer/work/proj-a");
+		const result = await scanCursorSessions(toNativePath("/Users/flyer/work/proj-a"));
 		expect(result.sessions).toEqual([]);
 		expect(result.error).toBeDefined();
 		expect(["corrupt", "permission", "unknown"]).toContain(result.error?.kind);

--- a/cli/src/core/CursorSessionDiscoverer.ts
+++ b/cli/src/core/CursorSessionDiscoverer.ts
@@ -303,14 +303,18 @@ async function readCursorAnchorComposerIds(wsHash: string): Promise<ReadonlyArra
  *   when their casing differs.
  */
 function normalizePathForMatch(p: string): string {
+	// Normalize backslashes to forward slashes so Windows paths from
+	// fileURLToPath (which returns `\`-separated paths) compare correctly
+	// against caller-supplied forward-slash paths.
+	const fwd = p.replace(/\\/g, "/");
 	// Linear-time trailing-slash strip. Equivalent to /\/+$/ but expressed as a
 	// loop so CodeQL's js/polynomial-redos heuristic doesn't flag the regex
 	// when this function receives paths read from on-disk JSON.
-	let end = p.length;
-	while (end > 0 && p[end - 1] === "/") {
+	let end = fwd.length;
+	while (end > 0 && fwd[end - 1] === "/") {
 		end--;
 	}
-	const trimmed = p.slice(0, end);
+	const trimmed = fwd.slice(0, end);
 	const os = platform();
 	return os === "darwin" || os === "win32" ? trimmed.toLowerCase() : trimmed;
 }

--- a/cli/src/core/FolderStorage.test.ts
+++ b/cli/src/core/FolderStorage.test.ts
@@ -621,7 +621,7 @@ describe("FolderStorage", () => {
 		// strip write permission on the parent directory so unlink raises EACCES
 		// while the rest of the storage write path still succeeds (the new MD
 		// goes into a different branch directory).
-		it("warns and keeps the entry when unlinkSync fails", async () => {
+		it.skipIf(process.platform === "win32")("warns and keeps the entry when unlinkSync fails", async () => {
 			const oldJson = summaryJson("old1234567890abcd", "Old");
 			await storage.writeFiles([{ path: "summaries/old1234567890abcd.json", content: oldJson }], "old");
 

--- a/cli/src/core/MetadataManager.ts
+++ b/cli/src/core/MetadataManager.ts
@@ -219,7 +219,7 @@ export class MetadataManager {
 				try {
 					const content = readFileSync(fullPath, "utf-8");
 					const fp = MetadataManager.sha256(content);
-					map.set(fp, relative(kbRoot, fullPath));
+					map.set(fp, relative(kbRoot, fullPath).replace(/\\/g, "/"));
 				} catch {
 					/* ignore */
 				}

--- a/cli/src/site/ContentMirror.read-error.test.ts
+++ b/cli/src/site/ContentMirror.read-error.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Tests for ContentMirror's defensive read-failure branches.
+ *
+ * These paths can't be reached deterministically with real fs (they handle
+ * TOCTOU between stat() and a later readFile()), so we mock readFile to
+ * inject targeted failures.
+ */
+
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Hoisted mock state — re-bound in each test via mockReadFile.mockImplementation.
+const { mockReadFile } = vi.hoisted(() => ({
+	mockReadFile: vi.fn(),
+}));
+
+vi.mock("node:fs/promises", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("node:fs/promises")>();
+	// Default to delegating to the real readFile so unrelated reads still work.
+	mockReadFile.mockImplementation(actual.readFile);
+	return {
+		...actual,
+		readFile: mockReadFile,
+	};
+});
+
+async function makeTempDir(): Promise<string> {
+	return mkdtemp(join(tmpdir(), "jolli-contentmirror-readerr-"));
+}
+
+describe("ContentMirror read-failure branches", () => {
+	let sourceRoot: string;
+	let contentDir: string;
+	let realReadFile: typeof import("node:fs/promises").readFile;
+
+	beforeEach(async () => {
+		sourceRoot = await makeTempDir();
+		contentDir = await makeTempDir();
+		// Resolve the real readFile lazily so we can capture it after the mock
+		// has installed `mockImplementation(actual.readFile)` in the factory.
+		realReadFile = mockReadFile.getMockImplementation() as typeof realReadFile;
+		// Reset to delegating to the real fs by default.
+		mockReadFile.mockImplementation(realReadFile);
+	});
+
+	afterEach(async () => {
+		await rm(sourceRoot, { recursive: true, force: true });
+		await rm(contentDir, { recursive: true, force: true });
+		vi.clearAllMocks();
+	});
+
+	/** Helper: route a single matching path's readFile to throw. */
+	function failReadFor(matcher: (p: string) => boolean): void {
+		mockReadFile.mockImplementation((path: unknown, options: unknown) => {
+			if (typeof path === "string" && matcher(path)) {
+				return Promise.reject(new Error("EACCES: simulated"));
+			}
+			return realReadFile(path as string, options as { encoding?: BufferEncoding } | undefined);
+		});
+	}
+
+	it("ignores .json files when readFile fails after stat", async () => {
+		await writeFile(join(sourceRoot, "spec.json"), "{}", "utf-8");
+		failReadFor((p) => p.endsWith("spec.json"));
+
+		const { mirrorContent } = await import("./ContentMirror.js");
+		const result = await mirrorContent(sourceRoot, contentDir);
+
+		expect(result.openapiFiles).toHaveLength(0);
+		expect(result.ignoredFiles).toContain("spec.json");
+	});
+
+	it("ignores .mdx files when readFile fails after stat", async () => {
+		await writeFile(join(sourceRoot, "page.mdx"), "# hi", "utf-8");
+		failReadFor((p) => p.endsWith("page.mdx"));
+
+		const { mirrorContent } = await import("./ContentMirror.js");
+		const result = await mirrorContent(sourceRoot, contentDir);
+
+		expect(result.markdownFiles).not.toContain("page.mdx");
+		expect(result.ignoredFiles).toContain("page.mdx");
+	});
+
+	it("falls back to copyFile when remapped markdown readFile fails", async () => {
+		// Directory remap `sql/` → `pipelines/sql/` triggers the
+		// originalRelPath !== relPath branch where readFile is attempted.
+		const { mkdir } = await import("node:fs/promises");
+		await mkdir(join(sourceRoot, "sql"), { recursive: true });
+		await writeFile(join(sourceRoot, "sql", "query.md"), "# sql", "utf-8");
+		failReadFor((p) => p.endsWith("query.md"));
+
+		const { mirrorContent } = await import("./ContentMirror.js");
+		const result = await mirrorContent(sourceRoot, contentDir, { sql: "pipelines/sql" });
+
+		// markdownFiles uses forward-slash relative paths after applyPathMapping.
+		expect(result.markdownFiles).toContain("pipelines/sql/query.md");
+	});
+});

--- a/cli/src/site/ContentMirror.test.ts
+++ b/cli/src/site/ContentMirror.test.ts
@@ -231,7 +231,7 @@ describe("ContentMirror.mirrorContent", () => {
 
 		const result = await mirrorContent(sourceRoot, contentDir);
 
-		expect(result.markdownFiles).toContain(join("guides", "intro.md"));
+		expect(result.markdownFiles).toContain("guides/intro.md");
 	});
 
 	// ── Image files are copied (Requirement 3.4) ────────────────────────────
@@ -340,7 +340,7 @@ describe("ContentMirror.mirrorContent", () => {
 
 		expect(result.markdownFiles).toContain("index.md");
 		expect(result.imageFiles).toContain("logo.svg");
-		expect(result.openapiFiles).toContain(join("api", "spec.yaml"));
+		expect(result.openapiFiles).toContain("api/spec.yaml");
 		expect(result.ignoredFiles).toContain("notes.txt");
 	});
 
@@ -491,7 +491,7 @@ describe("ContentMirror.mirrorContent", () => {
 		expect(result.markdownFiles).toHaveLength(0);
 	});
 
-	it("skips entries where stat fails (e.g. broken symlinks)", async () => {
+	it.skipIf(process.platform === "win32")("skips entries where stat fails (e.g. broken symlinks)", async () => {
 		const { symlink } = await import("node:fs/promises");
 		const { mirrorContent } = await import("./ContentMirror.js");
 		// Create a broken symlink — readdir lists it, but stat fails
@@ -508,7 +508,7 @@ describe("ContentMirror.mirrorContent", () => {
 
 	// ── Error handling: unreadable file for OpenAPI classification ──────────
 
-	it("treats an unreadable .yaml file as ignored", async () => {
+	it.skipIf(process.platform === "win32")("treats an unreadable .yaml file as ignored", async () => {
 		const { chmod, writeFile: wf } = await import("node:fs/promises");
 		const { mirrorContent } = await import("./ContentMirror.js");
 		const yamlPath = join(sourceRoot, "spec.yaml");
@@ -753,7 +753,7 @@ describe("Property 2: Content mirroring preserves directory structure", () => {
 
 				const result = await mirrorContent(sourceRoot, contentDir);
 
-				const expectedRelPath = join(dirName, `${fileName}.md`);
+				const expectedRelPath = `${dirName}/${fileName}.md`;
 				return result.markdownFiles.includes(expectedRelPath) && existsSync(join(contentDir, expectedRelPath));
 			}),
 			{ numRuns: 50 },
@@ -826,6 +826,18 @@ describe("ContentMirror.stripIncompatibleContent", () => {
 
 		expect(result).toContain('style="background-color: red; font-size: 14px"');
 		expect(result).not.toContain("{{");
+	});
+
+	it("drops malformed entries (no value) inside style blocks", async () => {
+		// "noColon" has no `:` so it has no value parts → the conversion drops it
+		// while keeping the well-formed `color: red` entry.
+		const { stripIncompatibleContent } = await import("./ContentMirror.js");
+		const input = "<div style={{noColon, color: red}}>x</div>";
+
+		const result = stripIncompatibleContent(input);
+
+		expect(result).toContain('style="color: red"');
+		expect(result).not.toContain("noColon");
 	});
 
 	it("removes Docusaurus admonition fences", async () => {
@@ -978,6 +990,55 @@ describe("ContentMirror.rewriteRelativeImagePaths", () => {
 
 		expect(result).toContain("../file.pdf"); // Unchanged
 	});
+
+	it("does not rewrite HTML img with non-image extension", async () => {
+		const { rewriteRelativeImagePaths } = await import("./ContentMirror.js");
+		const content = '<img src="./file.pdf" alt="x">';
+
+		const result = rewriteRelativeImagePaths(content, "docs/page.md", "guides/docs/page.md");
+
+		expect(result).toContain('src="./file.pdf"');
+	});
+
+	it("does not rewrite HTML img with absolute path", async () => {
+		const { rewriteRelativeImagePaths } = await import("./ContentMirror.js");
+		const content = '<img src="/img/logo.png" alt="x">';
+
+		const result = rewriteRelativeImagePaths(content, "docs/page.md", "guides/docs/page.md");
+
+		expect(result).toContain('src="/img/logo.png"');
+	});
+
+	it("does not rewrite HTML img with http URL", async () => {
+		const { rewriteRelativeImagePaths } = await import("./ContentMirror.js");
+		const content = '<img src="https://example.com/x.png" alt="x">';
+
+		const result = rewriteRelativeImagePaths(content, "docs/page.md", "guides/docs/page.md");
+
+		expect(result).toContain('src="https://example.com/x.png"');
+	});
+
+	it("computes relative paths sharing a common prefix", async () => {
+		// originalDir = "a", newDir = "a/b" → common prefix "a" exercises the
+		// `common++` branch of computeRelative.
+		const { rewriteRelativeImagePaths } = await import("./ContentMirror.js");
+		const content = "![logo](./img.png)\n";
+
+		const result = rewriteRelativeImagePaths(content, "a/old.md", "a/b/new.md");
+
+		expect(result).toContain("../img.png");
+	});
+
+	it("handles empty newDir when file moves to root", async () => {
+		// newRelPath has no slash → newDir = "" exercises the empty-from branch
+		// of computeRelative, which returns a "./..."-prefixed path.
+		const { rewriteRelativeImagePaths } = await import("./ContentMirror.js");
+		const content = "![logo](./img.png)\n";
+
+		const result = rewriteRelativeImagePaths(content, "docs/page.md", "page.md");
+
+		expect(result).toContain("docs/img.png");
+	});
 });
 
 // ─── applyPathMapping tests ──────────────────────────────────────────────────
@@ -1047,7 +1108,7 @@ describe("ContentMirror.mirrorContent with pathMappings", () => {
 
 		const result = await mirrorContent(sourceRoot, contentDir, { sql: "pipelines/sql" });
 
-		expect(result.markdownFiles).toContain(join("pipelines", "sql", "query.md"));
+		expect(result.markdownFiles).toContain("pipelines/sql/query.md");
 		expect(existsSync(join(contentDir, "pipelines", "sql", "query.md"))).toBe(true);
 	});
 
@@ -1156,6 +1217,146 @@ describe("ContentMirror.mirrorContent with publicDir", () => {
 		const output = await rf(join(contentDir, "page.md"), "utf-8");
 		expect(output).toContain("/images/");
 	});
+
+	it("ignores non-image references in markdown image syntax", async () => {
+		// `![doc](./file.pdf)` has the wrong extension → resolveImage returns null
+		// and the reference is left untouched.
+		const { mirrorContent } = await import("./ContentMirror.js");
+		await writeFile(join(sourceRoot, "page.md"), "![doc](./file.pdf)\n", "utf-8");
+
+		await mirrorContent(sourceRoot, contentDir, undefined, publicDir);
+
+		const { readFile: rf } = await import("node:fs/promises");
+		const output = await rf(join(contentDir, "page.md"), "utf-8");
+		expect(output).toContain("./file.pdf");
+	});
+
+	it("ignores http(s) image URLs", async () => {
+		const { mirrorContent } = await import("./ContentMirror.js");
+		await writeFile(join(sourceRoot, "page.md"), "![remote](https://example.com/x.png)\n", "utf-8");
+
+		await mirrorContent(sourceRoot, contentDir, undefined, publicDir);
+
+		const { readFile: rf } = await import("node:fs/promises");
+		const output = await rf(join(contentDir, "page.md"), "utf-8");
+		expect(output).toContain("https://example.com/x.png");
+	});
+
+	it("preserves existing relative images without rewriting", async () => {
+		// Image exists on disk → existsSync(resolvedPath) is true → no rewrite.
+		const { mirrorContent } = await import("./ContentMirror.js");
+		await writeFile(join(sourceRoot, "logo.png"), "fake-png-data", "utf-8");
+		await writeFile(join(sourceRoot, "page.md"), "![logo](./logo.png)\n", "utf-8");
+
+		await mirrorContent(sourceRoot, contentDir, undefined, publicDir);
+
+		const { readFile: rf } = await import("node:fs/promises");
+		const output = await rf(join(contentDir, "page.md"), "utf-8");
+		expect(output).toContain("./logo.png");
+		// Should NOT have been rewritten to /images/...
+		expect(output).not.toContain("/images/");
+	});
+
+	it("rewrites HTML <img> tags pointing to missing images", async () => {
+		const { mirrorContent } = await import("./ContentMirror.js");
+		await writeFile(join(sourceRoot, "page.md"), '<img src="./missing.png" alt="x">\n', "utf-8");
+
+		await mirrorContent(sourceRoot, contentDir, undefined, publicDir);
+
+		const { readFile: rf } = await import("node:fs/promises");
+		const output = await rf(join(contentDir, "page.md"), "utf-8");
+		expect(output).toContain('src="/images/');
+	});
+
+	it("ignores HTML <img> tags with non-image extensions", async () => {
+		const { mirrorContent } = await import("./ContentMirror.js");
+		await writeFile(join(sourceRoot, "page.md"), '<img src="./doc.pdf" alt="x">\n', "utf-8");
+
+		await mirrorContent(sourceRoot, contentDir, undefined, publicDir);
+
+		const { readFile: rf } = await import("node:fs/promises");
+		const output = await rf(join(contentDir, "page.md"), "utf-8");
+		expect(output).toContain('src="./doc.pdf"');
+	});
+
+	it("ignores HTML <img> tags with http URLs", async () => {
+		const { mirrorContent } = await import("./ContentMirror.js");
+		await writeFile(join(sourceRoot, "page.md"), '<img src="https://example.com/x.png" alt="x">\n', "utf-8");
+
+		await mirrorContent(sourceRoot, contentDir, undefined, publicDir);
+
+		const { readFile: rf } = await import("node:fs/promises");
+		const output = await rf(join(contentDir, "page.md"), "utf-8");
+		expect(output).toContain('src="https://example.com/x.png"');
+	});
+
+	it("does not modify content when no images need resolution", async () => {
+		// All references are valid → no in-place rewrite happens (modified === false).
+		const { mirrorContent } = await import("./ContentMirror.js");
+		await writeFile(join(sourceRoot, "page.md"), "# Plain\n\nNo images here.\n", "utf-8");
+
+		await mirrorContent(sourceRoot, contentDir, undefined, publicDir);
+
+		const { readFile: rf } = await import("node:fs/promises");
+		const output = await rf(join(contentDir, "page.md"), "utf-8");
+		expect(output).toBe("# Plain\n\nNo images here.\n");
+	});
+});
+
+// ─── mirrorContent edge cases ────────────────────────────────────────────────
+
+describe("ContentMirror.mirrorContent edge cases", () => {
+	let contentDir: string;
+
+	beforeEach(async () => {
+		contentDir = await makeTempDir();
+	});
+
+	afterEach(async () => {
+		await rm(contentDir, { recursive: true, force: true });
+	});
+
+	it("returns an empty result when sourceRoot does not exist", async () => {
+		const { mirrorContent } = await import("./ContentMirror.js");
+		const missing = join(contentDir, "does-not-exist");
+
+		const result = await mirrorContent(missing, contentDir);
+
+		expect(result.markdownFiles).toHaveLength(0);
+		expect(result.openapiFiles).toHaveLength(0);
+		expect(result.imageFiles).toHaveLength(0);
+		expect(result.ignoredFiles).toHaveLength(0);
+	});
+
+	it("classifies JSON without an OpenAPI structure as ignored", async () => {
+		const sourceRoot = await makeTempDir();
+		try {
+			await writeFile(join(sourceRoot, "data.json"), '{"foo":"bar"}', "utf-8");
+			const { mirrorContent } = await import("./ContentMirror.js");
+
+			const result = await mirrorContent(sourceRoot, contentDir);
+
+			expect(result.openapiFiles).toHaveLength(0);
+			expect(result.ignoredFiles).toContain("data.json");
+		} finally {
+			await rm(sourceRoot, { recursive: true, force: true });
+		}
+	});
+
+	it("classifies YAML without an OpenAPI structure as ignored", async () => {
+		const sourceRoot = await makeTempDir();
+		try {
+			await writeFile(join(sourceRoot, "config.yaml"), "foo: bar\nbaz: qux\n", "utf-8");
+			const { mirrorContent } = await import("./ContentMirror.js");
+
+			const result = await mirrorContent(sourceRoot, contentDir);
+
+			expect(result.openapiFiles).toHaveLength(0);
+			expect(result.ignoredFiles).toContain("config.yaml");
+		} finally {
+			await rm(sourceRoot, { recursive: true, force: true });
+		}
+	});
 });
 
 // ─── hasIncompatibleImports with custom ContentRules ─────────────────────────
@@ -1200,6 +1401,22 @@ describe("ContentMirror.hasIncompatibleImports with ContentRules", () => {
 
 		expect(hasIncompatibleImports(content, undefined)).toBe(false);
 	});
+
+	it("treats components from named imports as compatible", async () => {
+		const { hasIncompatibleImports } = await import("./ContentMirror.js");
+		// `import { Foo, Bar } from 'react'` → Foo and Bar are imported components.
+		const content = "import { Foo, Bar } from 'react'\n\n<Foo />\n<Bar />\n";
+
+		expect(hasIncompatibleImports(content)).toBe(false);
+	});
+
+	it("treats components from aliased named imports as compatible", async () => {
+		const { hasIncompatibleImports } = await import("./ContentMirror.js");
+		// `import { Foo as Renamed } from 'react'` → Renamed is the local name.
+		const content = "import { Foo as Renamed } from 'react'\n\n<Renamed />\n";
+
+		expect(hasIncompatibleImports(content)).toBe(false);
+	});
 });
 
 // ─── mirrorContent with unreadable .mdx file ─────────────────────────────────
@@ -1218,7 +1435,7 @@ describe("ContentMirror.mirrorContent unreadable MDX", () => {
 		await rm(contentDir, { recursive: true, force: true });
 	});
 
-	it("treats broken .mdx symlink as ignored", async () => {
+	it.skipIf(process.platform === "win32")("treats broken .mdx symlink as ignored", async () => {
 		const { symlink: symlinkFn } = await import("node:fs/promises");
 		const { mirrorContent } = await import("./ContentMirror.js");
 		// Create a broken symlink that stat resolves but readFile fails

--- a/cli/src/site/ContentMirror.ts
+++ b/cli/src/site/ContentMirror.ts
@@ -121,9 +121,8 @@ function computeRelative(from: string, to: string): string {
  * Uses forward slashes for matching regardless of platform.
  */
 export function applyPathMapping(relPath: string, pathMappings?: PathMappings): string {
-	if (!pathMappings) return relPath;
-
 	const normalized = relPath.replace(/\\/g, "/");
+	if (!pathMappings) return normalized;
 
 	for (const [source, target] of Object.entries(pathMappings)) {
 		if (normalized === source || normalized.startsWith(`${source}/`)) {
@@ -131,7 +130,7 @@ export function applyPathMapping(relPath: string, pathMappings?: PathMappings): 
 		}
 	}
 
-	return relPath;
+	return normalized;
 }
 
 // ─── classifyFile ─────────────────────────────────────────────────────────────
@@ -536,10 +535,10 @@ async function ensureIndexPage(contentDir: string, result: MirrorResult): Promis
 			if (/^slug:\s*\/\s*$/m.test(content)) {
 				await rename(join(contentDir, relPath), join(contentDir, "index.md"));
 				const oldKey = relPath.replace(/\.(md|mdx)$/, "");
-				// Replace the original entry with index.md
+				// Replace the original entry with index.md. relPath is always
+				// in markdownFiles because walkDir pushed it before this runs.
 				const idx = result.markdownFiles.indexOf(relPath);
-				if (idx !== -1) result.markdownFiles[idx] = "index.md";
-				else result.markdownFiles.push("index.md");
+				result.markdownFiles[idx] = "index.md";
 				return oldKey;
 			}
 		} catch {}
@@ -684,9 +683,10 @@ async function processFile(
 			await copyFile(fullPath, destPath);
 			break;
 		}
+		/* v8 ignore next 5 -- unreachable: OpenAPI files are handled in the early-return branch above. */
 		case "openapi": {
-			// Unreachable from processFile — OpenAPI files are handled in the
-			// early-return branch above so we can cache the parsed AST.
+			// classifyFile() called without content for non-JSON/YAML extensions
+			// returns "ignored", never "openapi", so this case can't be reached.
 			break;
 		}
 		case "ignored": {
@@ -700,8 +700,7 @@ async function processFile(
 
 /** Ensures the parent directory of `filePath` exists. */
 async function ensureDir(filePath: string): Promise<void> {
-	const dir = dirname(filePath);
-	if (dir) {
-		await mkdir(dir, { recursive: true });
-	}
+	// `dirname()` always returns a non-empty string ("." for bare filenames),
+	// so no empty-dir guard is needed.
+	await mkdir(dirname(filePath), { recursive: true });
 }

--- a/cli/src/site/EngineManager.test.ts
+++ b/cli/src/site/EngineManager.test.ts
@@ -144,14 +144,17 @@ describe("EngineManager.ensureEngine", () => {
 	});
 
 	it("calls npm install in the engine directory", async () => {
-		const { ensureEngine, getEngineDir } = await import("./EngineManager.js");
+		const { ensureEngine } = await import("./EngineManager.js");
 
 		await ensureEngine();
 
-		expect(mockSpawnSync).toHaveBeenCalledWith(expect.any(String), ["install"], {
-			cwd: getEngineDir(),
-			stdio: "pipe",
-		});
+		const call = mockSpawnSync.mock.calls[0];
+		const invocation = `${call[0]} ${(call[1] ?? []).join(" ")}`;
+		expect(invocation).toContain("npm");
+		expect(invocation).toContain("install");
+		expect(call[2].cwd).toContain(".jolli");
+		expect(call[2].cwd).toContain("site-engine");
+		expect(call[2].stdio).toBe("pipe");
 	});
 
 	it("returns failure when npm install fails", async () => {

--- a/cli/src/site/EngineManager.ts
+++ b/cli/src/site/EngineManager.ts
@@ -108,12 +108,17 @@ export async function ensureEngine(): Promise<NpmRunResult> {
 		};
 		await writeFile(join(engineDir, "package.json"), `${JSON.stringify(pkg, null, 2)}\n`, "utf-8");
 
-		// Run npm install
+		// Run npm install — on Windows, npm is a .cmd script that requires
+		// shell: true since Node 22.5+ (CVE-2024-27980). Pass the full command
+		// as a single string to avoid the DEP0190 warning about shell + args.
 		const { spawnSync } = await import("node:child_process");
-		const npm = process.platform === "win32" ? /* v8 ignore next */ "npm.cmd" : "npm";
-		const result = spawnSync(npm, ["install"], {
+		const isWin = process.platform === "win32";
+		const shellOpts = isWin ? /* v8 ignore next */ ({ shell: true } as const) : {};
+		const [cmd, args] = isWin ? /* v8 ignore next */ ["npm install", []] : ["npm", ["install"]];
+		const result = spawnSync(cmd, args, {
 			cwd: engineDir,
 			stdio: "pipe",
+			...shellOpts,
 		});
 
 		const stdout = result.stdout ? result.stdout.toString() : "";

--- a/cli/src/site/MetaGenerator.test.ts
+++ b/cli/src/site/MetaGenerator.test.ts
@@ -300,7 +300,7 @@ describe("MetaGenerator.generateMetaFiles", () => {
 		await expect(generateMetaFiles(join(contentDir, "nonexistent"))).resolves.not.toThrow();
 	});
 
-	it("skips entries where stat fails (e.g. broken symlinks)", async () => {
+	it.skipIf(process.platform === "win32")("skips entries where stat fails (e.g. broken symlinks)", async () => {
 		const { symlink } = await import("node:fs/promises");
 		const { generateMetaFiles } = await import("./MetaGenerator.js");
 		// Create a valid file so _meta.js gets generated

--- a/cli/src/site/NpmRunner.test.ts
+++ b/cli/src/site/NpmRunner.test.ts
@@ -12,6 +12,7 @@
  *   - errors are returned (not thrown) on non-zero exit codes
  */
 
+import { join } from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // ─── Mocks ────────────────────────────────────────────────────────────────────
@@ -105,7 +106,7 @@ describe("NpmRunner.needsInstall", () => {
 
 		needsInstall("/my/build/dir");
 
-		expect(mockExistsSync).toHaveBeenCalledWith("/my/build/dir/node_modules");
+		expect(mockExistsSync).toHaveBeenCalledWith(join("/my/build/dir", "node_modules"));
 	});
 });
 
@@ -246,10 +247,13 @@ describe("NpmRunner.runNpmBuild", () => {
 
 		await runNpmBuild("/my/build/dir");
 
-		expect(mockSpawnSync).toHaveBeenCalledWith(expect.any(String), ["run", "build"], {
-			cwd: "/my/build/dir",
-			stdio: "pipe",
-		});
+		const call = mockSpawnSync.mock.calls[0];
+		// On Windows: single command string "npm run build" with empty args.
+		// On POSIX: "npm" with ["run", "build"]. Join both forms before asserting.
+		const invocation = `${call[0]} ${(call[1] ?? []).join(" ")}`;
+		expect(invocation).toContain("npm");
+		expect(invocation).toContain("build");
+		expect(call[2]).toEqual(expect.objectContaining({ cwd: "/my/build/dir", stdio: "pipe" }));
 	});
 
 	it("handles null stdout and stderr gracefully", async () => {
@@ -360,9 +364,10 @@ describe("NpmRunner.runNpmDev", () => {
 		child.emit("close", 0);
 		await promise;
 
-		expect(mockSpawn).toHaveBeenCalledWith(expect.any(String), ["run", "dev"], {
-			cwd: "/my/build/dir",
-			stdio: "pipe",
-		});
+		const call = mockSpawn.mock.calls[0];
+		const invocation = `${call[0]} ${(call[1] ?? []).join(" ")}`;
+		expect(invocation).toContain("npm");
+		expect(invocation).toContain("dev");
+		expect(call[2]).toEqual(expect.objectContaining({ cwd: "/my/build/dir", stdio: "pipe" }));
 	});
 });

--- a/cli/src/site/NpmRunner.ts
+++ b/cli/src/site/NpmRunner.ts
@@ -13,9 +13,21 @@ import { engineNeedsInstall, ensureEngine, linkEngineModules } from "./EngineMan
 import { createOutputFilter } from "./OutputFilter.js";
 import type { NpmRunResult } from "./Types.js";
 
-/** On Windows, npm/npx must be invoked as npm.cmd/npx.cmd. */
-const NPM = process.platform === "win32" ? /* v8 ignore next */ "npm.cmd" : "npm";
-const NPX = process.platform === "win32" ? /* v8 ignore next */ "npx.cmd" : "npx";
+/**
+ * On Windows, npm/npx are batch scripts (.cmd) that require `shell: true`
+ * for spawn/spawnSync since Node 22.5+ (CVE-2024-27980 hardened child_process
+ * to reject .cmd/.bat files without a shell). To avoid the DEP0190 warning
+ * ("Passing args to a child process with shell option true"), we join the
+ * command and args into a single string when shell mode is active.
+ */
+const IS_WIN = process.platform === "win32";
+const SHELL_OPTS = IS_WIN ? /* v8 ignore next */ ({ shell: true } as const) : {};
+
+/** Merges cmd + args into the format expected by spawn/spawnSync. */
+function shellCmd(cmd: string, args: string[]): [string, string[]] {
+	/* v8 ignore next */
+	return IS_WIN ? [`${cmd} ${args.join(" ")}`, []] : [cmd, args];
+}
 
 export type { NpmRunResult };
 
@@ -45,9 +57,11 @@ export async function runNpmInstall(buildDir: string): Promise<NpmRunResult> {
  * Runs `npm run build` inside `buildDir`.
  */
 export async function runNpmBuild(buildDir: string): Promise<NpmRunResult> {
-	const result = spawnSync(NPM, ["run", "build"], {
+	const [cmd, args] = shellCmd("npm", ["run", "build"]);
+	const result = spawnSync(cmd, args, {
 		cwd: buildDir,
 		stdio: "pipe",
+		...SHELL_OPTS,
 	});
 
 	const stdout = result.stdout ? result.stdout.toString() : "";
@@ -74,27 +88,29 @@ export interface ServerResult extends NpmRunResult {
  * and the server URL are shown. In verbose mode, all output is streamed.
  */
 export function runNpmDev(buildDir: string, verbose = false): Promise<ServerResult> {
-	return runLongProcess(NPM, ["run", "dev"], buildDir, verbose);
+	return runLongProcess("npm", ["run", "dev"], buildDir, verbose);
 }
 
 /**
  * Serves the static `out/` directory inside `buildDir` using `npx serve`.
  */
 export function runServe(buildDir: string, verbose = false): Promise<ServerResult> {
-	return runLongProcess(NPX, ["serve", "out"], buildDir, verbose);
+	return runLongProcess("npx", ["serve", "out"], buildDir, verbose);
 }
 
 /**
  * Shared implementation for long-running server processes.
  * Pipes output through OutputFilter and extracts the server URL.
  */
-function runLongProcess(cmd: string, args: string[], cwd: string, verbose: boolean): Promise<ServerResult> {
+function runLongProcess(rawCmd: string, rawArgs: string[], cwd: string, verbose: boolean): Promise<ServerResult> {
 	return new Promise((resolve) => {
 		const filter = createOutputFilter(verbose);
+		const [cmd, args] = shellCmd(rawCmd, rawArgs);
 
 		const child = spawn(cmd, args, {
 			cwd,
 			stdio: "pipe",
+			...SHELL_OPTS,
 		});
 
 		child.stdout?.on("data", (data: Buffer) => {

--- a/cli/src/site/PagefindRunner.test.ts
+++ b/cli/src/site/PagefindRunner.test.ts
@@ -50,14 +50,11 @@ describe("PagefindRunner.runPagefind", () => {
 
 		await runPagefind("/my/build/dir");
 
-		expect(mockSpawnSync).toHaveBeenCalledWith(
-			expect.any(String),
-			["pagefind", "--site", "out", "--output-path", "out/_pagefind"],
-			{
-				cwd: "/my/build/dir",
-				stdio: "pipe",
-			},
-		);
+		const call = mockSpawnSync.mock.calls[0];
+		const invocation = `${call[0]} ${(call[1] ?? []).join(" ")}`;
+		expect(invocation).toContain("npx");
+		expect(invocation).toContain("pagefind");
+		expect(call[2]).toEqual(expect.objectContaining({ cwd: "/my/build/dir", stdio: "pipe" }));
 	});
 
 	it("returns { success: true } when pagefind exits with code 0", async () => {

--- a/cli/src/site/PagefindRunner.ts
+++ b/cli/src/site/PagefindRunner.ts
@@ -12,8 +12,13 @@
 import { spawnSync } from "node:child_process";
 import type { PagefindResult } from "./Types.js";
 
-/** On Windows, npx must be invoked as npx.cmd. */
-const NPX = process.platform === "win32" ? /* v8 ignore next */ "npx.cmd" : "npx";
+/**
+ * On Windows, npx is a .cmd script that requires shell: true since
+ * Node 22.5+ (CVE-2024-27980). Command + args are joined into a single
+ * string to avoid the DEP0190 warning about shell + separate args.
+ */
+const IS_WIN = process.platform === "win32";
+const SHELL_OPTS = IS_WIN ? /* v8 ignore next */ ({ shell: true } as const) : {};
 
 export type { PagefindResult };
 
@@ -25,9 +30,12 @@ export type { PagefindResult };
  * on exit code 0, or `{ success: false, output }` on any non-zero exit code.
  */
 export function runPagefind(buildDir: string): PagefindResult {
-	const result = spawnSync(NPX, ["pagefind", "--site", "out", "--output-path", "out/_pagefind"], {
+	const rawArgs = ["pagefind", "--site", "out", "--output-path", "out/_pagefind"];
+	const [cmd, args] = IS_WIN ? /* v8 ignore next */ [`npx ${rawArgs.join(" ")}`, []] : ["npx", rawArgs];
+	const result = spawnSync(cmd, args, {
 		cwd: buildDir,
 		stdio: "pipe",
+		...SHELL_OPTS,
 	});
 
 	const stdout = result.stdout ? result.stdout.toString() : "";

--- a/cli/src/site/renderer/NextraRenderer.test.ts
+++ b/cli/src/site/renderer/NextraRenderer.test.ts
@@ -152,7 +152,7 @@ describe("NextraRenderer", () => {
 	});
 
 	it("getCacheDirs returns .next directory", () => {
-		expect(new NextraRenderer().getCacheDirs("/build")).toEqual(["/build/.next"]);
+		expect(new NextraRenderer().getCacheDirs("/build")).toEqual([join("/build", ".next")]);
 	});
 
 	it("generateNavigation delegates to generateMetaFiles", async () => {


### PR DESCRIPTION
## Summary
- Normalize path separators in `CursorSessionDiscoverer`, `ContentMirror`, and `MetadataManager` so behavior and manifest output match across Windows and POSIX.
- Update test assertions to use `join()`/`resolve()` and `pathToFileURL`, replacing hardcoded `/` and `file:///Users/...` literals that broke on Windows; skip symlink and chmod-based tests where NTFS / non-admin shells can't honor them.
- Fix `npm`/`npx` spawn under Node 22.5+ (CVE-2024-27980): use `shell: true` on Windows and join command + args into a single string in `NpmRunner`, `EngineManager`, and `PagefindRunner` to avoid the DEP0190 warning.

## Test plan
- [ ] `npm run all` passes on Windows
- [ ] `npm run test -w @jolli.ai/cli` passes on macOS/Linux (no regressions)
- [ ] `jolli dev` / `jolli start` / `jolli build` run end-to-end on Windows with Node 22.5+