### PR TITLE
Replace stale-commit panel disposal with persistent stale-readonly mode and warning banner

### DIFF
--- a/vscode/src/JolliMemoryBridge.ts
+++ b/vscode/src/JolliMemoryBridge.ts
@@ -1653,6 +1653,22 @@ export class JolliMemoryBridge {
 	// `SummaryWebviewPanel` use these instead of importing the SummaryStore /
 	// PlanService / NoteService writers directly.
 
+	/**
+	 * Loads the orphan-branch index entry map via the Bridge's storage
+	 * instance. Threading storage matters in folder-mode (or any non-default
+	 * `storageMode`) because the default `resolveStorage()` falls back to a
+	 * fresh `OrphanBranchStorage` that would read the wrong file. Callers like
+	 * the SummaryWebviewPanel's stale-commit guard rely on the live index, so
+	 * routing through the Bridge keeps the read consistent with every
+	 * webview-driven write.
+	 */
+	async getSummaryIndexEntryMap(): Promise<
+		ReadonlyMap<string, import("../../cli/src/Types.js").SummaryIndexEntry>
+	> {
+		const storage = await this.getStorage();
+		return getIndexEntryMap(this.cwd, storage);
+	}
+
 	/** Writes a summary via the Bridge's DualWriteStorage instance. */
 	async storeSummary(
 		summary: CommitSummary,

--- a/vscode/src/views/SummaryCssBuilder.ts
+++ b/vscode/src/views/SummaryCssBuilder.ts
@@ -1235,6 +1235,64 @@ export function buildCss(): string {
     display: none !important;
   }
 
+  /* Stale-readonly mode.
+     Triggered when the panel's commit has been rewritten by amend / squash /
+     rebase during the panel's lifetime (SummaryWebviewPanel sets it from
+     ensureCommitNotRewritten). Reuses the data-foreign-safe whitelist so
+     both readonly modes share a single set of "always allowed" controls
+     (Copy / Save Markdown / Toggle / copy-hash / the stale banner's
+     Open-new-commit action button). The destructive-message guards in
+     SummaryWebviewPanel handlers already short-circuit the writes; this
+     layer removes the affordance so the user has no clickable trap.
+
+     Unlike foreign-readonly, this mode also renders a persistent banner
+     (.stale-banner) at the top of the page — the rewrite is a state
+     change during the panel's lifetime, so the user needs in-panel
+     context for why their buttons just disappeared. */
+  .page.stale-readonly button:not([data-foreign-safe]) {
+    display: none !important;
+  }
+
+  .stale-banner {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin: 0 0 16px 0;
+    padding: 12px 16px;
+    background: var(--vscode-inputValidation-warningBackground, #5a4a1a);
+    border: 1px solid var(--vscode-inputValidation-warningBorder, #cca700);
+    border-radius: 6px;
+    color: var(--vscode-foreground);
+  }
+  .stale-banner-icon {
+    font-size: 18px;
+    line-height: 1;
+  }
+  .stale-banner-text {
+    flex: 1;
+    line-height: 1.5;
+  }
+  .stale-banner-hash {
+    background: var(--vscode-textCodeBlock-background, rgba(0, 0, 0, 0.2));
+    padding: 1px 6px;
+    border-radius: 3px;
+    font-family: var(--vscode-editor-font-family, monospace);
+    font-size: 0.92em;
+  }
+  .stale-banner-action {
+    background: var(--vscode-button-background);
+    color: var(--vscode-button-foreground);
+    border: none;
+    padding: 6px 14px;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 13px;
+    white-space: nowrap;
+  }
+  .stale-banner-action:hover {
+    background: var(--vscode-button-hoverBackground);
+  }
+
 ${buildPrSectionCss()}
 `;
 }

--- a/vscode/src/views/SummaryHtmlBuilder.ts
+++ b/vscode/src/views/SummaryHtmlBuilder.ts
@@ -53,6 +53,25 @@ export interface BuildHtmlOptions {
 	 * the source repo, so this layer does not render an additional banner.
 	 */
 	readonly foreignRepoName?: string | null;
+	/**
+	 * Full 40-char hash of the live root commit when the panel's commit has
+	 * been rewritten by amend / squash / rebase. The `.page` root receives
+	 * a `stale-readonly` hook class (parallel to `foreign-readonly`) so the
+	 * same CSS rule that hides destructive buttons takes effect, and a
+	 * persistent banner is rendered at the top explaining where to go.
+	 *
+	 * The banner displays an 8-char short form for readability while the
+	 * action button's `data-target-hash` attribute carries the FULL hash.
+	 * Navigation needs the full hash because `getSummary()` only resolves
+	 * `commitAliases` for 40-char inputs and throws `AmbiguousHashError`
+	 * on prefix collisions.
+	 *
+	 * The banner is needed (unlike foreign-readonly which relies on the
+	 * tab-title prefix) because the rewrite happens during the panel's
+	 * lifetime — the user already had it open and would otherwise just see
+	 * buttons disappear without knowing why.
+	 */
+	readonly staleRewrittenInto?: string | null;
 }
 
 /**
@@ -65,7 +84,14 @@ export function buildHtml(
 	opts: BuildHtmlOptions = {},
 ): string {
 	const { transcriptHashSet, planTranslateSet, noteTranslateSet, nonce } = opts;
-	const pageClass = opts.foreignRepoName ? "page foreign-readonly" : "page";
+	// Both readonly modes share the same CSS rule that hides destructive
+	// buttons (see SummaryCssBuilder). A panel can in principle be both
+	// foreign AND stale (cross-repo summary whose commit was rewritten in
+	// the source repo) — emit both hook classes so the rule still matches.
+	const pageClasses = ["page"];
+	if (opts.foreignRepoName) pageClasses.push("foreign-readonly");
+	if (opts.staleRewrittenInto) pageClasses.push("stale-readonly");
+	const pageClass = pageClasses.join(" ");
 	const { topics: allTopics, sourceNodes } = collectSortedTopics(summary);
 	const stats = resolveDiffStats(summary);
 	const totalInsertions = stats.insertions;
@@ -84,6 +110,20 @@ export function buildHtml(
 		: "";
 	const nonceAttr = nonce ? ` nonce="${nonce}"` : "";
 
+	// Display short-form (8 chars) for readability; the action button keeps
+	// the full hash in data-target-hash so navigation goes through
+	// getSummary()'s 40-char alias-resolution path rather than the
+	// prefix-scan path that throws on collisions.
+	const staleFullHash = opts.staleRewrittenInto ?? "";
+	const staleShortHash = staleFullHash.substring(0, 8);
+	const staleBannerHtml = opts.staleRewrittenInto
+		? `<div class="stale-banner" role="status">
+  <span class="stale-banner-icon" aria-hidden="true">&#x26A0;&#xFE0F;</span>
+  <span class="stale-banner-text">This commit was rewritten into <code class="stale-banner-hash">${escHtml(staleShortHash)}</code>. This view is read-only; open the new commit's summary to make changes.</span>
+  <button class="stale-banner-action" id="staleOpenNewBtn" data-foreign-safe data-target-hash="${escHtml(staleFullHash)}">Open new commit's summary</button>
+</div>`
+		: "";
+
 	return `<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -95,6 +135,7 @@ ${csp}
 </head>
 <body>
 <div class="${pageClass}">
+${staleBannerHtml}
 ${buildAllConversationsSection(transcriptHashSet)}
 ${buildHeader(summary, totalFiles, totalInsertions, totalDeletions)}
 <hr class="separator" />

--- a/vscode/src/views/SummaryScriptBuilder.ts
+++ b/vscode/src/views/SummaryScriptBuilder.ts
@@ -91,6 +91,19 @@ export function buildScript(): string {
       vscode.postMessage({ command: 'push' });
     });
   }
+
+  // Stale-readonly banner: "Open new commit's summary" button. The live
+  // root hash is rendered into data-target-hash by buildHtml; the
+  // extension routes the message to jollimemory.viewSummary.
+  var staleOpenBtn = document.getElementById('staleOpenNewBtn');
+  if (staleOpenBtn) {
+    staleOpenBtn.addEventListener('click', function() {
+      var hash = staleOpenBtn.getAttribute('data-target-hash');
+      if (hash) {
+        vscode.postMessage({ command: 'openRewrittenCommit', hash: hash });
+      }
+    });
+  }
 ${buildPrSectionScript()}
 
   // Listen for messages from the extension (push + topic edit status updates).

--- a/vscode/src/views/SummaryWebviewPanel.handlePush.test.ts
+++ b/vscode/src/views/SummaryWebviewPanel.handlePush.test.ts
@@ -458,6 +458,9 @@ const stubBridge = {
 						artifacts,
 					) as Promise<void>),
 	),
+	// Stale-commit guard reads the index via this bridge wrapper. Default to
+	// "empty index" so push tests stay on the happy path.
+	getSummaryIndexEntryMap: vi.fn().mockResolvedValue(new Map()),
 } as unknown as import("../JolliMemoryBridge.js").JolliMemoryBridge;
 
 // ── Tests ────────────────────────────────────────────────────────────────────

--- a/vscode/src/views/SummaryWebviewPanel.test.ts
+++ b/vscode/src/views/SummaryWebviewPanel.test.ts
@@ -551,6 +551,11 @@ const stubBridge = {
 	archiveNoteForCommit: vi.fn((id: string, commitHash: string) =>
 		mockArchiveNoteForCommit(id, commitHash, workspaceRoot),
 	),
+	// Stale-commit guard reads the index via this bridge wrapper (storage
+	// threading — see JolliMemoryBridge.getSummaryIndexEntryMap docstring).
+	// Default to "empty index" so existing tests are unaffected; the
+	// stale-commit describe block overrides per test.
+	getSummaryIndexEntryMap: vi.fn().mockResolvedValue(new Map()),
 } as unknown as import("../JolliMemoryBridge.js").JolliMemoryBridge;
 const mainBranch = "main";
 
