### PR TITLE
UPDATE-RELEASE-DOCS-0.99: Release v0.99.0 with multi-agent support and Memory Bank

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,18 +71,28 @@ IntelliJ plugin: `cd intellij && ./gradlew build` (or `runIde` for a sandbox). S
 
 The product is built on a hook pipeline that runs in the user's project, not in this repo:
 
-1. **AI agent hooks** (Claude `StopHook` / `SessionStartHook`, Gemini `AfterAgent`) only record session metadata to `<projectDir>/.jolli/jollimemory/sessions.json`. They do not read transcripts, do not call the LLM, and run with `async: true` so they never block the agent. Codex and OpenCode have no hook — they're discovered by scanning `~/.codex/sessions/` or reading `~/.local/share/opencode/opencode.db` (Node 22.5+ `node:sqlite`, lazy-imported and feature-gated; the VSCode bundle targets Node 18 and tolerates the missing module).
+1. **AI agent hooks** (Claude `StopHook` / `SessionStartHook`, Gemini `AfterAgent`) only record session metadata to `<projectDir>/.jolli/jollimemory/sessions.json`. They do not read transcripts, do not call the LLM, and run with `async: true` so they never block the agent. Codex, OpenCode, Cursor (Composer), GitHub Copilot CLI, and VS Code Copilot Chat have **no hook** — each has a per-source detector + session discoverer + transcript reader triplet under `cli/src/core/` that runs at post-commit time. The OpenCode reader uses Node 22.5+ `node:sqlite` and is lazy-imported + feature-gated so the VSCode bundle (which targets Node 18) tolerates the missing module; the Cursor and Copilot triplets follow the same lazy-import pattern. Copilot CLI and Copilot Chat share a single `copilotEnabled` config flag — splitting them was rejected because users want them together.
 
 2. **Git hooks** drive a unified queue under `.jolli/jollimemory/git-op-queue/`. `post-commit` is synchronous (<5 ms) and only enqueues + spawns a detached `QueueWorker`; the worker holds a 5-min file lock, drains entries in timestamp order, runs the LLM where needed, and chain-spawns a successor if new entries appear after it finishes. Squash and rebase entries skip the LLM and just merge/migrate existing summaries. `prepare-commit-msg` writes `squash-pending.json` so the worker recognizes squash before deciding whether to call the LLM. See [`cli/DEVELOPMENT.md`](cli/DEVELOPMENT.md) for the queue rationale (each op gets its own file precisely because the previous single-slot pending files lost summaries during rapid amend/rebase sequences).
 
-### Storage: orphan branch + two `.jolli/jollimemory/` dirs
+### Storage: orphan branch + pluggable `StorageProvider` + two `.jolli/jollimemory/` dirs
 
 Summaries live on the git orphan branch `jollimemory/summaries/v3` in the user's repo and are written via plumbing only — the branch is **never checked out**. Read with `git show <branch>:<path>`; write with `hash-object` + `mktree` + `commit-tree` + `update-ref`.
+
+The orphan branch I/O is wrapped behind a `StorageProvider` interface (`cli/src/core/StorageProvider.ts`). Three backends ship today, picked by `StorageFactory` and swapped in at runtime via `setActiveStorage()` in `SummaryStore.ts`:
+
+- `OrphanBranchStorage` — orphan-branch-only, the legacy mode (the only mode in 0.98.0 and earlier).
+- `FolderStorage` — folder-only.
+- `DualWriteStorage` — **the default in 0.99.0** (`storageMode` defaults to `"dual-write"` in `StorageFactory.createStorage`). Writes go to both the orphan branch (system of record) and a Memory Bank folder under `<kbRoot>/.jolli/jollimemory/<dir>/` per-branch; reads come from the orphan branch. The `kbRoot` variable name and the `KB`-prefixed module names (`KBPathResolver`, `KBTypes`) are legacy identifiers from when the feature was internally called "Knowledge Base"; the user-facing label is "Memory Bank".
+
+The VS Code extension's `activate()` (and the IntelliJ plugin's equivalent) checks `MetadataManager.readMigrationState()` on every start: if the orphan branch has data but migration has not completed (fresh install, or the user wiped the folder), `MigrationEngine.runMigration()` runs automatically. There is no opt-in — Memory Bank is on by default. The Settings → Local Memory Bank entry point lets the user re-target the folder; it re-runs migration into a fresh `-N`-suffixed folder and archives the previous folder's repo identity (content files are untouched).
+
+Display and write paths in `SummaryStore.ts` / `LocalSearchProvider.ts` go through the active provider, so adding a fourth backend (e.g. SQLite, S3) is a single new class plus a factory wiring change. Existing code that hard-coded git plumbing is gone — don't reintroduce it.
 
 Local non-summary state is split across **two** `.jolli/jollimemory/` directories — don't conflate them:
 
 - `~/.jolli/jollimemory/` — **machine-global**: `config.json` (authToken / apiKey), `dist-paths/` (per-source dist-path indirection), `run-hook` / `run-cli` / `resolve-dist-path` hook entry scripts. Resolved by `getGlobalConfigDir()`.
-- `<projectDir>/.jolli/jollimemory/` — **per-project, gitignored**: `sessions.json`, `cursors.json`, `git-op-queue/`, `notes/`, `plans.json`, `briefing-cache.json`, `debug.log`, and the manual-disable marker (VS Code). Resolved by `getJolliMemoryDir(cwd)` in [`cli/src/Logger.ts`](cli/src/Logger.ts).
+- `<projectDir>/.jolli/jollimemory/` — **per-project, gitignored**: `sessions.json`, `cursors.json`, `git-op-queue/`, `notes/`, `plans.json`, `briefing-cache.json`, `debug.log`, and the manual-disable marker (VS Code, written by `ManualDisableFlag` — durable per-repo opt-out from auto-enable; once set, never auto-cleared by anything other than an explicit re-enable). Resolved by `getJolliMemoryDir(cwd)` in [`cli/src/Logger.ts`](cli/src/Logger.ts).
 
 ### VS Code extension bundles the CLI
 
