### PR TITLE
Add onboarding panel and auto-enable with durable opt-out

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ Monorepo with three deliverables that share the same product model and storage (
 
 - `cli/` — `@jolli.ai/cli` (npm workspace, Node 22.5+, ESM, Vite multi-entry lib build). Standalone command-line tool plus all git/agent hook scripts.
 - `vscode/` — `jollimemory-vscode` extension (npm workspace, esbuild → CJS). Bundles the CLI and hook scripts into its own `dist/` so it has **no dependency on a global CLI install**.
-- `intellij/` — separate Gradle/Kotlin project (JDK 21). Independent build, but installs the same git/agent hooks and writes to the same orphan branch + `~/.jolli/jollimemory/` state.
+- `intellij/` — separate Gradle/Kotlin project (JDK 21). Independent build, but installs the same git/agent hooks and writes to the same shared state: the orphan branch, the machine-global `~/.jolli/jollimemory/` (config + hook entry scripts), and the per-project `<projectDir>/.jolli/jollimemory/` (sessions, cursors, queue, …).
 
 Root `package.json` only coordinates the two npm workspaces; it does not touch `intellij/`. Use `.nvmrc` (currently `24.10.0`) for the Node version.
 
@@ -57,13 +57,18 @@ IntelliJ plugin: `cd intellij && ./gradlew build` (or `runIde` for a sandbox). S
 
 The product is built on a hook pipeline that runs in the user's project, not in this repo:
 
-1. **AI agent hooks** (Claude `StopHook` / `SessionStartHook`, Gemini `AfterAgent`) only record session metadata to `~/.jolli/jollimemory/sessions.json`. They do not read transcripts, do not call the LLM, and run with `async: true` so they never block the agent. Codex and OpenCode have no hook — they're discovered by scanning `~/.codex/sessions/` or reading `~/.local/share/opencode/opencode.db` (Node 22.5+ `node:sqlite`, lazy-imported and feature-gated; the VSCode bundle targets Node 18 and tolerates the missing module).
+1. **AI agent hooks** (Claude `StopHook` / `SessionStartHook`, Gemini `AfterAgent`) only record session metadata to `<projectDir>/.jolli/jollimemory/sessions.json`. They do not read transcripts, do not call the LLM, and run with `async: true` so they never block the agent. Codex and OpenCode have no hook — they're discovered by scanning `~/.codex/sessions/` or reading `~/.local/share/opencode/opencode.db` (Node 22.5+ `node:sqlite`, lazy-imported and feature-gated; the VSCode bundle targets Node 18 and tolerates the missing module).
 
 2. **Git hooks** drive a unified queue under `.jolli/jollimemory/git-op-queue/`. `post-commit` is synchronous (<5 ms) and only enqueues + spawns a detached `QueueWorker`; the worker holds a 5-min file lock, drains entries in timestamp order, runs the LLM where needed, and chain-spawns a successor if new entries appear after it finishes. Squash and rebase entries skip the LLM and just merge/migrate existing summaries. `prepare-commit-msg` writes `squash-pending.json` so the worker recognizes squash before deciding whether to call the LLM. See [`cli/DEVELOPMENT.md`](cli/DEVELOPMENT.md) for the queue rationale (each op gets its own file precisely because the previous single-slot pending files lost summaries during rapid amend/rebase sequences).
 
-### Storage: orphan branch + `~/.jolli/jollimemory/`
+### Storage: orphan branch + two `.jolli/jollimemory/` dirs
 
-Summaries live on the git orphan branch `jollimemory/summaries/v3` in the user's repo and are written via plumbing only — the branch is **never checked out**. Read with `git show <branch>:<path>`; write with `hash-object` + `mktree` + `commit-tree` + `update-ref`. Local non-summary state (sessions, cursors, config, locks, queue, dist-path indirection) lives under `~/.jolli/jollimemory/`.
+Summaries live on the git orphan branch `jollimemory/summaries/v3` in the user's repo and are written via plumbing only — the branch is **never checked out**. Read with `git show <branch>:<path>`; write with `hash-object` + `mktree` + `commit-tree` + `update-ref`.
+
+Local non-summary state is split across **two** `.jolli/jollimemory/` directories — don't conflate them:
+
+- `~/.jolli/jollimemory/` — **machine-global**: `config.json` (authToken / apiKey), `dist-paths/` (per-source dist-path indirection), `run-hook` / `run-cli` / `resolve-dist-path` hook entry scripts. Resolved by `getGlobalConfigDir()`.
+- `<projectDir>/.jolli/jollimemory/` — **per-project, gitignored**: `sessions.json`, `cursors.json`, `git-op-queue/`, `notes/`, `plans.json`, `briefing-cache.json`, `debug.log`, and the manual-disable marker (VS Code). Resolved by `getJolliMemoryDir(cwd)` in [`cli/src/Logger.ts`](cli/src/Logger.ts).
 
 ### VS Code extension bundles the CLI
 

--- a/docs/superpowers/plans/2026-05-07-vscode-improve-login-ux.md
+++ b/docs/superpowers/plans/2026-05-07-vscode-improve-login-ux.md
@@ -1,0 +1,677 @@
+# VS Code Onboarding Panel + Auto-Enable Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** In the VS Code extension, (1) auto-install Jolli Memory hooks on first activation but persistently honour an explicit user opt-out, and (2) replace the bare "disabled-banner" with an onboarding panel that promotes the Anthropic-API-key path as the recommended option while keeping Jolli sign-in as a secondary alternative.
+
+**Architecture:**
+- **Persistence:** The opt-out is a marker file at `<projectDir>/.jolli/jollimemory/disabled-by-user` — sibling of `sessions.json` / `cursors.json` / `git-op-queue/`, gitignored via the existing `.jolli/` rule. The file's *existence* is the boolean (the body holds an ISO timestamp purely for human debugging). `disableJolliMemory` writes the file; `enableJolliMemory` removes it. Encapsulated in [`vscode/src/services/ManualDisableFlag.ts`](../../../vscode/src/services/ManualDisableFlag.ts) so the CLI and IntelliJ surfaces can adopt the same marker later without diverging. (Earlier draft used `vscode.ExtensionContext.workspaceState`; that bound the opt-out to VS Code's per-machine workspaceStorage, so reinstalling VS Code or moving the project dir silently dropped the user's intent — the marker file fixes that.)
+- **Auto-enable trigger:** End of `activate()`, after `refreshStatusBar()` resolves the actual `enabled` value. If `!enabled && !manuallyDisabled`, the extension awaits `bridge.enable()` and re-runs `refreshStatusBar()`. This piggybacks on the existing enable command path so all stores stay in sync.
+- **Onboarding visibility:** A new derived field `configured = signedIn || hasApiKey` rides on the existing `SidebarState` snapshot pushed to the webview. The webview shows the onboarding panel iff `configured === false` (independent of `enabled`); otherwise the existing tab UI renders. The legacy `disabled-banner` inside the Status tab is preserved for the `enabled === false && configured === true` edge case.
+- **Onboarding actions:** "Configure API Key" (primary, recommended) runs `jollimemory.openSettings` (existing) so users land on the SettingsWebviewPanel they already know — no inline input mirror of the IntelliJ design, since reusing the settings page is simpler and matches the way every other API-key-style config is captured today. "Sign In / Sign Up" (secondary) runs `jollimemory.signIn` (existing OAuth flow).
+
+**Tech Stack:** TypeScript (ESM in `cli/`, esbuild-bundled CJS in `vscode/`), Vitest, vscode webview (CSP-strict, `.hidden` class for visibility), existing CSS/HTML/Script three-builder pattern in `vscode/src/views/Sidebar*Builder.ts`.
+
+---
+
+## File structure
+
+**New files:** none.
+
+**Modified files:**
+- `vscode/src/Extension.ts`
+  - `activate()` end-of-init: read `workspaceState.get("jollimemory.manuallyDisabled")`, conditionally call `bridge.enable()` once.
+  - `enableJolliMemory` command: set `manuallyDisabled = false`.
+  - `disableJolliMemory` command: set `manuallyDisabled = true` (before the async `bridge.disable()` so the opt-out is durable even if uninstall fails).
+- `vscode/src/views/SidebarMessages.ts`
+  - Extend `SidebarState` with `readonly configured: boolean`.
+- `vscode/src/views/SidebarWebviewProvider.ts`
+  - Add `configured` to the serialized state snapshot, computed from the StatusStore derived flags (`signedIn || hasApiKey`).
+  - Re-push state from existing auth and status listeners (already fire on sign-in/sign-out and config save).
+- `vscode/src/views/SidebarHtmlBuilder.ts`
+  - Add the onboarding-panel skeleton (`#onboarding-panel`) as a sibling of `#tab-bar` and `#tab-content-*`, hidden by default via `.hidden`.
+- `vscode/src/views/SidebarCssBuilder.ts`
+  - Add the onboarding-panel styles: card surface, RECOMMENDED badge, blue accent button, secondary outlined button, OR divider.
+- `vscode/src/views/SidebarScriptBuilder.ts`
+  - Toggle `#onboarding-panel` vs `#tab-bar`/`#tab-toolbar`/`#tab-content-*` based on `state.configured`.
+  - Wire the two onboarding buttons to `vscode.postMessage` outbound `command` actions.
+
+**Tests modified:**
+- `vscode/src/Extension.test.ts` — auto-enable + manualDisable persistence tests.
+- `vscode/src/views/SidebarHtmlBuilder.test.ts` — assert onboarding skeleton present, hidden by default.
+- `vscode/src/views/SidebarScriptBuilder.test.ts` — assert show/hide behaviour gated on `configured`.
+- `vscode/src/views/SidebarWebviewProvider.test.ts` — assert serialized state includes `configured` derived from auth + apiKey.
+
+---
+
+## Task 1: SidebarState gains `configured` field (host-side)
+
+**Files:**
+- Modify: `vscode/src/views/SidebarMessages.ts:21-50`
+- Modify: `vscode/src/views/SidebarWebviewProvider.ts` (the serializer that builds the state pushed to webview)
+- Test: `vscode/src/views/SidebarWebviewProvider.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+In `vscode/src/views/SidebarWebviewProvider.test.ts`, add to the existing `describe("serialize state")` group:
+
+```typescript
+it("derives configured=true when signedIn", () => {
+    const state = buildSidebarState({
+        enabled: true,
+        signedIn: true,
+        hasApiKey: false,
+        // ...other defaults already used in nearby tests
+    });
+    expect(state.configured).toBe(true);
+});
+
+it("derives configured=true when hasApiKey", () => {
+    const state = buildSidebarState({
+        enabled: true,
+        signedIn: false,
+        hasApiKey: true,
+    });
+    expect(state.configured).toBe(true);
+});
+
+it("derives configured=false when neither signedIn nor hasApiKey", () => {
+    const state = buildSidebarState({
+        enabled: true,
+        signedIn: false,
+        hasApiKey: false,
+    });
+    expect(state.configured).toBe(false);
+});
+```
+
+(`buildSidebarState` is the existing helper in this test file; if it doesn't yet expose `signedIn`/`hasApiKey` inputs, the test should be written against whatever provider method actually emits the snapshot — read the file first and adapt.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run test:vscode -- src/views/SidebarWebviewProvider.test.ts -t "configured"`
+Expected: FAIL — `state.configured` is `undefined`.
+
+- [ ] **Step 3: Add `configured` to `SidebarState`**
+
+In `vscode/src/views/SidebarMessages.ts`, extend the `SidebarState` interface:
+
+```typescript
+export interface SidebarState {
+    readonly enabled: boolean;
+    readonly authenticated: boolean;
+    /**
+     * True when the user can actually use Jolli Memory's AI features:
+     * either signed in to Jolli, or they've supplied an Anthropic API key.
+     * Drives the onboarding-panel vs main-UI split in the sidebar webview.
+     */
+    readonly configured: boolean;
+    readonly activeTab: SidebarTab;
+    readonly kbMode: KbMode;
+    readonly branchName: string;
+    readonly detached: boolean;
+    readonly kbRepoFolder?: string;
+    readonly degradedReason?: SidebarDegradedReason;
+}
+```
+
+- [ ] **Step 4: Compute `configured` in the serializer**
+
+In `vscode/src/views/SidebarWebviewProvider.ts`, find the spot that builds the `SidebarState` (the same place that already populates `authenticated` and `enabled`). Add:
+
+```typescript
+const configured = derived.signedIn || derived.hasApiKey;
+return {
+    enabled,
+    authenticated,
+    configured,
+    // ...rest
+};
+```
+
+(`derived` here is the StatusStore's StatusDerived value already in scope — see `StatusStore.derived.signedIn` and `StatusStore.derived.hasApiKey` defined in `StatusDataService.derive`.)
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `npm run test:vscode -- src/views/SidebarWebviewProvider.test.ts -t "configured"`
+Expected: PASS (3 tests).
+
+Run: `npm run typecheck:vscode`
+Expected: no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add vscode/src/views/SidebarMessages.ts vscode/src/views/SidebarWebviewProvider.ts vscode/src/views/SidebarWebviewProvider.test.ts
+git commit -s -m "feat(vscode): derive configured (signedIn || hasApiKey) on SidebarState"
+```
+
+---
+
+## Task 2: HTML skeleton for onboarding panel
+
+**Files:**
+- Modify: `vscode/src/views/SidebarHtmlBuilder.ts:35-72`
+- Test: `vscode/src/views/SidebarHtmlBuilder.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+In `vscode/src/views/SidebarHtmlBuilder.test.ts`, add:
+
+```typescript
+it("includes the onboarding panel skeleton, hidden by default", () => {
+    const html = buildSidebarHtml("nonce", "vscode-resource:", "codicon.css", DEFAULT_STRINGS);
+    expect(html).toContain('id="onboarding-panel"');
+    expect(html).toMatch(/<div class="onboarding-panel hidden"/);
+    expect(html).toContain("Get started with Jolli Memory");
+    expect(html).toContain("Sign in to Jolli");
+    expect(html).toContain("Use your Anthropic API key");
+    expect(html).toContain("RECOMMENDED");
+    expect(html).toContain('id="onboarding-signin-btn"');
+    expect(html).toContain('id="onboarding-apikey-btn"');
+});
+
+it("renders Anthropic API key as the recommended option above Sign in to Jolli", () => {
+    const html = buildSidebarHtml("nonce", "vscode-resource:", "codicon.css", DEFAULT_STRINGS);
+    const apikeyIdx = html.indexOf("Use your Anthropic API key");
+    const signinIdx = html.indexOf("Sign in to Jolli");
+    expect(apikeyIdx).toBeGreaterThan(-1);
+    expect(signinIdx).toBeGreaterThan(-1);
+    expect(apikeyIdx).toBeLessThan(signinIdx);
+    // RECOMMENDED badge should appear above (i.e. in the same DOM region as)
+    // the Anthropic card, not the Sign in card.
+    const badgeIdx = html.indexOf("RECOMMENDED");
+    expect(badgeIdx).toBeGreaterThan(apikeyIdx - 600); // within the apikey card block
+    expect(badgeIdx).toBeLessThan(signinIdx);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run test:vscode -- src/views/SidebarHtmlBuilder.test.ts -t "onboarding panel skeleton"`
+Expected: FAIL — strings not found.
+
+- [ ] **Step 3: Add the onboarding-panel skeleton**
+
+In `vscode/src/views/SidebarHtmlBuilder.ts`, modify the `<div class="sidebar-root">` block to add the onboarding panel as a sibling **before** `<div class="tab-bar">`. Note the order: the **Anthropic API key** option is the recommended primary path on top, and **Sign in to Jolli** sits below as the secondary alternative.
+
+```html
+<div class="onboarding-panel hidden" id="onboarding-panel" role="region" aria-label="Get started with Jolli Memory">
+  <header class="ob-header">
+    <div class="ob-title-row">
+      <i class="codicon codicon-sparkle ob-title-icon" aria-hidden="true"></i>
+      <h2 class="ob-title">Get started with Jolli Memory</h2>
+    </div>
+    <p class="ob-subtitle">Jolli Memory automatically captures your work context and surfaces relevant memories as you code. Choose how you'd like to set it up.</p>
+  </header>
+  <hr class="ob-divider" />
+  <section class="ob-card ob-card--recommended">
+    <span class="ob-badge">RECOMMENDED</span>
+    <div class="ob-card-row">
+      <i class="codicon codicon-key ob-card-icon" aria-hidden="true"></i>
+      <div class="ob-card-text">
+        <h3 class="ob-card-title">Use your Anthropic API key</h3>
+        <p class="ob-card-desc">Connect your own Anthropic API key for AI summarization. Memories are stored locally only.</p>
+      </div>
+    </div>
+  </section>
+  <button type="button" id="onboarding-apikey-btn" class="ob-btn ob-btn--primary">Configure API Key</button>
+  <div class="ob-or"><span>OR</span></div>
+  <section class="ob-card">
+    <div class="ob-card-row">
+      <i class="codicon codicon-cloud ob-card-icon" aria-hidden="true"></i>
+      <div class="ob-card-text">
+        <h3 class="ob-card-title">Sign in to Jolli</h3>
+        <p class="ob-card-desc">Use Jolli's cloud to sync memories across machines and get AI summarization out of the box. Free to get started.</p>
+      </div>
+    </div>
+  </section>
+  <button type="button" id="onboarding-signin-btn" class="ob-btn ob-btn--secondary">Sign In / Sign Up</button>
+</div>
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm run test:vscode -- src/views/SidebarHtmlBuilder.test.ts -t "onboarding panel skeleton"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add vscode/src/views/SidebarHtmlBuilder.ts vscode/src/views/SidebarHtmlBuilder.test.ts
+git commit -s -m "feat(vscode): add onboarding-panel HTML skeleton (Anthropic key recommended, Sign in fallback)"
+```
+
+---
+
+## Task 3: Onboarding-panel CSS
+
+**Files:**
+- Modify: `vscode/src/views/SidebarCssBuilder.ts` (append at end of returned CSS string)
+- Test: `vscode/src/views/SidebarCssBuilder.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+In `vscode/src/views/SidebarCssBuilder.test.ts`, add:
+
+```typescript
+it("emits onboarding-panel styles", () => {
+    const css = buildSidebarCss();
+    expect(css).toMatch(/\.onboarding-panel\b/);
+    expect(css).toMatch(/\.ob-card--recommended\b/);
+    expect(css).toMatch(/\.ob-badge\b/);
+    expect(css).toMatch(/\.ob-btn--primary\b/);
+    expect(css).toMatch(/\.ob-btn--secondary\b/);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run test:vscode -- src/views/SidebarCssBuilder.test.ts -t "onboarding-panel styles"`
+Expected: FAIL.
+
+- [ ] **Step 3: Append onboarding styles**
+
+In `vscode/src/views/SidebarCssBuilder.ts`, append at the end of `buildSidebarCss()`'s returned template literal:
+
+```css
+/* ── Onboarding panel ───────────────────────────────────────────── */
+.onboarding-panel {
+    padding: 16px;
+    overflow-y: auto;
+    height: 100%;
+    box-sizing: border-box;
+}
+.ob-header { margin-bottom: 12px; }
+.ob-title-row { display: flex; align-items: center; gap: 8px; }
+.ob-title-icon { font-size: 18px; color: var(--vscode-textLink-foreground); }
+.ob-title { font-size: 14px; font-weight: 600; margin: 0; }
+.ob-subtitle {
+    font-size: 12px;
+    color: var(--vscode-descriptionForeground);
+    margin: 6px 0 0 0;
+    line-height: 1.5;
+}
+.ob-divider {
+    border: none;
+    border-top: 1px solid var(--vscode-widget-border, var(--vscode-editorWidget-border));
+    margin: 12px 0 14px 0;
+}
+.ob-card {
+    position: relative;
+    border: 1px solid var(--vscode-widget-border, var(--vscode-editorWidget-border));
+    border-radius: 6px;
+    padding: 12px;
+    background: var(--vscode-editor-background);
+}
+.ob-card--recommended {
+    border-color: var(--vscode-focusBorder);
+    border-width: 1.5px;
+}
+.ob-badge {
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    font-size: 9px;
+    font-weight: 700;
+    letter-spacing: 0.5px;
+    padding: 3px 8px;
+    border-radius: 8px;
+    color: var(--vscode-textLink-activeForeground, var(--vscode-textLink-foreground));
+    background: color-mix(in srgb, var(--vscode-focusBorder) 20%, transparent);
+}
+.ob-card-row { display: flex; gap: 10px; align-items: flex-start; }
+.ob-card-icon {
+    font-size: 16px;
+    margin-top: 2px;
+    color: var(--vscode-foreground);
+}
+.ob-card-text { flex: 1; min-width: 0; }
+.ob-card-title { font-size: 12px; font-weight: 600; margin: 0; }
+.ob-card-desc {
+    font-size: 12px;
+    color: var(--vscode-descriptionForeground);
+    margin: 4px 0 0 0;
+    line-height: 1.5;
+}
+.ob-btn {
+    display: block;
+    width: 100%;
+    padding: 8px 12px;
+    margin-top: 8px;
+    border-radius: 4px;
+    font-size: 13px;
+    cursor: pointer;
+    text-align: center;
+    border: 1px solid transparent;
+}
+.ob-btn--primary {
+    background: var(--vscode-button-background);
+    color: var(--vscode-button-foreground);
+}
+.ob-btn--primary:hover { background: var(--vscode-button-hoverBackground); }
+.ob-btn--secondary {
+    background: transparent;
+    color: var(--vscode-foreground);
+    border-color: var(--vscode-widget-border, var(--vscode-editorWidget-border));
+}
+.ob-btn--secondary:hover { background: var(--vscode-list-hoverBackground); }
+.ob-or {
+    display: flex; align-items: center; gap: 10px;
+    margin: 14px 0;
+    font-size: 11px;
+    color: var(--vscode-descriptionForeground);
+}
+.ob-or::before, .ob-or::after {
+    content: "";
+    flex: 1;
+    border-top: 1px solid var(--vscode-widget-border, var(--vscode-editorWidget-border));
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm run test:vscode -- src/views/SidebarCssBuilder.test.ts -t "onboarding-panel styles"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add vscode/src/views/SidebarCssBuilder.ts vscode/src/views/SidebarCssBuilder.test.ts
+git commit -s -m "feat(vscode): add onboarding-panel CSS using vscode theme tokens"
+```
+
+---
+
+## Task 4: Webview script — toggle onboarding vs tabs based on `configured`
+
+**Files:**
+- Modify: `vscode/src/views/SidebarScriptBuilder.ts`
+- Test: `vscode/src/views/SidebarScriptBuilder.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+In `vscode/src/views/SidebarScriptBuilder.test.ts`, add:
+
+```typescript
+it("registers onboarding signin button to dispatch jollimemory.signIn", () => {
+    const js = buildSidebarScript();
+    expect(js).toContain("onboarding-signin-btn");
+    expect(js).toContain("'jollimemory.signIn'");
+});
+it("registers onboarding apikey button to dispatch jollimemory.openSettings", () => {
+    const js = buildSidebarScript();
+    expect(js).toContain("onboarding-apikey-btn");
+    expect(js).toContain("'jollimemory.openSettings'");
+});
+it("toggles onboarding panel on configured=false", () => {
+    const js = buildSidebarScript();
+    // The render() routine must add/remove the .hidden class on #onboarding-panel
+    // and inversely on #tab-bar / #tab-toolbar / #tab-content-* based on
+    // state.configured.
+    expect(js).toContain("state.configured");
+    expect(js).toContain("onboarding-panel");
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run test:vscode -- src/views/SidebarScriptBuilder.test.ts`
+Expected: FAIL.
+
+- [ ] **Step 3: Add the toggle and click handlers in the script builder**
+
+In `vscode/src/views/SidebarScriptBuilder.ts`, locate the part of the script that runs on every `state` update (the existing `render()` / state-dispatch closure). Add this block at the top of the render path, **before** the existing tab-bar visibility logic:
+
+```javascript
+const onboardingEl = document.getElementById('onboarding-panel');
+const tabBarEl = document.getElementById('tab-bar');
+const tabToolbarEl = document.getElementById('tab-toolbar');
+const tabContentBranch = document.getElementById('tab-content-branch');
+const tabContentKb = document.getElementById('tab-content-kb');
+const tabContentStatus = document.getElementById('tab-content-status');
+const onboardingHidden = state.configured !== false;
+onboardingEl.classList.toggle('hidden', onboardingHidden);
+tabBarEl.classList.toggle('hidden', !onboardingHidden);
+// tab-toolbar and tab-content-* keep their existing per-tab toggles when shown;
+// here we just force-hide them while onboarding is active.
+if (!onboardingHidden) {
+    tabToolbarEl.classList.add('hidden');
+    tabContentBranch.classList.add('hidden');
+    tabContentKb.classList.add('hidden');
+    tabContentStatus.classList.add('hidden');
+    return;  // skip the rest of render() — onboarding takes the whole view
+}
+```
+
+(The exact insertion point depends on the existing render shape — see the SidebarScriptBuilder file. The intent: when `configured === false`, only the onboarding panel is visible, and the rest of render() is skipped. When `true`, the existing behaviour is unchanged.)
+
+Then, at the end of the script's one-time DOMContentLoaded init block (next to the other `addEventListener` calls), add:
+
+```javascript
+document.getElementById('onboarding-signin-btn').addEventListener('click', () => {
+    vscode.postMessage({ type: 'command', command: 'jollimemory.signIn' });
+});
+document.getElementById('onboarding-apikey-btn').addEventListener('click', () => {
+    vscode.postMessage({ type: 'command', command: 'jollimemory.openSettings' });
+});
+```
+
+(Reuse the existing generic `command` outbound message protocol — see `SidebarMessages.ts` outbound types and the existing iconButton wiring at line ~302.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npm run test:vscode -- src/views/SidebarScriptBuilder.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add vscode/src/views/SidebarScriptBuilder.ts vscode/src/views/SidebarScriptBuilder.test.ts
+git commit -s -m "feat(vscode): show onboarding panel when sidebar state.configured is false"
+```
+
+---
+
+## Task 5: Persist `manuallyDisabled` on Disable, clear on Enable
+
+**Files:**
+- Modify: `vscode/src/Extension.ts:1177-1249` (the two command registrations)
+- Test: `vscode/src/Extension.test.ts:1264-1330` (existing `enableJolliMemory` / `disableJolliMemory` describe blocks)
+
+- [ ] **Step 1: Write the failing test**
+
+In `vscode/src/Extension.test.ts`, inside `describe("disableJolliMemory")`:
+
+```typescript
+it("persists manualDisable=true to workspaceState", async () => {
+    const handler = getRegisteredCommand("jollimemory.disableJolliMemory");
+    bridge.disable.mockResolvedValue({ success: true, message: "ok" });
+    await handler();
+    expect(workspaceStateUpdate).toHaveBeenCalledWith("jollimemory.manuallyDisabled", true);
+});
+```
+
+And inside `describe("enableJolliMemory")`:
+
+```typescript
+it("clears manualDisable in workspaceState", async () => {
+    const handler = getRegisteredCommand("jollimemory.enableJolliMemory");
+    bridge.enable.mockResolvedValue({ success: true, message: "ok" });
+    await handler();
+    expect(workspaceStateUpdate).toHaveBeenCalledWith("jollimemory.manuallyDisabled", false);
+});
+```
+
+(`workspaceStateUpdate` is the existing mock spy on `context.workspaceState.update` — see how nearby tests reference workspaceState. Add a spy if missing.)
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npm run test:vscode -- src/Extension.test.ts -t "manualDisable"`
+Expected: FAIL.
+
+- [ ] **Step 3: Persist the flag**
+
+In `vscode/src/Extension.ts`, just below the existing constants near the top of `activate()`, declare a helper key:
+
+```typescript
+const MANUAL_DISABLE_KEY = "jollimemory.manuallyDisabled";
+```
+
+Then in the `enableJolliMemory` registration, immediately after `if (!result.success)` returns / before the success branch's existing logic:
+
+```typescript
+await context.workspaceState.update(MANUAL_DISABLE_KEY, false);
+```
+
+(Place it after the `if (!result.success)` early-return so we only clear it on success.)
+
+In the `disableJolliMemory` registration, **before** the `await bridge.disable()` call (so the opt-out is durable even if uninstall fails):
+
+```typescript
+await context.workspaceState.update(MANUAL_DISABLE_KEY, true);
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npm run test:vscode -- src/Extension.test.ts -t "manualDisable"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add vscode/src/Extension.ts vscode/src/Extension.test.ts
+git commit -s -m "feat(vscode): persist manuallyDisabled flag in workspaceState"
+```
+
+---
+
+## Task 6: Auto-enable on activate when not manually disabled
+
+**Files:**
+- Modify: `vscode/src/Extension.ts` (the `activate()` body, after `refreshStatusBar()` resolves)
+- Test: `vscode/src/Extension.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+In `vscode/src/Extension.test.ts`, add a new describe block near the existing `activate()` tests:
+
+```typescript
+describe("auto-enable on activate", () => {
+    it("calls bridge.enable() when status.enabled=false and manuallyDisabled=false", async () => {
+        bridge.getStatus.mockResolvedValue({ enabled: false, /* ... */ });
+        workspaceStateGet.mockReturnValue(false);
+        await activate(mockContext);
+        expect(bridge.enable).toHaveBeenCalledTimes(1);
+    });
+
+    it("does NOT call bridge.enable() when status.enabled=false but manuallyDisabled=true", async () => {
+        bridge.getStatus.mockResolvedValue({ enabled: false, /* ... */ });
+        workspaceStateGet.mockReturnValue(true);
+        await activate(mockContext);
+        expect(bridge.enable).not.toHaveBeenCalled();
+    });
+
+    it("does NOT call bridge.enable() when status.enabled=true (already enabled)", async () => {
+        bridge.getStatus.mockResolvedValue({ enabled: true, /* ... */ });
+        workspaceStateGet.mockReturnValue(false);
+        await activate(mockContext);
+        expect(bridge.enable).not.toHaveBeenCalled();
+    });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npm run test:vscode -- src/Extension.test.ts -t "auto-enable on activate"`
+Expected: FAIL.
+
+- [ ] **Step 3: Add the auto-enable hook**
+
+In `vscode/src/Extension.ts`, find the line in `activate()` where `refreshStatusBar()` is first awaited (the `currentEnabled = status.enabled;` assignment after initial wiring). Right after that line, add:
+
+```typescript
+// Auto-enable on first run unless the user has explicitly opted out.
+// `manuallyDisabled` is only set to true by disableJolliMemory; on a fresh
+// install / fresh workspace it's undefined → falsy → we install.
+const manuallyDisabled =
+    context.workspaceState.get<boolean>(MANUAL_DISABLE_KEY) === true;
+if (!currentEnabled && !manuallyDisabled) {
+    log.info("activate", "Auto-enabling Jolli Memory (no opt-out recorded)");
+    const result = await bridge.enable();
+    if (result.success) {
+        const refreshed = await refreshStatusBar(
+            bridge, memoriesStore, plansStore, filesStore, commitsStore, statusBar,
+        );
+        currentEnabled = refreshed.enabled;
+        sidebarProvider.notifyEnabledChanged(refreshed.enabled);
+    } else {
+        log.warn("activate", "Auto-enable failed", { message: result.message });
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npm run test:vscode -- src/Extension.test.ts -t "auto-enable on activate"`
+Expected: PASS.
+
+- [ ] **Step 5: Run the full vscode test suite**
+
+Run: `npm run test:vscode`
+Expected: all tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add vscode/src/Extension.ts vscode/src/Extension.test.ts
+git commit -s -m "feat(vscode): auto-enable Jolli Memory on activate unless manually disabled"
+```
+
+---
+
+## Task 7: End-to-end smoke + final checks
+
+- [ ] **Step 1: Build the extension**
+
+Run: `cd vscode && npm run build && cd ..`
+Expected: build succeeds.
+
+- [ ] **Step 2: Run full pipeline**
+
+Run from repo root: `npm run typecheck && npm run lint && npm run test`
+Expected: all pass.
+
+- [ ] **Step 3: Manual smoke (in a real VS Code Extension Host)**
+
+Start with a fresh repo where Jolli is NOT installed and the workspaceState is clean:
+
+1. Reload VS Code in the dev sandbox (`F5` in `vscode/`).
+2. Open the JolliMemory side panel.
+3. **Expect:** sidebar shows the onboarding panel because `configured=false` (not signed in, no API key).
+4. Run `jollimemory.signIn` (or click Sign In / Sign Up).
+5. **Expect:** after OAuth, sidebar flips to the normal tabs — onboarding panel hidden.
+6. Run `Jolli Memory: Disable` from the command palette.
+7. Reload the window.
+8. **Expect:** sidebar still shows the disabled state — auto-enable was suppressed because `manuallyDisabled=true`.
+9. Run `Jolli Memory: Enable`.
+10. Reload the window.
+11. **Expect:** sidebar shows the normal tabs without re-prompting.
+
+- [ ] **Step 4: Final commit (if anything was tweaked during smoke)**
+
+```bash
+git status
+# If clean: skip. Otherwise:
+git add -p
+git commit -s -m "fix(vscode): <follow-up from smoke test>"
+```
+
+---
+
+## Self-review checklist
+
+- [ ] **Spec coverage:** Auto-enable on install? Task 6. Manual-disable persistence? Task 5. Highlight Anthropic API key as recommended (top + RECOMMENDED badge + primary button), Sign in as fallback? Tasks 2 + 3. Onboarding shows on `!configured`? Tasks 1 + 4.
+- [ ] **No placeholders:** Every `<description>` resolved to a concrete string; every step has runnable code or an exact command.
+- [ ] **Type consistency:** `MANUAL_DISABLE_KEY` is referenced uniformly in Tasks 5 and 6. `state.configured` is the same property name in Tasks 1 and 4. The two onboarding button IDs (`onboarding-signin-btn`, `onboarding-apikey-btn`) match across Tasks 2 and 4.
+- [ ] **No private DOM coupling:** the script toggles by id (`onboarding-panel`, `tab-bar`, etc.), all defined in the HTML skeleton in Task 2.

--- a/package-lock.json
+++ b/package-lock.json
@@ -8420,7 +8420,7 @@
 		},
 		"vscode": {
 			"name": "jollimemory-vscode",
-			"version": "0.98.20",
+			"version": "0.98.21",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@vscode/codicons": "^0.0.45",

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -2,7 +2,7 @@
 	"name": "jollimemory-vscode",
 	"displayName": "Jolli Memory",
 	"description": "VS Code sidebar for Jolli Memory — AI-powered commit summaries and smart git operations",
-	"version": "0.98.20",
+	"version": "0.98.21",
 	"publisher": "jolli",
 	"license": "Apache-2.0",
 	"icon": "assets/icon.png",

--- a/vscode/src/Extension.test.ts
+++ b/vscode/src/Extension.test.ts
@@ -783,6 +783,16 @@ vi.mock("./services/AuthService.js", () => ({
 	AuthService: MockAuthService,
 }));
 
+const { readManualDisableFlag, writeManualDisableFlag } = vi.hoisted(() => ({
+	readManualDisableFlag: vi.fn(async () => false),
+	writeManualDisableFlag: vi.fn(async () => undefined),
+}));
+
+vi.mock("./services/ManualDisableFlag.js", () => ({
+	readManualDisableFlag,
+	writeManualDisableFlag,
+}));
+
 vi.mock("node:os", () => ({
 	homedir,
 }));
@@ -1312,6 +1322,17 @@ describe("Extension", () => {
 					"Jolli Memory: git not found",
 				);
 			});
+
+			it("clears the manually-disabled marker on enable success", async () => {
+				writeManualDisableFlag.mockClear();
+				const handler = getRegisteredCommand("jollimemory.enableJolliMemory");
+				await handler();
+
+				expect(writeManualDisableFlag).toHaveBeenCalledWith(
+					"/test/workspace",
+					false,
+				);
+			});
 		});
 
 		describe("disableJolliMemory", () => {
@@ -1333,6 +1354,34 @@ describe("Extension", () => {
 
 				expect(showErrorMessage).toHaveBeenCalledWith(
 					"Jolli Memory: permission denied",
+				);
+			});
+
+			it("writes the manually-disabled marker before disabling", async () => {
+				writeManualDisableFlag.mockClear();
+				const handler = getRegisteredCommand("jollimemory.disableJolliMemory");
+				await handler();
+
+				expect(writeManualDisableFlag).toHaveBeenCalledWith(
+					"/test/workspace",
+					true,
+				);
+			});
+
+			it("writes the manually-disabled marker even when bridge.disable fails", async () => {
+				mockBridge.disable.mockResolvedValue({
+					success: false,
+					message: "permission denied",
+				});
+				writeManualDisableFlag.mockClear();
+				const handler = getRegisteredCommand("jollimemory.disableJolliMemory");
+				await handler();
+
+				// The opt-out is recorded *before* the async uninstall so it
+				// survives a failed Installer.uninstall().
+				expect(writeManualDisableFlag).toHaveBeenCalledWith(
+					"/test/workspace",
+					true,
 				);
 			});
 		});
@@ -2882,6 +2931,26 @@ describe("Extension", () => {
 			expect(() => onCreate?.()).not.toThrow();
 		});
 
+		it("HEAD watcher re-reads bridge.getCurrentBranch so branch label tracks branch switches", async () => {
+			// Activation called getCurrentBranch once at startup. After a HEAD
+			// change (branch switch / detached checkout), the watcher MUST call
+			// it again — otherwise currentBranchName freezes at the activation
+			// value and the Branch tab label drifts out of sync with the
+			// workspace's actual HEAD.
+			const callsBefore = mockBridge.getCurrentBranch.mock.calls.length;
+			const headWatcher = createFileSystemWatcher.mock.results[1]?.value;
+			const onChange = headWatcher?.onDidChange.mock.calls[0]?.[0] as
+				| (() => void)
+				| undefined;
+			expect(onChange).toBeDefined();
+			onChange?.();
+			// Allow the queued microtask (refreshBranchName is async) to flush.
+			await Promise.resolve();
+			expect(mockBridge.getCurrentBranch.mock.calls.length).toBeGreaterThan(
+				callsBefore,
+			);
+		});
+
 		it("wires orphan branch watcher to refresh callback", () => {
 			const orphanWatcher = createFileSystemWatcher.mock.results[2]?.value;
 			const onCreate = orphanWatcher?.onDidCreate.mock.calls[0]?.[0] as
@@ -3819,6 +3888,65 @@ describe("Extension", () => {
 				expect(mockStatusStore.refresh).toHaveBeenCalled();
 			});
 			expect(mockBridge.autoInstallForWorktree).not.toHaveBeenCalled();
+		});
+
+		// Auto-enable on activate: a fresh workspace with no opt-out should
+		// install hooks transparently. The opt-out is a marker file
+		// (`<projectDir>/.jolli/jollimemory/disabled-by-user`) that survives
+		// across IDE restarts AND project moves, since it's project-scoped
+		// rather than bound to VS Code's per-machine workspaceState.
+		describe("auto-enable on activate", () => {
+			it("calls bridge.enable when status.enabled=false and no opt-out recorded", async () => {
+				mockBridge.getStatus.mockResolvedValue({
+					enabled: false,
+					gitHookInstalled: false,
+					worktreeHooksInstalled: false,
+				});
+				mockBridge.enable.mockClear();
+				readManualDisableFlag.mockResolvedValue(false);
+
+				const ctx = makeContext();
+				activate(ctx);
+
+				await vi.waitFor(() => {
+					expect(mockBridge.enable).toHaveBeenCalled();
+				});
+			});
+
+			it("does NOT call bridge.enable when the manually-disabled marker is present", async () => {
+				mockBridge.getStatus.mockResolvedValue({
+					enabled: false,
+					gitHookInstalled: false,
+					worktreeHooksInstalled: false,
+				});
+				mockBridge.enable.mockClear();
+				readManualDisableFlag.mockResolvedValue(true);
+
+				const ctx = makeContext();
+				activate(ctx);
+
+				await vi.waitFor(() => {
+					expect(mockStatusStore.refresh).toHaveBeenCalled();
+				});
+				expect(mockBridge.enable).not.toHaveBeenCalled();
+			});
+
+			it("does NOT call bridge.enable when status.enabled is already true", async () => {
+				mockBridge.getStatus.mockResolvedValue({
+					enabled: true,
+					gitHookInstalled: true,
+					worktreeHooksInstalled: true,
+				});
+				mockBridge.enable.mockClear();
+
+				const ctx = makeContext();
+				activate(ctx);
+
+				await vi.waitFor(() => {
+					expect(mockStatusStore.refresh).toHaveBeenCalled();
+				});
+				expect(mockBridge.enable).not.toHaveBeenCalled();
+			});
 		});
 
 		it("logs error when refreshHookPathsIfStale rejects", async () => {

--- a/vscode/src/Extension.ts
+++ b/vscode/src/Extension.ts
@@ -62,6 +62,10 @@ import { PlansTreeProvider } from "./providers/PlansTreeProvider.js";
 import { StatusTreeProvider } from "./providers/StatusTreeProvider.js";
 import { AuthService } from "./services/AuthService.js";
 import { KbFoldersService } from "./services/KbFoldersService.js";
+import {
+	readManualDisableFlag,
+	writeManualDisableFlag,
+} from "./services/ManualDisableFlag.js";
 import { CommitsStore } from "./stores/CommitsStore.js";
 import { FilesStore } from "./stores/FilesStore.js";
 import { MemoriesStore } from "./stores/MemoriesStore.js";
@@ -253,6 +257,11 @@ function registerDegradedSidebar(
 		getInitialState: () => ({
 			enabled: false,
 			authenticated: false,
+			// In degraded mode (no workspace / no git) we never show the
+			// onboarding panel — the degraded UI takes priority. Reporting
+			// `configured: true` keeps the webview from gating on the
+			// onboarding flow when there's nothing to onboard against yet.
+			configured: true,
 			activeTab: "status",
 			kbMode: "folders",
 			branchName: "",
@@ -577,14 +586,54 @@ export function activate(context: vscode.ExtensionContext): void {
 	let currentBranchDetached = false;
 	const branchChangeEmitter = new vscode.EventEmitter<void>();
 
-	void bridge.getCurrentBranch().then((branch) => {
-		currentBranchName = branch;
-		currentBranchDetached = branch === "HEAD";
-		branchChangeEmitter.fire();
-	});
+	// Re-read the current branch name from git and notify subscribers if it
+	// changed. Called once at activation and again from the HEAD watcher so
+	// branch switches (regular and detached) update the sidebar tab label.
+	// Without the HEAD-watcher re-call, currentBranchName would freeze at
+	// activation time and drift out of sync with what `git branch --show-current`
+	// reports — producing the "tab name doesn't match workspace branch" bug.
+	const refreshBranchName = async (): Promise<void> => {
+		try {
+			const branch = await bridge.getCurrentBranch();
+			const detached = branch === "HEAD";
+			if (branch === currentBranchName && detached === currentBranchDetached) {
+				return;
+			}
+			currentBranchName = branch;
+			currentBranchDetached = detached;
+			branchChangeEmitter.fire();
+		} catch (err) {
+			log.warn("refreshBranchName", "Failed to read current branch", {
+				error: (err as Error).message,
+			});
+		}
+	};
+
+	void refreshBranchName();
 
 	let currentEnabled = true;
 	let currentAuthenticated = false;
+	// Tracks whether the user has either signed in to Jolli or supplied an
+	// Anthropic API key. Drives the onboarding-panel vs main-UI split. Updated
+	// from statusStore.onChange so sign-in / sign-out / settings save / config
+	// reload all converge on a single source of truth.
+	let currentConfigured = false;
+
+	// Deferred barrier that the SidebarWebviewProvider awaits before posting
+	// the first `init` message. We resolve it once `initialLoad()` (which
+	// includes statusStore.refresh) has finished, so currentConfigured /
+	// currentAuthenticated / currentBranchName have all been corrected from
+	// their pessimistic activate-time defaults. Without this gate the
+	// webview would render against `configured = false` on reload and visibly
+	// flash the onboarding panel before the real value arrives. Wrapped on
+	// the consumer side with .catch so a failed initialLoad never traps the
+	// webview in the loading placeholder.
+	let resolveInitialStateReady: () => void = () => {
+		// no-op until the real resolver replaces it
+	};
+	const initialStateReady = new Promise<void>((resolve) => {
+		resolveInitialStateReady = resolve;
+	});
 
 	const sidebarProvider = new SidebarWebviewProvider({
 		executeCommand: (cmd, ...args) =>
@@ -592,6 +641,7 @@ export function activate(context: vscode.ExtensionContext): void {
 		getInitialState: () => ({
 			enabled: currentEnabled,
 			authenticated: currentAuthenticated,
+			configured: currentConfigured,
 			activeTab: "branch",
 			kbMode: "folders",
 			branchName: currentBranchName,
@@ -650,6 +700,7 @@ export function activate(context: vscode.ExtensionContext): void {
 			filesStore.applyCheckboxBatch([[filePath, selected]]),
 		applyCommitCheckbox: (hash, selected) =>
 			commitsStore.onCheckboxToggle(hash, selected),
+		initialStateReady,
 	});
 	context.subscriptions.push(
 		sidebarProvider,
@@ -660,13 +711,35 @@ export function activate(context: vscode.ExtensionContext): void {
 		branchChangeEmitter,
 	);
 
-	void bridge.getStatus().then((s) => {
-		currentEnabled = s.enabled;
-		sidebarProvider.notifyEnabledChanged(s.enabled);
-	});
 	void loadConfig().then((cfg) => {
 		currentAuthenticated = !!cfg?.authToken;
 		sidebarProvider.notifyAuthChanged(currentAuthenticated);
+	});
+
+	// Keep `currentEnabled` and `currentConfigured` in lockstep with StatusStore
+	// so the disabled banner and onboarding-panel vs main-UI split flip the
+	// moment any underlying signal changes (enable/disable, sign-in/sign-out,
+	// settings save, config reload). Routing both through the same store also
+	// puts them under `initialStateReady`'s barrier — `initialLoad()` awaits
+	// `statusStore.refresh()`, which fires this subscription, so the first
+	// `init` message the webview receives reflects real state instead of the
+	// optimistic activate-time defaults. Previously `currentEnabled` had its
+	// own fire-and-forget `bridge.getStatus()` outside the barrier, which
+	// could race the `init` and briefly flash the main UI before flipping to
+	// disabled. Only fire `notify…` when the boolean actually changes to keep
+	// webview round-trips minimal.
+	context.subscriptions.push({
+		dispose: statusStore.onChange((snap) => {
+			const nextConfigured = snap.derived.signedIn || snap.derived.hasApiKey;
+			if (nextConfigured !== currentConfigured) {
+				currentConfigured = nextConfigured;
+				sidebarProvider.notifyConfiguredChanged(nextConfigured);
+			}
+			if (snap.status && snap.status.enabled !== currentEnabled) {
+				currentEnabled = snap.status.enabled;
+				sidebarProvider.notifyEnabledChanged(snap.status.enabled);
+			}
+		}),
 	});
 	// Pick up customKBPath from config now that loadConfig() can run async.
 	// Without this the sidebar would keep showing the default KB folder until
@@ -865,6 +938,12 @@ export function activate(context: vscode.ExtensionContext): void {
 			vscode.Uri.file(dirname(headPath)),
 			"HEAD",
 			() => {
+				// Branch label is the only piece that doesn't read from a store —
+				// re-fetch and emit through branchChangeEmitter so the Branch tab
+				// label tracks the workspace's actual HEAD across branch switches
+				// (regular + detached). The other refreshes drive the per-tab data
+				// stores, which already key off "current branch" implicitly.
+				void refreshBranchName();
 				statusStore.refresh().catch(handleError("headWatcher.status"));
 				plansStore.refresh().catch(handleError("headWatcher.plans"));
 				filesStore.refresh().catch(handleError("headWatcher.files"));
@@ -1159,16 +1238,37 @@ export function activate(context: vscode.ExtensionContext): void {
 			},
 		),
 		// Status panel
-		vscode.commands.registerCommand("jollimemory.refreshStatus", () => {
+		// Beyond refreshing the status store + status bar, this also re-pulls
+		// `bridge.getStatus()` (via refreshStatusBar's return value) and
+		// `loadConfig()` to resync the sidebar shell's `currentEnabled` /
+		// `currentAuthenticated` — those are only otherwise updated by
+		// startup promises and the enable/disable/auth commands, so without
+		// this any out-of-band change to hooks or auth would leave the
+		// disabled panel / Sign In/Out chrome stale until reload.
+		vscode.commands.registerCommand("jollimemory.refreshStatus", async () => {
 			statusStore.refresh().catch(handleError("refreshStatus"));
-			refreshStatusBar(
-				bridge,
-				memoriesStore,
-				plansStore,
-				filesStore,
-				commitsStore,
-				statusBar,
-			);
+			try {
+				const status = await refreshStatusBar(
+					bridge,
+					memoriesStore,
+					plansStore,
+					filesStore,
+					commitsStore,
+					statusBar,
+				);
+				if (status.enabled !== currentEnabled) {
+					currentEnabled = status.enabled;
+					sidebarProvider.notifyEnabledChanged(status.enabled);
+				}
+				const cfg = await loadConfig();
+				const nextAuth = !!cfg?.authToken;
+				if (nextAuth !== currentAuthenticated) {
+					currentAuthenticated = nextAuth;
+					sidebarProvider.notifyAuthChanged(nextAuth);
+				}
+			} catch (err) {
+				handleError("refreshStatus")(err);
+			}
 		}),
 
 		// enableJolliMemory / disableJolliMemory: two commands with different icons,
@@ -1184,6 +1284,10 @@ export function activate(context: vscode.ExtensionContext): void {
 					log.error("cmd", "enable failed", { message: result.message });
 					vscode.window.showErrorMessage(`Jolli Memory: ${result.message}`);
 				} else {
+					// Clear the opt-out so subsequent IDE restarts auto-enable as
+					// usual. Done only on success — a failed install means the
+					// previous (manuallyDisabled) state is still the user's intent.
+					await writeManualDisableFlag(workspaceRoot, false);
 					log.info("cmd", "enable succeeded — refreshing all panels");
 					// ORDER MATTERS:
 					//   1. refreshStatusBar flips every store's enabled flag
@@ -1227,6 +1331,9 @@ export function activate(context: vscode.ExtensionContext): void {
 			"jollimemory.disableJolliMemory",
 			async () => {
 				log.info("cmd", "disableJolliMemory invoked");
+				// Record the opt-out *before* the async uninstall so the user's
+				// intent is durable even if Installer.uninstall() throws or fails.
+				await writeManualDisableFlag(workspaceRoot, true);
 				const result = await bridge.disable();
 				if (!result.success) {
 					log.error("cmd", "disable failed", { message: result.message });
@@ -1964,7 +2071,11 @@ export function activate(context: vscode.ExtensionContext): void {
 	// - Memories lazy-load: `onSidebarFirstVisible` triggers ensureFirstLoad()
 
 	// ── Initial data load ────────────────────────────────────────────────────
-	initialLoad(
+	// Resolve `initialStateReady` once initialLoad finishes (success OR error
+	// path) so the sidebar webview never gets stuck in its loading
+	// placeholder. initialLoad already swallows errors internally and
+	// returns void, so a single .finally is enough to release the barrier.
+	void initialLoad(
 		bridge,
 		excludeFilter,
 		statusStore,
@@ -1973,7 +2084,9 @@ export function activate(context: vscode.ExtensionContext): void {
 		commitsStore,
 		memoriesStore,
 		statusBar,
-	);
+	).finally(() => {
+		resolveInitialStateReady();
+	});
 
 	// ── Auto-refresh hook paths on version upgrade ────────────────────────────
 	// VSCode installs each extension version into a versioned directory
@@ -2028,6 +2141,37 @@ export function activate(context: vscode.ExtensionContext): void {
 					statusBar,
 				);
 			}
+
+			// Auto-enable on first run unless the user has explicitly opted out.
+			// The opt-out is a marker file at
+			// `<projectDir>/.jolli/jollimemory/disabled-by-user` (sibling of
+			// sessions.json / cursors.json), so a fresh project / fresh worktree
+			// has no marker → falsy → install.
+			const manuallyDisabled = await readManualDisableFlag(workspaceRoot);
+			if (!status.enabled && !manuallyDisabled) {
+				log.info(
+					"activate",
+					"Auto-enabling Jolli Memory (no opt-out recorded)",
+				);
+				const enableResult = await bridge.enable();
+				if (!enableResult.success) {
+					log.warn("activate", "Auto-enable failed", {
+						message: enableResult.message,
+					});
+				} else {
+					await statusStore.refresh();
+					const refreshed = await refreshStatusBar(
+						bridge,
+						memoriesStore,
+						plansStore,
+						filesStore,
+						commitsStore,
+						statusBar,
+					);
+					currentEnabled = refreshed.enabled;
+					sidebarProvider.notifyEnabledChanged(refreshed.enabled);
+				}
+			}
 		})
 		.catch((err: unknown) => {
 			log.error("activate", "Failed to refresh hook paths", err);
@@ -2057,12 +2201,12 @@ function initialLoad(
 	commitsStore: CommitsStore,
 	memoriesStore: MemoriesStore,
 	statusBar: StatusBarManager,
-): void {
+): Promise<void> {
 	log.info("initialLoad", "Loading all panels");
 	// Load the exclude filter FIRST so the initial file list is already filtered.
 	// If loaded in parallel with filesStore.refresh(), the tree briefly shows
 	// all files (including excluded ones) before the filter kicks in.
-	excludeFilter
+	return excludeFilter
 		.load()
 		.then(() =>
 			Promise.all([

--- a/vscode/src/providers/StatusTreeProvider.test.ts
+++ b/vscode/src/providers/StatusTreeProvider.test.ts
@@ -338,16 +338,21 @@ describe("StatusTreeProvider", () => {
 		expect(items.find((item) => item.label === "Jolli Site")).toBeUndefined();
 	});
 
-	it("skips config loading when disabled", async () => {
+	it("loads config even when disabled, but renders no rows", async () => {
+		// Auth state (authToken / apiKey) is independent of whether hooks are
+		// installed — keeping config loaded while disabled lets the Sidebar's
+		// onboarding gate stay accurate, even though this provider itself
+		// surfaces no rows in the disabled state.
 		const bridge = {
 			cwd: "/repo",
 			getStatus: vi.fn(async () => makeStatus({ enabled: false })),
 		};
+		loadConfigFromDir.mockResolvedValue({});
 		const provider = makeStatusProvider(bridge as never);
 
 		await provider.refresh();
 
-		expect(loadConfigFromDir).not.toHaveBeenCalled();
+		expect(loadConfigFromDir).toHaveBeenCalled();
 		expect(provider.getChildren()).toEqual([]);
 	});
 
@@ -813,12 +818,17 @@ describe("StatusTreeProvider", () => {
 		});
 	});
 
-	it("does not call authService.refreshContextKey when disabled", async () => {
+	it("calls authService.refreshContextKey when disabled with the on-disk config", async () => {
+		// `jollimemory.signedIn` context key reflects whether the user is
+		// signed in, not whether hooks are installed — so disable must not
+		// stop us from syncing it. Otherwise the context key drifts stale
+		// after a disable and any when-clauses gating on it lie to the user.
 		const mockAuthService = { refreshContextKey: vi.fn() };
 		const bridge = {
 			cwd: "/repo",
 			getStatus: vi.fn(async () => makeStatus({ enabled: false })),
 		};
+		loadConfigFromDir.mockResolvedValue({ authToken: "t" });
 
 		const provider = makeStatusProvider(
 			bridge as never,
@@ -826,7 +836,9 @@ describe("StatusTreeProvider", () => {
 		);
 		await provider.refresh();
 
-		expect(mockAuthService.refreshContextKey).not.toHaveBeenCalled();
+		expect(mockAuthService.refreshContextKey).toHaveBeenCalledWith({
+			authToken: "t",
+		});
 	});
 
 	it("skips integration row when claudeDetected is false", async () => {

--- a/vscode/src/services/ManualDisableFlag.test.ts
+++ b/vscode/src/services/ManualDisableFlag.test.ts
@@ -1,0 +1,55 @@
+import { mkdtemp, readFile, rm, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+	readManualDisableFlag,
+	writeManualDisableFlag,
+} from "./ManualDisableFlag.js";
+
+describe("ManualDisableFlag", () => {
+	let cwd: string;
+
+	beforeEach(async () => {
+		cwd = await mkdtemp(join(tmpdir(), "jolli-disable-flag-"));
+	});
+
+	afterEach(async () => {
+		await rm(cwd, { recursive: true, force: true });
+	});
+
+	it("read returns false when the marker file does not exist", async () => {
+		expect(await readManualDisableFlag(cwd)).toBe(false);
+	});
+
+	it("write(true) creates the marker (and parent dirs) under .jolli/jollimemory/disabled-by-user", async () => {
+		await writeManualDisableFlag(cwd, true);
+
+		const expected = join(cwd, ".jolli", "jollimemory", "disabled-by-user");
+		await expect(stat(expected)).resolves.toBeDefined();
+		expect(await readManualDisableFlag(cwd)).toBe(true);
+	});
+
+	it("write(true) records an ISO timestamp body for human debugging", async () => {
+		await writeManualDisableFlag(cwd, true);
+		const body = await readFile(
+			join(cwd, ".jolli", "jollimemory", "disabled-by-user"),
+			"utf-8",
+		);
+		expect(body.trim()).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
+	});
+
+	it("write(false) removes the marker if it exists", async () => {
+		await writeManualDisableFlag(cwd, true);
+		expect(await readManualDisableFlag(cwd)).toBe(true);
+
+		await writeManualDisableFlag(cwd, false);
+		expect(await readManualDisableFlag(cwd)).toBe(false);
+	});
+
+	it("write(false) is a no-op when the marker is already absent", async () => {
+		await expect(writeManualDisableFlag(cwd, false)).resolves.toBeUndefined();
+		expect(await readManualDisableFlag(cwd)).toBe(false);
+	});
+});

--- a/vscode/src/services/ManualDisableFlag.ts
+++ b/vscode/src/services/ManualDisableFlag.ts
@@ -1,0 +1,56 @@
+/**
+ * ManualDisableFlag — file-backed opt-out marker for "user explicitly disabled
+ * Jolli Memory in this project."
+ *
+ * Stored at `<projectDir>/.jolli/jollimemory/disabled-by-user` (already
+ * gitignored via the project's `.jolli/` rule), making it project-scoped (per
+ * worktree, follows the project directory) instead of bound to VS Code's
+ * per-machine `workspaceState`. Sibling files in the same directory:
+ * `git-op-queue/`, `notes/`, `debug.log` (see `cli/src/Logger.ts`).
+ *
+ * Marker semantics: the file's *existence* is the boolean. The body holds an
+ * ISO timestamp purely for human debugging — readers don't parse it.
+ */
+
+import { mkdir, stat, unlink, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { getJolliMemoryDir } from "../../../cli/src/Logger.js";
+
+const FILE_NAME = "disabled-by-user";
+
+function flagPath(cwd: string): string {
+	return join(getJolliMemoryDir(cwd), FILE_NAME);
+}
+
+/** Returns true iff the marker file exists in this project. */
+export async function readManualDisableFlag(cwd: string): Promise<boolean> {
+	try {
+		await stat(flagPath(cwd));
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Sets the marker. `disabled=true` writes the file (creating the directory if
+ * needed); `disabled=false` removes it (no-op if already absent).
+ */
+export async function writeManualDisableFlag(
+	cwd: string,
+	disabled: boolean,
+): Promise<void> {
+	const path = flagPath(cwd);
+	if (disabled) {
+		await mkdir(dirname(path), { recursive: true });
+		await writeFile(path, `${new Date().toISOString()}\n`);
+		return;
+	}
+	try {
+		await unlink(path);
+	} catch (err) {
+		if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+			throw err;
+		}
+	}
+}

--- a/vscode/src/stores/StatusStore.test.ts
+++ b/vscode/src/stores/StatusStore.test.ts
@@ -48,14 +48,22 @@ describe("StatusStore", () => {
 		expect(authService.refreshContextKey).toHaveBeenCalled();
 	});
 
-	it("refresh clears config when status.enabled is false", async () => {
+	it("refresh keeps config (and derived signedIn / hasApiKey) when status.enabled is false", async () => {
+		// Disabling Jolli Memory only uninstalls hooks — it does not sign the
+		// user out or wipe their Anthropic API key. The Sidebar's onboarding-
+		// vs-main-UI gate is `signedIn || hasApiKey` and must continue to
+		// reflect on-disk credentials, otherwise the disabled state replaces
+		// the toolbar's "Enable" affordance with the onboarding panel and the
+		// user can never re-enable from the sidebar.
 		const bridge = {
 			getStatus: vi.fn(async () => makeStatus({ enabled: false })),
 		};
-		loadConfigFromDir.mockResolvedValue({ apiKey: "k" });
+		loadConfigFromDir.mockResolvedValue({ apiKey: "k", authToken: "t" });
 		const store = new StatusStore(bridge as never);
 		await store.refresh();
-		expect(store.getSnapshot().config).toBeNull();
+		expect(store.getSnapshot().config).toEqual({ apiKey: "k", authToken: "t" });
+		expect(store.getSnapshot().derived.hasApiKey).toBe(true);
+		expect(store.getSnapshot().derived.signedIn).toBe(true);
 	});
 
 	it("setStatus updates status snapshot with setStatus reason", () => {

--- a/vscode/src/stores/StatusStore.ts
+++ b/vscode/src/stores/StatusStore.ts
@@ -73,13 +73,16 @@ export class StatusStore extends BaseStore<StatusChangeReason, StatusSnapshot> {
 	}
 
 	async refresh(): Promise<void> {
+		// Config (authToken / apiKey) lives on disk independently of whether
+		// the git hook is installed; load it unconditionally so the Sidebar's
+		// `configured = signedIn || hasApiKey` gate keeps reflecting the
+		// user's credentials even when hooks are uninstalled. Otherwise
+		// disabling Jolli Memory would flip `configured` to false, swap the
+		// disabled-banner (which carries the Enable button) for the
+		// onboarding panel, and trap the user with no way to re-enable.
 		this.status = await this.bridge.getStatus();
-		if (this.status.enabled) {
-			this.config = await loadConfigFromDir(getGlobalConfigDir());
-			this.authService?.refreshContextKey(this.config);
-		} else {
-			this.config = null;
-		}
+		this.config = await loadConfigFromDir(getGlobalConfigDir());
+		this.authService?.refreshContextKey(this.config);
 		this.rebuildSnapshot("refresh");
 	}
 

--- a/vscode/src/views/SettingsCssBuilder.test.ts
+++ b/vscode/src/views/SettingsCssBuilder.test.ts
@@ -32,6 +32,21 @@ describe("SettingsCssBuilder", () => {
 		expect(css).toContain(".toggle-switch");
 	});
 
+	// Regression: long hints (e.g. Copilot's) used to push the toggle out
+	// of the right edge because `.settings-label` is `flex-shrink: 0` and
+	// nothing else in `.toggle-row` flex-grew, so the label was sized to
+	// max-content (the hint on one line). The fix lets the label flex into
+	// available space inside toggle rows so the hint wraps.
+	it("lets toggle-row labels flex so long hints wrap instead of pushing the toggle out", () => {
+		// `.toggle-row .settings-label { flex: 1; min-width: 0; ... }`
+		expect(css).toMatch(
+			/\.toggle-row\s+\.settings-label\s*\{[^}]*\bflex\s*:\s*1\b[^}]*\bmin-width\s*:\s*0\b/s,
+		);
+		// `.toggle-row` declares a gap so the now-flex-grown label keeps
+		// breathing room between itself and the toggle.
+		expect(css).toMatch(/\.toggle-row\s*\{[^}]*\bgap\s*:\s*\d/s);
+	});
+
 	it("contains validation error styles", () => {
 		expect(css).toContain(".error");
 		expect(css).toContain(".error-message");

--- a/vscode/src/views/SettingsCssBuilder.ts
+++ b/vscode/src/views/SettingsCssBuilder.ts
@@ -134,7 +134,16 @@ export function buildSettingsCss(): string {
     display: flex;
     align-items: center;
     justify-content: space-between;
+    gap: 12px;
     padding: 6px 0;
+  }
+  /* In toggle rows the label is the only flexible element — let it grow
+     into available space and shrink below its 140px min-width so long
+     hints (e.g. the Copilot row) wrap instead of pushing the toggle off
+     the right edge. */
+  .toggle-row .settings-label {
+    flex: 1;
+    min-width: 0;
   }
   .toggle-switch {
     position: relative;

--- a/vscode/src/views/SidebarCssBuilder.test.ts
+++ b/vscode/src/views/SidebarCssBuilder.test.ts
@@ -189,3 +189,59 @@ describe("checkbox + row-leading", () => {
 		expect(css).toContain("var(--vscode-checkbox-background)");
 	});
 });
+
+describe("onboarding panel styles", () => {
+	it("declares the onboarding-panel and card classes", () => {
+		const css = buildSidebarCss();
+		expect(css).toMatch(/\.onboarding-panel\b/);
+		expect(css).toMatch(/\.ob-card\b/);
+		expect(css).toMatch(/\.ob-card--recommended\b/);
+	});
+
+	it("declares the RECOMMENDED badge", () => {
+		const css = buildSidebarCss();
+		expect(css).toMatch(/\.ob-badge\b/);
+	});
+
+	it("declares primary and secondary onboarding buttons", () => {
+		const css = buildSidebarCss();
+		expect(css).toMatch(/\.ob-btn--primary\b/);
+		expect(css).toMatch(/\.ob-btn--secondary\b/);
+	});
+
+	it("uses VSCode theme tokens (focusBorder, button-background)", () => {
+		const css = buildSidebarCss();
+		// The recommended outline + RECOMMENDED badge accent colour come from
+		// --vscode-focusBorder so they adapt to Light / Dark / High-Contrast
+		// themes without hard-coded hex values.
+		expect(css).toContain("var(--vscode-focusBorder)");
+		expect(css).toContain("var(--vscode-button-background)");
+	});
+
+	it("renders the OR divider with flex-1 lines on either side", () => {
+		const css = buildSidebarCss();
+		expect(css).toMatch(/\.ob-or\b/);
+		expect(css).toMatch(/\.ob-or::before/);
+		expect(css).toMatch(/\.ob-or::after/);
+	});
+
+	it("declares a .loading-panel rule for the first-paint placeholder", () => {
+		const css = buildSidebarCss();
+		// The loading panel sits between webview-load and the host's first
+		// `init` message. Without dedicated centering styles it would
+		// render as a top-left codicon — this rule is what makes it look
+		// like a proper "Loading…" placeholder during reload.
+		expect(css).toMatch(/\.loading-panel\b/);
+		expect(css).toContain("var(--vscode-descriptionForeground)");
+	});
+
+	it("shares the onboarding-panel container rule with .disabled-panel", () => {
+		const css = buildSidebarCss();
+		// .disabled-panel reuses the onboarding container (padding/scroll/
+		// height) by way of a multi-selector rule rather than redeclaring
+		// the same declarations. This keeps the two full-viewport panels in
+		// lockstep so tweaking onboarding spacing automatically applies to
+		// the disabled CTA without a parallel edit.
+		expect(css).toMatch(/\.onboarding-panel\s*,\s*\.disabled-panel\s*\{/);
+	});
+});

--- a/vscode/src/views/SidebarCssBuilder.ts
+++ b/vscode/src/views/SidebarCssBuilder.ts
@@ -558,5 +558,137 @@ export function buildSidebarCss(): string {
     font-size: 11px;
     flex-shrink: 0;
   }
+
+  /* ── Loading panel ────────────────────────────────────────────────
+     First-paint placeholder shown until the host's 'init' message
+     arrives. Centered spinner + label using --vscode-descriptionForeground
+     so it adapts to all themes. The .codicon-modifier-spin class is
+     provided by codicon.css (already linked from the HTML head). */
+  .loading-panel {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 10px;
+    padding: 16px;
+    height: 100%;
+    box-sizing: border-box;
+    color: var(--vscode-descriptionForeground);
+  }
+  .loading-icon {
+    font-size: 20px;
+  }
+  .loading-text {
+    font-size: 12px;
+  }
+
+  /* ── Onboarding panel ─────────────────────────────────────────────
+     Shown when state.configured === false. Sibling of .tab-bar inside
+     .sidebar-root; toggled via the .hidden class by SidebarScriptBuilder.
+     Theme accents (border, badge, primary button) all come from
+     --vscode-focusBorder / --vscode-button-* so the panel adapts to
+     Light / Dark / High-Contrast without hard-coded hex values.
+
+     .disabled-panel is the user-disabled (state.enabled === false)
+     counterpart. It reuses the same container shell + .ob-* header /
+     button styles but renders a stripped-down body (header + Enable
+     button only — no option cards, no OR divider). Sharing the
+     container rule keeps padding/scroll behavior in lockstep. */
+  .onboarding-panel,
+  .disabled-panel {
+    padding: 16px;
+    overflow-y: auto;
+    height: 100%;
+    box-sizing: border-box;
+  }
+  .ob-header { margin-bottom: 12px; }
+  .ob-title-row { display: flex; align-items: center; gap: 8px; }
+  .ob-title-icon {
+    font-size: 18px;
+    color: var(--vscode-textLink-foreground);
+  }
+  .ob-title { font-size: 14px; font-weight: 600; margin: 0; }
+  .ob-subtitle {
+    font-size: 12px;
+    color: var(--vscode-descriptionForeground);
+    margin: 6px 0 0 0;
+    line-height: 1.5;
+  }
+  .ob-divider {
+    border: none;
+    border-top: 1px solid var(--vscode-widget-border, var(--vscode-editorWidget-border));
+    margin: 12px 0 14px 0;
+  }
+  .ob-card {
+    position: relative;
+    border: 1px solid var(--vscode-widget-border, var(--vscode-editorWidget-border));
+    border-radius: 6px;
+    padding: 12px;
+    background: var(--vscode-editor-background);
+  }
+  .ob-card--recommended {
+    border-color: var(--vscode-focusBorder);
+    border-width: 1.5px;
+    padding-top: 14px;
+  }
+  .ob-badge {
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    font-size: 9px;
+    font-weight: 700;
+    letter-spacing: 0.5px;
+    padding: 3px 8px;
+    border-radius: 8px;
+    color: var(--vscode-textLink-activeForeground, var(--vscode-textLink-foreground));
+    background: color-mix(in srgb, var(--vscode-focusBorder) 20%, transparent);
+  }
+  .ob-card-row { display: flex; gap: 10px; align-items: flex-start; }
+  .ob-card-icon {
+    font-size: 16px;
+    margin-top: 2px;
+    color: var(--vscode-foreground);
+  }
+  .ob-card-text { flex: 1; min-width: 0; }
+  .ob-card-title { font-size: 12px; font-weight: 600; margin: 0; }
+  .ob-card-desc {
+    font-size: 12px;
+    color: var(--vscode-descriptionForeground);
+    margin: 4px 0 0 0;
+    line-height: 1.5;
+  }
+  .ob-btn {
+    display: block;
+    width: 100%;
+    padding: 8px 12px;
+    margin-top: 8px;
+    border-radius: 4px;
+    font-size: 13px;
+    cursor: pointer;
+    text-align: center;
+    border: 1px solid transparent;
+  }
+  .ob-btn--primary {
+    background: var(--vscode-button-background);
+    color: var(--vscode-button-foreground);
+  }
+  .ob-btn--primary:hover { background: var(--vscode-button-hoverBackground); }
+  .ob-btn--secondary {
+    background: transparent;
+    color: var(--vscode-foreground);
+    border-color: var(--vscode-widget-border, var(--vscode-editorWidget-border));
+  }
+  .ob-btn--secondary:hover { background: var(--vscode-list-hoverBackground); }
+  .ob-or {
+    display: flex; align-items: center; gap: 10px;
+    margin: 14px 0;
+    font-size: 11px;
+    color: var(--vscode-descriptionForeground);
+  }
+  .ob-or::before, .ob-or::after {
+    content: "";
+    flex: 1;
+    border-top: 1px solid var(--vscode-widget-border, var(--vscode-editorWidget-border));
+  }
   `;
 }

--- a/vscode/src/views/SidebarHtmlBuilder.test.ts
+++ b/vscode/src/views/SidebarHtmlBuilder.test.ts
@@ -113,4 +113,143 @@ describe("SidebarHtmlBuilder", () => {
 		expect(html).toContain('"kbMemoriesEmpty":"No memories yet."');
 		expect(html).toContain('type="application/json"');
 	});
+
+	describe("onboarding panel skeleton", () => {
+		it("includes the onboarding panel, hidden by default", () => {
+			const html = buildSidebarHtml(
+				"test-nonce",
+				"vscode-resource:",
+				"https://example/codicon.css",
+				SIDEBAR_EMPTY_STRINGS,
+			);
+			expect(html).toContain('id="onboarding-panel"');
+			expect(html).toMatch(/<div class="onboarding-panel hidden"/);
+			expect(html).toContain("Get started with Jolli Memory");
+			expect(html).toContain("Sign in to Jolli");
+			expect(html).toContain("Use your Anthropic API key");
+			expect(html).toContain("RECOMMENDED");
+			expect(html).toContain('id="onboarding-signin-btn"');
+			expect(html).toContain('id="onboarding-apikey-btn"');
+		});
+
+		it("renders Anthropic API key as the recommended option above Sign in to Jolli", () => {
+			const html = buildSidebarHtml(
+				"test-nonce",
+				"vscode-resource:",
+				"https://example/codicon.css",
+				SIDEBAR_EMPTY_STRINGS,
+			);
+			const apikeyIdx = html.indexOf("Use your Anthropic API key");
+			const signinIdx = html.indexOf("Sign in to Jolli");
+			expect(apikeyIdx).toBeGreaterThan(-1);
+			expect(signinIdx).toBeGreaterThan(-1);
+			expect(apikeyIdx).toBeLessThan(signinIdx);
+			// The RECOMMENDED badge must live in the same DOM region as the
+			// Anthropic card — i.e. between the panel header and the Sign in card.
+			const badgeIdx = html.indexOf("RECOMMENDED");
+			expect(badgeIdx).toBeGreaterThan(-1);
+			expect(badgeIdx).toBeLessThan(signinIdx);
+		});
+
+		it("uses primary button class on Configure API Key and secondary on Sign In", () => {
+			const html = buildSidebarHtml(
+				"test-nonce",
+				"vscode-resource:",
+				"https://example/codicon.css",
+				SIDEBAR_EMPTY_STRINGS,
+			);
+			expect(html).toMatch(
+				/id="onboarding-apikey-btn"[^>]*class="ob-btn ob-btn--primary"/,
+			);
+			expect(html).toMatch(
+				/id="onboarding-signin-btn"[^>]*class="ob-btn ob-btn--secondary"/,
+			);
+		});
+	});
+
+	describe("loading panel skeleton", () => {
+		it("includes the loading panel visible by default with spinner + label", () => {
+			const html = buildSidebarHtml(
+				"test-nonce",
+				"vscode-resource:",
+				"https://example/codicon.css",
+				SIDEBAR_EMPTY_STRINGS,
+			);
+			// Loading panel is the first-paint placeholder. It must NOT be
+			// hidden by default — the script tears it down once init lands.
+			expect(html).toContain('id="loading-panel"');
+			expect(html).toMatch(/<div class="loading-panel"/);
+			expect(html).not.toMatch(/<div class="loading-panel hidden"/);
+			expect(html).toContain("codicon-loading codicon-modifier-spin");
+			expect(html).toContain("Loading…");
+		});
+
+		it("hides tab-bar and all tab-content panels by default so they don't peek through during loading", () => {
+			const html = buildSidebarHtml(
+				"test-nonce",
+				"vscode-resource:",
+				"https://example/codicon.css",
+				SIDEBAR_EMPTY_STRINGS,
+			);
+			// Without these defaults, reload would briefly show the tab bar
+			// before the script wires up applyConfigured/applyEnabled.
+			expect(html).toMatch(/<div class="tab-bar hidden"/);
+			expect(html).toMatch(
+				/<div class="tab-content hidden" id="tab-content-branch"/,
+			);
+			expect(html).toMatch(
+				/<div class="tab-content hidden" id="tab-content-kb"/,
+			);
+			expect(html).toMatch(
+				/<div class="tab-content hidden" id="tab-content-status"/,
+			);
+		});
+	});
+
+	describe("disabled panel skeleton", () => {
+		it("includes the disabled panel, hidden by default, with a header and Enable button", () => {
+			const html = buildSidebarHtml(
+				"test-nonce",
+				"vscode-resource:",
+				"https://example/codicon.css",
+				SIDEBAR_EMPTY_STRINGS,
+			);
+			expect(html).toContain('id="disabled-panel"');
+			expect(html).toMatch(/<div class="disabled-panel hidden"/);
+			expect(html).toContain('id="disabled-enable-btn"');
+			expect(html).toMatch(
+				/id="disabled-enable-btn"[^>]*class="ob-btn ob-btn--primary"/,
+			);
+			expect(html).toMatch(
+				/<button[^>]*id="disabled-enable-btn"[^>]*>Enable Jolli Memory<\/button>/,
+			);
+		});
+
+		it("reuses the onboarding header copy (Get started + subtitle) and omits the option cards", () => {
+			const html = buildSidebarHtml(
+				"test-nonce",
+				"vscode-resource:",
+				"https://example/codicon.css",
+				SIDEBAR_EMPTY_STRINGS,
+			);
+			// Slice from disabled-panel open to the next sibling (tab-bar);
+			// disabled-panel sits between onboarding-panel and tab-bar in the
+			// skeleton, so this window contains exactly the panel's body.
+			const start = html.indexOf('<div class="disabled-panel');
+			const end = html.indexOf('<div class="tab-bar', start);
+			expect(start).toBeGreaterThan(-1);
+			expect(end).toBeGreaterThan(start);
+			const panel = html.slice(start, end);
+			expect(panel).toContain("Get started with Jolli Memory");
+			expect(panel).toContain(
+				"Jolli Memory automatically captures your work context",
+			);
+			// Onboarding-only artefacts must NOT bleed into the disabled panel.
+			expect(panel).not.toContain("RECOMMENDED");
+			expect(panel).not.toContain("Use your Anthropic API key");
+			expect(panel).not.toContain("Sign in to Jolli");
+			expect(panel).not.toMatch(/class="ob-card/);
+			expect(panel).not.toMatch(/class="ob-or"/);
+		});
+	});
 });

--- a/vscode/src/views/SidebarHtmlBuilder.ts
+++ b/vscode/src/views/SidebarHtmlBuilder.ts
@@ -2,13 +2,29 @@
  * SidebarHtmlBuilder
  *
  * Builds the static HTML skeleton for the sidebar webview. The skeleton has:
+ *   - A loading panel that takes the full viewport on first paint. The host
+ *     pushes `configured` / `enabled` asynchronously (statusStore must spawn
+ *     the CLI to derive them), so without this neutral placeholder the
+ *     webview would default to onboarding (configured=false) and flicker to
+ *     the tab UI when the real values arrive on a reload. The init handler
+ *     hides this panel before applying the real configured/enabled flags.
+ *   - An onboarding panel rendered before the tab bar, hidden by default.
+ *     Shown when `state.configured === false` (no Jolli sign-in and no Anthropic
+ *     key). In that mode the tab bar and tab content are hidden; the onboarding
+ *     panel takes the entire viewport. The Anthropic API key path is positioned
+ *     as the recommended primary option above the secondary Sign in to Jolli card.
+ *   - A disabled panel sibling, hidden by default. Shown when the user is
+ *     configured but has explicitly disabled the extension (`state.enabled ===
+ *     false`). It reuses the onboarding header copy + the `.ob-*` styles, but
+ *     drops the option cards and shows a single primary "Enable" button. The
+ *     legacy disabled-banner inside the Status panel is kept for the degraded
+ *     (no-workspace / no-git) fallback only.
  *   - 2 labeled tab buttons (branch / Memory Bank) + a right-side icon area
  *     holding a status indicator icon (settings moved into the Status tab toolbar)
  *   - 3 tab content panels (one shown at a time, the others have the `.hidden` class)
- *   - A disabled-state intro rendered inside the Status panel itself (replaces
- *     the entries area when state.enabled === false). In disabled mode the tab
- *     bar and per-tab toolbar are hidden — only the Status panel is visible,
- *     showing the intro + Enable button instead of "No status to display".
+ *   - A disabled-state intro rendered inside the Status panel itself, used only
+ *     for the degraded fallback (no workspace / no git). The standard
+ *     user-disabled state shows the disabled-panel above instead.
  *
  * Visibility convention: every togglable element here uses the `.hidden` class
  * (defined in SidebarCssBuilder as `display: none !important`). We avoid the
@@ -43,7 +59,53 @@ export function buildSidebarHtml(
 </head>
 <body>
   <div class="sidebar-root" id="sidebar-root">
-    <div class="tab-bar" id="tab-bar" role="tablist">
+    <div class="loading-panel" id="loading-panel" role="status" aria-live="polite">
+      <i class="codicon codicon-loading codicon-modifier-spin loading-icon" aria-hidden="true"></i>
+      <span class="loading-text">Loading…</span>
+    </div>
+    <div class="onboarding-panel hidden" id="onboarding-panel" role="region" aria-label="Get started with Jolli Memory">
+      <header class="ob-header">
+        <div class="ob-title-row">
+          <i class="codicon codicon-sparkle ob-title-icon" aria-hidden="true"></i>
+          <h2 class="ob-title">Get started with Jolli Memory</h2>
+        </div>
+        <p class="ob-subtitle">Jolli Memory automatically captures your work context and surfaces relevant memories as you code. Choose how you'd like to set it up.</p>
+      </header>
+      <hr class="ob-divider" />
+      <section class="ob-card ob-card--recommended">
+        <span class="ob-badge">RECOMMENDED</span>
+        <div class="ob-card-row">
+          <i class="codicon codicon-key ob-card-icon" aria-hidden="true"></i>
+          <div class="ob-card-text">
+            <h3 class="ob-card-title">Use your Anthropic API key</h3>
+            <p class="ob-card-desc">Connect your own Anthropic API key for AI summarization. Memories are stored locally only.</p>
+          </div>
+        </div>
+      </section>
+      <button type="button" id="onboarding-apikey-btn" class="ob-btn ob-btn--primary">Configure API Key</button>
+      <div class="ob-or"><span>OR</span></div>
+      <section class="ob-card">
+        <div class="ob-card-row">
+          <i class="codicon codicon-cloud ob-card-icon" aria-hidden="true"></i>
+          <div class="ob-card-text">
+            <h3 class="ob-card-title">Sign in to Jolli</h3>
+            <p class="ob-card-desc">Use Jolli's cloud to sync memories across machines and get AI summarization out of the box. Free to get started.</p>
+          </div>
+        </div>
+      </section>
+      <button type="button" id="onboarding-signin-btn" class="ob-btn ob-btn--secondary">Sign In / Sign Up</button>
+    </div>
+    <div class="disabled-panel hidden" id="disabled-panel" role="region" aria-label="Enable Jolli Memory">
+      <header class="ob-header">
+        <div class="ob-title-row">
+          <i class="codicon codicon-sparkle ob-title-icon" aria-hidden="true"></i>
+          <h2 class="ob-title">Get started with Jolli Memory</h2>
+        </div>
+        <p class="ob-subtitle">Jolli Memory automatically captures your work context and surfaces relevant memories as you code. Enable Jolli Memory to get started.</p>
+      </header>
+      <button type="button" id="disabled-enable-btn" class="ob-btn ob-btn--primary">Enable Jolli Memory</button>
+    </div>
+    <div class="tab-bar hidden" id="tab-bar" role="tablist">
       <button class="tab active" type="button" data-tab="branch" role="tab" id="tab-button-branch"><i class="codicon codicon-git-branch tab-icon-leading" aria-hidden="true"></i><span class="tab-label">(loading)</span></button>
       <button class="tab" type="button" data-tab="kb" role="tab" id="tab-button-kb"><i class="codicon codicon-book tab-icon-leading" aria-hidden="true"></i><span class="tab-label">MEMORY BANK</span></button>
       <div class="tab-bar-right">
@@ -54,7 +116,7 @@ export function buildSidebarHtml(
     </div>
     <div class="tab-toolbar hidden" id="tab-toolbar"></div>
     <div class="tab-content hidden" id="tab-content-kb"><p class="placeholder">Loading...</p></div>
-    <div class="tab-content" id="tab-content-branch"><p class="placeholder">Loading...</p></div>
+    <div class="tab-content hidden" id="tab-content-branch"><p class="placeholder">Loading...</p></div>
     <div class="tab-content hidden" id="tab-content-status">
       <div class="disabled-banner hidden" id="disabled-banner">
         <p class="disabled-intro">Capture searchable memories from your AI coding sessions and weave them into your git history. Each commit gets an AI-generated summary you can recall later.</p>

--- a/vscode/src/views/SidebarMessages.ts
+++ b/vscode/src/views/SidebarMessages.ts
@@ -26,6 +26,19 @@ export interface SidebarState {
 	 * after the OAuth callback completes (signIn) and after signOut clears creds.
 	 */
 	readonly authenticated: boolean;
+	/**
+	 * Whether the user has provided enough credentials to actually use AI
+	 * features — signed in to Jolli OR has supplied an Anthropic API key. Drives
+	 * the onboarding panel vs main tabs split: when `false`, the webview shows
+	 * the onboarding panel; when `true`, the normal sidebar UI renders. Pushed
+	 * via `configured:changed` whenever auth state or the Anthropic key changes.
+	 *
+	 * Optional because the consumer (`SidebarScriptBuilder`) treats `undefined`
+	 * as "not yet known" via `configured !== false` and the HTML default state
+	 * shows the main UI — same behavior the host produces by sending
+	 * `configured: true` once `currentConfigured` is hydrated.
+	 */
+	readonly configured?: boolean;
 	readonly activeTab: SidebarTab;
 	readonly kbMode: KbMode;
 	readonly branchName: string;
@@ -284,4 +297,5 @@ export type SidebarInboundMsg =
 	  }
 	| { readonly type: "enabled:changed"; readonly enabled: boolean }
 	| { readonly type: "auth:changed"; readonly authenticated: boolean }
+	| { readonly type: "configured:changed"; readonly configured: boolean }
 	| { readonly type: "worker:busy"; readonly busy: boolean };

--- a/vscode/src/views/SidebarScriptBuilder.test.ts
+++ b/vscode/src/views/SidebarScriptBuilder.test.ts
@@ -117,15 +117,65 @@ describe("SidebarScriptBuilder", () => {
 		expect(js).toContain("state.authenticated = !!msg.authenticated");
 	});
 
-	it("disabled mode forces Status panel visible and hides KB/Branch panels", () => {
+	it("hides the loading-panel as soon as init arrives so the placeholder doesn't outlive the host's first state push", () => {
 		const js = buildSidebarScript();
-		// Explicit visibility flips for the disabled branch of applyEnabled.
-		// We toggle the .hidden class (instead of the HTML hidden attribute)
-		// because UA-stylesheet display:none for [hidden] loses to author
-		// rules like display:flex on .tab-bar / .tab-toolbar.
+		// The loading-panel is unhidden in HTML (no .hidden) and must be
+		// hidden by the init handler before any apply* call decides which
+		// of the configured / disabled / tab-UI panels to surface. This
+		// avoids both panels being visible at once during the init frame.
+		expect(js).toContain("getElementById('loading-panel')");
+		const initStart = js.indexOf("'init'");
+		const initEnd = js.indexOf("case ", initStart + 1);
+		expect(initStart).toBeGreaterThan(-1);
+		expect(js.slice(initStart, initEnd)).toContain(
+			"loadingPanel.classList.add('hidden')",
+		);
+	});
+
+	it("disabled mode hides every tab-content and shows the disabled-panel only", () => {
+		const js = buildSidebarScript();
+		// applyEnabled(false) lets the new disabled-panel take the entire
+		// viewport: every tab-content is hidden, the tab bar is hidden, and
+		// only the disabled-panel sibling is visible. The legacy
+		// disabled-banner stays hidden — it's reserved for the degraded
+		// fallback (no-workspace / no-git) which applyDegraded sets up
+		// explicitly afterwards.
 		expect(js).toContain("tabContents.kb.classList.add('hidden')");
 		expect(js).toContain("tabContents.branch.classList.add('hidden')");
-		expect(js).toContain("tabContents.status.classList.remove('hidden')");
+		expect(js).toContain("tabContents.status.classList.add('hidden')");
+		// `.toggle('hidden', !!enabled)` covers both directions:
+		// hidden when enabled, visible when disabled.
+		expect(js).toMatch(
+			/disabledPanel\.classList\.toggle\(['"]hidden['"], !!enabled\)/,
+		);
+		expect(js).toMatch(/tabBar\.classList\.toggle\(['"]hidden['"], !enabled\)/);
+		expect(js).toContain("disabledBanner.classList.add('hidden')");
+	});
+
+	it("wires the disabled-panel Enable button to jollimemory.enableJolliMemory", () => {
+		const js = buildSidebarScript();
+		expect(js).toContain("getElementById('disabled-enable-btn')");
+		// The button is its own listener (separate from the legacy in-Status
+		// banner enable-btn) and dispatches the Enable command.
+		expect(js).toMatch(
+			/disabledEnableBtn\.addEventListener\(['"]click['"][\s\S]{0,200}jollimemory\.enableJolliMemory/,
+		);
+	});
+
+	it("applyDegraded keeps the legacy disabled-banner path (Status panel + banner re-shown after applyEnabled(false))", () => {
+		const js = buildSidebarScript();
+		// applyDegraded must explicitly un-hide the Status tab content and
+		// the disabled-banner because applyEnabled(false) hides both.
+		// Without these, the reason-specific CTA (Open Folder / Initialize
+		// Git) would be invisible and the user would be stuck on a blank
+		// disabled-panel with the wrong button.
+		const start = js.indexOf("function applyDegraded");
+		const end = js.indexOf("function ", start + 1);
+		expect(start).toBeGreaterThan(-1);
+		const body = js.slice(start, end);
+		expect(body).toContain("disabledPanel.classList.add('hidden')");
+		expect(body).toContain("tabContents.status.classList.remove('hidden')");
+		expect(body).toContain("disabledBanner.classList.remove('hidden')");
 	});
 
 	it("re-renders toolbar on enabled:changed (Disable button visibility depends on enabled)", () => {
@@ -146,7 +196,7 @@ describe("SidebarScriptBuilder", () => {
 		expect(js).toContain("AI summary in progress…");
 	});
 
-	it("handles worker:busy by re-rendering toolbar only when on Branch tab", () => {
+	it("handles worker:busy by re-rendering toolbar AND branch on the Branch tab", () => {
 		const js = buildSidebarScript();
 		expect(js).toContain("'worker:busy'");
 		// Idempotent: skip re-render when the flag did not change.
@@ -157,9 +207,14 @@ describe("SidebarScriptBuilder", () => {
 		const handlerStart = js.indexOf("'worker:busy'");
 		const handlerEnd = js.indexOf("case ", handlerStart + 1);
 		expect(handlerStart).toBeGreaterThan(-1);
-		expect(js.slice(handlerStart, handlerEnd)).toContain(
-			"state.activeTab === 'branch'",
-		);
+		const body = js.slice(handlerStart, handlerEnd);
+		expect(body).toContain("state.activeTab === 'branch'");
+		// Toolbar repaint covers the "AI summary in progress…" indicator.
+		expect(body).toContain("renderToolbar()");
+		// Branch repaint covers the changes section's Commit-AI button —
+		// its disabled state depends on state.workerBusy, and renderToolbar
+		// alone wouldn't refresh it (section actions live in renderBranch).
+		expect(body).toContain("renderBranch()");
 	});
 
 	it("posts kb:expandFolder when an unexpanded folder is clicked", () => {
@@ -614,6 +669,22 @@ describe("SidebarScriptBuilder", () => {
 			const js = buildSidebarScript();
 			expect(js).toContain("'jollimemory.discardSelectedChanges'");
 		});
+
+		it("disables changes-commit-ai while a background AI summary is in progress", () => {
+			const js = buildSidebarScript();
+			// Even with selected changes, the Commit-AI button must stay
+			// disabled when state.workerBusy is true — kicking off another
+			// LLM call while the queue worker is mid-flight risks racing
+			// the same provider / hitting rate limits. Discard stays
+			// available because it's purely local (no LLM).
+			expect(js).toMatch(
+				/iconButton\('changes-commit-ai',[\s\S]*?disabled:\s*noneSelected\s*\|\|\s*state\.workerBusy/,
+			);
+			// Discard's disabled condition must NOT include workerBusy.
+			expect(js).toMatch(
+				/iconButton\('changes-discard',[\s\S]*?disabled:\s*noneSelected\s*\}/,
+			);
+		});
 	});
 
 	describe("section header click delegation", () => {
@@ -755,6 +826,55 @@ describe("SidebarScriptBuilder", () => {
 			expect(js).toMatch(
 				/ctxMenu\.addEventListener\('click',[\s\S]*?data-raw-msg[\s\S]*?data-cmd/,
 			);
+		});
+	});
+
+	describe("onboarding panel toggle", () => {
+		it("handles configured:changed messages", () => {
+			const js = buildSidebarScript();
+			expect(js).toContain("'configured:changed'");
+		});
+
+		it("references the onboarding panel id when toggling visibility", () => {
+			const js = buildSidebarScript();
+			expect(js).toContain("onboarding-panel");
+		});
+
+		it("wires onboarding signin button to dispatch jollimemory.signIn", () => {
+			const js = buildSidebarScript();
+			expect(js).toContain("onboarding-signin-btn");
+			expect(js).toContain("'jollimemory.signIn'");
+		});
+
+		it("wires onboarding apikey button to dispatch jollimemory.openSettings", () => {
+			const js = buildSidebarScript();
+			expect(js).toContain("onboarding-apikey-btn");
+			expect(js).toContain("'jollimemory.openSettings'");
+		});
+
+		it("reads configured from init state", () => {
+			const js = buildSidebarScript();
+			// The init handler must consult msg.state.configured to pick the
+			// onboarding-vs-main branch on first paint.
+			expect(js).toMatch(/msg\.state\.configured/);
+		});
+
+		it("applyConfigured(true) un-hides the tabBar via applyEnabled's toggle", () => {
+			const js = buildSidebarScript();
+			// applyConfigured(false) adds .hidden to #tab-bar to clear room
+			// for the onboarding panel. applyConfigured(true) delegates to
+			// applyEnabled(state.enabled), which now owns the tabBar
+			// .hidden flag (see "disabled mode hides every tab-content..."
+			// for the toggle assertion). The path back from onboarding is
+			// therefore covered by that single toggle in applyEnabled —
+			// when the host pushes enabled === true, tabBar reappears.
+			expect(js).toContain("function applyConfigured");
+			// The configured===true branch must end by delegating to applyEnabled
+			// so the tab bar / toolbar / contents resync against the host's
+			// enabled flag instead of being left stuck in onboarding-hidden state.
+			const start = js.indexOf("function applyConfigured");
+			const end = js.indexOf("function ", start + 1);
+			expect(js.slice(start, end)).toMatch(/applyEnabled\(state\.enabled\)/);
 		});
 	});
 });

--- a/vscode/src/views/SidebarScriptBuilder.ts
+++ b/vscode/src/views/SidebarScriptBuilder.ts
@@ -76,6 +76,12 @@ export function buildSidebarScript(): string {
     activeTab: 'branch',
     kbMode: 'folders',
     authenticated: false,
+    // 'enabled' / 'configured' default to truthy so the HTML default state
+    // (onboarding panel hidden, tab UI visible) does not flicker before the
+    // host's init message arrives. The init handler reconciles both fields
+    // against the real values from the host.
+    enabled: true,
+    configured: true,
     sectionsCollapsed: {},
     // Per-commit expand toggle (hash → bool). Native TreeView starts each
     // commit collapsed; we mirror that default but persist user toggles
@@ -110,6 +116,22 @@ export function buildSidebarScript(): string {
   const tabButtonKb = document.getElementById('tab-button-kb');
   const tabBranchBtn = document.getElementById('tab-button-branch');
   const statusIconBtn = document.getElementById('status-icon-btn');
+  // Onboarding panel — full-viewport replacement for the tab UI when the
+  // user has not configured AI yet (no Jolli sign-in and no Anthropic key).
+  const onboardingPanel = document.getElementById('onboarding-panel');
+  const onboardingSigninBtn = document.getElementById('onboarding-signin-btn');
+  const onboardingApikeyBtn = document.getElementById('onboarding-apikey-btn');
+  // Disabled panel — full-viewport "Enable" CTA shown when the user is
+  // configured but has explicitly disabled the extension. Sibling of the
+  // onboarding panel; mutually exclusive with it.
+  const disabledPanel = document.getElementById('disabled-panel');
+  const disabledEnableBtn = document.getElementById('disabled-enable-btn');
+  // Loading panel — visible on first paint (no .hidden in HTML), then
+  // hidden as soon as the host's init message arrives. Bridges the gap
+  // between webview-load and the first real configured/enabled values
+  // so reload doesn't briefly show the onboarding panel as a side effect
+  // of host's currentConfigured starting at false.
+  const loadingPanel = document.getElementById('loading-panel');
   const tabContents = {
     kb: document.getElementById('tab-content-kb'),
     branch: document.getElementById('tab-content-branch'),
@@ -371,6 +393,26 @@ export function buildSidebarScript(): string {
     vscode.postMessage({ type: 'command', command: enableBtn.dataset.command || 'jollimemory.enableJolliMemory' });
   });
 
+  // Onboarding panel buttons. The Anthropic API key path is the recommended
+  // primary action and routes to the existing Settings webview (where the
+  // user already configures their API key); Sign In / Sign Up runs the
+  // OAuth-based jollimemory.signIn command.
+  onboardingApikeyBtn.addEventListener('click', function() {
+    vscode.postMessage({ type: 'command', command: 'jollimemory.openSettings' });
+  });
+  onboardingSigninBtn.addEventListener('click', function() {
+    vscode.postMessage({ type: 'command', command: 'jollimemory.signIn' });
+  });
+
+  // Disabled-panel Enable button — same command as the legacy in-Status
+  // disabled-banner Enable button (jollimemory.enableJolliMemory). Wired
+  // separately because the two buttons live in disjoint DOM regions and
+  // only one is visible at a time (disabled-panel for user-opt-out,
+  // disabled-banner for the degraded fallback).
+  disabledEnableBtn.addEventListener('click', function() {
+    vscode.postMessage({ type: 'command', command: 'jollimemory.enableJolliMemory' });
+  });
+
   // Close context menu on outside click.
   document.addEventListener('click', function(e) {
     if (!ctxMenu.contains(e.target)) ctxMenu.classList.add('hidden');
@@ -387,6 +429,12 @@ export function buildSidebarScript(): string {
     switch (msg.type) {
       case 'init':
         if (typeof msg.state.authenticated === 'boolean') state.authenticated = msg.state.authenticated;
+        // Tear down the first-paint loading placeholder once init lands —
+        // every following branch (degraded, configured, disabled, normal)
+        // unhides exactly the panel it owns, so this is the single hand-off
+        // point. Doing it before applyDegraded means degraded paths don't
+        // need to know about the loading panel.
+        loadingPanel.classList.add('hidden');
         if (msg.state.degradedReason) {
           // Degraded path: no workspace folder open, or workspace is not a git
           // repo. Skip the rest of init (data providers aren't wired in this
@@ -395,6 +443,11 @@ export function buildSidebarScript(): string {
           break;
         }
         applyEnabled(msg.state.enabled);
+        // Onboarding gate sits on top of enabled — when configured===false it
+        // hides the tab UI applyEnabled just configured. configured defaults to
+        // true on undefined (e.g. older host code, transient init message)
+        // so the regular UI keeps working without a strict-host upgrade.
+        applyConfigured(msg.state.configured !== false);
         if (msg.state.activeTab) switchTab(msg.state.activeTab);
         if (msg.state.kbMode) state.kbMode = msg.state.kbMode;
         if (typeof msg.state.kbRepoFolder === 'string') kbRepoFolder = msg.state.kbRepoFolder;
@@ -425,13 +478,27 @@ export function buildSidebarScript(): string {
         // toolbar; re-render so the swap takes effect immediately.
         if (state.activeTab === 'status') renderToolbar();
         break;
+      case 'configured:changed':
+        applyConfigured(!!msg.configured);
+        // After flipping configured back to true we're back on the regular
+        // UI surface; refresh the toolbar so the active-tab buttons reflect
+        // the current state (e.g. Sign In/Out icon, worker-busy label).
+        if (msg.configured) renderToolbar();
+        break;
       case 'worker:busy': {
         const next = !!msg.busy;
         if (state.workerBusy === next) break;
         state.workerBusy = next;
-        // Only the Branch tab toolbar shows this indicator; other tabs ignore
-        // the flag, so re-render is scoped to avoid wiping their toolbars.
-        if (state.activeTab === 'branch') renderToolbar();
+        // Only the Branch tab reacts to workerBusy: the toolbar shows the
+        // "AI summary in progress…" indicator (renderToolbar) and the
+        // Changes section's Commit-AI icon must flip its disabled state
+        // (renderSectionActions reads state.workerBusy → renderBranch
+        // re-mounts the section action span). Other tabs ignore the flag
+        // so we don't wipe their toolbars.
+        if (state.activeTab === 'branch') {
+          renderToolbar();
+          renderBranch();
+        }
         break;
       }
       case 'branch:branchName':
@@ -481,48 +548,97 @@ export function buildSidebarScript(): string {
   }
 
   function applyEnabled(enabled) {
-    disabledBanner.classList.toggle('hidden', !!enabled);
+    state.enabled = !!enabled;
+    // While the onboarding panel is showing, keep all main-UI elements hidden
+    // regardless of the enabled flag — the onboarding flow takes the entire
+    // viewport. applyConfigured(true) re-invokes applyEnabled on its own when
+    // the user finishes configuring, so this branch never traps the UI.
+    if (state.configured === false) {
+      disabledPanel.classList.add('hidden');
+      disabledBanner.classList.add('hidden');
+      statusEntries.classList.add('hidden');
+      return;
+    }
     statusEntries.classList.toggle('hidden', !enabled);
-    // Tab bar itself stays visible always; we hide just the labeled KB / Branch
-    // tab buttons so only the Status icon remains in the bar when disabled.
-    tabButtonKb.classList.toggle('hidden', !enabled);
-    tabBranchBtn.classList.toggle('hidden', !enabled);
+    // The legacy disabled-banner inside the Status panel is reserved for the
+    // degraded (no-workspace / no-git) fallback. The standard user-disabled
+    // path uses the new disabled-panel above, so keep the banner hidden here
+    // and let applyDegraded re-show it when needed.
+    disabledBanner.classList.add('hidden');
+    // Disabled-panel mirrors enabled: hidden when enabled, visible when not.
+    disabledPanel.classList.toggle('hidden', !!enabled);
+    // Tab bar — hidden entirely in the disabled state because the
+    // disabled-panel takes the full viewport (no Status tab to land on).
+    tabBar.classList.toggle('hidden', !enabled);
     tabToolbar.classList.toggle('hidden', !enabled);
     // Invalidate the status-entries cache: visibility flipped, so the next
     // status:data push must repaint regardless of whether the JSON changed.
     lastStatusEntriesJson = null;
 
-    // Sync the .active class on tab buttons. When disabled, the Status icon is
-    // the only visible tab and Status content is force-shown, so the icon
-    // should look active regardless of state.activeTab. state.activeTab is
-    // preserved untouched so re-enabling restores the user's previous tab.
-    const visualActive = enabled ? state.activeTab : 'status';
-    document.querySelectorAll('.tab').forEach(function(elBtn) {
-      elBtn.classList.toggle('active', elBtn.getAttribute('data-tab') === visualActive);
-    });
-
     if (enabled) {
+      // Restore tab-button labels (cleared by disabled-mode overrides if any)
+      // and sync .active class against the persisted active tab.
+      tabButtonKb.classList.remove('hidden');
+      tabBranchBtn.classList.remove('hidden');
+      document.querySelectorAll('.tab').forEach(function(elBtn) {
+        elBtn.classList.toggle('active', elBtn.getAttribute('data-tab') === state.activeTab);
+      });
       // Normal mode: only the active tab's content is visible.
       Object.keys(tabContents).forEach(function(t) {
         tabContents[t].classList.toggle('hidden', t !== state.activeTab);
       });
     } else {
-      // Disabled mode: hide KB and Branch panels, force Status panel visible
-      // so the disabled-banner inside it (intro + Enable button) is the only
-      // thing the user sees — no labeled tabs, no toolbar, no entries area.
+      // Disabled mode: the disabled-panel is the entire UI. Hide every
+      // tab-content so the panel sits cleanly in the viewport, and clear the
+      // .active class on tab buttons so re-enable starts from a clean slate.
       tabContents.kb.classList.add('hidden');
       tabContents.branch.classList.add('hidden');
-      tabContents.status.classList.remove('hidden');
+      tabContents.status.classList.add('hidden');
+      document.querySelectorAll('.tab').forEach(function(elBtn) {
+        elBtn.classList.remove('active');
+      });
     }
   }
 
-  // Degraded mode (no workspace / no git) reuses the disabled visuals — same
-  // hidden tabs/toolbar, same banner-only Status panel — but swaps the banner
-  // copy and primary-button command for the reason-specific CTA. The standard
-  // "Enable Jolli Memory" path doesn't apply because the underlying problem is
-  // outside our control (user must open a folder or init git first).
+  // Toggles between the onboarding flow and the regular tab UI based on
+  // whether the user has supplied any AI credentials (Jolli sign-in OR
+  // Anthropic key). When configured=false the onboarding panel takes the
+  // entire sidebar viewport and every other element is hidden. When
+  // configured=true we restore the regular UI by re-running applyEnabled
+  // against the last-known enabled flag (host always pushes enabled:changed
+  // before we'd flip configured back, but defending against ordering keeps
+  // this idempotent).
+  function applyConfigured(configured) {
+    state.configured = !!configured;
+    if (!configured) {
+      onboardingPanel.classList.remove('hidden');
+      disabledPanel.classList.add('hidden');
+      tabBar.classList.add('hidden');
+      tabToolbar.classList.add('hidden');
+      tabContents.kb.classList.add('hidden');
+      tabContents.branch.classList.add('hidden');
+      tabContents.status.classList.add('hidden');
+      disabledBanner.classList.add('hidden');
+      return;
+    }
+    onboardingPanel.classList.add('hidden');
+    // applyEnabled() now manages the .hidden flag on tabBar itself (it hides
+    // the bar in disabled mode because disabled-panel owns the viewport),
+    // so just delegate — no manual tabBar.classList.remove('hidden') needed.
+    applyEnabled(state.enabled);
+  }
+
+  // Degraded mode (no workspace / no git) keeps the legacy disabled-banner
+  // path: it has reason-specific copy and a non-Enable primary command
+  // (Open Folder / Initialize Git) that the new disabled-panel doesn't
+  // model. We start from applyEnabled(false) — which hides everything
+  // including the disabled-panel — then explicitly swap in the Status tab
+  // + banner so the reason-specific CTA is the only visible element.
   function applyDegraded(reason) {
     applyEnabled(false);
+    disabledPanel.classList.add('hidden');
+    tabContents.status.classList.remove('hidden');
+    disabledBanner.classList.remove('hidden');
     const intro = disabledBanner.querySelector('.disabled-intro');
     if (reason === 'no-workspace') {
       if (intro) intro.textContent = 'Open a folder to start capturing memories from your AI coding sessions.';
@@ -1367,13 +1483,17 @@ export function buildSidebarScript(): string {
       // similarly has no work to do with zero selection. Disable both below
       // that threshold. Re-enables itself on the next branch:changesData
       // push (which always follows a checkbox toggle on the host side).
+      // Commit-AI is also disabled while a background AI summary is in
+      // progress (state.workerBusy) — kicking off another LLM call while
+      // the queue worker is mid-flight risks racing the same provider /
+      // hitting rate limits. Discard is local-only so it stays available.
       const selectedCount = branchData.changes.filter(function(c) {
         return !!c.isSelected;
       }).length;
       const noneSelected = selectedCount === 0;
       return [
         iconButton('changes-select-all', 'Select/Deselect All Files', 'check-all'),
-        iconButton('changes-commit-ai',  'Commit (AI message)',       'sparkle',  { disabled: noneSelected }),
+        iconButton('changes-commit-ai',  'Commit (AI message)',       'sparkle',  { disabled: noneSelected || state.workerBusy }),
         iconButton('changes-discard',    'Discard Selected Changes',  'discard',  { disabled: noneSelected }),
       ];
     }

--- a/vscode/src/views/SidebarWebviewProvider.test.ts
+++ b/vscode/src/views/SidebarWebviewProvider.test.ts
@@ -1,5 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { SidebarInboundMsg, SidebarOutboundMsg } from "./SidebarMessages";
+import type {
+	SidebarInboundMsg,
+	SidebarOutboundMsg,
+	SidebarState,
+} from "./SidebarMessages";
 import { SidebarWebviewProvider } from "./SidebarWebviewProvider";
 
 interface MockWebview {
@@ -45,6 +49,14 @@ vi.mock("vscode", () => ({
 		})),
 	},
 }));
+
+// Drains queued microtasks so the async ready handler (which awaits
+// deps.initialStateReady before posting init) gets a chance to run.
+// Two ticks: one for the await, one for the trailing then-block.
+async function flushReady(): Promise<void> {
+	await Promise.resolve();
+	await Promise.resolve();
+}
 
 function makeMockView(): MockWebviewView {
 	let messageHandler: ((msg: SidebarOutboundMsg) => void) | undefined;
@@ -97,10 +109,11 @@ describe("SidebarWebviewProvider", () => {
 		expect(view.webview.html).toContain('id="sidebar-root"');
 	});
 
-	it("posts `init` when client sends `ready`", () => {
+	it("posts `init` when client sends `ready`", async () => {
 		const view = makeMockView();
 		provider.resolveWebviewView(view as unknown as never);
 		view.webview.triggerMessage({ type: "ready" });
+		await flushReady();
 		const sent = view.webview.postMessage.mock.calls.map(
 			(c) => c[0],
 		) as SidebarInboundMsg[];
@@ -172,7 +185,7 @@ describe("SidebarWebviewProvider", () => {
 		).toBe(true);
 	});
 
-	it("posts worker:busy alongside status:data so the Branch toolbar can react", () => {
+	it("posts worker:busy alongside status:data so the Branch toolbar can react", async () => {
 		const view = makeMockView();
 		let busyValue = false;
 		let storedHandler: (() => void) | undefined;
@@ -198,6 +211,7 @@ describe("SidebarWebviewProvider", () => {
 		});
 		provider.resolveWebviewView(view as unknown as never);
 		view.webview.triggerMessage({ type: "ready" });
+		await flushReady();
 		// Initial pushStatus on ready: busy=false.
 		const initial = view.webview.postMessage.mock.calls.map((c) => c[0]);
 		expect(
@@ -223,6 +237,7 @@ describe("SidebarWebviewProvider", () => {
 			getInitialState: () => ({
 				enabled: true,
 				authenticated: false,
+				configured: true,
 				activeTab: "kb",
 				kbMode: "folders",
 				branchName: "main",
@@ -258,6 +273,7 @@ describe("SidebarWebviewProvider", () => {
 			getInitialState: () => ({
 				enabled: true,
 				authenticated: false,
+				configured: true,
 				activeTab: "kb",
 				kbMode: "folders",
 				branchName: "main",
@@ -324,7 +340,7 @@ describe("SidebarWebviewProvider", () => {
 		expect(exec).toHaveBeenCalledWith("vscode.open", expect.anything());
 	});
 
-	it("posts kb:memoriesData on ready and on memoriesProvider change", () => {
+	it("posts kb:memoriesData on ready and on memoriesProvider change", async () => {
 		const view = makeMockView();
 		let memHandler: (() => void) | undefined;
 		const memProvider = {
@@ -361,6 +377,7 @@ describe("SidebarWebviewProvider", () => {
 		});
 		provider.resolveWebviewView(view as unknown as never);
 		view.webview.triggerMessage({ type: "ready" });
+		await flushReady();
 		memHandler?.();
 		const msgs = view.webview.postMessage.mock.calls.map((c) => c[0]);
 		expect(
@@ -442,6 +459,7 @@ describe("SidebarWebviewProvider", () => {
 			getInitialState: () => ({
 				enabled: true,
 				authenticated: false,
+				configured: true,
 				activeTab: "kb",
 				kbMode: "folders",
 				branchName: "main",
@@ -466,7 +484,7 @@ describe("SidebarWebviewProvider", () => {
 		).toBe(true);
 	});
 
-	it("pushes initial branch name on ready", () => {
+	it("pushes initial branch name on ready", async () => {
 		const view = makeMockView();
 		const provider = new SidebarWebviewProvider({
 			executeCommand: vi.fn(),
@@ -486,6 +504,7 @@ describe("SidebarWebviewProvider", () => {
 		});
 		provider.resolveWebviewView(view as unknown as never);
 		view.webview.triggerMessage({ type: "ready" });
+		await flushReady();
 		const msgs = view.webview.postMessage.mock.calls.map((c) => c[0]);
 		expect(
 			msgs.some(
@@ -494,7 +513,7 @@ describe("SidebarWebviewProvider", () => {
 		).toBe(true);
 	});
 
-	it("posts branch:plansData on ready and on plansProvider change", () => {
+	it("posts branch:plansData on ready and on plansProvider change", async () => {
 		const view = makeMockView();
 		let plansHandler: (() => void) | undefined;
 		const plansProvider = {
@@ -519,6 +538,7 @@ describe("SidebarWebviewProvider", () => {
 		});
 		provider.resolveWebviewView(view as unknown as never);
 		view.webview.triggerMessage({ type: "ready" });
+		await flushReady();
 		plansHandler?.();
 		const msgs = view.webview.postMessage.mock.calls.map((c) => c[0]);
 		expect(
@@ -552,7 +572,7 @@ describe("SidebarWebviewProvider", () => {
 		);
 	});
 
-	it("posts branch:changesData on ready and on filesProvider change", () => {
+	it("posts branch:changesData on ready and on filesProvider change", async () => {
 		const view = makeMockView();
 		let filesHandler: (() => void) | undefined;
 		const filesProvider = {
@@ -579,6 +599,7 @@ describe("SidebarWebviewProvider", () => {
 		});
 		provider.resolveWebviewView(view as unknown as never);
 		view.webview.triggerMessage({ type: "ready" });
+		await flushReady();
 		filesHandler?.();
 		const msgs = view.webview.postMessage.mock.calls.map((c) => c[0]);
 		expect(
@@ -979,6 +1000,109 @@ describe("SidebarWebviewProvider", () => {
 		).toBe(true);
 	});
 
+	it("notifyConfiguredChanged posts configured:changed with the new configured flag", () => {
+		const view = makeMockView();
+		const provider = new SidebarWebviewProvider({
+			executeCommand: vi.fn(),
+			getInitialState: () => ({
+				enabled: true,
+				authenticated: false,
+				configured: false,
+				activeTab: "status",
+				kbMode: "folders",
+				branchName: "main",
+				detached: false,
+			}),
+			extensionUri: mockExtensionUri as unknown as never,
+		});
+		provider.resolveWebviewView(view as unknown as never);
+		view.webview.postMessage.mockClear();
+		provider.notifyConfiguredChanged(true);
+		const sent = view.webview.postMessage.mock.calls.map((c) => c[0]);
+		expect(
+			sent.some(
+				(m) =>
+					typeof m === "object" &&
+					m !== null &&
+					(m as { type?: unknown }).type === "configured:changed" &&
+					(m as { configured?: unknown }).configured === true,
+			),
+		).toBe(true);
+	});
+
+	it("init message carries configured field from getInitialState", async () => {
+		const view = makeMockView();
+		const provider = new SidebarWebviewProvider({
+			executeCommand: vi.fn(),
+			getInitialState: () => ({
+				enabled: true,
+				authenticated: false,
+				configured: false,
+				activeTab: "kb",
+				kbMode: "folders",
+				branchName: "main",
+				detached: false,
+			}),
+			extensionUri: mockExtensionUri as unknown as never,
+		});
+		provider.resolveWebviewView(view as unknown as never);
+		view.webview.triggerMessage({ type: "ready" });
+		await flushReady();
+		const sent = view.webview.postMessage.mock.calls.map((c) => c[0]);
+		const initMsg = sent.find(
+			(m): m is { type: "init"; state: SidebarState } =>
+				typeof m === "object" &&
+				m !== null &&
+				(m as { type?: unknown }).type === "init",
+		);
+		expect(initMsg).toBeDefined();
+		expect(initMsg?.state.configured).toBe(false);
+	});
+
+	it("waits for initialStateReady before posting init (so reload doesn't flash onboarding)", async () => {
+		const view = makeMockView();
+		// Construct a deferred we can resolve manually so we can observe the
+		// "before-resolve" and "after-resolve" snapshots of postMessage.
+		let resolveReady: () => void = () => {};
+		const initialStateReady = new Promise<void>((r) => {
+			resolveReady = r;
+		});
+		const provider = new SidebarWebviewProvider({
+			executeCommand: vi.fn(),
+			getInitialState: () => ({
+				enabled: true,
+				authenticated: false,
+				configured: true,
+				activeTab: "branch",
+				kbMode: "folders",
+				branchName: "main",
+				detached: false,
+			}),
+			extensionUri: mockExtensionUri as unknown as never,
+			initialStateReady,
+		});
+		provider.resolveWebviewView(view as unknown as never);
+		view.webview.triggerMessage({ type: "ready" });
+		await Promise.resolve();
+		// Before initialStateReady resolves, init must NOT have been posted.
+		// This is the gate that prevents the "first paint shows pessimistic
+		// configured=false → flicker to tab UI" bug on reload.
+		expect(
+			view.webview.postMessage.mock.calls.some((c) => {
+				const m = c[0] as { type?: unknown };
+				return m?.type === "init";
+			}),
+		).toBe(false);
+		resolveReady();
+		await flushReady();
+		expect(
+			view.webview.postMessage.mock.calls.some((c) => {
+				const m = c[0] as { type?: unknown };
+				return m?.type === "init";
+			}),
+		).toBe(true);
+	});
+
 	// postMessage runs before resolveWebviewView is called → no view handle → must
 	// be a silent no-op (the sidebar may receive notifyXxx() calls during startup
 	// before the view first becomes visible).
@@ -988,6 +1112,7 @@ describe("SidebarWebviewProvider", () => {
 			getInitialState: () => ({
 				enabled: true,
 				authenticated: false,
+				configured: true,
 				activeTab: "kb",
 				kbMode: "folders",
 				branchName: "main",
@@ -998,12 +1123,13 @@ describe("SidebarWebviewProvider", () => {
 		// Just verify it doesn't throw — there's no view to assert against.
 		expect(() => provider.notifyEnabledChanged(false)).not.toThrow();
 		expect(() => provider.notifyAuthChanged(true)).not.toThrow();
+		expect(() => provider.notifyConfiguredChanged(false)).not.toThrow();
 	});
 
 	// onSidebarFirstVisible fires exactly once across multiple `ready` messages —
 	// re-resolves of the view (e.g. user toggles the sidebar) must not re-trigger
 	// the lazy load.
-	it("onSidebarFirstVisible fires only once even across re-readies", () => {
+	it("onSidebarFirstVisible fires only once even across re-readies", async () => {
 		const view = makeMockView();
 		const onSidebarFirstVisible = vi.fn();
 		const provider = new SidebarWebviewProvider({
@@ -1011,6 +1137,7 @@ describe("SidebarWebviewProvider", () => {
 			getInitialState: () => ({
 				enabled: true,
 				authenticated: false,
+				configured: true,
 				activeTab: "kb",
 				kbMode: "folders",
 				branchName: "main",
@@ -1021,7 +1148,9 @@ describe("SidebarWebviewProvider", () => {
 		});
 		provider.resolveWebviewView(view as unknown as never);
 		view.webview.triggerMessage({ type: "ready" });
+		await flushReady();
 		view.webview.triggerMessage({ type: "ready" });
+		await flushReady();
 		expect(onSidebarFirstVisible).toHaveBeenCalledTimes(1);
 	});
 
@@ -1036,6 +1165,7 @@ describe("SidebarWebviewProvider", () => {
 			getInitialState: () => ({
 				enabled: true,
 				authenticated: false,
+				configured: true,
 				activeTab: "kb",
 				kbMode: "folders",
 				branchName: "main",
@@ -1246,6 +1376,7 @@ describe("SidebarWebviewProvider", () => {
 			getInitialState: () => ({
 				enabled: true,
 				authenticated: false,
+				configured: true,
 				activeTab: "kb",
 				kbMode: "folders",
 				branchName: "main",
@@ -1275,6 +1406,7 @@ describe("SidebarWebviewProvider", () => {
 			getInitialState: () => ({
 				enabled: true,
 				authenticated: false,
+				configured: true,
 				activeTab: "kb",
 				kbMode: "folders",
 				branchName: "main",
@@ -1378,6 +1510,7 @@ describe("SidebarWebviewProvider", () => {
 			getInitialState: () => ({
 				enabled: true,
 				authenticated: false,
+				configured: true,
 				activeTab: "kb",
 				kbMode: "folders",
 				branchName: "main",
@@ -1397,6 +1530,7 @@ describe("SidebarWebviewProvider", () => {
 			getInitialState: () => ({
 				enabled: true,
 				authenticated: false,
+				configured: true,
 				activeTab: "kb",
 				kbMode: "folders",
 				branchName: "main",

--- a/vscode/src/views/SidebarWebviewProvider.ts
+++ b/vscode/src/views/SidebarWebviewProvider.ts
@@ -78,6 +78,22 @@ export interface SidebarWebviewDeps {
 	applyFileCheckbox?: (filePath: string, selected: boolean) => void;
 	/** Toggle a single commit's selection state in CommitsStore. */
 	applyCommitCheckbox?: (hash: string, selected: boolean) => void;
+	/**
+	 * Resolves once the host has finished its first-pass initial load — in
+	 * particular once `statusStore.refresh()` has run so `getInitialState()`
+	 * returns the real `configured` / `enabled` flags rather than their
+	 * pessimistic activate-time defaults. The `ready` handler awaits this
+	 * before posting `init`, which prevents the webview from briefly
+	 * rendering the onboarding panel on reload (the bug this hooks into:
+	 * `currentConfigured = false` → init pushed pre-refresh →
+	 * applyConfigured(false) → onboarding flashes → configured:changed
+	 * arrives → tab UI restored).
+	 *
+	 * Must never reject — the host wraps it in a `.catch(() => undefined)`
+	 * so a failed initial load never traps the webview in the loading
+	 * placeholder.
+	 */
+	initialStateReady?: Promise<unknown>;
 }
 
 export class SidebarWebviewProvider
@@ -158,34 +174,55 @@ export class SidebarWebviewProvider
 		void this.view.webview.postMessage(msg);
 	}
 
+	/**
+	 * Awaits `deps.initialStateReady` (when provided) before posting `init`,
+	 * so the first state the webview sees already reflects the real
+	 * `configured` / `enabled` derived from `statusStore`. Without the
+	 * await, the webview would render against the host's pessimistic
+	 * activate-time defaults (configured=false) and visibly flash the
+	 * onboarding panel on reload.
+	 *
+	 * The promise is wrapped in `.catch` so a failed initial load still
+	 * lets `init` go out — better an unflashed onboarding panel than a
+	 * webview stuck on the loading placeholder forever.
+	 */
+	private async handleReady(): Promise<void> {
+		try {
+			await this.deps.initialStateReady;
+		} catch {
+			// fall through
+		}
+		this.postMessage({ type: "init", state: this.deps.getInitialState() });
+		// Trigger lazy-loaded data sources on first visibility. Idempotent —
+		// `firstVisibleFired` guards against re-firing on view re-resolves
+		// (e.g. user collapses + reopens the sidebar).
+		if (!this.firstVisibleFired) {
+			this.firstVisibleFired = true;
+			if (this.deps.onSidebarFirstVisible) {
+				void this.deps.onSidebarFirstVisible();
+			}
+		}
+		this.pushStatus();
+		this.pushMemories();
+		this.pushPlans();
+		this.pushChanges();
+		void this.pushCommits();
+		if (this.deps.branchWatcher) {
+			const cur = this.deps.branchWatcher.current();
+			this.postMessage({
+				type: "branch:branchName",
+				name: cur.name,
+				detached: cur.detached,
+			});
+		}
+	}
+
 	private handleOutbound(raw: unknown): void {
 		if (!isOutbound(raw)) return;
 		const msg: SidebarOutboundMsg = raw;
 		switch (msg.type) {
 			case "ready":
-				this.postMessage({ type: "init", state: this.deps.getInitialState() });
-				// Trigger lazy-loaded data sources on first visibility. Idempotent —
-				// `firstVisibleFired` guards against re-firing on view re-resolves
-				// (e.g. user collapses + reopens the sidebar).
-				if (!this.firstVisibleFired) {
-					this.firstVisibleFired = true;
-					if (this.deps.onSidebarFirstVisible) {
-						void this.deps.onSidebarFirstVisible();
-					}
-				}
-				this.pushStatus();
-				this.pushMemories();
-				this.pushPlans();
-				this.pushChanges();
-				void this.pushCommits();
-				if (this.deps.branchWatcher) {
-					const cur = this.deps.branchWatcher.current();
-					this.postMessage({
-						type: "branch:branchName",
-						name: cur.name,
-						detached: cur.detached,
-					});
-				}
+				void this.handleReady();
 				return;
 			case "command":
 				if (msg.args && msg.args.length > 0) {
@@ -332,6 +369,15 @@ export class SidebarWebviewProvider
 	/** Pushed after the OAuth callback completes (sign-in) and after signOut. */
 	notifyAuthChanged(authenticated: boolean): void {
 		this.postMessage({ type: "auth:changed", authenticated });
+	}
+
+	/**
+	 * Pushed whenever the user's `configured` state changes — i.e. whenever
+	 * either of the two underlying signals (`signedIn`, `hasApiKey`) flips.
+	 * Drives the onboarding-panel vs main-UI split in the webview.
+	 */
+	notifyConfiguredChanged(configured: boolean): void {
+		this.postMessage({ type: "configured:changed", configured });
 	}
 
 	private pushStatus(): void {


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## Plans & Notes

- VS Code Onboarding Panel + Auto-Enable Implementation Plan

## Quick recap

This batch of commits delivered a complete onboarding and first-run experience for the VS Code extension. A new onboarding panel now appears when users have not yet configured any AI credentials, presenting two paths: setting up an Anthropic API key (the recommended route, prominently marked and styled) or signing in to Jolli as a secondary option. The extension also gained auto-enable behavior on first activation, transparently installing git hooks unless the user has previously opted out — an opt-out that is now stored as a portable marker file inside the project directory rather than in VS Code's internal storage, so it survives IDE reinstalls and project moves. A loading placeholder was added to eliminate the jarring flash of the onboarding panel on every window reload, using a two-layer defense that holds back the first state push from the host until the true configuration is known. Several related bugs were also resolved: disabling the extension no longer incorrectly replaces the re-enable button with the onboarding screen, the branch name in the sidebar tab now stays in sync after switching branches, and the AI commit button correctly disables while a background summary is being generated. A layout bug in the Settings panel where long toggle-row hints pushed the toggle switch off screen was also corrected.

The developer investigated two reported bugs in the sidebar's state synchronization and manual-disable logic, confirmed both were valid, then fixed the higher-priority one. The fix ensures that pressing the Refresh button in the sidebar now fully resyncs the shell's enabled and authenticated state — not just the status rows — so the disabled panel and Sign In/Sign Out buttons reflect reality without requiring a full reload. The second bug, where a failed disable operation could permanently suppress auto-enable for a repository, was confirmed as a real edge case but left unfixed pending a design decision on the best recovery strategy. All existing tests continued to pass after the fix, and coverage thresholds were maintained.

This commit addressed two blocking issues introduced by an earlier onboarding panel feature. First, a TypeScript type mismatch caused the build to fail outright: a newly required field on the sidebar's state type was missing from dozens of test fixtures, which the test runner silently ignored but the type checker caught. Second, a subtle timing race meant the sidebar could briefly flash the wrong panel on reload — the "enabled" status was being fetched independently and outside the initialization barrier that guarantees the webview receives consistent state on first load. Both fixes were validated against the full test suite, which passed with over 98% statement coverage.

---

## E2E Test (7)
<details>
<summary><strong>1. No flash of wrong panel on window reload</strong></summary>
<br>
<blockquote>

**Preconditions:** Have the Jolli Memory extension installed and the sidebar open in VS Code.

**Steps:**
1. Open the VS Code command palette and run "Developer: Reload Window".
2. Immediately watch the Jolli Memory sidebar panel as the window reloads.
3. Wait for the sidebar to fully load and show its normal content.

**Expected Results:**
- During reload, the sidebar shows only a spinner and "Loading…" text — no onboarding panel or setup screen flashes briefly before the real content appears.
- Once loading completes, the correct panel (onboarding or main tabs) appears directly without any flicker.

</blockquote>
</details>
<details>
<summary><strong>2. Onboarding panel shown to unconfigured users</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a workspace open where Jolli Memory has not been signed in and no Anthropic API key has been set.

**Steps:**
1. Open the Jolli Memory sidebar.
2. Look at the panel that appears.
3. Check that two setup options are visible: one for an Anthropic API key and one for signing in to Jolli.
4. Confirm the Anthropic API key option has a "RECOMMENDED" badge and appears above the sign-in option.
5. Click the "Configure API Key" button and verify the Settings panel opens.
6. Go back to the sidebar, click "Sign In / Sign Up", and verify the sign-in flow starts.

**Expected Results:**
- The sidebar shows the onboarding panel (not the normal tabs) with a heading like "Get started with Jolli Memory".
- The Anthropic API key card appears first with a "RECOMMENDED" badge; the Jolli sign-in option appears below it separated by an "OR" divider.
- Clicking "Configure API Key" opens the Jolli Memory settings page.
- Clicking "Sign In / Sign Up" launches the OAuth sign-in flow.

</blockquote>
</details>
<details>
<summary><strong>3. Onboarding panel disappears after completing setup</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a workspace open where Jolli Memory has not been signed in and no Anthropic API key has been set.

**Steps:**
1. Open the Jolli Memory sidebar and confirm the onboarding panel is showing.
2. Click "Configure API Key" and enter a valid Anthropic API key in the settings, then save.
3. Return to the Jolli Memory sidebar.

**Expected Results:**
- After saving the API key, the onboarding panel is no longer visible.
- The normal sidebar tabs (Branch, Knowledge Base, Status, etc.) are now shown instead.

</blockquote>
</details>
<details>
<summary><strong>4. Auto-enable on first install</strong></summary>
<br>
<blockquote>

**Preconditions:** Use a workspace where Jolli Memory hooks have never been installed and the extension has not been manually disabled before.

**Steps:**
1. Install the Jolli Memory extension (or open a fresh workspace where it has never run).
2. Wait a few seconds for the extension to activate.
3. Open the Jolli Memory sidebar and check the Status tab.

**Expected Results:**
- Without any manual action, the extension reports that git hooks are enabled/installed.
- The user did not need to click any "Enable" button for this to happen.

</blockquote>
</details>
<details>
<summary><strong>5. Disable opt-out is remembered after VS Code reload</strong></summary>
<br>
<blockquote>

**Preconditions:** Have the Jolli Memory extension active and hooks enabled in a workspace.

**Steps:**
1. Open the Jolli Memory sidebar and disable Jolli Memory using the disable command or button.
2. Reload the VS Code window using "Developer: Reload Window".
3. Wait for the extension to fully activate.
4. Open the Jolli Memory sidebar and check whether hooks were automatically re-enabled.

**Expected Results:**
- After reloading, Jolli Memory remains disabled — it does not silently re-enable itself.
- The sidebar reflects the disabled state, not the onboarding panel (since the user has previously configured the extension).

</blockquote>
</details>
<details>
<summary><strong>6. Refresh button updates enabled and sign-in state in sidebar</strong></summary>
<br>
<blockquote>

**Preconditions:** Have the Jolli Memory sidebar open. Simulate an out-of-band change — for example, manually remove the git hooks using a terminal, or sign out via an external config change.

**Steps:**
1. Make an external change that affects the enabled or signed-in state (e.g. remove hooks from the terminal without using the VS Code command).
2. In the Jolli Memory sidebar, click the Refresh button.
3. Observe the sidebar's status indicators and Sign In / Sign Out button.

**Expected Results:**
- After clicking Refresh, the sidebar immediately reflects the current real state — for example, showing "disabled" if hooks were removed, or showing "Sign In" if the auth token was cleared.
- No VS Code window reload is needed for the sidebar to show the correct state.

</blockquote>
</details>
<details>
<summary><strong>7. Branch name in sidebar updates after switching branches</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a git repository open with at least two branches, and the Jolli Memory sidebar visible on the Branch tab.

**Steps:**
1. Note the branch name shown in the Jolli Memory sidebar's Branch tab.
2. Switch to a different git branch using the VS Code source control panel or the terminal (e.g. `git checkout other-branch`).
3. Look at the Branch tab label or branch name displayed in the sidebar without reloading VS Code.

**Expected Results:**
- The branch name shown in the sidebar updates to the new branch name shortly after switching, without requiring a window reload or manual refresh.

</blockquote>
</details>

---

## Topics (12)
<details>
<summary><strong>01 · Loading placeholder eliminates onboarding panel flash on window reload</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Every time the user reloaded the VS Code window, the sidebar would briefly flash the onboarding or setup panel before switching to the correct interface, making the extension appear broken on startup.

**💡 Decisions Behind the Code**

- **Double-layer defense over a single fix**: Fixing only the webview side (showing a loading state) would not have been enough — the host would still push a "not configured" signal immediately, causing the webview to swap from loading directly to the onboarding panel. Fixing only the host side (delaying the push) would not have been enough either, because the webview's default DOM state would still show the wrong panel during the wait. Both layers were required to eliminate the flash entirely.
- **Loading placeholder over blocking host activation**: Blocking the host's entire activation until the status check finished was considered but rejected because the status check spawns an external process that could be slow or hang, leaving the sidebar completely blank with no feedback. The loading placeholder gives the user a visible signal that something is happening, and the barrier is released on both success and failure paths so the UI always recovers.
- **Pessimistic default preserved, not flipped**: Changing the host's default "configured" value to optimistic was considered but rejected because it would cause the inverse flash for users who genuinely are not configured — they would briefly see the tab interface before being sent to onboarding. The loading state is neutral for both user types.

**✅ What Was Implemented**

- Added a loading placeholder panel (spinner and "Loading…" text) to the sidebar HTML that is shown by default. The tab bar and all tab content areas are hidden by default. The client-side script hides the loading panel and reveals the correct UI only after the first real state message arrives from the extension host, so no incorrect panel is ever shown.
- Introduced a deferred barrier in the extension host: the sidebar's ready handler now waits for the initial data load — including the git status check that determines whether the user is configured — to complete before pushing the first state message to the webview. The initial load function was changed to return a Promise whose completion resolves the barrier, with a finally guard ensuring the barrier is always released even on failure.
- Updated SidebarHtmlBuilder.ts, SidebarCssBuilder.ts, SidebarScriptBuilder.ts, SidebarWebviewProvider.ts, and Extension.ts to implement both layers of the fix.

**📁 FILES**
- `vscode/src/views/SidebarHtmlBuilder.ts`
- `vscode/src/views/SidebarScriptBuilder.ts`
- `vscode/src/views/SidebarWebviewProvider.ts`
- `vscode/src/Extension.ts`

</blockquote>
</details>
<details>
<summary><strong>02 · Opt-out preference migrated to portable project-directory marker file</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The user's explicit choice to disable Jolli Memory in a project was stored inside VS Code's internal per-machine workspace storage, meaning the preference could be silently lost if VS Code was reinstalled or the project directory was moved or renamed, causing Jolli Memory to re-enable itself unexpectedly.

**💡 Decisions Behind the Code**

- **File-backed marker over VS Code workspace state**: VS Code's workspace state is keyed to a machine-local IDE installation and does not travel with the project. A file inside the project directory is portable — it survives IDE reinstalls, project renames, and moves to a new machine. It also makes the opt-out inspectable and manually removable without needing VS Code, consistent with how all other per-project Jolli state is stored.
- **Existence-as-boolean over structured file content**: The file's content is never parsed by any reader — only its presence or absence matters. This keeps the read path trivially simple and immune to file corruption; any file, even an empty one, counts as disabled. Storing structured data would add a parse step with no benefit since there is only one bit of information to convey.
- **Load credentials regardless of enabled state**: Previously, credentials were only loaded when hooks were active, which caused a subtle trap: disabling Jolli Memory would flip the sidebar's "configured" flag to false, replacing the re-enable button with the onboarding screen and leaving the user with no way to re-enable from the sidebar. Loading credentials unconditionally fixes this at the cost of one extra disk read per status refresh, which is negligible.
- **Workspace scope, not global**: Storing the opt-out per project rather than globally respects the per-repository nature of git hooks, allowing users to disable Jolli Memory in a work repository without silencing it in personal repositories.

**✅ What Was Implemented**

- Created a new service (ManualDisableFlag.ts) that encapsulates the opt-out as a marker file at a fixed path inside the project directory, alongside other per-project Jolli state files. The file's existence represents the boolean; its body contains an ISO timestamp for human debugging only. Parent directories are created automatically on first write. The old workspace-state key and its associated constant were removed entirely.
- Updated the enable and disable commands in Extension.ts to call the new service's read and write functions instead of VS Code's workspace state API. The auto-enable logic on activation was updated to read the marker file asynchronously rather than doing a synchronous key lookup in workspace state.
- Decoupled credentials loading in the status store from the enabled/disabled state: configuration is now loaded unconditionally on every refresh, so the sidebar's "configured" gate always reflects the user's actual on-disk credentials regardless of whether hooks are installed.

**📁 FILES**
- `vscode/src/services/ManualDisableFlag.ts`
- `vscode/src/Extension.ts`
- `vscode/src/stores/StatusStore.ts`

</blockquote>
</details>
<details>
<summary><strong>03 · Onboarding panel guides unconfigured users toward API key or sign-in</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The sidebar showed a bare interface when users had not yet signed in or provided an API key, with no guidance on how to get started. New users needed a dedicated onboarding flow that presents both setup paths clearly.

**💡 Decisions Behind the Code**

- **Derive configured on the host side, not the webview**: The extension computes the credential check once and pushes a single boolean to the webview rather than having the webview receive both signals and derive it locally. This keeps the webview as a dumb renderer, preserves a single source of truth, and leaves room for future credential types without webview changes.
- **Reuse existing settings and sign-in flows**: Rather than building inline credential input within the onboarding panel, the API key button routes users to the existing Settings panel and the sign-in button triggers the existing OAuth flow. This reduces implementation complexity and keeps configuration UI centralized, at the cost of one extra navigation step.
- **Onboarding gate independent of the enabled flag**: Onboarding visibility is driven by credential presence, not by whether hooks are installed. Users who have configured credentials but disabled the extension do not see the onboarding panel again, keeping the two concerns — initial setup versus active use — separate and preventing re-prompting after explicit opt-out.
- **VSCode theme tokens as the sole color source**: Hard-coded hex values were avoided entirely. Using theme tokens ensures the panel automatically respects the user's theme preference across Light, Dark, and High-Contrast modes without separate CSS rules or maintenance burden. The fallback pattern provides graceful degradation across VSCode versions that may not expose all tokens.
- **Position Anthropic API key first and mark it recommended**: The self-hosted API key path is elevated as the primary recommendation — top position, RECOMMENDED badge, primary button styling — while Jolli sign-in is a secondary fallback. This reflects the product's preference for user data privacy and reduces cloud dependency.

**✅ What Was Implemented**

- Added a `configured` boolean field to the sidebar state, derived on the extension host as the logical OR of the signed-in and API-key-present signals. The host pushes a single boolean to the webview whenever either underlying signal changes, and the webview receives a corresponding message type to handle runtime updates. The field defaults to true for backward compatibility so older host code does not accidentally trigger the onboarding gate.
- Built the onboarding panel HTML skeleton in SidebarHtmlBuilder.ts with a header, two option cards (Anthropic API key marked RECOMMENDED and positioned first, Jolli sign-in as a secondary fallback), an OR divider, and corresponding action buttons. The panel is hidden by default and positioned before the tab bar in the DOM.
- Added complete CSS for the onboarding panel in SidebarCssBuilder.ts using VSCode theme tokens throughout — `--vscode-focusBorder` for recommended card borders and badge accents, `--vscode-button-background` and `--vscode-button-foreground` for primary buttons, and `--vscode-widget-border` with a fallback for dividers and secondary button borders — so the panel adapts automatically to Light, Dark, and High-Contrast themes.
- Implemented webview script logic in SidebarScriptBuilder.ts to toggle visibility between the onboarding panel and the main tab UI based on the `configured` state. When unconfigured, the panel takes the full viewport and all tab elements are hidden. The API key button dispatches the open-settings command; the sign-in button dispatches the OAuth sign-in command. When the user completes either path and `configured` flips to true, the script re-invokes the enabled-state logic to restore the correct UI.

**📁 FILES**
- `vscode/src/views/SidebarMessages.ts`
- `vscode/src/views/SidebarHtmlBuilder.ts`
- `vscode/src/views/SidebarCssBuilder.ts`
- `vscode/src/views/SidebarScriptBuilder.ts`
- `vscode/src/views/SidebarWebviewProvider.ts`

</blockquote>
</details>
<details>
<summary><strong>04 · Auto-enable git hooks on first activation with durable user opt-out</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

When a user installs the extension or opens a fresh workspace, they had to manually enable git hook integration before Jolli Memory would do anything, creating unnecessary friction for new users.

**💡 Decisions Behind the Code**

- **Persist opt-out before the async disable call**: Recording the user's intent synchronously before the uninstall attempt ensures durability — if the disable operation fails or the extension crashes, the user's choice is still honored on the next activation. This trades a small increase in state complexity for strong user intent preservation.
- **Placement after first status refresh**: The auto-enable logic runs after the initial status bar refresh rather than earlier in the activation sequence, ensuring the current enabled state is already known before attempting to enable and reducing the risk of race conditions.
- **Silent failure handling**: If auto-enable fails, the extension logs a warning but does not block activation or surface an error to the user. The extension remains functional and the user can manually enable later if needed, keeping the first-run experience smooth even in edge cases.

**✅ What Was Implemented**

- Added auto-enable logic to the `activate` function in Extension.ts, inserted after the initial status refresh so the current state is known before attempting to enable. If the extension is not yet enabled and the user has not set a manual opt-out, the extension calls the enable bridge transparently and refreshes the status bar.
- The disable command persists the opt-out flag before the async disable operation begins, guaranteeing the preference survives even if the uninstall call fails or times out. The enable command clears the flag on success to restore normal auto-enable behavior on subsequent restarts.
- Added test cases covering the three key scenarios: auto-enable on fresh install, skip when opted out, and skip when already enabled, as well as flag persistence on both successful and failed disable operations.

**📁 FILES**
- `vscode/src/Extension.ts`

</blockquote>
</details>
<details>
<summary><strong>05 · Disabled sidebar shows onboarding screen instead of re-enable button</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

After the auto-enable feature was introduced, disabling Jolli Memory and then viewing the sidebar would show the onboarding panel — intended for users who have never configured the extension — rather than the simpler re-enable panel, leaving users unable to re-enable from the sidebar.

**💡 Decisions Behind the Code**

- **Credentials are independent of hook installation**: Disabling Jolli Memory uninstalls git hooks but does not sign the user out or remove their API key. Treating these as coupled caused the sidebar's onboarding gate to misfire. Separating them means the "configured" signal accurately reflects whether the user has credentials, not whether hooks happen to be active, at the cost of one extra disk read per status refresh.

**✅ What Was Implemented**

The status store's refresh logic was changed to always load credentials from disk, removing the conditional that skipped credential loading when hooks were disabled. The status tree provider and its tests were updated to reflect that configuration is always loaded and the authentication context key is always refreshed, even in the disabled state.

**📁 FILES**
- `vscode/src/stores/StatusStore.ts`

</blockquote>
</details>
<details>
<summary><strong>06 · Branch name in sidebar tab drifts out of sync after switching branches</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

After switching git branches in the workspace, the branch name shown in the sidebar's Branch tab would sometimes still display the old branch name, even though the tab's data had already updated to reflect the new branch.

**💡 Decisions Behind the Code**

- **Reuse the existing HEAD watcher over adding a new one**: The HEAD file is already watched for branch-switch detection. Adding a second independent watcher for the same file would split the event source and risk ordering issues. Plugging the branch-name refresh into the existing callback keeps all HEAD-change reactions in one place and matches the established pattern for other store refreshes.
- **Deduplicate by comparing old and new values**: Without deduplication, every commit — which also rewrites HEAD — would fire a branch-change notification and trigger a sidebar re-render even when the branch name had not changed. The comparison guard keeps the notification semantically meaningful and avoids unnecessary UI churn.

**✅ What Was Implemented**

- Extracted a branch name refresh helper that reads the current branch from git, compares it to the stored value, and fires a change notification only when the name actually changed. This deduplication prevents spurious re-renders on commits to the same branch, which also rewrite the HEAD file.
- Updated the existing HEAD file watcher callback in Extension.ts to call this helper alongside the existing store refreshes. Previously the watcher refreshed all data stores but never re-read the branch name, so the label froze at the value captured during extension activation.

**📁 FILES**
- `vscode/src/Extension.ts`

</blockquote>
</details>
<details>
<summary><strong>07 · Settings panel toggle rows with long hints push toggle switch off screen</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The Settings panel looked broken for toggle rows with unusually long hint text — most visibly the Copilot integration row — where the toggle switch was pushed outside the visible area of the panel instead of the hint wrapping onto multiple lines.

**💡 Decisions Behind the Code**

- **Scoped override rather than global change**: The flex-shrink rule on labels exists for good reason in input rows — it prevents the label from being squeezed by an adjacent text field. Changing it globally would risk breaking those rows. Scoping the fix to toggle rows targets only the context where the problem occurs, leaving all other label behavior untouched, at the cost of a small amount of CSS specificity complexity.
- **`min-width: 0` as the key unlock**: Flex items default to a minimum width equal to their content's natural width, meaning they refuse to shrink below it. Setting this floor to zero explicitly allows the flex-grow rule to take effect and lets the browser wrap the hint text. Without this, adding a flex-grow rule alone would have had no visible effect on the overflow problem.

**✅ What Was Implemented**

- In SettingsCssBuilder.ts, added a `gap: 12px` to the `.toggle-row` rule and introduced a new scoped rule for label elements within toggle rows with `flex: 1` and `min-width: 0`. This overrides the inherited flex-shrink behavior that was appropriate for input rows but caused label elements in toggle rows to size themselves to the full single-line width of their hint text, leaving no space for the toggle.
- Added a regression test to SettingsCssBuilder.test.ts asserting that both the scoped label flex rule and the gap value are present in the generated CSS.

**📁 FILES**
- `vscode/src/views/SettingsCssBuilder.ts`

</blockquote>
</details>
<details>
<summary><strong>08 · Refresh button now resyncs sidebar enabled and auth state</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Pressing the Refresh button in the sidebar updated the status rows but left the disabled panel and Sign In/Sign Out buttons showing stale state. Any out-of-band change to hooks or authentication — such as an external tool removing hooks or a config file being cleared — would not be reflected in the sidebar shell until the extension was fully reloaded.

**💡 Decisions Behind the Code**

- **Reuse the status bar refresh's bridge call rather than issuing a new one**: The status bar refresh already calls into the bridge to get current state and returns the result. Awaiting that return value avoids a redundant second bridge round-trip during a single refresh, keeping the fix minimal and the call count unchanged.
- **Notify only on change, not unconditionally**: The existing enable/disable and auth commands only push updates to the sidebar when the value actually changes. Matching that pattern avoids unnecessary webview round-trips and keeps the sidebar's update contract consistent — the webview can trust that a notification always means something changed.
- **Fix the refresh command rather than routing everything through the status store's change event**: The three sidebar state signals come from different sources — bridge status, config auth token, and store-derived fields. Funneling all of them through the status store's change subscription would have made the store a broad coupling point responsible for signals it doesn't own. Keeping the refresh command explicit about what it re-pulls preserves the existing separation between the three signal sources.

**✅ What Was Implemented**

- `refreshStatus` in `Extension.ts` was converted to an async command. After the existing store refresh, it now awaits the return value of `refreshStatusBar` (which already calls into the bridge internally) to get the current enabled state, then calls `loadConfig` to get the current auth token. Both values are compared against the cached sidebar state variables, and the sidebar is notified only when a change is detected — matching the existing pattern used by the enable/disable and auth commands.
- Error handling was wrapped in a try/catch that routes through the same `handleError` utility already used by the store refresh, keeping failure behavior consistent with the rest of the command.

**📋 Future Enhancements**

The second confirmed bug — a failed disable operation writing a permanent opt-out marker before knowing whether uninstall succeeded — was explicitly deferred. Three recovery strategies were discussed (rollback the marker on failure, add a reconciliation prompt at startup, or introduce a three-state pending marker) but no approach was chosen. This needs a design decision before implementation.

**📁 FILES**
- `vscode/src/Extension.ts`

</blockquote>
</details>
<details>
<summary><strong>09 · Fix TypeScript build failure from required field missing in test fixtures</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

After the onboarding panel was added, the build broke because a new required boolean field on the sidebar state type was absent from 36 test fixtures. The test runner silently swallowed the type errors, so the author's local test run passed, but the type checker — required before every commit — failed outright.

**💡 Decisions Behind the Code**

- **Make the field optional rather than patch 36 fixtures**: Fixing each fixture individually would have been mechanical and fragile — any future fixture added without the field would silently reintroduce the problem. Making the field optional aligns the type with how the consumer already behaved in practice, making the contract explicit and self-enforcing going forward.
- **Rely on existing consumer fallback rather than adding a default**: The sidebar rendering logic already used a safe fallback expression that treated an absent value the same as "configured," meaning the HTML default state was already correct. Encoding that assumption in the type (optional rather than required) was lower-risk than adding a new default value in a separate location, which could diverge from the fallback over time.

**✅ What Was Implemented**

Changed the `configured` field in `SidebarState` (in `vscode/src/views/SidebarMessages.ts`) from required to optional, with an explanatory comment. This resolved all 36 type errors without touching any fixture files. The production consumer already treated the field as optional via a fallback expression, so the type now matches actual usage.

**📁 FILES**
- `vscode/src/views/SidebarMessages.ts`

</blockquote>
</details>
<details>
<summary><strong>10 · Fix sidebar flash race by unifying enabled-state updates under initialization barrier</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

On extension reload, the sidebar could briefly show the main UI before switching to the disabled panel. This happened because the "enabled" status was fetched via a separate, independent async call that was not coordinated with the initialization sequence that gates the first message sent to the webview.

**💡 Decisions Behind the Code**

- **Single subscription over two separate async calls**: Having two independent async fetches for related state values creates an inherent race window — whichever resolves second wins, but the webview may have already rendered based on the first. Routing both through one subscription tied to the same store refresh eliminates the race by construction, since the initialization barrier already awaits that store's refresh before allowing the first webview message to be sent.
- **Null-guard the initial snapshot rather than relying on default values**: The status store emits an empty snapshot before the first real refresh. Without a guard, the subscription would interpret the absent enabled field as a state change and fire a notification with an undefined value, potentially overwriting a valid cached state. Checking for a non-null status object before comparing values prevents this class of spurious update at negligible cost.

**✅ What Was Implemented**

- Removed the standalone fire-and-forget status fetch from `vscode/src/Extension.ts` that was updating `currentEnabled` outside the initialization barrier. The `currentEnabled` derivation was merged into the existing status store subscription that already handled `currentConfigured`, so both values now update from the same source and are guaranteed to be fresh before the webview receives its first state message.
- Added a null guard in the subscription handler so that an empty initial snapshot does not incorrectly reset `currentEnabled` to undefined and trigger a spurious notification.

**📁 FILES**
- `vscode/src/Extension.ts`

</blockquote>
</details>
<details>
<summary><strong>11 · AI commit button stays enabled while background summary generation is running</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

While an AI summary was being generated in the background, the AI commit button in the sidebar remained clickable as long as there were selected changes, allowing accidental use during an in-progress operation.

**💡 Decisions Behind the Code**

- **Re-render the whole branch section over surgically toggling one button**: When the worker-busy state changes, re-rendering the entire branch section is the simplest correct fix and is consistent with how the rest of the sidebar handles state updates. Surgically finding and toggling a single button's disabled attribute would be more fragile and inconsistent with the established pattern for other state changes such as new commits or plan updates.

**✅ What Was Implemented**

- Extended the disabled condition for the AI commit button in SidebarScriptBuilder.ts to include the worker-busy state, so the button is grayed out whenever a background AI operation is running regardless of how many changes are selected. The discard button's condition was left unchanged since discarding is a local-only operation unrelated to the AI worker.
- Updated the worker-busy message handler to also re-render the branch section when the Branch tab is active, so the button's disabled state is visually refreshed when the worker starts and stops.

**📁 FILES**
- `vscode/src/views/SidebarScriptBuilder.ts`

</blockquote>
</details>
<details>
<summary><strong>12 · Re-enable button label inconsistent between disabled panel and degraded-mode banner</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The re-enable button in the disabled-state sidebar panel was labeled just "Enable" rather than "Enable Jolli Memory," which was inconsistent with the identical button shown in the legacy degraded-mode banner.

**💡 Decisions Behind the Code**

- **Consistent action labels across surfaces**: Both the disabled panel and the legacy degraded-mode banner present the same user action — re-enabling the extension — so they should use identical wording. Diverging labels would suggest to users that these are different actions, adding unnecessary cognitive load.

**✅ What Was Implemented**

The button label in the disabled panel HTML template in SidebarHtmlBuilder.ts was updated to "Enable Jolli Memory" to match the existing wording, and the corresponding test assertion was updated to match.

**📁 FILES**
- `vscode/src/views/SidebarHtmlBuilder.ts`

</blockquote>
</details>

---

*Generated by Jolli Memory · May 7, 2026 at 11:55 PM*
<!-- jollimemory-summary-end -->