### PR TITLE
Add device_name support to CLI and VSCode auth login URLs

### DIFF
--- a/cli/src/auth/DeviceLabel.test.ts
+++ b/cli/src/auth/DeviceLabel.test.ts
@@ -1,0 +1,93 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("node:os", () => ({
+	hostname: vi.fn(),
+}));
+
+import { hostname } from "node:os";
+import { getDeviceLabel, sanitizeDeviceLabel } from "./DeviceLabel.js";
+
+describe("sanitizeDeviceLabel", () => {
+	it("preserves a typical macOS hostname unchanged", () => {
+		expect(sanitizeDeviceLabel("Foster-MacBook-Pro.local")).toBe("Foster-MacBook-Pro.local");
+	});
+
+	it("preserves a typical Windows hostname unchanged", () => {
+		expect(sanitizeDeviceLabel("DESKTOP-ABC123")).toBe("DESKTOP-ABC123");
+	});
+
+	it("preserves internal spaces, underscores, dots, and hyphens", () => {
+		expect(sanitizeDeviceLabel("my host_name.v1-prod")).toBe("my host_name.v1-prod");
+	});
+
+	it("trims surrounding whitespace before filtering", () => {
+		expect(sanitizeDeviceLabel("   desktop-1   ")).toBe("desktop-1");
+	});
+
+	it("strips disallowed characters (control chars, quotes, angle brackets, slashes)", () => {
+		// Mirror the server allow-list — anything outside [A-Za-z0-9 _.-] is dropped.
+		expect(sanitizeDeviceLabel('name"quoted')).toBe("namequoted");
+		expect(sanitizeDeviceLabel("name'apostrophe")).toBe("nameapostrophe");
+		expect(sanitizeDeviceLabel("<script>")).toBe("script");
+		expect(sanitizeDeviceLabel("path/with/slashes")).toBe("pathwithslashes");
+		expect(sanitizeDeviceLabel("tab\there")).toBe("tabhere");
+		expect(sanitizeDeviceLabel("null\x00byte")).toBe("nullbyte");
+	});
+
+	it("strips non-ASCII Unicode (e.g. accented characters)", () => {
+		expect(sanitizeDeviceLabel("café")).toBe("caf");
+	});
+
+	it("truncates to 32 characters", () => {
+		const long = "a".repeat(50);
+		const result = sanitizeDeviceLabel(long);
+		expect(result).toBe("a".repeat(32));
+		expect(result?.length).toBe(32);
+	});
+
+	it("truncates AFTER stripping, so disallowed bytes don't consume the budget", () => {
+		// 30 valid chars + 5 disallowed → after strip we have 30 chars, no truncation.
+		const input = `${"a".repeat(30)}<<<<<`;
+		expect(sanitizeDeviceLabel(input)).toBe("a".repeat(30));
+	});
+
+	it("returns undefined for an empty string", () => {
+		expect(sanitizeDeviceLabel("")).toBeUndefined();
+	});
+
+	it("returns undefined for whitespace-only input", () => {
+		expect(sanitizeDeviceLabel("   ")).toBeUndefined();
+	});
+
+	it("returns undefined when input contains only disallowed characters", () => {
+		// All bytes are outside the allow-list → cleaned string is empty.
+		expect(sanitizeDeviceLabel("///\x00\x01")).toBeUndefined();
+		expect(sanitizeDeviceLabel("中文")).toBeUndefined();
+	});
+});
+
+describe("getDeviceLabel", () => {
+	beforeEach(() => {
+		vi.resetAllMocks();
+	});
+
+	it("returns the sanitized hostname() value", () => {
+		vi.mocked(hostname).mockReturnValue("Foster-MBP.local");
+		expect(getDeviceLabel()).toBe("Foster-MBP.local");
+	});
+
+	it("applies the same sanitization rules as sanitizeDeviceLabel", () => {
+		vi.mocked(hostname).mockReturnValue("  has spaces and <unsafe>  ");
+		expect(getDeviceLabel()).toBe("has spaces and unsafe");
+	});
+
+	it("returns undefined when hostname() returns an empty string", () => {
+		vi.mocked(hostname).mockReturnValue("");
+		expect(getDeviceLabel()).toBeUndefined();
+	});
+
+	it("returns undefined when hostname() returns a value of only disallowed characters", () => {
+		vi.mocked(hostname).mockReturnValue("中文主机");
+		expect(getDeviceLabel()).toBeUndefined();
+	});
+});