@@ -111,6 +121,7 @@ The bridge is `SiteRenderer.renderOpenApiSpecs(contentDir, publicDir, specs)` in
 ## Project conventions worth knowing
 
 - **Biome** is the formatter and linter (config: [`cli/biome.json`](cli/biome.json)). Tabs, 4-wide, 120 column limit. Rules of note: `noExplicitAny: error`, `noUnusedImports/Variables: error`, `useImportType: warn`. CI runs `biome check --error-on-warnings` — warnings fail.
+- **Never include AI/Claude co-author information in commit messages.** No `Co-Authored-By: Claude …` trailers, no "🤖 Generated with …" footers — for either commits or PR descriptions. The repo is going open-source and history should read as human-authored work; only `Signed-off-by:` is required.
 
 (The DCO sign-off, `npm run all` gate, CLI coverage floor, and worktree-aware requirement are stated as critical rules at the top of this file; they are not repeated here to keep this file as a single source of truth.)
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 **Jolli Memory** automatically turns your AI coding sessions into structured development documentation attached to every commit, without any extra effort.
 
-When you work with AI agents like Claude Code, Codex, Gemini CLI, or OpenCode, the reasoning behind every decision lives in the conversation — *why this approach was chosen, what alternatives were considered, what problems came up along the way*. The moment you commit, that context is gone. Jolli Memory captures it automatically.
+When you work with AI agents like Claude Code, Codex, Gemini CLI, OpenCode, Cursor IDE, GitHub Copilot CLI, or VS Code Copilot Chat, the reasoning behind every decision lives in the conversation — *why this approach was chosen, what alternatives were considered, what problems came up along the way*. The moment you commit, that context is gone. Jolli Memory captures it automatically.
 
 ---
 
@@ -41,9 +41,10 @@ Monorepo hosting three deliverables that share the same product model and storag
 ## Product highlights
 
 - **Automatic** — git hooks run summary generation in a detached background process; your commit returns instantly (the summary appears 10–20 seconds later).
-- **Multi-agent** — works with Claude Code, Codex CLI, Gemini CLI, and OpenCode. Sessions are picked up automatically via agent hooks or filesystem/DB scanning.
-- **Local-first** — summaries and raw transcripts stay on your machine in a git orphan branch. Opt-in **Push to Jolli** shares summaries (not transcripts) with your team.
+- **Multi-agent** — works with Claude Code, Codex CLI, Gemini CLI, OpenCode, Cursor IDE, GitHub Copilot CLI, and VS Code Copilot Chat. Sessions are picked up automatically via agent hooks or filesystem/DB scanning.
+- **Local-first** — summaries and raw transcripts stay on your machine in a git orphan branch, and a **Memory Bank** folder additionally holds a plain-Markdown copy of every memory (dual-written automatically — the orphan branch is the source of truth). Opt-in **Push to Jolli** shares summaries (not transcripts) with your team.
 - **Structured format** — v3 tree with topics, triggers, decisions, and todos; correctly handles amend / squash / cherry-pick / rebase.
+- **Documentation site generator** — the CLI also ships a Nextra-based site generator (`jolli new` / `build` / `start` / `dev`) with theme packs, header / footer config, and an OpenAPI rich-rendering pipeline (per-endpoint MDX, no `swagger-ui-react` runtime).
 - **Privacy-respecting** — see the *Privacy* section in each surface's README for the exact data flow. The Jolli LLM proxy does not persist transcripts or diffs, and does not log them.
 
 ---

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,6 +1,18 @@
 # Changelog
 
-<!-- Last synced commit: ea9ad050b | 2026-04-23 -->
+<!-- Last synced commit: fd3e1e2e | 2026-05-08 -->
+
+## 0.99.0
+
+- **Three new AI agents supported** — Cursor IDE (Composer), GitHub Copilot CLI, and VS Code Copilot Chat. Conversations from all three are now folded into your commit summaries automatically, no hook installation needed.
+- **`jolli search`** — search across every branch's memories from the terminal. Returns full topic bodies (not snippets) and prints a clickable link per hit so the IntelliJ plugin and VS Code extension open the matching memory directly.
+- **`/jolli-search` agent skill** — same search, available from inside Claude Code or any agent that loads the skill.
+- **Site generator: `jolli new` / `build` / `start` / `dev`** — generate a documentation site from a folder of Markdown plus OpenAPI specs. Two built-in theme packs (Forge and Atlas), header / footer customization, and a `jolli dev` hot-reload server. See [`docs/site-json-reference.md`](docs/site-json-reference.md) and [`examples/`](examples/) for runnable configurations.
+- **Memory Bank** — every repo now gets a plain-Markdown copy of every memory on disk. The first time hooks run on a repo with existing memories, they migrate automatically; from then on, every new memory is written to **both** the git orphan branch (the source of truth) and the Memory Bank folder.
+- **Better recap quality** — prompts, summarization, and regeneration are all tighter. Squashing commits no longer loses decision details from the originals.
+- **`jolli auth` hardened** — sign-in now uses an authorization-code exchange with CSRF protection (RFC 6749), so credentials never appear in browser URLs.
+- **Smaller install footprint** — sourcemaps removed from production builds.
+- Bug fixes
 
 ## 0.98.0
 

