### PR TITLE
Fix OnboardingPanel font rendering and add API key help tooltip

### DIFF
--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/OnboardingPanel.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/OnboardingPanel.kt
@@ -87,7 +87,9 @@ class OnboardingPanel(
 		add(JPanel(FlowLayout(FlowLayout.LEFT, 6, 0)).apply {
 			alignmentX = LEFT_ALIGNMENT
 			add(JBLabel(JolliMemoryIcons.JolliLogo))
-			add(JBLabel("<html><b style='font-size:14pt'>Get started with Jolli Memory</b></html>"))
+			add(JBLabel("Get started with Jolli Memory").apply {
+				font = JBUI.Fonts.label(14f).asBold()
+			})
 		})
 		add(Box.createVerticalStrut(4))
 		add(JBLabel(
@@ -114,6 +116,9 @@ class OnboardingPanel(
 			icon = JolliMemoryIcons.Key,
 			title = "Use your Anthropic API key",
 			description = "Connect your own Anthropic API key for AI summarization. Memories are stored locally only.",
+			helpTooltip = "Don't have one?",
+			helpLinkText = "Create one at console.anthropic.com",
+			helpLinkUrl = "https://console.anthropic.com/",
 		)
 		section.add(card)
 		section.add(Box.createVerticalStrut(8))
@@ -267,7 +272,7 @@ class OnboardingPanel(
 		)
 	}
 
-	private fun createOptionCard(icon: javax.swing.Icon, title: String, description: String): JPanel = object : JPanel() {
+	private fun createOptionCard(icon: javax.swing.Icon, title: String, description: String, helpTooltip: String? = null, helpLinkText: String? = null, helpLinkUrl: String? = null): JPanel = object : JPanel() {
 		init { isOpaque = false }
 		override fun paintComponent(g: java.awt.Graphics) {
 			val g2 = g.create() as java.awt.Graphics2D
@@ -291,7 +296,20 @@ class OnboardingPanel(
 		add(JPanel().apply {
 			layout = BoxLayout(this, BoxLayout.Y_AXIS)
 			isOpaque = false
-			add(JBLabel("<html><b>$title</b></html>").apply { alignmentX = Component.LEFT_ALIGNMENT })
+			add(JPanel(FlowLayout(FlowLayout.LEFT, 4, 0)).apply {
+				isOpaque = false
+				alignmentX = Component.LEFT_ALIGNMENT
+				add(JBLabel("<html><b>$title</b></html>"))
+				if (helpTooltip != null) {
+					if (helpLinkText != null && helpLinkUrl != null) {
+						add(com.intellij.ui.ContextHelpLabel.createWithLink(null, helpTooltip, helpLinkText) {
+							com.intellij.ide.BrowserUtil.browse(helpLinkUrl)
+						})
+					} else {
+						add(com.intellij.ui.ContextHelpLabel.create(helpTooltip))
+					}
+				}
+			})
 			add(Box.createVerticalStrut(2))
 			add(JBLabel("<html><span style='color:gray'>$description</span></html>").apply {
 				alignmentX = Component.LEFT_ALIGNMENT


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## E2E Test (2)
<details>
<summary><strong>1. API key help tooltip appears on onboarding card</strong></summary>
<br>
<blockquote>

**Preconditions:** The plugin must not yet be configured so the onboarding screen is visible when the tool window opens.

**Steps:**
1. Open the JolliMemory tool window in your IDE.
2. Locate the card titled "Use your Anthropic API key".
3. Find the small "?" circle icon next to the card title.
4. Hover your mouse over the "?" icon.
5. Click the link that appears inside the tooltip.

**Expected Results:**
- A small "?" circle icon is visible directly beside the "Use your Anthropic API key" title.
- Hovering over the icon shows a tooltip containing the text "Don't have one?" and a clickable link labelled "Create one at console.anthropic.com".
- Clicking the link opens your default web browser and navigates to https://console.anthropic.com/.

</blockquote>
</details>
<details>
<summary><strong>2. Onboarding header text scales with IDE zoom level</strong></summary>
<br>
<blockquote>

**Preconditions:** The plugin must not yet be configured so the onboarding screen is visible. You will need to be able to change the IDE font size or zoom setting (found in Settings → Appearance & Behavior → Appearance).

**Steps:**
1. Open the JolliMemory tool window and note how large the "Get started with Jolli Memory" heading looks.
2. Open IDE Settings, go to Appearance & Behavior → Appearance, and increase the IDE font size by a few points, then click OK.
3. Return to the JolliMemory tool window and check the heading again.
4. Repeat step 2 but decrease the font size below the original value, then check the heading once more.

**Expected Results:**
- The "Get started with Jolli Memory" heading grows visibly larger when the IDE font size is increased.
- The heading shrinks visibly when the IDE font size is decreased.
- At every zoom level the heading text remains bold and clearly readable, with no clipping or overflow.

</blockquote>
</details>

---

## Topics (3)
<details>
<summary><strong>01 · Add API key help tooltip with link to Anthropic console</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The API key onboarding card had no guidance for users who don't yet have an Anthropic API key.

**💡 Decisions Behind the Code**

Used IntelliJ's `ContextHelpLabel.createWithLink()` rather than a custom tooltip or inline hyperlink so the UI matches platform conventions and handles accessibility/styling automatically. The parameters were made nullable with defaults so existing callers of `createOptionCard()` require no changes.

**✅ What Was Implemented**

Added `helpTooltip`, `helpLinkText`, and `helpLinkUrl` optional parameters to `createOptionCard()`. The API key card now renders a `ContextHelpLabel.createWithLink()` (`?` circle) beside the card title, with tooltip text "Don't have one?" and a clickable link opening `https://console.anthropic.com/` via `BrowserUtil.browse()`.

**📁 FILES**
- `intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/OnboardingPanel.kt`

</blockquote>
</details>
<details>
<summary><strong>02 · Fix onboarding header font to respect IDE zoom settings</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The "Get started with Jolli Memory" header used an HTML `font-size:14pt` inline style, which is hardcoded and does not scale with IDE font size or zoom level.

**💡 Decisions Behind the Code**

`JBUI.Fonts.label()` is the IntelliJ-idiomatic way to derive scaled fonts; it integrates with the IDE's HiDPI and accessibility zoom pipeline, whereas hardcoded HTML pt sizes bypass that entirely.

**✅ What Was Implemented**

Replaced the HTML `<b style='font-size:14pt'>` label with a plain `JBLabel` whose font is set to `JBUI.Fonts.label(14f).asBold()`, which is DPI- and zoom-aware.

**📁 FILES**
- `intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/OnboardingPanel.kt`

</blockquote>
</details>
<details>
<summary><strong>03 · Recover from accidental amend that mixed unrelated changes into one commit</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

OnboardingPanel changes were accidentally folded into an unrelated commit ("review: address PR feedback") via `git commit --amend`, creating a mixed commit that could cause merge conflicts or confusing history when merging to main.

**💡 Decisions Behind the Code**

A hard reset back to the pre-amend state was chosen over splitting the commit (soft reset + selective restage) because the developer was uncertain whether the split approach would introduce merge issues later. Starting clean eliminated that ambiguity at the cost of manually reapplying two small changes.

**✅ What Was Implemented**

Hard-reset the branch to `c5ed83c` (the state before the accidental amend), discarding the mixed commit entirely, then reapplied the OnboardingPanel changes as a clean separate commit.

**📁 FILES**
- `intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/OnboardingPanel.kt`

</blockquote>
</details>

---

*Generated by JolliMemory · May 8, 2026 at 11:57 AM*
<!-- jollimemory-summary-end -->