### PR TITLE
Slim recall output and fix verbose flag help text

### DIFF
--- a/cli/src/Cli.test.ts
+++ b/cli/src/Cli.test.ts
@@ -195,7 +195,7 @@ vi.mock("./core/ContextCompiler.js", () => ({
 		},
 		estimatedTokens: 0,
 	}),
-	DEFAULT_TOKEN_BUDGET: 50000,
+	DEFAULT_TOKEN_BUDGET: 20000,
 }));
 
 // Suppress console output
@@ -206,7 +206,12 @@ vi.spyOn(process.stdout, "write").mockImplementation(() => true);
 vi.spyOn(process.stderr, "write").mockImplementation(() => true);
 
 import { main } from "./Cli.js";
-import { compileTaskContext, listBranchCatalog, renderContextMarkdown } from "./core/ContextCompiler.js";
+import {
+	buildRecallPayload,
+	compileTaskContext,
+	listBranchCatalog,
+	renderContextMarkdown,
+} from "./core/ContextCompiler.js";
 import { loadConfigFromDir } from "./core/SessionTracker.js";
 import { exportSummaries } from "./core/SummaryExporter.js";
 import { hasMigrationMeta, migrateV1toV3 } from "./core/SummaryMigration.js";
@@ -1836,7 +1841,7 @@ describe("CLI", () => {
 			await main(["recall", "--catalog", "--format", "json", "--cwd", "/tmp/test"]);
 
 			expect(listBranchCatalog).toHaveBeenCalledWith("/tmp/test");
-			expect(console.log).toHaveBeenCalledWith(JSON.stringify(catalog, null, 2));
+			expect(console.log).toHaveBeenCalledWith(JSON.stringify(catalog));
 		});
 
 		it("should output markdown context for an exact branch match", async () => {
@@ -1933,6 +1938,99 @@ describe("CLI", () => {
 					(typeof c[0] === "string" && c[0].includes('"type": "recall"')),
 			);
 			expect(jsonCall).toBeDefined();
+		});
+
+		it("--verbose forwards verbose: true to buildRecallPayload", async () => {
+			// The real buildRecallPayload is mocked at module-load time (see top
+			// of file), so this test asserts the CLI surface — i.e. that the
+			// flag arrives at the projection layer. The behavioural contract
+			// (minor drop + >8-commit response drop opt-out) is covered by the
+			// unit tests in ContextCompiler.test.ts which exercise the real
+			// implementation.
+			vi.mocked(listBranchCatalog).mockResolvedValueOnce({
+				type: "catalog",
+				branches: [
+					{
+						branch: "feature/keep-everything",
+						commitCount: 9,
+						period: { start: "2026-05-15", end: "2026-05-17" },
+						commitMessages: ["c"],
+					},
+				],
+			});
+			vi.mocked(compileTaskContext).mockResolvedValueOnce({
+				branch: "feature/keep-everything",
+				period: { start: "2026-05-15", end: "2026-05-17" },
+				commitCount: 9,
+				totalFilesChanged: 1,
+				totalInsertions: 1,
+				totalDeletions: 0,
+				summaries: [],
+				plans: [],
+				notes: [],
+				keyDecisions: [],
+				stats: {
+					topicCount: 0,
+					planCount: 0,
+					noteCount: 0,
+					decisionCount: 0,
+					topicTokens: 0,
+					planTokens: 0,
+					noteTokens: 0,
+					decisionTokens: 0,
+					transcriptTokens: 0,
+					totalTokens: 0,
+				},
+			});
+
+			await main(["recall", "feature/keep-everything", "--format", "json", "--verbose", "--cwd", "/tmp/test"]);
+
+			// The third positional arg to buildRecallPayload must carry verbose:true.
+			expect(buildRecallPayload).toHaveBeenCalledWith(expect.anything(), expect.any(Number), { verbose: true });
+		});
+
+		it("recall without --verbose forwards verbose: false to buildRecallPayload (default trim active)", async () => {
+			vi.mocked(listBranchCatalog).mockResolvedValueOnce({
+				type: "catalog",
+				branches: [
+					{
+						branch: "feature/keep-everything",
+						commitCount: 3,
+						period: { start: "2026-05-15", end: "2026-05-17" },
+						commitMessages: ["c"],
+					},
+				],
+			});
+			vi.mocked(compileTaskContext).mockResolvedValueOnce({
+				branch: "feature/keep-everything",
+				period: { start: "2026-05-15", end: "2026-05-17" },
+				commitCount: 3,
+				totalFilesChanged: 1,
+				totalInsertions: 1,
+				totalDeletions: 0,
+				summaries: [],
+				plans: [],
+				notes: [],
+				keyDecisions: [],
+				stats: {
+					topicCount: 0,
+					planCount: 0,
+					noteCount: 0,
+					decisionCount: 0,
+					topicTokens: 0,
+					planTokens: 0,
+					noteTokens: 0,
+					decisionTokens: 0,
+					transcriptTokens: 0,
+					totalTokens: 0,
+				},
+			});
+
+			await main(["recall", "feature/keep-everything", "--format", "json", "--cwd", "/tmp/test"]);
+
+			// Default path: third arg explicitly carries verbose:false so the
+			// projection layer's pre-passes engage as designed.
+			expect(buildRecallPayload).toHaveBeenCalledWith(expect.anything(), expect.any(Number), { verbose: false });
 		});
 
 		it("should output error JSON when commitCount is 0", async () => {
@@ -2268,7 +2366,7 @@ describe("CLI", () => {
 			await main(["context", "--catalog", "--format", "json", "--cwd", "/tmp/test"]);
 
 			expect(listBranchCatalog).toHaveBeenCalledWith("/tmp/test");
-			expect(console.log).toHaveBeenCalledWith(JSON.stringify(catalog, null, 2));
+			expect(console.log).toHaveBeenCalledWith(JSON.stringify(catalog));
 		});
 
 		it("should output markdown (not JSON) when no exact match and format is not json", async () => {

--- a/cli/src/Cli.test.ts
+++ b/cli/src/Cli.test.ts
@@ -206,12 +206,7 @@ vi.spyOn(process.stdout, "write").mockImplementation(() => true);
 vi.spyOn(process.stderr, "write").mockImplementation(() => true);
 
 import { main } from "./Cli.js";
-import {
-	buildRecallPayload,
-	compileTaskContext,
-	listBranchCatalog,
-	renderContextMarkdown,
-} from "./core/ContextCompiler.js";
+import { compileTaskContext, listBranchCatalog, renderContextMarkdown } from "./core/ContextCompiler.js";
 import { loadConfigFromDir } from "./core/SessionTracker.js";
 import { exportSummaries } from "./core/SummaryExporter.js";
 import { hasMigrationMeta, migrateV1toV3 } from "./core/SummaryMigration.js";
@@ -1938,99 +1933,6 @@ describe("CLI", () => {
 					(typeof c[0] === "string" && c[0].includes('"type": "recall"')),
 			);
 			expect(jsonCall).toBeDefined();
-		});
-
-		it("--verbose forwards verbose: true to buildRecallPayload", async () => {
-			// The real buildRecallPayload is mocked at module-load time (see top
-			// of file), so this test asserts the CLI surface — i.e. that the
-			// flag arrives at the projection layer. The behavioural contract
-			// (minor drop + >8-commit response drop opt-out) is covered by the
-			// unit tests in ContextCompiler.test.ts which exercise the real
-			// implementation.
-			vi.mocked(listBranchCatalog).mockResolvedValueOnce({
-				type: "catalog",
-				branches: [
-					{
-						branch: "feature/keep-everything",
-						commitCount: 9,
-						period: { start: "2026-05-15", end: "2026-05-17" },
-						commitMessages: ["c"],
-					},
-				],
-			});
-			vi.mocked(compileTaskContext).mockResolvedValueOnce({
-				branch: "feature/keep-everything",
-				period: { start: "2026-05-15", end: "2026-05-17" },
-				commitCount: 9,
-				totalFilesChanged: 1,
-				totalInsertions: 1,
-				totalDeletions: 0,
-				summaries: [],
-				plans: [],
-				notes: [],
-				keyDecisions: [],
-				stats: {
-					topicCount: 0,
-					planCount: 0,
-					noteCount: 0,
-					decisionCount: 0,
-					topicTokens: 0,
-					planTokens: 0,
-					noteTokens: 0,
-					decisionTokens: 0,
-					transcriptTokens: 0,
-					totalTokens: 0,
-				},
-			});
-
-			await main(["recall", "feature/keep-everything", "--format", "json", "--verbose", "--cwd", "/tmp/test"]);
-
-			// The third positional arg to buildRecallPayload must carry verbose:true.
-			expect(buildRecallPayload).toHaveBeenCalledWith(expect.anything(), expect.any(Number), { verbose: true });
-		});
-
-		it("recall without --verbose forwards verbose: false to buildRecallPayload (default trim active)", async () => {
-			vi.mocked(listBranchCatalog).mockResolvedValueOnce({
-				type: "catalog",
-				branches: [
-					{
-						branch: "feature/keep-everything",
-						commitCount: 3,
-						period: { start: "2026-05-15", end: "2026-05-17" },
-						commitMessages: ["c"],
-					},
-				],
-			});
-			vi.mocked(compileTaskContext).mockResolvedValueOnce({
-				branch: "feature/keep-everything",
-				period: { start: "2026-05-15", end: "2026-05-17" },
-				commitCount: 3,
-				totalFilesChanged: 1,
-				totalInsertions: 1,
-				totalDeletions: 0,
-				summaries: [],
-				plans: [],
-				notes: [],
-				keyDecisions: [],
-				stats: {
-					topicCount: 0,
-					planCount: 0,
-					noteCount: 0,
-					decisionCount: 0,
-					topicTokens: 0,
-					planTokens: 0,
-					noteTokens: 0,
-					decisionTokens: 0,
-					transcriptTokens: 0,
-					totalTokens: 0,
-				},
-			});
-
-			await main(["recall", "feature/keep-everything", "--format", "json", "--cwd", "/tmp/test"]);
-
-			// Default path: third arg explicitly carries verbose:false so the
-			// projection layer's pre-passes engage as designed.
-			expect(buildRecallPayload).toHaveBeenCalledWith(expect.anything(), expect.any(Number), { verbose: false });
 		});
 
 		it("should output error JSON when commitCount is 0", async () => {

--- a/cli/src/commands/RecallCommand.ts
+++ b/cli/src/commands/RecallCommand.ts
@@ -171,7 +171,6 @@ async function outputRecall(
 		format?: string;
 		full?: boolean;
 		output?: string;
-		verbose?: boolean;
 	},
 	projectDir: string,
 ): Promise<void> {
@@ -219,9 +218,7 @@ async function outputRecall(
 	// from the structured fields; we deliberately do NOT pre-render markdown
 	// here (it would tempt the LLM back into paraphrase mode).
 	if (options.format === "json") {
-		const payload = buildRecallPayload(ctx, options.budget ?? DEFAULT_TOKEN_BUDGET, {
-			verbose: options.verbose === true,
-		});
+		const payload = buildRecallPayload(ctx, options.budget ?? DEFAULT_TOKEN_BUDGET);
 		console.log(JSON.stringify(payload));
 		return;
 	}
@@ -253,10 +250,6 @@ export function registerRecallCommand(program: Command): void {
 		.option("--include-transcripts", "Include transcript excerpts")
 		.option("--no-plans", "Exclude plan content")
 		.option("--catalog", "List all recorded branches (lightweight)")
-		.option(
-			"--verbose",
-			"Disable the minor-topic and >8-commit response pre-trims. Budget-driven trimming still applies — pass a higher --budget if you also want to suppress that.",
-		)
 		.option(
 			"--arg-stdin",
 			"Read the branch/keyword argument from stdin instead of argv (used by SKILL.md here-doc bridge)",

--- a/cli/src/commands/RecallCommand.ts
+++ b/cli/src/commands/RecallCommand.ts
@@ -171,6 +171,7 @@ async function outputRecall(
 		format?: string;
 		full?: boolean;
 		output?: string;
+		verbose?: boolean;
 	},
 	projectDir: string,
 ): Promise<void> {
@@ -218,8 +219,10 @@ async function outputRecall(
 	// from the structured fields; we deliberately do NOT pre-render markdown
 	// here (it would tempt the LLM back into paraphrase mode).
 	if (options.format === "json") {
-		const payload = buildRecallPayload(ctx, options.budget ?? DEFAULT_TOKEN_BUDGET);
-		console.log(JSON.stringify(payload, null, 2));
+		const payload = buildRecallPayload(ctx, options.budget ?? DEFAULT_TOKEN_BUDGET, {
+			verbose: options.verbose === true,
+		});
+		console.log(JSON.stringify(payload));
 		return;
 	}
 
@@ -250,6 +253,10 @@ export function registerRecallCommand(program: Command): void {
 		.option("--include-transcripts", "Include transcript excerpts")
 		.option("--no-plans", "Exclude plan content")
 		.option("--catalog", "List all recorded branches (lightweight)")
+		.option(
+			"--verbose",
+			"Disable the minor-topic and >8-commit response pre-trims. Budget-driven trimming still applies — pass a higher --budget if you also want to suppress that.",
+		)
 		.option(
 			"--arg-stdin",
 			"Read the branch/keyword argument from stdin instead of argv (used by SKILL.md here-doc bridge)",
@@ -307,7 +314,7 @@ export function registerRecallCommand(program: Command): void {
 				if (options.catalog) {
 					const catalog = await listBranchCatalog(projectDir);
 					if (options.format === "json") {
-						console.log(JSON.stringify(catalog, null, 2));
+						console.log(JSON.stringify(catalog));
 					} else {
 						console.log(renderCatalogText(catalog));
 					}
@@ -343,7 +350,7 @@ export function registerRecallCommand(program: Command): void {
 
 					// No exact match — return catalog with query for LLM semantic matching
 					if (options.format === "json") {
-						console.log(JSON.stringify({ ...catalog, query: branch }, null, 2));
+						console.log(JSON.stringify({ ...catalog, query: branch }));
 					} else {
 						console.log(renderCatalogText(catalog, branch));
 					}
@@ -369,7 +376,7 @@ export function registerRecallCommand(program: Command): void {
 
 				// Fallback: return catalog
 				if (options.format === "json") {
-					console.log(JSON.stringify(catalog, null, 2));
+					console.log(JSON.stringify(catalog));
 				} else {
 					console.log(renderCatalogText(catalog));
 				}

--- a/cli/src/core/ContextCompiler.test.ts
+++ b/cli/src/core/ContextCompiler.test.ts
@@ -1425,9 +1425,9 @@ describe("buildRecallPayload", () => {
 		expect(tight.commitCount).toBe(1);
 	});
 
-	it("uses default DEFAULT_TOKEN_BUDGET (50K) when no budget is passed", () => {
+	it("uses default DEFAULT_TOKEN_BUDGET (20K) when no budget is passed", () => {
 		const payload = buildRecallPayload(makeCtx());
-		// Default 50K easily fits a 1-commit fixture; nothing is truncated.
+		// Default 20K easily fits a 1-commit fixture; nothing is truncated.
 		expect(payload.truncated).toBeUndefined();
 		expect(payload.commits).toHaveLength(1);
 	});
@@ -1560,6 +1560,224 @@ describe("buildRecallPayload", () => {
 		expect(payload.totalInsertions).toBe(312);
 		expect(payload.totalDeletions).toBe(89);
 		expect(payload.period).toEqual({ start: "2026-04-10", end: "2026-04-15" });
+	});
+
+	it('drops topics with importance === "minor" from the payload', () => {
+		const summary = makeSummary({
+			topics: [
+				{
+					title: "Major work",
+					trigger: "t1",
+					response: "r1",
+					decisions: "d1",
+					importance: "major",
+				},
+				{
+					title: "Minor tweak",
+					trigger: "t2",
+					response: "r2",
+					decisions: "d2",
+					importance: "minor",
+				},
+			],
+		});
+		const payload = buildRecallPayload(makeCtx({ summaries: [summary] }), 100_000);
+		expect(payload.commits).toHaveLength(1);
+		expect(payload.commits[0].topics).toHaveLength(1);
+		expect(payload.commits[0].topics[0].title).toBe("Major work");
+		expect(payload.truncated).toBe(true);
+	});
+
+	it("drops the whole commit when every topic on it is minor", () => {
+		const major = makeSummary({
+			commitHash: "aaaaaaaa00000000000000000000000000000001",
+			topics: [
+				{
+					title: "Real work",
+					trigger: "t",
+					response: "r",
+					decisions: "d",
+					importance: "major",
+				},
+			],
+		});
+		const allMinor = makeSummary({
+			commitHash: "bbbbbbbb00000000000000000000000000000002",
+			topics: [
+				{
+					title: "Nit 1",
+					trigger: "t",
+					response: "r",
+					decisions: "d",
+					importance: "minor",
+				},
+				{
+					title: "Nit 2",
+					trigger: "t",
+					response: "r",
+					decisions: "d",
+					importance: "minor",
+				},
+			],
+		});
+		const payload = buildRecallPayload(makeCtx({ summaries: [major, allMinor], commitCount: 2 }), 100_000);
+		expect(payload.commits).toHaveLength(1);
+		expect(payload.commits[0].fullHash).toBe(major.commitHash);
+		expect(payload.truncated).toBe(true);
+		// Envelope commitCount reflects what was loaded (still 2), not what was kept (1).
+		expect(payload.commitCount).toBe(2);
+	});
+
+	it("keeps all topics when filtering minors would leave commits[] empty (pathological branch)", () => {
+		const onlyMinor = makeSummary({
+			topics: [
+				{
+					title: "Only nit",
+					trigger: "t",
+					response: "r",
+					decisions: "d",
+					importance: "minor",
+				},
+			],
+		});
+		const payload = buildRecallPayload(makeCtx({ summaries: [onlyMinor] }), 100_000);
+		// Filter would have evicted everything; safety guard keeps the topic so
+		// the downstream "commits=[] means no records" invariant is preserved.
+		expect(payload.commits).toHaveLength(1);
+		expect(payload.commits[0].topics).toHaveLength(1);
+		expect(payload.truncated).toBeUndefined();
+	});
+
+	it("does not drop minor topics when called with verbose: true", () => {
+		const summary = makeSummary({
+			topics: [
+				{
+					title: "Major",
+					trigger: "t",
+					response: "r",
+					decisions: "d",
+					importance: "major",
+				},
+				{
+					title: "Minor",
+					trigger: "t",
+					response: "r",
+					decisions: "d",
+					importance: "minor",
+				},
+			],
+		});
+		const payload = buildRecallPayload(makeCtx({ summaries: [summary] }), 100_000, { verbose: true });
+		expect(payload.commits[0].topics).toHaveLength(2);
+		expect(payload.truncated).toBeUndefined();
+	});
+
+	it("keeps topic.response for branches with at most 8 commits", () => {
+		const summaries = Array.from({ length: 8 }, (_, i) =>
+			makeSummary({
+				commitHash: `cccccccc00000000000000000000000000000${String(i).padStart(3, "0")}`.slice(0, 40),
+				topics: [
+					{
+						title: `T${i}`,
+						trigger: `trig-${i}`,
+						response: `resp-${i}`,
+						decisions: `dec-${i}`,
+						importance: "major",
+					},
+				],
+			}),
+		);
+		const payload = buildRecallPayload(makeCtx({ summaries, commitCount: 8 }), 100_000);
+		expect(payload.commits).toHaveLength(8);
+		expect(payload.commits.every((c) => c.topics[0].response !== undefined)).toBe(true);
+		expect(payload.truncated).toBeUndefined();
+	});
+
+	it("drops topic.response from every commit when the branch has more than 8 commits", () => {
+		const summaries = Array.from({ length: 9 }, (_, i) =>
+			makeSummary({
+				commitHash: `dddddddd00000000000000000000000000000${String(i).padStart(3, "0")}`.slice(0, 40),
+				topics: [
+					{
+						title: `T${i}`,
+						trigger: `trig-${i}`,
+						response: `resp-${i}`,
+						decisions: `dec-${i}`,
+						importance: "major",
+					},
+				],
+			}),
+		);
+		const payload = buildRecallPayload(makeCtx({ summaries, commitCount: 9 }), 100_000);
+		expect(payload.commits).toHaveLength(9);
+		expect(payload.commits.every((c) => c.topics[0].response === undefined)).toBe(true);
+		// trigger and decisions both survive — only response is targeted at this tier.
+		expect(payload.commits[0].topics[0].trigger).toBe("trig-0");
+		expect(payload.commits[0].topics[0].decisions).toBe("dec-0");
+		expect(payload.truncated).toBe(true);
+	});
+
+	it("keeps topic.response on >8 commits when called with verbose: true", () => {
+		const summaries = Array.from({ length: 12 }, (_, i) =>
+			makeSummary({
+				commitHash: `eeeeeeee00000000000000000000000000000${String(i).padStart(3, "0")}`.slice(0, 40),
+				topics: [
+					{
+						title: `T${i}`,
+						trigger: `trig-${i}`,
+						response: `resp-${i}`,
+						decisions: `dec-${i}`,
+						importance: "major",
+					},
+				],
+			}),
+		);
+		const payload = buildRecallPayload(makeCtx({ summaries, commitCount: 12 }), 100_000, { verbose: true });
+		expect(payload.commits.every((c) => c.topics[0].response !== undefined)).toBe(true);
+		expect(payload.truncated).toBeUndefined();
+	});
+
+	it("applies the >8-commit response-drop tier after minor-topic filtering, not before", () => {
+		// Build 10 commits but 3 of them are all-minor → after minor filter we have 7 commits.
+		// 7 ≤ 8, so the tier MUST NOT fire even though the raw count was >8.
+		const majorCommits = Array.from({ length: 7 }, (_, i) =>
+			makeSummary({
+				commitHash: `ffffffff00000000000000000000000000000${String(i).padStart(3, "0")}`.slice(0, 40),
+				topics: [
+					{
+						title: `T${i}`,
+						trigger: "t",
+						response: `resp-${i}`,
+						decisions: "d",
+						importance: "major",
+					},
+				],
+			}),
+		);
+		const minorOnlyCommits = Array.from({ length: 3 }, (_, i) =>
+			makeSummary({
+				commitHash: `99999999000000000000000000000000000${String(i).padStart(4, "0")}`.slice(0, 40),
+				topics: [
+					{
+						title: `M${i}`,
+						trigger: "t",
+						response: "r",
+						decisions: "d",
+						importance: "minor",
+					},
+				],
+			}),
+		);
+		const payload = buildRecallPayload(
+			makeCtx({
+				summaries: [...majorCommits, ...minorOnlyCommits],
+				commitCount: 10,
+			}),
+			100_000,
+		);
+		// 7 commits survived the minor filter; that's ≤8, so response stays.
+		expect(payload.commits).toHaveLength(7);
+		expect(payload.commits.every((c) => c.topics[0].response !== undefined)).toBe(true);
 	});
 });
 

--- a/cli/src/core/ContextCompiler.test.ts
+++ b/cli/src/core/ContextCompiler.test.ts
@@ -1648,30 +1648,6 @@ describe("buildRecallPayload", () => {
 		expect(payload.truncated).toBeUndefined();
 	});
 
-	it("does not drop minor topics when called with verbose: true", () => {
-		const summary = makeSummary({
-			topics: [
-				{
-					title: "Major",
-					trigger: "t",
-					response: "r",
-					decisions: "d",
-					importance: "major",
-				},
-				{
-					title: "Minor",
-					trigger: "t",
-					response: "r",
-					decisions: "d",
-					importance: "minor",
-				},
-			],
-		});
-		const payload = buildRecallPayload(makeCtx({ summaries: [summary] }), 100_000, { verbose: true });
-		expect(payload.commits[0].topics).toHaveLength(2);
-		expect(payload.truncated).toBeUndefined();
-	});
-
 	it("keeps topic.response for branches with at most 8 commits", () => {
 		const summaries = Array.from({ length: 8 }, (_, i) =>
 			makeSummary({
@@ -1717,26 +1693,6 @@ describe("buildRecallPayload", () => {
 		expect(payload.truncated).toBe(true);
 	});
 
-	it("keeps topic.response on >8 commits when called with verbose: true", () => {
-		const summaries = Array.from({ length: 12 }, (_, i) =>
-			makeSummary({
-				commitHash: `eeeeeeee00000000000000000000000000000${String(i).padStart(3, "0")}`.slice(0, 40),
-				topics: [
-					{
-						title: `T${i}`,
-						trigger: `trig-${i}`,
-						response: `resp-${i}`,
-						decisions: `dec-${i}`,
-						importance: "major",
-					},
-				],
-			}),
-		);
-		const payload = buildRecallPayload(makeCtx({ summaries, commitCount: 12 }), 100_000, { verbose: true });
-		expect(payload.commits.every((c) => c.topics[0].response !== undefined)).toBe(true);
-		expect(payload.truncated).toBeUndefined();
-	});
-
 	it("applies the >8-commit response-drop tier after minor-topic filtering, not before", () => {
 		// Build 10 commits but 3 of them are all-minor → after minor filter we have 7 commits.
 		// 7 ≤ 8, so the tier MUST NOT fire even though the raw count was >8.
@@ -1778,6 +1734,41 @@ describe("buildRecallPayload", () => {
 		// 7 commits survived the minor filter; that's ≤8, so response stays.
 		expect(payload.commits).toHaveLength(7);
 		expect(payload.commits.every((c) => c.topics[0].response !== undefined)).toBe(true);
+	});
+
+	it("chains pre-pass 2 with the budget loop: response stripped by tier, trigger stripped by budget on oldest", () => {
+		// 12 commits, each topic with verbose trigger + response. The tier
+		// (>8) drops every response. Budget then runs Step 2 (drop trigger
+		// from oldest commits) until measure() <= budget. The middle / newest
+		// commits keep their trigger; the oldest one(s) lose it. Decisions
+		// survives on every kept commit. The budget loop's Step 1 (drop
+		// response) is dead code on this path — pre-pass 2 already cleared
+		// it; the new responseAlreadyStripped guard skips Step 1 entirely.
+		const summaries = Array.from({ length: 12 }, (_, i) =>
+			makeSummary({
+				commitHash: `12345678000000000000000000000000000000${String(i).padStart(2, "0")}`.slice(0, 40),
+				topics: [
+					{
+						title: `T${i}`,
+						trigger: "T".repeat(1500),
+						response: "R".repeat(1500),
+						decisions: `dec-${i}`,
+						importance: "major",
+					},
+				],
+			}),
+		);
+		const payload = buildRecallPayload(makeCtx({ summaries, commitCount: 12 }), 2000);
+		expect(payload.truncated).toBe(true);
+		// Pre-pass 2: response gone everywhere.
+		expect(payload.commits.every((c) => c.topics[0].response === undefined)).toBe(true);
+		// Budget loop: at least the oldest commit lost trigger to fit the
+		// 2000-token budget; the newest commit kept its trigger because the
+		// loop stops as soon as measure() <= budget.
+		expect(payload.commits[0].topics[0].trigger).toBeUndefined();
+		expect(payload.commits[payload.commits.length - 1].topics[0].trigger).toBe("T".repeat(1500));
+		// Decisions survive on every kept commit (skill-template invariant).
+		expect(payload.commits.every((c) => typeof c.topics[0].decisions === "string")).toBe(true);
 	});
 });
 

--- a/cli/src/core/ContextCompiler.ts
+++ b/cli/src/core/ContextCompiler.ts
@@ -310,7 +310,7 @@ export const DEFAULT_TOKEN_BUDGET = 20000;
 /**
  * Commit-count threshold above which `buildRecallPayload` automatically
  * drops `topic.response` from every kept commit. Below or equal to this,
- * full `response` survives so short branches keep their verbose narrative.
+ * full `response` survives so short branches keep their narrative detail.
  *
  * Measured: `response` is consistently the longest topic field (~500–800
  * bytes typical) while contributing the least unique signal — `decisions`
@@ -318,25 +318,10 @@ export const DEFAULT_TOKEN_BUDGET = 20000;
  * Branches past this size are being used for "remind me of the shape",
  * not "walk me through the implementation".
  *
- * Override the auto-drop with `--verbose` on the CLI (sets
- * `BuildRecallPayloadOptions.verbose = true`).
+ * No opt-out: this is a policy trim. Use `jolli view --commit <hash>` to
+ * inspect a single commit's full stored topic content when needed.
  */
-export const RECALL_COMMIT_VERBOSE_THRESHOLD = 8;
-
-/**
- * Behaviour switches for {@link buildRecallPayload} that are not part of the
- * token budget — kept separate so existing callers passing only a number
- * keep compiling.
- */
-export interface BuildRecallPayloadOptions {
-	/**
-	 * When true, skip the recall-only pre-passes that drop `"minor"` topics
-	 * and (above the commit-count threshold) drop `topic.response`. The
-	 * regular budget-driven trim loop still runs. Use for "give me everything"
-	 * recall (`jolli recall <branch> --verbose --format json`).
-	 */
-	readonly verbose?: boolean;
-}
+export const RECALL_LARGE_BRANCH_THRESHOLD = 8;
 
 /**
  * Compiles task context for a branch from Jolli Memory's orphan branch data.
@@ -525,13 +510,8 @@ export async function compileTaskContext(options: ContextOptions, cwd?: string):
  * shipped without decisions — the skill template can rely on "all kept hits
  * are complete".
  */
-export function buildRecallPayload(
-	ctx: CompiledContext,
-	tokenBudget?: number,
-	options: BuildRecallPayloadOptions = {},
-): RecallPayload {
+export function buildRecallPayload(ctx: CompiledContext, tokenBudget?: number): RecallPayload {
 	const budget = tokenBudget ?? DEFAULT_TOKEN_BUDGET;
-	const verbose = options.verbose === true;
 
 	let plans: RecallPayloadPlan[] = ctx.plans.map((p) => ({ slug: p.slug, title: p.title, content: p.content }));
 	let notes: RecallPayloadNote[] = ctx.notes.map((n) => ({ id: n.id, title: n.title, content: n.content }));
@@ -551,46 +531,45 @@ export function buildRecallPayload(
 	let commits: SearchHit[] = ctx.summaries.map((s) => filterStubs(buildHit(s), resolvedPlanSlugs, resolvedNoteIds));
 	let truncated = false;
 
-	// Recall-only pre-pass: drop topics the LLM flagged as `"minor"`. These
+	// Recall-only pre-pass 1: drop topics the LLM flagged as `"minor"`. These
 	// are noise at the branch level — by definition the summarizer thought
 	// they don't carry decision-grade signal. Search Phase 2 keeps them
 	// (it ships the full SearchHit shape) so this trimming lives here, not
 	// in `buildHit`. If a commit's topics become empty after the filter,
 	// drop the whole commit — kept commits must always carry decisions
 	// per the skill-template contract. Safety: if the filter would evict
-	// every commit (pathological branch where every topic is minor),
-	// revert so downstream `commits=[]` doesn't ambiguously mean "no
-	// records found".
-	if (!verbose) {
-		const filtered: SearchHit[] = [];
-		let anyTopicDropped = false;
-		let anyCommitDropped = false;
-		for (const hit of commits) {
-			const kept = hit.topics.filter((t) => t.importance !== "minor");
-			if (kept.length === hit.topics.length) {
-				filtered.push(hit);
-				continue;
-			}
-			anyTopicDropped = true;
-			if (kept.length === 0) {
-				anyCommitDropped = true;
-				continue;
-			}
-			filtered.push({ ...hit, topics: kept });
+	// every commit (pathological branch where every topic is minor), skip
+	// the assignment so the original commits stay in place and downstream
+	// `commits=[]` doesn't ambiguously mean "no records found".
+	const filtered: SearchHit[] = [];
+	let anyTopicDropped = false;
+	let anyCommitDropped = false;
+	for (const hit of commits) {
+		const kept = hit.topics.filter((t) => t.importance !== "minor");
+		if (kept.length === hit.topics.length) {
+			filtered.push(hit);
+			continue;
 		}
-		if (filtered.length > 0) {
-			commits = filtered;
-			if (anyTopicDropped || anyCommitDropped) truncated = true;
+		anyTopicDropped = true;
+		if (kept.length === 0) {
+			anyCommitDropped = true;
+			continue;
 		}
+		filtered.push({ ...hit, topics: kept });
+	}
+	if (filtered.length > 0) {
+		commits = filtered;
+		if (anyTopicDropped || anyCommitDropped) truncated = true;
 	}
 
-	// Recall-only pre-pass: above the verbose threshold, `topic.response`
-	// drops from every kept commit. The measurement runs AFTER the minor
-	// filter so we tier by what would actually ship, not what was loaded.
-	// `trigger` and `decisions` survive — only `response` is targeted here;
-	// the existing budget-trim loop below may further drop `trigger` if
-	// it still doesn't fit.
-	if (!verbose && commits.length > RECALL_COMMIT_VERBOSE_THRESHOLD) {
+	// Recall-only pre-pass 2: above the large-branch threshold, drop
+	// `topic.response` from every kept commit. The measurement runs AFTER
+	// pre-pass 1 so we tier by what would actually ship, not what was
+	// loaded. `trigger` and `decisions` survive — only `response` is
+	// targeted here; the existing budget-trim loop below may further drop
+	// `trigger` if --budget still leaves us over-pressure.
+	const responseAlreadyStripped = commits.length > RECALL_LARGE_BRANCH_THRESHOLD;
+	if (responseAlreadyStripped) {
 		let anyDropped = false;
 		commits = commits.map((hit) => {
 			const trimmed = hit.topics.map((t) => {
@@ -621,8 +600,10 @@ export function buildRecallPayload(
 
 	const measure = (): number => estimateTokens(JSON.stringify({ ...envelope, commits, plans, notes }));
 
-	// Step 1: drop topic.response from oldest commits
-	for (let i = 0; i < commits.length && measure() > budget; i++) {
+	// Step 1: drop topic.response from oldest commits.
+	// Skip when pre-pass 2 already stripped response from every commit —
+	// the loop would otherwise spread-copy every topic for no reason.
+	for (let i = 0; !responseAlreadyStripped && i < commits.length && measure() > budget; i++) {
 		const hit = commits[i];
 		const trimmed = hit.topics.map((t) => {
 			if (t.response === undefined) return t;

--- a/cli/src/core/ContextCompiler.ts
+++ b/cli/src/core/ContextCompiler.ts
@@ -299,11 +299,44 @@ function deduplicatePlans(candidates: ReadonlyArray<PlanCandidate>): ReadonlyArr
 
 /**
  * Default token budget for recall output (`jolli recall --format json` and
- * `--full` markdown). 50K leaves ~75% of a 200K-context model free for the
- * surrounding conversation; 1M-context models almost never trip the budget
- * enforcement path. Users can override with `--budget <tokens>`.
+ * `--full` markdown). 20K leaves ~90% of a 200K-context model free for the
+ * surrounding conversation. Lower than the historical 50K so the trim loop
+ * engages on medium branches (20+ commits) — older `response` / `trigger`
+ * fields drop oldest-first before they bloat the LLM's context. Users who
+ * want the old behaviour can pass `--budget 50000`.
  */
-export const DEFAULT_TOKEN_BUDGET = 50000;
+export const DEFAULT_TOKEN_BUDGET = 20000;
+
+/**
+ * Commit-count threshold above which `buildRecallPayload` automatically
+ * drops `topic.response` from every kept commit. Below or equal to this,
+ * full `response` survives so short branches keep their verbose narrative.
+ *
+ * Measured: `response` is consistently the longest topic field (~500–800
+ * bytes typical) while contributing the least unique signal — `decisions`
+ * already captures "why", `recap` captures "what at the commit level".
+ * Branches past this size are being used for "remind me of the shape",
+ * not "walk me through the implementation".
+ *
+ * Override the auto-drop with `--verbose` on the CLI (sets
+ * `BuildRecallPayloadOptions.verbose = true`).
+ */
+export const RECALL_COMMIT_VERBOSE_THRESHOLD = 8;
+
+/**
+ * Behaviour switches for {@link buildRecallPayload} that are not part of the
+ * token budget — kept separate so existing callers passing only a number
+ * keep compiling.
+ */
+export interface BuildRecallPayloadOptions {
+	/**
+	 * When true, skip the recall-only pre-passes that drop `"minor"` topics
+	 * and (above the commit-count threshold) drop `topic.response`. The
+	 * regular budget-driven trim loop still runs. Use for "give me everything"
+	 * recall (`jolli recall <branch> --verbose --format json`).
+	 */
+	readonly verbose?: boolean;
+}
 
 /**
  * Compiles task context for a branch from Jolli Memory's orphan branch data.
@@ -492,8 +525,13 @@ export async function compileTaskContext(options: ContextOptions, cwd?: string):
  * shipped without decisions — the skill template can rely on "all kept hits
  * are complete".
  */
-export function buildRecallPayload(ctx: CompiledContext, tokenBudget?: number): RecallPayload {
+export function buildRecallPayload(
+	ctx: CompiledContext,
+	tokenBudget?: number,
+	options: BuildRecallPayloadOptions = {},
+): RecallPayload {
 	const budget = tokenBudget ?? DEFAULT_TOKEN_BUDGET;
+	const verbose = options.verbose === true;
 
 	let plans: RecallPayloadPlan[] = ctx.plans.map((p) => ({ slug: p.slug, title: p.title, content: p.content }));
 	let notes: RecallPayloadNote[] = ctx.notes.map((n) => ({ id: n.id, title: n.title, content: n.content }));
@@ -512,6 +550,59 @@ export function buildRecallPayload(ctx: CompiledContext, tokenBudget?: number): 
 	// is the oldest — matching the trim direction below.
 	let commits: SearchHit[] = ctx.summaries.map((s) => filterStubs(buildHit(s), resolvedPlanSlugs, resolvedNoteIds));
 	let truncated = false;
+
+	// Recall-only pre-pass: drop topics the LLM flagged as `"minor"`. These
+	// are noise at the branch level — by definition the summarizer thought
+	// they don't carry decision-grade signal. Search Phase 2 keeps them
+	// (it ships the full SearchHit shape) so this trimming lives here, not
+	// in `buildHit`. If a commit's topics become empty after the filter,
+	// drop the whole commit — kept commits must always carry decisions
+	// per the skill-template contract. Safety: if the filter would evict
+	// every commit (pathological branch where every topic is minor),
+	// revert so downstream `commits=[]` doesn't ambiguously mean "no
+	// records found".
+	if (!verbose) {
+		const filtered: SearchHit[] = [];
+		let anyTopicDropped = false;
+		let anyCommitDropped = false;
+		for (const hit of commits) {
+			const kept = hit.topics.filter((t) => t.importance !== "minor");
+			if (kept.length === hit.topics.length) {
+				filtered.push(hit);
+				continue;
+			}
+			anyTopicDropped = true;
+			if (kept.length === 0) {
+				anyCommitDropped = true;
+				continue;
+			}
+			filtered.push({ ...hit, topics: kept });
+		}
+		if (filtered.length > 0) {
+			commits = filtered;
+			if (anyTopicDropped || anyCommitDropped) truncated = true;
+		}
+	}
+
+	// Recall-only pre-pass: above the verbose threshold, `topic.response`
+	// drops from every kept commit. The measurement runs AFTER the minor
+	// filter so we tier by what would actually ship, not what was loaded.
+	// `trigger` and `decisions` survive — only `response` is targeted here;
+	// the existing budget-trim loop below may further drop `trigger` if
+	// it still doesn't fit.
+	if (!verbose && commits.length > RECALL_COMMIT_VERBOSE_THRESHOLD) {
+		let anyDropped = false;
+		commits = commits.map((hit) => {
+			const trimmed = hit.topics.map((t) => {
+				if (t.response === undefined) return t;
+				anyDropped = true;
+				const { response: _r, ...rest } = t;
+				return rest;
+			});
+			return { ...hit, topics: trimmed };
+		});
+		if (anyDropped) truncated = true;
+	}
 
 	// Build a stable envelope that surrounds commits/plans/notes so the budget
 	// measure reflects the actual JSON output size, not just the variable parts.

--- a/cli/src/install/SkillInstaller.ts
+++ b/cli/src/install/SkillInstaller.ts
@@ -317,9 +317,15 @@ You have a \`RecallPayload\` with these fields:
   - \`recap?\` — 1-3 paragraphs of plain-English narrative.
   - \`topics[]\` — each with **always present**: \`title\`, **\`decisions\` (★)**;
     **may be absent**: \`trigger?\`, \`response?\`, \`todo?\`, \`filesAffected?\`,
-    \`category?\`, \`importance?\`. \`trigger\` and \`response\` may be dropped by
-    budget trimming; \`decisions\` is never dropped from a kept commit (if the
-    budget can't fit it, the whole commit is omitted from \`commits[]\`).
+    \`category?\`, \`importance?\`. Trimming rules differ by field:
+    - \`response\` is **policy-trimmed unconditionally** when the branch
+      ships more than 8 kept commits — raising \`--budget\` will not bring
+      it back. Additionally, on tight budgets it may be dropped
+      oldest-first on shorter branches.
+    - \`trigger\` is only dropped by \`--budget\` (oldest-first); raising
+      \`--budget\` can restore it.
+    - \`decisions\` is never dropped from a kept commit (if the budget
+      can't fit it, the whole commit is omitted from \`commits[]\`).
   - \`plans?\` — \`{ slug, title }[]\` refs only; \`slug\` is the **normalized
     base slug** that always resolves to an entry in payload-level \`plans\`.
   - \`notes?\` — \`{ id, title }[]\` refs only; \`id\` always resolves to an

--- a/cli/src/install/SkillInstaller.ts
+++ b/cli/src/install/SkillInstaller.ts
@@ -423,9 +423,12 @@ top-level \`plans\` / \`notes\` array by its \`slug\` (plans) or \`id\` (notes):
 
 - Empty \`commits\`: tell the user no records were found; suggest running
   \`jolli enable\` if they expected records.
-- \`truncated: true\`: budget enforcement dropped fields or commits. Mention
-  it with a one-liner if the user asks for deeper detail; otherwise stay
-  silent.
+- \`truncated: true\`: policy trims or budget enforcement dropped fields
+  or commits. Policy trims drop \`importance: "minor"\` topics (and any
+  commit whose every topic is minor) and drop \`topic.response\` when the
+  branch ships more than 8 commits; budget trims drop oldest-first
+  \`response\` / \`trigger\` / plan / note content. Mention it with a
+  one-liner if the user asks for deeper detail; otherwise stay silent.
 
 ### type: "catalog" — branch lookup needed
 


### PR DESCRIPTION
<!-- jollimemory-summary-start -->
## Commits in this PR (3)

1. Slim recall output and fix verbose flag help text (`1775f33`)
2. Remove --verbose escape hatch; rename threshold; guard dead budget-loop step (`ee115e8`)
3. Distinguish policy vs budget trimming in recall skill schema doc (`ac964b3`)

## Quick recap (3)

### Commit 1 of 3: Slim recall output and fix verbose flag help text (`1775f33`)

The recall command's output is now significantly leaner by default, with several layers of automatic trimming working together before content reaches the language model. Topics that had already been flagged as low-signal are stripped in a pre-pass, and when every topic on a commit is low-signal the entire commit entry is removed from the payload. A safety guard ensures that a branch where every recorded topic is low-signal still produces a non-empty result, preserving the existing guarantee that an empty payload means no records exist rather than all records were filtered out.

On branches with more than eight commits of retained history after that initial filtering, the per-topic narrative walkthrough is also automatically omitted. The structured fields capturing decisions and outcomes remain intact at this stage; only the longest, lowest-signal narrative field is dropped. The default token budget was recalibrated to 20,000 tokens, so the trim loop engages reliably on medium-sized branches while still leaving the vast majority of a large-context model's window free for conversation.

Users who need the full, unfiltered picture can pass a verbose flag to the recall command. With the flag set, both the minor-topic filter and the narrative-field trim are disabled, and every recorded detail is returned up to the token budget. The verbose flag's help text was corrected to accurately describe what it disables, and a pointer to the separate budget flag was added for users who want to push the token ceiling higher as well.

### Commit 2 of 3: Remove --verbose escape hatch; rename threshold; guard dead budget-loop step (`ee115e8`)

The automatic trimming behavior applied to branch recall output — dropping low-signal topics and removing narrative detail on large branches — was previously possible to bypass with a developer flag. That escape hatch has been removed. Both trimming steps now run unconditionally on every recall request, making the output shape consistent and predictable regardless of how the command is invoked. Users who need the full stored content for a specific commit can still access it by inspecting that commit directly.

The constant controlling the large-branch trim tier was also renamed to better reflect what it actually does: it marks the point at which a branch is considered too large for detailed narrative output, not a threshold for a "verbose" mode. A performance guard was added so that when the large-branch pass has already cleared all narrative detail, a subsequent trimming loop skips its now-redundant iteration over every commit.

### Commit 3 of 3: Distinguish policy vs budget trimming in recall skill schema doc (`ac964b3`)

The skill contract that AI agents read when using the recall feature now accurately describes which missing fields can be recovered and which cannot. Previously, both the trigger and response fields were described together as recoverable by raising the budget limit. Response fields on large branches are now correctly documented as permanently absent regardless of budget, while trigger fields remain documented as budget-recoverable. Agents operating in repositories that install a new version of the tool will receive the corrected guidance and stop suggesting budget increases as a fix for an unrelated policy constraint.

## E2E Test (2)
<details>
<summary><strong>1. [1775f33] Minor topics are hidden from recall output by default</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a branch recorded in Jolli Memory that contains at least one commit with a mix of major and minor topics (the minor topics would have been flagged as low-importance by the summarizer).

**Steps:**
1. Open your terminal.
2. Run the recall command for that branch in JSON format, for example: `jolli recall <branch-name> --format json`
3. Look at the output and find the "commits" section.
4. Check the list of topics inside each commit entry.
5. Verify that no topic with an importance level of "minor" appears in the output.
6. Also check that if a commit had only minor topics, the entire commit entry is absent from the output.

**Expected Results:**
- Only topics flagged as major (or equivalent) appear under each commit.
- Any commit whose every topic was minor does not appear in the commits list at all.
- The output includes a "truncated: true" indicator, signalling that some content was filtered.

</blockquote>
</details>
<details>
<summary><strong>2. [1775f33] Response field is automatically removed on branches with more than 8 commits</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a branch in Jolli Memory with 9 or more recorded commits, each containing at least one major topic with a response narrative.

**Steps:**
1. Open your terminal.
2. Run: `jolli recall <branch-name> --format json`
3. Look inside the "commits" section and open any individual topic entry.
4. Check whether a "response" field is present inside the topic.
5. Confirm the "truncated: true" field appears at the top level of the output.
6. Also confirm that "trigger" and "decisions" fields are still present inside each topic.

**Expected Results:**
- No topic in any commit contains a "response" field.
- Every topic still has its "trigger" and "decisions" fields intact.
- The output contains "truncated: true" at the top level.

</blockquote>
</details>

## Topics (11)
<details>
<summary><strong>01 · [1775f33] Filter low-signal topics and trim narrative fields from recall output by default</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

As a branch grows, the recall payload becomes token-heavy with low-value content: topics the summarizer had already flagged as minor were included alongside high-signal work, and the longest narrative field on each topic was always sent regardless of branch size.

**💡 Decisions Behind the Code**

- **Filter before the budget loop, not inside it**: The minor-topic filter and the narrative-field trim are semantic pre-passes that run before the token-budget loop. Merging them into the budget loop would couple signal-quality and size concerns, making both harder to reason about and test independently. Keeping them separate means the budget loop always sees a clean, already-filtered set of commits.
- **Safety guard instead of silent empty result**: When every commit would be evicted by the minor-topic filter, the filter reverts rather than returning an empty payload. An empty commits array already has a defined meaning downstream ("no records found"), and silently producing one for a branch that does have records would be misleading and hard to debug.
- **Drop response first, not trigger or decisions**: The response field is consistently the longest topic field while carrying the least unique signal at recall time — decisions already captures the "why" and the commit-level recap captures the "what". Dropping it first preserves the fields most useful for orientation on a large branch, and leaves the existing budget-trim loop to handle any remaining overflow by targeting trigger.
- **Measure threshold against post-filter count, not raw branch size**: The 8-commit threshold is applied to commits that would actually ship in the payload. A branch with ten commits where three are all-minor drops to seven after filtering; seven is within the threshold, so the narrative trim does not fire. Measuring raw count would penalize branches that are effectively small after filtering, producing unnecessary data loss.
- **Options object over a positional flag**: The verbose option is delivered via a dedicated options struct rather than an additional positional parameter. The budget parameter is a plain number, and adding a boolean alongside it would have required callers to pass a sentinel value to reach the flag. A dedicated struct keeps call sites readable, leaves existing callers unchanged, and makes it straightforward to add further switches without breaking the signature again.

**✅ What Was Implemented**

- Added a minor-topic pre-pass in `buildRecallPayload` (`ContextCompiler.ts`) that removes any topic whose importance is `"minor"` before the token-budget trim loop runs. If all topics on a commit are removed, the entire commit entry is dropped. A safety guard reverts the filter when it would eliminate every commit, preserving the invariant that an empty commits array means "no records found".
- Added a `RECALL_COMMIT_VERBOSE_THRESHOLD` constant (value: 8, exported) to `ContextCompiler.ts`. When the surviving commit count after minor-topic filtering exceeds this threshold and verbose mode is off, a second pre-pass strips the response field from every topic and sets the truncated flag. Trigger and decisions fields are left intact at this tier; the existing budget loop may still drop trigger if the payload remains oversized.
- Introduced a `BuildRecallPayloadOptions` interface (exported from `ContextCompiler.ts`) with a `verbose` flag. Passing `verbose: true` bypasses both the minor-topic filter and the response-field trim entirely.
- Added eight test cases to `ContextCompiler.test.ts` covering: partial topic drop within a commit, whole-commit drop when every topic is minor, the all-minor safety guard, the verbose bypass, the boundary at exactly 8 commits (response kept), 9+ commits (response dropped, other fields survive), verbose override on large branches, and ordering (pre-pass fires on post-filter count, not raw commit count).

**📁 FILES**
- `cli/src/core/ContextCompiler.ts`
- `cli/src/core/ContextCompiler.test.ts`

</blockquote>
</details>
<details>
<summary><strong>02 · [1775f33] Add verbose flag to recall command to disable automatic content trimming</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The recall command was silently dropping low-signal topics and truncating long narrative fields on branches with many commits, with no way for users to opt out and see the full, unfiltered output.

**💡 Decisions Behind the Code**

- **Test scope boundary at the CLI layer**: The new CLI tests assert only that the flag value reaches the projection layer, not what the projection layer does with it. Duplicating trimming-logic coverage at the CLI level would couple the two layers unnecessarily, and the compiler unit tests already own that contract.
- **Explicit false on the default path**: The default call passes `{ verbose: false }` rather than omitting the option entirely. This makes the contract explicit and testable — a future reader can see at a glance that the default is an active choice, not an accidental omission, and the test can assert it without relying on undefined-equals-false semantics.

**✅ What Was Implemented**

- `RecallCommand.ts` gained a `--verbose` option wired into the output function. When the flag is present, the payload builder is called with `{ verbose: true }`, bypassing both the minor-topic filter and the response-field trim. The default path explicitly passes `{ verbose: false }`.
- Two new tests in `Cli.test.ts` assert the CLI surface contract: one confirms the payload builder receives `{ verbose: true }` when the flag is passed, and one confirms it receives `{ verbose: false }` on the default path. Behavioural coverage of what trimming actually does is left to the existing compiler unit tests.

**📁 FILES**
- `cli/src/commands/RecallCommand.ts`
- `cli/src/Cli.test.ts`

</blockquote>
</details>
<details>
<summary><strong>03 · [1775f33] Set default recall token budget to 20,000 tokens</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The previous default token budget was too generous at 50,000 tokens, allowing older low-value content to accumulate without triggering trimming logic on medium-sized branches.

**💡 Decisions Behind the Code**

**20K over 15K or the historical 50K**: A budget of 15,000 trimmed too aggressively for typical use, while 50,000 rarely exercised the enforcement path, allowing older verbose fields to silently bloat the context. 20,000 was chosen as a middle ground: it engages the trim loop on medium-sized branches while still leaving the vast majority of a large-context model's window available for the surrounding conversation. The historical 50K ceiling remains available via an explicit override for users who want maximum history.

**✅ What Was Implemented**

Updated `DEFAULT_TOKEN_BUDGET` in `ContextCompiler.ts` to 20000, along with the accompanying JSDoc comment noting that the new value leaves approximately 90% of a 200K-context model free for conversation. The constant was first reduced to 15,000 to ensure the trim loop fired on real-world medium branches, then raised to 20,000 as a middle ground that allows more commit history through without over-trimming.

**📁 FILES**
- `cli/src/core/ContextCompiler.ts`

</blockquote>
</details>
<details>
<summary><strong>04 · [1775f33] Rebase working branch onto latest remote main with DCO sign-off</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The working branch needed to be brought up to date with new commits that had landed on main, and the existing commit lacked the required sign-off that the project's contribution policy enforces on all pull requests.

**💡 Decisions Behind the Code**

- **Stash before rebase**: The two dirty files were unrelated to the branch's changes and would have blocked the rebase. Stashing and popping kept them intact without committing noise into the branch history.
- **Amend rather than a new commit for the sign-off**: Adding the trailer as a separate commit would have polluted the branch with a trivial fix-up and made the PR history harder to read. Amending keeps the sign-off co-located with the commit it certifies, which is the form CI expects.

**✅ What Was Implemented**

- Ran stash, fetch, and rebase onto the updated remote tip (`beabc71`), then popped the stash. Two pre-existing dirty files (`package-lock.json` and `vscode/package.json`) were preserved through the operation without modification.
- Amended the rebased commit with `git commit --amend -s --no-edit` to append the missing `Signed-off-by:` trailer, then force-pushed to replace the earlier unsigned version on the remote feature branch.

**📋 Future Enhancements**

The two pre-existing dirty files (`package-lock.json` and `vscode/package.json`, the latter showing a version bump from 0.99.1 to 0.99.83) were not addressed and remain in the working tree. A decision on whether to commit, revert, or ignore them is still needed.

**📁 FILES**
- `cli/src/commands/RecallCommand.ts`
- `cli/src/install/SkillInstaller.ts`

</blockquote>
</details>
<details>
<summary><strong>05 · [1775f33] Fix overpromising help text for the verbose recall flag</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The help text for the verbose flag promised that all topic fields would be included, but the implementation only disables two specific pre-trim passes, and budget-driven trimming still runs afterward.

**💡 Decisions Behind the Code**

Describing the flag in terms of what it actually disables — two specific pre-passes — rather than what it guarantees was chosen over a broader promise. The budget trim loop runs after the pre-passes and is controlled separately, so any wording implying complete field preservation would be incorrect. Pointing users toward the budget flag gives them a concrete path to get more output without overstating what the verbose flag alone achieves.

**✅ What Was Implemented**

Rewrote the `--verbose` option description in `RecallCommand.ts` to state that it disables the minor-topic and large-branch response pre-trims, and explicitly notes that budget-driven trimming still applies with a pointer to the `--budget` flag for users who want to suppress that too.

**📁 FILES**
- `cli/src/commands/RecallCommand.ts`

</blockquote>
</details>
<details>
<summary><strong>06 · [1775f33] Clarify all truncation causes in the recall skill documentation</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

A code review found that the recall output's truncated flag had taken on new meanings beyond budget enforcement, but the installed skill template still described it as budget-only, risking the assistant explaining omissions incorrectly to users.

**💡 Decisions Behind the Code**

Listing each trim cause explicitly rather than collapsing them into one phrase keeps the skill's guidance aligned with actual behaviour. The original wording was accurate when only budget trimming existed but became misleading after policy-based pre-passes were added; enumerating causes prevents the assistant from attributing omissions to the wrong source.

**✅ What Was Implemented**

Updated the `truncated: true` description in `SkillInstaller.ts` to enumerate all three trim sources: minor-importance topic filtering, automatic response dropping for branches with more than 8 commits, and the existing budget-driven oldest-first trimming. The existing instruction to mention truncation only when the user asks for deeper detail was preserved.

**📁 FILES**
- `cli/src/install/SkillInstaller.ts`

</blockquote>
</details>
<details>
<summary><strong>07 · [1775f33] Minify JSON output for recall and catalog commands</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

A customer reported that the recall command's JSON output was excessively large — a 31-commit branch was producing over 59 KB of data, causing truncation in downstream tools. Pretty-printed formatting was identified as a contributing factor inflating the output.

**💡 Decisions Behind the Code**

Minification was chosen as a low-risk, zero-information-loss first step. The JSON output is consumed by language models and automated pipelines, neither of which benefits from human-readable indentation. Measured savings on a real 31-commit payload were approximately 8–9%, smaller than the initial 30–35% estimate, because the dominant byte cost is long string fields rather than structural whitespace.

**✅ What Was Implemented**

Replaced all four pretty-printed `JSON.stringify` calls with compact equivalents in `RecallCommand.ts`, removing indentation and newlines from the JSON output. Updated two corresponding test assertions in `Cli.test.ts` to expect minified output instead of pretty-printed strings.

**📁 FILES**
- `cli/src/commands/RecallCommand.ts`
- `cli/src/Cli.test.ts`

</blockquote>
</details>
<details>
<summary><strong>08 · [ee115e8] Remove verbose escape hatch from branch recall output</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

A code review flagged that the `--verbose` flag was a poorly-designed escape hatch: it let users opt out of the automatic trimming policies, but those policies (dropping low-signal topics and stripping narrative detail on large branches) were intentional and should be unconditional. The flag also had misleading help text that overpromised what it could suppress.

**💡 Decisions Behind the Code**

- **Trimming policies should have no opt-out:** The review discussion concluded that the two automatic trim policies — dropping topics the summarizer rated as low-signal, and removing narrative detail on branches past a size threshold — are correctness decisions, not preferences. Keeping a flag that bypassed them created a false impression that the trimmed content was optional noise rather than a deliberate reduction. Removing the flag makes the contract explicit and eliminates a source of inconsistent output.
- **Simplicity over escape hatches:** The flag was described in the discussion as a "fake" escape hatch: it could not suppress the budget-driven trim loop, only the pre-passes, so users who needed full content already had a better path (inspecting individual commits directly). Removing it reduced the public API surface and eliminated two categories of test brittleness identified in the review without losing any real capability.
- **Dead-iteration guard added as a correctness signal:** The budget loop's Step 1 was identified as doing wasted work on large branches where pre-pass 2 had already cleared every response field. Adding the guard was low-risk and made the code's intent explicit — the loop condition now documents that this step is only meaningful when pre-pass 2 did not run.

**✅ What Was Implemented**

- Removed the `--verbose` CLI flag and its associated options interface entirely from `RecallCommand.ts` and `ContextCompiler.ts`. The two pre-pass trimming steps (minor-topic drop and large-branch response drop) now run unconditionally on every recall invocation. The `buildRecallPayload` function signature was simplified from three parameters back to two.
- Renamed the exported constant controlling the large-branch response-drop tier from a name containing "verbose" to `RECALL_LARGE_BRANCH_THRESHOLD` in `ContextCompiler.ts`, and updated its JSDoc to remove references to the now-deleted opt-out flag.
- Added a loop guard in the budget-trim step of `ContextCompiler.ts` so that when pre-pass 2 has already stripped all responses (the large-branch path), the budget loop's response-dropping iteration is skipped entirely rather than iterating over every commit and spreading unchanged objects.

**📁 FILES**
- `cli/src/core/ContextCompiler.ts`
- `cli/src/commands/RecallCommand.ts`

</blockquote>
</details>
<details>
<summary><strong>09 · [ee115e8] Add integration test covering pre-pass and budget-trim chain on large branches</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

A review gap was identified: the existing unit tests each covered individual pre-pass steps in isolation, but no test verified that the two passes worked correctly in sequence — specifically that after the large-branch response drop, the budget loop would then strip trigger fields from the oldest commits to meet a tight budget.

**💡 Decisions Behind the Code**

Adding this test locked down the full trim-policy chain as a single observable contract rather than leaving the interaction between the two passes implicit. The test also serves as a regression guard for the new loop guard: if the guard were accidentally removed, the test's budget assertions would still pass, but the intent documented in the test comment makes the expected behavior explicit for future readers.

**✅ What Was Implemented**

Added a new test in `ContextCompiler.test.ts` that builds a 12-commit fixture with large trigger and response fields, runs the payload builder with a very tight budget, and asserts that responses are gone everywhere (pre-pass 2), the oldest commit's trigger was removed (budget loop Step 2), the newest commit's trigger survived, and decisions are present on every kept commit.

**📁 FILES**
- `cli/src/core/ContextCompiler.test.ts`

</blockquote>
</details>
<details>
<summary><strong>10 · [ee115e8] Remove two verbose-flag CLI tests made obsolete by flag deletion</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Two CLI-level tests existed solely to assert that the verbose flag was forwarded correctly to the payload builder. With the flag removed, these tests became dead code and their removal was identified in the review as eliminating a known brittleness around argument-count assertions.

**💡 Decisions Behind the Code**

The tests were deleted rather than updated because their only purpose was to verify flag forwarding — a contract that no longer exists. Keeping them in any modified form would have tested nothing meaningful and preserved the import of a symbol that the CLI test suite no longer needs to observe directly.

**✅ What Was Implemented**

Deleted the two verbose-forwarding test cases from `Cli.test.ts` and removed the now-unused `buildRecallPayload` import from the test file's import block.

**📁 FILES**
- `cli/src/Cli.test.ts`

</blockquote>
</details>
<details>
<summary><strong>11 · [ac964b3] Fix misleading guidance on recovering missing recall fields</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The skill documentation embedded in the installer told users that both the trigger and response fields could be recovered by raising the budget limit. After a recent change, response is stripped unconditionally on large branches regardless of budget, so that advice was actively wrong and would send users on a fruitless troubleshooting path.

**💡 Decisions Behind the Code**

- **Separate the two fields rather than adding a caveat to the shared sentence**: Keeping a single sentence with a parenthetical exception would still be easy to misread. Splitting into distinct bullets makes the different recovery paths unambiguous for the AI agent reading the skill contract, which is the primary consumer of this text.
- **Leave the checked-in repo copy unchanged**: The checked-in skill file in this repository is a generated artefact that the version-comparison mechanism will overwrite automatically on the next install after a version bump. Manually patching it now would create a short-lived duplicate fix and add noise to the diff, so the decision was to rely on the normal release-and-reinstall cycle to propagate the correction.

**✅ What Was Implemented**

Updated the field-description block in `cli/src/install/SkillInstaller.ts` (around line 318) to split the trimming rules for `response` and `trigger` into separate, accurate bullet points. The `response` field is now documented as policy-trimmed unconditionally above 8 kept commits, with a note that raising the budget will not restore it. The `trigger` field is documented as budget-only, so users are correctly told that raising the budget can bring it back.

**📁 FILES**
- `cli/src/install/SkillInstaller.ts`

</blockquote>
</details>

---

*Generated by Jolli Memory · May 18, 2026 at 4:35 PM*
<!-- jollimemory-summary-end -->