### PR TITLE
Replace gh pr view with gh pr list for multi-PR-per-branch support

### DIFF
--- a/vscode/src/services/PrCommentService.test.ts
+++ b/vscode/src/services/PrCommentService.test.ts
@@ -164,6 +164,74 @@ function setupTmpFile() {
 	unlinkMock.mockResolvedValue(undefined);
 }
 
+/**
+ * Builds a `gh pr list --json …` stdout for a single PR.
+ *
+ * `gh pr list` returns an array; we wrap the input so callers can stay terse
+ * (`prJson({ number: 7 })`). State / isCrossRepository default to "OPEN" /
+ * `false` so the bulk of existing fixtures keep their semantics — they meant
+ * "an editable PR exists for this branch".
+ */
+function prJson(pr: {
+	number: number;
+	url?: string;
+	title?: string;
+	body?: string;
+	state?: "OPEN" | "CLOSED" | "MERGED";
+	isCrossRepository?: boolean;
+}): string {
+	return JSON.stringify([
+		{
+			url: "",
+			title: "",
+			body: "",
+			state: "OPEN" as const,
+			isCrossRepository: false,
+			...pr,
+		},
+	]);
+}
+
+/** Empty `gh pr list` response — drives the noPr branch in findPrForBranch. */
+const PR_LIST_EMPTY = "[]";
+
+/**
+ * Routes `gh pr list` by its `--state` argument so a single test can program
+ * both queries that `findPrForBranch` may make (first `--state open`, then
+ * `--state all` as fallback). git/auth/version probes are stubbed to success.
+ */
+function setupListByState(opts: {
+	currentBranch?: string;
+	open: string;
+	all: string;
+}): void {
+	setupExecFile((cmd, args) => {
+		if (cmd === "git" && args[0] === "rev-parse") {
+			return { stdout: `${opts.currentBranch ?? "feature/br"}\n` };
+		}
+		if (cmd === "gh" && args[0] === "--version") return { stdout: "gh 2.40\n" };
+		if (cmd === "gh" && args[0] === "auth") return { stdout: "ok\n" };
+		if (cmd === "gh" && args[0] === "pr" && args[1] === "list") {
+			const stateIdx = args.indexOf("--state");
+			const state = stateIdx >= 0 ? args[stateIdx + 1] : "";
+			return { stdout: state === "open" ? opts.open : opts.all };
+		}
+		return { stdout: "" };
+	});
+}
+
+/** Counts how many `gh pr list` calls reached the mock — used to assert that
+ * the open-hit happy path skips the second `--state all` query. */
+function countPrListCalls(): number {
+	return mockExecFileAsync.mock.calls.filter(
+		(call: Array<unknown>) =>
+			call[0] === "gh" &&
+			Array.isArray(call[1]) &&
+			(call[1] as Array<string>)[0] === "pr" &&
+			(call[1] as Array<string>)[1] === "list",
+	).length;
+}
+
 const CWD = "/fake/repo";
 const MARKER_START = "<!-- jollimemory-summary-start -->";
 const MARKER_END = "<!-- jollimemory-summary-end -->";
@@ -292,7 +360,7 @@ describe("PrCommentService", () => {
 						title: "Multi-commit PR",
 						body: "",
 					};
-					return { stdout: JSON.stringify(prData) };
+					return { stdout: prJson(prData) };
 				}
 				return { stdout: "" };
 			});
@@ -396,10 +464,7 @@ describe("PrCommentService", () => {
 					return { stdout: "Logged in\n" };
 				}
 				if (cmd === "gh" && args[0] === "pr") {
-					throw ghError({
-						message: "gh exit 1",
-						stderr: "no pull requests found",
-					});
+					return { stdout: PR_LIST_EMPTY };
 				}
 				return { stdout: "" };
 			});
@@ -440,10 +505,7 @@ describe("PrCommentService", () => {
 				}
 				if (cmd === "gh" && args[0] === "auth") return { stdout: "ok\n" };
 				if (cmd === "gh" && args[0] === "pr") {
-					throw ghError({
-						message: "gh exit 1",
-						stderr: "no pull requests found",
-					});
+					return { stdout: PR_LIST_EMPTY };
 				}
 				return { stdout: "" };
 			});
@@ -570,10 +632,7 @@ describe("PrCommentService", () => {
 					return { stdout: "Logged in\n" };
 				}
 				if (cmd === "gh" && args[0] === "pr") {
-					throw ghError({
-						message: "gh exit 1",
-						stderr: "no pull requests found",
-					});
+					return { stdout: PR_LIST_EMPTY };
 				}
 				return { stdout: "" };
 			});
@@ -609,7 +668,7 @@ describe("PrCommentService", () => {
 					return { stdout: "Logged in\n" };
 				}
 				if (cmd === "gh" && args[0] === "pr") {
-					return { stdout: JSON.stringify(prData) };
+					return { stdout: prJson(prData) };
 				}
 				return { stdout: "" };
 			});
