### PR TITLE
Add discard-selected action for multiple files in ChangesPanel

### DIFF
--- a/intellij/build.gradle.kts
+++ b/intellij/build.gradle.kts
@@ -443,6 +443,11 @@ kover {
 }
 
 tasks {
+    withType<JavaCompile> {
+        sourceCompatibility = "21"
+        targetCompatibility = "21"
+    }
+
     withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
         compilerOptions {
             jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21)

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/actions/DiscardSelectedAction.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/actions/DiscardSelectedAction.kt
@@ -1,0 +1,21 @@
+package ai.jolli.jollimemory.actions
+
+import ai.jolli.jollimemory.services.JolliMemoryService
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+
+/** Discards changes for all selected files in the Changes panel. */
+class DiscardSelectedAction : AnAction() {
+    override fun actionPerformed(e: AnActionEvent) {
+        val project = e.project ?: return
+        val registry = project.getService(JolliMemoryService::class.java).panelRegistry
+        registry?.changesPanel?.discardSelected()
+    }
+
+    override fun update(e: AnActionEvent) {
+        val service = e.project?.getService(JolliMemoryService::class.java)
+        val status = service?.getStatus()
+        val selectedFiles = service?.panelRegistry?.changesPanel?.getSelectedFiles()
+        e.presentation.isEnabled = status != null && status.enabled && !selectedFiles.isNullOrEmpty()
+    }
+}

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/ChangesPanel.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/ChangesPanel.kt
@@ -39,7 +39,9 @@ import javax.swing.BoxLayout
 import javax.swing.JButton
 import javax.swing.JCheckBox
 import javax.swing.JLabel
+import javax.swing.JMenuItem
 import javax.swing.JPanel
+import javax.swing.JPopupMenu
 import javax.swing.SwingUtilities
 import javax.swing.Timer
 
@@ -251,6 +253,57 @@ class ChangesPanel(
         repaint()
     }
 
+    /** Discards changes for all selected files after confirmation. */
+    fun discardSelected() {
+        val selected = getSelectedFiles()
+        if (selected.isEmpty()) return
+
+        val willDelete = selected.filter { it.statusCode in listOf("??", "A", "AM", "AD") }
+        val fileList = selected.take(10).joinToString("\n") { "  • ${it.relativePath}" }
+        val overflow = if (selected.size > 10) "\n  ...and ${selected.size - 10} more" else ""
+        val deleteWarning = if (willDelete.isNotEmpty()) {
+            "\n\n⚠ ${willDelete.size} file(s) will be permanently deleted (untracked/added)."
+        } else ""
+
+        val result = Messages.showYesNoDialog(
+            project,
+            "Discard changes to ${selected.size} file(s)?\n\n$fileList$overflow$deleteWarning\n\nThis action cannot be undone.",
+            "Discard Selected Changes",
+            "Discard All",
+            "Cancel",
+            Messages.getWarningIcon(),
+        )
+        if (result != Messages.YES) return
+
+        ApplicationManager.getApplication().executeOnPooledThread {
+            val gitOps = service.getGitOps() ?: return@executeOnPooledThread
+            val repoRoot = service.mainRepoRoot ?: project.basePath ?: return@executeOnPooledThread
+            discardFiles(selected, gitOps, repoRoot)
+            refreshFromGit()
+        }
+    }
+
+    /** Performs the git operations to discard a list of file changes. */
+    private fun discardFiles(files: List<FileChange>, gitOps: ai.jolli.jollimemory.bridge.GitOps, repoRoot: String) {
+        for (change in files) {
+            when (change.statusCode) {
+                "??" -> {
+                    try {
+                        val f = File(repoRoot, change.relativePath)
+                        if (f.isDirectory) f.deleteRecursively() else f.delete()
+                    } catch (_: Exception) { }
+                }
+                "A", "AM", "AD" -> {
+                    gitOps.exec("reset", "HEAD", "--", change.relativePath)
+                    try { File(repoRoot, change.relativePath).delete() } catch (_: Exception) { }
+                }
+                else -> {
+                    gitOps.exec("checkout", "HEAD", "--", change.relativePath)
+                }
+            }
+        }
+    }
+
     /**
      * Creates a VS Code-style file row:
      *   [checkbox] [icon] filename parentDir/   M  [⤺ discard on hover]
@@ -332,7 +385,9 @@ class ChangesPanel(
             border = JBUI.Borders.emptyLeft(2)
             addMouseListener(object : MouseAdapter() {
                 override fun mouseClicked(e: MouseEvent) {
-                    discardFile(change)
+                    if (SwingUtilities.isLeftMouseButton(e)) {
+                        discardFile(change)
+                    }
                 }
             })
         }
@@ -383,10 +438,26 @@ class ChangesPanel(
             child.addMouseListener(diffClickListener)
         }
 
+        // Right-click context menu
+        val contextMenuListener = object : MouseAdapter() {
+            override fun mousePressed(e: MouseEvent) { maybeShowPopup(e) }
+            override fun mouseReleased(e: MouseEvent) { maybeShowPopup(e) }
+            private fun maybeShowPopup(e: MouseEvent) {
+                if (!e.isPopupTrigger) return
+                val menu = JPopupMenu()
+                menu.add(JMenuItem("Discard Changes").apply {
+                    addActionListener { discardFile(change) }
+                })
+                menu.show(e.component, e.x, e.y)
+            }
+        }
+
         // Attach hover listener to the row and all child components
         row.addMouseListener(hoverListener)
+        row.addMouseListener(contextMenuListener)
         for (child in listOf(leftPanel, rightPanel, cb, iconLabel, nameLabel, pathLabel, statusLabel, discardLabel)) {
             child.addMouseListener(hoverListener)
+            child.addMouseListener(contextMenuListener)
         }
 
         // Constrain row height so BoxLayout doesn't stretch rows apart
@@ -416,28 +487,7 @@ class ChangesPanel(
         ApplicationManager.getApplication().executeOnPooledThread {
             val gitOps = service.getGitOps() ?: return@executeOnPooledThread
             val repoRoot = service.mainRepoRoot ?: project.basePath ?: return@executeOnPooledThread
-
-            when (change.statusCode) {
-                "??" -> {
-                    // Untracked file — delete it
-                    try {
-                        File(repoRoot, change.relativePath).delete()
-                    } catch (_: Exception) { /* best effort */ }
-                }
-                "A" -> {
-                    // Staged new file — unstage then delete
-                    gitOps.exec("reset", "HEAD", "--", change.relativePath)
-                    try {
-                        File(repoRoot, change.relativePath).delete()
-                    } catch (_: Exception) { /* best effort */ }
-                }
-                else -> {
-                    // Modified, deleted, renamed — restore from HEAD
-                    gitOps.exec("checkout", "HEAD", "--", change.relativePath)
-                }
-            }
-
-            // Refresh after discard
+            discardFiles(listOf(change), gitOps, repoRoot)
             refreshFromGit()
         }
     }

