### PR TITLE
Add JM space binding dialog and 412 binding-required handling

### DIFF
--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/bridge/GitRemoteUtils.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/bridge/GitRemoteUtils.kt
@@ -1,0 +1,196 @@
+package ai.jolli.jollimemory.bridge
+
+import java.net.URI
+
+/**
+ * GitRemoteUtils
+ *
+ * Resolves a workspace's canonical remote URL for the Jolli Memory push
+ * contract. The returned string is the stable identity key the server uses
+ * to look up `jolli_memory_repo_bindings`, so the same physical repo must
+ * always yield the same string regardless of clone transport or owner/repo
+ * casing the user happened to type in their `git clone` invocation.
+ *
+ * Mirrors `vscode/src/util/GitRemoteUtils.ts` byte-for-byte in normalization
+ * behavior — any change must be made in both places, otherwise a VS Code
+ * teammate and an IntelliJ teammate on the same repo will produce different
+ * `repoUrl` keys and end up with two separate bindings.
+ *
+ * Normalization rules:
+ *   - SSH scp form `git@host:owner/repo[.git]`          → `https://host/owner/repo`
+ *   - SSH URL  `ssh://git@host[:port]/path[.git]`       → `https://host[:port]/path`
+ *   - git URL  `git://host[:port]/path[.git]`           → `https://host[:port]/path`
+ *   - HTTP(S):  strip trailing `.git`, lower-case scheme + host
+ *   - No remote configured: fall back to `file://<workspaceRoot>` (forward slashes)
+ *
+ * Port handling:
+ *   - HTTP(S): always preserve the port (self-hosted forges on non-default
+ *     HTTPS ports are common).
+ *   - ssh / git: preserve the port unless it's the scheme's default (22 / 9418).
+ *
+ * Path-case handling:
+ *   - github.com / gitlab.com / bitbucket.org → lowercase path (these hosts
+ *     route owner/repo case-insensitively; not lowercasing would let two
+ *     clones with different casing fork into separate bindings).
+ *   - All other hosts → preserve path case (self-hosted Gitea/GitLab can be
+ *     case-sensitive; silently lowercasing would merge distinct repos).
+ *
+ * Trailing slashes and a single trailing `.git` are stripped.
+ */
+object GitRemoteUtils {
+
+    private val CASE_INSENSITIVE_PATH_HOSTS: Set<String> = setOf(
+        "github.com",
+        "gitlab.com",
+        "bitbucket.org",
+    )
+
+    /**
+     * Default wire ports for ssh / git. A port equal to the default carries
+     * no identity information, so `ssh://host:22/x` collapses with `ssh://host/x`.
+     * http/https are intentionally absent — keep whatever the user typed,
+     * since self-hosted forges sometimes serve on `:443`/`:80` explicitly.
+     */
+    private val SSH_GIT_DEFAULT_PORTS: Map<String, String> = mapOf(
+        "ssh" to "22",
+        "git" to "9418",
+    )
+
+    private val SSH_SCP_REGEX = Regex("""^([A-Za-z0-9_.+-]+@)([^:/\s]+):(.+)$""")
+
+    /** Returns the canonical, server-facing repo URL for the given workspace root. */
+    fun getCanonicalRepoUrl(workspaceRoot: String): String {
+        val remote = GitOps(workspaceRoot)
+            .exec("config", "--get", "remote.origin.url")
+            ?.trim()
+            .orEmpty()
+        if (remote.isEmpty()) {
+            return toFileUrl(workspaceRoot)
+        }
+        return normalizeRemoteUrl(remote, workspaceRoot)
+    }
+
+    /** Normalizes a remote URL string into the canonical form. Visible for tests. */
+    fun normalizeRemoteUrl(remote: String, workspaceRootForFallback: String): String {
+        val trimmed = remote.trim()
+        if (trimmed.isEmpty()) {
+            return toFileUrl(workspaceRootForFallback)
+        }
+
+        if (!trimmed.contains("://")) {
+            val sshMatch = SSH_SCP_REGEX.matchEntire(trimmed)
+            if (sshMatch != null) {
+                val host = sshMatch.groupValues[2].lowercase()
+                val pathPart = normalizePathCase(host, stripGitSuffixAndSlashes(sshMatch.groupValues[3]))
+                return "https://$host/$pathPart"
+            }
+        }
+
+        val parsed = try {
+            URI(trimmed)
+        } catch (_: Exception) {
+            return toFileUrl(workspaceRootForFallback)
+        }
+
+        val scheme = parsed.scheme?.lowercase()
+        if (scheme == "ssh" || scheme == "git" || scheme == "http" || scheme == "https") {
+            val host = parsed.host?.lowercase()
+                ?: return toFileUrl(workspaceRootForFallback)
+            val rawPath = parsed.path.orEmpty().trimStart('/')
+            val pathPart = normalizePathCase(host, stripGitSuffixAndSlashes(rawPath))
+            val port = if (parsed.port == -1) "" else parsed.port.toString()
+            val portSegment = canonicalPortSegment(scheme, port)
+            return "https://$host$portSegment/$pathPart"
+        }
+
+        if (scheme == "file") {
+            return toFileUrl(parsed.path.orEmpty())
+        }
+
+        return toFileUrl(workspaceRootForFallback)
+    }
+
+    /** Mirrors the server's `deriveRepoName` spec — used as the chooser default only. */
+    fun deriveRepoNameFromUrl(repoUrl: String): String {
+        val trimmed = repoUrl.trim()
+        if (trimmed.isEmpty()) {
+            return ""
+        }
+        val parsed = try {
+            URI(trimmed)
+        } catch (_: Exception) {
+            return trimmed.take(120)
+        }
+
+        val scheme = parsed.scheme?.lowercase()
+        val lastSegment = lastNonEmptyPathSegment(parsed.path.orEmpty())
+        if (scheme == "http" || scheme == "https" || scheme == "ssh" || scheme == "git") {
+            if (lastSegment.isNotEmpty()) {
+                return stripGitSuffixOnly(lastSegment)
+            }
+            return parsed.host?.lowercase().orEmpty()
+        }
+        if (scheme == "file") {
+            return if (lastSegment.isNotEmpty()) lastSegment else trimmed.take(120)
+        }
+        return trimmed.take(120)
+    }
+
+    /**
+     * Sanitizes a branch name into a path-safe slug for use inside `relativePath`.
+     * Mirrors the server's `stripPathUnsafeChars` (replace anything outside
+     * `[A-Za-z0-9._-]` and `/` with `_`, collapse runs, trim leading/trailing
+     * `_` and `/`).
+     */
+    fun sanitizeBranchSlug(branch: String?): String {
+        val raw = branch?.trim().orEmpty()
+        if (raw.isEmpty()) {
+            return "_"
+        }
+        val replaced = raw.replace(Regex("[^A-Za-z0-9._\\-/]"), "_")
+        val collapsed = replaced.replace(Regex("_+"), "_").replace(Regex("/+"), "/")
+        val trimmed = collapsed.trim('_', '/')
+        return trimmed.ifEmpty { "_" }
+    }
+
+    // ── Internal helpers ──────────────────────────────────────────────────
+
+    private fun toFileUrl(absolutePath: String): String {
+        val forward = absolutePath.replace('\\', '/').trimEnd('/')
+        if (forward.isEmpty()) {
+            return "file:///"
+        }
+        return if (forward.startsWith("/")) "file://$forward" else "file:///$forward"
+    }
+
+    private fun stripGitSuffixAndSlashes(path: String): String {
+        var p = path.trimEnd('/')
+        if (p.lowercase().endsWith(".git")) {
+            p = p.dropLast(4)
+        }
+        return p.trimEnd('/')
+    }
+
+    private fun normalizePathCase(host: String, pathPart: String): String {
+        return if (host in CASE_INSENSITIVE_PATH_HOSTS) pathPart.lowercase() else pathPart
+    }
+
+    private fun canonicalPortSegment(scheme: String, port: String): String {
+        if (port.isEmpty()) {
+            return ""
+        }
+        if (scheme == "ssh" || scheme == "git") {
+            return if (port == SSH_GIT_DEFAULT_PORTS[scheme]) "" else ":$port"
+        }
+        return ":$port"
+    }
+
+    private fun stripGitSuffixOnly(segment: String): String {
+        return if (segment.lowercase().endsWith(".git")) segment.dropLast(4) else segment
+    }
+
+    private fun lastNonEmptyPathSegment(pathname: String): String {
+        val parts = pathname.split("/").filter { it.isNotEmpty() }
+        return parts.lastOrNull().orEmpty()
+    }
+}

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/services/JolliApiClient.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/services/JolliApiClient.kt
@@ -76,9 +76,11 @@ object JolliApiClient {
         val title: String,
         val content: String,
         val commitHash: String,
+        val docType: String,
         val branch: String? = null,
-        val subFolder: String? = null,
         val docId: Int? = null,
+        val repoUrl: String? = null,
+        val relativePath: String? = null,
     )
 
     /** Response from a successful push. */
