### PR TITLE
Add opt-in DCO sign-off toggle for plugin commits

### DIFF
--- a/cli/src/Types.ts
+++ b/cli/src/Types.ts
@@ -738,6 +738,13 @@ export interface JolliMemoryConfig {
 	 * Anthropic otherwise) so existing configs keep working.
 	 */
 	readonly aiProvider?: "anthropic" | "jolli";
+	/**
+	 * When true, plugin-initiated `git commit` / `--amend` / squash invocations
+	 * pass `-s` to add a DCO `Signed-off-by:` trailer. Off by default. Read at
+	 * each commit site; not cached. The `-s` flag is idempotent — git skips
+	 * the trailer if an identical line already exists in the message.
+	 */
+	readonly dcoSignoff?: boolean;
 }
 
 /** Result of enable/disable operations */

--- a/vscode/src/JolliMemoryBridge.test.ts
+++ b/vscode/src/JolliMemoryBridge.test.ts
@@ -1677,6 +1677,27 @@ describe("JolliMemoryBridge", () => {
 			expect(savePluginSource).toHaveBeenCalledWith(TEST_CWD);
 			expect(hash).toBe("abc123def456");
 		});
+
+		it("omits -s when dcoSignoff is false (default)", async () => {
+			mockExecFileSuccess(""); // commit
+			mockExecFileSuccess("abc\n"); // rev-parse
+
+			await makeBridge().commit("feat: x");
+
+			const args = execFileMock.mock.calls[0]?.[1] as ReadonlyArray<string>;
+			expect(args).toEqual(["commit", "-m", "feat: x"]);
+		});
+
+		it("inserts -s into commit args when dcoSignoff is true", async () => {
+			loadConfig.mockResolvedValue({ dcoSignoff: true });
+			mockExecFileSuccess(""); // commit
+			mockExecFileSuccess("abc\n"); // rev-parse
+
+			await makeBridge().commit("feat: x");
+
+			const args = execFileMock.mock.calls[0]?.[1] as ReadonlyArray<string>;
+			expect(args).toEqual(["commit", "-s", "-m", "feat: x"]);
+		});
 	});
 
 	// ── amendCommit ──────────────────────────────────────────────────────
@@ -1697,6 +1718,29 @@ describe("JolliMemoryBridge", () => {
 			// amend-pending.json is no longer written — post-rewrite handles amend detection
 			expect(hash).toBe("newHash456");
 		});
+
+		it("omits -s when dcoSignoff is false (default)", async () => {
+			mockExecFileSuccess("old\n");
+			mockExecFileSuccess(""); // amend
+			mockExecFileSuccess("new\n");
+
+			await makeBridge().amendCommit("fix: x");
+
+			const args = execFileMock.mock.calls[1]?.[1] as ReadonlyArray<string>;
+			expect(args).toEqual(["commit", "--amend", "-m", "fix: x"]);
+		});
+
+		it("inserts -s into amend args when dcoSignoff is true", async () => {
+			loadConfig.mockResolvedValue({ dcoSignoff: true });
+			mockExecFileSuccess("old\n");
+			mockExecFileSuccess(""); // amend
+			mockExecFileSuccess("new\n");
+
+			await makeBridge().amendCommit("fix: x");
+
+			const args = execFileMock.mock.calls[1]?.[1] as ReadonlyArray<string>;
+			expect(args).toEqual(["commit", "--amend", "-s", "-m", "fix: x"]);
+		});
 	});
 
 	// ── amendCommitNoEdit ───────────────────────────────────────────────
@@ -1716,6 +1760,29 @@ describe("JolliMemoryBridge", () => {
 			expect(savePluginSource).toHaveBeenCalledWith(TEST_CWD);
 			// amend-pending.json is no longer written — post-rewrite handles amend detection
 			expect(hash).toBe("newHash456");
+		});
+
+		it("omits -s when dcoSignoff is false (default)", async () => {
+			mockExecFileSuccess("old\n");
+			mockExecFileSuccess(""); // amend --no-edit
+			mockExecFileSuccess("new\n");
+
+			await makeBridge().amendCommitNoEdit();
+
+			const args = execFileMock.mock.calls[1]?.[1] as ReadonlyArray<string>;
+			expect(args).toEqual(["commit", "--amend", "--no-edit"]);
+		});
+
+		it("inserts -s into amend --no-edit args when dcoSignoff is true", async () => {
+			loadConfig.mockResolvedValue({ dcoSignoff: true });
+			mockExecFileSuccess("old\n");
+			mockExecFileSuccess(""); // amend --no-edit
+			mockExecFileSuccess("new\n");
+
+			await makeBridge().amendCommitNoEdit();
+
+			const args = execFileMock.mock.calls[1]?.[1] as ReadonlyArray<string>;
+			expect(args).toEqual(["commit", "--amend", "-s", "--no-edit"]);
 		});
 	});
 