--- a/intellij/src/main/resources/META-INF/plugin.xml
+++ b/intellij/src/main/resources/META-INF/plugin.xml
@@ -89,6 +89,11 @@
                     text="AI Commit"
                     description="Generate AI commit message and commit selected files"
                     icon="/icons/sparkle.svg"/>
+            <action id="JolliMemory.DiscardSelected"
+                    class="ai.jolli.jollimemory.actions.DiscardSelectedAction"
+                    text="Discard Selected"
+                    description="Discard changes for all selected files"
+                    icon="/icons/discard.svg"/>
             <action id="JolliMemory.RefreshChanges"
                     class="ai.jolli.jollimemory.actions.RefreshChangesAction"
                     text="Refresh Changes"


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## E2E Test (5)
<details>
<summary><strong>1. Discard multiple selected files using the toolbar button</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a Git repository open in IntelliJ with at least three modified (but not committed) files visible in the JolliMemory Changes panel.

**Steps:**
1. Open the JolliMemory Changes panel and locate the list of changed files.
2. Check the checkboxes next to at least three files to select them.
3. Click the "Discard Selected" button in the Changes panel toolbar (it shows a discard icon).
4. Read the confirmation dialog that appears — verify it lists the names of the files you selected and warns that the action cannot be undone.
5. Click "Discard All" to confirm.
6. Check the Changes panel to verify the discarded files are no longer listed as changed.

**Expected Results:**
- The "Discard Selected" toolbar button should be clickable only when at least one file is checked.
- The confirmation dialog should list each selected file by name (up to ten, with an overflow count if more).
- After clicking "Discard All", the selected files should disappear from the Changes panel.
- Any files that were not selected should remain in the list unchanged.

</blockquote>
</details>
<details>
<summary><strong>2. Discard Selected toolbar button is disabled when nothing is selected</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a Git repository open with at least one changed file visible in the JolliMemory Changes panel.

**Steps:**
1. Open the JolliMemory Changes panel.
2. Make sure no file checkboxes are checked (deselect all if needed).
3. Look at the "Discard Selected" button in the toolbar.
4. Check a single file checkbox, then look at the button again.

