### PR TITLE
Suppress Windows console window flicker via Subprocess wrapper

### DIFF
--- a/cli/biome.json
+++ b/cli/biome.json
@@ -36,7 +36,8 @@
 					"level": "error",
 					"options": {
 						"paths": {
-							"node:child_process": "Use src/util/Subprocess.ts wrappers (execFileSyncHidden, execFileAsyncHidden, spawnHidden, spawnSyncHidden, execSyncHidden) instead — they inject windowsHide:true so child processes do not flash a console window on Windows. Subprocess.ts itself and *.test.ts files are exempt via overrides."
+							"node:child_process": "Use src/util/Subprocess.ts wrappers (execFileSyncHidden, execFileAsyncHidden, spawnHidden, spawnSyncHidden) instead — they inject windowsHide:true so child processes do not flash a console window on Windows. Subprocess.ts itself and *.test.ts files are exempt via overrides.",
+							"child_process": "Use src/util/Subprocess.ts wrappers (execFileSyncHidden, execFileAsyncHidden, spawnHidden, spawnSyncHidden) instead — they inject windowsHide:true so child processes do not flash a console window on Windows. Subprocess.ts itself and *.test.ts files are exempt via overrides."
 						}
 					}
 				}

--- a/cli/biome.json
+++ b/cli/biome.json
@@ -31,7 +31,15 @@
 			"style": {
 				"useConst": "warn",
 				"useImportType": "warn",
-				"useNodejsImportProtocol": "warn"
+				"useNodejsImportProtocol": "warn",
+				"noRestrictedImports": {
+					"level": "error",
+					"options": {
+						"paths": {
+							"node:child_process": "Use src/util/Subprocess.ts wrappers (execFileSyncHidden, execFileAsyncHidden, spawnHidden, spawnSyncHidden, execSyncHidden) instead — they inject windowsHide:true so child processes do not flash a console window on Windows. Subprocess.ts itself and *.test.ts files are exempt via overrides."
+						}
+					}
+				}
 			},
 			"suspicious": {
 				"noExplicitAny": "error"
@@ -43,5 +51,17 @@
 			"quoteStyle": "double",
 			"semicolons": "always"
 		}
-	}
+	},
+	"overrides": [
+		{
+			"includes": ["src/util/Subprocess.ts", "**/*.test.ts"],
+			"linter": {
+				"rules": {
+					"style": {
+						"noRestrictedImports": "off"
+					}
+				}
+			}
+		}
+	]
 }

--- a/cli/src/commands/CliUtils.ts
+++ b/cli/src/commands/CliUtils.ts
@@ -7,11 +7,11 @@
  * interactive prompt helpers, and other common CLI helpers.
  */
 
-import { execFileSync } from "node:child_process";
 import { createInterface } from "node:readline";
 import { getGlobalConfigDir } from "../core/SessionTracker.js";
 import type { AmbiguousHashError } from "../core/SummaryStore.js";
 import { compareSemver, traverseDistPaths } from "../install/DistPathResolver.js";
+import { execFileSyncHidden } from "../util/Subprocess.js";
 
 /** Package version — injected by Vite at build time, falls back to "dev" when running via tsx. */
 /* v8 ignore start -- compile-time ternary: always "dev" in test/tsx, always __PKG_VERSION__ in build */
