### PR TITLE
Refactor PR ops to branch-only scope

### DIFF
--- a/vscode/src/services/PrCommentService.test.ts
+++ b/vscode/src/services/PrCommentService.test.ts
@@ -383,7 +383,6 @@ describe("PrCommentService", () => {
 				command: "prStatus",
 				status: "noPr",
 				branch: "feature/my-branch",
-				crossBranch: false,
 			});
 		});
 
@@ -422,7 +421,6 @@ describe("PrCommentService", () => {
 				command: "prStatus",
 				status: "noPr",
 				branch: "feature/br",
-				crossBranch: false,
 			});
 		});
 
@@ -488,35 +486,6 @@ describe("PrCommentService", () => {
 			});
 		});
 
-		it("falls back to current branch when cross-branch detection yields no summary branch", async () => {
-			// Covers handleCheckPrStatus `summaryBranch ?? currentBranch` right branch:
-			// summaryCommitHash is set, merge-base --is-ancestor fails (cross-branch=true),
-			// but summaryBranch is undefined → fall back to currentBranch.
-			setupExecFile((cmd, args) => {
-				if (cmd === "git" && args[0] === "rev-list") return { stdout: "1\n" };
-				if (cmd === "git" && args[0] === "rev-parse")
-					return { stdout: "fallback-branch\n" };
-				// merge-base --is-ancestor fails → isCrossBranch=true
-				if (cmd === "git" && args[0] === "merge-base") {
-					throw new Error("not an ancestor");
-				}
-				if (cmd === "gh" && args[0] === "--version") return { stdout: "gh\n" };
-				if (cmd === "gh" && args[0] === "auth") return { stdout: "ok\n" };
-				if (cmd === "gh" && args[0] === "pr") throw new Error("no pr");
-				return { stdout: "" };
-			});
-
-			// summaryBranch=undefined, summaryCommitHash="deadbeef"
-			await handleCheckPrStatus(CWD, postMessage, undefined, "deadbeef");
-
-			expect(postMessage).toHaveBeenCalledWith({
-				command: "prStatus",
-				status: "noPr",
-				branch: "fallback-branch",
-				crossBranch: true,
-			});
-		});
-
 		it("posts unavailable when gh --version fails with a transient error twice", async () => {
 			setupExecFile((cmd, args) => {
 				if (cmd === "git" && args[0] === "rev-list") {
@@ -571,7 +540,6 @@ describe("PrCommentService", () => {
 				command: "prStatus",
 				status: "noPr",
 				branch: "feature/my-branch",
-				crossBranch: false,
 			});
 		});
 
@@ -642,7 +610,6 @@ describe("PrCommentService", () => {
 				command: "prStatus",
 				status: "noPr",
 				branch: "feature/branch",
-				crossBranch: false,
 			});
 		});
 
@@ -676,7 +643,6 @@ describe("PrCommentService", () => {
 				command: "prStatus",
 				status: "noPr",
 				branch: "feature/branch",
-				crossBranch: false,
 			});
 		});
 
@@ -752,137 +718,6 @@ describe("PrCommentService", () => {
 		});
 
 		// ── branch parameter tests ────────────────────────────────────────────
-
-		it("skips commit count check when commit is not reachable from HEAD (cross-branch)", async () => {
-			const prData = {
-				number: 10,
-				url: "https://pr/10",
-				title: "Old PR",
-				body: "",
-			};
-			setupExecFile((cmd, args) => {
-				if (cmd === "git" && args[0] === "rev-list") {
-					return { stdout: "5\n" }; // 5 commits on current branch
-				}
-				if (
-					cmd === "git" &&
-					args[0] === "merge-base" &&
-					args[1] === "--is-ancestor"
-				) {
-					// Non-ancestor: exit 1 → throw
-					throw new Error("not ancestor");
-				}
-				if (cmd === "gh" && args[0] === "--version") {
-					return { stdout: "ok\n" };
-				}
-				if (cmd === "gh" && args[0] === "auth") {
-					return { stdout: "ok\n" };
-				}
-				if (cmd === "gh" && args[0] === "pr") {
-					return { stdout: JSON.stringify(prData) };
-				}
-				return { stdout: "" };
-			});
-
-			// Commit not reachable from HEAD → cross-branch → skip multipleCommits
-			await handleCheckPrStatus(
-				CWD,
-				postMessage,
-				"feature/old-branch",
-				"abc123",
-			);
-
-			expect(postMessage).toHaveBeenCalledWith({
-				command: "prStatus",
-				status: "ready",
-				pr: { number: 10, url: "https://pr/10", title: "Old PR" },
-			});
-			expect(postMessage).not.toHaveBeenCalledWith(
-				expect.objectContaining({ status: "multipleCommits" }),
-			);
-		});
-
-		it("uses provided branch in noPr status message with crossBranch flag", async () => {
-			setupExecFile((cmd, args) => {
-				if (
-					cmd === "git" &&
-					args[0] === "merge-base" &&
-					args[1] === "--is-ancestor"
-				) {
-					// Non-ancestor → cross-branch
-					throw new Error("not ancestor");
-				}
-				if (cmd === "gh" && args[0] === "--version") {
-					return { stdout: "ok\n" };
-				}
-				if (cmd === "gh" && args[0] === "auth") {
-					return { stdout: "ok\n" };
-				}
-				if (cmd === "gh" && args[0] === "pr") {
-					throw new Error("no PR");
-				}
-				return { stdout: "" };
-			});
-
-			await handleCheckPrStatus(
-				CWD,
-				postMessage,
-				"feature/old-branch",
-				"abc123",
-			);
-
-			expect(postMessage).toHaveBeenCalledWith({
-				command: "prStatus",
-				status: "noPr",
-				branch: "feature/old-branch",
-				crossBranch: true,
-			});
-		});
-
-		it("uses current branch for PR lookup when commit is reachable (e.g. after rename)", async () => {
-			// Regression: after `git branch -m`, summary.branch holds the old name
-			// but the commit is still in the current branch's history. The PR
-			// lookup must target the CURRENT branch (not the summary's stale name)
-			// so a PR created after the rename is actually found.
-			setupExecFile((cmd, args) => {
-				if (
-					cmd === "git" &&
-					args[0] === "merge-base" &&
-					args[1] === "--is-ancestor"
-				) {
-					return { stdout: "" };
-				}
-				if (
-					cmd === "git" &&
-					args[0] === "rev-parse" &&
-					args[1] === "--abbrev-ref"
-				) {
-					return { stdout: "feature/new-name\n" };
-				}
-				if (cmd === "git" && args[0] === "rev-list") {
-					return { stdout: "1\n" };
-				}
-				if (cmd === "gh" && args[0] === "--version") {
-					return { stdout: "ok\n" };
-				}
-				if (cmd === "gh" && args[0] === "auth") {
-					return { stdout: "ok\n" };
-				}
-				if (cmd === "gh" && args[0] === "pr") {
-					throw new Error("no PR");
-				}
-				return { stdout: "" };
-			});
-
-			await handleCheckPrStatus(CWD, postMessage, "feature/old-name", "abc123");
-
-			expect(postMessage).toHaveBeenCalledWith({
-				command: "prStatus",
-				status: "noPr",
-				branch: "feature/new-name",
-				crossBranch: false,
-			});
-		});
 
 		// ── debug.log observability (non-goal: UI folding stays the same) ─────
 
