### PR TITLE
Add healMissingVisibleMarkdown to restore deleted Memory Bank files

### DIFF
--- a/cli/src/Cli.ts
+++ b/cli/src/Cli.ts
@@ -33,6 +33,7 @@ import { registerConvertCommand } from "./commands/ConvertCommand.js";
 import { registerDoctorCommand } from "./commands/DoctorCommand.js";
 import { registerDisableCommand, registerEnableCommand } from "./commands/EnableCommand.js";
 import { registerExportCommand, registerExportPromptCommand } from "./commands/ExportCommand.js";
+import { registerHealFolderCommand } from "./commands/HealFolderCommand.js";
 import { registerMigrateCommand } from "./commands/MigrateCommand.js";
 import { registerNewCommand } from "./commands/NewCommand.js";
 import { registerRecallCommand } from "./commands/RecallCommand.js";
@@ -182,6 +183,7 @@ export async function main(args?: ReadonlyArray<string>): Promise<void> {
 	registerRecallCommand(program);
 	registerSearchCommand(program);
 	registerMigrateCommand(program);
+	registerHealFolderCommand(program);
 	registerExportPromptCommand(program);
 	registerExportCommand(program);
 	registerAuthCommands(program);

--- a/cli/src/commands/HealFolderCommand.test.ts
+++ b/cli/src/commands/HealFolderCommand.test.ts
@@ -1,0 +1,225 @@
+import { Command } from "commander";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { HealResult, StorageProvider } from "../core/StorageProvider.js";
+import { registerHealFolderCommand } from "./HealFolderCommand.js";
+
+// Mock the storage factory so the command never touches a real ~/.jolli config
+// or a real git repo. Each test installs its own implementation via mockResolvedValue.
+const { mockCreateStorage, mockLoadConfig } = vi.hoisted(() => ({
+	mockCreateStorage: vi.fn(),
+	mockLoadConfig: vi.fn(),
+}));
+
+vi.mock("../core/StorageFactory.js", () => ({
+	createStorage: mockCreateStorage,
+}));
+
+vi.mock("../core/SessionTracker.js", async () => ({
+	loadConfig: mockLoadConfig,
+}));
+
+// Logger writes to disk in setLogDir; skip that path so tests don't create files.
+vi.mock("../Logger.js", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../Logger.js")>();
+	return {
+		...actual,
+		setLogDir: vi.fn(),
+		createLogger: () => ({
+			info: vi.fn(),
+			warn: vi.fn(),
+			error: vi.fn(),
+			debug: vi.fn(),
+		}),
+	};
+});
+
+function makeProgram(): Command {
+	const program = new Command();
+	program.exitOverride();
+	registerHealFolderCommand(program);
+	return program;
+}
+
+async function runCommand(args: string[]): Promise<{ stdout: string; stderr: string }> {
+	let stdout = "";
+	let stderr = "";
+	const origLog = console.log;
+	const origErr = console.error;
+	console.log = (msg: string) => {
+		stdout += `${msg}\n`;
+	};
+	console.error = (msg: string) => {
+		stderr += `${msg}\n`;
+	};
+	try {
+		await makeProgram().parseAsync(["node", "jolli", "heal-folder", ...args]);
+	} finally {
+		console.log = origLog;
+		console.error = origErr;
+	}
+	return { stdout, stderr };
+}
+
+function makeStorageWith(result: HealResult | null): StorageProvider {
+	const base: StorageProvider = {
+		readFile: vi.fn(),
+		writeFiles: vi.fn(),
+		listFiles: vi.fn(),
+		exists: vi.fn().mockResolvedValue(true),
+		ensure: vi.fn(),
+	};
+	if (result !== null) {
+		return {
+			...base,
+			healMissingVisibleMarkdown: vi.fn().mockResolvedValue(result),
+		};
+	}
+	return base;
+}
+
+describe("registerHealFolderCommand", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockLoadConfig.mockResolvedValue({ storageMode: "dual-write" });
+	});
+
+	afterEach(() => {
+		process.exitCode = undefined;
+	});
+
+	it("prints 'Heal not available' when the active storage lacks the heal method", async () => {
+		mockCreateStorage.mockResolvedValue(makeStorageWith(null));
+		const { stdout } = await runCommand(["--cwd", "/tmp/jolli-heal-test-orphan"]);
+		expect(stdout).toContain("Heal not available");
+		expect(stdout).toContain("storageMode=dual-write");
+	});
+
+	it("prints 'Manifest is empty' when the manifest had no entries", async () => {
+		mockCreateStorage.mockResolvedValue(makeStorageWith({ healed: 0, skipped: 0, failed: 0 }));
+		const { stdout } = await runCommand(["--cwd", "/tmp/jolli-heal-test-empty"]);
+		expect(stdout).toContain("Manifest is empty");
+	});
+
+	it("prints 'No heal needed' when entries exist but everything is on disk", async () => {
+		mockCreateStorage.mockResolvedValue(makeStorageWith({ healed: 0, skipped: 5, failed: 0 }));
+		const { stdout } = await runCommand(["--cwd", "/tmp/jolli-heal-test-clean"]);
+		expect(stdout).toContain("No heal needed");
+		expect(stdout).toContain("Skipped: 5");
+	});
+
+	it("reports healed counts and skipped files when files were regenerated", async () => {
+		mockCreateStorage.mockResolvedValue(makeStorageWith({ healed: 3, skipped: 18, failed: 0 }));
+		const { stdout } = await runCommand(["--cwd", "/tmp/jolli-heal-test-success"]);
+		expect(stdout).toContain("Healed:   3");
+		expect(stdout).toContain("Skipped:  18");
+		expect(stdout).not.toContain("Failed:");
+		expect(stdout).not.toContain("Re-run `jolli enable`");
+	});
+
+	it("reports failed entries with dropped IDs when manifest rows were dropped", async () => {
+		mockCreateStorage.mockResolvedValue(
+			makeStorageWith({
+				healed: 0,
+				skipped: 4,
+				failed: 2,
+				droppedIds: ["aabbccdd00112233", "eeff445566778899"],
+			}),
+		);
+		const { stdout } = await runCommand(["--cwd", "/tmp/jolli-heal-test-partial"]);
+		// Heal line is omitted when 0 — the CLI only prints non-zero counts.
+		expect(stdout).not.toMatch(/Healed:\s+0/);
+		expect(stdout).toContain("Failed:   2");
+		expect(stdout).toContain("Dropped from manifest: 2");
+		expect(stdout).toContain("aabbccdd, eeff4455");
+		expect(stdout).toContain("Re-run `jolli enable`");
+	});
+
+	it("folder-only mode keeps failed entries and tells the user not to expect orphan repopulation", async () => {
+		mockLoadConfig.mockResolvedValue({ storageMode: "folder" });
+		mockCreateStorage.mockResolvedValue(makeStorageWith({ healed: 0, skipped: 4, failed: 2 }));
+		const { stdout } = await runCommand(["--cwd", "/tmp/jolli-heal-test-folder-only"]);
+		expect(stdout).toContain("Failed:   2");
+		expect(stdout).not.toContain("Dropped from manifest");
+		expect(stdout).toContain("folder-only mode has no truth source");
+		expect(stdout).not.toContain("Re-run `jolli enable`");
+	});
+
+	it("reports both healed and failed counts together", async () => {
+		mockCreateStorage.mockResolvedValue(
+			makeStorageWith({ healed: 5, skipped: 10, failed: 1, droppedIds: ["dead00000000beef"] }),
+		);
+		const { stdout } = await runCommand(["--cwd", "/tmp/jolli-heal-test-mixed"]);
+		expect(stdout).toContain("Healed:   5");
+		expect(stdout).toContain("Skipped:  10");
+		expect(stdout).toContain("Failed:   1");
+	});
+
+	// When DualWriteStorage swallows a shadow exception it surfaces it via
+	// HealResult.error. The CLI must NOT report "No heal needed" in that case —
+	// the user explicitly ran a recovery command and deserves a true status.
+	it("prints an explicit error message when the heal pass aborted with an exception", async () => {
+		mockCreateStorage.mockResolvedValue(
+			makeStorageWith({ healed: 0, skipped: 0, failed: 0, error: "shadow storage manifest write failed" }),
+		);
+		const { stdout, stderr } = await runCommand(["--cwd", "/tmp/jolli-heal-test-errored"]);
+		expect(stderr).toContain("Heal errored");
+		expect(stderr).toContain("shadow storage manifest write failed");
+		expect(stdout).not.toContain("No heal needed");
+		expect(process.exitCode).toBe(1);
+	});
+
+	it("aborts with exit 1 when createStorage throws", async () => {
+		mockCreateStorage.mockRejectedValue(new Error("config.json corrupted"));
+		const { stderr } = await runCommand(["--cwd", "/tmp/jolli-heal-test-config-error"]);
+		expect(stderr).toContain("Heal aborted");
+		expect(stderr).toContain("config.json corrupted");
+		expect(stderr).toContain("jolli doctor");
+		expect(process.exitCode).toBe(1);
+	});
+
+	// Folder-only mode talks directly to FolderStorage which does NOT
+	// self-catch its manifest read/replace/regenerate throws. The CLI must
+	// wrap that path so a corrupted manifest / EACCES / ENOSPC becomes the
+	// same "Heal errored:" exit-1 path as a DualWriteStorage-surfaced error,
+	// instead of bubbling up as an uncaught promise rejection.
+	it("catches a synchronous throw from healMissingVisibleMarkdown (folder-only path)", async () => {
+		mockLoadConfig.mockResolvedValue({ storageMode: "folder" });
+		const base: StorageProvider = {
+			readFile: vi.fn(),
+			writeFiles: vi.fn(),
+			listFiles: vi.fn(),
+			exists: vi.fn().mockResolvedValue(true),
+			ensure: vi.fn(),
+		};
+		mockCreateStorage.mockResolvedValue({
+			...base,
+			healMissingVisibleMarkdown: vi.fn().mockRejectedValue(new Error("manifest.json is unreadable")),
+		});
+		const { stderr } = await runCommand(["--cwd", "/tmp/jolli-heal-test-folder-throw"]);
+		expect(stderr).toContain("Heal errored");
+		expect(stderr).toContain("manifest.json is unreadable");
+		expect(process.exitCode).toBe(1);
+	});
+
+	// When the underlying error carries an errno code (EACCES / ENOSPC / ...)
+	// the CLI must surface it so operators see the failure category, not just
+	// a bare message.
+	it("prepends the errno to the message when the thrown error has a `code`", async () => {
+		mockLoadConfig.mockResolvedValue({ storageMode: "folder" });
+		const eaccesError = Object.assign(new Error("permission denied opening manifest"), { code: "EACCES" });
+		const base: StorageProvider = {
+			readFile: vi.fn(),
+			writeFiles: vi.fn(),
+			listFiles: vi.fn(),
+			exists: vi.fn().mockResolvedValue(true),
+			ensure: vi.fn(),
+		};
+		mockCreateStorage.mockResolvedValue({
+			...base,
+			healMissingVisibleMarkdown: vi.fn().mockRejectedValue(eaccesError),
+		});
+		const { stderr } = await runCommand(["--cwd", "/tmp/jolli-heal-test-eacces"]);
+		expect(stderr).toContain("Heal errored: [EACCES] permission denied opening manifest");
+		expect(process.exitCode).toBe(1);
+	});
+});