--- a/cli/DEVELOPMENT.md
+++ b/cli/DEVELOPMENT.md
@@ -55,19 +55,25 @@ jolli status
 ## Architecture Overview
 
 ```
-                    AI Agent Session (Claude / Codex / Gemini / OpenCode)
+                    AI Agent Session
+              (Claude / Codex / Gemini / OpenCode /
+               Cursor / Copilot CLI / Copilot Chat)
                            │
                     ┌──────┴──────┐
                     │  Stop Event  │  (Claude only — Gemini uses AfterAgent;
-                    └──────┬──────┘   Codex / OpenCode have no hook)
+                    └──────┬──────┘   every other source has no hook)
                            │ stdin JSON
                     ┌──────┴──────┐
                     │  StopHook   │  Saves session info to
                     │  (Node.js)  │  ~/.jolli/jollimemory/sessions.json
                     └─────────────┘
                   (Codex sessions are discovered by scanning ~/.codex/sessions/
-                   at post-commit time; OpenCode by reading
-                   ~/.local/share/opencode/opencode.db via node:sqlite)
+                   at post-commit time. OpenCode reads
+                   ~/.local/share/opencode/opencode.db via node:sqlite.
+                   Cursor / Copilot CLI / Copilot Chat are each discovered by
+                   their own per-source detector + session discoverer at
+                   post-commit time, with the same lazy-import + feature-gate
+                   pattern as OpenCode.)
 
                     ... developer codes ...
 
@@ -135,8 +141,18 @@ jolli status
 | [GeminiSessionDetector.ts](src/core/GeminiSessionDetector.ts) | Detects Gemini CLI installation |
 | [OpenCodeSessionDiscoverer.ts](src/core/OpenCodeSessionDiscoverer.ts) | Discovers OpenCode sessions by reading `~/.local/share/opencode/opencode.db` (Node 22.5+ `node:sqlite`, lazy-imported and feature-gated). Surfaces a typed `OpenCodeScanError` when the DB is present but unreadable (corrupt / locked / schema mismatch) so the UI can render a dedicated "unavailable" row. |
 | [OpenCodeTranscriptReader.ts](src/core/OpenCodeTranscriptReader.ts) | Reads OpenCode message rows out of `opencode.db` and converts them into the shared `TranscriptEntry` shape used by the rest of the pipeline |
+| [CursorDetector.ts](src/core/CursorDetector.ts) / [CursorSessionDiscoverer.ts](src/core/CursorSessionDiscoverer.ts) / [CursorTranscriptReader.ts](src/core/CursorTranscriptReader.ts) | Cursor IDE (Composer) integration. Detector → "is Cursor installed", discoverer scans the workspace storage, reader normalises to `TranscriptEntry`. Same lazy-import + feature-gate pattern as OpenCode. |
+| [CopilotDetector.ts](src/core/CopilotDetector.ts) / [CopilotSessionDiscoverer.ts](src/core/CopilotSessionDiscoverer.ts) / [CopilotTranscriptReader.ts](src/core/CopilotTranscriptReader.ts) | GitHub Copilot CLI integration (same triplet pattern). |
+| [CopilotChatDetector.ts](src/core/CopilotChatDetector.ts) / [CopilotChatSessionDiscoverer.ts](src/core/CopilotChatSessionDiscoverer.ts) / [CopilotChatTranscriptReader.ts](src/core/CopilotChatTranscriptReader.ts) | VS Code Copilot Chat integration. Sessions live in the Copilot Chat conversation cache. Both Copilot CLI and Copilot Chat respect the single shared `copilotEnabled` config flag. |
 | [Summarizer.ts](src/core/Summarizer.ts) | Anthropic API calls for structured summary generation. Also exports `generateSquashMessage()` for the VSCode extension's squash flow |
-| [SummaryStore.ts](src/core/SummaryStore.ts) | Reads/writes summaries to the orphan branch (v3 tree format), merge/migrate operations |
+| [SummaryStore.ts](src/core/SummaryStore.ts) | Reads/writes summaries via the active `StorageProvider`. Default backend is the orphan branch; folder-mode and dual-write backends are pluggable (see Storage Layer below). Handles v3 tree merge / migrate operations. |
+| [StorageProvider.ts](src/core/StorageProvider.ts) / [StorageFactory.ts](src/core/StorageFactory.ts) | Storage abstraction: any backend implementing `StorageProvider` can be plugged in via `setActiveStorage()`. Factory selects the active backend (`OrphanBranchStorage`, `FolderStorage`, or `DualWriteStorage`) based on user config. |
+| [OrphanBranchStorage.ts](src/core/OrphanBranchStorage.ts) | Existing orphan-branch backend (default). Reads via `git show`, writes via `hash-object` + `mktree` + `commit-tree` + `update-ref`. |
+| [FolderStorage.ts](src/core/FolderStorage.ts) | Folder-mode backend: visible Markdown files under a chosen Memory Bank directory. |
+| [DualWriteStorage.ts](src/core/DualWriteStorage.ts) | Writes through to both orphan branch and folder storage so the orphan branch remains the system of record. |
+| [KBPathResolver.ts](src/core/KBPathResolver.ts) / [KBTypes.ts](src/core/KBTypes.ts) | Memory Bank path resolution (per-branch directories, kb root, dual-write metadata files). The `KB` prefix is the legacy identifier — the user-facing name is "Memory Bank". |
+| [MetadataManager.ts](src/core/MetadataManager.ts) | Reads / writes the kb metadata file (storage mode, paths, last-sync info). |
+| [MigrationEngine.ts](src/core/MigrationEngine.ts) | Drives migrations between storage modes (orphan → folder, folder → orphan, partial recovery). |
 | [SummaryTree.ts](src/core/SummaryTree.ts) | Tree traversal utilities (aggregate stats/turns, collect source nodes, `resolveDiffStats` display helper) |
 | [SummaryMigration.ts](src/core/SummaryMigration.ts) | v1→v3 migration logic for legacy orphan branch data |
 | [GitOperationDetector.ts](src/hooks/GitOperationDetector.ts) | Detects git operation type (commit, amend, squash, rebase, cherry-pick, revert) |

--- a/cli/README.md
+++ b/cli/README.md
@@ -22,6 +22,9 @@ When you use an AI coding agent, Jolli Memory keeps track of your active session
 | **Gemini CLI** | An `AfterAgent` hook fires after each agent completion |
 | **Codex CLI** | No hook needed — sessions are discovered automatically by scanning the filesystem |
 | **OpenCode** | No hook needed — sessions are discovered automatically by reading OpenCode's global SQLite database at `~/.local/share/opencode/opencode.db` (requires Node 22.5+) |
+| **Cursor IDE** (Composer) | No hook needed — sessions are discovered automatically by scanning the Cursor workspace storage |
+| **GitHub Copilot CLI** | No hook needed — sessions are discovered automatically by scanning Copilot CLI's session log |
+| **VS Code Copilot Chat** | No hook needed — sessions are discovered automatically by reading the Copilot Chat conversation cache |
 
 ### Git Hooks — generating summaries on commit
 
@@ -180,6 +183,49 @@ jolli recall --format json
 jolli recall --budget 30000 --format json
 ```
 
