### PR TITLE
Add OpenCode integration with SQLite session discovery

### DIFF
--- a/intellij/build.gradle.kts
+++ b/intellij/build.gradle.kts
@@ -33,8 +33,10 @@ dependencies {
     // The standalone hooks JAR bundles its own copies via the hooksRuntime configuration.
     compileOnly("com.google.code.gson:gson:2.12.1")
     compileOnly("org.jetbrains.kotlin:kotlin-stdlib")
+    compileOnly("org.xerial:sqlite-jdbc:3.49.1.0")
     hooksRuntime("com.google.code.gson:gson:2.12.1")
     hooksRuntime("org.jetbrains.kotlin:kotlin-stdlib:2.1.20")
+    hooksRuntime("org.xerial:sqlite-jdbc:3.49.1.0")
     testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
     testImplementation("io.mockk:mockk:1.13.16")

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/bridge/SummaryReader.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/bridge/SummaryReader.kt
@@ -4,6 +4,7 @@ import ai.jolli.jollimemory.core.CodexSessionDiscoverer
 import ai.jolli.jollimemory.core.CommitSummary
 import ai.jolli.jollimemory.core.GeminiSupport
 import ai.jolli.jollimemory.core.JmLogger
+import ai.jolli.jollimemory.core.OpenCodeSupport
 import ai.jolli.jollimemory.core.SessionTracker
 import ai.jolli.jollimemory.core.StatusInfo
 import com.google.gson.Gson
@@ -44,6 +45,8 @@ class SummaryReader(private val projectDir: String, private val git: GitOps) {
             codexEnabled = config.codexEnabled,
             geminiDetected = GeminiSupport.isGeminiInstalled(),
             geminiEnabled = config.geminiEnabled,
+            openCodeDetected = OpenCodeSupport.isOpenCodeInstalled(),
+            openCodeEnabled = config.openCodeEnabled,
         )
     }
 

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/core/OpenCodeSupport.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/core/OpenCodeSupport.kt
@@ -1,0 +1,268 @@
+package ai.jolli.jollimemory.core
+
+import com.google.gson.JsonParser
+import java.io.File
+import java.sql.DriverManager
+import java.time.Instant
+
+/**
+ * OpenCode Support — session discovery and transcript reading.
+ *
+ * OpenCode stores all data in a global SQLite database at
+ * ~/.local/share/opencode/opencode.db. Sessions are scoped to a project
+ * via the `directory` column in the `session` table.
+ *
+ * Cursor design: all sessions share one DB file. To give each session its own
+ * cursor key, we use a synthetic transcriptPath: "<globalDbPath>#<sessionId>".
+ */
+object OpenCodeSupport {
+
+	private val log = JmLogger.create("OpenCodeSupport")
+
+	/** Sessions older than 48 hours are considered stale (matches other sources). */
+	private const val SESSION_STALE_MS = 48 * 60 * 60 * 1000L
+
+	/** Returns the path to the global OpenCode database file. */
+	fun getDbPath(): String {
+		val xdgDataHome = System.getenv("XDG_DATA_HOME")
+			?: (System.getProperty("user.home") + File.separator + ".local" + File.separator + "share")
+		return xdgDataHome + File.separator + "opencode" + File.separator + "opencode.db"
+	}
+
+	/** Checks whether the OpenCode database exists. */
+	fun isOpenCodeInstalled(): Boolean {
+		return File(getDbPath()).isFile
+	}
+
+	/**
+	 * Discovers OpenCode sessions relevant to the given project directory.
+	 * Queries the global DB for recent sessions (within 48h) matching projectDir.
+	 */
+	fun discoverSessions(projectDir: String): List<SessionInfo> {
+		val dbPath = getDbPath()
+		val dbFile = File(dbPath)
+		if (!dbFile.isFile) return emptyList()
+
+		val cutoffMs = System.currentTimeMillis() - SESSION_STALE_MS
+		val isWindows = System.getProperty("os.name").lowercase().contains("win")
+		val isMac = System.getProperty("os.name").lowercase().contains("mac")
+		val caseInsensitive = isWindows || isMac
+
+		return try {
+			withReadOnlyDb(dbPath) { conn ->
+				val sql = buildString {
+					append("SELECT id, title, time_created, time_updated FROM session WHERE ")
+					if (caseInsensitive) {
+						append("LOWER(directory) = LOWER(?)")
+					} else {
+						append("directory = ?")
+					}
+					append(" AND time_updated > ? ORDER BY time_updated DESC")
+				}
+
+				val sessions = mutableListOf<SessionInfo>()
+				conn.prepareStatement(sql).use { stmt ->
+					stmt.setString(1, projectDir)
+					stmt.setLong(2, cutoffMs)
+					val rs = stmt.executeQuery()
+					while (rs.next()) {
+						val id = rs.getString("id")
+						val timeUpdated = rs.getLong("time_updated")
+						sessions.add(SessionInfo(
+							sessionId = id,
+							transcriptPath = "$dbPath#$id",
+							updatedAt = Instant.ofEpochMilli(timeUpdated).toString(),
+							source = TranscriptSource.opencode,
+						))
+					}
+				}
+				log.info("Discovered %d OpenCode session(s) for %s", sessions.size, projectDir)
+				sessions
+			}
+		} catch (e: Exception) {
+			log.error("OpenCode scan failed: %s", e.message)
+			emptyList()
+		}
+	}
+
+	/**
+	 * Reads messages from an OpenCode SQLite session and returns parsed transcript entries.
+	 * Supports cursor-based resumption by tracking the count of messages already processed.
+	 *
+	 * @param transcriptPath Synthetic path: "<dbPath>#<sessionId>"
+	 * @param cursor Optional cursor indicating how many messages were already processed
+	 * @param beforeTimestamp Optional ISO 8601 cutoff for commit attribution
+	 */
+	fun readTranscript(
+		transcriptPath: String,
+		cursor: TranscriptCursor?,
+		beforeTimestamp: String? = null,
+	): TranscriptReadResult {
+		val (dbPath, sessionId) = parseSyntheticPath(transcriptPath)
+		val startIndex = cursor?.lineNumber ?: 0
+		val cutoffTime = beforeTimestamp?.let { Instant.parse(it).toEpochMilli() }
+
+		try {
+			return withReadOnlyDb(dbPath) { conn ->
+				// Query messages with their parts via JOIN
+				val sql = """
+					SELECT m.id as msg_id, m.data as msg_data, m.time_created,
+					       p.data as part_data
+					FROM message m
+					LEFT JOIN part p ON p.message_id = m.id
+					WHERE m.session_id = ?
+					ORDER BY m.time_created ASC, p.time_created ASC
+				""".trimIndent()
+
+				// Group rows by message ID (preserving order)
+				val messageOrder = mutableListOf<String>()
+				val messageMap = mutableMapOf<String, MessageData>()
+
+				conn.prepareStatement(sql).use { stmt ->
+					stmt.setString(1, sessionId)
+					val rs = stmt.executeQuery()
+					while (rs.next()) {
+						val msgId = rs.getString("msg_id")
+						val msgData = rs.getString("msg_data")
+						val timeCreated = rs.getLong("time_created")
+						val partData = rs.getString("part_data")
+
+						if (msgId !in messageMap) {
+							messageMap[msgId] = MessageData(msgData, timeCreated, mutableListOf())
+							messageOrder.add(msgId)
+						}
+						if (partData != null) {
+							(messageMap[msgId]!!.parts as MutableList).add(partData)
+						}
+					}
+				}
+
+				// Skip already-processed messages (cursor-based incremental read)
+				val newMessageIds = if (startIndex < messageOrder.size) {
+					messageOrder.subList(startIndex, messageOrder.size)
+				} else {
+					emptyList()
+				}
+
+				val rawEntries = mutableListOf<TranscriptEntry>()
+				var lastConsumedIndex = startIndex
+
+				for (i in newMessageIds.indices) {
+					val msg = messageMap[newMessageIds[i]]!!
+
+					// Stop consuming when we hit messages after the cutoff
+					if (cutoffTime != null && msg.timeCreated > cutoffTime) {
+						break
+					}
+
+					val entry = parseOpenCodeMessage(msg.msgData, msg.parts, msg.timeCreated)
+					if (entry != null) {
+						rawEntries.add(entry)
+					}
+					lastConsumedIndex = startIndex + i + 1
+				}
+
+				val entries = TranscriptReader.mergeConsecutiveEntries(rawEntries)
+
+				val newCursor = TranscriptCursor(
+					transcriptPath = transcriptPath,
+					lineNumber = if (beforeTimestamp != null) lastConsumedIndex else messageOrder.size,
+					updatedAt = Instant.now().toString(),
+				)
+
+				val totalLinesRead = lastConsumedIndex - startIndex
+				log.info(
+					"Read OpenCode session %s: %d new messages, %d entries extracted (index %d→%d)",
+					sessionId.take(8), totalLinesRead, entries.size, startIndex, newCursor.lineNumber,
+				)
+
+				TranscriptReadResult(entries, newCursor, totalLinesRead)
+			}
+		} catch (e: Exception) {
+			log.error("Failed to read OpenCode session %s: %s", sessionId.take(8), e.message)
+			throw RuntimeException("Cannot read OpenCode session: $sessionId")
+		}
+	}
+
+	// ── Internal helpers ─────────────────────────────────────────────────────
+
+	private data class MessageData(
+		val msgData: String,
+		val timeCreated: Long,
+		val parts: List<String>,
+	)
+
+	/**
+	 * Opens a read-only JDBC connection to the SQLite database, runs the callback,
+	 * and closes the connection.
+	 */
+	private fun <T> withReadOnlyDb(dbPath: String, block: (java.sql.Connection) -> T): T {
+		val url = "jdbc:sqlite:file:$dbPath?mode=ro"
+		val conn = DriverManager.getConnection(url)
+		return try {
+			block(conn)
+		} finally {
+			conn.close()
+		}
+	}
+
+	/**
+	 * Parses a synthetic transcript path into its DB path and session ID components.
+	 * Format: "<dbPath>#<sessionId>"
+	 */
+	private fun parseSyntheticPath(transcriptPath: String): Pair<String, String> {
+		val hashIndex = transcriptPath.lastIndexOf('#')
+		if (hashIndex == -1 || hashIndex == 0 || hashIndex == transcriptPath.length - 1) {
+			throw IllegalArgumentException("Invalid OpenCode transcript path: $transcriptPath")
+		}
+		return Pair(transcriptPath.substring(0, hashIndex), transcriptPath.substring(hashIndex + 1))
+	}
+
+	/**
+	 * Parses a single OpenCode message into a TranscriptEntry.
+	 * Extracts role from message.data JSON, text from part.data JSONs.
+	 */
+	private fun parseOpenCodeMessage(msgDataJson: String, partDataJsons: List<String>, createdAtMs: Long): TranscriptEntry? {
+		val msgData = try {
+			JsonParser.parseString(msgDataJson).asJsonObject
+		} catch (_: Exception) {
+			return null
+		}
+
+		val role = msgData.get("role")?.asString ?: return null
+		val mappedRole = when (role) {
+			"user" -> "human"
+			"assistant" -> "assistant"
+			else -> return null
+		}
+
+		val text = extractTextFromParts(partDataJsons) ?: return null
+		val timestamp = Instant.ofEpochMilli(createdAtMs).toString()
+		return TranscriptEntry(mappedRole, text, timestamp)
+	}
+
+	/**
+	 * Extracts text content from OpenCode part data JSON strings.
+	 * Only "text" type parts are extracted; tool, patch, reasoning, finish, etc. are skipped.
+	 */
+	private fun extractTextFromParts(partDataJsons: List<String>): String? {
+		val textParts = mutableListOf<String>()
+
+		for (json in partDataJsons) {
+			val partData = try {
+				JsonParser.parseString(json).asJsonObject
+			} catch (_: Exception) {
+				continue
+			}
+
+			if (partData.get("type")?.asString == "text") {
+				val text = partData.get("text")?.asString?.trim()
+				if (!text.isNullOrEmpty()) {
+					textParts.add(text)
+				}
+			}
+		}
+
+		return if (textParts.isNotEmpty()) textParts.joinToString("\n") else null
+	}
+}

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/core/TranscriptParsers.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/core/TranscriptParsers.kt
@@ -55,5 +55,6 @@ fun getParserForSource(source: TranscriptSource): TranscriptParser {
         TranscriptSource.codex -> CodexTranscriptParser()
         TranscriptSource.claude -> ClaudeTranscriptParser()
         TranscriptSource.gemini -> ClaudeTranscriptParser() // Gemini uses dedicated reader
+        TranscriptSource.opencode -> ClaudeTranscriptParser() // OpenCode uses dedicated reader
     }
 }

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/core/Types.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/core/Types.kt
@@ -7,7 +7,7 @@ package ai.jolli.jollimemory.core
  */
 
 /** Which AI coding agent produced the transcript */