--- a/cli/src/commands/HealFolderCommand.ts
+++ b/cli/src/commands/HealFolderCommand.ts
@@ -1,0 +1,146 @@
+/**
+ * `jolli heal-folder` — explicit recovery of Memory Bank visible `.md` files
+ * the manifest tracks but the filesystem no longer contains.
+ *
+ * Why an explicit command exists when the sidebar already heals on refresh:
+ * users who don't open the Folders panel, or whose IDE caches a stale tree,
+ * need a one-shot recovery they can run from the terminal.
+ */
+
+import type { Command } from "commander";
+import { loadConfig } from "../core/SessionTracker.js";
+import { createStorage } from "../core/StorageFactory.js";
+import type { HealResult } from "../core/StorageProvider.js";
+import { createLogger, errMsg, setLogDir } from "../Logger.js";
+import { resolveProjectDir } from "./CliUtils.js";
+
+const log = createLogger("heal-folder");
+
+async function readStorageMode(): Promise<"dual-write" | "folder" | "orphan"> {
+	try {
+		const cfg = (await loadConfig()) as Record<string, unknown>;
+		const mode = cfg.storageMode as string | undefined;
+		if (mode === "folder" || mode === "orphan") return mode;
+		return "dual-write";
+	} catch {
+		return "dual-write";
+	}
+}
+
+async function runHealFolder(cwd: string): Promise<number> {
+	const mode = await readStorageMode();
+
+	let storage: Awaited<ReturnType<typeof createStorage>>;
+	try {
+		storage = await createStorage(cwd, cwd);
+	} catch (err) {
+		console.error(`\n  Heal aborted: cannot open Memory Bank storage. ${errMsg(err)}`);
+		console.error("  Run `jolli doctor` to diagnose the underlying config/storage issue.\n");
+		log.error("createStorage failed: %s", errMsg(err));
+		return 1;
+	}
+
+	if (!storage.healMissingVisibleMarkdown) {
+		console.log(
+			"\n  Heal not available: this repo is configured for orphan-only storage. " +
+				"Run `jolli configure --set storageMode=dual-write` (or `folder`) first.\n",
+		);
+		return 0;
+	}
+
+	console.log("\n  Scanning Memory Bank manifest for missing visible Markdown files...");
+	// In dual-write mode the orphan branch is the system of record, so it's
+	// safe to drop manifest rows whose hidden JSON is also missing. In
+	// folder-only mode there is no truth source to repopulate from, so
+	// preserve every manifest row (heal-folder still counts them as failed
+	// for visibility, but never deletes).
+	//
+	// DualWriteStorage catches its own delegated throws and surfaces them as
+	// `result.error`. Folder-only mode calls FolderStorage directly — which
+	// does not self-catch its manifest read / replace / regenerate failures.
+	// Wrap so a corrupted manifest, disk-full, or permission error becomes
+	// the same user-facing "Heal errored:" path instead of an uncaught
+	// rejection.
+	let result: HealResult;
+	try {
+		result = await storage.healMissingVisibleMarkdown({
+			dropOrphanedManifestEntries: mode === "dual-write",
+		});
+	} catch (err) {
+		const code = (err as NodeJS.ErrnoException)?.code;
+		const message = errMsg(err);
+		console.error(`\n  Heal errored: ${code ? `[${code}] ` : ""}${message}`);
+		console.error("  Re-run after resolving the underlying error (check storage permissions / disk space).\n");
+		log.error("heal-folder threw: %s%s", code ? `[${code}] ` : "", message);
+		return 1;
+	}
+
+	if (result.error) {
+		console.error(`  Heal errored: ${result.error}`);
+		console.error(
+			`  Counts may be partial: healed=${result.healed} skipped=${result.skipped} failed=${result.failed}`,
+		);
+		console.error("  Re-run after resolving the underlying error (check storage permissions / disk space).\n");
+		log.error("heal-folder errored: %s", result.error);
+		return 1;
+	}
+
+	if (result.healed === 0 && result.failed === 0) {
+		if (result.skipped === 0) {
+			console.log("  Manifest is empty — nothing to heal.\n");
+		} else {
+			console.log(`  No heal needed. Skipped: ${result.skipped} existing file(s).\n`);
+		}
+		log.info("heal-folder finished (no-op): skipped=%d", result.skipped);
+		return 0;
+	}
+
+	if (result.healed > 0) {
+		console.log(`  Healed:   ${result.healed} visible .md file(s) regenerated from hidden JSON`);
+	}
+	if (result.skipped > 0) {
+		// "Skipped" also covers entries whose manifest path drifted from the
+		// path heal would have computed — heal refuses to silently rewrite the
+		// manifest, leaving those for `jolli reconcile` to resolve.
+		console.log(
+			`  Skipped:  ${result.skipped} file(s) (already on disk or path-drifted — run \`jolli reconcile\` to resolve drift)`,
+		);
+	}
+	if (result.failed > 0) {
+		console.log(`  Failed:   ${result.failed} entry/entries (hidden JSON missing, malformed, or read-blocked)`);
+		const dropped = result.droppedIds ?? [];
+		if (dropped.length > 0) {
+			console.log(`            Dropped from manifest: ${dropped.length}`);
+			const preview = dropped
+				.slice(0, 5)
+				.map((id) => id.substring(0, 8))
+				.join(", ");
+			console.log(`              ${preview}${dropped.length > 5 ? ", ..." : ""}`);
+			console.log("            Re-run `jolli enable` to repopulate from the orphan branch.");
+		} else if (mode === "folder") {
+			console.log("            Manifest entries kept (folder-only mode has no truth source to repopulate).");
+			console.log(
+				"            Inspect `.jolli/manifest.json` and restore the hidden JSON, or remove the row manually.",
+			);
+		} else {
+			console.log("            Manifest entries kept (transient read error). Re-run later.");
+		}
+	}
+	console.log("");
+
+	log.info("heal-folder finished: healed=%d skipped=%d failed=%d", result.healed, result.skipped, result.failed);
+	return 0;
+}
+
+export function registerHealFolderCommand(program: Command): void {
+	program
+		.command("heal-folder")
+		.description("Restore missing Memory Bank Markdown files from the hidden JSON source")
+		.option("--cwd <dir>", "Project directory (default: git repo root)", resolveProjectDir())
+		.action(async (options: { cwd: string }) => {
+			setLogDir(options.cwd);
+			log.info("Running 'heal-folder' command");
+			const exit = await runHealFolder(options.cwd);
+			if (exit !== 0) process.exitCode = exit;
+		});
+}

--- a/cli/src/core/DualWriteStorage.test.ts
+++ b/cli/src/core/DualWriteStorage.test.ts
@@ -566,4 +566,180 @@ describe("DualWriteStorage", () => {
 			expect(markDirty).toHaveBeenCalled();
 		});
 	});
+
+	describe("healMissingVisibleMarkdown delegation", () => {
+		it("delegates to the folder-side provider and propagates the result", async () => {
+			const folderHeal = vi.fn().mockResolvedValue({ healed: 3, skipped: 5, failed: 1 });
+			const orphan = {
+				readFile: vi.fn(),
+				writeFiles: vi.fn(),
+				listFiles: vi.fn(),
+				exists: vi.fn().mockResolvedValue(true),
+				ensure: vi.fn(),
+			} as unknown as StorageProvider;
+			const folder = {
+				readFile: vi.fn(),
+				writeFiles: vi.fn(),
+				listFiles: vi.fn(),
+				exists: vi.fn().mockResolvedValue(true),
+				ensure: vi.fn(),
+				healMissingVisibleMarkdown: folderHeal,
+			} as unknown as StorageProvider;
+			const dual = new DualWriteStorage(orphan, folder);
+			const result = await dual.healMissingVisibleMarkdown();
+			expect(folderHeal).toHaveBeenCalled();
+			expect(result).toEqual({ healed: 3, skipped: 5, failed: 1 });
+		});
+
+		// Dual-write has the orphan branch as the truth source, so this seam
+		// MUST flip the drop flag on by default — that's the only way reconcile
+		// stops re-reporting ghost rows that migration can repopulate.
+		it("forwards dropOrphanedManifestEntries=true to the shadow by default", async () => {
+			const folderHeal = vi.fn().mockResolvedValue({ healed: 0, skipped: 0, failed: 0 });
+			const orphan = {
+				readFile: vi.fn(),
+				writeFiles: vi.fn(),
+				listFiles: vi.fn(),
+				exists: vi.fn().mockResolvedValue(true),
+				ensure: vi.fn(),
+			} as unknown as StorageProvider;
+			const folder = {
+				readFile: vi.fn(),
+				writeFiles: vi.fn(),
+				listFiles: vi.fn(),
+				exists: vi.fn().mockResolvedValue(true),
+				ensure: vi.fn(),
+				healMissingVisibleMarkdown: folderHeal,
+			} as unknown as StorageProvider;
+			const dual = new DualWriteStorage(orphan, folder);
+			await dual.healMissingVisibleMarkdown();
+			expect(folderHeal).toHaveBeenCalledWith({ dropOrphanedManifestEntries: true });
+		});
+
+		it("honours an explicit dropOrphanedManifestEntries=false override", async () => {
+			const folderHeal = vi.fn().mockResolvedValue({ healed: 0, skipped: 0, failed: 0 });
+			const orphan = {
+				readFile: vi.fn(),
+				writeFiles: vi.fn(),
+				listFiles: vi.fn(),
+				exists: vi.fn().mockResolvedValue(true),
+				ensure: vi.fn(),
+			} as unknown as StorageProvider;
+			const folder = {
+				readFile: vi.fn(),
+				writeFiles: vi.fn(),
+				listFiles: vi.fn(),
+				exists: vi.fn().mockResolvedValue(true),
+				ensure: vi.fn(),
+				healMissingVisibleMarkdown: folderHeal,
+			} as unknown as StorageProvider;
+			const dual = new DualWriteStorage(orphan, folder);
+			await dual.healMissingVisibleMarkdown({ dropOrphanedManifestEntries: false });
+			expect(folderHeal).toHaveBeenCalledWith({ dropOrphanedManifestEntries: false });
+		});
+
+		it("returns zero counts when the folder side lacks the method (no visible layer)", async () => {
+			const orphan = {
+				readFile: vi.fn(),
+				writeFiles: vi.fn(),
+				listFiles: vi.fn(),
+				exists: vi.fn().mockResolvedValue(true),
+				ensure: vi.fn(),
+			} as unknown as StorageProvider;
+			const folder = {
+				readFile: vi.fn(),
+				writeFiles: vi.fn(),
+				listFiles: vi.fn(),
+				exists: vi.fn().mockResolvedValue(true),
+				ensure: vi.fn(),
+			} as unknown as StorageProvider;
+			const dual = new DualWriteStorage(orphan, folder);
+			await expect(dual.healMissingVisibleMarkdown()).resolves.toEqual({ healed: 0, skipped: 0, failed: 0 });
+		});
+
+		// Symmetry: if shadow lacks heal but primary has it (someone swapped
+		// them at construction), the fallback path is exercised. Today the
+		// canonical wiring is primary=orphan / shadow=folder; this test pins
+		// that the lookup is by capability, not slot.
+		it("falls back to the primary side when only the primary implements heal", async () => {
+			const primaryHeal = vi.fn().mockResolvedValue({ healed: 2, skipped: 0, failed: 0 });
+			const orphan = {
+				readFile: vi.fn(),
+				writeFiles: vi.fn(),
+				listFiles: vi.fn(),
+				exists: vi.fn().mockResolvedValue(true),
+				ensure: vi.fn(),
+				healMissingVisibleMarkdown: primaryHeal,
+			} as unknown as StorageProvider;
+			const folder = {
+				readFile: vi.fn(),
+				writeFiles: vi.fn(),
+				listFiles: vi.fn(),
+				exists: vi.fn().mockResolvedValue(true),
+				ensure: vi.fn(),
+			} as unknown as StorageProvider;
+			const dual = new DualWriteStorage(orphan, folder);
+			const result = await dual.healMissingVisibleMarkdown();
+			expect(primaryHeal).toHaveBeenCalled();
+			expect(result.healed).toBe(2);
+		});
+
+		it("marks dirty and returns error-tagged result when the folder side throws", async () => {
+			const folderHeal = vi.fn().mockRejectedValue(new Error("manifest read failed"));
+			const markDirty = vi.fn();
+			const orphan = {
+				readFile: vi.fn(),
+				writeFiles: vi.fn(),
+				listFiles: vi.fn(),
+				exists: vi.fn().mockResolvedValue(true),
+				ensure: vi.fn(),
+			} as unknown as StorageProvider;
+			const folder = {
+				readFile: vi.fn(),
+				writeFiles: vi.fn(),
+				listFiles: vi.fn(),
+				exists: vi.fn().mockResolvedValue(true),
+				ensure: vi.fn(),
+				healMissingVisibleMarkdown: folderHeal,
+				markDirty,
+			} as unknown as StorageProvider;
+			const dual = new DualWriteStorage(orphan, folder);
+			const result = await dual.healMissingVisibleMarkdown();
+			expect(result.healed).toBe(0);
+			expect(result.skipped).toBe(0);
+			expect(result.failed).toBe(0);
+			// The error channel distinguishes a true no-op from a swallowed
+			// throw — the CLI / sidebar use this to avoid lying to the user.
+			expect(result.error).toBe("manifest read failed");
+			expect(markDirty).toHaveBeenCalledWith("healMissingVisibleMarkdown");
+		});
+
+		// When the swallowed throw carries an errno (EACCES on a permission
+		// issue, ENOSPC on a full disk, EBUSY on antivirus locks) the surfaced
+		// error must prepend the code so a downstream operator can dispatch on
+		// the failure category, not just guess from prose.
+		it("prepends the errno code to the surfaced error message", async () => {
+			const eacces = Object.assign(new Error("manifest is read-only"), { code: "EACCES" });
+			const folderHeal = vi.fn().mockRejectedValue(eacces);
+			const orphan = {
+				readFile: vi.fn(),
+				writeFiles: vi.fn(),
+				listFiles: vi.fn(),
+				exists: vi.fn().mockResolvedValue(true),
+				ensure: vi.fn(),
+			} as unknown as StorageProvider;
+			const folder = {
+				readFile: vi.fn(),
+				writeFiles: vi.fn(),
+				listFiles: vi.fn(),
+				exists: vi.fn().mockResolvedValue(true),
+				ensure: vi.fn(),
+				healMissingVisibleMarkdown: folderHeal,
+				markDirty: vi.fn(),
+			} as unknown as StorageProvider;
+			const dual = new DualWriteStorage(orphan, folder);
+			const result = await dual.healMissingVisibleMarkdown();
+			expect(result.error).toBe("[EACCES] manifest is read-only");
+		});
+	});
 });

--- a/cli/src/core/DualWriteStorage.ts
+++ b/cli/src/core/DualWriteStorage.ts
@@ -8,7 +8,7 @@
 
 import { createLogger, errMsg } from "../Logger.js";
 import type { FileWrite, SummaryIndexEntry } from "../Types.js";
-import type { StorageProvider } from "./StorageProvider.js";
+import type { HealOptions, HealResult, StorageProvider } from "./StorageProvider.js";
 
 const log = createLogger("DualWriteStorage");
 
@@ -86,6 +86,44 @@ export class DualWriteStorage implements StorageProvider {
 		} catch (err) {
 			log.warn("Shadow deleteNoteVisible failed (folder storage) for %s on %s: %s", id, branch, errMsg(err));
 			this.shadow.markDirty?.(`deleteNoteVisible ${branch}/${id}`);
+		}
+	}
+
+	async healMissingVisibleMarkdown(opts?: HealOptions): Promise<HealResult> {
+		// Heal target is the visible layer — only the folder side has one.
+		// Try shadow first (the canonical wiring in StorageFactory), then
+		// primary as a fallback in case the two are ever swapped at construction.
+		const target = this.shadow.healMissingVisibleMarkdown
+			? this.shadow
+			: this.primary.healMissingVisibleMarkdown
+				? this.primary
+				: null;
+		if (!target) return { healed: 0, skipped: 0, failed: 0 };
+		// The orphan branch is the system of record in dual-write mode, so a
+		// manifest row whose hidden JSON is also missing can be re-sourced by
+		// migration / enable. Pass through the caller's flag, defaulting to
+		// true at this seam: callers reach DualWriteStorage exactly when there
+		// IS a truth source to repopulate from.
+		const dropOrphanedManifestEntries = opts?.dropOrphanedManifestEntries ?? true;
+		// Pick a log label that names which side actually ran so post-mortems
+		// of error logs don't have to re-derive it from context. "Shadow" is
+		// the canonical wiring; the primary fallback is rare but reachable.
+		const targetLabel = target === this.shadow ? "shadow" : "primary";
+		try {
+			// The optional-chain guard at construction above guarantees the
+			// method exists on `target`; the `?.` here is for the linter.
+			const result = await target.healMissingVisibleMarkdown?.({ dropOrphanedManifestEntries });
+			return result ?? { healed: 0, skipped: 0, failed: 0 };
+		} catch (err) {
+			// Prepend the errno when present so the CLI surface and debug log
+			// both name the failure category. `errMsg` alone gives the raw
+			// message which often lacks the code (e.g. EACCES vs ENOSPC vs
+			// EBUSY) that drives the operator's next step.
+			const code = (err as NodeJS.ErrnoException)?.code;
+			const message = code ? `[${code}] ${errMsg(err)}` : errMsg(err);
+			log.warn("%s healMissingVisibleMarkdown failed: %s", targetLabel, message);
+			target.markDirty?.("healMissingVisibleMarkdown");
+			return { healed: 0, skipped: 0, failed: 0, error: message };
 		}
 	}
 