**Expected Results:**
- When no files are checked, the "Discard Selected" toolbar button should appear grayed out and not be clickable.
- As soon as at least one file is checked, the button should become active and clickable.

</blockquote>
</details>
<details>
<summary><strong>3. Permanent deletion warning for untracked or newly added files</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a Git repository open with at least one untracked file (a brand-new file never added to Git) visible in the JolliMemory Changes panel.

**Steps:**
1. Open the JolliMemory Changes panel and check the checkbox next to one or more untracked or newly added files.
2. Click the "Discard Selected" toolbar button.
3. Read the confirmation dialog carefully.

**Expected Results:**
- The confirmation dialog should include a warning message stating that the selected file(s) will be permanently deleted because they are untracked or newly added.
- The warning should mention how many files will be permanently deleted.

</blockquote>
</details>
<details>
<summary><strong>4. Discard a single file using the right-click context menu</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a Git repository open with at least one modified file visible in the JolliMemory Changes panel.

**Steps:**
1. Open the JolliMemory Changes panel.
2. Right-click on any file row in the list.
3. Click "Discard Changes" in the context menu that appears.
4. Confirm the action in the dialog if prompted.
5. Check the Changes panel to verify the file is no longer listed as changed.

**Expected Results:**
- Right-clicking any file row should show a small context menu containing a "Discard Changes" option.
- After confirming, that specific file should be removed from the Changes panel.
- All other files in the list should remain unaffected.

</blockquote>
</details>
<details>
<summary><strong>5. Cancel the discard confirmation dialog leaves files untouched</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a Git repository open with at least two modified files visible in the JolliMemory Changes panel.

**Steps:**
1. Open the JolliMemory Changes panel and check the checkboxes next to two or more files.
2. Click the "Discard Selected" toolbar button.
3. When the confirmation dialog appears, click "Cancel" instead of "Discard All".
4. Check the Changes panel.

**Expected Results:**
- Clicking "Cancel" should close the dialog without making any changes.
- All previously selected files should still appear in the Changes panel with their changes intact.

</blockquote>
</details>

---

## Topic (1)
<details>
<summary><strong>01 · Discard changes for multiple selected files in the Changes panel</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The Changes panel only supported discarding one file at a time. The developer wanted a way to discard changes across multiple selected files at once, with the same three interaction points already present in the VS Code extension: a toolbar button, a right-click context menu, and the existing per-file hover icon.

**💡 Decisions Behind the Code**

- **Shared discard logic over duplicated branches**: All three discard entry points (toolbar, hover icon, right-click menu) funnel into one `discardFiles()` helper rather than each carrying their own git operation branches. This keeps the status-code handling (untracked delete, staged-new unstage-then-delete, modified restore) in one place, so a future fix or new status type only needs to be made once.
- **Confirmation dialog with deletion warning**: Untracked and newly-added files are permanently deleted from disk with no git history to recover from, making them meaningfully more dangerous than reverting a tracked modification. The dialog calls this out explicitly with a count and warning rather than treating all discards as equivalent, giving users a chance to reconsider before data is gone.
- **All three interaction points implemented together**: Rather than shipping just the toolbar button and deferring the context menu, all three surfaces were added in one pass. The git operations are identical regardless of how the discard is triggered, so the incremental cost of adding the context menu and wiring the hover icon to the shared helper was low, and the result matches the VS Code extension's interaction model exactly.

**✅ What Was Implemented**

- Added `DiscardSelectedAction.kt`, a new action class that reads the current file selection from the Changes panel and triggers bulk discard. The action is disabled when no files are selected, keeping the toolbar button grayed out appropriately.
- Added `discardSelected()` and a shared `discardFiles()` helper to `ChangesPanel.kt`. The confirmation dialog lists up to ten affected files with an overflow count, and includes a permanent-deletion warning when untracked or newly-added files are in the selection. The existing single-file `discardFile()` method was refactored to delegate to the same `discardFiles()` helper, eliminating duplicated git operation logic.
- Added a right-click context menu to every file row in `ChangesPanel.kt` by attaching a `MouseAdapter` that listens for the platform popup trigger on both press and release events. The menu shows a single "Discard Changes" item that calls the existing single-file discard path. The new action was registered in `plugin.xml` with the discard icon.

**📁 FILES**
- `intellij/src/main/kotlin/ai/jolli/jollimemory/actions/DiscardSelectedAction.kt`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/ChangesPanel.kt`
- `intellij/src/main/resources/META-INF/plugin.xml`

</blockquote>
</details>

---

*Generated by Jolli Memory · May 18, 2026 at 5:08 PM*
<!-- jollimemory-summary-end -->