### PR TITLE
Add per-item commit selection with fixes and polish

### DIFF
--- a/cli/src/core/ActiveSessionAggregator.test.ts
+++ b/cli/src/core/ActiveSessionAggregator.test.ts
@@ -20,6 +20,7 @@ vi.mock("./TranscriptMessageCounter.js", () => ({
 
 import { listActiveConversations } from "./ActiveSessionAggregator.js";
 import { discoverCodexSessions } from "./CodexSessionDiscoverer.js";
+import { conversationKey, setExcluded } from "./CommitSelectionStore.js";
 import { scanCopilotChatSessions } from "./CopilotChatSessionDiscoverer.js";
 import { scanCopilotSessions } from "./CopilotSessionDiscoverer.js";
 import { scanCursorSessions } from "./CursorSessionDiscoverer.js";
@@ -586,5 +587,47 @@ describe("listActiveConversations", () => {
 			// log path.
 			expect(items).toEqual([]);
 		});
+	});
+
+	it("stamps isSelected=false on rows whose key is in the exclusion file", async () => {
+		const { mkdtempSync, rmSync } = await import("node:fs");
+		const { tmpdir } = await import("node:os");
+		const { join } = await import("node:path");
+		const projectDir = mkdtempSync(join(tmpdir(), "agg-selected-false-"));
+		try {
+			const sessionId = "sel-false-session";
+			vi.mocked(scanCursorSessions).mockResolvedValueOnce(
+				scan([{ sessionId, transcriptPath: "/x", updatedAt: iso(-HOUR), source: "cursor" }]),
+			);
+			await setExcluded(projectDir, "conversations", conversationKey("cursor", sessionId), true);
+
+			const items = await listActiveConversations({ cwd: projectDir, windowMs: 2 * DAY });
+
+			expect(items).toHaveLength(1);
+			expect(items[0].isSelected).toBe(false);
+		} finally {
+			rmSync(projectDir, { recursive: true, force: true });
+		}
+	});
+
+	it("defaults isSelected=true when the row is not in the exclusion file", async () => {
+		const { mkdtempSync, rmSync } = await import("node:fs");
+		const { tmpdir } = await import("node:os");
+		const { join } = await import("node:path");
+		const projectDir = mkdtempSync(join(tmpdir(), "agg-selected-true-"));
+		try {
+			vi.mocked(scanCursorSessions).mockResolvedValueOnce(
+				scan([
+					{ sessionId: "sel-true-session", transcriptPath: "/x", updatedAt: iso(-HOUR), source: "cursor" },
+				]),
+			);
+
+			const items = await listActiveConversations({ cwd: projectDir, windowMs: 2 * DAY });
+
+			expect(items).toHaveLength(1);
+			expect(items[0].isSelected).toBe(true);
+		} finally {
+			rmSync(projectDir, { recursive: true, force: true });
+		}
 	});
 });

--- a/cli/src/core/ActiveSessionAggregator.ts
+++ b/cli/src/core/ActiveSessionAggregator.ts
@@ -14,6 +14,7 @@
 
 import { createLogger, errMsg } from "../Logger.js";
 import type { SessionInfo, TranscriptEntry, TranscriptSource } from "../Types.js";
+import { conversationKey, readExclusions } from "./CommitSelectionStore.js";
 import { isStillHidden, loadHiddenConversations } from "./HiddenConversationsStore.js";
 import { resolveSessionTitle } from "./SessionTitleResolver.js";
 import { loadMergedTranscript, loadUnreadMergedTranscript } from "./TranscriptMessageCounter.js";
@@ -27,6 +28,14 @@ export interface ActiveConversationItem {
 	readonly messageCount: number;
 	readonly updatedAt: string;
 	readonly transcriptPath: string;
+	/**
+	 * Per-commit-selection signal. `false` = user has unchecked this row;
+	 * the QueueWorker will skip its transcript when generating the next
+	 * summary. Default `true` for any row absent from
+	 * `commit-selection.json`. Independent of `HiddenConversationsStore`
+	 * (which hides the row entirely).
+	 */
+	readonly isSelected: boolean;
 }
 
 export interface ListActiveOptions {
@@ -58,7 +67,11 @@ export async function listActiveConversationsWithDiagnostics(
 	const windowMs = opts.windowMs ?? DEFAULT_WINDOW_MS;
 	const cutoff = Date.now() - windowMs;
 
-	const [collected, hidden] = await Promise.all([collectFromAllSources(opts.cwd), loadHiddenConversations(opts.cwd)]);
+	const [collected, hidden, exclusions] = await Promise.all([
+		collectFromAllSources(opts.cwd),
+		loadHiddenConversations(opts.cwd),
+		readExclusions(opts.cwd),
+	]);
 	const fresh = collected.sessions.filter((s) => Date.parse(s.updatedAt) >= cutoff);
 
 	// Dedupe by (source, sessionId), keeping the most-recently-updated entry.
@@ -102,13 +115,15 @@ export async function listActiveConversationsWithDiagnostics(
 			// still visible. For sources that already carry a title, the extra
 			// read is harmless and skipped by resolveSessionTitle immediately.
 			const titleEntries = unread.length > 0 ? await safeLoadMerged(s, opts.cwd) : unread;
+			const source = s.source ?? "claude";
 			return {
 				sessionId: s.sessionId,
-				source: s.source ?? "claude",
+				source,
 				title: await resolveSessionTitle(s, titleEntries),
 				messageCount: unread.length,
 				updatedAt: s.updatedAt,
 				transcriptPath: s.transcriptPath,
+				isSelected: !exclusions.conversations.has(conversationKey(source, s.sessionId)),
 			};
 		}),
 	);

--- a/cli/src/core/CodexSessionDiscoverer.ts
+++ b/cli/src/core/CodexSessionDiscoverer.ts
@@ -56,7 +56,7 @@ export async function discoverCodexSessions(projectDir: string): Promise<Readonl
 	const archivedSessions = await scanFlatDirectory(archivedDir, resolvedProject);
 	sessions.push(...archivedSessions);
 
-	log.info("Discovered %d Codex session(s)", sessions.length);
+	log.debug("Discovered %d Codex session(s)", sessions.length);
 	return sessions;
 }
 

--- a/cli/src/core/CommitSelectionStore.test.ts
+++ b/cli/src/core/CommitSelectionStore.test.ts
@@ -1,0 +1,193 @@
+import { mkdir, readdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { JOLLI_DIR, JOLLIMEMORY_DIR } from "../Logger.js";
+import {
+	type CommitExclusions,
+	conversationKey,
+	deleteSelectionFile,
+	readExclusions,
+	setAllExcluded,
+	setExcluded,
+} from "./CommitSelectionStore.js";
+
+let cwd: string;
+
+beforeEach(async () => {
+	cwd = await mkdir(join(tmpdir(), `commit-sel-${Date.now()}-${Math.random()}`), {
+		recursive: true,
+	}).then((p) => p ?? "");
+	await mkdir(join(cwd, JOLLI_DIR, JOLLIMEMORY_DIR), { recursive: true });
+});
+
+afterEach(async () => {
+	await rm(cwd, { recursive: true, force: true });
+});
+
+function filePath(): string {
+	return join(cwd, JOLLI_DIR, JOLLIMEMORY_DIR, "commit-selection.json");
+}
+
+describe("CommitSelectionStore", () => {
+	it("returns empty exclusions when the file is missing", async () => {
+		const ex = await readExclusions(cwd);
+		expect(ex.conversations.size).toBe(0);
+		expect(ex.plans.size).toBe(0);
+		expect(ex.notes.size).toBe(0);
+	});
+
+	it("returns empty exclusions when the file is malformed", async () => {
+		await writeFile(filePath(), "not json", "utf8");
+		const ex = await readExclusions(cwd);
+		expect(ex.conversations.size).toBe(0);
+	});
+
+	it("setExcluded adds a conversation key and is readable", async () => {
+		await setExcluded(cwd, "conversations", conversationKey("claude", "abc"), true);
+		const ex = await readExclusions(cwd);
+		expect(ex.conversations.has(conversationKey("claude", "abc"))).toBe(true);
+	});
+
+	it("setExcluded(false) removes an existing key", async () => {
+		await setExcluded(cwd, "conversations", conversationKey("claude", "abc"), true);
+		await setExcluded(cwd, "conversations", conversationKey("claude", "abc"), false);
+		const ex = await readExclusions(cwd);
+		expect(ex.conversations.has(conversationKey("claude", "abc"))).toBe(false);
+	});
+
+	it("setAllExcluded bulk-adds the given keys for a kind", async () => {
+		await setAllExcluded(cwd, "plans", ["p1", "p2", "p3"], true);
+		const ex = await readExclusions(cwd);
+		expect([...ex.plans].sort()).toEqual(["p1", "p2", "p3"]);
+	});
+
+	it("setAllExcluded bulk-removes the given keys for a kind", async () => {
+		await setAllExcluded(cwd, "plans", ["p1", "p2", "p3"], true);
+		await setAllExcluded(cwd, "plans", ["p1", "p3"], false);
+		const ex = await readExclusions(cwd);
+		expect([...ex.plans].sort()).toEqual(["p2"]);
+	});
+
+	it("conversationKey joins source and sessionId with a colon", () => {
+		expect(conversationKey("claude", "abc")).toBe("claude:abc");
+	});
+
+	it("readExclusions rejects an unknown version", async () => {
+		await writeFile(filePath(), JSON.stringify({ version: 99, conversations: ["x"] }), "utf8");
+		const ex: CommitExclusions = await readExclusions(cwd);
+		expect(ex.conversations.size).toBe(0);
+	});
+
+	it("readExclusions coerces non-array fields to empty sets and filters out non-string entries", async () => {
+		await writeFile(
+			filePath(),
+			JSON.stringify({
+				version: 1,
+				conversations: "not-an-array",
+				plans: [42, "p1", null, "p2"],
+				notes: null,
+			}),
+			"utf8",
+		);
+		const ex = await readExclusions(cwd);
+		expect(ex.conversations.size).toBe(0);
+		expect(ex.notes.size).toBe(0);
+		expect([...ex.plans].sort()).toEqual(["p1", "p2"]);
+	});
+
+	it("tolerates a stale conversation key that no longer exists", async () => {
+		await setExcluded(cwd, "conversations", conversationKey("codex", "ghost"), true);
+		const ex = await readExclusions(cwd);
+		expect(ex.conversations.has(conversationKey("codex", "ghost"))).toBe(true);
+	});
+
+	it("notes round-trip independently of plans", async () => {
+		await setExcluded(cwd, "plans", "p1", true);
+		await setExcluded(cwd, "notes", "n1", true);
+		const ex = await readExclusions(cwd);
+		expect(ex.plans.has("p1")).toBe(true);
+		expect(ex.notes.has("n1")).toBe(true);
+		expect(ex.plans.has("n1")).toBe(false);
+	});
+
+	it("readExclusions returns empty and warns on non-ENOENT read failures", async () => {
+		// Make the selection path itself a directory so readFile yields EISDIR
+		// (a real non-ENOENT failure path) instead of "file missing".
+		await mkdir(filePath(), { recursive: true });
+		const ex = await readExclusions(cwd);
+		expect(ex.conversations.size).toBe(0);
+		expect(ex.plans.size).toBe(0);
+		expect(ex.notes.size).toBe(0);
+	});
+
+	it("deleteSelectionFile removes an existing file", async () => {
+		await setExcluded(cwd, "conversations", conversationKey("claude", "abc"), true);
+		await deleteSelectionFile(cwd);
+		// Re-reading should fall through the missing-file branch and yield empty.
+		const ex = await readExclusions(cwd);
+		expect(ex.conversations.size).toBe(0);
+	});
+
+	it("deleteSelectionFile is a no-op when the file does not exist (ENOENT)", async () => {
+		await expect(deleteSelectionFile(cwd)).resolves.toBeUndefined();
+	});
+
+	it("deleteSelectionFile swallows non-ENOENT unlink errors", async () => {
+		// Make the selection path a directory so unlink yields EISDIR/EPERM —
+		// the function should warn and resolve, not throw.
+		await mkdir(filePath(), { recursive: true });
+		await expect(deleteSelectionFile(cwd)).resolves.toBeUndefined();
+	});
+
+	it("concurrent setExcluded calls do not lose updates", async () => {
+		// Fire ten setExcluded calls in parallel for distinct keys. With an
+		// unlocked read-modify-write each call would race: later writes would
+		// overwrite earlier ones and the persisted file would end up missing
+		// some keys. After serialization all ten must survive.
+		const keys = Array.from({ length: 10 }, (_, i) => `k${i}`);
+		await Promise.all(keys.map((k) => setExcluded(cwd, "conversations", k, true)));
+		const ex = await readExclusions(cwd);
+		expect([...ex.conversations].sort()).toEqual(keys.sort());
+	});
+
+	it("concurrent setExcluded and setAllExcluded interleave safely", async () => {
+		// Mix a bulk write with single-key writes. All keys must survive.
+		const singles = ["s1", "s2", "s3"];
+		const bulk = ["b1", "b2", "b3", "b4"];
+		await Promise.all([
+			...singles.map((k) => setExcluded(cwd, "plans", k, true)),
+			setAllExcluded(cwd, "plans", bulk, true),
+		]);
+		const ex = await readExclusions(cwd);
+		expect([...ex.plans].sort()).toEqual([...singles, ...bulk].sort());
+	});
+
+	it("serialization chain recovers after a failed write", async () => {
+		// A projectDir containing a NUL byte makes writeFile reject with
+		// ERR_INVALID_ARG_VALUE — the failure must not poison subsequent
+		// writes on a healthy projectDir. The chain swallows the error in
+		// its bookkeeping so the next caller starts cleanly.
+		const broken = `${cwd}/\0bad`;
+		await expect(setExcluded(broken, "conversations", "x", true)).rejects.toThrow();
+		await setExcluded(cwd, "conversations", "y", true);
+		const ex = await readExclusions(cwd);
+		expect(ex.conversations.has("y")).toBe(true);
+	});
+
+	it("cleans up the .tmp file when rename fails so the directory does not accumulate orphans", async () => {
+		// Trigger a real rename failure by pre-creating the destination as a
+		// directory — `rename(file, existing-dir)` fails with EISDIR on POSIX
+		// and EPERM on Windows. The writeFile lands the .tmp on disk; the
+		// rename throws; the production code's tmp-cleanup branch must unlink
+		// it so the next retry doesn't leave a sibling Date.now()-suffixed
+		// orphan behind.
+		const dir = join(cwd, JOLLI_DIR, JOLLIMEMORY_DIR);
+		await mkdir(filePath(), { recursive: true }); // selection path = a directory
+
+		await expect(setExcluded(cwd, "plans", "x", true)).rejects.toThrow();
+
+		const orphans = (await readdir(dir)).filter((n) => n.startsWith("commit-selection.json.tmp"));
+		expect(orphans).toEqual([]);
+	});
+});

--- a/cli/src/core/CommitSelectionStore.ts
+++ b/cli/src/core/CommitSelectionStore.ts
@@ -1,0 +1,203 @@
+/**
+ * CommitSelectionStore
+ *
+ * Persists the set of sidebar items the user wants EXCLUDED from the next
+ * summary pipeline run. Three kinds (conversations / plans / notes) live
+ * in a single JSON file under
+ * `<projectDir>/.jolli/jollimemory/commit-selection.json`.
+ *
+ * Sticky semantics: an entry stays in this file until the user explicitly
+ * un-excludes the item (re-checks the row, or hits the section's Select /
+ * Deselect All button). No git operation, no pipeline outcome, no editor
+ * lifecycle event modifies the file — the QueueWorker only ever READS it.
+ *
+ * Distinct from `HiddenConversationsStore` (permanent hide — row vanishes
+ * from sidebar) and from `PlanEntry.ignored` / `NoteEntry.ignored`
+ * (permanent ignore at the plans-registry layer). Exclusions are visible
+ * in the sidebar with an unchecked box; the row still renders.
+ */
+
+import { mkdir, readFile, rename, unlink, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { createLogger, errMsg, isEnoent, JOLLI_DIR, JOLLIMEMORY_DIR } from "../Logger.js";
+import type { TranscriptSource } from "../Types.js";
+
+const log = createLogger("CommitSelection");
+
+const SELECTION_FILE = "commit-selection.json";
+const SELECTION_VERSION = 1 as const;
+
+export type ExclusionKind = "conversations" | "plans" | "notes";
+
+export interface CommitExclusions {
+	readonly conversations: ReadonlySet<string>;
+	readonly plans: ReadonlySet<string>;
+	readonly notes: ReadonlySet<string>;
+}
+
+interface PersistedShape {
+	readonly version: typeof SELECTION_VERSION;
+	readonly conversations: readonly string[];
+	readonly plans: readonly string[];
+	readonly notes: readonly string[];
+}
+
+function selectionPath(projectDir: string): string {
+	return join(projectDir, JOLLI_DIR, JOLLIMEMORY_DIR, SELECTION_FILE);
+}
+
+/**
+ * Encode (source, sessionId) into a single string key. The colon is
+ * reserved across jollimemory (TranscriptSource values never contain one)
+ * so the key is unambiguously splittable if a debugging tool ever needs to.
+ */
+export function conversationKey(source: TranscriptSource, sessionId: string): string {
+	return `${source}:${sessionId}`;
+}
+
+function emptyExclusions(): CommitExclusions {
+	return {
+		conversations: new Set<string>(),
+		plans: new Set<string>(),
+		notes: new Set<string>(),
+	};
+}
+
+export async function readExclusions(projectDir: string): Promise<CommitExclusions> {
+	let raw: string;
+	try {
+		raw = await readFile(selectionPath(projectDir), "utf8");
+	} catch (err) {
+		if (!isEnoent(err)) {
+			log.warn("readExclusions read failed: %s", errMsg(err));
+		}
+		return emptyExclusions();
+	}
+	let parsed: Partial<PersistedShape>;
+	try {
+		parsed = JSON.parse(raw) as Partial<PersistedShape>;
+	} catch (err) {
+		log.warn("readExclusions JSON parse failed: %s", errMsg(err));
+		return emptyExclusions();
+	}
+	if (parsed.version !== SELECTION_VERSION) {
+		log.warn("readExclusions version mismatch (got %s) — ignoring file", String(parsed.version));
+		return emptyExclusions();
+	}
+	return {
+		conversations: new Set(asStringArray(parsed.conversations)),
+		plans: new Set(asStringArray(parsed.plans)),
+		notes: new Set(asStringArray(parsed.notes)),
+	};
+}
+
+function asStringArray(v: unknown): readonly string[] {
+	if (!Array.isArray(v)) return [];
+	return v.filter((x): x is string => typeof x === "string");
+}
+
+async function writeExclusions(projectDir: string, next: CommitExclusions): Promise<void> {
+	const dir = join(projectDir, JOLLI_DIR, JOLLIMEMORY_DIR);
+	await mkdir(dir, { recursive: true });
+	const payload: PersistedShape = {
+		version: SELECTION_VERSION,
+		conversations: [...next.conversations],
+		plans: [...next.plans],
+		notes: [...next.notes],
+	};
+	const tmp = `${selectionPath(projectDir)}.tmp-${process.pid}-${Date.now()}`;
+	await writeFile(tmp, JSON.stringify(payload, null, "\t"), "utf8");
+	try {
+		await rename(tmp, selectionPath(projectDir));
+	} catch (err) {
+		// Atomic-write contract: the .tmp file is an implementation detail
+		// of the swap, not user-visible state. On Windows a rename can fail
+		// with EPERM/EBUSY (antivirus, file watcher, another reader). Without
+		// this cleanup the unique `Date.now()` suffix would accumulate one
+		// orphan per failed write. Best-effort unlink — the caller sees the
+		// original rename error, not a misleading "cleanup failed" wrapper.
+		await unlink(tmp).catch(() => undefined);
+		throw err;
+	}
+}
+
+function mutableClone(ex: CommitExclusions): {
+	conversations: Set<string>;
+	plans: Set<string>;
+	notes: Set<string>;
+} {
+	return {
+		conversations: new Set(ex.conversations),
+		plans: new Set(ex.plans),
+		notes: new Set(ex.notes),
+	};
+}
+
+// In-process serialization queue keyed by projectDir. setExcluded /
+// setAllExcluded share an unlocked read-modify-write pattern, and the
+// sidebar fires them as `void apply…(...)` (fire-and-forget) from
+// rapid checkbox clicks. Without a queue two concurrent calls would
+// (a) read the same pre-state and silently lose one update, and
+// (b) collide on the temp filename in writeExclusions (same pid +
+// same Date.now() ms) producing an ENOENT crash on the second rename.
+// One chain per projectDir keeps cross-project work parallel.
+const writeChains = new Map<string, Promise<void>>();
+
+function serialize<T>(projectDir: string, work: () => Promise<T>): Promise<T> {
+	const prior = writeChains.get(projectDir) ?? Promise.resolve();
+	const next = prior.then(work, work);
+	writeChains.set(
+		projectDir,
+		next.then(
+			() => undefined,
+			() => undefined,
+		),
+	);
+	return next;
+}
+
+export async function setExcluded(
+	projectDir: string,
+	kind: ExclusionKind,
+	key: string,
+	excluded: boolean,
+): Promise<void> {
+	return serialize(projectDir, async () => {
+		const current = await readExclusions(projectDir);
+		const next = mutableClone(current);
+		const set = next[kind];
+		if (excluded) set.add(key);
+		else set.delete(key);
+		await writeExclusions(projectDir, next);
+	});
+}
+
+export async function setAllExcluded(
+	projectDir: string,
+	kind: ExclusionKind,
+	keys: readonly string[],
+	excluded: boolean,
+): Promise<void> {
+	return serialize(projectDir, async () => {
+		const current = await readExclusions(projectDir);
+		const next = mutableClone(current);
+		const set = next[kind];
+		if (excluded) {
+			for (const k of keys) set.add(k);
+		} else {
+			for (const k of keys) set.delete(k);
+		}
+		await writeExclusions(projectDir, next);
+	});
+}
+
+/** Delete the file from disk. Tolerates ENOENT. Not used by the pipeline — exposed for tests / manual operator use. */
+export async function deleteSelectionFile(projectDir: string): Promise<void> {
+	try {
+		await unlink(selectionPath(projectDir));
+	} catch (err) {
+		if (!isEnoent(err)) {
+			log.warn("deleteSelectionFile failed: %s", errMsg(err));
+		}
+	}
+}

--- a/cli/src/core/CopilotChatSessionDiscoverer.ts
+++ b/cli/src/core/CopilotChatSessionDiscoverer.ts
@@ -167,7 +167,7 @@ export async function scanCopilotChatSessions(projectDir: string): Promise<Copil
 		log.debug("Both scans errored; reporting Scan A's, dropped Scan B's: %s", b.error.message);
 	}
 	if (sessions.length > 0) {
-		log.info("Discovered %d Copilot Chat session(s) for %s", sessions.length, projectDir);
+		log.debug("Discovered %d Copilot Chat session(s) for %s", sessions.length, projectDir);
 	}
 	return { sessions, error };
 }

--- a/cli/src/core/CopilotSessionDiscoverer.ts
+++ b/cli/src/core/CopilotSessionDiscoverer.ts
@@ -87,7 +87,7 @@ export async function scanCopilotSessions(projectDir: string): Promise<CopilotSc
 				];
 			});
 		});
-		log.info("Discovered %d Copilot session(s) for %s", sessions.length, normalized);
+		log.debug("Discovered %d Copilot session(s) for %s", sessions.length, normalized);
 		return { sessions };
 	} catch (error: unknown) {
 		const scanError = classifyScanError(error);

--- a/cli/src/core/CursorSessionDiscoverer.ts
+++ b/cli/src/core/CursorSessionDiscoverer.ts
@@ -166,7 +166,7 @@ export async function scanCursorSessions(projectDir: string): Promise<CursorScan
 			}
 		});
 
-		log.info("Discovered %d Cursor session(s) for %s", out.length, projectDir);
+		log.debug("Discovered %d Cursor session(s) for %s", out.length, projectDir);
 		return { sessions: out };
 	} catch (error: unknown) {
 		const scanError = classifyScanError(error);

--- a/cli/src/core/OpenCodeSessionDiscoverer.ts
+++ b/cli/src/core/OpenCodeSessionDiscoverer.ts
@@ -199,7 +199,7 @@ export async function scanOpenCodeSessions(projectDir: string): Promise<OpenCode
 			});
 		});
 
-		log.info("Discovered %d OpenCode session(s) for %s", sessions.length, projectDir);
+		log.debug("Discovered %d OpenCode session(s) for %s", sessions.length, projectDir);
 		return { sessions };
 	} catch (error: unknown) {
 		const scanError = classifyScanError(error);

--- a/cli/src/core/SqliteHelpers.test.ts
+++ b/cli/src/core/SqliteHelpers.test.ts
@@ -122,4 +122,75 @@ describe("withSqliteDb", () => {
 			}),
 		).rejects.toThrow("boom");
 	});
+
+	it("retries the callback when SQLITE_BUSY is thrown and eventually succeeds", async () => {
+		const { tmpdir } = await import("node:os");
+		const { mkdtemp } = await import("node:fs/promises");
+		const { join } = await import("node:path");
+		const { DatabaseSync } = await import("node:sqlite");
+		const dir = await mkdtemp(join(tmpdir(), "sqlite-helpers-"));
+		const dbPath = join(dir, "x.db");
+		new DatabaseSync(dbPath).close();
+
+		let attempts = 0;
+		const value = await withSqliteDb(
+			dbPath,
+			() => {
+				attempts++;
+				if (attempts < 2) {
+					throw new Error("SQLITE_BUSY: database is locked");
+				}
+				return "ok";
+			},
+			{ baseDelayMs: 0 },
+		);
+		expect(value).toBe("ok");
+		expect(attempts).toBe(2);
+	});
+
+	it("does not retry non-locked errors", async () => {
+		const { tmpdir } = await import("node:os");
+		const { mkdtemp } = await import("node:fs/promises");
+		const { join } = await import("node:path");
+		const { DatabaseSync } = await import("node:sqlite");
+		const dir = await mkdtemp(join(tmpdir(), "sqlite-helpers-"));
+		const dbPath = join(dir, "x.db");
+		new DatabaseSync(dbPath).close();
+
+		let attempts = 0;
+		await expect(
+			withSqliteDb(
+				dbPath,
+				() => {
+					attempts++;
+					throw new Error("SQLITE_CORRUPT: database disk image is malformed");
+				},
+				{ baseDelayMs: 0 },
+			),
+		).rejects.toThrow(/SQLITE_CORRUPT/);
+		expect(attempts).toBe(1);
+	});
+
+	it("gives up after maxAttempts and throws the last locked error", async () => {
+		const { tmpdir } = await import("node:os");
+		const { mkdtemp } = await import("node:fs/promises");
+		const { join } = await import("node:path");
+		const { DatabaseSync } = await import("node:sqlite");
+		const dir = await mkdtemp(join(tmpdir(), "sqlite-helpers-"));
+		const dbPath = join(dir, "x.db");
+		new DatabaseSync(dbPath).close();
+
+		let attempts = 0;
+		await expect(
+			withSqliteDb(
+				dbPath,
+				() => {
+					attempts++;
+					throw new Error("SQLITE_BUSY: database is locked");
+				},
+				{ maxAttempts: 3, baseDelayMs: 0 },
+			),
+		).rejects.toThrow(/SQLITE_BUSY/);
+		expect(attempts).toBe(3);
+	});
 });

