### PR TITLE
fix(site): restore preferRelative and forward-proof Nextra page wrapper

### DIFF
--- a/cli/src/site/NextraProjectWriter.ts
+++ b/cli/src/site/NextraProjectWriter.ts
@@ -323,6 +323,10 @@ export default withNextra({${exportLines}
   webpack(config) {
     // See JSDoc above for why this is here.
     config.infrastructureLogging = { ...(config.infrastructureLogging ?? {}), level: 'error' }
+    // Bare image paths in markdown (e.g. "logo.png" instead of "./logo.png")
+    // are common in Docusaurus content. Without preferRelative, webpack treats
+    // them as module imports and fails with "Module not found".
+    config.resolve.preferRelative = true
     return config
   },
 })
@@ -671,9 +675,9 @@ const Wrapper = useMDXComponents({}).wrapper
 export default async function Page(props: { params: Promise<{ mdxPath?: string[] }> }) {
   const params = await props.params
   const result = await importPage(params.mdxPath ?? [])
-  const { default: MDXContent, toc, metadata } = result
+  const { default: MDXContent, ...rest } = result
   return (
-    <Wrapper toc={toc} metadata={metadata}>
+    <Wrapper {...rest}>
       <MDXContent />
     </Wrapper>
   )


### PR DESCRIPTION
## Summary

Two regressions in the generated site code fixed:

- **`preferRelative` restored** — `ca91dae` accidentally removed `config.resolve.preferRelative = true` from the generated webpack config. Without it, bare image paths in markdown (e.g. `![img](logo.png)` instead of `![img](./logo.png)`) fail with `Module not found`. This is common in Docusaurus-migrated content like Feldera docs.

- **Nextra 4.6.1 `sourceCode` compat** — Nextra 4.6.1 added a `sourceCode` field to `importPage()`'s return type. The generated `page.tsx` destructured only `toc` and `metadata`, causing a TypeScript compile error. Switched to `...rest` spread so future Nextra additions pass through automatically.

## Test plan

- [x] `npm run all` passes (build, lint, 3455 CLI + 2161 VS Code tests)
- [x] Tested `jolli dev` with Feldera docs (201 files, 138 pages) — builds and serves successfully
- [x] Tested `jolli dev` with docs1 test site — builds and serves successfully

<!-- jollimemory-summary-start -->


## Quick recap

Two regressions that together made the generated documentation sites completely unusable were identified and fixed. The first had been introduced six days earlier during a large configuration refactor: a single webpack setting that allows markdown files to reference images by filename alone was accidentally removed, causing build failures for any project with content migrated from Docusaurus. Restoring that setting brought those sites back without requiring any changes to the source documentation.

The second regression surfaced when the underlying documentation framework released a new version that added an extra field to its page data structure. The generated page file had been listing only the fields it knew about, and the framework's validation rejected the result at runtime. The fix changed the generated file to forward all fields from the framework automatically, so future framework updates of the same kind will no longer require a corresponding change to the generator.

---

## E2E Test (2)
<details>
<summary><strong>1. Bare image paths load without errors</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a documentation project that includes at least one markdown file referencing an image by filename only (for example, writing "logo.png" rather than "./logo.png"), similar to content migrated from Docusaurus.

**Steps:**
1. Open the generated documentation site in your browser.
2. Navigate to a page that contains an image referenced by a bare filename (no "./" at the start).
3. Wait for the page to fully load.
4. Check whether the image appears on the page.
5. Open the browser's developer console (press F12) and look at the Console and Network tabs for any red error messages about missing files or modules.

**Expected Results:**
- The page loads completely without a build or runtime error screen.
- The image is visible on the page.
- No "Module not found" or similar errors appear in the browser console or network tab.

</blockquote>
</details>
<details>
<summary><strong>2. All pages display correctly after Nextra upgrade</strong></summary>
<br>
<blockquote>

**Preconditions:** Have the generated documentation site running with Nextra version 4.6.1 or later installed.

**Steps:**
1. Open the generated documentation site in your browser.
2. Click through several different pages in the navigation menu.
3. On each page, check that the main content area displays the page text normally.
4. Check that the table of contents (if present) appears in the sidebar or on the side of the page.
5. Look for any error messages, blank pages, or crash screens.

**Expected Results:**
- Every page visited shows its full content without any error or crash screen.
- No validation error message mentioning "children" or any other prop appears anywhere on the page.
- The table of contents and page metadata display as expected on each page.

</blockquote>
</details>

---

## Topics (2)
<details>
<summary><strong>01 · Restore bare image path support broken by earlier webpack config change</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Running the documentation site for a real-world project (migrated from Docusaurus) produced a build error saying images could not be found. The error had not appeared before a recent large refactor, suggesting something was accidentally removed.

**💡 Decisions Behind the Code**

- **Restore rather than rewrite content**: The Feldera docs (and likely other Docusaurus-origin content) use bare image paths throughout. Fixing every markdown file was ruled out as impractical for third-party content. Restoring the single webpack flag was the lowest-risk path and preserved backward compatibility for all existing sites.
- **Coexist with the logging change**: The `preferRelative` line and the `infrastructureLogging` assignment were placed side-by-side in the same webpack callback rather than choosing one over the other. Both serve independent purposes and neither conflicts with the other, so keeping both was strictly better than the status quo after `ca91dae`.

**✅ What Was Implemented**

Restored `config.resolve.preferRelative = true` inside the webpack callback in `NextraProjectWriter.ts`. This setting tells the bundler to try resolving bare filenames (e.g. `image.png`) as relative paths before treating them as package imports. The line had been present before commit `ca91dae` (merged six days prior) and was dropped when that commit rewrote the webpack callback to add infrastructure logging.

**📁 FILES**
- `cli/src/site/NextraProjectWriter.ts`

</blockquote>
</details>
<details>
<summary><strong>02 · Fix generated page wrapper to survive future Nextra API additions</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

After upgrading Nextra to version 4.6.1, every page on the generated site crashed at runtime with a validation error pointing at the `children` prop. The generated page file was not passing a newly required field that Nextra introduced in that release.

**💡 Decisions Behind the Code**

Using a rest-spread pattern instead of an explicit field list was chosen to make the generated code resilient to future Nextra releases. Nextra added `sourceCode` in 4.6.1 with no deprecation period; the same could happen again. An explicit list would require updating the generator every time Nextra extends its return type, whereas the spread approach forwards everything unconditionally and eliminates that maintenance surface entirely.

**✅ What Was Implemented**

Changed the destructuring pattern in the generated `page.tsx` inside `NextraProjectWriter.ts`. Previously the file explicitly named only `toc` and `metadata` from the page import result and forwarded those two fields to the wrapper component. The new pattern captures the default export separately and spreads all remaining fields onto the wrapper, so any fields Nextra adds in future releases are forwarded automatically without requiring a code change.

**📁 FILES**
- `cli/src/site/NextraProjectWriter.ts`

</blockquote>
</details>

---

*Generated by Jolli Memory · May 12, 2026 at 11:35 PM · via Anthropic*
<!-- jollimemory-summary-end -->