### PR TITLE
Add client_version to OAuth login URLs (CLI / VS Code / IntelliJ)

### DIFF
--- a/cli/src/auth/Login.test.ts
+++ b/cli/src/auth/Login.test.ts
@@ -741,6 +741,11 @@ describe("Login", () => {
 			expect(openedUrl).toContain("https://app.jolli.ai/login?");
 			expect(openedUrl).toContain("generate_api_key=true");
 			expect(openedUrl).toContain("client=cli");
+			// client_version pairs with client=cli so server-side min-version
+			// gating can run at sign-in. Test runs under tsx without
+			// __PKG_VERSION__ defined, so the fallback "dev" reaches the URL;
+			// what matters is that the param is populated.
+			expect(openedUrl).toMatch(/[?&]client_version=[^&]+/);
 			expect(mockExchangeCliCode).toHaveBeenCalledWith(TEST_JOLLI_URL, "browser-code");
 			expect(mockSaveAuthCredentials).toHaveBeenCalledWith({ token: "browser-token" });
 		});

--- a/cli/src/auth/Login.ts
+++ b/cli/src/auth/Login.ts
@@ -7,6 +7,8 @@
  * key) to the global config.
  */
 
+/// <reference path="../Globals.d.ts" />
+
 import { randomBytes, timingSafeEqual } from "node:crypto";
 import { createServer, type Server, type ServerResponse } from "node:http";
 import { URL } from "node:url";
@@ -15,6 +17,17 @@ import { loadConfig } from "../core/SessionTracker.js";
 import { saveAuthCredentials } from "./AuthConfig.js";
 import { exchangeCliCode } from "./CliExchange.js";
 import { getDeviceLabel } from "./DeviceLabel.js";
