### PR TITLE
Fix plan system to support external file paths cross-platform

### DIFF
--- a/cli/src/core/PathUtils.test.ts
+++ b/cli/src/core/PathUtils.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { withPlatform } from "../testUtils/withPlatform.js";
+import { normalizePathForCompare } from "./PathUtils.js";
+
+describe("normalizePathForCompare", () => {
+	it("unifies backslashes to forward slashes regardless of platform", () => {
+		withPlatform("linux", () => {
+			expect(normalizePathForCompare("C:\\Users\\foo\\bar.md")).toBe("C:/Users/foo/bar.md");
+		});
+	});
+
+	it("strips trailing slashes", () => {
+		withPlatform("linux", () => {
+			expect(normalizePathForCompare("/repo/docs/")).toBe("/repo/docs");
+			expect(normalizePathForCompare("/repo/docs///")).toBe("/repo/docs");
+		});
+	});
+
+	it("lowercases on Windows", () => {
+		withPlatform("win32", () => {
+			expect(normalizePathForCompare("C:\\Users\\Foo\\Bar.md")).toBe("c:/users/foo/bar.md");
+			// Case-only diff collapses to the same string
+			expect(normalizePathForCompare("c:\\users\\foo\\bar.md")).toBe(
+				normalizePathForCompare("C:\\Users\\Foo\\Bar.md"),
+			);
+		});
+	});
+
+	it("lowercases on macOS (Darwin/APFS default is case-insensitive)", () => {
+		withPlatform("darwin", () => {
+			expect(normalizePathForCompare("/Users/Flyer/Docs/Plan.md")).toBe("/users/flyer/docs/plan.md");
+			// Same file via case-different path normalizes identically
+			expect(normalizePathForCompare("/users/flyer/docs/plan.md")).toBe(
+				normalizePathForCompare("/Users/Flyer/Docs/Plan.md"),
+			);
+		});
+	});
+
+	it("preserves case on Linux (case-sensitive filesystem)", () => {
+		withPlatform("linux", () => {
+			expect(normalizePathForCompare("/repo/Docs/Plan.md")).toBe("/repo/Docs/Plan.md");
+			expect(normalizePathForCompare("/repo/Docs/Plan.md")).not.toBe(
+				normalizePathForCompare("/repo/docs/plan.md"),
+			);
+		});
+	});
+
+	it("treats mixed separators on Windows as the same path", () => {
+		withPlatform("win32", () => {
+			expect(normalizePathForCompare("C:/Users/foo/bar.md")).toBe(
+				normalizePathForCompare("C:\\Users\\foo\\bar.md"),
+			);
+		});
+	});
+
+	it("handles empty input and root-only paths defensively", () => {
+		withPlatform("linux", () => {
+			expect(normalizePathForCompare("")).toBe("");
+			// Single root slash gets stripped — fine because all production callers pass absolute file paths
+			expect(normalizePathForCompare("/")).toBe("");
+		});
+	});
+});

--- a/cli/src/core/PathUtils.ts
+++ b/cli/src/core/PathUtils.ts
@@ -1,0 +1,36 @@
+/**
+ * Shared path utilities used across the CLI hook pipeline and the VS Code
+ * extension. The extension inline-bundles `cli/src/**` at esbuild time (see
+ * CLAUDE.md "VS Code extension bundles the CLI"), so importing this module
+ * from `vscode/src/**` via the relative path is supported by design.
+ */
+
+/**
+ * Normalizes a filesystem path for equality comparison.
+ *
+ * Handles three sources of spurious inequality:
+ *   1. Mixed separators (`\` vs `/`) — Windows freely mixes both.
+ *   2. Case differences — Windows and macOS (default APFS) filesystems are
+ *      case-insensitive, so `C:\Users` and `c:\users` refer to the same file.
+ *   3. Trailing slashes.
+ *
+ * Deliberately does NOT call `path.resolve` because on Windows, POSIX-absolute
+ * paths like `/home/user/foo.md` (which Claude transcripts can produce when
+ * running under WSL or via cross-platform tooling) are treated as relative and
+ * resolved against the runtime cwd. All callers pass absolute paths, so
+ * separator + case normalization is sufficient.
+ *
+ * NOT resolved: symlinks and `..` segments. `realpath` would require extra I/O
+ * and could mask legitimate upgrades if either endpoint is a stale symlink.
+ */
+export function normalizePathForCompare(p: string): string {
+	let unified = p.replace(/\\/g, "/");
+	// Strip trailing slashes via a bounded loop rather than `/\/+$/` to avoid
+	// CodeQL "polynomial regex on uncontrolled data" (alert #28 on PR #122).
+	// The regex itself is linear-time, but switching to char-by-char keeps the
+	// security report clean for open-source release.
+	let end = unified.length;
+	while (end > 0 && unified[end - 1] === "/") end--;
+	if (end !== unified.length) unified = unified.slice(0, end);
+	return process.platform === "win32" || process.platform === "darwin" ? unified.toLowerCase() : unified;
+}