--- a/cli/src/auth/DeviceLabel.ts
+++ b/cli/src/auth/DeviceLabel.ts
@@ -1,0 +1,39 @@
+/**
+ * Device label helper for the OAuth login URL.
+ *
+ * The server uses the optional `device_name` query param to scope the
+ * idempotency key when minting an auto-generated Jolli API key, so the same
+ * user signing in from two machines under the same account ends up with two
+ * distinct API-key rows (one per device) instead of clobbering each other.
+ *
+ * Sanitization rules mirror the server's `sanitizeDeviceLabel` exactly —
+ * trim, keep only `[A-Za-z0-9 _.-]`, max 32 chars — so a sketchy hostname
+ * doesn't get silently dropped server-side and produce a name-column mismatch.
+ *
+ * Both CLI (`browserLogin`) and the VSCode extension (`AuthService.openSignInPage`)
+ * import this helper so the wire format stays identical across surfaces.
+ */
+
+import { hostname } from "node:os";
+
+const DEVICE_LABEL_ALLOWED = /[^A-Za-z0-9 _.-]/g;
+const DEVICE_LABEL_MAX_LEN = 32;
+
+/**
+ * Normalizes a raw device label to the server-accepted shape.
+ *
+ * Returns `undefined` when the result would be empty so callers can use
+ * `if (label)` to decide whether to append the query param at all.
+ */
+export function sanitizeDeviceLabel(raw: string): string | undefined {
+	const cleaned = raw.trim().replace(DEVICE_LABEL_ALLOWED, "").slice(0, DEVICE_LABEL_MAX_LEN);
+	return cleaned.length > 0 ? cleaned : undefined;
+}
+
+/**
+ * Returns the sanitized host machine name, or `undefined` if the hostname is
+ * empty / made up entirely of disallowed characters.
+ */
+export function getDeviceLabel(): string | undefined {
+	return sanitizeDeviceLabel(hostname());
+}

--- a/cli/src/auth/Login.test.ts
+++ b/cli/src/auth/Login.test.ts
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 const mockSaveAuthCredentials = vi.fn();
 const mockLoadConfig = vi.fn();
 const mockExchangeCliCode = vi.fn();
