### PR TITLE
Add inline Anthropic API key entry panel to sidebar onboarding

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8420,7 +8420,7 @@
 		},
 		"vscode": {
 			"name": "jollimemory-vscode",
-			"version": "0.98.21",
+			"version": "0.98.22",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@vscode/codicons": "^0.0.45",

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -2,7 +2,7 @@
 	"name": "jollimemory-vscode",
 	"displayName": "Jolli Memory",
 	"description": "VS Code sidebar for Jolli Memory — AI-powered commit summaries and smart git operations",
-	"version": "0.98.21",
+	"version": "0.98.22",
 	"publisher": "jolli",
 	"license": "Apache-2.0",
 	"icon": "assets/icon.png",

--- a/vscode/src/Extension.test.ts
+++ b/vscode/src/Extension.test.ts
@@ -24,18 +24,29 @@ const {
 	dispose: vi.fn(),
 }));
 
+const { mockNotifyApiKeySaveError } = vi.hoisted(() => ({
+	mockNotifyApiKeySaveError: vi.fn(),
+}));
+
 const { isWorkerBusy } = vi.hoisted(() => ({
 	isWorkerBusy: vi.fn(),
 }));
 
-const { loadConfig, getGlobalConfigDir, saveConfig, acquireLock, releaseLock } =
-	vi.hoisted(() => ({
-		loadConfig: vi.fn(),
-		getGlobalConfigDir: vi.fn(() => "/home/user/.jolli/jollimemory"),
-		saveConfig: vi.fn(),
-		acquireLock: vi.fn(),
-		releaseLock: vi.fn(),
-	}));
+const {
+	loadConfig,
+	getGlobalConfigDir,
+	saveConfig,
+	saveConfigScoped,
+	acquireLock,
+	releaseLock,
+} = vi.hoisted(() => ({
+	loadConfig: vi.fn(),
+	getGlobalConfigDir: vi.fn(() => "/home/user/.jolli/jollimemory"),
+	saveConfig: vi.fn(),
+	saveConfigScoped: vi.fn(),
+	acquireLock: vi.fn(),
+	releaseLock: vi.fn(),
+}));
 
 const {
 	cleanupV1IfExpired,
@@ -488,6 +499,7 @@ vi.mock("../../cli/src/core/SessionTracker.js", () => ({
 	loadConfig,
 	getGlobalConfigDir,
 	saveConfig,
+	saveConfigScoped,
 	acquireLock,
 	releaseLock,
 }));
@@ -761,6 +773,11 @@ vi.mock("./views/SidebarWebviewProvider.js", () => ({
 		refreshKnowledgeBaseFolders() {}
 		notifyEnabledChanged() {}
 		notifyAuthChanged() {}
+		notifyConfiguredChanged() {}
+		// Tracked via a shared vi.fn so saveAnthropicApiKey-error tests can
+		// assert the failure-path message routing without needing access to
+		// the constructed instance.
+		notifyApiKeySaveError = mockNotifyApiKeySaveError;
 	},
 }));
 
@@ -4054,6 +4071,97 @@ describe("Extension", () => {
 
 			expect(showWarningMessage).toHaveBeenCalled();
 			expect(mockAuthService.signOut).not.toHaveBeenCalled();
+		});
+	});
+
+	describe("saveAnthropicApiKey command", () => {
+		// Sidebar onboarding inline-input save path. The success branch is
+		// implicit: saveConfigScoped + statusStore.refresh make `configured`
+		// flip true, which triggers the existing configured:changed channel.
+		// We don't post an explicit success ack — only failures post
+		// apikey:saveError so the panel can re-enable Save and show inline.
+
+		it("registers the saveAnthropicApiKey command", () => {
+			activate(makeContext());
+			const handler = getRegisteredCommand("jollimemory.saveAnthropicApiKey");
+			expect(handler).toBeDefined();
+		});
+
+		it("saves only the apiKey field and refreshes statusStore on success", async () => {
+			activate(makeContext());
+			saveConfigScoped.mockResolvedValueOnce(undefined);
+			mockStatusStore.refresh.mockClear();
+
+			const handler = getRegisteredCommand("jollimemory.saveAnthropicApiKey");
+			await handler("sk-ant-test-key");
+
+			// The update is scoped to apiKey only — no hooks/integrations/etc.
+			// get rewritten. This is the contract that lets us bypass the
+			// full Settings webview without losing user-set fields elsewhere.
+			expect(saveConfigScoped).toHaveBeenCalledWith(
+				{ apiKey: "sk-ant-test-key" },
+				"/home/user/.jolli/jollimemory",
+			);
+			// statusStore.refresh re-derives `configured` from
+			// signedIn || hasApiKey, so it must run after save to flip the
+			// onboarding panel away. Without this the panel stays open.
+			expect(mockStatusStore.refresh).toHaveBeenCalled();
+			// Success path is implicit — no explicit error post.
+			expect(mockNotifyApiKeySaveError).not.toHaveBeenCalled();
+		});
+
+		it("trims surrounding whitespace before saving (paste-with-newline tolerance)", async () => {
+			activate(makeContext());
+			saveConfigScoped.mockResolvedValueOnce(undefined);
+
+			const handler = getRegisteredCommand("jollimemory.saveAnthropicApiKey");
+			await handler("  sk-ant-pasted  \n");
+
+			expect(saveConfigScoped).toHaveBeenCalledWith(
+				{ apiKey: "sk-ant-pasted" },
+				expect.any(String),
+			);
+		});
+
+		it("rejects empty input without touching disk and surfaces inline error", async () => {
+			activate(makeContext());
+			const handler = getRegisteredCommand("jollimemory.saveAnthropicApiKey");
+			await handler("   ");
+
+			// No write attempt — we don't want an empty-string apiKey on disk
+			// even transiently, since downstream code may treat empty-string
+			// differently from undefined.
+			expect(saveConfigScoped).not.toHaveBeenCalled();
+			expect(mockNotifyApiKeySaveError).toHaveBeenCalledWith(
+				"API key cannot be empty.",
+			);
+		});
+
+		it("rejects non-string input (defensive against malformed webview message) without saving", async () => {
+			activate(makeContext());
+			const handler = getRegisteredCommand("jollimemory.saveAnthropicApiKey");
+			await handler(42 as unknown);
+
+			expect(saveConfigScoped).not.toHaveBeenCalled();
+			expect(mockNotifyApiKeySaveError).toHaveBeenCalled();
+		});
+
+		it("posts apikey:saveError with the error message when saveConfigScoped throws", async () => {
+			activate(makeContext());
+			saveConfigScoped.mockRejectedValueOnce(new Error("EROFS: read-only fs"));
+
+			const handler = getRegisteredCommand("jollimemory.saveAnthropicApiKey");
+			await handler("sk-ant-real-key");
+
+			// We don't assert on mockStatusStore.refresh here because the
+			// activation path (initialLoad / hook-path refresh) calls it
+			// asynchronously and races with this test. The contract that
+			// matters — and that the user actually observes — is that the
+			// failure surfaces through notifyApiKeySaveError so the panel
+			// can re-enable Save and show the inline error.
+			expect(mockNotifyApiKeySaveError).toHaveBeenCalledWith(
+				"EROFS: read-only fs",
+			);
 		});
 	});
 