@@ -103,6 +105,12 @@ object JolliApiClient {
 
     /** Thrown when the server rejects the request due to outdated plugin version (HTTP 426). */
     class PluginOutdatedError(message: String) : RuntimeException(message)
+
+    /** Thrown when the server returns 412 because the repo has no space binding yet. */
+    class BindingRequiredError(
+        val repoUrl: String,
+        message: String = "This repo is not bound to a Memory space yet.",
+    ) : RuntimeException(message)
 
     /**
      * Parsed base URL with optional tenant slug extracted from the path.
@@ -197,7 +205,7 @@ object JolliApiClient {
         val raw = response.body() ?: ""
         val statusCode = response.statusCode()
 
-        return parseResponse(raw, statusCode)
+        return parseResponse(raw, statusCode, payload.repoUrl)
     }
 
     /**
@@ -311,6 +319,165 @@ object JolliApiClient {
         }
     }
 
+    // ── JM Space Binding endpoints (JOLLI-1335) ──────────────────────────
+
+    /** Result of GET /api/jolli-memory/spaces. */
+    data class JmSpacesListResult(
+        val spaces: List<ai.jolli.jollimemory.toolwindow.JmSpaceSummary>,
+        val defaultSpaceId: Int?,
+    )
+
+    /**
+     * GET /api/jolli-memory/spaces
+     *
+     * Lists existing JolliMemory spaces visible to the authenticated user.
+     * Accepts both a flat array body and a `{ spaces, defaultSpaceId }` envelope
+     * from the server (the flat form yields `defaultSpaceId = null`).
+     */
+    fun listSpaces(baseUrl: String, apiKey: String): JmSpacesListResult {
+        val keyMeta = parseJolliApiKey(apiKey)
+        val parsed = parseBaseUrl(baseUrl)
+        val targetUri = URI.create("${parsed.origin}/api/jolli-memory/spaces")
+
+        val requestBuilder = HttpRequest.newBuilder()
+            .uri(targetUri)
+            .header("Authorization", "Bearer $apiKey")
+            .header("x-jolli-client", "intellij-plugin/$pluginVersion")
+            .GET()
+            .timeout(Duration.ofSeconds(30))
+
+        if (parsed.tenantSlug != null) {
+            requestBuilder.header("x-tenant-slug", parsed.tenantSlug)
+        }
+        if (keyMeta?.o != null) {
+            requestBuilder.header("x-org-slug", keyMeta.o)
+        }
+
+        val response = client.send(requestBuilder.build(), HttpResponse.BodyHandlers.ofString())
+        val raw = response.body() ?: ""
+        val statusCode = response.statusCode()
+
+        if (statusCode == 426) {
+            throw PluginOutdatedError("Plugin version is outdated. Please update to the latest version.")
+        }
+        if (statusCode !in 200..299) {
+            throw RuntimeException("Failed to list spaces (HTTP $statusCode): ${raw.take(200)}")
+        }
+
+        return try {
+            val element = gson.fromJson(raw, com.google.gson.JsonElement::class.java)
+            if (element.isJsonArray) {
+                val spaces = element.asJsonArray.map { el ->
+                    val obj = el.asJsonObject
+                    ai.jolli.jollimemory.toolwindow.JmSpaceSummary(
+                        id = obj.get("id").asInt,
+                        name = obj.get("name").asString,
+                        slug = obj.get("slug").asString,
+                    )
+                }
+                JmSpacesListResult(spaces, defaultSpaceId = null)
+            } else {
+                val obj = element.asJsonObject
+                val spacesArr = obj.getAsJsonArray("spaces") ?: com.google.gson.JsonArray()
+                val spaces = spacesArr.map { el ->
+                    val s = el.asJsonObject
+                    ai.jolli.jollimemory.toolwindow.JmSpaceSummary(
+                        id = s.get("id").asInt,
+                        name = s.get("name").asString,
+                        slug = s.get("slug").asString,
+                    )
+                }
+                val defaultId = obj.get("defaultSpaceId")?.takeIf { it.isJsonPrimitive }?.asInt
+                JmSpacesListResult(spaces, defaultSpaceId = defaultId)
+            }
+        } catch (_: Exception) {
+            throw RuntimeException("Invalid JSON from list-spaces (HTTP $statusCode): ${raw.take(200)}")
+        }
+    }
+
+    /**
+     * POST /api/jolli-memory/bindings
+     *
+     * Binds a repo to a JM space. On success returns the binding info.
+     * Throws [ai.jolli.jollimemory.toolwindow.BindingAlreadyExistsException]
+     * on 409 when another user already bound the same repo (race condition).
+     */
+    fun createBinding(
+        baseUrl: String,
+        apiKey: String,
+        repoUrl: String,
+        repoName: String,
+        jmSpaceId: Int,
+    ): ai.jolli.jollimemory.toolwindow.BindingChooserResult {
+        val keyMeta = parseJolliApiKey(apiKey)
+        val parsed = parseBaseUrl(baseUrl)
+        val targetUri = URI.create("${parsed.origin}/api/jolli-memory/bindings")
+
+        val body = gson.toJson(mapOf(
+            "repoUrl" to repoUrl,
+            "repoName" to repoName,
+            "jmSpaceId" to jmSpaceId,
+        ))
+
+        val requestBuilder = HttpRequest.newBuilder()
+            .uri(targetUri)
+            .header("Content-Type", "application/json")
+            .header("Authorization", "Bearer $apiKey")
+            .header("x-jolli-client", "intellij-plugin/$pluginVersion")
+            .POST(HttpRequest.BodyPublishers.ofString(body))
+            .timeout(Duration.ofSeconds(30))
+
+        if (parsed.tenantSlug != null) {
+            requestBuilder.header("x-tenant-slug", parsed.tenantSlug)
+        }
+        if (keyMeta?.o != null) {
+            requestBuilder.header("x-org-slug", keyMeta.o)
+        }
+
+        val response = client.send(requestBuilder.build(), HttpResponse.BodyHandlers.ofString())
+        val raw = response.body() ?: ""
+        val statusCode = response.statusCode()
+
+        if (statusCode == 426) {
+            throw PluginOutdatedError("Plugin version is outdated. Please update to the latest version.")
+        }
+
+        return try {
+            @Suppress("UNCHECKED_CAST")
+            val json = gson.fromJson(raw, Map::class.java) as Map<String, Any?>
+
+            if (statusCode == 409 && json["error"] == "binding_already_exists") {
+                throw ai.jolli.jollimemory.toolwindow.BindingAlreadyExistsException(
+                    ai.jolli.jollimemory.toolwindow.BindingChooserResult(
+                        id = (json["id"] as? Double)?.toInt() ?: 0,
+                        jmSpaceId = (json["jmSpaceId"] as? Double)?.toInt() ?: 0,
+                        jmSpaceName = json["jmSpaceName"] as? String ?: "",
+                        repoName = json["repoName"] as? String ?: "",
+                    ),
+                )
+            }
+
+            if (statusCode !in 200..299) {
+                throw RuntimeException(json["error"] as? String ?: "HTTP $statusCode")
+            }
+
+            ai.jolli.jollimemory.toolwindow.BindingChooserResult(
+                id = (json["id"] as? Double)?.toInt() ?: 0,
+                jmSpaceId = (json["jmSpaceId"] as? Double)?.toInt() ?: 0,
+                jmSpaceName = json["jmSpaceName"] as? String ?: "",
+                repoName = json["repoName"] as? String ?: "",
+            )
+        } catch (e: ai.jolli.jollimemory.toolwindow.BindingAlreadyExistsException) {
+            throw e
+        } catch (e: PluginOutdatedError) {
+            throw e
+        } catch (e: RuntimeException) {
+            throw e
+        } catch (_: Exception) {
+            throw RuntimeException("Invalid JSON from create-binding (HTTP $statusCode): ${raw.take(200)}")
+        }
+    }
+
     // ── Internal helpers ────────────────────────────────────────────────────
 
     /**
@@ -331,7 +498,7 @@ object JolliApiClient {
     }
 
     /** Parses a push response, handling errors and status codes. */
-    private fun parseResponse(raw: String, statusCode: Int): JolliPushResult {
+    private fun parseResponse(raw: String, statusCode: Int, payloadRepoUrl: String? = null): JolliPushResult {
         return try {
             @Suppress("UNCHECKED_CAST")
             val json = gson.fromJson(raw, Map::class.java) as Map<String, Any?>
@@ -343,6 +510,10 @@ object JolliApiClient {
                     jrn = json["jrn"] as? String ?: "",
                     created = json["created"] as? Boolean ?: false,
                 )
+            } else if (statusCode == 412 && json["error"] == "binding_required") {
+                throw BindingRequiredError(
+                    repoUrl = json["repoUrl"] as? String ?: payloadRepoUrl ?: "",
+                )
             } else if (statusCode == 426) {
                 throw PluginOutdatedError(
                     json["message"] as? String
@@ -353,6 +524,8 @@ object JolliApiClient {
                     json["error"] as? String ?: "HTTP $statusCode"
                 )
             }
+        } catch (e: BindingRequiredError) {
+            throw e
         } catch (e: PluginOutdatedError) {
             throw e
         } catch (e: RuntimeException) {

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/services/JolliAuthService.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/services/JolliAuthService.kt
@@ -126,6 +126,9 @@ object JolliAuthService {
                         return@createContext
                     }
 
+                    val paramKeys = params.keys.sorted().joinToString(", ")
+                    log.info("Callback params received: [%s]", paramKeys)
+
                     val error = params["error"]
                     if (error != null) {
                         val message = getErrorMessage(error)

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/BindingChooserDialog.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/BindingChooserDialog.kt
@@ -1,0 +1,374 @@
+package ai.jolli.jollimemory.toolwindow
+
+import ai.jolli.jollimemory.services.JolliApiClient
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.application.ModalityState
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.DialogWrapper
+import com.intellij.ui.components.JBLabel
+import com.intellij.ui.components.JBList
+import com.intellij.ui.components.JBScrollPane
+import com.intellij.util.ui.JBUI
+import java.awt.BorderLayout
+import java.awt.Component
+import java.awt.Dimension
+import javax.swing.BorderFactory
+import javax.swing.Box
+import javax.swing.BoxLayout
+import javax.swing.DefaultListModel
+import javax.swing.JComponent
+import javax.swing.JPanel
+import javax.swing.ListSelectionModel
+
+/**
+ * A JolliMemory space returned by the list-spaces endpoint.
+ */
+data class JmSpaceSummary(
+	val id: Int,
+	val name: String,
+	val slug: String,
+)
+
+/**
+ * Result returned after a successful binding creation or race-winner acceptance.
+ */
+data class BindingChooserResult(
+	val id: Int,
+	val jmSpaceId: Int,
+	val jmSpaceName: String,
+	val repoName: String,
+)
+
+/**
+ * Discriminated outcome of the binding chooser dialog.
+ *
+ * The caller (push flow) uses a `when` block on this to decide whether to
+ * retry the push ([Selected]), show a cancellation message ([Cancelled]),
+ * or inform the user a chooser is already open ([AnotherOpen]).
+ */
+sealed class BindingChooserOutcome {
+	data class Selected(val result: BindingChooserResult) : BindingChooserOutcome()
+	object Cancelled : BindingChooserOutcome()
+	object AnotherOpen : BindingChooserOutcome()
+}
+
+/**
+ * Thrown when binding creation fails with 409 because another user
+ * already bound the same repo. Carries the winning binding's details.
+ */
+class BindingAlreadyExistsException(
+	val winner: BindingChooserResult,
+	message: String = "Another binding already exists for this repo.",
+) : RuntimeException(message)
+
+/**
+ * Modal dialog that lets the user pick a JolliMemory space to bind a repo to.
+ *
+ * Shown when the server returns 412 `binding_required` during a push. At most
+ * one dialog is open per `repoUrl`; callers should check [isAlreadyOpen] first.
+ *
+ * When the user clicks "Bind and Push", the dialog calls
+ * [JolliApiClient.createBinding] on a background thread and stays open
+ * until the call completes. On a 409 race collision it shows a banner; on
+ * success it closes and the caller reads the result via [getOutcome].
+ *
+ * The dialog does NOT create spaces — only lists existing ones. Space
+ * management happens on the jolli.ai web frontend.
+ */
+class BindingChooserDialog private constructor(
+	project: Project,
+	private val repoUrl: String,
+	private val suggestedRepoName: String,
+	private val spaces: List<JmSpaceSummary>,
+	private val defaultSpaceId: Int?,
+	private val baseUrl: String,
+	private val apiKey: String,
+) : DialogWrapper(project, true) {
+
+	private val listModel = DefaultListModel<JmSpaceSummary>()
+	private val spacesList = JBList(listModel)
+	private var bannerPanel: JPanel? = null
+	private var spacesPanel: JComponent? = null
+	private var emptyLabel: JBLabel? = null
+	private var errorLabel: JBLabel? = null
+	private var outcome: BindingChooserOutcome = BindingChooserOutcome.Cancelled
+
+	init {
+		title = "Choose a Memory Space"
+		setOKButtonText("Bind and Push")
+		setCancelButtonText("Cancel")
+		isOKActionEnabled = false
+		init()
+
+		for (space in spaces) {
+			listModel.addElement(space)
+		}
+		if (spaces.isEmpty()) {
+			emptyLabel?.isVisible = true
+			spacesList.isVisible = false
+		}
+
+		// Pre-select only the server-designated default space. If the server
+		// did not nominate one, leave every row unselected so the user must
+		// explicitly pick — auto-selecting the first row would silently bind
+		// the repo to whichever space happened to be returned first.
+		if (defaultSpaceId != null) {
+			for (i in 0 until listModel.size) {
+				if (listModel.getElementAt(i).id == defaultSpaceId) {
+					spacesList.selectedIndex = i
+					isOKActionEnabled = true
+					break
+				}
+			}
+		}
+	}
+
+	override fun createCenterPanel(): JComponent {
+		val root = JPanel(BorderLayout())
+		root.preferredSize = Dimension(480, 400)
+
+		// ── Header ──
+		val header = JPanel().apply {
+			layout = BoxLayout(this, BoxLayout.Y_AXIS)
+			border = JBUI.Borders.emptyBottom(12)
+			add(JBLabel("Choose a Memory space").apply {
+				font = JBUI.Fonts.label(14f).asBold()
+				alignmentX = Component.LEFT_ALIGNMENT
+			})
+			add(Box.createVerticalStrut(4))
+			add(JBLabel("<html><span style='color:gray'>Bind this repo to an existing space. Create or manage spaces on jolli.ai.</span></html>").apply {
+				alignmentX = Component.LEFT_ALIGNMENT
+			})
+			add(Box.createVerticalStrut(8))
+			add(JBLabel("<html><b>Repo:</b> ${escHtml(repoUrl)}</html>").apply {
+				alignmentX = Component.LEFT_ALIGNMENT
+			})
+		}
+		root.add(header, BorderLayout.NORTH)
+
+		// ── Race-winner banner (initially hidden) ──
+		bannerPanel = JPanel().apply {
+			layout = BoxLayout(this, BoxLayout.Y_AXIS)
+			border = BorderFactory.createCompoundBorder(
+				BorderFactory.createLineBorder(java.awt.Color(0xE0, 0xA0, 0x20), 1, true),
+				JBUI.Borders.empty(10),
+			)
+			isVisible = false
+		}
+
+		// ── Spaces list ──
+		spacesList.selectionMode = ListSelectionModel.SINGLE_SELECTION
+		spacesList.cellRenderer = SpaceCellRenderer()
+		spacesList.addListSelectionListener {
+			if (!it.valueIsAdjusting) {
+				isOKActionEnabled = spacesList.selectedValue != null
+			}
+		}
+
+		val emptyLbl = JBLabel("<html><span style='color:gray'>No Memory spaces available. Create one on jolli.ai, then try Push again.</span></html>").apply {
+			border = JBUI.Borders.empty(20)
+			isVisible = false
+			alignmentX = Component.LEFT_ALIGNMENT
+		}
+		emptyLabel = emptyLbl
+
+		val errLbl = JBLabel().apply {
+			border = JBUI.Borders.emptyTop(8)
+			isVisible = false
+			alignmentX = Component.LEFT_ALIGNMENT
+		}
+		errorLabel = errLbl
+
+		val listPanel = JPanel(BorderLayout()).apply {
+			add(JBScrollPane(spacesList), BorderLayout.CENTER)
+			add(emptyLbl, BorderLayout.SOUTH)
+		}
+		spacesPanel = listPanel
+
+		val center = JPanel().apply {
+			layout = BoxLayout(this, BoxLayout.Y_AXIS)
+			add(bannerPanel!!)
+			add(listPanel)
+			add(errLbl)
+		}
+		root.add(center, BorderLayout.CENTER)
+
+		return root
+	}
+
+	/**
+	 * Intercepts the OK action so the dialog stays open while the binding
+	 * API call runs on a background thread. Closes only on success or
+	 * after the user accepts a race-winner via the banner.
+	 */
+	override fun doOKAction() {
+		LOG.info("doOKAction entered (repoUrl=$repoUrl, outcome=$outcome, isOKActionEnabled=$isOKActionEnabled)")
+		// Race-winner path: user clicked "OK, Push Now" after banner was shown.
+		// outcome is already set by showRaceWinner(), just close.
+		if (outcome is BindingChooserOutcome.Selected) {
+			LOG.info("doOKAction: race-winner path, delegating to super.doOKAction()")
+			super.doOKAction()
+			return
+		}
+
+		val selected = spacesList.selectedValue
+		if (selected == null) {
+			LOG.info("doOKAction: no selection, returning without action")
+			return
+		}
+		LOG.info("doOKAction: selected space id=${selected.id} name=${selected.name}; calling setBusy(true)")
+		setBusy(true)
+		errorLabel?.isVisible = false
+
+		ApplicationManager.getApplication().executeOnPooledThread {
+			LOG.info("createBinding: pooled-thread start (jmSpaceId=${selected.id})")
+			try {
+				val result = JolliApiClient.createBinding(baseUrl, apiKey, repoUrl, suggestedRepoName, selected.id)
+				LOG.info("createBinding: returned id=${result.id} jmSpaceId=${result.jmSpaceId} name=${result.jmSpaceName}; scheduling invokeLater to close dialog")
+				ApplicationManager.getApplication().invokeLater(
+					{
+						LOG.info("createBinding-invokeLater: setting outcome and calling close(OK_EXIT_CODE) (isOKActionEnabled=$isOKActionEnabled)")
+						outcome = BindingChooserOutcome.Selected(result)
+						close(OK_EXIT_CODE)
+						LOG.info("createBinding-invokeLater: close(OK_EXIT_CODE) returned (isShowing=$isShowing)")
+					},
+					ModalityState.any(),
+				)
+			} catch (e: BindingAlreadyExistsException) {
+				LOG.info("createBinding: 409 race-winner — winner=${e.winner.jmSpaceName}")
+				ApplicationManager.getApplication().invokeLater(
+					{
+						showRaceWinner(e.winner)
+						setBusy(false)
+					},
+					ModalityState.any(),
+				)
+			} catch (e: Exception) {
+				LOG.warn("createBinding failed: ${e.message}", e)
+				ApplicationManager.getApplication().invokeLater(
+					{
+						showError(e.message ?: "Failed to register binding.")
+						setBusy(false)
+					},
+					ModalityState.any(),
+				)
+			}
+		}
+	}
+
+	override fun doCancelAction() {
+		LOG.info("doCancelAction entered (repoUrl=$repoUrl)")
+		outcome = BindingChooserOutcome.Cancelled
+		super.doCancelAction()
+	}
+
+	/** Returns the outcome after the dialog has been closed. */
+	fun getOutcome(): BindingChooserOutcome = outcome
+
+	override fun dispose() {
+		LOG.info("dispose called (repoUrl=$repoUrl, outcome=$outcome)")
+		openInstances.remove(repoUrl)
+		super.dispose()
+	}
+
+	// ── Internal helpers ────────────────────────────────────────────────
+
+	/**
+	 * Shows the race-winner banner when a 409 collision is detected.
+	 * Hides the spaces list and changes the OK button to "OK, Push Now".
+	 */
+	private fun showRaceWinner(winner: BindingChooserResult) {
+		outcome = BindingChooserOutcome.Selected(winner)
+		spacesPanel?.isVisible = false
+		errorLabel?.isVisible = false
+		bannerPanel?.apply {
+			removeAll()
+			add(JBLabel("<html>Another teammate just bound this repo to <b>${escHtml(winner.jmSpaceName)}</b>. Using that one.</html>").apply {
+				alignmentX = Component.LEFT_ALIGNMENT
+			})
+			isVisible = true
+			revalidate()
+			repaint()
+		}
+		setOKButtonText("OK, Push Now")
+		isOKActionEnabled = true
+	}
+
+	private fun setBusy(busy: Boolean) {
+		isOKActionEnabled = !busy
+		spacesList.isEnabled = !busy
+		setOKButtonText(if (busy) "Binding\u2026" else "Bind and Push")
+	}
+
+	private fun showError(message: String) {
+		errorLabel?.apply {
+			text = "<html><span style='color:#c0392b'>${escHtml(message)}</span></html>"
+			isVisible = true
+		}
+	}
+
+	private fun escHtml(s: String): String =
+		s.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;").replace("\"", "&quot;")
+
+	companion object {
+		private val LOG = Logger.getInstance(BindingChooserDialog::class.java)
+		private val openInstances = mutableMapOf<String, BindingChooserDialog>()
+
+		/**
+		 * Opens the chooser dialog for the given repo.
+		 *
+		 * Call [isAlreadyOpen] first to distinguish the "another chooser is
+		 * already showing" case from a fresh open.
+		 */
+		fun open(
+			project: Project,
+			repoUrl: String,
+			suggestedRepoName: String,
+			spaces: List<JmSpaceSummary>,
+			defaultSpaceId: Int?,
+			baseUrl: String,
+			apiKey: String,
+		): BindingChooserDialog {
+			val dialog = BindingChooserDialog(project, repoUrl, suggestedRepoName, spaces, defaultSpaceId, baseUrl, apiKey)
+			openInstances[repoUrl] = dialog
+			return dialog
+		}
+
+		/** Returns true if a chooser is already open for the given repo URL. */
+		fun isAlreadyOpen(repoUrl: String): Boolean {
+			val existing = openInstances[repoUrl]
+			return existing != null && existing.isShowing
+		}
+	}
+
+	/**
+	 * Cell renderer for the spaces list — shows space name in bold with
+	 * the slug in gray, adapting to the current selection colors.
+	 */
+	private class SpaceCellRenderer : javax.swing.ListCellRenderer<JmSpaceSummary> {
+		private val label = JBLabel()
+
+		override fun getListCellRendererComponent(
+			list: javax.swing.JList<out JmSpaceSummary>,
+			value: JmSpaceSummary?,
+			index: Int,
+			isSelected: Boolean,
+			cellHasFocus: Boolean,
+		): Component {
+			if (value == null) return label
+			label.text = "<html><b>${value.name}</b> <span style='color:gray'>/${value.slug}</span></html>"
+			label.border = JBUI.Borders.empty(6, 8)
+			if (isSelected) {
+				label.background = list.selectionBackground
+				label.foreground = list.selectionForeground
+				label.isOpaque = true
+			} else {
+				label.background = list.background
+				label.foreground = list.foreground
+				label.isOpaque = false
+			}
+			return label
+		}
+	}
+}

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/SummaryPanel.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/SummaryPanel.kt
@@ -1,6 +1,7 @@
 package ai.jolli.jollimemory.toolwindow
 
 import ai.jolli.jollimemory.bridge.GitOps
+import ai.jolli.jollimemory.bridge.GitRemoteUtils
 import ai.jolli.jollimemory.core.CommitSummary
 import ai.jolli.jollimemory.core.E2eTestScenario
 import ai.jolli.jollimemory.core.SessionTracker
@@ -251,7 +252,7 @@ class SummaryPanel(
         clipboard.setContents(StringSelection(markdown), null)
     }
 
-    private fun handlePushToJolli() {
+    private fun handlePushToJolli(retried: Boolean = false) {
         val summary = currentSummary
         val config = SessionTracker.loadConfig(cwd)
         if (config.jolliApiKey.isNullOrBlank()) {
@@ -274,6 +275,9 @@ class SummaryPanel(
         postToWebview("pushStarted")
         val baseUrl = resolvedBaseUrl.trimEnd('/')
 
+        val repoUrl = GitRemoteUtils.getCanonicalRepoUrl(cwd)
+        val relativePath = GitRemoteUtils.sanitizeBranchSlug(summary.branch)
+
         ApplicationManager.getApplication().executeOnPooledThread {
             try {
                 val planUrls = mutableListOf<PlanPushResult>()
@@ -286,9 +290,11 @@ class SummaryPanel(
                         title = SummaryUtils.buildPlanPushTitle(summary, plan.title),
                         content = planContent,
                         commitHash = summary.commitHash,
+                        docType = "plan",
                         branch = summary.branch,
-                        subFolder = "Plans",
                         docId = plan.jolliPlanDocId,
+                        repoUrl = repoUrl,
+                        relativePath = relativePath,
                     ))
                     planUrls.add(PlanPushResult(plan.slug, plan.title, "$baseUrl/articles?doc=${planResult.docId}", planResult.docId))
                 }
@@ -308,7 +314,9 @@ class SummaryPanel(
 
                 val result = JolliApiClient.pushToJolli(resolvedBaseUrl, config.jolliApiKey!!, JolliApiClient.JolliPushPayload(
                     title = pushTitle, content = markdown, commitHash = summary.commitHash,
+                    docType = "summary",
                     branch = summary.branch, docId = summary.jolliDocId,
+                    repoUrl = repoUrl, relativePath = relativePath,
                 ))
 
                 val fullUrl = "$baseUrl/articles?doc=${result.docId}"
@@ -334,6 +342,15 @@ class SummaryPanel(
                     val planMsg = if (planUrls.isNotEmpty()) " (with ${planUrls.size} plan${if (planUrls.size > 1) "s" else ""})" else ""
                     Messages.showInfoMessage(project, "$verb on Jolli Space$planMsg.", "Push Successful")
                 }
+            } catch (e: JolliApiClient.BindingRequiredError) {
+                if (retried) {
+                    ApplicationManager.getApplication().invokeLater {
+                        postToWebview("pushFailed")
+                        Messages.showErrorDialog(project, "Push failed: binding still not found after retry. Please try again.", "Push Error")
+                    }
+                } else {
+                    handleBindingRequired(e.repoUrl, resolvedBaseUrl, config.jolliApiKey!!)
+                }
             } catch (e: JolliApiClient.PluginOutdatedError) {
                 ApplicationManager.getApplication().invokeLater {
                     postToWebview("pushFailed")
@@ -343,6 +360,56 @@ class SummaryPanel(
                 ApplicationManager.getApplication().invokeLater {
                     postToWebview("pushFailed")
                     Messages.showErrorDialog(project, "Push failed: ${e.message}", "Push Error")
+                }
+            }
+        }
+    }
+
+    /**
+     * Handles a 412 binding_required error: fetches available spaces on the
+     * current background thread, then switches to the UI thread to show the
+     * chooser dialog. If the user picks a space, retries the push.
+     */
+    private fun handleBindingRequired(repoUrl: String, baseUrl: String, apiKey: String) {
+        val spacesResult = try {
+            JolliApiClient.listSpaces(baseUrl, apiKey)
+        } catch (e: Exception) {
+            ApplicationManager.getApplication().invokeLater {
+                postToWebview("pushFailed")
+                Messages.showErrorDialog(project, "Failed to load Memory spaces: ${e.message}", "Push Error")
+            }
+            return
+        }
+
+        val suggestedRepoName = GitRemoteUtils.deriveRepoNameFromUrl(repoUrl).ifEmpty { "repo" }
+
+        ApplicationManager.getApplication().invokeLater {
+            if (BindingChooserDialog.isAlreadyOpen(repoUrl)) {
+                postToWebview("pushFailed")
+                Messages.showInfoMessage(project, "A binding chooser is already open for this repo. Finish there, then push again.", "Chooser Already Open")
+                return@invokeLater
+            }
+
+            val dialog = BindingChooserDialog.open(
+                project, repoUrl, suggestedRepoName,
+                spacesResult.spaces, spacesResult.defaultSpaceId,
+                baseUrl, apiKey,
+            )
+            LOG.info("handleBindingRequired: showing chooser dialog (repoUrl=$repoUrl)")
+            dialog.show()
+            LOG.info("handleBindingRequired: dialog.show() returned; outcome=${dialog.getOutcome()}")
+
+            when (dialog.getOutcome()) {
+                is BindingChooserOutcome.Selected -> {
+                    handlePushToJolli(retried = true)
+                }
+                is BindingChooserOutcome.Cancelled -> {
+                    postToWebview("pushFailed")
+                    Messages.showInfoMessage(project, "Push cancelled — no Memory space was selected.", "Push Cancelled")
+                }
+                is BindingChooserOutcome.AnotherOpen -> {
+                    postToWebview("pushFailed")
+                    Messages.showInfoMessage(project, "A binding chooser is already open for this repo. Finish there, then push again.", "Chooser Already Open")
                 }
             }
         }

--- a/intellij/src/test/kotlin/ai/jolli/jollimemory/services/JolliApiClientTest.kt
+++ b/intellij/src/test/kotlin/ai/jolli/jollimemory/services/JolliApiClientTest.kt
@@ -106,10 +106,10 @@ class JolliApiClientTest {
 
     @Nested
     inner class ParseResponse {
-        private fun parseResponse(raw: String, statusCode: Int): Any {
-            val method: Method = JolliApiClient::class.java.getDeclaredMethod("parseResponse", String::class.java, Int::class.javaPrimitiveType)
+        private fun parseResponse(raw: String, statusCode: Int, payloadRepoUrl: String? = null): Any {
+            val method: Method = JolliApiClient::class.java.getDeclaredMethod("parseResponse", String::class.java, Int::class.javaPrimitiveType, String::class.java)
             method.isAccessible = true
-            return method.invoke(JolliApiClient, raw, statusCode)
+            return method.invoke(JolliApiClient, raw, statusCode, payloadRepoUrl)
         }
 
         @Test
@@ -163,10 +163,11 @@ class JolliApiClientTest {
 
     @Test
     fun `JolliPushPayload has correct defaults`() {
-        val payload = JolliApiClient.JolliPushPayload("Test", "Content", "abc123")
+        val payload = JolliApiClient.JolliPushPayload("Test", "Content", "abc123", "summary")
         payload.branch shouldBe null
-        payload.subFolder shouldBe null
         payload.docId shouldBe null
+        payload.repoUrl shouldBe null
+        payload.relativePath shouldBe null
     }
 
     @Test


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## Jolli Memory

https://jolli-local.me/main/articles?doc=27

## E2E Test (5)
<details>
<summary><strong>1. Space binding dialog opens and closes after successful bind</strong></summary>
<br>
<blockquote>

**Preconditions:** Have an IntelliJ project open with a Git repository that has no Jolli Memory space bound to it yet. Make sure at least one Memory space exists on your jolli.ai account.

**Steps:**
1. Open the Jolli Memory panel in IntelliJ and click the "Push" button to trigger a push for any plan or summary.
2. Wait for the "Choose a Memory Space" dialog to appear.
3. Click on one of the spaces shown in the list to select it.
4. Click the "Bind and Push" button.
5. Wait a few seconds while the button shows "Binding…" to indicate it is working.
6. Check that the dialog closes on its own and the push completes without the window staying frozen.

**Expected Results:**
- The dialog should close automatically after the binding is created.
- The push should proceed and finish normally — no spinner or frozen window left behind.
- The dialog should not remain stuck in a loading state after the server responds.

</blockquote>
</details>
<details>
<summary><strong>2. Space binding dialog shows race-winner banner when another user already bound the repo</strong></summary>
<br>
<blockquote>

**Preconditions:** Have two users or sessions ready so that a second binding can be created for the same repo while the dialog is open. Alternatively, ask a teammate to bind the repo from their machine just before you click "Bind and Push."

**Steps:**
1. Open the Jolli Memory panel and click "Push" to trigger the "Choose a Memory Space" dialog.
2. Select a space from the list but do NOT click "Bind and Push" yet.
3. Have a teammate (or second session) bind the same repo to any space from their machine.
4. Now click "Bind and Push" in your dialog.
5. Wait for the dialog to respond.
6. Check the message that appears inside the dialog.

**Expected Results:**
- A yellow banner should appear inside the dialog saying a teammate already bound the repo and naming the space they chose.
- The spaces list should be hidden and replaced by the banner.
- The button should change to "OK, Push Now."
- Clicking "OK, Push Now" should close the dialog and complete the push using the teammate's binding.

</blockquote>
</details>
<details>
<summary><strong>3. Space binding dialog shows empty state when no spaces exist</strong></summary>
<br>
<blockquote>

**Preconditions:** Have an IntelliJ project open with a Git repository that has no Jolli Memory space bound to it. Make sure the jolli.ai account has zero Memory spaces created.

**Steps:**
1. Open the Jolli Memory panel and click "Push" to trigger the "Choose a Memory Space" dialog.
2. Look at the area where the list of spaces would normally appear.
3. Check whether the "Bind and Push" button is clickable.

**Expected Results:**
- The list area should be empty with a message saying no Memory spaces are available and directing you to create one on jolli.ai.
- The "Bind and Push" button should be greyed out and not clickable.

</blockquote>
</details>
<details>
<summary><strong>4. Cancelling the space binding dialog does not push</strong></summary>
<br>
<blockquote>

**Preconditions:** Have an IntelliJ project open with a Git repository that has no Jolli Memory space bound to it.

**Steps:**
1. Open the Jolli Memory panel and click "Push" to trigger the "Choose a Memory Space" dialog.
2. Click the "Cancel" button without selecting any space.
3. Check the Jolli Memory panel for any push activity or success message.

**Expected Results:**
- The dialog should close immediately.
- No push should be sent — no success notification, no error, and no loading indicator should appear.

</blockquote>
</details>
<details>
<summary><strong>5. Push succeeds with correct repo identity after binding is set up</strong></summary>
<br>
<blockquote>

**Preconditions:** Have an IntelliJ project open with a Git repository that already has a Jolli Memory space bound to it (binding was created in a previous session or by a teammate).

**Steps:**
1. Open the Jolli Memory panel and click "Push" for any plan or summary.
2. Wait for the push to complete.
3. Open jolli.ai in a browser and navigate to the Memory space that is bound to this repo.
4. Check that the pushed document appears in the correct space.

**Expected Results:**
- The push should complete without any error or "binding required" dialog appearing.
- The document should appear in the correct Memory space on jolli.ai, confirming the repo was identified correctly regardless of how it was cloned (SSH or HTTPS).

</blockquote>
</details>

---

## Topics (3)
<details>
<summary><strong>01 · Dialog stuck on loading after successful space binding</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

After a user selected a JM space and clicked "Bind and Push," the backend successfully created the binding but the dialog remained frozen on a loading state and never closed.

**💡 Decisions Behind the Code**

- **Close directly vs. delegate to parent**: The parent's close method guards on whether the OK button is currently enabled, which is intentionally `false` during an in-flight request. Calling close directly bypasses that guard without removing the button-disable behavior, which still serves its purpose of preventing double-clicks.
- **Keep button-disable flag**: Removing the enabled/disabled toggle was considered since it no longer gates the close, but it still prevents users from firing duplicate binding requests while the HTTP call is in-flight, so it was retained with its scope narrowed to click-gating only.
- **Modality fix scope**: All three `invokeLater` calls in the same function received the fix, not just the success path, because the 409 race banner and error message had the identical modality problem and would have been invisible under the modal dialog.

**✅ What Was Implemented**

- Diagnosed root cause: `invokeLater` called from a background thread captures `NON_MODAL` modality state by default, causing the EDT to defer the close lambda indefinitely while the modal dialog is still showing (chicken-and-egg deadlock)
- Fixed by passing `ModalityState.any()` to all three `invokeLater` calls in `doOKAction()` (success path, 409 race path, and generic error path) in `BindingChooserDialog.kt`
- Replaced `super.doOKAction()` with `close(OK_EXIT_CODE)` on the success path to avoid the parent class's `isOKActionEnabled` guard silently blocking the close
- Added structured `LOG.info` / `LOG.warn` lines throughout the bind flow (enter, pool start, HTTP return, invokeLater fire, dispose) to make future diagnosis straightforward

**📁 FILES**
- `intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/BindingChooserDialog.kt`

</blockquote>
</details>
<details>
<summary><strong>02 · Wire new push payload fields to IntelliJ push flow</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The server's push contract was updated to require repo identity fields and a document type on every push request, but the IntelliJ plugin was still sending the old payload shape, causing pushes to be misrouted or rejected.

**💡 Decisions Behind the Code**

- **Compute once before the loop**: `repoUrl` and `relativePath` are derived from git config and branch name respectively — both are constant for a given push session, so computing them once avoids redundant git subprocess calls per plan.
- **Use shared utility over inline logic**: The existing ad-hoc repo-name derivation had three subtle differences from the VSCode client (case handling, empty fallback, unparseable URLs). Using the shared `GitRemoteUtils` ensures both IDE clients produce identical `repoName` values, preventing duplicate binding rows on the server.

**✅ What Was Implemented**

- Added `docType`, `repoUrl`, and `relativePath` to `JolliPushPayload`; removed `subFolder`
- In `SummaryPanel.kt`, compute `repoUrl` and `relativePath` once before the push loop using the new `GitRemoteUtils` utility
- Pass `docType = "plan"` to each per-plan push call and `docType = "summary"` to the summary push call
- Replaced ad-hoc repo-name derivation in `handleBindingRequired` with `GitRemoteUtils.deriveRepoNameFromUrl`
- Updated the payload defaults test to construct with the now-required `docType` field

**📁 FILES**
- `intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/SummaryPanel.kt`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/services/JolliApiClient.kt`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/bridge/GitRemoteUtils.kt`

</blockquote>
</details>
<details>
<summary><strong>03 · Add GitRemoteUtils for canonical repo URL normalization in IntelliJ</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The IntelliJ plugin needed to produce the same canonical repo URL as the VSCode extension so that both clients resolve to the same server-side binding row for a given repository, regardless of clone transport or casing differences.

**💡 Decisions Behind the Code**

- **Exact parity with VSCode implementation**: Any divergence in normalization would cause the same physical repo to produce two different URL keys, resulting in duplicate binding rows and broken cross-client push routing. The comment explicitly flags this constraint for future maintainers.
- **Case-insensitive path hosts allowlist**: Silently lowercasing all paths would merge distinct repos on case-sensitive self-hosted forges. Lowercasing only for the three major public hosts (GitHub, GitLab, Bitbucket) is the safe default that matches VSCode behavior.
- **Port handling asymmetry**: HTTP/HTTPS ports are always preserved because self-hosted forges on non-standard HTTPS ports are common. SSH/git default ports (22/9418) are stripped because they carry no identity information and would otherwise create duplicate keys.

**✅ What Was Implemented**

- Created `GitRemoteUtils.kt` in the `bridge` package, mirroring `vscode/src/util/GitRemoteUtils.ts` normalization rules
- Handles SSH scp form, SSH URL, git URL, HTTP/HTTPS, and local file paths
- Normalizes scheme and host to lowercase; strips trailing `.git`; preserves port for HTTP/HTTPS, drops default ports for SSH/git
- Lowercases path only for known case-insensitive hosts (GitHub, GitLab, Bitbucket); preserves case for self-hosted forges
- Includes `deriveRepoNameFromUrl` (display label from last path segment) and `sanitizeBranchSlug` (branch name to path-safe slug)

**📁 FILES**
- `intellij/src/main/kotlin/ai/jolli/jollimemory/bridge/GitRemoteUtils.kt`

</blockquote>
</details>

---

*Generated by Jolli Memory · May 11, 2026 at 3:38 PM*
<!-- jollimemory-summary-end -->