--- a/cli/src/core/FolderStorage.test.ts
+++ b/cli/src/core/FolderStorage.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -825,6 +825,406 @@ describe("FolderStorage", () => {
 			expect(wrote).toBe(true);
 			// Manifest title now mirrors the summary commit message.
 			expect(metadataManager.findById(commitHash)?.title).toBe("Fresh recovery commit");
+		});
+	});
+
+	// Regression coverage for the "visible .md vanished, manifest entry kept,
+	// hidden JSON intact" disk state. Pins the contract that:
+	//   - MetadataManager.reconcile preserves the manifest row (it's
+	//     deliberately conservative — its missing-file branch only logs WARN).
+	//   - Recovery is the explicit responsibility of healMissingVisibleMarkdown
+	//     (or regenerateVisibleMarkdown for a single entry).
+	describe("reconcile preserves missing entries; heal is the recovery path", () => {
+		beforeEach(async () => {
+			await storage.ensure();
+		});
+
+		it("reconcile keeps the manifest entry and leaves the .md missing", async () => {
+			const summaryJson = makeSummaryJson({
+				commitHash: "0011223344556677",
+				commitMessage: "feat: icon style",
+				branch: "feature/icon-style",
+			});
+			await storage.writeFiles([{ path: "summaries/0011223344556677.json", content: summaryJson }], "seed");
+
+			const branchDir = join(rootPath, "feature-icon-style");
+			const visiblePath = join(branchDir, "feat-icon-style-00112233.md");
+			const hiddenJsonPath = join(rootPath, ".jolli", "summaries", "0011223344556677.json");
+
+			expect(existsSync(visiblePath)).toBe(true);
+			expect(existsSync(hiddenJsonPath)).toBe(true);
+			expect(metadataManager.findById("0011223344556677")).toBeDefined();
+
+			unlinkSync(visiblePath);
+
+			const fixed = metadataManager.reconcile(rootPath);
+
+			expect(fixed).toBe(0);
+			expect(metadataManager.findById("0011223344556677")).toBeDefined();
+			expect(existsSync(hiddenJsonPath)).toBe(true);
+			// reconcile is intentionally non-healing — recovery lives in heal.
+			expect(existsSync(visiblePath)).toBe(false);
+		});
+
+		it("regenerateVisibleMarkdown recovers the same file reconcile leaves missing", async () => {
+			const summaryJson = makeSummaryJson({
+				commitHash: "0011223344556677",
+				commitMessage: "feat: icon style",
+				branch: "feature/icon-style",
+			});
+			await storage.writeFiles([{ path: "summaries/0011223344556677.json", content: summaryJson }], "seed");
+			const visiblePath = join(rootPath, "feature-icon-style", "feat-icon-style-00112233.md");
+			unlinkSync(visiblePath);
+			metadataManager.reconcile(rootPath);
+			expect(existsSync(visiblePath)).toBe(false);
+
+			const wrote = await storage.regenerateVisibleMarkdown({
+				commitHash: "0011223344556677",
+				commitMessage: "feat: icon style",
+				commitDate: "2026-01-15T10:00:00Z",
+				branch: "feature/icon-style",
+				generatedAt: "2026-01-15T10:00:00Z",
+				parentCommitHash: null,
+			});
+
+			expect(wrote).toBe(true);
+			expect(existsSync(visiblePath)).toBe(true);
+		});
+	});
+
+	describe("healMissingVisibleMarkdown", () => {
+		beforeEach(async () => {
+			await storage.ensure();
+		});
+
+		it("returns zero counts for an empty manifest", async () => {
+			const result = await storage.healMissingVisibleMarkdown();
+			expect(result).toEqual({ healed: 0, skipped: 0, failed: 0 });
+		});
+
+		it("regenerates the visible md when only the .md was deleted (hidden JSON intact)", async () => {
+			const summaryJson = makeSummaryJson({
+				commitHash: "0011223344556677",
+				commitMessage: "feat: icon style",
+				branch: "feature/icon-style",
+			});
+			await storage.writeFiles([{ path: "summaries/0011223344556677.json", content: summaryJson }], "seed");
+			const visiblePath = join(rootPath, "feature-icon-style", "feat-icon-style-00112233.md");
+			unlinkSync(visiblePath);
+
+			const result = await storage.healMissingVisibleMarkdown();
+
+			expect(result).toEqual({ healed: 1, skipped: 0, failed: 0 });
+			expect(existsSync(visiblePath)).toBe(true);
+			expect(metadataManager.findById("0011223344556677")).toBeDefined();
+		});
+
+		it("skips entries whose visible md is already on disk (counts as skipped)", async () => {
+			const summaryJson = makeSummaryJson({
+				commitHash: "alreadyhere12345",
+				commitMessage: "Already here",
+				branch: "main",
+			});
+			await storage.writeFiles([{ path: "summaries/alreadyhere12345.json", content: summaryJson }], "seed");
+			const visiblePath = join(rootPath, "main", "already-here-alreadyh.md");
+			const beforeBytes = readFileSync(visiblePath, "utf-8");
+
+			const result = await storage.healMissingVisibleMarkdown();
+
+			expect(result).toEqual({ healed: 0, skipped: 1, failed: 0 });
+			// Untouched (regenerateVisibleMarkdown short-circuits on existing file).
+			expect(readFileSync(visiblePath, "utf-8")).toBe(beforeBytes);
+		});
+
+		// Folder-only safety contract: the default heal call (no opts) must NOT
+		// drop manifest entries whose hidden JSON is also missing — the manifest
+		// is the last record we have in folder-only mode, and dropping it is
+		// permanent data loss.
+		it("keeps manifest entry when hidden JSON is also missing (default opts)", async () => {
+			const summaryJson = makeSummaryJson({
+				commitHash: "ghost11111111111",
+				commitMessage: "Lost commit",
+				branch: "main",
+			});
+			await storage.writeFiles([{ path: "summaries/ghost11111111111.json", content: summaryJson }], "seed");
+			unlinkSync(join(rootPath, "main", "lost-commit-ghost111.md"));
+			unlinkSync(join(rootPath, ".jolli", "summaries", "ghost11111111111.json"));
+
+			const result = await storage.healMissingVisibleMarkdown();
+
+			expect(result).toEqual({ healed: 0, skipped: 0, failed: 1 });
+			// Manifest entry preserved — no truth source to repopulate from.
+			expect(metadataManager.findById("ghost11111111111")).toBeDefined();
+		});
+
+		// Opt-in drop contract: callers backed by a truth source (orphan branch
+		// via DualWriteStorage, `jolli heal-folder` in dual-write mode) can
+		// request the drop so reconcile stops re-reporting the ghost.
+		it("drops manifest entry when hidden JSON is missing AND dropOrphanedManifestEntries=true", async () => {
+			const summaryJson = makeSummaryJson({
+				commitHash: "ghost22222222222",
+				commitMessage: "Lost commit",
+				branch: "main",
+			});
+			await storage.writeFiles([{ path: "summaries/ghost22222222222.json", content: summaryJson }], "seed");
+			unlinkSync(join(rootPath, "main", "lost-commit-ghost222.md"));
+			unlinkSync(join(rootPath, ".jolli", "summaries", "ghost22222222222.json"));
+
+			const result = await storage.healMissingVisibleMarkdown({ dropOrphanedManifestEntries: true });
+
+			expect(result.healed).toBe(0);
+			expect(result.failed).toBe(1);
+			expect(result.droppedIds).toEqual(["ghost22222222222"]);
+			expect(metadataManager.findById("ghost22222222222")).toBeUndefined();
+		});
+
+		// EACCES / EBUSY / EIO / antivirus locks must NEVER drop the manifest
+		// entry. Read errors that are not ENOENT are treated as transient.
+		it("does not drop manifest entry on transient (non-ENOENT) read errors even with drop opt-in", async () => {
+			const summaryJson = makeSummaryJson({
+				commitHash: "transientread123",
+				commitMessage: "Transient read",
+				branch: "main",
+			});
+			await storage.writeFiles([{ path: "summaries/transientread123.json", content: summaryJson }], "seed");
+			unlinkSync(join(rootPath, "main", "transient-read-transien.md"));
+
+			// Replace the hidden JSON file with a directory of the same name.
+			// readFileSync(dir, ...) throws with code "EISDIR" — a non-ENOENT
+			// failure that must NOT trigger a manifest drop.
+			const hiddenJsonPath = join(rootPath, ".jolli", "summaries", "transientread123.json");
+			unlinkSync(hiddenJsonPath);
+			mkdirSync(hiddenJsonPath, { recursive: true });
+
+			const result = await storage.healMissingVisibleMarkdown({ dropOrphanedManifestEntries: true });
+
+			expect(result.healed).toBe(0);
+			expect(result.failed).toBe(1);
+			expect(result.droppedIds).toBeUndefined();
+			expect(metadataManager.findById("transientread123")).toBeDefined();
+		});
+
+		// Malformed hidden JSON: heal cannot reconstruct without parseable data,
+		// but the data file is present so this is recoverable (user could fix
+		// the JSON by hand). Counts as failed; never drops.
+		it("counts malformed hidden JSON as failed and keeps the manifest entry", async () => {
+			const summaryJson = makeSummaryJson({
+				commitHash: "malformedjson456",
+				commitMessage: "Bad JSON",
+				branch: "main",
+			});
+			await storage.writeFiles([{ path: "summaries/malformedjson456.json", content: summaryJson }], "seed");
+			// hash8 = first 8 chars of commitHash ("malforme").
+			unlinkSync(join(rootPath, "main", "bad-json-malforme.md"));
+
+			const hiddenJsonPath = join(rootPath, ".jolli", "summaries", "malformedjson456.json");
+			writeFileSync(hiddenJsonPath, "{ this is : not valid json", "utf-8");
+
+			const result = await storage.healMissingVisibleMarkdown({ dropOrphanedManifestEntries: true });
+
+			expect(result.healed).toBe(0);
+			expect(result.failed).toBe(1);
+			expect(result.droppedIds).toBeUndefined();
+			expect(metadataManager.findById("malformedjson456")).toBeDefined();
+		});
+
+		// Path drift: the manifest's recorded path no longer matches the path
+		// the hidden JSON would produce. Heal must NOT silently rewrite the
+		// manifest path — that's a separate decision the caller should make
+		// after seeing the WARN.
+		it("WARNs and skips when the recomputed path diverges from the manifest path", async () => {
+			const summaryJson = makeSummaryJson({
+				commitHash: "drift00000000abcd",
+				commitMessage: "Original subject",
+				branch: "main",
+			});
+			await storage.writeFiles([{ path: "summaries/drift00000000abcd.json", content: summaryJson }], "seed");
+			const computedPath = join(rootPath, "main", "original-subject-drift000.md");
+			unlinkSync(computedPath);
+
+			// Forge the manifest so the recorded path points at a different file
+			// name. Heal must refuse to rewrite — that would orphan whatever the
+			// user has been navigating to.
+			const manifestPath = join(rootPath, ".jolli", "manifest.json");
+			const manifestRaw = JSON.parse(readFileSync(manifestPath, "utf-8")) as {
+				files: Array<{ fileId: string; path: string }>;
+			};
+			for (const f of manifestRaw.files) {
+				if (f.fileId === "drift00000000abcd") {
+					f.path = "renamed-folder/handpicked-name.md";
+				}
+			}
+			writeFileSync(manifestPath, JSON.stringify(manifestRaw, null, "\t"));
+			metadataManager = new MetadataManager(join(rootPath, ".jolli"));
+			storage = new FolderStorage(rootPath, metadataManager);
+
+			const result = await storage.healMissingVisibleMarkdown();
+
+			expect(result.healed).toBe(0);
+			// Path drift is counted under `skipped`, not `failed`: the hidden
+			// JSON is intact and the entry is recoverable via reconcile.
+			// `failed` is reserved for "hidden JSON missing / unreadable /
+			// malformed / regenerate refused" — those four cases the CLI's
+			// summary line names explicitly. Pinning this here so a future
+			// counter swap can't silently change what users see.
+			expect(result.failed).toBe(0);
+			expect(result.skipped).toBe(1);
+			// Manifest path NOT rewritten.
+			expect(metadataManager.findById("drift00000000abcd")?.path).toBe("renamed-folder/handpicked-name.md");
+			// Computed path NOT written either.
+			expect(existsSync(computedPath)).toBe(false);
+		});
+
+		it("ignores plan and note entries (only commits use heal-via-hidden-JSON)", async () => {
+			// One commit (will be healed), one plan, one note — heal must touch only the commit.
+			const summaryJson = makeSummaryJson({
+				commitHash: "commit1234567890",
+				commitMessage: "Real commit",
+				branch: "main",
+			});
+			await storage.writeFiles([{ path: "summaries/commit1234567890.json", content: summaryJson }], "c");
+			await storage.writeFiles([{ path: "plans/some-plan-deadbeef.md", content: "# Plan", branch: "main" }], "p");
+			await storage.writeFiles([{ path: "notes/some-note-cafebabe.md", content: "# Note", branch: "main" }], "n");
+
+			unlinkSync(join(rootPath, "main", "real-commit-commit12.md"));
+			unlinkSync(join(rootPath, "main", "plan--some-plan-deadbeef.md"));
+			unlinkSync(join(rootPath, "main", "note--some-note-cafebabe.md"));
+
+			const result = await storage.healMissingVisibleMarkdown();
+
+			expect(result.healed).toBe(1);
+			expect(result.failed).toBe(0);
+			expect(existsSync(join(rootPath, "main", "real-commit-commit12.md"))).toBe(true);
+			// Plans and notes have no hidden-JSON recovery path here — they aren't healed,
+			// but their manifest entries also aren't dropped (heal scope is commits only).
+			expect(metadataManager.findById("plan:some-plan-deadbeef")).toBeDefined();
+			expect(metadataManager.findById("note:some-note-cafebabe")).toBeDefined();
+		});
+
+		it("is idempotent — second call after a successful heal is a no-op", async () => {
+			const summaryJson = makeSummaryJson({
+				commitHash: "idempotent123456",
+				commitMessage: "Round trip",
+				branch: "main",
+			});
+			await storage.writeFiles([{ path: "summaries/idempotent123456.json", content: summaryJson }], "seed");
+			unlinkSync(join(rootPath, "main", "round-trip-idempote.md"));
+
+			const first = await storage.healMissingVisibleMarkdown();
+			const second = await storage.healMissingVisibleMarkdown();
+
+			expect(first.healed).toBe(1);
+			expect(second.healed).toBe(0);
+			expect(second.skipped).toBe(1);
+		});
+
+		// Reads the authoritative branch from the hidden JSON, not the manifest.
+		// The synthetic entry must NOT use `entry.source.branch` because legacy
+		// manifests can omit it — a `?? ""` fallback would route through
+		// `transcodeBranchName("")` → "default" and pollute branches.json.
+		it("uses the hidden JSON branch when the manifest entry's source.branch is absent", async () => {
+			const summaryJson = makeSummaryJson({
+				commitHash: "legacysrcbranch1",
+				commitMessage: "Legacy entry",
+				branch: "main",
+			});
+			await storage.writeFiles([{ path: "summaries/legacysrcbranch1.json", content: summaryJson }], "seed");
+			const correctPath = join(rootPath, "main", "legacy-entry-legacysr.md");
+			unlinkSync(correctPath);
+
+			// Simulate a legacy manifest entry that lost its source.branch backfill.
+			const manifestPath = join(rootPath, ".jolli", "manifest.json");
+			const manifestRaw = JSON.parse(readFileSync(manifestPath, "utf-8")) as {
+				files: Array<{ fileId: string; source: { branch?: string } }>;
+			};
+			for (const f of manifestRaw.files) {
+				if (f.fileId === "legacysrcbranch1") {
+					delete (f.source as { branch?: string }).branch;
+				}
+			}
+			writeFileSync(manifestPath, JSON.stringify(manifestRaw, null, "\t"));
+			metadataManager = new MetadataManager(join(rootPath, ".jolli"));
+			storage = new FolderStorage(rootPath, metadataManager);
+
+			const result = await storage.healMissingVisibleMarkdown();
+
+			expect(result).toEqual({ healed: 1, skipped: 0, failed: 0 });
+			expect(existsSync(correctPath)).toBe(true);
+			// Must NOT have written to a "default" branch folder.
+			expect(existsSync(join(rootPath, "default", "legacy-entry-legacysr.md"))).toBe(false);
+			// Must NOT have polluted branches.json with a ghost empty-branch mapping.
+			const branchesRaw = JSON.parse(readFileSync(join(rootPath, ".jolli", "branches.json"), "utf-8")) as {
+				mappings: Array<{ branch: string; folder: string }>;
+			};
+			expect(branchesRaw.mappings.find((m) => m.branch === "")).toBeUndefined();
+		});
+
+		// Reads the authoritative commitMessage from the hidden JSON, not the
+		// manifest. `entry.title` is preserved across regenerate to honour user
+		// edits and so can already diverge from the original commit subject;
+		// using it would emit a .md under a different slug.
+		it("uses the hidden JSON commitMessage when the manifest title has diverged", async () => {
+			const summaryJson = makeSummaryJson({
+				commitHash: "divergedtitle345",
+				commitMessage: "Original commit subject",
+				branch: "main",
+			});
+			await storage.writeFiles([{ path: "summaries/divergedtitle345.json", content: summaryJson }], "seed");
+			const correctPath = join(rootPath, "main", "original-commit-subject-diverged.md");
+			unlinkSync(correctPath);
+
+			// Simulate a manifest whose title field drifted away from the
+			// original commit subject (e.g. a future user-rename feature).
+			const manifestPath = join(rootPath, ".jolli", "manifest.json");
+			const manifestRaw = JSON.parse(readFileSync(manifestPath, "utf-8")) as {
+				files: Array<{ fileId: string; title?: string }>;
+			};
+			for (const f of manifestRaw.files) {
+				if (f.fileId === "divergedtitle345") {
+					f.title = "User renamed this entry";
+				}
+			}
+			writeFileSync(manifestPath, JSON.stringify(manifestRaw, null, "\t"));
+			metadataManager = new MetadataManager(join(rootPath, ".jolli"));
+			storage = new FolderStorage(rootPath, metadataManager);
+
+			const result = await storage.healMissingVisibleMarkdown();
+
+			expect(result).toEqual({ healed: 1, skipped: 0, failed: 0 });
+			expect(existsSync(correctPath)).toBe(true);
+			// Must NOT have written under the diverged title's slug.
+			expect(existsSync(join(rootPath, "main", "user-renamed-this-entry-diverged.md"))).toBe(false);
+		});
+
+		// Batch drop: N ghost rows must result in a single manifest rewrite,
+		// not N. We can't observe the IO directly without instrumenting, but
+		// we can verify the post-state is consistent (all N rows dropped,
+		// manifest still parseable, droppedIds returns all N fileIds).
+		it("batches manifest drops in a single rewrite when multiple entries are ghosts", async () => {
+			const ids = ["ghostA0000000aaaa", "ghostB0000000bbbb", "ghostC0000000cccc"];
+			for (const id of ids) {
+				const summaryJson = makeSummaryJson({
+					commitHash: id,
+					commitMessage: `Ghost ${id.slice(5, 6)}`,
+					branch: "main",
+				});
+				await storage.writeFiles([{ path: `summaries/${id}.json`, content: summaryJson }], "seed");
+				unlinkSync(join(rootPath, ".jolli", "summaries", `${id}.json`));
+			}
+			// Delete the visible files for all of them too.
+			for (const id of ids) {
+				const slugLetter = id.slice(5, 6).toUpperCase();
+				const hash8 = id.slice(0, 8);
+				unlinkSync(join(rootPath, "main", `ghost-${slugLetter.toLowerCase()}-${hash8}.md`));
+			}
+
+			const result = await storage.healMissingVisibleMarkdown({ dropOrphanedManifestEntries: true });
+
+			expect(result.failed).toBe(ids.length);
+			expect(result.droppedIds).toEqual(expect.arrayContaining(ids));
+			for (const id of ids) {
+				expect(metadataManager.findById(id)).toBeUndefined();
+			}
 		});
 	});
 

