### PR TITLE
Add Cursor IDE as transcript source and surface SQLite scan errors

### DIFF
--- a/intellij/build.gradle.kts
+++ b/intellij/build.gradle.kts
@@ -33,7 +33,7 @@ dependencies {
     // The standalone hooks JAR bundles its own copies via the hooksRuntime configuration.
     compileOnly("com.google.code.gson:gson:2.12.1")
     compileOnly("org.jetbrains.kotlin:kotlin-stdlib")
-    compileOnly("org.xerial:sqlite-jdbc:3.49.1.0")
+    implementation("org.xerial:sqlite-jdbc:3.49.1.0")
     hooksRuntime("com.google.code.gson:gson:2.12.1")
     hooksRuntime("org.jetbrains.kotlin:kotlin-stdlib:2.1.20")
     hooksRuntime("org.xerial:sqlite-jdbc:3.49.1.0")
@@ -41,6 +41,7 @@ dependencies {
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
     testImplementation("io.mockk:mockk:1.13.16")
     testImplementation("io.kotest:kotest-assertions-core:5.9.1")
+    testImplementation("org.xerial:sqlite-jdbc:3.49.1.0")
 }
 
 intellijPlatform {

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/bridge/SummaryReader.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/bridge/SummaryReader.kt
@@ -2,6 +2,7 @@ package ai.jolli.jollimemory.bridge
 
 import ai.jolli.jollimemory.core.CodexSessionDiscoverer
 import ai.jolli.jollimemory.core.CommitSummary
+import ai.jolli.jollimemory.core.CursorSupport
 import ai.jolli.jollimemory.core.GeminiSupport
 import ai.jolli.jollimemory.core.JmLogger
 import ai.jolli.jollimemory.core.OpenCodeSupport
@@ -30,6 +31,15 @@ class SummaryReader(private val projectDir: String, private val git: GitOps) {
         val branchExists = git.branchExists(ORPHAN_BRANCH)
         val summaryCount = if (branchExists) countSummaries() else 0
 
+        // Lightweight DB health checks — no full scan, just open + trivial query
+        val openCodeInstalled = OpenCodeSupport.isOpenCodeInstalled()
+        val openCodeError = if (openCodeInstalled && config.openCodeEnabled != false)
+            OpenCodeSupport.checkDbHealth() else null
+
+        val cursorInstalled = CursorSupport.isCursorInstalled()
+        val cursorError = if (cursorInstalled && config.cursorEnabled != false)
+            CursorSupport.checkDbHealth() else null
+
         return StatusInfo(
             enabled = hooksInstalled,
             claudeHookInstalled = installer.isClaudeHookInstalled(),
@@ -45,8 +55,12 @@ class SummaryReader(private val projectDir: String, private val git: GitOps) {
             codexEnabled = config.codexEnabled,
             geminiDetected = GeminiSupport.isGeminiInstalled(),
             geminiEnabled = config.geminiEnabled,
-            openCodeDetected = OpenCodeSupport.isOpenCodeInstalled(),
+            openCodeDetected = openCodeInstalled,
             openCodeEnabled = config.openCodeEnabled,
+            openCodeScanError = openCodeError,
+            cursorDetected = cursorInstalled,
+            cursorEnabled = config.cursorEnabled,
+            cursorScanError = cursorError,
         )
     }
 

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/core/CursorSupport.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/core/CursorSupport.kt
@@ -1,0 +1,409 @@
+package ai.jolli.jollimemory.core
+
+import com.google.gson.JsonParser
+import java.io.File
+import java.net.URI
+import java.nio.file.Paths
+import java.time.Instant
+
+/**
+ * Cursor Support — session discovery and transcript reading for Cursor's
+ * Composer AI agent.
+ *
+ * Cursor stores all Composer conversations in a *global* SQLite database at:
+ *   ~/Library/Application Support/Cursor/User/globalStorage/state.vscdb  (macOS)
+ *   ~/.config/Cursor/User/globalStorage/state.vscdb                      (Linux)
+ *   %APPDATA%/Cursor/User/globalStorage/state.vscdb                      (Windows)
+ *
+ * Rows in the `cursorDiskKV` table are JSON BLOBs keyed by:
+ *   composerData:<composerId>        — full composer metadata + bubble headers
+ *   bubbleId:<composerId>:<bubbleId> — individual message blobs
+ *
+ * There is NO authoritative "this composer belongs to this workspace" pointer in
+ * the global DB. Per-workspace `state.vscdb` files (under
+ * User/workspaceStorage/<wsHash>/) DO contain a `composer.composerData` row in
+ * their `ItemTable` with `lastFocusedComposerIds` and `selectedComposerIds`.
+ *
+ * Attribution algorithm (anchor-only with staleness cutoff):
+ *   1. Workspace lookup — scan each <wsHash>/workspace.json for a `folder` URI
+ *      that resolves to projectDir. Stop at the first match.
+ *   2. Anchor extraction — read the per-workspace state.vscdb and union the two
+ *      pointer arrays (`lastFocusedComposerIds` + `selectedComposerIds`).
+ *   3. Filter — include only anchored composers whose `lastUpdatedAt` is within
+ *      the last 48 h. Non-anchored composers are never included, preventing
+ *      cross-project transcript contamination on multi-repo machines.
+ *
+ * Synthetic transcript path: "<globalDbPath>#<composerId>" (matches OpenCode).
+ *
+ * Kotlin port of `cli/src/core/{CursorDetector,CursorSessionDiscoverer,CursorTranscriptReader,VscodeWorkspaceLocator}.ts`.
+ */
+object CursorSupport {
+
+	private val log = JmLogger.create("CursorSupport")
+
+	/** Sessions older than 48 hours are considered stale (matches other sources). */
+	private const val SESSION_STALE_MS = 48 * 60 * 60 * 1000L
+
+	/** Cursor bubble.type → transcript role. Other values (system messages, tool calls) are skipped. */
+	private val BUBBLE_TYPE_TO_ROLE = mapOf(1 to "human", 2 to "assistant")
+
+	/** Returns the user-data root for Cursor on the current platform. */
+	private fun getUserDataDir(): String {
+		val home = System.getProperty("user.home")
+		val osName = System.getProperty("os.name").lowercase()
+		return when {
+			osName.contains("mac") ->
+				home + File.separator + "Library" + File.separator + "Application Support" + File.separator + "Cursor"
+			osName.contains("win") ->
+				(System.getenv("APPDATA") ?: (home + File.separator + "AppData" + File.separator + "Roaming")) +
+					File.separator + "Cursor"
+			else ->
+				home + File.separator + ".config" + File.separator + "Cursor"
+		}
+	}
+
+	/** Returns the path to Cursor's global SQLite database. */
+	fun getGlobalDbPath(): String =
+		getUserDataDir() + File.separator + "User" + File.separator + "globalStorage" + File.separator + "state.vscdb"
+
+	/** Returns the workspaceStorage directory containing per-workspace state.vscdb files. */
+	private fun getWorkspaceStorageDir(): String =
+		getUserDataDir() + File.separator + "User" + File.separator + "workspaceStorage"
+
+	/** Checks whether Cursor's global database file exists. */
+	fun isCursorInstalled(): Boolean {
+		val dbPath = getGlobalDbPath()
+		val exists = File(dbPath).isFile
+		return exists
+	}
+
+	/**
+	 * Lightweight DB health check — opens the database and runs a trivial query
+	 * to detect locked/corrupt/permission errors without scanning all rows.
+	 */
+	fun checkDbHealth(): SqliteScanError? {
+		val dbPath = getGlobalDbPath()
+		if (!File(dbPath).isFile) return null
+		return try {
+			withReadOnlyDb(dbPath) { conn ->
+				conn.prepareStatement("SELECT 1 FROM cursorDiskKV LIMIT 1").use { it.executeQuery() }
+			}
+			null
+		} catch (e: Exception) {
+			classifyScanError(e)
+		}
+	}
+
+	/**
+	 * Discovers Cursor Composer sessions relevant to the given project directory.
+	 * Uses the anchor-only algorithm with staleness cutoff; see class kdoc for details.
+	 */
+	fun discoverSessions(projectDir: String): ScanResult {
+		val globalDbPath = getGlobalDbPath()
+		val globalDbFile = File(globalDbPath)
+		if (!globalDbFile.isFile) return ScanResult(emptyList())
+
+		// Step 1: Workspace lookup
+		val wsHash = findWorkspaceHash(projectDir)
+		if (wsHash == null) {
+			log.debug("No Cursor workspace found matching %s", projectDir)
+			return ScanResult(emptyList())
+		}
+
+		// Step 2: Anchor extraction (never throws — workspace-level failure degrades gracefully)
+		val anchorIds = readAnchorComposerIds(wsHash)
+		val anchorSet = anchorIds.toHashSet()
+
+		// Step 3 + 4: Time-window scan + union/dedupe on the global DB
+		val cutoffMs = System.currentTimeMillis() - SESSION_STALE_MS
+
+		return try {
+			withReadOnlyDb(globalDbPath) { conn ->
+				val sessions = mutableListOf<SessionInfo>()
+				val seenIds = HashSet<String>()
+
+				conn.prepareStatement("SELECT key, value FROM cursorDiskKV WHERE key LIKE 'composerData:%'").use { stmt ->
+					val rs = stmt.executeQuery()
+					while (rs.next()) {
+						val key = rs.getString("key")
+						val value = rs.getString("value") ?: continue
+
+						val parsed = try {
+							JsonParser.parseString(value).asJsonObject
+						} catch (_: Exception) {
+							log.warn("Skipping Cursor composer row %s: invalid JSON", key)
+							continue
+						}
+
+						val composerId = parsed.get("composerId")?.takeIf { it.isJsonPrimitive }?.asString
+						if (composerId == null) {
+							log.warn("Skipping Cursor composer row %s: missing composerId", key)
+							continue
+						}
+
+						val lastUpdatedAtElem = parsed.get("lastUpdatedAt")
+						val lastUpdatedAt = if (lastUpdatedAtElem?.isJsonPrimitive == true &&
+							lastUpdatedAtElem.asJsonPrimitive.isNumber
+						) {
+							lastUpdatedAtElem.asDouble.let { if (it.isFinite()) it.toLong() else null }
+						} else null
+
+						if (lastUpdatedAt == null) {
+							if (anchorSet.contains(composerId)) {
+								log.warn("Skipping Cursor composer %s: non-finite lastUpdatedAt", composerId)
+							}
+							continue
+						}
+
+						if (!anchorSet.contains(composerId)) continue
+						if (lastUpdatedAt < cutoffMs) continue
+
+						if (!seenIds.add(composerId)) continue
+
+						sessions.add(SessionInfo(
+							sessionId = composerId,
+							transcriptPath = "$globalDbPath#$composerId",
+							updatedAt = Instant.ofEpochMilli(lastUpdatedAt).toString(),
+							source = TranscriptSource.cursor,
+						))
+					}
+				}
+
+				log.info("Discovered %d Cursor session(s) for %s", sessions.size, projectDir)
+				ScanResult(sessions)
+			}
+		} catch (e: Exception) {
+			val scanError = classifyScanError(e)
+			log.error("Cursor scan failed (%s): %s", scanError.kind, scanError.message)
+			ScanResult(emptyList(), scanError)
+		}
+	}
+
+	/**
+	 * Reads messages from a Cursor Composer session and returns parsed transcript entries.
+	 * Supports cursor-based resumption: `cursor.lineNumber` tracks the count of bubbles
+	 * already processed.
+	 *
+	 * @param transcriptPath synthetic path: "<dbPath>#<composerId>"
+	 * @param cursor optional cursor indicating how many bubbles were already processed
+	 * @param beforeTimestamp optional ISO 8601 cutoff for commit attribution
+	 */
+	fun readTranscript(
+		transcriptPath: String,
+		cursor: TranscriptCursor?,
+		beforeTimestamp: String? = null,
+	): TranscriptReadResult {
+		val (dbPath, composerId) = parseSyntheticPath(transcriptPath)
+		val startIndex = cursor?.lineNumber ?: 0
+		val cutoffTime = beforeTimestamp?.let { Instant.parse(it).toEpochMilli() }
+
+		try {
+			return withReadOnlyDb(dbPath) { conn ->
+				// Load the composer index — fullConversationHeadersOnly is an ordered list of bubbles
+				val composerJson = conn.prepareStatement(
+					"SELECT value FROM cursorDiskKV WHERE key = ? LIMIT 1"
+				).use { stmt ->
+					stmt.setString(1, "composerData:$composerId")
+					val rs = stmt.executeQuery()
+					if (rs.next()) rs.getString("value") else null
+				} ?: throw RuntimeException("Composer $composerId not found in database")
+
+				val composer = try {
+					JsonParser.parseString(composerJson).asJsonObject
+				} catch (_: Exception) {
+					throw RuntimeException("Failed to parse composerData JSON for $composerId")
+				}
+
+				val headers = composer.getAsJsonArray("fullConversationHeadersOnly") ?: com.google.gson.JsonArray()
+				val totalBubbles = headers.size()
+
+				val rawEntries = mutableListOf<TranscriptEntry>()
+				var lastConsumedIndex = startIndex
+				var stoppedAtCutoff = false
+
+				val bubbleStmt = conn.prepareStatement("SELECT value FROM cursorDiskKV WHERE key = ? LIMIT 1")
+				bubbleStmt.use { stmt ->
+					for (i in startIndex until totalBubbles) {
+						if (stoppedAtCutoff) break
+						val headerElem = headers.get(i)
+						if (headerElem == null || !headerElem.isJsonObject) {
+							lastConsumedIndex = i + 1
+							continue
+						}
+						val header = headerElem.asJsonObject
+						val bubbleId = header.get("bubbleId")?.takeIf { it.isJsonPrimitive }?.asString
+						val headerType = header.get("type")?.takeIf {
+							it.isJsonPrimitive && it.asJsonPrimitive.isNumber
+						}?.asInt
+
+						if (bubbleId == null) {
+							lastConsumedIndex = i + 1
+							continue
+						}
+
+						stmt.clearParameters()
+						stmt.setString(1, "bubbleId:$composerId:$bubbleId")
+						val rs = stmt.executeQuery()
+						val bubbleJson = if (rs.next()) rs.getString("value") else null
+						if (bubbleJson == null) {
+							// Bubble missing — advance index but produce no entry
+							lastConsumedIndex = i + 1
+							continue
+						}
+
+						val bubble = try {
+							JsonParser.parseString(bubbleJson).asJsonObject
+						} catch (_: Exception) {
+							log.debug("Failed to parse bubble JSON for %s:%s", composerId, bubbleId)
+							lastConsumedIndex = i + 1
+							continue
+						}
+
+						val timestamp = bubble.get("createdAt")?.takeIf { it.isJsonPrimitive }?.asString
+
+						if (cutoffTime != null && timestamp != null) {
+							val bubbleTime = try { Instant.parse(timestamp).toEpochMilli() } catch (_: Exception) { null }
+							if (bubbleTime != null && bubbleTime > cutoffTime) {
+								stoppedAtCutoff = true
+								continue
+							}
+						}
+
+						val bubbleType = bubble.get("type")?.takeIf {
+							it.isJsonPrimitive && it.asJsonPrimitive.isNumber
+						}?.asInt ?: headerType
+						val role = bubbleType?.let { BUBBLE_TYPE_TO_ROLE[it] }
+						val text = bubble.get("text")?.takeIf { it.isJsonPrimitive }?.asString?.trim() ?: ""
+
+						if (role != null && text.isNotEmpty()) {
+							rawEntries.add(TranscriptEntry(role, text, timestamp))
+						}
+
+						lastConsumedIndex = i + 1
+					}
+				}
+
+				val entries = TranscriptReader.mergeConsecutiveEntries(rawEntries)
+
+				// When beforeTimestamp is set, advance cursor only to the last consumed bubble.
+				// Without beforeTimestamp, advance to end for backward compatibility.
+				val newCursor = TranscriptCursor(
+					transcriptPath = transcriptPath,
+					lineNumber = if (beforeTimestamp != null) lastConsumedIndex else totalBubbles,
+					updatedAt = Instant.now().toString(),
+				)
+
+				val totalLinesRead = lastConsumedIndex - startIndex
+				log.info(
+					"Read Cursor session %s: %d new bubbles, %d entries extracted (index %d→%d)",
+					composerId.take(8), totalLinesRead, entries.size, startIndex, newCursor.lineNumber,
+				)
+
+				TranscriptReadResult(entries, newCursor, totalLinesRead)
+			}
+		} catch (e: Exception) {
+			log.error("Failed to read Cursor session %s: %s", composerId.take(8), e.message)
+			throw RuntimeException("Cannot read Cursor session: $composerId")
+		}
+	}
+
+	// ── Internal helpers ─────────────────────────────────────────────────────
+
+	/**
+	 * Scans workspaceStorage for an entry whose `workspace.json` has a `folder`
+	 * URI resolving to projectDir. Returns the workspace hash on match, null otherwise.
+	 * Single-folder workspaces only — multi-root `.code-workspace` files are skipped.
+	 */
+	private fun findWorkspaceHash(projectDir: String): String? {
+		val wsStorageDir = File(getWorkspaceStorageDir())
+		if (!wsStorageDir.isDirectory) {
+			log.debug("Cursor workspaceStorage not readable at %s", wsStorageDir.path)
+			return null
+		}
+
+		val target = normalizePathForMatch(projectDir)
+		val entries = wsStorageDir.listFiles() ?: return null
+
+		for (entry in entries) {
+			val wsJson = File(entry, "workspace.json")
+			if (!wsJson.isFile) continue
+
+			val folderUri = try {
+				JsonParser.parseString(wsJson.readText()).asJsonObject
+					.get("folder")?.takeIf { it.isJsonPrimitive }?.asString
+			} catch (_: Exception) {
+				continue
+			} ?: continue
+
+			if (!folderUri.startsWith("file://")) continue
+
+			val folderPath = try {
+				Paths.get(URI(folderUri)).toString()
+			} catch (_: Exception) {
+				log.warn("Cursor workspace %s has unparseable folder URI: %s", entry.name, folderUri)
+				continue
+			}
+
+			if (normalizePathForMatch(folderPath) == target) {
+				return entry.name
+			}
+		}
+		return null
+	}
+
+	/**
+	 * Reads the per-workspace state.vscdb and extracts anchor composer IDs from the
+	 * `composer.composerData` row in ItemTable. Returns an empty list on any failure —
+	 * workspace-level errors do NOT abort the broader scan.
+	 */
+	private fun readAnchorComposerIds(wsHash: String): List<String> {
+		val wsDbPath = getWorkspaceStorageDir() + File.separator + wsHash + File.separator + "state.vscdb"
+		if (!File(wsDbPath).isFile) {
+			log.debug("Cursor workspace DB not found at %s — skipping anchor extraction", wsDbPath)
+			return emptyList()
+		}
+
+		return try {
+			withReadOnlyDb(wsDbPath) { conn ->
+				val value = conn.prepareStatement(
+					"SELECT value FROM ItemTable WHERE key = 'composer.composerData' LIMIT 1"
+				).use { stmt ->
+					val rs = stmt.executeQuery()
+					if (rs.next()) rs.getString("value") else null
+				} ?: return@withReadOnlyDb emptyList()
+
+				val parsed = try {
+					JsonParser.parseString(value).asJsonObject
+				} catch (_: Exception) {
+					log.warn("Cursor workspace %s composer.composerData is not valid JSON", wsHash)
+					return@withReadOnlyDb emptyList()
+				}
+
+				val lastFocused = parsed.getAsJsonArray("lastFocusedComposerIds")?.mapNotNull {
+					it.takeIf(com.google.gson.JsonElement::isJsonPrimitive)?.asString
+				}.orEmpty()
+				val selected = parsed.getAsJsonArray("selectedComposerIds")?.mapNotNull {
+					it.takeIf(com.google.gson.JsonElement::isJsonPrimitive)?.asString
+				}.orEmpty()
+
+				(lastFocused + selected).distinct()
+			}
+		} catch (e: Exception) {
+			log.warn("Failed to read Cursor workspace anchor IDs from %s: %s", wsDbPath, e.message)
+			emptyList()
+		}
+	}
+
+	/**
+	 * Normalises a filesystem path for workspace matching:
+	 *   - Backslashes → forward slashes (Windows path comparison)
+	 *   - Strip trailing slashes
+	 *   - Lowercase on macOS and Windows (case-insensitive filesystems)
+	 */
+	private fun normalizePathForMatch(p: String): String {
+		val fwd = p.replace('\\', '/')
+		val trimmed = fwd.trimEnd('/')
+		val osName = System.getProperty("os.name").lowercase()
+		return if (osName.contains("mac") || osName.contains("win")) trimmed.lowercase() else trimmed
+	}
+}

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/core/OpenCodeSupport.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/core/OpenCodeSupport.kt
@@ -2,7 +2,6 @@ package ai.jolli.jollimemory.core
 
 import com.google.gson.JsonParser
 import java.io.File
-import java.sql.DriverManager
 import java.time.Instant
 
 /**
@@ -31,17 +30,36 @@ object OpenCodeSupport {
 
 	/** Checks whether the OpenCode database exists. */
 	fun isOpenCodeInstalled(): Boolean {
-		return File(getDbPath()).isFile
+		val dbPath = getDbPath()
+		val exists = File(dbPath).isFile
+		return exists
+	}
+
+	/**
+	 * Lightweight DB health check — opens the database and runs a trivial query
+	 * to detect locked/corrupt/permission errors without scanning all rows.
+	 */
+	fun checkDbHealth(): SqliteScanError? {
+		val dbPath = getDbPath()
+		if (!File(dbPath).isFile) return null
+		return try {
+			withReadOnlyDb(dbPath) { conn ->
+				conn.prepareStatement("SELECT 1 FROM session LIMIT 1").use { it.executeQuery() }
+			}
+			null
+		} catch (e: Exception) {
+			classifyScanError(e)
+		}
 	}
 
 	/**
 	 * Discovers OpenCode sessions relevant to the given project directory.
 	 * Queries the global DB for recent sessions (within 48h) matching projectDir.
 	 */
-	fun discoverSessions(projectDir: String): List<SessionInfo> {
+	fun discoverSessions(projectDir: String): ScanResult {
 		val dbPath = getDbPath()
 		val dbFile = File(dbPath)
-		if (!dbFile.isFile) return emptyList()
+		if (!dbFile.isFile) return ScanResult(emptyList())
 
 		val cutoffMs = System.currentTimeMillis() - SESSION_STALE_MS
 		val isWindows = System.getProperty("os.name").lowercase().contains("win")
@@ -77,11 +95,12 @@ object OpenCodeSupport {
 					}
 				}
 				log.info("Discovered %d OpenCode session(s) for %s", sessions.size, projectDir)
-				sessions
+				ScanResult(sessions)
 			}
 		} catch (e: Exception) {
-			log.error("OpenCode scan failed: %s", e.message)
-			emptyList()
+			val scanError = classifyScanError(e)
+			log.error("OpenCode scan failed (%s): %s", scanError.kind, scanError.message)
+			ScanResult(emptyList(), scanError)
 		}
 	}
 
@@ -191,32 +210,6 @@ object OpenCodeSupport {
 		val timeCreated: Long,
 		val parts: List<String>,
 	)
-
-	/**
-	 * Opens a read-only JDBC connection to the SQLite database, runs the callback,
-	 * and closes the connection.
-	 */
-	private fun <T> withReadOnlyDb(dbPath: String, block: (java.sql.Connection) -> T): T {
-		val url = "jdbc:sqlite:file:$dbPath?mode=ro"
-		val conn = DriverManager.getConnection(url)
-		return try {
-			block(conn)
-		} finally {
-			conn.close()
-		}
-	}
-
-	/**
-	 * Parses a synthetic transcript path into its DB path and session ID components.
-	 * Format: "<dbPath>#<sessionId>"
-	 */
-	private fun parseSyntheticPath(transcriptPath: String): Pair<String, String> {
-		val hashIndex = transcriptPath.lastIndexOf('#')
-		if (hashIndex == -1 || hashIndex == 0 || hashIndex == transcriptPath.length - 1) {
-			throw IllegalArgumentException("Invalid OpenCode transcript path: $transcriptPath")
-		}
-		return Pair(transcriptPath.substring(0, hashIndex), transcriptPath.substring(hashIndex + 1))
-	}
 
 	/**
 	 * Parses a single OpenCode message into a TranscriptEntry.

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/core/SqliteHelpers.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/core/SqliteHelpers.kt
@@ -1,0 +1,110 @@
+package ai.jolli.jollimemory.core
+
+import org.sqlite.SQLiteException
+import java.nio.file.AccessDeniedException
+import java.sql.Connection
+import java.sql.DriverManager
+
+/**
+ * SQLite Helpers — shared utilities for SQLite-backed transcript sources
+ * (OpenCode, Cursor). Extracted from per-agent modules so additional agents
+ * don't end up importing from a file named for an unrelated one.
+ *
+ * Kotlin port of `cli/src/core/SqliteHelpers.ts`.
+ */
+
+/**
+ * Opens a read-only JDBC connection to the SQLite database, runs the callback,
+ * and closes the connection. Connection is always closed even if the block throws.
+ */
+fun <T> withReadOnlyDb(dbPath: String, block: (Connection) -> T): T {
+	// Explicitly load the SQLite JDBC driver — IntelliJ's plugin classloader
+	// doesn't pick up META-INF/services/java.sql.Driver auto-registration.
+	Class.forName("org.sqlite.JDBC")
+	val url = "jdbc:sqlite:file:$dbPath?mode=ro"
+	val conn = DriverManager.getConnection(url)
+	return try {
+		block(conn)
+	} finally {
+		conn.close()
+	}
+}
+
+/**
+ * Parses a synthetic transcript path "<dbPath>#<sessionId>" into its components.
+ * Used by SQLite-backed sources where all sessions share one DB file; the
+ * sessionId suffix gives each session its own cursor-registry key without
+ * changing the cursors.json schema.
+ *
+ * Assumes session IDs never contain '#' (true for Cursor UUIDs and OpenCode ULIDs).
+ */
+fun parseSyntheticPath(transcriptPath: String): Pair<String, String> {
+	val hashIndex = transcriptPath.lastIndexOf('#')
+	if (hashIndex == -1 || hashIndex == 0 || hashIndex == transcriptPath.length - 1) {
+		throw IllegalArgumentException("Invalid synthetic transcript path: $transcriptPath")
+	}
+	return Pair(transcriptPath.substring(0, hashIndex), transcriptPath.substring(hashIndex + 1))
+}
+
+/**
+ * Severity classification for SQLite scan failures, surfaced to the Status panel
+ * so users can distinguish a real failure from "zero sessions today".
+ *
+ * - `corrupt`    — SQLITE_CORRUPT / SQLITE_NOTADB. DB file unreadable.
+ * - `locked`     — SQLITE_BUSY / SQLITE_LOCKED. Another process holds the lock
+ *                  (Cursor itself is the usual culprit while it's running).
+ * - `permission` — SQLITE_PERM / SQLITE_AUTH / SQLITE_CANTOPEN / file ACL denial.
+ * - `schema`     — expected table or column missing. Likely upstream schema drift.
+ * - `unknown`    — everything else; surface as a generic scan-failed warning.
+ */
+enum class SqliteScanErrorKind { corrupt, locked, permission, schema, unknown }
+
+data class SqliteScanError(val kind: SqliteScanErrorKind, val message: String)
+
+/**
+ * Result of a session-discovery scan. [sessions] is empty when [error] is non-null
+ * (real failure) and also when the scan succeeded but found nothing (legitimate
+ * empty). UI inspects [error] to distinguish the two.
+ */
+data class ScanResult(val sessions: List<SessionInfo>, val error: SqliteScanError? = null)
+
+/**
+ * Maps a thrown error from a SQLite scan to a [SqliteScanError]. Prefers the
+ * structured `resultCode` from xerial sqlite-jdbc; falls back to message
+ * pattern-matching for wrapped or non-SQLiteException failures.
+ */
+fun classifyScanError(error: Throwable): SqliteScanError {
+	val message = error.message ?: error::class.java.simpleName
+
+	if (error is AccessDeniedException) {
+		return SqliteScanError(SqliteScanErrorKind.permission, message)
+	}
+	if (error is SQLiteException) {
+		val code = error.resultCode?.name ?: ""
+		when {
+			code.startsWith("SQLITE_CORRUPT") || code.startsWith("SQLITE_NOTADB") ->
+				return SqliteScanError(SqliteScanErrorKind.corrupt, message)
+			code.startsWith("SQLITE_BUSY") || code.startsWith("SQLITE_LOCKED") ->
+				return SqliteScanError(SqliteScanErrorKind.locked, message)
+			code.startsWith("SQLITE_PERM") || code.startsWith("SQLITE_AUTH") || code.startsWith("SQLITE_CANTOPEN") ->
+				return SqliteScanError(SqliteScanErrorKind.permission, message)
+		}
+		if (message.contains("no such table", ignoreCase = true) ||
+			message.contains("no such column", ignoreCase = true)
+		) {
+			return SqliteScanError(SqliteScanErrorKind.schema, message)
+		}
+	}
+
+	return when {
+		Regex("SQLITE_CORRUPT|SQLITE_NOTADB|file is not a database", RegexOption.IGNORE_CASE).containsMatchIn(message) ->
+			SqliteScanError(SqliteScanErrorKind.corrupt, message)
+		Regex("SQLITE_BUSY|SQLITE_LOCKED|database is locked", RegexOption.IGNORE_CASE).containsMatchIn(message) ->
+			SqliteScanError(SqliteScanErrorKind.locked, message)
+		Regex("no such table|no such column", RegexOption.IGNORE_CASE).containsMatchIn(message) ->
+			SqliteScanError(SqliteScanErrorKind.schema, message)
+		Regex("SQLITE_CANTOPEN|SQLITE_PERM|SQLITE_AUTH|unable to open|permission denied|access is denied", RegexOption.IGNORE_CASE).containsMatchIn(message) ->
+			SqliteScanError(SqliteScanErrorKind.permission, message)
+		else -> SqliteScanError(SqliteScanErrorKind.unknown, message)
+	}
+}

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/core/TranscriptParsers.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/core/TranscriptParsers.kt
@@ -56,5 +56,6 @@ fun getParserForSource(source: TranscriptSource): TranscriptParser {
         TranscriptSource.claude -> ClaudeTranscriptParser()
         TranscriptSource.gemini -> ClaudeTranscriptParser() // Gemini uses dedicated reader
         TranscriptSource.opencode -> ClaudeTranscriptParser() // OpenCode uses dedicated reader
+        TranscriptSource.cursor -> ClaudeTranscriptParser() // Cursor uses dedicated reader
     }
 }

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/core/TranscriptReader.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/core/TranscriptReader.kt
@@ -241,6 +241,7 @@ object TranscriptReader {
         val sessionId: String,
         val transcriptPath: String,
         val entries: List<TranscriptEntry>,
+        val source: TranscriptSource? = null,
     )
 }
 

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/core/Types.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/core/Types.kt
@@ -7,7 +7,7 @@ package ai.jolli.jollimemory.core
  */
 
 /** Which AI coding agent produced the transcript */