--- a/cli/src/core/PathUtils.ts
+++ b/cli/src/core/PathUtils.ts
@@ -25,10 +25,9 @@
  */
 export function normalizePathForCompare(p: string): string {
 	let unified = p.replace(/\\/g, "/");
-	// Strip trailing slashes via a bounded loop rather than `/\/+$/` to avoid
-	// CodeQL "polynomial regex on uncontrolled data" (alert #28 on PR #122).
-	// The regex itself is linear-time, but switching to char-by-char keeps the
-	// security report clean for open-source release.
+	// Strip trailing slashes via a bounded loop rather than `/\/+$/`. The regex
+	// is linear-time, but CodeQL flags any unbounded quantifier on input as a
+	// polynomial-regex risk; the loop form removes the false positive.
 	let end = unified.length;
 	while (end > 0 && unified[end - 1] === "/") end--;
 	if (end !== unified.length) unified = unified.slice(0, end);

--- a/cli/src/hooks/PostCommitHook.helpers.test.ts
+++ b/cli/src/hooks/PostCommitHook.helpers.test.ts
@@ -726,7 +726,7 @@ describe("PostCommitHook helpers", () => {
 						sluggy: {
 							slug: "sluggy",
 							title: "Sluggy",
-							sourcePath: "/mock-home/.claude/plans/sluggy.md",
+							sourcePath: planPath,
 							addedAt: "2026-02-18T00:00:00Z",
 							updatedAt: "2026-02-18T00:00:00Z",
 							branch: "feature/test",
@@ -741,7 +741,7 @@ describe("PostCommitHook helpers", () => {
 						sluggy: {
 							slug: "sluggy",
 							title: "Sluggy",
-							sourcePath: "/mock-home/.claude/plans/sluggy.md",
+							sourcePath: planPath,
 							addedAt: "2026-02-18T00:00:00Z",
 							updatedAt: "2026-02-18T00:00:00Z",
 							branch: "feature/test",

--- a/cli/src/hooks/PostCommitHook.helpers.test.ts
+++ b/cli/src/hooks/PostCommitHook.helpers.test.ts
@@ -675,6 +675,42 @@ describe("PostCommitHook helpers", () => {
 
 			expect(result.refs[0].title).toBe("sluggy");
 		});
+
+		it("reads the source file from entry.sourcePath for external plan paths (C2 regression)", async () => {
+			// Guards the switch from `join(plansDir, slug + ".md")` to
+			// `entry.sourcePath`. Old logic computed a synthetic ~/.claude/plans/
+			// path; external plans (e.g. docs/foo.md) lived outside that dir and
+			// would have failed existsSync silently. The new logic must read
+			// directly from the registry's sourcePath.
+			const externalPath = "/repo/docs/external-plan.md";
+			mockLoadPlansRegistry.mockResolvedValue({
+				version: 1,
+				plans: {
+					external: {
+						slug: "external",
+						title: "External",
+						sourcePath: externalPath,
+						addedAt: "2026-02-18T00:00:00Z",
+						updatedAt: "2026-02-18T00:00:00Z",
+						branch: "feature/test",
+						commitHash: null,
+						editCount: 1,
+					},
+				},
+			});
+			mockExistsSync.mockImplementation((p: string) => p === externalPath);
+			mockReadFileSync.mockImplementation((p: string) => (p === externalPath ? "# External\nbody" : ""));
+
+			const result = await __test__.associatePlansWithCommit(new Set(["external"]), "deadbeefcafebabe", "/repo");
+
+			expect(result.refs[0].slug).toBe("external-deadbeef");
+			expect(mockStorePlans).toHaveBeenCalledWith(
+				[{ slug: "external-deadbeef", content: "# External\nbody" }],
+				expect.stringContaining("deadbeef"),
+				"/repo",
+				undefined,
+			);
+		});
 	});
 
 	describe("associateLinearIssuesWithCommit (near-write reread merge)", () => {

--- a/cli/src/hooks/QueueWorker.ts
+++ b/cli/src/hooks/QueueWorker.ts
@@ -19,7 +19,6 @@
 import { spawn } from "node:child_process";
 import { createHash } from "node:crypto";
 import { existsSync, readFileSync } from "node:fs";
-import { homedir } from "node:os";
 import { basename, dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { discoverCodexSessions, isCodexInstalled } from "../core/CodexSessionDiscoverer.js";
@@ -492,7 +491,6 @@ async function associatePlansWithCommit(
 			.map(([s, e]) => `${s}(commitHash=${e.commitHash})`)
 			.join(", "),
 	);
-	const plansDir = join(homedir(), ".claude", "plans");
 	const planRefs: PlanReference[] = [];
 	const planFiles: Array<{ slug: string; content: string }> = [];
 	const markdownBySlug = new Map<string, string>();
@@ -526,7 +524,7 @@ async function associatePlansWithCommit(
 			continue;
 		}
 
-		const planFile = join(plansDir, `${slug}.md`);
+		const planFile = entry.sourcePath;
 		if (!existsSync(planFile)) continue;
 
 		// Read plan file content for orphan branch backup + content hash

--- a/cli/src/hooks/QueueWorker.ts
+++ b/cli/src/hooks/QueueWorker.ts
@@ -524,8 +524,15 @@ async function associatePlansWithCommit(
 			continue;
 		}
 
+		// Read the source file from the registry rather than rebuilding the
+		// path from slug — entries can point at arbitrary external `.md` files
+		// (see the symmetric explanation in vscode/src/core/PlanService.ts
+		// archivePlanForCommit).
 		const planFile = entry.sourcePath;
-		if (!existsSync(planFile)) continue;
+		if (!existsSync(planFile)) {
+			log.warn("Plan association: slug %s sourcePath %s missing on disk — skipping archive", slug, planFile);
+			continue;
+		}
 
 		// Read plan file content for orphan branch backup + content hash
 		const content = readFileSync(planFile, "utf-8");

--- a/cli/src/hooks/StopHook.test.ts
+++ b/cli/src/hooks/StopHook.test.ts
@@ -74,6 +74,7 @@ import {
 	saveSession,
 	upsertLinearIssueEntry,
 } from "../core/SessionTracker.js";
+import type { PlanEntry } from "../Types.js";
 import { withPlatform } from "../testUtils/withPlatform.js";
 import { handleStopHook } from "./StopHook.js";
 
@@ -879,15 +880,18 @@ describe("StopHook — plan discovery", () => {
 		);
 	});
 
-	it("should preserve commitHash from PostCommitHook even when StopHook scans the same slug", async () => {
-		// Simulates the race: PostCommitHook writes commitHash between StopHook's two
-		// loadPlansRegistry calls. The second (fresh) read sees the commitHash, and
-		// StopHook must not overwrite it — even though this slug was in its own scan.
+	it("should accept the fresh registry's archive-guard state when QueueWorker wins the race", async () => {
+		// Race: PostCommitHook / QueueWorker archives the plan between StopHook's
+		// two loadPlansRegistry calls. The fresh entry now has BOTH commitHash and
+		// contentHashAtCommit — the archive-guard pair. StopHook's merge must
+		// take the fresh entry wholesale rather than overlay just commitHash on
+		// its stale local copy: dropping contentHashAtCommit would cause
+		// PlanService.toPlanInfo to misclassify the entry as a snapshot copy.
 		vi.mocked(existsSync)
 			.mockReturnValueOnce(true) // transcript file
 			.mockReturnValueOnce(true); // plan file
 
-		// First loadPlansRegistry: plan is still uncommitted
+		// First load: plan is still uncommitted
 		vi.mocked(loadPlansRegistry)
 			.mockResolvedValueOnce({
 				version: 1,
@@ -904,7 +908,9 @@ describe("StopHook — plan discovery", () => {
 					},
 				},
 			})
-			// Second (fresh) loadPlansRegistry: PostCommitHook has now written commitHash
+			// Fresh load: QueueWorker has archived → both commitHash AND
+			// contentHashAtCommit are present (this is what associatePlansWithCommit
+			// actually writes in production).
 			.mockResolvedValueOnce({
 				version: 1,
 				plans: {
@@ -915,13 +921,16 @@ describe("StopHook — plan discovery", () => {
 						addedAt: "2026-01-01T00:00:00Z",
 						updatedAt: "2026-01-01T00:00:00Z",
 						branch: "main",
-						commitHash: "abc12345", // PostCommitHook wrote this
+						commitHash: "abc12345",
+						contentHashAtCommit: "deadbeefhash",
 						editCount: 3,
 					},
 				},
 			});
 
-		// StopHook scans the transcript and finds race-plan (editCount +1)
+		// StopHook scans the transcript and would increment editCount under
+		// the old per-field overlay; with the wholesale-fresh fix, editCount
+		// stays at 3 (the local +1 is dropped on purpose).
 		mockTranscriptWithLines([
 			'{"type":"tool_use","name":"Edit","input":{"file_path":"/home/user/.claude/plans/race-plan.md"}}',
 		]);
@@ -929,21 +938,19 @@ describe("StopHook — plan discovery", () => {
 		mockStdin(hookJson(TRANSCRIPT_PATH, PROJECT_DIR));
 		await handleStopHook();
 
-		// commitHash from PostCommitHook must be preserved — not wiped by StopHook's write
-		expect(savePlansRegistry).toHaveBeenCalledWith(
-			expect.objectContaining({
-				plans: expect.objectContaining({
-					"race-plan": expect.objectContaining({
-						commitHash: "abc12345",
-						editCount: 4, // editCount still incremented by StopHook
-					}),
-				}),
-			}),
-			PROJECT_DIR,
-		);
+		const saved = vi.mocked(savePlansRegistry).mock.calls[0]?.[0];
+		expect(saved?.plans["race-plan"]?.commitHash).toBe("abc12345");
+		// Critical: contentHashAtCommit must come through so the archive-guard
+		// branch in upsertEntry can revive this entry on the next file edit.
+		expect(saved?.plans["race-plan"]?.contentHashAtCommit).toBe("deadbeefhash");
 	});
 
-	it("should ignore fresh registry commit hashes for slugs not present in the current scan result", async () => {
+	it("should preserve concurrent slugs added between load and save (no per-slug clobber)", async () => {
+		// Race regression: while StopHook scans the transcript for `current-plan`,
+		// a sibling writer (QueueWorker, parallel StopHook, extension) appends
+		// `other-plan` to plans.json. The save-time merge must include the
+		// concurrent slug, not overwrite the whole plans map with our local
+		// snapshot that's missing it.
 		vi.mocked(existsSync).mockReturnValueOnce(true).mockReturnValueOnce(true);
 
 		vi.mocked(loadPlansRegistry)
@@ -994,8 +1001,264 @@ describe("StopHook — plan discovery", () => {
 		await handleStopHook();
 
 		const saved = vi.mocked(savePlansRegistry).mock.calls[0]?.[0];
+		// We don't touch `other-plan`, so its concurrent state passes through unchanged.
+		expect(saved?.plans["other-plan"]).toBeDefined();
+		expect(saved?.plans["other-plan"]?.commitHash).toBe("abc12345");
 		expect(saved?.plans["current-plan"]?.commitHash).toBeNull();
-		expect(saved?.plans["other-plan"]).toBeUndefined();
+	});
+
+	it("should preserve a QueueWorker archive entry written between load and save", async () => {
+		// Race scenario: AI edits docs/refactor-api.md → StopHook starts. User
+		// commits in parallel → QueueWorker promotes the plan to an archive
+		// guard and adds `refactor-api-abc12345`. StopHook's writeback must
+		// preserve both the guard upgrade and the new archive entry.
+		vi.mocked(existsSync).mockReturnValueOnce(true).mockReturnValueOnce(true);
+
+		// First load: uncommitted state (before QueueWorker's writes)
+		vi.mocked(loadPlansRegistry)
+			.mockResolvedValueOnce({
+				version: 1,
+				plans: {
+					"refactor-api": {
+						slug: "refactor-api",
+						title: "Refactor API",
+						sourcePath: "/repo/docs/refactor-api.md",
+						addedAt: "2026-01-01T00:00:00Z",
+						updatedAt: "2026-01-01T00:00:00Z",
+						branch: "unknown",
+						commitHash: null,
+						editCount: 5,
+					},
+				},
+			})
+			// Second load (freshRegistry): QueueWorker has run, guard installed + archive added
+			.mockResolvedValueOnce({
+				version: 1,
+				plans: {
+					"refactor-api": {
+						slug: "refactor-api",
+						title: "Refactor API",
+						sourcePath: "/repo/docs/refactor-api.md",
+						addedAt: "2026-01-01T00:00:00Z",
+						updatedAt: "2026-01-01T00:00:00Z",
+						branch: "unknown",
+						commitHash: "abc12345cafebabe",
+						contentHashAtCommit: "deadbeefhash",
+						editCount: 5,
+					},
+					"refactor-api-abc12345": {
+						slug: "refactor-api-abc12345",
+						title: "Refactor API",
+						sourcePath: "/repo/docs/refactor-api.md",
+						addedAt: "2026-01-01T00:00:00Z",
+						updatedAt: "2026-01-01T00:00:00Z",
+						branch: "unknown",
+						commitHash: "abc12345cafebabe",
+						editCount: 5,
+					},
+				},
+			});
+
+		// AI edited the external .md → our local plans will touch `refactor-api`
+		mockTranscriptWithLines([
+			'{"type":"tool_use","name":"Edit","input":{"file_path":"/repo/docs/refactor-api.md"}}',
+		]);
+
+		mockStdin(hookJson(TRANSCRIPT_PATH, PROJECT_DIR));
+		await handleStopHook();
+
+		const saved = vi.mocked(savePlansRegistry).mock.calls[0]?.[0];
+		// 1. Archive entry from QueueWorker must NOT be dropped.
+		expect(saved?.plans["refactor-api-abc12345"]).toBeDefined();
+		expect(saved?.plans["refactor-api-abc12345"]?.commitHash).toBe("abc12345cafebabe");
+		// 2. Our edit on `refactor-api` should carry the concurrent commitHash through.
+		expect(saved?.plans["refactor-api"]?.commitHash).toBe("abc12345cafebabe");
+		// 3. Critical: contentHashAtCommit must come through too. Without it,
+		//    PlanService.toPlanInfo's snapshot-copy filter (commitHash != null
+		//    && !contentHashAtCommit) catches the entry and hides it from the
+		//    panel, AND the upsertEntry archive-guard revive branch can never
+		//    fire because it gates on `existing.contentHashAtCommit`.
+		expect(saved?.plans["refactor-api"]?.contentHashAtCommit).toBe("deadbeefhash");
+	});
+
+	it("should let a subsequent file edit revive after QueueWorker won an earlier race", async () => {
+		// Integration regression: simulates two consecutive Stop events.
+		// Event 1: QueueWorker wins → freshRegistry has archive guard. After
+		//   our merge, plans.json's refactor-api carries the full guard pair.
+		// Event 2: user edits the file again → StopHook runs against the
+		//   post-merge registry. The upsertEntry archive-guard branch should
+		//   detect that the file content no longer matches contentHashAtCommit
+		//   and revive the entry as fresh uncommitted (commitHash back to null).
+		const planPath = "/repo/docs/refactor-api.md";
+
+		// ── Event 1: QueueWorker-wins race ──
+		vi.mocked(existsSync).mockReturnValue(true);
+		vi.mocked(loadPlansRegistry)
+			.mockResolvedValueOnce({
+				version: 1,
+				plans: {
+					"refactor-api": {
+						slug: "refactor-api",
+						title: "Refactor API",
+						sourcePath: planPath,
+						addedAt: "2026-01-01T00:00:00Z",
+						updatedAt: "2026-01-01T00:00:00Z",
+						branch: "unknown",
+						commitHash: null,
+						editCount: 5,
+					},
+				},
+			})
+			.mockResolvedValueOnce({
+				version: 1,
+				plans: {
+					"refactor-api": {
+						slug: "refactor-api",
+						title: "Refactor API",
+						sourcePath: planPath,
+						addedAt: "2026-01-01T00:00:00Z",
+						updatedAt: "2026-01-01T00:00:00Z",
+						branch: "unknown",
+						commitHash: "abc12345cafebabe",
+						contentHashAtCommit: "snapshot-hash",
+						editCount: 5,
+					},
+				},
+			});
+
+		mockTranscriptWithLines([`{"type":"tool_use","name":"Edit","input":{"file_path":"${planPath}"}}`]);
+		mockStdin(hookJson(TRANSCRIPT_PATH, PROJECT_DIR));
+		await handleStopHook();
+
+		const afterEvent1 = vi.mocked(savePlansRegistry).mock.calls[0]?.[0];
+		expect(afterEvent1?.plans["refactor-api"]?.contentHashAtCommit).toBe("snapshot-hash");
+
+		// ── Event 2: user edits the file again ──
+		// File content changed → sha256 of new content differs from
+		// "snapshot-hash". Mock readFileSync to return content whose hash will
+		// definitely not equal "snapshot-hash" (the mock default already does
+		// this — content "# Plan Title\n\nContent" hashes to a different value).
+		vi.mocked(loadCursorForTranscript).mockResolvedValue(null);
+		vi.mocked(loadPlansRegistry).mockReset();
+		vi.mocked(loadPlansRegistry).mockResolvedValue({
+			version: 1,
+			plans: { "refactor-api": afterEvent1?.plans["refactor-api"] as PlanEntry },
+		});
+		vi.mocked(savePlansRegistry).mockClear();
+		mockTranscriptWithLines([`{"type":"tool_use","name":"Edit","input":{"file_path":"${planPath}"}}`]);
+		mockStdin(hookJson("/path/to/session-2.jsonl", PROJECT_DIR));
+		await handleStopHook();
+
+		// upsertEntry archive-guard branch should fire: contentHashAtCommit
+		// present → compute file hash → mismatch → resurrect as fresh
+		// uncommitted entry with commitHash null.
+		const afterEvent2 = vi.mocked(savePlansRegistry).mock.calls[0]?.[0];
+		expect(afterEvent2?.plans["refactor-api"]?.commitHash).toBeNull();
+		expect(afterEvent2?.plans["refactor-api"]?.contentHashAtCommit).toBeUndefined();
+	});
+
+	it("should preserve an extension-flipped ignored flag on a slug we did not touch", async () => {
+		// Race scenario: while StopHook scans for `our-plan`, the user clicks
+		// Ignore on `unrelated-plan` in the panel. The extension writes
+		// ignored:true. StopHook's writeback must NOT clobber it.
+		vi.mocked(existsSync).mockReturnValueOnce(true).mockReturnValueOnce(true);
+
+		vi.mocked(loadPlansRegistry)
+			.mockResolvedValueOnce({
+				version: 1,
+				plans: {
+					"our-plan": {
+						slug: "our-plan",
+						title: "Ours",
+						sourcePath: "/home/user/.claude/plans/our-plan.md",
+						addedAt: "2026-01-01T00:00:00Z",
+						updatedAt: "2026-01-01T00:00:00Z",
+						branch: "unknown",
+						commitHash: null,
+						editCount: 0,
+					},
+					"unrelated-plan": {
+						slug: "unrelated-plan",
+						title: "Unrelated",
+						sourcePath: "/home/user/.claude/plans/unrelated-plan.md",
+						addedAt: "2026-01-01T00:00:00Z",
+						updatedAt: "2026-01-01T00:00:00Z",
+						branch: "unknown",
+						commitHash: null,
+						editCount: 0,
+					},
+				},
+			})
+			.mockResolvedValueOnce({
+				version: 1,
+				plans: {
+					"our-plan": {
+						slug: "our-plan",
+						title: "Ours",
+						sourcePath: "/home/user/.claude/plans/our-plan.md",
+						addedAt: "2026-01-01T00:00:00Z",
+						updatedAt: "2026-01-01T00:00:00Z",
+						branch: "unknown",
+						commitHash: null,
+						editCount: 0,
+					},
+					"unrelated-plan": {
+						slug: "unrelated-plan",
+						title: "Unrelated",
+						sourcePath: "/home/user/.claude/plans/unrelated-plan.md",
+						addedAt: "2026-01-01T00:00:00Z",
+						updatedAt: "2026-01-01T00:00:00Z",
+						branch: "unknown",
+						commitHash: null,
+						editCount: 0,
+						ignored: true, // extension flipped this between the two reads
+					},
+				},
+			});
+
+		mockTranscriptWithLines(['{"type":"tool_result","slug":"our-plan","content":"..."}']);
+
+		mockStdin(hookJson(TRANSCRIPT_PATH, PROJECT_DIR));
+		await handleStopHook();
+
+		const saved = vi.mocked(savePlansRegistry).mock.calls[0]?.[0];
+		expect(saved?.plans["unrelated-plan"]?.ignored).toBe(true);
+	});
+
+	it("should preserve a slug added by a parallel StopHook between load and save", async () => {
+		// Race scenario: two Claude Code sessions open on the same repo. Both
+		// StopHooks fire near-simultaneously. Session A registers `plan-a`,
+		// Session B registers `plan-b`. Neither's save should drop the other's.
+		vi.mocked(existsSync).mockReturnValueOnce(true).mockReturnValueOnce(true);
+
+		vi.mocked(loadPlansRegistry)
+			.mockResolvedValueOnce({ version: 1, plans: {} })
+			.mockResolvedValueOnce({
+				version: 1,
+				plans: {
+					"plan-b": {
+						slug: "plan-b",
+						title: "Plan B (from sibling)",
+						sourcePath: "/repo/docs/plan-b.md",
+						addedAt: "2026-01-01T00:00:00Z",
+						updatedAt: "2026-01-01T00:00:00Z",
+						branch: "unknown",
+						commitHash: null,
+						editCount: 1,
+					},
+				},
+			});
+
+		// Our session is registering `plan-a`
+		mockTranscriptWithLines(['{"type":"tool_use","name":"Write","input":{"file_path":"/repo/docs/plan-a.md"}}']);
+
+		mockStdin(hookJson(TRANSCRIPT_PATH, PROJECT_DIR));
+		await handleStopHook();
+
+		const saved = vi.mocked(savePlansRegistry).mock.calls[0]?.[0];
+		expect(saved?.plans["plan-a"]).toBeDefined();
+		expect(saved?.plans["plan-b"]).toBeDefined();
+		expect(saved?.plans["plan-b"]?.title).toBe("Plan B (from sibling)");
 	});
 
 	it("should resolve gracefully when readline emits an error during transcript scan", async () => {
@@ -1197,8 +1460,9 @@ describe("StopHook — plan discovery", () => {
 	});
 
 	it("should accept .md paths outside the workspace (e.g. cross-project plans directory)", async () => {
-		// `E:\jm-docs\` style paths must not be rejected — see "设计决策:不限制
-		// 外部路径必须位于 cwd 之内" in the plan doc.
+		// Cross-project plan directories (notes/specs stored outside the repo's
+		// own workspace) are a primary supported use case — auto-discovery
+		// must not reject absolute paths simply because they live outside cwd.
 		vi.mocked(existsSync)
 			.mockReturnValueOnce(true) // transcript file
 			.mockReturnValueOnce(true); // external plan file
@@ -1244,7 +1508,8 @@ describe("StopHook — plan discovery", () => {
 					sourcePath: "/repo/docs/design.md",
 					addedAt: "2026-01-01T00:00:00Z",
 					updatedAt: "2026-01-01T00:00:00Z",
-					branch: "main",
+					// "unknown" matches getCurrentBranch() default in tests (no git repo)
+					branch: "unknown",
 					commitHash: null,
 				},
 			},
@@ -1280,7 +1545,7 @@ describe("StopHook — plan discovery", () => {
 						sourcePath: "C:\\Repo\\Docs\\Design.md",
 						addedAt: "2026-01-01T00:00:00Z",
 						updatedAt: "2026-01-01T00:00:00Z",
-						branch: "main",
+						branch: "unknown", // matches getCurrentBranch() default in tests
 						commitHash: null,
 					},
 				},
@@ -1296,6 +1561,139 @@ describe("StopHook — plan discovery", () => {
 
 			expect(savePlansRegistry).not.toHaveBeenCalled();
 		});
+	});
+
+	it("should register a plan when a note exists for the same file BUT on a different branch", async () => {
+		// L1 regression: notes are branch-scoped (NoteService.toNoteInfo hides
+		// notes from other branches), so the note guard must also be
+		// branch-scoped. Without this check, a `main` note silently suppresses
+		// plan auto-registration on `feature/x`, even though the user can't see
+		// the note on that branch.
+		vi.mocked(existsSync)
+			.mockReturnValueOnce(true) // transcript file
+			.mockReturnValueOnce(true); // .md file on disk
+
+		vi.mocked(loadPlansRegistry).mockResolvedValue({
+			version: 1,
+			plans: {},
+			notes: {
+				"n-other": {
+					id: "n-other",
+					title: "Design (main)",
+					format: "markdown",
+					sourcePath: "/repo/docs/design.md",
+					addedAt: "2026-01-01T00:00:00Z",
+					updatedAt: "2026-01-01T00:00:00Z",
+					branch: "main",
+					commitHash: null,
+				},
+			},
+		});
+
+		mockTranscriptWithLines(['{"type":"tool_use","name":"Edit","input":{"file_path":"/repo/docs/design.md"}}']);
+
+		mockStdin(hookJson(TRANSCRIPT_PATH, PROJECT_DIR));
+		await handleStopHook();
+
+		// getCurrentBranch falls back to "unknown" under test (no git repo),
+		// which differs from the note's "main" → guard does NOT apply →
+		// plan IS registered.
+		expect(savePlansRegistry).toHaveBeenCalledWith(
+			expect.objectContaining({
+				plans: expect.objectContaining({
+					design: expect.objectContaining({ sourcePath: "/repo/docs/design.md" }),
+				}),
+			}),
+			PROJECT_DIR,
+		);
+	});
+
+	it("should NOT register a canonical ~/.claude/plans/ plan when it is already a note (L2)", async () => {
+		// L2 regression: a user can pick a file under ~/.claude/plans/ via the
+		// "Add Markdown File" picker, registering it as a note. The note guard
+		// must apply to the canonical loop too, not just the external loop.
+		vi.mocked(existsSync)
+			.mockReturnValueOnce(true) // transcript file
+			.mockReturnValueOnce(true); // canonical plan file
+
+		const canonicalPath = join("/home/user", ".claude", "plans", "shared.md");
+		vi.mocked(loadPlansRegistry).mockResolvedValue({
+			version: 1,
+			plans: {},
+			notes: {
+				"n-shared": {
+					id: "n-shared",
+					title: "Shared",
+					format: "markdown",
+					sourcePath: canonicalPath,
+					addedAt: "2026-01-01T00:00:00Z",
+					updatedAt: "2026-01-01T00:00:00Z",
+					branch: "unknown", // matches getCurrentBranch() default in tests
+					commitHash: null,
+				},
+			},
+		});
+
+		mockTranscriptWithLines([
+			'{"type":"tool_use","name":"Write","input":{"file_path":"/home/user/.claude/plans/shared.md"}}',
+		]);
+
+		mockStdin(hookJson(TRANSCRIPT_PATH, PROJECT_DIR));
+		await handleStopHook();
+
+		// Canonical loop matched the slug but the note guard suppressed the upsert.
+		expect(savePlansRegistry).not.toHaveBeenCalled();
+	});
+
+	it("should preserve notes and linearIssues fields when writing back to plans.json (C1)", async () => {
+		// C1 regression: discoverPlansFromTranscript previously wrote
+		// `{ version: 1, plans }` which silently dropped sibling fields
+		// (notes / linearIssues). loadPlansRegistry's contract is "spread to
+		// preserve optional fields"; the writeback must honor that.
+		vi.mocked(existsSync)
+			.mockReturnValueOnce(true) // transcript file
+			.mockReturnValueOnce(true); // external plan file
+
+		vi.mocked(loadPlansRegistry).mockResolvedValue({
+			version: 1,
+			plans: {},
+			notes: {
+				"n-keep": {
+					id: "n-keep",
+					title: "Keep me",
+					format: "snippet",
+					sourcePath: "/repo/.jolli/jollimemory/notes/n-keep.md",
+					addedAt: "2026-01-01T00:00:00Z",
+					updatedAt: "2026-01-01T00:00:00Z",
+					branch: "unknown",
+					commitHash: null,
+				},
+			},
+			linearIssues: {
+				"PROJ-1": {
+					ticketId: "PROJ-1",
+					title: "Keep me too",
+					url: "https://linear.app/x/PROJ-1",
+					sourcePath: "/repo/.jolli/jollimemory/linear-issues/PROJ-1.md",
+					branch: "main",
+					addedAt: "2026-01-01T00:00:00Z",
+					updatedAt: "2026-01-01T00:00:00Z",
+					commitHash: null,
+					sourceToolName: "mcp__linear__get_issue",
+				},
+			},
+		});
+
+		mockTranscriptWithLines(['{"type":"tool_use","name":"Write","input":{"file_path":"/repo/docs/new-plan.md"}}']);
+
+		mockStdin(hookJson(TRANSCRIPT_PATH, PROJECT_DIR));
+		await handleStopHook();
+
+		const saved = vi.mocked(savePlansRegistry).mock.calls[0]?.[0];
+		expect(saved?.notes).toBeDefined();
+		expect(saved?.notes?.["n-keep"]).toBeDefined();
+		expect(saved?.linearIssues).toBeDefined();
+		expect(saved?.linearIssues?.["PROJ-1"]).toBeDefined();
 	});
 
 	it("should skip external .md when source file no longer exists at upsert time", async () => {

--- a/cli/src/hooks/StopHook.test.ts
+++ b/cli/src/hooks/StopHook.test.ts
@@ -35,6 +35,17 @@ vi.mock("node:fs", async (importOriginal) => {
 	};
 });
 
+// Pin homedir() so fixtures' "/home/user/.claude/plans/<slug>.md" sourcePaths
+// align with what the implementation computes via join(homedir(), ...) — keeps
+// tests deterministic across Windows local and POSIX CI environments.
+vi.mock("node:os", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("node:os")>();
+	return {
+		...actual,
+		homedir: vi.fn().mockReturnValue("/home/user"),
+	};
+});
+
 // Mock node:readline so we can simulate line-by-line transcript scanning
 vi.mock("node:readline", () => ({
 	createInterface: vi.fn(),
@@ -50,6 +61,7 @@ vi.spyOn(console, "warn").mockImplementation(() => {});
 vi.spyOn(console, "error").mockImplementation(() => {});
 
 import { createReadStream, existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
 import { createInterface } from "node:readline";
 import { extractLinearIssuesFromTranscript } from "../core/LinearIssueExtractor.js";
 import { writeLinearIssueMarkdown } from "../core/LinearIssueStore.js";
@@ -512,12 +524,15 @@ describe("StopHook — plan discovery", () => {
 		);
 	});
 
-	it("should ignore Write/Edit tool calls that do not target the plans directory", async () => {
+	it("should ignore Write/Edit tool calls targeting non-.md files", async () => {
+		// Pure non-.md paths must not be registered. (External .md handling has its own
+		// suite below; the original `/tmp/not-a-plan.md` style path is now accepted as
+		// an external plan by design — see "External .md path detection" tests.)
 		vi.mocked(existsSync).mockReturnValue(true);
 
 		mockTranscriptWithLines([
-			'{"type":"tool_use","name":"Write","input":{"file_path":"/tmp/not-a-plan.md"}}',
-			'{"type":"tool_use","name":"Edit","input":{"file_path":"C:\\\\Users\\\\user\\\\Desktop\\\\note.md"}}',
+			'{"type":"tool_use","name":"Write","input":{"file_path":"/repo/src/index.ts"}}',
+			'{"type":"tool_use","name":"Edit","input":{"file_path":"/repo/config.json"}}',
 		]);
 
 		mockStdin(hookJson(TRANSCRIPT_PATH, PROJECT_DIR));
@@ -992,6 +1007,302 @@ describe("StopHook — plan discovery", () => {
 		// The error handler resolves the promise (does not reject).
 		// Cursor should still be updated (totalLines = 0 since no lines were read).
 		expect(savePlansRegistry).not.toHaveBeenCalled();
+	});
+
+	// ─── External .md path detection ────────────────────────────────────────
+
+	it("should register external .md file (docs/foo.md) as a plan", async () => {
+		vi.mocked(existsSync)
+			.mockReturnValueOnce(true) // transcript file
+			.mockReturnValueOnce(true); // external plan file
+
+		mockTranscriptWithLines(['{"type":"tool_use","name":"Write","input":{"file_path":"/repo/docs/foo-plan.md"}}']);
+
+		mockStdin(hookJson(TRANSCRIPT_PATH, PROJECT_DIR));
+		await handleStopHook();
+
+		expect(savePlansRegistry).toHaveBeenCalledWith(
+			expect.objectContaining({
+				plans: expect.objectContaining({
+					"foo-plan": expect.objectContaining({
+						slug: "foo-plan",
+						sourcePath: "/repo/docs/foo-plan.md",
+						commitHash: null,
+						editCount: 1,
+					}),
+				}),
+			}),
+			PROJECT_DIR,
+		);
+	});
+
+	it("should not register .md files under .claude/ (memory, skill, agent)", async () => {
+		vi.mocked(existsSync).mockReturnValue(true);
+
+		mockTranscriptWithLines([
+			'{"type":"tool_use","name":"Write","input":{"file_path":"/home/user/.claude/memory/feedback_x.md"}}',
+			'{"type":"tool_use","name":"Edit","input":{"file_path":"/home/user/.claude/skill/foo.md"}}',
+		]);
+
+		mockStdin(hookJson(TRANSCRIPT_PATH, PROJECT_DIR));
+		await handleStopHook();
+
+		expect(savePlansRegistry).not.toHaveBeenCalled();
+	});
+
+	it("should not register .md files under node_modules/", async () => {
+		vi.mocked(existsSync).mockReturnValue(true);
+
+		mockTranscriptWithLines([
+			'{"type":"tool_use","name":"Write","input":{"file_path":"/repo/node_modules/pkg/README.md"}}',
+		]);
+
+		mockStdin(hookJson(TRANSCRIPT_PATH, PROJECT_DIR));
+		await handleStopHook();
+
+		expect(savePlansRegistry).not.toHaveBeenCalled();
+	});
+
+	it("should not register common non-plan basenames (README.md / CLAUDE.md / case-insensitive variants)", async () => {
+		vi.mocked(existsSync).mockReturnValue(true);
+
+		mockTranscriptWithLines([
+			'{"type":"tool_use","name":"Write","input":{"file_path":"/repo/README.md"}}',
+			'{"type":"tool_use","name":"Edit","input":{"file_path":"/repo/CLAUDE.md"}}',
+			'{"type":"tool_use","name":"Edit","input":{"file_path":"/repo/Claude.md"}}',
+			'{"type":"tool_use","name":"Edit","input":{"file_path":"/repo/claude.md"}}',
+			'{"type":"tool_use","name":"Write","input":{"file_path":"/repo/AGENTS.md"}}',
+			'{"type":"tool_use","name":"Write","input":{"file_path":"/repo/CHANGELOG.md"}}',
+		]);
+
+		mockStdin(hookJson(TRANSCRIPT_PATH, PROJECT_DIR));
+		await handleStopHook();
+
+		expect(savePlansRegistry).not.toHaveBeenCalled();
+	});
+
+	it("should accumulate editCount across multiple Edit calls to the same external .md", async () => {
+		vi.mocked(existsSync)
+			.mockReturnValueOnce(true) // transcript file
+			.mockReturnValueOnce(true); // external plan file
+
+		mockTranscriptWithLines([
+			'{"type":"tool_use","name":"Write","input":{"file_path":"/repo/docs/multi.md"}}',
+			'{"type":"tool_use","name":"Edit","input":{"file_path":"/repo/docs/multi.md"}}',
+			'{"type":"tool_use","name":"Edit","input":{"file_path":"/repo/docs/multi.md"}}',
+		]);
+
+		mockStdin(hookJson(TRANSCRIPT_PATH, PROJECT_DIR));
+		await handleStopHook();
+
+		expect(savePlansRegistry).toHaveBeenCalledWith(
+			expect.objectContaining({
+				plans: expect.objectContaining({
+					multi: expect.objectContaining({ editCount: 3 }),
+				}),
+			}),
+			PROJECT_DIR,
+		);
+	});
+
+	it("should disambiguate external .md whose basename collides with an existing ~/.claude/plans/ slug", async () => {
+		vi.mocked(existsSync)
+			.mockReturnValueOnce(true) // transcript file
+			.mockReturnValueOnce(true); // external plan file
+
+		vi.mocked(loadPlansRegistry).mockResolvedValue({
+			version: 1,
+			plans: {
+				foo: {
+					slug: "foo",
+					title: "Canonical Foo",
+					sourcePath: "/home/user/.claude/plans/foo.md",
+					addedAt: "2026-01-01T00:00:00Z",
+					updatedAt: "2026-01-01T00:00:00Z",
+					branch: "main",
+					commitHash: null,
+					editCount: 1,
+				},
+			},
+		});
+
+		mockTranscriptWithLines(['{"type":"tool_use","name":"Write","input":{"file_path":"/repo/docs/foo.md"}}']);
+
+		mockStdin(hookJson(TRANSCRIPT_PATH, PROJECT_DIR));
+		await handleStopHook();
+
+		const saved = vi.mocked(savePlansRegistry).mock.calls[0]?.[0];
+		// Original `foo` is untouched, new slug is `foo-<hash8>`
+		expect(saved?.plans.foo?.sourcePath).toBe("/home/user/.claude/plans/foo.md");
+		const externalSlug = Object.keys(saved?.plans ?? {}).find((s) => /^foo-[0-9a-f]{8}$/.test(s));
+		expect(externalSlug).toBeDefined();
+		expect(saved?.plans[externalSlug as string]?.sourcePath).toBe("/repo/docs/foo.md");
+	});
+
+	it("should reuse hash-suffixed slug on subsequent edits (idempotent reverse-lookup)", async () => {
+		vi.mocked(existsSync)
+			.mockReturnValueOnce(true) // transcript file
+			.mockReturnValueOnce(true); // external plan file
+
+		// Registry has ONLY the hash-suffixed entry — base `foo` slot was cleaned up.
+		// Reverse-lookup by sourcePath must still find this entry and reuse its slug,
+		// rather than naively registering a fresh `foo` entry.
+		vi.mocked(loadPlansRegistry).mockResolvedValue({
+			version: 1,
+			plans: {
+				"foo-a3b7c2d1": {
+					slug: "foo-a3b7c2d1",
+					title: "External Foo",
+					sourcePath: "/repo/docs/foo.md",
+					addedAt: "2026-01-01T00:00:00Z",
+					updatedAt: "2026-01-01T00:00:00Z",
+					branch: "main",
+					commitHash: null,
+					editCount: 1,
+				},
+			},
+		});
+
+		mockTranscriptWithLines(['{"type":"tool_use","name":"Edit","input":{"file_path":"/repo/docs/foo.md"}}']);
+
+		mockStdin(hookJson(TRANSCRIPT_PATH, PROJECT_DIR));
+		await handleStopHook();
+
+		const saved = vi.mocked(savePlansRegistry).mock.calls[0]?.[0];
+		// Same slug reused, editCount incremented; no spurious `foo` entry created
+		expect(saved?.plans["foo-a3b7c2d1"]?.editCount).toBe(2);
+		expect(saved?.plans.foo).toBeUndefined();
+	});
+
+	it("should advance cursor + write registry when transcript has only external .md plans (no slug)", async () => {
+		// Regression guard: the early-exit must consider externalPlans, not just slugs.
+		vi.mocked(existsSync)
+			.mockReturnValueOnce(true) // transcript file
+			.mockReturnValueOnce(true); // external plan file
+
+		mockTranscriptWithLines(['{"type":"tool_use","name":"Write","input":{"file_path":"/repo/docs/lonely.md"}}']);
+
+		mockStdin(hookJson(TRANSCRIPT_PATH, PROJECT_DIR));
+		await handleStopHook();
+
+		expect(savePlansRegistry).toHaveBeenCalled();
+		expect(saveCursor).toHaveBeenCalledWith(
+			expect.objectContaining({
+				transcriptPath: `plan:${TRANSCRIPT_PATH}`,
+				lineNumber: 1,
+			}),
+			PROJECT_DIR,
+		);
+	});
+
+	it("should accept .md paths outside the workspace (e.g. cross-project plans directory)", async () => {
+		// `E:\jm-docs\` style paths must not be rejected — see "设计决策:不限制
+		// 外部路径必须位于 cwd 之内" in the plan doc.
+		vi.mocked(existsSync)
+			.mockReturnValueOnce(true) // transcript file
+			.mockReturnValueOnce(true); // external plan file
+
+		mockTranscriptWithLines([
+			'{"type":"tool_use","name":"Edit","input":{"file_path":"E:\\\\jm-docs\\\\some-plan.md"}}',
+		]);
+
+		mockStdin(hookJson(TRANSCRIPT_PATH, PROJECT_DIR));
+		await handleStopHook();
+
+		// The slug is the basename ("some-plan"); sourcePath is the un-escaped Windows path.
+		expect(savePlansRegistry).toHaveBeenCalledWith(
+			expect.objectContaining({
+				plans: expect.objectContaining({
+					"some-plan": expect.objectContaining({
+						sourcePath: "E:\\jm-docs\\some-plan.md",
+					}),
+				}),
+			}),
+			PROJECT_DIR,
+		);
+	});
+
+	it("should skip external .md when source file no longer exists at upsert time", async () => {
+		// Transcript exists but the .md was deleted between Edit and Stop.
+		vi.mocked(existsSync)
+			.mockReturnValueOnce(true) // transcript file
+			.mockReturnValueOnce(false); // external plan file gone
+
+		mockTranscriptWithLines(['{"type":"tool_use","name":"Write","input":{"file_path":"/repo/docs/gone.md"}}']);
+
+		mockStdin(hookJson(TRANSCRIPT_PATH, PROJECT_DIR));
+		await handleStopHook();
+
+		expect(savePlansRegistry).not.toHaveBeenCalled();
+	});
+
+	it("should derive slug platform-agnostically from Windows-style transcript paths (CI regression)", async () => {
+		// node:path.basename is platform-specific: on POSIX CI it does NOT
+		// recognize `\` as a separator, so `basename("E:\\jm-docs\\some-plan.md", ".md")`
+		// returns the entire string with `.md` stripped. The implementation must
+		// use a separator-agnostic split so this case yields slug "some-plan"
+		// regardless of the runtime platform.
+		vi.mocked(existsSync)
+			.mockReturnValueOnce(true) // transcript file
+			.mockReturnValueOnce(true); // external plan file
+
+		mockTranscriptWithLines([
+			'{"type":"tool_use","name":"Edit","input":{"file_path":"E:\\\\jm-docs\\\\some-plan.md"}}',
+		]);
+
+		mockStdin(hookJson(TRANSCRIPT_PATH, PROJECT_DIR));
+		await handleStopHook();
+
+		const saved = vi.mocked(savePlansRegistry).mock.calls[0]?.[0];
+		expect(saved?.plans["some-plan"]).toBeDefined();
+		// Make sure the buggy full-path slug never appears
+		const buggySlug = Object.keys(saved?.plans ?? {}).find((s) => s.includes("\\") || s.includes("/"));
+		expect(buggySlug).toBeUndefined();
+	});
+
+	it("should hash-suffix a canonical ~/.claude/plans/ slug when an external entry already holds the base slug", async () => {
+		// Collision-order regression: external `docs/foo.md` was registered first
+		// at slug `foo`. Later, a canonical `~/.claude/plans/foo.md` edit must
+		// NOT overwrite the external entry's sourcePath via upsertEntry — it
+		// must claim a hash-suffixed slot.
+		vi.mocked(existsSync)
+			.mockReturnValueOnce(true) // transcript file
+			.mockReturnValueOnce(true); // canonical plan file
+
+		vi.mocked(loadPlansRegistry).mockResolvedValue({
+			version: 1,
+			plans: {
+				foo: {
+					slug: "foo",
+					title: "External Foo",
+					sourcePath: "/repo/docs/foo.md", // external lives at base slug
+					addedAt: "2026-01-01T00:00:00Z",
+					updatedAt: "2026-01-01T00:00:00Z",
+					branch: "main",
+					commitHash: null,
+					editCount: 1,
+				},
+			},
+		});
+
+		mockTranscriptWithLines([
+			'{"type":"tool_use","name":"Write","input":{"file_path":"/home/user/.claude/plans/foo.md"}}',
+		]);
+
+		mockStdin(hookJson(TRANSCRIPT_PATH, PROJECT_DIR));
+		await handleStopHook();
+
+		const saved = vi.mocked(savePlansRegistry).mock.calls[0]?.[0];
+		// External entry's sourcePath must be untouched
+		expect(saved?.plans.foo?.sourcePath).toBe("/repo/docs/foo.md");
+		// Canonical lands in a hash-suffixed slug; assert via join() so the
+		// expected separators match what the implementation's `join(homedir(),
+		// ...)` produces on the current platform.
+		const canonicalSlug = Object.keys(saved?.plans ?? {}).find((s) => /^foo-[0-9a-f]{8}$/.test(s));
+		expect(canonicalSlug).toBeDefined();
+		expect(saved?.plans[canonicalSlug as string]?.sourcePath).toBe(
+			join("/home/user", ".claude", "plans", "foo.md"),
+		);
 	});
 });
 

--- a/cli/src/hooks/StopHook.test.ts
+++ b/cli/src/hooks/StopHook.test.ts
@@ -74,6 +74,7 @@ import {
 	saveSession,
 	upsertLinearIssueEntry,
 } from "../core/SessionTracker.js";
+import { withPlatform } from "../testUtils/withPlatform.js";
 import { handleStopHook } from "./StopHook.js";
 
 /** Helper to mock stdin with given content */
@@ -1220,6 +1221,81 @@ describe("StopHook — plan discovery", () => {
 			}),
 			PROJECT_DIR,
 		);
+	});
+
+	it("should NOT register external .md as a plan when it is already a markdown note", async () => {
+		// Product-regression guard: a user added `docs/design.md` via "Add Markdown
+		// File" (note semantics, manual selection). The AI then edits the same
+		// file in a session. StopHook must not also register it as a plan — that
+		// would shadow the user's note semantics, double-archive into the orphan
+		// branch, and surface the same file twice in the panel.
+		vi.mocked(existsSync)
+			.mockReturnValueOnce(true) // transcript file
+			.mockReturnValueOnce(true); // .md file on disk
+
+		vi.mocked(loadPlansRegistry).mockResolvedValue({
+			version: 1,
+			plans: {},
+			notes: {
+				"n-abc123": {
+					id: "n-abc123",
+					title: "Design Doc",
+					format: "markdown",
+					sourcePath: "/repo/docs/design.md",
+					addedAt: "2026-01-01T00:00:00Z",
+					updatedAt: "2026-01-01T00:00:00Z",
+					branch: "main",
+					commitHash: null,
+				},
+			},
+		});
+
+		mockTranscriptWithLines(['{"type":"tool_use","name":"Edit","input":{"file_path":"/repo/docs/design.md"}}']);
+
+		mockStdin(hookJson(TRANSCRIPT_PATH, PROJECT_DIR));
+		await handleStopHook();
+
+		expect(savePlansRegistry).not.toHaveBeenCalled();
+	});
+
+	it("should match note sourcePath case-insensitively on Windows (and Darwin)", async () => {
+		// Filesystem case mismatch (Note registered as "Design.md", AI edits "design.md"
+		// referring to same file on case-insensitive FS) must still trigger the
+		// note-shadowing guard. Asserts normalizePathForCompare is being applied
+		// to both sides of the lookup. Pinned to win32 via withPlatform so the
+		// case-folding branch runs on the Linux CI runner as well.
+		await withPlatform("win32", async () => {
+			vi.mocked(existsSync)
+				.mockReturnValueOnce(true) // transcript file
+				.mockReturnValueOnce(true); // .md file on disk
+
+			vi.mocked(loadPlansRegistry).mockResolvedValue({
+				version: 1,
+				plans: {},
+				notes: {
+					"n-abc": {
+						id: "n-abc",
+						title: "Design",
+						format: "markdown",
+						sourcePath: "C:\\Repo\\Docs\\Design.md",
+						addedAt: "2026-01-01T00:00:00Z",
+						updatedAt: "2026-01-01T00:00:00Z",
+						branch: "main",
+						commitHash: null,
+					},
+				},
+			});
+
+			mockTranscriptWithLines([
+				// AI used lowercase form
+				'{"type":"tool_use","name":"Edit","input":{"file_path":"c:\\\\repo\\\\docs\\\\design.md"}}',
+			]);
+
+			mockStdin(hookJson(TRANSCRIPT_PATH, PROJECT_DIR));
+			await handleStopHook();
+
+			expect(savePlansRegistry).not.toHaveBeenCalled();
+		});
 	});
 
 	it("should skip external .md when source file no longer exists at upsert time", async () => {

--- a/cli/src/hooks/StopHook.ts
+++ b/cli/src/hooks/StopHook.ts
@@ -32,6 +32,7 @@ import { createInterface } from "node:readline";
 import { fileURLToPath } from "node:url";
 import { extractLinearIssuesFromTranscript } from "../core/LinearIssueExtractor.js";
 import { writeLinearIssueMarkdown } from "../core/LinearIssueStore.js";
+import { normalizePathForCompare } from "../core/PathUtils.js";
 import {
 	loadConfig,
 	loadCursorForTranscript,
@@ -179,23 +180,6 @@ const EXTERNAL_EXCLUDE_BASENAMES = new Set([
 	"license.md",
 	"security.md",
 ]);
-
-/**
- * Normalize a path for case/separator-insensitive comparison. Used wherever
- * two strings should be treated as "same file" even if Windows case or
- * separator differs.
- *
- * Deliberately does NOT use `path.resolve` because on Windows, POSIX-absolute
- * paths like `/home/user/foo.md` (which Claude transcripts can produce when
- * running under WSL or via cross-platform tooling) are treated as relative and
- * resolved against the runtime cwd. That made same-file checks platform-
- * dependent. All callers pass absolute paths, so separator + case normalization
- * is sufficient.
- */
-function normalizePathForCompare(p: string): string {
-	const normalized = p.replace(/\\/g, "/");
-	return process.platform === "win32" ? normalized.toLowerCase() : normalized;
-}
 
 /**
  * Decide whether an external .md path is a plan candidate. Excludes
@@ -347,11 +331,27 @@ async function discoverPlansFromTranscript(sessionInfo: SessionInfo, cwd: string
 		upsertEntry(slug, planFile, editCount);
 	}
 
+	// Build a Set of normalized paths that already belong to a markdown note.
+	// Markdown notes added via "Add Markdown File" can point at arbitrary user
+	// .md files (NoteService allows `sourcePath = <user-picked path>`). If the
+	// AI later edits that same file, we must NOT also register it as a plan —
+	// it would shadow the user's explicit note semantics, double-archive into
+	// the orphan branch, and surface the same file twice in the panel
+	// (plans + notes are merged without sourcePath dedup downstream).
+	const noteSourcePaths = new Set<string>();
+	for (const note of Object.values(registry.notes ?? {})) {
+		if (note.sourcePath) noteSourcePaths.add(normalizePathForCompare(note.sourcePath));
+	}
+
 	// 2. External .md paths — slug resolved against current plans snapshot.
 	//    basenameNoExt is platform-agnostic so a Windows-style path parsed on
 	//    POSIX CI still yields a clean filename slug.
 	for (const [absPath, editCount] of externalPlans) {
 		if (!existsSync(absPath)) continue;
+		if (noteSourcePaths.has(normalizePathForCompare(absPath))) {
+			log.info("Plan discovery: %s already a note — skipping plan registration", absPath);
+			continue;
+		}
 		const baseSlug = basenameNoExt(absPath, ".md");
 		const slug = resolveUniqueSlug(baseSlug, absPath, plans);
 		upsertEntry(slug, absPath, editCount);

--- a/cli/src/hooks/StopHook.ts
+++ b/cli/src/hooks/StopHook.ts
@@ -27,7 +27,7 @@
 import { createHash } from "node:crypto";
 import { createReadStream, existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
-import { basename, join, resolve as pathResolve } from "node:path";
+import { join, resolve as pathResolve } from "node:path";
 import { createInterface } from "node:readline";
 import { fileURLToPath } from "node:url";
 import { extractLinearIssuesFromTranscript } from "../core/LinearIssueExtractor.js";
@@ -167,24 +167,30 @@ const PLANS_PATH_SLUG_REGEX = /[/\\]{1,2}\.claude[/\\]{1,2}plans[/\\]{1,2}([^/\\
  */
 const ANY_MD_PATH_REGEX = /"file_path":"([^"]+\.md)"/;
 
-/** Path segments excluded from external plan detection. */
-const EXTERNAL_EXCLUDE_SEGMENTS = [/[/\\]\.claude[/\\]/, /[/\\]node_modules[/\\]/, /[/\\]\.github[/\\]/];
+/**
+ * Path segments excluded from external plan detection. Case-insensitive (`i`
+ * flag) so Windows/macOS variants like `Node_Modules/` or `.GitHub/` are also
+ * filtered — matches the case-insensitive basename check below.
+ */
+const EXTERNAL_EXCLUDE_SEGMENTS = [/[/\\]\.claude[/\\]/i, /[/\\]node_modules[/\\]/i, /[/\\]\.github[/\\]/i];
 
 /** Basenames excluded — stored lowercase, compared after toLowerCase() on input. */
 const EXTERNAL_EXCLUDE_BASENAMES = new Set([
 	"claude.md",
+	"claude.local.md",
 	"agents.md",
 	"readme.md",
 	"changelog.md",
 	"contributing.md",
 	"license.md",
 	"security.md",
+	"code_of_conduct.md",
 ]);
 
 /**
- * Decide whether an external .md path is a plan candidate. Excludes
- * ~/.claude/ subtree (memory/skill/agent/session), node_modules, .github, and
- * common non-plan filenames at any depth (README.md, CLAUDE.md, etc.).
+ * Decide whether an external .md path is a plan candidate. Excludes any path
+ * under `.claude/`, `node_modules/`, or `.github/`, plus common non-plan
+ * filenames (README.md, CLAUDE.md, etc.) at any depth.
  */
 function isExternalPlanCandidate(absPath: string): boolean {
 	if (EXTERNAL_EXCLUDE_SEGMENTS.some((re) => re.test(absPath))) return false;
@@ -274,6 +280,12 @@ async function discoverPlansFromTranscript(sessionInfo: SessionInfo, cwd: string
 	const now = new Date().toISOString();
 	let branch: string | undefined;
 	let changed = false;
+	// Tracks slugs we actually modified in this run. Used at writeback time to
+	// merge our changes onto the freshest registry snapshot per-slug rather
+	// than overwriting the whole plans map — without this, any slug a sibling
+	// pipeline (QueueWorker archive, extension ignore, parallel StopHook) wrote
+	// between our load and save would be silently dropped.
+	const touchedSlugs = new Set<string>();
 
 	const upsertEntry = (slug: string, planFile: string, editCount: number): void => {
 		const existing = plans[slug];
@@ -296,12 +308,14 @@ async function discoverPlansFromTranscript(sessionInfo: SessionInfo, cwd: string
 					editCount,
 				};
 				changed = true;
+				touchedSlugs.add(slug);
 				log.info("Plan discovery: archived plan %s file changed — creating new entry", slug);
 			}
 		} else if (existing) {
 			if (existing.commitHash === null && !existing.ignored) {
 				plans[slug] = { ...existing, editCount: existing.editCount + editCount, updatedAt: now };
 				changed = true;
+				touchedSlugs.add(slug);
 			}
 		} else {
 			branch ??= getCurrentBranch(cwd);
@@ -316,31 +330,51 @@ async function discoverPlansFromTranscript(sessionInfo: SessionInfo, cwd: string
 				editCount,
 			};
 			changed = true;
+			touchedSlugs.add(slug);
 		}
 	};
+
+	// Build a Set of normalized paths that already belong to a markdown note
+	// on the current branch. Markdown notes added via "Add Markdown File" can
+	// point at arbitrary user .md files (NoteService allows
+	// `sourcePath = <user-picked path>`). If the AI later edits that same file,
+	// we must NOT also register it as a plan — it would shadow the user's
+	// explicit note semantics, double-archive into the orphan branch, and
+	// surface the same file twice in the panel (plans + notes are merged
+	// without sourcePath dedup downstream).
+	//
+	// Branch scoping: notes are branch-filtered in NoteService.toNoteInfo, so a
+	// note on `main` is invisible on `feature/x`. The guard must mirror that
+	// scope, otherwise a hidden cross-branch note silently suppresses plan
+	// auto-registration on the current branch.
+	const noteSourcePaths = new Set<string>();
+	const notesArr = Object.values(registry.notes ?? {});
+	if (notesArr.length > 0) {
+		branch ??= getCurrentBranch(cwd);
+		for (const note of notesArr) {
+			if (note.branch && note.branch !== branch) continue;
+			if (note.sourcePath) noteSourcePaths.add(normalizePathForCompare(note.sourcePath));
+		}
+	}
 
 	// 1. Canonical ~/.claude/plans/ slugs. We still route through
 	//    resolveUniqueSlug so that if an external entry was registered first
 	//    under the same slug (e.g. docs/foo.md → "foo"), the canonical
 	//    ~/.claude/plans/foo.md gets a hash-suffixed slug rather than silently
 	//    overwriting the external entry's sourcePath via upsertEntry.
+	//
+	//    Note guard is applied here too: a user may have added
+	//    `~/.claude/plans/foo.md` as a note via "Add Markdown File" (file
+	//    picker is unrestricted), so the same dedup applies.
 	for (const [rawSlug, editCount] of slugs) {
 		const planFile = join(homedir(), ".claude", "plans", `${rawSlug}.md`);
 		if (!existsSync(planFile)) continue;
+		if (noteSourcePaths.has(normalizePathForCompare(planFile))) {
+			log.info("Plan discovery: %s already a note — skipping plan registration", planFile);
+			continue;
+		}
 		const slug = resolveUniqueSlug(rawSlug, planFile, plans);
 		upsertEntry(slug, planFile, editCount);
-	}
-
-	// Build a Set of normalized paths that already belong to a markdown note.
-	// Markdown notes added via "Add Markdown File" can point at arbitrary user
-	// .md files (NoteService allows `sourcePath = <user-picked path>`). If the
-	// AI later edits that same file, we must NOT also register it as a plan —
-	// it would shadow the user's explicit note semantics, double-archive into
-	// the orphan branch, and surface the same file twice in the panel
-	// (plans + notes are merged without sourcePath dedup downstream).
-	const noteSourcePaths = new Set<string>();
-	for (const note of Object.values(registry.notes ?? {})) {
-		if (note.sourcePath) noteSourcePaths.add(normalizePathForCompare(note.sourcePath));
 	}
 
 	// 2. External .md paths — slug resolved against current plans snapshot.
@@ -358,20 +392,53 @@ async function discoverPlansFromTranscript(sessionInfo: SessionInfo, cwd: string
 	}
 
 	if (changed) {
-		// Re-read once more and preserve any commitHash updates from PostCommitHook.
-		// Only apply when the commitHash changed between reads — meaning PostCommitHook
-		// wrote it during this window. This avoids restoring a stale commitHash onto
-		// archive-guard entries that we deliberately reset to null.
+		// Re-read once more and merge per-slug onto the freshest snapshot.
+		//
+		// Why not just write our local `plans`: between our initial load and
+		// this save, sibling pipelines may have written to plans.json:
+		//   - QueueWorker may have added a `<slug>-<commitHash8>` archive entry
+		//     and upgraded the original slug into an archive guard
+		//   - Another StopHook (parallel session) may have added a new slug
+		//   - The extension may have flipped `ignored` on an entry
+		//
+		// Strategy: start with freshRegistry.plans as the baseline (preserves
+		// every concurrent write), then layer ONLY the slugs we explicitly
+		// touched on top. For each touched slug, also pull through any
+		// concurrent commitHash update (the PostCommitHook race already
+		// covered by the prior implementation).
 		const freshRegistry = await loadPlansRegistry(cwd);
-		for (const [slug, freshEntry] of Object.entries(freshRegistry.plans)) {
-			if (!freshEntry.commitHash) continue;
-			if (!plans[slug]) continue;
+		const merged: Record<string, PlanEntry> = { ...freshRegistry.plans };
+		for (const slug of touchedSlugs) {
+			const ours = plans[slug];
+			if (!ours) continue;
+			const fresh = freshRegistry.plans[slug];
+			const freshCommitHash = fresh?.commitHash;
 			const originalCommitHash = registry.plans[slug]?.commitHash ?? null;
-			if (freshEntry.commitHash !== originalCommitHash) {
-				plans[slug] = { ...plans[slug], commitHash: freshEntry.commitHash };
+			if (fresh && freshCommitHash && freshCommitHash !== originalCommitHash) {
+				// A sibling writer (typically QueueWorker) transitioned this slug
+				// from uncommitted to archived between our load and save: it set
+				// both `commitHash` AND `contentHashAtCommit` (the archive-guard
+				// pair). Use the fresh entry wholesale rather than overlaying one
+				// field on ours — otherwise `contentHashAtCommit` is dropped, the
+				// entry trips the snapshot-copy filter in PlanService.toPlanInfo
+				// (vanishes from the panel), and the upsertEntry archive-guard
+				// revive branch can never fire again (because it gates on
+				// `existing.contentHashAtCommit`).
+				//
+				// Our local editCount increment is intentionally dropped: once
+				// archived, editCount is invisible to the panel; the next
+				// Write/Edit will resurrect a fresh uncommitted entry with the
+				// correct count via the archive-guard branch in upsertEntry.
+				merged[slug] = fresh;
+			} else {
+				merged[slug] = ours;
 			}
 		}
-		await savePlansRegistry({ version: 1, plans }, cwd);
+		// Spread freshRegistry first to preserve notes / linearIssues — otherwise
+		// any sibling pipeline that wrote them between our load and save (e.g.
+		// the note service from the extension, the Linear discovery loop below)
+		// loses its work.
+		await savePlansRegistry({ ...freshRegistry, version: 1, plans: merged }, cwd);
 		log.info(
 			"Plan discovery: upserted %d slug(s) + %d external path(s) into plans.json",
 			slugs.size,
@@ -431,9 +498,18 @@ function scanTranscriptForPlans(
 				} else {
 					const extMatch = ANY_MD_PATH_REGEX.exec(line);
 					if (extMatch?.[1]) {
-						// Transcript JSON-escapes backslashes as "\\"; unescape before use
-						const absPath = extMatch[1].replace(/\\\\/g, "\\");
-						if (isExternalPlanCandidate(absPath)) {
+						// Transcripts are JSONL: the captured substring lives inside a JSON
+						// string literal, so all of `\\`, `\"`, `\n`, `\uXXXX` etc. are
+						// possible. Decode via JSON.parse to handle every escape uniformly
+						// — a simple `replace(/\\\\/g, "\\")` misses unicode-escaped
+						// non-ASCII filenames and any other valid JSON escape.
+						let absPath: string | null = null;
+						try {
+							absPath = JSON.parse(`"${extMatch[1]}"`) as string;
+						} catch {
+							// Malformed escape sequence — treat as non-candidate.
+						}
+						if (absPath && isExternalPlanCandidate(absPath)) {
 							externalPlans.set(absPath, (externalPlans.get(absPath) ?? 0) + 1);
 						}
 					}
@@ -526,12 +602,16 @@ async function discoverLinearIssuesFromTranscript(sessionInfo: SessionInfo, cwd:
 
 /** Extracts the first # heading from a markdown file. */
 function extractPlanTitle(filePath: string): string {
+	// Use a platform-agnostic basename for the fallback: node:path.basename
+	// only recognizes the current platform's separator, so a Windows path
+	// processed on POSIX would degrade into the entire path string.
+	const fallback = filePath.split(/[/\\]/).pop() ?? filePath;
 	try {
 		const content = readFileSync(filePath, "utf-8");
 		const match = /^#\s+(.+)/m.exec(content);
-		return match?.[1]?.trim() ?? basename(filePath);
+		return match?.[1]?.trim() ?? fallback;
 	} catch {
-		return basename(filePath);
+		return fallback;
 	}
 }
 

--- a/cli/src/hooks/StopHook.ts
+++ b/cli/src/hooks/StopHook.ts
@@ -24,6 +24,7 @@
  * This hook runs with { "async": true } so it doesn't block Claude Code.
  */
 
+import { createHash } from "node:crypto";
 import { createReadStream, existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { basename, join, resolve as pathResolve } from "node:path";
@@ -41,7 +42,7 @@ import {
 	upsertLinearIssueEntry,
 } from "../core/SessionTracker.js";
 import { createLogger, setLogDir } from "../Logger.js";
-import type { ClaudeHookInput, SessionInfo } from "../Types.js";
+import type { ClaudeHookInput, PlanEntry, SessionInfo } from "../Types.js";
 import { readStdin } from "./HookUtils.js";
 
 const log = createLogger("StopHook");
@@ -159,15 +160,103 @@ const WRITE_EDIT_REGEX = /"name":"(?:Write|Edit)"/;
 const PLANS_PATH_SLUG_REGEX = /[/\\]{1,2}\.claude[/\\]{1,2}plans[/\\]{1,2}([^/\\.]+)\.md/;
 
 /**
+ * Fallback regex: matches any Write/Edit tool_use file_path ending in .md.
+ * Runs only when PLANS_PATH_SLUG_REGEX misses, so ~/.claude/plans/ stays
+ * handled by the original slug-keyed code path.
+ */
+const ANY_MD_PATH_REGEX = /"file_path":"([^"]+\.md)"/;
+
+/** Path segments excluded from external plan detection. */
+const EXTERNAL_EXCLUDE_SEGMENTS = [/[/\\]\.claude[/\\]/, /[/\\]node_modules[/\\]/, /[/\\]\.github[/\\]/];
+
+/** Basenames excluded — stored lowercase, compared after toLowerCase() on input. */
+const EXTERNAL_EXCLUDE_BASENAMES = new Set([
+	"claude.md",
+	"agents.md",
+	"readme.md",
+	"changelog.md",
+	"contributing.md",
+	"license.md",
+	"security.md",
+]);
+
+/**
+ * Normalize a path for case/separator-insensitive comparison. Used wherever
+ * two strings should be treated as "same file" even if Windows case or
+ * separator differs.
+ *
+ * Deliberately does NOT use `path.resolve` because on Windows, POSIX-absolute
+ * paths like `/home/user/foo.md` (which Claude transcripts can produce when
+ * running under WSL or via cross-platform tooling) are treated as relative and
+ * resolved against the runtime cwd. That made same-file checks platform-
+ * dependent. All callers pass absolute paths, so separator + case normalization
+ * is sufficient.
+ */
+function normalizePathForCompare(p: string): string {
+	const normalized = p.replace(/\\/g, "/");
+	return process.platform === "win32" ? normalized.toLowerCase() : normalized;
+}
+
+/**
+ * Decide whether an external .md path is a plan candidate. Excludes
+ * ~/.claude/ subtree (memory/skill/agent/session), node_modules, .github, and
+ * common non-plan filenames at any depth (README.md, CLAUDE.md, etc.).
+ */
+function isExternalPlanCandidate(absPath: string): boolean {
+	if (EXTERNAL_EXCLUDE_SEGMENTS.some((re) => re.test(absPath))) return false;
+	const base = (absPath.split(/[/\\]/).pop() ?? "").toLowerCase();
+	return !EXTERNAL_EXCLUDE_BASENAMES.has(base);
+}
+
+/**
+ * Platform-agnostic basename + extension stripping. node:path.basename is
+ * locked to the runtime platform's separator — on POSIX it doesn't recognize
+ * `\` as a separator, so a Windows-style transcript path parsed on Linux CI
+ * yields `E:\jm-docs\some-plan` instead of `some-plan`. Splitting on both
+ * separators avoids that.
+ */
+function basenameNoExt(absPath: string, ext: string): string {
+	const last = absPath.split(/[/\\]/).pop() ?? "";
+	return last.endsWith(ext) ? last.slice(0, -ext.length) : last;
+}
+
+/**
+ * Returns a unique registry slug for a given absolute path.
+ *
+ * Resolution order:
+ *   1. SourcePath reverse-lookup: scan all entries, return the slug whose
+ *      sourcePath normalize-equals absPath. Idempotent — same file always
+ *      resolves to the same slug, including when the base slug entry has
+ *      been cleaned up but a hash-suffixed entry remains.
+ *   2. Base slug free: no entry at baseSlug → use baseSlug.
+ *   3. Base slug taken by a different file → `<baseSlug>-<pathHash8>`
+ *      (sha256(normalized absPath) first 8 hex chars).
+ *
+ * Existing entries are never renamed — backward-compatible across upgrades.
+ */
+function resolveUniqueSlug(baseSlug: string, absPath: string, plans: Record<string, PlanEntry>): string {
+	const targetNorm = normalizePathForCompare(absPath);
+	for (const [slug, entry] of Object.entries(plans)) {
+		if (normalizePathForCompare(entry.sourcePath) === targetNorm) return slug;
+	}
+	if (!plans[baseSlug]) return baseSlug;
+	const shortHash = createHash("sha256").update(targetNorm).digest("hex").slice(0, 8);
+	return `${baseSlug}-${shortHash}`;
+}
+
+/**
  * Incrementally scans the transcript for plan file references and updates plans.json.
  *
  * Uses a dedicated cursor (prefixed with "plan:") in cursors.json to track
  * how far the transcript has been scanned, so each StopHook invocation only
  * reads the newly appended lines.
  *
- * Detection covers two scenarios:
+ * Detection covers three scenarios:
  *   1. Plan mode: the transcript contains a "slug":"xxx" field
- *   2. Direct write: a Write/Edit tool call targets ~/.claude/plans/xxx.md
+ *   2. Direct write to ~/.claude/plans/: Write/Edit tool call hits the canonical dir
+ *   3. External .md files (e.g. docs/foo.md, E:\jm-docs\bar.md): Write/Edit tool
+ *      call on any .md path not excluded by isExternalPlanCandidate — slug is
+ *      derived from basename via resolveUniqueSlug for cross-path collisions.
  */
 async function discoverPlansFromTranscript(sessionInfo: SessionInfo, cwd: string): Promise<void> {
 	const transcriptPath = sessionInfo.transcriptPath;
@@ -180,11 +269,11 @@ async function discoverPlansFromTranscript(sessionInfo: SessionInfo, cwd: string
 	const cursor = await loadCursorForTranscript(cursorKey, cwd);
 	const startLine = cursor?.lineNumber ?? 0;
 
-	// Scan transcript from startLine, collecting discovered slugs and edit counts
-	const { slugs, totalLines } = await scanTranscriptForPlans(transcriptPath, startLine);
+	// Scan transcript from startLine, collecting discovered slugs / external paths
+	const { slugs, externalPlans, totalLines } = await scanTranscriptForPlans(transcriptPath, startLine);
 
-	if (slugs.size === 0) {
-		// No plans found, but still update cursor to avoid re-scanning
+	if (slugs.size === 0 && externalPlans.size === 0) {
+		// Nothing found, but still update cursor to avoid re-scanning
 		if (totalLines > startLine) {
 			await saveCursor(
 				{ transcriptPath: cursorKey, lineNumber: totalLines, updatedAt: new Date().toISOString() },
@@ -194,31 +283,23 @@ async function discoverPlansFromTranscript(sessionInfo: SessionInfo, cwd: string
 		return;
 	}
 
-	// Upsert discovered slugs into plans.json
-	// Re-read registry right before writing to minimize race window with PostCommitHook
+	// Upsert into plans.json. Re-read registry right before writing to
+	// minimize race window with PostCommitHook.
 	const registry = await loadPlansRegistry(cwd);
 	const plans = { ...registry.plans };
 	const now = new Date().toISOString();
 	let branch: string | undefined;
 	let changed = false;
 
-	for (const [slug, editCount] of slugs) {
-		const planFile = join(homedir(), ".claude", "plans", `${slug}.md`);
-		if (!existsSync(planFile)) {
-			continue;
-		}
-
+	const upsertEntry = (slug: string, planFile: string, editCount: number): void => {
 		const existing = plans[slug];
 		if (existing?.contentHashAtCommit) {
 			// Archived guard — never resurrect if user explicitly removed it
 			if (existing.ignored) {
-				continue;
+				return;
 			}
-			// Check if the source file was overwritten with new content
-			const { createHash } = require("node:crypto") as typeof import("node:crypto");
 			const currentHash = createHash("sha256").update(readFileSync(planFile, "utf-8")).digest("hex");
 			if (currentHash !== existing.contentHashAtCommit) {
-				// File overwritten → create fresh uncommitted entry
 				branch ??= getCurrentBranch(cwd);
 				plans[slug] = {
 					slug,
@@ -233,15 +314,12 @@ async function discoverPlansFromTranscript(sessionInfo: SessionInfo, cwd: string
 				changed = true;
 				log.info("Plan discovery: archived plan %s file changed — creating new entry", slug);
 			}
-			// If unchanged, skip (guard still active)
 		} else if (existing) {
-			// Increment editCount for uncommitted plans; skip committed/ignored
 			if (existing.commitHash === null && !existing.ignored) {
 				plans[slug] = { ...existing, editCount: existing.editCount + editCount, updatedAt: now };
 				changed = true;
 			}
 		} else {
-			// New plan entry — lazy-evaluate branch only when needed
 			branch ??= getCurrentBranch(cwd);
 			plans[slug] = {
 				slug,
@@ -255,6 +333,28 @@ async function discoverPlansFromTranscript(sessionInfo: SessionInfo, cwd: string
 			};
 			changed = true;
 		}
+	};
+
+	// 1. Canonical ~/.claude/plans/ slugs. We still route through
+	//    resolveUniqueSlug so that if an external entry was registered first
+	//    under the same slug (e.g. docs/foo.md → "foo"), the canonical
+	//    ~/.claude/plans/foo.md gets a hash-suffixed slug rather than silently
+	//    overwriting the external entry's sourcePath via upsertEntry.
+	for (const [rawSlug, editCount] of slugs) {
+		const planFile = join(homedir(), ".claude", "plans", `${rawSlug}.md`);
+		if (!existsSync(planFile)) continue;
+		const slug = resolveUniqueSlug(rawSlug, planFile, plans);
+		upsertEntry(slug, planFile, editCount);
+	}
+
+	// 2. External .md paths — slug resolved against current plans snapshot.
+	//    basenameNoExt is platform-agnostic so a Windows-style path parsed on
+	//    POSIX CI still yields a clean filename slug.
+	for (const [absPath, editCount] of externalPlans) {
+		if (!existsSync(absPath)) continue;
+		const baseSlug = basenameNoExt(absPath, ".md");
+		const slug = resolveUniqueSlug(baseSlug, absPath, plans);
+		upsertEntry(slug, absPath, editCount);
 	}
 
 	if (changed) {
@@ -272,7 +372,11 @@ async function discoverPlansFromTranscript(sessionInfo: SessionInfo, cwd: string
 			}
 		}
 		await savePlansRegistry({ version: 1, plans }, cwd);
-		log.info("Plan discovery: upserted %d slug(s) into plans.json: [%s]", slugs.size, [...slugs.keys()].join(", "));
+		log.info(
+			"Plan discovery: upserted %d slug(s) + %d external path(s) into plans.json",
+			slugs.size,
+			externalPlans.size,
+		);
 	}
 
 	// Update cursor so next invocation starts where we left off
@@ -281,14 +385,19 @@ async function discoverPlansFromTranscript(sessionInfo: SessionInfo, cwd: string
 
 /**
  * Scans a transcript JSONL file starting from a given line, looking for plan references.
- * Returns a map of slug → editCount for all plans discovered in the new lines.
+ *
+ * Returns two maps:
+ *   - `slugs`: slug → editCount for plans in ~/.claude/plans/ (slug-keyed)
+ *   - `externalPlans`: absPath → editCount for .md files outside ~/.claude/plans/
+ *     (slug resolution deferred to the upsert phase, which has the registry snapshot)
  */
 function scanTranscriptForPlans(
 	transcriptPath: string,
 	startLine: number,
-): Promise<{ slugs: Map<string, number>; totalLines: number }> {
+): Promise<{ slugs: Map<string, number>; externalPlans: Map<string, number>; totalLines: number }> {
 	return new Promise((resolve) => {
 		const slugs = new Map<string, number>();
+		const externalPlans = new Map<string, number>();
 		let lineNumber = 0;
 
 		const stream = createReadStream(transcriptPath, { encoding: "utf-8" });
@@ -311,19 +420,30 @@ function scanTranscriptForPlans(
 				}
 			}
 
-			// Detect Write/Edit to ~/.claude/plans/*.md
+			// Detect Write/Edit tool calls. First try the slug-keyed
+			// ~/.claude/plans/ path; only fall back to the generic .md regex
+			// when that misses, so existing behavior is preserved.
 			if (line.includes('"type":"tool_use"') && WRITE_EDIT_REGEX.test(line)) {
 				const pathMatch = PLANS_PATH_SLUG_REGEX.exec(line);
 				if (pathMatch?.[1]) {
 					const slug = pathMatch[1];
 					slugs.set(slug, (slugs.get(slug) ?? 0) + 1);
+				} else {
+					const extMatch = ANY_MD_PATH_REGEX.exec(line);
+					if (extMatch?.[1]) {
+						// Transcript JSON-escapes backslashes as "\\"; unescape before use
+						const absPath = extMatch[1].replace(/\\\\/g, "\\");
+						if (isExternalPlanCandidate(absPath)) {
+							externalPlans.set(absPath, (externalPlans.get(absPath) ?? 0) + 1);
+						}
+					}
 				}
 			}
 		});
 
-		rl.on("close", () => resolve({ slugs, totalLines: lineNumber }));
+		rl.on("close", () => resolve({ slugs, externalPlans, totalLines: lineNumber }));
 		/* v8 ignore start - defensive: readline error handler for rare stream failures */
-		rl.on("error", () => resolve({ slugs, totalLines: lineNumber }));
+		rl.on("error", () => resolve({ slugs, externalPlans, totalLines: lineNumber }));
 		/* v8 ignore stop */
 	});
 }

--- a/cli/src/testUtils/withPlatform.test.ts
+++ b/cli/src/testUtils/withPlatform.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { withPlatform } from "./withPlatform.js";
+
+describe("withPlatform", () => {
+	it("returns the sync result and restores process.platform", () => {
+		const before = process.platform;
+		const result = withPlatform("win32", () => {
+			expect(process.platform).toBe("win32");
+			return 42;
+		});
+		expect(result).toBe(42);
+		expect(process.platform).toBe(before);
+	});
+
+	it("restores process.platform when sync fn throws", () => {
+		const before = process.platform;
+		expect(() =>
+			withPlatform("darwin", () => {
+				expect(process.platform).toBe("darwin");
+				throw new Error("boom");
+			}),
+		).toThrow("boom");
+		expect(process.platform).toBe(before);
+	});
+
+	it("awaits async fn and restores process.platform after it resolves", async () => {
+		const before = process.platform;
+		const result = await withPlatform("linux", async () => {
+			expect(process.platform).toBe("linux");
+			return "ok";
+		});
+		expect(result).toBe("ok");
+		expect(process.platform).toBe(before);
+	});
+
+	it("restores process.platform when async fn rejects", async () => {
+		const before = process.platform;
+		await expect(
+			withPlatform("win32", async () => {
+				expect(process.platform).toBe("win32");
+				throw new Error("async boom");
+			}),
+		).rejects.toThrow("async boom");
+		expect(process.platform).toBe(before);
+	});
+});

--- a/cli/src/testUtils/withPlatform.ts
+++ b/cli/src/testUtils/withPlatform.ts
@@ -1,0 +1,43 @@
+/**
+ * Temporarily override `process.platform` for a single block. `process.platform`
+ * is a read-only getter, so simple assignment doesn't work — we redefine the
+ * property and restore the original descriptor afterwards.
+ *
+ * Lets a test pin `win32` / `darwin` / `linux` semantics deterministically
+ * regardless of the host OS, so platform-conditional code (path normalization,
+ * filesystem case rules) can be asserted from any CI runner without `it.skip`.
+ *
+ * Supports both sync and async `fn` — the platform is restored after the
+ * returned promise settles. Safe to nest only if callers do not run concurrently
+ * within the same Vitest file (Vitest runs tests in a file serially by default,
+ * but parallel tests in the same file would race on the global `process` object).
+ */
+export function withPlatform<T>(platform: NodeJS.Platform, fn: () => T): T {
+	// Node always exposes process.platform, so the descriptor is never undefined.
+	const original = Object.getOwnPropertyDescriptor(process, "platform") as PropertyDescriptor;
+	const restore = (): void => {
+		Object.defineProperty(process, "platform", original);
+	};
+	Object.defineProperty(process, "platform", { value: platform, configurable: true });
+	let result: T;
+	try {
+		result = fn();
+	} catch (err) {
+		restore();
+		throw err;
+	}
+	if (result instanceof Promise) {
+		return result.then(
+			(v) => {
+				restore();
+				return v;
+			},
+			(e) => {
+				restore();
+				throw e;
+			},
+		) as T;
+	}
+	restore();
+	return result;
+}

--- a/vscode/src/Extension.test.ts
+++ b/vscode/src/Extension.test.ts
@@ -2017,10 +2017,15 @@ describe("Extension", () => {
 				);
 			});
 
-			it("opens source file for uncommitted plans", async () => {
+			it("opens source file for uncommitted plans using filePath from PlanItem", async () => {
 				const handler = getRegisteredCommand("jollimemory.editPlan");
 				await handler({
-					plan: { slug: "my-plan", title: "My Plan", commitHash: undefined },
+					plan: {
+						slug: "my-plan",
+						title: "My Plan",
+						commitHash: undefined,
+						filePath: normalize("/home/user/.claude/plans/my-plan.md"),
+					},
 				});
 
 				expect(openTextDocument).toHaveBeenCalledWith(
@@ -2028,22 +2033,65 @@ describe("Extension", () => {
 				);
 			});
 
-			it("accepts string slug instead of PlanItem", async () => {
+			it("opens external-path plan using filePath from PlanItem", async () => {
+				// External plan: filePath is an arbitrary absolute path outside ~/.claude/plans/
 				const handler = getRegisteredCommand("jollimemory.editPlan");
-				// editPlan(slug: string, committed: false, title: "My Plan")
+				await handler({
+					plan: {
+						slug: "foo-plan",
+						title: "External Foo",
+						commitHash: undefined,
+						filePath: normalize("/repo/docs/foo-plan.md"),
+					},
+				});
+
+				expect(openTextDocument).toHaveBeenCalledWith(
+					normalize("/repo/docs/foo-plan.md"),
+				);
+			});
+
+			it("falls back to bridge.listPlans() when invoked with bare slug", async () => {
+				mockBridge.listPlans.mockResolvedValue([
+					{
+						slug: "my-plan",
+						filePath: normalize("/home/user/.claude/plans/my-plan.md"),
+					},
+				]);
+
+				const handler = getRegisteredCommand("jollimemory.editPlan");
 				await handler("my-plan", false, "My Plan");
 
+				expect(mockBridge.listPlans).toHaveBeenCalled();
 				expect(openTextDocument).toHaveBeenCalledWith(
 					normalize("/home/user/.claude/plans/my-plan.md"),
 				);
 			});
 
 			it("uses default committed and title values when only a slug is provided", async () => {
+				mockBridge.listPlans.mockResolvedValue([
+					{
+						slug: "my-plan",
+						filePath: normalize("/home/user/.claude/plans/my-plan.md"),
+					},
+				]);
+
 				const handler = getRegisteredCommand("jollimemory.editPlan");
 				await handler("my-plan");
 
 				expect(openTextDocument).toHaveBeenCalledWith(
 					normalize("/home/user/.claude/plans/my-plan.md"),
+				);
+			});
+
+			it("warns and returns when filePath cannot be resolved", async () => {
+				mockBridge.listPlans.mockResolvedValue([]);
+
+				const handler = getRegisteredCommand("jollimemory.editPlan");
+				await handler("missing-from-registry");
+
+				expect(openTextDocument).not.toHaveBeenCalled();
+				expect(showWarningMessage).toHaveBeenCalledWith(
+					expect.stringContaining("missing-from-registry"),
 				);
 			});
 
@@ -5059,7 +5107,11 @@ describe("Extension", () => {
 				merged: [
 					{
 						kind: "plan",
-						plan: { slug: "my-plan", title: "My Plan" },
+						plan: {
+							slug: "my-plan",
+							title: "My Plan",
+							filePath: "/home/user/.claude/plans/my-plan.md",
+						},
 					},
 				],
 				changeReason: "init",
@@ -5072,6 +5124,36 @@ describe("Extension", () => {
 			expect(executeCommand).toHaveBeenCalledWith(
 				"markdown.showPreview",
 				expect.objectContaining({ fsPath: expect.stringContaining("my-plan") }),
+			);
+		});
+
+		it("opens an external-path plan via its registry filePath", async () => {
+			const ctx = makeContext();
+			activate(ctx);
+
+			mockPlansStore.getSnapshot.mockReturnValueOnce({
+				merged: [
+					{
+						kind: "plan",
+						plan: {
+							slug: "foo-plan",
+							title: "External Foo",
+							filePath: "/repo/docs/foo-plan.md",
+						},
+					},
+				],
+				changeReason: "init",
+			} as never);
+			existsSync.mockImplementationOnce(() => true);
+
+			const handler = getRegisteredCommand("jollimemory.openPlanForPreview");
+			await handler("foo-plan");
+
+			expect(executeCommand).toHaveBeenCalledWith(
+				"markdown.showPreview",
+				expect.objectContaining({
+					fsPath: expect.stringContaining("foo-plan.md"),
+				}),
 			);
 		});
 

--- a/vscode/src/Extension.test.ts
+++ b/vscode/src/Extension.test.ts
@@ -2095,6 +2095,29 @@ describe("Extension", () => {
 				);
 			});
 
+			it("warns and returns when the resolved filePath does not exist on disk", async () => {
+				// C5 regression: registry can point at a file that has since been
+				// deleted (user moved/renamed it). editPlan must surface that
+				// rather than firing openTextDocument and letting VSCode swallow
+				// the FileNotFound error.
+				existsSync.mockReturnValueOnce(false);
+
+				const handler = getRegisteredCommand("jollimemory.editPlan");
+				await handler({
+					plan: {
+						slug: "stale-plan",
+						title: "Stale",
+						commitHash: undefined,
+						filePath: normalize("/repo/docs/stale-plan.md"),
+					},
+				});
+
+				expect(openTextDocument).not.toHaveBeenCalled();
+				expect(showWarningMessage).toHaveBeenCalledWith(
+					expect.stringContaining("not found on disk"),
+				);
+			});
+
 			it("shows error when committed plan content is not found", async () => {
 				readPlanFromBranch.mockResolvedValue(null);
 
@@ -5154,6 +5177,40 @@ describe("Extension", () => {
 				expect.objectContaining({
 					fsPath: expect.stringContaining("foo-plan.md"),
 				}),
+			);
+		});
+
+		it("falls back to the orphan-branch snapshot when the plan has no filePath (I16)", async () => {
+			// Plan is in the snapshot but `filePath` is empty (committed-plan case
+			// where the source file path is intentionally blanked). The preview
+			// command must fall through to showPlanPreview rather than firing
+			// markdown.showPreview against a missing local path. The signal is
+			// readPlanFromBranch being invoked, which only happens in the
+			// orphan-branch fallback.
+			const ctx = makeContext();
+			activate(ctx);
+
+			mockPlansStore.getSnapshot.mockReturnValueOnce({
+				merged: [
+					{
+						kind: "plan",
+						plan: {
+							slug: "committed-plan",
+							title: "Committed",
+							filePath: "",
+						},
+					},
+				],
+				changeReason: "init",
+			} as never);
+			readPlanFromBranch.mockResolvedValueOnce("# Body");
+
+			const handler = getRegisteredCommand("jollimemory.openPlanForPreview");
+			await handler("committed-plan");
+
+			expect(readPlanFromBranch).toHaveBeenCalledWith(
+				"committed-plan",
+				"/test/workspace",
 			);
 		});
 

--- a/vscode/src/Extension.ts
+++ b/vscode/src/Extension.ts
@@ -1688,6 +1688,20 @@ export function activate(context: vscode.ExtensionContext): void {
 						);
 						return;
 					}
+					// Mirror the existsSync guard in openPlanForPreview. Without it,
+					// a stale registry entry whose underlying file has been deleted
+					// fires openTextDocument → VSCode throws FileNotFound → command
+					// handler swallows it → user clicks but nothing happens.
+					if (!existsSync(filePath)) {
+						log.warn(
+							"cmd",
+							`editPlan: file missing on disk for ${slug}: ${filePath}`,
+						);
+						vscode.window.showWarningMessage(
+							`Plan "${slug}" file not found on disk: ${filePath}`,
+						);
+						return;
+					}
 					const doc = await vscode.workspace.openTextDocument(filePath);
 					await vscode.window.showTextDocument(doc);
 				}

--- a/vscode/src/Extension.ts
+++ b/vscode/src/Extension.ts
@@ -7,7 +7,6 @@
 
 import { execFileSync, execSync } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
-import { homedir } from "node:os";
 import { dirname, isAbsolute, join, resolve } from "node:path";
 import * as vscode from "vscode";
 import {
@@ -1665,8 +1664,30 @@ export function activate(context: vscode.ExtensionContext): void {
 					// Open rendered markdown preview (read-only) from orphan branch
 					await showPlanPreview(slug, planTitle);
 				} else {
-					// Open source file for editing
-					const filePath = join(homedir(), ".claude", "plans", `${slug}.md`);
+					// Resolve filePath via the registry. PlanItem (tree click) carries
+					// it directly; tooltip invocations pass only the slug, in which
+					// case we fall back to bridge.listPlans(). No filePath at this
+					// point means the registry is out of sync with the panel state —
+					// surface that explicitly rather than silently opening a stale
+					// ~/.claude/plans/<slug>.md that almost certainly does not exist.
+					let filePath: string | undefined;
+					if (typeof itemOrSlug !== "string") {
+						filePath = itemOrSlug.plan.filePath;
+					}
+					if (!filePath) {
+						const plans = await bridge.listPlans();
+						filePath = plans.find((p) => p.slug === slug)?.filePath;
+					}
+					if (!filePath) {
+						log.warn(
+							"cmd",
+							`editPlan: no filePath for slug ${slug} — registry may be stale`,
+						);
+						vscode.window.showWarningMessage(
+							`Plan "${slug}" not found — refresh the PLANS panel and try again.`,
+						);
+						return;
+					}
 					const doc = await vscode.workspace.openTextDocument(filePath);
 					await vscode.window.showTextDocument(doc);
 				}
@@ -1769,14 +1790,19 @@ export function activate(context: vscode.ExtensionContext): void {
 				log.info("cmd", `openPlanForPreview: ${slug}`);
 				// Look up plan info to know whether a committed snapshot exists.
 				// PlansStore already holds the latest snapshot; no need to ask
-				// the bridge.
+				// the bridge. We prefer the registry's filePath so external paths
+				// (e.g. docs/foo.md, E:\jm-docs\bar.md) render the on-disk file
+				// rather than a missing ~/.claude/plans/<slug>.md.
 				const snap = plansStore.getSnapshot();
 				const plan = snap.merged.find(
 					(e) => e.kind === "plan" && e.plan.slug === slug,
 				);
 				const planTitle = plan && plan.kind === "plan" ? plan.plan.title : slug;
-				const localPath = join(homedir(), ".claude", "plans", `${slug}.md`);
-				if (existsSync(localPath)) {
+				const localPath =
+					plan && plan.kind === "plan" && plan.plan.filePath
+						? plan.plan.filePath
+						: undefined;
+				if (localPath && existsSync(localPath)) {
 					await vscode.commands.executeCommand(
 						"markdown.showPreview",
 						vscode.Uri.file(localPath),

--- a/vscode/src/JolliMemoryBridge.ts
+++ b/vscode/src/JolliMemoryBridge.ts
@@ -26,6 +26,7 @@ import {
 } from "../../cli/src/core/KBPathResolver.js";
 import { discoverRepos } from "../../cli/src/core/KBRepoDiscoverer.js";
 import { MetadataManager } from "../../cli/src/core/MetadataManager.js";
+import { normalizePathForCompare } from "../../cli/src/core/PathUtils.js";
 import {
 	loadConfig,
 	savePluginSource,
@@ -168,29 +169,6 @@ function hasUnmigratedHooks(content: string): boolean {
 	const hasJolliMemoryHook =
 		lower.includes("stophook") || lower.includes("postcommithook");
 	return hasJolliMemoryHook && !lower.includes("dist-path");
-}
-
-/**
- * Normalizes a filesystem path for equality comparison.
- *
- * Handles three sources of spurious inequality that can leak in between the
- * `context.extensionPath` we get at runtime and the `distDir` we previously
- * wrote to `dist-paths/<source>`:
- *   1. Mixed separators (`\` vs `/`) — Windows freely mixes both.
- *   2. Case differences — Windows/macOS filesystems are case-insensitive by
- *      default, so `C:\Users` and `c:\users` refer to the same directory.
- *   3. Trailing slashes.
- *
- * NOT resolved: symlinks and `..` segments. `realpath` would require extra I/O
- * and could mask legitimate upgrades if either endpoint is a stale symlink.
- */
-function normalizePathForCompare(p: string): string {
-	const unified = p.replace(/\\/g, "/").replace(/\/+$/, "");
-	/* v8 ignore start -- process.platform is fixed per test-runner host (macOS CI); covering the Linux branch would require a cross-platform matrix */
-	return process.platform === "win32" || process.platform === "darwin"
-		? unified.toLowerCase()
-		: unified;
-	/* v8 ignore stop */
 }
 
 // ─── JolliMemoryBridge class ─────────────────────────────────────────────────

--- a/vscode/src/core/PlanService.test.ts
+++ b/vscode/src/core/PlanService.test.ts
@@ -515,8 +515,10 @@ describe("PlanService", () => {
 			expect(saved.plans["test-plan"].contentHashAtCommit).toBeUndefined();
 		});
 
-		it("skips storePlans when plan file does not exist during archive", async () => {
-			// Use a sourcePath different from the PLANS_DIR slug path so we can mock them separately
+		it("skips storePlans when sourcePath does not exist on disk", async () => {
+			// sourcePath gone → both the contentHash branch and the orphan-store branch
+			// skip, but the registry update still happens (so the caller can record
+			// the association even if the file vanished between detection and archive).
 			const entry = makeEntry({
 				editCount: 2,
 				sourcePath: "/other/path/test-plan.md",
@@ -526,13 +528,7 @@ describe("PlanService", () => {
 				plans: { "test-plan": entry },
 			});
 			mockReadFileSync.mockReturnValue("# Test Plan\nContent");
-			// sourcePath exists (line 262 true branch), but planFile in PLANS_DIR does not (line 296 false branch)
-			mockExistsSync.mockImplementation((path: string) => {
-				if (path === "/other/path/test-plan.md") {
-					return true;
-				}
-				return false;
-			});
+			mockExistsSync.mockReturnValue(false);
 
 			const result = await archivePlanForCommit(
 				"test-plan",
@@ -542,6 +538,41 @@ describe("PlanService", () => {
 
 			expect(result).not.toBeNull();
 			expect(storePlans).not.toHaveBeenCalled();
+		});
+
+		it("reads content from entry.sourcePath for external plan paths", async () => {
+			// Regression guard: archivePlanForCommit must read the actual sourcePath,
+			// not a synthetic ~/.claude/plans/<slug>.md path, so external plans like
+			// docs/foo.md are archived correctly.
+			const externalPath = "/repo/docs/foo-plan.md";
+			const entry = makeEntry({
+				slug: "foo-plan",
+				editCount: 1,
+				sourcePath: externalPath,
+			});
+			loadPlansRegistry.mockResolvedValue({
+				version: 1,
+				plans: { "foo-plan": entry },
+			});
+			mockReadFileSync.mockImplementation((path: unknown) =>
+				path === externalPath ? "# External\nbody" : "",
+			);
+			mockExistsSync.mockImplementation(
+				(path: unknown) => path === externalPath,
+			);
+
+			await archivePlanForCommit("foo-plan", "deadbeefcafebabe", CWD);
+
+			expect(storePlans).toHaveBeenCalledWith(
+				[
+					expect.objectContaining({
+						slug: "foo-plan-deadbeef",
+						content: "# External\nbody",
+					}),
+				],
+				expect.any(String),
+				CWD,
+			);
 		});
 	});
 
@@ -868,6 +899,35 @@ describe("PlanService", () => {
 			expect(savePlansRegistry).not.toHaveBeenCalled();
 			// toPlanInfo filters it out since it's still an unchanged archive guard
 			expect(plans.find((p) => p.slug === "guarded-plan")).toBeUndefined();
+		});
+
+		it("toPlanInfo guard reads from entry.sourcePath for external plan paths", async () => {
+			// Regression guard: the archive-guard check must hash entry.sourcePath
+			// (the actual on-disk file, possibly outside ~/.claude/plans/) rather than
+			// a synthetic PLANS_DIR/<slug>.md path.
+			const externalPath = "/repo/docs/foo-plan.md";
+			const guardEntry = makeEntry({
+				slug: "foo-plan",
+				commitHash: "abc12345",
+				contentHashAtCommit: "mock-hash", // matches what mockCreateHash returns
+				sourcePath: externalPath,
+			});
+			loadPlansRegistry.mockResolvedValue({
+				version: 1,
+				plans: { "foo-plan": guardEntry },
+			});
+
+			mockExistsSync.mockImplementation(
+				(path: unknown) => path === externalPath,
+			);
+			mockReadFileSync.mockImplementation((path: unknown) =>
+				path === externalPath ? "# Foo" : "",
+			);
+
+			const plans = await detectPlans(CWD);
+
+			// Hash matches → guard still active → not shown in panel
+			expect(plans.find((p) => p.slug === "foo-plan")).toBeUndefined();
 		});
 
 		it("shows committed plan with changed content (archive guard with modified file)", async () => {

--- a/vscode/src/core/PlanService.test.ts
+++ b/vscode/src/core/PlanService.test.ts
@@ -572,6 +572,11 @@ describe("PlanService", () => {
 				],
 				expect.any(String),
 				CWD,
+				// branch / storage are intentionally undefined — see archivePlanForCommit
+				// comment about FolderStorage resolving the branch from the commit hash
+				// embedded in the slug.
+				undefined,
+				undefined,
 			);
 		});
 	});

--- a/vscode/src/core/PlanService.ts
+++ b/vscode/src/core/PlanService.ts
@@ -115,7 +115,7 @@ function toPlanInfo(entry: PlanEntry, currentBranch?: string): PlanInfo | null {
 
 	// Skip archive guards (source file unchanged)
 	if (entry.contentHashAtCommit) {
-		const planFile = join(getPlansDir(), `${entry.slug}.md`);
+		const planFile = entry.sourcePath;
 		if (
 			!existsSync(planFile) ||
 			hashFileContent(planFile) === entry.contentHashAtCommit
@@ -396,13 +396,19 @@ export async function archivePlanForCommit(
 		cwd,
 	);
 
-	// Store plan file in orphan branch under new slug. branch is intentionally
-	// left undefined: FolderStorage.resolveBranchFromSlug uses the commit hash
-	// embedded in `newSlug` to look up the commit's branch from the manifest /
-	// index — that's the right home for the visible <branch>/plan--<slug>.md.
-	// Passing entry.branch would point at the plan's *home* branch, which can
-	// differ from the commit's branch when editing summaries cross-branch.
-	const planFile = join(getPlansDir(), `${slug}.md`);
+	// Store plan file in orphan branch under new slug.
+	//
+	// Source path: read from entry.sourcePath (same path used for
+	// contentHashAtCommit above) so the two snapshots can't diverge — and so
+	// external plans (e.g. docs/foo.md) are archived correctly.
+	//
+	// storePlans branch arg (below): intentionally left undefined.
+	// FolderStorage.resolveBranchFromSlug uses the commit hash embedded in
+	// `newSlug` to look up the commit's branch from the manifest / index —
+	// that's the right home for the visible <branch>/plan--<slug>.md. Passing
+	// entry.branch would point at the plan's *home* branch, which can differ
+	// from the commit's branch when editing summaries cross-branch.
+	const planFile = entry.sourcePath;
 	if (existsSync(planFile)) {
 		const content = fsReadFileSync(planFile, "utf-8");
 		await storePlans(


### PR DESCRIPTION
<!-- jollimemory-summary-start -->
## Commits in this PR (3)

1. Fix plan system to support external file paths cross-platform (`70c9cdf`)
2. Refactor normalizePathForCompare into shared PathUtils and guard note paths from plan registration (`06cfdd1`)
3. Fix external plan file path handling and note-guard scoping (`0d7c8a0`)

## Plans & Notes (2)

- Test External Path Plan Detection
- Test Canonical Path Plan Detection

## Quick recap (3)

### Commit 1 of 3: Fix plan system to support external file paths cross-platform (`70c9cdf`)

The automatic plan discovery system was extended to recognize plan files stored anywhere on disk. During an AI session, any markdown file the AI writes or edits is now evaluated as a potential plan: files under system directories, dependency folders, and common non-plan filenames are filtered out, while everything else is registered automatically. A collision-resistant slug assignment strategy ensures the same external file always maps to the same registry entry across multiple sessions, even when the registry has been partially cleaned up between runs.

Several related bugs in the plan-viewing, archiving, and commit-association workflows were fixed at the same time. The commands for opening a plan for editing and for rendering a preview previously reconstructed the file path from the plan's short name, which produced a path pointing nowhere for externally stored plans. Both commands now read the actual stored path from the registry, and the edit command surfaces a clear warning when no path can be found. The archiving and commit-association logic received the same fix, ensuring that plans stored outside the standard folder are correctly read and processed when commits are made.

Two silent data-corruption bugs in the plan registration hook were also resolved. The first caused garbled plan identifiers when a Windows-style file path was processed on a Linux system — the kind of mismatch that occurs when a Windows user's session transcript is evaluated on a CI server. A new separator-agnostic filename extraction now works correctly regardless of which operating system runs the hook. The second was an ordering hazard: if a plan file from an arbitrary folder was registered first under a given short name, and then a file with the same short name from the standard plans folder was edited, the hook would silently replace the first file's stored location with the second file's location. Both files are now preserved in the registry under distinct identifiers regardless of the order in which they are edited.

### Commit 2 of 3: Refactor normalizePathForCompare into shared PathUtils and guard note paths from plan registration (`06cfdd1`)

A safety guard was added to the automatic plan detection feature to protect files that a user has explicitly added as reference notes. Previously, if an AI session edited such a file, it would appear twice in the panel — once as the user's note and once as an auto-detected plan — and the plan copy would be pulled into the commit archiving pipeline, storing redundant history the user had no way to remove through normal actions. The guard now intercepts the conflict at the point where plan entries are written to the registry, keeping the panel and the archiving pipeline clean without any additional user intervention.

The path comparison logic used to determine whether two file references point to the same file was consolidated into a single shared module, correcting a gap where Mac users could have the same file treated as two distinct entries when referenced with different letter casing. Both the hook pipeline and the VS Code extension previously maintained separate copies of this logic, and the copies had drifted apart — the hook pipeline's copy was missing the macOS case-insensitivity handling that the extension already had. The shared module now covers Windows, macOS, and Linux consistently across both surfaces. A fix was also applied to correctly handle root-level paths, restoring full equivalence with the original logic the module was designed to replace.

The automated test coverage for these platform-sensitive code paths was strengthened with a new shared utility that lets any test temporarily pin the operating system identity to a specific platform for the duration of a single assertion block. The note-shadowing test was rewritten to use this utility, ensuring the full assertion runs on every CI platform — including Linux runners where the previous version would silently exit early without making any assertions.

### Commit 3 of 3: Fix external plan file path handling and note-guard scoping (`0d7c8a0`)

Several silent data-loss and silent-failure bugs in the plan discovery and archiving pipeline were fixed in this batch of changes. The most consequential fix addressed a long-standing issue where saving a newly discovered plan to the registry would erase all notes and linked issue records that had been stored alongside it — every successful plan discovery was quietly destroying other data. Plans, notes, and linked issues now all survive a registry write-back.

The note-collision guard, which prevents a file from being registered as both a note and a plan, was also corrected in two ways. It previously ignored which branch a note belonged to, so a note added on one branch could block plan registration on a completely different branch where that note was invisible to the user. It also only applied to files discovered through the external path scanner, leaving files in the standard plans directory unprotected. Both gaps are now closed, and the guard's behavior matches what the user can actually see in the interface.

Two user-facing silent failures were also addressed. Clicking the edit button on a plan whose file had been moved or deleted previously produced no response — the error was swallowed internally. The command now shows a warning message identifying the missing file. Separately, plan auto-discovery could silently skip files with non-ASCII characters in their paths on some systems, because the path decoding only handled one specific type of escape sequence. The decoding now handles the full range of escape sequences the transcript format can produce.

## E2E Test (3)
<details>
<summary><strong>1. [70c9cdf] Open a plan stored outside the standard plans folder</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a plan registered in the extension that was created from a file in a custom location (for example, a markdown file inside a project's "docs" folder rather than the default plans folder). The plan should appear in the plans list in the sidebar.

**Steps:**
1. Open the extension's side panel and find the plans list.
2. Locate the plan that was saved in the external "docs" folder (not the default plans location).
3. Right-click the plan (or use the edit icon next to it) to open it for editing.
4. Check which file opens in the editor.

**Expected Results:**
- The file that opens should be the actual markdown file from the external "docs" folder, not a missing or blank file.
- No error message or "file not found" warning should appear.

</blockquote>
</details>
<details>
<summary><strong>2. [70c9cdf] Preview a plan stored at an external file path</strong></summary>
<br>
<blockquote>

**Preconditions:** Have at least one plan registered that lives outside the default plans folder (for example, in a project subfolder). The plan should appear in the plans list.

**Steps:**
1. Open the extension's side panel and find the plans list.
2. Locate the plan stored in the external location.
3. Click the preview button (or right-click and choose "Preview") for that plan.
4. Check what appears in the preview panel.

**Expected Results:**
- The preview panel should open and display the rendered contents of the external markdown file.
- No blank panel, error, or "file not found" message should appear.

</blockquote>
</details>
<details>
<summary><strong>3. [70c9cdf] External plan file is automatically discovered and registered during a session</strong></summary>
<br>
<blockquote>

**Preconditions:** Start a new AI session in the extension. Have a markdown file ready in a project subfolder (for example, "docs/my-feature-plan.md") that is not inside the default plans folder and is not named README, CHANGELOG, or similar.

**Steps:**
1. During an active AI session, ask the assistant to write or edit the markdown file in the "docs" subfolder (for example, "docs/my-feature-plan.md").
2. End or stop the session.
3. Open the extension's side panel and look at the plans list.

**Expected Results:**
- The markdown file from the "docs" subfolder should now appear as a new plan entry in the plans list, with its filename used as the plan name.
- Common files like README.md or CHANGELOG.md should NOT appear in the list even if the assistant touched them during the session.

</blockquote>
</details>

## Topics (18)
<details>
<summary><strong>01 · [70c9cdf] Fix plan registration corruption when external and canonical files share a name</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

If a plan file outside the standard plans folder was registered first under a given short name, and then a file with the same short name inside the standard plans folder was edited, the hook would silently overwrite the external file's stored location with the canonical file's location, corrupting the registry without any warning.

**💡 Decisions Behind the Code**

- **Symmetric collision handling over a targeted upsert guard**: Rather than adding a rejection check inside the upsert function itself, the canonical loop was made to call the same slug-resolution function already used by the external loop. This keeps both code paths symmetric and avoids duplicating collision logic in two places, at the cost of a slightly less obvious data flow for the canonical case.
- **Hash suffix over silent overwrite or hard error**: When a slug collision is detected, the incoming entry receives a hash-derived suffix rather than failing or replacing the existing entry. This preserves both registrations and keeps the registry append-only, matching the product's stated guarantee that existing entries are never renamed or removed by the hook.

**✅ What Was Implemented**

- Updated the canonical plans loop in `StopHook.ts` to route through `resolveUniqueSlug` before writing a registry entry, mirroring the collision-avoidance logic already applied to external paths. If the base slug is already occupied by a different file, the canonical entry now receives a hash-suffixed slug rather than overwriting the existing entry's stored file path.
- Added two regression tests to `StopHook.test.ts`: one verifying that a Windows-style backslash path parsed on a POSIX system yields a clean short slug, and one verifying that a canonical file edited after an external file of the same name lands in a hash-suffixed slot while leaving the external entry's stored path untouched.

**📁 FILES**
- `cli/src/hooks/StopHook.ts`
- `cli/src/hooks/StopHook.test.ts`

</blockquote>
</details>
<details>
<summary><strong>02 · [70c9cdf] Auto-register external markdown plan files discovered during AI sessions</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Plans stored outside the standard plans folder were never picked up by the automatic plan discovery system. Only files inside the designated plans folder were recognized, meaning users who kept plans in a separate notes directory had to register them manually every time.

**💡 Decisions Behind the Code**

- **Blocklist over whitelist for path filtering**: Restricting external plans to specific allowed directories would have cut off the primary real-world use case — a notes directory completely outside the repository. A blocklist of known non-plan paths and filenames covers the common false-positive cases while remaining open to arbitrary layouts, which is the right trade-off for a tool used across heterogeneous project structures.
- **Reverse-lookup slug resolution for idempotency**: A naive approach of "use basename if free, otherwise append hash" would break when the base-slug entry is later cleaned up but the hash-suffixed entry remains — the next session would create a duplicate bare entry alongside the surviving hash-suffixed entry. Scanning all registry entries by normalized source path first ensures the same file always resolves to the same slug regardless of registry churn, at the cost of a linear scan that is negligible given typical registry sizes.
- **No workspace boundary restriction on external paths**: Limiting accepted paths to files inside the current working directory was considered and explicitly rejected. The motivating use case is a standalone notes directory that lives entirely outside any code repository. Enforcing a boundary would silently drop the most common external-plan scenario.

**✅ What Was Implemented**

- Extended `StopHook.ts` to detect any `.md` file touched by a Write or Edit tool call during a session, not just files inside the canonical plans folder. Added a fallback regex, a path-segment exclusion list (`.claude/`, `node_modules/`, `.github/`), a case-insensitive basename blocklist (`README.md`, `CLAUDE.md`, `AGENTS.md`, `CHANGELOG.md`, etc.), and an `isExternalPlanCandidate` guard. The `scanTranscriptForPlans` function now returns both the original slug map and a new `externalPlans` map of absolute paths to edit counts.
- Added `resolveUniqueSlug` in `StopHook.ts` to handle basename collisions between external files and existing registry entries. It first does a reverse-lookup by normalized source path (idempotent across sessions), then falls back to the bare basename if free, or appends an 8-character SHA-256 hash of the path if the basename is already taken by a different file. The early-exit condition in `discoverPlansFromTranscript` was also widened to consider external plans, fixing a bug where a session containing only external plan edits would silently skip the registry write.
- Updated `QueueWorker.ts` to read `entry.sourcePath` directly from the registry entry when locating a plan file for commit association, replacing the previous hard-coded path construction from the slug. Removed the now-dead `plansDir` variable and unused `homedir` import.

**📋 Future Enhancements**

Manual plan registration via the Add Plan UI does not yet support picking external paths — users can only get external plans auto-registered by having the AI edit them during a session. This gap was explicitly deferred to a follow-up.

**📁 FILES**
- `cli/src/hooks/StopHook.ts`
- `cli/src/hooks/QueueWorker.ts`

</blockquote>
</details>
<details>
<summary><strong>03 · [70c9cdf] Fix plan file open and preview commands to use stored registry paths</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The commands for opening a plan for editing and for opening a rendered preview both reconstructed the file path from the plan's short name. For plans stored at arbitrary external locations this produced a path that did not exist, silently opening a missing file or failing with no explanation.

**💡 Decisions Behind the Code**

Surfacing an explicit warning message when no path can be found makes the failure visible and actionable. The previous code would construct a path even when no such file existed, producing a confusing experience with no explanation. The extra registry lookup required for slug-only invocations is cheap and the clarity benefit is significant.

**✅ What Was Implemented**

- Rewrote the edit-plan command in `Extension.ts` to resolve the file path from the registry rather than constructing it from the slug. When invoked from a tree-view click the path comes directly from the plan item; when invoked with only a slug string it falls back to querying the bridge for the full plan list. If no path can be found the command now shows a warning message and returns early.
- Updated the preview command in `Extension.ts` to read the file path from the plans store snapshot, covering external paths in the same way. Removed the now-unused `homedir` import from `Extension.ts`.

**📁 FILES**
- `vscode/src/Extension.ts`

</blockquote>
</details>
<details>
<summary><strong>04 · [70c9cdf] Fix archive and commit-association logic to read stored file paths from registry</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The plan archiving and commit-association code derived the on-disk location of a plan file by reconstructing the path from the slug, ignoring the actual path stored in the registry. This caused silent failures for any plan whose file did not live in the standard plans folder.

**💡 Decisions Behind the Code**

The registry's stored path field was already the canonical record of where a plan file lives — it was simply not being used consistently. Centralizing all file reads through that field eliminates an entire class of path-reconstruction bugs and makes the system correct by construction for both standard and external plans, with no behavioral change for plans already stored in the standard location.

**✅ What Was Implemented**

Updated `PlanService.ts` so the archive guard and the orphan-content read both use `entry.sourcePath` from the registry entry. Fixed a test fixture in `PostCommitHook.helpers.test.ts` where a hard-coded forward-slash path diverged from the platform-native path constructed by the implementation on Windows, causing a spurious test failure after the registry-read change.

**📁 FILES**
- `vscode/src/core/PlanService.ts`
- `cli/src/hooks/PostCommitHook.helpers.test.ts`

</blockquote>
</details>
<details>
<summary><strong>05 · [70c9cdf] Fix plan slug derivation to work correctly across operating systems</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The code used a platform-specific utility to extract the filename from a plan's path. On Linux, this utility does not recognize the Windows backslash separator, so a Windows-style path — such as one produced by a Windows user whose session transcript is processed on a CI server — would generate a garbled identifier containing the entire path string rather than just the filename.

**💡 Decisions Behind the Code**

- **Split-based helper over platform-specific basename**: The split-on-both-separators approach was the originally intended strategy for this scenario. Using the platform-specific utility was a known risk that materialized when Windows-style paths were processed on Linux CI; the fix restores the originally planned approach.
- **Drop path resolution from path comparison rather than special-case it**: Removing the resolve step simplifies the comparison function and eliminates a class of cross-platform mismatch. The trade-off is that relative paths would no longer be normalized to absolute before comparison, but all callers in this codebase already pass absolute paths, so no real-world behavior changes.

**✅ What Was Implemented**

- Added a `basenameNoExt` helper in `StopHook.ts` that splits on both forward-slash and backslash separators before stripping the file extension, making it safe to call on Windows-style paths regardless of the runtime platform. The external plans loop was updated to use this helper in place of the platform-specific `basename` import from Node's path module.
- Updated `normalizePathForCompare` in `StopHook.ts` to avoid using `path.resolve`, which on Windows misinterprets POSIX-absolute paths as relative and resolves them against the working directory. The function now performs only separator and case normalization, which is sufficient given that all callers pass absolute paths.

**📁 FILES**
- `cli/src/hooks/StopHook.ts`

</blockquote>
</details>
<details>
<summary><strong>06 · [70c9cdf] Pin home directory in tests to make them deterministic across platforms</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Test fixtures used hardcoded POSIX-style home directory paths, but the implementation computes paths using the platform's native path joiner. On Windows this mismatch caused the reverse-lookup check to miss, making tests unreliable across environments.

**💡 Decisions Behind the Code**

Mocking the OS home directory at the module level was chosen over rewriting all fixtures to use platform-native separators. Rewriting fixtures would have required conditional logic or helper functions throughout the test file, while a single mock declaration at the top keeps all fixture strings readable and consistent with no per-test overhead.

**✅ What Was Implemented**

Added a module-level OS mock at the top of `StopHook.test.ts` that pins the home directory to a fixed POSIX-style value. This ensures that paths computed by the implementation during tests match the paths written in the fixtures, regardless of whether the tests run on Windows or Linux.

**📁 FILES**
- `cli/src/hooks/StopHook.test.ts`

</blockquote>
</details>
<details>
<summary><strong>07 · [06cfdd1] Fix path normalization edge case for root slash input</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The path comparison utility produced a wrong result when given a root-level path, diverging from the behavior of the original logic it was designed to replace.

**💡 Decisions Behind the Code**

- **Correctness over micro-optimization**: The character-code comparison was introduced to avoid minor overhead on short path strings, but it hurt readability without measurable benefit. Switching to a plain character literal makes the intent immediately obvious to any reader without changing runtime behavior on the short strings that paths represent.
- **Full regex equivalence as the correctness target**: The `end > 1` guard was intended as a safety rail but inadvertently changed observable behavior for the root-slash input case. Restoring exact parity with the regex the function replaced is the only safe contract when this utility is shared across multiple call sites, so the guard was dropped to `end > 0`.

**✅ What Was Implemented**

In `cli/src/core/PathUtils.ts`, the trailing-slash trimming loop in `normalizePathForCompare` was corrected on two points: the lower-bound guard was changed from `end > 1` to `end > 0`, and the slash check was rewritten from a numeric character-code comparison (`=== 47`) to a direct string character comparison (`=== "/"`). Together these restore full equivalence with the original regex behavior, including the edge case where the input is exactly `"/"`, which must normalize to an empty string.

**📁 FILES**
- `cli/src/core/PathUtils.ts`

</blockquote>
</details>
<details>
<summary><strong>08 · [06cfdd1] Guard explicitly registered note files from being auto-classified as plans</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The automatic plan detection feature would silently reclassify a user's manually-added reference document as a plan if an AI session happened to edit it. A file the user had added as a note could end up appearing twice in the panel and get pulled into the commit archiving pipeline with plan semantics the user never intended.

**💡 Decisions Behind the Code**

- **Source-level interception over UI-level deduplication**: The guard was placed at the point where plan entries are written to the registry rather than in the panel's merge or display layer. Filtering at the display layer would still allow the archiving pipeline to treat the file as a plan and store a redundant snapshot in git history — a side effect the user would have no way to undo through normal UI actions. Blocking at the source keeps the registry clean and prevents all downstream consequences without any additional user intervention.
- **No reverse cleanup when a note is added after a plan**: If a user lets the AI edit a file first (registering it as a plan) and only later adds it as a note via the UI, the existing plan entry is not automatically removed. Removing it would require one service to reach into another's data, adding complexity for a low-frequency edge case. The user can suppress the plan entry with the existing Ignore action, which is persistent.

**✅ What Was Implemented**

- In `cli/src/hooks/StopHook.ts`, added a pre-upsert guard in the plan discovery function that builds a normalized set of all paths already registered as markdown notes. Any external markdown file whose path matches an existing note entry is skipped with an info-level log message, preventing it from being registered as a plan.
- Added two regression tests in `cli/src/hooks/StopHook.test.ts`: one verifying that a file already registered as a note is never written to the plans registry, and one verifying the path comparison is case-insensitive on Windows and macOS. The case-insensitive test uses the shared `withPlatform` helper so it runs and asserts on all CI platforms rather than silently passing on Linux.

**📁 FILES**
- `cli/src/hooks/StopHook.ts`

</blockquote>
</details>
<details>
<summary><strong>09 · [06cfdd1] Extract shared path normalization helper into dedicated module</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The same path normalization logic existed as a private copy in two separate parts of the codebase, and the copies had drifted: the hook pipeline's copy only handled Windows case-insensitivity and missed macOS, where the default filesystem is also case-insensitive. Mac users could have the same file treated as two distinct registry entries when referenced with different letter casing.

**💡 Decisions Behind the Code**

- **Shared module over synchronized copies**: Extracting to a shared file was chosen over keeping two copies with a "keep in sync" comment. The macOS bug itself was caused by the copies drifting apart — one had the macOS fix, the other did not. A single source of truth eliminates that class of drift entirely, and the project already uses this pattern for other shared utilities.
- **No OS path resolver in the helper**: Using the OS path resolver to canonicalize paths was considered but rejected. On Windows, the resolver treats POSIX-absolute paths — which can appear in AI-generated transcripts from cross-platform tooling — as relative to the current working directory, producing wrong results. Since all callers already pass absolute paths, separator and case normalization is sufficient and avoids the platform-dependent resolution behavior.
- **Loop over regex for trailing-slash removal**: The scanner alert on the original regex was technically a false positive, as the expression runs in linear time with no catastrophic backtracking risk. However, suppressing it with an inline ignore comment would leave a permanent question mark for future reviewers and open-source contributors. A character-by-character loop was chosen because it is the form the scanner definitively cannot flag regardless of how its heuristics evolve, and it makes the intent immediately readable without regex knowledge.

**✅ What Was Implemented**

- Created `cli/src/core/PathUtils.ts` with a single exported `normalizePathForCompare` function that unifies backslash/forward-slash separators, strips trailing slashes, and lowercases paths on both Windows and macOS. The module includes a detailed comment explaining why `path.resolve` is deliberately avoided.
- The trailing-slash removal was rewritten from a regex to a bounded character-by-character loop to resolve a security scanner alert ahead of the open-source release. A comment was added explaining the rationale so future maintainers do not revert the change without understanding the context. The backslash-unification step was left as a regex since it carries no unbounded quantifier and was not flagged.
- Removed the local private copies from `cli/src/hooks/StopHook.ts` and `vscode/src/JolliMemoryBridge.ts`, replacing both with imports of the shared module. The VS Code extension bundles CLI source at build time, so the cross-package import is supported by the project's existing architecture.
- Added `cli/src/core/PathUtils.test.ts` with test cases covering all three platforms (Windows, macOS, Linux), mixed separators, trailing slashes, the case-sensitivity distinction between Linux and the other two, and edge cases for empty string and root-only slash inputs.

**📁 FILES**
- `cli/src/core/PathUtils.ts`
- `cli/src/hooks/StopHook.ts`
- `vscode/src/JolliMemoryBridge.ts`

</blockquote>
</details>
<details>
<summary><strong>10 · [06cfdd1] Shared test helper for pinning platform identity during test runs</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

A case-sensitivity test in the plan discovery suite was silently skipped on Linux CI runners, meaning the guard against note-shadowing by case-mismatched file paths was never actually verified in automated builds.

**💡 Decisions Behind the Code**

- **Shared helper over per-file copies**: The helper existed in the path utilities test file but was duplicated rather than shared. Extracting it to a dedicated test utilities directory means any future platform-conditional code path gets the same treatment without copy-paste drift. The two copies had already diverged slightly, and the plan discovery test was using a weaker pattern entirely, so a single canonical location eliminates that class of drift.
- **Runtime platform override over compile-time mocking**: The helper redefines the platform value at call time rather than using a module-level mock. This works because the production path-normalization code reads the platform at invocation time rather than at module load time, so the override is visible to the code under test without any module cache manipulation. The trade-off is that concurrent tests in the same file would race on the global object, which the documentation explicitly notes.

**✅ What Was Implemented**

- Created `cli/src/testUtils/withPlatform.ts` exporting a `withPlatform` helper that temporarily overrides `process.platform` for the duration of a sync or async callback, then restores the original value in a finally-equivalent path. The implementation handles both sync throws and async rejections, and includes a JSDoc warning about concurrent test races on the global `process` object.
- Refactored `cli/src/core/PathUtils.test.ts` to import from the new shared location, removing the local copy of the helper and the now-dead `afterEach(vi.restoreAllMocks)` call. Added edge-case assertions for empty string and root-only slash inputs.
- Updated the case-insensitive note-shadowing test in `cli/src/hooks/StopHook.test.ts` to wrap the entire assertion block in `withPlatform("win32", ...)` instead of the previous early-exit guard, so the test runs and asserts on every CI platform including Linux.

**📋 Future Enhancements**

The `FolderStorage.test.ts` typecheck error introduced in a separate commit on main was identified as a pre-existing issue unrelated to this work; it should be investigated and fixed independently.

**📁 FILES**
- `cli/src/testUtils/withPlatform.ts`

</blockquote>
</details>
<details>
<summary><strong>11 · [06cfdd1] Linear issue created to track note-shadowing bug</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The team needed a tracked issue to represent the problem where automatically discovered markdown files could shadow notes that had already been explicitly registered by the user.

**💡 Decisions Behind the Code**

Issue scope was kept narrow — describing only the problem, not the solution — to keep the ticket actionable and avoid pre-committing to an implementation approach before the fix was reviewed.

**✅ What Was Implemented**

Created Linear issue JOLLI-1551 "External plan auto-discovery shadows existing markdown notes" under the JolliMemory label on the JOLLI team, with a corresponding feature branch `feature/jolli-1551`.

**📁 FILES**
- `cli/src/hooks/StopHook.test.ts`

</blockquote>
</details>
<details>
<summary><strong>12 · [0d7c8a0] Note guard now respects branch scope to prevent cross-branch suppression</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

A reviewer identified that the guard preventing a file from being registered as both a note and a plan was ignoring which branch the note belonged to. A note added on one branch could silently block plan auto-registration on a completely different branch, even though that note would be invisible to the user on the current branch.

**💡 Decisions Behind the Code**

- **Branch filter mirrors the note visibility contract**: Notes are already hidden from users on branches other than the one they were added on. The guard was made to mirror that same scoping rule exactly, so the suppression behavior is consistent with what the user can actually see. Applying the guard globally across all branches would have been simpler to implement but would have produced confusing results where invisible notes blocked visible plan registration.
- **Guard placement moved before both loops**: Placing the note-path set construction before the canonical loop (rather than between the two loops as before) was the only way to apply the check symmetrically. The alternative — duplicating the logic in each loop — would have created two diverging implementations that could drift independently.

**✅ What Was Implemented**

- In `cli/src/hooks/StopHook.ts`, the note-source-path set is now built before both the canonical and external plan loops, and each note is skipped when its recorded branch differs from the current working branch. The branch lookup is deferred until at least one note exists, avoiding unnecessary git calls on projects with no notes.
- The same guard was extended to the canonical plans directory loop, which previously had no note-collision check at all. A file under the standard plans folder that a user had explicitly imported as a note will now be skipped during plan auto-registration on the matching branch.
- Regression tests were added to `cli/src/hooks/StopHook.test.ts` covering both the cross-branch case (note on `main` must not suppress registration on `feature/x`) and the canonical-directory case (a canonical plan file that is also a note must be skipped).

**📁 FILES**
- `cli/src/hooks/StopHook.ts`

</blockquote>
</details>
<details>
<summary><strong>13 · [0d7c8a0] Plan registry write-back no longer discards notes and linked issues</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Every time the hook ran and discovered a plan, it was overwriting the registry file with only the plans data, silently erasing any notes or linked issue records that had been stored alongside them. The registry's own load function included a comment warning that sibling fields must be preserved on save, but the save call did not follow that contract.

**💡 Decisions Behind the Code**

The fix uses a spread of the full registry object rather than selectively listing each optional field by name. Listing fields explicitly would require updating the save call every time a new optional field is added to the registry schema, making it easy to repeat the same data-loss bug in the future. The spread approach is self-maintaining and matches the intent already documented in the load function.

**✅ What Was Implemented**

In `cli/src/hooks/StopHook.ts`, the `savePlansRegistry` call at the end of plan discovery was changed to spread the freshly loaded registry object before overriding the version and plans fields. A regression test in `cli/src/hooks/StopHook.test.ts` verifies that after a plan is discovered and written, both the notes map and the linear issues map from the original registry are present in the saved output.

**📁 FILES**
- `cli/src/hooks/StopHook.ts`

</blockquote>
</details>
<details>
<summary><strong>14 · [0d7c8a0] Editing a deleted plan file now shows a warning instead of silently failing</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

When a user clicked the edit button on a plan whose underlying file had been moved or deleted, nothing happened. The editor command would attempt to open the file, the system would throw an error internally, and the error would be swallowed with no feedback to the user — contradicting the stated goal of surfacing file problems explicitly.

**💡 Decisions Behind the Code**

The guard was modeled directly on the equivalent check already present in the plan preview command, making the two commands consistent. The alternative — letting the editor framework surface its own file-not-found error — was rejected because that error is caught by the command registration layer and discarded, producing no visible feedback.

**✅ What Was Implemented**

In `vscode/src/Extension.ts`, the edit-plan command handler now checks whether the file exists on disk before attempting to open it. If the file is missing, a warning message is shown to the user naming the plan and the missing path, and the command returns early. A regression test in `vscode/src/Extension.test.ts` confirms that the document-open call is not made and the warning is shown when the file is absent.

**📁 FILES**
- `vscode/src/Extension.ts`

</blockquote>
</details>
<details>
<summary><strong>15 · [0d7c8a0] File path decoding in transcript scanning made robust against all escape sequences</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The transcript scanner was only unescaping double-backslashes when extracting file paths from recorded tool calls. Any path containing other valid escape sequences — such as unicode-escaped non-ASCII characters — would be stored in a garbled form that would never match a real file on disk, causing those plans to be silently skipped.

**💡 Decisions Behind the Code**

- **Full JSON parse over targeted replacement**: Using the language's own JSON parser to decode the path string handles the complete escape grammar in one step and stays correct if the transcript format evolves. A targeted replacement approach requires enumerating every escape sequence that could appear, and any gap produces a silent mismatch rather than a visible error.
- **Silent skip on parse failure**: A malformed escape sequence in a transcript line is treated as a non-candidate rather than an exception. Crashing or logging an error for every unrecognized line would produce noise on transcripts that contain non-plan tool calls with unusual content; skipping is the least-surprising behavior for a best-effort discovery pass.

**✅ What Was Implemented**

In `cli/src/hooks/StopHook.ts`, the single-replacement unescape was replaced with a full JSON string parse, which handles every escape sequence the transcript format can produce. If the captured path segment is malformed and cannot be parsed, it is treated as a non-candidate and skipped rather than crashing. The platform-agnostic title extraction fallback in the same file was also updated to use a cross-platform path split instead of the system-native basename function, fixing title degradation when Windows-style paths are processed on a Linux host.

**📁 FILES**
- `cli/src/hooks/StopHook.ts`

</blockquote>
</details>
<details>
<summary><strong>16 · [0d7c8a0] Path-segment exclusion list made case-insensitive and extended with missing filenames</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The list of path segments used to exclude non-plan files from auto-discovery was case-sensitive, while the filename portion of the same check was already lowercased before comparison. This asymmetry meant that paths using non-standard casing for folder names like `Node_Modules` or `.GitHub` would pass through the filter on Windows and macOS. Two common filenames were also missing from the exclusion list.

**💡 Decisions Behind the Code**

The case-insensitive flag was applied to the existing patterns rather than lowercasing the path before matching, keeping the fix local and symmetric with how the filename check already works. Adding `README.zh.md` and other locale variants was considered but rejected — the set of possible locale suffixes is unbounded, and the filename check already handles the base `readme.md` case.

**✅ What Was Implemented**

In `cli/src/hooks/StopHook.ts`, the three segment-matching patterns were given case-insensitive flags to match the existing behavior of the filename check. The filename exclusion set was extended with `claude.local.md` (the standard local override file used by the underlying AI tool) and `code_of_conduct.md` (a common open-source project file). The docstring for the candidate-check function was also tightened to accurately describe what the segment patterns actually match.

**📁 FILES**
- `cli/src/hooks/StopHook.ts`

</blockquote>
</details>
<details>
<summary><strong>17 · [0d7c8a0] External plan archiving logs a warning when the source file is missing</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

When the system tried to archive a plan at commit time and the plan's recorded file path no longer existed on disk, it would silently skip the plan with no indication to the developer or user that anything had been missed. This made it impossible to distinguish a successfully skipped plan from one that failed due to a stale registry entry.

**💡 Decisions Behind the Code**

The defensive check for whether the source path field is a valid string was deliberately omitted. The field is typed as required in the data model, and adding runtime type guards for values that the type system guarantees are present would add noise without meaningful protection — the project's own guidelines explicitly discourage defending against conditions the type system rules out.

**✅ What Was Implemented**

In `cli/src/hooks/QueueWorker.ts`, the silent `continue` on a missing source file was replaced with a `log.warn` call that records the plan slug and the missing path before skipping. A comment was added explaining why the path comes from the registry entry directly rather than being reconstructed from the slug, with a cross-reference to the parallel explanation in the plan service. A regression test in `cli/src/hooks/PostCommitHook.helpers.test.ts` verifies that an external plan whose source path is outside the standard plans directory is correctly read and archived.

**📁 FILES**
- `cli/src/hooks/QueueWorker.ts`

</blockquote>
</details>
<details>
<summary><strong>18 · [0d7c8a0] Internal code comments scrubbed of pull request and alert number references</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Two comments added during this work referenced a specific pull request number and a static analysis alert number by their identifiers. The project's contribution guidelines explicitly prohibit this because such references become meaningless once the PR is merged and the alert is resolved, leaving future readers with broken context.

**💡 Decisions Behind the Code**

The technical substance of both comments was preserved — only the ephemeral identifiers were removed. Deleting the explanation entirely would have left future readers without any reason for the non-obvious implementation choices; the goal was to make the reasoning self-contained and durable rather than dependent on external references.

**✅ What Was Implemented**

In `cli/src/core/PathUtils.ts`, the comment explaining the loop-based trailing-slash removal was rewritten to describe the technical reason (the static analysis tool flags unbounded quantifiers as a polynomial-regex risk) without citing the specific alert or PR numbers. In `cli/src/hooks/StopHook.test.ts`, a test comment that linked to an external plan document not checked into the repository was replaced with the actual rationale written inline.

**📁 FILES**
- `cli/src/core/PathUtils.ts`
- `cli/src/hooks/StopHook.ts`

</blockquote>
</details>

---

*Generated by Jolli Memory · May 19, 2026 at 6:20 PM*
<!-- jollimemory-summary-end -->