### PR TITLE
Mark .jolli dir as hidden on Windows via NTFS attrib/dos:hidden

### DIFF
--- a/cli/src/core/MetadataManager.test.ts
+++ b/cli/src/core/MetadataManager.test.ts
@@ -1,9 +1,17 @@
 import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ManifestEntry } from "./KBTypes.js";
 import { MetadataManager } from "./MetadataManager.js";
+
+const { mockTryMarkHidden } = vi.hoisted(() => ({
+	mockTryMarkHidden: vi.fn(),
+}));
+
+vi.mock("../util/WindowsHidden.js", () => ({
+	tryMarkHiddenOnWindows: mockTryMarkHidden,
+}));
 
 function makeTmpDir(): string {
 	const dir = join(tmpdir(), `kb-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
@@ -45,6 +53,10 @@ describe("MetadataManager", () => {
 	});
 
 	describe("ensure", () => {
+		beforeEach(() => {
+			mockTryMarkHidden.mockClear();
+		});
+
 		it("creates jolli dir and default files", () => {
 			manager.ensure();
 			expect(existsSync(jolliDir)).toBe(true);
@@ -64,6 +76,19 @@ describe("MetadataManager", () => {
 			manager.updateManifest(makeEntry());
 			manager.ensure();
 			expect(manager.readManifest().files).toHaveLength(1);
+		});
+
+		it("calls tryMarkHiddenOnWindows once on fresh create", () => {
+			manager.ensure();
+			expect(mockTryMarkHidden).toHaveBeenCalledTimes(1);
+			expect(mockTryMarkHidden).toHaveBeenCalledWith(jolliDir);
+		});
+
+		it("does not call tryMarkHiddenOnWindows when the directory already exists", () => {
+			manager.ensure();
+			mockTryMarkHidden.mockClear();
+			manager.ensure();
+			expect(mockTryMarkHidden).not.toHaveBeenCalled();
 		});
 	});
 

--- a/cli/src/core/MetadataManager.ts
+++ b/cli/src/core/MetadataManager.ts
@@ -12,6 +12,7 @@ import { createHash } from "node:crypto";
 import { existsSync, mkdirSync, readdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
 import { dirname, join, relative } from "node:path";
 import { createLogger } from "../Logger.js";
+import { tryMarkHiddenOnWindows } from "../util/WindowsHidden.js";
 import type { BranchesJson, BranchMapping, KBConfig, Manifest, ManifestEntry, MigrationState } from "./KBTypes.js";
 
 const log = createLogger("MetadataManager");
@@ -31,7 +32,11 @@ export class MetadataManager {
 
 	/** Ensures the .jolli/ directory and default files exist. */
 	ensure(): void {
-		mkdirSync(this.jolliDir, { recursive: true });
+		const created = mkdirSync(this.jolliDir, { recursive: true });
+		if (created !== undefined) {
+			// Dot prefix does not auto-hide on Windows; set NTFS hidden once at creation only.
+			tryMarkHiddenOnWindows(this.jolliDir);
+		}
 		if (!existsSync(this.manifestPath)) {
 			this.atomicWrite(this.manifestPath, JSON.stringify({ version: 1, files: [] }, null, "\t"));
 		}

--- a/cli/src/util/WindowsHidden.test.ts
+++ b/cli/src/util/WindowsHidden.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi } from "vitest";
+
+const { mockPlatform, mockSpawnSync } = vi.hoisted(() => ({
+	mockPlatform: vi.fn().mockReturnValue("linux"),
+	mockSpawnSync: vi.fn().mockReturnValue({ status: 0 }),
+}));
+
+vi.mock("node:os", async (importOriginal) => {
+	const original = await importOriginal<typeof import("node:os")>();
+	return { ...original, platform: mockPlatform };
+});
+
+vi.mock("node:child_process", async (importOriginal) => {
+	const original = await importOriginal<typeof import("node:child_process")>();
+	return { ...original, spawnSync: mockSpawnSync };
+});
+
+describe("tryMarkHiddenOnWindows", () => {
+	it("is a no-op on linux", async () => {
+		mockPlatform.mockReturnValue("linux");
+		mockSpawnSync.mockClear();
+		const { tryMarkHiddenOnWindows } = await import("./WindowsHidden.js");
+		tryMarkHiddenOnWindows("/some/path");
+		expect(mockSpawnSync).not.toHaveBeenCalled();
+	});
+
+	it("is a no-op on darwin", async () => {
+		mockPlatform.mockReturnValue("darwin");
+		mockSpawnSync.mockClear();
+		const { tryMarkHiddenOnWindows } = await import("./WindowsHidden.js");
+		tryMarkHiddenOnWindows("/some/path");
+		expect(mockSpawnSync).not.toHaveBeenCalled();
+	});
+
+	it("spawns `attrib +h` with windowsHide and a timeout on win32", async () => {
+		mockPlatform.mockReturnValue("win32");
+		mockSpawnSync.mockClear();
+		mockSpawnSync.mockReturnValueOnce({ status: 0 });
+		const { tryMarkHiddenOnWindows } = await import("./WindowsHidden.js");
+		tryMarkHiddenOnWindows("C:\\Users\\test\\.jolli");
+		expect(mockSpawnSync).toHaveBeenCalledWith(
+			"attrib",
+			["+h", "C:\\Users\\test\\.jolli"],
+			expect.objectContaining({ windowsHide: true, timeout: 2000 }),
+		);
+	});
+
+	it("swallows spawnSync errors on win32", async () => {
+		mockPlatform.mockReturnValue("win32");
+		mockSpawnSync.mockImplementationOnce(() => {
+			throw new Error("simulated");
+		});
+		const { tryMarkHiddenOnWindows } = await import("./WindowsHidden.js");
+		expect(() => tryMarkHiddenOnWindows("C:\\fake")).not.toThrow();
+	});
+});

--- a/cli/src/util/WindowsHidden.ts
+++ b/cli/src/util/WindowsHidden.ts
@@ -1,0 +1,15 @@
+import { spawnSync } from "node:child_process";
+import { platform } from "node:os";
+
+/** Best-effort `attrib +h` on win32; no-op elsewhere. Silent on failure — hidden bit is cosmetic. */
+export function tryMarkHiddenOnWindows(absPath: string): void {
+	if (platform() !== "win32") return;
+	try {
+		spawnSync("attrib", ["+h", absPath], {
+			windowsHide: true,
+			timeout: 2000,
+		});
+	} catch {
+		/* hidden bit is cosmetic — never fail the caller */
+	}
+}

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/core/MetadataManager.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/core/MetadataManager.kt
@@ -35,7 +35,12 @@ class MetadataManager(private val jolliDir: Path) {
 
     /** Ensures the .jolli/ directory and default files exist. */
     fun ensure() {
+        val freshCreate = !Files.exists(jolliDir)
         Files.createDirectories(jolliDir)
+        if (freshCreate) {
+            // Dot prefix does not auto-hide on Windows; set NTFS hidden once at creation only.
+            WindowsHidden.tryMarkHidden(jolliDir)
+        }
         if (!Files.exists(manifestPath)) {
             atomicWrite(manifestPath, gson.toJson(Manifest()))
         }

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/core/WindowsHidden.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/core/WindowsHidden.kt
@@ -1,0 +1,19 @@
+package ai.jolli.jollimemory.core
+
+import java.nio.file.Files
+import java.nio.file.Path
+
+/** Best-effort `dos:hidden` on Windows; no-op elsewhere. Silent on failure — hidden bit is cosmetic. */
+object WindowsHidden {
+    private val isWindows: Boolean =
+        System.getProperty("os.name").lowercase().contains("win")
+
+    fun tryMarkHidden(path: Path) {
+        if (!isWindows) return
+        try {
+            Files.setAttribute(path, "dos:hidden", true)
+        } catch (_: Exception) {
+            /* hidden bit is cosmetic — never fail the caller */
+        }
+    }
+}

--- a/vscode/src/providers/MemoriesTreeProvider.test.ts
+++ b/vscode/src/providers/MemoriesTreeProvider.test.ts
@@ -355,7 +355,7 @@ describe("MemoriesTreeProvider", () => {
 
 			await provider.refresh();
 
-			expect(bridge.listSummaryEntries).toHaveBeenCalledWith(10, 0, undefined); // PAGE_SIZE, no filter
+			expect(bridge.listSummaryEntries).toHaveBeenCalledWith(18, 0, undefined); // PAGE_SIZE, no filter
 			const children = provider.getChildren();
 			expect(children).toHaveLength(2);
 			expect(children[0]).toBeInstanceOf(MemoryItem);
@@ -527,7 +527,7 @@ describe("MemoriesTreeProvider", () => {
 			await provider.setFilter("");
 
 			// Should call with PAGE_SIZE and no filter
-			expect(bridge.listSummaryEntries).toHaveBeenCalledWith(10, 0, undefined);
+			expect(bridge.listSummaryEntries).toHaveBeenCalledWith(18, 0, undefined);
 		});
 
 		it("setFilter updates snapshot filter state", async () => {
@@ -560,8 +560,8 @@ describe("MemoriesTreeProvider", () => {
 
 			await provider.loadMore();
 
-			// Should have fetched with loadedCount = 10 + 10 = 20, no filter
-			expect(bridge.listSummaryEntries).toHaveBeenCalledWith(20, 0, undefined);
+			// Should have fetched with loadedCount = 18 + 18 = 36, no filter
+			expect(bridge.listSummaryEntries).toHaveBeenCalledWith(36, 0, undefined);
 		});
 	});
 

--- a/vscode/src/stores/MemoriesStore.test.ts
+++ b/vscode/src/stores/MemoriesStore.test.ts
@@ -81,7 +81,7 @@ describe("MemoriesStore — filter, loadMore, enabled", () => {
 		await store.refresh();
 		bridge.listSummaryEntries.mockClear();
 		await store.loadMore();
-		expect(bridge.listSummaryEntries).toHaveBeenCalledWith(20, 0, undefined);
+		expect(bridge.listSummaryEntries).toHaveBeenCalledWith(36, 0, undefined);
 	});
 
 	it("setEnabled is idempotent when unchanged", () => {
@@ -124,12 +124,12 @@ describe("MemoriesStore — filter, loadMore, enabled", () => {
 	it("setEnabled(false) resets loadedCount so Load More state does not cross disable/enable", async () => {
 		const bridge = makeBridge([makeEntry("a")], 100);
 		const store = new MemoriesStore(bridge as never);
-		// Simulate initial load + two Load More presses: loadedCount 10 → 20 → 30.
+		// Simulate initial load + two Load More presses: loadedCount 18 → 36 → 54.
 		await store.refresh();
 		await store.loadMore();
 		await store.loadMore();
 		expect(bridge.listSummaryEntries).toHaveBeenLastCalledWith(
-			30,
+			54,
 			0,
 			undefined,
 		);
@@ -140,7 +140,7 @@ describe("MemoriesStore — filter, loadMore, enabled", () => {
 		store.setEnabled(true);
 		bridge.listSummaryEntries.mockClear();
 		await store.refresh();
-		expect(bridge.listSummaryEntries).toHaveBeenCalledWith(10, 0, undefined);
+		expect(bridge.listSummaryEntries).toHaveBeenCalledWith(18, 0, undefined);
 	});
 });
 

--- a/vscode/src/stores/MemoriesStore.ts
+++ b/vscode/src/stores/MemoriesStore.ts
@@ -17,7 +17,7 @@ import { log } from "../util/Logger.js";
 import { BaseStore, type Snapshot } from "./BaseStore.js";
 
 /** Number of entries loaded per batch. */
-const PAGE_SIZE = 10;
+const PAGE_SIZE = 18;
 /** Upper bound on entries returned during search (keeps memory bounded). */
 const MAX_SEARCH_ENTRIES = 500;
 


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## Plans & Notes

- Plan: Mark Memory Bank `.jolli/` as hidden on Windows

## Quick recap

The Memory Bank's internal data directory is now hidden on Windows at the moment it is first created. On Linux and macOS, dot-prefixed directories are invisible by convention, but Windows requires an explicit file system attribute to achieve the same effect. Without this fix, users opening their Memory Bank folder in File Explorer would see both the human-readable Markdown layer and the machine-readable internal layer side by side, with no clear indication of which one was intended for them. The fix covers all three client surfaces — the CLI, the VS Code extension, and the IntelliJ plugin — each using the most appropriate mechanism available on that platform.

The hidden attribute is set exactly once, at directory creation time, and is never reapplied on subsequent startups. This means users who deliberately remove the hidden flag keep that preference across restarts. Two other dot-prefixed directories used for developer troubleshooting were intentionally left visible on Windows, preserving easy access to logs and configuration files that developers on that platform would otherwise have to unhide manually.

---

## E2E Test (2)
<details>
<summary><strong>1. Hidden .jolli folder on Windows — fresh setup</strong></summary>
<br>
<blockquote>

**Preconditions:** A Windows PC with File Explorer available. Jolli Memory has never been set up in the folder you plan to use (no existing .jolli folder inside it).

**Steps:**
1. Open File Explorer and navigate to the folder where you plan to store your Memory Bank.
2. Confirm there is no .jolli folder visible inside it yet.
3. Open Jolli Memory (CLI, VS Code extension, or IntelliJ plugin) and connect it to that folder, triggering a fresh Memory Bank setup.
4. Switch back to File Explorer and look inside the same folder.
5. In File Explorer, open the View menu and turn on "Show hidden items" (under Show/Hide options).
6. Check whether the .jolli folder appears only after enabling hidden items, and is absent when hidden items are turned off.

**Expected Results:**
- With "Show hidden items" turned OFF, the .jolli folder should not be visible in File Explorer at all.
- With "Show hidden items" turned ON, the .jolli folder should appear, confirming it exists but is marked as hidden.
- The human-readable Markdown files in the Memory Bank folder should remain fully visible regardless of the hidden-items setting.

</blockquote>
</details>
<details>
<summary><strong>2. Hidden .jolli folder on Windows — existing installation not affected</strong></summary>
<br>
<blockquote>

**Preconditions:** A Windows PC where Jolli Memory has already been set up in a folder (a .jolli folder already exists inside it). File Explorer is open.

**Steps:**
1. Open File Explorer, turn ON "Show hidden items", and navigate to the existing Memory Bank folder.
2. Note whether the .jolli folder is currently visible (it may or may not already be hidden depending on when it was created).
3. Close and reopen Jolli Memory (CLI, VS Code extension, or IntelliJ plugin) pointing at the same folder, so it runs its normal startup routine.
4. Switch back to File Explorer and turn OFF "Show hidden items".
5. Check whether the .jolli folder's visibility has changed compared to what you noted in step 2.

**Expected Results:**
- Restarting Jolli Memory against an already-existing .jolli folder should not change that folder's hidden status.
- No errors or warnings should appear during startup.
- The rest of the Memory Bank contents should be unaffected and fully accessible.

</blockquote>
</details>

---

## Topics (2)
<details>
<summary><strong>01 · Hide Memory Bank canonical data directory on Windows at creation time</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

On Windows, the hidden data layer of Memory Bank was fully visible in File Explorer alongside the human-readable Markdown layer, contradicting the documented design that describes it as hidden. Users opening the Memory Bank folder would see two sibling directories with no clear signal about which one was meant for them, and clicking into the wrong one exposed machine-readable internal files.

**💡 Decisions Behind the Code**

- **Scope limited to the canonical data directory only**: Two other dot-prefixed directories in the project — one for per-project state and one for global configuration — were deliberately left visible on Windows. Both contain logs, session data, and configuration files that developers routinely need to access directly for troubleshooting. Hiding them would remove a usability advantage that Windows offers over Linux and macOS, where those directories are hidden by naming convention whether the user wants it or not.
- **One-time-at-creation rather than idempotent-on-every-start**: An earlier draft proposed running the hide command on every startup to also cover existing installations. This was rejected because it would silently override a user's deliberate choice to un-hide the directory after the fact. The chosen approach respects user agency: once the attribute is set at creation, the tool never touches it again, so a user who manually removes the hidden flag keeps that preference across restarts.
- **Separate native implementations per platform rather than a single cross-platform subprocess**: The IntelliJ plugin uses a JDK file attribute API that requires no child process, while the CLI uses a subprocess call to the Windows built-in `attrib` tool. Spawning a subprocess from Kotlin just to call the Windows attribute utility would add latency and a fragile external dependency when the JDK already exposes the same capability natively. The CLI has no equivalent native API in Node.js, so the subprocess approach is the correct fit there.

**✅ What Was Implemented**

- A new platform-detection helper was added to the CLI codebase that calls the Windows `attrib +h` command via a child process when a directory is first created on Windows, and does nothing on other platforms. The helper is best-effort: it uses a short timeout and silently swallows any errors, because the hidden attribute is cosmetic and should never block the caller.
- The Memory Bank metadata manager was updated to detect whether the hidden data directory was freshly created (versus already existing) and call the helper exactly once at that moment. This means existing installations are not retroactively affected, and repeated startups do not incur unnecessary process spawning.
- The IntelliJ plugin received a parallel implementation using a JDK-native file attribute API instead of spawning an external process, keeping the behavior consistent across all three client surfaces (CLI, VS Code extension, IntelliJ plugin).
- The hidden attribute applies to the DOS hidden flag, which is honored across NTFS, FAT32, exFAT, and ReFS — not limited to NTFS despite the naming of the underlying mechanism.

**📁 FILES**
- `cli/src/util/WindowsHidden.ts`
- `cli/src/core/MetadataManager.ts`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/core/WindowsHidden.kt`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/core/MetadataManager.kt`
- `vscode/src/stores/MemoriesStore.ts`

</blockquote>
</details>
<details>
<summary><strong>02 · Increase default number of Timeline entries shown to fill the screen</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The Timeline view in the Memory Bank was showing only 10 entries by default, leaving a large blank area below them on a typical laptop screen.

**💡 Decisions Behind the Code**

- **Choosing 18 over other candidate values**: The developer initially suggested 50, then the user proposed 18, and the final value was confirmed empirically — the user reported exactly one blank row remaining on their actual 14-inch laptop screen with the current panel layout. This real-device measurement was more reliable than any theoretical calculation, especially after it emerged that each Timeline row is a two-line card (~45px tall) rather than a single-line tree item (~22px), which had caused earlier estimates to be badly wrong.
- **No infinite scroll or viewport-aware loading**: Truly eliminating blank space would require detecting the visible viewport height and loading exactly enough entries to fill it, but the VS Code TreeView API does not expose viewport events. A fixed page size is the only practical option within the current architecture, so the value was tuned empirically rather than solved generically.

**✅ What Was Implemented**

- Changed the page size constant in `vscode/src/stores/MemoriesStore.ts` from 10 to 18, which controls how many memory entries are fetched and rendered on initial load and after each "Load More" action.
- Updated hardcoded numeric assertions across `vscode/src/providers/MemoriesTreeProvider.test.ts` and `vscode/src/stores/MemoriesStore.test.ts` to reflect the new page size (18, 36, 54 for one, two, and three loads respectively).

**📁 FILES**
- `vscode/src/stores/MemoriesStore.ts`

</blockquote>
</details>

---
<!-- jollimemory-summary-end -->