### PR TITLE
Part of fix/code-exchange: Add code-exchange flow to JolliAuthService

### DIFF
--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/auth/JolliAuthUtils.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/auth/JolliAuthUtils.kt
@@ -1,0 +1,52 @@
+package ai.jolli.jollimemory.auth
+
+import ai.jolli.jollimemory.services.JolliApiClient
+import java.net.URI
+
+/**
+ * Shared auth helpers for the IntelliJ plugin — Kotlin port of
+ * `cli/src/core/JolliApiUtils.ts`.
+ */
+object JolliAuthUtils {
+
+	private val ALLOWED_JOLLI_HOSTS = listOf("jolli.ai", "jolli.dev", "jolli.cloud", "jolli-local.me")
+
+	/**
+	 * Validates a Jolli API key: decodes it and checks the embedded origin
+	 * against the allowlist. Mirrors the CLI's `validateJolliApiKey`.
+	 */
+	fun validateJolliApiKey(key: String) {
+		val meta = JolliApiClient.parseJolliApiKey(key)
+			?: throw IllegalArgumentException(
+				"Rejected Jolli API key: cannot be decoded. Paste the key exactly as issued by Jolli.",
+			)
+		assertJolliOriginAllowed(meta.u)
+	}
+
+	/**
+	 * Rejects origins that are not on the Jolli allowlist (HTTPS-only,
+	 * suffix-boundary match). Mirrors the CLI's `assertJolliOriginAllowed`.
+	 */
+	fun assertJolliOriginAllowed(origin: String) {
+		val uri: URI
+		try {
+			uri = URI.create(origin)
+		} catch (_: Exception) {
+			throw IllegalArgumentException("Rejected Jolli origin (unparseable): $origin")
+		}
+
+		val scheme = uri.scheme?.lowercase()
+		val host = uri.host?.lowercase().orEmpty()
+		val ok = scheme == "https" &&
+			host.isNotEmpty() &&
+			ALLOWED_JOLLI_HOSTS.any { h -> host == h || host.endsWith(".$h") }
+
+		if (!ok) {
+			throw IllegalArgumentException(
+				"Rejected Jolli origin \"$origin\". " +
+					"Only https://*.jolli.ai, https://*.jolli.dev, https://*.jolli.cloud, " +
+					"and https://*.jolli-local.me are permitted.",
+			)
+		}
+	}
+}

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/services/JolliAuthService.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/services/JolliAuthService.kt
@@ -1,15 +1,22 @@
 package ai.jolli.jollimemory.services
 
+import ai.jolli.jollimemory.auth.JolliAuthUtils
 import ai.jolli.jollimemory.auth.JolliConfigStore
 import ai.jolli.jollimemory.auth.JolliUrlConfig
 import ai.jolli.jollimemory.core.JmLogger
-import ai.jolli.jollimemory.core.JolliMemoryConfig
 import ai.jolli.jollimemory.core.SessionTracker
+import com.google.gson.Gson
+import com.google.gson.JsonObject
 import com.intellij.ide.BrowserUtil
 import com.intellij.openapi.Disposable
 import com.sun.net.httpserver.HttpServer
 import java.net.InetSocketAddress
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
 import java.security.SecureRandom
+import java.time.Duration
 import java.util.concurrent.Executors
 import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.ScheduledFuture