@@ -683,7 +742,7 @@ describe("PrCommentService", () => {
 				}
 				if (cmd === "gh" && args[0] === "pr") {
 					return {
-						stdout: JSON.stringify({ number: 0, url: "", title: "", body: "" }),
+						stdout: prJson({ number: 0, url: "", title: "", body: "" }),
 					};
 				}
 				return { stdout: "" };
@@ -809,7 +868,7 @@ describe("PrCommentService", () => {
 
 		it("does not emit warn/debug on the happy path (baseline)", async () => {
 			setupHappyProbesWithPrHandler(() => ({
-				stdout: JSON.stringify({
+				stdout: prJson({
 					number: 7,
 					url: "https://pr/7",
 					title: "t",
@@ -823,34 +882,27 @@ describe("PrCommentService", () => {
 			expect(debug).not.toHaveBeenCalled();
 		});
 
-		it("logs at debug when gh pr view stderr indicates 'no pull requests found'", async () => {
-			setupHappyProbesWithPrHandler(() => {
-				throw ghError({
-					message: "gh: exit 1",
-					code: 1,
-					stderr: "no pull requests found for branch feature/br\n",
-				});
-			});
+		it("posts noPr with branch name when gh pr list returns an empty array (no PR exists)", async () => {
+			// `gh pr list` never errors when no PR matches — it returns `[]`.
+			// The Task-1 noPr arm therefore replaces the old "stderr says no
+			// pull requests found" path: empty stdout array, no warn, no debug.
+			setupHappyProbesWithPrHandler(() => ({ stdout: PR_LIST_EMPTY }));
 
 			await handleCheckPrStatus(CWD, postMessage);
 
-			expect(debug).toHaveBeenCalledWith(
-				expect.any(String),
-				expect.stringContaining("No PR for branch feature/br"),
-			);
 			expect(warn).not.toHaveBeenCalled();
-			// UI folding unchanged — see plan non-goal
+			expect(debug).not.toHaveBeenCalled();
 			expect(postMessage).toHaveBeenCalledWith(
 				expect.objectContaining({ status: "noPr", branch: "feature/br" }),
 			);
 		});
 
-		it("posts unavailable (NOT noPr) when gh pr view fails with a non-expected stderr (e.g. auth/ratelimit)", async () => {
+		it("posts unavailable (NOT noPr) when gh pr list fails with a non-expected stderr (e.g. auth/ratelimit)", async () => {
 			// I-1 contract change: auth lapses, rate limits, and other gh
-			// non-zero exits that don't say "no pull requests found" used to
-			// be folded into noPr — leading the user to click Create PR and
-			// either fail or duplicate. Now they surface as `unavailable`
-			// with the real stderr in `reason`, and the UI shows Retry.
+			// non-zero exits used to be folded into noPr — leading the user
+			// to click Create PR and either fail or duplicate. Now they
+			// surface as `unavailable` with the real stderr in `reason`, and
+			// the UI shows Retry.
 			setupHappyProbesWithPrHandler(() => {
 				throw ghError({
 					message: "gh: exit 1",
@@ -864,7 +916,7 @@ describe("PrCommentService", () => {
 			expect(warn).toHaveBeenCalledWith(
 				expect.any(String),
 				expect.stringMatching(
-					/gh pr view failed for branch feature\/br.*code=1.*stderr:.*authentication required/s,
+					/gh pr list --state open failed for branch feature\/br.*code=1.*stderr:.*authentication required/s,
 				),
 			);
 			expect(debug).not.toHaveBeenCalled();
@@ -935,15 +987,12 @@ describe("PrCommentService", () => {
 				if (cmd === "gh" && args[0] === "auth") {
 					return { stdout: "ok\n" };
 				}
-				if (cmd === "gh" && args[0] === "pr" && args[1] === "view") {
-					const sepIdx = args.indexOf("--");
+				if (cmd === "gh" && args[0] === "pr" && args[1] === "list") {
+					const sepIdx = args.indexOf("--head");
 					if (sepIdx >= 0) {
 						prListHeadArg = args[sepIdx + 1];
 					}
-					throw ghError({
-						message: "gh exit 1",
-						stderr: "no pull requests found",
-					});
+					return { stdout: PR_LIST_EMPTY };
 				}
 				return { stdout: "" };
 			});
@@ -978,16 +1027,13 @@ describe("PrCommentService", () => {
 				if (cmd === "gh" && args[0] === "auth") {
 					return { stdout: "ok\n" };
 				}
-				if (cmd === "gh" && args[0] === "pr" && args[1] === "view") {
-					const sepIdx = args.indexOf("--");
+				if (cmd === "gh" && args[0] === "pr" && args[1] === "list") {
+					const sepIdx = args.indexOf("--head");
 					if (sepIdx >= 0) {
 						prViewBranchArg = args[sepIdx + 1];
 					}
 					// gh returns "no PR" for the stale name.
-					throw ghError({
-						message: "gh exit 1",
-						stderr: "no pull requests found",
-					});
+					return { stdout: PR_LIST_EMPTY };
 				}
 				return { stdout: "" };
 			});
@@ -1018,15 +1064,12 @@ describe("PrCommentService", () => {
 				if (cmd === "gh" && args[0] === "auth") {
 					return { stdout: "ok\n" };
 				}
-				if (cmd === "gh" && args[0] === "pr" && args[1] === "view") {
-					const sepIdx = args.indexOf("--");
+				if (cmd === "gh" && args[0] === "pr" && args[1] === "list") {
+					const sepIdx = args.indexOf("--head");
 					if (sepIdx >= 0) {
 						prListHeadArg = args[sepIdx + 1];
 					}
-					throw ghError({
-						message: "gh exit 1",
-						stderr: "no pull requests found",
-					});
+					return { stdout: PR_LIST_EMPTY };
 				}
 				return { stdout: "" };
 			});
@@ -1034,6 +1077,221 @@ describe("PrCommentService", () => {
 			await handleCheckPrStatus(CWD, postMessage);
 
 			expect(prListHeadArg).toBe("feature/current");
+		});
+
+		// ── state dispatch + previousPr + cross-repo + future state ──────────
+		//
+		// These pin the Task-1/Task-2 contract: findPrForBranch must prefer
+		// OPEN over historic state, must skip cross-repository PRs and unknown
+		// states, and the dispatch must hand the right shape to the webview.
+
+		it("posts ready (no previousPr) when --state open hits an OPEN PR and skips the --state all call", async () => {
+			setupListByState({
+				currentBranch: "feature/br",
+				open: prJson({
+					number: 7,
+					url: "https://pr/7",
+					title: "Open PR",
+					state: "OPEN",
+				}),
+				all: prJson({ number: 999, state: "MERGED" }), // never reached
+			});
+
+			await handleCheckPrStatus(CWD, postMessage);
+
+			expect(postMessage).toHaveBeenCalledWith({
+				command: "prStatus",
+				status: "ready",
+				pr: { number: 7, url: "https://pr/7", title: "Open PR" },
+			});
+			// Confirm no `previousPr` leaked into the ready payload.
+			const readyCall = postMessage.mock.calls.find(
+				(c) => (c[0] as { status?: string }).status === "ready",
+			);
+			expect(readyCall?.[0]).not.toHaveProperty("previousPr");
+			// And the historic-state fallback query never ran.
+			expect(countPrListCalls()).toBe(1);
+		});
+
+		it("posts noPr + previousPr.state=MERGED when --state open is empty and --state all returns a MERGED PR", async () => {
+			setupListByState({
+				currentBranch: "feature/br",
+				open: PR_LIST_EMPTY,
+				all: prJson({
+					number: 42,
+					url: "https://pr/42",
+					title: "Merged",
+					state: "MERGED",
+				}),
+			});
+
+			await handleCheckPrStatus(CWD, postMessage);
+
+			expect(postMessage).toHaveBeenCalledWith({
+				command: "prStatus",
+				status: "noPr",
+				branch: "feature/br",
+				previousPr: {
+					number: 42,
+					url: "https://pr/42",
+					state: "MERGED",
+				},
+			});
+			// Both queries fired — open (empty) then all (hit).
+			expect(countPrListCalls()).toBe(2);
+		});
+
+		it("posts noPr + previousPr.state=CLOSED when --state open is empty and --state all returns a CLOSED PR", async () => {
+			setupListByState({
+				currentBranch: "feature/br",
+				open: PR_LIST_EMPTY,
+				all: prJson({
+					number: 11,
+					url: "https://pr/11",
+					title: "Closed",
+					state: "CLOSED",
+				}),
+			});
+
+			await handleCheckPrStatus(CWD, postMessage);
+
+			expect(postMessage).toHaveBeenCalledWith({
+				command: "prStatus",
+				status: "noPr",
+				branch: "feature/br",
+				previousPr: {
+					number: 11,
+					url: "https://pr/11",
+					state: "CLOSED",
+				},
+			});
+		});
+
+		it("treats an unrecognised PR state as noPr and warns about it (defense-in-depth)", async () => {
+			// Future-proofing: if GitHub adds a fourth state value (e.g.
+			// "FROZEN" or "ARCHIVED"), don't render a confident UI — degrade
+			// to noPr with a warn log so the user can still Create PR.
+			setupListByState({
+				currentBranch: "feature/br",
+				open: prJson({ number: 5, state: "FROZEN" as never }),
+				all: PR_LIST_EMPTY,
+			});
+
+			await handleCheckPrStatus(CWD, postMessage);
+
+			expect(warn).toHaveBeenCalledWith(
+				expect.any(String),
+				expect.stringContaining('unexpected state "FROZEN"'),
+			);
+			expect(postMessage).toHaveBeenCalledWith(
+				expect.objectContaining({ status: "noPr", branch: "feature/br" }),
+			);
+			expect(postMessage).not.toHaveBeenCalledWith(
+				expect.objectContaining({ status: "ready" }),
+			);
+		});
+
+		it("treats a cross-repository (fork) PR as noPr — falls back through both queries", async () => {
+			// `gh pr list --head <branch>` matches fork heads of the same name
+			// because the manual doesn't accept `<owner>:<branch>`. Filtering
+			// `isCrossRepository === true` keeps Edit PR from binding to a
+			// stranger's PR; the safe degradation is "show Create PR".
+			setupListByState({
+				currentBranch: "feature/br",
+				open: prJson({
+					number: 100,
+					state: "OPEN",
+					isCrossRepository: true,
+				}),
+				all: prJson({
+					number: 101,
+					state: "MERGED",
+					isCrossRepository: true,
+				}),
+			});
+
+			await handleCheckPrStatus(CWD, postMessage);
+
+			expect(debug).toHaveBeenCalledWith(
+				expect.any(String),
+				expect.stringContaining(
+					"Ignoring cross-repository PR #100 for branch feature/br",
+				),
+			);
+			expect(postMessage).toHaveBeenCalledWith(
+				expect.objectContaining({ status: "noPr", branch: "feature/br" }),
+			);
+			expect(postMessage).not.toHaveBeenCalledWith(
+				expect.objectContaining({ previousPr: expect.anything() }),
+			);
+		});
+
+		it("tryExecGh wraps non-Error rejections into Error so lookupError still carries a reason", async () => {
+			// Defensive coverage for the `e instanceof Error ? e : new Error(String(e))`
+			// branch in tryExecGh — exercised when gh rejects with a non-Error value
+			// (very rare but possible if a future Node child_process runtime tweak
+			// skips the Error wrap). The reason field must still contain the
+			// stringified rejection so the webview shows it instead of a blank pane.
+			setupExecFile((cmd, args) => {
+				if (cmd === "git" && args[0] === "rev-parse")
+					return { stdout: "feature/br\n" };
+				if (cmd === "gh" && args[0] === "--version")
+					return { stdout: "gh 2.40\n" };
+				if (cmd === "gh" && args[0] === "auth") return { stdout: "ok\n" };
+				if (cmd === "gh" && args[0] === "pr" && args[1] === "list") {
+					throw "raw string rejection";
+				}
+				return { stdout: "" };
+			});
+
+			await handleCheckPrStatus(CWD, postMessage);
+
+			expect(postMessage).toHaveBeenCalledWith(
+				expect.objectContaining({
+					status: "unavailable",
+					reason: expect.stringContaining("raw string rejection"),
+				}),
+			);
+		});
+
+		it("does NOT issue a second --state all call when --state open errors (avoid duplicate failure)", async () => {
+			// Reflects the Task-1 decision: an error on the first query bubbles
+			// to lookupError immediately so the user gets one accurate reason,
+			// rather than two warn logs and a misleading "no PR" fallback.
+			let openCalled = false;
+			setupExecFile((cmd, args) => {
+				if (cmd === "git" && args[0] === "rev-parse")
+					return { stdout: "feature/br\n" };
+				if (cmd === "gh" && args[0] === "--version")
+					return { stdout: "gh 2.40\n" };
+				if (cmd === "gh" && args[0] === "auth") return { stdout: "ok\n" };
+				if (cmd === "gh" && args[0] === "pr" && args[1] === "list") {
+					const stateIdx = args.indexOf("--state");
+					const state = stateIdx >= 0 ? args[stateIdx + 1] : "";
+					if (state === "open") {
+						openCalled = true;
+						throw ghError({
+							message: "gh: exit 1",
+							code: 1,
+							stderr: "network down",
+						});
+					}
+					// If we ever fall through here, the test fails the assertion below.
+					return { stdout: PR_LIST_EMPTY };
+				}
+				return { stdout: "" };
+			});
+
+			await handleCheckPrStatus(CWD, postMessage);
+
+			expect(openCalled).toBe(true);
+			expect(countPrListCalls()).toBe(1);
+			expect(postMessage).toHaveBeenCalledWith(
+				expect.objectContaining({
+					status: "unavailable",
+					reason: expect.stringContaining("network down"),
+				}),
+			);
 		});
 	});
 
@@ -1059,8 +1317,8 @@ describe("PrCommentService", () => {
 					"git:rev-parse": () => ({ stdout: "feature/branch\n" }),
 					"gh:--version": () => ({ stdout: "gh 2.40.0\n" }),
 					"gh:auth": () => ({ stdout: "ok\n" }),
-					"gh:pr:view": () => ({
-						stdout: JSON.stringify({
+					"gh:pr:list": () => ({
+						stdout: prJson({
 							number: 77,
 							url: prUrl,
 							title: "Rebased PR",
@@ -1101,8 +1359,8 @@ describe("PrCommentService", () => {
 					"git:rev-parse": () => ({ stdout: "feature/branch\n" }),
 					"gh:--version": () => ({ stdout: "gh 2.40.0\n" }),
 					"gh:auth": () => ({ stdout: "ok\n" }),
-					"gh:pr:view": () => ({
-						stdout: JSON.stringify({
+					"gh:pr:list": () => ({
+						stdout: prJson({
 							number: 99,
 							url: prUrl,
 							title: "New PR",
@@ -1174,8 +1432,8 @@ describe("PrCommentService", () => {
 					"git:rev-parse": () => ({ stdout: "branch\n" }),
 					"gh:--version": () => ({ stdout: "ok\n" }),
 					"gh:auth": () => ({ stdout: "ok\n" }),
-					"gh:pr:view": () => ({
-						stdout: JSON.stringify({
+					"gh:pr:list": () => ({
+						stdout: prJson({
 							number: 55,
 							url: prUrl,
 							title: "T",
@@ -1255,8 +1513,8 @@ describe("PrCommentService", () => {
 					"git:rev-list": () => ({ stdout: "1\n" }),
 					"gh:--version": () => ({ stdout: "gh 2.40.0\n" }),
 					"gh:auth": () => ({ stdout: "ok\n" }),
-					"gh:pr:view": () => ({
-						stdout: JSON.stringify({
+					"gh:pr:list": () => ({
+						stdout: prJson({
 							number: 123,
 							url: prUrl,
 							title: "OK",
@@ -1275,6 +1533,84 @@ describe("PrCommentService", () => {
 				expect.objectContaining({ command: "prCreateBlockedCrossBranch" }),
 			);
 		});
+
+		it("refresh after successful Create PR flips section from MERGED+previousPr to ready (Task 6 regression)", async () => {
+			// Two-phase scenario across one `mockExecFileAsync.mockImplementation`:
+			//   Phase A (before pr create): --state open returns []; --state all
+			//                                returns a historic MERGED PR — the
+			//                                webview should see noPr + previousPr.
+			//   Phase B (after pr create):  --state open returns the new OPEN PR;
+			//                                the post-create refresh should
+			//                                surface it as ready without `previousPr`.
+			let phase: "before" | "after" = "before";
+			setupExecFile((cmd, args) => {
+				if (cmd === "git" && args[0] === "rev-parse")
+					return { stdout: "feature/br\n" };
+				if (cmd === "git" && args[0] === "push") return { stdout: "" };
+				if (cmd === "gh" && args[0] === "--version")
+					return { stdout: "gh 2.40\n" };
+				if (cmd === "gh" && args[0] === "auth") return { stdout: "ok\n" };
+				if (cmd === "gh" && args[0] === "pr" && args[1] === "create") {
+					phase = "after";
+					return { stdout: "https://pr/200\n" };
+				}
+				if (cmd === "gh" && args[0] === "pr" && args[1] === "list") {
+					const stateIdx = args.indexOf("--state");
+					const state = stateIdx >= 0 ? args[stateIdx + 1] : "";
+					if (phase === "before") {
+						if (state === "open") return { stdout: PR_LIST_EMPTY };
+						return {
+							stdout: prJson({
+								number: 100,
+								url: "https://pr/100",
+								title: "Old merged",
+								state: "MERGED",
+							}),
+						};
+					}
+					// Phase B: the new OPEN PR exists; --state all must not be
+					// queried because findPrForBranch returns on the open hit.
+					if (state === "open") {
+						return {
+							stdout: prJson({
+								number: 200,
+								url: "https://pr/200",
+								title: "New PR",
+								state: "OPEN",
+							}),
+						};
+					}
+					return { stdout: PR_LIST_EMPTY };
+				}
+				return { stdout: "" };
+			});
+
+			// Phase A: assert the pre-create section dispatched noPr + MERGED.
+			await handleCheckPrStatus(CWD, postMessage);
+			expect(postMessage).toHaveBeenCalledWith(
+				expect.objectContaining({
+					status: "noPr",
+					previousPr: expect.objectContaining({ state: "MERGED" }),
+				}),
+			);
+
+			postMessage.mockClear();
+
+			// Phase B: handleCreatePr flips phase via gh pr create, then its
+			// internal handleCheckPrStatus must dispatch ready with the new PR.
+			await handleCreatePr("New PR", "Body", CWD, postMessage);
+
+			const readyCalls = postMessage.mock.calls.filter(
+				(c) => (c[0] as { status?: string }).status === "ready",
+			);
+			expect(readyCalls).toHaveLength(1);
+			expect(readyCalls[0][0]).toEqual({
+				command: "prStatus",
+				status: "ready",
+				pr: { number: 200, url: "https://pr/200", title: "New PR" },
+			});
+			expect(readyCalls[0][0]).not.toHaveProperty("previousPr");
+		});
 	});
 
 	// ─── handlePrepareUpdatePr ──────────────────────────────────────────────
@@ -1291,9 +1627,9 @@ describe("PrCommentService", () => {
 				if (cmd === "git" && args[0] === "rev-parse") {
 					return { stdout: "feature/test-branch\n" };
 				}
-				if (cmd === "gh" && args[0] === "pr" && args[1] === "view") {
+				if (cmd === "gh" && args[0] === "pr" && args[1] === "list") {
 					return {
-						stdout: JSON.stringify({
+						stdout: prJson({
 							number: 10,
 							url: "https://url",
 							title: "PR Title",
@@ -1319,9 +1655,9 @@ describe("PrCommentService", () => {
 				if (cmd === "git" && args[0] === "rev-parse") {
 					return { stdout: "feature/test-branch\n" };
 				}
-				if (cmd === "gh" && args[0] === "pr" && args[1] === "view") {
+				if (cmd === "gh" && args[0] === "pr" && args[1] === "list") {
 					return {
-						stdout: JSON.stringify({
+						stdout: prJson({
 							number: 10,
 							url: "https://url",
 							title: "T",
@@ -1357,7 +1693,7 @@ describe("PrCommentService", () => {
 				if (cmd === "gh" && args[0] === "auth") {
 					return { stdout: "ok\n" };
 				}
-				if (cmd === "gh" && args[0] === "pr" && args[1] === "view") {
+				if (cmd === "gh" && args[0] === "pr" && args[1] === "list") {
 					throw ghError({
 						message: "gh exit 4",
 						code: 4,
@@ -1399,15 +1735,12 @@ describe("PrCommentService", () => {
 				if (cmd === "gh" && args[0] === "auth") {
 					return { stdout: "ok\n" };
 				}
-				if (cmd === "gh" && args[0] === "pr" && args[1] === "view") {
+				if (cmd === "gh" && args[0] === "pr" && args[1] === "list") {
 					// Mimic gh's real non-zero exit with the "no pull requests
 					// found" stderr line — findPrForBranch reads it via
 					// `(err as { stderr? }).stderr`, matches the regex,
 					// returns `{ kind: "noPr" }`.
-					throw ghError({
-						message: "gh exit 1",
-						stderr: "no pull requests found",
-					});
+					return { stdout: PR_LIST_EMPTY };
 				}
 				return { stdout: "" };
 			});
@@ -1465,9 +1798,9 @@ describe("PrCommentService", () => {
 				if (cmd === "git" && args[0] === "rev-parse") {
 					return { stdout: "feature/test-branch\n" };
 				}
-				if (cmd === "gh" && args[0] === "pr" && args[1] === "view") {
+				if (cmd === "gh" && args[0] === "pr" && args[1] === "list") {
 					return {
-						stdout: JSON.stringify({
+						stdout: prJson({
 							number: 10,
 							url: "https://url",
 							title: "T",
@@ -1494,13 +1827,13 @@ describe("PrCommentService", () => {
 				if (cmd === "git" && args[0] === "rev-parse") {
 					return { stdout: "feature/current\n" };
 				}
-				if (cmd === "gh" && args[0] === "pr" && args[1] === "view") {
-					const sepIdx = args.indexOf("--");
+				if (cmd === "gh" && args[0] === "pr" && args[1] === "list") {
+					const sepIdx = args.indexOf("--head");
 					if (sepIdx >= 0) {
 						prViewBranchArg = args[sepIdx + 1];
 					}
 					return {
-						stdout: JSON.stringify({
+						stdout: prJson({
 							number: 5,
 							url: "https://url",
 							title: "T",
@@ -1520,6 +1853,75 @@ describe("PrCommentService", () => {
 
 			expect(prViewBranchArg).toBe("feature/summary-branch");
 		});
+
+		// ── Task 3: state-guarded prepareUpdatePr ────────────────────────────
+		//
+		// When `findPrForBranch` returns a terminal-state PR (the panel's
+		// retainContextWhenHidden lets the user click a stale Edit PR after
+		// an external merge/close), prepareUpdatePr must refuse to assemble
+		// the form, warn explicitly, and re-emit prStatus so the section
+		// rebuilds with the noPr + previousPr view (button stops being stuck).
+
+		it("refuses to open the update form when PR is MERGED and repaints the section + warns", async () => {
+			setupListByState({
+				currentBranch: "feature/br",
+				open: PR_LIST_EMPTY,
+				all: prJson({
+					number: 42,
+					url: "https://pr/42",
+					title: "Merged",
+					state: "MERGED",
+				}),
+			});
+
+			await handlePrepareUpdatePr("body", CWD, postMessage);
+
+			expect(postMessage).not.toHaveBeenCalledWith(
+				expect.objectContaining({ command: "prShowUpdateForm" }),
+			);
+			expect(showWarningMessage).toHaveBeenCalledWith(
+				"PR #42 is merged — open a new PR instead.",
+			);
+			// prStatus repaint flips the main area to noPr + previousPr so
+			// the Edit PR button (Loading state) is discarded by the rebuild.
+			expect(postMessage).toHaveBeenCalledWith(
+				expect.objectContaining({
+					command: "prStatus",
+					status: "noPr",
+					previousPr: expect.objectContaining({
+						number: 42,
+						state: "MERGED",
+					}),
+				}),
+			);
+		});
+
+		it("refuses to open the update form when PR is CLOSED and repaints + warns", async () => {
+			setupListByState({
+				currentBranch: "feature/br",
+				open: PR_LIST_EMPTY,
+				all: prJson({
+					number: 13,
+					url: "https://pr/13",
+					title: "Closed",
+					state: "CLOSED",
+				}),
+			});
+
+			await handlePrepareUpdatePr("body", CWD, postMessage);
+
+			expect(postMessage).not.toHaveBeenCalledWith(
+				expect.objectContaining({ command: "prShowUpdateForm" }),
+			);
+			expect(showWarningMessage).toHaveBeenCalledWith(
+				"PR #13 is closed — open a new PR instead.",
+			);
+			expect(postMessage).toHaveBeenCalledWith(
+				expect.objectContaining({
+					previousPr: expect.objectContaining({ state: "CLOSED" }),
+				}),
+			);
+		});
 	});
 
 	// ─── handleUpdatePr ─────────────────────────────────────────────────────
@@ -1535,8 +1937,8 @@ describe("PrCommentService", () => {
 
 			setupExecFile((cmd, args) => {
 				// findPrForBranch
-				if (cmd === "gh" && args[0] === "pr" && args[1] === "view") {
-					return { stdout: JSON.stringify(pr) };
+				if (cmd === "gh" && args[0] === "pr" && args[1] === "list") {
+					return { stdout: prJson(pr) };
 				}
 				// execGh for pr edit (title change)
 				if (cmd === "gh" && args[0] === "pr" && args[1] === "edit") {
@@ -1610,10 +2012,7 @@ describe("PrCommentService", () => {
 				if (cmd === "git" && args[0] === "rev-parse") {
 					return { stdout: "branch\n" };
 				}
-				throw ghError({
-					message: "gh exit 1",
-					stderr: "no pull requests found",
-				});
+				return { stdout: PR_LIST_EMPTY };
 			});
 
 			await handleUpdatePr("T", "B", CWD, postMessage);
@@ -1661,9 +2060,9 @@ describe("PrCommentService", () => {
 				if (cmd === "git" && args[0] === "rev-parse") {
 					return { stdout: "branch\n" };
 				}
-				if (cmd === "gh" && args[0] === "pr" && args[1] === "view") {
+				if (cmd === "gh" && args[0] === "pr" && args[1] === "list") {
 					return {
-						stdout: JSON.stringify({
+						stdout: prJson({
 							number: 5,
 							url: "u",
 							title: "T",
@@ -1695,9 +2094,9 @@ describe("PrCommentService", () => {
 				if (cmd === "git" && args[0] === "rev-parse") {
 					return { stdout: "branch\n" };
 				}
-				if (cmd === "gh" && args[0] === "pr" && args[1] === "view") {
+				if (cmd === "gh" && args[0] === "pr" && args[1] === "list") {
 					return {
-						stdout: JSON.stringify({
+						stdout: prJson({
 							number: 5,
 							url: "u",
 							title: "T",
@@ -1722,8 +2121,8 @@ describe("PrCommentService", () => {
 		it("succeeds even when temp file cleanup fails (removeTempFile catch)", async () => {
 			const pr = { number: 7, url: "https://pr/7", title: "T", body: "" };
 			setupExecFile((cmd, args) => {
-				if (cmd === "gh" && args[0] === "pr" && args[1] === "view") {
-					return { stdout: JSON.stringify(pr) };
+				if (cmd === "gh" && args[0] === "pr" && args[1] === "list") {
+					return { stdout: prJson(pr) };
 				}
 				if (cmd === "gh" && args[0] === "pr" && args[1] === "edit") {
 					return { stdout: "" };
@@ -1780,13 +2179,13 @@ describe("PrCommentService", () => {
 				if (cmd === "git" && args[0] === "rev-parse") {
 					return { stdout: "feature/current\n" };
 				}
-				if (cmd === "gh" && args[0] === "pr" && args[1] === "view") {
-					const sepIdx = args.indexOf("--");
+				if (cmd === "gh" && args[0] === "pr" && args[1] === "list") {
+					const sepIdx = args.indexOf("--head");
 					if (sepIdx >= 0) {
 						prViewBranchArg = args[sepIdx + 1];
 					}
 					return {
-						stdout: JSON.stringify({
+						stdout: prJson({
 							number: 11,
 							url: "https://url",
 							title: "T",
@@ -1813,6 +2212,164 @@ describe("PrCommentService", () => {
 			);
 
 			expect(prViewBranchArg).toBe("feature/summary-branch");
+		});
+
+		// ── Task 3: state guard + symmetric repaint on noPr/lookupError ─────
+
+		it("refuses to update when PR is MERGED — clears Updating loading and repaints + warns", async () => {
+			setupListByState({
+				currentBranch: "feature/br",
+				open: PR_LIST_EMPTY,
+				all: prJson({
+					number: 42,
+					url: "https://pr/42",
+					title: "Merged",
+					state: "MERGED",
+				}),
+			});
+
+			await handleUpdatePr("T", "B", CWD, postMessage);
+
+			// Loading dismissed first so the form's Submit doesn't stay spinning.
+			expect(postMessage).toHaveBeenCalledWith({ command: "prUpdateFailed" });
+			// No gh pr edit was attempted.
+			const editCalls = mockExecFileAsync.mock.calls.filter(
+				(c: Array<unknown>) =>
+					c[0] === "gh" &&
+					Array.isArray(c[1]) &&
+					(c[1] as Array<string>)[1] === "edit",
+			);
+			expect(editCalls).toHaveLength(0);
+			// Section repaint flips the main area to noPr + previousPr.
+			expect(postMessage).toHaveBeenCalledWith(
+				expect.objectContaining({
+					command: "prStatus",
+					status: "noPr",
+					previousPr: expect.objectContaining({ state: "MERGED" }),
+				}),
+			);
+			expect(showWarningMessage).toHaveBeenCalledWith(
+				"PR #42 was merged between checking and updating — open a new PR instead.",
+			);
+		});
+
+		it("refuses to update when PR is CLOSED with the same clear-loading + repaint + warn shape", async () => {
+			setupListByState({
+				currentBranch: "feature/br",
+				open: PR_LIST_EMPTY,
+				all: prJson({ number: 13, state: "CLOSED" }),
+			});
+
+			await handleUpdatePr("T", "B", CWD, postMessage);
+
+			expect(postMessage).toHaveBeenCalledWith({ command: "prUpdateFailed" });
+			expect(showWarningMessage).toHaveBeenCalledWith(
+				"PR #13 was closed between checking and updating — open a new PR instead.",
+			);
+			expect(postMessage).toHaveBeenCalledWith(
+				expect.objectContaining({
+					previousPr: expect.objectContaining({ state: "CLOSED" }),
+				}),
+			);
+		});
+
+		it("noPr path also repaints the section (symmetric with handlePrepareUpdatePr)", async () => {
+			// Pre-fix asymmetry: updatePr only emitted prUpdateFailed and
+			// left the main area on a stale ready view. Now both Update form
+			// (Submit → prUpdateFailed) AND the main section (Edit PR button)
+			// get re-synced when the PR vanishes mid-submit.
+			setupListByState({
+				currentBranch: "feature/br",
+				open: PR_LIST_EMPTY,
+				all: PR_LIST_EMPTY,
+			});
+
+			await handleUpdatePr("T", "B", CWD, postMessage);
+
+			expect(postMessage).toHaveBeenCalledWith({ command: "prUpdateFailed" });
+			// The repaint sent a noPr prStatus, no previousPr (truly no PR).
+			const prStatusCalls = postMessage.mock.calls.filter(
+				(c) => (c[0] as { command?: string }).command === "prStatus",
+			);
+			expect(prStatusCalls).toHaveLength(1);
+			expect(prStatusCalls[0][0]).toEqual({
+				command: "prStatus",
+				status: "noPr",
+				branch: "feature/br",
+			});
+		});
+
+		it("lookupError path also repaints the section (symmetric with handlePrepareUpdatePr)", async () => {
+			setupExecFile((cmd, args) => {
+				if (cmd === "git" && args[0] === "rev-parse")
+					return { stdout: "feature/br\n" };
+				if (cmd === "gh" && args[0] === "--version")
+					return { stdout: "gh 2.40\n" };
+				if (cmd === "gh" && args[0] === "auth") return { stdout: "ok\n" };
+				if (cmd === "gh" && args[0] === "pr" && args[1] === "list") {
+					throw ghError({
+						message: "gh: exit 1",
+						code: 1,
+						stderr: "network down",
+					});
+				}
+				return { stdout: "" };
+			});
+
+			await handleUpdatePr("T", "B", CWD, postMessage);
+
+			expect(postMessage).toHaveBeenCalledWith({ command: "prUpdateFailed" });
+			expect(showErrorMessage).toHaveBeenCalledWith(
+				expect.stringContaining("network down"),
+			);
+			// The repaint surfaces the same reason via prStatus.unavailable.
+			expect(postMessage).toHaveBeenCalledWith(
+				expect.objectContaining({
+					command: "prStatus",
+					status: "unavailable",
+					reason: expect.stringContaining("network down"),
+				}),
+			);
+		});
+	});
+
+	// ─── buildPrMessageScript: previousPr rendering (Task 4) ───────────────
+
+	describe("buildPrMessageScript previousPr rendering", () => {
+		it("includes the previousPr branch in the noPr handler with DOM-safe construction", () => {
+			const js = buildPrMessageScript();
+			// The branch reads `msg.previousPr` (presence triggers the link).
+			expect(js).toContain("msg.previousPr");
+			// Anchor is built via DOM API — no innerHTML, no inline events.
+			expect(js).toContain("document.createElement('a')");
+			expect(js).not.toContain("innerHTML");
+			// state suffix is lowercased on render so users see "(merged)".
+			expect(js).toContain("msg.previousPr.state.toLowerCase()");
+			// "Previous PR #" literal is what the user reads above Create PR.
+			expect(js).toContain("'Previous PR #'");
+			// Sanity: the textContent reset on the noPr branch must occur so
+			// a "ready → noPr" transition doesn't leave the ready anchor in
+			// the DOM for the Cancel handler's firstChild test to resurface.
+			const noPrIdx = js.indexOf("s === 'noPr'");
+			const readyIdx = js.indexOf("s === 'ready'");
+			expect(noPrIdx).toBeGreaterThan(0);
+			expect(readyIdx).toBeGreaterThan(noPrIdx);
+			const noPrBlock = js.slice(noPrIdx, readyIdx);
+			expect(noPrBlock).toContain("prLinkRow.textContent = ''");
+		});
+	});
+
+	// ─── buildPrSectionScript: Cancel firstChild visibility (Task 5) ───────
+
+	describe("buildPrSectionScript Cancel handler firstChild visibility", () => {
+		it("decides link-row visibility off prLinkRow.firstChild (not blanket hide)", () => {
+			const js = buildPrSectionScript();
+			// Cancel handler must keep a "Previous PR #N" anchor visible when
+			// it survived the form-show, but hide an empty link row.
+			expect(js).toContain("prLinkRow.firstChild");
+			// Both branches present — the firstChild test must drive show/hide.
+			expect(js).toContain("prShow(prLinkRow)");
+			expect(js).toContain("prHide(prLinkRow)");
 		});
 	});
 });

--- a/vscode/src/services/PrCommentService.ts
+++ b/vscode/src/services/PrCommentService.ts
@@ -220,6 +220,8 @@ interface PrInfo {
 	url: string;
 	title: string;
 	body: string;
+	state: "OPEN" | "CLOSED" | "MERGED";
+	isCrossRepository: boolean;
 }
 
 /**
@@ -239,55 +241,106 @@ type PrLookup =
 
 /**
  * Returns PR info for the given branch.
- * Uses `gh pr view -- <branch>` which works for open, merged, and closed PRs.
  *
- * The `--` end-of-options sentinel prevents option injection: even if `branch`
- * starts with `-` (e.g. `--repo owner/evil`), `gh` treats it as a positional
- * argument rather than a flag. This is a defense-in-depth measure since the
- * value originates from persisted JSON on the orphan branch.
+ * Uses two `gh pr list --head <branch>` queries — first `--state open`, then
+ * `--state all` as fallback — to make the "OPEN takes precedence over historic
+ * terminal-state PRs" policy explicit. `gh pr view <branch>` collapses all
+ * states into one undocumented "most relevant" result, so we couldn't tell an
+ * OPEN PR apart from a MERGED follow-up that happens to share a branch.
+ *
+ * A branch can have multiple PRs over time: CLOSED-then-reopened, or the
+ * MERGED-then-follow-up pattern. We render the OPEN one when it exists, and
+ * the most recent terminal-state one (MERGED/CLOSED) as the "previousPr" hint
+ * when the branch has only history. See {@link handleCheckPrStatus} for how
+ * the dispatch decides between "Edit PR" and "Create PR + Previous PR" CTAs.
+ *
+ * `gh pr list --head <branch>` does NOT support `<owner>:<branch>` syntax —
+ * bare branch names can match same-named heads on forks. We filter
+ * `isCrossRepository === true` results to avoid mis-binding to a fork's PR;
+ * the safe degradation is "show Create PR" rather than editing someone else's.
  */
 async function findPrForBranch(cwd: string, branch: string): Promise<PrLookup> {
-	const args = ["pr", "view", "--json", "number,url,title,body", "--", branch];
+	const open = await listFirstPr(cwd, branch, "open");
+	// `found` → OPEN PR ready to edit. `lookupError` → don't paper over with a
+	// second call that may also fail; surface the real reason to the user.
+	if (open.kind !== "noPr") return open;
+	// No OPEN PR: try terminal-state PRs to surface a "Previous PR" hint.
+	return listFirstPr(cwd, branch, "all");
+}
+
+/**
+ * Runs `gh pr list --head <branch> --state <state> --limit 1` and returns
+ * the first valid PR (or `noPr` / `lookupError`).
+ *
+ * Rejects cross-repo (fork) PRs and unknown state values as `noPr` — the
+ * caller falls back to the next state query (or to overall `noPr`), keeping
+ * the error semantics strictly on gh invocation failure / JSON parse failure.
+ */
+async function listFirstPr(
+	cwd: string,
+	branch: string,
+	state: "open" | "all",
+): Promise<PrLookup> {
+	const args = [
+		"pr",
+		"list",
+		"--head",
+		branch,
+		"--state",
+		state,
+		"--limit",
+		"1",
+		"--json",
+		"number,url,title,body,state,isCrossRepository",
+	];
 	const result = await tryExecGh(args, cwd);
 
 	if (!result.ok) {
 		const stderr = result.stderr ?? "";
-		// "no pull requests found" is the expected miss path — keep it at
-		// debug to avoid noise on every WebView open. Anything else (auth,
-		// rate limit, network, repo config, non-zero exits) is a real
-		// failure and deserves warn so it shows at default log level.
-		const isExpectedNoPr = /no pull requests? found/i.test(stderr);
-		if (isExpectedNoPr) {
-			log.debug(TAG, `No PR for branch ${branch}`);
-			return { kind: "noPr" };
-		}
 		const reason = stderr.trim() || result.err.message;
 		log.warn(
 			TAG,
-			`gh pr view failed for branch ${branch} (code=${result.code}): ${result.err.message}${
+			`gh pr list --state ${state} failed for branch ${branch} (code=${result.code}): ${result.err.message}${
 				stderr ? ` | stderr: ${stderr.trim()}` : ""
 			}`,
 		);
 		return { kind: "lookupError", reason };
 	}
 
+	let arr: Array<PrInfo>;
 	try {
-		const parsed = JSON.parse(result.stdout) as PrInfo;
-		// `gh pr view --json number` returns `{"number": 0}` only in edge
-		// cases (e.g. the JSON shape changed in a future gh release).
-		// Treat as a real noPr — defense-in-depth, not a known reproducer.
-		return parsed.number ? { kind: "found", pr: parsed } : { kind: "noPr" };
+		arr = JSON.parse(result.stdout) as Array<PrInfo>;
 	} catch (err) {
+		/* v8 ignore next -- JSON.parse only throws SyntaxError (an Error); the String(err) fallback is defensive only */
 		const message = err instanceof Error ? err.message : String(err);
 		log.warn(
 			TAG,
-			`gh pr view returned unparseable JSON for branch ${branch}: ${message}. Raw length: ${result.stdout.length}`,
+			`gh pr list returned unparseable JSON for branch ${branch}: ${message}. Raw length: ${result.stdout.length}`,
 		);
 		return {
 			kind: "lookupError",
 			reason: `Unparseable response from gh: ${message}`,
 		};
 	}
+
+	if (!Array.isArray(arr) || arr.length === 0) return { kind: "noPr" };
+	const pr = arr[0];
+	if (!pr.number) return { kind: "noPr" };
+	if (pr.state !== "OPEN" && pr.state !== "CLOSED" && pr.state !== "MERGED") {
+		log.warn(
+			TAG,
+			`gh pr list returned unexpected state "${pr.state}" for branch ${branch}; ignoring.`,
+		);
+		return { kind: "noPr" };
+	}
+	if (pr.isCrossRepository) {
+		log.debug(
+			TAG,
+			`Ignoring cross-repository PR #${pr.number} for branch ${branch}`,
+		);
+		return { kind: "noPr" };
+	}
+	return { kind: "found", pr };
 }
 
 // ─── Temp file helper ────────────────────────────────────────────────────────
@@ -414,10 +467,27 @@ export async function handleCheckPrStatus(
 		}
 
 		const { pr } = lookup;
+		if (pr.state === "OPEN") {
+			postMessage({
+				command: "prStatus",
+				status: "ready",
+				pr: { number: pr.number, url: pr.url, title: pr.title },
+			});
+			return;
+		}
+		// MERGED or CLOSED: present as "no PR to edit" so the CTA flips to
+		// Create PR (a branch can host multiple PRs over time), but pass the
+		// terminal-state PR through as `previousPr` so the webview can render
+		// a one-line "Previous PR #N (merged|closed)" link above the button.
 		postMessage({
 			command: "prStatus",
-			status: "ready",
-			pr: { number: pr.number, url: pr.url, title: pr.title },
+			status: "noPr",
+			branch: targetBranch,
+			previousPr: {
+				number: pr.number,
+				url: pr.url,
+				state: pr.state,
+			},
 		});
 	} catch (err: unknown) {
 		const msg = err instanceof Error ? err.message : String(err);
@@ -533,6 +603,22 @@ export async function handlePrepareUpdatePr(
 		}
 
 		const { pr } = lookup;
+		if (pr.state !== "OPEN") {
+			// The webview's Edit PR button only renders when state is OPEN, but
+			// `retainContextWhenHidden` means a stale ready-view can still click
+			// through after an external merge/close. Repaint the section so the
+			// button gets rebuilt against the fresh (noPr + previousPr) state
+			// and the user gets an explicit reason for the rejection.
+			log.info(
+				TAG,
+				`Skipping prepareUpdatePr: PR #${pr.number} is ${pr.state}`,
+			);
+			vscode.window.showWarningMessage(
+				`PR #${pr.number} is ${pr.state.toLowerCase()} — open a new PR instead.`,
+			);
+			await handleCheckPrStatus(cwd, postMessage, summaryBranch);
+			return;
+		}
 		const newBody = replaceSummaryInBody(pr.body || "", markdown);
 
 		postMessage({
@@ -573,6 +659,10 @@ export async function handleUpdatePr(
 			vscode.window.showErrorMessage(
 				`Could not update PR for branch ${targetBranch} — ${lookup.reason}`,
 			);
+			// Symmetric with handlePrepareUpdatePr: also repaint the section so
+			// the main area syncs to the unavailable state — otherwise the user
+			// closes the form and still sees a stale ready view.
+			await handleCheckPrStatus(cwd, postMessage, summaryBranch);
 			return;
 		}
 
@@ -581,10 +671,23 @@ export async function handleUpdatePr(
 			vscode.window.showWarningMessage(
 				`No pull request found for branch ${targetBranch}.`,
 			);
+			await handleCheckPrStatus(cwd, postMessage, summaryBranch);
 			return;
 		}
 
 		const { pr } = lookup;
+		if (pr.state !== "OPEN") {
+			// Stale state: PR was merged/closed between checkPrStatus and the
+			// Submit click. Solve the same way prepareUpdatePr does — repaint
+			// + warn — but also clear the form's "Updating..." loading first.
+			postMessage({ command: "prUpdateFailed" });
+			log.info(TAG, `Skipping updatePr: PR #${pr.number} is ${pr.state}`);
+			vscode.window.showWarningMessage(
+				`PR #${pr.number} was ${pr.state.toLowerCase()} between checking and updating — open a new PR instead.`,
+			);
+			await handleCheckPrStatus(cwd, postMessage, summaryBranch);
+			return;
+		}
 
 		// Update title if changed
 		if (title !== pr.title) {
@@ -752,13 +855,22 @@ export function buildPrSectionScript(): string {
       // Restore Edit PR button state
       var editBtn = document.getElementById('editPrBtn');
       if (editBtn) { editBtn.textContent = 'Edit PR'; editBtn.disabled = false; }
-      // Restore correct visibility based on current state
+      // Restore correct visibility based on current state. For ready state
+      // the link row holds the current PR anchor. For noPr the link row is
+      // either empty (truly no PR) or holds a "Previous PR #N" anchor when
+      // the branch has a MERGED/CLOSED history — both cases are encoded by
+      // the noPr branch above as either an empty link row or a populated
+      // one, so firstChild is the right discriminator.
       if (prCurrentState === 'ready') {
         prHide(prStatusText);
         prShow(prLinkRow);
       } else {
         prShow(prStatusText);
-        prHide(prLinkRow);
+        if (prLinkRow.firstChild) {
+          prShow(prLinkRow);
+        } else {
+          prHide(prLinkRow);
+        }
       }
     });
   }
@@ -823,7 +935,26 @@ export function buildPrMessageScript(): string {
         prShow(prActions);
       } else if (s === 'noPr') {
         prHide(prLinkRow);
-        prStatusText.textContent = 'No pull request found for branch ' + msg.branch + '.';
+        // Clear residual link-row content so the Cancel handler's
+        // firstChild-based visibility check never resurfaces a stale ready
+        // anchor when this branch ran after a "ready → noPr" transition.
+        prLinkRow.textContent = '';
+        if (msg.previousPr) {
+          // A branch can host multiple PRs over time. When the most recent
+          // one is MERGED/CLOSED, surface it as a discoverable link above
+          // the Create PR button so the user can revisit the historic
+          // review/discussion without thinking it's the "current" PR.
+          prStatusText.textContent = 'No open pull request for branch ' + msg.branch + '.';
+          var prevA = document.createElement('a');
+          prevA.href = msg.previousPr.url;
+          prevA.textContent = 'Previous PR #' + msg.previousPr.number +
+            ' (' + msg.previousPr.state.toLowerCase() + ')';
+          prLinkRow.appendChild(prevA);
+          prShow(prLinkRow);
+        } else {
+          prStatusText.textContent = 'No pull request found for branch ' + msg.branch + '.';
+          // link row already cleared and hidden above; nothing more to do.
+        }
         prShow(prStatusText);
         prActions.textContent = '';
         var btn = document.createElement('button');


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## Quick recap

The summary page pull request section now reflects the actual state of a pull request on GitHub rather than always showing Edit PR. When a pull request has been merged or closed, the panel switches to a Create PR view and displays a note about the previous pull request, giving the user the context they need to decide whether to open a new one. The change covers the common workflow where a pull request is merged through GitHub's web interface and the developer then switches back to the branch to continue work.

The Edit PR button is now protected on the server side as well as in the UI. If a pull request is merged or closed while the panel is open in the background, clicking the stale Edit PR button will be rejected, the panel will repaint with the correct state, and the button will no longer be stuck in a loading state. An unrecognised pull request status from GitHub degrades safely to the Create PR view with a diagnostic warning rather than blocking the user.

---

## E2E Test (3)
<details>
<summary><strong>1. Merged PR no longer shows &quot;Edit PR&quot; button</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a branch that previously had a pull request which has since been merged on GitHub.

**Steps:**
1. Open Visual Studio Code with the Jolli Memory extension installed.
2. Switch to the branch that had the merged pull request.
3. Open the Jolli Memory summary panel.
4. Check the pull request section at the bottom of the panel.

**Expected Results:**
- The panel should NOT show an "Edit PR" button.
- Instead, the panel should show a "Create PR" button, indicating no open pull request exists.
- A brief note or context about the previously merged pull request should be visible near the button.

</blockquote>
</details>
<details>
<summary><strong>2. Closed PR no longer shows &quot;Edit PR&quot; button</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a branch that previously had a pull request which was closed (not merged) on GitHub.

**Steps:**
1. Open Visual Studio Code with the Jolli Memory extension installed.
2. Switch to the branch that had the closed pull request.
3. Open the Jolli Memory summary panel.
4. Check the pull request section at the bottom of the panel.

**Expected Results:**
- The panel should NOT show an "Edit PR" button.
- Instead, the panel should show a "Create PR" button.
- Context about the previously closed pull request should be visible near the button.

</blockquote>
</details>
<details>
<summary><strong>3. Creating a new PR after a merge correctly shows the new PR as ready to edit</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a branch whose previous pull request was merged on GitHub.

**Steps:**
1. Open the Jolli Memory summary panel on the branch with the merged pull request.
2. Confirm the panel shows a "Create PR" button with context about the merged pull request.
3. Click "Create PR" and fill in the title and description, then submit.
4. Wait for the panel to refresh after the new pull request is created.

**Expected Results:**
- After the new pull request is created, the panel should switch from showing "Create PR" to showing the "Edit PR" button for the newly created pull request.
- No mention of the old merged pull request should remain in the section.
- The new pull request's title and link should be visible in the panel.

</blockquote>
</details>

---

## Topics (2)
<details>
<summary><strong>01 · Replace single-PR lookup with multi-PR branch query for accurate status</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The summary page showed an "Edit PR" button even after a pull request had been merged or closed on GitHub. The root cause was that the tool fetched only the most recent pull request for a branch without checking whether it was still open, so the button never reflected the true state.

**💡 Decisions Behind the Code**

- **Two-step query over a single flexible fetch**: The original single-command fetch had undocumented behaviour when multiple pull requests existed for the same branch — there was no guarantee it would prefer an open one. Splitting into an explicit "open first, history second" pair gives a documented and predictable result at the cost of one extra network call in the no-open-PR case, which is acceptable.
- **Server-side guard in addition to UI hiding**: Hiding the Edit PR button when a pull request is closed is not sufficient protection, because the panel retains its state when the user switches away and back without reloading. An external merge during that window would leave the button in a stale state. Enforcing the check on the server side means the worst outcome is a warning and a panel repaint rather than a silent edit to a closed pull request.
- **Degrade unknown states to Create PR rather than blocking**: If GitHub ever introduces a new pull request lifecycle value, treating it as "no open PR" lets the user still create a new pull request rather than seeing an error. A warning is logged so the condition is visible in diagnostics without disrupting the user's workflow.

**✅ What Was Implemented**

- Replaced the single-PR fetch command with a two-step query in `findPrForBranch` inside `PrCommentService.ts`: first ask for any currently open pull request on the branch; if none exists, fall back to the most recent historical one. The result is typed as a three-way union — found, not found, or lookup error — so every caller must handle all cases explicitly. Pull requests belonging to forks are filtered out using a cross-repository flag returned by the query.
- Updated `handleCheckPrStatus` to dispatch different UI states based on the pull request's lifecycle status. An open pull request surfaces the Edit PR button as before; a merged or closed one triggers the Create PR path and passes along a summary of the previous pull request so the panel can show context. An unrecognised status value degrades safely to the Create PR path with a warning logged.
- Added state guards to the update handlers so that clicking a stale Edit PR button after an external merge or close is rejected at the server side. Both the prepare-update and submit-update paths now re-emit the current pull request status to the panel, which clears any stuck loading state on the button.

**📋 Future Enhancements**

The `--head <branch>` filter used by the query does not support specifying a repository owner, so a fork with an identically named branch could theoretically appear in results before the cross-repository filter removes it. If the first result is always a fork PR, the tool will fall through to the history query and may miss a real open PR. Raising the result limit and filtering client-side would close this gap.

**📁 FILES**
- `vscode/src/services/PrCommentService.ts`

</blockquote>
</details>
<details>
<summary><strong>02 · Migrate test fixtures from single-PR to list format and add state-dispatch coverage</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Switching the underlying pull request query from a single-object response to an array response broke every existing test fixture, and the new state-dispatch logic had no test coverage at all.

**💡 Decisions Behind the Code**

- **Indirect testing through public handlers rather than exporting internals**: The branch-lookup function is intentionally not exported. Testing it directly would require either exposing implementation details or adding a test-only export, both of which create maintenance burden. Driving tests through the public message handlers and asserting on the messages posted to the panel gives equivalent coverage with a more stable interface.
- **Empty array as the canonical "no PR" signal**: The real CLI returns an empty array when no pull request matches, not a non-zero exit. Updating the stubs to return an empty array rather than throwing an error makes the tests match production behaviour and removes a class of false-positive coverage where error-handling paths were being exercised instead of the intended no-PR path.

**✅ What Was Implemented**

- Added a `prJson` helper that wraps a single pull request object into the array format the new query returns, defaulting state to open and cross-repository to false. This let all existing "a PR exists" fixtures be updated with a one-word call rather than manual array construction. Also added `PR_LIST_EMPTY`, `setupListByState`, and `countPrListCalls` helpers to make the two-step query easy to program and verify in tests.
- Migrated fourteen fixture sites throughout `PrCommentService.test.ts` from the old single-object stdout format to the new array format, and replaced error-based "no PR found" stubs with empty-array responses to match the real CLI behaviour.
- Added sixteen new test cases covering: open-hit skips the history query; merged and closed states produce the correct panel payload; unrecognised states warn and degrade; cross-repository PRs are filtered; network errors surface as unavailable rather than no-PR; the Edit PR button is refused and the panel is repainted when a pull request is merged or closed; and the panel correctly flips from a merged-PR view to a ready view after a new pull request is created.

**📁 FILES**
- `vscode/src/services/PrCommentService.test.ts`

</blockquote>
</details>

---

*Generated by Jolli Memory · May 13, 2026 at 2:13 PM · via Anthropic*
<!-- jollimemory-summary-end -->