### PR TITLE
Refactor jolli-recall to use structured citations and free-form output

### DIFF
--- a/cli/src/Cli.test.ts
+++ b/cli/src/Cli.test.ts
@@ -167,7 +167,32 @@ vi.mock("./core/ContextCompiler.js", () => ({
 	}),
 	listBranchCatalog: vi.fn().mockResolvedValue({ type: "catalog", branches: [] }),
 	renderContextMarkdown: vi.fn().mockReturnValue("# Task Context: feature/test\n"),
-	DEFAULT_TOKEN_BUDGET: 30000,
+	buildRecallPayload: vi.fn().mockReturnValue({
+		type: "recall",
+		branch: "feature/test",
+		period: { start: "2026-03-28T10:00:00.000Z", end: "2026-03-28T10:00:00.000Z" },
+		commitCount: 0,
+		totalFilesChanged: 0,
+		totalInsertions: 0,
+		totalDeletions: 0,
+		commits: [],
+		plans: [],
+		notes: [],
+		stats: {
+			topicCount: 0,
+			planCount: 0,
+			noteCount: 0,
+			decisionCount: 0,
+			topicTokens: 0,
+			planTokens: 0,
+			noteTokens: 0,
+			decisionTokens: 0,
+			transcriptTokens: 0,
+			totalTokens: 0,
+		},
+		estimatedTokens: 0,
+	}),
+	DEFAULT_TOKEN_BUDGET: 50000,
 }));
 
 // Suppress console output

--- a/cli/src/commands/RecallCommand.ts
+++ b/cli/src/commands/RecallCommand.ts
@@ -16,8 +16,9 @@ import { execFileSync } from "node:child_process";
 import { mkdir, writeFile } from "node:fs/promises";
 import { dirname } from "node:path";
 import { type Command, Option } from "commander";
-import type { BranchCatalog, ContextOutput } from "../core/ContextCompiler.js";
+import type { BranchCatalog } from "../core/ContextCompiler.js";
 import {
+	buildRecallPayload,
 	compileTaskContext,
 	DEFAULT_TOKEN_BUDGET,
 	listBranchCatalog,
@@ -212,15 +213,13 @@ async function outputRecall(
 		return;
 	}
 
-	// Output path 2: --format json -> full JSON for skill/agent consumption
+	// Output path 2: --format json -> structured RecallPayload for skill/agent
+	// consumption. The skill template's LLM does its own grounded synthesis
+	// from the structured fields; we deliberately do NOT pre-render markdown
+	// here (it would tempt the LLM back into paraphrase mode).
 	if (options.format === "json") {
-		const markdown = renderContextMarkdown(ctx, options.budget ?? DEFAULT_TOKEN_BUDGET);
-		const output: ContextOutput = {
-			type: "recall",
-			stats: ctx.stats,
-			renderedMarkdown: markdown,
-		};
-		console.log(JSON.stringify(output, null, 2));
+		const payload = buildRecallPayload(ctx, options.budget ?? DEFAULT_TOKEN_BUDGET);
+		console.log(JSON.stringify(payload, null, 2));
 		return;
 	}
 

--- a/cli/src/core/ContextCompiler.test.ts
+++ b/cli/src/core/ContextCompiler.test.ts
@@ -1,6 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { CommitSummary, SummaryIndex } from "../Types.js";
-import { compileTaskContext, estimateTokens, listBranchCatalog, renderContextMarkdown } from "./ContextCompiler.js";
+import {
+	buildRecallPayload,
+	type CompiledContext,
+	compileTaskContext,
+	estimateTokens,
+	listBranchCatalog,
+	renderContextMarkdown,
+} from "./ContextCompiler.js";
 
 // ─── Mocks ───────────────────────────────────────────────────────────────────
 
@@ -1126,5 +1133,619 @@ describe("compileTaskContext — additional coverage", () => {
 
 		const ctx = await compileTaskContext({ branch: "feature/test" }, "/test");
 		expect(ctx.commitCount).toBe(1);
+	});
+});
+
+// ─── buildRecallPayload ──────────────────────────────────────────────────────
+
+describe("buildRecallPayload", () => {
+	function makeCtx(overrides: Partial<CompiledContext> = {}): CompiledContext {
+		return {
+			branch: "feature/test",
+			period: { start: "2026-03-01", end: "2026-03-15" },
+			commitCount: 1,
+			totalFilesChanged: 3,
+			totalInsertions: 100,
+			totalDeletions: 20,
+			summaries: [makeSummary()],
+			plans: [],
+			notes: [],
+			keyDecisions: [],
+			stats: {
+				topicCount: 1,
+				planCount: 0,
+				noteCount: 0,
+				decisionCount: 0,
+				topicTokens: 50,
+				planTokens: 0,
+				noteTokens: 0,
+				decisionTokens: 0,
+				transcriptTokens: 0,
+				totalTokens: 50,
+			},
+			...overrides,
+		};
+	}
+
+	it("projects each summary into a SearchHit and ships full payload at wide budget", () => {
+		const payload = buildRecallPayload(makeCtx(), 100_000);
+		expect(payload.type).toBe("recall");
+		expect(payload.commits).toHaveLength(1);
+		expect(payload.commits[0].fullHash).toBe("abc12345def67890");
+		expect(payload.commits[0].topics[0].decisions).toBe("Used factory pattern for extensibility");
+		expect(payload.truncated).toBeUndefined();
+	});
+
+	it("ships plans and notes top-level with content when budget allows", () => {
+		const payload = buildRecallPayload(
+			makeCtx({
+				plans: [{ slug: "p1", title: "P1", content: "plan body" }],
+				notes: [{ id: "n1", title: "N1", content: "note body" }],
+			}),
+			100_000,
+		);
+		expect(payload.plans[0]).toEqual({ slug: "p1", title: "P1", content: "plan body" });
+		expect(payload.notes[0]).toEqual({ id: "n1", title: "N1", content: "note body" });
+	});
+
+	it("under tight budget drops topic.response first (preserves trigger and decisions)", () => {
+		// Build a 4-commit ctx where the response field carries most of the bytes.
+		const summaries = [1, 2, 3, 4].map((i) =>
+			makeSummary({
+				commitHash: `aaaaaaaa00000000000000000000000000000000${i}`.slice(0, 40),
+				topics: [
+					{
+						title: `T${i}`,
+						trigger: `trig-${i}`,
+						response: "X".repeat(2000),
+						decisions: `dec-${i}`,
+					},
+				],
+			}),
+		);
+		const payload = buildRecallPayload(makeCtx({ summaries, commitCount: 4 }), 1500);
+		expect(payload.truncated).toBe(true);
+		// Older commits should have lost response first; decisions stays.
+		const oldest = payload.commits[0];
+		expect(oldest.topics[0].response).toBeUndefined();
+		expect(oldest.topics[0].decisions).toBeDefined();
+	});
+
+	it("escalates to dropping topic.trigger after response is gone", () => {
+		const summaries = [1, 2].map((i) =>
+			makeSummary({
+				commitHash: `bbbbbbbb00000000000000000000000000000000${i}`.slice(0, 40),
+				topics: [
+					{
+						title: `T${i}`,
+						trigger: "Y".repeat(1500),
+						response: "X".repeat(1500),
+						decisions: `dec-${i}`,
+					},
+				],
+			}),
+		);
+		const payload = buildRecallPayload(makeCtx({ summaries, commitCount: 2 }), 600);
+		expect(payload.truncated).toBe(true);
+		const oldest = payload.commits[0];
+		// Both verbose fields are gone; decisions remains.
+		expect(oldest.topics[0].response).toBeUndefined();
+		expect(oldest.topics[0].trigger).toBeUndefined();
+		expect(oldest.topics[0].decisions).toBeDefined();
+	});
+
+	it("drops plans[].content (keeps slug + title) before evicting commits", () => {
+		const payload = buildRecallPayload(
+			makeCtx({
+				plans: [{ slug: "p1", title: "P1", content: "Z".repeat(4000) }],
+			}),
+			500,
+		);
+		expect(payload.truncated).toBe(true);
+		// Plan entry survives as a citation anchor without content.
+		expect(payload.plans).toHaveLength(1);
+		expect(payload.plans[0]).toEqual({ slug: "p1", title: "P1" });
+	});
+
+	it("drops notes[].content (keeps id + title) under similar pressure", () => {
+		const payload = buildRecallPayload(
+			makeCtx({
+				notes: [{ id: "n1", title: "N1", content: "Z".repeat(4000) }],
+			}),
+			500,
+		);
+		expect(payload.truncated).toBe(true);
+		expect(payload.notes).toHaveLength(1);
+		expect(payload.notes[0]).toEqual({ id: "n1", title: "N1" });
+	});
+
+	it("evicts oldest commits wholesale when budget can't fit decisions", () => {
+		// Make every commit's decisions field huge so trim steps 1-4 don't help.
+		const summaries = [1, 2, 3].map((i) =>
+			makeSummary({
+				commitHash: `cccccccc00000000000000000000000000000000${i}`.slice(0, 40),
+				topics: [
+					{
+						title: `T${i}`,
+						trigger: `t${i}`,
+						response: `r${i}`,
+						decisions: "D".repeat(2000),
+					},
+				],
+			}),
+		);
+		const payload = buildRecallPayload(makeCtx({ summaries, commitCount: 3 }), 1200);
+		expect(payload.truncated).toBe(true);
+		expect(payload.commits.length).toBeLessThan(3);
+		// Every kept commit still has decisions on every topic — type contract honored.
+		for (const hit of payload.commits) {
+			for (const t of hit.topics) {
+				expect(t.decisions).toBeDefined();
+			}
+		}
+	});
+
+	// Coverage for the defensive early-return inside the response/trigger trim
+	// loops: when buildHit projection emits a topic without response/trigger
+	// (e.g. corrupt input where TopicSummary.response is missing), the trim step
+	// must skip it instead of double-counting `truncated`.
+	it("skips topics that already lack response when trim Step 1 runs", () => {
+		// Craft a summary whose topic genuinely lacks response/trigger by casting.
+		// buildHit's conditional spread propagates the absence to the SearchHit.
+		const summary = makeSummary({
+			commitHash: "ffffffff00000000000000000000000000000000",
+			topics: [
+				{
+					title: "T1",
+					// biome-ignore lint/suspicious/noExplicitAny: deliberately omitting required field for trim coverage
+					trigger: undefined as any,
+					// biome-ignore lint/suspicious/noExplicitAny: deliberately omitting required field for trim coverage
+					response: undefined as any,
+					decisions: "D".repeat(8000),
+				},
+				{ title: "T2", trigger: "tt", response: "X".repeat(8000), decisions: "dd" },
+			],
+		});
+		const payload = buildRecallPayload(makeCtx({ summaries: [summary], commitCount: 1 }), 2500);
+		expect(payload.truncated).toBe(true);
+		expect(payload.commits).toHaveLength(1);
+		// T2's response was the long field — it should be the one stripped, while
+		// T1 (which had no response in the first place) is left alone (early-return).
+		expect(payload.commits[0].topics[0].response).toBeUndefined();
+		expect(payload.commits[0].topics[1].response).toBeUndefined();
+	});
+
+	it("skips topics that already lack trigger when trim Step 2 runs", () => {
+		// Force both Step 1 and Step 2 to fire on the same commit. Topic 1 has no
+		// trigger, so Step 2's early-return branch fires for it; topic 2's
+		// trigger is the long field that must be stripped to fit budget.
+		const summary = makeSummary({
+			commitHash: "ffffeeee00000000000000000000000000000000",
+			topics: [
+				{
+					title: "T1",
+					// biome-ignore lint/suspicious/noExplicitAny: deliberately omitting required field for trim coverage
+					trigger: undefined as any,
+					response: "X".repeat(8000),
+					decisions: "A".repeat(1500),
+				},
+				{
+					title: "T2",
+					trigger: "B".repeat(2000),
+					response: "Y".repeat(8000),
+					decisions: "A".repeat(1500),
+				},
+			],
+		});
+		// Budget chosen so Step 1 (drop response) leaves us still over budget,
+		// forcing Step 2 (drop trigger) to fire.
+		const payload = buildRecallPayload(makeCtx({ summaries: [summary], commitCount: 1 }), 1100);
+		expect(payload.truncated).toBe(true);
+		expect(payload.commits).toHaveLength(1);
+		expect(payload.commits[0].topics[0].response).toBeUndefined();
+		expect(payload.commits[0].topics[1].response).toBeUndefined();
+		expect(payload.commits[0].topics[0].trigger).toBeUndefined();
+		expect(payload.commits[0].topics[1].trigger).toBeUndefined();
+	});
+
+	// Same defensive guard for the plan/note content trim steps. When a plan
+	// arrives without content (e.g. the orphan branch read returned empty),
+	// the trim step must skip it without flipping `truncated` for nothing.
+	it("skips plans/notes that already lack content when trim Step 3/4 runs", () => {
+		// Build a heavy ctx so we deterministically reach steps 3 and 4. Mix one
+		// content-bearing plan with one already-empty plan; same for notes.
+		const summary = makeSummary({
+			commitHash: "ffffffff10000000000000000000000000000000",
+			topics: [{ title: "T", trigger: "t", response: "r", decisions: "d" }],
+		});
+		const payload = buildRecallPayload(
+			makeCtx({
+				summaries: [summary],
+				commitCount: 1,
+				plans: [
+					{ slug: "p1", title: "P1", content: "Z".repeat(2000) },
+					// biome-ignore lint/suspicious/noExplicitAny: deliberately omitting content for trim coverage
+					{ slug: "p2", title: "P2", content: undefined as any },
+				],
+				notes: [
+					{ id: "n1", title: "N1", content: "Y".repeat(2000) },
+					// biome-ignore lint/suspicious/noExplicitAny: deliberately omitting content for trim coverage
+					{ id: "n2", title: "N2", content: undefined as any },
+				],
+			}),
+			500,
+		);
+		expect(payload.truncated).toBe(true);
+		// Both plans survive, both with content stripped (p2 was already absent).
+		expect(payload.plans).toHaveLength(2);
+		expect(payload.plans.find((p) => p.slug === "p1")?.content).toBeUndefined();
+		expect(payload.plans.find((p) => p.slug === "p2")?.content).toBeUndefined();
+		// Same for notes.
+		expect(payload.notes).toHaveLength(2);
+		expect(payload.notes.find((n) => n.id === "n1")?.content).toBeUndefined();
+		expect(payload.notes.find((n) => n.id === "n2")?.content).toBeUndefined();
+	});
+
+	// Pathological budgets used to evict every commit, leaving the ambiguous
+	// `commits=[]` state. Step 5 now stops at one commit — the empty array
+	// is reserved for "genuinely no records", and the skill template can keep
+	// its empty-handling rule simple. Pathological budgets accept a minor
+	// overage (estimatedTokens > budget) instead.
+	it("evicts oldest commits but always keeps at least one (avoids commits=[] ambiguity)", () => {
+		const summaries = [1, 2].map((i) =>
+			makeSummary({
+				commitHash: `dddddddd00000000000000000000000000000000${i}`.slice(0, 40),
+				topics: [{ title: `T${i}`, trigger: "t", response: "r", decisions: "D".repeat(1500) }],
+			}),
+		);
+		const payload = buildRecallPayload(makeCtx({ summaries, commitCount: 2 }), 50);
+		expect(payload.truncated).toBe(true);
+		// One commit kept (the most recent) — the older one is evicted.
+		expect(payload.commits).toHaveLength(1);
+		// Pathological budget: payload exceeds it. Truncation is signaled but
+		// the LLM still gets meaningful data instead of a misleading empty array.
+		expect(payload.estimatedTokens).toBeGreaterThan(50);
+	});
+
+	it("guarantees commits=[] iff commitCount=0 (empty-state invariant)", () => {
+		// Branch with no records at all → ctx.summaries empty → commits=[].
+		const empty = buildRecallPayload(makeCtx({ summaries: [], commitCount: 0 }), 100_000);
+		expect(empty.commits).toHaveLength(0);
+		expect(empty.commitCount).toBe(0);
+
+		// Branch with records but pathological budget → commits=[1], not [].
+		const tight = buildRecallPayload(
+			makeCtx({
+				summaries: [makeSummary({ topics: [{ title: "T", trigger: "t", response: "r", decisions: "D" }] })],
+				commitCount: 1,
+			}),
+			1,
+		);
+		expect(tight.commits.length).toBeGreaterThanOrEqual(1);
+		expect(tight.commitCount).toBe(1);
+	});
+
+	it("uses default DEFAULT_TOKEN_BUDGET (50K) when no budget is passed", () => {
+		const payload = buildRecallPayload(makeCtx());
+		// Default 50K easily fits a 1-commit fixture; nothing is truncated.
+		expect(payload.truncated).toBeUndefined();
+		expect(payload.commits).toHaveLength(1);
+	});
+
+	it("sets estimatedTokens to a positive number reflecting payload size", () => {
+		const payload = buildRecallPayload(makeCtx());
+		expect(payload.estimatedTokens).toBeGreaterThan(0);
+	});
+
+	// Stubs on commits must always resolve to a top-level entry. When a
+	// summary references a plan whose body couldn't be loaded (orphan-branch
+	// miss), the stub on the commit must be filtered out so the contract holds.
+	it("filters out plan stubs whose body did not load (no dangling stub)", () => {
+		const summary = makeSummary({
+			commitHash: "ee00000000000000000000000000000000000000",
+			plans: [
+				{
+					slug: "live-plan",
+					title: "Live",
+					editCount: 1,
+					addedAt: "2026-01-01",
+					updatedAt: "2026-01-01",
+				},
+				{
+					slug: "missing-plan",
+					title: "Missing",
+					editCount: 1,
+					addedAt: "2026-01-01",
+					updatedAt: "2026-01-01",
+				},
+			],
+		});
+		// ctx.plans only contains the resolved one — simulates readPlanFromBranch
+		// returning null for "missing-plan".
+		const payload = buildRecallPayload(
+			makeCtx({
+				summaries: [summary],
+				plans: [{ slug: "live-plan", title: "Live", content: "live body" }],
+			}),
+			100_000,
+		);
+		// Top-level has only the loaded plan.
+		expect(payload.plans.map((p) => p.slug)).toEqual(["live-plan"]);
+		// Commit's plan stubs are filtered to only the live one — no dangling stub.
+		expect(payload.commits[0].plans).toEqual([{ slug: "live-plan", title: "Live" }]);
+	});
+
+	it("filters out note stubs whose body did not load", () => {
+		const summary = makeSummary({
+			commitHash: "ee10000000000000000000000000000000000000",
+			notes: [
+				{ id: "live-note", title: "Live", format: "markdown", addedAt: "2026-01-01", updatedAt: "2026-01-01" },
+				{
+					id: "missing-note",
+					title: "Missing",
+					format: "markdown",
+					addedAt: "2026-01-01",
+					updatedAt: "2026-01-01",
+				},
+			],
+		});
+		const payload = buildRecallPayload(
+			makeCtx({
+				summaries: [summary],
+				notes: [{ id: "live-note", title: "Live", content: "live body" }],
+			}),
+			100_000,
+		);
+		expect(payload.notes.map((n) => n.id)).toEqual(["live-note"]);
+		expect(payload.commits[0].notes).toEqual([{ id: "live-note", title: "Live" }]);
+	});
+
+	it("strips ALL plan stubs when --no-plans leaves the top-level array empty", () => {
+		const summary = makeSummary({
+			commitHash: "ee20000000000000000000000000000000000000",
+			plans: [
+				{
+					slug: "p1",
+					title: "P1",
+					editCount: 1,
+					addedAt: "2026-01-01",
+					updatedAt: "2026-01-01",
+				},
+			],
+		});
+		const payload = buildRecallPayload(makeCtx({ summaries: [summary], plans: [] }), 100_000);
+		// No top-level entries → no commit stubs at all (the field is dropped).
+		expect(payload.plans).toEqual([]);
+		expect(payload.commits[0].plans).toBeUndefined();
+	});
+
+	it("strips ALL note stubs when --no-notes leaves the top-level array empty", () => {
+		const summary = makeSummary({
+			commitHash: "ee30000000000000000000000000000000000000",
+			notes: [{ id: "n1", title: "N1", format: "markdown", addedAt: "2026-01-01", updatedAt: "2026-01-01" }],
+		});
+		const payload = buildRecallPayload(makeCtx({ summaries: [summary], notes: [] }), 100_000);
+		expect(payload.notes).toEqual([]);
+		expect(payload.commits[0].notes).toBeUndefined();
+	});
+
+	// estimatedTokens / measure() must reflect the FULL JSON output, including
+	// the envelope (type/branch/period/stats/...) — not just commits/plans/notes.
+	// Otherwise tight budgets get a meaningfully under-counted figure.
+	it("estimatedTokens accounts for the envelope, not just commits/plans/notes", () => {
+		const payload = buildRecallPayload(makeCtx());
+		// The reported estimate should be at least as large as the bare commit
+		// JSON's tokens (envelope adds non-zero cost on top).
+		const justCommits = JSON.stringify(payload.commits);
+		// estimateTokens is char-len/4 for ASCII; envelope is ~150 chars → ~38
+		// extra tokens. Verify the gap so we know the envelope is in the count.
+		const bareLen = Math.max(1, Math.floor(justCommits.length / 4));
+		expect(payload.estimatedTokens).toBeGreaterThan(bareLen);
+	});
+
+	it("preserves branch-level aggregates verbatim", () => {
+		const payload = buildRecallPayload(
+			makeCtx({
+				branch: "feature/x",
+				commitCount: 7,
+				totalFilesChanged: 24,
+				totalInsertions: 312,
+				totalDeletions: 89,
+				period: { start: "2026-04-10", end: "2026-04-15" },
+			}),
+		);
+		expect(payload.branch).toBe("feature/x");
+		expect(payload.commitCount).toBe(7);
+		expect(payload.totalFilesChanged).toBe(24);
+		expect(payload.totalInsertions).toBe(312);
+		expect(payload.totalDeletions).toBe(89);
+		expect(payload.period).toEqual({ start: "2026-04-10", end: "2026-04-15" });
+	});
+});
+
+// ─── compileTaskContext: plan/note recursion + base-slug normalization ──────
+
+describe("compileTaskContext — recursive plan/note collection", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("collects plans referenced from nested children (v3 legacy data)", async () => {
+		mockGetIndex.mockResolvedValueOnce(
+			makeIndex([
+				{
+					commitHash: "rootroot12345678",
+					parentCommitHash: null,
+					commitMessage: "root",
+					commitDate: "2026-03-28T10:00:00Z",
+					branch: "feature/test",
+					generatedAt: "2026-03-28T10:01:00Z",
+				},
+			]),
+		);
+		mockGetSummary.mockResolvedValue(
+			makeSummary({
+				commitHash: "rootroot12345678",
+				plans: undefined,
+				children: [
+					makeSummary({
+						commitHash: "childchild0011223344",
+						plans: [
+							{
+								slug: "nested-plan",
+								title: "Nested Plan",
+								editCount: 1,
+								addedAt: "2026-03-28",
+								updatedAt: "2026-03-28",
+							},
+						],
+					}),
+				],
+			}),
+		);
+		mockReadPlan.mockResolvedValueOnce("nested plan content");
+
+		const ctx = await compileTaskContext({ branch: "feature/test" }, "/test");
+		expect(ctx.plans).toHaveLength(1);
+		expect(ctx.plans[0].slug).toBe("nested-plan");
+		expect(ctx.plans[0].content).toBe("nested plan content");
+	});
+
+	it("collects notes referenced from nested children", async () => {
+		mockGetIndex.mockResolvedValueOnce(
+			makeIndex([
+				{
+					commitHash: "rootroot12345678",
+					parentCommitHash: null,
+					commitMessage: "root",
+					commitDate: "2026-03-28T10:00:00Z",
+					branch: "feature/test",
+					generatedAt: "2026-03-28T10:01:00Z",
+				},
+			]),
+		);
+		mockGetSummary.mockResolvedValue(
+			makeSummary({
+				commitHash: "rootroot12345678",
+				notes: undefined,
+				children: [
+					makeSummary({
+						commitHash: "childchild0011223344",
+						notes: [
+							{
+								id: "nested-note",
+								title: "Nested Note",
+								format: "markdown",
+								addedAt: "2026-03-28",
+								updatedAt: "2026-03-28",
+							},
+						],
+					}),
+				],
+			}),
+		);
+		mockReadNote.mockResolvedValueOnce("nested note content");
+
+		const ctx = await compileTaskContext({ branch: "feature/test" }, "/test");
+		expect(ctx.notes).toHaveLength(1);
+		expect(ctx.notes[0].id).toBe("nested-note");
+		expect(ctx.notes[0].content).toBe("nested note content");
+	});
+
+	it("normalizes plan slug to base slug when archive suffix is present", async () => {
+		// Commit hash starts with "06d0f729..."; plan slug ends with the same
+		// 8-char prefix. Top-level plans entry should expose the base slug.
+		mockGetIndex.mockResolvedValueOnce(
+			makeIndex([
+				{
+					commitHash: "06d0f7299912345abcdef0123456789abcdef012",
+					parentCommitHash: null,
+					commitMessage: "archived",
+					commitDate: "2026-03-28T10:00:00Z",
+					branch: "feature/test",
+					generatedAt: "2026-03-28T10:01:00Z",
+				},
+			]),
+		);
+		mockGetSummary.mockResolvedValue(
+			makeSummary({
+				commitHash: "06d0f7299912345abcdef0123456789abcdef012",
+				plans: [
+					{
+						slug: "auth-redesign-06d0f729",
+						title: "Auth Redesign",
+						editCount: 1,
+						addedAt: "2026-03-28",
+						updatedAt: "2026-03-28",
+					},
+				],
+			}),
+		);
+		mockReadPlan.mockResolvedValueOnce("plan body");
+
+		const ctx = await compileTaskContext({ branch: "feature/test" }, "/test");
+		expect(ctx.plans).toHaveLength(1);
+		// Top-level slug is the canonical base form.
+		expect(ctx.plans[0].slug).toBe("auth-redesign");
+		// Reading the body still goes through the original (archived) path.
+		expect(mockReadPlan).toHaveBeenCalledWith("auth-redesign-06d0f729", "/test");
+	});
+
+	it("dedupes the same logical plan across pre-archive and post-archive commits", async () => {
+		mockGetIndex.mockResolvedValueOnce(
+			makeIndex([
+				{
+					commitHash: "preeeeee0011223344556677889900112233445566",
+					parentCommitHash: null,
+					commitMessage: "pre",
+					commitDate: "2026-03-27T10:00:00Z",
+					branch: "feature/test",
+					generatedAt: "2026-03-27T10:00:00Z",
+				},
+				{
+					commitHash: "06d0f7299912345abcdef0123456789abcdef012",
+					parentCommitHash: null,
+					commitMessage: "post",
+					commitDate: "2026-03-28T10:00:00Z",
+					branch: "feature/test",
+					generatedAt: "2026-03-28T10:00:00Z",
+				},
+			]),
+		);
+		mockGetSummary.mockImplementation(async (hash: string) => {
+			if (hash === "preeeeee0011223344556677889900112233445566") {
+				return makeSummary({
+					commitHash: "preeeeee0011223344556677889900112233445566",
+					plans: [
+						{
+							slug: "auth-redesign",
+							title: "Auth Redesign",
+							editCount: 1,
+							addedAt: "2026-03-26",
+							updatedAt: "2026-03-26",
+						},
+					],
+				});
+			}
+			return makeSummary({
+				commitHash: "06d0f7299912345abcdef0123456789abcdef012",
+				plans: [
+					{
+						slug: "auth-redesign-06d0f729",
+						title: "Auth Redesign",
+						editCount: 1,
+						addedAt: "2026-03-26",
+						updatedAt: "2026-03-28",
+					},
+				],
+			});
+		});
+		mockReadPlan.mockResolvedValue("plan body");
+
+		const ctx = await compileTaskContext({ branch: "feature/test" }, "/test");
+		// Both commits referenced the same logical plan — dedup yields one entry,
+		// keyed by base slug.
+		expect(ctx.plans).toHaveLength(1);
+		expect(ctx.plans[0].slug).toBe("auth-redesign");
 	});
 });

