### PR TITLE
Add --arg-stdin flag and here-doc bridge for multi-agent skill support

### DIFF
--- a/cli/src/Cli.test.ts
+++ b/cli/src/Cli.test.ts
@@ -2050,6 +2050,7 @@ describe("CLI", () => {
 			await main(["recall", "branch;rm -rf /", "--format", "json", "--cwd", "/tmp/test"]);
 
 			expect(console.log).toHaveBeenCalledWith(expect.stringContaining("Invalid characters"));
+			expect(process.exitCode).toBe(1);
 		});
 
 		it("should handle errors gracefully with human-readable output by default", async () => {
@@ -2067,6 +2068,9 @@ describe("CLI", () => {
 			await main(["recall", "feature/auth", "--catalog", "--format", "json", "--cwd", "/tmp/test"]);
 
 			expect(console.log).toHaveBeenCalledWith(expect.stringContaining("disk error"));
+			// Exit code MUST be 1 even on the JSON branch — CI / shell pipelines
+			// detect failure via exit code, not stdout parsing.
+			expect(process.exitCode).toBe(1);
 		});
 
 		it("should handle non-Error throws in recall catch block", async () => {
@@ -2075,6 +2079,7 @@ describe("CLI", () => {
 			await main(["recall", "feature/auth", "--catalog", "--cwd", "/tmp/test"]);
 
 			expect(console.error).toHaveBeenCalledWith(expect.stringContaining("string error"));
+			expect(process.exitCode).toBe(1);
 		});
 
 		it("should pass depth and budget options to compileTaskContext", async () => {
@@ -2460,6 +2465,121 @@ describe("CLI", () => {
 			const parsed = JSON.parse(output);
 			expect(parsed.type).toBe("error");
 			expect(parsed.message).toContain("No Jolli Memory records found");
+		});
+
+		// ── --arg-stdin (here-doc bridge from SKILL.md) ──
+		// The skill templates pipe the user's branch/keyword via a here-doc;
+		// recall reads stdin via the `--arg-stdin` flag so user-supplied shell
+		// metacharacters never reach the shell parser.
+
+		async function withStdin<T>(payload: string, fn: () => Promise<T>): Promise<T> {
+			const { Readable } = await import("node:stream");
+			const origStdin = process.stdin;
+			const stream = Readable.from([payload]);
+			Object.defineProperty(process, "stdin", { value: stream, configurable: true });
+			try {
+				return await fn();
+			} finally {
+				Object.defineProperty(process, "stdin", { value: origStdin, configurable: true });
+			}
+		}
+
+		it("--arg-stdin reads the branch/keyword from stdin (matching catalog branch)", async () => {
+			vi.mocked(listBranchCatalog).mockResolvedValueOnce({
+				type: "catalog",
+				branches: [
+					{
+						branch: "feature/auth",
+						commitCount: 1,
+						period: { start: "2026-03-28", end: "2026-03-28" },
+						commitMessages: ["c"],
+					},
+				],
+			});
+			vi.mocked(compileTaskContext).mockResolvedValueOnce({
+				branch: "feature/auth",
+				period: { start: "2026-03-28", end: "2026-03-28" },
+				commitCount: 1,
+				totalFilesChanged: 1,
+				totalInsertions: 0,
+				totalDeletions: 0,
+				summaries: [],
+				plans: [],
+				notes: [],
+				keyDecisions: [],
+				stats: {
+					topicCount: 0,
+					planCount: 0,
+					noteCount: 0,
+					decisionCount: 0,
+					topicTokens: 0,
+					planTokens: 0,
+					noteTokens: 0,
+					decisionTokens: 0,
+					transcriptTokens: 0,
+					totalTokens: 0,
+				},
+			});
+
+			await withStdin("feature/auth\n", () => main(["recall", "--arg-stdin", "--cwd", "/tmp/test"]));
+
+			expect(compileTaskContext).toHaveBeenCalledWith(
+				expect.objectContaining({ branch: "feature/auth" }),
+				"/tmp/test",
+			);
+		});
+
+		it("--arg-stdin with shell metacharacters in stdin is rejected by the safety pattern", async () => {
+			// The point of --arg-stdin is that the user input never touched a
+			// shell — the literal bytes arrive at the CLI verbatim. The deny-
+			// list still rejects them as a downstream safety net before the
+			// content can flow into git operations.
+			await withStdin("$(touch /tmp/jolli-pwn-stdin)\n", () =>
+				main(["recall", "--arg-stdin", "--format", "json", "--cwd", "/tmp/test"]),
+			);
+			const output = vi
+				.mocked(console.log)
+				.mock.calls.map((c) => String(c[0]))
+				.join("");
+			expect(output).toContain('"type":"error"');
+			expect(output).toContain("Invalid characters");
+			expect(process.exitCode).toBe(1);
+		});
+
+		it("--arg-stdin with empty stdin falls back to current branch (or empty catalog)", async () => {
+			// Empty stdin means "no branch supplied" — same behavior as omitting
+			// the positional words. With no current branch (mocked detached
+			// HEAD) and an empty catalog, recall emits the "no records" message.
+			mockExecFileSync.mockImplementation((_cmd: unknown, args: unknown) => {
+				const a = args as string[];
+				if (a.includes("--show-current")) throw new Error("detached HEAD");
+				if (a.includes("--show-toplevel")) return "/tmp/test\n";
+				return "";
+			});
+			vi.mocked(listBranchCatalog).mockResolvedValueOnce({ type: "catalog", branches: [] });
+
+			await withStdin("", () => main(["recall", "--arg-stdin", "--cwd", "/tmp/test"]));
+
+			expect(console.log).toHaveBeenCalledWith(expect.stringContaining("No Jolli Memory records found"));
+		});
+
+		it("rejects --arg-stdin combined with positional words (mutually exclusive, JSON output)", async () => {
+			await main(["recall", "--arg-stdin", "feature/auth", "--format", "json", "--cwd", "/tmp/test"]);
+
+			const output = vi
+				.mocked(console.log)
+				.mock.calls.map((c) => String(c[0]))
+				.join("");
+			expect(output).toContain('"type":"error"');
+			expect(output).toContain("mutually exclusive");
+			expect(process.exitCode).toBe(1);
+		});
+
+		it("rejects --arg-stdin combined with positional words (mutually exclusive, text output)", async () => {
+			await main(["recall", "--arg-stdin", "feature/auth", "--cwd", "/tmp/test"]);
+
+			expect(console.error).toHaveBeenCalledWith(expect.stringContaining("mutually exclusive"));
+			expect(process.exitCode).toBe(1);
 		});
 	});
 

--- a/cli/src/Types.ts
+++ b/cli/src/Types.ts
@@ -203,7 +203,7 @@ export interface LegacyCommitSummary {
 
 // ─── Commit-level classification types ───────────────────────────────────────
 
-/** How the commit was created (based on doc 34 §4.1 Hook participation matrix) */
+/** How the commit was created — the hook-participation classification. */
 export type CommitType = "commit" | "amend" | "squash" | "rebase" | "cherry-pick" | "revert";
 
 /** Whether the operation was triggered from the VSCode plugin or CLI/other git client */

--- a/cli/src/commands/CliUtils.test.ts
+++ b/cli/src/commands/CliUtils.test.ts
@@ -382,6 +382,54 @@ describe("CliUtils", () => {
 			const cjk = "中文-branch-名";
 			expect(await withFakeStdin(cjk)).toBe(cjk);
 		});
+
+		it("rejects immediately when stdin is an interactive TTY (no waiting for EOF)", async () => {
+			// Without this guard, `jolli recall --arg-stdin` in a normal
+			// terminal would hang forever — there's no EOF coming, no prompt
+			// shown to the user. The rejection happens synchronously after
+			// the Promise constructor runs, so a TTY caller exits in
+			// milliseconds with a clear error.
+			const fakeTty = { isTTY: true };
+			Object.defineProperty(process, "stdin", { value: fakeTty, configurable: true });
+			const { readStdin } = await import("./CliUtils.js");
+			await expect(readStdin()).rejects.toThrow(/requires piped stdin/);
+		});
+
+		it("rejects when stdin payload exceeds STDIN_MAX_BYTES (64 KiB cap)", async () => {
+			// Defense in depth: the --arg-stdin path only ever carries a
+			// branch name or short keyword query (skill templates pipe one
+			// line via here-doc). A compromised upstream feeding gigabytes
+			// must not be able to OOM the CLI. 64 KiB is many orders of
+			// magnitude above any legitimate input.
+			const { STDIN_MAX_BYTES } = await import("./CliUtils.js");
+			const tooBig = Buffer.alloc(STDIN_MAX_BYTES + 1, 0x61); // 'a' * (cap + 1)
+			await expect(withFakeStdin(tooBig)).rejects.toThrow(/exceeds .* bytes/);
+		});
+
+		it("accepts a payload at exactly STDIN_MAX_BYTES (boundary)", async () => {
+			// Boundary regression: the cap is "more than", not "at or above".
+			// An input of exactly the limit must succeed so this catches a
+			// future `>=` typo in the size check.
+			const { STDIN_MAX_BYTES } = await import("./CliUtils.js");
+			const atCap = Buffer.alloc(STDIN_MAX_BYTES, 0x62); // 'b' * cap
+			const result = await withFakeStdin(atCap);
+			expect(result.length).toBe(STDIN_MAX_BYTES);
+		});
+
+		it("ignores additional chunks that arrive after the cap-rejection has fired", async () => {
+			// Stream semantics: when a data event triggers the size-cap
+			// rejection, any subsequent data event still arrives (Readable
+			// drains the iterable before emitting 'end'). The `rejected`
+			// guard inside the data handler prevents the late chunk from
+			// pushing past the cap or fighting the already-rejected Promise.
+			const { STDIN_MAX_BYTES, readStdin } = await import("./CliUtils.js");
+			const { Readable } = await import("node:stream");
+			const first = Buffer.alloc(STDIN_MAX_BYTES + 1, 0x63);
+			const second = Buffer.from("trailing-garbage", "utf-8");
+			const stream = Readable.from([first, second]);
+			Object.defineProperty(process, "stdin", { value: stream, configurable: true });
+			await expect(readStdin()).rejects.toThrow(/exceeds .* bytes/);
+		});
 	});
 
 	describe("AmbiguousHashError construction invariants", () => {

--- a/cli/src/commands/CliUtils.test.ts
+++ b/cli/src/commands/CliUtils.test.ts
@@ -5,7 +5,7 @@
  * resolveProjectDir caching, and interactive detection.
  */
 
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const { mockExecFileSync } = vi.hoisted(() => ({
 	mockExecFileSync: vi.fn(),
@@ -318,6 +318,69 @@ describe("CliUtils", () => {
 				console.log = origLog;
 			}
 			expect(stdoutLines).toEqual([]);
+		});
+	});
+
+	// ─── readStdin ───────────────────────────────────────────────────────
+	// `readStdin` reads `process.stdin` to EOF and trims one trailing newline.
+	// The trim matters because the SKILL.md here-doc bridge always appends
+	// a `\n` before the terminator, so without the trim the user-input would
+	// gain an artificial trailing newline relative to a positional argument.
+	describe("readStdin", () => {
+		// Replace process.stdin with a synthetic Readable so each test feeds
+		// deterministic bytes. Restore the original handle in afterEach so a
+		// later test that imports something incidentally touching stdin
+		// (DistPathResolver, etc.) isn't broken.
+		const origStdin = process.stdin;
+		afterEach(() => {
+			Object.defineProperty(process, "stdin", { value: origStdin, configurable: true });
+		});
+
+		async function withFakeStdin(payload: string | Buffer): Promise<string> {
+			const { Readable } = await import("node:stream");
+			const stream = Readable.from(typeof payload === "string" ? [payload] : [payload]);
+			Object.defineProperty(process, "stdin", { value: stream, configurable: true });
+			const { readStdin } = await import("./CliUtils.js");
+			return readStdin();
+		}
+
+		it("returns the full body when stdin has no trailing newline", async () => {
+			expect(await withFakeStdin("feature/auth")).toBe("feature/auth");
+		});
+
+		it("trims a single trailing LF", async () => {
+			expect(await withFakeStdin("feature/auth\n")).toBe("feature/auth");
+		});
+
+		it("trims a single trailing CRLF (Windows here-doc)", async () => {
+			expect(await withFakeStdin("feature/auth\r\n")).toBe("feature/auth");
+		});
+
+		it("only trims ONE trailing newline (preserves intentional inner blanks)", async () => {
+			expect(await withFakeStdin("line1\nline2\n\n")).toBe("line1\nline2\n");
+		});
+
+		it("returns empty string when stdin is empty", async () => {
+			expect(await withFakeStdin("")).toBe("");
+		});
+
+		it("passes shell metacharacters through verbatim ($(), backticks, quotes)", async () => {
+			// This is the whole point of the --arg-stdin bridge: user-supplied
+			// shell metacharacters must arrive at the CLI as literal bytes,
+			// never going through any shell parser.
+			const evil = 'feature/$(touch /tmp/jolli-pwn-readstdin) `whoami` "quote\'mix"';
+			expect(await withFakeStdin(evil)).toBe(evil);
+		});
+
+		it("handles a Buffer chunk (not just string)", async () => {
+			expect(await withFakeStdin(Buffer.from("buf-input\n", "utf-8"))).toBe("buf-input");
+		});
+
+		it("handles multi-byte UTF-8 input correctly", async () => {
+			// UTF-8 bytes split across chunks would be a real failure mode if
+			// readStdin concatenated strings naively. Buffer.concat handles it.
+			const cjk = "中文-branch-名";
+			expect(await withFakeStdin(cjk)).toBe(cjk);
 		});
 	});
 

--- a/cli/src/commands/CliUtils.ts
+++ b/cli/src/commands/CliUtils.ts
@@ -141,6 +141,42 @@ export function isInteractive(): boolean {
 	return process.stdin.isTTY === true;
 }
 
+/**
+ * Reads the entire contents of `process.stdin` to a string, trims one trailing
+ * newline (LF or CRLF) if present, and returns the result.
+ *
+ * Used by `recall --arg-stdin` / `search --arg-stdin` to receive user-supplied
+ * argument text without it ever passing through the shell's argv parser. Skill
+ * templates pipe the user's input via a here-doc, so the argument cannot trigger
+ * `$()` / backtick expansion — that's the whole reason this exists.
+ *
+ * Behavior:
+ *   - Reads all chunks from stdin until EOF; binary safe (concatenates as UTF-8).
+ *   - Trims a single trailing `\n` or `\r\n` (a here-doc always appends one).
+ *     Inner newlines are preserved verbatim — the caller decides whether to
+ *     accept a multi-line argument.
+ *   - Resolves to `""` on empty stdin (the caller distinguishes that from a
+ *     missing flag).
+ */
+export function readStdin(): Promise<string> {
+	return new Promise((resolve, reject) => {
+		const chunks: Buffer[] = [];
+		const stdin = process.stdin;
+		stdin.on("data", (chunk: Buffer | string) => {
+			chunks.push(typeof chunk === "string" ? Buffer.from(chunk) : chunk);
+		});
+		stdin.on("end", () => {
+			let text = Buffer.concat(chunks).toString("utf-8");
+			if (text.endsWith("\r\n")) text = text.slice(0, -2);
+			else if (text.endsWith("\n")) text = text.slice(0, -1);
+			resolve(text);
+		});
+		/* v8 ignore start -- defensive: stdin error events are rare in practice */
+		stdin.on("error", reject);
+		/* v8 ignore stop */
+	});
+}
+
 const AMBIGUOUS_DISPLAY_LIMIT = 10;
 
 /**

--- a/cli/src/commands/CliUtils.ts
+++ b/cli/src/commands/CliUtils.ts
@@ -142,6 +142,15 @@ export function isInteractive(): boolean {
 }
 
 /**
+ * Hard cap on `--arg-stdin` payload size. The flag only ever carries a branch
+ * name or short keyword query (skill templates pipe a single line via here-doc).
+ * 64 KiB is many orders of magnitude above any legitimate input but small
+ * enough that a compromised or buggy upstream cannot OOM the CLI by streaming
+ * gigabytes into stdin.
+ */
+export const STDIN_MAX_BYTES = 64 * 1024;
+
+/**
  * Reads the entire contents of `process.stdin` to a string, trims one trailing
  * newline (LF or CRLF) if present, and returns the result.
  *
@@ -151,7 +160,11 @@ export function isInteractive(): boolean {
  * `$()` / backtick expansion — that's the whole reason this exists.
  *
  * Behavior:
+ *   - Rejects immediately when stdin is an interactive TTY. The flag is only
+ *     meaningful with piped input; calling it interactively would otherwise
+ *     hang forever waiting for EOF with no prompt to the user.
  *   - Reads all chunks from stdin until EOF; binary safe (concatenates as UTF-8).
+ *   - Rejects when the cumulative byte count exceeds {@link STDIN_MAX_BYTES}.
  *   - Trims a single trailing `\n` or `\r\n` (a here-doc always appends one).
  *     Inner newlines are preserved verbatim — the caller decides whether to
  *     accept a multi-line argument.
@@ -160,12 +173,31 @@ export function isInteractive(): boolean {
  */
 export function readStdin(): Promise<string> {
 	return new Promise((resolve, reject) => {
-		const chunks: Buffer[] = [];
 		const stdin = process.stdin;
+		if (stdin.isTTY) {
+			reject(
+				new Error(
+					"--arg-stdin requires piped stdin; it cannot be used interactively. Pipe the argument via a here-doc or echo.",
+				),
+			);
+			return;
+		}
+		const chunks: Buffer[] = [];
+		let total = 0;
+		let rejected = false;
 		stdin.on("data", (chunk: Buffer | string) => {
-			chunks.push(typeof chunk === "string" ? Buffer.from(chunk) : chunk);
+			if (rejected) return;
+			const buf = typeof chunk === "string" ? Buffer.from(chunk) : chunk;
+			total += buf.length;
+			if (total > STDIN_MAX_BYTES) {
+				rejected = true;
+				reject(new Error(`--arg-stdin payload exceeds ${STDIN_MAX_BYTES} bytes`));
+				return;
+			}
+			chunks.push(buf);
 		});
 		stdin.on("end", () => {
+			if (rejected) return;
 			let text = Buffer.concat(chunks).toString("utf-8");
 			if (text.endsWith("\r\n")) text = text.slice(0, -2);
 			else if (text.endsWith("\n")) text = text.slice(0, -1);

--- a/cli/src/commands/ExportCommand.ts
+++ b/cli/src/commands/ExportCommand.ts
@@ -5,7 +5,8 @@
  *   - `export` — Export commit summaries as markdown files to ~/Documents/jollimemory/<project>/
  *   - `export-prompt` — Print prompt templates to stdout, or write to a folder
  *      with manifest.json (for backend DB seeding) plus per-prompt .md files
- *      (for human review). See plan 121 for the manifest schema.
+ *      (for human review). The manifest schema is the `Manifest` /
+ *      `ManifestEntry` interfaces declared below.
  */
 
 import { mkdir, readFile, writeFile } from "node:fs/promises";
@@ -35,7 +36,7 @@ function extractPlaceholders(template: string): ReadonlyArray<string> {
 	return [...set].sort();
 }
 
-/** Manifest entry for a single prompt template — see plan 121 for schema. */
+/** Manifest entry for a single prompt template. */
 interface ManifestEntry {
 	readonly action: string;
 	readonly version: number;

--- a/cli/src/commands/RecallCommand.ts
+++ b/cli/src/commands/RecallCommand.ts
@@ -27,7 +27,7 @@ import {
 import { collectAllTopics } from "../core/SummaryTree.js";
 import { setLogDir } from "../Logger.js";
 import type { CommitSummary } from "../Types.js";
-import { formatShortDate, parsePositiveInt, resolveProjectDir, SAFE_ARGUMENT_PATTERN } from "./CliUtils.js";
+import { formatShortDate, parsePositiveInt, readStdin, resolveProjectDir, SAFE_ARGUMENT_PATTERN } from "./CliUtils.js";
 
 /**
  * Maximum branches shown in terminal-friendly catalog output.
@@ -146,7 +146,7 @@ function renderShortSummary(ctx: {
 	lines.push(`  Files changed: ${ctx.totalFilesChanged}`);
 	lines.push("");
 	lines.push("  Run with --full or --output <path> for full context.");
-	lines.push("  Run /jolli-recall in Claude Code for AI-assisted recall.");
+	lines.push("  Run the jolli-recall skill (e.g. /jolli-recall in Claude Code) for AI-assisted recall.");
 	lines.push("");
 
 	return lines.join("\n");
@@ -250,15 +250,44 @@ export function registerRecallCommand(program: Command): void {
 		.option("--include-transcripts", "Include transcript excerpts")
 		.option("--no-plans", "Exclude plan content")
 		.option("--catalog", "List all recorded branches (lightweight)")
+		.option(
+			"--arg-stdin",
+			"Read the branch/keyword argument from stdin instead of argv (used by SKILL.md here-doc bridge)",
+		)
 		.addOption(new Option("--format <fmt>", "Output format").choices(["md", "json"]))
 		.option("--cwd <dir>", "Project directory (default: git repo root)", resolveProjectDir())
 		.action(async (words: string[], options) => {
-			const branchOrKeyword = words.length > 0 ? words.join(" ") : undefined;
 			try {
 				const projectDir = options.cwd;
 				setLogDir(projectDir);
 
-				// Validate argument (prevent shell injection via $ARGUMENTS)
+				// --arg-stdin is mutually exclusive with positional words. The skill
+				// template's here-doc pipeline relies on stdin being the single
+				// source of truth for the user's argument; mixing them would silently
+				// drop one or the other and undermine the injection-defense contract.
+				if (options.argStdin && words.length > 0) {
+					const message =
+						"--arg-stdin and positional [words...] are mutually exclusive. Pass the argument via stdin OR positional, not both.";
+					if (options.format === "json") {
+						console.log(JSON.stringify({ type: "error", message }));
+					} else {
+						console.error(`\n  Error: ${message}\n`);
+					}
+					process.exitCode = 1;
+					return;
+				}
+
+				let branchOrKeyword: string | undefined;
+				if (options.argStdin) {
+					const fromStdin = await readStdin();
+					branchOrKeyword = fromStdin.length > 0 ? fromStdin : undefined;
+				} else {
+					branchOrKeyword = words.length > 0 ? words.join(" ") : undefined;
+				}
+
+				// Validate argument (defense in depth: the user input has already
+				// bypassed shell parsing via here-doc/argv, but malicious content
+				// could still flow downstream into git operations).
 				if (branchOrKeyword && !SAFE_ARGUMENT_PATTERN.test(branchOrKeyword)) {
 					const message =
 						"Invalid characters in argument. Only letters, numbers, hyphens, underscores, slashes, and dots are allowed.";
@@ -266,8 +295,8 @@ export function registerRecallCommand(program: Command): void {
 						console.log(JSON.stringify({ type: "error", message }));
 					} else {
 						console.error(`\n  Error: ${message}\n`);
-						process.exitCode = 1;
 					}
+					process.exitCode = 1;
 					return;
 				}
 
@@ -350,8 +379,10 @@ export function registerRecallCommand(program: Command): void {
 					console.log(JSON.stringify({ type: "error", message }));
 				} else {
 					console.error(`\n  Error: ${message}\n`);
-					process.exitCode = 1;
 				}
+				// Always set a non-zero exit code so CI / shell pipelines detect the
+				// failure regardless of which output format the caller asked for.
+				process.exitCode = 1;
 			}
 		});
 }

--- a/cli/src/commands/SearchCommand.test.ts
+++ b/cli/src/commands/SearchCommand.test.ts
@@ -557,4 +557,82 @@ describe("registerSearchCommand", () => {
 		expect(stdout).toContain('"type":"error"');
 		expect(stdout).toContain("string error");
 	});
+
+	// ─── --arg-stdin (here-doc bridge from SKILL.md) ─────────────────────
+	// The skill templates pipe user-supplied query text via a here-doc with an
+	// LLM-generated random delimiter; the CLI reads stdin instead of argv so
+	// shell metacharacters never reach a shell parser. These tests confirm
+	// the wiring: stdin content arrives at the search pipeline verbatim,
+	// mutual exclusion with positional args fires, and the empty-stdin case
+	// degrades to the same behavior as an empty positional query.
+
+	async function runWithStdin(args: string[], stdinPayload: string): Promise<{ stdout: string; stderr: string }> {
+		const { Readable } = await import("node:stream");
+		const origStdin = process.stdin;
+		const stream = Readable.from([stdinPayload]);
+		Object.defineProperty(process, "stdin", { value: stream, configurable: true });
+		try {
+			return await runCommand(args);
+		} finally {
+			Object.defineProperty(process, "stdin", { value: origStdin, configurable: true });
+		}
+	}
+
+	it("--arg-stdin reads the query from stdin verbatim (shell metacharacters preserved)", async () => {
+		// `$(date)` is a shell-injection probe — feeding it on stdin must NOT
+		// trigger the deny-list (the user input never went through the shell).
+		// The CLI rejects it because the query content still violates the
+		// `isSafeQuery` policy, but the value the CLI inspected is the literal
+		// string, not a command output.
+		const { stdout } = await runWithStdin(["--arg-stdin", "--cwd", "/tmp/jolli-search-test-empty"], "$(date)\n");
+		// Query is rejected at the validation layer, but the rejection means
+		// the CLI saw the literal `$(date)` — not the shell-expansion result.
+		expect(stdout).toContain('"type":"error"');
+		expect(stdout).toContain("Invalid characters");
+	});
+
+	it("--arg-stdin accepts a safe natural-language query and runs the catalog phase", async () => {
+		const { stdout } = await runWithStdin(
+			["--arg-stdin", "--cwd", "/tmp/jolli-search-test-empty"],
+			"why did we choose X?\n",
+		);
+		expect(stdout).toContain('"type": "search-catalog"');
+		expect(stdout).toContain('"query": "why did we choose X?"');
+	});
+
+	it("--arg-stdin with empty stdin behaves like an empty positional query (catalog only)", async () => {
+		const { stdout } = await runWithStdin(["--arg-stdin", "--cwd", "/tmp/jolli-search-test-empty"], "");
+		expect(stdout).toContain('"type": "search-catalog"');
+	});
+
+	it("--arg-stdin combined with --hashes performs the Phase 2 lookup using stdin as the highlight query", async () => {
+		mockGetSummary.mockResolvedValueOnce({
+			version: 4,
+			commitHash: "abcd1234abcd1234abcd1234abcd1234abcd1234",
+			commitMessage: "msg",
+			commitAuthor: "dev",
+			commitDate: "2026-04-01T00:00:00.000Z",
+			branch: "x",
+			generatedAt: "2026-04-01T00:00:00.000Z",
+			topics: [{ title: "t", trigger: "tr", response: "rs", decisions: "d" }],
+		});
+		const { stdout } = await runWithStdin(
+			[
+				"--arg-stdin",
+				"--hashes",
+				"abcd1234abcd1234abcd1234abcd1234abcd1234",
+				"--cwd",
+				"/tmp/jolli-search-test-found",
+			],
+			"auth\n",
+		);
+		expect(stdout).toContain('"type": "search"');
+	});
+
+	it("rejects --arg-stdin combined with positional words (mutually exclusive)", async () => {
+		const { stdout } = await runCommand(["--arg-stdin", "auth", "--cwd", "/tmp/jolli-search-test-empty"]);
+		expect(stdout).toContain('"type":"error"');
+		expect(stdout).toContain("mutually exclusive");
+		expect(process.exitCode).toBe(1);
+	});
 });

--- a/cli/src/commands/SearchCommand.ts
+++ b/cli/src/commands/SearchCommand.ts
@@ -23,7 +23,7 @@ import { type Command, Option } from "commander";
 import { LocalSearchProvider } from "../core/LocalSearchProvider.js";
 import { DEFAULT_CATALOG_LIMIT, DEFAULT_SEARCH_BUDGET, type SearchCatalog, type SearchResult } from "../core/Search.js";
 import { setLogDir } from "../Logger.js";
-import { isSafeQuery, parsePositiveInt, resolveProjectDir } from "./CliUtils.js";
+import { isSafeQuery, parsePositiveInt, readStdin, resolveProjectDir } from "./CliUtils.js";
 
 /**
  * Pattern matching a comma-separated list of **8- to 40-char hex SHAs**.
@@ -48,6 +48,7 @@ interface SearchOptions {
 	format?: "json" | "text";
 	output?: string;
 	cwd?: string;
+	argStdin?: boolean;
 }
 
 /**
@@ -164,6 +165,7 @@ export function registerSearchCommand(program: Command): void {
 		)
 		.addOption(new Option("--format <fmt>", "Output format").choices(["json", "text"]).default("json"))
 		.option("--output <path>", "Write output to file instead of stdout")
+		.option("--arg-stdin", "Read the query argument from stdin instead of argv (used by SKILL.md here-doc bridge)")
 		.option("--cwd <dir>", "Project directory (default: git repo root)", resolveProjectDir())
 		.action(async (words: string[], options: SearchOptions) => {
 			try {
@@ -172,7 +174,24 @@ export function registerSearchCommand(program: Command): void {
 				const projectDir = options.cwd as string;
 				setLogDir(projectDir);
 
-				const query = words.length > 0 ? words.join(" ") : "";
+				// --arg-stdin is mutually exclusive with positional words. The skill
+				// template's here-doc pipeline pushes the query via stdin and CLI
+				// flags via argv; allowing both at once would silently concatenate
+				// or drop one side and undermine the injection-defense contract.
+				if (options.argStdin && words.length > 0) {
+					emitError(
+						options,
+						"--arg-stdin and positional [words...] are mutually exclusive. Pass the query via stdin OR positional, not both.",
+					);
+					return;
+				}
+
+				let query: string;
+				if (options.argStdin) {
+					query = await readStdin();
+				} else {
+					query = words.length > 0 ? words.join(" ") : "";
+				}
 
 				// Validate query characters when present (prevents shell injection).
 				// Uses isSafeQuery — a deny-list of characters that escape a double-

--- a/cli/src/hooks/PostCommitHook.test.ts
+++ b/cli/src/hooks/PostCommitHook.test.ts
@@ -1385,7 +1385,7 @@ describe("queue-driven Worker", () => {
 			);
 			// The message-only amend ALSO writes diffStats (the full commit diff) on
 			// the migrated summary, so display code doesn't fall back to recursive
-			// aggregation of children. This was previously missed — see plan.
+			// aggregation of children.
 			const summaryArg = vi.mocked(storeSummary).mock.calls[0][0] as CommitSummary;
 			expect(summaryArg.diffStats).toEqual({ filesChanged: 3, insertions: 70, deletions: 15 });
 			// `stats` field stays undefined on the migrated summary (this path never

--- a/cli/src/hooks/SessionStartHook.test.ts
+++ b/cli/src/hooks/SessionStartHook.test.ts
@@ -293,7 +293,9 @@ describe("SessionStartHook", () => {
 
 		expect(writeSpy).toHaveBeenCalledTimes(1);
 		const output = writeSpy.mock.calls[0][0] as string;
-		expect(output).toContain("Tip: /jolli-recall");
+		// v5: cross-platform phrasing covers Codex / Cursor / etc. as well.
+		expect(output).toContain("Tip: run the jolli-recall skill");
+		expect(output).toContain("/jolli-recall in Claude Code");
 		expect(output).not.toContain("Warning:");
 		writeSpy.mockRestore();
 	});
@@ -1145,7 +1147,8 @@ describe("SessionStartHook", () => {
 
 		expect(writeSpy).toHaveBeenCalledTimes(1);
 		const output = writeSpy.mock.calls[0][0] as string;
-		expect(output).toContain("Tip: /jolli-recall");
+		expect(output).toContain("Tip: run the jolli-recall skill");
+		expect(output).toContain("/jolli-recall in Claude Code");
 		expect(output).not.toContain("Warning:");
 		writeSpy.mockRestore();
 	});

--- a/cli/src/hooks/SessionStartHook.ts
+++ b/cli/src/hooks/SessionStartHook.ts
@@ -287,13 +287,16 @@ function buildBriefingText(
 		lines.push(`Plans: ${planNames.join("; ")}`);
 	}
 
-	// Line 6: Recall suggestion based on time gap
+	// Line 6: Recall suggestion based on time gap. Phrasing covers every
+	// agent host — Claude Code uses `/jolli-recall`, other platforms (Codex,
+	// Cursor, OpenCode, Windsurf, Gemini) invoke the same skill via natural
+	// language, mentions, or their own slash syntax.
 	if (daysSinceLastCommit > 3) {
 		lines.push(
-			`Warning: ${daysSinceLastCommit} days since last commit. Suggest running /jolli-recall for full context.`,
+			`Warning: ${daysSinceLastCommit} days since last commit. Suggest running the jolli-recall skill (e.g. /jolli-recall in Claude Code) for full context.`,
 		);
 	} else if (daysSinceLastCommit > 0) {
-		lines.push("Tip: /jolli-recall for full context");
+		lines.push("Tip: run the jolli-recall skill (e.g. /jolli-recall in Claude Code) for full context");
 	}
 
 	return lines.join("\n");

--- a/cli/src/install/GitExclude.test.ts
+++ b/cli/src/install/GitExclude.test.ts
@@ -1,0 +1,268 @@
+/**
+ * GitExclude tests.
+ *
+ * The helpers shell out to `git rev-parse --git-path info/exclude` to find
+ * the right exclude file (linked worktrees and submodules don't have a plain
+ * `<projectDir>/.git/info/exclude`). Tests stand up real git repos in temp
+ * dirs so the integration with git is exercised end-to-end.
+ */
+import { execFile } from "node:child_process";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { normalizeGitPathOutput, resolveGitExcludePath, updateGitExclude } from "./GitExclude.js";
+
+const execFileAsync = promisify(execFile);
+
+let tempDir: string;
+
+async function gitInit(dir: string): Promise<void> {
+	// `-c init.defaultBranch=main` keeps the test deterministic across the
+	// user's local git config (some folks default to `master`).
+	await execFileAsync("git", ["-c", "init.defaultBranch=main", "init", "--quiet", dir], { windowsHide: true });
+}
+
+beforeEach(() => {
+	tempDir = mkdtempSync(join(tmpdir(), "jolli-git-exclude-"));
+});
+
+afterEach(() => {
+	rmSync(tempDir, { recursive: true, force: true });
+});
+
+// ─── normalizeGitPathOutput ────────────────────────────────────────────────
+
+describe("normalizeGitPathOutput", () => {
+	it("returns a win32-style absolute path unchanged", () => {
+		// Standard `git rev-parse` output on Windows with native Windows git.
+		const out = normalizeGitPathOutput("C:\\Users\\u\\repo\\.git\\info\\exclude", "/tmp/proj");
+		expect(out).toBe("C:\\Users\\u\\repo\\.git\\info\\exclude");
+	});
+
+	it("returns a POSIX-style absolute path unchanged (Windows + Git Bash case)", () => {
+		// Git Bash on Windows can emit `/c/Users/.../info/exclude`. Node's win32
+		// `isAbsolute` rejects this form, so the posix.isAbsolute fallback in
+		// `normalizeGitPathOutput` is what keeps the path from being wrongly
+		// join()'d under projectDir.
+		const out = normalizeGitPathOutput("/c/Users/u/repo/.git/info/exclude", "C:\\tmp\\proj");
+		expect(out).toBe("/c/Users/u/repo/.git/info/exclude");
+	});
+
+	it("joins a relative path under projectDir", () => {
+		const out = normalizeGitPathOutput(".git/info/exclude", "/tmp/proj");
+		// `join` normalizes the separator per platform; check the suffix in a
+		// separator-agnostic way.
+		expect(out.replace(/\\/g, "/")).toBe("/tmp/proj/.git/info/exclude");
+	});
+});
+
+// ─── resolveGitExcludePath ─────────────────────────────────────────────────
+
+describe("resolveGitExcludePath", () => {
+	it("returns the absolute path to .git/info/exclude in a regular repo", async () => {
+		await gitInit(tempDir);
+		const resolved = await resolveGitExcludePath(tempDir);
+		expect(resolved).not.toBeNull();
+		// On Windows git emits forward slashes; check the suffix in a separator-
+		// agnostic way.
+		expect(resolved?.replace(/\\/g, "/")).toMatch(/\.git\/info\/exclude$/);
+	});
+
+	it("returns null when projectDir is not inside a git repo", async () => {
+		// tempDir is freshly created, no `git init`, so `git rev-parse` fails.
+		const resolved = await resolveGitExcludePath(tempDir);
+		expect(resolved).toBeNull();
+	});
+
+	it("returns null when given a path that doesn't exist", async () => {
+		const resolved = await resolveGitExcludePath(join(tempDir, "nonexistent-subdir"));
+		expect(resolved).toBeNull();
+	});
+});
+
+// ─── updateGitExclude — fresh writes ───────────────────────────────────────
+
+describe("updateGitExclude — fresh writes", () => {
+	it("creates the managed block when info/exclude doesn't exist yet", async () => {
+		await gitInit(tempDir);
+		// `git init` creates a default exclude with comments. Remove it to
+		// simulate the no-file case.
+		const fs = await import("node:fs/promises");
+		const excludePath = (await resolveGitExcludePath(tempDir)) as string;
+		await fs.rm(excludePath, { force: true });
+
+		const ok = await updateGitExclude(tempDir, ["/.agents/skills/jolli-recall/"]);
+		expect(ok).toBe(true);
+
+		const written = readFileSync(excludePath, "utf-8");
+		expect(written).toContain("# >>> jolli skill exclude >>>");
+		expect(written).toContain("/.agents/skills/jolli-recall/");
+		expect(written).toContain("# <<< jolli skill exclude <<<");
+	});
+
+	it("appends the block when info/exclude exists with user content", async () => {
+		await gitInit(tempDir);
+		const excludePath = (await resolveGitExcludePath(tempDir)) as string;
+		// Plant user content. Note `info/exclude` is a regular file, no special
+		// handling needed.
+		await writeFile(excludePath, "# user comment\nmy-personal-ignore\n", "utf-8");
+
+		const ok = await updateGitExclude(tempDir, ["/.agents/skills/jolli-recall/"]);
+		expect(ok).toBe(true);
+
+		const written = readFileSync(excludePath, "utf-8");
+		// User content preserved on top.
+		expect(written.startsWith("# user comment\nmy-personal-ignore\n")).toBe(true);
+		// Block appended.
+		expect(written).toMatch(
+			/# >>> jolli skill exclude >>>\n\/\.agents\/skills\/jolli-recall\/\n# <<< jolli skill exclude <<</,
+		);
+	});
+
+	it("appends the block when info/exclude has no trailing newline", async () => {
+		await gitInit(tempDir);
+		const excludePath = (await resolveGitExcludePath(tempDir)) as string;
+		// Plant content with NO trailing newline.
+		await writeFile(excludePath, "user-line", "utf-8");
+
+		const ok = await updateGitExclude(tempDir, ["/.agents/skills/jolli-recall/"]);
+		expect(ok).toBe(true);
+
+		const written = readFileSync(excludePath, "utf-8");
+		// Separator newline must be inserted before the block so the user's
+		// last line and the block-start marker aren't smashed together.
+		expect(written.startsWith("user-line\n# >>> jolli skill exclude >>>")).toBe(true);
+	});
+
+	it("writes all paths in the order given", async () => {
+		await gitInit(tempDir);
+		const paths = [
+			"/.agents/skills/jolli-recall/",
+			"/.agents/skills/jolli-search/",
+			"/.claude/skills/jolli-recall/",
+			"/.claude/skills/jolli-search/",
+		];
+		const ok = await updateGitExclude(tempDir, paths);
+		expect(ok).toBe(true);
+
+		const excludePath = (await resolveGitExcludePath(tempDir)) as string;
+		const written = readFileSync(excludePath, "utf-8");
+		// All 4 paths present.
+		for (const p of paths) {
+			expect(written).toContain(p);
+		}
+		// And in the same relative order.
+		const positions = paths.map((p) => written.indexOf(p));
+		const sorted = [...positions].sort((a, b) => a - b);
+		expect(positions).toEqual(sorted);
+	});
+});
+
+// ─── updateGitExclude — idempotency and replacement ────────────────────────
+
+describe("updateGitExclude — idempotency", () => {
+	it("running twice with the same paths is a no-op (file content unchanged)", async () => {
+		await gitInit(tempDir);
+		const paths = ["/.agents/skills/jolli-recall/", "/.claude/skills/jolli-recall/"];
+		await updateGitExclude(tempDir, paths);
+		const excludePath = (await resolveGitExcludePath(tempDir)) as string;
+		const first = readFileSync(excludePath, "utf-8");
+
+		await updateGitExclude(tempDir, paths);
+		const second = readFileSync(excludePath, "utf-8");
+
+		expect(second).toBe(first);
+	});
+
+	it("rewrites the block when the path list changes (e.g. a skill removed)", async () => {
+		await gitInit(tempDir);
+		const excludePath = (await resolveGitExcludePath(tempDir)) as string;
+		await updateGitExclude(tempDir, [
+			"/.agents/skills/jolli-recall/",
+			"/.agents/skills/jolli-search/",
+			"/.agents/skills/jolli-old-removed/",
+		]);
+
+		await updateGitExclude(tempDir, ["/.agents/skills/jolli-recall/", "/.agents/skills/jolli-search/"]);
+		const written = readFileSync(excludePath, "utf-8");
+
+		expect(written).toContain("/.agents/skills/jolli-recall/");
+		expect(written).toContain("/.agents/skills/jolli-search/");
+		// Stale entry got removed during the rewrite.
+		expect(written).not.toContain("/.agents/skills/jolli-old-removed/");
+		// Exactly one managed block (no duplicates).
+		expect(written.match(/# >>> jolli skill exclude >>>/g)?.length).toBe(1);
+		expect(written.match(/# <<< jolli skill exclude <<</g)?.length).toBe(1);
+	});
+
+	it("preserves user content above and below the managed block during a rewrite", async () => {
+		await gitInit(tempDir);
+		const excludePath = (await resolveGitExcludePath(tempDir)) as string;
+		await writeFile(
+			excludePath,
+			"# user comment top\n*.user-pattern\n# >>> jolli skill exclude >>>\n/.agents/skills/jolli-old/\n# <<< jolli skill exclude <<<\n# user comment bottom\n",
+			"utf-8",
+		);
+
+		await updateGitExclude(tempDir, ["/.agents/skills/jolli-recall/"]);
+		const written = readFileSync(excludePath, "utf-8");
+
+		expect(written).toContain("# user comment top");
+		expect(written).toContain("*.user-pattern");
+		expect(written).toContain("# user comment bottom");
+		expect(written).toContain("/.agents/skills/jolli-recall/");
+		expect(written).not.toContain("/.agents/skills/jolli-old/");
+	});
+});
+
+// ─── updateGitExclude — failure modes ──────────────────────────────────────
+
+describe("updateGitExclude — failure modes", () => {
+	it("returns false (no throw) when projectDir is not a git repo", async () => {
+		// tempDir has no `.git` — `git rev-parse` will error.
+		const ok = await updateGitExclude(tempDir, ["/.agents/skills/jolli-recall/"]);
+		expect(ok).toBe(false);
+	});
+
+	it("returns false when projectDir doesn't exist at all", async () => {
+		const ok = await updateGitExclude(join(tempDir, "nonexistent"), ["/.agents/skills/jolli-recall/"]);
+		expect(ok).toBe(false);
+	});
+});
+
+// ─── updateGitExclude — linked worktree path ───────────────────────────────
+
+describe("updateGitExclude — linked worktree", () => {
+	it("writes to the main repo's info/exclude when invoked from a linked worktree", async () => {
+		await gitInit(tempDir);
+		// Need an initial commit so `git worktree add` succeeds.
+		const fs = await import("node:fs/promises");
+		await fs.writeFile(join(tempDir, "README.md"), "init\n");
+		await execFileAsync("git", ["-C", tempDir, "add", "README.md"], { windowsHide: true });
+		await execFileAsync(
+			"git",
+			["-C", tempDir, "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-m", "init"],
+			{ windowsHide: true },
+		);
+
+		const wtDir = join(tempDir, "wt");
+		await execFileAsync("git", ["-C", tempDir, "worktree", "add", "-b", "branch-x", wtDir], { windowsHide: true });
+
+		const ok = await updateGitExclude(wtDir, ["/.agents/skills/jolli-recall/"]);
+		expect(ok).toBe(true);
+
+		// `info/` lives under the COMMON git dir (main repo's .git/info/),
+		// not the per-worktree dir. resolveGitExcludePath delegates to
+		// `git rev-parse --git-path info/exclude` so this should resolve
+		// to the main repo's exclude file.
+		const wtExcludePath = (await resolveGitExcludePath(wtDir)) as string;
+		expect(wtExcludePath).not.toBeNull();
+		expect(existsSync(wtExcludePath)).toBe(true);
+
+		const written = readFileSync(wtExcludePath, "utf-8");
+		expect(written).toContain("/.agents/skills/jolli-recall/");
+	});
+});

--- a/cli/src/install/GitExclude.ts
+++ b/cli/src/install/GitExclude.ts
@@ -1,0 +1,191 @@
+/**
+ * Manages the per-repo `.git/info/exclude` file so generated Jolli skill
+ * directories (`.agents/skills/jolli-*`, `.claude/skills/jolli-*`) don't show
+ * up in `git status` for user repositories.
+ *
+ * We intentionally do **not** touch `.gitignore` — that file is shared with
+ * collaborators via git and modifying it on the user's behalf would push a
+ * Jolli-specific concern into their VCS history. `.git/info/exclude` is git's
+ * own escape hatch for local-only ignore rules; it isn't tracked or shared.
+ *
+ * Path resolution goes through `git rev-parse --git-path info/exclude` so the
+ * exclude file is found even when `.git` is a file (linked worktree) or lives
+ * elsewhere (submodule). Pure path joins under `<projectDir>/.git/info/exclude`
+ * silently miss those cases.
+ *
+ * Failure mode: if git is unavailable or the project isn't a git repo, the
+ * function logs a warning and returns without throwing. The skill files
+ * themselves still get written; the user just may see them in `git status`.
+ */
+
+import { execFile } from "node:child_process";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname, join, posix as posixPath, win32 as win32Path } from "node:path";
+import { promisify } from "node:util";
+import { createLogger } from "../Logger.js";
+
+const execFileAsync = promisify(execFile);
+const log = createLogger("GitExclude");
+
+/**
+ * Marker pair bracketing Jolli's managed block in `.git/info/exclude`. Lines
+ * between the start and end markers belong to Jolli and may be rewritten on
+ * future installs. Anything outside the markers is untouched.
+ */
+const BLOCK_START = "# >>> jolli skill exclude >>>";
+const BLOCK_END = "# <<< jolli skill exclude <<<";
+
+/**
+ * Resolves the absolute path to `.git/info/exclude` for `projectDir`.
+ *
+ * Uses `git rev-parse --git-path info/exclude` because:
+ *   - In a linked worktree, `.git` is a file pointing at the real gitdir, and
+ *     `info/` lives under the **common** dir, not the per-worktree one.
+ *   - Submodules store `.git` outside the repo working tree entirely.
+ * A naive `join(projectDir, ".git/info/exclude")` silently writes to the
+ * wrong place (or fails) in either case.
+ *
+ * Returns `null` when git isn't installed, the project isn't a repo, or any
+ * other invocation error — callers treat that as "fail soft, log only".
+ */
+/**
+ * Normalizes the output of `git rev-parse --git-path info/exclude`.
+ *
+ * Returns the input unchanged when it's an absolute path; otherwise joins it
+ * under `projectDir`. Accepts both win32-style (`C:\...`) and POSIX-style
+ * (`/c/Users/...`) absolute forms — Git Bash on Windows emits the latter,
+ * native Windows git emits the former, and we don't want to assume which.
+ *
+ * Important: we explicitly call `win32.isAbsolute` AND `posix.isAbsolute`
+ * rather than the platform-default `isAbsolute`. The form `git rev-parse`
+ * emits depends on git's own behavior (not on the platform running this
+ * code), so on a Linux CI runner a Windows-style path must still be
+ * recognized as absolute — otherwise it'd be wrongly join()'d under
+ * projectDir.
+ *
+ * Pure function for ease of unit testing — `resolveGitExcludePath` shells out
+ * to git, this helper handles the path normalization alone.
+ */
+export function normalizeGitPathOutput(relOrAbs: string, projectDir: string): string {
+	const absolute = win32Path.isAbsolute(relOrAbs) || posixPath.isAbsolute(relOrAbs);
+	return absolute ? relOrAbs : join(projectDir, relOrAbs);
+}
+
+export async function resolveGitExcludePath(projectDir: string): Promise<string | null> {
+	try {
+		const { stdout } = await execFileAsync("git", ["rev-parse", "--git-path", "info/exclude"], {
+			cwd: projectDir,
+			windowsHide: true,
+		});
+		const relOrAbs = stdout.trim();
+		/* v8 ignore start -- defensive: git rev-parse always emits a non-empty path on success */
+		if (relOrAbs.length === 0) return null;
+		/* v8 ignore stop */
+		return normalizeGitPathOutput(relOrAbs, projectDir);
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Appends or refreshes Jolli's managed block in `<projectDir>/.git/info/exclude`
+ * with the given `paths`. Idempotent — running it twice in a row is a no-op.
+ *
+ * Block format:
+ * ```
+ * # >>> jolli skill exclude >>>
+ * /.agents/skills/jolli-recall/
+ * /.agents/skills/jolli-search/
+ * /.claude/skills/jolli-recall/
+ * /.claude/skills/jolli-search/
+ * # <<< jolli skill exclude <<<
+ * ```
+ *
+ * If the markers already exist, the block between them is replaced with the
+ * current `paths` (so removing a skill from {@link SKILL_GIT_EXCLUDE_PATHS}
+ * later removes its exclude line on the next install). If the markers don't
+ * exist, the block is appended.
+ *
+ * **Never throws.** Logs and returns false on any I/O / git error so a broken
+ * `.git/info/exclude` setup doesn't break `jolli enable` for the whole user.
+ */
+export async function updateGitExclude(projectDir: string, paths: ReadonlyArray<string>): Promise<boolean> {
+	const excludePath = await resolveGitExcludePath(projectDir);
+	if (!excludePath) {
+		log.warn("Skipping .git/info/exclude update for %s: not a git repo or git unavailable", projectDir);
+		return false;
+	}
+
+	let existing = "";
+	try {
+		existing = await readFile(excludePath, "utf-8");
+	} catch (err: unknown) {
+		const code = (err as NodeJS.ErrnoException).code;
+		/* v8 ignore start -- defensive: non-ENOENT read errors (perm denied, EISDIR) */
+		if (code !== "ENOENT") {
+			log.warn("Failed to read %s: %s — skipping update", excludePath, (err as Error).message);
+			return false;
+		}
+		/* v8 ignore stop */
+	}
+
+	const managedBlock = renderBlock(paths);
+	const updated = applyBlock(existing, managedBlock);
+
+	if (updated === existing) {
+		return true; // No change needed.
+	}
+
+	try {
+		await mkdir(dirname(excludePath), { recursive: true });
+		await writeFile(excludePath, updated, "utf-8");
+		log.info("Updated %s with %d Jolli skill exclude paths", excludePath, paths.length);
+		return true;
+		/* v8 ignore start -- defensive: write failure on read-only fs / EPERM */
+	} catch (err: unknown) {
+		log.warn("Failed to write %s: %s", excludePath, (err as Error).message);
+		return false;
+	}
+	/* v8 ignore stop */
+}
+
+/**
+ * Renders the managed block including marker lines and a trailing newline.
+ * Lines are joined with `\n` (git is happy with LF on every platform; using
+ * the platform EOL here would diverge between developers on a team).
+ */
+function renderBlock(paths: ReadonlyArray<string>): string {
+	const lines = [BLOCK_START, ...paths, BLOCK_END];
+	return `${lines.join("\n")}\n`;
+}
+
+/**
+ * Replaces an existing managed block in `existing`, or appends one if no
+ * block is found. Preserves all other content verbatim.
+ *
+ * The scan is line-oriented and matches the marker lines exactly so a stray
+ * `# >>> jolli skill exclude >>>` substring inside a comment elsewhere in the
+ * file doesn't confuse the parser. The first matching marker pair wins —
+ * duplicate blocks (which shouldn't happen but might after manual edits) are
+ * left in place; only the first is rewritten.
+ */
+function applyBlock(existing: string, managedBlock: string): string {
+	const lines = existing.split("\n");
+	const startIdx = lines.indexOf(BLOCK_START);
+	const endIdx = lines.indexOf(BLOCK_END);
+
+	// `renderBlock` always appends a trailing `\n`; strip it before splitting so
+	// the spliced lines don't carry an empty trailing element.
+	const newBlockLines = managedBlock.slice(0, -1).split("\n");
+
+	if (startIdx !== -1 && endIdx !== -1 && endIdx > startIdx) {
+		const next = [...lines.slice(0, startIdx), ...newBlockLines, ...lines.slice(endIdx + 1)];
+		return next.join("\n");
+	}
+
+	if (existing.length === 0) {
+		return managedBlock;
+	}
+	const sep = existing.endsWith("\n") ? "" : "\n";
+	return `${existing}${sep}${managedBlock}`;
+}

--- a/cli/src/install/Installer.test.ts
+++ b/cli/src/install/Installer.test.ts
@@ -2367,12 +2367,52 @@ describe("Installer", () => {
 
 			const skillPath = join(tempDir, ".claude", "skills", "jolli-recall", "SKILL.md");
 			const contentBefore = await readFile(skillPath, "utf-8");
-			expect(contentBefore).toContain("jolli-skill-version:");
+			// v5: version now lives under spec-compliant `metadata.version`.
+			// We still recognize the legacy top-level key on read so a stale
+			// file isn't needlessly rewritten — see SkillInstaller.test.ts.
+			expect(contentBefore).toMatch(/metadata:\n {2}version:/);
 
 			// Record the file content, install again — should not overwrite
 			await install(tempDir);
 			const contentAfter = await readFile(skillPath, "utf-8");
 			expect(contentAfter).toBe(contentBefore);
+		});
+
+		it("writes SKILL.md to both .claude/skills/ and .agents/skills/", async () => {
+			await install(tempDir);
+			const recallClaude = join(tempDir, ".claude", "skills", "jolli-recall", "SKILL.md");
+			const recallAgents = join(tempDir, ".agents", "skills", "jolli-recall", "SKILL.md");
+			const searchClaude = join(tempDir, ".claude", "skills", "jolli-search", "SKILL.md");
+			const searchAgents = join(tempDir, ".agents", "skills", "jolli-search", "SKILL.md");
+			const claudeR = await readFile(recallClaude, "utf-8");
+			const agentsR = await readFile(recallAgents, "utf-8");
+			const claudeS = await readFile(searchClaude, "utf-8");
+			const agentsS = await readFile(searchAgents, "utf-8");
+			// Byte-identical across targets (v5 single-template invariant).
+			expect(claudeR).toBe(agentsR);
+			expect(claudeS).toBe(agentsS);
+		});
+	});
+
+	describe("install — uninstall conservative skill cleanup", () => {
+		it("uninstall logs a manual-cleanup hint instead of deleting skill directories", async () => {
+			// Install first so SKILL.md files exist in both target dirs.
+			await install(tempDir);
+
+			const recallClaude = join(tempDir, ".claude", "skills", "jolli-recall", "SKILL.md");
+			const recallAgents = join(tempDir, ".agents", "skills", "jolli-recall", "SKILL.md");
+			// Sanity: both written.
+			expect((await stat(recallClaude)).isFile()).toBe(true);
+			expect((await stat(recallAgents)).isFile()).toBe(true);
+
+			const result = await uninstall(tempDir);
+			expect(result.success).toBe(true);
+			// Skill files are deliberately left in place — users sometimes ship
+			// their own skills alongside Jolli's; a blind rm -rf would delete them.
+			expect((await stat(recallClaude)).isFile()).toBe(true);
+			expect((await stat(recallAgents)).isFile()).toBe(true);
+			// And the user is told how to remove them manually if they want to.
+			expect(result.warnings.some((w) => w.includes("rm -rf .agents/skills/jolli-*"))).toBe(true);
 		});
 	});
 

--- a/cli/src/install/Installer.ts
+++ b/cli/src/install/Installer.ts
@@ -62,6 +62,7 @@ import {
 	traverseDistPaths,
 } from "./DistPathResolver.js";
 import { installGeminiHook, isGeminiHookInstalled, removeGeminiHook } from "./GeminiHookInstaller.js";
+import { updateGitExclude } from "./GitExclude.js";
 import {
 	installGitHook,
 	installPostRewriteHook,
@@ -75,7 +76,7 @@ import {
 	removePrepareMsgHook,
 } from "./GitHookInstaller.js";
 import type { HookOpResult } from "./HookSettingsHelper.js";
-import { updateSkillIfNeeded } from "./SkillInstaller.js";
+import { SKILL_GIT_EXCLUDE_PATHS, updateSkillIfNeeded } from "./SkillInstaller.js";
 
 // ─── Re-exports for backward compatibility ──────────────────────────────────
 // External consumers import from "./Installer.js" — these re-exports keep
@@ -193,6 +194,17 @@ export async function install(cwd?: string, options?: { source?: "vscode-extensi
 				}
 				/* v8 ignore stop */
 			}
+			// SKILL.md is written for every enabled target — the cross-platform
+			// `.agents/skills/` target is unconditional, and `.claude/skills/`
+			// is gated inside the installer on `config.claudeEnabled !== false`.
+			// We update SKILL.md before the Claude-hook gate below so disabling
+			// Claude doesn't strand the `.agents/` skills target unupdated.
+			await updateSkillIfNeeded(wt, { claudeEnabled: config.claudeEnabled });
+			// Keep the user's `git status` clean by adding Jolli-managed skill
+			// paths to `.git/info/exclude`. Worktree-aware: linked worktrees
+			// may have their own gitdir, so we resolve per-worktree.
+			await updateGitExclude(wt, SKILL_GIT_EXCLUDE_PATHS);
+
 			if (config.claudeEnabled === false) continue;
 			const result = await installClaudeHook(wt);
 			/* v8 ignore start -- defensive: installClaudeHook currently never returns warnings */
@@ -204,8 +216,6 @@ export async function install(cwd?: string, options?: { source?: "vscode-extensi
 			if (wt === projectDir || claudeResult.path === undefined) {
 				claudeResult = result;
 			}
-			// Write/update SKILL.md if version changed
-			await updateSkillIfNeeded(wt);
 			// Install SessionStart hook for auto-briefing
 			await installSessionStartHook(wt);
 		}
@@ -456,6 +466,18 @@ export async function uninstall(cwd?: string): Promise<InstallResult> {
 
 		await removePostRewriteHook(projectDir);
 		await removePrepareMsgHook(projectDir);
+
+		// Conservative skill-cleanup policy: leave the generated SKILL.md files
+		// AND the `.git/info/exclude` block alone. Users sometimes ship their
+		// own skills alongside Jolli's under `.claude/skills/` or
+		// `.agents/skills/`, and a blind `rm -rf` of those directories on
+		// uninstall would delete unrelated user content. The exclude block is
+		// also harmless if left behind — git silently ignores entries that no
+		// longer match anything. Leaving the files behind also means re-enabling
+		// Jolli later is a no-op.
+		warnings.push(
+			"Skill files were left in place. To remove them manually: `rm -rf .agents/skills/jolli-* .claude/skills/jolli-*` and delete the `# >>> jolli skill exclude >>>` block from `.git/info/exclude` if you no longer want it.",
+		);
 
 		log.info("Uninstallation complete");
 		return {

--- a/cli/src/install/SkillInstaller.test.ts
+++ b/cli/src/install/SkillInstaller.test.ts
@@ -1,13 +1,28 @@
 /**
- * Focused tests for the per-skill upsert refactor: ensures both jolli-recall
- * and jolli-search are installed, that the alias `updateSkillIfNeeded` still
- * works, and that templates carry the security-required quoted ARGUMENTS.
+ * SkillInstaller tests.
+ *
+ * Asserts the v5 spec-compliant cross-platform shape:
+ *
+ * - One byte-identical SKILL.md written to both `.claude/skills/<name>/` and
+ *   `.agents/skills/<name>/` per skill.
+ * - Frontmatter contains only the spec-allowed fields (`name`, `description`,
+ *   `metadata`) — no Claude-private fields like `argument-hint` or `user-invocable`.
+ * - The invocation block uses a here-doc with an LLM-generated high-entropy
+ *   delimiter (`JOLLI_ARG_<DELIM>_END`) and `--arg-stdin`, NOT a fixed string,
+ *   NOT `$ARGUMENTS` argv interpolation, NOT a double-quoted argv string.
+ * - The Claude-target gate (`config.claudeEnabled === false`) skips
+ *   `.claude/skills/` but still writes `.agents/skills/`.
  */
-import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { updateSkillIfNeeded, updateSkillsIfNeeded } from "./SkillInstaller.js";
+import { SKILL_GIT_EXCLUDE_PATHS, updateSkillIfNeeded, updateSkillsIfNeeded } from "./SkillInstaller.js";
+
+// Vitest reuses vite's `define` config, so `__PKG_VERSION__` is the real
+// package.json version in tests. Use that value when planting legacy SKILL.md
+// fixtures so the version-up-to-date short-circuit can fire.
+const CURRENT_VERSION = typeof __PKG_VERSION__ !== "undefined" ? __PKG_VERSION__ : "dev";
 
 let tempDir: string;
 
@@ -19,158 +34,320 @@ afterEach(() => {
 	rmSync(tempDir, { recursive: true, force: true });
 });
 
-describe("updateSkillsIfNeeded", () => {
-	it("installs both jolli-recall and jolli-search SKILL.md files", async () => {
+// ─── Convenience readers ────────────────────────────────────────────────────
+
+function readRecall(target: "claude" | "agents" = "claude"): string {
+	const dir = target === "claude" ? ".claude/skills/jolli-recall" : ".agents/skills/jolli-recall";
+	return readFileSync(join(tempDir, dir, "SKILL.md"), "utf-8");
+}
+
+function readSearch(target: "claude" | "agents" = "claude"): string {
+	const dir = target === "claude" ? ".claude/skills/jolli-search" : ".agents/skills/jolli-search";
+	return readFileSync(join(tempDir, dir, "SKILL.md"), "utf-8");
+}
+
+// ─── Dual-target write ──────────────────────────────────────────────────────
+
+describe("updateSkillsIfNeeded — target dimension", () => {
+	it("writes both skills into both .claude/skills/ and .agents/skills/", async () => {
 		await updateSkillsIfNeeded(tempDir);
-		const recall = readFileSync(join(tempDir, ".claude/skills/jolli-recall/SKILL.md"), "utf-8");
-		const search = readFileSync(join(tempDir, ".claude/skills/jolli-search/SKILL.md"), "utf-8");
-		expect(recall).toContain("name: jolli-recall");
-		expect(search).toContain("name: jolli-search");
+		expect(existsSync(join(tempDir, ".claude/skills/jolli-recall/SKILL.md"))).toBe(true);
+		expect(existsSync(join(tempDir, ".claude/skills/jolli-search/SKILL.md"))).toBe(true);
+		expect(existsSync(join(tempDir, ".agents/skills/jolli-recall/SKILL.md"))).toBe(true);
+		expect(existsSync(join(tempDir, ".agents/skills/jolli-search/SKILL.md"))).toBe(true);
 	});
 
-	// Plan/note stubs on commits must use the right key names — `slug` for
-	// plans (because plan slugs carry archive-suffix semantics), `id` for
-	// notes (no archive mechanism). Earlier templates conflated both as
-	// "(slug + title)", which would point the LLM at a non-existent field
-	// when looking up a note.
-	it("recall template documents plan stubs (slug+title) and note stubs (id+title) distinctly", async () => {
+	it("writes byte-identical SKILL.md to .claude/skills/ and .agents/skills/", async () => {
 		await updateSkillsIfNeeded(tempDir);
-		const recall = readFileSync(join(tempDir, ".claude/skills/jolli-recall/SKILL.md"), "utf-8");
+		expect(readRecall("claude")).toBe(readRecall("agents"));
+		expect(readSearch("claude")).toBe(readSearch("agents"));
+	});
+
+	it("with claudeEnabled=false, skips .claude/skills/ but still writes .agents/skills/", async () => {
+		await updateSkillsIfNeeded(tempDir, { claudeEnabled: false });
+		expect(existsSync(join(tempDir, ".claude/skills/jolli-recall/SKILL.md"))).toBe(false);
+		expect(existsSync(join(tempDir, ".claude/skills/jolli-search/SKILL.md"))).toBe(false);
+		expect(existsSync(join(tempDir, ".agents/skills/jolli-recall/SKILL.md"))).toBe(true);
+		expect(existsSync(join(tempDir, ".agents/skills/jolli-search/SKILL.md"))).toBe(true);
+	});
+
+	it("with claudeEnabled=undefined (default), writes both targets", async () => {
+		await updateSkillsIfNeeded(tempDir, {});
+		expect(existsSync(join(tempDir, ".claude/skills/jolli-recall/SKILL.md"))).toBe(true);
+		expect(existsSync(join(tempDir, ".agents/skills/jolli-recall/SKILL.md"))).toBe(true);
+	});
+
+	it("exports the 4 git-exclude paths for the two skills × two targets", () => {
+		expect(SKILL_GIT_EXCLUDE_PATHS).toEqual([
+			"/.claude/skills/jolli-recall/",
+			"/.claude/skills/jolli-search/",
+			"/.agents/skills/jolli-recall/",
+			"/.agents/skills/jolli-search/",
+		]);
+	});
+});
+
+// ─── Frontmatter spec compliance ────────────────────────────────────────────
+
+describe("recall template frontmatter", () => {
+	it("uses spec-compliant fields only — name, description, metadata.version, metadata.vendor", async () => {
+		await updateSkillsIfNeeded(tempDir);
+		const recall = readRecall();
+		expect(recall).toMatch(/^---\nname: jolli-recall\n/);
+		expect(recall).toMatch(/description: Recall prior development context/);
+		expect(recall).toMatch(/metadata:\n {2}version: "[^"]+"\n {2}vendor: "jolli\.ai"/);
+	});
+
+	it("does NOT contain Claude-private top-level frontmatter fields", async () => {
+		await updateSkillsIfNeeded(tempDir);
+		const recall = readRecall();
+		// argument-hint / user-invocable / disable-model-invocation were Claude-only
+		// extensions. agentskills.io spec rejects them; Claude.ai App rejects them.
+		expect(recall).not.toMatch(/^argument-hint:/m);
+		expect(recall).not.toMatch(/^user-invocable:/m);
+		expect(recall).not.toMatch(/^disable-model-invocation:/m);
+	});
+
+	it("does NOT carry the legacy top-level jolli-skill-version key", async () => {
+		await updateSkillsIfNeeded(tempDir);
+		const recall = readRecall();
+		// New templates put the version under `metadata.version`. The legacy
+		// top-level key is still RECOGNIZED on read (so an existing SKILL.md
+		// from an older Jolli isn't needlessly rewritten), but new writes use
+		// the nested form only.
+		expect(recall).not.toMatch(/^jolli-skill-version:/m);
+		expect(recall).not.toMatch(/^jollimemory-version:/m);
+	});
+});
+
+describe("search template frontmatter", () => {
+	it("uses spec-compliant fields only", async () => {
+		await updateSkillsIfNeeded(tempDir);
+		const search = readSearch();
+		expect(search).toMatch(/^---\nname: jolli-search\n/);
+		expect(search).toMatch(/description: Search structured commit memories/);
+		expect(search).toMatch(/metadata:\n {2}version: "[^"]+"\n {2}vendor: "jolli\.ai"/);
+	});
+
+	it("does NOT contain Claude-private top-level frontmatter fields", async () => {
+		await updateSkillsIfNeeded(tempDir);
+		const search = readSearch();
+		expect(search).not.toMatch(/^argument-hint:/m);
+		expect(search).not.toMatch(/^user-invocable:/m);
+		expect(search).not.toMatch(/^disable-model-invocation:/m);
+	});
+});
+
+// ─── Shell-injection defense — here-doc + high-entropy delimiter ────────────
+
+describe("here-doc invocation pattern (security)", () => {
+	it("recall template uses --arg-stdin + here-doc with <DELIM> placeholder", async () => {
+		await updateSkillsIfNeeded(tempDir);
+		const recall = readRecall();
+		expect(recall).toMatch(/run-cli" recall --arg-stdin --format json <<'JOLLI_ARG_<DELIM>_END'/);
+		expect(recall).toMatch(/^JOLLI_ARG_<DELIM>_END$/m);
+	});
+
+	it("search template uses --arg-stdin + here-doc with <DELIM> placeholder", async () => {
+		await updateSkillsIfNeeded(tempDir);
+		const search = readSearch();
+		expect(search).toMatch(/run-cli" search --arg-stdin .*<<'JOLLI_ARG_<DELIM>_END'/);
+		expect(search).toMatch(/^JOLLI_ARG_<DELIM>_END$/m);
+	});
+
+	it("recall template requires LLM to generate a fresh 16-char hex delimiter per invocation", async () => {
+		await updateSkillsIfNeeded(tempDir);
+		const recall = readRecall();
+		expect(recall).toMatch(/Generate a fresh random 16-character hex string/);
+		expect(recall).toMatch(/Quickly scan the user's argument/);
+		expect(recall).toMatch(/regenerate the delimiter token and re-check/);
+	});
+
+	it("recall template has a STOP-if-unsafe instruction (refuses to interpolate into argv)", async () => {
+		await updateSkillsIfNeeded(tempDir);
+		const recall = readRecall();
+		expect(recall).toMatch(/STOP and tell the user/);
+		expect(recall).toMatch(/DO NOT attempt to interpolate the argument into argv/);
+		// Phrase wraps over a line break in the template, so allow whitespace
+		// between "injection" and "vector".
+		expect(recall).toMatch(/known shell injection\s+vector/);
+	});
+
+	it("search template has the same STOP-if-unsafe instruction", async () => {
+		await updateSkillsIfNeeded(tempDir);
+		const search = readSearch();
+		expect(search).toMatch(/STOP and tell the user/);
+		expect(search).toMatch(/DO NOT attempt to interpolate the argument into argv/);
+	});
+
+	// ── Shell-prerequisite pin: Git Bash on Windows ─────────────────────────
+	// Without this guidance, hosts whose default shell is WSL bash
+	// (`C:\Windows\System32\bash.exe`) miss the Jolli entry script because
+	// WSL's `$HOME` points to a separate Linux home, not `%USERPROFILE%`.
+	it("recall template pins the shell to Git Bash on Windows", async () => {
+		await updateSkillsIfNeeded(tempDir);
+		const recall = readRecall();
+		expect(recall).toMatch(/Git Bash/);
+		expect(recall).toMatch(/git-scm\.com\/download\/win/);
+		expect(recall).toMatch(/Install Git for Windows/);
+		// Must call out WSL bash specifically as not-supported.
+		expect(recall).toMatch(/WSL bash/);
+	});
+
+	it("search template pins the shell to Git Bash on Windows", async () => {
+		await updateSkillsIfNeeded(tempDir);
+		const search = readSearch();
+		expect(search).toMatch(/Git Bash/);
+		expect(search).toMatch(/git-scm\.com\/download\/win/);
+		expect(search).toMatch(/Install Git for Windows/);
+		expect(search).toMatch(/WSL bash/);
+	});
+
+	it("recall template forbids npm/npx/PowerShell fallback shortcuts", async () => {
+		await updateSkillsIfNeeded(tempDir);
+		const recall = readRecall();
+		// The "Do NOT fall back" line names the specific shortcuts a host LLM
+		// is most likely to invent when bash here-doc fails. All must be listed.
+		expect(recall).toMatch(/Do NOT fall back/);
+		expect(recall).toMatch(/`npm run`/);
+		expect(recall).toMatch(/`npx`/);
+		expect(recall).toMatch(/PowerShell-native/);
+	});
+
+	it("search template forbids npm/npx/PowerShell fallback shortcuts", async () => {
+		await updateSkillsIfNeeded(tempDir);
+		const search = readSearch();
+		expect(search).toMatch(/Do NOT fall back/);
+		expect(search).toMatch(/`npm run`/);
+		expect(search).toMatch(/`npx`/);
+		expect(search).toMatch(/PowerShell-native/);
+	});
+
+	// ── Regression guards: residue from v3/v4 must NOT slip back in ──
+	it("recall template carries no $ARGUMENTS residue", async () => {
+		await updateSkillsIfNeeded(tempDir);
+		const recall = readRecall();
+		// Legacy bash placeholders `${ARGUMENTS}` and `$ARGUMENTS` must be
+		// gone — the v5 template uses a here-doc instead.
+		expect(recall).not.toMatch(/\$\{ARGUMENTS\}/);
+		expect(recall).not.toMatch(/"\$ARGUMENTS"/);
+		expect(recall).not.toMatch(/'\$ARGUMENTS'/);
+	});
+
+	it("search template carries no $ARGUMENTS residue", async () => {
+		await updateSkillsIfNeeded(tempDir);
+		const search = readSearch();
+		expect(search).not.toMatch(/\$\{ARGUMENTS\}/);
+		expect(search).not.toMatch(/"\$ARGUMENTS"/);
+		expect(search).not.toMatch(/'\$ARGUMENTS'/);
+	});
+
+	it("recall template does NOT use a fixed delimiter (must be <DELIM> placeholder, not JOLLI_ARG_EOF)", async () => {
+		await updateSkillsIfNeeded(tempDir);
+		const recall = readRecall();
+		// v3 used a fixed delimiter (`JOLLI_ARG_EOF`). v5 requires the delimiter
+		// to be a per-invocation LLM-generated random hex value so prompt-injection
+		// attacks can't predict it. The marker has to remain a literal `<DELIM>`
+		// placeholder in the template so the LLM is told to substitute it.
+		expect(recall).not.toMatch(/<<'JOLLI_ARG_EOF'/);
+		expect(recall).not.toMatch(/^JOLLI_ARG_EOF$/m);
+	});
+
+	it("search template does NOT use a fixed delimiter", async () => {
+		await updateSkillsIfNeeded(tempDir);
+		const search = readSearch();
+		expect(search).not.toMatch(/<<'JOLLI_ARG_EOF'/);
+		expect(search).not.toMatch(/^JOLLI_ARG_EOF$/m);
+	});
+});
+
+// ─── Recall-template content pins (carried over from prior versions) ────────
+
+describe("recall template content", () => {
+	it("documents plan stubs (slug+title) and note stubs (id+title) distinctly", async () => {
+		await updateSkillsIfNeeded(tempDir);
+		const recall = readRecall();
 		expect(recall).toMatch(/`plans\?` — `\{ slug, title \}\[\]`/);
 		expect(recall).toMatch(/`notes\?` — `\{ id, title \}\[\]`/);
-		// Neither shape is described as the other.
 		expect(recall).not.toMatch(/`notes\?`[^.]*slug \+ title/);
 	});
 
-	// The stub-quoting paragraph used to unconditionally claim "content is
-	// already in your context" — but budget trimming can drop content while
-	// keeping the slug/title anchor. Without a conditional rule the LLM
-	// would fabricate quotes from a body it never received.
-	it("recall template conditionally guides quoting based on whether content is present", async () => {
+	it("conditionally guides quoting based on whether content is present", async () => {
 		await updateSkillsIfNeeded(tempDir);
-		const recall = readFileSync(join(tempDir, ".claude/skills/jolli-recall/SKILL.md"), "utf-8");
-		// Affirmative branch — content present → quote verbatim with attribution.
+		const recall = readRecall();
 		expect(recall).toMatch(/If the entry has `content`/);
-		// Negative branch — content absent → title-only anchor, no fabricated quotes.
 		expect(recall).toMatch(/If `content` is absent/);
 		expect(recall).toMatch(/never fabricate a quote/);
 	});
 
-	// Fact opener used to render as a single prose line that visually merged
-	// with the synthesis below. The skill template now mandates a heading +
-	// bullet block so the user has a clear, scannable verification anchor.
-	it("recall template Part A renders as `### Loaded` heading + bullet block (not a single prose line)", async () => {
+	it("Part A renders as `### Loaded` heading + bullet block", async () => {
 		await updateSkillsIfNeeded(tempDir);
-		const recall = readFileSync(join(tempDir, ".claude/skills/jolli-recall/SKILL.md"), "utf-8");
-		// The mandated example heading anchored on a real branch name.
+		const recall = readRecall();
 		expect(recall).toMatch(/### Loaded `feature\/auth`/);
-		// The bullet items the LLM should fill in.
 		expect(recall).toMatch(/\*\*Period:\*\*/);
 		expect(recall).toMatch(/\*\*Commits:\*\*/);
 		expect(recall).toMatch(/\*\*Captured:\*\*/);
-		// And the explicit ban on collapsing back to a single prose line.
 		expect(recall).toMatch(/heading \+ bullet shape is required/);
-		// The empty line between heading and bullets keeps markdown rendering correct.
 		expect(recall).toMatch(/### Loaded `feature\/auth`\n\n- \*\*Period:/);
 	});
 
-	// Principle 6 still gives a length anchor — search bounds itself naturally
-	// via Step-3 picking, recall has no equivalent — but the earlier "~500
-	// words at most" hard ceiling was the root cause of inline-bold paragraph
-	// cramming on multi-theme branches: 5+ themes with verbatim-quote bullets
-	// naturally exceed 500 words, and forcing them under the cap collapsed
-	// `###` sections into inline-bold prefixes that read as a markdown wall.
-	// The new wording keeps the brevity nudge as a soft target but explicitly
-	// subordinates it to section structure.
-	it("recall template encourages brevity but never at the cost of section structure (principle #6)", async () => {
+	it("encourages brevity but never at the cost of section structure (principle #6)", async () => {
 		await updateSkillsIfNeeded(tempDir);
-		const recall = readFileSync(join(tempDir, ".claude/skills/jolli-recall/SKILL.md"), "utf-8");
+		const recall = readRecall();
 		expect(recall).toMatch(/Brief by default/);
-		// Soft target ("aim for ~500"), not a hard ceiling ("at most").
 		expect(recall).toMatch(/aim for ~500 words/);
 		expect(recall).not.toMatch(/~500 words at most/);
-		// The explicit constraint that solves the wall-of-fragments failure mode:
-		// section structure beats word count.
 		expect(recall).toMatch(/inline-bold paragraph prefixes/);
 		expect(recall).toMatch(/may\s+legitimately run longer/);
-		// Escape hatch for theme-specific elaboration.
 		expect(recall).toMatch(/deep dive/);
-		// Negative: principle 6 still must NOT impose form constraints. Earlier
-		// drafts said "group by theme" / "3-5 decisions max" / "no subsection
-		// headings" — those conflict with Part B's "shape is your call".
 		expect(recall).not.toMatch(/Group commits by theme/);
 		expect(recall).not.toMatch(/3-5 key decisions max/);
 		expect(recall).not.toMatch(/No subsection headings/);
 	});
+});
 
-	// biome-ignore lint/suspicious/noTemplateCurlyInString: literal $\{ARGUMENTS} is the bash placeholder being asserted on
-	it("recall template quotes ${ARGUMENTS} (shell-injection defense)", async () => {
+// ─── Search-template content pins (carried over from prior versions) ────────
+
+describe("search template content", () => {
+	it("instructs the LLM to split the input into query + flags", async () => {
 		await updateSkillsIfNeeded(tempDir);
-		const recall = readFileSync(join(tempDir, ".claude/skills/jolli-recall/SKILL.md"), "utf-8");
-		// Recall takes the raw user input as branch/keyword; ${ARGUMENTS} must be
-		// wrapped in double quotes when interpolated into bash.
-		expect(recall).toMatch(/"\$\{ARGUMENTS\}"/);
-		// And no unquoted variants slipped in.
-		expect(recall).not.toMatch(/[^"]\$\{ARGUMENTS\}/);
+		const search = readSearch();
+		expect(search).toMatch(/Parse the user input into query \+ flags/);
+		// Worked-example table shows where flags go on argv (not in the here-doc body).
+		expect(search).toMatch(/--since 2w/);
 	});
 
-	it("search template instructs the LLM to split query and flags before invoking bash", async () => {
+	it("includes stale-CLI detection (older install missing the search command)", async () => {
 		await updateSkillsIfNeeded(tempDir);
-		const search = readFileSync(join(tempDir, ".claude/skills/jolli-search/SKILL.md"), "utf-8");
-		// Search no longer interpolates ${ARGUMENTS} verbatim because that would
-		// swallow flags like `--since 2w` into the query string. The template tells
-		// the LLM to construct bash with the query quoted and flags as separate
-		// unquoted tokens. Sanity-check that this guidance is present.
-		expect(search).toMatch(/Parse \$\{ARGUMENTS\} into query \+ flags/);
-		expect(search).toMatch(/"auth" --since 2w/);
-		// And the search template still uses double-quoted bash strings around the
-		// query portion in the worked examples.
-		expect(search).toMatch(/search "auth" --format json/);
-	});
-
-	it("search template includes stale-CLI detection (older install missing the search command)", async () => {
-		await updateSkillsIfNeeded(tempDir);
-		const search = readFileSync(join(tempDir, ".claude/skills/jolli-search/SKILL.md"), "utf-8");
+		const search = readSearch();
 		expect(search).toMatch(/unknown command 'search'/);
 		expect(search).toMatch(/npm update -g @jolli\.ai\/cli/);
 	});
 
-	it("search template explains catalog is not pre-filtered by query", async () => {
+	it("explains catalog is not pre-filtered by query", async () => {
 		await updateSkillsIfNeeded(tempDir);
-		const search = readFileSync(join(tempDir, ".claude/skills/jolli-search/SKILL.md"), "utf-8");
+		const search = readSearch();
 		expect(search).toMatch(/catalog is NOT pre-filtered by the user's query/);
 	});
 
-	it("search template forbids programmatic processing (temp files / scoring scripts)", async () => {
+	it("forbids programmatic processing (temp files / scoring scripts)", async () => {
 		await updateSkillsIfNeeded(tempDir);
-		const search = readFileSync(join(tempDir, ".claude/skills/jolli-search/SKILL.md"), "utf-8");
-		// Compressed wording vs earlier 4-bullet list, but covers the same two
-		// failure modes: writing to /tmp and running scoring shell scripts.
+		const search = readSearch();
 		expect(search).toMatch(/DO NOT\*\* process programmatically/);
 		expect(search).toMatch(/no temp files/);
 		expect(search).toMatch(/jq\/python\/grep/);
-		// Semantic picking is the affirmative side.
 		expect(search).toMatch(/Semantic picking/);
 	});
 
-	it("search template tells the LLM to retry with bigger budget before bothering the user", async () => {
+	it("tells the LLM to retry with bigger budget before bothering the user", async () => {
 		await updateSkillsIfNeeded(tempDir);
-		const search = readFileSync(join(tempDir, ".claude/skills/jolli-search/SKILL.md"), "utf-8");
+		const search = readSearch();
 		expect(search).toMatch(/--budget 50000/);
 	});
 
-	// ── Schema documentation in Step 5 ──
-	// The skill template now hands LLM the full SearchHit schema and lets it
-	// pick the output shape. These tests pin that the schema doc is present
-	// and complete, so any future SearchHit-shape change in Search.ts must be
-	// mirrored in the template.
-
-	it("search template documents every SearchHit identity / provenance field", async () => {
+	it("documents every SearchHit identity / provenance field", async () => {
 		await updateSkillsIfNeeded(tempDir);
-		const search = readFileSync(join(tempDir, ".claude/skills/jolli-search/SKILL.md"), "utf-8");
-		// Each top-level SearchHit field appears in the schema list. Some are
-		// self-explanatory and have no em-dash description (e.g. `branch`); we
-		// just assert the field name appears in `backticks` form.
+		const search = readSearch();
 		expect(search).toMatch(/`hash` —/);
 		expect(search).toMatch(/`fullHash` —/);
 		expect(search).toMatch(/`commitMessage` —/);
@@ -183,22 +360,17 @@ describe("updateSkillsIfNeeded", () => {
 		expect(search).toMatch(/`recap\?` —/);
 	});
 
-	it("search template marks `decisions` as the star field with explicit emphasis", async () => {
+	it("marks `decisions` as the star field with explicit emphasis", async () => {
 		await updateSkillsIfNeeded(tempDir);
-		const search = readFileSync(join(tempDir, ".claude/skills/jolli-search/SKILL.md"), "utf-8");
-		// Decisions is the highest-signal topic field; the template must call
-		// it out so the LLM leans on it for "why" / "rationale" queries.
+		const search = readSearch();
 		expect(search).toMatch(/`decisions` ★ \*\*THE STAR FIELD\*\*/);
-		// And a usage hint anchoring the LLM to the right query types.
 		expect(search).toMatch(/why did we choose X/);
 	});
 
-	it("search template documents every per-topic field", async () => {
+	it("documents every per-topic field", async () => {
 		await updateSkillsIfNeeded(tempDir);
-		const search = readFileSync(join(tempDir, ".claude/skills/jolli-search/SKILL.md"), "utf-8");
+		const search = readSearch();
 		expect(search).toMatch(/`title` —/);
-		// `trigger` and `response` are now optional in SearchHitTopic — the schema
-		// doc reflects that with `?` so the LLM doesn't expect them on every hit.
 		expect(search).toMatch(/`trigger\?` —/);
 		expect(search).toMatch(/`response\?` —/);
 		expect(search).toMatch(/`decisions` ★/);
@@ -208,157 +380,108 @@ describe("updateSkillsIfNeeded", () => {
 		expect(search).toMatch(/`importance\?` —/);
 	});
 
-	// `diffStats` schema: actual interface is { filesChanged, insertions,
-	// deletions } — older template wrongly wrote `files`. This test pins the
-	// fix so a future revert can't go unnoticed.
-	it("search template uses correct diffStats field name (filesChanged, not files)", async () => {
+	it("uses correct diffStats field name (filesChanged, not files)", async () => {
 		await updateSkillsIfNeeded(tempDir);
-		const search = readFileSync(join(tempDir, ".claude/skills/jolli-search/SKILL.md"), "utf-8");
+		const search = readSearch();
 		expect(search).toMatch(/`diffStats\?` — `\{ filesChanged, insertions, deletions \}`/);
 		expect(search).not.toMatch(/`diffStats\?` — `\{ files,/);
 	});
 
-	// Plan / note stubs: SearchHit now carries plan/note refs (slug/id + title)
-	// so the LLM can use them as grounding anchors. Search ships only stubs
-	// (no plan body) — the template must say so explicitly to avoid promising
-	// the user navigation that doesn't exist.
-	it("search template documents plan/note stubs and forbids navigation promises", async () => {
+	it("documents plan/note stubs and forbids navigation promises", async () => {
 		await updateSkillsIfNeeded(tempDir);
-		const search = readFileSync(join(tempDir, ".claude/skills/jolli-search/SKILL.md"), "utf-8");
+		const search = readSearch();
 		expect(search).toMatch(/`plans\?` — `\{ slug, title \}\[\]`/);
 		expect(search).toMatch(/`notes\?` — `\{ id, title \}\[\]`/);
 		expect(search).toMatch(/Do NOT promise the user they can navigate to the plan body/);
-		// Don't suggest /jolli-recall as a "see the plan body" path either —
-		// recall also doesn't show plan content directly to the user.
-		expect(search).not.toMatch(/see plan content via \/jolli-recall/);
 	});
 
-	// ── Universal principles ──
-	// The principles encode lessons from past dogfood failures and are the only
-	// hard constraints (the output shape itself is up to the LLM). These tests
-	// pin each principle so a careless edit can't silently drop one.
-
-	it("search template lists Lead-with-the-answer principle and forbids preamble openers", async () => {
+	it("lists Lead-with-the-answer principle and forbids preamble openers", async () => {
 		await updateSkillsIfNeeded(tempDir);
-		const search = readFileSync(join(tempDir, ".claude/skills/jolli-search/SKILL.md"), "utf-8");
+		const search = readSearch();
 		expect(search).toMatch(/Lead with the answer/);
-		// The compressed principle 1 directly forbids the two stock LLM openers.
 		expect(search).toMatch(/No "Let me analyze\.\.\." or "Found N commits\.\.\." preamble/);
 	});
 
-	it("search template requires file paths as markdown links", async () => {
+	it("requires file paths as markdown links", async () => {
 		await updateSkillsIfNeeded(tempDir);
-		const search = readFileSync(join(tempDir, ".claude/skills/jolli-search/SKILL.md"), "utf-8");
+		const search = readSearch();
 		expect(search).toMatch(/\[cli\/src\/Types\.ts\]\(cli\/src\/Types\.ts\)/);
 	});
 
-	it("search template forbids snippet dumps and demands complete verbatim clauses with self-contained meaning", async () => {
+	it("forbids snippet dumps and demands complete verbatim clauses", async () => {
 		await updateSkillsIfNeeded(tempDir);
-		const search = readFileSync(join(tempDir, ".claude/skills/jolli-search/SKILL.md"), "utf-8");
-		// Synthesize-don't-dump is still in.
+		const search = readSearch();
 		expect(search).toMatch(/Synthesize, don't dump/);
 		expect(search).toMatch(/wall-of-fragments/);
-		// Bold verbatim quotes are explicitly encouraged — but as complete
-		// clauses, not 2-3 word fragments that need surrounding paraphrase
-		// to be understood.
 		expect(search).toMatch(/verbatim quotes from stored data/);
 		expect(search).toMatch(/complete clauses \(typically 10-30 words\)/);
 		expect(search).toMatch(/not 2-3 word fragments/);
 		expect(search).toMatch(/skim the bold quote alone and understand its claim/);
-		// Worked example is a 17-word complete clause (anchors the LLM's
-		// output toward longer self-contained quotes, not snippet fragments).
 		expect(search).toMatch(
 			/\*\*"the stateless model lets us scale horizontally without a shared session store across regions"\*\*/,
 		);
-		// Bold-only-for-verbatim trust signal.
 		expect(search).toMatch(/Bold = verbatim from stored data/);
 		expect(search).toMatch(/Never use bold for general emphasis/);
-		// Negative: the deprecated 1-3 quotes-per-answer cap is gone (it
-		// interacted badly with recall's 400-word ceiling, starving the
-		// answer of grounding).
 		expect(search).not.toMatch(/Use sparingly \(1-3 quotes per answer\)/);
-		expect(search).not.toMatch(/short verbatim quotes/);
 	});
 
-	it("search template forbids exposing machinery (Phase 1 / Phase 2 / catalog / SearchHit)", async () => {
+	it("forbids exposing machinery", async () => {
 		await updateSkillsIfNeeded(tempDir);
-		const search = readFileSync(join(tempDir, ".claude/skills/jolli-search/SKILL.md"), "utf-8");
+		const search = readSearch();
 		expect(search).toMatch(/Don't expose machinery/);
-		// Specific machinery names are listed so the LLM has concrete forbids.
 		expect(search).toMatch(/"Phase 1"/);
 		expect(search).toMatch(/"Phase 2"/);
 		expect(search).toMatch(/"catalog"/);
 		expect(search).toMatch(/"SearchHit"/);
 	});
 
-	// Principle 7 ("No vscode:// links") and principle 4 ("Skip near-duplicates")
-	// were removed in the principles-simplification refactor. Pin both deletions
-	// so a casual revert can't reintroduce noise the template doesn't need.
-	it("search template does NOT carry the legacy vscode:// principle", async () => {
+	it("does NOT carry the legacy vscode:// principle", async () => {
 		await updateSkillsIfNeeded(tempDir);
-		const search = readFileSync(join(tempDir, ".claude/skills/jolli-search/SKILL.md"), "utf-8");
-		// CLI is the only "open commit" path now — but it's still mentioned by Step
-		// 4 as the disambiguation tool. The principle that called it out as a
-		// vscode:// alternative is gone.
+		const search = readSearch();
 		expect(search).not.toMatch(/Open in IDE/);
 		expect(search).not.toMatch(/vscode:\/\//);
 	});
 
-	it("search template does NOT carry the legacy near-duplicate principle (root-only filter handles it)", async () => {
+	it("does NOT carry the legacy near-duplicate principle", async () => {
 		await updateSkillsIfNeeded(tempDir);
-		const search = readFileSync(join(tempDir, ".claude/skills/jolli-search/SKILL.md"), "utf-8");
-		// Skip-near-duplicates was redundant with the catalog-side root-only filter
-		// and burned attention budget; removed. Don't reintroduce.
+		const search = readSearch();
 		expect(search).not.toMatch(/Skip near-duplicates/);
 	});
 
-	// ── Free-shape rendering (the central design point) ──
-
-	it("search template explicitly tells the LLM the output shape is its call", async () => {
+	it("explicitly tells the LLM the output shape is its call", async () => {
 		await updateSkillsIfNeeded(tempDir);
-		const search = readFileSync(join(tempDir, ".claude/skills/jolli-search/SKILL.md"), "utf-8");
-		// The whole point of the rewrite — pin the language that liberates the
-		// LLM from a fixed template. If a future edit adds back "Section 1 / 2 / 3"
-		// rigidity, this test catches it.
+		const search = readSearch();
 		expect(search).toMatch(/Output shape is entirely your call/);
-		// And the negative: no Section-N rigidity left over.
 		expect(search).not.toMatch(/Section 1 — Top-line summary/);
-		expect(search).not.toMatch(/Section 2 — Core commits table/);
-		expect(search).not.toMatch(/Section 3 — Grouped synthesis/);
-		// Don't even suggest specific shapes — earlier iterations had a 5-row
-		// "what is X → prose, compare A vs B → side-by-side, …" suggestion
-		// table that contradicted the "completely free shape" intent. Catch
-		// any future re-introduction.
-		expect(search).not.toMatch(/"compare A vs B".*side-by-side/);
 	});
 
-	it("search template tightens the Step 3 picks limit from 5-15 to 5-10", async () => {
+	it("tightens the Step 3 picks limit to 5-10", async () => {
 		await updateSkillsIfNeeded(tempDir);
-		const search = readFileSync(join(tempDir, ".claude/skills/jolli-search/SKILL.md"), "utf-8");
-		// Phase 2 now carries full topic content per hit — picking 15 risks
-		// blowing the chat context budget. 5-10 is the new band.
+		const search = readSearch();
 		expect(search).toMatch(/Pick \*\*5-10\*\*/);
 		expect(search).not.toMatch(/Pick 5-15/);
 	});
+});
 
-	// Skill templates ship to international users — they must stay English-only
-	// (the LLM is told to translate replies into the user's language). Lock this
-	// in: any future template edit that slips CJK / Hiragana / Katakana / Hangul
-	// chars into either SKILL.md is a regression caught here.
-	const CJK_AND_OTHER_NON_LATIN = /[\u3400-\u4DBF\u4E00-\u9FFF\uF900-\uFAFF\u3040-\u309F\u30A0-\u30FF\uAC00-\uD7AF]/u;
+// ─── No CJK leakage ─────────────────────────────────────────────────────────
+
+describe("English-only", () => {
+	const CJK_AND_OTHER_NON_LATIN = /[㐀-䶿一-鿿豈-﫿぀-ゟ゠-ヿ가-힯]/u;
 
 	it("recall template contains no CJK characters", async () => {
 		await updateSkillsIfNeeded(tempDir);
-		const recall = readFileSync(join(tempDir, ".claude/skills/jolli-recall/SKILL.md"), "utf-8");
-		expect(recall).not.toMatch(CJK_AND_OTHER_NON_LATIN);
+		expect(readRecall()).not.toMatch(CJK_AND_OTHER_NON_LATIN);
 	});
 
 	it("search template contains no CJK characters", async () => {
 		await updateSkillsIfNeeded(tempDir);
-		const search = readFileSync(join(tempDir, ".claude/skills/jolli-search/SKILL.md"), "utf-8");
-		expect(search).not.toMatch(CJK_AND_OTHER_NON_LATIN);
+		expect(readSearch()).not.toMatch(CJK_AND_OTHER_NON_LATIN);
 	});
+});
 
+// ─── Legacy cleanup + idempotency ───────────────────────────────────────────
+
+describe("legacy directories", () => {
 	it("removes legacy skill directories from previous versions", async () => {
 		const fs = await import("node:fs");
 		fs.mkdirSync(join(tempDir, ".claude/skills/jollimemory-recall"), { recursive: true });
@@ -368,21 +491,56 @@ describe("updateSkillsIfNeeded", () => {
 	});
 
 	it("upserts search even when recall already exists at the current version", async () => {
-		// Install once.
 		await updateSkillsIfNeeded(tempDir);
 		const fs = await import("node:fs");
-		// Manually delete the search skill to simulate the legacy-installer scenario
-		// (where only jolli-recall exists in .claude/skills/ on an older project).
 		fs.rmSync(join(tempDir, ".claude/skills/jolli-search"), { recursive: true, force: true });
-		// Re-run: search should be re-installed even though recall is at the current version.
 		await updateSkillsIfNeeded(tempDir);
 		expect(fs.existsSync(join(tempDir, ".claude/skills/jolli-search/SKILL.md"))).toBe(true);
 	});
 
-	it("backward-compat alias updateSkillIfNeeded still installs both skills", async () => {
+	it("backward-compat alias updateSkillIfNeeded installs both skills into both targets", async () => {
 		await updateSkillIfNeeded(tempDir);
+		expect(existsSync(join(tempDir, ".claude/skills/jolli-recall/SKILL.md"))).toBe(true);
+		expect(existsSync(join(tempDir, ".claude/skills/jolli-search/SKILL.md"))).toBe(true);
+		expect(existsSync(join(tempDir, ".agents/skills/jolli-recall/SKILL.md"))).toBe(true);
+		expect(existsSync(join(tempDir, ".agents/skills/jolli-search/SKILL.md"))).toBe(true);
+	});
+
+	it("backward-compat alias respects claudeEnabled=false", async () => {
+		await updateSkillIfNeeded(tempDir, { claudeEnabled: false });
+		expect(existsSync(join(tempDir, ".claude/skills/jolli-recall/SKILL.md"))).toBe(false);
+		expect(existsSync(join(tempDir, ".agents/skills/jolli-recall/SKILL.md"))).toBe(true);
+	});
+});
+
+// ─── Version-line recognition (legacy keys still respected on read) ─────────
+
+describe("version-line compatibility", () => {
+	it("recognizes a SKILL.md with the legacy `jolli-skill-version` key as up-to-date if the version matches", async () => {
+		// Plant a SKILL.md using the legacy top-level key at the CURRENT version.
+		// The installer should treat it as already up-to-date and not rewrite,
+		// even though the template now uses `metadata.version`. This protects
+		// users from a needless rewrite on upgrade.
 		const fs = await import("node:fs");
-		expect(fs.existsSync(join(tempDir, ".claude/skills/jolli-recall/SKILL.md"))).toBe(true);
-		expect(fs.existsSync(join(tempDir, ".claude/skills/jolli-search/SKILL.md"))).toBe(true);
+		const planted = `---\nname: jolli-recall\njolli-skill-version: ${CURRENT_VERSION}\n---\nlegacy body`;
+		fs.mkdirSync(join(tempDir, ".claude/skills/jolli-recall"), { recursive: true });
+		fs.writeFileSync(join(tempDir, ".claude/skills/jolli-recall/SKILL.md"), planted, "utf-8");
+		await updateSkillsIfNeeded(tempDir);
+		// .claude path was up-to-date: the legacy file was preserved verbatim.
+		expect(readRecall()).toBe(planted);
+		// .agents path didn't exist at all — installer creates it fresh.
+		expect(existsSync(join(tempDir, ".agents/skills/jolli-recall/SKILL.md"))).toBe(true);
+	});
+
+	it("rewrites when the file contains an unrecognized version line", async () => {
+		const fs = await import("node:fs");
+		const planted = `---\nname: jolli-recall\njolli-skill-version: 0.0.0-old\n---\nold body`;
+		fs.mkdirSync(join(tempDir, ".claude/skills/jolli-recall"), { recursive: true });
+		fs.writeFileSync(join(tempDir, ".claude/skills/jolli-recall/SKILL.md"), planted, "utf-8");
+		await updateSkillsIfNeeded(tempDir);
+		// Was rewritten — content no longer matches the plant.
+		expect(readRecall()).not.toBe(planted);
+		// And it now carries the new metadata.version form.
+		expect(readRecall()).toMatch(/metadata:\n {2}version:/);
 	});
 });

--- a/cli/src/install/SkillInstaller.ts
+++ b/cli/src/install/SkillInstaller.ts
@@ -1,17 +1,33 @@
 /**
  * Skill Installer
  *
- * Manages the installation, update, and cleanup of Jolli skill files for
- * Claude Code (`.claude/skills/<name>/SKILL.md`).
+ * Writes one byte-identical SKILL.md per skill to **both** target directories:
+ *
+ *   - `<projectDir>/.claude/skills/<name>/SKILL.md`  — for Claude Code
+ *   - `<projectDir>/.agents/skills/<name>/SKILL.md`  — for the cross-platform
+ *     Agent Skills standard, picked up by Codex CLI, Cursor 2.4+, Windsurf,
+ *     OpenCode, Gemini CLI, GitHub Copilot.
+ *
+ * Frontmatter is spec-compliant only (`name`, `description`, `metadata`) —
+ * no Claude-private fields (`argument-hint`, `user-invocable`) — so the same
+ * file passes `skills-ref validate` and runs on every host.
+ *
+ * **SECURITY — shell injection defense**: skill templates instruct the host
+ * LLM to invoke `jolli recall --arg-stdin` / `jolli search --arg-stdin` and
+ * feed the user's argument through a here-doc with a **fresh, LLM-generated
+ * 16-char hex delimiter** per invocation. The single-quoted delimiter token
+ * (`<<'JOLLI_ARG_<DELIM>_END'`) is POSIX's only here-doc form that suppresses
+ * every metacharacter (`$()`, backticks, `${VAR}`, `\`). Per-invocation high-
+ * entropy delimiters defeat prompt-injection attempts that pre-compute the
+ * delimiter into a payload. Known residual risks (the LLM not following the
+ * recipe, a 1-in-2^64 delimiter collision, a host that strips here-docs from
+ * the command before execution) are accepted trade-offs of this design.
  *
  * Each skill is upserted **independently** by hash of its template content
  * compared with the version recorded in the file. This avoids the trap where
  * a single skill's version match short-circuits the whole installer and
  * prevents a newer skill (e.g. `jolli-search`) from ever being installed on
  * projects whose `jolli-recall` already matches the current version.
- *
- * Future extensions: MCP server registration for Codex CLI / Gemini CLI /
- * Cursor / Windsurf — added by appending a new entry to {@link SKILLS}.
  */
 
 import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
@@ -32,11 +48,51 @@ const SKILL_VERSION = typeof __PKG_VERSION__ !== "undefined" ? __PKG_VERSION__ :
 /** Legacy skill directory names from previous versions (v1 and v2) */
 const LEGACY_SKILL_DIRS = ["jollimemory-recall", "jolli-memory-recall"];
 
-/** Each registered skill: directory name and template builder. */
+/**
+ * A Skill registration: directory name + template builder. Template content is
+ * host-agnostic — the same string is written into every target directory.
+ */
 interface SkillRegistration {
 	readonly name: string;
 	readonly build: () => string;
 }
+
+/**
+ * A target directory family for skill writes.
+ *
+ * - `host` is a stable identifier used in logs / tests.
+ * - `relativeDir` is the path under `<projectDir>` where SKILL.md files live.
+ * - `enabled` decides whether to write into this target for the given config.
+ *   `.claude/skills/` is gated on `config.claudeEnabled !== false`. The
+ *   `.agents/skills/` cross-platform target is unconditional today — splitting
+ *   it across a per-host detector list (`isCodexInstalled || isGeminiInstalled
+ *   || …`) would miss Cursor / OpenCode / Copilot-only users, and the cost is
+ *   ~10 KB of two SKILL.md files that `.git/info/exclude` keeps out of `git
+ *   status`.
+ */
+export interface SkillTarget {
+	readonly host: "claude-code" | "agents-std";
+	readonly relativeDir: ReadonlyArray<string>;
+	readonly enabled: (config: { claudeEnabled?: boolean }) => boolean;
+}
+
+/**
+ * Where `jolli enable` writes SKILL.md files. Order is preserved so logs and
+ * tests can rely on a stable iteration order.
+ */
+export const SKILL_TARGETS: ReadonlyArray<SkillTarget> = [
+	{
+		host: "claude-code",
+		relativeDir: [".claude", "skills"],
+		enabled: (config) => config.claudeEnabled !== false,
+	},
+	{
+		host: "agents-std",
+		relativeDir: [".agents", "skills"],
+		// Always-on. See SkillTarget JSDoc for the rationale.
+		enabled: () => true,
+	},
+];
 
 /**
  * Registry of skills installed by `jolli enable`. Adding a new skill is
@@ -48,15 +104,31 @@ const SKILLS: ReadonlyArray<SkillRegistration> = [
 ];
 
 /**
- * Installs or updates Jolli skill files in the project's `.claude/skills/`
- * directory. Cleans up legacy directory names from prior versions.
- *
- * Each skill is checked and upserted independently, so installing a new skill
- * (or updating one of several) is not blocked by another skill's version
- * matching the running CLI.
+ * Skill paths recorded in `.git/info/exclude` so they don't pollute
+ * `git status` in user repositories. Always 4 entries: 2 skills × 2 targets.
+ * Path format follows git's gitignore syntax — leading `/` anchors to the
+ * repo root, trailing `/` matches the directory and its contents.
  */
-export async function updateSkillsIfNeeded(projectDir: string): Promise<void> {
-	// Clean up legacy skill directories from previous versions
+export const SKILL_GIT_EXCLUDE_PATHS: ReadonlyArray<string> = SKILL_TARGETS.flatMap((target) =>
+	SKILLS.map((skill) => `/${target.relativeDir.join("/")}/${skill.name}/`),
+);
+
+/**
+ * Installs or updates Jolli skill files. The same byte-identical SKILL.md is
+ * written into each enabled target directory under {@link SKILL_TARGETS}; the
+ * Claude Code target is gated on `config.claudeEnabled !== false`, the
+ * cross-platform `.agents/skills/` target is unconditional.
+ *
+ * Cleans up legacy directory names from prior versions. Each skill is checked
+ * and upserted independently, so installing a new skill (or updating one of
+ * several) is not blocked by another skill's version matching the running CLI.
+ */
+export async function updateSkillsIfNeeded(
+	projectDir: string,
+	config: { claudeEnabled?: boolean } = {},
+): Promise<void> {
+	// Clean up legacy skill directories from previous versions. These only
+	// ever lived under `.claude/skills/` — `.agents/skills/` is a new target.
 	for (const legacyName of LEGACY_SKILL_DIRS) {
 		const legacyDir = join(projectDir, ".claude", "skills", legacyName);
 		try {
@@ -68,8 +140,12 @@ export async function updateSkillsIfNeeded(projectDir: string): Promise<void> {
 		/* v8 ignore stop */
 	}
 
-	for (const skill of SKILLS) {
-		await upsertSkill(projectDir, skill.name, skill.build());
+	for (const target of SKILL_TARGETS) {
+		if (!target.enabled(config)) continue;
+		const targetDir = join(projectDir, ...target.relativeDir);
+		for (const skill of SKILLS) {
+			await upsertSkill(targetDir, skill.name, skill.build());
+		}
 	}
 }
 
@@ -81,26 +157,40 @@ export async function updateSkillsIfNeeded(projectDir: string): Promise<void> {
  * old name is kept as a thin wrapper to avoid touching every call site in
  * one PR.
  */
-export async function updateSkillIfNeeded(projectDir: string): Promise<void> {
-	return updateSkillsIfNeeded(projectDir);
+export async function updateSkillIfNeeded(projectDir: string, config: { claudeEnabled?: boolean } = {}): Promise<void> {
+	return updateSkillsIfNeeded(projectDir, config);
 }
+
+/**
+ * Matches the version line in a SKILL.md frontmatter. Accepts:
+ *   - `metadata.version: "x.y.z"` (current — spec compliant, nested under
+ *     `metadata:` two-space-indented block).
+ *   - Legacy top-level `jolli-skill-version: x.y.z` /
+ *     `jollimemory-version: x.y.z` (kept so an old SKILL.md on disk is still
+ *     recognized as "up-to-date" and not needlessly rewritten on every install).
+ *
+ * Multi-line mode so `^  version:` matches the nested form. Captured group is
+ * the version string with surrounding whitespace and quotes trimmed downstream.
+ */
+const SKILL_VERSION_LINE = /(?:^|\n)(?:[ \t]+version|jolli-skill-version|jollimemory-version):\s*([^\r\n]+)/;
 
 /**
  * Writes one skill's SKILL.md file when its content version differs from
  * what's on disk. Idempotent.
  */
-async function upsertSkill(projectDir: string, name: string, content: string): Promise<void> {
-	const skillDir = join(projectDir, ".claude", "skills", name);
+async function upsertSkill(skillsDir: string, name: string, content: string): Promise<void> {
+	const skillDir = join(skillsDir, name);
 	const skillPath = join(skillDir, "SKILL.md");
 
 	try {
 		const existing = await readFile(skillPath, "utf-8");
-		const versionMatch = existing.match(/(?:jolli-skill-version|jollimemory-version):\s*(.+)/);
-		/* v8 ignore start -- version match: SKILL_VERSION is always "dev" in tests */
-		if (versionMatch && versionMatch[1].trim() === SKILL_VERSION) {
-			return; // Up to date
+		const versionMatch = existing.match(SKILL_VERSION_LINE);
+		if (versionMatch) {
+			const found = versionMatch[1].trim().replace(/^["']|["']$/g, "");
+			if (found === SKILL_VERSION) {
+				return; // Up to date
+			}
 		}
-		/* v8 ignore stop */
 	} catch {
 		// File doesn't exist — will create
 	}
@@ -119,22 +209,74 @@ async function upsertSkill(projectDir: string, name: string, content: string): P
 // ─── Skill Templates ────────────────────────────────────────────────────────
 
 /**
- * Recall skill template.
+ * Shared Step-1 preamble — instructs the LLM to invoke the CLI via a here-doc
+ * with a freshly-generated 16-char hex delimiter, and to STOP if the host
+ * can't support that recipe rather than fall back to an `argv` interpolation
+ * that would re-open the shell-injection door.
  *
- * **SECURITY NOTE**: every `${...}` placeholder substituted by the agent host
- * MUST be wrapped in double quotes when interpolated into a shell command.
- * Without quotes, user-supplied query text containing shell metacharacters
- * (`;`, `|`, `&`, backticks, etc.) executes as additional commands. The
- * `\${ARGUMENTS}` below sits inside `"..."` for that reason. CI should
- * enforce this with a lint check on this file.
+ * Also pins the shell choice on Windows: Git Bash, not WSL bash and not
+ * PowerShell. The Jolli entry script is written via Windows Node's
+ * `os.homedir()` to `%USERPROFILE%\\.jolli\\jollimemory\\run-cli`. Only Git
+ * Bash's `$HOME` aligns with `%USERPROFILE%`; WSL bash sees a separate Linux
+ * home and would miss the script even when it is correctly installed.
+ *
+ * The literal `<DELIM>` placeholder is intentional: the LLM is the one that
+ * generates the random value each invocation, which is what makes pre-computed
+ * prompt-injection payloads useless.
+ */
+function heredocInvocation(subcommand: "recall" | "search", flagSuffix: string): string {
+	return `### Shell prerequisite
+
+This block requires a POSIX bash shell. On Linux/macOS the system bash works.
+**On Windows, use Git Bash** (the bash bundled with Git for Windows). Other
+Windows "bash" options — \`C:\\Windows\\System32\\bash.exe\`, the WindowsApps
+alias, or any WSL bash — see a separate Linux home directory and will not
+find the Jolli entry script that lives under \`%USERPROFILE%\`.
+
+If Git Bash is not available on Windows, STOP and tell the user:
+"Jolli skill needs Git Bash on Windows. Install Git for Windows from
+https://git-scm.com/download/win and retry."
+
+Do NOT fall back to \`npm run\`, \`npx\`, \`node\` directly, PowerShell-native
+commands, WSL bash, or any workspace-local script — those bypass the
+security recipe and the dist resolver and will not produce valid output.
+
+### Invocation
+
+Generate a fresh random 16-character hex string (the "delimiter token") for
+this invocation — e.g. \`3f8a9b2c5d7e1f4a\`. Quickly scan the user's argument:
+if the argument text contains a line that is exactly \`JOLLI_ARG_<delimiter
+token>_END\`, regenerate the delimiter token and re-check.
+
+Then run this Bash, replacing the two \`<DELIM>\` occurrences with your
+delimiter token and replacing \`<user-arg>\` with the user's input verbatim:
+
+\`\`\`bash
+"$HOME/.jolli/jollimemory/run-cli" ${subcommand} --arg-stdin${flagSuffix} <<'JOLLI_ARG_<DELIM>_END'
+<user-arg>
+JOLLI_ARG_<DELIM>_END
+\`\`\`
+
+If you cannot follow the above structure (e.g., your environment doesn't
+support here-docs), STOP and tell the user "Jolli skill cannot run safely
+in this environment." DO NOT attempt to interpolate the argument into argv
+or any double-quoted shell string — that path has a known shell injection
+vector.`;
+}
+
+/**
+ * Recall skill template — describes the multi-step recall workflow to the
+ * host LLM. Byte-identical across every {@link SKILL_TARGETS} entry, so the
+ * file passes `skills-ref validate` and works on Claude Code, Codex, Cursor,
+ * Windsurf, OpenCode, and Gemini without per-host divergence.
  */
 function buildRecallSkillTemplate(): string {
 	return `---
 name: jolli-recall
-description: Recall prior development context from Jolli for the current branch
-argument-hint: "[branch or keyword]"
-user-invocable: true
-jolli-skill-version: ${SKILL_VERSION}
+description: Recall prior development context from Jolli for the current branch. Use when the user wants to recall, remember, or resume prior work on a branch.
+metadata:
+  version: "${SKILL_VERSION}"
+  vendor: "jolli.ai"
 ---
 
 # Jolli Recall
@@ -146,23 +288,18 @@ distilled topics (trigger / response / decisions / files), plus any plans
 and notes that the work referenced. Synthesize a grounded answer to the
 user's prompt about that branch.
 
-## Step 1: Parse the argument
+## Step 1: Run the CLI
 
-The user's input is either a branch name (exact or fragment) or empty (use
-the current git branch). Quote it when constructing bash to prevent shell
-injection.
+The user's input \`<user-arg>\` is either a branch name (exact or fragment) or
+empty (in which case the CLI uses the current git branch).
 
-## Step 2: Run the CLI
-
-\`\`\`
-"$HOME/.jolli/jollimemory/run-cli" recall "\${ARGUMENTS}" --format json
-\`\`\`
+${heredocInvocation("recall", " --format json")}
 
 If \`~/.jolli/jollimemory/run-cli\` does not exist, tell the user:
 "Jolli not installed. Please install via \`npm install -g @jolli.ai/cli && jolli enable\` or install the Jolli VS Code extension."
 Do not attempt further processing.
 
-## Step 3: Handle the response
+## Step 2: Handle the response
 
 The output is JSON with a \`type\` field. Three cases:
 
@@ -298,8 +435,8 @@ If a \`query\` field is present, semantic-match the user's input against
 \`branch\`, \`commitMessages\`, and \`topicTitles\` (the highest-signal source);
 support cross-language matching and time-relative queries.
 
-- One match: re-run \`"$HOME/.jolli/jollimemory/run-cli" recall "<branch>" --format json\`
-  and continue from Step 3.
+- One match: re-run Step 1 with the chosen branch as the user-arg and
+  continue from Step 2.
 - Multiple matches: list candidates, ask user to choose.
 - No matches: show the catalog, ask user to clarify.
 
@@ -319,22 +456,21 @@ payload from nothing.
 }
 
 /**
- * Search skill template.
+ * Search skill template — describes the two-phase catalog/detail search
+ * workflow to the host LLM. Byte-identical across every {@link SKILL_TARGETS}
+ * entry, same spec-compliant frontmatter as recall.
  *
  * Two-phase pattern: catalog scan → hash-targeted detail load. The chat LLM
  * does all semantic work (matching the user's query against catalog content);
  * the CLI is purely a deterministic data source.
- *
- * **SECURITY NOTE**: same shell-injection caveat as recall — every `${...}`
- * placeholder must be wrapped in double quotes when interpolated into Bash.
  */
 function buildSearchSkillTemplate(): string {
 	return `---
 name: jolli-search
-description: Search structured commit memories across all branches — decisions, topics, files
-argument-hint: "<keyword> [--since 2w]"
-user-invocable: true
-jolli-skill-version: ${SKILL_VERSION}
+description: Search structured commit memories across all branches — decisions, topics, files. Use when the user wants to find prior decisions, related commits, or how a topic was handled before.
+metadata:
+  version: "${SKILL_VERSION}"
+  vendor: "jolli.ai"
 ---
 
 # Jolli Search
@@ -352,13 +488,13 @@ for the chat LLM that runs this skill.
 
 ## When NOT to use
 
-- Need full context of a known branch → \`/jolli-recall <branch>\`.
+- Need full context of a known branch → run jolli-recall.
 - Looking at the current code → grep / read files directly.
 
-## Step 1: Parse \${ARGUMENTS} into query + flags
+## Step 1: Parse the user input into query + flags
 
-The user can include flags inline, e.g. \`/jolli-search auth --since 2w\`. Before
-invoking the CLI, split the argument string into two parts:
+The user can include flags inline, e.g. \`auth --since 2w\`. Before invoking
+the CLI, split the user's argument into two parts:
 
 1. **Query**: the user's keyword / sentence (everything that is NOT a CLI flag).
    The query may be in any human language and contain natural punctuation
@@ -367,20 +503,27 @@ invoking the CLI, split the argument string into two parts:
    \`--output <path>\`. Pass these through verbatim. Ignore any other token starting
    with \`--\`.
 
-Quote ONLY the query when constructing bash; pass flags as separate unquoted
-tokens. Examples:
+The query is delivered to the CLI on stdin via a here-doc, and flags go on
+argv as separate tokens. Never put flags inside the here-doc body.
+
+## Step 2: Run the catalog phase
+
+${heredocInvocation("search", " <flags> --format json")}
+
+Replace \`<flags>\` with the parsed flags from Step 1 (e.g. \`--since 2w --limit 30\`)
+or remove the placeholder entirely if there are no flags. Always include
+\`--format json\`.
+
+Worked examples (the part the LLM has to construct):
 
 | User input                                  | Bash you should run                                                                                |
 |---------------------------------------------|----------------------------------------------------------------------------------------------------|
-| \`auth\`                                    | \`"$HOME/.jolli/jollimemory/run-cli" search "auth" --format json\`                                |
-| \`auth --since 2w\`                         | \`"$HOME/.jolli/jollimemory/run-cli" search "auth" --since 2w --format json\`                     |
-| \`why did we choose X over Y? --since 1m\`  | \`"$HOME/.jolli/jollimemory/run-cli" search "why did we choose X over Y?" --since 1m --format json\` |
+| \`auth\`                                    | \`run-cli search --arg-stdin --format json <<'JOLLI_ARG_<DELIM>_END' …\`                            |
+| \`auth --since 2w\`                         | \`run-cli search --arg-stdin --since 2w --format json <<'JOLLI_ARG_<DELIM>_END' …\`                 |
+| \`why did we choose X over Y? --since 1m\`  | \`run-cli search --arg-stdin --since 1m --format json <<'JOLLI_ARG_<DELIM>_END' …\`                 |
 
-Always include \`--format json\`. Never put flags inside the query quotes.
-
-## Step 2: Get the catalog
-
-Run the bash command you constructed in Step 1.
+The \`…\` after \`<<'JOLLI_ARG_<DELIM>_END'\` is the here-doc body containing
+the query, followed on a new line by the closing \`JOLLI_ARG_<DELIM>_END\`.
 
 **Failure handling**:
 - If \`~/.jolli/jollimemory/run-cli\` does not exist: tell the user
@@ -434,12 +577,16 @@ larger budget still doesn't surface relevant commits.
 
 ## Step 4: Load full content for the picks
 
-Construct the Phase 2 bash with the same query quoting + flag separation rule
-from Step 1, plus \`--hashes <fullHash1,fullHash2,fullHash3>\`:
+Construct the Phase 2 bash with the same here-doc recipe from Step 2, but add
+\`--hashes <fullHash1,fullHash2,fullHash3>\` to the flags:
 
+\`\`\`bash
+"$HOME/.jolli/jollimemory/run-cli" search --arg-stdin --hashes <fullHash1>,<fullHash2>,<fullHash3> --format json <<'JOLLI_ARG_<DELIM>_END'
+<the query>
+JOLLI_ARG_<DELIM>_END
 \`\`\`
-"$HOME/.jolli/jollimemory/run-cli" search "<the query>" --hashes <fullHash1>,<fullHash2>,<fullHash3> --format json
-\`\`\`
+
+(Generate a new \`<DELIM>\` token for this invocation as in Step 2.)
 
 **Use \`hit.fullHash\` (40-char SHA), NOT \`hit.hash\` (8-char display)**. The
 CLI rejects abbreviated hashes — the 8-char display \`hash\` is for showing in

--- a/vscode/src/services/PrCommentService.test.ts
+++ b/vscode/src/services/PrCommentService.test.ts
@@ -1343,6 +1343,98 @@ describe("PrCommentService", () => {
 				expect(matched).toBeDefined();
 			});
 
+			it("ignores cross-repository (fork) PRs even when they have the highest number, and warns about each dropped ID", async () => {
+				// `gh pr list --head <branch>` matches by branch name only,
+				// which means a contributor fork that shares the head-branch
+				// name with the user's local branch shows up in the result.
+				// Without isCrossRepository filtering, the fork PR (#250)
+				// would be picked over the user's own upstream PR (#42) and
+				// — worse — become the target of Edit PR writes.
+				happyProbes([
+					{
+						number: 250,
+						url: "https://pr/250",
+						title: "Fork contribution",
+						body: "",
+						state: "OPEN",
+						isCrossRepository: true,
+					},
+					{
+						number: 42,
+						url: "https://pr/42",
+						title: "Upstream PR",
+						body: "",
+						state: "OPEN",
+						isCrossRepository: false,
+					},
+					{
+						number: 30,
+						url: "https://pr/30",
+						title: "Old fork PR",
+						body: "",
+						state: "MERGED",
+						isCrossRepository: true,
+					},
+					{
+						number: 25,
+						url: "https://pr/25",
+						title: "Upstream merged",
+						body: "",
+						state: "MERGED",
+						isCrossRepository: false,
+					},
+				]);
+
+				await handleCheckPrStatus(CWD, postMessage);
+
+				// The active PR must be the upstream-owned one, not the
+				// higher-numbered fork. History must only carry upstream
+				// rows, never fork rows.
+				expect(postMessage).toHaveBeenCalledWith(
+					expect.objectContaining({
+						status: "ready",
+						pr: expect.objectContaining({ number: 42 }),
+						history: [{ number: 25, url: "https://pr/25", state: "MERGED" }],
+					}),
+				);
+				// Both dropped fork IDs must appear in the warn log so the
+				// operator can reconcile against the gh / GitHub UI.
+				const warnCalls = warn.mock.calls.map((c) => c.join(" "));
+				const matched = warnCalls.find(
+					(line) =>
+						line.includes("cross-repository") &&
+						line.includes("#250") &&
+						line.includes("#30"),
+				);
+				expect(matched).toBeDefined();
+			});
+
+			it("returns noPr when every matching PR is a cross-repository fork PR", async () => {
+				// Pure-fork edge case: the user's branch happens to share its
+				// name with a contributor fork PR but the user has not opened
+				// their own PR yet. The panel must surface a Create PR
+				// affordance (kind:noPr), not present the fork PR as theirs.
+				happyProbes([
+					{
+						number: 99,
+						url: "https://pr/99",
+						title: "Contributor PR",
+						body: "",
+						state: "OPEN",
+						isCrossRepository: true,
+					},
+				]);
+
+				await handleCheckPrStatus(CWD, postMessage);
+
+				expect(postMessage).toHaveBeenCalledWith(
+					expect.objectContaining({
+						status: "noPr",
+						history: [],
+					}),
+				);
+			});
+
 			it("drops malformed entries with number 0 or missing state from history", async () => {
 				// Defense-in-depth: gh has been observed to return number 0 in
 				// rare edge cases; we'd rather show fewer history pills than

--- a/vscode/src/services/PrCommentService.test.ts
+++ b/vscode/src/services/PrCommentService.test.ts
@@ -292,7 +292,7 @@ describe("PrCommentService", () => {
 						title: "Multi-commit PR",
 						body: "",
 					};
-					return { stdout: JSON.stringify(prData) };
+					return { stdout: JSON.stringify([{ ...prData, state: "OPEN" }]) };
 				}
 				return { stdout: "" };
 			});
@@ -310,6 +310,7 @@ describe("PrCommentService", () => {
 					url: "https://github.com/example/repo/pull/42",
 					title: "Multi-commit PR",
 				},
+				history: [],
 			});
 		});
 
@@ -396,10 +397,8 @@ describe("PrCommentService", () => {
 					return { stdout: "Logged in\n" };
 				}
 				if (cmd === "gh" && args[0] === "pr") {
-					throw ghError({
-						message: "gh exit 1",
-						stderr: "no pull requests found",
-					});
+					// gh pr list returns an empty array (success exit) when no PRs match.
+					return { stdout: "[]" };
 				}
 				return { stdout: "" };
 			});
@@ -419,6 +418,7 @@ describe("PrCommentService", () => {
 				command: "prStatus",
 				status: "noPr",
 				branch: "feature/my-branch",
+				history: [],
 			});
 		});
 
@@ -440,10 +440,8 @@ describe("PrCommentService", () => {
 				}
 				if (cmd === "gh" && args[0] === "auth") return { stdout: "ok\n" };
 				if (cmd === "gh" && args[0] === "pr") {
-					throw ghError({
-						message: "gh exit 1",
-						stderr: "no pull requests found",
-					});
+					// gh pr list returns an empty array (success exit) when no PRs match.
+					return { stdout: "[]" };
 				}
 				return { stdout: "" };
 			});
@@ -462,6 +460,7 @@ describe("PrCommentService", () => {
 				command: "prStatus",
 				status: "noPr",
 				branch: "feature/br",
+				history: [],
 			});
 		});
 
@@ -570,10 +569,8 @@ describe("PrCommentService", () => {
 					return { stdout: "Logged in\n" };
 				}
 				if (cmd === "gh" && args[0] === "pr") {
-					throw ghError({
-						message: "gh exit 1",
-						stderr: "no pull requests found",
-					});
+					// gh pr list returns an empty array (success exit) when no PRs match.
+					return { stdout: "[]" };
 				}
 				return { stdout: "" };
 			});
@@ -584,6 +581,7 @@ describe("PrCommentService", () => {
 				command: "prStatus",
 				status: "noPr",
 				branch: "feature/my-branch",
+				history: [],
 			});
 		});
 
@@ -609,7 +607,7 @@ describe("PrCommentService", () => {
 					return { stdout: "Logged in\n" };
 				}
 				if (cmd === "gh" && args[0] === "pr") {
-					return { stdout: JSON.stringify(prData) };
+					return { stdout: JSON.stringify([{ ...prData, state: "OPEN" }]) };
 				}
 				return { stdout: "" };
 			});
@@ -624,6 +622,7 @@ describe("PrCommentService", () => {
 					url: "https://github.com/org/repo/pull/42",
 					title: "My PR",
 				},
+				history: [],
 			});
 		});
 
@@ -683,7 +682,9 @@ describe("PrCommentService", () => {
 				}
 				if (cmd === "gh" && args[0] === "pr") {
 					return {
-						stdout: JSON.stringify({ number: 0, url: "", title: "", body: "" }),
+						stdout: JSON.stringify([
+							{ number: 0, url: "", title: "", body: "", state: "OPEN" },
+						]),
 					};
 				}
 				return { stdout: "" };
@@ -695,6 +696,7 @@ describe("PrCommentService", () => {
 				command: "prStatus",
 				status: "noPr",
 				branch: "feature/branch",
+				history: [],
 			});
 		});
 
@@ -809,12 +811,15 @@ describe("PrCommentService", () => {
 
 		it("does not emit warn/debug on the happy path (baseline)", async () => {
 			setupHappyProbesWithPrHandler(() => ({
-				stdout: JSON.stringify({
-					number: 7,
-					url: "https://pr/7",
-					title: "t",
-					body: "b",
-				}),
+				stdout: JSON.stringify([
+					{
+						number: 7,
+						url: "https://pr/7",
+						title: "t",
+						body: "b",
+						state: "OPEN",
+					},
+				]),
 			}));
 
 			await handleCheckPrStatus(CWD, postMessage);
@@ -823,14 +828,13 @@ describe("PrCommentService", () => {
 			expect(debug).not.toHaveBeenCalled();
 		});
 
-		it("logs at debug when gh pr view stderr indicates 'no pull requests found'", async () => {
-			setupHappyProbesWithPrHandler(() => {
-				throw ghError({
-					message: "gh: exit 1",
-					code: 1,
-					stderr: "no pull requests found for branch feature/br\n",
-				});
-			});
+		it("logs at debug when gh pr list returns an empty array (no PRs match)", async () => {
+			// gh pr list returns `[]` on success exit when no PRs match the
+			// --head filter. findPrForBranch logs at debug and returns noPr —
+			// this is the standard "no PR" miss path under the list-based
+			// implementation, replacing the old stderr "no pull requests found"
+			// regex match.
+			setupHappyProbesWithPrHandler(() => ({ stdout: "[]" }));
 
 			await handleCheckPrStatus(CWD, postMessage);
 
@@ -840,16 +844,20 @@ describe("PrCommentService", () => {
 			);
 			expect(warn).not.toHaveBeenCalled();
 			expect(postMessage).toHaveBeenCalledWith(
-				expect.objectContaining({ status: "noPr", branch: "feature/br" }),
+				expect.objectContaining({
+					status: "noPr",
+					branch: "feature/br",
+					history: [],
+				}),
 			);
 		});
 
-		it("posts unavailable (NOT noPr) when gh pr view fails with a non-expected stderr (e.g. auth/ratelimit)", async () => {
+		it("posts unavailable (NOT noPr) when gh pr list fails with a non-empty stderr (e.g. auth/ratelimit)", async () => {
 			// I-1 contract change: auth lapses, rate limits, and other gh
-			// non-zero exits that don't say "no pull requests found" used to
-			// be folded into noPr — leading the user to click Create PR and
-			// either fail or duplicate. Now they surface as `unavailable`
-			// with the real stderr in `reason`, and the UI shows Retry.
+			// non-zero exits used to be folded into noPr — leading the user
+			// to click Create PR and either fail or duplicate. Now they
+			// surface as `unavailable` with the real stderr in `reason`,
+			// and the UI shows Retry.
 			setupHappyProbesWithPrHandler(() => {
 				throw ghError({
 					message: "gh: exit 1",
@@ -863,7 +871,7 @@ describe("PrCommentService", () => {
 			expect(warn).toHaveBeenCalledWith(
 				expect.any(String),
 				expect.stringMatching(
-					/gh pr view failed for branch feature\/br.*code=1.*stderr:.*authentication required/s,
+					/gh pr list failed for branch feature\/br.*code=1.*stderr:.*authentication required/s,
 				),
 			);
 			expect(debug).not.toHaveBeenCalled();
@@ -934,15 +942,13 @@ describe("PrCommentService", () => {
 				if (cmd === "gh" && args[0] === "auth") {
 					return { stdout: "ok\n" };
 				}
-				if (cmd === "gh" && args[0] === "pr" && args[1] === "view") {
-					const sepIdx = args.indexOf("--");
+				if (cmd === "gh" && args[0] === "pr" && args[1] === "list") {
+					const sepIdx = args.indexOf("--head");
 					if (sepIdx >= 0) {
 						prListHeadArg = args[sepIdx + 1];
 					}
-					throw ghError({
-						message: "gh exit 1",
-						stderr: "no pull requests found",
-					});
+					// gh pr list returns an empty array (success exit) when no PRs match.
+					return { stdout: "[]" };
 				}
 				return { stdout: "" };
 			});
@@ -955,6 +961,7 @@ describe("PrCommentService", () => {
 				expect.objectContaining({
 					status: "noPr",
 					branch: "feature/summary-branch",
+					history: [],
 				}),
 			);
 		});
@@ -977,16 +984,14 @@ describe("PrCommentService", () => {
 				if (cmd === "gh" && args[0] === "auth") {
 					return { stdout: "ok\n" };
 				}
-				if (cmd === "gh" && args[0] === "pr" && args[1] === "view") {
-					const sepIdx = args.indexOf("--");
+				if (cmd === "gh" && args[0] === "pr" && args[1] === "list") {
+					const sepIdx = args.indexOf("--head");
 					if (sepIdx >= 0) {
 						prViewBranchArg = args[sepIdx + 1];
 					}
 					// gh returns "no PR" for the stale name.
-					throw ghError({
-						message: "gh exit 1",
-						stderr: "no pull requests found",
-					});
+					// gh pr list returns an empty array (success exit) when no PRs match.
+					return { stdout: "[]" };
 				}
 				return { stdout: "" };
 			});
@@ -1001,6 +1006,7 @@ describe("PrCommentService", () => {
 				expect.objectContaining({
 					status: "noPr",
 					branch: "feature/old",
+					history: [],
 				}),
 			);
 		});
@@ -1017,15 +1023,13 @@ describe("PrCommentService", () => {
 				if (cmd === "gh" && args[0] === "auth") {
 					return { stdout: "ok\n" };
 				}
-				if (cmd === "gh" && args[0] === "pr" && args[1] === "view") {
-					const sepIdx = args.indexOf("--");
+				if (cmd === "gh" && args[0] === "pr" && args[1] === "list") {
+					const sepIdx = args.indexOf("--head");
 					if (sepIdx >= 0) {
 						prListHeadArg = args[sepIdx + 1];
 					}
-					throw ghError({
-						message: "gh exit 1",
-						stderr: "no pull requests found",
-					});
+					// gh pr list returns an empty array (success exit) when no PRs match.
+					return { stdout: "[]" };
 				}
 				return { stdout: "" };
 			});
@@ -1061,12 +1065,15 @@ describe("PrCommentService", () => {
 					if (cmd === "gh" && args[0] === "pr") {
 						ghPrCalls.push(args);
 						return {
-							stdout: JSON.stringify({
-								number: 7,
-								url: "https://github.com/other/repo/pull/7",
-								title: "Foreign PR",
-								body: "",
-							}),
+							stdout: JSON.stringify([
+								{
+									number: 7,
+									url: "https://github.com/other/repo/pull/7",
+									title: "Foreign PR",
+									body: "",
+									state: "OPEN",
+								},
+							]),
 						};
 					}
 					return { stdout: "" };
@@ -1100,7 +1107,247 @@ describe("PrCommentService", () => {
 						url: "https://github.com/other/repo/pull/7",
 						title: "Foreign PR",
 					},
+					history: [],
 				});
+			});
+
+			it("posts unavailable when repoUrl is provided without summaryBranch (foreign-repo guard)", async () => {
+				// Foreign-repo lookups MUST be paired with an explicit
+				// summaryBranch: the cwd-bound `getCurrentBranch` fallback would
+				// describe the *current* repo, which is the wrong branch when
+				// the user is viewing a Memory Bank summary from a different
+				// project. Pre-guard the call rather than send a misleading
+				// PR status from the wrong repo.
+				await handleCheckPrStatus(
+					CWD,
+					postMessage,
+					undefined,
+					"https://github.com/foreign/repo",
+				);
+				expect(postMessage).toHaveBeenCalledWith({
+					command: "prStatus",
+					status: "unavailable",
+				});
+				// No gh / git probes should have run on this guard path.
+				expect(mockExecFileAsync).not.toHaveBeenCalled();
+			});
+		});
+
+		// ─── Previously: PR history strip ────────────────────────────────────
+		// Covers the new `gh pr list --state all` shape: an active open PR is
+		// shown front-and-center while merged/closed PRs from the same branch
+		// flow into a "Previously:" inline strip below the actions. These
+		// tests pin both the discriminator (open → kind:found, merged-only →
+		// kind:noPr) AND the ordering (number-desc, latest first).
+		describe("PR history (Previously: strip)", () => {
+			function happyProbes(pr: ReadonlyArray<unknown>): void {
+				setupExecFile((cmd, args) => {
+					if (cmd === "git" && args[0] === "rev-list") return { stdout: "1\n" };
+					if (cmd === "git" && args[0] === "rev-parse")
+						return { stdout: "feature/br\n" };
+					if (cmd === "gh" && args[0] === "--version")
+						return { stdout: "ok\n" };
+					if (cmd === "gh" && args[0] === "auth") return { stdout: "ok\n" };
+					if (cmd === "gh" && args[0] === "pr" && args[1] === "list") {
+						return { stdout: JSON.stringify(pr) };
+					}
+					return { stdout: "" };
+				});
+			}
+
+			it("passes merged/closed PRs as history alongside ready status when an open PR exists", async () => {
+				happyProbes([
+					{
+						number: 104,
+						url: "https://pr/104",
+						title: "Active",
+						body: "",
+						state: "OPEN",
+					},
+					{
+						number: 102,
+						url: "https://pr/102",
+						title: "Old",
+						body: "",
+						state: "MERGED",
+					},
+					{
+						number: 98,
+						url: "https://pr/98",
+						title: "Older",
+						body: "",
+						state: "CLOSED",
+					},
+				]);
+
+				await handleCheckPrStatus(CWD, postMessage);
+
+				expect(postMessage).toHaveBeenCalledWith({
+					command: "prStatus",
+					status: "ready",
+					pr: { number: 104, url: "https://pr/104", title: "Active" },
+					history: [
+						{ number: 102, url: "https://pr/102", state: "MERGED" },
+						{ number: 98, url: "https://pr/98", state: "CLOSED" },
+					],
+				});
+			});
+
+			it("returns noPr (NOT ready on merged) when only merged/closed PRs exist", async () => {
+				// Pre-refactor (gh pr view) would surface a merged PR as
+				// `kind: "found"` because gh returns it for the branch. That
+				// showed Edit PR on a merged PR — editing a merged title/body
+				// works but is almost never what the user wants. Switching to
+				// gh pr list + state filter keeps merged/closed out of the
+				// "active PR" slot.
+				happyProbes([
+					{
+						number: 102,
+						url: "https://pr/102",
+						title: "Old",
+						body: "",
+						state: "MERGED",
+					},
+				]);
+
+				await handleCheckPrStatus(CWD, postMessage);
+
+				expect(postMessage).toHaveBeenCalledWith({
+					command: "prStatus",
+					status: "noPr",
+					branch: "feature/br",
+					history: [{ number: 102, url: "https://pr/102", state: "MERGED" }],
+				});
+			});
+
+			it("orders history by number descending (latest first)", async () => {
+				// gh's own order isn't guaranteed; we sort so the user always
+				// sees the most recently-numbered PR first.
+				happyProbes([
+					{
+						number: 50,
+						url: "https://pr/50",
+						title: "B",
+						body: "",
+						state: "MERGED",
+					},
+					{
+						number: 200,
+						url: "https://pr/200",
+						title: "C",
+						body: "",
+						state: "CLOSED",
+					},
+					{
+						number: 1,
+						url: "https://pr/1",
+						title: "A",
+						body: "",
+						state: "MERGED",
+					},
+				]);
+
+				await handleCheckPrStatus(CWD, postMessage);
+
+				expect(postMessage).toHaveBeenCalledWith(
+					expect.objectContaining({
+						status: "noPr",
+						history: [
+							{ number: 200, url: "https://pr/200", state: "CLOSED" },
+							{ number: 50, url: "https://pr/50", state: "MERGED" },
+							{ number: 1, url: "https://pr/1", state: "MERGED" },
+						],
+					}),
+				);
+			});
+
+			it("picks the highest-numbered open PR when gh returns more than one (anomaly)", async () => {
+				// GitHub allows at most one open PR per head branch, but if gh
+				// returns more we deterministically pick the latest and surface
+				// the older one(s) as history so nothing silently disappears.
+				happyProbes([
+					{
+						number: 10,
+						url: "https://pr/10",
+						title: "Stale open",
+						body: "",
+						state: "OPEN",
+					},
+					{
+						number: 20,
+						url: "https://pr/20",
+						title: "Newer open",
+						body: "",
+						state: "OPEN",
+					},
+				]);
+
+				await handleCheckPrStatus(CWD, postMessage);
+
+				expect(postMessage).toHaveBeenCalledWith(
+					expect.objectContaining({
+						status: "ready",
+						pr: expect.objectContaining({ number: 20 }),
+					}),
+				);
+			});
+
+			it("drops malformed entries with number 0 or missing state from history", async () => {
+				// Defense-in-depth: gh has been observed to return number 0 in
+				// rare edge cases; we'd rather show fewer history pills than
+				// crash the section. State is `unknown`-cast at parse, so a
+				// missing `state` survives type-check but must be filtered.
+				happyProbes([
+					{
+						number: 0,
+						url: "https://pr/0",
+						title: "",
+						body: "",
+						state: "MERGED",
+					},
+					{
+						number: 50,
+						url: "https://pr/50",
+						title: "Real",
+						body: "" /* no state */,
+					},
+					{
+						number: 60,
+						url: "https://pr/60",
+						title: "Real",
+						body: "",
+						state: "MERGED",
+					},
+				]);
+
+				await handleCheckPrStatus(CWD, postMessage);
+
+				expect(postMessage).toHaveBeenCalledWith(
+					expect.objectContaining({
+						status: "noPr",
+						history: [{ number: 60, url: "https://pr/60", state: "MERGED" }],
+					}),
+				);
+			});
+
+			it("posts unavailable with reason when gh returns non-array JSON (shape regression)", async () => {
+				// gh could conceivably return a single object instead of an
+				// array if its output shape changes; we treat that as a
+				// lookupError rather than guessing how to coerce it.
+				happyProbes(
+					JSON.parse(
+						'{"number":1,"state":"OPEN","url":"x","title":"y","body":""}',
+					) as ReadonlyArray<unknown>,
+				);
+
+				await handleCheckPrStatus(CWD, postMessage);
+
+				expect(postMessage).toHaveBeenCalledWith(
+					expect.objectContaining({
+						status: "unavailable",
+						reason: expect.stringContaining("expected array"),
+					}),
+				);
 			});
 		});
 	});
@@ -1127,13 +1374,16 @@ describe("PrCommentService", () => {
 					"git:rev-parse": () => ({ stdout: "feature/branch\n" }),
 					"gh:--version": () => ({ stdout: "gh 2.40.0\n" }),
 					"gh:auth": () => ({ stdout: "ok\n" }),
-					"gh:pr:view": () => ({
-						stdout: JSON.stringify({
-							number: 77,
-							url: prUrl,
-							title: "Rebased PR",
-							body: "",
-						}),
+					"gh:pr:list": () => ({
+						stdout: JSON.stringify([
+							{
+								number: 77,
+								url: prUrl,
+								title: "Rebased PR",
+								body: "",
+								state: "OPEN",
+							},
+						]),
 					}),
 				}),
 			);
@@ -1169,13 +1419,16 @@ describe("PrCommentService", () => {
 					"git:rev-parse": () => ({ stdout: "feature/branch\n" }),
 					"gh:--version": () => ({ stdout: "gh 2.40.0\n" }),
 					"gh:auth": () => ({ stdout: "ok\n" }),
-					"gh:pr:view": () => ({
-						stdout: JSON.stringify({
-							number: 99,
-							url: prUrl,
-							title: "New PR",
-							body: "",
-						}),
+					"gh:pr:list": () => ({
+						stdout: JSON.stringify([
+							{
+								number: 99,
+								url: prUrl,
+								title: "New PR",
+								body: "",
+								state: "OPEN",
+							},
+						]),
 					}),
 				}),
 			);
@@ -1242,13 +1495,16 @@ describe("PrCommentService", () => {
 					"git:rev-parse": () => ({ stdout: "branch\n" }),
 					"gh:--version": () => ({ stdout: "ok\n" }),
 					"gh:auth": () => ({ stdout: "ok\n" }),
-					"gh:pr:view": () => ({
-						stdout: JSON.stringify({
-							number: 55,
-							url: prUrl,
-							title: "T",
-							body: "",
-						}),
+					"gh:pr:list": () => ({
+						stdout: JSON.stringify([
+							{
+								number: 55,
+								url: prUrl,
+								title: "T",
+								body: "",
+								state: "OPEN",
+							},
+						]),
 					}),
 				}),
 			);
@@ -1323,13 +1579,16 @@ describe("PrCommentService", () => {
 					"git:rev-list": () => ({ stdout: "1\n" }),
 					"gh:--version": () => ({ stdout: "gh 2.40.0\n" }),
 					"gh:auth": () => ({ stdout: "ok\n" }),
-					"gh:pr:view": () => ({
-						stdout: JSON.stringify({
-							number: 123,
-							url: prUrl,
-							title: "OK",
-							body: "",
-						}),
+					"gh:pr:list": () => ({
+						stdout: JSON.stringify([
+							{
+								number: 123,
+								url: prUrl,
+								title: "OK",
+								body: "",
+								state: "OPEN",
+							},
+						]),
 					}),
 				}),
 			);
@@ -1359,14 +1618,17 @@ describe("PrCommentService", () => {
 				if (cmd === "git" && args[0] === "rev-parse") {
 					return { stdout: "feature/test-branch\n" };
 				}
-				if (cmd === "gh" && args[0] === "pr" && args[1] === "view") {
+				if (cmd === "gh" && args[0] === "pr" && args[1] === "list") {
 					return {
-						stdout: JSON.stringify({
-							number: 10,
-							url: "https://url",
-							title: "PR Title",
-							body: existingBody,
-						}),
+						stdout: JSON.stringify([
+							{
+								number: 10,
+								url: "https://url",
+								title: "PR Title",
+								body: existingBody,
+								state: "OPEN",
+							},
+						]),
 					};
 				}
 				return { stdout: "" };
@@ -1387,14 +1649,17 @@ describe("PrCommentService", () => {
 				if (cmd === "git" && args[0] === "rev-parse") {
 					return { stdout: "feature/test-branch\n" };
 				}
-				if (cmd === "gh" && args[0] === "pr" && args[1] === "view") {
+				if (cmd === "gh" && args[0] === "pr" && args[1] === "list") {
 					return {
-						stdout: JSON.stringify({
-							number: 10,
-							url: "https://url",
-							title: "T",
-							body: existingBody,
-						}),
+						stdout: JSON.stringify([
+							{
+								number: 10,
+								url: "https://url",
+								title: "T",
+								body: existingBody,
+								state: "OPEN",
+							},
+						]),
 					};
 				}
 				return { stdout: "" };
@@ -1425,7 +1690,7 @@ describe("PrCommentService", () => {
 				if (cmd === "gh" && args[0] === "auth") {
 					return { stdout: "ok\n" };
 				}
-				if (cmd === "gh" && args[0] === "pr" && args[1] === "view") {
+				if (cmd === "gh" && args[0] === "pr" && args[1] === "list") {
 					throw ghError({
 						message: "gh exit 4",
 						code: 4,
@@ -1467,15 +1732,13 @@ describe("PrCommentService", () => {
 				if (cmd === "gh" && args[0] === "auth") {
 					return { stdout: "ok\n" };
 				}
-				if (cmd === "gh" && args[0] === "pr" && args[1] === "view") {
+				if (cmd === "gh" && args[0] === "pr" && args[1] === "list") {
 					// Mimic gh's real non-zero exit with the "no pull requests
 					// found" stderr line — findPrForBranch reads it via
 					// `(err as { stderr? }).stderr`, matches the regex,
 					// returns `{ kind: "noPr" }`.
-					throw ghError({
-						message: "gh exit 1",
-						stderr: "no pull requests found",
-					});
+					// gh pr list returns an empty array (success exit) when no PRs match.
+					return { stdout: "[]" };
 				}
 				return { stdout: "" };
 			});
@@ -1492,6 +1755,7 @@ describe("PrCommentService", () => {
 					command: "prStatus",
 					status: "noPr",
 					branch: "feature/test-branch",
+					history: [],
 				}),
 			);
 		});
@@ -1533,14 +1797,17 @@ describe("PrCommentService", () => {
 				if (cmd === "git" && args[0] === "rev-parse") {
 					return { stdout: "feature/test-branch\n" };
 				}
-				if (cmd === "gh" && args[0] === "pr" && args[1] === "view") {
+				if (cmd === "gh" && args[0] === "pr" && args[1] === "list") {
 					return {
-						stdout: JSON.stringify({
-							number: 10,
-							url: "https://url",
-							title: "T",
-							body: "",
-						}),
+						stdout: JSON.stringify([
+							{
+								number: 10,
+								url: "https://url",
+								title: "T",
+								body: "",
+								state: "OPEN",
+							},
+						]),
 					};
 				}
 				return { stdout: "" };
@@ -1562,18 +1829,21 @@ describe("PrCommentService", () => {
 				if (cmd === "git" && args[0] === "rev-parse") {
 					return { stdout: "feature/current\n" };
 				}
-				if (cmd === "gh" && args[0] === "pr" && args[1] === "view") {
-					const sepIdx = args.indexOf("--");
+				if (cmd === "gh" && args[0] === "pr" && args[1] === "list") {
+					const sepIdx = args.indexOf("--head");
 					if (sepIdx >= 0) {
 						prViewBranchArg = args[sepIdx + 1];
 					}
 					return {
-						stdout: JSON.stringify({
-							number: 5,
-							url: "https://url",
-							title: "T",
-							body: "",
-						}),
+						stdout: JSON.stringify([
+							{
+								number: 5,
+								url: "https://url",
+								title: "T",
+								body: "",
+								state: "OPEN",
+							},
+						]),
 					};
 				}
 				return { stdout: "" };
@@ -1603,8 +1873,8 @@ describe("PrCommentService", () => {
 
 			setupExecFile((cmd, args) => {
 				// findPrForBranch
-				if (cmd === "gh" && args[0] === "pr" && args[1] === "view") {
-					return { stdout: JSON.stringify(pr) };
+				if (cmd === "gh" && args[0] === "pr" && args[1] === "list") {
+					return { stdout: JSON.stringify([{ ...pr, state: "OPEN" }]) };
 				}
 				// execGh for pr edit (title change)
 				if (cmd === "gh" && args[0] === "pr" && args[1] === "edit") {
@@ -1678,10 +1948,8 @@ describe("PrCommentService", () => {
 				if (cmd === "git" && args[0] === "rev-parse") {
 					return { stdout: "branch\n" };
 				}
-				throw ghError({
-					message: "gh exit 1",
-					stderr: "no pull requests found",
-				});
+				// gh pr list returns an empty array (success exit) when no PRs match.
+				return { stdout: "[]" };
 			});
 
 			await handleUpdatePr("T", "B", CWD, postMessage);
@@ -1729,14 +1997,17 @@ describe("PrCommentService", () => {
 				if (cmd === "git" && args[0] === "rev-parse") {
 					return { stdout: "branch\n" };
 				}
-				if (cmd === "gh" && args[0] === "pr" && args[1] === "view") {
+				if (cmd === "gh" && args[0] === "pr" && args[1] === "list") {
 					return {
-						stdout: JSON.stringify({
-							number: 5,
-							url: "u",
-							title: "T",
-							body: "",
-						}),
+						stdout: JSON.stringify([
+							{
+								number: 5,
+								url: "u",
+								title: "T",
+								body: "",
+								state: "OPEN",
+							},
+						]),
 					};
 				}
 				if (cmd === "gh" && args[0] === "pr" && args[1] === "edit") {
@@ -1763,14 +2034,17 @@ describe("PrCommentService", () => {
 				if (cmd === "git" && args[0] === "rev-parse") {
 					return { stdout: "branch\n" };
 				}
-				if (cmd === "gh" && args[0] === "pr" && args[1] === "view") {
+				if (cmd === "gh" && args[0] === "pr" && args[1] === "list") {
 					return {
-						stdout: JSON.stringify({
-							number: 5,
-							url: "u",
-							title: "T",
-							body: "",
-						}),
+						stdout: JSON.stringify([
+							{
+								number: 5,
+								url: "u",
+								title: "T",
+								body: "",
+								state: "OPEN",
+							},
+						]),
 					};
 				}
 				if (cmd === "gh" && args[0] === "pr" && args[1] === "edit") {
@@ -1790,8 +2064,8 @@ describe("PrCommentService", () => {
 		it("succeeds even when temp file cleanup fails (removeTempFile catch)", async () => {
 			const pr = { number: 7, url: "https://pr/7", title: "T", body: "" };
 			setupExecFile((cmd, args) => {
-				if (cmd === "gh" && args[0] === "pr" && args[1] === "view") {
-					return { stdout: JSON.stringify(pr) };
+				if (cmd === "gh" && args[0] === "pr" && args[1] === "list") {
+					return { stdout: JSON.stringify([{ ...pr, state: "OPEN" }]) };
 				}
 				if (cmd === "gh" && args[0] === "pr" && args[1] === "edit") {
 					return { stdout: "" };
@@ -1848,18 +2122,21 @@ describe("PrCommentService", () => {
 				if (cmd === "git" && args[0] === "rev-parse") {
 					return { stdout: "feature/current\n" };
 				}
-				if (cmd === "gh" && args[0] === "pr" && args[1] === "view") {
-					const sepIdx = args.indexOf("--");
+				if (cmd === "gh" && args[0] === "pr" && args[1] === "list") {
+					const sepIdx = args.indexOf("--head");
 					if (sepIdx >= 0) {
 						prViewBranchArg = args[sepIdx + 1];
 					}
 					return {
-						stdout: JSON.stringify({
-							number: 11,
-							url: "https://url",
-							title: "T",
-							body: "",
-						}),
+						stdout: JSON.stringify([
+							{
+								number: 11,
+								url: "https://url",
+								title: "T",
+								body: "",
+								state: "OPEN",
+							},
+						]),
 					};
 				}
 				if (cmd === "gh" && args[0] === "--version") {

--- a/vscode/src/services/PrCommentService.test.ts
+++ b/vscode/src/services/PrCommentService.test.ts
@@ -265,6 +265,43 @@ describe("PrCommentService", () => {
 			expect(js).toContain("createPrBtn");
 			expect(js).toContain("prFormSubmit");
 		});
+
+		it("renders Edit PR only under the 'ready' branch, never under 'noPr' (merged-only branches must not show Edit PR)", () => {
+			// PR description's core promise: a branch with only merged/closed
+			// PRs flows into kind:noPr and the panel surfaces a Create PR
+			// button, never Edit PR. The two branches are emitted as adjacent
+			// `if` blocks in the same JS string, so a future refactor that
+			// accidentally hoists editPrBtn into the noPr branch would silently
+			// regress this guarantee. Slice the noPr block out and assert the
+			// Edit PR identifier appears ONLY after that slice ends.
+			const js = buildPrMessageScript();
+			const noPrIdx = js.indexOf("s === 'noPr'");
+			const readyIdx = js.indexOf("s === 'ready'");
+			expect(noPrIdx).toBeGreaterThan(-1);
+			expect(readyIdx).toBeGreaterThan(noPrIdx);
+			const noPrBlock = js.slice(noPrIdx, readyIdx);
+			expect(noPrBlock).not.toContain("editPrBtn");
+			expect(noPrBlock).not.toContain("'Edit PR'");
+			// And the Create PR button MUST be the one wired up in the noPr branch.
+			expect(noPrBlock).toContain("createPrBtn");
+			expect(noPrBlock).toContain("'Create PR'");
+		});
+	});
+
+	// ─── PR history webview rendering: defense-in-depth assertions ──────────
+
+	describe("renderPrHistory (webview JS string)", () => {
+		it("guards history-link href with an https:// prefix check before assignment", () => {
+			// The webview never trusts upstream gh output unconditionally: an
+			// entry whose `url` is not an https:// string must be silently
+			// dropped so a malformed/compromised gh response cannot smuggle a
+			// `javascript:` or `data:` link into the panel. This pins the
+			// guard's literal substring so a refactor that loosens it (e.g.
+			// dropping the check, replacing with regex-less prefix match)
+			// fails the test instead of regressing the safety net.
+			const js = buildPrSectionScript();
+			expect(js).toContain("h.url.indexOf('https://')");
+		});
 	});
 
 	// ─── handleCheckPrStatus ────────────────────────────────────────────────
@@ -1261,10 +1298,14 @@ describe("PrCommentService", () => {
 				);
 			});
 
-			it("picks the highest-numbered open PR when gh returns more than one (anomaly)", async () => {
-				// GitHub allows at most one open PR per head branch, but if gh
-				// returns more we deterministically pick the latest and surface
-				// the older one(s) as history so nothing silently disappears.
+			it("picks the highest-numbered open PR when gh returns more than one (anomaly) and warns about the dropped IDs", async () => {
+				// GitHub enforces ≤1 open PR per head branch; if gh ever returns
+				// more (replication lag, stale cache, future API change), the
+				// lookup picks the latest by number. The other OPEN entries are
+				// NOT downgraded into the history strip — that would encode the
+				// anomaly into PrHistoryEntry's public shape. Instead they are
+				// logged via log.warn so the dropped IDs are recoverable from
+				// debug.log without bloating the type surface.
 				happyProbes([
 					{
 						number: 10,
@@ -1290,6 +1331,16 @@ describe("PrCommentService", () => {
 						pr: expect.objectContaining({ number: 20 }),
 					}),
 				);
+				// Dropped OPEN ids must surface in debug.log so the operator
+				// can correlate against gh / GitHub UI when this fires.
+				const warnCalls = warn.mock.calls.map((c) => c.join(" "));
+				const matched = warnCalls.find(
+					(line) =>
+						line.includes("Multiple open PRs") &&
+						line.includes("#20") &&
+						line.includes("#10"),
+				);
+				expect(matched).toBeDefined();
 			});
 
 			it("drops malformed entries with number 0 or missing state from history", async () => {

--- a/vscode/src/services/PrCommentService.test.ts
+++ b/vscode/src/services/PrCommentService.test.ts
@@ -839,7 +839,6 @@ describe("PrCommentService", () => {
 				expect.stringContaining("No PR for branch feature/br"),
 			);
 			expect(warn).not.toHaveBeenCalled();
-			// UI folding unchanged — see plan non-goal
 			expect(postMessage).toHaveBeenCalledWith(
 				expect.objectContaining({ status: "noPr", branch: "feature/br" }),
 			);
@@ -965,7 +964,7 @@ describe("PrCommentService", () => {
 			// summary still points at `feature/old`. We MUST query
 			// `feature/old` and report `noPr` for it — NOT silently retarget
 			// to `feature/new` or to currentBranch. Auto-recovery from
-			// renames is a separate spike (see plan doc "Out of scope").
+			// renames is out of scope here.
 			let prViewBranchArg: string | undefined;
 			setupExecFile((cmd, args) => {
 				if (cmd === "git" && args[0] === "rev-parse") {

--- a/vscode/src/services/PrCommentService.ts
+++ b/vscode/src/services/PrCommentService.ts
@@ -352,11 +352,27 @@ async function findPrForBranch(
 	const valid = parsed.filter(
 		(p) => p.number > 0 && typeof p.state === "string",
 	);
-	// Open: GitHub allows at most one open PR per head branch; if more than
-	// one appears (gh/GitHub anomaly) pick the highest-numbered (most recent).
+	// Open: GitHub enforces at most one open PR per head branch, so this
+	// filter normally yields 0 or 1 entries. The sort + slice[0] selection
+	// below is defensive: a transient gh/GitHub anomaly (replication lag,
+	// stale cache) could surface multiple OPEN rows briefly. We pick the
+	// highest-numbered (most recent) and log a warning so the dropped IDs
+	// are recoverable from debug.log; we deliberately do NOT widen the
+	// PrHistoryEntry type to carry OPEN — keeping that path unreachable in
+	// practice avoids encoding the anomaly into the public type surface.
 	const openPrs = valid
 		.filter((p) => p.state === "OPEN")
 		.sort((a, b) => b.number - a.number);
+	if (openPrs.length > 1) {
+		const dropped = openPrs
+			.slice(1)
+			.map((p) => `#${p.number}`)
+			.join(", ");
+		log.warn(
+			TAG,
+			`Multiple open PRs for branch ${branch} (GitHub usually allows one): kept #${openPrs[0].number} as active, ignored ${dropped}.`,
+		);
+	}
 	const closedPrs = valid
 		.filter((p) => p.state === "MERGED" || p.state === "CLOSED")
 		.sort((a, b) => b.number - a.number);
@@ -906,9 +922,18 @@ export function buildPrSectionScript(): string {
     label.className = 'pr-history-label';
     label.textContent = 'Previously:';
     prHistory.appendChild(label);
+    var renderedCount = 0;
     for (var i = 0; i < prLastHistory.length; i++) {
       var h = prLastHistory[i];
-      if (i > 0) {
+      // Defense in depth: the url comes from \`gh pr list --json url\` and is
+      // expected to be a github.com PR URL, but the webview never trusts
+      // upstream output unconditionally — anything that isn't https:// is
+      // skipped so a malformed/compromised gh response can't smuggle a
+      // javascript:/data: link into the panel. Separator emission is gated
+      // on renderedCount (not the loop index) so a dropped entry never
+      // leaves a stranded '·' bullet.
+      if (typeof h.url !== 'string' || h.url.indexOf('https://') !== 0) continue;
+      if (renderedCount > 0) {
         var sep = document.createElement('span');
         sep.className = 'pr-history-sep';
         sep.textContent = '·';
@@ -920,6 +945,7 @@ export function buildPrSectionScript(): string {
       link.className = h.state === 'MERGED' ? 'pr-history-merged' : 'pr-history-closed';
       link.textContent = '#' + h.number + ' (' + (h.state === 'MERGED' ? 'merged' : 'closed') + ')';
       prHistory.appendChild(link);
+      renderedCount++;
     }
     prShow(prHistory);
   }

--- a/vscode/src/services/PrCommentService.ts
+++ b/vscode/src/services/PrCommentService.ts
@@ -255,13 +255,21 @@ type PrLookup =
 	| { kind: "noPr"; history: ReadonlyArray<PrHistoryEntry> }
 	| { kind: "lookupError"; reason: string };
 
-/** Raw row shape returned by `gh pr list --json number,url,title,body,state`. */
+/**
+ * Raw row shape returned by `gh pr list --json
+ * number,url,title,body,state,isCrossRepository`.
+ *
+ * `isCrossRepository` is true when the PR was opened from a fork against this
+ * repo. We never want to show or edit a fork PR through this panel — see
+ * the filter in {@link findPrForBranch}.
+ */
 interface RawPrListRow {
 	readonly number: number;
 	readonly url: string;
 	readonly title: string;
 	readonly body: string;
 	readonly state: "OPEN" | "MERGED" | "CLOSED";
+	readonly isCrossRepository?: boolean;
 }
 
 /**
@@ -298,7 +306,7 @@ async function findPrForBranch(
 		"--head",
 		branch,
 		"--json",
-		"number,url,title,body,state",
+		"number,url,title,body,state,isCrossRepository",
 		...repoArgs,
 	];
 	const result = await tryExecGh(args, cwd);
@@ -349,9 +357,26 @@ async function findPrForBranch(
 	// Skip entries that look malformed — e.g. missing number (which `gh` has
 	// returned as 0 in edge cases) or missing state. We'd rather show fewer
 	// history pills than crash the section.
-	const valid = parsed.filter(
+	//
+	// Strict same-repo filter: `gh pr list --head <branch>` matches by branch
+	// name alone, so a contributor fork that happens to share the head-branch
+	// name (common in open-source repos) would otherwise be picked up here
+	// and — if it had the highest number — be selected as the "active" PR.
+	// That made Edit PR a wrong-target write vector. Dropping rows where
+	// `isCrossRepository` is true scopes the lookup to upstream-owned PRs,
+	// matching the old `gh pr view` behavior the previous CLI surface had.
+	const wellFormed = parsed.filter(
 		(p) => p.number > 0 && typeof p.state === "string",
 	);
+	const forkPrs = wellFormed.filter((p) => p.isCrossRepository === true);
+	if (forkPrs.length > 0) {
+		const dropped = forkPrs.map((p) => `#${p.number}`).join(", ");
+		log.warn(
+			TAG,
+			`Ignoring ${forkPrs.length} cross-repository (fork) PR(s) on branch ${branch}: ${dropped}. The panel only manages PRs owned by the upstream repo.`,
+		);
+	}
+	const valid = wellFormed.filter((p) => p.isCrossRepository !== true);
 	// Open: GitHub enforces at most one open PR per head branch, so this
 	// filter normally yields 0 or 1 entries. The sort + slice[0] selection
 	// below is defensive: a transient gh/GitHub anomaly (replication lag,

--- a/vscode/src/services/PrCommentService.ts
+++ b/vscode/src/services/PrCommentService.ts
@@ -223,7 +223,25 @@ interface PrInfo {
 }
 
 /**
+ * A closed (merged or closed-without-merge) PR shown in the "Previously"
+ * history strip below the active PR actions. URL is included so the webview
+ * can render each entry as a clickable link without re-querying gh.
+ */
+export interface PrHistoryEntry {
+	readonly number: number;
+	readonly url: string;
+	readonly state: "MERGED" | "CLOSED";
+}
+
+/**
  * Discriminated result of `findPrForBranch`.
+ *
+ * `kind === "found"` strictly means there is an open PR — when only merged /
+ * closed PRs exist on the branch we return `kind === "noPr"` with `history`
+ * populated. This keeps Edit PR off merged/closed entries (editing a merged
+ * PR's title/body works but is almost never what the user wants) and lets the
+ * user create a new PR on the same branch with the previous one visible as
+ * history.
  *
  * Pre-refactor this function returned `PrInfo | undefined` and collapsed four
  * distinct outcomes into the same `undefined` value: real no-PR, auth/network
@@ -233,18 +251,33 @@ interface PrInfo {
  * to decide between the three real outcomes.
  */
 type PrLookup =
-	| { kind: "found"; pr: PrInfo }
-	| { kind: "noPr" }
+	| { kind: "found"; pr: PrInfo; history: ReadonlyArray<PrHistoryEntry> }
+	| { kind: "noPr"; history: ReadonlyArray<PrHistoryEntry> }
 	| { kind: "lookupError"; reason: string };
+
+/** Raw row shape returned by `gh pr list --json number,url,title,body,state`. */
+interface RawPrListRow {
+	readonly number: number;
+	readonly url: string;
+	readonly title: string;
+	readonly body: string;
+	readonly state: "OPEN" | "MERGED" | "CLOSED";
+}
 
 /**
  * Returns PR info for the given branch.
- * Uses `gh pr view -- <branch>` which works for open, merged, and closed PRs.
  *
- * The `--` end-of-options sentinel prevents option injection: even if `branch`
- * starts with `-` (e.g. `--repo owner/evil`), `gh` treats it as a positional
- * argument rather than a flag. This is a defense-in-depth measure since the
- * value originates from persisted JSON on the orphan branch.
+ * Uses `gh pr list --state all --head <branch>` so we get the active PR (if
+ * any) AND closed history in a single round-trip. The webview shows the active
+ * one front-and-center, history as a "Previously: #N (merged) · ..." strip.
+ *
+ * Why list instead of view: `gh pr view <branch>` only returns the most-recent
+ * PR regardless of state, so a force-pushed branch with PR1 merged + PR2 open
+ * showed only PR2; PR1 disappeared from the UI even though the user could
+ * still navigate to it on GitHub. List + state filtering is the right shape.
+ *
+ * `gh pr list` returns `[]` (success exit, empty JSON array) when no PRs match,
+ * so we no longer need the brittle stderr regex for "no pull requests found".
  */
 async function findPrForBranch(
 	cwd: string,
@@ -259,53 +292,100 @@ async function findPrForBranch(
 	const repoArgs = repoUrl ? ["--repo", repoUrl] : [];
 	const args = [
 		"pr",
-		"view",
-		"--json",
-		"number,url,title,body",
-		...repoArgs,
-		"--",
+		"list",
+		"--state",
+		"all",
+		"--head",
 		branch,
+		"--json",
+		"number,url,title,body,state",
+		...repoArgs,
 	];
 	const result = await tryExecGh(args, cwd);
 
 	if (!result.ok) {
 		const stderr = result.stderr ?? "";
-		// "no pull requests found" is the expected miss path — keep it at
-		// debug to avoid noise on every WebView open. Anything else (auth,
-		// rate limit, network, repo config, non-zero exits) is a real
-		// failure and deserves warn so it shows at default log level.
-		const isExpectedNoPr = /no pull requests? found/i.test(stderr);
-		if (isExpectedNoPr) {
-			log.debug(TAG, `No PR for branch ${branch}`);
-			return { kind: "noPr" };
-		}
 		const reason = stderr.trim() || result.err.message;
 		log.warn(
 			TAG,
-			`gh pr view failed for branch ${branch} (code=${result.code}): ${result.err.message}${
+			`gh pr list failed for branch ${branch} (code=${result.code}): ${result.err.message}${
 				stderr ? ` | stderr: ${stderr.trim()}` : ""
 			}`,
 		);
 		return { kind: "lookupError", reason };
 	}
 
+	let parsed: ReadonlyArray<RawPrListRow>;
 	try {
-		const parsed = JSON.parse(result.stdout) as PrInfo;
-		// `gh pr view --json number` returns `{"number": 0}` only in edge
-		// cases (e.g. the JSON shape changed in a future gh release).
-		// Treat as a real noPr — defense-in-depth, not a known reproducer.
-		return parsed.number ? { kind: "found", pr: parsed } : { kind: "noPr" };
+		const raw = JSON.parse(result.stdout) as unknown;
+		// Defense in depth: gh could conceivably change its return shape; we
+		// only proceed when we got the array we expect.
+		if (!Array.isArray(raw)) {
+			log.warn(
+				TAG,
+				`gh pr list returned non-array JSON for branch ${branch}. Raw length: ${result.stdout.length}`,
+			);
+			return {
+				kind: "lookupError",
+				reason: "Unexpected response shape from gh (expected array)",
+			};
+		}
+		parsed = raw as ReadonlyArray<RawPrListRow>;
 	} catch (err) {
-		const message = err instanceof Error ? err.message : String(err);
+		// JSON.parse only throws SyntaxError (an Error subclass), so we can
+		// type-assert here and avoid an `instanceof Error ? : String()` branch
+		// whose `String()` fallback would be unreachable.
+		const message = (err as Error).message;
 		log.warn(
 			TAG,
-			`gh pr view returned unparseable JSON for branch ${branch}: ${message}. Raw length: ${result.stdout.length}`,
+			`gh pr list returned unparseable JSON for branch ${branch}: ${message}. Raw length: ${result.stdout.length}`,
 		);
 		return {
 			kind: "lookupError",
 			reason: `Unparseable response from gh: ${message}`,
 		};
 	}
+
+	// Skip entries that look malformed — e.g. missing number (which `gh` has
+	// returned as 0 in edge cases) or missing state. We'd rather show fewer
+	// history pills than crash the section.
+	const valid = parsed.filter(
+		(p) => p.number > 0 && typeof p.state === "string",
+	);
+	// Open: GitHub allows at most one open PR per head branch; if more than
+	// one appears (gh/GitHub anomaly) pick the highest-numbered (most recent).
+	const openPrs = valid
+		.filter((p) => p.state === "OPEN")
+		.sort((a, b) => b.number - a.number);
+	const closedPrs = valid
+		.filter((p) => p.state === "MERGED" || p.state === "CLOSED")
+		.sort((a, b) => b.number - a.number);
+
+	const history: ReadonlyArray<PrHistoryEntry> = closedPrs.map((p) => ({
+		number: p.number,
+		url: p.url,
+		state: p.state as "MERGED" | "CLOSED",
+	}));
+
+	if (openPrs.length === 0) {
+		// `log.debug` only when the branch has zero PRs at all — a branch with
+		// closed/merged-only PRs still flows into kind:noPr (so Edit PR stays
+		// off), but it's not "no PR at all", so spamming the same debug line
+		// would be misleading.
+		if (valid.length === 0) {
+			log.debug(TAG, `No PR for branch ${branch}`);
+		}
+		return { kind: "noPr", history };
+	}
+
+	const openPr = openPrs[0];
+	const pr: PrInfo = {
+		number: openPr.number,
+		url: openPr.url,
+		title: openPr.title,
+		body: openPr.body,
+	};
+	return { kind: "found", pr, history };
 }
 
 // ─── Temp file helper ────────────────────────────────────────────────────────
@@ -438,15 +518,17 @@ export async function handleCheckPrStatus(
 				command: "prStatus",
 				status: "noPr",
 				branch: targetBranch,
+				history: lookup.history,
 			});
 			return;
 		}
 
-		const { pr } = lookup;
+		const { pr, history } = lookup;
 		postMessage({
 			command: "prStatus",
 			status: "ready",
 			pr: { number: pr.number, url: pr.url, title: pr.title },
+			history,
 		});
 	} catch (err: unknown) {
 		const msg = err instanceof Error ? err.message : String(err);
@@ -659,6 +741,7 @@ export function buildPrSectionHtml(): string {
   <p class="pr-status-text" id="prStatusText">Checking PR status...</p>
   <div class="pr-link-row pr-hidden" id="prLinkRow"></div>
   <div class="pr-actions pr-hidden" id="prActions"></div>
+  <div class="pr-history pr-hidden" id="prHistory"></div>
   <div class="pr-form pr-hidden" id="prForm">
     <label class="pr-form-label">Title</label>
     <input type="text" class="pr-form-input" id="prTitleInput" />
@@ -705,6 +788,38 @@ export function buildPrSectionCss(): string {
   }
   .pr-actions {
     margin: 8px 0 4px;
+  }
+  /* ── PR History (Previously: …) ── */
+  /*
+   * Inline pill row shown beneath the active PR's actions. GitHub's own
+   * merged-purple / closed-red are used so the colors are recognizable, but
+   * a textual "(merged)" / "(closed)" label is also rendered — colorblind /
+   * high-contrast theme users still read the state from the text.
+   */
+  .pr-history {
+    margin: 6px 0 4px;
+    font-size: 0.88em;
+    color: var(--vscode-descriptionForeground);
+    line-height: 1.5;
+  }
+  .pr-history-label {
+    margin-right: 4px;
+  }
+  .pr-history a {
+    text-decoration: none;
+  }
+  .pr-history a:hover {
+    text-decoration: underline;
+  }
+  .pr-history-merged {
+    color: #8957e5;
+  }
+  .pr-history-closed {
+    color: #cf222e;
+  }
+  .pr-history-sep {
+    margin: 0 6px;
+    color: var(--vscode-descriptionForeground);
   }
   /* ── PR Create Form ── */
   .pr-form {
@@ -758,6 +873,7 @@ export function buildPrSectionScript(): string {
   var prStatusText = document.getElementById('prStatusText');
   var prLinkRow = document.getElementById('prLinkRow');
   var prActions = document.getElementById('prActions');
+  var prHistory = document.getElementById('prHistory');
   var prForm = document.getElementById('prForm');
   var prTitleInput = document.getElementById('prTitleInput');
   var prBodyInput = document.getElementById('prBodyInput');
@@ -765,10 +881,48 @@ export function buildPrSectionScript(): string {
   var prFormSubmit = document.getElementById('prFormSubmit');
 
   var prCurrentState = 'loading';
+  // Cache the last 'Previously:' history so the form-cancel handler can
+  // restore the strip without re-running gh.
+  var prLastHistory = [];
 
   /** Toggle visibility via the pr-hidden CSS class (CSP blocks inline style attributes). */
   function prShow(el) { if (el) el.classList.remove('pr-hidden'); }
   function prHide(el) { if (el) el.classList.add('pr-hidden'); }
+
+  /**
+   * Renders the "Previously: #N (merged) · #M (closed) · ..." strip.
+   * Hides the row when history is empty. Each entry links to the PR URL;
+   * merged/closed are color-coded AND text-labeled so users in high-contrast
+   * themes still see the state without depending on color.
+   */
+  function renderPrHistory(history) {
+    prLastHistory = Array.isArray(history) ? history : [];
+    if (prLastHistory.length === 0) {
+      prHide(prHistory);
+      return;
+    }
+    prHistory.textContent = '';
+    var label = document.createElement('span');
+    label.className = 'pr-history-label';
+    label.textContent = 'Previously:';
+    prHistory.appendChild(label);
+    for (var i = 0; i < prLastHistory.length; i++) {
+      var h = prLastHistory[i];
+      if (i > 0) {
+        var sep = document.createElement('span');
+        sep.className = 'pr-history-sep';
+        sep.textContent = '·';
+        prHistory.appendChild(sep);
+      }
+      var link = document.createElement('a');
+      link.href = h.url;
+      link.title = 'Open PR in browser';
+      link.className = h.state === 'MERGED' ? 'pr-history-merged' : 'pr-history-closed';
+      link.textContent = '#' + h.number + ' (' + (h.state === 'MERGED' ? 'merged' : 'closed') + ')';
+      prHistory.appendChild(link);
+    }
+    prShow(prHistory);
+  }
 
   // Auto-check PR status on load
   vscode.postMessage({ command: 'checkPrStatus' });
@@ -789,6 +943,8 @@ export function buildPrSectionScript(): string {
         prShow(prStatusText);
         prHide(prLinkRow);
       }
+      // Restore the 'Previously:' strip from the cached last history.
+      renderPrHistory(prLastHistory);
     });
   }
   if (prFormSubmit) {
@@ -820,6 +976,7 @@ export function buildPrMessageScript(): string {
         prShow(prStatusText);
         prHide(prLinkRow);
         prHide(prActions);
+        prHide(prHistory);
       } else if (s === 'notAuthenticated') {
         prStatusText.textContent = 'GitHub CLI (gh) is not authenticated. Run "gh auth login" in a terminal, then retry.';
         prShow(prStatusText);
@@ -834,6 +991,7 @@ export function buildPrMessageScript(): string {
         });
         prActions.appendChild(retryAuthBtn);
         prShow(prActions);
+        prHide(prHistory);
       } else if (s === 'unavailable') {
         prStatusText.textContent = msg.reason
           ? ('Could not load PR status — ' + msg.reason + '. Retry, or check the extension log.')
@@ -850,6 +1008,7 @@ export function buildPrMessageScript(): string {
         });
         prActions.appendChild(retryBtn);
         prShow(prActions);
+        prHide(prHistory);
       } else if (s === 'noPr') {
         prHide(prLinkRow);
         prStatusText.textContent = 'No pull request found for branch ' + msg.branch + '.';
@@ -868,6 +1027,7 @@ export function buildPrMessageScript(): string {
           btn.textContent = 'Loading...';
           vscode.postMessage({ command: 'prepareCreatePr' });
         });
+        renderPrHistory(msg.history);
       } else if (s === 'ready') {
         var pr = msg.pr;
         prHide(prStatusText);
@@ -893,6 +1053,7 @@ export function buildPrMessageScript(): string {
           editBtn.disabled = true;
           vscode.postMessage({ command: 'prepareUpdatePr' });
         });
+        renderPrHistory(msg.history);
       }
     }
 
@@ -903,6 +1064,7 @@ export function buildPrMessageScript(): string {
       var createBtn = document.getElementById('createPrBtn');
       if (createBtn) { createBtn.textContent = 'Create PR'; createBtn.disabled = false; }
       prHide(prActions);
+      prHide(prHistory);
       prShow(prForm);
       prForm.dataset.mode = 'create';
       prFormSubmit.textContent = 'Submit PR';
@@ -918,6 +1080,7 @@ export function buildPrMessageScript(): string {
       prHide(prStatusText);
       prHide(prLinkRow);
       prHide(prActions);
+      prHide(prHistory);
       prShow(prForm);
       prForm.dataset.mode = 'update';
       prFormSubmit.textContent = 'Update PR';

--- a/vscode/src/views/BindingChooserWebviewPanel.ts
+++ b/vscode/src/views/BindingChooserWebviewPanel.ts
@@ -9,7 +9,7 @@
  *
  * The plugin deliberately does NOT create spaces or offer move / delete /
  * rename / "view all bindings" affordances; everything beyond first-bind
- * happens on jolli.ai's web frontend (server plan §6).
+ * happens on jolli.ai's web frontend.
  */
 
 import { randomBytes } from "node:crypto";

--- a/vscode/src/views/SummaryUtils.ts
+++ b/vscode/src/views/SummaryUtils.ts
@@ -88,7 +88,7 @@ export function formatProviderLabel(
 	return `mixed: ${sources.map((s) => PROVIDER_LABELS[s]).join(", ")}`;
 }
 
-// ─── Push contract: relativePath construction (server plan §8) ───────────────
+// ─── Push contract: relativePath construction ───────────────────────────────
 
 /**
  * Returns the `relativePath` for any push: `<branchSlug>`. Summary, plan, and

--- a/vscode/src/views/SummaryWebviewPanel.test.ts
+++ b/vscode/src/views/SummaryWebviewPanel.test.ts
@@ -6931,6 +6931,43 @@ describe("SummaryWebviewPanel", () => {
 			);
 		});
 
+		it("also intercepts prepareUpdatePr and updatePr — neither must reach PrCommentService on a foreign panel", async () => {
+			// Regression guard: PrCommentService.handlePrepareUpdatePr /
+			// handleUpdatePr do NOT carry the foreign repoUrl plumbing that
+			// handleCheckPrStatus does, so if either ever leaked past the
+			// allowlist it would silently target a same-named branch PR in
+			// the CURRENT workspace's repo instead of the foreign repo's PR.
+			// Pin them into the deny list at the dispatcher layer so a
+			// future allowlist edit can't accidentally regress this.
+			const summary = makeSummary();
+			await SummaryWebviewPanel.show(
+				summary,
+				extensionUri,
+				workspaceRoot,
+				stubBridge,
+				mainBranch,
+				"memory",
+				"other-repo",
+			);
+			const dispatch = captureMessageHandler();
+
+			dispatch({ command: "prepareUpdatePr" });
+			dispatch({
+				command: "updatePr",
+				title: "x",
+				body: "y",
+			});
+			await flushPromises();
+
+			expect(showInformationMessage).toHaveBeenCalledTimes(2);
+			expect(showInformationMessage).toHaveBeenCalledWith(
+				expect.stringMatching(/from other-repo.*prepareUpdatePr.*disabled/i),
+			);
+			expect(showInformationMessage).toHaveBeenCalledWith(
+				expect.stringMatching(/from other-repo.*updatePr.*disabled/i),
+			);
+		});
+
 		it("still allows the read-only whitelist (copyMarkdown, downloadMarkdown) on a foreign panel", async () => {
 			const summary = makeSummary();
 			await SummaryWebviewPanel.show(


### PR DESCRIPTION
<!-- jollimemory-summary-start -->
## Commits in this PR (3)

1. Add --arg-stdin flag and here-doc bridge for multi-agent skill support (`fa98a6c`)
2. Switch PR lookup from gh pr view to gh pr list with history (`9e43cf5`)
3. Tighten --arg-stdin guards and PR-history rendering defenses (`878916c`)

## Quick recap (3)

### Commit 1 of 3: Add --arg-stdin flag and here-doc bridge for multi-agent skill support (`fa98a6c`)

The search and recall commands can now receive user queries through standard input rather than as command-line arguments. Skill templates pipe queries through this channel using a randomly generated delimiter, so special characters in a query never reach a shell parser. Passing a query both ways at once produces an immediate, clearly worded error, keeping the injection-defense contract strict and visible.

Every generated skill file now ships a single Bash here-document invocation block with an explicit shell-prerequisite directive that names Git Bash as the required shell on Windows and lists the WSL Bash launchers that must be avoided. This closes the failure mode where agents in Cursor defaulted to WSL Bash and could not locate the entry script. A PowerShell-native here-string companion block is deferred to a follow-up PR.

Two reliability bugs on Windows were also corrected. The recall command previously exited with a success code when it encountered an error and the caller had requested structured output, making failures invisible to shell pipelines and CI scripts; the exit code is now set unconditionally on any error path. Separately, the function that locates the Git exclude file could misidentify a Unix-style path returned by Git as a relative path, writing the managed block to the wrong location; the detection logic now explicitly checks for both Windows-style and POSIX-style absolute paths on every platform, including Linux CI runners where the original fix had introduced a new failure.

### Commit 2 of 3: Switch PR lookup from gh pr view to gh pr list with history (`9e43cf5`)

The pull request lookup in the VS Code extension was redesigned and then simplified, arriving at a single-query implementation that retrieves all pull requests for a branch in one network call. An intermediate design had introduced a two-phase approach — querying for open pull requests first and falling back to a broader query only when none were found — along with a "Previously:" strip in the panel that surfaced the most recent merged or closed pull request for long-lived branches. A cherry-pick conflict left two incompatible implementations merged together, and the team chose to restore the simpler, working version in full rather than reconcile the two approaches line by line.

The final state is a leaner lookup function that accepts an optional repository address for cross-repository browsing. The "Previously:" history strip, the state guards that blocked editing already-merged pull requests, and the panel repaints triggered by unexpected state changes were all removed as part of the restoration. One known gap remains: pull requests originating from forked repositories are not currently filtered from appearing as the active pull request, and that guard will need to be reintroduced in a follow-up change.

### Commit 3 of 3: Tighten --arg-stdin guards and PR-history rendering defenses (`878916c`)

The command-line tool's stdin flag now fails fast with a clear error message when a user runs it in a normal terminal window without piping any input. Previously the process would hang indefinitely with no feedback; now it exits immediately and tells the user exactly how to supply input correctly. A 64 KiB payload cap was added at the same time: any upstream process feeding an unreasonably large amount of data is rejected before the tool allocates memory for it, closing a potential resource exhaustion path.

The pull request history panel in the editor sidebar received two independent safety improvements. Links in the history strip are now validated before being assigned as destinations — any entry that does not carry a standard web address is silently dropped, and the visual separator between entries adjusts automatically so no stray bullet appears in its place. Separately, when GitHub's tooling returns more than one open pull request for the same branch (an anomaly the platform normally prevents), the tool now logs a warning identifying both the pull request it kept and the ones it set aside, making the situation recoverable from logs rather than invisible.

## Topics (12)
<details>
<summary><strong>01 · [fa98a6c] Cross-platform absolute path detection fixed for Git Bash and Linux CI</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

On Windows machines using Git Bash, the command that locates the Git exclude file could return a path in Unix style, which Windows path utilities do not recognize as absolute, causing the managed block to be written to the wrong file. A subsequent fix introduced a new bug: the detection logic used the operating system's default resolver, which behaves differently on Linux and Windows, causing tests to break on Linux CI runners even though the fix worked correctly on Windows.

**💡 Decisions Behind the Code**

- **Explicit namespace imports over platform default**: Using the platform-default path resolver meant the function's behavior changed depending on where the code ran, not on what data it received. The path format emitted by git depends on git's own configuration, not on the host OS, so the detection logic must handle both Windows-style and POSIX-style absolute paths regardless of platform. Calling both `win32` and `posix` namespaces explicitly makes the function a pure, deterministic helper that behaves identically on every platform.
- **Extract a pure helper rather than patching the inline condition**: The original single-line condition was not independently testable because the surrounding function shells out to Git. Extracting the normalization into a pure function made it straightforward to cover all three path forms with unit tests and gave the fix a clear, named home that documents the Git Bash edge case for future readers.
- **Accept either absolute form rather than normalizing to one**: Converting the POSIX-style path to a Windows path before the check would have worked but introduced a transformation step that could silently mangle unusual paths. Accepting either absolute form and returning it unchanged keeps the function's contract simple: it only decides whether to join, never rewrites the path itself.
- **Minimal targeted fix over broader refactor**: The bug was isolated to a single expression in one helper function. Expanding the fix to restructure how path resolution works across the codebase would have introduced unnecessary risk close to a merge. The narrowest possible change — swapping one import and one boolean expression — was chosen to keep the blast radius small and the fix easy to verify.

**✅ What Was Implemented**

- Extracted a new exported pure function `normalizeGitPathOutput` in `GitExclude.ts` that checks both Windows-style and POSIX-style absolute path forms before deciding whether to join the path under the project directory. The existing path-resolution function now delegates to this helper.
- Updated `normalizeGitPathOutput` to replace the platform-default `isAbsolute` import with explicit calls to both `win32Path.isAbsolute` and `posixPath.isAbsolute`, making the detection logic platform-agnostic and correct on both Linux CI and Windows developer machines.
- Updated the import line to remove the default `isAbsolute` and add `win32 as win32Path` alongside the existing `posix as posixPath`.
- Added three focused unit tests in `GitExclude.test.ts` covering the Windows-native path, the Git Bash POSIX-style path, and the relative path cases independently, without requiring a real Git repository.
- Fixed two pre-existing lint warnings in `GitExclude.ts` by replacing `findIndex` with `indexOf` for simple string equality searches.

**📁 FILES**
- `cli/src/install/GitExclude.ts`

</blockquote>
</details>
<details>
<summary><strong>02 · [fa98a6c] Stdin argument bridge added to search and recall commands for injection-safe invocation</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Skill templates pipe user input to the CLI via a here-document with a randomly generated delimiter so that shell metacharacters in the query never reach a shell parser. The CLI had no way to receive input through this channel; it only accepted arguments through argv, which the here-document bridge was specifically designed to bypass.

**💡 Decisions Behind the Code**

- **Stdin over a temporary file**: Receiving the argument through stdin rather than writing it to a temporary file and passing the path is self-contained — no cleanup is needed, no file path can be manipulated by a concurrent process, and the here-document delimiter already provides the boundary. A temp-file approach would have required unique naming, post-read deletion, and additional flag surface.
- **Single trailing newline trim, not full whitespace strip**: The utility trims exactly one trailing newline rather than stripping all trailing whitespace, because a here-document appends exactly one newline before the terminator. Stripping all whitespace would silently alter queries that intentionally end with a blank line, which could matter for multi-line search inputs in the future.
- **Hard mutual exclusion over silent precedence**: Allowing both stdin and positional arguments simultaneously would silently drop one source depending on which branch ran first, undermining the injection-defense contract the flag exists to provide. Hard rejection with a clear error message was chosen to make misuse immediately visible.

**✅ What Was Implemented**

- Added a shared stdin-reading utility in `CliUtils.ts` that reads all chunks from the process stdin stream to EOF, concatenates them as UTF-8, and trims exactly one trailing newline or CRLF (which a here-document always appends), returning an empty string on empty input.
- Added an `--arg-stdin` flag to both the search and recall commands. When the flag is present, the command reads its primary argument from stdin via the utility instead of from positional argv words.
- Enforced mutual exclusion between the new flag and positional arguments; violating this produces a structured error in both JSON and plain-text output modes with a non-zero exit code.

**📁 FILES**
- `cli/src/commands/CliUtils.ts`
- `cli/src/commands/SearchCommand.ts`
- `cli/src/commands/RecallCommand.ts`

</blockquote>
</details>
<details>
<summary><strong>03 · [fa98a6c] Skill template pins Bash on Windows via Git Bash; PowerShell-native path deferred to follow-up</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

AI coding agents running in different environments on Windows were failing to invoke the CLI correctly. Agents in Cursor spawned WSL Bash by default, whose home directory does not contain the installer's entry script. PowerShell-native agents likewise needed an explicit shell to point at, so the template now routes both cases through Git Bash; a PowerShell-native here-string invocation path is deferred to a separate follow-up PR.

**💡 Decisions Behind the Code**

- **Single Bash block plus an explicit Git Bash directive on Windows**: A PowerShell here-string companion block was considered but deferred to a follow-up PR — the immediate failure mode in testing was Cursor agents defaulting to WSL Bash whose home directory does not contain the installer entry script, which the Git Bash directive resolves on its own. The template therefore ships one Bash here-document block and pins the shell choice on Windows in plain language, eliminating the wrong-shell invocations seen in testing without taking on an untested PowerShell execution path mid-PR.
- **Declarative instruction over runtime shell-detection code**: Rather than embedding detection logic the agent would execute at runtime, the template uses plain-language directives telling the agent which shell to use. Agents were observed following explicit instructions reliably without programmatic detection, and detection code would have made the template longer and harder to maintain without improving reliability.
- **Git Bash as the single Bash target on Windows**: Alternatives evaluated included a PowerShell here-string-only path, a Windows batch companion script, and WSL path translation at runtime. All required the agent to detect its environment correctly — the original failure mode — or introduced untested execution paths. Git Bash shares the same home directory view as the Windows installer and is present on any Windows machine running a git-based IDE. A WSL path-translation prototype was abandoned when it was confirmed that WSL Bash on the test machine had no Node.js installed, making the final execution step impossible regardless of path resolution.

**✅ What Was Implemented**

- Updated the skill installer to emit a single Bash here-document invocation template in every generated skill file. The block carries an explicit shell-prerequisite directive that names Git Bash as the required shell on Windows and lists the WSL Bash launchers that must be avoided. A PowerShell-native here-string companion block is deferred to a follow-up PR.
- The Bash block includes an explicit prerequisite directive naming Git Bash as the required shell on Windows, listing the two WSL Bash launchers that must be avoided, providing a stop-and-tell message directing users to install Git for Windows if Git Bash is absent, and enumerating forbidden fallback substitutions including npm run, npx, direct node invocation, PowerShell-native commands, WSL Bash, and workspace-local scripts.

**📁 FILES**
- `cli/src/install/SkillInstaller.ts`

</blockquote>
</details>
<details>
<summary><strong>04 · [fa98a6c] Recall command now exits with a non-zero code on all error paths</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

When the recall command encountered an unexpected error and the caller had requested structured output, the process exited with a success code, making failures invisible to shell pipelines and automated scripts.

**💡 Decisions Behind the Code**

The search command's error handler already carried an explicit comment stating that a non-zero exit code must be set regardless of output format, and the recall command was supposed to follow the same contract. The exit code being inside the plain-text branch was an oversight rather than a deliberate choice, so no alternative approach was considered.

**✅ What Was Implemented**

- Moved the non-zero exit code assignment outside the output-format conditional in `RecallCommand.ts` so it applies unconditionally on any caught error, matching the contract already documented and enforced in the search command.
- Fixed a related pre-existing bug where the invalid-characters error path also set the exit code only inside the JSON branch; that assignment was likewise moved outside the format conditional.
- Added test assertions in `Cli.test.ts` covering both the JSON and plain-text error paths to lock this behavior.

**📁 FILES**
- `cli/src/commands/RecallCommand.ts`

</blockquote>
</details>
<details>
<summary><strong>05 · [fa98a6c] Recall tip wording made cross-platform to cover agents beyond Claude Code</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The session-start briefing and the recall command's short-output footer named only the Claude Code slash command syntax, leaving users of Cursor, Codex, Windsurf, and other agent hosts without a meaningful hint about how to invoke the same capability.

**💡 Decisions Behind the Code**

The tip was rewritten to describe the skill by name and include the Claude Code invocation in parentheses rather than replacing it entirely. This preserves discoverability for Claude Code users while signaling to users of other platforms that the same capability exists under their own invocation syntax.

**✅ What Was Implemented**

Updated the tip text in `SessionStartHook.ts` and the recall command's short-output renderer in `RecallCommand.ts` to use platform-neutral phrasing that names the skill generically and cites the Claude Code slash command as one example rather than the only form. Two test assertions that matched the old Claude-Code-specific string were updated to match the new phrasing.

**📁 FILES**
- `cli/src/hooks/SessionStartHook.ts`
- `cli/src/commands/RecallCommand.ts`

</blockquote>
</details>
<details>
<summary><strong>06 · [9e43cf5] PR lookup simplified to single query with optional cross-repository support</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Users working on long-lived branches that had gone through multiple merge cycles saw no trace of previously merged or closed pull requests, and the existing lookup risked surfacing an edit action on an already-merged pull request.

**💡 Decisions Behind the Code**

- **Single query over two-query fallback, then simplified further**: The initial redesign replaced two sequential network calls with one `--state all` query, eliminating double-failure logging and completing the result in one round-trip. A subsequent conflict-resolution step then discarded the richer history-array shape entirely in favor of a simpler single-result implementation, accepting the loss of the multi-PR history feature to restore a working, unambiguous codebase. The added complexity of the two-phase model was judged not worth carrying forward once the conflict made reconciliation costly.
- **Whole-file override over patch-level merge**: When a cherry-pick produced a file combining code from both divergent implementations, the team discarded the entire patched result and restored the target commit's file verbatim. Applying conflict resolution only to flagged hunks left non-conflicting new code from the other branch in place, causing test failures; replacing the whole file eliminated the ambiguity cleanly and at lower risk than line-by-line reconciliation.
- **Dropping state-aware PR history rather than reconciling**: The "Previously:" strip, state guards on edit and update, and panel repaints were all removed rather than ported forward. These features depended on a two-phase query design that conflicted with the simpler single-query approach being restored, and reconciling them would have required re-implementing the full feature set against the new interface; that work was deferred to a follow-up.
- **Cross-repository PR filtering deferred**: The guard that prevented pull requests from forked repositories from appearing as the active pull request was present in the intermediate implementation but was not carried forward during conflict resolution. Restoring a working baseline was prioritised over preserving every guard, with the fork-filtering gap accepted as a known follow-up item.

**✅ What Was Implemented**

- `PrCommentService.ts` went through two phases of redesign, arriving at a single `findPrForBranch` function that issues one `--state all` query per lookup. The `state` and `isCrossRepository` fields were removed from the `PrInfo` interface. An optional `repoUrl` parameter was added to support cross-repository browsing via the `--repo` flag.
- An intermediate two-phase design (open-state query first, all-states fallback only when no open PR was found) and its associated `PrHistoryEntry` type, `PrLookup` discriminated union, and `previousPr` field were introduced and then removed when a cherry-pick conflict left two incompatible implementations merged together. The team restored the simpler single-query implementation in full.
- State-guard blocks in the update handlers that rejected MERGED/CLOSED pull requests and triggered panel repaints were removed entirely, along with the "Previously:" strip in the webview and its associated cancel-handler link-row visibility logic.
- `PrCommentService.test.ts` was rewritten twice: first to cover the two-phase contract (helpers for list-by-state routing, call counting, and focused cases for open-hit, merged-only fallback, closed-only fallback, unrecognised state, cross-repository filtering, and non-Error rejection wrapping), then collapsed back to a passing suite against the simplified single-query implementation, with the two-phase helpers and their associated test suites deleted.

**📋 Future Enhancements**

Cross-repository (fork) PR filtering — the guard that prevented pull requests from forked repositories from appearing as the active pull request was not carried forward during conflict resolution and needs to be reintroduced separately.

**📁 FILES**
- `vscode/src/services/PrCommentService.ts`

</blockquote>
</details>
<details>
<summary><strong>07 · [9e43cf5] Add missing sign-off trailer to commit for CI compliance</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

An automatically triggered commit was missing the required developer sign-off, which would cause the continuous integration pipeline to reject the change.

**💡 Decisions Behind the Code**

Amending the existing commit rather than adding a separate fix-up commit kept the branch history clean and ensured every commit individually satisfies the sign-off requirement. A separate corrective commit would have technically passed CI but left a commit in the history that violated the project's rule that each commit must carry its own sign-off.

**✅ What Was Implemented**

Amended the most recent commit to append the missing sign-off trailer, then force-pushed the branch to remote with the lease guard to sync the corrected history.

</blockquote>
</details>
<details>
<summary><strong>08 · [9e43cf5] Rebase feature branch onto latest remote main before push</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The developer wanted to incorporate the latest changes from the main branch into the current feature branch before pushing.

**💡 Decisions Behind the Code**

Force-pushing with the lease guard rather than a plain push was chosen to safely overwrite the remote branch's now-diverged history after rebase, while the lease ensures the push is rejected if someone else has pushed to the same branch in the meantime. A regular pull was explicitly ruled out because it would create a merge commit and undo the rebase.

**✅ What Was Implemented**

Fetched the latest remote main and rebased the feature branch on top of it cleanly with no conflicts. A force push with the lease guard was identified as required afterward to sync the rebased branch to the remote.

</blockquote>
</details>
<details>
<summary><strong>09 · [878916c] Prevent command from hanging forever when run without piped input</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Users who accidentally ran the recall or search command with the stdin flag in a normal terminal window would see the process hang indefinitely with no prompt, no error, and no way to know what was wrong short of killing it manually.

**💡 Decisions Behind the Code**

- **Reject at the TTY boundary, not at a timeout:** A timeout-based approach would still leave the user waiting and would require choosing an arbitrary delay. Rejecting the moment an interactive terminal is detected gives instant feedback with a message that explains exactly what to do instead, at zero cost to legitimate piped callers.
- **Cap at 64 KiB rather than streaming without limit:** The flag is only ever used to carry a branch name or short keyword query piped from a skill template. Allowing unbounded input would let a compromised or buggy upstream exhaust the process's memory. 64 KiB is far above any realistic input while still being small enough to make the attack surface negligible. The cap is enforced incrementally per chunk so the process never allocates the full oversized buffer before rejecting.

**✅ What Was Implemented**

- `readStdin()` in `cli/src/commands/CliUtils.ts` now checks whether stdin is an interactive terminal at the very start and immediately rejects with a clear error message directing the user to pipe input via a here-doc or echo. The check runs before any stream listeners are attached, so the process exits in milliseconds rather than waiting forever for an EOF that will never arrive.
- A 64 KiB hard cap was added to the same function: each incoming chunk's byte count is accumulated, and if the running total exceeds the limit the promise rejects immediately and subsequent chunks are ignored via a `rejected` guard flag. The constant is exported as `STDIN_MAX_BYTES` so tests can reference the exact boundary. Four new tests in `cli/src/commands/CliUtils.test.ts` cover the TTY rejection, the over-limit case, the exact-boundary case, and the late-chunk-after-rejection case.

**📁 FILES**
- `cli/src/commands/CliUtils.ts`

</blockquote>
</details>
<details>
<summary><strong>10 · [878916c] Surface a warning when GitHub returns multiple open pull requests for one branch</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The code silently discarded any extra open pull requests beyond the first when GitHub returned more than one for the same branch — a rare but real anomaly. The pull request description had promised these would be surfaced so nothing disappeared quietly, but neither the implementation nor the tests enforced that promise.

**💡 Decisions Behind the Code**

- **Log the anomaly rather than encoding it into the history strip:** Downgrading extra open PRs into the history panel would require the history entry type to accept "open" as a valid state, which would make an exceptional and transient condition part of the permanent data shape. Logging instead keeps the type surface clean and still makes the dropped IDs recoverable from the debug log when the anomaly occurs.

**✅ What Was Implemented**

- In `vscode/src/services/PrCommentService.ts`, a `log.warn` call was added after the open-PR sort: when more than one open PR is found, the kept PR number and all dropped PR numbers are logged to the debug log. A detailed code comment explains that this path is expected to be unreachable in normal operation (GitHub enforces at most one open PR per branch) and documents the deliberate decision not to widen the history entry type to accommodate the anomaly.
- In `vscode/src/services/PrCommentService.test.ts`, the existing multi-open test was extended with assertions that verify the warning fires and that both the kept and dropped PR numbers appear in the logged output.

**📁 FILES**
- `vscode/src/services/PrCommentService.ts`

</blockquote>
</details>
<details>
<summary><strong>11 · [878916c] Block non-secure links from appearing in the pull request history panel</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The pull request history panel assigned link destinations directly from data returned by the GitHub command-line tool without any validation. A malformed or compromised response could have injected a non-web link into the panel.

**💡 Decisions Behind the Code**

The guard was implemented as a simple prefix string check rather than a full URL parser. The only URLs expected here are GitHub pull request URLs, which are always `https://` links. A prefix check is sufficient to block the meaningful attack vectors (javascript: and data: schemes) and adds no dependencies or complexity.

**✅ What Was Implemented**

- In `vscode/src/services/PrCommentService.ts`, the history rendering loop now checks each entry's URL before assigning it: any entry whose URL does not begin with `https://` is skipped entirely. The separator bullet between entries is emitted based on a `renderedCount` counter rather than the loop index, so a skipped entry never leaves a stranded separator in the panel.
- A new test in `vscode/src/services/PrCommentService.test.ts` pins the literal guard substring in the generated JavaScript string, so a future refactor that loosens or removes the check fails the test rather than silently regressing the protection.

**📁 FILES**
- `vscode/src/services/PrCommentService.ts`

</blockquote>
</details>
<details>
<summary><strong>12 · [878916c] Pin that the Edit PR button never appears on branches with only closed pull requests</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The pull request description promised that branches with no open pull request would show a Create PR button rather than an Edit PR button, but no test enforced this. A future refactor could accidentally hoist the Edit PR button into the wrong branch of the rendering logic and all existing tests would still pass.

**💡 Decisions Behind the Code**

The test operates on the generated JavaScript string rather than on rendered DOM output. This approach requires no browser environment or webview harness and runs in the same unit test suite as the rest of the service, keeping the feedback loop fast while still locking down the structural guarantee the PR description made.

**✅ What Was Implemented**

A new test in `vscode/src/services/PrCommentService.test.ts` locates the "no PR" and "ready" rendering branches within the generated JavaScript string, extracts the "no PR" block, and asserts that the Edit PR identifier is absent from it while the Create PR identifier is present. The test is structured so that any future change moving Edit PR into the wrong branch will fail immediately.

**📁 FILES**
- `vscode/src/services/PrCommentService.ts`

</blockquote>
</details>

---

*Generated by Jolli Memory · May 15, 2026 at 1:35 PM*
<!-- jollimemory-summary-end -->
