### PR TITLE
Update Jolli URL from app.jolli.ai to auth.jolli.ai and bump version to 0.99.1

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-<!-- Last synced commit: 322b6a73 | 2026-05-10 -->
+<!-- Last synced commit: d53654bc | 2026-05-13 -->
+
+## 0.99.1
+
+- Bug fixes
 
 ## 0.99.0
 

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@jolli.ai/cli",
-	"version": "0.99.0",
+	"version": "0.99.1",
 	"description": "AI development process auto-documentation tool - generates structured commit summaries from Claude Code, Codex, Gemini, OpenCode, Cursor, and Copilot sessions",
 	"main": "./dist/Cli.js",
 	"type": "module",

--- a/cli/src/auth/AuthConfig.test.ts
+++ b/cli/src/auth/AuthConfig.test.ts
@@ -19,7 +19,7 @@ describe("AuthConfig", () => {
 
 	describe("getJolliUrl", () => {
 		it("should return default URL when no env var is set", () => {
-			expect(getJolliUrl()).toBe("https://app.jolli.ai");
+			expect(getJolliUrl()).toBe("https://auth.jolli.ai");
 		});
 
 		it("should return JOLLI_URL env var when set", () => {
@@ -34,7 +34,7 @@ describe("AuthConfig", () => {
 
 		it("should return default when JOLLI_URL is empty", () => {
 			process.env.JOLLI_URL = "   ";
-			expect(getJolliUrl()).toBe("https://app.jolli.ai");
+			expect(getJolliUrl()).toBe("https://auth.jolli.ai");
 		});
 
 		it("should accept a staging jolli.dev host with trailing slash stripped", () => {

--- a/cli/src/auth/AuthConfig.ts
+++ b/cli/src/auth/AuthConfig.ts
@@ -8,7 +8,7 @@
 import { assertJolliOriginAllowed, validateJolliApiKey } from "../core/JolliApiUtils.js";
 import { loadConfig, saveConfig } from "../core/SessionTracker.js";
 
-const DEFAULT_JOLLI_URL = "https://app.jolli.ai";
+const DEFAULT_JOLLI_URL = "https://auth.jolli.ai";
 
 /**
  * Returns the Jolli server URL. Checks JOLLI_URL env var, then falls back to default.

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
 		},
 		"cli": {
 			"name": "@jolli.ai/cli",
-			"version": "0.99.0",
+			"version": "0.99.1",
 			"hasInstallScript": true,
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -8420,7 +8420,7 @@
 		},
 		"vscode": {
 			"name": "jollimemory-vscode",
-			"version": "0.99.0",
+			"version": "0.99.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@vscode/codicons": "^0.0.45",

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-<!-- Last synced commit: 322b6a73 | 2026-05-10 -->
+<!-- Last synced commit: d53654bc | 2026-05-13 -->
+
+## 0.99.1
+
+- Bug fixes
 
 ## 0.99.0
 

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -2,7 +2,7 @@
 	"name": "jollimemory-vscode",
 	"displayName": "Jolli Memory",
 	"description": "VS Code sidebar for Jolli Memory — AI-powered commit summaries and smart git operations",
-	"version": "0.99.0",
+	"version": "0.99.1",
 	"publisher": "jolli",
 	"license": "Apache-2.0",
 	"icon": "assets/icon.png",

--- a/vscode/src/views/SidebarCssBuilder.ts
+++ b/vscode/src/views/SidebarCssBuilder.ts
@@ -190,7 +190,28 @@ export function buildSidebarCss(): string {
   }
   .dropdown-item:hover { background: var(--vscode-menu-selectionBackground, var(--vscode-list-hoverBackground)); }
   .dropdown-item .dropdown-item-check { width: 14px; flex: 0 0 14px; font-size: 12px; }
-  .dropdown-item.current { font-weight: 600; }
+  /* .current = the row currently selected for viewing (drives the check icon).
+     .workspace = the IDE's workspace repo/branch, pinned to the top of the
+     dropdown by pinWorkspaceFirst() and bolded here so the user can always
+     spot the way back home — even when viewing a foreign repo or a sibling
+     branch. Same font-weight on both so two simultaneously-true rows look
+     uniform; the check icon alone distinguishes them. */
+  .dropdown-item.current,
+  .dropdown-item.workspace { font-weight: 600; }
+  /* Divider below the pinned workspace row groups it as its own section at
+     the top of the dropdown, mirroring VS Code's native branch picker which
+     separates the active branch from the alphabetical list. Applied as a
+     border-top on the *next* .dropdown-item via the adjacent-sibling
+     combinator (rather than border-bottom on the workspace row itself) so
+     the rule only matches when there genuinely is a next data row to
+     separate from — no orphan line when the workspace row is the only item
+     in the list, and the empty-state div (which is not a .dropdown-item)
+     never triggers it. */
+  .dropdown-item.workspace + .dropdown-item {
+    border-top: 1px solid var(--vscode-menu-separatorBackground, var(--vscode-panel-border, rgba(128,128,128,0.3)));
+    margin-top: 2px;
+    padding-top: 4px;
+  }
   .dropdown-empty {
     padding: 6px 10px;
     font-size: 12px;
@@ -367,28 +388,33 @@ export function buildSidebarCss(): string {
   .collapsible-section .section-header:hover .section-actions { visibility: visible; }
   .collapsible-section.collapsed .section-body { display: none; }
 
-  /* Bottom-of-section "Commit Memory" CTA — sits at the tail of the Changes
-     section body, separated from the file list by a thin top border so the
-     action chrome reads as "section footer" rather than "another file row".
-     Button aligns right (SCM-view convention) and the wrapper carries the
-     vertical breathing room that makes the divider feel intentional rather
-     than cramped. Button itself reuses VS Code's primary-button tokens so it
-     adapts to theme. Disabled state matches .iconbtn:disabled (opacity-only,
-     no hover background change) so the visual semantics are consistent with
-     the header sparkle iconbtn that points at the same command. */
+  /* Divider that separates the Changes file list from the Commit Memory CTA
+     below. Lives on the section body's bottom edge (not on the CTA wrapper)
+     so it inherits the section-body's collapse behaviour — when CHANGES is
+     collapsed, .section-body { display: none } hides both the file list and
+     this border in one go, while the CTA itself (a sibling of section-body)
+     stays visible and tucks directly under the header. Scoped to the Changes
+     section because that's the only section that mounts a CTA below it.
+     padding-bottom gives the line breathing room above the last file row so
+     the divider reads as intentional rather than cramped against content. */
+  .collapsible-section[data-section="changes"] .section-body {
+    padding-bottom: 12px;
+    border-bottom: 1px solid var(--vscode-widget-border, var(--vscode-editorWidget-border, var(--vscode-panel-border)));
+  }
+
+  /* Bottom-of-section "Commit Memory" CTA — sits below the Changes section
+     body. Button aligns right (SCM-view convention) and the wrapper carries
+     vertical breathing room above (gap from the divider that lives on the
+     section body) and below (gap to the next section header). Button reuses
+     VS Code's primary-button tokens so it adapts to theme. Disabled state
+     matches .iconbtn:disabled (opacity-only, no hover background change) so
+     the visual semantics are consistent with the header sparkle iconbtn that
+     points at the same command. */
   .commit-memory-action {
-    /* Horizontal spacing lives in padding (inside the border) so the
-       border-top can span the full webview width — flush to the
-       tab-content edges. Vertical padding is symmetric so the button has
-       equal breathing room above (from the divider) and below (to the
-       next section's own border-top); margin-top supplies the gap from
-       the last file row above the divider, and margin-bottom is 0 because
-       the next section header already brings its own 1px divider. */
     margin: 12px 0 0 0;
-    padding: 12px 8px 12px 8px;
+    padding: 0 8px 12px 8px;
     display: flex;
     justify-content: flex-end;
-    border-top: 1px solid var(--vscode-widget-border, var(--vscode-editorWidget-border, var(--vscode-panel-border)));
   }
   .commit-memory-btn {
     display: inline-flex;

--- a/vscode/src/views/SidebarScriptBuilder.ts
+++ b/vscode/src/views/SidebarScriptBuilder.ts
@@ -931,6 +931,24 @@ export function buildSidebarScript(): string {
     return !(repoMatch && branchMatch);
   }
 
+  // Branch list as the dropdown should see it. The host's listBranches reads
+  // <kbRoot>/.jolli/branches.json, so a brand-new git branch the user just
+  // created in the workspace — but on which no memory has been generated yet
+  // — is absent from the saved mapping. That left the user with no way to
+  // return to it after picking a foreign branch from the breadcrumb. Inject
+  // the workspace branch (state.branchName) when it's missing from the
+  // workspace repo's branch list so the breadcrumb stays round-trippable
+  // even before the first commit summary lands. No injection for foreign
+  // repos — they have no "workspace branch" concept.
+  function getEffectiveBranchList(repoName) {
+    const saved = branchChoicesByRepo[repoName] || [];
+    if (repoName !== state.currentRepoName) return saved;
+    const wb = state.branchName;
+    if (!wb) return saved;
+    if (saved.indexOf(wb) !== -1) return saved;
+    return [wb].concat(saved);
+  }
+
   function applyForeignReadonly() {
     root.classList.toggle('foreign-readonly', isViewingForeign());
   }
@@ -948,7 +966,7 @@ export function buildSidebarScript(): string {
     const detached = state.selectedBranchName ? false : state.detached;
     renderBreadcrumbBranchLabel(branchDisplay, detached);
     const repoForBranches = state.selectedRepoName || state.currentRepoName || '';
-    const branchList = branchChoicesByRepo[repoForBranches] || [];
+    const branchList = getEffectiveBranchList(repoForBranches);
     const branchChevron = breadcrumbBranchBtn.querySelector('.breadcrumb-seg-chevron');
     if (branchChevron) branchChevron.classList.toggle('hidden', branchList.length < 2);
     applyForeignReadonly();
@@ -976,8 +994,13 @@ export function buildSidebarScript(): string {
     const rows = [];
     items.forEach(function(it) {
       const isCurrent = !!it.current;
+      const isWorkspace = !!it.workspace;
+      // Two independent class flags: .current drives the leading check
+      // icon (selected for viewing); .workspace drives bold weight (the
+      // IDE's actual repo/branch). They can co-occur (initial state) or
+      // be on different rows (after the user picks a foreign target).
       const row = el('div', {
-        className: 'dropdown-item' + (isCurrent ? ' current' : ''),
+        className: 'dropdown-item' + (isCurrent ? ' current' : '') + (isWorkspace ? ' workspace' : ''),
         role: 'menuitem',
         'data-value': it.value,
       }, [
@@ -1052,20 +1075,39 @@ export function buildSidebarScript(): string {
     if (searchInput) searchInput.focus();
   }
 
+  // Pulls items flagged as 'workspace' to the front while preserving the
+  // host-supplied order (alphabetical) for the remainder. There is at most
+  // one workspace item per list — see renderBreadcrumbMenu callers — so this
+  // is effectively "move one element to index 0" with a guard for the
+  // already-first case.
+  function pinWorkspaceFirst(items) {
+    const idx = items.findIndex(function(it) { return !!it.workspace; });
+    if (idx <= 0) return items;
+    const head = items[idx];
+    return [head].concat(items.slice(0, idx)).concat(items.slice(idx + 1));
+  }
+
   breadcrumbRepoBtn.addEventListener('click', function(e) {
     e.stopPropagation();
     if (repoChoices.length < 2) return;
     const isOpen = breadcrumbRepoBtn.getAttribute('aria-expanded') === 'true';
     hideBreadcrumbMenu();
     if (isOpen) return;
+    // workspace flag marks the IDE-workspace repo and pins it to the top
+    // regardless of which repo the user has selected. The 'current' flag
+    // still tracks the picked-for-viewing repo (drives the check-mark) and
+    // is independent — when the user views a foreign repo, the workspace
+    // row is bold (.workspace) without a check and the foreign row carries
+    // the check without bold.
     const items = repoChoices.map(function(rc) {
       return {
         value: rc.repoName,
         label: rc.repoName + (rc.isCurrent ? ' (current)' : ''),
         current: rc.repoName === (state.selectedRepoName || state.currentRepoName),
+        workspace: !!rc.isCurrent,
       };
     });
-    showBreadcrumbMenu(breadcrumbRepoBtn, items, function(picked) {
+    showBreadcrumbMenu(breadcrumbRepoBtn, pinWorkspaceFirst(items), function(picked) {
       vscode.postMessage({ type: 'selection:request', repoName: picked });
     });
   });
@@ -1073,7 +1115,11 @@ export function buildSidebarScript(): string {
   breadcrumbBranchBtn.addEventListener('click', function(e) {
     e.stopPropagation();
     const repoForBranches = state.selectedRepoName || state.currentRepoName || '';
-    const list = branchChoicesByRepo[repoForBranches] || [];
+    // Effective list ensures the workspace branch is selectable even when
+    // it has no saved memories yet — without this a freshly-created branch
+    // becomes a trap: the user can leave it via the dropdown but cannot
+    // come back.
+    const list = getEffectiveBranchList(repoForBranches);
     if (list.length < 2) return;
     const isOpen = breadcrumbBranchBtn.getAttribute('aria-expanded') === 'true';
     hideBreadcrumbMenu();
@@ -1086,9 +1132,10 @@ export function buildSidebarScript(): string {
         value: b,
         label: b + (isWorkspaceBranch ? ' (current)' : ''),
         current: b === currentBranchInRepo,
+        workspace: isWorkspaceBranch,
       };
     });
-    showBreadcrumbMenu(breadcrumbBranchBtn, items, function(picked) {
+    showBreadcrumbMenu(breadcrumbBranchBtn, pinWorkspaceFirst(items), function(picked) {
       vscode.postMessage({ type: 'selection:request', branchName: picked });
     });
   });


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## Quick recap

The developer updated the Jolli authentication endpoint from app.jolli.ai to auth.jolli.ai across the CLI and VS Code extension, bumping both to version 0.99.1 to ship this change alongside other improvements. The breadcrumb dropdown now pins the user's workspace repository and branch to the top with bold styling and a visual separator, making it always visible and selectable even when viewing foreign repositories or newly created branches with no memories yet. Users can always return to a freshly created branch without being trapped after switching away. The divider between the Changes file list and the Commit Memory button now collapses together with the section, eliminating visual clutter when the Changes panel is collapsed.

---

## E2E Test (2)
<details>
<summary><strong>1. Workspace branch pinned to top of branch dropdown with bold styling</strong></summary>
<br>
<blockquote>

**Preconditions:** You have VS Code open with the Jolli Memory extension installed. You have a git repository with at least two branches. Create a new local branch that has no commit summaries saved yet (e.g., run `git checkout -b test-new-branch` without making any commits).

**Steps:**
1. Open the Jolli Memory sidebar in VS Code.
2. Click on the branch name in the breadcrumb at the top of the sidebar to open the branch dropdown menu.
3. Verify that your newly created branch (the workspace branch) appears at the very top of the list in bold text, even though it has no saved memories yet.
4. Switch to a different branch by clicking on another branch name in the dropdown.
5. Click on the branch dropdown again.
6. Verify that your workspace branch still appears at the top in bold, and you can click it to return to it.

**Expected Results:**
- The workspace branch name should always appear first in the dropdown list, above all other branches.
- The workspace branch name should be displayed in bold font weight, making it visually distinct from other branches.
- A thin separator line should appear below the workspace branch row, visually grouping it as its own section.
- You should be able to select the workspace branch from the dropdown even if it has no saved commit summaries yet.
- After switching away to another branch, the workspace branch should still be selectable and should remain pinned to the top of the dropdown.

</blockquote>
</details>
<details>
<summary><strong>2. Workspace repository pinned to top of repo dropdown with bold styling</strong></summary>
<br>
<blockquote>

**Preconditions:** You have VS Code open with the Jolli Memory extension installed. You have access to at least two git repositories that you can switch between.

**Steps:**
1. Open the Jolli Memory sidebar in VS Code.
2. Click on the repository name in the breadcrumb at the top of the sidebar to open the repository dropdown menu.
3. Verify that your current workspace repository appears at the very top of the list in bold text.
4. Switch to a different repository by clicking on another repository name in the dropdown.
5. Click on the repository dropdown again.
6. Verify that your workspace repository still appears at the top in bold, and you can click it to return to it.

**Expected Results:**
- The workspace repository name should always appear first in the dropdown list, above all other repositories.
- The workspace repository name should be displayed in bold font weight, making it visually distinct from other repositories.
- A thin separator line should appear below the workspace repository row, visually grouping it as its own section.
- After switching away to another repository, the workspace repository should still be selectable and should remain pinned to the top of the dropdown.

</blockquote>
</details>

---

## Topics (5)
<details>
<summary><strong>01 · Pin workspace repo and branch to top of breadcrumb dropdown with bold styling</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Users switching to a different repository or branch via the breadcrumb dropdown had no visual indicator of which repo and branch was their actual workspace. Newly created branches with no saved memories yet were not selectable in the dropdown, trapping users who switched away and could not return.

**💡 Decisions Behind the Code**

- **Workspace injection at render time rather than storage**: The workspace branch is injected into the effective list only during dropdown rendering rather than being permanently stored in the branches mapping. This keeps the persistent index clean (no synthetic entries) while ensuring the UI remains round-trippable even before the first memory is generated on a new branch.
- **Visual separation via border-bottom on section-body**: The divider between workspace and other items was placed as a `border-bottom` on the Changes section body (not on the CTA button wrapper) so it collapses together with the file list when the section is collapsed, keeping the UI clean. The divider uses an adjacent-sibling selector on the next `.dropdown-item` to avoid orphan lines when the workspace is the only item in the list.
- **Dual independent flags for current vs. workspace**: The `current` flag (drives the check icon for selected-for-viewing) and `workspace` flag (drives bold weight for the IDE's actual branch) are kept independent so they can appear on different rows when the user is viewing a foreign branch, making it clear both where they are and where home is.

**✅ What Was Implemented**

- Added `getEffectiveBranchList()` helper in `vscode/src/views/SidebarScriptBuilder.ts` to inject the workspace branch into the branch dropdown list even when it has no saved memories yet, ensuring users can always return to a freshly created branch.
- Modified repo and branch click handlers to flag workspace items with a `workspace` property and call `pinWorkspaceFirst()` to move them to the top of the dropdown list before rendering, independent of alphabetical ordering.
- Added `.workspace` CSS class styling in `vscode/src/views/SidebarCssBuilder.ts` to bold workspace rows with `font-weight: 600`, and added a 1px separator line below the workspace row using an adjacent-sibling combinator to visually group it as a distinct section at the top of the dropdown.

**📁 FILES**
- `vscode/src/views/SidebarScriptBuilder.ts`
- `vscode/src/views/SidebarCssBuilder.ts`

</blockquote>
</details>
<details>
<summary><strong>02 · Update Jolli authentication URL from app.jolli.ai to auth.jolli.ai</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The Jolli authentication endpoint moved from app.jolli.ai to auth.jolli.ai. The CLI and VS Code extension need to use the new URL for all authentication flows.

**💡 Decisions Behind the Code**

The change was applied directly to the source constant and its corresponding test expectations rather than introducing a configuration layer, keeping the authentication URL management simple and centralized in one location. The new URL is treated as the new baseline default, with no migration path or dual-endpoint support needed since this is a coordinated infrastructure change.

**✅ What Was Implemented**

- Updated the default Jolli URL constant in `cli/src/auth/AuthConfig.ts` from `https://app.jolli.ai` to `https://auth.jolli.ai`. This constant is used by the authentication configuration module to determine the server endpoint when no environment variable override is set.
- Updated test expectations in `cli/src/auth/AuthConfig.test.ts` to match the new default URL in two test cases: one verifying the default when no environment variable is set, and another verifying the default when the environment variable is empty or whitespace.

**📁 FILES**
- `cli/src/auth/AuthConfig.ts`
- `cli/src/auth/AuthConfig.test.ts`

</blockquote>
</details>
<details>
<summary><strong>03 · Move Commit Memory divider from button wrapper to section body for proper collapse behavior</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The divider separating the Changes file list from the Commit Memory button was visually part of the section but DOM-wise attached to the button wrapper, so it remained visible when the Changes section was collapsed, creating visual clutter.

**💡 Decisions Behind the Code**

Attaching the divider to the section body ensures it inherits the collapse behavior (`display: none`) automatically, eliminating the need for separate JavaScript logic to hide the line. This approach keeps the DOM structure and visual hierarchy aligned: the divider is semantically part of the section content, not the button chrome.

**✅ What Was Implemented**

- Moved the `border-top` divider from `.commit-memory-action` to `.collapsible-section[data-section="changes"] .section-body` as a `border-bottom`, making it part of the collapsible content.
- Added `padding-bottom: 12px` to the section body to preserve the visual breathing room above the divider that existed before.
- Adjusted `.commit-memory-action` padding from `12px 8px 12px 8px` to `0 8px 12px 8px`, removing the top padding since the spacing now comes from the section body's bottom padding.

**📁 FILES**
- `vscode/src/views/SidebarCssBuilder.ts`

</blockquote>
</details>
<details>
<summary><strong>04 · Bump CLI and VS Code extension versions to 0.99.1</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

A hotfix release 0.99.1 was needed to ship the authentication URL change and other bug fixes after the 0.99.0 release.

**💡 Decisions Behind the Code**

Both artifacts were bumped to the same patch version (0.99.1) to keep them synchronized for this hotfix release, even though they are independently published to npm and the VS Code Marketplace. The root `package.json` was intentionally left at 0.99.0 because it is a workspace coordinator that does not participate in any release process.

**✅ What Was Implemented**

- Incremented version in `cli/package.json` from 0.99.0 to 0.99.1.
- Incremented version in `vscode/package.json` from 0.99.0 to 0.99.1.
- Updated `package-lock.json` to reflect the new workspace package versions for both CLI and VS Code artifacts.

**📁 FILES**
- `cli/package.json`
- `vscode/package.json`
- `package-lock.json`

</blockquote>
</details>
<details>
<summary><strong>05 · Update changelog sync markers and add version 0.99.1 release notes</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The developer had just committed code changes and needed to update the changelog metadata to reflect the new commit boundary for future changelog maintenance work.

**💡 Decisions Behind the Code**

The sync marker format (8-character hash and ISO date) was preserved exactly as it appeared in the original comments. This consistency ensures that any downstream scripts or tools that parse these markers using regular expressions will continue to work without modification, and future maintainers will immediately recognize the format without needing to consult documentation.

**✅ What Was Implemented**

- Updated the "Last synced commit" marker in both `cli/CHANGELOG.md` and `vscode/CHANGELOG.md` from `322b6a73 | 2026-05-10` to `d53654bc | 2026-05-13`, using the 8-character short hash and ISO date format to maintain consistency with existing conventions.
- Added a new version 0.99.1 section to both changelog files with a placeholder "Bug fixes" entry, establishing the release notes structure for the upcoming patch version.

**📁 FILES**
- `cli/CHANGELOG.md`
- `vscode/CHANGELOG.md`

</blockquote>
</details>

---

*Generated by Jolli Memory · May 13, 2026 at 5:47 PM · via Anthropic*
<!-- jollimemory-summary-end -->