@@ -1022,30 +857,44 @@ describe("PrCommentService", () => {
 	// ─── handleCreatePr ─────────────────────────────────────────────────────
 
 	describe("handleCreatePr", () => {
-		it("blocks creation when memory's commit is not reachable from current HEAD", async () => {
-			setupExecFile((cmd, args) => {
-				if (
-					cmd === "git" &&
-					args[0] === "merge-base" &&
-					args[1] === "--is-ancestor"
-				) {
-					throw new Error("not ancestor");
-				}
-				return { stdout: "" };
-			});
-
-			await handleCreatePr(
-				"Title",
-				"Body",
-				CWD,
-				postMessage,
-				"feature/other",
-				"abc123",
+		it("creates the PR even when the summary's commit is no longer reachable (rebase-just-happened regression)", async () => {
+			// Regression: pre-refactor, a non-reachable summary commit would block
+			// PR creation. Branch-first model: ignore commit reachability — push
+			// + create PR using the CURRENT branch.
+			const prUrl = "https://github.com/org/repo/pull/77";
+			setupExecFile(
+				buildRouter({
+					// Whatever ancestor probe might still happen elsewhere — irrelevant
+					// to handleCreatePr now; left as a non-ancestor to prove we don't
+					// gate on it.
+					"git:merge-base": () => {
+						throw new Error("not ancestor");
+					},
+					"git:push": () => ({ stdout: "" }),
+					"gh:pr:create": () => ({ stdout: `${prUrl}\n` }),
+					"git:rev-list": () => ({ stdout: "1\n" }),
+					"git:rev-parse": () => ({ stdout: "feature/branch\n" }),
+					"gh:--version": () => ({ stdout: "gh 2.40.0\n" }),
+					"gh:auth": () => ({ stdout: "ok\n" }),
+					"gh:pr:view": () => ({
+						stdout: JSON.stringify({
+							number: 77,
+							url: prUrl,
+							title: "Rebased PR",
+							body: "",
+						}),
+					}),
+				}),
 			);
+			showInformationMessage.mockResolvedValue(undefined);
+
+			await handleCreatePr("Rebased PR", "PR body", CWD, postMessage);
 
 			expect(postMessage).toHaveBeenCalledWith({ command: "prCreating" });
-			expect(postMessage).toHaveBeenCalledWith({ command: "prCreateFailed" });
-			expect(showWarningMessage).toHaveBeenCalledWith(
+			expect(postMessage).not.toHaveBeenCalledWith({
+				command: "prCreateFailed",
+			});
+			expect(showWarningMessage).not.toHaveBeenCalledWith(
 				expect.stringContaining("Cannot create a PR"),
 			);
 		});
@@ -1168,12 +1017,9 @@ describe("PrCommentService", () => {
 	// ─── handlePrepareUpdatePr ──────────────────────────────────────────────
 
 	describe("handlePrepareUpdatePr", () => {
-		// New signature: caller pre-builds the markdown and passes the branch +
-		// commit hash separately. The function is now PR-lookup + marker-merge
-		// only — single-summary vs aggregated rendering happens upstream in
-		// SummaryWebviewPanel before the call.
-		const SUMMARY_BRANCH = "feature/test-branch";
-		const SUMMARY_HASH = "deadbeef";
+		// Caller pre-builds the markdown. The function is purely PR-lookup +
+		// marker-merge — single-summary vs aggregated rendering happens upstream
+		// in SummaryWebviewPanel before the call.
 		const MARKDOWN = "## Summary\nFixed a bug";
 
 		it("posts prShowUpdateForm with merged body when PR exists", async () => {
@@ -1195,88 +1041,13 @@ describe("PrCommentService", () => {
 				return { stdout: "" };
 			});
 
-			await handlePrepareUpdatePr(
-				SUMMARY_BRANCH,
-				SUMMARY_HASH,
-				MARKDOWN,
-				CWD,
-				postMessage,
-			);
+			await handlePrepareUpdatePr(MARKDOWN, CWD, postMessage);
 
 			expect(postMessage).toHaveBeenCalledWith({
 				command: "prShowUpdateForm",
 				title: "PR Title",
 				body: `Old description\n\n${MARKER_START}\n## Summary\nFixed a bug\n${MARKER_END}`,
 			});
-		});
-
-		it("falls back to current branch when summaryBranch is undefined under cross-branch", async () => {
-			// Covers `summaryBranch ?? currentBranch` fallback. With a commit hash
-			// that fails merge-base --is-ancestor → isCrossBranch=true; with no
-			// summaryBranch passed, target falls through to currentBranch.
-			setupExecFile((cmd, args) => {
-				if (cmd === "git" && args[0] === "merge-base") {
-					throw new Error("not an ancestor");
-				}
-				if (cmd === "git" && args[0] === "rev-parse") {
-					return { stdout: "fallback-branch\n" };
-				}
-				if (cmd === "gh" && args[0] === "pr" && args[1] === "view") {
-					return {
-						stdout: JSON.stringify({
-							number: 1,
-							url: "u",
-							title: "t",
-							body: "",
-						}),
-					};
-				}
-				return { stdout: "" };
-			});
-
-			await handlePrepareUpdatePr(
-				undefined,
-				SUMMARY_HASH,
-				MARKDOWN,
-				CWD,
-				postMessage,
-			);
-
-			expect(postMessage).toHaveBeenCalledWith(
-				expect.objectContaining({ command: "prShowUpdateForm" }),
-			);
-		});
-
-		it("treats undefined commitHash as not cross-branch (uses current branch)", async () => {
-			// When summaryCommitHash is undefined the cross-branch probe is skipped.
-			setupExecFile((cmd, args) => {
-				if (cmd === "git" && args[0] === "rev-parse") {
-					return { stdout: "feature/test-branch\n" };
-				}
-				if (cmd === "gh" && args[0] === "pr" && args[1] === "view") {
-					return {
-						stdout: JSON.stringify({
-							number: 5,
-							url: "u",
-							title: "t",
-							body: "",
-						}),
-					};
-				}
-				return { stdout: "" };
-			});
-
-			await handlePrepareUpdatePr(
-				SUMMARY_BRANCH,
-				undefined,
-				MARKDOWN,
-				CWD,
-				postMessage,
-			);
-
-			expect(postMessage).toHaveBeenCalledWith(
-				expect.objectContaining({ command: "prShowUpdateForm" }),
-			);
 		});
 
 		it("replaces existing markers in PR body", async () => {
@@ -1298,13 +1069,7 @@ describe("PrCommentService", () => {
 				return { stdout: "" };
 			});
 
-			await handlePrepareUpdatePr(
-				SUMMARY_BRANCH,
-				SUMMARY_HASH,
-				MARKDOWN,
-				CWD,
-				postMessage,
-			);
+			await handlePrepareUpdatePr(MARKDOWN, CWD, postMessage);
 
 			const call = postMessage.mock.calls[0][0];
 			expect(call.body).toContain("Before\n");
@@ -1322,13 +1087,7 @@ describe("PrCommentService", () => {
 				throw new Error("no PR");
 			});
 
-			await handlePrepareUpdatePr(
-				SUMMARY_BRANCH,
-				SUMMARY_HASH,
-				MARKDOWN,
-				CWD,
-				postMessage,
-			);
+			await handlePrepareUpdatePr(MARKDOWN, CWD, postMessage);
 
 			expect(showWarningMessage).toHaveBeenCalledWith(
 				"No pull request found for branch feature/test-branch.",
@@ -1344,13 +1103,7 @@ describe("PrCommentService", () => {
 				return { stdout: "" };
 			});
 
-			await handlePrepareUpdatePr(
-				SUMMARY_BRANCH,
-				SUMMARY_HASH,
-				MARKDOWN,
-				CWD,
-				postMessage,
-			);
+			await handlePrepareUpdatePr(MARKDOWN, CWD, postMessage);
 
 			expect(showErrorMessage).toHaveBeenCalledWith(
 				expect.stringContaining("git rev-parse exploded"),
@@ -1366,13 +1119,7 @@ describe("PrCommentService", () => {
 				return { stdout: "" };
 			});
 
-			await handlePrepareUpdatePr(
-				SUMMARY_BRANCH,
-				SUMMARY_HASH,
-				MARKDOWN,
-				CWD,
-				postMessage,
-			);
+			await handlePrepareUpdatePr(MARKDOWN, CWD, postMessage);
 
 			expect(showErrorMessage).toHaveBeenCalledWith(
 				expect.stringContaining("plain string error"),
@@ -1398,13 +1145,7 @@ describe("PrCommentService", () => {
 				return { stdout: "" };
 			});
 
-			await handlePrepareUpdatePr(
-				SUMMARY_BRANCH,
-				SUMMARY_HASH,
-				MARKDOWN,
-				CWD,
-				postMessage,
-			);
+			await handlePrepareUpdatePr(MARKDOWN, CWD, postMessage);
 
 			const call = postMessage.mock.calls[0][0];
 			expect(call.body).toBe(
@@ -1614,83 +1355,6 @@ describe("PrCommentService", () => {
 				"Updated PR #7",
 				"Open PR",
 			);
-		});
-
-		it("resolves target branch via summary branch when summaryCommitHash is unreachable", async () => {
-			// Covers handleUpdatePr's `summaryCommitHash ? ... : false` truthy branch,
-			// the `isCrossBranch ? ... : currentBranch` truthy branch, and the
-			// `summaryBranch ?? currentBranch` left branch (summaryBranch given).
-			const pr = { number: 9, url: "u", title: "Same", body: "" };
-			setupExecFile((cmd, args) => {
-				if (cmd === "git" && args[0] === "merge-base") {
-					throw new Error("not an ancestor");
-				}
-				if (cmd === "git" && args[0] === "rev-parse") {
-					return { stdout: "current-branch\n" };
-				}
-				if (cmd === "git" && args[0] === "rev-list") return { stdout: "1\n" };
-				if (cmd === "gh" && args[0] === "--version") return { stdout: "ok\n" };
-				if (cmd === "gh" && args[0] === "auth") return { stdout: "ok\n" };
-				if (cmd === "gh" && args[0] === "pr" && args[1] === "view") {
-					return { stdout: JSON.stringify(pr) };
-				}
-				if (cmd === "gh" && args[0] === "pr" && args[1] === "edit") {
-					return { stdout: "" };
-				}
-				return { stdout: "" };
-			});
-			showInformationMessage.mockResolvedValue(undefined);
-
-			await handleUpdatePr(
-				"Same",
-				"new body",
-				CWD,
-				postMessage,
-				"summary-branch",
-				"deadbeef",
-			);
-
-			expect(postMessage).toHaveBeenCalledWith({ command: "prUpdating" });
-			// Verify the PR lookup used the summary branch (passed via the 2nd rev-parse)
-			const viewCall = mockExecFileAsync.mock.calls.find(
-				(c) => c[0] === "gh" && c[1][0] === "pr" && c[1][1] === "view",
-			);
-			expect(viewCall?.[1]).toContain("summary-branch");
-		});
-
-		it("falls back to current branch when summaryCommitHash is unreachable but summaryBranch is undefined", async () => {
-			// Covers the `summaryBranch ?? currentBranch` right branch in handleUpdatePr.
-			const pr = { number: 9, url: "u", title: "Same", body: "" };
-			setupExecFile((cmd, args) => {
-				if (cmd === "git" && args[0] === "merge-base") {
-					throw new Error("not an ancestor");
-				}
-				if (cmd === "git" && args[0] === "rev-parse") {
-					return { stdout: "current-branch\n" };
-				}
-				if (cmd === "git" && args[0] === "rev-list") return { stdout: "1\n" };
-				if (cmd === "gh" && args[0] === "--version") return { stdout: "ok\n" };
-				if (cmd === "gh" && args[0] === "auth") return { stdout: "ok\n" };
-				if (cmd === "gh" && args[0] === "pr" && args[1] === "view") {
-					return { stdout: JSON.stringify(pr) };
-				}
-				if (cmd === "gh" && args[0] === "pr" && args[1] === "edit") {
-					return { stdout: "" };
-				}
-				return { stdout: "" };
-			});
-			showInformationMessage.mockResolvedValue(undefined);
-
-			await handleUpdatePr(
-				"Same",
-				"new body",
-				CWD,
-				postMessage,
-				undefined,
-				"deadbeef",
-			);
-
-			expect(postMessage).toHaveBeenCalledWith({ command: "prUpdating" });
 		});
 
 		it("opens external URL when user clicks 'Open PR' after update", async () => {

--- a/vscode/src/services/PrCommentService.test.ts
+++ b/vscode/src/services/PrCommentService.test.ts
@@ -232,6 +232,19 @@ describe("PrCommentService", () => {
 			expect(js).toContain("msg.command === 'prUpdating'");
 			expect(js).toContain("msg.command === 'prUpdateFailed'");
 		});
+
+		it("handles prCreateBlockedCrossBranch by resetting the Create PR / Submit button state", () => {
+			// Pins the cross-branch-guard reset branch into the rendered JS.
+			// Without this, a Biome auto-fix or dead-code sweep could silently
+			// drop the handler, and the user's clicked "Loading..." button
+			// would stay stuck forever when the panel-side guard fires.
+			const js = buildPrMessageScript();
+			expect(js).toContain("msg.command === 'prCreateBlockedCrossBranch'");
+			// The reset clears both the section-level Create PR button and the
+			// form-level Submit button so retry works after `checkout`.
+			expect(js).toContain("createPrBtn");
+			expect(js).toContain("prFormSubmit");
+		});
 	});
 
 	// ─── handleCheckPrStatus ────────────────────────────────────────────────
@@ -646,7 +659,12 @@ describe("PrCommentService", () => {
 			});
 		});
 
-		it("posts unavailable when gh available but getCurrentBranch throws", async () => {
+		it("posts unavailable with the real reason when gh is available but getCurrentBranch throws", async () => {
+			// Regression: the outer catch sits above both gh probes and the
+			// `getCurrentBranch` (git) call. Previously the UI always said
+			// "Could not reach GitHub CLI (gh)" — misleading when the failure
+			// was on the git side. The `reason` field lets the webview show
+			// the true error message.
 			setupExecFile((cmd, args) => {
 				if (cmd === "git" && args[0] === "rev-list") {
 					return { stdout: "1\n" };
@@ -657,7 +675,6 @@ describe("PrCommentService", () => {
 				if (cmd === "gh" && args[0] === "auth") {
 					return { stdout: "ok\n" };
 				}
-				// getCurrentBranch (git rev-parse) throws — triggers outer catch
 				if (cmd === "git" && args[0] === "rev-parse") {
 					throw new Error("git exploded");
 				}
@@ -669,6 +686,7 @@ describe("PrCommentService", () => {
 			expect(postMessage).toHaveBeenCalledWith({
 				command: "prStatus",
 				status: "unavailable",
+				reason: "git exploded",
 			});
 			expect(logError).toHaveBeenCalled();
 		});
@@ -696,6 +714,7 @@ describe("PrCommentService", () => {
 			expect(postMessage).toHaveBeenCalledWith({
 				command: "prStatus",
 				status: "unavailable",
+				reason: "string error from git",
 			});
 			expect(logError).toHaveBeenCalledWith(
 				expect.any(String),
@@ -703,17 +722,21 @@ describe("PrCommentService", () => {
 			);
 		});
 
-		it("posts unavailable when all commands fail (gh not found path)", async () => {
+		it("posts unavailable with the underlying error reason when all commands fail", async () => {
 			setupExecFile(() => {
 				throw new Error("command not found");
 			});
 
 			await handleCheckPrStatus(CWD, postMessage);
 
-			// getCommitCount catches → returns 0, isGhAvailable catches → returns false
+			// `getCurrentBranch` is the first call in the handler — it throws
+			// "command not found" and the outer catch surfaces that as the
+			// reason, instead of the previous hard-coded "could not reach gh"
+			// text (which misled users when git was the broken side).
 			expect(postMessage).toHaveBeenCalledWith({
 				command: "prStatus",
 				status: "unavailable",
+				reason: "command not found",
 			});
 		});
 
@@ -888,6 +911,49 @@ describe("PrCommentService", () => {
 				expect.objectContaining({
 					status: "noPr",
 					branch: "feature/summary-branch",
+				}),
+			);
+		});
+
+		it("strict branch routing: summaryBranch wins over currentBranch even when stale (post-rename)", async () => {
+			// Contract: after `git branch -m feature/old feature/new`, the
+			// summary still points at `feature/old`. We MUST query
+			// `feature/old` and report `noPr` for it — NOT silently retarget
+			// to `feature/new` or to currentBranch. Auto-recovery from
+			// renames is a separate spike (see plan doc "Out of scope").
+			let prViewBranchArg: string | undefined;
+			setupExecFile((cmd, args) => {
+				if (cmd === "git" && args[0] === "rev-parse") {
+					// User has already renamed → currentBranch is the new name.
+					return { stdout: "feature/new\n" };
+				}
+				if (cmd === "gh" && args[0] === "--version") {
+					return { stdout: "gh 2.40.0\n" };
+				}
+				if (cmd === "gh" && args[0] === "auth") {
+					return { stdout: "ok\n" };
+				}
+				if (cmd === "gh" && args[0] === "pr" && args[1] === "view") {
+					const sepIdx = args.indexOf("--");
+					if (sepIdx >= 0) {
+						prViewBranchArg = args[sepIdx + 1];
+					}
+					// gh returns "no PR" for the stale name.
+					return { stdout: "" };
+				}
+				return { stdout: "" };
+			});
+
+			await handleCheckPrStatus(CWD, postMessage, "feature/old");
+
+			// The lookup must hit the stale summaryBranch, not currentBranch.
+			expect(prViewBranchArg).toBe("feature/old");
+			// And the user-facing message must name the stale branch — that's
+			// how they realize the rename caused the mismatch.
+			expect(postMessage).toHaveBeenCalledWith(
+				expect.objectContaining({
+					status: "noPr",
+					branch: "feature/old",
 				}),
 			);
 		});
@@ -1225,12 +1291,29 @@ describe("PrCommentService", () => {
 			expect(call.body).not.toContain("old content");
 		});
 
-		it("shows warning when no PR is found", async () => {
+		it("shows warning AND re-runs status flow when no PR is found (un-sticks the Edit PR button)", async () => {
+			// Regression: the webview's Edit PR button sets itself to
+			// "Loading..." + disabled on click. If `handlePrepareUpdatePr`
+			// returns silently on the no-PR path, the button stays stuck
+			// forever. After this fix, the no-PR path re-runs
+			// `handleCheckPrStatus` so the section is repainted and the
+			// button is rebuilt fresh.
 			setupExecFile((cmd, args) => {
 				if (cmd === "git" && args[0] === "rev-parse") {
 					return { stdout: "feature/test-branch\n" };
 				}
-				throw new Error("no PR");
+				if (cmd === "gh" && args[0] === "--version") {
+					return { stdout: "gh 2.40.0\n" };
+				}
+				if (cmd === "gh" && args[0] === "auth") {
+					return { stdout: "ok\n" };
+				}
+				if (cmd === "gh" && args[0] === "pr" && args[1] === "view") {
+					// Mimic gh's "no pull requests found" stderr branch by
+					// throwing — findPrForBranch sees result.ok=false.
+					throw new Error("no pull requests found");
+				}
+				return { stdout: "" };
 			});
 
 			await handlePrepareUpdatePr(MARKDOWN, CWD, postMessage);
@@ -1238,7 +1321,15 @@ describe("PrCommentService", () => {
 			expect(showWarningMessage).toHaveBeenCalledWith(
 				"No pull request found for branch feature/test-branch.",
 			);
-			expect(postMessage).not.toHaveBeenCalled();
+			// The section must repaint via prStatus so the click-time button
+			// state is reset.
+			expect(postMessage).toHaveBeenCalledWith(
+				expect.objectContaining({
+					command: "prStatus",
+					status: "noPr",
+					branch: "feature/test-branch",
+				}),
+			);
 		});
 
 		it("shows error and logs when an unexpected error is thrown", async () => {

--- a/vscode/src/services/PrCommentService.test.ts
+++ b/vscode/src/services/PrCommentService.test.ts
@@ -137,6 +137,26 @@ function setupExecFile(
 	});
 }
 
+/**
+ * Builds a gh-shaped error where stderr is attached as a property — matches
+ * how `tryExecGh` extracts stderr in production (`(err as { stderr? }).stderr`).
+ * `setupExecFile`'s handler throws this to simulate a non-zero gh exit with
+ * a stderr line that drives the noPr / lookupError discriminator.
+ */
+function ghError(opts: {
+	message: string;
+	stderr?: string;
+	code?: string | number;
+}): Error {
+	const err = new Error(opts.message) as Error & {
+		stderr?: string;
+		code?: string | number;
+	};
+	if (opts.stderr !== undefined) err.stderr = opts.stderr;
+	if (opts.code !== undefined) err.code = opts.code;
+	return err;
+}
+
 function setupTmpFile() {
 	tmpdirMock.mockReturnValue("/tmp");
 	randomBytesMock.mockReturnValue({ toString: () => "a1b2c3d4e5f6" });
@@ -376,7 +396,10 @@ describe("PrCommentService", () => {
 					return { stdout: "Logged in\n" };
 				}
 				if (cmd === "gh" && args[0] === "pr") {
-					throw new Error("no PRs found");
+					throw ghError({
+						message: "gh exit 1",
+						stderr: "no pull requests found",
+					});
 				}
 				return { stdout: "" };
 			});
@@ -416,7 +439,12 @@ describe("PrCommentService", () => {
 					return { stdout: "gh version 2.40.0\n" };
 				}
 				if (cmd === "gh" && args[0] === "auth") return { stdout: "ok\n" };
-				if (cmd === "gh" && args[0] === "pr") throw new Error("no PR");
+				if (cmd === "gh" && args[0] === "pr") {
+					throw ghError({
+						message: "gh exit 1",
+						stderr: "no pull requests found",
+					});
+				}
 				return { stdout: "" };
 			});
 
@@ -542,7 +570,10 @@ describe("PrCommentService", () => {
 					return { stdout: "Logged in\n" };
 				}
 				if (cmd === "gh" && args[0] === "pr") {
-					throw new Error("no PRs found");
+					throw ghError({
+						message: "gh exit 1",
+						stderr: "no pull requests found",
+					});
 				}
 				return { stdout: "" };
 			});
@@ -596,7 +627,11 @@ describe("PrCommentService", () => {
 			});
 		});
 
-		it("posts noPr when gh pr view returns non-JSON output", async () => {
+		it("posts unavailable with lookup-error reason when gh pr view returns non-JSON output", async () => {
+			// I-1 contract change: pre-refactor, unparseable JSON was folded
+			// into noPr, which then showed a Create PR button — a token-lapse
+			// could trick users into creating duplicate PRs. Now the
+			// lookupError lane surfaces a Retry button with the real reason.
 			setupExecFile((cmd, args) => {
 				if (cmd === "git" && args[0] === "rev-list") {
 					return { stdout: "1\n" };
@@ -611,7 +646,6 @@ describe("PrCommentService", () => {
 					return { stdout: "Logged in\n" };
 				}
 				if (cmd === "gh" && args[0] === "pr") {
-					// Return non-JSON string — triggers the catch in findPrForBranch (lines 129-130)
 					return { stdout: "not valid json at all" };
 				}
 				return { stdout: "" };
@@ -619,11 +653,16 @@ describe("PrCommentService", () => {
 
 			await handleCheckPrStatus(CWD, postMessage);
 
-			expect(postMessage).toHaveBeenCalledWith({
-				command: "prStatus",
-				status: "noPr",
-				branch: "feature/branch",
-			});
+			expect(postMessage).toHaveBeenCalledWith(
+				expect.objectContaining({
+					command: "prStatus",
+					status: "unavailable",
+					reason: expect.stringContaining("Unparseable response from gh"),
+				}),
+			);
+			expect(postMessage).not.toHaveBeenCalledWith(
+				expect.objectContaining({ status: "noPr" }),
+			);
 		});
 
 		it("posts noPr when gh pr view returns valid JSON with number: 0 (falsy)", async () => {
@@ -765,20 +804,8 @@ describe("PrCommentService", () => {
 			});
 		}
 
-		/** Builds an Error with `code` and `stderr` attached, mimicking child_process execFile rejection shape. */
-		function ghError(opts: {
-			message: string;
-			code?: string | number;
-			stderr?: string;
-		}): Error {
-			const err = new Error(opts.message) as Error & {
-				code?: string | number;
-				stderr?: string;
-			};
-			if (opts.code !== undefined) err.code = opts.code;
-			if (opts.stderr !== undefined) err.stderr = opts.stderr;
-			return err;
-		}
+		// `ghError` is defined at module top — shared by tests inside and
+		// outside this describe to keep gh-mock shape consistent.
 
 		it("does not emit warn/debug on the happy path (baseline)", async () => {
 			setupHappyProbesWithPrHandler(() => ({
@@ -818,7 +845,12 @@ describe("PrCommentService", () => {
 			);
 		});
 
-		it("logs at warn when gh pr view fails with a non-expected stderr (e.g. auth/ratelimit)", async () => {
+		it("posts unavailable (NOT noPr) when gh pr view fails with a non-expected stderr (e.g. auth/ratelimit)", async () => {
+			// I-1 contract change: auth lapses, rate limits, and other gh
+			// non-zero exits that don't say "no pull requests found" used to
+			// be folded into noPr — leading the user to click Create PR and
+			// either fail or duplicate. Now they surface as `unavailable`
+			// with the real stderr in `reason`, and the UI shows Retry.
 			setupHappyProbesWithPrHandler(() => {
 				throw ghError({
 					message: "gh: exit 1",
@@ -837,7 +869,13 @@ describe("PrCommentService", () => {
 			);
 			expect(debug).not.toHaveBeenCalled();
 			expect(postMessage).toHaveBeenCalledWith(
-				expect.objectContaining({ status: "noPr", branch: "feature/br" }),
+				expect.objectContaining({
+					status: "unavailable",
+					reason: expect.stringContaining("authentication required"),
+				}),
+			);
+			expect(postMessage).not.toHaveBeenCalledWith(
+				expect.objectContaining({ status: "noPr" }),
 			);
 		});
 
@@ -857,7 +895,9 @@ describe("PrCommentService", () => {
 			);
 		});
 
-		it("logs at warn with Raw length when gh pr view returns unparseable JSON", async () => {
+		it("logs at warn with Raw length AND posts unavailable when gh pr view returns unparseable JSON", async () => {
+			// I-1: unparseable JSON now goes through lookupError → unavailable
+			// instead of being folded into noPr.
 			setupHappyProbesWithPrHandler(() => ({
 				stdout: "not-json-{{{",
 			}));
@@ -868,9 +908,11 @@ describe("PrCommentService", () => {
 				expect.any(String),
 				expect.stringMatching(/unparseable JSON.*Raw length: \d+/s),
 			);
-			// UI folding unchanged
 			expect(postMessage).toHaveBeenCalledWith(
-				expect.objectContaining({ status: "noPr", branch: "feature/br" }),
+				expect.objectContaining({
+					status: "unavailable",
+					reason: expect.stringContaining("Unparseable response from gh"),
+				}),
 			);
 		});
 
@@ -898,7 +940,10 @@ describe("PrCommentService", () => {
 					if (sepIdx >= 0) {
 						prListHeadArg = args[sepIdx + 1];
 					}
-					return { stdout: "" };
+					throw ghError({
+						message: "gh exit 1",
+						stderr: "no pull requests found",
+					});
 				}
 				return { stdout: "" };
 			});
@@ -939,7 +984,10 @@ describe("PrCommentService", () => {
 						prViewBranchArg = args[sepIdx + 1];
 					}
 					// gh returns "no PR" for the stale name.
-					return { stdout: "" };
+					throw ghError({
+						message: "gh exit 1",
+						stderr: "no pull requests found",
+					});
 				}
 				return { stdout: "" };
 			});
@@ -975,7 +1023,10 @@ describe("PrCommentService", () => {
 					if (sepIdx >= 0) {
 						prListHeadArg = args[sepIdx + 1];
 					}
-					return { stdout: "" };
+					throw ghError({
+						message: "gh exit 1",
+						stderr: "no pull requests found",
+					});
 				}
 				return { stdout: "" };
 			});
@@ -1291,6 +1342,46 @@ describe("PrCommentService", () => {
 			expect(call.body).not.toContain("old content");
 		});
 
+		it("shows error AND re-runs status flow when PR lookup fails (auth/ratelimit/JSON)", async () => {
+			// I-1: lookupError must not fold into noPr. The error toast tells
+			// the user the real reason; the status refresh repaints the
+			// section so the Edit PR button's "Loading..." state is reset
+			// (the section will now show `unavailable` + Retry).
+			setupExecFile((cmd, args) => {
+				if (cmd === "git" && args[0] === "rev-parse") {
+					return { stdout: "feature/test-branch\n" };
+				}
+				if (cmd === "gh" && args[0] === "--version") {
+					return { stdout: "gh 2.40.0\n" };
+				}
+				if (cmd === "gh" && args[0] === "auth") {
+					return { stdout: "ok\n" };
+				}
+				if (cmd === "gh" && args[0] === "pr" && args[1] === "view") {
+					throw ghError({
+						message: "gh exit 4",
+						code: 4,
+						stderr: "HTTP 401: Bad credentials",
+					});
+				}
+				return { stdout: "" };
+			});
+
+			await handlePrepareUpdatePr(MARKDOWN, CWD, postMessage);
+
+			expect(showErrorMessage).toHaveBeenCalledWith(
+				expect.stringContaining("HTTP 401"),
+			);
+			// Status repaint triggers — section will show unavailable + Retry.
+			expect(postMessage).toHaveBeenCalledWith(
+				expect.objectContaining({
+					command: "prStatus",
+					status: "unavailable",
+					reason: expect.stringContaining("HTTP 401"),
+				}),
+			);
+		});
+
 		it("shows warning AND re-runs status flow when no PR is found (un-sticks the Edit PR button)", async () => {
 			// Regression: the webview's Edit PR button sets itself to
 			// "Loading..." + disabled on click. If `handlePrepareUpdatePr`
@@ -1309,9 +1400,14 @@ describe("PrCommentService", () => {
 					return { stdout: "ok\n" };
 				}
 				if (cmd === "gh" && args[0] === "pr" && args[1] === "view") {
-					// Mimic gh's "no pull requests found" stderr branch by
-					// throwing — findPrForBranch sees result.ok=false.
-					throw new Error("no pull requests found");
+					// Mimic gh's real non-zero exit with the "no pull requests
+					// found" stderr line — findPrForBranch reads it via
+					// `(err as { stderr? }).stderr`, matches the regex,
+					// returns `{ kind: "noPr" }`.
+					throw ghError({
+						message: "gh exit 1",
+						stderr: "no pull requests found",
+					});
 				}
 				return { stdout: "" };
 			});
@@ -1514,7 +1610,10 @@ describe("PrCommentService", () => {
 				if (cmd === "git" && args[0] === "rev-parse") {
 					return { stdout: "branch\n" };
 				}
-				throw new Error("no PR");
+				throw ghError({
+					message: "gh exit 1",
+					stderr: "no pull requests found",
+				});
 			});
 
 			await handleUpdatePr("T", "B", CWD, postMessage);
@@ -1523,6 +1622,35 @@ describe("PrCommentService", () => {
 			expect(postMessage).toHaveBeenCalledWith({ command: "prUpdateFailed" });
 			expect(showWarningMessage).toHaveBeenCalledWith(
 				"No pull request found for branch branch.",
+			);
+		});
+
+		it("shows error toast and posts prUpdateFailed when PR lookup fails (auth/network)", async () => {
+			// I-1: distinguished from noPr — the form is open and the user
+			// clicked Submit. We surface the real error reason so they know
+			// it's not a "PR was deleted" situation, and bail out so they can
+			// retry.
+			setupExecFile((cmd, args) => {
+				if (cmd === "git" && args[0] === "rev-parse") {
+					return { stdout: "branch\n" };
+				}
+				throw ghError({
+					message: "gh exit 4",
+					code: 4,
+					stderr: "HTTP 401: Bad credentials",
+				});
+			});
+
+			await handleUpdatePr("T", "B", CWD, postMessage);
+
+			expect(postMessage).toHaveBeenCalledWith({ command: "prUpdating" });
+			expect(postMessage).toHaveBeenCalledWith({ command: "prUpdateFailed" });
+			expect(showErrorMessage).toHaveBeenCalledWith(
+				expect.stringContaining("HTTP 401"),
+			);
+			// Must NOT show the misleading "No pull request found" message.
+			expect(showWarningMessage).not.toHaveBeenCalledWith(
+				expect.stringContaining("No pull request found"),
 			);
 		});
 

--- a/vscode/src/services/PrCommentService.test.ts
+++ b/vscode/src/services/PrCommentService.test.ts
@@ -717,8 +717,6 @@ describe("PrCommentService", () => {
 			});
 		});
 
-		// ── branch parameter tests ────────────────────────────────────────────
-
 		// ── debug.log observability (non-goal: UI folding stays the same) ─────
 
 		/**
@@ -851,6 +849,74 @@ describe("PrCommentService", () => {
 			expect(postMessage).toHaveBeenCalledWith(
 				expect.objectContaining({ status: "noPr", branch: "feature/br" }),
 			);
+		});
+
+		// ── summaryBranch routing (Memory Bank) ──────────────────────────────
+		//
+		// When the user opens a summary from another branch in Memory Bank,
+		// the PR lookup must target the summary's branch, not the user's
+		// currently checked-out branch. We assert by capturing the `--head`
+		// argument passed to `gh pr list`.
+
+		it("queries the PR for the summary's branch when summaryBranch is passed", async () => {
+			let prListHeadArg: string | undefined;
+			setupExecFile((cmd, args) => {
+				if (cmd === "git" && args[0] === "rev-parse") {
+					return { stdout: "feature/current\n" };
+				}
+				if (cmd === "gh" && args[0] === "--version") {
+					return { stdout: "gh 2.40.0\n" };
+				}
+				if (cmd === "gh" && args[0] === "auth") {
+					return { stdout: "ok\n" };
+				}
+				if (cmd === "gh" && args[0] === "pr" && args[1] === "view") {
+					const sepIdx = args.indexOf("--");
+					if (sepIdx >= 0) {
+						prListHeadArg = args[sepIdx + 1];
+					}
+					return { stdout: "" };
+				}
+				return { stdout: "" };
+			});
+
+			await handleCheckPrStatus(CWD, postMessage, "feature/summary-branch");
+
+			expect(prListHeadArg).toBe("feature/summary-branch");
+			// noPr message also reflects the summary branch, not the current one.
+			expect(postMessage).toHaveBeenCalledWith(
+				expect.objectContaining({
+					status: "noPr",
+					branch: "feature/summary-branch",
+				}),
+			);
+		});
+
+		it("falls back to currentBranch when summaryBranch is undefined", async () => {
+			let prListHeadArg: string | undefined;
+			setupExecFile((cmd, args) => {
+				if (cmd === "git" && args[0] === "rev-parse") {
+					return { stdout: "feature/current\n" };
+				}
+				if (cmd === "gh" && args[0] === "--version") {
+					return { stdout: "gh 2.40.0\n" };
+				}
+				if (cmd === "gh" && args[0] === "auth") {
+					return { stdout: "ok\n" };
+				}
+				if (cmd === "gh" && args[0] === "pr" && args[1] === "view") {
+					const sepIdx = args.indexOf("--");
+					if (sepIdx >= 0) {
+						prListHeadArg = args[sepIdx + 1];
+					}
+					return { stdout: "" };
+				}
+				return { stdout: "" };
+			});
+
+			await handleCheckPrStatus(CWD, postMessage);
+
+			expect(prListHeadArg).toBe("feature/current");
 		});
 	});
 
@@ -1012,6 +1078,86 @@ describe("PrCommentService", () => {
 			});
 			expect(uriParse).toHaveBeenCalledWith(prUrl);
 		});
+
+		// ── Cross-branch guard (Memory Bank) ─────────────────────────────────
+		//
+		// When the user is viewing a summary on branch X while checked out on
+		// branch Y, `git push -u origin HEAD` would push Y's commits to X's PR
+		// — silently wrong. The service-side guard must reject before any
+		// push/create runs.
+
+		it("cross-branch: rejects with prCreateBlockedCrossBranch and skips push/create when summaryBranch differs from currentBranch", async () => {
+			let gitPushCalled = false;
+			let prCreateCalled = false;
+			setupExecFile(
+				buildRouter({
+					"git:rev-parse": () => ({ stdout: "feature/current\n" }),
+					"git:push": () => {
+						gitPushCalled = true;
+						return { stdout: "" };
+					},
+					"gh:pr:create": () => {
+						prCreateCalled = true;
+						return { stdout: "https://example/0\n" };
+					},
+				}),
+			);
+
+			await handleCreatePr(
+				"T",
+				"B",
+				CWD,
+				postMessage,
+				"feature/summary-branch",
+			);
+
+			expect(postMessage).toHaveBeenCalledWith({
+				command: "prCreateBlockedCrossBranch",
+				summaryBranch: "feature/summary-branch",
+				currentBranch: "feature/current",
+			});
+			expect(postMessage).not.toHaveBeenCalledWith({ command: "prCreating" });
+			expect(gitPushCalled).toBe(false);
+			expect(prCreateCalled).toBe(false);
+			expect(showWarningMessage).toHaveBeenCalledWith(
+				expect.stringContaining("feature/summary-branch"),
+			);
+		});
+
+		it("cross-branch: proceeds normally when summaryBranch equals currentBranch", async () => {
+			const prUrl = "https://github.com/org/repo/pull/123";
+			let gitPushCalled = false;
+			setupExecFile(
+				buildRouter({
+					"git:rev-parse": () => ({ stdout: "feature/same\n" }),
+					"git:push": () => {
+						gitPushCalled = true;
+						return { stdout: "" };
+					},
+					"gh:pr:create": () => ({ stdout: `${prUrl}\n` }),
+					"git:rev-list": () => ({ stdout: "1\n" }),
+					"gh:--version": () => ({ stdout: "gh 2.40.0\n" }),
+					"gh:auth": () => ({ stdout: "ok\n" }),
+					"gh:pr:view": () => ({
+						stdout: JSON.stringify({
+							number: 123,
+							url: prUrl,
+							title: "OK",
+							body: "",
+						}),
+					}),
+				}),
+			);
+			showInformationMessage.mockResolvedValue(undefined);
+
+			await handleCreatePr("T", "B", CWD, postMessage, "feature/same");
+
+			expect(gitPushCalled).toBe(true);
+			expect(postMessage).toHaveBeenCalledWith({ command: "prCreating" });
+			expect(postMessage).not.toHaveBeenCalledWith(
+				expect.objectContaining({ command: "prCreateBlockedCrossBranch" }),
+			);
+		});
 	});
 
 	// ─── handlePrepareUpdatePr ──────────────────────────────────────────────
@@ -1151,6 +1297,41 @@ describe("PrCommentService", () => {
 			expect(call.body).toBe(
 				`${MARKER_START}\n## Summary\nFixed a bug\n${MARKER_END}`,
 			);
+		});
+
+		// ── summaryBranch routing (Memory Bank) ──────────────────────────────
+
+		it("looks up the PR on summaryBranch when provided, not currentBranch", async () => {
+			let prViewBranchArg: string | undefined;
+			setupExecFile((cmd, args) => {
+				if (cmd === "git" && args[0] === "rev-parse") {
+					return { stdout: "feature/current\n" };
+				}
+				if (cmd === "gh" && args[0] === "pr" && args[1] === "view") {
+					const sepIdx = args.indexOf("--");
+					if (sepIdx >= 0) {
+						prViewBranchArg = args[sepIdx + 1];
+					}
+					return {
+						stdout: JSON.stringify({
+							number: 5,
+							url: "https://url",
+							title: "T",
+							body: "",
+						}),
+					};
+				}
+				return { stdout: "" };
+			});
+
+			await handlePrepareUpdatePr(
+				MARKDOWN,
+				CWD,
+				postMessage,
+				"feature/summary-branch",
+			);
+
+			expect(prViewBranchArg).toBe("feature/summary-branch");
 		});
 	});
 
@@ -1369,6 +1550,50 @@ describe("PrCommentService", () => {
 				expect(openExternal).toHaveBeenCalled();
 			});
 			expect(uriParse).toHaveBeenCalledWith(prUrl);
+		});
+
+		// ── summaryBranch routing (Memory Bank) ──────────────────────────────
+
+		it("updates the PR on summaryBranch when provided, not currentBranch", async () => {
+			let prViewBranchArg: string | undefined;
+			setupTmpFile();
+			setupExecFile((cmd, args) => {
+				if (cmd === "git" && args[0] === "rev-parse") {
+					return { stdout: "feature/current\n" };
+				}
+				if (cmd === "gh" && args[0] === "pr" && args[1] === "view") {
+					const sepIdx = args.indexOf("--");
+					if (sepIdx >= 0) {
+						prViewBranchArg = args[sepIdx + 1];
+					}
+					return {
+						stdout: JSON.stringify({
+							number: 11,
+							url: "https://url",
+							title: "T",
+							body: "",
+						}),
+					};
+				}
+				if (cmd === "gh" && args[0] === "--version") {
+					return { stdout: "gh 2.40.0\n" };
+				}
+				if (cmd === "gh" && args[0] === "auth") {
+					return { stdout: "ok\n" };
+				}
+				return { stdout: "" };
+			});
+			showInformationMessage.mockResolvedValue(undefined);
+
+			await handleUpdatePr(
+				"T",
+				"new body",
+				CWD,
+				postMessage,
+				"feature/summary-branch",
+			);
+
+			expect(prViewBranchArg).toBe("feature/summary-branch");
 		});
 	});
 });

--- a/vscode/src/services/PrCommentService.ts
+++ b/vscode/src/services/PrCommentService.ts
@@ -328,20 +328,22 @@ async function createPr(
 type PostMessageFn = (msg: Record<string, unknown>) => void;
 
 /**
- * Checks the PR status for the current branch and sends the result to the webview.
+ * Checks the PR status for the summary's branch and sends the result to the webview.
  *
- * PR operations are branch-scoped, not commit-scoped: we always look up the PR
- * on the current branch (`gh pr list --head <currentBranch>`), regardless of
- * which summary the user has open. This keeps the model predictable across
- * rebase / branch-switch and removes the cross-branch footgun where a stale
- * `summaryCommitHash` could route the lookup to the wrong branch.
+ * PR operations are branch-scoped, not commit-scoped: we look up the PR on
+ * `summaryBranch` (the branch the summary was generated on), with fallback to
+ * the current branch when no summary is in view. This keeps Memory Bank
+ * cross-branch navigation honest — clicking a summary on `feat-x` while
+ * checked out on `feat-y` shows `feat-x`'s PR, not `feat-y`'s. Commit hash
+ * is intentionally ignored to stay rebase-safe (the Flyer regression).
  */
 export async function handleCheckPrStatus(
 	cwd: string,
 	postMessage: PostMessageFn,
+	summaryBranch?: string,
 ): Promise<void> {
 	try {
-		const targetBranch = await getCurrentBranch(cwd);
+		const targetBranch = summaryBranch ?? (await getCurrentBranch(cwd));
 
 		// Check gh availability — distinguish "not installed" (definitive) from
 		// transient spawn errors so the user gets an actionable message.
@@ -392,22 +394,38 @@ export async function handleCheckPrStatus(
 }
 
 /**
- * Creates a new PR for the current branch using the user-provided title and body.
+ * Creates a new PR for the summary's branch.
  *
- * Branch-scoped: `git push -u origin HEAD` + `gh pr create` always act on the
- * checked-out branch. The summary that the webview was opened with is purely
- * informational here — it determines the PR body content (assembled by the
- * caller) but never gates whether a PR can be created.
+ * Routing is by `summaryBranch` (matches Check/Update PR), but the physical
+ * `git push -u origin HEAD` requires that branch to be the one currently
+ * checked out. So we guard: if `summaryBranch !== currentBranch` (Memory Bank
+ * cross-branch view), reject with `prCreateBlockedCrossBranch` and let the
+ * webview prompt the user to checkout first. When `summaryBranch` is undefined
+ * (no summary context), fall back to current-branch behavior.
  */
 export async function handleCreatePr(
 	title: string,
 	body: string,
 	cwd: string,
 	postMessage: PostMessageFn,
+	summaryBranch?: string,
 ): Promise<void> {
-	postMessage({ command: "prCreating" });
-
 	try {
+		const currentBranch = await getCurrentBranch(cwd);
+		if (summaryBranch && summaryBranch !== currentBranch) {
+			vscode.window.showWarningMessage(
+				`This summary is on branch ${summaryBranch}. Checkout ${summaryBranch} to create its PR.`,
+			);
+			postMessage({
+				command: "prCreateBlockedCrossBranch",
+				summaryBranch,
+				currentBranch,
+			});
+			return;
+		}
+
+		postMessage({ command: "prCreating" });
+
 		// Ensure branch is pushed
 		log.info(TAG, "Pushing branch to origin...");
 		await pushBranch(cwd);
@@ -418,7 +436,7 @@ export async function handleCreatePr(
 		log.info(TAG, `PR created: ${prUrl}`);
 
 		// Refresh section to show the new PR
-		await handleCheckPrStatus(cwd, postMessage);
+		await handleCheckPrStatus(cwd, postMessage, summaryBranch);
 
 		// Toast with "Open PR" action
 		vscode.window
@@ -437,11 +455,13 @@ export async function handleCreatePr(
 }
 
 /**
- * Prepares the Update PR form by fetching the current branch's PR data,
- * replacing the marker region with the caller-provided markdown, and
- * sending the pre-filled title + body to the webview.
+ * Prepares the Update PR form by fetching the summary's PR data, replacing
+ * the marker region with the caller-provided markdown, and sending the
+ * pre-filled title + body to the webview.
  *
- * Branch-scoped: looks up the PR on the current branch. The caller assembles
+ * Routes by `summaryBranch` (Memory Bank cross-branch viewing needs to target
+ * the summary's branch, not whatever the user has checked out). Falls back to
+ * `currentBranch` when `summaryBranch` is undefined. The caller assembles
  * `markdown` (single-summary or branch-aggregated) — this function only
  * handles the GitHub-side lookup + marker replacement.
  */
@@ -449,9 +469,10 @@ export async function handlePrepareUpdatePr(
 	markdown: string,
 	cwd: string,
 	postMessage: PostMessageFn,
+	summaryBranch?: string,
 ): Promise<void> {
 	try {
-		const targetBranch = await getCurrentBranch(cwd);
+		const targetBranch = summaryBranch ?? (await getCurrentBranch(cwd));
 		const pr = await findPrForBranch(cwd, targetBranch);
 		if (!pr) {
 			vscode.window.showWarningMessage(
@@ -475,21 +496,24 @@ export async function handlePrepareUpdatePr(
 }
 
 /**
- * Updates the current branch's PR title and description with the user-edited
- * values from the form.
+ * Updates the summary's PR title and description with the user-edited values
+ * from the form.
  *
- * Branch-scoped: always updates the PR on the current branch.
+ * Routes by `summaryBranch` (Memory Bank cross-branch viewing edits the
+ * summary's branch's PR, not currentBranch's). Falls back to `currentBranch`
+ * when `summaryBranch` is undefined.
  */
 export async function handleUpdatePr(
 	title: string,
 	body: string,
 	cwd: string,
 	postMessage: PostMessageFn,
+	summaryBranch?: string,
 ): Promise<void> {
 	postMessage({ command: "prUpdating" });
 
 	try {
-		const targetBranch = await getCurrentBranch(cwd);
+		const targetBranch = summaryBranch ?? (await getCurrentBranch(cwd));
 		const pr = await findPrForBranch(cwd, targetBranch);
 		if (!pr) {
 			postMessage({ command: "prUpdateFailed" });
@@ -509,8 +533,9 @@ export async function handleUpdatePr(
 
 		log.info(TAG, `Updated PR #${pr.number}`);
 
-		// Refresh section to reflect new state
-		await handleCheckPrStatus(cwd, postMessage);
+		// Refresh section to reflect new state — pass summaryBranch through so
+		// the refresh stays scoped to the same branch we just updated.
+		await handleCheckPrStatus(cwd, postMessage, summaryBranch);
 
 		vscode.window
 			.showInformationMessage(`Updated PR #${pr.number}`, "Open PR")
@@ -819,6 +844,20 @@ export function buildPrMessageScript(): string {
       prFormSubmit.textContent = 'Submit PR';
       prFormSubmit.disabled = false;
       prFormCancel.disabled = false;
+    }
+    // ── PR create blocked by cross-branch guard ──
+    // Fires when the summary's branch differs from the current branch. The
+    // extension side has already shown a warning toast; here we just revert
+    // any "Loading..." / "Creating..." UI back to a clickable state so the
+    // user can checkout the right branch and retry without a stale UI.
+    if (msg.command === 'prCreateBlockedCrossBranch') {
+      var blockedBtn = document.getElementById('createPrBtn');
+      if (blockedBtn) { blockedBtn.textContent = 'Create PR'; blockedBtn.disabled = false; }
+      if (prFormSubmit) {
+        prFormSubmit.textContent = 'Submit PR';
+        prFormSubmit.disabled = false;
+      }
+      if (prFormCancel) { prFormCancel.disabled = false; }
     }
     if (msg.command === 'prUpdating' && prFormSubmit) {
       prFormSubmit.textContent = 'Updating...';

--- a/vscode/src/services/PrCommentService.ts
+++ b/vscode/src/services/PrCommentService.ts
@@ -210,46 +210,6 @@ async function getCurrentBranch(cwd: string): Promise<string> {
 	return raw.trim();
 }
 
-// ─── Cross-branch detection ─────────────────────────────────────────────────
-//
-// A memory is "cross-branch" when the commit it was recorded for is NOT in
-// the current branch's history. That happens when the user is viewing a
-// memory from a different branch (e.g. browsing history while checked out
-// elsewhere), or when that branch was deleted and recreated pointing at
-// different commits.
-//
-// The common case is the opposite: the memory's commit IS in the current
-// branch's history. That is when Create/Update PR operations make sense,
-// because `git push origin HEAD` and `gh pr create` act on the current
-// branch — and the current branch is the one that actually contains the
-// commit the memory is about.
-//
-// We use commit reachability instead of comparing branch names because
-// names are mutable labels: `git branch -m`, delete-and-recreate, and
-// force-push all break name equality without changing whether the commit
-// is part of the current branch's history. Reachability is the invariant
-// that actually matches the semantics we want.
-
-/**
- * Returns true if `commitHash` is in the current branch's history (reachable
- * from HEAD).
- *
- * `git merge-base --is-ancestor` exits 0 when the commit is an ancestor of
- * HEAD, 1 when it is not, and other codes on internal errors — in all
- * failure modes we conservatively return false.
- */
-export async function isCommitReachableFromHead(
-	cwd: string,
-	commitHash: string,
-): Promise<boolean> {
-	try {
-		await execGit(["merge-base", "--is-ancestor", commitHash, "HEAD"], cwd);
-		return true;
-	} catch {
-		return false;
-	}
-}
-
 /** Pushes the current branch to origin (no-op if already pushed). */
 async function pushBranch(cwd: string): Promise<void> {
 	await execGit(["push", "-u", "origin", "HEAD"], cwd);
@@ -368,36 +328,20 @@ async function createPr(
 type PostMessageFn = (msg: Record<string, unknown>) => void;
 
 /**
- * Checks the PR status and sends the result to the webview.
+ * Checks the PR status for the current branch and sends the result to the webview.
  *
- * @param summaryBranch - The branch recorded in the summary at commit time.
- *   Resolved via {@link resolveTargetBranch} so we always pass an explicit
- *   branch to `gh pr view`, avoiding HEAD fall-through mis-association.
- * @param summaryCommitHash - The summary's commit hash. Used to determine if
- *   the memory belongs to the current branch via commit reachability, which is
- *   immune to branch rename / delete-and-recreate / force-push scenarios.
+ * PR operations are branch-scoped, not commit-scoped: we always look up the PR
+ * on the current branch (`gh pr list --head <currentBranch>`), regardless of
+ * which summary the user has open. This keeps the model predictable across
+ * rebase / branch-switch and removes the cross-branch footgun where a stale
+ * `summaryCommitHash` could route the lookup to the wrong branch.
  */
 export async function handleCheckPrStatus(
 	cwd: string,
 	postMessage: PostMessageFn,
-	summaryBranch?: string,
-	summaryCommitHash?: string,
 ): Promise<void> {
 	try {
-		// The happy path is !isCrossBranch: the memory's commit is on the
-		// current branch, so Create/Update PR acts on it. See the Cross-branch
-		// section above for why we rely on commit reachability here.
-		const isCrossBranch = summaryCommitHash
-			? !(await isCommitReachableFromHead(cwd, summaryCommitHash))
-			: false;
-
-		// PR lookup must use the branch that actually contains the commit:
-		//   • Normal / rename / force-push → current branch (memory is on it)
-		//   • Cross-branch → summary.branch (our best guess for the other branch)
-		const currentBranch = await getCurrentBranch(cwd);
-		const targetBranch = isCrossBranch
-			? (summaryBranch ?? currentBranch)
-			: currentBranch;
+		const targetBranch = await getCurrentBranch(cwd);
 
 		// Check gh availability — distinguish "not installed" (definitive) from
 		// transient spawn errors so the user gets an actionable message.
@@ -431,7 +375,6 @@ export async function handleCheckPrStatus(
 				command: "prStatus",
 				status: "noPr",
 				branch: targetBranch,
-				crossBranch: isCrossBranch,
 			});
 			return;
 		}
@@ -449,42 +392,22 @@ export async function handleCheckPrStatus(
 }
 
 /**
- * Creates a new PR with the user-provided title and body.
+ * Creates a new PR for the current branch using the user-provided title and body.
  *
- * @param summaryBranch - The branch recorded in the summary. Passed through
- *   to the post-create refresh so the PR section re-queries for the same
- *   target branch.
- * @param summaryCommitHash - The summary's commit hash. Used to check that
- *   the memory's commit is reachable from the current HEAD, meaning `git push
- *   origin HEAD` and `gh pr create` operate on a branch that actually contains
- *   this work. Immune to branch rename / delete-and-recreate / force-push.
+ * Branch-scoped: `git push -u origin HEAD` + `gh pr create` always act on the
+ * checked-out branch. The summary that the webview was opened with is purely
+ * informational here — it determines the PR body content (assembled by the
+ * caller) but never gates whether a PR can be created.
  */
 export async function handleCreatePr(
 	title: string,
 	body: string,
 	cwd: string,
 	postMessage: PostMessageFn,
-	summaryBranch?: string,
-	summaryCommitHash?: string,
 ): Promise<void> {
 	postMessage({ command: "prCreating" });
 
 	try {
-		// Cross-branch guard: if the memory's commit is NOT on the current
-		// branch, a PR created from HEAD would not contain this commit.
-		// Non-cross-branch (the normal case) falls through to the push +
-		// create flow below. See the Cross-branch section above.
-		if (
-			summaryCommitHash &&
-			!(await isCommitReachableFromHead(cwd, summaryCommitHash))
-		) {
-			postMessage({ command: "prCreateFailed" });
-			vscode.window.showWarningMessage(
-				"Cannot create a PR — the memory's commit is not in the current branch's history. Check out a branch that includes this commit first.",
-			);
-			return;
-		}
-
 		// Ensure branch is pushed
 		log.info(TAG, "Pushing branch to origin...");
 		await pushBranch(cwd);
@@ -495,12 +418,7 @@ export async function handleCreatePr(
 		log.info(TAG, `PR created: ${prUrl}`);
 
 		// Refresh section to show the new PR
-		await handleCheckPrStatus(
-			cwd,
-			postMessage,
-			summaryBranch,
-			summaryCommitHash,
-		);
+		await handleCheckPrStatus(cwd, postMessage);
 
 		// Toast with "Open PR" action
 		vscode.window
@@ -519,34 +437,21 @@ export async function handleCreatePr(
 }
 
 /**
- * Prepares the Update PR form by fetching the current PR data,
+ * Prepares the Update PR form by fetching the current branch's PR data,
  * replacing the marker region with the caller-provided markdown, and
  * sending the pre-filled title + body to the webview.
  *
- * The caller is responsible for assembling `markdown` (single-summary or
- * branch-aggregated) and for cross-branch detection — so this function
- * only handles the GitHub-side lookup + marker replacement, keeping its
- * single-responsibility scope. See `SummaryWebviewPanel.handlePrepareUpdatePr`.
- *
- * `summaryBranch` / `summaryCommitHash` are passed through to mirror the
- * branch-resolution logic in `handleCheckPrStatus` (cross-branch falls back
- * to `summaryBranch`; normal case uses the current branch).
+ * Branch-scoped: looks up the PR on the current branch. The caller assembles
+ * `markdown` (single-summary or branch-aggregated) — this function only
+ * handles the GitHub-side lookup + marker replacement.
  */
 export async function handlePrepareUpdatePr(
-	summaryBranch: string | undefined,
-	summaryCommitHash: string | undefined,
 	markdown: string,
 	cwd: string,
 	postMessage: PostMessageFn,
 ): Promise<void> {
 	try {
-		const isCrossBranch = summaryCommitHash
-			? !(await isCommitReachableFromHead(cwd, summaryCommitHash))
-			: false;
-		const currentBranch = await getCurrentBranch(cwd);
-		const targetBranch = isCrossBranch
-			? (summaryBranch ?? currentBranch)
-			: currentBranch;
+		const targetBranch = await getCurrentBranch(cwd);
 		const pr = await findPrForBranch(cwd, targetBranch);
 		if (!pr) {
 			vscode.window.showWarningMessage(
@@ -570,35 +475,21 @@ export async function handlePrepareUpdatePr(
 }
 
 /**
- * Updates the PR title and description with the user-edited values from the form.
+ * Updates the current branch's PR title and description with the user-edited
+ * values from the form.
  *
- * @param summaryBranch - The branch recorded in the summary. Resolved to an
- *   explicit branch name internally — never falls through to HEAD semantics.
- * @param summaryCommitHash - The summary's commit hash. Passed through to the
- *   post-update refresh so cross-branch detection stays consistent with
- *   `handleCheckPrStatus`.
+ * Branch-scoped: always updates the PR on the current branch.
  */
 export async function handleUpdatePr(
 	title: string,
 	body: string,
 	cwd: string,
 	postMessage: PostMessageFn,
-	summaryBranch?: string,
-	summaryCommitHash?: string,
 ): Promise<void> {
 	postMessage({ command: "prUpdating" });
 
 	try {
-		// Mirrors handleCheckPrStatus's lookup strategy:
-		//   • !isCrossBranch (normal case) → update the PR on current branch
-		//   • isCrossBranch → fall back to summary's stored branch
-		const isCrossBranch = summaryCommitHash
-			? !(await isCommitReachableFromHead(cwd, summaryCommitHash))
-			: false;
-		const currentBranch = await getCurrentBranch(cwd);
-		const targetBranch = isCrossBranch
-			? (summaryBranch ?? currentBranch)
-			: currentBranch;
+		const targetBranch = await getCurrentBranch(cwd);
 		const pr = await findPrForBranch(cwd, targetBranch);
 		if (!pr) {
 			postMessage({ command: "prUpdateFailed" });
@@ -619,12 +510,7 @@ export async function handleUpdatePr(
 		log.info(TAG, `Updated PR #${pr.number}`);
 
 		// Refresh section to reflect new state
-		await handleCheckPrStatus(
-			cwd,
-			postMessage,
-			summaryBranch,
-			summaryCommitHash,
-		);
+		await handleCheckPrStatus(cwd, postMessage);
 
 		vscode.window
 			.showInformationMessage(`Updated PR #${pr.number}`, "Open PR")
@@ -847,29 +733,22 @@ export function buildPrMessageScript(): string {
         prShow(prActions);
       } else if (s === 'noPr') {
         prHide(prLinkRow);
-        if (msg.crossBranch) {
-          prStatusText.textContent = 'No pull request found for branch ' + msg.branch + '. Check out that branch to create a PR.';
-          prShow(prStatusText);
-          prActions.textContent = '';
-          prHide(prActions);
-        } else {
-          prStatusText.textContent = 'No pull request found for branch ' + msg.branch + '.';
-          prShow(prStatusText);
-          prActions.textContent = '';
-          var btn = document.createElement('button');
-          btn.className = 'action-btn';
-          btn.id = 'createPrBtn';
-          btn.textContent = 'Create PR';
-          prActions.appendChild(btn);
-          prShow(prActions);
-          // Bind Create PR button — request fresh body from backend so that
-          // content generated after the webview opened (e.g. E2E test) is included.
-          btn.addEventListener('click', function() {
-            btn.disabled = true;
-            btn.textContent = 'Loading...';
-            vscode.postMessage({ command: 'prepareCreatePr' });
-          });
-        }
+        prStatusText.textContent = 'No pull request found for branch ' + msg.branch + '.';
+        prShow(prStatusText);
+        prActions.textContent = '';
+        var btn = document.createElement('button');
+        btn.className = 'action-btn';
+        btn.id = 'createPrBtn';
+        btn.textContent = 'Create PR';
+        prActions.appendChild(btn);
+        prShow(prActions);
+        // Bind Create PR button — request fresh body from backend so that
+        // content generated after the webview opened (e.g. E2E test) is included.
+        btn.addEventListener('click', function() {
+          btn.disabled = true;
+          btn.textContent = 'Loading...';
+          vscode.postMessage({ command: 'prepareCreatePr' });
+        });
       } else if (s === 'ready') {
         var pr = msg.pr;
         prHide(prStatusText);

--- a/vscode/src/services/PrCommentService.ts
+++ b/vscode/src/services/PrCommentService.ts
@@ -223,6 +223,21 @@ interface PrInfo {
 }
 
 /**
+ * Discriminated result of `findPrForBranch`.
+ *
+ * Pre-refactor this function returned `PrInfo | undefined` and collapsed four
+ * distinct outcomes into the same `undefined` value: real no-PR, auth/network
+ * failure, unparseable JSON, and zero-numbered JSON. Callers then showed a
+ * "No PR found" + Create PR button for all four, which misled users into
+ * creating duplicate PRs after a token lapse. The union forces each caller
+ * to decide between the three real outcomes.
+ */
+type PrLookup =
+	| { kind: "found"; pr: PrInfo }
+	| { kind: "noPr" }
+	| { kind: "lookupError"; reason: string };
+
+/**
  * Returns PR info for the given branch.
  * Uses `gh pr view -- <branch>` which works for open, merged, and closed PRs.
  *
@@ -231,10 +246,7 @@ interface PrInfo {
  * argument rather than a flag. This is a defense-in-depth measure since the
  * value originates from persisted JSON on the orphan branch.
  */
-async function findPrForBranch(
-	cwd: string,
-	branch: string,
-): Promise<PrInfo | undefined> {
+async function findPrForBranch(cwd: string, branch: string): Promise<PrLookup> {
 	const args = ["pr", "view", "--json", "number,url,title,body", "--", branch];
 	const result = await tryExecGh(args, cwd);
 
@@ -247,26 +259,34 @@ async function findPrForBranch(
 		const isExpectedNoPr = /no pull requests? found/i.test(stderr);
 		if (isExpectedNoPr) {
 			log.debug(TAG, `No PR for branch ${branch}`);
-		} else {
-			log.warn(
-				TAG,
-				`gh pr view failed for branch ${branch} (code=${result.code}): ${result.err.message}${
-					stderr ? ` | stderr: ${stderr.trim()}` : ""
-				}`,
-			);
+			return { kind: "noPr" };
 		}
-		return;
+		const reason = stderr.trim() || result.err.message;
+		log.warn(
+			TAG,
+			`gh pr view failed for branch ${branch} (code=${result.code}): ${result.err.message}${
+				stderr ? ` | stderr: ${stderr.trim()}` : ""
+			}`,
+		);
+		return { kind: "lookupError", reason };
 	}
 
 	try {
 		const parsed = JSON.parse(result.stdout) as PrInfo;
-		return parsed.number ? parsed : undefined;
+		// `gh pr view --json number` returns `{"number": 0}` only in edge
+		// cases (e.g. the JSON shape changed in a future gh release).
+		// Treat as a real noPr — defense-in-depth, not a known reproducer.
+		return parsed.number ? { kind: "found", pr: parsed } : { kind: "noPr" };
 	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err);
 		log.warn(
 			TAG,
-			`gh pr view returned unparseable JSON for branch ${branch}: ${(err as Error).message}. Raw length: ${result.stdout.length}`,
+			`gh pr view returned unparseable JSON for branch ${branch}: ${message}. Raw length: ${result.stdout.length}`,
 		);
-		return;
+		return {
+			kind: "lookupError",
+			reason: `Unparseable response from gh: ${message}`,
+		};
 	}
 }
 
@@ -370,9 +390,21 @@ export async function handleCheckPrStatus(
 		}
 
 		// Always pass an explicit branch — never rely on HEAD semantics
-		const pr = await findPrForBranch(cwd, targetBranch);
+		const lookup = await findPrForBranch(cwd, targetBranch);
 
-		if (!pr) {
+		if (lookup.kind === "lookupError") {
+			// Reuse the `unavailable + reason` channel (already wired for the
+			// outer-catch git/gh failures). The user sees the real cause and
+			// gets a Retry button instead of a misleading "Create PR" CTA.
+			postMessage({
+				command: "prStatus",
+				status: "unavailable",
+				reason: lookup.reason,
+			});
+			return;
+		}
+
+		if (lookup.kind === "noPr") {
 			postMessage({
 				command: "prStatus",
 				status: "noPr",
@@ -381,6 +413,7 @@ export async function handleCheckPrStatus(
 			return;
 		}
 
+		const { pr } = lookup;
 		postMessage({
 			command: "prStatus",
 			status: "ready",
@@ -478,20 +511,28 @@ export async function handlePrepareUpdatePr(
 ): Promise<void> {
 	try {
 		const targetBranch = summaryBranch ?? (await getCurrentBranch(cwd));
-		const pr = await findPrForBranch(cwd, targetBranch);
-		if (!pr) {
-			vscode.window.showWarningMessage(
-				`No pull request found for branch ${targetBranch}.`,
+		const lookup = await findPrForBranch(cwd, targetBranch);
+
+		// Both `noPr` and `lookupError` paths need to repaint the section:
+		// the webview's Edit PR button sets itself to "Loading..." + disabled
+		// on click. Returning without `prStatus` leaves it stuck forever.
+		if (lookup.kind === "lookupError") {
+			vscode.window.showErrorMessage(
+				`Could not load PR for branch ${targetBranch} — ${lookup.reason}`,
 			);
-			// Re-run the status flow so the section rebuilds: the click-time
-			// `Edit PR` button is set to "Loading..." + disabled by the webview
-			// (see editBtn handler below). Returning silently leaves it stuck.
-			// `prStatus` repaints the section from scratch and replaces the
-			// stale button with a fresh `Create PR` / `Edit PR` / noPr UI.
 			await handleCheckPrStatus(cwd, postMessage, summaryBranch);
 			return;
 		}
 
+		if (lookup.kind === "noPr") {
+			vscode.window.showWarningMessage(
+				`No pull request found for branch ${targetBranch}.`,
+			);
+			await handleCheckPrStatus(cwd, postMessage, summaryBranch);
+			return;
+		}
+
+		const { pr } = lookup;
 		const newBody = replaceSummaryInBody(pr.body || "", markdown);
 
 		postMessage({
@@ -525,14 +566,25 @@ export async function handleUpdatePr(
 
 	try {
 		const targetBranch = summaryBranch ?? (await getCurrentBranch(cwd));
-		const pr = await findPrForBranch(cwd, targetBranch);
-		if (!pr) {
+		const lookup = await findPrForBranch(cwd, targetBranch);
+
+		if (lookup.kind === "lookupError") {
+			postMessage({ command: "prUpdateFailed" });
+			vscode.window.showErrorMessage(
+				`Could not update PR for branch ${targetBranch} — ${lookup.reason}`,
+			);
+			return;
+		}
+
+		if (lookup.kind === "noPr") {
 			postMessage({ command: "prUpdateFailed" });
 			vscode.window.showWarningMessage(
 				`No pull request found for branch ${targetBranch}.`,
 			);
 			return;
 		}
+
+		const { pr } = lookup;
 
 		// Update title if changed
 		if (title !== pr.title) {

--- a/vscode/src/services/PrCommentService.ts
+++ b/vscode/src/services/PrCommentService.ts
@@ -335,7 +335,7 @@ type PostMessageFn = (msg: Record<string, unknown>) => void;
  * the current branch when no summary is in view. This keeps Memory Bank
  * cross-branch navigation honest — clicking a summary on `feat-x` while
  * checked out on `feat-y` shows `feat-x`'s PR, not `feat-y`'s. Commit hash
- * is intentionally ignored to stay rebase-safe (the Flyer regression).
+ * is intentionally ignored to stay rebase-safe across squash/amend.
  */
 export async function handleCheckPrStatus(
 	cwd: string,
@@ -389,7 +389,12 @@ export async function handleCheckPrStatus(
 	} catch (err: unknown) {
 		const msg = err instanceof Error ? err.message : String(err);
 		log.error(TAG, `Check PR status failed: ${msg}`);
-		postMessage({ command: "prStatus", status: "unavailable" });
+		// Surface the real reason so the webview can distinguish git failures
+		// (e.g. detached HEAD, .git/index.lock, permission) from gh failures.
+		// The previous "Could not reach GitHub CLI (gh)" text was misleading
+		// whenever the throw came from `getCurrentBranch` rather than the gh
+		// probes — the catch sits above both code paths.
+		postMessage({ command: "prStatus", status: "unavailable", reason: msg });
 	}
 }
 
@@ -478,6 +483,12 @@ export async function handlePrepareUpdatePr(
 			vscode.window.showWarningMessage(
 				`No pull request found for branch ${targetBranch}.`,
 			);
+			// Re-run the status flow so the section rebuilds: the click-time
+			// `Edit PR` button is set to "Loading..." + disabled by the webview
+			// (see editBtn handler below). Returning silently leaves it stuck.
+			// `prStatus` repaints the section from scratch and replaces the
+			// stale button with a fresh `Create PR` / `Edit PR` / noPr UI.
+			await handleCheckPrStatus(cwd, postMessage, summaryBranch);
 			return;
 		}
 
@@ -743,7 +754,9 @@ export function buildPrMessageScript(): string {
         prActions.appendChild(retryAuthBtn);
         prShow(prActions);
       } else if (s === 'unavailable') {
-        prStatusText.textContent = 'Could not reach GitHub CLI (gh). This is often transient — retry, or check the extension log.';
+        prStatusText.textContent = msg.reason
+          ? ('Could not load PR status — ' + msg.reason + '. Retry, or check the extension log.')
+          : 'Could not reach GitHub CLI (gh). This is often transient — retry, or check the extension log.';
         prShow(prStatusText);
         prHide(prLinkRow);
         prActions.textContent = '';

--- a/vscode/src/views/SummaryWebviewPanel.test.ts
+++ b/vscode/src/views/SummaryWebviewPanel.test.ts
@@ -455,11 +455,15 @@ function makeSummary(overrides?: Partial<CommitSummary>): CommitSummary {
 
 const extensionUri = { fsPath: "/ext", toString: () => "/ext" } as never;
 const workspaceRoot = "/workspace";
-// Bridge stub used to satisfy the panel ctor signature; tests in this file
-// don't exercise branch-summary loading. Methods stay unused.
+// Bridge stub used to satisfy the panel ctor signature. `getCurrentBranch` is
+// the only method exercised here — by the cross-branch guard in
+// `handlePrepareCreatePr` and by `loadBranchSummariesForPr`. It defaults to
+// matching `makeSummary().branch` so existing tests stay on the same-branch
+// path; cross-branch tests override with `vi.spyOn(stubBridge, ...)`.
 const stubBridge = {
 	listBranchCommits: vi.fn(),
 	getSummary: vi.fn(),
+	getCurrentBranch: vi.fn().mockResolvedValue("feature/test"),
 } as unknown as import("../JolliMemoryBridge.js").JolliMemoryBridge;
 const mainBranch = "main";
 
@@ -2548,7 +2552,7 @@ describe("SummaryWebviewPanel", () => {
 		// ── PR handlers ──────────────────────────────────────────────────────
 
 		describe("checkPrStatus", () => {
-			it("delegates to handleCheckPrStatus", async () => {
+			it("delegates to handleCheckPrStatus, passing summary.branch", async () => {
 				const dispatch = await setupPanel();
 
 				dispatch({ command: "checkPrStatus" });
@@ -2557,6 +2561,7 @@ describe("SummaryWebviewPanel", () => {
 				expect(mockHandleCheckPrStatus).toHaveBeenCalledWith(
 					workspaceRoot,
 					expect.any(Function),
+					"feature/test",
 				);
 			});
 
@@ -2576,7 +2581,7 @@ describe("SummaryWebviewPanel", () => {
 		});
 
 		describe("createPr", () => {
-			it("delegates to handleCreatePr", async () => {
+			it("delegates to handleCreatePr, passing summary.branch", async () => {
 				const dispatch = await setupPanel();
 
 				dispatch({ command: "createPr", title: "PR Title", body: "PR Body" });
@@ -2587,6 +2592,7 @@ describe("SummaryWebviewPanel", () => {
 					"PR Body",
 					workspaceRoot,
 					expect.any(Function),
+					"feature/test",
 				);
 			});
 
@@ -2658,11 +2664,17 @@ describe("SummaryWebviewPanel", () => {
 				});
 			});
 
-			it("appends missing-summary footnote when summaries.length <= 1 but missingCount > 0", async () => {
+			it("appends missing-summary footnote on the single-summary tier when missingCount > 0", async () => {
+				// Footnote contextualizes "alongside the 1 branch summary shown,
+				// N more on this branch were skipped" — coherent with the body.
+				const branchSummary = makeSummary({
+					commitHash: "BRANCHONLY",
+					commitMessage: "the one summary",
+				});
 				mockLoadBranchSummaries.mockResolvedValueOnce({
-					summaries: [],
+					summaries: [branchSummary],
 					missingCount: 3,
-					totalCount: 3,
+					totalCount: 4,
 				});
 				mockBuildPrMarkdown.mockReturnValueOnce("# only body");
 				const dispatch = await setupPanel({ commitMessage: "lone msg" });
@@ -2679,6 +2691,31 @@ describe("SummaryWebviewPanel", () => {
 				expect(body).toContain(
 					"> Note: 3 commit(s) without summary were skipped.",
 				);
+			});
+
+			it("zero-summary fallback (currentSummary) does NOT append footnote even when missingCount > 0", async () => {
+				// 0-summary tier = rebase just happened, worker hasn't caught up.
+				// Body comes from currentSummary (possibly stale or from another
+				// branch), so a current-branch "N skipped" note would describe
+				// commits unrelated to the body — drop the footnote.
+				mockLoadBranchSummaries.mockResolvedValueOnce({
+					summaries: [],
+					missingCount: 3,
+					totalCount: 3,
+				});
+				mockBuildPrMarkdown.mockReturnValueOnce("# fallback body");
+				const dispatch = await setupPanel({ commitMessage: "fallback msg" });
+
+				dispatch({ command: "prepareCreatePr" });
+				await flushPromises();
+
+				const call = postMessage.mock.calls.find(
+					(c) => (c[0] as { command?: string }).command === "prShowCreateForm",
+				);
+				expect(call).toBeDefined();
+				const body = (call?.[0] as { body: string }).body;
+				expect(body).toContain("# fallback body");
+				expect(body).not.toContain("commit(s) without summary were skipped");
 			});
 
 			it("branch has exactly 1 summary: uses summaries[0], NOT the webview's currentSummary", async () => {
@@ -2783,6 +2820,33 @@ describe("SummaryWebviewPanel", () => {
 					expect.objectContaining({ command: "prShowCreateForm" }),
 				);
 			});
+
+			it("cross-branch (Memory Bank): blocks Create PR with prCreateBlockedCrossBranch instead of opening the form", async () => {
+				// User has checked out branch Y but is looking at a summary on
+				// branch X in Memory Bank. Create PR must NOT push Y's HEAD to X's
+				// PR — block before the form opens.
+				(
+					stubBridge.getCurrentBranch as ReturnType<typeof vi.fn>
+				).mockResolvedValueOnce("feature/other-branch");
+				const dispatch = await setupPanel({ branch: "feature/test" });
+
+				dispatch({ command: "prepareCreatePr" });
+				await flushPromises();
+
+				expect(postMessage).toHaveBeenCalledWith({
+					command: "prCreateBlockedCrossBranch",
+					summaryBranch: "feature/test",
+					currentBranch: "feature/other-branch",
+				});
+				// Form must not open; loader must not be called.
+				expect(postMessage).not.toHaveBeenCalledWith(
+					expect.objectContaining({ command: "prShowCreateForm" }),
+				);
+				expect(mockLoadBranchSummaries).not.toHaveBeenCalled();
+				expect(showWarningMessage).toHaveBeenCalledWith(
+					expect.stringContaining("feature/test"),
+				);
+			});
 		});
 
 		describe("prepareUpdatePr", () => {
@@ -2797,6 +2861,7 @@ describe("SummaryWebviewPanel", () => {
 					"# update body",
 					workspaceRoot,
 					expect.any(Function),
+					"feature/test",
 				);
 			});
 
@@ -2821,10 +2886,36 @@ describe("SummaryWebviewPanel", () => {
 					"# aggregated update",
 					workspaceRoot,
 					expect.any(Function),
+					"feature/test",
 				);
 			});
 
-			it("appends missing-summary footnote on the single-summary fallback when missingCount > 0", async () => {
+			it("appends missing-summary footnote on the single-summary tier when missingCount > 0", async () => {
+				const branchSummary = makeSummary({
+					commitHash: "BRANCHONLY",
+					commitMessage: "the one summary",
+				});
+				mockLoadBranchSummaries.mockResolvedValueOnce({
+					summaries: [branchSummary],
+					missingCount: 4,
+					totalCount: 5,
+				});
+				mockBuildPrMarkdown.mockReturnValueOnce("# update body");
+				const dispatch = await setupPanel();
+
+				dispatch({ command: "prepareUpdatePr" });
+				await flushPromises();
+
+				const md = mockHandlePrepareUpdatePr.mock.calls[0][0];
+				expect(md).toContain("# update body");
+				expect(md).toContain(
+					"> Note: 4 commit(s) without summary were skipped.",
+				);
+			});
+
+			it("zero-summary fallback does NOT append footnote even when missingCount > 0", async () => {
+				// Same semantic as the prepareCreatePr counterpart: body from
+				// currentSummary should not carry a current-branch footnote.
 				mockLoadBranchSummaries.mockResolvedValueOnce({
 					summaries: [],
 					missingCount: 4,
@@ -2838,9 +2929,7 @@ describe("SummaryWebviewPanel", () => {
 
 				const md = mockHandlePrepareUpdatePr.mock.calls[0][0];
 				expect(md).toContain("# update body");
-				expect(md).toContain(
-					"> Note: 4 commit(s) without summary were skipped.",
-				);
+				expect(md).not.toContain("commit(s) without summary were skipped");
 			});
 
 			it("worker-busy: shows warning + re-runs handleCheckPrStatus to reset the button", async () => {
@@ -2872,10 +2961,33 @@ describe("SummaryWebviewPanel", () => {
 
 				expect(postMessage).toHaveBeenCalledWith({ command: "prDataLoaded" });
 			});
+
+			it("cross-branch (Memory Bank): skips branch aggregation and uses currentSummary for the body", async () => {
+				// On Y looking at X's summary in Memory Bank: aggregating Y's
+				// commits into X's PR description is misleading — force the
+				// single-summary fallback by skipping loadBranchSummaries.
+				(
+					stubBridge.getCurrentBranch as ReturnType<typeof vi.fn>
+				).mockResolvedValueOnce("feature/other-branch");
+				mockBuildPrMarkdown.mockReturnValueOnce("# clicked summary body");
+				const dispatch = await setupPanel({ branch: "feature/test" });
+
+				dispatch({ command: "prepareUpdatePr" });
+				await flushPromises();
+
+				expect(mockLoadBranchSummaries).not.toHaveBeenCalled();
+				expect(mockBuildAggregatedPrMarkdown).not.toHaveBeenCalled();
+				expect(mockHandlePrepareUpdatePr).toHaveBeenCalledWith(
+					"# clicked summary body",
+					workspaceRoot,
+					expect.any(Function),
+					"feature/test",
+				);
+			});
 		});
 
 		describe("updatePr", () => {
-			it("delegates to handleUpdatePr", async () => {
+			it("delegates to handleUpdatePr, passing summary.branch", async () => {
 				const dispatch = await setupPanel();
 
 				dispatch({ command: "updatePr", title: "Updated", body: "Body" });
@@ -2886,6 +2998,7 @@ describe("SummaryWebviewPanel", () => {
 					"Body",
 					workspaceRoot,
 					expect.any(Function),
+					"feature/test",
 				);
 			});
 

--- a/vscode/src/views/SummaryWebviewPanel.test.ts
+++ b/vscode/src/views/SummaryWebviewPanel.test.ts
@@ -304,14 +304,11 @@ const {
 	mockHandleCreatePr,
 	mockHandlePrepareUpdatePr,
 	mockHandleUpdatePr,
-	mockIsCommitReachableFromHead,
 } = vi.hoisted(() => ({
 	mockHandleCheckPrStatus: vi.fn().mockResolvedValue(undefined),
 	mockHandleCreatePr: vi.fn().mockResolvedValue(undefined),
 	mockHandlePrepareUpdatePr: vi.fn().mockResolvedValue(undefined),
 	mockHandleUpdatePr: vi.fn().mockResolvedValue(undefined),
-	// Default: commit IS reachable from HEAD (i.e., NOT cross-branch).
-	mockIsCommitReachableFromHead: vi.fn().mockResolvedValue(true),
 }));
 
 vi.mock("../services/PrCommentService.js", () => ({
@@ -319,7 +316,6 @@ vi.mock("../services/PrCommentService.js", () => ({
 	handleCreatePr: mockHandleCreatePr,
 	handlePrepareUpdatePr: mockHandlePrepareUpdatePr,
 	handleUpdatePr: mockHandleUpdatePr,
-	isCommitReachableFromHead: mockIsCommitReachableFromHead,
 	wrapWithMarkers: (s: string) => `[MARKERS]${s}[/MARKERS]`,
 }));
 
@@ -2561,8 +2557,6 @@ describe("SummaryWebviewPanel", () => {
 				expect(mockHandleCheckPrStatus).toHaveBeenCalledWith(
 					workspaceRoot,
 					expect.any(Function),
-					"feature/test",
-					"abc123",
 				);
 			});
 
@@ -2593,8 +2587,6 @@ describe("SummaryWebviewPanel", () => {
 					"PR Body",
 					workspaceRoot,
 					expect.any(Function),
-					"feature/test",
-					"abc123",
 				);
 			});
 
@@ -2689,21 +2681,67 @@ describe("SummaryWebviewPanel", () => {
 				);
 			});
 
-			it("uses single-summary path on cross-branch (commit not reachable from HEAD)", async () => {
-				mockIsCommitReachableFromHead.mockResolvedValueOnce(false);
-				mockBuildPrMarkdown.mockReturnValueOnce("# cross body");
-				const dispatch = await setupPanel({ commitMessage: "cross msg" });
+			it("branch has exactly 1 summary: uses summaries[0], NOT the webview's currentSummary", async () => {
+				// Branch-first guarantee: even if the panel was opened on a stale
+				// or different summary, when the current branch has one indexed
+				// summary the PR body/title come from THAT summary — the
+				// currentSummary is only a fallback for the length===0 tier.
+				const branchSummary = makeSummary({
+					commitHash: "BRANCH001",
+					commitMessage: "real branch commit",
+				});
+				mockLoadBranchSummaries.mockResolvedValueOnce({
+					summaries: [branchSummary],
+					missingCount: 0,
+					totalCount: 1,
+				});
+				mockBuildPrMarkdown.mockReturnValueOnce("# branch body");
+				const dispatch = await setupPanel({
+					commitHash: "STALEVIEW",
+					commitMessage: "stale viewer commit",
+				});
 
 				dispatch({ command: "prepareCreatePr" });
 				await flushPromises();
 
-				// Cross-branch must NOT call loadBranchSummaries.
-				expect(mockLoadBranchSummaries).not.toHaveBeenCalled();
+				// PR body source = summaries[0], not currentSummary
+				expect(mockBuildPrMarkdown).toHaveBeenCalledWith(
+					expect.objectContaining({ commitHash: "BRANCH001" }),
+				);
 				expect(mockBuildAggregatedPrMarkdown).not.toHaveBeenCalled();
 				expect(postMessage).toHaveBeenCalledWith({
 					command: "prShowCreateForm",
-					body: "[MARKERS]# cross body[/MARKERS]",
-					title: "cross msg",
+					body: "[MARKERS]# branch body[/MARKERS]",
+					title: "real branch commit",
+				});
+			});
+
+			it("branch has 0 summaries: falls back to currentSummary (rebase-not-yet-summarized tier)", async () => {
+				// Worker hasn't produced a summary for the rebased hash yet —
+				// the form should still be usable with the pre-rebase summary
+				// the webview was opened with.
+				mockLoadBranchSummaries.mockResolvedValueOnce({
+					summaries: [],
+					missingCount: 0,
+					totalCount: 0,
+				});
+				mockBuildPrMarkdown.mockReturnValueOnce("# fallback body");
+				const dispatch = await setupPanel({
+					commitHash: "PREREBASEHASH",
+					commitMessage: "pre-rebase msg",
+				});
+
+				dispatch({ command: "prepareCreatePr" });
+				await flushPromises();
+
+				expect(mockBuildPrMarkdown).toHaveBeenCalledWith(
+					expect.objectContaining({ commitHash: "PREREBASEHASH" }),
+				);
+				expect(mockBuildAggregatedPrMarkdown).not.toHaveBeenCalled();
+				expect(postMessage).toHaveBeenCalledWith({
+					command: "prShowCreateForm",
+					body: "[MARKERS]# fallback body[/MARKERS]",
+					title: "pre-rebase msg",
 				});
 			});
 
@@ -2756,8 +2794,6 @@ describe("SummaryWebviewPanel", () => {
 				await flushPromises();
 
 				expect(mockHandlePrepareUpdatePr).toHaveBeenCalledWith(
-					"feature/test",
-					"abc123",
 					"# update body",
 					workspaceRoot,
 					expect.any(Function),
@@ -2782,8 +2818,6 @@ describe("SummaryWebviewPanel", () => {
 
 				expect(mockBuildAggregatedPrMarkdown).toHaveBeenCalledWith([sA, sB], 0);
 				expect(mockHandlePrepareUpdatePr).toHaveBeenCalledWith(
-					"feature/test",
-					"abc123",
 					"# aggregated update",
 					workspaceRoot,
 					expect.any(Function),
@@ -2802,7 +2836,7 @@ describe("SummaryWebviewPanel", () => {
 				dispatch({ command: "prepareUpdatePr" });
 				await flushPromises();
 
-				const md = mockHandlePrepareUpdatePr.mock.calls[0][2];
+				const md = mockHandlePrepareUpdatePr.mock.calls[0][0];
 				expect(md).toContain("# update body");
 				expect(md).toContain(
 					"> Note: 4 commit(s) without summary were skipped.",
@@ -2826,8 +2860,6 @@ describe("SummaryWebviewPanel", () => {
 			it("forwards postMessage callback to the webview panel", async () => {
 				mockHandlePrepareUpdatePr.mockImplementationOnce(
 					(
-						_branch: string,
-						_hash: string,
 						_md: string,
 						_cwd: string,
 						pm: (msg: Record<string, unknown>) => void,
@@ -2854,8 +2886,6 @@ describe("SummaryWebviewPanel", () => {
 					"Body",
 					workspaceRoot,
 					expect.any(Function),
-					"feature/test",
-					"abc123",
 				);
 			});
 

--- a/vscode/src/views/SummaryWebviewPanel.test.ts
+++ b/vscode/src/views/SummaryWebviewPanel.test.ts
@@ -2847,6 +2847,34 @@ describe("SummaryWebviewPanel", () => {
 					expect.stringContaining("feature/test"),
 				);
 			});
+
+			it("detached HEAD / git error: gives a distinct message rather than asking the user to 'checkout HEAD'", async () => {
+				// Regression: `bridge.getCurrentBranch()` returns the sentinel
+				// string "HEAD" when git can't resolve the current branch
+				// (detached, .git/index.lock, permission). Telling the user to
+				// "Checkout HEAD" is nonsense — the repo is in a transient bad
+				// state, not on a different branch. We must surface that.
+				(
+					stubBridge.getCurrentBranch as ReturnType<typeof vi.fn>
+				).mockResolvedValueOnce("HEAD");
+				const dispatch = await setupPanel({ branch: "feature/test" });
+
+				dispatch({ command: "prepareCreatePr" });
+				await flushPromises();
+
+				expect(postMessage).toHaveBeenCalledWith({
+					command: "prCreateBlockedCrossBranch",
+					summaryBranch: "feature/test",
+					currentBranch: "HEAD",
+				});
+				// Distinct toast — NOT "Checkout HEAD to create its PR".
+				expect(showWarningMessage).toHaveBeenCalledWith(
+					expect.stringContaining("Cannot determine the current branch"),
+				);
+				expect(showWarningMessage).not.toHaveBeenCalledWith(
+					expect.stringContaining("Checkout HEAD"),
+				);
+			});
 		});
 
 		describe("prepareUpdatePr", () => {

--- a/vscode/src/views/SummaryWebviewPanel.ts
+++ b/vscode/src/views/SummaryWebviewPanel.ts
@@ -197,8 +197,12 @@ function isForeignSafeCommand(command: WebviewMessage["command"]): boolean {
 //   • 0 branch summaries  → fall back to currentSummary (rebase just happened
 //                           and the worker has not produced a summary for the
 //                           new commit hash yet — keeps the form usable)
-// `missingCount > 0` appends a "K skipped" footnote so partial-coverage
-// branches don't render as misleading.
+// `missingCount > 0` appends a "K skipped" footnote ONLY when summaries.length
+// >= 1 — the footnote contextualizes "alongside the branch summaries shown, N
+// more were skipped". On the 0-summary fallback the body comes from
+// currentSummary (possibly stale or from another branch), so a current-branch
+// "N skipped" note would describe commits unrelated to the body and read as
+// noise.
 function buildPrBodyMarkdown(
 	currentSummary: CommitSummary,
 	summaries: ReadonlyArray<CommitSummary>,
@@ -209,7 +213,7 @@ function buildPrBodyMarkdown(
 	}
 	const source = summaries.length === 1 ? summaries[0] : currentSummary;
 	const base = buildPrMarkdown(source);
-	if (missingCount <= 0) return base;
+	if (missingCount <= 0 || summaries.length === 0) return base;
 	return `${base}\n\n> Note: ${missingCount} commit(s) without summary were skipped.`;
 }
 
@@ -551,8 +555,10 @@ export class SummaryWebviewPanel {
 				);
 				break;
 			case "checkPrStatus":
-				handleCheckPrStatus(this.workspaceRoot, (msg) =>
-					this.panel.webview.postMessage(msg),
+				handleCheckPrStatus(
+					this.workspaceRoot,
+					(msg) => this.panel.webview.postMessage(msg),
+					this.currentSummary?.branch,
 				).catch((err: unknown) =>
 					log.error("SummaryPanel", `Check PR status failed: ${err}`),
 				);
@@ -564,6 +570,7 @@ export class SummaryWebviewPanel {
 						message.body,
 						this.workspaceRoot,
 						(msg) => this.panel.webview.postMessage(msg),
+						this.currentSummary?.branch,
 					),
 					"Create PR failed",
 				);
@@ -589,6 +596,7 @@ export class SummaryWebviewPanel {
 						this.workspaceRoot,
 						(msg: Record<string, unknown>) =>
 							this.panel.webview.postMessage(msg),
+						this.currentSummary?.branch,
 					),
 					"Update PR failed",
 				);
@@ -887,7 +895,27 @@ export class SummaryWebviewPanel {
 			return;
 		}
 
-		const { summaries, missingCount } = await this.loadCurrentBranchSummaries();
+		// Cross-branch guard: Create PR requires being checked out on the
+		// summary's branch (because `git push -u origin HEAD` pushes the current
+		// branch). Block before opening the form to avoid misleading the user.
+		if (summary.branch) {
+			const currentBranch = await this.bridge.getCurrentBranch();
+			if (summary.branch !== currentBranch) {
+				vscode.window.showWarningMessage(
+					`This summary is on branch ${summary.branch}. Checkout ${summary.branch} to create its PR.`,
+				);
+				postMessage({
+					command: "prCreateBlockedCrossBranch",
+					summaryBranch: summary.branch,
+					currentBranch,
+				});
+				return;
+			}
+		}
+
+		const { summaries, missingCount } = await this.loadBranchSummariesForPr(
+			summary.branch,
+		);
 		const markdown = buildPrBodyMarkdown(summary, summaries, missingCount);
 		const title = pickPrTitle(summary, summaries);
 		postMessage({
@@ -908,10 +936,17 @@ export class SummaryWebviewPanel {
 			return;
 		}
 
-		const { summaries, missingCount } = await this.loadCurrentBranchSummaries();
+		const { summaries, missingCount } = await this.loadBranchSummariesForPr(
+			summary.branch,
+		);
 		const markdown = buildPrBodyMarkdown(summary, summaries, missingCount);
 
-		await handlePrepareUpdatePr(markdown, this.workspaceRoot, postMessage);
+		await handlePrepareUpdatePr(
+			markdown,
+			this.workspaceRoot,
+			postMessage,
+			summary.branch,
+		);
 	}
 
 	// Returns true when worker is busy: shows the toast and re-runs the
@@ -925,14 +960,40 @@ export class SummaryWebviewPanel {
 		vscode.window.showWarningMessage(
 			"Jolli Memory: AI summary is being generated. Please wait a moment.",
 		);
-		await handleCheckPrStatus(this.workspaceRoot, postMessage);
+		await handleCheckPrStatus(
+			this.workspaceRoot,
+			postMessage,
+			this.currentSummary?.branch,
+		);
 		return true;
 	}
 
-	private async loadCurrentBranchSummaries(): Promise<{
+	/**
+	 * Loads summaries for PR body aggregation, scoped to the summary's branch.
+	 *
+	 * Memory Bank lets the user open any historical summary, including ones on
+	 * branches they're not currently checked out on. In that cross-branch case
+	 * aggregating `currentBranch`'s commits into a PR for `summaryBranch` is
+	 * misleading — the body would describe commits unrelated to that PR. So we
+	 * force the single-summary fallback by returning an empty array, and
+	 * `buildPrBodyMarkdown` / `pickPrTitle` fall back to the clicked summary.
+	 *
+	 * When `summaryBranch === currentBranch` (or `summaryBranch` is undefined),
+	 * we run the existing HEAD-based `loadBranchSummaries` to get the full
+	 * branch-aggregation behavior.
+	 */
+	private async loadBranchSummariesForPr(
+		summaryBranch: string | undefined,
+	): Promise<{
 		summaries: ReadonlyArray<CommitSummary>;
 		missingCount: number;
 	}> {
+		if (summaryBranch) {
+			const currentBranch = await this.bridge.getCurrentBranch();
+			if (summaryBranch !== currentBranch) {
+				return { summaries: [], missingCount: 0 };
+			}
+		}
 		const result = await loadBranchSummaries(this.bridge, this.mainBranch);
 		return {
 			summaries: result.summaries,

--- a/vscode/src/views/SummaryWebviewPanel.ts
+++ b/vscode/src/views/SummaryWebviewPanel.ts
@@ -898,12 +898,21 @@ export class SummaryWebviewPanel {
 		// Cross-branch guard: Create PR requires being checked out on the
 		// summary's branch (because `git push -u origin HEAD` pushes the current
 		// branch). Block before opening the form to avoid misleading the user.
+		//
+		// `bridge.getCurrentBranch()` returns the literal sentinel "HEAD" when
+		// `git rev-parse --abbrev-ref HEAD` yields nothing — detached HEAD,
+		// `.git/index.lock`, or permission failures. Telling the user to
+		// "checkout <summary.branch>" in that state is wrong (the repo is in
+		// a transient bad state, not on a different branch); they'd checkout
+		// and only then discover the real problem. Use a distinct message.
 		if (summary.branch) {
 			const currentBranch = await this.bridge.getCurrentBranch();
 			if (summary.branch !== currentBranch) {
-				vscode.window.showWarningMessage(
-					`This summary is on branch ${summary.branch}. Checkout ${summary.branch} to create its PR.`,
-				);
+				const message =
+					currentBranch === "HEAD"
+						? `Cannot determine the current branch (detached HEAD or git error). Resolve the repository state, then retry creating the PR for ${summary.branch}.`
+						: `This summary is on branch ${summary.branch}. Checkout ${summary.branch} to create its PR.`;
+				vscode.window.showWarningMessage(message);
 				postMessage({
 					command: "prCreateBlockedCrossBranch",
 					summaryBranch: summary.branch,

--- a/vscode/src/views/SummaryWebviewPanel.ts
+++ b/vscode/src/views/SummaryWebviewPanel.ts
@@ -71,7 +71,6 @@ import {
 	handleCreatePr,
 	handlePrepareUpdatePr,
 	handleUpdatePr,
-	isCommitReachableFromHead,
 	wrapWithMarkers,
 } from "../services/PrCommentService.js";
 import {
@@ -189,23 +188,50 @@ function isForeignSafeCommand(command: WebviewMessage["command"]): boolean {
 	return FOREIGN_SAFE_COMMANDS.has(command);
 }
 
-// Single source of truth for Create/Update PR body assembly. Aggregates
-// when the branch has 2+ summaries; otherwise falls back to single-summary
-// `buildPrMarkdown` and (when missingCount > 0) appends a "K skipped"
-// footnote so partial-coverage branches don't render as misleading
-// single-commit PRs.
+// Single source of truth for Create/Update PR body assembly. Branch-first
+// three-tier selection:
+//   • ≥2 branch summaries → aggregate them
+//   • 1 branch summary    → use that one (NOT currentSummary, which may be
+//                           stale or from another branch the webview was
+//                           opened on)
+//   • 0 branch summaries  → fall back to currentSummary (rebase just happened
+//                           and the worker has not produced a summary for the
+//                           new commit hash yet — keeps the form usable)
+// `missingCount > 0` appends a "K skipped" footnote so partial-coverage
+// branches don't render as misleading.
 function buildPrBodyMarkdown(
 	currentSummary: CommitSummary,
 	summaries: ReadonlyArray<CommitSummary>,
 	missingCount: number,
-	isCrossBranch: boolean,
 ): string {
-	if (!isCrossBranch && summaries.length >= 2) {
+	if (summaries.length >= 2) {
 		return buildAggregatedPrMarkdown(summaries, missingCount);
 	}
-	const base = buildPrMarkdown(currentSummary);
+	const source = summaries.length === 1 ? summaries[0] : currentSummary;
+	const base = buildPrMarkdown(source);
 	if (missingCount <= 0) return base;
 	return `${base}\n\n> Note: ${missingCount} commit(s) without summary were skipped.`;
+}
+
+/**
+ * Picks the commit message to use as the PR title, mirroring
+ * {@link buildPrBodyMarkdown}'s three-tier selection so title and body always
+ * come from the same source.
+ *   • ≥2 branch summaries → the last (most recent) one's message
+ *   • 1 branch summary    → that summary's message
+ *   • 0 branch summaries  → fall back to currentSummary's message
+ */
+function pickPrTitle(
+	currentSummary: CommitSummary,
+	summaries: ReadonlyArray<CommitSummary>,
+): string {
+	if (summaries.length >= 2) {
+		return summaries[summaries.length - 1].commitMessage;
+	}
+	if (summaries.length === 1) {
+		return summaries[0].commitMessage;
+	}
+	return currentSummary.commitMessage;
 }
 
 export class SummaryWebviewPanel {
@@ -525,11 +551,8 @@ export class SummaryWebviewPanel {
 				);
 				break;
 			case "checkPrStatus":
-				handleCheckPrStatus(
-					this.workspaceRoot,
-					(msg) => this.panel.webview.postMessage(msg),
-					this.currentSummary?.branch,
-					this.currentSummary?.commitHash,
+				handleCheckPrStatus(this.workspaceRoot, (msg) =>
+					this.panel.webview.postMessage(msg),
 				).catch((err: unknown) =>
 					log.error("SummaryPanel", `Check PR status failed: ${err}`),
 				);
@@ -541,8 +564,6 @@ export class SummaryWebviewPanel {
 						message.body,
 						this.workspaceRoot,
 						(msg) => this.panel.webview.postMessage(msg),
-						this.currentSummary?.branch,
-						this.currentSummary?.commitHash,
 					),
 					"Create PR failed",
 				);
@@ -568,8 +589,6 @@ export class SummaryWebviewPanel {
 						this.workspaceRoot,
 						(msg: Record<string, unknown>) =>
 							this.panel.webview.postMessage(msg),
-						this.currentSummary?.branch,
-						this.currentSummary?.commitHash,
 					),
 					"Update PR failed",
 				);
@@ -864,22 +883,13 @@ export class SummaryWebviewPanel {
 			this.panel.webview.postMessage(msg);
 		};
 
-		if (await this.handleWorkerBusyOrContinue(summary, postMessage)) {
+		if (await this.handleWorkerBusyOrContinue(postMessage)) {
 			return;
 		}
 
-		const { isCrossBranch, summaries, missingCount } =
-			await this.resolveBranchContext(summary);
-		const markdown = buildPrBodyMarkdown(
-			summary,
-			summaries,
-			missingCount,
-			isCrossBranch,
-		);
-		const useAggregate = !isCrossBranch && summaries.length >= 2;
-		const title = useAggregate
-			? summaries[summaries.length - 1].commitMessage
-			: summary.commitMessage;
+		const { summaries, missingCount } = await this.loadCurrentBranchSummaries();
+		const markdown = buildPrBodyMarkdown(summary, summaries, missingCount);
+		const title = pickPrTitle(summary, summaries);
 		postMessage({
 			command: "prShowCreateForm",
 			body: wrapWithMarkers(markdown),
@@ -894,32 +904,19 @@ export class SummaryWebviewPanel {
 			this.panel.webview.postMessage(msg);
 		};
 
-		if (await this.handleWorkerBusyOrContinue(summary, postMessage)) {
+		if (await this.handleWorkerBusyOrContinue(postMessage)) {
 			return;
 		}
 
-		const { isCrossBranch, summaries, missingCount } =
-			await this.resolveBranchContext(summary);
-		const markdown = buildPrBodyMarkdown(
-			summary,
-			summaries,
-			missingCount,
-			isCrossBranch,
-		);
+		const { summaries, missingCount } = await this.loadCurrentBranchSummaries();
+		const markdown = buildPrBodyMarkdown(summary, summaries, missingCount);
 
-		await handlePrepareUpdatePr(
-			summary.branch,
-			summary.commitHash,
-			markdown,
-			this.workspaceRoot,
-			postMessage,
-		);
+		await handlePrepareUpdatePr(markdown, this.workspaceRoot, postMessage);
 	}
 
 	// Returns true when worker is busy: shows the toast and re-runs the
 	// status check so the click-time "Loading..." button gets rebuilt.
 	private async handleWorkerBusyOrContinue(
-		summary: CommitSummary,
 		postMessage: (msg: Record<string, unknown>) => void,
 	): Promise<boolean> {
 		if (!(await isWorkerBusy(this.workspaceRoot))) {
@@ -928,30 +925,16 @@ export class SummaryWebviewPanel {
 		vscode.window.showWarningMessage(
 			"Jolli Memory: AI summary is being generated. Please wait a moment.",
 		);
-		await handleCheckPrStatus(
-			this.workspaceRoot,
-			postMessage,
-			summary.branch,
-			summary.commitHash,
-		);
+		await handleCheckPrStatus(this.workspaceRoot, postMessage);
 		return true;
 	}
 
-	private async resolveBranchContext(summary: CommitSummary): Promise<{
-		isCrossBranch: boolean;
+	private async loadCurrentBranchSummaries(): Promise<{
 		summaries: ReadonlyArray<CommitSummary>;
 		missingCount: number;
 	}> {
-		const isCrossBranch = !(await isCommitReachableFromHead(
-			this.workspaceRoot,
-			summary.commitHash,
-		));
-		if (isCrossBranch) {
-			return { isCrossBranch: true, summaries: [], missingCount: 0 };
-		}
 		const result = await loadBranchSummaries(this.bridge, this.mainBranch);
 		return {
-			isCrossBranch: false,
 			summaries: result.summaries,
 			missingCount: result.missingCount,
 		};


### PR DESCRIPTION
<!-- jollimemory-summary-start -->
## Commits in this PR (4)

1. Refactor PR ops to branch-only scope, remove cross-branch logic (`9e9299e`)
2. Route PR ops to summaryBranch with cross-branch guard (`e389787`)
3. Address PR review: button refresh, error reasons, repo-state guards (`f66cc66`)
4. Refactor findPrForBranch to return PrLookup union, surface lookupError as unavailable instead of noPr (`e0c876d`)

## Quick recap (4)

### Commit 1 of 4: Refactor PR ops to branch-only scope, remove cross-branch logic (`9e9299e`)

This commit removed all commit-level gating from the pull request workflow in the VS Code extension, replacing it with a simpler branch-scoped model. Previously, PR creation and updates checked whether the summary's recorded commit hash was reachable from the current branch's HEAD — a check that broke after a rebase, because the rewritten commits have new hashes even though the work is identical. The developer explored a reverse-alias lookup approach first, simulated it successfully, but ultimately concluded that PR operations are inherently branch-level actions and the commit check was never architecturally necessary. The new model always operates on the currently checked-out branch, regardless of which summary the webview has open. PR body generation was also improved to prefer summaries belonging to the current branch, only falling back to the webview's open summary when the branch has no summaries at all. Nine cross-branch-specific tests were removed and three new regression tests were added covering the rebase scenario, the single-summary branch-first case, and the empty-branch fallback.

### Commit 2 of 4: Route PR ops to summaryBranch with cross-branch guard (`e389787`)

This commit corrected a fundamental routing mistake in how the extension's PR operations determined which pull request to display and act on. Previously, all PR actions — checking status, editing descriptions, and creating new PRs — were scoped to whichever branch the user currently had checked out, ignoring the branch recorded in the summary being viewed. This broke the Memory Bank feature, where users can freely browse summaries from any branch: clicking a summary from branch X while on branch Y would show Y's PR instead of X's. The fix routes all read and edit operations through the branch stored in the summary itself, while adding a targeted guard for the Create PR action, which physically requires the user to be checked out on the correct branch before pushing. A secondary bug was also fixed where a "skipped commits" footnote was incorrectly appended to PR descriptions even when no branch summaries were available, producing a note that described commits unrelated to the body being shown.

### Commit 3 of 4: Address PR review: button refresh, error reasons, repo-state guards (`f66cc66`)

This commit addressed several issues raised in a pull request review for the PR operations feature. The most visible fix prevents the "Edit PR" button from getting permanently stuck in a loading state when a pull request can no longer be found — previously the code would show a warning and return silently, leaving the button disabled forever; now it re-runs the status check so the section repaints itself. A second fix surfaces the real reason when PR status cannot be loaded, distinguishing git failures (detached HEAD, lock files, permission errors) from GitHub CLI failures, which had previously all been reported with the same misleading message. A third fix gives a distinct, actionable warning when the repository is in a broken state (detached HEAD) rather than incorrectly telling the user to check out a branch. The commit also removed an internal team name from a code comment, and added several contract tests to pin down routing behavior after branch renames and to guard against silent removal of the cross-branch button-reset handler.

### Commit 4 of 4: Refactor findPrForBranch to return PrLookup union, surface lookupError as unavailable instead of noPr (`e0c876d`)

The extension previously could not tell the difference between a branch that genuinely has no pull request and a branch whose pull request lookup failed due to an expired token, a rate limit, or a network error. In all failure cases, the UI fell back to showing a "Create PR" button — a button that would either error out or silently create a duplicate pull request when clicked after an authentication lapse. The PR lookup function was refactored to return one of three distinct outcomes — found, confirmed absent, or lookup failed — and each call site was updated to handle all three. Lookup failures now route through the existing "unavailable" display path, which already shows the real error reason and a Retry button, leaving the webview itself unchanged.

The real CLI error output, such as an HTTP 401 message, is now surfaced directly in the UI rather than replaced with a generic failure notice. Users and support staff can see the actual cause without digging through extension logs. The Edit PR button's loading state is also no longer left permanently stuck when a lookup fails mid-edit — an error toast appears and the PR status section repaints immediately. Test mocks were corrected to match the shape of real CLI errors, closing a pre-existing gap where the wrong code branch was being exercised in tests.

## E2E Test (3)
<details>
<summary><strong>1. [9e9299e] Create PR works normally after rebasing a branch</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a local Git repository open in VS Code with the Jolli Memory extension installed. Make sure you have at least one memory summary recorded on a feature branch, then rebase that branch onto main (which rewrites the commit hashes).

**Steps:**
1. After rebasing your feature branch, open the Jolli Memory panel in VS Code without switching branches.
2. Open a memory summary that was recorded before the rebase.
3. Scroll down to the pull request section of the summary panel.
4. Verify that a "Create PR" button is visible (not a warning about checking out a different branch).
5. Click "Create PR" and wait for the loading indicator to finish.
6. Check that a success message appears and the PR section updates to show the newly created pull request link.

**Expected Results:**
- The "Create PR" button should be visible immediately after the rebase, with no error or warning about the commit not being in the current branch's history.
- Clicking "Create PR" should successfully create the pull request without showing a "Cannot create a PR" warning message.
- The PR section should refresh and display the new pull request number and a link to it.

</blockquote>
</details>
<details>
<summary><strong>2. [e389787] Viewing a historical summary from another branch shows that branch's PR status</strong></summary>
<br>
<blockquote>

**Preconditions:** Have two branches in the repository — one currently checked out (e.g. "feature/current") and one with a historical summary stored in Memory Bank (e.g. "feature/other"). The "feature/other" branch should have an open pull request on GitHub.

**Steps:**
1. Open the Memory Bank panel in the extension and browse to a summary that was generated on "feature/other" while you are checked out on "feature/current".
2. Click the "Check PR Status" button on that summary.
3. Check the PR status result displayed in the panel.
4. Confirm the branch name shown in the status matches "feature/other", not "feature/current".

**Expected Results:**
- The PR status displayed reflects the pull request for "feature/other", not the currently checked-out "feature/current".
- The branch label shown alongside the status reads "feature/other".

</blockquote>
</details>
<details>
<summary><strong>3. [e389787] Editing a PR description targets the summary's branch, not the checked-out branch</strong></summary>
<br>
<blockquote>

**Preconditions:** Have two branches — one currently checked out (e.g. "feature/current") and one with a summary in Memory Bank (e.g. "feature/other") that has an open pull request on GitHub.

**Steps:**
1. Open the Memory Bank panel and navigate to a summary on "feature/other" while "feature/current" is checked out.
2. Click the button to update or edit the PR description for that summary.
3. Observe which PR's title and body are pre-filled in the edit form.
4. Submit the update and confirm the result.

**Expected Results:**
- The edit form pre-fills with the title and body from "feature/other"'s pull request, not "feature/current"'s.
- After submitting, the PR on "feature/other" is updated on GitHub.
- The PR status shown in the panel reflects "feature/other"'s PR.

</blockquote>
</details>

## Topics (9)
<details>
<summary><strong>01 · [9e9299e] Remove commit reachability gate that blocked PR creation after rebase</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

A teammate reported that after rebasing a branch, clicking "Create PR" showed an error saying the memory's commit was not in the current branch's history. The rebase rewrites commit hashes, so the stale hash held by the open webview panel was no longer recognized as part of the branch — even though the work was identical.

**💡 Decisions Behind the Code**

- **Branch model over commit alias lookup**: An alternative approach using the existing commit-alias index was explored and successfully simulated — after a rebase, the index maps new hashes back to old ones, so a reverse lookup could find a reachable replacement hash. This was rejected because it adds a timing dependency (the background worker must finish scanning before the user clicks), increases complexity, and perpetuates the conceptually wrong model that PR operations are commit-scoped. Switching to a pure branch model is simpler, more predictable, and matches how GitHub itself treats PRs.
- **Branch-first fallback order for PR body**: The original plan used the webview's open summary as the sole fallback for single-summary branches, which meant a user viewing a summary from a different branch could accidentally populate the current branch's PR with unrelated content. The three-tier approach (aggregate → single branch summary → open summary) ensures the current branch's own content is always preferred, with the open-summary fallback reserved only for the narrow window where the branch index is temporarily empty after a rebase.
- **Removing cross-branch Update PR routing**: The old model allowed a user to update a PR on branch Y while checked out on branch X, by routing the GitHub API call through the summary's stored branch name. This capability was removed rather than preserved, because it creates an unpredictable mental model and was not known to be actively used. The simpler rule — PR operations always target the current branch — is easier to reason about and eliminates an entire class of routing bugs.

**✅ What Was Implemented**

- The cross-branch detection logic was removed from all four PR handlers in `PrCommentService.ts`. Each handler now resolves the target branch by simply reading the current checkout, eliminating the `git merge-base --is-ancestor` probe and the `summaryBranch`/`summaryCommitHash` parameters from all public signatures. The `isCommitReachableFromHead` helper function and its surrounding documentation block were deleted entirely.
- The webview JavaScript in `PrCommentService.ts` was simplified: the `noPr` state no longer branches on a `crossBranch` flag. The "Create PR" button is now always shown when no PR exists for the current branch, and the cross-branch warning message path was removed.
- In `SummaryWebviewPanel.ts`, PR body and title generation were updated to a branch-first three-tier strategy: aggregate when the branch has two or more summaries, use the single branch summary when there is exactly one, and only fall back to the webview's currently open summary when the branch has no summaries at all (covering the window between a rebase and the background worker catching up).

**📋 Future Enhancements**

The PR body and title selection each independently repeat the same three-tier branch-first logic. Extracting a shared helper with a discriminated-union return type was discussed and noted as a follow-up to prevent the two from drifting apart in future changes.

**📁 FILES**
- `vscode/src/services/PrCommentService.ts`
- `vscode/src/views/SummaryWebviewPanel.ts`

</blockquote>
</details>
<details>
<summary><strong>02 · [e389787] PR operations now follow the viewed summary's branch, not the current checkout</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

When browsing historical summaries in Memory Bank, all PR actions — checking status, editing descriptions, and creating PRs — were incorrectly scoped to the user's currently checked-out branch rather than the branch the summary was generated on. This meant viewing a summary from branch X while on branch Y would show Y's PR, edit Y's PR body, and potentially push Y's commits into X's PR.

**💡 Decisions Behind the Code**

- **Route by summary branch, not current checkout**: The earlier design assumed the webview was always opened from the active working context, making the current branch and the summary branch effectively identical. Memory Bank broke this assumption by making cross-branch browsing a primary workflow. Routing by the summary's recorded branch is the only model consistent with the webview acting as a fixed pointer to a specific branch's history rather than a live view of the current workspace state.
- **Create PR requires physical checkout; all other operations do not**: Checking PR status and editing a PR description can be performed against any branch remotely without being checked out on it. Creating a PR, however, requires pushing the local branch to the remote, which is a physical operation tied to the current checkout. Rather than blocking all PR actions on cross-branch views, only the create action is guarded, preserving full read and edit capability from Memory Bank while preventing the footgun of pushing the wrong branch's commits.
- **Block cross-branch create at the panel layer before loading summaries**: The guard is enforced before any branch summary loading or form preparation begins, not after. This avoids wasted work and ensures the user sees an immediate, clear message rather than a partially loaded form that then fails. A matching guard also exists in the service layer as a second line of defense, so the protection holds even if the panel layer is bypassed.

**✅ What Was Implemented**

- In the PR service layer, all four exported handler functions — check status, prepare create, create, and prepare/execute update — gained an optional branch parameter. Each function now resolves its target branch from this parameter first, falling back to the current checkout only when no summary branch is provided. The create handler additionally reads the current branch upfront to enforce the cross-branch guard before any push or PR creation runs.
- In the webview panel, every dispatch case that invokes a PR handler was updated to pass the branch recorded on the currently displayed summary. The worker-busy fallback path that re-runs the status check was also updated to carry the summary branch through, preventing a stale re-check from reverting to the wrong branch.
- The PR body aggregation path was split into a branch-aware loader: when the user is viewing a summary from a different branch than the one checked out, the aggregation step is skipped entirely and the body falls back to the single summary being viewed, preventing commits from the wrong branch from appearing in the PR description.

**📁 FILES**
- `vscode/src/services/PrCommentService.ts`
- `vscode/src/views/SummaryWebviewPanel.ts`

</blockquote>
</details>
<details>
<summary><strong>03 · [e389787] Skipped-commits footnote removed from PR descriptions when no branch summaries exist</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

A reviewer identified that the "N commits without summary were skipped" footnote was being appended to PR descriptions even in the zero-summary fallback case, where the body is sourced from the currently viewed summary rather than from branch history. In that situation the footnote described commits entirely unrelated to the body content, making it misleading noise.

**💡 Decisions Behind the Code**

- **Footnote only contextualizes summaries that are actually shown**: The footnote's purpose is to tell the reader "alongside the branch summaries you see here, N more commits were omitted." When the body comes from the fallback single-summary path, there are no branch summaries shown, so the note has no referent and reads as confusing. Gating on a nonzero summary count makes the footnote semantically accurate in all cases without requiring a separate code path for the fallback.

**✅ What Was Implemented**

The footnote logic in the PR body builder was tightened to require at least one branch summary to be present before appending the note. Two existing tests that had been asserting the incorrect behavior — using an empty summary list while expecting a footnote — were corrected to use a real single-summary fixture. Two new tests were added to explicitly assert that the zero-summary fallback path produces no footnote even when the missing-count is nonzero, covering both the create and update preparation flows.

**📋 Future Enhancements**

Branch rename auto-correction was discussed as a follow-up: when a summary's recorded branch no longer exists locally, the system should attempt to resolve the new name via git reflog, local branch tip scanning, and remote PR lookup before falling back to a user-visible error. This was explicitly deferred to a separate spike to keep the current routing fix narrow and reviewable.

**📁 FILES**
- `vscode/src/views/SummaryWebviewPanel.ts`

</blockquote>
</details>
<details>
<summary><strong>04 · [f66cc66] Edit PR button permanently stuck in loading after PR disappears</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

If a pull request was closed by a teammate while a user had the panel open, clicking "Edit PR" would set the button to a loading/disabled state and never recover — the code showed a warning toast and returned without sending any message back to the panel to reset the UI.

**💡 Decisions Behind the Code**

- **Re-run status flow rather than sending a targeted reset message**: The symmetrical fix would have been to send a dedicated "reset button" message, mirroring how the update-failed path works. Instead, re-running the full status check was chosen because it repaints the entire section from scratch, which is more robust — it handles any intermediate state the section might be in and keeps the no-PR and update-failed paths consistent in their recovery behavior.

**✅ What Was Implemented**

- In `PrCommentService.ts`, the no-PR path inside `handlePrepareUpdatePr` was extended to call `handleCheckPrStatus` before returning. This causes the panel section to fully repaint with a fresh status (either "no PR" or "ready"), which rebuilds the button from scratch and clears the stuck loading state.
- The corresponding test in `PrCommentService.test.ts` was rewritten: the old assertion (`postMessage` not called) was replaced with a positive assertion that a `prStatus` message with `status: "noPr"` is sent, and the mock setup was expanded to simulate a realistic gh CLI "no pull requests found" response rather than a generic throw.

**📁 FILES**
- `vscode/src/services/PrCommentService.ts`

</blockquote>
</details>
<details>
<summary><strong>05 · [f66cc66] PR status error message blames wrong tool when git is the actual failure</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

When checking PR status failed due to a git problem (such as a detached HEAD, a locked index file, or a permission error), the panel always displayed a message saying it could not reach the GitHub CLI — which was wrong and sent users looking in the wrong place.

**💡 Decisions Behind the Code**

- **Additive `reason` field rather than replacing the message**: Adding an optional field to the existing message type meant zero risk of breaking callers that don't yet read it, and the webview could degrade gracefully to the old text when the field is absent. Changing the message type or splitting into two message commands would have required coordinated updates across more code paths.

**✅ What Was Implemented**

- In `PrCommentService.ts`, the outer catch block in `handleCheckPrStatus` was changed to include the actual error message as a `reason` field on the `prStatus` unavailable message, rather than sending a bare status with no detail.
- In the webview JavaScript (also in `PrCommentService.ts`), the unavailable status handler was updated to prefer the `reason` field when present, displaying "Could not load PR status — [reason]" instead of the hardcoded GitHub CLI message. The original fallback text is preserved when no reason is provided.
- Two existing tests in `PrCommentService.test.ts` were updated to assert the new `reason` field is present in the posted message, confirming the real error text is forwarded.

**📁 FILES**
- `vscode/src/services/PrCommentService.ts`

</blockquote>
</details>
<details>
<summary><strong>06 · [f66cc66] Detached HEAD state misidentified as wrong-branch checkout error</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

When the repository was in a broken state (detached HEAD, locked git index, or permission failure), the panel's cross-branch guard would tell the user to "Checkout HEAD to create its PR" — which is nonsensical and would send them on a fruitless checkout attempt before they discovered the real problem.

**💡 Decisions Behind the Code**

- **Sentinel string check at the panel layer**: The bridge layer already returned the literal string "HEAD" as a sentinel for all git-broken states, so checking for it at the point of message construction was the lowest-risk fix — it required no changes to the bridge contract and no new error types. The trade-off is that the sentinel is an implicit convention rather than a typed result, but changing the bridge return type was considered out of scope for this review-fix pass.

**✅ What Was Implemented**

- In `SummaryWebviewPanel.ts`, the cross-branch guard inside `prepareCreatePr` was extended to check whether the resolved current branch is the sentinel string "HEAD" before choosing which warning message to show. When it is, a distinct message is displayed explaining that the current branch cannot be determined and asking the user to resolve the repository state first.
- A new test in `SummaryWebviewPanel.test.ts` asserts that the distinct "Cannot determine the current branch" message is shown and that the old "Checkout HEAD" phrasing is never used.

**📁 FILES**
- `vscode/src/views/SummaryWebviewPanel.ts`

</blockquote>
</details>
<details>
<summary><strong>07 · [f66cc66] Contract tests for branch routing after rename and cross-branch button reset</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Two behavioral contracts had no tests pinning them down: that a summary's original branch always wins for PR lookup even after the user renames the branch, and that the cross-branch guard's button-reset handler in the webview JavaScript cannot be silently removed by a linter or dead-code sweep.

**💡 Decisions Behind the Code**

- **Explicit string-presence tests for webview JavaScript**: The webview script is built as a string at runtime, so type-checking and import analysis cannot catch dead-code removal. A lightweight string-contains assertion was chosen as the lowest-cost way to make the contract machine-checkable, accepting that it tests the rendered output rather than behavior directly.
- **Stale-branch routing as an explicit contract, not auto-recovery**: The test deliberately asserts that the old branch name is used and the mismatch is surfaced to the user, rather than testing any automatic retargeting. This was a conscious design choice documented in the plan: auto-recovery from renames is deferred to a future spike, and the test locks in the current behavior so that future work cannot accidentally introduce silent retargeting without a deliberate contract change.

**✅ What Was Implemented**

- A new test in `PrCommentService.test.ts` covers the post-rename routing contract: it simulates a user who has renamed their branch, confirms that the PR lookup is issued against the original (stale) branch name, and asserts that the status message names that stale branch — making the mismatch visible to the user rather than silently retargeting.
- A new test for `buildPrMessageScript` asserts that the rendered webview JavaScript contains the cross-branch command handler token and references both the section-level and form-level button identifiers, so any automated cleanup that removes the handler will immediately break the test suite.

**📋 Future Enhancements**

Implement automatic PR retargeting after branch rename as a separate spike — the current behavior surfaces the stale branch name to the user but does not recover automatically. This was explicitly deferred and noted in the plan documentation.

**📁 FILES**
- `vscode/src/services/PrCommentService.test.ts`
- `vscode/src/views/SummaryWebviewPanel.test.ts`

</blockquote>
</details>
<details>
<summary><strong>08 · [e0c876d] Distinguish genuine &quot;no PR&quot; from lookup failure to prevent misleading Create PR button</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

When the GitHub CLI failed due to an expired token, rate limiting, or a network error, the extension showed the same "Create PR" button it shows when a branch truly has no pull request. A user clicking that button after a token lapse would either get an error or accidentally create a duplicate pull request.

**💡 Decisions Behind the Code**

- **Reuse the existing unavailable channel rather than adding a new UI state**: The webview already had an "unavailable" display path wired up in a prior session, complete with a reason string and a Retry button. Routing lookup-error through that same channel meant zero webview changes and no new UI states to test or maintain. A dedicated "lookup failed" state would have added complexity for no user-visible benefit.
- **Surface the real CLI stderr as the error reason**: Rather than showing a generic "lookup failed" message, the reason field is populated with the actual stderr line from the CLI (for example, "HTTP 401: Bad credentials"). This gives users and support staff actionable information immediately, at the cost of occasionally exposing raw CLI output. The trade-off was judged worthwhile because a generic message would force users to dig through extension logs to understand what went wrong.
- **Correct test mocks to match real CLI error shape**: The existing tests threw plain JavaScript errors to simulate CLI failures, but the production code reads the stderr field from the error object — a field that plain errors do not have. Fixing the mocks to attach stderr as a property made the tests accurately reflect real CLI behavior and exposed which cases should now route to lookup-error instead of no-PR.

**✅ What Was Implemented**

- The PR lookup function's return type was changed from a nullable value to a three-way discriminated union: found, no-PR, and lookup-error. The lookup-error case now captures the real failure reason (the CLI's stderr output or a parse-failure message) instead of discarding it. Unparseable CLI output, which previously also collapsed into no-PR, now produces a lookup-error with a descriptive reason string.
- All three call sites were updated to handle the new union. The status-check handler routes lookup-error through the existing "unavailable + reason" display channel, giving the user the real cause and a Retry button. The prepare-edit and submit-edit handlers each show an error toast with the real reason and then repaint the PR status section so the Edit PR button's loading state is not left permanently stuck.
- Test mocks were corrected to attach a stderr property to simulated error objects, matching the shape of real CLI errors. Previously, plain JavaScript errors were thrown, which caused the wrong code branch to be exercised in tests and masked the gap between the no-PR and lookup-error paths.

**📁 FILES**
- `vscode/src/services/PrCommentService.ts`

</blockquote>
</details>
<details>
<summary><strong>09 · [e0c876d] Rebase current branch onto updated remote main after merge conflict</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The remote main branch had moved forward with new commits while the developer's branch was in progress, and the branch needed to be brought up to date before continuing work.

**💡 Decisions Behind the Code**

- **Rebase over merge**: A rebase was chosen rather than a merge commit to keep the branch history linear and avoid a noisy merge bubble in the log. This is the standard approach for feature branches in this repository and keeps the eventual pull request diff clean.
- **Stash version-noise before rebasing**: Minor version-number changes in working-tree files were stashed before the rebase began rather than committed or discarded. This avoided polluting the rebase with unrelated changes while still preserving them for later, at the cost of a small extra step to restore afterward.

**✅ What Was Implemented**

- Fetched the latest remote main and identified five new upstream commits, one of which touched a file already modified on the current branch, creating a rebase conflict in the webview panel source file. The conflict was resolved by preserving both the upstream multi-repo infrastructure additions and the local comment changes to the PR body builder function.
- After the rebase completed cleanly with all subsequent commits applying without issue, a missing sign-off was detected on the earliest rebased commit. The commit was amended to add the required sign-off, restoring compliance with the repository's contribution policy.

**📁 FILES**
- `SummaryWebviewPanel.ts`

</blockquote>
</details>

---

*Generated by Jolli Memory · May 12, 2026 at 10:48 AM*
<!-- jollimemory-summary-end -->