-enum class TranscriptSource { claude, codex, gemini }
+enum class TranscriptSource { claude, codex, gemini, opencode }
 
 /** Metadata about an AI coding session */
 data class SessionInfo(
@@ -288,6 +288,7 @@ data class JolliMemoryConfig(
     val claudeEnabled: Boolean? = null,
     val codexEnabled: Boolean? = null,
     val geminiEnabled: Boolean? = null,
+    val openCodeEnabled: Boolean? = null,
     /** AI summarization provider: "jolli" (proxy) or "anthropic" (direct). null defers to legacy "Anthropic wins" routing. */
     val aiProvider: String? = null,
     val logLevel: String? = null,
@@ -364,6 +365,8 @@ data class StatusInfo(
     val codexEnabled: Boolean? = null,
     val geminiDetected: Boolean? = null,
     val geminiEnabled: Boolean? = null,
+    val openCodeDetected: Boolean? = null,
+    val openCodeEnabled: Boolean? = null,
 )
 
 /** Log levels */

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/hooks/PostCommitHook.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/hooks/PostCommitHook.kt
@@ -147,7 +147,14 @@ object PostCommitHook {
             }
 
             // 4. Load sessions and read transcripts
-            val sessions = SessionTracker.loadAllSessions(cwd)
+            val allSessions = SessionTracker.loadAllSessions(cwd).toMutableList()
+
+            // On-demand discovery: OpenCode (SQLite-backed, no hook)
+            if (config.openCodeEnabled != false && OpenCodeSupport.isOpenCodeInstalled()) {
+                allSessions.addAll(OpenCodeSupport.discoverSessions(cwd))
+            }
+
+            val sessions = allSessions
             if (sessions.isEmpty()) {
                 log.info("No active sessions — skipping summarization")
                 return
@@ -165,6 +172,9 @@ object PostCommitHook {
                     TranscriptSource.gemini -> {
                         val entries = GeminiSupport.readGeminiTranscript(session.transcriptPath)
                         TranscriptReadResult(entries, TranscriptCursor(session.transcriptPath, entries.size, Instant.now().toString()), entries.size)
+                    }
+                    TranscriptSource.opencode -> {
+                        OpenCodeSupport.readTranscript(session.transcriptPath, cursor)
                     }
                     else -> {
                         val parser = getParserForSource(source)

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/SettingsDialog.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/SettingsDialog.kt
@@ -93,6 +93,7 @@ class SettingsDialog(
     private val claudeEnabledCheckbox = JBCheckBox("Claude Code — Session tracking via Stop hook", true)
     private val codexEnabledCheckbox = JBCheckBox("Codex CLI — Session discovery via filesystem scan", true)
     private val geminiEnabledCheckbox = JBCheckBox("Gemini CLI — Session tracking via AfterAgent hook", true)
+    private val openCodeEnabledCheckbox = JBCheckBox("OpenCode — Session discovery via SQLite database scan", true)
     private val excludePatternsField = JBTextField()
     private val pauseCheckbox = JBCheckBox("Pause Jolli Memory (temporarily disable hooks without losing configuration)")
 
@@ -163,6 +164,7 @@ class SettingsDialog(
             .addComponent(claudeEnabledCheckbox, 4)
             .addComponent(codexEnabledCheckbox, 4)
             .addComponent(geminiEnabledCheckbox, 4)
+            .addComponent(openCodeEnabledCheckbox, 4)
             .panel))
 
         return wrapTabContent(panel)
@@ -572,7 +574,7 @@ class SettingsDialog(
         }
 
         if (!claudeEnabledCheckbox.isSelected && !codexEnabledCheckbox.isSelected &&
-            !geminiEnabledCheckbox.isSelected
+            !geminiEnabledCheckbox.isSelected && !openCodeEnabledCheckbox.isSelected
         ) {
             return ValidationInfo("At least one platform must be enabled", claudeEnabledCheckbox)
         }
@@ -632,6 +634,7 @@ class SettingsDialog(
             claudeEnabled = claudeEnabledCheckbox.isSelected,
             codexEnabled = codexEnabledCheckbox.isSelected,
             geminiEnabled = geminiEnabledCheckbox.isSelected,
+            openCodeEnabled = openCodeEnabledCheckbox.isSelected,
             excludePatterns = if (excludePatterns.isNotEmpty()) excludePatterns else null,
             aiProvider = provider,
             knowledgeBasePath = kbPath,
@@ -730,6 +733,7 @@ class SettingsDialog(
         claudeEnabledCheckbox.isSelected = config.claudeEnabled != false
         codexEnabledCheckbox.isSelected = config.codexEnabled != false
         geminiEnabledCheckbox.isSelected = config.geminiEnabled != false
+        openCodeEnabledCheckbox.isSelected = config.openCodeEnabled != false
         pauseCheckbox.isSelected = config.paused == true
 
         // Memory Bank

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/StatusPanel.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/StatusPanel.kt
@@ -3,6 +3,7 @@ package ai.jolli.jollimemory.toolwindow
 import ai.jolli.jollimemory.JolliMemoryIcons
 import ai.jolli.jollimemory.core.CodexSessionDiscoverer
 import ai.jolli.jollimemory.core.GeminiSupport
+import ai.jolli.jollimemory.core.OpenCodeSupport
 import ai.jolli.jollimemory.core.JolliMemoryConfig
 import ai.jolli.jollimemory.core.SessionTracker
 import ai.jolli.jollimemory.core.StorageFactory
@@ -199,6 +200,20 @@ class StatusPanel(
                 enabledTooltip = "Gemini CLI AfterAgent hook installed — session tracking is enabled",
                 disabledTooltip = "Gemini CLI detected but session tracking is disabled in config",
                 hookMissingTooltip = "Gemini CLI detected but AfterAgent hook is not installed",
+            )
+        }
+
+        // 9. OpenCode Integration (no hooks needed — just detection)
+        val openCodeDetected = status.openCodeDetected ?: OpenCodeSupport.isOpenCodeInstalled()
+        if (openCodeDetected) {
+            val enabled = config.openCodeEnabled != false
+            addIntegrationRow(
+                enabled = enabled,
+                hookInstalled = null,
+                label = "OpenCode Integration",
+                enabledTooltip = "OpenCode database found — session discovery is enabled",
+                disabledTooltip = "OpenCode detected but session discovery is disabled in config",
+                hookMissingTooltip = null,
             )
         }
 

--- a/intellij/src/test/kotlin/ai/jolli/jollimemory/core/TypesTest.kt
+++ b/intellij/src/test/kotlin/ai/jolli/jollimemory/core/TypesTest.kt
@@ -10,7 +10,7 @@ class TypesTest {
     inner class Enums {
         @Test
         fun `TranscriptSource has correct values`() {
-            TranscriptSource.entries.map { it.name } shouldBe listOf("claude", "codex", "gemini")
+            TranscriptSource.entries.map { it.name } shouldBe listOf("claude", "codex", "gemini", "opencode")
         }
 
         @Test


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## E2E Test (4)
<details>
<summary><strong>1. OpenCode appears in the Settings dialog</strong></summary>
<br>
<blockquote>

**Preconditions:** Have the JolliMemory IntelliJ plugin installed and the Settings dialog accessible from the tool window.

**Steps:**
1. Open IntelliJ and navigate to the JolliMemory tool window.
2. Click the Settings (gear) icon to open the JolliMemory Settings dialog.
3. Look at the list of platform checkboxes (Claude Code, Codex CLI, Gemini CLI, etc.).
4. Verify that a new checkbox labeled "OpenCode — Session discovery via SQLite database scan" is visible in the list.
5. Uncheck the OpenCode checkbox, then click OK to save.
6. Reopen Settings and verify the OpenCode checkbox is still unchecked (the setting was saved).

**Expected Results:**
- The Settings dialog shows an "OpenCode — Session discovery via SQLite database scan" checkbox alongside the other platform options.
- After saving with the box unchecked and reopening Settings, the checkbox remains unchecked.

</blockquote>
</details>
<details>
<summary><strong>2. All platforms unchecked triggers validation error including OpenCode</strong></summary>
<br>
<blockquote>

**Preconditions:** Have the JolliMemory Settings dialog open.

**Steps:**
1. Open the JolliMemory Settings dialog.
2. Uncheck all four platform checkboxes: Claude Code, Codex CLI, Gemini CLI, and OpenCode.
3. Click OK to attempt saving.
4. Verify that an error message appears preventing the dialog from closing.
5. Re-check only the OpenCode checkbox and click OK again.

**Expected Results:**
- When all four checkboxes are unchecked, a validation error appears saying at least one platform must be enabled, and the dialog does not close.
- After re-checking OpenCode alone and clicking OK, the dialog closes successfully with no error.

</blockquote>
</details>
<details>
<summary><strong>3. OpenCode detected and shown in the Status panel</strong></summary>
<br>
<blockquote>

**Preconditions:** Have OpenCode installed on the machine (its database file exists at the default location under your home folder). Have a project open in IntelliJ with the JolliMemory plugin active.

**Steps:**
1. Open the JolliMemory tool window in IntelliJ.
2. Look at the status panel that lists detected integrations (Claude, Codex, Gemini, etc.).
3. Verify that an "OpenCode Integration" row appears in the list.
4. Hover over the OpenCode row to see its tooltip.
5. Open Settings, uncheck the OpenCode checkbox, save, and return to the status panel.
6. Hover over the OpenCode row again and check the tooltip text.

**Expected Results:**
- When OpenCode is detected and enabled, the status panel shows an "OpenCode Integration" row with a tooltip saying the database was found and session discovery is enabled.
- After disabling OpenCode in Settings, the row's tooltip changes to indicate OpenCode was detected but session discovery is disabled.

</blockquote>
</details>
<details>
<summary><strong>4. OpenCode sessions included in commit summary when enabled</strong></summary>
<br>
<blockquote>

**Preconditions:** Have OpenCode installed and at least one conversation started in the current project within the last 48 hours. Have the JolliMemory plugin configured with OpenCode enabled in Settings.

**Steps:**
1. Make a small code change in the project and commit it using IntelliJ's built-in commit dialog.
2. Wait for the JolliMemory post-commit summary notification to appear.
3. Open the JolliMemory tool window and review the generated commit summary.
4. Verify the summary reflects content from your recent OpenCode conversation.
5. Now open Settings, uncheck OpenCode, save, make another small commit, and check the new summary.

**Expected Results:**
- With OpenCode enabled, the commit summary includes context drawn from the recent OpenCode conversation in that project.
- With OpenCode disabled, the new commit summary no longer includes OpenCode conversation content (only other enabled sources contribute).

</blockquote>
</details>

---

## Topic (1)
<details>
<summary><strong>01 · Add OpenCode AI tool integration to IntelliJ plugin</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The VS Code extension had already gained support for reading sessions from OpenCode (a SQLite-backed AI coding tool), and the team wanted the IntelliJ plugin to have the same capability so users of that IDE would also get their OpenCode conversations included in commit summaries.

**💡 Decisions Behind the Code**

- **SQLite via JDBC instead of a file parser**: OpenCode stores all data in a relational database rather than JSONL or JSON files, so it cannot use the existing line-based `TranscriptReader` infrastructure. A dedicated top-level branch in the dispatch switch (mirroring the existing Gemini branch) was added rather than forcing a `TranscriptParser` implementation.
- **On-demand discovery outside `loadAllSessions`**: OpenCode has no install-time hook that registers sessions into `sessions.json`, so sessions are discovered by scanning the SQLite DB immediately before the transcript-reading loop — the same pattern already used for Codex. Discovered sessions are ephemeral and not persisted.
- **Synthetic transcript path `<dbPath>#<sessionId>`**: All OpenCode sessions share one global database file, so a plain file path cannot serve as a unique cursor key. Encoding the session ID into the path gives each session its own cursor slot without changing the cursor storage schema.

**✅ What Was Implemented**

- Created `OpenCodeSupport.kt` implementing session discovery (SQLite query against `~/.local/share/opencode/opencode.db` filtered by project directory and 48h recency) and transcript reading (message/part JOIN, text-only part filtering, cursor-based resumption, role mapping)
- Wired discovery into `PostCommitHook.kt` after `loadAllSessions()` and added a dedicated `TranscriptSource.opencode` dispatch branch; added `opencode` enum value to `Types.kt` and `openCodeEnabled` config/status fields
- Added `org.xerial:sqlite-jdbc:3.49.1.0` to `build.gradle.kts` (both `compileOnly` and `hooksRuntime`), OpenCode checkbox to `SettingsDialog.kt`, and detection row to `StatusPanel.kt`

**📁 FILES**
- `intellij/src/main/kotlin/ai/jolli/jollimemory/core/OpenCodeSupport.kt`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/hooks/PostCommitHook.kt`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/core/Types.kt`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/SettingsDialog.kt`
- `intellij/build.gradle.kts`

</blockquote>
</details>

---

*Generated by JolliMemory · May 7, 2026 at 2:54 PM*
<!-- jollimemory-summary-end -->