+const mockGetDeviceLabel = vi.fn();
 
 vi.mock("./AuthConfig.js", () => ({
 	saveAuthCredentials: (...args: unknown[]) => mockSaveAuthCredentials(...args),
@@ -15,6 +16,10 @@ vi.mock("../core/SessionTracker.js", () => ({
 
 vi.mock("./CliExchange.js", () => ({
 	exchangeCliCode: (...args: unknown[]) => mockExchangeCliCode(...args),
+}));
+
+vi.mock("./DeviceLabel.js", () => ({
+	getDeviceLabel: () => mockGetDeviceLabel(),
 }));
 
 const mockOpen = vi.fn();
@@ -39,6 +44,9 @@ describe("Login", () => {
 		mockLoadConfig.mockResolvedValue({});
 		// Default: exchange succeeds with token only. Tests override per-call.
 		mockExchangeCliCode.mockResolvedValue({ token: "tk-default" });
+		// Default: no device label so URL-construction tests that don't care
+		// about the param stay unchanged. Multi-device tests override per-call.
+		mockGetDeviceLabel.mockReturnValue(undefined);
 	});
 
 	afterEach(() => {
@@ -765,6 +773,73 @@ describe("Login", () => {
 			// a new key is being minted, so it must be present even when one exists.
 			expect(openUrl).toContain("client=cli");
 			expect(mockSaveAuthCredentials).toHaveBeenCalledWith({ token: "browser-token-2" });
+		});
+
+		// ── device_name (per-device API-key scoping) ──────────────────────
+		// The server uses device_name to scope its auto-generated-key
+		// idempotency check so signing in from a second machine doesn't
+		// invalidate the first machine's key. Only meaningful when paired
+		// with generate_api_key=true.
+
+		it("appends device_name when generate_api_key is requested and getDeviceLabel returns a value", async () => {
+			mockLoadConfig.mockResolvedValue({});
+			mockGetDeviceLabel.mockReturnValue("Foster-MBP");
+			mockExchangeCliCode.mockResolvedValue({ token: "dev-tk" });
+			mockOpen.mockImplementation(simulateBrowserCallback("dev-code"));
+
+			await browserLogin(TEST_JOLLI_URL);
+
+			const openedUrl = mockOpen.mock.calls[0][0] as string;
+			expect(openedUrl).toContain("generate_api_key=true");
+			expect(new URL(openedUrl).searchParams.get("device_name")).toBe("Foster-MBP");
+		});
+
+		it("URL-encodes a device_name that contains spaces or dots", async () => {
+			// Hostnames like "Foster MacBook Pro.local" must round-trip safely
+			// through the URL — otherwise the server sees a malformed query.
+			mockLoadConfig.mockResolvedValue({});
+			mockGetDeviceLabel.mockReturnValue("Foster MacBook Pro.local");
+			mockExchangeCliCode.mockResolvedValue({ token: "enc-tk" });
+			mockOpen.mockImplementation(simulateBrowserCallback("enc-code"));
+
+			await browserLogin(TEST_JOLLI_URL);
+
+			const openedUrl = mockOpen.mock.calls[0][0] as string;
+			// Raw URL must show percent-encoding for the space.
+			expect(openedUrl).toContain("device_name=Foster%20MacBook%20Pro.local");
+			// And the decoded value matches what getDeviceLabel returned.
+			expect(new URL(openedUrl).searchParams.get("device_name")).toBe("Foster MacBook Pro.local");
+		});
+
+		it("omits device_name when getDeviceLabel returns undefined (sanitized to empty)", async () => {
+			// Hostname like "中文" sanitizes to undefined — we must not send the
+			// param so the server falls back to its legacy keyName path.
+			mockLoadConfig.mockResolvedValue({});
+			mockGetDeviceLabel.mockReturnValue(undefined);
+			mockExchangeCliCode.mockResolvedValue({ token: "nodl-tk" });
+			mockOpen.mockImplementation(simulateBrowserCallback("nodl-code"));
+
+			await browserLogin(TEST_JOLLI_URL);
+
+			const openedUrl = mockOpen.mock.calls[0][0] as string;
+			expect(openedUrl).toContain("generate_api_key=true");
+			expect(openedUrl).not.toContain("device_name");
+		});
+
+		it("omits device_name when generate_api_key is not being requested", async () => {
+			// Pre-existing jolliApiKey → no generate_api_key. device_name is
+			// only meaningful at key-creation time, so it must not appear here
+			// even if the machine has a perfectly valid hostname.
+			mockLoadConfig.mockResolvedValue({ jolliApiKey: "jk_existing" });
+			mockGetDeviceLabel.mockReturnValue("Foster-MBP");
+			mockExchangeCliCode.mockResolvedValue({ token: "no-gen-tk" });
+			mockOpen.mockImplementation(simulateBrowserCallback("no-gen-code"));
+
+			await browserLogin(TEST_JOLLI_URL);
+
+			const openedUrl = mockOpen.mock.calls[0][0] as string;
+			expect(openedUrl).not.toContain("generate_api_key");
+			expect(openedUrl).not.toContain("device_name");
 		});
 
 		it("rejects when open() throws (e.g. headless server)", async () => {

--- a/cli/src/auth/Login.ts
+++ b/cli/src/auth/Login.ts
@@ -14,6 +14,7 @@ import open from "open";
 import { loadConfig } from "../core/SessionTracker.js";
 import { saveAuthCredentials } from "./AuthConfig.js";
 import { exchangeCliCode } from "./CliExchange.js";
+import { getDeviceLabel } from "./DeviceLabel.js";
 
 /**
  * Opens the browser to `${jolliUrl}/login` with a CLI callback URL, waits for
@@ -53,6 +54,14 @@ export function browserLogin(jolliUrl: string): Promise<void> {
 					let loginUrl = `${jolliUrl}/login?cli_callback=${encodeURIComponent(callbackUrl)}&state=${expectedState}&client=cli`;
 					if (!config.jolliApiKey) {
 						loginUrl += "&generate_api_key=true";
+						// `device_name` scopes the server's per-user idempotency key so
+						// signing in from a second machine doesn't invalidate the first
+						// machine's auto-generated API key. Only meaningful when we're
+						// asking the server to mint a new key — paired with generate_api_key.
+						const deviceLabel = getDeviceLabel();
+						if (deviceLabel) {
+							loginUrl += `&device_name=${encodeURIComponent(deviceLabel)}`;
+						}
 					}
 
 					console.log("Opening browser to login...");

--- a/vscode/src/services/AuthService.test.ts
+++ b/vscode/src/services/AuthService.test.ts
@@ -18,6 +18,10 @@ const { loadConfig } = vi.hoisted(() => ({
 	loadConfig: vi.fn().mockResolvedValue({}),
 }));
 
+const { getDeviceLabel } = vi.hoisted(() => ({
+	getDeviceLabel: vi.fn(),
+}));
+
 const {
 	executeCommand,
 	openExternal,
@@ -105,6 +109,10 @@ vi.mock("../../../cli/src/auth/CliExchange.js", () => ({
 	exchangeCliCode,
 }));
 
+vi.mock("../../../cli/src/auth/DeviceLabel.js", () => ({
+	getDeviceLabel,
+}));
+
 vi.mock("../../../cli/src/core/SessionTracker.js", () => ({
 	loadConfig,
 }));
@@ -156,6 +164,9 @@ describe("AuthService", () => {
 		// Default: code-exchange succeeds and returns a token only. Tests that
 		// need an API key or different failure modes override per-call.
 		exchangeCliCode.mockResolvedValue({ token: "test-token" });
+		// Default: no device label so URL-construction tests that don't care
+		// about the param stay unchanged. Multi-device tests override per-call.
+		getDeviceLabel.mockReturnValue(undefined);
 		service = new AuthService();
 	});
 
@@ -756,6 +767,65 @@ describe("AuthService", () => {
 			const parsed = uriParse.mock.calls[0]?.[0] ?? "";
 			expect(parsed).not.toContain("generate_api_key");
 			expect(parsed).toContain("client=vscode");
+		});
+
+		// ── device_name (per-device API-key scoping) ──────────────────────
+		// The server uses device_name to scope its auto-generated-key
+		// idempotency check so signing in from a second machine doesn't
+		// invalidate the first machine's key. Only meaningful when paired
+		// with generate_api_key=true.
+
+		it("appends device_name when generate_api_key is requested and getDeviceLabel returns a value", async () => {
+			getDeviceLabel.mockReturnValue("Foster-MBP");
+
+			await service.openSignInPage();
+
+			const parsed = uriParse.mock.calls[0]?.[0] ?? "";
+			expect(parsed).toContain("generate_api_key=true");
+			expect(new URL(parsed).searchParams.get("device_name")).toBe(
+				"Foster-MBP",
+			);
+		});
+
+		it("URL-encodes a device_name that contains spaces or dots", async () => {
+			// Hostnames like "Foster MacBook Pro.local" must round-trip safely
+			// through the URL — otherwise the server sees a malformed query.
+			getDeviceLabel.mockReturnValue("Foster MacBook Pro.local");
+
+			await service.openSignInPage();
+
+			const parsed = uriParse.mock.calls[0]?.[0] ?? "";
+			expect(parsed).toContain("device_name=Foster%20MacBook%20Pro.local");
+			expect(new URL(parsed).searchParams.get("device_name")).toBe(
+				"Foster MacBook Pro.local",
+			);
+		});
+
+		it("omits device_name when getDeviceLabel returns undefined (sanitized to empty)", async () => {
+			// Hostnames that sanitize to undefined (empty / only disallowed
+			// characters) must not appear on the URL so the server falls back
+			// to its legacy keyName path.
+			getDeviceLabel.mockReturnValue(undefined);
+
+			await service.openSignInPage();
+
+			const parsed = uriParse.mock.calls[0]?.[0] ?? "";
+			expect(parsed).toContain("generate_api_key=true");
+			expect(parsed).not.toContain("device_name");
+		});
+
+		it("omits device_name when generate_api_key is not being requested", async () => {
+			// Pre-existing jolliApiKey → no generate_api_key. device_name is
+			// only meaningful at key-creation time, so it must not appear here
+			// even if the machine has a perfectly valid hostname.
+			loadConfig.mockResolvedValueOnce({ jolliApiKey: "sk-jol-existing" });
+			getDeviceLabel.mockReturnValue("Foster-MBP");
+
+			await service.openSignInPage();
+
+			const parsed = uriParse.mock.calls[0]?.[0] ?? "";
+			expect(parsed).not.toContain("generate_api_key");
+			expect(parsed).not.toContain("device_name");
 		});
 
 		it("should show an error message when openExternal returns false", async () => {

--- a/vscode/src/services/AuthService.ts
+++ b/vscode/src/services/AuthService.ts
@@ -19,6 +19,7 @@ import {
 	saveAuthCredentials,
 } from "../../../cli/src/auth/AuthConfig.js";
 import { exchangeCliCode } from "../../../cli/src/auth/CliExchange.js";
+import { getDeviceLabel } from "../../../cli/src/auth/DeviceLabel.js";
 import { loadConfig } from "../../../cli/src/core/SessionTracker.js";
 import type { JolliMemoryConfig } from "../../../cli/src/Types.js";
 import { log } from "../util/Logger.js";
@@ -221,6 +222,14 @@ export class AuthService {
 		// Mirrors the CLI's browserLogin() behaviour in Login.ts.
 		const { jolliApiKey } = await loadConfig();
 		const generateKeyParam = jolliApiKey ? "" : "&generate_api_key=true";
+		// `device_name` scopes the server's per-user idempotency key so signing
+		// in from a second machine doesn't invalidate the first machine's
+		// auto-generated API key. Only meaningful when we're asking the server
+		// to mint a new key — paired with generate_api_key.
+		const deviceLabel = jolliApiKey ? undefined : getDeviceLabel();
+		const deviceLabelParam = deviceLabel
+			? `&device_name=${encodeURIComponent(deviceLabel)}`
+			: "";
 		// 256-bit CSRF nonce per RFC 6749 §10.12. Sent on the login URL and
 		// validated on the matching handleAuthCallback().
 		const state = randomBytes(32).toString("hex");
@@ -229,7 +238,7 @@ export class AuthService {
 		// a friendly error dialog instead of an unhandled command exception.
 		let loginUrl: string;
 		try {
-			loginUrl = `${getJolliUrl()}/login?cli_callback=${encodeURIComponent(callbackUri)}&state=${state}${generateKeyParam}&client=vscode`;
+			loginUrl = `${getJolliUrl()}/login?cli_callback=${encodeURIComponent(callbackUri)}&state=${state}${generateKeyParam}${deviceLabelParam}&client=vscode`;
 		} catch (err: unknown) {
 			const message = err instanceof Error ? err.message : String(err);
 			log.error("AuthService", "getJolliUrl rejected: %s", message);


### PR DESCRIPTION
<!-- jollimemory-summary-start -->


## Quick recap

Signing into Jolli from multiple devices now results in a separate API key for each machine rather than a single shared key that gets overwritten on every new login. The CLI and VSCode extension both read the host machine's name at login time and attach it to the login URL when requesting a new API key, so the server can store and retrieve a key scoped to that specific device. Devices that are already authenticated are completely unaffected — the machine name is only sent during the key-creation step.

A shared helper was introduced to sanitize the machine hostname before it is sent, applying the same character and length rules the server enforces. This means a hostname accepted on the client side will always be accepted on the server side without silent truncation or rejection. The parameter name sent in the URL was also corrected to match what the web backend actually reads, ensuring the device label appears on newly created keys in the Jolli account settings rather than being silently ignored.

---

## E2E Test (1)
<details>
<summary><strong>1. Second device login no longer invalidates first device's session</strong></summary>
<br>
<blockquote>

**Preconditions:** Have two separate computers (or two separate browser profiles) where you can sign into Jolli. Make sure neither device is currently signed in — sign out on both if needed.

**Steps:**
1. On the first computer, open the Jolli CLI or the Jolli VS Code extension and start the sign-in flow (for example, run the login command or click "Sign In" in the VS Code sidebar).
2. Complete the sign-in in the browser on the first computer. Confirm the first computer is successfully authenticated and can use Jolli normally.
3. On the second computer, open the Jolli CLI or VS Code extension and start the sign-in flow the same way.
4. Complete the sign-in in the browser on the second computer. Confirm the second computer is successfully authenticated.
5. Go back to the first computer and try to use Jolli (for example, run any CLI command or trigger any action in the VS Code extension that requires authentication).
6. Check whether the first computer is still signed in and working.

**Expected Results:**
- The first computer should still be fully authenticated and able to use Jolli without being asked to sign in again.
- The second computer should also be authenticated and working at the same time.
- Neither device's session should have been invalidated by the other device signing in.

</blockquote>
</details>

---

## Topic (1)
<details>
<summary><strong>01 · Per-device API key naming via machine hostname in login URLs</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

When the same user signed into Jolli from multiple devices, each new login invalidated the API key held by every previously signed-in device, creating a cycle where only the most recently logged-in device could authenticate. The fix required each client to identify its host machine when requesting a new API key so the server could maintain a separate key per device.

**💡 Decisions Behind the Code**

- **Hostname as the device identifier over a generated UUID**: A hostname requires no persistent storage, no install-time setup, and no config writes — it is a one-line call available on every platform. The trade-off is that two machines with identical hostnames under the same account would still collide, and renaming a machine creates an orphaned key row. These edge cases were judged low-frequency and self-healing (the orphaned row is visible and deletable in the API-key UI), making the simplicity win decisive.
- **`device_name` over the originally shipped `device_label` wire name**: The initial implementation sent `device_label`, but the web backend had settled on `device_name` as the parameter it reads when naming auto-generated API keys. The internal TypeScript identifiers (`getDeviceLabel`, `DeviceLabel.ts`, `deviceLabel` variables, `sanitizeDeviceLabel`) were deliberately left unchanged — the internal concept name and the HTTP wire name are treated as independent concerns, keeping the rename diff minimal and avoiding unrelated churn.
- **Gate device name strictly on the key-creation path**: The device name only affects the name column used as an idempotency key when the server mints a new API key. Sending it on sessions that already have a key would be meaningless noise and could confuse future readers of the URL-building logic. Keeping it paired with `generate_api_key=true` makes the intent self-documenting and avoids any risk of the server misinterpreting the param in a non-creation context.
- **Minimal diff discipline — no opportunistic refactoring**: During implementation, a variable in the VSCode auth service was reformatted to align two adjacent conditional expressions. This was explicitly rejected as out of scope and reverted to the smallest possible addition, preserving the principle that each commit should be auditable for exactly its stated purpose and avoiding unrelated diffs that complicate review or bisect.
- **CLI and VSCode updated together, IntelliJ deferred**: Both the CLI login flow and the VSCode auth service send this parameter, so both had to be updated together to stay consistent. The IntelliJ plugin was not changed because it was not yet confirmed to send this parameter at all, making it a separate follow-up.

**✅ What Was Implemented**

- Created `cli/src/auth/DeviceLabel.ts` with two exported functions: `sanitizeDeviceLabel` (trims input, strips characters outside `[A-Za-z0-9 _.-]`, truncates to 32 characters, returns `undefined` for empty results) and `getDeviceLabel` (wraps `os.hostname()` through the sanitizer). Sanitization rules mirror the server's implementation exactly so a hostname passing client-side validation is guaranteed to pass server-side validation without silent truncation or mismatch.
- Updated `cli/src/auth/Login.ts` and `vscode/src/services/AuthService.ts` to call `getDeviceLabel()` and append `device_name=<encoded>` to the login URL, but only when the client is also requesting a new API key. When a key already exists, neither `generate_api_key` nor `device_name` appears on the URL, preserving the existing no-op path for already-authenticated sessions.
- Updated the doc-comment in `cli/src/auth/DeviceLabel.ts` to reference the correct wire parameter name (`device_name`). All test descriptions and assertions in `cli/src/auth/Login.test.ts` and `vscode/src/services/AuthService.test.ts` were updated to match.

**📋 Future Enhancements**

- The VSCode plugin's own login URL construction in its separate repository has not yet been updated to call the equivalent of `getDeviceLabel()` and append the parameter. The server and shared helper are ready; multi-device usage will work end-to-end for plugin users once that follow-up change lands.
- The CLI tool in `tools/jollimemory` is off-limits for this change and will need a separate PR once that restriction is lifted.

**📁 FILES**
- `cli/src/auth/DeviceLabel.ts`
- `cli/src/auth/Login.ts`
- `vscode/src/services/AuthService.ts`

</blockquote>
</details>

---

<!-- jollimemory-summary-end -->