--- a/vscode/src/Extension.ts
+++ b/vscode/src/Extension.ts
@@ -17,8 +17,10 @@ import {
 } from "../../cli/src/core/KBPathResolver.js";
 import {
 	acquireLock,
+	getGlobalConfigDir,
 	loadConfig,
 	releaseLock,
+	saveConfigScoped,
 } from "../../cli/src/core/SessionTracker.js";
 import {
 	cleanupV1IfExpired,
@@ -239,6 +241,7 @@ const ALL_DECLARED_COMMANDS: ReadonlyArray<string> = [
 	"jollimemory.openInClaudeCode",
 	"jollimemory.signIn",
 	"jollimemory.signOut",
+	"jollimemory.saveAnthropicApiKey",
 ];
 
 /**
@@ -1994,6 +1997,36 @@ export function activate(context: vscode.ExtensionContext): void {
 				},
 			);
 		}),
+
+		// Inline onboarding API key save — wired from the sidebar's apikey-panel
+		// (the user clicks "Configure API Key" → types a key → Save). Touches
+		// only the apiKey field so we don't silently overwrite hooks /
+		// integrations / exclude patterns the user may have configured by other
+		// means. Successful save flips configured=true via statusStore.refresh,
+		// which retires the apikey-panel through the existing
+		// configured:changed plumbing — no explicit success ack needed here.
+		// On failure we surface the message inline through
+		// notifyApiKeySaveError so the user sees it without leaving the panel.
+		vscode.commands.registerCommand(
+			"jollimemory.saveAnthropicApiKey",
+			async (rawKey: unknown) => {
+				log.info("cmd", "saveAnthropicApiKey invoked");
+				const key = typeof rawKey === "string" ? rawKey.trim() : "";
+				if (key.length === 0) {
+					sidebarProvider.notifyApiKeySaveError("API key cannot be empty.");
+					return;
+				}
+				try {
+					await saveConfigScoped({ apiKey: key }, getGlobalConfigDir());
+					await statusStore.refresh();
+				} catch (err) {
+					const message =
+						err instanceof Error ? err.message : "Failed to save the API key.";
+					log.error("cmd", `saveAnthropicApiKey failed: ${message}`);
+					sidebarProvider.notifyApiKeySaveError(message);
+				}
+			},
+		),
 
 		// Auth — sign in / sign out via browser-based OAuth flow.
 		vscode.commands.registerCommand("jollimemory.signIn", async () => {

--- a/vscode/src/views/SidebarCssBuilder.test.ts
+++ b/vscode/src/views/SidebarCssBuilder.test.ts
@@ -235,13 +235,38 @@ describe("onboarding panel styles", () => {
 		expect(css).toContain("var(--vscode-descriptionForeground)");
 	});
 
-	it("shares the onboarding-panel container rule with .disabled-panel", () => {
+	it("shares the onboarding-panel container rule with .disabled-panel and .apikey-panel", () => {
 		const css = buildSidebarCss();
-		// .disabled-panel reuses the onboarding container (padding/scroll/
-		// height) by way of a multi-selector rule rather than redeclaring
-		// the same declarations. This keeps the two full-viewport panels in
-		// lockstep so tweaking onboarding spacing automatically applies to
-		// the disabled CTA without a parallel edit.
-		expect(css).toMatch(/\.onboarding-panel\s*,\s*\.disabled-panel\s*\{/);
+		// All three full-viewport configured===false views (onboarding cards,
+		// apikey input, and disabled CTA) reuse the same container rule
+		// (padding/scroll/height) by way of a multi-selector rule rather
+		// than redeclaring the same declarations. This keeps tweaks to
+		// onboarding spacing in lockstep across every sibling panel.
+		expect(css).toMatch(
+			/\.onboarding-panel\s*,\s*\.disabled-panel\s*,\s*\.apikey-panel\s*\{/,
+		);
+	});
+
+	it("declares apikey-panel-specific styles for input + inline error", () => {
+		const css = buildSidebarCss();
+		// The inline API key entry has three custom pieces beyond the shared
+		// container: the label (.apikey-label), the password input
+		// (.apikey-input), and the inline error span (.apikey-error). The
+		// input is themed via --vscode-input-* so it matches Settings + the
+		// rest of the host UI.
+		expect(css).toMatch(/\.apikey-label\b/);
+		expect(css).toMatch(/\.apikey-input\b/);
+		expect(css).toMatch(/\.apikey-error\b/);
+		expect(css).toContain("var(--vscode-input-background)");
+		expect(css).toContain("var(--vscode-errorForeground)");
+	});
+
+	it("disables the .ob-btn:disabled state so the Save button has visible affordance when empty", () => {
+		const css = buildSidebarCss();
+		// The apikey-panel Save button starts disabled and toggles based on
+		// input value. Without the :disabled rule it'd look identical to the
+		// active state, which would make the apikey form look broken on
+		// first paint.
+		expect(css).toMatch(/\.ob-btn:disabled\s*\{/);
 	});
 });

--- a/vscode/src/views/SidebarCssBuilder.ts
+++ b/vscode/src/views/SidebarCssBuilder.ts
@@ -595,7 +595,8 @@ export function buildSidebarCss(): string {
      button only — no option cards, no OR divider). Sharing the
      container rule keeps padding/scroll behavior in lockstep. */
   .onboarding-panel,
-  .disabled-panel {
+  .disabled-panel,
+  .apikey-panel {
     padding: 16px;
     overflow-y: auto;
     height: 100%;
@@ -679,6 +680,45 @@ export function buildSidebarCss(): string {
     border-color: var(--vscode-widget-border, var(--vscode-editorWidget-border));
   }
   .ob-btn--secondary:hover { background: var(--vscode-list-hoverBackground); }
+  .ob-btn:disabled {
+    opacity: 0.5;
+    cursor: default;
+  }
+  .ob-btn:disabled:hover { background: var(--vscode-button-background); }
+  /* ── API key entry panel ──────────────────────────────────────────
+     Reuses .ob-header / .ob-btn from the onboarding panel. The label +
+     input pair sits between the header and the Save/Back buttons. The
+     inline error span is hidden via .hidden by default and surfaces
+     only after the host posts an apikey:saveError back. */
+  .apikey-label {
+    display: block;
+    font-size: 12px;
+    font-weight: 600;
+    margin: 12px 0 6px 0;
+    color: var(--vscode-foreground);
+  }
+  .apikey-input {
+    display: block;
+    width: 100%;
+    padding: 6px 8px;
+    box-sizing: border-box;
+    background: var(--vscode-input-background);
+    color: var(--vscode-input-foreground);
+    border: 1px solid var(--vscode-input-border, var(--vscode-widget-border, transparent));
+    border-radius: 4px;
+    font-size: 12px;
+    font-family: var(--vscode-editor-font-family, monospace);
+  }
+  .apikey-input:focus {
+    outline: 1px solid var(--vscode-focusBorder);
+    outline-offset: -1px;
+  }
+  .apikey-error {
+    margin: 8px 0 0 0;
+    font-size: 12px;
+    color: var(--vscode-errorForeground);
+    line-height: 1.4;
+  }
   .ob-or {
     display: flex; align-items: center; gap: 10px;
     margin: 14px 0;

--- a/vscode/src/views/SidebarHtmlBuilder.test.ts
+++ b/vscode/src/views/SidebarHtmlBuilder.test.ts
@@ -225,6 +225,57 @@ describe("SidebarHtmlBuilder", () => {
 			);
 		});
 
+		it("includes the apikey-panel, hidden by default, with input + Save (initially disabled) + Back + inline error", () => {
+			const html = buildSidebarHtml(
+				"test-nonce",
+				"vscode-resource:",
+				"https://example/codicon.css",
+				SIDEBAR_EMPTY_STRINGS,
+			);
+			expect(html).toContain('id="apikey-panel"');
+			expect(html).toMatch(/<div class="apikey-panel hidden"/);
+			// Password input keeps the typed key off-screen and disables
+			// browser autofill (Anthropic keys aren't a username/password
+			// pair so autofill suggestions would be wrong noise).
+			expect(html).toMatch(
+				/<input type="password"[^>]*id="apikey-input"[^>]*autocomplete="off"/,
+			);
+			// Save starts disabled — empty input is not a valid key. The
+			// script flips it on input. Without the disabled attribute the
+			// user could click Save with an empty field and we'd round-trip
+			// to the host just to surface "API key cannot be empty."
+			expect(html).toMatch(
+				/<button[^>]*id="apikey-save-btn"[^>]*\sdisabled[^>]*>Save<\/button>/,
+			);
+			expect(html).toMatch(
+				/<button[^>]*id="apikey-back-btn"[^>]*>Back<\/button>/,
+			);
+			// Inline error span is hidden until populated by an
+			// apikey:saveError message from the host.
+			expect(html).toMatch(/<p class="apikey-error hidden"/);
+			expect(html).toContain('id="apikey-error"');
+		});
+
+		it("places the apikey-panel between onboarding-panel and disabled-panel so configured===false views are siblings", () => {
+			const html = buildSidebarHtml(
+				"test-nonce",
+				"vscode-resource:",
+				"https://example/codicon.css",
+				SIDEBAR_EMPTY_STRINGS,
+			);
+			// The three configured===false views must be DOM siblings in this
+			// order so the script's exclusive toggle (only one of the three
+			// visible at a time) maps cleanly to top-down scan order. Out of
+			// order they'd still render correctly, but we'd lose the
+			// "first-of-three is the default" intuition.
+			const ob = html.indexOf('<div class="onboarding-panel');
+			const ak = html.indexOf('<div class="apikey-panel');
+			const di = html.indexOf('<div class="disabled-panel');
+			expect(ob).toBeGreaterThan(-1);
+			expect(ak).toBeGreaterThan(ob);
+			expect(di).toBeGreaterThan(ak);
+		});
+
 		it("reuses the onboarding header copy (Get started + subtitle) and omits the option cards", () => {
 			const html = buildSidebarHtml(
 				"test-nonce",

--- a/vscode/src/views/SidebarHtmlBuilder.ts
+++ b/vscode/src/views/SidebarHtmlBuilder.ts
@@ -13,6 +13,12 @@
  *     key). In that mode the tab bar and tab content are hidden; the onboarding
  *     panel takes the entire viewport. The Anthropic API key path is positioned
  *     as the recommended primary option above the secondary Sign in to Jolli card.
+ *   - An API key entry panel sibling, hidden by default. Shown when the user
+ *     clicks "Configure API Key" from the onboarding panel — replaces the
+ *     onboarding cards with a focused input + Save/Back so users can save the
+ *     key without opening the full Settings page (which surfaces a dozen
+ *     unrelated fields). Successful save flips `configured` to true via
+ *     statusStore, which hides this panel through `applyConfigured(true)`.
  *   - A disabled panel sibling, hidden by default. Shown when the user is
  *     configured but has explicitly disabled the extension (`state.enabled ===
  *     false`). It reuses the onboarding header copy + the `.ob-*` styles, but
@@ -89,11 +95,25 @@ export function buildSidebarHtml(
           <i class="codicon codicon-cloud ob-card-icon" aria-hidden="true"></i>
           <div class="ob-card-text">
             <h3 class="ob-card-title">Sign in to Jolli</h3>
-            <p class="ob-card-desc">Use Jolli's cloud to sync memories across machines and get AI summarization out of the box. Free to get started.</p>
+            <p class="ob-card-desc">Use your Jolli account for AI summarization. Memories are stored locally, with the option to push to Jolli cloud.</p>
           </div>
         </div>
       </section>
       <button type="button" id="onboarding-signin-btn" class="ob-btn ob-btn--secondary">Sign In / Sign Up</button>
+    </div>
+    <div class="apikey-panel hidden" id="apikey-panel" role="region" aria-label="Configure Anthropic API key">
+      <header class="ob-header">
+        <div class="ob-title-row">
+          <i class="codicon codicon-key ob-title-icon" aria-hidden="true"></i>
+          <h2 class="ob-title">Configure your Anthropic API key</h2>
+        </div>
+        <p class="ob-subtitle">Paste your Anthropic API key. The key is stored locally only.</p>
+      </header>
+      <label class="apikey-label" for="apikey-input">API key</label>
+      <input type="password" id="apikey-input" class="apikey-input" autocomplete="off" spellcheck="false" placeholder="sk-ant-..." />
+      <p class="apikey-error hidden" id="apikey-error" role="alert"></p>
+      <button type="button" id="apikey-save-btn" class="ob-btn ob-btn--primary" disabled>Save</button>
+      <button type="button" id="apikey-back-btn" class="ob-btn ob-btn--secondary">Back</button>
     </div>
     <div class="disabled-panel hidden" id="disabled-panel" role="region" aria-label="Enable Jolli Memory">
       <header class="ob-header">

--- a/vscode/src/views/SidebarMessages.ts
+++ b/vscode/src/views/SidebarMessages.ts
@@ -298,4 +298,15 @@ export type SidebarInboundMsg =
 	| { readonly type: "enabled:changed"; readonly enabled: boolean }
 	| { readonly type: "auth:changed"; readonly authenticated: boolean }
 	| { readonly type: "configured:changed"; readonly configured: boolean }
-	| { readonly type: "worker:busy"; readonly busy: boolean };
+	| { readonly type: "worker:busy"; readonly busy: boolean }
+	| {
+			/**
+			 * Posted only on the failure path of the inline onboarding API key
+			 * save (jollimemory.saveAnthropicApiKey). The success path is
+			 * implicit: a successful save flips `configured` true via
+			 * statusStore, which triggers the existing `configured:changed`
+			 * channel and retires the apikey-panel through `applyConfigured(true)`.
+			 */
+			readonly type: "apikey:saveError";
+			readonly message: string;
+	  };

--- a/vscode/src/views/SidebarScriptBuilder.test.ts
+++ b/vscode/src/views/SidebarScriptBuilder.test.ts
@@ -117,17 +117,31 @@ describe("SidebarScriptBuilder", () => {
 		expect(js).toContain("state.authenticated = !!msg.authenticated");
 	});
 
-	it("hides the loading-panel as soon as init arrives so the placeholder doesn't outlive the host's first state push", () => {
+	it("hides the loading-panel on the first host message (any type), not only on init", () => {
 		const js = buildSidebarScript();
-		// The loading-panel is unhidden in HTML (no .hidden) and must be
-		// hidden by the init handler before any apply* call decides which
-		// of the configured / disabled / tab-UI panels to surface. This
-		// avoids both panels being visible at once during the init frame.
+		// The loading-panel is unhidden in HTML (no .hidden) and must be hidden
+		// before any apply* call decides which of the configured / disabled /
+		// tab-UI panels to surface. The hand-off used to live inside the init
+		// case, but statusStore.refresh during initialLoad posts
+		// configured:changed / enabled:changed BEFORE init — those handlers
+		// call applyEnabled/applyConfigured which surface the disabled-panel
+		// or onboarding-panel while loading is still up. Hiding at the top of
+		// handleMessage (before the switch) covers every state-bearing path.
 		expect(js).toContain("getElementById('loading-panel')");
-		const initStart = js.indexOf("'init'");
+		const fnStart = js.indexOf("function handleMessage");
+		const switchStart = js.indexOf("switch", fnStart);
+		expect(fnStart).toBeGreaterThan(-1);
+		expect(switchStart).toBeGreaterThan(fnStart);
+		expect(js.slice(fnStart, switchStart)).toContain(
+			"loadingPanel.classList.add('hidden')",
+		);
+		// And the redundant hide inside the init case is gone — keeping it
+		// duplicated invites future drift where someone updates one site but
+		// not the other.
+		const initStart = js.indexOf("case 'init'");
 		const initEnd = js.indexOf("case ", initStart + 1);
 		expect(initStart).toBeGreaterThan(-1);
-		expect(js.slice(initStart, initEnd)).toContain(
+		expect(js.slice(initStart, initEnd)).not.toContain(
 			"loadingPanel.classList.add('hidden')",
 		);
 	});
@@ -835,6 +849,52 @@ describe("SidebarScriptBuilder", () => {
 			expect(js).toContain("'configured:changed'");
 		});
 
+		it("configured:changed false→true (onboarding completed) switches to the Status tab", () => {
+			const js = buildSidebarScript();
+			// Both onboarding completion paths — sign-in OAuth callback and
+			// inline API key save — flip configured from false to true via
+			// statusStore.refresh, so the same handler must land the user on
+			// the Status tab (where they see auth state, settings entry, and
+			// the worker indicator) instead of the default Branch tab.
+			const start = js.indexOf("case 'configured:changed'");
+			expect(start).toBeGreaterThan(-1);
+			const end = js.indexOf("case '", start + 1);
+			const body = js.slice(start, end);
+			// Capture the prior value BEFORE applyConfigured mutates it; the
+			// edge detection collapses to !wasConfigured && msg.configured.
+			// Reading state.configured AFTER applyConfigured would always
+			// reflect the new value and the edge detection would collapse to
+			// always-false (true→true) or always-true (false→false), neither
+			// of which fires switchTab('status') correctly.
+			expect(body).toMatch(
+				/const\s+wasConfigured\s*=\s*state\.configured[\s\S]{0,200}applyConfigured\(/,
+			);
+			expect(body).toMatch(
+				/!wasConfigured[\s\S]{0,40}switchTab\(['"]status['"]\)/,
+			);
+		});
+
+		it("configured:changed true→true (already configured) does NOT auto-switch the user's tab", () => {
+			const js = buildSidebarScript();
+			// Re-broadcasts of configured=true happen routinely (host
+			// statusStore.refresh during background polls, init race). We
+			// must not yank the user out of whatever tab they're on — the
+			// auto-switch is gated on the false→true edge, not the value.
+			const start = js.indexOf("case 'configured:changed'");
+			const end = js.indexOf("case '", start + 1);
+			const body = js.slice(start, end);
+			// The switchTab('status') call MUST be guarded by !wasConfigured.
+			// A bare switchTab('status') inside the msg.configured branch
+			// would steal the tab on every same-value push.
+			const switchIdx = body.indexOf("switchTab('status')");
+			expect(switchIdx).toBeGreaterThan(-1);
+			// Walk backwards to the nearest `if` and assert it gates on the edge.
+			const guardSlice = body.slice(0, switchIdx);
+			const lastIfIdx = guardSlice.lastIndexOf("if");
+			expect(lastIfIdx).toBeGreaterThan(-1);
+			expect(guardSlice.slice(lastIfIdx)).toContain("!wasConfigured");
+		});
+
 		it("references the onboarding panel id when toggling visibility", () => {
 			const js = buildSidebarScript();
 			expect(js).toContain("onboarding-panel");
@@ -846,10 +906,142 @@ describe("SidebarScriptBuilder", () => {
 			expect(js).toContain("'jollimemory.signIn'");
 		});
 
-		it("wires onboarding apikey button to dispatch jollimemory.openSettings", () => {
+		it("wires onboarding apikey button to swap into the inline apikey-panel (NOT openSettings)", () => {
 			const js = buildSidebarScript();
 			expect(js).toContain("onboarding-apikey-btn");
-			expect(js).toContain("'jollimemory.openSettings'");
+			// Configure API Key now stays in-panel: it switches to the
+			// apikey-panel sibling instead of opening the full Settings
+			// webview, so the user sees a single API key field instead of
+			// the dozen unrelated Settings options.
+			const start = js.indexOf("onboardingApikeyBtn.addEventListener");
+			const end = js.indexOf("});", start);
+			expect(start).toBeGreaterThan(-1);
+			const handler = js.slice(start, end);
+			expect(handler).toContain("showApikeyPanel");
+			// The handler MUST NOT post the openSettings command — that's
+			// the legacy gear-icon path and would re-open the regression.
+			expect(handler).not.toContain("jollimemory.openSettings");
+		});
+
+		it("apikey-panel: showApikeyPanel hides onboarding cards and shows the input view (and resets transient state)", () => {
+			const js = buildSidebarScript();
+			expect(js).toContain("function showApikeyPanel");
+			const start = js.indexOf("function showApikeyPanel");
+			const end = js.indexOf("function ", start + 1);
+			const body = js.slice(start, end);
+			// Mutually exclusive view swap.
+			expect(body).toContain("onboardingPanel.classList.add('hidden')");
+			expect(body).toContain("apikeyPanel.classList.remove('hidden')");
+			// Reset transient state on every (re-)entry: clear any stale
+			// error / value / saving label that might have been left over
+			// from a prior attempt the user backed out of.
+			expect(body).toContain("apikeyError.classList.add('hidden')");
+			expect(body).toContain("apikeyError.textContent = ''");
+			expect(body).toContain("apikeyInput.value = ''");
+			expect(body).toContain("apikeySaveBtn.disabled = true");
+			expect(body).toMatch(/apikeySaveBtn\.textContent\s*=\s*['"]Save['"]/);
+		});
+
+		it("apikey-panel: Save button disabled while input is empty, enabled on non-empty trim", () => {
+			const js = buildSidebarScript();
+			// The button starts disabled (HTML attribute) and the input
+			// listener flips it based on `value.trim().length === 0`. Trim
+			// matters because pasting "  sk-ant-...  " with stray whitespace
+			// would otherwise look valid client-side and then fail server-side.
+			expect(js).toMatch(
+				/apikeyInput\.addEventListener\(['"]input['"][\s\S]{0,400}apikeySaveBtn\.disabled\s*=\s*apikeyInput\.value\.trim\(\)\.length\s*===\s*0/,
+			);
+		});
+
+		it("apikey-panel: Enter key in the input submits when Save is enabled", () => {
+			const js = buildSidebarScript();
+			// Keyboard accelerator parity with the click path. preventDefault
+			// stops the form-submit-style page reload that would otherwise
+			// blow away the webview state.
+			expect(js).toMatch(
+				/apikeyInput\.addEventListener\(['"]keydown['"][\s\S]{0,400}e\.key\s*===\s*['"]Enter['"][\s\S]{0,200}submitApikey\(\)/,
+			);
+		});
+
+		it("apikey-panel: submitApikey dispatches jollimemory.saveAnthropicApiKey with the trimmed key and shows Saving…", () => {
+			const js = buildSidebarScript();
+			expect(js).toContain("function submitApikey");
+			const start = js.indexOf("function submitApikey");
+			const end = js.indexOf("\n  }", start);
+			const body = js.slice(start, end);
+			// Trim is enforced once more on the host-bound side so a race
+			// where the disabled flag got bypassed (focus-lost + click
+			// timing) still doesn't ship whitespace to disk.
+			expect(body).toMatch(/apikeyInput\.value\.trim\(\)/);
+			expect(body).toMatch(/apikeySaveBtn\.textContent\s*=\s*['"]Saving/);
+			expect(body).toContain("'jollimemory.saveAnthropicApiKey'");
+			// The arg is forwarded as args:[key] so executeCommand's variadic
+			// invocation in SidebarWebviewProvider.handleOutbound spreads it
+			// into the registered handler's first positional parameter.
+			expect(body).toMatch(/args:\s*\[\s*key\s*\]/);
+		});
+
+		it("apikey-panel: Back button restores the onboarding cards view", () => {
+			const js = buildSidebarScript();
+			expect(js).toContain("function showOnboardingPanel");
+			expect(js).toMatch(
+				/apikeyBackBtn\.addEventListener\(['"]click['"]\s*,\s*showOnboardingPanel\)/,
+			);
+		});
+
+		it("apikey-panel: apikey:saveError re-enables Save and surfaces the message inline (only when panel is still active)", () => {
+			const js = buildSidebarScript();
+			// Anchor on the case label to avoid landing on the comment that
+			// also mentions the message type inside submitApikey.
+			expect(js).toContain("case 'apikey:saveError'");
+			const start = js.indexOf("case 'apikey:saveError'");
+			const end = js.indexOf("break", start);
+			const body = js.slice(start, end);
+			// Guard: if the panel was already retired by applyConfigured
+			// (success raced past us), don't re-show the input — the user
+			// is already on the main UI and a stale error would be confusing.
+			expect(body).toContain("apikeyPanel.classList.contains('hidden')");
+			// Re-enable Save (re-deriving from input.trim()) and restore the
+			// label so the user can edit and retry.
+			expect(body).toMatch(/apikeySaveBtn\.disabled\s*=/);
+			expect(body).toMatch(/apikeySaveBtn\.textContent\s*=\s*['"]Save['"]/);
+			expect(body).toContain("apikeyError.classList.remove('hidden')");
+			// Fall-back string when the host posts an empty/non-string message.
+			expect(body).toContain("Failed to save the API key.");
+		});
+
+		it("applyConfigured(true) hides the apikey-panel along with the onboarding-panel", () => {
+			const js = buildSidebarScript();
+			// The apikey-panel is a sub-view of the configured===false flow,
+			// so the same configured:changed(true) hand-off that retires the
+			// onboarding cards must retire the input view too. Otherwise a
+			// successful save would flip configured but leave the input
+			// stranded on top of the tab UI.
+			const start = js.indexOf("function applyConfigured");
+			const trueBranch = js.indexOf(
+				"onboardingPanel.classList.add('hidden')",
+				start,
+			);
+			expect(trueBranch).toBeGreaterThan(-1);
+			const window = js.slice(trueBranch, trueBranch + 400);
+			expect(window).toContain("apikeyPanel.classList.add('hidden')");
+		});
+
+		it("applyConfigured(false) resets to the cards view (not the apikey-panel)", () => {
+			const js = buildSidebarScript();
+			// The apikey-panel is not a stable state — it's a transient
+			// sub-view the user opted into. If configured flips back to
+			// false (e.g. user signed out), reset to the cards so they can
+			// pick API key OR Sign In again, not whichever sub-view they
+			// happened to be on last.
+			const start = js.indexOf("function applyConfigured");
+			const falseBranch = js.indexOf(
+				"onboardingPanel.classList.remove('hidden')",
+				start,
+			);
+			expect(falseBranch).toBeGreaterThan(-1);
+			const window = js.slice(falseBranch, falseBranch + 400);
+			expect(window).toContain("apikeyPanel.classList.add('hidden')");
 		});
 
 		it("reads configured from init state", () => {

--- a/vscode/src/views/SidebarScriptBuilder.ts
+++ b/vscode/src/views/SidebarScriptBuilder.ts
@@ -126,6 +126,16 @@ export function buildSidebarScript(): string {
   // onboarding panel; mutually exclusive with it.
   const disabledPanel = document.getElementById('disabled-panel');
   const disabledEnableBtn = document.getElementById('disabled-enable-btn');
+  // API key entry panel — replaces the onboarding cards when the user
+  // clicks "Configure API Key". Also a sibling of onboarding-panel: only
+  // one of {onboarding, apikey, disabled} is visible at any time when
+  // configured===false. Successful save flips configured to true via
+  // statusStore, after which applyConfigured(true) hides this panel.
+  const apikeyPanel = document.getElementById('apikey-panel');
+  const apikeyInput = document.getElementById('apikey-input');
+  const apikeyError = document.getElementById('apikey-error');
+  const apikeySaveBtn = document.getElementById('apikey-save-btn');
+  const apikeyBackBtn = document.getElementById('apikey-back-btn');
   // Loading panel — visible on first paint (no .hidden in HTML), then
   // hidden as soon as the host's init message arrives. Bridges the gap
   // between webview-load and the first real configured/enabled values
@@ -393,16 +403,70 @@ export function buildSidebarScript(): string {
     vscode.postMessage({ type: 'command', command: enableBtn.dataset.command || 'jollimemory.enableJolliMemory' });
   });
 
-  // Onboarding panel buttons. The Anthropic API key path is the recommended
-  // primary action and routes to the existing Settings webview (where the
-  // user already configures their API key); Sign In / Sign Up runs the
-  // OAuth-based jollimemory.signIn command.
+  // Onboarding panel buttons. Configure API Key swaps the cards view for the
+  // inline apikey-panel (single input + Save) so the user doesn't have to
+  // open the full Settings webview just to set one value. Sign In / Sign Up
+  // runs the OAuth-based jollimemory.signIn command.
   onboardingApikeyBtn.addEventListener('click', function() {
-    vscode.postMessage({ type: 'command', command: 'jollimemory.openSettings' });
+    showApikeyPanel();
   });
   onboardingSigninBtn.addEventListener('click', function() {
     vscode.postMessage({ type: 'command', command: 'jollimemory.signIn' });
   });
+
+  // ---- API key entry panel ----
+  // showApikeyPanel / showOnboardingPanel toggle exclusively between the two
+  // configured===false views. Only one of {onboarding-panel, apikey-panel}
+  // is visible at a time. Both are hidden simultaneously by applyConfigured(true)
+  // when the user finishes configuring (typed key saved or signed in).
+  function showApikeyPanel() {
+    onboardingPanel.classList.add('hidden');
+    apikeyPanel.classList.remove('hidden');
+    apikeyError.classList.add('hidden');
+    apikeyError.textContent = '';
+    apikeyInput.value = '';
+    apikeySaveBtn.disabled = true;
+    apikeySaveBtn.textContent = 'Save';
+    setTimeout(function() { apikeyInput.focus(); }, 0);
+  }
+  function showOnboardingPanel() {
+    apikeyPanel.classList.add('hidden');
+    onboardingPanel.classList.remove('hidden');
+  }
+  apikeyBackBtn.addEventListener('click', showOnboardingPanel);
+  apikeyInput.addEventListener('input', function() {
+    apikeySaveBtn.disabled = apikeyInput.value.trim().length === 0;
+    // Typing dismisses any prior error so the user isn't staring at a stale
+    // message while editing.
+    if (!apikeyError.classList.contains('hidden')) {
+      apikeyError.classList.add('hidden');
+      apikeyError.textContent = '';
+    }
+  });
+  apikeyInput.addEventListener('keydown', function(e) {
+    if (e.key === 'Enter' && !apikeySaveBtn.disabled) {
+      e.preventDefault();
+      submitApikey();
+    }
+  });
+  apikeySaveBtn.addEventListener('click', submitApikey);
+  function submitApikey() {
+    const key = apikeyInput.value.trim();
+    if (key.length === 0) return;
+    apikeySaveBtn.disabled = true;
+    apikeySaveBtn.textContent = 'Saving…';
+    apikeyError.classList.add('hidden');
+    apikeyError.textContent = '';
+    // Successful save flips configured via statusStore.onChange → the panel
+    // is hidden by applyConfigured(true). Failure comes back as an
+    // 'apikey:saveError' message handled below; we re-enable the Save button
+    // and surface the error inline.
+    vscode.postMessage({
+      type: 'command',
+      command: 'jollimemory.saveAnthropicApiKey',
+      args: [key],
+    });
+  }
 
   // Disabled-panel Enable button — same command as the legacy in-Status
   // disabled-banner Enable button (jollimemory.enableJolliMemory). Wired
@@ -426,15 +490,18 @@ export function buildSidebarScript(): string {
   });
 
   function handleMessage(msg) {
+    // Tear down the first-paint loading placeholder on the FIRST host message,
+    // not just on init. Used to gate this on init exclusively, but the hosts
+    // statusStore.refresh during initialLoad fires onChange synchronously and
+    // posts configured:changed / enabled:changed BEFORE the gated init —
+    // those handlers call applyConfigured/applyEnabled which un-hide the
+    // onboarding-panel or disabled-panel while loading-panel is still up,
+    // leaving both stacked in the flex column. Hiding here covers every
+    // state-bearing entry path uniformly. Idempotent on already-hidden.
+    loadingPanel.classList.add('hidden');
     switch (msg.type) {
       case 'init':
         if (typeof msg.state.authenticated === 'boolean') state.authenticated = msg.state.authenticated;
-        // Tear down the first-paint loading placeholder once init lands —
-        // every following branch (degraded, configured, disabled, normal)
-        // unhides exactly the panel it owns, so this is the single hand-off
-        // point. Doing it before applyDegraded means degraded paths don't
-        // need to know about the loading panel.
-        loadingPanel.classList.add('hidden');
         if (msg.state.degradedReason) {
           // Degraded path: no workspace folder open, or workspace is not a git
           // repo. Skip the rest of init (data providers aren't wired in this
@@ -478,12 +545,40 @@ export function buildSidebarScript(): string {
         // toolbar; re-render so the swap takes effect immediately.
         if (state.activeTab === 'status') renderToolbar();
         break;
-      case 'configured:changed':
+      case 'configured:changed': {
+        // Capture the prior value BEFORE applyConfigured mutates state.configured —
+        // we use the false→true edge to detect "user just finished onboarding"
+        // (either sign-in OAuth callback or API key save). Same-value pushes
+        // (host re-broadcasts during background refresh, init race) leave
+        // wasConfigured===true so the auto-switch below is skipped.
+        const wasConfigured = state.configured;
         applyConfigured(!!msg.configured);
         // After flipping configured back to true we're back on the regular
         // UI surface; refresh the toolbar so the active-tab buttons reflect
         // the current state (e.g. Sign In/Out icon, worker-busy label).
-        if (msg.configured) renderToolbar();
+        if (msg.configured) {
+          // Land the user on the Status tab the first time they finish
+          // onboarding so they see the live state of what they just
+          // configured (auth status, settings entry, worker indicator)
+          // instead of the default Branch tab. Both sign-in and API key
+          // paths converge on this same configured=false→true transition.
+          if (!wasConfigured) switchTab('status');
+          renderToolbar();
+        }
+        break;
+      }
+      case 'apikey:saveError':
+        // Only re-enable Save + show the error if the apikey-panel is still
+        // the active surface. If the panel has been retired (success path
+        // raced past us), stay quiet — applyConfigured already hid us.
+        if (!apikeyPanel.classList.contains('hidden')) {
+          apikeySaveBtn.disabled = apikeyInput.value.trim().length === 0;
+          apikeySaveBtn.textContent = 'Save';
+          apikeyError.textContent = typeof msg.message === 'string' && msg.message.length > 0
+            ? msg.message
+            : 'Failed to save the API key.';
+          apikeyError.classList.remove('hidden');
+        }
         break;
       case 'worker:busy': {
         const next = !!msg.busy;
@@ -611,7 +706,11 @@ export function buildSidebarScript(): string {
   function applyConfigured(configured) {
     state.configured = !!configured;
     if (!configured) {
+      // Land on the cards view when configured flips back to false (e.g.
+      // user signed out). The apikey-panel is a sub-view of onboarding,
+      // not a stable state on its own, so we always reset back to cards.
       onboardingPanel.classList.remove('hidden');
+      apikeyPanel.classList.add('hidden');
       disabledPanel.classList.add('hidden');
       tabBar.classList.add('hidden');
       tabToolbar.classList.add('hidden');
@@ -622,6 +721,10 @@ export function buildSidebarScript(): string {
       return;
     }
     onboardingPanel.classList.add('hidden');
+    // Hide apikey-panel here too — when the user successfully saves a key,
+    // statusStore re-derives configured=true and we land here. This is the
+    // single hand-off that retires the apikey input view.
+    apikeyPanel.classList.add('hidden');
     // applyEnabled() now manages the .hidden flag on tabBar itself (it hides
     // the bar in disabled mode because disabled-panel owns the viewport),
     // so just delegate — no manual tabBar.classList.remove('hidden') needed.

--- a/vscode/src/views/SidebarWebviewProvider.test.ts
+++ b/vscode/src/views/SidebarWebviewProvider.test.ts
@@ -1000,6 +1000,36 @@ describe("SidebarWebviewProvider", () => {
 		).toBe(true);
 	});
 
+	it("notifyApiKeySaveError posts apikey:saveError with the supplied message", () => {
+		const view = makeMockView();
+		const provider = new SidebarWebviewProvider({
+			executeCommand: vi.fn(),
+			getInitialState: () => ({
+				enabled: true,
+				authenticated: false,
+				configured: false,
+				activeTab: "status",
+				kbMode: "folders",
+				branchName: "main",
+				detached: false,
+			}),
+			extensionUri: mockExtensionUri as unknown as never,
+		});
+		provider.resolveWebviewView(view as unknown as never);
+		view.webview.postMessage.mockClear();
+		provider.notifyApiKeySaveError("disk full");
+		const sent = view.webview.postMessage.mock.calls.map((c) => c[0]);
+		expect(
+			sent.some(
+				(m) =>
+					typeof m === "object" &&
+					m !== null &&
+					(m as { type?: unknown }).type === "apikey:saveError" &&
+					(m as { message?: unknown }).message === "disk full",
+			),
+		).toBe(true);
+	});
+
 	it("notifyConfiguredChanged posts configured:changed with the new configured flag", () => {
 		const view = makeMockView();
 		const provider = new SidebarWebviewProvider({
@@ -1124,6 +1154,7 @@ describe("SidebarWebviewProvider", () => {
 		expect(() => provider.notifyEnabledChanged(false)).not.toThrow();
 		expect(() => provider.notifyAuthChanged(true)).not.toThrow();
 		expect(() => provider.notifyConfiguredChanged(false)).not.toThrow();
+		expect(() => provider.notifyApiKeySaveError("anything")).not.toThrow();
 	});
 
 	// onSidebarFirstVisible fires exactly once across multiple `ready` messages —

--- a/vscode/src/views/SidebarWebviewProvider.ts
+++ b/vscode/src/views/SidebarWebviewProvider.ts
@@ -380,6 +380,17 @@ export class SidebarWebviewProvider
 		this.postMessage({ type: "configured:changed", configured });
 	}
 
+	/**
+	 * Pushed only on the failure path of the inline onboarding API key save.
+	 * Successful saves flip `configured` and ride the regular
+	 * `configured:changed` channel — no explicit success ack here. The
+	 * failure path needs an explicit message because nothing in
+	 * statusStore changes to trigger the existing reactive plumbing.
+	 */
+	notifyApiKeySaveError(message: string): void {
+		this.postMessage({ type: "apikey:saveError", message });
+	}
+
 	private pushStatus(): void {
 		if (!this.deps.statusProvider) return;
 		this.postMessage({


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## Quick recap

This commit replaced the "Configure API Key" button's behavior in the onboarding sidebar: instead of opening the full Settings panel with dozens of unrelated fields, clicking the button now reveals a focused inline input panel directly within the sidebar. The developer added a new sibling panel containing a single password field, a Save button, a Back button, and an inline error display. On successful save, only the API key field is written to disk, and the existing status-refresh pipeline automatically dismisses the panel by flipping the configured state. On failure, an inline error message appears without leaving the panel. The commit also wired both the sign-in and API key save paths to automatically navigate the user to the Status tab upon first-time configuration, making that behavior explicit rather than relying on accidental state persistence.

---

## E2E Test (4)
<details>
<summary><strong>1. Inline API key entry in onboarding sidebar</strong></summary>
<br>
<blockquote>

**Preconditions:** The extension is installed and activated. You are on a fresh setup where no API key has been configured yet (the onboarding panel is visible in the sidebar).

**Steps:**
1. Open the Jolli Memory sidebar in VS Code.
2. On the onboarding panel, click the "Configure API Key" button.
3. Verify that you stay in the sidebar (the full Settings page does NOT open).
4. Type your Anthropic API key into the password field that appears.
5. Click the "Save" button and wait for the save to complete.
6. Verify that the sidebar automatically switches to the Status tab and the onboarding panel disappears.

**Expected Results:**
- The "Configure API Key" button should be replaced by a focused input panel with a single password field, a label, and Save/Back buttons.
- The Save button should start disabled (grayed out) and become enabled only after you type a non-empty key.
- After clicking Save, the key should be stored locally and the sidebar should show the Status tab (not remain on onboarding or jump to a different tab).
- If you paste a key with extra whitespace (e.g., "  sk-ant-xxx  \n"), it should be trimmed and saved correctly.

</blockquote>
</details>
<details>
<summary><strong>2. API key entry error handling and recovery</strong></summary>
<br>
<blockquote>

**Preconditions:** The extension is installed and the onboarding panel is visible (no API key configured yet).

**Steps:**
1. Open the Jolli Memory sidebar and click "Configure API Key".
2. Leave the password field empty and click the "Save" button.
3. Verify that an error message appears inline below the input field.
4. Type a valid API key into the field.
5. Click "Save" again.

**Expected Results:**
- When you try to save an empty key, an error message should appear below the input field (e.g., "API key cannot be empty.") without closing the panel.
- The Save button should remain enabled so you can correct and retry.
- After entering a valid key and clicking Save, the error message should disappear and the save should succeed.

</blockquote>
</details>
<details>
<summary><strong>3. Back button restores onboarding view</strong></summary>
<br>
<blockquote>

**Preconditions:** The extension is installed and the onboarding panel is visible.

**Steps:**
1. Open the Jolli Memory sidebar and click "Configure API Key".
2. Type a partial or test API key into the password field.
3. Click the "Back" button.
4. Verify that the onboarding cards reappear.

**Expected Results:**
- The API key entry panel should close and the original onboarding panel with the "Configure API Key" and "Sign In / Sign Up" buttons should be visible again.
- Any text you typed in the password field should be cleared (not retained if you re-enter the panel).

</blockquote>
</details>
<details>
<summary><strong>4. Auto-switch to Status tab after sign-in completion</strong></summary>
<br>
<blockquote>

**Preconditions:** The extension is installed and you are on the onboarding panel (not yet configured).

**Steps:**
1. Open the Jolli Memory sidebar.
2. Click "Sign In / Sign Up" and complete the OAuth sign-in flow in your browser.
3. Return to VS Code and wait for the sidebar to update.
4. Verify which tab is now active in the sidebar.

**Expected Results:**
- After sign-in completes, the sidebar should automatically switch to and display the Status tab (showing your authentication state and extension settings).
- The onboarding panel should disappear.
- If you manually switch to a different tab (e.g., Branch or Memory) and then trigger a background refresh, the sidebar should NOT jump back to Status — your chosen tab should remain active.

</blockquote>
</details>

---

## Topics (2)
<details>
<summary><strong>01 · Inline API key entry panel replaces Settings page in onboarding sidebar</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

When a new user clicked "Configure API Key" in the onboarding sidebar, they were taken to the full Settings page, which surfaces a dozen unrelated fields. The user wanted a focused, in-place experience: a single input field for the key, with Save and Back, without leaving the sidebar.

**💡 Decisions Behind the Code**

- **Separate panel rather than expanding the existing onboarding view**: Adding the input as a collapsible section inside the onboarding cards panel would have entangled the cards' state with the input's state, making future additions (like a "Try Jolli first" flow) harder to isolate. A sibling panel with exclusive visibility — the same pattern already used for the disabled panel — keeps each configured-false state self-contained and independently testable.
- **Success path uses the existing status-refresh pipeline, not an explicit acknowledgment**: Rather than adding a dedicated "save succeeded" message from host to webview, the implementation relies on the fact that a successful save causes the configured flag to flip, which already triggers panel dismissal through the existing reactive channel. This avoids a parallel state machine and means the onboarding panel retirement logic stays in one place regardless of which path (sign-in or API key) completed configuration.
- **Only the API key field is written on save, not the full config**: Writing only the changed field prevents silently overwriting hooks, integrations, or exclude patterns the user may have set through other means. The trade-off is a slightly more targeted write call, but the safety benefit — no destructive side effects from the inline save path — outweighs the marginal complexity.

**✅ What Was Implemented**

- A new sibling panel was added to the sidebar HTML alongside the existing onboarding cards and disabled panels. It contains a password input (with autocomplete off), a Save button that starts disabled until the field is non-empty, a Back button, and a hidden inline error paragraph that surfaces only on failure. The CSS container rule was extended to cover this new panel so spacing and scroll behavior stay in lockstep with the other full-viewport panels.
- A new host command was registered that accepts the raw key, trims whitespace, writes only the API key field to disk (leaving all other config untouched), then triggers a status refresh. The success path is entirely implicit: the refresh causes the configured flag to flip true, which fires the existing configured-changed channel and dismisses the panel automatically. The failure path posts a dedicated save-error message back to the webview so the inline error span can be populated without a panel transition.
- The sidebar script was updated to wire the "Configure API Key" button to swap panels in place rather than dispatch the open-settings command. Helper functions handle showing the input panel (resetting stale error/value state on every entry), submitting the key, and restoring the onboarding cards view on Back. An Enter-key handler in the input provides keyboard parity with the click path.

**📁 FILES**
- `vscode/src/views/SidebarHtmlBuilder.ts`
- `vscode/src/views/SidebarScriptBuilder.ts`
- `vscode/src/views/SidebarCssBuilder.ts`
- `vscode/src/Extension.ts`
- `vscode/src/views/SidebarMessages.ts`

</blockquote>
</details>
<details>
<summary><strong>02 · First-time configuration automatically navigates user to Status tab</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

After completing onboarding (either via sign-in or API key save), the sidebar would land on whatever tab was last active rather than reliably showing the Status tab. The user wanted both completion paths to consistently bring up the Status tab, matching the expected post-setup experience.

**💡 Decisions Behind the Code**

- **Edge detection on the false-to-true transition rather than reacting to the value itself**: Both onboarding completion paths converge on the same configured-changed channel, so the right place to trigger the tab switch is at that single convergence point. Reacting to the value alone (rather than the transition) would steal the user's tab on every routine status refresh, which happens in the background throughout normal use. Capturing the prior value before the state update and gating on the edge keeps the behavior scoped to the one moment it is actually meaningful.
- **Explicit code rather than relying on persisted webview state**: The prior behavior — where sign-in appeared to land on Status — was an artifact of the webview's state persistence restoring whatever tab the user had last manually selected. This was fragile and non-deterministic for new installs. Making the navigation explicit ensures both completion paths behave identically and predictably regardless of prior session state.

**✅ What Was Implemented**

The configured-changed message handler in the sidebar script was updated to capture the previous configured value before applying the new state. When the value transitions from false to true — meaning onboarding just completed — the script calls the tab-switch function targeting the Status tab. Same-value re-broadcasts (which occur during background status polls and on init) are explicitly excluded from triggering the switch, so the user's current tab is never stolen during normal operation.

**📁 FILES**
- `vscode/src/views/SidebarScriptBuilder.ts`

</blockquote>
</details>

---

*Generated by Jolli Memory · May 8, 2026 at 5:54 PM*
<!-- jollimemory-summary-end -->