@@ -1950,6 +2017,35 @@ describe("JolliMemoryBridge", () => {
 
 			expect(hash).toBe("newSquashHash");
 			expect(saveSquashPending).toHaveBeenCalledWith([], "forkPoint", TEST_CWD);
+		});
+
+		it("omits -s on the squash commit when dcoSignoff is false (default)", async () => {
+			mockExecFileSuccess("headBefore\n");
+			mockExecFileSuccess("forkPoint\n");
+			mockExecFileSuccess(""); // reset --soft
+			mockExecFileSuccess(""); // commit
+			mockExecFileSuccess("newSquashHash\n");
+
+			await makeBridge().squashCommits(["oldest", "newest"], "msg");
+
+			const commitArgs = execFileMock.mock
+				.calls[3]?.[1] as ReadonlyArray<string>;
+			expect(commitArgs).toEqual(["commit", "-m", "msg"]);
+		});
+
+		it("inserts -s into the squash commit args when dcoSignoff is true", async () => {
+			loadConfig.mockResolvedValue({ dcoSignoff: true });
+			mockExecFileSuccess("headBefore\n");
+			mockExecFileSuccess("forkPoint\n");
+			mockExecFileSuccess(""); // reset --soft
+			mockExecFileSuccess(""); // commit
+			mockExecFileSuccess("newSquashHash\n");
+
+			await makeBridge().squashCommits(["oldest", "newest"], "msg");
+
+			const commitArgs = execFileMock.mock
+				.calls[3]?.[1] as ReadonlyArray<string>;
+			expect(commitArgs).toEqual(["commit", "-s", "-m", "msg"]);
 		});
 	});
 