-enum class TranscriptSource { claude, codex, gemini, opencode }
+enum class TranscriptSource { claude, codex, gemini, opencode, cursor }
 
 /** Metadata about an AI coding session */
 data class SessionInfo(
@@ -292,6 +292,7 @@ data class JolliMemoryConfig(
     val codexEnabled: Boolean? = null,
     val geminiEnabled: Boolean? = null,
     val openCodeEnabled: Boolean? = null,
+    val cursorEnabled: Boolean? = null,
     /** AI summarization provider: "jolli" (proxy) or "anthropic" (direct). null defers to legacy "Anthropic wins" routing. */
     val aiProvider: String? = null,
     val logLevel: String? = null,
@@ -370,6 +371,10 @@ data class StatusInfo(
     val geminiEnabled: Boolean? = null,
     val openCodeDetected: Boolean? = null,
     val openCodeEnabled: Boolean? = null,
+    val openCodeScanError: SqliteScanError? = null,
+    val cursorDetected: Boolean? = null,
+    val cursorEnabled: Boolean? = null,
+    val cursorScanError: SqliteScanError? = null,
 )
 
 /** Log levels */

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/hooks/PostCommitHook.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/hooks/PostCommitHook.kt
@@ -155,11 +155,17 @@ object PostCommitHook {
 
             // On-demand discovery: OpenCode (SQLite-backed, no hook)
             if (config.openCodeEnabled != false && OpenCodeSupport.isOpenCodeInstalled()) {
-                allSessions.addAll(OpenCodeSupport.discoverSessions(cwd))
+                allSessions.addAll(OpenCodeSupport.discoverSessions(cwd).sessions)
+            }
+
+            // On-demand discovery: Cursor (SQLite-backed, no hook)
+            if (config.cursorEnabled != false && CursorSupport.isCursorInstalled()) {
+                allSessions.addAll(CursorSupport.discoverSessions(cwd).sessions)
             }
 
             val sessions = allSessions
-            log.info("Total sessions found: %d", sessions.size)
+            log.info("Discovered %d session(s): %s", sessions.size,
+                sessions.joinToString(", ") { "${it.source ?: "claude"}:${it.sessionId.take(8)}" })
             if (sessions.isEmpty()) {
                 log.info("No active sessions — skipping summarization")
                 return
@@ -171,30 +177,51 @@ object PostCommitHook {
 
             for (session in sessions) {
                 val source = session.source ?: TranscriptSource.claude
-                val cursor = SessionTracker.loadCursorForTranscript(session.transcriptPath, cwd)
+                try {
+                    val cursor = SessionTracker.loadCursorForTranscript(session.transcriptPath, cwd)
+                    log.info("Reading session %s source=%s cursor=%s",
+                        session.sessionId.take(8), source, cursor?.lineNumber ?: "none")
 
-                val result = when (source) {
-                    TranscriptSource.gemini -> {
-                        val entries = GeminiSupport.readGeminiTranscript(session.transcriptPath)
-                        TranscriptReadResult(entries, TranscriptCursor(session.transcriptPath, entries.size, Instant.now().toString()), entries.size)
+                    val result = when (source) {
+                        TranscriptSource.gemini -> {
+                            val entries = GeminiSupport.readGeminiTranscript(session.transcriptPath)
+                            TranscriptReadResult(entries, TranscriptCursor(session.transcriptPath, entries.size, Instant.now().toString()), entries.size)
+                        }
+                        TranscriptSource.opencode -> {
+                            OpenCodeSupport.readTranscript(session.transcriptPath, cursor, commitInfo.date)
+                        }
+                        TranscriptSource.cursor -> {
+                            CursorSupport.readTranscript(session.transcriptPath, cursor, commitInfo.date)
+                        }
+                        else -> {
+                            val parser = getParserForSource(source)
+                            TranscriptReader.readTranscript(session.transcriptPath, cursor, parser)
+                        }
                     }
-                    TranscriptSource.opencode -> {
-                        OpenCodeSupport.readTranscript(session.transcriptPath, cursor)
-                    }
-                    else -> {
-                        val parser = getParserForSource(source)
-                        TranscriptReader.readTranscript(session.transcriptPath, cursor, parser)
-                    }
-                }
 
-                if (result.entries.isNotEmpty()) {
-                    sessionTranscripts.add(TranscriptReader.SessionTranscript(
-                        session.sessionId, session.transcriptPath, result.entries
-                    ))
+                    log.info("Session %s (%s): %d entries, %d lines read",
+                        session.sessionId.take(8), source, result.entries.size, result.totalLinesRead)
+                    for ((idx, entry) in result.entries.take(3).withIndex()) {
+                        val snippet = entry.content.take(120).replace("\n", " ")
+                        log.info("  entry[%d] role=%s: %s%s", idx, entry.role, snippet,
+                            if (entry.content.length > 120) "..." else "")
+                    }
+                    if (result.entries.size > 3) {
+                        log.info("  ...and %d more entries", result.entries.size - 3)
+                    }
+
+                    if (result.entries.isNotEmpty()) {
+                        sessionTranscripts.add(TranscriptReader.SessionTranscript(
+                            session.sessionId, session.transcriptPath, result.entries, source
+                        ))
+                    }
+                    totalEntries += result.totalLinesRead
+                    totalTurns += result.entries.count { it.role == "human" }
+                    SessionTracker.saveCursor(result.newCursor, cwd)
+                } catch (e: Exception) {
+                    log.warn("Failed to read transcript for session %s (%s), skipping: %s",
+                        session.sessionId.take(8), source, e.message ?: e.toString())
                 }
-                totalEntries += result.totalLinesRead
-                totalTurns += result.entries.count { it.role == "human" }
-                SessionTracker.saveCursor(result.newCursor, cwd)
             }
 
             // 5. Get diff
@@ -310,9 +337,11 @@ object PostCommitHook {
 
             // Store transcript data alongside summary
             val storedSessions = sessionTranscripts.map { st ->
-                StoredSession(st.sessionId, entries = st.entries)
+                log.info("StoredSession: sessionId=%s, source=%s, entries=%d", st.sessionId.take(8), st.source, st.entries.size)
+                StoredSession(st.sessionId, source = st.source, entries = st.entries)
             }
             val storedTranscript = StoredTranscript(storedSessions)
+            log.info("StoredTranscript: %d session(s) total", storedSessions.size)
 
             log.info("Step 9: Calling store.storeSummary for %s (branch=%s)", commitInfo.hash.take(8), branch)
             store.storeSummary(summary, force = force, transcript = storedTranscript, planProgress = planProgressArtifacts.takeIf { it.isNotEmpty() })

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/services/JolliMemoryService.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/services/JolliMemoryService.kt
@@ -100,7 +100,7 @@ class JolliMemoryService(private val project: Project) : Disposable {
 
     fun initialize() {
         if (isInitialized) return
-        val sb = StringBuilder()
+val sb = StringBuilder()
         val basePath = project.basePath
         sb.appendLine("basePath=$basePath")
 
@@ -120,6 +120,7 @@ class JolliMemoryService(private val project: Project) : Disposable {
         val gitOps = GitOps(basePath)
         val resolvedRoot = gitOps.resolveMainWorktreeRoot() ?: basePath
         mainRepoRoot = resolvedRoot
+        JmLogger.setLogDir(resolvedRoot)
         sb.appendLine("resolvedRoot=$resolvedRoot")
 
         // Check key files in resolved root

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/JolliMemoryToolWindowFactory.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/JolliMemoryToolWindowFactory.kt
@@ -467,6 +467,8 @@ private class StatusIndicatorLabel(
         if (!status.gitHookInstalled) return true
         if (status.claudeDetected == true && !status.claudeHookInstalled) return true
         if (status.geminiDetected == true && !status.geminiHookInstalled) return true
+        if (status.openCodeScanError != null) return true
+        if (status.cursorScanError != null) return true
         return false
     }
 
@@ -538,7 +540,7 @@ private class StatusIndicatorLabel(
         sb.append("<p><span style='color:$hookColor'>\u25CF</span> <b>Hooks:</b> $hooksDesc</p>")
 
         // Sessions
-        sb.append("<p><span style='color:#3FB950'>\u25CF</span> <b>Sessions:</b> ${status.activeSessions}</p>")
+        sb.append("<p><span style='color:#3FB950'>\u25CF</span> <b>Sessions (Claude/Gemini):</b> ${status.activeSessions}</p>")
 
         // Stored Memories
         sb.append("<p><span style='color:#3FB950'>\u25CF</span> <b>Stored Memories:</b> ${status.summaryCount} total</p>")
@@ -570,6 +572,28 @@ private class StatusIndicatorLabel(
             val color = if (status.geminiHookInstalled) "#3FB950" else "#D29922"
             val desc = if (status.geminiHookInstalled) "hook installed" else "hook not installed"
             sb.append("<p><span style='color:$color'>\u25CF</span> <b>Gemini:</b> $desc</p>")
+        }
+        if (status.openCodeDetected == true) {
+            val scanError = status.openCodeScanError
+            if (scanError != null) {
+                val detail = if (scanError.message != null) "${scanError.kind}: ${scanError.message}" else scanError.kind
+                sb.append("<p><span style='color:#F85149'>\u25CF</span> <b>OpenCode:</b> unavailable \u2014 $detail</p>")
+            } else if (status.openCodeEnabled == false) {
+                sb.append("<p><span style='color:#D29922'>\u25CF</span> <b>OpenCode:</b> detected but disabled</p>")
+            } else {
+                sb.append("<p><span style='color:#3FB950'>\u25CF</span> <b>OpenCode:</b> detected</p>")
+            }
+        }
+        if (status.cursorDetected == true) {
+            val scanError = status.cursorScanError
+            if (scanError != null) {
+                val detail = if (scanError.message != null) "${scanError.kind}: ${scanError.message}" else scanError.kind
+                sb.append("<p><span style='color:#F85149'>\u25CF</span> <b>Cursor:</b> unavailable \u2014 $detail</p>")
+            } else if (status.cursorEnabled == false) {
+                sb.append("<p><span style='color:#D29922'>\u25CF</span> <b>Cursor:</b> detected but disabled</p>")
+            } else {
+                sb.append("<p><span style='color:#3FB950'>\u25CF</span> <b>Cursor:</b> detected</p>")
+            }
         }
 
         // Error

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/SettingsDialog.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/SettingsDialog.kt
@@ -94,6 +94,7 @@ class SettingsDialog(
     private val codexEnabledCheckbox = JBCheckBox("Codex CLI — Session discovery via filesystem scan", true)
     private val geminiEnabledCheckbox = JBCheckBox("Gemini CLI — Session tracking via AfterAgent hook", true)
     private val openCodeEnabledCheckbox = JBCheckBox("OpenCode — Session discovery via SQLite database scan", true)
+    private val cursorEnabledCheckbox = JBCheckBox("Cursor IDE — Composer session discovery via SQLite database scan", true)
     private val excludePatternsField = JBTextField()
     private val pauseCheckbox = JBCheckBox("Pause Jolli Memory (temporarily disable hooks without losing configuration)")
 
@@ -165,6 +166,7 @@ class SettingsDialog(
             .addComponent(codexEnabledCheckbox, 4)
             .addComponent(geminiEnabledCheckbox, 4)
             .addComponent(openCodeEnabledCheckbox, 4)
+            .addComponent(cursorEnabledCheckbox, 4)
             .panel))
 
         return wrapTabContent(panel)
@@ -574,7 +576,8 @@ class SettingsDialog(
         }
 
         if (!claudeEnabledCheckbox.isSelected && !codexEnabledCheckbox.isSelected &&
-            !geminiEnabledCheckbox.isSelected && !openCodeEnabledCheckbox.isSelected
+            !geminiEnabledCheckbox.isSelected && !openCodeEnabledCheckbox.isSelected &&
+            !cursorEnabledCheckbox.isSelected
         ) {
             return ValidationInfo("At least one platform must be enabled", claudeEnabledCheckbox)
         }
@@ -635,6 +638,7 @@ class SettingsDialog(
             codexEnabled = codexEnabledCheckbox.isSelected,
             geminiEnabled = geminiEnabledCheckbox.isSelected,
             openCodeEnabled = openCodeEnabledCheckbox.isSelected,
+            cursorEnabled = cursorEnabledCheckbox.isSelected,
             excludePatterns = if (excludePatterns.isNotEmpty()) excludePatterns else null,
             aiProvider = provider,
             knowledgeBasePath = kbPath,
@@ -734,6 +738,7 @@ class SettingsDialog(
         codexEnabledCheckbox.isSelected = config.codexEnabled != false
         geminiEnabledCheckbox.isSelected = config.geminiEnabled != false
         openCodeEnabledCheckbox.isSelected = config.openCodeEnabled != false
+        cursorEnabledCheckbox.isSelected = config.cursorEnabled != false
         pauseCheckbox.isSelected = config.paused == true
 
         // Memory Bank

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/StatusPanel.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/StatusPanel.kt
@@ -3,6 +3,7 @@ package ai.jolli.jollimemory.toolwindow
 import ai.jolli.jollimemory.JolliMemoryIcons
 import ai.jolli.jollimemory.core.CodexSessionDiscoverer
 import ai.jolli.jollimemory.core.GeminiSupport
+import ai.jolli.jollimemory.core.CursorSupport
 import ai.jolli.jollimemory.core.OpenCodeSupport
 import ai.jolli.jollimemory.core.JolliMemoryConfig
 import ai.jolli.jollimemory.core.SessionTracker
@@ -131,12 +132,12 @@ class StatusPanel(
             tooltip = hooksTooltip,
         ))
 
-        // 2. Sessions (generic label covering all integrations)
+        // 2. Sessions (Claude/Gemini — other sources are discovered on-demand at commit time)
         listModel.addElement(StatusRow(
             icon = Icon.PULSE,
             label = "Sessions",
             description = "${status.activeSessions}",
-            tooltip = "${status.activeSessions} active session${if (status.activeSessions != 1) "s" else ""} across all integrations",
+            tooltip = "${status.activeSessions} active Claude/Gemini session${if (status.activeSessions != 1) "s" else ""}",
         ))
 
         // 4. Stored Memories
@@ -206,15 +207,49 @@ class StatusPanel(
         // 9. OpenCode Integration (no hooks needed — just detection)
         val openCodeDetected = status.openCodeDetected ?: OpenCodeSupport.isOpenCodeInstalled()
         if (openCodeDetected) {
-            val enabled = config.openCodeEnabled != false
-            addIntegrationRow(
-                enabled = enabled,
-                hookInstalled = null,
-                label = "OpenCode Integration",
-                enabledTooltip = "OpenCode database found — session discovery is enabled",
-                disabledTooltip = "OpenCode detected but session discovery is disabled in config",
-                hookMissingTooltip = null,
-            )
+            val openCodeEnabled = config.openCodeEnabled != false
+            val openCodeScanError = status.openCodeScanError
+            if (openCodeEnabled && openCodeScanError != null) {
+                listModel.addElement(StatusRow(
+                    Icon.WARN,
+                    "OpenCode Integration",
+                    "unavailable — ${openCodeScanError.kind}",
+                    "OpenCode DB scan failed (${openCodeScanError.kind}): ${openCodeScanError.message}",
+                ))
+            } else {
+                addIntegrationRow(
+                    enabled = openCodeEnabled,
+                    hookInstalled = null,
+                    label = "OpenCode Integration",
+                    enabledTooltip = "OpenCode database found — session discovery is enabled",
+                    disabledTooltip = "OpenCode detected but session discovery is disabled in config",
+                    hookMissingTooltip = null,
+                )
+            }
+        }
+
+        // 10. Cursor Integration (no hooks needed — just detection)
+        val cursorDetected = status.cursorDetected ?: CursorSupport.isCursorInstalled()
+        if (cursorDetected) {
+            val cursorEnabled = config.cursorEnabled != false
+            val cursorScanError = status.cursorScanError
+            if (cursorEnabled && cursorScanError != null) {
+                listModel.addElement(StatusRow(
+                    Icon.WARN,
+                    "Cursor Integration",
+                    "unavailable — ${cursorScanError.kind}",
+                    "Cursor DB scan failed (${cursorScanError.kind}): ${cursorScanError.message}",
+                ))
+            } else {
+                addIntegrationRow(
+                    enabled = cursorEnabled,
+                    hookInstalled = null,
+                    label = "Cursor Integration",
+                    enabledTooltip = "Cursor database found — Composer session discovery is enabled",
+                    disabledTooltip = "Cursor detected but Composer session discovery is disabled in config",
+                    hookMissingTooltip = null,
+                )
+            }
         }
 
         add(JBScrollPane(statusList), BorderLayout.CENTER)

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/SummaryPanel.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/SummaryPanel.kt
@@ -828,7 +828,8 @@ class SummaryPanel(
         ApplicationManager.getApplication().executeOnPooledThread {
             try {
                 val seen = mutableSetOf<String>()
-                var totalEntries = 0; var claudeSessions = 0; var codexSessions = 0
+                var totalEntries = 0
+                val sessionsBySource = mutableMapOf<String, Int>()
                 for (hash in hashSnapshot) {
                     val transcript = store.readTranscript(hash) ?: continue
                     @Suppress("SENSELESS_COMPARISON")
@@ -841,11 +842,11 @@ class SummaryPanel(
                         totalEntries += entries.size
                         if (seen.contains(key)) continue
                         seen.add(key)
-                        if (source == "codex") codexSessions++ else claudeSessions++
+                        sessionsBySource[source] = (sessionsBySource[source] ?: 0) + 1
                     }
                 }
                 ApplicationManager.getApplication().invokeLater {
-                    postToWebview("transcriptStatsLoaded", mapOf("totalEntries" to totalEntries, "claudeSessions" to claudeSessions, "codexSessions" to codexSessions))
+                    postToWebview("transcriptStatsLoaded", mapOf("totalEntries" to totalEntries, "sessionsBySource" to sessionsBySource))
                 }
             } catch (e: Exception) {
                 LOG.warn("Failed to load transcript stats: ${e.message}", e)

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/views/SummaryScriptBuilder.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/views/SummaryScriptBuilder.kt
@@ -973,7 +973,8 @@ ${buildPrMessageScript()}
     var tabsHtml = '';
     for (var t = 0; t < groupOrder.length; t++) {
       var tabGroup = groups[groupOrder[t]];
-      var tabSourceLabel = tabGroup.source === 'codex' ? 'Codex' : 'Claude';
+      var displayNames = {claude:'Claude',codex:'Codex',gemini:'Gemini',opencode:'OpenCode',cursor:'Cursor',copilot:'Copilot',copilotChat:'Copilot Chat'};
+      var tabSourceLabel = displayNames[tabGroup.source] || tabGroup.source;
       var tabEntryCount = tabGroup.entries.length;
       var activeClass = t === 0 ? ' active' : '';
       tabsHtml += '<button class="modal-tab' + activeClass + '" data-tab-key="' + groupOrder[t] + '">';
@@ -1358,11 +1359,16 @@ ${buildPrMessageScript()}
     }
     if (msg.command === 'transcriptStatsLoaded') {
       if (conversationsStats) {
+        var displayNames = {claude:'Claude',codex:'Codex',gemini:'Gemini',opencode:'OpenCode',cursor:'Cursor',copilot:'Copilot',copilotChat:'Copilot Chat'};
+        var sources = msg.sessionsBySource || {};
         var parts = [];
-        if (msg.claudeSessions > 0) parts.push('<strong>' + msg.claudeSessions + '</strong> Claude');
-        if (msg.codexSessions > 0) parts.push('<strong>' + msg.codexSessions + '</strong> Codex');
-        var totalSessions = (msg.claudeSessions || 0) + (msg.codexSessions || 0);
-        conversationsStats.innerHTML = '<strong>' + msg.totalEntries + '</strong> entries across <strong>' + totalSessions + '</strong> session' + (totalSessions !== 1 ? 's' : '') + ' (' + parts.join(', ') + ')';
+        var totalSessions = 0;
+        Object.keys(sources).forEach(function(key) {
+          var count = sources[key];
+          totalSessions += count;
+          parts.push('<strong>' + count + '</strong> ' + (displayNames[key] || key));
+        });
+        conversationsStats.innerHTML = '<strong>' + msg.totalEntries + '</strong> entries across <strong>' + totalSessions + '</strong> session' + (totalSessions !== 1 ? 's' : '') + (parts.length > 0 ? ' (' + parts.join(', ') + ')' : '');
       }
     }
   });

--- a/intellij/src/test/kotlin/ai/jolli/jollimemory/core/CursorSupportTest.kt
+++ b/intellij/src/test/kotlin/ai/jolli/jollimemory/core/CursorSupportTest.kt
@@ -1,0 +1,419 @@
+package ai.jolli.jollimemory.core
+
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import java.sql.DriverManager
+import java.time.Instant
+
+class CursorSupportTest {
+
+    private var originalHome: String? = null
+
+    @BeforeEach
+    fun setup() {
+        originalHome = System.getProperty("user.home")
+    }
+
+    @AfterEach
+    fun teardown() {
+        originalHome?.let { System.setProperty("user.home", it) }
+    }
+
+    /** Returns the platform-correct Cursor user-data dir under the given home. */
+    private fun cursorUserDataDir(home: File): File {
+        val osName = System.getProperty("os.name").lowercase()
+        return when {
+            osName.contains("mac") -> File(home, "Library/Application Support/Cursor")
+            osName.contains("win") -> File(home, "AppData/Roaming/Cursor")
+            else -> File(home, ".config/Cursor")
+        }
+    }
+
+    /** Creates the Cursor user-data dir layout under `home` and returns the workspaceStorage subdir. */
+    private fun setupCursorHome(home: File): File {
+        val wsStorage = File(cursorUserDataDir(home), "User/workspaceStorage")
+        wsStorage.mkdirs()
+        return wsStorage
+    }
+
+    /** Path where CursorSupport.getGlobalDbPath() will look. */
+    private fun globalDbFile(home: File): File =
+        File(cursorUserDataDir(home), "User/globalStorage/state.vscdb").also { it.parentFile.mkdirs() }
+
+    /** Creates a per-workspace state.vscdb with an ItemTable row for composer.composerData. */
+    private fun createWorkspaceDb(
+        path: File,
+        folderUri: String,
+        lastFocused: List<String> = emptyList(),
+        selected: List<String> = emptyList(),
+    ) {
+        path.parentFile.mkdirs()
+        // workspace.json next to the DB
+        File(path.parentFile, "workspace.json").writeText("""{"folder": "$folderUri"}""")
+
+        DriverManager.getConnection("jdbc:sqlite:${path.absolutePath}").use { conn ->
+            conn.createStatement().use { st ->
+                st.execute("CREATE TABLE ItemTable (key TEXT PRIMARY KEY, value TEXT NOT NULL)")
+            }
+            val composerData = """{"lastFocusedComposerIds":${lastFocused.toJsonStringArray()},"selectedComposerIds":${selected.toJsonStringArray()}}"""
+            conn.prepareStatement("INSERT INTO ItemTable(key, value) VALUES (?, ?)").use { ps ->
+                ps.setString(1, "composer.composerData")
+                ps.setString(2, composerData)
+                ps.executeUpdate()
+            }
+        }
+    }
+
+    /** Creates a global state.vscdb with a cursorDiskKV table; rows are passed as (key, value). */
+    private fun createGlobalDb(path: File, rows: List<Pair<String, String>>) {
+        path.parentFile.mkdirs()
+        DriverManager.getConnection("jdbc:sqlite:${path.absolutePath}").use { conn ->
+            conn.createStatement().use { st ->
+                st.execute("CREATE TABLE cursorDiskKV ([key] TEXT PRIMARY KEY, value TEXT)")
+            }
+            conn.prepareStatement("INSERT INTO cursorDiskKV([key], value) VALUES (?, ?)").use { ps ->
+                for ((k, v) in rows) {
+                    ps.setString(1, k)
+                    ps.setString(2, v)
+                    ps.executeUpdate()
+                }
+            }
+        }
+    }
+
+    private fun composerData(id: String, lastUpdatedAt: Long, headers: List<Pair<String, Int>> = emptyList()): String {
+        val headersJson = headers.joinToString(",") { (bid, type) -> """{"bubbleId":"$bid","type":$type}""" }
+        return """{"composerId":"$id","lastUpdatedAt":$lastUpdatedAt,"fullConversationHeadersOnly":[$headersJson]}"""
+    }
+
+    private fun bubbleData(type: Int?, text: String?, createdAt: String? = null): String {
+        val parts = mutableListOf<String>()
+        if (type != null) parts.add("\"type\":$type")
+        if (text != null) parts.add("\"text\":${jsonString(text)}")
+        if (createdAt != null) parts.add("\"createdAt\":\"$createdAt\"")
+        return "{${parts.joinToString(",")}}"
+    }
+
+    private fun jsonString(s: String) = "\"" + s.replace("\\", "\\\\").replace("\"", "\\\"") + "\""
+    private fun List<String>.toJsonStringArray() = joinToString(prefix = "[", postfix = "]") { jsonString(it) }
+
+    private fun fileUri(f: File): String {
+        // Use absolutePath (not canonicalPath) so the URI matches what callers pass to
+        // discoverSessions; canonicalPath would resolve macOS's /var → /private/var
+        // symlink and mismatch.
+        return "file://" + f.absolutePath
+    }
+
+    @Nested
+    inner class IsCursorInstalled {
+        @Test
+        fun `false when global DB does not exist`(@TempDir tempDir: File) {
+            System.setProperty("user.home", tempDir.absolutePath)
+            CursorSupport.isCursorInstalled() shouldBe false
+        }
+
+        @Test
+        fun `true when global DB exists`(@TempDir tempDir: File) {
+            System.setProperty("user.home", tempDir.absolutePath)
+            val db = globalDbFile(tempDir)
+            createGlobalDb(db, emptyList())
+            CursorSupport.isCursorInstalled() shouldBe true
+        }
+    }
+
+    @Nested
+    inner class DiscoverSessions {
+
+        @Test
+        fun `no matching workspace returns empty`(@TempDir tempDir: File) {
+            System.setProperty("user.home", tempDir.absolutePath)
+            val projectDir = File(tempDir, "my-project").also { it.mkdirs() }
+            val otherProject = File(tempDir, "other-project").also { it.mkdirs() }
+            val wsStorage = setupCursorHome(tempDir)
+            createWorkspaceDb(File(wsStorage, "abc/state.vscdb"), fileUri(otherProject))
+            createGlobalDb(globalDbFile(tempDir), listOf(
+                "composerData:c1" to composerData("c1", System.currentTimeMillis())
+            ))
+
+            val result = CursorSupport.discoverSessions(projectDir.absolutePath)
+            result.sessions.shouldBeEmpty()
+            result.error.shouldBeNull()
+        }
+
+        @Test
+        fun `anchor composer older than 48h is excluded`(@TempDir tempDir: File) {
+            System.setProperty("user.home", tempDir.absolutePath)
+            val projectDir = File(tempDir, "my-project").also { it.mkdirs() }
+            val wsStorage = setupCursorHome(tempDir)
+            createWorkspaceDb(File(wsStorage, "ws1/state.vscdb"), fileUri(projectDir),
+                lastFocused = listOf("ancient-composer"))
+            val ancientTime = System.currentTimeMillis() - 30L * 24 * 60 * 60 * 1000  // 30 days ago
+            createGlobalDb(globalDbFile(tempDir), listOf(
+                "composerData:ancient-composer" to composerData("ancient-composer", ancientTime),
+            ))
+
+            val result = CursorSupport.discoverSessions(projectDir.absolutePath)
+            result.error.shouldBeNull()
+            result.sessions.shouldBeEmpty()
+        }
+
+        @Test
+        fun `anchor-only filtering with staleness cutoff and dedupe`(@TempDir tempDir: File) {
+            System.setProperty("user.home", tempDir.absolutePath)
+            val projectDir = File(tempDir, "my-project").also { it.mkdirs() }
+            val wsStorage = setupCursorHome(tempDir)
+            createWorkspaceDb(File(wsStorage, "ws1/state.vscdb"), fileUri(projectDir),
+                lastFocused = listOf("focused", "both", "anchorStale"),
+                selected = listOf("selected", "both"))  // "both" overlaps lastFocused
+            val now = System.currentTimeMillis()
+            val recent = now - 1000
+            val ancient = now - 30L * 24 * 60 * 60 * 1000
+            createGlobalDb(globalDbFile(tempDir), listOf(
+                "composerData:focused" to composerData("focused", recent),        // anchor + recent
+                "composerData:selected" to composerData("selected", recent),      // anchor + recent
+                "composerData:both" to composerData("both", recent),              // anchor + recent (deduped)
+                "composerData:fresh" to composerData("fresh", recent),            // recent but not anchored — excluded
+                "composerData:stale" to composerData("stale", ancient),           // neither — excluded
+                "composerData:anchorStale" to composerData("anchorStale", ancient), // anchored but stale — excluded
+            ))
+
+            val result = CursorSupport.discoverSessions(projectDir.absolutePath)
+            result.error.shouldBeNull()
+            // Only anchored + recent sessions returned; unanchored "fresh" must NOT leak in
+            result.sessions.map { it.sessionId } shouldContainExactlyInAnyOrder
+                listOf("focused", "selected", "both")
+        }
+
+        @Test
+        fun `corrupt global DB returns ScanResult with corrupt error`(@TempDir tempDir: File) {
+            System.setProperty("user.home", tempDir.absolutePath)
+            val projectDir = File(tempDir, "my-project").also { it.mkdirs() }
+            val wsStorage = setupCursorHome(tempDir)
+            createWorkspaceDb(File(wsStorage, "ws1/state.vscdb"), fileUri(projectDir))
+            // Write garbage to the global DB — fails SQLite header check
+            val globalDb = globalDbFile(tempDir)
+            globalDb.writeBytes(ByteArray(64) { 0xFF.toByte() })
+
+            val result = CursorSupport.discoverSessions(projectDir.absolutePath)
+            result.sessions.shouldBeEmpty()
+            result.error.shouldNotBeNull()
+            // Either corrupt (clean SQLite check) or unknown (depending on how JDBC reports it)
+            result.error!!.kind shouldBeOneOf listOf(SqliteScanErrorKind.corrupt, SqliteScanErrorKind.unknown)
+        }
+
+        @Test
+        fun `malformed composer row is silently skipped`(@TempDir tempDir: File) {
+            System.setProperty("user.home", tempDir.absolutePath)
+            val projectDir = File(tempDir, "my-project").also { it.mkdirs() }
+            val wsStorage = setupCursorHome(tempDir)
+            createWorkspaceDb(File(wsStorage, "ws1/state.vscdb"), fileUri(projectDir),
+                lastFocused = listOf("good"))
+            val now = System.currentTimeMillis()
+            createGlobalDb(globalDbFile(tempDir), listOf(
+                "composerData:bad-json" to "{not valid json",
+                "composerData:good" to composerData("good", now - 1000),
+            ))
+
+            val result = CursorSupport.discoverSessions(projectDir.absolutePath)
+            result.error.shouldBeNull()
+            result.sessions.map { it.sessionId } shouldContainExactly listOf("good")
+        }
+
+        @Test
+        fun `composer with missing composerId is skipped`(@TempDir tempDir: File) {
+            System.setProperty("user.home", tempDir.absolutePath)
+            val projectDir = File(tempDir, "my-project").also { it.mkdirs() }
+            val wsStorage = setupCursorHome(tempDir)
+            createWorkspaceDb(File(wsStorage, "ws1/state.vscdb"), fileUri(projectDir),
+                lastFocused = listOf("ok"))
+            val now = System.currentTimeMillis()
+            createGlobalDb(globalDbFile(tempDir), listOf(
+                "composerData:no-id" to """{"lastUpdatedAt":$now}""",
+                "composerData:ok" to composerData("ok", now - 1000),
+            ))
+
+            val result = CursorSupport.discoverSessions(projectDir.absolutePath)
+            result.error.shouldBeNull()
+            result.sessions.map { it.sessionId } shouldContainExactly listOf("ok")
+        }
+
+        @Test
+        fun `composer with non-finite lastUpdatedAt is skipped`(@TempDir tempDir: File) {
+            System.setProperty("user.home", tempDir.absolutePath)
+            val projectDir = File(tempDir, "my-project").also { it.mkdirs() }
+            val wsStorage = setupCursorHome(tempDir)
+            createWorkspaceDb(File(wsStorage, "ws1/state.vscdb"), fileUri(projectDir),
+                lastFocused = listOf("weird", "good"))
+            val now = System.currentTimeMillis()
+            createGlobalDb(globalDbFile(tempDir), listOf(
+                "composerData:weird" to """{"composerId":"weird","lastUpdatedAt":"not-a-number"}""",
+                "composerData:good" to composerData("good", now - 1000),
+            ))
+
+            val result = CursorSupport.discoverSessions(projectDir.absolutePath)
+            result.error.shouldBeNull()
+            result.sessions.map { it.sessionId } shouldContainExactly listOf("good")
+        }
+
+        @Test
+        fun `synthetic transcript path encodes composer id`(@TempDir tempDir: File) {
+            System.setProperty("user.home", tempDir.absolutePath)
+            val projectDir = File(tempDir, "my-project").also { it.mkdirs() }
+            val wsStorage = setupCursorHome(tempDir)
+            createWorkspaceDb(File(wsStorage, "ws1/state.vscdb"), fileUri(projectDir),
+                lastFocused = listOf("my-composer"))
+            createGlobalDb(globalDbFile(tempDir), listOf(
+                "composerData:my-composer" to composerData("my-composer", System.currentTimeMillis())
+            ))
+
+            val result = CursorSupport.discoverSessions(projectDir.absolutePath)
+            val s = result.sessions.single()
+            s.transcriptPath.endsWith("#my-composer") shouldBe true
+            s.source shouldBe TranscriptSource.cursor
+        }
+    }
+
+    @Nested
+    inner class ReadTranscript {
+
+        @Test
+        fun `parses bubbles and maps type to role`(@TempDir tempDir: File) {
+            System.setProperty("user.home", tempDir.absolutePath)
+            val db = globalDbFile(tempDir)
+            createGlobalDb(db, listOf(
+                "composerData:c1" to composerData("c1", 1_700_000_000_000L, listOf("b1" to 1, "b2" to 2)),
+                "bubbleId:c1:b1" to bubbleData(type = 1, text = "Hello"),
+                "bubbleId:c1:b2" to bubbleData(type = 2, text = "Hi there"),
+            ))
+
+            val result = CursorSupport.readTranscript("${db.absolutePath}#c1", cursor = null)
+            result.entries shouldHaveSize 2
+            result.entries[0].role shouldBe "human"
+            result.entries[0].content shouldBe "Hello"
+            result.entries[1].role shouldBe "assistant"
+            result.entries[1].content shouldBe "Hi there"
+        }
+
+        @Test
+        fun `consecutive same-role entries are merged`(@TempDir tempDir: File) {
+            System.setProperty("user.home", tempDir.absolutePath)
+            val db = globalDbFile(tempDir)
+            createGlobalDb(db, listOf(
+                "composerData:c1" to composerData("c1", 1_700_000_000_000L, listOf("b1" to 1, "b2" to 1, "b3" to 2)),
+                "bubbleId:c1:b1" to bubbleData(1, "first"),
+                "bubbleId:c1:b2" to bubbleData(1, "second"),
+                "bubbleId:c1:b3" to bubbleData(2, "reply"),
+            ))
+
+            val result = CursorSupport.readTranscript("${db.absolutePath}#c1", cursor = null)
+            result.entries shouldHaveSize 2
+            result.entries[0].role shouldBe "human"
+            result.entries[1].role shouldBe "assistant"
+        }
+
+        @Test
+        fun `empty-text bubble is skipped`(@TempDir tempDir: File) {
+            System.setProperty("user.home", tempDir.absolutePath)
+            val db = globalDbFile(tempDir)
+            createGlobalDb(db, listOf(
+                "composerData:c1" to composerData("c1", 1_700_000_000_000L, listOf("b1" to 1, "b2" to 2)),
+                "bubbleId:c1:b1" to bubbleData(1, "  "),  // whitespace only
+                "bubbleId:c1:b2" to bubbleData(2, "kept"),
+            ))
+
+            val result = CursorSupport.readTranscript("${db.absolutePath}#c1", cursor = null)
+            result.entries shouldHaveSize 1
+            result.entries[0].content shouldBe "kept"
+        }
+
+        @Test
+        fun `missing bubble row advances index without producing entry`(@TempDir tempDir: File) {
+            System.setProperty("user.home", tempDir.absolutePath)
+            val db = globalDbFile(tempDir)
+            createGlobalDb(db, listOf(
+                "composerData:c1" to composerData("c1", 1_700_000_000_000L, listOf("missing" to 1, "present" to 2)),
+                "bubbleId:c1:present" to bubbleData(2, "kept"),
+            ))
+
+            val result = CursorSupport.readTranscript("${db.absolutePath}#c1", cursor = null)
+            result.entries shouldHaveSize 1
+            result.entries[0].content shouldBe "kept"
+            result.newCursor.lineNumber shouldBe 2  // both indices consumed
+        }
+
+        @Test
+        fun `malformed bubble JSON is skipped`(@TempDir tempDir: File) {
+            System.setProperty("user.home", tempDir.absolutePath)
+            val db = globalDbFile(tempDir)
+            createGlobalDb(db, listOf(
+                "composerData:c1" to composerData("c1", 1_700_000_000_000L, listOf("bad" to 1, "good" to 2)),
+                "bubbleId:c1:bad" to "{not valid",
+                "bubbleId:c1:good" to bubbleData(2, "ok"),
+            ))
+
+            val result = CursorSupport.readTranscript("${db.absolutePath}#c1", cursor = null)
+            result.entries shouldHaveSize 1
+            result.entries[0].content shouldBe "ok"
+        }
+
+        @Test
+        fun `cursor-based incremental read skips already-processed bubbles`(@TempDir tempDir: File) {
+            System.setProperty("user.home", tempDir.absolutePath)
+            val db = globalDbFile(tempDir)
+            createGlobalDb(db, listOf(
+                "composerData:c1" to composerData("c1", 1_700_000_000_000L, listOf("b1" to 1, "b2" to 2, "b3" to 1)),
+                "bubbleId:c1:b1" to bubbleData(1, "skipped"),
+                "bubbleId:c1:b2" to bubbleData(2, "skipped-too"),
+                "bubbleId:c1:b3" to bubbleData(1, "fresh"),
+            ))
+
+            val priorCursor = TranscriptCursor("${db.absolutePath}#c1", 2, Instant.now().toString())
+            val result = CursorSupport.readTranscript("${db.absolutePath}#c1", cursor = priorCursor)
+            result.entries.map { it.content } shouldContainExactly listOf("fresh")
+        }
+
+        @Test
+        fun `unknown bubble type is skipped`(@TempDir tempDir: File) {
+            System.setProperty("user.home", tempDir.absolutePath)
+            val db = globalDbFile(tempDir)
+            createGlobalDb(db, listOf(
+                "composerData:c1" to composerData("c1", 1_700_000_000_000L, listOf("b1" to 99, "b2" to 1)),
+                "bubbleId:c1:b1" to bubbleData(99, "system msg"),
+                "bubbleId:c1:b2" to bubbleData(1, "user msg"),
+            ))
+
+            val result = CursorSupport.readTranscript("${db.absolutePath}#c1", cursor = null)
+            result.entries.map { it.content } shouldContainExactly listOf("user msg")
+        }
+
+        @Test
+        fun `composer not found throws`(@TempDir tempDir: File) {
+            System.setProperty("user.home", tempDir.absolutePath)
+            val db = globalDbFile(tempDir)
+            createGlobalDb(db, emptyList())
+
+            try {
+                CursorSupport.readTranscript("${db.absolutePath}#missing-id", cursor = null)
+                throw AssertionError("expected RuntimeException")
+            } catch (_: RuntimeException) {
+                // ok
+            }
+        }
+    }
+}
+
+/** Kotest-style helper not in our project's matcher set — provides "shouldBeOneOf". */
+private infix fun <T> T.shouldBeOneOf(options: Collection<T>) {
+    if (this !in options) throw AssertionError("expected $this to be one of $options")
+}

--- a/intellij/src/test/kotlin/ai/jolli/jollimemory/core/SqliteHelpersTest.kt
+++ b/intellij/src/test/kotlin/ai/jolli/jollimemory/core/SqliteHelpersTest.kt
@@ -1,0 +1,147 @@
+package ai.jolli.jollimemory.core
+
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.sqlite.SQLiteErrorCode
+import org.sqlite.SQLiteException
+import java.nio.file.AccessDeniedException
+
+class SqliteHelpersTest {
+
+    @Nested
+    inner class ClassifyScanError {
+
+        @Test
+        fun `SQLITE_CORRUPT maps to corrupt`() {
+            val e = SQLiteException("database disk image is malformed", SQLiteErrorCode.SQLITE_CORRUPT)
+            classifyScanError(e).kind shouldBe SqliteScanErrorKind.corrupt
+        }
+
+        @Test
+        fun `SQLITE_NOTADB maps to corrupt`() {
+            val e = SQLiteException("file is not a database", SQLiteErrorCode.SQLITE_NOTADB)
+            classifyScanError(e).kind shouldBe SqliteScanErrorKind.corrupt
+        }
+
+        @Test
+        fun `SQLITE_BUSY maps to locked`() {
+            val e = SQLiteException("database is locked", SQLiteErrorCode.SQLITE_BUSY)
+            classifyScanError(e).kind shouldBe SqliteScanErrorKind.locked
+        }
+
+        @Test
+        fun `SQLITE_LOCKED maps to locked`() {
+            val e = SQLiteException("database table is locked", SQLiteErrorCode.SQLITE_LOCKED)
+            classifyScanError(e).kind shouldBe SqliteScanErrorKind.locked
+        }
+
+        @Test
+        fun `SQLITE_PERM maps to permission`() {
+            val e = SQLiteException("access permission denied", SQLiteErrorCode.SQLITE_PERM)
+            classifyScanError(e).kind shouldBe SqliteScanErrorKind.permission
+        }
+
+        @Test
+        fun `SQLITE_CANTOPEN maps to permission`() {
+            val e = SQLiteException("unable to open database file", SQLiteErrorCode.SQLITE_CANTOPEN)
+            classifyScanError(e).kind shouldBe SqliteScanErrorKind.permission
+        }
+
+        @Test
+        fun `SQLITE_ERROR with 'no such table' maps to schema`() {
+            val e = SQLiteException("no such table: cursorDiskKV", SQLiteErrorCode.SQLITE_ERROR)
+            classifyScanError(e).kind shouldBe SqliteScanErrorKind.schema
+        }
+
+        @Test
+        fun `SQLITE_ERROR with 'no such column' maps to schema`() {
+            val e = SQLiteException("no such column: lastUpdatedAt", SQLiteErrorCode.SQLITE_ERROR)
+            classifyScanError(e).kind shouldBe SqliteScanErrorKind.schema
+        }
+
+        @Test
+        fun `AccessDeniedException maps to permission`() {
+            val e = AccessDeniedException("/some/locked/path")
+            classifyScanError(e).kind shouldBe SqliteScanErrorKind.permission
+        }
+
+        @Test
+        fun `non-SQLite exception with corrupt message falls back to corrupt via message regex`() {
+            val e = RuntimeException("wrapped: SQLITE_CORRUPT: bad file")
+            classifyScanError(e).kind shouldBe SqliteScanErrorKind.corrupt
+        }
+
+        @Test
+        fun `non-SQLite exception with locked message falls back to locked via message regex`() {
+            val e = RuntimeException("wrapped: database is locked elsewhere")
+            classifyScanError(e).kind shouldBe SqliteScanErrorKind.locked
+        }
+
+        @Test
+        fun `non-SQLite exception with schema message falls back to schema via message regex`() {
+            val e = RuntimeException("upstream: no such table foo")
+            classifyScanError(e).kind shouldBe SqliteScanErrorKind.schema
+        }
+
+        @Test
+        fun `unrecognized error maps to unknown`() {
+            val e = RuntimeException("totally unrelated boom")
+            classifyScanError(e).kind shouldBe SqliteScanErrorKind.unknown
+        }
+
+        @Test
+        fun `message is preserved in returned error`() {
+            val e = RuntimeException("specific failure detail")
+            classifyScanError(e).message shouldBe "specific failure detail"
+        }
+    }
+
+    @Nested
+    inner class ParseSyntheticPath {
+
+        @Test
+        fun `splits valid path on last hash`() {
+            val (db, id) = parseSyntheticPath("/path/to/state.vscdb#composer-abc")
+            db shouldBe "/path/to/state.vscdb"
+            id shouldBe "composer-abc"
+        }
+
+        @Test
+        fun `lastIndexOf preserves hash in db path`() {
+            val (db, id) = parseSyntheticPath("/path/with #symbol/state.vscdb#composer-xyz")
+            db shouldBe "/path/with #symbol/state.vscdb"
+            id shouldBe "composer-xyz"
+        }
+
+        @Test
+        fun `missing hash throws`() {
+            try {
+                parseSyntheticPath("/no/hash/here")
+                throw AssertionError("expected IllegalArgumentException")
+            } catch (_: IllegalArgumentException) {
+                // ok
+            }
+        }
+
+        @Test
+        fun `leading hash throws`() {
+            try {
+                parseSyntheticPath("#only-id")
+                throw AssertionError("expected IllegalArgumentException")
+            } catch (_: IllegalArgumentException) {
+                // ok
+            }
+        }
+
+        @Test
+        fun `trailing hash throws`() {
+            try {
+                parseSyntheticPath("/path/db#")
+                throw AssertionError("expected IllegalArgumentException")
+            } catch (_: IllegalArgumentException) {
+                // ok
+            }
+        }
+    }
+}

--- a/intellij/src/test/kotlin/ai/jolli/jollimemory/core/TypesTest.kt
+++ b/intellij/src/test/kotlin/ai/jolli/jollimemory/core/TypesTest.kt
@@ -10,7 +10,7 @@ class TypesTest {
     inner class Enums {
         @Test
         fun `TranscriptSource has correct values`() {
-            TranscriptSource.entries.map { it.name } shouldBe listOf("claude", "codex", "gemini", "opencode")
+            TranscriptSource.entries.map { it.name } shouldBe listOf("claude", "codex", "gemini", "opencode", "cursor")
         }
 
         @Test


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## Quick recap

The plugin now successfully reads live conversation history from both Cursor IDE and OpenCode. Two correctness gaps in the post-commit hook were closed: transcripts are now filtered to exclude messages created after the commit, and a failure reading one source no longer aborts processing for all remaining sessions in the same run.

Getting the SQLite integration working inside the IntelliJ plugin required two separate fixes. The driver JAR was not being shipped with the plugin at all, causing an immediate crash on startup. After bundling it, a second failure surfaced: the IDE's standard Java class-loading mechanism could not see the newly bundled driver, so database connections still failed. An explicit one-time driver registration call at first use resolved this, and the status popup now shows the full error message inline when an integration is unavailable — making future diagnosis possible without opening a log file.

---

## E2E Test (2)
<details>
<summary><strong>1. Cursor IDE detected and shown in status panel</strong></summary>
<br>
<blockquote>

**Preconditions:** Have Cursor IDE installed on the test machine so its data folder exists. Open a project in the Jolli Memory plugin that you have previously worked on inside Cursor.

**Steps:**
1. Open your project in the IDE that has the Jolli Memory plugin installed.
2. Open the Jolli Memory status panel (look for the Jolli Memory icon or menu entry).
3. Check the list of detected AI tools shown in the panel.
4. Verify that "Cursor" appears in the list and shows as detected.
5. Now open the same project in Cursor, have a short conversation with the Cursor AI assistant, then switch back to the IDE with the plugin.
6. Trigger a git commit on the project and check that the commit summary includes content from your Cursor conversation.

**Expected Results:**
- The status panel should show Cursor as a detected AI source.
- After committing, the generated summary should reflect the conversation you had in Cursor, confirming that Cursor transcripts are being read and included.

</blockquote>
</details>
<details>
<summary><strong>2. SQLite scan error surfaced in status panel when Cursor or OpenCode database is locked</strong></summary>
<br>
<blockquote>

**Preconditions:** Have either Cursor IDE or OpenCode installed. The easiest way to trigger a locked database is to have Cursor actively running while you check the status panel.

**Steps:**
1. Make sure Cursor (or OpenCode) is open and actively in use so its database may be locked.
2. Open the Jolli Memory status panel in your IDE.
3. Look at the entry for Cursor (or OpenCode) in the panel.
4. Check whether any warning or error indicator appears next to that entry.
5. Close Cursor (or OpenCode) completely, then refresh or reopen the Jolli Memory status panel.
6. Check the same entry again.

**Expected Results:**
- While Cursor is running and the database is locked, the status panel should show a warning or error message next to the Cursor entry (such as "locked" or a similar indicator) rather than silently showing zero sessions.
- After closing Cursor, the error indicator should disappear and the panel should show Cursor sessions normally.

</blockquote>
</details>

---

## Topics (4)
<details>
<summary><strong>01 · SQLite driver not available to plugin at runtime causing crash on startup</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

After adding live SQLite scanning for OpenCode and Cursor sessions, the plugin crashed on startup with a "no class definition found" error for the SQLite driver. The driver JAR was present at compile time but not shipped inside the plugin, so the IDE's class loader couldn't find it when the status panel tried to open a database.

**💡 Decisions Behind the Code**

- **Bundle vs. rely on host JVM**: The SQLite driver had been marked compile-only on the assumption that all SQLite access happened inside the standalone hooks JAR, which bundles its own copy. Adding live scans inside the plugin broke that assumption. Bundling the driver into the plugin was the only correct path — the IDE's JVM has no SQLite driver of its own, and there was no other mechanism to make it available at runtime.
- **Explicit class loading over service discovery**: JDBC's standard auto-registration mechanism uses the system class loader, which cannot see JARs loaded by the plugin's isolated class loader. Explicitly loading the driver class by name at first use is the established workaround for this IntelliJ plugin constraint. The alternative — restructuring the plugin to use a different class loader delegation model — would have been far more invasive for a narrow problem.

**✅ What Was Implemented**

- Changed `org.xerial:sqlite-jdbc` from `compileOnly` to `implementation` in `intellij/build.gradle.kts` so the driver JAR is bundled into the plugin's `lib/` directory at build time. This raised the plugin zip from 17 MB to 31 MB.
- Added a lazy one-time `Class.forName("org.sqlite.JDBC")` call at the top of `withReadOnlyDb` in `intellij/src/main/kotlin/ai/jolli/jollimemory/core/SqliteHelpers.kt`. This forces the driver's static initializer to run from the plugin's class loader and register itself with the JDBC driver manager, resolving a second failure ("no suitable driver found") that appeared after the first fix.

**📁 FILES**
- `intellij/build.gradle.kts`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/core/SqliteHelpers.kt`

</blockquote>
</details>
<details>
<summary><strong>02 · Cursor IDE added as transcript source with per-session error isolation</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The post-commit hook needed to read conversation transcripts from Cursor IDE and OpenCode in addition to the existing sources. There were also two correctness gaps: transcripts newer than the commit timestamp were being included, and a failure reading one source could abort processing for all remaining sessions.

**💡 Decisions Behind the Code**

- **Fix both gaps together in one edit**: The timestamp cutoff fix was a two-character change (passing an already-available variable), and the error isolation was a small wrapper around the same block. Combining them into one edit kept the diff minimal and avoided a second build/test cycle. The risk of the combined change was assessed as very low since both paths were already exercised by existing tests.
- **Continue-on-error over fail-fast**: Aborting the entire post-commit run when one session source fails is a poor trade-off — a locked Cursor database should not prevent Claude or Gemini transcripts from being summarized. The continue-on-error pattern mirrors how the CLI worker already handles per-session failures, keeping behavior consistent across platforms.

**✅ What Was Implemented**

- Wrapped the per-session transcript reading block in `PostCommitHook.kt` in a try/catch that logs the error and continues to the next session on failure. This prevents a locked or corrupt database for one source from aborting the entire post-commit run.
- Passed `commitInfo.date` as the `beforeTimestamp` argument to `OpenCodeSupport.readTranscript` and `CursorSupport.readTranscript`. Transcript messages newer than the commit are now excluded, matching the behavior already implemented in the reader functions but previously not activated from the hook.

**📁 FILES**
- `intellij/src/main/kotlin/ai/jolli/jollimemory/hooks/PostCommitHook.kt`

</blockquote>
</details>
<details>
<summary><strong>03 · Status popup now shows full error detail for unavailable integrations</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The hover popup on the status indicator was showing "unavailable — unknown" for OpenCode with no further detail, making it impossible to diagnose why the integration was failing without digging through log files.

**💡 Decisions Behind the Code**

Surfacing the error message directly in the popup was chosen over log-file inspection because it gives immediate, in-context feedback without requiring the developer to locate and tail a log file. The message is already captured in the structured error object at scan time, so no additional work was needed to produce it — only to display it.

**✅ What Was Implemented**

Added the raw error message as a gray sub-line beneath the "unavailable" label in the status popup HTML builder in `JolliMemoryToolWindowFactory.kt`, with HTML entity escaping applied. This was added for both the OpenCode and Cursor rows. The change was introduced as a diagnostic aid during the SQLite driver investigation and left in place as a permanent improvement.

**📁 FILES**
- `intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/JolliMemoryToolWindowFactory.kt`

</blockquote>
</details>
<details>
<summary><strong>04 · IntelliJ plugin build requires JDK 21 — path documented for future sessions</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The plugin build failed repeatedly because the default Java installation on the machine was version 17 (too old to emit the required bytecode) and the newest available version was 25 (too new for the Gradle version in use). The correct JDK had to be located and the build re-run manually.

**💡 Decisions Behind the Code**

The JDK path was recorded in project memory rather than hardcoded into the build configuration. Adding a Gradle toolchain block to `build.gradle.kts` would make the build self-contained and eliminate the manual override, but that change was deferred — the memory entry is sufficient for now and avoids touching build configuration during an unrelated debugging session.

**✅ What Was Implemented**

Identified the working JDK at `/opt/homebrew/Cellar/openjdk@21/21.0.11` and confirmed that setting `JAVA_HOME` to that path before running the Gradle build resolves both the "JVM target mismatch" and "unsupported Java version" errors. The path and override pattern were saved to the project memory file so future sessions do not need to rediscover it.

**📋 Future Enhancements**

Consider adding a Gradle Java toolchain declaration to `intellij/build.gradle.kts` so the build automatically selects JDK 21 without requiring a manual `JAVA_HOME` override.

**📁 FILES**
- `intellij/build.gradle.kts`

</blockquote>
</details>

---

*Generated by Jolli Memory · May 15, 2026 at 2:06 PM · via Anthropic*
<!-- jollimemory-summary-end -->