--- a/cli/src/core/SqliteHelpers.ts
+++ b/cli/src/core/SqliteHelpers.ts
@@ -30,14 +30,43 @@ export interface SqliteDbHandle {
  * The module is imported dynamically so the ExperimentalWarning only appears
  * when this helper is actually invoked — not when PostCommitHook merely
  * transitively imports this file.
+ *
+ * SQLITE_BUSY recovery: when the host application (OpenCode, Cursor, Copilot
+ * Chat) is mid-write at the moment the QueueWorker tries to read, the open or
+ * first query fails with `database is locked`. Those write transactions are
+ * millisecond-scale, so a short exponential retry (150ms × 2^attempt) clears
+ * the race the overwhelming majority of the time. Without this, a busy-lock at
+ * worker start time silently drops the entire source's sessions from the
+ * commit's attribution — including any conversation the user just checked in
+ * the sidebar, which then never gets a cursor advance and stays visible
+ * forever. Only `locked` retries; other classified errors (corrupt, permission,
+ * schema) are persistent and rethrown immediately.
  */
-export async function withSqliteDb<T>(dbPath: string, fn: (db: SqliteDbHandle) => T): Promise<T> {
+export interface WithSqliteDbOptions {
+	readonly maxAttempts?: number;
+	readonly baseDelayMs?: number;
+}
+
+export async function withSqliteDb<T>(
+	dbPath: string,
+	fn: (db: SqliteDbHandle) => T,
+	opts: WithSqliteDbOptions = {},
+): Promise<T> {
+	const maxAttempts = opts.maxAttempts ?? 3;
+	const baseDelayMs = opts.baseDelayMs ?? 150;
 	const { DatabaseSync } = await import("node:sqlite");
-	const db = new DatabaseSync(dbPath, { readOnly: true });
-	try {
-		return fn(db as unknown as SqliteDbHandle);
-	} finally {
-		db.close();
+	for (let attempt = 1; ; attempt++) {
+		let db: InstanceType<typeof DatabaseSync> | undefined;
+		try {
+			db = new DatabaseSync(dbPath, { readOnly: true });
+			return fn(db as unknown as SqliteDbHandle);
+		} catch (err) {
+			const kind = classifyScanError(err)?.kind;
+			if (kind !== "locked" || attempt >= maxAttempts) throw err;
+			await new Promise((resolve) => setTimeout(resolve, baseDelayMs * 2 ** (attempt - 1)));
+		} finally {
+			db?.close();
+		}
 	}
 }
 

--- a/cli/src/hooks/PostCommitHook.test.ts
+++ b/cli/src/hooks/PostCommitHook.test.ts
@@ -229,6 +229,23 @@ vi.mock("../core/HiddenConversationsStore.js", async (importOriginal) => {
 	};
 });
 
+// CommitSelectionStore: pipeline reads this at the top of executePipeline /
+// handleAmendPipeline. Real readFile under fake timers can hang because the
+// I/O completion callback never gets scheduled. Mock with empty exclusions
+// by default; tests covering the exclusion filter live in
+// QueueWorker.selection.test.ts which does not use fake timers.
+vi.mock("../core/CommitSelectionStore.js", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../core/CommitSelectionStore.js")>();
+	return {
+		...actual,
+		readExclusions: vi.fn(async () => ({
+			conversations: new Set<string>(),
+			plans: new Set<string>(),
+			notes: new Set<string>(),
+		})),
+	};
+});
+
 // Suppress console output
 vi.spyOn(console, "log").mockImplementation(() => {});
 vi.spyOn(console, "warn").mockImplementation(() => {});

--- a/cli/src/hooks/QueueWorker.selection.test.ts
+++ b/cli/src/hooks/QueueWorker.selection.test.ts
@@ -1,0 +1,737 @@
+/**
+ * QueueWorker.selection.test
+ *
+ * Verifies that the summary pipeline respects commit-selection.json exclusions:
+ *  - Excluded conversations are dropped from the sessionTranscripts fed to the LLM.
+ *  - Excluded plans are dropped from the plans block.
+ *  - Excluded notes are dropped from the notes block.
+ *  - The pipeline never writes to commit-selection.json (read-only consumer).
+ *
+ * Drives executePipeline (and processQueueEntry for non-LLM op types) via
+ * __test__ exports. All external IO is mocked identically to PostCommitHook.test.ts
+ * except CommitSelectionStore — which exercises the real on-disk read path
+ * against a temp directory.
+ */
+
+import { mkdtempSync, rmSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// --- Module stubs (same surface as PostCommitHook.test.ts) ---
+
+vi.mock("node:child_process", () => ({
+	spawn: vi.fn().mockReturnValue({ unref: vi.fn(), pid: 9999 }),
+	execSync: vi.fn(),
+}));
+
+vi.mock("../core/StorageFactory.js", () => ({
+	createStorage: vi.fn().mockResolvedValue({
+		readFile: vi.fn().mockResolvedValue(null),
+		writeFiles: vi.fn().mockResolvedValue(undefined),
+		listFiles: vi.fn().mockResolvedValue([]),
+		exists: vi.fn().mockResolvedValue(true),
+		ensure: vi.fn().mockResolvedValue(undefined),
+	}),
+}));
+
+vi.mock("../core/GitOps.js", () => ({
+	getProjectRootDir: vi.fn().mockImplementation((cwd: string) => Promise.resolve(cwd)),
+	getCommitInfo: vi.fn(),
+	getHeadHash: vi.fn(),
+	getParentHash: vi.fn(),
+	getDiffContent: vi.fn(),
+	getDiffStats: vi.fn(),
+	getCurrentBranch: vi.fn(),
+	getLastReflogAction: vi.fn(),
+	readFileFromBranch: vi.fn(),
+}));
+
+vi.mock("../core/SessionTracker.js", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../core/SessionTracker.js")>();
+	return {
+		loadAllSessions: vi.fn().mockResolvedValue([]),
+		loadCursorForTranscript: vi.fn().mockResolvedValue(null),
+		saveCursor: vi.fn().mockResolvedValue(undefined),
+		loadConfig: vi.fn().mockResolvedValue({}),
+		loadSquashPending: vi.fn(),
+		deleteSquashPending: vi.fn(),
+		loadPluginSource: vi.fn(),
+		deletePluginSource: vi.fn(),
+		loadPlansRegistry: vi.fn().mockResolvedValue({ version: 1, plans: {} }),
+		savePlansRegistry: vi.fn().mockResolvedValue(undefined),
+		associatePlanWithCommit: vi.fn().mockResolvedValue(undefined),
+		associateNoteWithCommit: vi.fn().mockResolvedValue(undefined),
+		associateLinearIssueWithCommit: vi.fn().mockResolvedValue(undefined),
+		detectUncommittedLinearIssueIds: vi.fn().mockResolvedValue([]),
+		detectActivePlansForBranch: vi.fn().mockResolvedValue([]),
+		detectActiveNotesForBranch: vi.fn().mockResolvedValue([]),
+		getLinearIssueEntriesForBranch: vi.fn().mockResolvedValue([]),
+		filterSessionsByEnabledIntegrations: actual.filterSessionsByEnabledIntegrations,
+		dequeueAllGitOperations: vi.fn().mockResolvedValue([]),
+		deleteQueueEntry: vi.fn().mockResolvedValue(undefined),
+		enqueueGitOperation: vi.fn(),
+	};
+});
+
+vi.mock("../core/LinearIssueStore.js", () => ({
+	linearIssuePath: vi.fn((key: string, cwd: string) => `${cwd}/.jolli/jollimemory/linear-issues/${key}.md`),
+	readLinearIssueMarkdown: vi.fn().mockResolvedValue(null),
+	renameLinearIssueMarkdown: vi.fn().mockResolvedValue(undefined),
+	hashLinearIssueContentFromMarkdown: vi.fn().mockReturnValue("fakehash"),
+}));
+
+vi.mock("../core/PlanPromptFormatter.js", () => ({
+	formatPlansBlock: vi.fn().mockResolvedValue(""),
+}));
+
+vi.mock("../core/NotePromptFormatter.js", () => ({
+	formatNotesBlock: vi.fn().mockResolvedValue(""),
+}));
+
+vi.mock("../core/Locks.js", () => ({
+	acquireWorkerLock: vi.fn().mockResolvedValue(true),
+	releaseWorkerLock: vi.fn().mockResolvedValue(undefined),
+	refreshWorkerLockMtime: vi.fn(),
+	isWorkerLockHeld: vi.fn(),
+}));
+
+vi.mock("../core/TranscriptReader.js", () => ({
+	readTranscript: vi.fn(),
+	buildMultiSessionContext: vi.fn().mockReturnValue(""),
+}));
+
+vi.mock("../core/TranscriptParser.js", () => ({
+	getParserForSource: vi.fn().mockReturnValue({ parseLine: vi.fn() }),
+}));
+
+vi.mock("../core/Summarizer.js", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../core/Summarizer.js")>();
+	return {
+		generateSummary: vi.fn(),
+		generateSquashConsolidation: vi.fn().mockResolvedValue(null),
+		mechanicalConsolidate: actual.mechanicalConsolidate,
+		extractTicketIdFromMessage: actual.extractTicketIdFromMessage,
+		formatSourceCommitsForSquash: actual.formatSourceCommitsForSquash,
+	};
+});
+
+vi.mock("../core/SummaryStore.js", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../core/SummaryStore.js")>();
+	return {
+		storeSummary: vi.fn().mockResolvedValue(undefined),
+		getSummary: vi.fn().mockResolvedValue(null),
+		mergeManyToOne: vi.fn().mockResolvedValue(undefined),
+		migrateOneToOne: vi.fn().mockResolvedValue(undefined),
+		storePlans: vi.fn().mockResolvedValue(undefined),
+		storeNotes: vi.fn().mockResolvedValue(undefined),
+		storeLinearIssues: vi.fn().mockResolvedValue(undefined),
+		setActiveStorage: vi.fn(),
+		resolveStorage: vi.fn(),
+		stripFunctionalMetadata: actual.stripFunctionalMetadata,
+		resolveEffectiveTopics: actual.resolveEffectiveTopics,
+		expandSourcesForConsolidation: actual.expandSourcesForConsolidation,
+	};
+});
+
+vi.mock("node:fs", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("node:fs")>();
+	return {
+		...actual,
+		existsSync: vi.fn().mockReturnValue(false),
+		readFileSync: vi.fn().mockReturnValue(""),
+	};
+});
+
+vi.mock("../core/CodexSessionDiscoverer.js", () => ({
+	discoverCodexSessions: vi.fn().mockResolvedValue([]),
+	isCodexInstalled: vi.fn().mockResolvedValue(false),
+}));
+
+vi.mock("../core/OpenCodeSessionDiscoverer.js", () => ({
+	discoverOpenCodeSessions: vi.fn().mockResolvedValue([]),
+	isOpenCodeInstalled: vi.fn().mockResolvedValue(false),
+}));
+
+vi.mock("../core/OpenCodeTranscriptReader.js", () => ({
+	readOpenCodeTranscript: vi.fn().mockResolvedValue({
+		entries: [],
+		newCursor: { transcriptPath: "", lineNumber: 0, updatedAt: "" },
+		totalLinesRead: 0,
+	}),
+}));
+
+vi.mock("../core/CursorDetector.js", () => ({
+	isCursorInstalled: vi.fn().mockResolvedValue(false),
+}));
+
+vi.mock("../core/CursorSessionDiscoverer.js", () => ({
+	discoverCursorSessions: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock("../core/CursorTranscriptReader.js", () => ({
+	readCursorTranscript: vi.fn().mockResolvedValue({
+		entries: [],
+		newCursor: { transcriptPath: "", lineNumber: 0, updatedAt: "" },
+		totalLinesRead: 0,
+	}),
+}));
+
+vi.mock("../core/GeminiTranscriptReader.js", () => ({
+	readGeminiTranscript: vi.fn().mockResolvedValue({
+		entries: [],
+		newCursor: { transcriptPath: "", lineNumber: 0, updatedAt: "" },
+		totalLinesRead: 0,
+	}),
+}));
+
+vi.mock("../core/CopilotDetector.js", () => ({
+	isCopilotInstalled: vi.fn().mockResolvedValue(false),
+	getCopilotDbPath: vi.fn().mockReturnValue("/mock/.copilot/session-store.db"),
+}));
+
+vi.mock("../core/CopilotSessionDiscoverer.js", () => ({
+	discoverCopilotSessions: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock("../core/CopilotChatDetector.js", () => ({
+	isCopilotChatInstalled: vi.fn().mockResolvedValue(false),
+	getCopilotChatStorageDir: vi.fn().mockReturnValue("/mock/Code/User/globalStorage/github.copilot-chat"),
+}));
+
+vi.mock("../core/CopilotChatSessionDiscoverer.js", () => ({
+	discoverCopilotChatSessions: vi.fn().mockResolvedValue([]),
+	scanCopilotChatSessions: vi.fn().mockResolvedValue({ sessions: [] }),
+}));
+
+vi.mock("../core/CopilotChatTranscriptReader.js", () => ({
+	readCopilotChatTranscript: vi.fn().mockResolvedValue({
+		entries: [],
+		newCursor: { transcriptPath: "", lineNumber: 0, updatedAt: "" },
+		totalLinesRead: 0,
+	}),
+}));
+
+vi.mock("../core/CopilotTranscriptReader.js", () => ({
+	readCopilotTranscript: vi.fn().mockResolvedValue({
+		entries: [],
+		newCursor: { transcriptPath: "", lineNumber: 0, updatedAt: "" },
+		totalLinesRead: 0,
+	}),
+}));
+
+vi.mock("../core/ConversationOverlayStore.js", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../core/ConversationOverlayStore.js")>();
+	return {
+		...actual,
+		applyOverlaysToSessions: vi.fn(async (sessions: unknown) => sessions),
+		loadOverlay: vi.fn(async () => null),
+	};
+});
+
+vi.mock("../core/HiddenConversationsStore.js", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../core/HiddenConversationsStore.js")>();
+	return {
+		...actual,
+		loadHiddenConversations: vi.fn(async () => ({ version: 1, entries: {} })),
+	};
+});
+
+vi.mock("../core/StaleChildMarkdownCleanup.js", () => ({
+	cleanupBranchStaleChildMarkdown: vi.fn().mockResolvedValue({ deleted: 0, failed: 0 }),
+}));
+
+vi.mock("../core/PlanProgressEvaluator.js", () => ({
+	evaluatePlanProgress: vi.fn().mockResolvedValue(null),
+}));
+
+vi.spyOn(console, "log").mockImplementation(() => {});
+vi.spyOn(console, "warn").mockImplementation(() => {});
+vi.spyOn(console, "error").mockImplementation(() => {});
+
+// --- Real imports (after vi.mock hoisting) ---
+
+import { conversationKey, setExcluded } from "../core/CommitSelectionStore.js";
+import { getCommitInfo, getCurrentBranch, getDiffContent, getDiffStats } from "../core/GitOps.js";
+import { formatNotesBlock } from "../core/NotePromptFormatter.js";
+import { formatPlansBlock } from "../core/PlanPromptFormatter.js";
+import {
+	detectActiveNotesForBranch,
+	detectActivePlansForBranch,
+	loadAllSessions,
+	loadConfig,
+	loadCursorForTranscript,
+	loadPlansRegistry,
+	saveCursor,
+} from "../core/SessionTracker.js";
+import type { SummaryResult } from "../core/Summarizer.js";
+import { generateSummary } from "../core/Summarizer.js";
+import { storeSummary } from "../core/SummaryStore.js";
+import { buildMultiSessionContext, readTranscript } from "../core/TranscriptReader.js";
+import type { GitOperation, NoteEntry, PlanEntry } from "../Types.js";
+import { __test__ } from "./QueueWorker.js";
+
+const { executePipeline, processQueueEntry } = __test__;
+
+// --- Minimal mock helpers ---
+
+function makeSummaryResult(): SummaryResult {
+	return {
+		transcriptEntries: 1,
+		llm: { model: "test-model", inputTokens: 10, outputTokens: 5, apiLatencyMs: 100, stopReason: "end_turn" },
+		stats: { filesChanged: 1, insertions: 2, deletions: 1 },
+		topics: [{ title: "T", trigger: "X", response: "Y", decisions: "Z" }],
+	};
+}
+
+function makeCommitOp(overrides?: Partial<GitOperation>): GitOperation {
+	return {
+		type: "commit",
+		commitHash: "abc12345",
+		commitSource: "cli",
+		createdAt: "2026-01-01T00:00:00.000Z",
+		branch: "main",
+		...overrides,
+	};
+}
+
+/** Seed standard git mocks so the pipeline gets past diff/branch lookups. */
+function seedGitMocks(_cwd: string): void {
+	vi.mocked(getCommitInfo).mockResolvedValue({
+		hash: "abc12345",
+		message: "test commit",
+		author: "Test User",
+		date: "2026-01-01",
+	});
+	vi.mocked(getCurrentBranch).mockResolvedValue("main");
+	vi.mocked(getDiffContent).mockResolvedValue("diff --git a/foo.ts b/foo.ts");
+	vi.mocked(getDiffStats).mockResolvedValue({ filesChanged: 1, insertions: 2, deletions: 1 });
+	vi.mocked(loadConfig).mockResolvedValue({
+		codexEnabled: false,
+		openCodeEnabled: false,
+		cursorEnabled: false,
+		copilotEnabled: false,
+	} as never);
+	vi.mocked(saveCursor).mockResolvedValue(undefined);
+	vi.mocked(generateSummary).mockResolvedValue(makeSummaryResult());
+}
+
+/** Seed one claude session so loadSessionTranscripts produces a SessionTranscript. */
+function seedClaudeSession(sessionId: string, marker: string): void {
+	vi.mocked(loadAllSessions).mockResolvedValue([
+		{
+			sessionId,
+			transcriptPath: `/fake/${sessionId}.jsonl`,
+			updatedAt: "2026-01-01T00:00:00Z",
+			source: "claude" as const,
+		},
+	]);
+	vi.mocked(loadCursorForTranscript).mockResolvedValue(null);
+	vi.mocked(readTranscript).mockResolvedValue({
+		entries: [{ role: "human", content: marker, timestamp: "t0" }],
+		newCursor: { transcriptPath: `/fake/${sessionId}.jsonl`, lineNumber: 1, updatedAt: "2026-01-01T00:00:00Z" },
+		totalLinesRead: 1,
+	});
+}
+
+/** Return the selectionFilePath for a given projectDir. */
+function selectionPath(projectDir: string): string {
+	return join(projectDir, ".jolli", "jollimemory", "commit-selection.json");
+}
+
+// --- Test suite ---
+
+describe("QueueWorker selection filter", () => {
+	let projectDir: string;
+
+	beforeEach(() => {
+		projectDir = mkdtempSync(join(tmpdir(), "qw-selection-"));
+		vi.clearAllMocks();
+		// Restore per-test defaults that clearAllMocks resets:
+		vi.mocked(detectActivePlansForBranch).mockResolvedValue([]);
+		vi.mocked(detectActiveNotesForBranch).mockResolvedValue([]);
+	});
+
+	afterEach(() => {
+		rmSync(projectDir, { recursive: true, force: true });
+	});
+
+	it("skips a conversation that is marked excluded in commit-selection.json", async () => {
+		const claudeSessionId = "claude-sess-A";
+		const claudeMarker = "UNIQUE_CLAUDE_CONTENT_MARKER";
+		seedGitMocks(projectDir);
+		seedClaudeSession(claudeSessionId, claudeMarker);
+
+		// Mark claude session as excluded
+		await setExcluded(projectDir, "conversations", conversationKey("claude", claudeSessionId), true);
+
+		// Track what buildMultiSessionContext receives
+		const capturedSessions: unknown[] = [];
+		vi.mocked(buildMultiSessionContext).mockImplementation((sessions) => {
+			capturedSessions.push(...sessions);
+			return "";
+		});
+
+		await executePipeline(projectDir, makeCommitOp());
+
+		// The excluded session must not reach buildMultiSessionContext
+		expect(capturedSessions).toHaveLength(0);
+	});
+
+	it("passes non-excluded conversations through to buildMultiSessionContext", async () => {
+		const claudeSessionId = "claude-sess-B";
+		const claudeMarker = "KEEP_THIS_CONTENT";
+		seedGitMocks(projectDir);
+		seedClaudeSession(claudeSessionId, claudeMarker);
+
+		// Do NOT exclude this session
+		const capturedSessions: unknown[] = [];
+		vi.mocked(buildMultiSessionContext).mockImplementation((sessions) => {
+			capturedSessions.push(...sessions);
+			return claudeMarker;
+		});
+
+		await executePipeline(projectDir, makeCommitOp());
+
+		expect(capturedSessions).toHaveLength(1);
+	});
+
+	it("does not advance the cursor for an excluded conversation", async () => {
+		// Regression: when the worker advanced cursors for excluded sessions, the
+		// sidebar's "messageCount > 0" filter dropped them on the next 60-second
+		// refresh — making the *unchecked* rows disappear alongside the committed
+		// ones. The fix is to skip the read entirely for excluded sessions.
+		const claudeSessionId = "claude-sess-excluded";
+		seedGitMocks(projectDir);
+		seedClaudeSession(claudeSessionId, "EXCLUDED_CONTENT");
+
+		await setExcluded(projectDir, "conversations", conversationKey("claude", claudeSessionId), true);
+
+		await executePipeline(projectDir, makeCommitOp());
+
+		expect(vi.mocked(saveCursor)).not.toHaveBeenCalled();
+		expect(vi.mocked(readTranscript)).not.toHaveBeenCalled();
+	});
+
+	it("advances the cursor for a non-excluded conversation", async () => {
+		const claudeSessionId = "claude-sess-included";
+		seedGitMocks(projectDir);
+		seedClaudeSession(claudeSessionId, "INCLUDED_CONTENT");
+
+		await executePipeline(projectDir, makeCommitOp());
+
+		expect(vi.mocked(saveCursor)).toHaveBeenCalledTimes(1);
+	});
+
+	it("does not advance the cursor for an excluded conversation on the amend path", async () => {
+		const claudeSessionId = "claude-sess-amend-excluded";
+		seedGitMocks(projectDir);
+		seedClaudeSession(claudeSessionId, "EXCLUDED_AMEND_CONTENT");
+
+		await setExcluded(projectDir, "conversations", conversationKey("claude", claudeSessionId), true);
+
+		const amendOp = makeCommitOp({ type: "amend", sourceHashes: ["old-hash-0001"] });
+		await executePipeline(projectDir, amendOp);
+
+		expect(vi.mocked(saveCursor)).not.toHaveBeenCalled();
+		expect(vi.mocked(readTranscript)).not.toHaveBeenCalled();
+	});
+
+	it("filters excluded plans out of the plans block input", async () => {
+		seedGitMocks(projectDir);
+		// No sessions — diff alone will trigger the pipeline
+		vi.mocked(loadAllSessions).mockResolvedValue([]);
+		vi.mocked(buildMultiSessionContext).mockReturnValue("");
+
+		const keepPlan: PlanEntry = {
+			slug: "plan-keep",
+			title: "Keep Plan",
+			sourcePath: "/fake/plan-keep.md",
+			addedAt: "2026-01-01T00:00:00Z",
+			updatedAt: "2026-01-01T00:00:00Z",
+			branch: "main",
+			commitHash: null,
+			editCount: 0,
+		};
+		const skipPlan: PlanEntry = {
+			slug: "plan-skip",
+			title: "Skip Plan",
+			sourcePath: "/fake/plan-skip.md",
+			addedAt: "2026-01-01T00:00:00Z",
+			updatedAt: "2026-01-01T00:00:00Z",
+			branch: "main",
+			commitHash: null,
+			editCount: 0,
+		};
+		vi.mocked(detectActivePlansForBranch).mockResolvedValue([keepPlan, skipPlan]);
+
+		// Exclude "plan-skip"
+		await setExcluded(projectDir, "plans", "plan-skip", true);
+
+		const capturedPlanArgs: PlanEntry[][] = [];
+		vi.mocked(formatPlansBlock).mockImplementation(async (entries) => {
+			capturedPlanArgs.push([...entries] as PlanEntry[]);
+			return "";
+		});
+
+		await executePipeline(projectDir, makeCommitOp());
+
+		expect(capturedPlanArgs).toHaveLength(1);
+		const passedSlugs = capturedPlanArgs[0].map((p) => p.slug);
+		expect(passedSlugs).toContain("plan-keep");
+		expect(passedSlugs).not.toContain("plan-skip");
+	});
+
+	it("filters excluded notes out of the notes block input", async () => {
+		seedGitMocks(projectDir);
+		vi.mocked(loadAllSessions).mockResolvedValue([]);
+		vi.mocked(buildMultiSessionContext).mockReturnValue("");
+
+		const keepNote: NoteEntry = {
+			id: "note-keep",
+			title: "Keep Note",
+			format: "markdown",
+			addedAt: "2026-01-01T00:00:00Z",
+			updatedAt: "2026-01-01T00:00:00Z",
+			branch: "main",
+			commitHash: null,
+		};
+		const skipNote: NoteEntry = {
+			id: "note-skip",
+			title: "Skip Note",
+			format: "markdown",
+			addedAt: "2026-01-01T00:00:00Z",
+			updatedAt: "2026-01-01T00:00:00Z",
+			branch: "main",
+			commitHash: null,
+		};
+		vi.mocked(detectActiveNotesForBranch).mockResolvedValue([keepNote, skipNote]);
+
+		// Exclude "note-skip"
+		await setExcluded(projectDir, "notes", "note-skip", true);
+
+		const capturedNoteArgs: NoteEntry[][] = [];
+		vi.mocked(formatNotesBlock).mockImplementation(async (entries) => {
+			capturedNoteArgs.push([...entries] as NoteEntry[]);
+			return "";
+		});
+
+		await executePipeline(projectDir, makeCommitOp());
+
+		expect(capturedNoteArgs).toHaveLength(1);
+		const passedIds = capturedNoteArgs[0].map((n) => n.id);
+		expect(passedIds).toContain("note-keep");
+		expect(passedIds).not.toContain("note-skip");
+	});
+
+	it("never writes commit-selection.json from the pipeline (commit path)", async () => {
+		const claudeSessionId = "claude-sess-C";
+		seedGitMocks(projectDir);
+		seedClaudeSession(claudeSessionId, "content-C");
+		vi.mocked(buildMultiSessionContext).mockReturnValue("");
+
+		// Plant an exclusion so the file exists before the run
+		await setExcluded(projectDir, "conversations", conversationKey("claude", claudeSessionId), true);
+		const before = await readFile(selectionPath(projectDir), "utf8");
+
+		await executePipeline(projectDir, makeCommitOp());
+
+		const after = await readFile(selectionPath(projectDir), "utf8");
+		expect(after).toBe(before);
+	});
+
+	it("never writes commit-selection.json on the amend path", async () => {
+		const claudeSessionId = "claude-sess-D";
+		seedGitMocks(projectDir);
+		seedClaudeSession(claudeSessionId, "content-D");
+		vi.mocked(buildMultiSessionContext).mockReturnValue("");
+
+		// The amend path: op.type = "amend", op.sourceHashes[0] must be set
+		// executePipeline hands off to handleAmendPipeline when op.type === "amend"
+		const amendOp = makeCommitOp({ type: "amend", sourceHashes: ["old-hash-0000"] });
+
+		await setExcluded(projectDir, "conversations", conversationKey("claude", claudeSessionId), true);
+		const before = await readFile(selectionPath(projectDir), "utf8");
+
+		await executePipeline(projectDir, amendOp);
+
+		const after = await readFile(selectionPath(projectDir), "utf8");
+		expect(after).toBe(before);
+	});
+
+	it("never writes commit-selection.json on the squash path via processQueueEntry", async () => {
+		seedGitMocks(projectDir);
+		vi.mocked(loadAllSessions).mockResolvedValue([]);
+		vi.mocked(buildMultiSessionContext).mockReturnValue("");
+
+		// squash op: needs sourceHashes + an existing summary to proceed
+		// getSummary returns null by default → handleSquashFromQueue skips (warns and returns)
+		// so no writes are attempted but the pipeline is entered
+		const squashOp = makeCommitOp({
+			type: "squash",
+			sourceHashes: ["src-hash-0001"],
+		});
+
+		await setExcluded(projectDir, "conversations", conversationKey("claude", "any-id"), true);
+		const before = await readFile(selectionPath(projectDir), "utf8");
+
+		// processQueueEntry is the production dispatch path for squash
+		await processQueueEntry(squashOp, projectDir, {} as never, false);
+
+		const after = await readFile(selectionPath(projectDir), "utf8");
+		expect(after).toBe(before);
+	});
+
+	it("never writes commit-selection.json on the rebase-pick path via processQueueEntry", async () => {
+		seedGitMocks(projectDir);
+		vi.mocked(loadAllSessions).mockResolvedValue([]);
+
+		const rebasePickOp = makeCommitOp({
+			type: "rebase-pick",
+			sourceHashes: ["src-hash-0002"],
+		});
+
+		await setExcluded(projectDir, "conversations", conversationKey("claude", "any-id"), true);
+		const before = await readFile(selectionPath(projectDir), "utf8");
+
+		await processQueueEntry(rebasePickOp, projectDir, {} as never, false);
+
+		const after = await readFile(selectionPath(projectDir), "utf8");
+		expect(after).toBe(before);
+	});
+
+	it("never writes commit-selection.json on the rebase-squash path via processQueueEntry", async () => {
+		seedGitMocks(projectDir);
+		vi.mocked(loadAllSessions).mockResolvedValue([]);
+
+		const rebaseSquashOp = makeCommitOp({
+			type: "rebase-squash",
+			sourceHashes: ["src-hash-0003"],
+		});
+
+		await setExcluded(projectDir, "conversations", conversationKey("claude", "any-id"), true);
+		const before = await readFile(selectionPath(projectDir), "utf8");
+
+		await processQueueEntry(rebaseSquashOp, projectDir, {} as never, false);
+
+		const after = await readFile(selectionPath(projectDir), "utf8");
+		expect(after).toBe(before);
+	});
+
+	// ─── Archive-path exclusion (regression: PR #125 only filtered the prompt block) ──
+	// The two tests below drive the same pipeline through to `storeSummary` and assert
+	// that the excluded plan / note slug is absent from `summary.plans` / `summary.notes`.
+	// Without the archive-side filter the excluded entry still gets associated with the
+	// commit, written to the orphan branch, and disappears from the panel.
+
+	it("filters excluded plans out of summary.plans on the archive path", async () => {
+		seedGitMocks(projectDir);
+		vi.mocked(loadAllSessions).mockResolvedValue([]);
+		vi.mocked(buildMultiSessionContext).mockReturnValue("");
+
+		vi.mocked(loadPlansRegistry).mockResolvedValue({
+			version: 1,
+			plans: {
+				"plan-keep": {
+					slug: "plan-keep",
+					title: "Keep Plan",
+					sourcePath: "/fake/plan-keep.md",
+					addedAt: "2026-01-01T00:00:00Z",
+					updatedAt: "2026-01-01T00:00:00Z",
+					branch: "main",
+					commitHash: null,
+					editCount: 1,
+				},
+				"plan-skip": {
+					slug: "plan-skip",
+					title: "Skip Plan",
+					sourcePath: "/fake/plan-skip.md",
+					addedAt: "2026-01-01T00:00:00Z",
+					updatedAt: "2026-01-01T00:00:00Z",
+					branch: "main",
+					commitHash: null,
+					editCount: 1,
+				},
+			},
+		});
+
+		const fs = await import("node:fs");
+		vi.mocked(fs.existsSync).mockImplementation((p) => {
+			const s = String(p);
+			return s.endsWith("plan-keep.md") || s.endsWith("plan-skip.md");
+		});
+		vi.mocked(fs.readFileSync).mockImplementation((p) => {
+			const s = String(p);
+			if (s.endsWith("plan-keep.md")) return "# Keep Plan\nbody";
+			if (s.endsWith("plan-skip.md")) return "# Skip Plan\nbody";
+			return "";
+		});
+
+		await setExcluded(projectDir, "plans", "plan-skip", true);
+
+		await executePipeline(projectDir, makeCommitOp());
+
+		expect(vi.mocked(storeSummary)).toHaveBeenCalledTimes(1);
+		const summaryArg = vi.mocked(storeSummary).mock.calls[0][0];
+		const archivedPlanSlugs = (summaryArg.plans ?? []).map((p) => p.slug);
+		// commitHash short = "abc12345" → newSlug pattern is `<slug>-abc12345`
+		expect(archivedPlanSlugs).toContain("plan-keep-abc12345");
+		expect(archivedPlanSlugs).not.toContain("plan-skip-abc12345");
+	});
+
+	it("filters excluded notes out of summary.notes on the archive path", async () => {
+		seedGitMocks(projectDir);
+		vi.mocked(loadAllSessions).mockResolvedValue([]);
+		vi.mocked(buildMultiSessionContext).mockReturnValue("");
+
+		vi.mocked(loadPlansRegistry).mockResolvedValue({
+			version: 1,
+			plans: {},
+			notes: {
+				"note-keep": {
+					id: "note-keep",
+					title: "Keep Note",
+					format: "markdown",
+					sourcePath: "/fake/note-keep.md",
+					addedAt: "2026-01-01T00:00:00Z",
+					updatedAt: "2026-01-01T00:00:00Z",
+					branch: "main",
+					commitHash: null,
+				},
+				"note-skip": {
+					id: "note-skip",
+					title: "Skip Note",
+					format: "markdown",
+					sourcePath: "/fake/note-skip.md",
+					addedAt: "2026-01-01T00:00:00Z",
+					updatedAt: "2026-01-01T00:00:00Z",
+					branch: "main",
+					commitHash: null,
+				},
+			},
+		});
+
+		const fs = await import("node:fs");
+		vi.mocked(fs.existsSync).mockImplementation((p) => {
+			const s = String(p);
+			return s.endsWith("note-keep.md") || s.endsWith("note-skip.md");
+		});
+		vi.mocked(fs.readFileSync).mockImplementation((p) => {
+			const s = String(p);
+			if (s.endsWith("note-keep.md")) return "# Keep Note\nbody";
+			if (s.endsWith("note-skip.md")) return "# Skip Note\nbody";
+			return "";
+		});
+
+		await setExcluded(projectDir, "notes", "note-skip", true);
+
+		await executePipeline(projectDir, makeCommitOp());
+
+		expect(vi.mocked(storeSummary)).toHaveBeenCalledTimes(1);
+		const summaryArg = vi.mocked(storeSummary).mock.calls[0][0];
+		const archivedNoteIds = (summaryArg.notes ?? []).map((n) => n.id);
+		expect(archivedNoteIds).toContain("note-keep-abc12345");
+		expect(archivedNoteIds).not.toContain("note-skip-abc12345");
+	});
+});

--- a/cli/src/hooks/QueueWorker.ts
+++ b/cli/src/hooks/QueueWorker.ts
@@ -21,6 +21,7 @@ import { existsSync, readFileSync } from "node:fs";
 import { basename, dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { discoverCodexSessions, isCodexInstalled } from "../core/CodexSessionDiscoverer.js";
+import { conversationKey, readExclusions } from "../core/CommitSelectionStore.js";
 import { applyOverlaysToSessions } from "../core/ConversationOverlayStore.js";
 import { isCopilotChatInstalled } from "../core/CopilotChatDetector.js";
 import { discoverCopilotChatSessions } from "../core/CopilotChatSessionDiscoverer.js";
@@ -955,7 +956,11 @@ async function executePipeline(cwd: string, op: GitOperation, force = false): Pr
 		return;
 	}
 
-	// Step 3+4: Load sessions and read transcripts with time cutoff for queue-driven attribution
+	// Step 3+4: Load sessions and read transcripts with time cutoff for queue-driven attribution.
+	// Excluded conversations are filtered inside `loadSessionTranscripts` BEFORE any cursor
+	// advance — keep the plans/notes exclusion read here, but no `sessionTranscripts.filter`
+	// step is needed.
+	const exclusions = await readExclusions(cwd);
 	const { sessionTranscripts, totalEntries, humanEntries } = await loadSessionTranscripts(cwd, config, op.createdAt);
 
 	// Step 5: Get git diff and stats (moved before guard to enable diff-only summaries)
@@ -997,11 +1002,13 @@ async function executePipeline(cwd: string, op: GitOperation, force = false): Pr
 	// Step 6b: Assemble the three structured prompt blocks (plans / notes /
 	// linear-issues). Pure registry-driven: no transcript re-scan. User's
 	// Ignore on the panel takes effect immediately on the next commit.
-	const [activePlanEntries, activeNoteEntries, activeLinearIssueEntries] = await Promise.all([
+	const [rawActivePlanEntries, rawActiveNoteEntries, activeLinearIssueEntries] = await Promise.all([
 		detectActivePlansForBranch(cwd, branch),
 		detectActiveNotesForBranch(cwd, branch),
 		getLinearIssueEntriesForBranch(cwd, branch),
 	]);
+	const activePlanEntries = rawActivePlanEntries.filter((p) => !exclusions.plans.has(p.slug));
+	const activeNoteEntries = rawActiveNoteEntries.filter((n) => !exclusions.notes.has(n.id));
 	const plansBlock = await formatPlansBlock(activePlanEntries);
 	const notesBlock = await formatNotesBlock(activeNoteEntries);
 	const linearIssueRefsForPrompt: LinearIssueRef[] = [];
@@ -1085,13 +1092,21 @@ async function executePipeline(cwd: string, op: GitOperation, force = false): Pr
 	}
 	log.info("API summary generated (%s)", formatElapsed(stepStart));
 
-	// Step 8a: Read uncommitted plan slugs from plans.json registry
+	// Step 8a: Read uncommitted plan slugs from plans.json registry.
+	// Apply per-item exclusions BEFORE associate* — these helpers have side effects
+	// (savePlansRegistry archive entry + storePlans to the orphan branch), so a
+	// post-filter on `planAssociation.refs` would still leave the excluded plan
+	// archived on disk. The prompt-block filter at Step 6b only governs LLM input;
+	// the archive path is a separate registry scan and must be filtered here.
 	const planSlugs = await detectPlanSlugsFromRegistry(cwd, branch);
+	for (const excludedSlug of exclusions.plans) planSlugs.delete(excludedSlug);
 	const planAssociation = await associatePlansWithCommit(planSlugs, commitInfo.hash, cwd, branch);
 	const planRefs = planAssociation.refs;
 
-	// Step 8a2: Read uncommitted note IDs from plans.json registry
+	// Step 8a2: Read uncommitted note IDs from plans.json registry.
+	// Same archive-side exclusion as Step 8a — see comment above.
 	const noteIds = await detectUncommittedNoteIds(cwd, branch);
+	for (const excludedId of exclusions.notes) noteIds.delete(excludedId);
 	const noteRefs = await associateNotesWithCommit(noteIds, commitInfo.hash, cwd, branch);
 
 	// Step 8a3: Read uncommitted Linear issue ticketIds from plans.json registry
@@ -1549,8 +1564,11 @@ async function handleAmendPipeline(
 		log.info("No old summary found for %s — will create fresh summary for amended commit", oldHash.substring(0, 8));
 	}
 
-	// Load sessions and read transcripts with time cutoff.
+	// Load sessions and read transcripts with time cutoff. Excluded conversations are
+	// filtered inside `loadSessionTranscripts` BEFORE any cursor advance — keep the
+	// plans/notes exclusion read here, but no `sessionTranscripts.filter` step is needed.
 	const amendConfig = await loadConfig();
+	const amendExclusions = await readExclusions(cwd);
 	const { sessionTranscripts, totalEntries, humanEntries } = await loadSessionTranscripts(
 		cwd,
 		amendConfig,
@@ -1634,11 +1652,13 @@ async function handleAmendPipeline(
 	// Same registry-driven prompt assembly as executePipeline (see Stage 2 wiring).
 	/* v8 ignore start -- amend-pipeline prompt-block assembly mirrors executePipeline's Stage 2 path. The amend path is exercised via PostCommitHook.helpers tests but not the prompt-block content specifically; the helpers and shapes are covered by their own dedicated tests. */
 	const branchForBlocks = await getCurrentBranch(cwd);
-	const [amendPlanEntries, amendNoteEntries, amendLinearEntries] = await Promise.all([
+	const [rawAmendPlanEntries, rawAmendNoteEntries, amendLinearEntries] = await Promise.all([
 		detectActivePlansForBranch(cwd, branchForBlocks),
 		detectActiveNotesForBranch(cwd, branchForBlocks),
 		getLinearIssueEntriesForBranch(cwd, branchForBlocks),
 	]);
+	const amendPlanEntries = rawAmendPlanEntries.filter((p) => !amendExclusions.plans.has(p.slug));
+	const amendNoteEntries = rawAmendNoteEntries.filter((n) => !amendExclusions.notes.has(n.id));
 	const amendPlansBlock = await formatPlansBlock(amendPlanEntries);
 	const amendNotesBlock = await formatNotesBlock(amendNoteEntries);
 	const amendLinearRefs: LinearIssueRef[] = [];
@@ -1911,7 +1931,21 @@ async function loadSessionTranscripts(
 		log.info("No active sessions found — will infer topics from diff if available");
 	}
 
-	const raw = await readAllTranscripts(allSessions, cwd, beforeTimestamp);
+	// Drop sessions the user unchecked in the sidebar BEFORE reading transcripts.
+	// Reading advances per-transcript cursors via `saveCursor`, and the sidebar's
+	// active-conversations list uses `messageCount > 0` (unread = cursor → EOF)
+	// to decide whether to render a row — so any cursor advance silently removes
+	// the row on the next 60-second refresh. That regression made *unchecked*
+	// conversations disappear alongside the committed ones after every commit;
+	// excluding here keeps them visible with the unchecked box, as the per-item
+	// selection design spec requires ("excluded items stay visible so the user
+	// knows the item exists and can put it back in").
+	const conversationExclusions = (await readExclusions(cwd)).conversations;
+	const includedSessions = allSessions.filter(
+		(s) => !conversationExclusions.has(conversationKey(s.source ?? "claude", s.sessionId)),
+	);
+
+	const raw = await readAllTranscripts(includedSessions, cwd, beforeTimestamp);
 
 	// Apply per-session conversation-edit overlays (panel-authored deletes/edits
 	// from ConversationDetailsPanel) BEFORE the values flow into either the

--- a/docs/superpowers/plans/2026-05-19-commit-item-selection.md
+++ b/docs/superpowers/plans/2026-05-19-commit-item-selection.md
@@ -1,0 +1,1399 @@
+# Commit-time item selection — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+>
+> **Execution model for this plan:** Tasks 1–10 only WRITE code and tests — **do not run tests, do not lint, do not commit**. All verification (`npm run all`, manual smoke test) and the **single** commit happen in Task 11. If the implementer subagent normally runs tests after every change, override that behavior here: write the code, save the file, move on.
+
+**Goal:** Add per-row + per-section selection checkboxes to Conversations, Plans, Notes, and the Changes-panel file list. Unchecking writes a sticky entry to a new project-local `commit-selection.json` that the summary pipeline filters on; the file is **never** auto-cleared by any git operation.
+
+**Architecture:** New `CommitSelectionStore` in `cli/src/core/` holds an on-disk exclusion set. `ActiveSessionAggregator` and `PlansTreeProvider.serialize()` read the store and stamp `isSelected: boolean` onto each row. `QueueWorker.runSummaryPipeline` reads the store and filters sessions / plans / notes before LLM input. Webview gains per-row checkboxes and a "Select / Deselect All" header icon button (same shape as the existing Changes/Commits one). Changes-panel `FilesStore.refresh()` flips its seed-selection default to "all selected"; the Commits panel default is intentionally unchanged.
+
+**Tech Stack:** TypeScript (ESM, Node 22.5+), Biome lint, Vitest, esbuild bundling for the VS Code extension. No new dependencies.
+
+**Spec:** [docs/superpowers/specs/2026-05-19-commit-item-selection-design.md](../specs/2026-05-19-commit-item-selection-design.md)
+
+---
+
+## File Structure
+
+**Create:**
+
+- `cli/src/core/CommitSelectionStore.ts` — sticky exclusion store
+- `cli/src/core/CommitSelectionStore.test.ts` — focused unit tests
+- `cli/src/hooks/QueueWorker.selection.test.ts` — pipeline filter integration
+- `vscode/src/commands/SelectAllSelection.ts` — Select/Deselect All command handlers
+- `vscode/src/commands/SelectAllSelection.test.ts` — command behavior tests
+
+**Modify (CLI):**
+
+- `cli/src/core/ActiveSessionAggregator.ts` — add `isSelected` to interface; populate from store
+- `cli/src/core/ActiveSessionAggregator.test.ts` — extend with isSelected coverage
+- `cli/src/hooks/QueueWorker.ts` — read exclusions + filter sessions / plans / notes inside `runSummaryPipeline`; **never write**
+
+**Modify (VSCode):**
+
+- `vscode/src/views/SidebarMessages.ts` — three new outbound message types
+- `vscode/src/views/SidebarWebviewProvider.ts` — new dep callbacks + handler dispatch
+- `vscode/src/views/SidebarWebviewProvider.test.ts` — extend
+- `vscode/src/views/SidebarScriptBuilder.ts` — per-row checkboxes; two new section-header `check-all` icon buttons; cmdMap entries; click handlers
+- `vscode/src/views/SidebarScriptBuilder.test.ts` — extend
+- `vscode/src/providers/PlansTreeProvider.ts` — populate `isSelected` on plan / note rows in `serialize()`
+- `vscode/src/providers/PlansTreeProvider.test.ts` — extend
+- `vscode/src/services/ActiveSessionsProvider.ts` — pass `isSelected` through (likely no-op)
+- `vscode/src/services/ActiveSessionsProvider.test.ts` — extend
+- `vscode/src/Extension.ts` — register two new commands; wire three per-row callbacks; pass cwd through to provider
+- `vscode/src/stores/FilesStore.ts` — flip `refresh()` seed: every raw entry goes into `selectedPaths`
+- `vscode/src/stores/FilesStore.test.ts` — extend
+- `cli/CHANGELOG.md`, `vscode/CHANGELOG.md` — single bullet each (Task 11)
+
+Convention reminders (from CLAUDE.md):
+
+- The single final commit must be signed off: `git commit -s -m "…"`. NO `Co-Authored-By: Claude` / "🤖 Generated" trailers. CI rejects PRs without DCO.
+- VSCode source imports CLI core via the relative path `../../../cli/src/core/<Name>.js` — esbuild resolves at bundle time. Don't refactor those into package imports.
+- VSCode webview CSP forbids inline `style=""` / `onclick=""` — wire everything via CSS class + `addEventListener` (memory note `feedback_vscode_webview_csp_no_inline.md`).
+- Inside `SidebarScriptBuilder` template literals, never use backticks in comments — wrap identifier mentions in `'…'` or `"…"` (memory note `feedback_sidebar_script_builder_backtick_trap.md`).
+- CLI test coverage floor is 97 % statements / 96 % branches / 97 % functions / 97 % lines on **new** code under `cli/src/`. Don't add untested branches.
+
+---
+
+## Task 1: Create CommitSelectionStore (CLI)
+
+**Files:**
+
+- Create: `cli/src/core/CommitSelectionStore.ts`
+- Create: `cli/src/core/CommitSelectionStore.test.ts`
+
+- [ ] **Step 1: Skim `cli/src/core/HiddenConversationsStore.ts` for reference**
+
+Confirm the atomic-write + null-prototype pattern. The new store follows the same shape but holds three sets (conversations / plans / notes) instead of one map. Do not modify HiddenConversationsStore.
+
+- [ ] **Step 2: Write `cli/src/core/CommitSelectionStore.test.ts`**
+
+```ts
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { JOLLI_DIR, JOLLIMEMORY_DIR } from "../Logger.js";
+import {
+	conversationKey,
+	type CommitExclusions,
+	readExclusions,
+	setAllExcluded,
+	setExcluded,
+} from "./CommitSelectionStore.js";
+
+let cwd: string;
+
+beforeEach(async () => {
+	cwd = await mkdir(join(tmpdir(), `commit-sel-${Date.now()}-${Math.random()}`), {
+		recursive: true,
+	}).then((p) => p ?? "");
+	await mkdir(join(cwd, JOLLI_DIR, JOLLIMEMORY_DIR), { recursive: true });
+});
+
+afterEach(async () => {
+	await rm(cwd, { recursive: true, force: true });
+});
+
+function filePath(): string {
+	return join(cwd, JOLLI_DIR, JOLLIMEMORY_DIR, "commit-selection.json");
+}
+
+describe("CommitSelectionStore", () => {
+	it("returns empty exclusions when the file is missing", async () => {
+		const ex = await readExclusions(cwd);
+		expect(ex.conversations.size).toBe(0);
+		expect(ex.plans.size).toBe(0);
+		expect(ex.notes.size).toBe(0);
+	});
+
+	it("returns empty exclusions when the file is malformed", async () => {
+		await writeFile(filePath(), "not json", "utf8");
+		const ex = await readExclusions(cwd);
+		expect(ex.conversations.size).toBe(0);
+	});
+
+	it("setExcluded adds a conversation key and is readable", async () => {
+		await setExcluded(cwd, "conversations", conversationKey("claude", "abc"), true);
+		const ex = await readExclusions(cwd);
+		expect(ex.conversations.has(conversationKey("claude", "abc"))).toBe(true);
+	});
+
+	it("setExcluded(false) removes an existing key", async () => {
+		await setExcluded(cwd, "conversations", conversationKey("claude", "abc"), true);
+		await setExcluded(cwd, "conversations", conversationKey("claude", "abc"), false);
+		const ex = await readExclusions(cwd);
+		expect(ex.conversations.has(conversationKey("claude", "abc"))).toBe(false);
+	});
+
+	it("setAllExcluded bulk-adds the given keys for a kind", async () => {
+		await setAllExcluded(cwd, "plans", ["p1", "p2", "p3"], true);
+		const ex = await readExclusions(cwd);
+		expect([...ex.plans].sort()).toEqual(["p1", "p2", "p3"]);
+	});
+
+	it("setAllExcluded bulk-removes the given keys for a kind", async () => {
+		await setAllExcluded(cwd, "plans", ["p1", "p2", "p3"], true);
+		await setAllExcluded(cwd, "plans", ["p1", "p3"], false);
+		const ex = await readExclusions(cwd);
+		expect([...ex.plans].sort()).toEqual(["p2"]);
+	});
+
+	it("conversationKey joins source and sessionId with a colon", () => {
+		expect(conversationKey("claude", "abc")).toBe("claude:abc");
+	});
+
+	it("readExclusions rejects an unknown version", async () => {
+		await writeFile(filePath(), JSON.stringify({ version: 99, conversations: ["x"] }), "utf8");
+		const ex: CommitExclusions = await readExclusions(cwd);
+		expect(ex.conversations.size).toBe(0);
+	});
+
+	it("tolerates a stale conversation key that no longer exists", async () => {
+		await setExcluded(cwd, "conversations", conversationKey("codex", "ghost"), true);
+		const ex = await readExclusions(cwd);
+		expect(ex.conversations.has(conversationKey("codex", "ghost"))).toBe(true);
+	});
+
+	it("notes round-trip independently of plans", async () => {
+		await setExcluded(cwd, "plans", "p1", true);
+		await setExcluded(cwd, "notes", "n1", true);
+		const ex = await readExclusions(cwd);
+		expect(ex.plans.has("p1")).toBe(true);
+		expect(ex.notes.has("n1")).toBe(true);
+		expect(ex.plans.has("n1")).toBe(false);
+	});
+});
+```
+
+- [ ] **Step 3: Implement `cli/src/core/CommitSelectionStore.ts`**
+
+```ts
+/**
+ * CommitSelectionStore
+ *
+ * Persists the set of sidebar items the user wants EXCLUDED from the next
+ * summary pipeline run. Three kinds (conversations / plans / notes) live
+ * in a single JSON file under
+ * `<projectDir>/.jolli/jollimemory/commit-selection.json`.
+ *
+ * Sticky semantics: an entry stays in this file until the user explicitly
+ * un-excludes the item (re-checks the row, or hits the section's Select /
+ * Deselect All button). No git operation, no pipeline outcome, no editor
+ * lifecycle event modifies the file — the QueueWorker only ever READS it.
+ *
+ * Distinct from `HiddenConversationsStore` (permanent hide — row vanishes
+ * from sidebar) and from `PlanEntry.ignored` / `NoteEntry.ignored`
+ * (permanent ignore at the plans-registry layer). Exclusions are visible
+ * in the sidebar with an unchecked box; the row still renders.
+ */
+
+import { mkdir, readFile, rename, unlink, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { createLogger, errMsg, isEnoent, JOLLI_DIR, JOLLIMEMORY_DIR } from "../Logger.js";
+import type { TranscriptSource } from "../Types.js";
+
+const log = createLogger("CommitSelection");
+
+const SELECTION_FILE = "commit-selection.json";
+const SELECTION_VERSION = 1 as const;
+
+export type ExclusionKind = "conversations" | "plans" | "notes";
+
+export interface CommitExclusions {
+	readonly conversations: ReadonlySet<string>;
+	readonly plans: ReadonlySet<string>;
+	readonly notes: ReadonlySet<string>;
+}
+
+interface PersistedShape {
+	readonly version: typeof SELECTION_VERSION;
+	readonly conversations: readonly string[];
+	readonly plans: readonly string[];
+	readonly notes: readonly string[];
+}
+
+function selectionPath(projectDir: string): string {
+	return join(projectDir, JOLLI_DIR, JOLLIMEMORY_DIR, SELECTION_FILE);
+}
+
+/**
+ * Encode (source, sessionId) into a single string key. The colon is
+ * reserved across jollimemory (TranscriptSource values never contain one)
+ * so the key is unambiguously splittable if a debugging tool ever needs to.
+ */
+export function conversationKey(source: TranscriptSource, sessionId: string): string {
+	return `${source}:${sessionId}`;
+}
+
+function emptyExclusions(): CommitExclusions {
+	return {
+		conversations: new Set<string>(),
+		plans: new Set<string>(),
+		notes: new Set<string>(),
+	};
+}
+
+export async function readExclusions(projectDir: string): Promise<CommitExclusions> {
+	let raw: string;
+	try {
+		raw = await readFile(selectionPath(projectDir), "utf8");
+	} catch (err) {
+		if (!isEnoent(err)) {
+			log.warn("readExclusions read failed: %s", errMsg(err));
+		}
+		return emptyExclusions();
+	}
+	let parsed: Partial<PersistedShape>;
+	try {
+		parsed = JSON.parse(raw) as Partial<PersistedShape>;
+	} catch (err) {
+		log.warn("readExclusions JSON parse failed: %s", errMsg(err));
+		return emptyExclusions();
+	}
+	if (parsed.version !== SELECTION_VERSION) {
+		log.warn("readExclusions version mismatch (got %s) — ignoring file", String(parsed.version));
+		return emptyExclusions();
+	}
+	return {
+		conversations: new Set(asStringArray(parsed.conversations)),
+		plans: new Set(asStringArray(parsed.plans)),
+		notes: new Set(asStringArray(parsed.notes)),
+	};
+}
+
+function asStringArray(v: unknown): readonly string[] {
+	if (!Array.isArray(v)) return [];
+	return v.filter((x): x is string => typeof x === "string");
+}
+
+async function writeExclusions(projectDir: string, next: CommitExclusions): Promise<void> {
+	const dir = join(projectDir, JOLLI_DIR, JOLLIMEMORY_DIR);
+	await mkdir(dir, { recursive: true });
+	const payload: PersistedShape = {
+		version: SELECTION_VERSION,
+		conversations: [...next.conversations],
+		plans: [...next.plans],
+		notes: [...next.notes],
+	};
+	const tmp = `${selectionPath(projectDir)}.tmp-${process.pid}-${Date.now()}`;
+	await writeFile(tmp, JSON.stringify(payload, null, "\t"), "utf8");
+	await rename(tmp, selectionPath(projectDir));
+}
+
+function mutableClone(ex: CommitExclusions): {
+	conversations: Set<string>;
+	plans: Set<string>;
+	notes: Set<string>;
+} {
+	return {
+		conversations: new Set(ex.conversations),
+		plans: new Set(ex.plans),
+		notes: new Set(ex.notes),
+	};
+}
+
+export async function setExcluded(
+	projectDir: string,
+	kind: ExclusionKind,
+	key: string,
+	excluded: boolean,
+): Promise<void> {
+	const current = await readExclusions(projectDir);
+	const next = mutableClone(current);
+	const set = next[kind];
+	if (excluded) set.add(key);
+	else set.delete(key);
+	await writeExclusions(projectDir, next);
+}
+
+export async function setAllExcluded(
+	projectDir: string,
+	kind: ExclusionKind,
+	keys: readonly string[],
+	excluded: boolean,
+): Promise<void> {
+	const current = await readExclusions(projectDir);
+	const next = mutableClone(current);
+	const set = next[kind];
+	if (excluded) {
+		for (const k of keys) set.add(k);
+	} else {
+		for (const k of keys) set.delete(k);
+	}
+	await writeExclusions(projectDir, next);
+}
+
+/** Delete the file from disk. Tolerates ENOENT. Not used by the pipeline — exposed for tests / manual operator use. */
+export async function deleteSelectionFile(projectDir: string): Promise<void> {
+	try {
+		await unlink(selectionPath(projectDir));
+	} catch (err) {
+		if (!isEnoent(err)) {
+			log.warn("deleteSelectionFile failed: %s", errMsg(err));
+		}
+	}
+}
+```
+
+---
+
+## Task 2: ActiveConversationItem.isSelected (CLI)
+
+**Files:**
+
+- Modify: `cli/src/core/ActiveSessionAggregator.ts` (interface + populate logic)
+- Modify: `cli/src/core/ActiveSessionAggregator.test.ts` (extend)
+
+- [ ] **Step 1: Skim the existing test file's fixture helpers**
+
+Read `cli/src/core/ActiveSessionAggregator.test.ts` (first 100 lines) so the new tests reuse the same fixture pattern (mkdtemp, mocked sources, etc.).
+
+- [ ] **Step 2: Append failing tests to `cli/src/core/ActiveSessionAggregator.test.ts`**
+
+Add at the top of the test file:
+
+```ts
+import { conversationKey, setExcluded } from "./CommitSelectionStore.js";
+```
+
+Inside the existing top-level `describe(...)` block, append:
+
+```ts
+it("stamps isSelected=false on rows whose key is in the exclusion file", async () => {
+	// Arrange: project dir with one claude session that would pass filters.
+	const cwd = await createFixtureWithOneClaudeSession(); // existing helper in this file
+	const sessionId = await getFixtureSessionId(cwd);     // existing helper
+
+	// Mark the row excluded.
+	await setExcluded(cwd, "conversations", conversationKey("claude", sessionId), true);
+
+	const { items } = await listActiveConversationsWithDiagnostics({ cwd, windowMs: 60_000 });
+
+	expect(items).toHaveLength(1);
+	expect(items[0].isSelected).toBe(false);
+});
+
+it("defaults isSelected=true when the row is not in the exclusion file", async () => {
+	const cwd = await createFixtureWithOneClaudeSession();
+	const { items } = await listActiveConversationsWithDiagnostics({ cwd, windowMs: 60_000 });
+	expect(items).toHaveLength(1);
+	expect(items[0].isSelected).toBe(true);
+});
+```
+
+If the existing test file uses different helper names, substitute them — the helpers are the fixture creators in that file, not invented here. If no such helper exists, inline the fixture creation following the patterns at the top of the test file.
+
+- [ ] **Step 3: Add the field to the interface in `cli/src/core/ActiveSessionAggregator.ts`**
+
+Replace the interface (around line 23):
+
+```ts
+export interface ActiveConversationItem {
+	readonly sessionId: string;
+	readonly source: TranscriptSource;
+	readonly title: string;
+	readonly messageCount: number;
+	readonly updatedAt: string;
+	readonly transcriptPath: string;
+	/**
+	 * Per-commit-selection signal. `false` = user has unchecked this row;
+	 * the QueueWorker will skip its transcript when generating the next
+	 * summary. Default `true` for any row absent from
+	 * `commit-selection.json`. Independent of `HiddenConversationsStore`
+	 * (which hides the row entirely).
+	 */
+	readonly isSelected: boolean;
+}
+```
+
+- [ ] **Step 4: Populate `isSelected` in `listActiveConversationsWithDiagnostics`**
+
+Add the import at the top of the file:
+
+```ts
+import { conversationKey, readExclusions } from "./CommitSelectionStore.js";
+```
+
+Alongside the existing `Promise.all([collectFromAllSources(...), loadHiddenConversations(...)])`, add `readExclusions(opts.cwd)`. Then in the items map, derive `isSelected`:
+
+```ts
+const [collected, hidden, exclusions] = await Promise.all([
+	collectFromAllSources(opts.cwd),
+	loadHiddenConversations(opts.cwd),
+	readExclusions(opts.cwd),
+]);
+
+// … existing dedupe / filter logic unchanged …
+
+const items: ActiveConversationItem[] = await Promise.all(
+	visible.map(async (s) => {
+		const unread = await safeLoadUnreadMerged(s, opts.cwd);
+		const titleEntries = unread.length > 0 ? await safeLoadMerged(s, opts.cwd) : unread;
+		const source = s.source ?? "claude";
+		return {
+			sessionId: s.sessionId,
+			source,
+			title: await resolveSessionTitle(s, titleEntries),
+			messageCount: unread.length,
+			updatedAt: s.updatedAt,
+			transcriptPath: s.transcriptPath,
+			isSelected: !exclusions.conversations.has(conversationKey(source, s.sessionId)),
+		};
+	}),
+);
+```
+
+---
+
+## Task 3: QueueWorker filter integration (CLI)
+
+**Files:**
+
+- Modify: `cli/src/hooks/QueueWorker.ts` (inside `runSummaryPipeline` / `executePipeline`)
+- Create: `cli/src/hooks/QueueWorker.selection.test.ts`
+
+- [ ] **Step 1: Skim the current pipeline header**
+
+Read `cli/src/hooks/QueueWorker.ts` lines 870–1000 to locate:
+
+- `executePipeline(cwd, op, force)` entry
+- `loadSessionTranscripts(cwd)` call site
+- `detectActivePlansForBranch` / `detectActiveNotesForBranch` call sites
+- `generateSummary(summaryParams)` call site
+
+The filter goes between "load all" and "pass to LLM" at each of those points. No file path edits elsewhere.
+
+- [ ] **Step 2: Create `cli/src/hooks/QueueWorker.selection.test.ts`**
+
+Use the existing `QueueWorker.overlay.test.ts` fixture pattern as the model. Skeleton (replace fixture-builder names with whatever already exists in `QueueWorker.overlay.test.ts`):
+
+```ts
+import { readFile } from "node:fs/promises";
+import { describe, expect, it } from "vitest";
+import { conversationKey, setExcluded } from "../core/CommitSelectionStore.js";
+// If overlay test does not export fixture helpers, copy them inline here.
+// Do NOT introduce a new fixture helper file — keep the duplication local
+// until a third test file in this directory needs the same pattern.
+
+describe("QueueWorker selection filter", () => {
+	it("skips a conversation that is marked excluded in commit-selection.json", async () => {
+		const ctx = await buildPipelineFixture(); // claude + codex sessions present, one commit queued
+		await setExcluded(ctx.cwd, "conversations", conversationKey("codex", ctx.codexSessionId), true);
+
+		const summaryParams = await runPipelineAndCapture(ctx); // returns args generateSummary was called with
+
+		expect(summaryParams.conversation).not.toContain(ctx.codexTranscriptMarker);
+		expect(summaryParams.conversation).toContain(ctx.claudeTranscriptMarker);
+	});
+
+	it("filters excluded plans out of formatPlansBlock input", async () => {
+		const ctx = await buildPipelineFixture({ withPlanIds: ["plan-keep", "plan-skip"] });
+		await setExcluded(ctx.cwd, "plans", "plan-skip", true);
+		const summaryParams = await runPipelineAndCapture(ctx);
+		expect(summaryParams.plans).toContain("plan-keep");
+		expect(summaryParams.plans).not.toContain("plan-skip");
+	});
+
+	it("filters excluded notes out of formatNotesBlock input", async () => {
+		const ctx = await buildPipelineFixture({ withNoteIds: ["note-keep", "note-skip"] });
+		await setExcluded(ctx.cwd, "notes", "note-skip", true);
+		const summaryParams = await runPipelineAndCapture(ctx);
+		expect(summaryParams.notes).toContain("note-keep");
+		expect(summaryParams.notes).not.toContain("note-skip");
+	});
+
+	it("never writes commit-selection.json from the pipeline (commit path)", async () => {
+		const ctx = await buildPipelineFixture();
+		await setExcluded(ctx.cwd, "conversations", conversationKey("codex", ctx.codexSessionId), true);
+		const before = await readFile(ctx.selectionFilePath, "utf8");
+		await runPipelineAndCapture(ctx); // normal commit op
+		const after = await readFile(ctx.selectionFilePath, "utf8");
+		expect(after).toBe(before);
+	});
+
+	it("never writes commit-selection.json on the amend path", async () => {
+		const ctx = await buildPipelineFixture({ opType: "amend" });
+		await setExcluded(ctx.cwd, "conversations", conversationKey("codex", ctx.codexSessionId), true);
+		const before = await readFile(ctx.selectionFilePath, "utf8");
+		await runPipelineAndCapture(ctx);
+		const after = await readFile(ctx.selectionFilePath, "utf8");
+		expect(after).toBe(before);
+	});
+
+	it("never writes commit-selection.json on rebase-pick / squash / failure paths", async () => {
+		for (const op of ["squash", "rebase-pick", "rebase-squash"] as const) {
+			const ctx = await buildPipelineFixture({ opType: op });
+			await setExcluded(ctx.cwd, "conversations", conversationKey("codex", ctx.codexSessionId), true);
+			const before = await readFile(ctx.selectionFilePath, "utf8");
+			await runPipelineAndCapture(ctx);
+			expect(await readFile(ctx.selectionFilePath, "utf8")).toBe(before);
+		}
+	});
+});
+```
+
+- [ ] **Step 3: Modify `cli/src/hooks/QueueWorker.ts` — add the filter**
+
+Add the import at the top of the file:
+
+```ts
+import { conversationKey, readExclusions } from "../core/CommitSelectionStore.js";
+```
+
+Inside `executePipeline(cwd, op, force)`, before transcript loading and plan/note detection:
+
+```ts
+const exclusions = await readExclusions(cwd);
+```
+
+Right after `await loadSessionTranscripts(cwd)`:
+
+```ts
+const filteredSessions = sessions.filter(
+	(s) => !exclusions.conversations.has(conversationKey(s.source, s.sessionId)),
+);
+// use filteredSessions below in place of sessions
+```
+
+Right after `detectActivePlansForBranch(cwd, branch)`:
+
+```ts
+const filteredPlans = plans.filter((p) => !exclusions.plans.has(p.id));
+```
+
+Right after `detectActiveNotesForBranch(cwd, branch)`:
+
+```ts
+const filteredNotes = notes.filter((n) => !exclusions.notes.has(n.id));
+```
+
+Variable names should match what the existing code uses — adapt if `sessions` is called something else. The exact identifier doesn't matter; what matters is that `formatPlansBlock` / `formatNotesBlock` / `buildMultiSessionContext` receives the filtered arrays.
+
+**Do not** add any `clear()` / write call. The pipeline is read-only against this file.
+
+---
+
+## Task 4: PlansTreeProvider stamps isSelected on plan / note rows (VSCode)
+
+**Files:**
+
+- Modify: `vscode/src/providers/PlansTreeProvider.ts` (`serialize()` and a new `refreshExclusions` helper)
+- Modify: `vscode/src/providers/PlansTreeProvider.test.ts` (extend)
+- Modify: `vscode/src/Extension.ts` (pass cwd into `PlansTreeProvider` constructor if not already)
+
+- [ ] **Step 1: Skim both files**
+
+Find `serialize()` (around line 205) and the existing test file. Note that `SerializedTreeItem.isSelected` is already an optional field — only the populate step is new.
+
+- [ ] **Step 2: Append failing tests to `PlansTreeProvider.test.ts`**
+
+```ts
+import { setExcluded } from "../../../cli/src/core/CommitSelectionStore.js";
+
+it("stamps isSelected=false on a plan row whose slug is in the exclusion set", async () => {
+	const cwd = await mkdtempPlansFixture(["plan-keep", "plan-skip"]); // existing helper
+	await setExcluded(cwd, "plans", "plan-skip", true);
+
+	const provider = new PlansTreeProvider(/* construct with cwd */);
+	await provider.refreshExclusions();
+	const items = provider.serialize();
+
+	const skip = items.find((i) => i.id?.endsWith("plan-skip"));
+	const keep = items.find((i) => i.id?.endsWith("plan-keep"));
+	expect(skip?.isSelected).toBe(false);
+	expect(keep?.isSelected).toBe(true);
+});
+
+it("stamps isSelected=true by default when no exclusion file is present", async () => {
+	const provider = new PlansTreeProvider(/* construct */);
+	await provider.refreshExclusions();
+	const items = provider.serialize();
+	for (const it of items) {
+		expect(it.isSelected).toBe(true);
+	}
+});
+```
+
+- [ ] **Step 3: Update `PlansTreeProvider` to load + cache exclusions**
+
+`serialize()` is synchronous; it cannot itself `await readExclusions`. Cache the exclusions on the provider and refresh them whenever the file might have changed. Add to the class:
+
+```ts
+import { readExclusions, type CommitExclusions } from "../../../cli/src/core/CommitSelectionStore.js";
+
+// class fields:
+private exclusions: CommitExclusions = { conversations: new Set(), plans: new Set(), notes: new Set() };
+
+// public refresh entry point:
+async refreshExclusions(): Promise<void> {
+	this.exclusions = await readExclusions(this.cwd);
+	this._onDidChangeTreeData.fire();
+}
+```
+
+If the constructor does not already take a `cwd: string`, add one. Update `vscode/src/Extension.ts` where `new PlansTreeProvider(plansStore)` is called (around line 514) to pass the workspace folder path:
+
+```ts
+const plansProvider = new PlansTreeProvider(plansStore, cwd);
+```
+
+Where `cwd` is the same workspace path the rest of `Extension.ts` already uses (search for nearby usages of `workspaceFolder.uri.fsPath` to confirm).
+
+Also kick off an initial refresh in the constructor (fire-and-forget — the empty default exclusions are safe until the read resolves):
+
+```ts
+constructor(plansStore: PlansStore, private readonly cwd: string) {
+	// …existing init…
+	void this.refreshExclusions();
+}
+```
+
+- [ ] **Step 4: Populate `isSelected` in `serialize()`**
+
+Replace the existing `serialize()` body:
+
+```ts
+serialize(): ReadonlyArray<SerializedTreeItem> {
+	return this.getChildren().map((it) => {
+		let idHint: string;
+		let isSelected = true;
+		if (it instanceof PlanItem) {
+			idHint = it.plan.slug;
+			isSelected = !this.exclusions.plans.has(idHint);
+		} else if (it instanceof NoteItem) {
+			idHint = it.note.id;
+			isSelected = !this.exclusions.notes.has(idHint);
+		} else {
+			idHint = it.issue.mapKey;
+			// Linear-issue rows are not user-selectable; default true (no exclusion key applies).
+		}
+		const ser = treeItemToSerialized(it, idHint);
+		return { ...ser, isSelected };
+	});
+}
+```
+
+---
+
+## Task 5: ActiveSessionsProvider passes isSelected through (VSCode)
+
+**Files:**
+
+- Modify: `vscode/src/services/ActiveSessionsProvider.ts` (likely no production change)
+- Modify: `vscode/src/services/ActiveSessionsProvider.test.ts` (extend)
+
+The CLI aggregator already populates `isSelected` (Task 2). This provider is a thin wrapper — most likely no code change is needed (the field rides through structural sharing). The test below pins the contract.
+
+- [ ] **Step 1: Append a pass-through test to `ActiveSessionsProvider.test.ts`**
+
+```ts
+it("passes isSelected through from the aggregator to the webview payload", async () => {
+	const provider = makeProviderWithFakeAggregator([
+		{
+			sessionId: "abc",
+			source: "claude",
+			title: "t",
+			messageCount: 1,
+			updatedAt: new Date().toISOString(),
+			transcriptPath: "/tmp/x",
+			isSelected: false,
+		},
+	]);
+	const { items } = await provider.listActiveConversationsWithDiagnostics();
+	expect(items[0].isSelected).toBe(false);
+});
+```
+
+If `makeProviderWithFakeAggregator` doesn't exist, build the fake inline following the surrounding test patterns. If the provider's current projection drops fields explicitly, add `isSelected` to that projection in `ActiveSessionsProvider.ts`. Otherwise no production-code change is required.
+
+---
+
+## Task 6: New outbound message types + handler dispatch (VSCode)
+
+**Files:**
+
+- Modify: `vscode/src/views/SidebarMessages.ts` (3 new types)
+- Modify: `vscode/src/views/SidebarWebviewProvider.ts` (deps + handler)
+- Modify: `vscode/src/views/SidebarWebviewProvider.test.ts` (extend)
+
+- [ ] **Step 1: Append failing tests to `SidebarWebviewProvider.test.ts`**
+
+```ts
+it("dispatches branch:toggleConversationSelection to applyConversationCheckbox", async () => {
+	const calls: Array<{ source: string; sessionId: string; selected: boolean }> = [];
+	const provider = makeProvider({
+		applyConversationCheckbox: (source, sessionId, selected) => {
+			calls.push({ source, sessionId, selected });
+		},
+	});
+	await provider.handleOutboundForTest({
+		type: "branch:toggleConversationSelection",
+		source: "claude",
+		sessionId: "abc",
+		selected: false,
+	});
+	expect(calls).toEqual([{ source: "claude", sessionId: "abc", selected: false }]);
+});
+
+it("dispatches branch:togglePlanSelection to applyPlanCheckbox", async () => {
+	const calls: Array<{ planId: string; selected: boolean }> = [];
+	const provider = makeProvider({
+		applyPlanCheckbox: (planId, selected) => calls.push({ planId, selected }),
+	});
+	await provider.handleOutboundForTest({
+		type: "branch:togglePlanSelection",
+		planId: "plan-slug",
+		selected: false,
+	});
+	expect(calls).toEqual([{ planId: "plan-slug", selected: false }]);
+});
+
+it("dispatches branch:toggleNoteSelection to applyNoteCheckbox", async () => {
+	const calls: Array<{ noteId: string; selected: boolean }> = [];
+	const provider = makeProvider({
+		applyNoteCheckbox: (noteId, selected) => calls.push({ noteId, selected }),
+	});
+	await provider.handleOutboundForTest({
+		type: "branch:toggleNoteSelection",
+		noteId: "note-id",
+		selected: false,
+	});
+	expect(calls).toEqual([{ noteId: "note-id", selected: false }]);
+});
+```
+
+(`makeProvider` and `handleOutboundForTest` are existing helpers in this test file — match the shape of the `toggleFileSelection` tests.)
+
+- [ ] **Step 2: Add the new message types in `vscode/src/views/SidebarMessages.ts`**
+
+Inside the `SidebarOutboundMsg` discriminated union, alongside `branch:toggleFileSelection`:
+
+```ts
+| {
+		readonly type: "branch:toggleConversationSelection";
+		readonly source: TranscriptSource;
+		readonly sessionId: string;
+		readonly selected: boolean;
+  }
+| {
+		readonly type: "branch:togglePlanSelection";
+		readonly planId: string;
+		readonly selected: boolean;
+  }
+| {
+		readonly type: "branch:toggleNoteSelection";
+		readonly noteId: string;
+		readonly selected: boolean;
+  }
+```
+
+- [ ] **Step 3: Add the dep callbacks to `vscode/src/views/SidebarWebviewProvider.ts`**
+
+Next to `applyFileCheckbox` / `applyCommitCheckbox` (around line 115):
+
+```ts
+applyConversationCheckbox?: (source: TranscriptSource, sessionId: string, selected: boolean) => void | Promise<void>;
+applyPlanCheckbox?:         (planId: string, selected: boolean) => void | Promise<void>;
+applyNoteCheckbox?:         (noteId: string, selected: boolean) => void | Promise<void>;
+```
+
+In `handleOutbound` (around line 519), add three cases:
+
+```ts
+case "branch:toggleConversationSelection":
+	await this.deps.applyConversationCheckbox?.(msg.source, msg.sessionId, msg.selected);
+	break;
+case "branch:togglePlanSelection":
+	await this.deps.applyPlanCheckbox?.(msg.planId, msg.selected);
+	break;
+case "branch:toggleNoteSelection":
+	await this.deps.applyNoteCheckbox?.(msg.noteId, msg.selected);
+	break;
+```
+
+- [ ] **Step 4: Expose `pushConversations` / `pushPlans` as public refresh methods**
+
+The Extension callbacks in Task 7 need to re-push panels after a successful write. If `pushConversations` / `pushPlans` are currently private, add small public wrappers:
+
+```ts
+public async refreshConversationsPanel(): Promise<void> {
+	await this.pushConversations();
+}
+
+public async refreshPlansPanel(): Promise<void> {
+	await this.pushPlans();
+}
+```
+
+If they're already public, skip this step.
+
+---
+
+## Task 7: Wire toggle callbacks in Extension.ts (VSCode)
+
+**Files:**
+
+- Modify: `vscode/src/Extension.ts`
+
+- [ ] **Step 1: Locate the existing `applyFileCheckbox` / `applyCommitCheckbox` wiring (around line 726)**
+
+```ts
+applyFileCheckbox: (filePath, selected) =>
+	filesStore.applyCheckboxBatch([[filePath, selected]]),
+applyCommitCheckbox: (hash, selected) =>
+	commitsStore.onCheckboxToggle(hash, selected),
+```
+
+- [ ] **Step 2: Add three new wirings underneath**
+
+Add this import block at the top of `Extension.ts`:
+
+```ts
+import {
+	conversationKey,
+	setAllExcluded,
+	setExcluded,
+} from "../../cli/src/core/CommitSelectionStore.js";
+```
+
+(`setAllExcluded` is used in Task 9; declare it now to keep the import single-line.)
+
+Add the three callbacks to the SidebarWebviewProvider deps:
+
+```ts
+applyConversationCheckbox: async (source, sessionId, selected) => {
+	await setExcluded(
+		cwd,
+		"conversations",
+		conversationKey(source, sessionId),
+		!selected,
+	);
+	// Re-push the conversations panel so the checkbox state in the UI
+	// reflects the new on-disk truth.
+	await sidebarProvider.refreshConversationsPanel();
+},
+applyPlanCheckbox: async (planId, selected) => {
+	await setExcluded(cwd, "plans", planId, !selected);
+	await plansProvider.refreshExclusions();
+},
+applyNoteCheckbox: async (noteId, selected) => {
+	await setExcluded(cwd, "notes", noteId, !selected);
+	await plansProvider.refreshExclusions();
+},
+```
+
+`cwd` should already be in scope at this construction point — verify by searching for the existing `applyFileCheckbox` line and reusing whatever local holds the workspace path there.
+
+---
+
+## Task 8: Sidebar render — per-row checkboxes (VSCode)
+
+**Files:**
+
+- Modify: `vscode/src/views/SidebarScriptBuilder.ts` (per-row render + click handlers)
+- Modify: `vscode/src/views/SidebarScriptBuilder.test.ts` (extend)
+
+- [ ] **Step 1: Locate the conversation, plan, and note row render blocks**
+
+```bash
+grep -n "branch:openConversation\|branch:openPlan\|branch:openNote" vscode/src/views/SidebarScriptBuilder.ts
+```
+
+Use those line numbers as the anchor.
+
+- [ ] **Step 2: Append failing tests to `SidebarScriptBuilder.test.ts`**
+
+```ts
+it("renders a checked conversation checkbox when isSelected=true", () => {
+	const html = buildConversationRow({ /* …minimal fixture, isSelected: true… */ });
+	expect(html).toContain('class="jm-row-check jm-conv-check"');
+	expect(html).toContain(" checked ");
+});
+
+it("renders an unchecked conversation checkbox when isSelected=false", () => {
+	const html = buildConversationRow({ /* …isSelected: false… */ });
+	expect(html).toContain('class="jm-row-check jm-conv-check"');
+	expect(html).not.toContain(" checked ");
+});
+
+it("renders a plan-row checkbox driven by isSelected", () => {
+	const html = buildPlanRow({ /* …isSelected: false… */ });
+	expect(html).toContain('class="jm-row-check jm-plan-check"');
+	expect(html).not.toContain(" checked ");
+});
+
+it("renders a note-row checkbox driven by isSelected", () => {
+	const html = buildNoteRow({ /* …isSelected: false… */ });
+	expect(html).toContain('class="jm-row-check jm-note-check"');
+	expect(html).not.toContain(" checked ");
+});
+```
+
+If `buildConversationRow` / `buildPlanRow` / `buildNoteRow` are not directly exported, exercise the wider render function — whatever shape the existing checkbox tests already use.
+
+- [ ] **Step 3: Add a leading checkbox to the conversation row template**
+
+Mirror the existing file/commit checkbox: CSS class + `addEventListener` (NO inline `style=""` / `onclick=""` per CSP). Use the existing `escAttr` (or whatever name the file gives its attribute escaper).
+
+Inside the conversation row rendering function, BEFORE the title `<span>`:
+
+```js
+'<input type="checkbox" class="jm-row-check jm-conv-check" '
+  + 'data-source="' + escAttr(it.source) + '" '
+  + 'data-session="' + escAttr(it.sessionId) + '" '
+  + (it.isSelected ? 'checked ' : '')
+  + '/>'
+```
+
+For plan rows:
+
+```js
+'<input type="checkbox" class="jm-row-check jm-plan-check" '
+  + 'data-plan-id="' + escAttr(it.id) + '" '
+  + (it.isSelected ? 'checked ' : '')
+  + '/>'
+```
+
+For note rows:
+
+```js
+'<input type="checkbox" class="jm-row-check jm-note-check" '
+  + 'data-note-id="' + escAttr(it.id) + '" '
+  + (it.isSelected ? 'checked ' : '')
+  + '/>'
+```
+
+- [ ] **Step 4: Add the click handler at the delegated-event entry point**
+
+Find the existing change-listener for `.jm-file-check` / `.jm-commit-check` (search for `branch:toggleFileSelection` in the file). Insert three new branches near it. Each branch must call `e.stopPropagation()` so the row's `click` handler doesn't fire after the checkbox toggle (otherwise the detail panel would open every time the user toggles a row).
+
+```js
+const convCheck = e.target.closest('.jm-conv-check');
+if (convCheck) {
+	vscode.postMessage({
+		type: 'branch:toggleConversationSelection',
+		source: convCheck.getAttribute('data-source'),
+		sessionId: convCheck.getAttribute('data-session'),
+		selected: convCheck.checked,
+	});
+	e.stopPropagation();
+	return;
+}
+const planCheck = e.target.closest('.jm-plan-check');
+if (planCheck) {
+	vscode.postMessage({
+		type: 'branch:togglePlanSelection',
+		planId: planCheck.getAttribute('data-plan-id'),
+		selected: planCheck.checked,
+	});
+	e.stopPropagation();
+	return;
+}
+const noteCheck = e.target.closest('.jm-note-check');
+if (noteCheck) {
+	vscode.postMessage({
+		type: 'branch:toggleNoteSelection',
+		noteId: noteCheck.getAttribute('data-note-id'),
+		selected: noteCheck.checked,
+	});
+	e.stopPropagation();
+	return;
+}
+```
+
+- [ ] **Step 5: Add a CSS rule for `.jm-row-check`**
+
+Find the section's CSS string (search for `.jm-file-check` styles). Append:
+
+```css
+.jm-row-check { margin-right: 6px; vertical-align: middle; }
+```
+
+If a shared class already covers this layout, reuse it.
+
+---
+
+## Task 9: Select / Deselect All commands + header buttons (VSCode)
+
+**Files:**
+
+- Create: `vscode/src/commands/SelectAllSelection.ts`
+- Create: `vscode/src/commands/SelectAllSelection.test.ts`
+- Modify: `vscode/src/Extension.ts` (register two commands)
+- Modify: `vscode/src/views/SidebarScriptBuilder.ts` (two new icon buttons + cmdMap entries)
+- Modify: `vscode/src/views/SidebarScriptBuilder.test.ts` (extend if section actions are testable)
+
+- [ ] **Step 1: Write failing tests in `vscode/src/commands/SelectAllSelection.test.ts`**
+
+```ts
+import { describe, expect, it } from "vitest";
+import {
+	conversationKey,
+	readExclusions,
+	setAllExcluded,
+	setExcluded,
+} from "../../../cli/src/core/CommitSelectionStore.js";
+import {
+	selectAllConversationsCommand,
+	selectAllPlansAndNotesCommand,
+} from "./SelectAllSelection.js";
+
+describe("selectAllConversationsCommand", () => {
+	it("excludes everything when nothing is currently excluded", async () => {
+		const ctx = await makeCtxWithVisibleConversations([
+			{ source: "claude", sessionId: "a" },
+			{ source: "codex",  sessionId: "b" },
+		]);
+		await selectAllConversationsCommand(ctx);
+		const ex = await readExclusions(ctx.cwd);
+		expect(ex.conversations.has(conversationKey("claude", "a"))).toBe(true);
+		expect(ex.conversations.has(conversationKey("codex",  "b"))).toBe(true);
+	});
+
+	it("clears the visible set when everything is currently excluded", async () => {
+		const ctx = await makeCtxWithVisibleConversations([
+			{ source: "claude", sessionId: "a" },
+			{ source: "codex",  sessionId: "b" },
+		]);
+		await setAllExcluded(ctx.cwd, "conversations", [
+			conversationKey("claude", "a"),
+			conversationKey("codex",  "b"),
+		], true);
+		await selectAllConversationsCommand(ctx);
+		const ex = await readExclusions(ctx.cwd);
+		expect(ex.conversations.size).toBe(0);
+	});
+
+	it("with mixed state, switches to all-excluded", async () => {
+		const ctx = await makeCtxWithVisibleConversations([
+			{ source: "claude", sessionId: "a" },
+			{ source: "codex",  sessionId: "b" },
+		]);
+		await setExcluded(ctx.cwd, "conversations", conversationKey("claude", "a"), true);
+		await selectAllConversationsCommand(ctx);
+		const ex = await readExclusions(ctx.cwd);
+		expect(ex.conversations.size).toBe(2);
+	});
+});
+
+describe("selectAllPlansAndNotesCommand", () => {
+	it("flips plans AND notes together based on the combined visible state", async () => {
+		const ctx = await makeCtxWithVisiblePlansAndNotes(
+			["plan-1", "plan-2"],
+			["note-1"],
+		);
+		await selectAllPlansAndNotesCommand(ctx);
+		const ex = await readExclusions(ctx.cwd);
+		expect([...ex.plans].sort()).toEqual(["plan-1", "plan-2"]);
+		expect([...ex.notes]).toEqual(["note-1"]);
+	});
+});
+```
+
+`makeCtxWithVisibleConversations` / `makeCtxWithVisiblePlansAndNotes` are local fixture builders the test file itself defines — they construct a `SelectAllCtx` (see implementation below) with a stub `activeSessions` / `plansProvider` and a temporary `cwd`.
+
+- [ ] **Step 2: Implement `vscode/src/commands/SelectAllSelection.ts`**
+
+```ts
+import {
+	conversationKey,
+	readExclusions,
+	setAllExcluded,
+} from "../../../cli/src/core/CommitSelectionStore.js";
+import type { ActiveSessionsProvider } from "../services/ActiveSessionsProvider.js";
+import type { PlansTreeProvider } from "../providers/PlansTreeProvider.js";
+
+export interface SelectAllCtx {
+	readonly cwd: string;
+	readonly activeSessions: Pick<ActiveSessionsProvider, "listActiveConversationsWithDiagnostics">;
+	readonly plansProvider: Pick<PlansTreeProvider, "serialize" | "refreshExclusions">;
+	readonly onChanged: () => Promise<void> | void;
+}
+
+export async function selectAllConversationsCommand(ctx: SelectAllCtx): Promise<void> {
+	const { items } = await ctx.activeSessions.listActiveConversationsWithDiagnostics();
+	const keys = items.map((it) => conversationKey(it.source, it.sessionId));
+	const allCurrentlyExcluded = items.length > 0 && items.every((it) => it.isSelected === false);
+	await setAllExcluded(ctx.cwd, "conversations", keys, !allCurrentlyExcluded);
+	await ctx.onChanged();
+}
+
+export async function selectAllPlansAndNotesCommand(ctx: SelectAllCtx): Promise<void> {
+	const rows = ctx.plansProvider.serialize();
+	// Split rows by kind. Adapt the predicate to whatever id-naming convention
+	// `treeItemToSerialized` uses — if ids carry no prefix, expose a `kind`
+	// discriminator on SerializedTreeItem and switch on that instead.
+	const planRows = rows.filter((r) => typeof r.id === "string" && r.id.startsWith("plan:"));
+	const noteRows = rows.filter((r) => typeof r.id === "string" && r.id.startsWith("note:"));
+	const planKeys = planRows.map((r) => stripPrefix(r.id!, "plan:"));
+	const noteKeys = noteRows.map((r) => stripPrefix(r.id!, "note:"));
+
+	const visibleSelectable = [...planRows, ...noteRows];
+	const allCurrentlyExcluded =
+		visibleSelectable.length > 0 && visibleSelectable.every((r) => r.isSelected === false);
+
+	const target = !allCurrentlyExcluded;
+	await setAllExcluded(ctx.cwd, "plans", planKeys, target);
+	await setAllExcluded(ctx.cwd, "notes", noteKeys, target);
+	await ctx.plansProvider.refreshExclusions();
+	await ctx.onChanged();
+}
+
+function stripPrefix(id: string, prefix: string): string {
+	return id.startsWith(prefix) ? id.slice(prefix.length) : id;
+}
+```
+
+When implementing, verify the actual id prefix used by `treeItemToSerialized` in `PlansTreeProvider.ts` and adjust the `startsWith` predicates. If ids carry no prefix, add a `kind: "plan" | "note" | "linear"` discriminator to `SerializedTreeItem` in `SidebarMessages.ts` and switch on that — cleaner than string sniffing.
+
+- [ ] **Step 3: Register the commands in `Extension.ts`**
+
+Near `jollimemory.selectAllFiles`:
+
+```ts
+vscode.commands.registerCommand("jollimemory.selectAllConversations", () =>
+	selectAllConversationsCommand({
+		cwd,
+		activeSessions: activeSessionsProvider,
+		plansProvider,
+		onChanged: () => sidebarProvider.refreshConversationsPanel(),
+	}),
+);
+vscode.commands.registerCommand("jollimemory.selectAllPlansAndNotes", () =>
+	selectAllPlansAndNotesCommand({
+		cwd,
+		activeSessions: activeSessionsProvider,
+		plansProvider,
+		onChanged: () => sidebarProvider.refreshPlansPanel(),
+	}),
+);
+```
+
+Add the two new ids to the registered-commands constant at the top of `Extension.ts` (search for `"jollimemory.selectAllFiles"` and append the new ids in the same array).
+
+- [ ] **Step 4: Add icon buttons in `SidebarScriptBuilder.ts`**
+
+Find the conversations section's actions block (search for the section id — `'conversations'` or similar):
+
+```js
+items.push(iconButton('conversations-select-all', 'Select/Deselect All Conversations', 'check-all'));
+```
+
+For the plans-and-notes section (search `plans-add-menu`):
+
+```js
+items.push(iconButton('plans-select-all', 'Select/Deselect All Plans & Notes', 'check-all'));
+```
+
+Order in each header: alongside the existing add-menu / refresh icons; pick a position consistent with how Changes has `Select All` first.
+
+- [ ] **Step 5: Extend `cmdMap`**
+
+```js
+const cmdMap = {
+	'changes-select-all':         'jollimemory.selectAllFiles',
+	'changes-commit-ai':          'jollimemory.commitAI',
+	'changes-discard':            'jollimemory.discardSelectedChanges',
+	'commits-select-all':         'jollimemory.selectAllCommits',
+	'commits-squash':             'jollimemory.squash',
+	'commits-push-branch':        'jollimemory.pushBranch',
+	'conversations-select-all':   'jollimemory.selectAllConversations',
+	'plans-select-all':           'jollimemory.selectAllPlansAndNotes',
+};
+```
+
+---
+
+## Task 10: Flip FilesStore default to all-selected (VSCode)
+
+**Files:**
+
+- Modify: `vscode/src/stores/FilesStore.ts` (refresh seed step)
+- Modify: `vscode/src/stores/FilesStore.test.ts` (extend)
+
+- [ ] **Step 1: Append failing tests to `FilesStore.test.ts`**
+
+```ts
+it("seeds selectedPaths with every raw file on first refresh", async () => {
+	const bridge = makeBridgeStub([
+		{ relativePath: "a.ts", isSelected: false /* …other fields…*/ },
+		{ relativePath: "b.ts", isSelected: false },
+		{ relativePath: "c.ts", isSelected: false },
+	]);
+	const store = new FilesStore(bridge, /* …other deps… */);
+	await store.refresh();
+	expect(store.getSnapshot().visibleFiles.map((f) => f.relativePath).sort()).toEqual(["a.ts", "b.ts", "c.ts"]);
+	for (const f of store.getSnapshot().visibleFiles) {
+		expect(f.isSelected).toBe(true);
+	}
+});
+
+it("preserves an explicit user uncheck across a same-raw refresh", async () => {
+	const bridge = makeBridgeStub([
+		{ relativePath: "a.ts", isSelected: false },
+		{ relativePath: "b.ts", isSelected: false },
+	]);
+	const store = new FilesStore(bridge, /* … */);
+	await store.refresh();
+	store.applyCheckboxBatch([["a.ts", false]]);
+	await store.refresh();
+	const visible = store.getSnapshot().visibleFiles;
+	expect(visible.find((f) => f.relativePath === "a.ts")?.isSelected).toBe(false);
+	expect(visible.find((f) => f.relativePath === "b.ts")?.isSelected).toBe(true);
+});
+```
+
+Use the existing `makeBridgeStub` helper / `FileStatus` shape from the surrounding tests.
+
+- [ ] **Step 2: Modify `FilesStore.refresh()` (lines 142–157 today)**
+
+The store needs a negative-memory set so an explicit user uncheck survives a refresh against the same `raw`. Replace the seeding loop:
+
+```ts
+// Seed selection from every freshly-seen file. Default-select matches the
+// behavior of conversations / plans / notes: the user opts out per-row.
+// Stale unchecks survive refresh via `unselectedPaths`; we never re-add a
+// path the user has explicitly removed from `selectedPaths`.
+for (const f of raw) {
+	if (!this.unselectedPaths?.has(f.relativePath)) {
+		this.selectedPaths.add(f.relativePath);
+	}
+}
+```
+
+Update `applyCheckboxBatch` so it populates the new set:
+
+```ts
+applyCheckboxBatch(items: ReadonlyArray<readonly [path: string, checked: boolean]>): void {
+	if (items.length === 0) return;
+	for (const [path, checked] of items) {
+		if (checked) {
+			this.selectedPaths.add(path);
+			this.unselectedPaths?.delete(path);
+		} else {
+			this.selectedPaths.delete(path);
+			this.unselectedPaths ??= new Set<string>();
+			this.unselectedPaths.add(path);
+		}
+	}
+	this.rebuildSnapshot({ reorder: false, reason: "userCheckbox" });
+}
+```
+
+Declare the field:
+
+```ts
+private unselectedPaths?: Set<string>;
+```
+
+Make sure the existing prune-stale-selections step also prunes `unselectedPaths`:
+
+```ts
+const currentPaths = new Set(raw.map((f) => f.relativePath));
+for (const p of [...this.selectedPaths]) {
+	if (!currentPaths.has(p)) this.selectedPaths.delete(p);
+}
+if (this.unselectedPaths) {
+	for (const p of [...this.unselectedPaths]) {
+		if (!currentPaths.has(p)) this.unselectedPaths.delete(p);
+	}
+}
+```
+
+If a simpler implementation can preserve the user-uncheck-across-refresh invariant without `unselectedPaths`, use that — but verify both new tests still pass.
+
+---
+
+## Task 11: Final integration — run, smoke test, single commit
+
+**Files:** all touched by Tasks 1–10, plus `cli/CHANGELOG.md`, `vscode/CHANGELOG.md`
+
+- [ ] **Step 1: Update CHANGELOG entries**
+
+Append a single bullet to the "Unreleased" section of both `cli/CHANGELOG.md` and `vscode/CHANGELOG.md`:
+
+```
+- Add per-row checkboxes and a Select/Deselect All button on Conversations and Plans & Notes; uncheck excludes the item from future summaries, sticky until re-checked. Default-select the Changes panel files (file behavior is the only change visible without unchecking).
+```
+
+- [ ] **Step 2: Run the project-wide gate**
+
+```bash
+npm run all
+```
+
+Expected: clean → build → lint → test all pass for both workspaces. CLI coverage must stay ≥97 % statements / 96 % branches / 97 % functions / 97 % lines (CLAUDE.md hard rule).
+
+If a coverage gap is reported, add focused tests to close it (do NOT lower the threshold). The most likely thin spots:
+
+- `CommitSelectionStore` ENOENT / parse-error branches (cover with intentionally-corrupt fixture).
+- `QueueWorker.executePipeline` filter branches when one kind has 0 items (cover with empty plans / notes fixture).
+
+If a test fails, fix the underlying code or test until `npm run all` is green. Do not proceed to Step 3 with a red build.
+
+- [ ] **Step 3: Manual smoke test in VS Code dev host**
+
+```bash
+cd vscode && npm run deploy
+```
+
+Then **Developer: Reload Window** in the VS Code instance that just got the VSIX installed. Smoke checklist:
+
+1. Open a project with an active Claude / Codex / Cursor / Copilot conversation.
+2. Sidebar shows conversation rows with a leading checkbox, all checked.
+3. Uncheck one conversation → checkbox stays unchecked.
+4. Reload window → checkbox is still unchecked (sticky).
+5. Make a trivial commit → wait for the post-commit hook to finish (5–30s).
+6. Open the resulting memory file (orphan branch) → confirm the unchecked conversation's content is NOT mentioned in the summary.
+7. The checkbox stays unchecked after the commit (sticky).
+8. Repeat for a plan and a note in the Plans & Notes section.
+9. Click the conversations header "Select/Deselect All" → all conversations flip.
+10. Verify the Changes panel now defaults every file to checked.
+11. Verify the Commits panel defaults remain unchecked (squash candidates).
+
+Fix any regression surfaced by the smoke test; re-run `npm run all` after the fix.
+
+- [ ] **Step 4: Single DCO-signed commit covering everything**
+
+```bash
+git add cli/src/core/CommitSelectionStore.ts cli/src/core/CommitSelectionStore.test.ts \
+        cli/src/core/ActiveSessionAggregator.ts cli/src/core/ActiveSessionAggregator.test.ts \
+        cli/src/hooks/QueueWorker.ts cli/src/hooks/QueueWorker.selection.test.ts \
+        vscode/src/views/SidebarMessages.ts \
+        vscode/src/views/SidebarWebviewProvider.ts vscode/src/views/SidebarWebviewProvider.test.ts \
+        vscode/src/views/SidebarScriptBuilder.ts vscode/src/views/SidebarScriptBuilder.test.ts \
+        vscode/src/providers/PlansTreeProvider.ts vscode/src/providers/PlansTreeProvider.test.ts \
+        vscode/src/services/ActiveSessionsProvider.ts vscode/src/services/ActiveSessionsProvider.test.ts \
+        vscode/src/stores/FilesStore.ts vscode/src/stores/FilesStore.test.ts \
+        vscode/src/commands/SelectAllSelection.ts vscode/src/commands/SelectAllSelection.test.ts \
+        vscode/src/Extension.ts \
+        cli/CHANGELOG.md vscode/CHANGELOG.md
+
+git commit -s -m "$(cat <<'EOF'
+Add per-item commit-time selection across the sidebar
+
+Conversations, plans, notes, and the Changes-panel file list each get a
+per-row checkbox plus a Select/Deselect All header button. Unchecking
+writes a sticky entry to .jolli/jollimemory/commit-selection.json that
+the summary pipeline filters on; the file is never auto-cleared by any
+git operation. The Commits-squash panel default is intentionally
+unchanged because squash is destructive.
+EOF
+)"
+```
+
+If the `git add` command lists a file that was not actually modified (e.g. ActiveSessionsProvider.ts when Task 5 turned out to need no production change), drop that path from the `add` line. `git status` before the commit confirms the real working set.
+
+---
+
+## Self-review checklist (done while writing)
+
+- **Spec coverage:** each spec section has a task — Storage (Task 1), Pipeline integration (Task 3), ActiveConversationItem (Task 2), Plans/Notes isSelected (Task 4), ActiveSessionsProvider (Task 5), wire protocol (Task 6), per-row toggle persistence (Task 7), per-row render (Task 8), Select-All buttons + commands (Task 9), File panel default (Task 10), end-to-end + commit (Task 11).
+- **Placeholder scan:** no "TBD" / "implement later" / "similar to Task N" stubs. Every code change shows a code block. The few "adapt to actual naming" hints are explicit, bounded resolution instructions for the executor, not stubs.
+- **Type consistency:** `CommitExclusions`, `ExclusionKind`, `conversationKey`, `setExcluded`, `setAllExcluded`, `readExclusions` names are stable across Tasks 1, 2, 3, 4, 6, 7, 9. `op.type` matches the existing `GitOperation.type` discriminator (verified against [QueueWorker.ts:327](../../cli/src/hooks/QueueWorker.ts)).
+- **Execution-model note honored:** Tasks 1–10 contain no "run tests" / "lint" / "commit" steps. All such steps live in Task 11 as the single final integration.
+- **YAGNI:** no `clear()` method on the store; no per-row provider observer wiring (provider re-push is enough); no commits-panel default change (deliberately out of scope per spec); no IntelliJ port.
+- **TDD shape:** each task still lands tests before implementation — only the test/lint/commit *runs* are deferred to Task 11.
+- **Single commit at the end:** all 21 touched paths land in one DCO-signed commit. Smoke-test fallout fixes are folded into the same commit before it lands.

--- a/docs/superpowers/specs/2026-05-19-commit-item-selection-design.md
+++ b/docs/superpowers/specs/2026-05-19-commit-item-selection-design.md
@@ -1,0 +1,305 @@
+# Commit-time item selection (conversations, plans, notes, files)
+
+Date: 2026-05-19
+Status: Draft — pending implementation plan
+
+## Summary
+
+Today every active conversation, plan, note, and changed file is automatically rolled into the next commit's summary (or, for files, into the next commit itself). The user has no way to say "skip this one" without permanently hiding or ignoring the item.
+
+This spec introduces a per-item selection layer for the four kinds of items shown in the sidebar — **conversations**, **plans**, **notes**, and **changed files** — using a uniform "default selected, user can uncheck to exclude" model. Excluded items stay in the workspace exactly where they were; they're simply not fed to the next summary pipeline / commit.
+
+Exclusion is **sticky**: an unchecked item stays excluded across commits, amends, rebases, and editor restarts until the user explicitly re-checks it. This makes the new checkbox semantically distinct from the existing permanent **hide / ignore** mechanisms — those make the row disappear; *this* keeps the row visible (so the user knows it exists and can re-include it later) but holds it out of the next summary.
+
+## Goals
+
+- Per-row checkboxes on conversations, plans, and notes rows in the sidebar.
+- A "Select / Deselect All" icon button in each section's sticky title bar, **with the same shape and behavior as the existing Changes / Commits Select-All button** (single codicon `check-all` icon, toggles between "all selected" and "all deselected"; no tri-state UI).
+- Default = selected, for all four kinds (conversations, plans, notes, files). A freshly seen item is selected; the user has to explicitly uncheck it.
+- An item's exclusion state is **sticky**: it stays excluded across commits, amends, rebases, editor restarts, and project re-opens, until the user explicitly re-checks it. The new mechanism is therefore distinct from — and orthogonal to — the existing permanent **hide / ignore** flags.
+- Excluded conversations / plans / notes stay visible in the sidebar with an unchecked box (so the user knows the item exists and can put it back in).
+
+## Non-goals
+
+- Replacing or merging the existing **permanent** hide/ignore mechanisms (`HiddenConversationsStore`, `PlanEntry.ignored`, `NoteEntry.ignored`). Those keep their current behavior; selection is orthogonal.
+- Adding a per-row "ignore from now on" toggle. Permanent ignore stays where it is today (delete-all-entries for conversations; right-click menu for plans/notes).
+- Cross-branch / cross-worktree selection memory. Selection is per project dir (worktree-aware via the existing `.jolli/jollimemory/` resolver) and per commit cycle.
+- Selecting individual *entries within* a conversation transcript. Selection is at the conversation level only.
+- Changing the **Commits panel** default selection. That panel drives squash (history-rewrite), not summary-input selection; its existing "default unselected" stays. See "Commits panel default — intentionally unchanged".
+
+## Current state (verified)
+
+- **Conversations sidebar** ([SidebarWebviewProvider.ts](../../../vscode/src/views/SidebarWebviewProvider.ts), [ActiveSessionsProvider.ts](../../../vscode/src/services/ActiveSessionsProvider.ts), [ActiveSessionAggregator.ts](../../../cli/src/core/ActiveSessionAggregator.ts)): renders all sessions ≤48h, minus those in `HiddenConversationsStore`. No selection model.
+- **Plans & Notes** (`SidebarMessages.ts:branch:plansData`, `PlansProvider.serialize()`): renders all non-`ignored` entries via `SerializedTreeItem`. The type already has an optional `isSelected` field, but it's only populated for changes / commits rows today.
+- **Changes panel** ([FilesStore.ts](../../../vscode/src/stores/FilesStore.ts) lines 70–153): uses GitHub-Desktop-style in-memory `selectedPaths: Set<string>`; **default is unselected** today — `FilesStore.refresh()` lines 143–153 only seed into `selectedPaths` when the bridge returns `isSelected:true`, and the bridge always returns `false` in production. A `toggleSelectAll()` button already exists.
+- **Commits panel** ([CommitsStore.ts](../../../vscode/src/stores/CommitsStore.ts) lines 142–190): separate `checkedHashes: Set<string>` with **range semantics** — checking commit N also checks 0..N; unchecking N also unchecks N..end (because squash operates on a contiguous range from HEAD). Default is unselected; the panel is used to drive `Squash Selected` (disabled below 2 commits) and `Push Branch`. **This spec intentionally does not change the Commits-panel default** — see "File panel default" below for the rationale.
+- **Commit pipeline** ([QueueWorker.ts](../../../cli/src/hooks/QueueWorker.ts) `runSummaryPipeline`): loads transcripts via `loadSessionTranscripts(cwd)`, plans/notes via `detectActivePlansForBranch` / `detectActiveNotesForBranch`, then calls `generateSummary()`. No filtering hook exists between "load all" and "pass to LLM".
+- **Existing wire messages**: `branch:toggleFileSelection`, `branch:toggleCommitSelection`. Both already round-trip through `SidebarWebviewProvider.handleOutbound()` → `applyFileCheckbox` / `applyCommitCheckbox` callbacks → store. No equivalents for conversations / plans / notes.
+
+## Semantics
+
+### Default
+
+Every visible item is selected by default. "Visible" means: passes the existing filters (recency window, hidden / ignored, exclude patterns). Permanently hidden / ignored items are not shown and therefore not selectable — they're already out.
+
+A "new" item — one not previously seen by the selection store — is treated as selected. The store records exclusions, not selections, so absence of a record means included.
+
+### Excluding (unchecking)
+
+Unchecking an item:
+
+- For conversations / plans / notes: writes the item key into `commit-selection.json`. From that moment on, every pipeline run skips the item, until the user explicitly re-checks (which removes the key) or the item permanently disappears via hide / ignore (which makes the entry a harmless no-op).
+- For files: removes the path from `FilesStore.selectedPaths`. Sticky within the current sidebar session; on next refresh after a commit lands or on editor restart, the path is reseeded as selected (see "File panel default" below).
+
+### Lifecycle of an exclusion
+
+1. User unchecks item X at T₀ → key written into `commit-selection.json`.
+2. User runs any git operation that triggers `runSummaryPipeline` (`commit`, `amend`, …) at T₁ → pipeline reads the exclusion set, filters X out, generates / regenerates the summary. **File is not cleared.**
+3. Sidebar re-renders → X still rendered, still unchecked.
+4. User makes another commit at T₂ → X again filtered out.
+5. User re-checks X at T₃ → key removed from `commit-selection.json`.
+6. User's next commit at T₄ → X is included in the summary.
+
+The same flow applies to plans and notes. There is no automatic reset point: amend, rebase, squash, editor restart, branch switch — none of these touch `commit-selection.json`.
+
+If X is permanently hidden / ignored between T₁ and T₃, X stops being rendered (so the user cannot uncheck or re-check it) but its key may linger in `commit-selection.json`. That residual entry is harmless: it cannot match anything in the candidate set, so it's a no-op filter. No proactive GC.
+
+### When does the exclusion set get cleared?
+
+**Only by explicit user action**, never automatically. The user clears an exclusion by:
+
+- Re-checking the row's checkbox (removes that single key).
+- Clicking the section's "Select / Deselect All" button when not already all-selected (the toggle flips everything to selected, removing every visible key from the store in one atomic write).
+- Manually deleting / editing `<projectDir>/.jolli/jollimemory/commit-selection.json` (advanced; not exposed in UI).
+
+No git operation, no pipeline outcome, no `op.type` distinction, and no editor lifecycle event modifies the file.
+
+(Files are not in `commit-selection.json` — their selection is in-memory in `FilesStore`. See "Storage" below.)
+
+## UX
+
+### Per-row checkbox
+
+Conversation rows and plan/note rows render a leading checkbox, sized and aligned to match the existing file/commit checkbox in the Changes / Commits panels. Default state is checked.
+
+Toggling fires a new outbound message (see "Wire protocol" below). The extension persists the toggle and re-pushes the updated panel data; the row's checkbox reflects the post-persist state, so a failed write surfaces as the checkbox snapping back.
+
+### Per-section Select / Deselect All button
+
+Each new section's sticky title bar gets an icon button matching the existing Changes / Commits pattern at [SidebarScriptBuilder.ts:2378](../../../vscode/src/views/SidebarScriptBuilder.ts) / [:2401](../../../vscode/src/views/SidebarScriptBuilder.ts):
+
+- **Conversations** header: `iconButton('conversations-select-all', 'Select/Deselect All Conversations', 'check-all')`
+- **Plans & Notes** header: `iconButton('plans-select-all', 'Select/Deselect All Plans & Notes', 'check-all')`
+
+(The Changes panel already has this button; no UI change there — the only file-panel change is the default state, below.)
+
+Click behavior — same as `FilesStore.toggleSelectAll()`:
+
+- If **every visible item is selected** → deselect all visible.
+- Otherwise (none selected, or mixed) → select all visible.
+
+There is no tri-state visual; the icon is a single static codicon. State is computed from the rows on each click.
+
+Scope of "all visible" = items currently in the panel's rendered list, i.e. after recency / hidden / ignore / exclude filters. Items off-screen (e.g. hidden conversations, archived plans) are unaffected.
+
+Plans & Notes share one button — it covers both plans rows and notes rows in that panel — matching how the section combines both kinds today.
+
+### File panel default
+
+`FilesStore.refresh()`'s post-prune seeding step adds **every** path in `raw` to `selectedPaths`, not just the bridge's `isSelected:true` rows. Net effect: a freshly populated panel arrives with every file checked. The existing prune-stale-selections step still removes paths no longer in `raw`; the existing exclude-pattern prune in `applyExcludeFilterChange()` still kicks excluded paths out. User unchecks still work and persist for as long as the file remains in `raw` (i.e., until the next commit clears the working-tree change, or until the user re-stages externally).
+
+This brings file behavior into line with conversations / plans / notes: **default fully included, opt out per commit**.
+
+### Commits panel default — intentionally unchanged
+
+The Commits-panel default stays **unselected**, despite the surface similarity to the Files panel. The Commits panel drives `Squash Selected` (and `Push Branch` for the multi-commit case), which is a destructive history-rewriting operation gated by 2-or-more contiguous commits. Auto-pre-selecting every commit on the branch would default the UI to "squash the whole branch every time" — far higher blast radius than "include this conversation in the summary".
+
+Squash is also semantically different from the four kinds this spec actually targets:
+
+- Files, conversations, plans, notes are **inputs** that the user can include or omit from a generated artifact (a commit, a summary). The default "include everything, opt out specific items" matches the user's likely intent.
+- Commits in the Commits panel are **history-rewrite targets**: they describe an operation the user must consciously opt into. The default "select nothing, opt in specific items" matches the much-higher-stakes nature of the action.
+
+If the user later wants Commits to also default-select, that's a separate, much-larger UX decision — out of scope for this spec.
+
+## Storage
+
+### Conversations / plans / notes — on disk
+
+New module: `cli/src/core/CommitSelectionStore.ts`.
+
+File: `<projectDir>/.jolli/jollimemory/commit-selection.json` (resolved via the existing `getJolliMemoryDir(cwd)` so worktrees each get their own).
+
+Shape:
+
+```jsonc
+{
+  "excludedConversations": [
+    { "source": "claude" | "codex" | "gemini" | "cursor" | "opencode" | "copilot-cli" | "copilot-chat", "sessionId": "..." }
+  ],
+  "excludedPlans":  ["plan-uuid-1", "plan-uuid-2"],
+  "excludedNotes":  ["note-uuid-1"]
+}
+```
+
+API:
+
+- `readExclusions(cwd): CommitExclusions` — returns empty sets on missing / malformed file.
+- `setExcluded(cwd, kind, key, excluded: boolean): void` — atomic tmp+rename write; idempotent. `excluded=false` removes the key.
+- `setAllExcluded(cwd, kind, keys, excluded: boolean): void` — single-write bulk variant for the Select / Deselect All command. Bulk-add or bulk-remove every key in `keys`.
+
+There is no `clear()` method. Removing every exclusion happens via `setAllExcluded(…, false)` driven by the user's Select-All action. Keeping the file shape stable (even when empty) makes diffs / debugging easier than alternating between "file present" and "file absent".
+
+Write atomicity: tmp file + rename, same as `HiddenConversationsStore` ([HiddenConversationsStore.ts](../../../cli/src/core/HiddenConversationsStore.ts)). Concurrent QueueWorker reads and sidebar toggles are safe: the worker reads once at the start of `runSummaryPipeline`; a toggle landing after that read just takes effect on the next pipeline run.
+
+Stale-key tolerance: filters intersect the exclusion set with the candidate set. An exclusion entry for a session that has aged out of the 48h window, or a plan that's been archived, is a no-op at filter time. No proactive GC — keys naturally accumulate but each one is a small string, and the user can always trigger Select-All to wipe the visible portion. If the file grows unwieldy (multiple kilobytes), that's a signal the user has been excluding aggressively and may want to convert the long-term exclusions to permanent hide / ignore — out of scope for this spec but worth noting in a follow-up.
+
+### Files — in-memory only
+
+Files reuse `FilesStore.selectedPaths` unchanged. They are **not** added to `commit-selection.json` because:
+
+- File selection already gates a separate, durable channel — the git index — via `bridge.stageFiles(selectedPaths)`. Once a file is staged + committed, the working-tree state is already mutated; there's no "did this exclusion get consumed" question to answer post-hoc.
+- Persisting file unchecks across editor restarts is out of scope — the file may even have disappeared from `git status` by then, and translating between "this exact file in this exact state" and "the user's intent about that file" is its own design problem.
+
+The only file-side code change is in `FilesStore.refresh()`: seed `selectedPaths` with every entry of `raw`. File exclusion is sticky **only within the current sidebar session**; that's a deliberate scope limit, consistent with how today's selected-file set already behaves (just inverted default).
+
+## Wire protocol
+
+### Webview → Extension — per-row toggles
+
+Three new variants on `SidebarOutboundMsg`:
+
+```ts
+{ type: "branch:toggleConversationSelection";
+  source: ConversationSource;
+  sessionId: string;
+  selected: boolean }
+
+{ type: "branch:togglePlanSelection";
+  planId: string;
+  selected: boolean }
+
+{ type: "branch:toggleNoteSelection";
+  noteId: string;
+  selected: boolean }
+```
+
+### Webview → Extension — section-level Select / Deselect All
+
+Reuses the existing icon-button → `{type:'command', command:'…'}` channel (see `cmdMap` at [SidebarScriptBuilder.ts:2936](../../../vscode/src/views/SidebarScriptBuilder.ts)). Two new entries:
+
+```js
+'conversations-select-all': 'jollimemory.selectAllConversations',
+'plans-select-all':         'jollimemory.selectAllPlansAndNotes',
+```
+
+Two new VSCode commands registered in `Extension.ts` alongside `jollimemory.selectAllFiles`:
+
+- `jollimemory.selectAllConversations`: ask the conversations store / aggregator for the current visible-set; if every one is selected (i.e. zero entries in `excludedConversations` intersect the visible-set) → write all visible into `excludedConversations`; otherwise → remove the visible-set entries from `excludedConversations`. Then trigger a re-push.
+- `jollimemory.selectAllPlansAndNotes`: same logic over plans + notes combined. The store call writes both `excludedPlans` and `excludedNotes` in a single `setAllExcluded` batch (or two — the file is rewritten atomically once either way).
+
+No per-section "set all" outbound message — the command goes through the same channel as `jollimemory.selectAllFiles` does today.
+
+### Extension → Webview (existing message shapes)
+
+- `ActiveConversationItem` gains `isSelected: boolean` (required, default true, computed by the extension from `commit-selection.json` ∩ visible-set).
+- `SerializedTreeItem` already has optional `isSelected` — for plan / note rows, the `PlansProvider` populates it from `commit-selection.json` ∩ visible-set; for file / commit rows, behavior is unchanged.
+- Section header buttons render a fixed codicon and do not display selection state — no new field needed. The toggle decision is made server-side when the command fires, reading the current selection state from the store.
+
+### Extension callbacks
+
+Mirroring the existing `applyFileCheckbox` / `applyCommitCheckbox`, `SidebarWebviewProvider.deps` gains:
+
+```ts
+applyConversationCheckbox?: (source: ConversationSource, sessionId: string, selected: boolean) => void;
+applyPlanCheckbox?:         (planId: string, selected: boolean) => void;
+applyNoteCheckbox?:         (noteId: string, selected: boolean) => void;
+```
+
+These wire through to `CommitSelectionStore` writes, then trigger a panel re-push (re-read `commit-selection.json` → re-emit `branch:conversationsData` / `branch:plansData`).
+
+## Commit pipeline integration
+
+`QueueWorker.runSummaryPipeline` (see [QueueWorker.ts](../../../cli/src/hooks/QueueWorker.ts)) changes:
+
+1. Near the top of the pipeline (before `loadSessionTranscripts` and `detectActivePlansForBranch` / `detectActiveNotesForBranch`):
+
+   ```ts
+   const exclusions = CommitSelectionStore.readExclusions(cwd);
+   ```
+
+2. After `loadSessionTranscripts(cwd)`, filter:
+
+   ```ts
+   sessions = sessions.filter(s => !exclusions.conversations.has(`${s.source}:${s.sessionId}`));
+   ```
+
+3. After `detectActivePlansForBranch` / `detectActiveNotesForBranch`, filter the returned arrays by `exclusions.plans` / `exclusions.notes` (set membership on `id`).
+
+That's the whole change. The pipeline **never writes** to `commit-selection.json` — there is no clear step, no per-`op.type` branching, no failure-vs-success bookkeeping. Read once, filter, proceed.
+
+The squash / rebase-squash code path (`runSquashPipeline` / `generateSquashConsolidation`) does not read or write `commit-selection.json`. The rebase-pick path likewise does not touch it.
+
+## Testing
+
+CLI (must hit the 97 % coverage floor on new code):
+
+- `CommitSelectionStore.test.ts`:
+  - empty file / missing file / malformed JSON → returns empty.
+  - `setExcluded(kind, key, true)` writes the key; `setExcluded(kind, key, false)` removes it.
+  - `setAllExcluded` bulk-adds and bulk-removes a key set in a single write.
+  - Atomic write under concurrent process simulation (tmp+rename collision).
+  - File with stale keys is still readable and yields a usable set.
+
+- `QueueWorker.selection.test.ts`:
+  - Exclusion of one conversation → that transcript is absent from `generateSummary` input.
+  - Exclusion of one plan / note → absent from `formatPlansBlock` / `formatNotesBlock`.
+  - Pipeline never writes to `commit-selection.json`: file present before → still present after (initial-commit, amend, squash, rebase-pick, rebase-squash, and failure paths).
+  - Two consecutive commits with the same exclusion file → same item filtered out both times.
+  - Re-checking the item (via `setExcluded(…, false)` between two commits) → first commit excludes, second commit includes.
+
+VSCode:
+
+- `SidebarWebviewProvider.test.ts`:
+  - `branch:toggleConversationSelection` outbound → `applyConversationCheckbox` callback invoked with correct args.
+  - Same for plan / note toggle.
+
+- `Extension.ts` command-registration tests (or a focused new test file):
+  - `jollimemory.selectAllConversations` with mixed state → all flipped to selected (exclusions for visible-set removed).
+  - Same command with all-selected state → all flipped to deselected (visible-set added to exclusions).
+  - `jollimemory.selectAllPlansAndNotes` covers both plans and notes in one atomic write.
+
+- `ActiveSessionsProvider.test.ts`:
+  - `isSelected` is `false` exactly when `commit-selection.json` lists `{source, sessionId}`.
+  - `isSelected` defaults to `true` for items not in the exclusion file.
+
+- `FilesStore.test.ts`:
+  - Refresh against `raw` of N new files → `selectedPaths.size === N`.
+  - User unchecks one → `selectedPaths.size === N-1`.
+  - Refresh again with same `raw` → unchecked path stays unchecked (selection survives within session).
+  - Refresh with one path removed → `selectedPaths` is pruned to N-1.
+
+- Sidebar webview render (script-builder unit tests):
+  - Conversation row with `isSelected:false` renders an unchecked box.
+  - Section header icon button renders with the right action id (`conversations-select-all` / `plans-select-all`) and is mapped to the right VSCode command in `cmdMap`.
+
+## Risks & mitigations
+
+- **Exclusion is forever until reverted.** Because exclusion is sticky across commits, amends, restarts, and sessions, a user who unchecks an item once and forgets about it will see that item silently absent from every future summary. Mitigation: the sidebar always reflects the on-disk state, so excluded rows render unchecked — the "I excluded this" intent is always visually surfaced; the section "Select / Deselect All" button is also a one-click escape valve to wipe the visible portion of the exclusion set.
+
+- **VSCode webview CSP blocks inline styles.** Memory note `feedback_vscode_webview_csp_no_inline.md` reminds us: all checkbox styling and event wiring goes through a CSS class + `addEventListener`, never inline `style=""` or `onclick=""`.
+
+- **Template-literal backtick trap.** Per `feedback_sidebar_script_builder_backtick_trap.md`: any new `buildXxx` template literal that mentions JS identifiers in comments must single/double-quote them — backticks inside the literal will silently truncate the script.
+
+- **Lazy-data race.** Per `feedback_lazy_data_trigger_on_all_entrypoints.md`: when `commit-selection.json` is the lazy source for `isSelected`, every entrypoint (initial load, tab switch, post-toggle re-push, post-pipeline refresh) must trigger a re-read.
+
+- **Worktree dual writes.** Two worktrees share the orphan branch but each has its own `.jolli/jollimemory/`. Selection in worktree A does not bleed into worktree B — that's the intended isolation.
+
+- **Test coverage regression.** CLI floor is 97 % statements / 96 % branches. `CommitSelectionStore` must come with a focused test file, and the `QueueWorker.runSummaryPipeline` branches added by the filter step are testable via the existing fixture pattern in `QueueWorker.overlay.test.ts`.
+
+## Out-of-scope follow-ups
+
+These are deliberately deferred — call them out in the PR description so reviewers know they were considered:
+
+- A confirmation toast when committing with > 0 excluded items.
+- Keyboard shortcuts on the Select / Deselect All button.
+- Exposing the same selection over the IntelliJ plugin. The Kotlin port can be added once the on-disk format is stable; until then IntelliJ commits behave as today (everything included).

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## 0.99.2
 
 - **Active AI Conversations panel** — a new **CONVERSATIONS** section in the Branch tab lists your recent AI coding sessions across every supported tool, with the title, agent, and message count at a glance. Click a row to open the full transcript and edit or delete messages — the next commit's memory is generated from your curated version, not the raw conversation.
+- **Per-item commit selection** — uncheck any conversation, plan, note, or file in the Branch tab to keep it out of the next commit's memory. Your choice sticks across commits and restarts until you put it back, and each section has a `Select / Deselect All` shortcut at the top.
 
 ## 0.99.1
 

--- a/vscode/src/Extension.test.ts
+++ b/vscode/src/Extension.test.ts
@@ -28,6 +28,10 @@ const { mockNotifyApiKeySaveError } = vi.hoisted(() => ({
 	mockNotifyApiKeySaveError: vi.fn(),
 }));
 
+const { mockRefreshConversationsPanel } = vi.hoisted(() => ({
+	mockRefreshConversationsPanel: vi.fn(() => Promise.resolve()),
+}));
+
 const { isWorkerBusy } = vi.hoisted(() => ({
 	isWorkerBusy: vi.fn(),
 }));
@@ -799,6 +803,7 @@ vi.mock("./views/SidebarWebviewProvider.js", () => ({
 		resolveWebviewView() {}
 		dispose() {}
 		refreshKnowledgeBaseFolders() {}
+		refreshConversationsPanel = mockRefreshConversationsPanel;
 		notifyEnabledChanged() {}
 		notifyAuthChanged() {}
 		notifyConfiguredChanged() {}
@@ -3114,7 +3119,8 @@ describe("Extension", () => {
 			activate(ctx);
 		});
 
-		it("refreshes history and plans when the worker lock is deleted", async () => {
+		it("refreshes history, plans, and conversations when the worker lock is deleted", async () => {
+			mockRefreshConversationsPanel.mockClear();
 			const lockWatcher = createFileSystemWatcher.mock.results[3]?.value;
 			const onDelete = lockWatcher?.onDidDelete.mock.calls[0]?.[0] as
 				| (() => void)
@@ -3127,6 +3133,11 @@ describe("Extension", () => {
 				expect(mockStatusStore.setWorkerBusy).toHaveBeenCalledWith(false);
 				expect(mockCommitsStore.refresh).toHaveBeenCalled();
 				expect(mockPlansStore.refresh).toHaveBeenCalled();
+				// The CONVERSATIONS section is polled on a 60s timer, so without
+				// this hook the row that the worker just consumed would linger
+				// for up to a minute. Refreshing here keeps the section in sync
+				// with the worker's cursor advance.
+				expect(mockRefreshConversationsPanel).toHaveBeenCalled();
 			});
 			expect(executeCommand).toHaveBeenCalledWith(
 				"setContext",

--- a/vscode/src/Extension.ts
+++ b/vscode/src/Extension.ts
@@ -9,6 +9,10 @@ import { existsSync, readFileSync } from "node:fs";
 import { dirname, isAbsolute, join, resolve } from "node:path";
 import * as vscode from "vscode";
 import {
+	conversationKey,
+	setExcluded,
+} from "../../cli/src/core/CommitSelectionStore.js";
+import {
 	extractRepoName,
 	getRemoteUrl,
 	resolveKbParent,
@@ -36,6 +40,10 @@ import type { StatusInfo } from "../../cli/src/Types.js";
 import { execFileSyncHidden } from "../../cli/src/util/Subprocess.js";
 import { CommitCommand } from "./commands/CommitCommand.js";
 import { PushCommand } from "./commands/PushCommand.js";
+import {
+	selectAllConversationsCommand,
+	selectAllPlansAndNotesCommand,
+} from "./commands/SelectAllSelection.js";
 import { SquashCommand } from "./commands/SquashCommand.js";
 import { getNotesDir } from "./core/NoteService.js";
 import {
@@ -224,6 +232,8 @@ const ALL_DECLARED_COMMANDS: ReadonlyArray<string> = [
 	"jollimemory.pushBranch",
 	"jollimemory.selectAllFiles",
 	"jollimemory.selectAllCommits",
+	"jollimemory.selectAllConversations",
+	"jollimemory.selectAllPlansAndNotes",
 	"jollimemory.searchMemories",
 	"jollimemory.clearMemoryFilter",
 	"jollimemory.loadMoreMemories",
@@ -513,7 +523,7 @@ export function activate(context: vscode.ExtensionContext): void {
 	// ── Tree providers (thin subscribers over stores) ────────────────────────
 	const statusProvider = new StatusTreeProvider(statusStore);
 	const memoriesProvider = new MemoriesTreeProvider(memoriesStore);
-	const plansProvider = new PlansTreeProvider(plansStore);
+	const plansProvider = new PlansTreeProvider(plansStore, workspaceRoot);
 	const filesProvider = new FilesTreeProvider(filesStore);
 	const historyProvider = new HistoryTreeProvider(commitsStore);
 
@@ -646,7 +656,14 @@ export function activate(context: vscode.ExtensionContext): void {
 		resolveInitialStateReady = resolve;
 	});
 
-	const sidebarProvider = new SidebarWebviewProvider({
+	// Hoisted so selectAllConversationsCommand can reference it directly
+	// in the command registration below without going through sidebarProvider.
+	const activeSessionsProvider = new ActiveSessionsProvider({
+		getWorkspaceCwd: () => vscode.workspace.workspaceFolders?.[0]?.uri.fsPath,
+	});
+
+	let sidebarProvider: SidebarWebviewProvider;
+	sidebarProvider = new SidebarWebviewProvider({
 		executeCommand: (cmd, ...args) =>
 			vscode.commands.executeCommand(cmd, ...args),
 		getInitialState: () => ({
@@ -744,12 +761,26 @@ export function activate(context: vscode.ExtensionContext): void {
 			filesStore.applyCheckboxBatch([[filePath, selected]]),
 		applyCommitCheckbox: (hash, selected) =>
 			commitsStore.onCheckboxToggle(hash, selected),
-		// Active Conversations source for the Branch tab. Reads workspaceCwd
-		// lazily so a future workspace-folder change doesn't strand the
-		// provider on a stale path.
-		activeSessionsProvider: new ActiveSessionsProvider({
-			getWorkspaceCwd: () => vscode.workspace.workspaceFolders?.[0]?.uri.fsPath,
-		}),
+		applyConversationCheckbox: async (source, sessionId, selected) => {
+			await setExcluded(
+				workspaceRoot,
+				"conversations",
+				conversationKey(source, sessionId),
+				!selected,
+			);
+			await sidebarProvider.refreshConversationsPanel();
+		},
+		applyPlanCheckbox: async (planId, selected) => {
+			await setExcluded(workspaceRoot, "plans", planId, !selected);
+			await plansProvider.refreshExclusions();
+		},
+		applyNoteCheckbox: async (noteId, selected) => {
+			await setExcluded(workspaceRoot, "notes", noteId, !selected);
+			await plansProvider.refreshExclusions();
+		},
+		// Active Conversations source for the Branch tab (hoisted above so
+		// selectAllConversationsCommand can reference it directly).
+		activeSessionsProvider: activeSessionsProvider,
 		initialStateReady,
 	});
 	sidebarProviderRef = sidebarProvider;
@@ -1103,6 +1134,14 @@ export function activate(context: vscode.ExtensionContext): void {
 		}
 		// Refresh PLANS panel so commit hash prefix appears after Worker associates plans.
 		plansStore.refresh().catch(handleError("lockWatcher.onDidDelete.plans"));
+		// Refresh CONVERSATIONS panel too — the worker advanced cursors for the
+		// included sessions, so those rows should drop out immediately rather
+		// than waiting up to 60s for the background poll. Excluded rows stay
+		// because their cursors weren't touched (see QueueWorker
+		// loadSessionTranscripts pre-read exclusion filter).
+		sidebarProvider
+			.refreshConversationsPanel()
+			.catch(handleError("lockWatcher.onDidDelete.conversations"));
 	});
 	context.subscriptions.push(lockWatcher);
 	// Check initial state — lock file might already exist on activation
@@ -1427,6 +1466,24 @@ export function activate(context: vscode.ExtensionContext): void {
 		vscode.commands.registerCommand("jollimemory.selectAllFiles", () => {
 			filesStore.toggleSelectAll();
 		}),
+
+		vscode.commands.registerCommand("jollimemory.selectAllConversations", () =>
+			selectAllConversationsCommand({
+				cwd: workspaceRoot,
+				activeSessions: activeSessionsProvider,
+				plansProvider,
+				onChanged: () => sidebarProvider.refreshConversationsPanel(),
+			}),
+		),
+
+		vscode.commands.registerCommand("jollimemory.selectAllPlansAndNotes", () =>
+			selectAllPlansAndNotesCommand({
+				cwd: workspaceRoot,
+				activeSessions: activeSessionsProvider,
+				plansProvider,
+				onChanged: () => sidebarProvider.refreshPlansPanel(),
+			}),
+		),
 
 		vscode.commands.registerCommand("jollimemory.commitAI", () => {
 			log.info("cmd", "commitAI invoked");

--- a/vscode/src/commands/SelectAllSelection.test.ts
+++ b/vscode/src/commands/SelectAllSelection.test.ts
@@ -1,0 +1,306 @@
+import { mkdir, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+	conversationKey,
+	readExclusions,
+	setAllExcluded,
+	setExcluded,
+} from "../../../cli/src/core/CommitSelectionStore.js";
+import { JOLLI_DIR, JOLLIMEMORY_DIR } from "../../../cli/src/Logger.js";
+import type { SerializedTreeItem } from "../views/SidebarMessages.js";
+import {
+	type SelectAllCtx,
+	selectAllConversationsCommand,
+	selectAllPlansAndNotesCommand,
+} from "./SelectAllSelection.js";
+
+// ── Temp-dir lifecycle ────────────────────────────────────────────────────────
+
+let cwd: string;
+
+beforeEach(async () => {
+	cwd = await mkdir(
+		join(tmpdir(), `select-all-${Date.now()}-${Math.random()}`),
+		{
+			recursive: true,
+		},
+	).then((p) => p ?? "");
+	await mkdir(join(cwd, JOLLI_DIR, JOLLIMEMORY_DIR), { recursive: true });
+});
+
+afterEach(async () => {
+	await rm(cwd, { recursive: true, force: true });
+});
+
+// ── Fixture builders ──────────────────────────────────────────────────────────
+
+/**
+ * Builds a SelectAllCtx whose activeSessions stub returns the given items.
+ * Each item's `isSelected` is read back from the real CommitSelectionStore
+ * on each call so the tests can mutate exclusions between calls and see the
+ * updated `isSelected` values.
+ */
+function makeConversationCtx(
+	conversations: Array<{
+		source:
+			| "claude"
+			| "codex"
+			| "gemini"
+			| "opencode"
+			| "cursor"
+			| "copilotcli"
+			| "copilotchat";
+		sessionId: string;
+	}>,
+	changed: Array<() => void | Promise<void>> = [],
+): SelectAllCtx {
+	return {
+		cwd,
+		activeSessions: {
+			async listWithDiagnostics() {
+				// Re-read exclusions each time so `isSelected` reflects current state.
+				const ex = await readExclusions(cwd);
+				const items = conversations.map((c) => ({
+					sessionId: c.sessionId,
+					source: c.source,
+					title: c.sessionId,
+					messageCount: 0,
+					updatedAt: new Date().toISOString(),
+					transcriptPath: "/tmp/fake",
+					isSelected: !ex.conversations.has(
+						conversationKey(c.source, c.sessionId),
+					),
+				}));
+				return { items, failedSources: [] };
+			},
+		},
+		plansProvider: {
+			serialize: () => [],
+			async refreshExclusions() {},
+		},
+		onChanged: async () => {
+			for (const fn of changed) await fn();
+		},
+	};
+}
+
+/**
+ * Builds a SelectAllCtx whose plansProvider.serialize() returns fixed rows
+ * derived from the given planIds and noteIds. `isSelected` is re-read from
+ * CommitSelectionStore on each serialize() call.
+ */
+function makePlansCtx(
+	planIds: string[],
+	noteIds: string[],
+	changed: Array<() => void | Promise<void>> = [],
+): SelectAllCtx {
+	let cachedExclusions = {
+		plans: new Set<string>(),
+		notes: new Set<string>(),
+		conversations: new Set<string>(),
+	};
+	return {
+		cwd,
+		activeSessions: {
+			async listWithDiagnostics() {
+				return { items: [], failedSources: [] };
+			},
+		},
+		plansProvider: {
+			serialize(): ReadonlyArray<SerializedTreeItem> {
+				const planRows: SerializedTreeItem[] = planIds.map((id) => ({
+					id,
+					label: id,
+					contextValue: "plan",
+					isSelected: !cachedExclusions.plans.has(id),
+				}));
+				const noteRows: SerializedTreeItem[] = noteIds.map((id) => ({
+					id,
+					label: id,
+					contextValue: "note",
+					isSelected: !cachedExclusions.notes.has(id),
+				}));
+				return [...planRows, ...noteRows];
+			},
+			async refreshExclusions() {
+				// Re-read so the next serialize() sees the new state.
+				cachedExclusions = await readExclusions(cwd);
+			},
+		},
+		onChanged: async () => {
+			for (const fn of changed) await fn();
+		},
+	};
+}
+
+// ── selectAllConversationsCommand ─────────────────────────────────────────────
+
+describe("selectAllConversationsCommand", () => {
+	it("excludes everything when nothing is currently excluded", async () => {
+		const ctx = makeConversationCtx([
+			{ source: "claude", sessionId: "a" },
+			{ source: "codex", sessionId: "b" },
+		]);
+		await selectAllConversationsCommand(ctx);
+		const ex = await readExclusions(cwd);
+		expect(ex.conversations.has(conversationKey("claude", "a"))).toBe(true);
+		expect(ex.conversations.has(conversationKey("codex", "b"))).toBe(true);
+	});
+
+	it("clears the visible set when everything is currently excluded", async () => {
+		// First, exclude all.
+		await setAllExcluded(
+			cwd,
+			"conversations",
+			[conversationKey("claude", "a"), conversationKey("codex", "b")],
+			true,
+		);
+
+		// Ctx re-reads exclusions on each call — will report isSelected:false for both.
+		const ctx = makeConversationCtx([
+			{ source: "claude", sessionId: "a" },
+			{ source: "codex", sessionId: "b" },
+		]);
+		await selectAllConversationsCommand(ctx);
+		const ex = await readExclusions(cwd);
+		expect(ex.conversations.size).toBe(0);
+	});
+
+	it("with mixed state, switches to all-selected", async () => {
+		// Exclude only "a".
+		await setExcluded(
+			cwd,
+			"conversations",
+			conversationKey("claude", "a"),
+			true,
+		);
+
+		// Ctx re-reads exclusions — "a" isSelected:false, "b" isSelected:true → mixed.
+		const ctx = makeConversationCtx([
+			{ source: "claude", sessionId: "a" },
+			{ source: "codex", sessionId: "b" },
+		]);
+		await selectAllConversationsCommand(ctx);
+		const ex = await readExclusions(cwd);
+		// Spec: "If every visible item is selected → deselect all. Otherwise
+		// (none selected, or mixed) → select all." Mixed → select all,
+		// i.e. exclusions cleared for the visible set.
+		expect(ex.conversations.has(conversationKey("claude", "a"))).toBe(false);
+		expect(ex.conversations.has(conversationKey("codex", "b"))).toBe(false);
+	});
+
+	it("does nothing to exclusions when item list is empty", async () => {
+		const ctx = makeConversationCtx([]);
+		await selectAllConversationsCommand(ctx);
+		const ex = await readExclusions(cwd);
+		expect(ex.conversations.size).toBe(0);
+	});
+
+	it("calls onChanged", async () => {
+		let called = false;
+		const ctx = makeConversationCtx(
+			[{ source: "claude", sessionId: "x" }],
+			[
+				() => {
+					called = true;
+				},
+			],
+		);
+		await selectAllConversationsCommand(ctx);
+		expect(called).toBe(true);
+	});
+});
+
+// ── selectAllPlansAndNotesCommand ─────────────────────────────────────────────
+
+describe("selectAllPlansAndNotesCommand", () => {
+	it("excludes plans and notes together when nothing is excluded", async () => {
+		const ctx = makePlansCtx(["plan-1", "plan-2"], ["note-1"]);
+		await selectAllPlansAndNotesCommand(ctx);
+		const ex = await readExclusions(cwd);
+		expect([...ex.plans].sort()).toEqual(["plan-1", "plan-2"]);
+		expect([...ex.notes]).toEqual(["note-1"]);
+	});
+
+	it("selects all when every plan and note is excluded", async () => {
+		await setAllExcluded(cwd, "plans", ["plan-1", "plan-2"], true);
+		await setAllExcluded(cwd, "notes", ["note-1"], true);
+
+		const ctx = makePlansCtx(["plan-1", "plan-2"], ["note-1"]);
+		// refreshExclusions() is called inside the command — ctx will see current exclusions.
+		await ctx.plansProvider.refreshExclusions();
+		await selectAllPlansAndNotesCommand(ctx);
+
+		const ex = await readExclusions(cwd);
+		expect(ex.plans.size).toBe(0);
+		expect(ex.notes.size).toBe(0);
+	});
+
+	it("switches to all-selected with mixed state (some plan excluded)", async () => {
+		await setExcluded(cwd, "plans", "plan-1", true);
+
+		const ctx = makePlansCtx(["plan-1", "plan-2"], ["note-1"]);
+		await ctx.plansProvider.refreshExclusions();
+		await selectAllPlansAndNotesCommand(ctx);
+
+		const ex = await readExclusions(cwd);
+		// Spec: mixed → select all → exclusions for visible plans/notes cleared.
+		expect(ex.plans.has("plan-1")).toBe(false);
+		expect(ex.plans.has("plan-2")).toBe(false);
+		expect(ex.notes.has("note-1")).toBe(false);
+	});
+
+	it("ignores linearissue rows", async () => {
+		// Construct a ctx that includes a linearissue row alongside a plan.
+		const linearRow: SerializedTreeItem = {
+			id: "LIN-123",
+			label: "Linear issue",
+			contextValue: "linearissue",
+			isSelected: true,
+		};
+		const planRow: SerializedTreeItem = {
+			id: "plan-1",
+			label: "Plan 1",
+			contextValue: "plan",
+			isSelected: true,
+		};
+		const stubCtx: SelectAllCtx = {
+			cwd,
+			activeSessions: {
+				async listWithDiagnostics() {
+					return { items: [], failedSources: [] };
+				},
+			},
+			plansProvider: {
+				serialize() {
+					return [planRow, linearRow];
+				},
+				async refreshExclusions() {},
+			},
+			onChanged: async () => {},
+		};
+		await selectAllPlansAndNotesCommand(stubCtx);
+		const ex = await readExclusions(cwd);
+		expect(ex.plans.has("plan-1")).toBe(true);
+		// Linear row must not be added to any exclusion set.
+		expect(ex.plans.has("LIN-123")).toBe(false);
+		expect(ex.notes.has("LIN-123")).toBe(false);
+	});
+
+	it("calls onChanged", async () => {
+		let called = false;
+		const ctx = makePlansCtx(
+			["plan-1"],
+			[],
+			[
+				() => {
+					called = true;
+				},
+			],
+		);
+		await selectAllPlansAndNotesCommand(ctx);
+		expect(called).toBe(true);
+	});
+});

--- a/vscode/src/commands/SelectAllSelection.ts
+++ b/vscode/src/commands/SelectAllSelection.ts
@@ -1,0 +1,86 @@
+/**
+ * SelectAllSelection — Select / Deselect All commands for the Conversations
+ * and Plans & Notes panels.
+ *
+ * These mirror `FilesStore.toggleSelectAll()` / the existing
+ * `jollimemory.selectAllFiles` command: if every visible row is currently
+ * selected, the command deselects all; otherwise it selects all.
+ *
+ * Discriminating plan rows from note rows
+ * ──────────────────────────────────────
+ * `PlansTreeProvider.serialize()` returns `SerializedTreeItem[]` where the
+ * `contextValue` field is `"plan"`, `"note"`, or `"linearissue"` (set by the
+ * corresponding Item constructor in PlansTreeProvider). The `id` field carries
+ * the raw plan slug (for plans) or note id (for notes) — no prefix. We switch
+ * on `contextValue` to split the two groups. Linear-issue rows have no
+ * exclusion key and are skipped. This is **Option B-variant (contextValue)**:
+ * the discriminator already existed on SerializedTreeItem; no schema changes
+ * were needed.
+ */
+
+import {
+	conversationKey,
+	setAllExcluded,
+} from "../../../cli/src/core/CommitSelectionStore.js";
+import type { PlansTreeProvider } from "../providers/PlansTreeProvider.js";
+import type { ActiveSessionsProvider } from "../services/ActiveSessionsProvider.js";
+
+export interface SelectAllCtx {
+	readonly cwd: string;
+	readonly activeSessions: Pick<ActiveSessionsProvider, "listWithDiagnostics">;
+	readonly plansProvider: Pick<
+		PlansTreeProvider,
+		"serialize" | "refreshExclusions"
+	>;
+	readonly onChanged: () => Promise<void> | void;
+}
+
+/**
+ * Flip selection state for all visible conversations.
+ * Matches `FilesStore.toggleSelectAll()` / the design spec: only when every
+ * visible row is currently selected does the click deselect all; in every
+ * other state (none selected, or mixed) it selects all.
+ */
+export async function selectAllConversationsCommand(
+	ctx: SelectAllCtx,
+): Promise<void> {
+	const { items } = await ctx.activeSessions.listWithDiagnostics();
+	const keys = items.map((it) => conversationKey(it.source, it.sessionId));
+	// `isSelected !== false` because "absence of a record means included"
+	// — undefined/true both count as selected.
+	const allCurrentlySelected =
+		items.length > 0 && items.every((it) => it.isSelected !== false);
+	// Flip: only all-selected → exclude all; otherwise → clear exclusions.
+	await setAllExcluded(ctx.cwd, "conversations", keys, allCurrentlySelected);
+	await ctx.onChanged();
+}
+
+/**
+ * Flip selection state for all visible plans AND notes in one shot.
+ * Linear-issue rows have no exclusion key and are ignored.
+ * The "all selected" check spans both groups together (matching FilesStore
+ * behaviour which considers the combined visible set).
+ */
+export async function selectAllPlansAndNotesCommand(
+	ctx: SelectAllCtx,
+): Promise<void> {
+	// serialize() output: contextValue is "plan" | "note" | "linearissue";
+	// id is the raw plan slug (for plans) or note id (for notes).
+	const rows = ctx.plansProvider.serialize();
+	const planRows = rows.filter((r) => r.contextValue === "plan");
+	const noteRows = rows.filter((r) => r.contextValue === "note");
+	const planKeys = planRows.map((r) => r.id);
+	const noteKeys = noteRows.map((r) => r.id);
+
+	const visibleSelectable = [...planRows, ...noteRows];
+	// `isSelected !== false` because "absence of a record means included".
+	const allCurrentlySelected =
+		visibleSelectable.length > 0 &&
+		visibleSelectable.every((r) => r.isSelected !== false);
+	const target = allCurrentlySelected;
+
+	await setAllExcluded(ctx.cwd, "plans", planKeys, target);
+	await setAllExcluded(ctx.cwd, "notes", noteKeys, target);
+	await ctx.plansProvider.refreshExclusions();
+	await ctx.onChanged();
+}

--- a/vscode/src/providers/FilesTreeProvider.test.ts
+++ b/vscode/src/providers/FilesTreeProvider.test.ts
@@ -256,10 +256,14 @@ describe("FilesTreeProvider", () => {
 			"a.ts",
 			"ignore.log",
 		]);
-		// ignore.log is selected but excluded by *.log — getSelectedFiles() must filter it out
+		// Default-select seeds every freshly-seen path; the *.log exclude pattern
+		// then drops ignore.log from getSelectedFiles even though it was seeded.
 		expect(
-			provider.getSelectedFiles().map((file) => file.relativePath),
-		).toEqual(["a.ts"]);
+			provider
+				.getSelectedFiles()
+				.map((file) => file.relativePath)
+				.sort(),
+		).toEqual(["a.ts", "b.ts"]);
 		expect(provider.getExcludedCount()).toBe(1);
 		expect(provider.getVisibleFileCount()).toBe(2);
 		expect(
@@ -459,14 +463,16 @@ describe("FilesTreeProvider", () => {
 		);
 		await provider.refresh();
 
-		// Select all visible (a.ts, b.ts — skip.log is excluded)
+		// After refresh the default-select seed has already selected every
+		// visible path (skip.log is excluded). First toggle therefore flips
+		// the all-selected state to "all unselected".
+		provider.toggleSelectAll();
+		expect(provider.getSelectedFiles()).toHaveLength(0);
+
+		// Second toggle re-selects every visible file.
 		provider.toggleSelectAll();
 		const selected = provider.getSelectedFiles().map((f) => f.relativePath);
 		expect(selected.sort()).toEqual(["a.ts", "b.ts"]);
-
-		// Toggle again → deselect all visible
-		provider.toggleSelectAll();
-		expect(provider.getSelectedFiles()).toHaveLength(0);
 	});
 
 	it("keeps already-selected visible files selected when selecting the remaining files", async () => {
@@ -478,6 +484,13 @@ describe("FilesTreeProvider", () => {
 			makeExcludeFilter(),
 		);
 		await provider.refresh();
+
+		// Default-select seeds both as selected; uncheck a.ts so the panel is
+		// in a mixed state (b.ts selected, a.ts unselected). toggleSelectAll
+		// should converge to "all selected" rather than "all unselected"
+		// because not every visible row is currently selected.
+		const [itemA] = provider.getChildren();
+		provider.onCheckboxToggle(itemA, false);
 
 		provider.toggleSelectAll();
 
@@ -549,8 +562,13 @@ describe("FilesTreeProvider", () => {
 			makeExcludeFilter(),
 		);
 		await provider.refresh();
-		const [itemA] = provider.getChildren();
+		const [itemA, itemB] = provider.getChildren();
 
+		// Default-select gives both files isSelected:true. Uncheck b.ts so the
+		// batch that targets only a.ts has a distinct "other" file to leave
+		// alone. The batch then re-asserts a.ts:true (no-op) and b.ts stays
+		// unchecked.
+		provider.onCheckboxToggle(itemB, false);
 		provider.onCheckboxToggleBatch([[itemA, true]]);
 
 		expect(provider.getFiles()).toEqual([
@@ -899,8 +917,11 @@ describe("FilesTreeProvider.serialize", () => {
 		);
 		await provider.refresh(true);
 
-		const [itemA] = provider.getChildren();
-		provider.onCheckboxToggle(itemA, true);
+		// Both files default-select after refresh. Uncheck b.ts so the next
+		// refresh has to remember a real uncheck (this exercises the negative
+		// memory in FilesStore.unselectedPaths).
+		const [, itemB] = provider.getChildren();
+		provider.onCheckboxToggle(itemB, false);
 
 		bridge.listFiles.mockResolvedValueOnce([
 			makeFile("a.ts", false),

--- a/vscode/src/providers/PlansTreeProvider.test.ts
+++ b/vscode/src/providers/PlansTreeProvider.test.ts
@@ -1,4 +1,8 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { setExcluded } from "../../../cli/src/core/CommitSelectionStore.js";
 import type { NoteInfo, PlanInfo } from "../Types.js";
 
 const {
@@ -582,6 +586,69 @@ describe("PlansTreeProvider", () => {
 
 			const items = provider.serialize?.();
 			expect(items?.[0]?.id).toBe("note-abc");
+		});
+	});
+
+	describe("isSelected via exclusions cache", () => {
+		/**
+		 * Build a PlansStore+PlansTreeProvider pair with the given plan slugs
+		 * rooted at cwd. The store is pre-populated via an initial refresh() call.
+		 */
+		async function makePlansProviderWithCwd(
+			slugs: readonly string[],
+			cwd: string,
+		) {
+			const plans = slugs.map((slug) => makePlan({ slug, title: slug }));
+			const bridge = {
+				listPlans: vi.fn(async () => plans),
+				listNotes: vi.fn(async () => []),
+				listLinearIssues: vi.fn(async () => []),
+			};
+			const store = new PlansStore(bridge as never);
+			const provider = new PlansTreeProvider(store, cwd);
+			// Populate the store before serializing
+			await store.refresh();
+			return provider;
+		}
+
+		it("stamps isSelected=false on a plan row whose slug is in the exclusion set", async () => {
+			const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "jolli-test-"));
+			try {
+				await setExcluded(cwd, "plans", "plan-skip", true);
+
+				const provider = await makePlansProviderWithCwd(
+					["plan-keep", "plan-skip"],
+					cwd,
+				);
+				await provider.refreshExclusions();
+				const items = provider.serialize();
+
+				const skip = items.find(
+					(i) => typeof i.id === "string" && i.id.endsWith("plan-skip"),
+				);
+				const keep = items.find(
+					(i) => typeof i.id === "string" && i.id.endsWith("plan-keep"),
+				);
+				expect(skip?.isSelected).toBe(false);
+				expect(keep?.isSelected).toBe(true);
+			} finally {
+				fs.rmSync(cwd, { recursive: true, force: true });
+			}
+		});
+
+		it("stamps isSelected=true by default when no exclusion file is present", async () => {
+			const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "jolli-test-"));
+			try {
+				const provider = await makePlansProviderWithCwd(["plan-alpha"], cwd);
+				await provider.refreshExclusions();
+				const items = provider.serialize();
+
+				for (const item of items) {
+					expect(item.isSelected).toBe(true);
+				}
+			} finally {
+				fs.rmSync(cwd, { recursive: true, force: true });
+			}
 		});
 	});
 });

--- a/vscode/src/providers/PlansTreeProvider.ts
+++ b/vscode/src/providers/PlansTreeProvider.ts
@@ -7,6 +7,10 @@
  */
 
 import * as vscode from "vscode";
+import {
+	type CommitExclusions,
+	readExclusions,
+} from "../../../cli/src/core/CommitSelectionStore.js";
 import type { PlansStore } from "../stores/PlansStore.js";
 import type { LinearIssueInfo, NoteInfo, PlanInfo } from "../Types.js";
 import {
@@ -173,9 +177,18 @@ export class PlansTreeProvider
 	>();
 	readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
 
+	private readonly store: PlansStore;
 	private readonly unsubscribe: () => void;
+	private readonly cwd: string;
+	private exclusions: CommitExclusions = {
+		conversations: new Set(),
+		plans: new Set(),
+		notes: new Set(),
+	};
 
-	constructor(private readonly store: PlansStore) {
+	constructor(store: PlansStore, cwd = "") {
+		this.store = store;
+		this.cwd = cwd;
 		this.unsubscribe = store.onChange((snap) => {
 			void vscode.commands.executeCommand(
 				"setContext",
@@ -184,6 +197,12 @@ export class PlansTreeProvider
 			);
 			this._onDidChangeTreeData.fire(undefined);
 		});
+		void this.refreshExclusions();
+	}
+
+	async refreshExclusions(): Promise<void> {
+		this.exclusions = await readExclusions(this.cwd);
+		this._onDidChangeTreeData.fire(undefined);
 	}
 
 	getTreeItem(element: TreeItem): vscode.TreeItem {
@@ -205,10 +224,19 @@ export class PlansTreeProvider
 	serialize(): ReadonlyArray<SerializedTreeItem> {
 		return this.getChildren().map((it) => {
 			let idHint: string;
-			if (it instanceof PlanItem) idHint = it.plan.slug;
-			else if (it instanceof NoteItem) idHint = it.note.id;
-			else idHint = it.issue.mapKey;
-			return treeItemToSerialized(it, idHint);
+			let isSelected = true;
+			if (it instanceof PlanItem) {
+				idHint = it.plan.slug;
+				isSelected = !this.exclusions.plans.has(idHint);
+			} else if (it instanceof NoteItem) {
+				idHint = it.note.id;
+				isSelected = !this.exclusions.notes.has(idHint);
+			} else {
+				idHint = it.issue.mapKey;
+				// Linear-issue rows are not user-selectable; default true (no exclusion key applies).
+			}
+			const ser = treeItemToSerialized(it, idHint);
+			return { ...ser, isSelected };
 		});
 	}
 

--- a/vscode/src/services/ActiveSessionsProvider.test.ts
+++ b/vscode/src/services/ActiveSessionsProvider.test.ts
@@ -22,12 +22,20 @@ vi.mock("../../../cli/src/core/ActiveSessionAggregator.js", () => ({
 	listActiveConversationsWithDiagnostics: vi.fn(),
 }));
 
+vi.mock("../util/Logger.js", () => ({
+	log: {
+		warn: vi.fn(),
+	},
+}));
+
 import { listActiveConversationsWithDiagnostics } from "../../../cli/src/core/ActiveSessionAggregator.js";
+import { log } from "../util/Logger.js";
 import { ActiveSessionsProvider } from "./ActiveSessionsProvider.js";
 
 describe("ActiveSessionsProvider", () => {
 	beforeEach(() => {
 		vi.mocked(listActiveConversationsWithDiagnostics).mockReset();
+		vi.mocked(log.warn).mockReset();
 	});
 
 	it("returns aggregator items verbatim from list()", async () => {
@@ -39,6 +47,7 @@ describe("ActiveSessionsProvider", () => {
 				messageCount: 1,
 				updatedAt: "2026-05-15T00:00:00Z",
 				transcriptPath: "/x",
+				isSelected: true,
 			},
 		];
 		vi.mocked(listActiveConversationsWithDiagnostics).mockResolvedValueOnce({
@@ -98,5 +107,111 @@ describe("ActiveSessionsProvider", () => {
 			"gemini",
 			"opencode",
 		]);
+		expect(log.warn).toHaveBeenCalledTimes(1);
+	});
+
+	it("logs a repeated aggregator failure only once until recovery", async () => {
+		vi.mocked(listActiveConversationsWithDiagnostics).mockRejectedValue(
+			new Error("boom"),
+		);
+		const p = new ActiveSessionsProvider({ getWorkspaceCwd: () => "/proj" });
+
+		await p.listWithDiagnostics();
+		await p.listWithDiagnostics();
+
+		expect(log.warn).toHaveBeenCalledTimes(1);
+	});
+
+	it("logs the same aggregator failure again after a successful refresh", async () => {
+		vi.mocked(listActiveConversationsWithDiagnostics)
+			.mockRejectedValueOnce(new Error("boom"))
+			.mockResolvedValueOnce({ items: [], failedSources: [] })
+			.mockRejectedValueOnce(new Error("boom"));
+		const p = new ActiveSessionsProvider({ getWorkspaceCwd: () => "/proj" });
+
+		await p.listWithDiagnostics();
+		await p.listWithDiagnostics();
+		await p.listWithDiagnostics();
+
+		expect(log.warn).toHaveBeenCalledTimes(2);
+	});
+
+	it("passes isSelected=false through from the aggregator to list()", async () => {
+		const items = [
+			{
+				sessionId: "abc",
+				source: "claude" as const,
+				title: "Test conversation",
+				messageCount: 5,
+				updatedAt: "2026-05-18T12:00:00Z",
+				transcriptPath: "/tmp/transcript.json",
+				isSelected: false,
+			},
+		];
+		vi.mocked(listActiveConversationsWithDiagnostics).mockResolvedValueOnce({
+			items,
+			failedSources: [],
+		});
+
+		const p = new ActiveSessionsProvider({ getWorkspaceCwd: () => "/proj" });
+		const result = await p.list();
+		expect(result).toHaveLength(1);
+		expect(result[0].isSelected).toBe(false);
+	});
+
+	it("passes isSelected=true through from the aggregator to list()", async () => {
+		const items = [
+			{
+				sessionId: "xyz",
+				source: "cursor" as const,
+				title: "Another conversation",
+				messageCount: 3,
+				updatedAt: "2026-05-19T10:30:00Z",
+				transcriptPath: "/tmp/transcript2.json",
+				isSelected: true,
+			},
+		];
+		vi.mocked(listActiveConversationsWithDiagnostics).mockResolvedValueOnce({
+			items,
+			failedSources: [],
+		});
+
+		const p = new ActiveSessionsProvider({ getWorkspaceCwd: () => "/proj" });
+		const result = await p.list();
+		expect(result).toHaveLength(1);
+		expect(result[0].isSelected).toBe(true);
+	});
+
+	it("passes isSelected through from the aggregator to listWithDiagnostics()", async () => {
+		const items = [
+			{
+				sessionId: "mixed1",
+				source: "claude" as const,
+				title: "Selected item",
+				messageCount: 10,
+				updatedAt: "2026-05-19T08:00:00Z",
+				transcriptPath: "/tmp/t1.json",
+				isSelected: true,
+			},
+			{
+				sessionId: "mixed2",
+				source: "gemini" as const,
+				title: "Deselected item",
+				messageCount: 4,
+				updatedAt: "2026-05-18T14:00:00Z",
+				transcriptPath: "/tmp/t2.json",
+				isSelected: false,
+			},
+		];
+		vi.mocked(listActiveConversationsWithDiagnostics).mockResolvedValueOnce({
+			items,
+			failedSources: [],
+		});
+
+		const p = new ActiveSessionsProvider({ getWorkspaceCwd: () => "/proj" });
+		const result = await p.listWithDiagnostics();
+		expect(result.items).toHaveLength(2);
+		expect(result.items[0].isSelected).toBe(true);
+		expect(result.items[1].isSelected).toBe(false);
 	});
 });

--- a/vscode/src/services/ActiveSessionsProvider.ts
+++ b/vscode/src/services/ActiveSessionsProvider.ts
@@ -20,6 +20,8 @@ const WINDOW_MS = 2 * 24 * 60 * 60 * 1000; // 48h, per spec §3
  * tests and a single seam to swap implementations.
  */
 export class ActiveSessionsProvider {
+	private lastAggregatorFailure: string | undefined;
+
 	constructor(private readonly deps: ActiveSessionsDeps) {}
 
 	async list(): Promise<readonly ActiveConversationItem[]> {
@@ -39,10 +41,12 @@ export class ActiveSessionsProvider {
 		const cwd = this.deps.getWorkspaceCwd();
 		if (!cwd) return { items: [], failedSources: [] };
 		try {
-			return await listActiveConversationsWithDiagnostics({
+			const result = await listActiveConversationsWithDiagnostics({
 				cwd,
 				windowMs: WINDOW_MS,
 			});
+			this.lastAggregatorFailure = undefined;
+			return result;
 		} catch (err) {
 			// Aggregator itself threw (not just one source) — every source is
 			// effectively unavailable. Reporting `failedSources: []` would
@@ -50,11 +54,15 @@ export class ActiveSessionsProvider {
 			// from a healthy-but-empty list and suppresses the partial-data
 			// banner. Flag the full TRANSCRIPT_SOURCES set instead so the
 			// user sees the broken state surfaced in the UI.
-			log.warn(
-				"ActiveSessionsProvider",
-				"listActiveConversations threw",
-				errMsg(err),
-			);
+			const message = errMsg(err);
+			if (this.lastAggregatorFailure !== message) {
+				log.warn(
+					"ActiveSessionsProvider",
+					"listActiveConversations threw",
+					message,
+				);
+				this.lastAggregatorFailure = message;
+			}
 			return { items: [], failedSources: [...TRANSCRIPT_SOURCES] };
 		}
 	}

--- a/vscode/src/stores/FilesStore.test.ts
+++ b/vscode/src/stores/FilesStore.test.ts
@@ -181,19 +181,23 @@ describe("FilesStore — mutations", () => {
 		]);
 	});
 
-	it("toggleSelectAll selects all then deselects all with selectAll reason", async () => {
+	it("toggleSelectAll deselects all (default-selected) then re-selects all with selectAll reason", async () => {
 		const bridge = makeBridge([makeFile("a.ts"), makeFile("b.ts")]);
 		const store = new FilesStore(bridge as never, "/repo", makeFilter());
 		await store.refresh();
+		// After refresh all files are default-selected.
+		expect(store.getSnapshot().selectedFiles).toHaveLength(2);
 
+		// First toggle: all selected → deselects all.
 		store.toggleSelectAll();
 		let snap = store.getSnapshot();
 		expect(snap.changeReason).toBe("selectAll");
-		expect(snap.selectedFiles).toHaveLength(2);
+		expect(snap.selectedFiles).toHaveLength(0);
 
+		// Second toggle: none selected → selects all.
 		store.toggleSelectAll();
 		snap = store.getSnapshot();
-		expect(snap.selectedFiles).toHaveLength(0);
+		expect(snap.selectedFiles).toHaveLength(2);
 	});
 
 	it("applyExcludeFilterChange recomputes visibility without re-querying bridge", async () => {
@@ -306,9 +310,9 @@ describe("FilesStore — mutations", () => {
 		const bridge = makeBridge([makeFile("a.ts"), makeFile("ignore.log")]);
 		const store = new FilesStore(bridge as never, "/repo", filter);
 		await store.refresh();
-		store.applyCheckboxBatch([["a.ts", true]]);
+		// Both files are default-selected after refresh.
 		expect(store.getSnapshot().visibleCount).toBeGreaterThan(0);
-		expect(store.getSnapshot().selectedFiles.length).toBe(1);
+		expect(store.getSnapshot().selectedFiles.length).toBe(2);
 
 		store.setEnabled(false);
 
@@ -327,7 +331,8 @@ describe("FilesStore — misc coverage", () => {
 		const bridge = makeBridge([makeFile("a.ts"), makeFile("b.ts")]);
 		const store = new FilesStore(bridge as never, "/repo", makeFilter());
 		await store.refresh();
-		store.applyCheckboxBatch([["a.ts", true]]);
+		// Both files are default-selected; uncheck b.ts so only a.ts remains.
+		store.applyCheckboxBatch([["b.ts", false]]);
 		expect([...store.getSelectedPaths()]).toEqual(["a.ts"]);
 	});
 
@@ -416,6 +421,84 @@ describe("FilesStore — concurrency", () => {
 		const bridge = makeBridge([makeFile("a.ts", true)]);
 		const store = new FilesStore(bridge as never, "/repo", makeFilter());
 		await store.refresh();
+		expect(
+			store.getSnapshot().selectedFiles.map((f) => f.relativePath),
+		).toEqual(["a.ts"]);
+	});
+});
+
+describe("FilesStore — default-select behaviour", () => {
+	it("seeds selectedPaths with every raw file on first refresh", async () => {
+		const bridge = makeBridge([
+			makeFile("a.ts"),
+			makeFile("b.ts"),
+			makeFile("c.ts"),
+		]);
+		const store = new FilesStore(bridge as never, "/repo", makeFilter());
+		await store.refresh();
+		const visible = store.getSnapshot().visibleFiles;
+		expect(visible.map((f) => f.relativePath).sort()).toEqual([
+			"a.ts",
+			"b.ts",
+			"c.ts",
+		]);
+		for (const f of visible) {
+			expect(f.isSelected).toBe(true);
+		}
+	});
+
+	it("preserves an explicit user uncheck across a same-raw refresh", async () => {
+		const bridge = makeBridge([makeFile("a.ts"), makeFile("b.ts")]);
+		const store = new FilesStore(bridge as never, "/repo", makeFilter());
+		await store.refresh();
+		store.applyCheckboxBatch([["a.ts", false]]);
+		await store.refresh();
+		const visible = store.getSnapshot().visibleFiles;
+		expect(visible.find((f) => f.relativePath === "a.ts")?.isSelected).toBe(
+			false,
+		);
+		expect(visible.find((f) => f.relativePath === "b.ts")?.isSelected).toBe(
+			true,
+		);
+	});
+
+	it("re-checks a path that was previously unchecked, surviving refresh as selected", async () => {
+		const bridge = makeBridge([makeFile("a.ts")]);
+		const store = new FilesStore(bridge as never, "/repo", makeFilter());
+		await store.refresh();
+		store.applyCheckboxBatch([["a.ts", false]]); // user unchecks
+		store.applyCheckboxBatch([["a.ts", true]]); // user re-checks
+		await store.refresh();
+		const visible = store.getSnapshot().visibleFiles;
+		expect(visible.find((f) => f.relativePath === "a.ts")?.isSelected).toBe(
+			true,
+		);
+	});
+
+	it("toggleSelectAll deselect populates unselectedPaths so refresh keeps files deselected", async () => {
+		const bridge = makeBridge([makeFile("a.ts"), makeFile("b.ts")]);
+		const store = new FilesStore(bridge as never, "/repo", makeFilter());
+		await store.refresh();
+		// All selected by default; deselect all via toggleSelectAll.
+		store.toggleSelectAll();
+		expect(store.getSnapshot().selectedFiles).toHaveLength(0);
+		// Refresh must not re-select them.
+		await store.refresh();
+		expect(store.getSnapshot().selectedFiles).toHaveLength(0);
+	});
+
+	it("prunes vanished paths from unselectedPaths so they don't affect future refreshes", async () => {
+		const bridge = {
+			listFiles: vi
+				.fn()
+				.mockResolvedValueOnce([makeFile("a.ts"), makeFile("b.ts")])
+				.mockResolvedValueOnce([makeFile("a.ts")]),
+		};
+		const store = new FilesStore(bridge as never, "/repo", makeFilter());
+		await store.refresh();
+		store.applyCheckboxBatch([["b.ts", false]]); // uncheck b.ts
+		await store.refresh(); // b.ts vanishes from status
+		// a.ts must still be selected (default).
 		expect(
 			store.getSnapshot().selectedFiles.map((f) => f.relativePath),
 		).toEqual(["a.ts"]);

--- a/vscode/src/stores/FilesStore.ts
+++ b/vscode/src/stores/FilesStore.ts
@@ -68,6 +68,7 @@ export class FilesStore extends BaseStore<FilesChangeReason, FilesSnapshot> {
 	/** Latest bridge output, before selection overlay / sort / exclude. */
 	private rawFiles: ReadonlyArray<FileStatus> = [];
 	private readonly selectedPaths = new Set<string>();
+	private unselectedPaths?: Set<string>;
 	private fileOrder = new Map<string, number>();
 	private enabled = true;
 	private migrating = false;
@@ -139,15 +140,21 @@ export class FilesStore extends BaseStore<FilesChangeReason, FilesSnapshot> {
 				this.selectedPaths.delete(p);
 			}
 		}
+		// Mirror prune on the negative-memory set so dead unchecks don't accumulate.
+		if (this.unselectedPaths) {
+			for (const p of [...this.unselectedPaths]) {
+				if (!currentPaths.has(p)) {
+					this.unselectedPaths.delete(p);
+				}
+			}
+		}
 
-		// Seed selection from any `isSelected: true` entries returned by the
-		// bridge.  In production the bridge always returns `isSelected: false`
-		// because selection is host-side UI state, but callers (and tests) may
-		// pre-populate the flag to bootstrap a "this file is selected" fixture.
-		// Migrating those into `selectedPaths` keeps the legacy semantics and
-		// keeps selection state centralized in the store.
+		// Default-select: every freshly-seen path enters `selectedPaths` unless
+		// the user has explicitly unchecked it (held in `unselectedPaths`). This
+		// matches the per-row default semantics added in commit-selection design
+		// for the conversations / plans / notes panels.
 		for (const f of raw) {
-			if (f.isSelected) {
+			if (!this.unselectedPaths?.has(f.relativePath)) {
 				this.selectedPaths.add(f.relativePath);
 			}
 		}
@@ -170,8 +177,11 @@ export class FilesStore extends BaseStore<FilesChangeReason, FilesSnapshot> {
 		for (const [path, checked] of items) {
 			if (checked) {
 				this.selectedPaths.add(path);
+				this.unselectedPaths?.delete(path);
 			} else {
 				this.selectedPaths.delete(path);
+				this.unselectedPaths ??= new Set<string>();
+				this.unselectedPaths.add(path);
 			}
 		}
 		this.rebuildSnapshot({ reorder: false, reason: "userCheckbox" });
@@ -186,8 +196,11 @@ export class FilesStore extends BaseStore<FilesChangeReason, FilesSnapshot> {
 		for (const f of visible) {
 			if (target) {
 				this.selectedPaths.add(f.relativePath);
+				this.unselectedPaths?.delete(f.relativePath);
 			} else {
 				this.selectedPaths.delete(f.relativePath);
+				this.unselectedPaths ??= new Set<string>();
+				this.unselectedPaths.add(f.relativePath);
 			}
 		}
 		this.rebuildSnapshot({ reorder: false, reason: "selectAll" });
@@ -202,18 +215,27 @@ export class FilesStore extends BaseStore<FilesChangeReason, FilesSnapshot> {
 		for (const f of this.rawFiles) {
 			if (this.excludeFilter.isExcluded(f.relativePath)) {
 				this.selectedPaths.delete(f.relativePath);
+				this.unselectedPaths?.delete(f.relativePath);
 			}
 		}
 		this.rebuildSnapshot({ reorder: false, reason: "excludeFilter" });
 	}
 
-	/** Programmatic deselect of specific paths (e.g. after discard). */
+	/**
+	 * Programmatic deselect of specific paths (e.g. after discard).
+	 *
+	 * Also records each path in `unselectedPaths` so the next `refresh()` does
+	 * not silently re-seed them via the default-select loop. The negative
+	 * memory is what makes "user-driven uncheck" survive across refreshes.
+	 */
 	deselectPaths(paths: ReadonlyArray<string>): void {
 		let changed = false;
 		for (const p of paths) {
 			if (this.selectedPaths.delete(p)) {
 				changed = true;
 			}
+			this.unselectedPaths ??= new Set<string>();
+			this.unselectedPaths.add(p);
 		}
 		if (!changed) {
 			return;
@@ -242,6 +264,7 @@ export class FilesStore extends BaseStore<FilesChangeReason, FilesSnapshot> {
 		if (!e) {
 			this.rawFiles = [];
 			this.selectedPaths.clear();
+			this.unselectedPaths = undefined;
 			this.fileOrder.clear();
 		}
 		this.rebuildSnapshot({ reorder: false, reason: "enabled" });

--- a/vscode/src/views/SidebarCssBuilder.ts
+++ b/vscode/src/views/SidebarCssBuilder.ts
@@ -371,6 +371,10 @@ export function buildSidebarCss(): string {
   .collapsible-section .section-header {
     display: flex;
     align-items: center;
+    /* Mirror .tree-node's gap:4px so the section title starts at the same
+       x-coordinate as the row's row-leading slot — i.e. the section title
+       text left edge column-aligns with the row's checkbox / leading icon. */
+    gap: 4px;
     background: var(--vscode-sideBarSectionHeader-background, transparent);
     color: var(--vscode-sideBarSectionHeader-foreground, var(--vscode-foreground));
     padding: 4px 8px;
@@ -396,7 +400,10 @@ export function buildSidebarCss(): string {
   .collapsible-section .section-actions {
     display: inline-flex;
     gap: 2px;
-    margin-left: 8px;
+    /* 4px here + 4px from the section-header flex gap above = 8px of breathing
+       room to the right of the section title (the value before the header gap
+       existed). Keep these two numbers in lockstep if either changes. */
+    margin-left: 4px;
     visibility: hidden;
   }
   .collapsible-section .section-header:hover .section-actions { visibility: visible; }
@@ -623,11 +630,18 @@ export function buildSidebarCss(): string {
   .tree-node.tree-node--changes .gs-letter { margin-left: 0; }
 
   /* CONVERSATIONS section rows: one active AI session per row. Inherits the
-     base .tree-node flex layout; the extra rules below set the per-row gap
-     and add a small badge + meta column for source / message count / time.
-     .label keeps the existing .tree-node .label ellipsis behavior. */
-  .tree-node.conversation-row {
-    gap: 8px;
+     base .tree-node flex layout (gap: 4px) so the leading checkbox / icon
+     column-aligns with plan, note, and change rows in the sibling sections.
+     The wider 8px breathing room around the trailing metadata chips
+     (badge / count / time) is restored via per-chip margin-left below —
+     overriding the row-level gap would also widen twirl → row-leading and
+     break section column alignment. */
+  .tree-node.conversation-row .badge,
+  .tree-node.conversation-row .count,
+  .tree-node.conversation-row .time {
+    /* 4px here + 4px from the base .tree-node flex gap = 8px total spacing
+       to the left neighbor. Keep these two numbers paired if either moves. */
+    margin-left: 4px;
   }
   /* Source badge — outline pill. Default to descriptionForeground for unknown
      sources; per-source rules below override fg/bg/border with the brand hue.
@@ -852,7 +866,11 @@ export function buildSidebarCss(): string {
     width: 18px;
     display: inline-flex;
     align-items: center;
-    justify-content: center;
+    /* Left-align so the checkbox / leading icon's left edge column-aligns with
+       the .section-header's title text (both sit at padding 8 + twirl 12 +
+       gap 4 = 24px from the row's left edge). Centering instead would push
+       the checkbox right by ~2.5px and break the alignment with the header. */
+    justify-content: flex-start;
     flex-shrink: 0;
   }
   .row-leading input[type="checkbox"] {

--- a/vscode/src/views/SidebarMessages.ts
+++ b/vscode/src/views/SidebarMessages.ts
@@ -478,6 +478,22 @@ export type SidebarOutboundMsg =
 			readonly selected: boolean;
 	  }
 	| {
+			readonly type: "branch:toggleConversationSelection";
+			readonly source: TranscriptSource;
+			readonly sessionId: string;
+			readonly selected: boolean;
+	  }
+	| {
+			readonly type: "branch:togglePlanSelection";
+			readonly planId: string;
+			readonly selected: boolean;
+	  }
+	| {
+			readonly type: "branch:toggleNoteSelection";
+			readonly noteId: string;
+			readonly selected: boolean;
+	  }
+	| {
 			readonly type: "section:toggle";
 			readonly section: string;
 			readonly open: boolean;

--- a/vscode/src/views/SidebarScriptBuilder.test.ts
+++ b/vscode/src/views/SidebarScriptBuilder.test.ts
@@ -1561,4 +1561,114 @@ describe("SidebarScriptBuilder", () => {
 			expect(js).toContain("'conversations-warning'");
 		});
 	});
+
+	// ── Per-row selection checkboxes (conversations, plans, notes) ────────────
+	// Task 8: each conversation row, plan row, and note row renders a leading
+	// checkbox that posts a toggle message when changed. Tests assert on the
+	// generated JS/HTML strings because the wider test suite uses string-based
+	// assertions throughout (no jsdom execution).
+	describe("per-row selection checkboxes", () => {
+		it("renderConversationRow emits a jm-conv-check checkbox with data-source and data-session", () => {
+			const js = buildSidebarScript();
+			// The 'jm-conv-check' class must appear in the renderConversationRow
+			// function body.
+			const fnStart = js.indexOf("function renderConversationRow");
+			const fnEnd = js.indexOf("\n  function ", fnStart + 1);
+			const fn =
+				fnEnd > fnStart
+					? js.slice(fnStart, fnEnd)
+					: js.slice(fnStart, fnStart + 3000);
+			expect(fn).toContain("'jm-conv-check'");
+			expect(fn).toContain("'data-source'");
+			expect(fn).toContain("'data-session'");
+			// The '.checked' assignment that drives the isSelected state.
+			expect(fn).toMatch(/\.checked\s*=\s*!!item\.isSelected/);
+		});
+
+		it("renderConversationRow guards the click listener against checkbox clicks", () => {
+			const js = buildSidebarScript();
+			const fnStart = js.indexOf("function renderConversationRow");
+			const fnEnd = js.indexOf("\n  function ", fnStart + 1);
+			const fn =
+				fnEnd > fnStart
+					? js.slice(fnStart, fnEnd)
+					: js.slice(fnStart, fnStart + 3000);
+			// The direct click listener must bail out when the click target
+			// is a checkbox, so clicking 'jm-conv-check' does not also open
+			// the conversation panel.
+			expect(fn).toMatch(/\[data-checkbox="1"\]/);
+		});
+
+		it("renderPlanRow emits a jm-plan-check checkbox with data-plan-id for plan rows", () => {
+			const js = buildSidebarScript();
+			const fnStart = js.indexOf("function renderPlanRow");
+			const fnEnd = js.indexOf("\n  function ", fnStart + 1);
+			const fn =
+				fnEnd > fnStart
+					? js.slice(fnStart, fnEnd)
+					: js.slice(fnStart, fnStart + 3000);
+			expect(fn).toContain("'jm-plan-check'");
+			expect(fn).toContain("'data-plan-id'");
+			// The plan slug is stored in item.id and carried into 'data-plan-id'.
+			expect(fn).toMatch(/data-plan-id.*item\.id/);
+		});
+
+		it("renderPlanRow emits a jm-note-check checkbox with data-note-id for note rows", () => {
+			const js = buildSidebarScript();
+			const fnStart = js.indexOf("function renderPlanRow");
+			const fnEnd = js.indexOf("\n  function ", fnStart + 1);
+			const fn =
+				fnEnd > fnStart
+					? js.slice(fnStart, fnEnd)
+					: js.slice(fnStart, fnStart + 3000);
+			expect(fn).toContain("'jm-note-check'");
+			expect(fn).toContain("'data-note-id'");
+			// The note id is stored in item.id and carried into 'data-note-id'.
+			expect(fn).toMatch(/data-note-id.*item\.id/);
+		});
+
+		it("renderPlanRow does not emit a checkbox for linearissue rows (not user-selectable)", () => {
+			const js = buildSidebarScript();
+			const fnStart = js.indexOf("function renderPlanRow");
+			const fnEnd = js.indexOf("\n  function ", fnStart + 1);
+			const fn =
+				fnEnd > fnStart
+					? js.slice(fnStart, fnEnd)
+					: js.slice(fnStart, fnStart + 3000);
+			// The checkbox is gated on '!isLinearIssue', so 'isLinearIssue' must
+			// appear in the function as the exclusion guard.
+			expect(fn).toMatch(/isLinearIssue/);
+		});
+
+		it("change listener posts branch:toggleConversationSelection for jm-conv-check", () => {
+			const js = buildSidebarScript();
+			expect(js).toContain("type: 'branch:toggleConversationSelection'");
+			expect(js).toContain("'jm-conv-check'");
+		});
+
+		it("change listener posts branch:togglePlanSelection for jm-plan-check", () => {
+			const js = buildSidebarScript();
+			expect(js).toContain("type: 'branch:togglePlanSelection'");
+			expect(js).toContain("'jm-plan-check'");
+		});
+
+		it("change listener posts branch:toggleNoteSelection for jm-note-check", () => {
+			const js = buildSidebarScript();
+			expect(js).toContain("type: 'branch:toggleNoteSelection'");
+			expect(js).toContain("'jm-note-check'");
+		});
+
+		it("change listener sends planId from data-plan-id and noteId from data-note-id", () => {
+			const js = buildSidebarScript();
+			expect(js).toContain("getAttribute('data-plan-id')");
+			expect(js).toContain("getAttribute('data-note-id')");
+		});
+
+		it("change listener sends source and sessionId from data-source and data-session", () => {
+			const js = buildSidebarScript();
+			// Conversation toggle reads data-source and data-session off the checkbox.
+			expect(js).toContain("getAttribute('data-source')");
+			expect(js).toContain("getAttribute('data-session')");
+		});
+	});
 });

--- a/vscode/src/views/SidebarScriptBuilder.ts
+++ b/vscode/src/views/SidebarScriptBuilder.ts
@@ -2356,8 +2356,14 @@ export function buildSidebarScript(): string {
     // Codicons mirror the legacy native TreeView action icons declared in
     // package.json contributes.commands — keeping a single source of truth so
     // webview UI matches command palette / keybindings.
+    if (sectionId === 'conversations') {
+      return [
+        iconButton('conversations-select-all', 'Select/Deselect All Conversations', 'check-all'),
+      ];
+    }
     if (sectionId === 'plans') {
       return [
+        iconButton('plans-select-all', 'Select/Deselect All Plans & Notes', 'check-all'),
         iconButton('plans-add-menu', 'Add Plan / Note / Snippet', 'add'),
       ];
     }
@@ -2434,13 +2440,40 @@ export function buildSidebarScript(): string {
     const iconEl = el('i', {
       className: 'codicon codicon-' + iconKey + (colorClass ? ' ' + colorClass : ''),
     });
-    // Plans rows omit the .row-leading checkbox slot — that 18px column
-    // only carries weight in the Changes section (where it holds a real
-    // checkbox). Keeping it on plans rows just to vertically align with
-    // changes was over-alignment: the two sections are visually
-    // independent, so the empty slot read as "something missing".
+    // Selection checkbox — only for plan and note rows; Linear-issue rows
+    // are not user-selectable (no exclusion key applies) and get no checkbox.
+    // 'data-checkbox="1"' opts into the delegated click guard so clicking
+    // the checkbox does not also open the plan or note editor.
+    // For plans: 'data-plan-id' carries the plan slug (item.id = slug from
+    // PlansTreeProvider.serialize). For notes: 'data-note-id' carries the
+    // note id (item.id = note.id from the same serialize path).
+    let rowCheck = null;
+    if (isNote) {
+      const noteCb = el('input', {
+        type: 'checkbox',
+        className: 'jm-note-check',
+        'data-checkbox': '1',
+        'data-note-id': item.id,
+      });
+      noteCb.checked = !!item.isSelected;
+      rowCheck = noteCb;
+    } else if (!isLinearIssue) {
+      const planCb = el('input', {
+        type: 'checkbox',
+        className: 'jm-plan-check',
+        'data-checkbox': '1',
+        'data-plan-id': item.id,
+      });
+      planCb.checked = !!item.isSelected;
+      rowCheck = planCb;
+    }
+    // Wrap checkbox in .row-leading so plan/note rows share the same fixed
+    // 18px leading slot as Changes rows — column-aligns across sections.
+    // Linear-issue rows have no checkbox but still get an empty slot so they
+    // stay column-aligned with their sibling plan/note rows in the same list.
     const kids = [
       el('span', { className: 'twirl' }),
+      el('span', { className: 'row-leading' }, rowCheck ? [rowCheck] : []),
       el('span', { className: 'icon' }, [iconEl]),
       el('span', { className: 'label', text: item.label }),
     ];
@@ -2491,8 +2524,22 @@ export function buildSidebarScript(): string {
     // share an identical string (panel renders msg.title verbatim, no
     // re-derived fallback).
     const displayTitle = item.title || '(untitled)';
+    // Selection checkbox — wrapped in .row-leading after the twirl so it
+    // shares the same fixed 18px leading slot as Changes rows (column-
+    // aligned across sections). 'data-checkbox="1"' opts into the delegated
+    // click guard so clicking the checkbox does not also fire the row's
+    // open-conversation listener.
+    const convCb = el('input', {
+      type: 'checkbox',
+      className: 'jm-conv-check',
+      'data-checkbox': '1',
+      'data-source': item.source,
+      'data-session': item.sessionId,
+    });
+    convCb.checked = !!item.isSelected;
     const kids = [
       el('span', { className: 'twirl' }),
+      el('span', { className: 'row-leading' }, [convCb]),
       el('span', { className: 'icon' }, [
         el('i', { className: 'codicon codicon-comment-discussion' }),
       ]),
@@ -2513,7 +2560,12 @@ export function buildSidebarScript(): string {
       'data-source': item.source,
       title: displayTitle,
     }, kids);
-    root.addEventListener('click', function() {
+    root.addEventListener('click', function(e) {
+      // Guard: clicking the checkbox should not also open the conversation
+      // panel. 'data-checkbox="1"' is enough for the delegated click handler
+      // at the tabContents.branch level, but this direct listener fires on
+      // the same click event, so we need to bail out here too.
+      if (e.target && e.target.closest && e.target.closest('[data-checkbox="1"]')) return;
       // Belt-and-suspenders: the aggregator already filters rows with
       // messageCount === 0 (those would open a panel that just says
       // 'No conversation entries to display.'). If a future change
@@ -2748,8 +2800,13 @@ export function buildSidebarScript(): string {
       'data-id': item.id,
     }, kids);
     if (!expanded) return row;
+    // Children share the parent commit's depth (not depth + 1) so the
+    // file-row icon column-aligns with the commit row's leading M↓ /
+    // git-commit icon. The chevron on the commit row already signals the
+    // parent/child relationship, so an extra 20px indent on the file rows
+    // would just visually break the icon column without adding info.
     const fileRows = item.children.map(function(c) {
-      return renderCommitFileRow(c, depth + 1);
+      return renderCommitFileRow(c, depth);
     });
     return [row].concat(fileRows);
   }
@@ -2934,12 +2991,14 @@ export function buildSidebarScript(): string {
         return;
       }
       const cmdMap = {
-        'changes-select-all':  'jollimemory.selectAllFiles',
-        'changes-commit-ai':   'jollimemory.commitAI',
-        'changes-discard':     'jollimemory.discardSelectedChanges',
-        'commits-select-all':  'jollimemory.selectAllCommits',
-        'commits-squash':      'jollimemory.squash',
-        'commits-push-branch': 'jollimemory.pushBranch',
+        'changes-select-all':        'jollimemory.selectAllFiles',
+        'changes-commit-ai':         'jollimemory.commitAI',
+        'changes-discard':           'jollimemory.discardSelectedChanges',
+        'commits-select-all':        'jollimemory.selectAllCommits',
+        'commits-squash':            'jollimemory.squash',
+        'commits-push-branch':       'jollimemory.pushBranch',
+        'conversations-select-all':  'jollimemory.selectAllConversations',
+        'plans-select-all':          'jollimemory.selectAllPlansAndNotes',
       };
       if (cmdMap[a]) {
         vscode.postMessage({ type: 'command', command: cmdMap[a] });
@@ -3095,15 +3154,50 @@ export function buildSidebarScript(): string {
     }
   });
 
-  // Checkbox toggle — routed by data-checkbox-kind:
-  //   'commit' → branch:toggleCommitSelection (commits squash flow)
-  //   anything else (default 'file') → branch:toggleFileSelection (changes
-  //   discard / commit flow). The default-to-file fallback preserves the
-  //   original behaviour for renderChangeRow which doesn't set the kind.
+  // Checkbox toggle — routed by class name for conversation/plan/note rows,
+  // then by data-checkbox-kind for commit rows, and finally the default-to-file
+  // fallback for renderChangeRow (which does not set 'data-checkbox-kind').
+  //
+  // Conversation rows: 'jm-conv-check' class → branch:toggleConversationSelection
+  //   data-source + data-session identify the session uniquely across providers.
+  // Plan rows: 'jm-plan-check' class → branch:togglePlanSelection
+  //   data-plan-id carries the plan slug (same key as 'setExcluded' uses).
+  // Note rows: 'jm-note-check' class → branch:toggleNoteSelection
+  //   data-note-id carries the note id (same key as 'setExcluded' uses).
+  // Commit rows: data-checkbox-kind='commit' → branch:toggleCommitSelection
+  // File rows: everything else → branch:toggleFileSelection (default fallback)
   tabContents.branch.addEventListener('change', function(e) {
     const cb = e.target.closest('[data-checkbox="1"]');
     if (!cb) return;
     e.stopPropagation();
+    // Conversation checkbox — class 'jm-conv-check'
+    if (cb.classList.contains('jm-conv-check')) {
+      vscode.postMessage({
+        type: 'branch:toggleConversationSelection',
+        source: cb.getAttribute('data-source'),
+        sessionId: cb.getAttribute('data-session'),
+        selected: !!cb.checked,
+      });
+      return;
+    }
+    // Plan checkbox — class 'jm-plan-check'
+    if (cb.classList.contains('jm-plan-check')) {
+      vscode.postMessage({
+        type: 'branch:togglePlanSelection',
+        planId: cb.getAttribute('data-plan-id'),
+        selected: !!cb.checked,
+      });
+      return;
+    }
+    // Note checkbox — class 'jm-note-check'
+    if (cb.classList.contains('jm-note-check')) {
+      vscode.postMessage({
+        type: 'branch:toggleNoteSelection',
+        noteId: cb.getAttribute('data-note-id'),
+        selected: !!cb.checked,
+      });
+      return;
+    }
     const kind = cb.getAttribute('data-checkbox-kind') || 'file';
     if (kind === 'commit') {
       vscode.postMessage({

--- a/vscode/src/views/SidebarWebviewProvider.test.ts
+++ b/vscode/src/views/SidebarWebviewProvider.test.ts
@@ -1651,6 +1651,112 @@ describe("SidebarWebviewProvider", () => {
 		expect(applyCommitCheckbox).toHaveBeenCalledWith("abc1234", true);
 	});
 
+	it("dispatches branch:toggleConversationSelection to applyConversationCheckbox", () => {
+		const view = makeMockView();
+		const applyConversationCheckbox = vi.fn();
+		const provider = new SidebarWebviewProvider({
+			executeCommand: vi.fn(),
+			getInitialState: () => ({
+				enabled: true,
+				authenticated: false,
+				activeTab: "branch",
+				kbMode: "folders",
+				branchName: "main",
+				detached: false,
+			}),
+			extensionUri: mockExtensionUri as unknown as never,
+			applyConversationCheckbox,
+		});
+		provider.resolveWebviewView(view as unknown as never);
+		view.webview.triggerMessage({
+			type: "branch:toggleConversationSelection",
+			source: "claude",
+			sessionId: "abc",
+			selected: false,
+		});
+		expect(applyConversationCheckbox).toHaveBeenCalledWith(
+			"claude",
+			"abc",
+			false,
+		);
+	});
+
+	it("rejects branch:toggleConversationSelection with an unknown source", () => {
+		const view = makeMockView();
+		const applyConversationCheckbox = vi.fn();
+		const provider = new SidebarWebviewProvider({
+			executeCommand: vi.fn(),
+			getInitialState: () => ({
+				enabled: true,
+				authenticated: false,
+				activeTab: "branch",
+				kbMode: "folders",
+				branchName: "main",
+				detached: false,
+			}),
+			extensionUri: mockExtensionUri as unknown as never,
+			applyConversationCheckbox,
+		});
+		provider.resolveWebviewView(view as unknown as never);
+		view.webview.triggerMessage({
+			type: "branch:toggleConversationSelection",
+			source: "../../etc/passwd",
+			sessionId: "abc",
+			selected: false,
+		});
+		expect(applyConversationCheckbox).not.toHaveBeenCalled();
+	});
+
+	it("dispatches branch:togglePlanSelection to applyPlanCheckbox", () => {
+		const view = makeMockView();
+		const applyPlanCheckbox = vi.fn();
+		const provider = new SidebarWebviewProvider({
+			executeCommand: vi.fn(),
+			getInitialState: () => ({
+				enabled: true,
+				authenticated: false,
+				activeTab: "branch",
+				kbMode: "folders",
+				branchName: "main",
+				detached: false,
+			}),
+			extensionUri: mockExtensionUri as unknown as never,
+			applyPlanCheckbox,
+		});
+		provider.resolveWebviewView(view as unknown as never);
+		view.webview.triggerMessage({
+			type: "branch:togglePlanSelection",
+			planId: "plan-slug",
+			selected: false,
+		});
+		expect(applyPlanCheckbox).toHaveBeenCalledWith("plan-slug", false);
+	});
+
+	it("dispatches branch:toggleNoteSelection to applyNoteCheckbox", () => {
+		const view = makeMockView();
+		const applyNoteCheckbox = vi.fn();
+		const provider = new SidebarWebviewProvider({
+			executeCommand: vi.fn(),
+			getInitialState: () => ({
+				enabled: true,
+				authenticated: false,
+				activeTab: "branch",
+				kbMode: "folders",
+				branchName: "main",
+				detached: false,
+			}),
+			extensionUri: mockExtensionUri as unknown as never,
+			applyNoteCheckbox,
+		});
+		provider.resolveWebviewView(view as unknown as never);
+		view.webview.triggerMessage({
+			type: "branch:toggleNoteSelection",
+			noteId: "note-id",
+			selected: false,
+		});
+		expect(applyNoteCheckbox).toHaveBeenCalledWith("note-id", false);
+	});
+
 	// switch's `default` arm — message has a string `type` but it isn't one of
 	// the handled cases. Must not throw and must not invoke any side effects.
 	it("ignores unknown outbound message types via the switch default", () => {

--- a/vscode/src/views/SidebarWebviewProvider.ts
+++ b/vscode/src/views/SidebarWebviewProvider.ts
@@ -9,6 +9,7 @@
 
 import { randomBytes } from "node:crypto";
 import * as vscode from "vscode";
+import type { TranscriptSource } from "../../../cli/src/Types.js";
 import { isTranscriptSource } from "../../../cli/src/Types.js";
 import type { ActiveSessionsProvider } from "../services/ActiveSessionsProvider.js";
 import { log } from "../util/Logger.js";
@@ -123,6 +124,22 @@ export interface SidebarWebviewDeps {
 	applyFileCheckbox?: (filePath: string, selected: boolean) => void;
 	/** Toggle a single commit's selection state in CommitsStore. */
 	applyCommitCheckbox?: (hash: string, selected: boolean) => void;
+	/** Toggle a single conversation's selection state in ConversationsStore. */
+	applyConversationCheckbox?: (
+		source: TranscriptSource,
+		sessionId: string,
+		selected: boolean,
+	) => void | Promise<void>;
+	/** Toggle a single plan's selection state in PlansStore. */
+	applyPlanCheckbox?: (
+		planId: string,
+		selected: boolean,
+	) => void | Promise<void>;
+	/** Toggle a single note's selection state in NotesStore. */
+	applyNoteCheckbox?: (
+		noteId: string,
+		selected: boolean,
+	) => void | Promise<void>;
 	/**
 	 * Resolves once the host has finished its first-pass initial load — in
 	 * particular once `statusStore.refresh()` has run so `getInitialState()`
@@ -530,6 +547,27 @@ export class SidebarWebviewProvider
 			case "branch:toggleCommitSelection":
 				this.deps.applyCommitCheckbox?.(msg.hash, msg.selected);
 				return;
+			case "branch:toggleConversationSelection":
+				if (!isTranscriptSource(msg.source)) {
+					log.warn(
+						"SidebarWebviewProvider",
+						"Rejected branch:toggleConversationSelection with unknown source",
+						{ source: String(msg.source) },
+					);
+					return;
+				}
+				void this.deps.applyConversationCheckbox?.(
+					msg.source,
+					msg.sessionId,
+					msg.selected,
+				);
+				return;
+			case "branch:togglePlanSelection":
+				void this.deps.applyPlanCheckbox?.(msg.planId, msg.selected);
+				return;
+			case "branch:toggleNoteSelection":
+				void this.deps.applyNoteCheckbox?.(msg.noteId, msg.selected);
+				return;
 			case "refresh":
 				this.handleRefresh(msg.scope);
 				return;
@@ -869,6 +907,14 @@ export class SidebarWebviewProvider
 		} else {
 			void this.deps.executeCommand("vscode.open", vscode.Uri.file(abs));
 		}
+	}
+
+	public async refreshConversationsPanel(): Promise<void> {
+		await this.pushConversations();
+	}
+
+	public async refreshPlansPanel(): Promise<void> {
+		this.pushPlans();
 	}
 
 	dispose(): void {


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## Quick recap

The developer added per-item selection controls to the sidebar, allowing users to exclude specific conversations, plans, and notes from the next summary pipeline run without permanently hiding them. Exclusions now persist across commits, editor restarts, and rebases until the user explicitly re-checks the item or clicks Select All, keeping the user's intent always visible in the sidebar. Files default to selected by default, matching the new model of "include everything, opt out specific items," while the Commits panel remains unselected to reflect the higher stakes of history-rewriting operations.

The sidebar's checkbox columns are now visually aligned across all sections—Conversations, Plans & Notes, and Changes—through unified flex spacing and a consolidated checkbox styling system. The Select-All command now correctly toggles to the appropriate state when some items are selected and others are not, eliminating the previous polarity bug.

The developer also fixed two critical reliability issues. When the QueueWorker reads session databases at the moment the host application writes to them, the read now retries with exponential backoff instead of silently skipping the source, ensuring newly-checked conversations receive a cursor advance and disappear from the sidebar as expected. Additionally, file deselections now persist across refresh, preventing user-driven unchecks from silently re-selecting on the next update.

---

## E2E Test (8)
<details>
<summary><strong>1. Checkbox selection and deselection in sidebar</strong></summary>
<br>
<blockquote>

**Steps:**
1. Open the sidebar and locate the Conversations section.
2. Find a conversation row and click the checkbox to the left of its name to uncheck it.
3. Verify the checkbox is now unchecked and the row remains visible (not hidden).
4. Click the "Deselect All" button in the Conversations section header.
5. Verify all conversation checkboxes are now unchecked.
6. Click "Select All" and verify all checkboxes return to checked state.

**Expected Results:**
- Unchecked conversations remain visible in the sidebar with an empty checkbox.
- The "Select All" and "Deselect All" buttons toggle all checkboxes in their section.
- Checkboxes are aligned vertically with consistent spacing across Conversations, Plans & Notes, and Changes sections.

</blockquote>
</details>
<details>
<summary><strong>2. Excluded items do not appear in summary pipeline</strong></summary>
<br>
<blockquote>

**Steps:**
1. Open the sidebar and uncheck one conversation, one plan, and one note by clicking their checkboxes.
2. Trigger a summary commit (e.g., click "Generate Summary" or equivalent).
3. Wait for the pipeline to complete.
4. Review the generated summary output or commit message.

**Expected Results:**
- The unchecked conversation's transcript does not appear in the summary.
- The unchecked plan does not appear in the plans section of the summary.
- The unchecked note does not appear in the notes section of the summary.
- All checked items are included in the summary as normal.

</blockquote>
</details>
<details>
<summary><strong>3. Checkbox state persists across sidebar refresh</strong></summary>
<br>
<blockquote>

**Steps:**
1. Open the sidebar and uncheck two conversations by clicking their checkboxes.
2. Close and reopen the sidebar (or refresh the application).
3. Verify the two conversations are still unchecked.
4. Uncheck a plan and a note.
5. Refresh the application again.
6. Verify all four unchecked items remain unchecked.

**Expected Results:**
- Unchecked items retain their unchecked state after closing and reopening the sidebar.
- Unchecked items retain their state after application refresh.
- No manual re-selection is required.

</blockquote>
</details>
<details>
<summary><strong>4. Files default to selected and stay deselected after refresh</strong></summary>
<br>
<blockquote>

**Steps:**
1. Open the Files panel in the sidebar.
2. Verify all file checkboxes are checked by default.
3. Uncheck one or more files by clicking their checkboxes.
4. Close and reopen the Files panel (or refresh the application).
5. Verify the unchecked files remain unchecked.

**Expected Results:**
- All files appear selected (checked) when the Files panel first opens.
- Unchecked files persist their unchecked state across panel close/reopen and application refresh.

</blockquote>
</details>
<details>
<summary><strong>5. Retry on database lock during session discovery</strong></summary>
<br>
<blockquote>

**Steps:**
1. Open the application while the host editor (OpenCode, Cursor, or Copilot Chat) is actively writing to its session database.
2. Trigger a session discovery or summary pipeline run.
3. Wait for the pipeline to complete without errors.
4. Verify that all active conversations from the host editor appear in the sidebar.

**Expected Results:**
- The pipeline completes successfully even if the database was briefly locked.
- No conversations are silently dropped from the sidebar.
- Newly-checked conversations receive cursor advances and do not remain visible indefinitely.

</blockquote>
</details>
<details>
<summary><strong>6. Select-All correctly handles mixed selection state</strong></summary>
<br>
<blockquote>

**Steps:**
1. Open the sidebar and manually check some conversations and uncheck others (creating a mixed state).
2. Click the "Select All" button in the Conversations section header.
3. Verify all conversation checkboxes are now checked.
4. Uncheck some conversations again to create a mixed state.
5. Click "Deselect All".
6. Verify all conversation checkboxes are now unchecked.

**Expected Results:**
- "Select All" checks all items regardless of prior mixed state.
- "Deselect All" unchecks all items regardless of prior mixed state.
- No items are left in an inconsistent state.

</blockquote>
</details>
<details>
<summary><strong>7. Checkbox columns align across all sidebar sections</strong></summary>
<br>
<blockquote>

**Steps:**
1. Open the sidebar and view the Conversations, Plans & Notes, and Changes sections simultaneously (scroll if needed).
2. Examine the left edge of the checkboxes in each section.
3. Examine the left edge of the section header text (e.g., "Conversations", "Plans & Notes").
4. Verify visual alignment of checkbox columns and header text across sections.

**Expected Results:**
- All checkboxes in Conversations, Plans & Notes, and Changes sections have their left edges aligned vertically.
- Section header text starts at the same horizontal position across all sections.
- No inconsistent spacing or indentation between sections.

</blockquote>
</details>
<details>
<summary><strong>8. Excluded plans and notes are removed from archive</strong></summary>
<br>
<blockquote>

**Steps:**
1. Open the sidebar and uncheck one plan and one note.
2. Trigger a summary commit.
3. Wait for the pipeline to complete and the orphan branch to be updated.
4. Inspect the orphan branch or archive output (e.g., via git or file explorer).

**Expected Results:**
- The unchecked plan does not appear in the archived plans registry.
- The unchecked note does not appear in the archived notes.
- All checked plans and notes are archived normally.

</blockquote>
</details>

---

## Topics (12)
<details>
<summary><strong>01 · Filter excluded plans and notes on archive path in QueueWorker</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

User reported that unchecking a plan or note in the selection UI still resulted in both files being archived and disappearing from the panel. Diagnosis revealed that PR #125's exclusion filter was only applied to the LLM prompt path, not the archive path where plans/notes are actually written to the orphan branch.

**💡 Decisions Behind the Code**

Filter must be applied BEFORE the associate* calls, not after, because those functions have irreversible side effects (writing to plans.json registry and orphan branch files). A post-filter on the refs array would leave the excluded entries already archived on disk. The archive path uses `detectPlanSlugsFromRegistry` (registry view) while the prompt path uses `detectActivePlansForBranch` (branch view) — two independent scans with different return types and semantics — so they cannot share a single unified filter. The caller-side filter at this point is the minimal change that mirrors PR #125's approach and prevents future similar misses.

**✅ What Was Implemented**

Added pre-filtering of `planSlugs` and `noteIds` sets in `executePipeline` (QueueWorker.ts:1092-1104) before calling `associatePlansWithCommit` and `associateNotesWithCommit`. The filter removes excluded entries from the registry scan results before the side effects (savePlansRegistry + storePlans) occur. Added two regression tests in QueueWorker.selection.test.ts that verify excluded plans and notes are absent from the final summary.

**📋 Future Enhancements**

Design-level follow-up (separate PR): converge the two scan functions by adding an `exclusions` parameter to `detectActivePlansForBranch`, `detectPlanSlugsFromRegistry`, and their note equivalents, moving the filter logic into the scan functions themselves. This would prevent future archive-path filters from being forgotten when new scan callers are added (e.g., linearIssues currently also lacks exclusions filtering).

**📁 FILES**
- `cli/src/hooks/QueueWorker.ts`
- `cli/src/hooks/QueueWorker.selection.test.ts`

</blockquote>
</details>
<details>
<summary><strong>02 · Validate and document dual-scan architecture for plans and notes</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

During code review, multiple agents independently flagged that the prompt-path and archive-path scans for plans/notes use fundamentally different functions with different return types and semantics, making it easy to miss applying filters to one path or the other.

**💡 Decisions Behind the Code**

Rather than immediately refactoring to unify the scans (which would require changes to PlansStore's revived-guard write flow and plans.json schema), the decision was to document the architectural constraint clearly so future maintainers understand why two separate filters are necessary. This preserves the current design's correctness while making the reasoning explicit. A full unification (Option C in the conversation) was deferred as a follow-up because it would add 400+ LOC and impact the plans.json schema.

**✅ What Was Implemented**

Added detailed comments in QueueWorker.ts (lines 1092-1104) explaining why the archive path requires a separate filter: the two scans (`detectActivePlansForBranch` vs `detectPlanSlugsFromRegistry`) have different business semantics (prompt path excludes revived-guard entries to avoid duplication; archive path includes them to support re-archiving edited plans). Documented that this is a fundamental architectural difference, not a bug in the scan functions themselves.

**📋 Future Enhancements**

Follow-up PR to implement Option A: add `exclusions?: ReadonlySet<string>` parameter to all four detect functions (plans/notes × 2 each), moving filter logic into the scan layer. This prevents future callers from forgetting to apply exclusions.

**📁 FILES**
- `cli/src/hooks/QueueWorker.ts`

</blockquote>
</details>
<details>
<summary><strong>03 · Verify conversations exclusion filter does not have same dual-scan bug</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

After fixing the plans/notes dual-scan filter bug, user asked whether conversations had the same problem, since they also support exclusion filtering.

**💡 Decisions Behind the Code**

The conversations design is superior because it filters at the data-source level before any consumer reads it, making it impossible to miss a path. Plans/notes cannot use this pattern because the prompt path and archive path have conflicting semantic requirements (prompt must exclude revived-guard entries; archive must include them). The architectural difference was documented to explain why plans/notes needed a different fix strategy.

**✅ What Was Implemented**

Confirmed that conversations do NOT have this bug because they use a single-entry-point filter design: `loadSessionTranscripts` (QueueWorker.ts:1939-1942) filters before reading, and all downstream paths (LLM prompt, orphan branch archive, cursor advance) consume the same filtered `sessionTranscripts` array. This is architecturally different from plans/notes, which split into two independent scans with different data sources.

**📋 Future Enhancements**

None — conversations are correctly designed. The insight is useful for future feature design: prefer single-entry-point filtering over dual-scan filtering when possible.

**📁 FILES**
- `cli/src/hooks/QueueWorker.ts (analysis only`
- `no changes)`

</blockquote>
</details>
<details>
<summary><strong>04 · Clean up stale git worktrees and temporary review directories</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

User encountered git error "fix/external-plan-files is already used by worktree at /private/tmp/pr122-review" when trying to check out a branch, indicating orphaned worktree metadata and temporary directories from previous PR reviews.

**💡 Decisions Behind the Code**

Used `git worktree remove` instead of `rm -rf` to properly clean git metadata (`.git/worktrees/<id>/`), preventing "ghost" worktrees that would require `git worktree prune` to fully recover. Cleaned both jollimemory and jolli backend repos because they share /private/tmp as a review staging area, and leaving one repo's prunable worktrees behind would leave orphaned directories. Verified all directories were safe to delete (no uncommitted changes, no active work).

**✅ What Was Implemented**

Removed the active but unwanted worktree `/private/tmp/pr122-review` using `git worktree remove`. Ran `git worktree prune` to clean 8 prunable jollimemory worktrees and 4 prunable jolli backend worktrees. Deleted the corresponding 8 orphaned 68K directories in /private/tmp (jollimemory review remnants) and 4 empty 0B directories (jolli backend review remnants). Final state: 4 active jollimemory worktrees (main, pr116-review, feature-wt1, change-storage-to-folder) and 4 active jolli backend worktrees.

**📋 Future Enhancements**

Consider creating a shell alias or cleanup script that runs `git worktree prune` across all known repos and cleans /private/tmp/pr*-review directories in one command, to prevent future accumulation of review remnants.

**📁 FILES**
- `(no source files; git metadata and temporary directories only)`

</blockquote>
</details>
<details>
<summary><strong>05 · Per-item commit-time selection with sticky exclusions across sidebar</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Users needed a way to exclude specific conversations, plans, and notes from the next summary pipeline run without permanently hiding them. Previously, all active items were always included in the summary generation.

**💡 Decisions Behind the Code**

- **Sticky exclusion, never auto-cleared**: Exclusions persist across commits, amends, rebases, and editor restarts until the user explicitly re-checks or clicks Select All. This keeps the checkbox semantically distinct from permanent hide/ignore (which hide the row entirely) and makes the user's intent always visible in the sidebar. The trade-off is that a forgotten exclusion silently omits an item from every future summary; mitigation is the always-visible unchecked state and the one-click Select All escape valve.
- **Serialization via Promise chain over file-level locking**: An in-process per-directory queue serializes all writes to the exclusion file, preventing concurrent async calls from losing updates. File locks add I/O overhead and complexity without addressing the real bottleneck (concurrent async calls within one process). The queue is simpler, faster, and sufficient because the sidebar is single-threaded and only one process writes exclusions at a time. Failed writes are swallowed in the queue's bookkeeping and allow the next caller to proceed cleanly, preventing one bad projectDir from blocking all future writes.
- **Exclusion stored on disk for conversations/plans/notes, in-memory for files**: Conversations, plans, and notes exclusions are persisted to `commit-selection.json` so they survive editor restarts and are available to the post-commit QueueWorker. Files exclusions remain in-memory (within-session only) because file selection already gates the git index, a separate durable channel; persisting file unchecks across restarts is out of scope and would require translating between "this exact file in this exact state" and user intent.
- **Files default changed to selected, Commits default unchanged**: Files now default to selected (matching the new conversations/plans/notes model of "include everything, opt out specific items"), but Commits panel stays unselected because squash is a destructive history-rewrite operation with much higher stakes than summary input. The two panels serve different purposes: files/conversations/plans/notes are inputs to a generated artifact; commits are targets of a history-rewriting operation that requires conscious opt-in.
- **Filter before transcript read, not after**: Placing the exclusion check inside `loadSessionTranscripts` before `readAllTranscripts` is called ensures the truth source (cursor file) is never polluted by excluded sessions. This is more robust than filtering the results afterward, because any cursor advance is permanent and invisible to the sidebar until the next poll. The fix directly addresses the root cause rather than patching the symptom.

**✅ What Was Implemented**

- **CommitSelectionStore module** — new persistent store that reads and writes exclusion state to `.jolli/jollimemory/commit-selection.json`. Provides atomic read/write operations with three independent exclusion sets for conversations, plans, and notes. Tolerates missing or malformed files and uses atomic write-then-rename to prevent corruption. Includes an in-process serialization queue that ensures all writes to a project's exclusion file are serialized, preventing concurrent read-modify-write races and file collisions.
- **Sidebar UI checkboxes** — each conversation, plan, and note row now displays a leading checkbox. Unchecking marks that item as excluded in the persistent file. Section headers expose Select/Deselect All buttons that toggle between all-selected and all-deselected states. Files panel default changed from unselected to selected to align with the new model.
- **ActiveSessionAggregator integration** — added `isSelected` boolean field to each conversation row, populated from the exclusion store at startup. Rows absent from the exclusion file default to `isSelected: true`.
- **QueueWorker pipeline filtering** — the summary pipeline reads exclusions once at the start of `executePipeline` and filters out excluded conversations, plans, and notes before passing them to the LLM. The pipeline never writes to the exclusion file (read-only consumer). Exclusion filter runs before transcript reading to prevent cursor pollution on excluded sessions.
- **Input validation and concurrent safety** — the conversation selection handler now validates untrusted input the same way the conversation open handler does. All writes to the exclusion file are serialized through a per-directory Promise chain, preventing concurrent updates from losing data or causing file collisions.
- **Comprehensive test coverage** — 578-line test suite in `QueueWorker.selection.test.ts` exercises the full pipeline with real exclusion file reads. Additional tests in `CommitSelectionStore.test.ts` and `ActiveSessionAggregator.test.ts` verify round-trip persistence, edge cases (missing files, malformed JSON, stale keys), concurrent write safety, and independent per-kind storage. Achieved 100% code coverage across all dimensions.

**📁 FILES**
- `cli/src/core/CommitSelectionStore.ts`
- `cli/src/core/ActiveSessionAggregator.ts`
- `cli/src/hooks/QueueWorker.ts`
- `vscode/src/views/SidebarScriptBuilder.ts`
- `vscode/src/views/SidebarWebviewProvider.ts`

</blockquote>
</details>
<details>
<summary><strong>06 · Fix Select-All polarity bug and align checkbox columns across sections</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The Select-All command for conversations and plans was toggling to the wrong state when some items were selected and others were not. Additionally, checkbox and icon columns in the Conversations, Plans & Notes, and Changes sections were visually misaligned with inconsistent spacing.

**💡 Decisions Behind the Code**

- **Flex gap as a hidden alignment variable**: The root cause was that `.section-header` and `.tree-node` used different flex gap values (0 vs 4px), which silently shifted all downstream child elements. The fix treats flex gap as a global column-alignment constraint that must be synchronized across all containers in the same visual column, not as a local spacing detail.
- **Checkbox container unification**: Rather than maintaining two separate checkbox styling systems (`.row-leading` for Changes, `.jm-row-check` for Conversations/Plans/Notes), consolidating to a single `.row-leading` container reduces CSS rules, eliminates the mental model of "two different checkbox types," and makes future alignment changes affect all sections uniformly.
- **Depth vs depth+1 for file rows**: Commit file rows previously indented one extra level to visually separate them from their parent. Removing this indent trades a small amount of visual nesting depth for stronger column alignment and cleaner information hierarchy, since the chevron on the parent commit row already signals the parent-child relationship.

**✅ What Was Implemented**

- **Select-All polarity fix** — corrected the logic in `SelectAllSelection.ts` by changing the key variable from `allCurrentlyExcluded` to `allCurrentlySelected` and inverting the condition. Now when some items are selected and others are not (mixed state), the command correctly selects all remaining items instead of deselecting everything. Uses `isSelected !== false` rather than strict equality to treat undefined values (newly-added items never stamped into the exclusion store) as selected, preserving the default-selected product behavior.
- **Unified checkbox layout** — wrapped conversation, plan, and note checkboxes in a fixed-width `.row-leading` slot (18px) instead of inline `.jm-row-check` elements with margin. This mirrors the Changes section's existing checkbox container and ensures checkbox left edges align precisely with section header text.
- **Synchronized flex gap across sections** — modified `.section-header` CSS to add `gap: 4px`, matching the base `.tree-node` flex gap so section titles and row checkboxes now start at the same x-coordinate (24px from the left edge). Changed `.row-leading` from `justify-content: center` to `justify-content: flex-start` to eliminate the ~2.5px offset that centering introduced.
- **Fixed conversation row metadata spacing** — moved the 8px breathing room from a row-level `gap: 8px` override to per-element `margin-left: 4px` on badges, counts, and timestamps. This preserves visual spacing around metadata chips while keeping the base row gap at 4px for column alignment.
- **Corrected commit file row indentation** — updated commit file rows to use the parent commit's depth instead of depth+1, so file icons align vertically with their parent commit's icon column rather than indenting an extra 20px.

**📁 FILES**
- `vscode/src/commands/SelectAllSelection.ts`
- `vscode/src/views/SidebarCssBuilder.ts`

</blockquote>
</details>
<details>
<summary><strong>07 · Fix SQLite locked database errors during session discovery with exponential retry</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

When the QueueWorker tried to read session databases at the exact moment the host application was writing to them, the read would fail with a "database is locked" error. The worker would silently skip that entire source, causing newly-checked conversations to never get a cursor advance and remain visible in the sidebar forever.

**💡 Decisions Behind the Code**

- **Retry at the shared entry point**: Placing retry logic in `withSqliteDb` rather than in each individual discoverer ensures consistent behavior across all sources and eliminates code duplication. The retry is transparent to callers and requires no interface changes.
- **Exponential backoff with short base delay**: A 150ms base delay with 2^attempt multiplier balances responsiveness against the typical millisecond-scale write transactions that cause the lock. Longer delays would slow down legitimate errors; shorter delays would require more retries for transient locks.
- **Only retry locked errors**: Errors like database corruption or permission denial are persistent and will fail on every retry. Distinguishing locked errors (transient, recoverable) from other errors (persistent, unrecoverable) via the existing `classifyScanError` classifier prevents wasted retry attempts and preserves fast failure for real problems.

**✅ What Was Implemented**

- **Exponential retry logic in withSqliteDb** — added automatic retry mechanism to `SqliteHelpers.ts` that retries up to 3 times with 150ms base delay and exponential backoff (150ms, 300ms, 600ms) when a read attempt fails with a locked error. Non-locked errors (corruption, permission, schema) are rethrown immediately without retry. This single change automatically benefits all four SQLite-backed sources: OpenCode, Cursor, Copilot Chat, and Copilot.
- **Test coverage** — added three new test cases to SqliteHelpers.test.ts covering locked retry success, non-locked error passthrough, and maxAttempts exhaustion. All tests use zero-delay injection to avoid timing dependencies.

**📁 FILES**
- `cli/src/core/SqliteHelpers.ts`

</blockquote>
</details>
<details>
<summary><strong>08 · Fix file deselection persistence across refresh after default-select flip</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

When the default-select behavior was flipped to seed all newly-seen files as selected, the FilesStore.deselectPaths() method was not recording deselected paths in the negative memory, causing user-driven unchecks to silently re-select on the next refresh.

**💡 Decisions Behind the Code**

Deselection is treated as a form of negative memory that must survive refresh, just like the existing unselectedPaths mechanism. Rather than special-casing the deselectPaths() call, the solution integrates it into the same exclusion-tracking system that already handles user-driven unchecks. This keeps the mental model consistent: any path removed from selection is recorded so the default-select loop will not resurrect it.

**✅ What Was Implemented**

- **FilesStore.deselectPaths() now records negative memory** — updated the method to record each deselected path in the unselectedPaths set alongside removing it from selectedPaths. This ensures that when refresh() runs its default-select loop, it skips paths the user has explicitly unchecked, preserving the deselection across refreshes.
- **Test suite updated** — six failing tests in FilesTreeProvider.test.ts were updated to reflect the new default-select-all behavior. Tests now uncheck specific files to exercise the negative memory path and verify they stay unchecked after refresh.

**📁 FILES**
- `vscode/src/stores/FilesStore.ts`

</blockquote>
</details>
<details>
<summary><strong>09 · Reduce log noise from periodic conversation list polling</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The sidebar refreshes the conversation list every minute, and each refresh was logging "Discovered N sessions" messages from five different session discoverers. This produced a steady stream of routine log output that obscured real errors and made debugging harder.

**💡 Decisions Behind the Code**

- **Downgrade successful discovery logs to debug**: Successful discovery is the happy path and occurs every minute. Logging it at info level creates noise that drowns out actual problems. Debug level preserves the information for troubleshooting while keeping the default log stream clean.
- **Deduplicate repeated errors in the provider**: Rather than silencing errors entirely, deduplication ensures that a persistent error is logged once (alerting the user) but not repeated every minute (avoiding spam). Recovery is tracked by successful polls, so transient failures followed by recovery remain visible.

**✅ What Was Implemented**

- **Downgrade discovery logs to debug level** — changed "Discovered N session(s)" log messages from info to debug level in all five discoverers: OpenCodeSessionDiscoverer.ts, CursorSessionDiscoverer.ts, CopilotSessionDiscoverer.ts, CopilotChatSessionDiscoverer.ts, and CodexSessionDiscoverer.ts. These messages now only appear when debug logging is explicitly enabled.
- **Deduplicate repeated errors in ActiveSessionsProvider** — modified the provider to track the last aggregator failure message and only log a warning if the message changes. Once the aggregator recovers (returns successfully), the failure state resets so the same error will be logged again if it recurs.

**📁 FILES**
- `cli/src/core/OpenCodeSessionDiscoverer.ts`
- `vscode/src/services/ActiveSessionsProvider.ts`

</blockquote>
</details>
<details>
<summary><strong>10 · Design per-item commit selection specification</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Users had no way to exclude specific conversations, plans, or notes from a commit's summary without permanently hiding or ignoring them. The sidebar included all active items by default with no per-commit opt-out mechanism.

**💡 Decisions Behind the Code**

The design separates exclusion state from permanent hide/ignore semantics by storing it in a dedicated file rather than embedding it in existing registries. This allows users to toggle exclusions on and off without side effects, and the state survives commits, amends, rebases, and restarts until explicitly cleared.

**✅ What Was Implemented**

Created a comprehensive design specification (`docs/superpowers/specs/2026-05-19-commit-item-selection-design.md`) defining a checkbox-based selection model for conversations, plans, notes, and files. The spec covers semantics (default selected, sticky exclusion), storage (on-disk `commit-selection.json` for conversations/plans/notes; in-memory for files), wire protocol (new outbound messages for per-row toggles; reuse of existing icon-button command channel for Select/Deselect All), and pipeline integration (read exclusions at the start of `runSummaryPipeline`, filter candidates, never write back). Defined the new `CommitSelectionStore` module with atomic read/write operations using tmp+rename atomicity, matching the existing `HiddenConversationsStore` pattern.

**📁 FILES**
- `docs/superpowers/specs/2026-05-19-commit-item-selection-design.md`

</blockquote>
</details>
<details>
<summary><strong>11 · Implementation plan for per-item commit selection feature</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The team completed a design specification for allowing users to selectively exclude conversations, plans, and notes from the next commit summary. An implementation plan was needed to guide the development work across both the CLI and VSCode extension layers.

**💡 Decisions Behind the Code**

- **Sticky exclusion semantics over auto-clear**: The exclusion file is never cleared by git operations, pipeline outcomes, or editor lifecycle events. Users must explicitly re-check a row or use the section button to include it again. This preserves user intent across multiple commits and prevents surprise re-inclusion of items they intentionally filtered out.
- **Read-only pipeline**: The `QueueWorker` reads the exclusion store but never writes it. This keeps the pipeline deterministic and prevents side effects; only the webview (user interaction) modifies the file. The separation of concerns makes the pipeline testable and auditable.
- **Deferred verification to final integration task**: Consolidating all testing, linting, and the single final commit into task 11 reduces context switching and allows developers to focus on code correctness without interruption. Running all tests together at the end also catches integration issues that might not surface in isolated task-by-task runs.

**✅ What Was Implemented**

Created a comprehensive 1592-line implementation plan at `docs/superpowers/plans/2026-05-19-commit-item-selection.md` that breaks the feature into 11 concrete tasks with step-by-step instructions. The plan specifies a new `CommitSelectionStore` module in the CLI that persists exclusions to a sticky `commit-selection.json` file, integration into `ActiveSessionAggregator` to stamp an `isSelected` boolean field on each conversation row, pipeline filtering in `QueueWorker.runSummaryPipeline` to skip excluded items before passing data to the LLM, and VSCode webview changes to add per-row checkboxes and section-level "Select All / Deselect All" buttons. Each task includes failing test scaffolding, implementation guidance, and commit instructions following the project's DCO sign-off and no-Claude-attribution conventions. All testing, linting, and committing was consolidated into a single final integration task to reduce cognitive overhead and produce a cleaner final commit history.

**📁 FILES**
- `docs/superpowers/plans/2026-05-19-commit-item-selection.md`

</blockquote>
</details>
<details>
<summary><strong>12 · Update release notes for per-item selection feature</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The per-item selection feature was ready to ship but the changelog entries were still marked as "Unreleased" and needed to be finalized for the 0.99.2 release.

**💡 Decisions Behind the Code**

The changelog entries emphasize user-visible behavior (checkboxes, stickiness, section buttons) rather than implementation details. They clarify that exclusions are independent of the existing hide feature and that the file list default changed to match the new per-item selection paradigm.

**✅ What Was Implemented**

Moved the per-item selection feature description from the "Unreleased" section to the 0.99.2 release notes in both CLI and VS Code changelogs. Rewrote the VS Code entry to emphasize the sticky exclusion behavior and the Select/Deselect All shortcuts, and clarified that only the default file selection flips (per-file checkbox behavior is unchanged). Added entry to `cli/CHANGELOG.md` describing per-item commit selection: every active conversation, plan, and note row now has a leading checkbox; unchecking excludes that item from the next summary pipeline run. Exclusion is sticky across commits, amends, rebases, and restarts until re-checked.

**📁 FILES**
- `cli/CHANGELOG.md`
- `vscode/CHANGELOG.md`

</blockquote>
</details>

---

*Generated by Jolli Memory · May 20, 2026 at 2:23 PM*
<!-- jollimemory-summary-end -->