### PR TITLE
Refactor getSummary - separate abbreviated-hash resolution from cross-tree fallback

### DIFF
--- a/cli/src/commands/CliUtils.test.ts
+++ b/cli/src/commands/CliUtils.test.ts
@@ -230,27 +230,52 @@ describe("CliUtils", () => {
 	describe("printAmbiguousHash", () => {
 		// 40-char SHA fixtures matching production: AmbiguousHashError.matches
 		// always carries `index.entries[].commitHash` values which are 40 chars.
-		const SHA_A = "abc1234567890abc1234567890abc1234567890ab";
-		const SHA_B = "abc9876543210abc9876543210abc9876543210ab";
-		const SHA_C = "abc1111111111111111111111111111111111111ab";
+		const SHA_A = "abc1234567890abc1234567890abc1234567890ab".slice(0, 40);
+		const SHA_B = "abc9876543210abc9876543210abc9876543210ab".slice(0, 40);
+		const SHA_C = "abc1111111111111111111111111111111111111ab".slice(0, 40);
+
+		/** Captures console.error output of `fn` and returns the joined text. */
+		async function captureStderr(fn: () => void): Promise<string> {
+			const out: string[] = [];
+			const origErr = console.error;
+			console.error = (msg: string) => out.push(msg);
+			try {
+				fn();
+			} finally {
+				console.error = origErr;
+			}
+			return out.join("\n");
+		}
 
 		it("prints the prefix, count, and full match list when matches fit the display cap", async () => {
 			const { printAmbiguousHash } = await import("./CliUtils.js");
 			const { AmbiguousHashError } = await import("../core/SummaryStore.js");
-			const matches = [SHA_A.slice(0, 40), SHA_B.slice(0, 40), SHA_C.slice(0, 40)];
-			const out: string[] = [];
-			const origLog = console.log;
-			console.log = (msg: string) => out.push(msg);
-			try {
+			const matches = [SHA_A, SHA_B, SHA_C];
+			const joined = await captureStderr(() => {
 				printAmbiguousHash(new AmbiguousHashError("abc", matches));
-			} finally {
-				console.log = origLog;
-			}
-			const joined = out.join("\n");
+			});
 			expect(joined).toContain("abbreviation `abc` is ambiguous");
 			expect(joined).toContain("Matched 3 commits");
 			for (const hash of matches) expect(joined).toContain(hash);
 			// No "and N more" line when under the cap.
+			expect(joined).not.toContain("more");
+		});
+
+		it("includes every match (no '… and N more' tail) at exactly the display cap of 10", async () => {
+			// Boundary regression: catches `>` vs `>=` bugs in the truncation
+			// branch. With cap=10 and matches.length=10, the 10th element must
+			// still be inlined and the "and N more" line must NOT appear.
+			const { printAmbiguousHash } = await import("./CliUtils.js");
+			const { AmbiguousHashError } = await import("../core/SummaryStore.js");
+			const matches = Array.from({ length: 10 }, (_, i) => {
+				const stem = `${String(i).padStart(2, "0")}`;
+				return (stem + "f".repeat(40)).slice(0, 40);
+			});
+			const joined = await captureStderr(() => {
+				printAmbiguousHash(new AmbiguousHashError("00", matches));
+			});
+			expect(joined).toContain("Matched 10 commits");
+			for (const hash of matches) expect(joined).toContain(hash);
 			expect(joined).not.toContain("more");
 		});
 
@@ -265,15 +290,9 @@ describe("CliUtils", () => {
 				const stem = `${String(i).padStart(2, "0")}`;
 				return (stem + "0".repeat(40)).slice(0, 40); // 40-char hex
 			});
-			const out: string[] = [];
-			const origLog = console.log;
-			console.log = (msg: string) => out.push(msg);
-			try {
+			const joined = await captureStderr(() => {
 				printAmbiguousHash(new AmbiguousHashError("00", matches));
-			} finally {
-				console.log = origLog;
-			}
-			const joined = out.join("\n");
+			});
 			expect(joined).toContain("Matched 25 commits");
 			// First 10 are listed.
 			for (let i = 0; i < 10; i++) {
@@ -282,6 +301,72 @@ describe("CliUtils", () => {
 			// The 11th and beyond are NOT inlined.
 			expect(joined).not.toContain(matches[10]);
 			expect(joined).toContain("and 15 more");
+		});
+
+		it("does not write to stdout (clean for piped consumers)", async () => {
+			// Caller convention: hint goes to stderr so `jolli view --commit
+			// abc | tee file` keeps stdout clean. Without this guard a lazy
+			// console.log slip would silently regress the pipe contract.
+			const { printAmbiguousHash } = await import("./CliUtils.js");
+			const { AmbiguousHashError } = await import("../core/SummaryStore.js");
+			const stdoutLines: string[] = [];
+			const origLog = console.log;
+			console.log = (msg: string) => stdoutLines.push(msg);
+			try {
+				printAmbiguousHash(new AmbiguousHashError("abc", [SHA_A, SHA_B]));
+			} finally {
+				console.log = origLog;
+			}
+			expect(stdoutLines).toEqual([]);
+		});
+	});
+
+	describe("AmbiguousHashError construction invariants", () => {
+		it("rejects matches.length < 2 (use null/undefined for 'not found' instead)", async () => {
+			const { AmbiguousHashError } = await import("../core/SummaryStore.js");
+			expect(() => new AmbiguousHashError("abc", [])).toThrow(/requires ≥2 matches/);
+			expect(() => new AmbiguousHashError("abc", ["only-one"])).toThrow(/requires ≥2 matches/);
+		});
+
+		it("rejects an empty prefix (would otherwise match every entry on prefix scan)", async () => {
+			const { AmbiguousHashError } = await import("../core/SummaryStore.js");
+			expect(() => new AmbiguousHashError("", ["a", "b"])).toThrow(/prefix must be 1\.\.39 chars/);
+		});
+
+		it("rejects a 40-char prefix (full SHA wouldn't be ambiguous in the index)", async () => {
+			const { AmbiguousHashError } = await import("../core/SummaryStore.js");
+			const fortyChar = "a".repeat(40);
+			expect(() => new AmbiguousHashError(fortyChar, ["x", "y"])).toThrow(/prefix must be 1\.\.39 chars/);
+		});
+	});
+
+	describe("AmbiguousHashError.is (duck-typed guard)", () => {
+		it("matches both real instances and shape-equivalent objects across bundles", async () => {
+			const { AmbiguousHashError } = await import("../core/SummaryStore.js");
+			// Real instance — covers the common in-process case.
+			const real = new AmbiguousHashError("ab", ["aaaa", "bbbb"]);
+			expect(AmbiguousHashError.is(real)).toBe(true);
+
+			// Cross-bundle simulation: an Error with the same name + fields but
+			// a different prototype chain (what an IPC-deserialized error
+			// payload would look like). instanceof would FAIL here; is() must
+			// SUCCEED to keep callers forward-compatible.
+			const crossBundle = Object.assign(new Error("..."), {
+				name: "AmbiguousHashError",
+				prefix: "ab",
+				matches: ["aaaa", "bbbb"],
+			});
+			expect(AmbiguousHashError.is(crossBundle)).toBe(true);
+
+			// Negative cases: not Error / wrong name / missing fields.
+			expect(AmbiguousHashError.is(null)).toBe(false);
+			expect(AmbiguousHashError.is(new Error("plain"))).toBe(false);
+			expect(AmbiguousHashError.is({ name: "AmbiguousHashError", prefix: "ab", matches: [] })).toBe(false); // not Error
+			expect(
+				AmbiguousHashError.is(
+					Object.assign(new Error("..."), { name: "AmbiguousHashError", prefix: "ab" }), // missing matches
+				),
+			).toBe(false);
 		});
 	});
 });

--- a/cli/src/commands/CliUtils.test.ts
+++ b/cli/src/commands/CliUtils.test.ts
@@ -13,6 +13,11 @@ const { mockExecFileSync } = vi.hoisted(() => ({
 
 vi.mock("node:child_process", () => ({
 	execFileSync: mockExecFileSync,
+	// `printAmbiguousHash`'s tests import the real AmbiguousHashError from
+	// SummaryStore.ts → which transitively imports GitOps.ts → which calls
+	// `promisify(execFile)` at module load. Stub it to a no-op so the
+	// import doesn't blow up; we don't actually invoke any git here.
+	execFile: () => undefined,
 }));
 
 vi.mock("../core/SessionTracker.js", () => ({
@@ -219,6 +224,64 @@ describe("CliUtils", () => {
 			const { SAFE_ARGUMENT_PATTERN } = await import("./CliUtils.js");
 			expect(SAFE_ARGUMENT_PATTERN.test("branch;rm -rf /")).toBe(false);
 			expect(SAFE_ARGUMENT_PATTERN.test("$(whoami)")).toBe(false);
+		});
+	});
+
+	describe("printAmbiguousHash", () => {
+		// 40-char SHA fixtures matching production: AmbiguousHashError.matches
+		// always carries `index.entries[].commitHash` values which are 40 chars.
+		const SHA_A = "abc1234567890abc1234567890abc1234567890ab";
+		const SHA_B = "abc9876543210abc9876543210abc9876543210ab";
+		const SHA_C = "abc1111111111111111111111111111111111111ab";
+
+		it("prints the prefix, count, and full match list when matches fit the display cap", async () => {
+			const { printAmbiguousHash } = await import("./CliUtils.js");
+			const { AmbiguousHashError } = await import("../core/SummaryStore.js");
+			const matches = [SHA_A.slice(0, 40), SHA_B.slice(0, 40), SHA_C.slice(0, 40)];
+			const out: string[] = [];
+			const origLog = console.log;
+			console.log = (msg: string) => out.push(msg);
+			try {
+				printAmbiguousHash(new AmbiguousHashError("abc", matches));
+			} finally {
+				console.log = origLog;
+			}
+			const joined = out.join("\n");
+			expect(joined).toContain("abbreviation `abc` is ambiguous");
+			expect(joined).toContain("Matched 3 commits");
+			for (const hash of matches) expect(joined).toContain(hash);
+			// No "and N more" line when under the cap.
+			expect(joined).not.toContain("more");
+		});
+
+		it("truncates long match lists and adds an 'and N more' tail", async () => {
+			// A 1-2 char abbreviation in a large repo can collide with hundreds
+			// of entries — printing them all floods the terminal. We cap the
+			// visible list at 10 and summarize the rest. Use realistic 40-char
+			// SHAs so the formatter sees production-shaped input.
+			const { printAmbiguousHash } = await import("./CliUtils.js");
+			const { AmbiguousHashError } = await import("../core/SummaryStore.js");
+			const matches = Array.from({ length: 25 }, (_, i) => {
+				const stem = `${String(i).padStart(2, "0")}`;
+				return (stem + "0".repeat(40)).slice(0, 40); // 40-char hex
+			});
+			const out: string[] = [];
+			const origLog = console.log;
+			console.log = (msg: string) => out.push(msg);
+			try {
+				printAmbiguousHash(new AmbiguousHashError("00", matches));
+			} finally {
+				console.log = origLog;
+			}
+			const joined = out.join("\n");
+			expect(joined).toContain("Matched 25 commits");
+			// First 10 are listed.
+			for (let i = 0; i < 10; i++) {
+				expect(joined).toContain(matches[i]);
+			}
+			// The 11th and beyond are NOT inlined.
+			expect(joined).not.toContain(matches[10]);
+			expect(joined).toContain("and 15 more");
 		});
 	});
 });

--- a/cli/src/commands/CliUtils.ts
+++ b/cli/src/commands/CliUtils.ts
@@ -10,6 +10,7 @@
 import { execFileSync } from "node:child_process";
 import { createInterface } from "node:readline";
 import { getGlobalConfigDir } from "../core/SessionTracker.js";
+import type { AmbiguousHashError } from "../core/SummaryStore.js";
 import { compareSemver, traverseDistPaths } from "../install/DistPathResolver.js";
 
 /** Package version — injected by Vite at build time, falls back to "dev" when running via tsx. */
@@ -138,6 +139,33 @@ export function formatShortDate(iso: string): string {
 /** Returns true when stdin is an interactive terminal (not piped/CI). */
 export function isInteractive(): boolean {
 	return process.stdin.isTTY === true;
+}
+
+/** Cap on how many colliding hashes we list when an abbreviation is ambiguous. */
+const AMBIGUOUS_DISPLAY_LIMIT = 10;
+
+/**
+ * Prints a git-style "abbreviation is ambiguous" message for {@link AmbiguousHashError}.
+ *
+ * Shared by `view` / `export` / any future command whose `--commit <ref>` calls
+ * `getSummary` with potentially abbreviated input. Caller is responsible for
+ * setting `process.exitCode` so a single helper covers both quiet (subcommand)
+ * and noisy (top-level) callers without surprising them.
+ *
+ * Trims `matches` to {@link AMBIGUOUS_DISPLAY_LIMIT} so a 1-2 character prefix
+ * against a multi-thousand-commit repo doesn't flood the terminal.
+ */
+export function printAmbiguousHash(error: AmbiguousHashError): void {
+	console.log(`\n  abbreviation \`${error.prefix}\` is ambiguous; please use a longer prefix.`);
+	console.log(`  Matched ${error.matches.length} commits:`);
+	const head = error.matches.slice(0, AMBIGUOUS_DISPLAY_LIMIT);
+	for (const hash of head) {
+		console.log(`    ${hash}`);
+	}
+	if (error.matches.length > AMBIGUOUS_DISPLAY_LIMIT) {
+		console.log(`    … and ${error.matches.length - AMBIGUOUS_DISPLAY_LIMIT} more`);
+	}
+	console.log("");
 }
 
 /**

--- a/cli/src/commands/CliUtils.ts
+++ b/cli/src/commands/CliUtils.ts
@@ -141,7 +141,6 @@ export function isInteractive(): boolean {
 	return process.stdin.isTTY === true;
 }
 
-/** Cap on how many colliding hashes we list when an abbreviation is ambiguous. */
 const AMBIGUOUS_DISPLAY_LIMIT = 10;
 
 /**
@@ -152,20 +151,23 @@ const AMBIGUOUS_DISPLAY_LIMIT = 10;
  * setting `process.exitCode` so a single helper covers both quiet (subcommand)
  * and noisy (top-level) callers without surprising them.
  *
- * Trims `matches` to {@link AMBIGUOUS_DISPLAY_LIMIT} so a 1-2 character prefix
- * against a multi-thousand-commit repo doesn't flood the terminal.
+ * Writes to **stderr** so downstream `tee` / pipe consumers don't see the hint
+ * mixed into stdout (the project's `SearchCommand.emitError` follows the same
+ * convention for text-mode error output). Trims `matches` to
+ * {@link AMBIGUOUS_DISPLAY_LIMIT} so a 1-2 character prefix against a multi-
+ * thousand-commit repo doesn't flood the terminal.
  */
 export function printAmbiguousHash(error: AmbiguousHashError): void {
-	console.log(`\n  abbreviation \`${error.prefix}\` is ambiguous; please use a longer prefix.`);
-	console.log(`  Matched ${error.matches.length} commits:`);
+	console.error(`\n  abbreviation \`${error.prefix}\` is ambiguous; please use a longer prefix.`);
+	console.error(`  Matched ${error.matches.length} commits:`);
 	const head = error.matches.slice(0, AMBIGUOUS_DISPLAY_LIMIT);
 	for (const hash of head) {
-		console.log(`    ${hash}`);
+		console.error(`    ${hash}`);
 	}
 	if (error.matches.length > AMBIGUOUS_DISPLAY_LIMIT) {
-		console.log(`    … and ${error.matches.length - AMBIGUOUS_DISPLAY_LIMIT} more`);
+		console.error(`    … and ${error.matches.length - AMBIGUOUS_DISPLAY_LIMIT} more`);
 	}
-	console.log("");
+	console.error("");
 }
 
 /**

--- a/cli/src/commands/ExportCommand.test.ts
+++ b/cli/src/commands/ExportCommand.test.ts
@@ -1,0 +1,88 @@
+import { Command } from "commander";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { registerExportCommand } from "./ExportCommand.js";
+
+vi.mock("../core/SummaryExporter.js", () => ({
+	exportSummaries: vi.fn(),
+}));
+
+vi.mock("../core/SummaryStore.js", async () => {
+	const actual = await vi.importActual<typeof import("../core/SummaryStore.js")>("../core/SummaryStore.js");
+	return {
+		// Real AmbiguousHashError so the command's `instanceof` check matches.
+		AmbiguousHashError: actual.AmbiguousHashError,
+	};
+});
+
+import { exportSummaries } from "../core/SummaryExporter.js";
+import { AmbiguousHashError } from "../core/SummaryStore.js";
+
+const mockExport = vi.mocked(exportSummaries);
+
+function makeProgram(): Command {
+	const program = new Command();
+	program.exitOverride();
+	registerExportCommand(program);
+	return program;
+}
+
+async function runCommand(args: string[]): Promise<{ stdout: string; stderr: string }> {
+	let stdout = "";
+	let stderr = "";
+	const origLog = console.log;
+	const origErr = console.error;
+	console.log = (msg: string) => {
+		stdout += `${msg}\n`;
+	};
+	console.error = (msg: string) => {
+		stderr += `${msg}\n`;
+	};
+	try {
+		await makeProgram().parseAsync(["node", "jolli", "export", ...args]);
+	} finally {
+		console.log = origLog;
+		console.error = origErr;
+	}
+	return { stdout, stderr };
+}
+
+describe("registerExportCommand — ambiguous --commit handling", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	afterEach(() => {
+		process.exitCode = undefined;
+	});
+
+	it("renders 'use a longer prefix' and exits non-zero when --commit is ambiguous", async () => {
+		// SummaryExporter calls getSummary, which now throws AmbiguousHashError
+		// when an abbreviated SHA collides with multiple index entries. Without
+		// this catch ExportCommand would crash with an unhandled rejection;
+		// users get the same friendly hint as `jolli view`.
+		const collidingHashes = [
+			"abcdef1234567890abcdef1234567890abcdef12",
+			"abcdef9876543210abcdef9876543210abcdef98",
+		];
+		mockExport.mockRejectedValueOnce(new AmbiguousHashError("abcdef", collidingHashes));
+
+		const { stdout } = await runCommand(["--commit", "abcdef", "--cwd", "/tmp/jolli-export-test"]);
+
+		expect(stdout).toContain("abbreviation `abcdef` is ambiguous");
+		expect(stdout).toContain("please use a longer prefix");
+		for (const hash of collidingHashes) {
+			expect(stdout).toContain(hash);
+		}
+		expect(process.exitCode).toBe(1);
+	});
+
+	it("propagates non-Ambiguous errors from exportSummaries", async () => {
+		// Defensive: the catch only handles AmbiguousHashError. Anything else
+		// (storage failure, fs error) bubbles up so it isn't masked as "no
+		// summaries found to export".
+		mockExport.mockRejectedValueOnce(new Error("disk full"));
+		await expect(runCommand(["--commit", "abc12345", "--cwd", "/tmp/jolli-export-test"])).rejects.toThrow(
+			"disk full",
+		);
+	});
+});

--- a/cli/src/commands/ExportCommand.test.ts
+++ b/cli/src/commands/ExportCommand.test.ts
@@ -66,12 +66,15 @@ describe("registerExportCommand — ambiguous --commit handling", () => {
 		];
 		mockExport.mockRejectedValueOnce(new AmbiguousHashError("abcdef", collidingHashes));
 
-		const { stdout } = await runCommand(["--commit", "abcdef", "--cwd", "/tmp/jolli-export-test"]);
+		const { stdout, stderr } = await runCommand(["--commit", "abcdef", "--cwd", "/tmp/jolli-export-test"]);
 
-		expect(stdout).toContain("abbreviation `abcdef` is ambiguous");
-		expect(stdout).toContain("please use a longer prefix");
+		// Hint goes to stderr (matches `jolli view`'s convention so piped
+		// stdout consumers stay clean); stdout doesn't get the prose.
+		expect(stderr).toContain("abbreviation `abcdef` is ambiguous");
+		expect(stderr).toContain("please use a longer prefix");
+		expect(stdout).not.toContain("abbreviation");
 		for (const hash of collidingHashes) {
-			expect(stdout).toContain(hash);
+			expect(stderr).toContain(hash);
 		}
 		expect(process.exitCode).toBe(1);
 	});

--- a/cli/src/commands/ExportCommand.ts
+++ b/cli/src/commands/ExportCommand.ts
@@ -14,8 +14,9 @@ import { fileURLToPath } from "node:url";
 import type { Command } from "commander";
 import { TEMPLATES } from "../core/PromptTemplates.js";
 import { exportSummaries } from "../core/SummaryExporter.js";
+import { AmbiguousHashError } from "../core/SummaryStore.js";
 import { createLogger, setLogDir } from "../Logger.js";
-import { resolveProjectDir } from "./CliUtils.js";
+import { printAmbiguousHash, resolveProjectDir } from "./CliUtils.js";
 
 const log = createLogger("ExportCommand");
 
@@ -241,11 +242,24 @@ export function registerExportCommand(program: Command): void {
 			setLogDir(options.cwd);
 			log.info("Running 'export' command");
 
-			const result = await exportSummaries({
-				commit: options.commit,
-				project: options.project,
-				cwd: options.cwd,
-			});
+			let result: Awaited<ReturnType<typeof exportSummaries>>;
+			try {
+				result = await exportSummaries({
+					commit: options.commit,
+					project: options.project,
+					cwd: options.cwd,
+				});
+			} catch (error: unknown) {
+				// Abbreviated --commit value matched multiple index entries.
+				// Mirror ViewCommand's "use a longer prefix" hint so the user
+				// knows how to disambiguate; everything else propagates.
+				if (error instanceof AmbiguousHashError) {
+					printAmbiguousHash(error);
+					process.exitCode = 1;
+					return;
+				}
+				throw error;
+			}
 
 			if (result.totalSummaries === 0) {
 				console.log("\n  No summaries found to export.\n");

--- a/cli/src/commands/ExportCommand.ts
+++ b/cli/src/commands/ExportCommand.ts
@@ -253,7 +253,7 @@ export function registerExportCommand(program: Command): void {
 				// Abbreviated --commit value matched multiple index entries.
 				// Mirror ViewCommand's "use a longer prefix" hint so the user
 				// knows how to disambiguate; everything else propagates.
-				if (error instanceof AmbiguousHashError) {
+				if (AmbiguousHashError.is(error)) {
 					printAmbiguousHash(error);
 					process.exitCode = 1;
 					return;

--- a/cli/src/commands/SearchCommand.test.ts
+++ b/cli/src/commands/SearchCommand.test.ts
@@ -248,6 +248,60 @@ describe("registerSearchCommand", () => {
 		expect(stdout).toContain("abcd1234abcd1234abcd1234abcd1234abcd1234");
 	});
 
+	it("Phase 2 path: 8-char abbreviated hash flows end-to-end through getSummary's prefix scan", async () => {
+		// Integration coverage for the loosened HASH_LIST_PATTERN: parseHashList
+		// accepts the 8-char abbrev, the CLI passes it to LocalSearchProvider,
+		// which passes it to getSummary, which (in production) resolves it via
+		// the new in-memory prefix scan. Mock returns a summary keyed at the
+		// FULL 40-char SHA — buildHit then renders `hit.hash` as the first 8.
+		const fullHash = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
+		mockGetSummary.mockResolvedValueOnce({
+			version: 4,
+			commitHash: fullHash,
+			commitMessage: "feat: thing",
+			commitAuthor: "dev",
+			commitDate: "2026-04-01T00:00:00.000Z",
+			branch: "feature/thing",
+			generatedAt: "2026-04-01T00:00:00.000Z",
+			recap: "Did the thing",
+			topics: [{ title: "T", trigger: "tr", response: "rs", decisions: "d" }],
+		});
+		const { stdout } = await runCommand([
+			"thing",
+			"--hashes",
+			"deadbeef", // 8-char abbreviation
+			"--cwd",
+			"/tmp/jolli-search-test-abbrev",
+		]);
+		expect(stdout).toContain('"type": "search"');
+		// LocalSearchProvider was called with the abbreviated form (CLI doesn't
+		// expand to full SHA — that's getSummary's job in real use).
+		expect(mockGetSummary).toHaveBeenCalledTimes(1);
+		expect(mockGetSummary.mock.calls[0][0]).toBe("deadbeef");
+		// The result contains the full 40-char SHA (returned by getSummary)
+		// and the 8-char display hash matches the abbreviation.
+		expect(stdout).toContain(fullHash);
+	});
+
+	it("Phase 2 path: dedupes duplicate --hashes input", async () => {
+		// Regression: a copy-pasted list with accidental duplicates shouldn't
+		// double-load the same summary. parseHashList collapses duplicates
+		// into a single entry, so getSummary is only invoked once per unique
+		// hash.
+		mockGetSummary.mockResolvedValue({
+			version: 4,
+			commitHash: "abcd1234abcd1234abcd1234abcd1234abcd1234",
+			commitMessage: "m",
+			commitAuthor: "d",
+			commitDate: "2026-04-01T00:00:00.000Z",
+			branch: "b",
+			generatedAt: "2026-04-01T00:00:00.000Z",
+			topics: [],
+		});
+		await runCommand(["q", "--hashes", "abcd1234,abcd1234,abcd1234", "--cwd", "/tmp/jolli-search-test-dedupe"]);
+		expect(mockGetSummary).toHaveBeenCalledTimes(1);
+	});
+
 	it("--output writes file and prints confirmation", async () => {
 		const { stdout } = await runCommand([
 			"auth",

--- a/cli/src/commands/SearchCommand.test.ts
+++ b/cli/src/commands/SearchCommand.test.ts
@@ -2,11 +2,17 @@ import { Command } from "commander";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { parseHashList, registerSearchCommand } from "./SearchCommand.js";
 
-vi.mock("../core/SummaryStore.js", () => ({
-	getCatalogWithLazyBuild: vi.fn(async () => ({ version: 1, entries: [] })),
-	getIndex: vi.fn(async () => null),
-	getSummary: vi.fn(async () => null),
-}));
+vi.mock("../core/SummaryStore.js", async () => {
+	const actual = await vi.importActual<typeof import("../core/SummaryStore.js")>("../core/SummaryStore.js");
+	return {
+		// Re-export the real AmbiguousHashError so `instanceof` checks in
+		// LocalSearchProvider see the same class the tests would throw.
+		AmbiguousHashError: actual.AmbiguousHashError,
+		getCatalogWithLazyBuild: vi.fn(async () => ({ version: 1, entries: [] })),
+		getIndex: vi.fn(async () => null),
+		getSummary: vi.fn(async () => null),
+	};
+});
 
 import { getCatalogWithLazyBuild, getIndex } from "../core/SummaryStore.js";
 
@@ -50,20 +56,30 @@ describe("parseHashList", () => {
 		).toEqual(["abcd1234abcd1234abcd1234abcd1234abcd1234", "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"]);
 	});
 
-	it("rejects too-short hashes", () => {
+	it("rejects hashes shorter than 8 characters", () => {
+		// Below 8 we don't try to resolve — the catalog never emits anything
+		// shorter, and very short inputs would just produce ambiguous matches.
 		expect(parseHashList("abc")).toBeNull();
+		expect(parseHashList("1234567")).toBeNull();
 	});
 
-	it("rejects 8-char abbreviations (must be the full 40-char SHA)", () => {
-		// Regression: earlier the pattern was 4-64 chars and abbreviations relied
-		// on `getSummary`'s git rev-parse + tree-hash fallback. That fallback
-		// silently resolves to the wrong commit when two distinct commits share
-		// a tree (cherry-pick, rebase). The CLI now rejects abbreviations at the
-		// boundary so the contract is enforced — `hit.fullHash`, not `hit.hash`.
-		expect(parseHashList("abcd1234")).toBeNull();
-		expect(parseHashList("abcd1234,deadbeef")).toBeNull();
-		// 39 chars: one shy of full SHA, still rejected.
-		expect(parseHashList("abcd1234abcd1234abcd1234abcd1234abcd123")).toBeNull();
+	it("accepts 8-char abbreviations (matches the catalog's `hash` field length)", () => {
+		// Once getSummary resolves abbrevs via in-memory index prefix scan
+		// (returning AmbiguousHashError for collisions instead of silently
+		// picking one), the CLI boundary can safely accept either `hit.hash`
+		// (8-char) or `hit.fullHash` (40-char) from the catalog output.
+		expect(parseHashList("abcd1234")).toEqual(["abcd1234"]);
+		expect(parseHashList("abcd1234,deadbeef")).toEqual(["abcd1234", "deadbeef"]);
+		// Mixed lengths in the same call: one 8-char abbrev, one full 40-char SHA.
+		expect(parseHashList("abcd1234,abcd1234abcd1234abcd1234abcd1234abcd1234")).toEqual([
+			"abcd1234",
+			"abcd1234abcd1234abcd1234abcd1234abcd1234",
+		]);
+	});
+
+	it("rejects hashes longer than 40 characters", () => {
+		// 41 hex chars: longer than any real SHA-1 — likely garbage / typo.
+		expect(parseHashList("abcd1234abcd1234abcd1234abcd1234abcd12345")).toBeNull();
 	});
 
 	it("rejects trailing comma", () => {
@@ -76,9 +92,9 @@ describe("parseHashList", () => {
 	});
 
 	it("rejects non-hex characters", () => {
-		// 40-char string with a non-hex letter ("z") — would have passed the old
-		// hex-only check based on length but for the wrong reason; explicit here.
+		// "z" is not a valid hex digit.
 		expect(parseHashList("zzz12345abcd1234abcd1234abcd1234abcd1234")).toBeNull();
+		expect(parseHashList("abcd123g")).toBeNull(); // 8 chars, "g" is not hex
 	});
 
 	it("normalizes mixed case to lowercase", () => {
@@ -166,21 +182,20 @@ describe("registerSearchCommand", () => {
 		expect(stdout).toContain('"type":"error"');
 	});
 
-	it("rejects --hashes with abbreviated SHAs and tells the caller to use fullHash", async () => {
-		// Earlier the CLI accepted 4-64 char hashes and `getSummary`'s tree-hash
-		// fallback resolved them. That fallback can silently match the wrong
-		// commit when two commits share a tree (cherry-pick, rebase). Now the
-		// CLI rejects anything other than 40-char SHAs at the boundary.
+	it("rejects --hashes that don't fit the 8-40 hex pattern (too short / non-hex)", async () => {
+		// Abbreviated SHAs ≥ 8 are now ACCEPTED — `getSummary` resolves them via
+		// in-memory index prefix scan with explicit AmbiguousHashError on collisions,
+		// so the boundary no longer has to enforce "full SHA only". Inputs that
+		// don't look like a hex SHA at all (too short, non-hex chars) still error.
 		const { stdout } = await runCommand([
 			"auth",
 			"--hashes",
-			"abcd1234,deadbeef",
+			"abc,defg", // both segments < 8 chars
 			"--cwd",
 			"/tmp/jolli-search-test-empty",
 		]);
 		expect(stdout).toContain('"type":"error"');
-		expect(stdout).toContain("fullHash");
-		expect(stdout).toContain("40-character");
+		expect(stdout).toContain("8 to 40 characters");
 	});
 
 	it("requires query when --hashes is provided", async () => {

--- a/cli/src/commands/SearchCommand.ts
+++ b/cli/src/commands/SearchCommand.ts
@@ -26,19 +26,19 @@ import { setLogDir } from "../Logger.js";
 import { isSafeQuery, parsePositiveInt, resolveProjectDir } from "./CliUtils.js";
 
 /**
- * Pattern matching a comma-separated list of **40-char full SHA hashes**.
+ * Pattern matching a comma-separated list of **8- to 40-char hex SHAs**.
  *
- * Full hashes only — no abbreviations. Earlier this allowed 4-64 hex chars
- * relying on `getSummary`'s tree-hash fallback to resolve abbreviations, but
- * that fallback is unsafe for the search caller: when two distinct commits
- * share the same git tree (cherry-pick, rebase that produces an identical
- * tree, etc.), the abbrev resolves to the wrong index entry silently. The
- * skill template's catalog output exposes both `hash` (8-char display) and
- * `fullHash` (40-char), and Step 4 of the template now explicitly tells the
- * LLM to pass `fullHash` here. Locking the pattern to exactly 40 characters
- * enforces that contract at the boundary.
+ * Accepts abbreviated SHAs (≥ 8 chars, jolli's catalog `hash` field length) up
+ * to full 40-char SHAs. The lower bound mirrors what the catalog emits, so the
+ * LLM can echo back either `hit.hash` or `hit.fullHash` and have it resolve.
+ *
+ * Earlier this was locked to exactly 40 because `getSummary`'s tree-hash
+ * fallback could silently mis-resolve cherry-pick / rebase twins that share a
+ * tree. Once `getSummary` resolves abbreviated input via in-memory index
+ * prefix scan (with explicit `AmbiguousHashError` on collisions), the boundary
+ * can safely accept abbreviations again.
  */
-const HASH_LIST_PATTERN = /^[0-9a-f]{40}(,[0-9a-f]{40})*$/i;
+const HASH_LIST_PATTERN = /^[0-9a-f]{8,40}(,[0-9a-f]{8,40})*$/i;
 
 interface SearchOptions {
 	since?: string;
@@ -174,13 +174,13 @@ export function registerSearchCommand(program: Command): void {
 					return;
 				}
 
-				// --hashes implies Phase 2; require full 40-char SHAs and a query.
+				// --hashes implies Phase 2; require 8-40 char hex SHAs and a query.
 				if (options.hashes !== undefined) {
 					const parsed = parseHashList(options.hashes);
 					if (!parsed || parsed.length === 0) {
 						emitError(
 							options,
-							"Invalid --hashes value. Expected comma-separated 40-character full hex SHAs (use `hit.fullHash` from the Phase 1 catalog, not `hit.hash`).",
+							"Invalid --hashes value. Expected comma-separated hex SHAs of 8 to 40 characters (use `hit.hash` or `hit.fullHash` from the Phase 1 catalog).",
 						);
 						return;
 					}

--- a/cli/src/commands/SearchCommand.ts
+++ b/cli/src/commands/SearchCommand.ts
@@ -50,16 +50,29 @@ interface SearchOptions {
 	cwd?: string;
 }
 
-/** Splits a `--hashes` value into a list of trimmed, lowercased hashes. */
+/**
+ * Splits a `--hashes` value into a list of trimmed, lowercased hashes.
+ *
+ * Deduplicates while preserving first-seen order so a copy-pasted list with
+ * accidental duplicates (e.g. `abc1234,abc1234`) doesn't double-load the
+ * same summary downstream. The order matters because `LocalSearchProvider.
+ * loadHits` returns `results` in input order — the caller may rely on that
+ * ordering for rendering.
+ */
 export function parseHashList(value: string | undefined): ReadonlyArray<string> | null {
 	if (!value) return null;
 	const trimmed = value.trim();
 	if (trimmed.length === 0) return null;
 	if (!HASH_LIST_PATTERN.test(trimmed)) return null;
-	return trimmed
-		.split(",")
-		.map((h) => h.trim().toLowerCase())
-		.filter((h) => h.length > 0);
+	const seen = new Set<string>();
+	const out: string[] = [];
+	for (const raw of trimmed.split(",")) {
+		const h = raw.trim().toLowerCase();
+		if (h.length === 0 || seen.has(h)) continue;
+		seen.add(h);
+		out.push(h);
+	}
+	return out;
 }
 
 /**

--- a/cli/src/commands/ViewCommand.test.ts
+++ b/cli/src/commands/ViewCommand.test.ts
@@ -65,13 +65,16 @@ describe("registerViewCommand", () => {
 		];
 		mockGetSummary.mockRejectedValueOnce(new AmbiguousHashError("abcdef", collidingHashes));
 
-		const { stdout } = await runCommand(["--commit", "abcdef", "--cwd", "/tmp/jolli-view-test"]);
+		const { stdout, stderr } = await runCommand(["--commit", "abcdef", "--cwd", "/tmp/jolli-view-test"]);
 
-		expect(stdout).toContain("abbreviation `abcdef` is ambiguous");
-		expect(stdout).toContain("please use a longer prefix");
+		// Hint goes to stderr (so it doesn't pollute piped stdout consumers
+		// like `jolli view --commit abc | tee file`); stdout stays clean.
+		expect(stderr).toContain("abbreviation `abcdef` is ambiguous");
+		expect(stderr).toContain("please use a longer prefix");
+		expect(stdout).not.toContain("abbreviation");
 		// Both colliding hashes are shown so the user can pick.
 		for (const hash of collidingHashes) {
-			expect(stdout).toContain(hash);
+			expect(stderr).toContain(hash);
 		}
 		expect(process.exitCode).toBe(1);
 	});

--- a/cli/src/commands/ViewCommand.test.ts
+++ b/cli/src/commands/ViewCommand.test.ts
@@ -1,0 +1,112 @@
+import { Command } from "commander";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { registerViewCommand } from "./ViewCommand.js";
+
+vi.mock("../core/SummaryStore.js", async () => {
+	const actual = await vi.importActual<typeof import("../core/SummaryStore.js")>("../core/SummaryStore.js");
+	return {
+		// Real AmbiguousHashError so the command's `instanceof` check passes
+		// against errors thrown by mocked getSummary.
+		AmbiguousHashError: actual.AmbiguousHashError,
+		getIndex: vi.fn(async () => null),
+		getSummary: vi.fn(async () => null),
+	};
+});
+
+import { AmbiguousHashError, getIndex, getSummary } from "../core/SummaryStore.js";
+
+const mockGetIndex = vi.mocked(getIndex);
+const mockGetSummary = vi.mocked(getSummary);
+
+function makeProgram(): Command {
+	const program = new Command();
+	program.exitOverride();
+	registerViewCommand(program);
+	return program;
+}
+
+async function runCommand(args: string[]): Promise<{ stdout: string; stderr: string }> {
+	let stdout = "";
+	let stderr = "";
+	const origLog = console.log;
+	const origErr = console.error;
+	console.log = (msg: string) => {
+		stdout += `${msg}\n`;
+	};
+	console.error = (msg: string) => {
+		stderr += `${msg}\n`;
+	};
+	try {
+		await makeProgram().parseAsync(["node", "jolli", "view", ...args]);
+	} finally {
+		console.log = origLog;
+		console.error = origErr;
+	}
+	return { stdout, stderr };
+}
+
+describe("registerViewCommand", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	afterEach(() => {
+		process.exitCode = undefined;
+	});
+
+	it("renders a 'use a longer prefix' message and exits non-zero when --commit is ambiguous", async () => {
+		// getSummary throws when an abbreviated hash collides with multiple
+		// index entries. ViewCommand should surface this as a git-style hint
+		// listing the colliding hashes, rather than letting the error abort
+		// the process with a stack trace.
+		const collidingHashes = [
+			"abcdef1234567890abcdef1234567890abcdef12",
+			"abcdef9876543210abcdef9876543210abcdef98",
+		];
+		mockGetSummary.mockRejectedValueOnce(new AmbiguousHashError("abcdef", collidingHashes));
+
+		const { stdout } = await runCommand(["--commit", "abcdef", "--cwd", "/tmp/jolli-view-test"]);
+
+		expect(stdout).toContain("abbreviation `abcdef` is ambiguous");
+		expect(stdout).toContain("please use a longer prefix");
+		// Both colliding hashes are shown so the user can pick.
+		for (const hash of collidingHashes) {
+			expect(stdout).toContain(hash);
+		}
+		expect(process.exitCode).toBe(1);
+	});
+
+	it("propagates non-Ambiguous errors instead of swallowing them", async () => {
+		// Defensive: only AmbiguousHashError is caught and rendered. Anything
+		// else (e.g. a transient I/O error) should bubble up so it isn't
+		// silently masked as "no summary found".
+		mockGetSummary.mockRejectedValueOnce(new Error("disk on fire"));
+
+		await expect(runCommand(["--commit", "deadbeef", "--cwd", "/tmp/jolli-view-test"])).rejects.toThrow(
+			"disk on fire",
+		);
+	});
+
+	it("renders 'No summary found' when --commit is a SHA with no match", async () => {
+		// Sanity: the new error-handling branch did not regress the plain
+		// not-found message for non-numeric input.
+		mockGetSummary.mockResolvedValueOnce(null);
+
+		const { stdout } = await runCommand(["--commit", "abcdef12", "--cwd", "/tmp/jolli-view-test"]);
+
+		expect(stdout).toContain("No summary found for commit abcdef12");
+		// SHA path doesn't set a non-zero exit code (consistent with prior behavior).
+		expect(process.exitCode).toBeUndefined();
+	});
+
+	it("stays silent when --commit is a numeric index that doesn't exist", async () => {
+		// Numeric path goes through getIndex, not getSummary. resolveCommit
+		// already prints its own "No summary at index" message; ViewCommand
+		// must not double-print "No summary found for commit 99".
+		mockGetIndex.mockResolvedValueOnce({ version: 3, entries: [] });
+
+		const { stdout } = await runCommand(["--commit", "99", "--cwd", "/tmp/jolli-view-test"]);
+
+		expect(stdout).not.toContain("No summary found for commit 99");
+	});
+});

--- a/cli/src/commands/ViewCommand.ts
+++ b/cli/src/commands/ViewCommand.ts
@@ -263,7 +263,7 @@ export function registerViewCommand(program: Command): void {
 				try {
 					summary = await resolveCommit(options.commit, options.cwd);
 				} catch (error: unknown) {
-					if (error instanceof AmbiguousHashError) {
+					if (AmbiguousHashError.is(error)) {
 						printAmbiguousHash(error);
 						process.exitCode = 1;
 						return;

--- a/cli/src/commands/ViewCommand.ts
+++ b/cli/src/commands/ViewCommand.ts
@@ -13,11 +13,11 @@ import { pathToFileURL } from "node:url";
 import { type Command, Option } from "commander";
 import { getDisplayDate } from "../core/SummaryFormat.js";
 import { buildMarkdown } from "../core/SummaryMarkdownBuilder.js";
-import { getIndex, getSummary } from "../core/SummaryStore.js";
+import { AmbiguousHashError, getIndex, getSummary } from "../core/SummaryStore.js";
 import { aggregateTurns, collectAllTopics, formatDurationLabel, resolveDiffStats } from "../core/SummaryTree.js";
 import { createLogger, setLogDir } from "../Logger.js";
 import type { CommitSummary, SummaryIndexEntry, TopicSummary } from "../Types.js";
-import { formatShortDate, parsePositiveInt, resolveProjectDir } from "./CliUtils.js";
+import { formatShortDate, parsePositiveInt, printAmbiguousHash, resolveProjectDir } from "./CliUtils.js";
 
 const log = createLogger("view");
 
@@ -255,8 +255,21 @@ export function registerViewCommand(program: Command): void {
 			log.info("Running 'view' command");
 
 			if (options.commit) {
-				// View specific commit (by index or SHA)
-				const summary = await resolveCommit(options.commit, options.cwd);
+				// View specific commit (by index or SHA). The lookup may throw
+				// AmbiguousHashError when an abbreviated SHA matches multiple
+				// commits — show a git-style "use a longer prefix" message and
+				// list the colliding hashes so the user can disambiguate.
+				let summary: CommitSummary | null;
+				try {
+					summary = await resolveCommit(options.commit, options.cwd);
+				} catch (error: unknown) {
+					if (error instanceof AmbiguousHashError) {
+						printAmbiguousHash(error);
+						process.exitCode = 1;
+						return;
+					}
+					throw error;
+				}
 				if (!summary) {
 					if (!/^\d+$/.test(options.commit)) {
 						console.log(`\n  No summary found for commit ${options.commit}\n`);

--- a/cli/src/core/LocalSearchProvider.test.ts
+++ b/cli/src/core/LocalSearchProvider.test.ts
@@ -5,13 +5,19 @@ import { DEFAULT_CATALOG_LIMIT, DEFAULT_SEARCH_BUDGET } from "./Search.js";
 
 // ─── Mocks ───────────────────────────────────────────────────────────────────
 
-vi.mock("./SummaryStore.js", () => ({
-	getCatalogWithLazyBuild: vi.fn(),
-	getIndex: vi.fn(),
-	getSummary: vi.fn(),
-}));
+vi.mock("./SummaryStore.js", async () => {
+	const actual = await vi.importActual<typeof import("./SummaryStore.js")>("./SummaryStore.js");
+	return {
+		// Real AmbiguousHashError so loadHits's `instanceof` check matches the
+		// errors thrown by mocked getSummary.
+		AmbiguousHashError: actual.AmbiguousHashError,
+		getCatalogWithLazyBuild: vi.fn(),
+		getIndex: vi.fn(),
+		getSummary: vi.fn(),
+	};
+});
 
-import { getCatalogWithLazyBuild, getIndex, getSummary } from "./SummaryStore.js";
+import { AmbiguousHashError, getCatalogWithLazyBuild, getIndex, getSummary } from "./SummaryStore.js";
 
 const mockGetIndex = vi.mocked(getIndex);
 const mockGetCatalog = vi.mocked(getCatalogWithLazyBuild);
@@ -484,6 +490,38 @@ describe("LocalSearchProvider.loadHits", () => {
 		const result = await provider.loadHits({ query: "auth", hashes: ["found", "missing"] });
 		expect(result.results).toHaveLength(1);
 		expect(result.failedHashes).toEqual(["missing"]);
+	});
+
+	it("records ambiguous abbreviated hashes in failedHashes without aborting the batch", async () => {
+		// loadHits used to bubble any throw out, which would 500-style abort the
+		// whole search request the moment one abbreviated hash was ambiguous.
+		// We catch AmbiguousHashError, mark just that hash as failed, and keep
+		// loading the rest so the LLM caller still gets a partial result it can
+		// reason about (and try a longer prefix on next iteration).
+		mockGetSummary.mockImplementation(async (hash: string) => {
+			if (hash === "good1234") return makeSummary("good1234");
+			if (hash === "ambig") {
+				throw new AmbiguousHashError("ambig", [
+					"ambig1111111111111111111111111111111111",
+					"ambig2222222222222222222222222222222222",
+				]);
+			}
+			return null;
+		});
+		const provider = new LocalSearchProvider("/test");
+		const result = await provider.loadHits({ query: "x", hashes: ["good1234", "ambig"] });
+		expect(result.results).toHaveLength(1);
+		expect(result.results[0].hash).toBe("good1234");
+		expect(result.failedHashes).toEqual(["ambig"]);
+	});
+
+	it("propagates non-Ambiguous errors from getSummary (don't silently swallow)", async () => {
+		// Defensive: only AmbiguousHashError is caught. Anything else (storage
+		// failure, OOM, etc.) should bubble up so it isn't masked as "failed
+		// hash".
+		mockGetSummary.mockRejectedValueOnce(new Error("storage offline"));
+		const provider = new LocalSearchProvider("/test");
+		await expect(provider.loadHits({ query: "x", hashes: ["whatever"] })).rejects.toThrow("storage offline");
 	});
 
 	it("emits identity / provenance / narrative fields on each hit", async () => {

--- a/cli/src/core/LocalSearchProvider.ts
+++ b/cli/src/core/LocalSearchProvider.ts
@@ -32,7 +32,7 @@ import { DEFAULT_CATALOG_LIMIT, DEFAULT_SEARCH_BUDGET } from "./Search.js";
 import type { SearchProvider, SearchSource } from "./SearchProvider.js";
 import type { StorageProvider } from "./StorageProvider.js";
 import { getDisplayDate } from "./SummaryFormat.js";
-import { getCatalogWithLazyBuild, getIndex, getSummary } from "./SummaryStore.js";
+import { AmbiguousHashError, getCatalogWithLazyBuild, getIndex, getSummary } from "./SummaryStore.js";
 import { collectDisplayTopics } from "./SummaryTree.js";
 import { estimateTokens } from "./TokenEstimator.js";
 
@@ -166,7 +166,21 @@ export class LocalSearchProvider implements SearchProvider {
 		let totalTokens = 0;
 
 		for (const hash of options.hashes) {
-			const summary = await getSummary(hash, this.cwd, this.storage);
+			let summary: CommitSummary | null;
+			try {
+				summary = await getSummary(hash, this.cwd, this.storage);
+			} catch (error: unknown) {
+				// Abbreviated hash collided with multiple index entries. We log it
+				// and record the ambiguous input in `failedHashes` so the LLM
+				// caller sees a partial result rather than a 500-style abort —
+				// other unambiguous hashes in the same batch are still loaded.
+				if (error instanceof AmbiguousHashError) {
+					log.debug("loadHits: %s is ambiguous (%d matches) — skipping", hash, error.matches.length);
+					failed.push(hash);
+					continue;
+				}
+				throw error;
+			}
 			if (!summary) {
 				log.debug("loadHits: no summary for %s — recording as failed", hash.substring(0, 8));
 				failed.push(hash);

--- a/cli/src/core/LocalSearchProvider.ts
+++ b/cli/src/core/LocalSearchProvider.ts
@@ -170,12 +170,21 @@ export class LocalSearchProvider implements SearchProvider {
 			try {
 				summary = await getSummary(hash, this.cwd, this.storage);
 			} catch (error: unknown) {
-				// Abbreviated hash collided with multiple index entries. We log it
-				// and record the ambiguous input in `failedHashes` so the LLM
-				// caller sees a partial result rather than a 500-style abort —
-				// other unambiguous hashes in the same batch are still loaded.
-				if (error instanceof AmbiguousHashError) {
-					log.debug("loadHits: %s is ambiguous (%d matches) — skipping", hash, error.matches.length);
+				// Abbreviated hash collided with multiple index entries. We log
+				// it and record the ambiguous input in `failedHashes` so the
+				// LLM caller sees a partial result rather than a 500-style
+				// abort — other unambiguous hashes in the same batch are still
+				// loaded. `failedHashes` currently flattens "ambiguous" and
+				// "missing" into one signal; bumping to warn so production
+				// observers can tell which hashes need a longer prefix even
+				// without a schema upgrade. (Splitting the schema into
+				// `{hash, reason, matches?}` is tracked as a follow-up.)
+				if (AmbiguousHashError.is(error)) {
+					log.warn(
+						"loadHits: hash %s is ambiguous (%d matches) — recording as failed",
+						hash,
+						error.matches.length,
+					);
 					failed.push(hash);
 					continue;
 				}

--- a/cli/src/core/SummaryStore.test.ts
+++ b/cli/src/core/SummaryStore.test.ts
@@ -38,6 +38,7 @@ import {
 } from "./GitOps.js";
 import { acquireLock, releaseLock } from "./SessionTracker.js";
 import {
+	AmbiguousHashError,
 	deleteTranscript,
 	expandSourcesForConsolidation,
 	getIndex,
@@ -291,12 +292,10 @@ describe("SummaryStore", () => {
 	describe("getSummary (direct-read)", () => {
 		// readFileFromBranch is mocked per test. Lookup contract:
 		//   1. Try readSummaryFile(hash) -- 1 read; if it returns non-null, return.
-		//   2. Otherwise loadIndex (1 read), check commitAliases, optional tree-hash
-		//      scan, then a final readSummaryFile(matchedHash) when an alias hits.
-		//
-		// Direct file read returns the original summary for any hash that ever
-		// owned a `summaries/{hash}.json` file -- which is every hash that entered
-		// the system, since mergeManyToOne / migrateOneToOne never delete old files.
+		//   2. Otherwise loadIndex (1 read), then branch by input length:
+		//      - 40-char SHA → check commitAliases, then tree-hash fallback.
+		//      - shorter prefix → index prefix scan (own describe block below),
+		//        then tree-hash fallback.
 
 		it("returns the original summary directly via readSummaryFile (root hash)", async () => {
 			const summary = createMockSummary();
@@ -323,17 +322,21 @@ describe("SummaryStore", () => {
 			expect(result?.topics?.[0].title).toBe("Fix login");
 		});
 
-		it("falls back to commitAliases when direct read misses", async () => {
-			const summary = createMockSummary("knownhash00");
-			const index = v3Index([rootEntry("knownhash00")], { unknownhash0: "knownhash00" });
+		it("falls back to commitAliases when direct read misses (40-char old SHA → new SHA)", async () => {
+			// Alias keys are 40-char in production — use 40-char fixtures so the
+			// length-branched lookup takes the alias-map path rather than prefix scan.
+			const oldHash = "1111111111111111111111111111111111111111";
+			const newHash = "2222222222222222222222222222222222222222";
+			const summary = createMockSummary(newHash);
+			const index = v3Index([rootEntry(newHash)], { [oldHash]: newHash });
 
 			vi.mocked(readFileFromBranch)
-				.mockResolvedValueOnce(null) // direct readSummaryFile("unknownhash0") miss
+				.mockResolvedValueOnce(null) // direct readSummaryFile(oldHash) miss
 				.mockResolvedValueOnce(JSON.stringify(index)) // loadIndex
 				.mockResolvedValueOnce(JSON.stringify(summary)); // readSummaryFile(aliasHash)
 
-			const result = await getSummary("unknownhash0");
-			expect(result?.commitHash).toBe("knownhash00");
+			const result = await getSummary(oldHash);
+			expect(result?.commitHash).toBe(newHash);
 		});
 
 		it("returns null when the file read fails AND there is no index", async () => {
@@ -355,9 +358,209 @@ describe("SummaryStore", () => {
 			vi.mocked(readFileFromBranch)
 				.mockResolvedValueOnce(null) // direct miss
 				.mockResolvedValueOnce(JSON.stringify(index)); // loadIndex (no aliases match)
-			// getTreeHash mock left unconfigured -> resolves to undefined, no match
+			// getTreeHash mock left unconfigured -> resolves to null, no match.
+			// Use 18-char input so the prefix-scan branch runs and produces 0
+			// matches (knownhash00 doesn't start with absolutely-unknown).
 			const result = await getSummary("absolutely-unknown");
 			expect(result).toBeNull();
+		});
+	});
+
+	describe("getSummary (abbreviated-hash prefix scan)", () => {
+		// Inputs shorter than 40 characters take the index-prefix-scan branch
+		// after Step 1 misses. Resolution is purely in-memory via index.entries.
+
+		const ENTRY_ONE = "abcdef1234567890abcdef1234567890abcdef12"; // 40 chars
+		const ENTRY_TWO = "abcdef9876543210abcdef9876543210abcdef98"; // 40 chars, shares "abcdef" prefix
+		const ENTRY_THREE = "fedcba0000000000000000000000000000000000";
+
+		it("resolves an abbreviated hash to the unique matching entry without touching git or alias map", async () => {
+			const summary = createMockSummary(ENTRY_ONE);
+			const index = v3Index([rootEntry(ENTRY_ONE), rootEntry(ENTRY_THREE)]);
+
+			vi.mocked(readFileFromBranch)
+				.mockResolvedValueOnce(null) // Step 1 readSummaryFile("abcdef12") miss
+				.mockResolvedValueOnce(JSON.stringify(index)) // loadIndex
+				.mockResolvedValueOnce(JSON.stringify(summary)); // readSummaryFile(matched.commitHash)
+
+			// "abcdef12" matches only ENTRY_ONE (ENTRY_THREE starts with "fedcba")
+			const result = await getSummary("abcdef12");
+			expect(result?.commitHash).toBe(ENTRY_ONE);
+			// The behavioral assertion: prefix scan resolves without invoking
+			// the git tree-hash subprocess. Read counts are intentionally NOT
+			// asserted — they're an implementation detail (caching / batching
+			// could change them) and the no-git-call check is the contract.
+			expect(vi.mocked(getTreeHash)).not.toHaveBeenCalled();
+		});
+
+		it("throws AmbiguousHashError when an abbreviated hash matches multiple entries", async () => {
+			const index = v3Index([rootEntry(ENTRY_ONE), rootEntry(ENTRY_TWO), rootEntry(ENTRY_THREE)]);
+
+			vi.mocked(readFileFromBranch)
+				.mockResolvedValueOnce(null) // Step 1 miss
+				.mockResolvedValueOnce(JSON.stringify(index)); // loadIndex
+
+			// "abcdef" matches both ENTRY_ONE and ENTRY_TWO
+			let caught: unknown;
+			try {
+				await getSummary("abcdef");
+			} catch (error: unknown) {
+				caught = error;
+			}
+			expect(caught).toBeInstanceOf(AmbiguousHashError);
+			expect((caught as AmbiguousHashError).prefix).toBe("abcdef");
+			// Order of matches is incidental (could change to e.g. sort by date
+			// for deterministic display) — only the SET of colliding hashes is
+			// part of the contract.
+			expect([...(caught as AmbiguousHashError).matches].sort()).toEqual([ENTRY_ONE, ENTRY_TWO].sort());
+			expect((caught as AmbiguousHashError).matches).toHaveLength(2);
+			expect((caught as AmbiguousHashError).message).toContain("abbreviation `abcdef` is ambiguous");
+		});
+
+		it("falls through to tree-hash fallback when an abbreviated hash has no prefix match in the index", async () => {
+			// The hash isn't in the index by name, but git might still resolve it.
+			// We can't exercise the tree-hash hit branch here (it's marked
+			// `v8 ignore`), but we verify that we ATTEMPT the cross-tree fallback
+			// — getTreeHash should be called.
+			const index = v3Index([rootEntry(ENTRY_ONE)]);
+			vi.mocked(readFileFromBranch)
+				.mockResolvedValueOnce(null) // Step 1 miss
+				.mockResolvedValueOnce(JSON.stringify(index)); // loadIndex
+			vi.mocked(getTreeHash).mockResolvedValueOnce(null); // no tree resolved → null result
+
+			// "deadbeef" has 0 prefix matches (ENTRY_ONE starts with "abcdef…")
+			const result = await getSummary("deadbeef");
+			expect(result).toBeNull();
+			expect(vi.mocked(getTreeHash)).toHaveBeenCalledWith("deadbeef", undefined);
+		});
+
+		it("treats very short prefixes the same as longer ones — multiple matches still throw", async () => {
+			// Validates that we don't need a hard minimum-length check at the
+			// resolver level: an extremely short input simply hits more entries
+			// and surfaces the same AmbiguousHashError, which carries the user-
+			// actionable signal.
+			const index = v3Index([rootEntry(ENTRY_ONE), rootEntry(ENTRY_TWO)]);
+			vi.mocked(readFileFromBranch)
+				.mockResolvedValueOnce(null) // Step 1 miss
+				.mockResolvedValueOnce(JSON.stringify(index)); // loadIndex
+
+			await expect(getSummary("a")).rejects.toThrow(AmbiguousHashError);
+		});
+
+		it("lowercases the user input before resolving (UPPERCASE prefix still hits)", async () => {
+			// Index `commitHash` values are stored lowercase. Without normalizing
+			// at the resolver boundary, `--commit ABCDEF12` would scan against
+			// lowercase entries and miss every step except the v3 tree-hash
+			// fallback. We lowercase up front so all callers (CLI, sidebar, URI
+			// handler) see consistent behavior.
+			const summary = createMockSummary(ENTRY_ONE);
+			const index = v3Index([rootEntry(ENTRY_ONE)]);
+			vi.mocked(readFileFromBranch)
+				.mockResolvedValueOnce(null) // Step 1 miss (lowercase already)
+				.mockResolvedValueOnce(JSON.stringify(index))
+				.mockResolvedValueOnce(JSON.stringify(summary));
+
+			const result = await getSummary("ABCDEF12"); // uppercase prefix
+			expect(result?.commitHash).toBe(ENTRY_ONE);
+		});
+
+		it("returns null on an empty index (no entries to scan)", async () => {
+			// Sanity edge case: prefix scan over zero entries returns 0 matches
+			// and falls through to Step 4 cleanly.
+			const index = v3Index([]);
+			vi.mocked(readFileFromBranch)
+				.mockResolvedValueOnce(null) // Step 1 miss
+				.mockResolvedValueOnce(JSON.stringify(index)); // loadIndex (empty)
+			vi.mocked(getTreeHash).mockResolvedValueOnce(null);
+
+			const result = await getSummary("abcdef12");
+			expect(result).toBeNull();
+		});
+
+		it("works against a v1 index — prefix scan matches entries regardless of index version", async () => {
+			// v1 indexes have entries with `parentCommitHash: undefined` (vs v3's
+			// explicit null). The prefix-scan loop iterates `index.entries`
+			// without referencing parentCommitHash, so it should resolve cleanly
+			// — and Step 4 (cross-tree) is gated to v3 only, so v1 input that
+			// misses prefix scan ends up null with no git call.
+			const summary = createMockSummary(ENTRY_ONE);
+			const v1Entry: SummaryIndexEntry = {
+				commitHash: ENTRY_ONE,
+				parentCommitHash: undefined, // v1 marker
+				commitMessage: "v1 commit",
+				commitDate: "2026-02-19T10:00:00Z",
+				branch: "main",
+				generatedAt: "2026-02-19T10:00:05Z",
+			};
+			const v1Index: SummaryIndex = { version: 1, entries: [v1Entry] };
+			vi.mocked(readFileFromBranch)
+				.mockResolvedValueOnce(null) // Step 1 miss
+				.mockResolvedValueOnce(JSON.stringify(v1Index)) // loadIndex
+				.mockResolvedValueOnce(JSON.stringify(summary)); // readSummaryFile(matched)
+
+			const result = await getSummary("abcdef12");
+			expect(result?.commitHash).toBe(ENTRY_ONE);
+			// Step 4 was gated to v3 — v1 with 0 prefix matches must NOT call git.
+			expect(vi.mocked(getTreeHash)).not.toHaveBeenCalled();
+		});
+
+		it("v1 index with a non-matching prefix returns null and skips Step 4", async () => {
+			// Verifies the Step-4-gated-to-v3 behavior on the miss path.
+			const v1Entry: SummaryIndexEntry = {
+				commitHash: ENTRY_ONE,
+				parentCommitHash: undefined,
+				commitMessage: "v1",
+				commitDate: "2026-02-19T10:00:00Z",
+				branch: "main",
+				generatedAt: "2026-02-19T10:00:05Z",
+			};
+			const v1Index: SummaryIndex = { version: 1, entries: [v1Entry] };
+			vi.mocked(readFileFromBranch).mockResolvedValueOnce(null).mockResolvedValueOnce(JSON.stringify(v1Index));
+
+			const result = await getSummary("deadbeef"); // no prefix match
+			expect(result).toBeNull();
+			expect(vi.mocked(getTreeHash)).not.toHaveBeenCalled();
+		});
+	});
+
+	describe("getSummary (full-SHA Step 4 fallthrough)", () => {
+		// Locks in the four-step contract for full SHA inputs that miss
+		// Steps 1+2 — i.e. direct file read fails AND alias map has no entry.
+		// Without this we only test Step 4 fallthrough on the abbreviated branch.
+
+		it("returns null when 40-char input misses direct file, alias map, AND tree-hash", async () => {
+			const fullHash = "ffffffffffffffffffffffffffffffffffffffff";
+			const otherEntry = "0000000000000000000000000000000000000001";
+			const index = v3Index([rootEntry(otherEntry)]); // no alias for fullHash, no matching tree
+			vi.mocked(readFileFromBranch)
+				.mockResolvedValueOnce(null) // Step 1 miss
+				.mockResolvedValueOnce(JSON.stringify(index)); // loadIndex
+			// getTreeHash mock: we let it resolve to null to confirm Step 4 was
+			// invoked but produced no match.
+			vi.mocked(getTreeHash).mockResolvedValueOnce(null);
+
+			const result = await getSummary(fullHash);
+			expect(result).toBeNull();
+			expect(vi.mocked(getTreeHash)).toHaveBeenCalledWith(fullHash, undefined);
+		});
+
+		it("hits commitAliases via lowercase normalization when the input is UPPERCASE 40-char", async () => {
+			// Catches the case the reviewer flagged: alias map keys are
+			// lowercase in production, so an UPPERCASE 40-char input must
+			// lowercase before lookup or the alias path silently misses.
+			const oldHashLower = "abcdef1234567890abcdef1234567890abcdef12";
+			const oldHashUpper = oldHashLower.toUpperCase();
+			const newHash = "1111111111111111111111111111111111111111";
+			const summary = createMockSummary(newHash);
+			const index = v3Index([rootEntry(newHash)], { [oldHashLower]: newHash });
+
+			vi.mocked(readFileFromBranch)
+				.mockResolvedValueOnce(null) // Step 1: readSummaryFile(lowercase) miss
+				.mockResolvedValueOnce(JSON.stringify(index)) // loadIndex
+				.mockResolvedValueOnce(JSON.stringify(summary)); // readSummaryFile(aliasHash)
+
+			const result = await getSummary(oldHashUpper);
+			expect(result?.commitHash).toBe(newHash);
 		});
 	});
 

--- a/cli/src/core/SummaryStore.test.ts
+++ b/cli/src/core/SummaryStore.test.ts
@@ -562,6 +562,41 @@ describe("SummaryStore", () => {
 			const result = await getSummary(oldHashUpper);
 			expect(result?.commitHash).toBe(newHash);
 		});
+
+		it("returns null on empty-string input without scanning the index", async () => {
+			// Without the empty-string guard, "" would fall through to prefix
+			// scan where `e.commitHash.startsWith("")` matches every entry,
+			// and `getSummary` would throw `AmbiguousHashError("", [all])`.
+			// Guard at the top short-circuits cleanly to null with no I/O.
+			const result = await getSummary("");
+			expect(result).toBeNull();
+			expect(vi.mocked(readFileFromBranch)).not.toHaveBeenCalled();
+		});
+
+		it("does NOT resolve an abbreviated hash that only matches a key in commitAliases", async () => {
+			// Contract: the alias map is consulted only on the FULL-SHA branch.
+			// An abbreviated input that happens to be a prefix of an alias key
+			// (but not of any entry's commitHash) must NOT resolve via the
+			// alias path — that path is for amend / rebase rewrites where the
+			// caller knows the exact 40-char old SHA. Resolving short prefixes
+			// against alias keys would be a surprising back-door.
+			const onlyAliasEntry = "ffffffffffffffffffffffffffffffffffffffff";
+			const aliasOldHash = "abcdef1234567890abcdef1234567890abcdef12"; // 40-char alias key
+			const index = v3Index(
+				// Entry's commitHash starts with "ff…", so the prefix scan
+				// will MISS for an "abcd…" prefix even though the alias map
+				// has "abcd…" as a key.
+				[rootEntry(onlyAliasEntry)],
+				{ [aliasOldHash]: onlyAliasEntry },
+			);
+			vi.mocked(readFileFromBranch)
+				.mockResolvedValueOnce(null) // Step 1: readSummaryFile("abcdef12") miss
+				.mockResolvedValueOnce(JSON.stringify(index)); // loadIndex
+			vi.mocked(getTreeHash).mockResolvedValueOnce(null); // Step 4 also misses
+
+			const result = await getSummary("abcdef12");
+			expect(result).toBeNull();
+		});
 	});
 
 	describe("listSummaries", () => {

--- a/cli/src/core/SummaryStore.ts
+++ b/cli/src/core/SummaryStore.ts
@@ -816,14 +816,56 @@ const FULL_HASH_LENGTH = 40;
  */
 export class AmbiguousHashError extends Error {
 	readonly prefix: string;
+	/**
+	 * Full 40-char SHAs of every entry that matched the abbreviated prefix.
+	 * Carries the full list (not just a count) so user-facing callers can
+	 * render the colliding hashes for disambiguation — `jolli view` /
+	 * `jolli export` print them via {@link printAmbiguousHash} so the user
+	 * can copy-paste a longer prefix.
+	 */
 	readonly matches: ReadonlyArray<string>;
 	constructor(prefix: string, matches: ReadonlyArray<string>) {
+		// Invariant guards — these should be unreachable from production
+		// callers (`getSummary` only constructs this when ≥2 prefix matches
+		// were found, and the prefix it passed was a non-empty user input).
+		// Defensive throw makes the bug surface at the construction site
+		// rather than as confusing downstream behavior.
+		if (matches.length < 2) {
+			throw new Error(
+				`AmbiguousHashError requires ≥2 matches (got ${matches.length}); use null/undefined for "not found"`,
+			);
+		}
+		if (prefix.length === 0 || prefix.length >= FULL_HASH_LENGTH) {
+			throw new Error(
+				`AmbiguousHashError prefix must be 1..${FULL_HASH_LENGTH - 1} chars (got length ${prefix.length})`,
+			);
+		}
 		super(
 			`abbreviation \`${prefix}\` is ambiguous; please use a longer prefix (matched ${matches.length} commits)`,
 		);
 		this.name = "AmbiguousHashError";
 		this.prefix = prefix;
 		this.matches = matches;
+	}
+
+	/**
+	 * Duck-typed type guard that survives cross-bundle scenarios.
+	 *
+	 * `instanceof` only works when both sides reference the same class
+	 * identity. esbuild inlines `cli/src/**` into the VS Code extension
+	 * bundle today, so identity is preserved — but if a future caller
+	 * crosses an IPC boundary (worker, child process, serialized error
+	 * payload), the prototype chain breaks while name + fields survive.
+	 * Catch sites should prefer this over `instanceof` for forward-
+	 * compatibility.
+	 */
+	static is(error: unknown): error is AmbiguousHashError {
+		return (
+			error instanceof Error &&
+			error.name === "AmbiguousHashError" &&
+			typeof (error as { prefix?: unknown }).prefix === "string" &&
+			Array.isArray((error as { matches?: unknown }).matches)
+		);
 	}
 }
 
@@ -881,6 +923,13 @@ export async function getSummary(
 	cwd?: string,
 	storage?: StorageProvider,
 ): Promise<CommitSummary | null> {
+	// Empty input is meaningless — return null rather than letting it fall
+	// to the prefix scan, where `"".startsWith()` would match every entry
+	// and surface as `AmbiguousHashError("", [all-of-index])`. Callers like
+	// `JolliMemoryBridge.getSummary` don't pre-validate length, so the
+	// guard belongs here.
+	if (commitHash.length === 0) return null;
+
 	// Normalize to lowercase up front. Index entries / file names / alias
 	// keys are all written lowercase, so without this a user typing
 	// `--commit ABC123…` would miss every step except Step 4's git-mediated
@@ -1357,6 +1406,14 @@ async function loadIndex(cwd?: string, storage?: StorageProvider): Promise<Summa
 	const store = resolveStorage(storage, cwd);
 	const content = await store.readFile(INDEX_FILE);
 	if (!content) {
+		// Surface as warn: in a healthy installation the index always exists
+		// once any summary has been generated. A null read here means either
+		// (a) fresh repo / no summaries yet, or (b) git failed to read from
+		// the orphan branch — `store.readFile` swallows the underlying git
+		// error and returns null, so production needs the warn to notice (b).
+		// Callers (`getSummary`, `listSummaries`, …) treat this as "nothing
+		// to return" rather than throwing, so the warn is the only signal.
+		log.warn("loadIndex: index.json unreadable from orphan branch (fresh repo or git read failed)");
 		return null;
 	}
 

--- a/cli/src/core/SummaryStore.ts
+++ b/cli/src/core/SummaryStore.ts
@@ -802,24 +802,77 @@ export async function getTranscriptHashes(cwd?: string): Promise<Set<string>> {
 // ─── Public read API ──────────────────────────────────────────────────────────
 
 /**
+ * Length of a full SHA-1 git commit hash. Anything shorter is treated as an
+ * abbreviated prefix and resolved via index scan rather than direct file /
+ * alias lookup, since both of those keys are 40-char in production.
+ */
+const FULL_HASH_LENGTH = 40;
+
+/**
+ * Thrown by {@link getSummary} when an abbreviated hash matches multiple
+ * entries in the index. Surfacing this (rather than silently picking one)
+ * lets user-facing callers prompt for a longer prefix; internal callers that
+ * always supply 40-char SHAs (e.g. iterating index entries) never trigger it.
+ */
+export class AmbiguousHashError extends Error {
+	readonly prefix: string;
+	readonly matches: ReadonlyArray<string>;
+	constructor(prefix: string, matches: ReadonlyArray<string>) {
+		super(
+			`abbreviation \`${prefix}\` is ambiguous; please use a longer prefix (matched ${matches.length} commits)`,
+		);
+		this.name = "AmbiguousHashError";
+		this.prefix = prefix;
+		this.matches = matches;
+	}
+}
+
+/**
+ * Returns all index entries whose commitHash starts with the given prefix.
+ *
+ * Used by {@link getSummary} to resolve abbreviated hashes (jolli's catalog
+ * emits 8-char prefixes) without invoking git — purely in-memory, so it is
+ * unaffected by working-tree state (rebase / squash dropping the commit
+ * doesn't lose the index record) and by tree-hash collisions (cherry-pick
+ * twins that share a tree but live as distinct entries).
+ */
+function findEntriesByPrefix(
+	prefix: string,
+	entries: ReadonlyArray<SummaryIndexEntry>,
+): ReadonlyArray<SummaryIndexEntry> {
+	return entries.filter((e) => e.commitHash.startsWith(prefix));
+}
+
+/**
  * Retrieves a summary for a specific commit hash.
  *
- * Lookup order:
- * 1. **Direct file read** (`summaries/{commitHash}.json`). Works for any hash
- *    that was ever a root at write time. This is the primary path -- it
- *    bypasses the index entirely and returns the commit's ORIGINAL summary
- *    rather than the (potentially stripped) version embedded in a squash root.
- *    Storage invariant: `mergeManyToOne` / `migrateOneToOne` never delete the
- *    old `summaries/{oldHash}.json` files, so every hash that entered the
- *    system keeps its own file.
- * 2. **Alias / treeHash fallback**: when direct read misses, check the index
- *    for cross-branch aliases (cached + on-the-fly tree-hash matching). Used
- *    when the caller passes a hash that isn't a recorded root, e.g. a commit
- *    on a different branch that shares a tree hash with a recorded one.
+ * Lookup steps:
+ *   1. Direct file read — `summaries/{hash}.json`. Hits for any hash that ever
+ *      owned a summary file (production: 40-char SHAs only); a deterministic
+ *      cheap miss otherwise. Returns the commit's ORIGINAL summary even after
+ *      a squash/rebase has folded it into a container, since `mergeManyToOne` /
+ *      `migrateOneToOne` keep the old files. (Bypassing the embedded child view
+ *      is intentional: under the unified Hoist strip, embedded children no
+ *      longer carry topics/recap.)
  *
- * Direct file read intentionally bypasses the embedded child view: under the
- * unified Hoist strip, embedded children no longer carry topics/recap, so
- * returning them would silently degrade results.
+ *   then, branched by input length:
+ *
+ *   if hash.length === 40 (full SHA):
+ *     2. Alias map lookup — `index.commitAliases[hash]` for amend/rebase
+ *        chains where an old SHA was rewritten to a new one. Keys are
+ *        always 40-char in production.
+ *
+ *   if hash.length < 40 (abbreviated, e.g. catalog's 8-char output):
+ *     3. Index prefix scan — entries whose `commitHash` starts with the input.
+ *        - 1 match → return that summary
+ *        - ≥ 2 matches → throw {@link AmbiguousHashError}
+ *        - 0 matches → fall through to Step 4
+ *
+ *   finally, if nothing above hit:
+ *     4. Cross-tree fallback — `git rev-parse hash^{tree}` then match by
+ *        tree hash to an indexed entry. Catches cherry-pick / rebase copies
+ *        that share a tree with an indexed commit but aren't themselves in
+ *        the index. This is the only step that requires a live git repo.
  *
  * Returns null if no summary exists for that commit.
  */
@@ -828,21 +881,59 @@ export async function getSummary(
 	cwd?: string,
 	storage?: StorageProvider,
 ): Promise<CommitSummary | null> {
-	// Step 1: Direct file read -- works for any hash that was ever indexed.
-	const direct = await readSummaryFile(commitHash, cwd, storage);
+	// Normalize to lowercase up front. Index entries / file names / alias
+	// keys are all written lowercase, so without this a user typing
+	// `--commit ABC123…` would miss every step except Step 4's git-mediated
+	// fallback (which `git rev-parse` would mask by normalizing). Doing it
+	// here protects every caller (CLI, sidebar, URI handler) uniformly.
+	const hash = commitHash.toLowerCase();
+
+	// Step 1: Direct file read. Tried for all inputs; storage is the only
+	// O(1) lookup that can hit on a full SHA, and a deterministic miss for
+	// shorter inputs in production.
+	const direct = await readSummaryFile(hash, cwd, storage);
 	if (direct) return direct;
 
-	// Step 2: Cross-branch fallback via aliases / tree hash.
 	const index = await loadIndex(cwd, storage);
 	if (!index) return null;
 
-	const aliasHash = index.commitAliases?.[commitHash];
-	if (aliasHash) {
-		return readSummaryFile(aliasHash, cwd, storage);
+	const isFullHash = hash.length === FULL_HASH_LENGTH;
+
+	if (isFullHash) {
+		// Step 2: Alias lookup — `commitAliases` is keyed by 40-char OLD SHA.
+		// Note: this branch only runs for full SHAs. Abbreviated input that
+		// would only resolve via an alias entry (e.g. an old SHA that's been
+		// GC'd from the working repo) won't hit here — pass the full 40-char
+		// SHA to reach aliased rewrites reliably. The realistic blast radius
+		// is small: `scanTreeHashAliases` only writes aliases for hashes git
+		// has already resolved at scan time, so they're already 40-char in
+		// practice, and abbreviated input is overwhelmingly catalog output
+		// (which targets live, indexed entries — not aliased rewrites).
+		const aliasHash = index.commitAliases?.[hash];
+		if (aliasHash) {
+			return readSummaryFile(aliasHash, cwd, storage);
+		}
+	} else {
+		// Step 3: Index prefix scan for abbreviated input. Deterministic, in
+		// memory, and immune to tree-hash collisions — we match on the index's
+		// own `commitHash` field, not on tree hashes.
+		const matches = findEntriesByPrefix(hash, index.entries);
+		if (matches.length === 1) {
+			return readSummaryFile(matches[0].commitHash, cwd, storage);
+		}
+		if (matches.length >= 2) {
+			throw new AmbiguousHashError(
+				hash,
+				matches.map((m) => m.commitHash),
+			);
+		}
+		// matches.length === 0 → fall through to Step 4.
 	}
 
+	// Step 4: Cross-tree fallback. Requires a live git repo to resolve the
+	// hash to a tree, then we look for any indexed entry sharing that tree.
 	if (index.version === 3) {
-		const treeHash = await getTreeHash(commitHash, cwd);
+		const treeHash = await getTreeHash(hash, cwd);
 		/* v8 ignore start -- tree hash fallback: requires real git repo */
 		if (treeHash) {
 			const entryMap = new Map(index.entries.map((e) => [e.commitHash, e]));

--- a/vscode/src/JolliMemoryBridge.ts
+++ b/vscode/src/JolliMemoryBridge.ts
@@ -1348,7 +1348,16 @@ export class JolliMemoryBridge {
 		this.cachedRootEntries = null;
 	}
 
-	/** Returns the full summary for a single commit hash, or null if not found. */
+	/**
+	 * Returns the full summary for a single commit hash, or null if not found.
+	 *
+	 * **May throw `AmbiguousHashError`** if `hash` is an abbreviated SHA that
+	 * matches multiple index entries. All current callers pass full 40-char
+	 * SHAs (sidebar items, URI-handler regex `[0-9a-f]{40}`), so the throw is
+	 * structurally unreachable today — but if a future caller wires user-
+	 * typed abbreviations through here (e.g. a "go to commit" quick-pick),
+	 * wrap this in try/catch and surface a "use a longer prefix" hint.
+	 */
 	async getSummary(hash: string): Promise<CommitSummary | null> {
 		const storage = await this.getStorage();
 		return getSummary(hash, this.cwd, storage);


### PR DESCRIPTION


<!-- jollimemory-summary-start -->

## Quick recap

Abbreviated commit hashes can now be passed anywhere the tool accepts a commit reference. Previously, the tool required full 40-character hashes everywhere, and the older resolution strategy could silently return the wrong commit's summary when two commits shared an identical file tree — a failure invisible to both users and the language model. The lookup now works entirely in memory by scanning the stored index for entries matching the given prefix. A unique match loads the summary normally; when a prefix matches several commits, the tool surfaces a clear message listing up to ten colliding hashes and asks for a longer prefix, with a count of any additional matches beyond ten.

The same graceful handling was extended to every command that accepts a commit reference. The export command, which previously crashed with an unhandled error on an ambiguous abbreviation, now prints a disambiguation hint and exits cleanly. Multi-hash search requests became more resilient as well: a single ambiguous hash in a batch no longer aborts the entire request — the ambiguous entry is recorded as failed and the rest of the batch completes, giving callers a useful partial result.

Input validation was also relaxed to match what the catalog naturally produces. The CLI now accepts hashes as short as eight characters — the length of the short hash field the catalog emits — so users and the AI assistant can pass either form without needing to know which field to use. Inputs below eight characters are still rejected, as extremely short prefixes are almost always ambiguous.

---

## E2E Test (3)
<details>
<summary><strong>1. Abbreviated commit hash — ambiguous match shows &quot;use a longer prefix&quot; message</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a Jolli project with at least two commits whose hashes share the same first several characters (or use any project and supply a very short prefix like 3–5 characters that is likely to collide).

**Steps:**
1. Open a terminal and navigate to your Jolli project folder.
2. Run the "view" command with a short commit abbreviation that matches more than one commit — for example, type `jolli view --commit abc` and press Enter.
3. Check the output printed in the terminal.
4. Run the same short abbreviation using the "export" command — for example, type `jolli export --commit abc` and press Enter.
5. Check the output and note the exit status (the terminal prompt should indicate a non-zero / error exit).

**Expected Results:**
- jolli view --commit f
- abbreviation `f` is ambiguous; please use a longer prefix.
- Matched 6 commits:
- f456bc4e9025c29f4d1b317e090dc399fb5b9b2b
- f27bb66ad9f111b065763b384ab4b9317177f239
- fb8d438775a7708aed05a3c7bcb65241ed7d2a40
- fd6d0bf8a84c562165bf86721c2f14c56e506bbe
- f950ace2fa57e183c47be6ac6f39ed4fede55df8
- f11264b0195fc62c0c4d7a27dc98ffc5a6ae090e

</blockquote>
</details>
<details>
<summary><strong>2. Abbreviated commit hash — unique match resolves successfully</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a Jolli project with at least one stored commit summary. Note the first 8 or more characters of a commit hash from the catalog output (the short "hash" field shown in search results).

**Steps:**
1. Open a terminal and navigate to your Jolli project folder.
2. Run a search to get the catalog and note a short hash value shown in the results (the 8-character "hash" field).
3. Run `jolli view --commit <short-hash>` using that 8-character value and press Enter.
4. Check the output in the terminal.

**Expected Results:**
- The command should successfully display the commit summary for that commit — the same content you would see when using the full 40-character hash.
- No error or "ambiguous" message should appear.
- The terminal should exit cleanly with no error code.

</blockquote>
</details>
<details>
<summary><strong>3. Search command accepts 8-character abbreviated hashes in --hashes flag</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a Jolli project with at least one stored commit summary. Note an 8-character short hash from the catalog (the "hash" field in search results).

**Steps:**
1. Open a terminal and navigate to your Jolli project folder.
2. Run a search using the `--hashes` flag with an 8-character hash — for example: `jolli search "your query" --hashes abcd1234` and press Enter.
3. Check the output for results or error messages.
4. Now try passing a hash that is only 3 characters long — for example: `jolli search "your query" --hashes abc` — and press Enter.
5. Check the output for an error message.

**Expected Results:**
- In step 3, the command should accept the 8-character hash and return search results (or a "no summary found" message if that hash has no stored summary) — it should NOT show a validation error about hash length.
- In step 5, the command should show a validation error message stating that hashes must be between 8 and 40 characters. It should NOT mention "fullHash" or "40-character" as the only valid format.

</blockquote>
</details>

---

## Topics (4)
<details>
<summary><strong>01 · Abbreviated commit hashes now resolve safely via in-memory index scan</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The tool required full 40-character commit hashes everywhere, and the older resolution strategy could silently return the wrong commit's summary when two commits shared an identical file tree. Users wanted to pass shorter hashes — as the catalog naturally emits — without risking silent mis-resolution.

**💡 Decisions Behind the Code**

- **In-memory prefix scan over git subprocess**: Resolving abbreviations by scanning the already-loaded index avoids spawning a git process and is unaffected by working-tree state such as rebases or squashes. The previous tree-hash fallback was kept only as a last resort for hashes that appear nowhere in the index, preserving backward compatibility for cross-branch alias scenarios.
- **Throw on ambiguity rather than silently pick or return null**: When a short prefix matches multiple index entries, the design throws a named error carrying the full list of colliding hashes. Returning null would give a misleading "not found" signal for what is actually an "input too vague" situation, and silently picking the first match would reproduce the original data-integrity bug where a cherry-picked commit's summary is returned for the wrong hash.
- **Normalize at the entry point, not at each call site**: Lowercasing once at the boundary of the lookup function protects every caller — CLI flags, sidebar, URI handler — without requiring each to remember to normalize. Applying the fix at individual call sites would be fragile and easy to miss in future callers.
- **Partial-batch failure in search rather than full abort**: When one hash in a multi-hash search request is ambiguous, aborting the whole request forces the caller to retry everything. Recording just the ambiguous entry as failed lets the caller receive a useful partial result and retry only the problematic hash with a longer prefix.
- **Catch only the specific ambiguous-hash error type, re-throw everything else**: A broad catch in the export and view commands would mask unrelated failures such as disk errors or storage corruption. Catching only the known error type keeps the safety net narrow and intentional, and setting the exit code rather than calling process.exit directly lets the command finish its cleanup path normally and remain testable.

**✅ What Was Implemented**

- `SummaryStore.ts` gained a new `AmbiguousHashError` class and a `findEntriesByPrefix` helper. When `getSummary` receives a hash shorter than 40 characters and the direct file read misses, it scans the in-memory index for entries whose commit hash starts with the given prefix. A unique match proceeds to load the summary file; multiple matches throw `AmbiguousHashError` carrying the prefix and all colliding full hashes; zero matches fall through to the existing tree-hash subprocess fallback.
- `getSummary` also normalizes the incoming hash to lowercase at the very top of the function body, before any lookup step runs, so uppercase or mixed-case input from any caller is handled uniformly across all four resolution steps.
- `LocalSearchProvider.ts` wraps its `getSummary` call in a try/catch that intercepts `AmbiguousHashError`, logs it, records the ambiguous input in `failedHashes`, and continues processing the remaining hashes in the batch — so one ambiguous entry no longer aborts the entire search request.
- `ViewCommand.ts` and `ExportCommand.ts` each catch `AmbiguousHashError`, print a git-style "use a longer prefix" message via a shared `printAmbiguousHash` helper in `CliUtils.ts`, set a non-zero exit code, and return cleanly rather than letting the error propagate as an unhandled exception. The helper caps display at ten matching hashes and appends an "… and N more" tail when the list exceeds ten.
- `SearchCommand.ts` changed its hash-list validation pattern to accept 8–40 hex characters (previously requiring exactly 40), matching the minimum length the catalog emits. The error message was updated accordingly.

**📋 Future Enhancements**

- File a follow-up issue for the IntelliJ plugin owner to mirror the new abbreviated hash resolution design (index prefix scan replacing the git subprocess path).

**📁 FILES**
- `cli/src/core/SummaryStore.ts`
- `cli/src/core/LocalSearchProvider.ts`
- `cli/src/commands/ViewCommand.ts`
- `cli/src/commands/ExportCommand.ts`
- `cli/src/commands/SearchCommand.ts`

</blockquote>
</details>
<details>
<summary><strong>02 · Test suite hardened for ambiguous-hash paths, edge cases, and realistic fixtures</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The new resolution logic introduced branching paths — unique match, ambiguous match, no match, non-ambiguous error propagation — that had no test coverage, and existing tests used unrealistically short placeholder hashes that did not exercise the correct code paths.

**💡 Decisions Behind the Code**

- **Re-export the real error class from mocks rather than defining a stub**: A stub class would be a different object identity and the `instanceof` guard in production code would silently fall through to the re-throw branch, making the catch block untestable. Re-exporting the real class via `vi.importActual` ensures the check works correctly across the module boundary that the mock system creates.
- **Drop the read-count assertion**: Asserting on the number of internal file reads ties tests to implementation details like caching or batching strategies that could change without affecting observable behavior. The meaningful contract — that the git subprocess is never called when a prefix scan resolves the result — is preserved as the sole behavioral assertion.
- **Compare sorted arrays for collision sets**: The order in which colliding hashes are returned is an incidental implementation detail; only the set of colliding hashes is part of the contract. Sorting before comparison makes the test resilient to future changes such as ordering matches by date for display purposes.

**✅ What Was Implemented**

- `SummaryStore.test.ts` gained a dedicated describe block covering: unique prefix resolution, `AmbiguousHashError` on collision, fallthrough to the tree-hash subprocess when no prefix matches, ambiguity on very short prefixes, full-SHA Step 4 fallthrough (returning null when all lookup steps miss), uppercase 40-char hash normalization before alias lookup, version-1 index prefix resolution (where `parentCommitHash` is undefined), and an empty-index edge case. Five existing tests were updated to use 40-character fixture hashes matching production reality.
- `LocalSearchProvider.test.ts` and `ViewCommand.test.ts` updated their mock calls to re-export the real `AmbiguousHashError` class via `vi.importActual` so that `instanceof` checks inside production code work correctly against errors thrown by the mocked function. New tests cover the ambiguous-batch-skip path, the non-ambiguous error re-throw path in the search provider, and the ambiguous-hash display path in the view command.
- `CliUtils.test.ts` covers the under-cap path (all hashes shown, no tail) and the over-cap path (first ten shown, correct remainder count in the tail). The read-count assertion that previously tied tests to internal caching details was removed; the ambiguous-hash collision test was changed to compare sorted arrays rather than asserting a specific order.

**📁 FILES**
- `cli/src/core/SummaryStore.test.ts`
- `cli/src/core/LocalSearchProvider.test.ts`
- `cli/src/commands/ViewCommand.test.ts`
- `cli/src/commands/CliUtils.test.ts`

</blockquote>
</details>
<details>
<summary><strong>03 · VS Code bridge documents ambiguous-hash error contract for future callers</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

A code reviewer flagged that the method responsible for fetching a commit's full summary could throw an error under certain conditions, but this was not documented anywhere, leaving future contributors unaware of the risk if they wired in new call sites.

**💡 Decisions Behind the Code**

The decision was made to document the error contract in the existing comment rather than adding a runtime guard or changing the method signature. All current callers are already safe by construction, so adding defensive code would be dead weight today; the comment instead acts as a forward-looking contract notice targeting the one realistic future scenario — a "go to commit" quick-pick — and tells that future developer exactly what to do without over-engineering the present code.

**✅ What Was Implemented**

Updated the JSDoc comment on `getSummary` in `vscode/src/JolliMemoryBridge.ts` to explicitly flag that the method may throw an `AmbiguousHashError` when a shortened commit identifier matches more than one index entry. The comment explains that all current callers pass full 40-character hashes (sidebar items and the URI-handler route), making the throw unreachable today, and advises future callers that accept user-typed short identifiers to wrap the call in a try/catch and surface a "use a longer prefix" hint.

**📋 Future Enhancements**

- A tracker issue for the IntelliJ equivalent of this bridge, where the same ambiguous-hash scenario may apply, was explicitly deferred and remains outstanding.

**📁 FILES**
- `vscode/src/JolliMemoryBridge.ts`

</blockquote>
</details>
<details>
<summary><strong>04 · Coverage threshold and planning document removed from shipped commit</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

After squashing several commits into one, two files were found to have been included that did not belong in the final deliverable: an internal planning document and a coverage threshold change that had been bumped during development.

**💡 Decisions Behind the Code**

- **Amend over reset-and-recommit**: Using `git commit --amend` was the only safe path for preserving the existing summary. A soft reset followed by a new commit would not fire the post-rewrite hook, leaving the old summary as an orphan and potentially triggering a redundant AI generation pass; amend is the canonical operation the queue worker is built to respond to.
- **Revert threshold file rather than delete it**: The coverage thresholds file needed to stay in the repository at its previous values, not disappear. Reverting to the main-branch version via checkout staged the file as a tracked modification back to baseline rather than removing it from the tree.

**✅ What Was Implemented**

- `cli/vite.config.ts` was reverted to its pre-refactor state, rolling the coverage thresholds for statements, functions, and lines back from 98 to 97 (branches threshold remained at 96), staged as a tracked modification via `git checkout main -- cli/vite.config.ts`.
- The planning document (`docs/PLAN - getSummary 重构 ...`) was removed entirely from the commit using `git rm`, deleting all 257 lines of architecture notes, decision tables, and rollout steps that had been added during the design phase.
- Both changes were folded into the existing commit using `git commit --amend --no-edit`, which triggered the post-rewrite hook so the queue worker migrated the existing summary to the new commit hash rather than generating a fresh one.

**📋 Future Enhancements**

- The removed items (threshold bump and plan document) were backed up to `/tmp` during the session. If either is wanted in a permanent branch, a follow-up commit on a separate branch was outlined but not executed.

**📁 FILES**
- `cli/vite.config.ts`

</blockquote>
</details>

---

*Generated by Jolli Memory · May 8, 2026 at 4:45 PM*
<!-- jollimemory-summary-end -->