### PR TITLE
Implement head-only memory display with cross-repo guards

### DIFF
--- a/cli/src/Types.ts
+++ b/cli/src/Types.ts
@@ -111,6 +111,19 @@ export interface GitOperation {
 	readonly type: "commit" | "amend" | "squash" | "rebase-pick" | "rebase-squash" | "cherry-pick" | "revert";
 	/** Target commit hash */
 	readonly commitHash: string;
+	/**
+	 * Branch the operation landed on, captured at enqueue time.
+	 *
+	 * Required so the worker's tail cleanup (cleanupBranchStaleChildMarkdown)
+	 * targets the right `<branch>/` directory even if the user has `git
+	 * checkout`'d away between enqueue and drain. Reading the live branch
+	 * from the worker would clean the wrong tree.
+	 *
+	 * Optional in the type only to tolerate stale on-disk queue entries
+	 * written by pre-0.99.x code; the worker skips cleanup when missing
+	 * rather than guessing the live branch.
+	 */
+	readonly branch?: string;
 	/** Source hashes: amend's oldHash, squash/rebase's source commit hashes */
 	readonly sourceHashes?: ReadonlyArray<string>;
 	/** Whether the operation was triggered from the VSCode plugin or CLI */

--- a/cli/src/commands/ViewCommand.ts
+++ b/cli/src/commands/ViewCommand.ts
@@ -47,6 +47,12 @@ function truncate(str: string, maxLen: number): string {
 
 /**
  * Filters root entries from the index and returns them sorted newest-first.
+ *
+ * Intentionally root-only (not leaf): aligned with `jolli search` and
+ * `SessionStartHook`. The 2026-05-12 leaf-only-memory-display redesign
+ * switched the VS Code display surfaces (Timeline, Memory Bank tree,
+ * Branch tab) to leaves; the CLI surfaces stay on root semantics until
+ * a follow-up explicitly verifies their tests + UX under the leaf model.
  */
 function getRootEntries(entries: ReadonlyArray<SummaryIndexEntry>): Array<SummaryIndexEntry> {
 	return entries

--- a/cli/src/core/ContextCompiler.ts
+++ b/cli/src/core/ContextCompiler.ts
@@ -9,6 +9,7 @@
 
 import { createLogger } from "../Logger.js";
 import type { CommitSummary, SummaryIndexEntry } from "../Types.js";
+import { filterToBranchHeads } from "./HeadEntryFilter.js";
 import { extractBaseSlug } from "./PlanSlug.js";
 import type { SearchHit } from "./Search.js";
 import { collectAllNotesWithHosts, collectAllPlansWithHosts, getDisplayDate } from "./SummaryFormat.js";
@@ -166,10 +167,15 @@ export async function listBranchCatalog(cwd?: string): Promise<BranchCatalog> {
 		return { type: "catalog", branches: [] };
 	}
 
-	const rootEntries = index.entries.filter((e) => e.parentCommitHash === null || e.parentCommitHash === undefined);
+	// One entry per (branch, live-tip-version) via v4 Hoist heads (parent==null —
+	// see HeadEntryFilter for the invariant). Earlier amend/squash versions live
+	// on as children and are intentionally excluded: the branch catalog anchors
+	// LLM context on what `git log` currently shows, not on every historical
+	// version that has been superseded.
+	const headEntries = filterToBranchHeads(index.entries);
 
 	const branchMap = new Map<string, SummaryIndexEntry[]>();
-	for (const entry of rootEntries) {
+	for (const entry of headEntries) {
 		const list = branchMap.get(entry.branch);
 		if (list) {
 			list.push(entry);
@@ -310,29 +316,31 @@ export async function compileTaskContext(options: ContextOptions, cwd?: string):
 		return emptyContext(branch);
 	}
 
-	// Step 1: Filter root entries for this branch
-	let rootEntries = index.entries.filter(
-		(e) => e.branch === branch && (e.parentCommitHash === null || e.parentCommitHash === undefined),
-	);
+	// Step 1: Filter to v4 Hoist heads (parent==null — see HeadEntryFilter) on
+	// the requested branch. Heads are the live tips of commit history — what
+	// `git log` currently shows — and serve as the narrative anchors for LLM
+	// context. Superseded versions live as children and are excluded so the
+	// model isn't fed multiple variants of the same logical commit.
+	let headEntries = filterToBranchHeads(index.entries.filter((e) => e.branch === branch));
 
 	// Step 2: Sort by activity date (oldest first for narrative).
 	// Uses getDisplayDate so amended old commits surface as recent activity.
-	rootEntries = [...rootEntries].sort(
+	headEntries = [...headEntries].sort(
 		(a, b) => new Date(getDisplayDate(a)).getTime() - new Date(getDisplayDate(b)).getTime(),
 	);
 
 	// Step 3: Apply depth limit
-	if (depth !== undefined && depth > 0 && rootEntries.length > depth) {
-		rootEntries = rootEntries.slice(-depth);
+	if (depth !== undefined && depth > 0 && headEntries.length > depth) {
+		headEntries = headEntries.slice(-depth);
 	}
 
-	if (rootEntries.length === 0) {
+	if (headEntries.length === 0) {
 		return emptyContext(branch);
 	}
 
 	// Step 4: Load full summaries
 	const summaries: CommitSummary[] = [];
-	for (const entry of rootEntries) {
+	for (const entry of headEntries) {
 		const summary = await getSummary(entry.commitHash, cwd);
 		if (summary) {
 			summaries.push(summary);

--- a/cli/src/core/DualWriteStorage.test.ts
+++ b/cli/src/core/DualWriteStorage.test.ts
@@ -287,4 +287,173 @@ describe("DualWriteStorage", () => {
 		const dual = new DualWriteStorage(primary, shadow);
 		await expect(dual.writeFiles([{ path: "ok.txt", content: "data" }], "write")).resolves.toBeUndefined();
 	});
+
+	describe("deleteVisibleMarkdown delegation", () => {
+		it("delegates to the folder-side provider", async () => {
+			const folderDelete = vi.fn().mockResolvedValue(undefined);
+			const orphan = {
+				readFile: vi.fn(),
+				writeFiles: vi.fn(),
+				listFiles: vi.fn(),
+				exists: vi.fn().mockResolvedValue(true),
+				ensure: vi.fn(),
+			} as unknown as StorageProvider;
+			const folder = {
+				readFile: vi.fn(),
+				writeFiles: vi.fn(),
+				listFiles: vi.fn(),
+				exists: vi.fn().mockResolvedValue(true),
+				ensure: vi.fn(),
+				deleteVisibleMarkdown: folderDelete,
+			} as unknown as StorageProvider;
+			const dual = new DualWriteStorage(orphan, folder);
+			const entry = {
+				commitHash: "deadbeef",
+				parentCommitHash: null,
+				commitMessage: "Add login",
+				commitDate: "2026-05-12T00:00:00Z",
+				branch: "main",
+				generatedAt: "2026-05-12T00:00:00Z",
+			};
+			await dual.deleteVisibleMarkdown(entry);
+			expect(folderDelete).toHaveBeenCalledWith(entry);
+		});
+
+		it("is a no-op when the folder side lacks the method", async () => {
+			const orphan = {
+				readFile: vi.fn(),
+				writeFiles: vi.fn(),
+				listFiles: vi.fn(),
+				exists: vi.fn().mockResolvedValue(true),
+				ensure: vi.fn(),
+			} as unknown as StorageProvider;
+			const folder = {
+				readFile: vi.fn(),
+				writeFiles: vi.fn(),
+				listFiles: vi.fn(),
+				exists: vi.fn().mockResolvedValue(true),
+				ensure: vi.fn(),
+			} as unknown as StorageProvider;
+			const dual = new DualWriteStorage(orphan, folder);
+			await expect(
+				dual.deleteVisibleMarkdown({
+					commitHash: "deadbeef",
+					parentCommitHash: null,
+					commitMessage: "x",
+					commitDate: "2026-05-12T00:00:00Z",
+					branch: "main",
+					generatedAt: "2026-05-12T00:00:00Z",
+				}),
+			).resolves.toBeUndefined();
+		});
+
+		it("marks dirty when the folder side throws", async () => {
+			const folderDelete = vi.fn().mockRejectedValue(new Error("disk gone"));
+			const markDirty = vi.fn();
+			const orphan = {
+				readFile: vi.fn(),
+				writeFiles: vi.fn(),
+				listFiles: vi.fn(),
+				exists: vi.fn().mockResolvedValue(true),
+				ensure: vi.fn(),
+			} as unknown as StorageProvider;
+			const folder = {
+				readFile: vi.fn(),
+				writeFiles: vi.fn(),
+				listFiles: vi.fn(),
+				exists: vi.fn().mockResolvedValue(true),
+				ensure: vi.fn(),
+				deleteVisibleMarkdown: folderDelete,
+				markDirty,
+			} as unknown as StorageProvider;
+			const dual = new DualWriteStorage(orphan, folder);
+			await dual.deleteVisibleMarkdown({
+				commitHash: "deadbeef",
+				parentCommitHash: null,
+				commitMessage: "x",
+				commitDate: "2026-05-12T00:00:00Z",
+				branch: "main",
+				generatedAt: "2026-05-12T00:00:00Z",
+			});
+			expect(markDirty).toHaveBeenCalled();
+		});
+	});
+
+	describe("regenerateVisibleMarkdown delegation", () => {
+		const entry = {
+			commitHash: "deadbeef",
+			parentCommitHash: null,
+			commitMessage: "Restore me",
+			commitDate: "2026-05-12T00:00:00Z",
+			branch: "main",
+			generatedAt: "2026-05-12T00:00:00Z",
+		};
+
+		it("delegates to the folder-side provider and propagates the boolean result", async () => {
+			const folderRegen = vi.fn().mockResolvedValue(true);
+			const orphan = {
+				readFile: vi.fn(),
+				writeFiles: vi.fn(),
+				listFiles: vi.fn(),
+				exists: vi.fn().mockResolvedValue(true),
+				ensure: vi.fn(),
+			} as unknown as StorageProvider;
+			const folder = {
+				readFile: vi.fn(),
+				writeFiles: vi.fn(),
+				listFiles: vi.fn(),
+				exists: vi.fn().mockResolvedValue(true),
+				ensure: vi.fn(),
+				regenerateVisibleMarkdown: folderRegen,
+			} as unknown as StorageProvider;
+			const dual = new DualWriteStorage(orphan, folder);
+			const ok = await dual.regenerateVisibleMarkdown(entry);
+			expect(folderRegen).toHaveBeenCalledWith(entry);
+			expect(ok).toBe(true);
+		});
+
+		it("returns false when the folder side lacks the method (no visible layer)", async () => {
+			const orphan = {
+				readFile: vi.fn(),
+				writeFiles: vi.fn(),
+				listFiles: vi.fn(),
+				exists: vi.fn().mockResolvedValue(true),
+				ensure: vi.fn(),
+			} as unknown as StorageProvider;
+			const folder = {
+				readFile: vi.fn(),
+				writeFiles: vi.fn(),
+				listFiles: vi.fn(),
+				exists: vi.fn().mockResolvedValue(true),
+				ensure: vi.fn(),
+			} as unknown as StorageProvider;
+			const dual = new DualWriteStorage(orphan, folder);
+			await expect(dual.regenerateVisibleMarkdown(entry)).resolves.toBe(false);
+		});
+
+		it("marks dirty and returns false when the folder side throws", async () => {
+			const folderRegen = vi.fn().mockRejectedValue(new Error("disk gone"));
+			const markDirty = vi.fn();
+			const orphan = {
+				readFile: vi.fn(),
+				writeFiles: vi.fn(),
+				listFiles: vi.fn(),
+				exists: vi.fn().mockResolvedValue(true),
+				ensure: vi.fn(),
+			} as unknown as StorageProvider;
+			const folder = {
+				readFile: vi.fn(),
+				writeFiles: vi.fn(),
+				listFiles: vi.fn(),
+				exists: vi.fn().mockResolvedValue(true),
+				ensure: vi.fn(),
+				regenerateVisibleMarkdown: folderRegen,
+				markDirty,
+			} as unknown as StorageProvider;
+			const dual = new DualWriteStorage(orphan, folder);
+			const ok = await dual.regenerateVisibleMarkdown(entry);
+			expect(ok).toBe(false);
+			expect(markDirty).toHaveBeenCalled();
+		});
+	});
 });

--- a/cli/src/core/DualWriteStorage.ts
+++ b/cli/src/core/DualWriteStorage.ts
@@ -7,7 +7,7 @@
  */
 
 import { createLogger } from "../Logger.js";
-import type { FileWrite } from "../Types.js";
+import type { FileWrite, SummaryIndexEntry } from "../Types.js";
 import type { StorageProvider } from "./StorageProvider.js";
 
 const log = createLogger("DualWriteStorage");
@@ -33,6 +33,39 @@ export class DualWriteStorage implements StorageProvider {
 		} catch (e) {
 			log.warn("Shadow write failed (folder storage): %s", e instanceof Error ? e.message : String(e));
 			this.shadow.markDirty?.(message);
+		}
+	}
+
+	async deleteVisibleMarkdown(entry: SummaryIndexEntry): Promise<void> {
+		if (!this.shadow.deleteVisibleMarkdown) return;
+		try {
+			await this.shadow.deleteVisibleMarkdown(entry);
+		} catch (err) {
+			const hash8 = entry.commitHash.substring(0, 8);
+			log.warn(
+				"Shadow deleteVisibleMarkdown failed (folder storage) for %s/%s: %s",
+				entry.branch,
+				hash8,
+				err instanceof Error ? err.message : String(err),
+			);
+			this.shadow.markDirty?.(`deleteVisibleMarkdown ${entry.branch}/${hash8}`);
+		}
+	}
+
+	async regenerateVisibleMarkdown(entry: SummaryIndexEntry): Promise<boolean> {
+		if (!this.shadow.regenerateVisibleMarkdown) return false;
+		try {
+			return await this.shadow.regenerateVisibleMarkdown(entry);
+		} catch (err) {
+			const hash8 = entry.commitHash.substring(0, 8);
+			log.warn(
+				"Shadow regenerateVisibleMarkdown failed (folder storage) for %s/%s: %s",
+				entry.branch,
+				hash8,
+				err instanceof Error ? err.message : String(err),
+			);
+			this.shadow.markDirty?.(`regenerateVisibleMarkdown ${entry.branch}/${hash8}`);
+			return false;
 		}
 	}
 

--- a/cli/src/core/FolderStorage.test.ts
+++ b/cli/src/core/FolderStorage.test.ts
@@ -362,6 +362,234 @@ describe("FolderStorage", () => {
 		});
 	});
 
+	describe("deleteVisibleMarkdown", () => {
+		beforeEach(async () => {
+			await storage.ensure();
+		});
+
+		it("deletes the visible md file and leaves .jolli/ untouched", async () => {
+			const summaryJson = makeSummaryJson({
+				commitHash: "deadbeef12345678",
+				commitMessage: "Add login",
+				branch: "feature/login",
+			});
+			await storage.writeFiles([{ path: "summaries/deadbeef12345678.json", content: summaryJson }], "seed");
+
+			const visiblePath = join(rootPath, "feature-login", "add-login-deadbeef.md");
+			expect(existsSync(visiblePath)).toBe(true);
+
+			await storage.deleteVisibleMarkdown({
+				commitHash: "deadbeef12345678",
+				commitMessage: "Add login",
+				commitDate: "2026-01-15T10:00:00Z",
+				branch: "feature/login",
+				generatedAt: "2026-01-15T10:00:00Z",
+				parentCommitHash: null,
+			});
+
+			expect(existsSync(visiblePath)).toBe(false);
+			// Hidden JSON intact.
+			const hiddenPath = join(rootPath, ".jolli", "summaries", "deadbeef12345678.json");
+			expect(existsSync(hiddenPath)).toBe(true);
+		});
+
+		it("is idempotent on a missing file (no throw)", async () => {
+			await expect(
+				storage.deleteVisibleMarkdown({
+					commitHash: "ffffffffffffffff",
+					commitMessage: "ghost",
+					commitDate: "2026-01-15T10:00:00Z",
+					branch: "ghost-branch",
+					generatedAt: "2026-01-15T10:00:00Z",
+					parentCommitHash: null,
+				}),
+			).resolves.toBeUndefined();
+		});
+
+		it("preserves a hand-edited md (fingerprint mismatch — same protection cleanupSupersededDescendants gives at write time)", async () => {
+			// Regression: cleanupBranchStaleChildMarkdown (called by QueueWorker
+			// tail and MigrationEngine) routes through this method to delete
+			// hoisted older versions. Without fingerprint protection here, a
+			// user who hand-edited a stale child MD before the worker drained
+			// would silently lose those edits — only the write-time path's
+			// cleanupSupersededDescendants protected them, and that path is not
+			// involved in the tail-cleanup or migration flows.
+			const summaryJson = makeSummaryJson({
+				commitHash: "deadbeef12345678",
+				commitMessage: "Add login",
+				branch: "feature/login",
+			});
+			await storage.writeFiles([{ path: "summaries/deadbeef12345678.json", content: summaryJson }], "seed");
+
+			const visiblePath = join(rootPath, "feature-login", "add-login-deadbeef.md");
+			expect(existsSync(visiblePath)).toBe(true);
+
+			writeFileSync(visiblePath, "# Hand-edited\n\nUser changed this", "utf-8");
+
+			await storage.deleteVisibleMarkdown({
+				commitHash: "deadbeef12345678",
+				commitMessage: "Add login",
+				commitDate: "2026-01-15T10:00:00Z",
+				branch: "feature/login",
+				generatedAt: "2026-01-15T10:00:00Z",
+				parentCommitHash: "newroot1234567890",
+			});
+
+			expect(existsSync(visiblePath)).toBe(true);
+			expect(readFileSync(visiblePath, "utf-8")).toContain("Hand-edited");
+			expect(metadataManager.findById("deadbeef12345678")).toBeDefined();
+		});
+
+		it("drops the manifest entry alongside the visible md on successful delete", async () => {
+			// Mirrors cleanupSupersededDescendants' "ghost entry" cleanup: if we
+			// removed the file but kept the manifest record, future migrations
+			// / scans would re-trip on a path that no longer exists.
+			const summaryJson = makeSummaryJson({
+				commitHash: "cafe1234cafe1234",
+				commitMessage: "Add cafe",
+				branch: "main",
+			});
+			await storage.writeFiles([{ path: "summaries/cafe1234cafe1234.json", content: summaryJson }], "seed");
+			expect(metadataManager.findById("cafe1234cafe1234")).toBeDefined();
+
+			await storage.deleteVisibleMarkdown({
+				commitHash: "cafe1234cafe1234",
+				commitMessage: "Add cafe",
+				commitDate: "2026-01-15T10:00:00Z",
+				branch: "main",
+				generatedAt: "2026-01-15T10:00:00Z",
+				parentCommitHash: "newroot1234567890",
+			});
+
+			expect(metadataManager.findById("cafe1234cafe1234")).toBeUndefined();
+		});
+
+		it("leaves the <branch>/ directory in place after the last md is removed", async () => {
+			const summaryJson = makeSummaryJson({
+				commitHash: "aaaa11112222bbbb",
+				commitMessage: "Solo entry",
+				branch: "lone-branch",
+			});
+			await storage.writeFiles([{ path: "summaries/aaaa11112222bbbb.json", content: summaryJson }], "seed");
+
+			await storage.deleteVisibleMarkdown({
+				commitHash: "aaaa11112222bbbb",
+				commitMessage: "Solo entry",
+				commitDate: "2026-01-15T10:00:00Z",
+				branch: "lone-branch",
+				generatedAt: "2026-01-15T10:00:00Z",
+				parentCommitHash: null,
+			});
+
+			const branchDir = join(rootPath, "lone-branch");
+			expect(existsSync(branchDir)).toBe(true);
+		});
+	});
+
+	describe("regenerateVisibleMarkdown", () => {
+		beforeEach(async () => {
+			await storage.ensure();
+		});
+
+		it("re-emits the visible md from hidden JSON when the .md is missing", async () => {
+			const summaryJson = makeSummaryJson({
+				commitHash: "deadbeef12345678",
+				commitMessage: "Restore me",
+				branch: "feature/restore",
+			});
+			// Seed both hidden + visible.
+			await storage.writeFiles([{ path: "summaries/deadbeef12345678.json", content: summaryJson }], "seed");
+			const visiblePath = join(rootPath, "feature-restore", "restore-me-deadbeef.md");
+			expect(existsSync(visiblePath)).toBe(true);
+			// Simulate post-0.99.2 disk state: head .md deleted, hidden JSON intact.
+			require("node:fs").unlinkSync(visiblePath);
+			expect(existsSync(visiblePath)).toBe(false);
+
+			const wrote = await storage.regenerateVisibleMarkdown({
+				commitHash: "deadbeef12345678",
+				commitMessage: "Restore me",
+				commitDate: "2026-01-15T10:00:00Z",
+				branch: "feature/restore",
+				generatedAt: "2026-01-15T10:00:00Z",
+				parentCommitHash: null,
+			});
+
+			expect(wrote).toBe(true);
+			expect(existsSync(visiblePath)).toBe(true);
+		});
+
+		it("returns true and is a no-op when the visible md already exists", async () => {
+			const summaryJson = makeSummaryJson({
+				commitHash: "cafebabe12345678",
+				commitMessage: "Already here",
+				branch: "main",
+			});
+			await storage.writeFiles([{ path: "summaries/cafebabe12345678.json", content: summaryJson }], "seed");
+			const visiblePath = join(rootPath, "main", "already-here-cafebabe.md");
+			const before = require("node:fs").readFileSync(visiblePath, "utf-8");
+
+			const wrote = await storage.regenerateVisibleMarkdown({
+				commitHash: "cafebabe12345678",
+				commitMessage: "Already here",
+				commitDate: "2026-01-15T10:00:00Z",
+				branch: "main",
+				generatedAt: "2026-01-15T10:00:00Z",
+				parentCommitHash: null,
+			});
+
+			expect(wrote).toBe(true);
+			// File untouched (idempotent fast path).
+			const after = require("node:fs").readFileSync(visiblePath, "utf-8");
+			expect(after).toBe(before);
+		});
+
+		it("returns false when hidden JSON source is missing — cannot regenerate", async () => {
+			const wrote = await storage.regenerateVisibleMarkdown({
+				commitHash: "ffffffffffffffff",
+				commitMessage: "Lost summary",
+				commitDate: "2026-01-15T10:00:00Z",
+				branch: "ghost-branch",
+				generatedAt: "2026-01-15T10:00:00Z",
+				parentCommitHash: null,
+			});
+
+			expect(wrote).toBe(false);
+		});
+
+		it("preserves existing manifest title when regenerating (companion of backfillTitle)", async () => {
+			const summaryJson = makeSummaryJson({
+				commitHash: "feedbabe12345678",
+				commitMessage: "Auto-generated message",
+				branch: "main",
+			});
+			await storage.writeFiles([{ path: "summaries/feedbabe12345678.json", content: summaryJson }], "seed");
+			// Simulate user-edited title in manifest, then delete the .md to mimic
+			// the post-0.99.2 disk state.
+			const mm = new MetadataManager(join(rootPath, ".jolli"));
+			mm.updateManifest({
+				path: "main/auto-generated-message-feedbabe.md",
+				fileId: "feedbabe12345678",
+				type: "commit",
+				fingerprint: "fp",
+				source: { commitHash: "feedbabe12345678", branch: "main" },
+				title: "Hand-edited title",
+			});
+			require("node:fs").unlinkSync(join(rootPath, "main", "auto-generated-message-feedbabe.md"));
+
+			await storage.regenerateVisibleMarkdown({
+				commitHash: "feedbabe12345678",
+				commitMessage: "Auto-generated message",
+				commitDate: "2026-01-15T10:00:00Z",
+				branch: "main",
+				generatedAt: "2026-01-15T10:00:00Z",
+				parentCommitHash: null,
+			});
+
+			// .md regenerated, but manifest title preserved.
+			expect(mm.findById("feedbabe12345678")?.title).toBe("Hand-edited title");
+		});
+	});
+
 	describe("slugify", () => {
 		it("basic message", () => {
 			expect(FolderStorage.slugify("Add login feature")).toBe("add-login-feature");

--- a/cli/src/core/FolderStorage.ts
+++ b/cli/src/core/FolderStorage.ts
@@ -15,7 +15,7 @@
 import { existsSync, mkdirSync, readdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
 import { dirname, join, relative } from "node:path";
 import { createLogger } from "../Logger.js";
-import type { CommitSummary, FileWrite, SummaryIndex } from "../Types.js";
+import type { CommitSummary, FileWrite, SummaryIndex, SummaryIndexEntry } from "../Types.js";
 import { MetadataManager } from "./MetadataManager.js";
 import type { StorageProvider } from "./StorageProvider.js";
 import { buildMarkdown } from "./SummaryMarkdownBuilder.js";
@@ -110,6 +110,140 @@ export class FolderStorage implements StorageProvider {
 	isDirty(): boolean {
 		const statusPath = join(this.rootPath, ".jolli", "shadow-status.json");
 		return existsSync(statusPath);
+	}
+
+	/**
+	 * Remove ONLY the visible <branch>/<slug>-<hash8>.md file for this entry.
+	 * Leaves .jolli/summaries/<hash>.json and .jolli/index.json in place;
+	 * drops the manifest entry on successful delete (mirrors cleanupSuperseded-
+	 * Descendants — keeping a manifest record for a deleted file would let
+	 * future scans re-trip on a ghost path). Idempotent on a missing file.
+	 *
+	 * Fingerprint-guarded: skips deletion when the on-disk SHA differs from
+	 * the manifest's recorded fingerprint, since that means a user has
+	 * hand-edited the file. Same protection cleanupSupersededDescendants
+	 * applies at write time, lifted into the StorageProvider boundary so
+	 * tail-cleanup (QueueWorker) and migration callers inherit it.
+	 *
+	 * See StorageProvider.deleteVisibleMarkdown for the contract.
+	 */
+	async deleteVisibleMarkdown(entry: SummaryIndexEntry): Promise<void> {
+		const manifestEntry = this.metadataManager.findById(entry.commitHash);
+		const branchFolder = this.metadataManager.resolveFolderForBranch(entry.branch);
+		const slug = FolderStorage.slugify(entry.commitMessage);
+		const hash8 = entry.commitHash.substring(0, 8);
+		const relativePath = manifestEntry?.path ?? `${branchFolder}/${slug}-${hash8}.md`;
+		const absPath = join(this.rootPath, relativePath);
+
+		if (!existsSync(absPath)) {
+			if (manifestEntry) this.metadataManager.removeFromManifest(entry.commitHash);
+			return;
+		}
+
+		if (manifestEntry?.fingerprint) {
+			let onDiskFingerprint: string;
+			try {
+				onDiskFingerprint = MetadataManager.sha256(readFileSync(absPath, "utf-8"));
+			} catch (err) {
+				log.warn("Cannot read %s for fingerprint check: %s — keeping file", relativePath, String(err));
+				return;
+			}
+			if (onDiskFingerprint !== manifestEntry.fingerprint) {
+				log.warn(
+					"Skipping cleanup of %s — file modified since manifest record (likely hand-edited)",
+					relativePath,
+				);
+				return;
+			}
+		}
+
+		try {
+			unlinkSync(absPath);
+			if (manifestEntry) this.metadataManager.removeFromManifest(entry.commitHash);
+			log.info("Deleted visible MD: %s", relativePath);
+		} catch (err) {
+			// TOCTOU between existsSync above and unlinkSync here: a concurrent
+			// writer / cleanup pass may have removed the file. Treat ENOENT as
+			// success (drop the manifest entry, same as the missing-file branch
+			// above) and surface anything else so callers can record dirty state.
+			const code = (err as NodeJS.ErrnoException).code;
+			if (code === "ENOENT") {
+				if (manifestEntry) this.metadataManager.removeFromManifest(entry.commitHash);
+				return;
+			}
+			throw err;
+		}
+	}
+
+	/**
+	 * Re-emit the visible <branch>/<slug>-<hash8>.md from the hidden
+	 * .jolli/summaries/<hash>.json source. Idempotent: a `.md` already on disk
+	 * causes an early return without re-reading or re-writing. Used by
+	 * MigrationEngine.runStaleChildCleanup to recover head `.md` files that
+	 * 0.99.2's inverted leaf-only pass mistakenly deleted.
+	 *
+	 * Returns true when the `.md` ended up on disk (regenerated or already
+	 * present), false when the hidden JSON source was missing or unparseable
+	 * — in which case regeneration is impossible and the caller can surface
+	 * a warning. See StorageProvider.regenerateVisibleMarkdown for the contract.
+	 *
+	 * Does NOT reuse `generateSummaryMarkdown`. That path is the normal-write
+	 * pipeline and has two side effects we must avoid here:
+	 *   - it overwrites the manifest `title` field, clobbering user-edited
+	 *     titles (which `backfillTitle` is contractually obligated to preserve);
+	 *   - it calls `cleanupSupersededDescendants`, which only makes sense after
+	 *     a fresh write where a new root has just superseded older children —
+	 *     not when we're merely restoring a previously deleted head.
+	 */
+	async regenerateVisibleMarkdown(entry: SummaryIndexEntry): Promise<boolean> {
+		const branchFolder = this.metadataManager.resolveFolderForBranch(entry.branch);
+		const slug = FolderStorage.slugify(entry.commitMessage);
+		const hash8 = entry.commitHash.substring(0, 8);
+		const relativePath = `${branchFolder}/${slug}-${hash8}.md`;
+		const absPath = join(this.rootPath, relativePath);
+		if (existsSync(absPath)) return true;
+
+		const summaryJson = await this.readFile(`summaries/${entry.commitHash}.json`);
+		if (!summaryJson) {
+			log.warn("regenerateVisibleMarkdown: hidden summaries/%s.json missing", entry.commitHash.substring(0, 8));
+			return false;
+		}
+		let summary: CommitSummary;
+		try {
+			summary = JSON.parse(summaryJson) as CommitSummary;
+		} catch (err) {
+			log.warn(
+				"regenerateVisibleMarkdown: malformed summaries/%s.json — %s",
+				entry.commitHash.substring(0, 8),
+				err instanceof Error ? err.message : String(err),
+			);
+			return false;
+		}
+
+		const frontmatter = this.buildYamlFrontmatter(summary);
+		const body = buildMarkdown(summary);
+		const markdown = `${frontmatter}\n${body}`;
+		this.atomicWrite(absPath, markdown);
+
+		// Update manifest to track the regenerated .md, but preserve any
+		// existing title — backfillTitle's contract is "do not touch entries
+		// that already have a title", and regenerate is its companion.
+		const existing = this.metadataManager.findById(entry.commitHash);
+		const fingerprint = MetadataManager.sha256(markdown);
+		this.metadataManager.updateManifest({
+			path: relativePath,
+			fileId: summary.commitHash,
+			type: "commit",
+			fingerprint,
+			source: {
+				commitHash: summary.commitHash,
+				branch: summary.branch,
+				generatedAt: summary.generatedAt,
+			},
+			title: existing?.title ?? summary.commitMessage,
+		});
+		log.info("Regenerated visible MD: %s", relativePath);
+		return true;
 	}
 
 	// ── Markdown generation ────────────────────────────────────────────────

--- a/cli/src/core/HeadEntryFilter.test.ts
+++ b/cli/src/core/HeadEntryFilter.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vitest";
+import type { SummaryIndexEntry } from "../Types.js";
+import { filterToBranchHeads, getBranchHeads } from "./HeadEntryFilter.js";
+
+function e(
+	commitHash: string,
+	branch: string,
+	parent: string | null | undefined,
+	repoName?: string,
+): SummaryIndexEntry {
+	return {
+		commitHash,
+		parentCommitHash: parent,
+		commitMessage: commitHash,
+		commitDate: "2026-05-12T00:00:00Z",
+		branch,
+		generatedAt: "2026-05-12T00:00:00Z",
+		...(repoName !== undefined ? { repoName } : {}),
+	};
+}
+
+describe("HeadEntryFilter", () => {
+	describe("getBranchHeads", () => {
+		it("returns empty set for empty input", () => {
+			expect(getBranchHeads([])).toEqual(new Set());
+		});
+
+		it("returns the single entry when there's only one (root)", () => {
+			expect(getBranchHeads([e("a", "main", null)])).toEqual(new Set(["a"]));
+		});
+
+		it("returns only the root of a v4 Hoist chain (root + hoisted older children)", () => {
+			// Under v4 Hoist: 'a' is the live head; 'b' and 'c' are older versions
+			// that were squash/amend-rewritten and now sit in a.children[].
+			// Index encoding: b.parent = a, c.parent = a.
+			const heads = getBranchHeads([e("a", "main", null), e("b", "main", "a"), e("c", "main", "a")]);
+			expect(heads).toEqual(new Set(["a"]));
+		});
+
+		it("returns multiple heads when a branch has multiple independent commits", () => {
+			// Two independent commits on the same branch, each its own Hoist root.
+			// (e.g. branch has 2 distinct git commits, neither amended into the other.)
+			const heads = getBranchHeads([
+				e("a", "main", null),
+				e("b", "main", "a"),
+				e("x", "main", null),
+				e("y", "main", "x"),
+			]);
+			expect(heads).toEqual(new Set(["a", "x"]));
+		});
+
+		it("ignores branch when judging head — only parentCommitHash matters", () => {
+			// rebase-pick across branches creates parent links across branch labels.
+			// Under v4 Hoist 'a' is still a head on its branch as long as parent==null.
+			const heads = getBranchHeads([e("a", "feature-x", null), e("aprime", "feature-y", "a")]);
+			// 'a' is head (parent null). 'aprime' has parent → NOT a head.
+			expect(heads).toEqual(new Set(["a"]));
+		});
+
+		it("ignores repoName when judging head — only parentCommitHash matters", () => {
+			const heads = getBranchHeads([
+				e("a", "main", null, "repoA"),
+				e("b", "main", "a", "repoA"),
+				e("x", "main", null, "repoB"),
+				e("y", "main", "x", "repoB"),
+			]);
+			expect(heads).toEqual(new Set(["a", "x"]));
+		});
+
+		it("treats undefined parentCommitHash (legacy v1) as head", () => {
+			// v1 entries never had `parentCommitHash`. The field-only test uses
+			// `== null` which is true for both null and undefined, so v1 entries
+			// are classified as heads — the correct migration semantics.
+			expect(getBranchHeads([e("a", "main", undefined)])).toEqual(new Set(["a"]));
+		});
+
+		it("does NOT treat a dangling parent pointer as a head (semantics change vs ChainLeafFilter)", () => {
+			// Previously this returned {b} because the old DAG-scan algorithm
+			// inferred "no entry in scope claims b as a parent, so b is root".
+			// Under v4 Hoist semantics, b.parent has a non-null value (even if
+			// it resolves to nothing in the current index), so b was written as
+			// a hoisted child of something — not a live head. Reflecting this
+			// honestly is more useful than masking it.
+			expect(getBranchHeads([e("b", "main", "a")])).toEqual(new Set());
+		});
+
+		it("returns empty set when every entry has a parent (cycle / all-children case)", () => {
+			// 2-cycle: a→b, b→a — neither has null parent.
+			expect(getBranchHeads([e("a", "main", "b"), e("b", "main", "a")])).toEqual(new Set());
+			// 3-cycle: a→c, b→a, c→b — same.
+			expect(getBranchHeads([e("a", "main", "c"), e("b", "main", "a"), e("c", "main", "b")])).toEqual(new Set());
+		});
+	});
+
+	describe("filterToBranchHeads", () => {
+		it("returns entries whose parentCommitHash is null", () => {
+			const root = e("a", "main", null);
+			const child = e("b", "main", "a");
+			expect(filterToBranchHeads([root, child])).toEqual([root]);
+		});
+
+		it("preserves input order among heads", () => {
+			const child1 = e("b", "main", "a");
+			const root1 = e("a", "main", null);
+			const child2 = e("y", "main", "x");
+			const root2 = e("x", "main", null);
+			expect(filterToBranchHeads([child1, root1, child2, root2]).map((x) => x.commitHash)).toEqual(["a", "x"]);
+		});
+
+		it("treats undefined parentCommitHash as head (v1 legacy)", () => {
+			const legacy = e("a", "main", undefined);
+			expect(filterToBranchHeads([legacy])).toEqual([legacy]);
+		});
+	});
+});

--- a/cli/src/core/HeadEntryFilter.ts
+++ b/cli/src/core/HeadEntryFilter.ts
@@ -1,0 +1,51 @@
+/**
+ * HeadEntryFilter — single source of truth for "which entries are v4 Hoist heads?".
+ *
+ * v4 Hoist write path (see `flattenSummaryTree` in SummaryStore.ts and
+ * `mergeManyToOne` for squash): every new commit / amend / squash writes a
+ * fresh root summary with `parentCommitHash = null`, and every prior version
+ * it supersedes becomes a child stripped of functional metadata and reassigned
+ * `parentCommitHash = <new root hash>`. So the index invariant is:
+ *
+ *   parentCommitHash == null  →  current live "head" entry (the version
+ *                                git log / git show now references)
+ *   parentCommitHash != null  →  older version that has been hoisted into
+ *                                some head's children[] (no longer visible
+ *                                in git log; preserved in the index purely
+ *                                for hierarchical drill-down).
+ *
+ * The previous ChainLeafFilter judged heads as DAG leaves ("no other entry
+ * names me as parent"). That reads natural under Git's parent direction but is
+ * **opposite** to v4 Hoist's direction: under Hoist, the head is the root
+ * (no parent), and the DAG leaves are precisely the discarded older versions.
+ * Anything looking up "what should be displayed / kept on disk" must use the
+ * Hoist-aligned reading, which is what this module provides.
+ *
+ * No `(repoName, branch)` scoping is needed: the head test reads one field on
+ * one entry and ignores everything else. Cycles, dangling-parent rows, and
+ * cross-branch / cross-repo parent pointers are all handled correctly by the
+ * field-only check — any entry whose `parentCommitHash` is non-null is
+ * categorically not a head, regardless of where that pointer resolves.
+ */
+
+import type { SummaryIndexEntry } from "../Types.js";
+
+/** Returns the set of commitHashes that are v4 Hoist heads (parent == null). */
+export function getBranchHeads(entries: Iterable<SummaryIndexEntry>): Set<string> {
+	const heads = new Set<string>();
+	for (const entry of entries) {
+		if (entry.parentCommitHash == null) {
+			heads.add(entry.commitHash);
+		}
+	}
+	return heads;
+}
+
+/** Convenience: returns only the entries that are heads. Preserves input order. */
+export function filterToBranchHeads<T extends SummaryIndexEntry>(entries: Iterable<T>): T[] {
+	const result: T[] = [];
+	for (const e of entries) {
+		if (e.parentCommitHash == null) result.push(e);
+	}
+	return result;
+}

--- a/cli/src/core/KBTypes.ts
+++ b/cli/src/core/KBTypes.ts
@@ -53,4 +53,23 @@ export interface MigrationState {
 	readonly migratedEntries: number;
 	readonly failedHashes?: readonly string[];
 	readonly lastMigratedHash?: string;
+	/**
+	 * v2 leaf-cleanup step (shipped briefly in 0.99.2, never read after that
+	 * release). Its algorithm was inverted under v4 Hoist semantics — it kept
+	 * stale children and deleted heads. Retained in the type purely so existing
+	 * on-disk migration.json entries that carry this field still parse; the
+	 * field is never written or read by code after 0.99.2.
+	 * @deprecated use {@link staleChildCleanup} instead.
+	 */
+	readonly leafCleanup?: { readonly completedAt: string };
+	/**
+	 * v3 stale-child cleanup step (added 2026-05-12 to replace the inverted
+	 * `leafCleanup` from 0.99.2): one-shot deletion of visible .md files for
+	 * v4 Hoist hoisted children (entries with `parentCommitHash != null`),
+	 * combined with one-shot regeneration of head .md files erroneously
+	 * deleted by 0.99.2's inverted pass. `completedAt` set on first successful
+	 * run; subsequent activate runs skip when present. Absent = not yet
+	 * attempted (or only the 0.99.2 inverted pass ran — re-run is required).
+	 */
+	readonly staleChildCleanup?: { readonly completedAt: string };
 }

--- a/cli/src/core/LocalSearchProvider.ts
+++ b/cli/src/core/LocalSearchProvider.ts
@@ -99,6 +99,11 @@ export class LocalSearchProvider implements SearchProvider {
 		// getDisplayDate for the same reason.
 		const sinceTimestamp = sinceParsed.kind === "ok" ? sinceParsed.ts : null;
 		const indexEntries = index?.entries ?? [];
+		// Intentionally root-only (not leaf): aligned with `jolli view` and
+		// `SessionStartHook`. The 2026-05-12 leaf-only-memory-display redesign
+		// flipped the VS Code display surfaces (Timeline, Memory Bank tree,
+		// Branch tab) to leaves; CLI catalog/search stays on root semantics
+		// until a follow-up explicitly verifies its tests + UX under leaves.
 		const candidates = indexEntries
 			.filter(isRootEntry)
 			.filter((e) => sinceTimestamp === null || new Date(getDisplayDate(e)).getTime() >= sinceTimestamp)

--- a/cli/src/core/MigrationEngine.test.ts
+++ b/cli/src/core/MigrationEngine.test.ts
@@ -694,6 +694,281 @@ describe("MigrationEngine", () => {
 		});
 	});
 
+	describe("v3 stale-child cleanup", () => {
+		// Local helpers — self-contained so as not to touch outer beforeEach state.
+		let kbRoot: string;
+
+		beforeEach(() => {
+			kbRoot = makeTmpDir();
+		});
+
+		afterEach(() => {
+			rmrf(kbRoot);
+		});
+
+		function makeFolderStorage(): FolderStorage {
+			const mm = new MetadataManager(join(kbRoot, ".jolli"));
+			return new FolderStorage(kbRoot, mm);
+		}
+
+		function makeOrphanStorage(): InMemoryStorage {
+			return new InMemoryStorage();
+		}
+
+		function makeMetadataManager(rootPath: string): MetadataManager {
+			return new MetadataManager(join(rootPath, ".jolli"));
+		}
+
+		function visibleMdExists(rootPath: string, branch: string, slugAndHash: string): boolean {
+			const { existsSync } = require("node:fs");
+			return existsSync(join(rootPath, branch, `${slugAndHash}.md`));
+		}
+
+		/** Seed a v4 Hoist chain: head `aaa` (parent=null), hoisted child `bbb` (parent=aaa). */
+		async function seedHoistChain(fs2: FolderStorage): Promise<void> {
+			await fs2.writeFiles(
+				[
+					{
+						path: "summaries/aaa.json",
+						content: JSON.stringify({
+							version: 3,
+							commitHash: "aaa",
+							commitMessage: "head",
+							commitAuthor: "x",
+							commitDate: "2026-05-12T00:00:00Z",
+							branch: "main",
+							generatedAt: "2026-05-12T00:00:00Z",
+							topics: [],
+						}),
+					},
+					{
+						path: "summaries/bbb.json",
+						content: JSON.stringify({
+							version: 3,
+							commitHash: "bbb",
+							commitMessage: "stalechild",
+							commitAuthor: "x",
+							commitDate: "2026-05-12T00:00:00Z",
+							branch: "main",
+							generatedAt: "2026-05-12T00:00:00Z",
+							topics: [],
+						}),
+					},
+					{
+						path: "index.json",
+						content: JSON.stringify({
+							version: 3,
+							entries: [
+								{
+									commitHash: "aaa",
+									parentCommitHash: null,
+									commitMessage: "head",
+									commitDate: "2026-05-12T00:00:00Z",
+									branch: "main",
+									generatedAt: "2026-05-12T00:00:00Z",
+								},
+								{
+									commitHash: "bbb",
+									parentCommitHash: "aaa",
+									commitMessage: "stalechild",
+									commitDate: "2026-05-12T00:00:00Z",
+									branch: "main",
+									generatedAt: "2026-05-12T00:00:00Z",
+								},
+							],
+						}),
+					},
+				],
+				"seed",
+			);
+		}
+
+		it("deletes stale children (parent!=null) and keeps heads (parent=null), records completedAt", async () => {
+			const fs2 = makeFolderStorage();
+			await seedHoistChain(fs2);
+
+			const mm = makeMetadataManager(kbRoot);
+			const engine = new MigrationEngine(makeOrphanStorage(), fs2, mm);
+			const state = await engine.runStaleChildCleanup();
+
+			expect(state.staleChildCleanup?.completedAt).toBeTruthy();
+			// head `aaa` kept; stale child `bbb` deleted.
+			expect(visibleMdExists(kbRoot, "main", "head-aaa")).toBe(true);
+			expect(visibleMdExists(kbRoot, "main", "stalechild-bbb")).toBe(false);
+		});
+
+		it("regenerates missing head .md from hidden JSON before deleting stale children (recovery from 0.99.2's inverted pass)", async () => {
+			const fs2 = makeFolderStorage();
+			await seedHoistChain(fs2);
+
+			// Simulate the post-0.99.2 disk state: head .md was wrongly deleted,
+			// stale child .md was wrongly kept.
+			const { unlinkSync } = require("node:fs");
+			unlinkSync(join(kbRoot, "main", "head-aaa.md"));
+
+			const mm = makeMetadataManager(kbRoot);
+			const engine = new MigrationEngine(makeOrphanStorage(), fs2, mm);
+			await engine.runStaleChildCleanup();
+
+			// Head was regenerated from hidden summaries/aaa.json.
+			expect(visibleMdExists(kbRoot, "main", "head-aaa")).toBe(true);
+			// Stale child cleaned.
+			expect(visibleMdExists(kbRoot, "main", "stalechild-bbb")).toBe(false);
+		});
+
+		it("is a no-op when staleChildCleanup.completedAt is already set", async () => {
+			const fs2 = makeFolderStorage();
+			const mm = makeMetadataManager(kbRoot);
+			mm.saveMigrationState({
+				status: "completed",
+				totalEntries: 0,
+				migratedEntries: 0,
+				staleChildCleanup: { completedAt: "2026-05-01T00:00:00Z" },
+			});
+			const engine = new MigrationEngine(makeOrphanStorage(), fs2, mm);
+			const state = await engine.runStaleChildCleanup();
+			expect(state.staleChildCleanup?.completedAt).toBe("2026-05-01T00:00:00Z");
+		});
+
+		it("does NOT short-circuit on the legacy 0.99.2 leafCleanup.completedAt — that pass was inverted and must be re-done", async () => {
+			const fs2 = makeFolderStorage();
+			await seedHoistChain(fs2);
+
+			// Delete head .md to simulate the inverted 0.99.2 outcome, and set
+			// the legacy leafCleanup flag as if 0.99.2 already "completed" the job.
+			const { unlinkSync } = require("node:fs");
+			unlinkSync(join(kbRoot, "main", "head-aaa.md"));
+
+			const mm = makeMetadataManager(kbRoot);
+			mm.saveMigrationState({
+				status: "completed",
+				totalEntries: 2,
+				migratedEntries: 2,
+				leafCleanup: { completedAt: "2026-05-12T10:00:00Z" },
+			});
+
+			const engine = new MigrationEngine(makeOrphanStorage(), fs2, mm);
+			const state = await engine.runStaleChildCleanup();
+
+			// New step ran regardless of legacy flag — head regenerated, stale child deleted.
+			expect(visibleMdExists(kbRoot, "main", "head-aaa")).toBe(true);
+			expect(visibleMdExists(kbRoot, "main", "stalechild-bbb")).toBe(false);
+			expect(state.staleChildCleanup?.completedAt).toBeTruthy();
+			// Legacy field preserved so any host code in transition still sees it.
+			expect(state.leafCleanup?.completedAt).toBe("2026-05-12T10:00:00Z");
+		});
+
+		// C1: failure-gate. If regenerate or stale-child cleanup raised on any
+		// entry, writing `staleChildCleanup.completedAt` would permanently mute
+		// the recovery path on the next startup. The 0.99.2 head-deletion bug
+		// is exactly the scenario this step exists to repair — silent
+		// permanent-skip on partial failure would mean the .md files we
+		// claimed to regenerate are gone forever and the user has no signal.
+		it("does NOT record completedAt when regenerateVisibleMarkdown raises for some heads", async () => {
+			const fs2 = makeFolderStorage();
+			await seedHoistChain(fs2);
+			// Force regenerateVisibleMarkdown to throw — simulates a corrupt
+			// hidden summaries/aaa.json or a transient write error.
+			const origRegen = fs2.regenerateVisibleMarkdown?.bind(fs2);
+			if (!origRegen) throw new Error("FolderStorage missing regenerateVisibleMarkdown");
+			(fs2 as { regenerateVisibleMarkdown?: typeof origRegen }).regenerateVisibleMarkdown = async () => {
+				throw new Error("synthetic regen failure");
+			};
+
+			const mm = makeMetadataManager(kbRoot);
+			const engine = new MigrationEngine(makeOrphanStorage(), fs2, mm);
+			const state = await engine.runStaleChildCleanup();
+
+			// Gate NOT written → next startup will retry.
+			expect(state.staleChildCleanup?.completedAt).toBeFalsy();
+			// Persisted state agrees with returned state (no silent divergence).
+			expect(mm.readMigrationState()?.staleChildCleanup?.completedAt).toBeFalsy();
+		});
+
+		// C1 self-healing: a failed run leaves the gate open. The next run on
+		// the same MetadataManager (e.g. next VS Code activate) must NOT
+		// short-circuit. Pins the round-trip behaviour the user actually sees.
+		it("re-runs on the next invocation after a failed run (does not short-circuit)", async () => {
+			const fs2 = makeFolderStorage();
+			await seedHoistChain(fs2);
+			const origRegen = fs2.regenerateVisibleMarkdown?.bind(fs2);
+			if (!origRegen) throw new Error("FolderStorage missing regenerateVisibleMarkdown");
+
+			let regenCalls = 0;
+			(fs2 as { regenerateVisibleMarkdown?: typeof origRegen }).regenerateVisibleMarkdown = async (entry) => {
+				regenCalls++;
+				if (regenCalls === 1) throw new Error("first run fails");
+				return origRegen(entry);
+			};
+
+			// Delete the head .md so a successful regen has work to do on retry.
+			const { unlinkSync } = require("node:fs");
+			unlinkSync(join(kbRoot, "main", "head-aaa.md"));
+
+			const mm = makeMetadataManager(kbRoot);
+			const engine = new MigrationEngine(makeOrphanStorage(), fs2, mm);
+
+			// Run 1 fails → gate not set.
+			await engine.runStaleChildCleanup();
+			expect(mm.readMigrationState()?.staleChildCleanup?.completedAt).toBeFalsy();
+
+			// Run 2 succeeds → gate set, head regenerated.
+			const state2 = await engine.runStaleChildCleanup();
+			expect(state2.staleChildCleanup?.completedAt).toBeTruthy();
+			expect(visibleMdExists(kbRoot, "main", "head-aaa")).toBe(true);
+		});
+
+		// C2: an unreadable / unparseable folder index.json is the exact
+		// post-0.99.2 corruption shape this step is supposed to recover from.
+		// regenerateMissingHeadMarkdown returning {0,0,0} (success-shaped) for
+		// this case would let runStaleChildCleanup write the gate and never
+		// retry — same permanent-mute trap as C1, different entry point.
+		it("does NOT record completedAt when folder index.json is unreadable", async () => {
+			const fs2 = makeFolderStorage();
+			// Seed only hidden summaries; no index.json at all so the regen
+			// step has nothing to consult.
+			await fs2.writeFiles(
+				[
+					{
+						path: "summaries/aaa.json",
+						content: JSON.stringify({
+							version: 3,
+							commitHash: "aaa",
+							commitMessage: "head",
+							commitAuthor: "x",
+							commitDate: "2026-05-12T00:00:00Z",
+							branch: "main",
+							generatedAt: "2026-05-12T00:00:00Z",
+							topics: [],
+						}),
+					},
+				],
+				"seed summary without index",
+			);
+
+			const mm = makeMetadataManager(kbRoot);
+			const engine = new MigrationEngine(makeOrphanStorage(), fs2, mm);
+			const state = await engine.runStaleChildCleanup();
+
+			expect(state.staleChildCleanup?.completedAt).toBeFalsy();
+			expect(mm.readMigrationState()?.staleChildCleanup?.completedAt).toBeFalsy();
+		});
+
+		// C2: index.json present but corrupt — exercises the JSON.parse catch
+		// path in regenerateMissingHeadMarkdown. Same gate-policy guarantee.
+		it("does NOT record completedAt when folder index.json is unparseable", async () => {
+			const fs2 = makeFolderStorage();
+			await fs2.writeFiles([{ path: "index.json", content: "{ this is not json" }], "corrupt index");
+
+			const mm = makeMetadataManager(kbRoot);
+			const engine = new MigrationEngine(makeOrphanStorage(), fs2, mm);
+			const state = await engine.runStaleChildCleanup();
+
+			expect(state.staleChildCleanup?.completedAt).toBeFalsy();
+			expect(mm.readMigrationState()?.staleChildCleanup?.completedAt).toBeFalsy();
+		});
+	});
+
 	describe("malformed orphan parse errors as non-Error", () => {
 		// Mock JSON.parse to throw a non-Error so the parse-error log path takes
 		// the `String(e)` else branch in `e instanceof Error ? e.message : String(e)`.

--- a/cli/src/core/MigrationEngine.ts
+++ b/cli/src/core/MigrationEngine.ts
@@ -16,6 +16,7 @@ import { createLogger } from "../Logger.js";
 import type { CommitSummary, SummaryIndex } from "../Types.js";
 import type { MigrationState } from "./KBTypes.js";
 import type { MetadataManager } from "./MetadataManager.js";
+import { cleanupAllBranchesStaleChildMarkdown } from "./StaleChildMarkdownCleanup.js";
 import type { StorageProvider } from "./StorageProvider.js";
 
 const log = createLogger("MigrationEngine");
@@ -128,6 +129,17 @@ export class MigrationEngine {
 			skipped,
 			failedHashes.length,
 		);
+
+		// v3 step: regenerate any head visible .md files that 0.99.2's inverted
+		// leaf cleanup wrongly deleted, then drain the stale-child backlog left
+		// by amend / rebase / squash sequences from before this code shipped.
+		// Idempotent. See runStaleChildCleanup for details.
+		try {
+			await this.runStaleChildCleanup();
+		} catch (err) {
+			log.warn("stale-child cleanup raised: %s", err instanceof Error ? err.message : String(err));
+		}
+
 		return finalState;
 	}
 
@@ -162,6 +174,135 @@ export class MigrationEngine {
 			);
 		}
 		return valid;
+	}
+
+	/**
+	 * v3 step (replaces the inverted v2 `runLeafCleanup` from 0.99.2): one-shot
+	 * reconciliation of the visible .md layer with the v4 Hoist storage model:
+	 *
+	 *   1. Regenerate any head .md (`parentCommitHash == null` entry) whose
+	 *      visible file is missing — undoes the damage of 0.99.2's leaf-only
+	 *      pass which inverted the semantics and deleted heads while keeping
+	 *      hoisted older children.
+	 *   2. Delete every stale-child .md (`parentCommitHash != null`) — these
+	 *      are older versions hoisted into a head's `children[]` and should
+	 *      not surface as standalone Memories.
+	 *
+	 * Idempotent via `state.staleChildCleanup.completedAt`. The legacy
+	 * `state.leafCleanup` field from 0.99.2 is intentionally NOT consulted —
+	 * users who ran 0.99.2 must run this pass exactly once to repair the
+	 * inverted state, regardless of what `leafCleanup.completedAt` says.
+	 *
+	 * Called from `runMigration` after v1 completes; also invoked directly
+	 * from VS Code/IDE activate paths for already-migrated users who need
+	 * the one-shot repair.
+	 */
+	async runStaleChildCleanup(): Promise<MigrationState> {
+		const existing = this.metadataManager.readMigrationState();
+		if (existing?.staleChildCleanup?.completedAt) {
+			log.info("stale-child cleanup already completed at %s — skipping", existing.staleChildCleanup.completedAt);
+			return existing;
+		}
+
+		log.info("=== stale-child cleanup started ===");
+
+		// Phase 1: regenerate head .md that 0.99.2's inverted pass deleted.
+		const regen = await this.regenerateMissingHeadMarkdown();
+		log.info(
+			"Head regenerate: regenerated=%d skipped=%d failed=%d",
+			regen.regenerated,
+			regen.skipped,
+			regen.failed,
+		);
+
+		// Phase 2: delete every stale-child visible .md.
+		const result = await cleanupAllBranchesStaleChildMarkdown(undefined, this.folderStorage);
+		log.info("Stale-child cleanup: deleted=%d failed=%d", result.deleted, result.failed);
+
+		// Only stamp `staleChildCleanup.completedAt` when both phases ran clean.
+		// The stamp is a permanent skip-gate read at the top of this method; if
+		// we wrote it on partial failure, the 0.99.2 recovery we couldn't
+		// finish would never be retried on the next VS Code activate and the
+		// missing head .md files would be silently lost. Returning state
+		// without the stamp lets the next invocation re-attempt.
+		const cleanRun = regen.failed === 0 && result.failed === 0;
+		const merged: MigrationState = {
+			status: existing?.status ?? "completed",
+			totalEntries: existing?.totalEntries ?? 0,
+			migratedEntries: existing?.migratedEntries ?? 0,
+			...(existing?.failedHashes ? { failedHashes: existing.failedHashes } : {}),
+			...(existing?.lastMigratedHash ? { lastMigratedHash: existing.lastMigratedHash } : {}),
+			// Preserve the legacy 0.99.2 field if present so we don't accidentally
+			// invalidate it for any host code that still reads it during transition.
+			...(existing?.leafCleanup ? { leafCleanup: existing.leafCleanup } : {}),
+			...(cleanRun ? { staleChildCleanup: { completedAt: new Date().toISOString() } } : {}),
+		};
+		if (!cleanRun) {
+			log.warn(
+				"stale-child cleanup did not finish cleanly (regen.failed=%d, child.failed=%d) — will retry on next invocation",
+				regen.failed,
+				result.failed,
+			);
+		}
+		this.metadataManager.saveMigrationState(merged);
+		return merged;
+	}
+
+	/**
+	 * Walk every head entry (`parentCommitHash == null`) in the folder index
+	 * and re-emit its visible `.md` from the hidden JSON source if missing.
+	 * Idempotent (skips entries whose `.md` is already on disk). Used by
+	 * runStaleChildCleanup to recover heads that 0.99.2 erroneously deleted.
+	 */
+	private async regenerateMissingHeadMarkdown(): Promise<{
+		regenerated: number;
+		skipped: number;
+		failed: number;
+	}> {
+		if (!this.folderStorage.regenerateVisibleMarkdown) {
+			return { regenerated: 0, skipped: 0, failed: 0 };
+		}
+		const indexJson = await this.folderStorage.readFile("index.json");
+		if (!indexJson) {
+			// Folder index.json should always exist by the time this runs (runMigration
+			// writes it; the VS Code activate caller only invokes us when migration has
+			// previously completed). Missing index here implies corruption / wipe, not
+			// a legitimately-empty state — surface as failure so runStaleChildCleanup
+			// withholds its idempotency stamp and retries on the next invocation.
+			log.warn("regenerateMissingHeadMarkdown: folder index.json missing — treating as failure");
+			return { regenerated: 0, skipped: 0, failed: 1 };
+		}
+		let index: SummaryIndex;
+		try {
+			index = JSON.parse(indexJson) as SummaryIndex;
+		} catch (e) {
+			log.warn(
+				"regenerateMissingHeadMarkdown: cannot parse index.json — %s",
+				e instanceof Error ? e.message : String(e),
+			);
+			return { regenerated: 0, skipped: 0, failed: 1 };
+		}
+		const heads = index.entries.filter((e) => e.parentCommitHash == null);
+
+		let regenerated = 0;
+		let skipped = 0;
+		let failed = 0;
+		for (const head of heads) {
+			try {
+				const wrote = await this.folderStorage.regenerateVisibleMarkdown(head);
+				if (wrote) regenerated++;
+				else skipped++;
+			} catch (err) {
+				failed++;
+				log.warn(
+					"regenerateVisibleMarkdown failed for %s on %s: %s",
+					head.commitHash.substring(0, 8),
+					head.branch,
+					err instanceof Error ? err.message : String(err),
+				);
+			}
+		}
+		return { regenerated, skipped, failed };
 	}
 
 	/** Loads migration state. */

--- a/cli/src/core/StaleChildMarkdownCleanup.test.ts
+++ b/cli/src/core/StaleChildMarkdownCleanup.test.ts
@@ -1,0 +1,237 @@
+import { describe, expect, it, vi } from "vitest";
+import type { SummaryIndexEntry } from "../Types.js";
+import { cleanupAllBranchesStaleChildMarkdown, cleanupBranchStaleChildMarkdown } from "./StaleChildMarkdownCleanup.js";
+import type { StorageProvider } from "./StorageProvider.js";
+
+vi.mock("./SummaryStore.js", async (orig) => {
+	const real = (await orig()) as Record<string, unknown>;
+	return { ...real, getIndexEntryMap: vi.fn() };
+});
+
+const { getIndexEntryMap } = await import("./SummaryStore.js");
+
+function e(commitHash: string, branch: string, parent: string | null): SummaryIndexEntry {
+	return {
+		commitHash,
+		parentCommitHash: parent,
+		commitMessage: `msg-${commitHash}`,
+		commitDate: "2026-05-12T00:00:00Z",
+		branch,
+		generatedAt: "2026-05-12T00:00:00Z",
+	};
+}
+
+function makeStorage(): StorageProvider & {
+	readonly deletions: SummaryIndexEntry[];
+} {
+	const deletions: SummaryIndexEntry[] = [];
+	return {
+		readFile: vi.fn(),
+		writeFiles: vi.fn(),
+		listFiles: vi.fn(),
+		exists: vi.fn(),
+		ensure: vi.fn(),
+		deleteVisibleMarkdown: async (entry) => {
+			deletions.push(entry);
+		},
+		deletions,
+	};
+}
+
+describe("StaleChildMarkdownCleanup", () => {
+	describe("cleanupBranchStaleChildMarkdown", () => {
+		it("deletes entries with parent!=null on the named branch (keeps the head)", async () => {
+			// v4 Hoist chain: a (head, parent=null), b (hoisted child of a), c
+			// (hoisted child of b — an older squashed version's older version).
+			// New semantics: keep 'a' (head), delete 'b' and 'c' (stale children).
+			(getIndexEntryMap as ReturnType<typeof vi.fn>).mockResolvedValue(
+				new Map<string, SummaryIndexEntry>([
+					["a", e("a", "main", null)],
+					["b", e("b", "main", "a")],
+					["c", e("c", "main", "b")],
+				]),
+			);
+			const storage = makeStorage();
+			const result = await cleanupBranchStaleChildMarkdown("/cwd", "main", storage);
+			expect(result.deleted).toBe(2);
+			expect(storage.deletions.map((d) => d.commitHash).sort()).toEqual(["b", "c"]);
+		});
+
+		it("does not touch entries on other branches", async () => {
+			(getIndexEntryMap as ReturnType<typeof vi.fn>).mockResolvedValue(
+				new Map<string, SummaryIndexEntry>([
+					["a", e("a", "main", null)],
+					["b", e("b", "main", "a")],
+					["x", e("x", "feature", null)],
+					["y", e("y", "feature", "x")],
+				]),
+			);
+			const storage = makeStorage();
+			await cleanupBranchStaleChildMarkdown("/cwd", "main", storage);
+			// Only main's stale child (b) deleted; feature's stale child (y) untouched.
+			expect(storage.deletions.map((d) => d.commitHash)).toEqual(["b"]);
+		});
+
+		it("keeps multiple heads on the same branch (independent commits)", async () => {
+			// Two independent commits on one branch, each a Hoist root with no children:
+			// nothing to clean up.
+			(getIndexEntryMap as ReturnType<typeof vi.fn>).mockResolvedValue(
+				new Map<string, SummaryIndexEntry>([
+					["a", e("a", "main", null)],
+					["x", e("x", "main", null)],
+				]),
+			);
+			const storage = makeStorage();
+			const result = await cleanupBranchStaleChildMarkdown("/cwd", "main", storage);
+			expect(result.deleted).toBe(0);
+			expect(storage.deletions).toEqual([]);
+		});
+
+		it("is a no-op when storage lacks deleteVisibleMarkdown", async () => {
+			(getIndexEntryMap as ReturnType<typeof vi.fn>).mockResolvedValue(
+				new Map<string, SummaryIndexEntry>([
+					["a", e("a", "main", null)],
+					["b", e("b", "main", "a")],
+				]),
+			);
+			const storage = {
+				readFile: vi.fn(),
+				writeFiles: vi.fn(),
+				listFiles: vi.fn(),
+				exists: vi.fn(),
+				ensure: vi.fn(),
+			} satisfies StorageProvider;
+			const result = await cleanupBranchStaleChildMarkdown("/cwd", "main", storage);
+			expect(result.deleted).toBe(0);
+		});
+	});
+
+	describe("cleanupAllBranchesStaleChildMarkdown", () => {
+		it("walks every branch and deletes parent!=null entries (keeps every head)", async () => {
+			(getIndexEntryMap as ReturnType<typeof vi.fn>).mockResolvedValue(
+				new Map<string, SummaryIndexEntry>([
+					["a", e("a", "main", null)],
+					["b", e("b", "main", "a")],
+					["x", e("x", "feature", null)],
+					["y", e("y", "feature", "x")],
+				]),
+			);
+			const storage = makeStorage();
+			const result = await cleanupAllBranchesStaleChildMarkdown("/cwd", storage);
+			expect(result.deleted).toBe(2);
+			expect(storage.deletions.map((d) => d.commitHash).sort()).toEqual(["b", "y"]);
+		});
+
+		it("is a no-op when storage lacks deleteVisibleMarkdown", async () => {
+			(getIndexEntryMap as ReturnType<typeof vi.fn>).mockResolvedValue(
+				new Map<string, SummaryIndexEntry>([
+					["a", e("a", "main", null)],
+					["b", e("b", "main", "a")],
+				]),
+			);
+			const storage = {
+				readFile: vi.fn(),
+				writeFiles: vi.fn(),
+				listFiles: vi.fn(),
+				exists: vi.fn(),
+				ensure: vi.fn(),
+			} satisfies StorageProvider;
+			const result = await cleanupAllBranchesStaleChildMarkdown("/cwd", storage);
+			expect(result.deleted).toBe(0);
+		});
+	});
+
+	describe("error handling", () => {
+		it("counts failures when deleteVisibleMarkdown throws on every call", async () => {
+			(getIndexEntryMap as ReturnType<typeof vi.fn>).mockResolvedValue(
+				new Map<string, SummaryIndexEntry>([
+					["a", e("a", "main", null)],
+					["b", e("b", "main", "a")],
+					["c", e("c", "main", "b")],
+				]),
+			);
+			const storage: StorageProvider & {
+				readonly deletions: SummaryIndexEntry[];
+			} = {
+				readFile: vi.fn(),
+				writeFiles: vi.fn(),
+				listFiles: vi.fn(),
+				exists: vi.fn(),
+				ensure: vi.fn(),
+				deleteVisibleMarkdown: async () => {
+					throw new Error("disk error");
+				},
+				deletions: [],
+			};
+			const result = await cleanupBranchStaleChildMarkdown("/cwd", "main", storage);
+			expect(result.deleted).toBe(0);
+			expect(result.failed).toBe(2);
+		});
+
+		it("continues deletion even if one fails", async () => {
+			(getIndexEntryMap as ReturnType<typeof vi.fn>).mockResolvedValue(
+				new Map<string, SummaryIndexEntry>([
+					["a", e("a", "main", null)],
+					["b", e("b", "main", "a")],
+					["c", e("c", "main", "b")],
+				]),
+			);
+			let callCount = 0;
+			const deletions: SummaryIndexEntry[] = [];
+			const storage: StorageProvider & {
+				readonly deletions: SummaryIndexEntry[];
+			} = {
+				readFile: vi.fn(),
+				writeFiles: vi.fn(),
+				listFiles: vi.fn(),
+				exists: vi.fn(),
+				ensure: vi.fn(),
+				deleteVisibleMarkdown: async (entry) => {
+					callCount++;
+					if (entry.commitHash === "b") {
+						throw new Error("failed");
+					}
+					deletions.push(entry);
+				},
+				deletions,
+			};
+			const result = await cleanupBranchStaleChildMarkdown("/cwd", "main", storage);
+			expect(result.deleted).toBe(1);
+			expect(result.failed).toBe(1);
+			expect(storage.deletions.map((d) => d.commitHash)).toEqual(["c"]);
+			expect(callCount).toBe(2);
+		});
+
+		it("counts failures in cleanupAllBranchesStaleChildMarkdown when deletion throws", async () => {
+			(getIndexEntryMap as ReturnType<typeof vi.fn>).mockResolvedValue(
+				new Map<string, SummaryIndexEntry>([
+					["a", e("a", "main", null)],
+					["b", e("b", "main", "a")],
+					["x", e("x", "feature", null)],
+					["y", e("y", "feature", "x")],
+				]),
+			);
+			const deletions: SummaryIndexEntry[] = [];
+			const storage: StorageProvider & {
+				readonly deletions: SummaryIndexEntry[];
+			} = {
+				readFile: vi.fn(),
+				writeFiles: vi.fn(),
+				listFiles: vi.fn(),
+				exists: vi.fn(),
+				ensure: vi.fn(),
+				deleteVisibleMarkdown: async (entry) => {
+					if (entry.commitHash === "b") {
+						throw new Error("disk error");
+					}
+					deletions.push(entry);
+				},
+				deletions,
+			};
+			const result = await cleanupAllBranchesStaleChildMarkdown("/cwd", storage);
+			expect(result.deleted).toBe(1);
+			expect(result.failed).toBe(1);
+			expect(storage.deletions.map((d) => d.commitHash)).toEqual(["y"]);
+		});
+	});
+});

--- a/cli/src/core/StaleChildMarkdownCleanup.ts
+++ b/cli/src/core/StaleChildMarkdownCleanup.ts
@@ -1,0 +1,97 @@
+/**
+ * StaleChildMarkdownCleanup — shared helper for "delete visible .md files of
+ * hoisted older versions" under the v4 Hoist storage model.
+ *
+ * Under v4 Hoist, every new commit / amend / squash writes a fresh head with
+ * `parentCommitHash == null` and reassigns the prior version's index entry
+ * to `parentCommitHash = <new head>` (see SummaryStore.flattenSummaryTree).
+ * Visible Markdown should only be published for live heads; the entries with
+ * non-null `parentCommitHash` are internal-history nodes hoisted into some
+ * head's `children[]` and should not have a sibling .md surfaced to the user.
+ *
+ * Two entry points:
+ *   - cleanupBranchStaleChildMarkdown(cwd, branch, storage): scoped to one
+ *     branch of the active repo. Called by QueueWorker at the tail of every
+ *     op so the disk invariant is restored after amend / rebase / squash.
+ *   - cleanupAllBranchesStaleChildMarkdown(cwd, storage): walks every branch
+ *     in the index. Called by MigrationEngine's one-shot step on activate to
+ *     drain any backlog accumulated before this code shipped (and to undo
+ *     the inverted 0.99.2 leaf-only deletion that wrongly preserved children
+ *     and deleted heads).
+ *
+ * Reads from index via getIndexEntryMap. Deletes via storage.deleteVisibleMarkdown
+ * (optional method; no-op when the storage backend has no visible layer, e.g.
+ * OrphanBranchStorage).
+ */
+
+import { createLogger } from "../Logger.js";
+import type { StorageProvider } from "./StorageProvider.js";
+import { getIndexEntryMap } from "./SummaryStore.js";
+
+const log = createLogger("StaleChildMarkdownCleanup");
+
+export interface CleanupResult {
+	readonly deleted: number;
+	readonly failed: number;
+}
+
+/** Delete visible .md files for hoisted older versions on a single branch. */
+export async function cleanupBranchStaleChildMarkdown(
+	cwd: string | undefined,
+	branch: string,
+	storage: StorageProvider,
+): Promise<CleanupResult> {
+	if (!storage.deleteVisibleMarkdown) {
+		return { deleted: 0, failed: 0 };
+	}
+	const map = await getIndexEntryMap(cwd, storage);
+	const branchStaleChildren = [...map.values()].filter((e) => e.branch === branch && e.parentCommitHash != null);
+
+	let deleted = 0;
+	let failed = 0;
+	for (const entry of branchStaleChildren) {
+		try {
+			await storage.deleteVisibleMarkdown(entry);
+			deleted++;
+		} catch (err) {
+			failed++;
+			log.warn(
+				"deleteVisibleMarkdown failed for %s on %s: %s",
+				entry.commitHash.substring(0, 8),
+				branch,
+				err instanceof Error ? err.message : String(err),
+			);
+		}
+	}
+	return { deleted, failed };
+}
+
+/** Delete visible .md files for hoisted older versions across every branch in the index. */
+export async function cleanupAllBranchesStaleChildMarkdown(
+	cwd: string | undefined,
+	storage: StorageProvider,
+): Promise<CleanupResult> {
+	if (!storage.deleteVisibleMarkdown) {
+		return { deleted: 0, failed: 0 };
+	}
+	const map = await getIndexEntryMap(cwd, storage);
+	const staleChildren = [...map.values()].filter((e) => e.parentCommitHash != null);
+
+	let deleted = 0;
+	let failed = 0;
+	for (const entry of staleChildren) {
+		try {
+			await storage.deleteVisibleMarkdown(entry);
+			deleted++;
+		} catch (err) {
+			failed++;
+			log.warn(
+				"deleteVisibleMarkdown failed for %s on %s: %s",
+				entry.commitHash.substring(0, 8),
+				entry.branch,
+				err instanceof Error ? err.message : String(err),
+			);
+		}
+	}
+	return { deleted, failed };
+}

--- a/cli/src/core/StorageProvider.ts
+++ b/cli/src/core/StorageProvider.ts
@@ -1,4 +1,4 @@
-import type { FileWrite } from "../Types.js";
+import type { FileWrite, SummaryIndexEntry } from "../Types.js";
 
 export interface StorageProvider {
 	/** Read a file's content. Returns null if not found. */
@@ -31,4 +31,31 @@ export interface StorageProvider {
 
 	/** Check if storage is marked as out-of-sync. Optional. */
 	isDirty?(): boolean;
+
+	/**
+	 * Remove the user-visible Markdown copy for a single summary entry.
+	 * Does NOT touch .jolli/summaries/<hash>.json, .jolli/index.json, or any
+	 * orphan-branch state. Idempotent: a missing file is not an error.
+	 *
+	 * Optional: implemented by FolderStorage and delegated by DualWriteStorage.
+	 * OrphanBranchStorage does not implement it (no visible layer).
+	 */
+	deleteVisibleMarkdown?(entry: SummaryIndexEntry): Promise<void>;
+
+	/**
+	 * Re-emit the user-visible Markdown copy for a single summary entry from
+	 * the hidden `.jolli/summaries/<hash>.json` source. Used to recover head
+	 * (`parentCommitHash == null`) `.md` files that were erroneously deleted by
+	 * 0.99.2's inverted leaf-only cleanup. Does NOT touch hidden JSON, index,
+	 * or orphan-branch state.
+	 *
+	 * Returns true when a `.md` was (re)written, false when the hidden JSON
+	 * source is missing (cannot regenerate). The implementation is allowed to
+	 * skip when the target `.md` already exists on disk; callers must not
+	 * depend on whether a write actually happened (idempotent contract).
+	 *
+	 * Optional: implemented by FolderStorage and delegated by DualWriteStorage.
+	 * OrphanBranchStorage does not implement it (no visible layer).
+	 */
+	regenerateVisibleMarkdown?(entry: SummaryIndexEntry): Promise<boolean>;
 }

--- a/cli/src/core/SummaryStore.ts
+++ b/cli/src/core/SummaryStore.ts
@@ -1529,12 +1529,18 @@ async function loadIndex(cwd?: string, storage?: StorageProvider): Promise<Summa
 	if (!content) {
 		// Surface as warn: in a healthy installation the index always exists
 		// once any summary has been generated. A null read here means either
-		// (a) fresh repo / no summaries yet, or (b) git failed to read from
-		// the orphan branch — `store.readFile` swallows the underlying git
-		// error and returns null, so production needs the warn to notice (b).
-		// Callers (`getSummary`, `listSummaries`, …) treat this as "nothing
-		// to return" rather than throwing, so the warn is the only signal.
-		log.warn("loadIndex: index.json unreadable from orphan branch (fresh repo or git read failed)");
+		// (a) fresh repo / no summaries yet, or (b) the backend's read failed
+		// (git plumbing for OrphanBranchStorage; fs/EACCES for FolderStorage)
+		// — `store.readFile` swallows the underlying error and returns null,
+		// so production needs the warn to notice (b). Callers (`getSummary`,
+		// `listSummaries`, …) treat this as "nothing to return" rather than
+		// throwing, so the warn is the only signal. Tagging the storage class
+		// keeps cross-repo foreign reads (FolderStorage on a sibling Memory
+		// Bank) from being misread as workspace orphan-branch failures.
+		log.warn(
+			"loadIndex: index.json unreadable from %s (fresh repo or backend read failed)",
+			store.constructor.name,
+		);
 		return null;
 	}
 

--- a/cli/src/hooks/PostCommitHook.ts
+++ b/cli/src/hooks/PostCommitHook.ts
@@ -10,7 +10,7 @@
  * which has the authoritative old-to-new hash mapping from git's stdin.
  */
 
-import { execSync } from "node:child_process";
+import { execFileSync, execSync } from "node:child_process";
 import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
 import { basename, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -46,6 +46,20 @@ export function postCommitEntry(cwd: string): void {
 	} catch (err: unknown) {
 		log.error("Failed to read HEAD hash: %s", (err as Error).message);
 		return;
+	}
+
+	// Capture branch at hook time. The worker's tail cleanup targets this
+	// directory, so reading the live branch when the worker drains would
+	// pick the wrong one if the user has `git checkout`'d away in between.
+	// Detached HEAD's "HEAD" label is preserved — head-detached commits
+	// still land in a logical branch directory under that label.
+	let branch: string;
+	try {
+		branch =
+			execFileSync("git", ["rev-parse", "--abbrev-ref", "HEAD"], { cwd, encoding: "utf-8" }).trim() || "HEAD";
+	} catch (err: unknown) {
+		log.warn("Failed to read current branch: %s — proceeding without tail cleanup hint", (err as Error).message);
+		branch = "";
 	}
 
 	// Detect commit source (plugin vs CLI)
@@ -93,6 +107,7 @@ export function postCommitEntry(cwd: string): void {
 	const op: GitOperation = {
 		type: opType,
 		commitHash,
+		...(branch && { branch }),
 		...(sourceHashes && { sourceHashes }),
 		commitSource,
 		createdAt: new Date().toISOString(),

--- a/cli/src/hooks/PostRewriteHook.ts
+++ b/cli/src/hooks/PostRewriteHook.ts
@@ -25,6 +25,7 @@ import { existsSync, unlinkSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { createInterface } from "node:readline";
 import { fileURLToPath } from "node:url";
+import { getCurrentBranch } from "../core/GitOps.js";
 import { isWorkerLockHeld } from "../core/Locks.js";
 import { enqueueGitOperation } from "../core/SessionTracker.js";
 import { createLogger, getJolliMemoryDir, setLogDir } from "../Logger.js";
@@ -59,10 +60,22 @@ export async function handlePostRewriteHook(command: string, cwd: string): Promi
 	// Detect commit source (plugin vs CLI)
 	const commitSource: CommitSource = detectCommitSource(cwd);
 
+	// Capture branch once for both subhandlers so the worker's tail cleanup
+	// can target the right `<branch>/` directory even if the user checks
+	// out elsewhere between this hook firing and the worker draining.
+	// Empty on read failure → enqueue omits the field and the worker's
+	// tail-step skips cleanup rather than guessing the live branch.
+	let branch = "";
+	try {
+		branch = await getCurrentBranch(cwd);
+	} catch (err) {
+		log.warn("Failed to read current branch: %s — proceeding without tail cleanup hint", String(err));
+	}
+
 	if (command === "amend") {
-		await handleAmend(mappings, commitSource, cwd);
+		await handleAmend(mappings, commitSource, cwd, branch);
 	} else if (command === "rebase") {
-		await handleRebase(mappings, commitSource, cwd);
+		await handleRebase(mappings, commitSource, cwd, branch);
 	} else {
 		log.info("Unknown command '%s', skipping", command);
 	}
@@ -89,11 +102,13 @@ async function handleAmend(
 	mappings: ReadonlyArray<HashMapping>,
 	commitSource: CommitSource,
 	cwd: string,
+	branch: string,
 ): Promise<void> {
 	const { oldHash, newHash } = mappings[0];
 	const op: GitOperation = {
 		type: "amend",
 		commitHash: newHash,
+		...(branch && { branch }),
 		sourceHashes: [oldHash],
 		commitSource,
 		createdAt: new Date().toISOString(),
@@ -110,6 +125,7 @@ async function handleRebase(
 	mappings: ReadonlyArray<HashMapping>,
 	commitSource: CommitSource,
 	cwd: string,
+	branch: string,
 ): Promise<void> {
 	// Group by new-hash: pick = {new: [old]}, squash = {new: [old1, old2, ...]}
 	const groups = new Map<string, string[]>();
@@ -126,6 +142,7 @@ async function handleRebase(
 		const op: GitOperation = {
 			type,
 			commitHash: newHash,
+			...(branch && { branch }),
 			sourceHashes: oldHashes,
 			commitSource,
 			createdAt: new Date().toISOString(),

--- a/cli/src/hooks/QueueWorker.test.ts
+++ b/cli/src/hooks/QueueWorker.test.ts
@@ -75,6 +75,11 @@ vi.mock("../core/StorageFactory.js", () => ({
 	}),
 }));
 
+vi.mock("../core/StaleChildMarkdownCleanup.js", () => ({
+	cleanupBranchStaleChildMarkdown: vi.fn().mockResolvedValue({ deleted: 0, failed: 0 }),
+	cleanupAllBranchesStaleChildMarkdown: vi.fn().mockResolvedValue({ deleted: 0, failed: 0 }),
+}));
+
 vi.mock("../core/SummaryStore.js", async (importOriginal) => {
 	const actual = await importOriginal<typeof import("../core/SummaryStore.js")>();
 	return {
@@ -212,6 +217,7 @@ import {
 	saveCursor,
 	savePlansRegistry,
 } from "../core/SessionTracker.js";
+import { cleanupBranchStaleChildMarkdown } from "../core/StaleChildMarkdownCleanup.js";
 import { generateSummary } from "../core/Summarizer.js";
 import { storeSummary } from "../core/SummaryStore.js";
 import { buildMultiSessionContext } from "../core/TranscriptReader.js";
@@ -951,6 +957,114 @@ describe("QueueWorker", () => {
 				expect.objectContaining({ commitSource: "cli", commitType: "squash" }),
 				expect.objectContaining({ topics: expect.any(Array) }),
 			);
+		});
+	});
+
+	describe("post-op stale-child cleanup", () => {
+		const mockStorage = {
+			readFile: vi.fn(),
+			writeFiles: vi.fn(),
+			listFiles: vi.fn(),
+			exists: vi.fn().mockResolvedValue(true),
+			ensure: vi.fn(),
+			deleteVisibleMarkdown: vi.fn(),
+		};
+
+		beforeEach(() => {
+			vi.mocked(cleanupBranchStaleChildMarkdown).mockClear();
+			vi.mocked(cleanupBranchStaleChildMarkdown).mockResolvedValue({
+				deleted: 0,
+				failed: 0,
+			});
+			// getCurrentBranch is consumed by the tail cleanup step regardless of op
+			// type; setupPipelineMocks() at the top of every other test rebuilds the
+			// full mock pack, but here we only need the branch reader.
+			vi.mocked(getCurrentBranch).mockResolvedValue("feature/test");
+		});
+
+		// Use op.type === "rebase-pick" with no sourceHashes: the handler early-
+		// returns at the top of handleRebasePickFromQueue without any LLM /
+		// transcript machinery, so processQueueEntry's switch falls through cleanly
+		// into the tail cleanup. This isolates the test to the cleanup wiring.
+		it("invokes cleanupBranchStaleChildMarkdown after the op handler returns", async () => {
+			await __test__.processQueueEntry(
+				{
+					type: "rebase-pick",
+					commitHash: "deadbeef1234567890abcdef0123456789abcdef",
+					branch: "feature/test",
+					createdAt: new Date().toISOString(),
+				} as never,
+				"/test/cwd",
+				mockStorage as never,
+				false,
+			);
+
+			expect(cleanupBranchStaleChildMarkdown).toHaveBeenCalledWith("/test/cwd", "feature/test", mockStorage);
+		});
+
+		it("swallows cleanup errors — the op succeeds even when cleanup throws", async () => {
+			vi.mocked(cleanupBranchStaleChildMarkdown).mockRejectedValueOnce(new Error("disk-gone"));
+
+			await expect(
+				__test__.processQueueEntry(
+					{
+						type: "rebase-pick",
+						commitHash: "feedface1234567890abcdef0123456789abcdef",
+						branch: "feature/test",
+						createdAt: new Date().toISOString(),
+					} as never,
+					"/test/cwd",
+					mockStorage as never,
+					false,
+				),
+			).resolves.toBeUndefined();
+		});
+
+		// Regression: the tail step used to read getCurrentBranch(cwd) every
+		// time, which is wrong when the user has `git checkout`'d to a different
+		// branch between enqueue and drain. The cleanup would then prune the
+		// wrong branch's directory and leave the original branch's hoisted
+		// older versions stranded on disk. The branch must come from the queued
+		// op (captured at enqueue time inside the git hook).
+		it("uses op.branch for cleanup, not the live getCurrentBranch", async () => {
+			// Simulate: enqueued on feature/A, user has since switched to main.
+			vi.mocked(getCurrentBranch).mockResolvedValue("main");
+
+			await __test__.processQueueEntry(
+				{
+					type: "rebase-pick",
+					commitHash: "deadbeef1234567890abcdef0123456789abcdef",
+					branch: "feature/A",
+					createdAt: new Date().toISOString(),
+				} as never,
+				"/test/cwd",
+				mockStorage as never,
+				false,
+			);
+
+			expect(cleanupBranchStaleChildMarkdown).toHaveBeenCalledWith("/test/cwd", "feature/A", mockStorage);
+			expect(cleanupBranchStaleChildMarkdown).not.toHaveBeenCalledWith("/test/cwd", "main", mockStorage);
+		});
+
+		it("skips cleanup (no live-branch fallback) when op.branch is missing", async () => {
+			// Stale on-disk queue entries from before the branch-recording
+			// landed have no op.branch. The conservative choice is to skip
+			// rather than fall through to getCurrentBranch — falling through
+			// is precisely the bug we're fixing.
+			vi.mocked(getCurrentBranch).mockResolvedValue("main");
+
+			await __test__.processQueueEntry(
+				{
+					type: "rebase-pick",
+					commitHash: "feedface1234567890abcdef0123456789abcdef",
+					createdAt: new Date().toISOString(),
+				} as never,
+				"/test/cwd",
+				mockStorage as never,
+				false,
+			);
+
+			expect(cleanupBranchStaleChildMarkdown).not.toHaveBeenCalled();
 		});
 	});
 });

--- a/cli/src/hooks/QueueWorker.ts
+++ b/cli/src/hooks/QueueWorker.ts
@@ -51,7 +51,9 @@ import {
 	saveCursor,
 	savePlansRegistry,
 } from "../core/SessionTracker.js";
+import { cleanupBranchStaleChildMarkdown } from "../core/StaleChildMarkdownCleanup.js";
 import { createStorage } from "../core/StorageFactory.js";
+import type { StorageProvider } from "../core/StorageProvider.js";
 import {
 	extractTicketIdFromMessage,
 	generateSquashConsolidation,
@@ -239,7 +241,7 @@ export async function runWorker(cwd: string, force = false): Promise<void> {
 				// exit cleanly. The subsequent chain-spawn (line below) picks up leftovers.
 				if (processedCount >= MAX_ENTRIES_PER_RUN) break;
 				try {
-					await processQueueEntry(op, cwd, force);
+					await processQueueEntry(op, cwd, storage, force);
 				} catch (error: unknown) {
 					// Queue entries are deleted regardless of success or failure (fire-and-forget).
 					// Retry is intentionally not implemented: pipeline steps (transcript cursor
@@ -287,7 +289,12 @@ export async function runWorker(cwd: string, force = false): Promise<void> {
  * Processes a single queue entry based on its type.
  * Called by runWorker() for each entry in the queue.
  */
-async function processQueueEntry(op: GitOperation, cwd: string, force: boolean): Promise<void> {
+async function processQueueEntry(
+	op: GitOperation,
+	cwd: string,
+	storage: StorageProvider,
+	force: boolean,
+): Promise<void> {
 	log.info("Processing queue entry: type=%s hash=%s", op.type, op.commitHash.substring(0, 8));
 
 	switch (op.type) {
@@ -313,6 +320,34 @@ async function processQueueEntry(op: GitOperation, cwd: string, force: boolean):
 
 		default:
 			log.warn("Unknown queue entry type: %s", (op as GitOperation).type);
+	}
+
+	// Tail step: prune visible .md files for hoisted older versions
+	// (`parentCommitHash != null`) on the branch the op landed on. Reading
+	// the live branch would point at the wrong tree if the user has `git
+	// checkout`'d away between enqueue and drain, so we use op.branch (set
+	// by every hook in this version). Pre-0.99.x queue entries that lack
+	// op.branch are skipped — guessing the live branch is exactly the bug
+	// the captured field is meant to prevent. Failures MUST NOT roll back
+	// the op.
+	if (!op.branch) {
+		log.warn(
+			"Stale-child cleanup skipped for %s: queue entry has no branch field (pre-0.99.x format)",
+			op.commitHash.substring(0, 8),
+		);
+		return;
+	}
+	try {
+		const { deleted, failed } = await cleanupBranchStaleChildMarkdown(cwd, op.branch, storage);
+		if (deleted > 0 || failed > 0) {
+			log.info("Stale-child cleanup on %s: deleted=%d failed=%d", op.branch, deleted, failed);
+		}
+	} catch (err) {
+		log.warn(
+			"Stale-child cleanup tail step failed for %s: %s",
+			op.commitHash.substring(0, 8),
+			err instanceof Error ? err.message : String(err),
+		);
 	}
 }
 
@@ -1625,6 +1660,7 @@ export const __test__ = {
 	handleSquashFromQueue,
 	loadSessionTranscripts,
 	buildStoredTranscript,
+	processQueueEntry,
 };
 
 /**

--- a/cli/src/hooks/SessionStartHook.ts
+++ b/cli/src/hooks/SessionStartHook.ts
@@ -99,6 +99,11 @@ async function generateBriefing(projectDir: string): Promise<string | null> {
 		return null;
 	}
 
+	// Intentionally root-only (not leaf): aligned with `jolli view` and
+	// `jolli search`. The 2026-05-12 leaf-only-memory-display redesign flipped
+	// the VS Code display surfaces (Timeline, Memory Bank tree, Branch tab) to
+	// leaves; this session-briefing path stays on root semantics until a
+	// follow-up explicitly verifies its tests + UX under the leaf model.
 	const rootEntries = index.entries.filter(
 		(e) => e.branch === branch && (e.parentCommitHash === null || e.parentCommitHash === undefined),
 	);

--- a/docs/superpowers/plans/2026-05-12-leaf-only-memory-display.md
+++ b/docs/superpowers/plans/2026-05-12-leaf-only-memory-display.md
@@ -1,0 +1,1586 @@
+# Leaf-Only Memory Display Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Align Memory Bank tree, Timeline / KB Memories, and Branch tab Memories on showing only the leaf of each `(repo, branch)` amend chain. Visible `<branch>/<slug>-<hash8>.md` files for non-leaves are cleaned up; orphan branch + `<repo>/.jolli/` JSON archive stay untouched.
+
+**Architecture:** A single `ChainLeafFilter` helper computes per-`(repoName, branch)` chain leaves from index entries. Two consumers call it: read-path filters in `JolliMemoryBridge` (Timeline + foreign Branch tab) and a shared `LeafMarkdownCleanup` helper that drives both a one-shot startup `MigrationEngine` v2 step and a per-op `QueueWorker` tail step. `FolderStorage.deleteVisibleMarkdown` performs the narrow disk delete, propagated through `DualWriteStorage`.
+
+**Tech Stack:** TypeScript (CLI Node 22.5+ ESM, VS Code esbuild→CJS); Vitest; existing `StorageProvider` interface; `MetadataManager` for migration state.
+
+**Reference:** [docs/superpowers/specs/2026-05-12-leaf-only-memory-display-design.md](../specs/2026-05-12-leaf-only-memory-display-design.md)
+
+**Branch:** `fix-change-other-repo-memory` (existing work continues here)
+
+---
+
+## Preflight (do once before Task 1)
+
+This branch currently carries uncommitted Sidebar work from an earlier session — the leaf-only PR is **separate**. Either commit those changes on a side branch first, or stash them so the working tree is clean before Task 1's commits start landing on `fix-change-other-repo-memory`. Verify:
+
+```bash
+git status --short
+# Expected: only docs/ (current spec/plan files) — no other dirty paths.
+```
+
+If `vscode/src/views/SidebarScriptBuilder.ts` (or its test) is dirty, stash:
+
+```bash
+git stash push -m "pre-leaf-only sidebar work" vscode/src/views/SidebarScriptBuilder.ts vscode/src/views/SidebarScriptBuilder.test.ts
+```
+
+(Recover later with `git stash pop` — done out-of-band, not part of this plan.)
+
+---
+
+## Task 1: `ChainLeafFilter` — pure helper for chain-leaf computation
+
+**Files:**
+- Create: `cli/src/core/ChainLeafFilter.ts`
+- Create: `cli/src/core/ChainLeafFilter.test.ts`
+
+This is the single source of truth for "given a flat list of `SummaryIndexEntry`s, which `commitHash`es are leaves of their `(repoName, branch)`-scoped chain?" Both bridge read paths and disk cleanup call this.
+
+- [ ] **Step 1: Write the failing test file**
+
+Create `cli/src/core/ChainLeafFilter.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import { filterToBranchLeaves, getBranchLeaves } from "./ChainLeafFilter.js";
+import type { SummaryIndexEntry } from "../Types.js";
+
+function e(
+	commitHash: string,
+	branch: string,
+	parent: string | null | undefined,
+	repoName?: string,
+): SummaryIndexEntry {
+	return {
+		commitHash,
+		parentCommitHash: parent,
+		commitMessage: commitHash,
+		commitDate: "2026-05-12T00:00:00Z",
+		branch,
+		generatedAt: "2026-05-12T00:00:00Z",
+		...(repoName !== undefined ? { repoName } : {}),
+	};
+}
+
+describe("ChainLeafFilter", () => {
+	describe("getBranchLeaves", () => {
+		it("returns empty set for empty input", () => {
+			expect(getBranchLeaves([])).toEqual(new Set());
+		});
+
+		it("returns the single entry when there's only one", () => {
+			expect(getBranchLeaves([e("a", "main", null)])).toEqual(new Set(["a"]));
+		});
+
+		it("collapses a linear chain to its leaf", () => {
+			// a (root) → b → c (leaf)
+			const leaves = getBranchLeaves([
+				e("a", "main", null),
+				e("b", "main", "a"),
+				e("c", "main", "b"),
+			]);
+			expect(leaves).toEqual(new Set(["c"]));
+		});
+
+		it("keeps parallel chains on the same branch each as a separate leaf", () => {
+			// chain 1: a → b ;  chain 2: x → y
+			const leaves = getBranchLeaves([
+				e("a", "main", null),
+				e("b", "main", "a"),
+				e("x", "main", null),
+				e("y", "main", "x"),
+			]);
+			expect(leaves).toEqual(new Set(["b", "y"]));
+		});
+
+		it("scopes leaf judgement by branch — rebase-pick keeps each branch's tip", () => {
+			// branch X: a (leaf) ;  branch Y: a' parent = a (cross-branch parent ignored)
+			const leaves = getBranchLeaves([
+				e("a", "feature-x", null),
+				e("aprime", "feature-y", "a"),
+			]);
+			// `a` is leaf on X (no entry on X parents it); `aprime` is leaf on Y.
+			expect(leaves).toEqual(new Set(["a", "aprime"]));
+		});
+
+		it("scopes leaf judgement by repoName — same branch name in two repos stays isolated", () => {
+			const leaves = getBranchLeaves([
+				e("a", "main", null, "repoA"),
+				e("b", "main", "a", "repoA"),
+				e("x", "main", null, "repoB"),
+				e("y", "main", "x", "repoB"),
+			]);
+			expect(leaves).toEqual(new Set(["b", "y"]));
+		});
+
+		it("treats undefined parentCommitHash (legacy v1) as root, still a leaf if no descendant", () => {
+			const leaves = getBranchLeaves([e("a", "main", undefined)]);
+			expect(leaves).toEqual(new Set(["a"]));
+		});
+
+		it("treats a dangling parent pointer as a regular root in scope", () => {
+			// b's parent 'a' is not in the list. b is a root in scope; still leaf if nothing parents it.
+			expect(getBranchLeaves([e("b", "main", "a")])).toEqual(new Set(["b"]));
+		});
+
+		it("collapses a 2-cycle (a↔b) to zero leaves", () => {
+			// Malicious / corrupted index. Documented behavior: both members parent
+			// each other in scope, so neither is a leaf.
+			const leaves = getBranchLeaves([
+				e("a", "main", "b"),
+				e("b", "main", "a"),
+			]);
+			expect(leaves).toEqual(new Set());
+		});
+	});
+
+	describe("filterToBranchLeaves", () => {
+		it("returns entries whose commitHash is a leaf", () => {
+			const root = e("a", "main", null);
+			const leaf = e("b", "main", "a");
+			expect(filterToBranchLeaves([root, leaf])).toEqual([leaf]);
+		});
+
+		it("preserves input order among the leaves", () => {
+			const leaf1 = e("b", "main", "a");
+			const root = e("a", "main", null);
+			const leaf2 = e("y", "main", "x");
+			const root2 = e("x", "main", null);
+			expect(
+				filterToBranchLeaves([leaf1, root, leaf2, root2]).map((x) => x.commitHash),
+			).toEqual(["b", "y"]);
+		});
+	});
+});
+```
+
+- [ ] **Step 2: Run test, verify it fails (module not found)**
+
+```bash
+npm run test -w @jolli.ai/cli -- src/core/ChainLeafFilter.test.ts
+```
+Expected: FAIL — `Failed to resolve import "./ChainLeafFilter.js"`.
+
+- [ ] **Step 3: Create the implementation**
+
+Create `cli/src/core/ChainLeafFilter.ts`:
+
+```ts
+/**
+ * ChainLeafFilter — single source of truth for "which entries are chain leaves?".
+ *
+ * Scope: a leaf is judged within a single `(repoName, branch)` group.
+ * - Cross-branch parent links (rebase-pick X→Y) do NOT demote `c1` on X.
+ * - Cross-repo parent links (rare, structurally not produced today) similarly
+ *   do not cross repo boundaries — same-named branches in two repos stay
+ *   independent.
+ *
+ * Cycle safety: an index where two entries in the same scope parent each
+ * other (`a→b, b→a`) collapses to zero leaves — neither is a leaf because
+ * the other parents it. Bad data hides itself rather than crashing the
+ * renderer. Documented; no exception is thrown.
+ *
+ * Legacy v1 entries have `parentCommitHash === undefined`; treated as
+ * roots (no parent claim), still leaf-eligible if no descendant points at
+ * them in scope.
+ */
+
+import type { SummaryIndexEntry } from "../Types.js";
+
+const SCOPE_SEP = "\0";
+
+function scopeKey(e: Pick<SummaryIndexEntry, "repoName" | "branch">): string {
+	return `${e.repoName ?? ""}${SCOPE_SEP}${e.branch}`;
+}
+
+/** Returns the set of commitHashes that are leaves of their `(repoName, branch)`-scoped chain. */
+export function getBranchLeaves(
+	entries: Iterable<SummaryIndexEntry>,
+): Set<string> {
+	const all: SummaryIndexEntry[] = [];
+	const parentedByScope = new Map<string, Set<string>>();
+
+	for (const entry of entries) {
+		all.push(entry);
+		const parent = entry.parentCommitHash;
+		if (parent != null) {
+			const key = scopeKey(entry);
+			let bucket = parentedByScope.get(key);
+			if (!bucket) {
+				bucket = new Set();
+				parentedByScope.set(key, bucket);
+			}
+			bucket.add(parent);
+		}
+	}
+
+	const leaves = new Set<string>();
+	for (const entry of all) {
+		const parented = parentedByScope.get(scopeKey(entry));
+		if (!parented || !parented.has(entry.commitHash)) {
+			leaves.add(entry.commitHash);
+		}
+	}
+	return leaves;
+}
+
+/** Convenience: returns only the entries whose commitHash is a branch leaf. Preserves input order. */
+export function filterToBranchLeaves<T extends SummaryIndexEntry>(
+	entries: Iterable<T>,
+): T[] {
+	const buffered: T[] = [];
+	for (const e of entries) buffered.push(e);
+	const leaves = getBranchLeaves(buffered);
+	return buffered.filter((e) => leaves.has(e.commitHash));
+}
+```
+
+- [ ] **Step 4: Run test, verify all pass**
+
+```bash
+npm run test -w @jolli.ai/cli -- src/core/ChainLeafFilter.test.ts
+```
+Expected: PASS (10 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cli/src/core/ChainLeafFilter.ts cli/src/core/ChainLeafFilter.test.ts
+git commit -s -m "Add ChainLeafFilter: per-(repo, branch) leaf computation
+
+Single source of truth used by both display read-path filters and disk
+cleanup. Cycle-safe (a↔b collapses to zero leaves) and tolerates
+dangling-parent + legacy-v1 (undefined parent) entries."
+```
+
+---
+
+## Task 2: `StorageProvider.deleteVisibleMarkdown` — narrow interface + FolderStorage impl
+
+**Files:**
+- Modify: `cli/src/core/StorageProvider.ts`
+- Modify: `cli/src/core/FolderStorage.ts`
+- Modify: `cli/src/core/FolderStorage.test.ts`
+
+Adds an optional interface method (orphan storage has no visible md, so it stays unimplemented), and a real implementation on `FolderStorage` that deletes ONLY the visible `<branch>/<slug>-<hash8>.md` file. `.jolli/summaries/<hash>.json` and `.jolli/index.json` are untouched.
+
+- [ ] **Step 1: Write failing test for `FolderStorage.deleteVisibleMarkdown`**
+
+Append to `cli/src/core/FolderStorage.test.ts` (inside the `describe("FolderStorage", …)` block, after the existing `describe("amend/squash cleanup of superseded MDs", …)` block):
+
+```ts
+	describe("deleteVisibleMarkdown", () => {
+		beforeEach(async () => {
+			await storage.ensure();
+		});
+
+		it("deletes the visible md file and leaves .jolli/ untouched", async () => {
+			const summaryJson = makeSummaryJson({
+				commitHash: "deadbeef12345678",
+				commitMessage: "Add login",
+				branch: "feature/login",
+			});
+			await storage.writeFiles(
+				[{ path: "summaries/deadbeef12345678.json", content: summaryJson }],
+				"seed",
+			);
+
+			const visiblePath = join(rootPath, "feature/login", "add-login-deadbeef.md");
+			expect(existsSync(visiblePath)).toBe(true);
+
+			await storage.deleteVisibleMarkdown({
+				commitHash: "deadbeef12345678",
+				commitMessage: "Add login",
+				commitDate: "2026-01-15T10:00:00Z",
+				branch: "feature/login",
+				generatedAt: "2026-01-15T10:00:00Z",
+				parentCommitHash: null,
+			});
+
+			expect(existsSync(visiblePath)).toBe(false);
+			// Hidden JSON intact.
+			expect(
+				existsSync(join(rootPath, ".jolli", "summaries", "deadbeef12345678.json")),
+			).toBe(true);
+		});
+
+		it("is idempotent on a missing file (no throw)", async () => {
+			await expect(
+				storage.deleteVisibleMarkdown({
+					commitHash: "ffffffffffffffff",
+					commitMessage: "ghost",
+					commitDate: "2026-01-15T10:00:00Z",
+					branch: "ghost-branch",
+					generatedAt: "2026-01-15T10:00:00Z",
+					parentCommitHash: null,
+				}),
+			).resolves.toBeUndefined();
+		});
+
+		it("leaves the <branch>/ directory in place after the last md is removed", async () => {
+			const summaryJson = makeSummaryJson({
+				commitHash: "aaaa11112222bbbb",
+				commitMessage: "Solo entry",
+				branch: "lone-branch",
+			});
+			await storage.writeFiles(
+				[{ path: "summaries/aaaa11112222bbbb.json", content: summaryJson }],
+				"seed",
+			);
+
+			await storage.deleteVisibleMarkdown({
+				commitHash: "aaaa11112222bbbb",
+				commitMessage: "Solo entry",
+				commitDate: "2026-01-15T10:00:00Z",
+				branch: "lone-branch",
+				generatedAt: "2026-01-15T10:00:00Z",
+				parentCommitHash: null,
+			});
+
+			expect(existsSync(join(rootPath, "lone-branch"))).toBe(true);
+		});
+	});
+```
+
+- [ ] **Step 2: Run test, verify failure**
+
+```bash
+npm run test -w @jolli.ai/cli -- src/core/FolderStorage.test.ts -t "deleteVisibleMarkdown"
+```
+Expected: FAIL — `storage.deleteVisibleMarkdown is not a function`.
+
+- [ ] **Step 3: Extend `StorageProvider` interface**
+
+Edit `cli/src/core/StorageProvider.ts` — add this method after the existing methods, before the closing `}`:
+
+```ts
+	/**
+	 * Remove the user-visible Markdown copy for a single summary entry.
+	 * Does NOT touch .jolli/summaries/<hash>.json, .jolli/index.json, or any
+	 * orphan-branch state. Idempotent: a missing file is not an error.
+	 *
+	 * Optional: implemented by FolderStorage and delegated by DualWriteStorage.
+	 * OrphanBranchStorage does not implement it (no visible layer).
+	 */
+	deleteVisibleMarkdown?(entry: SummaryIndexEntry): Promise<void>;
+```
+
+And add the import at the top of `StorageProvider.ts`:
+
+```ts
+import type { FileWrite, SummaryIndexEntry } from "../Types.js";
+```
+
+(Replacing the existing `import type { FileWrite } from "../Types.js";` line.)
+
+- [ ] **Step 4: Implement on `FolderStorage`**
+
+Edit `cli/src/core/FolderStorage.ts`. Add to the imports at the top — `SummaryIndexEntry` to the `../Types.js` import line (it already imports `FileWrite` / `CommitSummary` etc.; add `SummaryIndexEntry` to the list).
+
+Then add the method body inside the `FolderStorage` class. A good spot is right after `clearDirty()` / `isDirty()`, before the `// ── Markdown generation ───` divider (around line 114). Insert:
+
+```ts
+	/**
+	 * Remove ONLY the visible <branch>/<slug>-<hash8>.md file for this entry.
+	 * Leaves .jolli/summaries/<hash>.json, .jolli/index.json, manifest entry,
+	 * and the <branch>/ directory itself in place. Idempotent on a missing
+	 * file. See StorageProvider.deleteVisibleMarkdown for the contract.
+	 */
+	async deleteVisibleMarkdown(entry: SummaryIndexEntry): Promise<void> {
+		const branchFolder = this.metadataManager.resolveFolderForBranch(entry.branch);
+		const slug = FolderStorage.slugify(entry.commitMessage);
+		const hash8 = entry.commitHash.substring(0, 8);
+		const relativePath = `${branchFolder}/${slug}-${hash8}.md`;
+		const absPath = join(this.rootPath, relativePath);
+		if (!existsSync(absPath)) return;
+		try {
+			unlinkSync(absPath);
+			log.info("Deleted visible MD (leaf cleanup): %s", relativePath);
+		} catch (err) {
+			// EEXIST race with concurrent writer is the only realistic non-fatal
+			// failure; surface anything else so callers can record dirty state.
+			const code = (err as NodeJS.ErrnoException).code;
+			if (code === "ENOENT") return;
+			throw err;
+		}
+	}
+```
+
+- [ ] **Step 5: Run tests, verify all pass**
+
+```bash
+npm run test -w @jolli.ai/cli -- src/core/FolderStorage.test.ts
+```
+Expected: PASS (existing + 3 new tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add cli/src/core/StorageProvider.ts cli/src/core/FolderStorage.ts cli/src/core/FolderStorage.test.ts
+git commit -s -m "Add FolderStorage.deleteVisibleMarkdown — visible-md-only delete
+
+Narrow, idempotent API used by the upcoming leaf-cleanup paths. Touches
+nothing under .jolli/ and leaves the <branch>/ directory in place after
+removing its last md file (avoids ENOENT race with the next writer)."
+```
+
+---
+
+## Task 3: `DualWriteStorage` — delegate `deleteVisibleMarkdown` to the folder side
+
+**Files:**
+- Modify: `cli/src/core/DualWriteStorage.ts`
+- Modify: `cli/src/core/DualWriteStorage.test.ts`
+
+`DualWriteStorage` wraps two providers (orphan primary + folder shadow). It must forward `deleteVisibleMarkdown` to the folder side and swallow any failure into the existing dirty-mark mechanism.
+
+- [ ] **Step 1: Write failing test**
+
+Open `cli/src/core/DualWriteStorage.test.ts` and append a new `describe` block at the end (inside the outer `describe("DualWriteStorage", …)`):
+
+```ts
+	describe("deleteVisibleMarkdown delegation", () => {
+		it("delegates to the folder-side provider", async () => {
+			const folderDelete = vi.fn().mockResolvedValue(undefined);
+			const orphan = makeMockStorage();
+			const folder = { ...makeMockStorage(), deleteVisibleMarkdown: folderDelete };
+			const dual = new DualWriteStorage(orphan, folder);
+			const entry = {
+				commitHash: "deadbeef",
+				parentCommitHash: null,
+				commitMessage: "Add login",
+				commitDate: "2026-05-12T00:00:00Z",
+				branch: "main",
+				generatedAt: "2026-05-12T00:00:00Z",
+			};
+			await dual.deleteVisibleMarkdown(entry);
+			expect(folderDelete).toHaveBeenCalledWith(entry);
+		});
+
+		it("is a no-op when the folder side lacks the method", async () => {
+			const orphan = makeMockStorage();
+			const folder = makeMockStorage(); // no deleteVisibleMarkdown
+			const dual = new DualWriteStorage(orphan, folder);
+			await expect(
+				dual.deleteVisibleMarkdown({
+					commitHash: "deadbeef",
+					parentCommitHash: null,
+					commitMessage: "x",
+					commitDate: "2026-05-12T00:00:00Z",
+					branch: "main",
+					generatedAt: "2026-05-12T00:00:00Z",
+				}),
+			).resolves.toBeUndefined();
+		});
+
+		it("marks dirty when the folder side throws", async () => {
+			const folderDelete = vi
+				.fn()
+				.mockRejectedValue(new Error("disk gone"));
+			const markDirty = vi.fn();
+			const orphan = makeMockStorage();
+			const folder = {
+				...makeMockStorage(),
+				deleteVisibleMarkdown: folderDelete,
+				markDirty,
+			};
+			const dual = new DualWriteStorage(orphan, folder);
+			await dual.deleteVisibleMarkdown({
+				commitHash: "deadbeef",
+				parentCommitHash: null,
+				commitMessage: "x",
+				commitDate: "2026-05-12T00:00:00Z",
+				branch: "main",
+				generatedAt: "2026-05-12T00:00:00Z",
+			});
+			expect(markDirty).toHaveBeenCalled();
+		});
+	});
+```
+
+If `makeMockStorage` does not exist in the test file's helpers, scan the file for the existing factory and use whatever shape the prior tests use (typically `{ readFile, writeFiles, listFiles, exists, ensure }` stubs). If absent, define inline at the top of the new block.
+
+- [ ] **Step 2: Run test, verify failure**
+
+```bash
+npm run test -w @jolli.ai/cli -- src/core/DualWriteStorage.test.ts -t "deleteVisibleMarkdown delegation"
+```
+Expected: FAIL — method missing on `DualWriteStorage`.
+
+- [ ] **Step 3: Implement delegation**
+
+Edit `cli/src/core/DualWriteStorage.ts`. Add the method inside the class (a good spot is right after the existing `writeFiles` so the read-then-write methods stay grouped):
+
+```ts
+	async deleteVisibleMarkdown(entry: SummaryIndexEntry): Promise<void> {
+		if (!this.shadow.deleteVisibleMarkdown) return;
+		try {
+			await this.shadow.deleteVisibleMarkdown(entry);
+		} catch (err) {
+			log.warn(
+				"Shadow deleteVisibleMarkdown failed for %s: %s",
+				entry.commitHash.substring(0, 8),
+				err instanceof Error ? err.message : String(err),
+			);
+			this.shadow.markDirty?.(`deleteVisibleMarkdown ${entry.commitHash.substring(0, 8)}`);
+		}
+	}
+```
+
+Then add `SummaryIndexEntry` to the `../Types.js` import line at the top.
+
+- [ ] **Step 4: Run test, verify all pass**
+
+```bash
+npm run test -w @jolli.ai/cli -- src/core/DualWriteStorage.test.ts
+```
+Expected: PASS (existing + 3 new).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cli/src/core/DualWriteStorage.ts cli/src/core/DualWriteStorage.test.ts
+git commit -s -m "Delegate DualWriteStorage.deleteVisibleMarkdown to folder side
+
+Orphan side has no visible layer, so the call routes only to the
+folder-side provider. Failures get swallowed into markDirty (matches the
+write-side dirty-mark contract); orphan reads stay authoritative."
+```
+
+---
+
+## Task 4: `LeafMarkdownCleanup` — shared cleanup helper (Migration + Worker callers)
+
+**Files:**
+- Create: `cli/src/core/LeafMarkdownCleanup.ts`
+- Create: `cli/src/core/LeafMarkdownCleanup.test.ts`
+
+One module called both by `MigrationEngine` (one-shot over every branch) and `QueueWorker` (per-op over the active branch). Reads the index via the existing `getIndexEntryMap`, computes leaves via `ChainLeafFilter`, deletes via `storage.deleteVisibleMarkdown`.
+
+- [ ] **Step 1: Write failing test**
+
+Create `cli/src/core/LeafMarkdownCleanup.test.ts`:
+
+```ts
+import { describe, expect, it, vi } from "vitest";
+import {
+	cleanupAllBranchesLeafMarkdown,
+	cleanupBranchLeafMarkdown,
+} from "./LeafMarkdownCleanup.js";
+import type { StorageProvider } from "./StorageProvider.js";
+import type { SummaryIndexEntry } from "../Types.js";
+
+vi.mock("./SummaryStore.js", async (orig) => {
+	const real = (await orig()) as Record<string, unknown>;
+	return { ...real, getIndexEntryMap: vi.fn() };
+});
+
+const { getIndexEntryMap } = await import("./SummaryStore.js");
+
+function e(
+	commitHash: string,
+	branch: string,
+	parent: string | null,
+): SummaryIndexEntry {
+	return {
+		commitHash,
+		parentCommitHash: parent,
+		commitMessage: `msg-${commitHash}`,
+		commitDate: "2026-05-12T00:00:00Z",
+		branch,
+		generatedAt: "2026-05-12T00:00:00Z",
+	};
+}
+
+function makeStorage(): StorageProvider & {
+	readonly deletions: SummaryIndexEntry[];
+} {
+	const deletions: SummaryIndexEntry[] = [];
+	return {
+		readFile: vi.fn(),
+		writeFiles: vi.fn(),
+		listFiles: vi.fn(),
+		exists: vi.fn(),
+		ensure: vi.fn(),
+		deleteVisibleMarkdown: async (entry) => {
+			deletions.push(entry);
+		},
+		deletions,
+	};
+}
+
+describe("LeafMarkdownCleanup", () => {
+	describe("cleanupBranchLeafMarkdown", () => {
+		it("deletes non-leaves on the named branch", async () => {
+			(getIndexEntryMap as ReturnType<typeof vi.fn>).mockResolvedValue(
+				new Map<string, SummaryIndexEntry>([
+					["a", e("a", "main", null)],
+					["b", e("b", "main", "a")],
+					["c", e("c", "main", "b")],
+				]),
+			);
+			const storage = makeStorage();
+			const result = await cleanupBranchLeafMarkdown(
+				"/cwd",
+				"main",
+				storage,
+			);
+			expect(result.deleted).toBe(2);
+			expect(storage.deletions.map((d) => d.commitHash).sort()).toEqual([
+				"a",
+				"b",
+			]);
+		});
+
+		it("does not touch entries on other branches", async () => {
+			(getIndexEntryMap as ReturnType<typeof vi.fn>).mockResolvedValue(
+				new Map<string, SummaryIndexEntry>([
+					["a", e("a", "main", null)],
+					["b", e("b", "main", "a")],
+					["x", e("x", "feature", null)],
+					["y", e("y", "feature", "x")],
+				]),
+			);
+			const storage = makeStorage();
+			await cleanupBranchLeafMarkdown("/cwd", "main", storage);
+			// Only main's non-leaf (a) deleted; feature's non-leaf (x) untouched.
+			expect(storage.deletions.map((d) => d.commitHash)).toEqual(["a"]);
+		});
+
+		it("is a no-op when storage lacks deleteVisibleMarkdown", async () => {
+			(getIndexEntryMap as ReturnType<typeof vi.fn>).mockResolvedValue(
+				new Map<string, SummaryIndexEntry>([
+					["a", e("a", "main", null)],
+					["b", e("b", "main", "a")],
+				]),
+			);
+			const storage = {
+				readFile: vi.fn(),
+				writeFiles: vi.fn(),
+				listFiles: vi.fn(),
+				exists: vi.fn(),
+				ensure: vi.fn(),
+			} satisfies StorageProvider;
+			const result = await cleanupBranchLeafMarkdown(
+				"/cwd",
+				"main",
+				storage,
+			);
+			expect(result.deleted).toBe(0);
+		});
+	});
+
+	describe("cleanupAllBranchesLeafMarkdown", () => {
+		it("walks every branch in the index and deletes their non-leaves", async () => {
+			(getIndexEntryMap as ReturnType<typeof vi.fn>).mockResolvedValue(
+				new Map<string, SummaryIndexEntry>([
+					["a", e("a", "main", null)],
+					["b", e("b", "main", "a")],
+					["x", e("x", "feature", null)],
+					["y", e("y", "feature", "x")],
+				]),
+			);
+			const storage = makeStorage();
+			const result = await cleanupAllBranchesLeafMarkdown(
+				"/cwd",
+				storage,
+			);
+			expect(result.deleted).toBe(2);
+			expect(storage.deletions.map((d) => d.commitHash).sort()).toEqual([
+				"a",
+				"x",
+			]);
+		});
+	});
+});
+```
+
+- [ ] **Step 2: Run test, verify failure**
+
+```bash
+npm run test -w @jolli.ai/cli -- src/core/LeafMarkdownCleanup.test.ts
+```
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement**
+
+Create `cli/src/core/LeafMarkdownCleanup.ts`:
+
+```ts
+/**
+ * LeafMarkdownCleanup — shared helper for "delete non-leaf visible .md files".
+ *
+ * Two entry points:
+ *   - cleanupBranchLeafMarkdown(cwd, branch, storage): scoped to one branch
+ *     of the active repo. Called by QueueWorker at the tail of every op so
+ *     the disk invariant is restored after amend / rebase / squash.
+ *   - cleanupAllBranchesLeafMarkdown(cwd, storage): walks every branch in
+ *     the index. Called by MigrationEngine's v2 step at startup to drain
+ *     any backlog accumulated before this code shipped.
+ *
+ * Reads from index via getIndexEntryMap. Computes leaves via ChainLeafFilter.
+ * Deletes via storage.deleteVisibleMarkdown (optional method; no-op when
+ * the storage backend has no visible layer, e.g. OrphanBranchStorage).
+ */
+
+import { createLogger } from "../Logger.js";
+import { getBranchLeaves } from "./ChainLeafFilter.js";
+import type { StorageProvider } from "./StorageProvider.js";
+import { getIndexEntryMap } from "./SummaryStore.js";
+
+const log = createLogger("LeafMarkdownCleanup");
+
+export interface CleanupResult {
+	readonly deleted: number;
+	readonly failed: number;
+}
+
+/** Delete non-leaf visible .md files on a single branch. */
+export async function cleanupBranchLeafMarkdown(
+	cwd: string | undefined,
+	branch: string,
+	storage: StorageProvider,
+): Promise<CleanupResult> {
+	if (!storage.deleteVisibleMarkdown) {
+		return { deleted: 0, failed: 0 };
+	}
+	const map = await getIndexEntryMap(cwd, storage);
+	const branchEntries = [...map.values()].filter((e) => e.branch === branch);
+	const leaves = getBranchLeaves(branchEntries);
+
+	let deleted = 0;
+	let failed = 0;
+	for (const entry of branchEntries) {
+		if (leaves.has(entry.commitHash)) continue;
+		try {
+			await storage.deleteVisibleMarkdown(entry);
+			deleted++;
+		} catch (err) {
+			failed++;
+			log.warn(
+				"deleteVisibleMarkdown failed for %s on %s: %s",
+				entry.commitHash.substring(0, 8),
+				branch,
+				err instanceof Error ? err.message : String(err),
+			);
+		}
+	}
+	return { deleted, failed };
+}
+
+/** Delete non-leaf visible .md files across every branch in the index. */
+export async function cleanupAllBranchesLeafMarkdown(
+	cwd: string | undefined,
+	storage: StorageProvider,
+): Promise<CleanupResult> {
+	if (!storage.deleteVisibleMarkdown) {
+		return { deleted: 0, failed: 0 };
+	}
+	const map = await getIndexEntryMap(cwd, storage);
+	const allEntries = [...map.values()];
+	const leaves = getBranchLeaves(allEntries);
+
+	let deleted = 0;
+	let failed = 0;
+	for (const entry of allEntries) {
+		if (leaves.has(entry.commitHash)) continue;
+		try {
+			await storage.deleteVisibleMarkdown(entry);
+			deleted++;
+		} catch (err) {
+			failed++;
+			log.warn(
+				"deleteVisibleMarkdown failed for %s on %s: %s",
+				entry.commitHash.substring(0, 8),
+				entry.branch,
+				err instanceof Error ? err.message : String(err),
+			);
+		}
+	}
+	return { deleted, failed };
+}
+```
+
+- [ ] **Step 4: Run test, verify pass**
+
+```bash
+npm run test -w @jolli.ai/cli -- src/core/LeafMarkdownCleanup.test.ts
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cli/src/core/LeafMarkdownCleanup.ts cli/src/core/LeafMarkdownCleanup.test.ts
+git commit -s -m "Add LeafMarkdownCleanup helper (Migration + Worker share)
+
+cleanupBranchLeafMarkdown(cwd, branch, storage) for per-op cleanup;
+cleanupAllBranchesLeafMarkdown(cwd, storage) for the one-shot migration
+sweep. Both no-op cleanly when storage has no visible layer."
+```
+
+---
+
+## Task 5: Bridge filter — `listSummaryEntries` switches to leaf semantics
+
+**Files:**
+- Modify: `vscode/src/JolliMemoryBridge.ts`
+- Modify: `vscode/src/JolliMemoryBridge.test.ts`
+
+Replace the existing `parentCommitHash != null` rejection with `filterToBranchLeaves`. Dedup-by-commitHash for cross-repo aliasing stays. Existing tests will FAIL because the old behavior asserted "shows roots" — they need updating to the new "shows leaves" semantics.
+
+- [ ] **Step 1: Update the existing test that asserts old behavior**
+
+Edit `vscode/src/JolliMemoryBridge.test.ts`. Find the test `it("filters out entries with parentCommitHash", …)` near line 3126 and replace its whole `it(...)` block with:
+
+```ts
+		it("filters chain non-leaves out, surfacing the leaf instead", async () => {
+			const root = makeEntry("aaa", "2025-01-01T00:00:00Z", "root", "main");
+			const leaf = makeEntry(
+				"bbb",
+				"2025-01-02T00:00:00Z",
+				"child",
+				"main",
+				"aaa",
+			);
+			getIndexEntryMap.mockResolvedValue(
+				new Map([
+					["aaa", root],
+					["bbb", leaf],
+				]),
+			);
+
+			const bridge = makeBridge();
+			const result = await bridge.listSummaryEntries(10);
+
+			// New semantics: leaves only. `bbb` is the leaf of chain aaa→bbb.
+			expect(result.entries).toHaveLength(1);
+			expect(result.entries[0].commitHash).toBe("bbb");
+		});
+
+		it("treats each branch as independent — rebase-pick keeps both branches' tips", async () => {
+			const xOnly = makeEntry(
+				"aaa",
+				"2025-01-01T00:00:00Z",
+				"X tip",
+				"feature-x",
+			);
+			const yChild = makeEntry(
+				"bbb",
+				"2025-01-02T00:00:00Z",
+				"Y child of X",
+				"feature-y",
+				"aaa",
+			);
+			getIndexEntryMap.mockResolvedValue(
+				new Map([
+					["aaa", xOnly],
+					["bbb", yChild],
+				]),
+			);
+
+			const bridge = makeBridge();
+			const result = await bridge.listSummaryEntries(10);
+
+			// `aaa` still leaf on feature-x; `bbb` leaf on feature-y.
+			expect(result.entries.map((e) => e.commitHash).sort()).toEqual([
+				"aaa",
+				"bbb",
+			]);
+		});
+
+		it("returns the leaf even when its chain root was removed from the index (dangling parent)", async () => {
+			// Only the descendant remains; parent 'aaa' is gone.
+			const leaf = makeEntry(
+				"bbb",
+				"2025-01-02T00:00:00Z",
+				"orphan child",
+				"main",
+				"aaa",
+			);
+			getIndexEntryMap.mockResolvedValue(new Map([["bbb", leaf]]));
+
+			const bridge = makeBridge();
+			const result = await bridge.listSummaryEntries(10);
+			expect(result.entries).toHaveLength(1);
+			expect(result.entries[0].commitHash).toBe("bbb");
+		});
+```
+
+- [ ] **Step 2: Run tests, verify the new ones fail and any old-behavior assertions also fail**
+
+```bash
+npm run test:vscode -- src/JolliMemoryBridge.test.ts -t "listSummaryEntries"
+```
+Expected: FAIL — "filters chain non-leaves out" expects `bbb`, current code returns `aaa`.
+
+- [ ] **Step 3: Replace the filter in `listSummaryEntries`**
+
+Edit `vscode/src/JolliMemoryBridge.ts`. At the top of the file, add to the existing import block from `cli`:
+
+```ts
+import { filterToBranchLeaves } from "../../cli/src/core/ChainLeafFilter.js";
+```
+
+(Place it next to the other `cli/src/core/*` imports; the existing pattern uses these relative paths because the VS Code esbuild bundle inlines them — see CLAUDE.md.)
+
+Find the block inside `listSummaryEntries` that currently reads (around the `cachedRootEntries` assignment, near line 1397):
+
+```ts
+			const seen = new Set<string>();
+			this.cachedRootEntries = merged
+				.filter((e) => {
+					if (e.parentCommitHash != null || seen.has(e.commitHash)) {
+						return false;
+					}
+					seen.add(e.commitHash);
+					return true;
+				})
+				.sort(
+					(a, b) =>
+						Date.parse(getDisplayDate(b)) - Date.parse(getDisplayDate(a)),
+				);
+```
+
+Replace with:
+
+```ts
+			// Leaf filter is the headline behavior: collapses each (repoName, branch)
+			// chain to its tip rather than its root. The trailing dedup is a
+			// separate concern — same commit can appear under two repos via
+			// tree-hash aliasing, and the current-repo copy wins (it was pushed to
+			// `merged` first in step 1).
+			const seen = new Set<string>();
+			const leaves = filterToBranchLeaves(merged);
+			this.cachedRootEntries = leaves
+				.filter((e) => {
+					if (seen.has(e.commitHash)) return false;
+					seen.add(e.commitHash);
+					return true;
+				})
+				.sort(
+					(a, b) =>
+						Date.parse(getDisplayDate(b)) - Date.parse(getDisplayDate(a)),
+				);
+```
+
+- [ ] **Step 4: Run tests, verify all pass**
+
+```bash
+npm run test:vscode -- src/JolliMemoryBridge.test.ts -t "listSummaryEntries"
+```
+Expected: PASS.
+
+Also run the whole bridge file to catch downstream test impact:
+
+```bash
+npm run test:vscode -- src/JolliMemoryBridge.test.ts
+```
+Expected: PASS. If other tests reference the old behavior, update them to expect leaves (same renaming pattern as Step 1).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add vscode/src/JolliMemoryBridge.ts vscode/src/JolliMemoryBridge.test.ts
+git commit -s -m "listSummaryEntries: filter chains to leaves, not roots
+
+Timeline / KB Memories list now shows the current tip of each
+(repoName, branch) chain instead of the original commit. Cross-repo
+dedup by commitHash stays; tests updated to assert the new semantics."
+```
+
+---
+
+## Task 6: Bridge filter — `listBranchMemories` adds leaf filter (foreign view)
+
+**Files:**
+- Modify: `vscode/src/JolliMemoryBridge.ts`
+- Modify: `vscode/src/JolliMemoryBridge.test.ts`
+
+`listBranchMemories` currently returns every entry on the branch (no filter). The foreign Branch tab needs leaf-only too.
+
+- [ ] **Step 1: Write failing test**
+
+Find the existing `describe("listBranchMemories", …)` in `vscode/src/JolliMemoryBridge.test.ts`. (If none, search for the method by name to find where to insert.) Add inside it:
+
+```ts
+		it("returns only chain leaves on the named branch", async () => {
+			const root = makeEntry("aaa", "2025-01-01T00:00:00Z", "root", "main");
+			const child = makeEntry(
+				"bbb",
+				"2025-01-02T00:00:00Z",
+				"leaf",
+				"main",
+				"aaa",
+			);
+			const other = makeEntry(
+				"ccc",
+				"2025-01-03T00:00:00Z",
+				"other branch",
+				"feature",
+			);
+			getIndexEntryMap.mockResolvedValue(
+				new Map([
+					["aaa", root],
+					["bbb", child],
+					["ccc", other],
+				]),
+			);
+
+			const bridge = makeBridge();
+			const result = await bridge.listBranchMemories(
+				"workspace-repo",
+				"main",
+			);
+			expect(result.map((e) => e.commitHash)).toEqual(["bbb"]);
+		});
+```
+
+(If the test file's `makeEntry` factory in the `listSummaryEntries` block isn't visible at this scope, either lift it to the outer `describe` or define it locally inside the `listBranchMemories` block.)
+
+- [ ] **Step 2: Run test, verify failure**
+
+```bash
+npm run test:vscode -- src/JolliMemoryBridge.test.ts -t "listBranchMemories"
+```
+Expected: FAIL — current `listBranchMemories` returns both `aaa` and `bbb`.
+
+- [ ] **Step 3: Add the filter**
+
+Edit `listBranchMemories` in `vscode/src/JolliMemoryBridge.ts`. The current body (around line 1484) reads:
+
+```ts
+		try {
+			const map = await getIndexEntryMap(cwd, storage);
+			const items: SummaryIndexEntry[] = [];
+			for (const entry of map.values()) {
+				if (entry.branch === branchName) {
+					items.push({ ...entry, repoName });
+				}
+			}
+			items.sort(
+				(a, b) => Date.parse(getDisplayDate(b)) - Date.parse(getDisplayDate(a)),
+			);
+			return items;
+		} catch (err) { ... }
+```
+
+Replace the inner block with:
+
+```ts
+		try {
+			const map = await getIndexEntryMap(cwd, storage);
+			const branchEntries: SummaryIndexEntry[] = [];
+			for (const entry of map.values()) {
+				if (entry.branch === branchName) {
+					branchEntries.push({ ...entry, repoName });
+				}
+			}
+			const leaves = filterToBranchLeaves(branchEntries);
+			leaves.sort(
+				(a, b) => Date.parse(getDisplayDate(b)) - Date.parse(getDisplayDate(a)),
+			);
+			return leaves;
+		} catch (err) { ... }
+```
+
+(Same `filterToBranchLeaves` import added in Task 5 covers this.)
+
+- [ ] **Step 4: Run tests, verify pass**
+
+```bash
+npm run test:vscode -- src/JolliMemoryBridge.test.ts
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add vscode/src/JolliMemoryBridge.ts vscode/src/JolliMemoryBridge.test.ts
+git commit -s -m "listBranchMemories: filter to chain leaves on the named branch
+
+Foreign-view Branch tab now matches the Memory Bank tree count (also
+leaf-only after Tasks 7/8 drain disk). Cross-branch chains keep each
+branch's tip independent."
+```
+
+---
+
+## Task 7: `MigrationEngine` v2 step — one-shot leaf cleanup on startup
+
+**Files:**
+- Modify: `cli/src/core/KBTypes.ts`
+- Modify: `cli/src/core/MigrationEngine.ts`
+- Modify: `cli/src/core/MigrationEngine.test.ts`
+
+Extends `MigrationState` with a `leafCleanup` block and runs `cleanupAllBranchesLeafMarkdown` once per repo after the existing v1 migration completes. Idempotent gate via `leafCleanup.completedAt`.
+
+- [ ] **Step 1: Extend `MigrationState`**
+
+Edit `cli/src/core/KBTypes.ts`. Update the `MigrationState` interface (around line 49) to append the new optional block:
+
+```ts
+/** .jolli/migration.json — tracks orphan→folder migration progress */
+export interface MigrationState {
+	readonly status: "pending" | "in_progress" | "completed" | "partial" | "failed";
+	readonly totalEntries: number;
+	readonly migratedEntries: number;
+	readonly failedHashes?: readonly string[];
+	readonly lastMigratedHash?: string;
+	/**
+	 * v2 leaf-cleanup step (added 2026-05-12): one-shot deletion of non-leaf
+	 * visible .md files. `completedAt` set on first successful run; subsequent
+	 * runs skip when present. Absent = not yet attempted.
+	 */
+	readonly leafCleanup?: { readonly completedAt: string };
+}
+```
+
+- [ ] **Step 2: Write failing test for the v2 step**
+
+Append to `cli/src/core/MigrationEngine.test.ts` (inside the outermost `describe`):
+
+```ts
+	describe("v2 leaf cleanup", () => {
+		it("deletes non-leaves and records completedAt", async () => {
+			// Seed the folder storage with a chain a → b (b is leaf on main).
+			const folderStorage = makeFolderStorage(); // existing helper in test file
+			await folderStorage.writeFiles(
+				[
+					{
+						path: "summaries/aaa.json",
+						content: JSON.stringify({
+							version: 3,
+							commitHash: "aaa",
+							commitMessage: "root",
+							commitAuthor: "x",
+							commitDate: "2026-05-12T00:00:00Z",
+							branch: "main",
+							generatedAt: "2026-05-12T00:00:00Z",
+							topics: [],
+						}),
+					},
+					{
+						path: "summaries/bbb.json",
+						content: JSON.stringify({
+							version: 3,
+							commitHash: "bbb",
+							commitMessage: "leaf",
+							commitAuthor: "x",
+							commitDate: "2026-05-12T00:00:00Z",
+							branch: "main",
+							generatedAt: "2026-05-12T00:00:00Z",
+							topics: [],
+						}),
+					},
+					{
+						path: "index.json",
+						content: JSON.stringify({
+							version: 3,
+							entries: [
+								{
+									commitHash: "aaa",
+									parentCommitHash: null,
+									commitMessage: "root",
+									commitDate: "2026-05-12T00:00:00Z",
+									branch: "main",
+									generatedAt: "2026-05-12T00:00:00Z",
+								},
+								{
+									commitHash: "bbb",
+									parentCommitHash: "aaa",
+									commitMessage: "leaf",
+									commitDate: "2026-05-12T00:00:00Z",
+									branch: "main",
+									generatedAt: "2026-05-12T00:00:00Z",
+								},
+							],
+						}),
+					},
+				],
+				"seed",
+			);
+
+			const engine = new MigrationEngine(
+				makeOrphanStorage(/* same seed or empty — main migration not under test here */),
+				folderStorage,
+				makeMetadataManager(folderStorage.rootPath),
+			);
+			const state = await engine.runLeafCleanup();
+
+			expect(state.leafCleanup?.completedAt).toBeTruthy();
+			// `aaa` md gone, `bbb` md kept.
+			expect(visibleMdExists(folderStorage.rootPath, "main", "root-aaa")).toBe(false);
+			expect(visibleMdExists(folderStorage.rootPath, "main", "leaf-bbb")).toBe(true);
+		});
+
+		it("is a no-op when leafCleanup.completedAt is already set", async () => {
+			const folderStorage = makeFolderStorage();
+			const metadataManager = makeMetadataManager(folderStorage.rootPath);
+			metadataManager.saveMigrationState({
+				status: "completed",
+				totalEntries: 0,
+				migratedEntries: 0,
+				leafCleanup: { completedAt: "2026-05-01T00:00:00Z" },
+			});
+			const engine = new MigrationEngine(
+				makeOrphanStorage(),
+				folderStorage,
+				metadataManager,
+			);
+			const state = await engine.runLeafCleanup();
+			expect(state.leafCleanup?.completedAt).toBe("2026-05-01T00:00:00Z");
+		});
+	});
+```
+
+If `makeFolderStorage` / `makeOrphanStorage` / `makeMetadataManager` / `visibleMdExists` helpers don't already exist in the test file, scan for the existing setup (the existing migration tests already construct these — reuse their pattern, or extract their bodies to local helpers at the top of this `describe`).
+
+- [ ] **Step 3: Run test, verify failure**
+
+```bash
+npm run test -w @jolli.ai/cli -- src/core/MigrationEngine.test.ts -t "v2 leaf cleanup"
+```
+Expected: FAIL — `engine.runLeafCleanup is not a function`.
+
+- [ ] **Step 4: Implement `runLeafCleanup` on `MigrationEngine`**
+
+Edit `cli/src/core/MigrationEngine.ts`. Add import at top:
+
+```ts
+import { cleanupAllBranchesLeafMarkdown } from "./LeafMarkdownCleanup.js";
+```
+
+Add the new method as a public member after the existing `validateMigration()`:
+
+```ts
+	/**
+	 * v2 step (added 2026-05-12): one-shot leaf-only cleanup of visible .md
+	 * files on the folder storage. Idempotent via `state.leafCleanup.completedAt`.
+	 * Called from `runMigration` after the v1 migration completes; can also be
+	 * invoked directly (e.g. by hosts that already finished v1 but missed v2).
+	 */
+	async runLeafCleanup(): Promise<MigrationState> {
+		const existing = this.metadataManager.readMigrationState();
+		if (existing?.leafCleanup?.completedAt) {
+			log.info("v2 leaf cleanup already completed at %s — skipping", existing.leafCleanup.completedAt);
+			return existing;
+		}
+
+		log.info("=== v2 leaf cleanup started ===");
+		const result = await cleanupAllBranchesLeafMarkdown(undefined, this.folderStorage);
+		log.info("v2 leaf cleanup: deleted=%d failed=%d", result.deleted, result.failed);
+
+		const merged: MigrationState = {
+			status: existing?.status ?? "completed",
+			totalEntries: existing?.totalEntries ?? 0,
+			migratedEntries: existing?.migratedEntries ?? 0,
+			...(existing?.failedHashes ? { failedHashes: existing.failedHashes } : {}),
+			...(existing?.lastMigratedHash ? { lastMigratedHash: existing.lastMigratedHash } : {}),
+			leafCleanup: { completedAt: new Date().toISOString() },
+		};
+		this.metadataManager.saveMigrationState(merged);
+		return merged;
+	}
+```
+
+Then call it from inside `runMigration`, right before the final `return finalState` line — append:
+
+```ts
+		// v2 step: drain backlog of non-leaf visible .md files left by amend /
+		// rebase / squash sequences from before this code shipped. Idempotent.
+		try {
+			await this.runLeafCleanup();
+		} catch (err) {
+			log.warn("v2 leaf cleanup raised: %s", err instanceof Error ? err.message : String(err));
+		}
+```
+
+- [ ] **Step 5: Run tests, verify pass**
+
+```bash
+npm run test -w @jolli.ai/cli -- src/core/MigrationEngine.test.ts
+```
+Expected: PASS (existing + 2 new).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add cli/src/core/KBTypes.ts cli/src/core/MigrationEngine.ts cli/src/core/MigrationEngine.test.ts
+git commit -s -m "MigrationEngine: add v2 leaf-cleanup step + completedAt gate
+
+One-shot pass per repo over every branch via cleanupAllBranchesLeafMarkdown.
+Records leafCleanup.completedAt in migration.json so the next boot skips.
+Invoked at the tail of runMigration and exposed publicly for direct calls."
+```
+
+---
+
+## Task 8: `QueueWorker` tail step — per-op incremental cleanup
+
+**Files:**
+- Modify: `cli/src/hooks/QueueWorker.ts`
+- Modify: `cli/src/hooks/QueueWorker.test.ts`
+
+Run `cleanupBranchLeafMarkdown` once after `processQueueEntry`'s switch returns, scoped to the current branch. Wrapped in try/catch — cleanup failure must NOT roll back the queue entry.
+
+- [ ] **Step 1: Expose `processQueueEntry` via `__test__` + add mock for the cleanup module**
+
+The existing test file already uses an `__test__` export pattern (see `cli/src/hooks/QueueWorker.ts:1603`). The new tests drive `processQueueEntry` directly. First, add `processQueueEntry` to the `__test__` export in `QueueWorker.ts`:
+
+```ts
+export const __test__ = {
+	detectPlanSlugsFromRegistry,
+	detectUncommittedNoteIds,
+	hoistMetadataFromOldSummary,
+	associatePlansWithCommit,
+	executePipeline,
+	handleAmendPipeline,
+	handleSquashFromQueue,
+	loadSessionTranscripts,
+	buildStoredTranscript,
+	processQueueEntry,
+};
+```
+
+Next, at the top of `cli/src/hooks/QueueWorker.test.ts`, add a `vi.mock` for the new cleanup module alongside the existing mocks:
+
+```ts
+vi.mock("../core/LeafMarkdownCleanup.js", () => ({
+	cleanupBranchLeafMarkdown: vi.fn().mockResolvedValue({ deleted: 0, failed: 0 }),
+	cleanupAllBranchesLeafMarkdown: vi.fn().mockResolvedValue({ deleted: 0, failed: 0 }),
+}));
+```
+
+Then add this import next to the existing `import { __test__, runWorker } from "./QueueWorker.js";` line:
+
+```ts
+import { cleanupBranchLeafMarkdown } from "../core/LeafMarkdownCleanup.js";
+```
+
+Append the new tests inside the outer `describe("QueueWorker", …)`:
+
+```ts
+	describe("post-op leaf cleanup", () => {
+		const mockStorage = {
+			readFile: vi.fn(),
+			writeFiles: vi.fn(),
+			listFiles: vi.fn(),
+			exists: vi.fn().mockResolvedValue(true),
+			ensure: vi.fn(),
+			deleteVisibleMarkdown: vi.fn(),
+		};
+
+		beforeEach(() => {
+			vi.mocked(cleanupBranchLeafMarkdown).mockClear();
+			vi.mocked(cleanupBranchLeafMarkdown).mockResolvedValue({
+				deleted: 0,
+				failed: 0,
+			});
+		});
+
+		it("invokes cleanupBranchLeafMarkdown after processing an amend op", async () => {
+			await __test__.processQueueEntry(
+				{
+					type: "amend",
+					commitHash: "deadbeef1234567890abcdef0123456789abcdef",
+					createdAt: new Date().toISOString(),
+				} as never,
+				"/test/cwd",
+				mockStorage as never,
+				false,
+			);
+
+			expect(cleanupBranchLeafMarkdown).toHaveBeenCalledWith(
+				"/test/cwd",
+				"feature/test", // mocked getCurrentBranch in the test scaffold
+				mockStorage,
+			);
+		});
+
+		it("swallows cleanup errors — the op succeeds even when cleanup throws", async () => {
+			vi.mocked(cleanupBranchLeafMarkdown).mockRejectedValueOnce(
+				new Error("disk-gone"),
+			);
+
+			await expect(
+				__test__.processQueueEntry(
+					{
+						type: "commit",
+						commitHash: "feedface1234567890abcdef0123456789abcdef",
+						createdAt: new Date().toISOString(),
+					} as never,
+					"/test/cwd",
+					mockStorage as never,
+					false,
+				),
+			).resolves.toBeUndefined();
+		});
+	});
+```
+
+(The `getCurrentBranch` mock is already configured at the top of the test file to return `"feature/test"` — see existing setup.)
+
+- [ ] **Step 2: Run test, verify failure**
+
+```bash
+npm run test -w @jolli.ai/cli -- src/hooks/QueueWorker.test.ts -t "post-op leaf cleanup"
+```
+Expected: FAIL — cleanup is not yet wired.
+
+- [ ] **Step 3: Thread storage into `processQueueEntry`**
+
+Edit `cli/src/hooks/QueueWorker.ts`. Add import at top:
+
+```ts
+import { cleanupBranchLeafMarkdown } from "../core/LeafMarkdownCleanup.js";
+```
+
+Currently `processQueueEntry(op, cwd, force)` accesses storage indirectly via the module-level `setActiveStorage` singleton inside SummaryStore. The cleanup call needs the storage instance directly (for the optional `deleteVisibleMarkdown` method), so promote `storage` to a parameter.
+
+Update the call site at `runWorker` (around line 228) from:
+
+```ts
+					await processQueueEntry(op, cwd, force);
+```
+
+to:
+
+```ts
+					await processQueueEntry(op, cwd, storage, force);
+```
+
+Update `processQueueEntry`'s signature (around line 275) from:
+
+```ts
+async function processQueueEntry(op: GitOperation, cwd: string, force: boolean): Promise<void> {
+```
+
+to:
+
+```ts
+async function processQueueEntry(
+	op: GitOperation,
+	cwd: string,
+	storage: StorageProvider,
+	force: boolean,
+): Promise<void> {
+```
+
+Add the `StorageProvider` import to the top of the file (or extend the existing one if `StorageProvider` is already imported elsewhere — grep first):
+
+```ts
+import type { StorageProvider } from "../core/StorageProvider.js";
+```
+
+Then append the tail step after the switch statement (right before the function's final `}`):
+
+```ts
+	// Tail step: prune visible .md files that this op left non-leaf on the
+	// active branch. Pure index-driven — works the same for amend, rebase-pick,
+	// squash, and rebase-squash. Failures here MUST NOT roll back the op.
+	try {
+		const branch = await getCurrentBranch(cwd);
+		const { deleted, failed } = await cleanupBranchLeafMarkdown(cwd, branch, storage);
+		if (deleted > 0 || failed > 0) {
+			log.info(
+				"Leaf cleanup on %s: deleted=%d failed=%d",
+				branch,
+				deleted,
+				failed,
+			);
+		}
+	} catch (err) {
+		log.warn(
+			"Leaf cleanup tail step failed for %s: %s",
+			op.commitHash.substring(0, 8),
+			err instanceof Error ? err.message : String(err),
+		);
+	}
+```
+
+- [ ] **Step 4: Run tests, verify pass**
+
+```bash
+npm run test -w @jolli.ai/cli -- src/hooks/QueueWorker.test.ts
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cli/src/hooks/QueueWorker.ts cli/src/hooks/QueueWorker.test.ts
+git commit -s -m "QueueWorker: tail leaf-cleanup step after every op
+
+Runs cleanupBranchLeafMarkdown against the active branch once
+processQueueEntry's switch returns. Failures swallowed into a warn log
+so a cleanup hiccup never rolls back the queue entry."
+```
+
+---
+
+## Task 9: CLI parity audit + full gate
+
+**Files:** none expected to change.
+
+`jolli` CLI commands (`search`, etc.) read through `SummaryStore` / `getIndexEntryMap` — the same modules the bridge uses. Verify by grep + smoke test.
+
+- [ ] **Step 1: Grep for any direct read paths**
+
+```bash
+grep -rn "parentCommitHash != null\|parentCommitHash !==\|\.parentCommitHash\b" cli/src/commands cli/src/core 2>/dev/null
+```
+Expected: every match either inside a write/storage path or already routed through `getIndexEntryMap` callers (`listSummaryEntries`, etc.). If you find a command that filters entries with `parentCommitHash != null` for display, switch it to `filterToBranchLeaves`.
+
+- [ ] **Step 2: Smoke-test a search command against a tmpdir-rooted repo**
+
+Set up a tmpdir with a fake `.jolli/index.json` containing a 3-entry chain (`a→b→c`), run:
+
+```bash
+cd <tmpdir>
+node <jolli-cli-dist>/cli.js search --limit 10
+```
+Expected: only `c` (the leaf) listed.
+
+(If no `search` command exists, substitute whichever CLI surface reads the index for display — `jolli list`, `jolli history`, etc.)
+
+- [ ] **Step 3: Run the full gate**
+
+```bash
+cd /Users/flyer/jolli/code/jollimemory
+npm run all
+```
+Expected: PASS — CLI 97%+ coverage holds; VS Code tests pass; biome clean.
+
+- [ ] **Step 4: Manual UI smoke test**
+
+Build the VSCode extension and reload it in a real workspace that already has chain memories (a repo with a 5-amend chain):
+
+```bash
+cd vscode && npm run deploy
+# In VS Code: Developer: Reload Window.
+```
+
+Verify:
+- Memory Bank tree shows leaf-only.
+- Timeline / KB Memories list shows leaf-only.
+- Branch tab Memories (workspace) shows what `git log mergeBase..HEAD` gives — unchanged behavior, but the now-deleted non-leaf `.md` files no longer surface in any view that read from disk or storage.
+- Click a leaf row → Summary panel opens normally.
+
+- [ ] **Step 5: Commit the audit notes (only if any code changed)**
+
+If grep surfaced and fixed a stray filter site in cli/src/, commit those changes. Otherwise skip.
+
+---
+
+## Self-review checkpoints (run after Task 9)
+
+- [ ] Spec coverage: each section of `docs/superpowers/specs/2026-05-12-leaf-only-memory-display-design.md` (ChainLeafFilter, FolderStorage.deleteVisibleMarkdown, listSummaryEntries / listBranchMemories filters, MigrationEngine v2, QueueWorker incremental, CLI parity) maps to a task above.
+- [ ] No regression in `cleanupSupersededDescendants`: that older write-time cleanup path stays in place as defense-in-depth; the new leaf-cleanup runs additionally. Both are idempotent.
+- [ ] Coverage floor: CLI 97% statements / 96% branches / 97% functions / 97% lines (per `cli/vite.config.ts`). New files have ≥97% coverage from their `.test.ts` siblings.
+- [ ] `npm run all` green.

--- a/docs/superpowers/specs/2026-05-12-leaf-only-memory-display-design.md
+++ b/docs/superpowers/specs/2026-05-12-leaf-only-memory-display-design.md
@@ -1,0 +1,268 @@
+# Leaf-Only Memory Display — Cleanup Visible `.md` Files After Amend / Rebase
+
+**Date:** 2026-05-12
+**Status:** Approved for implementation
+**Branch:** `fix-change-other-repo-memory`
+
+## Background
+
+After `git commit --amend` or interactive rebase reorders a chain of related commits, the user ends up with three views in Jolli that show different counts of the "same" memory:
+
+| View | Source | Count for a 5-amend chain |
+|---|---|---|
+| Memory Bank tree (folder browse) | enumerates `<localFolder>/<repo>/<branch>/*.md` on disk | 5 |
+| Timeline / KB Memories list | `JolliMemoryBridge.listSummaryEntries` (current filter: `parentCommitHash != null` + dedup by `commitHash`, sorted by date) | 2 (only chain roots) |
+| Branch tab Memories — workspace mode | `JolliMemoryBridge.listBranchCommits` → `git log mergeBase..HEAD` enriched with index | 1 (only the commit on HEAD) |
+| Branch tab Memories — foreign mode | `JolliMemoryBridge.listBranchMemories` (no parent filter) | 5 |
+
+Each view's behavior is documented and intentional, but the inconsistency is confusing. The user's intent: **all three views should agree, showing only the tip of each chain — the surviving commit after amend / rebase.**
+
+The archive layers (the orphan branch `jollimemory/summaries/v3` and the hidden `<localFolder>/<repo>/.jolli/` JSON store) remain a permanent record. Only the *visible* layer changes.
+
+## Goals
+
+- **Display alignment.** Memory Bank tree, Timeline / KB Memories list, and Branch tab Memories all show exactly one row per `(branch, chain)` — the chain's leaf.
+- **Disk alignment.** Visible Markdown files under `<localFolder>/<repo>/<branch>/*.md` contain only chain leaves. Stale `.md` files from amended-away commits are deleted on the next QueueWorker pass and during a one-shot startup migration that drains the existing backlog.
+- **Archive preservation.** The orphan branch and the hidden `.jolli/` JSON store (summaries, transcripts, index) keep every revision in the chain. Nothing in this design touches them.
+
+## Non-goals
+
+- Self-healing missing leaf `.md` files (current dual-write blind spot — out of scope).
+- A "trash quarantine" with N-day retention for deleted `.md` files (delete is happy-path lossy; archive layers remain the recovery surface).
+- Changes to the orphan branch / `.jolli/index.json` schema. The chain relationship (`parentCommitHash`) already exists; this design only adds a derived filter on top.
+- IntelliJ plugin parity. The Kotlin port has its own read paths; pinning the contract for CLI + VS Code first, IntelliJ catches up in a separate work item.
+
+## Design decisions (locked)
+
+1. **Cleanup scope.** Delete *only* the visible `<branch>/<slug>-<hash8>.md` layer. The orphan branch and `<repo>/.jolli/` (summaries, transcripts, plans, notes, `index.json`) stay intact.
+2. **Existing data.** One-shot migration at extension / CLI startup drains the backlog; QueueWorker maintains the invariant going forward.
+3. **Leaf definition.** Per `(repoName, branch)` scope. A `SummaryIndexEntry` `e` is a leaf iff there is **no other entry `e'` with the same `repoName` and `branch` such that `e'.parentCommitHash === e.commitHash`**. Cross-branch `parentCommitHash` links (rebase-pick `c1` from branch X to branch Y producing `c1'`) do **not** demote `c1` to non-leaf when viewed under branch X. Cross-repo links similarly do not cross repo boundaries. Each `(repo, branch)` judges its own tips.
+4. **Implementation slicing.** Single PR (Approach A). All five workstreams ship together so there is no observable inconsistency window.
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────┐
+│ Display layer  (3 read surfaces — all leaf-only)        │
+│   • Memory Bank tree (folder browse)                     │
+│   • Timeline / KB Memories list                          │
+│   • Branch tab Memories (workspace + foreign)            │
+└────────────────────┬────────────────────────────────────┘
+                     │ reads via
+                     ▼
+┌─────────────────────────────────────────────────────────┐
+│ ChainLeafFilter  (new, single source of truth)          │
+│   getBranchLeaves(entries) → Set<commitHash>             │
+└────────────────────┬────────────────────────────────────┘
+                     │ called by
+       ┌─────────────┼─────────────┬──────────────┐
+       ▼             ▼             ▼              ▼
+  listSummary    listBranch    Migration     QueueWorker
+   Entries       Memories      v2 step       incremental
+                                                cleanup
+                                ▼              ▼
+                        ┌──────────────────────────┐
+                        │ FolderStorage            │
+                        │   deleteVisibleMarkdown  │  (new, narrow API)
+                        └──────────────────────────┘
+                                ▼
+                  <localFolder>/<repo>/<branch>/*.md
+                  (only leaves remain on disk)
+
+  Archive (untouched):
+  • orphan branch jollimemory/summaries/v3
+  • <localFolder>/<repo>/.jolli/summaries/<hash>.json
+  • <localFolder>/<repo>/.jolli/transcripts/<hash>.json
+  • <localFolder>/<repo>/.jolli/index.json
+```
+
+## Components
+
+### 1. `ChainLeafFilter` (new, `cli/src/core/ChainLeafFilter.ts`)
+
+Pure function. Two exported helpers:
+
+```ts
+/** Returns the set of commitHashes that are leaves of their chain on their branch. */
+export function getBranchLeaves(
+  entries: Iterable<SummaryIndexEntry>,
+): Set<string>;
+
+/** Convenience: returns only the entries whose commitHash is a branch leaf. */
+export function filterToBranchLeaves<T extends SummaryIndexEntry>(
+  entries: Iterable<T>,
+): T[];
+```
+
+**Algorithm** (linear, two-pass):
+
+```
+1. byScope: Map<(repoName ?? '') + '\0' + branch, SummaryIndexEntry[]>
+       ← group entries by (entry.repoName, entry.branch)
+2. for each (scope, list) in byScope:
+     parentedInScope = { e.parentCommitHash for e in list if e.parentCommitHash != null }
+     for each e in list:
+         if e.commitHash NOT in parentedInScope:
+             leaves.add(e.commitHash)
+3. return leaves
+```
+
+**Why scope on `(repoName, branch)`, not branch alone:** the same branch name (`main`, `feature/x`) frequently exists across repos. Grouping by `branch` alone would let entries from repo A demote entries from repo B (or vice-versa) when their parent / child relationships happen to land on the same hash. Scoping on the tuple keeps each repo's chains independent — same algorithm, narrower scope. For single-repo inputs (entries without `repoName`, e.g. the bare result of `getIndexEntryMap` before `listSummaryEntries`'s merge step), `repoName ?? ''` degenerates to one repo-scope and the behavior is identical to single-repo branch grouping.
+
+Cycle safety: a malicious / corrupted index where `parentCommitHash` forms a loop (`a→b, b→a` in the same `(repoName, branch)` scope) means **neither** `a` nor `b` is a leaf (each is parented by the other in scope). That collapses an entire cycle to zero displayed rows; acceptable — bad data hides itself rather than crashing the renderer. Documented in the function header.
+
+Used by:
+- `JolliMemoryBridge.listSummaryEntries` (replaces existing `parentCommitHash != null` filter; the dedup by `commitHash` stays because cross-repo aliasing is orthogonal to chain collapse).
+- `JolliMemoryBridge.listBranchMemories` (current path has no filter; adds this one).
+- `MigrationEngine` v2 step.
+- `QueueWorker.cleanupBranchVisibleMarkdown` (new step, see below).
+
+### 2. `FolderStorage.deleteVisibleMarkdown` (new method, `cli/src/core/FolderStorage.ts`)
+
+```ts
+/**
+ * Removes only the visible Markdown file at <kbRoot>/<branch>/<slug>-<hash8>.md.
+ * Does NOT touch .jolli/summaries/<hash>.json, .jolli/index.json, or the orphan
+ * branch. Idempotent: a missing file is not an error.
+ */
+async deleteVisibleMarkdown(entry: SummaryIndexEntry): Promise<void>;
+```
+
+- Recomputes the same path that `FolderStorage` uses to *write* the visible md (slug derivation via `FolderStorage.slugify()`, `<hash8>` suffix). If the slug derivation changes in the future, this stays in lockstep because both writer and deleter share the same private helper.
+- `ENOENT` swallowed (idempotent). Other errors propagate.
+- Leaves the `<branch>/` directory in place even if it becomes empty (avoids ENOENT race with the next write).
+
+### 3. `MigrationEngine` v2 step (extend `cli/src/core/MigrationEngine.ts`)
+
+Adds a new step run after the existing v1 (dual-write enablement) migration.
+
+**Trigger:** Extension `activate()` and CLI commands that hit `MigrationEngine.runMigration` (existing entry points). Idempotent.
+
+**Logic:**
+
+```
+for each repo discovered under localFolder (current + foreign):
+    map = read .jolli/index.json into SummaryIndexEntry list
+    leaves = ChainLeafFilter.getBranchLeaves(map.values())
+    for each entry where entry.commitHash ∉ leaves:
+        FolderStorage.deleteVisibleMarkdown(entry)
+write metadata { v2: { completedAt: <iso> } }
+```
+
+**State file:** Extend `MetadataManager`'s migration-state object with a `v2` block. A repo with `v2.completedAt` set is skipped on subsequent boots. Forced re-run (manual `v2` reset) is a no-op against an already-leaf-only disk.
+
+**Failure mode:** If a delete throws (non-ENOENT), the step logs and continues — partial cleanup is fine because the next boot resumes and is idempotent. `completedAt` is written only when the whole repo finishes without exceptions.
+
+### 4. `QueueWorker.cleanupBranchVisibleMarkdown` (new step, `cli/src/hooks/QueueWorker.ts`)
+
+A single new step appended to every op-pipeline tail (post-commit, amend, rebase-pick, rebase-squash, squash). Receives `branch: string`, performs:
+
+```
+entries = getIndexEntryMap(cwd, storage).values().filter(e => e.branch === branch)
+leaves = ChainLeafFilter.getBranchLeaves(entries)
+for each entry where entry.commitHash ∉ leaves:
+    FolderStorage.deleteVisibleMarkdown(entry)
+```
+
+**Why uniform across op types:** the cleanup is purely a function of the index's current state, not which op produced it. Sharing one step means the four pipelines all converge on the same invariant. The migration v2 step calls the same code module (different scope: iterates branches under a repo).
+
+### 5. Read-path filter replacements (`vscode/src/JolliMemoryBridge.ts`)
+
+**`listSummaryEntries`** — current:
+
+```ts
+this.cachedRootEntries = merged
+    .filter((e) => {
+        if (e.parentCommitHash != null || seen.has(e.commitHash)) return false;
+        seen.add(e.commitHash);
+        return true;
+    })
+    .sort(...);
+```
+
+→ replaces the `parentCommitHash != null` rejection with `ChainLeafFilter.filterToBranchLeaves`. Because the merge step already stamps `repoName` onto every entry before this filter runs, `ChainLeafFilter` groups correctly on `(repoName, branch)`. Dedup by `commitHash` stays — it handles a different concern (cross-repo tree-hash aliasing collapses the same physical commit appearing under two repos).
+
+**`listBranchMemories`** — current returns every matching `entry.branch === branchName`. Wraps the iteration in `ChainLeafFilter.getBranchLeaves(entries)` and filters to those.
+
+**No display-layer change.** Webview and tree provider stay agnostic; once the bridge returns leaf-filtered lists, the existing renderers do the right thing.
+
+### 6. `KbFoldersService.listChildren` (no code change)
+
+Reads disk. Migration + worker incremental cleanup guarantee the disk only contains leaf `.md` files. No filter needed.
+
+### 7. CLI parity audit (verify, expected zero code change)
+
+CLI commands (`jolli search`, `jolli list`, etc.) read through `SummaryStore` / `getIndexEntryMap` — the same modules `JolliMemoryBridge` uses. Filter replacements in shared code propagate automatically. The audit step is a grep + spot-check to confirm no command bypasses the shared read path.
+
+## Data flow (example: user makes 5 amends)
+
+```
+Each `git commit --amend` fires post-commit hook → QueueWorker enqueue.
+
+Per op the worker now runs:
+  1. (existing) generate summary for new HEAD
+        → orphan: commit-tree linking parent
+        → .jolli/summaries/<new>.json
+        → <branch>/<slug>-<new8>.md
+        → .jolli/index.json append (parent = old hash)
+  2. (NEW) cleanupBranchVisibleMarkdown(branch)
+        → read index entries for this branch
+        → ChainLeafFilter.getBranchLeaves
+        → for each non-leaf: FolderStorage.deleteVisibleMarkdown
+        → disk converges to leaf-only
+
+After 5 amends:
+  orphan:                 5 commits        ← archive intact
+  .jolli/summaries/*.json: 5 files          ← archive intact
+  .jolli/index.json:       5 entries (c5 leaf, chain c5→c4→c3→c2→c1)
+  <branch>/*.md:           1 file (c5)      ← cleaned
+  Memory Bank tree:        1 row            ← disk
+  Timeline:                1 row            ← ChainLeafFilter
+  Branch tab workspace:    1 row            ← git log
+  Branch tab foreign:      1 row            ← ChainLeafFilter
+```
+
+## Edge cases
+
+1. **Rebase pick `c1` (branch X) → `c1'` (branch Y).** Leaf-by-branch keeps `c1` as a leaf under X (no entry on X parents `c1`) and `c1'` as a leaf under Y. Two branches, two leaves. ✓
+2. **Squash N commits → 1 commit.** The existing LLM-driven `generateSquashConsolidation` pipeline creates the new entry with `parentCommitHash` referencing the chain it absorbed. The new cleanup step deletes the N old `.md` files; the squashed commit's `.md` survives. ✓
+3. **Migration idempotency.** Per-repo `v2.completedAt` gate; deletes are idempotent. Re-running against a leaf-only disk is a no-op.
+4. **Migration mid-run crash.** `completedAt` written only after success. Next boot re-scans. `deleteVisibleMarkdown` ignores `ENOENT`.
+5. **User manually deleted a leaf's `.md`.** Cleanup does not restore (current dual-write blind spot — out of scope per non-goals). Recovery: rerun migration or trigger any new amend (dual-write recreates the leaf md on next write).
+6. **Concurrent worktree amends.** QueueWorker's existing 5-minute file lock serializes; cleanup runs inside the lock.
+7. **Empty `<branch>/` directory after cleanup.** Left in place. Avoids ENOENT race with the next write into that branch.
+8. **Cross-repo foreign view.** Foreign-repo read path already instantiates `FolderStorage` against the target `kbRoot` and reads its `index.json` — `ChainLeafFilter` works without git context. ✓
+9. **Corrupted `parentCommitHash` (loop, dangling pointer).** Loop → all loop members lost to display (both parent each other). Dangling pointer → child is leaf normally; orphan entry treated as a root. Documented in `ChainLeafFilter`. No crash.
+10. **Branch rename / deletion in git after memories were recorded.** `entry.branch` is whatever the worker captured at commit time. Cleanup keys off the stored branch string, not the live git ref — orphaned branch directories (`<old-branch>/`) keep their leaves intact (a separate housekeeping concern).
+
+## Testing strategy
+
+| Layer | Type | Coverage |
+|---|---|---|
+| `ChainLeafFilter` | unit (cli) | single chain / parallel chains / cross-branch isolation / dangling parent / cycle (a↔b) / empty input / single entry |
+| `FolderStorage.deleteVisibleMarkdown` | unit (cli) | file exists → removed; file missing → no-op; .jolli/-side file with same hash → untouched; subdir contents undisturbed |
+| `MigrationEngine` v2 step | integration (vscode) | fresh repo no-op; existing chain converges; multiple branches each converge; `v2.completedAt` gate respected; partial-failure restart |
+| `QueueWorker` incremental cleanup | integration (cli) | post-amend / post-rebase-pick / post-squash / post-rebase-squash each result in correct disk state; cross-branch op leaves the other branch's `.md` files alone |
+| `listSummaryEntries` filter | unit (vscode bridge) | clean chain `c1(root)→c2→c3`: old filter returned `c1` (root with `parent==null`), new filter returns `c3` (leaf). This intentional behavior flip is the headline change — the Timeline / KB Memories list now reflects the *latest* commit of each chain rather than the original. Dangling-parent chain (`c1` removed from index, `c2→c3` remain): old returned empty, new returns `c3`. |
+| `listBranchMemories` filter | unit (vscode bridge) | foreign view returns leaves only; cross-branch rebase-pick keeps both branches' leaves visible |
+
+CI gate: existing `npm run all` (CLI 97% coverage floor) plus the new tests above. Migration test uses tmpdir-rooted FolderStorage to avoid touching real `.jolli/`.
+
+## Risks & rollback
+
+- **Risk: bug in leaf computation hides legitimate entries from display.** Mitigation: archive layers untouched — flipping a single read path back to the prior filter recovers display while a fix is prepared. Hotfix surface is a single function.
+- **Risk: migration deletes too aggressively.** Mitigation: deletes only target the visible `.md` layer; `.jolli/summaries/<hash>.json` and `index.json` retain the data needed to regenerate any `.md` via the existing dual-write writer path.
+- **Risk: worker cleanup races with a manual disk edit.** Mitigation: existing 5-minute file lock; worker cleanup is the same scope as the rest of the pipeline (not a new lock domain).
+- **Rollback plan:** revert the single PR. Existing chains regrow their visible `.md` files as soon as the next dual-write runs (each amend rewrites the new leaf's `.md` already; the orphaned older ones would not return — that asymmetry is acceptable because they are still present in `.jolli/` and the orphan branch).
+
+## Implementation order (single PR — Approach A)
+
+Within the PR, components land in this order so each diff is reviewable in isolation:
+
+1. `ChainLeafFilter` + unit tests.
+2. `FolderStorage.deleteVisibleMarkdown` + unit tests.
+3. Replace `listSummaryEntries` / `listBranchMemories` filters; update existing bridge tests.
+4. `MigrationEngine` v2 step + integration test.
+5. `QueueWorker.cleanupBranchVisibleMarkdown` wired into op pipelines + integration tests.
+6. CLI parity audit (grep + spot-check; expected zero code change).
+7. Run `npm run all`, hand-verify against a real chain on a scratch repo.

--- a/vscode/src/Extension.test.ts
+++ b/vscode/src/Extension.test.ts
@@ -228,9 +228,11 @@ const {
 		// can disable destructive actions for foreign-origin summaries.
 		// Default sourceRepoName=null preserves the legacy "local panel"
 		// semantics for tests that don't care about provenance.
-		getSummaryAnyRepoWithSource: vi
-			.fn()
-			.mockResolvedValue({ summary: null, sourceRepoName: null }),
+		getSummaryAnyRepoWithSource: vi.fn().mockResolvedValue({
+			summary: null,
+			sourceRepoName: null,
+			sourceRemoteUrl: null,
+		}),
 		listPlans: vi.fn().mockResolvedValue([]),
 		removePlan: vi.fn().mockResolvedValue(undefined),
 		listNotes: vi.fn().mockResolvedValue([]),
@@ -564,6 +566,12 @@ const {
 			status: "completed" as const,
 			migratedEntries: 0,
 			totalEntries: 0,
+		})),
+		runStaleChildCleanup: vi.fn(async () => ({
+			status: "completed" as const,
+			migratedEntries: 0,
+			totalEntries: 0,
+			staleChildCleanup: { completedAt: "2026-05-12T00:00:00Z" },
 		})),
 	};
 	return {
@@ -1293,6 +1301,135 @@ describe("Extension", () => {
 		});
 	});
 
+	// ── KB folder auto-init / v3 stale-child cleanup on activate ─────────────
+	//
+	// Regression coverage for two related bugs:
+	//   (1) Users whose v1 KB migration had already completed before v2 leaf
+	//       cleanup shipped never had the backlog drained — runLeafCleanup
+	//       was only invoked at the tail of runMigration, and runMigration
+	//       only ran when migration state was missing or non-completed.
+	//   (2) Worse, the 0.99.2 leaf-only algorithm was inverted under v4
+	//       Hoist semantics — it kept hoisted stale children and deleted
+	//       heads. So even when leafCleanup did run, it broke disk state.
+	// The activate path now invokes runStaleChildCleanup independently for
+	// the already-completed branch. State key is `staleChildCleanup`. The
+	// legacy `leafCleanup.completedAt` flag is intentionally NOT consulted —
+	// 0.99.2 users must re-run the corrective pass.
+	describe("activate — KB v3 stale-child cleanup", () => {
+		beforeEach(() => {
+			mockOrphanInstance.exists.mockReset();
+			mockMigrationEngineInstance.runMigration.mockReset();
+			mockMigrationEngineInstance.runMigration.mockResolvedValue({
+				status: "completed",
+				migratedEntries: 0,
+				totalEntries: 0,
+			});
+			mockMigrationEngineInstance.runStaleChildCleanup.mockReset();
+			mockMigrationEngineInstance.runStaleChildCleanup.mockResolvedValue({
+				status: "completed",
+				migratedEntries: 0,
+				totalEntries: 0,
+				staleChildCleanup: { completedAt: "2026-05-12T00:00:00Z" },
+			});
+			mockMetadataManagerInstance.readMigrationState.mockReset();
+		});
+
+		it("runs runStaleChildCleanup when v1 migration is completed but staleChildCleanup has never run", async () => {
+			mockOrphanInstance.exists.mockResolvedValue(true);
+			mockMetadataManagerInstance.readMigrationState.mockReturnValue({
+				status: "completed",
+				totalEntries: 5,
+				migratedEntries: 5,
+			});
+
+			activate(makeContext());
+
+			await vi.waitFor(() => {
+				expect(
+					mockMigrationEngineInstance.runStaleChildCleanup,
+				).toHaveBeenCalledTimes(1);
+			});
+			expect(mockMigrationEngineInstance.runMigration).not.toHaveBeenCalled();
+		});
+
+		it("skips runStaleChildCleanup when staleChildCleanup.completedAt is already set", async () => {
+			mockOrphanInstance.exists.mockResolvedValue(true);
+			mockMetadataManagerInstance.readMigrationState.mockReturnValue({
+				status: "completed",
+				totalEntries: 5,
+				migratedEntries: 5,
+				staleChildCleanup: { completedAt: "2026-05-01T00:00:00Z" },
+			});
+
+			activate(makeContext());
+
+			// Give activate's fire-and-forget initializeKB() a chance to settle.
+			await vi.waitFor(() => {
+				expect(mockOrphanInstance.exists).toHaveBeenCalled();
+			});
+			expect(
+				mockMigrationEngineInstance.runStaleChildCleanup,
+			).not.toHaveBeenCalled();
+			expect(mockMigrationEngineInstance.runMigration).not.toHaveBeenCalled();
+		});
+
+		it("still runs runStaleChildCleanup even when the legacy 0.99.2 leafCleanup.completedAt is set (corrective re-run)", async () => {
+			// Critical regression: 0.99.2 users carry leafCleanup.completedAt
+			// from the inverted pass. They must NOT be short-circuited — the
+			// new step has to run to undo the damage.
+			mockOrphanInstance.exists.mockResolvedValue(true);
+			mockMetadataManagerInstance.readMigrationState.mockReturnValue({
+				status: "completed",
+				totalEntries: 5,
+				migratedEntries: 5,
+				leafCleanup: { completedAt: "2026-05-12T10:00:00Z" },
+			});
+
+			activate(makeContext());
+
+			await vi.waitFor(() => {
+				expect(
+					mockMigrationEngineInstance.runStaleChildCleanup,
+				).toHaveBeenCalledTimes(1);
+			});
+		});
+
+		it("runs full runMigration (not runStaleChildCleanup) on fresh install with no migration state", async () => {
+			mockOrphanInstance.exists.mockResolvedValue(true);
+			mockMetadataManagerInstance.readMigrationState.mockReturnValue(null);
+
+			activate(makeContext());
+
+			await vi.waitFor(() => {
+				expect(mockMigrationEngineInstance.runMigration).toHaveBeenCalledTimes(
+					1,
+				);
+			});
+			expect(
+				mockMigrationEngineInstance.runStaleChildCleanup,
+			).not.toHaveBeenCalled();
+		});
+
+		it("does nothing when orphan branch does not exist", async () => {
+			mockOrphanInstance.exists.mockResolvedValue(false);
+			mockMetadataManagerInstance.readMigrationState.mockReturnValue({
+				status: "completed",
+				totalEntries: 5,
+				migratedEntries: 5,
+			});
+
+			activate(makeContext());
+
+			await vi.waitFor(() => {
+				expect(mockOrphanInstance.exists).toHaveBeenCalled();
+			});
+			expect(mockMigrationEngineInstance.runMigration).not.toHaveBeenCalled();
+			expect(
+				mockMigrationEngineInstance.runStaleChildCleanup,
+			).not.toHaveBeenCalled();
+		});
+	});
+
 	// ── Command handlers ────────────────────────────────────────────────
 
 	describe("command handlers", () => {
@@ -1562,6 +1699,7 @@ describe("Extension", () => {
 				mockBridge.getSummaryAnyRepoWithSource.mockResolvedValue({
 					summary,
 					sourceRepoName: null,
+					sourceRemoteUrl: null,
 				});
 
 				const handler = getRegisteredCommand("jollimemory.viewMemorySummary");
@@ -1578,6 +1716,7 @@ describe("Extension", () => {
 					expect.any(String),
 					"memory",
 					null,
+					null,
 				);
 			});
 
@@ -1586,6 +1725,7 @@ describe("Extension", () => {
 				mockBridge.getSummaryAnyRepoWithSource.mockResolvedValue({
 					summary,
 					sourceRepoName: null,
+					sourceRemoteUrl: null,
 				});
 
 				const handler = getRegisteredCommand("jollimemory.viewMemorySummary");
@@ -1602,21 +1742,22 @@ describe("Extension", () => {
 					expect.any(String),
 					"memory",
 					null,
+					null,
 				);
 			});
 
-			it("passes sourceRepoName through to the panel for foreign-origin memories", async () => {
-				// The whole point of the provenance plumbing: when a Memory
-				// Bank cross-repo lookup found the summary in `other-repo`,
-				// the panel must learn about it so destructive commands are
-				// disabled. Pinning the contract end-to-end (handler →
-				// bridge.getSummaryAnyRepoWithSource → panel.show) so any
-				// regression in the wiring fails this test instead of
-				// shipping silently and corrupting the wrong workspace.
+			it("passes sourceRepoName and sourceRemoteUrl through to the panel for foreign-origin memories", async () => {
+				// End-to-end pinning of provenance plumbing: a Memory Bank
+				// cross-repo lookup found the summary in `other-repo` AND
+				// captured its remote URL. The panel needs both — repoName
+				// gates destructive commands, remoteUrl powers the read-only
+				// `gh pr view --repo` query for the PR section. A regression
+				// dropping either breaks a different user-facing surface.
 				const summary = { hash: "xyz999", content: "foreign memory" };
 				mockBridge.getSummaryAnyRepoWithSource.mockResolvedValue({
 					summary,
 					sourceRepoName: "other-repo",
+					sourceRemoteUrl: "https://github.com/other/repo.git",
 				});
 
 				const handler = getRegisteredCommand("jollimemory.viewMemorySummary");
@@ -1630,6 +1771,7 @@ describe("Extension", () => {
 					expect.any(String),
 					"memory",
 					"other-repo",
+					"https://github.com/other/repo.git",
 				);
 			});
 
@@ -2478,12 +2620,16 @@ describe("Extension", () => {
 						`---\ntype: commit\ncommitHash: abc123def456789\nignored\nbranch: main\n---\n# Body\n`,
 					);
 					const summary = { commitHash: "abc123def456789", topics: [] };
-					mockBridge.getSummaryAnyRepo.mockResolvedValueOnce(summary);
+					mockBridge.getSummaryAnyRepoWithSource.mockResolvedValueOnce({
+						summary,
+						sourceRepoName: null,
+						sourceRemoteUrl: null,
+					});
 
 					const handler = getRegisteredCommand("jollimemory.openMemoryFile");
 					await handler("/fake/summary.md");
 
-					expect(mockBridge.getSummaryAnyRepo).toHaveBeenCalledWith(
+					expect(mockBridge.getSummaryAnyRepoWithSource).toHaveBeenCalledWith(
 						"abc123def456789",
 					);
 					expect(MockSummaryWebviewPanel.show).toHaveBeenCalledWith(
@@ -2493,6 +2639,8 @@ describe("Extension", () => {
 						mockBridge,
 						expect.any(String),
 						"kb",
+						null,
+						null,
 					);
 					expect(executeCommand).not.toHaveBeenCalledWith(
 						"markdown.showPreview",
@@ -2534,16 +2682,16 @@ describe("Extension", () => {
 					readFileSync.mockReturnValueOnce(
 						`---\ntype: commit\nbogus-line-without-colon\ncommitHash: 1234567890abcdef\n---\n`,
 					);
-					mockBridge.getSummaryAnyRepo.mockResolvedValueOnce({
-						commitHash: "1234567890abcdef",
-						topics: [],
+					mockBridge.getSummaryAnyRepoWithSource.mockResolvedValueOnce({
+						summary: { commitHash: "1234567890abcdef", topics: [] },
+						sourceRepoName: null,
 					});
 
 					const handler = getRegisteredCommand("jollimemory.openMemoryFile");
 					await handler("/fake/stray.md");
 
 					// Parser ignored the colonless line and still found commitHash.
-					expect(mockBridge.getSummaryAnyRepo).toHaveBeenCalledWith(
+					expect(mockBridge.getSummaryAnyRepoWithSource).toHaveBeenCalledWith(
 						"1234567890abcdef",
 					);
 				});
@@ -2586,16 +2734,61 @@ describe("Extension", () => {
 					readFileSync.mockReturnValueOnce(
 						`---\ntype: commit\ncommitHash: ffffffff00000000\n---\n`,
 					);
-					mockBridge.getSummaryAnyRepo.mockResolvedValueOnce(null);
+					mockBridge.getSummaryAnyRepoWithSource.mockResolvedValueOnce({
+						summary: null,
+						sourceRepoName: null,
+					});
 
 					const handler = getRegisteredCommand("jollimemory.openMemoryFile");
 					await handler("/fake/orphan.md");
 
-					expect(mockBridge.getSummaryAnyRepo).toHaveBeenCalledWith(
+					expect(mockBridge.getSummaryAnyRepoWithSource).toHaveBeenCalledWith(
 						"ffffffff00000000",
 					);
 					expect(MockSummaryWebviewPanel.show).not.toHaveBeenCalled();
 					expect(executeCommand).toHaveBeenCalledWith(
+						"markdown.showPreview",
+						expect.anything(),
+					);
+				});
+
+				it("passes sourceRepoName through to the panel for foreign-origin Memory Bank entries", async () => {
+					// Memory Bank cross-repo provenance: when the clicked .md
+					// belongs to a non-current repo (KBRepoDiscoverer aggregates
+					// every repo under the localFolder parent), the panel must
+					// learn about it so destructive commands (push / edit /
+					// createPr) are disabled — their handlers all write to
+					// `workspaceRoot`'s git / orphan branch and would silently
+					// corrupt the wrong project's Jolli Memory space. Same
+					// provenance contract pinned in the viewMemorySummary test
+					// block above; this entry point is independent of that one.
+					readFileSync.mockReturnValueOnce(
+						`---\ntype: commit\ncommitHash: deadbeefcafef00d\n---\nfrom-other-repo\n`,
+					);
+					const summary = { commitHash: "deadbeefcafef00d", topics: [] };
+					mockBridge.getSummaryAnyRepoWithSource.mockResolvedValueOnce({
+						summary,
+						sourceRepoName: "other-repo",
+						sourceRemoteUrl: "https://github.com/other/repo.git",
+					});
+
+					const handler = getRegisteredCommand("jollimemory.openMemoryFile");
+					await handler("/fake/foreign-repo-summary.md");
+
+					expect(mockBridge.getSummaryAnyRepoWithSource).toHaveBeenCalledWith(
+						"deadbeefcafef00d",
+					);
+					expect(MockSummaryWebviewPanel.show).toHaveBeenCalledWith(
+						summary,
+						expect.anything(),
+						"/test/workspace",
+						mockBridge,
+						expect.any(String),
+						"kb",
+						"other-repo",
+						"https://github.com/other/repo.git",
+					);
+					expect(executeCommand).not.toHaveBeenCalledWith(
 						"markdown.showPreview",
 						expect.anything(),
 					);
@@ -4551,11 +4744,17 @@ describe("Extension", () => {
 			// Cross-repo: external deep links may target a memory whose summary
 			// lives in a non-current repo under the Memory Bank parent, so the
 			// URI handler walks the same aggregated view the Memories tab uses
-			// (getSummaryAnyRepo) — pinned here for the same reason as the
-			// copyRecallPrompt / openInClaudeCode handlers above.
+			// (getSummaryAnyRepoWithSource) — pinned here for the same reason
+			// as the copyRecallPrompt / openInClaudeCode handlers above, with
+			// the provenance variant so the panel can disable destructive
+			// actions for foreign-origin summaries.
 			it("opens SummaryWebviewPanel in commit slot when the summary exists", async () => {
 				const summary = { hash: "abc1234", content: "summary text" };
-				mockBridge.getSummaryAnyRepo.mockResolvedValue(summary);
+				mockBridge.getSummaryAnyRepoWithSource.mockResolvedValueOnce({
+					summary,
+					sourceRepoName: null,
+					sourceRemoteUrl: null,
+				});
 
 				const handler = getHandler();
 				await handler.handleUri({
@@ -4565,7 +4764,7 @@ describe("Extension", () => {
 						"vscode://jolli.jollimemory-vscode/summary/0123456789abcdef0123456789abcdef01234567",
 				});
 
-				expect(mockBridge.getSummaryAnyRepo).toHaveBeenCalledWith(
+				expect(mockBridge.getSummaryAnyRepoWithSource).toHaveBeenCalledWith(
 					"0123456789abcdef0123456789abcdef01234567",
 				);
 				expect(MockSummaryWebviewPanel.show).toHaveBeenCalledWith(
@@ -4575,13 +4774,19 @@ describe("Extension", () => {
 					expect.anything(), // bridge
 					"main", // mainBranch from mocked CommitsStore.getMainBranch()
 					"commit",
+					null,
+					null,
 				);
 				// Summary route must NOT trigger the OAuth path.
 				expect(mockAuthService.handleAuthCallback).not.toHaveBeenCalled();
 			});
 
 			it("shows info message when no summary is found", async () => {
-				mockBridge.getSummaryAnyRepo.mockResolvedValue(null);
+				mockBridge.getSummaryAnyRepoWithSource.mockResolvedValueOnce({
+					summary: null,
+					sourceRepoName: null,
+					sourceRemoteUrl: null,
+				});
 
 				const handler = getHandler();
 				await handler.handleUri({
@@ -4597,12 +4802,48 @@ describe("Extension", () => {
 				expect(MockSummaryWebviewPanel.show).not.toHaveBeenCalled();
 			});
 
+			it("passes sourceRepoName through to the panel for foreign-origin deep links", async () => {
+				// External deep links (Slack message, browser bookmark) may land
+				// on a SHA whose summary lives in a non-current repo under the
+				// Memory Bank parent. Same provenance contract as
+				// viewMemorySummary / openMemoryFile: without `sourceRepoName`
+				// the panel would let the user click Push to Jolli, which
+				// pushes the foreign repo's memory to the *current* repo's
+				// Jolli Memory space, corrupting the wrong project.
+				const summary = { hash: "abc1234", content: "foreign summary" };
+				mockBridge.getSummaryAnyRepoWithSource.mockResolvedValueOnce({
+					summary,
+					sourceRepoName: "other-repo",
+					sourceRemoteUrl: "https://github.com/other/repo.git",
+				});
+
+				const handler = getHandler();
+				await handler.handleUri({
+					path: "/summary/0123456789abcdef0123456789abcdef01234567",
+					query: "",
+					toString: () =>
+						"vscode://jolli.jollimemory-vscode/summary/0123456789abcdef0123456789abcdef01234567",
+				});
+
+				expect(MockSummaryWebviewPanel.show).toHaveBeenCalledWith(
+					summary,
+					expect.anything(),
+					"/test/workspace",
+					expect.anything(), // bridge
+					"main",
+					"commit",
+					"other-repo",
+					"https://github.com/other/repo.git",
+				);
+			});
+
 			it("rejects abbreviated hashes (must be a full 40-char SHA)", async () => {
-				// `bridge.getSummaryAnyRepo` (and the current-repo `getSummary` it
-				// falls back to) walks alias / tree-hash resolution for non-direct
-				// hits, which silently resolves the wrong commit when two distinct
-				// commits share the same tree (cherry-pick, identical re-commit).
-				// Same hardening as `search --hashes`.
+				// `bridge.getSummaryAnyRepoWithSource` (and the current-repo
+				// `getSummary` it falls back to) walks alias / tree-hash
+				// resolution for non-direct hits, which silently resolves the
+				// wrong commit when two distinct commits share the same tree
+				// (cherry-pick, identical re-commit). Same hardening as
+				// `search --hashes`.
 				const handler = getHandler();
 				await handler.handleUri({
 					path: "/summary/abc1234",
@@ -4610,7 +4851,7 @@ describe("Extension", () => {
 					toString: () => "vscode://jolli.jollimemory-vscode/summary/abc1234",
 				});
 
-				expect(mockBridge.getSummaryAnyRepo).not.toHaveBeenCalled();
+				expect(mockBridge.getSummaryAnyRepoWithSource).not.toHaveBeenCalled();
 				expect(MockSummaryWebviewPanel.show).not.toHaveBeenCalled();
 			});
 

--- a/vscode/src/Extension.ts
+++ b/vscode/src/Extension.ts
@@ -635,6 +635,12 @@ export function activate(context: vscode.ExtensionContext): void {
 			kbMode: "folders",
 			branchName: currentBranchName,
 			detached: currentBranchDetached,
+			// Display name of the workspace's repo — feeds the left half of the
+			// header breadcrumb. Without this the webview shows `(workspace)`
+			// as a placeholder and `isViewingForeign()` can't compare repo
+			// identity, so foreign-readonly chrome stays inactive even after
+			// the user picks another repo from the dropdown.
+			currentRepoName: sidebarRepoName,
 		}),
 		extensionUri: context.extensionUri,
 		statusProvider: {
@@ -665,6 +671,31 @@ export function activate(context: vscode.ExtensionContext): void {
 			getMode: historyProvider.getMode.bind(historyProvider),
 		},
 		kbFolders: kbFoldersService,
+		// Breadcrumb dropdowns. The discoverRepos output carries `kbRoot` /
+		// `dirName` fields that the webview doesn't need (selector key is
+		// the configured repoName, with remoteUrl forwarded for cross-repo
+		// PR lookups); flatten to RepoChoice here so SidebarMessages stays
+		// the single source of truth for what crosses the wire.
+		selection: {
+			listRepos: () =>
+				kbFoldersService.listRepos().map((r) => ({
+					repoName: r.repoName,
+					remoteUrl: r.remoteUrl ?? undefined,
+					isCurrent: r.isCurrentRepo,
+				})),
+			listBranches: (repoName: string) =>
+				kbFoldersService.listBranches(repoName),
+			listBranchMemories: async (repoName: string, branchName: string) => {
+				const entries = await bridge.listBranchMemories(repoName, branchName);
+				return entries.map((e) => ({
+					commitHash: e.commitHash,
+					title: e.commitMessage.split("\n")[0] || e.commitHash.slice(0, 8),
+					branch: e.branch,
+					repoName: e.repoName ?? repoName,
+					timestamp: Date.parse(e.commitDate || e.generatedAt) || 0,
+				}));
+			},
+		},
 		// relPath's first segment is now a repo directory name under
 		// <kbParent>; join'ing on kbParent gives back the absolute on-disk
 		// path. Same shape as the IntelliJ Memory Bank tree.
@@ -829,11 +860,20 @@ export function activate(context: vscode.ExtensionContext): void {
 			initializeKBFolder(kbRoot, repoName, remoteUrl);
 
 			// Auto-migrate if orphan branch has data but migration not completed.
-			// This covers two real-world entry points: (1) fresh install of the
-			// folder-mode extension on a repo previously using orphan storage, and
-			// (2) the user manually wiped the KB folder (which also nukes
-			// migration.json, making readMigrationState() return null and forcing
-			// a re-migration).
+			// Three entry points:
+			//   (1) Fresh install of the folder-mode extension on a repo
+			//       previously using orphan storage.
+			//   (2) User manually wiped the KB folder (which also nukes
+			//       migration.json, making readMigrationState() return null
+			//       and forcing a re-migration).
+			//   (3) Already-migrated user whose v1 migration completed before
+			//       v3 stale-child cleanup shipped (or who only got 0.99.2's
+			//       inverted leaf-only pass, which mistakenly deleted heads
+			//       and kept hoisted children). runStaleChildCleanup is
+			//       idempotent via state.staleChildCleanup.completedAt; we
+			//       intentionally do NOT look at state.leafCleanup — that
+			//       legacy flag tracked the inverted pass and must not block
+			//       the corrective re-run.
 			const orphan = new OrphanBranchStorage(workspaceRoot);
 			if (await orphan.exists()) {
 				const mm = new MetadataManager(join(kbRoot, ".jolli"));
@@ -854,6 +894,16 @@ export function activate(context: vscode.ExtensionContext): void {
 					// until the user clicks Refresh — a UX bug that surfaces every
 					// post-wipe reload. Push a reset so the client re-fetches once
 					// migration's writes are on disk.
+					sidebarProvider.refreshKnowledgeBaseFolders();
+				} else if (!migrationState.staleChildCleanup?.completedAt) {
+					const folder = new FolderStorage(kbRoot, mm);
+					await folder.ensure();
+					const engine = new MigrationEngine(orphan, folder, mm);
+					const result = await engine.runStaleChildCleanup();
+					log.info(
+						"activate",
+						`KB v3 stale-child cleanup: completedAt=${result.staleChildCleanup?.completedAt ?? "n/a"}`,
+					);
 					sidebarProvider.refreshKnowledgeBaseFolders();
 				}
 			}
@@ -1815,7 +1865,7 @@ export function activate(context: vscode.ExtensionContext): void {
 				// actions (push/edit) when the summary is from a foreign repo,
 				// since those handlers all write to `workspaceRoot`'s git/
 				// orphan branch and would silently corrupt the wrong project.
-				const { summary, sourceRepoName } =
+				const { summary, sourceRepoName, sourceRemoteUrl } =
 					await bridge.getSummaryAnyRepoWithSource(hash);
 				if (!summary) {
 					vscode.window.showInformationMessage(
@@ -1831,6 +1881,7 @@ export function activate(context: vscode.ExtensionContext): void {
 					commitsStore.getMainBranch(),
 					"memory",
 					sourceRepoName,
+					sourceRemoteUrl,
 				);
 			},
 		),
@@ -1857,11 +1908,16 @@ export function activate(context: vscode.ExtensionContext): void {
 				if (meta) {
 					// Memory Bank folder view shows every repo under the parent
 					// (`localFolder`), so a clicked summary .md may belong to a
-					// non-current repo. Use the cross-repo lookup so the rich
-					// SummaryWebviewPanel renders for foreign-repo memories too;
-					// otherwise we'd silently fall through to plain markdown
-					// preview, losing the push / copy-as-recall affordances.
-					const summary = await bridge.getSummaryAnyRepo(meta.commitHash);
+					// non-current repo. Use the provenance-bearing cross-repo
+					// lookup so the rich SummaryWebviewPanel renders for
+					// foreign-repo memories AND learns which repo the summary
+					// came from. Without `sourceRepoName`, the panel would
+					// allow destructive commands (push / edit / createPr) that
+					// write to `workspaceRoot`'s git / orphan branch — silently
+					// pushing a foreign repo's memory to the *current* repo's
+					// Jolli Memory space, corrupting the wrong project.
+					const { summary, sourceRepoName, sourceRemoteUrl } =
+						await bridge.getSummaryAnyRepoWithSource(meta.commitHash);
 					if (summary) {
 						await SummaryWebviewPanel.show(
 							summary,
@@ -1870,6 +1926,8 @@ export function activate(context: vscode.ExtensionContext): void {
 							bridge,
 							commitsStore.getMainBranch(),
 							"kb",
+							sourceRepoName,
+							sourceRemoteUrl,
 						);
 						return;
 					}
@@ -2143,13 +2201,18 @@ export function activate(context: vscode.ExtensionContext): void {
 				// Cross-repo: external deep links into vscode://…/summary/<sha> may
 				// target a memory whose summary lives in a non-current repo under
 				// the Memory Bank parent (e.g. a Slack link pasted while a different
-				// workspace is open). Use getSummaryAnyRepo so the deep link resolves
-				// against the same aggregated view the Memories tab presents.
+				// workspace is open). Use the provenance-bearing cross-repo lookup
+				// so the panel learns which repo the summary came from; without
+				// `sourceRepoName`, destructive commands (push / edit / createPr)
+				// would write to `workspaceRoot`'s git / orphan branch and silently
+				// route the foreign repo's memory to the *current* repo's Jolli
+				// Memory space.
 				const summaryMatch = uri.path.match(/^\/summary\/([0-9a-f]{40})$/);
 				if (summaryMatch) {
 					const hash = summaryMatch[1];
 					const shortHash = hash.substring(0, 7);
-					const summary = await bridge.getSummaryAnyRepo(hash);
+					const { summary, sourceRepoName, sourceRemoteUrl } =
+						await bridge.getSummaryAnyRepoWithSource(hash);
 					if (!summary) {
 						vscode.window.showInformationMessage(
 							`Jolli Memory: No summary found for commit ${shortHash}.`,
@@ -2163,6 +2226,8 @@ export function activate(context: vscode.ExtensionContext): void {
 						bridge,
 						commitsStore.getMainBranch(),
 						"commit",
+						sourceRepoName,
+						sourceRemoteUrl,
 					);
 					return;
 				}

--- a/vscode/src/JolliMemoryBridge.test.ts
+++ b/vscode/src/JolliMemoryBridge.test.ts
@@ -2206,7 +2206,7 @@ describe("JolliMemoryBridge", () => {
 		// Without provenance the panel could load a foreign-origin summary
 		// and then accept push/edit messages that write to the WRONG repo.
 
-		it("returns sourceRepoName=null when the summary lives in the current repo", async () => {
+		it("returns sourceRepoName=null and sourceRemoteUrl=null when the summary lives in the current repo", async () => {
 			const own = { commitHash: "aaa", topics: [] };
 			getSummary.mockResolvedValueOnce(own);
 			const bridge = makeBridge();
@@ -2217,10 +2217,11 @@ describe("JolliMemoryBridge", () => {
 			// null is the load-bearing signal here — non-null would silently
 			// flip the panel to read-only even though the summary is local.
 			expect(result.sourceRepoName).toBeNull();
+			expect(result.sourceRemoteUrl).toBeNull();
 			expect(discoverRepos).not.toHaveBeenCalled();
 		});
 
-		it("returns sourceRepoName=<foreign repoName> when the summary falls through to a non-current repo", async () => {
+		it("returns sourceRepoName and sourceRemoteUrl from the foreign DiscoveredRepo when the summary falls through", async () => {
 			const foreign = { commitHash: "bbb", topics: [] };
 			getSummary.mockResolvedValueOnce(null).mockResolvedValueOnce(foreign);
 			discoverRepos.mockReturnValue([
@@ -2235,7 +2236,12 @@ describe("JolliMemoryBridge", () => {
 					kbRoot: "/mock/home/Documents/jolli/other-repo",
 					repoName: "other-repo",
 					dirName: "other-repo",
-					remoteUrl: null,
+					// remoteUrl is the load-bearing field for the new PR-section
+					// foreign path: the panel hands it to PrCommentService which
+					// pins gh to `--repo <url>`. A regression that dropped this
+					// field would silently fall back to querying the current
+					// workspace's PR (data leak), so we pin the propagation here.
+					remoteUrl: "https://github.com/other/repo.git",
 					isCurrentRepo: false,
 				},
 			]);
@@ -2244,14 +2250,11 @@ describe("JolliMemoryBridge", () => {
 			const result = await bridge.getSummaryAnyRepoWithSource("bbb");
 
 			expect(result.summary).toEqual(foreign);
-			// The repoName is the one from DiscoveredRepo (config.repoName,
-			// not dirName) — it's what the panel surfaces in the title and
-			// the "denied" notification, so users see a name they recognize
-			// from the Memory Bank tree, not a collision-suffixed dirname.
 			expect(result.sourceRepoName).toBe("other-repo");
+			expect(result.sourceRemoteUrl).toBe("https://github.com/other/repo.git");
 		});
 
-		it("returns sourceRepoName=null when no repo has the summary", async () => {
+		it("returns sourceRepoName=null and sourceRemoteUrl=null when no repo has the summary", async () => {
 			getSummary.mockResolvedValue(null);
 			discoverRepos.mockReturnValue([]);
 			const bridge = makeBridge();
@@ -2260,6 +2263,7 @@ describe("JolliMemoryBridge", () => {
 
 			expect(result.summary).toBeNull();
 			expect(result.sourceRepoName).toBeNull();
+			expect(result.sourceRemoteUrl).toBeNull();
 		});
 	});
 
@@ -2873,6 +2877,100 @@ describe("JolliMemoryBridge", () => {
 		});
 	});
 
+	// ── listBranchMemories ──────────────────────────────────────────
+
+	describe("listBranchMemories()", () => {
+		function makeEntry(
+			hash: string,
+			date: string,
+			msg: string,
+			branch: string,
+			parent?: string,
+		) {
+			return {
+				commitHash: hash,
+				commitDate: date,
+				commitMessage: msg,
+				branch,
+				parentCommitHash: parent ?? null,
+				topicCount: 1,
+			};
+		}
+
+		it("dedupes commitAliases that point to the same head — alias from rebase-pick must not double-count", async () => {
+			// Regression: getIndexEntryMap registers each entry under BOTH its
+			// canonical commitHash and every alias from index.commitAliases.
+			// A real-world observation: alias `8d8ac10f → c5801c12` (rebase-pick
+			// produced the alias) made `map.values()` yield the c5801c12 entry
+			// twice, so listBranchMemories returned [c5801c12, c5801c12, af74e2cb]
+			// and the sidebar rendered three rows for two heads. Fix: dedup by
+			// commitHash, mirroring listSummaryEntries.
+			const head1 = makeEntry(
+				"aaa",
+				"2025-01-01T00:00:00Z",
+				"First head",
+				"main",
+			);
+			const head2 = makeEntry(
+				"bbb",
+				"2025-01-02T00:00:00Z",
+				"Second head",
+				"main",
+			);
+			// Simulate the Map shape returned by getIndexEntryMap when commitAliases
+			// is present: an alias key `aliasaaa` points to the SAME entry object
+			// as `aaa`. Both keys enumerate via `.values()`.
+			getIndexEntryMap.mockResolvedValue(
+				new Map([
+					["aaa", head1],
+					["aliasaaa", head1], // alias for aaa
+					["bbb", head2],
+				]),
+			);
+
+			const bridge = makeBridge();
+			const result = await bridge.listBranchMemories("test-repo", "main");
+			expect(result.map((e) => e.commitHash).sort()).toEqual(["aaa", "bbb"]);
+			expect(result).toHaveLength(2);
+		});
+
+		it("returns only v4 Hoist heads (parent=null) on the named branch", async () => {
+			// `aaa` is the live head (parent=null). `bbb` is a hoisted older
+			// version (parent=aaa). Under v4 Hoist semantics the head surfaces;
+			// `bbb` is internal history that lives inside aaa.children[].
+			const head = makeEntry("aaa", "2025-01-01T00:00:00Z", "head", "main");
+			const hoisted = makeEntry(
+				"bbb",
+				"2025-01-02T00:00:00Z",
+				"hoisted older version",
+				"main",
+				"aaa",
+			);
+			const other = makeEntry(
+				"ccc",
+				"2025-01-03T00:00:00Z",
+				"other branch",
+				"feature",
+			);
+			getIndexEntryMap.mockResolvedValue(
+				new Map([
+					["aaa", head],
+					["bbb", hoisted],
+					["ccc", other],
+				]),
+			);
+
+			const bridge = makeBridge();
+			// Pass the mocked currentRepoName ("test-repo") so listBranchMemories
+			// routes through the workspace-storage branch — that path uses the
+			// already-mocked getIndexEntryMap. Foreign routing goes through
+			// discoverRepos (which is mocked to []), so foreign callers would
+			// short-circuit before reaching the index.
+			const result = await bridge.listBranchMemories("test-repo", "main");
+			expect(result.map((e) => e.commitHash)).toEqual(["aaa"]);
+		});
+	});
+
 	// ── resolveCommitMeta (tested indirectly via listBranchCommits) ──────
 
 	describe("resolveCommitMeta edge cases", () => {
@@ -3119,27 +3217,85 @@ describe("JolliMemoryBridge", () => {
 			expect(result.totalCount).toBe(3);
 		});
 
-		it("filters out entries with parentCommitHash", async () => {
-			const root = makeEntry("aaa", "2025-01-01T00:00:00Z", "root", "main");
-			const child = makeEntry(
+		it("filters hoisted older versions out, surfacing only the head", async () => {
+			// `aaa` is the live head (parent=null). `bbb` was hoisted into
+			// aaa.children[] by squash/amend — it represents an older version
+			// of the same commit. Display surfaces the head, hides bbb.
+			const head = makeEntry("aaa", "2025-01-01T00:00:00Z", "head", "main");
+			const hoisted = makeEntry(
 				"bbb",
 				"2025-01-02T00:00:00Z",
-				"child",
+				"hoisted older version",
 				"main",
 				"aaa",
 			);
 			getIndexEntryMap.mockResolvedValue(
 				new Map([
-					["aaa", root],
-					["bbb", child],
+					["aaa", head],
+					["bbb", hoisted],
 				]),
 			);
 
 			const bridge = makeBridge();
 			const result = await bridge.listSummaryEntries(10);
 
+			// New semantics (v4 Hoist): heads only. `aaa` is the head, `bbb`
+			// hides as internal history under aaa.children[].
 			expect(result.entries).toHaveLength(1);
 			expect(result.entries[0].commitHash).toBe("aaa");
+		});
+
+		it("surfaces every parent=null head on a branch regardless of cross-branch parent pointers", async () => {
+			// Two independent heads, one on each branch. The head test is
+			// strictly per-entry (parentCommitHash == null), so branch labels
+			// and stray cross-branch parent pointers don't change the result.
+			const xHead = makeEntry(
+				"aaa",
+				"2025-01-01T00:00:00Z",
+				"X head",
+				"feature-x",
+			);
+			const yHead = makeEntry(
+				"bbb",
+				"2025-01-02T00:00:00Z",
+				"Y head",
+				"feature-y",
+			);
+			getIndexEntryMap.mockResolvedValue(
+				new Map([
+					["aaa", xHead],
+					["bbb", yHead],
+				]),
+			);
+
+			const bridge = makeBridge();
+			const result = await bridge.listSummaryEntries(10);
+
+			expect(result.entries.map((e) => e.commitHash).sort()).toEqual([
+				"aaa",
+				"bbb",
+			]);
+		});
+
+		it("does NOT surface an entry whose parent is missing from the index (semantics change vs old leaf filter)", async () => {
+			// Only the hoisted child remains; its head was dropped from the
+			// index (corrupt/partial state). The old ChainLeafFilter treated
+			// this as "dangling parent → root → leaf" and surfaced it. The
+			// v4 Hoist head test is stricter: parentCommitHash has a non-null
+			// value, so this is categorically not a head. Reflecting that
+			// honestly is more useful than papering over corrupt state.
+			const orphanedChild = makeEntry(
+				"bbb",
+				"2025-01-02T00:00:00Z",
+				"orphan child",
+				"main",
+				"aaa",
+			);
+			getIndexEntryMap.mockResolvedValue(new Map([["bbb", orphanedChild]]));
+
+			const bridge = makeBridge();
+			const result = await bridge.listSummaryEntries(10);
+			expect(result.entries).toHaveLength(0);
 		});
 
 		it("deduplicates aliases with the same commitHash", async () => {

--- a/vscode/src/JolliMemoryBridge.ts
+++ b/vscode/src/JolliMemoryBridge.ts
@@ -18,6 +18,7 @@ import { join } from "node:path";
 import { promisify } from "node:util";
 import { FolderStorage } from "../../cli/src/core/FolderStorage.js";
 import { getDiffStats } from "../../cli/src/core/GitOps.js";
+import { filterToBranchHeads } from "../../cli/src/core/HeadEntryFilter.js";
 import {
 	extractRepoName,
 	getRemoteUrl,
@@ -1389,17 +1390,17 @@ export class JolliMemoryBridge {
 				);
 			}
 
-			// Deduplicate by commitHash. Current-repo entries were pushed first
-			// so when a tree-hash alias links the same commit across two repo
-			// folders (rare, but possible after rebase-pick across a fork) the
-			// current-repo copy wins — which is the version the user expects to
-			// see in their own workspace.
+			// Head filter is the headline behavior: keeps only v4 Hoist roots
+			// (`parentCommitHash == null` — the live commit version), hiding
+			// every older version hoisted into some head's children[]. The
+			// trailing dedup is a separate concern — same commit can appear
+			// under two repos via tree-hash aliasing, and the current-repo
+			// copy wins (it was pushed to `merged` first in step 1).
 			const seen = new Set<string>();
-			this.cachedRootEntries = merged
+			const heads = filterToBranchHeads(merged);
+			this.cachedRootEntries = heads
 				.filter((e) => {
-					if (e.parentCommitHash != null || seen.has(e.commitHash)) {
-						return false;
-					}
+					if (seen.has(e.commitHash)) return false;
 					seen.add(e.commitHash);
 					return true;
 				})
@@ -1428,6 +1429,93 @@ export class JolliMemoryBridge {
 	/** Clears the cached root entries so the next listSummaryEntries call re-reads the index. */
 	invalidateEntriesCache(): void {
 		this.cachedRootEntries = null;
+	}
+
+	/**
+	 * Lists every head {@link SummaryIndexEntry} stored for one specific
+	 * repo's one specific branch. Used by the sidebar's foreign-readonly view
+	 * where the user picked a non-workspace branch from the breadcrumb
+	 * dropdown and expects the Memories section to match the Memory Bank
+	 * tree's count for that branch.
+	 *
+	 * Filter semantics aligned with {@link listSummaryEntries}: both apply
+	 * {@link filterToBranchHeads} — only entries with `parentCommitHash == null`
+	 * (v4 Hoist roots, the live commit versions) surface. Older versions that
+	 * have been hoisted into some head's children[] stay hidden. This keeps
+	 * the Memory Bank tree count, Memories panel count, and these counts in
+	 * agreement.
+	 *
+	 * Resolves the right storage based on whether `repoName` is the workspace
+	 * repo (uses the active storage configured for the workspace) or a foreign
+	 * one (instantiates {@link FolderStorage} pointed at that repo's kbRoot,
+	 * mirroring how {@link listSummaryEntries} step 2 walks discovered repos).
+	 */
+	async listBranchMemories(
+		repoName: string,
+		branchName: string,
+	): Promise<ReadonlyArray<SummaryIndexEntry>> {
+		const currentRepoName = extractRepoName(this.cwd);
+		let storage: StorageProvider;
+		let cwd: string | undefined;
+		if (repoName === currentRepoName) {
+			storage = await this.getStorage();
+			cwd = this.cwd;
+		} else {
+			try {
+				const cfg = (await loadConfig()) as Record<string, unknown>;
+				const customKBPath = cfg.localFolder as string | undefined;
+				const kbParent = resolveKbParent(customKBPath);
+				const currentRemoteUrl = getRemoteUrl(this.cwd);
+				const repos = discoverRepos(
+					currentRepoName,
+					currentRemoteUrl,
+					kbParent,
+				);
+				const target = repos.find((r) => r.repoName === repoName);
+				if (!target) return [];
+				const mm = new MetadataManager(join(target.kbRoot, ".jolli"));
+				storage = new FolderStorage(target.kbRoot, mm);
+				cwd = undefined;
+			} catch (err) {
+				log.warn(
+					"listBranchMemories",
+					`Failed to resolve foreign repo '${repoName}': ${
+						err instanceof Error ? err.message : String(err)
+					}`,
+				);
+				return [];
+			}
+		}
+
+		try {
+			const map = await getIndexEntryMap(cwd, storage);
+			// `getIndexEntryMap` registers each entry under both its canonical
+			// commitHash AND every alias hash from `index.commitAliases` (set by
+			// rebase-pick / tree-hash cross-branch matching). So `map.values()`
+			// can return the same entry object multiple times. Dedup by
+			// commitHash before returning, mirroring listSummaryEntries' step 3.
+			const seen = new Set<string>();
+			const branchEntries: SummaryIndexEntry[] = [];
+			for (const entry of map.values()) {
+				if (entry.branch !== branchName) continue;
+				if (seen.has(entry.commitHash)) continue;
+				seen.add(entry.commitHash);
+				branchEntries.push({ ...entry, repoName });
+			}
+			const heads = filterToBranchHeads(branchEntries);
+			heads.sort(
+				(a, b) => Date.parse(getDisplayDate(b)) - Date.parse(getDisplayDate(a)),
+			);
+			return heads;
+		} catch (err) {
+			log.warn(
+				"listBranchMemories",
+				`Failed to load entries: ${
+					err instanceof Error ? err.message : String(err)
+				}`,
+			);
+			return [];
+		}
 	}
 
 	/**
@@ -1466,21 +1554,32 @@ export class JolliMemoryBridge {
 
 	/**
 	 * Same lookup as {@link getSummaryAnyRepo} but also returns the source
-	 * repo's `repoName` when the hit came from a non-current repo. Callers
-	 * that need to gate write actions (panel push/edit) on foreign-vs-local
-	 * provenance use this; callers that only need to render the summary
+	 * repo's `repoName` and `remoteUrl` when the hit came from a non-current
+	 * repo. Callers that need to gate write actions on foreign-vs-local
+	 * provenance use `sourceRepoName`; callers that need to drive read-only
+	 * remote queries against the foreign repo (e.g. `gh pr view --repo …`)
+	 * use `sourceRemoteUrl`. Callers that only need to render the summary
 	 * use the thinner {@link getSummaryAnyRepo} wrapper.
 	 *
 	 * `sourceRepoName: null` means the summary was found in the current
 	 * workspace's primary storage — safe for read+write. A non-null value
 	 * means the summary lives in another repo's FolderStorage; the caller
-	 * must treat the panel as read-only.
+	 * must treat the panel as read-only. `sourceRemoteUrl` is null when no
+	 * remoteUrl was recorded in that KB folder's config (local-only repo).
 	 */
-	async getSummaryAnyRepoWithSource(
-		hash: string,
-	): Promise<{ summary: CommitSummary | null; sourceRepoName: string | null }> {
+	async getSummaryAnyRepoWithSource(hash: string): Promise<{
+		summary: CommitSummary | null;
+		sourceRepoName: string | null;
+		sourceRemoteUrl: string | null;
+	}> {
 		const current = await this.getSummary(hash);
-		if (current) return { summary: current, sourceRepoName: null };
+		if (current) {
+			return {
+				summary: current,
+				sourceRepoName: null,
+				sourceRemoteUrl: null,
+			};
+		}
 
 		try {
 			const cfg = (await loadConfig()) as Record<string, unknown>;
@@ -1496,7 +1595,11 @@ export class JolliMemoryBridge {
 					const repoStorage = new FolderStorage(repo.kbRoot, mm);
 					const summary = await getSummary(hash, undefined, repoStorage);
 					if (summary) {
-						return { summary, sourceRepoName: repo.repoName };
+						return {
+							summary,
+							sourceRepoName: repo.repoName,
+							sourceRemoteUrl: repo.remoteUrl,
+						};
 					}
 				} catch (err) {
 					log.warn(
@@ -1515,7 +1618,7 @@ export class JolliMemoryBridge {
 				}`,
 			);
 		}
-		return { summary: null, sourceRepoName: null };
+		return { summary: null, sourceRepoName: null, sourceRemoteUrl: null };
 	}
 
 	// ── Git utility methods ───────────────────────────────────────────────

--- a/vscode/src/services/KbFoldersService.test.ts
+++ b/vscode/src/services/KbFoldersService.test.ts
@@ -811,6 +811,70 @@ describe("KbFoldersService — multi-repo & parent listing", () => {
 	});
 });
 
+describe("KbFoldersService — breadcrumb selection helpers", () => {
+	let tmpParent: string;
+	let svc: KbFoldersService;
+
+	beforeEach(() => {
+		tmpParent = mkdtempSync(join(tmpdir(), "kbfolders-sel-"));
+	});
+	afterEach(() => {
+		rmSync(tmpParent, { recursive: true, force: true });
+	});
+
+	it("listRepos surfaces every Memory Bank repo with isCurrentRepo set against the workspace identity", () => {
+		seedRepo(tmpParent, "alpha", { repoName: "alpha" });
+		seedRepo(tmpParent, "beta", { repoName: "beta" });
+		svc = new KbFoldersService(() => ({
+			kbParent: tmpParent,
+			currentRepoName: "beta",
+			currentRemoteUrl: null,
+		}));
+		const repos = svc.listRepos();
+		expect(repos.map((r) => r.repoName).sort()).toEqual(["alpha", "beta"]);
+		const beta = repos.find((r) => r.repoName === "beta");
+		expect(beta?.isCurrentRepo).toBe(true);
+		const alpha = repos.find((r) => r.repoName === "alpha");
+		expect(alpha?.isCurrentRepo).toBe(false);
+	});
+
+	it("listBranches returns branches.json mappings (canonical names, not folder names) for the named repo", () => {
+		const repoDir = seedRepo(tmpParent, "alpha", { repoName: "alpha" });
+		// Drive the registry via resolveFolderForBranch so the sanitization
+		// transcode (e.g. `feature/x` → `feature-x`) is exercised — listBranches
+		// must return the original branch name, not the on-disk folder.
+		const mm = new MetadataManager(join(repoDir, ".jolli"));
+		mm.resolveFolderForBranch("main");
+		mm.resolveFolderForBranch("feature/x");
+		svc = new KbFoldersService(() => ({
+			kbParent: tmpParent,
+			currentRepoName: "alpha",
+			currentRemoteUrl: null,
+		}));
+		expect(svc.listBranches("alpha")).toEqual(["feature/x", "main"]);
+	});
+
+	it("listBranches returns [] for an unknown repo without throwing", () => {
+		seedRepo(tmpParent, "alpha", { repoName: "alpha" });
+		svc = new KbFoldersService(() => ({
+			kbParent: tmpParent,
+			currentRepoName: "alpha",
+			currentRemoteUrl: null,
+		}));
+		expect(svc.listBranches("does-not-exist")).toEqual([]);
+	});
+
+	it("listBranches returns [] when the repo has no branches.json yet (fresh repo)", () => {
+		seedRepo(tmpParent, "alpha", { repoName: "alpha" });
+		svc = new KbFoldersService(() => ({
+			kbParent: tmpParent,
+			currentRepoName: "alpha",
+			currentRemoteUrl: null,
+		}));
+		expect(svc.listBranches("alpha")).toEqual([]);
+	});
+});
+
 describe("parseMdTitle", () => {
 	it("extracts a basic H1", () => {
 		expect(parseMdTitle("# hello\nbody")).toBe("hello");

--- a/vscode/src/services/KbFoldersService.ts
+++ b/vscode/src/services/KbFoldersService.ts
@@ -78,6 +78,40 @@ export interface KbFoldersContext {
 export class KbFoldersService {
 	constructor(private readonly getContext: () => KbFoldersContext) {}
 
+	/**
+	 * Enumerates every Memory Bank repo under `<kbParent>`. Wraps `discoverRepos`
+	 * with the cached context (kbParent / currentRepoName / currentRemoteUrl).
+	 * Used by the sidebar breadcrumb to populate the repo dropdown — `isCurrentRepo`
+	 * flags the workspace's own repo for sorting / labeling.
+	 */
+	listRepos(): readonly DiscoveredRepo[] {
+		const ctx = this.getContext();
+		return discoverRepos(
+			ctx.currentRepoName,
+			ctx.currentRemoteUrl,
+			ctx.kbParent,
+		);
+	}
+
+	/**
+	 * Lists every branch known for a discovered repo. The source of truth is
+	 * `<kbRoot>/.jolli/branches.json` (`MetadataManager.listBranchMappings()`),
+	 * not a `readdirSync` of `<kbRoot>` — git allows `/` in branch names which
+	 * get sanitized on disk, and the mapping preserves the original branch
+	 * name; scanning the filesystem would also surface user-dropped folders as
+	 * fake branches. Result is de-duplicated and sorted alphabetically. An
+	 * unknown repo returns `[]`; a fresh repo with no `branches.json` yet
+	 * also returns `[]` because `MetadataManager` defaults to an empty
+	 * mapping registry (readJson swallows missing-file / parse errors).
+	 */
+	listBranches(repoName: string): readonly string[] {
+		const repo = this.listRepos().find((r) => r.repoName === repoName);
+		if (!repo) return [];
+		const mm = new MetadataManager(join(repo.kbRoot, ".jolli"));
+		const names = mm.listBranchMappings().map((m) => m.branch);
+		return Array.from(new Set(names)).sort();
+	}
+
 	async listChildren(relPath: string): Promise<FolderNode> {
 		const safe = this.validateRelPath(relPath);
 		const ctx = this.getContext();

--- a/vscode/src/services/PrCommentService.test.ts
+++ b/vscode/src/services/PrCommentService.test.ts
@@ -1035,6 +1035,75 @@ describe("PrCommentService", () => {
 
 			expect(prListHeadArg).toBe("feature/current");
 		});
+
+		// ─── Explicit-repo (foreign) path ───────────────────────────────────
+		// Memory Bank cross-repo browsing: when the panel knows the summary
+		// belongs to a non-current repo, it passes the foreign repo's
+		// remoteUrl as the 4th arg. The handler must skip the cwd-bound
+		// current-branch lookup and instead pin every gh command to
+		// `--repo <url>`. Without this, the panel would either query the
+		// wrong repo's PR (silent data leak) or sit stuck on "Checking PR
+		// status..." because the dispatch guard rejected the message.
+		describe("foreign-repo path (gh --repo)", () => {
+			it("skips git lookups and pins `gh pr view` to the supplied remote url", async () => {
+				const ghPrCalls: Array<Array<string>> = [];
+				setupExecFile((cmd, args) => {
+					if (cmd === "git") {
+						// Any git invocation here is a regression: foreign-repo
+						// path has no working tree to query.
+						throw new Error(`unexpected git ${args.join(" ")}`);
+					}
+					if (cmd === "gh" && args[0] === "--version") {
+						return { stdout: "gh version 2.40.0\n" };
+					}
+					if (cmd === "gh" && args[0] === "auth") {
+						return { stdout: "Logged in\n" };
+					}
+					if (cmd === "gh" && args[0] === "pr") {
+						ghPrCalls.push(args);
+						return {
+							stdout: JSON.stringify({
+								number: 7,
+								url: "https://github.com/other/repo/pull/7",
+								title: "Foreign PR",
+								body: "",
+							}),
+						};
+					}
+					return { stdout: "" };
+				});
+
+				await handleCheckPrStatus(
+					CWD,
+					postMessage,
+					"feature/foreign-branch",
+					"https://github.com/other/repo.git",
+				);
+
+				expect(ghPrCalls).toHaveLength(1);
+				expect(ghPrCalls[0]).toEqual(
+					expect.arrayContaining([
+						"--repo",
+						"https://github.com/other/repo.git",
+					]),
+				);
+				// targetBranch must come from summaryBranch — never from
+				// `getCurrentBranch(cwd)` (cwd is the current repo, not the
+				// foreign one).
+				expect(ghPrCalls[0]).toEqual(
+					expect.arrayContaining(["feature/foreign-branch"]),
+				);
+				expect(postMessage).toHaveBeenCalledWith({
+					command: "prStatus",
+					status: "ready",
+					pr: {
+						number: 7,
+						url: "https://github.com/other/repo/pull/7",
+						title: "Foreign PR",
+					},
+				});
+			});
+		});
 	});
 
 	// ─── handleCreatePr ─────────────────────────────────────────────────────

--- a/vscode/src/services/PrCommentService.ts
+++ b/vscode/src/services/PrCommentService.ts
@@ -246,8 +246,26 @@ type PrLookup =
  * argument rather than a flag. This is a defense-in-depth measure since the
  * value originates from persisted JSON on the orphan branch.
  */
-async function findPrForBranch(cwd: string, branch: string): Promise<PrLookup> {
-	const args = ["pr", "view", "--json", "number,url,title,body", "--", branch];
+async function findPrForBranch(
+	cwd: string,
+	branch: string,
+	repoUrl?: string | null,
+): Promise<PrLookup> {
+	// When repoUrl is provided we are looking up a PR for a non-current
+	// repo (Memory Bank cross-repo browsing). gh resolves --repo via the
+	// REST API so the spawn cwd no longer needs to be inside a git working
+	// tree; the local cwd is still passed because spawn requires one and
+	// it doubles as a sensible default for stderr / temp-file locality.
+	const repoArgs = repoUrl ? ["--repo", repoUrl] : [];
+	const args = [
+		"pr",
+		"view",
+		"--json",
+		"number,url,title,body",
+		...repoArgs,
+		"--",
+		branch,
+	];
 	const result = await tryExecGh(args, cwd);
 
 	if (!result.ok) {
@@ -361,8 +379,19 @@ export async function handleCheckPrStatus(
 	cwd: string,
 	postMessage: PostMessageFn,
 	summaryBranch?: string,
+	repoUrl?: string | null,
 ): Promise<void> {
 	try {
+		// Foreign-repo path (Memory Bank cross-repo browsing): when the
+		// caller hands us an explicit repoUrl, the panel is showing a
+		// summary that belongs to a non-current repo. The cwd-bound
+		// current-branch fallback would describe the *current* repo, so we
+		// require summaryBranch and let `findPrForBranch` route the gh call
+		// through `--repo`.
+		if (repoUrl && !summaryBranch) {
+			postMessage({ command: "prStatus", status: "unavailable" });
+			return;
+		}
 		const targetBranch = summaryBranch ?? (await getCurrentBranch(cwd));
 
 		// Check gh availability — distinguish "not installed" (definitive) from
@@ -390,7 +419,7 @@ export async function handleCheckPrStatus(
 		}
 
 		// Always pass an explicit branch — never rely on HEAD semantics
-		const lookup = await findPrForBranch(cwd, targetBranch);
+		const lookup = await findPrForBranch(cwd, targetBranch, repoUrl);
 
 		if (lookup.kind === "lookupError") {
 			// Reuse the `unavailable + reason` channel (already wired for the

--- a/vscode/src/views/SidebarCssBuilder.test.ts
+++ b/vscode/src/views/SidebarCssBuilder.test.ts
@@ -336,4 +336,27 @@ describe("onboarding panel styles", () => {
 		// first paint.
 		expect(css).toMatch(/\.ob-btn:disabled\s*\{/);
 	});
+
+	it("caps the breadcrumb dropdown and lets the inner list scroll", () => {
+		const css = buildSidebarCss();
+		// The outer .dropdown-menu becomes a flex column so the search header
+		// stays pinned while .dropdown-list scrolls. Without max-height the
+		// long branch list overflows the viewport with no scrollbar (the
+		// original bug). Without min-height:0 on the flex child, overflow on
+		// .dropdown-list is silently ignored — a classic flex foot-gun.
+		expect(css).toMatch(/\.dropdown-menu\s*\{[^}]*max-height:\s*50vh/);
+		expect(css).toMatch(/\.dropdown-menu\s*\{[^}]*flex-direction:\s*column/);
+		expect(css).toMatch(/\.dropdown-list\s*\{[^}]*overflow-y:\s*auto/);
+		expect(css).toMatch(/\.dropdown-list\s*\{[^}]*min-height:\s*0/);
+	});
+
+	it("declares the breadcrumb dropdown search and empty-state classes", () => {
+		const css = buildSidebarCss();
+		// Search input is themed against --vscode-input-* so it matches the
+		// rest of the host UI. The empty-state row is the "No matches" line
+		// the script shows when the filter clears every row.
+		expect(css).toContain(".dropdown-search");
+		expect(css).toContain(".dropdown-empty");
+		expect(css).toContain("var(--vscode-input-background)");
+	});
 });

--- a/vscode/src/views/SidebarCssBuilder.ts
+++ b/vscode/src/views/SidebarCssBuilder.ts
@@ -48,70 +48,185 @@ export function buildSidebarCss(): string {
     background: var(--vscode-button-hoverBackground, var(--vscode-button-background));
   }
 
+  /* Header bar — was the tab-bar in the previous tab-UI design; now a flex
+     row with breadcrumb on the left and a fixed icon strip on the right.
+     The old .tab class names (data-tab="kb" / data-tab="status") are kept on
+     the icon buttons so the script's existing switchTab dispatch keeps
+     working — only the visual treatment changed. */
   .tab-bar {
     display: flex;
+    align-items: center;
     background: var(--vscode-sideBarSectionHeader-background, transparent);
     border-bottom: 1px solid var(--vscode-panel-border, rgba(128,128,128,0.2));
     flex-shrink: 0;
+    gap: 4px;
+    padding: 2px 4px 2px 6px;
+    min-height: 28px;
   }
-  /* Labeled tabs (Branch / Memory Bank) size to their content rather than
-     splitting the tab-bar evenly: flex-grow:0 stops them from claiming free
-     space, flex-basis:auto starts them at the natural label width, and
-     flex-shrink:1 + min-width:0 still let them collapse with text-overflow
-     when the sidebar is too narrow to fit them. max-width caps a single
-     long branch name (e.g. "feature/JOLLI-9999-long-name") so it can't
-     push the right-side toolbar off-screen. The status-indicator pill
-     overrides this with flex: 0 0 auto below. */
-  .tab {
-    flex: 0 1 auto;
-    max-width: 180px;
-    padding: 6px 6px;
-    font-size: 11px;
-    color: var(--vscode-descriptionForeground);
-    cursor: pointer;
-    border: none;
-    background: transparent;
-    border-bottom: 2px solid transparent;
-    /* inline-flex centers icon+label horizontally; min-width:0 lets the
-       label span shrink with text-overflow inside the flex item. */
+
+  /* Breadcrumb: <repo-seg> / <branch-seg>. Each segment is a button so the
+     dropdown affordance is keyboard-reachable; when there's only one repo
+     (the workspace's own) the chevron is removed by toggling .hidden on
+     .breadcrumb-seg-chevron and the segment behaves like static text. */
+  .breadcrumb {
     display: inline-flex;
     align-items: center;
-    justify-content: center;
+    gap: 2px;
+    min-width: 0;
+    flex: 1 1 auto;
+  }
+  .breadcrumb-seg {
+    display: inline-flex;
+    align-items: center;
     gap: 4px;
+    padding: 3px 6px;
+    border: none;
+    background: transparent;
+    color: var(--vscode-foreground);
+    cursor: pointer;
+    font-size: 11px;
+    border-radius: 3px;
     min-width: 0;
   }
-  .tab .tab-icon-leading {
-    flex: 0 0 auto;
-    font-size: 14px;
-    line-height: 1;
-  }
-  .tab .tab-label {
+  .breadcrumb-seg:hover { background: var(--vscode-toolbar-hoverBackground, rgba(128,128,128,0.15)); }
+  .breadcrumb-seg[aria-expanded="true"] { background: var(--vscode-toolbar-activeBackground, rgba(0,122,204,0.2)); }
+  .breadcrumb-seg-icon { flex: 0 0 auto; font-size: 13px; opacity: 0.8; }
+  .breadcrumb-seg-label {
     min-width: 0;
+    max-width: 140px;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
   }
-  .tab.active {
-    color: var(--vscode-foreground);
-    border-bottom-color: var(--vscode-focusBorder, #007acc);
+  .breadcrumb-seg-chevron { flex: 0 0 auto; font-size: 11px; opacity: 0.6; }
+  .breadcrumb-sep {
+    color: var(--vscode-descriptionForeground);
+    font-size: 11px;
+    flex: 0 0 auto;
+    user-select: none;
   }
-  .tab:hover { color: var(--vscode-foreground); }
+  /* Right-side icon strip — Memory Bank / Settings / Status. \`margin-left: auto\`
+     pins it to the right when the breadcrumb collapses; \`flex-shrink: 0\` stops
+     it from being elided when the sidebar is narrow (the breadcrumb truncates
+     instead via text-overflow on .breadcrumb-seg-label). */
+  .tab-bar-right { display: flex; align-items: center; gap: 2px; margin-left: auto; flex-shrink: 0; }
 
-  /* Right-side icon area in the tab bar — holds status indicator + settings + future icons.
-     \`margin-left: auto\` keeps it pinned to the right when the labeled KB / Branch tabs are
-     present (their \`flex: 1\` already consumes free space, so the auto margin is a no-op) AND
-     when those tabs are .hidden in disabled mode (auto margin then pushes this block right). */
-  .tab-bar-right { display: flex; align-items: center; gap: 4px; padding: 0 6px; margin-left: auto; flex-shrink: 0; }
+  /* Header-bar icon button — square button hosting a single codicon. The
+     legacy .tab class is preserved so the existing switchTab dispatch
+     (document.querySelectorAll('.tab[data-tab]')) still finds these buttons.
+     The .active marker means the corresponding overlay panel is currently
+     open; clicking the active icon again collapses back to the Branch view. */
+  .tab {
+    flex: 0 0 auto;
+    padding: 4px 6px;
+    border: none;
+    background: transparent;
+    color: var(--vscode-icon-foreground, var(--vscode-foreground));
+    cursor: pointer;
+    border-radius: 3px;
+    min-width: 24px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+  }
+  .tab.tab-icon { /* explicit modifier preserved for selector specificity in legacy hover/active rules */ }
+  .tab:hover { background: var(--vscode-toolbar-hoverBackground, rgba(128,128,128,0.15)); }
+  .tab.active { background: var(--vscode-toolbar-activeBackground, rgba(0,122,204,0.2)); color: var(--vscode-foreground); }
 
-  /* Icon-style "tab" — used for the status indicator. Visually distinct from labeled tabs. */
-  .tab.tab-icon { flex: 0 0 auto; padding: 4px 6px; border-bottom: none; min-width: 24px; }
-  .tab.tab-icon.active { border-bottom: none; background: var(--vscode-toolbar-activeBackground, rgba(0,122,204,0.2)); }
-  .tab.tab-icon:hover { background: var(--vscode-toolbar-hoverBackground, rgba(128,128,128,0.15)); }
+  /* Dropdown menu for the breadcrumb repo / branch pickers. Anchored to the
+     triggering segment via inline left/top set by the script (we can't
+     position it with CSS alone because the segment widths vary with their
+     labels). */
+  .dropdown-menu {
+    position: absolute;
+    z-index: 10;
+    min-width: 160px;
+    max-width: 280px;
+    background: var(--vscode-menu-background, var(--vscode-editor-background));
+    color: var(--vscode-menu-foreground, var(--vscode-foreground));
+    border: 1px solid var(--vscode-menu-border, var(--vscode-panel-border, rgba(128,128,128,0.3)));
+    box-shadow: 0 2px 8px rgba(0,0,0,0.3);
+    padding: 4px 0;
+    border-radius: 3px;
+    display: flex;
+    flex-direction: column;
+    max-height: 50vh;
+  }
+  /* Search box stays pinned at the top; only the list scrolls. The host
+     also sets an inline max-height on the menu when the available viewport
+     space is tighter than 50vh — see showBreadcrumbMenu. */
+  .dropdown-search {
+    flex: 0 0 auto;
+    padding: 4px 6px;
+    border-bottom: 1px solid var(--vscode-menu-separatorBackground, var(--vscode-panel-border, rgba(128,128,128,0.3)));
+  }
+  .dropdown-search input {
+    width: 100%;
+    padding: 3px 6px;
+    font-size: 12px;
+    font-family: inherit;
+    color: var(--vscode-input-foreground);
+    background: var(--vscode-input-background);
+    border: 1px solid var(--vscode-input-border, transparent);
+    border-radius: 2px;
+    outline: none;
+  }
+  .dropdown-search input:focus {
+    border-color: var(--vscode-focusBorder);
+  }
+  .dropdown-list {
+    flex: 1 1 auto;
+    overflow-y: auto;
+    min-height: 0;
+  }
+  .dropdown-item {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 4px 10px;
+    cursor: pointer;
+    font-size: 12px;
+    white-space: nowrap;
+  }
+  .dropdown-item:hover { background: var(--vscode-menu-selectionBackground, var(--vscode-list-hoverBackground)); }
+  .dropdown-item .dropdown-item-check { width: 14px; flex: 0 0 14px; font-size: 12px; }
+  .dropdown-item.current { font-weight: 600; }
+  .dropdown-empty {
+    padding: 6px 10px;
+    font-size: 12px;
+    color: var(--vscode-descriptionForeground);
+    font-style: italic;
+  }
 
   /* Status indicator color classes — applied to the codicon-circle-filled inside #status-icon-btn. */
   .status-icon-ok { color: var(--vscode-testing-iconPassed, #89d185); }
   .status-icon-warn { color: var(--vscode-testing-iconQueued, #cca700); }
   .status-icon-error { color: var(--vscode-testing-iconFailed, #f48771); }
+
+  /* Foreign-readonly chrome on the Branch panel. Mirrors the
+     SummaryWebviewPanel.foreign-readonly default-deny: when the user is
+     viewing a non-workspace repo or non-current branch, the writable surfaces
+     collapse so a click can't trigger a write against a foreign repo.
+     - Plans & Notes and Changes sections vanish entirely (their data is
+       inherently workspace-local; rendering them with a "n/a" placeholder
+       would just be noise). The script also skips pushing these sections in
+       foreign mode (see renderBranch), so the CSS rule is defense in depth
+       against a future code path that forgets to gate.
+     - Memory checkboxes hidden via visibility (not display:none, which would
+       collapse the row-leading slot and break commit-row alignment with
+       commit-file child rows).
+     - The Memories-section header actions (Squash / Push) are suppressed at
+       the script level (renderSectionActions returns []), so no CSS rule is
+       needed there — and adding display:none to .section-actions reflows
+       the section-header (legacy bug, guarded by the test "never uses
+       display:none for .section-actions"). */
+  .sidebar-root.foreign-readonly .collapsible-section[data-section="plans"],
+  .sidebar-root.foreign-readonly .collapsible-section[data-section="changes"] {
+    display: none;
+  }
+  .sidebar-root.foreign-readonly .collapsible-section[data-section="commits"] input[type="checkbox"][data-checkbox-kind="commit"] {
+    visibility: hidden;
+  }
 
   .tab-toolbar {
     display: flex;
@@ -251,6 +366,55 @@ export function buildSidebarCss(): string {
   }
   .collapsible-section .section-header:hover .section-actions { visibility: visible; }
   .collapsible-section.collapsed .section-body { display: none; }
+
+  /* Bottom-of-section "Commit Memory" CTA — sits at the tail of the Changes
+     section body, separated from the file list by a thin top border so the
+     action chrome reads as "section footer" rather than "another file row".
+     Button aligns right (SCM-view convention) and the wrapper carries the
+     vertical breathing room that makes the divider feel intentional rather
+     than cramped. Button itself reuses VS Code's primary-button tokens so it
+     adapts to theme. Disabled state matches .iconbtn:disabled (opacity-only,
+     no hover background change) so the visual semantics are consistent with
+     the header sparkle iconbtn that points at the same command. */
+  .commit-memory-action {
+    /* Horizontal spacing lives in padding (inside the border) so the
+       border-top can span the full webview width — flush to the
+       tab-content edges. Vertical padding is symmetric so the button has
+       equal breathing room above (from the divider) and below (to the
+       next section's own border-top); margin-top supplies the gap from
+       the last file row above the divider, and margin-bottom is 0 because
+       the next section header already brings its own 1px divider. */
+    margin: 12px 0 0 0;
+    padding: 12px 8px 12px 8px;
+    display: flex;
+    justify-content: flex-end;
+    border-top: 1px solid var(--vscode-widget-border, var(--vscode-editorWidget-border, var(--vscode-panel-border)));
+  }
+  .commit-memory-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 14px;
+    background: var(--vscode-button-background);
+    color: var(--vscode-button-foreground);
+    border: 1px solid transparent;
+    border-radius: 3px;
+    font-size: 13px;
+    cursor: pointer;
+  }
+  .commit-memory-btn:hover {
+    background: var(--vscode-button-hoverBackground, var(--vscode-button-background));
+  }
+  .commit-memory-btn:disabled {
+    opacity: 0.5;
+    cursor: default;
+  }
+  .commit-memory-btn:disabled:hover {
+    background: var(--vscode-button-background);
+  }
+  .commit-memory-btn .codicon {
+    font-size: 14px;
+  }
 
   .tree-node {
     display: flex;

--- a/vscode/src/views/SidebarHtmlBuilder.test.ts
+++ b/vscode/src/views/SidebarHtmlBuilder.test.ts
@@ -33,28 +33,48 @@ describe("SidebarHtmlBuilder", () => {
 		expect(occurrences).toBeGreaterThanOrEqual(3);
 	});
 
-	it("renders 2 labeled tab buttons + status icon button + settings icon button", () => {
+	it("renders the header bar with breadcrumb (repo + branch) and 3 right-side icon buttons", () => {
 		const html = buildSidebarHtml(
 			"n",
 			"vscode-resource:",
 			"https://example/codicon.css",
 			SIDEBAR_EMPTY_STRINGS,
 		);
-		// Two labeled tabs
+		// Breadcrumb segments: repo on the left, branch on the right, with a
+		// chevron-down per segment that the script hides when there is no
+		// real choice (initially hidden via .hidden in the static skeleton so
+		// the breadcrumb doesn't dangle a no-op affordance before the host
+		// pushes the repo/branch enumeration).
+		expect(html).toContain('id="breadcrumb"');
+		expect(html).toContain('id="breadcrumb-repo-btn"');
+		expect(html).toContain('id="breadcrumb-branch-btn"');
+		expect(html).toContain('id="breadcrumb-repo-label"');
+		expect(html).toContain('id="breadcrumb-branch-label"');
+		expect(html).toMatch(
+			/<i[^>]*class="codicon codicon-chevron-down breadcrumb-seg-chevron hidden"/,
+		);
+		// 3 icon buttons on the right side. Memory Bank and Status carry
+		// data-tab for the switchTab dispatch; Settings carries
+		// data-action="open-settings" so the existing event handler routes it
+		// to the openSettings command without going through tab dispatch.
+		expect(html).toContain('id="kb-icon-btn"');
 		expect(html).toContain('data-tab="kb"');
-		expect(html).toContain('data-tab="branch"');
-		// Status icon button (not a labeled tab — lives in tab-bar-right)
+		expect(html).toContain('id="settings-icon-btn"');
+		expect(html).toContain('data-action="open-settings"');
 		expect(html).toContain('id="status-icon-btn"');
-		expect(html).toContain("codicon-circle-filled");
-		// Settings was moved into the Status tab toolbar (rendered by JS), so it
-		// must NOT live in the static HTML skeleton anymore.
-		expect(html).not.toContain('data-action="open-settings"');
-		// Status icon still carries data-tab="status" for switchTab compatibility
 		expect(html).toContain('data-tab="status"');
+		expect(html).toContain("codicon-circle-filled");
+		// The branch label is now part of the breadcrumb, not a tab button.
+		// data-tab="branch" no longer appears anywhere because Branch is the
+		// implicit default view that surfaces whenever no overlay is active.
+		expect(html).not.toContain('data-tab="branch"');
 		// Native title="Status" was removed in favor of attachTextTip (which
 		// renders a dynamic OK/Warnings/Errors tooltip from JS). Keeping both
 		// would cause the native title to flash before the project tip shows.
 		expect(html).not.toContain('id="status-icon-btn" title=');
+		// Dropdown menu container — empty by default, populated on demand by
+		// the script when a breadcrumb segment is clicked.
+		expect(html).toContain('id="breadcrumb-menu"');
 	});
 
 	it("includes 3 tab content panels with stable ids", () => {

--- a/vscode/src/views/SidebarHtmlBuilder.ts
+++ b/vscode/src/views/SidebarHtmlBuilder.ts
@@ -25,9 +25,24 @@
  *     drops the option cards and shows a single primary "Enable" button. The
  *     legacy disabled-banner inside the Status panel is kept for the degraded
  *     (no-workspace / no-git) fallback only.
- *   - 2 labeled tab buttons (branch / Memory Bank) + a right-side icon area
- *     holding a status indicator icon (settings moved into the Status tab toolbar)
- *   - 3 tab content panels (one shown at a time, the others have the `.hidden` class)
+ *   - A header bar (`#tab-bar`) split into two halves:
+ *       * Left: breadcrumb showing `<repo> / <branch>` with chevron dropdown
+ *         affordances. The dropdowns are populated on demand by the host via
+ *         `selection:repos` / `selection:branches` messages; when only one
+ *         repo or one branch is known, the chevron is suppressed so the row
+ *         doesn't dangle a no-op affordance. The breadcrumb text doubles as
+ *         the "what am I viewing" indicator — `branchName` lives here now
+ *         instead of inside a labeled tab.
+ *       * Right: 3 icon buttons — Memory Bank, Settings, Status. Memory Bank
+ *         and Status are toggle buttons (`data-tab="kb"` / `data-tab="status"`)
+ *         that open the corresponding overlay panel; clicking an already-active
+ *         icon collapses the overlay back to the default Branch view. Settings
+ *         posts `jollimemory.openSettings` (moved out of the Status toolbar so
+ *         configuration lives in the same row as the other top-level actions).
+ *   - 3 tab content panels (one shown at a time, the others have the `.hidden` class).
+ *     The Branch panel is the persistent default; KB / Status are toggled by
+ *     the icon buttons. Renamed user-facing string: "Commits" → "Memories"
+ *     (the section is still keyed `commits` internally for back-compat).
  *   - A disabled-state intro rendered inside the Status panel itself, used only
  *     for the degraded fallback (no workspace / no git). The standard
  *     user-disabled state shows the disabled-panel above instead.
@@ -125,15 +140,33 @@ export function buildSidebarHtml(
       </header>
       <button type="button" id="disabled-enable-btn" class="ob-btn ob-btn--primary">Enable Jolli Memory</button>
     </div>
-    <div class="tab-bar hidden" id="tab-bar" role="tablist">
-      <button class="tab active" type="button" data-tab="branch" role="tab" id="tab-button-branch"><i class="codicon codicon-git-branch tab-icon-leading" aria-hidden="true"></i><span class="tab-label">(loading)</span></button>
-      <button class="tab" type="button" data-tab="kb" role="tab" id="tab-button-kb"><i class="codicon codicon-book tab-icon-leading" aria-hidden="true"></i><span class="tab-label">MEMORY BANK</span></button>
+    <div class="tab-bar hidden" id="tab-bar" role="toolbar" aria-label="Jolli Memory header">
+      <div class="breadcrumb" id="breadcrumb">
+        <button class="breadcrumb-seg" type="button" id="breadcrumb-repo-btn" aria-haspopup="menu" aria-expanded="false">
+          <i class="codicon codicon-repo breadcrumb-seg-icon" aria-hidden="true"></i>
+          <span class="breadcrumb-seg-label" id="breadcrumb-repo-label">(repo)</span>
+          <i class="codicon codicon-chevron-down breadcrumb-seg-chevron hidden" aria-hidden="true"></i>
+        </button>
+        <span class="breadcrumb-sep" aria-hidden="true">/</span>
+        <button class="breadcrumb-seg" type="button" id="breadcrumb-branch-btn" aria-haspopup="menu" aria-expanded="false">
+          <i class="codicon codicon-git-branch breadcrumb-seg-icon" aria-hidden="true"></i>
+          <span class="breadcrumb-seg-label" id="breadcrumb-branch-label">(loading)</span>
+          <i class="codicon codicon-chevron-down breadcrumb-seg-chevron hidden" aria-hidden="true"></i>
+        </button>
+      </div>
       <div class="tab-bar-right">
-        <button class="tab tab-icon" type="button" data-tab="status" id="status-icon-btn">
+        <button class="tab tab-icon" type="button" data-tab="kb" id="kb-icon-btn" aria-label="Memory Bank">
+          <i class="codicon codicon-book" aria-hidden="true"></i>
+        </button>
+        <button class="tab tab-icon" type="button" data-action="open-settings" id="settings-icon-btn" aria-label="Settings">
+          <i class="codicon codicon-gear" aria-hidden="true"></i>
+        </button>
+        <button class="tab tab-icon" type="button" data-tab="status" id="status-icon-btn" aria-label="Status">
           <i class="codicon codicon-circle-filled"></i>
         </button>
       </div>
     </div>
+    <div class="dropdown-menu hidden" id="breadcrumb-menu" role="menu"></div>
     <div class="tab-toolbar hidden" id="tab-toolbar"></div>
     <div class="tab-content hidden" id="tab-content-kb"><p class="placeholder">Loading...</p></div>
     <div class="tab-content hidden" id="tab-content-branch"><p class="placeholder">Loading...</p></div>

--- a/vscode/src/views/SidebarMessages.ts
+++ b/vscode/src/views/SidebarMessages.ts
@@ -44,6 +44,30 @@ export interface SidebarState {
 	readonly branchName: string;
 	readonly detached: boolean;
 	/**
+	 * Display name of the workspace's repo. Used as the left segment of the
+	 * header breadcrumb and as the "home" anchor for the cross-repo dropdown.
+	 * Optional during early-init / degraded modes where extractRepoName has not
+	 * yet run; the webview falls back to "(workspace)" when undefined.
+	 */
+	readonly currentRepoName?: string;
+	/**
+	 * Which repo the user is currently *viewing* through the breadcrumb. When
+	 * equal to currentRepoName (or undefined), the sidebar is in normal mode.
+	 * When different, the sidebar is in foreign-readonly mode — Plans & Notes
+	 * and Changes are hidden; the Memories list drops its checkboxes and
+	 * squash/push toolbar buttons. The host is responsible for refilling the
+	 * branch:* data feeds with the selected repo's content; this field is
+	 * the renderer's signal to switch to read-only chrome.
+	 */
+	readonly selectedRepoName?: string;
+	/**
+	 * Which branch is being viewed inside the selected repo. Same readonly
+	 * semantics as selectedRepoName: when this differs from branchName (the
+	 * workspace's actual HEAD) the sidebar enters foreign-readonly mode even
+	 * if the repo matches. Undefined = "viewing the workspace branch".
+	 */
+	readonly selectedBranchName?: string;
+	/**
 	 * Set when activate() couldn't complete its normal init (no workspace folder
 	 * open, or workspace isn't a git repo). The webview swaps the standard
 	 * disabled banner for a reason-specific CTA (Open Folder / Initialize Git).
@@ -213,9 +237,62 @@ export interface MemoryHover {
 	readonly shortHash: string;
 }
 
+/**
+ * Minimal projection of `SummaryIndexEntry` for the foreign-readonly Branch
+ * tab Memories section. Carries just the display fields the webview's
+ * commit-row renderer reads, so the wire payload stays small. Does NOT
+ * collapse amend/rebase chains — one item per stored summary file.
+ */
+export interface BranchMemoryItem {
+	readonly commitHash: string;
+	/** Commit message (first line; rendered as the row's primary label). */
+	readonly title: string;
+	/** Branch name as stored in the index. */
+	readonly branch: string;
+	/** Repo name (echoed from the request so the webview can key its cache). */
+	readonly repoName: string;
+	/** ms since epoch derived from `commitDate` / `generatedAt`. */
+	readonly timestamp: number;
+}
+
+/**
+ * Entry in the breadcrumb repo dropdown. `repoName` is the display label and
+ * the selector key; `remoteUrl` is forwarded to the host so a cross-repo
+ * memory fetch can pin its remote-bound queries (e.g. `gh pr view --repo
+ * <url>`) without re-deriving them. `isCurrent` flags the workspace's own
+ * repo so the dropdown can sort / style it specially.
+ */
+export interface RepoChoice {
+	readonly repoName: string;
+	readonly remoteUrl?: string;
+	readonly isCurrent: boolean;
+}
+
 export type SidebarOutboundMsg =
 	| { readonly type: "ready" }
 	| { readonly type: "tab:switched"; readonly tab: SidebarTab }
+	| {
+			/**
+			 * Webview asks the host to materialize the breadcrumb selection
+			 * change. Host responds by repopulating branch:* feeds with the
+			 * selected repo+branch and (eventually) by pushing a `selection:set`
+			 * confirmation. Either field undefined = "stay on current".
+			 */
+			readonly type: "selection:request";
+			readonly repoName?: string;
+			readonly branchName?: string;
+	  }
+	| {
+			/**
+			 * Foreign-readonly Branch tab can't derive its Memories section
+			 * from `branchData.commits` (workspace-HEAD-bound) — webview asks
+			 * the host for all memories on the picked repo+branch instead.
+			 * Host responds with `selection:branchMemories`.
+			 */
+			readonly type: "selection:requestBranchMemories";
+			readonly repoName: string;
+			readonly branchName: string;
+	  }
 	| { readonly type: "kb:setMode"; readonly mode: KbMode }
 	| { readonly type: "kb:expandFolder"; readonly path: string }
 	| { readonly type: "kb:openFile"; readonly path: string }
@@ -335,6 +412,60 @@ export type SidebarInboundMsg =
 	| { readonly type: "auth:changed"; readonly authenticated: boolean }
 	| { readonly type: "configured:changed"; readonly configured: boolean }
 	| { readonly type: "worker:busy"; readonly busy: boolean }
+	| {
+			/**
+			 * Push the list of repos discoverable under the Memory Bank parent.
+			 * Drives the breadcrumb repo dropdown. When `repos.length <= 1`, the
+			 * webview hides the dropdown affordance entirely (no point offering
+			 * a switcher with one option).
+			 */
+			readonly type: "selection:repos";
+			readonly repos: ReadonlyArray<RepoChoice>;
+	  }
+	| {
+			/**
+			 * Push the list of branches available inside the currently selected
+			 * repo. Re-sent whenever the user switches repos.
+			 */
+			readonly type: "selection:branches";
+			readonly repoName: string;
+			readonly branches: ReadonlyArray<string>;
+	  }
+	| {
+			/**
+			 * Host confirms the breadcrumb selection has been applied. The
+			 * webview adopts these values and recomputes its readonly chrome.
+			 * `repoName === currentRepoName && branchName === workspace branch`
+			 * means "back to normal mode".
+			 */
+			readonly type: "selection:set";
+			readonly repoName?: string;
+			readonly branchName?: string;
+	  }
+	| {
+			/**
+			 * Response to `selection:requestBranchMemories`. Items are the raw
+			 * unfiltered SummaryIndexEntry projection for the requested
+			 * repo+branch — includes amend/rebase children that the global
+			 * KB Memories list collapses out. Used only by the foreign-readonly
+			 * Branch tab Memories section.
+			 */
+			readonly type: "selection:branchMemories";
+			readonly repoName: string;
+			readonly branchName: string;
+			readonly items: ReadonlyArray<BranchMemoryItem>;
+	  }
+	| {
+			/**
+			 * Host tells the webview to drop its `branchMemoriesCache` (and any
+			 * in-flight `branchMemoriesPending` marker) and re-trigger the lazy
+			 * `selection:requestBranchMemories` fetch for the active foreign
+			 * selection. Sent on toolbar Refresh — without this signal the
+			 * session-sticky cache would never re-fetch, leaving the Memories
+			 * panel pinned to whatever the first selection load returned.
+			 */
+			readonly type: "selection:invalidateBranchMemories";
+	  }
 	| {
 			/**
 			 * Posted only on the failure path of the inline onboarding API key

--- a/vscode/src/views/SidebarScriptBuilder.test.ts
+++ b/vscode/src/views/SidebarScriptBuilder.test.ts
@@ -1144,4 +1144,218 @@ describe("SidebarScriptBuilder", () => {
 			expect(js.slice(start, end)).toMatch(/applyEnabled\(state\.enabled\)/);
 		});
 	});
+
+	describe("Commit Memory button visibility on the Changes section", () => {
+		// User-visible CTA must remain rendered (a) when Changes is empty (so
+		// users can discover it during onboarding before they've staged
+		// anything), AND (b) when the Changes section is collapsed (Commit
+		// Memory is a group action across Plans + Changes + Commits — folding
+		// Changes alone shouldn't hide it). It is implicitly hidden in
+		// foreign-readonly mode because the whole Changes section is dropped
+		// above the predicate. Neither items.length nor `collapsed` may gate
+		// the push site.
+		it("pushes the button on the Changes section without gating on items.length or collapsed", () => {
+			const js = buildSidebarScript();
+			// Find the push site. Must match `s.id === 'changes'` but NOT
+			// include `!collapsed` (regression — collapsing Changes hid the
+			// group CTA) nor `s.items.length` (regression — empty Changes hid
+			// the discoverability affordance).
+			const renderSectionStart = js.indexOf("function renderSection");
+			expect(renderSectionStart).toBeGreaterThan(-1);
+			const renderSectionEnd = js.indexOf(
+				"function ",
+				renderSectionStart + "function renderSection".length,
+			);
+			const body = js.slice(renderSectionStart, renderSectionEnd);
+			expect(body).toMatch(
+				/if\s*\(\s*s\.id\s*===\s*'changes'\s*\)\s*\{\s*sectionKids\.push\(renderCommitMemoryButton\(\)\)/,
+			);
+			// Defense-in-depth: neither old buggy predicate may reappear.
+			expect(body).not.toMatch(
+				/s\.items\.length\s*>\s*0[\s\S]{0,80}renderCommitMemoryButton/,
+			);
+			expect(body).not.toMatch(
+				/!collapsed[\s\S]{0,80}renderCommitMemoryButton/,
+			);
+		});
+
+		it("Changes section is dropped entirely in foreign-readonly mode (renderBranch only pushes plans/changes when !foreign)", () => {
+			const js = buildSidebarScript();
+			// The two non-Memories sections must be guarded by the foreign check
+			// so the button predicate above never has a chance to match a foreign
+			// branch tab. This is the implicit "hide the button when foreign"
+			// path: no section, no predicate match, no button.
+			const renderBranchStart = js.indexOf("function renderBranch");
+			expect(renderBranchStart).toBeGreaterThan(-1);
+			const renderBranchEnd = js.indexOf(
+				"function ",
+				renderBranchStart + "function renderBranch".length,
+			);
+			const body = js.slice(renderBranchStart, renderBranchEnd);
+			expect(body).toMatch(/const foreign\s*=\s*isViewingForeign\(\)/);
+			expect(body).toMatch(/if\s*\(\s*!foreign\s*\)/);
+		});
+	});
+
+	describe("foreign-mode memory click routes through cross-repo lookup", () => {
+		// Regression: after switching to a foreign repo/branch via the breadcrumb,
+		// clicking a row in the Branch tab's Memories section silently no-ops.
+		// Root cause: `branch:openCommit` → `jollimemory.viewSummary` →
+		// `bridge.getSummary` is single-repo. Foreign memories live in another
+		// repo's FolderStorage, so getSummary returns null and the handler's
+		// `if (!summary) return;` swallows the click. The fix: in foreign mode,
+		// route through `kb:openMemory` (→ `viewMemorySummary` → cross-repo
+		// `getSummaryAnyRepoWithSource`), same path the KB tab already uses.
+		it("commitWithMemory row click posts kb:openMemory in foreign mode", () => {
+			const js = buildSidebarScript();
+			// Locate the row-dispatch block inside tabContents.branch click handler.
+			const branchClickIdx = js.indexOf(
+				"tabContents.branch.addEventListener('click'",
+			);
+			expect(branchClickIdx).toBeGreaterThan(-1);
+			const ctxBlockIdx = js.indexOf(
+				"ctx === 'commit' || ctx === 'commitWithMemory'",
+				branchClickIdx,
+			);
+			expect(ctxBlockIdx).toBeGreaterThan(-1);
+			// The window after the predicate must show both branches:
+			// foreign → kb:openMemory; workspace → branch:openCommit.
+			const window = js.slice(ctxBlockIdx, ctxBlockIdx + 1200);
+			expect(window).toContain("isViewingForeign()");
+			expect(window).toContain("'kb:openMemory'");
+			expect(window).toContain("'branch:openCommit'");
+		});
+
+		it("inline viewSummary button routes through viewMemorySummary in foreign mode", () => {
+			const js = buildSidebarScript();
+			// Find the inline-action `viewSummary` branch inside the Branch tab
+			// click handler — the eye-icon button on commitWithMemory rows.
+			const viewSummaryIdx = js.indexOf("action === 'viewSummary'");
+			expect(viewSummaryIdx).toBeGreaterThan(-1);
+			const window = js.slice(viewSummaryIdx, viewSummaryIdx + 800);
+			// Foreign mode must dispatch the cross-repo command; workspace mode
+			// keeps the single-repo viewSummary (panel slot "commit").
+			expect(window).toContain("isViewingForeign()");
+			expect(window).toContain("'jollimemory.viewMemorySummary'");
+			expect(window).toContain("'jollimemory.viewSummary'");
+		});
+	});
+
+	describe("selection:set lazy branch-memories trigger", () => {
+		// Regression: when the user picked a foreign branch directly (without
+		// first picking a repo) the trigger guarded on state.selectedRepoName,
+		// which is undefined on that path. The request never fired, the
+		// Memories list rendered empty until the user also picked a repo.
+		// Render, isViewingForeign, and the response handler all use the
+		// `selectedX || currentX` fallback; the trigger must match.
+		it("falls back to currentRepoName/branchName when the explicit pick omits the repo", () => {
+			const js = buildSidebarScript();
+			const setStart = js.indexOf("case 'selection:set'");
+			expect(setStart).toBeGreaterThan(-1);
+			const setEnd = js.indexOf("case '", setStart + 1);
+			const block = js.slice(setStart, setEnd);
+			// Both the repo and branch must be computed via the fallback —
+			// otherwise picking only a branch (workspace repo + foreign branch)
+			// never reaches selection:requestBranchMemories.
+			expect(block).toMatch(
+				/state\.selectedRepoName\s*\|\|\s*state\.currentRepoName/,
+			);
+			expect(block).toMatch(
+				/state\.selectedBranchName\s*\|\|\s*state\.branchName/,
+			);
+			// And the resulting `repo`/`branch` locals must be what the trigger
+			// sends to the host (not the raw state.selected* properties).
+			expect(block).toMatch(
+				/selection:requestBranchMemories[\s\S]*repoName:\s*repo[\s\S]*branchName:\s*branch/,
+			);
+		});
+	});
+
+	describe("selection:invalidateBranchMemories handler", () => {
+		// Pins the three-way cache-key alignment (trigger / response / render)
+		// extended to a fourth call site: invalidate. branchMemoriesCache is
+		// session-sticky once written, so toolbar Refresh in foreign mode would
+		// be a no-op without this handler. The fallback expression here must
+		// match the other three call sites or invalidate refetches an empty key.
+		it("drops every cache entry and re-fires the request with the same fallback key", () => {
+			const js = buildSidebarScript();
+			const caseStart = js.indexOf("case 'selection:invalidateBranchMemories'");
+			expect(caseStart).toBeGreaterThan(-1);
+			const caseEnd = js.indexOf("case '", caseStart + 1);
+			const block = js.slice(caseStart, caseEnd);
+
+			// All cached keys are dropped — refresh implies the user expects a
+			// fresh read for any repo+branch they navigate to next, not just
+			// the active one.
+			expect(block).toMatch(
+				/for\s*\(\s*const\s+\w+\s+in\s+branchMemoriesCache\s*\)\s*delete/,
+			);
+			expect(block).toMatch(
+				/for\s*\(\s*const\s+\w+\s+in\s+branchMemoriesPending\s*\)\s*delete/,
+			);
+
+			// Same fallback expression as the selection:set trigger and the
+			// response-match check — drift here means refresh sends a request
+			// for one key while the render path reads from another.
+			expect(block).toMatch(
+				/state\.selectedRepoName\s*\|\|\s*state\.currentRepoName/,
+			);
+			expect(block).toMatch(
+				/state\.selectedBranchName\s*\|\|\s*state\.branchName/,
+			);
+			expect(block).toMatch(
+				/selection:requestBranchMemories[\s\S]*repoName:\s*repo[\s\S]*branchName:\s*branch/,
+			);
+		});
+	});
+
+	describe("breadcrumb dropdown filter + scrolling", () => {
+		it("renders the menu body as a search header plus a scrollable list", () => {
+			const js = buildSidebarScript();
+			// The list container is what scrolls (overflow-y is on .dropdown-list,
+			// not the outer .dropdown-menu) so the search header stays pinned.
+			expect(js).toContain("className: 'dropdown-list'");
+			expect(js).toContain("className: 'dropdown-search'");
+		});
+
+		it("only shows the filter input when the list is large enough to be worth searching", () => {
+			const js = buildSidebarScript();
+			// Threshold is encoded as a single constant so a future tweak only
+			// touches one place; keep the assertion loose enough to survive a
+			// rename but tight enough to catch a silent removal.
+			expect(js).toMatch(/SEARCH_THRESHOLD\s*=\s*\d+/);
+			expect(js).toContain("items.length >= SEARCH_THRESHOLD");
+		});
+
+		it("filters items by case-insensitive substring against the item label", () => {
+			const js = buildSidebarScript();
+			// Lowercase the query and the label, then check substring inclusion.
+			// Matching the source verbatim is brittle, but these two anchors
+			// together pin the algorithm down.
+			expect(js).toMatch(/\.toLowerCase\(\)/);
+			expect(js).toMatch(/rows\[i\]\.label\.indexOf\(q\)/);
+		});
+
+		it("toggles a 'No matches' message when the filter produces zero visible rows", () => {
+			const js = buildSidebarScript();
+			expect(js).toContain("'No matches'");
+			expect(js).toContain(
+				"emptyMsg.classList.toggle('hidden', visible !== 0)",
+			);
+		});
+
+		it("clamps the menu height to the space below the anchor so the list scrolls in-bounds", () => {
+			const js = buildSidebarScript();
+			// CSS caps at 50vh; JS tightens to whatever space is left below the
+			// anchor. Without this the dropdown overflows the viewport bottom
+			// edge with no scrollbar (the bug being fixed here).
+			expect(js).toContain("window.innerHeight - r.bottom");
+			expect(js).toContain("breadcrumbMenu.style.maxHeight");
+		});
+
+		it("focuses the filter input on open so the user can type immediately", () => {
+			const js = buildSidebarScript();
+			expect(js).toContain("searchInput.focus()");
+		});
+	});
 });

--- a/vscode/src/views/SidebarScriptBuilder.ts
+++ b/vscode/src/views/SidebarScriptBuilder.ts
@@ -106,9 +106,29 @@ export function buildSidebarScript(): string {
   const disabledBanner = document.getElementById('disabled-banner');
   const enableBtn = document.getElementById('enable-btn');
   const ctxMenu = document.getElementById('context-menu');
-  const tabButtonKb = document.getElementById('tab-button-kb');
-  const tabBranchBtn = document.getElementById('tab-button-branch');
+  const kbIconBtn = document.getElementById('kb-icon-btn');
   const statusIconBtn = document.getElementById('status-icon-btn');
+  const settingsIconBtn = document.getElementById('settings-icon-btn');
+  const breadcrumbRepoBtn = document.getElementById('breadcrumb-repo-btn');
+  const breadcrumbBranchBtn = document.getElementById('breadcrumb-branch-btn');
+  const breadcrumbRepoLabel = document.getElementById('breadcrumb-repo-label');
+  const breadcrumbBranchLabel = document.getElementById('breadcrumb-branch-label');
+  const breadcrumbMenu = document.getElementById('breadcrumb-menu');
+  // Repo/branch enumeration for the dropdowns. Populated by selection:repos /
+  // selection:branches inbound messages. Until the host pushes either, the
+  // chevron stays hidden and the segment behaves as a static label.
+  let repoChoices = [];
+  let branchChoicesByRepo = {};
+  // Cache of unfiltered per-branch memories for the foreign-readonly Branch
+  // tab. Keyed by '<repoName>::<branchName>'. Host populates lazily in
+  // response to selection:requestBranchMemories. Cache-miss while a fetch is
+  // in flight = empty array → empty state in the Memories section, which
+  // immediately fills once selection:branchMemories arrives.
+  const branchMemoriesCache = {};
+  const branchMemoriesPending = {};
+  function branchMemoriesKey(repoName, branchName) {
+    return (repoName || '') + '::' + (branchName || '');
+  }
   // Onboarding panel — full-viewport replacement for the tab UI when the
   // user has not configured AI yet (no Jolli sign-in and no Anthropic key).
   const onboardingPanel = document.getElementById('onboarding-panel');
@@ -205,12 +225,20 @@ export function buildSidebarScript(): string {
     return el;
   }
 
-  // Status icon lives in the static HTML skeleton (not the toolbar), so attach
-  // its tooltip once here. renderStatus updates dataset.tip in lockstep with
-  // the indicator color so the hover text always matches the dot.
+  // Header-bar icons live in the static HTML skeleton (not the toolbar), so
+  // attach their tooltips once here. renderStatus updates dataset.tip on
+  // statusIconBtn in lockstep with the indicator color so the hover text
+  // always matches the dot; KB and Settings have static tooltips.
   if (statusIconBtn) attachTextTip(statusIconBtn, 'Jolli Memory: All good');
+  if (kbIconBtn) attachTextTip(kbIconBtn, 'Memory Bank');
+  if (settingsIconBtn) attachTextTip(settingsIconBtn, 'Settings');
 
   // ---- Tab switching ----
+  // The new icon-driven header doesn't have a Branch button — the Branch view
+  // is the default that surfaces whenever no overlay (KB / Status) is active.
+  // Clicking the active KB or Status icon a second time collapses back to
+  // Branch; that toggle behavior is implemented at the click-handler level
+  // (icon clicks pass the icon's data-tab through a switchTabFromIcon shim).
   function switchTab(tab) {
     if (state.activeTab === tab) return;
     const outgoing = tabContents[state.activeTab];
@@ -218,7 +246,9 @@ export function buildSidebarScript(): string {
 
     state.activeTab = tab;
     persist();
-    document.querySelectorAll('.tab').forEach(function(elBtn) {
+    // Only tab-icon buttons (KB / Status) carry .active — Branch is the
+    // implicit default so no button is highlighted in Branch mode.
+    document.querySelectorAll('.tab[data-tab]').forEach(function(elBtn) {
       elBtn.classList.toggle('active', elBtn.getAttribute('data-tab') === tab);
     });
     Object.keys(tabContents).forEach(function(t) { tabContents[t].classList.toggle('hidden', t !== tab); });
@@ -245,11 +275,20 @@ export function buildSidebarScript(): string {
     vscode.postMessage({ type: 'tab:switched', tab: tab });
   }
 
-  document.querySelectorAll('.tab').forEach(function(elBtn) {
-    elBtn.addEventListener('click', function() { switchTab(elBtn.getAttribute('data-tab')); });
+  // Icon buttons own the click-to-toggle behavior: clicking the icon that
+  // matches the active tab collapses back to Branch instead of being a no-op.
+  // Only [data-tab] elements participate; [data-action] icons (Settings)
+  // route through the open-settings handler below.
+  document.querySelectorAll('.tab[data-tab]').forEach(function(elBtn) {
+    elBtn.addEventListener('click', function() {
+      const target = elBtn.getAttribute('data-tab');
+      if (state.activeTab === target) switchTab('branch');
+      else switchTab(target);
+    });
   });
 
-  // Settings button in the tab-bar-right area — not a .tab so not covered above.
+  // Settings icon lives in tab-bar-right with data-action="open-settings".
+  // Routes to the openSettings command rather than the tab dispatch.
   tabBar.addEventListener('click', function(e) {
     const settingsBtn = e.target.closest('[data-action="open-settings"]');
     if (settingsBtn) {
@@ -312,16 +351,15 @@ export function buildSidebarScript(): string {
       items.push(iconButton('refresh', 'Refresh', 'refresh'));
       mountIn(tabToolbar, items);
     } else if (state.activeTab === 'status') {
-      // Order: configuration → account → power → refresh.
-      // - Settings (was on the global tab bar; moved here so configuration lives
-      //   in the same panel as the status it affects).
+      // Order: account → power → refresh. Settings has been promoted to the
+      // top-level icon row on the header bar so it's reachable from every
+      // panel, not just Status.
       // - Sign In / Sign Out swaps based on state.authenticated; only one is
       //   ever visible (mutually exclusive flows, no point showing both).
       // - Disable: visible only when enabled — toolbar itself is hidden in
       //   disabled mode, and Enable is offered on the disabled-banner instead.
       // - Refresh: rightmost (matches the convention used on the other tabs).
       const items = [
-        iconButton('open-settings', 'Settings', 'gear'),
         state.authenticated
           ? iconButton('sign-out', 'Sign Out', 'sign-out')
           : iconButton('sign-in', 'Sign In', 'sign-in'),
@@ -510,7 +548,12 @@ export function buildSidebarScript(): string {
         applyConfigured(msg.state.configured !== false);
         if (msg.state.activeTab) switchTab(msg.state.activeTab);
         if (msg.state.kbMode) state.kbMode = msg.state.kbMode;
-        renderBranchTabName(msg.state.branchName, msg.state.detached);
+        state.branchName = msg.state.branchName;
+        state.detached = !!msg.state.detached;
+        state.currentRepoName = msg.state.currentRepoName;
+        state.selectedRepoName = msg.state.selectedRepoName;
+        state.selectedBranchName = msg.state.selectedBranchName;
+        renderBreadcrumb();
         renderToolbar();
         if (msg.state.enabled && state.activeTab === 'kb') {
           if (state.kbMode === 'folders') {
@@ -589,7 +632,116 @@ export function buildSidebarScript(): string {
         break;
       }
       case 'branch:branchName':
-        renderBranchTabName(msg.name, msg.detached);
+        state.branchName = msg.name;
+        state.detached = !!msg.detached;
+        renderBreadcrumb();
+        // Workspace branch changed — if the user was viewing the workspace
+        // branch (no override), the breadcrumb label has just updated and
+        // foreign-readonly chrome may need to lift. If the user was viewing
+        // a foreign branch the predicate is unaffected.
+        if (state.activeTab === 'branch') renderBranch();
+        break;
+      case 'selection:repos':
+        repoChoices = Array.isArray(msg.repos) ? msg.repos.slice() : [];
+        renderBreadcrumb();
+        break;
+      case 'selection:branches':
+        if (msg.repoName) {
+          branchChoicesByRepo[msg.repoName] = Array.isArray(msg.branches) ? msg.branches.slice() : [];
+          renderBreadcrumb();
+        }
+        break;
+      case 'selection:set':
+        state.selectedRepoName = msg.repoName;
+        state.selectedBranchName = msg.branchName;
+        renderBreadcrumb();
+        // Picking a repo/branch from the breadcrumb returns focus to the
+        // Branch tab — the Memory Bank and Status overlays are global
+        // workspace-oriented surfaces, so leaving them open while the
+        // breadcrumb has shifted to a different context is disorienting.
+        // switchTab handles the panel swap + Branch re-render itself; the
+        // else branch covers the already-on-Branch case where we still
+        // need to re-render to pick up the new selection.
+        if (state.activeTab !== 'branch') {
+          switchTab('branch');
+        } else {
+          renderBranch();
+        }
+        // Branch tab foreign view needs per-branch memories from the host
+        // (workspace-bound branchData.commits can't represent a foreign pick).
+        // Request lazily when the selection materializes; the response fills
+        // branchMemoriesCache and a renderBranch() inside that handler paints
+        // the rows. Skip if already cached or a fetch is pending — host pushes
+        // are sticky for the life of the session.
+        //
+        // Repo/branch fall back to the workspace's own — picking only a branch
+        // (without first picking a repo) leaves state.selectedRepoName
+        // undefined but should still trigger a fetch for currentRepoName +
+        // pickedBranch. The render path, isViewingForeign, and the response
+        // handler all use the same selectedX-||-currentX fallback; the
+        // trigger key MUST match or the request never fires and the Memories
+        // section stays empty until the user re-picks the repo.
+        {
+          const repo = state.selectedRepoName || state.currentRepoName;
+          const branch = state.selectedBranchName || state.branchName;
+          if (isViewingForeign() && repo && branch) {
+            const key = branchMemoriesKey(repo, branch);
+            if (!branchMemoriesCache[key] && !branchMemoriesPending[key]) {
+              branchMemoriesPending[key] = true;
+              vscode.postMessage({
+                type: 'selection:requestBranchMemories',
+                repoName: repo,
+                branchName: branch,
+              });
+            }
+          }
+        }
+        break;
+      case 'selection:branchMemories':
+        // Cache by repoName::branchName. The response echoes both keys so we
+        // can match even if state.selected* has moved on (user picked again
+        // mid-fetch). If the result still matches the active selection AND
+        // we're on the Branch tab in foreign mode, re-render so the section
+        // populates.
+        {
+          const k = branchMemoriesKey(msg.repoName, msg.branchName);
+          branchMemoriesCache[k] = msg.items.slice();
+          delete branchMemoriesPending[k];
+          const activeKey = branchMemoriesKey(
+            state.selectedRepoName || state.currentRepoName,
+            state.selectedBranchName || state.branchName,
+          );
+          if (k === activeKey && state.activeTab === 'branch' && isViewingForeign()) {
+            renderBranch();
+          }
+        }
+        break;
+      case 'selection:invalidateBranchMemories':
+        // Toolbar Refresh while viewing a foreign repo+branch: the cache is
+        // session-sticky (populated once per key on selection:set, never
+        // re-fetched) so without this signal Refresh would not change what
+        // the user sees. Drop every cached key, then re-trigger the lazy
+        // fetch for the currently-active foreign selection. Other keys
+        // refetch on demand the next time the user navigates to them.
+        {
+          for (const k in branchMemoriesCache) delete branchMemoriesCache[k];
+          for (const k in branchMemoriesPending) delete branchMemoriesPending[k];
+          const repo = state.selectedRepoName || state.currentRepoName;
+          const branch = state.selectedBranchName || state.branchName;
+          if (isViewingForeign() && repo && branch) {
+            const key = branchMemoriesKey(repo, branch);
+            branchMemoriesPending[key] = true;
+            vscode.postMessage({
+              type: 'selection:requestBranchMemories',
+              repoName: repo,
+              branchName: branch,
+            });
+            // Repaint while the request is in flight so the section drops
+            // its old rows for an empty "Loading"-equivalent state until
+            // selection:branchMemories arrives.
+            if (state.activeTab === 'branch') renderBranch();
+          }
+        }
         break;
       case 'status:data':
         renderStatus(msg.entries);
@@ -664,11 +816,10 @@ export function buildSidebarScript(): string {
     lastStatusEntriesJson = null;
 
     if (enabled) {
-      // Restore tab-button labels (cleared by disabled-mode overrides if any)
-      // and sync .active class against the persisted active tab.
-      tabButtonKb.classList.remove('hidden');
-      tabBranchBtn.classList.remove('hidden');
-      document.querySelectorAll('.tab').forEach(function(elBtn) {
+      // Sync .active class on the icon buttons against the persisted active
+      // tab. Branch has no button so it never gets .active — the absence of
+      // .active on KB/Status icons is the visual signal that Branch is current.
+      document.querySelectorAll('.tab[data-tab]').forEach(function(elBtn) {
         elBtn.classList.toggle('active', elBtn.getAttribute('data-tab') === state.activeTab);
       });
       // Normal mode: only the active tab's content is visible.
@@ -682,7 +833,7 @@ export function buildSidebarScript(): string {
       tabContents.kb.classList.add('hidden');
       tabContents.branch.classList.add('hidden');
       tabContents.status.classList.add('hidden');
-      document.querySelectorAll('.tab').forEach(function(elBtn) {
+      document.querySelectorAll('.tab[data-tab]').forEach(function(elBtn) {
         elBtn.classList.remove('active');
       });
     }
@@ -747,25 +898,215 @@ export function buildSidebarScript(): string {
     }
   }
 
-  function renderBranchTabName(name, detached) {
-    // Tab button is "<i class=codicon> + <span class=tab-label>" — only update
-    // the label text so we never wipe the leading icon. textContent on the
-    // button itself would clobber the <i> child.
-    const labelEl = tabBranchBtn.querySelector('.tab-label');
+  function renderBreadcrumbBranchLabel(name, detached) {
+    // Only update the label text — leave the leading icon and chevron alone.
     if (!name) {
-      if (labelEl) labelEl.textContent = '(no branch)';
-      tabBranchBtn.title = '';
+      breadcrumbBranchLabel.textContent = '(no branch)';
+      breadcrumbBranchBtn.title = '';
       return;
     }
     if (detached) {
       const short = name.length > 7 ? name.slice(0, 7) : name;
-      if (labelEl) labelEl.textContent = '(detached: ' + short + ')';
-      tabBranchBtn.title = 'detached HEAD: ' + name;
+      breadcrumbBranchLabel.textContent = '(detached: ' + short + ')';
+      breadcrumbBranchBtn.title = 'detached HEAD: ' + name;
       return;
     }
-    if (labelEl) labelEl.textContent = name;
-    tabBranchBtn.title = name;
+    breadcrumbBranchLabel.textContent = name;
+    breadcrumbBranchBtn.title = name;
   }
+
+  function renderBreadcrumbRepoLabel(name) {
+    breadcrumbRepoLabel.textContent = name || '(workspace)';
+    breadcrumbRepoBtn.title = name || '';
+  }
+
+  // Single source of truth for "is the user browsing somewhere other than the
+  // workspace's own repo+branch?" The renderers consult this to decide
+  // whether to render checkboxes, squash/push buttons, plans/changes
+  // sections. The host is responsible for refilling branch:* data when the
+  // selection changes; this function only flips the visual chrome.
+  function isViewingForeign() {
+    const repoMatch = !state.selectedRepoName || state.selectedRepoName === state.currentRepoName;
+    const branchMatch = !state.selectedBranchName || state.selectedBranchName === state.branchName;
+    return !(repoMatch && branchMatch);
+  }
+
+  function applyForeignReadonly() {
+    root.classList.toggle('foreign-readonly', isViewingForeign());
+  }
+
+  function renderBreadcrumb() {
+    // Repo: show selectedRepoName when set, else currentRepoName. The chevron
+    // is only meaningful when there is a real choice (>= 2 repos).
+    const repoDisplay = state.selectedRepoName || state.currentRepoName || '';
+    renderBreadcrumbRepoLabel(repoDisplay);
+    const repoChevron = breadcrumbRepoBtn.querySelector('.breadcrumb-seg-chevron');
+    if (repoChevron) repoChevron.classList.toggle('hidden', repoChoices.length < 2);
+    // Branch: show selectedBranchName when set, else fall back to the
+    // workspace branch (branchName/detached are always the workspace's).
+    const branchDisplay = state.selectedBranchName || state.branchName;
+    const detached = state.selectedBranchName ? false : state.detached;
+    renderBreadcrumbBranchLabel(branchDisplay, detached);
+    const repoForBranches = state.selectedRepoName || state.currentRepoName || '';
+    const branchList = branchChoicesByRepo[repoForBranches] || [];
+    const branchChevron = breadcrumbBranchBtn.querySelector('.breadcrumb-seg-chevron');
+    if (branchChevron) branchChevron.classList.toggle('hidden', branchList.length < 2);
+    applyForeignReadonly();
+  }
+
+  function hideBreadcrumbMenu() {
+    breadcrumbMenu.classList.add('hidden');
+    breadcrumbRepoBtn.setAttribute('aria-expanded', 'false');
+    breadcrumbBranchBtn.setAttribute('aria-expanded', 'false');
+  }
+
+  function showBreadcrumbMenu(anchorBtn, items, onPick) {
+    if (!items || items.length === 0) return;
+    clear(breadcrumbMenu);
+    // Reset inline max-height left over from a previous open so the CSS
+    // default (50vh) governs again until we compute the real cap below.
+    breadcrumbMenu.style.maxHeight = '';
+
+    // Show the filter input only when scanning by eye gets tedious. 8 is
+    // roughly one viewport-height of rows in a typical sidebar width.
+    const SEARCH_THRESHOLD = 8;
+    const showSearch = items.length >= SEARCH_THRESHOLD;
+
+    const list = el('div', { className: 'dropdown-list', role: 'none' });
+    const rows = [];
+    items.forEach(function(it) {
+      const isCurrent = !!it.current;
+      const row = el('div', {
+        className: 'dropdown-item' + (isCurrent ? ' current' : ''),
+        role: 'menuitem',
+        'data-value': it.value,
+      }, [
+        el('i', {
+          className: 'codicon dropdown-item-check ' + (isCurrent ? 'codicon-check' : ''),
+          'aria-hidden': 'true',
+        }),
+        el('span', { text: it.label }),
+      ]);
+      row.addEventListener('click', function() {
+        hideBreadcrumbMenu();
+        onPick(it.value);
+      });
+      list.appendChild(row);
+      rows.push({ el: row, label: String(it.label || '').toLowerCase() });
+    });
+    const emptyMsg = el('div', { className: 'dropdown-empty hidden', text: 'No matches' });
+    list.appendChild(emptyMsg);
+
+    let searchInput = null;
+    if (showSearch) {
+      searchInput = el('input', {
+        type: 'text',
+        placeholder: 'Filter...',
+        'aria-label': 'Filter list',
+        autocomplete: 'off',
+        spellcheck: 'false',
+      });
+      searchInput.addEventListener('input', function() {
+        const q = String(searchInput.value || '').trim().toLowerCase();
+        let visible = 0;
+        for (let i = 0; i < rows.length; i++) {
+          const match = q === '' || rows[i].label.indexOf(q) !== -1;
+          rows[i].el.classList.toggle('hidden', !match);
+          if (match) visible++;
+        }
+        emptyMsg.classList.toggle('hidden', visible !== 0);
+      });
+      // The document-level click handler closes the menu on outside clicks;
+      // clicks inside the menu already short-circuit via breadcrumbMenu.contains,
+      // but stopping propagation on the input itself keeps the menu open even
+      // if a future change tightens that guard.
+      searchInput.addEventListener('click', function(e) { e.stopPropagation(); });
+      searchInput.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') {
+          // Let the document-level Escape handler close the menu so behaviour
+          // matches clicking outside; stopping here would trap focus.
+          return;
+        }
+      });
+      const searchWrap = el('div', { className: 'dropdown-search' }, [searchInput]);
+      breadcrumbMenu.appendChild(searchWrap);
+    }
+    breadcrumbMenu.appendChild(list);
+
+    // Position relative to the viewport. The menu uses position:absolute
+    // anchored to the document, so getBoundingClientRect is enough. CSS
+    // caps the menu at 50vh; if the anchor sits close to the viewport
+    // bottom we tighten that further to whatever space remains, so the
+    // list scrolls inside the menu instead of overflowing off-screen.
+    const r = anchorBtn.getBoundingClientRect();
+    breadcrumbMenu.style.left = String(Math.round(r.left)) + 'px';
+    breadcrumbMenu.style.top = String(Math.round(r.bottom + 2)) + 'px';
+    const availableBelow = window.innerHeight - r.bottom - 12;
+    const cap50vh = Math.round(window.innerHeight * 0.5);
+    // Math.max with a floor keeps the menu usable even when the anchor is
+    // pinned near the bottom edge (e.g. user shrank the sidebar height).
+    const cappedMax = Math.max(120, Math.min(cap50vh, availableBelow));
+    breadcrumbMenu.style.maxHeight = String(cappedMax) + 'px';
+    breadcrumbMenu.classList.remove('hidden');
+    anchorBtn.setAttribute('aria-expanded', 'true');
+    if (searchInput) searchInput.focus();
+  }
+
+  breadcrumbRepoBtn.addEventListener('click', function(e) {
+    e.stopPropagation();
+    if (repoChoices.length < 2) return;
+    const isOpen = breadcrumbRepoBtn.getAttribute('aria-expanded') === 'true';
+    hideBreadcrumbMenu();
+    if (isOpen) return;
+    const items = repoChoices.map(function(rc) {
+      return {
+        value: rc.repoName,
+        label: rc.repoName + (rc.isCurrent ? ' (current)' : ''),
+        current: rc.repoName === (state.selectedRepoName || state.currentRepoName),
+      };
+    });
+    showBreadcrumbMenu(breadcrumbRepoBtn, items, function(picked) {
+      vscode.postMessage({ type: 'selection:request', repoName: picked });
+    });
+  });
+
+  breadcrumbBranchBtn.addEventListener('click', function(e) {
+    e.stopPropagation();
+    const repoForBranches = state.selectedRepoName || state.currentRepoName || '';
+    const list = branchChoicesByRepo[repoForBranches] || [];
+    if (list.length < 2) return;
+    const isOpen = breadcrumbBranchBtn.getAttribute('aria-expanded') === 'true';
+    hideBreadcrumbMenu();
+    if (isOpen) return;
+    const currentBranchInRepo = state.selectedBranchName || state.branchName;
+    const isWorkspaceRepo = repoForBranches === state.currentRepoName;
+    const items = list.map(function(b) {
+      const isWorkspaceBranch = isWorkspaceRepo && b === state.branchName;
+      return {
+        value: b,
+        label: b + (isWorkspaceBranch ? ' (current)' : ''),
+        current: b === currentBranchInRepo,
+      };
+    });
+    showBreadcrumbMenu(breadcrumbBranchBtn, items, function(picked) {
+      vscode.postMessage({ type: 'selection:request', branchName: picked });
+    });
+  });
+
+  // Dismiss the dropdown on any outside click — guarding against clicks
+  // inside the menu itself, which would otherwise close before onPick runs.
+  document.addEventListener('click', function(e) {
+    if (breadcrumbMenu.classList.contains('hidden')) return;
+    if (breadcrumbMenu.contains(e.target)) return;
+    if (breadcrumbRepoBtn.contains(e.target)) return;
+    if (breadcrumbBranchBtn.contains(e.target)) return;
+    hideBreadcrumbMenu();
+  });
+  document.addEventListener('keydown', function(e) {
+    if (e.key === 'Escape' && !breadcrumbMenu.classList.contains('hidden')) {
+      hideBreadcrumbMenu();
+    }
+  });
 
   // Map iconColor / iconKey to a predefined CSS class (defined in
   // SidebarCssBuilder). We use a class instead of a dynamic style="color:..."
@@ -1126,7 +1467,14 @@ export function buildSidebarScript(): string {
   function renderMemories() {
     const container = tabContents.kb;
     const nodes = [];
-    if (memoriesState.items.length === 0) {
+    // KB tab Memories timeline is intentionally NOT scoped by the breadcrumb —
+    // it's the global "every memory I've created" activity stream. The
+    // breadcrumb selection drives the Branch tab Memories section instead,
+    // via branchMemoriesCache / getForeignCommitItems. Showing the same data
+    // in both places, gated differently, was the source of confusion that
+    // led to two separate code paths.
+    const visibleItems = memoriesState.items;
+    if (visibleItems.length === 0) {
       nodes.push(el('div', { className: 'empty-state', text: STRINGS.kbMemoriesEmpty || 'No memories yet.' }));
       mountIn(container, nodes);
       return;
@@ -1137,13 +1485,13 @@ export function buildSidebarScript(): string {
     // views (Memory Bank aggregating other repos) the badge disambiguates
     // same-named branches across repos.
     const repoNames = new Set();
-    for (let i = 0; i < memoriesState.items.length; i++) {
-      const r = memoriesState.items[i].repoName;
+    for (let i = 0; i < visibleItems.length; i++) {
+      const r = visibleItems[i].repoName;
       if (r) repoNames.add(r);
     }
     const showRepoBadge = repoNames.size > 1;
-    for (let i = 0; i < memoriesState.items.length; i++) {
-      const m = memoriesState.items[i];
+    for (let i = 0; i < visibleItems.length; i++) {
+      const m = visibleItems[i];
       // No title= attribute — hover content is rendered by the custom
       // .hover-card popup (renderHoverCard / showHoverCard below) so the
       // legacy native MarkdownString experience (codicons + command links)
@@ -1571,12 +1919,56 @@ export function buildSidebarScript(): string {
 
   function renderBranch() {
     const container = tabContents.branch;
-    const sections = [
-      { id: 'plans', title: 'Plans & Notes', items: branchData.plans, emptyText: STRINGS.plansEmpty || 'No plans or notes yet.' },
-      { id: 'changes', title: 'Changes', items: branchData.changes, emptyText: STRINGS.changesEmpty || 'No changes.' },
-      { id: 'commits', title: 'Commits', items: branchData.commits, emptyText: STRINGS.commitsEmpty || 'No commits yet.' },
-    ];
+    // Plans & Notes and Changes are workspace-local — they have no meaningful
+    // representation for a foreign repo/branch selection. Drop them entirely
+    // in foreign-readonly mode so the panel reduces to the Memories list.
+    const foreign = isViewingForeign();
+    const sections = [];
+    if (!foreign) {
+      sections.push({ id: 'plans', title: 'Plans & Notes', items: branchData.plans, emptyText: STRINGS.plansEmpty || 'No plans or notes yet.' });
+      sections.push({ id: 'changes', title: 'Changes', items: branchData.changes, emptyText: STRINGS.changesEmpty || 'No changes.' });
+    }
+    // Section id stays 'commits' (back-compat: section-toggle state and CSS
+    // selectors key off it), but the user-facing title is now "Memories"
+    // because every selected row maps to — or will become — a Jolli memory.
+    //
+    // Data source switches with the breadcrumb selection:
+    //  - workspace view → branchData.commits (rich BranchCommit shape pushed
+    //    by host via branch:commitsData; supports checkboxes / squash / push).
+    //  - foreign view   → memoriesState.items filtered by selectedRepoName +
+    //    selectedBranchName, adapted to the display-item shape renderCommitRow
+    //    consumes. Host doesn't refetch commits on selection change (the bridge
+    //    only knows how to git-log workspace HEAD), so we re-derive locally
+    //    from the cross-repo summary index that's already loaded.
+    const commitsItems = foreign ? getForeignCommitItems() : branchData.commits;
+    sections.push({ id: 'commits', title: 'Memories', items: commitsItems, emptyText: STRINGS.commitsEmpty || 'No memories yet.' });
     mountIn(container, sections.map(renderSection));
+  }
+
+  // Adapts BranchMemoryItem → the minimal display-item shape renderCommitRow
+  // reads. Foreign-readonly mode already suppresses squash / push / checkbox
+  // (renderSectionActions returns [] and isMulti is forced false), so the
+  // BranchCommit-specific fields (isSelected, children-as-files, etc.) don't
+  // need real values — null/false placeholders are enough.
+  //
+  // Data source is branchMemoriesCache (host-fetched per repo+branch, no
+  // parent filter — matches Memory Bank tree's count). Cache miss returns []
+  // until the pending selection:branchMemories response arrives.
+  function getForeignCommitItems() {
+    const repo = state.selectedRepoName || state.currentRepoName || '';
+    const branch = state.selectedBranchName || state.branchName || '';
+    if (!repo || !branch) return [];
+    const items = branchMemoriesCache[branchMemoriesKey(repo, branch)] || [];
+    return items.map(function(m) {
+      return {
+        id: m.commitHash,
+        label: m.title || m.commitHash.slice(0, 8),
+        description: m.timestamp ? timeAgo(m.timestamp) : '',
+        contextValue: 'commitWithMemory',
+        children: null,
+        isSelected: false,
+      };
+    });
   }
 
   function renderSection(s) {
@@ -1608,13 +2000,46 @@ export function buildSidebarScript(): string {
               }
               return acc;
             }, []));
+    // Primary CTA mounted as a SIBLING of .section-body so it survives the
+    // Changes section being collapsed. Commit Memory operates on the group
+    // (Plans + Changes + Commits selections together), so hiding it whenever
+    // the user folds Changes makes the cross-panel action unreachable. The
+    // header sparkle iconbtn is too easy to miss, and a labelled button
+    // mirrors the SCM "Commit" pattern users expect. Stays visible when
+    // Changes is empty (sits below the empty-state placeholder, disabled via
+    // renderCommitMemoryButton's selectedCount===0 guard). Foreign-readonly
+    // mode drops the Changes section entirely above, so the s.id==='changes'
+    // predicate already implicitly excludes foreign view — no extra check
+    // needed.
+    const sectionKids = [
+      el('div', { className: 'section-header' }, headerKids),
+      el('div', { className: 'section-body' }, bodyKids),
+    ];
+    if (s.id === 'changes') {
+      sectionKids.push(renderCommitMemoryButton());
+    }
     return el('div', {
       className: 'collapsible-section' + (collapsed ? ' collapsed' : ''),
       'data-section': s.id,
+    }, sectionKids);
+  }
+
+  function renderCommitMemoryButton() {
+    const selectedCount = branchData.changes.filter(function(c) {
+      return !!c.isSelected;
+    }).length;
+    const disabled = selectedCount === 0 || state.workerBusy;
+    const btn = el('button', {
+      type: 'button',
+      className: 'commit-memory-btn',
+      'data-action': 'changes-commit-memory',
+      'aria-label': 'Commit Memory',
     }, [
-      el('div', { className: 'section-header' }, headerKids),
-      el('div', { className: 'section-body' }, bodyKids),
+      el('i', { className: 'codicon codicon-sparkle' }),
+      el('span', { className: 'commit-memory-btn-label', text: 'Commit Memory' }),
     ]);
+    if (disabled) btn.disabled = true;
+    return el('div', { className: 'commit-memory-action' }, [btn]);
   }
 
   function renderSectionActions(sectionId) {
@@ -1646,6 +2071,10 @@ export function buildSidebarScript(): string {
       ];
     }
     if (sectionId === 'commits') {
+      // Foreign-readonly: hide every write-action on the Memories section
+      // (Squash, Push Branch, Select All). The user can still open and read
+      // individual memories via the row's inline View Memory icon.
+      if (isViewingForeign()) return [];
       const m = branchData.commitsMode;
       if (m === 'multi') {
         // Squash is only meaningful with 2+ commits selected. Disable the
@@ -1861,7 +2290,9 @@ export function buildSidebarScript(): string {
     // ThemeIcon("git-commit") whenever the checkbox was hidden). The slot
     // width is kept constant so commit rows align horizontally with
     // commit-file rows regardless of mode.
-    const isMulti = branchData.commitsMode === 'multi';
+    // Foreign-readonly suppresses the checkbox even in multi mode — squash
+    // wouldn't be meaningful against a foreign repo's history.
+    const isMulti = branchData.commitsMode === 'multi' && !isViewingForeign();
     let leading;
     if (isMulti) {
       const cb = el('input', {
@@ -2080,6 +2511,15 @@ export function buildSidebarScript(): string {
   // must run before the section-header collapse-toggle catch-all — otherwise
   // every action-button click also collapses the panel.
   tabContents.branch.addEventListener('click', function(e) {
+    // Bottom-of-section Commit Memory CTA — not gated on .section-actions
+    // because it lives inside .section-body, not the header. Routes to the
+    // same command as the header sparkle iconbtn.
+    const commitMemoryBtn = e.target.closest('.commit-memory-btn[data-action="changes-commit-memory"]');
+    if (commitMemoryBtn && !commitMemoryBtn.disabled) {
+      vscode.postMessage({ type: 'command', command: 'jollimemory.commitAI' });
+      e.stopPropagation();
+      return;
+    }
     // Section toolbar actions.
     const sectionAction = e.target.closest('.section-actions [data-action]');
     if (sectionAction) {
@@ -2168,7 +2608,11 @@ export function buildSidebarScript(): string {
         });
       }
       if (action === 'viewSummary') {
-        vscode.postMessage({ type: 'command', command: 'jollimemory.viewSummary', args: [id] });
+        // Foreign rows live in another repo's storage — single-repo
+        // viewSummary silently misses. Route through viewMemorySummary
+        // (cross-repo) and into the "memory" panel slot in foreign mode.
+        const cmd = isViewingForeign() ? 'jollimemory.viewMemorySummary' : 'jollimemory.viewSummary';
+        vscode.postMessage({ type: 'command', command: cmd, args: [id] });
       }
       e.stopPropagation();
       return;
@@ -2208,7 +2652,14 @@ export function buildSidebarScript(): string {
         });
       }
       if (ctx === 'commit' || ctx === 'commitWithMemory') {
-        vscode.postMessage({ type: 'branch:openCommit', hash: id });
+        // Foreign rows are cross-repo memories — reuse kb:openMemory
+        // (→ viewMemorySummary, cross-repo) so the Memory slot opens
+        // instead of the Commit slot's single-repo lookup silently missing.
+        if (isViewingForeign()) {
+          vscode.postMessage({ type: 'kb:openMemory', commitHash: id });
+        } else {
+          vscode.postMessage({ type: 'branch:openCommit', hash: id });
+        }
       }
       if (ctx === 'commitFile') {
         const oldPath = row.getAttribute('data-old-path');

--- a/vscode/src/views/SidebarWebviewProvider.test.ts
+++ b/vscode/src/views/SidebarWebviewProvider.test.ts
@@ -1686,4 +1686,209 @@ describe("SidebarWebviewProvider", () => {
 		provider.resolveWebviewView(view as unknown as never);
 		expect(view.badge).toEqual({ value: 9, tooltip: "fresh" });
 	});
+
+	// ── Breadcrumb selection (selection:repos / selection:branches / selection:request) ──
+	// These tests verify the host-side wiring of the breadcrumb dropdowns —
+	// the previous gap (UI built, host wiring missing) is what made the repo
+	// segment render as `(workspace)` and both chevrons stay hidden.
+
+	function makeSelectionProvider(opts: {
+		listRepos: ReturnType<typeof vi.fn>;
+		listBranches: ReturnType<typeof vi.fn>;
+		currentRepoName?: string;
+	}): SidebarWebviewProvider {
+		return new SidebarWebviewProvider({
+			executeCommand: vi.fn().mockResolvedValue(undefined) as never,
+			getInitialState: () => ({
+				enabled: true,
+				authenticated: false,
+				configured: true,
+				activeTab: "branch",
+				kbMode: "folders",
+				branchName: "main",
+				detached: false,
+				currentRepoName: opts.currentRepoName ?? "workspace-repo",
+			}),
+			extensionUri: mockExtensionUri as unknown as never,
+			selection: {
+				listRepos: opts.listRepos,
+				listBranches: opts.listBranches,
+			},
+		});
+	}
+
+	it("pushes selection:repos and selection:branches for the current repo on ready", async () => {
+		const view = makeMockView();
+		const listRepos = vi.fn().mockReturnValue([
+			{ repoName: "workspace-repo", isCurrent: true },
+			{ repoName: "other-repo", isCurrent: false, remoteUrl: "git@x:y" },
+		]);
+		const listBranches = vi
+			.fn()
+			.mockImplementation((r: string) =>
+				r === "workspace-repo" ? ["main", "feature-x"] : ["topic"],
+			);
+		const provider = makeSelectionProvider({ listRepos, listBranches });
+		provider.resolveWebviewView(view as unknown as never);
+		view.webview.triggerMessage({ type: "ready" });
+		await flushReady();
+		const sent = view.webview.postMessage.mock.calls.map(
+			(c) => c[0],
+		) as SidebarInboundMsg[];
+		expect(sent).toContainEqual({
+			type: "selection:repos",
+			repos: [
+				{ repoName: "workspace-repo", isCurrent: true },
+				{ repoName: "other-repo", isCurrent: false, remoteUrl: "git@x:y" },
+			],
+		});
+		// listBranches is consulted only for the workspace repo at ready-time;
+		// foreign-repo branches are lazy-loaded when the user picks the repo.
+		expect(listBranches).toHaveBeenCalledTimes(1);
+		expect(listBranches).toHaveBeenCalledWith("workspace-repo");
+		expect(sent).toContainEqual({
+			type: "selection:branches",
+			repoName: "workspace-repo",
+			branches: ["main", "feature-x"],
+		});
+	});
+
+	it("init carries currentRepoName so the breadcrumb shows the real repo name (not (workspace))", async () => {
+		const view = makeMockView();
+		const provider = makeSelectionProvider({
+			listRepos: vi.fn().mockReturnValue([]),
+			listBranches: vi.fn().mockReturnValue([]),
+			currentRepoName: "jollimemory",
+		});
+		provider.resolveWebviewView(view as unknown as never);
+		view.webview.triggerMessage({ type: "ready" });
+		await flushReady();
+		const init = view.webview.postMessage.mock.calls
+			.map((c) => c[0] as SidebarInboundMsg)
+			.find(
+				(m): m is SidebarInboundMsg & { type: "init" } => m.type === "init",
+			);
+		expect(init).toBeDefined();
+		expect((init as { state: SidebarState }).state.currentRepoName).toBe(
+			"jollimemory",
+		);
+	});
+
+	it("selection:request with repoName pushes selection:branches and selection:set with auto-picked branch", () => {
+		const view = makeMockView();
+		const listRepos = vi.fn().mockReturnValue([
+			{ repoName: "workspace-repo", isCurrent: true },
+			{ repoName: "other-repo", isCurrent: false },
+		]);
+		const listBranches = vi
+			.fn()
+			.mockImplementation((r: string) =>
+				r === "other-repo" ? ["release", "draft"] : [],
+			);
+		const provider = makeSelectionProvider({ listRepos, listBranches });
+		provider.resolveWebviewView(view as unknown as never);
+		view.webview.postMessage.mockClear();
+		view.webview.triggerMessage({
+			type: "selection:request",
+			repoName: "other-repo",
+		});
+		const sent = view.webview.postMessage.mock.calls.map(
+			(c) => c[0],
+		) as SidebarInboundMsg[];
+		expect(sent).toContainEqual({
+			type: "selection:branches",
+			repoName: "other-repo",
+			branches: ["release", "draft"],
+		});
+		expect(sent).toContainEqual({
+			type: "selection:set",
+			repoName: "other-repo",
+			branchName: "release",
+		});
+	});
+
+	it("selection:request with only branchName posts selection:set without re-listing branches", () => {
+		const view = makeMockView();
+		const listRepos = vi.fn().mockReturnValue([
+			{ repoName: "workspace-repo", isCurrent: true },
+			{ repoName: "other-repo", isCurrent: false },
+		]);
+		const listBranches = vi
+			.fn()
+			.mockImplementation((r: string) =>
+				r === "other-repo" ? ["release", "draft"] : ["main"],
+			);
+		const provider = makeSelectionProvider({ listRepos, listBranches });
+		provider.resolveWebviewView(view as unknown as never);
+		// First land on a foreign repo so selectedRepoName is populated.
+		view.webview.triggerMessage({
+			type: "selection:request",
+			repoName: "other-repo",
+		});
+		view.webview.postMessage.mockClear();
+		listBranches.mockClear();
+		view.webview.triggerMessage({
+			type: "selection:request",
+			branchName: "draft",
+		});
+		expect(listBranches).not.toHaveBeenCalled();
+		const sent = view.webview.postMessage.mock.calls.map(
+			(c) => c[0],
+		) as SidebarInboundMsg[];
+		expect(sent).toEqual([
+			{
+				type: "selection:set",
+				repoName: "other-repo",
+				branchName: "draft",
+			},
+		]);
+	});
+
+	it("selection:request for an unknown repo is a no-op (no messages, no state mutation)", () => {
+		const view = makeMockView();
+		const listRepos = vi
+			.fn()
+			.mockReturnValue([{ repoName: "workspace-repo", isCurrent: true }]);
+		const listBranches = vi.fn().mockReturnValue([]);
+		const provider = makeSelectionProvider({ listRepos, listBranches });
+		provider.resolveWebviewView(view as unknown as never);
+		view.webview.postMessage.mockClear();
+		view.webview.triggerMessage({
+			type: "selection:request",
+			repoName: "ghost-repo",
+		});
+		expect(view.webview.postMessage).not.toHaveBeenCalled();
+		expect(listBranches).not.toHaveBeenCalled();
+	});
+
+	it("selection:request is silently ignored when the selection dep is absent", () => {
+		const view = makeMockView();
+		const provider = new SidebarWebviewProvider({
+			executeCommand: vi.fn().mockResolvedValue(undefined) as never,
+			getInitialState: () => ({
+				enabled: true,
+				authenticated: false,
+				configured: true,
+				activeTab: "branch",
+				kbMode: "folders",
+				branchName: "main",
+				detached: false,
+				currentRepoName: "workspace-repo",
+			}),
+			extensionUri: mockExtensionUri as unknown as never,
+		});
+		provider.resolveWebviewView(view as unknown as never);
+		view.webview.postMessage.mockClear();
+		expect(() =>
+			view.webview.triggerMessage({
+				type: "selection:request",
+				repoName: "anything",
+			}),
+		).not.toThrow();
+		// No selection:* messages posted because the dep isn't wired.
+		const sent = view.webview.postMessage.mock.calls.map(
+			(c) => (c[0] as SidebarInboundMsg).type,
+		);
+		expect(sent.filter((t) => t.startsWith("selection:"))).toEqual([]);
+	});
 });

--- a/vscode/src/views/SidebarWebviewProvider.ts
+++ b/vscode/src/views/SidebarWebviewProvider.ts
@@ -13,8 +13,10 @@ import { log } from "../util/Logger.js";
 import { SIDEBAR_EMPTY_STRINGS } from "./SidebarEmptyMessages.js";
 import { buildSidebarHtml } from "./SidebarHtmlBuilder.js";
 import type {
+	BranchMemoryItem,
 	FolderNode,
 	MemoryItem,
+	RepoChoice,
 	SerializedTreeItem,
 	SidebarInboundMsg,
 	SidebarOutboundMsg,
@@ -42,6 +44,29 @@ export interface SidebarWebviewDeps {
 		getWorkerBusy(): boolean;
 	};
 	kbFolders?: { listChildren(relPath: string): Promise<FolderNode> };
+	/**
+	 * Source for the breadcrumb repo/branch dropdowns. `listRepos` enumerates
+	 * every Memory Bank repo (current + foreign); `listBranches(repoName)`
+	 * returns the branches known for that repo. Kept separate from `kbFolders`
+	 * because the breadcrumb has no Folders-tab dependency: a webview with
+	 * only the breadcrumb wired (e.g. a future trimmed-down host) still needs
+	 * these. Both are sync — implementations read JSON metadata that's already
+	 * cheap to slurp; pushRepos fires inside `handleReady`'s synchronous tail.
+	 */
+	selection?: {
+		listRepos(): readonly RepoChoice[];
+		listBranches(repoName: string): readonly string[];
+		/**
+		 * Returns every memory stored for the named repo+branch — including
+		 * amend/rebase children — so the foreign-readonly Branch tab Memories
+		 * section can match Memory Bank tree counts. The global KB Memories
+		 * list intentionally collapses chains; this path bypasses that filter.
+		 */
+		listBranchMemories(
+			repoName: string,
+			branchName: string,
+		): Promise<ReadonlyArray<BranchMemoryItem>>;
+	};
 	/** Returns absolute path under kbRoot for a relative path. */
 	resolveKbAbs?: (relPath: string) => string;
 	memoriesProvider?: {
@@ -117,6 +142,15 @@ export class SidebarWebviewProvider
 	 * filesStore.onChange. resolveWebviewView re-applies whatever's pending.
 	 */
 	private pendingBadge: vscode.WebviewView["badge"];
+	/**
+	 * Breadcrumb selection — mirrors `state.selectedRepoName` /
+	 * `selectedBranchName` on the webview side. Undefined = viewing the
+	 * workspace's own repo / branch (no foreign-readonly chrome). Held on the
+	 * host so a webview reload can resync via `getInitialState`-adjacent
+	 * pushes; today we drop on reload since the dropdowns re-populate fresh.
+	 */
+	private selectedRepoName: string | undefined;
+	private selectedBranchName: string | undefined;
 
 	constructor(private readonly deps: SidebarWebviewDeps) {}
 
@@ -244,6 +278,15 @@ export class SidebarWebviewProvider
 				detached: cur.detached,
 			});
 		}
+		// Populate the breadcrumb dropdowns. Repos are pushed unconditionally
+		// — even a single-repo result lets the webview decide whether to hide
+		// the chevron (it suppresses < 2 entries). Branches are pushed for the
+		// workspace's own repo so the branch dropdown is immediately usable;
+		// foreign-repo branches are fetched lazily when the user picks that
+		// repo via `selection:request`.
+		this.pushRepos();
+		const init = this.deps.getInitialState();
+		if (init.currentRepoName) this.pushBranches(init.currentRepoName);
 	}
 
 	private handleOutbound(raw: unknown): void {
@@ -356,9 +399,118 @@ export class SidebarWebviewProvider
 			case "refresh":
 				this.handleRefresh(msg.scope);
 				return;
+			case "selection:request":
+				this.handleSelectionRequest(msg.repoName, msg.branchName);
+				return;
+			case "selection:requestBranchMemories":
+				void this.handleBranchMemoriesRequest(msg.repoName, msg.branchName);
+				return;
 			default:
 				return;
 		}
+	}
+
+	/**
+	 * Resolves a breadcrumb pick from the webview into:
+	 *   - updated host-side selection state (so subsequent pushes stay
+	 *     consistent if we ever wire foreign-repo data into commitsStore),
+	 *   - a `selection:set` ack so the webview can re-render its breadcrumb
+	 *     and flip `.foreign-readonly` chrome,
+	 *   - (when the repo changed) a fresh `selection:branches` for the newly
+	 *     selected repo so its branch dropdown is populated.
+	 *
+	 * Repo picks auto-default to the first known branch. If the repo has no
+	 * branches registered in `.jolli/branches.json` (e.g. an empty Memory
+	 * Bank entry), `selectedBranchName` is left undefined and the webview
+	 * falls back to showing the workspace branch label — a known minor UX
+	 * wart for an edge case rather than a correctness bug.
+	 */
+	private handleSelectionRequest(
+		repoName: string | undefined,
+		branchName: string | undefined,
+	): void {
+		if (!this.deps.selection) return;
+		if (repoName) {
+			const repos = this.deps.selection.listRepos();
+			const target = repos.find((r) => r.repoName === repoName);
+			if (!target) return;
+			this.selectedRepoName = target.repoName;
+			const branches = this.deps.selection.listBranches(target.repoName);
+			this.selectedBranchName = branches[0];
+			this.postMessage({
+				type: "selection:branches",
+				repoName: target.repoName,
+				branches: [...branches],
+			});
+			this.postMessage({
+				type: "selection:set",
+				repoName: this.selectedRepoName,
+				branchName: this.selectedBranchName,
+			});
+			return;
+		}
+		if (branchName) {
+			this.selectedBranchName = branchName;
+			this.postMessage({
+				type: "selection:set",
+				repoName: this.selectedRepoName,
+				branchName,
+			});
+		}
+	}
+
+	/**
+	 * Resolves a webview request for "all memories on this repo+branch".
+	 * Always echoes the request's repoName+branchName on the response so the
+	 * webview can match it against its own cache key even if a faster newer
+	 * request has already overwritten its in-flight selection state.
+	 */
+	private async handleBranchMemoriesRequest(
+		repoName: string,
+		branchName: string,
+	): Promise<void> {
+		if (!this.deps.selection) return;
+		try {
+			const items = await this.deps.selection.listBranchMemories(
+				repoName,
+				branchName,
+			);
+			this.postMessage({
+				type: "selection:branchMemories",
+				repoName,
+				branchName,
+				items: [...items],
+			});
+		} catch (err) {
+			log.warn(
+				"SidebarWebviewProvider",
+				`handleBranchMemoriesRequest failed for ${repoName}/${branchName}: ${
+					err instanceof Error ? err.message : String(err)
+				}`,
+			);
+			this.postMessage({
+				type: "selection:branchMemories",
+				repoName,
+				branchName,
+				items: [],
+			});
+		}
+	}
+
+	private pushRepos(): void {
+		if (!this.deps.selection) return;
+		const repos = this.deps.selection.listRepos();
+		this.postMessage({ type: "selection:repos", repos: [...repos] });
+	}
+
+	private pushBranches(repoName: string): void {
+		if (!this.deps.selection) return;
+		const branches = this.deps.selection.listBranches(repoName);
+		this.postMessage({
+			type: "selection:branches",
+			repoName,
+			branches: [...branches],
+		});
 	}
 
 	/**
@@ -377,6 +529,14 @@ export class SidebarWebviewProvider
 			void this.deps.executeCommand("jollimemory.refreshPlans");
 			void this.deps.executeCommand("jollimemory.refreshFiles");
 			void this.deps.executeCommand("jollimemory.refreshHistory");
+			// The workspace-scoped refresh* commands above don't reach the
+			// foreign-readonly Branch view's `branchMemoriesCache` (host pushes
+			// land in branchData but the foreign render path reads from the
+			// per-(repo, branch) cache instead). Without this signal a user
+			// viewing a foreign repo+branch sees the Memories section frozen on
+			// whatever the first selection load returned, no matter how many
+			// times they click Refresh.
+			this.postMessage({ type: "selection:invalidateBranchMemories" });
 		}
 		if (scope === "status" || scope === "all") {
 			void this.deps.executeCommand("jollimemory.refreshStatus");

--- a/vscode/src/views/SummaryCssBuilder.test.ts
+++ b/vscode/src/views/SummaryCssBuilder.test.ts
@@ -51,4 +51,18 @@ describe("SummaryCssBuilder", () => {
 		expect(css).toContain("--callout-detail-bg");
 		expect(css).toContain("--callout-detail-label");
 	});
+
+	// ─── Foreign-repo read-only mode ──────────────────────────────────────
+	// SummaryHtmlBuilder marks .page with `foreign-readonly` when the loaded
+	// summary belongs to a non-current repo. The CSS below hides every
+	// destructive control. PR section is NOT hidden — checkPrStatus is
+	// reachable in foreign mode via gh `--repo <remoteUrl>` so the panel
+	// still surfaces the foreign repo's PR (read-only).
+	describe("foreign-readonly mode", () => {
+		it("hides every non-whitelisted button under .page.foreign-readonly", () => {
+			expect(css).toMatch(
+				/\.page\.foreign-readonly\s+button:not\(\[data-foreign-safe\]\)\s*\{[^}]*display:\s*none/,
+			);
+		});
+	});
 });

--- a/vscode/src/views/SummaryCssBuilder.ts
+++ b/vscode/src/views/SummaryCssBuilder.ts
@@ -1220,6 +1220,21 @@ export function buildCss(): string {
     color: #fff;
   }
 
+  /* Foreign-repo read-only mode.
+     When SummaryHtmlBuilder marks .page with the foreign-readonly hook
+     class (SummaryWebviewPanel sets it when the loaded summary belongs
+     to a non-current repo via Memory Bank cross-repo lookup), every
+     button without an explicit data-foreign-safe whitelist marker is
+     hidden. The destructive-message guard in
+     SummaryWebviewPanel.dispatchWebviewMessage already short-circuits
+     the underlying handlers; this layer removes the affordance so
+     users never see a Push / Edit / Delete control they cannot use.
+     Safe controls today: Copy / Save Markdown, copy-hash, the two
+     expand/collapse toggles. */
+  .page.foreign-readonly button:not([data-foreign-safe]) {
+    display: none !important;
+  }
+
 ${buildPrSectionCss()}
 `;
 }

--- a/vscode/src/views/SummaryHtmlBuilder.test.ts
+++ b/vscode/src/views/SummaryHtmlBuilder.test.ts
@@ -263,6 +263,30 @@ describe("SummaryHtmlBuilder", () => {
 			expect(html).not.toContain("nonce=");
 		});
 
+		// ─── Foreign-repo read-only mode ──────────────────────────────────────
+		// When the panel renders a summary that came from a non-current repo
+		// (Memory Bank cross-repo lookup), every destructive control must be
+		// removed from the UI rather than just denied at the message layer —
+		// users should never see a Push / Edit / Delete affordance they can't
+		// actually use. SummaryHtmlBuilder exposes a hook class
+		// `foreign-readonly` on the .page root; SummaryCssBuilder owns the
+		// matching `display: none` rules. The default (no foreignRepoName)
+		// path stays free of foreign markup so non-foreign panels are
+		// untouched.
+		describe("foreign-repo read-only mode", () => {
+			it("adds the foreign-readonly hook class on the .page root when foreignRepoName is set", () => {
+				const html = buildHtml(makeSummary(), {
+					foreignRepoName: "other-repo",
+				});
+				expect(html).toMatch(/class="page foreign-readonly"/);
+			});
+
+			it("renders no foreign-readonly markup when foreignRepoName is omitted", () => {
+				const html = buildHtml(makeSummary());
+				expect(html).not.toContain("foreign-readonly");
+			});
+		});
+
 		it('shows "No topics available" message when topics are empty', () => {
 			collectSortedTopics.mockReturnValue({
 				topics: [],

--- a/vscode/src/views/SummaryHtmlBuilder.ts
+++ b/vscode/src/views/SummaryHtmlBuilder.ts
@@ -43,6 +43,15 @@ export interface BuildHtmlOptions {
 	readonly planTranslateSet?: ReadonlySet<string>;
 	readonly noteTranslateSet?: ReadonlySet<string>;
 	readonly nonce?: string;
+	/**
+	 * When set, the summary belongs to a non-current repo (Memory Bank
+	 * cross-repo lookup). The .page root receives a `foreign-readonly` hook
+	 * class; SummaryCssBuilder hides every destructive control under that
+	 * class so users only see read-only affordances (Copy / Download).
+	 * The panel tab title (set in SummaryWebviewPanel.update) already names
+	 * the source repo, so this layer does not render an additional banner.
+	 */
+	readonly foreignRepoName?: string | null;
 }
 
 /**
@@ -55,6 +64,7 @@ export function buildHtml(
 	opts: BuildHtmlOptions = {},
 ): string {
 	const { transcriptHashSet, planTranslateSet, noteTranslateSet, nonce } = opts;
+	const pageClass = opts.foreignRepoName ? "page foreign-readonly" : "page";
 	const { topics: allTopics, sourceNodes } = collectSortedTopics(summary);
 	const stats = resolveDiffStats(summary);
 	const totalInsertions = stats.insertions;
@@ -83,7 +93,7 @@ ${csp}
 <style${nonceAttr}>${buildCss()}</style>
 </head>
 <body>
-<div class="page">
+<div class="${pageClass}">
 ${buildAllConversationsSection(transcriptHashSet)}
 ${buildHeader(summary, totalFiles, totalInsertions, totalDeletions)}
 <hr class="separator" />
@@ -95,7 +105,7 @@ ${buildSourceCommits(sourceNodes)}
 <div class="section">
   <div class="section-header">
     <div class="section-title" title="${topicsLabel}">&#x1F4DD; ${allTopics.length === 1 ? "Topic" : "Topics"} <span class="section-count">${allTopics.length}</span></div>
-    <button class="toggle-all-btn" id="toggleAllBtn" title="Expand / Collapse all topics">Collapse All</button>
+    <button class="toggle-all-btn" id="toggleAllBtn" title="Expand / Collapse all topics" data-foreign-safe>Collapse All</button>
   </div>
   ${topicsHtml}
 </div>
@@ -206,10 +216,10 @@ function buildHeader(
 <h1 class="page-title">${escHtml(summary.commitMessage)}</h1>
 <div class="header-actions">
   <div class="split-btn-group">
-    <button class="action-btn" id="copyMdBtn">Copy Markdown</button>
-    <button class="action-btn split-toggle" id="copyMdDropdown" title="More export options">&#x25BE;</button>
+    <button class="action-btn" id="copyMdBtn" data-foreign-safe>Copy Markdown</button>
+    <button class="action-btn split-toggle" id="copyMdDropdown" title="More export options" data-foreign-safe>&#x25BE;</button>
     <div class="split-menu" id="copyMdMenu">
-      <button class="split-menu-item" id="downloadMdBtn">Save as Markdown File</button>
+      <button class="split-menu-item" id="downloadMdBtn" data-foreign-safe>Save as Markdown File</button>
     </div>
   </div>
   <button class="action-btn primary" id="pushJolliBtn">${pushLabel}</button>
@@ -219,7 +229,7 @@ function buildHeader(
     <div class="prop-label">Commit</div>
     <div class="prop-value">
       <span class="hash">${escHtml(summary.commitHash.substring(0, 8))}</span>
-      <button class="hash-copy" data-hash="${escHtml(summary.commitHash)}" title="Copy full hash">\u29C9</button>
+      <button class="hash-copy" data-hash="${escHtml(summary.commitHash)}" title="Copy full hash" data-foreign-safe>\u29C9</button>
     </div>
   </div>
   <div class="prop-row">
@@ -437,7 +447,7 @@ export function buildE2eTestSection(summary: CommitSummary): string {
   <div class="section-header">
     <div class="section-title">\uD83E\uDDEA E2E Test <span class="section-count">${scenarios.length}</span></div>
     <span class="topic-actions">
-      <button class="toggle-all-btn" id="toggleAllE2eBtn" title="Expand / Collapse all scenarios">Collapse All</button>
+      <button class="toggle-all-btn" id="toggleAllE2eBtn" title="Expand / Collapse all scenarios" data-foreign-safe>Collapse All</button>
       <button class="topic-action-btn" id="regenE2eBtn" title="Regenerate">&#x21BB;</button>
       <button class="topic-action-btn" id="deleteE2eBtn" title="Delete">\uD83D\uDDD1</button>
     </span>

--- a/vscode/src/views/SummaryWebviewPanel.test.ts
+++ b/vscode/src/views/SummaryWebviewPanel.test.ts
@@ -632,6 +632,30 @@ describe("SummaryWebviewPanel", () => {
 			);
 		});
 
+		it("passes foreignRepoName through to buildHtml so CSS can hide destructive controls", async () => {
+			// The foreign-readonly hook lives in SummaryHtmlBuilder /
+			// SummaryCssBuilder. SummaryWebviewPanel's responsibility is
+			// just plumbing — make sure update() forwards the provenance the
+			// constructor received so the rendered HTML actually gets the
+			// hook class. Without this assertion a regression that drops the
+			// argument from the options object would still ship green tests
+			// at the buildHtml layer.
+			const summary = makeSummary();
+			await SummaryWebviewPanel.show(
+				summary,
+				extensionUri,
+				workspaceRoot,
+				stubBridge,
+				mainBranch,
+				"memory",
+				"other-repo",
+			);
+			expect(mockBuildHtml).toHaveBeenCalledWith(
+				summary,
+				expect.objectContaining({ foreignRepoName: "other-repo" }),
+			);
+		});
+
 		it("dispose handler removes the commit panel from the per-hash map", async () => {
 			const summary = makeSummary();
 			await SummaryWebviewPanel.show(
@@ -2552,7 +2576,10 @@ describe("SummaryWebviewPanel", () => {
 		// ── PR handlers ──────────────────────────────────────────────────────
 
 		describe("checkPrStatus", () => {
-			it("delegates to handleCheckPrStatus, passing summary.branch", async () => {
+			it("delegates to handleCheckPrStatus with null repoUrl for the local panel", async () => {
+				// Local panels (foreignRepoName=null) leave the 4th arg null so
+				// PrCommentService falls back to its existing implicit-repo
+				// path (`gh pr view -- <branch>` from `cwd`'s working tree).
 				const dispatch = await setupPanel();
 
 				dispatch({ command: "checkPrStatus" });
@@ -2562,6 +2589,36 @@ describe("SummaryWebviewPanel", () => {
 					workspaceRoot,
 					expect.any(Function),
 					"feature/test",
+					null,
+				);
+			});
+
+			it("passes foreign repo's remoteUrl as the 4th arg when the panel is foreign-origin", async () => {
+				// Memory Bank cross-repo browsing path: the panel was created
+				// with foreignRepoName + foreignRepoUrl, so checkPrStatus must
+				// hand the remote URL to PrCommentService — pinning the gh
+				// query to the foreign repo instead of the current workspace.
+				const summary = makeSummary();
+				await SummaryWebviewPanel.show(
+					summary,
+					extensionUri,
+					workspaceRoot,
+					stubBridge,
+					mainBranch,
+					"memory",
+					"other-repo",
+					"https://github.com/other/repo.git",
+				);
+				const dispatch = captureMessageHandler();
+
+				dispatch({ command: "checkPrStatus" });
+				await flushPromises();
+
+				expect(mockHandleCheckPrStatus).toHaveBeenCalledWith(
+					workspaceRoot,
+					expect.any(Function),
+					"feature/test",
+					"https://github.com/other/repo.git",
 				);
 			});
 
@@ -3131,7 +3188,13 @@ describe("SummaryWebviewPanel", () => {
 				mockReadTranscriptsForCommits.mockResolvedValue(transcriptMap);
 
 				const summary = makeSummary();
-				await SummaryWebviewPanel.show(summary, extensionUri, workspaceRoot);
+				await SummaryWebviewPanel.show(
+					summary,
+					extensionUri,
+					workspaceRoot,
+					stubBridge,
+					mainBranch,
+				);
 				const dispatch = captureMessageHandler();
 
 				dispatch({ command: "loadTranscriptStats" });
@@ -6359,7 +6422,13 @@ describe("SummaryWebviewPanel", () => {
 				mockReadTranscriptsForCommits.mockResolvedValue(transcriptMap);
 
 				const summary = makeSummary();
-				await SummaryWebviewPanel.show(summary, extensionUri, workspaceRoot);
+				await SummaryWebviewPanel.show(
+					summary,
+					extensionUri,
+					workspaceRoot,
+					stubBridge,
+					mainBranch,
+				);
 				const dispatch = captureMessageHandler();
 
 				dispatch({ command: "loadTranscriptStats" });
@@ -6404,7 +6473,13 @@ describe("SummaryWebviewPanel", () => {
 				mockReadTranscriptsForCommits.mockResolvedValue(transcriptMap);
 
 				const summary = makeSummary();
-				await SummaryWebviewPanel.show(summary, extensionUri, workspaceRoot);
+				await SummaryWebviewPanel.show(
+					summary,
+					extensionUri,
+					workspaceRoot,
+					stubBridge,
+					mainBranch,
+				);
 				const dispatch = captureMessageHandler();
 
 				dispatch({ command: "loadTranscriptStats" });
@@ -6449,7 +6524,13 @@ describe("SummaryWebviewPanel", () => {
 				mockReadTranscriptsForCommits.mockResolvedValue(transcriptMap);
 
 				const summary = makeSummary();
-				await SummaryWebviewPanel.show(summary, extensionUri, workspaceRoot);
+				await SummaryWebviewPanel.show(
+					summary,
+					extensionUri,
+					workspaceRoot,
+					stubBridge,
+					mainBranch,
+				);
 				const dispatch = captureMessageHandler();
 
 				dispatch({ command: "loadTranscriptStats" });
@@ -6491,7 +6572,13 @@ describe("SummaryWebviewPanel", () => {
 				mockReadTranscriptsForCommits.mockResolvedValue(transcriptMap);
 
 				const summary = makeSummary();
-				await SummaryWebviewPanel.show(summary, extensionUri, workspaceRoot);
+				await SummaryWebviewPanel.show(
+					summary,
+					extensionUri,
+					workspaceRoot,
+					stubBridge,
+					mainBranch,
+				);
 				const dispatch = captureMessageHandler();
 
 				dispatch({ command: "loadTranscriptStats" });
@@ -6536,7 +6623,13 @@ describe("SummaryWebviewPanel", () => {
 				mockReadTranscriptsForCommits.mockResolvedValue(transcriptMap);
 
 				const summary = makeSummary();
-				await SummaryWebviewPanel.show(summary, extensionUri, workspaceRoot);
+				await SummaryWebviewPanel.show(
+					summary,
+					extensionUri,
+					workspaceRoot,
+					stubBridge,
+					mainBranch,
+				);
 				const dispatch = captureMessageHandler();
 
 				dispatch({ command: "loadTranscriptStats" });

--- a/vscode/src/views/SummaryWebviewPanel.ts
+++ b/vscode/src/views/SummaryWebviewPanel.ts
@@ -182,6 +182,11 @@ export type SummaryPanelSource = "memory" | "commit" | "kb";
 const FOREIGN_SAFE_COMMANDS: ReadonlySet<WebviewMessage["command"]> = new Set([
 	"copyMarkdown",
 	"downloadMarkdown",
+	// Read-only PR lookup. The case handler routes the call through
+	// `gh --repo <foreignRepoUrl>` so this never touches the current
+	// workspace's git/GitHub; when foreignRepoUrl is null (local-only
+	// foreign repo) the handler short-circuits with `unavailable`.
+	"checkPrStatus",
 ]);
 
 function isForeignSafeCommand(command: WebviewMessage["command"]): boolean {
@@ -292,6 +297,14 @@ export class SummaryWebviewPanel {
 	 * commands with a clear notification.
 	 */
 	private readonly foreignRepoName: string | null;
+	/**
+	 * Foreign repo's `remote.origin.url` (from the KB folder's
+	 * `.jolli/config.json`). Non-null only when `foreignRepoName` is also
+	 * non-null. Used by the read-only PR section to route `gh pr view`
+	 * through `--repo <url>`, so the displayed PR matches the foreign
+	 * summary rather than the current workspace's repo.
+	 */
+	private readonly foreignRepoUrl: string | null;
 
 	private constructor(
 		extensionUri: vscode.Uri,
@@ -301,6 +314,7 @@ export class SummaryWebviewPanel {
 		bridge: JolliMemoryBridge,
 		mainBranch: string,
 		foreignRepoName: string | null,
+		foreignRepoUrl: string | null,
 	) {
 		this.extensionUri = extensionUri;
 		this.workspaceRoot = workspaceRoot;
@@ -309,6 +323,7 @@ export class SummaryWebviewPanel {
 		this.bridge = bridge;
 		this.mainBranch = mainBranch;
 		this.foreignRepoName = foreignRepoName;
+		this.foreignRepoUrl = foreignRepoUrl;
 		// Distinct viewType per source keeps the two panels independently identified by VSCode.
 		const viewType =
 			source === "memory"
@@ -555,10 +570,17 @@ export class SummaryWebviewPanel {
 				);
 				break;
 			case "checkPrStatus":
+				// Foreign-origin panels route the query to the foreign repo
+				// via `gh --repo <foreignRepoUrl>` so the displayed PR matches
+				// the loaded summary, not the current workspace. When the
+				// foreign repo is local-only (no remoteUrl in its KB config),
+				// pass null and let PrCommentService short-circuit to
+				// `unavailable` rather than silently querying this workspace.
 				handleCheckPrStatus(
 					this.workspaceRoot,
 					(msg) => this.panel.webview.postMessage(msg),
 					this.currentSummary?.branch,
+					this.foreignRepoName ? this.foreignRepoUrl : null,
 				).catch((err: unknown) =>
 					log.error("SummaryPanel", `Check PR status failed: ${err}`),
 				);
@@ -691,6 +713,7 @@ export class SummaryWebviewPanel {
 		mainBranch: string,
 		source: SummaryPanelSource = "commit",
 		foreignRepoName: string | null = null,
+		foreignRepoUrl: string | null = null,
 	): Promise<void> {
 		if (source === "commit" || source === "kb") {
 			const existing = SummaryWebviewPanel.commitPanels.get(summary.commitHash);
@@ -740,6 +763,7 @@ export class SummaryWebviewPanel {
 			bridge,
 			mainBranch,
 			foreignRepoName,
+			foreignRepoUrl,
 		);
 		if (source === "memory") {
 			SummaryWebviewPanel.currentMemoryPanel = instance;
@@ -775,6 +799,7 @@ export class SummaryWebviewPanel {
 			planTranslateSet: this.planTranslateSet,
 			noteTranslateSet: this.noteTranslateSet,
 			nonce,
+			foreignRepoName: this.foreignRepoName,
 		});
 	}
 


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## Quick recap

The Memory Bank now displays only the current tip of each amendment chain rather than the entire history, with a critical recovery path for users affected by version 0.99.2's inverted cleanup bug. The system regenerates all head markdown files from hidden JSON sources before deleting stale children, ensuring no data loss. A new tail cleanup step runs after every queue operation to maintain consistency with the head-only display model, and fingerprint verification was moved into the storage layer itself so all cleanup paths inherit protection against accidental deletion of hand-edited memory files.

Users viewing memories from other repositories now see read-only panels with all destructive action buttons hidden, and the PR status check correctly queries the foreign repository's remote URL instead of the current workspace. The sidebar shifted from a tab-based layout to a breadcrumb header showing the current repository and branch, with dropdown menus for switching between repositories and branches. When users select a foreign repository or branch, the sidebar automatically hides editable sections like Plans and Notes, and the Memories list populates with entries from the selected branch instead of the workspace's HEAD. Memory clicks in foreign-mode browsing now route through the cross-repository lookup path, ensuring consistent behavior across all entry points.

The queue worker now captures the branch at operation enqueue time (inside the git hook) and uses that recorded branch for cleanup, rather than reading the live branch at drain time, which would target the wrong directory if a user checked out a different branch between committing and the worker draining the queue. The migration engine's idempotency gate is written only when both the head-markdown regeneration and stale-child deletion phases complete cleanly, allowing the next VS Code activation to retry the work without user intervention if either phase fails partway through. The Commit Memory button now survives section collapse and remains accessible as a cross-panel action, and the foreign branch memories cache responds to explicit invalidation signals so users see fresh data when they click the toolbar Refresh button.

---

## E2E Test (8)
<details>
<summary><strong>1. Memory display shows only current versions, not historical amendments</strong></summary>
<br>
<blockquote>

**Steps:**
1. Open the Memory Bank sidebar panel in VS Code
2. Navigate to a branch that has memories with amendment history (e.g., a memory you edited multiple times)
3. Look at the list of memories displayed under that branch
4. Verify that you see only one entry per memory (the current version), not multiple entries for each amendment
5. Click on one memory to open its details and confirm it shows the latest content

**Expected Results:**
- The Memory Bank list should display only the tip/current version of each memory chain
- No intermediate or historical versions should appear in the list
- When you open a memory, you see the most recent edits, not an older intermediate state

</blockquote>
</details>
<details>
<summary><strong>2. Cross-repository memories are read-only with hidden edit buttons</strong></summary>
<br>
<blockquote>

**Preconditions:** Have access to memories from another repository (either by opening a memory from a different repo or by having a multi-repo setup)

**Steps:**
1. Open the Memory Bank and navigate to view a memory from a different repository (not your current workspace)
2. Open that memory's detail view
3. Look for action buttons like "Edit", "Delete", "Push to Jolli", and "Create PR"
4. Attempt to click any of these buttons
5. Try to check or uncheck any checkboxes in the memory list

**Expected Results:**
- All write/edit buttons should be hidden or disabled when viewing a foreign repository's memory
- Only read-only buttons like "Copy Markdown", "Save as File", and "Copy Hash" should be visible
- Checkboxes should be disabled or not appear in the memory list
- No destructive action should be possible on foreign memories

</blockquote>
</details>
<details>
<summary><strong>3. PR status displays correctly for memories from other repositories</strong></summary>
<br>
<blockquote>

**Steps:**
1. Open a memory from a different repository that has an associated pull request
2. Scroll to the PR section in the memory details
3. Wait for the PR status to load
4. Verify the PR information displays (title, status, link)

**Expected Results:**
- The PR section should show the correct PR information from the foreign repository
- The status should not be stuck on "loading" or show incorrect PR data from the current workspace
- The PR link should point to the correct repository's PR

</blockquote>
</details>
<details>
<summary><strong>4. Sidebar header shows current repo and branch with dropdown selection</strong></summary>
<br>
<blockquote>

**Steps:**
1. Open the VS Code sidebar with the Memory Bank panel
2. Look at the top of the sidebar (the header area)
3. Verify you see the current repository name and branch name displayed as a breadcrumb (e.g., "my-repo / main")
4. Click on the repository name or branch name to open a dropdown
5. Select a different repository or branch from the dropdown
6. Verify the sidebar updates to show memories from the selected repo/branch

**Expected Results:**
- The sidebar header should display the current repo and branch as a breadcrumb, not as tabs
- Clicking the repo or branch name should open a dropdown list of available options
- Selecting a different repo or branch should update the memory list below
- A chevron icon should appear next to the repo/branch name only when multiple options are available

</blockquote>
</details>
<details>
<summary><strong>5. Memories section shows correct entries when switching to a non-workspace branch</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a multi-branch setup with memories on different branches

**Steps:**
1. Open the sidebar and use the breadcrumb dropdown to select a branch other than your workspace's current branch
2. Wait for the Memories section to load
3. Verify that the list shows memories that belong to the selected branch
4. Switch back to your workspace's main branch using the dropdown
5. Verify the Memories section updates to show the correct memories for that branch

**Expected Results:**
- When you select a non-workspace branch, the Memories list should populate with entries from that branch
- The list should not be empty or show stale data from the previous branch
- Switching branches should refresh the list to show the correct memories for each branch

</blockquote>
</details>
<details>
<summary><strong>6. Sidebar prevents accidental edits when viewing foreign branches</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a multi-repo or multi-branch setup where you can view non-workspace branches

**Steps:**
1. Open the sidebar and use the breadcrumb to select a branch that is not your current workspace branch
2. Look at the Memories section and the Plans/Notes/Changes sections
3. Verify that checkboxes next to memories are hidden or disabled
4. Verify that the Plans and Changes sections are hidden
5. Try to click any action buttons in the Memories section header (like Squash or Push)

**Expected Results:**
- Checkboxes should not appear or should be disabled in the Memories list
- The Plans section should be hidden
- The Changes section should be hidden
- No action buttons should appear in the Memories section header when viewing a foreign branch

</blockquote>
</details>
<details>
<summary><strong>7. Memory files are cleaned up after amend, rebase, or squash operations</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a memory with amendment history on disk

**Steps:**
1. Open a memory and perform an amend operation (edit and save)
2. Wait for the operation to complete
3. Check the file system to verify that old intermediate markdown files have been removed
4. Repeat with a rebase-pick or squash operation
5. Verify that only the current memory file remains on disk, not multiple versions

**Expected Results:**
- After each operation (amend, rebase, squash), old intermediate markdown files should be deleted
- Only the current/latest version of the memory should remain as a visible markdown file
- The hidden metadata (.jolli folder) should remain intact with all history preserved

</blockquote>
</details>
<details>
<summary><strong>8. Migrated users have their current memories restored after upgrade</strong></summary>
<br>
<blockquote>

**Preconditions:** Have completed a knowledge base migration in a previous version

**Steps:**
1. Upgrade to the new version
2. Open the Memory Bank sidebar
3. Verify that all your current active memories are visible and accessible
4. Check that you can open and view each memory without errors
5. Verify that old intermediate versions are not cluttering the memory list

**Expected Results:**
- All current active memories should be restored and visible
- The memory list should show only the latest version of each memory
- No memories should be missing or inaccessible
- The sidebar should load without errors or warnings

</blockquote>
</details>

---

## Topics (11)
<details>
<summary><strong>01 · Head-only memory display with leaf cleanup and migration recovery</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The Memory Bank was displaying entire amendment chains instead of just the current tip of each memory, and a critical bug in version 0.99.2's cleanup pass had deleted the wrong files, causing users to lose their current active commits.

**💡 Decisions Behind the Code**

- **Rename over in-place reversal**: Changing the algorithm while keeping old function names would create a dangerous code smell where future readers assume Git-direction semantics, leading to subtle bugs. Renaming `ChainLeafFilter` → `HeadEntryFilter` and `LeafMarkdownCleanup` → `StaleChildMarkdownCleanup` makes the semantic shift explicit and prevents misinterpretation.
- **Regenerate before cleanup**: Rather than trying to detect which files were wrongly deleted by 0.99.2, the fix regenerates all heads from hidden JSON sources (idempotent: skips if the markdown already exists) before deleting stale children. This approach ensures no data loss and works correctly whether a user upgraded from 0.99.2 or is on a fresh install.
- **Leaf semantics for display only**: VS Code surfaces switched to head-only filtering while CLI surfaces and internal LLM-context pipelines intentionally retained root semantics. This split was documented with inline comments to prevent future confusion and to mark the CLI paths as deferred for a follow-up UX verification pass.
- **Tail step after every operation**: Rather than embedding cleanup logic inside each operation handler, the cleanup runs as a uniform tail step after the switch statement. This keeps operation handlers focused and ensures consistency across all operation types without code duplication.
- **Storage-agnostic design**: The helper checks for the optional `deleteVisibleMarkdown` method at runtime rather than requiring it. This allows the same cleanup logic to work with any storage backend, including those without a visible markdown layer, without forcing implementations to provide stub methods.

**✅ What Was Implemented**

- Replaced the leaf-filter algorithm with a head-entry filter that identifies tips by checking `parentCommitHash == null` under v4 Hoist semantics. Renamed `ChainLeafFilter` to `HeadEntryFilter` and `LeafMarkdownCleanup` to `StaleChildMarkdownCleanup`, inverting the logic to delete markdown files for entries with non-null parents while preserving heads.
- Updated the migration engine to regenerate all head markdown files from hidden JSON sources before cleaning up stale children, ensuring users who ran the inverted 0.99.2 pass have their current active commits restored. Renamed the migration state field from `leafCleanup` to `staleChildCleanup` to force a re-run for anyone who already completed the broken version.
- Modified the memory bridge to apply head-only filtering in the list summary and branch memory methods, collapsing each amendment chain to its tip per branch. Added comprehensive test coverage verifying head-only filtering on single branches, rebase-pick operations preserving independent branch tips, and dangling parents where the root was deleted but the leaf remains.
- Implemented a new v2 migration step that deletes non-leaf visible markdown files from folder storage, running automatically after v1 migration completes. The step is idempotent via completion tracking and includes error handling that logs warnings but does not roll back the migration.
- Modified the queue worker to add a tail cleanup step after every operation handler completes, calling the cleanup function with the current branch and storage. The step logs the result with deleted and failed counts and swallows errors so operation success is not affected by cleanup failures.
- Created `LeafMarkdownCleanup.ts` with two exported functions: `cleanupBranchLeafMarkdown` (scoped to a single branch, called by QueueWorker after amend/rebase/squash operations) and `cleanupAllBranchesLeafMarkdown` (walks every branch in the index, called by MigrationEngine v2 at startup). Both functions read the index, compute leaf commits, and delete non-leaf files via the optional `storage.deleteVisibleMarkdown` method with graceful degradation when the storage backend lacks a visible layer.
- Added `deleteVisibleMarkdown` method to the `StorageProvider` interface and implemented it in `FolderStorage` to locate and remove the visible markdown file using the branch folder, slugified commit message, and 8-character commit hash. The method is idempotent: it silently returns if the file does not exist, and it leaves the branch directory and all hidden metadata intact.
- Added delegation in `DualWriteStorage` to forward the `deleteVisibleMarkdown` call to the folder-side provider. When the folder-side deletion fails, the method logs a warning and calls the provider's `markDirty` method to flag the storage as needing reconciliation, rather than propagating the error.
- Added `regenerateVisibleMarkdown(entry)` method to `StorageProvider` interface and implemented it in `FolderStorage`. The method reads the hidden JSON source, re-emits the visible markdown, and updates the manifest while preserving any existing user-edited title. The method is idempotent: if the markdown already exists on disk, it returns immediately without re-reading or re-writing.
- Modified the extension activate path to invoke leaf cleanup independently when migration state is completed but cleanup has never run. The cleanup is gated by an existing idempotent guard to ensure it runs only once per workspace, even across multiple reloads.
- Added deduplication logic to `listBranchMemories` in the memory bridge to filter out duplicate entries by commit hash before returning the list, mirroring the existing pattern in `listSummaryEntries`.

**📁 FILES**
- `cli/src/core/HeadEntryFilter.ts`
- `cli/src/core/StaleChildMarkdownCleanup.ts`
- `cli/src/core/LeafMarkdownCleanup.ts`
- `vscode/src/JolliMemoryBridge.ts`
- `cli/src/hooks/QueueWorker.ts`

</blockquote>
</details>
<details>
<summary><strong>02 · Fix stale-child cleanup idempotency gate to retry on partial failure</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The migration engine was writing a permanent "completed" marker even when the head-markdown regeneration or stale-child deletion steps failed partway through, causing the recovery process to skip on the next startup and permanently lose the user's recovered files.

**💡 Decisions Behind the Code**

The idempotency gate (`completedAt`) serves as a permanent skip-marker on the next startup. Writing it on partial failure creates an irreversible state where unfinished recovery work is silently abandoned. The fix treats the gate as a "success-only" marker: it is written only when both phases complete cleanly, and omitted on any failure. This allows the next VS Code activation to re-attempt the recovery without user intervention. The alternative — logging a warning and hoping the user notices — would leave the user's recovered files permanently lost with no actionable signal.

**✅ What Was Implemented**

- Modified `MigrationEngine.runStaleChildCleanup()` to only write the `staleChildCleanup.completedAt` timestamp when both the regeneration and cleanup phases finish with zero failures. On partial failure, the gate is omitted, allowing the next invocation to retry the entire sequence.
- Updated `regenerateMissingHeadMarkdown()` to treat a missing or unparseable `index.json` as a failure (incrementing the failed counter) rather than silently returning success-shaped `{0,0,0}`. This ensures the outer gate recognizes corruption and withholds the idempotency stamp.
- Added four new test cases covering the failure paths: regeneration throwing an exception, multi-round self-healing, missing folder index, and corrupt JSON index. Each test verifies that the gate is not written and that a subsequent run retries the work.

**📁 FILES**
- `cli/src/core/MigrationEngine.ts`

</blockquote>
</details>
<details>
<summary><strong>03 · Cross-repository memory viewing with read-only guards and breadcrumb navigation</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

When users opened memories from other repositories in the Memory Bank, the PR section would show incorrect PR information from the current workspace, and users could see and click destructive action buttons when viewing foreign repository memories, creating a risk of silently pushing foreign memories to the current workspace's Jolli Memory space.

**💡 Decisions Behind the Code**

- **Explicit repo parameter over implicit inference**: Rather than attempting to locate the foreign repository's local working tree on disk (which may not exist in a Memory Bank setup), the solution passes the remote URL string directly to `gh pr view --repo <url>`. This avoids schema changes to KBConfig and keeps the implementation localized to the PR query layer, reducing cross-cutting concerns.
- **CSS-based default-deny over per-button guards**: Rather than adding conditional rendering logic to each button individually, a single CSS rule with a whitelist of safe controls ensures that any future write-operation button added to the panel is automatically hidden without requiring code changes. This reduces the surface area for accidental regressions where a new button might be forgotten.
- **Visual hiding over message-layer rejection alone**: Although the webview message dispatcher already rejects destructive commands for foreign summaries, hiding the buttons prevents user confusion and eliminates the "click and get rejected" experience. The message-layer guard remains as a defense-in-depth safeguard.
- **Enforce provenance on all paths**: The codebase had two variants of the cross-repo lookup helper—one that dropped provenance and one that preserved it. Rather than allowing different entry points to use different variants, all paths that can display a summary to the user now use the full-provenance version. This eliminates a class of bugs where one entry point might bypass safety guards that another enforces.
- **Route at webview dispatch layer**: The fix routes at the webview dispatch layer rather than upgrading the host-side `bridge.getSummary` to cross-repo lookup. This preserves the semantic distinction between the two panel slots: the "commit" slot (single-repo, for workspace browsing) and the "memory" slot (cross-repo, for Memory Bank entries). The KB tab already uses the cross-repo path successfully, so reusing that same command and handler avoids duplicating logic and ensures consistent behavior across both entry points.

**✅ What Was Implemented**

- Extended `getSummaryAnyRepoWithSource` in JolliMemoryBridge to return `sourceRemoteUrl` alongside `sourceRepoName`, capturing the foreign repository's remote URL from its KBConfig. Modified `handleCheckPrStatus` in PrCommentService to accept an optional `repoUrl` parameter and skip all local git lookups when querying a foreign repository, pinning `gh pr view` to the supplied remote URL via the `--repo` flag.
- Added `checkPrStatus` to the `FOREIGN_SAFE_COMMANDS` whitelist in SummaryWebviewPanel, allowing the PR status check message to pass through the foreign-origin guard when a valid `sourceRemoteUrl` is available.
- Extended `BuildHtmlOptions` in SummaryHtmlBuilder to accept a `foreignRepoName` parameter and conditionally add the `foreign-readonly` CSS class to the page container when the summary originates from a non-current repository. Added a CSS rule in SummaryCssBuilder that hides all buttons except those marked with `data-foreign-safe` when the `foreign-readonly` class is present. Five read-only controls (Copy Markdown, Save as File, Copy Hash, Toggle buttons) are explicitly marked as safe; all other buttons automatically disappear.
- Updated SummaryWebviewPanel to transparently pass `foreignRepoName` from the constructor through to the HTML builder, ensuring the read-only styling is applied whenever a foreign summary is loaded.
- Replaced calls to `getSummaryAnyRepo` with `getSummaryAnyRepoWithSource` in two entry points: `openMemoryFile` (Memory Bank folder view) and the URI handler for `/summary/<hash>` deep links. Both now destructure the full result including `sourceRepoName` and `sourceRemoteUrl`. Updated all three cross-repo entry points (`viewMemorySummary`, `openMemoryFile`, `uriHandler`) to pass both `sourceRepoName` and `sourceRemoteUrl` as parameters to `SummaryWebviewPanel.show()`, establishing a consistent contract across all paths that can load foreign summaries.
- Modified the webview dispatch layer in SidebarScriptBuilder.ts to detect foreign-mode browsing and route memory clicks through the cross-repository lookup path instead of the single-repository path. When viewing a foreign repo, both the inline "View Memory" button and memory row clicks now dispatch `kb:openMemory` (which calls `viewMemorySummary` with cross-repo lookup) instead of `branch:openCommit` (which calls `viewSummary` with single-repo lookup).

**📁 FILES**
- `vscode/src/JolliMemoryBridge.ts`
- `vscode/src/services/PrCommentService.ts`
- `vscode/src/views/SummaryWebviewPanel.ts`
- `vscode/src/views/SummaryHtmlBuilder.ts`

</blockquote>
</details>
<details>
<summary><strong>04 · Sidebar redesign with breadcrumb header and per-branch memory enumeration</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The sidebar UI needed to shift from a tab-based layout to a breadcrumb-based header showing the current repo and branch, with separate icon buttons for Memory Bank, Settings, and Status panels. When users switched to a non-workspace branch via the breadcrumb dropdown, the Memories section showed no entries because the host was only fetching memories for the workspace's HEAD, not the selected branch.

**💡 Decisions Behind the Code**

- **Preserve existing tab dispatch logic**: The `.tab` class and `data-tab` attributes were kept on the icon buttons even though they are now icon-only, allowing the script's `switchTab` selector and routing to work unchanged. This avoided rewriting the tab state machine and message handlers.
- **Breadcrumb segments as buttons, not static labels**: Making each segment a button (with `aria-haspopup="menu"`) ensures dropdown selection is keyboard-reachable and follows accessibility conventions, rather than requiring JavaScript-only click handling on non-interactive elements.
- **Chevron visibility gated by choice count**: The chevron-down icon is hidden when there is only one repo or one branch, preventing a no-op affordance from appearing. This is controlled by the script after the host pushes `selection:repos` and `selection:branches` messages.
- **Use `MetadataManager.listBranchMappings()` instead of filesystem scan**: The canonical branch registry in `branches.json` is the source of truth, not the on-disk folder structure. This avoids misidentifying empty directories as branches and correctly handles branch names with `/` that get sanitized on disk.
- **Auto-pick first branch when repo changes**: When the user selects a foreign repo, the handler automatically selects the first available branch rather than leaving `selectedBranchName` undefined. This prevents a half-foreign state where the repo differs from workspace but the branch name happens to match, which would confuse `isViewingForeign()`.

**✅ What Was Implemented**

- Replaced the labeled tab bar with a breadcrumb header displaying `<repo> / <branch>` segments on the left and three icon buttons (Memory Bank, Settings, Status) on the right. Each breadcrumb segment includes a chevron-down affordance that appears only when multiple choices are available. Renamed the "Commits" section to "Memories" in the Branch panel. The section key remains `commits` internally for backward compatibility with existing data structures and message handlers.
- Updated CSS to style the new breadcrumb layout, icon buttons, and dropdown menu. The old `.tab` class was preserved on icon buttons so the existing `switchTab` dispatch logic continues to work without modification. Clicking an active icon button now returns to the Branch view (the persistent default), collapsing any open overlay panel.
- Added `.foreign-readonly` CSS rules that hide the Plans and Changes sections and suppress checkbox visibility in the Memories section when the user is viewing a foreign repo or branch. The script applies the `.foreign-readonly` class to the root element via `applyForeignReadonly()` when `isViewingForeign()` returns true. Updated `renderSectionActions('commits')` to return an empty array in foreign mode, preventing Squash and Push icons from appearing in the Memories section header. Updated `renderCommitRow` to skip rendering checkboxes when in foreign mode.
- Added `listRepos()` and `listBranches(repoName)` methods to `KbFoldersService`. `listRepos()` wraps `discoverRepos()` and marks the workspace's own repo with `isCurrentRepo: true`. `listBranches()` reads the canonical branch mappings from `<kbRoot>/.jolli/branches.json` via `MetadataManager`, preserving branch names that contain `/` (e.g., `feature/x`) which would be sanitized on disk.
- Extended `SidebarWebviewProvider` with a `selection` dependency object containing `listRepos`, `listBranches`, and `listBranchMemories`. Added internal state fields `selectedRepoName` and `selectedBranchName`, and methods `pushRepos()` and `pushBranches()` that post the enumeration messages to the webview. On ready, both lists are pushed immediately. Added a `case "selection:request"` handler in `handleOutbound` that receives the user's dropdown selection, updates internal state, and posts back a `selection:set` message. When the user picks a repo, the handler automatically selects the first available branch for that repo to avoid a "foreign repo + workspace branch" semantic mismatch.
- Added `listBranchMemories(repoName, branchName)` to `JolliMemoryBridge`. This method bypasses the `parentCommitHash != null` filter that `listSummaryEntries()` applies, returning all entries (including amend/rebase children) for a specific branch. It resolves the correct storage based on whether the repo is the workspace's own or a foreign one, mirroring the logic in `listSummaryEntries()`.
- Extended `SidebarWebviewProvider` with `listBranchMemories` in the `selection` dependency and a handler for the `selection:branchMemories` inbound message. The webview caches results in `branchMemoriesCache` keyed by `<repoName>::<branchName>` and triggers a fetch when the user selects a foreign branch. Updated `getForeignCommitItems()` in the script to read from `branchMemoriesCache` and adapt `SummaryIndexEntry` objects to the shape expected by `renderCommitRow()`, preserving commit hash, title, branch, repo name, and timestamp.
- Added `currentRepoName: sidebarRepoName` to the initial state object in `Extension.ts` `getInitialState()`. The `sidebarRepoName` value was already being computed and passed to `kbFoldersService`; it now also feeds the webview's init state.

**📁 FILES**
- `vscode/src/views/SidebarHtmlBuilder.ts`
- `vscode/src/views/SidebarWebviewProvider.ts`
- `vscode/src/services/KbFoldersService.ts`
- `vscode/src/JolliMemoryBridge.ts`

</blockquote>
</details>
<details>
<summary><strong>05 · Protect hand-edited memory files from deletion during cleanup</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The new head-only memory display feature introduced a cleanup path that unconditionally deletes older memory markdown files, bypassing the fingerprint protection that existed in the write-time cleanup path. Users who manually edited stale memory files would silently lose those edits.

**💡 Decisions Behind the Code**

Pushing the fingerprint check down to the storage boundary ensures that all deletion paths inherit the protection automatically, rather than requiring each caller to remember to check. This is safer than leaving the responsibility distributed across multiple call sites. The protection mirrors what the write-time cleanup path already does, so this change unifies the safety model across all cleanup flows.

**✅ What Was Implemented**

- Moved fingerprint verification into `FolderStorage.deleteVisibleMarkdown` itself so all callers (QueueWorker tail cleanup, MigrationEngine, and any future cleanup paths) inherit the protection. The method now checks whether the on-disk file's SHA matches the manifest fingerprint before deletion; if the fingerprint is missing or mismatched, the file is skipped with a warning.
- Added manifest entry cleanup alongside file deletion so that successfully deleted files do not leave ghost entries that future scans would re-trip on.
- Added two regression tests in FolderStorage.test.ts covering hand-edited file preservation and manifest cleanup on successful deletion.

**📁 FILES**
- `cli/src/core/FolderStorage.ts`

</blockquote>
</details>
<details>
<summary><strong>06 · Record branch at operation enqueue time for correct tail cleanup</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The queue worker's tail cleanup step reads the current branch from the filesystem when draining the queue, but if a user commits on one branch and then checks out a different branch before the worker runs, cleanup targets the wrong branch directory and leaves stale memory files behind on the original branch.

**💡 Decisions Behind the Code**

- **Record at enqueue time, not drain time**: The branch must be captured inside the git hook when the operation is created, not when the worker drains the queue. Reading the live branch at drain time is precisely the bug being fixed, so falling back to that behavior would reintroduce the problem. Recording the branch in the operation itself makes the intent explicit and prevents future developers from accidentally reverting to live-branch lookup.
- **Skip cleanup rather than fallback for missing branch**: For queue entries written by older code that lack the branch field, the conservative choice is to skip cleanup entirely rather than fall back to `getCurrentBranch`. Falling back would silently repeat the original bug. Skipping with a warning is safer and makes the limitation visible in logs.

**✅ What Was Implemented**

- Added an optional `branch` field to the `GitOperation` type in Types.ts, captured at enqueue time by each git hook (PostCommitHook and PostRewriteHook) so the branch is recorded before the user can change it.
- Updated PostCommitHook.ts to capture the current branch using `execFileSync` (matching the safety pattern already used elsewhere in the codebase) and include it in the queued operation.
- Updated PostRewriteHook.ts to capture the branch once at hook entry and pass it to both the amend and rebase subhandlers.
- Modified QueueWorker.ts to use `op.branch` for cleanup instead of reading the live branch; when the field is missing (for pre-0.99.x queue entries), cleanup is skipped with a warning rather than falling back to the live branch, which would repeat the bug.
- Added two regression tests in QueueWorker.test.ts verifying that cleanup uses the recorded branch and that missing branch fields cause cleanup to be skipped.

**📁 FILES**
- `cli/src/Types.ts`
- `cli/src/hooks/PostCommitHook.ts`
- `cli/src/hooks/PostRewriteHook.ts`
- `cli/src/hooks/QueueWorker.ts`

</blockquote>
</details>
<details>
<summary><strong>07 · Per-repository per-branch leaf detection with cycle handling</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The codebase needed a centralized, scoped mechanism to identify which commit entries are tips of their respective branch chains, accounting for cross-branch parent links and multi-repository scenarios where same-named branches should remain independent.

**💡 Decisions Behind the Code**

- **Scope isolation by (repoName, branch) tuple**: Ensures that rebase-pick operations do not incorrectly mark the branch-X commit as non-leaf, and same-named branches in different repositories remain independent. This design preserves the semantic meaning of "leaf" as the tip of a chain within its own branch context rather than globally across all entries.
- **Silent cycle collapse over exception throwing**: Cycles silently collapse to zero leaves rather than throwing an exception, treating malformed or corrupted index data as a recoverable state that hides itself in the output rather than crashing the renderer.
- **Legacy v1 backward compatibility**: Entries with `undefined` parent hashes are treated as roots, maintaining backward compatibility while still allowing them to be identified as leaves if no descendant points to them in scope.

**✅ What Was Implemented**

- Created `ChainLeafFilter.ts` with two exported functions: `getBranchLeaves()` computes the set of commit hashes that are leaves within their `(repoName, branch)` scope, and `filterToBranchLeaves()` filters an entry list to only those whose hash is a leaf, preserving input order.
- The implementation uses a scope key combining repo name and branch to isolate parent-child relationships, ensuring cross-branch rebase-picks and cross-repo links do not incorrectly demote entries on their original branch.
- Added comprehensive test suite covering empty input, single entries, linear chains, parallel chains on the same branch, cross-branch parent links, cross-repo isolation, legacy v1 entries with undefined parent hashes, dangling parent pointers, and cycle detection (two entries parenting each other collapse to zero leaves). Added a 3-cycle detection test to verify the filter correctly collapses longer cycles to an empty leaf set.

**📁 FILES**
- `cli/src/core/ChainLeafFilter.ts`

</blockquote>
</details>
<details>
<summary><strong>08 · Add cache invalidation for foreign branch memories on toolbar refresh</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

When a user switched to a foreign repository and branch in the sidebar, then clicked the toolbar Refresh button, the memories panel remained frozen on whatever data was loaded during the initial selection. The session-sticky cache had no mechanism to drop stale entries when the user explicitly requested a refresh.

**💡 Decisions Behind the Code**

The cache is session-sticky by design: once populated for a (repo, branch) key, it persists until the session ends, avoiding redundant fetches during normal navigation. However, this design breaks when the user explicitly requests a refresh — they expect to see fresh data, not the cached snapshot. Rather than making every tab switch or selection change trigger a refetch (which would defeat the cache), the invalidation is tied to the explicit user action (toolbar Refresh). The fallback key expression must match exactly across the trigger site, response-match check, and render lookup to avoid the cache-key consistency bug documented in the review. Using the same expression in the invalidation handler ensures that refresh refetches the correct key.

**✅ What Was Implemented**

- Added a new `selection:invalidateBranchMemories` inbound message type to signal the webview to drop all cached branch memories and re-trigger the lazy fetch for the currently-active foreign selection.
- Modified `SidebarWebviewProvider.handleRefresh()` to post this invalidation message whenever the refresh scope includes `branch` or `all`, ensuring that foreign-readonly views see fresh data on user demand.
- Updated the webview script to clear both the `branchMemoriesCache` and `branchMemoriesPending` maps on receiving the invalidation, then re-fire the `selection:requestBranchMemories` request using the same fallback key expression (`selectedRepoName || currentRepoName` and `selectedBranchName || branchName`) that the initial selection uses.

**📁 FILES**
- `vscode/src/views/SidebarWebviewProvider.ts`
- `vscode/src/views/SidebarScriptBuilder.ts`

</blockquote>
</details>
<details>
<summary><strong>09 · Move Commit Memory button outside Changes section body to survive collapse</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

When a user collapsed the Changes section in the sidebar, the Commit Memory button (a group action spanning Plans, Changes, and Commits) was also hidden, making the cross-panel action unreachable without expanding the section again.

**💡 Decisions Behind the Code**

The Commit Memory button is a group action that operates across three panels (Plans, Changes, Commits), not a Changes-specific action. Hiding it when the user collapses Changes makes the cross-panel affordance unreachable and breaks the mental model that collapsing a section only hides that section's content, not actions that span multiple sections. Mounting the button as a sibling of the body (rather than a child) ensures it survives the `display: none` rule applied to collapsed bodies. The button remains implicitly hidden in foreign-readonly mode because the entire Changes section is dropped above the predicate, so no additional guard is needed.

**✅ What Was Implemented**

- Refactored the Changes section rendering in `SidebarScriptBuilder.ts` to construct the section's child elements as an array (`sectionKids`) that includes both the header and body, then conditionally appends the Commit Memory button as a sibling of the body rather than a child of it.
- Updated the CSS selector logic so the button is rendered whenever `s.id === 'changes'`, without gating on the `collapsed` state or the presence of items in the body.
- Added regression tests to verify that the button is pushed without gating on `collapsed` or `items.length`, and that the old buggy predicates do not reappear.

**📁 FILES**
- `vscode/src/views/SidebarScriptBuilder.ts`

</blockquote>
</details>
<details>
<summary><strong>10 · Correct head-vs-leaf naming and semantics in context compiler comments</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The context compiler contained contradictory comments about whether the v4 Hoist heads (entries with `parentCommitHash == null`) represent "chronological original commits" or "live post-amend tips". This mismatch with the authoritative HeadEntryFilter documentation created confusion for future maintainers and risked introducing bugs during refactoring.

**💡 Decisions Behind the Code**

Inline filter expressions are fragile: they can diverge from the authoritative HeadEntryFilter logic if either is updated independently. Using the named function `filterToBranchHeads()` as the single call site makes the invariant explicit and centralizes the definition. The comment rewrites prioritize the actual semantics (live tips, post-amend) over the historical narrative, because the code's behavior is determined by what `parentCommitHash == null` means in the v4 Hoist model, not by what the original commit message said. Removing the contradictory claim about CLI surfaces eliminates a source of confusion for future readers and aligns the documentation with the actual implementation.

**✅ What Was Implemented**

- Rewrote comments in `listBranchCatalog()` and `compileTaskContext()` to correctly describe heads as "live tips of commit history" and "what `git log` currently shows", not as historical originals. Clarified that superseded versions live as children and are excluded to avoid feeding the LLM multiple variants of the same logical commit.
- Replaced inline `filter((e) => e.parentCommitHash === null)` expressions with calls to `filterToBranchHeads()`, making the v4 Hoist invariant explicit and eliminating the risk of the filter logic drifting from its single source of truth.
- Removed the claim that "Display paths (Timeline, jolli search/view, sidebar) switched to leaf-only" from the context compiler, as this statement contradicted the ViewCommand and LocalSearchProvider comments which correctly noted that CLI surfaces remain intentionally root-only.

**📁 FILES**
- `cli/src/core/ContextCompiler.ts`

</blockquote>
</details>
<details>
<summary><strong>11 · Improve error diagnostics for foreign repository memory loading failures</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

When a foreign repository's memory index failed to load, the warning message was generic and did not distinguish between workspace orphan-branch failures and cross-repo FolderStorage failures, making it difficult for users to diagnose whether the problem was a git issue or a file-system issue.

**💡 Decisions Behind the Code**

The warning is the only signal users receive when index loading fails, because callers treat null as "nothing to return" rather than throwing. Adding the storage class name is a low-cost observability improvement that helps route the diagnosis: if the tag says `FolderStorage`, the user knows to check file permissions or the Memory Bank path; if it says `OrphanBranchStorage`, the user knows to check git. This change does not alter the recovery logic, only the diagnostic signal.

**✅ What Was Implemented**

- Modified `SummaryStore.loadIndex()` to include the storage backend class name in the warning message, allowing users and developers to see whether the failure came from `OrphanBranchStorage` (workspace git plumbing) or `FolderStorage` (cross-repo file system).
- Updated the warning text to clarify that the message covers both fresh-repo scenarios (no summaries yet) and actual backend failures, and to note that the storage class tag helps distinguish cross-repo foreign reads from workspace orphan-branch issues.

**📁 FILES**
- `cli/src/core/SummaryStore.ts`

</blockquote>
</details>

---

*Generated by Jolli Memory · May 13, 2026 at 1:30 AM · via Anthropic*
<!-- jollimemory-summary-end -->