@@ -119,9 +119,8 @@ let _cachedProjectDir: string | undefined;
 export function resolveProjectDir(): string {
 	if (_cachedProjectDir !== undefined) return _cachedProjectDir;
 	try {
-		_cachedProjectDir = execFileSync("git", ["rev-parse", "--show-toplevel"], {
+		_cachedProjectDir = execFileSyncHidden("git", ["rev-parse", "--show-toplevel"], {
 			encoding: "utf-8",
-			windowsHide: true,
 		}).trim();
 	} catch {
 		_cachedProjectDir = process.cwd();

--- a/cli/src/commands/RecallCommand.ts
+++ b/cli/src/commands/RecallCommand.ts
@@ -12,7 +12,6 @@
  *   - `--catalog`: list all recorded branches
  */
 
-import { execFileSync } from "node:child_process";
 import { mkdir, writeFile } from "node:fs/promises";
 import { dirname } from "node:path";
 import { type Command, Option } from "commander";
@@ -27,6 +26,7 @@ import {
 import { collectAllTopics } from "../core/SummaryTree.js";
 import { setLogDir } from "../Logger.js";
 import type { CommitSummary } from "../Types.js";
+import { execFileSyncHidden } from "../util/Subprocess.js";
 import { formatShortDate, parsePositiveInt, readStdin, resolveProjectDir, SAFE_ARGUMENT_PATTERN } from "./CliUtils.js";
 
 /**
@@ -318,10 +318,9 @@ export function registerRecallCommand(program: Command): void {
 				let branch = branchOrKeyword as string | undefined;
 				if (!branch) {
 					try {
-						branch = execFileSync("git", ["branch", "--show-current"], {
+						branch = execFileSyncHidden("git", ["branch", "--show-current"], {
 							encoding: "utf-8",
 							cwd: projectDir,
-							windowsHide: true,
 						}).trim();
 					} catch {
 						branch = undefined;

--- a/cli/src/core/GitOps.ts
+++ b/cli/src/core/GitOps.ts
@@ -8,14 +8,12 @@
  * Pattern adapted from: tools/jolliagent/src/tools/tools/git_shared.ts
  */
 
-import { execFile, spawn } from "node:child_process";
 import { readFile, stat } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
-import { promisify } from "node:util";
 import { createLogger } from "../Logger.js";
 import type { CommitInfo, DiffStats, FileWrite, GitCommandResult } from "../Types.js";
+import { execFileAsyncHidden, spawnHidden } from "../util/Subprocess.js";
 
-const execFileAsync = promisify(execFile);
 const MAX_GIT_BUFFER_BYTES = 10 * 1024 * 1024; // 10MB
 /** NUL byte — used as entry separator in `git ls-tree -z` output. */
 const NUL = "\x00";
@@ -31,9 +29,8 @@ export async function execGit(args: ReadonlyArray<string>, cwd?: string): Promis
 	log.debug("git %s", fullArgs.join(" "));
 
 	try {
-		const { stdout, stderr } = await execFileAsync("git", fullArgs, {
+		const { stdout, stderr } = await execFileAsyncHidden("git", fullArgs, {
 			maxBuffer: MAX_GIT_BUFFER_BYTES,
-			windowsHide: true,
 		});
 		const result: GitCommandResult = {
 			stdout: stdout.trimEnd(),
@@ -563,7 +560,7 @@ function execGitWithStdin(args: ReadonlyArray<string>, input: string, cwd?: stri
 	log.debug("git (stdin) %s", fullArgs.join(" "));
 
 	return new Promise((resolve, reject) => {
-		const proc = spawn("git", fullArgs, { stdio: ["pipe", "pipe", "pipe"], windowsHide: true });
+		const proc = spawnHidden("git", fullArgs, { stdio: ["pipe", "pipe", "pipe"] });
 		let stdout = "";
 		let stderr = "";
 

--- a/cli/src/core/KBPathResolver.ts
+++ b/cli/src/core/KBPathResolver.ts
@@ -9,11 +9,11 @@
  * - Folder exists + different remoteUrl → add suffix: {repoName}-2, -3, etc.
  */
 
-import { execFileSync } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { basename, dirname, isAbsolute, join } from "node:path";
 import { createLogger } from "../Logger.js";
+import { execFileSyncHidden } from "../util/Subprocess.js";
 import type { KBConfig } from "./KBTypes.js";
 import { MetadataManager } from "./MetadataManager.js";
 
@@ -127,11 +127,10 @@ export function extractRepoName(projectPath: string): string {
 
 function tryGitCommand(cwd: string, args: string[]): string | null {
 	try {
-		const out = execFileSync("git", args, {
+		const out = execFileSyncHidden("git", args, {
 			cwd,
 			encoding: "utf-8",
 			timeout: 5000,
-			windowsHide: true,
 		}).trim();
 		return out || null;
 	} catch {

--- a/cli/src/core/Locks.test.ts
+++ b/cli/src/core/Locks.test.ts
@@ -11,10 +11,11 @@ vi.mock("node:fs/promises", async (importOriginal) => {
 	return { ...original };
 });
 
-// Same trick for node:child_process — needed by the fallback-path test, which
-// forces `git rev-parse` to fail to exercise the per-worktree fallback.
-vi.mock("node:child_process", async (importOriginal) => {
-	const original = await importOriginal<typeof import("node:child_process")>();
+// Same trick for the Subprocess wrapper — needed by the fallback-path test,
+// which forces `git rev-parse` to fail to exercise the per-worktree fallback.
+// Locks.ts calls `Subprocess.execFileAsyncHidden`, so we spy on this module.
+vi.mock("../util/Subprocess.js", async (importOriginal) => {
+	const original = await importOriginal<typeof import("../util/Subprocess.js")>();
 	return { ...original };
 });
 
@@ -378,18 +379,15 @@ describe("Locks", () => {
 		});
 
 		it("falls back to <cwd>/.jolli/jollimemory/ when git rev-parse fails", async () => {
-			// Force the resolver into the catch path by making `execFile` throw.
-			// Tests run with `mkdtemp` so the cache hasn't seen tempDir yet — but
-			// reset to be safe in case a previous it-block populated it.
+			// Force the resolver into the catch path by making the Subprocess
+			// wrapper reject. Tests run with `mkdtemp` so the cache hasn't seen
+			// tempDir yet — but reset to be safe in case a previous it-block
+			// populated it.
 			__resetSharedLockDirCache();
-			const childProcess = await import("node:child_process");
-			const execSpy = vi.spyOn(childProcess, "execFile").mockImplementation(
-				// @ts-expect-error -- vi.spyOn signature for overloaded execFile is awkward; the runtime call shape matches what the resolver invokes
-				(_file: string, _args: ReadonlyArray<string>, _opts: unknown, cb: (err: Error) => void) => {
-					cb(new Error("simulated: git not found"));
-					return {} as unknown;
-				},
-			);
+			const Subprocess = await import("../util/Subprocess.js");
+			const execSpy = vi
+				.spyOn(Subprocess, "execFileAsyncHidden")
+				.mockRejectedValue(new Error("simulated: git not found"));
 
 			expect(await acquireOrphanWriteLock(tempDir)).toBe(true);
 			const fallback = join(tempDir, ".jolli", "jollimemory", ORPHAN_WRITE_LOCK_FILE);
@@ -402,8 +400,8 @@ describe("Locks", () => {
 
 		it("caches the resolved path so repeated polls don't spawn git on every iteration", async () => {
 			__resetSharedLockDirCache();
-			const childProcess = await import("node:child_process");
-			const execSpy = vi.spyOn(childProcess, "execFile");
+			const Subprocess = await import("../util/Subprocess.js");
+			const execSpy = vi.spyOn(Subprocess, "execFileAsyncHidden");
 
 			expect(await acquireOrphanWriteLock(tempDir)).toBe(true);
 			await releaseOrphanWriteLock(tempDir);

--- a/cli/src/core/Locks.ts
+++ b/cli/src/core/Locks.ts
@@ -59,23 +59,20 @@
  * release path.
  */
 
-import * as childProcess from "node:child_process";
 import { mkdir, readFile, rm, stat, utimes, writeFile } from "node:fs/promises";
 import { isAbsolute, join, resolve as resolvePath } from "node:path";
-import { promisify } from "node:util";
 import { createLogger, getJolliMemoryDir } from "../Logger.js";
+import * as Subprocess from "../util/Subprocess.js";
 
 const log = createLogger("Locks");
 
 /**
- * Lazily promisify so tests that swap out `childProcess.execFile` after module
- * load (via `vi.spyOn`) actually pick up the mock — eager promisification at
- * module load would close over the original function.
+ * Calls through `Subprocess` (rather than capturing a local reference) so
+ * tests can `vi.spyOn(Subprocess, "execFileAsyncHidden")` and have the
+ * resolver pick up the mock without us pre-binding the function.
  */
-function gitRevParseCommonDir(cwd: string): Promise<{ stdout: string }> {
-	return promisify(childProcess.execFile)("git", ["rev-parse", "--git-common-dir"], { cwd }) as Promise<{
-		stdout: string;
-	}>;
+function gitRevParseCommonDir(cwd: string): Promise<{ stdout: string; stderr: string }> {
+	return Subprocess.execFileAsyncHidden("git", ["rev-parse", "--git-common-dir"], { cwd });
 }
 
 export const WORKER_LOCK_FILE = "worker.lock";

--- a/cli/src/core/SummaryExporter.test.ts
+++ b/cli/src/core/SummaryExporter.test.ts
@@ -10,7 +10,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 // ─── Hoisted mocks ───────────────────────────────────────────────────────────
 
 const mocks = vi.hoisted(() => ({
-	execFileSync: vi.fn(),
+	execFileSyncHidden: vi.fn(),
 	existsSync: vi.fn(),
 	mkdirSync: vi.fn(),
 	readdirSync: vi.fn(),
@@ -21,7 +21,7 @@ const mocks = vi.hoisted(() => ({
 	buildMarkdown: vi.fn(),
 }));
 
-vi.mock("node:child_process", () => ({ execFileSync: mocks.execFileSync }));
+vi.mock("../util/Subprocess.js", () => ({ execFileSyncHidden: mocks.execFileSyncHidden }));
 vi.mock("node:fs", () => ({
 	existsSync: mocks.existsSync,
 	mkdirSync: mocks.mkdirSync,
@@ -66,7 +66,7 @@ describe("SummaryExporter", () => {
 		vi.clearAllMocks();
 		writtenFiles.clear();
 		mocks.homedir.mockReturnValue("/home/user");
-		mocks.execFileSync.mockReturnValue("/mock/project\n");
+		mocks.execFileSyncHidden.mockReturnValue("/mock/project\n");
 		mocks.existsSync.mockImplementation((p: string) => writtenFiles.has(p));
 		mocks.writeFileSync.mockImplementation((p: string) => writtenFiles.add(p));
 		mocks.readdirSync.mockReturnValue([]);
@@ -176,7 +176,7 @@ describe("SummaryExporter", () => {
 	});
 
 	it("should derive project name from git repo root", async () => {
-		mocks.execFileSync.mockReturnValue("/home/user/repos/cool-project\n");
+		mocks.execFileSyncHidden.mockReturnValue("/home/user/repos/cool-project\n");
 		mocks.listSummaries.mockResolvedValue([]);
 
 		const result = await exportSummaries({});
@@ -203,7 +203,7 @@ describe("SummaryExporter", () => {
 	});
 
 	it("should fall back to cwd basename when git command fails", async () => {
-		mocks.execFileSync.mockImplementation(() => {
+		mocks.execFileSyncHidden.mockImplementation(() => {
 			throw new Error("not a git repo");
 		});
 		mocks.listSummaries.mockResolvedValue([]);
@@ -214,7 +214,7 @@ describe("SummaryExporter", () => {
 	});
 
 	it("should fall back to process.cwd when git command fails and no cwd provided", async () => {
-		mocks.execFileSync.mockImplementation(() => {
+		mocks.execFileSyncHidden.mockImplementation(() => {
 			throw new Error("not a git repo");
 		});
 		mocks.listSummaries.mockResolvedValue([]);

--- a/cli/src/core/SummaryExporter.ts
+++ b/cli/src/core/SummaryExporter.ts
@@ -8,11 +8,11 @@
  * in the output directory (matched by the 8-char commit hash prefix).
  */
 
-import { execFileSync } from "node:child_process";
 import { existsSync, mkdirSync, readdirSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { basename, join } from "node:path";
 import type { CommitSummary } from "../Types.js";
+import { execFileSyncHidden } from "../util/Subprocess.js";
 import { getDisplayDate } from "./SummaryFormat.js";
 import { buildMarkdown } from "./SummaryMarkdownBuilder.js";
 import { getSummary, listSummaries } from "./SummaryStore.js";
@@ -48,10 +48,9 @@ export interface ExportResult {
 /** Resolves the project name from the git repo root directory name. */
 function resolveProjectName(cwd?: string): string {
 	try {
-		const repoRoot = execFileSync("git", ["rev-parse", "--show-toplevel"], {
+		const repoRoot = execFileSyncHidden("git", ["rev-parse", "--show-toplevel"], {
 			encoding: "utf-8",
 			cwd,
-			windowsHide: true,
 		}).trim();
 		return basename(repoRoot);
 	} catch {

--- a/cli/src/hooks/GitOperationDetector.test.ts
+++ b/cli/src/hooks/GitOperationDetector.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("node:child_process", () => ({
-	execSync: vi.fn(),
+vi.mock("../util/Subprocess.js", () => ({
+	execFileSyncHidden: vi.fn(),
 }));
 
 vi.mock("node:fs", async (importOriginal) => {
@@ -34,11 +34,11 @@ vi.spyOn(console, "log").mockImplementation(() => {});
 vi.spyOn(console, "warn").mockImplementation(() => {});
 vi.spyOn(console, "error").mockImplementation(() => {});
 
-import { execSync } from "node:child_process";
 import { existsSync, readFileSync, statSync } from "node:fs";
 import { join } from "node:path";
 import { getCommitRange, getHeadHash, getLastReflogAction, isAncestor, readOrigHead } from "../core/GitOps.js";
 import { loadSquashPending, saveSquashPending } from "../core/SessionTracker.js";
+import { execFileSyncHidden } from "../util/Subprocess.js";
 import {
 	detectCommitOperation,
 	detectResetSquash,
@@ -136,19 +136,19 @@ describe("GitOperationDetector", () => {
 
 	describe("readLastReflogSubject", () => {
 		it("should return the trimmed reflog subject on success", () => {
-			vi.mocked(execSync).mockReturnValueOnce("commit (amend): Fix typo\n");
+			vi.mocked(execFileSyncHidden).mockReturnValueOnce("commit (amend): Fix typo\n");
 
 			const result = readLastReflogSubject("/test/repo");
 
 			expect(result).toBe("commit (amend): Fix typo");
-			expect(execSync).toHaveBeenCalledWith("git reflog -1 --format=%gs", {
+			expect(execFileSyncHidden).toHaveBeenCalledWith("git", ["reflog", "-1", "--format=%gs"], {
 				cwd: "/test/repo",
 				encoding: "utf-8",
 			});
 		});
 
-		it("should return null when execSync throws", () => {
-			vi.mocked(execSync).mockImplementationOnce(() => {
+		it("should return null when execFileSyncHidden throws", () => {
+			vi.mocked(execFileSyncHidden).mockImplementationOnce(() => {
 				throw new Error("fatal: reflog is empty");
 			});
 
@@ -219,7 +219,7 @@ describe("GitOperationDetector", () => {
 		});
 
 		it("should detect amend via reflog subject", () => {
-			vi.mocked(execSync).mockReturnValueOnce("commit (amend): Fix typo\n");
+			vi.mocked(execFileSyncHidden).mockReturnValueOnce("commit (amend): Fix typo\n");
 
 			const result = detectCommitOperation(CWD);
 
@@ -243,7 +243,7 @@ describe("GitOperationDetector", () => {
 		});
 
 		it("should fall back to 'commit' when no special signals are present", () => {
-			vi.mocked(execSync).mockReturnValueOnce("commit: Add new feature\n");
+			vi.mocked(execFileSyncHidden).mockReturnValueOnce("commit: Add new feature\n");
 
 			const result = detectCommitOperation(CWD);
 
@@ -251,7 +251,7 @@ describe("GitOperationDetector", () => {
 		});
 
 		it("should fall back to 'commit' when reflog cannot be read", () => {
-			vi.mocked(execSync).mockImplementationOnce(() => {
+			vi.mocked(execFileSyncHidden).mockImplementationOnce(() => {
 				throw new Error("fatal: reflog is empty");
 			});
 
@@ -277,7 +277,7 @@ describe("GitOperationDetector", () => {
 			vi.mocked(existsSync).mockImplementation((p) => {
 				return String(p).endsWith("squash-pending.json");
 			});
-			vi.mocked(execSync).mockReturnValueOnce("commit (amend): Fix typo\n");
+			vi.mocked(execFileSyncHidden).mockReturnValueOnce("commit (amend): Fix typo\n");
 
 			const result = detectCommitOperation(CWD);
 
@@ -460,7 +460,7 @@ describe("GitOperationDetector", () => {
 		});
 
 		it("should detect amend via reflog subject", () => {
-			vi.mocked(execSync).mockReturnValueOnce("commit (amend): fix typo\n");
+			vi.mocked(execFileSyncHidden).mockReturnValueOnce("commit (amend): fix typo\n");
 
 			const result = detectCommitOperation(CWD);
 
@@ -485,7 +485,7 @@ describe("GitOperationDetector", () => {
 
 		it("should default to commit when nothing else matches", () => {
 			// execSync returns normal commit reflog
-			vi.mocked(execSync).mockReturnValueOnce("commit: add feature\n");
+			vi.mocked(execFileSyncHidden).mockReturnValueOnce("commit: add feature\n");
 
 			const result = detectCommitOperation(CWD);
 
@@ -493,7 +493,7 @@ describe("GitOperationDetector", () => {
 		});
 
 		it("should default to commit when reflog read fails", () => {
-			vi.mocked(execSync).mockImplementationOnce(() => {
+			vi.mocked(execFileSyncHidden).mockImplementationOnce(() => {
 				throw new Error("reflog empty");
 			});
 

--- a/cli/src/hooks/GitOperationDetector.ts
+++ b/cli/src/hooks/GitOperationDetector.ts
@@ -33,12 +33,12 @@
  *   "cherry-pick: <message>"       — cherry-pick
  */
 
-import { execSync } from "node:child_process";
 import { existsSync, readFileSync, statSync } from "node:fs";
 import { isAbsolute, join } from "node:path";
 import { getCommitRange, getHeadHash, getLastReflogAction, isAncestor, readOrigHead } from "../core/GitOps.js";
 import { loadSquashPending, saveSquashPending } from "../core/SessionTracker.js";
 import { createLogger } from "../Logger.js";
+import { execFileSyncHidden } from "../util/Subprocess.js";
 
 const log = createLogger("GitOperationDetector");
 
@@ -97,7 +97,7 @@ export function isRebaseInProgress(cwd: string): boolean {
  */
 export function readLastReflogSubject(cwd: string): string | null {
 	try {
-		return execSync("git reflog -1 --format=%gs", { cwd, encoding: "utf-8" }).trim();
+		return execFileSyncHidden("git", ["reflog", "-1", "--format=%gs"], { cwd, encoding: "utf-8" }).trim();
 	} catch {
 		log.debug("Failed to read git reflog");
 		return null;

--- a/cli/src/hooks/PostCommitHook.ts
+++ b/cli/src/hooks/PostCommitHook.ts
@@ -10,12 +10,12 @@
  * which has the authoritative old-to-new hash mapping from git's stdin.
  */
 
-import { execFileSync, execSync } from "node:child_process";
 import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
 import { basename, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { createLogger } from "../Logger.js";
 import type { CommitSource, GitOperation } from "../Types.js";
+import { execFileSyncHidden } from "../util/Subprocess.js";
 import { detectCommitOperation, isRebaseInProgress, resolveGitDir } from "./GitOperationDetector.js";
 import { launchWorker } from "./QueueWorker.js";
 
@@ -42,7 +42,7 @@ export function postCommitEntry(cwd: string): void {
 	// Read commit hash (HEAD is the just-created commit)
 	let commitHash: string;
 	try {
-		commitHash = execSync("git rev-parse HEAD", { cwd, encoding: "utf-8" }).trim();
+		commitHash = execFileSyncHidden("git", ["rev-parse", "HEAD"], { cwd, encoding: "utf-8" }).trim();
 	} catch (err: unknown) {
 		log.error("Failed to read HEAD hash: %s", (err as Error).message);
 		return;
@@ -56,7 +56,8 @@ export function postCommitEntry(cwd: string): void {
 	let branch: string;
 	try {
 		branch =
-			execFileSync("git", ["rev-parse", "--abbrev-ref", "HEAD"], { cwd, encoding: "utf-8" }).trim() || "HEAD";
+			execFileSyncHidden("git", ["rev-parse", "--abbrev-ref", "HEAD"], { cwd, encoding: "utf-8" }).trim() ||
+			"HEAD";
 	} catch (err: unknown) {
 		log.warn("Failed to read current branch: %s — proceeding without tail cleanup hint", (err as Error).message);
 		branch = "";
@@ -79,7 +80,7 @@ export function postCommitEntry(cwd: string): void {
 			// so stale files should not occur. This validation is retained as a defensive fallback.
 			// !pending.expectedParentHash is intentional backward compatibility: older squash-pending
 			// files may lack this field, and should still be treated as valid.
-			const parentHash = execSync("git rev-parse HEAD~1", { cwd, encoding: "utf-8" }).trim();
+			const parentHash = execFileSyncHidden("git", ["rev-parse", "HEAD~1"], { cwd, encoding: "utf-8" }).trim();
 			if (!pending.expectedParentHash || parentHash === pending.expectedParentHash) {
 				sourceHashes = pending.sourceHashes;
 				log.info("Squash-pending validated: %d source hashes", pending.sourceHashes.length);

--- a/cli/src/hooks/QueueWorker.ts
+++ b/cli/src/hooks/QueueWorker.ts
@@ -16,7 +16,6 @@
  * Entry point: can be run directly with `--worker --cwd <path>` or spawned by `launchWorker()`.
  */
 
-import { spawn } from "node:child_process";
 import { createHash } from "node:crypto";
 import { existsSync, readFileSync } from "node:fs";
 import { basename, dirname, join, resolve } from "node:path";
@@ -114,6 +113,7 @@ import type {
 	TranscriptReadResult,
 	TranscriptSource,
 } from "../Types.js";
+import { spawnHidden } from "../util/Subprocess.js";
 
 const log = createLogger("QueueWorker");
 
@@ -205,7 +205,7 @@ export function launchWorker(cwd: string): void {
 	const dir = dirname(fileURLToPath(import.meta.url));
 	const scriptPath = join(dir, "QueueWorker.js");
 
-	const child = spawn(
+	const child = spawnHidden(
 		process.execPath,
 		// --disable-warning silences node:sqlite's ExperimentalWarning during OpenCode
 		// scans; it also suppresses any other experimental warnings in this subprocess.
@@ -214,7 +214,6 @@ export function launchWorker(cwd: string): void {
 			detached: true,
 			stdio: "ignore",
 			cwd,
-			windowsHide: true,
 		},
 	);
 	child.unref();

--- a/cli/src/hooks/SessionStartHook.ts
+++ b/cli/src/hooks/SessionStartHook.ts
@@ -23,7 +23,6 @@
  *   - .jolli/jollimemory/plans.json → associated plan names
  */
 
-import { execFileSync } from "node:child_process";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { readFileFromBranch } from "../core/GitOps.js";
@@ -32,6 +31,7 @@ import { getIndex } from "../core/SummaryStore.js";
 import { collectAllTopics } from "../core/SummaryTree.js";
 import { createLogger, ORPHAN_BRANCH, setLogDir } from "../Logger.js";
 import type { CommitSummary, DiffStats, PlansRegistry, SummaryIndexEntry } from "../Types.js";
+import { execFileSyncHidden } from "../util/Subprocess.js";
 import { readStdin } from "./HookUtils.js";
 
 const log = createLogger("SessionStartHook");
@@ -378,10 +378,9 @@ function saveBriefingCache(projectDir: string, branch: string, lastCommitHash: s
 function getCurrentHeadHash(projectDir: string): string | null {
 	try {
 		return (
-			execFileSync("git", ["rev-parse", "HEAD"], {
+			execFileSyncHidden("git", ["rev-parse", "HEAD"], {
 				encoding: "utf-8",
 				cwd: projectDir,
-				windowsHide: true,
 			}).trim() || null
 		);
 	} catch {
@@ -392,10 +391,9 @@ function getCurrentHeadHash(projectDir: string): string | null {
 function getCurrentBranch(projectDir: string): string | null {
 	try {
 		return (
-			execFileSync("git", ["branch", "--show-current"], {
+			execFileSyncHidden("git", ["branch", "--show-current"], {
 				encoding: "utf-8",
 				cwd: projectDir,
-				windowsHide: true,
 			}).trim() || null
 		);
 	} catch {

--- a/cli/src/hooks/StopHook.ts
+++ b/cli/src/hooks/StopHook.ts
@@ -44,6 +44,7 @@ import {
 } from "../core/SessionTracker.js";
 import { createLogger, setLogDir } from "../Logger.js";
 import type { ClaudeHookInput, PlanEntry, SessionInfo } from "../Types.js";
+import { execFileSyncHidden } from "../util/Subprocess.js";
 import { readStdin } from "./HookUtils.js";
 
 const log = createLogger("StopHook");
@@ -618,8 +619,7 @@ function extractPlanTitle(filePath: string): string {
 /** Returns the current git branch name. */
 function getCurrentBranch(cwd: string): string {
 	try {
-		const { execFileSync } = require("node:child_process") as typeof import("node:child_process");
-		return execFileSync("git", ["rev-parse", "--abbrev-ref", "HEAD"], {
+		return execFileSyncHidden("git", ["rev-parse", "--abbrev-ref", "HEAD"], {
 			cwd,
 			encoding: "utf-8",
 			stdio: ["ignore", "pipe", "ignore"],

--- a/cli/src/install/GitExclude.ts
+++ b/cli/src/install/GitExclude.ts
@@ -18,13 +18,11 @@
  * themselves still get written; the user just may see them in `git status`.
  */
 
-import { execFile } from "node:child_process";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { dirname, join, posix as posixPath, win32 as win32Path } from "node:path";
-import { promisify } from "node:util";
 import { createLogger } from "../Logger.js";
+import { execFileAsyncHidden } from "../util/Subprocess.js";
 
-const execFileAsync = promisify(execFile);
 const log = createLogger("GitExclude");
 
 /**
@@ -73,9 +71,8 @@ export function normalizeGitPathOutput(relOrAbs: string, projectDir: string): st
 
 export async function resolveGitExcludePath(projectDir: string): Promise<string | null> {
 	try {
-		const { stdout } = await execFileAsync("git", ["rev-parse", "--git-path", "info/exclude"], {
+		const { stdout } = await execFileAsyncHidden("git", ["rev-parse", "--git-path", "info/exclude"], {
 			cwd: projectDir,
-			windowsHide: true,
 		});
 		const relOrAbs = stdout.trim();
 		/* v8 ignore start -- defensive: git rev-parse always emits a non-empty path on success */

--- a/cli/src/site/EngineManager.ts
+++ b/cli/src/site/EngineManager.ts
@@ -120,11 +120,11 @@ export async function ensureEngine(): Promise<NpmRunResult> {
 		// Run npm install — on Windows, npm is a .cmd script that requires
 		// shell: true since Node 22.5+ (CVE-2024-27980). Pass the full command
 		// as a single string to avoid the DEP0190 warning about shell + args.
-		const { spawnSync } = await import("node:child_process");
+		const { spawnSyncHidden } = await import("../util/Subprocess.js");
 		const isWin = process.platform === "win32";
 		const shellOpts = isWin ? /* v8 ignore next */ ({ shell: true } as const) : {};
 		const [cmd, args] = isWin ? /* v8 ignore next */ ["npm install", []] : ["npm", ["install"]];
-		const result = spawnSync(cmd, args, {
+		const result = spawnSyncHidden(cmd, args, {
 			cwd: engineDir,
 			stdio: "pipe",
 			...shellOpts,

--- a/cli/src/site/NpmRunner.ts
+++ b/cli/src/site/NpmRunner.ts
@@ -6,9 +6,9 @@
  * throwing, so the caller can print the error and set the exit code.
  */
 
-import { spawn, spawnSync } from "node:child_process";
 import { existsSync } from "node:fs";
 import { join } from "node:path";
+import { spawnHidden, spawnSyncHidden } from "../util/Subprocess.js";
 import { engineNeedsInstall, ensureEngine, linkEngineModules } from "./EngineManager.js";
 import { createOutputFilter } from "./OutputFilter.js";
 import type { NpmRunResult } from "./Types.js";
@@ -58,7 +58,7 @@ export async function runNpmInstall(buildDir: string): Promise<NpmRunResult> {
  */
 export async function runNpmBuild(buildDir: string): Promise<NpmRunResult> {
 	const [cmd, args] = shellCmd("npm", ["run", "build"]);
-	const result = spawnSync(cmd, args, {
+	const result = spawnSyncHidden(cmd, args, {
 		cwd: buildDir,
 		stdio: "pipe",
 		...SHELL_OPTS,
@@ -107,7 +107,7 @@ function runLongProcess(rawCmd: string, rawArgs: string[], cwd: string, verbose:
 		const filter = createOutputFilter(verbose);
 		const [cmd, args] = shellCmd(rawCmd, rawArgs);
 
-		const child = spawn(cmd, args, {
+		const child = spawnHidden(cmd, args, {
 			cwd,
 			stdio: "pipe",
 			...SHELL_OPTS,

--- a/cli/src/site/PagefindRunner.ts
+++ b/cli/src/site/PagefindRunner.ts
@@ -9,7 +9,7 @@
  * throwing, so the caller can print the error and set the exit code.
  */
 
-import { spawnSync } from "node:child_process";
+import { spawnSyncHidden } from "../util/Subprocess.js";
 import type { PagefindResult } from "./Types.js";
 
 /**
@@ -32,7 +32,7 @@ export type { PagefindResult };
 export function runPagefind(buildDir: string): PagefindResult {
 	const rawArgs = ["pagefind", "--site", "out", "--output-path", "out/_pagefind"];
 	const [cmd, args] = IS_WIN ? /* v8 ignore next */ [`npx ${rawArgs.join(" ")}`, []] : ["npx", rawArgs];
-	const result = spawnSync(cmd, args, {
+	const result = spawnSyncHidden(cmd, args, {
 		cwd: buildDir,
 		stdio: "pipe",
 		...SHELL_OPTS,

--- a/cli/src/util/Subprocess.test.ts
+++ b/cli/src/util/Subprocess.test.ts
@@ -1,0 +1,238 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockExecFileSync = vi.fn().mockReturnValue(Buffer.from("ok"));
+const mockExecSync = vi.fn().mockReturnValue(Buffer.from("ok"));
+const mockSpawn = vi.fn().mockReturnValue({ pid: 1, unref: vi.fn() });
+const mockSpawnSync = vi
+	.fn()
+	.mockReturnValue({ status: 0, stdout: Buffer.from(""), stderr: Buffer.from(""), pid: 1, output: [] });
+const mockExecFile = vi
+	.fn()
+	.mockImplementation(
+		(
+			_file: string,
+			_args: ReadonlyArray<string>,
+			_options: unknown,
+			callback: (err: null, result: { stdout: string; stderr: string }) => void,
+		) => {
+			callback(null, { stdout: "", stderr: "" });
+		},
+	);
+
+vi.mock("node:child_process", () => ({
+	execFileSync: mockExecFileSync,
+	execSync: mockExecSync,
+	spawn: mockSpawn,
+	spawnSync: mockSpawnSync,
+	execFile: mockExecFile,
+}));
+
+describe("Subprocess", () => {
+	beforeEach(() => {
+		mockExecFileSync.mockClear();
+		mockExecSync.mockClear();
+		mockSpawn.mockClear();
+		mockSpawnSync.mockClear();
+		mockExecFile.mockClear();
+	});
+
+	describe("execFileSyncHidden", () => {
+		it("injects windowsHide:true when no options given", async () => {
+			const { execFileSyncHidden } = await import("./Subprocess.js");
+			execFileSyncHidden("git", ["status"]);
+			expect(mockExecFileSync).toHaveBeenCalledWith(
+				"git",
+				["status"],
+				expect.objectContaining({ windowsHide: true }),
+			);
+		});
+
+		it("preserves user options and adds windowsHide:true", async () => {
+			const { execFileSyncHidden } = await import("./Subprocess.js");
+			execFileSyncHidden("git", ["status"], { cwd: "/tmp", encoding: "utf-8" });
+			expect(mockExecFileSync).toHaveBeenCalledWith(
+				"git",
+				["status"],
+				expect.objectContaining({ cwd: "/tmp", encoding: "utf-8", windowsHide: true }),
+			);
+		});
+
+		it("lets caller override windowsHide:false explicitly", async () => {
+			const { execFileSyncHidden } = await import("./Subprocess.js");
+			execFileSyncHidden("git", ["status"], { windowsHide: false });
+			expect(mockExecFileSync).toHaveBeenCalledWith(
+				"git",
+				["status"],
+				expect.objectContaining({ windowsHide: false }),
+			);
+		});
+
+		it("supports calling without args array", async () => {
+			const { execFileSyncHidden } = await import("./Subprocess.js");
+			execFileSyncHidden("git");
+			expect(mockExecFileSync).toHaveBeenCalledWith(
+				"git",
+				undefined,
+				expect.objectContaining({ windowsHide: true }),
+			);
+		});
+	});
+
+	describe("execSyncHidden", () => {
+		it("injects windowsHide:true when no options given", async () => {
+			const { execSyncHidden } = await import("./Subprocess.js");
+			execSyncHidden("git status");
+			expect(mockExecSync).toHaveBeenCalledWith("git status", expect.objectContaining({ windowsHide: true }));
+		});
+
+		it("preserves user options and adds windowsHide:true", async () => {
+			const { execSyncHidden } = await import("./Subprocess.js");
+			execSyncHidden("git status", { cwd: "/tmp", encoding: "utf-8" });
+			expect(mockExecSync).toHaveBeenCalledWith(
+				"git status",
+				expect.objectContaining({ cwd: "/tmp", encoding: "utf-8", windowsHide: true }),
+			);
+		});
+
+		it("lets caller override windowsHide:false explicitly", async () => {
+			const { execSyncHidden } = await import("./Subprocess.js");
+			execSyncHidden("git status", { windowsHide: false });
+			expect(mockExecSync).toHaveBeenCalledWith("git status", expect.objectContaining({ windowsHide: false }));
+		});
+	});
+
+	describe("spawnHidden", () => {
+		it("injects windowsHide:true when no options given", async () => {
+			const { spawnHidden } = await import("./Subprocess.js");
+			spawnHidden("git", ["status"]);
+			expect(mockSpawn).toHaveBeenCalledWith("git", ["status"], expect.objectContaining({ windowsHide: true }));
+		});
+
+		it("preserves user options and adds windowsHide:true", async () => {
+			const { spawnHidden } = await import("./Subprocess.js");
+			spawnHidden("node", ["script.js"], { detached: true, stdio: "ignore", cwd: "/tmp" });
+			expect(mockSpawn).toHaveBeenCalledWith(
+				"node",
+				["script.js"],
+				expect.objectContaining({ detached: true, stdio: "ignore", cwd: "/tmp", windowsHide: true }),
+			);
+		});
+
+		it("lets caller override windowsHide:false explicitly", async () => {
+			const { spawnHidden } = await import("./Subprocess.js");
+			spawnHidden("git", ["status"], { windowsHide: false });
+			expect(mockSpawn).toHaveBeenCalledWith("git", ["status"], expect.objectContaining({ windowsHide: false }));
+		});
+
+		it("supports 2-arg form: spawn(command, options) without args array", async () => {
+			const { spawnHidden } = await import("./Subprocess.js");
+			// TypeScript: the 2-arg `spawn(command, options)` overload exists at runtime;
+			// the wrapper detects via Array.isArray and forwards through the args-less spawn call.
+			(spawnHidden as (cmd: string, opts: object) => unknown)("node", { detached: true, stdio: "ignore" });
+			expect(mockSpawn).toHaveBeenCalledWith(
+				"node",
+				expect.objectContaining({ detached: true, stdio: "ignore", windowsHide: true }),
+			);
+		});
+
+		it("treats a missing 2nd arg as no options (still injects windowsHide:true)", async () => {
+			const { spawnHidden } = await import("./Subprocess.js");
+			(spawnHidden as (cmd: string) => unknown)("node");
+			expect(mockSpawn).toHaveBeenCalledWith("node", expect.objectContaining({ windowsHide: true }));
+		});
+	});
+
+	describe("spawnSyncHidden", () => {
+		it("injects windowsHide:true when no options given", async () => {
+			const { spawnSyncHidden } = await import("./Subprocess.js");
+			spawnSyncHidden("git", ["status"]);
+			expect(mockSpawnSync).toHaveBeenCalledWith(
+				"git",
+				["status"],
+				expect.objectContaining({ windowsHide: true }),
+			);
+		});
+
+		it("preserves user options and adds windowsHide:true", async () => {
+			const { spawnSyncHidden } = await import("./Subprocess.js");
+			spawnSyncHidden("attrib", ["+h", "C:/tmp/file"], { timeout: 2000 });
+			expect(mockSpawnSync).toHaveBeenCalledWith(
+				"attrib",
+				["+h", "C:/tmp/file"],
+				expect.objectContaining({ timeout: 2000, windowsHide: true }),
+			);
+		});
+
+		it("lets caller override windowsHide:false explicitly", async () => {
+			const { spawnSyncHidden } = await import("./Subprocess.js");
+			spawnSyncHidden("git", ["status"], { windowsHide: false });
+			expect(mockSpawnSync).toHaveBeenCalledWith(
+				"git",
+				["status"],
+				expect.objectContaining({ windowsHide: false }),
+			);
+		});
+	});
+
+	describe("execFileAsyncHidden", () => {
+		it("injects windowsHide:true when no options given", async () => {
+			const { execFileAsyncHidden } = await import("./Subprocess.js");
+			await execFileAsyncHidden("git", ["status"]);
+			expect(mockExecFile).toHaveBeenCalledWith(
+				"git",
+				["status"],
+				expect.objectContaining({ windowsHide: true }),
+				expect.any(Function),
+			);
+		});
+
+		it("preserves user options and adds windowsHide:true", async () => {
+			const { execFileAsyncHidden } = await import("./Subprocess.js");
+			await execFileAsyncHidden("git", ["status"], { cwd: "/tmp", encoding: "utf-8" });
+			expect(mockExecFile).toHaveBeenCalledWith(
+				"git",
+				["status"],
+				expect.objectContaining({ cwd: "/tmp", encoding: "utf-8", windowsHide: true }),
+				expect.any(Function),
+			);
+		});
+
+		it("lets caller override windowsHide:false explicitly", async () => {
+			const { execFileAsyncHidden } = await import("./Subprocess.js");
+			await execFileAsyncHidden("git", ["status"], { windowsHide: false });
+			expect(mockExecFile).toHaveBeenCalledWith(
+				"git",
+				["status"],
+				expect.objectContaining({ windowsHide: false }),
+				expect.any(Function),
+			);
+		});
+
+		it("resolves with stdout/stderr from execFile callback", async () => {
+			mockExecFile.mockImplementationOnce(
+				(
+					_file: string,
+					_args: ReadonlyArray<string>,
+					_options: unknown,
+					callback: (err: null, result: { stdout: string; stderr: string }) => void,
+				) => {
+					callback(null, { stdout: "main\n", stderr: "" });
+				},
+			);
+			const { execFileAsyncHidden } = await import("./Subprocess.js");
+			const result = await execFileAsyncHidden("git", ["rev-parse", "--abbrev-ref", "HEAD"]);
+			expect(result).toEqual({ stdout: "main\n", stderr: "" });
+		});
+
+		it("rejects when execFile callback yields an error", async () => {
+			const err = new Error("boom");
+			mockExecFile.mockImplementationOnce(
+				(_file: string, _args: ReadonlyArray<string>, _options: unknown, callback: (err: Error) => void) => {
+					callback(err);
+				},
+			);
+			const { execFileAsyncHidden } = await import("./Subprocess.js");
+			await expect(execFileAsyncHidden("git", ["bogus"])).rejects.toBe(err);
+		});
+	});
+});

--- a/cli/src/util/Subprocess.test.ts
+++ b/cli/src/util/Subprocess.test.ts
@@ -1,7 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockExecFileSync = vi.fn().mockReturnValue(Buffer.from("ok"));
-const mockExecSync = vi.fn().mockReturnValue(Buffer.from("ok"));
 const mockSpawn = vi.fn().mockReturnValue({ pid: 1, unref: vi.fn() });
 const mockSpawnSync = vi
 	.fn()
@@ -21,7 +20,6 @@ const mockExecFile = vi
 
 vi.mock("node:child_process", () => ({
 	execFileSync: mockExecFileSync,
-	execSync: mockExecSync,
 	spawn: mockSpawn,
 	spawnSync: mockSpawnSync,
 	execFile: mockExecFile,
@@ -30,7 +28,6 @@ vi.mock("node:child_process", () => ({
 describe("Subprocess", () => {
 	beforeEach(() => {
 		mockExecFileSync.mockClear();
-		mockExecSync.mockClear();
 		mockSpawn.mockClear();
 		mockSpawnSync.mockClear();
 		mockExecFile.mockClear();
@@ -75,29 +72,6 @@ describe("Subprocess", () => {
 				undefined,
 				expect.objectContaining({ windowsHide: true }),
 			);
-		});
-	});
-
-	describe("execSyncHidden", () => {
-		it("injects windowsHide:true when no options given", async () => {
-			const { execSyncHidden } = await import("./Subprocess.js");
-			execSyncHidden("git status");
-			expect(mockExecSync).toHaveBeenCalledWith("git status", expect.objectContaining({ windowsHide: true }));
-		});
-
-		it("preserves user options and adds windowsHide:true", async () => {
-			const { execSyncHidden } = await import("./Subprocess.js");
-			execSyncHidden("git status", { cwd: "/tmp", encoding: "utf-8" });
-			expect(mockExecSync).toHaveBeenCalledWith(
-				"git status",
-				expect.objectContaining({ cwd: "/tmp", encoding: "utf-8", windowsHide: true }),
-			);
-		});
-
-		it("lets caller override windowsHide:false explicitly", async () => {
-			const { execSyncHidden } = await import("./Subprocess.js");
-			execSyncHidden("git status", { windowsHide: false });
-			expect(mockExecSync).toHaveBeenCalledWith("git status", expect.objectContaining({ windowsHide: false }));
 		});
 	});
 

--- a/cli/src/util/Subprocess.ts
+++ b/cli/src/util/Subprocess.ts
@@ -1,0 +1,132 @@
+/**
+ * Subprocess — thin wrapper around node:child_process that injects
+ * `windowsHide: true` by default. Without it, GUI parent processes
+ * (VS Code, IntelliJ, Sourcetree) on Windows allocate a visible conhost
+ * window for each console child (git.exe, gh.exe, …) — a black flash
+ * users see on every commit / rebase.
+ *
+ * Use this module everywhere instead of `node:child_process`. A biome
+ * `noRestrictedImports` rule enforces it for non-test source files.
+ *
+ * Callers may explicitly override by passing `windowsHide: false`.
+ */
+
+import {
+	type ExecFileOptions,
+	type ExecFileSyncOptions,
+	type ExecFileSyncOptionsWithBufferEncoding,
+	type ExecFileSyncOptionsWithStringEncoding,
+	type ExecSyncOptions,
+	type ExecSyncOptionsWithBufferEncoding,
+	type ExecSyncOptionsWithStringEncoding,
+	execFile,
+	execFileSync,
+	execSync,
+	type SpawnOptions,
+	type SpawnSyncOptions,
+	type SpawnSyncOptionsWithBufferEncoding,
+	type SpawnSyncOptionsWithStringEncoding,
+	type SpawnSyncReturns,
+	spawn,
+	spawnSync,
+} from "node:child_process";
+import { promisify } from "node:util";
+
+const HIDDEN = { windowsHide: true } as const;
+
+/**
+ * Promisified `execFile` with `windowsHide: true` injected by default.
+ *
+ * We promisify inside the call (not at module load) so that tests using
+ * `vi.mock("node:child_process", …)` see their mock — eager promisification
+ * would close over the original `execFile` before the mock takes effect.
+ * Same reason `cli/src/core/Locks.ts` does lazy promisification.
+ */
+export function execFileAsyncHidden(
+	file: string,
+	args?: ReadonlyArray<string>,
+	options?: ExecFileOptions,
+): Promise<{ stdout: string; stderr: string }> {
+	return promisify(execFile)(file, args as ReadonlyArray<string>, { ...HIDDEN, ...(options ?? {}) }) as Promise<{
+		stdout: string;
+		stderr: string;
+	}>;
+}
+
+export function execFileSyncHidden(
+	file: string,
+	args: ReadonlyArray<string> | undefined,
+	options: ExecFileSyncOptionsWithStringEncoding,
+): string;
+export function execFileSyncHidden(
+	file: string,
+	args: ReadonlyArray<string> | undefined,
+	options: ExecFileSyncOptionsWithBufferEncoding,
+): Buffer;
+export function execFileSyncHidden(
+	file: string,
+	args?: ReadonlyArray<string>,
+	options?: ExecFileSyncOptions,
+): Buffer | string;
+export function execFileSyncHidden(
+	file: string,
+	args?: ReadonlyArray<string>,
+	options?: ExecFileSyncOptions,
+): Buffer | string {
+	return execFileSync(file, args as ReadonlyArray<string>, { ...HIDDEN, ...(options ?? {}) });
+}
+
+export function execSyncHidden(command: string, options: ExecSyncOptionsWithStringEncoding): string;
+export function execSyncHidden(command: string, options: ExecSyncOptionsWithBufferEncoding): Buffer;
+export function execSyncHidden(command: string, options?: ExecSyncOptions): Buffer | string;
+export function execSyncHidden(command: string, options?: ExecSyncOptions): Buffer | string {
+	return execSync(command, { ...HIDDEN, ...(options ?? {}) });
+}
+
+/**
+ * `spawn` with `windowsHide: true` injected by default.
+ *
+ * Cast to `typeof spawn` so we inherit Node's full overload set — in particular
+ * the `SpawnOptionsWithoutStdio` / `SpawnOptionsWithStdioTuple<...>` overloads
+ * that narrow the return type to `ChildProcessWithoutNullStreams` /
+ * `ChildProcessByStdio<Writable, Readable, Readable>`. Without this, callers
+ * with `stdio: "pipe"` or `stdio: ["pipe","pipe","pipe"]` would lose the
+ * non-null stream guarantee and need `proc.stdout!` everywhere.
+ *
+ * Runtime: handles both 2-arg (`spawn(cmd, opts)`) and 3-arg
+ * (`spawn(cmd, args, opts)`) call shapes that Node's spawn supports.
+ */
+export const spawnHidden = ((
+	command: string,
+	argsOrOptions?: ReadonlyArray<string> | SpawnOptions,
+	maybeOptions?: SpawnOptions,
+) => {
+	if (Array.isArray(argsOrOptions)) {
+		return spawn(command, argsOrOptions as ReadonlyArray<string>, { ...HIDDEN, ...(maybeOptions ?? {}) });
+	}
+	const opts = (argsOrOptions ?? {}) as SpawnOptions;
+	return spawn(command, { ...HIDDEN, ...opts });
+}) as typeof spawn;
+
+export function spawnSyncHidden(
+	command: string,
+	args: ReadonlyArray<string> | undefined,
+	options: SpawnSyncOptionsWithStringEncoding,
+): SpawnSyncReturns<string>;
+export function spawnSyncHidden(
+	command: string,
+	args: ReadonlyArray<string> | undefined,
+	options: SpawnSyncOptionsWithBufferEncoding,
+): SpawnSyncReturns<Buffer>;
+export function spawnSyncHidden(
+	command: string,
+	args?: ReadonlyArray<string>,
+	options?: SpawnSyncOptions,
+): SpawnSyncReturns<Buffer | string>;
+export function spawnSyncHidden(
+	command: string,
+	args?: ReadonlyArray<string>,
+	options?: SpawnSyncOptions,
+): SpawnSyncReturns<Buffer | string> {
+	return spawnSync(command, args as ReadonlyArray<string>, { ...HIDDEN, ...(options ?? {}) });
+}

--- a/cli/src/util/Subprocess.ts
+++ b/cli/src/util/Subprocess.ts
@@ -16,12 +16,8 @@ import {
 	type ExecFileSyncOptions,
 	type ExecFileSyncOptionsWithBufferEncoding,
 	type ExecFileSyncOptionsWithStringEncoding,
-	type ExecSyncOptions,
-	type ExecSyncOptionsWithBufferEncoding,
-	type ExecSyncOptionsWithStringEncoding,
 	execFile,
 	execFileSync,
-	execSync,
 	type SpawnOptions,
 	type SpawnSyncOptions,
 	type SpawnSyncOptionsWithBufferEncoding,
@@ -74,13 +70,6 @@ export function execFileSyncHidden(
 	options?: ExecFileSyncOptions,
 ): Buffer | string {
 	return execFileSync(file, args as ReadonlyArray<string>, { ...HIDDEN, ...(options ?? {}) });
-}
-
-export function execSyncHidden(command: string, options: ExecSyncOptionsWithStringEncoding): string;
-export function execSyncHidden(command: string, options: ExecSyncOptionsWithBufferEncoding): Buffer;
-export function execSyncHidden(command: string, options?: ExecSyncOptions): Buffer | string;
-export function execSyncHidden(command: string, options?: ExecSyncOptions): Buffer | string {
-	return execSync(command, { ...HIDDEN, ...(options ?? {}) });
 }
 
 /**

--- a/cli/src/util/WindowsHidden.ts
+++ b/cli/src/util/WindowsHidden.ts
@@ -1,12 +1,11 @@
-import { spawnSync } from "node:child_process";
 import { platform } from "node:os";
+import { spawnSyncHidden } from "./Subprocess.js";
 
 /** Best-effort `attrib +h` on win32; no-op elsewhere. Silent on failure — hidden bit is cosmetic. */
 export function tryMarkHiddenOnWindows(absPath: string): void {
 	if (platform() !== "win32") return;
 	try {
-		spawnSync("attrib", ["+h", absPath], {
-			windowsHide: true,
+		spawnSyncHidden("attrib", ["+h", absPath], {
 			timeout: 2000,
 		});
 	} catch {

--- a/vscode/biome.json
+++ b/vscode/biome.json
@@ -1,0 +1,40 @@
+{
+	"$schema": "https://biomejs.dev/schemas/2.2.6/schema.json",
+	"files": {
+		"includes": ["src/**"]
+	},
+	"assist": {
+		"enabled": false
+	},
+	"formatter": {
+		"enabled": false
+	},
+	"linter": {
+		"enabled": true,
+		"rules": {
+			"recommended": true,
+			"style": {
+				"noRestrictedImports": {
+					"level": "error",
+					"options": {
+						"paths": {
+							"node:child_process": "Use cli/src/util/Subprocess.ts wrappers (execFileSyncHidden, execFileAsyncHidden, spawnHidden, spawnSyncHidden, execSyncHidden) instead — they inject windowsHide:true so child processes do not flash a console window on Windows. *.test.ts files are exempt via overrides."
+						}
+					}
+				}
+			}
+		}
+	},
+	"overrides": [
+		{
+			"includes": ["**/*.test.ts"],
+			"linter": {
+				"rules": {
+					"style": {
+						"noRestrictedImports": "off"
+					}
+				}
+			}
+		}
+	]
+}

--- a/vscode/biome.json
+++ b/vscode/biome.json
@@ -18,7 +18,8 @@
 					"level": "error",
 					"options": {
 						"paths": {
-							"node:child_process": "Use cli/src/util/Subprocess.ts wrappers (execFileSyncHidden, execFileAsyncHidden, spawnHidden, spawnSyncHidden, execSyncHidden) instead — they inject windowsHide:true so child processes do not flash a console window on Windows. *.test.ts files are exempt via overrides."
+							"node:child_process": "Use cli/src/util/Subprocess.ts wrappers (execFileSyncHidden, execFileAsyncHidden, spawnHidden, spawnSyncHidden) instead — they inject windowsHide:true so child processes do not flash a console window on Windows. *.test.ts files are exempt via overrides.",
+							"child_process": "Use cli/src/util/Subprocess.ts wrappers (execFileSyncHidden, execFileAsyncHidden, spawnHidden, spawnSyncHidden) instead — they inject windowsHide:true so child processes do not flash a console window on Windows. *.test.ts files are exempt via overrides."
 						}
 					}
 				}

--- a/vscode/src/Extension.test.ts
+++ b/vscode/src/Extension.test.ts
@@ -112,23 +112,28 @@ const { buildClaudeCodeContext } = vi.hoisted(() => ({
 }));
 
 const { execSync, execFileSync } = vi.hoisted(() => ({
-	// Mock git rev-parse --git-path calls used by resolveGitPath() in Extension.ts.
-	// Returns realistic paths so HEAD and orphan-ref watchers are created in tests,
-	// preserving the createFileSystemWatcher mock call order.
+	// `execSync` is retained for any legacy mock paths but Extension.ts itself
+	// no longer calls it — kept here so the `node:child_process` mock factory
+	// below has something to export. Default impl throws so any unexpected
+	// caller fails loudly.
 	execSync: vi.fn((cmd: string) => {
-		if (cmd.includes("rev-parse --git-path HEAD")) {
-			return Buffer.from("/test/workspace/.git/HEAD\n");
-		}
-		if (cmd.includes("rev-parse --git-path refs/heads/")) {
-			return Buffer.from(
-				"/test/workspace/.git/refs/heads/__jolli_orphan_branch__\n",
-			);
-		}
 		throw new Error(`Unmocked exec: ${cmd}`);
 	}),
-	// Used by the no-git Initialize Git path. Default impl throws so unmocked
-	// calls fail loudly; the no-git tests override .mockImplementation per case.
+	// resolveGitPath() now uses execFileSyncHidden("git", ["rev-parse", "--git-path", rel])
+	// so we intercept those calls here. Returns realistic paths so HEAD and
+	// orphan-ref watchers are created, preserving the createFileSystemWatcher
+	// mock call order.
+	// The no-git Initialize Git path calls execFileSyncHidden("git", ["init"]) —
+	// those tests override .mockImplementation per case.
 	execFileSync: vi.fn((bin: string, args: ReadonlyArray<string>) => {
+		if (bin === "git" && args[0] === "rev-parse" && args[1] === "--git-path") {
+			if (args[2] === "HEAD") {
+				return "/test/workspace/.git/HEAD\n";
+			}
+			if (typeof args[2] === "string" && args[2].startsWith("refs/heads/")) {
+				return "/test/workspace/.git/refs/heads/__jolli_orphan_branch__\n";
+			}
+		}
 		throw new Error(`Unmocked execFile: ${bin} ${args.join(" ")}`);
 	}),
 }));
@@ -1003,7 +1008,7 @@ describe("Extension", () => {
 		it("warns but keeps activating when rev-parse --git-path fails", () => {
 			// Throw for all resolveGitPath queries → both HEAD and orphan-ref watchers
 			// skip creation, hitting the `else` branches that log auto-refresh-disabled warnings.
-			execSync.mockImplementation(() => {
+			execFileSync.mockImplementation(() => {
 				throw new Error("not a git repo");
 			});
 			const ctx = makeContext();
@@ -1023,15 +1028,26 @@ describe("Extension", () => {
 
 		it("resolves non-absolute git-paths against cwd", () => {
 			// Returns a relative path → covers the `isAbsolute(out) ? out : resolve(cwd, out)` right branch.
-			execSync.mockImplementation((cmd: string) => {
-				if (cmd.includes("rev-parse --git-path HEAD")) {
-					return Buffer.from(".git/HEAD\n");
-				}
-				if (cmd.includes("rev-parse --git-path refs/heads/")) {
-					return Buffer.from(".git/refs/heads/__jolli_orphan_branch__\n");
-				}
-				throw new Error(`Unmocked exec: ${cmd}`);
-			});
+			execFileSync.mockImplementation(
+				(bin: string, args: ReadonlyArray<string>) => {
+					if (
+						bin === "git" &&
+						args[0] === "rev-parse" &&
+						args[1] === "--git-path"
+					) {
+						if (args[2] === "HEAD") {
+							return ".git/HEAD\n";
+						}
+						if (
+							typeof args[2] === "string" &&
+							args[2].startsWith("refs/heads/")
+						) {
+							return ".git/refs/heads/__jolli_orphan_branch__\n";
+						}
+					}
+					throw new Error(`Unmocked execFile: ${bin} ${args.join(" ")}`);
+				},
+			);
 			const ctx = makeContext();
 
 			activate(ctx);

--- a/vscode/src/Extension.ts
+++ b/vscode/src/Extension.ts
@@ -5,7 +5,6 @@
  * Called by VSCode when the extension activates (workspaceContains:.git).
  */
 
-import { execFileSync, execSync } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
 import { dirname, isAbsolute, join, resolve } from "node:path";
 import * as vscode from "vscode";
@@ -34,6 +33,7 @@ import {
 } from "../../cli/src/core/SummaryStore.js";
 import { ORPHAN_BRANCH } from "../../cli/src/Logger.js";
 import type { StatusInfo } from "../../cli/src/Types.js";
+import { execFileSyncHidden } from "../../cli/src/util/Subprocess.js";
 import { CommitCommand } from "./commands/CommitCommand.js";
 import { PushCommand } from "./commands/PushCommand.js";
 import { SquashCommand } from "./commands/SquashCommand.js";
@@ -151,11 +151,14 @@ function resolveGitPath(
 	relativeToGitDir: string,
 ): string | undefined {
 	try {
-		const out = execSync(`git rev-parse --git-path ${relativeToGitDir}`, {
-			cwd,
-		})
-			.toString()
-			.trim();
+		const out = execFileSyncHidden(
+			"git",
+			["rev-parse", "--git-path", relativeToGitDir],
+			{
+				cwd,
+				encoding: "utf-8",
+			},
+		).trim();
 		return isAbsolute(out) ? out : resolve(cwd, out);
 	} catch {
 		return;
@@ -295,7 +298,7 @@ export function activate(context: vscode.ExtensionContext): void {
 	if (!existsSync(join(workspaceRoot, ".git"))) {
 		const initGit = () => {
 			try {
-				execFileSync("git", ["init"], { cwd: workspaceRoot });
+				execFileSyncHidden("git", ["init"], { cwd: workspaceRoot });
 				return vscode.window
 					.showInformationMessage(
 						"Git initialized. Please reload the window to activate Jolli Memory.",

--- a/vscode/src/JolliMemoryBridge.test.ts
+++ b/vscode/src/JolliMemoryBridge.test.ts
@@ -1068,7 +1068,7 @@ describe("JolliMemoryBridge", () => {
 			expect(execFileMock).toHaveBeenCalledWith(
 				"git",
 				["add", "--", "a.ts", "b.ts"],
-				{ cwd: TEST_CWD, encoding: "utf8" },
+				{ cwd: TEST_CWD, encoding: "utf8", windowsHide: true },
 				expect.any(Function),
 			);
 			expect(execFileMock).toHaveBeenCalledTimes(1);
@@ -1108,7 +1108,7 @@ describe("JolliMemoryBridge", () => {
 			expect(execFileMock).toHaveBeenCalledWith(
 				"git",
 				["add", "--", "a.ts", "b.ts"],
-				{ cwd: TEST_CWD, encoding: "utf8" },
+				{ cwd: TEST_CWD, encoding: "utf8", windowsHide: true },
 				expect.any(Function),
 			);
 			expect(execFileMock).toHaveBeenCalledTimes(1);
@@ -1124,7 +1124,7 @@ describe("JolliMemoryBridge", () => {
 			expect(execFileMock).toHaveBeenCalledWith(
 				"git",
 				["rm", "--cached", "--ignore-unmatch", "--", "a.ts", "b.ts"],
-				{ cwd: TEST_CWD, encoding: "utf8" },
+				{ cwd: TEST_CWD, encoding: "utf8", windowsHide: true },
 				expect.any(Function),
 			);
 			expect(execFileMock).toHaveBeenCalledTimes(1);
@@ -1144,14 +1144,14 @@ describe("JolliMemoryBridge", () => {
 				1,
 				"git",
 				["add", "--", "a.ts"],
-				{ cwd: TEST_CWD, encoding: "utf8" },
+				{ cwd: TEST_CWD, encoding: "utf8", windowsHide: true },
 				expect.any(Function),
 			);
 			expect(execFileMock).toHaveBeenNthCalledWith(
 				2,
 				"git",
 				["rm", "--cached", "--ignore-unmatch", "--", "b.ts"],
-				{ cwd: TEST_CWD, encoding: "utf8" },
+				{ cwd: TEST_CWD, encoding: "utf8", windowsHide: true },
 				expect.any(Function),
 			);
 		});
@@ -1178,14 +1178,14 @@ describe("JolliMemoryBridge", () => {
 				1,
 				"git",
 				["add", "--", "healthy.ts"],
-				{ cwd: TEST_CWD, encoding: "utf8" },
+				{ cwd: TEST_CWD, encoding: "utf8", windowsHide: true },
 				expect.any(Function),
 			);
 			expect(execFileMock).toHaveBeenNthCalledWith(
 				2,
 				"git",
 				["rm", "--cached", "--ignore-unmatch", "--", "ignored-and-gone.ts"],
-				{ cwd: TEST_CWD, encoding: "utf8" },
+				{ cwd: TEST_CWD, encoding: "utf8", windowsHide: true },
 				expect.any(Function),
 			);
 		});
@@ -1204,7 +1204,7 @@ describe("JolliMemoryBridge", () => {
 			expect(execFileMock).toHaveBeenCalledWith(
 				"git",
 				["add", "--", "dangling-link"],
-				{ cwd: TEST_CWD, encoding: "utf8" },
+				{ cwd: TEST_CWD, encoding: "utf8", windowsHide: true },
 				expect.any(Function),
 			);
 			expect(execFileMock).toHaveBeenCalledTimes(1);
@@ -1269,7 +1269,7 @@ describe("JolliMemoryBridge", () => {
 			expect(execFileMock).toHaveBeenCalledWith(
 				"git",
 				["restore", "--staged", "--", "src/main.ts"],
-				{ cwd: TEST_CWD, encoding: "utf8" },
+				{ cwd: TEST_CWD, encoding: "utf8", windowsHide: true },
 				expect.any(Function),
 			);
 		});
@@ -1285,7 +1285,7 @@ describe("JolliMemoryBridge", () => {
 			expect(execFileMock).toHaveBeenCalledWith(
 				"git",
 				["restore", "--staged", "--", "a.ts", "b.ts"],
-				{ cwd: TEST_CWD, encoding: "utf8" },
+				{ cwd: TEST_CWD, encoding: "utf8", windowsHide: true },
 				expect.any(Function),
 			);
 		});
@@ -1336,7 +1336,7 @@ describe("JolliMemoryBridge", () => {
 			expect(execFileMock).toHaveBeenCalledWith(
 				"git",
 				["restore", "--", "file.ts"],
-				{ cwd: TEST_CWD, encoding: "utf8" },
+				{ cwd: TEST_CWD, encoding: "utf8", windowsHide: true },
 				expect.any(Function),
 			);
 		});
@@ -1350,7 +1350,7 @@ describe("JolliMemoryBridge", () => {
 			expect(execFileMock).toHaveBeenCalledWith(
 				"git",
 				["restore", "--staged", "--worktree", "--", "file.ts"],
-				{ cwd: TEST_CWD, encoding: "utf8" },
+				{ cwd: TEST_CWD, encoding: "utf8", windowsHide: true },
 				expect.any(Function),
 			);
 		});
@@ -1364,7 +1364,7 @@ describe("JolliMemoryBridge", () => {
 			expect(execFileMock).toHaveBeenCalledWith(
 				"git",
 				["restore", "--staged", "--worktree", "--", "file.ts"],
-				{ cwd: TEST_CWD, encoding: "utf8" },
+				{ cwd: TEST_CWD, encoding: "utf8", windowsHide: true },
 				expect.any(Function),
 			);
 		});
@@ -1378,7 +1378,7 @@ describe("JolliMemoryBridge", () => {
 			expect(execFileMock).toHaveBeenCalledWith(
 				"git",
 				["restore", "--", "file.ts"],
-				{ cwd: TEST_CWD, encoding: "utf8" },
+				{ cwd: TEST_CWD, encoding: "utf8", windowsHide: true },
 				expect.any(Function),
 			);
 		});
@@ -1392,7 +1392,7 @@ describe("JolliMemoryBridge", () => {
 			expect(execFileMock).toHaveBeenCalledWith(
 				"git",
 				["restore", "--staged", "--worktree", "--", "file.ts"],
-				{ cwd: TEST_CWD, encoding: "utf8" },
+				{ cwd: TEST_CWD, encoding: "utf8", windowsHide: true },
 				expect.any(Function),
 			);
 		});
@@ -1408,7 +1408,7 @@ describe("JolliMemoryBridge", () => {
 			expect(execFileMock).toHaveBeenCalledWith(
 				"git",
 				["restore", "--staged", "--", "new.ts"],
-				{ cwd: TEST_CWD, encoding: "utf8" },
+				{ cwd: TEST_CWD, encoding: "utf8", windowsHide: true },
 				expect.any(Function),
 			);
 			expect(unlink).toHaveBeenCalledWith(`${TEST_CWD}/new.ts`);
@@ -1425,7 +1425,7 @@ describe("JolliMemoryBridge", () => {
 			expect(execFileMock).toHaveBeenCalledWith(
 				"git",
 				["restore", "--staged", "--", "new.ts"],
-				{ cwd: TEST_CWD, encoding: "utf8" },
+				{ cwd: TEST_CWD, encoding: "utf8", windowsHide: true },
 				expect.any(Function),
 			);
 			expect(unlink).toHaveBeenCalledWith(`${TEST_CWD}/new.ts`);
@@ -1470,7 +1470,7 @@ describe("JolliMemoryBridge", () => {
 			expect(execFileMock).toHaveBeenCalledWith(
 				"git",
 				["restore", "--staged", "--", "copy.ts"],
-				{ cwd: TEST_CWD, encoding: "utf8" },
+				{ cwd: TEST_CWD, encoding: "utf8", windowsHide: true },
 				expect.any(Function),
 			);
 			expect(unlink).toHaveBeenCalledWith(`${TEST_CWD}/copy.ts`);
@@ -1488,13 +1488,13 @@ describe("JolliMemoryBridge", () => {
 			expect(execFileMock).toHaveBeenCalledWith(
 				"git",
 				["restore", "--staged", "--", "new.ts", "old.ts"],
-				{ cwd: TEST_CWD, encoding: "utf8" },
+				{ cwd: TEST_CWD, encoding: "utf8", windowsHide: true },
 				expect.any(Function),
 			);
 			expect(execFileMock).toHaveBeenCalledWith(
 				"git",
 				["restore", "--", "old.ts"],
-				{ cwd: TEST_CWD, encoding: "utf8" },
+				{ cwd: TEST_CWD, encoding: "utf8", windowsHide: true },
 				expect.any(Function),
 			);
 			expect(unlink).toHaveBeenCalledWith(`${TEST_CWD}/new.ts`);
@@ -1511,7 +1511,7 @@ describe("JolliMemoryBridge", () => {
 			expect(execFileMock).toHaveBeenCalledWith(
 				"git",
 				["restore", "--staged", "--", "new.ts"],
-				{ cwd: TEST_CWD, encoding: "utf8" },
+				{ cwd: TEST_CWD, encoding: "utf8", windowsHide: true },
 				expect.any(Function),
 			);
 			// Should NOT call git restore -- (worktree restore, without --staged)
@@ -1536,13 +1536,13 @@ describe("JolliMemoryBridge", () => {
 			expect(execFileMock).toHaveBeenCalledWith(
 				"git",
 				["restore", "--staged", "--", "new.ts", "old.ts"],
-				{ cwd: TEST_CWD, encoding: "utf8" },
+				{ cwd: TEST_CWD, encoding: "utf8", windowsHide: true },
 				expect.any(Function),
 			);
 			expect(execFileMock).toHaveBeenCalledWith(
 				"git",
 				["restore", "--", "old.ts"],
-				{ cwd: TEST_CWD, encoding: "utf8" },
+				{ cwd: TEST_CWD, encoding: "utf8", windowsHide: true },
 				expect.any(Function),
 			);
 		});
@@ -1590,7 +1590,7 @@ describe("JolliMemoryBridge", () => {
 			expect(execFileMock).toHaveBeenCalledWith(
 				"git",
 				["restore", "--staged", "--", "new.ts"],
-				{ cwd: TEST_CWD, encoding: "utf8" },
+				{ cwd: TEST_CWD, encoding: "utf8", windowsHide: true },
 				expect.any(Function),
 			);
 			// No separate restore for old path
@@ -1614,13 +1614,13 @@ describe("JolliMemoryBridge", () => {
 			expect(execFileMock).toHaveBeenCalledWith(
 				"git",
 				["restore", "--staged", "--worktree", "--", "staged.ts"],
-				{ cwd: TEST_CWD, encoding: "utf8" },
+				{ cwd: TEST_CWD, encoding: "utf8", windowsHide: true },
 				expect.any(Function),
 			);
 			expect(execFileMock).toHaveBeenCalledWith(
 				"git",
 				["restore", "--", "unstaged.ts"],
-				{ cwd: TEST_CWD, encoding: "utf8" },
+				{ cwd: TEST_CWD, encoding: "utf8", windowsHide: true },
 				expect.any(Function),
 			);
 			expect(unlink).toHaveBeenCalledWith(`${TEST_CWD}/new.ts`);
@@ -2093,7 +2093,7 @@ describe("JolliMemoryBridge", () => {
 			expect(execFileMock).toHaveBeenLastCalledWith(
 				"git",
 				["push", "-u", "origin", "feature/new"],
-				{ cwd: TEST_CWD, encoding: "utf8" },
+				{ cwd: TEST_CWD, encoding: "utf8", windowsHide: true },
 				expect.any(Function),
 			);
 		});
@@ -2112,7 +2112,7 @@ describe("JolliMemoryBridge", () => {
 			expect(execFileMock).toHaveBeenLastCalledWith(
 				"git",
 				["push", "-u", "origin", "feature/test"],
-				{ cwd: TEST_CWD, encoding: "utf8" },
+				{ cwd: TEST_CWD, encoding: "utf8", windowsHide: true },
 				expect.any(Function),
 			);
 		});
@@ -2131,7 +2131,7 @@ describe("JolliMemoryBridge", () => {
 			expect(execFileMock).toHaveBeenLastCalledWith(
 				"git",
 				["push"],
-				{ cwd: TEST_CWD, encoding: "utf8" },
+				{ cwd: TEST_CWD, encoding: "utf8", windowsHide: true },
 				expect.any(Function),
 			);
 		});
@@ -2152,7 +2152,7 @@ describe("JolliMemoryBridge", () => {
 			expect(execFileMock).toHaveBeenLastCalledWith(
 				"git",
 				["push", "--force-with-lease"],
-				{ cwd: TEST_CWD, encoding: "utf8" },
+				{ cwd: TEST_CWD, encoding: "utf8", windowsHide: true },
 				expect.any(Function),
 			);
 		});
@@ -2534,7 +2534,7 @@ describe("JolliMemoryBridge", () => {
 			expect(execFileMock).toHaveBeenCalledWith(
 				"git",
 				["diff", "--cached", "-z", "--name-only"],
-				{ cwd: TEST_CWD, encoding: "utf8" },
+				{ cwd: TEST_CWD, encoding: "utf8", windowsHide: true },
 				expect.any(Function),
 			);
 		});
@@ -2571,7 +2571,7 @@ describe("JolliMemoryBridge", () => {
 			expect(execFileMock).toHaveBeenCalledWith(
 				"git",
 				["read-tree", "tree123"],
-				{ cwd: TEST_CWD, encoding: "utf8" },
+				{ cwd: TEST_CWD, encoding: "utf8", windowsHide: true },
 				expect.any(Function),
 			);
 		});
@@ -2585,7 +2585,7 @@ describe("JolliMemoryBridge", () => {
 			expect(execFileMock).toHaveBeenCalledWith(
 				"git",
 				["reset"],
-				{ cwd: TEST_CWD, encoding: "utf8" },
+				{ cwd: TEST_CWD, encoding: "utf8", windowsHide: true },
 				expect.any(Function),
 			);
 		});

--- a/vscode/src/JolliMemoryBridge.ts
+++ b/vscode/src/JolliMemoryBridge.ts
@@ -10,12 +10,10 @@
  * - All git operations → subprocess via execGit() helper
  */
 
-import { execFile } from "node:child_process";
 import { existsSync, lstatSync, readFileSync } from "node:fs";
 import { lstat, rm, unlink } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
-import { promisify } from "node:util";
 import { FolderStorage } from "../../cli/src/core/FolderStorage.js";
 import { getDiffStats } from "../../cli/src/core/GitOps.js";
 import { filterToBranchHeads } from "../../cli/src/core/HeadEntryFilter.js";
@@ -73,6 +71,7 @@ import type {
 	StoredTranscript,
 	SummaryIndexEntry,
 } from "../../cli/src/Types.js";
+import { execFileAsyncHidden } from "../../cli/src/util/Subprocess.js";
 import {
 	detectLinearIssues,
 	openLinearIssueInBrowser as openLinearIssueInBrowserImpl,
@@ -103,8 +102,6 @@ import { mergeCommitMessages } from "./util/CommitMessageUtils.js";
 import { log } from "./util/Logger.js";
 import { loadGlobalConfig } from "./util/WorkspaceUtils.js";
 
-const execFileAsync = promisify(execFile);
-
 // ─── Git helpers ────────────────────────────────────────────────────────────
 
 /**
@@ -112,7 +109,7 @@ const execFileAsync = promisify(execFile);
  * Throws on non-zero exit.
  */
 async function execGit(args: Array<string>, cwd: string): Promise<string> {
-	const { stdout } = await execFileAsync("git", args, {
+	const { stdout } = await execFileAsyncHidden("git", args, {
 		cwd,
 		encoding: "utf8",
 	});

--- a/vscode/src/core/PlanService.ts
+++ b/vscode/src/core/PlanService.ts
@@ -11,7 +11,6 @@
  * - Filtering: Branch-aware visibility, archive guards, ignored entries
  */
 
-import { execFileSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import {
 	existsSync,
@@ -30,6 +29,7 @@ import {
 import type { StorageProvider } from "../../../cli/src/core/StorageProvider.js";
 import { storePlans } from "../../../cli/src/core/SummaryStore.js";
 import type { PlanReference } from "../../../cli/src/Types.js";
+import { execFileSyncHidden } from "../../../cli/src/util/Subprocess.js";
 import type { PlanEntry, PlanInfo } from "../Types.js";
 import { log } from "../util/Logger.js";
 
@@ -497,7 +497,7 @@ function hashFileContent(filePath: string): string {
 
 export function getCurrentBranch(cwd: string): string {
 	try {
-		return execFileSync("git", ["rev-parse", "--abbrev-ref", "HEAD"], {
+		return execFileSyncHidden("git", ["rev-parse", "--abbrev-ref", "HEAD"], {
 			cwd,
 			encoding: "utf-8",
 			stdio: ["ignore", "pipe", "ignore"],

--- a/vscode/src/services/PrCommentService.ts
+++ b/vscode/src/services/PrCommentService.ts
@@ -12,16 +12,13 @@
  * All GitHub/git operations go through the `gh` / `git` CLI — no new dependencies.
  */
 
-import { execFile } from "node:child_process";
 import { randomBytes } from "node:crypto";
 import { unlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { promisify } from "node:util";
 import * as vscode from "vscode";
+import { execFileAsyncHidden } from "../../../cli/src/util/Subprocess.js";
 import { log } from "../util/Logger.js";
-
-const execFileAsync = promisify(execFile);
 
 const TAG = "PrSection";
 
@@ -57,7 +54,10 @@ function replaceSummaryInBody(
 
 /** Runs a gh command and returns stdout. Throws on non-zero exit. */
 async function execGh(args: Array<string>, cwd: string): Promise<string> {
-	const { stdout } = await execFileAsync("gh", args, { cwd, encoding: "utf8" });
+	const { stdout } = await execFileAsyncHidden("gh", args, {
+		cwd,
+		encoding: "utf8",
+	});
 	return stdout;
 }
 
@@ -113,7 +113,7 @@ async function probeGh(
 	cwd: string,
 ): Promise<GhProbeResult> {
 	try {
-		const { stdout } = await execFileAsync("gh", args, {
+		const { stdout } = await execFileAsyncHidden("gh", args, {
 			cwd,
 			encoding: "utf8",
 		});
@@ -197,7 +197,7 @@ async function checkGhAuthenticated(
 
 /** Runs a git command and returns stdout. */
 async function execGit(args: Array<string>, cwd: string): Promise<string> {
-	const { stdout } = await execFileAsync("git", args, {
+	const { stdout } = await execFileAsyncHidden("git", args, {
 		cwd,
 		encoding: "utf8",
 	});

--- a/vscode/src/views/SummaryWebviewPanel.ts
+++ b/vscode/src/views/SummaryWebviewPanel.ts
@@ -13,11 +13,11 @@
  * - "Copy Markdown" button exports the summary as plain Markdown to the clipboard
  */
 
-import { execSync } from "node:child_process";
 import { randomBytes } from "node:crypto";
 import { existsSync } from "node:fs";
 import { join } from "node:path";
 import * as vscode from "vscode";
+import { execFileSyncHidden } from "../../../cli/src/util/Subprocess.js";
 import {
 	loadPlansRegistry,
 	savePlansRegistry,
@@ -1538,13 +1538,10 @@ export class SummaryWebviewPanel {
 		// Get diff for the commit (truncated to avoid huge prompts)
 		let diff = "";
 		try {
-			diff = execSync(
-				`git diff ${summary.commitHash}~1 ${summary.commitHash} -- . ":(exclude)*.lock"`,
-				{
-					cwd: this.workspaceRoot,
-					encoding: "utf-8",
-					maxBuffer: 512 * 1024,
-				},
+			diff = execFileSyncHidden(
+				"git",
+				["diff", `${summary.commitHash}~1`, summary.commitHash, "--", ".", ":(exclude)*.lock"],
+				{ cwd: this.workspaceRoot, encoding: "utf-8", maxBuffer: 512 * 1024 },
 			).substring(0, 30000);
 		} catch {
 			// Diff may fail for initial commits; proceed without it


### PR DESCRIPTION
<!-- jollimemory-summary-start -->
## Commits in this PR (2)

1. Suppress Windows console window flicker via Subprocess wrapper (`dc3e6a4`)
2. Remove execSyncHidden and ban bare child_process imports (`fface76`)

## Quick recap (2)

### Commit 1 of 2: Suppress Windows console window flicker via Subprocess wrapper (`dc3e6a4`)

Windows users working in graphical editors no longer see a black console window flash on screen during git commits and rebases. A new centralized subprocess wrapper now handles all background process launches across the project, and the console suppression flag is applied automatically on every call without any per-call configuration required.

To keep the fix permanent, a lint rule was added that makes bypassing the wrapper a build error. Any future subprocess call that skips the wrapper will be caught during the build rather than discovered through user reports. As part of the same migration, a shell command used to detect amend and rebase operations was replaced with a safer argument-array form, closing a latent shell-injection risk at no cost to existing behavior.

### Commit 2 of 2: Remove execSyncHidden and ban bare child_process imports (`fface76`)

The developer closed two structural gaps left open by an earlier fix for the flashing console window problem on Windows. The shell-string execution helper that had been listed as a recommended alternative in developer guidance was removed entirely from the codebase. With no remaining call sites to migrate, deletion was straightforward, and any future attempt to reintroduce shell-string execution now requires an explicit, visible override rather than a call to a sanctioned utility.

The import guardrail was also tightened so that both the modern and legacy spellings of the child process module are explicitly blocked by the same lint rule. Previously, the protection depended on two independent rules working in concert, meaning a configuration change to either one could silently reopen the bypass. The rule now stands on its own: a direct import of the child process module in either form produces a hard build error pointing developers to the approved wrappers.

## Topics (3)
<details>
<summary><strong>01 · [dc3e6a4] Eliminate console window flicker during git operations on Windows</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Windows users working in graphical editors saw a black command-line window briefly flash on screen every time they performed a git commit or rebase. The project's git hooks were launching background processes without suppressing the console window that Windows automatically creates for them.

**💡 Decisions Behind the Code**

- **Wrapper layer over per-call options**: A single wrapper module was introduced rather than adding the suppression flag to every individual subprocess call. This guarantees the behavior by construction, keeps call sites clean, and eliminates the class of bug where a new call is added without the flag. The lint rule closes the loop by making it structurally impossible to bypass the wrapper accidentally.
- **Lint-time enforcement over code-review convention**: A build error was chosen to enforce wrapper usage rather than relying on human discipline during code review. This means the CI pipeline rejects any future code that imports the raw Node API directly, turning a recurring human-discipline problem into an automated one. The wrapper file and test files are explicitly exempted via overrides so the rule does not block the implementation itself.
- **Array-argument form over shell-string form**: The git reflog call in the operation detector was previously constructed as a shell string, which carries a shell-injection risk if any argument were ever interpolated. The migration to the array-argument wrapper fixed this as a side effect, with no behavior change for the current hardcoded arguments.

**✅ What Was Implemented**

- Created `cli/src/util/Subprocess.ts` as a thin wrapper around Node's child process APIs, exporting five drop-in replacements (`execFileSyncHidden`, `execFileAsyncHidden`, `spawnHidden`, `spawnSyncHidden`, `execSyncHidden`) that automatically inject the `windowsHide: true` flag on every call. A companion test file validates all five wrappers with 18 tests at 100% coverage.
- Migrated all production subprocess calls across the CLI package to import from the new wrapper instead of `node:child_process` directly, covering hook entry points (`PostCommitHook.ts`, `GitOperationDetector.ts`, `StopHook.ts`, `QueueWorker.ts`, `SessionStartHook.ts`), core utilities (`GitOps.ts`, `Locks.ts`, `KBPathResolver.ts`, `SummaryExporter.ts`, `GitExclude.ts`), and CLI commands (`CliUtils.ts`, `RecallCommand.ts`).
- Corrected the `git reflog` call in `GitOperationDetector.ts` from a shell-interpolated `execSync` invocation to a safer array-argument `execFileSyncHidden` call as part of the same migration, closing a latent shell-injection risk.
- Added a `noRestrictedImports` lint rule to both `cli/biome.json` and a new `vscode/biome.json` that makes direct imports of `node:child_process` a build error everywhere except the wrapper itself and test files, preventing future regressions.

**📁 FILES**
- `cli/src/util/Subprocess.ts`
- `cli/src/hooks/PostCommitHook.ts`
- `cli/src/hooks/GitOperationDetector.ts`
- `cli/src/hooks/StopHook.ts`
- `cli/src/hooks/QueueWorker.ts`

</blockquote>
</details>
<details>
<summary><strong>02 · [fface76] Remove shell-string execution wrapper and close structural injection risk</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

A code reviewer flagged that the previous fix left a shell-string execution helper in place and even listed it as a recommended alternative in the lint guidance, meaning the underlying class of risk was not structurally prevented — only one call site had been cleaned up.

**💡 Decisions Behind the Code**

- **Delete rather than deprecate**: Removing the export entirely was chosen over marking it deprecated or adding a lint suppression comment. Because no production call sites existed anywhere in the codebase, deletion carried zero migration cost while making the constraint structural — any future attempt to use shell-string execution must now be an explicit, reviewer-visible bypass rather than a call to a sanctioned helper.
- **Bundle the cleanup into the same commit**: The shell-string removal was folded into the same change as the lint-rule tightening rather than deferred to a follow-up. The two fixes together close the gap the reviewer identified; splitting them would have left the lint message advertising a now-deleted function, creating a confusing intermediate state.

**✅ What Was Implemented**

- `cli/src/util/Subprocess.ts`: removed the `execSyncHidden` function entirely, including all four overload signatures and the implementation, along with the four type imports (`ExecSyncOptions`, `ExecSyncOptionsWithBufferEncoding`, `ExecSyncOptionsWithStringEncoding`, `execSync`) that were only needed to support it.
- `cli/src/util/Subprocess.test.ts`: deleted the `describe("execSyncHidden", …)` block (three tests), the `mockExecSync` mock definition, its entry in the `vi.mock` factory, and its `mockClear` call in `beforeEach` — reducing the test suite from 20 to 17 cases.
- Both `cli/biome.json` and `vscode/biome.json`: removed `execSyncHidden` from the lint error message's list of approved replacements, so the guidance now only points developers toward the safe wrappers that remain.

**📁 FILES**
- `cli/src/util/Subprocess.ts`
- `cli/biome.json`
- `vscode/biome.json`

</blockquote>
</details>
<details>
<summary><strong>03 · [fface76] Extend import ban to cover both forms of the child process module name</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

A reviewer pointed out that the lint rule only blocked imports using the newer prefixed module name, leaving the older unprefixed form as an unguarded bypass route that would silently pass the build check.

**💡 Decisions Behind the Code**

- **Explicit dual-entry over relying on rule interaction**: The previous setup depended on two separate lint rules working in concert — one to rewrite the import form, another to block the rewritten form — to achieve full coverage. Adding the unprefixed name directly to the banned-paths list makes the guardrail self-contained: it holds even if the protocol-normalization rule is later disabled or reconfigured, and the intent is immediately legible to anyone reading the config.
- **Error level, not warning**: Both entries are configured as hard errors rather than warnings. This ensures a developer cannot accidentally commit a direct import even in an environment where warnings are not treated as failures, removing a category of CI configuration drift that could silently re-open the gap.

**✅ What Was Implemented**

Added `"child_process"` as a second entry alongside `"node:child_process"` in the `noRestrictedImports` paths configuration in both `cli/biome.json` and `vscode/biome.json`. Both entries share the same error message directing developers to the approved wrappers. An independent verification step confirmed that dynamic imports and require-style calls using either module name are also caught by this rule.

**📁 FILES**
- `cli/biome.json`
- `vscode/biome.json`

</blockquote>
</details>

---

*Generated by Jolli Memory · May 20, 2026 at 10:16 AM*
<!-- jollimemory-summary-end -->