### PR TITLE
Persist plan/note state across squash/rebase and clean up visible MD

### DIFF
--- a/cli/src/core/DualWriteStorage.test.ts
+++ b/cli/src/core/DualWriteStorage.test.ts
@@ -456,4 +456,114 @@ describe("DualWriteStorage", () => {
 			expect(markDirty).toHaveBeenCalled();
 		});
 	});
+
+	describe("deletePlanVisible delegation", () => {
+		const orphanStub = () =>
+			({
+				readFile: vi.fn(),
+				writeFiles: vi.fn(),
+				listFiles: vi.fn(),
+				exists: vi.fn().mockResolvedValue(true),
+				ensure: vi.fn(),
+			}) as unknown as StorageProvider;
+
+		it("delegates to the folder-side provider", async () => {
+			const folderDelete = vi.fn().mockResolvedValue(undefined);
+			const folder = {
+				readFile: vi.fn(),
+				writeFiles: vi.fn(),
+				listFiles: vi.fn(),
+				exists: vi.fn().mockResolvedValue(true),
+				ensure: vi.fn(),
+				deletePlanVisible: folderDelete,
+			} as unknown as StorageProvider;
+			const dual = new DualWriteStorage(orphanStub(), folder);
+			await dual.deletePlanVisible("my-plan", "main");
+			expect(folderDelete).toHaveBeenCalledWith("my-plan", "main");
+		});
+
+		it("is a no-op when the folder side lacks the method", async () => {
+			const folder = {
+				readFile: vi.fn(),
+				writeFiles: vi.fn(),
+				listFiles: vi.fn(),
+				exists: vi.fn().mockResolvedValue(true),
+				ensure: vi.fn(),
+			} as unknown as StorageProvider;
+			const dual = new DualWriteStorage(orphanStub(), folder);
+			await expect(dual.deletePlanVisible("my-plan", "main")).resolves.toBeUndefined();
+		});
+
+		it("marks dirty when the folder side throws", async () => {
+			const folderDelete = vi.fn().mockRejectedValue(new Error("disk gone"));
+			const markDirty = vi.fn();
+			const folder = {
+				readFile: vi.fn(),
+				writeFiles: vi.fn(),
+				listFiles: vi.fn(),
+				exists: vi.fn().mockResolvedValue(true),
+				ensure: vi.fn(),
+				deletePlanVisible: folderDelete,
+				markDirty,
+			} as unknown as StorageProvider;
+			const dual = new DualWriteStorage(orphanStub(), folder);
+			await dual.deletePlanVisible("my-plan", "main");
+			expect(markDirty).toHaveBeenCalled();
+		});
+	});
+
+	describe("deleteNoteVisible delegation", () => {
+		const orphanStub = () =>
+			({
+				readFile: vi.fn(),
+				writeFiles: vi.fn(),
+				listFiles: vi.fn(),
+				exists: vi.fn().mockResolvedValue(true),
+				ensure: vi.fn(),
+			}) as unknown as StorageProvider;
+
+		it("delegates to the folder-side provider", async () => {
+			const folderDelete = vi.fn().mockResolvedValue(undefined);
+			const folder = {
+				readFile: vi.fn(),
+				writeFiles: vi.fn(),
+				listFiles: vi.fn(),
+				exists: vi.fn().mockResolvedValue(true),
+				ensure: vi.fn(),
+				deleteNoteVisible: folderDelete,
+			} as unknown as StorageProvider;
+			const dual = new DualWriteStorage(orphanStub(), folder);
+			await dual.deleteNoteVisible("note-123", "main");
+			expect(folderDelete).toHaveBeenCalledWith("note-123", "main");
+		});
+
+		it("is a no-op when the folder side lacks the method", async () => {
+			const folder = {
+				readFile: vi.fn(),
+				writeFiles: vi.fn(),
+				listFiles: vi.fn(),
+				exists: vi.fn().mockResolvedValue(true),
+				ensure: vi.fn(),
+			} as unknown as StorageProvider;
+			const dual = new DualWriteStorage(orphanStub(), folder);
+			await expect(dual.deleteNoteVisible("note-123", "main")).resolves.toBeUndefined();
+		});
+
+		it("marks dirty when the folder side throws", async () => {
+			const folderDelete = vi.fn().mockRejectedValue(new Error("disk gone"));
+			const markDirty = vi.fn();
+			const folder = {
+				readFile: vi.fn(),
+				writeFiles: vi.fn(),
+				listFiles: vi.fn(),
+				exists: vi.fn().mockResolvedValue(true),
+				ensure: vi.fn(),
+				deleteNoteVisible: folderDelete,
+				markDirty,
+			} as unknown as StorageProvider;
+			const dual = new DualWriteStorage(orphanStub(), folder);
+			await dual.deleteNoteVisible("note-123", "main");
+			expect(markDirty).toHaveBeenCalled();
+		});
+	});
 });

--- a/cli/src/core/DualWriteStorage.ts
+++ b/cli/src/core/DualWriteStorage.ts
@@ -69,6 +69,26 @@ export class DualWriteStorage implements StorageProvider {
 		}
 	}
 
+	async deletePlanVisible(slug: string, branch: string): Promise<void> {
+		if (!this.shadow.deletePlanVisible) return;
+		try {
+			await this.shadow.deletePlanVisible(slug, branch);
+		} catch (err) {
+			log.warn("Shadow deletePlanVisible failed (folder storage) for %s on %s: %s", slug, branch, errMsg(err));
+			this.shadow.markDirty?.(`deletePlanVisible ${branch}/${slug}`);
+		}
+	}
+
+	async deleteNoteVisible(id: string, branch: string): Promise<void> {
+		if (!this.shadow.deleteNoteVisible) return;
+		try {
+			await this.shadow.deleteNoteVisible(id, branch);
+		} catch (err) {
+			log.warn("Shadow deleteNoteVisible failed (folder storage) for %s on %s: %s", id, branch, errMsg(err));
+			this.shadow.markDirty?.(`deleteNoteVisible ${branch}/${id}`);
+		}
+	}
+
 	async listFiles(prefix: string): Promise<string[]> {
 		return this.primary.listFiles(prefix);
 	}

--- a/cli/src/core/FolderStorage.test.ts
+++ b/cli/src/core/FolderStorage.test.ts
@@ -563,6 +563,120 @@ describe("FolderStorage", () => {
 		});
 	});
 