+
+/**
+ * Surface version sent on the login URL as `client_version`. Pairs with
+ * `client=cli` so the server can gate sign-in (and downstream auto-prompts)
+ * on the same min-version policy applied to subsequent `x-jolli-client`
+ * HTTP requests. Build-time `__PKG_VERSION__` is the `cli/package.json`
+ * version in the standalone CLI bundle and falls back to `"dev"` under
+ * tsx / tests, matching the convention in `core/LlmClient.ts`.
+ */
+/* v8 ignore next -- compile-time ternary: always "dev" in tests, always __PKG_VERSION__ in build */
+const CLIENT_VERSION = typeof __PKG_VERSION__ !== "undefined" ? __PKG_VERSION__ : "dev";
 
 /**
  * Opens the browser to `${jolliUrl}/login` with a CLI callback URL, waits for
@@ -48,10 +61,12 @@ export function browserLogin(jolliUrl: string): Promise<void> {
 					const callbackUrl = `http://127.0.0.1:${actualPort}/callback`;
 
 					// `client=cli` always identifies the originating surface to the
-					// server (telemetry, surface-aware behavior). `generate_api_key=true`
+					// server (telemetry, surface-aware behavior). `client_version`
+					// pairs with it so server-side min-version gating can run at
+					// sign-in, not only on later API calls. `generate_api_key=true`
 					// is independent: only asked for when there's no existing key.
 					const config = await loadConfig();
-					let loginUrl = `${jolliUrl}/login?cli_callback=${encodeURIComponent(callbackUrl)}&state=${expectedState}&client=cli`;
+					let loginUrl = `${jolliUrl}/login?cli_callback=${encodeURIComponent(callbackUrl)}&state=${expectedState}&client=cli&client_version=${encodeURIComponent(CLIENT_VERSION)}`;
 					if (!config.jolliApiKey) {
 						loginUrl += "&generate_api_key=true";
 						// `device_name` scopes the server's per-user idempotency key so

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/services/JolliAuthService.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/services/JolliAuthService.kt
@@ -93,9 +93,18 @@ object JolliAuthService {
             SecureRandom().nextBytes(stateBytes)
             val state = stateBytes.joinToString("") { "%02x".format(it) }
             val callbackUrl = "http://localhost:$port/callback?state=$state"
-            val encodedCallback = java.net.URLEncoder.encode(callbackUrl, Charsets.UTF_8)
-            val loginUrl = "$jolliUrl/login?cli_callback=$encodedCallback" +
-                "&generate_api_key=true&client=intellij"
+            // Only ask the server to mint a fresh Jolli API key when the user
+            // doesn't already have one — otherwise sign-in would overwrite a
+            // manually configured key (and a subsequent sign-out would then
+            // delete it). Mirrors the conditional in browserLogin() / VS Code
+            // openSignInPage().
+            val existingApiKey = SessionTracker.loadConfig().jolliApiKey
+            val loginUrl = buildLoginUrl(
+                jolliUrl = jolliUrl,
+                callbackUrl = callbackUrl,
+                clientVersion = JolliApiClient.pluginVersion,
+                generateApiKey = existingApiKey.isNullOrBlank(),
+            )
             log.info("Login URL: %s", loginUrl)
 
             httpServer.createContext("/callback") { exchange ->
@@ -217,6 +226,44 @@ object JolliAuthService {
         server = null
         serverExecutor?.shutdownNow()
         serverExecutor = null
+    }
+
+    /**
+     * Builds the OAuth launch URL. `client=intellij` identifies the originating
+     * surface; `client_version` pairs with it so the server can attribute the
+     * resulting `signup_source` / `signup_client_version` and apply per-surface
+     * min-version gating at sign-in, not only on later `x-jolli-client` HTTP
+     * requests. Mirrors the CLI / VS Code wire shape — query params are in the
+     * same order across all three surfaces (`cli_callback`, `state`*, `client`,
+     * `client_version`, `generate_api_key`) so the URL reads identically modulo
+     * the surface label.
+     *
+     * (*) IntelliJ omits a top-level `state=` param because the CSRF nonce is
+     *     embedded inside the callback URL itself; the other params still
+     *     align positionally.
+     *
+     * Defensive URL-encoding: normal semver and the `"0.0.0"` fallback are
+     * URL-safe, but a pre-release tag with `+` or whitespace would otherwise
+     * be lost. The `"0.0.0"` from `JolliApiClient.pluginVersion` is a
+     * deliberately gate-failing sentinel — a missing classpath resource trips
+     * the server's min-version check loudly instead of attributing a real
+     * sign-in to a misleading version. The TypeScript ports use `"dev"`
+     * instead because their bundler injects `__PKG_VERSION__` at build time;
+     * a missing constant there means a tsx/test run (a benign developer
+     * build), not a packaging error.
+     */
+    internal fun buildLoginUrl(
+        jolliUrl: String,
+        callbackUrl: String,
+        clientVersion: String,
+        generateApiKey: Boolean,
+    ): String {
+        val encodedCallback = java.net.URLEncoder.encode(callbackUrl, Charsets.UTF_8)
+        val encodedVersion = java.net.URLEncoder.encode(clientVersion, Charsets.UTF_8)
+        val generateKeyParam = if (generateApiKey) "&generate_api_key=true" else ""
+        return "$jolliUrl/login?cli_callback=$encodedCallback" +
+            "&client=intellij&client_version=$encodedVersion" +
+            generateKeyParam
     }
 
     internal fun parseQuery(query: String): Map<String, String> {

--- a/intellij/src/test/kotlin/ai/jolli/jollimemory/services/JolliAuthServiceTest.kt
+++ b/intellij/src/test/kotlin/ai/jolli/jollimemory/services/JolliAuthServiceTest.kt
@@ -56,6 +56,70 @@ class JolliAuthServiceTest {
         result["key"] shouldBe "second"
     }
 
+    // --- buildLoginUrl tests ---
+
+    @Test
+    fun `buildLoginUrl pairs client with client_version and orders params consistently`() {
+        // client=intellij + client_version is what the backend reads via
+        // useCaptureCliCallback to populate signup_source /
+        // signup_client_version. Mirrors the CLI / VS Code login URL shape —
+        // keep these params in lockstep across all three surfaces.
+        val url = JolliAuthService.buildLoginUrl(
+            jolliUrl = "https://app.jolli.ai",
+            callbackUrl = "http://localhost:54321/callback?state=abc",
+            clientVersion = "1.4.2",
+            generateApiKey = true,
+        )
+        url shouldContain "https://app.jolli.ai/login?cli_callback="
+        url shouldContain "client=intellij"
+        url shouldContain "client_version=1.4.2"
+        url shouldContain "generate_api_key=true"
+        // Callback must be percent-encoded so the `?state=` inside doesn't
+        // collide with the outer query string's `&`.
+        url shouldContain "http%3A%2F%2Flocalhost%3A54321%2Fcallback%3Fstate%3Dabc"
+        // Param order should match CLI / VS Code:
+        // cli_callback → client → client_version → generate_api_key. A pinned
+        // ordering keeps the three surfaces' URLs visually comparable in
+        // captures / logs and protects against silent drift when one surface
+        // is refactored in isolation.
+        val clientIdx = url.indexOf("client=intellij")
+        val versionIdx = url.indexOf("client_version=")
+        val generateIdx = url.indexOf("generate_api_key=")
+        (clientIdx < versionIdx) shouldBe true
+        (versionIdx < generateIdx) shouldBe true
+    }
+
+    @Test
+    fun `buildLoginUrl omits generate_api_key when caller flags an existing key`() {
+        // Preserves manually configured keys: if we always asked the server to
+        // mint one, the new key would clobber the existing entry on sign-in.
+        // Matches CLI's `if (!config.jolliApiKey) loginUrl += "&generate_api_key=true"`
+        // and VS Code's `generateKeyParam = jolliApiKey ? "" : "&generate_api_key=true"`.
+        val url = JolliAuthService.buildLoginUrl(
+            jolliUrl = "https://app.jolli.ai",
+            callbackUrl = "http://localhost:54321/callback",
+            clientVersion = "1.4.2",
+            generateApiKey = false,
+        )
+        url shouldContain "client=intellij"
+        url shouldContain "client_version=1.4.2"
+        (url.contains("generate_api_key")) shouldBe false
+    }
+
+    @Test
+    fun `buildLoginUrl URL-encodes unusual version strings defensively`() {
+        // The fallback "0.0.0" and normal semver are URL-safe, but a stray
+        // pre-release tag with "+" or whitespace would otherwise be lost.
+        // Encoding keeps the param value round-trippable on the server.
+        val url = JolliAuthService.buildLoginUrl(
+            jolliUrl = "https://app.jolli.ai",
+            callbackUrl = "http://localhost:54321/callback",
+            clientVersion = "1.4.2+build 7",
+            generateApiKey = true,
+        )
+        url shouldContain "client_version=1.4.2%2Bbuild+7"
+    }
+
     // --- getErrorMessage tests ---
 
     @Test

--- a/vscode/src/services/AuthService.test.ts
+++ b/vscode/src/services/AuthService.test.ts
@@ -660,6 +660,11 @@ describe("AuthService", () => {
 			);
 			expect(parsed).toContain("generate_api_key=true");
 			expect(parsed).toContain("client=vscode");
+			// client_version pairs with client=vscode so server-side min-version
+			// gating can run at sign-in. Test bundles don't define __PKG_VERSION__,
+			// so the fallback "dev" is what reaches the URL here — what matters
+			// is that the param is populated and not the literal value.
+			expect(parsed).toMatch(/[?&]client_version=[^&]+/);
 		});
 
 		it("should include a 256-bit hex state nonce on the login URL (RFC 6749 §10.12)", async () => {

--- a/vscode/src/services/AuthService.ts
+++ b/vscode/src/services/AuthService.ts
@@ -11,6 +11,8 @@
  * Display info (site URL, tenant) is derived from the API key metadata.
  */
 
+/// <reference path="../../../cli/src/Globals.d.ts" />
+
 import { randomBytes, timingSafeEqual } from "node:crypto";
 import * as vscode from "vscode";
 import {
@@ -24,6 +26,19 @@ import { loadConfig } from "../../../cli/src/core/SessionTracker.js";
 import type { JolliMemoryConfig } from "../../../cli/src/Types.js";
 import { log } from "../util/Logger.js";
 import { EXTENSION_ID, resolveUriScheme } from "../util/UriSchemeResolver.js";
+
+/**
+ * Surface version sent on the login URL as `client_version`. Pairs with
+ * `client=vscode` so the server can gate sign-in on the same min-version
+ * policy applied to subsequent `x-jolli-client` HTTP requests. Build-time
+ * `__PKG_VERSION__` is the `vscode/package.json` version (the surface the
+ * user installed and would upgrade), not the inlined CLI package version,
+ * matching the convention in `core/LlmClient.ts`. Falls back to `"dev"`
+ * under tsx / tests.
+ */
+/* v8 ignore next -- compile-time ternary: always "dev" in tests, always __PKG_VERSION__ in build */
+const CLIENT_VERSION =
+	typeof __PKG_VERSION__ !== "undefined" ? __PKG_VERSION__ : "dev";
 
 /** VSCode URI callback path for OAuth redirects */
 const AUTH_CALLBACK_PATH = "/auth-callback";
@@ -281,7 +296,11 @@ export class AuthService {
 		// a friendly error dialog instead of an unhandled command exception.
 		let loginUrl: string;
 		try {
-			loginUrl = `${getJolliUrl()}/login?cli_callback=${encodeURIComponent(callbackUri)}&state=${state}${generateKeyParam}${deviceLabelParam}&client=vscode`;
+			// Param order matches CLI / IntelliJ:
+			// cli_callback → state → client → client_version → generate_api_key → device_name.
+			// A pinned ordering keeps the three surfaces visually comparable in
+			// captures / logs and protects against silent drift on isolated edits.
+			loginUrl = `${getJolliUrl()}/login?cli_callback=${encodeURIComponent(callbackUri)}&state=${state}&client=vscode&client_version=${encodeURIComponent(CLIENT_VERSION)}${generateKeyParam}${deviceLabelParam}`;
 		} catch (err: unknown) {
 			const message = err instanceof Error ? err.message : String(err);
 			log.error("AuthService", "getJolliUrl rejected: %s", message);


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## Quick recap

The developer added client version tracking to the OAuth login flow across all three client surfaces: CLI, VS Code, and IntelliJ. Each surface now sends its own version number alongside the existing surface identifier when initiating login, allowing the backend to apply version-specific policies at sign-in time. The version information is sourced from each surface's own package metadata and URL-encoded defensively to handle edge cases.

The three surfaces now build OAuth login URLs with parameters in a consistent sequence, making captured URLs visually comparable during debugging and protecting against silent drift during isolated refactors. IntelliJ's sign-in flow was also corrected to check for an existing manually configured API key before requesting a fresh one from the server, preventing the new key from overwriting the user's configuration — a safeguard that CLI and VS Code already had in place. The expanded documentation clarifies why fallback version values differ across surfaces and explains the rationale for parameter ordering, reducing the risk of future maintainers inadvertently changing intentional inconsistencies.

---

## E2E Test (2)
<details>
<summary><strong>1. IntelliJ sign-in preserves manually configured API keys</strong></summary>
<br>
<blockquote>

**Preconditions:** Have IntelliJ open with Jolli Memory plugin installed. Have a manually configured API key already saved in the plugin settings.

**Steps:**
1. Open the Jolli Memory plugin settings and verify your API key is currently saved.
2. Click the "Sign In" button in the plugin.
3. Complete the OAuth login flow in your browser and return to IntelliJ.
4. Wait for the sign-in process to complete.
5. Open the plugin settings again and check your API key.

**Expected Results:**
- Your original manually configured API key should still be present and unchanged after sign-in completes.
- The sign-in should succeed without overwriting your existing key.

</blockquote>
</details>
<details>
<summary><strong>2. Client version parameter appears in OAuth login URLs across all three clients</strong></summary>
<br>
<blockquote>

**Preconditions:** Have the CLI, VS Code extension, and IntelliJ plugin all installed and ready to use.

**Steps:**
1. In the CLI, run the login command and observe the browser URL that opens.
2. Check that the URL contains a "client_version" parameter with a version number.
3. In VS Code, open the command palette and run the sign-in command, then observe the browser URL.
4. Check that the URL contains a "client_version" parameter with a version number.
5. In IntelliJ, click the sign-in button and observe the browser URL that opens.
6. Check that the URL contains a "client_version" parameter with a version number.

**Expected Results:**
- All three clients should include a "client_version" parameter in their OAuth login URLs.
- Each parameter should contain a version number (e.g., "1.4.2" or "dev" in test environments).
- The parameter should appear in the same position relative to other parameters across all three clients.

</blockquote>
</details>

---

## Topics (5)
<details>
<summary><strong>01 · Standardize OAuth login URL parameter order across three client surfaces</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The CLI, VS Code, and IntelliJ clients were building OAuth login URLs with query parameters in inconsistent orders, making it harder to visually compare captured URLs during debugging and creating risk of silent drift if one surface were refactored in isolation.

**💡 Decisions Behind the Code**

- **Pinned parameter order for maintainability**: Rather than treating parameter order as an implementation detail, the three surfaces now follow an identical sequence. This makes URLs visually comparable in logs and network captures, and protects against accidental reordering when one surface is edited in isolation. The cost is a minor constraint on future refactors, but the debugging and consistency benefit outweighs it.
- **Explicit fallback semantics in documentation**: The docstring now distinguishes why IntelliJ uses `"0.0.0"` (a gate-failing sentinel for missing classpath resources) while TypeScript ports use `"dev"` (a benign indicator of a bundler-injected development build). This prevents future maintainers from "fixing" the inconsistency without understanding the intent.

**✅ What Was Implemented**

- Reordered query parameters in VS Code's login URL builder to match CLI and IntelliJ: `cli_callback` → `state` → `client` → `client_version` → `generate_api_key`. Added inline comments documenting the pinned order across all three surfaces.
- Updated IntelliJ's `buildLoginUrl` function signature to accept a `generateApiKey` boolean parameter and conditionally append the parameter only when true, matching the conditional logic already present in CLI and VS Code.
- Expanded IntelliJ's docstring to explain the rationale for parameter ordering, the semantic difference between fallback version values across surfaces (`"0.0.0"` for packaging errors vs. `"dev"` for normal development builds), and why the CSRF nonce is embedded in the callback URL rather than as a top-level `state` parameter.

**📁 FILES**
- `intellij/src/main/kotlin/ai/jolli/jollimemory/services/JolliAuthService.kt`
- `vscode/src/services/AuthService.ts`

</blockquote>
</details>
<details>
<summary><strong>02 · Add client version parameter to OAuth login URLs across three client surfaces</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The backend signup source tracking system needs to know the version of the client initiating OAuth login, not just which surface (CLI, VS Code, IntelliJ) is making the request. Currently only the surface type is sent; the version information is missing from the login URL.

**💡 Decisions Behind the Code**

- **Version source selection**: Each surface reads its own package version (CLI reads cli/package.json, VS Code reads vscode/package.json, IntelliJ reads from Gradle-injected classpath resource) rather than sharing a single version constant. This ensures each client reports the version that users actually upgrade, not a shared dependency version, and aligns with existing conventions in the codebase where each surface independently declares its client identification.
- **URL encoding strategy**: All three surfaces apply URL encoding to the version parameter even though normal semantic versions are URL-safe. This defensive approach prevents edge cases with pre-release tags containing special characters from being silently truncated, and matches OWASP sanitization practices at system boundaries.
- **Testability through extraction**: IntelliJ's URL building was extracted into a separate internal function to enable unit tests to inject arbitrary version strings, since the JVM platform lacks build-time constant injection mechanisms like esbuild. This mirrors the testing approach already used for other URL-building logic in the same service.

**✅ What Was Implemented**

- Modified CLI login URL builder to append `&client_version=` parameter using the build-time injected `__PKG_VERSION__` constant from the CLI package, with fallback to `"dev"` in test environments. Added test assertion to verify the parameter is present in the generated URL.
- Modified VS Code authentication service to append `&client_version=` parameter using the build-time injected `__PKG_VERSION__` constant from the VS Code package, with fallback to `"dev"` in test environments. Added test assertion to verify the parameter is present in the generated URL.
- Refactored IntelliJ authentication service to extract URL building logic into a testable `buildLoginUrl` function that appends `&client_version=` using the plugin version read from classpath resources at runtime. Added two test cases covering normal semver versions and unusual version strings with special characters.

**📁 FILES**
- `cli/src/auth/Login.ts`
- `vscode/src/services/AuthService.ts`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/services/JolliAuthService.kt`

</blockquote>
</details>
<details>
<summary><strong>03 · Fix IntelliJ sign-in flow to preserve manually configured API keys</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

IntelliJ was unconditionally requesting a fresh API key on every sign-in, which would overwrite any manually configured key the user had set. CLI and VS Code already guarded against this by checking for an existing key first.

**💡 Decisions Behind the Code**

The check is performed at the call site (in the sign-in flow) rather than inside `buildLoginUrl` itself, keeping the URL builder function pure and testable. This mirrors the pattern already established in CLI and VS Code, where the decision to include the parameter is made before constructing the URL string.

**✅ What Was Implemented**

- Modified the sign-in flow in `JolliAuthService` to load the user's existing configuration and check whether `jolliApiKey` is already set before calling `buildLoginUrl`.
- Pass the result of that check (`existingApiKey.isNullOrBlank()`) as the `generateApiKey` parameter to `buildLoginUrl`, ensuring the server is only asked to mint a new key when the user does not already have one.
- Added a detailed comment explaining the rationale: manually configured keys should not be overwritten, and the behavior now mirrors the conditional logic in the CLI and VS Code implementations.

**📁 FILES**
- `intellij/src/main/kotlin/ai/jolli/jollimemory/services/JolliAuthService.kt`

</blockquote>
</details>
<details>
<summary><strong>04 · Expand IntelliJ OAuth URL builder test coverage for parameter ordering and conditional key generation</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The IntelliJ `buildLoginUrl` function was refactored to accept a new parameter and reorder its output; existing tests needed to be updated and extended to cover the new conditional logic and verify parameter ordering consistency.

**💡 Decisions Behind the Code**

Test assertions use index-based ordering checks rather than regex or string splitting, making the intent explicit: the test verifies that `client` appears before `client_version`, which appears before `generate_api_key`. This approach is more maintainable than brittle substring matching and documents the contract clearly for future readers.

**✅ What Was Implemented**

- Renamed the existing test from `buildLoginUrl encodes callback and version...` to `buildLoginUrl pairs client with client_version and orders params consistently` and added assertions that verify the three parameters appear in the correct sequence using index comparisons.
- Added a new test `buildLoginUrl omits generate_api_key when caller flags an existing key` that verifies the function correctly omits the `generate_api_key` parameter when `generateApiKey=false`, ensuring the conditional logic works as intended.
- Updated the URL-encoding edge-case test to pass the new `generateApiKey` parameter to the refactored function signature.

**📁 FILES**
- `intellij/src/test/kotlin/ai/jolli/jollimemory/services/JolliAuthServiceTest.kt`

</blockquote>
</details>
<details>
<summary><strong>05 · Resolve merge conflict in context compiler during feature branch rebase</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

A feature branch adding knowledge compilation caching was being rebased onto a newer base that had refactored variable names in the context compiler, creating a three-way merge conflict that needed manual resolution.

**💡 Decisions Behind the Code**

The feature branch's caching implementation was retained over the base branch's manual loop because it provides better performance and maintainability while covering the same use cases. The base branch's variable naming convention was applied uniformly across the merged code to ensure the file follows current naming standards and reduces future confusion about what the variable represents.

**✅ What Was Implemented**

- Merged import statements from both sides of the conflict to preserve both the new `validateCache` and `loadSummaries` functions from the feature branch and the `filterToBranchHeads` function from the base branch.
- Replaced the base branch's manual loop over entries with the feature branch's `validateCache` and `loadSummaries` caching approach, which is more efficient and provides the same functionality.
- Renamed all occurrences of `rootEntries` (the variable name used in the feature branch) to `headEntries` (the new naming convention introduced in the base branch) throughout the file to maintain consistency with the v4 Hoist heads semantic.

**📁 FILES**
- `cli/src/core/ContextCompiler.ts`

</blockquote>
</details>

---

*Generated by Jolli Memory · May 16, 2026 at 5:55 PM · via Anthropic*
<!-- jollimemory-summary-end -->