### PR TITLE
Split worker and orphan-write locks into separate directories with PID-ownership checks

### DIFF
--- a/cli/src/Cli.test.ts
+++ b/cli/src/Cli.test.ts
@@ -33,8 +33,6 @@ vi.mock("./core/SessionTracker.js", () => ({
 	loadConfig: vi.fn().mockResolvedValue({}),
 	saveConfig: vi.fn().mockResolvedValue(undefined),
 	// Used by doctor / clean commands
-	isLockStale: vi.fn().mockResolvedValue(false),
-	releaseLock: vi.fn().mockResolvedValue(undefined),
 	loadAllSessions: vi.fn().mockResolvedValue([]),
 	countActiveQueueEntries: vi.fn().mockResolvedValue(0),
 	countStaleSessions: vi.fn().mockResolvedValue(0),
@@ -43,6 +41,11 @@ vi.mock("./core/SessionTracker.js", () => ({
 	pruneStaleQueueEntries: vi.fn().mockResolvedValue(0),
 	checkStaleSquashPending: vi.fn().mockResolvedValue(null),
 	deleteSquashPending: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("./core/Locks.js", () => ({
+	isWorkerLockStale: vi.fn().mockResolvedValue(false),
+	releaseWorkerLock: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock("./core/JolliApiUtils.js", async () => {
@@ -3444,15 +3447,14 @@ describe("CLI", () => {
 			} = {},
 		): Promise<string[]> {
 			const { getStatus } = await import("./install/Installer.js");
-			const { isLockStale, countActiveQueueEntries, loadConfig, loadAllSessions } = await import(
-				"./core/SessionTracker.js"
-			);
+			const { countActiveQueueEntries, loadConfig, loadAllSessions } = await import("./core/SessionTracker.js");
+			const { isWorkerLockStale } = await import("./core/Locks.js");
 			const { orphanBranchExists } = await import("./core/GitOps.js");
 			const { traverseDistPaths } = await import("./install/DistPathResolver.js");
 
 			// Reset (prevent bleed-over from prior tests' mockResolvedValueOnce)
 			vi.mocked(getStatus).mockReset();
-			vi.mocked(isLockStale).mockReset();
+			vi.mocked(isWorkerLockStale).mockReset();
 			vi.mocked(countActiveQueueEntries).mockReset();
 			vi.mocked(loadConfig).mockReset();
 			vi.mocked(loadAllSessions).mockReset();
@@ -3469,7 +3471,7 @@ describe("CLI", () => {
 				summaryCount: 0,
 				orphanBranch: "jollimemory/summaries/v3",
 			});
-			vi.mocked(isLockStale).mockResolvedValue(overrides.lockStale ?? false);
+			vi.mocked(isWorkerLockStale).mockResolvedValue(overrides.lockStale ?? false);
 			vi.mocked(countActiveQueueEntries).mockResolvedValue(overrides.activeQueue ?? 0);
 			vi.mocked(loadConfig).mockResolvedValue(overrides.apiKey ? { apiKey: overrides.apiKey } : {});
 			vi.mocked(loadAllSessions).mockResolvedValue([]);
@@ -3489,7 +3491,7 @@ describe("CLI", () => {
 
 			expect(output).toContain("Jolli Memory Doctor");
 			expect(output).toContain("✓ Git hooks");
-			expect(output).toContain("✓ Lock file");
+			expect(output).toContain("✓ Worker lock");
 			expect(output).toContain("✓ Config");
 			expect(output).toContain("✓ dist-paths/cli");
 			expect(output).not.toContain("Run with --fix");
@@ -3503,7 +3505,7 @@ describe("CLI", () => {
 
 		it("should flag stuck lock file as fail", async () => {
 			const output = (await runDoctor(["doctor"], { lockStale: true })).join("\n");
-			expect(output).toContain("✗ Lock file");
+			expect(output).toContain("✗ Worker lock");
 			expect(output).toContain("stuck");
 		});
 
@@ -3585,12 +3587,12 @@ describe("CLI", () => {
 		});
 
 		it("should auto-fix stale lock when --fix is passed", async () => {
-			const { releaseLock } = await import("./core/SessionTracker.js");
-			vi.mocked(releaseLock).mockClear();
+			const { releaseWorkerLock } = await import("./core/Locks.js");
+			vi.mocked(releaseWorkerLock).mockClear();
 
 			const output = (await runDoctor(["doctor", "--fix"], { lockStale: true })).join("\n");
 
-			expect(releaseLock).toHaveBeenCalled();
+			expect(releaseWorkerLock).toHaveBeenCalled();
 			expect(output).toContain("Applying fixes");
 			expect(output).toContain("released");
 		});
@@ -3655,8 +3657,8 @@ describe("CLI", () => {
 
 		it("should set exitCode=1 when --fix repairs some but unfixable failures remain (Gap B)", async () => {
 			// Lock fixer succeeds; dist-path has no fixer and stays broken.
-			const { releaseLock } = await import("./core/SessionTracker.js");
-			vi.mocked(releaseLock).mockClear();
+			const { releaseWorkerLock } = await import("./core/Locks.js");
+			vi.mocked(releaseWorkerLock).mockClear();
 			process.exitCode = 0;
 
 			const output = (
@@ -3667,7 +3669,7 @@ describe("CLI", () => {
 				})
 			).join("\n");
 
-			expect(releaseLock).toHaveBeenCalled();
+			expect(releaseWorkerLock).toHaveBeenCalled();
 			expect(output).toContain("✗ dist-paths");
 			expect(process.exitCode).toBe(1);
 			process.exitCode = 0;
@@ -3677,9 +3679,9 @@ describe("CLI", () => {
 			// --fix passed, but the only failure is dist-path which has no fixer,
 			// so fixesToApply is empty. Must still exit 1 — the ✗ is still there.
 			const { install } = await import("./install/Installer.js");
-			const { releaseLock } = await import("./core/SessionTracker.js");
+			const { releaseWorkerLock } = await import("./core/Locks.js");
 			vi.mocked(install).mockClear();
-			vi.mocked(releaseLock).mockClear();
+			vi.mocked(releaseWorkerLock).mockClear();
 			process.exitCode = 0;
 
 			const output = (await runDoctor(["doctor", "--fix"], { distPaths: [], apiKey: "sk-ant-test" })).join("\n");
@@ -3688,7 +3690,7 @@ describe("CLI", () => {
 			expect(output).not.toContain("Applying fixes");
 			expect(output).toContain("✗ dist-paths");
 			expect(install).not.toHaveBeenCalled();
-			expect(releaseLock).not.toHaveBeenCalled();
+			expect(releaseWorkerLock).not.toHaveBeenCalled();
 			expect(process.exitCode).toBe(1);
 			process.exitCode = 0;
 		});
@@ -4800,14 +4802,13 @@ describe("CLI", () => {
 			vi.mocked(getGlobalConfigDir).mockReturnValue(tmpGlobalDir);
 
 			const { getStatus } = await import("./install/Installer.js");
-			const { isLockStale, countActiveQueueEntries, loadConfig, loadAllSessions } = await import(
-				"./core/SessionTracker.js"
-			);
+			const { countActiveQueueEntries, loadConfig, loadAllSessions } = await import("./core/SessionTracker.js");
+			const { isWorkerLockStale } = await import("./core/Locks.js");
 			const { orphanBranchExists } = await import("./core/GitOps.js");
 			const { traverseDistPaths } = await import("./install/DistPathResolver.js");
 
 			vi.mocked(getStatus).mockReset();
-			vi.mocked(isLockStale).mockReset();
+			vi.mocked(isWorkerLockStale).mockReset();
 			vi.mocked(countActiveQueueEntries).mockReset();
 			vi.mocked(loadConfig).mockReset();
 			vi.mocked(loadAllSessions).mockReset();
@@ -4824,7 +4825,7 @@ describe("CLI", () => {
 				summaryCount: 0,
 				orphanBranch: "jollimemory/summaries/v3",
 			});
-			vi.mocked(isLockStale).mockResolvedValue(false);
+			vi.mocked(isWorkerLockStale).mockResolvedValue(false);
 			vi.mocked(countActiveQueueEntries).mockResolvedValue(0);
 			vi.mocked(loadConfig).mockResolvedValue({ apiKey: "sk-ant-test" });
 			vi.mocked(loadAllSessions).mockResolvedValue([]);

--- a/cli/src/commands/DoctorCommand.ts
+++ b/cli/src/commands/DoctorCommand.ts
@@ -14,14 +14,8 @@ import { join } from "node:path";
 import type { Command } from "commander";
 import { orphanBranchExists } from "../core/GitOps.js";
 import { resolveLlmCredentialSource } from "../core/LlmClient.js";
-import {
-	countActiveQueueEntries,
-	getGlobalConfigDir,
-	isLockStale,
-	loadAllSessions,
-	loadConfig,
-	releaseLock,
-} from "../core/SessionTracker.js";
+import { isWorkerLockStale, releaseWorkerLock } from "../core/Locks.js";
+import { countActiveQueueEntries, getGlobalConfigDir, loadAllSessions, loadConfig } from "../core/SessionTracker.js";
 import { traverseDistPaths } from "../install/DistPathResolver.js";
 import { getStatus, install } from "../install/Installer.js";
 import { createLogger, ORPHAN_BRANCH, setLogDir } from "../Logger.js";
@@ -91,20 +85,24 @@ async function runDoctor(cwd: string, fix: boolean): Promise<void> {
 		message: branchExists ? "exists" : "not yet created (will be created on first commit)",
 	});
 
-	// 3. Lock file (stuck = exists AND older than 5 min; a normal active lock is < 5 min)
-	const lockStale = await isLockStale(cwd);
-	if (lockStale) {
+	// 3. Worker lock (stuck = exists AND older than LOCK_TIMEOUT_MS; a normal worker
+	// refreshes mtime every minute, so any age > 5 min implies a crashed worker).
+	// `orphan-write.lock` is held only for milliseconds and is not surfaced here —
+	// if a stale orphan-write lock ever appears, doctor's `--fix` would release it
+	// implicitly via a re-run of the affected operation.
+	const workerLockStale = await isWorkerLockStale(cwd);
+	if (workerLockStale) {
 		checks.push({
-			name: "Lock file",
+			name: "Worker lock",
 			status: "fail",
 			message: "stuck (older than 5 min — Worker probably crashed) — use --fix to release",
 			fixer: async () => {
-				await releaseLock(cwd);
+				await releaseWorkerLock(cwd);
 				return "released";
 			},
 		});
 	} else {
-		checks.push({ name: "Lock file", status: "ok", message: "not stuck" });
+		checks.push({ name: "Worker lock", status: "ok", message: "not stuck" });
 	}
 
 	// 4. Active sessions (informational; stale entries are cleanup concerns → `clean`)

--- a/cli/src/core/Locks.test.ts
+++ b/cli/src/core/Locks.test.ts
@@ -1,7 +1,8 @@
+import { execFileSync } from "node:child_process";
 import { mkdtemp, rm, stat, utimes, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 // Re-export node:fs/promises through a mock so individual tests can `vi.spyOn`
 // specific members (ESM exports are not configurable by default).
@@ -10,11 +11,19 @@ vi.mock("node:fs/promises", async (importOriginal) => {
 	return { ...original };
 });
 
+// Same trick for node:child_process — needed by the fallback-path test, which
+// forces `git rev-parse` to fail to exercise the per-worktree fallback.
+vi.mock("node:child_process", async (importOriginal) => {
+	const original = await importOriginal<typeof import("node:child_process")>();
+	return { ...original };
+});
+
 vi.spyOn(console, "log").mockImplementation(() => {});
 vi.spyOn(console, "warn").mockImplementation(() => {});
 vi.spyOn(console, "error").mockImplementation(() => {});
 
 import {
+	__resetSharedLockDirCache,
 	acquireOrphanWriteLock,
 	acquireWorkerLock,
 	DEFAULT_ORPHAN_WRITE_POLL_MS,
@@ -28,15 +37,51 @@ import {
 	WORKER_LOCK_FILE,
 } from "./Locks.js";
 
+/**
+ * Worker lock dir = per-worktree (`<cwd>/.jolli/jollimemory/`).
+ * Same path regardless of git presence.
+ */
+function workerLockPath(tempDir: string): string {
+	return join(tempDir, ".jolli", "jollimemory", WORKER_LOCK_FILE);
+}
+
+/**
+ * Orphan-write lock dir = `<git-common-dir>/jollimemory/` when the cwd is
+ * inside a git repo. The default test setup does `git init` in the tempdir,
+ * so the common dir is `<tempDir>/.git`.
+ */
+function orphanWriteLockPath(tempDir: string): string {
+	return join(tempDir, ".git", "jollimemory", ORPHAN_WRITE_LOCK_FILE);
+}
+
 describe("Locks", () => {
 	let tempDir: string;
 
-	beforeEach(async () => {
+	// `git init` per test would spawn ~30 subprocesses across this file, which
+	// has been observed to push the v8-coverage worker pool over its memory
+	// budget on Windows CI. Init once per file and clean lock files between
+	// tests instead — each test still observes a fresh lock state, just inside
+	// the same git repo.
+	beforeAll(async () => {
 		tempDir = await mkdtemp(join(tmpdir(), "jollimemory-locks-"));
+		execFileSync("git", ["init", "--quiet"], { cwd: tempDir, stdio: "ignore" });
+	});
+
+	afterAll(async () => {
+		await rm(tempDir, { recursive: true, force: true });
+	});
+
+	beforeEach(async () => {
+		__resetSharedLockDirCache();
+		// Clean any lock file that an earlier test left behind so each test
+		// starts with both locks definitively unheld. `force: true` covers the
+		// usual "file does not exist" case.
+		await rm(join(tempDir, ".jolli", "jollimemory", WORKER_LOCK_FILE), { force: true });
+		await rm(join(tempDir, ".git", "jollimemory", ORPHAN_WRITE_LOCK_FILE), { force: true });
 	});
 
 	afterEach(async () => {
-		await rm(tempDir, { recursive: true, force: true });
+		__resetSharedLockDirCache();
 		vi.restoreAllMocks();
 	});
 
@@ -56,9 +101,8 @@ describe("Locks", () => {
 
 		it("reclaims a stale lock (older than LOCK_TIMEOUT_MS) and acquires", async () => {
 			expect(await acquireWorkerLock(tempDir)).toBe(true);
-			const lockPath = join(tempDir, ".jolli", "jollimemory", WORKER_LOCK_FILE);
 			const past = new Date(Date.now() - LOCK_TIMEOUT_MS - 60_000);
-			await utimes(lockPath, past, past);
+			await utimes(workerLockPath(tempDir), past, past);
 			expect(await acquireWorkerLock(tempDir)).toBe(true);
 			await releaseWorkerLock(tempDir);
 		});
@@ -71,6 +115,8 @@ describe("Locks", () => {
 		});
 
 		it("releaseWorkerLock swallows filesystem errors", async () => {
+			// Take the lock first so the PID check passes and we get to rm().
+			await acquireWorkerLock(tempDir);
 			const fsPromises = await import("node:fs/promises");
 			const rmSpy = vi.spyOn(fsPromises, "rm").mockRejectedValueOnce(new Error("EACCES"));
 			await expect(releaseWorkerLock(tempDir)).resolves.toBeUndefined();
@@ -113,9 +159,8 @@ describe("Locks", () => {
 
 		it("isWorkerLockStale returns true when lock is older than LOCK_TIMEOUT_MS", async () => {
 			await acquireWorkerLock(tempDir);
-			const lockPath = join(tempDir, ".jolli", "jollimemory", WORKER_LOCK_FILE);
 			const past = new Date(Date.now() - LOCK_TIMEOUT_MS - 60_000);
-			await utimes(lockPath, past, past);
+			await utimes(workerLockPath(tempDir), past, past);
 			expect(await isWorkerLockStale(tempDir)).toBe(true);
 			await releaseWorkerLock(tempDir);
 		});
@@ -124,10 +169,8 @@ describe("Locks", () => {
 	describe("refreshWorkerLockMtime", () => {
 		it("bumps the lock's mtime so a long-lived worker is not reaped", async () => {
 			await acquireWorkerLock(tempDir);
-			const lockPath = join(tempDir, ".jolli", "jollimemory", WORKER_LOCK_FILE);
-
 			const past = new Date(Date.now() - LOCK_TIMEOUT_MS - 60_000);
-			await utimes(lockPath, past, past);
+			await utimes(workerLockPath(tempDir), past, past);
 			expect(await isWorkerLockStale(tempDir)).toBe(true);
 
 			await refreshWorkerLockMtime(tempDir);
@@ -139,6 +182,26 @@ describe("Locks", () => {
 
 		it("silently no-ops when the lock file is missing", async () => {
 			await expect(refreshWorkerLockMtime(tempDir)).resolves.toBeUndefined();
+		});
+
+		// PID-ownership guard: if a stale-reclaim race put a different process's
+		// PID into our worker.lock, refreshing the mtime would let the other
+		// process's stale-reclaim window get extended on our behalf.
+		it("does not bump mtime when the lock is owned by a different PID", async () => {
+			// Simulate a different owner: write a foreign PID into worker.lock and
+			// backdate it so the test can detect any unwanted mtime bump.
+			const lockPath = workerLockPath(tempDir);
+			const fsPromises = await import("node:fs/promises");
+			await fsPromises.mkdir(join(tempDir, ".jolli", "jollimemory"), { recursive: true });
+			await writeFile(lockPath, "999999", "utf-8");
+			const backdated = new Date(Date.now() - 2 * LOCK_TIMEOUT_MS);
+			await utimes(lockPath, backdated, backdated);
+
+			await refreshWorkerLockMtime(tempDir);
+
+			// mtime should NOT have been advanced — the lock isn't ours.
+			const after = await stat(lockPath);
+			expect(Math.abs(after.mtimeMs - backdated.getTime())).toBeLessThan(1000);
 		});
 	});
 
@@ -194,14 +257,14 @@ describe("Locks", () => {
 
 		it("reclaims a stale orphan-write lock", async () => {
 			expect(await acquireOrphanWriteLock(tempDir)).toBe(true);
-			const lockPath = join(tempDir, ".jolli", "jollimemory", ORPHAN_WRITE_LOCK_FILE);
 			const past = new Date(Date.now() - LOCK_TIMEOUT_MS - 60_000);
-			await utimes(lockPath, past, past);
+			await utimes(orphanWriteLockPath(tempDir), past, past);
 			expect(await acquireOrphanWriteLock(tempDir, { timeoutMs: 100 })).toBe(true);
 			await releaseOrphanWriteLock(tempDir);
 		});
 
 		it("releaseOrphanWriteLock swallows filesystem errors", async () => {
+			await acquireOrphanWriteLock(tempDir);
 			const fsPromises = await import("node:fs/promises");
 			const rmSpy = vi.spyOn(fsPromises, "rm").mockRejectedValueOnce(new Error("EACCES"));
 			await expect(releaseOrphanWriteLock(tempDir)).resolves.toBeUndefined();
@@ -214,9 +277,8 @@ describe("Locks", () => {
 			expect(await acquireWorkerLock(tempDir)).toBe(true);
 			expect(await acquireOrphanWriteLock(tempDir, { timeoutMs: 100 })).toBe(true);
 
-			const dir = join(tempDir, ".jolli", "jollimemory");
-			expect((await stat(join(dir, WORKER_LOCK_FILE))).isFile()).toBe(true);
-			expect((await stat(join(dir, ORPHAN_WRITE_LOCK_FILE))).isFile()).toBe(true);
+			expect((await stat(workerLockPath(tempDir))).isFile()).toBe(true);
+			expect((await stat(orphanWriteLockPath(tempDir))).isFile()).toBe(true);
 
 			await releaseOrphanWriteLock(tempDir);
 			await releaseWorkerLock(tempDir);
@@ -231,10 +293,9 @@ describe("Locks", () => {
 
 		it("isWorkerLockHeld ignores a stale worker.lock + fresh orphan-write.lock", async () => {
 			// Plant a stale worker.lock the way a crashed worker would leave it.
-			const dir = join(tempDir, ".jolli", "jollimemory");
 			const fsPromises = await import("node:fs/promises");
-			await fsPromises.mkdir(dir, { recursive: true });
-			const stalePath = join(dir, WORKER_LOCK_FILE);
+			await fsPromises.mkdir(join(tempDir, ".jolli", "jollimemory"), { recursive: true });
+			const stalePath = workerLockPath(tempDir);
 			await writeFile(stalePath, "12345", "utf-8");
 			const past = new Date(Date.now() - LOCK_TIMEOUT_MS - 60_000);
 			await utimes(stalePath, past, past);
@@ -242,6 +303,121 @@ describe("Locks", () => {
 			expect(await acquireOrphanWriteLock(tempDir)).toBe(true);
 			expect(await isWorkerLockHeld(tempDir)).toBe(false);
 			await releaseOrphanWriteLock(tempDir);
+		});
+	});
+
+	// ── PID ownership on release ────────────────────────────────────────────
+	//
+	// Stale-reclaim race the PID check guards against:
+	//   1. Process A acquires lock (mtime t0)
+	//   2. A blocks long enough that age ≥ LOCK_TIMEOUT_MS
+	//   3. Process B's tryAcquireOnce removes A's lock and writes its own PID
+	//   4. A wakes up and runs its `finally { releaseLock }` block
+	//   5. Without the PID check: A would `rm` B's lock → C arrives → no lock
+	//      visible → C acquires → B and C now both write concurrently.
+	// The check makes step 5 a no-op.
+	describe("PID ownership on release", () => {
+		it("worker.lock release skips rm when the file's PID is not ours", async () => {
+			const lockPath = workerLockPath(tempDir);
+			const fsPromises = await import("node:fs/promises");
+			await fsPromises.mkdir(join(tempDir, ".jolli", "jollimemory"), { recursive: true });
+			// Plant a foreign PID into the worker lock — emulates the post-reclaim state.
+			const foreignPid = String(process.pid + 1);
+			await writeFile(lockPath, foreignPid, "utf-8");
+
+			await releaseWorkerLock(tempDir);
+
+			// File must still be there (not removed by us).
+			const after = await stat(lockPath);
+			expect(after.isFile()).toBe(true);
+		});
+
+		it("worker.lock release removes the file when the PID matches us", async () => {
+			await acquireWorkerLock(tempDir);
+			await releaseWorkerLock(tempDir);
+			await expect(stat(workerLockPath(tempDir))).rejects.toThrow();
+		});
+
+		it("worker.lock release is a no-op when the file is missing (idempotent)", async () => {
+			await expect(releaseWorkerLock(tempDir)).resolves.toBeUndefined();
+		});
+
+		it("orphan-write.lock release skips rm when the file's PID is not ours", async () => {
+			const fsPromises = await import("node:fs/promises");
+			await fsPromises.mkdir(join(tempDir, ".git", "jollimemory"), { recursive: true });
+			const lockPath = orphanWriteLockPath(tempDir);
+			const foreignPid = String(process.pid + 1);
+			await writeFile(lockPath, foreignPid, "utf-8");
+
+			await releaseOrphanWriteLock(tempDir);
+
+			const after = await stat(lockPath);
+			expect(after.isFile()).toBe(true);
+		});
+
+		it("orphan-write.lock release removes the file when the PID matches us", async () => {
+			await acquireOrphanWriteLock(tempDir);
+			await releaseOrphanWriteLock(tempDir);
+			await expect(stat(orphanWriteLockPath(tempDir))).rejects.toThrow();
+		});
+	});
+
+	// ── git-common-dir resolution ──────────────────────────────────────────
+	//
+	// orphan-write.lock must live at `<git-common-dir>/jollimemory/` so all
+	// worktrees of the same repository serialize on the same lock file. The
+	// default beforeEach has `git init`'d the tempdir, so the common dir is
+	// <tempDir>/.git/. Both the file's actual location and a (non-init'd)
+	// fallback path are exercised here.
+	describe("orphan-write.lock path resolution", () => {
+		it("places the lock at <git-common-dir>/jollimemory/ when cwd is inside a git repo", async () => {
+			expect(await acquireOrphanWriteLock(tempDir)).toBe(true);
+			const expected = join(tempDir, ".git", "jollimemory", ORPHAN_WRITE_LOCK_FILE);
+			expect((await stat(expected)).isFile()).toBe(true);
+			await releaseOrphanWriteLock(tempDir);
+		});
+
+		it("falls back to <cwd>/.jolli/jollimemory/ when git rev-parse fails", async () => {
+			// Force the resolver into the catch path by making `execFile` throw.
+			// Tests run with `mkdtemp` so the cache hasn't seen tempDir yet — but
+			// reset to be safe in case a previous it-block populated it.
+			__resetSharedLockDirCache();
+			const childProcess = await import("node:child_process");
+			const execSpy = vi.spyOn(childProcess, "execFile").mockImplementation(
+				// @ts-expect-error -- vi.spyOn signature for overloaded execFile is awkward; the runtime call shape matches what the resolver invokes
+				(_file: string, _args: ReadonlyArray<string>, _opts: unknown, cb: (err: Error) => void) => {
+					cb(new Error("simulated: git not found"));
+					return {} as unknown;
+				},
+			);
+
+			expect(await acquireOrphanWriteLock(tempDir)).toBe(true);
+			const fallback = join(tempDir, ".jolli", "jollimemory", ORPHAN_WRITE_LOCK_FILE);
+			expect((await stat(fallback)).isFile()).toBe(true);
+			await releaseOrphanWriteLock(tempDir);
+
+			execSpy.mockRestore();
+			__resetSharedLockDirCache();
+		});
+
+		it("caches the resolved path so repeated polls don't spawn git on every iteration", async () => {
+			__resetSharedLockDirCache();
+			const childProcess = await import("node:child_process");
+			const execSpy = vi.spyOn(childProcess, "execFile");
+
+			expect(await acquireOrphanWriteLock(tempDir)).toBe(true);
+			await releaseOrphanWriteLock(tempDir);
+			const callsAfterFirstAcquire = execSpy.mock.calls.length;
+
+			// Multiple subsequent acquire/release cycles must hit the cache (zero
+			// additional `git rev-parse` invocations).
+			for (let i = 0; i < 5; i++) {
+				await acquireOrphanWriteLock(tempDir);
+				await releaseOrphanWriteLock(tempDir);
+			}
+			expect(execSpy.mock.calls.length).toBe(callsAfterFirstAcquire);
+
+			execSpy.mockRestore();
 		});
 	});
 });

--- a/cli/src/core/Locks.test.ts
+++ b/cli/src/core/Locks.test.ts
@@ -1,0 +1,247 @@
+import { mkdtemp, rm, stat, utimes, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Re-export node:fs/promises through a mock so individual tests can `vi.spyOn`
+// specific members (ESM exports are not configurable by default).
+vi.mock("node:fs/promises", async (importOriginal) => {
+	const original = await importOriginal<typeof import("node:fs/promises")>();
+	return { ...original };
+});
+
+vi.spyOn(console, "log").mockImplementation(() => {});
+vi.spyOn(console, "warn").mockImplementation(() => {});
+vi.spyOn(console, "error").mockImplementation(() => {});
+
+import {
+	acquireOrphanWriteLock,
+	acquireWorkerLock,
+	DEFAULT_ORPHAN_WRITE_POLL_MS,
+	isWorkerLockHeld,
+	isWorkerLockStale,
+	LOCK_TIMEOUT_MS,
+	ORPHAN_WRITE_LOCK_FILE,
+	refreshWorkerLockMtime,
+	releaseOrphanWriteLock,
+	releaseWorkerLock,
+	WORKER_LOCK_FILE,
+} from "./Locks.js";
+
+describe("Locks", () => {
+	let tempDir: string;
+
+	beforeEach(async () => {
+		tempDir = await mkdtemp(join(tmpdir(), "jollimemory-locks-"));
+	});
+
+	afterEach(async () => {
+		await rm(tempDir, { recursive: true, force: true });
+		vi.restoreAllMocks();
+	});
+
+	describe("worker.lock — fail-fast", () => {
+		it("acquires and releases", async () => {
+			expect(await acquireWorkerLock(tempDir)).toBe(true);
+			await releaseWorkerLock(tempDir);
+			expect(await acquireWorkerLock(tempDir)).toBe(true);
+			await releaseWorkerLock(tempDir);
+		});
+
+		it("a second acquire returns false immediately while held", async () => {
+			expect(await acquireWorkerLock(tempDir)).toBe(true);
+			expect(await acquireWorkerLock(tempDir)).toBe(false);
+			await releaseWorkerLock(tempDir);
+		});
+
+		it("reclaims a stale lock (older than LOCK_TIMEOUT_MS) and acquires", async () => {
+			expect(await acquireWorkerLock(tempDir)).toBe(true);
+			const lockPath = join(tempDir, ".jolli", "jollimemory", WORKER_LOCK_FILE);
+			const past = new Date(Date.now() - LOCK_TIMEOUT_MS - 60_000);
+			await utimes(lockPath, past, past);
+			expect(await acquireWorkerLock(tempDir)).toBe(true);
+			await releaseWorkerLock(tempDir);
+		});
+
+		it("returns false when writeFile fails (race condition)", async () => {
+			const fsPromises = await import("node:fs/promises");
+			const writeSpy = vi.spyOn(fsPromises, "writeFile").mockRejectedValueOnce(new Error("EEXIST"));
+			expect(await acquireWorkerLock(tempDir)).toBe(false);
+			writeSpy.mockRestore();
+		});
+
+		it("releaseWorkerLock swallows filesystem errors", async () => {
+			const fsPromises = await import("node:fs/promises");
+			const rmSpy = vi.spyOn(fsPromises, "rm").mockRejectedValueOnce(new Error("EACCES"));
+			await expect(releaseWorkerLock(tempDir)).resolves.toBeUndefined();
+			rmSpy.mockRestore();
+		});
+	});
+
+	describe("isWorkerLockHeld / isWorkerLockStale", () => {
+		it("isWorkerLockHeld returns false when no lock exists", async () => {
+			expect(await isWorkerLockHeld(tempDir)).toBe(false);
+		});
+
+		it("isWorkerLockHeld returns true when worker.lock is fresh", async () => {
+			await acquireWorkerLock(tempDir);
+			expect(await isWorkerLockHeld(tempDir)).toBe(true);
+			await releaseWorkerLock(tempDir);
+		});
+
+		it("isWorkerLockHeld returns false after release", async () => {
+			await acquireWorkerLock(tempDir);
+			await releaseWorkerLock(tempDir);
+			expect(await isWorkerLockHeld(tempDir)).toBe(false);
+		});
+
+		it("isWorkerLockHeld is NOT influenced by orphan-write.lock", async () => {
+			expect(await acquireOrphanWriteLock(tempDir)).toBe(true);
+			expect(await isWorkerLockHeld(tempDir)).toBe(false);
+			await releaseOrphanWriteLock(tempDir);
+		});
+
+		it("isWorkerLockStale returns false when no lock exists", async () => {
+			expect(await isWorkerLockStale(tempDir)).toBe(false);
+		});
+
+		it("isWorkerLockStale returns false for a fresh lock", async () => {
+			await acquireWorkerLock(tempDir);
+			expect(await isWorkerLockStale(tempDir)).toBe(false);
+			await releaseWorkerLock(tempDir);
+		});
+
+		it("isWorkerLockStale returns true when lock is older than LOCK_TIMEOUT_MS", async () => {
+			await acquireWorkerLock(tempDir);
+			const lockPath = join(tempDir, ".jolli", "jollimemory", WORKER_LOCK_FILE);
+			const past = new Date(Date.now() - LOCK_TIMEOUT_MS - 60_000);
+			await utimes(lockPath, past, past);
+			expect(await isWorkerLockStale(tempDir)).toBe(true);
+			await releaseWorkerLock(tempDir);
+		});
+	});
+
+	describe("refreshWorkerLockMtime", () => {
+		it("bumps the lock's mtime so a long-lived worker is not reaped", async () => {
+			await acquireWorkerLock(tempDir);
+			const lockPath = join(tempDir, ".jolli", "jollimemory", WORKER_LOCK_FILE);
+
+			const past = new Date(Date.now() - LOCK_TIMEOUT_MS - 60_000);
+			await utimes(lockPath, past, past);
+			expect(await isWorkerLockStale(tempDir)).toBe(true);
+
+			await refreshWorkerLockMtime(tempDir);
+			expect(await isWorkerLockStale(tempDir)).toBe(false);
+			expect(await isWorkerLockHeld(tempDir)).toBe(true);
+
+			await releaseWorkerLock(tempDir);
+		});
+
+		it("silently no-ops when the lock file is missing", async () => {
+			await expect(refreshWorkerLockMtime(tempDir)).resolves.toBeUndefined();
+		});
+	});
+
+	describe("orphan-write.lock — timeout-with-poll", () => {
+		it("acquires and releases", async () => {
+			expect(await acquireOrphanWriteLock(tempDir)).toBe(true);
+			await releaseOrphanWriteLock(tempDir);
+			expect(await acquireOrphanWriteLock(tempDir)).toBe(true);
+			await releaseOrphanWriteLock(tempDir);
+		});
+
+		it("a second acquire waits for the first holder, then succeeds", async () => {
+			expect(await acquireOrphanWriteLock(tempDir)).toBe(true);
+
+			// Schedule a release ~80 ms in the future, then race a new acquire
+			// with a 1 s budget. With a 50 ms poll the second call sees the
+			// release within ~one poll and returns true.
+			const releasedAt = setTimeout(() => {
+				void releaseOrphanWriteLock(tempDir);
+			}, 80);
+
+			const start = Date.now();
+			const acquired = await acquireOrphanWriteLock(tempDir, { timeoutMs: 1000, pollMs: 25 });
+			const elapsed = Date.now() - start;
+			clearTimeout(releasedAt);
+
+			expect(acquired).toBe(true);
+			expect(elapsed).toBeLessThan(500);
+			await releaseOrphanWriteLock(tempDir);
+		});
+
+		it("returns false after timeoutMs when the lock stays held", async () => {
+			expect(await acquireOrphanWriteLock(tempDir)).toBe(true);
+
+			const start = Date.now();
+			const acquired = await acquireOrphanWriteLock(tempDir, { timeoutMs: 150, pollMs: 25 });
+			const elapsed = Date.now() - start;
+
+			expect(acquired).toBe(false);
+			expect(elapsed).toBeGreaterThanOrEqual(140);
+			await releaseOrphanWriteLock(tempDir);
+		});
+
+		it("falls back to the default poll interval when pollMs is omitted", async () => {
+			// Sanity check that the constant is small enough to avoid flaky tests.
+			expect(DEFAULT_ORPHAN_WRITE_POLL_MS).toBeLessThanOrEqual(100);
+
+			expect(await acquireOrphanWriteLock(tempDir)).toBe(true);
+			const acquired = await acquireOrphanWriteLock(tempDir, { timeoutMs: 80 });
+			expect(acquired).toBe(false);
+			await releaseOrphanWriteLock(tempDir);
+		});
+
+		it("reclaims a stale orphan-write lock", async () => {
+			expect(await acquireOrphanWriteLock(tempDir)).toBe(true);
+			const lockPath = join(tempDir, ".jolli", "jollimemory", ORPHAN_WRITE_LOCK_FILE);
+			const past = new Date(Date.now() - LOCK_TIMEOUT_MS - 60_000);
+			await utimes(lockPath, past, past);
+			expect(await acquireOrphanWriteLock(tempDir, { timeoutMs: 100 })).toBe(true);
+			await releaseOrphanWriteLock(tempDir);
+		});
+
+		it("releaseOrphanWriteLock swallows filesystem errors", async () => {
+			const fsPromises = await import("node:fs/promises");
+			const rmSpy = vi.spyOn(fsPromises, "rm").mockRejectedValueOnce(new Error("EACCES"));
+			await expect(releaseOrphanWriteLock(tempDir)).resolves.toBeUndefined();
+			rmSpy.mockRestore();
+		});
+	});
+
+	describe("worker.lock and orphan-write.lock are independent", () => {
+		it("can hold both simultaneously", async () => {
+			expect(await acquireWorkerLock(tempDir)).toBe(true);
+			expect(await acquireOrphanWriteLock(tempDir, { timeoutMs: 100 })).toBe(true);
+
+			const dir = join(tempDir, ".jolli", "jollimemory");
+			expect((await stat(join(dir, WORKER_LOCK_FILE))).isFile()).toBe(true);
+			expect((await stat(join(dir, ORPHAN_WRITE_LOCK_FILE))).isFile()).toBe(true);
+
+			await releaseOrphanWriteLock(tempDir);
+			await releaseWorkerLock(tempDir);
+		});
+
+		it("acquireOrphanWriteLock with worker.lock present still succeeds (lock files don't share state)", async () => {
+			expect(await acquireWorkerLock(tempDir)).toBe(true);
+			expect(await acquireOrphanWriteLock(tempDir, { timeoutMs: 100 })).toBe(true);
+			await releaseOrphanWriteLock(tempDir);
+			await releaseWorkerLock(tempDir);
+		});
+
+		it("isWorkerLockHeld ignores a stale worker.lock + fresh orphan-write.lock", async () => {
+			// Plant a stale worker.lock the way a crashed worker would leave it.
+			const dir = join(tempDir, ".jolli", "jollimemory");
+			const fsPromises = await import("node:fs/promises");
+			await fsPromises.mkdir(dir, { recursive: true });
+			const stalePath = join(dir, WORKER_LOCK_FILE);
+			await writeFile(stalePath, "12345", "utf-8");
+			const past = new Date(Date.now() - LOCK_TIMEOUT_MS - 60_000);
+			await utimes(stalePath, past, past);
+
+			expect(await acquireOrphanWriteLock(tempDir)).toBe(true);
+			expect(await isWorkerLockHeld(tempDir)).toBe(false);
+			await releaseOrphanWriteLock(tempDir);
+		});
+	});
+});

--- a/cli/src/core/Locks.ts
+++ b/cli/src/core/Locks.ts
@@ -1,0 +1,209 @@
+/**
+ * File-based lock primitives for Jolli Memory.
+ *
+ * Two locks live side-by-side under `.jolli/jollimemory/`:
+ *
+ *   - `worker.lock`        — held by QueueWorker for the duration of a queue drain
+ *                            (typically 30-60 s while the LLM runs). Fail-fast: a second
+ *                            worker that tries to acquire it returns false immediately so
+ *                            only one drain runs at a time. PostRewriteHook / PostCommitHook
+ *                            consult `isWorkerLockHeld` to decide whether to spawn a new
+ *                            worker.
+ *
+ *   - `orphan-write.lock`  — held by anyone writing to the orphan summary branch,
+ *                            including the worker itself (briefly, around each
+ *                            `writeFiles` critical section). Acquired with a poll
+ *                            loop and a caller-chosen timeout because contention is
+ *                            millisecond-scale and waiting briefly avoids needless
+ *                            "deferred" outcomes.
+ *
+ * Splitting the two roles is the fix for the orphan-queue-entry race: previously a
+ * single `lock` file served both purposes, so a non-worker holder (e.g.
+ * `scanTreeHashAliases`) made `isLockHeld` return true and PostRewriteHook
+ * incorrectly assumed a Worker was running.
+ */
+
+import { mkdir, rm, stat, utimes, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { createLogger, getJolliMemoryDir } from "../Logger.js";
+
+const log = createLogger("Locks");
+
+export const WORKER_LOCK_FILE = "worker.lock";
+export const ORPHAN_WRITE_LOCK_FILE = "orphan-write.lock";
+
+/** Lock timeout: a lock older than this is considered stale and reclaimable. */
+export const LOCK_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
+
+/** Default wait budget for `acquireOrphanWriteLock` (background callers). */
+export const DEFAULT_ORPHAN_WRITE_TIMEOUT_MS = 1000;
+
+/** Default poll interval while waiting for `orphan-write.lock`. */
+export const DEFAULT_ORPHAN_WRITE_POLL_MS = 50;
+
+/** Optional knobs for `acquireOrphanWriteLock`. */
+export interface OrphanWriteLockOpts {
+	readonly timeoutMs?: number;
+	readonly pollMs?: number;
+}
+
+async function ensureLockDir(cwd?: string): Promise<string> {
+	const dir = getJolliMemoryDir(cwd);
+	await mkdir(dir, { recursive: true });
+	return dir;
+}
+
+/**
+ * Best-effort single attempt at creating `lockPath` exclusively.
+ * Returns true on success. Returns false if another process already holds it
+ * (and the existing lock is fresh) or if a filesystem error blocked us.
+ *
+ * Stale locks (older than `LOCK_TIMEOUT_MS`) are removed and the caller will
+ * succeed on the retry / next call.
+ */
+async function tryAcquireOnce(lockPath: string): Promise<boolean> {
+	try {
+		const lockStat = await stat(lockPath);
+		const age = Date.now() - lockStat.mtimeMs;
+		if (age < LOCK_TIMEOUT_MS) {
+			return false;
+		}
+		log.warn("Removing stale lock file %s (age: %dms)", lockPath, age);
+		await rm(lockPath, { force: true });
+	} catch (error: unknown) {
+		const err = error as { code?: string };
+		/* v8 ignore start -- defensive: non-ENOENT errors from stat are rare filesystem issues */
+		if (err.code !== "ENOENT") {
+			log.error("Failed to check lock file %s: %s", lockPath, (error as Error).message);
+			return false;
+		}
+		/* v8 ignore stop */
+	}
+
+	try {
+		await writeFile(lockPath, String(process.pid), { flag: "wx" });
+		return true;
+		/* v8 ignore start -- race condition: another process grabbed the lock between check and write */
+	} catch {
+		return false;
+	}
+	/* v8 ignore stop */
+}
+
+/**
+ * Acquires the worker lock. Fail-fast: returns false immediately when another
+ * worker already holds it.
+ */
+export async function acquireWorkerLock(cwd?: string): Promise<boolean> {
+	const dir = await ensureLockDir(cwd);
+	return tryAcquireOnce(join(dir, WORKER_LOCK_FILE));
+}
+
+/**
+ * Releases the worker lock. Swallows filesystem errors — releasing is
+ * best-effort and we never want a release failure to crash a hook.
+ */
+export async function releaseWorkerLock(cwd?: string): Promise<void> {
+	const dir = getJolliMemoryDir(cwd);
+	try {
+		await rm(join(dir, WORKER_LOCK_FILE), { force: true });
+		/* v8 ignore next 3 -- filesystem permission error during lock release */
+	} catch (error: unknown) {
+		log.error("Failed to release worker lock: %s", (error as Error).message);
+	}
+}
+
+/**
+ * Returns true when `worker.lock` exists and is younger than `LOCK_TIMEOUT_MS`.
+ * Used by PostRewriteHook and PostCommitHook to decide whether a worker is
+ * already running. The check intentionally ignores `orphan-write.lock` so a
+ * brief background writer (scanTreeHashAliases, getCatalogWithLazyBuild) does
+ * not falsely advertise "worker is running".
+ */
+export async function isWorkerLockHeld(cwd?: string): Promise<boolean> {
+	const dir = getJolliMemoryDir(cwd);
+	const lockPath = join(dir, WORKER_LOCK_FILE);
+	try {
+		const lockStat = await stat(lockPath);
+		return Date.now() - lockStat.mtimeMs < LOCK_TIMEOUT_MS;
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Returns true when `worker.lock` exists but is older than `LOCK_TIMEOUT_MS`.
+ * Used by `doctor` to detect a crashed worker that left its lock behind.
+ */
+export async function isWorkerLockStale(cwd?: string): Promise<boolean> {
+	const dir = getJolliMemoryDir(cwd);
+	const lockPath = join(dir, WORKER_LOCK_FILE);
+	try {
+		const lockStat = await stat(lockPath);
+		return Date.now() - lockStat.mtimeMs >= LOCK_TIMEOUT_MS;
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Bumps the mtime on `worker.lock` so a long-running worker (e.g. an LLM call
+ * that exceeds `LOCK_TIMEOUT_MS`) cannot be stolen by the stale-lock reclaimer.
+ * The worker calls this on a periodic timer for the duration of its run.
+ *
+ * Silently ignores ENOENT and any other filesystem error — a missing lock means
+ * the worker is no longer holding it, and a transient utimes failure is not
+ * worth crashing on.
+ */
+export async function refreshWorkerLockMtime(cwd?: string): Promise<void> {
+	const dir = getJolliMemoryDir(cwd);
+	const lockPath = join(dir, WORKER_LOCK_FILE);
+	try {
+		const now = new Date();
+		await utimes(lockPath, now, now);
+		/* v8 ignore next 3 -- transient utimes failure on a lock file is intentionally swallowed */
+	} catch {
+		// Lock file gone or filesystem hiccup — refresh is best-effort.
+	}
+}
+
+function sleep(ms: number): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Acquires `orphan-write.lock`, waiting up to `timeoutMs` for an existing
+ * holder to release it. Returns true on success, false on timeout.
+ *
+ * `orphan-write.lock` is held only for the brief window of a single
+ * `StorageProvider.writeFiles` call (read-modify-write of index/catalog),
+ * so even a 1 s poll budget is enough to ride out almost all real contention.
+ * The worker uses 5 s — its writes are post-LLM and must land.
+ */
+export async function acquireOrphanWriteLock(cwd?: string, opts: OrphanWriteLockOpts = {}): Promise<boolean> {
+	const timeoutMs = opts.timeoutMs ?? DEFAULT_ORPHAN_WRITE_TIMEOUT_MS;
+	const pollMs = opts.pollMs ?? DEFAULT_ORPHAN_WRITE_POLL_MS;
+	const dir = await ensureLockDir(cwd);
+	const lockPath = join(dir, ORPHAN_WRITE_LOCK_FILE);
+	const deadline = Date.now() + timeoutMs;
+
+	while (true) {
+		if (await tryAcquireOnce(lockPath)) return true;
+		if (Date.now() >= deadline) return false;
+		await sleep(pollMs);
+	}
+}
+
+/**
+ * Releases `orphan-write.lock`. Like `releaseWorkerLock`, swallows errors so a
+ * failed release never propagates back to a hook or queue worker.
+ */
+export async function releaseOrphanWriteLock(cwd?: string): Promise<void> {
+	const dir = getJolliMemoryDir(cwd);
+	try {
+		await rm(join(dir, ORPHAN_WRITE_LOCK_FILE), { force: true });
+		/* v8 ignore next 3 -- filesystem permission error during lock release */
+	} catch (error: unknown) {
+		log.error("Failed to release orphan-write lock: %s", (error as Error).message);
+	}
+}

--- a/cli/src/core/Locks.ts
+++ b/cli/src/core/Locks.ts
@@ -1,38 +1,95 @@
 /**
  * File-based lock primitives for Jolli Memory.
  *
- * Two locks live side-by-side under `.jolli/jollimemory/`:
+ * Two locks live in two distinct directories:
  *
  *   - `worker.lock`        — held by QueueWorker for the duration of a queue drain
- *                            (typically 30-60 s while the LLM runs). Fail-fast: a second
- *                            worker that tries to acquire it returns false immediately so
- *                            only one drain runs at a time. PostRewriteHook / PostCommitHook
- *                            consult `isWorkerLockHeld` to decide whether to spawn a new
- *                            worker.
+ *                            (typically 30-60 s while the LLM runs). Fail-fast: a
+ *                            second worker that tries to acquire it returns false
+ *                            immediately so only one drain runs at a time.
+ *                            **Per-worktree** because the queue itself is
+ *                            per-worktree (`<cwd>/.jolli/jollimemory/git-op-queue/`):
+ *                            two worktrees correctly run their own workers in
+ *                            parallel against their own queues. Lives at
+ *                            `<cwd>/.jolli/jollimemory/worker.lock`.
  *
  *   - `orphan-write.lock`  — held by anyone writing to the orphan summary branch,
  *                            including the worker itself (briefly, around each
  *                            `writeFiles` critical section). Acquired with a poll
  *                            loop and a caller-chosen timeout because contention is
- *                            millisecond-scale and waiting briefly avoids needless
- *                            "deferred" outcomes.
+ *                            millisecond-scale. **Shared across worktrees** because
+ *                            the orphan ref is repo-level, not worktree-level: a
+ *                            per-worktree path would let two worktrees race on the
+ *                            same ref. Lives at `<git-common-dir>/jollimemory/
+ *                            orphan-write.lock`, with a fallback to the per-worktree
+ *                            path when not in a git repository.
  *
  * Splitting the two roles is the fix for the orphan-queue-entry race: previously a
  * single `lock` file served both purposes, so a non-worker holder (e.g.
  * `scanTreeHashAliases`) made `isLockHeld` return true and PostRewriteHook
  * incorrectly assumed a Worker was running.
+ *
+ * **Ownership-checked release.** Both release functions read the lock file and
+ * compare its PID against `process.pid` before removing. Without the check, a
+ * stale-reclaim race could let process A delete process B's freshly-acquired
+ * lock and re-open the concurrent-write window:
+ *   1. A holds lock, lock becomes stale (≥ `LOCK_TIMEOUT_MS`)
+ *   2. B's `tryAcquireOnce` removes A's lock and writes its own PID
+ *   3. A's finally block runs `releaseLock` — without the PID check, A would rm B's lock
+ *   4. C now sees no lock and acquires concurrently with B → corrupt writes
+ * The PID check turns step 3 into a no-op.
+ *
+ * **Residual stale-reclaim window we don't close.** The symmetric race in
+ * `tryAcquireOnce`'s stale branch is open: between B's `stat` (sees age ≥
+ * TIMEOUT) and B's `rm`, A can fire one `refreshWorkerLockMtime` and bump
+ * mtime fresh — B then deletes a now-fresh lock, A keeps running, and both
+ * believe they hold it. A second PID read before `rm` would NOT close this:
+ * the PID is still A's at every checkpoint, only mtime moved. Closing it
+ * properly needs an atomic "rm-iff-mtime-unchanged" primitive (e.g.
+ * link/rename pattern), out of scope here. The window requires A to call
+ * `utimes` in the sub-millisecond gap between B's `stat` and `rm`, at the one
+ * boundary tick inside a 60 s refresh cycle — vanishingly unlikely.
+ *
+ * **Why PID, not a UUID token.** PID-reuse collision inside one lock lifetime
+ * would require: OS restart within `LOCK_TIMEOUT_MS` AND the lock file
+ * surviving the restart AND the new PID matching the dead holder's exact
+ * value AND that recycled-PID process happening to acquire the same lock. We
+ * accept this as an intentional simplification — a token file would close it
+ * but the collision probability doesn't justify the extra read on every
+ * release path.
  */
 
-import { mkdir, rm, stat, utimes, writeFile } from "node:fs/promises";
-import { join } from "node:path";
+import * as childProcess from "node:child_process";
+import { mkdir, readFile, rm, stat, utimes, writeFile } from "node:fs/promises";
+import { isAbsolute, join, resolve as resolvePath } from "node:path";
+import { promisify } from "node:util";
 import { createLogger, getJolliMemoryDir } from "../Logger.js";
 
 const log = createLogger("Locks");
 
+/**
+ * Lazily promisify so tests that swap out `childProcess.execFile` after module
+ * load (via `vi.spyOn`) actually pick up the mock — eager promisification at
+ * module load would close over the original function.
+ */
+function gitRevParseCommonDir(cwd: string): Promise<{ stdout: string }> {
+	return promisify(childProcess.execFile)("git", ["rev-parse", "--git-common-dir"], { cwd }) as Promise<{
+		stdout: string;
+	}>;
+}
+
 export const WORKER_LOCK_FILE = "worker.lock";
 export const ORPHAN_WRITE_LOCK_FILE = "orphan-write.lock";
 
-/** Lock timeout: a lock older than this is considered stale and reclaimable. */
+/**
+ * Lock timeout: a lock older than this is considered stale and reclaimable.
+ *
+ * Invariant: must be greater than 2 × `WORKER_LOCK_REFRESH_INTERVAL_MS` (the
+ * worker's heartbeat cadence, 60 s in `QueueWorker.ts`). A live worker bumps
+ * mtime on that cadence, so as long as TIMEOUT > 2 × INTERVAL a single missed
+ * bump (GC pause, slow scheduler tick) cannot push the lock across the stale
+ * boundary. Currently 5 min vs 60 s — ample margin.
+ */
 export const LOCK_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
 
 /** Default wait budget for `acquireOrphanWriteLock` (background callers). */
@@ -47,8 +104,84 @@ export interface OrphanWriteLockOpts {
 	readonly pollMs?: number;
 }
 
-async function ensureLockDir(cwd?: string): Promise<string> {
+/**
+ * Cache of the resolved shared (orphan-write) lock directory keyed by cwd.
+ * Resolution invokes `git rev-parse --git-common-dir`, so caching avoids a
+ * subprocess spawn on every poll iteration of `acquireOrphanWriteLock`.
+ *
+ * The cache is keyed by the input cwd, and each unique cwd produces a
+ * deterministic resolution (either a real common dir or the worktree
+ * fallback), so a stale entry is only possible if the user converts a
+ * non-git directory into a git repo mid-process — accept that as a cost
+ * paid by the next process restart. Tests can clear the cache via the
+ * exported `__resetSharedLockDirCache` helper.
+ */
+const sharedLockDirCache = new Map<string, string>();
+
+/**
+ * Test-only: clears the cached `git rev-parse --git-common-dir` results.
+ * Production code should never need this; it exists so unit tests can flip a
+ * tempdir from "not a git repo" to "is a git repo" mid-test.
+ */
+export function __resetSharedLockDirCache(): void {
+	sharedLockDirCache.clear();
+}
+
+/**
+ * Resolves the directory that holds locks shared across all worktrees of the
+ * same repository. Returns `<git-common-dir>/jollimemory/` for git
+ * worktrees, or falls back to the per-worktree `getJolliMemoryDir(cwd)` path
+ * when the resolution fails (cwd is not in a git repo, git is missing, etc.).
+ *
+ * Why git-common-dir: linked worktrees created by `git worktree add` each
+ * have their own working tree but share the main repo's `.git/` (with its
+ * single set of refs, including the orphan summary ref). `git rev-parse
+ * --git-common-dir` is the documented way to locate that shared `.git/`
+ * regardless of which worktree the caller is in. Putting the lock under it
+ * means every worktree resolves to the same path → the lock actually
+ * serializes concurrent orphan-branch writers.
+ *
+ * Why a `jollimemory/` subdir under it (rather than `jollimemory-locks/` or
+ * similar): keeps the naming consistent with the existing per-worktree
+ * `.jolli/jollimemory/` directory used for everything else, just rooted in
+ * git-common-dir instead of the worktree.
+ */
+async function resolveSharedLockDir(cwd?: string): Promise<string> {
+	const key = cwd ?? process.cwd();
+	const cached = sharedLockDirCache.get(key);
+	if (cached !== undefined) return cached;
+
+	let resolved: string;
+	try {
+		const { stdout } = await gitRevParseCommonDir(key);
+		const commonDir = stdout.trim();
+		// `git rev-parse` may return either a relative path (e.g. ".git" when
+		// cwd IS the repo root) or an absolute path (linked worktrees). Resolve
+		// against cwd so callers always get an absolute path.
+		const absoluteCommonDir = isAbsolute(commonDir) ? commonDir : resolvePath(key, commonDir);
+		resolved = join(absoluteCommonDir, "jollimemory");
+		/* v8 ignore start -- fallback path: requires running outside a git repo, not the common case */
+	} catch {
+		// Not in a git repo, or `git` not on PATH — fall back to the
+		// per-worktree dir. Single-worktree behaviour is unchanged from the
+		// pre-PR design; multi-worktree environments simply can't benefit from
+		// the shared-lock semantics in this fallback.
+		log.debug("resolveSharedLockDir: git rev-parse failed for cwd=%s — falling back to per-worktree dir", key);
+		resolved = getJolliMemoryDir(key);
+	}
+	/* v8 ignore stop */
+	sharedLockDirCache.set(key, resolved);
+	return resolved;
+}
+
+async function ensureWorktreeLockDir(cwd?: string): Promise<string> {
 	const dir = getJolliMemoryDir(cwd);
+	await mkdir(dir, { recursive: true });
+	return dir;
+}
+
+async function ensureSharedLockDir(cwd?: string): Promise<string> {
+	const dir = await resolveSharedLockDir(cwd);
 	await mkdir(dir, { recursive: true });
 	return dir;
 }
@@ -91,26 +224,61 @@ async function tryAcquireOnce(lockPath: string): Promise<boolean> {
 }
 
 /**
+ * Reads the PID currently written into `lockPath`. Returns null when the file
+ * is missing or unreadable — callers treat that as "not ours".
+ */
+async function readLockOwnerPid(lockPath: string): Promise<string | null> {
+	try {
+		const content = await readFile(lockPath, "utf-8");
+		const pid = content.trim();
+		return pid.length > 0 ? pid : null;
+		/* v8 ignore next 3 -- ENOENT / unreadable: caller treats null as "not ours" */
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Removes `lockPath` only if its written PID matches the current process.
+ * No-op when the file is missing OR owned by another PID — protects against
+ * the stale-reclaim race where this process's release would otherwise delete
+ * a different process's freshly-acquired lock.
+ */
+async function releaseIfOwned(lockPath: string, label: string): Promise<void> {
+	const ownerPid = await readLockOwnerPid(lockPath);
+	if (ownerPid !== null && ownerPid !== String(process.pid)) {
+		log.warn(
+			"Skipping release of %s: held by pid %s, not us (pid %s) — stale-reclaim race",
+			label,
+			ownerPid,
+			process.pid,
+		);
+		return;
+	}
+	try {
+		await rm(lockPath, { force: true });
+		/* v8 ignore next 3 -- filesystem permission error during lock release */
+	} catch (error: unknown) {
+		log.error("Failed to release %s: %s", label, (error as Error).message);
+	}
+}
+
+/**
  * Acquires the worker lock. Fail-fast: returns false immediately when another
  * worker already holds it.
  */
 export async function acquireWorkerLock(cwd?: string): Promise<boolean> {
-	const dir = await ensureLockDir(cwd);
+	const dir = await ensureWorktreeLockDir(cwd);
 	return tryAcquireOnce(join(dir, WORKER_LOCK_FILE));
 }
 
 /**
- * Releases the worker lock. Swallows filesystem errors — releasing is
- * best-effort and we never want a release failure to crash a hook.
+ * Releases the worker lock — only if the lock file's PID matches us. The PID
+ * gate guards the stale-reclaim race; see the module-level comment.
  */
 export async function releaseWorkerLock(cwd?: string): Promise<void> {
 	const dir = getJolliMemoryDir(cwd);
-	try {
-		await rm(join(dir, WORKER_LOCK_FILE), { force: true });
-		/* v8 ignore next 3 -- filesystem permission error during lock release */
-	} catch (error: unknown) {
-		log.error("Failed to release worker lock: %s", (error as Error).message);
-	}
+	await releaseIfOwned(join(dir, WORKER_LOCK_FILE), "worker.lock");
 }
 
 /**
@@ -151,13 +319,19 @@ export async function isWorkerLockStale(cwd?: string): Promise<boolean> {
  * that exceeds `LOCK_TIMEOUT_MS`) cannot be stolen by the stale-lock reclaimer.
  * The worker calls this on a periodic timer for the duration of its run.
  *
- * Silently ignores ENOENT and any other filesystem error — a missing lock means
- * the worker is no longer holding it, and a transient utimes failure is not
- * worth crashing on.
+ * Skips the bump when the lock is owned by a different PID — refreshing
+ * someone else's lock would extend the lifetime of a lock the holder already
+ * lost (after a stale-reclaim) and let the original holder believe it still
+ * owns the lock when it doesn't.
  */
 export async function refreshWorkerLockMtime(cwd?: string): Promise<void> {
 	const dir = getJolliMemoryDir(cwd);
 	const lockPath = join(dir, WORKER_LOCK_FILE);
+	const ownerPid = await readLockOwnerPid(lockPath);
+	if (ownerPid !== null && ownerPid !== String(process.pid)) {
+		// Lock was reclaimed by another process — stop refreshing.
+		return;
+	}
 	try {
 		const now = new Date();
 		await utimes(lockPath, now, now);
@@ -178,12 +352,12 @@ function sleep(ms: number): Promise<void> {
  * `orphan-write.lock` is held only for the brief window of a single
  * `StorageProvider.writeFiles` call (read-modify-write of index/catalog),
  * so even a 1 s poll budget is enough to ride out almost all real contention.
- * The worker uses 5 s — its writes are post-LLM and must land.
+ * The worker uses 30 s — its writes are post-LLM and must land.
  */
 export async function acquireOrphanWriteLock(cwd?: string, opts: OrphanWriteLockOpts = {}): Promise<boolean> {
 	const timeoutMs = opts.timeoutMs ?? DEFAULT_ORPHAN_WRITE_TIMEOUT_MS;
 	const pollMs = opts.pollMs ?? DEFAULT_ORPHAN_WRITE_POLL_MS;
-	const dir = await ensureLockDir(cwd);
+	const dir = await ensureSharedLockDir(cwd);
 	const lockPath = join(dir, ORPHAN_WRITE_LOCK_FILE);
 	const deadline = Date.now() + timeoutMs;
 
@@ -195,15 +369,10 @@ export async function acquireOrphanWriteLock(cwd?: string, opts: OrphanWriteLock
 }
 
 /**
- * Releases `orphan-write.lock`. Like `releaseWorkerLock`, swallows errors so a
- * failed release never propagates back to a hook or queue worker.
+ * Releases `orphan-write.lock` — only if the lock file's PID matches us. See
+ * `releaseWorkerLock` for the rationale; both releases share `releaseIfOwned`.
  */
 export async function releaseOrphanWriteLock(cwd?: string): Promise<void> {
-	const dir = getJolliMemoryDir(cwd);
-	try {
-		await rm(join(dir, ORPHAN_WRITE_LOCK_FILE), { force: true });
-		/* v8 ignore next 3 -- filesystem permission error during lock release */
-	} catch (error: unknown) {
-		log.error("Failed to release orphan-write lock: %s", (error as Error).message);
-	}
+	const dir = await resolveSharedLockDir(cwd);
+	await releaseIfOwned(join(dir, ORPHAN_WRITE_LOCK_FILE), "orphan-write.lock");
 }

--- a/cli/src/core/SessionTracker.test.ts
+++ b/cli/src/core/SessionTracker.test.ts
@@ -40,7 +40,6 @@ vi.spyOn(console, "error").mockImplementation(() => {});
 
 import type { GitOperation, SessionInfo, SessionsRegistry, SquashPendingState, TranscriptCursor } from "../Types.js";
 import {
-	acquireLock,
 	associateNoteWithCommit,
 	associatePlanWithCommit,
 	checkStaleSquashPending,
@@ -55,8 +54,6 @@ import {
 	ensureJolliMemoryDir,
 	filterSessionsByEnabledIntegrations,
 	getGlobalConfigDir,
-	isLockHeld,
-	isLockStale,
 	loadAllSessions,
 	loadConfig,
 	loadConfigFromDir,
@@ -68,7 +65,6 @@ import {
 	loadSquashPending,
 	pruneStaleQueueEntries,
 	pruneStaleSessions,
-	releaseLock,
 	saveConfig,
 	saveConfigScoped,
 	saveCursor,
@@ -433,73 +429,6 @@ describe("SessionTracker", () => {
 			await writeFile(join(dir, "config.json"), "not json", "utf-8");
 			const config = await loadConfigFromDir(dir);
 			expect(config).toEqual({});
-		});
-	});
-
-	describe("acquireLock / releaseLock", () => {
-		it("should acquire and release lock", async () => {
-			const acquired = await acquireLock(tempDir);
-			expect(acquired).toBe(true);
-
-			await releaseLock(tempDir);
-
-			const acquired2 = await acquireLock(tempDir);
-			expect(acquired2).toBe(true);
-			await releaseLock(tempDir);
-		});
-
-		it("should fail to acquire when lock exists", async () => {
-			const acquired1 = await acquireLock(tempDir);
-			expect(acquired1).toBe(true);
-
-			const acquired2 = await acquireLock(tempDir);
-			expect(acquired2).toBe(false);
-
-			await releaseLock(tempDir);
-		});
-
-		it("should remove stale lock and acquire", async () => {
-			const dir = await ensureJolliMemoryDir(tempDir);
-			const lockPath = join(dir, "lock");
-			await writeFile(lockPath, "12345", "utf-8");
-
-			// Manually set mtime to 10 minutes ago
-			const { utimes } = await import("node:fs/promises");
-			const past = new Date(Date.now() - 10 * 60 * 1000);
-			await utimes(lockPath, past, past);
-
-			const acquired = await acquireLock(tempDir);
-			expect(acquired).toBe(true);
-			await releaseLock(tempDir);
-		});
-
-		it("should return false when checking the lock file fails unexpectedly", async () => {
-			const fsPromises = await import("node:fs/promises");
-			const statSpy = vi
-				.spyOn(fsPromises, "stat")
-				.mockRejectedValueOnce(Object.assign(new Error("stat failed"), { code: "EIO" }));
-
-			await expect(acquireLock(tempDir)).resolves.toBe(false);
-
-			statSpy.mockRestore();
-		});
-
-		it("should return false when creating the lock file loses a race", async () => {
-			const fsPromises = await import("node:fs/promises");
-			const writeSpy = vi.spyOn(fsPromises, "writeFile").mockRejectedValueOnce(new Error("already exists"));
-
-			await expect(acquireLock(tempDir)).resolves.toBe(false);
-
-			writeSpy.mockRestore();
-		});
-
-		it("should swallow filesystem errors when releasing the lock", async () => {
-			const fsPromises = await import("node:fs/promises");
-			const rmSpy = vi.spyOn(fsPromises, "rm").mockRejectedValueOnce(new Error("permission denied"));
-
-			await expect(releaseLock(tempDir)).resolves.toBeUndefined();
-
-			rmSpy.mockRestore();
 		});
 	});
 
@@ -1139,26 +1068,6 @@ describe("SessionTracker", () => {
 		});
 	});
 
-	// ── isLockHeld ─────────────────────────────────────────────────────────
-
-	describe("isLockHeld", () => {
-		it("should return false when no lock file exists", async () => {
-			expect(await isLockHeld(tempDir)).toBe(false);
-		});
-
-		it("should return true when lock file exists and is fresh", async () => {
-			await acquireLock(tempDir);
-			expect(await isLockHeld(tempDir)).toBe(true);
-			await releaseLock(tempDir);
-		});
-
-		it("should return false after lock is released", async () => {
-			await acquireLock(tempDir);
-			await releaseLock(tempDir);
-			expect(await isLockHeld(tempDir)).toBe(false);
-		});
-	});
-
 	// ── loadConfig (global shorthand) ────────────────────────────────────
 
 	describe("loadConfig", () => {
@@ -1179,31 +1088,6 @@ describe("SessionTracker", () => {
 			await saveConfig({ apiKey: "global-key" });
 			const config = await loadConfig();
 			expect(config.apiKey).toBe("global-key");
-		});
-	});
-
-	// ── isLockStale ──────────────────────────────────────────────────────
-
-	describe("isLockStale", () => {
-		it("should return false when no lock file exists", async () => {
-			expect(await isLockStale(tempDir)).toBe(false);
-		});
-
-		it("should return false when lock file is fresh (< 5 min)", async () => {
-			await acquireLock(tempDir);
-			expect(await isLockStale(tempDir)).toBe(false);
-			await releaseLock(tempDir);
-		});
-
-		it("should return true when lock file is older than 5 min", async () => {
-			await acquireLock(tempDir);
-			// Backdate the lock file's mtime to 10 minutes ago
-			const lockPath = join(tempDir, ".jolli/jollimemory/lock");
-			const tenMinAgo = new Date(Date.now() - 10 * 60 * 1000);
-			const { utimes } = await import("node:fs/promises");
-			await utimes(lockPath, tenMinAgo, tenMinAgo);
-			expect(await isLockStale(tempDir)).toBe(true);
-			await releaseLock(tempDir);
 		});
 	});
 

--- a/cli/src/core/SessionTracker.ts
+++ b/cli/src/core/SessionTracker.ts
@@ -5,10 +5,11 @@
  *   - sessions.json: Registry of all active Claude Code sessions (Map<sessionId, SessionInfo>)
  *   - cursors.json: Per-transcript cursor positions (Map<transcriptPath, TranscriptCursor>)
  *   - config.json: Optional configuration (API key, model, etc.)
- *   - lock: Concurrency lock file
  *
  * Supports multiple concurrent Claude Code sessions. Stale sessions (>48h)
  * are automatically pruned during saveSession, along with their cursors.
+ *
+ * Lock primitives (`worker.lock` / `orphan-write.lock`) live in `Locks.ts`.
  */
 
 import { mkdir, readdir, readFile, rename, rm, stat, writeFile } from "node:fs/promises";
@@ -32,14 +33,10 @@ const log = createLogger("SessionTracker");
 const SESSIONS_FILE = "sessions.json";
 const CURSORS_FILE = "cursors.json";
 const CONFIG_FILE = "config.json";
-const LOCK_FILE = "lock";
 const PLANS_FILE = "plans.json";
 
 /** Sessions older than 48 hours are considered stale and pruned automatically */
 const SESSION_STALE_MS = 48 * 60 * 60 * 1000;
-
-/** Lock timeout: if a lock is older than this, consider it stale */
-const LOCK_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
 
 /**
  * Ensures the .jolli/jollimemory/ directory exists.
@@ -266,66 +263,6 @@ export async function loadConfig(): Promise<JolliMemoryConfig> {
  */
 export async function saveConfig(update: Partial<JolliMemoryConfig>): Promise<void> {
 	return saveConfigScoped(update, getGlobalConfigDir());
-}
-
-/**
- * Acquires a simple file-based lock to prevent concurrent operations.
- * Returns true if lock was acquired, false if another process holds it.
- *
- * If a lock file exists but is older than LOCK_TIMEOUT_MS, considers it stale
- * and removes it.
- */
-export async function acquireLock(cwd?: string): Promise<boolean> {
-	const dir = await ensureJolliMemoryDir(cwd);
-	const lockPath = join(dir, LOCK_FILE);
-
-	try {
-		// Check for existing lock
-		const lockStat = await stat(lockPath);
-		const age = Date.now() - lockStat.mtimeMs;
-
-		if (age < LOCK_TIMEOUT_MS) {
-			log.warn("Lock file exists (age: %dms), another process may be running", age);
-			return false;
-		}
-
-		// Stale lock — remove it
-		log.warn("Removing stale lock file (age: %dms)", age);
-		await rm(lockPath, { force: true });
-	} catch (error: unknown) {
-		const err = error as { code?: string };
-		/* v8 ignore next 4 - defensive: non-ENOENT errors from stat are rare filesystem issues */
-		if (err.code !== "ENOENT") {
-			log.error("Failed to check lock file: %s", (error as Error).message);
-			return false;
-		}
-		// No lock file exists, proceed
-	}
-
-	// Create lock file with PID
-	try {
-		await writeFile(lockPath, String(process.pid), { flag: "wx" });
-		return true;
-		/* v8 ignore next 4 - race condition: another process grabbed lock between check and write */
-	} catch {
-		log.warn("Failed to acquire lock (another process may have grabbed it)");
-		return false;
-	}
-}
-
-/**
- * Releases the file-based lock.
- */
-export async function releaseLock(cwd?: string): Promise<void> {
-	const dir = getJolliMemoryDir(cwd);
-	const lockPath = join(dir, LOCK_FILE);
-
-	try {
-		await rm(lockPath, { force: true });
-		/* v8 ignore next 3 - filesystem permission error during lock release */
-	} catch (error: unknown) {
-		log.error("Failed to release lock: %s", (error as Error).message);
-	}
 }
 
 const SQUASH_PENDING_FILE = "squash-pending.json";
@@ -617,40 +554,6 @@ export async function deleteQueueEntry(filePath: string): Promise<void> {
 		log.error("Failed to delete queue entry %s: %s", filePath, (error as Error).message);
 	}
 	/* v8 ignore stop */
-}
-
-/**
- * Checks whether the Worker lock is currently held (another Worker is running).
- * Used by PostRewriteHook to decide whether to spawn a Worker.
- */
-export async function isLockHeld(cwd?: string): Promise<boolean> {
-	const dir = getJolliMemoryDir(cwd);
-	const lockPath = join(dir, LOCK_FILE);
-	try {
-		const lockStat = await stat(lockPath);
-		const age = Date.now() - lockStat.mtimeMs;
-		// Lock is held if it exists and is not stale (< 5 min)
-		return age < LOCK_TIMEOUT_MS;
-	} catch {
-		return false; // No lock file = not held
-	}
-}
-
-/**
- * Checks whether the Worker lock file exists but is stale (older than LOCK_TIMEOUT_MS).
- * A stale lock indicates a crashed Worker that never cleaned up its lock file.
- * Used by `doctor` to detect stuck locks that need manual release.
- */
-export async function isLockStale(cwd?: string): Promise<boolean> {
-	const dir = getJolliMemoryDir(cwd);
-	const lockPath = join(dir, LOCK_FILE);
-	try {
-		const lockStat = await stat(lockPath);
-		const age = Date.now() - lockStat.mtimeMs;
-		return age >= LOCK_TIMEOUT_MS;
-	} catch {
-		return false; // No lock file = not stale
-	}
 }
 
 // --- plugin-source marker ---

--- a/cli/src/core/SummaryMigration.ts
+++ b/cli/src/core/SummaryMigration.ts
@@ -19,10 +19,43 @@ import {
 	writeFileToBranch,
 	writeMultipleFilesToBranch,
 } from "./GitOps.js";
+import { acquireOrphanWriteLock, releaseOrphanWriteLock } from "./Locks.js";
 
 const log = createLogger("SummaryMigration");
 
 const INDEX_FILE = "index.json";
+
+/**
+ * Wait budget when v1→v3 migration tries to acquire `orphan-write.lock`.
+ * Migration is one-time per repo and runs at activation; it's tolerable to
+ * wait through a concurrent post-commit Worker writing a summary, so we use
+ * the same generous worker-path budget as in SummaryStore. See
+ * `ORPHAN_WRITE_REQUIRED_TIMEOUT_MS` there for full rationale.
+ */
+const MIGRATION_LOCK_TIMEOUT_MS = 30_000;
+
+/**
+ * Acquires `orphan-write.lock`, runs `fn`, releases on exit. Throws on
+ * timeout — migration runs at activation; if the lock can't be acquired
+ * inside 30 s, the caller logs and the migration is retried on next
+ * activation (the v1 branch isn't deleted until migration meta is written,
+ * so retry is safe).
+ */
+async function withMigrationOrphanWriteLock<T>(
+	cwd: string | undefined,
+	label: string,
+	fn: () => Promise<T>,
+): Promise<T> {
+	const acquired = await acquireOrphanWriteLock(cwd, { timeoutMs: MIGRATION_LOCK_TIMEOUT_MS });
+	if (!acquired) {
+		throw new Error(`${label}: could not acquire orphan-write lock within ${MIGRATION_LOCK_TIMEOUT_MS}ms`);
+	}
+	try {
+		return await fn();
+	} finally {
+		await releaseOrphanWriteLock(cwd);
+	}
+}
 
 /**
  * Checks whether the legacy v1 orphan branch exists.
@@ -96,12 +129,18 @@ export async function migrateV1toV3(cwd?: string): Promise<{ migrated: number; s
 	}
 
 	if (filesToWrite.length > 0) {
-		await writeMultipleFilesToBranch(
-			ORPHAN_BRANCH,
-			filesToWrite,
-			`Migrate ${migrated} summaries from v1 to v3 tree format`,
-			cwd,
-		);
+		// Write under orphan-write.lock so we don't race the post-commit Worker
+		// (which also writes the orphan branch). This goes via raw GitOps rather
+		// than the StorageProvider abstraction, so the lock has to live here
+		// rather than being inherited from a StorageProvider wrapper.
+		await withMigrationOrphanWriteLock(cwd, "migrateV1toV3", async () => {
+			await writeMultipleFilesToBranch(
+				ORPHAN_BRANCH,
+				filesToWrite,
+				`Migrate ${migrated} summaries from v1 to v3 tree format`,
+				cwd,
+			);
+		});
 		log.info("Migration complete: %d migrated, %d skipped", migrated, skipped);
 	} else {
 		log.info("No summaries to migrate");
@@ -149,13 +188,16 @@ export async function hasMigrationMeta(cwd?: string): Promise<boolean> {
  */
 export async function writeMigrationMeta(cwd?: string): Promise<void> {
 	const meta: MigrationMeta = { v1MigratedAt: new Date().toISOString() };
-	await writeFileToBranch(
-		ORPHAN_BRANCH,
-		MIGRATION_META_FILE,
-		JSON.stringify(meta, null, "\t"),
-		"Record v1→v3 migration timestamp",
-		cwd,
-	);
+	// Single-file orphan-branch write — same lock semantics as migrateV1toV3.
+	await withMigrationOrphanWriteLock(cwd, "writeMigrationMeta", async () => {
+		await writeFileToBranch(
+			ORPHAN_BRANCH,
+			MIGRATION_META_FILE,
+			JSON.stringify(meta, null, "\t"),
+			"Record v1→v3 migration timestamp",
+			cwd,
+		);
+	});
 	log.info("Wrote migration metadata to %s", MIGRATION_META_FILE);
 }
 

--- a/cli/src/core/SummaryMigration.ts
+++ b/cli/src/core/SummaryMigration.ts
@@ -84,6 +84,25 @@ export async function migrateV1toV3(cwd?: string): Promise<{ migrated: number; s
 		return { migrated: 0, skipped: 0 };
 	}
 
+	// Hold orphan-write.lock for the ENTIRE read-build-write cycle.
+	//
+	// Earlier the lock only wrapped the final writeMultipleFilesToBranch call,
+	// which left a window where the post-commit Worker could land a fresh v3
+	// summary in `index.json` after we read v1 / built `filesToWrite` but
+	// before we acquired the lock. Migration's index.json — built solely from
+	// `rebuildIndexFromV1` — would then clobber the worker's entry on write
+	// (the summary file would survive but become unreachable from the index).
+	//
+	// Holding the lock through the whole body means the worker's storeSummary
+	// (which acquires the same lock around its own LMW) waits until migration
+	// completes; its write then layers on top of the migration's index. The
+	// only cost is a worker `storeSummary` whose 30 s timeout is exhausted by
+	// a very large migration — that is one summary lost, but the queue is
+	// drained correctly afterwards.
+	return withMigrationOrphanWriteLock(cwd, "migrateV1toV3", () => migrateV1toV3Locked(cwd));
+}
+
+async function migrateV1toV3Locked(cwd?: string): Promise<{ migrated: number; skipped: number }> {
 	// Read all summary files from v1
 	const v1Files = await listFilesInBranch(ORPHAN_BRANCH_V1, "summaries/", cwd);
 	log.info("Found %d summary files in v1 branch", v1Files.length);
@@ -129,18 +148,12 @@ export async function migrateV1toV3(cwd?: string): Promise<{ migrated: number; s
 	}
 
 	if (filesToWrite.length > 0) {
-		// Write under orphan-write.lock so we don't race the post-commit Worker
-		// (which also writes the orphan branch). This goes via raw GitOps rather
-		// than the StorageProvider abstraction, so the lock has to live here
-		// rather than being inherited from a StorageProvider wrapper.
-		await withMigrationOrphanWriteLock(cwd, "migrateV1toV3", async () => {
-			await writeMultipleFilesToBranch(
-				ORPHAN_BRANCH,
-				filesToWrite,
-				`Migrate ${migrated} summaries from v1 to v3 tree format`,
-				cwd,
-			);
-		});
+		await writeMultipleFilesToBranch(
+			ORPHAN_BRANCH,
+			filesToWrite,
+			`Migrate ${migrated} summaries from v1 to v3 tree format`,
+			cwd,
+		);
 		log.info("Migration complete: %d migrated, %d skipped", migrated, skipped);
 	} else {
 		log.info("No summaries to migrate");

--- a/cli/src/core/SummaryStore.catalog.test.ts
+++ b/cli/src/core/SummaryStore.catalog.test.ts
@@ -21,24 +21,20 @@ import {
 	toCatalogEntry,
 } from "./SummaryStore.js";
 
-vi.mock("./SessionTracker.js", async () => {
-	const actual = await vi.importActual<typeof import("./SessionTracker.js")>("./SessionTracker.js");
-	return {
-		...actual,
-		acquireLock: vi.fn(async () => true),
-		releaseLock: vi.fn(async () => undefined),
-	};
-});
+vi.mock("./Locks.js", () => ({
+	acquireOrphanWriteLock: vi.fn(async () => true),
+	releaseOrphanWriteLock: vi.fn(async () => undefined),
+}));
 
 vi.mock("./GitOps.js", () => ({
 	getDiffStats: vi.fn(async () => ({ filesChanged: 0, insertions: 0, deletions: 0 })),
 	getTreeHash: vi.fn(async () => "deadbeef"),
 }));
 
-import { acquireLock, releaseLock } from "./SessionTracker.js";
+import { acquireOrphanWriteLock, releaseOrphanWriteLock } from "./Locks.js";
 
-const mockAcquire = vi.mocked(acquireLock);
-const mockRelease = vi.mocked(releaseLock);
+const mockAcquire = vi.mocked(acquireOrphanWriteLock);
+const mockRelease = vi.mocked(releaseOrphanWriteLock);
 
 // ─── Memory-backed StorageProvider for hermetic tests ────────────────────────
 

--- a/cli/src/core/SummaryStore.test.ts
+++ b/cli/src/core/SummaryStore.test.ts
@@ -1897,7 +1897,8 @@ describe("SummaryStore", () => {
 				],
 				{ knownAlias: "root1" },
 			);
-			vi.mocked(readFileFromBranch).mockResolvedValueOnce(JSON.stringify(index));
+			// scanTreeHashAliases reads twice: preflight (no lock) + inside-lock re-read.
+			vi.mocked(readFileFromBranch).mockResolvedValue(JSON.stringify(index));
 			vi.mocked(getTreeHash).mockResolvedValueOnce("tree-1");
 
 			const result = await scanTreeHashAliases(["unknown1", "root1", "knownAlias"]);
@@ -1947,7 +1948,8 @@ describe("SummaryStore", () => {
 				{ ...rootEntry("older-root", "Older", "2026-02-18T10:00:00Z"), treeHash: "tree-1" },
 				{ ...rootEntry("newer-root", "Newer", "2026-02-19T10:00:00Z"), treeHash: "tree-1" },
 			]);
-			vi.mocked(readFileFromBranch).mockResolvedValueOnce(JSON.stringify(index));
+			// scanTreeHashAliases reads twice: preflight + inside-lock re-read.
+			vi.mocked(readFileFromBranch).mockResolvedValue(JSON.stringify(index));
 			vi.mocked(getTreeHash).mockResolvedValueOnce("tree-1");
 
 			const result = await scanTreeHashAliases(["unknown1"]);
@@ -1983,7 +1985,8 @@ describe("SummaryStore", () => {
 					treeHash: "tree-1",
 				},
 			]);
-			vi.mocked(readFileFromBranch).mockResolvedValueOnce(JSON.stringify(index));
+			// scanTreeHashAliases reads twice: preflight + inside-lock re-read.
+			vi.mocked(readFileFromBranch).mockResolvedValue(JSON.stringify(index));
 			vi.mocked(getTreeHash).mockResolvedValueOnce("tree-1");
 
 			const result = await scanTreeHashAliases(["unknown1"]);
@@ -2015,7 +2018,8 @@ describe("SummaryStore", () => {
 					treeHash: "tree-1",
 				},
 			]);
-			vi.mocked(readFileFromBranch).mockResolvedValueOnce(JSON.stringify(index));
+			// scanTreeHashAliases reads twice: preflight + inside-lock re-read.
+			vi.mocked(readFileFromBranch).mockResolvedValue(JSON.stringify(index));
 			vi.mocked(getTreeHash).mockResolvedValueOnce("tree-1");
 
 			const result = await scanTreeHashAliases(["unknown1"]);
@@ -2024,6 +2028,92 @@ describe("SummaryStore", () => {
 			const files = vi.mocked(writeMultipleFilesToBranch).mock.calls[0][1] as ReadonlyArray<FileWrite>;
 			const persistedIndex = JSON.parse(files[0].content) as SummaryIndex;
 			expect(persistedIndex.commitAliases).toEqual({ unknown1: "cycle-newer" });
+		});
+
+		// ── regression: lost-update race ─────────────────────────────────────
+		//
+		// Before this fix, scanTreeHashAliases read `index` outside the lock,
+		// computed `newAliases`, then acquired the lock and wrote
+		// `{ ...index, commitAliases: mergedAliases }`. If the worker wrote a
+		// new entry to `index.entries` between scan's preflight read and scan's
+		// lock-acquire, the worker's entry would be clobbered when scan wrote
+		// back its stale `entries`. The fix re-reads inside the lock and merges
+		// only `commitAliases` into the fresh index, preserving any entries the
+		// worker added concurrently.
+		it("preserves worker-written entries that landed between preflight and lock acquire", async () => {
+			const preflightIdx = v3Index(
+				[{ ...rootEntry("root1", "Root", "2026-02-18T10:00:00Z"), treeHash: "tree-1" }],
+				{},
+			);
+			// Simulates a worker that ran storeSummary between scan's preflight
+			// read and scan's inside-lock re-read: a brand-new root entry has
+			// landed in the index.
+			const freshIdx = v3Index(
+				[
+					{ ...rootEntry("root1", "Root", "2026-02-18T10:00:00Z"), treeHash: "tree-1" },
+					{ ...rootEntry("worker-new", "Worker added me", "2026-02-19T11:00:00Z"), treeHash: "tree-2" },
+				],
+				{},
+			);
+			vi.mocked(readFileFromBranch)
+				.mockResolvedValueOnce(JSON.stringify(preflightIdx)) // preflight (no lock)
+				.mockResolvedValueOnce(JSON.stringify(freshIdx)); // inside-lock re-read
+			vi.mocked(getTreeHash).mockResolvedValueOnce("tree-1");
+
+			const result = await scanTreeHashAliases(["unknown1"]);
+
+			expect(result).toBe(true);
+			const files = vi.mocked(writeMultipleFilesToBranch).mock.calls[0][1] as ReadonlyArray<FileWrite>;
+			const persistedIndex = JSON.parse(files[0].content) as SummaryIndex;
+
+			// Critical assertion: the worker's new entry must survive scan's write.
+			const persistedHashes = persistedIndex.entries.map((e) => e.commitHash);
+			expect(persistedHashes).toContain("root1");
+			expect(persistedHashes).toContain("worker-new");
+			// And scan's alias is recorded.
+			expect(persistedIndex.commitAliases).toEqual({ unknown1: "root1" });
+		});
+
+		it("drops a candidate that was already aliased by a concurrent writer", async () => {
+			// Preflight: unknown1 is unaliased; tree-1 matches root1.
+			const preflightIdx = v3Index([{ ...rootEntry("root1", "Root"), treeHash: "tree-1" }], {});
+			// Fresh: a concurrent scan/writer already aliased unknown1 → root1.
+			const freshIdx = v3Index([{ ...rootEntry("root1", "Root"), treeHash: "tree-1" }], {
+				unknown1: "root1",
+			});
+			vi.mocked(readFileFromBranch)
+				.mockResolvedValueOnce(JSON.stringify(preflightIdx))
+				.mockResolvedValueOnce(JSON.stringify(freshIdx));
+			vi.mocked(getTreeHash).mockResolvedValueOnce("tree-1");
+
+			const result = await scanTreeHashAliases(["unknown1"]);
+
+			// Already-aliased → nothing new to write.
+			expect(result).toBe(false);
+			expect(writeMultipleFilesToBranch).not.toHaveBeenCalled();
+		});
+
+		it("drops a candidate whose hash already exists as an entry in the fresh index", async () => {
+			// Preflight: unknown1 is missing entirely.
+			const preflightIdx = v3Index([{ ...rootEntry("root1", "Root"), treeHash: "tree-1" }], {});
+			// Fresh: a concurrent worker stored a real summary for unknown1
+			// (it is now a first-class entry, no alias needed).
+			const freshIdx = v3Index(
+				[
+					{ ...rootEntry("root1", "Root"), treeHash: "tree-1" },
+					{ ...rootEntry("unknown1", "Worker stored me", "2026-02-19T11:00:00Z"), treeHash: "tree-9" },
+				],
+				{},
+			);
+			vi.mocked(readFileFromBranch)
+				.mockResolvedValueOnce(JSON.stringify(preflightIdx))
+				.mockResolvedValueOnce(JSON.stringify(freshIdx));
+			vi.mocked(getTreeHash).mockResolvedValueOnce("tree-1");
+
+			const result = await scanTreeHashAliases(["unknown1"]);
+
+			expect(result).toBe(false);
+			expect(writeMultipleFilesToBranch).not.toHaveBeenCalled();
 		});
 	});
 

--- a/cli/src/core/SummaryStore.test.ts
+++ b/cli/src/core/SummaryStore.test.ts
@@ -11,9 +11,9 @@ vi.mock("./GitOps.js", () => ({
 	orphanBranchExists: vi.fn().mockResolvedValue(true),
 }));
 
-vi.mock("./SessionTracker.js", () => ({
-	acquireLock: vi.fn(),
-	releaseLock: vi.fn(),
+vi.mock("./Locks.js", () => ({
+	acquireOrphanWriteLock: vi.fn(),
+	releaseOrphanWriteLock: vi.fn(),
 }));
 
 // Suppress console output
@@ -36,7 +36,7 @@ import {
 	readFileFromBranch,
 	writeMultipleFilesToBranch,
 } from "./GitOps.js";
-import { acquireLock, releaseLock } from "./SessionTracker.js";
+import { acquireOrphanWriteLock, releaseOrphanWriteLock } from "./Locks.js";
 import {
 	AmbiguousHashError,
 	deleteTranscript,
@@ -116,8 +116,8 @@ describe("SummaryStore", () => {
 		// Default: getTreeHash returns null (no treeHash tracking by default)
 		vi.mocked(getTreeHash).mockResolvedValue(null);
 		vi.mocked(getDiffStats).mockResolvedValue({ filesChanged: 1, insertions: 5, deletions: 2 });
-		vi.mocked(acquireLock).mockResolvedValue(true);
-		vi.mocked(releaseLock).mockResolvedValue(undefined);
+		vi.mocked(acquireOrphanWriteLock).mockResolvedValue(true);
+		vi.mocked(releaseOrphanWriteLock).mockResolvedValue(undefined);
 	});
 
 	describe("storeSummary", () => {
@@ -1931,15 +1931,15 @@ describe("SummaryStore", () => {
 			expect(writeMultipleFilesToBranch).not.toHaveBeenCalled();
 		});
 
-		it("should defer alias writes when the shared lock cannot be acquired", async () => {
+		it("should defer alias writes when orphan-write lock cannot be acquired", async () => {
 			const index = v3Index([{ ...rootEntry("root1", "Root"), treeHash: "tree-1" }]);
 			vi.mocked(readFileFromBranch).mockResolvedValueOnce(JSON.stringify(index));
 			vi.mocked(getTreeHash).mockResolvedValueOnce("tree-1");
-			vi.mocked(acquireLock).mockResolvedValueOnce(false);
+			vi.mocked(acquireOrphanWriteLock).mockResolvedValueOnce(false);
 
 			await expect(scanTreeHashAliases(["unknown1"])).resolves.toBe(false);
 			expect(writeMultipleFilesToBranch).not.toHaveBeenCalled();
-			expect(releaseLock).not.toHaveBeenCalled();
+			expect(releaseOrphanWriteLock).not.toHaveBeenCalled();
 		});
 
 		it("should alias to the most recent shallow match when tree hash depth ties", async () => {

--- a/cli/src/core/SummaryStore.ts
+++ b/cli/src/core/SummaryStore.ts
@@ -37,8 +37,8 @@ import type {
 	TopicSummary,
 } from "../Types.js";
 import { getDiffStats, getTreeHash } from "./GitOps.js";
+import { acquireOrphanWriteLock, releaseOrphanWriteLock } from "./Locks.js";
 import { OrphanBranchStorage } from "./OrphanBranchStorage.js";
-import { acquireLock, releaseLock } from "./SessionTracker.js";
 import type { StorageProvider } from "./StorageProvider.js";
 import type { SquashConsolidationSource } from "./Summarizer.js";
 import { getDisplayDate } from "./SummaryFormat.js";
@@ -58,6 +58,40 @@ const log = createLogger("SummaryStore");
 
 const INDEX_FILE = "index.json";
 const CATALOG_FILE = "catalog.json";
+
+/**
+ * Default wait budget for orphan-write lock when an orphan-branch write must
+ * succeed (worker path). Kept generous because the lock is normally held only
+ * for milliseconds — exhausting 5 s means a real fault, not normal contention.
+ */
+const ORPHAN_WRITE_REQUIRED_TIMEOUT_MS = 5000;
+
+/**
+ * Default wait budget for orphan-write lock on best-effort paths
+ * (background scans, admin cleanup) where deferring is acceptable.
+ */
+const ORPHAN_WRITE_BEST_EFFORT_TIMEOUT_MS = 1000;
+
+/**
+ * Acquires `orphan-write.lock` for a critical section that MUST land
+ * (worker path). Throws on timeout — callers rely on the lock to avoid
+ * lost-update races against background scans.
+ */
+async function withRequiredOrphanWriteLock<T>(
+	cwd: string | undefined,
+	label: string,
+	fn: () => Promise<T>,
+): Promise<T> {
+	const acquired = await acquireOrphanWriteLock(cwd, { timeoutMs: ORPHAN_WRITE_REQUIRED_TIMEOUT_MS });
+	if (!acquired) {
+		throw new Error(`${label}: could not acquire orphan-write lock within ${ORPHAN_WRITE_REQUIRED_TIMEOUT_MS}ms`);
+	}
+	try {
+		return await fn();
+	} finally {
+		await releaseOrphanWriteLock(cwd);
+	}
+}
 
 /**
  * Returns true if the entry is a root-level summary (not a child of a
@@ -95,64 +129,66 @@ export async function storeSummary(
 		readonly planProgress?: ReadonlyArray<PlanProgressArtifact>;
 	},
 ): Promise<void> {
-	const existingIndex = await loadIndex(cwd);
-	const existingCatalog = await loadCatalog(cwd);
-	const existingEntries = existingIndex?.entries ? [...existingIndex.entries] : [];
-	const entryMap = new Map(existingEntries.map((e) => [e.commitHash, e]));
+	await withRequiredOrphanWriteLock(cwd, "storeSummary", async () => {
+		const existingIndex = await loadIndex(cwd);
+		const existingCatalog = await loadCatalog(cwd);
+		const existingEntries = existingIndex?.entries ? [...existingIndex.entries] : [];
+		const entryMap = new Map(existingEntries.map((e) => [e.commitHash, e]));
 
-	// Duplicate guard: skip if root already indexed and force=false
-	if (!force && entryMap.has(summary.commitHash)) {
-		log.info(
-			"Summary for commit %s already exists — skipping (use force to overwrite)",
-			summary.commitHash.substring(0, 8),
-		);
-		return;
-	}
+		// Duplicate guard: skip if root already indexed and force=false
+		if (!force && entryMap.has(summary.commitHash)) {
+			log.info(
+				"Summary for commit %s already exists — skipping (use force to overwrite)",
+				summary.commitHash.substring(0, 8),
+			);
+			return;
+		}
 
-	// Flatten the entire tree into index entries and upsert
-	const newEntries = await flattenSummaryTree(summary, null, cwd, entryMap);
-	for (const entry of newEntries) {
-		entryMap.set(entry.commitHash, entry);
-	}
+		// Flatten the entire tree into index entries and upsert
+		const newEntries = await flattenSummaryTree(summary, null, cwd, entryMap);
+		for (const entry of newEntries) {
+			entryMap.set(entry.commitHash, entry);
+		}
 
-	const newIndex: SummaryIndex = {
-		version: 3,
-		entries: [...entryMap.values()],
-		commitAliases: existingIndex?.commitAliases,
-	};
+		const newIndex: SummaryIndex = {
+			version: 3,
+			entries: [...entryMap.values()],
+			commitAliases: existingIndex?.commitAliases,
+		};
 
-	const verb = force ? "Overwrite" : "Add";
-	const files: FileWrite[] = [
-		{ path: `summaries/${summary.commitHash}.json`, content: JSON.stringify(summary, null, "\t") },
-		{ path: INDEX_FILE, content: JSON.stringify(newIndex, null, "\t") },
-		buildCatalogFileWrite(existingCatalog, entryMap, summary),
-	];
+		const verb = force ? "Overwrite" : "Add";
+		const files: FileWrite[] = [
+			{ path: `summaries/${summary.commitHash}.json`, content: JSON.stringify(summary, null, "\t") },
+			{ path: INDEX_FILE, content: JSON.stringify(newIndex, null, "\t") },
+			buildCatalogFileWrite(existingCatalog, entryMap, summary),
+		];
 
-	// Append transcript file if provided
-	if (artifacts?.transcript && artifacts.transcript.sessions.length > 0) {
-		files.push({
-			path: `transcripts/${summary.commitHash}.json`,
-			content: JSON.stringify(artifacts.transcript, null, "\t"),
-		});
-	}
-
-	// Append plan progress files if provided
-	if (artifacts?.planProgress) {
-		for (const progress of artifacts.planProgress) {
+		// Append transcript file if provided
+		if (artifacts?.transcript && artifacts.transcript.sessions.length > 0) {
 			files.push({
-				path: `plan-progress/${progress.planSlug}.json`,
-				content: JSON.stringify(progress, null, "\t"),
+				path: `transcripts/${summary.commitHash}.json`,
+				content: JSON.stringify(artifacts.transcript, null, "\t"),
 			});
 		}
-	}
 
-	const store = resolveStorage(undefined, cwd);
-	await store.writeFiles(
-		files,
-		`${verb} summary for ${summary.commitHash.substring(0, 8)}: ${summary.commitMessage.substring(0, 50)}`,
-	);
+		// Append plan progress files if provided
+		if (artifacts?.planProgress) {
+			for (const progress of artifacts.planProgress) {
+				files.push({
+					path: `plan-progress/${progress.planSlug}.json`,
+					content: JSON.stringify(progress, null, "\t"),
+				});
+			}
+		}
 
-	log.info("Summary stored successfully for commit %s", summary.commitHash.substring(0, 8));
+		const store = resolveStorage(undefined, cwd);
+		await store.writeFiles(
+			files,
+			`${verb} summary for ${summary.commitHash.substring(0, 8)}: ${summary.commitMessage.substring(0, 50)}`,
+		);
+
+		log.info("Summary stored successfully for commit %s", summary.commitHash.substring(0, 8));
+	});
 }
 
 /**
@@ -170,6 +206,17 @@ export async function storeSummary(
  * how `runSquashPipeline` propagates these fields on squash / amend.
  */
 export async function migrateOneToOne(
+	oldSummary: CommitSummary,
+	newCommitInfo: CommitInfo,
+	cwd?: string,
+	metadata?: { readonly commitType?: CommitType; readonly commitSource?: CommitSource },
+): Promise<void> {
+	await withRequiredOrphanWriteLock(cwd, "migrateOneToOne", () =>
+		migrateOneToOneLocked(oldSummary, newCommitInfo, cwd, metadata),
+	);
+}
+
+async function migrateOneToOneLocked(
 	oldSummary: CommitSummary,
 	newCommitInfo: CommitInfo,
 	cwd?: string,
@@ -539,6 +586,18 @@ export async function mergeManyToOne(
 	metadata?: { readonly commitType?: CommitType; readonly commitSource?: CommitSource },
 	consolidated?: ConsolidatedTopics,
 ): Promise<{ orphanedDocIds: number[] }> {
+	return withRequiredOrphanWriteLock(cwd, "mergeManyToOne", () =>
+		mergeManyToOneLocked(oldSummaries, newCommitInfo, cwd, metadata, consolidated),
+	);
+}
+
+async function mergeManyToOneLocked(
+	oldSummaries: ReadonlyArray<CommitSummary>,
+	newCommitInfo: CommitInfo,
+	cwd?: string,
+	metadata?: { readonly commitType?: CommitType; readonly commitSource?: CommitSource },
+	consolidated?: ConsolidatedTopics,
+): Promise<{ orphanedDocIds: number[] }> {
 	log.info("Merging %d summaries into %s", oldSummaries.length, newCommitInfo.hash.substring(0, 8));
 
 	// Sort children by activity date descending (newest first) via getDisplayDate.
@@ -654,13 +713,21 @@ export async function mergeManyToOne(
  * Use only for admin cleanup of truly orphaned root entries.
  */
 export async function removeFromIndex(commitHash: string, cwd?: string): Promise<void> {
-	// Acquire the shared lock before touching index/catalog: this function
+	// Acquire orphan-write.lock before touching index/catalog: this function
 	// performs a multi-file write that races with QueueWorker / scanTreeHashAliases
 	// / storeSummary if unsynchronized. Loading the data inside the lock window
 	// guarantees we operate on the most recent on-disk state.
-	const locked = await acquireLock(cwd);
+	//
+	// Best-effort path: defer when the lock is contended. removeFromIndex is an
+	// admin cleanup and the caller can retry; deferring beats stomping a fresher
+	// concurrent write.
+	const locked = await acquireOrphanWriteLock(cwd, { timeoutMs: ORPHAN_WRITE_BEST_EFFORT_TIMEOUT_MS });
 	if (!locked) {
-		log.warn("removeFromIndex: could not acquire lock — skipping removal of %s", commitHash.substring(0, 8));
+		log.warn(
+			"removeFromIndex: could not acquire orphan-write lock within %dms — skipping removal of %s",
+			ORPHAN_WRITE_BEST_EFFORT_TIMEOUT_MS,
+			commitHash.substring(0, 8),
+		);
 		return;
 	}
 	try {
@@ -692,7 +759,7 @@ export async function removeFromIndex(commitHash: string, cwd?: string): Promise
 		await store.writeFiles(files, `Remove index entry for ${commitHash.substring(0, 8)}`);
 		log.info("Removed %s from index", commitHash.substring(0, 8));
 	} finally {
-		await releaseLock(cwd);
+		await releaseOrphanWriteLock(cwd);
 	}
 }
 
@@ -769,9 +836,11 @@ export async function saveTranscriptsBatch(
 		.filter(Boolean)
 		.join(", ");
 
-	const store = resolveStorage(undefined, cwd);
-	await store.writeFiles(files, `Update transcripts: ${summary}`);
-	log.info("Transcript batch: %s", summary);
+	await withRequiredOrphanWriteLock(cwd, "saveTranscriptsBatch", async () => {
+		const store = resolveStorage(undefined, cwd);
+		await store.writeFiles(files, `Update transcripts: ${summary}`);
+		log.info("Transcript batch: %s", summary);
+	});
 }
 
 /**
@@ -1145,12 +1214,14 @@ export async function scanTreeHashAliases(
 
 	if (Object.keys(newAliases).length === 0) return false;
 
-	// Acquire the shared lock before writing to the orphan branch.
-	// The Worker holds the same lock during summarization, and migrations hold
-	// it too — skipping the write here is safe since the next UI refresh will retry.
-	const locked = await acquireLock(cwd);
+	// Acquire orphan-write.lock before writing to the orphan branch.
+	// Background path: deferring is acceptable — the next UI refresh re-enters
+	// scanTreeHashAliases, which is why this used `log.warn` historically. The
+	// log level is now `debug` because deferral is the expected outcome under
+	// contention, not a warning condition.
+	const locked = await acquireOrphanWriteLock(cwd, { timeoutMs: ORPHAN_WRITE_BEST_EFFORT_TIMEOUT_MS });
 	if (!locked) {
-		log.warn("scanTreeHashAliases: could not acquire lock — alias write deferred");
+		log.debug("scanTreeHashAliases: orphan-write lock contention — alias write deferred");
 		return false;
 	}
 	try {
@@ -1160,7 +1231,7 @@ export async function scanTreeHashAliases(
 		const store = resolveStorage(storage, cwd);
 		await store.writeFiles(files, `Add ${Object.keys(newAliases).length} tree hash alias(es)`);
 	} finally {
-		await releaseLock(cwd);
+		await releaseOrphanWriteLock(cwd);
 	}
 
 	return true;
@@ -1194,9 +1265,13 @@ export async function indexNeedsMigration(cwd?: string): Promise<boolean> {
  * For each top-level summary, loads the full JSON tree and flattens it into index entries.
  * Calls `getTreeHash` for each node to populate `treeHash` fields.
  *
- * All orphan branch writes use the shared lock (callers must hold `acquireLock` before calling).
+ * Acquires `orphan-write.lock` internally — callers no longer need to wrap.
  */
 export async function migrateIndexToV3(cwd?: string): Promise<{ migrated: number; skipped: number }> {
+	return withRequiredOrphanWriteLock(cwd, "migrateIndexToV3", () => migrateIndexToV3Locked(cwd));
+}
+
+async function migrateIndexToV3Locked(cwd?: string): Promise<{ migrated: number; skipped: number }> {
 	const existingIndex = await loadIndex(cwd);
 	if (!existingIndex) {
 		log.info("No index found — nothing to migrate");
@@ -1537,13 +1612,15 @@ export async function getCatalogWithLazyBuild(cwd?: string, storage?: StoragePro
 		return preflightCatalog;
 	}
 
-	// We have work to do. Acquire the shared lock so concurrent worker writes
+	// We have work to do. Acquire orphan-write.lock so concurrent worker writes
 	// can't race with our update; if the lock is contended, fall back to the
 	// preflight in-memory result (a stale-but-coherent view is better than
 	// stomping a fresher write).
-	const locked = await acquireLock(cwd);
+	const locked = await acquireOrphanWriteLock(cwd, { timeoutMs: ORPHAN_WRITE_BEST_EFFORT_TIMEOUT_MS });
 	if (!locked) {
-		log.debug("getCatalogWithLazyBuild: lock contention — returning in-memory catalog without writeback");
+		log.debug(
+			"getCatalogWithLazyBuild: orphan-write lock contention — returning in-memory catalog without writeback",
+		);
 		// Build the in-memory updated view so caller still sees current roots.
 		const cleaned = preflightCatalog.entries.filter((e) => preflightRoots.has(e.commitHash));
 		const newEntries: CatalogEntry[] = [];
@@ -1593,7 +1670,7 @@ export async function getCatalogWithLazyBuild(cwd?: string, storage?: StoragePro
 		await store.writeFiles([{ path: CATALOG_FILE, content: JSON.stringify(updated, null, "\t") }], message);
 		return updated;
 	} finally {
-		await releaseLock(cwd);
+		await releaseOrphanWriteLock(cwd);
 	}
 }
 
@@ -1663,9 +1740,11 @@ export async function storePlans(
 		branch,
 	}));
 
-	const store = resolveStorage(undefined, cwd);
-	await store.writeFiles(files, commitMessage);
-	log.info("Stored %d plan file(s)", planFiles.length);
+	await withRequiredOrphanWriteLock(cwd, "storePlans", async () => {
+		const store = resolveStorage(undefined, cwd);
+		await store.writeFiles(files, commitMessage);
+		log.info("Stored %d plan file(s)", planFiles.length);
+	});
 }
 
 /**
@@ -1720,9 +1799,11 @@ export async function storeNotes(
 		branch,
 	}));
 
-	const store = resolveStorage(undefined, cwd);
-	await store.writeFiles(files, commitMessage);
-	log.info("Stored %d note file(s)", noteFiles.length);
+	await withRequiredOrphanWriteLock(cwd, "storeNotes", async () => {
+		const store = resolveStorage(undefined, cwd);
+		await store.writeFiles(files, commitMessage);
+		log.info("Stored %d note file(s)", noteFiles.length);
+	});
 }
 
 /**

--- a/cli/src/core/SummaryStore.ts
+++ b/cli/src/core/SummaryStore.ts
@@ -60,22 +60,40 @@ const INDEX_FILE = "index.json";
 const CATALOG_FILE = "catalog.json";
 
 /**
- * Default wait budget for orphan-write lock when an orphan-branch write must
- * succeed (worker path). Kept generous because the lock is normally held only
- * for milliseconds — exhausting 5 s means a real fault, not normal contention.
+ * Wait budget for orphan-write lock on the worker path (writes that must land).
+ *
+ * 30 s is sized for the worst legitimate contention we expect: a fresh-install
+ * v1 → v3 migration on a large repository running concurrently with a commit
+ * (a few seconds of held lock). Normal background-scan contention is 50–200 ms,
+ * so 30 s leaves ~100× headroom.
+ *
+ * On timeout `withRequiredOrphanWriteLock` throws and the worker's outer
+ * `processQueueEntry` catch deletes the queue entry. We deliberately do NOT
+ * preserve the entry for retry: the cursor for read transcripts has already
+ * advanced past the relevant range by the time `storeSummary` is called
+ * (see `saveCursor` in QueueWorker), so a retried run would build a summary
+ * over the wrong transcript window — corrupt output is worse than missing
+ * output. This matches the system-wide "fire-and-forget, don't retry"
+ * philosophy documented at QueueWorker.runWorker's catch block.
+ *
+ * The probability of timing out at 30 s is far below other inherent failure
+ * modes (LLM call, network, user kill), so the practical loss risk is
+ * negligible.
  */
-const ORPHAN_WRITE_REQUIRED_TIMEOUT_MS = 5000;
+const ORPHAN_WRITE_REQUIRED_TIMEOUT_MS = 30_000;
 
 /**
- * Default wait budget for orphan-write lock on best-effort paths
- * (background scans, admin cleanup) where deferring is acceptable.
+ * Wait budget for orphan-write lock on best-effort paths (background scans,
+ * admin cleanup). 1 s is enough to ride out the typical 50–200 ms held
+ * window with margin; deferring on contention is acceptable because the
+ * caller will be re-invoked (next UI refresh, next admin run).
  */
 const ORPHAN_WRITE_BEST_EFFORT_TIMEOUT_MS = 1000;
 
 /**
  * Acquires `orphan-write.lock` for a critical section that MUST land
- * (worker path). Throws on timeout — callers rely on the lock to avoid
- * lost-update races against background scans.
+ * (worker path). Throws on timeout — see `ORPHAN_WRITE_REQUIRED_TIMEOUT_MS`
+ * for why "lose this entry" is the chosen failure mode.
  */
 async function withRequiredOrphanWriteLock<T>(
 	cwd: string | undefined,
@@ -1182,26 +1200,29 @@ export async function scanTreeHashAliases(
 	cwd?: string,
 	storage?: StorageProvider,
 ): Promise<boolean> {
-	const index = await loadIndex(cwd, storage);
-	if (!index || index.version !== 3) return false;
+	// ── Phase 1: preflight (no lock) ────────────────────────────────────────
+	// Compute candidate aliases against the current index. Tree-hash lookup is
+	// O(n) git calls — expensive — so we keep it outside the lock to avoid
+	// blocking concurrent worker writes. The lookup result is "tentative":
+	// Phase 2 re-validates against the freshly-loaded index inside the lock.
+	const preflightIndex = await loadIndex(cwd, storage);
+	if (!preflightIndex || preflightIndex.version !== 3) return false;
 
-	const existingAliases = { ...(index.commitAliases ?? {}) };
-	const entryHashSet = new Set(index.entries.map((e) => e.commitHash));
-	const entryMap = new Map(index.entries.map((e) => [e.commitHash, e]));
+	const preflightAliases = preflightIndex.commitAliases ?? {};
+	const preflightEntryHashSet = new Set(preflightIndex.entries.map((e) => e.commitHash));
+	const preflightEntryMap = new Map(preflightIndex.entries.map((e) => [e.commitHash, e]));
 
-	const newAliases: Record<string, string> = {};
-
+	const candidates: Record<string, string> = {};
 	for (const hash of commitHashes) {
-		// Skip if already known directly or via alias
-		if (entryHashSet.has(hash) || existingAliases[hash]) continue;
+		if (preflightEntryHashSet.has(hash) || preflightAliases[hash]) continue;
 
 		const treeHash = await getTreeHash(hash, cwd);
 		if (!treeHash) continue;
 
 		/* v8 ignore start -- tree hash match: requires real git repo with matching tree hashes */
-		const matchEntry = findShallowstByTreeHash(treeHash, index.entries, entryMap);
+		const matchEntry = findShallowstByTreeHash(treeHash, preflightIndex.entries, preflightEntryMap);
 		if (matchEntry) {
-			newAliases[hash] = matchEntry.commitHash;
+			candidates[hash] = matchEntry.commitHash;
 			log.info(
 				"Tree hash match: %s → %s (treeHash: %s)",
 				hash.substring(0, 8),
@@ -1212,29 +1233,54 @@ export async function scanTreeHashAliases(
 		/* v8 ignore stop */
 	}
 
-	if (Object.keys(newAliases).length === 0) return false;
+	if (Object.keys(candidates).length === 0) return false;
 
-	// Acquire orphan-write.lock before writing to the orphan branch.
-	// Background path: deferring is acceptable — the next UI refresh re-enters
-	// scanTreeHashAliases, which is why this used `log.warn` historically. The
-	// log level is now `debug` because deferral is the expected outcome under
-	// contention, not a warning condition.
+	// ── Phase 2: critical section (lock) ────────────────────────────────────
+	// Acquire orphan-write.lock and re-load the index. The previous
+	// implementation reused the preflight `index` object inside the lock, which
+	// caused a lost-update: a worker that wrote new entries after preflight but
+	// before our lock-acquire would see its `entries` clobbered when we wrote
+	// `{ ...preflightIndex, commitAliases }` back. Re-reading the freshly
+	// persisted index inside the lock and merging only `commitAliases` keeps
+	// the worker's `entries` intact.
+	//
+	// Background path: deferring is acceptable on contention — the next UI
+	// refresh re-enters scanTreeHashAliases. log.debug, not warn, because
+	// deferral is the expected outcome under contention.
 	const locked = await acquireOrphanWriteLock(cwd, { timeoutMs: ORPHAN_WRITE_BEST_EFFORT_TIMEOUT_MS });
 	if (!locked) {
 		log.debug("scanTreeHashAliases: orphan-write lock contention — alias write deferred");
 		return false;
 	}
 	try {
-		const mergedAliases = { ...existingAliases, ...newAliases };
-		const newIndex: SummaryIndex = { ...index, commitAliases: mergedAliases };
+		const freshIndex = await loadIndex(cwd, storage);
+		if (!freshIndex || freshIndex.version !== 3) return false;
+
+		const freshAliases = freshIndex.commitAliases ?? {};
+		const freshEntryHashSet = new Set(freshIndex.entries.map((e) => e.commitHash));
+
+		// Drop candidates a concurrent writer has resolved (now in entries) or
+		// already aliased; only persist ones still genuinely missing.
+		const finalAliases: Record<string, string> = { ...freshAliases };
+		let added = 0;
+		for (const [aliasHash, targetHash] of Object.entries(candidates)) {
+			if (freshEntryHashSet.has(aliasHash)) continue;
+			if (finalAliases[aliasHash]) continue;
+			finalAliases[aliasHash] = targetHash;
+			added++;
+		}
+		if (added === 0) return false;
+
+		// Build newIndex from freshIndex (not preflightIndex) so any entries the
+		// worker added between preflight and lock-acquire are preserved.
+		const newIndex: SummaryIndex = { ...freshIndex, commitAliases: finalAliases };
 		const files: FileWrite[] = [{ path: INDEX_FILE, content: JSON.stringify(newIndex, null, "\t") }];
 		const store = resolveStorage(storage, cwd);
-		await store.writeFiles(files, `Add ${Object.keys(newAliases).length} tree hash alias(es)`);
+		await store.writeFiles(files, `Add ${added} tree hash alias(es)`);
+		return true;
 	} finally {
 		await releaseOrphanWriteLock(cwd);
 	}
-
-	return true;
 }
 
 /**

--- a/cli/src/hooks/PostCommitHook.helpers.test.ts
+++ b/cli/src/hooks/PostCommitHook.helpers.test.ts
@@ -124,7 +124,6 @@ vi.mock("../core/GitOps.js", () => ({
 }));
 
 vi.mock("../core/SessionTracker.js", () => ({
-	acquireLock: vi.fn(),
 	associatePlanWithCommit: mockAssociatePlanWithCommit,
 	deleteAmendPending: vi.fn(),
 	deletePluginSource: mockDeletePluginSource,
@@ -137,9 +136,15 @@ vi.mock("../core/SessionTracker.js", () => ({
 	loadPlansRegistry: mockLoadPlansRegistry,
 	loadPluginSource: mockLoadPluginSource,
 	loadSquashPending: mockLoadSquashPending,
-	releaseLock: vi.fn(),
 	saveCursor: mockSaveCursor,
 	savePlansRegistry: mockSavePlansRegistry,
+}));
+
+vi.mock("../core/Locks.js", () => ({
+	acquireWorkerLock: vi.fn(async () => true),
+	releaseWorkerLock: vi.fn(),
+	refreshWorkerLockMtime: vi.fn(),
+	isWorkerLockHeld: vi.fn(),
 }));
 
 vi.mock("../core/SummaryStore.js", async (importOriginal) => {

--- a/cli/src/hooks/PostCommitHook.test.ts
+++ b/cli/src/hooks/PostCommitHook.test.ts
@@ -36,8 +36,6 @@ vi.mock("../core/SessionTracker.js", async (importOriginal) => {
 		loadCursorForTranscript: vi.fn(),
 		saveCursor: vi.fn(),
 		loadConfig: vi.fn(),
-		acquireLock: vi.fn(),
-		releaseLock: vi.fn(),
 		loadSquashPending: vi.fn(),
 		deleteSquashPending: vi.fn(),
 		loadPluginSource: vi.fn(),
@@ -47,13 +45,19 @@ vi.mock("../core/SessionTracker.js", async (importOriginal) => {
 		associatePlanWithCommit: vi.fn(),
 		associateNoteWithCommit: vi.fn(),
 		filterSessionsByEnabledIntegrations: actual.filterSessionsByEnabledIntegrations,
-		// Queue functions (new)
+		// Queue functions
 		dequeueAllGitOperations: vi.fn(),
 		deleteQueueEntry: vi.fn(),
 		enqueueGitOperation: vi.fn(),
-		isLockHeld: vi.fn(),
 	};
 });
+
+vi.mock("../core/Locks.js", () => ({
+	acquireWorkerLock: vi.fn(),
+	releaseWorkerLock: vi.fn(),
+	refreshWorkerLockMtime: vi.fn(),
+	isWorkerLockHeld: vi.fn(),
+}));
 
 vi.mock("../core/TranscriptReader.js", () => ({
 	readTranscript: vi.fn(),
@@ -199,10 +203,10 @@ import {
 	getProjectRootDir,
 	readFileFromBranch,
 } from "../core/GitOps.js";
+import { acquireWorkerLock, releaseWorkerLock } from "../core/Locks.js";
 import { discoverOpenCodeSessions, isOpenCodeInstalled } from "../core/OpenCodeSessionDiscoverer.js";
 import { readOpenCodeTranscript } from "../core/OpenCodeTranscriptReader.js";
 import {
-	acquireLock,
 	associateNoteWithCommit,
 	associatePlanWithCommit,
 	deleteQueueEntry,
@@ -212,7 +216,6 @@ import {
 	loadCursorForTranscript,
 	loadPlansRegistry,
 	loadSquashPending,
-	releaseLock,
 	saveCursor,
 	savePlansRegistry,
 } from "../core/SessionTracker.js";
@@ -318,8 +321,8 @@ describe("PostCommitHook", () => {
 		vi.useFakeTimers();
 
 		// Default: lock can be acquired
-		vi.mocked(acquireLock).mockResolvedValue(true);
-		vi.mocked(releaseLock).mockResolvedValue();
+		vi.mocked(acquireWorkerLock).mockResolvedValue(true);
+		vi.mocked(releaseWorkerLock).mockResolvedValue();
 		// Default: empty config (prevents undefined access after loadConfig)
 		vi.mocked(loadConfig).mockResolvedValue({});
 		// Default: no Codex sessions (prevent undefined.length crash)
@@ -339,7 +342,7 @@ describe("PostCommitHook", () => {
 
 		await runWorker("/test/project");
 
-		expect(acquireLock).toHaveBeenCalled();
+		expect(acquireWorkerLock).toHaveBeenCalled();
 		expect(getCommitInfo).toHaveBeenCalledWith("abc123", "/test/project");
 		expect(loadAllSessions).toHaveBeenCalled();
 		expect(readTranscript).toHaveBeenCalled();
@@ -347,7 +350,7 @@ describe("PostCommitHook", () => {
 		expect(generateSummary).toHaveBeenCalled();
 		expect(storeSummary).toHaveBeenCalled();
 		expect(saveCursor).toHaveBeenCalled();
-		expect(releaseLock).toHaveBeenCalled();
+		expect(releaseWorkerLock).toHaveBeenCalled();
 	});
 
 	it("should mark summaries as plugin-sourced when queue entry has commitSource:plugin", async () => {
@@ -436,7 +439,7 @@ describe("PostCommitHook", () => {
 		await runWorker("/test/project");
 
 		expect(generateSummary).not.toHaveBeenCalled();
-		expect(releaseLock).toHaveBeenCalled();
+		expect(releaseWorkerLock).toHaveBeenCalled();
 	});
 
 	it("should generate summary when no sessions but diff is non-empty (Part A fix)", async () => {
@@ -526,12 +529,12 @@ describe("PostCommitHook", () => {
 	});
 
 	it("should skip when lock cannot be acquired", async () => {
-		vi.mocked(acquireLock).mockResolvedValue(false);
+		vi.mocked(acquireWorkerLock).mockResolvedValue(false);
 
 		await runWorker("/test/project");
 
 		expect(getCommitInfo).not.toHaveBeenCalled();
-		expect(releaseLock).not.toHaveBeenCalled();
+		expect(releaseWorkerLock).not.toHaveBeenCalled();
 	});
 
 	it("should release lock even on pipeline error", async () => {
@@ -539,7 +542,7 @@ describe("PostCommitHook", () => {
 
 		await runWorker("/test/project");
 
-		expect(releaseLock).toHaveBeenCalled();
+		expect(releaseWorkerLock).toHaveBeenCalled();
 	});
 
 	// Note: rebase skip and amend-polling tests removed — these behaviors are now
@@ -818,8 +821,8 @@ describe("queue-driven Worker", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 		vi.useFakeTimers();
-		vi.mocked(acquireLock).mockResolvedValue(true);
-		vi.mocked(releaseLock).mockResolvedValue();
+		vi.mocked(acquireWorkerLock).mockResolvedValue(true);
+		vi.mocked(releaseWorkerLock).mockResolvedValue();
 	});
 
 	it("processes a commit queue entry through the full LLM pipeline", async () => {
@@ -850,7 +853,7 @@ describe("queue-driven Worker", () => {
 	});
 
 	it("exits without processing when lock cannot be acquired", async () => {
-		vi.mocked(acquireLock).mockResolvedValue(false);
+		vi.mocked(acquireWorkerLock).mockResolvedValue(false);
 		vi.mocked(dequeueAllGitOperations).mockResolvedValue([DEFAULT_COMMIT_OP]);
 
 		await runWorker("/test/project");

--- a/cli/src/hooks/PostRewriteHook.test.ts
+++ b/cli/src/hooks/PostRewriteHook.test.ts
@@ -23,7 +23,10 @@ vi.mock("../core/GitOps.js", () => ({
 
 vi.mock("../core/SessionTracker.js", () => ({
 	enqueueGitOperation: vi.fn(),
-	isLockHeld: vi.fn(),
+}));
+
+vi.mock("../core/Locks.js", () => ({
+	isWorkerLockHeld: vi.fn(),
 }));
 
 // Mock QueueWorker's launchWorker (imported by PostRewriteHook for conditional spawn)
@@ -36,7 +39,8 @@ vi.spyOn(console, "log").mockImplementation(() => {});
 vi.spyOn(console, "warn").mockImplementation(() => {});
 vi.spyOn(console, "error").mockImplementation(() => {});
 
-import { enqueueGitOperation, isLockHeld } from "../core/SessionTracker.js";
+import { isWorkerLockHeld } from "../core/Locks.js";
+import { enqueueGitOperation } from "../core/SessionTracker.js";
 import { handlePostRewriteHook } from "./PostRewriteHook.js";
 import { launchWorker } from "./QueueWorker.js";
 
@@ -60,7 +64,7 @@ function setStdinLines(lines: string[]): void {
 describe("PostRewriteHook", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
-		vi.mocked(isLockHeld).mockResolvedValue(false);
+		vi.mocked(isWorkerLockHeld).mockResolvedValue(false);
 		vi.mocked(enqueueGitOperation).mockResolvedValue(true);
 		// Default: no plugin-source file
 		mockExistsSync.mockReturnValue(false);
@@ -86,7 +90,7 @@ describe("PostRewriteHook", () => {
 
 		it("should spawn Worker when lock is free after amend enqueue", async () => {
 			setStdinLines(["aaaa1111 bbbb2222"]);
-			vi.mocked(isLockHeld).mockResolvedValue(false);
+			vi.mocked(isWorkerLockHeld).mockResolvedValue(false);
 
 			await handlePostRewriteHook("amend", "/test/project");
 
@@ -95,7 +99,7 @@ describe("PostRewriteHook", () => {
 
 		it("should NOT spawn Worker when lock is held after amend enqueue", async () => {
 			setStdinLines(["aaaa1111 bbbb2222"]);
-			vi.mocked(isLockHeld).mockResolvedValue(true);
+			vi.mocked(isWorkerLockHeld).mockResolvedValue(true);
 
 			await handlePostRewriteHook("amend", "/test/project");
 
@@ -173,7 +177,7 @@ describe("PostRewriteHook", () => {
 
 		it("should spawn Worker when lock is free after rebase enqueue", async () => {
 			setStdinLines(["aaaa1111 bbbb2222"]);
-			vi.mocked(isLockHeld).mockResolvedValue(false);
+			vi.mocked(isWorkerLockHeld).mockResolvedValue(false);
 
 			await handlePostRewriteHook("rebase", "/test/project");
 
@@ -182,7 +186,7 @@ describe("PostRewriteHook", () => {
 
 		it("should NOT spawn Worker when lock is held after rebase enqueue", async () => {
 			setStdinLines(["aaaa1111 bbbb2222"]);
-			vi.mocked(isLockHeld).mockResolvedValue(true);
+			vi.mocked(isWorkerLockHeld).mockResolvedValue(true);
 
 			await handlePostRewriteHook("rebase", "/test/project");
 
@@ -284,5 +288,32 @@ describe("PostRewriteHook", () => {
 		await handlePostRewriteHook("unknown-command", "/test/project");
 
 		expect(enqueueGitOperation).not.toHaveBeenCalled();
+	});
+
+	// ── regression: orphan-write held but worker.lock empty ──────────────
+	//
+	// Before the lock split, a non-Worker holder of the (single) lock —
+	// notably scanTreeHashAliases triggered by VS Code's branch refresh —
+	// caused isLockHeld to return true; PostRewriteHook then assumed a
+	// Worker was running and skipped the spawn, leaving rebase-pick
+	// queue entries to rot. This test pins the new behaviour: only
+	// `worker.lock` blocks the spawn — orphan-write contention does not.
+	describe("regression: rebase + concurrent orphan-write does not orphan queue entries", () => {
+		it("spawns Worker even when only orphan-write.lock would have been held under the old single-lock model", async () => {
+			setStdinLines(["aaaa1111 bbbb2222"]);
+			// Worker.lock is free. Under the old shared-lock model, a background
+			// scan holding the (single) lock would also have flipped this to true
+			// and suppressed the spawn — that's the bug. The fix: the spawn
+			// decision consults worker.lock only.
+			vi.mocked(isWorkerLockHeld).mockResolvedValue(false);
+
+			await handlePostRewriteHook("rebase", "/test/project");
+
+			expect(enqueueGitOperation).toHaveBeenCalledWith(
+				expect.objectContaining({ type: "rebase-pick", commitHash: "bbbb2222" }),
+				"/test/project",
+			);
+			expect(launchWorker).toHaveBeenCalledWith("/test/project");
+		});
 	});
 });

--- a/cli/src/hooks/PostRewriteHook.ts
+++ b/cli/src/hooks/PostRewriteHook.ts
@@ -25,7 +25,8 @@ import { existsSync, unlinkSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { createInterface } from "node:readline";
 import { fileURLToPath } from "node:url";
-import { enqueueGitOperation, isLockHeld } from "../core/SessionTracker.js";
+import { isWorkerLockHeld } from "../core/Locks.js";
+import { enqueueGitOperation } from "../core/SessionTracker.js";
 import { createLogger, getJolliMemoryDir, setLogDir } from "../Logger.js";
 import type { CommitSource, GitOperation } from "../Types.js";
 import { launchWorker } from "./QueueWorker.js";
@@ -66,12 +67,15 @@ export async function handlePostRewriteHook(command: string, cwd: string): Promi
 		log.info("Unknown command '%s', skipping", command);
 	}
 
-	// Spawn Worker if lock is free (entries are queued, need someone to process them)
-	const lockHeld = await isLockHeld(cwd);
-	if (!lockHeld) {
+	// Spawn Worker only if no Worker is already running. We deliberately check
+	// `worker.lock` (not the older shared lock) so a brief background writer
+	// holding `orphan-write.lock` does not falsely block the spawn — that race
+	// was the cause of orphaned queue entries during rebase + VS Code panel scan.
+	const workerRunning = await isWorkerLockHeld(cwd);
+	if (!workerRunning) {
 		launchWorker(cwd);
 	} else {
-		log.info("Worker lock is held — queued entries will be consumed by the running Worker");
+		log.info("Worker is already running — queued entries will be drained by it");
 	}
 
 	log.info("=== Post-rewrite hook finished ===");

--- a/cli/src/hooks/QueueWorker.test.ts
+++ b/cli/src/hooks/QueueWorker.test.ts
@@ -21,8 +21,6 @@ vi.mock("../core/SessionTracker.js", async (importOriginal) => {
 		loadCursorForTranscript: vi.fn(),
 		saveCursor: vi.fn(),
 		loadConfig: vi.fn().mockResolvedValue({}),
-		acquireLock: vi.fn().mockResolvedValue(true),
-		releaseLock: vi.fn(),
 		loadPlansRegistry: vi.fn().mockResolvedValue({ version: 1, plans: {} }),
 		savePlansRegistry: vi.fn().mockResolvedValue(undefined),
 		associatePlanWithCommit: vi.fn(),
@@ -31,9 +29,15 @@ vi.mock("../core/SessionTracker.js", async (importOriginal) => {
 		dequeueAllGitOperations: vi.fn().mockResolvedValue([]),
 		deleteQueueEntry: vi.fn(),
 		enqueueGitOperation: vi.fn(),
-		isLockHeld: vi.fn(),
 	};
 });
+
+vi.mock("../core/Locks.js", () => ({
+	acquireWorkerLock: vi.fn().mockResolvedValue(true),
+	releaseWorkerLock: vi.fn(),
+	refreshWorkerLockMtime: vi.fn(),
+	isWorkerLockHeld: vi.fn(),
+}));
 
 vi.mock("../core/TranscriptReader.js", () => ({
 	readTranscript: vi.fn(),
@@ -196,16 +200,15 @@ import { discoverCursorSessions } from "../core/CursorSessionDiscoverer.js";
 import { readCursorTranscript } from "../core/CursorTranscriptReader.js";
 import { getCommitInfo, getCurrentBranch, getDiffContent, getDiffStats } from "../core/GitOps.js";
 import { LlmCredentialError } from "../core/LlmClient.js";
+import { acquireWorkerLock, releaseWorkerLock } from "../core/Locks.js";
 import { discoverOpenCodeSessions, isOpenCodeInstalled } from "../core/OpenCodeSessionDiscoverer.js";
 import { readOpenCodeTranscript } from "../core/OpenCodeTranscriptReader.js";
 import {
-	acquireLock,
 	dequeueAllGitOperations,
 	loadAllSessions,
 	loadConfig,
 	loadCursorForTranscript,
 	loadPlansRegistry,
-	releaseLock,
 	saveCursor,
 	savePlansRegistry,
 } from "../core/SessionTracker.js";
@@ -243,8 +246,8 @@ function setupPipelineMocks(hash = "abc12345def67890"): void {
 describe("QueueWorker", () => {
 	beforeEach(() => {
 		vi.resetAllMocks();
-		vi.mocked(acquireLock).mockResolvedValue(true);
-		vi.mocked(releaseLock).mockResolvedValue(undefined);
+		vi.mocked(acquireWorkerLock).mockResolvedValue(true);
+		vi.mocked(releaseWorkerLock).mockResolvedValue(undefined);
 		vi.mocked(dequeueAllGitOperations).mockResolvedValue([]);
 		vi.mocked(loadConfig).mockResolvedValue(
 			{} as ReturnType<typeof loadConfig> extends Promise<infer T> ? T : never,
@@ -383,7 +386,7 @@ describe("QueueWorker", () => {
 			await runWorker("/test/cwd");
 
 			// Worker should complete without throwing (error caught internally)
-			expect(releaseLock).toHaveBeenCalled();
+			expect(releaseWorkerLock).toHaveBeenCalled();
 		});
 
 		// The dispatcher's "fail loudly" promise (PR #93) is undermined if the

--- a/cli/src/hooks/QueueWorker.ts
+++ b/cli/src/hooks/QueueWorker.ts
@@ -34,11 +34,11 @@ import { readCursorTranscript } from "../core/CursorTranscriptReader.js";
 import { readGeminiTranscript } from "../core/GeminiTranscriptReader.js";
 import { getCommitInfo, getCurrentBranch, getDiffContent, getDiffStats } from "../core/GitOps.js";
 import { isLlmCredentialError } from "../core/LlmClient.js";
+import { acquireWorkerLock, refreshWorkerLockMtime, releaseWorkerLock } from "../core/Locks.js";
 import { discoverOpenCodeSessions, isOpenCodeInstalled } from "../core/OpenCodeSessionDiscoverer.js";
 import { readOpenCodeTranscript } from "../core/OpenCodeTranscriptReader.js";
 import { evaluatePlanProgress } from "../core/PlanProgressEvaluator.js";
 import {
-	acquireLock,
 	associateNoteWithCommit,
 	associatePlanWithCommit,
 	deleteQueueEntry,
@@ -48,7 +48,6 @@ import {
 	loadConfig,
 	loadCursorForTranscript,
 	loadPlansRegistry,
-	releaseLock,
 	saveCursor,
 	savePlansRegistry,
 } from "../core/SessionTracker.js";
@@ -99,6 +98,13 @@ const log = createLogger("QueueWorker");
 
 /** Delay before retry on API failure (ms) */
 const RETRY_DELAY_MS = 2000;
+
+/**
+ * How often to bump the worker.lock's mtime while the worker is running.
+ * Comfortably below `LOCK_TIMEOUT_MS` (5 min) so even a missed tick keeps
+ * the lock alive against the stale-lock reclaimer.
+ */
+const WORKER_LOCK_REFRESH_INTERVAL_MS = 60_000;
 
 // ─── Shared helpers for plans & notes re-association ─────────────────────────
 
@@ -203,12 +209,20 @@ export async function runWorker(cwd: string, force = false): Promise<void> {
 	const storage = await createStorage(cwd, cwd);
 	setActiveStorage(storage);
 
-	// Acquire lock to prevent concurrent runs
-	const lockAcquired = await acquireLock(cwd);
+	// Acquire worker.lock to prevent concurrent runs (a second worker exits immediately)
+	const lockAcquired = await acquireWorkerLock(cwd);
 	if (!lockAcquired) {
-		log.warn("Could not acquire lock, another worker may be running. Exiting.");
+		log.warn("Could not acquire worker lock, another worker may be running. Exiting.");
 		return;
 	}
+
+	// Periodically bump the lock's mtime so a long-running LLM call (rare, but
+	// possible when an upstream is slow) cannot be reaped by the stale-lock
+	// reclaimer at LOCK_TIMEOUT_MS. Refresh interval is comfortably below the
+	// timeout so a missed tick still leaves plenty of margin.
+	const refreshTimer = setInterval(() => {
+		void refreshWorkerLockMtime(cwd);
+	}, WORKER_LOCK_REFRESH_INTERVAL_MS);
 
 	try {
 		// Drain the queue: process all entries, then check for new ones (added during processing)
@@ -254,7 +268,8 @@ export async function runWorker(cwd: string, force = false): Promise<void> {
 		log.error("Worker failed: %s", (error as Error).message);
 	} finally {
 		/* v8 ignore stop */
-		await releaseLock(cwd);
+		clearInterval(refreshTimer);
+		await releaseWorkerLock(cwd);
 		log.info("=== Queue worker finished ===");
 	}
 

--- a/vscode/src/Extension.test.ts
+++ b/vscode/src/Extension.test.ts
@@ -32,21 +32,13 @@ const { isWorkerBusy } = vi.hoisted(() => ({
 	isWorkerBusy: vi.fn(),
 }));
 
-const {
-	loadConfig,
-	getGlobalConfigDir,
-	saveConfig,
-	saveConfigScoped,
-	acquireLock,
-	releaseLock,
-} = vi.hoisted(() => ({
-	loadConfig: vi.fn(),
-	getGlobalConfigDir: vi.fn(() => "/home/user/.jolli/jollimemory"),
-	saveConfig: vi.fn(),
-	saveConfigScoped: vi.fn(),
-	acquireLock: vi.fn(),
-	releaseLock: vi.fn(),
-}));
+const { loadConfig, getGlobalConfigDir, saveConfig, saveConfigScoped } =
+	vi.hoisted(() => ({
+		loadConfig: vi.fn(),
+		getGlobalConfigDir: vi.fn(() => "/home/user/.jolli/jollimemory"),
+		saveConfig: vi.fn(),
+		saveConfigScoped: vi.fn(),
+	}));
 
 const {
 	cleanupV1IfExpired,
@@ -524,8 +516,6 @@ vi.mock("../../cli/src/core/SessionTracker.js", () => ({
 	getGlobalConfigDir,
 	saveConfig,
 	saveConfigScoped,
-	acquireLock,
-	releaseLock,
 }));
 
 vi.mock("../../cli/src/core/SummaryMigration.js", () => ({
@@ -1287,7 +1277,6 @@ describe("Extension", () => {
 
 		it("runs index migration when needed", async () => {
 			indexNeedsMigration.mockResolvedValue(true);
-			acquireLock.mockResolvedValue(true);
 			migrateIndexToV3.mockResolvedValue({ migrated: 3, skipped: 0 });
 
 			const ctx = makeContext();
@@ -1297,24 +1286,10 @@ describe("Extension", () => {
 				expect(migrateIndexToV3).toHaveBeenCalledWith("/test/workspace");
 			});
 
-			expect(acquireLock).toHaveBeenCalledWith("/test/workspace");
-			expect(releaseLock).toHaveBeenCalledWith("/test/workspace");
+			// migrateIndexToV3 acquires `orphan-write.lock` internally; the
+			// extension no longer wraps the call in an outer lock acquisition.
 			expect(mockCommitsStore.setMigrating).toHaveBeenCalledWith(true);
 			expect(mockCommitsStore.setMigrating).toHaveBeenCalledWith(false);
-		});
-
-		it("defers index migration when lock cannot be acquired", async () => {
-			indexNeedsMigration.mockResolvedValue(true);
-			acquireLock.mockResolvedValue(false);
-
-			const ctx = makeContext();
-			activate(ctx);
-
-			await vi.waitFor(() => {
-				expect(acquireLock).toHaveBeenCalled();
-			});
-
-			expect(migrateIndexToV3).not.toHaveBeenCalled();
 		});
 	});
 
@@ -2746,7 +2721,6 @@ describe("Extension", () => {
 
 		it("logs error and clears migrating state when index migration throws", async () => {
 			indexNeedsMigration.mockResolvedValue(true);
-			acquireLock.mockResolvedValue(true);
 			migrateIndexToV3.mockRejectedValue(new Error("corrupt index"));
 
 			const ctx = makeContext();
@@ -2763,9 +2737,6 @@ describe("Extension", () => {
 			expect(mockStatusStore.setMigrating).toHaveBeenCalledWith(false);
 			expect(mockCommitsStore.setMigrating).toHaveBeenCalledWith(false);
 			expect(mockFilesStore.setMigrating).toHaveBeenCalledWith(false);
-
-			// Lock should be released even on error
-			expect(releaseLock).toHaveBeenCalledWith("/test/workspace");
 		});
 	});
 

--- a/vscode/src/Extension.ts
+++ b/vscode/src/Extension.ts
@@ -983,12 +983,20 @@ export function activate(context: vscode.ExtensionContext): void {
 		);
 	}
 
-	// ── Lock file watcher ────────────────────────────────────────────────
-	// When the post-commit Worker is running, it holds .jolli/jollimemory/lock.
-	// Disable Commit/Squash/Push buttons during this time to prevent race conditions
-	// (Bug 3: squash commit while previous Worker holds the lock).
+	// ── Worker lock file watcher ────────────────────────────────────────
+	// When the post-commit Worker is running, it holds
+	// `.jolli/jollimemory/worker.lock`. Disable Commit/Squash/Push buttons during
+	// this time to prevent race conditions (Bug 3: squash commit while previous
+	// Worker holds the lock).
+	//
+	// We deliberately watch only `worker.lock`, not the sibling
+	// `orphan-write.lock`. The orphan-write mutex is held for milliseconds at a
+	// time and exists to serialize concurrent orphan-branch writers; surfacing
+	// it as "worker busy" would flicker buttons every time a background scan
+	// writes a tree-hash alias. The split is the fix for the orphaned-queue-
+	// entry bug; pre-split, both roles shared a single `lock` file.
 	const lockWatcher = vscode.workspace.createFileSystemWatcher(
-		new vscode.RelativePattern(workspaceRoot, ".jolli/jollimemory/lock"),
+		new vscode.RelativePattern(workspaceRoot, ".jolli/jollimemory/worker.lock"),
 	);
 	const setWorkerBusy = (busy: boolean) => {
 		statusStore.setWorkerBusy(busy);

--- a/vscode/src/Extension.ts
+++ b/vscode/src/Extension.ts
@@ -16,10 +16,8 @@ import {
 	resolveKbParent,
 } from "../../cli/src/core/KBPathResolver.js";
 import {
-	acquireLock,
 	getGlobalConfigDir,
 	loadConfig,
-	releaseLock,
 	saveConfigScoped,
 } from "../../cli/src/core/SessionTracker.js";
 import {
@@ -2391,8 +2389,9 @@ function handleError(commandName: string): (err: unknown) => void {
  * (every tree node has its own entry with `parentCommitHash`). Runs once after the
  * v1 orphan branch migration and on subsequent activations until the index is at v3.
  *
- * Uses the shared worker lock (`acquireLock`) so it never runs concurrently with the
- * post-commit hook Worker writing to the orphan branch.
+ * `migrateIndexToV3` acquires `orphan-write.lock` internally so it never races
+ * with the post-commit hook Worker or any background scan writing to the orphan
+ * branch.
  *
  * Sets all providers to "migrating" state and refreshes them afterward.
  */
@@ -2422,25 +2421,11 @@ async function migrateIndexIfNeeded(
 	try {
 		log.info("migrate", "Index v1 detected — migrating to v3 flat format");
 
-		// Acquire the shared worker lock to prevent concurrent orphan branch writes
-		const lockAcquired = await acquireLock(cwd);
-		if (!lockAcquired) {
-			log.warn(
-				"migrate",
-				"Could not acquire worker lock for index migration — deferring",
-			);
-			return;
-		}
-
-		try {
-			const { migrated, skipped } = await migrateIndexToV3(cwd);
-			log.info(
-				"migrate",
-				`Index migration complete: ${migrated} entries migrated, ${skipped} skipped`,
-			);
-		} finally {
-			await releaseLock(cwd);
-		}
+		const { migrated, skipped } = await migrateIndexToV3(cwd);
+		log.info(
+			"migrate",
+			`Index migration complete: ${migrated} entries migrated, ${skipped} skipped`,
+		);
 	} catch (err: unknown) {
 		log.error("migrate", "Index v1 → v3 migration failed", err);
 	} finally {

--- a/vscode/src/util/LockUtils.ts
+++ b/vscode/src/util/LockUtils.ts
@@ -1,15 +1,26 @@
 /**
  * LockUtils.ts — Shared lock file utilities for the JolliMemory VSCode extension.
  *
- * The post-commit Worker holds `.jolli/jollimemory/lock` while running the
- * LLM summarization pipeline (~20-40s). These helpers let the extension and
- * command classes check the lock state to prevent race conditions.
+ * The post-commit Worker holds `.jolli/jollimemory/worker.lock` while running
+ * the LLM summarization pipeline (~20-40s). These helpers let the extension and
+ * command classes check the lock state to prevent race conditions
+ * (Commit / Squash / Push are gated on it).
+ *
+ * Notes on the lock split:
+ *   - `worker.lock` is the QueueWorker's "I'm draining the queue" marker; this
+ *     is the file we watch here.
+ *   - The sibling `orphan-write.lock` is a short-lived (millisecond-scale)
+ *     mutex around individual orphan-branch writes; it is irrelevant to the
+ *     worker-busy state and intentionally not surfaced.
+ *   - Pre-split, both roles shared a single `lock` file. Watching that path
+ *     after the split would silently always return false — which is why this
+ *     module is updated in lockstep with `Locks.ts`.
  */
 
 import { stat } from "node:fs/promises";
 import { join } from "node:path";
 
-/** Lock timeout matches SessionTracker.LOCK_TIMEOUT_MS (5 minutes). */
+/** Lock timeout matches `LOCK_TIMEOUT_MS` in cli/src/core/Locks.ts (5 minutes). */
 const LOCK_TIMEOUT_MS = 5 * 60 * 1000;
 
 /**
@@ -18,7 +29,9 @@ const LOCK_TIMEOUT_MS = 5 * 60 * 1000;
  */
 export async function isWorkerBusy(cwd: string): Promise<boolean> {
 	try {
-		const lockStat = await stat(join(cwd, ".jolli", "jollimemory", "lock"));
+		const lockStat = await stat(
+			join(cwd, ".jolli", "jollimemory", "worker.lock"),
+		);
 		const ageMs = Date.now() - lockStat.mtimeMs;
 		return ageMs < LOCK_TIMEOUT_MS;
 	} catch {


### PR DESCRIPTION
<!-- jollimemory-summary-start -->
## Commits in this PR (3)

1. Split worker and orphan-write locks to fix orphaned queue entries (`0291c58`)
2. Tighten orphan-write lock: full LMW, longer worker timeout, sync VS Code watchers (`d24f1de`)
3. Split worker and orphan-write locks into separate directories with PID-ownership checks (`fd15246`)

## Quick recap (3)

### Commit 1 of 3: Split worker and orphan-write locks to fix orphaned queue entries (`0291c58`)

A long-standing race condition in the queue processing pipeline was resolved. Previously, a single shared lock file served two unrelated purposes: signaling that a worker was actively draining the queue, and protecting brief writes to the summary branch. Whenever a background writer held that lock — even for milliseconds — the post-rewrite hook saw it as evidence of a running worker and skipped spawning a new one, leaving the queued session permanently unprocessed.

The fix introduces two separate lock files with distinct acquisition strategies matched to their actual contention patterns. The worker lock is now the sole signal that a drain is in progress, and background writers use an entirely separate lock that the hook never consults. All write operations on the summary branch now acquire the background lock around their full read-modify-write cycle, closing a secondary window where concurrent writers could overwrite each other's index updates. The old unified lock and all its associated functions were removed from the codebase entirely, eliminating the possibility of future callers accidentally reintroducing the same confusion.

### Commit 2 of 3: Tighten orphan-write lock: full LMW, longer worker timeout, sync VS Code watchers (`d24f1de`)

Four related bugs in the orphan-branch write coordination were fixed in this batch of changes. The most significant was a lost-update race: a background scan that resolves commit aliases was reading the shared index before acquiring the write lock, then writing back a stale copy that silently dropped any entries a concurrent worker had added in the meantime. The fix splits the scan into a preflight phase (expensive git lookups, no lock held) and a locked phase that re-reads the freshly persisted index before merging, preserving all concurrent writes.

The write lock timeout was also extended from 5 seconds to 30 seconds, with detailed documentation explaining the reasoning. The previous timeout was too short to survive a large-repository one-time migration running at the same moment as a commit. The failure mode on timeout — discarding the queue entry rather than retrying — was deliberately kept, because the transcript reading cursor advances before the write attempt, making a retry produce a summary over the wrong content.

Two additional gaps were closed: the one-time v1-to-v3 migration path was writing directly to the orphan branch without holding the write lock at all, and the VS Code extension was still watching the old combined lock file path after the lock was split into two separate files. The extension now correctly tracks only the worker lock for button-guard purposes, and the migration path acquires the write lock around both of its raw branch writes.

### Commit 3 of 3: Split worker and orphan-write locks into separate directories with PID-ownership checks (`fd15246`)

Three concurrency bugs in the locking system were fixed in this batch of commits. The most critical was a data-loss window in the migration path: when upgrading from an older storage format, the process previously held its write lock only during the final file-write step. A background worker landing a new summary entry during the earlier read-and-build phase would have its entry silently erased from the index — the summary file would survive on disk but become unreachable. The lock now covers the entire read-build-write cycle, so any concurrent write queues behind the migration and is applied on top of the completed result.

The second fix addressed a race where a slow process's lock could be reclaimed as stale by a second process, only for the original process's cleanup code to then delete the second process's freshly acquired lock — reopening the concurrent-write window it was meant to close. Both lock release functions and the periodic lock-refresh operation now read the stored owner identity before acting, and skip the operation entirely when the lock belongs to a different process.

The third fix corrected a structural problem: the write lock protecting the shared summary branch was stored inside each worktree's own local directory, meaning two worktrees of the same repository could each hold "their own" copy of the lock simultaneously and write to the shared branch concurrently. The lock is now stored inside the repository's shared git directory, which all worktrees resolve to the same physical path. The per-commit worker lock was intentionally left per-worktree, since each worktree processes its own independent queue and running those workers in parallel is the correct behavior.

## Topics (8)
<details>
<summary><strong>01 · [0291c58] Split worker and orphan-write locks to fix orphaned queue entries</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

A race condition caused queue entries to be permanently orphaned: when any background writer briefly held the single shared lock file, the post-rewrite hook mistakenly concluded a worker was already running and skipped spawning a new one. The queue entry was never processed.

**💡 Decisions Behind the Code**

- **Two locks instead of one**: The core insight from the pre-implementation review was that a single lock file cannot simultaneously mean "a worker is draining the queue" and "someone is writing to the orphan branch." Giving each role its own file makes `isWorkerLockHeld` unambiguous — a brief background writer can no longer produce a false positive that suppresses worker spawning. The trade-off is a slightly more complex locking surface, but the two locks are fully independent and never nest, so deadlock is not a concern.
- **Fail-fast for worker lock, poll-with-timeout for orphan-write lock**: Worker lock contention means two workers are racing — the right answer is immediate rejection, not waiting. Orphan-write lock contention is millisecond-scale (a single file write), so a short poll loop almost always succeeds within one or two intervals and avoids needless "deferred" outcomes that would leave index state inconsistent. Using different strategies for each lock matches the actual contention profile of each use case.
- **Worker path throws on orphan-write timeout; background path defers silently**: The pre-implementation review flagged that a failed write in the worker path must not silently delete the queue entry. The 5-second timeout for the worker path is long enough to outlast any realistic background writer, and throwing causes the queue entry to remain for retry. Background callers (catalog scans, alias resolution) use 1 second and log at debug level on deferral — these are opportunistic writes and a missed update is recoverable on the next run.

**✅ What Was Implemented**

- Created `cli/src/core/Locks.ts` with two independent lock primitives: `worker.lock` (fail-fast, held for the full duration of a queue drain) and `orphan-write.lock` (poll-with-timeout, held only during each read-modify-write critical section on the orphan branch). The worker lock also gains a `refreshWorkerLockMtime` function called on a 60-second interval so long-running LLM calls cannot be mistaken for a crashed worker. The root-cause fix is in `PostRewriteHook.ts`, which now calls `isWorkerLockHeld` — a function that checks only `worker.lock` and ignores `orphan-write.lock`.
- Migrated all orphan-branch write paths in `cli/src/core/SummaryStore.ts` to acquire `orphan-write.lock` around their full read-modify-write cycle: `storeSummary`, `migrateOneToOne`, `mergeManyToOne`, `removeFromIndex`, `scanTreeHashAliases`, `getCatalogWithLazyBuild`, `migrateIndexToV3`, `saveTranscriptsBatch`, `storePlans`, and `storeNotes`. A shared helper `withRequiredOrphanWriteLock` reduces boilerplate for the worker path (5 s timeout, throws on failure) while background callers use a 1 s timeout and defer gracefully.
- Removed the old `acquireLock`, `releaseLock`, `isLockHeld`, `isLockStale`, and `LOCK_FILE` exports from `cli/src/core/SessionTracker.ts` entirely. `cli/src/commands/DoctorCommand.ts` was updated to use `isWorkerLockStale` and `releaseWorkerLock` from the new module, and its UI label was changed from "Lock file" to "Worker lock".

**📋 Future Enhancements**

The `removeFromIndex` failure path still defers with a log warning rather than throwing to the caller, deviating from the original plan. This was preserved to avoid breaking an existing test that asserts defer behavior, but should be revisited if `removeFromIndex` gains a production caller that requires strict delivery guarantees.

**📁 FILES**
- `cli/src/core/Locks.ts`
- `cli/src/core/SummaryStore.ts`
- `cli/src/hooks/PostRewriteHook.ts`
- `cli/src/commands/DoctorCommand.ts`
- `cli/src/core/SessionTracker.ts`

</blockquote>
</details>
<details>
<summary><strong>02 · [d24f1de] Fix lost-update race in tree-hash alias scanning</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

A background scan that matches commit aliases could overwrite entries that a concurrent worker had just written, permanently losing those summaries. The scan read the index before acquiring the write lock, then wrote back a stale copy that didn't include the worker's new data.

**💡 Decisions Behind the Code**

- **Keep expensive git calls outside the lock**: Tree-hash lookups are O(n) git operations and can take hundreds of milliseconds on large repositories. Running them inside the lock would block every concurrent orphan-branch writer for that entire duration. The preflight result is treated as tentative and re-validated inside the lock at negligible cost, giving safety without the throughput penalty.
- **Merge only the alias field, not the full index**: Writing back the preflight index object (even with updated aliases) would silently drop any entries the worker added after the preflight read. Merging only the alias delta into the freshly loaded index preserves all concurrent writes and keeps the fix minimal in scope.

**✅ What Was Implemented**

- Refactored `scanTreeHashAliases` in `cli/src/core/SummaryStore.ts` into two phases: a preflight phase (outside the lock) that performs the expensive tree-hash lookups, and a critical section (inside the lock) that re-reads the freshly persisted index before merging. The write now uses the fresh index as its base, so any entries the worker added between preflight and lock-acquire are preserved. Candidates that a concurrent writer already resolved are silently dropped.
- Added three regression tests in `cli/src/core/SummaryStore.test.ts` covering the lost-update scenario (worker entry survives scan's write), the already-aliased candidate drop, and the already-promoted-to-entry candidate drop. Existing tree-hash tests were updated to supply two mock reads (preflight + inside-lock re-read) instead of one.

**📁 FILES**
- `cli/src/core/SummaryStore.ts`

</blockquote>
</details>
<details>
<summary><strong>03 · [d24f1de] Extend orphan-write lock timeout to 30 seconds with documented rationale</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The previous 5-second timeout on the write lock was too short: a large-repository one-time migration running concurrently with a commit could hold the lock for several seconds, causing the worker to time out and permanently lose a summary entry.

**💡 Decisions Behind the Code**

- **30 seconds, not 5 minutes**: The user initially questioned whether 5 minutes had any meaning. Analysis showed that the real worst-case contention is a one-time migration taking a few seconds, not a stale-lock scenario. A 5-minute timeout would cause workers to block for 5 minutes on a stale lock before the stale-reclaim mechanism fires, degrading UX far more than the rare data loss it would prevent. 30 seconds covers the legitimate worst case with ~10× headroom and keeps blocking time acceptable.
- **Delete the queue entry on timeout, not preserve it**: Preserving the entry for retry sounds safer but is actually worse: the transcript cursor advances before the write attempt, so a retried run reads only the subsequent transcript window and generates a summary for the wrong content. Corrupt output is a worse outcome than a missing summary, so the existing delete-on-failure behavior is kept unchanged.

**✅ What Was Implemented**

Changed `ORPHAN_WRITE_REQUIRED_TIMEOUT_MS` in `cli/src/core/SummaryStore.ts` from 5 000 ms to 30 000 ms. Added an extensive inline comment explaining the sizing rationale, why "lose this entry" is the correct failure mode on timeout (cursor has already advanced past the relevant transcript window, making retry produce a corrupt summary), and why this matches the system-wide no-retry philosophy.

**📁 FILES**
- `cli/src/core/SummaryStore.ts`

</blockquote>
</details>
<details>
<summary><strong>04 · [d24f1de] Lock orphan-branch writes in the one-time migration path</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The v1-to-v3 migration wrote directly to the orphan branch using raw git operations, bypassing the write lock entirely. A concurrent post-commit worker writing a summary at the same moment could corrupt the branch.

**💡 Decisions Behind the Code**

Adding the lock directly at the call sites rather than refactoring the migration to go through the shared storage abstraction kept the change minimal. The migration is a one-time activation path; pulling it into the abstraction layer would expand scope significantly for negligible long-term benefit.

**✅ What Was Implemented**

Added `withMigrationOrphanWriteLock` helper in `cli/src/core/SummaryMigration.ts` that acquires the orphan-write lock with a 30-second timeout and releases it on exit. Wrapped both raw-write call sites — the bulk summary migration and the migration-metadata write — with this helper. Added a module-level comment explaining why the lock lives here rather than in a shared abstraction (the migration bypasses the storage provider layer by design, as a one-time path not worth refactoring).

**📁 FILES**
- `cli/src/core/SummaryMigration.ts`

</blockquote>
</details>
<details>
<summary><strong>05 · [d24f1de] Sync VS Code worker-busy indicators to the correct lock file</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

After the lock was split into a worker lock and a short-lived write lock, the VS Code extension was still watching the old combined lock file path. This meant the "worker busy" button state and the post-worker UI refresh never fired, silently breaking the Commit, Squash, and Push button guards.

**💡 Decisions Behind the Code**

Only the worker lock is surfaced to the UI, not the short-lived write lock. The write lock is held for milliseconds at a time by background scans; exposing it as "worker busy" would cause the Commit/Squash/Push buttons to flicker constantly during normal use. The worker lock, by contrast, is held for the full duration of the LLM summarization pipeline (tens of seconds), which is exactly the window where blocking user actions is correct.

**✅ What Was Implemented**

- Updated `vscode/src/util/LockUtils.ts` to stat `worker.lock` instead of the old `lock` path. Expanded the module comment to explain the two-lock split and why only the worker lock is relevant to busy state.
- Updated `vscode/src/Extension.ts` to watch `worker.lock` via `createFileSystemWatcher`. Added an inline comment explaining why the short-lived orphan-write lock is intentionally not surfaced (watching it would cause button flicker on every background alias scan).

**📁 FILES**
- `vscode/src/util/LockUtils.ts`
- `vscode/src/Extension.ts`

</blockquote>
</details>
<details>
<summary><strong>06 · [fd15246] Migration lock now covers full read-build-write cycle to prevent index corruption</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

A code review found that the migration process only held its write lock during the final file-write step, leaving a window where a background worker could write a new summary entry that the migration would then silently erase from the index.

**💡 Decisions Behind the Code**

Holding the lock for the entire read-build-write cycle means any concurrent worker write will queue behind the migration and layer its entry on top of the completed migration index, rather than being silently dropped. The trade-off is that a very large migration could exhaust a worker's 30-second write timeout, losing one summary entry — but that entry will be recovered on the next commit, and index consistency is more important than avoiding that rare single-entry delay.

**✅ What Was Implemented**

- `SummaryMigration.ts`: refactored `migrateV1toV3` to acquire the orphan-write lock before reading the v1 branch, building the file list, and reconstructing the index — not just around the final write call. The body was extracted into a private `migrateV1toV3Locked` helper so the public function's early-exit guard remains outside the lock.

**📁 FILES**
- `cli/src/core/SummaryMigration.ts`

</blockquote>
</details>
<details>
<summary><strong>07 · [fd15246] Lock release now verifies ownership before removing to prevent stale-reclaim race</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

A review identified that when a slow process's lock was reclaimed as stale by a second process, the original process's cleanup code would still delete the lock — now owned by the second process — reopening a concurrent-write window.

**💡 Decisions Behind the Code**

- **PID over UUID token**: A simple process ID written into the lock file was chosen over a random UUID token. PID reuse within the lifetime of a single lock is theoretically possible but practically negligible for short-lived hook processes, and the simpler approach avoids adding a token-generation and token-passing mechanism across the call stack. A warning log on the skip path makes the race visible in diagnostics without adding complexity.
- **Shared helper for both locks**: Both release functions and the mtime refresh were unified through a single `releaseIfOwned` helper rather than duplicating the ownership check. This keeps the guard logic in one place and ensures future lock types automatically inherit the same protection.

**✅ What Was Implemented**

- `Locks.ts`: added `readLockOwnerPid` and `releaseIfOwned` helpers. Both `releaseWorkerLock` and `releaseOrphanWriteLock` now read the process ID stored in the lock file and skip the delete when it belongs to a different process, logging a warning instead.
- `Locks.ts`: `refreshWorkerLockMtime` gained the same ownership check — it skips the timestamp bump when the lock file records a foreign process ID, preventing the original holder from inadvertently extending a lock it no longer owns.
- `Locks.test.ts`: new PID-ownership tests cover the skip-on-foreign-PID path for both locks and for the mtime refresh, plus the happy-path remove-on-matching-PID case.

**📁 FILES**
- `cli/src/core/Locks.ts`

</blockquote>
</details>
<details>
<summary><strong>08 · [fd15246] Orphan-write lock moved to shared git directory so all worktrees use the same file</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The orphan summary branch is a single shared resource across all git worktrees of a repository, but the write lock was stored inside each worktree's own local directory — meaning two worktrees could each hold "their" lock simultaneously and write to the branch concurrently.

**💡 Decisions Behind the Code**

- **`.git/jollimemory/` over a worktree-adjacent `.jolli/` path**: Placing the shared lock inside the git directory (rather than alongside the main worktree's local state folder) was chosen after evaluating three options. The git directory is guaranteed to exist as long as any worktree is alive, avoids a linked worktree writing into the main worktree's directory, and is invisible to users browsing the working tree. A path adjacent to the main worktree's local folder would require the main worktree's root to exist and would cross a conceptual ownership boundary — a linked worktree writing files into a sibling worktree's directory.
- **Worker lock stays per-worktree**: The worker lock was deliberately left in the per-worktree directory. Each worktree has its own independent commit queue, and two worktrees running their own workers in parallel is correct and desirable — serializing them through a shared worker lock would cause one worktree's queue to stall for the entire duration of the other's language-model call, with no mechanism to restart the stalled worker afterward.
- **Lazy subprocess invocation for caching**: The git subprocess call is wrapped lazily rather than at module load time so that test code replacing the underlying function after import actually intercepts the call. The resolved path is then cached per working directory so repeated lock poll iterations pay the subprocess cost only once.

**✅ What Was Implemented**

- `Locks.ts`: added `resolveSharedLockDir`, which runs `git rev-parse --git-common-dir` to locate the repository's shared git directory and places the orphan-write lock under a `jollimemory/` subdirectory there. Results are cached per working directory to avoid spawning a subprocess on every poll iteration. Falls back to the per-worktree path when git is unavailable or the directory is not a git repository.
- `Locks.ts`: `acquireOrphanWriteLock` and `releaseOrphanWriteLock` now route through `resolveSharedLockDir`; the worker lock continues to use the per-worktree path unchanged, since each worktree's queue is independent and parallel worker execution across worktrees is correct behavior.
- `Locks.test.ts`: restructured to `git init` once per file (rather than per test) to avoid memory pressure from spawning ~30 subprocesses; added tests for the git-common-dir path, the fallback path, and the cache-hit behavior.

**📁 FILES**
- `cli/src/core/Locks.ts`

</blockquote>
</details>

---

*Generated by Jolli Memory · May 9, 2026 at 7:44 PM*
<!-- jollimemory-summary-end -->