--- a/cli/src/core/FolderStorage.ts
+++ b/cli/src/core/FolderStorage.ts
@@ -17,7 +17,7 @@ import { dirname, join, relative } from "node:path";
 import { createLogger, errMsg } from "../Logger.js";
 import type { CommitSummary, FileWrite, SummaryIndex, SummaryIndexEntry } from "../Types.js";
 import { MetadataManager } from "./MetadataManager.js";
-import type { StorageProvider } from "./StorageProvider.js";
+import type { HealOptions, HealResult, StorageProvider } from "./StorageProvider.js";
 import { buildMarkdown } from "./SummaryMarkdownBuilder.js";
 
 const log = createLogger("FolderStorage");
@@ -209,22 +209,19 @@ export class FolderStorage implements StorageProvider {
 	/**
 	 * Re-emit the visible <branch>/<slug>-<hash8>.md from the hidden
 	 * .jolli/summaries/<hash>.json source. Idempotent: a `.md` already on disk
-	 * causes an early return without re-reading or re-writing. Used by
-	 * MigrationEngine.runStaleChildCleanup to recover head `.md` files that
-	 * 0.99.2's inverted leaf-only pass mistakenly deleted.
+	 * causes an early return.
 	 *
 	 * Returns true when the `.md` ended up on disk (regenerated or already
-	 * present), false when the hidden JSON source was missing or unparseable
-	 * — in which case regeneration is impossible and the caller can surface
-	 * a warning. See StorageProvider.regenerateVisibleMarkdown for the contract.
+	 * present), false when the hidden JSON was missing or unparseable.
+	 * See StorageProvider.regenerateVisibleMarkdown for the contract.
 	 *
-	 * Does NOT reuse `generateSummaryMarkdown`. That path is the normal-write
-	 * pipeline and has two side effects we must avoid here:
+	 * Does NOT reuse `generateSummaryMarkdown`. That path has two side
+	 * effects we must avoid when restoring a previously written entry:
 	 *   - it overwrites the manifest `title` field, clobbering user-edited
-	 *     titles (which `backfillTitle` is contractually obligated to preserve);
-	 *   - it calls `cleanupSupersededDescendants`, which only makes sense after
-	 *     a fresh write where a new root has just superseded older children —
-	 *     not when we're merely restoring a previously deleted head.
+	 *     titles that `backfillTitle` is contractually obligated to preserve;
+	 *   - it calls `cleanupSupersededDescendants`, which only makes sense
+	 *     after a fresh write where a new root has just superseded older
+	 *     children — not when we're merely restoring a previously deleted head.
 	 */
 	async regenerateVisibleMarkdown(entry: SummaryIndexEntry): Promise<boolean> {
 		const branchFolder = this.metadataManager.resolveFolderForBranch(entry.branch);
@@ -275,6 +272,188 @@ export class FolderStorage implements StorageProvider {
 		});
 		log.info("Regenerated visible MD: %s", relativePath);
 		return true;
+	}
+
+	/**
+	 * See StorageProvider.healMissingVisibleMarkdown for the contract.
+	 *
+	 * Implementation notes (the non-obvious bits):
+	 *
+	 *   - The hidden `.jolli/summaries/<hash>.json` is the single source of
+	 *     truth for `branch` + `commitMessage`. Manifest derivatives drift:
+	 *     `source.branch` is optional (legacy pre-backfill rows omit it; a
+	 *     `?? ""` fallback would route through `transcodeBranchName("")` →
+	 *     `"default"` and pollute `branches.json`), and `title` is preserved
+	 *     across regenerate to honour user edits.
+	 *   - ENOENT on the hidden JSON is treated differently from other read
+	 *     errors. ENOENT is "really gone" and (when the caller opts in)
+	 *     eligible for manifest drop; EACCES / EBUSY / EIO are transient and
+	 *     NEVER drop — the manifest row is the last record we have.
+	 *   - Manifest drops are batched into a single rewrite at the end. The
+	 *     prior per-row `removeFromManifest` was O(N²) on ghost-heavy
+	 *     manifests and could leave the file half-cleaned on mid-loop failure.
+	 *   - When the recomputed `${branchFolder}/${slug}-${hash8}.md` differs
+	 *     from the manifest's existing `entry.path` (e.g. user renamed a
+	 *     branch folder by hand, or slugify changed across versions), we WARN
+	 *     and skip rather than silently rewriting the manifest path.
+	 */
+	async healMissingVisibleMarkdown(opts?: HealOptions): Promise<HealResult> {
+		const manifest = this.metadataManager.readManifest();
+		const commitEntries = manifest.files.filter((f) => f.type === "commit");
+
+		let healed = 0;
+		let skipped = 0;
+		let failed = 0;
+		const dropCandidates: string[] = [];
+
+		for (const entry of commitEntries) {
+			const absPath = join(this.rootPath, entry.path);
+			if (existsSync(absPath)) {
+				skipped++;
+				continue;
+			}
+
+			const hiddenJsonAbs = join(this.rootPath, ".jolli", "summaries", `${entry.fileId}.json`);
+			let summaryJson: string;
+			try {
+				summaryJson = readFileSync(hiddenJsonAbs, "utf-8");
+			} catch (err) {
+				const code = (err as NodeJS.ErrnoException).code;
+				if (code === "ENOENT") {
+					failed++;
+					if (opts?.dropOrphanedManifestEntries) {
+						dropCandidates.push(entry.fileId);
+						log.warn(
+							"healMissingVisibleMarkdown: hidden JSON missing for %s — will drop manifest entry",
+							entry.fileId.substring(0, 8),
+						);
+					} else {
+						log.warn(
+							"healMissingVisibleMarkdown: hidden JSON missing for %s — keeping manifest entry (no truth source to repopulate)",
+							entry.fileId.substring(0, 8),
+						);
+					}
+					continue;
+				}
+				// EACCES / EBUSY / EIO / antivirus lock: never drop on a
+				// transient read failure — the manifest row is the last
+				// breadcrumb. Caller (reconcile / CLI) will retry next pass.
+				failed++;
+				log.warn(
+					"healMissingVisibleMarkdown: hidden JSON read failed for %s [%s]: %s — keeping manifest entry",
+					entry.fileId.substring(0, 8),
+					code ?? "?",
+					errMsg(err),
+				);
+				continue;
+			}
+
+			let summary: CommitSummary;
+			try {
+				summary = JSON.parse(summaryJson) as CommitSummary;
+			} catch (err) {
+				failed++;
+				log.warn(
+					"healMissingVisibleMarkdown: malformed hidden JSON for %s: %s",
+					entry.fileId.substring(0, 8),
+					errMsg(err),
+				);
+				continue;
+			}
+
+			// Compute where regenerate WILL write, then compare against the
+			// manifest's recorded path. A mismatch means the manifest has
+			// drifted (rename, slugify-rule change, branch-folder collision
+			// suffix); rewriting it silently would orphan whatever the user
+			// has been navigating to. WARN and skip — let the next reconcile
+			// pick this up explicitly.
+			const branchFolder = this.metadataManager.resolveFolderForBranch(summary.branch);
+			const slug = FolderStorage.slugify(summary.commitMessage);
+			const hash8 = summary.commitHash.substring(0, 8);
+			const computedRelPath = `${branchFolder}/${slug}-${hash8}.md`;
+			if (computedRelPath !== entry.path) {
+				// Path drift is not a heal failure: the hidden JSON is intact,
+				// readable, and parseable — we're choosing not to overwrite the
+				// manifest path silently. Count it as skipped so the CLI's
+				// `failed` summary (which says "hidden JSON missing, malformed,
+				// or read-blocked") stays accurate. Reconcile is the right tool
+				// to resolve drift.
+				skipped++;
+				log.warn(
+					"healMissingVisibleMarkdown: manifest path drift for %s — manifest=%s computed=%s — keeping manifest entry, run reconcile",
+					entry.fileId.substring(0, 8),
+					entry.path,
+					computedRelPath,
+				);
+				continue;
+			}
+
+			const syntheticEntry: SummaryIndexEntry = {
+				commitHash: summary.commitHash,
+				parentCommitHash: null,
+				commitMessage: summary.commitMessage,
+				commitDate: summary.commitDate,
+				branch: summary.branch,
+				generatedAt: summary.generatedAt,
+			};
+
+			try {
+				const wrote = await this.regenerateVisibleMarkdown(syntheticEntry);
+				if (wrote) {
+					healed++;
+				} else {
+					// regenerate could not recover (hidden JSON disappeared
+					// between our read above and regenerate's re-read — TOCTOU
+					// — or the parse inside regenerate failed). Source was
+					// intact a moment ago; treat as transient, keep the row.
+					failed++;
+					log.warn(
+						"healMissingVisibleMarkdown: regenerate returned false for %s — retry on next pass",
+						entry.fileId.substring(0, 8),
+					);
+				}
+			} catch (err) {
+				failed++;
+				log.warn(
+					"healMissingVisibleMarkdown: regenerate failed for %s: %s",
+					entry.fileId.substring(0, 8),
+					errMsg(err),
+				);
+			}
+		}
+
+		// Batch drop — one manifest read+write covers every orphaned row,
+		// instead of N rewrites inside the loop.
+		const droppedIds = dropCandidates.length > 0 ? this.dropManifestEntries(dropCandidates) : [];
+
+		if (healed > 0 || failed > 0) {
+			log.info(
+				"healMissingVisibleMarkdown: healed=%d skipped=%d failed=%d dropped=%d",
+				healed,
+				skipped,
+				failed,
+				droppedIds.length,
+			);
+		}
+		// Only surface droppedIds when there's something to report — keeps the
+		// no-op result shape `{healed:0,skipped:N,failed:0}` simple.
+		return droppedIds.length > 0 ? { healed, skipped, failed, droppedIds } : { healed, skipped, failed };
+	}
+
+	private dropManifestEntries(fileIds: readonly string[]): string[] {
+		if (fileIds.length === 0) return [];
+		const drop = new Set(fileIds);
+		const before = this.metadataManager.readManifest();
+		// Return what was actually in the manifest at write time, not the
+		// caller's wish list. Heal collects candidates from an earlier read,
+		// so a concurrent writer (git hook QueueWorker, migration) may have
+		// removed some rows in between. Reporting candidate IDs would tell the
+		// user we dropped rows that were already gone.
+		const actuallyDropped = before.files.filter((f) => drop.has(f.fileId)).map((f) => f.fileId);
+		if (actuallyDropped.length === 0) return [];
+		const kept = before.files.filter((f) => !drop.has(f.fileId));
+		this.metadataManager.replaceFiles(kept);
+		return actuallyDropped;
 	}
 
 	// ── Markdown generation ────────────────────────────────────────────────

