### PR TITLE
feat(cli): site.json parity with web — _meta-driven nav, semantic footer, scoped layout, branding alias

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,6 +120,20 @@ The `jolli new` / `build` / `start` / `dev` commands generate a Nextra v4 docs s
 
 The bridge is `SiteRenderer.renderOpenApiSpecs(contentDir, publicDir, specs)` in `cli/src/site/renderer/SiteRenderer.ts`. `StartCommand` builds the `OpenApiSpecInput[]` from `MirrorResult.openapiDocs` (the parsed-once-cached AST from `ContentMirror`) via `buildPipeline`. The legacy `swagger-ui-react` MDX shim is gone — that dependency is no longer in `NEXTRA_DEPENDENCIES`. See [`cli/DEVELOPMENT.md`](cli/DEVELOPMENT.md) for module-by-module detail and the full file-flow diagram.
 
+### Site generation: layout, navbar, and footer architecture
+
+The CLI's Nextra layouts are deliberately thin — `<Navbar logo={<SiteLogo />}><ThemeSwitch /></Navbar>` for Forge, `<Navbar logo={<SiteLogo />} />` for Atlas / default. **No `<a>` or `<details>` JSX is spliced into the navbar.** Page tabs (Documentation, API Reference, customer-supplied `header.items`) flow through:
+
+1. `MetaGenerator.generateMetaFiles(contentDir, sidebar, rootInjection)` writes the **root `content/_meta.js`** with auto-injected `__documentation` + `__api-reference` keys (single-spec direct link vs multi-spec dropdown shape) plus customer `header.items` materialised as slug-keyed page-tab entries. URLs flow through `Sanitize.sanitizeUrl` so `javascript:` / `data:` / `vbscript:` are clamped to `"#"`.
+2. Nextra's `<Navbar>` reads the page-map and renders the entries natively (chevron, hover, mobile drawer all come for free).
+3. Layouts wrap content in `<ScopedNextraLayout>` (emitted to `<buildDir>/components/ScopedNextraLayout.tsx` from the `scopePageMap` filter in `cli/src/site/ScopePageMap.ts`) so the sidebar scopes cleanly when the user is inside `/api-{slug}/…`.
+
+Pack footers (Forge / Atlas) emit semantic class names targeted by the pack stylesheets — `themes/Footer.ts` builds the JSX with `.{prefix}-footer-columns`, `.{prefix}-footer-col`, `.{prefix}-footer-bottom`, `.{prefix}-footer-copyright`, `.{prefix}-footer-social`, `.{prefix}-footer-powered` so the pack CSS does the layout. The default theme has no pack stylesheet so it keeps the inline-style footer fallback.
+
+Schema aliasing happens at site.json read time — `SiteJsonReader.coerceBrandingToTheme` maps the deprecated nested `branding.*` block into the canonical `theme.*` (and `footer.social` → `footer.socialLinks`). Downstream code only ever reads the canonical shape.
+
+URL/HTML escaping is consolidated in `cli/src/site/Sanitize.ts` — every layout, footer renderer, and `_meta.js` writer imports from there so a future tightening of the allow-list happens in one place.
+
 ### Auth & origin allowlist
 
 `jolliApiKey` (`sk-jol-…`) is a plain or JWT-shaped token whose payload encodes the tenant URL in a base64url-decoded segment. Three places consume it: CLI (`cli/src/core/JolliApiUtils.ts`, canonical `parseJolliApiKey` + `assertJolliOriginAllowed`), VS Code extension (which imports the canonical CLI helpers via the bundled path), and the IntelliJ plugin (Kotlin port). The allowlist is `jolli.ai`, `jolli.dev`, `jolli.cloud`, `jolli-local.me`, HTTPS-only, with a suffix-boundary check (`host === h || host.endsWith("." + h)`). Validation is **save-time** (OAuth callback, `configure --set`, settings UI, `JOLLI_URL` env at read time) — request paths trust the saved value. Keep the three implementations in lockstep.

--- a/cli/docs/site-json-reference.md
+++ b/cli/docs/site-json-reference.md
@@ -29,6 +29,18 @@ Run `jolli dev .` in the folder containing this file to start a dev server.
 | `pathMappings` | `Record<string, string>` | No | Remap source folders to different content paths. |
 | `favicon` | `string` | No | Favicon URL. Deprecated; use `theme.favicon` instead. |
 | `theme` | `ThemeConfig` | No | Visual theme pack and branding options. |
+| `branding` | `BrandingConfig` | No | Deprecated nested-shape alias for `theme`. Coerced at load time; `theme.*` wins on conflict. New site.json files should use `theme` directly. |
+
+### How navbar entries reach the browser
+
+`header.items` and `nav` are NOT spliced into the layout JSX as `<a>` / `<details>` tags. The CLI writes them into the **root `content/_meta.js`** so Nextra's `<Navbar>` renders them as native page tabs — the chevron on dropdowns, the hover styling, and the mobile-drawer integration come from Nextra and not from custom JSX.
+
+When OpenAPI specs are detected, two extra entries are auto-injected into the same `_meta.js`:
+
+- **`Documentation`** — links back to `/`. Always present whenever any specs are detected.
+- **`API Reference`** — for a single spec, a direct link to `/api-{slug}`. For two or more specs, a `type: "menu"` dropdown with one sub-entry per spec.
+
+A header item whose label matches `Documentation` / `API` / `API Reference` (case-insensitive) suppresses the matching auto-entry — customer overrides win.
 
 ---
 
@@ -171,13 +183,37 @@ Controls the visual appearance of the generated site.
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `pack` | `"default"` \| `"forge"` \| `"atlas"` | `"default"` | Theme pack to use. |
+| `pack` | `"forge"` \| `"atlas"` \| `"default"` | `"forge"` | Theme pack to use. `"forge"` is the implicit default. `"default"` is an explicit opt-in for the pre-pack vanilla `nextra-theme-docs` look. |
 | `primaryHue` | `number` (0-360) | Pack default | Accent colour hue. Forge: 228 (indigo), Atlas: 200 (blue). |
 | `defaultTheme` | `"light"` \| `"dark"` \| `"system"` | Pack default | Initial colour scheme. Forge: `"light"`, Atlas: `"dark"`. |
 | `fontFamily` | `string` | Pack default | Body font. See font options below. |
 | `logoUrl` | `string` | None | Logo image URL (light mode). |
 | `logoUrlDark` | `string` | None | Logo image URL (dark mode). Falls back to `logoUrl`. |
+| `logoText` | `string` | Site `title` | Override for the text shown alongside (or instead of) the logo image. Useful when the wordmark differs from the page title. |
+| `logoDisplay` | `"text"` \| `"image"` \| `"both"` | Auto¹ | What the navbar logo renders. |
 | `favicon` | `string` | None | Favicon URL. |
+
+¹ When `logoDisplay` is unset, the layout infers `"both"` if `logoUrl` is set and `"text"` otherwise — preserving pre-`logoDisplay` behaviour. `"image"` with no `logoUrl` falls back to `"text"` to avoid an empty navbar logo.
+
+### Deprecated alias: `branding`
+
+The CLI also accepts a `branding` block in a nested shape. Fields are coerced into `theme.*` at load time; `theme.*` wins on conflict.
+
+| `branding.*` | Coerces to |
+|---|---|
+| `branding.themePack` | `theme.pack` |
+| `branding.colors.primaryHue` | `theme.primaryHue` |
+| `branding.fontFamily` | `theme.fontFamily` |
+| `branding.defaultTheme` | `theme.defaultTheme` |
+| `branding.favicon` | `theme.favicon` |
+| `branding.logo.image` | `theme.logoUrl` |
+| `branding.logo.imageDark` | `theme.logoUrlDark` |
+| `branding.logo.text` | `theme.logoText` |
+| `branding.logo.display` | `theme.logoDisplay` |
+
+`footer.social` is also accepted as an alias for `footer.socialLinks` with the same precedence rule.
+
+New site.json files should use `theme` and `footer.socialLinks` directly. The aliases exist for back-compat with the older nested format.
 
 ### Theme packs
 

--- a/cli/src/commands/StartCommand.test.ts
+++ b/cli/src/commands/StartCommand.test.ts
@@ -672,6 +672,23 @@ describe("StartCommand additional branches", () => {
 		expect(specs[0].specName).toBe("spec");
 	});
 
+	it("prints a friendly error and sets exitCode = 1 on OpenAPI spec-name collisions (no uncaught throw)", async () => {
+		// Two source files with different paths but the same basename collide
+		// on the derived spec slug. Without the try/catch around
+		// buildOpenApiSpecInputs, the throw becomes an unhandled promise
+		// rejection that crashes the process before the watcher even starts.
+		setupSuccessfulRun({
+			openapiFiles: ["api/spec.yaml", "other/spec.yaml"],
+		});
+		const program = await makeProgram();
+		await program.parseAsync(["build", "/my-docs"], { from: "user" });
+
+		expect(process.exitCode).toBe(1);
+		const errOutput = consoleErrorSpy.mock.calls.map((c: unknown[]) => c.join(" ")).join("\n");
+		expect(errOutput).toMatch(/spec name collision/i);
+		expect(mockRenderOpenApiSpecs).not.toHaveBeenCalled();
+	});
+
 	it("does not render OpenAPI specs when openapiFiles is empty", async () => {
 		setupSuccessfulRun({ openapiFiles: [] });
 		const program = await makeProgram();
@@ -845,5 +862,100 @@ describe("StartCommand additional branches", () => {
 
 		const output = consoleSpy.mock.calls.map((c: unknown[]) => c.join(" ")).join("\n");
 		expect(output).toContain("Indexed 0 pages");
+	});
+});
+
+// ─── buildRootInjectionInput unit tests ──────────────────────────────────────
+
+/**
+ * Direct unit tests for the exported `buildRootInjectionInput` helper. The
+ * legacy `nav` shorthand fallback is the back-compat lifeline for existing
+ * CLI sites — pinning it explicitly so a regression doesn't slip through
+ * the integration paths.
+ */
+describe("buildRootInjectionInput", () => {
+	type MirrorResult = Parameters<typeof import("./StartCommand.js").buildRootInjectionInput>[2];
+	type OpenApiDocs = MirrorResult["openapiDocs"];
+	const EMPTY_MIRROR: MirrorResult = {
+		markdownFiles: [],
+		openapiFiles: [],
+		openapiDocs: {},
+		imageFiles: [],
+		ignoredFiles: [],
+		downgradedCount: 0,
+	};
+
+	it("returns headerItems unchanged when populated, ignoring legacy nav", async () => {
+		const { buildRootInjectionInput } = await import("./StartCommand.js");
+		const result = buildRootInjectionInput(
+			[{ label: "Pricing", url: "/pricing" }],
+			[{ label: "Old", href: "/old" }],
+			EMPTY_MIRROR,
+		);
+		expect(result.headerItems).toEqual([{ label: "Pricing", url: "/pricing" }]);
+	});
+
+	it("coerces legacy nav into header items when headerItems is undefined", async () => {
+		const { buildRootInjectionInput } = await import("./StartCommand.js");
+		const result = buildRootInjectionInput(
+			undefined,
+			[
+				{ label: "Guides", href: "/guides" },
+				{ label: "GitHub", href: "https://github.com/x" },
+			],
+			EMPTY_MIRROR,
+		);
+		expect(result.headerItems).toEqual([
+			{ label: "Guides", url: "/guides" },
+			{ label: "GitHub", url: "https://github.com/x" },
+		]);
+	});
+
+	it("coerces legacy nav into header items when headerItems is an empty array", async () => {
+		const { buildRootInjectionInput } = await import("./StartCommand.js");
+		const result = buildRootInjectionInput([], [{ label: "Docs", href: "/docs" }], EMPTY_MIRROR);
+		expect(result.headerItems).toEqual([{ label: "Docs", url: "/docs" }]);
+	});
+
+	it("returns headerItems undefined when neither headerItems nor legacy nav is populated", async () => {
+		const { buildRootInjectionInput } = await import("./StartCommand.js");
+		const result = buildRootInjectionInput(undefined, [], EMPTY_MIRROR);
+		expect(result.headerItems).toBeUndefined();
+	});
+
+	it("returns headerItems undefined when both headerItems and legacy nav are empty arrays", async () => {
+		const { buildRootInjectionInput } = await import("./StartCommand.js");
+		const result = buildRootInjectionInput([], [], EMPTY_MIRROR);
+		expect(result.headerItems).toBeUndefined();
+	});
+
+	it("derives apiSpecs from openapiFiles + openapiDocs, picking up the title when present", async () => {
+		const { buildRootInjectionInput } = await import("./StartCommand.js");
+		const mirror: MirrorResult = {
+			...EMPTY_MIRROR,
+			openapiFiles: ["api/petstore.yaml"],
+			openapiDocs: {
+				"api/petstore.yaml": { info: { title: "Petstore" } },
+			} as unknown as OpenApiDocs,
+		};
+		const result = buildRootInjectionInput(undefined, [], mirror);
+		expect(result.apiSpecs).toEqual([{ specName: "petstore", title: "Petstore" }]);
+	});
+
+	it("falls back to undefined title when info.title is missing or non-string", async () => {
+		const { buildRootInjectionInput } = await import("./StartCommand.js");
+		const mirror: MirrorResult = {
+			...EMPTY_MIRROR,
+			openapiFiles: ["api/petstore.yaml", "api/users.yaml"],
+			openapiDocs: {
+				"api/petstore.yaml": { info: {} },
+				"api/users.yaml": { info: { title: 42 } },
+			} as unknown as OpenApiDocs,
+		};
+		const result = buildRootInjectionInput(undefined, [], mirror);
+		expect(result.apiSpecs).toEqual([
+			{ specName: "petstore", title: undefined },
+			{ specName: "users", title: undefined },
+		]);
 	});
 });

--- a/cli/src/commands/StartCommand.ts
+++ b/cli/src/commands/StartCommand.ts
@@ -11,6 +11,7 @@ import { join, resolve } from "node:path";
 import type { Command } from "commander";
 import { resolveFavicon } from "../site/AssetResolver.js";
 import { clearDir, mirrorContent } from "../site/ContentMirror.js";
+import type { RootApiSpec, RootInjectionInput } from "../site/MetaGenerator.js";
 import { needsInstall, runNpmInstall, runServe } from "../site/NpmRunner.js";
 import { buildPipeline } from "../site/openapi/OpenApiPipeline.js";
 import { deriveSpecName } from "../site/openapi/SpecName.js";
@@ -19,6 +20,7 @@ import { resolveRenderer, type SiteRenderer } from "../site/renderer/index.js";
 import type { OpenApiSpecInput } from "../site/renderer/SiteRenderer.js";
 import { readSiteJson } from "../site/SiteJsonReader.js";
 import { startSourceWatcher } from "../site/SourceWatcher.js";
+import type { HeaderItem, NavLink } from "../site/Types.js";
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -111,14 +113,65 @@ async function syncContent(
 		sidebar["/"] = { index: label, ...sidebar["/"] };
 	}
 
-	await renderer.generateNavigation(contentDir, sidebar);
-
 	if (mirrorResult.openapiFiles.length > 0) {
-		const specInputs = buildOpenApiSpecInputs(mirrorResult);
+		let specInputs: OpenApiSpecInput[];
+		try {
+			specInputs = buildOpenApiSpecInputs(mirrorResult);
+		} catch (err) {
+			// Spec-name collisions throw with a clear "Rename one of the source
+			// files" message. In the dev watcher, an uncaught throw becomes an
+			// unhandled promise rejection that crashes the process; in the
+			// initial pass it short-circuits before the watcher even starts.
+			// Either way, surface the message and let the caller decide whether
+			// to retry on the next change.
+			console.error(`  Error: ${err instanceof Error ? err.message : String(err)}`);
+			return { success: false };
+		}
 		await renderer.renderOpenApiSpecs(contentDir, publicDir, specInputs);
 	}
 
+	// Build the root-_meta.js injection payload. The renderer turns these
+	// into native Nextra page tabs (chevron / hover / mobile drawer) by
+	// writing them to the root `content/_meta.js` — no JSX nav-children
+	// rendering in `<Navbar>`.
+	const rootInjection = buildRootInjectionInput(
+		siteJsonResult.config.header?.items,
+		siteJsonResult.config.nav,
+		mirrorResult,
+	);
+
+	await renderer.generateNavigation(contentDir, sidebar, rootInjection);
+
 	return { success: true, mirrorResult };
+}
+
+/**
+ * Builds the `RootInjectionInput` from header config + detected specs.
+ * Used by both initial render and the dev watcher.
+ *
+ * Falls back to coercing the legacy `nav` shorthand into dropdown-less
+ * header items when `header.items` is empty/missing — matches the documented
+ * `nav` semantics in `Types.ts` so existing CLI sites with only a flat
+ * `nav: [...]` block keep rendering navbar tabs after the move from JSX
+ * navbar children to Nextra-native page-tabs.
+ */
+export function buildRootInjectionInput(
+	headerItems: HeaderItem[] | undefined,
+	legacyNav: NavLink[] | undefined,
+	mirrorResult: Awaited<ReturnType<typeof mirrorContent>>,
+): RootInjectionInput {
+	const apiSpecs: RootApiSpec[] = mirrorResult.openapiFiles.map((relPath) => {
+		const doc = mirrorResult.openapiDocs[relPath];
+		const title = typeof doc?.info?.title === "string" ? doc.info.title : undefined;
+		return { specName: deriveSpecName(relPath), title };
+	});
+	const effectiveHeaderItems =
+		headerItems && headerItems.length > 0
+			? headerItems
+			: legacyNav && legacyNav.length > 0
+				? legacyNav.map((n) => ({ label: n.label, url: n.href }))
+				: undefined;
+	return { apiSpecs, headerItems: effectiveHeaderItems };
 }
 
 // ─── prepareContent ──────────────────────────────────────────────────────────