--- a/cli/src/core/ContextCompiler.ts
+++ b/cli/src/core/ContextCompiler.ts
@@ -9,7 +9,10 @@
 
 import { createLogger } from "../Logger.js";
 import type { CommitSummary, SummaryIndexEntry } from "../Types.js";
-import { getDisplayDate } from "./SummaryFormat.js";
+import { extractBaseSlug } from "./PlanSlug.js";
+import type { SearchHit } from "./Search.js";
+import { collectAllNotesWithHosts, collectAllPlansWithHosts, getDisplayDate } from "./SummaryFormat.js";
+import { buildHit } from "./SummaryProjection.js";
 import {
 	getCatalogWithLazyBuild,
 	getIndex,
@@ -60,11 +63,54 @@ export interface CompiledContext {
 	readonly stats: ContextStats;
 }
 
-/** JSON output for SKILL.md (stats + rendered markdown, no raw data duplication) */
-export interface ContextOutput {
+/**
+ * Branch-scoped plan / note body shipped at the top of {@link RecallPayload}.
+ *
+ * `slug` (plan) / `id` (note) is the **canonical key** also used by every
+ * matching {@link SearchHit.plans}/`notes` stub on `commits[]`, so a stub-to-body
+ * lookup never fails for a kept commit.
+ *
+ * `content` may be omitted when budget enforcement strips bodies in the order
+ * documented at {@link buildRecallPayload}. The slug+title pair still serves
+ * as a citation anchor when content is absent.
+ */
+export interface RecallPayloadPlan {
+	readonly slug: string;
+	readonly title: string;
+	readonly content?: string;
+}
+export interface RecallPayloadNote {
+	readonly id: string;
+	readonly title: string;
+	readonly content?: string;
+}
+
+/**
+ * Structured output of `jolli recall --format json`.
+ *
+ * Replaces the prior `ContextOutput` (which shipped a single pre-rendered
+ * markdown blob). The shift to structured fields is the same data discipline
+ * that jolli-search already validated: the skill-template LLM produces a
+ * grounded, citation-anchored answer instead of paraphrasing a markdown blob.
+ */
+export interface RecallPayload {
 	readonly type: "recall";
+	readonly branch: string;
+	readonly period: { readonly start: string; readonly end: string };
+	readonly commitCount: number;
+	readonly totalFilesChanged: number;
+	readonly totalInsertions: number;
+	readonly totalDeletions: number;
+	/** Per-commit projection — same shape jolli-search ships from Phase 2. */
+	readonly commits: ReadonlyArray<SearchHit>;
+	/** Branch-scoped, deduplicated plan bodies. Slug is the canonical base slug. */
+	readonly plans: ReadonlyArray<RecallPayloadPlan>;
+	/** Branch-scoped, deduplicated note bodies. Id is the canonical key. */
+	readonly notes: ReadonlyArray<RecallPayloadNote>;
 	readonly stats: ContextStats;
-	readonly renderedMarkdown: string;
+	readonly estimatedTokens: number;
+	/** Set when budget enforcement removed at least one field (or commit). */
+	readonly truncated?: boolean;
 }
 
 export interface BranchCatalogEntry {
@@ -181,60 +227,77 @@ export async function listBranchCatalog(cwd?: string): Promise<BranchCatalog> {
 	return { type: "catalog", branches };
 }
 
-// ─── Plan deduplication ──────────────────────────────────────────────────────
+// ─── Plan / note collection ──────────────────────────────────────────────────
 
+/**
+ * Per-summary plan candidate enriched with the host commit's hash. The host
+ * hash is the commit (root or nested child) where the reference lives — used
+ * by {@link extractBaseSlug} to peel any `-<shortHash>` archive suffix.
+ */
 interface PlanCandidate {
-	readonly slug: string;
+	readonly originalSlug: string;
+	readonly baseSlug: string;
 	readonly title: string;
-	readonly commitHash: string;
+	readonly hostCommitHash: string;
+	/** Activity date carried by the summary that owned this candidate. */
 	readonly commitDate: string;
 	readonly generatedAt: string;
 }
 
 /**
- * Deduplicates plan references by base slug.
- * Archived plans have slug format "base-slug-<shortHash>". We extract the base
- * by cross-validating the trailing hash against the actual commit's shortHash.
+ * Collects plan references across the whole tree (root + nested children) of
+ * each summary, computing the canonical **base slug** for each via
+ * {@link extractBaseSlug}. Recursion mirrors what {@link buildHit} does for
+ * SearchHit stubs, so a plan referenced from a v3-legacy nested child surfaces
+ * in both the SearchHit stub list AND the top-level payload — a stub never
+ * dangles.
+ */
+function collectPlanCandidates(summaries: ReadonlyArray<CommitSummary>): ReadonlyArray<PlanCandidate> {
+	const out: PlanCandidate[] = [];
+	for (const summary of summaries) {
+		for (const { planRef, hostCommitHash } of collectAllPlansWithHosts(summary)) {
+			out.push({
+				originalSlug: planRef.slug,
+				baseSlug: extractBaseSlug(planRef.slug, hostCommitHash),
+				title: planRef.title,
+				hostCommitHash,
+				commitDate: summary.commitDate,
+				generatedAt: summary.generatedAt,
+			});
+		}
+	}
+	return out;
+}
+
+/**
+ * Deduplicates plan candidates by canonical **base slug**, keeping the one
+ * with the latest activity per group.
  *
- * When the same plan appears in multiple commits, keep the one with the latest
- * activity (see {@link getDisplayDate}) — that's the user's most recent
- * edit/amend of the plan reference.
+ * After this step, `payload.plans[].slug` (canonical) matches every
+ * `commits[].plans[].slug` stub on a 1:1 basis — the lookup never fails.
  */
 function deduplicatePlans(candidates: ReadonlyArray<PlanCandidate>): ReadonlyArray<PlanCandidate> {
 	const baseSlugMap = new Map<string, PlanCandidate>();
 
 	for (const plan of candidates) {
-		const baseSlug = extractBaseSlug(plan.slug, plan.commitHash);
-		const existing = baseSlugMap.get(baseSlug);
+		const existing = baseSlugMap.get(plan.baseSlug);
 		if (!existing || new Date(getDisplayDate(plan)).getTime() > new Date(getDisplayDate(existing)).getTime()) {
-			baseSlugMap.set(baseSlug, plan);
+			baseSlugMap.set(plan.baseSlug, plan);
 		}
 	}
 
 	return [...baseSlugMap.values()];
 }
 
-/**
- * Extracts the base slug from an archived slug by cross-validating the trailing
- * hash against the commit's actual short hash.
- */
-function extractBaseSlug(slug: string, commitHash: string): string {
-	const shortHash = commitHash.substring(0, 8);
-	if (slug.endsWith(`-${shortHash}`)) {
-		return slug.slice(0, -(shortHash.length + 1));
-	}
-	// Try 7-char hash too
-	const shortHash7 = commitHash.substring(0, 7);
-	if (slug.endsWith(`-${shortHash7}`)) {
-		return slug.slice(0, -(shortHash7.length + 1));
-	}
-	// No match — slug is the base
-	return slug;
-}
-
 // ─── Core compilation ────────────────────────────────────────────────────────
 
-export const DEFAULT_TOKEN_BUDGET = 30000;
+/**
+ * Default token budget for recall output (`jolli recall --format json` and
+ * `--full` markdown). 50K leaves ~75% of a 200K-context model free for the
+ * surrounding conversation; 1M-context models almost never trip the budget
+ * enforcement path. Users can override with `--budget <tokens>`.
+ */
+export const DEFAULT_TOKEN_BUDGET = 50000;
 
 /**
  * Compiles task context for a branch from Jolli Memory's orphan branch data.
@@ -296,54 +359,50 @@ export async function compileTaskContext(options: ContextOptions, cwd?: string):
 		}
 	}
 
-	// Step 6: Load and deduplicate plans
+	// Step 6: Load and deduplicate plans.
+	//
+	// Walk each summary tree (root + nested children) so v3-legacy / IntelliJ-
+	// squash data with plans stashed in children doesn't get silently dropped —
+	// matches the recursion in `buildHit`'s plan-stub projection so every stub
+	// resolves to a top-level plan entry. Slug is normalized to its canonical
+	// **base slug** (archive suffix peeled) so pre-archive and post-archive
+	// commits referencing the same plan collapse to one entry.
 	const plans: { slug: string; title: string; content: string }[] = [];
 	if (includePlans) {
-		const planCandidates: PlanCandidate[] = [];
-		for (const summary of summaries) {
-			if (summary.plans) {
-				for (const planRef of summary.plans) {
-					planCandidates.push({
-						slug: planRef.slug,
-						title: planRef.title,
-						commitHash: summary.commitHash,
-						commitDate: summary.commitDate,
-						generatedAt: summary.generatedAt,
-					});
-				}
-			}
-		}
-
+		const planCandidates = collectPlanCandidates(summaries);
 		const deduplicated = deduplicatePlans(planCandidates);
 		for (const plan of deduplicated) {
-			const content = await readPlanFromBranch(plan.slug, cwd);
+			// Read by the **original** slug (the path on disk at archive time);
+			// expose the **base slug** so SearchHit stubs match without knowing
+			// which archived suffix happens to be on disk.
+			const content = await readPlanFromBranch(plan.originalSlug, cwd);
 			if (content) {
-				plans.push({ slug: plan.slug, title: plan.title, content });
+				plans.push({ slug: plan.baseSlug, title: plan.title, content });
 			} else {
-				log.warn("Plan %s referenced but not found in orphan branch", plan.slug);
+				log.warn("Plan %s referenced but not found in orphan branch", plan.originalSlug);
 			}
 		}
 	}
 
-	// Step 6b: Load and deduplicate notes
+	// Step 6b: Load and deduplicate notes.
+	// Same recursion rationale as plans (cover v3-legacy nested-child notes).
+	// Notes have no archive-suffix mechanism, so id is the natural canonical key.
 	const notes: { id: string; title: string; content: string }[] = [];
 	if (includeNotes) {
 		const seenIds = new Set<string>();
 		for (const summary of summaries) {
-			if (summary.notes) {
-				for (const noteRef of summary.notes) {
-					if (seenIds.has(noteRef.id)) continue;
-					seenIds.add(noteRef.id);
-					// Snippets carry their content inline; markdown notes read from orphan branch
-					if (noteRef.format === "snippet" && noteRef.content) {
-						notes.push({ id: noteRef.id, title: noteRef.title, content: noteRef.content });
+			for (const { noteRef } of collectAllNotesWithHosts(summary)) {
+				if (seenIds.has(noteRef.id)) continue;
+				seenIds.add(noteRef.id);
+				// Snippets carry their content inline; markdown notes read from orphan branch
+				if (noteRef.format === "snippet" && noteRef.content) {
+					notes.push({ id: noteRef.id, title: noteRef.title, content: noteRef.content });
+				} else {
+					const content = await readNoteFromBranch(noteRef.id, cwd);
+					if (content) {
+						notes.push({ id: noteRef.id, title: noteRef.title, content });
 					} else {
-						const content = await readNoteFromBranch(noteRef.id, cwd);
-						if (content) {
-							notes.push({ id: noteRef.id, title: noteRef.title, content });
-						} else {
-							log.warn("Note %s referenced but not found in orphan branch", noteRef.id);
-						}
+						log.warn("Note %s referenced but not found in orphan branch", noteRef.id);
 					}
 				}
 			}
@@ -404,6 +463,165 @@ export async function compileTaskContext(options: ContextOptions, cwd?: string):
 }
 
 // ─── Markdown rendering ──────────────────────────────────────────────────────
+
+// ─── Structured payload (jolli recall --format json) ────────────────────────
+
+/**
+ * Projects a {@link CompiledContext} into the structured {@link RecallPayload}
+ * shape consumed by the `/jolli-recall` skill template, applying budget
+ * enforcement at the **field** level.
+ *
+ * Trim order (oldest commit first within each step):
+ *   1. drop `topic.response` (longest field, lowest signal)
+ *   2. drop `topic.trigger`
+ *   3. drop `plans[].content` (keep slug + title as a citation anchor)
+ *   4. drop `notes[].content`
+ *   5. drop the entire oldest commit from `commits[]` (with its decisions)
+ *
+ * Type contract: every {@link SearchHit} that survives in `commits[]` carries
+ * `decisions` on every topic and full identity fields. When the budget is so
+ * tight that decisions can't fit, the commit is removed wholesale rather than
+ * shipped without decisions — the skill template can rely on "all kept hits
+ * are complete".
+ */
+export function buildRecallPayload(ctx: CompiledContext, tokenBudget?: number): RecallPayload {
+	const budget = tokenBudget ?? DEFAULT_TOKEN_BUDGET;
+
+	let plans: RecallPayloadPlan[] = ctx.plans.map((p) => ({ slug: p.slug, title: p.title, content: p.content }));
+	let notes: RecallPayloadNote[] = ctx.notes.map((n) => ({ id: n.id, title: n.title, content: n.content }));
+
+	// Resolved-key sets — a stub on a commit is considered "live" only if its
+	// slug/id has a matching entry at the payload top level. This guards the
+	// `always resolves` contract documented in the recall skill template:
+	// stubs whose body wasn't loaded (orphan-branch read failed) or wasn't
+	// requested (`--no-plans` / `--no-notes`) get filtered out of the
+	// per-commit hit instead of dangling.
+	const resolvedPlanSlugs = new Set(plans.map((p) => p.slug));
+	const resolvedNoteIds = new Set(notes.map((n) => n.id));
+
+	// Per the chronological invariant in compileTaskContext (Step 2), summaries
+	// are sorted oldest first. We project commits from this order so commits[0]
+	// is the oldest — matching the trim direction below.
+	let commits: SearchHit[] = ctx.summaries.map((s) => filterStubs(buildHit(s), resolvedPlanSlugs, resolvedNoteIds));
+	let truncated = false;
+
+	// Build a stable envelope that surrounds commits/plans/notes so the budget
+	// measure reflects the actual JSON output size, not just the variable parts.
+	// estimatedTokens / truncated are not included (chicken-and-egg with measure
+	// itself); their ~15-token cost is negligible against any realistic budget.
+	const envelope = {
+		type: "recall" as const,
+		branch: ctx.branch,
+		period: ctx.period,
+		commitCount: ctx.commitCount,
+		totalFilesChanged: ctx.totalFilesChanged,
+		totalInsertions: ctx.totalInsertions,
+		totalDeletions: ctx.totalDeletions,
+		stats: ctx.stats,
+	};
+
+	const measure = (): number => estimateTokens(JSON.stringify({ ...envelope, commits, plans, notes }));
+
+	// Step 1: drop topic.response from oldest commits
+	for (let i = 0; i < commits.length && measure() > budget; i++) {
+		const hit = commits[i];
+		const trimmed = hit.topics.map((t) => {
+			if (t.response === undefined) return t;
+			truncated = true;
+			const { response: _r, ...rest } = t;
+			return rest;
+		});
+		commits[i] = { ...hit, topics: trimmed };
+	}
+
+	// Step 2: drop topic.trigger from oldest commits
+	for (let i = 0; i < commits.length && measure() > budget; i++) {
+		const hit = commits[i];
+		const trimmed = hit.topics.map((t) => {
+			if (t.trigger === undefined) return t;
+			truncated = true;
+			const { trigger: _t, ...rest } = t;
+			return rest;
+		});
+		commits[i] = { ...hit, topics: trimmed };
+	}
+
+	// Step 3: drop plans[].content (slug + title remain as citation anchors)
+	if (measure() > budget && plans.some((p) => p.content !== undefined)) {
+		plans = plans.map((p) => {
+			if (p.content === undefined) return p;
+			truncated = true;
+			return { slug: p.slug, title: p.title };
+		});
+	}
+
+	// Step 4: drop notes[].content
+	if (measure() > budget && notes.some((n) => n.content !== undefined)) {
+		notes = notes.map((n) => {
+			if (n.content === undefined) return n;
+			truncated = true;
+			return { id: n.id, title: n.title };
+		});
+	}
+
+	// Step 5: drop the oldest commit wholesale (with its decisions) until we fit.
+	// Always keep at least one commit — otherwise `commits=[]` would
+	// ambiguously mean "no records found" OR "budget evicted everything",
+	// forcing the skill template to teach the LLM a 3-way state machine
+	// for a case only pathological budgets (< envelope size) ever trigger.
+	// Keeping ≥1 commit makes empty-commits unambiguously mean "no records",
+	// at the cost of a minor overage when `--budget` is set absurdly low.
+	while (measure() > budget && commits.length > 1) {
+		commits = commits.slice(1);
+		truncated = true;
+	}
+
+	const estimatedTokens = measure();
+
+	return {
+		type: "recall",
+		branch: ctx.branch,
+		period: ctx.period,
+		commitCount: ctx.commitCount,
+		totalFilesChanged: ctx.totalFilesChanged,
+		totalInsertions: ctx.totalInsertions,
+		totalDeletions: ctx.totalDeletions,
+		commits,
+		plans,
+		notes,
+		stats: ctx.stats,
+		estimatedTokens,
+		...(truncated && { truncated: true }),
+	};
+}
+
+/**
+ * Strips plan/note stubs whose canonical key has no matching entry at the
+ * payload top level. Without this guard the "always resolve" contract breaks
+ * in two paths: (1) `readPlanFromBranch` / `readNoteFromBranch` returned null
+ * (orphan-branch read miss); (2) the caller passed `--no-plans` / `--no-notes`,
+ * leaving the top-level array empty while `summary.plans` / `summary.notes`
+ * still feed buildHit's stub projection.
+ */
+function filterStubs(hit: SearchHit, resolvedPlanSlugs: Set<string>, resolvedNoteIds: Set<string>): SearchHit {
+	const liveStubPlans = hit.plans?.filter((p) => resolvedPlanSlugs.has(p.slug));
+	const liveStubNotes = hit.notes?.filter((n) => resolvedNoteIds.has(n.id));
+
+	const next: { -readonly [K in keyof SearchHit]: SearchHit[K] } = { ...hit };
+	if (liveStubPlans && liveStubPlans.length > 0) {
+		next.plans = liveStubPlans;
+	} else {
+		delete next.plans;
+	}
+	if (liveStubNotes && liveStubNotes.length > 0) {
+		next.notes = liveStubNotes;
+	} else {
+		delete next.notes;
+	}
+	return next;
+}
+
+// ─── Markdown rendering (used by --full / --output / default short summary) ─
 
 /**
  * Renders a compiled context into Markdown, applying token budget truncation.

--- a/cli/src/core/LocalSearchProvider.ts
+++ b/cli/src/core/LocalSearchProvider.ts
@@ -25,15 +25,14 @@ import type {
 	SearchCatalogEntry,
 	SearchCatalogTopic,
 	SearchHit,
-	SearchHitTopic,
 	SearchResult,
 } from "./Search.js";
 import { DEFAULT_CATALOG_LIMIT, DEFAULT_SEARCH_BUDGET } from "./Search.js";
 import type { SearchProvider, SearchSource } from "./SearchProvider.js";
 import type { StorageProvider } from "./StorageProvider.js";
 import { getDisplayDate } from "./SummaryFormat.js";
+import { buildHit } from "./SummaryProjection.js";
 import { AmbiguousHashError, getCatalogWithLazyBuild, getIndex, getSummary } from "./SummaryStore.js";
-import { collectDisplayTopics } from "./SummaryTree.js";
 import { estimateTokens } from "./TokenEstimator.js";
 
 const log = createLogger("LocalSearchProvider");
@@ -310,42 +309,5 @@ function trimEntry(entry: SearchCatalogEntry): SearchCatalogEntry {
 	};
 }
 
-/**
- * Projects a full `CommitSummary` down to a `SearchHit`. Walks the v3 tree via
- * `collectDisplayTopics` so embedded children (legacy squash nests) are
- * resolved before being copied into the hit's `topics[]`.
- *
- * Drops internal metadata (`generatedAt` / `commitSource` / `transcriptEntries`
- * / `conversationTurns` / `llm` / `treeHash` / `jolliDocId/Url` /
- * `orphanedDocIds`) and large payloads with no search value
- * (`e2eTestGuide` / `plans` / `notes`). See SearchHit doc for the rationale.
- */
-function buildHit(summary: CommitSummary): SearchHit {
-	const topics = collectDisplayTopics(summary).map(
-		(t) =>
-			({
-				title: t.title,
-				trigger: t.trigger,
-				response: t.response,
-				decisions: t.decisions,
-				...(t.todo !== undefined && { todo: t.todo }),
-				...(t.filesAffected && t.filesAffected.length > 0 && { filesAffected: t.filesAffected }),
-				...(t.category !== undefined && { category: t.category }),
-				...(t.importance !== undefined && { importance: t.importance }),
-			}) satisfies SearchHitTopic,
-	);
-
-	return {
-		hash: summary.commitHash.substring(0, 8),
-		fullHash: summary.commitHash,
-		commitMessage: summary.commitMessage,
-		commitAuthor: summary.commitAuthor,
-		commitDate: summary.commitDate,
-		branch: summary.branch,
-		...(summary.commitType !== undefined && { commitType: summary.commitType }),
-		...(summary.ticketId && { ticketId: summary.ticketId }),
-		...(summary.diffStats !== undefined && { diffStats: summary.diffStats }),
-		...(summary.recap && { recap: summary.recap }),
-		topics,
-	};
-}
+// `buildHit` lives in SummaryProjection.ts so jolli-recall and jolli-search
+// share the exact same projection contract; see that module's doc for why.

--- a/cli/src/core/PlanSlug.test.ts
+++ b/cli/src/core/PlanSlug.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { extractBaseSlug } from "./PlanSlug.js";
+
+describe("extractBaseSlug", () => {
+	it("strips an 8-char host hash suffix", () => {
+		expect(extractBaseSlug("auth-redesign-06d0f729", "06d0f72912345abcdef")).toBe("auth-redesign");
+	});
+
+	it("strips a 7-char host hash suffix when no 8-char match", () => {
+		expect(extractBaseSlug("auth-redesign-06d0f72", "06d0f72912345abcdef")).toBe("auth-redesign");
+	});
+
+	it("returns slug unchanged when no archive suffix matches", () => {
+		expect(extractBaseSlug("auth-redesign", "06d0f72912345abcdef")).toBe("auth-redesign");
+	});
+
+	it("returns slug unchanged when trailing token doesn't match the host hash", () => {
+		// Slug ends with 8 hex chars but they aren't the prefix of `commitHash`.
+		// extractBaseSlug must NOT strip — that would corrupt a slug that
+		// legitimately includes hex chars in its name.
+		expect(extractBaseSlug("auth-redesign-deadbeef", "06d0f72912345abcdef")).toBe("auth-redesign-deadbeef");
+	});
+
+	it("prefers 8-char strip when both 7- and 8-char prefixes match", () => {
+		// commit "06d0f729..." — slug ends in -06d0f729 (8 chars). The 8-char branch
+		// fires first; the 7-char branch is a fallback. Verify the slice length is
+		// the 8-char one (not 7).
+		expect(extractBaseSlug("topic-06d0f729", "06d0f72912345abcdef")).toBe("topic");
+	});
+});

--- a/cli/src/core/PlanSlug.ts
+++ b/cli/src/core/PlanSlug.ts
@@ -1,0 +1,32 @@
+/**
+ * PlanSlug — Plan slug normalization shared between recall payload assembly
+ * and SearchHit projection.
+ *
+ * When a plan is archived at a particular commit, its file in the orphan
+ * branch is renamed from `plans/<slug>.md` to `plans/<slug>-<shortHash>.md`,
+ * and the `PlanReference.slug` recorded on subsequent commits carries the
+ * suffixed form. To resolve "is this the same logical plan?" across
+ * pre-archive and post-archive references, both call sites must collapse the
+ * slug back to its **base** form by cross-validating the trailing
+ * `-<shortHash>` against the host commit's hash.
+ *
+ * Two short-hash widths (7 and 8) are accepted because both have appeared in
+ * historical archive runs.
+ */
+
+/**
+ * Returns the base slug — the slug with any `-<hostShortHash>` archive suffix
+ * stripped. If no such suffix is present (or the trailing token doesn't match
+ * `commitHash`), the slug is returned unchanged.
+ */
+export function extractBaseSlug(slug: string, commitHash: string): string {
+	const shortHash8 = commitHash.substring(0, 8);
+	if (slug.endsWith(`-${shortHash8}`)) {
+		return slug.slice(0, -(shortHash8.length + 1));
+	}
+	const shortHash7 = commitHash.substring(0, 7);
+	if (slug.endsWith(`-${shortHash7}`)) {
+		return slug.slice(0, -(shortHash7.length + 1));
+	}
+	return slug;
+}

--- a/cli/src/core/Search.ts
+++ b/cli/src/core/Search.ts
@@ -101,11 +101,24 @@ export interface SearchCatalog {
  */
 export interface SearchHitTopic {
 	readonly title: string;
-	/** 1-2 sentences describing what prompted the work. */
-	readonly trigger: string;
-	/** Implementation summary; may include code references. Verbose. */
-	readonly response: string;
-	/** ★ Design choices + the reasoning behind each. Multi-line markdown bullets. */
+	/**
+	 * 1-2 sentences describing what prompted the work. Optional because recall
+	 * may drop it under tight `--budget`; search Phase 2 always populates it.
+	 */
+	readonly trigger?: string;
+	/**
+	 * Implementation summary; may include code references. Verbose. Optional
+	 * for the same reason as `trigger` — recall trimming drops `response` first
+	 * (longest field, lowest signal); search Phase 2 always populates it.
+	 */
+	readonly response?: string;
+	/**
+	 * ★ Design choices + the reasoning behind each. Multi-line markdown bullets.
+	 *
+	 * **Required.** Never dropped from a kept commit. Recall budget enforcement
+	 * removes the entire commit from `commits[]` when `decisions` won't fit,
+	 * rather than emitting a SearchHit topic without it.
+	 */
 	readonly decisions: string;
 	/** Residual work the LLM noticed during summarization (rare but valuable). */
 	readonly todo?: string;
@@ -138,7 +151,11 @@ export interface SearchHitTopic {
  *     leaf-level distillation.
  *   - No internal metadata (`generatedAt`, `commitSource`, `transcriptEntries`,
  *     `conversationTurns`, `llm`, `treeHash`, `jolliDocId/Url`,
- *     `orphanedDocIds`, `e2eTestGuide`, `plans`, `notes`).
+ *     `orphanedDocIds`, `e2eTestGuide`).
+ *
+ * Plan / note refs ARE shipped, as `plans?` / `notes?` stubs (slug/id +
+ * title only — bodies are not transmitted via SearchHit; recall ships them
+ * at the RecallPayload top level).
  */
 export interface SearchHit {
 	// Identity + provenance
@@ -159,6 +176,26 @@ export interface SearchHit {
 
 	// Structured body — the meaty field
 	readonly topics: ReadonlyArray<SearchHitTopic>;
+
+	/**
+	 * Plan refs that this commit (or one of its hoisted children) declared a
+	 * relationship with. Stub only — the slug+title pair is provided as a
+	 * grounding anchor.
+	 *
+	 * `slug` is the **base slug** (archive-suffix stripped via `extractBaseSlug`)
+	 * so it resolves consistently across pre-archive / post-archive commits and
+	 * can be used as a lookup key into `RecallPayload.plans` (in recall) or
+	 * left as a citation hint (in search, where bodies are not shipped).
+	 */
+	readonly plans?: ReadonlyArray<{ readonly slug: string; readonly title: string }>;
+
+	/**
+	 * Note refs that this commit (or one of its hoisted children) declared a
+	 * relationship with. Stub only.
+	 *
+	 * Notes have no archive-suffix mechanism, so `id` is the natural key.
+	 */
+	readonly notes?: ReadonlyArray<{ readonly id: string; readonly title: string }>;
 }
 
 /**

--- a/cli/src/core/SummaryFormat.test.ts
+++ b/cli/src/core/SummaryFormat.test.ts
@@ -1,11 +1,14 @@
 import { describe, expect, it } from "vitest";
-import type { CommitSummary, PlanReference } from "../Types.js";
+import type { CommitSummary, NoteReference, PlanReference } from "../Types.js";
 import {
 	buildNotePushTitle,
 	buildPanelTitle,
 	buildPlanPushTitle,
 	buildPushTitle,
+	collectAllNotes,
+	collectAllNotesWithHosts,
 	collectAllPlans,
+	collectAllPlansWithHosts,
 	collectSortedTopics,
 	formatDate,
 	formatFullDate,
@@ -382,5 +385,171 @@ describe("collectAllPlans", () => {
 		});
 		const plans = collectAllPlans(summary);
 		expect(plans).toHaveLength(2);
+	});
+});
+
+// ─── collectAllNotes ────────────────────────────────────────────────────────
+
+function noteRef(overrides: Partial<NoteReference> = {}): NoteReference {
+	return {
+		id: "note-1",
+		title: "Note 1",
+		format: "markdown",
+		addedAt: "2026-01-01T00:00:00Z",
+		updatedAt: "2026-01-01T00:00:00Z",
+		...overrides,
+	};
+}
+
+describe("collectAllNotes", () => {
+	it("collects notes from a leaf node", () => {
+		const notes = collectAllNotes(leaf({ notes: [noteRef()] }));
+		expect(notes).toHaveLength(1);
+		expect(notes[0].id).toBe("note-1");
+	});
+
+	it("deduplicates by id, keeping the most recently updated", () => {
+		const older = noteRef({ id: "note-x", title: "v1", updatedAt: "2026-01-10" });
+		const newer = noteRef({ id: "note-x", title: "v2", updatedAt: "2026-01-20" });
+		const summary = leaf({
+			notes: [older],
+			children: [leaf({ notes: [newer], commitHash: "child1" })],
+		});
+		const notes = collectAllNotes(summary);
+		expect(notes).toHaveLength(1);
+		expect(notes[0].title).toBe("v2");
+	});
+
+	it("keeps newer note when an older duplicate is encountered later in the walk", () => {
+		const newer = noteRef({ id: "note-x", title: "v2", updatedAt: "2026-01-20" });
+		const older = noteRef({ id: "note-x", title: "v1", updatedAt: "2026-01-10" });
+		const summary = leaf({
+			notes: [newer],
+			children: [leaf({ notes: [older], commitHash: "child1" })],
+		});
+		const notes = collectAllNotes(summary);
+		expect(notes).toHaveLength(1);
+		expect(notes[0].title).toBe("v2");
+	});
+
+	it("returns empty array when no notes exist", () => {
+		expect(collectAllNotes(leaf())).toHaveLength(0);
+	});
+
+	it("collects notes from nested children", () => {
+		const summary = leaf({
+			children: [
+				leaf({
+					commitHash: "child1",
+					notes: [noteRef({ id: "n1" })],
+					children: [leaf({ commitHash: "grandchild", notes: [noteRef({ id: "n2" })] })],
+				}),
+			],
+		});
+		const notes = collectAllNotes(summary);
+		expect(notes).toHaveLength(2);
+	});
+});
+
+// ─── collectAllPlansWithHosts ───────────────────────────────────────────────
+
+describe("collectAllPlansWithHosts", () => {
+	it("reports the host commit hash for each plan", () => {
+		const plan: PlanReference = {
+			slug: "p1",
+			title: "P1",
+			editCount: 1,
+			addedAt: "2026-01-01",
+			updatedAt: "2026-01-01",
+		};
+		const summary = leaf({ commitHash: "root123", plans: [plan] });
+		const result = collectAllPlansWithHosts(summary);
+		expect(result).toHaveLength(1);
+		expect(result[0].planRef.slug).toBe("p1");
+		expect(result[0].hostCommitHash).toBe("root123");
+	});
+
+	it("reports the child commit hash when the plan lives in a child", () => {
+		const plan: PlanReference = {
+			slug: "p1",
+			title: "P1",
+			editCount: 1,
+			addedAt: "2026-01-01",
+			updatedAt: "2026-01-01",
+		};
+		const summary = leaf({ commitHash: "root123", children: [leaf({ commitHash: "child456", plans: [plan] })] });
+		const result = collectAllPlansWithHosts(summary);
+		expect(result).toHaveLength(1);
+		expect(result[0].hostCommitHash).toBe("child456");
+	});
+
+	it("dedupes by slug and keeps the winner's host hash", () => {
+		const older: PlanReference = {
+			slug: "p1",
+			title: "v1",
+			editCount: 1,
+			addedAt: "2026-01-01",
+			updatedAt: "2026-01-10",
+		};
+		const newer: PlanReference = {
+			slug: "p1",
+			title: "v2",
+			editCount: 2,
+			addedAt: "2026-01-01",
+			updatedAt: "2026-01-20",
+		};
+		const summary = leaf({
+			commitHash: "root",
+			plans: [older],
+			children: [leaf({ commitHash: "child", plans: [newer] })],
+		});
+		const result = collectAllPlansWithHosts(summary);
+		expect(result).toHaveLength(1);
+		expect(result[0].planRef.title).toBe("v2");
+		expect(result[0].hostCommitHash).toBe("child");
+	});
+
+	it("returns empty array when no plans exist", () => {
+		expect(collectAllPlansWithHosts(leaf())).toHaveLength(0);
+	});
+});
+
+// ─── collectAllNotesWithHosts ───────────────────────────────────────────────
+
+describe("collectAllNotesWithHosts", () => {
+	it("reports the host commit hash for each note", () => {
+		const summary = leaf({ commitHash: "root123", notes: [noteRef()] });
+		const result = collectAllNotesWithHosts(summary);
+		expect(result).toHaveLength(1);
+		expect(result[0].noteRef.id).toBe("note-1");
+		expect(result[0].hostCommitHash).toBe("root123");
+	});
+
+	it("reports the child commit hash when the note lives in a child", () => {
+		const summary = leaf({
+			commitHash: "root",
+			children: [leaf({ commitHash: "child", notes: [noteRef({ id: "n1" })] })],
+		});
+		const result = collectAllNotesWithHosts(summary);
+		expect(result).toHaveLength(1);
+		expect(result[0].hostCommitHash).toBe("child");
+	});
+
+	it("dedupes by id and keeps the winner's host hash", () => {
+		const older = noteRef({ id: "n1", title: "v1", updatedAt: "2026-01-10" });
+		const newer = noteRef({ id: "n1", title: "v2", updatedAt: "2026-01-20" });
+		const summary = leaf({
+			commitHash: "root",
+			notes: [older],
+			children: [leaf({ commitHash: "child", notes: [newer] })],
+		});
+		const result = collectAllNotesWithHosts(summary);
+		expect(result).toHaveLength(1);
+		expect(result[0].noteRef.title).toBe("v2");
+		expect(result[0].hostCommitHash).toBe("child");
+	});
+
+	it("returns empty array when no notes exist", () => {
+		expect(collectAllNotesWithHosts(leaf())).toHaveLength(0);
 	});
 });

--- a/cli/src/core/SummaryFormat.ts
+++ b/cli/src/core/SummaryFormat.ts
@@ -6,7 +6,7 @@
  * VS Code webview. This file has zero VS Code dependencies.
  */
 
-import type { CommitSummary, PlanReference } from "../Types.js";
+import type { CommitSummary, NoteReference, PlanReference } from "../Types.js";
 import { collectDisplayTopics, collectSourceNodes, type TopicWithDate } from "./SummaryTree.js";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -210,4 +210,96 @@ export function collectAllPlans(summary: CommitSummary): ReadonlyArray<PlanRefer
 
 	walk(summary);
 	return [...planMap.values()];
+}
+
+/**
+ * Recursively collects all note references from a summary tree.
+ * Deduplicates by id, keeping the most recently updated version.
+ */
+export function collectAllNotes(summary: CommitSummary): ReadonlyArray<NoteReference> {
+	const noteMap = new Map<string, NoteReference>();
+
+	function walk(node: CommitSummary): void {
+		if (node.notes) {
+			for (const note of node.notes) {
+				const existing = noteMap.get(note.id);
+				if (!existing || note.updatedAt > existing.updatedAt) {
+					noteMap.set(note.id, note);
+				}
+			}
+		}
+		if (node.children) {
+			for (const child of node.children) {
+				walk(child);
+			}
+		}
+	}
+
+	walk(summary);
+	return [...noteMap.values()];
+}
+
+/**
+ * Like {@link collectAllPlans} but also reports the host commit hash for each
+ * plan reference — the commit (root or nested child) where the reference was
+ * declared. Required for base-slug normalization, which strips a trailing
+ * `-<hostHash>` suffix introduced when a plan was archived at that commit.
+ *
+ * Same dedup contract as {@link collectAllPlans} (latest `updatedAt` wins per
+ * slug), with the winner's `hostCommitHash` reported alongside.
+ */
+export function collectAllPlansWithHosts(
+	summary: CommitSummary,
+): ReadonlyArray<{ readonly planRef: PlanReference; readonly hostCommitHash: string }> {
+	const map = new Map<string, { planRef: PlanReference; hostCommitHash: string }>();
+
+	function walk(node: CommitSummary): void {
+		if (node.plans) {
+			for (const plan of node.plans) {
+				const existing = map.get(plan.slug);
+				if (!existing || plan.updatedAt > existing.planRef.updatedAt) {
+					map.set(plan.slug, { planRef: plan, hostCommitHash: node.commitHash });
+				}
+			}
+		}
+		if (node.children) {
+			for (const child of node.children) {
+				walk(child);
+			}
+		}
+	}
+
+	walk(summary);
+	return [...map.values()];
+}
+
+/**
+ * Like {@link collectAllNotes} but also reports the host commit hash for each
+ * note reference. Notes have no archive-suffix mechanism today, but the API
+ * is symmetric to {@link collectAllPlansWithHosts} so future archive-style
+ * normalization (or per-host attribution) can plug in without churn.
+ */
+export function collectAllNotesWithHosts(
+	summary: CommitSummary,
+): ReadonlyArray<{ readonly noteRef: NoteReference; readonly hostCommitHash: string }> {
+	const map = new Map<string, { noteRef: NoteReference; hostCommitHash: string }>();
+
+	function walk(node: CommitSummary): void {
+		if (node.notes) {
+			for (const note of node.notes) {
+				const existing = map.get(note.id);
+				if (!existing || note.updatedAt > existing.noteRef.updatedAt) {
+					map.set(note.id, { noteRef: note, hostCommitHash: node.commitHash });
+				}
+			}
+		}
+		if (node.children) {
+			for (const child of node.children) {
+				walk(child);
+			}
+		}
+	}
+
+	walk(summary);
+	return [...map.values()];
 }

--- a/cli/src/core/SummaryProjection.test.ts
+++ b/cli/src/core/SummaryProjection.test.ts
@@ -1,0 +1,223 @@
+import { describe, expect, it } from "vitest";
+import type { CommitSummary, NoteReference, PlanReference } from "../Types.js";
+import { buildHit } from "./SummaryProjection.js";
+
+function leaf(overrides: Partial<CommitSummary> = {}): CommitSummary {
+	return {
+		version: 4,
+		commitHash: "06d0f72912345abcdef0123456789abcdef01234",
+		commitMessage: "feat: thing",
+		commitAuthor: "Test User",
+		commitDate: "2026-03-01T10:00:00.000Z",
+		branch: "feature/test",
+		generatedAt: "2026-03-01T10:01:00.000Z",
+		stats: { filesChanged: 2, insertions: 10, deletions: 5 },
+		topics: [{ title: "Topic A", trigger: "t", response: "r", decisions: "d" }],
+		...overrides,
+	};
+}
+
+function planRef(o: Partial<PlanReference> = {}): PlanReference {
+	return {
+		slug: "auth-redesign",
+		title: "Auth Redesign",
+		editCount: 1,
+		addedAt: "2026-01-01",
+		updatedAt: "2026-01-01",
+		...o,
+	};
+}
+
+function noteRef(o: Partial<NoteReference> = {}): NoteReference {
+	return {
+		id: "note-1",
+		title: "A note",
+		format: "markdown",
+		addedAt: "2026-01-01T00:00:00Z",
+		updatedAt: "2026-01-01T00:00:00Z",
+		...o,
+	};
+}
+
+describe("buildHit", () => {
+	it("projects a v4 summary's identity, recap, topics, and diffStats", () => {
+		const hit = buildHit(
+			leaf({
+				ticketId: "JOLLI-123",
+				diffStats: { filesChanged: 3, insertions: 10, deletions: 2 },
+				recap: "did stuff",
+			}),
+		);
+		expect(hit.hash).toBe("06d0f729");
+		expect(hit.fullHash).toBe("06d0f72912345abcdef0123456789abcdef01234");
+		expect(hit.commitMessage).toBe("feat: thing");
+		expect(hit.commitAuthor).toBe("Test User");
+		expect(hit.branch).toBe("feature/test");
+		expect(hit.ticketId).toBe("JOLLI-123");
+		expect(hit.diffStats).toEqual({ filesChanged: 3, insertions: 10, deletions: 2 });
+		expect(hit.recap).toBe("did stuff");
+		expect(hit.topics).toHaveLength(1);
+		expect(hit.topics[0]).toEqual({
+			title: "Topic A",
+			trigger: "t",
+			response: "r",
+			decisions: "d",
+		});
+	});
+
+	it("walks v3 nested children for topics via collectDisplayTopics", () => {
+		const hit = buildHit(
+			leaf({
+				version: 3,
+				topics: undefined,
+				children: [
+					leaf({
+						commitHash: "child1234567890abcdef0123456789abcdef0123",
+						topics: [{ title: "Child Topic", trigger: "ct", response: "cr", decisions: "cd" }],
+					}),
+				],
+			}),
+		);
+		// Child topics surface in the projection — same recursion contract as
+		// collectDisplayTopics.
+		expect(hit.topics.length).toBeGreaterThanOrEqual(1);
+		const titles = hit.topics.map((t) => t.title);
+		expect(titles).toContain("Child Topic");
+	});
+
+	it("emits plan stubs from root-level plans (slug + title only)", () => {
+		const hit = buildHit(leaf({ plans: [planRef()] }));
+		expect(hit.plans).toEqual([{ slug: "auth-redesign", title: "Auth Redesign" }]);
+	});
+
+	it("emits note stubs from root-level notes (id + title only)", () => {
+		const hit = buildHit(leaf({ notes: [noteRef()] }));
+		expect(hit.notes).toEqual([{ id: "note-1", title: "A note" }]);
+	});
+
+	it("collects plan / note stubs from nested children (v3 legacy)", () => {
+		const hit = buildHit(
+			leaf({
+				children: [
+					leaf({
+						commitHash: "child1234567890abcdef0123456789abcdef0123",
+						plans: [planRef({ slug: "child-plan", title: "Child Plan" })],
+						notes: [noteRef({ id: "child-note", title: "Child Note" })],
+					}),
+				],
+			}),
+		);
+		expect(hit.plans?.[0].slug).toBe("child-plan");
+		expect(hit.notes?.[0].id).toBe("child-note");
+	});
+
+	it("normalizes plan stub slug to the base slug (archive suffix stripped)", () => {
+		// Plan was archived at the root commit (06d0f729...) and its slug carries
+		// the matching short-hash suffix. Stub slug must be the archive-stripped
+		// canonical form so it matches RecallPayload.plans entries.
+		const hit = buildHit(
+			leaf({
+				plans: [planRef({ slug: "auth-redesign-06d0f729", title: "Auth Redesign" })],
+			}),
+		);
+		expect(hit.plans?.[0].slug).toBe("auth-redesign");
+	});
+
+	it("dedupes stubs by slug / id when the same ref appears in root and child", () => {
+		// Same logical plan referenced both at root and in a child — should
+		// surface once. Same for notes.
+		const hit = buildHit(
+			leaf({
+				plans: [planRef({ slug: "auth-redesign" })],
+				notes: [noteRef({ id: "n1" })],
+				children: [
+					leaf({
+						commitHash: "child1234567890abcdef0123456789abcdef0123",
+						plans: [planRef({ slug: "auth-redesign", title: "Older" })],
+						notes: [noteRef({ id: "n1", title: "Older note" })],
+					}),
+				],
+			}),
+		);
+		expect(hit.plans).toHaveLength(1);
+		expect(hit.notes).toHaveLength(1);
+	});
+
+	it("omits plans / notes / optional fields when not present (no empty arrays)", () => {
+		const hit = buildHit(leaf({ topics: [{ title: "T", trigger: "t", response: "r", decisions: "d" }] }));
+		expect(hit.plans).toBeUndefined();
+		expect(hit.notes).toBeUndefined();
+		expect(hit.recap).toBeUndefined();
+		expect(hit.ticketId).toBeUndefined();
+	});
+
+	it("preserves topic optional fields (todo / filesAffected / category / importance)", () => {
+		const hit = buildHit(
+			leaf({
+				topics: [
+					{
+						title: "T",
+						trigger: "t",
+						response: "r",
+						decisions: "d",
+						todo: "todo-thing",
+						filesAffected: ["src/a.ts"],
+						category: "feature",
+						importance: "major",
+					},
+				],
+			}),
+		);
+		expect(hit.topics[0].todo).toBe("todo-thing");
+		expect(hit.topics[0].filesAffected).toEqual(["src/a.ts"]);
+		expect(hit.topics[0].category).toBe("feature");
+		expect(hit.topics[0].importance).toBe("major");
+	});
+
+	it("strips empty filesAffected arrays (keeps shape clean)", () => {
+		const hit = buildHit(
+			leaf({
+				topics: [{ title: "T", trigger: "t", response: "r", decisions: "d", filesAffected: [] }],
+			}),
+		);
+		expect(hit.topics[0].filesAffected).toBeUndefined();
+	});
+
+	it("preserves commitType when present", () => {
+		const hit = buildHit(leaf({ commitType: "squash" }));
+		expect(hit.commitType).toBe("squash");
+	});
+
+	// Stub-level dedup runs AFTER base-slug normalization, so two plan refs that
+	// look distinct (`plan` and `plan-<hostHash>`) but collapse to the same base
+	// slug must fold into a single stub.
+	it("dedupes plan stubs that collapse to the same base slug after normalization", () => {
+		// Root commit hash starts with `06d0f729` — both slugs strip to "auth".
+		const hit = buildHit(
+			leaf({
+				commitHash: "06d0f72912345abcdef0123456789abcdef01234",
+				plans: [planRef({ slug: "auth" }), planRef({ slug: "auth-06d0f729", title: "v2" })],
+			}),
+		);
+		expect(hit.plans).toHaveLength(1);
+		expect(hit.plans?.[0].slug).toBe("auth");
+	});
+
+	// Same fold for notes — id comes through dedupeById; if two ids land equal
+	// only the first survives.
+	it("dedupes note stubs when two refs share an id across different hosts", () => {
+		const hit = buildHit(
+			leaf({
+				commitHash: "06d0f72912345abcdef0123456789abcdef01234",
+				notes: [noteRef({ id: "n1", title: "First" })],
+				children: [
+					leaf({
+						commitHash: "abcdef1234567890abcdef0123456789abcdef00",
+						notes: [noteRef({ id: "n1", title: "Second", updatedAt: "2024-01-01T00:00:00Z" })],
+					}),
+				],
+			}),
+		);
+		expect(hit.notes).toHaveLength(1);
+	});
+});

--- a/cli/src/core/SummaryProjection.ts
+++ b/cli/src/core/SummaryProjection.ts
@@ -1,0 +1,94 @@
+/**
+ * SummaryProjection — Projects a stored {@link CommitSummary} down to the
+ * outward-facing {@link SearchHit} shape consumed by both jolli-search Phase 2
+ * and jolli-recall.
+ *
+ * Two reasons this lives in its own module rather than inside
+ * `LocalSearchProvider`:
+ *   1. Recall is not a "search provider" — putting the projection under the
+ *      Search-namespaced provider would force recall to import from a
+ *      misleadingly named source. `SummaryProjection` reads cleanly as
+ *      "convert a summary into the public hit shape" and makes no claim about
+ *      where the summary came from or how it was selected.
+ *   2. The projection is the precise contract surface between stored data
+ *      (CommitSummary, with full topic + plan + note tree) and exposed data
+ *      (SearchHit + stub refs). Sharing a single implementation prevents
+ *      search and recall from drifting on what gets shipped vs stripped.
+ *
+ * Plan/note stubs use the **base slug** (archive-suffix stripped) so the same
+ * logical plan cited from a pre-archive commit and a post-archive commit
+ * resolves to one canonical entry in {@link RecallPayload.plans}.
+ */
+
+import type { CommitSummary } from "../Types.js";
+import { extractBaseSlug } from "./PlanSlug.js";
+import type { SearchHit, SearchHitTopic } from "./Search.js";
+import { collectAllNotesWithHosts, collectAllPlansWithHosts } from "./SummaryFormat.js";
+import { collectDisplayTopics } from "./SummaryTree.js";
+
+/**
+ * Builds a {@link SearchHit} from a stored {@link CommitSummary}.
+ *
+ * Walks the summary tree via {@link collectDisplayTopics} so legacy v3 data
+ * with topics in nested children comes out flattened. Strips internal /
+ * pushed-doc metadata (commitSource, transcriptEntries, llm, treeHash,
+ * jolliDocId/Url, …) and large unrelated payloads (e2eTestGuide); see the
+ * SearchHit doc for the full omit rationale.
+ */
+export function buildHit(summary: CommitSummary): SearchHit {
+	const topics: SearchHitTopic[] = collectDisplayTopics(summary).map(
+		(t) =>
+			({
+				title: t.title,
+				...(t.trigger !== undefined && { trigger: t.trigger }),
+				...(t.response !== undefined && { response: t.response }),
+				decisions: t.decisions,
+				...(t.todo !== undefined && { todo: t.todo }),
+				...(t.filesAffected && t.filesAffected.length > 0 && { filesAffected: t.filesAffected }),
+				...(t.category !== undefined && { category: t.category }),
+				...(t.importance !== undefined && { importance: t.importance }),
+			}) satisfies SearchHitTopic,
+	);
+
+	const planStubs = dedupeBySlug(
+		collectAllPlansWithHosts(summary).map(({ planRef, hostCommitHash }) => ({
+			slug: extractBaseSlug(planRef.slug, hostCommitHash),
+			title: planRef.title,
+		})),
+	);
+
+	// Note: no dedup pass needed here. `collectAllNotesWithHosts` already dedups
+	// by note id at the Map level, and notes have no archive-suffix mechanism
+	// like plans, so the (id, title) tuples here are guaranteed unique.
+	const noteStubs = collectAllNotesWithHosts(summary).map(({ noteRef }) => ({
+		id: noteRef.id,
+		title: noteRef.title,
+	}));
+
+	return {
+		hash: summary.commitHash.substring(0, 8),
+		fullHash: summary.commitHash,
+		commitMessage: summary.commitMessage,
+		commitAuthor: summary.commitAuthor,
+		commitDate: summary.commitDate,
+		branch: summary.branch,
+		...(summary.commitType !== undefined && { commitType: summary.commitType }),
+		...(summary.ticketId && { ticketId: summary.ticketId }),
+		...(summary.diffStats !== undefined && { diffStats: summary.diffStats }),
+		...(summary.recap && { recap: summary.recap }),
+		topics,
+		...(planStubs.length > 0 && { plans: planStubs }),
+		...(noteStubs.length > 0 && { notes: noteStubs }),
+	};
+}
+
+function dedupeBySlug<T extends { slug: string }>(items: ReadonlyArray<T>): ReadonlyArray<T> {
+	const seen = new Set<string>();
+	const out: T[] = [];
+	for (const item of items) {
+		if (seen.has(item.slug)) continue;
+		seen.add(item.slug);
+		out.push(item);
+	}
+	return out;
+}

--- a/cli/src/install/SkillInstaller.test.ts
+++ b/cli/src/install/SkillInstaller.test.ts
@@ -79,15 +79,15 @@ describe("updateSkillsIfNeeded", () => {
 	// recall has no equivalent. Principle 6 gives a concrete word ceiling +
 	// explicit deep-dive escape hatch. **Length only — no form constraint.**
 	// LLM still picks the output shape (per Part B's "shape is your call").
-	it("recall template caps default answer length at ~400 words (principle #6)", async () => {
+	it("recall template caps default answer length at ~500 words (principle #6)", async () => {
 		await updateSkillsIfNeeded(tempDir);
 		const recall = readFileSync(join(tempDir, ".claude/skills/jolli-recall/SKILL.md"), "utf-8");
 		// Concrete word ceiling — actionable for LLM in a way "one screen" wasn't.
-		// 400 was picked over 200 after dogfood: a substantive 5-commit branch
-		// naturally produces ~700-800 words; 200 is too aggressive and forces
-		// loss of detail, 400 is roughly one screen of plain prose.
+		// 500 was picked after dogfood: a substantive 5-commit branch with
+		// quoted decisions naturally produces ~700-800 words; 400 was too tight
+		// once the verbatim-quote convention got upgraded to complete clauses.
 		expect(recall).toMatch(/Brief by default/);
-		expect(recall).toMatch(/~400 words at most/);
+		expect(recall).toMatch(/~500 words at most/);
 		// Escape hatch. Use \s+ to tolerate the line wrap inside the principle.
 		expect(recall).toMatch(/Long-form\s+output is opt-in/);
 		expect(recall).toMatch(/deep dive/);
@@ -248,16 +248,32 @@ describe("updateSkillsIfNeeded", () => {
 		expect(search).toMatch(/\[cli\/src\/Types\.ts\]\(cli\/src\/Types\.ts\)/);
 	});
 
-	it("search template forbids snippet dumps but ENCOURAGES short bold verbatim quotes from recap/decisions", async () => {
+	it("search template forbids snippet dumps and demands complete verbatim clauses with self-contained meaning", async () => {
 		await updateSkillsIfNeeded(tempDir);
 		const search = readFileSync(join(tempDir, ".claude/skills/jolli-search/SKILL.md"), "utf-8");
-		// Synthesize-don't-dump is still in (no wall-of-fragments).
+		// Synthesize-don't-dump is still in.
 		expect(search).toMatch(/Synthesize, don't dump/);
 		expect(search).toMatch(/wall-of-fragments/);
-		// Bold verbatim quotes are explicitly encouraged.
-		expect(search).toMatch(/short verbatim quotes/);
-		// And a worked example anchoring the format the LLM should emit.
-		expect(search).toMatch(/\*\*"stateless, scales horizontally"\*\*/);
+		// Bold verbatim quotes are explicitly encouraged — but as complete
+		// clauses, not 2-3 word fragments that need surrounding paraphrase
+		// to be understood.
+		expect(search).toMatch(/verbatim quotes from stored data/);
+		expect(search).toMatch(/complete clauses \(typically 10-30 words\)/);
+		expect(search).toMatch(/not 2-3 word fragments/);
+		expect(search).toMatch(/skim the bold quote alone and understand its claim/);
+		// Worked example is a 17-word complete clause (anchors the LLM's
+		// output toward longer self-contained quotes, not snippet fragments).
+		expect(search).toMatch(
+			/\*\*"the stateless model lets us scale horizontally without a shared session store across regions"\*\*/,
+		);
+		// Bold-only-for-verbatim trust signal.
+		expect(search).toMatch(/Bold = verbatim from stored data/);
+		expect(search).toMatch(/Never use bold for general emphasis/);
+		// Negative: the deprecated 1-3 quotes-per-answer cap is gone (it
+		// interacted badly with recall's 400-word ceiling, starving the
+		// answer of grounding).
+		expect(search).not.toMatch(/Use sparingly \(1-3 quotes per answer\)/);
+		expect(search).not.toMatch(/short verbatim quotes/);
 	});
 
 	it("search template forbids exposing machinery (Phase 1 / Phase 2 / catalog / SearchHit)", async () => {

--- a/cli/src/install/SkillInstaller.test.ts
+++ b/cli/src/install/SkillInstaller.test.ts
@@ -74,26 +74,30 @@ describe("updateSkillsIfNeeded", () => {
 		expect(recall).toMatch(/### Loaded `feature\/auth`\n\n- \*\*Period:/);
 	});
 
-	// recall outputs were running long (multi-screen) because the LLM had no
-	// length anchor — search bounds itself naturally via Step-3 picking,
-	// recall has no equivalent. Principle 6 gives a concrete word ceiling +
-	// explicit deep-dive escape hatch. **Length only — no form constraint.**
-	// LLM still picks the output shape (per Part B's "shape is your call").
-	it("recall template caps default answer length at ~500 words (principle #6)", async () => {
+	// Principle 6 still gives a length anchor — search bounds itself naturally
+	// via Step-3 picking, recall has no equivalent — but the earlier "~500
+	// words at most" hard ceiling was the root cause of inline-bold paragraph
+	// cramming on multi-theme branches: 5+ themes with verbatim-quote bullets
+	// naturally exceed 500 words, and forcing them under the cap collapsed
+	// `###` sections into inline-bold prefixes that read as a markdown wall.
+	// The new wording keeps the brevity nudge as a soft target but explicitly
+	// subordinates it to section structure.
+	it("recall template encourages brevity but never at the cost of section structure (principle #6)", async () => {
 		await updateSkillsIfNeeded(tempDir);
 		const recall = readFileSync(join(tempDir, ".claude/skills/jolli-recall/SKILL.md"), "utf-8");
-		// Concrete word ceiling — actionable for LLM in a way "one screen" wasn't.
-		// 500 was picked after dogfood: a substantive 5-commit branch with
-		// quoted decisions naturally produces ~700-800 words; 400 was too tight
-		// once the verbatim-quote convention got upgraded to complete clauses.
 		expect(recall).toMatch(/Brief by default/);
-		expect(recall).toMatch(/~500 words at most/);
-		// Escape hatch. Use \s+ to tolerate the line wrap inside the principle.
-		expect(recall).toMatch(/Long-form\s+output is opt-in/);
+		// Soft target ("aim for ~500"), not a hard ceiling ("at most").
+		expect(recall).toMatch(/aim for ~500 words/);
+		expect(recall).not.toMatch(/~500 words at most/);
+		// The explicit constraint that solves the wall-of-fragments failure mode:
+		// section structure beats word count.
+		expect(recall).toMatch(/inline-bold paragraph prefixes/);
+		expect(recall).toMatch(/may\s+legitimately run longer/);
+		// Escape hatch for theme-specific elaboration.
 		expect(recall).toMatch(/deep dive/);
-		// Negative: principle 6 must NOT impose form constraints. Earlier drafts
-		// said "group by theme" / "3-5 decisions max" / "no subsection headings"
-		// — those conflict with Part B's "shape is your call". Length only.
+		// Negative: principle 6 still must NOT impose form constraints. Earlier
+		// drafts said "group by theme" / "3-5 decisions max" / "no subsection
+		// headings" — those conflict with Part B's "shape is your call".
 		expect(recall).not.toMatch(/Group commits by theme/);
 		expect(recall).not.toMatch(/3-5 key decisions max/);
 		expect(recall).not.toMatch(/No subsection headings/);

--- a/cli/src/install/SkillInstaller.test.ts
+++ b/cli/src/install/SkillInstaller.test.ts
@@ -28,6 +28,77 @@ describe("updateSkillsIfNeeded", () => {
 		expect(search).toContain("name: jolli-search");
 	});
 
+	// Plan/note stubs on commits must use the right key names — `slug` for
+	// plans (because plan slugs carry archive-suffix semantics), `id` for
+	// notes (no archive mechanism). Earlier templates conflated both as
+	// "(slug + title)", which would point the LLM at a non-existent field
+	// when looking up a note.
+	it("recall template documents plan stubs (slug+title) and note stubs (id+title) distinctly", async () => {
+		await updateSkillsIfNeeded(tempDir);
+		const recall = readFileSync(join(tempDir, ".claude/skills/jolli-recall/SKILL.md"), "utf-8");
+		expect(recall).toMatch(/`plans\?` — `\{ slug, title \}\[\]`/);
+		expect(recall).toMatch(/`notes\?` — `\{ id, title \}\[\]`/);
+		// Neither shape is described as the other.
+		expect(recall).not.toMatch(/`notes\?`[^.]*slug \+ title/);
+	});
+
+	// The stub-quoting paragraph used to unconditionally claim "content is
+	// already in your context" — but budget trimming can drop content while
+	// keeping the slug/title anchor. Without a conditional rule the LLM
+	// would fabricate quotes from a body it never received.
+	it("recall template conditionally guides quoting based on whether content is present", async () => {
+		await updateSkillsIfNeeded(tempDir);
+		const recall = readFileSync(join(tempDir, ".claude/skills/jolli-recall/SKILL.md"), "utf-8");
+		// Affirmative branch — content present → quote verbatim with attribution.
+		expect(recall).toMatch(/If the entry has `content`/);
+		// Negative branch — content absent → title-only anchor, no fabricated quotes.
+		expect(recall).toMatch(/If `content` is absent/);
+		expect(recall).toMatch(/never fabricate a quote/);
+	});
+
+	// Fact opener used to render as a single prose line that visually merged
+	// with the synthesis below. The skill template now mandates a heading +
+	// bullet block so the user has a clear, scannable verification anchor.
+	it("recall template Part A renders as `### Loaded` heading + bullet block (not a single prose line)", async () => {
+		await updateSkillsIfNeeded(tempDir);
+		const recall = readFileSync(join(tempDir, ".claude/skills/jolli-recall/SKILL.md"), "utf-8");
+		// The mandated example heading anchored on a real branch name.
+		expect(recall).toMatch(/### Loaded `feature\/auth`/);
+		// The bullet items the LLM should fill in.
+		expect(recall).toMatch(/\*\*Period:\*\*/);
+		expect(recall).toMatch(/\*\*Commits:\*\*/);
+		expect(recall).toMatch(/\*\*Captured:\*\*/);
+		// And the explicit ban on collapsing back to a single prose line.
+		expect(recall).toMatch(/heading \+ bullet shape is required/);
+		// The empty line between heading and bullets keeps markdown rendering correct.
+		expect(recall).toMatch(/### Loaded `feature\/auth`\n\n- \*\*Period:/);
+	});
+
+	// recall outputs were running long (multi-screen) because the LLM had no
+	// length anchor — search bounds itself naturally via Step-3 picking,
+	// recall has no equivalent. Principle 6 gives a concrete word ceiling +
+	// explicit deep-dive escape hatch. **Length only — no form constraint.**
+	// LLM still picks the output shape (per Part B's "shape is your call").
+	it("recall template caps default answer length at ~400 words (principle #6)", async () => {
+		await updateSkillsIfNeeded(tempDir);
+		const recall = readFileSync(join(tempDir, ".claude/skills/jolli-recall/SKILL.md"), "utf-8");
+		// Concrete word ceiling — actionable for LLM in a way "one screen" wasn't.
+		// 400 was picked over 200 after dogfood: a substantive 5-commit branch
+		// naturally produces ~700-800 words; 200 is too aggressive and forces
+		// loss of detail, 400 is roughly one screen of plain prose.
+		expect(recall).toMatch(/Brief by default/);
+		expect(recall).toMatch(/~400 words at most/);
+		// Escape hatch. Use \s+ to tolerate the line wrap inside the principle.
+		expect(recall).toMatch(/Long-form\s+output is opt-in/);
+		expect(recall).toMatch(/deep dive/);
+		// Negative: principle 6 must NOT impose form constraints. Earlier drafts
+		// said "group by theme" / "3-5 decisions max" / "no subsection headings"
+		// — those conflict with Part B's "shape is your call". Length only.
+		expect(recall).not.toMatch(/Group commits by theme/);
+		expect(recall).not.toMatch(/3-5 key decisions max/);
+		expect(recall).not.toMatch(/No subsection headings/);
+	});
+
 	// biome-ignore lint/suspicious/noTemplateCurlyInString: literal $\{ARGUMENTS} is the bash placeholder being asserted on
 	it("recall template quotes ${ARGUMENTS} (shell-injection defense)", async () => {
 		await updateSkillsIfNeeded(tempDir);
@@ -122,8 +193,10 @@ describe("updateSkillsIfNeeded", () => {
 		await updateSkillsIfNeeded(tempDir);
 		const search = readFileSync(join(tempDir, ".claude/skills/jolli-search/SKILL.md"), "utf-8");
 		expect(search).toMatch(/`title` —/);
-		expect(search).toMatch(/`trigger` —/);
-		expect(search).toMatch(/`response` —/);
+		// `trigger` and `response` are now optional in SearchHitTopic — the schema
+		// doc reflects that with `?` so the LLM doesn't expect them on every hit.
+		expect(search).toMatch(/`trigger\?` —/);
+		expect(search).toMatch(/`response\?` —/);
 		expect(search).toMatch(/`decisions` ★/);
 		expect(search).toMatch(/`todo\?` —/);
 		expect(search).toMatch(/`filesAffected\?` —/);
@@ -131,27 +204,48 @@ describe("updateSkillsIfNeeded", () => {
 		expect(search).toMatch(/`importance\?` —/);
 	});
 
+	// `diffStats` schema: actual interface is { filesChanged, insertions,
+	// deletions } — older template wrongly wrote `files`. This test pins the
+	// fix so a future revert can't go unnoticed.
+	it("search template uses correct diffStats field name (filesChanged, not files)", async () => {
+		await updateSkillsIfNeeded(tempDir);
+		const search = readFileSync(join(tempDir, ".claude/skills/jolli-search/SKILL.md"), "utf-8");
+		expect(search).toMatch(/`diffStats\?` — `\{ filesChanged, insertions, deletions \}`/);
+		expect(search).not.toMatch(/`diffStats\?` — `\{ files,/);
+	});
+
+	// Plan / note stubs: SearchHit now carries plan/note refs (slug/id + title)
+	// so the LLM can use them as grounding anchors. Search ships only stubs
+	// (no plan body) — the template must say so explicitly to avoid promising
+	// the user navigation that doesn't exist.
+	it("search template documents plan/note stubs and forbids navigation promises", async () => {
+		await updateSkillsIfNeeded(tempDir);
+		const search = readFileSync(join(tempDir, ".claude/skills/jolli-search/SKILL.md"), "utf-8");
+		expect(search).toMatch(/`plans\?` — `\{ slug, title \}\[\]`/);
+		expect(search).toMatch(/`notes\?` — `\{ id, title \}\[\]`/);
+		expect(search).toMatch(/Do NOT promise the user they can navigate to the plan body/);
+		// Don't suggest /jolli-recall as a "see the plan body" path either —
+		// recall also doesn't show plan content directly to the user.
+		expect(search).not.toMatch(/see plan content via \/jolli-recall/);
+	});
+
 	// ── Universal principles ──
 	// The principles encode lessons from past dogfood failures and are the only
 	// hard constraints (the output shape itself is up to the LLM). These tests
 	// pin each principle so a careless edit can't silently drop one.
 
-	it("search template lists Lead-with-the-answer principle and forbids Found-N-out-of-M opener", async () => {
+	it("search template lists Lead-with-the-answer principle and forbids preamble openers", async () => {
 		await updateSkillsIfNeeded(tempDir);
 		const search = readFileSync(join(tempDir, ".claude/skills/jolli-search/SKILL.md"), "utf-8");
 		expect(search).toMatch(/Lead with the answer/);
-		// Negative rationale must be present so future contributors don't add the
-		// "Found N out of M" opener back as helpful coverage info.
-		expect(search).toMatch(/Found N relevant commits out of M/);
+		// The compressed principle 1 directly forbids the two stock LLM openers.
+		expect(search).toMatch(/No "Let me analyze\.\.\." or "Found N commits\.\.\." preamble/);
 	});
 
-	it("search template requires file paths as markdown links and forbids backtick-only", async () => {
+	it("search template requires file paths as markdown links", async () => {
 		await updateSkillsIfNeeded(tempDir);
 		const search = readFileSync(join(tempDir, ".claude/skills/jolli-search/SKILL.md"), "utf-8");
 		expect(search).toMatch(/\[cli\/src\/Types\.ts\]\(cli\/src\/Types\.ts\)/);
-		// Negative-rationale prose is split across two lines after the markdown
-		// example, so use \s+ for whitespace tolerance.
-		expect(search).toMatch(/Never wrap\s+file paths in backticks alone/);
 	});
 
 	it("search template forbids snippet dumps but ENCOURAGES short bold verbatim quotes from recap/decisions", async () => {
@@ -160,30 +254,42 @@ describe("updateSkillsIfNeeded", () => {
 		// Synthesize-don't-dump is still in (no wall-of-fragments).
 		expect(search).toMatch(/Synthesize, don't dump/);
 		expect(search).toMatch(/wall-of-fragments/);
-		// New: bold verbatim quotes are explicitly encouraged. This is the principle
-		// that makes "the answer came from real stored data" visually obvious to the
-		// user — bolding signals "this came from `recap` or `decisions` verbatim".
+		// Bold verbatim quotes are explicitly encouraged.
 		expect(search).toMatch(/short verbatim quotes/);
-		// The bold convention is reserved for verbatim — not generic emphasis.
-		expect(search).toMatch(/Bold in this skill means "verbatim from stored data"/);
 		// And a worked example anchoring the format the LLM should emit.
 		expect(search).toMatch(/\*\*"stateless, scales horizontally"\*\*/);
 	});
 
-	it("search template forbids exposing search machinery (Phase 1 / Phase 2 / catalog)", async () => {
+	it("search template forbids exposing machinery (Phase 1 / Phase 2 / catalog / SearchHit)", async () => {
 		await updateSkillsIfNeeded(tempDir);
 		const search = readFileSync(join(tempDir, ".claude/skills/jolli-search/SKILL.md"), "utf-8");
-		expect(search).toMatch(/Don't expose search machinery/);
+		expect(search).toMatch(/Don't expose machinery/);
+		// Specific machinery names are listed so the LLM has concrete forbids.
+		expect(search).toMatch(/"Phase 1"/);
+		expect(search).toMatch(/"Phase 2"/);
+		expect(search).toMatch(/"catalog"/);
+		expect(search).toMatch(/"SearchHit"/);
 	});
 
-	it("search template forbids Open-in-IDE / vscode:// links and points at jolli view as fallback", async () => {
+	// Principle 7 ("No vscode:// links") and principle 4 ("Skip near-duplicates")
+	// were removed in the principles-simplification refactor. Pin both deletions
+	// so a casual revert can't reintroduce noise the template doesn't need.
+	it("search template does NOT carry the legacy vscode:// principle", async () => {
 		await updateSkillsIfNeeded(tempDir);
 		const search = readFileSync(join(tempDir, ".claude/skills/jolli-search/SKILL.md"), "utf-8");
-		// Earlier iterations rendered [Open in IDE](vscode://...) — chat webview
-		// silently strips the click. Don't resurrect.
-		expect(search).toMatch(/No `\[Open in IDE\]\(vscode:\/\/\.\.\.\)`/);
-		// The replacement open action — works in any chat surface via Bash tool.
-		expect(search).toMatch(/jolli view --commit <hash>/);
+		// CLI is the only "open commit" path now — but it's still mentioned by Step
+		// 4 as the disambiguation tool. The principle that called it out as a
+		// vscode:// alternative is gone.
+		expect(search).not.toMatch(/Open in IDE/);
+		expect(search).not.toMatch(/vscode:\/\//);
+	});
+
+	it("search template does NOT carry the legacy near-duplicate principle (root-only filter handles it)", async () => {
+		await updateSkillsIfNeeded(tempDir);
+		const search = readFileSync(join(tempDir, ".claude/skills/jolli-search/SKILL.md"), "utf-8");
+		// Skip-near-duplicates was redundant with the catalog-side root-only filter
+		// and burned attention budget; removed. Don't reintroduce.
+		expect(search).not.toMatch(/Skip near-duplicates/);
 	});
 
 	// ── Free-shape rendering (the central design point) ──

--- a/cli/src/install/SkillInstaller.ts
+++ b/cli/src/install/SkillInstaller.ts
@@ -141,57 +141,163 @@ jolli-skill-version: ${SKILL_VERSION}
 
 > Every commit deserves a Memory. Every memory deserves a Recall.
 
-## Step 1: Load Context
+Load the structured development context for a branch — commits with their
+distilled topics (trigger / response / decisions / files), plus any plans
+and notes that the work referenced. Synthesize a grounded answer to the
+user's prompt about that branch.
 
-Run this Bash command to load Jolli context data:
+## Step 1: Parse the argument
+
+The user's input is either a branch name (exact or fragment) or empty (use
+the current git branch). Quote it when constructing bash to prevent shell
+injection.
+
+## Step 2: Run the CLI
 
 \`\`\`
-"$HOME/.jolli/jollimemory/run-cli" recall "\${ARGUMENTS}" --budget 30000 --format json
+"$HOME/.jolli/jollimemory/run-cli" recall "\${ARGUMENTS}" --format json
 \`\`\`
 
-If the file \`~/.jolli/jollimemory/run-cli\` does not exist, tell the user:
+If \`~/.jolli/jollimemory/run-cli\` does not exist, tell the user:
 "Jolli not installed. Please install via \`npm install -g @jolli.ai/cli && jolli enable\` or install the Jolli VS Code extension."
 Do not attempt further processing.
 
-## Step 2: Process the Result
+## Step 3: Handle the response
 
-The command output is JSON with a "type" field. Handle each case:
+The output is JSON with a \`type\` field. Three cases:
 
-### type: "recall" — Full context loaded successfully
-Generate the loading report:
+### type: "recall" — full payload returned
 
-**Part 1: Loading Confirmation & Statistics**
-- Time span, commit count, file change statistics
-- Total context size (tokens) and percentage of context window used
-- Breakdown by content type: N topics (~X tokens), N plans (~Y tokens), N decisions (~Z tokens)
+You have a \`RecallPayload\` with these fields:
 
-**Part 2: Understanding Summary**
-In your own words, summarize what you understood:
-- What this branch is implementing (one sentence)
-- Key technical decisions and why they were made
-- What was last worked on
-- Main files involved
+- \`branch\`, \`period: { start, end }\`, \`commitCount\`, \`totalFilesChanged\`,
+  \`totalInsertions\`, \`totalDeletions\` — branch-level facts.
+- \`commits[]\` — per-commit projection. Each carries:
+  - identity (always present): \`hash\` (8-char display), \`fullHash\`, \`branch\`,
+    \`commitDate\`, \`commitAuthor\`, \`commitMessage\`; optional \`commitType?\`,
+    \`ticketId?\`.
+  - \`diffStats?\` — \`{ filesChanged, insertions, deletions }\`.
+  - \`recap?\` — 1-3 paragraphs of plain-English narrative.
+  - \`topics[]\` — each with **always present**: \`title\`, **\`decisions\` (★)**;
+    **may be absent**: \`trigger?\`, \`response?\`, \`todo?\`, \`filesAffected?\`,
+    \`category?\`, \`importance?\`. \`trigger\` and \`response\` may be dropped by
+    budget trimming; \`decisions\` is never dropped from a kept commit (if the
+    budget can't fit it, the whole commit is omitted from \`commits[]\`).
+  - \`plans?\` — \`{ slug, title }[]\` refs only; \`slug\` is the **normalized
+    base slug** that always resolves to an entry in payload-level \`plans\`.
+  - \`notes?\` — \`{ id, title }[]\` refs only; \`id\` always resolves to an
+    entry in payload-level \`notes\`. (Notes use \`id\`, not \`slug\` — they
+    have no archive-suffix mechanism.)
+- \`plans[]\` — branch-deduplicated plan bodies: \`{ slug, title, content? }\`.
+  \`content\` may be absent under tight budget — when absent, the entry is
+  still a valid grounding anchor but you can't quote from it.
+- \`notes[]\` — same shape and trimming rule as plans.
+- \`stats\`, \`estimatedTokens\`, \`truncated?\`.
 
-This section is critical for building user trust — the user needs to see that
-you accurately understand the prior work.
+Render in two parts (in order):
 
-**Part 3: Next Steps**
-Ask: "What would you like to work on next?"
+#### Part A — Forced fact opener (no paraphrase, no interpretation)
 
-### type: "catalog" — Branch lookup needed
-The CLI returned a catalog because no exact branch match was found.
-If a "query" field is present, use semantic matching against the catalog's
-branch names, commit messages, and topicTitles (LLM-distilled per-commit titles):
-- Match across languages: e.g. CJK keywords should match English branch names/messages
-- Match by time: e.g. "last week" or date-related queries should match by date range
-- Match topicTitles when present — they carry far more signal than commit messages
-- One match: load it with Bash: \`"$HOME/.jolli/jollimemory/run-cli" recall "<branch>" --budget 30000 --format json\`, then output the full report above
-- Multiple matches: show candidates, ask user to choose
-- No matches: show full catalog, ask user to clarify
+Render the loaded confirmation as a heading + bullet block (not a prose
+line). **Facts only — do not interpret what the branch is "about" here.**
+The mandated shape:
 
-If no "query" field (user ran without arguments and current branch has no records):
-- Show the branch catalog in a friendly format
-- Ask which branch they want to recall
+\`\`\`markdown
+### Loaded \`feature/auth\`
+
+- **Period:** 2026-04-10 → 2026-04-15 (5 days)
+- **Commits:** 8 (+312 −89, 24 files)
+- **Captured:** 12 topics, 5 key decisions, 2 plans, 3 notes
+\`\`\`
+
+The heading + bullet shape is required — a single prose line blends into
+the synthesis below and the user loses the visual anchor for verification.
+Save interpretation for Part B.
+
+#### Part B — Free-form synthesis
+
+Pick whatever shape best serves the user's prompt: prose narrative,
+chronological timeline, decision-focused bullet list, side-by-side
+comparison, mixed. The principles below are the only constraints.
+
+#### Universal principles (apply regardless of shape)
+
+1. **Lead with the answer.** No "Let me analyze..." or "Found N commits..."
+   preamble.
+
+2. **Ground every concrete claim** to a hash and/or file. Use \`(abc12345)\`
+   for hashes and \`[middleware/auth.ts](middleware/auth.ts)\` for files.
+
+3. **Synthesize, don't dump — but DO use short verbatim quotes.** Read
+   everything; fold into coherent prose or bullets. **However**, when a
+   single short sentence or phrase from \`decisions\` / \`recap\` /
+   \`plans[].content\` / \`notes[].content\` captures the answer concisely,
+   quote it verbatim in **bold** with attribution. Examples:
+
+   - *the design chose JWT because* **"stateless, scales horizontally"**
+     *(decisions, abc12345)*
+   - *per the auth-redesign plan,* **"all session tokens must be opaque"**
+     *(plan: auth-redesign)*
+
+   Use sparingly (1-3 quotes per answer); never wall-of-fragments.
+
+4. **Reply in the user's language.** Template is English; user-visible
+   output matches the user.
+
+5. **Don't expose machinery.** No "RecallPayload" / "commits array" /
+   "JSON field" / "SearchHit" mentions.
+
+6. **Brief by default — keep the answer to ~400 words at most.**
+   Long-form output is opt-in; render it only when the user explicitly
+   asks for a "deep dive" or asks for detail on a specific theme.
+
+#### Plan / note stubs on commits
+
+When a commit carries \`plans?\` / \`notes?\` stubs, use the stub title as a
+grounding anchor for narrative ("the auth-redesign plan guides this work").
+
+**To quote from a plan or note body**, look up the matching entry in the
+top-level \`plans\` / \`notes\` array by its \`slug\` (plans) or \`id\` (notes):
+
+- If the entry has \`content\`: quote verbatim with \`(plan: <slug>)\` /
+  \`(note: <id>)\` attribution if relevant to the user's prompt.
+- If \`content\` is absent (budget trimming dropped the body): use **only**
+  the title as a citation anchor — never fabricate a quote from a body
+  you cannot see.
+
+#### Empty / partial handling
+
+- Empty \`commits\`: tell the user no records were found; suggest running
+  \`jolli enable\` if they expected records.
+- \`truncated: true\`: budget enforcement dropped fields or commits. Mention
+  it with a one-liner if the user asks for deeper detail; otherwise stay
+  silent.
+
+### type: "catalog" — branch lookup needed
+
+Returned when no exact branch match was found. Has a \`branches[]\` array
+with \`branch\`, \`commitCount\`, \`period\`, \`commitMessages\`, \`topicTitles?\`.
+If a \`query\` field is present, semantic-match the user's input against
+\`branch\`, \`commitMessages\`, and \`topicTitles\` (the highest-signal source);
+support cross-language matching and time-relative queries.
+
+- One match: re-run \`"$HOME/.jolli/jollimemory/run-cli" recall "<branch>" --format json\`
+  and continue from Step 3.
+- Multiple matches: list candidates, ask user to choose.
+- No matches: show the catalog, ask user to clarify.
+
+### type: "error" — CLI returned a hard error
+
+Has a \`message\` string. Common cases:
+
+- Branch matched but its summaries failed to load.
+- No records in the repo at all.
+- Invalid argument or internal failure.
+
+Surface the message verbatim to the user (translated into their language if
+non-English). For "no records in this repo" specifically, suggest running
+\`jolli enable\` if they expected records. Do NOT retry or fabricate a recall
+payload from nothing.
 `;
 }
 
@@ -347,7 +453,7 @@ Each \`results[i]\` is a \`SearchHit\`:
 - \`ticketId?\` — render as \`[TICKET-1234]\` badge
 
 **Change scale**:
-- \`diffStats?\` — \`{ files, insertions, deletions }\`
+- \`diffStats?\` — \`{ filesChanged, insertions, deletions }\`
 
 **Narrative**:
 - \`recap?\` — 1-3 paragraphs of plain-English narrative. Highest-quality prose; primary source for "what is X" / "explain X".
@@ -355,31 +461,29 @@ Each \`results[i]\` is a \`SearchHit\`:
 **Topics** — \`topics: SearchHitTopic[]\` (★ the meat):
 
   - \`title\` — one-sentence label
-  - \`trigger\` — 1-2 sentences, what prompted the work
-  - \`response\` — implementation summary, may include code; longest field
+  - \`trigger?\` — 1-2 sentences, what prompted the work
+  - \`response?\` — implementation summary, may include code; longest field
   - \`decisions\` ★ **THE STAR FIELD** — design choices + *why*, as markdown bullets. Primary source for "why did we choose X" / "what alternatives" / "rationale". Not in the diff; only here.
   - \`todo?\` — residual work the LLM flagged (rare)
   - \`filesAffected?\` — per-topic file list. Render as markdown links: \`[cli/src/Types.ts](cli/src/Types.ts)\`.
   - \`category?\` — \`feature\` / \`bugfix\` / \`refactor\` / \`tech-debt\` / \`docs\` / \`test\` / \`devops\` / \`ux\`
   - \`importance?\` — \`major\` / \`minor\`
 
+**Plan / note stubs**:
+- \`plans?\` — \`{ slug, title }[]\` — plan refs this commit declared. Search ships only stubs (no plan body); use the title as a grounding anchor in your narrative ("the decision is consistent with the auth-redesign plan referenced by this commit"). **Do NOT promise the user they can navigate to the plan body from search** — search Phase 2 carries no plan content.
+- \`notes?\` — \`{ id, title }[]\` — same shape and rule as plans.
+
 ### B. Universal principles (apply regardless of shape)
 
-Non-negotiable. Encoded from past dogfood failures.
+1. **Lead with the answer.** No "Let me analyze..." or "Found N commits..." preamble.
 
-1. **Lead with the answer**, not with search mechanics. Never open with "Found N relevant commits out of M". Coverage chatter belongs only in the empty/partial branches below.
+2. **Ground every concrete claim** to a hash and/or file. Use \`(abc1234)\` for hashes and \`[cli/src/Types.ts](cli/src/Types.ts)\` for files.
 
-2. **Ground every concrete claim** to a hash and/or file. Use \`(abc1234)\` for hashes and \`[cli/src/Types.ts](cli/src/Types.ts)\` for files. Never wrap file paths in backticks alone — markdown-link form stays readable AND becomes clickable.
+3. **Synthesize, don't dump — but DO use short verbatim quotes.** Read everything; fold into coherent prose or bullets. **However**, when a single short sentence or phrase from \`recap\` or \`decisions\` captures the answer concisely, quote it verbatim in **bold** with attribution: e.g. *the design chose JWT because* **"stateless, scales horizontally"** *(decisions, abc1234)*. Use sparingly (1-3 quotes per answer); never wall-of-fragments.
 
-3. **Synthesize, don't dump — but DO use short verbatim quotes.** Read everything; fold into coherent prose or bullets. **However**, when a single short sentence or phrase from \`recap\` or \`decisions\` captures the answer concisely, quote it verbatim in **bold** with attribution: e.g. *the design chose JWT because* **"stateless, scales horizontally"** *(decisions, abc1234)*. Bold in this skill means "verbatim from stored data" — it builds user confidence that answers come from real recorded decisions, not LLM paraphrase. Use sparingly (1-3 quotes per answer); never wall-of-fragments.
+4. **Reply in the user's language.** Template is English; user-visible output matches the user.
 
-4. **Skip near-duplicates** from amend / squash chains (same \`commitMessage\`, similar topics). One row per logical change.
-
-5. **Reply in the user's language.** Template is English; user-visible output matches the user.
-
-6. **Don't expose search machinery.** No "Phase 1" / "Phase 2" / "catalog" / "SearchHit JSON" mentions.
-
-7. **No \`[Open in IDE](vscode://...)\` links** — chat webview filters non-http(s) clicks (anthropics/claude-code#26952). Use \`jolli view --commit <hash>\` as the per-commit open action.
+5. **Don't expose machinery.** No "Phase 1" / "Phase 2" / "catalog" / "SearchCatalog" / "SearchHit" / "JSON field" mentions.
 
 ### C. Output shape
 

--- a/cli/src/install/SkillInstaller.ts
+++ b/cli/src/install/SkillInstaller.ts
@@ -217,8 +217,11 @@ Save interpretation for Part B.
 #### Part B — Free-form synthesis
 
 Pick whatever shape best serves the user's prompt: prose narrative,
-chronological timeline, decision-focused bullet list, side-by-side
-comparison, mixed. The principles below are the only constraints.
+chronological timeline, decision-focused bullet list, per-theme
+\`###\` sections, side-by-side comparison, mixed. When multiple
+distinct themes emerge across the commits, prefer \`###\` per theme —
+inline-bold paragraph prefixes blend into a wall under markdown
+rendering. The principles below are the only constraints.
 
 #### Universal principles (apply regardless of shape)
 
@@ -256,9 +259,14 @@ comparison, mixed. The principles below are the only constraints.
 5. **Don't expose machinery.** No "RecallPayload" / "commits array" /
    "JSON field" / "SearchHit" mentions.
 
-6. **Brief by default — keep the answer to ~500 words at most.**
-   Long-form output is opt-in; render it only when the user explicitly
-   asks for a "deep dive" or asks for detail on a specific theme.
+6. **Brief by default — synthesize, don't dump every commit.** Skip
+   routine commits and merge overlapping themes; aim for ~500 words
+   on a typical branch, but favor section structure over compression.
+   Never collapse \`###\` themes into inline-bold paragraph prefixes
+   just to hit a word count — that produces a wall and defeats the
+   structure's purpose. Branches with many distinct themes may
+   legitimately run longer; a "deep dive" on a specific theme is
+   opt-in.
 
 #### Plan / note stubs on commits
 

--- a/cli/src/install/SkillInstaller.ts
+++ b/cli/src/install/SkillInstaller.ts
@@ -228,18 +228,27 @@ comparison, mixed. The principles below are the only constraints.
 2. **Ground every concrete claim** to a hash and/or file. Use \`(abc12345)\`
    for hashes and \`[middleware/auth.ts](middleware/auth.ts)\` for files.
 
-3. **Synthesize, don't dump — but DO use short verbatim quotes.** Read
-   everything; fold into coherent prose or bullets. **However**, when a
-   single short sentence or phrase from \`decisions\` / \`recap\` /
-   \`plans[].content\` / \`notes[].content\` captures the answer concisely,
-   quote it verbatim in **bold** with attribution. Examples:
+3. **Synthesize, don't dump — but DO use verbatim quotes from stored
+   data.** Read everything; fold into coherent prose or bullets.
+   Whenever a phrase from \`decisions\` / \`recap\` / \`plans[].content\` /
+   \`notes[].content\` captures the answer more compactly than your
+   paraphrase, quote it verbatim in **bold** with attribution.
 
-   - *the design chose JWT because* **"stateless, scales horizontally"**
-     *(decisions, abc12345)*
-   - *per the auth-redesign plan,* **"all session tokens must be opaque"**
-     *(plan: auth-redesign)*
+   Quote **complete clauses (typically 10-30 words)** — not 2-3 word
+   fragments that depend on your surrounding paraphrase to mean
+   anything. The reader should be able to skim the bold quote alone
+   and understand its claim. Format, embedded in narrative:
 
-   Use sparingly (1-3 quotes per answer); never wall-of-fragments.
+   *The design chose JWT because* **"the stateless model lets us scale
+   horizontally without a shared session store across regions"**
+   *(decisions, abc12345)*; *per the auth-redesign plan,* **"all session
+   tokens must be opaque, with no client-readable claims, so rotation
+   never breaks the API"** *(plan: auth-redesign)*.
+
+   **Bold = verbatim from stored data.** Never use bold for general
+   emphasis. Quotes belong inside running prose or bullets that carry
+   their own narrative — never as bare bullets stripped of context.
+   Stringing bare quotes is the wall-of-fragments failure mode.
 
 4. **Reply in the user's language.** Template is English; user-visible
    output matches the user.
@@ -247,7 +256,7 @@ comparison, mixed. The principles below are the only constraints.
 5. **Don't expose machinery.** No "RecallPayload" / "commits array" /
    "JSON field" / "SearchHit" mentions.
 
-6. **Brief by default — keep the answer to ~400 words at most.**
+6. **Brief by default — keep the answer to ~500 words at most.**
    Long-form output is opt-in; render it only when the user explicitly
    asks for a "deep dive" or asks for detail on a specific theme.
 
@@ -479,7 +488,11 @@ Each \`results[i]\` is a \`SearchHit\`:
 
 2. **Ground every concrete claim** to a hash and/or file. Use \`(abc1234)\` for hashes and \`[cli/src/Types.ts](cli/src/Types.ts)\` for files.
 
-3. **Synthesize, don't dump — but DO use short verbatim quotes.** Read everything; fold into coherent prose or bullets. **However**, when a single short sentence or phrase from \`recap\` or \`decisions\` captures the answer concisely, quote it verbatim in **bold** with attribution: e.g. *the design chose JWT because* **"stateless, scales horizontally"** *(decisions, abc1234)*. Use sparingly (1-3 quotes per answer); never wall-of-fragments.
+3. **Synthesize, don't dump — but DO use verbatim quotes from stored data.** Read everything; fold into coherent prose or bullets. Whenever a phrase from \`recap\` or \`decisions\` captures the answer more compactly than your paraphrase, quote it verbatim in **bold** with attribution.
+
+   Quote **complete clauses (typically 10-30 words)** — not 2-3 word fragments that depend on your surrounding paraphrase to mean anything. The reader should be able to skim the bold quote alone and understand its claim. Format, embedded in narrative: *the design chose JWT because* **"the stateless model lets us scale horizontally without a shared session store across regions"** *(decisions, abc1234)*.
+
+   **Bold = verbatim from stored data.** Never use bold for general emphasis. Quotes belong inside running prose or bullets that carry their own narrative — never as bare bullets stripped of context. Stringing bare quotes is the wall-of-fragments failure mode.
 
 4. **Reply in the user's language.** Template is English; user-visible output matches the user.
 


### PR DESCRIPTION
<!-- jollimemory-summary-start -->
## Commits in this PR (2)

1. Refactor recall to ship structured RecallPayload with budget trimming (`2085089`)
2. Upgrade search skill verbatim-quote rules to complete clauses (`692e0f8`)

## Quick recap (2)

### Commit 1 of 2: Refactor recall to ship structured RecallPayload with budget trimming (`2085089`)

The recall command's JSON output was rebuilt from the ground up. Instead of sending a pre-rendered markdown summary to the skill template, the command now ships a structured payload containing per-commit data, branch statistics, and plan and note bodies — the same approach the search skill already uses. A graduated budget-trimming sequence strips verbose fields progressively before evicting whole commits, and the commits array is now guaranteed to be non-empty whenever the branch has any records at all, giving the skill template a clean and unambiguous signal for the "no records" case.

The recall skill template was also updated to match. The branch statistics section now renders as a titled heading with labeled bullet points, giving users an immediately scannable confirmation that the right branch was loaded before any interpretation begins. A word ceiling was added to the free-form synthesis section — output is now capped at roughly 400 words by default, with longer responses available on explicit request. The ceiling constrains only length, leaving the model free to choose whatever structure best fits the content.

### Commit 2 of 2: Upgrade search skill verbatim-quote rules to complete clauses (`692e0f8`)

The verbatim quoting rules in the search skill were overhauled to require complete, self-contained clauses rather than short word fragments. Quoted phrases now need to carry their own meaning — subject, verb, and claim — so a reader skimming only the bold text can understand what the stored data actually says. The worked examples embedded in the skill instructions were rewritten to demonstrate this longer form, and the hard limit of one to three quotes per answer was removed in favor of a use-it-when-it-helps density rule. The word budget for search answers was also expanded slightly to give the model room to include fuller quotes alongside narrative prose. Future commit summaries and search answers will show noticeably longer, more self-contained bold quotes grounded in the original stored text.

## Topics (5)
<details>
<summary><strong>01 · [2085089] Recall command now ships structured data payload instead of rendered markdown</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The recall command's JSON output mode was sending a pre-rendered markdown blob to the skill template, which tempted the language model into paraphrasing mode rather than grounded synthesis from raw data. The team wanted the same discipline already proven by the search skill: structured fields the model reasons over directly.

**💡 Decisions Behind the Code**

- **Structured payload over pre-rendered markdown**: Shipping a markdown blob meant the model's first act was to re-interpret and paraphrase content that had already been rendered for human reading. Structured fields let the model perform grounded synthesis with citation anchors, matching the discipline the search skill already validated in production.
- **Budget trimming in code rather than truncating the markdown string**: A graduated trim sequence (verbose fields first, bodies second, whole commits last) preserves the most useful grounding data within the token ceiling. Truncating a markdown string at a character boundary would silently destroy citation anchors mid-sentence with no signal to the model.
- **Always keep at least one commit under pathological budgets**: Allowing the commits array to go empty created an ambiguous state where the model could not distinguish "branch has no records" from "budget was too tight." Reserving the empty array exclusively for the zero-records case keeps the skill template's empty-handling rule simple and unambiguous, at the cost of a minor budget overage in extreme edge cases.

**✅ What Was Implemented**

- `RecallCommand.ts` was updated to call the new `buildRecallPayload` function instead of `renderContextMarkdown`, replacing the old `ContextOutput` type (which carried a single `renderedMarkdown` string) with a fully structured `RecallPayload` that includes per-commit projections, branch-level aggregates, top-level plan and note bodies, stats, and a token estimate.
- `ContextCompiler.ts` gained the `RecallPayload`, `RecallPayloadPlan`, and `RecallPayloadNote` interfaces alongside the `buildRecallPayload` function, which projects each compiled summary into a `SearchHit` via the existing `buildHit` helper and applies a multi-step budget trimming sequence: drop topic responses, drop topic triggers, drop plan bodies, drop note bodies, then evict oldest commits — stopping before the array goes empty.
- `ContextCompiler.test.ts` received an extensive new test suite covering the full trim cascade, the stub-filtering invariant (no dangling plan/note stubs on commits), the empty-state guarantee, envelope token accounting, and branch-aggregate passthrough.

**📁 FILES**
- `cli/src/commands/RecallCommand.ts`
- `cli/src/core/ContextCompiler.ts`
- `cli/src/Cli.test.ts`

</blockquote>
</details>
<details>
<summary><strong>02 · [2085089] Recall output format improved with structured fact opener and length ceiling</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

After dogfooding the recall skill, the output was visually hard to scan — the branch statistics appeared as a single run-on prose line indistinguishable from the synthesis below it — and the free-form synthesis regularly exceeded a full screen even for modest branches.

**💡 Decisions Behind the Code**

- **Heading and bullets for the fact opener rather than prose**: The prose example in the original template caused the model to produce a single dense line that blended visually into the synthesis. A mandated structural shape gives the user an immediate verifiable anchor before any interpretation begins.
- **Word ceiling only, no form constraints on the synthesis**: An earlier draft also restricted the number of themes and banned subsection headings. The developer rejected this on the grounds that it limited the model's expressive range unnecessarily — the only real problem was total length, not structure. Constraining only the word count leaves the model free to choose bullets, headings, or prose as the content warrants.

**✅ What Was Implemented**

- The recall skill template in `SkillInstaller.ts` was updated so the fact opener is now a required heading-plus-bullets shape, with a fenced example showing the mandated format including bold labels for period, commits, and captured counts.
- A sixth universal principle was added to the template capping default output at roughly 400 words, with an explicit escape hatch allowing longer output only when the user asks for a deep dive on a specific theme.

**📁 FILES**
- `cli/src/install/SkillInstaller.ts`

</blockquote>
</details>
<details>
<summary><strong>03 · [2085089] Fixed misleading empty-commits guidance and fabricated-quote risk in skill template</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

A review identified two internal contradictions in the recall skill template: the empty-commits handling told the model to report "no records found" even when records existed but were budget-evicted, and the plan/note stub section encouraged the model to quote content verbatim even when that content might have been stripped by budget trimming.

**💡 Decisions Behind the Code**

Fixing the empty-commits ambiguity at the data layer rather than adding a three-branch conditional to the template kept the template simple and honest. Adding a third case to the template would have required the model to reason about token budgets — an implementation detail that belongs in the compiler, not in the skill instructions.

**✅ What Was Implemented**

- The empty-commits handling in `SkillInstaller.ts` was left unchanged in the template (the fix moved to the compiler layer — see the payload refactor topic), preserving the simple rule that an empty commits array always means genuinely no records.
- The plan/note stub section was rewritten to be conditional: when a top-level entry carries content the model may quote it with attribution; when content is absent due to budget trimming the model must use only the title as a citation anchor and must not fabricate a quote from a body it does not have.

**📁 FILES**
- `cli/src/install/SkillInstaller.ts`
- `cli/src/core/ContextCompiler.ts`

</blockquote>
</details>
<details>
<summary><strong>04 · [2085089] Corrected stale documentation listing plans and notes as absent from search results</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

A code comment in the search module still listed plans and notes under "notable absences" even though both fields had already been added to the search result type, creating a misleading reference for future maintainers.

**💡 Decisions Behind the Code**

No design decision was involved — this was a documentation-only correction to keep the comment accurate after the fields were added.

**✅ What Was Implemented**

The "Notable absences" comment in `Search.ts` was updated to remove plans and notes from the absent list and add a clarifying note that plan and note references are now shipped as stubs on each result.

**📁 FILES**
- `cli/src/core/Search.ts`

</blockquote>
</details>
<details>
<summary><strong>05 · [692e0f8] Verbatim quote rules upgraded to require complete self-contained clauses</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The search skill's prompt was producing sparse, fragmentary bold quotes — two or three words that depended entirely on surrounding paraphrase to carry meaning. The user wanted quoted phrases to stand alone so a reader skimming only the bold text could understand the claim without reading the rest of the sentence.

**💡 Decisions Behind the Code**

- **Remove the per-answer quote cap rather than raise it:** The 1-3 cap was identified as a dead letter in the search skill (long answers naturally exceeded it) but a hard constraint in the recall skill where the 400-word ceiling amplified its effect. Replacing the numeric cap with a density-and-structure rule — quote whenever a phrase is more compact than paraphrase — keeps the intent (no wall-of-fragments) without starving shorter answers of grounding evidence.
- **Require complete clauses (10-30 words) instead of short phrases:** Short fragments shift the burden of meaning onto the model's surrounding paraphrase, which defeats the trust-signal purpose of bold verbatim quotes. A complete clause carries its own subject, verb, and claim, so a reader can verify the stored data independently. The 10-30 word range was chosen to cover typical decision rationale sentences without mandating full multi-clause sentences.
- **Replace bullet-list examples with inline prose examples:** The previous examples were formatted as bullet points, which implicitly taught the model that verbatim quotes belong in lists. The new example is embedded in a running sentence, matching the actual desired output form and eliminating the contradiction with the wall-of-fragments prohibition.

**✅ What Was Implemented**

- Updated the verbatim-quote rule in both the recall-style and search-style skill templates inside `SkillInstaller.ts`. The old rule encouraged "short verbatim quotes" with a hard cap of 1-3 per answer; the new rule removes the cap, requires complete clauses of typically 10-30 words, and adds an explicit self-check: "the reader should be able to skim the bold quote alone and understand its claim." The worked example was replaced with a 17-word complete clause to anchor the model's output toward that length.
- The word ceiling for the search skill was raised from ~400 to ~500 words to give the model room to embed longer quotes without crowding out narrative prose.
- Tests in `SkillInstaller.test.ts` were rewritten to assert the new requirements: presence of "complete clauses (typically 10-30 words)", "not 2-3 word fragments", and the new worked example string; and absence of the deprecated "Use sparingly (1-3 quotes per answer)" and "short verbatim quotes" strings.

**📁 FILES**
- `cli/src/install/SkillInstaller.ts`
- `cli/src/install/SkillInstaller.test.ts`

</blockquote>
</details>

---

*Generated by Jolli Memory · May 9, 2026 at 2:34 PM*
<!-- jollimemory-summary-end -->