### PR TITLE
Fix AuthService to preserve nonce on openExternal false for Copy flow

### DIFF
--- a/vscode/src/services/AuthService.test.ts
+++ b/vscode/src/services/AuthService.test.ts
@@ -688,23 +688,54 @@ describe("AuthService", () => {
 			expect(first).not.toBe(second);
 		});
 
-		it("should clear pendingState when openExternal returns false (covers leak-on-launch-failure path)", async () => {
-			// Sets pendingState, then openExternal fails → state must be
-			// cleared so it doesn't validate a future code callback.
+		it("should preserve pendingState when openExternal returns false (Copy path completes via paste-in-browser)", async () => {
+			// `openExternal` resolves `false` when the user picks either "Copy"
+			// or "Cancel" in VSCode's external-URI consent dialog. The API
+			// doesn't distinguish them, but the Copy flow needs the nonce
+			// preserved — the user is about to paste the URL into a browser
+			// and finish sign-in normally. A captured nonce from the URL must
+			// therefore validate successfully on the subsequent callback.
 			openExternal.mockResolvedValueOnce(false);
 			await service.openSignInPage();
 
-			// A subsequent code callback would fail with "state mismatch" even
-			// if it carries the nonce from the failed attempt's URL — because
-			// pendingState is null again.
-			const failedUrl = uriParse.mock.calls[0]?.[0] ?? "";
-			const failedState = new URL(failedUrl).searchParams.get("state") ?? "";
+			const url = uriParse.mock.calls[0]?.[0] ?? "";
+			const state = new URL(url).searchParams.get("state") ?? "";
 			const result = await service.handleAuthCallback(
-				makeUri("/auth-callback", `code=stale&state=${failedState}`) as never,
+				makeUri("/auth-callback", `code=abc123&state=${state}`) as never,
 			);
-			expect(result.success).toBe(false);
-			if (!result.success) {
-				expect(result.error).toContain("state mismatch");
+
+			expect(result).toEqual({ success: true });
+			expect(exchangeCliCode).toHaveBeenCalledWith(
+				"https://app.jolli.ai",
+				"abc123",
+			);
+		});
+
+		it("should expire pendingState after the TTL when no callback arrives (Cancel path leftover)", async () => {
+			// The Cancel branch of the consent dialog can't be distinguished
+			// from Copy at the API surface, so we keep the nonce alive for
+			// PENDING_STATE_TTL_MS (5 min) and then drop it. After expiry,
+			// a callback carrying the same state must be rejected.
+			vi.useFakeTimers();
+			try {
+				openExternal.mockResolvedValueOnce(false);
+				await service.openSignInPage();
+
+				const url = uriParse.mock.calls[0]?.[0] ?? "";
+				const state = new URL(url).searchParams.get("state") ?? "";
+
+				// Advance just past the 5-minute TTL.
+				vi.advanceTimersByTime(5 * 60 * 1000 + 1);
+
+				const result = await service.handleAuthCallback(
+					makeUri("/auth-callback", `code=late&state=${state}`) as never,
+				);
+				expect(result.success).toBe(false);
+				if (!result.success) {
+					expect(result.error).toContain("state mismatch");
+				}
+			} finally {
+				vi.useRealTimers();
 			}
 		});
 
@@ -716,6 +747,54 @@ describe("AuthService", () => {
 			const failedState = new URL(failedUrl).searchParams.get("state") ?? "";
 			const result = await service.handleAuthCallback(
 				makeUri("/auth-callback", `code=stale&state=${failedState}`) as never,
+			);
+			expect(result.success).toBe(false);
+			if (!result.success) {
+				expect(result.error).toContain("state mismatch");
+			}
+		});
+
+		it("should cancel a stale TTL timer when a fresh sign-in is started", async () => {
+			// First attempt: Copy/Cancel path arms a 5-min TTL timer for nonce A.
+			// Second attempt: a successful launch arms a fresh nonce B. The
+			// previous timer must be cancelled — otherwise it would fire 5 min
+			// later and wipe nonce B mid-flight, breaking the second sign-in.
+			vi.useFakeTimers();
+			try {
+				openExternal.mockResolvedValueOnce(false); // attempt 1: Copy/Cancel
+				await service.openSignInPage();
+				openExternal.mockResolvedValueOnce(true); // attempt 2: Open
+				await service.openSignInPage();
+
+				// Advance past attempt 1's TTL. If its timer wasn't cancelled,
+				// it would null out the freshly-committed nonce B here.
+				vi.advanceTimersByTime(5 * 60 * 1000 + 1);
+
+				const secondUrl = uriParse.mock.calls[1]?.[0] ?? "";
+				const secondState = new URL(secondUrl).searchParams.get("state") ?? "";
+				const result = await service.handleAuthCallback(
+					makeUri("/auth-callback", `code=abc&state=${secondState}`) as never,
+				);
+				expect(result).toEqual({ success: true });
+			} finally {
+				vi.useRealTimers();
+			}
+		});
+
+		it("should drop in-flight pendingState on signOut", async () => {
+			// signOut is meant to clear *all* auth state. A late callback from
+			// a sign-in attempt that started before sign-out must not retroactively
+			// complete sign-in against the cleared credentials.
+			openExternal.mockResolvedValueOnce(false);
+			await service.openSignInPage();
+
+			const url = uriParse.mock.calls[0]?.[0] ?? "";
+			const state = new URL(url).searchParams.get("state") ?? "";
+
+			await service.signOut();
+
+			const result = await service.handleAuthCallback(
+				makeUri("/auth-callback", `code=abc&state=${state}`) as never,
 			);
 			expect(result.success).toBe(false);
 			if (!result.success) {
@@ -828,14 +907,18 @@ describe("AuthService", () => {
 			expect(parsed).not.toContain("device_name");
 		});
 
-		it("should show an error message when openExternal returns false", async () => {
+		it("should NOT show an error message when openExternal returns false (Copy path is a legitimate user choice, not a failure)", async () => {
+			// Previously the `!opened` branch surfaced "Couldn't launch the
+			// browser…" — but that fires under the Copy path too, where the
+			// user *intends* to complete sign-in by pasting the URL. Showing
+			// an error there mis-signals failure and (paired with the old
+			// pendingState reset) made the subsequent callback fail with
+			// "state mismatch". The branch is now a silent log only.
 			openExternal.mockResolvedValueOnce(false);
 
 			await service.openSignInPage();
 
-			expect(showErrorMessage).toHaveBeenCalledWith(
-				expect.stringContaining("Couldn't launch the browser"),
-			);
+			expect(showErrorMessage).not.toHaveBeenCalled();
 		});
 
 		it("should show an error message when openExternal throws", async () => {

--- a/vscode/src/services/AuthService.ts
+++ b/vscode/src/services/AuthService.ts
@@ -29,6 +29,18 @@ import { EXTENSION_ID, resolveUriScheme } from "../util/UriSchemeResolver.js";
 const AUTH_CALLBACK_PATH = "/auth-callback";
 
 /**
+ * How long an in-flight sign-in nonce stays valid when {@link vscode.env.openExternal}
+ * resolves `false`. That return value is ambiguous — it means the user picked
+ * either "Copy" or "Cancel" from VSCode's external-URI consent dialog, and the
+ * API doesn't distinguish them. The Copy path must keep the nonce because the
+ * user will paste the URL into a browser and complete sign-in normally; the
+ * Cancel path leaves a nonce we'd otherwise never reclaim. Picking a TTL
+ * shorter than the server-side `state` TTL (typically ~10 minutes) lets the
+ * Cancel-leftover age out before the server-issued state does.
+ */
+const PENDING_STATE_TTL_MS = 5 * 60 * 1000;
+
+/**
  * Result of handling an auth callback URI. Discriminated on `success` so the
  * error branch is guaranteed to carry a message — prevents UIs from surfacing
  * "...: undefined" when something goes wrong.
@@ -62,6 +74,26 @@ export class AuthService {
 	private pendingState: string | null = null;
 
 	/**
+	 * Deferred-expiry timer for {@link pendingState}. Started only when
+	 * {@link vscode.env.openExternal} resolves `false` — VSCode's "Open
+	 * external URI?" consent dialog returns `false` for both "Copy" (URL
+	 * copied to clipboard, user pastes into browser, sign-in still
+	 * proceeds) and "Cancel" (user aborted). The API can't tell them
+	 * apart, so we keep the nonce alive for {@link PENDING_STATE_TTL_MS}
+	 * so the Copy path can complete, and let the Cancel path's leftover
+	 * nonce age out automatically.
+	 */
+	private pendingStateTimer: ReturnType<typeof setTimeout> | null = null;
+
+	/** Cancels any pending TTL expiry. Safe to call when no timer is set. */
+	private cancelPendingStateTimer(): void {
+		if (this.pendingStateTimer !== null) {
+			clearTimeout(this.pendingStateTimer);
+			this.pendingStateTimer = null;
+		}
+	}
+
+	/**
 	 * Handles the OAuth callback URI from the browser redirect.
 	 *
 	 * Two callback shapes are accepted, in priority order:
@@ -87,6 +119,13 @@ export class AuthService {
 			log.warn("AuthService", "Ignoring unknown URI path: %s", uri.path);
 			return { success: false, error: "Unknown callback path" };
 		}
+
+		// The callback has arrived — cancel any deferred-expiry timer started
+		// by openSignInPage()'s `!opened` branch. Single-consumption of
+		// pendingState happens a few lines down; the timer is purely a
+		// belt-and-suspenders for the "user cancelled the consent dialog"
+		// case where no callback ever arrives.
+		this.cancelPendingStateTimer();
 
 		const params = new URLSearchParams(uri.query);
 		const error = params.get("error");
@@ -196,6 +235,10 @@ export class AuthService {
 
 	/** Clears auth credentials from config.json and resets the context key. */
 	async signOut(): Promise<void> {
+		// Drop any in-flight sign-in alongside the persisted credentials so a
+		// late callback from a prior attempt can't land after signOut.
+		this.cancelPendingStateTimer();
+		this.pendingState = null;
 		// Writes `{ authToken: undefined, jolliApiKey: undefined }` to the global
 		// config — JSON.stringify omits undefined fields so both are removed.
 		await clearAuthCredentials();
@@ -249,19 +292,40 @@ export class AuthService {
 		}
 		// Commit pendingState only after the URL builds — otherwise a thrown
 		// getJolliUrl() would leave behind a state that pairs with no
-		// outgoing nonce.
+		// outgoing nonce. Clear any prior deferred-expiry timer so a rapid
+		// second sign-in attempt doesn't wipe its own freshly-committed
+		// state when the previous attempt's TTL fires.
+		this.cancelPendingStateTimer();
 		this.pendingState = state;
 		log.info("AuthService", "Opening browser for sign-in");
 		try {
 			const opened = await vscode.env.openExternal(vscode.Uri.parse(loginUrl));
 			if (!opened) {
-				this.pendingState = null;
-				log.warn("AuthService", "openExternal returned false for login URL");
-				vscode.window.showErrorMessage(
-					"Couldn't launch the browser for sign-in. Please try again.",
+				// `openExternal` resolves `false` for BOTH "Copy" and "Cancel" in
+				// VSCode's external-URI consent dialog — the API doesn't
+				// distinguish them. The Copy flow needs pendingState preserved
+				// so the user can paste the URL into a browser and complete
+				// sign-in normally; the Cancel flow leaves a nonce we'd
+				// otherwise never reclaim. Defer expiry by PENDING_STATE_TTL_MS
+				// so Copy works and Cancel leftovers age out automatically.
+				log.info(
+					"AuthService",
+					"openExternal returned false (user picked Copy or Cancel); preserving nonce for %d ms",
+					PENDING_STATE_TTL_MS,
 				);
+				this.pendingStateTimer = setTimeout(() => {
+					this.pendingState = null;
+					this.pendingStateTimer = null;
+				}, PENDING_STATE_TTL_MS);
+				// Don't block process exit on the timer — the extension host
+				// shouldn't be kept alive by an idle sign-in TTL.
+				this.pendingStateTimer.unref?.();
 			}
 		} catch (err: unknown) {
+			// A genuine launch failure (no available URI handler, browser
+			// process unavailable, etc.) — no callback can ever arrive, so
+			// drop the nonce immediately and surface the error.
+			this.cancelPendingStateTimer();
 			this.pendingState = null;
 			const message = err instanceof Error ? err.message : String(err);
 			log.error("AuthService", "openExternal failed: %s", message);


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## Quick recap

The developer fixed a login flow regression where users who selected "Copy" in VSCode's external URI dialog would see an error message and be unable to complete sign-in by pasting the URL into a browser. The root cause was that the extension treated VSCode's `false` return value (which covers both "Copy" and "Cancel" without distinguishing them) as a launch failure and immediately discarded the authentication nonce. The fix preserves the nonce for 5 minutes when `openExternal` returns false, allowing the Copy path to complete normally while automatically reclaiming the nonce if the user selected Cancel and never returns. The 5-minute window is deliberately shorter than server-side OAuth state expiry so the client-side nonce ages out gracefully if abandoned.

---

## E2E Test (3)
<details>
<summary><strong>1. Copy login URL and complete sign-in by pasting in browser</strong></summary>
<br>
<blockquote>

**Steps:**
1. Open the Jolli extension in VSCode and click "Sign In".
2. When VSCode shows the "Open external URI?" dialog, click "Copy" to copy the login URL to your clipboard.
3. Open a web browser and paste the URL into the address bar, then press Enter.
4. Complete the sign-in flow in the browser (enter credentials, approve consent, etc.).
5. Return to VSCode and verify that the sign-in completes successfully — you should see your account name displayed in the extension.

**Expected Results:**
- The login URL should be copied to your clipboard without showing an error message in VSCode.
- After pasting the URL in the browser and completing sign-in, VSCode should recognize the callback and log you in.
- No "state mismatch" or "Couldn't launch the browser" error should appear.

</blockquote>
</details>
<details>
<summary><strong>2. Cancel login dialog and retry sign-in without interference</strong></summary>
<br>
<blockquote>

**Steps:**
1. Open the Jolli extension in VSCode and click "Sign In".
2. When VSCode shows the "Open external URI?" dialog, click "Cancel" to dismiss it.
3. Wait 10 seconds, then click "Sign In" again.
4. This time, when the dialog appears, click "Open" to allow VSCode to open the browser.
5. Complete the sign-in flow in the browser.
6. Return to VSCode and verify that the second sign-in attempt completes successfully.

**Expected Results:**
- The first attempt should close without showing an error message.
- The second sign-in attempt should proceed normally and complete without interference from the first attempt.
- You should be logged in after the second attempt succeeds.

</blockquote>
</details>
<details>
<summary><strong>3. Sign out clears in-flight sign-in state</strong></summary>
<br>
<blockquote>

**Steps:**
1. Open the Jolli extension in VSCode and click "Sign In".
2. When VSCode shows the "Open external URI?" dialog, click "Copy" to copy the login URL.
3. Immediately click the "Sign Out" button in the extension (do not complete the sign-in in the browser).
4. Open a web browser, paste the copied URL, and complete the sign-in flow.
5. Return to VSCode and verify that you remain signed out.

**Expected Results:**
- After signing out, the callback from the browser should be rejected.
- You should remain signed out in VSCode — no account name should appear in the extension.
- No automatic sign-in should occur from the late callback.

</blockquote>
</details>

---

## Topic (1)
<details>
<summary><strong>01 · Fix AuthService to preserve nonce on openExternal false for Copy flow</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

When users selected "Copy" in VSCode's external URI consent dialog during login, the extension incorrectly cleared the authentication nonce and showed an error message. This prevented users from manually pasting the login URL into a browser and completing sign-in, even though the Copy flow is a legitimate user choice.

**💡 Decisions Behind the Code**

The VSCode `env.openExternal` API returns `false` for both "Copy" and "Cancel" in the consent dialog without distinguishing them. Rather than treating `false` as a uniform failure signal, the fix preserves the nonce for both cases and uses a 5-minute TTL to reclaim the Cancel-path leftover. This TTL is shorter than typical server-side OAuth state expiry (10 minutes), ensuring the client-side nonce ages out before the server rejects it. The alternative of trying to detect which button the user clicked would require VSCode API changes or workarounds that don't exist.

**✅ What Was Implemented**

- Modified `AuthService.ts` to distinguish between the Copy/Cancel path (where the nonce must be preserved) and genuine launch failures (where it should be cleared). When `openExternal` returns false, the nonce now stays alive for 5 minutes via a deferred TTL timer instead of being immediately cleared. The error message is no longer shown for the Copy path.
- Added `PENDING_STATE_TTL_MS` constant (5 minutes) and `pendingStateTimer` field to manage the deferred expiry. The timer is cancelled when a callback arrives, when a fresh sign-in is started, or when the user signs out.
- Rewrote five test cases in `AuthService.test.ts` to verify the new behavior: Copy path preserves the nonce and allows callback validation to succeed; Cancel path's leftover nonce expires after TTL; rapid successive sign-in attempts don't interfere with each other; sign-out clears in-flight state; and genuine exceptions still clear the nonce immediately.

**📁 FILES**
- `vscode/src/services/AuthService.ts`
- `vscode/src/services/AuthService.test.ts`

</blockquote>
</details>

---

*Generated by Jolli Memory · May 18, 2026 at 10:19 AM · via Anthropic*
<!-- jollimemory-summary-end -->