+	describe("deletePlanVisible", () => {
+		beforeEach(async () => {
+			await storage.ensure();
+		});
+
+		it("deletes the visible plan--<slug>.md and leaves .jolli/plans/<slug>.md untouched", async () => {
+			await storage.writeFiles(
+				[{ path: "plans/my-plan-abc12345.md", content: "# Plan\n\nBody", branch: "feature/login" }],
+				"seed plan",
+			);
+			const visiblePath = join(rootPath, "feature-login", "plan--my-plan-abc12345.md");
+			const hiddenPath = join(rootPath, ".jolli", "plans", "my-plan-abc12345.md");
+			expect(existsSync(visiblePath)).toBe(true);
+			expect(existsSync(hiddenPath)).toBe(true);
+
+			await storage.deletePlanVisible("my-plan-abc12345", "feature/login");
+
+			expect(existsSync(visiblePath)).toBe(false);
+			// Hidden mirror is intentionally preserved — the orphan branch source
+			// stays addressable so a re-association regenerates the visible copy.
+			expect(existsSync(hiddenPath)).toBe(true);
+			expect(metadataManager.findById("plan:my-plan-abc12345")).toBeUndefined();
+		});
+
+		it("is idempotent on a missing file", async () => {
+			await expect(storage.deletePlanVisible("ghost-plan", "ghost-branch")).resolves.toBeUndefined();
+		});
+
+		it("preserves a hand-edited plan md (fingerprint mismatch)", async () => {
+			await storage.writeFiles(
+				[{ path: "plans/edited-plan-abc12345.md", content: "# Plan\n\nOriginal", branch: "main" }],
+				"seed plan",
+			);
+			const visiblePath = join(rootPath, "main", "plan--edited-plan-abc12345.md");
+			expect(existsSync(visiblePath)).toBe(true);
+
+			writeFileSync(visiblePath, "---\ntype: plan\n---\n\n# Hand-edited\n\nUser changed this", "utf-8");
+
+			await storage.deletePlanVisible("edited-plan-abc12345", "main");
+
+			expect(existsSync(visiblePath)).toBe(true);
+			expect(readFileSync(visiblePath, "utf-8")).toContain("Hand-edited");
+			// Manifest entry kept — the hand-edited file is still tracked.
+			expect(metadataManager.findById("plan:edited-plan-abc12345")).toBeDefined();
+		});
+
+		it("falls back to <branchFolder>/plan--<slug>.md when no manifest entry exists", async () => {
+			// Simulate a stale visible file without a manifest record (e.g. from
+			// a folder that pre-dates manifest tracking).
+			mkdirSync(join(rootPath, "main"), { recursive: true });
+			const visiblePath = join(rootPath, "main", "plan--orphan-plan.md");
+			writeFileSync(visiblePath, "# Stale", "utf-8");
+			expect(metadataManager.findById("plan:orphan-plan")).toBeUndefined();
+
+			await storage.deletePlanVisible("orphan-plan", "main");
+
+			expect(existsSync(visiblePath)).toBe(false);
+		});
+	});
+
+	describe("deleteNoteVisible", () => {
+		beforeEach(async () => {
+			await storage.ensure();
+		});
+
+		it("deletes the visible note--<id>.md and leaves .jolli/notes/<id>.md untouched", async () => {
+			await storage.writeFiles(
+				[{ path: "notes/my-note-abc12345.md", content: "# Note\n\nBody", branch: "feature/x" }],
+				"seed note",
+			);
+			const visiblePath = join(rootPath, "feature-x", "note--my-note-abc12345.md");
+			const hiddenPath = join(rootPath, ".jolli", "notes", "my-note-abc12345.md");
+			expect(existsSync(visiblePath)).toBe(true);
+			expect(existsSync(hiddenPath)).toBe(true);
+
+			await storage.deleteNoteVisible("my-note-abc12345", "feature/x");
+
+			expect(existsSync(visiblePath)).toBe(false);
+			expect(existsSync(hiddenPath)).toBe(true);
+			expect(metadataManager.findById("note:my-note-abc12345")).toBeUndefined();
+		});
+
+		it("is idempotent on a missing file", async () => {
+			await expect(storage.deleteNoteVisible("ghost-note", "ghost-branch")).resolves.toBeUndefined();
+		});
+
+		it("preserves a hand-edited note md (fingerprint mismatch)", async () => {
+			await storage.writeFiles(
+				[{ path: "notes/edited-note-abc12345.md", content: "# Note\n\nOriginal", branch: "main" }],
+				"seed note",
+			);
+			const visiblePath = join(rootPath, "main", "note--edited-note-abc12345.md");
+			expect(existsSync(visiblePath)).toBe(true);
+
+			writeFileSync(visiblePath, "---\ntype: note\n---\n\n# Hand-edited", "utf-8");
+
+			await storage.deleteNoteVisible("edited-note-abc12345", "main");
+
+			expect(existsSync(visiblePath)).toBe(true);
+			expect(metadataManager.findById("note:edited-note-abc12345")).toBeDefined();
+		});
+
+		it("falls back to <branchFolder>/note--<id>.md when no manifest entry exists", async () => {
+			mkdirSync(join(rootPath, "main"), { recursive: true });
+			const visiblePath = join(rootPath, "main", "note--orphan-note.md");
+			writeFileSync(visiblePath, "# Stale", "utf-8");
+			expect(metadataManager.findById("note:orphan-note")).toBeUndefined();
+
+			await storage.deleteNoteVisible("orphan-note", "main");
+
+			expect(existsSync(visiblePath)).toBe(false);
+		});
+	});
+
 	describe("regenerateVisibleMarkdown", () => {
 		beforeEach(async () => {
 			await storage.ensure();

--- a/cli/src/core/FolderStorage.ts
+++ b/cli/src/core/FolderStorage.ts
@@ -128,15 +128,46 @@ export class FolderStorage implements StorageProvider {
 	 * See StorageProvider.deleteVisibleMarkdown for the contract.
 	 */
 	async deleteVisibleMarkdown(entry: SummaryIndexEntry): Promise<void> {
-		const manifestEntry = this.metadataManager.findById(entry.commitHash);
-		const branchFolder = this.metadataManager.resolveFolderForBranch(entry.branch);
 		const slug = FolderStorage.slugify(entry.commitMessage);
 		const hash8 = entry.commitHash.substring(0, 8);
-		const relativePath = manifestEntry?.path ?? `${branchFolder}/${slug}-${hash8}.md`;
+		await this.deleteVisibleArtifact(entry.commitHash, entry.branch, `${slug}-${hash8}.md`);
+	}
+
+	/**
+	 * See StorageProvider.deletePlanVisible for the contract. Delegates to the
+	 * shared `deleteVisibleArtifact` helper with the plan's manifest fileId
+	 * (`plan:<slug>`) and the conventional `plan--<slug>.md` filename.
+	 */
+	async deletePlanVisible(slug: string, branch: string): Promise<void> {
+		await this.deleteVisibleArtifact(`plan:${slug}`, branch, `plan--${slug}.md`);
+	}
+
+	/**
+	 * See StorageProvider.deleteNoteVisible for the contract. Delegates to the
+	 * shared `deleteVisibleArtifact` helper with the note's manifest fileId
+	 * (`note:<id>`) and the conventional `note--<id>.md` filename.
+	 */
+	async deleteNoteVisible(id: string, branch: string): Promise<void> {
+		await this.deleteVisibleArtifact(`note:${id}`, branch, `note--${id}.md`);
+	}
+
+	/**
+	 * Shared body for `deleteVisibleMarkdown` (summary), `deletePlanVisible`,
+	 * and `deleteNoteVisible`. Looks up the manifest entry by `fileId`, falls
+	 * back to a convention-based `<branchFolder>/<fallbackFileName>` path when
+	 * the manifest record is missing, fingerprint-guards against hand-edits,
+	 * and drops the manifest record on successful delete (or when the file is
+	 * already gone — keeping a manifest entry for a deleted file would let
+	 * future scans re-trip on a ghost path).
+	 */
+	private async deleteVisibleArtifact(fileId: string, branch: string, fallbackFileName: string): Promise<void> {
+		const manifestEntry = this.metadataManager.findById(fileId);
+		const branchFolder = this.metadataManager.resolveFolderForBranch(branch);
+		const relativePath = manifestEntry?.path ?? `${branchFolder}/${fallbackFileName}`;
 		const absPath = join(this.rootPath, relativePath);
 
 		if (!existsSync(absPath)) {
-			if (manifestEntry) this.metadataManager.removeFromManifest(entry.commitHash);
+			if (manifestEntry) this.metadataManager.removeFromManifest(fileId);
 			return;
 		}
 
@@ -161,13 +192,13 @@ export class FolderStorage implements StorageProvider {
 
 		try {
 			unlinkSync(absPath);
-			if (manifestEntry) this.metadataManager.removeFromManifest(entry.commitHash);
+			if (manifestEntry) this.metadataManager.removeFromManifest(fileId);
 			log.info("Deleted visible MD: %s", relativePath);
 			/* v8 ignore start -- TOCTOU defense: a concurrent writer removes the file between existsSync and unlinkSync. Requires multi-process scheduling to reproduce; the ENOENT-vs-rethrow split is asserted at code-review level. */
 		} catch (err) {
 			const code = (err as NodeJS.ErrnoException).code;
 			if (code === "ENOENT") {
-				if (manifestEntry) this.metadataManager.removeFromManifest(entry.commitHash);
+				if (manifestEntry) this.metadataManager.removeFromManifest(fileId);
 				return;
 			}
 			throw err;

--- a/cli/src/core/SessionTracker.test.ts
+++ b/cli/src/core/SessionTracker.test.ts
@@ -698,6 +698,173 @@ describe("SessionTracker", () => {
 			await expect(loadPlansRegistry(tempDir)).resolves.toEqual(before);
 		});
 
+		// Squash / rebase reuses associatePlanWithCommit to re-anchor metadata on the
+		// new commit. Pre-fix, only the archive entry's commitHash got updated and the
+		// guard entry was left pointing at the soon-to-be-orphan commit — so a user
+		// edit to the source file would "revive" the guard with a stale hash label.
+		describe("guard-entry migration on squash/rebase", () => {
+			it("should migrate the guard entry's commitHash and recompute contentHashAtCommit when the file is unchanged", async () => {
+				const planFile = join(tempDir, "plan.md");
+				const planBody = "# My Plan\n\nstep 1\n";
+				await writeFile(planFile, planBody, "utf-8");
+				const { createHash } = await import("node:crypto");
+				const fileHash = createHash("sha256").update(planBody).digest("hex");
+
+				const before = {
+					version: 1 as const,
+					plans: {
+						"my-plan": {
+							slug: "my-plan",
+							title: "My Plan",
+							sourcePath: planFile,
+							addedAt: "2026-03-01T10:00:00Z",
+							updatedAt: "2026-03-01T10:00:00Z",
+							branch: "feature/x",
+							commitHash: "35080b05360866b87dc03dfe9204ec148f263660",
+							contentHashAtCommit: fileHash,
+							editCount: 1,
+						},
+						"my-plan-35080b05": {
+							slug: "my-plan-35080b05",
+							title: "My Plan",
+							sourcePath: planFile,
+							addedAt: "2026-03-01T10:00:00Z",
+							updatedAt: "2026-03-01T10:00:00Z",
+							branch: "feature/x",
+							commitHash: "35080b05360866b87dc03dfe9204ec148f263660",
+							editCount: 1,
+						},
+					},
+				};
+				await savePlansRegistry(before as unknown as Parameters<typeof savePlansRegistry>[0], tempDir);
+
+				await associatePlanWithCommit("my-plan-35080b05", "6c66a12e50f0cf1129f8e63b340897832d22ecee", tempDir);
+
+				const after = await loadPlansRegistry(tempDir);
+				expect(after.plans["my-plan-35080b05"]?.commitHash).toBe("6c66a12e50f0cf1129f8e63b340897832d22ecee");
+				expect(after.plans["my-plan"]?.commitHash).toBe("6c66a12e50f0cf1129f8e63b340897832d22ecee");
+				expect(after.plans["my-plan"]?.contentHashAtCommit).toBe(fileHash);
+			});
+
+			it("should preserve contentHashAtCommit even when the source file has been edited since archive (revival signal must survive squash)", async () => {
+				// squash/rebase only rewrites the commit hash; it does not commit
+				// the working-tree state. If the user edited the source between the
+				// original archive and the squash, those edits remain uncommitted —
+				// the next post-commit detection must still see liveHash !==
+				// contentHashAtCommit to surface the revival. Recomputing from the
+				// live file here would silently consume that signal.
+				const planFile = join(tempDir, "plan.md");
+				const oldBody = "# Old Plan\n";
+				const newBody = "# New Plan\n\nadded after squash\n";
+				await writeFile(planFile, newBody, "utf-8");
+				const { createHash } = await import("node:crypto");
+				const oldHash = createHash("sha256").update(oldBody).digest("hex");
+				const newHash = createHash("sha256").update(newBody).digest("hex");
+				expect(oldHash).not.toBe(newHash);
+
+				const before = {
+					version: 1 as const,
+					plans: {
+						"my-plan": {
+							slug: "my-plan",
+							title: "My Plan",
+							sourcePath: planFile,
+							addedAt: "2026-03-01T10:00:00Z",
+							updatedAt: "2026-03-01T10:00:00Z",
+							branch: "feature/x",
+							commitHash: "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+							contentHashAtCommit: oldHash,
+							editCount: 1,
+						},
+						"my-plan-deadbeef": {
+							slug: "my-plan-deadbeef",
+							title: "My Plan",
+							sourcePath: planFile,
+							addedAt: "2026-03-01T10:00:00Z",
+							updatedAt: "2026-03-01T10:00:00Z",
+							branch: "feature/x",
+							commitHash: "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+							editCount: 1,
+						},
+					},
+				};
+				await savePlansRegistry(before as unknown as Parameters<typeof savePlansRegistry>[0], tempDir);
+
+				await associatePlanWithCommit("my-plan-deadbeef", "feedfacefeedfacefeedfacefeedfacefeedface", tempDir);
+
+				const after = await loadPlansRegistry(tempDir);
+				expect(after.plans["my-plan"]?.commitHash).toBe("feedfacefeedfacefeedfacefeedfacefeedface");
+				expect(after.plans["my-plan"]?.contentHashAtCommit).toBe(oldHash);
+			});
+
+			it("should preserve the existing contentHashAtCommit when the source file is missing", async () => {
+				const before = {
+					version: 1 as const,
+					plans: {
+						"my-plan": {
+							slug: "my-plan",
+							title: "My Plan",
+							sourcePath: join(tempDir, "does-not-exist.md"),
+							addedAt: "2026-03-01T10:00:00Z",
+							updatedAt: "2026-03-01T10:00:00Z",
+							branch: "feature/x",
+							commitHash: "35080b05360866b87dc03dfe9204ec148f263660",
+							contentHashAtCommit: "stalehash",
+							editCount: 1,
+						},
+						"my-plan-35080b05": {
+							slug: "my-plan-35080b05",
+							title: "My Plan",
+							sourcePath: join(tempDir, "does-not-exist.md"),
+							addedAt: "2026-03-01T10:00:00Z",
+							updatedAt: "2026-03-01T10:00:00Z",
+							branch: "feature/x",
+							commitHash: "35080b05360866b87dc03dfe9204ec148f263660",
+							editCount: 1,
+						},
+					},
+				};
+				await savePlansRegistry(before as unknown as Parameters<typeof savePlansRegistry>[0], tempDir);
+
+				await associatePlanWithCommit("my-plan-35080b05", "6c66a12e50f0cf1129f8e63b340897832d22ecee", tempDir);
+
+				const after = await loadPlansRegistry(tempDir);
+				expect(after.plans["my-plan"]?.commitHash).toBe("6c66a12e50f0cf1129f8e63b340897832d22ecee");
+				expect(after.plans["my-plan"]?.contentHashAtCommit).toBe("stalehash");
+			});
+
+			it("should not migrate any guard when the archive id has no -<shortHash> suffix", async () => {
+				// Defensive: a caller could pass a base-slug-shaped id (no suffix). The
+				// function must not invent a guard target out of an unrelated entry.
+				const before = {
+					version: 1 as const,
+					plans: {
+						"my-plan": {
+							slug: "my-plan",
+							title: "My Plan",
+							sourcePath: join(tempDir, "plan.md"),
+							addedAt: "2026-03-01T10:00:00Z",
+							updatedAt: "2026-03-01T10:00:00Z",
+							branch: "feature/x",
+							commitHash: null,
+							contentHashAtCommit: "stalehash",
+							editCount: 1,
+						},
+					},
+				};
+				await savePlansRegistry(before as unknown as Parameters<typeof savePlansRegistry>[0], tempDir);
+
+				await associatePlanWithCommit("my-plan", "6c66a12e50f0cf1129f8e63b340897832d22ecee", tempDir);
+
+				const after = await loadPlansRegistry(tempDir);
+				// Direct migration of the named entry still happens, but contentHashAtCommit
+				// is left alone — only guard-entry migration triggered through an archive id
+				// recomputes it.
+				expect(after.plans["my-plan"]?.commitHash).toBe("6c66a12e50f0cf1129f8e63b340897832d22ecee");
+				expect(after.plans["my-plan"]?.contentHashAtCommit).toBe("stalehash");
+			});
+		});
+
 		it("should load a single plan entry by slug", async () => {
 			const registry = {
 				version: 1 as const,
@@ -784,6 +951,200 @@ describe("SessionTracker", () => {
 			await associateNoteWithCommit("missing-note", "abcdef1234567890", tempDir);
 
 			await expect(loadPlansRegistry(tempDir)).resolves.toEqual(before);
+		});
+
+		describe("guard-entry migration on squash/rebase", () => {
+			it("should migrate the guard entry's commitHash and recompute contentHashAtCommit when the source file is unchanged", async () => {
+				const noteFile = join(tempDir, "note.md");
+				const body = "# Active AI Conversations — Design Document\n\nA note body.\n";
+				await writeFile(noteFile, body, "utf-8");
+				const { createHash } = await import("node:crypto");
+				const fileHash = createHash("sha256").update(body).digest("hex");
+
+				const before = {
+					version: 1 as const,
+					plans: {},
+					notes: {
+						"note-035b": {
+							id: "note-035b",
+							title: "Active AI Conversations — Design Document",
+							format: "markdown" as const,
+							sourcePath: noteFile,
+							addedAt: "2026-03-01T10:00:00Z",
+							updatedAt: "2026-03-01T10:00:00Z",
+							branch: "feature/active-conversations",
+							commitHash: "35080b05360866b87dc03dfe9204ec148f263660",
+							contentHashAtCommit: fileHash,
+						},
+						"note-035b-35080b05": {
+							id: "note-035b-35080b05",
+							title: "Active AI Conversations — Design Document",
+							format: "markdown" as const,
+							sourcePath: noteFile,
+							addedAt: "2026-03-01T10:00:00Z",
+							updatedAt: "2026-03-01T10:00:00Z",
+							branch: "feature/active-conversations",
+							commitHash: "35080b05360866b87dc03dfe9204ec148f263660",
+						},
+					},
+				};
+				await savePlansRegistry(before as unknown as Parameters<typeof savePlansRegistry>[0], tempDir);
+
+				await associateNoteWithCommit(
+					"note-035b-35080b05",
+					"6c66a12e50f0cf1129f8e63b340897832d22ecee",
+					tempDir,
+				);
+
+				const after = await loadPlansRegistry(tempDir);
+				expect(after.notes?.["note-035b-35080b05"]?.commitHash).toBe(
+					"6c66a12e50f0cf1129f8e63b340897832d22ecee",
+				);
+				expect(after.notes?.["note-035b"]?.commitHash).toBe("6c66a12e50f0cf1129f8e63b340897832d22ecee");
+				expect(after.notes?.["note-035b"]?.contentHashAtCommit).toBe(fileHash);
+			});
+
+			it("should preserve contentHashAtCommit even when the source file has been edited since archive (revival signal must survive squash)", async () => {
+				// Same invariant as the plan-side test: squash only rewrites the
+				// commit hash, so contentHashAtCommit (the archive-time anchor)
+				// must not be replaced with the live file hash — otherwise the
+				// revival signal for uncommitted edits is lost.
+				const noteFile = join(tempDir, "note.md");
+				const oldBody = "# Old Note\n";
+				const newBody = "# New Note\n\nadded after squash\n";
+				await writeFile(noteFile, newBody, "utf-8");
+				const { createHash } = await import("node:crypto");
+				const oldHash = createHash("sha256").update(oldBody).digest("hex");
+				const newHash = createHash("sha256").update(newBody).digest("hex");
+				expect(oldHash).not.toBe(newHash);
+
+				const before = {
+					version: 1 as const,
+					plans: {},
+					notes: {
+						"note-035b": {
+							id: "note-035b",
+							title: "Old Note",
+							format: "markdown" as const,
+							sourcePath: noteFile,
+							addedAt: "2026-03-01T10:00:00Z",
+							updatedAt: "2026-03-01T10:00:00Z",
+							branch: "feature/x",
+							commitHash: "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+							contentHashAtCommit: oldHash,
+						},
+						"note-035b-deadbeef": {
+							id: "note-035b-deadbeef",
+							title: "Old Note",
+							format: "markdown" as const,
+							sourcePath: noteFile,
+							addedAt: "2026-03-01T10:00:00Z",
+							updatedAt: "2026-03-01T10:00:00Z",
+							branch: "feature/x",
+							commitHash: "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+						},
+					},
+				};
+				await savePlansRegistry(before as unknown as Parameters<typeof savePlansRegistry>[0], tempDir);
+
+				await associateNoteWithCommit(
+					"note-035b-deadbeef",
+					"feedfacefeedfacefeedfacefeedfacefeedface",
+					tempDir,
+				);
+
+				const after = await loadPlansRegistry(tempDir);
+				expect(after.notes?.["note-035b"]?.commitHash).toBe("feedfacefeedfacefeedfacefeedfacefeedface");
+				expect(after.notes?.["note-035b"]?.contentHashAtCommit).toBe(oldHash);
+			});
+
+			it("should preserve the existing contentHashAtCommit when the source file is missing", async () => {
+				const before = {
+					version: 1 as const,
+					plans: {},
+					notes: {
+						"note-035b": {
+							id: "note-035b",
+							title: "Gone Note",
+							format: "markdown" as const,
+							sourcePath: join(tempDir, "missing.md"),
+							addedAt: "2026-03-01T10:00:00Z",
+							updatedAt: "2026-03-01T10:00:00Z",
+							branch: "feature/x",
+							commitHash: "35080b05360866b87dc03dfe9204ec148f263660",
+							contentHashAtCommit: "stalehash",
+						},
+						"note-035b-35080b05": {
+							id: "note-035b-35080b05",
+							title: "Gone Note",
+							format: "markdown" as const,
+							sourcePath: join(tempDir, "missing.md"),
+							addedAt: "2026-03-01T10:00:00Z",
+							updatedAt: "2026-03-01T10:00:00Z",
+							branch: "feature/x",
+							commitHash: "35080b05360866b87dc03dfe9204ec148f263660",
+						},
+					},
+				};
+				await savePlansRegistry(before as unknown as Parameters<typeof savePlansRegistry>[0], tempDir);
+
+				await associateNoteWithCommit(
+					"note-035b-35080b05",
+					"6c66a12e50f0cf1129f8e63b340897832d22ecee",
+					tempDir,
+				);
+
+				const after = await loadPlansRegistry(tempDir);
+				expect(after.notes?.["note-035b"]?.commitHash).toBe("6c66a12e50f0cf1129f8e63b340897832d22ecee");
+				expect(after.notes?.["note-035b"]?.contentHashAtCommit).toBe("stalehash");
+			});
+
+			it("should leave the guard alone when its commitHash does not match the archive id suffix", async () => {
+				// Defensive: if the guard already points at a different commit (e.g.
+				// user manually edited plans.json, or a parallel migration ran first),
+				// don't clobber its commitHash based on a stale archive id.
+				const before = {
+					version: 1 as const,
+					plans: {},
+					notes: {
+						"note-035b": {
+							id: "note-035b",
+							title: "Note",
+							format: "snippet" as const,
+							addedAt: "2026-03-01T10:00:00Z",
+							updatedAt: "2026-03-01T10:00:00Z",
+							branch: "feature/x",
+							commitHash: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+							contentHashAtCommit: "stalehash",
+						},
+						"note-035b-deadbeef": {
+							id: "note-035b-deadbeef",
+							title: "Note",
+							format: "snippet" as const,
+							addedAt: "2026-03-01T10:00:00Z",
+							updatedAt: "2026-03-01T10:00:00Z",
+							branch: "feature/x",
+							commitHash: "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+						},
+					},
+				};
+				await savePlansRegistry(before as unknown as Parameters<typeof savePlansRegistry>[0], tempDir);
+
+				await associateNoteWithCommit(
+					"note-035b-deadbeef",
+					"6c66a12e50f0cf1129f8e63b340897832d22ecee",
+					tempDir,
+				);
+
+				const after = await loadPlansRegistry(tempDir);
+				expect(after.notes?.["note-035b-deadbeef"]?.commitHash).toBe(
+					"6c66a12e50f0cf1129f8e63b340897832d22ecee",
+				);
+				// Guard untouched because its commitHash didn't match the archive id's
+				// `deadbeef` suffix — different commit lineage.
+				expect(after.notes?.["note-035b"]?.commitHash).toBe("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+				expect(after.notes?.["note-035b"]?.contentHashAtCommit).toBe("stalehash");
+			});
 		});
 	});
 

--- a/cli/src/core/SessionTracker.ts
+++ b/cli/src/core/SessionTracker.ts
@@ -741,8 +741,29 @@ export async function savePlansRegistry(registry: PlansRegistry, cwd?: string): 
 }
 
 /**
+ * If `archivedKey` looks like a per-commit archive id (base + `-XXXXXXXX` short
+ * hash), returns the base/guard key plus the embedded oldShortHash. Otherwise
+ * returns null — callers then skip guard-entry migration entirely. This is the
+ * single inflection point that distinguishes "first-time association" from
+ * "squash/rebase re-anchoring of an existing archive".
+ */
+function splitArchivedKey(archivedKey: string): { baseKey: string; oldShortHash: string } | null {
+	const match = archivedKey.match(/^(.+)-([0-9a-f]{8})$/);
+	if (!match) return null;
+	return { baseKey: match[1] as string, oldShortHash: match[2] as string };
+}
+
+/**
  * Updates a single plan entry's commitHash in the registry.
- * Called by PostCommitHook (on commit) and PostRewriteHook (on rebase).
+ * Called via `reassociateMetadata` from `QueueWorker` after squash / rebase.
+ *
+ * When `slug` is an archive id (`<baseSlug>-<oldShortHash>`) and the
+ * corresponding guard entry exists with `commitHash` matching that old short
+ * hash, the guard is migrated alongside it: its `commitHash` is moved to the
+ * new hash. `contentHashAtCommit` is left untouched — squash/rebase only
+ * rewrites commit metadata, not file content, so the archive-time anchor must
+ * survive so that uncommitted edits to the source still surface as a revived
+ * guard on the next post-commit detection.
  */
 export async function associatePlanWithCommit(slug: string, commitHash: string, cwd?: string): Promise<void> {
 	const registry = await loadPlansRegistry(cwd);
@@ -751,18 +772,36 @@ export async function associatePlanWithCommit(slug: string, commitHash: string, 
 		log.debug("associatePlanWithCommit: slug %s not in registry, skipping", slug);
 		return;
 	}
-	const updated: PlansRegistry = {
-		...registry,
-		plans: {
-			...registry.plans,
-			[slug]: { ...entry, commitHash, updatedAt: new Date().toISOString() },
-		},
+	const now = new Date().toISOString();
+	const nextPlans: Record<string, PlanEntry> = {
+		...registry.plans,
+		[slug]: { ...entry, commitHash, updatedAt: now },
 	};
+
+	const split = splitArchivedKey(slug);
+	if (split) {
+		const guard = registry.plans[split.baseKey];
+		if (guard?.contentHashAtCommit && guard.commitHash?.startsWith(split.oldShortHash)) {
+			nextPlans[split.baseKey] = {
+				...guard,
+				commitHash,
+				updatedAt: now,
+			};
+			log.info("associatePlanWithCommit: also migrated guard %s → %s", split.baseKey, commitHash.substring(0, 8));
+		}
+	}
+
+	const updated: PlansRegistry = { ...registry, plans: nextPlans };
 	await savePlansRegistry(updated, cwd);
 	log.info("associatePlanWithCommit: %s → %s", slug, commitHash.substring(0, 8));
 }
 
-/** Updates the commitHash for a note entry in the registry (used after squash/rebase). */
+/**
+ * Updates the commitHash for a note entry in the registry (used after squash/rebase).
+ *
+ * Same guard-entry migration semantics as `associatePlanWithCommit` — see that
+ * function's doc-comment for the rationale.
+ */
 export async function associateNoteWithCommit(noteId: string, commitHash: string, cwd?: string): Promise<void> {
 	const registry = await loadPlansRegistry(cwd);
 	const entry = registry.notes?.[noteId];
@@ -770,14 +809,27 @@ export async function associateNoteWithCommit(noteId: string, commitHash: string
 		log.debug("associateNoteWithCommit: id %s not in registry, skipping", noteId);
 		return;
 	}
+	const now = new Date().toISOString();
 	const notes = registry.notes as NonNullable<PlansRegistry["notes"]>;
-	const updated: PlansRegistry = {
-		...registry,
-		notes: {
-			...notes,
-			[noteId]: { ...entry, commitHash, updatedAt: new Date().toISOString() },
-		},
+	const nextNotes: Record<string, NoteEntry> = {
+		...notes,
+		[noteId]: { ...entry, commitHash, updatedAt: now },
 	};
+
+	const split = splitArchivedKey(noteId);
+	if (split) {
+		const guard = notes[split.baseKey];
+		if (guard?.contentHashAtCommit && guard.commitHash?.startsWith(split.oldShortHash)) {
+			nextNotes[split.baseKey] = {
+				...guard,
+				commitHash,
+				updatedAt: now,
+			};
+			log.info("associateNoteWithCommit: also migrated guard %s → %s", split.baseKey, commitHash.substring(0, 8));
+		}
+	}
+
+	const updated: PlansRegistry = { ...registry, notes: nextNotes };
 	await savePlansRegistry(updated, cwd);
 	log.info("associateNoteWithCommit: %s → %s", noteId, commitHash.substring(0, 8));
 }

--- a/cli/src/core/StorageProvider.ts
+++ b/cli/src/core/StorageProvider.ts
@@ -58,4 +58,25 @@ export interface StorageProvider {
 	 * OrphanBranchStorage does not implement it (no visible layer).
 	 */
 	regenerateVisibleMarkdown?(entry: SummaryIndexEntry): Promise<boolean>;
+
+	/**
+	 * Remove the user-visible Markdown copy of a plan for the given branch
+	 * (`<branchFolder>/plan--<slug>.md`). Mirrors `deleteVisibleMarkdown`'s
+	 * contract — does NOT touch the orphan-branch source, `.jolli/plans/<slug>.md`,
+	 * or the local plans registry. Fingerprint-guarded: a hand-edited file is
+	 * left in place. Idempotent on a missing file.
+	 *
+	 * Optional: implemented by FolderStorage and delegated by DualWriteStorage.
+	 * OrphanBranchStorage does not implement it (no visible layer).
+	 */
+	deletePlanVisible?(slug: string, branch: string): Promise<void>;
+
+	/**
+	 * Remove the user-visible Markdown copy of a note for the given branch
+	 * (`<branchFolder>/note--<id>.md`). Same contract as `deletePlanVisible`.
+	 *
+	 * Optional: implemented by FolderStorage and delegated by DualWriteStorage.
+	 * OrphanBranchStorage does not implement it (no visible layer).
+	 */
+	deleteNoteVisible?(id: string, branch: string): Promise<void>;
 }

--- a/cli/src/core/SummaryStore.test.ts
+++ b/cli/src/core/SummaryStore.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // Mock GitOps
 vi.mock("./GitOps.js", () => ({
@@ -37,8 +37,11 @@ import {
 	writeMultipleFilesToBranch,
 } from "./GitOps.js";
 import { acquireOrphanWriteLock, releaseOrphanWriteLock } from "./Locks.js";
+import type { StorageProvider } from "./StorageProvider.js";
 import {
 	AmbiguousHashError,
+	deleteNoteVisibleArtifact,
+	deletePlanVisibleArtifact,
 	deleteTranscript,
 	expandSourcesForConsolidation,
 	getIndex,
@@ -61,6 +64,7 @@ import {
 	removeFromIndex,
 	saveTranscriptsBatch,
 	scanTreeHashAliases,
+	setActiveStorage,
 	storeLinearIssues,
 	storeNotes,
 	storePlans,
@@ -2340,6 +2344,39 @@ describe("SummaryStore", () => {
 			vi.mocked(readFileFromBranch).mockRejectedValueOnce(new Error("missing"));
 			await expect(readPlanFromBranch("plan-a")).resolves.toBeNull();
 		});
+
+		describe("deletePlanVisibleArtifact", () => {
+			afterEach(() => {
+				setActiveStorage(undefined);
+			});
+
+			it("delegates to the active storage when it implements deletePlanVisible", async () => {
+				const deletePlanVisible = vi.fn().mockResolvedValue(undefined);
+				setActiveStorage({
+					readFile: vi.fn(),
+					writeFiles: vi.fn(),
+					listFiles: vi.fn(),
+					exists: vi.fn().mockResolvedValue(true),
+					ensure: vi.fn(),
+					deletePlanVisible,
+				} as unknown as StorageProvider);
+
+				await deletePlanVisibleArtifact("my-plan-abc12345", "feature/login");
+				expect(deletePlanVisible).toHaveBeenCalledWith("my-plan-abc12345", "feature/login");
+			});
+
+			it("is a no-op when the active storage lacks deletePlanVisible (orphan-only mode)", async () => {
+				setActiveStorage({
+					readFile: vi.fn(),
+					writeFiles: vi.fn(),
+					listFiles: vi.fn(),
+					exists: vi.fn().mockResolvedValue(true),
+					ensure: vi.fn(),
+				} as unknown as StorageProvider);
+
+				await expect(deletePlanVisibleArtifact("plan-a", "main")).resolves.toBeUndefined();
+			});
+		});
 	});
 
 	describe("readPlanProgress", () => {
@@ -2616,6 +2653,39 @@ describe("SummaryStore", () => {
 			await storeNotes([], "Empty commit");
 
 			expect(writeMultipleFilesToBranch).not.toHaveBeenCalled();
+		});
+
+		describe("deleteNoteVisibleArtifact", () => {
+			afterEach(() => {
+				setActiveStorage(undefined);
+			});
+
+			it("delegates to the active storage when it implements deleteNoteVisible", async () => {
+				const deleteNoteVisible = vi.fn().mockResolvedValue(undefined);
+				setActiveStorage({
+					readFile: vi.fn(),
+					writeFiles: vi.fn(),
+					listFiles: vi.fn(),
+					exists: vi.fn().mockResolvedValue(true),
+					ensure: vi.fn(),
+					deleteNoteVisible,
+				} as unknown as StorageProvider);
+
+				await deleteNoteVisibleArtifact("note-42", "main");
+				expect(deleteNoteVisible).toHaveBeenCalledWith("note-42", "main");
+			});
+
+			it("is a no-op when the active storage lacks deleteNoteVisible", async () => {
+				setActiveStorage({
+					readFile: vi.fn(),
+					writeFiles: vi.fn(),
+					listFiles: vi.fn(),
+					exists: vi.fn().mockResolvedValue(true),
+					ensure: vi.fn(),
+				} as unknown as StorageProvider);
+
+				await expect(deleteNoteVisibleArtifact("note-42", "main")).resolves.toBeUndefined();
+			});
 		});
 	});
 

--- a/cli/src/core/SummaryStore.ts
+++ b/cli/src/core/SummaryStore.ts
@@ -52,7 +52,21 @@ export function setActiveStorage(storage: StorageProvider | undefined): void {
 }
 
 export function resolveStorage(storage?: StorageProvider, cwd?: string): StorageProvider {
-	return storage ?? activeStorageOverride ?? new OrphanBranchStorage(cwd);
+	if (storage) return storage;
+	if (activeStorageOverride) return activeStorageOverride;
+	// Fail-safe fallback: orphan branch is the system of record, so a missed storage
+	// thread still preserves data. But it bypasses DualWriteStorage, so folder-mode
+	// users silently lose this write. Warn so the gap shows up in debug.log instead
+	// of as a phantom missing file weeks later. VITEST guard mirrors Logger.ts.
+	/* v8 ignore start -- warning only fires outside VITEST; coverage runs are always under VITEST. */
+	if (!process.env.VITEST) {
+		log.warn(
+			"resolveStorage fallback to OrphanBranchStorage — caller did not thread storage or call setActiveStorage. Folder-mode users will miss this write. cwd=%s",
+			cwd ?? "(undef)",
+		);
+	}
+	/* v8 ignore stop */
+	return new OrphanBranchStorage(cwd);
 }
 
 const log = createLogger("SummaryStore");
@@ -147,6 +161,7 @@ export async function storeSummary(
 		readonly transcript?: StoredTranscript;
 		readonly planProgress?: ReadonlyArray<PlanProgressArtifact>;
 	},
+	storage?: StorageProvider,
 ): Promise<void> {
 	await withRequiredOrphanWriteLock(cwd, "storeSummary", async () => {
 		const existingIndex = await loadIndex(cwd);
@@ -200,7 +215,7 @@ export async function storeSummary(
 			}
 		}
 
-		const store = resolveStorage(undefined, cwd);
+		const store = resolveStorage(storage, cwd);
 		await store.writeFiles(
 			files,
 			`${verb} summary for ${summary.commitHash.substring(0, 8)}: ${summary.commitMessage.substring(0, 50)}`,
@@ -882,6 +897,7 @@ export async function saveTranscriptsBatch(
 	writes: ReadonlyArray<{ readonly hash: string; readonly data: StoredTranscript }>,
 	deletes: ReadonlyArray<string>,
 	cwd?: string,
+	storage?: StorageProvider,
 ): Promise<void> {
 	const files: FileWrite[] = [];
 
@@ -909,7 +925,7 @@ export async function saveTranscriptsBatch(
 		.join(", ");
 
 	await withRequiredOrphanWriteLock(cwd, "saveTranscriptsBatch", async () => {
-		const store = resolveStorage(undefined, cwd);
+		const store = resolveStorage(storage, cwd);
 		await store.writeFiles(files, `Update transcripts: ${summary}`);
 		log.info("Transcript batch: %s", summary);
 	});
@@ -1837,6 +1853,7 @@ export async function storePlans(
 	commitMessage: string,
 	cwd?: string,
 	branch?: string,
+	storage?: StorageProvider,
 ): Promise<void> {
 	if (planFiles.length === 0) return;
 
@@ -1847,7 +1864,7 @@ export async function storePlans(
 	}));
 
 	await withRequiredOrphanWriteLock(cwd, "storePlans", async () => {
-		const store = resolveStorage(undefined, cwd);
+		const store = resolveStorage(storage, cwd);
 		await store.writeFiles(files, commitMessage);
 		log.info("Stored %d plan file(s)", planFiles.length);
 	});
@@ -1868,6 +1885,28 @@ export async function readPlanFromBranch(
 	} catch {
 		return null;
 	}
+}
+
+/**
+ * Removes ONLY the user-visible `<branch>/plan--<slug>.md` from the Memory
+ * Bank folder layer. Leaves the orphan-branch source (`plans/<slug>.md`),
+ * the hidden `.jolli/plans/<slug>.md` mirror, and the local plans registry
+ * untouched — callers that want to dissociate a plan from a commit (rather
+ * than delete the plan itself) use this to clean up the per-branch visible
+ * artifact while the plan remains addressable for future re-association.
+ *
+ * No-op when the active storage backend has no visible layer (e.g.
+ * OrphanBranchStorage in legacy `orphan-only` mode).
+ */
+export async function deletePlanVisibleArtifact(
+	slug: string,
+	branch: string,
+	cwd?: string,
+	storage?: StorageProvider,
+): Promise<void> {
+	const store = resolveStorage(storage, cwd);
+	if (!store.deletePlanVisible) return;
+	await store.deletePlanVisible(slug, branch);
 }
 
 /**
@@ -1896,6 +1935,7 @@ export async function storeNotes(
 	commitMessage: string,
 	cwd?: string,
 	branch?: string,
+	storage?: StorageProvider,
 ): Promise<void> {
 	if (noteFiles.length === 0) return;
 
@@ -1906,10 +1946,29 @@ export async function storeNotes(
 	}));
 
 	await withRequiredOrphanWriteLock(cwd, "storeNotes", async () => {
-		const store = resolveStorage(undefined, cwd);
+		const store = resolveStorage(storage, cwd);
 		await store.writeFiles(files, commitMessage);
 		log.info("Stored %d note file(s)", noteFiles.length);
 	});
+}
+
+/**
+ * Removes ONLY the user-visible `<branch>/note--<id>.md` from the Memory
+ * Bank folder layer. Symmetric with `deletePlanVisibleArtifact` — the
+ * orphan-branch source (`notes/<id>.md`), the hidden `.jolli/notes/<id>.md`
+ * mirror, and the local notes registry are left untouched.
+ *
+ * No-op when the active storage backend has no visible layer.
+ */
+export async function deleteNoteVisibleArtifact(
+	id: string,
+	branch: string,
+	cwd?: string,
+	storage?: StorageProvider,
+): Promise<void> {
+	const store = resolveStorage(storage, cwd);
+	if (!store.deleteNoteVisible) return;
+	await store.deleteNoteVisible(id, branch);
 }
 
 /**
@@ -1939,6 +1998,7 @@ export async function storeLinearIssues(
 	commitMessage: string,
 	cwd?: string,
 	branch?: string,
+	storage?: StorageProvider,
 ): Promise<void> {
 	if (linearFiles.length === 0) return;
 
@@ -1949,7 +2009,7 @@ export async function storeLinearIssues(
 	}));
 
 	await withRequiredOrphanWriteLock(cwd, "storeLinearIssues", async () => {
-		const store = resolveStorage(undefined, cwd);
+		const store = resolveStorage(storage, cwd);
 		await store.writeFiles(files, commitMessage);
 		log.info("Stored %d Linear issue file(s)", linearFiles.length);
 	});

--- a/cli/src/hooks/PostCommitHook.helpers.test.ts
+++ b/cli/src/hooks/PostCommitHook.helpers.test.ts
@@ -395,6 +395,98 @@ describe("PostCommitHook helpers", () => {
 			expect([...slugs]).toEqual(["eligible"]);
 		});
 
+		// Iterative-commit revival: user edits a previously-archived plan and commits
+		// again. The guard entry's contentHashAtCommit no longer matches the file,
+		// and we want the new content to be re-archived into the new commit (a fresh
+		// `slug-<newShortHash>` entry plus an updated guard). Before this fix the
+		// detect function skipped guards outright, leaving the plan visibly "stuck"
+		// in the PLANS & NOTES panel pointing at the previous commit hash.
+		it("includes revived guard plans whose source file no longer matches contentHashAtCommit", async () => {
+			const { createHash } = await import("node:crypto");
+			const oldHash = createHash("sha256").update("v1 content\n").digest("hex");
+			const liveBody = "v2 content\n";
+			mockLoadPlansRegistry.mockResolvedValue({
+				version: 1,
+				plans: {
+					"revived-plan": {
+						slug: "revived-plan",
+						title: "Revived",
+						sourcePath: "/repo/plans/revived-plan.md",
+						commitHash: "deadbeefdeadbeef",
+						contentHashAtCommit: oldHash,
+						branch: "main",
+						editCount: 0,
+						addedAt: "x",
+						updatedAt: "y",
+					},
+				},
+			});
+			mockExistsSync.mockImplementation((p: string) => p === "/repo/plans/revived-plan.md");
+			mockReadFileSync.mockImplementation((p: string) => {
+				if (p === "/repo/plans/revived-plan.md") return liveBody;
+				throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+			});
+
+			const slugs = await __test__.detectPlanSlugsFromRegistry("/repo", "main");
+			expect([...slugs]).toEqual(["revived-plan"]);
+		});
+
+		it("excludes guard plans whose source file still matches contentHashAtCommit", async () => {
+			const { createHash } = await import("node:crypto");
+			const body = "v1 content\n";
+			const hash = createHash("sha256").update(body).digest("hex");
+			mockLoadPlansRegistry.mockResolvedValue({
+				version: 1,
+				plans: {
+					"stable-plan": {
+						slug: "stable-plan",
+						title: "Stable",
+						sourcePath: "/repo/plans/stable-plan.md",
+						commitHash: "deadbeefdeadbeef",
+						contentHashAtCommit: hash,
+						branch: "main",
+						editCount: 0,
+						addedAt: "x",
+						updatedAt: "y",
+					},
+				},
+			});
+			mockExistsSync.mockImplementation((p: string) => p === "/repo/plans/stable-plan.md");
+			mockReadFileSync.mockImplementation((p: string) => {
+				if (p === "/repo/plans/stable-plan.md") return body;
+				throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+			});
+
+			const slugs = await __test__.detectPlanSlugsFromRegistry("/repo", "main");
+			expect(slugs.size).toBe(0);
+		});
+
+		it("excludes guard plans whose source file is missing on disk", async () => {
+			// Source gone → panel already hides via the "file missing" branch in
+			// toPlanInfo; we don't want to surface it as "uncommitted" and try to
+			// re-archive a file we can't read.
+			mockLoadPlansRegistry.mockResolvedValue({
+				version: 1,
+				plans: {
+					"gone-plan": {
+						slug: "gone-plan",
+						title: "Gone",
+						sourcePath: "/repo/plans/gone-plan.md",
+						commitHash: "deadbeefdeadbeef",
+						contentHashAtCommit: "anything",
+						branch: "main",
+						editCount: 0,
+						addedAt: "x",
+						updatedAt: "y",
+					},
+				},
+			});
+			mockExistsSync.mockReturnValue(false);
+
+			const slugs = await __test__.detectPlanSlugsFromRegistry("/repo", "main");
+			expect(slugs.size).toBe(0);
+		});
+
 		it("excludes uncommitted plans whose branch differs from the target branch", async () => {
 			// Regression guard for the cross-branch leak: before adding the branch
 			// filter, plans on `feature/summarize-include-linear-issues` were being

--- a/cli/src/hooks/QueueWorker.test.ts
+++ b/cli/src/hooks/QueueWorker.test.ts
@@ -857,6 +857,89 @@ describe("QueueWorker", () => {
 			const ids = await __test__.detectUncommittedNoteIds("/test/cwd", "feature/active");
 			expect([...ids]).toEqual(["current-note"]);
 		});
+
+		// Iterative-commit revival mirror of detectPlanSlugsFromRegistry: a previously
+		// archived note's source file has been edited since archive, so the new
+		// content needs to re-enter the working area and be carried into the next
+		// commit.
+		it("includes revived guard notes whose source file no longer matches contentHashAtCommit", async () => {
+			const { createHash } = await import("node:crypto");
+			const oldHash = createHash("sha256").update("v1\n").digest("hex");
+			vi.mocked(loadPlansRegistry).mockResolvedValueOnce({
+				version: 1,
+				plans: {},
+				notes: {
+					"revived-note": {
+						id: "revived-note",
+						title: "Revived",
+						format: "markdown" as const,
+						sourcePath: "/repo/notes/revived-note.md",
+						addedAt: "x",
+						updatedAt: "y",
+						branch: "main",
+						commitHash: "deadbeefdeadbeef",
+						contentHashAtCommit: oldHash,
+					},
+				},
+			});
+			vi.mocked(existsSync).mockImplementation((p) => p === "/repo/notes/revived-note.md");
+			vi.mocked(readFileSync).mockImplementation((p) => (p === "/repo/notes/revived-note.md" ? "v2\n" : ""));
+
+			const ids = await __test__.detectUncommittedNoteIds("/test/cwd", "main");
+			expect([...ids]).toEqual(["revived-note"]);
+		});
+
+		it("excludes guard notes whose source file still matches contentHashAtCommit", async () => {
+			const { createHash } = await import("node:crypto");
+			const body = "v1\n";
+			const hash = createHash("sha256").update(body).digest("hex");
+			vi.mocked(loadPlansRegistry).mockResolvedValueOnce({
+				version: 1,
+				plans: {},
+				notes: {
+					"stable-note": {
+						id: "stable-note",
+						title: "Stable",
+						format: "markdown" as const,
+						sourcePath: "/repo/notes/stable-note.md",
+						addedAt: "x",
+						updatedAt: "y",
+						branch: "main",
+						commitHash: "deadbeefdeadbeef",
+						contentHashAtCommit: hash,
+					},
+				},
+			});
+			vi.mocked(existsSync).mockImplementation((p) => p === "/repo/notes/stable-note.md");
+			vi.mocked(readFileSync).mockImplementation((p) => (p === "/repo/notes/stable-note.md" ? body : ""));
+
+			const ids = await __test__.detectUncommittedNoteIds("/test/cwd", "main");
+			expect(ids.size).toBe(0);
+		});
+
+		it("excludes guard notes whose source file is missing on disk", async () => {
+			vi.mocked(loadPlansRegistry).mockResolvedValueOnce({
+				version: 1,
+				plans: {},
+				notes: {
+					"gone-note": {
+						id: "gone-note",
+						title: "Gone",
+						format: "markdown" as const,
+						sourcePath: "/repo/notes/gone-note.md",
+						addedAt: "x",
+						updatedAt: "y",
+						branch: "main",
+						commitHash: "deadbeefdeadbeef",
+						contentHashAtCommit: "anything",
+					},
+				},
+			});
+			vi.mocked(existsSync).mockReturnValue(false);
+
+			const ids = await __test__.detectUncommittedNoteIds("/test/cwd", "main");
+			expect(ids.size).toBe(0);
+		});
 	});
 
 	describe("buildStoredTranscript", () => {

--- a/cli/src/hooks/QueueWorker.ts
+++ b/cli/src/hooks/QueueWorker.ts
@@ -17,6 +17,7 @@
  */
 
 import { spawn } from "node:child_process";
+import { createHash } from "node:crypto";
 import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { basename, dirname, join, resolve } from "node:path";
@@ -399,9 +400,32 @@ function formatElapsed(startMs: number): string {
 }
 
 /**
+ * Reads the live source file at `path` and returns its sha256 hex digest.
+ * Returns null when the file is missing or unreadable — callers treat that
+ * as "no comparison data available" rather than a re-archive trigger.
+ */
+function safeHashFileSync(path: string): string | null {
+	if (!existsSync(path)) return null;
+	try {
+		const body = readFileSync(path, "utf-8");
+		return createHash("sha256").update(body).digest("hex");
+	} catch {
+		return null;
+	}
+}
+
+/**
  * Reads uncommitted plan slugs from plans.json registry.
  * Plans are discovered by the StopHook at transcript scan time, so the
  * registry is already up-to-date when the post-commit hook runs.
+ *
+ * Surfaces two distinct categories:
+ *   1. Fresh — never archived (`commitHash === null`, no `contentHashAtCommit`).
+ *   2. Revived guard — previously archived, but the source file has been edited
+ *      since archive (`contentHashAtCommit` exists and no longer matches the
+ *      file's live hash). Without this, a user iterating on the same plan
+ *      across commits would see the panel "stuck" on a stale commit hash —
+ *      see PLANS & NOTES guard-revival bug.
  */
 async function detectPlanSlugsFromRegistry(cwd: string, branch: string): Promise<Set<string>> {
 	const registry = await loadPlansRegistry(cwd);
@@ -412,8 +436,16 @@ async function detectPlanSlugsFromRegistry(cwd: string, branch: string): Promise
 		// cross-branch plans archived to feature/linear-issues-as-panel-item's
 		// 786c5330 even though their entry.branch said feature/summarize-include-linear-issues).
 		if (entry.branch !== branch) continue;
-		if (entry.commitHash === null && !entry.ignored && !entry.contentHashAtCommit) {
+		if (entry.ignored) continue;
+		if (entry.commitHash === null && !entry.contentHashAtCommit) {
 			slugs.add(slug);
+			continue;
+		}
+		if (entry.commitHash !== null && entry.contentHashAtCommit && entry.sourcePath) {
+			const liveHash = safeHashFileSync(entry.sourcePath);
+			if (liveHash && liveHash !== entry.contentHashAtCommit) {
+				slugs.add(slug);
+			}
 		}
 	}
 	log.info("Plan registry scan: found %d uncommitted slug(s) on %s: [%s]", slugs.size, branch, [...slugs].join(", "));
@@ -473,18 +505,21 @@ async function associatePlansWithCommit(
 			log.info("Plan association: slug %s not in registry — skipping", slug);
 			continue;
 		}
-		// Skip if ignored (user removed from list), archived, or already associated
+		// Skip if ignored, or if the entry is a per-commit archive snapshot
+		// (commitHash set but no contentHashAtCommit — these are the
+		// `slug-<shortHash>` artifacts, not user-facing working-area rows).
+		// Guard entries (commitHash + contentHashAtCommit) are deliberately
+		// NOT skipped here: detectPlanSlugsFromRegistry only forwards them
+		// when their source file diverged from the guard hash, which means
+		// the user iterated on the plan and we need to re-archive the new
+		// content under this commit.
 		if (entry.ignored) {
 			log.info("Plan association: slug %s is ignored — skipping", slug);
 			continue;
 		}
-		if (entry.contentHashAtCommit) {
-			log.info("Plan association: slug %s is a guard entry (already archived) — skipping", slug);
-			continue;
-		}
-		if (entry.commitHash !== null) {
+		if (entry.commitHash !== null && !entry.contentHashAtCommit) {
 			log.info(
-				"Plan association: slug %s already associated with %s — skipping",
+				"Plan association: slug %s is an archive snapshot for %s — skipping",
 				slug,
 				entry.commitHash.substring(0, 8),
 			);
@@ -568,8 +603,10 @@ async function associatePlansWithCommit(
 
 /**
  * Reads uncommitted note IDs from plans.json registry.
- * Notes with `commitHash === null` and no `contentHashAtCommit` (not yet archived)
- * are candidates for association with the current commit.
+ *
+ * Surfaces two distinct categories — the same fresh / revived-guard split that
+ * detectPlanSlugsFromRegistry uses. See that function's doc-comment for the
+ * iterative-commit revival rationale.
  */
 async function detectUncommittedNoteIds(cwd: string, branch: string): Promise<Set<string>> {
 	const registry = await loadPlansRegistry(cwd);
@@ -580,8 +617,16 @@ async function detectUncommittedNoteIds(cwd: string, branch: string): Promise<Se
 		// the current commit on commit. See the cross-branch leak documented at
 		// detectPlanSlugsFromRegistry above.
 		if (entry.branch !== branch) continue;
-		if (entry.commitHash === null && !entry.ignored && !entry.contentHashAtCommit) {
+		if (entry.ignored) continue;
+		if (entry.commitHash === null && !entry.contentHashAtCommit) {
 			ids.add(id);
+			continue;
+		}
+		if (entry.commitHash !== null && entry.contentHashAtCommit && entry.sourcePath) {
+			const liveHash = safeHashFileSync(entry.sourcePath);
+			if (liveHash && liveHash !== entry.contentHashAtCommit) {
+				ids.add(id);
+			}
 		}
 	}
 	log.info("Note registry scan: found %d uncommitted note(s) on %s: [%s]", ids.size, branch, [...ids].join(", "));

--- a/vscode/src/JolliMemoryBridge.test.ts
+++ b/vscode/src/JolliMemoryBridge.test.ts
@@ -40,13 +40,31 @@ const { generateCommitMessage, generateSquashMessage } = vi.hoisted(() => ({
 	generateSquashMessage: vi.fn(),
 }));
 
-const { getIndexEntryMap, getSummary, listSummaries, scanTreeHashAliases } =
-	vi.hoisted(() => ({
-		getIndexEntryMap: vi.fn(),
-		getSummary: vi.fn(),
-		listSummaries: vi.fn(),
-		scanTreeHashAliases: vi.fn(),
-	}));
+const {
+	deleteNoteVisibleArtifact,
+	deletePlanVisibleArtifact,
+	getIndexEntryMap,
+	getSummary,
+	listSummaries,
+	saveTranscriptsBatch,
+	scanTreeHashAliases,
+	storeLinearIssues,
+	storeNotes,
+	storePlans,
+	storeSummary,
+} = vi.hoisted(() => ({
+	deleteNoteVisibleArtifact: vi.fn(),
+	deletePlanVisibleArtifact: vi.fn(),
+	getIndexEntryMap: vi.fn(),
+	getSummary: vi.fn(),
+	listSummaries: vi.fn(),
+	saveTranscriptsBatch: vi.fn(),
+	scanTreeHashAliases: vi.fn(),
+	storeLinearIssues: vi.fn(),
+	storeNotes: vi.fn(),
+	storePlans: vi.fn(),
+	storeSummary: vi.fn(),
+}));
 
 const { getDiffStats } = vi.hoisted(() => ({
 	getDiffStats: vi.fn(),
@@ -72,16 +90,19 @@ const { installerInstall, installerUninstall, installerGetStatus } = vi.hoisted(
 	}),
 );
 
-const { detectPlans, ignorePlan } = vi.hoisted(() => ({
+const { archivePlanForCommit, detectPlans, ignorePlan } = vi.hoisted(() => ({
+	archivePlanForCommit: vi.fn(),
 	detectPlans: vi.fn(),
 	ignorePlan: vi.fn(),
 }));
 
 const {
+	archiveNoteForCommit,
 	detectNotes,
 	saveNote: saveNoteFn,
 	removeNote: removeNoteFn,
 } = vi.hoisted(() => ({
+	archiveNoteForCommit: vi.fn(),
 	detectNotes: vi.fn(),
 	saveNote: vi.fn(),
 	removeNote: vi.fn(),
@@ -178,10 +199,17 @@ vi.mock("../../cli/src/core/Summarizer.js", () => ({
 }));
 
 vi.mock("../../cli/src/core/SummaryStore.js", () => ({
+	deleteNoteVisibleArtifact,
+	deletePlanVisibleArtifact,
 	getIndexEntryMap,
 	getSummary,
 	listSummaries,
+	saveTranscriptsBatch,
 	scanTreeHashAliases,
+	storeLinearIssues,
+	storeNotes,
+	storePlans,
+	storeSummary,
 }));
 
 vi.mock("../../cli/src/core/GitOps.js", () => ({
@@ -226,11 +254,13 @@ vi.mock("../../cli/src/Logger.js", () => ({
 }));
 
 vi.mock("./core/PlanService.js", () => ({
+	archivePlanForCommit,
 	detectPlans,
 	ignorePlan,
 }));
 
 vi.mock("./core/NoteService.js", () => ({
+	archiveNoteForCommit,
 	detectNotes,
 	saveNote: saveNoteFn,
 	removeNote: removeNoteFn,
@@ -2491,6 +2521,29 @@ describe("JolliMemoryBridge", () => {
 		});
 	});
 
+	describe("cleanupVisiblePlanArtifact()", () => {
+		it("passes the Bridge's storage instance through to deletePlanVisibleArtifact", async () => {
+			// Reason: SummaryStore wrappers fall back to `new OrphanBranchStorage(cwd)`
+			// when no storage is passed, which silently no-ops (no `deletePlanVisible`
+			// method). The Bridge must thread its DualWriteStorage in so the visible
+			// `<branch>/plan--<slug>.md` actually gets deleted.
+			deletePlanVisibleArtifact.mockResolvedValue(undefined);
+			const bridge = makeBridge();
+
+			await bridge.cleanupVisiblePlanArtifact("my-plan", "feature/x");
+
+			expect(deletePlanVisibleArtifact).toHaveBeenCalledWith(
+				"my-plan",
+				"feature/x",
+				TEST_CWD,
+				expect.objectContaining({
+					readFile: expect.any(Function),
+					writeFiles: expect.any(Function),
+				}),
+			);
+		});
+	});
+
 	// ── Notes ─────────────────────────────────────────────────────────────
 
 	describe("listNotes()", () => {
@@ -2538,6 +2591,167 @@ describe("JolliMemoryBridge", () => {
 			await bridge.removeNote("note-id");
 
 			expect(removeNoteFn).toHaveBeenCalledWith("note-id", TEST_CWD);
+		});
+	});
+
+	describe("cleanupVisibleNoteArtifact()", () => {
+		it("passes the Bridge's storage instance through to deleteNoteVisibleArtifact", async () => {
+			deleteNoteVisibleArtifact.mockResolvedValue(undefined);
+			const bridge = makeBridge();
+
+			await bridge.cleanupVisibleNoteArtifact("note-42", "main");
+
+			expect(deleteNoteVisibleArtifact).toHaveBeenCalledWith(
+				"note-42",
+				"main",
+				TEST_CWD,
+				expect.objectContaining({
+					readFile: expect.any(Function),
+					writeFiles: expect.any(Function),
+				}),
+			);
+		});
+	});
+
+	// ── Storage-threaded writers ─────────────────────────────────────────
+	// Every wrapper must forward the Bridge's DualWriteStorage as the trailing
+	// `storage` arg — otherwise the underlying SummaryStore writer falls back
+	// to `resolveStorage(undefined, cwd)` (= a fresh `OrphanBranchStorage`) and
+	// the Memory Bank folder never gets the write.
+
+	const storageShape = expect.objectContaining({
+		readFile: expect.any(Function),
+		writeFiles: expect.any(Function),
+	});
+
+	describe("storeSummary()", () => {
+		it("forwards the Bridge's storage to SummaryStore.storeSummary", async () => {
+			storeSummary.mockResolvedValue(undefined);
+			const bridge = makeBridge();
+			const summary = {
+				version: 3,
+				commitHash: "abc1",
+				commitMessage: "test",
+				commitDate: "2026-05-18T00:00:00Z",
+				branch: "main",
+				generatedAt: "2026-05-18T00:00:01Z",
+			} as never;
+
+			await bridge.storeSummary(summary, true);
+
+			expect(storeSummary).toHaveBeenCalledWith(
+				summary,
+				TEST_CWD,
+				true,
+				undefined,
+				storageShape,
+			);
+		});
+	});
+
+	describe("storePlans()", () => {
+		it("forwards the Bridge's storage to SummaryStore.storePlans", async () => {
+			storePlans.mockResolvedValue(undefined);
+			const bridge = makeBridge();
+
+			await bridge.storePlans(
+				[{ slug: "p1", content: "# Plan" }],
+				"msg",
+				"feature/x",
+			);
+
+			expect(storePlans).toHaveBeenCalledWith(
+				[{ slug: "p1", content: "# Plan" }],
+				"msg",
+				TEST_CWD,
+				"feature/x",
+				storageShape,
+			);
+		});
+	});
+
+	describe("storeNotes()", () => {
+		it("forwards the Bridge's storage to SummaryStore.storeNotes", async () => {
+			storeNotes.mockResolvedValue(undefined);
+			const bridge = makeBridge();
+
+			await bridge.storeNotes([{ id: "n1", content: "# Note" }], "msg");
+
+			expect(storeNotes).toHaveBeenCalledWith(
+				[{ id: "n1", content: "# Note" }],
+				"msg",
+				TEST_CWD,
+				undefined,
+				storageShape,
+			);
+		});
+	});
+
+	describe("storeLinearIssues()", () => {
+		it("forwards the Bridge's storage to SummaryStore.storeLinearIssues", async () => {
+			storeLinearIssues.mockResolvedValue(undefined);
+			const bridge = makeBridge();
+
+			await bridge.storeLinearIssues(
+				[{ archivedKey: "PROJ-1-abcd1234", content: "# Issue" }],
+				"msg",
+			);
+
+			expect(storeLinearIssues).toHaveBeenCalledWith(
+				[{ archivedKey: "PROJ-1-abcd1234", content: "# Issue" }],
+				"msg",
+				TEST_CWD,
+				undefined,
+				storageShape,
+			);
+		});
+	});
+
+	describe("saveTranscriptsBatch()", () => {
+		it("forwards the Bridge's storage to SummaryStore.saveTranscriptsBatch", async () => {
+			saveTranscriptsBatch.mockResolvedValue(undefined);
+			const bridge = makeBridge();
+
+			await bridge.saveTranscriptsBatch([], ["hash1"]);
+
+			expect(saveTranscriptsBatch).toHaveBeenCalledWith(
+				[],
+				["hash1"],
+				TEST_CWD,
+				storageShape,
+			);
+		});
+	});
+
+	describe("archivePlanForCommit()", () => {
+		it("forwards the Bridge's storage to PlanService.archivePlanForCommit", async () => {
+			archivePlanForCommit.mockResolvedValue(null);
+			const bridge = makeBridge();
+
+			await bridge.archivePlanForCommit("plan-a", "deadbeef");
+
+			expect(archivePlanForCommit).toHaveBeenCalledWith(
+				"plan-a",
+				"deadbeef",
+				TEST_CWD,
+				storageShape,
+			);
+		});
+	});
+
+	describe("archiveNoteForCommit()", () => {
+		it("forwards the Bridge's storage to NoteService.archiveNoteForCommit", async () => {
+			archiveNoteForCommit.mockResolvedValue(null);
+			const bridge = makeBridge();
+
+			await bridge.archiveNoteForCommit("note-1", "deadbeef");
+
+			expect(archiveNoteForCommit).toHaveBeenCalledWith(
+				"note-1",
+				"deadbeef",
+				TEST_CWD,
+				storageShape,
+			);
 		});
 	});
 

--- a/vscode/src/JolliMemoryBridge.ts
+++ b/vscode/src/JolliMemoryBridge.ts
@@ -39,10 +39,17 @@ import {
 } from "../../cli/src/core/Summarizer.js";
 import { getDisplayDate } from "../../cli/src/core/SummaryFormat.js";
 import {
+	deleteNoteVisibleArtifact,
+	deletePlanVisibleArtifact,
 	getIndexEntryMap,
 	getSummary,
 	listSummaries,
+	saveTranscriptsBatch,
 	scanTreeHashAliases,
+	storeLinearIssues,
+	storeNotes,
+	storePlans,
+	storeSummary,
 } from "../../cli/src/core/SummaryStore.js";
 import {
 	compareSemver,
@@ -58,7 +65,11 @@ import { ORPHAN_BRANCH } from "../../cli/src/Logger.js";
 import type {
 	CommitSummary,
 	NoteFormat,
+	NoteReference,
+	PlanProgressArtifact,
+	PlanReference,
 	StatusInfo,
+	StoredTranscript,
 	SummaryIndexEntry,
 } from "../../cli/src/Types.js";
 import {
@@ -67,8 +78,17 @@ import {
 	openLinearIssueMarkdown as openLinearIssueMarkdownImpl,
 	setLinearIssueIgnored,
 } from "./core/LinearIssueService.js";
-import { detectNotes, removeNote, saveNote } from "./core/NoteService.js";
-import { detectPlans, ignorePlan } from "./core/PlanService.js";
+import {
+	archiveNoteForCommit,
+	detectNotes,
+	removeNote,
+	saveNote,
+} from "./core/NoteService.js";
+import {
+	archivePlanForCommit,
+	detectPlans,
+	ignorePlan,
+} from "./core/PlanService.js";
 import type {
 	BranchCommit,
 	BranchCommitsResult,
@@ -1628,6 +1648,101 @@ export class JolliMemoryBridge {
 		return { summary: null, sourceRepoName: null, sourceRemoteUrl: null };
 	}
 
+	// ── Storage-threaded writers (webview-initiated) ─────────────────────
+	//
+	// All `SummaryStore` writers default to `resolveStorage(undefined, cwd)`,
+	// which falls back to a fresh `OrphanBranchStorage(cwd)` because the
+	// extension process never installs `setActiveStorage` (only QueueWorker
+	// does — it runs in a separate process). That fallback writes only to the
+	// orphan branch, leaving the Memory Bank folder out of sync whenever a
+	// panel action (translate / editTopic / removePlan / archiveLinear / …)
+	// rewrites a summary or content artifact.
+	//
+	// These thin wrappers fetch the Bridge's `DualWriteStorage` once and pass
+	// it through to the underlying writer's new `storage?` parameter, so
+	// every webview-driven write hits both backends. Callers in
+	// `SummaryWebviewPanel` use these instead of importing the SummaryStore /
+	// PlanService / NoteService writers directly.
+
+	/** Writes a summary via the Bridge's DualWriteStorage instance. */
+	async storeSummary(
+		summary: CommitSummary,
+		force = false,
+		artifacts?: {
+			readonly transcript?: StoredTranscript;
+			readonly planProgress?: ReadonlyArray<PlanProgressArtifact>;
+		},
+	): Promise<void> {
+		const storage = await this.getStorage();
+		await storeSummary(summary, this.cwd, force, artifacts, storage);
+	}
+
+	/** Writes plan files (orphan-branch + Memory Bank visible MD). */
+	async storePlans(
+		planFiles: ReadonlyArray<{ slug: string; content: string }>,
+		commitMessage: string,
+		branch?: string,
+	): Promise<void> {
+		const storage = await this.getStorage();
+		await storePlans(planFiles, commitMessage, this.cwd, branch, storage);
+	}
+
+	/** Writes note files (orphan-branch + Memory Bank visible MD). */
+	async storeNotes(
+		noteFiles: ReadonlyArray<{ id: string; content: string }>,
+		commitMessage: string,
+		branch?: string,
+	): Promise<void> {
+		const storage = await this.getStorage();
+		await storeNotes(noteFiles, commitMessage, this.cwd, branch, storage);
+	}
+
+	/** Writes Linear-issue archived snapshots. */
+	async storeLinearIssues(
+		linearFiles: ReadonlyArray<{ archivedKey: string; content: string }>,
+		commitMessage: string,
+		branch?: string,
+	): Promise<void> {
+		const storage = await this.getStorage();
+		await storeLinearIssues(
+			linearFiles,
+			commitMessage,
+			this.cwd,
+			branch,
+			storage,
+		);
+	}
+
+	/** Batched transcript write+delete. */
+	async saveTranscriptsBatch(
+		writes: ReadonlyArray<{
+			readonly hash: string;
+			readonly data: StoredTranscript;
+		}>,
+		deletes: ReadonlyArray<string>,
+	): Promise<void> {
+		const storage = await this.getStorage();
+		await saveTranscriptsBatch(writes, deletes, this.cwd, storage);
+	}
+
+	/** Archives a plan and associates it with a commit. */
+	async archivePlanForCommit(
+		slug: string,
+		commitHash: string,
+	): Promise<PlanReference | null> {
+		const storage = await this.getStorage();
+		return archivePlanForCommit(slug, commitHash, this.cwd, storage);
+	}
+
+	/** Archives a note and associates it with a commit. */
+	async archiveNoteForCommit(
+		id: string,
+		commitHash: string,
+	): Promise<NoteReference | null> {
+		const storage = await this.getStorage();
+		return archiveNoteForCommit(id, commitHash, this.cwd, storage);
+	}
+
 	// ── Git utility methods ───────────────────────────────────────────────
 
 	/** Returns the git user.name configured for this repo. */
@@ -1736,6 +1851,23 @@ export class JolliMemoryBridge {
 		await ignorePlan(slug, this.cwd);
 	}
 
+	/**
+	 * Cleans up the user-visible `<branch>/plan--<slug>.md` in the Memory Bank
+	 * folder. Routed through the Bridge's storage instance so the call honours
+	 * the configured `storageMode` (dual-write / folder-only) — calling the
+	 * SummaryStore wrapper directly from the panel would fall back to a fresh
+	 * `OrphanBranchStorage(cwd)` (no visible-layer methods) and silently no-op,
+	 * because the extension process does not install `setActiveStorage`.
+	 * No-op when the active backend has no visible layer (orphan-only mode).
+	 */
+	async cleanupVisiblePlanArtifact(
+		slug: string,
+		branch: string,
+	): Promise<void> {
+		const storage = await this.getStorage();
+		await deletePlanVisibleArtifact(slug, branch, this.cwd, storage);
+	}
+
 	// ── Notes ────────────────────────────────────────────────────────────
 
 	/** Lists user-created notes from plans.json registry. */
@@ -1756,6 +1888,17 @@ export class JolliMemoryBridge {
 	/** Removes a note: deletes file for uncommitted notes, removes from registry. */
 	async removeNote(id: string): Promise<void> {
 		await removeNote(id, this.cwd);
+	}
+
+	/**
+	 * Cleans up the user-visible `<branch>/note--<id>.md` in the Memory Bank
+	 * folder. See `cleanupVisiblePlanArtifact` for why this must route through
+	 * the Bridge's storage instance rather than the SummaryStore wrapper's
+	 * default-storage fallback.
+	 */
+	async cleanupVisibleNoteArtifact(id: string, branch: string): Promise<void> {
+		const storage = await this.getStorage();
+		await deleteNoteVisibleArtifact(id, branch, this.cwd, storage);
 	}
 
 	// ── Linear issues ────────────────────────────────────────────────────

--- a/vscode/src/core/NoteService.test.ts
+++ b/vscode/src/core/NoteService.test.ts
@@ -1118,6 +1118,8 @@ describe("NoteService", () => {
 				[{ id: "test-note-06d0f729", content: "file content" }],
 				expect.stringContaining("Associate note"),
 				CWD,
+				undefined,
+				undefined,
 			);
 		});
 

--- a/vscode/src/core/NoteService.ts
+++ b/vscode/src/core/NoteService.ts
@@ -22,6 +22,7 @@ import {
 	loadPlansRegistry,
 	savePlansRegistry,
 } from "../../../cli/src/core/SessionTracker.js";
+import type { StorageProvider } from "../../../cli/src/core/StorageProvider.js";
 import { storeNotes } from "../../../cli/src/core/SummaryStore.js";
 import { getJolliMemoryDir } from "../../../cli/src/Logger.js";
 import type { NoteFormat, NoteReference } from "../../../cli/src/Types.js";
@@ -191,6 +192,7 @@ export async function archiveNoteForCommit(
 	id: string,
 	commitHash: string,
 	cwd: string,
+	storage?: StorageProvider,
 ): Promise<NoteReference | null> {
 	const registry = await loadPlansRegistry(cwd);
 	const notes = { ...(registry.notes ?? {}) };
@@ -234,11 +236,15 @@ export async function archiveNoteForCommit(
 	};
 	await savePlansRegistry({ ...registry, notes }, cwd);
 
-	// Store note in orphan branch
+	// Store note in orphan branch. branch left undefined — see archivePlan-
+	// ForCommit for the rationale (FolderStorage resolves the commit's branch
+	// from the hash suffix in newId).
 	await storeNotes(
 		[{ id: newId, content: noteContent }],
 		`Associate note ${newId} with commit ${shortHash}`,
 		cwd,
+		undefined,
+		storage,
 	);
 
 	// Clean up the local snippet file — content is now in the orphan branch

--- a/vscode/src/core/PlanService.test.ts
+++ b/vscode/src/core/PlanService.test.ts
@@ -459,6 +459,8 @@ describe("PlanService", () => {
 				[{ slug: "test-plan-06d0f729", content: "# Test Plan\nContent" }],
 				expect.stringContaining("Associate plan"),
 				CWD,
+				undefined,
+				undefined,
 			);
 		});
 

--- a/vscode/src/core/PlanService.ts
+++ b/vscode/src/core/PlanService.ts
@@ -27,6 +27,7 @@ import {
 	loadPlansRegistry,
 	savePlansRegistry,
 } from "../../../cli/src/core/SessionTracker.js";
+import type { StorageProvider } from "../../../cli/src/core/StorageProvider.js";
 import { storePlans } from "../../../cli/src/core/SummaryStore.js";
 import type { PlanReference } from "../../../cli/src/Types.js";
 import type { PlanEntry, PlanInfo } from "../Types.js";
@@ -333,6 +334,7 @@ export async function archivePlanForCommit(
 	slug: string,
 	commitHash: string,
 	cwd: string,
+	storage?: StorageProvider,
 ): Promise<PlanReference | null> {
 	const registry = await loadPlansRegistry(cwd);
 	let entry = registry.plans[slug];
@@ -394,7 +396,12 @@ export async function archivePlanForCommit(
 		cwd,
 	);
 
-	// Store plan file in orphan branch under new slug
+	// Store plan file in orphan branch under new slug. branch is intentionally
+	// left undefined: FolderStorage.resolveBranchFromSlug uses the commit hash
+	// embedded in `newSlug` to look up the commit's branch from the manifest /
+	// index — that's the right home for the visible <branch>/plan--<slug>.md.
+	// Passing entry.branch would point at the plan's *home* branch, which can
+	// differ from the commit's branch when editing summaries cross-branch.
 	const planFile = join(getPlansDir(), `${slug}.md`);
 	if (existsSync(planFile)) {
 		const content = fsReadFileSync(planFile, "utf-8");
@@ -402,6 +409,8 @@ export async function archivePlanForCommit(
 			[{ slug: newSlug, content }],
 			`Associate plan ${newSlug} with commit ${shortHash}`,
 			cwd,
+			undefined,
+			storage,
 		);
 	}
 

--- a/vscode/src/views/SummaryWebviewPanel.handlePush.test.ts
+++ b/vscode/src/views/SummaryWebviewPanel.handlePush.test.ts
@@ -437,10 +437,27 @@ async function setupPanel(
 }
 
 // Bridge stub used only to satisfy the panel ctor signature; handlePush tests
-// don't exercise branch-summary loading, so the stub's methods stay unused.
+// exercise the push path which threads writes through `this.bridge.storeSummary`,
+// so the stub delegates to module-level mockStoreSummary to keep existing
+// assertions like `expect(mockStoreSummary).toHaveBeenCalled()` working.
 const stubBridge = {
 	listBranchCommits: vi.fn(),
 	getSummary: vi.fn(),
+	storeSummary: vi.fn(
+		(
+			summary: import("../../../cli/src/Types.js").CommitSummary,
+			force = false,
+			artifacts?: unknown,
+		): Promise<void> =>
+			artifacts === undefined
+				? (mockStoreSummary(summary, "/workspace", force) as Promise<void>)
+				: (mockStoreSummary(
+						summary,
+						"/workspace",
+						force,
+						artifacts,
+					) as Promise<void>),
+	),
 } as unknown as import("../JolliMemoryBridge.js").JolliMemoryBridge;
 
 // ── Tests ────────────────────────────────────────────────────────────────────

--- a/vscode/src/views/SummaryWebviewPanel.test.ts
+++ b/vscode/src/views/SummaryWebviewPanel.test.ts
@@ -487,6 +487,70 @@ const stubBridge = {
 	listBranchCommits: vi.fn(),
 	getSummary: vi.fn(),
 	getCurrentBranch: vi.fn().mockResolvedValue("feature/test"),
+	cleanupVisiblePlanArtifact: vi.fn().mockResolvedValue(undefined),
+	cleanupVisibleNoteArtifact: vi.fn().mockResolvedValue(undefined),
+	// Bridge wrappers delegate to the module-level SummaryStore/PlanService/
+	// NoteService mocks with workspaceRoot injected, so existing assertions
+	// like `expect(mockStoreSummary).toHaveBeenCalledWith(summary, workspaceRoot, true)`
+	// keep working after the panel migrated to `this.bridge.storeSummary(...)`.
+	// Delegate the bridge wrappers without forwarding trailing `undefined`
+	// arguments — `toHaveBeenLastCalledWith` is arity-strict and existing
+	// assertions only specify the args that were originally passed.
+	storeSummary: vi.fn(
+		(
+			summary: import("../../../cli/src/Types.js").CommitSummary,
+			force = false,
+			artifacts?: unknown,
+		): Promise<void> =>
+			artifacts === undefined
+				? (mockStoreSummary(summary, workspaceRoot, force) as Promise<void>)
+				: (mockStoreSummary(
+						summary,
+						workspaceRoot,
+						force,
+						artifacts,
+					) as Promise<void>),
+	),
+	storePlans: vi.fn(
+		(
+			planFiles: ReadonlyArray<{ slug: string; content: string }>,
+			message: string,
+			branch?: string,
+		): Promise<void> =>
+			branch === undefined
+				? (mockStorePlans(planFiles, message, workspaceRoot) as Promise<void>)
+				: (mockStorePlans(
+						planFiles,
+						message,
+						workspaceRoot,
+						branch,
+					) as Promise<void>),
+	),
+	storeNotes: vi.fn(
+		(
+			noteFiles: ReadonlyArray<{ id: string; content: string }>,
+			message: string,
+			branch?: string,
+		): Promise<void> =>
+			branch === undefined
+				? (mockStoreNotes(noteFiles, message, workspaceRoot) as Promise<void>)
+				: (mockStoreNotes(
+						noteFiles,
+						message,
+						workspaceRoot,
+						branch,
+					) as Promise<void>),
+	),
+	saveTranscriptsBatch: vi.fn(
+		(writes: ReadonlyArray<unknown>, deletes: ReadonlyArray<string>) =>
+			mockSaveTranscriptsBatch(writes, deletes, workspaceRoot) as Promise<void>,
+	),
+	archivePlanForCommit: vi.fn((slug: string, commitHash: string) =>
+		mockArchivePlanForCommit(slug, commitHash, workspaceRoot),
+	),
+	archiveNoteForCommit: vi.fn((id: string, commitHash: string) =>
+		mockArchiveNoteForCommit(id, commitHash, workspaceRoot),
+	),
 } as unknown as import("../JolliMemoryBridge.js").JolliMemoryBridge;
 const mainBranch = "main";
 
@@ -2441,6 +2505,15 @@ describe("SummaryWebviewPanel", () => {
 					}),
 					workspaceRoot,
 					true,
+				);
+				// Cleans up the visible <branch>/plan--<slug>.md in dual-write mode
+				// so the Memory Bank tree view doesn't keep a ghost file behind.
+				// Routes through the Bridge so it picks up the extension's
+				// DualWriteStorage instance (the SummaryStore wrapper alone
+				// would fall back to OrphanBranchStorage and silently no-op).
+				expect(stubBridge.cleanupVisiblePlanArtifact).toHaveBeenCalledWith(
+					"plan-a",
+					expect.any(String),
 				);
 			});
 
@@ -5954,7 +6027,7 @@ describe("SummaryWebviewPanel", () => {
 
 				expect(showWarningMessage).toHaveBeenCalledWith(
 					'Remove note "Note A" from this commit?',
-					{ modal: true },
+					expect.objectContaining({ modal: true }),
 					"Remove",
 				);
 				expect(mockUnassociateNoteFromCommit).toHaveBeenCalledWith(
@@ -5969,6 +6042,13 @@ describe("SummaryWebviewPanel", () => {
 					}),
 					workspaceRoot,
 					true,
+				);
+				// Cleans up the visible <branch>/note--<id>.md in dual-write mode
+				// so the Memory Bank tree view doesn't keep a ghost file behind.
+				// Routes through the Bridge (see removePlan test for rationale).
+				expect(stubBridge.cleanupVisibleNoteArtifact).toHaveBeenCalledWith(
+					"note-a",
+					expect.any(String),
 				);
 			});
 

--- a/vscode/src/views/SummaryWebviewPanel.ts
+++ b/vscode/src/views/SummaryWebviewPanel.ts
@@ -33,10 +33,6 @@ import {
 	readNoteFromBranch,
 	readPlanFromBranch,
 	readTranscriptsForCommits,
-	saveTranscriptsBatch,
-	storeNotes,
-	storePlans,
-	storeSummary,
 } from "../../../cli/src/core/SummaryStore.js";
 import {
 	deleteTopicInTree,
@@ -51,13 +47,11 @@ import type {
 } from "../../../cli/src/Types.js";
 import { setLinearIssueIgnored } from "../core/LinearIssueService.js";
 import {
-	archiveNoteForCommit,
 	ignoreNote,
 	saveNote,
 	unassociateNoteFromCommit,
 } from "../core/NoteService.js";
 import {
-	archivePlanForCommit,
 	ignorePlan,
 	listAvailablePlans,
 	unassociatePlanFromCommit,
@@ -1189,7 +1183,7 @@ export class SummaryWebviewPanel {
 					? { notes: applyNoteUrls(summary.notes, noteUrls) }
 					: {}),
 			};
-			await storeSummary(updatedSummary, this.workspaceRoot, true);
+			await this.bridge.storeSummary(updatedSummary, true);
 
 			// Update in-memory state and fully re-render the WebView so PR section picks up
 			// the new plan/note URLs and jolliDocUrl in its markdown body
@@ -1212,7 +1206,7 @@ export class SummaryWebviewPanel {
 				updatedSummary,
 				baseUrl,
 				jolliApiKey,
-				this.workspaceRoot,
+				this.bridge,
 			);
 			if (cleanedSummary) {
 				this.currentSummary = cleanedSummary;
@@ -1403,7 +1397,7 @@ export class SummaryWebviewPanel {
 			throw new Error(`Memory index ${topicIndex} is out of range`);
 		}
 
-		await storeSummary(result.result, this.workspaceRoot, true);
+		await this.bridge.storeSummary(result.result, true);
 		this.currentSummary = result.result;
 
 		// Re-render just the updated topic and send the HTML to the webview for in-place replacement.
@@ -1433,7 +1427,7 @@ export class SummaryWebviewPanel {
 		const updated: CommitSummary = trimmed
 			? { ...summary, recap: trimmed }
 			: { ...summary, recap: undefined };
-		await storeSummary(updated, this.workspaceRoot, true);
+		await this.bridge.storeSummary(updated, true);
 		this.currentSummary = updated;
 		// Server-render the section so the webview gets the canonical HTML
 		// (including the trailing <hr/> separator). Empty result removes the
@@ -1487,7 +1481,7 @@ export class SummaryWebviewPanel {
 		}
 
 		const updated: CommitSummary = { ...summary, recap: trimmed };
-		await storeSummary(updated, this.workspaceRoot, true);
+		await this.bridge.storeSummary(updated, true);
 		this.currentSummary = updated;
 
 		this.panel.webview.postMessage({
@@ -1525,7 +1519,7 @@ export class SummaryWebviewPanel {
 			throw new Error(`Memory index ${topicIndex} is out of range`);
 		}
 
-		await storeSummary(result.result, this.workspaceRoot, true);
+		await this.bridge.storeSummary(result.result, true);
 		this.update(result.result);
 		this.panel.webview.postMessage({ command: "topicDeleted", topicIndex });
 	}
@@ -1580,7 +1574,7 @@ export class SummaryWebviewPanel {
 			...summary,
 			e2eTestGuide: scenarios,
 		};
-		await storeSummary(updatedSummary, this.workspaceRoot, true);
+		await this.bridge.storeSummary(updatedSummary, true);
 		this.currentSummary = updatedSummary;
 
 		// Send rendered HTML to webview for in-place replacement
@@ -1608,7 +1602,7 @@ export class SummaryWebviewPanel {
 			...summary,
 			e2eTestGuide: scenarios,
 		};
-		await storeSummary(updatedSummary, this.workspaceRoot, true);
+		await this.bridge.storeSummary(updatedSummary, true);
 		this.currentSummary = updatedSummary;
 
 		const html = buildE2eTestSection(updatedSummary);
@@ -1662,7 +1656,7 @@ export class SummaryWebviewPanel {
 			...summary,
 			e2eTestGuide: newScenarios,
 		};
-		await storeSummary(updatedSummary, this.workspaceRoot, true);
+		await this.bridge.storeSummary(updatedSummary, true);
 		this.currentSummary = updatedSummary;
 
 		const html = renderE2eScenario(merged, index);
@@ -1713,7 +1707,7 @@ export class SummaryWebviewPanel {
 			...summary,
 			e2eTestGuide: remaining.length > 0 ? remaining : undefined,
 		};
-		await storeSummary(updatedSummary, this.workspaceRoot, true);
+		await this.bridge.storeSummary(updatedSummary, true);
 		this.currentSummary = updatedSummary;
 
 		const html = buildE2eTestSection(updatedSummary);
@@ -1743,7 +1737,7 @@ export class SummaryWebviewPanel {
 			...summary,
 			e2eTestGuide: undefined,
 		};
-		await storeSummary(updatedSummary, this.workspaceRoot, true);
+		await this.bridge.storeSummary(updatedSummary, true);
 		this.currentSummary = updatedSummary;
 
 		const html = buildE2eTestSection(updatedSummary);
@@ -1768,11 +1762,7 @@ export class SummaryWebviewPanel {
 	}
 
 	private async handleSavePlan(slug: string, content: string): Promise<void> {
-		await storePlans(
-			[{ slug, content }],
-			`Edit plan ${slug}`,
-			this.workspaceRoot,
-		);
+		await this.bridge.storePlans([{ slug, content }], `Edit plan ${slug}`);
 		await this.syncPlanTitle(slug, content);
 
 		this.panel.webview.postMessage({ command: "planSaved", slug });
@@ -1798,7 +1788,7 @@ export class SummaryWebviewPanel {
 			...this.currentSummary,
 			plans: updatedPlans,
 		};
-		await storeSummary(updatedSummary, this.workspaceRoot, true);
+		await this.bridge.storeSummary(updatedSummary, true);
 		this.currentSummary = updatedSummary;
 		this.update(updatedSummary);
 
@@ -1826,7 +1816,7 @@ export class SummaryWebviewPanel {
 			{
 				modal: true,
 				detail:
-					"The plan will no longer be associated with this commit. The plan file itself is not deleted.",
+					"The plan will be unlinked from this commit and its Memory Bank copy in the branch folder will be removed. The plan source on the orphan branch is preserved.",
 			},
 			"Remove",
 		);
@@ -1840,7 +1830,7 @@ export class SummaryWebviewPanel {
 			...summary,
 			plans: updatedPlans.length > 0 ? updatedPlans : undefined,
 		};
-		await storeSummary(updatedSummary, this.workspaceRoot, true);
+		await this.bridge.storeSummary(updatedSummary, true);
 		this.currentSummary = updatedSummary;
 
 		// Clear commitHash in plans.json
@@ -1849,6 +1839,14 @@ export class SummaryWebviewPanel {
 		// Mark as ignored so the plan doesn't reappear in the sidebar on next refresh
 		// (unassociate only sets commitHash=null — the entry would still be visible)
 		await ignorePlan(slug, this.workspaceRoot);
+
+		// Remove the visible <branchFolder>/plan--<slug>.md in dual-write/folder
+		// modes so the Memory Bank tree view stops showing a ghost file. Goes
+		// through the Bridge so it picks up the extension's DualWriteStorage
+		// instance — calling the SummaryStore wrapper directly here would fall
+		// back to OrphanBranchStorage and silently no-op (the extension process
+		// does not install setActiveStorage; only QueueWorker does).
+		await this.bridge.cleanupVisiblePlanArtifact(slug, summary.branch);
 
 		this.update(updatedSummary);
 	}
@@ -1879,10 +1877,9 @@ export class SummaryWebviewPanel {
 			return;
 		}
 
-		const planRef = await archivePlanForCommit(
+		const planRef = await this.bridge.archivePlanForCommit(
 			selected.slug,
 			summary.commitHash,
-			this.workspaceRoot,
 		);
 		if (!planRef) {
 			vscode.window.showErrorMessage(
@@ -1896,7 +1893,7 @@ export class SummaryWebviewPanel {
 			...summary,
 			plans: [...existingPlans, planRef],
 		};
-		await storeSummary(updatedSummary, this.workspaceRoot, true);
+		await this.bridge.storeSummary(updatedSummary, true);
 		this.currentSummary = updatedSummary;
 		this.update(updatedSummary);
 	}
@@ -1923,10 +1920,9 @@ export class SummaryWebviewPanel {
 			"markdown",
 			this.workspaceRoot,
 		);
-		const noteRef = await archiveNoteForCommit(
+		const noteRef = await this.bridge.archiveNoteForCommit(
 			noteInfo.id,
 			summary.commitHash,
-			this.workspaceRoot,
 		);
 		if (!noteRef) {
 			// Clean up the orphaned note entry so it doesn't linger in the sidebar
@@ -1942,7 +1938,7 @@ export class SummaryWebviewPanel {
 			...summary,
 			notes: [...existingNotes, noteRef],
 		};
-		await storeSummary(updatedSummary, this.workspaceRoot, true);
+		await this.bridge.storeSummary(updatedSummary, true);
 		this.currentSummary = updatedSummary;
 		await this.refreshNoteTranslateSet(updatedSummary);
 		this.update(updatedSummary);
@@ -1967,10 +1963,9 @@ export class SummaryWebviewPanel {
 			"snippet",
 			this.workspaceRoot,
 		);
-		const noteRef = await archiveNoteForCommit(
+		const noteRef = await this.bridge.archiveNoteForCommit(
 			noteInfo.id,
 			summary.commitHash,
-			this.workspaceRoot,
 		);
 		if (!noteRef) {
 			await ignoreNote(noteInfo.id, this.workspaceRoot);
@@ -1985,7 +1980,7 @@ export class SummaryWebviewPanel {
 			...summary,
 			notes: [...existingNotes, noteRef],
 		};
-		await storeSummary(updatedSummary, this.workspaceRoot, true);
+		await this.bridge.storeSummary(updatedSummary, true);
 		this.currentSummary = updatedSummary;
 		await this.refreshNoteTranslateSet(updatedSummary);
 		this.update(updatedSummary);
@@ -2030,7 +2025,7 @@ export class SummaryWebviewPanel {
 		content: string,
 		format: string,
 	): Promise<void> {
-		await storeNotes([{ id, content }], `Edit note ${id}`, this.workspaceRoot);
+		await this.bridge.storeNotes([{ id, content }], `Edit note ${id}`);
 
 		// Sync title and (for snippets) inline content in the summary
 		if (this.currentSummary?.notes) {
@@ -2053,7 +2048,7 @@ export class SummaryWebviewPanel {
 				...this.currentSummary,
 				notes: updatedNotes,
 			};
-			await storeSummary(updatedSummary, this.workspaceRoot, true);
+			await this.bridge.storeSummary(updatedSummary, true);
 			this.currentSummary = updatedSummary;
 			this.update(updatedSummary);
 		}
@@ -2070,7 +2065,11 @@ export class SummaryWebviewPanel {
 
 		const choice = await vscode.window.showWarningMessage(
 			`Remove note "${title}" from this commit?`,
-			{ modal: true },
+			{
+				modal: true,
+				detail:
+					"The note will be unlinked from this commit and its Memory Bank copy in the branch folder will be removed. The note source on the orphan branch is preserved.",
+			},
 			"Remove",
 		);
 		if (choice !== "Remove") {
@@ -2082,12 +2081,19 @@ export class SummaryWebviewPanel {
 			...summary,
 			notes: updatedNotes.length > 0 ? updatedNotes : undefined,
 		};
-		await storeSummary(updatedSummary, this.workspaceRoot, true);
+		await this.bridge.storeSummary(updatedSummary, true);
 		this.currentSummary = updatedSummary;
 		await unassociateNoteFromCommit(id, this.workspaceRoot);
 		// Mark as ignored so the note doesn't reappear in the sidebar on next refresh
 		// (unassociate only sets commitHash=null — the entry would still be visible)
 		await ignoreNote(id, this.workspaceRoot);
+
+		// Remove the visible <branchFolder>/note--<id>.md in dual-write/folder
+		// modes so the Memory Bank tree view stops showing a ghost file. Goes
+		// through the Bridge so it picks up the extension's DualWriteStorage
+		// instance (see handleRemovePlan for the rationale).
+		await this.bridge.cleanupVisibleNoteArtifact(id, summary.branch);
+
 		this.update(updatedSummary);
 	}
 
@@ -2194,7 +2200,7 @@ export class SummaryWebviewPanel {
 			linearIssues:
 				updatedLinearIssues.length > 0 ? updatedLinearIssues : undefined,
 		};
-		await storeSummary(updatedSummary, this.workspaceRoot, true);
+		await this.bridge.storeSummary(updatedSummary, true);
 		this.currentSummary = updatedSummary;
 
 		// Hide both entries from the panel: the snapshot key and the ticketId
@@ -2238,10 +2244,9 @@ export class SummaryWebviewPanel {
 		});
 
 		// Save translated content and sync title to summary + registry
-		await storePlans(
+		await this.bridge.storePlans(
 			[{ slug, content: translated }],
 			`Translate plan ${slug} to English`,
-			this.workspaceRoot,
 		);
 		await this.syncPlanTitle(slug, translated);
 
@@ -2293,10 +2298,9 @@ export class SummaryWebviewPanel {
 		});
 
 		// Save translated content to orphan branch
-		await storeNotes(
+		await this.bridge.storeNotes(
 			[{ id, content: translated }],
 			`Translate note ${id} to English`,
-			this.workspaceRoot,
 		);
 
 		// Sync title and (for snippets) inline content in the summary
@@ -2320,7 +2324,7 @@ export class SummaryWebviewPanel {
 				...this.currentSummary,
 				notes: updatedNotes,
 			};
-			await storeSummary(updatedSummary, this.workspaceRoot, true);
+			await this.bridge.storeSummary(updatedSummary, true);
 			this.currentSummary = updatedSummary;
 		}
 
@@ -2548,7 +2552,7 @@ export class SummaryWebviewPanel {
 		}
 
 		if (writes.length > 0 || deletes.length > 0) {
-			await saveTranscriptsBatch(writes, deletes, this.workspaceRoot);
+			await this.bridge.saveTranscriptsBatch(writes, deletes);
 		}
 
 		// Refresh cache and webview
@@ -2567,7 +2571,7 @@ export class SummaryWebviewPanel {
 			return;
 		}
 
-		await saveTranscriptsBatch([], hashes, this.workspaceRoot);
+		await this.bridge.saveTranscriptsBatch([], hashes);
 
 		// Refresh cache and webview
 		if (this.currentSummary) {
@@ -2665,7 +2669,7 @@ async function cleanupOrphanedDocs(
 	updatedSummary: CommitSummary,
 	baseUrl: string,
 	apiKey: string,
-	workspaceRoot: string,
+	bridge: JolliMemoryBridge,
 ): Promise<CommitSummary | null> {
 	const orphanedIds = originalSummary.orphanedDocIds
 		? [...originalSummary.orphanedDocIds]
@@ -2705,7 +2709,7 @@ async function cleanupOrphanedDocs(
 			? { orphanedDocIds: remaining }
 			: { orphanedDocIds: undefined }),
 	};
-	await storeSummary(cleaned, workspaceRoot, true);
+	await bridge.storeSummary(cleaned, true);
 	return cleaned;
 }
 


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## Quick recap

This batch of commits fixed a critical data loss bug and added new features for managing AI conversations and memory artifacts. When users performed squash or rebase operations on commits containing archived plans or notes, the system was losing track of those entries entirely—they would vanish from the panel or point to commit hashes that no longer existed. The developer fixed this by migrating guard entries during rebase and squash operations, and by preserving the archive-time content hash so that users' uncommitted edits to archived items remain detectable after the operation completes. Users can now safely rebase and squash without losing their archived plans and notes.

The extension's webview panel was also writing summaries, plans, notes, and transcripts only to an internal branch, leaving the user-visible Memory Bank folder stale. The developer threaded storage through the webview's write operations and added cleanup logic to delete visible Markdown files when plans or notes are removed from the summary panel. Users now see their edits reflected immediately in the Memory Bank folder, and deleted items no longer appear as ghost files in the tree view.

---

## E2E Test (7)
<details>
<summary><strong>1. Plans and notes persist after squash or rebase operation</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a git repository with at least one archived plan or note in the Memory Bank folder. The plan or note should have been created on a commit that you can later squash or rebase.

**Steps:**
1. Open the Memory Bank folder in your file explorer and verify that a plan file (named `plan--<name>.md`) or note file (named `note--<id>.md`) is visible in a branch folder.
2. In your git client, perform a squash or rebase operation on the commit that contains the plan or note.
3. After the squash or rebase completes, refresh the Memory Bank folder view in your file explorer.
4. Verify that the plan or note file is still visible in the branch folder (it should now be associated with the new commit hash).
5. Open the plan or note file and confirm its content is intact and unchanged.

**Expected Results:**
- The plan or note file should remain visible in the Memory Bank folder after the squash or rebase.
- The file should not appear as a "ghost" or stale entry.
- The content of the file should be exactly as it was before the operation.
- If you later edit the source file and commit, the system should detect the edit as a "revived" plan or note (not lose track of it).

</blockquote>
</details>
<details>
<summary><strong>2. Webview writes to plans and notes sync to Memory Bank folder</strong></summary>
<br>
<blockquote>

**Preconditions:** Have the VS Code extension open with a Memory Bank folder configured. Have at least one plan or note already created.

**Steps:**
1. Open the summary detail panel in the VS Code webview.
2. Click on an existing plan or note to open its editor.
3. Make a small edit to the plan or note (e.g. add a sentence or change a title).
4. Click the save button in the webview panel.
5. Switch to your file explorer and refresh the Memory Bank folder view.
6. Open the corresponding `plan--<name>.md` or `note--<id>.md` file in the folder.

**Expected Results:**
- The edit you made in the webview should appear in the visible Markdown file in the Memory Bank folder.
- The file should not be empty or stale.
- The change should be immediately visible without requiring a commit or manual sync.

</blockquote>
</details>
<details>
<summary><strong>3. Deleted plans and notes are removed from Memory Bank folder</strong></summary>
<br>
<blockquote>

**Preconditions:** Have the VS Code extension open with a Memory Bank folder configured. Have at least one plan or note visible in the folder.

**Steps:**
1. Open the summary detail panel in the VS Code webview.
2. Locate the plan or note you want to delete.
3. Click the delete or remove button for that plan or note.
4. Confirm the deletion when prompted.
5. Switch to your file explorer and refresh the Memory Bank folder view.

**Expected Results:**
- The corresponding `plan--<name>.md` or `note--<id>.md` file should be removed from the branch folder.
- The file should no longer appear in the file explorer.
- The hidden `.jolli/` metadata files should still exist (not visible to the user, but the system should retain them for recovery).
- If you undo the deletion in the webview, the visible file should reappear in the folder.

</blockquote>
</details>
<details>
<summary><strong>4. Warning appears when writes fall back to orphan branch storage</strong></summary>
<br>
<blockquote>

**Preconditions:** Have the VS Code extension running with debug logging enabled (or check the extension output panel).

**Steps:**
1. Perform an operation that writes a plan, note, or summary through the webview (e.g. edit and save a plan).
2. Open the VS Code output panel and look for the "Jolli Memory" or extension log channel.
3. Search the logs for a warning message about "orphan branch" or "storage resolution fallback".

**Expected Results:**
- If the Memory Bank folder is not properly configured or the storage parameter was not threaded through, a warning message should appear in the logs.
- The warning should include the current working directory for context.
- The warning should NOT appear during test runs (it is suppressed in test mode).
- If the Memory Bank folder is properly configured, no warning should appear.

</blockquote>
</details>
<details>
<summary><strong>5. Uncommitted edits to archived plans or notes are detected after squash or rebase</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a git repository with an archived plan or note. Have the source file (e.g. `plan.md`) locally edited but not yet committed.

**Steps:**
1. Edit the source file for an archived plan or note (e.g. add text to `plan.md`).
2. Do not commit this change yet.
3. Perform a squash or rebase operation on the commit that contains the archived plan or note.
4. After the squash or rebase completes, run a post-commit detection or refresh the Memory Bank view.
5. Check the summary detail panel or the registry to see if the plan or note is marked as "revived" or shows uncommitted edits.

**Expected Results:**
- The system should detect that the source file has been edited since the archive time.
- The plan or note should be surfaced as a "revived" entry (not lost or orphaned).
- The edit should be attributed to the new commit hash (after the squash or rebase), not the old one.
- The system should not silently lose track of the uncommitted changes.

</blockquote>
</details>
<details>
<summary><strong>6. Guard entry commit hash is updated during squash or rebase, but archive-time content hash is preserved</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a plan or note that was archived, then edited in the source file (but not committed), then squashed or rebased.

**Steps:**
1. Create and archive a plan or note on commit A.
2. Edit the source file for that plan or note (do not commit).
3. Perform a squash or rebase that rewrites commit A to commit B.
4. Inspect the internal registry (plans.json or notes.json) to verify the guard entry.
5. Check that the guard entry's commit hash points to B, but the archive-time content hash is unchanged.

**Expected Results:**
- The guard entry's `commitHash` should be updated to the new commit B.
- The guard entry's `contentHashAtCommit` should remain the same as before the squash or rebase.
- This preservation ensures that the next post-commit detection can still detect the uncommitted edits as a "revival" signal.

</blockquote>
</details>
<details>
<summary><strong>7. Hand-edited plan or note files are preserved when deletion is attempted</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a plan or note file in the Memory Bank folder. Manually edit the file in a text editor to add custom content not generated by the system.

**Steps:**
1. Open a plan or note file (e.g. `plan--my-plan.md`) in a text editor.
2. Add custom content or modify the file in a way that changes its fingerprint (e.g. add a custom section).
3. Save the file.
4. In the VS Code webview, attempt to delete that plan or note.
5. Check the file explorer to see if the file still exists.

**Expected Results:**
- The file should NOT be deleted because its fingerprint no longer matches the system-generated version.
- The file should remain in the Memory Bank folder with your custom edits intact.
- The system should preserve hand-edited files to avoid data loss.
- The manifest entry for the file should also be preserved.

</blockquote>
</details>

---

## Topics (5)
<details>
<summary><strong>01 · Fix squash/rebase guard migration to preserve archive-time content hash</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

When users edited an already-archived plan or note but had not yet committed those edits, then performed a squash or rebase operation, the system would silently lose track of those uncommitted changes. The next post-commit detection would fail to surface the edits as a "revived" guard because the archive-time content hash had been overwritten during the guard migration.

**💡 Decisions Behind the Code**

The archive-time content hash is a load-bearing invariant for the revival detection system. Post-commit detection relies on the inequality `liveHash !== contentHashAtCommit` to identify when a user has edited an archived plan or note since it was last committed. Recomputing the hash from the live file during squash or rebase would silently erase this signal, causing edits to vanish from the user's view. Since these operations do not commit the working-tree state—they only rewrite commit metadata—there is no semantic reason to update the archive-time anchor.

**✅ What Was Implemented**

Removed the `recomputeContentHashAtCommit` helper function and its call sites in `associatePlanWithCommit` and `associateNoteWithCommit`. The guard migration now preserves the original `contentHashAtCommit` unchanged, since squash and rebase operations only rewrite commit metadata, not file content. Updated docstrings to clarify that the guard's `commitHash` is migrated to the new commit, but `contentHashAtCommit` (the archive-time anchor) is left untouched. Flipped two test cases in SessionTracker.test.ts to assert the correct invariant: `contentHashAtCommit` must survive the migration so that uncommitted edits still trigger revival detection on the next post-commit run.

**📁 FILES**
- `cli/src/core/SessionTracker.ts`
- `cli/src/core/SessionTracker.test.ts`

</blockquote>
</details>
<details>
<summary><strong>02 · Persist plan and note state across squash and rebase operations</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

When users squashed or rebased commits containing archived plans or notes, the registry entries became orphaned—the guard entry pointed to a commit hash that no longer existed in git, causing the panel to display stale entries with invalid commit references instead of tracking them under the new commit.

**💡 Decisions Behind the Code**

- **Centralized migration in associate functions over scattered call sites**: The fix was placed in `associatePlanWithCommit()` and `associateNoteWithCommit()` rather than in reassociation paths because these helpers are the single point where all commit re-anchoring happens (squash, rebase-pick, and amend all flow through them). This ensures all future callers automatically benefit from guard migration without scattering the logic across multiple call sites.
- **Guard entry migration as the source-of-truth fix over post-hoc detection**: Rather than trying to detect and repair orphaned entries after the fact, the approach migrates the guard entry itself during the rebase or squash operation. This ensures the registry remains the single source of truth and avoids race conditions where detection might miss entries or run at the wrong time in the commit lifecycle.
- **Revived-guard detection for iterative edits**: Users often continue editing a plan after archiving it. Instead of treating this as an error or requiring manual re-archiving, the system automatically detects when `contentHashAtCommit` no longer matches the live source and re-anchors the entry to the current commit. This preserves user intent without requiring explicit action.
- **Defensive pattern matching**: The guard migration only triggers when the archive ID has the `-XXXXXXXX` suffix pattern and the guard's existing `commitHash` matches that suffix, providing defensive checks against accidental overwrites if the registry state is inconsistent.

**✅ What Was Implemented**

Modified `associatePlanWithCommit()` and `associateNoteWithCommit()` in SessionTracker.ts to detect and migrate paired guard entries when an archive entry is re-anchored to a new commit. The migration logic parses the archive ID's embedded short hash suffix, identifies the corresponding guard entry, and updates the guard's `commitHash` to reflect the new commit. Added `splitArchivedKey()` helper to extract the guard entry name from archive-format entry IDs. Extended `detectPlanSlugsFromRegistry()` and `detectUncommittedNoteIds()` in QueueWorker.ts to surface "revived" guard entries—cases where a user continued editing a previously-archived plan or note after the commit was rewritten. These entries are automatically re-anchored to the current commit instead of remaining stuck on a stale hash. Added `safeHashFileSync()` helper to safely read and hash source files, returning null when files are missing or unreadable so that missing-file cases are excluded from revival detection.

**📁 FILES**
- `cli/src/core/SessionTracker.ts`
- `cli/src/hooks/QueueWorker.ts`

</blockquote>
</details>
<details>
<summary><strong>03 · Thread storage through webview writes and sync Memory Bank folder</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The VS Code extension's webview panel was writing summaries, plans, notes, and transcripts only to the orphan branch, leaving the Memory Bank folder stale. Operations like translate, edit topic, and save snippet never synchronized to the user-visible Markdown layer.

**💡 Decisions Behind the Code**

- **Non-breaking optional parameter over forced refactor**: The non-breaking parameter approach (adding `storage?` as a trailing optional argument) allows `QueueWorker` to continue using the global `setActiveStorage` override without modification, while the extension explicitly threads its storage through the Bridge. This avoids forcing a refactor of the CLI's queue-worker initialization and keeps the two execution contexts (CLI background worker vs. extension foreground) independent.
- **Explicit threading in Bridge over global state**: The Bridge already held the storage instance and used it for reads; extending this pattern to writes makes the threading explicit and auditable at every call site, avoiding a global state dependency that would break multi-workspace safety.

**✅ What Was Implemented**

Added optional `storage?: StorageProvider` parameter to all five `SummaryStore` writer functions (`storeSummary`, `storePlans`, `storeNotes`, `storeLinearIssues`, `saveTranscriptsBatch`) and the two archive functions in `PlanService` and `NoteService`, allowing callers to inject a dual-write storage backend. Created seven storage-aware wrapper methods in `JolliMemoryBridge` (`storeSummary`, `storePlans`, `storeNotes`, `storeLinearIssues`, `saveTranscriptsBatch`, `archivePlanForCommit`, `archiveNoteForCommit`) that retrieve the Bridge's `DualWriteStorage` instance and pass it through to the underlying functions. Updated `SummaryWebviewPanel` to route all 24+ write operations through the Bridge wrappers instead of calling `SummaryStore` directly, eliminating the orphan-only code path for webview writes.

**📁 FILES**
- `cli/src/core/SummaryStore.ts`
- `vscode/src/JolliMemoryBridge.ts`
- `vscode/src/views/SummaryWebviewPanel.ts`

</blockquote>
</details>
<details>
<summary><strong>04 · Delete visible Memory Bank copies when plans and notes are removed</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

When users deleted plans or notes from the summary detail panel, the orphan branch metadata was updated but the user-visible Markdown files in the Memory Bank folder remained, appearing as stale "ghost files" in the tree view.

**💡 Decisions Behind the Code**

- **Shared deletion helper over duplicated logic**: Extracting `deleteVisibleArtifact` consolidates manifest lookup, branch folder resolution, fingerprint validation, and TOCTOU defense into one place, reducing maintenance burden and ensuring consistent behavior across all three deletion paths.
- **Visible-layer cleanup only, not registry cleanup**: Deleting a plan's visible markdown does not touch the orphan-branch source, the hidden `.jolli/` mirror, or the local registry. These remain addressable for future re-association, preserving the system of record and allowing users to recover deleted plans if needed.

**✅ What Was Implemented**

Added `deletePlanVisible` and `deleteNoteVisible` optional methods to the `StorageProvider` interface, implemented by `FolderStorage` to remove the user-visible `plan--<slug>.md` and `note--<id>.md` files from the branch folder while preserving the orphan-branch source and hidden `.jolli/` mirrors. Refactored `FolderStorage` to extract a shared `deleteVisibleArtifact` helper that handles manifest lookup, branch folder resolution, fingerprint validation, and TOCTOU defense for all three visible-layer deletion paths (summary, plan, note), eliminating duplicated logic. Extended `DualWriteStorage` to delegate plan and note deletion to the folder-side provider with error handling and dirty-flag marking. Wired the new delete methods through `SummaryWebviewPanel`'s remove-plan and remove-note paths so the visible files are cleaned up alongside the unassociation.

**📁 FILES**
- `cli/src/core/StorageProvider.ts`
- `cli/src/core/FolderStorage.ts`
- `vscode/src/JolliMemoryBridge.ts`

</blockquote>
</details>
<details>
<summary><strong>05 · Warn when storage resolution falls back to orphan branch</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

When callers forget to thread the storage parameter through function calls, the system silently falls back to orphan branch storage, causing folder-mode users to lose writes without any visible indication.

**💡 Decisions Behind the Code**

Fail-safe with visibility over silent failure: keeping orphan branch as the fallback ensures data is never lost, but adding a warning makes the bug visible in debug logs rather than manifesting as phantom missing files weeks later. This balances safety (users don't lose data) with debuggability (developers see the problem immediately).

**✅ What Was Implemented**

Modified `resolveStorage` in `SummaryStore.ts` to emit a warning log message when falling back to `OrphanBranchStorage`, including the current working directory for context. The warning is suppressed during test runs (when `VITEST` environment variable is set) to avoid spam in test output.

**📋 Future Enhancements**

After the storage-threading migration completes, monitor whether the fallback warning fires in production. If it does, investigate which call sites were missed and add them to the storage-threading migration. Consider adding a `jolli folder reconcile` command to backfill any writes that were silently lost to orphan branch during the transition period.

**📁 FILES**
- `cli/src/core/SummaryStore.ts`

</blockquote>
</details>

---

*Generated by Jolli Memory · May 19, 2026 at 2:09 PM · via Anthropic*
<!-- jollimemory-summary-end -->