### PR TITLE
fix(ci): use gitsign verify-tag for release tag signatures

### DIFF
--- a/.github/workflows/publish-cli.yaml
+++ b/.github/workflows/publish-cli.yaml
@@ -123,11 +123,15 @@ jobs:
                     IDENTITY_REGEX: '^.+@jolli\.ai$'
                     OIDC_ISSUER: 'https://github.com/login/oauth'
                 run: |
-                    # Verify the tag *object* (refs/tags/...) — not the bare
-                    # tag name, which gitsign's revision parser could resolve to
-                    # a same-named branch or a commit pointed at by a lightweight
-                    # tag. The previous step asserted this is an annotated tag.
-                    if ! gitsign verify "refs/tags/${TAG}" \
+                    # `gitsign verify-tag` is the tag-specific verifier; the
+                    # bare `gitsign verify` is for commit envelopes and rejects
+                    # tag signatures with "unsupported signature type". Pass the
+                    # bare tag name — the previous step already asserted
+                    # refs/tags/${TAG} is an annotated tag object, so the
+                    # revision-parser ambiguity that bare names normally invite
+                    # (same-named branch, or lightweight tag at a commit) has
+                    # been ruled out before we reach this point.
+                    if ! gitsign verify-tag "${TAG}" \
                         --certificate-identity-regexp="${IDENTITY_REGEX}" \
                         --certificate-oidc-issuer="${OIDC_ISSUER}"; then
                         echo "::error::tag ${TAG} is not signed via sigstore by a trusted identity"

--- a/.github/workflows/publish-vscode.yaml
+++ b/.github/workflows/publish-vscode.yaml
@@ -117,11 +117,15 @@ jobs:
                     IDENTITY_REGEX: '^.+@jolli\.ai$'
                     OIDC_ISSUER: 'https://github.com/login/oauth'
                 run: |
-                    # Verify the tag *object* (refs/tags/...) — not the bare
-                    # tag name, which gitsign's revision parser could resolve to
-                    # a same-named branch or a commit pointed at by a lightweight
-                    # tag. The previous step asserted this is an annotated tag.
-                    if ! gitsign verify "refs/tags/${TAG}" \
+                    # `gitsign verify-tag` is the tag-specific verifier; the
+                    # bare `gitsign verify` is for commit envelopes and rejects
+                    # tag signatures with "unsupported signature type". Pass the
+                    # bare tag name — the previous step already asserted
+                    # refs/tags/${TAG} is an annotated tag object, so the
+                    # revision-parser ambiguity that bare names normally invite
+                    # (same-named branch, or lightweight tag at a commit) has
+                    # been ruled out before we reach this point.
+                    if ! gitsign verify-tag "${TAG}" \
                         --certificate-identity-regexp="${IDENTITY_REGEX}" \
                         --certificate-oidc-issuer="${OIDC_ISSUER}"; then
                         echo "::error::tag ${TAG} is not signed via sigstore by a trusted identity"


### PR DESCRIPTION
## Summary

- `publish-vscode.yaml` and `publish-cli.yaml` called `gitsign verify "refs/tags/<TAG>"`, which is the **commit-envelope** verifier. Tag signatures are wrapped in a different envelope, so the verify step always failed with \`Error: unsupported signature type\`, regardless of which \`gitsign\` version was used to sign the tag.
- Switch both workflows to \`gitsign verify-tag "<TAG>"\` — the tag-specific verifier — and pass the bare tag name. The earlier step (\`git cat-file -t refs/tags/<TAG>\`) already asserts the ref is an annotated tag object, which is what makes the bare name safe at this point.
- Updated comments to record the new defense-in-depth chain (the assertion above replaces the previous \`refs/tags/...\`-form-as-defense rationale).

This is why \`release-vscode-v0.99.0\` could not publish despite the tag being well-formed and signed by an \`@jolli.ai\` Fulcio cert. The same bug exists in \`publish-cli.yaml\` — both products have never successfully published 0.99.0.

## Test plan

- [ ] After merge, dispatch \`Publish VS Code Extension\` workflow with \`tag=release-vscode-v0.99.0\` and \`dry_run=true\`; the *Verify tag signature via sigstore* step should pass for the first time.
- [ ] Confirm the *Verify tag is reachable from a release/\*.x branch* step passes (the tag commit \`5b304d8d\` is now reachable from \`release/0.99.x\`).
- [ ] Re-run with \`dry_run=false\` to perform the real publish on both VS Code Marketplace and Open VSX.
- [ ] Re-tag \`release-cli-v0.99.0\` analogously and dispatch \`Publish CLI to NPM\` to confirm the CLI workflow is also unblocked by this change.