+### `jolli search`
+
+Searches stored memories on the local catalog with a two-phase pipeline (catalog scan → topic match). Returns full topic bodies — not match snippets — and prints a stable `/summary/<hash>` URI per hit so an AI agent can deep-link back to the right memory. Also powers the [`/jolli-search` skill](#session-context-recall) for in-agent search.
+
+```bash
+# Search memories on the current branch
+jolli search "rate limiter"
+
+# Limit to recent commits and a specific branch
+jolli search "auth refactor" --since 2026-04-01 --branch feature/auth
+
+# Cap the result count, JSON output for skills/agents
+jolli search "windows path" --limit 5 --format json
+```
+
+`--since` accepts an ISO date or RFC 3339 timestamp; bad values are rejected with exit 1 (no silent empty result). SHAs in `/summary/<hash>` URIs are always full 40-character SHAs.
+
+### Site generation: `jolli new` / `build` / `start` / `dev`
+
+Generates a Nextra v4 documentation site from a `Content_Folder` of Markdown plus optional OpenAPI specs. Designed for product / API documentation alongside (or instead of) your AI commit memories.
+
+```bash
+# Scaffold a new site (creates Content_Folder/ + site.json)
+jolli new my-docs
+
+# Build the static site to <out>/dist
+jolli build
+
+# Serve the built site
+jolli start
+
+# Hot-reload dev server (watches Content_Folder/ and re-syncs on change)
+jolli dev
+```
+
+Highlights:
+
+- **Theme packs**: `Forge` (clean dev docs, sidebar-first, Inter) and `Atlas` (editorial, dark default, serif). Customize `accentHue`, `fontFamily`, logos, and default theme mode in `site.json`.
+- **Header / footer config**: `header.items` supports per-item dropdowns; `footer` supports copyright, link columns, and social icons.
+- **OpenAPI rich pipeline**: each endpoint is compiled into a per-endpoint MDX page with auto-generated cURL / JS / TS / Python / Go code samples — no `swagger-ui-react` runtime.
+
+See [`docs/site-json-reference.md`](docs/site-json-reference.md) and [`examples/`](examples/) for runnable configurations.
+
 ### `jolli configure`
 
 Manages settings stored in `~/.jolli/jollimemory/config.json`. API keys are masked in the display output.
@@ -201,7 +247,7 @@ jolli configure --set excludePatterns=docs/**,*.log,node_modules
 jolli configure --remove jolliApiKey
 ```
 
-Supported keys: `apiKey`, `model`, `maxTokens`, `jolliApiKey`, `authToken`, `codexEnabled`, `geminiEnabled`, `claudeEnabled`, `openCodeEnabled`, `logLevel`, `excludePatterns`. Run `jolli configure --list-keys` for descriptions and types. Unknown keys and malformed values (e.g. `maxTokens=8192abc`, `logLevel=banana`) are rejected with exit code 1.
+Supported keys: `apiKey`, `model`, `maxTokens`, `jolliApiKey`, `authToken`, `claudeEnabled`, `codexEnabled`, `geminiEnabled`, `openCodeEnabled`, `cursorEnabled`, `copilotEnabled`, `logLevel`, `excludePatterns`. `copilotEnabled` controls both GitHub Copilot CLI and VS Code Copilot Chat as a single switch. Run `jolli configure --list-keys` for descriptions and types. Unknown keys and malformed values (e.g. `maxTokens=8192abc`, `logLevel=banana`) are rejected with exit code 1.
 
 ### `jolli doctor`
 
@@ -337,6 +383,8 @@ Jolli Memory feeds prior development context back into your AI agent so it can p
 
 If the current branch has no memories, the command shows a catalog of branches that do, letting you pick one to recall. You can also pass a branch name or keyword as an argument (e.g. `/jolli-recall auth-refactor`).
 
+**Targeted search** — run `/jolli-search <keyword>` (or `jolli search <keyword>` from the terminal) to search across every branch's memories. It returns full topic bodies along with `/summary/<hash>` URIs that the IntelliJ plugin and VS Code extension treat as deep links into the matching memory.
+
 ## Configuration
 
 Settings are stored globally in `~/.jolli/jollimemory/config.json`. The recommended way to manage them is via `jolli configure` — see [the command reference above](#jolli-configure) — which validates keys and types and masks secrets on display.
@@ -353,6 +401,8 @@ Settings are stored globally in `~/.jolli/jollimemory/config.json`. The recommen
 | `codexEnabled` | boolean | auto-detect | Enable Codex CLI session discovery |
 | `geminiEnabled` | boolean | auto-detect | Enable Gemini CLI session tracking |
 | `openCodeEnabled` | boolean | auto-detect | Enable OpenCode session discovery (requires Node 22.5+) |
+| `cursorEnabled` | boolean | auto-detect | Enable Cursor IDE (Composer) session discovery |
+| `copilotEnabled` | boolean | auto-detect | Enable GitHub Copilot CLI **and** VS Code Copilot Chat session discovery (single shared switch) |
 | `excludePatterns` | string[] | — | Glob patterns for file exclusion (set via `jolli configure --set excludePatterns=glob1,glob2`) |
 
 **Authentication setup** — three options:

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@jolli.ai/cli",
-	"version": "0.98.0",
+	"version": "0.99.0",
 	"description": "AI development process auto-documentation tool - generates structured commit summaries from Claude Code / Codex / Gemini sessions",
 	"main": "./dist/Cli.js",
 	"type": "module",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "jollimemory",
-	"version": "0.98.0",
+	"version": "0.99.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "jollimemory",
-			"version": "0.98.0",
+			"version": "0.99.0",
 			"license": "Apache-2.0",
 			"workspaces": [
 				"cli",
@@ -15,7 +15,7 @@
 		},
 		"cli": {
 			"name": "@jolli.ai/cli",
-			"version": "0.98.0",
+			"version": "0.99.0",
 			"hasInstallScript": true,
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -8420,7 +8420,7 @@
 		},
 		"vscode": {
 			"name": "jollimemory-vscode",
-			"version": "0.98.22",
+			"version": "0.99.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@vscode/codicons": "^0.0.45",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jollimemory",
-	"version": "0.98.0",
+	"version": "0.99.0",
 	"description": "AI development process auto-documentation tool - monorepo for CLI, VS Code extension and IntelliJ plugin",
 	"private": true,
 	"workspaces": [

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -1,6 +1,19 @@
 # Changelog
 
-<!-- Last synced commit: ea9ad050b | 2026-04-23 -->
+<!-- Last synced commit: fd3e1e2e | 2026-05-08 -->
+
+## 0.99.0
+
+- **Onboarding panel + auto-enable** — fresh installs now show a sidebar onboarding flow that walks you through sign-in (or pasting an Anthropic API key inline) and enabling git hooks. After the first repo is enabled, newly opened workspaces auto-enable in the background. Click **Disable** any time and that decision sticks across reloads — auto-enable never overrides an explicit choice.
+- **Three new AI agents supported** — Cursor IDE (Composer), GitHub Copilot CLI, and VS Code Copilot Chat. All are discovered automatically and shown alongside Claude / Codex / Gemini / OpenCode in the Status panel; toggles live in **Settings → Integrations** (Copilot CLI and Copilot Chat share a single switch).
+- **Multi-commit pull requests** — when a branch has more than one commit, **Create & Update PR** now produces a single rolled-up description across every commit (Plans → E2E Test Guide → Topics, each topic folded by default). Single-commit PRs are unchanged.
+- **Memory Bank** — every repo now gets a plain-Markdown copy of every memory on disk. The first time the extension activates on a repo with existing memories, it migrates them automatically; from then on, every new memory is written to **both** the git orphan branch (still the source of truth) and the Memory Bank folder. Change the folder location any time from **Settings → Local Memory Bank**.
+- **Open memory by hash** — clicking a `/summary/<hash>` link in agent output (for example from the new CLI `jolli search`) now opens the matching memory's Summary Webview directly.
+- **Hardened sign-in** — uses an authorization-code exchange with CSRF protection (RFC 6749) so credentials never appear in browser URLs.
+- **Better recap and PR descriptions** — prompts, regeneration, and squash-merge of memories are all tighter; PR sections fold each topic in `<details>` blocks so long branches stay scannable.
+- **E2E test guide editing** — edit or delete individual scenarios instead of all-or-nothing regeneration.
+- **Smaller VSIX** — sourcemaps removed from production builds; install size meaningfully smaller.
+- Bug fixes
 
 ## 0.98.0
 

--- a/vscode/DEVELOPMENT.md
+++ b/vscode/DEVELOPMENT.md
@@ -5,15 +5,14 @@
 ## First-time Setup
 
 ```bash
-# 1. Build the jollimemory core (the extension bundles it at build time via esbuild)
-cd cli
-npm install && npm run build
-
-# 2. Install extension dev dependencies
-cd ../vscode
+# 1. Install workspace dependencies (npm workspaces — run once at the repo root, covers cli + vscode)
 npm install
 
+# 2. Build the jollimemory core (the extension bundles it at build time via esbuild)
+npm run build:cli
+
 # 3. Deploy (bumps patch version, builds, packages, and installs into your VS Code)
+cd vscode
 npm run deploy
 ```
 
@@ -42,8 +41,8 @@ Ctrl+Shift+P → Developer: Reload Window
 The extension bundles `cli/src/**` at build time. If you change files under `cli/src/`, rebuild the core first:
 
 ```bash
-cd cli && npm run build
-cd ../vscode && npm run deploy
+npm run build:cli            # from the repo root
+cd vscode && npm run deploy
 ```
 
 ---
@@ -62,8 +61,11 @@ These hooks track which AI sessions are active. They only record session metadat
 | **Gemini CLI** | `GeminiAfterAgentHook` | Same stdin format as Claude's StopHook; additionally outputs `{}` to stdout (Gemini hook spec). |
 | **Codex CLI** | _(no hook)_ | Sessions discovered by scanning `~/.codex/sessions/` at post-commit time. |
 | **OpenCode** | _(no hook)_ | Sessions discovered by reading `~/.local/share/opencode/opencode.db` (SQLite) at post-commit time. Requires Node 22.5+ for `node:sqlite`; the discoverer is lazy-imported and feature-gated, so older hosts (e.g. VS Code's bundled Electron Node) silently skip OpenCode without breaking anything else. |
+| **Cursor IDE** (Composer) | _(no hook)_ | Sessions discovered by `CursorDetector` + `CursorSessionDiscoverer` scanning Cursor's workspace storage at post-commit time. |
+| **GitHub Copilot CLI** | _(no hook)_ | Sessions discovered by `CopilotDetector` + `CopilotSessionDiscoverer` scanning the Copilot CLI session log. |
+| **VS Code Copilot Chat** | _(no hook)_ | Sessions discovered by `CopilotChatDetector` + `CopilotChatSessionDiscoverer` reading the Copilot Chat conversation cache. |
 
-Per-integration enable/disable lives in the global config (`claudeEnabled`, `geminiEnabled`, `codexEnabled`, `openCodeEnabled`) and is toggled from the **Settings** webview. Discoverable-but-disabled integrations show up in the Status panel as "detected but disabled". OpenCode additionally surfaces a separate **scan-error** row when the DB is present but unreadable (corrupt, locked, schema-incompatible) — this avoids the past failure mode where a corrupt DB rendered as a healthy-looking integration.
+Per-integration enable/disable lives in the global config (`claudeEnabled`, `geminiEnabled`, `codexEnabled`, `openCodeEnabled`, `cursorEnabled`, `copilotEnabled`) and is toggled from the **Settings** webview. The single `copilotEnabled` switch covers both Copilot CLI and Copilot Chat — splitting them was rejected because users almost always want them together. Discoverable-but-disabled integrations show up in the Status panel as "detected but disabled". OpenCode and the Copilot family additionally surface a separate **scan-error** row when their backing store is present but unreadable (corrupt, locked, schema-incompatible) — this avoids the past failure mode where a corrupt DB rendered as a healthy-looking integration.
 
 ### Git Hooks — Summary Generation Pipeline
 
@@ -105,7 +107,8 @@ src/
 │   └── CommitsStore.ts           # Branch commits + range selection
 │
 ├── services/                     # Stateless services
-│   ├── AuthService.ts            # OAuth callback URI handling, sign-in / sign-out, jollimemory.signedIn context key
+│   ├── AuthService.ts            # OAuth callback URI handling (code-exchange flow + CSRF state validation per RFC 6749), sign-in / sign-out, jollimemory.signedIn context key
+│   ├── ManualDisableFlag.ts      # Durable per-repo opt-out for auto-enable (set when user clicks Disable; respected on every activation)
 │   ├── JolliPushService.ts       # HTTP client for pushing summaries to a Jolli Space
 │   ├── PrCommentService.ts       # GitHub PR creation/update via gh CLI; PR section markers
 │   └── data/                     # Pure derivations consumed by providers (no VSCode imports, no state)
@@ -120,15 +123,24 @@ src/
 │   ├── MemoriesTreeProvider.ts
 │   ├── PlansTreeProvider.ts      # Plans + Notes (one panel)
 │   ├── FilesTreeProvider.ts
-│   └── HistoryTreeProvider.ts    # Commits + per-commit file children + checkbox range logic
+│   ├── HistoryTreeProvider.ts    # Commits + per-commit file children + checkbox range logic
+│   └── KnowledgeBaseTreeProvider.ts  # Branch-aware Memory Bank folder tree (the class name keeps the legacy "KnowledgeBase" identifier)
 │
 ├── views/                        # Webview panels (HTML + CSS + JS, served via webview API)
+│   ├── SidebarWebviewProvider.ts         # Top-level sidebar webview that renders the onboarding flow, status, Memory Bank folders, and acts as the host for the in-sidebar panels
+│   ├── SidebarHtmlBuilder.ts             # HTML assembly for the sidebar (onboarding panel, sections, Memory Bank tree)
+│   ├── SidebarCssBuilder.ts              # Sidebar stylesheet (CSP-compatible — no inline style)
+│   ├── SidebarScriptBuilder.ts           # Embedded JS — onboarding interactions, message bus, lazy data fetches
+│   ├── SidebarMessages.ts                # Typed message contracts between extension host and sidebar webview
+│   │
 │   ├── SummaryWebviewPanel.ts            # Per-commit summary panel (orchestrator)
 │   ├── SummaryHtmlBuilder.ts             # Assembles HTML from modular blocks
 │   ├── SummaryCssBuilder.ts              # Notion-like stylesheet
 │   ├── SummaryScriptBuilder.ts           # Embedded JS for toggles, edit/delete, PR interactions
-│   ├── SummaryMarkdownBuilder.ts         # Markdown export for clipboard / Jolli push
-│   ├── SummaryPrMarkdownBuilder.ts       # PR-section variant of the Markdown export
+│   ├── SummaryMarkdownBuilder.ts         # Single-commit Markdown export for clipboard / Jolli push
+│   ├── SummaryPrMarkdownBuilder.ts       # PR-section variant of the Markdown export (collapsible <details> per topic)
+│   ├── SummaryPrAggregateMarkdownBuilder.ts  # Multi-commit branch-summary variant — rolls up every commit on the branch into a single PR description
+│   ├── BranchSummaryLoader.ts            # Walks the branch and loads every commit's stored summary for the aggregate PR builder
 │   ├── SummaryUtils.ts                   # Shared helpers (HTML escaping, date formatting, topic sorting)
 │   │
 │   ├── SettingsWebviewPanel.ts           # Singleton settings form (API keys, integrations, exclude patterns, push action)
@@ -249,6 +261,19 @@ Both panels are singletons (one instance at a time, focused if reopened) and use
 **Memories panel — lazy load + filter** — The Memories tree only fetches its first page on first visibility (`onDidChangeVisibility` in `Extension.ts`). Subsequent loads come from the in-store cache. When a filter is active, the bridge returns the matched set in one call and the "Load More" affordance is suppressed; without a filter it paginates. All this logic is split between `MemoriesStore` (cache + cursor) and `MemoriesDataService` (pure derivations like the description string and `canLoadMore`).
 
 **Bulk export** — `ExportMemoriesCommand` exports every memory in the workspace to `~/Documents/jollimemory/<project>/` via the core `SummaryExporter`. The result toast offers an **Open folder** action when anything was written or skipped.
+
+**Onboarding panel + auto-enable + durable opt-out** — `SidebarWebviewProvider` renders an onboarding flow on first activation (sign-in or inline Anthropic API key, then enable hooks). After the first repo is enabled, every newly opened workspace runs `installAll` automatically in the background. `ManualDisableFlag` records the user's explicit **Disable** decision into a per-repo file under `.jolli/jollimemory/`; on every activation the flag is checked first, so auto-enable never overrides a manual opt-out. Tests cover the four state combinations (never enabled, auto-enabled, manually enabled, manually disabled) so the durable flag does not get re-armed by unrelated config changes.
+
+**Aggregate PR descriptions for multi-commit branches** — `BranchSummaryLoader` walks every commit between the branch's fork point and HEAD and loads each commit's stored summary; `SummaryPrAggregateMarkdownBuilder` then composes a single PR description with one collapsible `<details>` block per topic across all commits, preceded by Plans and the E2E Test Guide. The single-commit code path is unchanged (`SummaryPrMarkdownBuilder`); `PrCommentService` picks the right builder based on commit count.
+
+**Memory Bank folder mode** — When the user opts in (Settings → Local Memory Bank → Migrate to Memory Bank), the extension drives the CLI's `StorageProvider` abstraction via `setActiveStorage()`. The sidebar webview shows a branch-aware folder view rendered by `KnowledgeBaseTreeProvider` (the class name still uses the legacy "KnowledgeBase" identifier; the user-facing label is "Memory Bank").
+
+Two commands implement the lifecycle:
+
+- `jollimemory.migrateToKnowledgeBase` — first migration. Picks a target folder, copies every existing memory into it as Markdown via `MigrationEngine`, and switches the active storage to `DualWriteStorage`.
+- `jollimemory.rebuildKnowledgeBase` — re-migration. Triggered by clicking **Migrate to Memory Bank** in Settings after a previous migration. Creates a new `-N`-suffixed folder, runs the migration into it, and archives the previous folder's repo identity so the next `resolveKBPath()` picks the new one.
+
+Both commands keep the orphan branch as the system of record; the folder is always derivable from it.
 
 ---
 

--- a/vscode/README.md
+++ b/vscode/README.md
@@ -27,10 +27,12 @@ Or search for **Jolli Memory** in the Extensions sidebar (`⌘⇧X` / `Ctrl+Shif
 
 ### First run
 
+On a fresh install, the sidebar opens to an **onboarding panel** that walks you through the three steps below. Once one repo is enabled, every newly opened workspace auto-enables in the background — clicking **Disable** is recorded as a durable opt-out and respected on every subsequent activation.
+
 1. Click the Jolli icon in the activity bar to open the sidebar.
-2. In the **Status** panel, either click **Sign In to Jolli** (OAuth) or open the **Settings** gear icon and paste an Anthropic API key.
-3. Click `(⊘)` in the Status panel to install git hooks in the current repository.
-4. Restart any active AI agent session (Claude Code / Codex / Gemini / OpenCode) so hooks take effect.
+2. In the onboarding panel, either click **Sign In to Jolli** (OAuth) or paste an Anthropic API key directly into the inline entry panel. (You can also open the **Settings** gear later.)
+3. Click **Enable Jolli Memory** to install git hooks in the current repository.
+4. Restart any active AI agent session (Claude Code / Codex / Gemini / OpenCode / Cursor / Copilot) so hooks take effect.
 5. Make a commit as usual — the summary appears in the **Commits** panel within ~10-20 seconds.
 
 ---
@@ -43,7 +45,7 @@ After each commit, Jolli Memory reads your selected AI session transcripts and t
 
 | Panel | What it shows |
 | -- | -- |
-| **Status** | Whether Jolli Memory is enabled, active AI agent sessions (Claude, Codex, Gemini, OpenCode), and how many memories are stored. Toggle Jolli Memory on/off with the `(●)` / `(⊘)` buttons; sign in or out of your Jolli account via the **Sign In to Jolli** / **Sign Out of Jolli** actions in the same panel toolbar. |
+| **Status** | Whether Jolli Memory is enabled, active AI agent sessions (Claude, Codex, Gemini, OpenCode, Cursor, Copilot CLI, Copilot Chat), and how many memories are stored. Toggle Jolli Memory on/off with the `(●)` / `(⊘)` buttons; sign in or out of your Jolli account via the **Sign In to Jolli** / **Sign Out of Jolli** actions in the same panel toolbar. A small busy indicator appears while a queue worker is running. |
 | **Memories** | Every stored memory across all branches, with instant search and filter. Click `(🔍)` in the panel title bar to filter by keyword, or click the **Load More** item at the bottom of the list to fetch older entries. |
 | **Plans & Notes** | Plans auto-detected from Claude Code sessions, plus your own notes (text snippets or imported Markdown files). Edit, remove, or associate items with commits. Use the **+ Add** dropdown to add a plan, a Markdown file, or a quick text snippet. |
 | **Changes** | All changed files with checkboxes to stage or unstage. Supports an exclude filter for hiding irrelevant files. |
@@ -65,6 +67,9 @@ When you use an AI coding agent, Jolli Memory keeps track of your active session
 | **Gemini CLI** | An `AfterAgent` hook fires after each agent completion |
 | **Codex CLI** | No hook needed — sessions are discovered automatically by scanning the filesystem |
 | **OpenCode** | No hook needed — sessions are discovered automatically by reading OpenCode's global SQLite database (requires a host VS Code with Node 22.5+) |
+| **Cursor IDE** (Composer) | No hook needed — sessions are discovered automatically by scanning Cursor workspace storage |
+| **GitHub Copilot CLI** | No hook needed — sessions are discovered automatically by scanning the Copilot CLI session log |
+| **VS Code Copilot Chat** | No hook needed — sessions are discovered automatically by reading the Copilot Chat conversation cache |
 
 ### Git Hooks — generating summaries on commit
 
@@ -198,7 +203,7 @@ Click **Sign Out of Jolli** from the same toolbar to clear the stored credential
 Click the gear icon `(⚙)` in the Memories panel toolbar (or any **Open Settings** action) to open a dedicated Settings webview with grouped sections:
 
 * **Authentication** — Anthropic `apiKey`, `model`, `maxTokens`, `jolliApiKey`
-* **Integrations** — toggles for Claude / Codex / Gemini / OpenCode session tracking
+* **Integrations** — toggles for Claude / Codex / Gemini / OpenCode / Cursor / Copilot session tracking. (Copilot CLI and VS Code Copilot Chat share a single switch.)
 * **Local Memories** — `localFolder` + default `pushAction` (see above)
 * **Files** — `excludePatterns` for the Changes panel
 
@@ -231,8 +236,17 @@ At the bottom of every memory panel, Jolli Memory can create or update a GitHub 
 
 * **Create PR**: pre-fills the PR description with a structured summary: Jolli Memory URL → Plans → E2E Test Guide → Topics (Why → Decisions → What → Future Enhancements → Files). All topic bodies are folded by default so the PR stays scannable.
 * **Update PR**: refreshes the summary section in place (using `<!-- jollimemory-summary -->` markers) without affecting any text you've added manually.
+* **Multi-commit PRs**: when the branch has more than one commit, the PR description aggregates every commit's memory into a single roll-up — Plans, E2E Test Guide, then a Topics section that combines all commits with each topic folded by default.
 
 Requires the `gh` CLI to be installed and authenticated.
+
+### Memory Bank
+
+Every repo automatically gets a plain-Markdown copy of every memory on disk, alongside the canonical storage on the `jollimemory/summaries/v3` orphan branch. The Memory Bank folder is created the first time the extension activates on a repo, and any pre-existing memories on the orphan branch are migrated into it without any action on your part.
+
+From then on, every new memory is **dual-written**: the orphan branch remains the source of truth, and the Memory Bank folder holds a `.md` copy you can open, search, and version like any other file.
+
+To change where the folder lives, open **Settings → Local Memory Bank**, click **Browse…** to pick a location, then click **Migrate to Memory Bank**. A fresh `-N`-suffixed folder is created at the new location and the previous folder is left in place on disk; nothing is deleted.
 
 
 ## Session Context Recall
@@ -263,6 +277,8 @@ Most settings can be configured directly from the **Status** panel in the sideba
 | `codexEnabled` | boolean | auto-detect | Enable Codex CLI session discovery |
 | `geminiEnabled` | boolean | auto-detect | Enable Gemini CLI session tracking |
 | `openCodeEnabled` | boolean | auto-detect | Enable OpenCode session discovery (requires a host VS Code with Node 22.5+) |
+| `cursorEnabled` | boolean | auto-detect | Enable Cursor IDE (Composer) session discovery |
+| `copilotEnabled` | boolean | auto-detect | Enable GitHub Copilot CLI **and** VS Code Copilot Chat session discovery (single shared switch) |
 | `localFolder` | string | — | Absolute path where **Push to Jolli & Local** writes Markdown copies of pushed summaries |
 | `pushAction` | enum | `jolli` | Default Push action: `jolli` (Jolli Space only) or `both` (Jolli Space + local folder) |
 | `excludePatterns` | string[] | — | Glob patterns for hiding files from the Changes panel |

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -2,7 +2,7 @@
 	"name": "jollimemory-vscode",
 	"displayName": "Jolli Memory",
 	"description": "VS Code sidebar for Jolli Memory — AI-powered commit summaries and smart git operations",
-	"version": "0.98.22",
+	"version": "0.99.0",
 	"publisher": "jolli",
 	"license": "Apache-2.0",
 	"icon": "assets/icon.png",


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## Quick recap

The team completed a comprehensive v0.99.0 release documentation cycle, updating version numbers across the monorepo and rewriting changelogs and developer guides to reflect six new AI agent integrations, a dual-write Memory Bank storage system, a terminal search command, and a documentation site generator. All documentation was carefully reviewed for accuracy: user-facing names were corrected (Knowledge Base → Memory Bank), internal implementation details were stripped from release notes to keep them scannable, and setup instructions were fixed to match the actual npm workspace structure. A parallel code review of the sidebar API key entry panel found no new issues, though two pre-existing vulnerabilities in unrelated code paths were documented for future hardening work.

---

## Topic (1)
<details>
<summary><strong>01 · Release v0.99.0 documentation and version bump across CLI, VSCode, and monorepo</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The team prepared a v0.99.0 release with significant new features (multi-agent support, Memory Bank storage, site generator, search) and needed to update all version numbers and documentation to reflect the changes.

**💡 Decisions Behind the Code**

- **Changelog density and user focus**: Removed internal implementation details (module names, schema versions, timeout values, Windows CI fixes) and kept only user-visible capabilities. This keeps release notes scannable and prevents technical jargon from obscuring the actual value proposition to end users.
- **Memory Bank naming consistency**: Corrected all user-facing references from "Knowledge Base" to "Memory Bank" while preserving internal code identifiers (`KBPathResolver`, `KBTypes`, `kbRoot`) with explicit "legacy identifier" annotations in developer docs. This prevents confusion between the user-facing feature name and internal naming artifacts.
- **Accurate feature description over aspirational wording**: Removed "opt-in" and "preview" labels from Memory Bank after verifying that `storageMode` defaults to `"dual-write"` and auto-migration runs on first activation. Changelog now reflects actual default behavior rather than overstating user control.
- **Workspace-aware setup instructions**: Corrected `vscode/DEVELOPMENT.md` to run `npm install` once at repo root (npm workspaces pattern) rather than per-subdirectory, preventing lockfile drift and matching the actual monorepo structure.

**✅ What Was Implemented**

- Updated version numbers to 0.99.0 in `cli/package.json`, `vscode/package.json`, `package.json` (root), and `package-lock.json` (3 workspace entries); kept `intellij/build.gradle.kts` at 0.97.9 per user direction.
- Rewrote `cli/CHANGELOG.md` and `vscode/CHANGELOG.md` with 0.99.0 entries covering new agents (Cursor, Copilot CLI, Copilot Chat), Memory Bank dual-write storage, search command, site generator, and hardened auth — removed low-value technical details and aligned style with prior releases.
- Expanded `cli/README.md` with new transcript sources table rows, `jolli search` and site generation command sections, and updated configuration table to include `cursorEnabled` and `copilotEnabled` flags.
- Updated `vscode/README.md` to document onboarding flow, new agents in Status panel, Memory Bank folder management, and `/summary/<hash>` URI deep-linking.
- Revised `vscode/DEVELOPMENT.md` to correct npm workspace setup (install at repo root, not in subdirectories), expanded Sources and Core Modules tables with new agents and storage layer classes.
- Enhanced `CLAUDE.md` with detailed Storage section explaining `StorageProvider` abstraction, three backend implementations, auto-migration behavior, and legacy `KB` naming; added note on avoiding AI co-author trailers in commits.
- Updated root `README.md` to list all six new transcript sources and added "Documentation site generator" as a product highlight.

**📁 FILES**
- `CLAUDE.md`
- `README.md`
- `cli/CHANGELOG.md`
- `cli/README.md`
- `cli/DEVELOPMENT.md`

</blockquote>
</details>

---

*Generated by Jolli Memory · May 8, 2026 at 11:52 PM*
<!-- jollimemory-summary-end -->