--- a/cli/src/site/ContentMirror.test.ts
+++ b/cli/src/site/ContentMirror.test.ts
@@ -385,7 +385,10 @@ describe("ContentMirror.mirrorContent", () => {
 
 	it("copies .mdx files without incompatible imports normally", async () => {
 		const { mirrorContent } = await import("./ContentMirror.js");
-		const mdxContent = `import SwaggerUI from 'swagger-ui-react'\n\n# API\n`;
+		// Use a default-safe prefix (`nextra/components`) — the Nextra renderer
+		// pipeline allows these natively and ContentMirror's own DEFAULT_SAFE_IMPORT_PREFIXES
+		// includes the `nextra` family.
+		const mdxContent = `import { Callout } from 'nextra/components'\n\n# API\n`;
 		await writeFile(join(sourceRoot, "api.mdx"), mdxContent, "utf-8");
 
 		const result = await mirrorContent(sourceRoot, contentDir);

--- a/cli/src/site/ContentMirror.ts
+++ b/cli/src/site/ContentMirror.ts
@@ -184,14 +184,7 @@ export function classifyFile(filePath: string, content?: string): FileType {
  * Default package prefixes that are known to be safe.
  * Used as fallback when no ContentRules are provided.
  */
-const DEFAULT_SAFE_IMPORT_PREFIXES = [
-	"nextra",
-	"nextra-theme-docs",
-	"next/",
-	"next-themes",
-	"react",
-	"swagger-ui-react",
-];
+const DEFAULT_SAFE_IMPORT_PREFIXES = ["nextra", "nextra-theme-docs", "next/", "next-themes", "react"];
 
 /**
  * Default components provided by the framework that don't need explicit imports.
@@ -417,7 +410,7 @@ export async function mirrorContent(
 		downgradedCount: 0,
 	};
 
-	await walkDir(sourceRoot, sourceRoot, contentDir, result, pathMappings, contentRules);
+	await walkDir(sourceRoot, sourceRoot, contentDir, result, pathMappings, contentRules, publicDir);
 
 	// If no index.md exists at root, look for a file with `slug: /` frontmatter
 	// (common in Docusaurus projects) and rename it to index.md
@@ -555,6 +548,7 @@ async function walkDir(
 	result: MirrorResult,
 	pathMappings?: PathMappings,
 	contentRules?: ContentRules,
+	publicDir?: string,
 ): Promise<void> {
 	let entries: string[];
 	try {
@@ -580,9 +574,9 @@ async function walkDir(
 		}
 
 		if (entryStat.isDirectory()) {
-			await walkDir(fullPath, sourceRoot, contentDir, result, pathMappings, contentRules);
+			await walkDir(fullPath, sourceRoot, contentDir, result, pathMappings, contentRules, publicDir);
 		} else if (entryStat.isFile()) {
-			await processFile(fullPath, sourceRoot, contentDir, result, pathMappings, contentRules);
+			await processFile(fullPath, sourceRoot, contentDir, result, pathMappings, contentRules, publicDir);
 		}
 	}
 }
@@ -596,6 +590,7 @@ async function processFile(
 	result: MirrorResult,
 	pathMappings?: PathMappings,
 	contentRules?: ContentRules,
+	publicDir?: string,
 ): Promise<void> {
 	const originalRelPath = relative(sourceRoot, fullPath);
 	const relPath = applyPathMapping(originalRelPath, pathMappings);
@@ -681,6 +676,17 @@ async function processFile(
 			const destPath = join(contentDir, relPath);
 			await ensureDir(destPath);
 			await copyFile(fullPath, destPath);
+			// Also mirror into publicDir at the *original* relative path so any
+			// browser-absolute references (e.g. `/favicon.svg`,
+			// `/assets/logo.svg` from site.json or hand-written markdown) resolve
+			// against Next.js's public/ root. Original (non-pathMapped) path is
+			// used because absolute refs in site.json are written against the
+			// source folder layout, not the post-mapping layout.
+			if (publicDir) {
+				const publicDest = join(publicDir, originalRelPath);
+				await ensureDir(publicDest);
+				await copyFile(fullPath, publicDest);
+			}
 			break;
 		}
 		/* v8 ignore next 5 -- unreachable: OpenAPI files are handled in the early-return branch above. */

--- a/cli/src/site/EngineManager.ts
+++ b/cli/src/site/EngineManager.ts
@@ -14,7 +14,7 @@ import { existsSync, lstatSync, readFileSync, unlinkSync } from "node:fs";
 import { mkdir, readFile, rm, symlink, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
-import { NEXTRA_DEPENDENCIES, NEXTRA_DEV_DEPENDENCIES } from "./NextraProjectWriter.js";
+import { NEXTRA_DEPENDENCIES, NEXTRA_DEV_DEPENDENCIES, NEXTRA_OVERRIDES } from "./NextraProjectWriter.js";
 import type { NpmRunResult } from "./Types.js";
 
 // ─── Paths ──────────────────────────────────────────────────────────────────
@@ -36,11 +36,16 @@ interface EngineMetadata {
 // ─── computeDepsHash ────────────────────────────────────────────────────────
 
 /**
- * Computes a SHA-256 hash of the dependency version specs.
- * Changes when dependency versions are updated in NextraProjectWriter.
+ * Computes a SHA-256 hash of the dependency version specs (including
+ * `overrides`). Changes when any version is updated in NextraProjectWriter,
+ * which triggers an engine reinstall on the next CLI invocation.
  */
 export function computeDepsHash(): string {
-	const combined = JSON.stringify({ ...NEXTRA_DEPENDENCIES, ...NEXTRA_DEV_DEPENDENCIES });
+	const combined = JSON.stringify({
+		...NEXTRA_DEPENDENCIES,
+		...NEXTRA_DEV_DEPENDENCIES,
+		overrides: NEXTRA_OVERRIDES,
+	});
 	return createHash("sha256").update(combined).digest("hex").slice(0, 16);
 }
 
@@ -98,13 +103,17 @@ export async function ensureEngine(): Promise<NpmRunResult> {
 	try {
 		await mkdir(engineDir, { recursive: true });
 
-		// Write engine package.json
+		// Write engine package.json. Mirrors the per-site package.json shape
+		// (including `overrides`) so the engine resolves the same transitive
+		// graph the customer sees — see `NEXTRA_OVERRIDES` JSDoc for why we
+		// constrain `zod` here.
 		const pkg = {
 			name: "jolli-site-engine",
 			version: "0.0.1",
 			private: true,
 			dependencies: { ...NEXTRA_DEPENDENCIES },
 			devDependencies: { ...NEXTRA_DEV_DEPENDENCIES },
+			overrides: { ...NEXTRA_OVERRIDES },
 		};
 		await writeFile(join(engineDir, "package.json"), `${JSON.stringify(pkg, null, 2)}\n`, "utf-8");
 

--- a/cli/src/site/MetaGenerator.test.ts
+++ b/cli/src/site/MetaGenerator.test.ts
@@ -21,7 +21,7 @@ import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import * as fc from "fast-check";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -607,5 +607,375 @@ describe("MetaGenerator.generateMetaFiles with sidebar overrides", () => {
 
 		const metaContent = await readFile(join(pagesDir, "_meta.js"), "utf-8");
 		expect(metaContent).toContain("Home Page");
+	});
+});
+
+// ─── injectRootNavEntries (root-only auto-injection) ─────────────────────────
+
+describe("MetaGenerator.generateMetaFiles with rootInjection", () => {
+	let tempDir: string;
+
+	beforeEach(async () => {
+		tempDir = await mkdtemp(join(tmpdir(), "jolli-meta-inject-test-"));
+		// Need at least one *visible* markdown file in the root for processDir
+		// to write the root _meta.js — the folder-walker skips writing the
+		// file when every entry is hidden (`index.md` alone counts as hidden).
+		await writeFile(join(tempDir, "index.md"), "# Home\n", "utf-8");
+		await writeFile(join(tempDir, "about.md"), "# About\n", "utf-8");
+	});
+
+	afterEach(async () => {
+		await rm(tempDir, { recursive: true, force: true });
+	});
+
+	async function readRootMeta(): Promise<string> {
+		return readFile(join(tempDir, "_meta.js"), "utf-8");
+	}
+
+	// ── No specs / no header.items: no injection ─────────────────────────────
+
+	it("injects nothing when there are no specs and no header.items", async () => {
+		const { generateMetaFiles } = await import("./MetaGenerator.js");
+		await generateMetaFiles(tempDir, undefined, { apiSpecs: [], headerItems: [] });
+		const meta = await readRootMeta();
+		expect(meta).not.toContain("__documentation");
+		expect(meta).not.toContain("__api-reference");
+	});
+
+	it("injects nothing when rootInjection is omitted entirely", async () => {
+		const { generateMetaFiles } = await import("./MetaGenerator.js");
+		await generateMetaFiles(tempDir);
+		const meta = await readRootMeta();
+		expect(meta).not.toContain("__documentation");
+	});
+
+	// ── Single spec auto-injection ───────────────────────────────────────────
+
+	it("single spec: injects __documentation + the per-spec entry as the visible API Reference link", async () => {
+		const { generateMetaFiles } = await import("./MetaGenerator.js");
+		await generateMetaFiles(tempDir, undefined, {
+			apiSpecs: [{ specName: "petstore", title: "Petstore" }],
+		});
+		const meta = await readRootMeta();
+		expect(meta).toContain('"__documentation":');
+		expect(meta).toContain('"title":"Documentation"');
+		expect(meta).toContain('"href":"/"');
+		expect(meta).toContain('"api-petstore":');
+		expect(meta).toContain('"title":"API Reference"');
+		expect(meta).toContain('"href":"/api-petstore"');
+		// Single-spec form does NOT emit the dropdown key.
+		expect(meta).not.toContain("__api-reference");
+	});
+
+	// ── Multi-spec auto-injection ────────────────────────────────────────────
+
+	it("multi-spec: emits hidden per-spec entries plus a visible __api-reference dropdown", async () => {
+		const { generateMetaFiles } = await import("./MetaGenerator.js");
+		await generateMetaFiles(tempDir, undefined, {
+			apiSpecs: [
+				{ specName: "petstore", title: "Petstore API" },
+				{ specName: "users", title: "Users API" },
+			],
+		});
+		const meta = await readRootMeta();
+		// Per-spec entries — hidden navbar tabs.
+		expect(meta).toContain('"api-petstore":');
+		expect(meta).toContain('"display":"hidden"');
+		expect(meta).toContain('"api-users":');
+		// Visible dropdown.
+		expect(meta).toContain('"__api-reference":');
+		expect(meta).toContain('"type":"menu"');
+		expect(meta).toContain('"href":"/api-petstore"');
+		expect(meta).toContain('"href":"/api-users"');
+	});
+
+	it("multi-spec falls back to the slug as title when the parsed info.title is missing", async () => {
+		const { generateMetaFiles } = await import("./MetaGenerator.js");
+		await generateMetaFiles(tempDir, undefined, {
+			apiSpecs: [{ specName: "petstore" }, { specName: "users", title: "" }],
+		});
+		const meta = await readRootMeta();
+		expect(meta).toContain('"title":"petstore"');
+		expect(meta).toContain('"title":"users"');
+	});
+
+	// ── User overrides win ───────────────────────────────────────────────────
+
+	it("skips __documentation when the user declares a 'Documentation' header item", async () => {
+		const { generateMetaFiles } = await import("./MetaGenerator.js");
+		await generateMetaFiles(tempDir, undefined, {
+			apiSpecs: [{ specName: "petstore" }],
+			headerItems: [{ label: "Documentation", url: "/docs" }],
+		});
+		const meta = await readRootMeta();
+		expect(meta).not.toContain("__documentation");
+		// User entry survives, slug-keyed.
+		expect(meta).toContain('"nav-documentation":');
+		expect(meta).toContain('"href":"/docs"');
+	});
+
+	it("skips __api-reference when the user declares an 'API Reference' header item", async () => {
+		const { generateMetaFiles } = await import("./MetaGenerator.js");
+		await generateMetaFiles(tempDir, undefined, {
+			apiSpecs: [{ specName: "petstore" }, { specName: "users" }],
+			headerItems: [{ label: "API Reference", url: "/api" }],
+		});
+		const meta = await readRootMeta();
+		expect(meta).not.toContain('"__api-reference":');
+		// Per-spec hidden entries are still emitted (they're folder-bindings).
+		expect(meta).toContain('"api-petstore":');
+		// User entry survives.
+		expect(meta).toContain('"nav-api-reference":');
+	});
+
+	it("matches override labels case-insensitively", async () => {
+		const { generateMetaFiles } = await import("./MetaGenerator.js");
+		await generateMetaFiles(tempDir, undefined, {
+			apiSpecs: [{ specName: "petstore" }],
+			headerItems: [{ label: "DOCUMENTATION", url: "/docs" }],
+		});
+		const meta = await readRootMeta();
+		expect(meta).not.toContain("__documentation");
+	});
+
+	it("recognises the short label 'API' as an API Reference override", async () => {
+		const { generateMetaFiles } = await import("./MetaGenerator.js");
+		await generateMetaFiles(tempDir, undefined, {
+			apiSpecs: [{ specName: "petstore" }],
+			headerItems: [{ label: "API", url: "/api" }],
+		});
+		const meta = await readRootMeta();
+		// Single-spec API Reference auto-entry is suppressed; the api-petstore
+		// folder binding should not be emitted as a navbar link either.
+		expect(meta).not.toContain('"title":"API Reference"');
+	});
+
+	// ── header.items materialisation ─────────────────────────────────────────
+
+	it("materialises a flat header item as type:'page' with the configured href", async () => {
+		const { generateMetaFiles } = await import("./MetaGenerator.js");
+		await generateMetaFiles(tempDir, undefined, {
+			headerItems: [{ label: "Pricing", url: "/pricing" }],
+		});
+		const meta = await readRootMeta();
+		expect(meta).toContain('"nav-pricing":');
+		expect(meta).toContain('"type":"page"');
+		expect(meta).toContain('"href":"/pricing"');
+	});
+
+	it("materialises a header item with sub-items as type:'menu' with sub-entries", async () => {
+		const { generateMetaFiles } = await import("./MetaGenerator.js");
+		await generateMetaFiles(tempDir, undefined, {
+			headerItems: [
+				{
+					label: "Resources",
+					items: [
+						{ label: "Blog", url: "/blog" },
+						{ label: "Changelog", url: "/changelog" },
+					],
+				},
+			],
+		});
+		const meta = await readRootMeta();
+		expect(meta).toContain('"nav-resources":');
+		expect(meta).toContain('"type":"menu"');
+		expect(meta).toContain('"blog":{"title":"Blog","href":"/blog"}');
+		expect(meta).toContain('"changelog":{"title":"Changelog","href":"/changelog"}');
+	});
+
+	// ── Security: URL sanitisation ───────────────────────────────────────────
+
+	it("sanitises javascript: URLs in flat header.items[].url to '#'", async () => {
+		const { generateMetaFiles } = await import("./MetaGenerator.js");
+		await generateMetaFiles(tempDir, undefined, {
+			headerItems: [{ label: "Bad", url: "javascript:alert(1)" }],
+		});
+		const meta = await readRootMeta();
+		expect(meta).not.toMatch(/javascript:alert/i);
+		expect(meta).toContain('"href":"#"');
+	});
+
+	it("sanitises javascript: URLs in dropdown sub-items to '#'", async () => {
+		const { generateMetaFiles } = await import("./MetaGenerator.js");
+		await generateMetaFiles(tempDir, undefined, {
+			headerItems: [
+				{
+					label: "Menu",
+					items: [{ label: "Bad", url: "JAVASCRIPT:alert(1)" }],
+				},
+			],
+		});
+		const meta = await readRootMeta();
+		expect(meta).not.toMatch(/javascript:alert/i);
+		expect(meta).toContain('"href":"#"');
+	});
+
+	it("sanitises data: and vbscript: URLs to '#'", async () => {
+		const { generateMetaFiles } = await import("./MetaGenerator.js");
+		await generateMetaFiles(tempDir, undefined, {
+			headerItems: [
+				{ label: "DataUrl", url: "data:text/html,<script>alert(1)</script>" },
+				{ label: "VbsUrl", url: "vbscript:msgbox(1)" },
+			],
+		});
+		const meta = await readRootMeta();
+		expect(meta).not.toContain("data:text/html");
+		expect(meta).not.toContain("vbscript:");
+		expect(meta).not.toContain("<script>");
+	});
+
+	it("preserves http(s), mailto, tel, fragment, and relative hrefs unchanged", async () => {
+		const { generateMetaFiles } = await import("./MetaGenerator.js");
+		await generateMetaFiles(tempDir, undefined, {
+			headerItems: [
+				{ label: "Site", url: "https://example.com/path" },
+				{ label: "Email", url: "mailto:hi@example.com" },
+				{ label: "Phone", url: "tel:+15551234567" },
+				{ label: "Fragment", url: "#section" },
+				{ label: "Relative", url: "/path/to/page" },
+			],
+		});
+		const meta = await readRootMeta();
+		expect(meta).toContain("https://example.com/path");
+		expect(meta).toContain("mailto:hi@example.com");
+		expect(meta).toContain("tel:+15551234567");
+		expect(meta).toContain("#section");
+		expect(meta).toContain("/path/to/page");
+	});
+
+	// ── Key collision handling ───────────────────────────────────────────────
+
+	it("does not overwrite existing _meta keys when sidebar overrides already declare them", async () => {
+		const { generateMetaFiles } = await import("./MetaGenerator.js");
+		// Sidebar override pins __documentation to a custom value.
+		await generateMetaFiles(
+			tempDir,
+			{ "/": { __documentation: { title: "Custom Docs", href: "/docs" } } },
+			{ apiSpecs: [{ specName: "petstore" }] },
+		);
+		const meta = await readRootMeta();
+		expect(meta).toContain('"title":"Custom Docs"');
+		expect(meta).toContain('"href":"/docs"');
+		// And does not double-inject the same key.
+		const occurrences = meta.match(/"__documentation":/g) ?? [];
+		expect(occurrences.length).toBe(1);
+	});
+
+	it("disambiguates two header.items with identical labels by appending an index", async () => {
+		const { generateMetaFiles } = await import("./MetaGenerator.js");
+		await generateMetaFiles(tempDir, undefined, {
+			headerItems: [
+				{ label: "Docs", url: "/a" },
+				{ label: "Docs", url: "/b" },
+			],
+		});
+		const meta = await readRootMeta();
+		// First gets `nav-docs`, second gets a suffixed key so both survive.
+		expect(meta).toContain('"nav-docs":');
+		expect(meta).toMatch(/"nav-docs-1":/);
+		expect(meta).toContain("/a");
+		expect(meta).toContain("/b");
+	});
+
+	it("disambiguates dropdown sub-items with identical labels so neither is silently overwritten", async () => {
+		const { generateMetaFiles } = await import("./MetaGenerator.js");
+		await generateMetaFiles(tempDir, undefined, {
+			headerItems: [
+				{
+					label: "Resources",
+					items: [
+						{ label: "Blog", url: "/a" },
+						{ label: "Blog", url: "/b" },
+					],
+				},
+			],
+		});
+		const meta = await readRootMeta();
+		// Both sub-items survive — first as `blog`, second with an index suffix.
+		expect(meta).toContain('"blog":{"title":"Blog","href":"/a"}');
+		expect(meta).toMatch(/"blog-1":\{"title":"Blog","href":"\/b"\}/);
+	});
+
+	it("falls back to nav-{idx} for header items whose label slugs to empty", async () => {
+		const { generateMetaFiles } = await import("./MetaGenerator.js");
+		await generateMetaFiles(tempDir, undefined, {
+			headerItems: [{ label: "!!!", url: "/symbol" }],
+		});
+		const meta = await readRootMeta();
+		expect(meta).toContain('"nav-0":');
+		expect(meta).toContain('"href":"/symbol"');
+	});
+
+	// ── Defensive: malformed header items ────────────────────────────────────
+
+	it("skips malformed header items missing 'label' instead of crashing the build", async () => {
+		const { generateMetaFiles } = await import("./MetaGenerator.js");
+		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+		// Cast to bypass type check — site.json is parsed without shape validation
+		// in production, so missing-label objects can reach injectRootNavEntries.
+		await generateMetaFiles(tempDir, undefined, {
+			headerItems: [
+				{ url: "/no-label" } as unknown as { label: string; url: string },
+				{ label: "Valid", url: "/ok" },
+			],
+		});
+		const meta = await readRootMeta();
+		expect(meta).toContain('"nav-valid":');
+		expect(meta).toContain("/ok");
+		expect(meta).not.toContain("/no-label");
+		expect(warnSpy).toHaveBeenCalled();
+		warnSpy.mockRestore();
+	});
+
+	it("skips malformed dropdown sub-items missing 'label' instead of crashing", async () => {
+		const { generateMetaFiles } = await import("./MetaGenerator.js");
+		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+		await generateMetaFiles(tempDir, undefined, {
+			headerItems: [
+				{
+					label: "Resources",
+					items: [
+						{ url: "/no-label" } as unknown as { label: string; url: string },
+						{ label: "Blog", url: "/blog" },
+					],
+				},
+			],
+		});
+		const meta = await readRootMeta();
+		expect(meta).toContain('"nav-resources":');
+		expect(meta).toContain('"blog":{"title":"Blog","href":"/blog"}');
+		expect(meta).not.toContain("/no-label");
+		expect(warnSpy).toHaveBeenCalled();
+		warnSpy.mockRestore();
+	});
+
+	it("skips header items with whitespace-only 'label'", async () => {
+		const { generateMetaFiles } = await import("./MetaGenerator.js");
+		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+		await generateMetaFiles(tempDir, undefined, {
+			headerItems: [
+				{ label: "   ", url: "/whitespace" },
+				{ label: "Real", url: "/real" },
+			],
+		});
+		const meta = await readRootMeta();
+		expect(meta).toContain('"nav-real":');
+		expect(meta).not.toContain("/whitespace");
+		expect(warnSpy).toHaveBeenCalled();
+		warnSpy.mockRestore();
+	});
+
+	// ── Non-root scope is unaffected ─────────────────────────────────────────
+
+	it("does NOT inject auto-entries into nested folder _meta.js files", async () => {
+		const { generateMetaFiles } = await import("./MetaGenerator.js");
+		await mkdir(join(tempDir, "guides"), { recursive: true });
+		await writeFile(join(tempDir, "guides", "intro.md"), "# Intro\n", "utf-8");
+
+		await generateMetaFiles(tempDir, undefined, { apiSpecs: [{ specName: "petstore" }] });
+
+		const nestedMeta = await readFile(join(tempDir, "guides", "_meta.js"), "utf-8");
+		expect(nestedMeta).not.toContain("__documentation");
+		expect(nestedMeta).not.toContain("api-petstore");
 	});
 });

--- a/cli/src/site/MetaGenerator.ts
+++ b/cli/src/site/MetaGenerator.ts
@@ -15,7 +15,36 @@
 
 import { mkdir, readdir, stat, writeFile } from "node:fs/promises";
 import { basename, extname, join, relative, sep } from "node:path";
-import type { SidebarItemValue, SidebarOverrides } from "./Types.js";
+import { sanitizeUrl } from "./Sanitize.js";
+import type { HeaderItem, SidebarItemValue, SidebarOverrides } from "./Types.js";
+
+// ─── Root-injection types ────────────────────────────────────────────────────
+
+/**
+ * One detected OpenAPI spec used by `injectRootNavEntries` to decide
+ * single-spec vs multi-spec navbar shape.
+ */
+export interface RootApiSpec {
+	/** URL slug (matches `/api-{specName}` route + `content/api-{specName}/` folder). */
+	specName: string;
+	/** Display title from `info.title`. Falls back to the slug when unset. */
+	title?: string;
+}
+
+/**
+ * Optional inputs for root `_meta.js` augmentation. None of these affect
+ * non-root meta files.
+ */
+export interface RootInjectionInput {
+	/** Detected OpenAPI specs — drives the auto-injected `Documentation` + `API Reference` entries. */
+	apiSpecs?: RootApiSpec[];
+	/**
+	 * `site.json`'s `header.items`. Each entry is materialised as a root
+	 * `_meta.js` key so Nextra renders it as a native page-tab (with chevron
+	 * for `items`-bearing dropdowns) instead of custom JSX.
+	 */
+	headerItems?: HeaderItem[];
+}
 
 // ─── MetaEntry ────────────────────────────────────────────────────────────────
 
@@ -128,14 +157,29 @@ function buildOverriddenEntries(filenames: string[], override: Record<string, Si
  *
  * When `sidebarOverrides` is provided, directories with matching path keys
  * use the declared ordering/labels instead of alphabetical auto-generation.
+ *
+ * `rootInjection` only affects the root-level `_meta.js`. It auto-injects
+ * `__documentation` + `__api-reference` entries from detected OpenAPI specs
+ * and materialises `header.items` (from site.json) as native Nextra page
+ * tabs — navbar styling, chevron, and mobile drawer integration come from
+ * Nextra natively.
  */
-export async function generateMetaFiles(contentDir: string, sidebarOverrides?: SidebarOverrides): Promise<void> {
-	await processDir(contentDir, contentDir, sidebarOverrides);
+export async function generateMetaFiles(
+	contentDir: string,
+	sidebarOverrides?: SidebarOverrides,
+	rootInjection?: RootInjectionInput,
+): Promise<void> {
+	await processDir(contentDir, contentDir, sidebarOverrides, rootInjection);
 }
 
 // ─── processDir (internal recursive helper) ───────────────────────────────────
 
-async function processDir(dir: string, contentDir: string, sidebarOverrides?: SidebarOverrides): Promise<boolean> {
+async function processDir(
+	dir: string,
+	contentDir: string,
+	sidebarOverrides?: SidebarOverrides,
+	rootInjection?: RootInjectionInput,
+): Promise<boolean> {
 	let entries: string[];
 	try {
 		entries = await readdir(dir);
@@ -158,7 +202,7 @@ async function processDir(dir: string, contentDir: string, sidebarOverrides?: Si
 		}
 
 		if (entryStat.isDirectory()) {
-			const hasContent = await processDir(fullPath, contentDir, sidebarOverrides);
+			const hasContent = await processDir(fullPath, contentDir, sidebarOverrides, rootInjection);
 			if (hasContent) {
 				contentItems.push(entry);
 			}
@@ -179,7 +223,13 @@ async function processDir(dir: string, contentDir: string, sidebarOverrides?: Si
 	const pathKey = `/${relPath.split(sep).join("/")}`.replace(/\/$/, "") || "/";
 
 	const override = sidebarOverrides?.[pathKey];
-	const metaEntries = buildMetaEntries(contentItems, override);
+	let metaEntries = buildMetaEntries(contentItems, override);
+
+	// Root-only augmentation: auto-inject `Documentation` / `API Reference`
+	// page tabs and materialise `header.items` as Nextra-native tabs.
+	if (pathKey === "/" && rootInjection) {
+		metaEntries = injectRootNavEntries(metaEntries, rootInjection);
+	}
 
 	// Don't write _meta.js if all entries are hidden (e.g. folder with only index.md).
 	// Nextra fails to prerender folders with _meta.js that has no visible entries.
@@ -193,20 +243,217 @@ async function processDir(dir: string, contentDir: string, sidebarOverrides?: Si
 	return true;
 }
 
+// ─── injectRootNavEntries ────────────────────────────────────────────────────
+
+/**
+ * Reserved keys for the auto-injected root navbar entries. Exported so tests
+ * (and future inspector tooling) can assert against the canonical string.
+ */
+export const DOC_HOME_NAV_KEY = "__documentation";
+export const OPENAPI_NAV_KEY = "__api-reference";
+
+/** Customer-side labels that suppress auto-injection (case-insensitive). */
+const DOCUMENTATION_LABELS = new Set(["documentation"]);
+const API_REFERENCE_LABELS = new Set(["api reference", "api"]);
+
+/**
+ * Slugifies a header-item label into a stable `_meta.js` key. Uses a
+ * `nav-` prefix to namespace customer-supplied entries so they cannot
+ * collide with auto-injected `__documentation` / `__api-reference` /
+ * `api-{slug}` keys, even via crafted labels.
+ *
+ * Falls back to `nav-${idx}` when slugification yields an empty string —
+ * e.g. a label that was all punctuation.
+ */
+function navKeyFromLabel(label: string, idx: number): string {
+	const slug = label
+		.toLowerCase()
+		.replace(/[^\w\s-]/g, "")
+		.replace(/\s+/g, "-")
+		.replace(/-+/g, "-")
+		.replace(/^-+|-+$/g, "");
+	return slug ? `nav-${slug}` : `nav-${idx}`;
+}
+
+/**
+ * Returns a new entry list with auto-injected `Documentation` / `API Reference`
+ * tabs and materialised `header.items` entries:
+ *
+ *   - `__documentation` page-tab linking to `/` whenever the customer has any
+ *     specs and hasn't already declared a header item labelled "Documentation".
+ *   - **Single spec, no override**: the spec's `api-{slug}` entry doubles as
+ *     the visible "API Reference" navbar tab — `{ title: "API Reference",
+ *     type: "page", href: "/api-{slug}" }`. The href makes it a link in docs
+ *     scope; `<ScopedNextraLayout>` strips the href when inside the spec's
+ *     folder so Nextra binds it for sidebar scoping.
+ *   - **Multi-spec (or single spec with a user "API Reference" override)**:
+ *     each spec is recorded as a hidden page-tab + a visible
+ *     `__api-reference` dropdown (`type: "menu"`) whose `items` map is one
+ *     sub-entry per spec.
+ *   - User-supplied `header.items` are appended after the auto entries with
+ *     `nav-{slug}` keys derived from the label so customer reordering is a
+ *     no-op on the generated keys. URLs flow through `sanitizeUrl` —
+ *     `javascript:` / `data:` URLs are clamped to `"#"`.
+ *     A header item with a clashing label (Documentation / API / API
+ *     Reference, case-insensitive) suppresses the matching auto injection —
+ *     customer overrides win.
+ *
+ * Order matters: Nextra renders root tabs in `_meta.js` declaration order,
+ * and we want `Documentation` first (primary anchor), `API Reference` next,
+ * then user-supplied tabs.
+ */
+function injectRootNavEntries(existing: MetaEntry[], input: RootInjectionInput): MetaEntry[] {
+	const apiSpecs = input.apiSpecs ?? [];
+	// `HeaderItem.label: string` is required at the type level, but site.json
+	// is parsed without shape validation, so a customer who writes
+	// `{ url: "/foo" }` (label omitted) reaches us with `label === undefined`.
+	// Skip malformed entries with a console warning instead of crashing the
+	// build pipeline with `TypeError: Cannot read properties of undefined`.
+	const headerItems = (input.headerItems ?? []).filter((item) => {
+		if (typeof item?.label !== "string" || item.label.trim() === "") {
+			console.warn(`[jolli] Skipping header.items entry with missing or empty 'label': ${JSON.stringify(item)}`);
+			return false;
+		}
+		return true;
+	});
+
+	const userLabels = new Set<string>();
+	for (const item of headerItems) {
+		userLabels.add(item.label.trim().toLowerCase());
+	}
+	const skipDocumentation = [...DOCUMENTATION_LABELS].some((label) => userLabels.has(label));
+	const skipApiReference = [...API_REFERENCE_LABELS].some((label) => userLabels.has(label));
+
+	const injected: MetaEntry[] = [];
+
+	if (apiSpecs.length > 0 && !skipDocumentation) {
+		injected.push({
+			key: DOC_HOME_NAV_KEY,
+			value: { title: "Documentation", type: "page", href: "/" },
+		});
+	}
+
+	if (apiSpecs.length === 1 && !skipApiReference) {
+		// Single-spec form — the per-spec entry IS the visible navbar API
+		// Reference link. Carries an `href` so it acts as a navigation link
+		// in docs scope; `<ScopedNextraLayout>` strips the href when inside
+		// the spec's folder so Nextra binds it for sidebar scoping.
+		const spec = apiSpecs[0];
+		injected.push({
+			key: `api-${spec.specName}`,
+			value: { title: "API Reference", type: "page", href: `/api-${spec.specName}` },
+		});
+	} else if (apiSpecs.length > 1) {
+		// Multi-spec — per-spec entries are hidden by default, the visible
+		// dropdown at `OPENAPI_NAV_KEY` handles navigation. Each spec entry
+		// is kept so `<ScopedNextraLayout>` can un-hide the active one for
+		// sidebar binding.
+		for (const spec of apiSpecs) {
+			injected.push({
+				key: `api-${spec.specName}`,
+				value: { title: spec.title?.trim() || spec.specName, type: "page", display: "hidden" },
+			});
+		}
+		if (!skipApiReference) {
+			const items: Record<string, { title: string; href: string }> = {};
+			for (const spec of apiSpecs) {
+				items[spec.specName] = {
+					title: spec.title?.trim() || spec.specName,
+					href: `/api-${spec.specName}`,
+				};
+			}
+			injected.push({
+				key: OPENAPI_NAV_KEY,
+				value: { title: "API Reference", type: "menu", items },
+			});
+		}
+	}
+
+	// User-supplied header items — coerced into Nextra page-tab shape with
+	// sanitised URLs and slug-derived keys (stable across reordering).
+	const usedNavKeys = new Set<string>();
+	headerItems.forEach((item, idx) => {
+		let key = navKeyFromLabel(item.label, idx);
+		// Defuse two `header.items` entries with the same label collapsing onto
+		// one key (Nextra reads the last definition wins; we'd rather keep all
+		// entries by appending an index suffix on collision).
+		if (usedNavKeys.has(key)) {
+			key = `${key}-${idx}`;
+		}
+		usedNavKeys.add(key);
+
+		if (item.items && item.items.length > 0) {
+			const items: Record<string, { title: string; href?: string }> = {};
+			const usedSubKeys = new Set<string>();
+			// Same defensive filter as the outer loop — `ExternalLink.label: string`
+			// is required at the type level but site.json shape isn't validated.
+			const validSubItems = item.items.filter((sub) => {
+				if (typeof sub?.label !== "string" || sub.label.trim() === "") {
+					console.warn(
+						`[jolli] Skipping header.items[].items entry with missing/empty 'label': ${JSON.stringify(sub)}`,
+					);
+					return false;
+				}
+				return true;
+			});
+			validSubItems.forEach((sub, subIdx) => {
+				// `navKeyFromLabel` always returns `nav-{slug}` or `nav-{idx}`, so
+				// after stripping the prefix we always have at least one character.
+				let subKey = navKeyFromLabel(sub.label, subIdx).replace(/^nav-/, "");
+				// Same dedup discipline as the outer header-items loop: two sub-items
+				// with the same label otherwise collapse to one entry (last wins).
+				if (usedSubKeys.has(subKey)) {
+					subKey = `${subKey}-${subIdx}`;
+				}
+				usedSubKeys.add(subKey);
+				// Mirror the outer-item url-defensive pattern: `ExternalLink.url` is
+				// required at the type level but site.json shape isn't validated, so a
+				// sub-item with a missing `url` would otherwise crash `sanitizeUrl`'s
+				// `url.trim()` call. Emit the entry without href when url is missing
+				// so the build doesn't blow up on a malformed config.
+				const subValue: { title: string; href?: string } = { title: sub.label };
+				if (sub.url) {
+					subValue.href = sanitizeUrl(sub.url);
+				}
+				items[subKey] = subValue;
+			});
+			injected.push({ key, value: { title: item.label, type: "menu", items } });
+		} else {
+			const value: Record<string, unknown> = { title: item.label, type: "page" };
+			if (item.url) {
+				value.href = sanitizeUrl(item.url);
+			}
+			injected.push({ key, value });
+		}
+	});
+
+	if (injected.length === 0) {
+		return existing;
+	}
+
+	// De-duplicate against keys the existing entry list already declares
+	// (e.g. when the customer wrote a manual `_meta.js` override that
+	// already pins `__documentation`).
+	const existingKeys = new Set(existing.map((e) => e.key));
+	const filtered = injected.filter((e) => !existingKeys.has(e.key));
+	return [...filtered, ...existing];
+}
+
 // ─── writeMetaFile (internal helper) ─────────────────────────────────────────
 
 /**
  * Serialises `entries` into a Nextra v4 `_meta.js` ES-module and writes it
  * to `<dir>/_meta.js`.
  *
- * String values are written as simple strings. Object values are written as
- * JSON objects (for external links, hidden items, etc.).
+ * Both keys and values flow through `JSON.stringify` so a customer-supplied
+ * sidebar override label or key containing `"`, `\`, or other JS-string-
+ * significant characters cannot produce an unparseable `_meta.js` (which
+ * would crash the customer's `next build` pointing at a file they don't own).
+ * Object values were already going through `JSON.stringify`; this consolidates
+ * the string-value branch onto the same path.
  */
 async function writeMetaFile(dir: string, entries: MetaEntry[]): Promise<void> {
-	const lines = entries.map(({ key, value }) => {
-		const serialized = typeof value === "string" ? `"${value}"` : JSON.stringify(value);
-		return `  "${key}": ${serialized},`;
-	});
+	const lines = entries.map(({ key, value }) => `  ${JSON.stringify(key)}: ${JSON.stringify(value)},`);
 	const content = `export default {\n${lines.join("\n")}\n}\n`;
 
 	await mkdir(dir, { recursive: true });

--- a/cli/src/site/NextraProjectWriter.test.ts
+++ b/cli/src/site/NextraProjectWriter.test.ts
@@ -31,6 +31,13 @@ async function makeTempDir(): Promise<string> {
 	return mkdtemp(join(tmpdir(), "jolli-nextrawriter-test-"));
 }
 
+/**
+ * Pinned to `theme.pack: "default"` so the existing assertions keep exercising
+ * the vanilla-Nextra default layout. The dispatcher now picks Forge when
+ * `theme.pack` is unset, so an `unset` SAMPLE_CONFIG would silently move
+ * every test into the Forge code path. Tests covering the new unset-pack →
+ * Forge behavior live below in their own `describe` block.
+ */
 const SAMPLE_CONFIG = {
 	title: "My API Docs",
 	description: "Documentation for My API",
@@ -38,6 +45,7 @@ const SAMPLE_CONFIG = {
 		{ label: "Home", href: "/" },
 		{ label: "GitHub", href: "https://github.com/example" },
 	],
+	theme: { pack: "default" as const },
 };
 
 // ─── generatePackageJson unit tests ──────────────────────────────────────────
@@ -178,18 +186,20 @@ describe("NextraProjectWriter.generateLayout", () => {
 		expect(generateLayout(SAMPLE_CONFIG)).toContain("Documentation for My API");
 	});
 
-	it("contains nav item labels", async () => {
+	it("uses <ScopedNextraLayout> instead of vanilla <Layout> (sidebar scoping)", async () => {
 		const { generateLayout } = await import("./NextraProjectWriter.js");
 		const result = generateLayout(SAMPLE_CONFIG);
-		expect(result).toContain("Home");
-		expect(result).toContain("GitHub");
+		expect(result).toContain("import ScopedNextraLayout from '../components/ScopedNextraLayout'");
+		expect(result).toContain("<ScopedNextraLayout");
 	});
 
-	it("contains nav item hrefs", async () => {
+	it("default layout's <Navbar> has no JSX children — nav comes from root _meta.js", async () => {
 		const { generateLayout } = await import("./NextraProjectWriter.js");
 		const result = generateLayout(SAMPLE_CONFIG);
-		expect(result).toContain("/");
-		expect(result).toContain("https://github.com/example");
+		// Nav items live in `content/_meta.js` (written by MetaGenerator).
+		// The layout's navbar only renders the logo prop.
+		expect(result).not.toContain('href={"/"}');
+		expect(result).not.toContain("https://github.com/example");
 	});
 
 	it("imports nextra-theme-docs Layout and Navbar", async () => {
@@ -230,15 +240,19 @@ describe("NextraProjectWriter.generateLayout", () => {
 
 	// ── theme.pack dispatcher (Phase 1) ──────────────────────────────────────
 
-	it("uses the default layout when theme.pack is unset", async () => {
-		const { generateLayout, generateDefaultLayout } = await import("./NextraProjectWriter.js");
-		expect(generateLayout(SAMPLE_CONFIG)).toBe(generateDefaultLayout(SAMPLE_CONFIG));
+	it("uses the Forge layout when theme.pack is unset (Forge is the implicit default)", async () => {
+		const { generateLayout, generateForgeLayout } = await import("./NextraProjectWriter.js");
+		const config = {
+			title: "My API Docs",
+			description: "Documentation for My API",
+			// no `theme` block — must dispatch to Forge, not the vanilla default.
+		};
+		expect(generateLayout(config)).toBe(generateForgeLayout(config));
 	});
 
 	it("uses the default layout when theme.pack is explicitly 'default'", async () => {
 		const { generateLayout, generateDefaultLayout } = await import("./NextraProjectWriter.js");
-		const config = { ...SAMPLE_CONFIG, theme: { pack: "default" as const } };
-		expect(generateLayout(config)).toBe(generateDefaultLayout(SAMPLE_CONFIG));
+		expect(generateLayout(SAMPLE_CONFIG)).toBe(generateDefaultLayout(SAMPLE_CONFIG));
 	});
 
 	it("forge pack returns the Forge layout (forge-sidebar-logo + forge.css import)", async () => {
@@ -257,74 +271,102 @@ describe("NextraProjectWriter.generateLayout", () => {
 		expect(result).toContain("./themes/atlas.css");
 	});
 
-	it("default layout passes through theme branding fields without crashing (no-op for now)", async () => {
-		const { generateLayout } = await import("./NextraProjectWriter.js");
-		const config = {
+	it("default layout renders the title in <b> when no logo image or text is configured", async () => {
+		const { generateDefaultLayout } = await import("./NextraProjectWriter.js");
+		const result = generateDefaultLayout(SAMPLE_CONFIG);
+		expect(result).toContain('<b>{"My API Docs"}</b>');
+		expect(result).not.toContain("<img");
+	});
+
+	it("default layout uses theme.logoText for the navbar text when set", async () => {
+		const { generateDefaultLayout } = await import("./NextraProjectWriter.js");
+		const result = generateDefaultLayout({ ...SAMPLE_CONFIG, theme: { logoText: "ACME" } });
+		expect(result).toContain('<b>{"ACME"}</b>');
+		expect(result).not.toContain('<b>{"My API Docs"}</b>');
+	});
+
+	it("default layout renders an <img> from theme.logoUrl alongside the text by default", async () => {
+		const { generateDefaultLayout } = await import("./NextraProjectWriter.js");
+		const result = generateDefaultLayout({ ...SAMPLE_CONFIG, theme: { logoUrl: "/logo.svg" } });
+		expect(result).toContain('<img src={"/logo.svg"}');
+		expect(result).toContain('<b>{"My API Docs"}</b>');
+	});
+
+	it("default layout emits dark-swap classes and a <style> rule when both logoUrl and logoUrlDark are set", async () => {
+		const { generateDefaultLayout } = await import("./NextraProjectWriter.js");
+		const result = generateDefaultLayout({
+			...SAMPLE_CONFIG,
+			theme: { logoUrl: "/light.svg", logoUrlDark: "/dark.svg" },
+		});
+		expect(result).toContain('className="jolli-default-logo-light"');
+		expect(result).toContain('className="jolli-default-logo-dark"');
+		expect(result).toContain(".dark .jolli-default-logo-light");
+	});
+
+	it("default layout logoDisplay='text' suppresses the image even when logoUrl is set", async () => {
+		const { generateDefaultLayout } = await import("./NextraProjectWriter.js");
+		const result = generateDefaultLayout({
+			...SAMPLE_CONFIG,
+			theme: { logoUrl: "/logo.svg", logoDisplay: "text" },
+		});
+		expect(result).not.toContain("<img");
+		expect(result).toContain('<b>{"My API Docs"}</b>');
+	});
+
+	it("default layout logoDisplay='image' suppresses the text label when logoUrl is set", async () => {
+		const { generateDefaultLayout } = await import("./NextraProjectWriter.js");
+		const result = generateDefaultLayout({
+			...SAMPLE_CONFIG,
+			theme: { logoUrl: "/logo.svg", logoDisplay: "image" },
+		});
+		expect(result).toContain('<img src={"/logo.svg"}');
+		expect(result).not.toContain('<b>{"My API Docs"}</b>');
+	});
+
+	it("default layout logoDisplay='image' falls back to text when logoUrl is unset", async () => {
+		const { generateDefaultLayout } = await import("./NextraProjectWriter.js");
+		const result = generateDefaultLayout({ ...SAMPLE_CONFIG, theme: { logoDisplay: "image" } });
+		expect(result).not.toContain("<img");
+		expect(result).toContain('<b>{"My API Docs"}</b>');
+	});
+
+	it("default layout passes through favicon, primaryHue, etc. without crashing", async () => {
+		const { generateDefaultLayout } = await import("./NextraProjectWriter.js");
+		const result = generateDefaultLayout({
 			...SAMPLE_CONFIG,
 			theme: {
 				logoUrl: "/logo.svg",
 				logoUrlDark: "/logo-dark.svg",
 				favicon: "/favicon.ico",
 				primaryHue: 200,
-				defaultTheme: "dark" as const,
-				fontFamily: "inter" as const,
+				defaultTheme: "dark",
+				fontFamily: "inter",
 			},
-		};
-		const result = generateLayout(config);
+		});
 		expect(result).toContain("My API Docs");
 		expect(result).toContain("nextra-theme-docs");
 	});
 
-	// ── header / footer (post-1392 schema) ────────────────────────────────────
+	// ── footer (default theme: inline-style fallback, no pack CSS) ────────────
+	// These tests pin behavior of the vanilla `nextra-theme-docs` default
+	// layout — `theme: { pack: "default" }` is required because the dispatcher
+	// picks Forge when `theme.pack` is unset. Pack-specific footer behavior is
+	// exercised in `themes/Footer.test.ts` and the per-pack layout tests.
 
-	it("renders header.items direct links the same way as legacy nav", async () => {
+	const DEFAULT_PACK_THEME = { pack: "default" as const };
+
+	it("default layout footer body still uses inline-style flex layout (no pack CSS to target classes)", async () => {
 		const { generateLayout } = await import("./NextraProjectWriter.js");
 		const result = generateLayout({
 			title: "T",
 			description: "D",
-			nav: [],
-			header: { items: [{ label: "Guides", url: "/guides" }] },
+			theme: DEFAULT_PACK_THEME,
+			footer: { copyright: "2026 Acme Inc." },
 		});
-		expect(result).toContain('<a href={"/guides"}');
-		expect(result).toContain('{"Guides"}');
-	});
-
-	it("prefers header.items over the legacy nav shorthand when both are set", async () => {
-		const { generateLayout } = await import("./NextraProjectWriter.js");
-		const result = generateLayout({
-			title: "T",
-			description: "D",
-			nav: [{ label: "FromNav", href: "/nav" }],
-			header: { items: [{ label: "FromHeader", url: "/header" }] },
-		});
-		expect(result).toContain("FromHeader");
-		expect(result).not.toContain("FromNav");
-	});
-
-	it("renders a <details> dropdown when a header item has sub-items", async () => {
-		const { generateLayout } = await import("./NextraProjectWriter.js");
-		const result = generateLayout({
-			title: "T",
-			description: "D",
-			nav: [],
-			header: {
-				items: [
-					{
-						label: "Resources",
-						items: [
-							{ label: "Blog", url: "/blog" },
-							{ label: "Changelog", url: "/changelog" },
-						],
-					},
-				],
-			},
-		});
-		expect(result).toContain("<details");
-		expect(result).toContain("<summary");
-		expect(result).toContain('{"Resources"}');
-		expect(result).toContain('{"Blog"}');
-		expect(result).toContain('{"Changelog"}');
-		expect(result).toContain('<a href={"/blog"}');
+		// Default theme has no pack stylesheet, so it keeps the inline-style
+		// fallback. Forge / Atlas use semantic class names — see their tests.
+		expect(result).toContain("<Footer>");
+		expect(result).toContain('{"2026 Acme Inc."}');
 	});
 
 	it("emits a bare <Footer /> when no footer config is provided (back-compat)", async () => {
@@ -338,7 +380,7 @@ describe("NextraProjectWriter.generateLayout", () => {
 		const result = generateLayout({
 			title: "T",
 			description: "D",
-			nav: [],
+			theme: DEFAULT_PACK_THEME,
 			footer: { columns: [], socialLinks: {} },
 		});
 		expect(result).toContain("footer={<Footer />}");
@@ -349,7 +391,7 @@ describe("NextraProjectWriter.generateLayout", () => {
 		const result = generateLayout({
 			title: "T",
 			description: "D",
-			nav: [],
+			theme: DEFAULT_PACK_THEME,
 			footer: { copyright: "2026 Acme Inc." },
 		});
 		expect(result).toContain("<Footer>");
@@ -361,7 +403,7 @@ describe("NextraProjectWriter.generateLayout", () => {
 		const result = generateLayout({
 			title: "T",
 			description: "D",
-			nav: [],
+			theme: DEFAULT_PACK_THEME,
 			footer: {
 				columns: [
 					{
@@ -385,7 +427,7 @@ describe("NextraProjectWriter.generateLayout", () => {
 		const result = generateLayout({
 			title: "T",
 			description: "D",
-			nav: [],
+			theme: DEFAULT_PACK_THEME,
 			footer: { socialLinks: { youtube: "https://yt.example", github: "https://gh.example" } },
 		});
 		// github appears before youtube in SOCIAL_PLATFORMS; verify ordering survived.
@@ -399,43 +441,12 @@ describe("NextraProjectWriter.generateLayout", () => {
 		expect(result).not.toContain('aria-label={"twitter"}');
 	});
 
-	it("sanitizes javascript: URLs in header items to '#'", async () => {
-		const { generateLayout } = await import("./NextraProjectWriter.js");
-		const result = generateLayout({
-			title: "T",
-			description: "D",
-			nav: [],
-			header: { items: [{ label: "Bad", url: "javascript:alert(1)" }] },
-		});
-		expect(result).not.toContain("javascript:alert");
-		expect(result).toContain('<a href={"#"}');
-	});
-
-	it("sanitizes javascript: URLs in dropdown sub-items to '#'", async () => {
-		const { generateLayout } = await import("./NextraProjectWriter.js");
-		const result = generateLayout({
-			title: "T",
-			description: "D",
-			nav: [],
-			header: {
-				items: [
-					{
-						label: "Menu",
-						items: [{ label: "Bad", url: "JAVASCRIPT:alert(1)" }],
-					},
-				],
-			},
-		});
-		expect(result).not.toMatch(/javascript:alert/i);
-		expect(result).toContain('<a href={"#"}');
-	});
-
 	it("sanitizes javascript: URLs in footer column links and social links", async () => {
 		const { generateLayout } = await import("./NextraProjectWriter.js");
 		const result = generateLayout({
 			title: "T",
 			description: "D",
-			nav: [],
+			theme: DEFAULT_PACK_THEME,
 			footer: {
 				columns: [{ title: "X", links: [{ label: "Bad", url: "javascript:alert(1)" }] }],
 				socialLinks: { github: "data:text/html,evil" },
@@ -673,21 +684,49 @@ describe("NextraProjectWriter.initNextraProject", () => {
 		expect(layoutContent).toContain("New description");
 	});
 
-	it("regenerates app/layout.tsx with updated nav on subsequent run", async () => {
+	it("regenerates app/layout.tsx with updated title on subsequent run (nav now flows through _meta.js)", async () => {
 		const { initNextraProject } = await import("./NextraProjectWriter.js");
 		const buildDir = join(tempDir, ".jolli-site");
 
 		await initNextraProject(buildDir, SAMPLE_CONFIG);
 
-		const updatedConfig = {
-			...SAMPLE_CONFIG,
-			nav: [{ label: "New Link", href: "/new" }],
-		};
+		const updatedConfig = { ...SAMPLE_CONFIG, title: "Updated Title", nav: [{ label: "New Link", href: "/new" }] };
 		await initNextraProject(buildDir, updatedConfig);
 
 		const layoutContent = await readFile(join(buildDir, "app", "layout.tsx"), "utf-8");
-		expect(layoutContent).toContain("New Link");
-		expect(layoutContent).toContain("/new");
+		expect(layoutContent).toContain("Updated Title");
+		// Nav items are written to root _meta.js by MetaGenerator, NOT into layout.tsx.
+		expect(layoutContent).not.toContain("/new");
+	});
+
+	it("initNextraProject writes components/ScopedNextraLayout.tsx with the runtime page-map filter", async () => {
+		const { initNextraProject } = await import("./NextraProjectWriter.js");
+		const buildDir = join(tempDir, ".jolli-site");
+
+		await initNextraProject(buildDir, SAMPLE_CONFIG);
+
+		expect(existsSync(join(buildDir, "components", "ScopedNextraLayout.tsx"))).toBe(true);
+		const content = await readFile(join(buildDir, "components", "ScopedNextraLayout.tsx"), "utf-8");
+		expect(content).toContain('"use client"');
+		expect(content).toContain("scopePageMap");
+		expect(content).toContain("usePathname");
+	});
+
+	it("ScopedNextraLayout.tsx declares scopePageMap BEFORE the default export (RSC tree-shaking gotcha)", async () => {
+		const { initNextraProject } = await import("./NextraProjectWriter.js");
+		const buildDir = join(tempDir, ".jolli-site");
+
+		await initNextraProject(buildDir, SAMPLE_CONFIG);
+
+		const content = await readFile(join(buildDir, "components", "ScopedNextraLayout.tsx"), "utf-8");
+		// Next.js's "use client" / RSC compiler tree-shakes function declarations
+		// placed AFTER the default export. The component throws "scopePageMap is
+		// not defined" at render time when this ordering regresses.
+		const helperIdx = content.indexOf("function scopePageMap");
+		const exportIdx = content.indexOf("export default function ScopedNextraLayout");
+		expect(helperIdx).toBeGreaterThan(-1);
+		expect(exportIdx).toBeGreaterThan(-1);
+		expect(helperIdx).toBeLessThan(exportIdx);
 	});
 
 	it("written package.json is valid JSON with required dependencies", async () => {
@@ -729,13 +768,27 @@ describe("NextraProjectWriter.initNextraProject", () => {
 		expect(existsSync(join(buildDir, "app", "themes", "forge.css"))).toBe(true);
 	});
 
-	it("does NOT write app/themes/forge.css for the default pack", async () => {
+	it("does NOT write app/themes/forge.css when theme.pack is explicitly 'default'", async () => {
 		const { initNextraProject } = await import("./NextraProjectWriter.js");
 		const buildDir = join(tempDir, ".jolli-site");
 
 		await initNextraProject(buildDir, SAMPLE_CONFIG);
 
 		expect(existsSync(join(buildDir, "app", "themes", "forge.css"))).toBe(false);
+	});
+
+	it("DOES write app/themes/forge.css when theme.pack is unset (Forge is the implicit default)", async () => {
+		const { initNextraProject } = await import("./NextraProjectWriter.js");
+		const buildDir = join(tempDir, ".jolli-site");
+		const config = {
+			title: "My API Docs",
+			description: "Documentation for My API",
+			// no `theme` block — Forge CSS still has to land or the layout import breaks.
+		};
+
+		await initNextraProject(buildDir, config);
+
+		expect(existsSync(join(buildDir, "app", "themes", "forge.css"))).toBe(true);
 	});
 
 	it("forge.css reflects theme.primaryHue in the generated overrides", async () => {
@@ -873,7 +926,7 @@ describe("Property 5: site.json fields are preserved in generated Nextra config"
 		);
 	});
 
-	it("generateLayout always contains all nav item labels", async () => {
+	it("generateLayout never embeds nav item labels — they go through root _meta.js instead", async () => {
 		const { generateLayout } = await import("./NextraProjectWriter.js");
 
 		fc.assert(
@@ -884,25 +937,17 @@ describe("Property 5: site.json fields are preserved in generated Nextra config"
 				(title, description, nav) => {
 					const config = { title, description, nav };
 					const result = generateLayout(config);
-					return nav.every(({ label }) => result.includes(label));
+					// Only `title` and the `<Navbar logo=…>` slot reach the layout —
+					// nav item labels and hrefs do not.
+					return nav.every(({ href }) => !result.includes(`href={${JSON.stringify(href)}}`));
 				},
 			),
 			{ numRuns: 100 },
 		);
 	});
 
-	it("generateLayout always contains the sanitized form of every nav item href", async () => {
+	it("generateLayout always uses <ScopedNextraLayout> and never embeds nav hrefs as JSX-expression attributes", async () => {
 		const { generateLayout } = await import("./NextraProjectWriter.js");
-
-		// sanitizeUrl trims whitespace and replaces non-safe schemes with "#".
-		// The output embeds each href via JSON.stringify(sanitizeUrl(href)).
-		function expectedHref(href: string): string {
-			const trimmed = href.trim();
-			if (trimmed === "" || /^(?:https?:|mailto:|tel:|[#?/]|\.\.?\/)/i.test(trimmed)) {
-				return JSON.stringify(trimmed);
-			}
-			return JSON.stringify("#");
-		}
 
 		fc.assert(
 			fc.property(
@@ -912,7 +957,12 @@ describe("Property 5: site.json fields are preserved in generated Nextra config"
 				(title, description, nav) => {
 					const config = { title, description, nav };
 					const result = generateLayout(config);
-					return nav.every(({ href }) => result.includes(expectedHref(href)));
+					// Nav items now flow through `_meta.js`, never spliced into the
+					// layout JSX. The pack layouts emit unrelated anchors (Forge's
+					// sidebar-logo wrapper has `<a href="/">`), so the assertion is
+					// scoped to the JSX-expression form (`<a href={…}>`) the old
+					// nav-children code used for nav links.
+					return result.includes("ScopedNextraLayout") && !/<a href=\{/.test(result);
 				},
 			),
 			{ numRuns: 100 },

--- a/cli/src/site/NextraProjectWriter.ts
+++ b/cli/src/site/NextraProjectWriter.ts
@@ -15,13 +15,16 @@
 import { existsSync } from "node:fs";
 import { mkdir, writeFile } from "node:fs/promises";
 import { join } from "node:path";
-import type { FooterConfig, HeaderConfig, HeaderItem, NavLink, ThemeConfig, ThemePack } from "./Types.js";
+import { sanitizeUrl } from "./Sanitize.js";
+import { SCOPE_PAGE_MAP_RUNTIME_SOURCE } from "./ScopePageMap.js";
+import type { FooterConfig, HeaderConfig, LogoDisplay, ThemeConfig, ThemePack } from "./Types.js";
 import {
 	buildAtlasCss,
 	buildAtlasFontFamilyCssValue,
 	generateAtlasLayoutTsx,
 	resolveAtlasLayoutInput,
 } from "./themes/atlas/index.js";
+import { SOCIAL_PLATFORMS } from "./themes/Footer.js";
 import {
 	buildForgeCss,
 	buildForgeFontFamilyCssValue,
@@ -38,7 +41,6 @@ import {
 export interface NextraProjectConfig {
 	title: string;
 	description: string;
-	nav: NavLink[];
 	header?: HeaderConfig;
 	footer?: FooterConfig;
 	/**
@@ -76,28 +78,31 @@ export async function initNextraProject(
 	// Always regenerate config files so they reflect the latest site.json values.
 	await writeFile(join(buildDir, "package.json"), generatePackageJson(), "utf-8");
 	await writeFile(join(buildDir, "next.config.mjs"), generateNextConfig(options.staticExport), "utf-8");
-	await writeFile(join(buildDir, "app", "layout.tsx"), generateLayout(config), "utf-8");
+	await writeLayoutTsx(buildDir, config);
 	await writeFile(join(buildDir, "app", "not-found.tsx"), generateNotFound(), "utf-8");
 	await writeFile(join(buildDir, "app", "[[...mdxPath]]", "page.tsx"), generateCatchAllPage(), "utf-8");
 	await writeFile(join(buildDir, "mdx-components.tsx"), generateMdxComponents(), "utf-8");
 	await writeFile(join(buildDir, "tsconfig.json"), generateTsConfig(), "utf-8");
+	await writeScopedNextraLayoutComponent(buildDir);
 
-	// Pack-specific stylesheet — only written when the user opts into a
-	// non-default pack. Each pack's layout imports its own CSS file, so the
-	// file has to land before `next dev` reads the layout module.
-	if (config.theme?.pack === "forge") {
+	// Pack-specific stylesheet. Forge is the implicit default: a site.json
+	// with no `theme.pack` renders Forge. The vanilla `nextra-theme-docs`
+	// look is still reachable via `theme.pack: "default"`, which writes no
+	// pack CSS.
+	const pack = config.theme?.pack ?? "forge";
+	if (pack === "forge") {
 		await mkdir(join(buildDir, "app", "themes"), { recursive: true });
-		const primaryHue = config.theme.primaryHue ?? 228;
-		const fontFamily = config.theme.fontFamily ?? "inter";
+		const primaryHue = config.theme?.primaryHue ?? 228;
+		const fontFamily = config.theme?.fontFamily ?? "inter";
 		const css = buildForgeCss({
 			accentHue: primaryHue,
 			fontFamily: buildForgeFontFamilyCssValue(fontFamily),
 		});
 		await writeFile(join(buildDir, "app", "themes", "forge.css"), css, "utf-8");
-	} else if (config.theme?.pack === "atlas") {
+	} else if (pack === "atlas") {
 		await mkdir(join(buildDir, "app", "themes"), { recursive: true });
-		const primaryHue = config.theme.primaryHue ?? 200;
-		const fontFamily = config.theme.fontFamily ?? "source-serif";
+		const primaryHue = config.theme?.primaryHue ?? 200;
+		const fontFamily = config.theme?.fontFamily ?? "source-serif";
 		const css = buildAtlasCss({
 			accentHue: primaryHue,
 			fontFamily: buildAtlasFontFamilyCssValue(fontFamily),
@@ -108,25 +113,122 @@ export async function initNextraProject(
 	return { isNew };
 }
 
+// ─── writeScopedNextraLayoutComponent ────────────────────────────────────────
+
+/**
+ * Emits `<buildDir>/components/ScopedNextraLayout.tsx` — the runtime client
+ * wrapper around Nextra's `<Layout>` that filters the pageMap by URL so the
+ * sidebar scopes cleanly to either docs or the active OpenAPI spec.
+ *
+ * Without this wrapper, Nextra's `normalizePages` collapses sidebar items
+ * from every top-level page-tab into a single merged `docsDirectories` list.
+ * That works fine when every root entry is a folder-bound page-tab, but our
+ * generator mixes top-level docs items (string entries) with `api-{spec}`
+ * page-tabs. The result is a sidebar that bleeds docs items onto API pages
+ * and vice versa.
+ *
+ * `display: 'hidden'` doesn't fix this either: Nextra short-circuits sidebar
+ * scoping for the active hidden tab. So we filter on the client by matching
+ * `usePathname()` against `/api-{slug}/…`.
+ *
+ * `SCOPE_PAGE_MAP_RUNTIME_SOURCE` (in `ScopePageMap.ts`) bundles the pure
+ * filter function + helpers into one ready-to-inline string. The same
+ * helpers are unit-tested in `ScopePageMap.test.ts` so behaviour changes
+ * propagate to both the tests and the emitted client.
+ */
+export async function writeScopedNextraLayoutComponent(buildDir: string): Promise<void> {
+	await mkdir(join(buildDir, "components"), { recursive: true });
+	// `// @ts-nocheck` disables type-checking for the whole file because the
+	// embedded helpers (above the React component) are pasted from a plain JS
+	// string (`SCOPE_PAGE_MAP_RUNTIME_SOURCE` in `ScopePageMap.ts`) that carries
+	// no TypeScript annotations. In a strict-mode customer Next.js build that
+	// produces noImplicitAny errors on every helper. The React component below
+	// is small and well-typed in its source-of-truth file (`ScopePageMap.ts` +
+	// the TSX template here), so the loss in IDE checking on the emitted file
+	// is acceptable.
+	// Helpers must appear BEFORE the React component, not after. Next.js's
+	// "use client" / RSC compiler is unreliable about preserving hoisted
+	// function declarations placed after the default export — they get
+	// tree-shaken from the client bundle and the component throws
+	// "scopePageMap is not defined" at render time.
+	const content = `// @ts-nocheck
+"use client";
+
+import { Layout } from "nextra-theme-docs";
+import { useEffect, useMemo, type ComponentProps, type ReactNode } from "react";
+import { usePathname } from "next/navigation";
+
+// Pure pageMap-filtering logic — pasted verbatim from
+// SCOPE_PAGE_MAP_RUNTIME_SOURCE in ScopePageMap.ts (a hand-maintained string
+// literal, not Function.prototype.toString()ed, so Vite's identifier mangling
+// in the CLI build can't break the customer's runtime). Behaviour parity with
+// the typed function is asserted in ScopePageMap.test.ts.
+${SCOPE_PAGE_MAP_RUNTIME_SOURCE}
+
+type LayoutProps = ComponentProps<typeof Layout>;
+type PageMap = LayoutProps["pageMap"];
+
+interface Props extends Omit<LayoutProps, "pageMap" | "children"> {
+  pageMap: PageMap;
+  children: ReactNode;
+}
+
+export default function ScopedNextraLayout({ pageMap, children, ...layoutProps }: Props) {
+  const pathname = usePathname() ?? "/";
+
+  const { scopedPageMap, isMultiSpec } = useMemo(
+    () => scopePageMap(pageMap as never, pathname),
+    [pageMap, pathname],
+  );
+
+  useEffect(() => {
+    document.documentElement.dataset.jolliMultiSpec = isMultiSpec ? "true" : "false";
+  }, [isMultiSpec]);
+
+  return (
+    <Layout pageMap={scopedPageMap as PageMap} {...layoutProps}>
+      {children}
+    </Layout>
+  );
+}
+`;
+	await writeFile(join(buildDir, "components", "ScopedNextraLayout.tsx"), content, "utf-8");
+}
+
+// ─── writeLayoutTsx (internal) ───────────────────────────────────────────────
+
+/**
+ * Writes `app/layout.tsx` from a `NextraProjectConfig`. Internal — every
+ * navbar / sidebar augmentation now flows through `MetaGenerator`'s root
+ * `_meta.js` injection, so the layout is written once during
+ * `initNextraProject` and never re-written per-render.
+ */
+async function writeLayoutTsx(buildDir: string, config: NextraProjectConfig): Promise<void> {
+	await mkdir(join(buildDir, "app"), { recursive: true });
+	await writeFile(join(buildDir, "app", "layout.tsx"), generateLayout(config), "utf-8");
+}
+
 // ─── generatePackageJson ──────────────────────────────────────────────────────
 
 /**
- * Returns the contents of the `package.json` that should be written into the
- * hidden build directory.
+ * Runtime dependencies for a Nextra v4 docs site. Shared with EngineManager.
  *
- * Includes all dependencies required by a Nextra v4 docs site:
- *   next, nextra, nextra-theme-docs, react, react-dom, and pagefind.
+ * Nextra ^4.6.1: 4.2.x had a Zod schema in `nextra-theme-docs/dist/layout.js`
+ * that rejected JSX element props that crossed our `<ScopedNextraLayout>`
+ * client-component boundary — `Validation error: Must be a valid React node
+ * at "footer"` — even though the elements *did* pass `isValidElement` when
+ * checked directly. 4.6.x relaxed the schema; the floor pin is here so
+ * fresh installs pick up a passing version.
  *
  * The previous `swagger-ui-react` dependency is gone — the new OpenAPI
- * pipeline (Phase 4 of feature/openapi-rich-renderer) renders per-endpoint
- * MDX pages with a custom component tree, so the user's site no longer
- * pulls a Swagger UI bundle (~600 KB shaved off the runtime).
+ * pipeline renders per-endpoint MDX pages with a custom component tree,
+ * so the user's site no longer pulls a Swagger UI bundle (~600 KB shaved
+ * off the runtime).
  */
-/** Runtime dependencies for a Nextra v4 docs site. Shared with EngineManager. */
 export const NEXTRA_DEPENDENCIES: Record<string, string> = {
 	next: "^15.0.0",
-	nextra: "4.2.17",
-	"nextra-theme-docs": "4.2.17",
+	nextra: "^4.6.1",
+	"nextra-theme-docs": "^4.6.1",
 	react: "^19.0.0",
 	"react-dom": "^19.0.0",
 	pagefind: "^1.0.0",
@@ -138,6 +240,37 @@ export const NEXTRA_DEV_DEPENDENCIES: Record<string, string> = {
 	typescript: "^5.0.0",
 };
 
+/**
+ * npm `overrides` constraints applied to every generated `package.json`.
+ * Shared with EngineManager so the shared engine and per-site dirs stay
+ * aligned on the same transitive dep graph.
+ *
+ * `zod ~4.3.0` — Zod 4.4 changed `z.custom()` strict-object semantics:
+ * `LayoutPropsSchema` in `nextra-theme-docs/dist/schemas.js` declares
+ * `children: reactNode` as required, while the `Layout` component
+ * destructures `children` out of its props before parsing the rest.
+ * Under Zod ≤4.3 the missing field falls through to `reactNode`'s
+ * `data == null` branch and validation passes. Under Zod ≥4.4 the
+ * strict-object check fires before the custom predicate runs and every
+ * Layout render throws `Invalid input: expected nonoptional, received
+ * undefined → at children`. The CLI emits a fresh `package.json` with no
+ * lockfile, so a clean install resolves whichever Zod the registry's
+ * caret-range happens to point at — pin it transitively here. Remove
+ * this override when Nextra ships a release that either (a) marks
+ * `children` optional in the schema or (b) doesn't destructure it before
+ * parsing.
+ */
+export const NEXTRA_OVERRIDES: Record<string, string> = {
+	zod: "~4.3.0",
+};
+
+/**
+ * Returns the contents of the `package.json` that should be written into the
+ * hidden build directory. Pulls in all runtime + dev dependencies required by
+ * a Nextra v4 docs site (see `NEXTRA_DEPENDENCIES` / `NEXTRA_DEV_DEPENDENCIES`)
+ * plus `NEXTRA_OVERRIDES` to constrain transitive deps that have known
+ * incompatibilities with the Nextra version we ship.
+ */
 export function generatePackageJson(): string {
 	const pkg = {
 		name: "jolli-site",
@@ -150,6 +283,7 @@ export function generatePackageJson(): string {
 		},
 		dependencies: { ...NEXTRA_DEPENDENCIES },
 		devDependencies: { ...NEXTRA_DEV_DEPENDENCIES },
+		overrides: { ...NEXTRA_OVERRIDES },
 	};
 
 	return JSON.stringify(pkg, null, 2);
@@ -163,6 +297,17 @@ export function generatePackageJson(): string {
  *
  * Nextra v4 no longer accepts `theme` or `themeConfig` options — those are
  * configured via `app/layout.tsx` and `mdx-components.tsx` instead.
+ *
+ * `infrastructureLogging.level = 'error'` silences webpack's pack-file cache
+ * snapshot warning (`Caching failed for pack: Error: Can't resolve 'nextra'
+ * in <build-dir>`). This is a long-standing Next.js + ESM-config quirk
+ * (vercel/next.js#27650, #35872, #47394, #57128) — webpack can't fully
+ * snapshot dependencies that flow through `next.config.mjs`'s top-level
+ * `import nextra from 'nextra'` because the config is loaded by Node
+ * directly rather than processed through webpack. The warning is non-fatal
+ * (the page renders, the cache just doesn't persist), but for the OSS dev
+ * experience we'd rather not show six lines of red text on every
+ * `jolli dev` startup. Real webpack errors still surface.
  */
 export function generateNextConfig(staticExport?: boolean): string {
 	const exportLines = staticExport ? `\n  output: 'export',\n  images: { unoptimized: true },` : "";
@@ -174,69 +319,24 @@ const withNextra = nextra({
 })
 
 export default withNextra({${exportLines}
+  reactStrictMode: true,
   webpack(config) {
-    config.resolve.preferRelative = true
+    // See JSDoc above for why this is here.
+    config.infrastructureLogging = { ...(config.infrastructureLogging ?? {}), level: 'error' }
     return config
-  }
+  },
 })
 `;
 }
 
 // ─── generateLayout helpers ──────────────────────────────────────────────────
 
-/** Social platforms supported in the footer, in display order. */
-const SOCIAL_PLATFORMS = ["github", "twitter", "discord", "linkedin", "youtube"] as const;
-
 /**
- * Allow http(s), mailto, tel, fragments, query strings, and absolute or
- * relative paths. Anything else (e.g. `javascript:`, `data:`, `vbscript:`)
- * is replaced with `"#"` so a malicious site.json can't inject a script URL.
+ * Builds the inner JSX of `<Footer>` for the default theme, or `""` when
+ * there's nothing to render. Uses inline styles because the default theme
+ * has no pack stylesheet to host class-based selectors. Forge / Atlas
+ * use semantic class names emitted by `themes/Footer.ts`.
  */
-function sanitizeUrl(url: string): string {
-	const trimmed = url.trim();
-	if (trimmed === "" || /^(?:https?:|mailto:|tel:|[#?/]|\.\.?\/)/i.test(trimmed)) {
-		return trimmed;
-	}
-	return "#";
-}
-
-/**
- * Resolves the navbar's logical item list. `header.items` wins when set;
- * otherwise the legacy flat `nav` is coerced into dropdown-less items so
- * pre-`header` site.json files keep rendering unchanged.
- */
-function resolveHeaderItems(config: NextraProjectConfig): HeaderItem[] {
-	if (config.header?.items && config.header.items.length > 0) {
-		return config.header.items;
-	}
-	return config.nav.map((n) => ({ label: n.label, url: n.href }));
-}
-
-/** Renders a single header item — either an `<a>` or a `<details>` dropdown. */
-function renderNavbarChild(item: HeaderItem): string {
-	const jsLabel = JSON.stringify(item.label);
-	if (item.items && item.items.length > 0) {
-		const subLinks = item.items
-			.map((sub) => {
-				const jsSubLabel = JSON.stringify(sub.label);
-				const jsSubHref = JSON.stringify(sanitizeUrl(sub.url));
-				return `              <a href={${jsSubHref}} style={{ display: 'block', padding: '0.25rem 0.75rem', whiteSpace: 'nowrap' }}>{${jsSubLabel}}</a>`;
-			})
-			.join("\n");
-		return [
-			`          <details style={{ marginLeft: '1rem', display: 'inline-block', position: 'relative' }}>`,
-			`            <summary style={{ cursor: 'pointer', listStyle: 'none' }}>{${jsLabel}}</summary>`,
-			`            <div style={{ position: 'absolute', top: '100%', left: 0, marginTop: '0.25rem', background: 'var(--nextra-bg, #fff)', border: '1px solid var(--nextra-border, #e5e7eb)', borderRadius: 4, padding: '0.25rem 0', minWidth: 160, zIndex: 10 }}>`,
-			subLinks,
-			`            </div>`,
-			`          </details>`,
-		].join("\n");
-	}
-	const jsHref = JSON.stringify(sanitizeUrl(item.url ?? "#"));
-	return `          <a href={${jsHref}} style={{ marginLeft: '1rem' }}>{${jsLabel}}</a>`;
-}
-
-/** Builds the inner JSX of `<Footer>`, or `""` when there's nothing to render. */
 function buildFooterBody(footer: FooterConfig | undefined): string {
 	if (!footer) return "";
 
@@ -307,30 +407,38 @@ function buildFooterBody(footer: FooterConfig | undefined): string {
 /**
  * Returns the contents of `app/layout.tsx`. Dispatches to a pack-specific
  * generator based on `config.theme?.pack`:
- *   - `default` (or unset) → vanilla `nextra-theme-docs` with header/footer
- *   - `forge` → Forge pack (clean dev docs)
+ *   - unset (or `forge`) → Forge pack (clean dev docs)
  *   - `atlas` → Atlas pack (editorial)
+ *   - `default` → vanilla `nextra-theme-docs` (back-compat opt-in for sites
+ *     that explicitly want the pre-pack visual)
  */
 export function generateLayout(config: NextraProjectConfig): string {
-	const pack: ThemePack = config.theme?.pack ?? "default";
+	const pack: ThemePack = config.theme?.pack ?? "forge";
 	switch (pack) {
-		case "forge":
-			return generateForgeLayout(config);
 		case "atlas":
 			return generateAtlasLayout(config);
-		default:
+		case "default":
 			return generateDefaultLayout(config);
+		default:
+			return generateForgeLayout(config);
 	}
 }
 
 // ─── generateDefaultLayout ───────────────────────────────────────────────────
 
 /**
- * Vanilla `nextra-theme-docs` layout with header dropdown and footer support.
- * Maps `title`, `description`, `nav` / `header`, and `footer` from `site.json`
- * into the Nextra Layout, Navbar, and Footer components. `nav` is the legacy
- * flat shorthand; `header.items` (which supports per-item dropdowns) wins
- * when set.
+ * Vanilla `nextra-theme-docs` layout with footer support. Page tabs come
+ * from the root `_meta.js` (Nextra renders them natively); the navbar
+ * itself only carries the logo. Sidebar scoping is handled by
+ * `<ScopedNextraLayout>` based on the URL — same architecture as Forge /
+ * Atlas, just without a pack stylesheet.
+ *
+ * Logo composition mirrors Forge / Atlas: `theme.logoText` overrides the text,
+ * `theme.logoDisplay` controls whether image / text / both render. When
+ * `theme.logoUrlDark` is set alongside `theme.logoUrl`, a small inline `<style>`
+ * block toggles the two images via the `.dark` root class — same trick the
+ * pack stylesheets use. Without a pack, the default layout has no per-pack
+ * stylesheet to host the rule, so it's inlined here.
  */
 export function generateDefaultLayout(config: NextraProjectConfig): string {
 	const { title, description } = config;
@@ -338,18 +446,39 @@ export function generateDefaultLayout(config: NextraProjectConfig): string {
 	const jsTitle = JSON.stringify(title);
 	const jsDescription = JSON.stringify(description);
 
-	const headerItems = resolveHeaderItems(config);
-	const navLinks = headerItems.map(renderNavbarChild).join("\n");
-	const navbarChildren = headerItems.length > 0 ? `\n${navLinks}\n        ` : "";
-
 	const footerBody = buildFooterBody(config.footer);
 	const footerJsx = footerBody === "" ? `<Footer />` : `<Footer>\n${footerBody}\n      </Footer>`;
 
-	return `import { Footer, Layout, Navbar } from 'nextra-theme-docs'
+	const logoMarkup = buildDefaultLogoMarkup(config);
+	// Inline `<style>` block toggles the two logo `<img>`s by `.dark` root class.
+	// The default theme has no pack stylesheet to host this rule, so it ships in
+	// the layout itself. Forge / Atlas put the equivalent rule in their pack CSS.
+	const logoDarkSwapStyle =
+		config.theme?.logoUrl && config.theme.logoUrlDark
+			? `<style>{\`.jolli-default-logo-light{display:inline-block}.jolli-default-logo-dark{display:none}.dark .jolli-default-logo-light{display:none}.dark .jolli-default-logo-dark{display:inline-block}\`}</style>`
+			: "";
+
+	// `nextThemes.defaultTheme` controls the initial colour scheme `next-themes`
+	// applies on first load (subsequent loads honour the user's stored choice).
+	// Without this prop the default layout silently fell back to whatever
+	// `next-themes` defaulted to, ignoring `theme.defaultTheme` from the
+	// customer's site.json — Forge / Atlas already pass it; defaulting to
+	// `"system"` here matches Nextra's documented behaviour.
+	const jsDefaultTheme = JSON.stringify(config.theme?.defaultTheme ?? "system");
+
+	// Favicon. Top-level `favicon` wins for back-compat (matches Forge/Atlas
+	// precedence); `theme.favicon` is the canonical placement going forward.
+	// The asset itself is mirrored into `public/` by ContentMirror, so a
+	// browser-absolute path like `/favicon.svg` resolves naturally.
+	const faviconHref = config.favicon ?? config.theme?.favicon;
+	const faviconLink = faviconHref ? `<link rel="icon" href={${JSON.stringify(sanitizeUrl(faviconHref))}} />` : "";
+
+	return `import { Footer, Navbar } from 'nextra-theme-docs'
 import { Head } from 'nextra/components'
 import { getPageMap } from 'nextra/page-map'
 import 'nextra-theme-docs/style.css'
 import '../styles/api.css'
+import ScopedNextraLayout from '../components/ScopedNextraLayout'
 
 export const metadata = {
   title: ${jsTitle},
@@ -359,17 +488,21 @@ export const metadata = {
 export default async function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en" dir="ltr" suppressHydrationWarning>
-      <Head />
+      <Head>
+        ${faviconLink}
+        ${logoDarkSwapStyle}
+      </Head>
       <body>
-        <Layout
+        <ScopedNextraLayout
           navbar={
-            <Navbar logo={<b>{${jsTitle}}</b>}>${navbarChildren}</Navbar>
+            <Navbar logo={<span style={{ display: 'inline-flex', alignItems: 'center', gap: '0.5rem' }}>${logoMarkup}</span>} />
           }
           pageMap={await getPageMap()}
           footer={${footerJsx}}
+          nextThemes={{ defaultTheme: ${jsDefaultTheme} }}
         >
           {children}
-        </Layout>
+        </ScopedNextraLayout>
       </body>
     </html>
   )
@@ -377,18 +510,71 @@ export default async function RootLayout({ children }: { children: React.ReactNo
 `;
 }
 
+// ─── Default-layout logo helpers ─────────────────────────────────────────────
+
+/**
+ * Resolves `LogoDisplay` for the default layout. Same auto-default rules as
+ * Forge / Atlas: `"both"` when `logoUrl` is set, `"text"` otherwise. Explicit
+ * `theme.logoDisplay` wins. `"image"` with no `logoUrl` falls back to `"text"`.
+ */
+function resolveDefaultLogoDisplay(theme: ThemeConfig | undefined): LogoDisplay {
+	const display = theme?.logoDisplay;
+	const hasImage = Boolean(theme?.logoUrl);
+	if (display === "image" && !hasImage) return "text";
+	if (display) return display;
+	return hasImage ? "both" : "text";
+}
+
+/**
+ * Builds the inline JSX for the default-layout navbar logo. Returns a string
+ * suitable for splicing inside a JSX expression — `<img>` tags use bracketed
+ * attributes (`src={...}`), and the text label is wrapped in `<b>` to match
+ * the previous default styling.
+ */
+function buildDefaultLogoMarkup(config: NextraProjectConfig): string {
+	const display = resolveDefaultLogoDisplay(config.theme);
+	const logoText = config.theme?.logoText ?? config.title;
+	const jsLogoText = JSON.stringify(logoText);
+	const textMarkup = `<b>{${jsLogoText}}</b>`;
+
+	const logoUrl = config.theme?.logoUrl;
+	const logoUrlDark = config.theme?.logoUrlDark;
+	const jsAlt = JSON.stringify(logoText);
+
+	let imageMarkup = "";
+	if (logoUrl) {
+		const jsLightSrc = JSON.stringify(sanitizeUrl(logoUrl));
+		if (logoUrlDark) {
+			const jsDarkSrc = JSON.stringify(sanitizeUrl(logoUrlDark));
+			imageMarkup =
+				`<img src={${jsLightSrc}} alt={${jsAlt}} className="jolli-default-logo-light" style={{ height: '1.5rem' }} />` +
+				`<img src={${jsDarkSrc}} alt={${jsAlt}} className="jolli-default-logo-dark" style={{ height: '1.5rem' }} />`;
+		} else {
+			imageMarkup = `<img src={${jsLightSrc}} alt={${jsAlt}} style={{ height: '1.5rem' }} />`;
+		}
+	}
+
+	switch (display) {
+		case "image":
+			return imageMarkup;
+		case "text":
+			return textMarkup;
+		default:
+			return `${imageMarkup}${textMarkup}`;
+	}
+}
+
 // ─── generateForgeLayout ─────────────────────────────────────────────────────
 
 /**
  * Forge pack layout — clean developer-docs visual style. The pack-specific
  * stylesheet is written to `app/themes/forge.css` by `initNextraProject`.
- * See `themes/forge/Layout.ts` for the template and the SaaS-port notes.
+ * See `themes/forge/Layout.ts` for the template.
  */
 export function generateForgeLayout(config: NextraProjectConfig): string {
 	const input = resolveForgeLayoutInput({
 		title: config.title,
 		description: config.description,
-		nav: config.nav,
 		header: config.header,
 		footer: config.footer,
 		theme: config.theme,
@@ -402,13 +588,12 @@ export function generateForgeLayout(config: NextraProjectConfig): string {
 /**
  * Atlas pack layout — editorial handbook visual style. The pack-specific
  * stylesheet is written to `app/themes/atlas.css` by `initNextraProject`.
- * See `themes/atlas/Layout.ts` for the template and the SaaS-port notes.
+ * See `themes/atlas/Layout.ts` for the template.
  */
 export function generateAtlasLayout(config: NextraProjectConfig): string {
 	const input = resolveAtlasLayoutInput({
 		title: config.title,
 		description: config.description,
-		nav: config.nav,
 		header: config.header,
 		footer: config.footer,
 		theme: config.theme,
@@ -462,6 +647,14 @@ export function useMDXComponents(components: Record<string, React.ComponentType>
  * its table of contents and metadata.
  */
 export function generateCatchAllPage(): string {
+	// Coerce `params.mdxPath` to `[]` before passing to `importPage`. The Next.js
+	// `[[...mdxPath]]` optional catch-all leaves `mdxPath` undefined for the root
+	// route ("/"), and webpack's dev-mode dynamic-import analyser then logs
+	// `Error: Cannot find module './undefined'` once per importPage call site
+	// while still resolving the page correctly at runtime. The noise is
+	// cosmetic but lands on every `jolli dev` startup — bad first-impression
+	// for the OSS dev experience. The empty-array form makes Nextra's
+	// `importPage` resolve the root explicitly and webpack drops the warning.
 	return `import { generateStaticParamsFor, importPage } from 'nextra/pages'
 import { useMDXComponents } from '../../mdx-components'
 
@@ -469,7 +662,7 @@ export const generateStaticParams = generateStaticParamsFor('mdxPath')
 
 export async function generateMetadata(props: { params: Promise<{ mdxPath?: string[] }> }) {
   const params = await props.params
-  const { metadata } = await importPage(params.mdxPath)
+  const { metadata } = await importPage(params.mdxPath ?? [])
   return metadata
 }
 
@@ -477,7 +670,7 @@ const Wrapper = useMDXComponents({}).wrapper
 
 export default async function Page(props: { params: Promise<{ mdxPath?: string[] }> }) {
   const params = await props.params
-  const result = await importPage(params.mdxPath)
+  const result = await importPage(params.mdxPath ?? [])
   const { default: MDXContent, toc, metadata } = result
   return (
     <Wrapper toc={toc} metadata={metadata}>

--- a/cli/src/site/Sanitize.test.ts
+++ b/cli/src/site/Sanitize.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Tests for `Sanitize.ts` — the consolidated URL allow-list and HTML escape
+ * helpers shared across every layout, footer renderer, and `_meta.js` writer.
+ *
+ * `sanitizeUrl` and `escapeHtml` are also exercised indirectly through
+ * Footer.test.ts and MetaGenerator.test.ts, but pinning the helpers
+ * directly here means a future tightening (or accidental loosening) of the
+ * allow-list shows up as a localised test failure rather than a cascade of
+ * far-away assertions.
+ */
+
+import { describe, expect, it } from "vitest";
+import { escapeHtml, sanitizeUrl } from "./Sanitize.js";
+
+// ─── sanitizeUrl: safe schemes pass through ──────────────────────────────────
+
+describe("sanitizeUrl — safe schemes", () => {
+	it("preserves http URLs verbatim", () => {
+		expect(sanitizeUrl("http://example.com/path")).toBe("http://example.com/path");
+	});
+
+	it("preserves https URLs verbatim", () => {
+		expect(sanitizeUrl("https://example.com/path?q=1#frag")).toBe("https://example.com/path?q=1#frag");
+	});
+
+	it("preserves mailto: URLs verbatim", () => {
+		expect(sanitizeUrl("mailto:hi@example.com")).toBe("mailto:hi@example.com");
+	});
+
+	it("preserves tel: URLs verbatim", () => {
+		expect(sanitizeUrl("tel:+15551234567")).toBe("tel:+15551234567");
+	});
+
+	it("preserves fragment-only URLs verbatim", () => {
+		expect(sanitizeUrl("#section")).toBe("#section");
+	});
+
+	it("preserves query-only URLs verbatim", () => {
+		expect(sanitizeUrl("?q=1&x=y")).toBe("?q=1&x=y");
+	});
+
+	it("preserves root-relative paths verbatim", () => {
+		expect(sanitizeUrl("/assets/logo.svg")).toBe("/assets/logo.svg");
+	});
+
+	it("preserves dot-relative paths verbatim (./)", () => {
+		expect(sanitizeUrl("./sibling.md")).toBe("./sibling.md");
+	});
+
+	it("preserves dot-relative paths verbatim (../)", () => {
+		expect(sanitizeUrl("../parent/page.md")).toBe("../parent/page.md");
+	});
+
+	it("treats schemes case-insensitively", () => {
+		expect(sanitizeUrl("HTTPS://example.com")).toBe("HTTPS://example.com");
+		expect(sanitizeUrl("MAILTO:hi@x.com")).toBe("MAILTO:hi@x.com");
+	});
+});
+
+// ─── sanitizeUrl: dangerous schemes clamped ──────────────────────────────────
+
+describe("sanitizeUrl — dangerous schemes", () => {
+	it("clamps javascript: URLs to '#'", () => {
+		expect(sanitizeUrl("javascript:alert(1)")).toBe("#");
+	});
+
+	it("clamps data: URLs to '#'", () => {
+		expect(sanitizeUrl("data:text/html,<script>alert(1)</script>")).toBe("#");
+	});
+
+	it("clamps vbscript: URLs to '#'", () => {
+		expect(sanitizeUrl("vbscript:msgbox(1)")).toBe("#");
+	});
+
+	it("clamps file: URLs to '#'", () => {
+		expect(sanitizeUrl("file:///etc/passwd")).toBe("#");
+	});
+
+	it("clamps unrecognised schemes to '#' (e.g. typoed 'htps://')", () => {
+		expect(sanitizeUrl("htps://example.com")).toBe("#");
+	});
+
+	it("blocks dangerous schemes prefixed with whitespace (trim before scheme check)", () => {
+		expect(sanitizeUrl("  javascript:alert(1)")).toBe("#");
+		expect(sanitizeUrl("\tjavascript:alert(1)")).toBe("#");
+	});
+});
+
+// ─── sanitizeUrl: scheme-relative rejection ──────────────────────────────────
+
+describe("sanitizeUrl — scheme-relative URLs", () => {
+	// Browsers parse `//evil.com/x` as same-protocol cross-origin. A malicious
+	// site.json with `header.items: [{ url: "//evil.com" }]` could otherwise
+	// redirect users; `<img src="//evil.com">` could leak referrer context.
+	// Single-leading-slash (root-relative) is allowed; double-slash is not.
+
+	it("clamps a bare scheme-relative URL to '#'", () => {
+		expect(sanitizeUrl("//evil.com/x")).toBe("#");
+	});
+
+	it("clamps a scheme-relative URL with a path/query to '#'", () => {
+		expect(sanitizeUrl("//evil.com/track?u=1#x")).toBe("#");
+	});
+
+	it("clamps a triple-slash variant (still scheme-relative-shaped) to '#'", () => {
+		expect(sanitizeUrl("///evil.com")).toBe("#");
+	});
+
+	it("does NOT block legitimate single-slash root-relative paths", () => {
+		// Pin the negative — `/foo/bar` must still pass through; the rejection
+		// only fires on `//`.
+		expect(sanitizeUrl("/foo/bar")).toBe("/foo/bar");
+		expect(sanitizeUrl("/")).toBe("/");
+	});
+});
+
+// ─── sanitizeUrl: empty / whitespace ─────────────────────────────────────────
+
+describe("sanitizeUrl — empty / whitespace inputs", () => {
+	it("returns an empty string unchanged when given an empty string", () => {
+		expect(sanitizeUrl("")).toBe("");
+	});
+
+	it("returns an empty string when given whitespace only (after trim)", () => {
+		expect(sanitizeUrl("   ")).toBe("");
+		expect(sanitizeUrl("\t\n")).toBe("");
+	});
+
+	it("trims leading / trailing whitespace from valid URLs", () => {
+		expect(sanitizeUrl("  https://example.com  ")).toBe("https://example.com");
+	});
+});
+
+// ─── escapeHtml ──────────────────────────────────────────────────────────────
+
+describe("escapeHtml", () => {
+	it("escapes ampersand FIRST so subsequent entities are not double-escaped", () => {
+		// If `&` were escaped after `<`, the entity `&lt;` would become `&amp;lt;`.
+		expect(escapeHtml("a & b")).toBe("a &amp; b");
+		expect(escapeHtml("<a&b>")).toBe("&lt;a&amp;b&gt;");
+	});
+
+	it("escapes angle brackets so `<script>` cannot inject a tag", () => {
+		expect(escapeHtml("<script>")).toBe("&lt;script&gt;");
+	});
+
+	it('escapes double quotes so attribute values cannot break out of `"…"`', () => {
+		expect(escapeHtml('a"b')).toBe("a&quot;b");
+	});
+
+	it("escapes single quotes (defensive — single-quoted attribute boundaries)", () => {
+		expect(escapeHtml("a'b")).toBe("a&#39;b");
+	});
+
+	it("escapes curly braces so spliced text cannot open a JSX expression", () => {
+		// JSX text mode treats `{` as an expression delimiter; numeric character
+		// references render as the literal char in the browser but stay inert
+		// during the customer's MDX/TSX compile.
+		expect(escapeHtml("a {x} b")).toBe("a &#123;x&#125; b");
+	});
+
+	it("returns the input unchanged when no special chars are present", () => {
+		expect(escapeHtml("plain text 123")).toBe("plain text 123");
+	});
+
+	it("handles every special character at once", () => {
+		expect(escapeHtml(`<a href="x" class='y'>{z}&w</a>`)).toBe(
+			"&lt;a href=&quot;x&quot; class=&#39;y&#39;&gt;&#123;z&#125;&amp;w&lt;/a&gt;",
+		);
+	});
+});

--- a/cli/src/site/Sanitize.ts
+++ b/cli/src/site/Sanitize.ts
@@ -1,0 +1,63 @@
+/**
+ * Sanitize.ts — URL and HTML escape helpers for the site-generation pipeline.
+ *
+ * Single source of truth for the allow-list-based URL sanitiser used by every
+ * layout, footer renderer, and `_meta.js` writer. Previously these helpers
+ * were duplicated across `themes/forge/Layout.ts`, `themes/atlas/Layout.ts`,
+ * `themes/Footer.ts`, `NextraProjectWriter.ts`, and `renderer/nextra/Components.ts` —
+ * five copies of the same allow-list. Consolidating here means a future
+ * tightening of the allow-list (e.g. blocking `data:` even where benign) only
+ * has to be made once.
+ *
+ * The `openapi/Escape.ts` module is purpose-built for the per-endpoint MDX
+ * pipeline (YAML, MDX text, JS strings, inline-code, HTML entities for table
+ * cells) and stays separate — different mediums, different escaping rules.
+ */
+
+// ─── sanitizeUrl ─────────────────────────────────────────────────────────────
+
+const SAFE_URL_PATTERN = /^(?:https?:|mailto:|tel:|[#?]|\/(?!\/)|\.\.?\/)/i;
+
+/**
+ * Allow http(s), mailto, tel, fragments, query strings, root-relative
+ * paths (`/foo/bar`), and dot-relative paths (`./`, `../`). Anything else
+ * (`javascript:`, `data:`, `vbscript:`, etc.) is replaced with `"#"` so a
+ * malicious site.json cannot inject a script URL into the generated layout,
+ * footer, or `_meta.js`.
+ *
+ * Scheme-relative URLs (`//evil.com/x`) are explicitly rejected — they look
+ * like an absolute path to the leading-`/` check but the browser parses them
+ * as same-protocol cross-origin, which would let a malicious `site.json`
+ * redirect users (e.g. `header.items: [{ url: "//evil.com" }]`) or exfiltrate
+ * referrer context via `<img src="//evil.com">`. The negative lookahead
+ * `\/(?!\/)` accepts a single leading slash but not a double.
+ *
+ * Trims leading / trailing whitespace before testing the scheme so a value
+ * like `"  javascript:alert(1)"` cannot bypass the check.
+ */
+export function sanitizeUrl(url: string): string {
+	const trimmed = url.trim();
+	if (trimmed === "" || SAFE_URL_PATTERN.test(trimmed)) {
+		return trimmed;
+	}
+	return "#";
+}
+
+// ─── escapeHtml ──────────────────────────────────────────────────────────────
+
+/**
+ * Escape characters with special meaning when spliced into generated JSX
+ * (`app/layout.tsx`, footer body strings) or HTML attributes. Handles
+ * `&`, `<`, `>`, `"`, single quotes, and curly braces (which would
+ * otherwise open a JSX expression).
+ */
+export function escapeHtml(str: string): string {
+	return str
+		.replace(/&/g, "&amp;")
+		.replace(/</g, "&lt;")
+		.replace(/>/g, "&gt;")
+		.replace(/"/g, "&quot;")
+		.replace(/'/g, "&#39;")
+		.replace(/\{/g, "&#123;")
+		.replace(/\}/g, "&#125;");
+}

--- a/cli/src/site/ScopePageMap.test.ts
+++ b/cli/src/site/ScopePageMap.test.ts
@@ -1,0 +1,339 @@
+/**
+ * Tests for `scopePageMap` — the runtime pageMap filter embedded into the
+ * generated `<ScopedNextraLayout>` client component.
+ *
+ * This filter ships verbatim into the customer's `app/layout.tsx`, so any
+ * behaviour change here lands in every customer site on the next CLI build.
+ */
+
+import { describe, expect, it } from "vitest";
+import { SCOPE_PAGE_MAP_RUNTIME_SOURCE, type ScopePageMapItem, scopePageMap } from "./ScopePageMap.js";
+
+/**
+ * Shared fixture builder — produces a pageMap shape that mirrors what
+ * Nextra's `getPageMap()` returns after merge-meta. The first item is the
+ * `data` block (root `_meta.ts`), followed by file/folder items.
+ */
+function buildPageMap(opts: {
+	dataEntries: Record<string, unknown>;
+	folderNames: Array<string>;
+	fileNames?: Array<string>;
+}): Array<ScopePageMapItem> {
+	const items: Array<ScopePageMapItem> = [{ data: opts.dataEntries }];
+	for (const name of opts.folderNames) {
+		items.push({ name, route: `/${name}`, children: [] } as ScopePageMapItem);
+	}
+	for (const name of opts.fileNames ?? []) {
+		items.push({ name, route: name === "index" ? "/" : `/${name}` } as ScopePageMapItem);
+	}
+	return items;
+}
+
+function getData(result: ReturnType<typeof scopePageMap>): Record<string, unknown> {
+	const first = result.scopedPageMap[0];
+	if (first && "data" in first && first.data) {
+		return first.data as Record<string, unknown>;
+	}
+	throw new Error("Expected first item to be the data block");
+}
+
+function getFolderNames(result: ReturnType<typeof scopePageMap>): Array<string> {
+	return result.scopedPageMap
+		.filter((i) => "name" in i && typeof (i as { name: string }).name === "string")
+		.map((i) => (i as { name: string }).name);
+}
+
+describe("scopePageMap — single-spec site", () => {
+	const SINGLE_SPEC_PAGEMAP = buildPageMap({
+		dataEntries: {
+			index: { display: "hidden" },
+			"getting-started": "Getting Started",
+			__documentation: { title: "Documentation", type: "page", href: "/" },
+			"api-petstore": { title: "API Reference", type: "page", href: "/api-petstore" },
+		},
+		folderNames: ["api-petstore"],
+		fileNames: ["index", "getting-started"],
+	});
+
+	it("on a docs route, keeps the api-petstore folder and data entry so the navbar tab renders as a link", () => {
+		const result = scopePageMap(SINGLE_SPEC_PAGEMAP, "/getting-started");
+
+		// Folder for the spec is preserved in docs scope when its data entry
+		// carries an `href` — Nextra renders a navbar tab from a data override
+		// only when there's a matching pageMap item to attach it to. Without
+		// the folder, the "API Reference" tab silently disappears in docs scope.
+		expect(getFolderNames(result)).toContain("api-petstore");
+		expect(getFolderNames(result)).toContain("index");
+		expect(getFolderNames(result)).toContain("getting-started");
+
+		// Data: api-petstore retained as a link entry so the navbar tab is a
+		// link to /api-petstore (not a folder-bound sidebar tab). Documentation
+		// also kept.
+		const data = getData(result);
+		expect(data["api-petstore"]).toEqual({
+			title: "API Reference",
+			type: "page",
+			href: "/api-petstore",
+		});
+		expect(data.__documentation).toBeDefined();
+		expect(data.index).toBeDefined();
+	});
+
+	it("on the active spec route, keeps the api-petstore folder and strips href so Nextra folder-binds it", () => {
+		const result = scopePageMap(SINGLE_SPEC_PAGEMAP, "/api-petstore/pets/list");
+
+		// Folders: active spec folder is kept. Non-api top-level items (the docs
+		// files) pass through unchanged — the wrapper only touches the api-* slot.
+		expect(getFolderNames(result)).toContain("api-petstore");
+		expect(getFolderNames(result)).toContain("getting-started");
+
+		// Data: active spec entry has href stripped so Nextra binds the folder
+		// for sidebar scoping. Title is preserved.
+		const data = getData(result);
+		expect(data["api-petstore"]).toEqual({ title: "API Reference", type: "page" });
+		expect(data.__documentation).toBeDefined();
+	});
+
+	it("classifies a single-spec site as not multi-spec (one folder + one data entry = 2 mentions)", () => {
+		const result = scopePageMap(SINGLE_SPEC_PAGEMAP, "/");
+		expect(result.isMultiSpec).toBe(false);
+	});
+});
+
+describe("scopePageMap — multi-spec site", () => {
+	const MULTI_SPEC_PAGEMAP = buildPageMap({
+		dataEntries: {
+			index: { display: "hidden" },
+			"getting-started": "Getting Started",
+			__documentation: { title: "Documentation", type: "page", href: "/" },
+			"api-petstore": { title: "Petstore API", type: "page", display: "hidden" },
+			"api-users": { title: "Users API", type: "page", display: "hidden" },
+			"__api-reference": {
+				title: "API Reference",
+				type: "menu",
+				items: {
+					petstore: { title: "Petstore API", href: "/api-petstore" },
+					users: { title: "Users API", href: "/api-users" },
+				},
+			},
+		},
+		folderNames: ["api-petstore", "api-users"],
+		fileNames: ["index", "getting-started"],
+	});
+
+	it("on a docs route, drops every api-* folder and every hidden api-* data entry, keeping the dropdown", () => {
+		const result = scopePageMap(MULTI_SPEC_PAGEMAP, "/getting-started");
+
+		expect(getFolderNames(result)).not.toContain("api-petstore");
+		expect(getFolderNames(result)).not.toContain("api-users");
+
+		const data = getData(result);
+		// Hidden per-spec entries (no href) are dropped to keep the data block clean.
+		expect(data["api-petstore"]).toBeUndefined();
+		expect(data["api-users"]).toBeUndefined();
+		// Dropdown menu (key is __api-reference, not api-*) survives.
+		expect(data["__api-reference"]).toBeDefined();
+		expect(data.__documentation).toBeDefined();
+	});
+
+	it("on the active spec route, keeps the active spec folder, drops other api-* folders, and unhides its data entry", () => {
+		const result = scopePageMap(MULTI_SPEC_PAGEMAP, "/api-petstore/pets/list");
+
+		// Folders: active spec kept; other api-* folder dropped so its
+		// children don't pollute the active sidebar. Non-api top-level items
+		// pass through.
+		expect(getFolderNames(result)).toContain("api-petstore");
+		expect(getFolderNames(result)).not.toContain("api-users");
+
+		const data = getData(result);
+		// Active spec: display: hidden stripped so Nextra binds it as a
+		// visible folder-bound page-tab and scopes the sidebar to its
+		// children. CSS hides the now-visible navbar tab.
+		expect(data["api-petstore"]).toEqual({ title: "Petstore API", type: "page" });
+		// Other spec: dropped from data so its data entry doesn't fail
+		// Nextra's "metaItem references missing folder" validation.
+		expect(data["api-users"]).toBeUndefined();
+		// Dropdown + Documentation: preserved so the user can navigate elsewhere.
+		expect(data["__api-reference"]).toBeDefined();
+		expect(data.__documentation).toBeDefined();
+	});
+
+	it("classifies multi-spec sites as multi-spec (>2 api-* mentions across folders + data)", () => {
+		const result = scopePageMap(MULTI_SPEC_PAGEMAP, "/");
+		expect(result.isMultiSpec).toBe(true);
+	});
+});
+
+describe("scopePageMap — edge cases", () => {
+	it("returns an empty pageMap unchanged", () => {
+		const result = scopePageMap([], "/");
+		expect(result.scopedPageMap).toEqual([]);
+		expect(result.isMultiSpec).toBe(false);
+	});
+
+	it("treats the bare /api-foo route as API scope (no trailing slash, no children path)", () => {
+		const pageMap = buildPageMap({
+			dataEntries: {
+				"api-foo": { title: "API Reference", type: "page", href: "/api-foo" },
+			},
+			folderNames: ["api-foo"],
+		});
+		const result = scopePageMap(pageMap, "/api-foo");
+
+		expect(getFolderNames(result)).toContain("api-foo");
+		expect(getData(result)["api-foo"]).toEqual({ title: "API Reference", type: "page" });
+	});
+
+	it("does not treat /api as API scope — the regex requires a slug after the api- prefix", () => {
+		// The data entry has no href, so the link-form preservation path doesn't
+		// fire and the folder is dropped in docs scope.
+		const pageMap = buildPageMap({
+			dataEntries: {
+				"api-foo": { title: "Hidden", type: "page", display: "hidden" },
+			},
+			folderNames: ["api-foo"],
+		});
+		// `/api` doesn't match `/api-{slug}`; should fall through to docs scope.
+		const result = scopePageMap(pageMap, "/api");
+		expect(getFolderNames(result)).not.toContain("api-foo");
+	});
+
+	it("keeps a link-form api folder in docs scope so the navbar tab renders", () => {
+		// Counterpart to the test above — when the data entry has an href, the
+		// folder must be preserved even in docs scope so Nextra has an item to
+		// attach the navbar tab to.
+		const pageMap = buildPageMap({
+			dataEntries: {
+				"api-foo": { title: "API Reference", type: "page", href: "/api-foo" },
+			},
+			folderNames: ["api-foo"],
+		});
+		const result = scopePageMap(pageMap, "/getting-started");
+		expect(getFolderNames(result)).toContain("api-foo");
+	});
+
+	it("preserves non-api folders verbatim regardless of scope", () => {
+		const pageMap = buildPageMap({
+			dataEntries: { docs: "Docs" },
+			folderNames: ["docs", "api-foo"],
+		});
+		const apiResult = scopePageMap(pageMap, "/api-foo");
+		expect(getFolderNames(apiResult)).toContain("api-foo");
+		// `docs` folder is non-api so it stays.
+		expect(getFolderNames(apiResult)).toContain("docs");
+	});
+
+	it("keeps non-string-key items (any unrecognized shape) untouched", () => {
+		const opaqueItem = { someOtherShape: true } as ScopePageMapItem;
+		const pageMap: Array<ScopePageMapItem> = [{ data: { __documentation: { href: "/" } } }, opaqueItem];
+		const result = scopePageMap(pageMap, "/");
+		expect(result.scopedPageMap).toContain(opaqueItem);
+	});
+
+	it("treats string-typed data entries (e.g. {key: 'Label'}) as opaque — no api-* substring matching on the value", () => {
+		const pageMap = buildPageMap({
+			dataEntries: {
+				"some-page": "api-something-in-label",
+				__documentation: { title: "Documentation", type: "page", href: "/" },
+			},
+			folderNames: ["some-page"],
+		});
+		const result = scopePageMap(pageMap, "/getting-started");
+		expect(getData(result)["some-page"]).toBe("api-something-in-label");
+	});
+});
+
+// ─── Parity: SCOPE_PAGE_MAP_RUNTIME_SOURCE matches the typed function ───────
+
+/**
+ * The runtime source string is what actually ships into the customer's
+ * Next.js bundle (via `<ScopedNextraLayout>`). The typed `scopePageMap`
+ * function above is what the CLI's tests + tooling consume. Both must
+ * produce identical output for every input — drift means the customer's
+ * site behaves differently from what our tests verify.
+ *
+ * We materialise the string via `new Function` (no module scope, no
+ * imports — exactly the constraints of the customer's pasted file), then
+ * run both implementations through a representative fixture set and assert
+ * deep equality.
+ */
+describe("scopePageMap runtime source parity", () => {
+	const runtimeScopePageMap = new Function(
+		`${SCOPE_PAGE_MAP_RUNTIME_SOURCE}\nreturn scopePageMap;`,
+	)() as typeof scopePageMap;
+
+	const FIXTURES: Array<{ name: string; pageMap: Array<ScopePageMapItem>; pathname: string }> = [
+		{
+			name: "single-spec, docs route",
+			pageMap: buildPageMap({
+				dataEntries: {
+					index: { display: "hidden" },
+					"getting-started": "Getting Started",
+					__documentation: { title: "Documentation", type: "page", href: "/" },
+					"api-petstore": { title: "API Reference", type: "page", href: "/api-petstore" },
+				},
+				folderNames: ["api-petstore"],
+				fileNames: ["index", "getting-started"],
+			}),
+			pathname: "/getting-started",
+		},
+		{
+			name: "single-spec, active spec route",
+			pageMap: buildPageMap({
+				dataEntries: {
+					"api-petstore": { title: "API Reference", type: "page", href: "/api-petstore" },
+				},
+				folderNames: ["api-petstore"],
+			}),
+			pathname: "/api-petstore/pets/list",
+		},
+		{
+			name: "multi-spec, docs route",
+			pageMap: buildPageMap({
+				dataEntries: {
+					"api-petstore": { title: "Petstore", type: "page", display: "hidden" },
+					"api-users": { title: "Users", type: "page", display: "hidden" },
+					"__api-reference": {
+						title: "API Reference",
+						type: "menu",
+						items: { petstore: { title: "Petstore", href: "/api-petstore" } },
+					},
+				},
+				folderNames: ["api-petstore", "api-users"],
+			}),
+			pathname: "/",
+		},
+		{
+			name: "multi-spec, active spec route",
+			pageMap: buildPageMap({
+				dataEntries: {
+					"api-petstore": { title: "Petstore", type: "page", display: "hidden" },
+					"api-users": { title: "Users", type: "page", display: "hidden" },
+				},
+				folderNames: ["api-petstore", "api-users"],
+			}),
+			pathname: "/api-petstore/foo",
+		},
+		{
+			name: "empty pageMap",
+			pageMap: [],
+			pathname: "/",
+		},
+		{
+			name: "non-api folders only",
+			pageMap: buildPageMap({
+				dataEntries: { docs: "Docs" },
+				folderNames: ["docs"],
+			}),
+			pathname: "/docs",
+		},
+	];
+
+	for (const fixture of FIXTURES) {
+		it(`runtime source matches typed function: ${fixture.name}`, () => {
+			const typed = scopePageMap(fixture.pageMap, fixture.pathname);
+			const runtime = runtimeScopePageMap(fixture.pageMap, fixture.pathname);
+			expect(runtime).toEqual(typed);
+		});
+	}
+});

--- a/cli/src/site/ScopePageMap.ts
+++ b/cli/src/site/ScopePageMap.ts
@@ -1,0 +1,317 @@
+/**
+ * Pure pageMap-filtering logic shared between the CLI generator (which embeds
+ * the function source into the emitted `<ScopedNextraLayout>` client
+ * component) and the unit tests (which test the function directly).
+ *
+ * The actual emitted component is built by
+ * `NextraProjectWriter.writeScopedNextraLayoutComponent`, which inlines the
+ * runtime source string below. Keeping the typed logic here means there is
+ * one source of truth — change behaviour here and both the generated client
+ * and the tests pick it up (with the runtime-string parity test as the
+ * tripwire — see `ScopePageMap.test.ts`).
+ *
+ * IMPORTANT: do NOT import anything in this module that the generated client
+ * cannot resolve (no Node-only APIs, no Nextra runtime imports). The function
+ * gets stringified and pasted into the customer's Next.js app, where its
+ * only ambient dependencies are JS built-ins.
+ */
+
+/** Item shape mirrors Nextra's PageMapItem just enough for filtering. */
+export type ScopeMetaValue = unknown;
+export interface ScopeDataItem {
+	data: Record<string, ScopeMetaValue>;
+}
+export interface ScopeNamedItem {
+	name: string;
+	[k: string]: unknown;
+}
+export type ScopePageMapItem = ScopeDataItem | ScopeNamedItem | Record<string, unknown>;
+
+export interface ScopeResult {
+	scopedPageMap: Array<ScopePageMapItem>;
+	isMultiSpec: boolean;
+}
+
+const API_PREFIX = "api-";
+
+/** Counts api-* mentions across folders and data entries in one pass. */
+function countApiMentions(pageMap: ReadonlyArray<ScopePageMapItem>): number {
+	let total = 0;
+	for (const item of pageMap) {
+		if ("name" in item && typeof item.name === "string" && item.name.startsWith(API_PREFIX)) {
+			total += 1;
+		}
+		if ("data" in item && item.data) {
+			for (const key of Object.keys(item.data)) {
+				if (key.startsWith(API_PREFIX)) {
+					total += 1;
+				}
+			}
+		}
+	}
+	return total;
+}
+
+/**
+ * Strips `href` and `display` from an active spec's data entry so Nextra
+ * folder-binds it instead of treating it as a link or hiding it. Non-object
+ * values (rare — e.g. a string title) pass through unchanged.
+ */
+function unhideActiveSpec(val: unknown): unknown {
+	if (val === null || typeof val !== "object") {
+		return val;
+	}
+	const rest: Record<string, unknown> = {};
+	for (const [k, v] of Object.entries(val)) {
+		if (k === "href" || k === "display") {
+			continue;
+		}
+		rest[k] = v;
+	}
+	return rest;
+}
+
+/** Decides whether to keep an `api-*` data entry in the current scope, and
+ *  what shape to keep it in. Returns `undefined` to drop. */
+function scopedApiDataEntry(
+	key: string,
+	val: unknown,
+	isApiScope: boolean,
+	activeSpecKey: string | undefined,
+): unknown {
+	if (isApiScope) {
+		if (key !== activeSpecKey) {
+			return;
+		}
+		return unhideActiveSpec(val);
+	}
+	// Docs scope: keep link-form entries, drop hidden ones.
+	if (val !== null && typeof val === "object" && "href" in val) {
+		return val;
+	}
+	return;
+}
+
+function scopeDataBlock(
+	data: Record<string, unknown>,
+	isApiScope: boolean,
+	activeSpecKey: string | undefined,
+): Record<string, unknown> {
+	const newData: Record<string, unknown> = {};
+	for (const [key, val] of Object.entries(data)) {
+		if (!key.startsWith(API_PREFIX)) {
+			newData[key] = val;
+			continue;
+		}
+		const scoped = scopedApiDataEntry(key, val, isApiScope, activeSpecKey);
+		if (scoped !== undefined) {
+			newData[key] = scoped;
+		}
+	}
+	return newData;
+}
+
+/**
+ * Collect the set of `api-*` data-entry keys that carry an `href` (single-spec
+ * navbar link form). Nextra renders a navbar tab from a data override only
+ * when there is a corresponding folder in the pageMap to attach it to — so
+ * when we drop the folder, the tab disappears too. We keep folders for these
+ * link-form entries even in docs scope so the navbar tab survives.
+ */
+function collectLinkFormApiKeys(pageMap: ReadonlyArray<ScopePageMapItem>): Set<string> {
+	const out = new Set<string>();
+	for (const item of pageMap) {
+		if (!("data" in item) || !item.data) {
+			continue;
+		}
+		for (const [key, val] of Object.entries(item.data)) {
+			if (!key.startsWith(API_PREFIX)) {
+				continue;
+			}
+			if (val !== null && typeof val === "object" && "href" in val) {
+				out.add(key);
+			}
+		}
+	}
+	return out;
+}
+
+/**
+ * Filters the pageMap to the active scope:
+ *   - In API scope (URL under `/api-{slug}`): keep only that spec's folder
+ *     plus non-api data entries (`__documentation`, `__api-reference`),
+ *     and unhide the active spec's data entry so Nextra binds it for
+ *     sidebar scoping (drops `href` for the single-spec case and
+ *     `display: 'hidden'` for the multi-spec case).
+ *   - In docs scope (anywhere else): keep folders for link-form entries
+ *     (single-spec sites whose data entry has `href`) so Nextra still
+ *     renders the navbar tab; drop everything else. Keep `api-*` data
+ *     entries that carry an `href` (so the navbar tab is a link, not a
+ *     folder-bound page); drop the rest.
+ *
+ * Counts api-* entries before filtering so multi-spec sites can set the
+ * `data-jolli-multi-spec` attribute used by pack CSS to hide the per-spec
+ * navbar tab in API scope (the dropdown takes its place).
+ */
+export function scopePageMap(pageMap: ReadonlyArray<ScopePageMapItem>, pathname: string): ScopeResult {
+	const apiMatch = /^\/(api-[^/]+)/.exec(pathname);
+	const isApiScope = apiMatch !== null;
+	const activeSpecKey = apiMatch?.[1];
+	// Folder + data-entry counts can double-count the same spec (one folder +
+	// one data entry per spec). `isMultiSpec` only drives a CSS toggle, so
+	// erring on the side of "single" when in doubt is fine.
+	const isMultiSpec = countApiMentions(pageMap) > 2;
+
+	const linkFormKeys = collectLinkFormApiKeys(pageMap);
+
+	const scoped: Array<ScopePageMapItem> = [];
+	for (const item of pageMap) {
+		if ("data" in item && item.data) {
+			const newData = scopeDataBlock(item.data as Record<string, unknown>, isApiScope, activeSpecKey);
+			// biome-ignore lint/suspicious/noExplicitAny: Nextra's PageMap union widens unsafely on spread; cast at the boundary.
+			scoped.push({ ...(item as any), data: newData });
+			continue;
+		}
+		if ("name" in item && typeof item.name === "string") {
+			const name = item.name;
+			const isApiFolder = name.startsWith(API_PREFIX);
+			const keepFolder =
+				!isApiFolder ||
+				(isApiScope && name === activeSpecKey) ||
+				// Docs scope: keep the folder when a link-form data entry exists for
+				// it, otherwise Nextra has no underlying item to render the navbar
+				// tab against and the "API Reference" link silently disappears.
+				(!isApiScope && linkFormKeys.has(name));
+			if (keepFolder) {
+				scoped.push(item);
+			}
+			continue;
+		}
+		scoped.push(item);
+	}
+
+	return { scopedPageMap: scoped, isMultiSpec };
+}
+
+/**
+ * Hand-maintained JS source of `scopePageMap` and its helpers, ready to be
+ * inlined verbatim into the generated `<ScopedNextraLayout>` client
+ * component. Kept as a string literal (rather than `Function.prototype
+ * .toString()`-stringified) so the CLI's Vite production build can mangle
+ * identifiers freely without breaking the customer's runtime — minified
+ * names like `Gi` would point at nothing once pasted into the customer's
+ * Next.js app.
+ *
+ * Drift between the typed function above and this string is caught by the
+ * parity test in `ScopePageMap.test.ts`, which evaluates the string and
+ * runs it through the same fixtures the typed function is tested against.
+ * If you change the typed `scopePageMap`, mirror the change here.
+ */
+export const SCOPE_PAGE_MAP_RUNTIME_SOURCE = `const API_PREFIX = ${JSON.stringify(API_PREFIX)};
+
+function countApiMentions(pageMap) {
+  let total = 0;
+  for (const item of pageMap) {
+    if ("name" in item && typeof item.name === "string" && item.name.startsWith(API_PREFIX)) {
+      total += 1;
+    }
+    if ("data" in item && item.data) {
+      for (const key of Object.keys(item.data)) {
+        if (key.startsWith(API_PREFIX)) {
+          total += 1;
+        }
+      }
+    }
+  }
+  return total;
+}
+
+function unhideActiveSpec(val) {
+  if (val === null || typeof val !== "object") {
+    return val;
+  }
+  const rest = {};
+  for (const [k, v] of Object.entries(val)) {
+    if (k === "href" || k === "display") {
+      continue;
+    }
+    rest[k] = v;
+  }
+  return rest;
+}
+
+function scopedApiDataEntry(key, val, isApiScope, activeSpecKey) {
+  if (isApiScope) {
+    if (key !== activeSpecKey) {
+      return;
+    }
+    return unhideActiveSpec(val);
+  }
+  if (val !== null && typeof val === "object" && "href" in val) {
+    return val;
+  }
+  return;
+}
+
+function scopeDataBlock(data, isApiScope, activeSpecKey) {
+  const newData = {};
+  for (const [key, val] of Object.entries(data)) {
+    if (!key.startsWith(API_PREFIX)) {
+      newData[key] = val;
+      continue;
+    }
+    const scoped = scopedApiDataEntry(key, val, isApiScope, activeSpecKey);
+    if (scoped !== undefined) {
+      newData[key] = scoped;
+    }
+  }
+  return newData;
+}
+
+function collectLinkFormApiKeys(pageMap) {
+  const out = new Set();
+  for (const item of pageMap) {
+    if (!("data" in item) || !item.data) {
+      continue;
+    }
+    for (const [key, val] of Object.entries(item.data)) {
+      if (!key.startsWith(API_PREFIX)) {
+        continue;
+      }
+      if (val !== null && typeof val === "object" && "href" in val) {
+        out.add(key);
+      }
+    }
+  }
+  return out;
+}
+
+function scopePageMap(pageMap, pathname) {
+  const apiMatch = /^\\/(api-[^/]+)/.exec(pathname);
+  const isApiScope = apiMatch !== null;
+  const activeSpecKey = apiMatch ? apiMatch[1] : undefined;
+  const isMultiSpec = countApiMentions(pageMap) > 2;
+  const linkFormKeys = collectLinkFormApiKeys(pageMap);
+  const scoped = [];
+  for (const item of pageMap) {
+    if ("data" in item && item.data) {
+      const newData = scopeDataBlock(item.data, isApiScope, activeSpecKey);
+      scoped.push({ ...item, data: newData });
+      continue;
+    }
+    if ("name" in item && typeof item.name === "string") {
+      const name = item.name;
+      const isApiFolder = name.startsWith(API_PREFIX);
+      const keepFolder =
+        !isApiFolder ||
+        (isApiScope && name === activeSpecKey) ||
+        (!isApiScope && linkFormKeys.has(name));
+      if (keepFolder) {
+        scoped.push(item);
+      }
+      continue;
+    }
+    scoped.push(item);
+  }
+  return { scopedPageMap: scoped, isMultiSpec };
+}`;

--- a/cli/src/site/SiteJsonReader.test.ts
+++ b/cli/src/site/SiteJsonReader.test.ts
@@ -428,4 +428,143 @@ describe("SiteJsonReader.readSiteJson", () => {
 
 		expect(result.config.sidebar).toBeUndefined();
 	});
+
+	// ── branding → theme alias coercion ──────────────────────────────────────
+
+	it("coerces branding.themePack into theme.pack", async () => {
+		const { readSiteJson } = await import("./SiteJsonReader.js");
+		const siteJson = {
+			title: "T",
+			description: "D",
+			nav: [],
+			branding: { themePack: "forge" },
+		};
+		await writeFile(join(tempDir, "site.json"), JSON.stringify(siteJson), "utf-8");
+		const result = await readSiteJson(tempDir);
+		expect(result.config.theme?.pack).toBe("forge");
+	});
+
+	it("coerces branding.colors.primaryHue into theme.primaryHue", async () => {
+		const { readSiteJson } = await import("./SiteJsonReader.js");
+		const siteJson = {
+			title: "T",
+			description: "D",
+			nav: [],
+			branding: { colors: { primaryHue: 217 } },
+		};
+		await writeFile(join(tempDir, "site.json"), JSON.stringify(siteJson), "utf-8");
+		const result = await readSiteJson(tempDir);
+		expect(result.config.theme?.primaryHue).toBe(217);
+	});
+
+	it("coerces branding.logo.{text,image,imageDark,display} into theme.{logoText,logoUrl,logoUrlDark,logoDisplay}", async () => {
+		const { readSiteJson } = await import("./SiteJsonReader.js");
+		const siteJson = {
+			title: "T",
+			description: "D",
+			nav: [],
+			branding: {
+				logo: {
+					text: "ACME",
+					image: "/logo.svg",
+					imageDark: "/logo-dark.svg",
+					display: "both",
+				},
+			},
+		};
+		await writeFile(join(tempDir, "site.json"), JSON.stringify(siteJson), "utf-8");
+		const result = await readSiteJson(tempDir);
+		expect(result.config.theme?.logoText).toBe("ACME");
+		expect(result.config.theme?.logoUrl).toBe("/logo.svg");
+		expect(result.config.theme?.logoUrlDark).toBe("/logo-dark.svg");
+		expect(result.config.theme?.logoDisplay).toBe("both");
+	});
+
+	it("coerces branding.{favicon,fontFamily,defaultTheme} into theme.{favicon,fontFamily,defaultTheme}", async () => {
+		const { readSiteJson } = await import("./SiteJsonReader.js");
+		const siteJson = {
+			title: "T",
+			description: "D",
+			nav: [],
+			branding: {
+				favicon: "/favicon.svg",
+				fontFamily: "ibm-plex",
+				defaultTheme: "system",
+			},
+		};
+		await writeFile(join(tempDir, "site.json"), JSON.stringify(siteJson), "utf-8");
+		const result = await readSiteJson(tempDir);
+		expect(result.config.theme?.favicon).toBe("/favicon.svg");
+		expect(result.config.theme?.fontFamily).toBe("ibm-plex");
+		expect(result.config.theme?.defaultTheme).toBe("system");
+	});
+
+	it("theme.* wins over branding.* when both are set on the same field", async () => {
+		const { readSiteJson } = await import("./SiteJsonReader.js");
+		const siteJson = {
+			title: "T",
+			description: "D",
+			nav: [],
+			branding: { themePack: "forge", defaultTheme: "system" },
+			theme: { pack: "atlas", defaultTheme: "dark" },
+		};
+		await writeFile(join(tempDir, "site.json"), JSON.stringify(siteJson), "utf-8");
+		const result = await readSiteJson(tempDir);
+		expect(result.config.theme?.pack).toBe("atlas");
+		expect(result.config.theme?.defaultTheme).toBe("dark");
+	});
+
+	it("merges unrelated branding.* and theme.* fields without dropping either", async () => {
+		const { readSiteJson } = await import("./SiteJsonReader.js");
+		const siteJson = {
+			title: "T",
+			description: "D",
+			nav: [],
+			branding: { themePack: "forge" },
+			theme: { primaryHue: 100 },
+		};
+		await writeFile(join(tempDir, "site.json"), JSON.stringify(siteJson), "utf-8");
+		const result = await readSiteJson(tempDir);
+		expect(result.config.theme?.pack).toBe("forge");
+		expect(result.config.theme?.primaryHue).toBe(100);
+	});
+
+	it("leaves theme unset when no branding or theme block is present", async () => {
+		const { readSiteJson } = await import("./SiteJsonReader.js");
+		const siteJson = { title: "T", description: "D", nav: [] };
+		await writeFile(join(tempDir, "site.json"), JSON.stringify(siteJson), "utf-8");
+		const result = await readSiteJson(tempDir);
+		expect(result.config.theme).toBeUndefined();
+	});
+
+	// ── footer.social → footer.socialLinks alias ─────────────────────────────
+
+	it("coerces footer.social into footer.socialLinks", async () => {
+		const { readSiteJson } = await import("./SiteJsonReader.js");
+		const siteJson = {
+			title: "T",
+			description: "D",
+			nav: [],
+			footer: { social: { github: "https://github.com/acme" } },
+		};
+		await writeFile(join(tempDir, "site.json"), JSON.stringify(siteJson), "utf-8");
+		const result = await readSiteJson(tempDir);
+		expect(result.config.footer?.socialLinks).toEqual({ github: "https://github.com/acme" });
+	});
+
+	it("footer.socialLinks wins over footer.social when both are set", async () => {
+		const { readSiteJson } = await import("./SiteJsonReader.js");
+		const siteJson = {
+			title: "T",
+			description: "D",
+			nav: [],
+			footer: {
+				social: { github: "https://github.com/old" },
+				socialLinks: { github: "https://github.com/new" },
+			},
+		};
+		await writeFile(join(tempDir, "site.json"), JSON.stringify(siteJson), "utf-8");
+		const result = await readSiteJson(tempDir);
+		expect(result.config.footer?.socialLinks).toEqual({ github: "https://github.com/new" });
+	});
 });

--- a/cli/src/site/SiteJsonReader.ts
+++ b/cli/src/site/SiteJsonReader.ts
@@ -95,7 +95,88 @@ async function readExistingSiteJson(filePath: string): Promise<SiteJsonResult> {
 		...Object.fromEntries(Object.entries(obj).filter(([k]) => !["title", "description", "nav"].includes(k))),
 	};
 
+	coerceBrandingToTheme(config);
+	coerceFooterSocialAlias(config);
+
 	return { config, usedDefault: false };
+}
+
+// ─── Schema aliasing ─────────────────────────────────────────────────────────
+
+/**
+ * Migrates the deprecated `branding.*` block into the canonical `theme.*`
+ * block so downstream code only ever reads `theme`. `theme.*` wins when
+ * both are set — a single-field override on top of a `branding` block keeps
+ * working without forcing the customer to rewrite the whole block.
+ *
+ * Mapping (every field is optional):
+ *   - `branding.themePack`           → `theme.pack`
+ *   - `branding.colors.primaryHue`   → `theme.primaryHue`
+ *   - `branding.fontFamily`          → `theme.fontFamily`
+ *   - `branding.defaultTheme`        → `theme.defaultTheme`
+ *   - `branding.favicon`             → `theme.favicon`
+ *   - `branding.logo.image`          → `theme.logoUrl`
+ *   - `branding.logo.imageDark`      → `theme.logoUrlDark`
+ *   - `branding.logo.text`           → `theme.logoText`
+ *   - `branding.logo.display`        → `theme.logoDisplay`
+ *
+ * `branding.logo.alt` is intentionally dropped — the CLI renderer derives
+ * `<img alt>` from the title/logoText, and there's no plumbed-through
+ * customization point for an explicit alt string yet.
+ *
+ * Mutates `config.theme` in place. Leaves `config.branding` intact so a
+ * follow-up reader can inspect it for diagnostics — downstream code should
+ * not read `branding` directly.
+ */
+function coerceBrandingToTheme(config: SiteJson): void {
+	const branding = config.branding;
+	if (!branding) return;
+
+	const existing = config.theme ?? {};
+	const merged = { ...existing };
+
+	if (branding.themePack !== undefined && merged.pack === undefined) {
+		merged.pack = branding.themePack;
+	}
+	if (branding.favicon !== undefined && merged.favicon === undefined) {
+		merged.favicon = branding.favicon;
+	}
+	if (branding.fontFamily !== undefined && merged.fontFamily === undefined) {
+		merged.fontFamily = branding.fontFamily;
+	}
+	if (branding.defaultTheme !== undefined && merged.defaultTheme === undefined) {
+		merged.defaultTheme = branding.defaultTheme;
+	}
+	if (branding.colors?.primaryHue !== undefined && merged.primaryHue === undefined) {
+		merged.primaryHue = branding.colors.primaryHue;
+	}
+	if (branding.logo) {
+		if (branding.logo.image !== undefined && merged.logoUrl === undefined) {
+			merged.logoUrl = branding.logo.image;
+		}
+		if (branding.logo.imageDark !== undefined && merged.logoUrlDark === undefined) {
+			merged.logoUrlDark = branding.logo.imageDark;
+		}
+		if (branding.logo.text !== undefined && merged.logoText === undefined) {
+			merged.logoText = branding.logo.text;
+		}
+		if (branding.logo.display !== undefined && merged.logoDisplay === undefined) {
+			merged.logoDisplay = branding.logo.display;
+		}
+	}
+
+	config.theme = merged;
+}
+
+/**
+ * Migrates the deprecated `footer.social` field into the canonical
+ * `footer.socialLinks`. `socialLinks` wins if both are set.
+ */
+function coerceFooterSocialAlias(config: SiteJson): void {
+	if (!config.footer) return;
+	if (config.footer.social && !config.footer.socialLinks) {
+		config.footer.socialLinks = config.footer.social;
+	}
 }
 
 // ─── createSiteJson ──────────────────────────────────────────────────────────

--- a/cli/src/site/Types.ts
+++ b/cli/src/site/Types.ts
@@ -17,8 +17,7 @@ export interface NavLink {
 
 /**
  * A simple labelled URL — used as a footer-column link, a header-dropdown
- * sub-item, etc. Matches the SaaS `ExternalLink` shape (minus the editor-only
- * `id` field, which the CLI doesn't need).
+ * sub-item, etc.
  */
 export interface ExternalLink {
 	label: string;
@@ -27,7 +26,7 @@ export interface ExternalLink {
 
 /**
  * Header navbar item — direct link (`url`) OR dropdown (`items`),
- * mutually exclusive. Matches the SaaS `HeaderNavItem` shape.
+ * mutually exclusive.
  */
 export interface HeaderItem {
 	label: string;
@@ -60,6 +59,11 @@ export interface FooterConfig {
 	copyright?: string;
 	columns?: FooterColumn[];
 	socialLinks?: SocialLinks;
+	/**
+	 * Deprecated nested-shape alias for `socialLinks`. Coerced to `socialLinks`
+	 * at site.json load time; `socialLinks` wins when both are set.
+	 */
+	social?: SocialLinks;
 }
 
 /**
@@ -92,31 +96,38 @@ export type PathMappings = Record<string, string>;
 
 /**
  * Visual theme pack — picks the layout/CSS shell.
- *   - `default` — vanilla `nextra-theme-docs` (current behaviour, shipped before
- *     theme packs existed). The fallback when `theme.pack` is unset.
  *   - `forge` — clean developer-docs pack: light default, sidebar-first layout,
- *     Inter typography, hairline borders. Mirrors the SaaS Forge pack post-1392.
+ *     Inter typography, hairline borders. **The fallback when `theme.pack`
+ *     is unset.**
  *   - `atlas` — editorial pack: dark default, top-nav, serif headlines,
- *     airy spacing, masthead footer. Mirrors the SaaS Atlas pack.
+ *     airy spacing, masthead footer.
+ *   - `default` — vanilla `nextra-theme-docs` (the pre-pack visual, shipped
+ *     before theme packs existed). Kept as an explicit opt-in for sites that
+ *     prefer the unstyled Nextra look; never picked implicitly.
  */
 export type ThemePack = "default" | "forge" | "atlas";
 
 /** Initial colour scheme for visitors. */
 export type DefaultThemeMode = "light" | "dark" | "system";
 
-/**
- * Font families a pack can resolve via Google Fonts. Names match the SaaS
- * `FontFamily` enum so a single site.json works in both surfaces.
- */
+/** Font families a pack can resolve via Google Fonts. */
 export type FontFamily = "inter" | "space-grotesk" | "ibm-plex" | "source-sans" | "source-serif";
 
 /**
- * Visual theme block in site.json. Mirrors the customer-facing surface of
- * the SaaS `SiteBranding` (post-1392), minus tenant-only fields (`siteName` —
- * the CLI uses `title` at the top level instead, `customCss`, `legacyBranding`).
+ * How the navbar logo composes its image and text parts:
+ *   - `"text"`  — render only the logo text (defaults to `title`, or `logoText` if set)
+ *   - `"image"` — render only the logo image (`logoUrl`); falls back to text if `logoUrl` is unset
+ *   - `"both"`  — render image followed by text
  *
- * All fields are optional; each pack's manifest supplies defaults (e.g. Forge
- * defaults to `primaryHue: 228`, `defaultTheme: "light"`, `fontFamily: "inter"`).
+ * When `logoDisplay` is unset, the layout infers `"both"` if `logoUrl` is set
+ * and `"text"` otherwise — preserving pre-`logoDisplay` behaviour.
+ */
+export type LogoDisplay = "text" | "image" | "both";
+
+/**
+ * Visual theme block in site.json. All fields are optional; each pack's
+ * manifest supplies defaults (e.g. Forge defaults to `primaryHue: 228`,
+ * `defaultTheme: "light"`, `fontFamily: "inter"`).
  */
 export interface ThemeConfig {
 	pack?: ThemePack;
@@ -124,6 +135,17 @@ export interface ThemeConfig {
 	logoUrl?: string;
 	/** Optional dark-mode logo variant. The pack swaps when `.dark` is active. */
 	logoUrlDark?: string;
+	/**
+	 * Custom logo text. When unset, the site `title` is used. Useful when the
+	 * page title ("Acme Documentation") differs from the brand wordmark ("ACME").
+	 */
+	logoText?: string;
+	/**
+	 * Whether the navbar logo shows the image, the text, or both. See
+	 * `LogoDisplay` for the resolution rules. The auto-default preserves
+	 * pre-`logoDisplay` behaviour, so existing sites need no change.
+	 */
+	logoDisplay?: LogoDisplay;
 	/**
 	 * Favicon URL. When the legacy top-level `favicon` field is also set, the
 	 * top-level value wins (deprecated alias kept for back-compat).
@@ -137,6 +159,35 @@ export interface ThemeConfig {
 	fontFamily?: FontFamily;
 }
 
+/**
+ * Logo subfields under `branding.logo`. The canonical shape is the flat
+ * `theme.logoUrl` / `theme.logoText` etc. — `BrandingConfig` is read as a
+ * deprecated alias and coerced into `theme` at site.json load time.
+ */
+export interface BrandingLogoConfig {
+	text?: string;
+	image?: string;
+	imageDark?: string;
+	display?: LogoDisplay;
+	/** Schema-compatibility passthrough — currently ignored by the CLI renderer. */
+	alt?: string;
+}
+
+/**
+ * Visual branding block — the deprecated nested-shape alias for `theme`.
+ * Mapping happens at load time in `SiteJsonReader.coerceBrandingToTheme`.
+ * When both `branding` and `theme` are present, `theme.*` wins (so callers
+ * can override a single field without rewriting the whole block).
+ */
+export interface BrandingConfig {
+	themePack?: ThemePack;
+	logo?: BrandingLogoConfig;
+	favicon?: string;
+	colors?: { primaryHue?: number };
+	fontFamily?: FontFamily;
+	defaultTheme?: DefaultThemeMode;
+}
+
 /** The parsed contents of site.json */
 export interface SiteJson {
 	title: string;
@@ -147,15 +198,9 @@ export interface SiteJson {
 	 * items at render time so existing CLI sites keep working unchanged.
 	 */
 	nav: NavLink[];
-	/**
-	 * Header navbar — supports per-item dropdowns. Mirrors the SaaS
-	 * `HeaderLinksConfig` shape so a single `site.json` works in both systems.
-	 */
+	/** Header navbar — supports per-item dropdowns. */
 	header?: HeaderConfig;
-	/**
-	 * Site footer — copyright, columns of links, and social-icon URLs.
-	 * Mirrors the SaaS `FooterConfig` shape.
-	 */
+	/** Site footer — copyright, columns of links, and social-icon URLs. */
 	footer?: FooterConfig;
 	sidebar?: SidebarOverrides;
 	pathMappings?: PathMappings;
@@ -167,6 +212,12 @@ export interface SiteJson {
 	renderer?: string;
 	/** Visual styling — see `ThemeConfig`. */
 	theme?: ThemeConfig;
+	/**
+	 * Deprecated nested-shape alias for `theme`. Coerced to `theme.*` at
+	 * site.json load time; `theme.*` wins when both are set. New site.json
+	 * files should use `theme` directly.
+	 */
+	branding?: BrandingConfig;
 	[key: string]: unknown; // unknown fields are silently ignored
 }
 

--- a/cli/src/site/openapi/CodeSampleGenerator.test.ts
+++ b/cli/src/site/openapi/CodeSampleGenerator.test.ts
@@ -1,11 +1,10 @@
 /**
  * Tests for CodeSampleGenerator.
  *
- * Ported from nextra-generator. Same coverage: Python literal
- * encoding, Go string-literal escaping, end-to-end sample emission with
- * tricky content (strings containing `true`/`false`/`null`, payloads with
- * backticks). New helper-targeted tests added for query-string + auth
- * scheme branches that the original suite covered indirectly.
+ * Coverage: Python literal encoding, Go string-literal escaping, end-to-end
+ * sample emission with tricky content (strings containing `true`/`false`/
+ * `null`, payloads with backticks), plus helper-targeted tests for the
+ * query-string and auth-scheme branches.
  */
 
 import { describe, expect, it } from "vitest";

--- a/cli/src/site/openapi/Escape.ts
+++ b/cli/src/site/openapi/Escape.ts
@@ -12,10 +12,18 @@ const YAML_SPECIAL_VALUES = new Set(["true", "false", "yes", "no", "on", "off", 
 // ─── escapeYaml ──────────────────────────────────────────────────────────────
 
 /**
- * Escapes special characters in YAML string values and quotes the value if
- * it would otherwise be parsed as a non-string type:
+ * Escapes a string so it can be dropped into YAML frontmatter as a scalar
+ * value. Quotes the value if it would otherwise be parsed as a non-string
+ * type or break the scalar boundary:
  *  - Strings starting with a digit (would be parsed as a number)
  *  - YAML special values (`true`, `false`, `null`, `yes`, `no`, `on`, `off`, `~`)
+ *  - Strings containing a newline / carriage return — without quoting these,
+ *    the second line is read as the next implicit key and the document fails
+ *    to parse (Vercel build crash on Nextra `remark-mdx-frontmatter`). The
+ *    newline is rewritten as the YAML `\n` escape, valid only inside a
+ *    double-quoted scalar.
+ *  - Strings containing a backslash — must be doubled inside double-quoted
+ *    scalars, otherwise YAML reads it as the start of an escape sequence.
  */
 export function escapeYaml(str: string): string {
 	const hasSpecialChars = /[:#[\]{}|>`\n\r]/.test(str) || str.includes('"') || str.includes("'");

--- a/cli/src/site/openapi/SchemaExample.test.ts
+++ b/cli/src/site/openapi/SchemaExample.test.ts
@@ -1,8 +1,7 @@
 /**
  * Tests for SchemaExample — synthesises example payloads from OpenAPI schemas.
  *
- * Ported from nextra-generator with no behavioural changes.
- * These also document the function's intentional gaps (no $ref, no oneOf /
+ * Also documents the function's intentional gaps (no $ref, no oneOf /
  * anyOf / allOf, no enum / default / nullable handling) so we don't quietly
  * regress.
  */

--- a/cli/src/site/renderer/NextraRenderer.test.ts
+++ b/cli/src/site/renderer/NextraRenderer.test.ts
@@ -139,10 +139,22 @@ describe("NextraRenderer", () => {
 		}
 	});
 
-	it("api.css uses generateApiCss's internal default (220) when no theme is set", async () => {
-		const buildDir = await mkdtemp(join(tmpdir(), "jolli-nextra-default-"));
+	it("api.css falls back to Forge's manifest hue (228) when no theme block is set (Forge is the implicit default)", async () => {
+		const buildDir = await mkdtemp(join(tmpdir(), "jolli-nextra-implicit-forge-"));
 		try {
 			const config = { title: "T", description: "D", nav: [] };
+			await new NextraRenderer().initProject(buildDir, config, { staticExport: true });
+			const css = await readFile(join(buildDir, "styles", "api.css"), "utf-8");
+			expect(css).toContain("hsl(228 84% 50%)");
+		} finally {
+			await rm(buildDir, { recursive: true, force: true });
+		}
+	});
+
+	it("api.css uses generateApiCss's internal default (220) when theme.pack is explicitly 'default'", async () => {
+		const buildDir = await mkdtemp(join(tmpdir(), "jolli-nextra-explicit-default-"));
+		try {
+			const config = { title: "T", description: "D", nav: [], theme: { pack: "default" as const } };
 			await new NextraRenderer().initProject(buildDir, config, { staticExport: true });
 			const css = await readFile(join(buildDir, "styles", "api.css"), "utf-8");
 			expect(css).toContain("hsl(220 84% 50%)");
@@ -155,11 +167,12 @@ describe("NextraRenderer", () => {
 		expect(new NextraRenderer().getCacheDirs("/build")).toEqual([join("/build", ".next")]);
 	});
 
-	it("generateNavigation delegates to generateMetaFiles", async () => {
+	it("generateNavigation delegates to generateMetaFiles, passing the rootInjection payload through", async () => {
 		const { generateMetaFiles } = await import("../MetaGenerator.js");
 		const sidebar = { "/": { intro: "Intro" } };
-		await new NextraRenderer().generateNavigation("/content", sidebar);
-		expect(generateMetaFiles).toHaveBeenCalledWith("/content", sidebar);
+		const rootInjection = { apiSpecs: [{ specName: "petstore", title: "Petstore" }] };
+		await new NextraRenderer().generateNavigation("/content", sidebar, rootInjection);
+		expect(generateMetaFiles).toHaveBeenCalledWith("/content", sidebar, rootInjection);
 	});
 
 	it("getContentRules returns safe import prefixes including nextra and react", () => {

--- a/cli/src/site/renderer/NextraRenderer.ts
+++ b/cli/src/site/renderer/NextraRenderer.ts
@@ -10,12 +10,14 @@
 
 import { mkdir, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
-import { generateMetaFiles } from "../MetaGenerator.js";
+import { generateMetaFiles, type RootInjectionInput } from "../MetaGenerator.js";
 import { initNextraProject } from "../NextraProjectWriter.js";
 import { runNpmBuild, runNpmDev, type ServerResult } from "../NpmRunner.js";
 import type { OutputFilter } from "../OutputFilter.js";
 import { createOutputFilter as createFilter } from "../OutputFilter.js";
 import type { NpmRunResult, SidebarOverrides, SiteJson } from "../Types.js";
+import { ATLAS_MANIFEST } from "../themes/atlas/Manifest.js";
+import { FORGE_MANIFEST } from "../themes/forge/Manifest.js";
 import { generateApiCss } from "./nextra/ApiCss.js";
 import { emitNextraOpenApiFiles, generateApiComponents } from "./nextra/index.js";
 import type { TemplateFile } from "./nextra/Types.js";
@@ -30,31 +32,25 @@ const PROVIDED_COMPONENTS = new Set(["Fragment", "Callout", "Cards", "Card", "Fi
 const PAGE_COUNT_PATTERN = /Generating static pages.*?(\d+)\/(\d+)/s;
 
 /**
- * Pack manifest defaults — kept in sync with `themes/<pack>/Manifest.ts`.
- * Hardcoded here because importing the manifests from inside `renderer/`
- * would invert the dependency direction (renderer should not depend on
- * pack-specific modules; ApiCss is pack-agnostic).
- */
-const FORGE_DEFAULT_HUE = 228;
-const ATLAS_DEFAULT_HUE = 200;
-
-/**
  * Resolves the accent hue passed to `generateApiCss`. `theme.primaryHue`
- * wins when set; otherwise we fall back to a pack-aware default so the
- * API surface visually matches the pack the customer picked. Returning
- * `undefined` lets `generateApiCss` apply its own internal default (220).
+ * wins when set; otherwise we fall back to the pack manifest's default so
+ * the API surface visually matches the pack the customer picked. Unset
+ * `theme.pack` is treated as Forge (matches the layout dispatcher in
+ * `NextraProjectWriter.generateLayout`); explicit `theme.pack: "default"`
+ * falls through to `generateApiCss`'s internal default (220).
  */
 function resolveApiAccentHue(config: SiteJson): number | undefined {
 	if (typeof config.theme?.primaryHue === "number") {
 		return config.theme.primaryHue;
 	}
-	switch (config.theme?.pack) {
-		case "forge":
-			return FORGE_DEFAULT_HUE;
+	const pack = config.theme?.pack ?? "forge";
+	switch (pack) {
 		case "atlas":
-			return ATLAS_DEFAULT_HUE;
-		default:
+			return ATLAS_MANIFEST.defaults.primaryHue;
+		case "default":
 			return undefined;
+		default:
+			return FORGE_MANIFEST.defaults.primaryHue;
 	}
 }
 
@@ -91,8 +87,12 @@ export class NextraRenderer implements SiteRenderer {
 		return [join(buildDir, ".next")];
 	}
 
-	async generateNavigation(contentDir: string, sidebar?: SidebarOverrides): Promise<void> {
-		await generateMetaFiles(contentDir, sidebar);
+	async generateNavigation(
+		contentDir: string,
+		sidebar?: SidebarOverrides,
+		rootInjection?: RootInjectionInput,
+	): Promise<void> {
+		await generateMetaFiles(contentDir, sidebar, rootInjection);
 	}
 
 	/**

--- a/cli/src/site/renderer/SiteRenderer.ts
+++ b/cli/src/site/renderer/SiteRenderer.ts
@@ -8,6 +8,7 @@
  * framework-specific functions directly.
  */
 
+import type { RootInjectionInput } from "../MetaGenerator.js";
 import type { ServerResult } from "../NpmRunner.js";
 import type { OutputFilter } from "../OutputFilter.js";
 import type { OpenApiPipelineResult } from "../openapi/Types.js";
@@ -68,10 +69,17 @@ export interface SiteRenderer {
 	getCacheDirs(buildDir: string): string[];
 
 	/**
-	 * Generate navigation/sidebar files from the content directory
-	 * structure and sidebar overrides.
+	 * Generate navigation / sidebar files from the content-directory structure
+	 * and sidebar overrides. `rootInjection` carries detected OpenAPI specs
+	 * and `header.items` from `site.json` so the renderer can materialise
+	 * `Documentation` / `API Reference` page tabs and customer header tabs
+	 * as native Nextra navbar entries (chevron, hover, mobile drawer).
 	 */
-	generateNavigation(contentDir: string, sidebar?: SidebarOverrides): Promise<void>;
+	generateNavigation(
+		contentDir: string,
+		sidebar?: SidebarOverrides,
+		rootInjection?: RootInjectionInput,
+	): Promise<void>;
 
 	/**
 	 * Render OpenAPI specs into framework-appropriate pages. Each input

--- a/cli/src/site/renderer/nextra/ApiCss.ts
+++ b/cli/src/site/renderer/nextra/ApiCss.ts
@@ -4,13 +4,12 @@
  *
  * Surfaces, typography, and dark-mode colours hook into Nextra's existing
  * `--nextra-*` tokens so the API pages match the rest of the docs site
- * without any per-customer theming. The accent hue is the only knob and
- * defaults to a Nextra-ish blue (220) — Phase 6 hardcodes this; theme
- * customisation is a future enhancement.
+ * without per-customer theming. The accent hue is the only knob and
+ * defaults to a Nextra-ish blue (220).
  *
- * Ported verbatim (modulo this header) from themes/ApiCss.ts.
- * That source layered the output onto Forge / Atlas / Classic theme-pack
- * stylesheets; we emit it standalone since jolliai has no theme packs.
+ * Emitted as a standalone `styles/api.css` file and imported alongside
+ * any pack stylesheet (`themes/forge.css` / `themes/atlas.css`) by the
+ * generated `app/layout.tsx`.
  */
 
 import type { TemplateFile } from "./Types.js";

--- a/cli/src/site/themes/Footer.test.ts
+++ b/cli/src/site/themes/Footer.test.ts
@@ -1,0 +1,356 @@
+/**
+ * Tests for the shared footer body builder used by Forge / Atlas.
+ *
+ * Two layers exercised:
+ *   - Low-level helpers (`renderFooterColumns`, `renderSocialLinks`,
+ *     `buildFooterScaffold`) — pack-agnostic JSX-string emitters.
+ *   - High-level pack builders (`buildForgeFooterBody`, `buildAtlasFooterBody`) —
+ *     compose the helpers into the pack-specific bottom-row shapes.
+ *
+ * The pack stylesheets in `themes/{forge,atlas}/Css.ts` target the exact
+ * class names emitted here, so every assertion that pins a class is
+ * load-bearing — losing one would visually break the rendered footer
+ * even though the tree still emits "something".
+ */
+
+import { describe, expect, it } from "vitest";
+import type { FooterConfig } from "../Types.js";
+import {
+	buildAtlasFooterBody,
+	buildFooterScaffold,
+	buildForgeFooterBody,
+	renderFooterColumns,
+	renderSocialLinks,
+	SOCIAL_LABELS,
+	SOCIAL_PLATFORMS,
+} from "./Footer.js";
+
+// ─── renderFooterColumns ─────────────────────────────────────────────────────
+
+describe("renderFooterColumns", () => {
+	it("returns empty string when columns is undefined", () => {
+		expect(renderFooterColumns({}, "forge")).toBe("");
+	});
+
+	it("returns empty string when columns is an empty array", () => {
+		expect(renderFooterColumns({ columns: [] }, "forge")).toBe("");
+	});
+
+	it("emits {prefix}-footer-columns wrapper with one {prefix}-footer-col per column", () => {
+		const result = renderFooterColumns(
+			{
+				columns: [
+					{ title: "Product", links: [{ label: "Pricing", url: "/pricing" }] },
+					{ title: "Community", links: [{ label: "Discord", url: "https://discord.gg/x" }] },
+				],
+			},
+			"forge",
+		);
+		expect(result).toContain('<div className="forge-footer-columns">');
+		// Use a precise pattern (quote-terminated) so we don't double-count the
+		// `forge-footer-col` substring inside `forge-footer-columns`.
+		expect(result.match(/forge-footer-col"/g)?.length).toBe(2);
+		expect(result).toContain("<h4>Product</h4>");
+		expect(result).toContain("<h4>Community</h4>");
+		expect(result).toContain('href="/pricing"');
+		expect(result).toContain('href="https://discord.gg/x"');
+	});
+
+	it("uses the supplied class prefix (atlas) for atlas pack", () => {
+		const result = renderFooterColumns({ columns: [{ title: "X", links: [{ label: "Y", url: "/y" }] }] }, "atlas");
+		expect(result).toContain('<div className="atlas-footer-columns">');
+		expect(result).toContain('<div className="atlas-footer-col">');
+	});
+
+	it("escapes HTML-special characters in column titles and link labels", () => {
+		const result = renderFooterColumns(
+			{
+				columns: [{ title: 'Tools <"&">', links: [{ label: "A & B {c}", url: "/x" }] }],
+			},
+			"forge",
+		);
+		expect(result).not.toContain('<"&">');
+		expect(result).toContain("&lt;");
+		expect(result).toContain("&amp;");
+		expect(result).toContain("&quot;");
+		expect(result).toContain("&#123;");
+		expect(result).toContain("&#125;");
+	});
+
+	it("sanitises javascript: link URLs to '#'", () => {
+		const result = renderFooterColumns(
+			{ columns: [{ title: "X", links: [{ label: "Bad", url: "javascript:alert(1)" }] }] },
+			"forge",
+		);
+		expect(result).not.toMatch(/javascript:alert/i);
+		expect(result).toContain('href="#"');
+	});
+
+	it("HTML-attribute-escapes URLs so quotes/angle-brackets cannot break the JSX `href` attribute", () => {
+		// `sanitizeUrl` only enforces a scheme allow-list — it does NOT escape
+		// HTML-special chars in the rest of the URL. Without `escapeHtml` on
+		// top, a URL like `https://x.com/?q="bad"` would close the `href="…"`
+		// JSX attribute prematurely and break the customer's TSX build. Pin
+		// the escaping so a future refactor can't silently regress it.
+		const result = renderFooterColumns(
+			{
+				columns: [
+					{
+						title: "Links",
+						links: [
+							{ label: "Quote", url: 'https://x.com/?q="bad"' },
+							{ label: "Angle", url: "https://x.com/<a>" },
+						],
+					},
+				],
+			},
+			"forge",
+		);
+		expect(result).not.toMatch(/href="https:\/\/x\.com\/\?q="/);
+		expect(result).toContain("&quot;");
+		expect(result).toContain("&lt;");
+		expect(result).toContain("&gt;");
+	});
+
+	it("preserves http(s), mailto, tel, fragments, query strings, and relative paths", () => {
+		const result = renderFooterColumns(
+			{
+				columns: [
+					{
+						title: "Links",
+						links: [
+							{ label: "Web", url: "https://example.com" },
+							{ label: "Mail", url: "mailto:hi@example.com" },
+							{ label: "Phone", url: "tel:+15551234567" },
+							{ label: "Frag", url: "#anchor" },
+							{ label: "Query", url: "?q=1" },
+							{ label: "Rel", url: "../up" },
+							{ label: "Abs", url: "/abs/path" },
+						],
+					},
+				],
+			},
+			"forge",
+		);
+		expect(result).toContain('href="https://example.com"');
+		expect(result).toContain('href="mailto:hi@example.com"');
+		expect(result).toContain('href="tel:+15551234567"');
+		expect(result).toContain('href="#anchor"');
+		expect(result).toContain('href="?q=1"');
+		expect(result).toContain('href="../up"');
+		expect(result).toContain('href="/abs/path"');
+	});
+});
+
+// ─── renderSocialLinks ───────────────────────────────────────────────────────
+
+describe("renderSocialLinks", () => {
+	it("returns empty string when socialLinks is undefined", () => {
+		expect(renderSocialLinks(undefined, "forge")).toBe("");
+	});
+
+	it("returns empty string when no platforms are populated", () => {
+		expect(renderSocialLinks({}, "forge")).toBe("");
+	});
+
+	it("emits one <a> per populated platform with platform-specific class and aria-label", () => {
+		const result = renderSocialLinks({ github: "https://gh.example", twitter: "https://tw.example" }, "forge");
+		expect(result).toContain('aria-label="GitHub"');
+		expect(result).toContain('aria-label="Twitter"');
+		expect(result).toContain('className="forge-footer-social-github"');
+		expect(result).toContain('className="forge-footer-social-twitter"');
+		expect(result).toContain('<div className="forge-footer-social">');
+	});
+
+	it("emits platforms in canonical SOCIAL_PLATFORMS order (github before youtube)", () => {
+		const result = renderSocialLinks({ youtube: "https://yt.example", github: "https://gh.example" }, "forge");
+		expect(result.indexOf("gh.example")).toBeLessThan(result.indexOf("yt.example"));
+	});
+
+	it("omits unpopulated platforms (does not emit empty <a>)", () => {
+		const result = renderSocialLinks({ github: "https://gh.example" }, "forge");
+		expect(result).toContain("github");
+		for (const platform of SOCIAL_PLATFORMS) {
+			if (platform === "github") continue;
+			expect(result).not.toContain(`aria-label="${SOCIAL_LABELS[platform]}"`);
+		}
+	});
+
+	it("treats empty-string URLs as unpopulated", () => {
+		const result = renderSocialLinks({ github: "", twitter: "https://tw.example" }, "forge");
+		expect(result).not.toContain("github");
+		expect(result).toContain("twitter");
+	});
+
+	it("sanitises javascript: URLs to '#' and removes the script payload", () => {
+		const result = renderSocialLinks({ github: "javascript:alert(1)" }, "forge");
+		expect(result).not.toMatch(/javascript:alert/i);
+		expect(result).toContain('href="#"');
+	});
+
+	it("HTML-attribute-escapes social URLs so quotes cannot break the JSX `href` attribute", () => {
+		// Same defense as renderFooterColumns — `sanitizeUrl` doesn't escape
+		// arbitrary chars after the scheme, so a malformed URL with `"` or
+		// `<` would otherwise break the customer's TSX compile.
+		const result = renderSocialLinks({ github: 'https://x.com/?q="bad"' }, "forge");
+		expect(result).not.toMatch(/href="https:\/\/x\.com\/\?q="/);
+		expect(result).toContain("&quot;");
+	});
+
+	it("uses the supplied class prefix for atlas pack", () => {
+		const result = renderSocialLinks({ github: "https://gh.example" }, "atlas");
+		expect(result).toContain("atlas-footer-social-github");
+		expect(result).toContain('<div className="atlas-footer-social">');
+	});
+});
+
+// ─── buildFooterScaffold ─────────────────────────────────────────────────────
+
+describe("buildFooterScaffold", () => {
+	it("emits the {prefix}-footer outer wrapper and {prefix}-footer-bottom inner wrapper", () => {
+		const result = buildFooterScaffold("forge", "", ["<span>row</span>"]);
+		expect(result).toContain('<div className="forge-footer">');
+		expect(result).toContain('<div className="forge-footer-bottom">');
+		expect(result).toContain("<span>row</span>");
+	});
+
+	it("includes the columns block when supplied", () => {
+		const result = buildFooterScaffold("forge", '<div className="forge-footer-columns">x</div>', []);
+		expect(result).toContain('<div className="forge-footer-columns">x</div>');
+	});
+
+	it("omits the columns block when an empty string is passed", () => {
+		const result = buildFooterScaffold("forge", "", ["<span>only</span>"]);
+		// The wrapper still appears (always emitted), but no columns div between the wrapper and the bottom block.
+		expect(result).not.toContain("forge-footer-columns");
+	});
+
+	it("filters empty-string bottom rows so callers can pass socialJsx unconditionally", () => {
+		const result = buildFooterScaffold("forge", "", [
+			"<span>copyright</span>",
+			"", // unpopulated social
+			"<span>powered</span>",
+		]);
+		// All non-empty rows are present.
+		expect(result).toContain("copyright");
+		expect(result).toContain("powered");
+		// The empty string did not produce an extra wrapper line.
+		expect(result.match(/\n {12}\n/g)).toBeNull();
+	});
+
+	it("preserves the order of bottom rows", () => {
+		const result = buildFooterScaffold("atlas", "", [
+			"<span>first</span>",
+			"<span>second</span>",
+			"<span>third</span>",
+		]);
+		expect(result.indexOf("first")).toBeLessThan(result.indexOf("second"));
+		expect(result.indexOf("second")).toBeLessThan(result.indexOf("third"));
+	});
+});
+
+// ─── buildForgeFooterBody ────────────────────────────────────────────────────
+
+describe("buildForgeFooterBody", () => {
+	it("falls back to a year © siteName · Powered by Jolli line when footerConfig is undefined", () => {
+		const result = buildForgeFooterBody("Acme Docs");
+		expect(result).toContain("Acme Docs");
+		expect(result).toContain("Powered by Jolli");
+		expect(result).toContain("new Date().getFullYear()");
+	});
+
+	it("escapes HTML in the fallback siteName", () => {
+		const result = buildForgeFooterBody('Acme "Tools" <suite>');
+		expect(result).not.toContain('Acme "Tools" <suite>');
+		expect(result).toContain("&quot;");
+		expect(result).toContain("&lt;");
+	});
+
+	it("emits the configured copyright string with class forge-footer-copyright", () => {
+		const config: FooterConfig = { copyright: "© 2026 Acme" };
+		const result = buildForgeFooterBody("Acme Docs", config);
+		expect(result).toContain('className="forge-footer-copyright"');
+		expect(result).toContain("© 2026 Acme");
+	});
+
+	it("uses a default copyright (year © siteName) when footer block is set but copyright is unset", () => {
+		const config: FooterConfig = { columns: [] };
+		const result = buildForgeFooterBody("Acme", config);
+		expect(result).toContain('className="forge-footer-copyright"');
+		expect(result).toContain("Acme");
+		expect(result).toContain("new Date().getFullYear()");
+	});
+
+	it("always emits the 'Powered by Jolli' branding span when columns or social or copyright are configured", () => {
+		const result = buildForgeFooterBody("Acme", { copyright: "© Acme" });
+		expect(result).toContain('className="forge-footer-powered"');
+		expect(result).toContain("Powered by Jolli");
+	});
+
+	it("composes columns + social + copyright + powered branding in order", () => {
+		const config: FooterConfig = {
+			copyright: "© 2026 Acme",
+			columns: [{ title: "X", links: [{ label: "Y", url: "/y" }] }],
+			socialLinks: { github: "https://gh.example" },
+		};
+		const result = buildForgeFooterBody("Acme", config);
+		expect(result.indexOf("forge-footer-columns")).toBeLessThan(result.indexOf("forge-footer-bottom"));
+		expect(result.indexOf("forge-footer-copyright")).toBeLessThan(result.indexOf("forge-footer-social"));
+		expect(result.indexOf("forge-footer-social")).toBeLessThan(result.indexOf("forge-footer-powered"));
+	});
+
+	it("escapes HTML in the customer-supplied copyright string", () => {
+		const result = buildForgeFooterBody("X", { copyright: '<script>alert("x")</script>' });
+		expect(result).not.toContain("<script>");
+		expect(result).toContain("&lt;script&gt;");
+	});
+});
+
+// ─── buildAtlasFooterBody ────────────────────────────────────────────────────
+
+describe("buildAtlasFooterBody", () => {
+	it("emits a masthead-style fallback wrapping the siteName when footerConfig is undefined", () => {
+		const result = buildAtlasFooterBody("Acme");
+		expect(result).toContain('className="atlas-footer-masthead"');
+		expect(result).toContain('className="atlas-footer-copy"');
+		expect(result).toContain("Acme");
+		expect(result).toContain("Powered by Jolli");
+	});
+
+	it("escapes HTML in the masthead siteName", () => {
+		const result = buildAtlasFooterBody("Acme & <Co>");
+		expect(result).not.toContain("Acme & <Co>");
+		expect(result).toContain("&amp;");
+		expect(result).toContain("&lt;");
+	});
+
+	it("uses customer copyright (with · Powered by Jolli suffix) when set", () => {
+		const result = buildAtlasFooterBody("Acme", { copyright: "© 2026 Acme" });
+		expect(result).toContain("© 2026 Acme · Powered by Jolli");
+	});
+
+	it("emits the full atlas-footer scaffold when footerConfig is configured", () => {
+		const config: FooterConfig = {
+			copyright: "© Acme",
+			columns: [{ title: "Z", links: [{ label: "Q", url: "/q" }] }],
+			socialLinks: { github: "https://gh.example" },
+		};
+		const result = buildAtlasFooterBody("Acme", config);
+		expect(result).toContain('className="atlas-footer"');
+		expect(result).toContain('className="atlas-footer-bottom"');
+		expect(result).toContain('className="atlas-footer-columns"');
+		expect(result).toContain('className="atlas-footer-social"');
+		expect(result).toContain('className="atlas-footer-masthead"');
+	});
+
+	it("escapes HTML in customer-supplied copyright", () => {
+		const result = buildAtlasFooterBody("X", { copyright: '<img src=x onerror="alert(1)">' });
+		expect(result).not.toContain("<img");
+		expect(result).toContain("&lt;img");
+	});
+
+	it("does not render a Powered-by-Jolli row separately (atlas folds it into the masthead copy)", () => {
+		const result = buildAtlasFooterBody("Acme", { columns: [] });
+		expect(result.match(/Powered by Jolli/g)?.length).toBe(1);
+	});
+});

--- a/cli/src/site/themes/Footer.ts
+++ b/cli/src/site/themes/Footer.ts
@@ -1,0 +1,160 @@
+/**
+ * Footer.ts — semantic-class footer body builder shared by Forge / Atlas.
+ *
+ * URL / HTML escaping is delegated to the consolidated `Sanitize.ts` module
+ * so every footer surface shares one allow-list.
+ *
+ * The pack stylesheets in `themes/{forge,atlas}/Css.ts` target a fixed set
+ * of class names — `.{prefix}-footer`, `.{prefix}-footer-columns`,
+ * `.{prefix}-footer-col`, `.{prefix}-footer-bottom`, `.{prefix}-footer-copyright`,
+ * `.{prefix}-footer-social`, `.{prefix}-footer-powered`. Emitting matching
+ * JSX is what makes the footer look right; without it the pack CSS targets
+ * nothing and the layout collapses to default flex spacing with the wrong
+ * typography.
+ *
+ * Helpers return JSX strings (not React nodes) because they're spliced
+ * into a layout `app/layout.tsx` template at generation time; the customer
+ * Next.js build is what eventually compiles them.
+ */
+
+import { escapeHtml, sanitizeUrl } from "../Sanitize.js";
+import type { FooterConfig, SocialLinks } from "../Types.js";
+
+/** Social platforms recognised by the footer renderer (in display order). */
+export const SOCIAL_PLATFORMS = ["github", "twitter", "discord", "linkedin", "youtube"] as const;
+export type SocialPlatform = (typeof SOCIAL_PLATFORMS)[number];
+
+/** Human-readable labels used for `aria-label` on social-icon links. */
+export const SOCIAL_LABELS: Record<SocialPlatform, string> = {
+	github: "GitHub",
+	twitter: "Twitter",
+	discord: "Discord",
+	linkedin: "LinkedIn",
+	youtube: "YouTube",
+};
+
+// ─── renderFooterColumns ─────────────────────────────────────────────────────
+
+/**
+ * Render a footer's columns row. Returns "" when there are no columns —
+ * callers can `if (cols)` to decide whether to wrap it.
+ */
+export function renderFooterColumns(footerConfig: FooterConfig, classPrefix: string): string {
+	if (!footerConfig.columns || footerConfig.columns.length === 0) {
+		return "";
+	}
+	const cols = footerConfig.columns
+		.map((col) => {
+			const links = col.links
+				.map((link) => `<li><a href="${escapeHtml(sanitizeUrl(link.url))}">${escapeHtml(link.label)}</a></li>`)
+				.join("");
+			return `<div className="${classPrefix}-footer-col"><h4>${escapeHtml(col.title)}</h4><ul>${links}</ul></div>`;
+		})
+		.join("");
+	return `<div className="${classPrefix}-footer-columns">${cols}</div>`;
+}
+
+// ─── renderSocialLinks ───────────────────────────────────────────────────────
+
+/**
+ * Render the social-icon link row. Returns "" when no platforms are set.
+ */
+export function renderSocialLinks(socialLinks: SocialLinks | undefined, classPrefix: string): string {
+	if (!socialLinks) {
+		return "";
+	}
+	const links = SOCIAL_PLATFORMS.filter((platform) => socialLinks[platform])
+		.map((platform) => {
+			const url = escapeHtml(sanitizeUrl(socialLinks[platform] as string));
+			const label = SOCIAL_LABELS[platform];
+			return `<a href="${url}" aria-label="${label}" className="${classPrefix}-footer-social-${platform}">${label}</a>`;
+		})
+		.join("");
+	if (!links) {
+		return "";
+	}
+	return `<div className="${classPrefix}-footer-social">${links}</div>`;
+}
+
+// ─── buildFooterScaffold ─────────────────────────────────────────────────────
+
+/**
+ * Wraps a pack's bottom-row content in the standard footer scaffold:
+ *
+ *   <div className="{prefix}-footer">
+ *     {columnsJsx if any}
+ *     <div className="{prefix}-footer-bottom">
+ *       {bottom rows, in order}
+ *     </div>
+ *   </div>
+ *
+ * Each pack's bottom row differs (Forge: copyright + social + branding;
+ * Atlas: masthead + social), so the rows themselves are passed in. Empty
+ * strings are filtered so callers can pass `socialJsx` unconditionally.
+ */
+export function buildFooterScaffold(classPrefix: string, columnsJsx: string, bottomRows: Array<string>): string {
+	const filteredBottom = bottomRows.filter(Boolean);
+	const blocks: string[] = [`<div className="${classPrefix}-footer">`];
+	if (columnsJsx) {
+		blocks.push(`  ${columnsJsx}`);
+	}
+	blocks.push(`  <div className="${classPrefix}-footer-bottom">`);
+	for (const row of filteredBottom) {
+		blocks.push(`    ${row}`);
+	}
+	blocks.push(`  </div>`);
+	blocks.push(`</div>`);
+	return blocks.join("\n          ");
+}
+
+// ─── buildForgeFooterBody ────────────────────────────────────────────────────
+
+/**
+ * Build the inner JSX of `<Footer>` for the Forge pack. When `footerConfig`
+ * is unset, falls back to a simple "year © siteName" line. When set,
+ * renders a columns row + a bottom row with copyright, social-icon links,
+ * and the "Powered by Jolli" branding.
+ */
+export function buildForgeFooterBody(siteName: string, footerConfig?: FooterConfig): string {
+	const escapedName = escapeHtml(siteName);
+	if (!footerConfig) {
+		return `{new Date().getFullYear()} © ${escapedName} · Powered by Jolli`;
+	}
+
+	const copyright = footerConfig.copyright
+		? `<span className="forge-footer-copyright">${escapeHtml(footerConfig.copyright)}</span>`
+		: `<span className="forge-footer-copyright">{new Date().getFullYear()} © ${escapedName}</span>`;
+
+	return buildFooterScaffold("forge", renderFooterColumns(footerConfig, "forge"), [
+		copyright,
+		renderSocialLinks(footerConfig.socialLinks, "forge"),
+		`<span className="forge-footer-powered">Powered by Jolli</span>`,
+	]);
+}
+
+// ─── buildAtlasFooterBody ────────────────────────────────────────────────────
+
+/**
+ * Build the inner JSX of `<Footer>` for the Atlas pack. Atlas leans on a
+ * masthead-style bottom row (large site-name display + small copy line)
+ * and adds the columns + social row above when `footerConfig` is set.
+ */
+export function buildAtlasFooterBody(siteName: string, footerConfig?: FooterConfig): string {
+	const escapedName = escapeHtml(siteName);
+
+	const masthead = [
+		`<div className="atlas-footer-masthead">${escapedName}</div>`,
+		footerConfig?.copyright
+			? `<div className="atlas-footer-copy">${escapeHtml(footerConfig.copyright)} · Powered by Jolli</div>`
+			: `<div className="atlas-footer-copy">{new Date().getFullYear()} · Powered by Jolli</div>`,
+	].join("");
+
+	if (!footerConfig) {
+		return `<div>${masthead}</div>`;
+	}
+
+	return buildFooterScaffold("atlas", renderFooterColumns(footerConfig, "atlas"), [
+		`<div>${masthead}</div>`,
+		renderSocialLinks(footerConfig.socialLinks, "atlas"),
+	]);
+}

--- a/cli/src/site/themes/atlas/Css.test.ts
+++ b/cli/src/site/themes/atlas/Css.test.ts
@@ -54,8 +54,12 @@ describe("buildAtlasCss", () => {
 		expect(overrideMarkerIdx).toBeGreaterThan(baseMarkerIdx);
 	});
 
-	it("does NOT include the auth banner block (CLI-strip)", () => {
+	it("includes the .jolli-auth-banner ruleset (carried even though CLI sites don't render it)", () => {
+		// CLI-generated sites have no auth and never emit the .jolli-auth-banner
+		// element. The CSS rule is still carried so any future shared-DOM
+		// scenario that does emit it keeps the same look without duplicating
+		// CSS — keeping the rule is cheaper than dropping it.
 		const result = buildAtlasCss({ accentHue: 200 });
-		expect(result).not.toContain(".jolli-auth-banner");
+		expect(result).toContain(".jolli-auth-banner");
 	});
 });

--- a/cli/src/site/themes/atlas/Css.ts
+++ b/cli/src/site/themes/atlas/Css.ts
@@ -5,9 +5,11 @@
  * cream when toggled to light), wider content column, airy spacing, masthead-
  * style footer. Accent color used as ambient glow rather than solid fill.
  *
- * Vendored from the SaaS Atlas pack. The auth banner block has been stripped (CLI sites have no
- * JWT auth) and the API-reference companion stylesheet is consumed via
- * `styles/api.css` from the rich-renderer pipeline rather than appended here.
+ * The auth-banner ruleset is carried even though CLI sites don't currently
+ * render the element — it costs nothing and stays in step with any future
+ * shared-DOM scenario that does emit it. The API-reference companion
+ * stylesheet is written separately as `styles/api.css` and imported
+ * alongside this file from the layout.
  */
 
 const ATLAS_BASE_CSS = `/*
@@ -537,21 +539,37 @@ article hr {
 
 article strong { color: var(--atlas-text-strong) !important; font-weight: 600 !important; }
 
-/* Code — full-bleed, soft surface, no gutter */
+/* Inline code — soft surface pill. Tighter horizontal padding (0.3em) plus a
+   small margin-inline keeps the pill from visually swallowing adjacent letters
+   on tight lines: without the margin, the rounded background can paint right
+   up against neighbouring glyphs and read as if a character is missing.
+   box-decoration-break: clone ensures the pill renders correctly when an
+   inline code span wraps across two lines (each line gets its own padded box
+   instead of one rectangle that spans both). */
 article code:not(pre code) {
   font-size: 0.8125em !important;
   font-weight: 500 !important;
   color: var(--atlas-text-strong) !important;
   background: var(--atlas-border-soft) !important;
   border-radius: 4px !important;
-  padding: 0.15em 0.4em !important;
+  padding: 0.15em 0.3em !important;
+  margin: 0 0.15em !important;
+  -webkit-box-decoration-break: clone !important;
+  box-decoration-break: clone !important;
 }
 
 /* Atlas code blocks — printed-listing style. No card border, no rounded
    corners; instead the block extends past the article column by ~1rem each
    side and is bookended by hairline rules above and below, so code reads
-   like a typeset listing in a print magazine rather than an inset card. */
-.nextra-code {
+   like a typeset listing in a print magazine rather than an inset card.
+
+   The :has(pre) qualifier is critical: Nextra v4 also applies the
+   .nextra-code class to inline code in some contexts, and without the
+   qualifier the negative-margin / position-relative full-bleed treatment
+   leaks onto inline code, visually overlapping adjacent text. (Forge sidesteps
+   this entirely by putting all its full-bleed styling on .nextra-code pre
+   instead of the wrapper — same outcome, different shape.) */
+.nextra-code:has(pre) {
   position: relative !important;
   margin: 2rem -1rem !important;
 }
@@ -966,6 +984,32 @@ footer .atlas-footer-copy {
 }
 
 /* ═══════════════════════════════════════════════════════════════════════════
+   AUTH BANNER — yellow alert pattern, slightly warmer in Atlas. CLI sites
+   don't currently render the .jolli-auth-banner element (no JWT auth), but
+   the rule is carried so any future shared-DOM scenario that does emit it
+   keeps the same look without duplicating CSS.
+   ═══════════════════════════════════════════════════════════════════════════ */
+
+.jolli-auth-banner {
+  width: 100%;
+  background-color: #fef3c7;
+  border-bottom: 1px solid #fcd34d;
+  padding: 8px 16px;
+  font-size: 13px;
+  color: #78350f;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+}
+
+.dark .jolli-auth-banner {
+  background-color: rgba(120, 53, 15, 0.18);
+  border-bottom-color: rgba(202, 138, 4, 0.3);
+  color: #fde68a;
+}
+
+/* ═══════════════════════════════════════════════════════════════════════════
    SEARCH RESULTS DROPDOWN — Nextra portals the dropdown to body level. By
    default it inherits the search input's width (clipping long result titles)
    and stacks below the sidebar (whose left half then paints over the
@@ -1055,9 +1099,9 @@ ${fontDecl}  --nextra-primary-hue:        ${hue};
 
 /**
  * Build the complete Atlas stylesheet (base + customer overrides). The
- * API-reference companion stylesheet that the SaaS appends here is left out
- * — the CLI's rich-renderer writes `styles/api.css` separately and the
- * layout imports it alongside `themes/atlas.css`.
+ * API-reference companion stylesheet is emitted separately as
+ * `styles/api.css` and imported alongside `themes/atlas.css` from the
+ * layout, so the two stylesheets stay independently reviewable.
  */
 export function buildAtlasCss(input: AtlasOverrideInput): string {
 	return ATLAS_BASE_CSS + buildAtlasOverrides(input);

--- a/cli/src/site/themes/atlas/Layout.test.ts
+++ b/cli/src/site/themes/atlas/Layout.test.ts
@@ -19,7 +19,6 @@ import { ATLAS_MANIFEST } from "./Manifest.js";
 const BASE_INPUT = {
 	title: "Acme Handbook",
 	description: "Editorial-style content site",
-	nav: [],
 	primaryHue: ATLAS_MANIFEST.defaults.primaryHue,
 	defaultTheme: ATLAS_MANIFEST.defaults.defaultTheme,
 	fontFamily: ATLAS_MANIFEST.defaults.fontFamily,
@@ -32,7 +31,6 @@ describe("resolveAtlasLayoutInput", () => {
 		const result = resolveAtlasLayoutInput({
 			title: "T",
 			description: "D",
-			nav: [],
 			theme: undefined,
 			legacyFavicon: undefined,
 		});
@@ -45,7 +43,6 @@ describe("resolveAtlasLayoutInput", () => {
 		const result = resolveAtlasLayoutInput({
 			title: "T",
 			description: "D",
-			nav: [],
 			theme: { primaryHue: 30, defaultTheme: "light", fontFamily: "ibm-plex" },
 			legacyFavicon: undefined,
 		});
@@ -58,7 +55,6 @@ describe("resolveAtlasLayoutInput", () => {
 		const result = resolveAtlasLayoutInput({
 			title: "T",
 			description: "D",
-			nav: [],
 			theme: { favicon: "/theme.ico" },
 			legacyFavicon: "/legacy.ico",
 		});
@@ -76,7 +72,6 @@ describe("resolveAtlasLayoutInput", () => {
 		const result = resolveAtlasLayoutInput({
 			title: "T",
 			description: "D",
-			nav: [],
 			header,
 			footer,
 			theme: undefined,
@@ -84,6 +79,18 @@ describe("resolveAtlasLayoutInput", () => {
 		});
 		expect(result.header).toBe(header);
 		expect(result.footer).toBe(footer);
+	});
+
+	it("propagates theme.logoText and theme.logoDisplay to the resolved input", () => {
+		const result = resolveAtlasLayoutInput({
+			title: "T",
+			description: "D",
+			theme: { logoText: "ACME", logoDisplay: "image", logoUrl: "/logo.svg" },
+			legacyFavicon: undefined,
+		});
+		expect(result.logoText).toBe("ACME");
+		expect(result.logoDisplay).toBe("image");
+		expect(result.logoUrl).toBe("/logo.svg");
 	});
 });
 
@@ -144,20 +151,56 @@ describe("generateAtlasLayoutTsx", () => {
 		expect(result).toContain('className="atlas-logo-dark"');
 	});
 
+	it("uses logoText for the logo span when set, instead of title", () => {
+		const result = generateAtlasLayoutTsx({ ...BASE_INPUT, logoText: "ACME" });
+		expect(result).toContain('<span>{"ACME"}</span>');
+		expect(result).not.toContain('<span>{"Acme Handbook"}</span>');
+	});
+
+	it("logoDisplay='text' suppresses the image even when logoUrl is set", () => {
+		const result = generateAtlasLayoutTsx({
+			...BASE_INPUT,
+			logoUrl: "/logo.svg",
+			logoDisplay: "text",
+		});
+		expect(result).not.toContain("<img ");
+		expect(result).toContain('<span>{"Acme Handbook"}</span>');
+	});
+
+	it("logoDisplay='image' suppresses the text span when logoUrl is set", () => {
+		const result = generateAtlasLayoutTsx({
+			...BASE_INPUT,
+			logoUrl: "/logo.svg",
+			logoDisplay: "image",
+		});
+		expect(result).toContain("<img ");
+		expect(result).not.toContain('<span>{"Acme Handbook"}</span>');
+	});
+
+	it("logoDisplay='image' falls back to text when logoUrl is unset", () => {
+		const result = generateAtlasLayoutTsx({ ...BASE_INPUT, logoDisplay: "image" });
+		expect(result).not.toContain("<img ");
+		expect(result).toContain('<span>{"Acme Handbook"}</span>');
+	});
+
+	it("logoDisplay='both' renders image + text together", () => {
+		const result = generateAtlasLayoutTsx({
+			...BASE_INPUT,
+			logoUrl: "/logo.svg",
+			logoText: "ACME",
+			logoDisplay: "both",
+		});
+		expect(result).toContain('<img src={"/logo.svg"}');
+		expect(result).toContain('<span>{"ACME"}</span>');
+	});
+
 	it("includes the favicon <link> when configured and omits it when not", () => {
 		expect(generateAtlasLayoutTsx(BASE_INPUT)).not.toContain('rel="icon"');
 		const withFavicon = generateAtlasLayoutTsx({ ...BASE_INPUT, favicon: "/favicon.ico" });
 		expect(withFavicon).toContain('<link rel="icon" href={"/favicon.ico"}');
 	});
 
-	it("sanitizes javascript: URLs in nav, favicon, and logoUrl to '#'", () => {
-		const navResult = generateAtlasLayoutTsx({
-			...BASE_INPUT,
-			nav: [{ label: "Bad", href: "javascript:alert(1)" }],
-		});
-		expect(navResult).not.toMatch(/javascript:alert/i);
-		expect(navResult).toContain('<a href={"#"}');
-
+	it("sanitizes javascript: URLs in favicon and logoUrl to '#'", () => {
 		const favResult = generateAtlasLayoutTsx({ ...BASE_INPUT, favicon: "javascript:alert(1)" });
 		expect(favResult).not.toMatch(/javascript:alert/i);
 
@@ -166,121 +209,58 @@ describe("generateAtlasLayoutTsx", () => {
 		expect(logoResult).toContain('<img src={"#"}');
 	});
 
-	it("renders nav items as <a> children of <Navbar> (Atlas keeps the legacy nav shorthand support)", () => {
-		const result = generateAtlasLayoutTsx({
-			...BASE_INPUT,
-			nav: [{ label: "Guides", href: "/guides" }],
-		});
-		expect(result).toContain('href={"/guides"}');
-		expect(result).toContain('{"Guides"}');
+	it("renders <Navbar> with no JSX children — nav items go through _meta.js", () => {
+		const result = generateAtlasLayoutTsx(BASE_INPUT);
+		// New architecture: Atlas's navbar has only the logo prop, no
+		// children. Page tabs come from the root _meta.js (Nextra renders
+		// them natively with chevron / hover / mobile drawer). The layout
+		// input no longer carries `nav` at all — enforced at the type level.
+		expect(result).toContain("<Navbar logo={<SiteLogo />} />");
 	});
 
-	// ── header.items support ─────────────────────────────────────────────────
-
-	it("prefers header.items over legacy nav when both are set", () => {
-		const result = generateAtlasLayoutTsx({
-			...BASE_INPUT,
-			nav: [{ label: "FromNav", href: "/nav" }],
-			header: { items: [{ label: "FromHeader", url: "/header" }] },
-		});
-		expect(result).toContain("FromHeader");
-		expect(result).not.toContain("FromNav");
+	it("uses <ScopedNextraLayout> instead of vanilla <Layout>", () => {
+		const result = generateAtlasLayoutTsx(BASE_INPUT);
+		expect(result).toContain("import ScopedNextraLayout from '../components/ScopedNextraLayout'");
+		expect(result).toContain("<ScopedNextraLayout");
+		expect(result).toContain("</ScopedNextraLayout>");
 	});
 
-	it("renders a <details> dropdown when a header item has sub-items", () => {
-		const result = generateAtlasLayoutTsx({
-			...BASE_INPUT,
-			header: {
-				items: [
-					{
-						label: "Resources",
-						items: [
-							{ label: "Blog", url: "/blog" },
-							{ label: "Changelog", url: "/changelog" },
-						],
-					},
-				],
-			},
-		});
-		expect(result).toContain("<details");
-		expect(result).toContain("<summary");
-		expect(result).toContain('{"Resources"}');
-		expect(result).toContain('{"Blog"}');
-		expect(result).toContain('href={"/blog"}');
-	});
-
-	it("renders a direct link for header items without sub-items", () => {
-		const result = generateAtlasLayoutTsx({
-			...BASE_INPUT,
-			header: { items: [{ label: "Docs", url: "/docs" }] },
-		});
-		expect(result).toContain('href={"/docs"}');
-		expect(result).not.toContain("<details");
-	});
-
-	it("falls back to '#' for header items with no url and no sub-items", () => {
-		const result = generateAtlasLayoutTsx({
-			...BASE_INPUT,
-			header: { items: [{ label: "Empty" }] },
-		});
-		expect(result).toContain('href={"#"}');
-	});
-
-	it("sanitizes javascript: URLs in header dropdown sub-items", () => {
-		const result = generateAtlasLayoutTsx({
-			...BASE_INPUT,
-			header: {
-				items: [{ label: "Menu", items: [{ label: "Bad", url: "javascript:alert(1)" }] }],
-			},
-		});
-		expect(result).not.toMatch(/javascript:alert/i);
-		expect(result).toContain('href={"#"}');
-	});
-
-	it("falls back to legacy nav when header.items is empty", () => {
-		const result = generateAtlasLayoutTsx({
-			...BASE_INPUT,
-			nav: [{ label: "NavLink", href: "/nav" }],
-			header: { items: [] },
-		});
-		expect(result).toContain("NavLink");
-	});
-
-	// ── footer support ───────────────────────────────────────────────────────
+	// ── footer (semantic classes — pack CSS targets these) ───────────────────
 
 	it("renders default copyright footer when no footer config is set", () => {
 		const result = generateAtlasLayoutTsx(BASE_INPUT);
 		expect(result).toContain("<Footer>");
-		expect(result).toContain("new Date().getFullYear()");
+		expect(result).toContain("atlas-footer-masthead");
 	});
 
-	it("renders footer copyright text", () => {
+	it("emits atlas-footer wrapper class when footer config is set", () => {
 		const result = generateAtlasLayoutTsx({
 			...BASE_INPUT,
 			footer: { copyright: "2026 Acme Inc." },
 		});
-		expect(result).toContain("<Footer>");
-		expect(result).toContain('{"2026 Acme Inc."}');
+		expect(result).toContain('className="atlas-footer"');
+		expect(result).toContain('className="atlas-footer-bottom"');
+		expect(result).toContain('className="atlas-footer-masthead"');
+		expect(result).toContain('className="atlas-footer-copy"');
+		expect(result).toContain("2026 Acme Inc.");
 	});
 
-	it("renders footer columns with titles and links", () => {
+	it("emits atlas-footer-columns and atlas-footer-col classes for columns", () => {
 		const result = generateAtlasLayoutTsx({
 			...BASE_INPUT,
 			footer: {
 				columns: [
 					{
 						title: "Product",
-						links: [
-							{ label: "Pricing", url: "/pricing" },
-							{ label: "Docs", url: "/docs" },
-						],
+						links: [{ label: "Pricing", url: "/pricing" }],
 					},
 				],
 			},
 		});
-		expect(result).toContain('{"Product"}');
-		expect(result).toContain('{"Pricing"}');
-		expect(result).toContain('href={"/pricing"}');
+		expect(result).toContain('className="atlas-footer-columns"');
+		expect(result).toContain('className="atlas-footer-col"');
+		expect(result).toContain("Product");
+		expect(result).toContain('href="/pricing"');
 	});
 
 	it("renders footer social links in canonical platform order", () => {

--- a/cli/src/site/themes/atlas/Layout.ts
+++ b/cli/src/site/themes/atlas/Layout.ts
@@ -2,10 +2,6 @@
  * Atlas layout generator — produces `app/layout.tsx` for sites that pick
  * `theme.pack === "atlas"` in their `site.json`.
  *
- * Adapted from the SaaS Atlas layout, with the same SaaS-only bits stripped
- * as the Forge port (`ScopedNextraLayout`, auth banner, auth provider,
- * `filterAuthFromPageMap`).
- *
  * Atlas differs from Forge layout-wise in a handful of places:
  *   - logo lives only in the navbar (`.atlas-navbar-logo`) — no separate
  *     sidebar logo wrapper
@@ -24,15 +20,9 @@
  *   - `favicon`            → `<link rel="icon">` (top-level `favicon` wins)
  */
 
-import type {
-	DefaultThemeMode,
-	ExternalLink,
-	FontFamily,
-	FooterConfig,
-	HeaderConfig,
-	HeaderItem,
-	NavLink,
-} from "../../Types.js";
+import { sanitizeUrl } from "../../Sanitize.js";
+import type { DefaultThemeMode, FontFamily, FooterConfig, HeaderConfig, LogoDisplay } from "../../Types.js";
+import { buildAtlasFooterBody } from "../Footer.js";
 import { ATLAS_MANIFEST } from "./Manifest.js";
 
 // ─── Font config ─────────────────────────────────────────────────────────────
@@ -76,7 +66,6 @@ const FONT_CONFIG: Record<FontFamily, FontEntry> = {
 export interface AtlasLayoutInput {
 	title: string;
 	description: string;
-	nav: NavLink[];
 	header?: HeaderConfig;
 	footer?: FooterConfig;
 	primaryHue: number;
@@ -84,19 +73,14 @@ export interface AtlasLayoutInput {
 	fontFamily: FontFamily;
 	logoUrl?: string;
 	logoUrlDark?: string;
+	/** Optional override for the text shown alongside (or instead of) the logo image. Falls back to `title`. */
+	logoText?: string;
+	/** Override for the logo composition mode. See `LogoDisplay` in `Types.ts` for the auto-default rules. */
+	logoDisplay?: LogoDisplay;
 	favicon?: string;
 }
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
-
-/** See `themes/forge/Layout.ts` — same allow-list, same fail-closed default. */
-function sanitizeUrl(url: string): string {
-	const trimmed = url.trim();
-	if (trimmed === "" || /^(?:https?:|mailto:|tel:|[#?/]|\.\.?\/)/i.test(trimmed)) {
-		return trimmed;
-	}
-	return "#";
-}
 
 /**
  * Logo slot markup for the Atlas navbar. JSX-expression attributes
@@ -127,107 +111,37 @@ function buildLogoSlots(input: AtlasLayoutInput): { light: string; dark: string 
 }
 
 /**
- * Resolves the navbar's logical item list. `header.items` wins when set;
- * otherwise legacy `nav` is coerced into dropdown-less items.
+ * Resolves the effective `LogoDisplay` mode. See the matching helper in
+ * `themes/forge/Layout.ts` for the rules.
  */
-function resolveHeaderItems(input: AtlasLayoutInput): HeaderItem[] {
-	if (input.header?.items && input.header.items.length > 0) {
-		return input.header.items;
-	}
-	return input.nav.map((n) => ({ label: n.label, url: n.href }));
+function resolveLogoDisplay(input: AtlasLayoutInput): LogoDisplay {
+	if (input.logoDisplay === "image" && !input.logoUrl) return "text";
+	if (input.logoDisplay) return input.logoDisplay;
+	return input.logoUrl ? "both" : "text";
 }
 
-/** Renders a single header item — either an `<a>` or a `<details>` dropdown. */
-function renderNavbarChild(item: HeaderItem): string {
-	const jsLabel = JSON.stringify(item.label);
-	if (item.items && item.items.length > 0) {
-		const subLinks = item.items
-			.map((sub: ExternalLink) => {
-				const jsSubLabel = JSON.stringify(sub.label);
-				const jsSubHref = JSON.stringify(sanitizeUrl(sub.url));
-				return `              <a href={${jsSubHref}} style={{ display: 'block', padding: '0.25rem 0.75rem', whiteSpace: 'nowrap' }}>{${jsSubLabel}}</a>`;
-			})
-			.join("\n");
-		return [
-			`          <details style={{ marginLeft: '1rem', display: 'inline-block', position: 'relative' }}>`,
-			`            <summary style={{ cursor: 'pointer', listStyle: 'none' }}>{${jsLabel}}</summary>`,
-			`            <div style={{ position: 'absolute', top: '100%', left: 0, marginTop: '0.25rem', background: 'var(--nextra-bg, #fff)', border: '1px solid var(--nextra-border, #e5e7eb)', borderRadius: 4, padding: '0.25rem 0', minWidth: 160, zIndex: 10 }}>`,
-			subLinks,
-			`            </div>`,
-			`          </details>`,
-		].join("\n");
+/**
+ * Composes the navbar logo markup from light/dark image slots and a text
+ * template. `textTemplate` is a JSX snippet with the literal token `TEXT`
+ * where the logo text expression should be spliced.
+ */
+function composeLogoMarkup(
+	input: AtlasLayoutInput,
+	logoSlots: { light: string; dark: string },
+	textTemplate: string,
+): string {
+	const display = resolveLogoDisplay(input);
+	const logoText = input.logoText ?? input.title;
+	const textMarkup = textTemplate.replace("TEXT", JSON.stringify(logoText));
+	const imageMarkup = `${logoSlots.light}${logoSlots.dark}`;
+	switch (display) {
+		case "image":
+			return imageMarkup;
+		case "text":
+			return textMarkup;
+		default:
+			return `${imageMarkup}${textMarkup}`;
 	}
-	const jsHref = JSON.stringify(sanitizeUrl(item.url ?? "#"));
-	return `          <a href={${jsHref}} style={{ marginLeft: '1rem' }}>{${jsLabel}}</a>`;
-}
-
-/** Social platforms supported in the footer, in display order. */
-const SOCIAL_PLATFORMS = ["github", "twitter", "discord", "linkedin", "youtube"] as const;
-
-/** Builds the inner JSX of `<Footer>`, or `""` when there's nothing to render. */
-function buildFooterBody(footer: FooterConfig | undefined): string {
-	if (!footer) return "";
-
-	const hasColumns = footer.columns && footer.columns.length > 0;
-	const hasCopyright = typeof footer.copyright === "string" && footer.copyright.length > 0;
-	const socials = footer.socialLinks;
-	const socialEntries = socials
-		? SOCIAL_PLATFORMS.filter((p) => typeof socials[p] === "string" && socials[p] !== "")
-		: [];
-	const hasSocial = socialEntries.length > 0;
-
-	if (!hasColumns && !hasCopyright && !hasSocial) return "";
-
-	const blocks: string[] = [];
-
-	if (hasColumns) {
-		const columnsJsx = (footer.columns ?? [])
-			.map((col) => {
-				const jsTitle = JSON.stringify(col.title);
-				const links = col.links
-					.map((link: ExternalLink) => {
-						const jsLabel = JSON.stringify(link.label);
-						const jsHref = JSON.stringify(sanitizeUrl(link.url));
-						return `                <li><a href={${jsHref}}>{${jsLabel}}</a></li>`;
-					})
-					.join("\n");
-				return [
-					`            <div style={{ minWidth: 140 }}>`,
-					`              <h4 style={{ margin: '0 0 0.5rem', fontSize: '0.875rem', fontWeight: 600 }}>{${jsTitle}}</h4>`,
-					`              <ul style={{ listStyle: 'none', padding: 0, margin: 0 }}>`,
-					links,
-					`              </ul>`,
-					`            </div>`,
-				].join("\n");
-			})
-			.join("\n");
-		blocks.push(
-			`          <div style={{ display: 'flex', gap: '2rem', flexWrap: 'wrap', marginBottom: '1rem' }}>\n${columnsJsx}\n          </div>`,
-		);
-	}
-
-	if (hasCopyright || hasSocial) {
-		const bottom: string[] = [];
-		if (hasCopyright) {
-			const jsCopyright = JSON.stringify(footer.copyright);
-			bottom.push(`            <span>{${jsCopyright}}</span>`);
-		}
-		if (hasSocial && socials) {
-			const social = socialEntries
-				.map((p) => {
-					const jsHref = JSON.stringify(sanitizeUrl(socials[p] ?? ""));
-					const jsLabel = JSON.stringify(p);
-					return `              <a href={${jsHref}} aria-label={${jsLabel}}>{${jsLabel}}</a>`;
-				})
-				.join("\n");
-			bottom.push(`            <div style={{ display: 'flex', gap: '0.75rem' }}>\n${social}\n            </div>`);
-		}
-		blocks.push(
-			`          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', flexWrap: 'wrap', gap: '1rem' }}>\n${bottom.join("\n")}\n          </div>`,
-		);
-	}
-
-	return [`        <div style={{ width: '100%' }}>`, ...blocks, `        </div>`].join("\n");
 }
 
 // ─── generateAtlasLayoutTsx ──────────────────────────────────────────────────
@@ -235,7 +149,12 @@ function buildFooterBody(footer: FooterConfig | undefined): string {
 /**
  * Returns the full contents of `app/layout.tsx` for an Atlas-themed site.
  * Caller is responsible for writing `app/themes/atlas.css` (which this
+ * layout imports) and `components/ScopedNextraLayout.tsx` (which this
  * layout imports) — see `initNextraProject` in `NextraProjectWriter`.
+ *
+ * Navbar has only a logo (no children) — page tabs come from the root
+ * `_meta.js`. Sidebar scoping is handled by `<ScopedNextraLayout>` based
+ * on the URL.
  */
 export function generateAtlasLayoutTsx(input: AtlasLayoutInput): string {
 	const jsTitle = JSON.stringify(input.title);
@@ -247,24 +166,18 @@ export function generateAtlasLayoutTsx(input: AtlasLayoutInput): string {
 	const faviconLink = input.favicon ? `<link rel="icon" href={${JSON.stringify(sanitizeUrl(input.favicon))}} />` : "";
 
 	const logo = buildLogoSlots(input);
-	const logoMarkup = `${logo.light}${logo.dark}<span>{${jsTitle}}</span>`;
+	const logoMarkup = composeLogoMarkup(input, logo, "<span>{TEXT}</span>");
 
-	const headerItems = resolveHeaderItems(input);
-	const navLinks = headerItems.map(renderNavbarChild).join("\n");
-	const navbarChildren = headerItems.length > 0 ? `\n${navLinks}\n        ` : "";
+	const footerBody = buildAtlasFooterBody(input.title, input.footer);
+	const footerJsx = `<Footer>${footerBody}</Footer>`;
 
-	const footerBody = buildFooterBody(input.footer);
-	const footerJsx =
-		footerBody === ""
-			? `<Footer>{new Date().getFullYear()} © {${jsTitle}}</Footer>`
-			: `<Footer>\n${footerBody}\n      </Footer>`;
-
-	return `import { Footer, Layout, Navbar } from 'nextra-theme-docs'
+	return `import { Footer, Navbar } from 'nextra-theme-docs'
 import { Head } from 'nextra/components'
 import { getPageMap } from 'nextra/page-map'
 import 'nextra-theme-docs/style.css'
 import '../styles/api.css'
 import './themes/atlas.css'
+import ScopedNextraLayout from '../components/ScopedNextraLayout'
 
 export const metadata = {
   title: ${jsTitle},
@@ -277,7 +190,7 @@ const SiteLogo = () => (
   </span>
 )
 
-const navbar = <Navbar logo={<SiteLogo />}>${navbarChildren}</Navbar>
+const navbar = <Navbar logo={<SiteLogo />} />
 const footer = ${footerJsx}
 
 export default async function RootLayout({ children }: { children: React.ReactNode }) {
@@ -288,7 +201,7 @@ export default async function RootLayout({ children }: { children: React.ReactNo
         ${faviconLink}
       </Head>
       <body>
-        <Layout
+        <ScopedNextraLayout
           navbar={navbar}
           pageMap={await getPageMap()}
           footer={footer}
@@ -299,7 +212,7 @@ export default async function RootLayout({ children }: { children: React.ReactNo
           nextThemes={{ defaultTheme: ${jsDefaultTheme} }}
         >
           {children}
-        </Layout>
+        </ScopedNextraLayout>
       </body>
     </html>
   )
@@ -318,7 +231,6 @@ export default async function RootLayout({ children }: { children: React.ReactNo
 export function resolveAtlasLayoutInput(args: {
 	title: string;
 	description: string;
-	nav: NavLink[];
 	header?: HeaderConfig;
 	footer?: FooterConfig;
 	theme:
@@ -328,6 +240,8 @@ export function resolveAtlasLayoutInput(args: {
 				fontFamily?: FontFamily;
 				logoUrl?: string;
 				logoUrlDark?: string;
+				logoText?: string;
+				logoDisplay?: LogoDisplay;
 				favicon?: string;
 		  }
 		| undefined;
@@ -337,7 +251,6 @@ export function resolveAtlasLayoutInput(args: {
 	return {
 		title: args.title,
 		description: args.description,
-		nav: args.nav,
 		header: args.header,
 		footer: args.footer,
 		primaryHue: t.primaryHue ?? ATLAS_MANIFEST.defaults.primaryHue,
@@ -345,6 +258,8 @@ export function resolveAtlasLayoutInput(args: {
 		fontFamily: t.fontFamily ?? ATLAS_MANIFEST.defaults.fontFamily,
 		logoUrl: t.logoUrl,
 		logoUrlDark: t.logoUrlDark,
+		logoText: t.logoText,
+		logoDisplay: t.logoDisplay,
 		favicon: args.legacyFavicon ?? t.favicon,
 	};
 }

--- a/cli/src/site/themes/atlas/Manifest.ts
+++ b/cli/src/site/themes/atlas/Manifest.ts
@@ -4,8 +4,6 @@
  * Designed to feel materially different from Forge so users have a real
  * reason to pick. Top-nav layout (vs Forge's sidebar-dominant), serif
  * headlines, dark-default mode, airy spacing, masthead-style footer.
- *
- * Mirrors `ATLAS_MANIFEST` from the SaaS Atlas pack.
  */
 
 import type { DefaultThemeMode, FontFamily } from "../../Types.js";

--- a/cli/src/site/themes/forge/Css.ts
+++ b/cli/src/site/themes/forge/Css.ts
@@ -9,9 +9,8 @@
  * the end of the file so customer accent + sidebar/header bg overrides take
  * precedence via the cascade.
  *
- * Vendored from the SaaS Forge pack. The auth banner block has been stripped (CLI sites don't
- * have JWT auth) and the API-reference companion stylesheet (`buildApiCss`)
- * is intentionally not appended yet — it lands in a follow-up commit so the
+ * The API-reference companion stylesheet is written separately as
+ * `styles/api.css` and imported alongside this file from the layout, so
  * OpenAPI page styling can be reviewed in isolation.
  */
 
@@ -1297,9 +1296,9 @@ ${fontDecl}  --nextra-primary-hue:        ${hue};
 
 /**
  * Build the complete Forge stylesheet (base + customer overrides). The
- * API-reference companion stylesheet that the SaaS appends here is left out
- * for now; OpenAPI pages render with the default Nextra styling until the
- * follow-up commit ports `ApiCss` over.
+ * API-reference companion stylesheet is emitted separately as
+ * `styles/api.css` and imported alongside `themes/forge.css` from the
+ * layout, so the two stylesheets stay independently reviewable.
  */
 export function buildForgeCss(input: ForgeOverrideInput): string {
 	return FORGE_BASE_CSS + buildForgeOverrides(input);

--- a/cli/src/site/themes/forge/Layout.test.ts
+++ b/cli/src/site/themes/forge/Layout.test.ts
@@ -16,7 +16,6 @@ import { FORGE_MANIFEST } from "./Manifest.js";
 const BASE_INPUT = {
 	title: "Acme Docs",
 	description: "API reference + guides",
-	nav: [],
 	primaryHue: FORGE_MANIFEST.defaults.primaryHue,
 	defaultTheme: FORGE_MANIFEST.defaults.defaultTheme,
 	fontFamily: FORGE_MANIFEST.defaults.fontFamily,
@@ -29,7 +28,6 @@ describe("resolveForgeLayoutInput", () => {
 		const result = resolveForgeLayoutInput({
 			title: "T",
 			description: "D",
-			nav: [],
 			theme: undefined,
 			legacyFavicon: undefined,
 		});
@@ -42,7 +40,6 @@ describe("resolveForgeLayoutInput", () => {
 		const result = resolveForgeLayoutInput({
 			title: "T",
 			description: "D",
-			nav: [],
 			theme: { primaryHue: 200, defaultTheme: "dark", fontFamily: "source-serif" },
 			legacyFavicon: undefined,
 		});
@@ -55,7 +52,6 @@ describe("resolveForgeLayoutInput", () => {
 		const result = resolveForgeLayoutInput({
 			title: "T",
 			description: "D",
-			nav: [],
 			theme: { favicon: "/theme.ico" },
 			legacyFavicon: "/legacy.ico",
 		});
@@ -66,7 +62,6 @@ describe("resolveForgeLayoutInput", () => {
 		const result = resolveForgeLayoutInput({
 			title: "T",
 			description: "D",
-			nav: [],
 			theme: { favicon: "/theme.ico" },
 			legacyFavicon: undefined,
 		});
@@ -84,7 +79,6 @@ describe("resolveForgeLayoutInput", () => {
 		const result = resolveForgeLayoutInput({
 			title: "T",
 			description: "D",
-			nav: [],
 			header,
 			footer,
 			theme: undefined,
@@ -92,6 +86,18 @@ describe("resolveForgeLayoutInput", () => {
 		});
 		expect(result.header).toBe(header);
 		expect(result.footer).toBe(footer);
+	});
+
+	it("propagates theme.logoText and theme.logoDisplay to the resolved input", () => {
+		const result = resolveForgeLayoutInput({
+			title: "T",
+			description: "D",
+			theme: { logoText: "ACME", logoDisplay: "image", logoUrl: "/logo.svg" },
+			legacyFavicon: undefined,
+		});
+		expect(result.logoText).toBe("ACME");
+		expect(result.logoDisplay).toBe("image");
+		expect(result.logoUrl).toBe("/logo.svg");
 	});
 });
 
@@ -175,28 +181,64 @@ describe("generateForgeLayoutTsx", () => {
 		expect(result).toContain('<img src={"/dark.svg"}');
 	});
 
-	it("renders nav items as <a> children of <Navbar> alongside <ThemeSwitch />", () => {
-		const result = generateForgeLayoutTsx({
-			...BASE_INPUT,
-			nav: [
-				{ label: "Guides", href: "/guides" },
-				{ label: "GitHub", href: "https://github.com/acme" },
-			],
-		});
-		expect(result).toContain('href={"/guides"}');
-		expect(result).toContain('{"Guides"}');
-		expect(result).toContain('href={"https://github.com/acme"}');
-		expect(result).toContain('{"GitHub"}');
-		expect(result).toContain("<ThemeSwitch />");
+	it("uses logoText for the logo span when set, instead of title", () => {
+		const result = generateForgeLayoutTsx({ ...BASE_INPUT, logoText: "ACME" });
+		expect(result).toContain('<span>{"ACME"}</span>');
+		expect(result).not.toContain('<span>{"Acme Docs"}</span>');
 	});
 
-	it("sanitizes javascript: URLs in nav hrefs to '#'", () => {
+	it("logoDisplay='text' suppresses the image even when logoUrl is set", () => {
 		const result = generateForgeLayoutTsx({
 			...BASE_INPUT,
-			nav: [{ label: "Bad", href: "javascript:alert(1)" }],
+			logoUrl: "/logo.svg",
+			logoDisplay: "text",
 		});
-		expect(result).not.toMatch(/javascript:alert/i);
-		expect(result).toContain('<a href={"#"}');
+		expect(result).not.toContain("<img ");
+		expect(result).toContain('<span>{"Acme Docs"}</span>');
+	});
+
+	it("logoDisplay='image' suppresses the text span when logoUrl is set", () => {
+		const result = generateForgeLayoutTsx({
+			...BASE_INPUT,
+			logoUrl: "/logo.svg",
+			logoDisplay: "image",
+		});
+		expect(result).toContain("<img ");
+		// The forge-navbar-logo wrapper still wraps the image, but no inner <span> with the title text.
+		expect(result).not.toContain('<span>{"Acme Docs"}</span>');
+	});
+
+	it("logoDisplay='image' falls back to text when logoUrl is unset (avoids empty navbar logo)", () => {
+		const result = generateForgeLayoutTsx({ ...BASE_INPUT, logoDisplay: "image" });
+		expect(result).not.toContain("<img ");
+		expect(result).toContain('<span>{"Acme Docs"}</span>');
+	});
+
+	it("logoDisplay='both' renders image + text together", () => {
+		const result = generateForgeLayoutTsx({
+			...BASE_INPUT,
+			logoUrl: "/logo.svg",
+			logoText: "ACME",
+			logoDisplay: "both",
+		});
+		expect(result).toContain('<img src={"/logo.svg"}');
+		expect(result).toContain('<span>{"ACME"}</span>');
+	});
+
+	it("renders <Navbar> with only <ThemeSwitch /> as children — nav items go through _meta.js", () => {
+		const result = generateForgeLayoutTsx(BASE_INPUT);
+		// New architecture: nav items are NOT spliced into the layout JSX.
+		// MetaGenerator writes them to root _meta.js where Nextra renders
+		// them natively (chevron / hover / mobile drawer). The layout input
+		// no longer carries `nav` at all — enforced at the type level.
+		expect(result).toContain("<Navbar logo={<SiteLogo />}><ThemeSwitch /></Navbar>");
+	});
+
+	it("uses <ScopedNextraLayout> instead of vanilla <Layout>", () => {
+		const result = generateForgeLayoutTsx(BASE_INPUT);
+		expect(result).toContain("import ScopedNextraLayout from '../components/ScopedNextraLayout'");
+		expect(result).toContain("<ScopedNextraLayout");
+		expect(result).toContain("</ScopedNextraLayout>");
 	});
 
 	it("sanitizes javascript: URLs in favicon to '#'", () => {
@@ -220,79 +262,7 @@ describe("generateForgeLayoutTsx", () => {
 		expect(result).toContain('alt={"Acme \\"Tools\\""}');
 	});
 
-	// ── header.items support ─────────────────────────────────────────────────
-
-	it("prefers header.items over legacy nav when both are set", () => {
-		const result = generateForgeLayoutTsx({
-			...BASE_INPUT,
-			nav: [{ label: "FromNav", href: "/nav" }],
-			header: { items: [{ label: "FromHeader", url: "/header" }] },
-		});
-		expect(result).toContain("FromHeader");
-		expect(result).not.toContain("FromNav");
-	});
-
-	it("renders a <details> dropdown when a header item has sub-items", () => {
-		const result = generateForgeLayoutTsx({
-			...BASE_INPUT,
-			header: {
-				items: [
-					{
-						label: "Resources",
-						items: [
-							{ label: "Blog", url: "/blog" },
-							{ label: "Changelog", url: "/changelog" },
-						],
-					},
-				],
-			},
-		});
-		expect(result).toContain("<details");
-		expect(result).toContain("<summary");
-		expect(result).toContain('{"Resources"}');
-		expect(result).toContain('{"Blog"}');
-		expect(result).toContain('href={"/blog"}');
-	});
-
-	it("renders a direct link for header items without sub-items", () => {
-		const result = generateForgeLayoutTsx({
-			...BASE_INPUT,
-			header: { items: [{ label: "Docs", url: "/docs" }] },
-		});
-		expect(result).toContain('href={"/docs"}');
-		expect(result).toContain('{"Docs"}');
-		expect(result).not.toContain("<details");
-	});
-
-	it("falls back to '#' for header items with no url and no sub-items", () => {
-		const result = generateForgeLayoutTsx({
-			...BASE_INPUT,
-			header: { items: [{ label: "Empty" }] },
-		});
-		expect(result).toContain('href={"#"}');
-	});
-
-	it("sanitizes javascript: URLs in header dropdown sub-items", () => {
-		const result = generateForgeLayoutTsx({
-			...BASE_INPUT,
-			header: {
-				items: [{ label: "Menu", items: [{ label: "Bad", url: "javascript:alert(1)" }] }],
-			},
-		});
-		expect(result).not.toMatch(/javascript:alert/i);
-		expect(result).toContain('href={"#"}');
-	});
-
-	it("falls back to legacy nav when header.items is empty", () => {
-		const result = generateForgeLayoutTsx({
-			...BASE_INPUT,
-			nav: [{ label: "NavLink", href: "/nav" }],
-			header: { items: [] },
-		});
-		expect(result).toContain("NavLink");
-	});
-
-	// ── footer support ───────────────────────────────────────────────────────
+	// ── footer (semantic classes — pack CSS targets these) ───────────────────
 
 	it("renders default copyright footer when no footer config is set", () => {
 		const result = generateForgeLayoutTsx(BASE_INPUT);
@@ -300,53 +270,44 @@ describe("generateForgeLayoutTsx", () => {
 		expect(result).toContain("new Date().getFullYear()");
 	});
 
-	it("renders footer copyright text", () => {
+	it("emits forge-footer wrapper class when footer config is set", () => {
 		const result = generateForgeLayoutTsx({
 			...BASE_INPUT,
 			footer: { copyright: "2026 Acme Inc." },
 		});
-		expect(result).toContain("<Footer>");
-		expect(result).toContain('{"2026 Acme Inc."}');
+		expect(result).toContain('className="forge-footer"');
+		expect(result).toContain('className="forge-footer-bottom"');
+		expect(result).toContain('className="forge-footer-copyright"');
+		expect(result).toContain('className="forge-footer-powered"');
+		expect(result).toContain("2026 Acme Inc.");
 	});
 
-	it("renders footer columns with titles and links", () => {
+	it("emits forge-footer-columns and forge-footer-col classes for columns", () => {
 		const result = generateForgeLayoutTsx({
 			...BASE_INPUT,
 			footer: {
 				columns: [
 					{
 						title: "Product",
-						links: [
-							{ label: "Pricing", url: "/pricing" },
-							{ label: "Docs", url: "/docs" },
-						],
+						links: [{ label: "Pricing", url: "/pricing" }],
 					},
 				],
 			},
 		});
-		expect(result).toContain('{"Product"}');
-		expect(result).toContain('{"Pricing"}');
-		expect(result).toContain('href={"/pricing"}');
+		expect(result).toContain('className="forge-footer-columns"');
+		expect(result).toContain('className="forge-footer-col"');
+		expect(result).toContain("Product");
+		expect(result).toContain('href="/pricing"');
 	});
 
-	it("renders footer social links in canonical platform order", () => {
+	it("emits forge-footer-social wrapper for social-icon links", () => {
 		const result = generateForgeLayoutTsx({
 			...BASE_INPUT,
-			footer: { socialLinks: { youtube: "https://yt.example", github: "https://gh.example" } },
+			footer: { socialLinks: { github: "https://gh.example" } },
 		});
-		const ghIdx = result.indexOf("gh.example");
-		const ytIdx = result.indexOf("yt.example");
-		expect(ghIdx).toBeGreaterThan(-1);
-		expect(ytIdx).toBeGreaterThan(-1);
-		expect(ghIdx).toBeLessThan(ytIdx);
-	});
-
-	it("renders default copyright footer when footer has no content", () => {
-		const result = generateForgeLayoutTsx({
-			...BASE_INPUT,
-			footer: { columns: [], socialLinks: {} },
-		});
-		expect(result).toContain("new Date().getFullYear()");
+		expect(result).toContain('className="forge-footer-social"');
+		expect(result).toContain('className="forge-footer-social-github"');
+		expect(result).toContain("https://gh.example");
 	});
 
 	it("sanitizes javascript: URLs in footer links and social links", () => {
@@ -354,10 +315,10 @@ describe("generateForgeLayoutTsx", () => {
 			...BASE_INPUT,
 			footer: {
 				columns: [{ title: "X", links: [{ label: "Bad", url: "javascript:alert(1)" }] }],
-				socialLinks: { github: "data:text/html,evil" },
+				socialLinks: { github: "javascript:evil" },
 			},
 		});
 		expect(result).not.toContain("javascript:alert");
-		expect(result).not.toContain("data:text/html");
+		expect(result).not.toContain("javascript:evil");
 	});
 });

--- a/cli/src/site/themes/forge/Layout.ts
+++ b/cli/src/site/themes/forge/Layout.ts
@@ -2,13 +2,6 @@
  * Forge layout generator — produces `app/layout.tsx` for sites that pick
  * `theme.pack === "forge"` in their `site.json`.
  *
- * Adapted from the SaaS Forge layout, with the SaaS-only bits stripped:
- *
- *   - `ScopedNextraLayout` → vanilla `<Layout>` from `nextra-theme-docs`
- *   - `<AuthBanner>` / `<Auth0Provider>` slots removed (CLI sites are
- *     not multi-tenant and don't gate on JWT auth)
- *   - `filterAuthFromPageMap` removed (no `/auth` callback page)
- *
  * The Forge-specific wrapper elements (`.forge-sidebar-logo`,
  * `.forge-sidebar-search`, `.forge-navbar-logo`) are preserved verbatim
  * because Css.ts targets them.
@@ -24,15 +17,9 @@
  *                            for back-compat; `theme.favicon` is the fallback)
  */
 
-import type {
-	DefaultThemeMode,
-	ExternalLink,
-	FontFamily,
-	FooterConfig,
-	HeaderConfig,
-	HeaderItem,
-	NavLink,
-} from "../../Types.js";
+import { sanitizeUrl } from "../../Sanitize.js";
+import type { DefaultThemeMode, FontFamily, FooterConfig, HeaderConfig, LogoDisplay } from "../../Types.js";
+import { buildForgeFooterBody } from "../Footer.js";
 import { FORGE_MANIFEST } from "./Manifest.js";
 
 // ─── Font config ─────────────────────────────────────────────────────────────
@@ -75,7 +62,6 @@ const FONT_CONFIG: Record<FontFamily, FontEntry> = {
 export interface ForgeLayoutInput {
 	title: string;
 	description: string;
-	nav: NavLink[];
 	header?: HeaderConfig;
 	footer?: FooterConfig;
 	primaryHue: number;
@@ -83,23 +69,14 @@ export interface ForgeLayoutInput {
 	fontFamily: FontFamily;
 	logoUrl?: string;
 	logoUrlDark?: string;
+	/** Optional override for the text shown alongside (or instead of) the logo image. Falls back to `title`. */
+	logoText?: string;
+	/** Override for the logo composition mode. See `LogoDisplay` in `Types.ts` for the auto-default rules. */
+	logoDisplay?: LogoDisplay;
 	favicon?: string;
 }
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
-
-/**
- * Allow http(s), mailto, tel, fragments, query strings, and relative paths.
- * Anything else (`javascript:`, `data:`, `vbscript:`) is replaced with `"#"`
- * so a malicious site.json can't smuggle a script URL into the layout.
- */
-function sanitizeUrl(url: string): string {
-	const trimmed = url.trim();
-	if (trimmed === "" || /^(?:https?:|mailto:|tel:|[#?/]|\.\.?\/)/i.test(trimmed)) {
-		return trimmed;
-	}
-	return "#";
-}
 
 /**
  * Logo slot markup used in both the navbar logo + sidebar logo positions.
@@ -131,107 +108,44 @@ function buildLogoSlots(input: ForgeLayoutInput): { light: string; dark: string 
 }
 
 /**
- * Resolves the navbar's logical item list. `header.items` wins when set;
- * otherwise legacy `nav` is coerced into dropdown-less items.
+ * Resolves the effective `LogoDisplay` mode for an input. When the customer
+ * sets `logoDisplay` explicitly, that wins. Otherwise the legacy auto-default
+ * applies — `"both"` if `logoUrl` is set, `"text"` otherwise — so existing
+ * site.json files render unchanged.
+ *
+ * Special case: `display: "image"` with no `logoUrl` configured falls back to
+ * `"text"`. Rendering an empty navbar logo would be a worse UX than honouring
+ * the customer's intent partially.
  */
-function resolveHeaderItems(input: ForgeLayoutInput): HeaderItem[] {
-	if (input.header?.items && input.header.items.length > 0) {
-		return input.header.items;
-	}
-	return input.nav.map((n) => ({ label: n.label, url: n.href }));
+function resolveLogoDisplay(input: ForgeLayoutInput): LogoDisplay {
+	if (input.logoDisplay === "image" && !input.logoUrl) return "text";
+	if (input.logoDisplay) return input.logoDisplay;
+	return input.logoUrl ? "both" : "text";
 }
 
-/** Renders a single header item — either an `<a>` or a `<details>` dropdown. */
-function renderNavbarChild(item: HeaderItem): string {
-	const jsLabel = JSON.stringify(item.label);
-	if (item.items && item.items.length > 0) {
-		const subLinks = item.items
-			.map((sub: ExternalLink) => {
-				const jsSubLabel = JSON.stringify(sub.label);
-				const jsSubHref = JSON.stringify(sanitizeUrl(sub.url));
-				return `              <a href={${jsSubHref}} style={{ display: 'block', padding: '0.25rem 0.75rem', whiteSpace: 'nowrap' }}>{${jsSubLabel}}</a>`;
-			})
-			.join("\n");
-		return [
-			`          <details style={{ marginLeft: '1rem', display: 'inline-block', position: 'relative' }}>`,
-			`            <summary style={{ cursor: 'pointer', listStyle: 'none' }}>{${jsLabel}}</summary>`,
-			`            <div style={{ position: 'absolute', top: '100%', left: 0, marginTop: '0.25rem', background: 'var(--nextra-bg, #fff)', border: '1px solid var(--nextra-border, #e5e7eb)', borderRadius: 4, padding: '0.25rem 0', minWidth: 160, zIndex: 10 }}>`,
-			subLinks,
-			`            </div>`,
-			`          </details>`,
-		].join("\n");
+/**
+ * Builds the inner markup for the logo slot. `textTemplate` is a JSX snippet
+ * with the literal token `TEXT` where the logo text expression should be
+ * spliced — Forge / Atlas / default each use different element wrappers, so
+ * the caller passes the wrapper and this helper handles the composition.
+ */
+function composeLogoMarkup(
+	input: ForgeLayoutInput,
+	logoSlots: { light: string; dark: string },
+	textTemplate: string,
+): string {
+	const display = resolveLogoDisplay(input);
+	const logoText = input.logoText ?? input.title;
+	const textMarkup = textTemplate.replace("TEXT", JSON.stringify(logoText));
+	const imageMarkup = `${logoSlots.light}${logoSlots.dark}`;
+	switch (display) {
+		case "image":
+			return imageMarkup;
+		case "text":
+			return textMarkup;
+		default:
+			return `${imageMarkup}${textMarkup}`;
 	}
-	const jsHref = JSON.stringify(sanitizeUrl(item.url ?? "#"));
-	return `          <a href={${jsHref}} style={{ marginLeft: '1rem' }}>{${jsLabel}}</a>`;
-}
-
-/** Social platforms supported in the footer, in display order. */
-const SOCIAL_PLATFORMS = ["github", "twitter", "discord", "linkedin", "youtube"] as const;
-
-/** Builds the inner JSX of `<Footer>`, or `""` when there's nothing to render. */
-function buildFooterBody(footer: FooterConfig | undefined): string {
-	if (!footer) return "";
-
-	const hasColumns = footer.columns && footer.columns.length > 0;
-	const hasCopyright = typeof footer.copyright === "string" && footer.copyright.length > 0;
-	const socials = footer.socialLinks;
-	const socialEntries = socials
-		? SOCIAL_PLATFORMS.filter((p) => typeof socials[p] === "string" && socials[p] !== "")
-		: [];
-	const hasSocial = socialEntries.length > 0;
-
-	if (!hasColumns && !hasCopyright && !hasSocial) return "";
-
-	const blocks: string[] = [];
-
-	if (hasColumns) {
-		const columnsJsx = (footer.columns ?? [])
-			.map((col) => {
-				const jsTitle = JSON.stringify(col.title);
-				const links = col.links
-					.map((link: ExternalLink) => {
-						const jsLabel = JSON.stringify(link.label);
-						const jsHref = JSON.stringify(sanitizeUrl(link.url));
-						return `                <li><a href={${jsHref}}>{${jsLabel}}</a></li>`;
-					})
-					.join("\n");
-				return [
-					`            <div style={{ minWidth: 140 }}>`,
-					`              <h4 style={{ margin: '0 0 0.5rem', fontSize: '0.875rem', fontWeight: 600 }}>{${jsTitle}}</h4>`,
-					`              <ul style={{ listStyle: 'none', padding: 0, margin: 0 }}>`,
-					links,
-					`              </ul>`,
-					`            </div>`,
-				].join("\n");
-			})
-			.join("\n");
-		blocks.push(
-			`          <div style={{ display: 'flex', gap: '2rem', flexWrap: 'wrap', marginBottom: '1rem' }}>\n${columnsJsx}\n          </div>`,
-		);
-	}
-
-	if (hasCopyright || hasSocial) {
-		const bottom: string[] = [];
-		if (hasCopyright) {
-			const jsCopyright = JSON.stringify(footer.copyright);
-			bottom.push(`            <span>{${jsCopyright}}</span>`);
-		}
-		if (hasSocial && socials) {
-			const social = socialEntries
-				.map((p) => {
-					const jsHref = JSON.stringify(sanitizeUrl(socials[p] ?? ""));
-					const jsLabel = JSON.stringify(p);
-					return `              <a href={${jsHref}} aria-label={${jsLabel}}>{${jsLabel}}</a>`;
-				})
-				.join("\n");
-			bottom.push(`            <div style={{ display: 'flex', gap: '0.75rem' }}>\n${social}\n            </div>`);
-		}
-		blocks.push(
-			`          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', flexWrap: 'wrap', gap: '1rem' }}>\n${bottom.join("\n")}\n          </div>`,
-		);
-	}
-
-	return [`        <div style={{ width: '100%' }}>`, ...blocks, `        </div>`].join("\n");
 }
 
 // ─── generateForgeLayoutTsx ──────────────────────────────────────────────────
@@ -239,7 +153,13 @@ function buildFooterBody(footer: FooterConfig | undefined): string {
 /**
  * Returns the full contents of `app/layout.tsx` for a Forge-themed site.
  * Caller is responsible for writing `app/themes/forge.css` (which this
+ * layout imports) and `components/ScopedNextraLayout.tsx` (which this
  * layout imports) — see `initNextraProject` in `NextraProjectWriter`.
+ *
+ * Navbar children are reduced to `<ThemeSwitch />` only — page tabs come
+ * from the root `_meta.js` (Nextra renders them natively with chevron /
+ * hover / mobile drawer styling). Sidebar scoping is handled by
+ * `<ScopedNextraLayout>` based on the URL.
  */
 export function generateForgeLayoutTsx(input: ForgeLayoutInput): string {
 	const jsTitle = JSON.stringify(input.title);
@@ -251,25 +171,18 @@ export function generateForgeLayoutTsx(input: ForgeLayoutInput): string {
 	const faviconLink = input.favicon ? `<link rel="icon" href={${JSON.stringify(sanitizeUrl(input.favicon))}} />` : "";
 
 	const logo = buildLogoSlots(input);
-	const logoMarkup = `${logo.light}${logo.dark}<span>{${jsTitle}}</span>`;
+	const logoMarkup = composeLogoMarkup(input, logo, "<span>{TEXT}</span>");
 
-	const headerItems = resolveHeaderItems(input);
-	const navLinks = headerItems.map(renderNavbarChild).join("\n");
-	const navbarChildren =
-		headerItems.length > 0 ? `\n${navLinks}\n          <ThemeSwitch />\n        ` : "<ThemeSwitch />";
+	const footerBody = buildForgeFooterBody(input.title, input.footer);
+	const footerJsx = `<Footer>${footerBody}</Footer>`;
 
-	const footerBody = buildFooterBody(input.footer);
-	const footerJsx =
-		footerBody === ""
-			? `<Footer>{new Date().getFullYear()} © {${jsTitle}}</Footer>`
-			: `<Footer>\n${footerBody}\n      </Footer>`;
-
-	return `import { Footer, Layout, Navbar, ThemeSwitch } from 'nextra-theme-docs'
+	return `import { Footer, Navbar, ThemeSwitch } from 'nextra-theme-docs'
 import { Head, Search } from 'nextra/components'
 import { getPageMap } from 'nextra/page-map'
 import 'nextra-theme-docs/style.css'
 import '../styles/api.css'
 import './themes/forge.css'
+import ScopedNextraLayout from '../components/ScopedNextraLayout'
 
 export const metadata = {
   title: ${jsTitle},
@@ -282,7 +195,7 @@ const SiteLogo = () => (
   </span>
 )
 
-const navbar = <Navbar logo={<SiteLogo />}>${navbarChildren}</Navbar>
+const navbar = <Navbar logo={<SiteLogo />}><ThemeSwitch /></Navbar>
 const footer = ${footerJsx}
 
 export default async function RootLayout({ children }: { children: React.ReactNode }) {
@@ -303,7 +216,7 @@ export default async function RootLayout({ children }: { children: React.ReactNo
           <Search placeholder="Search…" />
         </div>
 
-        <Layout
+        <ScopedNextraLayout
           navbar={navbar}
           pageMap={await getPageMap()}
           footer={footer}
@@ -313,7 +226,7 @@ export default async function RootLayout({ children }: { children: React.ReactNo
           nextThemes={{ defaultTheme: ${jsDefaultTheme} }}
         >
           {children}
-        </Layout>
+        </ScopedNextraLayout>
       </body>
     </html>
   )
@@ -335,7 +248,6 @@ export default async function RootLayout({ children }: { children: React.ReactNo
 export function resolveForgeLayoutInput(args: {
 	title: string;
 	description: string;
-	nav: NavLink[];
 	header?: HeaderConfig;
 	footer?: FooterConfig;
 	theme:
@@ -345,6 +257,8 @@ export function resolveForgeLayoutInput(args: {
 				fontFamily?: FontFamily;
 				logoUrl?: string;
 				logoUrlDark?: string;
+				logoText?: string;
+				logoDisplay?: LogoDisplay;
 				favicon?: string;
 		  }
 		| undefined;
@@ -354,7 +268,6 @@ export function resolveForgeLayoutInput(args: {
 	return {
 		title: args.title,
 		description: args.description,
-		nav: args.nav,
 		header: args.header,
 		footer: args.footer,
 		primaryHue: t.primaryHue ?? FORGE_MANIFEST.defaults.primaryHue,
@@ -362,6 +275,8 @@ export function resolveForgeLayoutInput(args: {
 		fontFamily: t.fontFamily ?? FORGE_MANIFEST.defaults.fontFamily,
 		logoUrl: t.logoUrl,
 		logoUrlDark: t.logoUrlDark,
+		logoText: t.logoText,
+		logoDisplay: t.logoDisplay,
 		favicon: args.legacyFavicon ?? t.favicon,
 	};
 }

--- a/cli/src/site/themes/forge/Manifest.ts
+++ b/cli/src/site/themes/forge/Manifest.ts
@@ -2,11 +2,6 @@
  * Forge theme pack manifest — declares the pack's identity and the defaults
  * applied when a customer-overridable field on `theme` (in `site.json`) is
  * absent.
- *
- * Mirrors `FORGE_MANIFEST` from the SaaS Forge pack. Customer fields the CLI doesn't surface yet (e.g.
- * `requiredPackages` for SaaS deploy validation) are omitted — the CLI runs
- * `npm install` against the same `nextra-theme-docs` deps the default pack
- * already declares in `package.json`.
  */
 
 import type { DefaultThemeMode, FontFamily } from "../../Types.js";


### PR DESCRIPTION
## Summary

Brings the CLI's layout pipeline up to feature parity with the broader site-generation surface so a single `site.json` renders consistently, and the existing pack stylesheets that ship on this branch finally have matching DOM to style.

Closes the visible parity gaps that surfaced during testing.

## Motivation

User testing surfaced six overlapping issues, each with a different root cause:

1. `branding.themePack: "forge"` — schema mismatch with the canonical `theme.*` shape.
2. `branding.defaultTheme: "system"` was ignored — default layout didn't pass `nextThemes`.
3. Logo and favicon files referenced via `/assets/logo.svg` 404'd despite existing — `ContentMirror` copied images only to `content/`, not `public/`.
4. API Reference navbar dropdown rendered as raw `<details>` JSX with no chevron — layouts rendered `header.items` as custom JSX instead of feeding Nextra's native page-tab mechanism.
5. Forge / Atlas footer spacing looked wrong — pack stylesheets target `.{prefix}-footer-*` classes; layouts emitted inline-style flex JSX so the CSS matched no DOM.
6. Sidebar showed docs entries when navigating into `/api-{spec}/...` — no per-URL pageMap scoping.

## What's in this PR

### Schema aliasing (read-time, downstream code unchanged)

- `branding.*` is read as a deprecated alias for `theme.*`. Mapping covers `themePack`, `logo.{text,image,imageDark,display}`, `favicon`, `colors.primaryHue`, `fontFamily`, `defaultTheme`. `theme.*` wins on conflict so single-field overrides still work.
- `footer.social` is read as an alias for `footer.socialLinks`.

### New schema fields under `theme`

- **`theme.logoText`** — overrides the navbar logo text. Defaults to site `title`.
- **`theme.logoDisplay`** — `"text"` | `"image"` | `"both"`. Auto-defaults preserve prior visual output. `"image"` with no `logoUrl` falls back to text.

### Architectural refactor — navbar, sidebar, and footer

This is the bulk of the change and the part that fixes the visible bugs:

**Layouts strip the JSX nav-children path entirely.** Forge emits `<Navbar logo={<SiteLogo />}><ThemeSwitch /></Navbar>`; Atlas / default emit `<Navbar logo={<SiteLogo />} />`. Page tabs come from the root `content/_meta.js` and Nextra renders them natively — chevron on dropdowns, hover styling, mobile drawer integration all built-in.

**`MetaGenerator.injectRootNavEntries` writes the auto-entries.** Detected OpenAPI specs produce `__documentation` + `__api-reference` keys at the root `_meta.js`:

- 1 spec → direct link to `/api-{slug}`
- 2+ specs → `type: "menu"` dropdown with one sub-entry per spec, plus `display: "hidden"` per-spec page tabs that `<ScopedNextraLayout>` un-hides on demand
- User-supplied header items with a clashing label (case-insensitive match on `Documentation` / `API` / `API Reference`) suppress the matching auto-injection — customer overrides win
- Customer `header.items` are materialised as Nextra page-tab entries with slug-derived keys (`nav-{slug}`) so reordering doesn't churn the generated `_meta.js`. Duplicate-label entries auto-disambiguate.

**`<ScopedNextraLayout>` client wrapper.** New `cli/src/site/ScopePageMap.ts` carries the pure pageMap-filter; `writeScopedNextraLayoutComponent` emits a client-side wrapper around Nextra's `<Layout>` that filters by URL. Sidebar scopes cleanly to either docs or the active spec.

**Semantic footer classes.** New `cli/src/site/themes/Footer.ts` provides `buildForgeFooterBody` / `buildAtlasFooterBody` / `buildFooterScaffold` / `renderFooterColumns` / `renderSocialLinks`. Pack footers now emit `.{prefix}-footer-columns`, `.{prefix}-footer-col`, `.{prefix}-footer-bottom`, `.{prefix}-footer-copyright`, `.{prefix}-footer-social`, `.{prefix}-footer-powered` — class names the existing pack CSS already targets.

### Default-layout parity with Forge / Atlas

- Now passes `nextThemes={{ defaultTheme }}` to `<Layout>` so `theme.defaultTheme` is actually honored. Was silently ignored.
- Now emits `<link rel="icon">` from `theme.favicon` (or legacy top-level `favicon`). Was emitting nothing.
- Renders `theme.logoUrl` / `logoUrlDark` (was a typed-but-ignored gap — fields existed on the type, layouts ignored them).
- Wraps content in `<ScopedNextraLayout>` like the pack themes.

### Asset bundling fix

`ContentMirror` now copies image files to **both** `<build>/content/<rel>` (where Nextra's webpack staticImage resolver picks up relative refs in markdown) and `<build>/public/<rel>` (where Next.js serves browser-absolute paths). Previously only the `content/` copy was made, so `theme.logoUrl: "/assets/logo.svg"` pointing at a file in the source folder 404'd in the browser.

### Security and DRY consolidation

- New `cli/src/site/Sanitize.ts` consolidates `sanitizeUrl` + `escapeHtml` into one module. Five duplicated copies (across `themes/forge/Layout.ts`, `themes/atlas/Layout.ts`, `themes/Footer.ts`, `NextraProjectWriter.ts`) collapsed to one. A future tightening of the URL allow-list happens once.
- Sanitisation now applied at every URL emission point — including the `_meta.js` writer (closes a gap where `header.items[].url: "javascript:alert(1)"` was written through unsanitised). All URL-emitting paths fail-closed to `"#"` for non-allowlisted schemes.
- `sanitizeUrl` now explicitly rejects scheme-relative URLs (`//evil.com/x`) — they previously slipped through the leading-`/` check. A malicious `site.json` with `header.items: [{ url: "//evil.com" }]` could otherwise have rendered `<a href="//evil.com">` (same-protocol cross-origin redirect) or `<img src="//evil.com">` (referrer exfiltration).

## Files

| File | Change |
|---|---|
| `cli/src/site/Types.ts` | `BrandingConfig` + `BrandingLogoConfig` + `LogoDisplay` types. `branding?` on `SiteJson`, `social?` alias on `FooterConfig`, `logoText` / `logoDisplay` on `ThemeConfig` |
| `cli/src/site/SiteJsonReader.ts` | `coerceBrandingToTheme` + `coerceFooterSocialAlias` run on site.json load |
| `cli/src/site/Sanitize.ts` (new) | Consolidated `sanitizeUrl` + `escapeHtml` |
| `cli/src/site/ScopePageMap.ts` (new) | Pure `scopePageMap` runtime filter + parity-tested string source |
| `cli/src/site/MetaGenerator.ts` | `RootInjectionInput` type + `injectRootNavEntries` + `DOC_HOME_NAV_KEY` / `OPENAPI_NAV_KEY` constants |
| `cli/src/site/ContentMirror.ts` | Image case mirrors to both `contentDir` and `publicDir` |
| `cli/src/site/NextraProjectWriter.ts` | `writeScopedNextraLayoutComponent` emits the client wrapper. Default layout: `<ScopedNextraLayout>`, `nextThemes`, favicon link, logo composition with dark-mode swap. Adds `NEXTRA_OVERRIDES` (zod ~4.3.0) so Nextra's `LayoutPropsSchema` doesn't reject `children` on fresh installs |
| `cli/src/site/EngineManager.ts` | Engine deps-hash now includes `NEXTRA_OVERRIDES` so a version change triggers an engine reinstall |
| `cli/src/site/themes/Footer.ts` (new) | Footer scaffold helpers (Forge + Atlas pack-prefixed semantic classes) |
| `cli/src/site/themes/forge/Layout.ts` | Drops JSX nav-children rendering; uses `<ScopedNextraLayout>`; `buildForgeFooterBody` |
| `cli/src/site/themes/atlas/Layout.ts` | Same surgery as Forge |
| `cli/src/site/renderer/SiteRenderer.ts` + `NextraRenderer.ts` | `generateNavigation` accepts `RootInjectionInput` |
| `cli/src/commands/StartCommand.ts` | `syncContent` builds `RootInjectionInput` from detected specs + customer `header.items` and passes it through to `generateNavigation` |
| `cli/docs/site-json-reference.md` | Documents `branding` / `footer.social` aliases, `theme.logoText` / `logoDisplay`, and the `_meta.js`-driven navbar architecture |
| `CLAUDE.md` | New `Site generation: layout, navbar, and footer architecture` section |

Deleted: `cli/src/site/HeaderInjection.ts` + test (superseded by `MetaGenerator.injectRootNavEntries`).

## Backwards compatibility

No existing `site.json` field is renamed or repurposed:

- `branding` block ignored by code that reads `theme` only — coercion runs at load, downstream callers see the canonical shape they always saw.
- `logoDisplay` unset → `"both"` if `logoUrl` is set, `"text"` otherwise (matches prior behavior).
- `logoText` unset → falls back to `title`.
- `nextThemes.defaultTheme` defaults to `"system"` matching Nextra's prior implicit default.
- API navbar injection skipped on sites with no OpenAPI specs.
- `header.items` no longer renders as raw JSX, but the same data shape produces equivalent (and visually better) output via Nextra's native page-tab rendering — chevron on dropdowns, hover, mobile drawer all come from Nextra natively.
- Existing image refs to `Content_Folder/foo.png` keep working — they continue to land in `content/` (and now also in `public/`).