@@ -117,30 +124,54 @@ object JolliAuthService {
                         sendHtml(exchange, html, 400)
                         onError(message)
                     } else {
-                        val token = params["token"]
-                        val space = params["space"]
-                        val jolliApiKey = params["jolli_api_key"]
+                        val code = params["code"]
+                        val legacyToken = params["token"]
 
-                        if (token.isNullOrBlank()) {
-                            val html = errorHtml("No token received from server.")
-                            sendHtml(exchange, html, 400)
-                            onError("No token received from server.")
-                        } else {
-                            val globalDir = SessionTracker.getGlobalConfigDir()
-                            val existing = SessionTracker.loadConfigFromDir(globalDir)
-                            SessionTracker.saveConfigToDir(existing.copy(
-                                authToken = token,
-                                jolliApiKey = if (!jolliApiKey.isNullOrBlank()) jolliApiKey else existing.jolliApiKey,
-                            ), globalDir)
-                            if (!space.isNullOrBlank()) {
-                                JolliConfigStore.saveSpace(space)
+                        val result: LoginResult = if (!code.isNullOrBlank()) {
+                            // JOLLI-1270 code-exchange (preferred)
+                            try {
+                                exchangeCode(jolliUrl, code)
+                            } catch (e: Exception) {
+                                val msg = e.message ?: "Code exchange failed"
+                                sendHtml(exchange, errorHtml(msg), 400)
+                                onError(msg)
+                                shutdown()
+                                return@createContext
                             }
-
-                            val html = successHtml()
-                            sendHtml(exchange, html, 200)
-                            notifyAuthListeners()
-                            onSuccess(LoginResult(token, space, jolliApiKey))
+                        } else if (!legacyToken.isNullOrBlank()) {
+                            // Legacy token-in-URL fallback for pre-1270 servers
+                            log.warn("Using legacy token-in-URL callback — server has not been upgraded to code-exchange (JOLLI-1270).")
+                            LoginResult(
+                                token = legacyToken,
+                                space = params["space"],
+                                jolliApiKey = params["jolli_api_key"],
+                            )
+                        } else {
+                            val msg = "No authorization code or token received from server."
+                            sendHtml(exchange, errorHtml(msg), 400)
+                            onError(msg)
+                            shutdown()
+                            return@createContext
                         }
+
+                        if (!result.jolliApiKey.isNullOrBlank()) {
+                            JolliAuthUtils.validateJolliApiKey(result.jolliApiKey)
+                        }
+
+                        val globalDir = SessionTracker.getGlobalConfigDir()
+                        val existing = SessionTracker.loadConfigFromDir(globalDir)
+                        SessionTracker.saveConfigToDir(existing.copy(
+                            authToken = result.token,
+                            jolliApiKey = if (!result.jolliApiKey.isNullOrBlank()) result.jolliApiKey else existing.jolliApiKey,
+                        ), globalDir)
+                        if (!result.space.isNullOrBlank()) {
+                            JolliConfigStore.saveSpace(result.space)
+                        }
+
+                        val html = successHtml()
+                        sendHtml(exchange, html, 200)
+                        notifyAuthListeners()
+                        onSuccess(result)
                     }
                 } catch (e: Exception) {
                     log.warn("Callback error: ${e.message}")
@@ -198,11 +229,77 @@ object JolliAuthService {
         }
     }
 
+    /**
+     * Exchanges a single-use authorization code for credentials via POST to
+     * `/api/auth/cli-exchange`. Mirrors the CLI's `exchangeCliCode()`.
+     */
+    internal fun exchangeCode(jolliUrl: String, code: String): LoginResult {
+        JolliAuthUtils.assertJolliOriginAllowed(jolliUrl)
+        val parsed = URI.create(jolliUrl)
+        val origin = if (parsed.port != -1) "${parsed.scheme}://${parsed.host}:${parsed.port}" else "${parsed.scheme}://${parsed.host}"
+        val tenantSlug = (parsed.path ?: "").split('/').firstOrNull { it.isNotEmpty() }
+
+        val exchangeUrl = "$origin/api/auth/cli-exchange"
+        val requestBody = Gson().toJson(mapOf("code" to code))
+        val requestBuilder = HttpRequest.newBuilder()
+            .uri(URI.create(exchangeUrl))
+            .header("content-type", "application/json")
+            .timeout(Duration.ofSeconds(20))
+            .POST(HttpRequest.BodyPublishers.ofString(requestBody))
+
+        if (tenantSlug != null) {
+            requestBuilder.header("x-tenant-slug", tenantSlug)
+        }
+
+        val response: HttpResponse<String>
+        try {
+            response = HttpClient.newHttpClient()
+                .send(requestBuilder.build(), HttpResponse.BodyHandlers.ofString())
+        } catch (e: java.net.http.HttpTimeoutException) {
+            throw RuntimeException("Sign-in timed out after 20s waiting for Jolli. Please try again.")
+        } catch (e: Exception) {
+            throw RuntimeException("Couldn't reach Jolli to complete sign-in: ${e.message}")
+        }
+
+        if (response.statusCode() == 404) {
+            throw RuntimeException("Sign-in code expired or already used. Please try signing in again.")
+        }
+        if (response.statusCode() !in 200..299) {
+            throw RuntimeException("Sign-in failed (HTTP ${response.statusCode()}).")
+        }
+
+        val payload: JsonObject
+        try {
+            payload = Gson().fromJson(response.body(), JsonObject::class.java)
+        } catch (e: Exception) {
+            throw RuntimeException("Sign-in failed: server returned malformed response (${e.message}).")
+        }
+
+        val token = payload.get("token")?.takeIf { it.isJsonPrimitive }?.asString
+        if (token.isNullOrBlank()) {
+            throw RuntimeException("Sign-in failed: server response did not include a token.")
+        }
+
+        val jolliApiKey = payload.get("jolliApiKey")?.takeIf { it.isJsonPrimitive }?.asString
+        val space = payload.get("space")?.takeIf { it.isJsonPrimitive }?.asString
+
+        log.info("cli-exchange completed (apiKey present: %s, space: %s)", jolliApiKey != null, space ?: "<none>")
+        return LoginResult(token = token, space = space, jolliApiKey = jolliApiKey)
+    }
+
     internal fun getErrorMessage(code: String): String = when (code) {
         "access_denied" -> "Access was denied. Please try again."
         "invalid_request" -> "Invalid login request. Please try again."
         "server_error" -> "Server error during login. Please try again later."
         "temporarily_unavailable" -> "Service temporarily unavailable. Please try again later."
+        "oauth_failed" -> "OAuth authentication failed. Please try again."
+        "session_missing" -> "Session expired or missing. Please try again."
+        "invalid_provider" -> "Invalid authentication provider."
+        "auth_fetch_failed" -> "Failed to fetch user information from the authentication provider."
+        "no_verified_emails" -> "No verified email addresses found on your account."
+        "failed_to_get_token" -> "We couldn't retrieve your credentials. Please try signing in again."
+        "user_denied" -> "Sign-in was cancelled. You can try again from Settings."
+        "invalid_callback" -> "The sign-in callback was rejected by the server. Please try again."
         else -> "Login failed: $code"
     }
 

--- a/intellij/src/test/kotlin/ai/jolli/jollimemory/auth/JolliAuthUtilsTest.kt
+++ b/intellij/src/test/kotlin/ai/jolli/jollimemory/auth/JolliAuthUtilsTest.kt
@@ -1,0 +1,123 @@
+package ai.jolli.jollimemory.auth
+
+import io.kotest.matchers.string.shouldContain
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
+import java.util.Base64
+
+class JolliAuthUtilsTest {
+
+    /** Builds a sk-jol- key with the given embedded URL. */
+    private fun fakeKey(url: String): String {
+        val meta = """{"t":"tenant","u":"$url"}"""
+        val encoded = Base64.getUrlEncoder().withoutPadding().encodeToString(meta.toByteArray())
+        return "sk-jol-$encoded.fakesecret"
+    }
+
+    @Test
+    fun `accepts https jolli-ai`() {
+        assertDoesNotThrow { JolliAuthUtils.assertJolliOriginAllowed("https://jolli.ai") }
+    }
+
+    @Test
+    fun `accepts https subdomain of jolli-ai`() {
+        assertDoesNotThrow { JolliAuthUtils.assertJolliOriginAllowed("https://app.jolli.ai") }
+    }
+
+    @Test
+    fun `accepts https jolli-dev`() {
+        assertDoesNotThrow { JolliAuthUtils.assertJolliOriginAllowed("https://jolli.dev") }
+    }
+
+    @Test
+    fun `accepts https subdomain of jolli-dev`() {
+        assertDoesNotThrow { JolliAuthUtils.assertJolliOriginAllowed("https://foo.jolli.dev") }
+    }
+
+    @Test
+    fun `accepts https jolli-cloud`() {
+        assertDoesNotThrow { JolliAuthUtils.assertJolliOriginAllowed("https://jolli.cloud") }
+    }
+
+    @Test
+    fun `accepts https jolli-local-me`() {
+        assertDoesNotThrow { JolliAuthUtils.assertJolliOriginAllowed("https://jolli-local.me") }
+    }
+
+    @Test
+    fun `accepts https subdomain of jolli-local-me`() {
+        assertDoesNotThrow { JolliAuthUtils.assertJolliOriginAllowed("https://dev.jolli-local.me") }
+    }
+
+    @Test
+    fun `rejects http even for allowlisted host`() {
+        val ex = assertThrows<IllegalArgumentException> {
+            JolliAuthUtils.assertJolliOriginAllowed("http://jolli.ai")
+        }
+        ex.message shouldContain "Rejected Jolli origin"
+    }
+
+    @Test
+    fun `rejects non-allowlisted host`() {
+        val ex = assertThrows<IllegalArgumentException> {
+            JolliAuthUtils.assertJolliOriginAllowed("https://evil.com")
+        }
+        ex.message shouldContain "Rejected Jolli origin"
+    }
+
+    @Test
+    fun `rejects suffix trick`() {
+        val ex = assertThrows<IllegalArgumentException> {
+            JolliAuthUtils.assertJolliOriginAllowed("https://notjolli.ai")
+        }
+        ex.message shouldContain "Rejected Jolli origin"
+    }
+
+    @Test
+    fun `rejects allowlisted host embedded in attacker domain`() {
+        val ex = assertThrows<IllegalArgumentException> {
+            JolliAuthUtils.assertJolliOriginAllowed("https://jolli.ai.evil.com")
+        }
+        ex.message shouldContain "Rejected Jolli origin"
+    }
+
+    @Test
+    fun `rejects unparseable origin`() {
+        val ex = assertThrows<IllegalArgumentException> {
+            JolliAuthUtils.assertJolliOriginAllowed("not a url")
+        }
+        ex.message shouldContain "unparseable"
+    }
+
+    // --- validateJolliApiKey tests ---
+
+    @Test
+    fun `validateJolliApiKey accepts key with allowlisted origin`() {
+        assertDoesNotThrow { JolliAuthUtils.validateJolliApiKey(fakeKey("https://jolli.ai")) }
+    }
+
+    @Test
+    fun `validateJolliApiKey rejects key with non-allowlisted origin`() {
+        val ex = assertThrows<IllegalArgumentException> {
+            JolliAuthUtils.validateJolliApiKey(fakeKey("https://evil.com"))
+        }
+        ex.message shouldContain "Rejected Jolli origin"
+    }
+
+    @Test
+    fun `validateJolliApiKey rejects undecodable key`() {
+        val ex = assertThrows<IllegalArgumentException> {
+            JolliAuthUtils.validateJolliApiKey("sk-jol-notbase64")
+        }
+        ex.message shouldContain "cannot be decoded"
+    }
+
+    @Test
+    fun `validateJolliApiKey rejects non-jolli key`() {
+        val ex = assertThrows<IllegalArgumentException> {
+            JolliAuthUtils.validateJolliApiKey("sk-other-abc123")
+        }
+        ex.message shouldContain "cannot be decoded"
+    }
+}

--- a/intellij/src/test/kotlin/ai/jolli/jollimemory/services/JolliAuthServiceTest.kt
+++ b/intellij/src/test/kotlin/ai/jolli/jollimemory/services/JolliAuthServiceTest.kt
@@ -1,7 +1,9 @@
 package ai.jolli.jollimemory.services
 
+import ai.jolli.jollimemory.auth.JolliAuthUtils
 import ai.jolli.jollimemory.core.JolliMemoryConfig
 import ai.jolli.jollimemory.core.SessionTracker
+import com.sun.net.httpserver.HttpServer
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 import io.mockk.every
@@ -11,6 +13,8 @@ import io.mockk.unmockkObject
 import io.mockk.verify
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.net.InetSocketAddress
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
@@ -73,6 +77,7 @@ class JolliAuthServiceTest {
     @AfterEach
     fun tearDown() {
         try { unmockkObject(SessionTracker) } catch (_: Exception) {}
+        try { unmockkObject(JolliAuthUtils) } catch (_: Exception) {}
     }
 
     @Test
@@ -106,6 +111,182 @@ class JolliAuthServiceTest {
 
         notified shouldBe true
         disposable.dispose()
+    }
+
+    // --- getErrorMessage tests for new error codes ---
+
+    @Test
+    fun `getErrorMessage returns messages for JOLLI-1270 error codes`() {
+        JolliAuthService.getErrorMessage("oauth_failed") shouldContain "OAuth"
+        JolliAuthService.getErrorMessage("session_missing") shouldContain "Session"
+        JolliAuthService.getErrorMessage("no_verified_emails") shouldContain "verified email"
+        JolliAuthService.getErrorMessage("user_denied") shouldContain "cancelled"
+        JolliAuthService.getErrorMessage("invalid_callback") shouldContain "rejected"
+        JolliAuthService.getErrorMessage("failed_to_get_token") shouldContain "credentials"
+        JolliAuthService.getErrorMessage("auth_fetch_failed") shouldContain "fetch"
+        JolliAuthService.getErrorMessage("invalid_provider") shouldContain "provider"
+    }
+
+    // --- exchangeCode tests ---
+
+    /** Bypasses origin allowlist so tests can use http://127.0.0.1. */
+    private fun allowLocalOrigins() {
+        mockkObject(JolliAuthUtils)
+        every { JolliAuthUtils.assertJolliOriginAllowed(any()) } returns Unit
+    }
+
+    /** Starts a local HTTP server that responds with the given status and body. */
+    private fun startFakeExchangeServer(statusCode: Int, body: String): HttpServer {
+        val server = HttpServer.create(InetSocketAddress("127.0.0.1", 0), 0)
+        server.createContext("/api/auth/cli-exchange") { exchange ->
+            val bytes = body.toByteArray(Charsets.UTF_8)
+            exchange.sendResponseHeaders(statusCode, bytes.size.toLong())
+            exchange.responseBody.use { it.write(bytes) }
+        }
+        server.start()
+        return server
+    }
+
+    @Test
+    fun `exchangeCode returns token and optional fields on success`() {
+        allowLocalOrigins()
+        val server = startFakeExchangeServer(200, """{"token":"jwt-abc","jolliApiKey":"sk-jol-123","space":"my-space"}""")
+        try {
+            val result = JolliAuthService.exchangeCode("http://127.0.0.1:${server.address.port}", "test-code")
+            result.token shouldBe "jwt-abc"
+            result.jolliApiKey shouldBe "sk-jol-123"
+            result.space shouldBe "my-space"
+        } finally {
+            server.stop(0)
+        }
+    }
+
+    @Test
+    fun `exchangeCode returns token when optional fields are absent`() {
+        allowLocalOrigins()
+        val server = startFakeExchangeServer(200, """{"token":"jwt-only"}""")
+        try {
+            val result = JolliAuthService.exchangeCode("http://127.0.0.1:${server.address.port}", "test-code")
+            result.token shouldBe "jwt-only"
+            result.jolliApiKey shouldBe null
+            result.space shouldBe null
+        } finally {
+            server.stop(0)
+        }
+    }
+
+    @Test
+    fun `exchangeCode throws on 404 (expired code)`() {
+        allowLocalOrigins()
+        val server = startFakeExchangeServer(404, """{"error":"not_found"}""")
+        try {
+            val ex = assertThrows<RuntimeException> {
+                JolliAuthService.exchangeCode("http://127.0.0.1:${server.address.port}", "expired-code")
+            }
+            ex.message shouldContain "expired or already used"
+        } finally {
+            server.stop(0)
+        }
+    }
+
+    @Test
+    fun `exchangeCode throws on non-OK status`() {
+        allowLocalOrigins()
+        val server = startFakeExchangeServer(500, """{"error":"internal"}""")
+        try {
+            val ex = assertThrows<RuntimeException> {
+                JolliAuthService.exchangeCode("http://127.0.0.1:${server.address.port}", "some-code")
+            }
+            ex.message shouldContain "HTTP 500"
+        } finally {
+            server.stop(0)
+        }
+    }
+
+    @Test
+    fun `exchangeCode throws on missing token in response`() {
+        allowLocalOrigins()
+        val server = startFakeExchangeServer(200, """{"jolliApiKey":"sk-jol-123"}""")
+        try {
+            val ex = assertThrows<RuntimeException> {
+                JolliAuthService.exchangeCode("http://127.0.0.1:${server.address.port}", "some-code")
+            }
+            ex.message shouldContain "did not include a token"
+        } finally {
+            server.stop(0)
+        }
+    }
+
+    @Test
+    fun `exchangeCode throws on malformed JSON response`() {
+        allowLocalOrigins()
+        val server = startFakeExchangeServer(200, "not json at all")
+        try {
+            val ex = assertThrows<RuntimeException> {
+                JolliAuthService.exchangeCode("http://127.0.0.1:${server.address.port}", "some-code")
+            }
+            ex.message shouldContain "malformed response"
+        } finally {
+            server.stop(0)
+        }
+    }
+
+    @Test
+    fun `exchangeCode throws on network error`() {
+        allowLocalOrigins()
+        // Connect to a port with nothing listening
+        val ex = assertThrows<RuntimeException> {
+            JolliAuthService.exchangeCode("http://127.0.0.1:1", "some-code")
+        }
+        ex.message shouldContain "Couldn't reach Jolli"
+    }
+
+    @Test
+    fun `exchangeCode sends tenant slug header for path-based URLs`() {
+        allowLocalOrigins()
+        var receivedSlug: String? = null
+        val server = HttpServer.create(InetSocketAddress("127.0.0.1", 0), 0)
+        server.createContext("/api/auth/cli-exchange") { exchange ->
+            receivedSlug = exchange.requestHeaders.getFirst("x-tenant-slug")
+            val body = """{"token":"jwt-abc"}""".toByteArray(Charsets.UTF_8)
+            exchange.sendResponseHeaders(200, body.size.toLong())
+            exchange.responseBody.use { it.write(body) }
+        }
+        server.start()
+        try {
+            JolliAuthService.exchangeCode("http://127.0.0.1:${server.address.port}/dev", "test-code")
+            receivedSlug shouldBe "dev"
+        } finally {
+            server.stop(0)
+        }
+    }
+
+    @Test
+    fun `exchangeCode does not send tenant slug for root URLs`() {
+        allowLocalOrigins()
+        var receivedSlug: String? = "should-be-null"
+        val server = HttpServer.create(InetSocketAddress("127.0.0.1", 0), 0)
+        server.createContext("/api/auth/cli-exchange") { exchange ->
+            receivedSlug = exchange.requestHeaders.getFirst("x-tenant-slug")
+            val body = """{"token":"jwt-abc"}""".toByteArray(Charsets.UTF_8)
+            exchange.sendResponseHeaders(200, body.size.toLong())
+            exchange.responseBody.use { it.write(body) }
+        }
+        server.start()
+        try {
+            JolliAuthService.exchangeCode("http://127.0.0.1:${server.address.port}", "test-code")
+            receivedSlug shouldBe null
+        } finally {
+            server.stop(0)
+        }
+    }
+
+    @Test
+    fun `exchangeCode rejects non-allowlisted origin`() {
+        val ex = assertThrows<IllegalArgumentException> {
+            JolliAuthService.exchangeCode("https://evil.com", "some-code")
+        }
+        ex.message shouldContain "Rejected Jolli origin"
     }
 
     // --- login timeout test ---


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## E2E Test (4)
<details>
<summary><strong>1. Sign-in completes successfully after browser approval</strong></summary>
<br>
<blockquote>

**Preconditions:** Have the IntelliJ plugin installed and be signed out. Ensure you have a working internet connection and valid account credentials.

**Steps:**
1. Open IntelliJ and click the JolliMemory plugin icon or go to Settings and find the JolliMemory sign-in option.
2. Click "Sign In" to start the login flow — your browser should open automatically to the Jolli login page.
3. In the browser, approve access when prompted (log in with your account if needed and click "Allow" or "Authorize").
4. Switch back to IntelliJ and wait a few seconds.
5. Check that the plugin no longer shows a loading or "waiting" state.
6. Verify that your account name or a "signed in" indicator appears in the plugin panel.

**Expected Results:**
- The browser shows a success page after you approve access.
- IntelliJ does not show a timeout error or "couldn't reach Jolli" message.
- The plugin panel shows you as signed in, with no error dialogs appearing.

</blockquote>
</details>
<details>
<summary><strong>2. Expired or already-used sign-in link shows a clear error</strong></summary>
<br>
<blockquote>

**Preconditions:** Have the IntelliJ plugin installed and be signed out.

**Steps:**
1. Start the sign-in flow in IntelliJ by clicking "Sign In" — your browser opens to the Jolli login page.
2. Do not complete the login in the browser. Instead, wait several minutes (or close and restart the sign-in flow to generate a fresh link, making the first one stale).
3. Go back to the original browser tab with the old login link and try to approve access there.
4. Switch back to IntelliJ and observe what message appears.

**Expected Results:**
- The plugin displays an error message indicating the sign-in code has expired or was already used.
- The message prompts you to try signing in again.
- No crash or blank/frozen state occurs — the plugin remains usable so you can start a new sign-in attempt.

</blockquote>
</details>
<details>
<summary><strong>3. Cancelled sign-in shows a friendly message</strong></summary>
<br>
<blockquote>

**Preconditions:** Have the IntelliJ plugin installed and be signed out.

**Steps:**
1. Click "Sign In" in the JolliMemory plugin panel — your browser opens to the Jolli login page.
2. On the authorization page in the browser, click "Deny", "Cancel", or close the approval dialog without approving.
3. Switch back to IntelliJ and observe the message shown in the plugin.

**Expected Results:**
- The plugin displays a message along the lines of "Sign-in was cancelled. You can try again from Settings."
- No generic or cryptic error code is shown to you.
- The plugin remains usable and you can attempt to sign in again.

</blockquote>
</details>
<details>
<summary><strong>4. Sign-in error messages are human-readable for all failure types</strong></summary>
<br>
<blockquote>

**Preconditions:** Have access to a test or staging Jolli environment where specific error conditions (such as unverified email, invalid provider, or session expiry) can be triggered during login.

**Steps:**
1. Attempt to sign in using an account that has no verified email address on file, and observe the error message shown in IntelliJ.
2. Attempt to sign in using an unsupported or misconfigured authentication provider, and observe the error message.
3. Trigger a session-expiry scenario (for example, by letting a login session time out on the server side) and observe the error message.
4. For each case, check that the message shown is plain English with a clear explanation.

**Expected Results:**
- The "no verified email" error shows a message mentioning verified email addresses, not a raw code like "no_verified_emails".
- The "invalid provider" error shows a message mentioning the authentication provider.
- The "session expired" error shows a message mentioning the session and prompts you to try again.
- In all cases, the message is readable by a non-technical user with no error codes or jargon visible.

</blockquote>
</details>

---

## Topics (3)
<details>
<summary><strong>01 · Add secure code-exchange login flow to IntelliJ plugin auth</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The IntelliJ plugin's sign-in flow was broken: after the user approved access in the browser, the plugin would hang and eventually show a timeout error saying it couldn't reach Jolli to complete sign-in. The callback was arriving correctly, but the second step of exchanging the authorization code for credentials was failing.

**💡 Decisions Behind the Code**

- **Same URL for login and exchange**: The plugin uses the same `jolliUrl` for both opening the browser login page and POSTing the code exchange, mirroring the CLI and VSCode extension. In production, the frontend and API share a host, so this works without a separate config value. Local environments where the frontend and backend are on different ports require pointing `JOLLI_URL` at the backend or using a deployed URL.
- **Legacy token fallback**: Rather than dropping support for pre-JOLLI-1270 servers, the callback handler falls back to the old `?token=` path with a warning log, keeping the plugin compatible with older server deployments.
- **Blocking HTTP call accepted**: The exchange POST uses a synchronous `HttpClient.send()` on the callback thread, matching the CLI's pattern. This is acceptable because only one callback is expected per login flow.

**✅ What Was Implemented**

- Added `exchangeCode()` to `JolliAuthService.kt`: POSTs the single-use code to `/api/auth/cli-exchange` with a 20-second timeout, parses the JSON response, and returns a `LoginResult`; includes tenant-slug header support for path-based URLs.
- Rewrote the callback handler to prefer `?code=` (JOLLI-1270 secure path) and fall back to `?token=` (legacy) with a warning log, then unified the credential-saving logic into a single branch.
- Extended `getErrorMessage()` with eight new error codes introduced by the code-exchange flow (`oauth_failed`, `session_missing`, `no_verified_emails`, `user_denied`, `invalid_callback`, `failed_to_get_token`, `auth_fetch_failed`, `invalid_provider`).

**📁 FILES**
- `intellij/src/main/kotlin/ai/jolli/jollimemory/services/JolliAuthService.kt`
- `intellij/src/test/kotlin/ai/jolli/jollimemory/services/JolliAuthServiceTest.kt`

</blockquote>
</details>
<details>
<summary><strong>02 · Add unit tests for code-exchange flow and new error codes</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The new code-exchange logic needed test coverage to verify correct behavior across success, failure, and edge-case scenarios.

**💡 Decisions Behind the Code**

A real embedded HTTP server was used for `exchangeCode` tests rather than mocking the HTTP client, so the full request/response cycle — including header inspection and status code handling — is exercised without faking internal implementation details.

**✅ What Was Implemented**

- Added a `startFakeExchangeServer()` helper that spins up a local HTTP server on a random port to simulate the exchange endpoint.
- Added eight `exchangeCode` tests covering: success with all fields, success with optional fields absent, 404 (expired code), non-OK status, missing token in response, malformed JSON, network error, and tenant-slug header presence/absence.
- Added `getErrorMessage` tests asserting human-readable strings for all eight new JOLLI-1270 error codes.

**📁 FILES**
- `intellij/src/test/kotlin/ai/jolli/jollimemory/services/JolliAuthServiceTest.kt`

</blockquote>
</details>
<details>
<summary><strong>03 · Remove unused import and debug log line from auth service</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

During a code review, an unused import and a temporary debug log line were identified in the auth service and flagged for cleanup before merging.

**💡 Decisions Behind the Code**

Both removals were straightforward cleanup with no alternatives considered.

**✅ What Was Implemented**

- Removed the unused `JolliMemoryConfig` import from `JolliAuthService.kt`.
- Removed the debug log line that printed the code prefix during the exchange flow.

**📁 FILES**
- `intellij/src/main/kotlin/ai/jolli/jollimemory/services/JolliAuthService.kt`

</blockquote>
</details>

---

*Generated by JolliMemory · May 6, 2026 at 6:21 PM*
<!-- jollimemory-summary-end -->