--- a/vscode/src/JolliMemoryBridge.ts
+++ b/vscode/src/JolliMemoryBridge.ts
@@ -731,11 +731,22 @@ export class JolliMemoryBridge {
 
 	// ── Commit operations ─────────────────────────────────────────────────
 
+	/**
+	 * Returns `["-s"]` when the user has enabled DCO sign-off in settings,
+	 * otherwise `[]`. Read on each call so a settings flip takes effect
+	 * immediately without an extension reload.
+	 */
+	private async signoffArgs(): Promise<Array<string>> {
+		const cfg = await loadConfig();
+		return cfg.dcoSignoff ? ["-s"] : [];
+	}
+
 	/** Creates a new commit with the given message. Returns the new commit hash. */
 	async commit(message: string): Promise<string> {
 		log.info("bridge", "commit()", { message });
 		await savePluginSource(this.cwd);
-		await execGit(["commit", "-m", message], this.cwd);
+		const signoff = await this.signoffArgs();
+		await execGit(["commit", ...signoff, "-m", message], this.cwd);
 		const hash = await this.getHEADHash();
 		log.info("bridge", `Commit created: ${hash}`);
 		return hash;
@@ -752,7 +763,8 @@ export class JolliMemoryBridge {
 		// Amend detection is handled by post-rewrite(amend) which enqueues the operation
 		// with the old→new hash mapping from git's stdin.
 		await savePluginSource(this.cwd);
-		await execGit(["commit", "--amend", "-m", message], this.cwd);
+		const signoff = await this.signoffArgs();
+		await execGit(["commit", "--amend", ...signoff, "-m", message], this.cwd);
 		const hash = await this.getHEADHash();
 		log.info("bridge", "Amend created", {
 			headBeforeAmend: shortHash(headBeforeAmend),
@@ -768,7 +780,8 @@ export class JolliMemoryBridge {
 			headBeforeAmend: shortHash(headBeforeAmend),
 		});
 		await savePluginSource(this.cwd);
-		await execGit(["commit", "--amend", "--no-edit"], this.cwd);
+		const signoff = await this.signoffArgs();
+		await execGit(["commit", "--amend", ...signoff, "--no-edit"], this.cwd);
 		const hash = await this.getHEADHash();
 		log.info("bridge", "Amend (no-edit) created", {
 			headBeforeAmend: shortHash(headBeforeAmend),
@@ -1254,7 +1267,8 @@ export class JolliMemoryBridge {
 		log.debug("bridge", "git reset --soft complete");
 
 		// Step 4: create the squash commit
-		await execGit(["commit", "-m", message], this.cwd);
+		const signoff = await this.signoffArgs();
+		await execGit(["commit", ...signoff, "-m", message], this.cwd);
 		const newHash = await this.getHEADHash();
 		log.info("bridge", "Squash commit created", {
 			headBeforeSquash: shortHash(headBeforeSquash),

--- a/vscode/src/views/SettingsHtmlBuilder.test.ts
+++ b/vscode/src/views/SettingsHtmlBuilder.test.ts
@@ -169,6 +169,13 @@ describe("SettingsHtmlBuilder", () => {
 		expect(html).not.toContain("Pause Jolli Memory");
 	});
 
+	it("Others tab contains the DCO sign-off toggle", () => {
+		expect(html).toContain('id="dcoSignoff"');
+		expect(html).toContain("Sign commits with DCO");
+		// Hint references the trailer added by `-s`.
+		expect(html).toContain("Signed-off-by");
+	});
+
 	// ── Action bar / shared ──
 
 	it("contains Apply Changes button", () => {

--- a/vscode/src/views/SettingsHtmlBuilder.ts
+++ b/vscode/src/views/SettingsHtmlBuilder.ts
@@ -182,11 +182,21 @@ export function buildSettingsHtml(nonce: string): string {
 
     <!-- ── Tab 5: Others ── -->
     <section class="tab-panel hidden" data-panel="others" role="tabpanel">
-      <p class="section-hint">Hide files from the Changes panel and AI commits.</p>
+      <div class="toggle-row">
+        <label class="settings-label" for="dcoSignoff">
+          Sign commits with DCO
+          <span class="hint">Adds a <code>Signed-off-by</code> trailer (<code>git commit -s</code>) to commits made by Jolli Memory (commit / amend / squash). Required by many open-source projects' CI.</span>
+        </label>
+        <label class="toggle-switch">
+          <input type="checkbox" id="dcoSignoff" />
+          <span class="toggle-slider"></span>
+        </label>
+      </div>
+
       <div class="settings-row column">
         <label class="settings-label" for="excludePatterns">
-          Patterns
-          <span class="hint">Comma-separated globs, e.g. **/*.vsix, dist/**, node_modules/*</span>
+          Exclude Patterns
+          <span class="hint">Hide files from the Changes panel and AI commits. Comma-separated globs, e.g. <code>**/*.vsix</code>, <code>dist/**</code>, <code>node_modules/*</code>.</span>
         </label>
         <input type="text" id="excludePatterns" placeholder="**/*.vsix, docs/*.md" spellcheck="false" />
       </div>

--- a/vscode/src/views/SettingsScriptBuilder.test.ts
+++ b/vscode/src/views/SettingsScriptBuilder.test.ts
@@ -92,6 +92,28 @@ describe("SettingsScriptBuilder", () => {
 		);
 	});
 
+	// ── DCO sign-off toggle ──
+
+	it("references the dcoSignoff DOM input", () => {
+		expect(script).toContain("getElementById('dcoSignoff')");
+	});
+
+	it("ships dcoSignoff in the save payload", () => {
+		expect(script).toContain("dcoSignoff: dcoSignoffInput.checked");
+	});
+
+	it("loads dcoSignoff from host message and coerces to boolean", () => {
+		expect(script).toContain(
+			"dcoSignoffInput.checked = !!msg.settings.dcoSignoff",
+		);
+	});
+
+	it("includes dcoSignoff in dirty tracking", () => {
+		expect(script).toContain(
+			"dcoSignoffInput.checked !== initialState.dcoSignoff",
+		);
+	});
+
 	// ── Tab switching ──
 
 	it("wires .tab-button clicks to .tab-active toggle and panel show/hide", () => {

--- a/vscode/src/views/SettingsScriptBuilder.ts
+++ b/vscode/src/views/SettingsScriptBuilder.ts
@@ -42,6 +42,7 @@ export function buildSettingsScript(): string {
   const rebuildKbBtn = document.getElementById('rebuildKbBtn');
   const rebuildKbStatus = document.getElementById('rebuildKbStatus');
   const excludePatternsInput = document.getElementById('excludePatterns');
+  const dcoSignoffInput = document.getElementById('dcoSignoff');
   const applyBtn = document.getElementById('applyBtn');
   const saveFeedback = document.getElementById('saveFeedback');
   const anthropicMissingWarn = document.getElementById('anthropicMissingWarn');
@@ -311,6 +312,7 @@ export function buildSettingsScript(): string {
       copilotEnabled: copilotEnabledInput.checked,
       localFolder: localFolderInput.value,
       excludePatterns: excludePatternsInput.value,
+      dcoSignoff: dcoSignoffInput.checked,
     };
     checkDirty();
   }
@@ -329,7 +331,8 @@ export function buildSettingsScript(): string {
       cursorEnabledInput.checked !== initialState.cursorEnabled ||
       copilotEnabledInput.checked !== initialState.copilotEnabled ||
       localFolderInput.value !== initialState.localFolder ||
-      excludePatternsInput.value !== initialState.excludePatterns
+      excludePatternsInput.value !== initialState.excludePatterns ||
+      dcoSignoffInput.checked !== initialState.dcoSignoff
     );
     updateApplyBtn();
   }
@@ -388,6 +391,7 @@ export function buildSettingsScript(): string {
   [claudeEnabledInput, codexEnabledInput, geminiEnabledInput, openCodeEnabledInput, cursorEnabledInput, copilotEnabledInput].forEach(function(input) {
     input.addEventListener('change', function() { validateAll(); checkDirty(); clearSaveFeedback(); });
   });
+  dcoSignoffInput.addEventListener('change', function() { checkDirty(); clearSaveFeedback(); });
 
   // ── Apply Changes ──
   // Returns true if the apply message was posted, false if a validation error
@@ -420,6 +424,7 @@ export function buildSettingsScript(): string {
         copilotEnabled: copilotEnabledInput.checked,
         localFolder: localFolderInput.value.trim(),
         excludePatterns: excludePatternsInput.value,
+        dcoSignoff: dcoSignoffInput.checked,
       },
       maskedApiKey: maskedApiKey,
       maskedJolliApiKey: maskedJolliApiKey,
@@ -472,6 +477,7 @@ export function buildSettingsScript(): string {
         copilotEnabledInput.checked = msg.settings.copilotEnabled;
         localFolderInput.value = msg.settings.localFolder || '';
         excludePatternsInput.value = msg.settings.excludePatterns;
+        dcoSignoffInput.checked = !!msg.settings.dcoSignoff;
         maskedApiKey = msg.maskedApiKey;
         maskedJolliApiKey = msg.maskedJolliApiKey;
         // Clear all validation errors on fresh load

--- a/vscode/src/views/SettingsWebviewPanel.test.ts
+++ b/vscode/src/views/SettingsWebviewPanel.test.ts
@@ -316,6 +316,57 @@ describe("SettingsWebviewPanel", () => {
 			);
 		});
 
+		it("forwards dcoSignoff: true to settingsLoaded when set on disk", async () => {
+			mockLoadConfigFromDir.mockResolvedValue({
+				apiKey: undefined,
+				model: "sonnet",
+				maxTokens: null,
+				jolliApiKey: undefined,
+				claudeEnabled: true,
+				codexEnabled: true,
+				geminiEnabled: true,
+				excludePatterns: [],
+				dcoSignoff: true,
+			});
+
+			await SettingsWebviewPanel.show(extensionUri, workspaceRoot);
+			const dispatch = captureMessageHandler();
+			dispatch({ command: "loadSettings" });
+			await flushPromises();
+
+			expect(postMessage).toHaveBeenCalledWith(
+				expect.objectContaining({
+					command: "settingsLoaded",
+					settings: expect.objectContaining({ dcoSignoff: true }),
+				}),
+			);
+		});
+
+		it("defaults dcoSignoff to false when absent from config", async () => {
+			mockLoadConfigFromDir.mockResolvedValue({
+				apiKey: undefined,
+				model: "sonnet",
+				maxTokens: null,
+				jolliApiKey: undefined,
+				claudeEnabled: true,
+				codexEnabled: true,
+				geminiEnabled: true,
+				excludePatterns: [],
+			});
+
+			await SettingsWebviewPanel.show(extensionUri, workspaceRoot);
+			const dispatch = captureMessageHandler();
+			dispatch({ command: "loadSettings" });
+			await flushPromises();
+
+			expect(postMessage).toHaveBeenCalledWith(
+				expect.objectContaining({
+					command: "settingsLoaded",
+					settings: expect.objectContaining({ dcoSignoff: false }),
+				}),
+			);
+		});
+
 		it("returns short key without known prefix as-is", async () => {
 			mockLoadConfigFromDir.mockResolvedValue({
 				apiKey: "shortkey",
@@ -725,6 +776,60 @@ describe("SettingsWebviewPanel", () => {
 
 			expect(mockSaveConfigScoped).toHaveBeenCalledWith(
 				expect.objectContaining({ excludePatterns: undefined }),
+				expect.any(String),
+			);
+		});
+
+		it("saves dcoSignoff: true when toggle is on", async () => {
+			const dispatch = await setupWithLoadedConfig();
+
+			dispatch({
+				command: "applySettings",
+				maskedApiKey: "",
+				maskedJolliApiKey: "",
+				settings: {
+					apiKey: "",
+					model: "sonnet",
+					maxTokens: null,
+					jolliApiKey: "",
+					claudeEnabled: true,
+					codexEnabled: true,
+					geminiEnabled: true,
+					excludePatterns: "",
+					dcoSignoff: true,
+				},
+			});
+			await flushPromises();
+
+			expect(mockSaveConfigScoped).toHaveBeenCalledWith(
+				expect.objectContaining({ dcoSignoff: true }),
+				expect.any(String),
+			);
+		});
+
+		it("omits dcoSignoff (undefined) when toggle is off", async () => {
+			const dispatch = await setupWithLoadedConfig();
+
+			dispatch({
+				command: "applySettings",
+				maskedApiKey: "",
+				maskedJolliApiKey: "",
+				settings: {
+					apiKey: "",
+					model: "sonnet",
+					maxTokens: null,
+					jolliApiKey: "",
+					claudeEnabled: true,
+					codexEnabled: true,
+					geminiEnabled: true,
+					excludePatterns: "",
+					dcoSignoff: false,
+				},
+			});
+			await flushPromises();
+
+			expect(mockSaveConfigScoped).toHaveBeenCalledWith(
+				expect.objectContaining({ dcoSignoff: undefined }),
 				expect.any(String),
 			);
 		});

--- a/vscode/src/views/SettingsWebviewPanel.ts
+++ b/vscode/src/views/SettingsWebviewPanel.ts
@@ -54,6 +54,7 @@ interface SettingsPayload {
 	readonly copilotEnabled: boolean;
 	readonly localFolder: string;
 	readonly excludePatterns: string;
+	readonly dcoSignoff: boolean;
 }
 
 interface HookSyncFailure {
@@ -368,6 +369,7 @@ export class SettingsWebviewPanel {
 			excludePatterns: config.excludePatterns
 				? config.excludePatterns.join(", ")
 				: "",
+			dcoSignoff: config.dcoSignoff === true,
 		};
 
 		const signedIn = this.authService?.isSignedIn(config) ?? false;
@@ -469,6 +471,7 @@ export class SettingsWebviewPanel {
 					? settings.localFolder
 					: undefined,
 			excludePatterns: excludePatterns.length > 0 ? excludePatterns : undefined,
+			dcoSignoff: settings.dcoSignoff ? true : undefined,
 		};
 
 		const repoRoot = await getProjectRootDir(this.workspaceRoot);


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## Quick recap

Contributors can now opt in to having a Developer Certificate of Origin sign-off line automatically appended to every commit the plugin makes on their behalf. The toggle lives in the Others tab of the Settings panel, defaults to off, and takes effect on the very next commit after being enabled — no extension reload required. All four commit operations the plugin performs are covered: initial commits, amendments, no-edit amendments, and squashes.

The setting is stored machine-wide in the shared config file. When the toggle is off, the key is omitted from the file entirely, so existing setups are untouched and no migration is needed for users who never enable the feature. A post-implementation code review identified a subtle edge case where a malformed stored value could silently enable sign-off even with the toggle appearing disabled in the UI; a stricter equality check is documented as a follow-up fix. IntelliJ support was intentionally left out of this batch and is tracked as a separate task for a teammate, with the design document providing a reference for the changes needed on that side.

---

## E2E Test (3)
<details>
<summary><strong>1. DCO sign-off toggle appears in Settings</strong></summary>
<br>
<blockquote>

**Steps:**
1. Open the Jolli Memory extension in VS Code and click the settings (gear) icon to open the Settings panel.
2. Click the "Others" tab at the top of the Settings panel.
3. Look for a toggle labelled "Sign commits with DCO" near the top of the tab.
4. Check that a short description mentioning "Signed-off-by" is visible beneath or beside the label.
5. Verify the toggle is in the OFF position by default.

**Expected Results:**
- The Others tab contains a visible toggle row labelled "Sign commits with DCO".
- A hint explaining that it adds a "Signed-off-by" trailer is shown.
- The toggle is switched off when the Settings panel is opened for the first time (no prior configuration).

</blockquote>
</details>
<details>
<summary><strong>2. Enabling DCO sign-off and saving persists the setting</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a workspace open in VS Code with the Jolli Memory extension active.

**Steps:**
1. Open the Jolli Memory Settings panel and navigate to the "Others" tab.
2. Click the "Sign commits with DCO" toggle to turn it ON.
3. Click the "Apply Changes" button.
4. Close the Settings panel, then reopen it and go back to the "Others" tab.
5. Verify the "Sign commits with DCO" toggle is still in the ON position.

**Expected Results:**
- After saving, the toggle remains ON when the Settings panel is reopened.
- No error message appears during save.

</blockquote>
</details>
<details>
<summary><strong>3. DCO sign-off line appears in commits when toggle is on</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a Git repository open with at least one staged file change. The "Sign commits with DCO" toggle must be turned ON and saved in Settings (see previous scenario).

**Steps:**
1. In the Jolli Memory panel, create a new commit with a short message such as "test: verify dco".
2. After the commit completes, open a terminal and run `git log -1` to inspect the most recent commit.
3. Check the commit message body for a line beginning with "Signed-off-by:" followed by your name and email.
4. Now go back to Settings, turn the "Sign commits with DCO" toggle OFF, and click "Apply Changes".
5. Stage another small change and create a new commit with the message "test: no dco".
6. Run `git log -1` again and confirm there is no "Signed-off-by:" line in the commit message.

**Expected Results:**
- When the toggle is ON, every commit created through Jolli Memory (regular commit, amend, or squash) includes a "Signed-off-by: Your Name <email>" line at the end of the commit message.
- When the toggle is OFF, commits created through Jolli Memory contain no "Signed-off-by:" line.

</blockquote>
</details>

---

## Topics (3)
<details>
<summary><strong>01 · Opt-in DCO sign-off toggle added to all plugin commit operations</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Some open-source projects require a Developer Certificate of Origin sign-off line on every commit as part of their contribution policy. Contributors using the plugin to create commits had no way to have that trailer added automatically and had to remember to do it manually every time.

**💡 Decisions Behind the Code**

- **Opt-in rather than opt-out**: The toggle defaults to off. DCO sign-off is a project-specific requirement, not a universal one, and enabling it by default would add unexpected trailers to commits in projects that don't need them. Users who need it must explicitly turn it on.
- **Machine-global scope over per-repository**: A single machine-wide setting stored in the shared config file was chosen over a per-repository override. A per-repo approach would have required extending the config read chain and forcing users to re-enable the toggle for every new repository. The sign-off trailer is harmless in projects that don't require it, making a global default safe.
- **Read config on every commit rather than caching at startup**: The helper re-reads the config file each time a commit is made, so a user can flip the toggle and have it take effect on the very next commit without reloading the extension. Commits are infrequent relative to file I/O, so the freshness benefit outweighs the negligible overhead of the extra read.
- **Store `undefined` instead of `false` when the toggle is off**: When saving, the panel writes `true` to disk only when the toggle is on and omits the key entirely when it is off. This keeps config files clean for the majority of users who never touch the setting, and existing configs continue to work without any migration.
- **Toggle placed in the Others settings tab**: Rather than creating a new tab or embedding the toggle inside a commit-flow dialog, the toggle was placed alongside other miscellaneous machine-level options, matching the existing information architecture and avoiding adding UI surface area for a single boolean setting.

**✅ What Was Implemented**

- `cli/src/Types.ts` gained a `dcoSignoff?: boolean` field on the shared config type. `vscode/src/JolliMemoryBridge.ts` gained a private `signoffArgs()` helper that reads the config fresh on every call and returns `["-s"]` when the setting is enabled or `[]` when it is not; the helper is spread into the argument list for all four commit entry points: regular commit, amend with message, amend no-edit, and squash commit.
- `vscode/src/views/SettingsHtmlBuilder.ts` adds a toggle row in the Others tab of the Settings panel. `vscode/src/views/SettingsScriptBuilder.ts` binds the checkbox to the save payload and dirty-tracking logic. `vscode/src/views/SettingsWebviewPanel.ts` maps the boolean to `true | undefined` on save (omitting the key entirely when off) and coerces it back to a boolean on load.
- A post-implementation code review flagged that a truthy check on the stored config value could misfire if the value were ever a non-boolean truthy string, silently enabling sign-off even when the toggle appeared disabled. A strict equality check (`=== true`) was recommended as a follow-up fix.

**📋 Future Enhancements**

- IntelliJ parity: a teammate needs to add the `dcoSignoff` field to the Kotlin config type, wire it into the settings dialog, and insert the conditional flag into the four commit call sites in `CommitAIAction` and `SquashAction`. Note that the IntelliJ plugin reads a different config file than the VS Code extension, so the integration path needs its own design pass.
- Strict equality guard: the code review recommended changing the truthy check in `JolliMemoryBridge.ts` to a strict `=== true` comparison to prevent malformed config values from silently enabling sign-off.
- Per-repository override support was noted as a future extensibility point but has not been designed or scheduled.

**📁 FILES**
- `cli/src/Types.ts`
- `vscode/src/JolliMemoryBridge.ts`
- `vscode/src/views/SettingsHtmlBuilder.ts`
- `vscode/src/views/SettingsScriptBuilder.ts`
- `vscode/src/views/SettingsWebviewPanel.ts`

</blockquote>
</details>
<details>
<summary><strong>02 · Settings panel hint text restructured and Exclude Patterns label clarified</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The descriptive hint text for the file exclusion patterns input was floating between two sections with no visual connection to the field it described, making the Settings panel layout look broken.

**💡 Decisions Behind the Code**

- **Merge into label rather than reposition the standalone paragraph**: A floating paragraph between sections has no semantic connection to any field, while a hint span inside a label is visually and structurally tied to its input — this is the standard pattern already used elsewhere in the panel. Merging was the lower-complexity fix and produced a layout consistent with the rest of the Settings panel.
- **Rename label to "Exclude Patterns"**: With the DCO sign-off toggle now sharing the Others tab, the single word "Patterns" became ambiguous. Renaming to "Exclude Patterns" makes the field's purpose self-evident without requiring the surrounding hint text to carry that load.

**✅ What Was Implemented**

In `vscode/src/views/SettingsHtmlBuilder.ts`, the standalone paragraph containing the hint text was removed and its content merged into the hint span inside the Exclude Patterns label element. The visible label text was also renamed from "Patterns" to "Exclude Patterns" for clarity, and example glob values in the hint were wrapped in code tags for better readability.

**📁 FILES**
- `vscode/src/views/SettingsHtmlBuilder.ts`

</blockquote>
</details>
<details>
<summary><strong>03 · Chinese-language design plan document added for DCO sign-off setting</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Before beginning implementation, the developer wanted a written design plan covering scope, UX placement, config schema changes, affected call sites across both IDEs, and edge cases.

**💡 Decisions Behind the Code**

IntelliJ support was explicitly deferred to a teammate during the planning session. The symmetric changes needed for IntelliJ were recorded as a reference section in the document rather than implemented, keeping the PR scope tight and avoiding cross-team merge conflicts on shared Kotlin files.

**✅ What Was Implemented**

Added `docs/2026-05-19-dco-签名设置-计划.md`, a comprehensive Chinese-language design and implementation plan covering: scope definition (VS Code and CLI only, with IntelliJ explicitly deferred to a teammate), a UX wireframe for the Settings panel toggle placement, the config schema change, all eight affected call sites across both IDEs, edge-case analysis (idempotency with amend, missing git identity, GPG orthogonality), a test plan, and an ordered implementation checklist.

**📋 Future Enhancements**

- IntelliJ side: the design document's section on IntelliJ lists the required changes as a follow-up task for a separate contributor. The IntelliJ plugin reads a different config file, so the integration path needs its own design pass before implementation.

**📁 FILES**
- `docs/2026-05-19-dco-签名设置-计划.md`

</blockquote>
</details>

---

*Generated by Jolli Memory · May 20, 2026 at 12:04 PM · via Anthropic*
<!-- jollimemory-summary-end -->