--- a/cli/src/core/MetadataManager.ts
+++ b/cli/src/core/MetadataManager.ts
@@ -70,6 +70,17 @@ export class MetadataManager {
 		return true;
 	}
 
+	/**
+	 * Replace the manifest's files array in a single atomic write. Used by
+	 * batch operations (heal-folder, migration cleanup) where touching the
+	 * manifest once per row would be O(N²) and leave half-cleaned state on
+	 * mid-loop failure.
+	 */
+	replaceFiles(files: readonly ManifestEntry[]): void {
+		const manifest = this.readManifest();
+		this.atomicWrite(this.manifestPath, JSON.stringify({ ...manifest, files: [...files] }, null, "\t"));
+	}
+
 	findByPath(path: string): ManifestEntry | undefined {
 		return this.readManifest().files.find((f) => f.path === path);
 	}

--- a/cli/src/core/StaleChildMarkdownCleanup.test.ts
+++ b/cli/src/core/StaleChildMarkdownCleanup.test.ts
@@ -87,6 +87,30 @@ describe("StaleChildMarkdownCleanup", () => {
 			expect(storage.deletions).toEqual([]);
 		});
 
+		it("keeps a series of plain commits on the active branch across many branches in the index", async () => {
+			// Customer-shaped fixture: the index carries plain-commit heads from
+			// several historical branches plus the active branch. The cleanup
+			// pass is scoped to one branch, so heads on the OTHER branches must
+			// never be touched even when they share the same parent=null shape.
+			(getIndexEntryMap as ReturnType<typeof vi.fn>).mockResolvedValue(
+				new Map<string, SummaryIndexEntry>([
+					["a1", e("a1", "feat-2747", null)],
+					["a2", e("a2", "feat-2747", null)],
+					["a3", e("a3", "feat-2747", null)],
+					["a4", e("a4", "feat-2747", null)],
+					["a5", e("a5", "feat-2747", null)],
+					["b1", e("b1", "feat-2841", null)],
+					["b2", e("b2", "feat-2841", null)],
+					["c1", e("c1", "feat-2719", null)],
+				]),
+			);
+			const storage = makeStorage();
+			const result = await cleanupBranchStaleChildMarkdown("/cwd", "feat-2747", storage);
+			expect(result.deleted).toBe(0);
+			expect(result.failed).toBe(0);
+			expect(storage.deletions).toEqual([]);
+		});
+
 		it("is a no-op when storage lacks deleteVisibleMarkdown", async () => {
 			(getIndexEntryMap as ReturnType<typeof vi.fn>).mockResolvedValue(
 				new Map<string, SummaryIndexEntry>([

--- a/cli/src/core/StaleChildMarkdownCleanup.ts
+++ b/cli/src/core/StaleChildMarkdownCleanup.ts
@@ -15,9 +15,11 @@
  *     op so the disk invariant is restored after amend / rebase / squash.
  *   - cleanupAllBranchesStaleChildMarkdown(cwd, storage): walks every branch
  *     in the index. Called by MigrationEngine's one-shot step on activate to
- *     drain any backlog accumulated before this code shipped (and to undo
- *     the inverted 0.99.2 leaf-only deletion that wrongly preserved children
- *     and deleted heads).
+ *     drain any backlog of hoisted children (`parentCommitHash != null`)
+ *     accumulated before this code shipped. CANNOT restore heads that the
+ *     0.99.2 inverted leaf-only deletion bug already removed from disk —
+ *     that recovery path is `FolderStorage.healMissingVisibleMarkdown`,
+ *     which re-emits visible Markdown from hidden `summaries/<hash>.json`.
  *
  * Reads from index via getIndexEntryMap. Deletes via storage.deleteVisibleMarkdown
  * (optional method; no-op when the storage backend has no visible layer, e.g.

--- a/cli/src/core/StorageProvider.ts
+++ b/cli/src/core/StorageProvider.ts
@@ -44,15 +44,10 @@ export interface StorageProvider {
 
 	/**
 	 * Re-emit the user-visible Markdown copy for a single summary entry from
-	 * the hidden `.jolli/summaries/<hash>.json` source. Used to recover head
-	 * (`parentCommitHash == null`) `.md` files that were erroneously deleted by
-	 * 0.99.2's inverted leaf-only cleanup. Does NOT touch hidden JSON, index,
-	 * or orphan-branch state.
-	 *
-	 * Returns true when a `.md` was (re)written, false when the hidden JSON
-	 * source is missing (cannot regenerate). The implementation is allowed to
-	 * skip when the target `.md` already exists on disk; callers must not
-	 * depend on whether a write actually happened (idempotent contract).
+	 * the hidden `.jolli/summaries/<hash>.json` source. Idempotent: skips when
+	 * the target `.md` already exists. Returns true when the file is on disk
+	 * after the call (regenerated or already there), false when the hidden
+	 * JSON source is missing or unparseable.
 	 *
 	 * Optional: implemented by FolderStorage and delegated by DualWriteStorage.
 	 * OrphanBranchStorage does not implement it (no visible layer).
@@ -79,4 +74,67 @@ export interface StorageProvider {
 	 * OrphanBranchStorage does not implement it (no visible layer).
 	 */
 	deleteNoteVisible?(id: string, branch: string): Promise<void>;
+
+	/**
+	 * Walk the manifest and re-emit any commit-typed visible `.md` the manifest
+	 * still records but the filesystem no longer contains. Reads the hidden
+	 * `.jolli/summaries/<hash>.json` as the authoritative source for branch +
+	 * commit message (manifest fields can drift across renames or user edits).
+	 *
+	 * Counts:
+	 * - `healed`: visible `.md` written this pass.
+	 * - `skipped`: manifest entries whose `.md` was already on disk, AND
+	 *   entries whose recomputed visible path differs from the manifest's
+	 *   recorded path (heal refuses to silently rewrite — reconcile owns
+	 *   that). The hidden JSON is intact in both cases.
+	 * - `failed`: manifest entries that could not be recovered (hidden JSON
+	 *   missing / unreadable / malformed, or regenerate refused).
+	 *
+	 * Idempotent: a second pass with no new deletions reports every entry as
+	 * `skipped` (the loop's own `existsSync` short-circuits before reaching the
+	 * regenerate step).
+	 *
+	 * When `opts.dropOrphanedManifestEntries` is true, manifest rows whose
+	 * hidden JSON is also missing (ENOENT only — transient EACCES/EBUSY/EIO
+	 * never drop) are removed from the manifest and returned in `droppedIds`.
+	 * Callers MUST only set this flag when a higher-level truth source (e.g.
+	 * the orphan branch in dual-write mode) can re-source the entries — in
+	 * folder-only mode dropping is permanent data loss.
+	 *
+	 * Optional: implemented by FolderStorage and delegated by DualWriteStorage.
+	 * OrphanBranchStorage does not implement it (no visible layer).
+	 */
+	healMissingVisibleMarkdown?(opts?: HealOptions): Promise<HealResult>;
+}
+
+/** Options for a heal-missing-markdown pass. */
+export interface HealOptions {
+	/**
+	 * Drop manifest entries whose hidden JSON is ALSO missing (ENOENT only).
+	 * Default false — safe for any storage mode. Callers backed by a truth
+	 * source that can repopulate the manifest (orphan branch, dual-write
+	 * primary) may set this to true to stop reconcile from re-reporting
+	 * unrecoverable rows; folder-only callers must NOT set this — the
+	 * manifest is the last record and dropping it is data loss.
+	 */
+	readonly dropOrphanedManifestEntries?: boolean;
+}
+
+/** Outcome of a heal-missing-markdown pass; consumed by reconcile-callers and the `jolli heal-folder` CLI. */
+export interface HealResult {
+	readonly healed: number;
+	readonly skipped: number;
+	readonly failed: number;
+	/**
+	 * Manifest entries that were dropped because their hidden JSON was also
+	 * missing AND `opts.dropOrphanedManifestEntries` was true. Empty when no
+	 * rows were dropped (either nothing to drop, or the caller opted out).
+	 */
+	readonly droppedIds?: readonly string[];
+	/**
+	 * Populated when the heal pass aborted with an exception (e.g. delegated
+	 * shadow storage threw before completing). The numeric counts may be
+	 * partial in that case; treat the pass as "errored", not "no-op".
+	 */
+	readonly error?: string;
 }

--- a/vscode/src/Extension.ts
+++ b/vscode/src/Extension.ts
@@ -544,11 +544,26 @@ export function activate(context: vscode.ExtensionContext): void {
 	// The async branch below re-resolves once config is loaded, and the
 	// settings-save callback re-resolves whenever the user picks a new folder.
 	let sidebarKbParent = resolveKbParent();
-	const kbFoldersService = new KbFoldersService(() => ({
-		kbParent: sidebarKbParent,
-		currentRepoName: sidebarRepoName,
-		currentRemoteUrl: sidebarRemoteUrl,
-	}));
+	// Forward-declared so KbFoldersService can post a refresh into the
+	// sidebar when a background heal regenerates `.md` files. SidebarWebviewProvider
+	// is constructed later in activate(); the ref is filled in then.
+	let sidebarProviderRef: { refreshKnowledgeBaseFolders(): void } | undefined;
+	const kbFoldersService = new KbFoldersService(
+		() => ({
+			kbParent: sidebarKbParent,
+			currentRepoName: sidebarRepoName,
+			currentRemoteUrl: sidebarRemoteUrl,
+		}),
+		(info) => {
+			// Heal recovered files during this listChildren — the call itself
+			// already awaited the heal so the recovered files are in the tree
+			// it returned. But cached subtrees the webview is still showing
+			// (sibling branches, repos under the same parent) need a redraw
+			// so manifest-derived labels stay in sync. Cheap; refresh is a
+			// single repaint.
+			if (info.healed > 0) sidebarProviderRef?.refreshKnowledgeBaseFolders();
+		},
+	);
 
 	// Re-resolves sidebarKbParent from the latest config and (if the path has
 	// changed) tells the sidebar webview to drop its cached folder tree so the
@@ -734,6 +749,7 @@ export function activate(context: vscode.ExtensionContext): void {
 		}),
 		initialStateReady,
 	});
+	sidebarProviderRef = sidebarProvider;
 	context.subscriptions.push(
 		sidebarProvider,
 		vscode.window.registerWebviewViewProvider(

--- a/vscode/src/services/KbFoldersService.test.ts
+++ b/vscode/src/services/KbFoldersService.test.ts
@@ -1,5 +1,6 @@
 import {
 	chmodSync,
+	existsSync,
 	mkdirSync,
 	mkdtempSync,
 	readFileSync,
@@ -375,6 +376,303 @@ describe("KbFoldersService — single repo (under multi-repo parent)", () => {
 		expect(manifestOnDisk.files[0].path).toBe(
 			"renamed-branch/memory-abc12345.md",
 		);
+	});
+
+	it("regenerates a missing visible .md before returning the listing when hidden JSON is intact", async () => {
+		// Regression: manifest entry present, hidden JSON intact, visible .md
+		// deleted externally (iCloud eviction, manual rm, prior cleanup bugs).
+		// reconcile() alone only WARN-logs the missing file. listChildren must
+		// finish the heal inline so the recovered file is already on disk by
+		// the time the tree it returns is enumerated — otherwise the user has
+		// to refresh twice to see it come back.
+		const summaryJson = JSON.stringify({
+			version: 3,
+			commitHash: "0011223344556677",
+			commitMessage: "feat: icon style",
+			commitAuthor: "Author Name",
+			commitDate: "2026-05-14T18:15:00Z",
+			branch: "feature/icon-style",
+			generatedAt: "2026-05-14T18:15:01Z",
+			topics: [{ title: "Icon", trigger: "t", response: "r", decisions: "d" }],
+			stats: { filesChanged: 1, insertions: 2, deletions: 0 },
+		});
+		mkdirSync(join(repoDir, ".jolli", "summaries"), { recursive: true });
+		writeFileSync(
+			join(repoDir, ".jolli", "summaries", "0011223344556677.json"),
+			summaryJson,
+		);
+
+		const visibleRelPath = "feature-icon-style/feat-icon-style-00112233.md";
+		writeFileSync(
+			join(repoDir, ".jolli", "manifest.json"),
+			JSON.stringify({
+				version: 1,
+				files: [
+					{
+						path: visibleRelPath,
+						type: "commit",
+						fileId: "0011223344556677",
+						fingerprint: "fp-stale",
+						source: {
+							commitHash: "0011223344556677",
+							branch: "feature/icon-style",
+							generatedAt: "2026-05-14T18:15:01Z",
+						},
+						title: "feat: icon style",
+					},
+				],
+			}),
+		);
+
+		// Branch folder exists (with another file so the directory survives)
+		// but the target .md is missing — simulates external deletion.
+		mkdirSync(join(repoDir, "feature-icon-style"), { recursive: true });
+		writeFileSync(
+			join(repoDir, "feature-icon-style", "other-commit.md"),
+			"# unrelated\n",
+		);
+
+		// Trigger the reconcile + heal pipeline on the repo root.
+		await svc.listChildren("myrepo");
+
+		// Heal awaits inline — by the time listChildren returns the file must
+		// already be on disk. No polling needed.
+		const target = join(repoDir, visibleRelPath);
+		expect(existsSync(target)).toBe(true);
+		// And the regenerated content carries the YAML frontmatter the
+		// FolderStorage emitter writes — proves we went through the proper
+		// regenerate path, not a partial restore.
+		const regenerated = readFileSync(target, "utf-8");
+		expect(regenerated).toContain("commitHash: 0011223344556677");
+		expect(regenerated).toContain("branch: feature/icon-style");
+	});
+
+	it("invokes onHealed callback when heal regenerated files, allowing the consumer to refresh siblings", async () => {
+		const summaryJson = JSON.stringify({
+			version: 3,
+			commitHash: "aaaabbbbccccdddd",
+			commitMessage: "fix: bug",
+			commitAuthor: "Author",
+			commitDate: "2026-05-14T18:15:00Z",
+			branch: "main",
+			generatedAt: "2026-05-14T18:15:01Z",
+		});
+		mkdirSync(join(repoDir, ".jolli", "summaries"), { recursive: true });
+		writeFileSync(
+			join(repoDir, ".jolli", "summaries", "aaaabbbbccccdddd.json"),
+			summaryJson,
+		);
+		writeFileSync(
+			join(repoDir, ".jolli", "manifest.json"),
+			JSON.stringify({
+				version: 1,
+				files: [
+					{
+						path: "main/fix-bug-aaaabbbb.md",
+						type: "commit",
+						fileId: "aaaabbbbccccdddd",
+						fingerprint: "fp",
+						source: {
+							commitHash: "aaaabbbbccccdddd",
+							branch: "main",
+							generatedAt: "2026-05-14T18:15:01Z",
+						},
+						title: "fix: bug",
+					},
+				],
+			}),
+		);
+		mkdirSync(join(repoDir, "main"), { recursive: true });
+
+		const calls: Array<{
+			repoDirName: string;
+			healed: number;
+			droppedIds: readonly string[];
+		}> = [];
+		const svcWithCallback = new KbFoldersService(
+			() => ({
+				kbParent: tmpParent,
+				currentRepoName: "myrepo",
+				currentRemoteUrl: null,
+			}),
+			(info) => calls.push(info),
+		);
+
+		await svcWithCallback.listChildren("myrepo");
+
+		expect(calls).toHaveLength(1);
+		expect(calls[0]?.repoDirName).toBe("myrepo");
+		expect(calls[0]?.healed).toBe(1);
+	});
+
+	it("skips reconcile + heal on a second listing for the same repo when the first pass was clean", async () => {
+		// No missing files at all — first call records repo as clean, second
+		// call must not re-run reconcile (which would touch the manifest file
+		// mtime even on no-op).
+		writeFileSync(
+			join(repoDir, ".jolli", "manifest.json"),
+			JSON.stringify({ version: 1, files: [] }),
+		);
+
+		await svc.listChildren("myrepo");
+		const manifestPath = join(repoDir, ".jolli", "manifest.json");
+		const mtimeAfterFirst = require("node:fs").statSync(manifestPath).mtimeMs;
+
+		// Wait a tick so a re-write would produce a measurable mtime delta.
+		await new Promise((r) => setTimeout(r, 20));
+
+		await svc.listChildren("myrepo");
+		const mtimeAfterSecond = require("node:fs").statSync(manifestPath).mtimeMs;
+
+		expect(mtimeAfterSecond).toBe(mtimeAfterFirst);
+	});
+
+	it("notifyDirty() re-arms reconcile + heal after a clean pass", async () => {
+		// Regression: cleanRepos was a per-session memo with no caller-visible
+		// invalidation path. After the first clean pass, manual Refresh /
+		// kb:foldersReset and external file deletion (iCloud eviction, manual
+		// rm) all left the memo intact, so subsequent listChildren skipped
+		// reconcile + heal and the deleted .md was never restored. This test
+		// pins the contract: notifyDirty() drops the memo so the next
+		// listChildren actually re-runs heal — observable by deleting a
+		// visible .md the manifest references and watching heal regenerate it.
+		const summaryJson = JSON.stringify({
+			version: 3,
+			commitHash: "deadbeef11112222",
+			commitMessage: "fix: thing",
+			commitAuthor: "Author",
+			commitDate: "2026-05-19T18:15:00Z",
+			branch: "main",
+			generatedAt: "2026-05-19T18:15:01Z",
+		});
+		mkdirSync(join(repoDir, ".jolli", "summaries"), { recursive: true });
+		writeFileSync(
+			join(repoDir, ".jolli", "summaries", "deadbeef11112222.json"),
+			summaryJson,
+		);
+		const visibleRel = "main/fix-thing-deadbeef.md";
+		mkdirSync(join(repoDir, "main"), { recursive: true });
+		writeFileSync(join(repoDir, visibleRel), "# existing\n");
+		writeFileSync(
+			join(repoDir, ".jolli", "manifest.json"),
+			JSON.stringify({
+				version: 1,
+				files: [
+					{
+						path: visibleRel,
+						type: "commit",
+						fileId: "deadbeef11112222",
+						fingerprint: "fp",
+						source: {
+							commitHash: "deadbeef11112222",
+							branch: "main",
+							generatedAt: "2026-05-19T18:15:01Z",
+						},
+						title: "fix: thing",
+					},
+				],
+			}),
+		);
+
+		// First listing — visible md is on disk, heal counts it as skipped,
+		// healed=0 && failed=0, so the repo is marked clean.
+		await svc.listChildren("myrepo");
+
+		// External actor deletes the visible md. Without notifyDirty(), the
+		// memo would block heal and the file would stay deleted.
+		rmSync(join(repoDir, visibleRel));
+		expect(existsSync(join(repoDir, visibleRel))).toBe(false);
+
+		// Confirm the memo really does block heal on its own — sanity check.
+		await svc.listChildren("myrepo");
+		expect(existsSync(join(repoDir, visibleRel))).toBe(false);
+
+		// notifyDirty() drops the memo; next listing must re-run heal and
+		// regenerate the deleted file from the hidden JSON.
+		svc.notifyDirty();
+		await svc.listChildren("myrepo");
+		expect(existsSync(join(repoDir, visibleRel))).toBe(true);
+	});
+
+	it("does NOT leak the clean memo across kbParent roots that share a repo basename", async () => {
+		// Regression: cleanRepos was keyed by `firstSeg` (repo dirName) rather
+		// than the absolute kbRoot path. When the user changed "Local Folder"
+		// in settings, the same KbFoldersService instance survived with stale
+		// memo entries. If the new parent happened to host a repo with the
+		// same basename, its first listing would skip reconcile + heal based
+		// on a clean flag set by a completely different repo. Pinning by
+		// absolute kbRoot prevents the cross-root leak — we exercise this by
+		// re-pointing the service's context at a new kbParent and verifying
+		// heal still runs against the new repo even though its basename
+		// matches one already memoized in the old root.
+		writeFileSync(
+			join(repoDir, ".jolli", "manifest.json"),
+			JSON.stringify({ version: 1, files: [] }),
+		);
+
+		// Mutable context so the test can flip kbParent mid-flight, the same
+		// way refreshSidebarKbRoot() does in Extension.ts.
+		let activeParent = tmpParent;
+		const swapSvc = new KbFoldersService(() => ({
+			kbParent: activeParent,
+			currentRepoName: "myrepo",
+			currentRemoteUrl: null,
+		}));
+
+		await swapSvc.listChildren("myrepo");
+
+		const altParent = mkdtempSync(join(tmpdir(), "kbfolders-alt-"));
+		try {
+			const altRepoDir = seedRepo(altParent, "myrepo", { repoName: "myrepo" });
+			// Seed alt repo with a missing visible .md so heal has real work.
+			const summaryJson = JSON.stringify({
+				version: 3,
+				commitHash: "feed12340000aaaa",
+				commitMessage: "alt: real",
+				commitAuthor: "Author",
+				commitDate: "2026-05-19T18:15:00Z",
+				branch: "main",
+				generatedAt: "2026-05-19T18:15:01Z",
+			});
+			mkdirSync(join(altRepoDir, ".jolli", "summaries"), { recursive: true });
+			writeFileSync(
+				join(altRepoDir, ".jolli", "summaries", "feed12340000aaaa.json"),
+				summaryJson,
+			);
+			const altVisibleRel = "main/alt-real-feed1234.md";
+			mkdirSync(join(altRepoDir, "main"), { recursive: true });
+			writeFileSync(
+				join(altRepoDir, ".jolli", "manifest.json"),
+				JSON.stringify({
+					version: 1,
+					files: [
+						{
+							path: altVisibleRel,
+							type: "commit",
+							fileId: "feed12340000aaaa",
+							fingerprint: "fp",
+							source: {
+								commitHash: "feed12340000aaaa",
+								branch: "main",
+								generatedAt: "2026-05-19T18:15:01Z",
+							},
+							title: "alt: real",
+						},
+					],
+				}),
+			);
+
+			// Flip the context — same service instance, new kbParent. If the
+			// memo were keyed by dirName, the existing "myrepo" entry from
+			// the original root would suppress heal here; keying by absolute
+			// kbRoot keeps the new repo unmemoized so heal runs and the
+			// missing .md gets regenerated.
+			activeParent = altParent;
+			await swapSvc.listChildren("myrepo");
+			expect(existsSync(join(altRepoDir, altVisibleRel))).toBe(true);
+		} finally {
+			rmSync(altParent, { recursive: true, force: true });
+		}
 	});
 
 	it("classifies a single-file relPath via manifest", async () => {

--- a/vscode/src/services/KbFoldersService.ts
+++ b/vscode/src/services/KbFoldersService.ts
@@ -49,6 +49,7 @@
 
 import { promises as fs } from "node:fs";
 import { isAbsolute, join, normalize } from "node:path";
+import { FolderStorage } from "../../../cli/src/core/FolderStorage.js";
 import {
 	type DiscoveredRepo,
 	discoverRepos,
@@ -75,8 +76,47 @@ export interface KbFoldersContext {
 	readonly currentRemoteUrl: string | null;
 }
 
+/**
+ * Optional callback the consumer can pass to be notified when a background
+ * heal pass actually regenerated visible `.md` files. The consumer is
+ * expected to refresh the sidebar tree so the recovered files become visible
+ * without the user having to click again.
+ */
+export type KbFoldersHealedCallback = (info: {
+	repoDirName: string;
+	healed: number;
+	droppedIds: readonly string[];
+}) => void;
+
 export class KbFoldersService {
-	constructor(private readonly getContext: () => KbFoldersContext) {}
+	/**
+	 * Absolute kbRoot paths whose last heal pass returned `healed=0 && failed=0`.
+	 * The manifest is in sync with disk; future listChildren calls for those
+	 * repos skip the reconcile + heal pipeline entirely. Cleared by
+	 * `notifyDirty()` so manual refresh / external write events re-arm the
+	 * check. Keyed by absolute path rather than dirName so that switching
+	 * `kbParent` (the user's "Local Folder" setting) cannot leak a clean memo
+	 * onto a same-basename repo under the new parent.
+	 */
+	private readonly cleanRepos = new Set<string>();
+
+	constructor(
+		private readonly getContext: () => KbFoldersContext,
+		private readonly onHealed?: KbFoldersHealedCallback,
+	) {}
+
+	/**
+	 * Drop the per-session "this repo is clean" memo. Called from
+	 * `SidebarWebviewProvider.refreshKnowledgeBaseFolders()` so every refresh
+	 * path — manual Refresh button, settings save, migration, rebuild, kbParent
+	 * move — re-arms the check on the next listChildren. The optional
+	 * `kbRoot` argument scopes invalidation to a single repo for callers that
+	 * know exactly which one changed; omit it to clear the whole memo.
+	 */
+	notifyDirty(kbRoot?: string): void {
+		if (kbRoot) this.cleanRepos.delete(kbRoot);
+		else this.cleanRepos.clear();
+	}
 
 	/**
 	 * Enumerates every Memory Bank repo under `<kbParent>`. Wraps `discoverRepos`
@@ -131,26 +171,87 @@ export class KbFoldersService {
 
 		if (repo) {
 			// Reconcile manifest paths against the live filesystem before
-			// listing inside this repo. Matches IntelliJ's KBExplorerPanel,
-			// which calls reconcile() prior to building its tree. Without
-			// this the VSCode Folders tab kept stale manifest paths after a
-			// user manually renamed a branch folder under the Memory Bank,
-			// dropping every file in that folder back to fileKind="other" —
-			// its memory / plan / note labels disappeared, even though the
-			// orphan branch and .jolli/index.json were unaffected. Runs on
-			// every list-inside-repo (not just subRel === "") so the
-			// webview's lazy-expand cache restoration — which can call
-			// listChildren on a deep path directly after reload, skipping
-			// the repo root — still reaches a self-healed manifest. The
-			// per-call cost stays bounded because reconcile() short-circuits
-			// when every manifest path is still on disk; the full walk only
-			// fires once after a real rename. Swallows failures because the
-			// reconcile is a best-effort heal — a manifest write failure
-			// here would degrade labelling but must not block the listing.
-			try {
-				new MetadataManager(join(repo.kbRoot, ".jolli")).reconcile(repo.kbRoot);
-			} catch {
-				/* best-effort heal; degrade to stale labels rather than empty tree */
+			// listing inside this repo. Matches IntelliJ's KBExplorerPanel.
+			// Without this the VSCode Folders tab kept stale manifest paths
+			// after a user manually renamed a branch folder, dropping every
+			// file in that folder back to fileKind="other" — labels disappeared
+			// even though the orphan branch and .jolli/index.json were intact.
+			// Runs on every list-inside-repo (not just subRel === "") so a
+			// webview lazy-expand that lands on a deep path directly still
+			// reaches a self-healed manifest. Per-call cost stays bounded
+			// because reconcile() short-circuits when every manifest path is
+			// still on disk; the full walk only fires after a real rename.
+			//
+			// Heal awaits inline (not fire-and-forget): the regenerated `.md`
+			// files MUST be on disk before listInRepo enumerates the folder,
+			// otherwise this listChildren call returns a tree that still
+			// omits the recovered files and the user has to refresh again.
+			// Heal is cheap in steady state — M existsSync + one manifest
+			// read; the per-session `cleanRepos` set skips even that once the
+			// manifest is known clean.
+			//
+			// Folder-only safety: heal here passes `dropOrphanedManifestEntries:
+			// false` explicitly. Manifest rows whose hidden JSON is also missing
+			// are kept (failed++) rather than silently deleted — the sidebar
+			// path can't tell whether the active StorageProvider is folder-only
+			// or dual-write (it constructs a bare FolderStorage to skip the
+			// per-listing factory cost), so we MUST assume folder-only and
+			// preserve. The explicit `jolli heal-folder` CLI reads the
+			// storageMode config and is the place where dropping can be opted
+			// into. Passing the flag explicitly (rather than relying on the
+			// FolderStorage default) makes that contract visible at the call
+			// site and survives future signature changes.
+			//
+			// Concurrency note: this path now writes (regenerate + possibly
+			// replaceFiles) but holds no lock. Two concurrent listChildren
+			// calls on the same repo (e.g. webview re-init racing with manual
+			// Refresh) can both miss `cleanRepos` and both run heal. Single
+			// `.md` writes are safe (atomicWrite); the manifest read-modify-
+			// write window is bounded by reconcile + replaceFiles, both via
+			// MetadataManager's atomicWrite. With drop disabled here, the only
+			// manifest mutation the sidebar heal can do is `updateManifest`
+			// inside regenerate, which is keyed by fileId and is idempotent
+			// under concurrent re-runs.
+			if (!this.cleanRepos.has(repo.kbRoot)) {
+				try {
+					const mm = new MetadataManager(join(repo.kbRoot, ".jolli"));
+					mm.reconcile(repo.kbRoot);
+					const storage = new FolderStorage(repo.kbRoot, mm);
+					const healResult = await storage.healMissingVisibleMarkdown({
+						dropOrphanedManifestEntries: false,
+					});
+					if (healResult.healed === 0 && healResult.failed === 0) {
+						this.cleanRepos.add(repo.kbRoot);
+					}
+					if (healResult.healed > 0) {
+						this.onHealed?.({
+							repoDirName: firstSeg,
+							healed: healResult.healed,
+							droppedIds: healResult.droppedIds ?? [],
+						});
+					}
+				} catch (err) {
+					// Surface user-actionable disk / permission errors so the
+					// extension's debug log captures them. Heal is best-effort
+					// for labelling — we still list the tree below.
+					const code = (err as NodeJS.ErrnoException)?.code;
+					const message = err instanceof Error ? err.message : String(err);
+					if (
+						code === "ENOSPC" ||
+						code === "EROFS" ||
+						code === "EACCES" ||
+						code === "EPERM"
+					) {
+						// Loud category — caller should consider toasting.
+						console.warn(
+							`[KbFolders] heal blocked for ${firstSeg} [${code}]: ${message}`,
+						);
+					} else {
+						console.warn(
+							`[KbFolders] heal failed for ${firstSeg} [${code ?? "?"}]: ${message}`,
+						);
+					}
+				}
 			}
 			const node = await this.listInRepo(repo.kbRoot, subRel);
 			// Prefix every relPath with the firstSeg so cached webview paths

--- a/vscode/src/views/SidebarWebviewProvider.test.ts
+++ b/vscode/src/views/SidebarWebviewProvider.test.ts
@@ -1936,6 +1936,42 @@ describe("SidebarWebviewProvider", () => {
 		expect(kbFolders.listChildren).toHaveBeenCalledWith("");
 	});
 
+	it("refreshKnowledgeBaseFolders invalidates the kbFolders cleanRepos memo", async () => {
+		// Regression: refreshKnowledgeBaseFolders posted kb:foldersReset and
+		// re-fetched the root, but the kbFoldersService.cleanRepos memo lived
+		// for the whole session. After the first clean pass, manual Refresh /
+		// settings save / external file deletion (iCloud eviction) all
+		// short-circuited reconcile + heal and the deleted file was never
+		// restored. Pinning notifyDirty() on this path keeps every refresh
+		// entrypoint re-armed.
+		const view = makeMockView();
+		const tree = { name: "", relPath: "", isDirectory: true, children: [] };
+		const notifyDirty = vi.fn();
+		const kbFolders = {
+			listChildren: vi.fn().mockResolvedValue(tree),
+			notifyDirty,
+		};
+		const provider = new SidebarWebviewProvider({
+			executeCommand: vi.fn(),
+			getInitialState: () => ({
+				enabled: true,
+				authenticated: false,
+				configured: true,
+				activeTab: "kb",
+				kbMode: "folders",
+				branchName: "main",
+				detached: false,
+			}),
+			extensionUri: mockExtensionUri as unknown as never,
+			kbFolders,
+		});
+		provider.resolveWebviewView(view as unknown as never);
+		notifyDirty.mockClear();
+		provider.refreshKnowledgeBaseFolders();
+		await new Promise((r) => setTimeout(r, 0));
+		expect(notifyDirty).toHaveBeenCalledTimes(1);
+	});
+
 	// setBadge re-attaches the activity-bar badge surface that the legacy
 	// TreeView-based sidebar provided. WebviewView shares the `.badge` API
 	// with TreeView — these tests pin the contract that (a) badges set

--- a/vscode/src/views/SidebarWebviewProvider.ts
+++ b/vscode/src/views/SidebarWebviewProvider.ts
@@ -46,7 +46,15 @@ export interface SidebarWebviewDeps {
 		 */
 		getWorkerBusy(): boolean;
 	};
-	kbFolders?: { listChildren(relPath: string): Promise<FolderNode> };
+	kbFolders?: {
+		listChildren(relPath: string): Promise<FolderNode>;
+		/**
+		 * Drops the per-session "this repo is clean" memo so the next
+		 * listChildren re-runs reconcile + heal. Optional so existing tests
+		 * (which inject only `listChildren`) keep working.
+		 */
+		notifyDirty?: (kbRoot?: string) => void;
+	};
 	/**
 	 * Source for the breadcrumb repo/branch dropdowns. `listRepos` enumerates
 	 * every Memory Bank repo (current + foreign); `listBranches(repoName)`
@@ -686,6 +694,13 @@ export class SidebarWebviewProvider
 	 * and the next `ready` will pick up the new state via getInitialState().
 	 */
 	refreshKnowledgeBaseFolders(): void {
+		// Drop the "this repo is clean" memo before re-fetching so external
+		// writes (post-commit, migration, manual file deletion / iCloud
+		// eviction) actually re-trigger reconcile + heal. Without this the
+		// memo would survive the kb:foldersReset and the follow-up
+		// handleExpandFolder("") would short-circuit past the heal pipeline,
+		// leaving evicted .md files unrecovered until a window reload.
+		this.deps.kbFolders?.notifyDirty?.();
 		this.postMessage({ type: "kb:foldersReset" });
 		void this.handleExpandFolder("");
 	}


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## Quick recap

The developer added automatic recovery for Memory Bank files that were deleted by external causes while their metadata remained intact. When users expand a repository in the sidebar, missing visible Markdown files are automatically regenerated from the hidden JSON source. A new `jolli heal-folder` command also allows users to manually trigger recovery from the terminal. The heal operation is idempotent and safe to run on every panel refresh, imposing no performance penalty on the hot path.

The healer anchors all path reconstruction to the hidden JSON summary files, which contain the authoritative branch and commit message and are never modified by user edits. This prevents the healer from writing files to the wrong folder even when the manifest has drifted or is incomplete due to legacy data or user edits. A critical safety improvement prevents permanent data loss: manifest entries are preserved by default when their hidden JSON source is also missing, and only dropped when the caller explicitly has a truth source (the orphan branch in dual-write mode) to repopulate from. Entries that fail to heal due to transient I/O errors are now distinguished from truly missing files and are preserved for retry, while path drift is detected and logged as a warning rather than silently overwriting user edits.

The sidebar now heals missing files synchronously within the file-listing call, so recovered files appear immediately without requiring a manual refresh. The per-session cache that tracks clean repos is now keyed by absolute path instead of directory name, eliminating collisions when users switch their "Local Folder" setting to a different parent. The cache is automatically invalidated on every sidebar refresh, covering all refresh paths with a single choke point. Manifest drops are batched into a single write operation to improve performance from O(N²) to O(N). Comprehensive test coverage reproduces the actual user-reported scenario and validates all edge cases, including idempotency, handling of ghost entries where the hidden JSON is also missing, and the new opt-in drop behavior that prevents accidental data loss in folder-only mode.

---

## E2E Test (6)
<details>
<summary><strong>1. Recover missing Memory Bank files from hidden backup</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a Memory Bank folder where some commit summary files have been accidentally deleted from disk (but the hidden backup files still exist). You can simulate this by:
1. Opening your Memory Bank folder in a file explorer
2. Navigating to a branch folder (e.g., "main" or "feature-xyz")
3. Deleting one or more `.md` files manually

**Steps:**
1. Open the VS Code sidebar and expand the Memory Bank Folders panel
2. Click on the repository that has missing files
3. Wait 2-3 seconds and observe the file list
4. Verify that the deleted files now reappear in the branch folders
5. Open one of the recovered files to confirm it contains the correct commit message and content

**Expected Results:**
- The missing `.md` files should automatically regenerate in their original locations
- The recovered files should display the same commit messages and content as before deletion
- No manual refresh or restart should be required — recovery happens automatically when you expand the folder

</blockquote>
</details>
<details>
<summary><strong>2. Run explicit recovery command from terminal</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a Memory Bank folder with missing commit summary files (same setup as the previous scenario)

**Steps:**
1. Open a terminal and navigate to your Memory Bank project directory
2. Run the command: `jolli heal-folder`
3. Wait for the command to complete and read the output
4. Verify the counts reported (e.g., "Healed: 3 visible .md file(s) regenerated from hidden JSON")
5. Check the Memory Bank folder in your file explorer to confirm the files are now present

**Expected Results:**
- The command should print a summary showing how many files were recovered
- If all files were already present, it should print "No heal needed"
- If some files could not be recovered, it should list the count of failed entries and explain why
- All recovered files should appear in the correct branch folders with correct names

</blockquote>
</details>
<details>
<summary><strong>3. Prevent accidental data loss when switching Memory Bank locations</strong></summary>
<br>
<blockquote>

**Preconditions:** Have two different parent directories, each containing a Memory Bank folder with the same name (e.g., both have a "my-project" folder). The first location should have some missing files that were previously healed.

**Steps:**
1. Open VS Code with the first Memory Bank location configured
2. Expand the Memory Bank Folders panel and verify files are present
3. Go to Settings and change the Memory Bank parent folder to the second location
4. Wait for the sidebar to refresh
5. Expand the Memory Bank Folders panel again and verify the file list

**Expected Results:**
- The sidebar should show the correct files for the second location
- Files from the first location should NOT appear in the second location's file list
- If the second location has missing files, they should be healed independently without interference from the first location's state

</blockquote>
</details>
<details>
<summary><strong>4. Understand recovery limitations in folder-only mode</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a Memory Bank configured in folder-only mode (not dual-write). Create a missing file scenario by deleting both the visible `.md` file AND the hidden backup file for one commit.

**Steps:**
1. Open a terminal and run: `jolli heal-folder`
2. Read the output carefully, looking for the "Failed" count
3. Check the message about what to do with failed entries
4. Verify that the manifest entry still exists (the commit is still listed in `.jolli/manifest.json`)

**Expected Results:**
- The command should report the failed entry count
- The message should explain that folder-only mode has no backup source to restore from
- The manifest entry should be preserved (not deleted) so you can manually restore the hidden backup if needed
- The message should NOT mention "Re-run `jolli enable`" (that only appears in dual-write mode)

</blockquote>
</details>
<details>
<summary><strong>5. Verify path drift detection prevents silent overwrites</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a Memory Bank where you manually edited a commit summary file's location or name in the manifest, and the hidden backup file still exists with the original path information.

**Steps:**
1. Open a terminal and run: `jolli heal-folder`
2. Read the output and look for the "Skipped" count
3. Check the message about path-drifted entries
4. Verify that the manually-edited file location was NOT overwritten

**Expected Results:**
- The command should report the entry as "Skipped" (not "Healed")
- The message should mention "path-drifted" entries and suggest running `jolli reconcile` to resolve drift
- Your manually-edited file location should remain unchanged
- The hidden backup should still be intact for later recovery if needed

</blockquote>
</details>
<details>
<summary><strong>6. Distinguish transient read errors from permanent file loss</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a Memory Bank folder where a hidden backup file exists but is temporarily inaccessible (e.g., locked by another process, permission denied, or disk full). You can simulate this by temporarily changing folder permissions or having the file open in another application.

**Steps:**
1. Open a terminal and run: `jolli heal-folder`
2. Wait for the command to complete
3. Read the output and look for the "Failed" count
4. Verify that the manifest entry was NOT deleted
5. Restore normal access to the file (close the lock, restore permissions, or free disk space)
6. Run `jolli heal-folder` again

**Expected Results:**
- The first run should report the entry as "Failed" (not dropped from manifest)
- The message should indicate a transient read error (permission, disk space, or file locked)
- The manifest entry should still exist after the first run
- The second run (after restoring access) should successfully recover the file

</blockquote>
</details>

---

## Topics (10)
<details>
<summary><strong>01 · Restore deleted Memory Bank files from hidden JSON source</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Users reported that commit summaries appeared to be missing from their Memory Bank after external factors such as iCloud eviction, manual deletion, or prior-version cleanup bugs removed the visible Markdown files, even though the underlying data in hidden JSON and the orphan branch remained intact.

**💡 Decisions Behind the Code**

- **Hidden JSON as single source of truth**: The hidden JSON (summaries/{hash}.json) is the authoritative source for branch and commit message because it is written once at initial summary generation and never modified by user edits or manifest updates. Reading the hidden JSON first ensures the healer recovers files to their original locations regardless of manifest drift.
- **Idempotent and safe for hot paths**: The heal method is designed to be called on every panel refresh without performance penalty. The fast path is M `existsSync` calls (where M is manifest size), and the slow path only fires for genuinely-missing files. Calling twice in a row produces zero healed counts on the second pass because file regeneration short-circuits when the `.md` already exists on disk.
- **Automatic healing on first access with per-session caching**: Healing runs transparently when a user first expands a repository in the sidebar, rather than requiring manual invocation. A per-session cache tracks clean repos to avoid repeated scans on every list operation when no external changes have occurred.

**✅ What Was Implemented**

- Added `healMissingVisibleMarkdown` method to `FolderStorage` that walks the manifest, identifies commit entries whose visible `.md` files are missing, and regenerates them from the hidden `.jolli/summaries/<hash>.json` source. The healer reads the hidden JSON summary file first to extract the authoritative branch and commit message, then uses those values to construct the synthetic entry and write the markdown file to the correct location.
- Integrated heal into `KbFoldersService` as a call after each `reconcile()` pass, so users see missing files restored automatically when they expand a repository node in the sidebar. The sidebar now heals missing files synchronously within the file-listing call, so recovered files appear immediately without requiring a manual refresh.
- Added `jolli heal-folder` CLI command that invokes the heal method and reports counts of healed, skipped, and failed entries, with mode-specific guidance about whether failed entries can be repopulated from the orphan branch.
- Delegated heal through `DualWriteStorage` to the folder-side provider, with error handling that marks the storage dirty if the heal attempt fails.

**📋 Future Enhancements**

- The per-session memo tracking clean repos is never invalidated when external changes occur (e.g., when the user clicks Refresh or when a post-commit hook writes new files). A follow-up should wire invalidation into all external-change entry points.

**📁 FILES**
- `cli/src/core/FolderStorage.ts`
- `cli/src/commands/HealFolderCommand.ts`
- `vscode/src/services/KbFoldersService.ts`

</blockquote>
</details>
<details>
<summary><strong>02 · Fix silent data loss when manifest rows are dropped without a truth source</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The heal-folder recovery command was permanently deleting manifest entries whose hidden JSON files were also missing, even in folder-only mode where the manifest is the last record of that data, making data loss irreversible for users without an orphan branch to repopulate from.

**💡 Decisions Behind the Code**

- **Opt-in deletion is safer than opt-out**: The default behavior preserves manifest rows even when hidden JSON is missing, because folder-only mode has no truth source to repopulate from. Only callers that explicitly have a truth source (dual-write mode via the orphan branch) request the drop. This fail-safe direction prevents accidental permanent data loss.
- **Error channel distinguishes true no-ops from swallowed exceptions**: Adding an `error` field to `HealResult` lets the CLI avoid lying to users who explicitly ran a recovery command. A user sees "Heal errored" instead of "No heal needed" when the heal pass threw an exception, even if zero files were healed.
- **Storage mode awareness in CLI guidance**: The command now reads `storageMode` from config and adjusts its output accordingly. Dual-write mode tells users to re-run `jolli enable` to repopulate from the orphan branch; folder-only mode tells them to manually restore the hidden JSON or remove the manifest row. This prevents misleading advice.

**✅ What Was Implemented**

- Modified `FolderStorage.healMissingVisibleMarkdown` to accept an `opts` parameter with `dropOrphanedManifestEntries` flag (defaults to false), and only drop manifest rows when explicitly opted in. Entries that fail to heal are now preserved by default, with the failed count reported to the user.
- Updated `DualWriteStorage` to pass `dropOrphanedManifestEntries: true` by default when calling the folder storage heal method, since dual-write mode has the orphan branch as a truth source. Added error channel to `HealResult` so CLI can distinguish between "no heal needed" and "heal errored".
- Modified `HealFolderCommand` to read the storage mode from config and only request manifest drops in dual-write mode, with mode-specific guidance printed to the user about whether failed entries can be repopulated.

**📁 FILES**
- `cli/src/core/FolderStorage.ts`
- `cli/src/core/DualWriteStorage.ts`
- `cli/src/commands/HealFolderCommand.ts`

</blockquote>
</details>
<details>
<summary><strong>03 · Distinguish transient read errors from missing files during heal</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The heal process was treating all file read errors (permission denied, disk full, file locked) the same as missing files, which could cause manifest entries to be dropped when the real problem was a transient I/O error that might resolve on retry.

**💡 Decisions Behind the Code**

Separating errno categories prevents silent data loss from transient conditions. A permission error or disk-full condition is not the same as a deleted file — the manifest row should survive so the user can retry after fixing the underlying issue. This distinction is critical for safety in production environments where temporary I/O glitches are common.

**✅ What Was Implemented**

- Modified `FolderStorage.readFile` to distinguish `ENOENT` (file truly missing) from other errors like `EACCES`, `EBUSY`, `EIO`, and `EISDIR`. Only `ENOENT` is treated as "missing"; other errors are now re-thrown so they propagate as failures rather than silently becoming null.
- Updated heal logic to count read errors that are not `ENOENT` as failed entries without dropping the manifest row, preserving the data for later retry when the transient condition clears. Added categorized error logging for transient errors (`ENOSPC`, `EACCES`, `EROFS`, `EBUSY`) so users and support can diagnose permission or disk-space issues.

**📁 FILES**
- `cli/src/core/FolderStorage.ts`

</blockquote>
</details>
<details>
<summary><strong>04 · Detect and warn when manifest paths drift during heal</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The heal process was silently overwriting manifest path entries with newly computed paths, which could lose the user's manual edits or cause mismatches if branch folder names changed or slugification rules evolved between versions.

**💡 Decisions Behind the Code**

Skipping the update when paths diverge is more conservative than silently overwriting. The manifest entry is preserved as-is, and the user gets visibility into the mismatch via the WARN log. This prevents accidental loss of user-edited branch folder names or other path customizations, while still allowing the user to manually resolve the drift if needed. Path drift is not a heal failure — the hidden JSON is readable and intact, so reconcile is the appropriate tool to resolve the drift.

**✅ What Was Implemented**

Added path comparison in `FolderStorage.healMissingVisibleMarkdown`: before calling `regenerateVisibleMarkdown`, the heal loop now compares the manifest's stored path against the newly computed path from the hidden JSON. If they differ, a WARN is logged and the entry is skipped (not updated). The heal counter now correctly classifies path-drifted entries as skipped rather than failed, since the hidden JSON is intact and the entry is fully recoverable via reconcile.

**📁 FILES**
- `cli/src/core/FolderStorage.ts`

</blockquote>
</details>
<details>
<summary><strong>05 · Fix cleanRepos memo to use absolute paths and prevent cross-root leaks</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

When users changed their "Local Folder" setting to point to a different parent directory, the per-session memo tracking which repos had clean heal passes would leak across roots — if the new parent contained a repo with the same folder name as one already memoized under the old parent, the new repo would incorrectly skip reconcile and heal based on stale state from a completely different repo.

**💡 Decisions Behind the Code**

- **Absolute path keying over directory name**: Using the full `kbRoot` path as the memo key eliminates the collision risk entirely. Directory names are not unique across different parent folders, but absolute paths are globally unique within a session. This is simpler and safer than trying to composite the parent path with the directory name.
- **Invalidation at the refresh boundary**: Rather than scattering `notifyDirty()` calls across five different call sites (settings save, migration, rebuild, kbParent change, orphan listener), wiring it into `refreshKnowledgeBaseFolders()` creates a single choke point that automatically covers all refresh paths. This reduces the risk of missing an invalidation path in the future.

**✅ What Was Implemented**

- Changed `KbFoldersService` to key the clean repos memo by absolute `kbRoot` path instead of directory name, preventing same-basename repos under different parents from colliding in the memo.
- Updated `notifyDirty()` method signature to accept an optional `kbRoot` parameter (absolute path) instead of `repoDirName`, allowing callers to invalidate the memo for a specific repo or clear it entirely.
- Wired `notifyDirty()` into `SidebarWebviewProvider.refreshKnowledgeBaseFolders()` so every refresh path (manual Refresh button, settings save, migration, rebuild, kbParent move) re-arms the heal check on the next listing.
- Added regression tests verifying that `notifyDirty()` re-arms heal after a clean pass and that switching `kbParent` to a new root with a same-basename repo does not leak the old memo.

**📁 FILES**
- `vscode/src/services/KbFoldersService.ts`
- `vscode/src/views/SidebarWebviewProvider.ts`

</blockquote>
</details>
<details>
<summary><strong>06 · Batch manifest drops into a single write to avoid O(N²) performance</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The heal process was dropping orphaned manifest entries one at a time, causing the manifest file to be read and written once per dropped entry. For repos with many missing files, this created unnecessary I/O overhead.

**💡 Decisions Behind the Code**

Batching the drops reduces I/O from O(N²) to O(N) and ensures the manifest is never left in a partially-cleaned state if a write fails mid-way. This is especially important for large repos where heal might need to drop dozens of entries.

**✅ What Was Implemented**

- Added `MetadataManager.replaceFiles` method to replace the entire manifest entries list in a single read-modify-write cycle. Modified `FolderStorage.healMissingVisibleMarkdown` to collect all dropped IDs during the heal loop and call `replaceFiles` once at the end instead of calling `removeFromManifest` repeatedly.

**📁 FILES**
- `cli/src/core/MetadataManager.ts`
- `cli/src/core/FolderStorage.ts`

</blockquote>
</details>
<details>
<summary><strong>07 · End-to-end regression test for missing visible Markdown recovery</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The heal feature needed test coverage that reproduced the actual user-reported scenario: manifest entry present, hidden JSON intact, but visible `.md` file deleted by external causes.

**💡 Decisions Behind the Code**

The regression test was written as a "golden master" that documents the current broken behavior (visible `.md` stays missing after reconcile) with an explicit comment saying "flip this assertion when heal lands." This approach pins the bug in CI and makes the fix verifiable: when heal is implemented, the test assertion changes from `.toBe(false)` to `.toBe(true)`, proving the gap is closed. Both test suites from the feature branch and main were preserved during merge conflict resolution because they were independent and complementary—neither was a duplicate or override of the other, ensuring the final code is tested against both the new healing logic and the existing fallback behavior.

**✅ What Was Implemented**

- Added `reconcile heal gap (regression repro)` test suite in `FolderStorage.test.ts` that pins the current non-self-healing behavior and verifies that `regenerateVisibleMarkdown` can recover the same file that `reconcile` leaves missing.
- Added `healMissingVisibleMarkdown` test suite with six cases covering: empty manifest, successful regeneration, skipped existing files, dropped ghost entries (hidden JSON missing), ignored plan/note entries (heal scope is commits only), and idempotency.
- Added two regression tests that verify files are recovered to their correct locations even when the manifest has drifted or is incomplete: one verifies that a manifest entry with missing `source.branch` still writes to the correct branch folder (not "default"), and another verifies that a manifest entry whose title has diverged from the original commit message still writes under the original commit message's slug.
- Added integration test in `KbFoldersService.test.ts` that simulates the full user workflow: manifest entry exists, hidden JSON exists, visible `.md` is deleted, then `listChildren` is called and the file is regenerated in the background.
- Added test to `SidebarWebviewProvider.test.ts` verifying that `refreshKnowledgeBaseFolders()` calls `notifyDirty()` to invalidate the memo.

**📁 FILES**
- `cli/src/core/FolderStorage.test.ts`
- `vscode/src/services/KbFoldersService.test.ts`

</blockquote>
</details>
<details>
<summary><strong>08 · Improve error logging clarity in dual-write storage heal operations</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

When heal operations failed in dual-write storage, the error log message always said "Shadow healMissingVisibleMarkdown failed" even when the primary storage was the one that actually failed, making post-mortems harder because the log did not match reality.

**💡 Decisions Behind the Code**

Naming the actual target in the log message is a low-cost improvement that eliminates ambiguity in error investigation. The label is computed once at the start of the try block, so there is no performance cost, and it makes the log message immediately actionable without requiring the reader to understand the dual-write architecture.

**✅ What Was Implemented**

Updated `DualWriteStorage` to compute a `targetLabel` variable that names which storage target (shadow or primary) actually ran, and use that label in the error log message instead of hardcoding "Shadow". This makes error logs self-documenting so readers do not have to re-derive which side failed from context.

**📁 FILES**
- `cli/src/core/DualWriteStorage.ts`

</blockquote>
</details>
<details>
<summary><strong>09 · Clarify recovery path for stale child markdown cleanup and bug history</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The docstring in StaleChildMarkdownCleanup claimed to "undo" a prior cleanup bug, but the actual implementation cannot restore heads that were already deleted from disk — it can only prevent future deletions. This misleading documentation could cause future maintainers to misdiagnose data loss issues or attempt recovery through the wrong code path.

**💡 Decisions Behind the Code**

The docstring was rewritten to separate two distinct concerns: (1) what the cleanup pass accomplishes (draining backlog of children with `parentCommitHash != null`), and (2) what it cannot do (restore deleted heads). This prevents future readers from attempting recovery through the wrong code path and makes the relationship between cleanup and heal explicit. The change acknowledges prior bugs as historical fact rather than claiming to undo them, which is more honest about the system's recovery capabilities.

**✅ What Was Implemented**

Updated the docstring in `cli/src/core/StaleChildMarkdownCleanup.ts` to accurately describe what the cleanup functions do and do not do. The revised text clarifies that `cleanupAllBranchesStaleChildMarkdown` drains backlog of hoisted children but cannot restore heads already removed by prior bugs, and explicitly directs readers to `FolderStorage.healMissingVisibleMarkdown` as the correct recovery path for missing visible Markdown files.

**📁 FILES**
- `cli/src/core/StaleChildMarkdownCleanup.ts`

</blockquote>
</details>
<details>
<summary><strong>10 · Test coverage for plain commits across multiple branches in cleanup</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The StaleChildMarkdownCleanup test suite needed verification that the cleanup process correctly handles scenarios where multiple branches have plain commits (commits with no parent) in the index simultaneously.

**💡 Decisions Behind the Code**

The test validates a critical safety property: cleanup operations must be branch-scoped and never touch commits belonging to other branches, even when those commits share the same structural shape (parent=null). This prevents accidental data loss when multiple feature branches coexist in the index with similar commit patterns.

**✅ What Was Implemented**

Added a new test case to `cli/src/core/StaleChildMarkdownCleanup.test.ts` that verifies the cleanup operation preserves plain commits on non-active branches while processing the active branch. The test creates an index with plain commits from three different branches and confirms that running cleanup scoped to one branch leaves all entries untouched, with zero deletions and zero failures.

**📁 FILES**
- `cli/src/core/StaleChildMarkdownCleanup.test.ts`

</blockquote>
</details>

---

*Generated by Jolli Memory · May 19, 2026 at 7:16 PM · via Anthropic*
<!-- jollimemory-summary-end -->