@@ -7419,6 +7424,693 @@ describe("SummaryWebviewPanel", () => {
 				typeof c[0] === "string" ? c[0].includes("disabled") : false,
 			);
 			expect(denialCalls).toHaveLength(0);
+		});
+	});
+
+	// ── Stale-commit (rewritten-into) guard ──────────────────────────────────
+	// When a commit shown in the panel is rewritten by amend / squash / rebase,
+	// the panel for the OLD hash stays open and any subsequent write from it
+	// silently overwrites the orphaned commit's summary on the orphan branch.
+	// Most visibly, Push to Jolli writes `jolliDocId` / `jolliDocUrl` to the
+	// orphaned commit, leaving the live HEAD's summary without those fields.
+	// `ensureCommitNotRewritten` blocks every write handler when the panel's
+	// commitHash is no longer a root entry in the index — i.e. has a non-null
+	// `parentCommitHash`, the marker jollimemory writes when the original commit
+	// is folded into a new root by amend/squash/rebase.
+
+	describe("stale-commit guard", () => {
+		// Helper: build an index entry map representing the chain
+		// `commitHash` → `parentCommitHash` → ... → `rootHash`. Returns the map
+		// in the shape `getIndexEntryMap` resolves to.
+		function buildChainEntryMap(
+			chain: ReadonlyArray<{ hash: string; parent: string | null }>,
+		): Map<string, { commitHash: string; parentCommitHash: string | null }> {
+			const map = new Map<
+				string,
+				{ commitHash: string; parentCommitHash: string | null }
+			>();
+			for (const link of chain) {
+				map.set(link.hash, {
+					commitHash: link.hash,
+					parentCommitHash: link.parent,
+				});
+			}
+			return map;
+		}
+
+		async function setupCommit(
+			hash: string,
+		): Promise<(msg: Record<string, unknown>) => void> {
+			await SummaryWebviewPanel.show(
+				makeSummary({ commitHash: hash }),
+				extensionUri,
+				workspaceRoot,
+				stubBridge,
+				mainBranch,
+			);
+			return captureMessageHandler();
+		}
+
+		it("allows push when the commit is still a root entry", async () => {
+			(
+				stubBridge.getSummaryIndexEntryMap as ReturnType<typeof vi.fn>
+			).mockResolvedValue(
+				buildChainEntryMap([{ hash: "abc123", parent: null }]),
+			);
+			const dispatch = await setupCommit("abc123");
+
+			dispatch({ command: "push" });
+			await flushPromises();
+
+			// Guard let it through; runJolliPush would be reached. Since no API
+			// key is configured by default, the user-facing warning is the
+			// "configure Jolli API Key" one — NOT our "rewritten into" message.
+			const rewriteWarnings = showWarningMessage.mock.calls.filter((c) =>
+				typeof c[0] === "string" ? c[0].includes("rewritten into") : false,
+			);
+			expect(rewriteWarnings).toHaveLength(0);
+		});
+
+		it("allows push when the commit is absent from the index (legacy / external / pre-index)", async () => {
+			(
+				stubBridge.getSummaryIndexEntryMap as ReturnType<typeof vi.fn>
+			).mockResolvedValue(new Map());
+			const dispatch = await setupCommit("abc123");
+
+			dispatch({ command: "push" });
+			await flushPromises();
+
+			const rewriteWarnings = showWarningMessage.mock.calls.filter((c) =>
+				typeof c[0] === "string" ? c[0].includes("rewritten into") : false,
+			);
+			expect(rewriteWarnings).toHaveLength(0);
+		});
+
+		it("blocks push when the commit was rewritten into a new root", async () => {
+			// abc123 → ROOT_NEW (one-step rewrite, e.g. single amend)
+			(
+				stubBridge.getSummaryIndexEntryMap as ReturnType<typeof vi.fn>
+			).mockResolvedValue(
+				buildChainEntryMap([
+					{ hash: "abc123", parent: "rootnew0" },
+					{ hash: "rootnew0", parent: null },
+				]),
+			);
+			const dispatch = await setupCommit("abc123");
+
+			dispatch({ command: "push" });
+			await flushPromises();
+
+			// User-facing warning surfaces the live root's short hash.
+			expect(showWarningMessage).toHaveBeenCalledWith(
+				expect.stringContaining("rewritten into rootnew0"),
+			);
+			expect(showWarningMessage).toHaveBeenCalledWith(
+				expect.stringContaining("abc123"),
+			);
+			expect(showWarningMessage).toHaveBeenCalledWith(
+				expect.stringContaining("push to Jolli"),
+			);
+			// Side effect: panel disposed so the stale tab can't be reused.
+			expect(
+				firstCommitPanel<{ panel: { dispose: ReturnType<typeof vi.fn> } }>()
+					.panel.dispose,
+			).toHaveBeenCalled();
+			// And the storage write never happened.
+			expect(mockStoreSummary).not.toHaveBeenCalled();
+		});
+
+		it("walks a multi-hop parent chain to the final live root", async () => {
+			// abc123 → mid0001 → mid0002 → finalroot
+			(
+				stubBridge.getSummaryIndexEntryMap as ReturnType<typeof vi.fn>
+			).mockResolvedValue(
+				buildChainEntryMap([
+					{ hash: "abc123", parent: "mid0001" },
+					{ hash: "mid0001", parent: "mid0002" },
+					{ hash: "mid0002", parent: "finalrt" },
+					{ hash: "finalrt", parent: null },
+				]),
+			);
+			const dispatch = await setupCommit("abc123");
+
+			dispatch({ command: "push" });
+			await flushPromises();
+
+			expect(showWarningMessage).toHaveBeenCalledWith(
+				expect.stringContaining("rewritten into finalrt"),
+			);
+			expect(mockStoreSummary).not.toHaveBeenCalled();
+		});
+
+		it("breaks out of a cyclic parent chain instead of looping forever", async () => {
+			// Defensive: index links form a DAG by construction, but a corrupted
+			// file shouldn't lock the UI in an infinite loop.
+			//   abc123 → cyclea → cycleb → cyclea (cycle back)
+			(
+				stubBridge.getSummaryIndexEntryMap as ReturnType<typeof vi.fn>
+			).mockResolvedValue(
+				buildChainEntryMap([
+					{ hash: "abc123", parent: "cyclea0" },
+					{ hash: "cyclea0", parent: "cycleb0" },
+					{ hash: "cycleb0", parent: "cyclea0" },
+				]),
+			);
+			const dispatch = await setupCommit("abc123");
+
+			dispatch({ command: "push" });
+			await flushPromises();
+
+			// We surface whichever hash the walk landed on before detecting the
+			// cycle — either cyclea0 or cycleb0, depending on iteration order;
+			// the important thing is that no crash and no storage write happens.
+			expect(showWarningMessage).toHaveBeenCalledWith(
+				expect.stringMatching(/rewritten into (cyclea0|cycleb0)/),
+			);
+			expect(mockStoreSummary).not.toHaveBeenCalled();
+		});
+
+		it("blocks the same write across all guarded handlers (edit memory)", async () => {
+			(
+				stubBridge.getSummaryIndexEntryMap as ReturnType<typeof vi.fn>
+			).mockResolvedValue(
+				buildChainEntryMap([
+					{ hash: "abc123", parent: "rootnew0" },
+					{ hash: "rootnew0", parent: null },
+				]),
+			);
+			const dispatch = await setupCommit("abc123");
+
+			dispatch({
+				command: "editTopic",
+				topicIndex: 0,
+				updates: { title: "new" },
+			});
+			await flushPromises();
+
+			expect(showWarningMessage).toHaveBeenCalledWith(
+				expect.stringContaining("edit memory"),
+			);
+			expect(mockStoreSummary).not.toHaveBeenCalled();
+		});
+
+		it("blocks generate E2E test guide with the correct operation label", async () => {
+			(
+				stubBridge.getSummaryIndexEntryMap as ReturnType<typeof vi.fn>
+			).mockResolvedValue(
+				buildChainEntryMap([
+					{ hash: "abc123", parent: "rootnew0" },
+					{ hash: "rootnew0", parent: null },
+				]),
+			);
+			const dispatch = await setupCommit("abc123");
+
+			dispatch({ command: "generateE2eTest" });
+			await flushPromises();
+
+			expect(showWarningMessage).toHaveBeenCalledWith(
+				expect.stringContaining("generate E2E test guide"),
+			);
+			expect(mockStoreSummary).not.toHaveBeenCalled();
+		});
+
+		it("blocks edit E2E scenario when the commit was rewritten", async () => {
+			(
+				stubBridge.getSummaryIndexEntryMap as ReturnType<typeof vi.fn>
+			).mockResolvedValue(
+				buildChainEntryMap([
+					{ hash: "abc123", parent: "rootnew0" },
+					{ hash: "rootnew0", parent: null },
+				]),
+			);
+			await SummaryWebviewPanel.show(
+				makeSummary({
+					commitHash: "abc123",
+					e2eTestGuide: [
+						{
+							title: "Scenario 1",
+							preconditions: "",
+							steps: ["step"],
+							expectedResults: ["ok"],
+						},
+					],
+				}),
+				extensionUri,
+				workspaceRoot,
+				stubBridge,
+				mainBranch,
+			);
+			const dispatch = captureMessageHandler();
+
+			dispatch({
+				command: "editE2eScenario",
+				index: 0,
+				updates: { title: "x" },
+			});
+			await flushPromises();
+
+			expect(showWarningMessage).toHaveBeenCalledWith(
+				expect.stringContaining("edit E2E scenario"),
+			);
+			expect(mockStoreSummary).not.toHaveBeenCalled();
+		});
+
+		it("blocks delete E2E scenario BEFORE the confirm dialog", async () => {
+			(
+				stubBridge.getSummaryIndexEntryMap as ReturnType<typeof vi.fn>
+			).mockResolvedValue(
+				buildChainEntryMap([
+					{ hash: "abc123", parent: "rootnew0" },
+					{ hash: "rootnew0", parent: null },
+				]),
+			);
+			await SummaryWebviewPanel.show(
+				makeSummary({
+					commitHash: "abc123",
+					e2eTestGuide: [
+						{
+							title: "Scenario 1",
+							preconditions: "",
+							steps: ["step"],
+							expectedResults: ["ok"],
+						},
+					],
+				}),
+				extensionUri,
+				workspaceRoot,
+				stubBridge,
+				mainBranch,
+			);
+			const dispatch = captureMessageHandler();
+
+			dispatch({ command: "deleteE2eScenario", index: 0 });
+			await flushPromises();
+
+			// Stale warning surfaced, confirm dialog ("Delete scenario ...?") never shown.
+			expect(showWarningMessage).toHaveBeenCalledWith(
+				expect.stringContaining("delete E2E scenario"),
+			);
+			const confirmCalls = showWarningMessage.mock.calls.filter((c) =>
+				typeof c[0] === "string" ? c[0].startsWith("Delete scenario") : false,
+			);
+			expect(confirmCalls).toHaveLength(0);
+			expect(mockStoreSummary).not.toHaveBeenCalled();
+		});
+
+		it("blocks delete E2E test guide BEFORE the confirm dialog", async () => {
+			(
+				stubBridge.getSummaryIndexEntryMap as ReturnType<typeof vi.fn>
+			).mockResolvedValue(
+				buildChainEntryMap([
+					{ hash: "abc123", parent: "rootnew0" },
+					{ hash: "rootnew0", parent: null },
+				]),
+			);
+			const dispatch = await setupCommit("abc123");
+
+			dispatch({ command: "deleteE2eTest" });
+			await flushPromises();
+
+			expect(showWarningMessage).toHaveBeenCalledWith(
+				expect.stringContaining("delete E2E test guide"),
+			);
+			const confirmCalls = showWarningMessage.mock.calls.filter((c) =>
+				typeof c[0] === "string" ? c[0] === "Delete E2E Test Guide?" : false,
+			);
+			expect(confirmCalls).toHaveLength(0);
+			expect(mockStoreSummary).not.toHaveBeenCalled();
+		});
+
+		it("blocks generate recap with the correct operation label", async () => {
+			(
+				stubBridge.getSummaryIndexEntryMap as ReturnType<typeof vi.fn>
+			).mockResolvedValue(
+				buildChainEntryMap([
+					{ hash: "abc123", parent: "rootnew0" },
+					{ hash: "rootnew0", parent: null },
+				]),
+			);
+			const dispatch = await setupCommit("abc123");
+
+			dispatch({ command: "generateRecap" });
+			await flushPromises();
+
+			expect(showWarningMessage).toHaveBeenCalledWith(
+				expect.stringContaining("generate recap"),
+			);
+			expect(mockStoreSummary).not.toHaveBeenCalled();
+		});
+
+		it("blocks delete memory BEFORE the confirm dialog", async () => {
+			(
+				stubBridge.getSummaryIndexEntryMap as ReturnType<typeof vi.fn>
+			).mockResolvedValue(
+				buildChainEntryMap([
+					{ hash: "abc123", parent: "rootnew0" },
+					{ hash: "rootnew0", parent: null },
+				]),
+			);
+			const dispatch = await setupCommit("abc123");
+
+			dispatch({ command: "deleteTopic", topicIndex: 0 });
+			await flushPromises();
+
+			expect(showWarningMessage).toHaveBeenCalledWith(
+				expect.stringContaining("delete memory"),
+			);
+			// Confirm dialog ("Delete memory?" / "Delete this memory?") never shown.
+			const confirmCalls = showWarningMessage.mock.calls.filter((c) =>
+				typeof c[0] === "string" ? c[0].startsWith("Delete") : false,
+			);
+			expect(confirmCalls).toHaveLength(0);
+			expect(mockStoreSummary).not.toHaveBeenCalled();
+		});
+
+		it("blocks edit E2E test guide (deprecated bulk edit path)", async () => {
+			(
+				stubBridge.getSummaryIndexEntryMap as ReturnType<typeof vi.fn>
+			).mockResolvedValue(
+				buildChainEntryMap([
+					{ hash: "abc123", parent: "rootnew0" },
+					{ hash: "rootnew0", parent: null },
+				]),
+			);
+			const dispatch = await setupCommit("abc123");
+
+			dispatch({ command: "editE2eTest", scenarios: [] });
+			await flushPromises();
+
+			expect(showWarningMessage).toHaveBeenCalledWith(
+				expect.stringContaining("edit E2E test guide"),
+			);
+			expect(mockStoreSummary).not.toHaveBeenCalled();
+		});
+
+		// Plan / note / Linear-issue write entry points — same stale-commit bug
+		// class as the E2E/topic/recap handlers above. Each here drives a write
+		// to `bridge.storeSummary` with the stale `currentSummary.commitHash`,
+		// or an archive call (archivePlanForCommit / archiveNoteForCommit) that
+		// binds new content to the orphaned commit.
+
+		it("blocks remove plan BEFORE confirm + storeSummary", async () => {
+			(
+				stubBridge.getSummaryIndexEntryMap as ReturnType<typeof vi.fn>
+			).mockResolvedValue(
+				buildChainEntryMap([
+					{ hash: "abc123", parent: "rootnew0" },
+					{ hash: "rootnew0", parent: null },
+				]),
+			);
+			await SummaryWebviewPanel.show(
+				makeSummary({
+					commitHash: "abc123",
+					plans: [{ slug: "p", title: "P" }],
+				}),
+				extensionUri,
+				workspaceRoot,
+				stubBridge,
+				mainBranch,
+			);
+			const dispatch = captureMessageHandler();
+
+			dispatch({ command: "removePlan", slug: "p", title: "P" });
+			await flushPromises();
+
+			expect(showWarningMessage).toHaveBeenCalledWith(
+				expect.stringContaining("remove plan"),
+			);
+			const confirmCalls = showWarningMessage.mock.calls.filter((c) =>
+				typeof c[0] === "string" ? c[0].startsWith("Remove plan") : false,
+			);
+			expect(confirmCalls).toHaveLength(0);
+			expect(mockStoreSummary).not.toHaveBeenCalled();
+		});
+
+		it("blocks remove note BEFORE confirm + storeSummary", async () => {
+			(
+				stubBridge.getSummaryIndexEntryMap as ReturnType<typeof vi.fn>
+			).mockResolvedValue(
+				buildChainEntryMap([
+					{ hash: "abc123", parent: "rootnew0" },
+					{ hash: "rootnew0", parent: null },
+				]),
+			);
+			await SummaryWebviewPanel.show(
+				makeSummary({
+					commitHash: "abc123",
+					notes: [{ id: "n", title: "N", format: "snippet" }],
+				}),
+				extensionUri,
+				workspaceRoot,
+				stubBridge,
+				mainBranch,
+			);
+			const dispatch = captureMessageHandler();
+
+			dispatch({ command: "removeNote", id: "n", title: "N" });
+			await flushPromises();
+
+			expect(showWarningMessage).toHaveBeenCalledWith(
+				expect.stringContaining("remove note"),
+			);
+			expect(mockStoreSummary).not.toHaveBeenCalled();
+		});
+
+		it("blocks remove Linear issue BEFORE confirm + storeSummary", async () => {
+			(
+				stubBridge.getSummaryIndexEntryMap as ReturnType<typeof vi.fn>
+			).mockResolvedValue(
+				buildChainEntryMap([
+					{ hash: "abc123", parent: "rootnew0" },
+					{ hash: "rootnew0", parent: null },
+				]),
+			);
+			await SummaryWebviewPanel.show(
+				makeSummary({
+					commitHash: "abc123",
+					linearIssues: [
+						{
+							archivedKey: "JOLLI-1-abc",
+							ticketId: "JOLLI-1",
+							title: "T",
+							url: "https://linear.app/x",
+							capturedAt: "2026-01-01T00:00:00Z",
+						},
+					],
+				}),
+				extensionUri,
+				workspaceRoot,
+				stubBridge,
+				mainBranch,
+			);
+			const dispatch = captureMessageHandler();
+
+			dispatch({
+				command: "removeLinearIssue",
+				archivedKey: "JOLLI-1-abc",
+				ticketId: "JOLLI-1",
+			});
+			await flushPromises();
+
+			expect(showWarningMessage).toHaveBeenCalledWith(
+				expect.stringContaining("remove Linear issue"),
+			);
+			expect(mockStoreSummary).not.toHaveBeenCalled();
+		});
+
+		it("blocks add plan BEFORE the QuickPick + archivePlanForCommit", async () => {
+			(
+				stubBridge.getSummaryIndexEntryMap as ReturnType<typeof vi.fn>
+			).mockResolvedValue(
+				buildChainEntryMap([
+					{ hash: "abc123", parent: "rootnew0" },
+					{ hash: "rootnew0", parent: null },
+				]),
+			);
+			mockListAvailablePlans.mockReturnValue([
+				{ slug: "available-plan", title: "Available Plan" },
+			]);
+			const dispatch = await setupCommit("abc123");
+
+			dispatch({ command: "addPlan" });
+			await flushPromises();
+
+			expect(showWarningMessage).toHaveBeenCalledWith(
+				expect.stringContaining("add plan"),
+			);
+			expect(showQuickPick).not.toHaveBeenCalled();
+			expect(mockArchivePlanForCommit).not.toHaveBeenCalled();
+			expect(mockStoreSummary).not.toHaveBeenCalled();
+		});
+
+		it("blocks add markdown note BEFORE the file picker", async () => {
+			(
+				stubBridge.getSummaryIndexEntryMap as ReturnType<typeof vi.fn>
+			).mockResolvedValue(
+				buildChainEntryMap([
+					{ hash: "abc123", parent: "rootnew0" },
+					{ hash: "rootnew0", parent: null },
+				]),
+			);
+			const dispatch = await setupCommit("abc123");
+
+			dispatch({ command: "addMarkdownNote" });
+			await flushPromises();
+
+			expect(showWarningMessage).toHaveBeenCalledWith(
+				expect.stringContaining("add markdown note"),
+			);
+			expect(showOpenDialog).not.toHaveBeenCalled();
+			expect(mockArchiveNoteForCommit).not.toHaveBeenCalled();
+			expect(mockStoreSummary).not.toHaveBeenCalled();
+		});
+
+		it("blocks save snippet (no saveNote / archive / storeSummary)", async () => {
+			(
+				stubBridge.getSummaryIndexEntryMap as ReturnType<typeof vi.fn>
+			).mockResolvedValue(
+				buildChainEntryMap([
+					{ hash: "abc123", parent: "rootnew0" },
+					{ hash: "rootnew0", parent: null },
+				]),
+			);
+			const dispatch = await setupCommit("abc123");
+
+			dispatch({
+				command: "saveSnippet",
+				title: "T",
+				content: "some content",
+			});
+			await flushPromises();
+
+			expect(showWarningMessage).toHaveBeenCalledWith(
+				expect.stringContaining("save snippet"),
+			);
+			expect(mockSaveNote).not.toHaveBeenCalled();
+			expect(mockArchiveNoteForCommit).not.toHaveBeenCalled();
+			expect(mockStoreSummary).not.toHaveBeenCalled();
+		});
+
+		it("blocks save plan BEFORE storePlans (no plan content write)", async () => {
+			(
+				stubBridge.getSummaryIndexEntryMap as ReturnType<typeof vi.fn>
+			).mockResolvedValue(
+				buildChainEntryMap([
+					{ hash: "abc123", parent: "rootnew0" },
+					{ hash: "rootnew0", parent: null },
+				]),
+			);
+			const dispatch = await setupCommit("abc123");
+
+			dispatch({
+				command: "savePlan",
+				slug: "p",
+				content: "# Title\n\nbody",
+			});
+			await flushPromises();
+
+			expect(showWarningMessage).toHaveBeenCalledWith(
+				expect.stringContaining("save plan"),
+			);
+			expect(mockStorePlans).not.toHaveBeenCalled();
+			expect(mockStoreSummary).not.toHaveBeenCalled();
+		});
+
+		it("blocks save note BEFORE storeNotes", async () => {
+			(
+				stubBridge.getSummaryIndexEntryMap as ReturnType<typeof vi.fn>
+			).mockResolvedValue(
+				buildChainEntryMap([
+					{ hash: "abc123", parent: "rootnew0" },
+					{ hash: "rootnew0", parent: null },
+				]),
+			);
+			const dispatch = await setupCommit("abc123");
+
+			dispatch({
+				command: "saveNote",
+				id: "n",
+				content: "# Title\n\nbody",
+				format: "markdown",
+			});
+			await flushPromises();
+
+			expect(showWarningMessage).toHaveBeenCalledWith(
+				expect.stringContaining("save note"),
+			);
+			expect(mockStoreNotes).not.toHaveBeenCalled();
+			expect(mockStoreSummary).not.toHaveBeenCalled();
+		});
+
+		it("blocks translate plan BEFORE readPlanFromBranch", async () => {
+			(
+				stubBridge.getSummaryIndexEntryMap as ReturnType<typeof vi.fn>
+			).mockResolvedValue(
+				buildChainEntryMap([
+					{ hash: "abc123", parent: "rootnew0" },
+					{ hash: "rootnew0", parent: null },
+				]),
+			);
+			const dispatch = await setupCommit("abc123");
+
+			dispatch({ command: "translatePlan", slug: "p" });
+			await flushPromises();
+
+			expect(showWarningMessage).toHaveBeenCalledWith(
+				expect.stringContaining("translate plan"),
+			);
+			expect(mockReadPlanFromBranch).not.toHaveBeenCalled();
+			expect(mockStorePlans).not.toHaveBeenCalled();
+			expect(mockStoreSummary).not.toHaveBeenCalled();
+		});
+
+		it("blocks translate note when the commit was rewritten", async () => {
+			(
+				stubBridge.getSummaryIndexEntryMap as ReturnType<typeof vi.fn>
+			).mockResolvedValue(
+				buildChainEntryMap([
+					{ hash: "abc123", parent: "rootnew0" },
+					{ hash: "rootnew0", parent: null },
+				]),
+			);
+			await SummaryWebviewPanel.show(
+				makeSummary({
+					commitHash: "abc123",
+					notes: [{ id: "n", title: "N", format: "snippet", content: "中文" }],
+				}),
+				extensionUri,
+				workspaceRoot,
+				stubBridge,
+				mainBranch,
+			);
+			const dispatch = captureMessageHandler();
+
+			dispatch({ command: "translateNote", id: "n" });
+			await flushPromises();
+
+			expect(showWarningMessage).toHaveBeenCalledWith(
+				expect.stringContaining("translate note"),
+			);
+			expect(mockStoreNotes).not.toHaveBeenCalled();
+			expect(mockStoreSummary).not.toHaveBeenCalled();
+		});
+
+		it("reads the index via the bridge (storage-threaded), not via direct SummaryStore", async () => {
+			// Storage-threading regression guard: ensureCommitNotRewritten must
+			// route through bridge.getSummaryIndexEntryMap so folder-mode users
+			// get the correct backend. A direct `getIndexEntryMap(cwd)` call
+			// would silently fall back to OrphanBranchStorage and read the wrong
+			// file under non-default storage modes.
+			const spy = stubBridge.getSummaryIndexEntryMap as ReturnType<
+				typeof vi.fn
+			>;
+			spy.mockResolvedValue(new Map());
+			const dispatch = await setupCommit("abc123");
+
+			dispatch({ command: "push" });
+			await flushPromises();
+
+			expect(spy).toHaveBeenCalled();
 		});
 	});
 

--- a/vscode/src/views/SummaryWebviewPanel.test.ts
+++ b/vscode/src/views/SummaryWebviewPanel.test.ts
@@ -7824,7 +7824,15 @@ describe("SummaryWebviewPanel", () => {
 			await SummaryWebviewPanel.show(
 				makeSummary({
 					commitHash: "abc123",
-					plans: [{ slug: "p", title: "P" }],
+					plans: [
+						{
+							slug: "p",
+							title: "P",
+							editCount: 0,
+							addedAt: "2026-01-01T00:00:00Z",
+							updatedAt: "2026-01-01T00:00:00Z",
+						},
+					],
 				}),
 				extensionUri,
 				workspaceRoot,
@@ -7858,7 +7866,15 @@ describe("SummaryWebviewPanel", () => {
 			await SummaryWebviewPanel.show(
 				makeSummary({
 					commitHash: "abc123",
-					notes: [{ id: "n", title: "N", format: "snippet" }],
+					notes: [
+						{
+							id: "n",
+							title: "N",
+							format: "snippet",
+							addedAt: "2026-01-01T00:00:00Z",
+							updatedAt: "2026-01-01T00:00:00Z",
+						},
+					],
 				}),
 				extensionUri,
 				workspaceRoot,
@@ -7894,7 +7910,8 @@ describe("SummaryWebviewPanel", () => {
 							ticketId: "JOLLI-1",
 							title: "T",
 							url: "https://linear.app/x",
-							capturedAt: "2026-01-01T00:00:00Z",
+							referencedAt: "2026-01-01T00:00:00Z",
+							sourceToolName: "linear:get-issue",
 						},
 					],
 				}),
@@ -8076,7 +8093,16 @@ describe("SummaryWebviewPanel", () => {
 			await SummaryWebviewPanel.show(
 				makeSummary({
 					commitHash: "abc123",
-					notes: [{ id: "n", title: "N", format: "snippet", content: "中文" }],
+					notes: [
+						{
+							id: "n",
+							title: "N",
+							format: "snippet",
+							content: "中文",
+							addedAt: "2026-01-01T00:00:00Z",
+							updatedAt: "2026-01-01T00:00:00Z",
+						},
+					],
 				}),
 				extensionUri,
 				workspaceRoot,
@@ -8111,6 +8137,162 @@ describe("SummaryWebviewPanel", () => {
 			await flushPromises();
 
 			expect(spy).toHaveBeenCalled();
+		});
+
+		// ── Race-window: amend lands BETWEEN entry guard and write ───────────
+		// Entry guard passes (commit is still root at click time) but the
+		// commit gets rewritten during the long-async step (LLM call /
+		// QuickPick / confirm modal). The second guard must catch this and
+		// block the write. Verifying by flipping the index entry map between
+		// the first and second `getSummaryIndexEntryMap` calls.
+
+		/** Returns a `getSummaryIndexEntryMap` mock that resolves to `firstMap`
+		 *  on the first call and `restMap` on every subsequent call — simulates
+		 *  an amend landing between entry guard and pre-write re-check. */
+		function makeRacingEntryMapMock(
+			firstMap: ReadonlyMap<
+				string,
+				{ commitHash: string; parentCommitHash: string | null }
+			>,
+			restMap: ReadonlyMap<
+				string,
+				{ commitHash: string; parentCommitHash: string | null }
+			>,
+		) {
+			let calls = 0;
+			return vi.fn(() => {
+				calls += 1;
+				return Promise.resolve(calls === 1 ? firstMap : restMap);
+			});
+		}
+
+		it("race-window: blocks generate E2E test guide if amend lands during the LLM call", async () => {
+			const rootMap = buildChainEntryMap([{ hash: "abc123", parent: null }]);
+			const rewrittenMap = buildChainEntryMap([
+				{ hash: "abc123", parent: "rootnew0" },
+				{ hash: "rootnew0", parent: null },
+			]);
+			(
+				stubBridge as unknown as {
+					getSummaryIndexEntryMap: ReturnType<typeof vi.fn>;
+				}
+			).getSummaryIndexEntryMap = makeRacingEntryMapMock(rootMap, rewrittenMap);
+			mockGenerateE2eTest.mockResolvedValue([
+				{ title: "Scenario", steps: [], expectedResults: [] },
+			]);
+			const dispatch = await setupCommit("abc123");
+
+			dispatch({ command: "generateE2eTest" });
+			await flushPromises();
+
+			// LLM call DID happen (entry guard let it through); the result was
+			// discarded by the pre-write guard.
+			expect(mockGenerateE2eTest).toHaveBeenCalled();
+			expect(showWarningMessage).toHaveBeenCalledWith(
+				expect.stringContaining("rewritten into rootnew0"),
+			);
+			expect(mockStoreSummary).not.toHaveBeenCalled();
+		});
+
+		it("race-window: blocks delete memory if amend lands while confirm modal is open", async () => {
+			const rootMap = buildChainEntryMap([{ hash: "abc123", parent: null }]);
+			const rewrittenMap = buildChainEntryMap([
+				{ hash: "abc123", parent: "rootnew0" },
+				{ hash: "rootnew0", parent: null },
+			]);
+			(
+				stubBridge as unknown as {
+					getSummaryIndexEntryMap: ReturnType<typeof vi.fn>;
+				}
+			).getSummaryIndexEntryMap = makeRacingEntryMapMock(rootMap, rewrittenMap);
+			// User confirms the deletion — modal returns "Delete".
+			showWarningMessage.mockResolvedValueOnce("Delete");
+			const dispatch = await setupCommit("abc123");
+
+			dispatch({ command: "deleteTopic", topicIndex: 0 });
+			await flushPromises();
+
+			// Confirm modal WAS shown (entry guard let it through); the
+			// post-confirm guard blocked the storeSummary write.
+			expect(showWarningMessage).toHaveBeenCalledWith(
+				expect.stringMatching(/^Delete /),
+				expect.any(Object),
+				"Delete",
+			);
+			expect(mockStoreSummary).not.toHaveBeenCalled();
+		});
+
+		it("race-window: blocks add plan if amend lands while QuickPick is open", async () => {
+			const rootMap = buildChainEntryMap([{ hash: "abc123", parent: null }]);
+			const rewrittenMap = buildChainEntryMap([
+				{ hash: "abc123", parent: "rootnew0" },
+				{ hash: "rootnew0", parent: null },
+			]);
+			(
+				stubBridge as unknown as {
+					getSummaryIndexEntryMap: ReturnType<typeof vi.fn>;
+				}
+			).getSummaryIndexEntryMap = makeRacingEntryMapMock(rootMap, rewrittenMap);
+			mockListAvailablePlans.mockReturnValue([{ slug: "p", title: "P" }]);
+			// User picks a plan from the QuickPick.
+			showQuickPick.mockResolvedValueOnce({
+				label: "P",
+				description: "p.md",
+				slug: "p",
+			});
+			const dispatch = await setupCommit("abc123");
+
+			dispatch({ command: "addPlan" });
+			await flushPromises();
+
+			// QuickPick DID open (entry guard let it through); the post-pick
+			// guard blocked both the archive and storeSummary.
+			expect(showQuickPick).toHaveBeenCalled();
+			expect(mockArchivePlanForCommit).not.toHaveBeenCalled();
+			expect(mockStoreSummary).not.toHaveBeenCalled();
+		});
+
+		it("race-window: blocks translate plan if amend lands during the LLM call", async () => {
+			const rootMap = buildChainEntryMap([{ hash: "abc123", parent: null }]);
+			const rewrittenMap = buildChainEntryMap([
+				{ hash: "abc123", parent: "rootnew0" },
+				{ hash: "rootnew0", parent: null },
+			]);
+			(
+				stubBridge as unknown as {
+					getSummaryIndexEntryMap: ReturnType<typeof vi.fn>;
+				}
+			).getSummaryIndexEntryMap = makeRacingEntryMapMock(rootMap, rewrittenMap);
+			mockReadPlanFromBranch.mockResolvedValue("# 中文标题\n\nbody");
+			mockTranslateToEnglish.mockResolvedValue("# English Title\n\nbody");
+			await SummaryWebviewPanel.show(
+				makeSummary({
+					commitHash: "abc123",
+					plans: [
+						{
+							slug: "p",
+							title: "中文标题",
+							editCount: 0,
+							addedAt: "2026-01-01T00:00:00Z",
+							updatedAt: "2026-01-01T00:00:00Z",
+						},
+					],
+				}),
+				extensionUri,
+				workspaceRoot,
+				stubBridge,
+				mainBranch,
+			);
+			const dispatch = captureMessageHandler();
+
+			dispatch({ command: "translatePlan", slug: "p" });
+			await flushPromises();
+
+			// LLM translate DID run (entry guard let it through); the post-LLM
+			// guard blocked storePlans + syncPlanTitle (storeSummary).
+			expect(mockTranslateToEnglish).toHaveBeenCalled();
+			expect(mockStorePlans).not.toHaveBeenCalled();
+			expect(mockStoreSummary).not.toHaveBeenCalled();
 		});
 	});
 

--- a/vscode/src/views/SummaryWebviewPanel.test.ts
+++ b/vscode/src/views/SummaryWebviewPanel.test.ts
@@ -7471,6 +7471,26 @@ describe("SummaryWebviewPanel", () => {
 			return captureMessageHandler();
 		}
 
+		/**
+		 * Asserts the stale-commit modal was raised with the expected
+		 * substrings in its message. `showWarningMessage` is called with
+		 * `(msg, { modal: true, detail }, "Open new commit's summary")` —
+		 * checking presence via mock.calls.some lets each test target a
+		 * specific operation label without binding to the full arg shape.
+		 */
+		function expectStaleModalShown(...substrings: ReadonlyArray<string>): void {
+			const matched = showWarningMessage.mock.calls.find(
+				(c) =>
+					typeof c[0] === "string" &&
+					substrings.every((s) => (c[0] as string).includes(s)) &&
+					typeof c[1] === "object" &&
+					c[1] !== null &&
+					(c[1] as { modal?: boolean }).modal === true &&
+					c[2] === "Open new commit's summary",
+			);
+			expect(matched).toBeDefined();
+		}
+
 		it("allows push when the commit is still a root entry", async () => {
 			(
 				stubBridge.getSummaryIndexEntryMap as ReturnType<typeof vi.fn>
@@ -7521,21 +7541,23 @@ describe("SummaryWebviewPanel", () => {
 			dispatch({ command: "push" });
 			await flushPromises();
 
-			// User-facing warning surfaces the live root's short hash.
-			expect(showWarningMessage).toHaveBeenCalledWith(
-				expect.stringContaining("rewritten into rootnew0"),
+			// User-facing modal carries the old and new short hashes plus the
+			// operation label so the user knows exactly what was blocked.
+			expectStaleModalShown(
+				"rewritten into rootnew0",
+				"abc123",
+				"push to Jolli",
 			);
-			expect(showWarningMessage).toHaveBeenCalledWith(
-				expect.stringContaining("abc123"),
+			// Panel transitions to stale-readonly (NOT disposed) — buildHtml is
+			// re-invoked with `staleRewrittenInto` set so the rendered output
+			// gets the .stale-readonly hook class and the banner. We verify
+			// the option, not the rendered HTML, because buildHtml is mocked.
+			const staleRender = mockBuildHtml.mock.calls.find(
+				(c) =>
+					(c[1] as { staleRewrittenInto?: string } | undefined)
+						?.staleRewrittenInto === "rootnew0",
 			);
-			expect(showWarningMessage).toHaveBeenCalledWith(
-				expect.stringContaining("push to Jolli"),
-			);
-			// Side effect: panel disposed so the stale tab can't be reused.
-			expect(
-				firstCommitPanel<{ panel: { dispose: ReturnType<typeof vi.fn> } }>()
-					.panel.dispose,
-			).toHaveBeenCalled();
+			expect(staleRender).toBeDefined();
 			// And the storage write never happened.
 			expect(mockStoreSummary).not.toHaveBeenCalled();
 		});
@@ -7557,9 +7579,7 @@ describe("SummaryWebviewPanel", () => {
 			dispatch({ command: "push" });
 			await flushPromises();
 
-			expect(showWarningMessage).toHaveBeenCalledWith(
-				expect.stringContaining("rewritten into finalrt"),
-			);
+			expectStaleModalShown("rewritten into finalrt");
 			expect(mockStoreSummary).not.toHaveBeenCalled();
 		});
 
@@ -7584,9 +7604,13 @@ describe("SummaryWebviewPanel", () => {
 			// We surface whichever hash the walk landed on before detecting the
 			// cycle — either cyclea0 or cycleb0, depending on iteration order;
 			// the important thing is that no crash and no storage write happens.
-			expect(showWarningMessage).toHaveBeenCalledWith(
-				expect.stringMatching(/rewritten into (cyclea0|cycleb0)/),
+			const cycleModal = showWarningMessage.mock.calls.find(
+				(c) =>
+					typeof c[0] === "string" &&
+					/rewritten into (cyclea0|cycleb0)/.test(c[0]) &&
+					c[2] === "Open new commit's summary",
 			);
+			expect(cycleModal).toBeDefined();
 			expect(mockStoreSummary).not.toHaveBeenCalled();
 		});
 
@@ -7608,9 +7632,7 @@ describe("SummaryWebviewPanel", () => {
 			});
 			await flushPromises();
 
-			expect(showWarningMessage).toHaveBeenCalledWith(
-				expect.stringContaining("edit memory"),
-			);
+			expectStaleModalShown("edit memory");
 			expect(mockStoreSummary).not.toHaveBeenCalled();
 		});
 
@@ -7628,9 +7650,7 @@ describe("SummaryWebviewPanel", () => {
 			dispatch({ command: "generateE2eTest" });
 			await flushPromises();
 
-			expect(showWarningMessage).toHaveBeenCalledWith(
-				expect.stringContaining("generate E2E test guide"),
-			);
+			expectStaleModalShown("generate E2E test guide");
 			expect(mockStoreSummary).not.toHaveBeenCalled();
 		});
 
@@ -7669,9 +7689,7 @@ describe("SummaryWebviewPanel", () => {
 			});
 			await flushPromises();
 
-			expect(showWarningMessage).toHaveBeenCalledWith(
-				expect.stringContaining("edit E2E scenario"),
-			);
+			expectStaleModalShown("edit E2E scenario");
 			expect(mockStoreSummary).not.toHaveBeenCalled();
 		});
 
@@ -7707,9 +7725,7 @@ describe("SummaryWebviewPanel", () => {
 			await flushPromises();
 
 			// Stale warning surfaced, confirm dialog ("Delete scenario ...?") never shown.
-			expect(showWarningMessage).toHaveBeenCalledWith(
-				expect.stringContaining("delete E2E scenario"),
-			);
+			expectStaleModalShown("delete E2E scenario");
 			const confirmCalls = showWarningMessage.mock.calls.filter((c) =>
 				typeof c[0] === "string" ? c[0].startsWith("Delete scenario") : false,
 			);
@@ -7731,9 +7747,7 @@ describe("SummaryWebviewPanel", () => {
 			dispatch({ command: "deleteE2eTest" });
 			await flushPromises();
 
-			expect(showWarningMessage).toHaveBeenCalledWith(
-				expect.stringContaining("delete E2E test guide"),
-			);
+			expectStaleModalShown("delete E2E test guide");
 			const confirmCalls = showWarningMessage.mock.calls.filter((c) =>
 				typeof c[0] === "string" ? c[0] === "Delete E2E Test Guide?" : false,
 			);
@@ -7755,9 +7769,7 @@ describe("SummaryWebviewPanel", () => {
 			dispatch({ command: "generateRecap" });
 			await flushPromises();
 
-			expect(showWarningMessage).toHaveBeenCalledWith(
-				expect.stringContaining("generate recap"),
-			);
+			expectStaleModalShown("generate recap");
 			expect(mockStoreSummary).not.toHaveBeenCalled();
 		});
 
@@ -7775,9 +7787,7 @@ describe("SummaryWebviewPanel", () => {
 			dispatch({ command: "deleteTopic", topicIndex: 0 });
 			await flushPromises();
 
-			expect(showWarningMessage).toHaveBeenCalledWith(
-				expect.stringContaining("delete memory"),
-			);
+			expectStaleModalShown("delete memory");
 			// Confirm dialog ("Delete memory?" / "Delete this memory?") never shown.
 			const confirmCalls = showWarningMessage.mock.calls.filter((c) =>
 				typeof c[0] === "string" ? c[0].startsWith("Delete") : false,
@@ -7800,9 +7810,7 @@ describe("SummaryWebviewPanel", () => {
 			dispatch({ command: "editE2eTest", scenarios: [] });
 			await flushPromises();
 
-			expect(showWarningMessage).toHaveBeenCalledWith(
-				expect.stringContaining("edit E2E test guide"),
-			);
+			expectStaleModalShown("edit E2E test guide");
 			expect(mockStoreSummary).not.toHaveBeenCalled();
 		});
 
@@ -7844,9 +7852,7 @@ describe("SummaryWebviewPanel", () => {
 			dispatch({ command: "removePlan", slug: "p", title: "P" });
 			await flushPromises();
 
-			expect(showWarningMessage).toHaveBeenCalledWith(
-				expect.stringContaining("remove plan"),
-			);
+			expectStaleModalShown("remove plan");
 			const confirmCalls = showWarningMessage.mock.calls.filter((c) =>
 				typeof c[0] === "string" ? c[0].startsWith("Remove plan") : false,
 			);
@@ -7886,9 +7892,7 @@ describe("SummaryWebviewPanel", () => {
 			dispatch({ command: "removeNote", id: "n", title: "N" });
 			await flushPromises();
 
-			expect(showWarningMessage).toHaveBeenCalledWith(
-				expect.stringContaining("remove note"),
-			);
+			expectStaleModalShown("remove note");
 			expect(mockStoreSummary).not.toHaveBeenCalled();
 		});
 
@@ -7929,9 +7933,7 @@ describe("SummaryWebviewPanel", () => {
 			});
 			await flushPromises();
 
-			expect(showWarningMessage).toHaveBeenCalledWith(
-				expect.stringContaining("remove Linear issue"),
-			);
+			expectStaleModalShown("remove Linear issue");
 			expect(mockStoreSummary).not.toHaveBeenCalled();
 		});
 
@@ -7952,9 +7954,7 @@ describe("SummaryWebviewPanel", () => {
 			dispatch({ command: "addPlan" });
 			await flushPromises();
 
-			expect(showWarningMessage).toHaveBeenCalledWith(
-				expect.stringContaining("add plan"),
-			);
+			expectStaleModalShown("add plan");
 			expect(showQuickPick).not.toHaveBeenCalled();
 			expect(mockArchivePlanForCommit).not.toHaveBeenCalled();
 			expect(mockStoreSummary).not.toHaveBeenCalled();
@@ -7974,9 +7974,7 @@ describe("SummaryWebviewPanel", () => {
 			dispatch({ command: "addMarkdownNote" });
 			await flushPromises();
 
-			expect(showWarningMessage).toHaveBeenCalledWith(
-				expect.stringContaining("add markdown note"),
-			);
+			expectStaleModalShown("add markdown note");
 			expect(showOpenDialog).not.toHaveBeenCalled();
 			expect(mockArchiveNoteForCommit).not.toHaveBeenCalled();
 			expect(mockStoreSummary).not.toHaveBeenCalled();
@@ -8000,9 +7998,7 @@ describe("SummaryWebviewPanel", () => {
 			});
 			await flushPromises();
 
-			expect(showWarningMessage).toHaveBeenCalledWith(
-				expect.stringContaining("save snippet"),
-			);
+			expectStaleModalShown("save snippet");
 			expect(mockSaveNote).not.toHaveBeenCalled();
 			expect(mockArchiveNoteForCommit).not.toHaveBeenCalled();
 			expect(mockStoreSummary).not.toHaveBeenCalled();
@@ -8026,9 +8022,7 @@ describe("SummaryWebviewPanel", () => {
 			});
 			await flushPromises();
 
-			expect(showWarningMessage).toHaveBeenCalledWith(
-				expect.stringContaining("save plan"),
-			);
+			expectStaleModalShown("save plan");
 			expect(mockStorePlans).not.toHaveBeenCalled();
 			expect(mockStoreSummary).not.toHaveBeenCalled();
 		});
@@ -8052,9 +8046,7 @@ describe("SummaryWebviewPanel", () => {
 			});
 			await flushPromises();
 
-			expect(showWarningMessage).toHaveBeenCalledWith(
-				expect.stringContaining("save note"),
-			);
+			expectStaleModalShown("save note");
 			expect(mockStoreNotes).not.toHaveBeenCalled();
 			expect(mockStoreSummary).not.toHaveBeenCalled();
 		});
@@ -8073,9 +8065,7 @@ describe("SummaryWebviewPanel", () => {
 			dispatch({ command: "translatePlan", slug: "p" });
 			await flushPromises();
 
-			expect(showWarningMessage).toHaveBeenCalledWith(
-				expect.stringContaining("translate plan"),
-			);
+			expectStaleModalShown("translate plan");
 			expect(mockReadPlanFromBranch).not.toHaveBeenCalled();
 			expect(mockStorePlans).not.toHaveBeenCalled();
 			expect(mockStoreSummary).not.toHaveBeenCalled();
@@ -8114,9 +8104,7 @@ describe("SummaryWebviewPanel", () => {
 			dispatch({ command: "translateNote", id: "n" });
 			await flushPromises();
 
-			expect(showWarningMessage).toHaveBeenCalledWith(
-				expect.stringContaining("translate note"),
-			);
+			expectStaleModalShown("translate note");
 			expect(mockStoreNotes).not.toHaveBeenCalled();
 			expect(mockStoreSummary).not.toHaveBeenCalled();
 		});
@@ -8188,9 +8176,7 @@ describe("SummaryWebviewPanel", () => {
 			// LLM call DID happen (entry guard let it through); the result was
 			// discarded by the pre-write guard.
 			expect(mockGenerateE2eTest).toHaveBeenCalled();
-			expect(showWarningMessage).toHaveBeenCalledWith(
-				expect.stringContaining("rewritten into rootnew0"),
-			);
+			expectStaleModalShown("rewritten into rootnew0");
 			expect(mockStoreSummary).not.toHaveBeenCalled();
 		});
 
@@ -8293,6 +8279,197 @@ describe("SummaryWebviewPanel", () => {
 			expect(mockTranslateToEnglish).toHaveBeenCalled();
 			expect(mockStorePlans).not.toHaveBeenCalled();
 			expect(mockStoreSummary).not.toHaveBeenCalled();
+		});
+
+		// ── Stale-readonly mode transitions ───────────────────────────────
+
+		it("clicking 'Open new commit's summary' on the modal fires jollimemory.viewSummary with the live root hash", async () => {
+			(
+				stubBridge.getSummaryIndexEntryMap as ReturnType<typeof vi.fn>
+			).mockResolvedValue(
+				buildChainEntryMap([
+					{ hash: "abc123", parent: "rootnew0" },
+					{ hash: "rootnew0", parent: null },
+				]),
+			);
+			// User chooses to navigate to the live commit's summary.
+			showWarningMessage.mockResolvedValueOnce("Open new commit's summary");
+			const dispatch = await setupCommit("abc123");
+
+			dispatch({ command: "push" });
+			await flushPromises();
+
+			expect(executeCommand).toHaveBeenCalledWith(
+				"jollimemory.viewSummary",
+				"rootnew0",
+			);
+		});
+
+		it("dismissing the modal leaves the panel open in stale-readonly mode (no viewSummary dispatch)", async () => {
+			(
+				stubBridge.getSummaryIndexEntryMap as ReturnType<typeof vi.fn>
+			).mockResolvedValue(
+				buildChainEntryMap([
+					{ hash: "abc123", parent: "rootnew0" },
+					{ hash: "rootnew0", parent: null },
+				]),
+			);
+			// User dismisses the modal (Esc or "x" button) — undefined return.
+			showWarningMessage.mockResolvedValueOnce(undefined);
+			const dispatch = await setupCommit("abc123");
+
+			dispatch({ command: "push" });
+			await flushPromises();
+
+			// No navigation triggered, but panel was re-rendered in stale mode.
+			const viewSummaryCalls = executeCommand.mock.calls.filter(
+				(c) => c[0] === "jollimemory.viewSummary",
+			);
+			expect(viewSummaryCalls).toHaveLength(0);
+			const staleRender = mockBuildHtml.mock.calls.find(
+				(c) =>
+					(c[1] as { staleRewrittenInto?: string } | undefined)
+						?.staleRewrittenInto === "rootnew0",
+			);
+			expect(staleRender).toBeDefined();
+		});
+
+		it("openRewrittenCommit webview message (banner button click) opens the new commit's panel", async () => {
+			// Set up a fresh panel — banner action is independent of the modal
+			// flow, the webview can post it any time the user clicks the
+			// banner button (e.g. after dismissing the modal).
+			const dispatch = await setupCommit("abc123");
+
+			dispatch({ command: "openRewrittenCommit", hash: "newroot0" });
+			await flushPromises();
+
+			expect(executeCommand).toHaveBeenCalledWith(
+				"jollimemory.viewSummary",
+				"newroot0",
+			);
+		});
+
+		it("second guard trip is silent: no second modal, no second re-render", async () => {
+			(
+				stubBridge.getSummaryIndexEntryMap as ReturnType<typeof vi.fn>
+			).mockResolvedValue(
+				buildChainEntryMap([
+					{ hash: "abc123", parent: "rootnew0" },
+					{ hash: "rootnew0", parent: null },
+				]),
+			);
+			showWarningMessage.mockResolvedValue(undefined);
+			const dispatch = await setupCommit("abc123");
+
+			dispatch({ command: "push" });
+			await flushPromises();
+
+			const firstModalCount = showWarningMessage.mock.calls.filter(
+				(c) =>
+					typeof c[0] === "string" &&
+					(c[0] as string).includes("rewritten into"),
+			).length;
+			const firstStaleRenders = mockBuildHtml.mock.calls.filter(
+				(c) =>
+					(c[1] as { staleRewrittenInto?: string } | undefined)
+						?.staleRewrittenInto === "rootnew0",
+			).length;
+
+			// Second click on any guarded action — should NOT raise another
+			// modal or re-render. The dispatcher / handler short-circuits
+			// purely on the `staleRewrittenInto` field.
+			dispatch({ command: "generateE2eTest" });
+			await flushPromises();
+
+			const secondModalCount = showWarningMessage.mock.calls.filter(
+				(c) =>
+					typeof c[0] === "string" &&
+					(c[0] as string).includes("rewritten into"),
+			).length;
+			const secondStaleRenders = mockBuildHtml.mock.calls.filter(
+				(c) =>
+					(c[1] as { staleRewrittenInto?: string } | undefined)
+						?.staleRewrittenInto === "rootnew0",
+			).length;
+			expect(secondModalCount).toBe(firstModalCount);
+			expect(secondStaleRenders).toBe(firstStaleRenders);
+		});
+
+		it("passes the FULL 40-char root hash to buildHtml (not the short display form)", async () => {
+			// Regression guard for the banner's "Open new commit's summary"
+			// action. buildHtml receives `staleRewrittenInto` and is
+			// responsible for rendering the short form for display while
+			// keeping the full hash in `data-target-hash`. The panel must
+			// store the full hash; if it pre-truncates, navigation breaks
+			// (getSummary alias lookup is 40-char only, prefix scan can
+			// throw on collisions).
+			const fullChildHash = "a".repeat(40);
+			const fullRootHash = "b".repeat(40);
+			(
+				stubBridge.getSummaryIndexEntryMap as ReturnType<typeof vi.fn>
+			).mockResolvedValue(
+				buildChainEntryMap([
+					{ hash: fullChildHash, parent: fullRootHash },
+					{ hash: fullRootHash, parent: null },
+				]),
+			);
+			showWarningMessage.mockResolvedValueOnce(undefined);
+			const dispatch = await setupCommit(fullChildHash);
+
+			dispatch({ command: "push" });
+			await flushPromises();
+
+			// buildHtml gets the untruncated value.
+			const staleRender = mockBuildHtml.mock.calls.find(
+				(c) =>
+					(c[1] as { staleRewrittenInto?: string } | undefined)
+						?.staleRewrittenInto === fullRootHash,
+			);
+			expect(staleRender).toBeDefined();
+			// The modal still uses the short form for readability.
+			expectStaleModalShown(
+				"rewritten into bbbbbbbb",
+				"aaaaaaaa",
+				"push to Jolli",
+			);
+		});
+
+		// ── Transcript handlers (P2 #2) ──────────────────────────────────
+
+		it("blocks save all transcripts when the commit was rewritten", async () => {
+			(
+				stubBridge.getSummaryIndexEntryMap as ReturnType<typeof vi.fn>
+			).mockResolvedValue(
+				buildChainEntryMap([
+					{ hash: "abc123", parent: "rootnew0" },
+					{ hash: "rootnew0", parent: null },
+				]),
+			);
+			const dispatch = await setupCommit("abc123");
+
+			dispatch({ command: "saveAllTranscripts", entries: [] });
+			await flushPromises();
+
+			expectStaleModalShown("save transcripts");
+			expect(mockSaveTranscriptsBatch).not.toHaveBeenCalled();
+		});
+
+		it("blocks delete all transcripts when the commit was rewritten", async () => {
+			(
+				stubBridge.getSummaryIndexEntryMap as ReturnType<typeof vi.fn>
+			).mockResolvedValue(
+				buildChainEntryMap([
+					{ hash: "abc123", parent: "rootnew0" },
+					{ hash: "rootnew0", parent: null },
+				]),
+			);
+			const dispatch = await setupCommit("abc123");
+
+			dispatch({ command: "deleteAllTranscripts" });
+			await flushPromises();
+
+			expectStaleModalShown("delete transcripts");
+			expect(mockSaveTranscriptsBatch).not.toHaveBeenCalled();
 		});
 	});
 

--- a/vscode/src/views/SummaryWebviewPanel.ts
+++ b/vscode/src/views/SummaryWebviewPanel.ts
@@ -159,7 +159,8 @@ type WebviewMessage =
 	  }
 	| { command: "deleteAllTranscripts" }
 	| { command: "editRecap"; recap: string }
-	| { command: "generateRecap" };
+	| { command: "generateRecap" }
+	| { command: "openRewrittenCommit"; hash: string };
 
 /** Entry data sent back from the webview on Save All. */
 interface TranscriptEntryUpdate {
@@ -192,6 +193,10 @@ const FOREIGN_SAFE_COMMANDS: ReadonlySet<WebviewMessage["command"]> = new Set([
 	// workspace's git/GitHub; when foreignRepoUrl is null (local-only
 	// foreign repo) the handler short-circuits with `unavailable`.
 	"checkPrStatus",
+	// Navigation-only — fires `jollimemory.viewSummary` against a hash
+	// supplied by the stale banner the panel itself rendered. No write
+	// path, no workspace coupling beyond opening another panel.
+	"openRewrittenCommit",
 ]);
 
 function isForeignSafeCommand(command: WebviewMessage["command"]): boolean {
@@ -285,6 +290,25 @@ export class SummaryWebviewPanel {
 	 * skip the webview write (panel.webview.html throws on a disposed panel).
 	 */
 	private disposed = false;
+	/**
+	 * Full 40-char hash of the live root commit when this panel's commit has
+	 * been rewritten by amend / squash / rebase (set by
+	 * `ensureCommitNotRewritten` on first detection). Once non-null the panel
+	 * renders in stale-readonly mode: every destructive button is hidden via
+	 * CSS, the banner explains where to go, and subsequent write attempts
+	 * short-circuit silently without re-showing the modal. The field is
+	 * never cleared — once the underlying commit is gone, the only sane
+	 * transition is for the user to open the new commit's summary in its
+	 * own panel.
+	 *
+	 * Why full hash: the banner's "Open new commit's summary" button posts
+	 * this value through to `jollimemory.viewSummary` → `getSummary()`.
+	 * `getSummary()` only resolves `commitAliases` for 40-char inputs and
+	 * throws `AmbiguousHashError` on prefix collisions. A short prefix here
+	 * would silently fail to navigate in those cases. Display short-form is
+	 * computed at render time in `buildHtml`.
+	 */
+	private staleRewrittenInto: string | undefined;
 
 	private readonly bridge: JolliMemoryBridge;
 	// Snapshot of `CommitsStore.getMainBranch()` at panel creation. Revisit
@@ -674,6 +698,12 @@ export class SummaryWebviewPanel {
 					"Delete transcripts failed",
 				);
 				break;
+			case "openRewrittenCommit":
+				this.catchAndShow(
+					this.openRewrittenCommit(message.hash),
+					"Open rewritten commit failed",
+				);
+				break;
 		}
 	}
 
@@ -726,16 +756,29 @@ export class SummaryWebviewPanel {
 	 * We detect this via the index: every rewrite by jollimemory's own queue
 	 * sets `parentCommitHash` on the old entry pointing at the new root. An
 	 * entry with `parentCommitHash != null` therefore means "this commit has
-	 * been folded into another" — block the write, surface where to go (the
-	 * live root reached by walking the parent chain), and dispose the panel so
-	 * the stale tab can't be reused.
+	 * been folded into another" — block the write and transition the panel
+	 * into stale-readonly mode (parallel to foreign-readonly): a banner
+	 * appears, every destructive button is hidden via CSS, and a one-time
+	 * modal offers the user a button to jump straight to the new commit's
+	 * summary. The panel itself is kept open so the user can still read the
+	 * orphaned commit's content (which they may need for context) and so they
+	 * don't lose their place mid-task (e.g. mid-LLM-wait).
 	 *
 	 * Returns `true` when the operation may proceed (commit is still a root,
 	 * or absent from the index entirely — legacy / external commits / freshly
 	 * created entries the worker has not yet indexed). Returns `false` after
-	 * surfacing the warning and disposing; callers must short-circuit.
+	 * triggering the stale-readonly transition; callers must short-circuit.
+	 *
+	 * Idempotent: once the panel is already in stale-readonly mode, returns
+	 * false silently without re-firing the modal — every subsequent click on
+	 * a destructive control would otherwise spam the user.
 	 */
 	private async ensureCommitNotRewritten(operation: string): Promise<boolean> {
+		// Already stale → short-circuit without re-prompting. The CSS hides
+		// the destructive buttons; this guards the dispatcher path against
+		// any direct postMessage from a stale tab that survived a webview
+		// reload.
+		if (this.staleRewrittenInto) return false;
 		if (!this.currentSummary) return true;
 		const hash = this.currentSummary.commitHash;
 		// Route through the Bridge so the read picks up the extension's
@@ -762,11 +805,63 @@ export class SummaryWebviewPanel {
 			rootHash = parent.parentCommitHash;
 		}
 
-		void vscode.window.showWarningMessage(
-			`Cannot ${operation}: commit ${hash.substring(0, 8)} was rewritten into ${rootHash.substring(0, 8)}. Open that commit's summary instead.`,
-		);
-		this.panel.dispose();
+		await this.enterStaleReadonlyMode(operation, hash, rootHash);
 		return false;
+	}
+
+	/**
+	 * Transitions the panel into stale-readonly mode after a guard detects
+	 * the underlying commit was rewritten. One-shot: only the FIRST guard
+	 * trip reaches here (subsequent attempts short-circuit on the
+	 * `staleRewrittenInto` field). Fires a modal so the user understands
+	 * what changed and gets a one-click jump to the live commit's panel,
+	 * then re-renders the webview in stale-readonly mode so the banner
+	 * appears and destructive buttons disappear.
+	 */
+	private async enterStaleReadonlyMode(
+		operation: string,
+		hash: string,
+		rootHash: string,
+	): Promise<void> {
+		const shortRoot = rootHash.substring(0, 8);
+		const shortHash = hash.substring(0, 8);
+		// Store the FULL hash so the banner's "Open new commit's summary"
+		// action resolves through `getSummary()`'s alias lookup (40-char
+		// only) and side-steps prefix-collision throws. Display short-form
+		// is derived at render time in `buildHtml`.
+		this.staleRewrittenInto = rootHash;
+		// Re-render BEFORE the modal so the banner and hidden-button state
+		// are visible the moment the user dismisses the modal — they get
+		// instant feedback that the panel changed even if they click
+		// "Stay here".
+		if (this.currentSummary) {
+			this.update(this.currentSummary);
+		}
+		const openLabel = "Open new commit's summary";
+		const choice = await vscode.window.showWarningMessage(
+			`Cannot ${operation}: commit ${shortHash} was rewritten into ${shortRoot}.`,
+			{
+				modal: true,
+				detail:
+					"This panel is now read-only. The buttons that write to the commit's summary have been hidden so further edits don't land on the orphaned commit. Open the new commit's summary to continue your work — or stay here to keep reading.",
+			},
+			openLabel,
+		);
+		if (choice === openLabel) {
+			await this.openRewrittenCommit(rootHash);
+		}
+	}
+
+	/**
+	 * Opens the summary panel for the live root that replaced this panel's
+	 * (now-orphaned) commit. Delegates to the existing
+	 * `jollimemory.viewSummary` command rather than calling
+	 * `SummaryWebviewPanel.show` directly so the lookup path stays uniform
+	 * (it handles "summary not found" with a toast and runs the same
+	 * pre-render refresh as the sidebar entry point).
+	 */
+	private async openRewrittenCommit(rootHash: string): Promise<void> {
+		await vscode.commands.executeCommand("jollimemory.viewSummary", rootHash);
 	}
 
 	/**
@@ -867,14 +962,16 @@ export class SummaryWebviewPanel {
 			return;
 		}
 		this.currentSummary = summary;
-		// Prefix the tab title with the foreign repo's name so the user can
-		// tell at a glance that this panel is read-only. The "<<" arrows
-		// echo IntelliJ's "from <repo>" convention while staying short
-		// enough not to truncate the commit message on narrow tab bars.
+		// Prefix the tab title to communicate panel state at a glance.
+		// Foreign-repo prefix comes first since it's intrinsic to the panel,
+		// stale prefix comes second since it's a transient state of the
+		// underlying commit. Both can coexist on a foreign panel whose
+		// source commit was rewritten in the foreign repo.
 		const baseTitle = buildPanelTitle(summary);
-		this.panel.title = this.foreignRepoName
-			? `← ${this.foreignRepoName}: ${baseTitle}`
-			: baseTitle;
+		let title = baseTitle;
+		if (this.foreignRepoName) title = `← ${this.foreignRepoName}: ${title}`;
+		if (this.staleRewrittenInto) title = `⚠ Rewritten — ${title}`;
+		this.panel.title = title;
 		const nonce = randomBytes(16).toString("base64");
 		this.panel.webview.html = buildHtml(summary, {
 			transcriptHashSet: this.transcriptHashSet,
@@ -882,6 +979,7 @@ export class SummaryWebviewPanel {
 			noteTranslateSet: this.noteTranslateSet,
 			nonce,
 			foreignRepoName: this.foreignRepoName,
+			staleRewrittenInto: this.staleRewrittenInto ?? null,
 		});
 	}
 
@@ -2696,6 +2794,14 @@ export class SummaryWebviewPanel {
 	private async handleSaveAllTranscripts(
 		entries: ReadonlyArray<TranscriptEntryUpdate>,
 	): Promise<void> {
+		// Stale-commit guard: transcript writes are keyed by the panel's
+		// `transcriptHashSet`, which reflects the stale tree after amend.
+		// Letting these go through would mutate the orphaned commit's
+		// `transcripts/<hash>.json` files instead of the new HEAD's — same
+		// silent-mismatch class the summary handlers guard against.
+		if (!(await this.ensureCommitNotRewritten("save transcripts"))) {
+			return;
+		}
 		// Group entries by commitHash
 		const byCommit = new Map<string, Array<TranscriptEntryUpdate>>();
 		for (const entry of entries) {
@@ -2791,6 +2897,13 @@ export class SummaryWebviewPanel {
 
 	/** Deletes all transcript files for the current summary tree (scoped by operation boundary). */
 	private async handleDeleteAllTranscripts(): Promise<void> {
+		// Stale-commit guard: same rationale as handleSaveAllTranscripts —
+		// `transcriptHashSet` reflects the orphaned tree post-amend, and a
+		// bulk delete against it would wipe transcripts the new HEAD still
+		// references as descendants of its hoisted tree.
+		if (!(await this.ensureCommitNotRewritten("delete transcripts"))) {
+			return;
+		}
 		const hashes = [...this.transcriptHashSet];
 		if (hashes.length === 0) {
 			return;

--- a/vscode/src/views/SummaryWebviewPanel.ts
+++ b/vscode/src/views/SummaryWebviewPanel.ts
@@ -713,6 +713,63 @@ export class SummaryWebviewPanel {
 	}
 
 	/**
+	 * Pre-write guard for handlers that persist to the orphan branch.
+	 *
+	 * The panel is keyed by `commitHash` in the static `commitPanels` map, so a
+	 * panel opened against commit X stays open after amend / squash / rebase
+	 * rewrites X into Y. Without this guard, any subsequent write from the
+	 * still-open panel (Push to Jolli, Generate E2E, edit memory / recap /
+	 * scenario) silently overwrites the orphaned commit's summary on the orphan
+	 * branch — most visibly losing `jolliDocId` / `jolliDocUrl` for the user
+	 * because the new HEAD's summary was hoisted from the pre-push old summary.
+	 *
+	 * We detect this via the index: every rewrite by jollimemory's own queue
+	 * sets `parentCommitHash` on the old entry pointing at the new root. An
+	 * entry with `parentCommitHash != null` therefore means "this commit has
+	 * been folded into another" — block the write, surface where to go (the
+	 * live root reached by walking the parent chain), and dispose the panel so
+	 * the stale tab can't be reused.
+	 *
+	 * Returns `true` when the operation may proceed (commit is still a root,
+	 * or absent from the index entirely — legacy / external commits / freshly
+	 * created entries the worker has not yet indexed). Returns `false` after
+	 * surfacing the warning and disposing; callers must short-circuit.
+	 */
+	private async ensureCommitNotRewritten(operation: string): Promise<boolean> {
+		if (!this.currentSummary) return true;
+		const hash = this.currentSummary.commitHash;
+		// Route through the Bridge so the read picks up the extension's
+		// DualWriteStorage / FolderStorage instance instead of the
+		// `resolveStorage()` fallback to a fresh OrphanBranchStorage. In
+		// folder-mode the index lives in the folder, not the orphan branch —
+		// missing this would let the guard miss real rewrites (or fire on
+		// stale orphan-branch data) under that storage mode.
+		const entryMap = await this.bridge.getSummaryIndexEntryMap();
+		const entry = entryMap.get(hash);
+
+		// Not in index (legacy / external / pre-index race) or still a root → allow.
+		if (!entry || entry.parentCommitHash == null) return true;
+
+		// Walk up the parentCommitHash chain to find the live root. The cycle
+		// guard is defensive — index links form a DAG by construction, but a
+		// corrupted file shouldn't lock the UI in an infinite loop.
+		let rootHash = entry.parentCommitHash;
+		const visited = new Set<string>([hash]);
+		while (!visited.has(rootHash)) {
+			visited.add(rootHash);
+			const parent = entryMap.get(rootHash);
+			if (!parent || parent.parentCommitHash == null) break;
+			rootHash = parent.parentCommitHash;
+		}
+
+		void vscode.window.showWarningMessage(
+			`Cannot ${operation}: commit ${hash.substring(0, 8)} was rewritten into ${rootHash.substring(0, 8)}. Open that commit's summary instead.`,
+		);
+		this.panel.dispose();
+		return false;
+	}
+
+	/**
 	 * Opens the Commit Memory panel for the given summary.
 	 *
 	 * Memory source (single slot): the existing memory panel — if any — is
@@ -1074,6 +1131,12 @@ export class SummaryWebviewPanel {
 		if (this.pushInProgress) {
 			return;
 		}
+		// Check BEFORE setting pushInProgress so that a stale-commit early exit
+		// doesn't leave the flag stuck (the panel is about to be disposed anyway,
+		// but defensive against future code paths that survive the guard).
+		if (!(await this.ensureCommitNotRewritten("push to Jolli"))) {
+			return;
+		}
 		this.pushInProgress = true;
 
 		try {
@@ -1391,6 +1454,9 @@ export class SummaryWebviewPanel {
 		if (!summary) {
 			return;
 		}
+		if (!(await this.ensureCommitNotRewritten("edit memory"))) {
+			return;
+		}
 
 		const result = updateTopicInTree(summary, topicIndex, updates);
 		if (!result) {
@@ -1421,6 +1487,9 @@ export class SummaryWebviewPanel {
 	private async handleEditRecap(recap: string): Promise<void> {
 		const summary = this.currentSummary;
 		if (!summary) {
+			return;
+		}
+		if (!(await this.ensureCommitNotRewritten("edit recap"))) {
 			return;
 		}
 		const trimmed = recap.trim();
@@ -1454,6 +1523,9 @@ export class SummaryWebviewPanel {
 	private async handleGenerateRecap(): Promise<void> {
 		const summary = this.currentSummary;
 		if (!summary) {
+			return;
+		}
+		if (!(await this.ensureCommitNotRewritten("generate recap"))) {
 			return;
 		}
 
@@ -1499,6 +1571,11 @@ export class SummaryWebviewPanel {
 		if (!summary) {
 			return;
 		}
+		// Check BEFORE the confirm dialog so the user isn't asked to confirm a
+		// destructive action that won't actually take effect on this commit.
+		if (!(await this.ensureCommitNotRewritten("delete memory"))) {
+			return;
+		}
 
 		const choice = await vscode.window.showWarningMessage(
 			title ? "Delete memory?" : "Delete this memory?",
@@ -1528,6 +1605,9 @@ export class SummaryWebviewPanel {
 	private async handleGenerateE2eTest(): Promise<void> {
 		const summary = this.currentSummary;
 		if (!summary) {
+			return;
+		}
+		if (!(await this.ensureCommitNotRewritten("generate E2E test guide"))) {
 			return;
 		}
 
@@ -1594,6 +1674,9 @@ export class SummaryWebviewPanel {
 		if (!summary) {
 			return;
 		}
+		if (!(await this.ensureCommitNotRewritten("edit E2E test guide"))) {
+			return;
+		}
 
 		const updatedSummary: CommitSummary = {
 			...summary,
@@ -1625,6 +1708,9 @@ export class SummaryWebviewPanel {
 				"editE2eScenario: index out of range",
 				index,
 			);
+			return;
+		}
+		if (!(await this.ensureCommitNotRewritten("edit E2E scenario"))) {
 			return;
 		}
 
@@ -1688,6 +1774,10 @@ export class SummaryWebviewPanel {
 			);
 			return;
 		}
+		// Check BEFORE the confirm dialog (same rationale as handleDeleteTopic).
+		if (!(await this.ensureCommitNotRewritten("delete E2E scenario"))) {
+			return;
+		}
 
 		const scenarioTitle = title ?? summary.e2eTestGuide[index].title;
 		const choice = await vscode.window.showWarningMessage(
@@ -1715,6 +1805,10 @@ export class SummaryWebviewPanel {
 	private async handleDeleteE2eTest(): Promise<void> {
 		const summary = this.currentSummary;
 		if (!summary) {
+			return;
+		}
+		// Check BEFORE the confirm dialog (same rationale as handleDeleteTopic).
+		if (!(await this.ensureCommitNotRewritten("delete E2E test guide"))) {
 			return;
 		}
 
@@ -1759,6 +1853,15 @@ export class SummaryWebviewPanel {
 	}
 
 	private async handleSavePlan(slug: string, content: string): Promise<void> {
+		// Block the plan-write BEFORE it lands: although plan files are global
+		// (one copy per slug, not per commit), this handler's side effect is
+		// syncPlanTitle which writes back to the panel's stale summary. Letting
+		// the plan write proceed alone would persist user intent but the title
+		// sync would silently apply to an orphaned commit's summary, so we
+		// treat the whole handler as a write against the stale commit.
+		if (!(await this.ensureCommitNotRewritten("save plan"))) {
+			return;
+		}
 		await this.bridge.storePlans([{ slug, content }], `Edit plan ${slug}`);
 		await this.syncPlanTitle(slug, content);
 
@@ -1807,6 +1910,10 @@ export class SummaryWebviewPanel {
 		if (!summary?.plans) {
 			return;
 		}
+		// Check BEFORE the confirm dialog (same rationale as handleDeleteTopic).
+		if (!(await this.ensureCommitNotRewritten("remove plan"))) {
+			return;
+		}
 
 		const choice = await vscode.window.showWarningMessage(
 			`Remove plan "${title}" from this commit?`,
@@ -1851,6 +1958,11 @@ export class SummaryWebviewPanel {
 	private async handleAddPlan(): Promise<void> {
 		const summary = this.currentSummary;
 		if (!summary) {
+			return;
+		}
+		// Check BEFORE the QuickPick so the user isn't prompted to pick a plan
+		// that would be associated with an orphaned commit.
+		if (!(await this.ensureCommitNotRewritten("add plan"))) {
 			return;
 		}
 
@@ -1898,6 +2010,11 @@ export class SummaryWebviewPanel {
 	private async handleAddMarkdownNote(): Promise<void> {
 		const summary = this.currentSummary;
 		if (!summary) {
+			return;
+		}
+		// Check BEFORE the file picker so the user isn't asked to choose a note
+		// that would be archived against an orphaned commit.
+		if (!(await this.ensureCommitNotRewritten("add markdown note"))) {
 			return;
 		}
 
@@ -1951,6 +2068,9 @@ export class SummaryWebviewPanel {
 		}
 		if (!content.trim()) {
 			throw new Error("Snippet content is required");
+		}
+		if (!(await this.ensureCommitNotRewritten("save snippet"))) {
+			return;
 		}
 
 		const noteInfo = await saveNote(
@@ -2022,6 +2142,11 @@ export class SummaryWebviewPanel {
 		content: string,
 		format: string,
 	): Promise<void> {
+		// Same rationale as handleSavePlan: the note body is global, but the
+		// title/content sync writes back to the panel's stale summary.
+		if (!(await this.ensureCommitNotRewritten("save note"))) {
+			return;
+		}
 		await this.bridge.storeNotes([{ id, content }], `Edit note ${id}`);
 
 		// Sync title and (for snippets) inline content in the summary
@@ -2057,6 +2182,10 @@ export class SummaryWebviewPanel {
 	private async handleRemoveNote(id: string, title: string): Promise<void> {
 		const summary = this.currentSummary;
 		if (!summary?.notes) {
+			return;
+		}
+		// Check BEFORE the confirm dialog (same rationale as handleDeleteTopic).
+		if (!(await this.ensureCommitNotRewritten("remove note"))) {
 			return;
 		}
 
@@ -2175,6 +2304,10 @@ export class SummaryWebviewPanel {
 		if (!summary?.linearIssues) {
 			return;
 		}
+		// Check BEFORE the confirm dialog (same rationale as handleDeleteTopic).
+		if (!(await this.ensureCommitNotRewritten("remove Linear issue"))) {
+			return;
+		}
 
 		const choice = await vscode.window.showWarningMessage(
 			`Remove Linear issue "${ticketId}" from this commit?`,
@@ -2213,6 +2346,10 @@ export class SummaryWebviewPanel {
 
 	/** Translates a plan from its current language to English via LLM. */
 	private async handleTranslatePlan(slug: string): Promise<void> {
+		// Same rationale as handleSavePlan: title sync goes to the stale summary.
+		if (!(await this.ensureCommitNotRewritten("translate plan"))) {
+			return;
+		}
 		const content = await readPlanFromBranch(slug, this.workspaceRoot);
 		if (content === null) {
 			vscode.window.showErrorMessage(
@@ -2265,6 +2402,10 @@ export class SummaryWebviewPanel {
 	private async handleTranslateNote(id: string): Promise<void> {
 		const noteRef = this.currentSummary?.notes?.find((n) => n.id === id);
 		if (!noteRef) {
+			return;
+		}
+		// Same rationale as handleSavePlan: title sync goes to the stale summary.
+		if (!(await this.ensureCommitNotRewritten("translate note"))) {
 			return;
 		}
 		const content =

--- a/vscode/src/views/SummaryWebviewPanel.ts
+++ b/vscode/src/views/SummaryWebviewPanel.ts
@@ -1122,6 +1122,20 @@ export class SummaryWebviewPanel {
 	 * to the webview. Wrapped in `Promise.allSettled` semantics by
 	 * {@link toJolliResultMessage} so a thrown error becomes a structured
 	 * `pushToJolliResult` instead of an uncaught rejection.
+	 *
+	 * Known race window (intentionally not double-guarded): once
+	 * `pushToJolli` has been kicked off (1–3s HTTP round-trip in practice),
+	 * an amend landing mid-call would let `runJolliPush` persist the
+	 * resulting `jolliDocId` to the now-orphaned commit's summary. We accept
+	 * this because:
+	 *   - the window is short and requires concurrent user action on the
+	 *     same workspace (sidebar Amend / terminal `git commit --amend`),
+	 *   - re-checking AFTER pushToJolli but BEFORE storeSummary would leave
+	 *     the article created on the Jolli side without a local record,
+	 *     causing the next push of the new HEAD to create a duplicate
+	 *     article instead of updating in place.
+	 * Trade-off is favourable for the common case; documented here so a
+	 * future maintainer doesn't quietly add the re-check without realising.
 	 */
 	private async handlePush(): Promise<void> {
 		// Prevent concurrent pushes: the button can be re-clicked when
@@ -1552,6 +1566,12 @@ export class SummaryWebviewPanel {
 			return;
 		}
 
+		// Race-window re-check: amend can land during the LLM call (10–60s).
+		// Without this the recap would be persisted to the now-orphaned commit.
+		if (!(await this.ensureCommitNotRewritten("generate recap"))) {
+			return;
+		}
+
 		const updated: CommitSummary = { ...summary, recap: trimmed };
 		await this.bridge.storeSummary(updated, true);
 		this.currentSummary = updated;
@@ -1588,6 +1608,13 @@ export class SummaryWebviewPanel {
 			"Delete",
 		);
 		if (choice !== "Delete") {
+			return;
+		}
+
+		// Race-window re-check: amend can land between the entry guard and the
+		// user dismissing the modal. Without this the delete would persist to
+		// the now-orphaned commit's summary.
+		if (!(await this.ensureCommitNotRewritten("delete memory"))) {
 			return;
 		}
 
@@ -1644,6 +1671,11 @@ export class SummaryWebviewPanel {
 				"No major topics in this commit, so there's nothing to test.",
 			);
 			this.panel.webview.postMessage({ command: "e2eTestError" });
+			return;
+		}
+
+		// Race-window re-check: amend can land during the LLM call (10–60s).
+		if (!(await this.ensureCommitNotRewritten("generate E2E test guide"))) {
 			return;
 		}
 
@@ -1789,6 +1821,11 @@ export class SummaryWebviewPanel {
 			return;
 		}
 
+		// Race-window re-check: amend can land while the confirm modal is open.
+		if (!(await this.ensureCommitNotRewritten("delete E2E scenario"))) {
+			return;
+		}
+
 		const remaining = summary.e2eTestGuide.filter((_, i) => i !== index);
 		const updatedSummary: CommitSummary = {
 			...summary,
@@ -1821,6 +1858,11 @@ export class SummaryWebviewPanel {
 			"Delete",
 		);
 		if (choice !== "Delete") {
+			return;
+		}
+
+		// Race-window re-check: amend can land while the confirm modal is open.
+		if (!(await this.ensureCommitNotRewritten("delete E2E test guide"))) {
 			return;
 		}
 
@@ -1928,6 +1970,11 @@ export class SummaryWebviewPanel {
 			return;
 		}
 
+		// Race-window re-check: amend can land while the confirm modal is open.
+		if (!(await this.ensureCommitNotRewritten("remove plan"))) {
+			return;
+		}
+
 		// Update CommitSummary: remove plan from plans array
 		const updatedPlans = summary.plans.filter((p) => p.slug !== slug);
 		const updatedSummary: CommitSummary = {
@@ -1986,6 +2033,14 @@ export class SummaryWebviewPanel {
 			return;
 		}
 
+		// Race-window re-check: amend can land while the QuickPick is open.
+		// `archivePlanForCommit` would otherwise bind the plan to an orphaned
+		// commit hash, and the subsequent `storeSummary` would write to the
+		// orphaned summary.
+		if (!(await this.ensureCommitNotRewritten("add plan"))) {
+			return;
+		}
+
 		const planRef = await this.bridge.archivePlanForCommit(
 			selected.slug,
 			summary.commitHash,
@@ -2024,6 +2079,13 @@ export class SummaryWebviewPanel {
 			title: "Select a Markdown file to add as a note",
 		});
 		if (!fileUri || fileUri.length === 0) {
+			return;
+		}
+
+		// Race-window re-check: amend can land while the file picker is open.
+		// `archiveNoteForCommit` would otherwise bind the note to an orphaned
+		// commit hash.
+		if (!(await this.ensureCommitNotRewritten("add markdown note"))) {
 			return;
 		}
 
@@ -2202,6 +2264,11 @@ export class SummaryWebviewPanel {
 			return;
 		}
 
+		// Race-window re-check: amend can land while the confirm modal is open.
+		if (!(await this.ensureCommitNotRewritten("remove note"))) {
+			return;
+		}
+
 		const updatedNotes = summary.notes.filter((n) => n.id !== id);
 		const updatedSummary: CommitSummary = {
 			...summary,
@@ -2322,6 +2389,11 @@ export class SummaryWebviewPanel {
 			return;
 		}
 
+		// Race-window re-check: amend can land while the confirm modal is open.
+		if (!(await this.ensureCommitNotRewritten("remove Linear issue"))) {
+			return;
+		}
+
 		const updatedLinearIssues = summary.linearIssues.filter(
 			(l) => l.archivedKey !== archivedKey,
 		);
@@ -2376,6 +2448,14 @@ export class SummaryWebviewPanel {
 			content,
 			config: translateConfig,
 		});
+
+		// Race-window re-check: amend can land during the LLM call (10–60s).
+		// `syncPlanTitle` would otherwise persist the new title to the stale
+		// commit's summary. `storePlans` is global content so we let it run
+		// regardless — losing the translated body would discard real user work.
+		if (!(await this.ensureCommitNotRewritten("translate plan"))) {
+			return;
+		}
 
 		// Save translated content and sync title to summary + registry
 		await this.bridge.storePlans(
@@ -2434,6 +2514,13 @@ export class SummaryWebviewPanel {
 			content,
 			config: translateConfig,
 		});
+
+		// Race-window re-check: amend can land during the LLM call (10–60s).
+		// The note body sync below would otherwise persist to the stale summary.
+		// `storeNotes` is global content so we let it run regardless.
+		if (!(await this.ensureCommitNotRewritten("translate note"))) {
+			return;
+		}
 
 		// Save translated content to orphan branch
 		await this.bridge.storeNotes(


### PR DESCRIPTION
<!-- jollimemory-summary-start -->
## Commits in this PR (3)

1. Closes JOLLI-1550: Guard all write paths against stale rewritten commits (`7f71000`)
2. Add race-window re-checks to SummaryWebviewPanel write paths (`7cba9e2`)
3. Replace stale-commit panel disposal with persistent stale-readonly mode and warning banner (`7b5dd42`)

## Quick recap (3)

### Commit 1 of 3: Closes JOLLI-1550: Guard all write paths against stale rewritten commits (`7f71000`)

A new safety mechanism was added to the commit summary panel to prevent writes from landing on commits that have since been amended, squashed, or rebased. Previously, if a summary panel remained open after its commit was rewritten, actions like "Push to Jolli," topic edits, recap generation, and end-to-end test operations would silently write to the orphaned commit, leaving the live commit's summary without its document link or other fields. The panel now checks the commit index before any write, identifies whether the commit has been superseded, and if so shows a warning naming both the stale commit and the live root it was folded into, then closes itself so the user can open the correct summary from the branch panel.

Coverage was extended well beyond the initial set of write operations. Plan management, note management, and Linear issue removal were all added to the protected set, and save and translate operations for plans and notes are guarded as well. Every handler that could produce a write tied to the panel's current commit now checks for a rewrite first, and every check fires before any picker, confirmation dialog, or archive call — the panel behaves as fully read-only once its commit has been superseded.

The index lookup that powers the guard was also corrected to always consult the same storage backend as the rest of the panel's write operations. In folder-storage mode the original implementation read from the wrong location, which could cause real rewrites to go undetected. The lookup now routes through the same bridge layer that handles all other writes, so the guard and the writers always see the same data regardless of which storage mode is active.

### Commit 2 of 3: Add race-window re-checks to SummaryWebviewPanel write paths (`7cba9e2`)

The Summary panel now guards against a class of data-corruption bug where a commit could be rewritten while a slow operation was in progress. Previously, the safety check ran only at the moment a user clicked an action button. If the user then waited through an AI generation call or interacted with a confirmation dialog — during which they or another tool amended the commit — the result would be silently written to the now-outdated commit record. A second check was added immediately before each final write in every handler with a meaningful wait, covering AI generation, translation, confirmation dialogs, and selection menus. The push flow was deliberately left with only the entry check: blocking a write after a successful remote call would leave the newly created article without a local record, producing a duplicate on the next push.

### Commit 3 of 3: Replace stale-commit panel disposal with persistent stale-readonly mode and warning banner (`7b5dd42`)

When a commit summary panel detected that its underlying commit had been rewritten by an amend, squash, or rebase, it previously closed itself immediately and showed a brief corner notification. The panel now stays open and transitions into a persistent read-only state: a yellow warning banner appears at the top of the summary explaining what happened, all editing controls are hidden, and a centered modal dialog gives the user a direct button to open the new commit's summary. Dismissing the modal leaves the panel intact so the user can keep reading the orphaned commit's content. Any further attempts to trigger a write action on the stale panel are silently blocked without raising another dialog.

## E2E Test (8)
<details>
<summary><strong>1. [7f71000] Stale-commit guard blocks plan and note actions on a rewritten commit</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a commit whose summary is open in the Jolli Memory panel. The commit must have been rewritten (for example, amended) so that it is no longer the live root — the extension should be in folder-storage mode or any non-default storage configuration to exercise the corrected code path.

**Steps:**
1. Open the Jolli Memory panel and navigate to the summary for the rewritten commit.
2. Click "Add Plan" and wait for a response.
3. Check whether a warning message appears instead of the plan picker opening.
4. Click "Add Markdown Note" and wait for a response.
5. Check whether a warning message appears instead of a file picker opening.
6. Try "Remove Plan" (if a plan is listed) and verify a warning appears before any confirmation dialog.

**Expected Results:**
- Each action should immediately show a warning message containing the name of the blocked operation (for example, "add plan", "add markdown note", "remove plan").
- No plan picker, file picker, or confirmation dialog should open for any of these actions.
- No changes should be saved to the summary.

</blockquote>
</details>
<details>
<summary><strong>2. [7f71000] Stale-commit guard blocks save, translate, and remove actions on a rewritten commit</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a commit summary open in the Jolli Memory panel where the commit has been rewritten. The summary should include at least one plan, one note, and one Linear issue so all removal paths can be tested.

**Steps:**
1. Open the summary for the rewritten commit in the Jolli Memory panel.
2. Open an existing plan and click "Save" — check that a warning appears and no save occurs.
3. Click "Translate" on the same plan — check that a warning appears and no translation starts.
4. Open an existing note and click "Save" — check that a warning appears and no save occurs.
5. Click "Remove" next to a Linear issue — check that a warning appears before any confirmation dialog.
6. Click "Remove" next to a note — check that a warning appears before any confirmation dialog.

**Expected Results:**
- Every action should be blocked with a warning message that names the specific operation (for example, "save plan", "translate plan", "save note", "remove note", "remove Linear issue").
- No confirmation dialogs should appear for removal actions.
- No content should be written or updated in the summary.

</blockquote>
</details>
<details>
<summary><strong>3. [7f71000] Stale panel blocked after amending a commit</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a Git repository open in VS Code with at least one commit that has a Jolli Memory summary. The commit's summary panel should be open and visible.

**Steps:**
1. Open the summary panel for a commit (the panel showing memories, recap, and the "Push to Jolli" button).
2. Without closing the panel, amend that commit in your terminal (for example, run `git commit --amend --no-edit`), so the original commit is replaced by a new one.
3. Return to VS Code and click the "Push to Jolli" button in the still-open summary panel for the old commit.
4. Wait a moment for the action to process.
5. Check whether a warning message appears in the bottom-right corner of VS Code.
6. Check whether the summary panel closes automatically.

**Expected Results:**
- A warning notification should appear saying the commit was "rewritten into" a newer commit hash, and that you should open that commit's summary instead.
- The warning should mention the operation "push to Jolli".
- The panel for the old (amended) commit should close on its own.
- No data should be written — the old commit's summary should not gain a Jolli document ID or URL, and the new commit's summary should be unaffected.

</blockquote>
</details>
<details>
<summary><strong>4. [7f71000] Stale panel blocked for destructive actions (delete memory, delete E2E scenario) before confirmation dialog</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a Git repository open with a commit summary that contains at least one memory entry and one E2E test scenario. Keep the summary panel open, then amend the commit in the terminal so the panel becomes stale.

**Steps:**
1. With the stale summary panel still open (after the commit was amended), click the delete button next to one of the memory entries.
2. Check whether a "Delete memory?" confirmation dialog appears, or whether a warning notification appears instead.
3. Dismiss any notification, then click the delete button next to one of the E2E test scenarios.
4. Again check whether a confirmation dialog appears or a warning notification appears instead.

**Expected Results:**
- For both delete actions, a warning notification should appear saying the commit was rewritten, mentioning "delete memory" or "delete E2E scenario" respectively.
- No confirmation dialog ("Delete memory?" or "Delete scenario…?") should appear at any point — the guard should stop the action before asking the user to confirm.
- Nothing should be deleted; the summary data should remain unchanged.

</blockquote>
</details>
<details>
<summary><strong>5. [7cba9e2] Race-window block: AI generation (E2E test guide) after commit is rewritten mid-operation</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a commit open in the Jolli sidebar panel. Arrange a way to amend the commit (e.g. stage a small change ready to go) so you can trigger an amend while the AI is working.

**Steps:**
1. Open the Jolli sidebar and navigate to the commit's summary panel.
2. Click the button to generate an E2E test guide for the commit.
3. While the AI generation is in progress (before it finishes), amend the commit in your terminal or via the source control sidebar (e.g. run `git commit --amend --no-edit`).
4. Wait for the AI generation to finish.
5. Check whether a warning message appears in the panel and whether the E2E test guide was saved.

**Expected Results:**
- A warning message should appear indicating the commit was rewritten (mentioning the new commit hash).
- The E2E test guide should NOT be saved to the panel — no new test guide content should appear.
- The panel should not crash or show a silent failure; the warning should be clearly visible.

</blockquote>
</details>
<details>
<summary><strong>6. [7cba9e2] Race-window block: deleting a memory topic after commit is rewritten while confirm dialog is open</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a commit open in the Jolli sidebar panel that has at least one memory topic listed. Arrange a way to amend the commit while the confirmation dialog is open.

**Steps:**
1. Open the Jolli sidebar and navigate to a commit that has at least one memory topic.
2. Click the delete button next to a memory topic — a confirmation dialog should appear asking you to confirm the deletion.
3. While the confirmation dialog is still open, amend the commit in your terminal (e.g. `git commit --amend --no-edit`).
4. Click "Delete" to confirm the deletion in the dialog.
5. Check whether a warning message appears and whether the memory topic was actually removed.

**Expected Results:**
- A warning message should appear indicating the commit was rewritten.
- The memory topic should NOT be deleted — it should still appear in the panel unchanged.
- No silent data loss should occur.

</blockquote>
</details>
<details>
<summary><strong>7. [7cba9e2] Race-window block: adding a plan after commit is rewritten while the plan picker is open</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a commit open in the Jolli sidebar panel. Have at least one plan available to add. Arrange a way to amend the commit while the plan selection menu is open.

**Steps:**
1. Open the Jolli sidebar and navigate to a commit's summary panel.
2. Click the button to add a plan — a selection menu (QuickPick) should appear listing available plans.
3. While the selection menu is still open, amend the commit in your terminal (e.g. `git commit --amend --no-edit`).
4. Select a plan from the menu to confirm your choice.
5. Check whether a warning message appears and whether the plan was added to the commit.

**Expected Results:**
- A warning message should appear indicating the commit was rewritten.
- The plan should NOT be added to the commit — the plans list should remain unchanged.
- No plan should be incorrectly linked to the old (orphaned) commit.

</blockquote>
</details>
<details>
<summary><strong>8. [7cba9e2] Race-window block: translating a plan after commit is rewritten during the AI translation call</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a commit open in the Jolli sidebar panel that has at least one plan written in a non-English language. Arrange a way to amend the commit while the translation is in progress.

**Steps:**
1. Open the Jolli sidebar and navigate to a commit that has a plan with non-English content.
2. Click the translate button for that plan to start AI translation.
3. While the translation is in progress, amend the commit in your terminal (e.g. `git commit --amend --no-edit`).
4. Wait for the translation to finish.
5. Check whether a warning message appears and whether the translated title was saved to the commit summary.

**Expected Results:**
- A warning message should appear indicating the commit was rewritten.
- The translated plan title should NOT be synced back to the commit summary — the summary should remain unchanged.
- The translation itself may be saved to the plan's content file (this is expected and intentional), but the commit summary should not be updated.

</blockquote>
</details>

## Topics (6)
<details>
<summary><strong>01 · [7f71000] Stale-commit guard reads index through bridge for correct storage backend</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The guard that prevents writing to a commit that has since been rewritten was reading the commit index directly, bypassing the layer that knows which storage backend is active. In folder-storage mode this caused the guard to read from the wrong location, meaning real rewrites could go undetected or false blocks could fire.

**💡 Decisions Behind the Code**

- **Route through the bridge rather than expose storage directly**: The bridge already owns the authoritative storage instance for all webview-driven writes. Keeping the index read on the same path as every write means the guard and the writers always see the same backend. Exposing the storage object directly to the panel would have created a second ownership point and risked the two drifting apart in future refactors.
- **Add a dedicated regression-guard test**: The fix is a routing change rather than a behavior change, so a normal functional test would not catch a future developer reverting to the direct import. A test that explicitly asserts the bridge method was called makes the storage-threading contract visible and machine-checked.

**✅ What Was Implemented**

- Added `getSummaryIndexEntryMap()` to `JolliMemoryBridge.ts`: this wrapper retrieves the active storage instance (dual-write or folder) and passes it through to the underlying index read, ensuring the correct file is consulted regardless of which storage mode is configured.
- Updated `ensureCommitNotRewritten` in `SummaryWebviewPanel.ts` to call `this.bridge.getSummaryIndexEntryMap()` instead of importing and calling the store function directly. The direct import of `getIndexEntryMap` from `SummaryStore` was removed from the panel entirely.
- Updated test infrastructure in both `SummaryWebviewPanel.test.ts` and `SummaryWebviewPanel.handlePush.test.ts`: removed the `SummaryStore` mock for `getIndexEntryMap`, added `getSummaryIndexEntryMap` as a stub on the bridge object, and added a regression-guard test that explicitly asserts the bridge method is called rather than the direct import.

**📁 FILES**
- `vscode/src/JolliMemoryBridge.ts`
- `vscode/src/views/SummaryWebviewPanel.ts`

</blockquote>
</details>
<details>
<summary><strong>02 · [7f71000] Stale-commit guard extended to cover plan, note, and Linear issue write paths</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The guard that blocks writes to a rewritten commit only covered push, topic and recap editing, and end-to-end test operations. Plan management, note management, and Linear issue removal could still write data tied to an orphaned commit, silently associating new content with a commit hash that no longer exists as a live root.

**💡 Decisions Behind the Code**

- **Block before any user interaction, not after**: For handlers that open a picker or confirmation dialog, the guard fires first. Letting the user complete a multi-step flow only to reject it at the final write would be confusing and wasteful; blocking at the entry point keeps the experience consistent with the existing push and delete-topic guards.
- **Treat save and translate as writes against the stale commit**: Plan and note bodies are global files, so one could argue the body write is safe. The decision was to guard the whole handler anyway, because the title-sync step that follows always writes back to the panel's stale summary. Splitting the handler into a safe body-write and a blocked sync would add complexity with no user benefit — the panel is stale and should be treated as read-only in its entirety.

**✅ What Was Implemented**

- Added the stale-commit check to six handlers that were previously unguarded: remove plan, add plan (before the picker opens), add markdown note (before the file dialog opens), save snippet, remove note, and remove Linear issue. Each check fires before any user-facing dialog or archive call so the user is never prompted to complete an action that will be blocked.
- Added the guard to four save and translate handlers whose side effects write back to the panel's current summary: save plan, save note, translate plan, and translate note. Even though plan and note files are stored globally, each of these handlers synchronises the title or content back into the stale summary, so the whole handler is treated as a write against the orphaned commit.
- Added eleven new tests in `SummaryWebviewPanel.test.ts` covering each newly guarded handler, verifying that the warning is shown and that no downstream write (archive, store, or summary update) is called.

**📁 FILES**
- `vscode/src/views/SummaryWebviewPanel.ts`

</blockquote>
</details>
<details>
<summary><strong>03 · [7f71000] Block all writes to summary panels whose commit has been rewritten</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

A user reported that after amending a commit, the "Push to Jolli" document ID and URL disappeared from the summary. Investigation revealed the panel for the old commit stayed open after the amend, and when the user clicked "Push to Jolli" the write went to the orphaned commit rather than the live one, leaving the current commit's summary without those fields.

**💡 Decisions Behind the Code**

- **Index-based detection over git reachability check**: Using the index's `parentCommitHash` field was chosen over spawning a `git branch --contains` subprocess. The index check is a pure in-memory lookup against data jollimemory already maintains, while the git approach would add subprocess latency and could produce false positives when branches are deleted or switched. Critically, the index also carries the identity of the live root, enabling the warning message to tell the user exactly where to go.
- **Guard placement before confirmation dialogs on destructive operations**: For delete handlers, the stale-commit check was placed before the "are you sure?" dialog. Asking a user to confirm a deletion and then silently doing nothing would be confusing and erode trust; surfacing the stale-commit warning first makes the failure reason immediately clear and avoids a misleading interaction.
- **Dispose the panel on detection**: When a stale commit is detected the panel is disposed rather than just blocking the single operation. Keeping the panel open would leave the user with a tab that rejects every action with no clear path forward. Disposing it forces the user to open the current commit's summary from the branch panel, which is the correct recovery path.

**✅ What Was Implemented**

- Added `ensureCommitNotRewritten` to `SummaryWebviewPanel.ts`, a pre-write guard that reads the summary index through the bridge and checks whether the panel's commit hash has a non-null `parentCommitHash` entry — the marker jollimemory writes when a commit is folded into a new root by amend, squash, or rebase. If the commit has been rewritten, the guard walks the parent chain to find the live root, shows a warning naming both the stale hash and the live root hash, disposes the panel, and returns false so the caller short-circuits immediately.
- Wired the guard into ten write-path handlers in the initial implementation: Push to Jolli, edit memory, edit recap, generate recap, delete memory, generate E2E test guide, edit E2E test guide, edit E2E scenario, delete E2E scenario, and delete E2E test guide. For destructive operations the guard fires before the confirmation dialog so users are never asked to confirm an action that cannot take effect.
- Added thirteen new tests in `SummaryWebviewPanel.test.ts` and `SummaryWebviewPanel.handlePush.test.ts` covering: root entry allowed through, absent-from-index allowed through, single-hop rewrite blocked, multi-hop chain walked to final root, cyclic chain broken safely, and per-handler operation label verification.

**📁 FILES**
- `vscode/src/views/SummaryWebviewPanel.ts`

</blockquote>
</details>
<details>
<summary><strong>04 · [7cba9e2] Guard against stale commit writes after long async operations</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

A reviewer flagged that the safety check preventing writes to outdated commits only ran once at the start of each action. During slow operations like AI generation (30–60 seconds) or while a user interacts with a confirmation dialog or selection menu, the underlying commit could be rewritten. When the operation finished, data would silently be saved to the now-orphaned old commit instead of the current one.

**💡 Decisions Behind the Code**

- **Selective second-guard placement**: The re-check was added only to handlers with a meaningful async gap — AI calls (tens of seconds) and user-facing dialogs (unbounded wait). Handlers that only do millisecond-level file I/O were left with just the entry guard, keeping the change focused and avoiding unnecessary complexity.
- **Push handler exception — write through rather than block**: For the push flow, blocking the local save after a successful remote call would be worse than writing to a stale commit. The remote article would exist with no local record, and the next push of the new commit would create a duplicate. Accepting the small race risk on a 1–3 second window is the safer trade-off for users, and the decision is documented in the code for future maintainers.
- **Global content (plan/note body) written regardless of race**: For translate operations, the translated text itself is stored globally and not tied to a specific commit, so that write is allowed to proceed even when the re-check fails. Only the commit-specific metadata sync is blocked, preserving the user's translation work.

**✅ What Was Implemented**

- Added a second safety re-check immediately before the final write in every handler that involves a long wait: `handleGenerateRecap`, `handleGenerateE2eTest`, `handleTranslatePlan`, and `handleTranslateNote` each re-check after the AI call completes; `handleDeleteTopic`, `handleDeleteE2eScenario`, `handleDeleteE2eTest`, `handleRemovePlan`, `handleRemoveNote`, and `handleRemoveLinearIssue` re-check after the confirmation modal closes; `handleAddPlan` and `handleAddMarkdownNote` re-check after the selection UI closes. If the commit has been rewritten in the interim, the operation is aborted and a warning is shown.
- Added a code comment to `handlePush` documenting why it intentionally does NOT get a second re-check: the HTTP call is short (1–3 seconds), and blocking the write after a successful push would leave the newly created remote article without a local record, causing a duplicate article on the next push of the new commit.
- Added four new race-window tests using a `makeRacingEntryMapMock` helper that returns the original commit map on the first call and a rewritten map on subsequent calls, precisely simulating an amend landing between the entry check and the pre-write re-check.

**📁 FILES**
- `vscode/src/views/SummaryWebviewPanel.ts`

</blockquote>
</details>
<details>
<summary><strong>05 · [7cba9e2] Fix invalid TypeScript types in test fixtures for references</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

A reviewer noted that several test fixtures introduced in a previous session were missing required fields, meaning the tests passed at runtime but would fail a TypeScript type check. This created a gap between what the tests validated and what the actual data model required.

**💡 Decisions Behind the Code**

The fixes were purely mechanical — each field was either missing from the type definition or using a name that did not exist on the type. No design trade-offs were involved; the goal was simply to make the test fixtures match the actual data model so that TypeScript type checking passes alongside the runtime tests.

**✅ What Was Implemented**

Fixed four fixture objects in `SummaryWebviewPanel.test.ts`: added `editCount`, `addedAt`, and `updatedAt` to two plan reference fixtures; added `addedAt` and `updatedAt` to two note reference fixtures; replaced a non-existent `capturedAt` field on a Linear issue reference fixture with the correct `referencedAt` and `sourceToolName` fields.

**📁 FILES**
- `vscode/src/views/SummaryWebviewPanel.test.ts`

</blockquote>
</details>
<details>
<summary><strong>06 · [7b5dd42] Replace stale commit panel close with persistent read-only warning mode</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

When a commit had been rewritten by an amend, squash, or rebase, the summary panel was immediately closed and a brief toast notification appeared. The user lost their place, had no way to navigate to the new commit's summary, and the toast disappeared before they could act on it.

**💡 Decisions Behind the Code**

- **Keep the panel open instead of closing it**: Closing the tab on a stale detection was disorienting, especially when the user had been waiting on a long-running operation. The existing foreign-repo read-only mode already proved that a panel can remain useful in a locked-down state, so the same pattern was applied here. The user retains their reading context and gets a clear in-panel explanation of what changed.
- **Modal dialog over toast notification**: A toast auto-dismisses in roughly ten seconds and appears in a corner, making it easy to miss during a busy workflow. A modal is center-screen and requires an explicit action, ensuring the user sees the old and new commit hashes and the "Open new commit's summary" button before continuing. The trade-off is a small interruption, which is acceptable for a one-time, high-stakes state change.
- **Reuse the foreign-readonly CSS whitelist rather than a separate stale-specific one**: Both read-only modes share the same concept of "buttons that are safe to show even when writes are blocked." Introducing a second whitelist would require every future button author to remember two attributes. A single `data-foreign-safe` marker covers both modes, and a panel that is simultaneously foreign and stale (a cross-repo summary whose source commit was rewritten) gets both hook classes with no extra logic.

**✅ What Was Implemented**

- `SummaryWebviewPanel.ts` gained a `staleRewrittenInto` field and a new `enterStaleReadonlyMode()` method. On first detection of a rewritten commit, the panel re-renders with the stale state set, then raises a modal dialog (blocking, center-screen) naming the old and new short hashes and the blocked operation. The user can click "Open new commit's summary" to jump directly to the live commit's panel, or dismiss to stay. The `panel.dispose()` call was removed entirely. Subsequent write attempts short-circuit silently on the already-set field without re-raising the modal.
- `SummaryHtmlBuilder.ts` received a new `staleRewrittenInto` option on `BuildHtmlOptions`. When set, the page root element gains a `stale-readonly` hook class (parallel to the existing `foreign-readonly` class) and a persistent yellow warning banner is injected at the top of the page, including a button that posts an `openRewrittenCommit` message back to the extension.
- `SummaryCssBuilder.ts` and `SummaryScriptBuilder.ts` were extended to hide all destructive buttons under the `stale-readonly` class (reusing the existing `data-foreign-safe` whitelist) and to wire the banner button's click event to post the navigation message.

**📁 FILES**
- `vscode/src/views/SummaryWebviewPanel.ts`
- `vscode/src/views/SummaryHtmlBuilder.ts`
- `vscode/src/views/SummaryCssBuilder.ts`
- `vscode/src/views/SummaryScriptBuilder.ts`

</blockquote>
</details>

---

*Generated by Jolli Memory · May 20, 2026 at 3:58 PM*
<!-- jollimemory-summary-end -->