### PR TITLE
Add regenerate-summary feature

### DIFF
--- a/cli/src/core/LinearIssueExtractor.ts
+++ b/cli/src/core/LinearIssueExtractor.ts
@@ -413,7 +413,13 @@ function renderOneIssue(ref: LinearIssueRef, maxCharsPerIssue: number): string {
 	return lines.join("\n");
 }
 
-function truncate(s: string, maxChars: number): string {
+/**
+ * Truncates `s` to `maxChars` and appends a "...[truncated, N more chars]"
+ * marker so the LLM sees that data was cut. Shared by the regenerate path's
+ * prompt-block builder (Regenerator.ts) — same wire format keeps the LLM's
+ * cue text identical across first-run and regenerate.
+ */
+export function truncate(s: string, maxChars: number): string {
 	if (s.length <= maxChars) return s;
 	const remaining = s.length - maxChars;
 	return `${s.slice(0, maxChars)}\n…[truncated, ${remaining} more chars]`;

--- a/cli/src/core/RegenerateContext.test.ts
+++ b/cli/src/core/RegenerateContext.test.ts
@@ -3,9 +3,16 @@ import type { CommitSummary, StoredTranscript } from "../Types.js";
 import { loadRegenerateContext } from "./RegenerateContext.js";
 import * as SummaryStore from "./SummaryStore.js";
 
-vi.mock("./SummaryStore.js", () => ({
-	readTranscript: vi.fn(),
-}));
+vi.mock("./SummaryStore.js", async () => {
+	const actual = await vi.importActual<typeof import("./SummaryStore.js")>("./SummaryStore.js");
+	return {
+		readTranscriptsForCommits: vi.fn(),
+		// Use the real normalizeToV4 so v3 legacy plan/note/linear counts
+		// surface from children — the regression the v3 → v4 normalize
+		// targets surfaces here too.
+		normalizeToV4: actual.normalizeToV4,
+	};
+});
 
 const baseSummary: CommitSummary = {
 	version: 4,
@@ -17,12 +24,16 @@ const baseSummary: CommitSummary = {
 	generatedAt: "2026-05-21T00:01:00Z",
 } as CommitSummary;
 
+function singleHashMap(hash: string, stored: StoredTranscript): Map<string, StoredTranscript> {
+	return new Map([[hash, stored]]);
+}
+
 describe("loadRegenerateContext", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 	});
 
-	it("returns counts and sources from the stored transcript", async () => {
+	it("returns counts and sources from the stored transcript on a leaf summary", async () => {
 		const stored: StoredTranscript = {
 			sessions: [
 				{
@@ -40,7 +51,9 @@ describe("loadRegenerateContext", () => {
 				},
 			],
 		};
-		vi.mocked(SummaryStore.readTranscript).mockResolvedValue(stored);
+		vi.mocked(SummaryStore.readTranscriptsForCommits).mockResolvedValue(
+			singleHashMap(baseSummary.commitHash, stored),
+		);
 
 		const ctx = await loadRegenerateContext(
 			{
@@ -63,8 +76,8 @@ describe("loadRegenerateContext", () => {
 		});
 	});
 
-	it("returns zero counts when transcript is missing (no special-case branch)", async () => {
-		vi.mocked(SummaryStore.readTranscript).mockResolvedValue(null);
+	it("returns zero counts when no transcript is stored anywhere in the tree", async () => {
+		vi.mocked(SummaryStore.readTranscriptsForCommits).mockResolvedValue(new Map());
 		const ctx = await loadRegenerateContext(baseSummary, "/repo");
 		expect(ctx).toEqual({
 			entryCount: 0,
@@ -77,26 +90,183 @@ describe("loadRegenerateContext", () => {
 		});
 	});
 
-	it("deduplicates source list", async () => {
-		vi.mocked(SummaryStore.readTranscript).mockResolvedValue({
-			sessions: [
-				{ sessionId: "a", source: "claude", entries: [] },
-				{ sessionId: "b", source: "claude", entries: [] },
-			],
-		});
+	it("deduplicates source list across the tree", async () => {
+		vi.mocked(SummaryStore.readTranscriptsForCommits).mockResolvedValue(
+			singleHashMap(baseSummary.commitHash, {
+				sessions: [
+					{ sessionId: "a", source: "claude", entries: [] },
+					{ sessionId: "b", source: "claude", entries: [] },
+				],
+			}),
+		);
 		const ctx = await loadRegenerateContext(baseSummary, "/repo");
 		expect(ctx.sources).toEqual(["Claude"]);
 	});
 
-	it("preserves session-list source order (first occurrence wins)", async () => {
-		vi.mocked(SummaryStore.readTranscript).mockResolvedValue({
-			sessions: [
-				{ sessionId: "a", source: "codex", entries: [] },
-				{ sessionId: "b", source: "claude", entries: [] },
-				{ sessionId: "c", source: "codex", entries: [] },
+	it("dedups sessionCount by source:sessionId when the same session appears in multiple commit transcripts", async () => {
+		// A single AI session can have its entries spliced across multiple
+		// commit transcripts (squash slicing, amend rewriting). The webview's
+		// All Conversations card collapses these via source:sessionId and we
+		// must match — otherwise the confirm dialog over-reports session
+		// count and confuses the user.
+		const tree: CommitSummary = {
+			...baseSummary,
+			commitHash: "root",
+			children: [
+				{ ...baseSummary, commitHash: "leaf-1" } as CommitSummary,
+				{ ...baseSummary, commitHash: "leaf-2" } as CommitSummary,
 			],
-		});
-		const ctx = await loadRegenerateContext(baseSummary, "/repo");
-		expect(ctx.sources).toEqual(["Codex", "Claude"]);
+		} as CommitSummary;
+
+		vi.mocked(SummaryStore.readTranscriptsForCommits).mockResolvedValue(
+			new Map([
+				[
+					"leaf-1",
+					{
+						sessions: [
+							{
+								sessionId: "shared-session",
+								source: "claude",
+								entries: [{ role: "human", content: "h1", timestamp: "2026-05-21T00:00:00Z" }],
+							},
+						],
+					},
+				],
+				[
+					"leaf-2",
+					{
+						sessions: [
+							{
+								sessionId: "shared-session",
+								source: "claude",
+								entries: [{ role: "human", content: "h2", timestamp: "2026-05-21T01:00:00Z" }],
+							},
+						],
+					},
+				],
+			]),
+		);
+
+		const ctx = await loadRegenerateContext(tree, "/repo");
+		// 2 entries (one per commit slice), but only 1 session (same source:sessionId).
+		expect(ctx.entryCount).toBe(2);
+		expect(ctx.sessionCount).toBe(1);
+	});
+
+	it("counts v3 child-only attachments via the normalizeToV4 step", async () => {
+		// Before the normalize-then-operate refactor, plansCount/notesCount/
+		// linearCount only saw root.fields — for legacy v3 summaries where the
+		// attachments lived on a child, the confirm dialog reported 0 even
+		// when the LLM was about to be re-run on those very attachments.
+		// Now they're hoisted to root by normalizeToV4 before counting.
+		const v3WithChildAttachments: CommitSummary = {
+			...baseSummary,
+			version: 3,
+			plans: undefined,
+			notes: undefined,
+			linearIssues: undefined,
+			children: [
+				{
+					...baseSummary,
+					commitHash: "child-hash",
+					version: 3,
+					plans: [
+						{
+							slug: "p-c",
+							title: "child plan",
+							editCount: 1,
+							addedAt: "2026-05-20T00:00:00Z",
+							updatedAt: "2026-05-20T00:00:00Z",
+						},
+					],
+					notes: [
+						{
+							id: "n-c",
+							title: "child note",
+							format: "snippet",
+							addedAt: "2026-05-20T00:00:00Z",
+							updatedAt: "2026-05-20T00:00:00Z",
+						},
+					],
+					linearIssues: [
+						{
+							archivedKey: "JOLLI-1-abc",
+							ticketId: "JOLLI-1",
+							title: "T",
+							url: "https://linear.app/x",
+							referencedAt: "2026-05-20T00:00:00Z",
+							sourceToolName: "mcp__linear__get_issue",
+						},
+					],
+				},
+			],
+		} as CommitSummary;
+
+		vi.mocked(SummaryStore.readTranscriptsForCommits).mockResolvedValue(new Map());
+
+		const ctx = await loadRegenerateContext(v3WithChildAttachments, "/repo");
+		expect(ctx.plansCount).toBe(1);
+		expect(ctx.notesCount).toBe(1);
+		expect(ctx.linearCount).toBe(1);
+	});
+
+	it("aggregates counts + sources across the whole summary tree (squash / amend case)", async () => {
+		// The webview's All Conversations card shows transcripts for EVERY
+		// commit hash in the tree. loadRegenerateContext must match that
+		// total or the confirm dialog under-reports entries and misleads
+		// users into thinking the regenerate has less input than it does.
+		const tree: CommitSummary = {
+			...baseSummary,
+			commitHash: "root-squash",
+			children: [
+				{ ...baseSummary, commitHash: "leaf-1" } as CommitSummary,
+				{ ...baseSummary, commitHash: "leaf-2" } as CommitSummary,
+			],
+		} as CommitSummary;
+
+		vi.mocked(SummaryStore.readTranscriptsForCommits).mockResolvedValue(
+			new Map([
+				[
+					"leaf-1",
+					{
+						sessions: [
+							{
+								sessionId: "s-leaf1",
+								source: "claude",
+								entries: [
+									{ role: "human", content: "h1", timestamp: "2026-05-21T00:00:00Z" },
+									{ role: "assistant", content: "a1", timestamp: "2026-05-21T00:00:01Z" },
+								],
+							},
+						],
+					},
+				],
+				[
+					"leaf-2",
+					{
+						sessions: [
+							{
+								sessionId: "s-leaf2",
+								source: "codex",
+								entries: [{ role: "human", content: "h2", timestamp: "2026-05-21T00:01:00Z" }],
+							},
+						],
+					},
+				],
+			]),
+		);
+
+		const ctx = await loadRegenerateContext(tree, "/repo");
+
+		// All 3 entries (2 from leaf-1, 1 from leaf-2) counted across 2 sessions.
+		expect(ctx.entryCount).toBe(3);
+		expect(ctx.sessionCount).toBe(2);
+		expect(ctx.humanTurns).toBe(2);
+		expect(new Set(ctx.sources)).toEqual(new Set(["Claude", "Codex"]));
+
+		// readTranscriptsForCommits should have been asked for every hash
+		// in the tree, including the synthetic root with no own transcript.
+		const requested = vi.mocked(SummaryStore.readTranscriptsForCommits).mock.calls[0][0];
+		expect(new Set(requested)).toEqual(new Set(["root-squash", "leaf-1", "leaf-2"]));
 	});
 });

--- a/cli/src/core/RegenerateContext.test.ts
+++ b/cli/src/core/RegenerateContext.test.ts
@@ -103,6 +103,24 @@ describe("loadRegenerateContext", () => {
 		expect(ctx.sources).toEqual(["Claude"]);
 	});
 
+	it("defaults missing session.source to 'claude' for sessionId dedup keys", async () => {
+		// Legacy / partial stored sessions may not carry .source. The
+		// dedup key uses `session.source ?? "claude"` so two sessions
+		// with the same sessionId but neither carrying source collapse
+		// to one session count.
+		vi.mocked(SummaryStore.readTranscriptsForCommits).mockResolvedValue(
+			singleHashMap(baseSummary.commitHash, {
+				sessions: [
+					{ sessionId: "dup", entries: [] },
+					{ sessionId: "dup", entries: [] },
+				],
+			}),
+		);
+
+		const ctx = await loadRegenerateContext(baseSummary, "/repo");
+		expect(ctx.sessionCount).toBe(1);
+	});
+
 	it("dedups sessionCount by source:sessionId when the same session appears in multiple commit transcripts", async () => {
 		// A single AI session can have its entries spliced across multiple
 		// commit transcripts (squash slicing, amend rewriting). The webview's

--- a/cli/src/core/RegenerateContext.test.ts
+++ b/cli/src/core/RegenerateContext.test.ts
@@ -1,0 +1,102 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { CommitSummary, StoredTranscript } from "../Types.js";
+import { loadRegenerateContext } from "./RegenerateContext.js";
+import * as SummaryStore from "./SummaryStore.js";
+
+vi.mock("./SummaryStore.js", () => ({
+	readTranscript: vi.fn(),
+}));
+
+const baseSummary: CommitSummary = {
+	version: 4,
+	commitHash: "abc1234567890",
+	commitMessage: "Test commit",
+	commitAuthor: "tester",
+	commitDate: "2026-05-21T00:00:00Z",
+	branch: "main",
+	generatedAt: "2026-05-21T00:01:00Z",
+} as CommitSummary;
+
+describe("loadRegenerateContext", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("returns counts and sources from the stored transcript", async () => {
+		const stored: StoredTranscript = {
+			sessions: [
+				{
+					sessionId: "s1",
+					source: "claude",
+					entries: [
+						{ role: "human", content: "hi", timestamp: "2026-05-21T00:00:00Z" },
+						{ role: "assistant", content: "hello", timestamp: "2026-05-21T00:00:01Z" },
+					],
+				},
+				{
+					sessionId: "s2",
+					source: "codex",
+					entries: [{ role: "human", content: "x", timestamp: "2026-05-21T00:00:02Z" }],
+				},
+			],
+		};
+		vi.mocked(SummaryStore.readTranscript).mockResolvedValue(stored);
+
+		const ctx = await loadRegenerateContext(
+			{
+				...baseSummary,
+				plans: [{ slug: "p1" } as never],
+				notes: [],
+				linearIssues: [{ archivedKey: "li-1" } as never],
+			} as CommitSummary,
+			"/repo",
+		);
+
+		expect(ctx).toEqual({
+			entryCount: 3,
+			sessionCount: 2,
+			sources: ["Claude", "Codex"],
+			humanTurns: 2,
+			plansCount: 1,
+			notesCount: 0,
+			linearCount: 1,
+		});
+	});
+
+	it("returns zero counts when transcript is missing (no special-case branch)", async () => {
+		vi.mocked(SummaryStore.readTranscript).mockResolvedValue(null);
+		const ctx = await loadRegenerateContext(baseSummary, "/repo");
+		expect(ctx).toEqual({
+			entryCount: 0,
+			sessionCount: 0,
+			sources: [],
+			humanTurns: 0,
+			plansCount: 0,
+			notesCount: 0,
+			linearCount: 0,
+		});
+	});
+
+	it("deduplicates source list", async () => {
+		vi.mocked(SummaryStore.readTranscript).mockResolvedValue({
+			sessions: [
+				{ sessionId: "a", source: "claude", entries: [] },
+				{ sessionId: "b", source: "claude", entries: [] },
+			],
+		});
+		const ctx = await loadRegenerateContext(baseSummary, "/repo");
+		expect(ctx.sources).toEqual(["Claude"]);
+	});
+
+	it("preserves session-list source order (first occurrence wins)", async () => {
+		vi.mocked(SummaryStore.readTranscript).mockResolvedValue({
+			sessions: [
+				{ sessionId: "a", source: "codex", entries: [] },
+				{ sessionId: "b", source: "claude", entries: [] },
+				{ sessionId: "c", source: "codex", entries: [] },
+			],
+		});
+		const ctx = await loadRegenerateContext(baseSummary, "/repo");
+		expect(ctx.sources).toEqual(["Codex", "Claude"]);
+	});
+});

--- a/cli/src/core/RegenerateContext.ts
+++ b/cli/src/core/RegenerateContext.ts
@@ -1,4 +1,5 @@
 import type { CommitSummary } from "../Types.js";
+import type { StorageProvider } from "./StorageProvider.js";
 import { normalizeToV4, readTranscriptsForCommits } from "./SummaryStore.js";
 import { collectAllTranscriptHashes } from "./SummaryTree.js";
 import { transcriptSourceLabel } from "./TranscriptSourceLabel.js";
@@ -35,10 +36,18 @@ export interface RegenerateContext {
 	readonly linearCount: number;
 }
 
-export async function loadRegenerateContext(summary: CommitSummary, cwd: string): Promise<RegenerateContext> {
+export async function loadRegenerateContext(
+	summary: CommitSummary,
+	cwd: string,
+	storage?: StorageProvider,
+): Promise<RegenerateContext> {
 	const normalized = normalizeToV4(summary);
 	const treeHashes = collectAllTranscriptHashes(normalized);
-	const transcriptMap = await readTranscriptsForCommits(treeHashes, cwd);
+	// `storage` is threaded so folder-only Memory Bank users read transcripts
+	// from FolderStorage instead of the OrphanBranchStorage fallback in
+	// resolveStorage — otherwise the confirm dialog would report 0 transcript
+	// entries even when the user can see them in the All Conversations card.
+	const transcriptMap = await readTranscriptsForCommits(treeHashes, cwd, storage);
 
 	let entryCount = 0;
 	let humanTurns = 0;

--- a/cli/src/core/RegenerateContext.ts
+++ b/cli/src/core/RegenerateContext.ts
@@ -1,0 +1,48 @@
+import type { CommitSummary } from "../Types.js";
+import { readTranscript } from "./SummaryStore.js";
+import { transcriptSourceLabel } from "./TranscriptSourceLabel.js";
+
+/**
+ * Counts and source list shown to the user in the regenerate-summary confirm
+ * dialog. Computed from the persisted transcript on the orphan branch plus
+ * the summary's own attached-artifact references.
+ *
+ * Returns zero-valued counts (NOT null) when no transcript was persisted for
+ * the commit — the regenerate path still runs in that case, just with an
+ * empty conversation. The confirm dialog adjusts copy on entryCount === 0.
+ */
+export interface RegenerateContext {
+	readonly entryCount: number;
+	readonly sessionCount: number;
+	readonly sources: ReadonlyArray<string>;
+	readonly humanTurns: number;
+	readonly plansCount: number;
+	readonly notesCount: number;
+	readonly linearCount: number;
+}
+
+export async function loadRegenerateContext(summary: CommitSummary, cwd: string): Promise<RegenerateContext> {
+	const stored = await readTranscript(summary.commitHash, cwd);
+
+	let entryCount = 0;
+	let humanTurns = 0;
+	const sourceSet = new Set<string>();
+	const sessions = stored?.sessions ?? [];
+	for (const session of sessions) {
+		entryCount += session.entries.length;
+		for (const entry of session.entries) {
+			if (entry.role === "human") humanTurns++;
+		}
+		sourceSet.add(transcriptSourceLabel(session.source));
+	}
+
+	return {
+		entryCount,
+		sessionCount: sessions.length,
+		sources: Array.from(sourceSet),
+		humanTurns,
+		plansCount: summary.plans?.length ?? 0,
+		notesCount: summary.notes?.length ?? 0,
+		linearCount: summary.linearIssues?.length ?? 0,
+	};
+}

--- a/cli/src/core/RegenerateContext.ts
+++ b/cli/src/core/RegenerateContext.ts
@@ -1,15 +1,29 @@
 import type { CommitSummary } from "../Types.js";
-import { readTranscript } from "./SummaryStore.js";
+import { normalizeToV4, readTranscriptsForCommits } from "./SummaryStore.js";
+import { collectAllTranscriptHashes } from "./SummaryTree.js";
 import { transcriptSourceLabel } from "./TranscriptSourceLabel.js";
 
 /**
  * Counts and source list shown to the user in the regenerate-summary confirm
- * dialog. Computed from the persisted transcript on the orphan branch plus
- * the summary's own attached-artifact references.
+ * dialog. Aggregated across the ENTIRE summary tree (root + all descendants)
+ * so squash / amend / rebase commits report the same number of transcripts
+ * the user sees in the webview's All Conversations card.
+ *
+ * Sessions are deduped by `${source}:${sessionId}`: the same AI session may
+ * persist into multiple commit transcripts (e.g. squash slices a single
+ * Claude session across N commits), and the webview already collapses those
+ * via the same key (see `SummaryWebviewPanel` conversations-stats logic).
+ * Entries are NOT deduped — each commit transcript holds a different slice
+ * of the session, and the union equals the full conversation.
+ *
+ * Attachment counts (plans / notes / linearIssues) read the NORMALIZED root
+ * after `normalizeToV4`, so v3 legacy summaries whose attachments lived on
+ * a child still report the correct numbers.
  *
  * Returns zero-valued counts (NOT null) when no transcript was persisted for
- * the commit — the regenerate path still runs in that case, just with an
- * empty conversation. The confirm dialog adjusts copy on entryCount === 0.
+ * any commit in the tree — the regenerate path still runs in that case, just
+ * with an empty conversation. The confirm dialog adjusts copy on
+ * entryCount === 0.
  */
 export interface RegenerateContext {
 	readonly entryCount: number;
@@ -22,27 +36,33 @@ export interface RegenerateContext {
 }
 
 export async function loadRegenerateContext(summary: CommitSummary, cwd: string): Promise<RegenerateContext> {
-	const stored = await readTranscript(summary.commitHash, cwd);
+	const normalized = normalizeToV4(summary);
+	const treeHashes = collectAllTranscriptHashes(normalized);
+	const transcriptMap = await readTranscriptsForCommits(treeHashes, cwd);
 
 	let entryCount = 0;
 	let humanTurns = 0;
+	const seenSessions = new Set<string>();
 	const sourceSet = new Set<string>();
-	const sessions = stored?.sessions ?? [];
-	for (const session of sessions) {
-		entryCount += session.entries.length;
-		for (const entry of session.entries) {
-			if (entry.role === "human") humanTurns++;
+	for (const stored of transcriptMap.values()) {
+		for (const session of stored.sessions) {
+			entryCount += session.entries.length;
+			for (const entry of session.entries) {
+				if (entry.role === "human") humanTurns++;
+			}
+			const sourceKey = session.source ?? "claude";
+			seenSessions.add(`${sourceKey}:${session.sessionId}`);
+			sourceSet.add(transcriptSourceLabel(session.source));
 		}
-		sourceSet.add(transcriptSourceLabel(session.source));
 	}
 
 	return {
 		entryCount,
-		sessionCount: sessions.length,
+		sessionCount: seenSessions.size,
 		sources: Array.from(sourceSet),
 		humanTurns,
-		plansCount: summary.plans?.length ?? 0,
-		notesCount: summary.notes?.length ?? 0,
-		linearCount: summary.linearIssues?.length ?? 0,
+		plansCount: normalized.plans?.length ?? 0,
+		notesCount: normalized.notes?.length ?? 0,
+		linearCount: normalized.linearIssues?.length ?? 0,
 	};
 }

--- a/cli/src/core/Regenerator.test.ts
+++ b/cli/src/core/Regenerator.test.ts
@@ -7,12 +7,25 @@ import * as SummaryStore from "./SummaryStore.js";
 import * as TranscriptReader from "./TranscriptReader.js";
 
 vi.mock("./Summarizer.js", () => ({ generateSummary: vi.fn() }));
-vi.mock("./SummaryStore.js", () => ({
-	readTranscript: vi.fn(),
-	readLinearIssueFromBranch: vi.fn(),
-	readPlanFromBranch: vi.fn(),
-	readNoteFromBranch: vi.fn(),
-}));
+// Mock the four orphan-branch / transcript IO entry points but route
+// stripFunctionalMetadata to the REAL implementation. A hand-written stub
+// would only strip a single level (the test author's level) — the real impl
+// recurses through children at every step, and the regenerate v3 → v4
+// migration depends on that recursion (grandchildren in squash-over-amend
+// trees would otherwise leak own-hoist fields).
+vi.mock("./SummaryStore.js", async () => {
+	const actual = await vi.importActual<typeof import("./SummaryStore.js")>("./SummaryStore.js");
+	return {
+		readTranscriptsForCommits: vi.fn(),
+		readLinearIssueFromBranch: vi.fn(),
+		readPlanFromBranch: vi.fn(),
+		readNoteFromBranch: vi.fn(),
+		// Use the real normalizeToV4 — these tests exercise the full
+		// regenerate path including the v3 → v4 migration step, so a mock
+		// would defeat the regression coverage for child-only attachments.
+		normalizeToV4: actual.normalizeToV4,
+	};
+});
 vi.mock("./GitOps.js", () => ({ getDiffContent: vi.fn() }));
 vi.mock("./TranscriptReader.js", () => ({ buildMultiSessionContext: vi.fn() }));
 
@@ -62,7 +75,10 @@ const successResult = {
 describe("regenerateSummary", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
-		vi.mocked(SummaryStore.readTranscript).mockResolvedValue(storedTranscript);
+		// Default: one stored transcript under the root commit hash.
+		vi.mocked(SummaryStore.readTranscriptsForCommits).mockResolvedValue(
+			new Map([[baseSummary.commitHash, storedTranscript]]),
+		);
 		vi.mocked(GitOps.getDiffContent).mockResolvedValue("DIFF");
 		vi.mocked(TranscriptReader.buildMultiSessionContext).mockReturnValue("CONV");
 		vi.mocked(SummaryStore.readLinearIssueFromBranch).mockResolvedValue(null);
@@ -72,7 +88,7 @@ describe("regenerateSummary", () => {
 	});
 
 	it("still runs generateSummary when no transcript is stored (empty conversation)", async () => {
-		vi.mocked(SummaryStore.readTranscript).mockResolvedValue(null);
+		vi.mocked(SummaryStore.readTranscriptsForCommits).mockResolvedValue(new Map());
 		await regenerateSummary(baseSummary, "/repo", config);
 		expect(TranscriptReader.buildMultiSessionContext).toHaveBeenCalledWith([]);
 		expect(Summarizer.generateSummary).toHaveBeenCalledWith(
@@ -128,6 +144,96 @@ describe("regenerateSummary", () => {
 		// generatedAt should be refreshed to a now-ish ISO timestamp
 		expect(updated.generatedAt).not.toBe(baseSummary.generatedAt);
 		expect(new Date(updated.generatedAt).toString()).not.toBe("Invalid Date");
+	});
+
+	it("aggregates transcripts across the entire tree (root + children + grandchildren)", async () => {
+		// Squash-over-amend tree: root has no transcript of its own (the
+		// squash commit is synthetic), each leaf has its own conversation.
+		// Regenerator must union every session so the LLM sees what the
+		// webview's All Conversations card already showed the user.
+		const tree: CommitSummary = {
+			...baseSummary,
+			commitHash: "rootsquash",
+			children: [
+				{
+					...baseSummary,
+					commitHash: "amend-root",
+					children: [
+						{
+							...baseSummary,
+							commitHash: "original-leaf",
+						},
+					],
+				},
+				{
+					...baseSummary,
+					commitHash: "other-leaf",
+				},
+			],
+		} as CommitSummary;
+		vi.mocked(SummaryStore.readTranscriptsForCommits).mockResolvedValue(
+			new Map([
+				// Root itself has no AI conversation (synthetic squash).
+				[
+					"amend-root",
+					{
+						sessions: [
+							{
+								sessionId: "amend-session",
+								source: "claude",
+								entries: [
+									{ role: "human", content: "fix bug", timestamp: "2026-05-21T01:00:00Z" },
+									{ role: "assistant", content: "done", timestamp: "2026-05-21T01:00:01Z" },
+								],
+							},
+						],
+					},
+				],
+				[
+					"original-leaf",
+					{
+						sessions: [
+							{
+								sessionId: "leaf-session",
+								source: "codex",
+								entries: [{ role: "human", content: "first cut", timestamp: "2026-05-21T00:30:00Z" }],
+							},
+						],
+					},
+				],
+				[
+					"other-leaf",
+					{
+						sessions: [
+							{
+								sessionId: "other-session",
+								source: "claude",
+								entries: [{ role: "human", content: "side fix", timestamp: "2026-05-21T00:45:00Z" }],
+							},
+						],
+					},
+				],
+			]),
+		);
+
+		await regenerateSummary(tree, "/repo", config);
+
+		// readTranscriptsForCommits should be asked for the full tree hash set.
+		const requestedHashes = vi.mocked(SummaryStore.readTranscriptsForCommits).mock.calls[0][0];
+		expect(new Set(requestedHashes)).toEqual(new Set(["rootsquash", "amend-root", "original-leaf", "other-leaf"]));
+
+		// buildMultiSessionContext receives a SessionTranscript[] union of all
+		// three commits' sessions — one per leaf, 4 entries total.
+		const sessionsArg = vi.mocked(TranscriptReader.buildMultiSessionContext).mock.calls[0][0];
+		expect(sessionsArg).toHaveLength(3);
+		const sessionIds = sessionsArg.map((s) => s.sessionId).sort();
+		expect(sessionIds).toEqual(["amend-session", "leaf-session", "other-session"]);
+
+		const totalEntries = sessionsArg.reduce((sum, s) => sum + s.entries.length, 0);
+		expect(totalEntries).toBe(4);
+
+		// generateSummary sees the aggregated transcriptEntries count.
+		expect(Summarizer.generateSummary).toHaveBeenCalledWith(expect.objectContaining({ transcriptEntries: 4 }));
 	});
 
 	it("reads attached plans / notes / linear-issues from the orphan branch as prompt blocks", async () => {
@@ -223,14 +329,392 @@ describe("regenerateSummary", () => {
 		expect("conversationTurns" in updated).toBe(false);
 	});
 
-	it("preserves recap when generateSummary omits it from the result", async () => {
+	it("clears recap when generateSummary omits it from the result (always-overwrite semantics)", async () => {
+		// Confirm dialog promises Recap is OVERWRITTEN — when the LLM produces
+		// no recap (e.g. commit has no major topics), the old recap must NOT
+		// silently survive. Empty string explicitly communicates "no recap".
 		vi.mocked(Summarizer.generateSummary).mockResolvedValueOnce({
 			...successResult,
 			recap: undefined,
 		});
 		const { updated } = await regenerateSummary(baseSummary, "/repo", config);
-		// generateSummary did not return recap — old summary's recap stays.
-		expect(updated.recap).toBe("old recap");
+		expect(updated.recap).toBe("");
+	});
+
+	it("upgrades v3 legacy summaries to v4 and strips own-hoist fields from children", async () => {
+		// Regression for the v3-with-children fallthrough: collectDisplayTopics
+		// recurses into children when version < 4, which would merge stale
+		// children topics with the freshly-regenerated root topics. Regenerator
+		// upgrades to v4 (root-authoritative display) AND strips children so
+		// countTopics / index entries also report the right value.
+		const v3Legacy: CommitSummary = {
+			...baseSummary,
+			version: 3,
+			topics: [{ title: "old root topic", trigger: "t", response: "r", decisions: "d" }],
+			recap: "old root recap",
+			children: [
+				{
+					...baseSummary,
+					commitHash: "child000000000000",
+					version: 3,
+					topics: [{ title: "stale child topic", trigger: "t", response: "r", decisions: "d" }],
+					recap: "stale child recap",
+				},
+			],
+		} as CommitSummary;
+
+		const { updated } = await regenerateSummary(v3Legacy, "/repo", config);
+
+		expect(updated.version).toBe(4);
+		expect(updated.topics?.[0]?.title).toBe("new topic");
+		expect(updated.children).toHaveLength(1);
+		// stripFunctionalMetadata removes the own-hoist fields from the child.
+		expect(updated.children?.[0]?.topics).toBeUndefined();
+		expect(updated.children?.[0]?.recap).toBeUndefined();
+		// Identity fields are preserved on the stripped child.
+		expect(updated.children?.[0]?.commitHash).toBe("child000000000000");
+	});
+
+	it("strips own-hoist fields recursively through grandchildren (squash-over-amend tree)", async () => {
+		// Regression for the recursive-strip claim: a v3 squash-over-amend
+		// shape carries topics/recap two levels deep. Regenerator must
+		// flatten the entire subtree to root-authoritative or the index's
+		// countTopics (which recurses) would still surface stale data.
+		const v3Nested: CommitSummary = {
+			...baseSummary,
+			version: 3,
+			children: [
+				{
+					...baseSummary,
+					commitHash: "child000000000000",
+					version: 3,
+					topics: [{ title: "stale child topic", trigger: "t", response: "r", decisions: "d" }],
+					recap: "stale child recap",
+					children: [
+						{
+							...baseSummary,
+							commitHash: "grandchild0000000",
+							version: 3,
+							topics: [
+								{
+									title: "stale grandchild topic",
+									trigger: "t",
+									response: "r",
+									decisions: "d",
+								},
+							],
+							recap: "stale grandchild recap",
+						},
+					],
+				},
+			],
+		} as CommitSummary;
+
+		const { updated } = await regenerateSummary(v3Nested, "/repo", config);
+
+		expect(updated.version).toBe(4);
+		// Child stripped.
+		expect(updated.children?.[0]?.topics).toBeUndefined();
+		expect(updated.children?.[0]?.recap).toBeUndefined();
+		// Grandchild stripped too — proves recursion.
+		expect(updated.children?.[0]?.children?.[0]?.topics).toBeUndefined();
+		expect(updated.children?.[0]?.children?.[0]?.recap).toBeUndefined();
+		// Identity fields preserved at every level.
+		expect(updated.children?.[0]?.commitHash).toBe("child000000000000");
+		expect(updated.children?.[0]?.children?.[0]?.commitHash).toBe("grandchild0000000");
+	});
+
+	it("bumps version to 4 even on a v3 LEAF summary with no children", async () => {
+		// Guards against accidentally conditioning the version bump on the
+		// `summary.children !== undefined` branch — leaf summaries must
+		// upgrade too. (collectDisplayTopics still gates on version, so a v3
+		// leaf without a bump would keep walking the legacy recursive path
+		// even though there's nothing to recurse into.)
+		const v3Leaf: CommitSummary = {
+			...baseSummary,
+			version: 3,
+			children: undefined,
+		} as CommitSummary;
+
+		const { updated } = await regenerateSummary(v3Leaf, "/repo", config);
+
+		expect(updated.version).toBe(4);
+		expect(updated.children).toBeUndefined();
+	});
+
+	it("hoists v3 legacy child-only plans / notes / linearIssues / e2e / jolliDoc to root BEFORE stripping children", async () => {
+		// v3 legacy regression: pre-Hoist amend / squash put attachments and
+		// push doc IDs on the child node, not root. Without the hoist step,
+		// stripFunctionalMetadata would erase the only copy and lose:
+		//   - plan + note + linear-issue references (user attachments)
+		//   - jolliDocId / jolliDocUrl (the next push would create a duplicate
+		//     article instead of updating the existing one)
+		//   - e2eTestGuide (user-generated test scenarios)
+		const v3WithChildOnlyMeta: CommitSummary = {
+			...baseSummary,
+			version: 3,
+			// root has none of these — they live only on the child below.
+			plans: undefined,
+			notes: undefined,
+			linearIssues: undefined,
+			e2eTestGuide: undefined,
+			jolliDocId: undefined,
+			jolliDocUrl: undefined,
+			children: [
+				{
+					...baseSummary,
+					commitHash: "leafabcdef000000",
+					version: 3,
+					plans: [
+						{
+							slug: "feature-x",
+							title: "Feature X",
+							editCount: 1,
+							addedAt: "2026-05-20T00:00:00Z",
+							updatedAt: "2026-05-20T00:00:00Z",
+						},
+					],
+					notes: [
+						{
+							id: "note-1",
+							title: "Note 1",
+							format: "snippet",
+							addedAt: "2026-05-20T00:00:00Z",
+							updatedAt: "2026-05-20T00:00:00Z",
+						},
+					],
+					linearIssues: [
+						{
+							archivedKey: "JOLLI-1-leaf",
+							ticketId: "JOLLI-1",
+							title: "Ticket 1",
+							url: "https://linear.app/x",
+							referencedAt: "2026-05-20T00:00:00Z",
+							sourceToolName: "mcp__linear__get_issue",
+						},
+					],
+					e2eTestGuide: [
+						{
+							title: "Scenario 1",
+							preconditions: "",
+							steps: ["step 1"],
+							expectedResults: ["ok"],
+						} as never,
+					],
+					jolliDocId: 42,
+					jolliDocUrl: "https://jolli.ai/d/42",
+				},
+			],
+		} as CommitSummary;
+
+		const { updated } = await regenerateSummary(v3WithChildOnlyMeta, "/repo", config);
+
+		// Tree upgraded to v4 + children stripped (H1 invariant still holds).
+		expect(updated.version).toBe(4);
+		expect(updated.children?.[0]?.plans).toBeUndefined();
+		expect(updated.children?.[0]?.notes).toBeUndefined();
+		expect(updated.children?.[0]?.jolliDocId).toBeUndefined();
+
+		// AND child-only metadata is hoisted to root — the rescue this test guards.
+		expect(updated.plans?.[0]?.slug).toBe("feature-x");
+		expect(updated.notes?.[0]?.id).toBe("note-1");
+		expect(updated.linearIssues?.[0]?.archivedKey).toBe("JOLLI-1-leaf");
+		expect(updated.e2eTestGuide?.[0]?.title).toBe("Scenario 1");
+		expect(updated.jolliDocId).toBe(42);
+		expect(updated.jolliDocUrl).toBe("https://jolli.ai/d/42");
+	});
+
+	it("feeds v3 child-only plans / notes / linear-issues into the LLM prompt (normalize before rebuild*Block)", async () => {
+		// Regression for the H1 ordering bug: rebuild*Block used to read
+		// summary.plans / .notes / .linearIssues directly, so v3 legacy
+		// commits with attachments only on a child got an empty prompt
+		// even though hoist later rescued the field for storage. After the
+		// normalize-then-operate refactor, normalizeToV4 runs first, so
+		// rebuild*Block sees the union root and the LLM sees the body.
+		const v3ChildOnlyRefs: CommitSummary = {
+			...baseSummary,
+			version: 3,
+			plans: undefined,
+			notes: undefined,
+			linearIssues: undefined,
+			children: [
+				{
+					...baseSummary,
+					commitHash: "leafabcdef000000",
+					version: 3,
+					plans: [
+						{
+							slug: "p-child",
+							title: "Child plan",
+							editCount: 1,
+							addedAt: "2026-05-20T00:00:00Z",
+							updatedAt: "2026-05-20T00:00:00Z",
+						},
+					],
+					notes: [
+						{
+							id: "n-child",
+							title: "Child note",
+							format: "snippet",
+							addedAt: "2026-05-20T00:00:00Z",
+							updatedAt: "2026-05-20T00:00:00Z",
+						},
+					],
+					linearIssues: [
+						{
+							archivedKey: "JOLLI-7-leaf",
+							ticketId: "JOLLI-7",
+							title: "T",
+							url: "https://linear.app/y",
+							referencedAt: "2026-05-20T00:00:00Z",
+							sourceToolName: "mcp__linear__get_issue",
+						},
+					],
+				},
+			],
+		} as CommitSummary;
+		vi.mocked(SummaryStore.readPlanFromBranch).mockResolvedValueOnce("plan body for p-child");
+		vi.mocked(SummaryStore.readNoteFromBranch).mockResolvedValueOnce("note body for n-child");
+		vi.mocked(SummaryStore.readLinearIssueFromBranch).mockResolvedValueOnce("linear body for JOLLI-7");
+
+		await regenerateSummary(v3ChildOnlyRefs, "/repo", config);
+
+		// The reads went through under the hoisted slug / id / archivedKey.
+		expect(SummaryStore.readPlanFromBranch).toHaveBeenCalledWith("p-child", "/repo");
+		expect(SummaryStore.readNoteFromBranch).toHaveBeenCalledWith("n-child", "/repo");
+		expect(SummaryStore.readLinearIssueFromBranch).toHaveBeenCalledWith("JOLLI-7-leaf", "/repo");
+
+		// And the bodies landed in the prompt.
+		const params = vi.mocked(Summarizer.generateSummary).mock.calls[0][0];
+		expect(params.plans).toContain("plan body for p-child");
+		expect(params.notes).toContain("note body for n-child");
+		expect(params.linearIssues).toContain("linear body for JOLLI-7");
+	});
+
+	it("rescues child-only orphanedDocIds before stripping descendants", async () => {
+		// Regression: prior to the normalize-then-operate refactor, the
+		// updated summary picked up root.orphanedDocIds + jolliMeta's new
+		// orphans, but stripFunctionalMetadata then dropped child-level
+		// orphanedDocIds before they could be merged. Now normalizeToV4
+		// unions everything to root first.
+		const v3WithChildOrphans: CommitSummary = {
+			...baseSummary,
+			version: 3,
+			orphanedDocIds: [1],
+			children: [
+				{
+					...baseSummary,
+					commitHash: "c-1",
+					version: 3,
+					orphanedDocIds: [2, 3],
+				},
+			],
+		} as CommitSummary;
+
+		const { updated } = await regenerateSummary(v3WithChildOrphans, "/repo", config);
+
+		expect(new Set(updated.orphanedDocIds ?? [])).toEqual(new Set([1, 2, 3]));
+		// Child stripped of its own copy.
+		expect(updated.children?.[0]?.orphanedDocIds).toBeUndefined();
+	});
+
+	it("rescues orphanedDocIds from grandchildren too (3-level squash-over-squash)", async () => {
+		// The shape that motivates M2 is squash-of-squash — the orphan IDs
+		// can sit at depth 2, never depth 1. Confirms collectDescendantOrphaned
+		// DocIds inside normalizeToV4 walks past the first hop, not just the
+		// immediate children. Without recursion this test would fail (only
+		// id 1 would surface, missing 4).
+		const v3DeepOrphans: CommitSummary = {
+			...baseSummary,
+			version: 3,
+			orphanedDocIds: [1],
+			children: [
+				{
+					...baseSummary,
+					commitHash: "c-1",
+					version: 3,
+					// No own orphans at depth 1 — proves we don't stop here.
+					children: [
+						{
+							...baseSummary,
+							commitHash: "g-1",
+							version: 3,
+							orphanedDocIds: [4, 5],
+						},
+					],
+				},
+			],
+		} as CommitSummary;
+
+		const { updated } = await regenerateSummary(v3DeepOrphans, "/repo", config);
+
+		expect(new Set(updated.orphanedDocIds ?? [])).toEqual(new Set([1, 4, 5]));
+		expect(updated.children?.[0]?.children?.[0]?.orphanedDocIds).toBeUndefined();
+	});
+
+	it("dedups same-slug plans across the v3 tree by picking the newer updatedAt", async () => {
+		// normalizeToV4 runs on v3 input only (v4 fast-paths because the
+		// invariant is already established — children shouldn't carry own
+		// plans). On v3 legacy data where the same plan slug appears on
+		// both root and a child, collectChildPlans picks the newer.
+		const v3RootAndChildSame: CommitSummary = {
+			...baseSummary,
+			version: 3,
+			plans: [
+				{
+					slug: "shared-plan",
+					title: "Shared (root, older)",
+					editCount: 1,
+					addedAt: "2026-05-20T00:00:00Z",
+					updatedAt: "2026-05-20T00:00:00Z",
+				},
+			],
+			children: [
+				{
+					...baseSummary,
+					commitHash: "child000",
+					version: 3,
+					plans: [
+						{
+							slug: "shared-plan",
+							title: "Shared (child, newer)",
+							editCount: 2,
+							addedAt: "2026-05-20T00:00:00Z",
+							updatedAt: "2026-05-21T00:00:00Z",
+						},
+					],
+				},
+			],
+		} as CommitSummary;
+
+		const { updated } = await regenerateSummary(v3RootAndChildSame, "/repo", config);
+
+		expect(updated.plans).toHaveLength(1);
+		expect(updated.plans?.[0]?.title).toBe("Shared (child, newer)");
+	});
+
+	it("is a no-op for the v4 + already-stripped children case (idempotent)", async () => {
+		const v4Tree: CommitSummary = {
+			...baseSummary,
+			version: 4,
+			children: [
+				{
+					...baseSummary,
+					commitHash: "child111111111111",
+					version: 4,
+					// Children already stripped — no topics / recap.
+					topics: undefined,
+					recap: undefined,
+				} as CommitSummary,
+			],
+		};
+
+		const { updated } = await regenerateSummary(v4Tree, "/repo", config);
+
+		expect(updated.version).toBe(4);
+		expect(updated.children).toHaveLength(1);
+		expect(updated.children?.[0]?.commitHash).toBe("child111111111111");
+		expect(updated.children?.[0]?.topics).toBeUndefined();
 	});
 
 	it("falls back to summary.stats when summary.diffStats is absent (v3 legacy)", async () => {

--- a/cli/src/core/Regenerator.test.ts
+++ b/cli/src/core/Regenerator.test.ts
@@ -255,10 +255,12 @@ describe("regenerateSummary", () => {
 
 		await regenerateSummary(withRefs, "/repo", config);
 
-		expect(SummaryStore.readPlanFromBranch).toHaveBeenCalledWith("p-1", "/repo");
-		expect(SummaryStore.readPlanFromBranch).toHaveBeenCalledWith("p-2", "/repo");
-		expect(SummaryStore.readNoteFromBranch).toHaveBeenCalledWith("n-1", "/repo");
-		expect(SummaryStore.readLinearIssueFromBranch).toHaveBeenCalledWith("JOLLI-1-abc", "/repo");
+		// Third arg is the optional StorageProvider; tests pass undefined,
+		// production code routes through bridge.regenerateSummary which supplies it.
+		expect(SummaryStore.readPlanFromBranch).toHaveBeenCalledWith("p-1", "/repo", undefined);
+		expect(SummaryStore.readPlanFromBranch).toHaveBeenCalledWith("p-2", "/repo", undefined);
+		expect(SummaryStore.readNoteFromBranch).toHaveBeenCalledWith("n-1", "/repo", undefined);
+		expect(SummaryStore.readLinearIssueFromBranch).toHaveBeenCalledWith("JOLLI-1-abc", "/repo", undefined);
 
 		const params = vi.mocked(Summarizer.generateSummary).mock.calls[0][0];
 		expect(params.plans).toContain("plan body 1");
@@ -580,9 +582,9 @@ describe("regenerateSummary", () => {
 		await regenerateSummary(v3ChildOnlyRefs, "/repo", config);
 
 		// The reads went through under the hoisted slug / id / archivedKey.
-		expect(SummaryStore.readPlanFromBranch).toHaveBeenCalledWith("p-child", "/repo");
-		expect(SummaryStore.readNoteFromBranch).toHaveBeenCalledWith("n-child", "/repo");
-		expect(SummaryStore.readLinearIssueFromBranch).toHaveBeenCalledWith("JOLLI-7-leaf", "/repo");
+		expect(SummaryStore.readPlanFromBranch).toHaveBeenCalledWith("p-child", "/repo", undefined);
+		expect(SummaryStore.readNoteFromBranch).toHaveBeenCalledWith("n-child", "/repo", undefined);
+		expect(SummaryStore.readLinearIssueFromBranch).toHaveBeenCalledWith("JOLLI-7-leaf", "/repo", undefined);
 
 		// And the bodies landed in the prompt.
 		const params = vi.mocked(Summarizer.generateSummary).mock.calls[0][0];
@@ -650,6 +652,314 @@ describe("regenerateSummary", () => {
 
 		expect(new Set(updated.orphanedDocIds ?? [])).toEqual(new Set([1, 4, 5]));
 		expect(updated.children?.[0]?.children?.[0]?.orphanedDocIds).toBeUndefined();
+	});
+
+	it("truncates oversized plan bodies at PLAN_MAX_CHARS (20000) so a pathological plan can't blow out the prompt", async () => {
+		// Without per-item truncation, a 100KB plan body would be embedded
+		// verbatim in the <plan> block and dominate the LLM call cost.
+		const withBigPlan: CommitSummary = {
+			...baseSummary,
+			plans: [
+				{
+					slug: "huge",
+					title: "Huge",
+					editCount: 1,
+					addedAt: "2026-05-20T00:00:00Z",
+					updatedAt: "2026-05-20T00:00:00Z",
+				} as never,
+			],
+		} as CommitSummary;
+		const big = "x".repeat(50000);
+		vi.mocked(SummaryStore.readPlanFromBranch).mockResolvedValueOnce(big);
+
+		await regenerateSummary(withBigPlan, "/repo", config);
+
+		const params = vi.mocked(Summarizer.generateSummary).mock.calls[0][0];
+		// Truncation marker present, body cut to ~20000 chars (plus the
+		// truncation tail) rather than the full 50000.
+		expect(params.plans).toContain("[truncated,");
+		expect((params.plans ?? "").length).toBeLessThan(30000);
+	});
+
+	it("truncates oversized linear-issue bodies at LINEAR_MAX_CHARS (4000)", async () => {
+		const withBigLinear: CommitSummary = {
+			...baseSummary,
+			linearIssues: [
+				{
+					archivedKey: "JOLLI-1-abc",
+					ticketId: "JOLLI-1",
+					title: "T",
+					url: "https://linear.app/x",
+					referencedAt: "2026-05-21T00:00:00Z",
+					sourceToolName: "mcp__linear__get_issue",
+				} as never,
+			],
+		} as CommitSummary;
+		const big = "y".repeat(10000);
+		vi.mocked(SummaryStore.readLinearIssueFromBranch).mockResolvedValueOnce(big);
+
+		await regenerateSummary(withBigLinear, "/repo", config);
+
+		const params = vi.mocked(Summarizer.generateSummary).mock.calls[0][0];
+		expect(params.linearIssues).toContain("[truncated,");
+	});
+
+	it("caps the total <linear-issues> block at LINEAR_TOTAL_CHARS (30000) by dropping the oldest", async () => {
+		const mkRef = (key: string, referencedAt: string) =>
+			({
+				archivedKey: key,
+				ticketId: key,
+				title: key,
+				url: "https://linear.app/x",
+				referencedAt,
+				sourceToolName: "mcp__linear__get_issue",
+			}) as never;
+		const withMany: CommitSummary = {
+			...baseSummary,
+			linearIssues: [
+				mkRef("oldest", "2026-05-18T00:00:00Z"),
+				mkRef("middle", "2026-05-19T00:00:00Z"),
+				mkRef("newer", "2026-05-20T00:00:00Z"),
+				mkRef("newest", "2026-05-21T00:00:00Z"),
+				mkRef("freshest", "2026-05-22T00:00:00Z"),
+				mkRef("future", "2026-05-23T00:00:00Z"),
+				mkRef("further", "2026-05-24T00:00:00Z"),
+				mkRef("furthest", "2026-05-25T00:00:00Z"),
+				mkRef("beyond", "2026-05-26T00:00:00Z"),
+			],
+		} as CommitSummary;
+		const big = "y".repeat(4000);
+		vi.mocked(SummaryStore.readLinearIssueFromBranch).mockResolvedValue(big);
+
+		await regenerateSummary(withMany, "/repo", config);
+
+		const params = vi.mocked(Summarizer.generateSummary).mock.calls[0][0];
+		// Newest selected; oldest dropped under greedy newest-first.
+		expect(params.linearIssues).toContain('id="beyond"');
+		expect(params.linearIssues).not.toContain('id="oldest"');
+	});
+
+	it("truncates oversized note bodies at NOTE_MAX_CHARS (4000) and caps total at NOTE_TOTAL_CHARS (12000)", async () => {
+		const mkNote = (id: string, updatedAt: string) =>
+			({
+				id,
+				title: id,
+				format: "snippet",
+				addedAt: updatedAt,
+				updatedAt,
+			}) as never;
+		const withManyNotes: CommitSummary = {
+			...baseSummary,
+			notes: [
+				mkNote("oldest-note", "2026-05-18T00:00:00Z"),
+				mkNote("middle-note", "2026-05-19T00:00:00Z"),
+				mkNote("newer-note", "2026-05-20T00:00:00Z"),
+				mkNote("newest-note", "2026-05-21T00:00:00Z"),
+				mkNote("freshest-note", "2026-05-22T00:00:00Z"),
+			],
+		} as CommitSummary;
+		const big = "n".repeat(8000);
+		vi.mocked(SummaryStore.readNoteFromBranch).mockResolvedValue(big);
+
+		await regenerateSummary(withManyNotes, "/repo", config);
+
+		const params = vi.mocked(Summarizer.generateSummary).mock.calls[0][0];
+		// 4000-char per-note hits truncate; total cap kicks in around 3 notes.
+		expect(params.notes).toContain("[truncated,");
+		expect(params.notes).toContain('id="freshest-note"');
+		expect(params.notes).not.toContain('id="oldest-note"');
+	});
+
+	it("preserves transcript session.source when stored session has a source set", async () => {
+		// And omits the `source` key when StoredSession.source is undefined —
+		// the conditional spread covers the optional-field shape that the
+		// SessionTranscript consumer (buildMultiSessionContext) expects.
+		vi.mocked(SummaryStore.readTranscriptsForCommits).mockResolvedValue(
+			new Map([
+				[
+					baseSummary.commitHash,
+					{
+						sessions: [
+							// One with source, one without — exercises both branches
+							// of the `s.source !== undefined ? ... : {}` spread.
+							{ sessionId: "with-src", source: "claude", entries: [] },
+							{ sessionId: "no-src", entries: [] },
+						],
+					},
+				],
+			]),
+		);
+
+		await regenerateSummary(baseSummary, "/repo", config);
+
+		const sessionsArg = vi.mocked(TranscriptReader.buildMultiSessionContext).mock.calls[0][0];
+		expect(sessionsArg[0]).toMatchObject({ sessionId: "with-src", source: "claude" });
+		expect(sessionsArg[1]).toMatchObject({ sessionId: "no-src" });
+		expect(sessionsArg[1]).not.toHaveProperty("source");
+	});
+
+	it("preserves transcript transcriptPath when stored session carries it (vs the '(stored)' fallback)", async () => {
+		// Default fixture uses no transcriptPath → we fall back to "(stored)".
+		// This case feeds a real one through so the ?? branch the other side
+		// of that nullish-coalesce gets exercised.
+		vi.mocked(SummaryStore.readTranscriptsForCommits).mockResolvedValue(
+			new Map([
+				[
+					baseSummary.commitHash,
+					{
+						sessions: [
+							{
+								sessionId: "with-path",
+								source: "claude",
+								transcriptPath: "/abs/path/to/transcript.jsonl",
+								entries: [],
+							},
+						],
+					},
+				],
+			]),
+		);
+
+		await regenerateSummary(baseSummary, "/repo", config);
+
+		const sessionsArg = vi.mocked(TranscriptReader.buildMultiSessionContext).mock.calls[0][0];
+		expect(sessionsArg[0]?.transcriptPath).toBe("/abs/path/to/transcript.jsonl");
+	});
+
+	it("falls back to summary.stats when diffStats is absent (v3 legacy)", async () => {
+		// normalizeToV4 doesn't touch diffStats / stats, so a v3 legacy
+		// commit whose original summary only carried `.stats` still needs
+		// the `?? normalized.stats` fallback before generateSummary sees it.
+		const v3Stats: CommitSummary = {
+			...baseSummary,
+			version: 3,
+			diffStats: undefined,
+			stats: { filesChanged: 7, insertions: 9, deletions: 11 },
+		} as CommitSummary;
+
+		await regenerateSummary(v3Stats, "/repo", config);
+
+		const params = vi.mocked(Summarizer.generateSummary).mock.calls[0][0];
+		expect(params.diffStats).toEqual({ filesChanged: 7, insertions: 9, deletions: 11 });
+	});
+
+	it("falls back to zero diffStats when both diffStats and stats are absent", async () => {
+		const noStats: CommitSummary = {
+			...baseSummary,
+			diffStats: undefined,
+			stats: undefined,
+		} as CommitSummary;
+
+		await regenerateSummary(noStats, "/repo", config);
+
+		const params = vi.mocked(Summarizer.generateSummary).mock.calls[0][0];
+		expect(params.diffStats).toEqual({ filesChanged: 0, insertions: 0, deletions: 0 });
+	});
+
+	it("omits conversationTurns from the updated summary when generateSummary returns it undefined", async () => {
+		vi.mocked(Summarizer.generateSummary).mockResolvedValueOnce({
+			...successResult,
+			conversationTurns: undefined,
+		});
+
+		const { updated } = await regenerateSummary(baseSummary, "/repo", config);
+
+		expect("conversationTurns" in updated).toBe(false);
+	});
+
+	it("does not crash when linearIssues / notes refs lack their timestamp fields (legacy v3)", async () => {
+		// Defensive `?? ""` against legacy data with no referencedAt /
+		// updatedAt. Two refs each so the Array.sort comparator actually
+		// runs (a single-element array short-circuits the comparator).
+		const legacyTimestamps: CommitSummary = {
+			...baseSummary,
+			linearIssues: [
+				{
+					archivedKey: "L-1",
+					ticketId: "T1",
+					title: "t1",
+					url: "u1",
+					referencedAt: undefined,
+					sourceToolName: "x",
+				} as never,
+				{
+					archivedKey: "L-2",
+					ticketId: "T2",
+					title: "t2",
+					url: "u2",
+					referencedAt: undefined,
+					sourceToolName: "x",
+				} as never,
+			],
+			notes: [
+				{ id: "n-1", title: "n1", format: "snippet", updatedAt: undefined } as never,
+				{ id: "n-2", title: "n2", format: "snippet", updatedAt: undefined } as never,
+			],
+		} as CommitSummary;
+		vi.mocked(SummaryStore.readLinearIssueFromBranch).mockResolvedValue("LB");
+		vi.mocked(SummaryStore.readNoteFromBranch).mockResolvedValue("NB");
+
+		await expect(regenerateSummary(legacyTimestamps, "/repo", config)).resolves.toBeDefined();
+		const params = vi.mocked(Summarizer.generateSummary).mock.calls[0][0];
+		expect(params.linearIssues).toContain("LB");
+		expect(params.notes).toContain("NB");
+	});
+
+	it("uses empty string for ref.url when LinearIssueCommitRef.url is missing", async () => {
+		// Legacy/corrupt LinearIssueCommitRef may lack the url field — the
+		// `ref.url ?? ""` fallback ensures escapeForText doesn't choke on
+		// undefined. Output renders `<url></url>` (empty inner text).
+		const noUrl: CommitSummary = {
+			...baseSummary,
+			linearIssues: [
+				{
+					archivedKey: "JOLLI-9-abc",
+					ticketId: "JOLLI-9",
+					title: "T",
+					url: undefined,
+					referencedAt: "2026-05-21T00:00:00Z",
+					sourceToolName: "mcp__linear__get_issue",
+				} as never,
+			],
+		} as CommitSummary;
+		vi.mocked(SummaryStore.readLinearIssueFromBranch).mockResolvedValueOnce("body");
+
+		await regenerateSummary(noUrl, "/repo", config);
+
+		const params = vi.mocked(Summarizer.generateSummary).mock.calls[0][0];
+		expect(params.linearIssues).toContain("<url></url>");
+	});
+
+	it("caps the total <plans> block at PLAN_TOTAL_CHARS (60000) and drops the oldest plan when exceeded", async () => {
+		// 4 plans, each at PLAN_MAX_CHARS — fits 3 within 60000 budget,
+		// drops the 4th (oldest). Confirms greedy-newest-first selection.
+		const mkPlan = (slug: string, updatedAt: string) =>
+			({
+				slug,
+				title: slug,
+				editCount: 1,
+				addedAt: updatedAt,
+				updatedAt,
+			}) as never;
+		const withManyPlans: CommitSummary = {
+			...baseSummary,
+			plans: [
+				mkPlan("oldest", "2026-05-18T00:00:00Z"),
+				mkPlan("middle", "2026-05-19T00:00:00Z"),
+				mkPlan("newer", "2026-05-20T00:00:00Z"),
+				mkPlan("newest", "2026-05-21T00:00:00Z"),
+			],
+		} as CommitSummary;
+		const big = "x".repeat(20000);
+		vi.mocked(SummaryStore.readPlanFromBranch).mockResolvedValue(big);
+
+		await regenerateSummary(withManyPlans, "/repo", config);
+
+		const params = vi.mocked(Summarizer.generateSummary).mock.calls[0][0];
+		expect(params.plans).toContain("newest");
+		expect(params.plans).toContain("newer");
+		// The 4th (oldest) plan is the one dropped under greedy newest-first.
+		expect(params.plans).not.toContain('slug="oldest"');
 	});
 
 	it("dedups same-slug plans across the v3 tree by picking the newer updatedAt", async () => {

--- a/cli/src/core/Regenerator.test.ts
+++ b/cli/src/core/Regenerator.test.ts
@@ -1,0 +1,246 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { CommitSummary, LlmConfig, StoredTranscript } from "../Types.js";
+import * as GitOps from "./GitOps.js";
+import { regenerateSummary } from "./Regenerator.js";
+import * as Summarizer from "./Summarizer.js";
+import * as SummaryStore from "./SummaryStore.js";
+import * as TranscriptReader from "./TranscriptReader.js";
+
+vi.mock("./Summarizer.js", () => ({ generateSummary: vi.fn() }));
+vi.mock("./SummaryStore.js", () => ({
+	readTranscript: vi.fn(),
+	readLinearIssueFromBranch: vi.fn(),
+	readPlanFromBranch: vi.fn(),
+	readNoteFromBranch: vi.fn(),
+}));
+vi.mock("./GitOps.js", () => ({ getDiffContent: vi.fn() }));
+vi.mock("./TranscriptReader.js", () => ({ buildMultiSessionContext: vi.fn() }));
+
+const config: LlmConfig = { apiKey: "k", model: "haiku" } as LlmConfig;
+
+const baseSummary: CommitSummary = {
+	version: 4,
+	commitHash: "abcdef1234567890",
+	commitMessage: "Refactor X",
+	commitAuthor: "tester",
+	commitDate: "2026-05-21T00:00:00Z",
+	branch: "main",
+	generatedAt: "2026-05-21T00:01:00Z",
+	diffStats: { filesChanged: 2, insertions: 10, deletions: 3 },
+	topics: [{ title: "old topic", trigger: "t", response: "r", decisions: "d" }],
+	recap: "old recap",
+	e2eTestGuide: [{ name: "old e2e" } as never],
+} as CommitSummary;
+
+const storedTranscript: StoredTranscript = {
+	sessions: [
+		{
+			sessionId: "s1",
+			source: "claude",
+			entries: [{ role: "human", content: "hi", timestamp: "2026-05-21T00:00:00Z" }],
+		},
+	],
+};
+
+const successResult = {
+	transcriptEntries: 1,
+	conversationTurns: 1,
+	llm: {
+		model: "haiku",
+		inputTokens: 1,
+		outputTokens: 1,
+		apiLatencyMs: 1,
+		stopReason: null,
+		source: "anthropic-config",
+	} as never,
+	stats: { filesChanged: 2, insertions: 10, deletions: 3 },
+	topics: [{ title: "new topic", trigger: "t2", response: "r2", decisions: "d2" }],
+	recap: "new recap",
+	ticketId: "JOLLI-9999",
+};
+
+describe("regenerateSummary", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		vi.mocked(SummaryStore.readTranscript).mockResolvedValue(storedTranscript);
+		vi.mocked(GitOps.getDiffContent).mockResolvedValue("DIFF");
+		vi.mocked(TranscriptReader.buildMultiSessionContext).mockReturnValue("CONV");
+		vi.mocked(SummaryStore.readLinearIssueFromBranch).mockResolvedValue(null);
+		vi.mocked(SummaryStore.readPlanFromBranch).mockResolvedValue(null);
+		vi.mocked(SummaryStore.readNoteFromBranch).mockResolvedValue(null);
+		vi.mocked(Summarizer.generateSummary).mockResolvedValue(successResult);
+	});
+
+	it("still runs generateSummary when no transcript is stored (empty conversation)", async () => {
+		vi.mocked(SummaryStore.readTranscript).mockResolvedValue(null);
+		await regenerateSummary(baseSummary, "/repo", config);
+		expect(TranscriptReader.buildMultiSessionContext).toHaveBeenCalledWith([]);
+		expect(Summarizer.generateSummary).toHaveBeenCalledWith(
+			expect.objectContaining({ transcriptEntries: 0, conversation: "CONV" }),
+		);
+	});
+
+	it("calls generateSummary with reconstructed inputs", async () => {
+		await regenerateSummary(baseSummary, "/repo", config);
+
+		expect(GitOps.getDiffContent).toHaveBeenCalledWith("abcdef1234567890~1", "abcdef1234567890", "/repo");
+		expect(TranscriptReader.buildMultiSessionContext).toHaveBeenCalledWith([
+			{
+				sessionId: "s1",
+				transcriptPath: "(stored)",
+				source: "claude",
+				entries: storedTranscript.sessions[0].entries,
+			},
+		]);
+		expect(Summarizer.generateSummary).toHaveBeenCalledWith(
+			expect.objectContaining({
+				conversation: "CONV",
+				diff: "DIFF",
+				commitInfo: {
+					hash: "abcdef1234567890",
+					message: "Refactor X",
+					author: "tester",
+					date: "2026-05-21T00:00:00Z",
+				},
+				diffStats: { filesChanged: 2, insertions: 10, deletions: 3 },
+				transcriptEntries: 1,
+				config,
+			}),
+		);
+	});
+
+	it("replaces topics + recap; preserves ticketId, e2eTestGuide, and other fields", async () => {
+		const baseWithTicket: CommitSummary = {
+			...baseSummary,
+			ticketId: "JOLLI-1111",
+		} as CommitSummary;
+
+		const { updated } = await regenerateSummary(baseWithTicket, "/repo", config);
+
+		expect(updated.topics?.[0]?.title).toBe("new topic");
+		expect(updated.recap).toBe("new recap");
+		// ticketId must come from the old summary even though the LLM produced "JOLLI-9999"
+		expect(updated.ticketId).toBe("JOLLI-1111");
+		// e2eTestGuide must be preserved verbatim
+		expect(updated.e2eTestGuide).toEqual(baseSummary.e2eTestGuide);
+		expect(updated.commitMessage).toBe("Refactor X");
+		expect(updated.commitHash).toBe("abcdef1234567890");
+		// generatedAt should be refreshed to a now-ish ISO timestamp
+		expect(updated.generatedAt).not.toBe(baseSummary.generatedAt);
+		expect(new Date(updated.generatedAt).toString()).not.toBe("Invalid Date");
+	});
+
+	it("reads attached plans / notes / linear-issues from the orphan branch as prompt blocks", async () => {
+		const withRefs: CommitSummary = {
+			...baseSummary,
+			plans: [{ slug: "p-1", title: "Plan 1" } as never, { slug: "p-2", title: "Plan 2" } as never],
+			notes: [{ id: "n-1", title: "Note 1", format: "markdown" } as never],
+			linearIssues: [
+				{ archivedKey: "JOLLI-1-abc", ticketId: "JOLLI-1", title: "T", url: "https://linear.app/x" } as never,
+			],
+		} as CommitSummary;
+		vi.mocked(SummaryStore.readPlanFromBranch)
+			.mockResolvedValueOnce("# Plan 1\n\nplan body 1")
+			.mockResolvedValueOnce("# Plan 2\n\nplan body 2");
+		vi.mocked(SummaryStore.readNoteFromBranch).mockResolvedValueOnce("note body");
+		vi.mocked(SummaryStore.readLinearIssueFromBranch).mockResolvedValueOnce(
+			'---\nticketId: "JOLLI-1"\n---\nissue body',
+		);
+
+		await regenerateSummary(withRefs, "/repo", config);
+
+		expect(SummaryStore.readPlanFromBranch).toHaveBeenCalledWith("p-1", "/repo");
+		expect(SummaryStore.readPlanFromBranch).toHaveBeenCalledWith("p-2", "/repo");
+		expect(SummaryStore.readNoteFromBranch).toHaveBeenCalledWith("n-1", "/repo");
+		expect(SummaryStore.readLinearIssueFromBranch).toHaveBeenCalledWith("JOLLI-1-abc", "/repo");
+
+		const params = vi.mocked(Summarizer.generateSummary).mock.calls[0][0];
+		expect(params.plans).toContain("plan body 1");
+		expect(params.plans).toContain("plan body 2");
+		expect(params.notes).toContain("note body");
+		expect(params.linearIssues).toContain("issue body");
+	});
+
+	it("emits empty prompt blocks when no plans / notes / linear-issues are attached", async () => {
+		await regenerateSummary(baseSummary, "/repo", config);
+		const params = vi.mocked(Summarizer.generateSummary).mock.calls[0][0];
+		expect(params.plans).toBe("");
+		expect(params.notes).toBe("");
+		expect(params.linearIssues).toBe("");
+		expect(SummaryStore.readPlanFromBranch).not.toHaveBeenCalled();
+		expect(SummaryStore.readNoteFromBranch).not.toHaveBeenCalled();
+		expect(SummaryStore.readLinearIssueFromBranch).not.toHaveBeenCalled();
+	});
+
+	it("skips refs whose archive content is missing from the orphan branch", async () => {
+		const withRefs: CommitSummary = {
+			...baseSummary,
+			plans: [{ slug: "p-missing" } as never],
+		} as CommitSummary;
+		vi.mocked(SummaryStore.readPlanFromBranch).mockResolvedValueOnce(null);
+		await regenerateSummary(withRefs, "/repo", config);
+		const params = vi.mocked(Summarizer.generateSummary).mock.calls[0][0];
+		expect(params.plans).toBe("");
+	});
+
+	it("skips missing-archive notes the same way as missing-archive plans", async () => {
+		const withRefs: CommitSummary = {
+			...baseSummary,
+			notes: [{ id: "n-missing" } as never],
+		} as CommitSummary;
+		vi.mocked(SummaryStore.readNoteFromBranch).mockResolvedValueOnce(null);
+		await regenerateSummary(withRefs, "/repo", config);
+		const params = vi.mocked(Summarizer.generateSummary).mock.calls[0][0];
+		expect(params.notes).toBe("");
+	});
+
+	it("skips missing-archive linear issues the same way as missing-archive plans", async () => {
+		const withRefs: CommitSummary = {
+			...baseSummary,
+			linearIssues: [
+				{
+					archivedKey: "PROJ-1-deadbeef",
+					ticketId: "PROJ-1",
+					title: "T",
+					url: "https://linear.app/x",
+				} as never,
+			],
+		} as CommitSummary;
+		vi.mocked(SummaryStore.readLinearIssueFromBranch).mockResolvedValueOnce(null);
+		await regenerateSummary(withRefs, "/repo", config);
+		const params = vi.mocked(Summarizer.generateSummary).mock.calls[0][0];
+		expect(params.linearIssues).toBe("");
+	});
+
+	it("preserves conversationTurns when generateSummary omits it from the result", async () => {
+		vi.mocked(Summarizer.generateSummary).mockResolvedValueOnce({
+			...successResult,
+			conversationTurns: undefined,
+		});
+		const { updated } = await regenerateSummary(baseSummary, "/repo", config);
+		// generateSummary did not return conversationTurns; updated should not
+		// shadow the value with undefined (preserve baseSummary's behavior).
+		expect("conversationTurns" in updated).toBe(false);
+	});
+
+	it("preserves recap when generateSummary omits it from the result", async () => {
+		vi.mocked(Summarizer.generateSummary).mockResolvedValueOnce({
+			...successResult,
+			recap: undefined,
+		});
+		const { updated } = await regenerateSummary(baseSummary, "/repo", config);
+		// generateSummary did not return recap — old summary's recap stays.
+		expect(updated.recap).toBe("old recap");
+	});
+
+	it("falls back to summary.stats when summary.diffStats is absent (v3 legacy)", async () => {
+		const legacy: CommitSummary = {
+			...baseSummary,
+			diffStats: undefined,
+			stats: { filesChanged: 7, insertions: 70, deletions: 7 },
+		} as CommitSummary;
+		await regenerateSummary(legacy, "/repo", config);
+		const params = vi.mocked(Summarizer.generateSummary).mock.calls[0][0];
+		expect(params.diffStats).toEqual({ filesChanged: 7, insertions: 70, deletions: 7 });
+	});
+});

--- a/cli/src/core/Regenerator.ts
+++ b/cli/src/core/Regenerator.ts
@@ -1,7 +1,10 @@
 import { createLogger } from "../Logger.js";
-import type { CommitSummary, LlmConfig, SummaryResult } from "../Types.js";
+import type { CommitSummary, LlmConfig } from "../Types.js";
 import { getDiffContent } from "./GitOps.js";
-import { generateSummary } from "./Summarizer.js";
+import { truncate } from "./LinearIssueExtractor.js";
+import { escapeForAttr, escapeForText } from "./PromptXmlEscape.js";
+import type { StorageProvider } from "./StorageProvider.js";
+import { generateSummary, type SummaryResult } from "./Summarizer.js";
 import {
 	normalizeToV4,
 	readLinearIssueFromBranch,
@@ -68,6 +71,7 @@ export async function regenerateSummary(
 	summary: CommitSummary,
 	cwd: string,
 	config: LlmConfig,
+	storage?: StorageProvider,
 ): Promise<RegenerateResult> {
 	log.info("Regenerating summary for %s", summary.commitHash.substring(0, 8));
 
@@ -76,9 +80,12 @@ export async function regenerateSummary(
 	const normalized = normalizeToV4(summary);
 
 	// Aggregate transcripts across the entire tree (see "Transcript aggregation"
-	// in the doc comment above).
+	// in the doc comment above). `storage` is threaded so folder-only Memory
+	// Bank users read from FolderStorage instead of the OrphanBranchStorage
+	// fallback in resolveStorage — without it the LLM would see an empty
+	// conversation on every regenerate in folder-only mode.
 	const treeHashes = collectAllTranscriptHashes(normalized);
-	const transcriptMap = await readTranscriptsForCommits(treeHashes, cwd);
+	const transcriptMap = await readTranscriptsForCommits(treeHashes, cwd, storage);
 	const sessions: SessionTranscript[] = [];
 	for (const stored of transcriptMap.values()) {
 		for (const s of stored.sessions) {
@@ -94,9 +101,9 @@ export async function regenerateSummary(
 	const diff = await getDiffContent(`${normalized.commitHash}~1`, normalized.commitHash, cwd);
 
 	const [linearIssues, plans, notes] = await Promise.all([
-		rebuildLinearBlock(normalized, cwd),
-		rebuildPlansBlock(normalized, cwd),
-		rebuildNotesBlock(normalized, cwd),
+		rebuildLinearBlock(normalized, cwd, storage),
+		rebuildPlansBlock(normalized, cwd, storage),
+		rebuildNotesBlock(normalized, cwd, storage),
 	]);
 
 	const totalEntries = sessions.reduce((sum, s) => sum + s.entries.length, 0);
@@ -155,67 +162,111 @@ export async function regenerateSummary(
 // All three helpers receive a NORMALIZED summary, so root.{plans,notes,
 // linearIssues} are already the authoritative tree-wide union.
 
-async function rebuildLinearBlock(summary: CommitSummary, cwd: string): Promise<string> {
+// Budgets — must stay aligned with the first-run formatters byte-for-byte.
+// See PlanPromptFormatter.ts:18-19, NotePromptFormatter.ts:18-19, and
+// LinearIssueExtractor.ts:57-58 for the source-of-truth defaults. Without
+// these caps a single pathologically large plan / note / linear issue could
+// blow out the SUMMARIZE prompt's token budget and inflate cost. Drifting
+// from first-run also makes summary-quality A/B comparison apples-to-oranges
+// because the LLM sees different input shapes on the two paths.
+const PLAN_MAX_CHARS = 20000;
+const PLAN_TOTAL_CHARS = 60000;
+const NOTE_MAX_CHARS = 4000;
+const NOTE_TOTAL_CHARS = 12000;
+const LINEAR_MAX_CHARS = 4000;
+const LINEAR_TOTAL_CHARS = 30000;
+
+async function rebuildLinearBlock(
+	summary: CommitSummary,
+	cwd: string,
+	storage: StorageProvider | undefined,
+): Promise<string> {
 	const refs = summary.linearIssues ?? [];
 	if (refs.length === 0) return "";
+	// Newest reference first; selection is greedy until LINEAR_TOTAL_CHARS,
+	// dropped refs silently omitted (user already saw the count in the
+	// confirm dialog; skipping the oldest is the safer of two over-budget
+	// outcomes vs. arbitrary mid-truncation).
+	// Defensive `?? ""` against legacy fixtures or v3 data missing the
+	// timestamp — the sort doesn't promise stable ordering for those, but
+	// it must not crash.
+	const sorted = [...refs].sort((a, b) => (b.referencedAt ?? "").localeCompare(a.referencedAt ?? ""));
+
 	const rendered: string[] = [];
-	for (const ref of refs) {
-		const md = await readLinearIssueFromBranch(ref.archivedKey, cwd);
+	let totalLen = 0;
+	for (const ref of sorted) {
+		const md = await readLinearIssueFromBranch(ref.archivedKey, cwd, storage);
 		if (md === null) continue;
-		rendered.push(
-			[
-				`<issue id="${escapeAttr(ref.ticketId)}">`,
-				`  <title>${escapeText(ref.title)}</title>`,
-				`  <url>${escapeText(ref.url)}</url>`,
-				"  <archived-markdown>",
-				escapeText(md),
-				"  </archived-markdown>",
-				"</issue>",
-			].join("\n"),
-		);
+		const body = truncate(md, LINEAR_MAX_CHARS);
+		const block = [
+			`<issue id="${escapeForAttr(ref.ticketId)}">`,
+			`  <title>${escapeForText(ref.title)}</title>`,
+			`  <url>${escapeForText(ref.url ?? "")}</url>`,
+			"  <archived-markdown>",
+			escapeForText(body),
+			"  </archived-markdown>",
+			"</issue>",
+		].join("\n");
+		if (totalLen + block.length > LINEAR_TOTAL_CHARS) break;
+		rendered.push(block);
+		totalLen += block.length;
 	}
 	if (rendered.length === 0) return "";
 	return `<linear-issues>\n${rendered.join("\n")}\n</linear-issues>`;
 }
 
-async function rebuildPlansBlock(summary: CommitSummary, cwd: string): Promise<string> {
+async function rebuildPlansBlock(
+	summary: CommitSummary,
+	cwd: string,
+	storage: StorageProvider | undefined,
+): Promise<string> {
 	const refs = summary.plans ?? [];
 	if (refs.length === 0) return "";
+	const sorted = [...refs].sort((a, b) => (b.updatedAt ?? "").localeCompare(a.updatedAt ?? ""));
+
 	const rendered: string[] = [];
-	for (const ref of refs) {
-		const md = await readPlanFromBranch(ref.slug, cwd);
+	let totalLen = 0;
+	for (const ref of sorted) {
+		const md = await readPlanFromBranch(ref.slug, cwd, storage);
 		if (md === null) continue;
-		rendered.push(
-			[`<plan slug="${escapeAttr(ref.slug)}" title="${escapeAttr(ref.title)}">`, escapeText(md), "</plan>"].join(
-				"\n",
-			),
-		);
+		const body = truncate(md, PLAN_MAX_CHARS);
+		const block = [
+			`<plan slug="${escapeForAttr(ref.slug)}" title="${escapeForAttr(ref.title)}">`,
+			escapeForText(body),
+			"</plan>",
+		].join("\n");
+		if (totalLen + block.length > PLAN_TOTAL_CHARS) break;
+		rendered.push(block);
+		totalLen += block.length;
 	}
 	if (rendered.length === 0) return "";
 	return `<plans>\n${rendered.join("\n")}\n</plans>`;
 }
 
-async function rebuildNotesBlock(summary: CommitSummary, cwd: string): Promise<string> {
+async function rebuildNotesBlock(
+	summary: CommitSummary,
+	cwd: string,
+	storage: StorageProvider | undefined,
+): Promise<string> {
 	const refs = summary.notes ?? [];
 	if (refs.length === 0) return "";
+	const sorted = [...refs].sort((a, b) => (b.updatedAt ?? "").localeCompare(a.updatedAt ?? ""));
+
 	const rendered: string[] = [];
-	for (const ref of refs) {
-		const md = await readNoteFromBranch(ref.id, cwd);
+	let totalLen = 0;
+	for (const ref of sorted) {
+		const md = await readNoteFromBranch(ref.id, cwd, storage);
 		if (md === null) continue;
-		rendered.push(
-			[`<note id="${escapeAttr(ref.id)}" title="${escapeAttr(ref.title)}">`, escapeText(md), "</note>"].join(
-				"\n",
-			),
-		);
+		const body = truncate(md, NOTE_MAX_CHARS);
+		const block = [
+			`<note id="${escapeForAttr(ref.id)}" title="${escapeForAttr(ref.title)}">`,
+			escapeForText(body),
+			"</note>",
+		].join("\n");
+		if (totalLen + block.length > NOTE_TOTAL_CHARS) break;
+		rendered.push(block);
+		totalLen += block.length;
 	}
 	if (rendered.length === 0) return "";
 	return `<notes>\n${rendered.join("\n")}\n</notes>`;
-}
-
-function escapeAttr(s: string): string {
-	return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/"/g, "&quot;");
-}
-
-function escapeText(s: string): string {
-	return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
 }

--- a/cli/src/core/Regenerator.ts
+++ b/cli/src/core/Regenerator.ts
@@ -2,7 +2,14 @@ import { createLogger } from "../Logger.js";
 import type { CommitSummary, LlmConfig, SummaryResult } from "../Types.js";
 import { getDiffContent } from "./GitOps.js";
 import { generateSummary } from "./Summarizer.js";
-import { readLinearIssueFromBranch, readNoteFromBranch, readPlanFromBranch, readTranscript } from "./SummaryStore.js";
+import {
+	normalizeToV4,
+	readLinearIssueFromBranch,
+	readNoteFromBranch,
+	readPlanFromBranch,
+	readTranscriptsForCommits,
+} from "./SummaryStore.js";
+import { collectAllTranscriptHashes } from "./SummaryTree.js";
 import { buildMultiSessionContext, type SessionTranscript } from "./TranscriptReader.js";
 
 const log = createLogger("Regenerator");
@@ -25,14 +32,37 @@ export interface RegenerateResult {
  * Fields replaced:        topics, recap, diffStats, transcriptEntries,
  *                         conversationTurns, llm, generatedAt
  * Fields preserved:       ticketId, e2eTestGuide, plans, notes, linearIssues,
- *                         children, commitType, commitSource, jolliDocUrl,
- *                         jolliDocId, orphanedDocIds, everything else.
+ *                         commitType, commitSource, jolliDocUrl, jolliDocId,
+ *                         orphanedDocIds, everything else on root.
+ *
+ * The function opens by calling `normalizeToV4(summary)` — a pure helper
+ * that collapses every v3-special-case into the v4 unified-Hoist invariant
+ * the rest of the regenerate path depends on:
+ *   - root holds the authoritative Copy-Hoist fields (unioned across the
+ *     whole tree, so child-only attachments and pending-cleanup doc IDs are
+ *     surfaced to root)
+ *   - every descendant is stripped of own-hoist fields
+ *   - version is 4
+ *
+ * Downstream code (transcript aggregation, prompt-block rebuild, LLM
+ * generation, updated-summary assembly) then assumes v4 without further
+ * special-casing.
+ *
+ * Transcript aggregation:
+ *   - Reads transcripts for EVERY commit hash in the (normalized) summary
+ *     tree via `collectAllTranscriptHashes` + `readTranscriptsForCommits`.
+ *     Squash / amend / rebase summaries persist AI conversations under each
+ *     source commit's hash; reading only `summary.commitHash` would feed an
+ *     empty conversation to the LLM. Mirrors the webview's All Conversations
+ *     card (`SummaryWebviewPanel.refreshTranscriptHashes`).
  *
  * Preservation of ticketId and e2eTestGuide is deliberate (see plan §1.2):
- *   - ticketId is a stable identifier; the LLM may not see the original ticket
- *     ID in this re-run and would otherwise drop or change it.
+ *   - ticketId is a stable identifier; the LLM may not see the original
+ *     ticket ID in this re-run and would otherwise drop or change it.
  *   - e2eTestGuide is a user-initiated secondary artifact; the user can
- *     regenerate it independently if they want.
+ *     regenerate it independently. Note that `normalizeToV4` may surface a
+ *     child-only e2e to root — that's the deferred-migration completing,
+ *     not a behavior change.
  */
 export async function regenerateSummary(
 	summary: CommitSummary,
@@ -41,21 +71,32 @@ export async function regenerateSummary(
 ): Promise<RegenerateResult> {
 	log.info("Regenerating summary for %s", summary.commitHash.substring(0, 8));
 
-	const stored = await readTranscript(summary.commitHash, cwd);
+	// One-shot v3 → v4 normalization; the rest of this function reads from
+	// `normalized` and assumes the v4 invariant. No-op for v4 input.
+	const normalized = normalizeToV4(summary);
 
-	const sessions: SessionTranscript[] = (stored?.sessions ?? []).map((s) => ({
-		sessionId: s.sessionId,
-		transcriptPath: s.transcriptPath ?? "(stored)",
-		...(s.source !== undefined ? { source: s.source } : {}),
-		entries: s.entries,
-	}));
+	// Aggregate transcripts across the entire tree (see "Transcript aggregation"
+	// in the doc comment above).
+	const treeHashes = collectAllTranscriptHashes(normalized);
+	const transcriptMap = await readTranscriptsForCommits(treeHashes, cwd);
+	const sessions: SessionTranscript[] = [];
+	for (const stored of transcriptMap.values()) {
+		for (const s of stored.sessions) {
+			sessions.push({
+				sessionId: s.sessionId,
+				transcriptPath: s.transcriptPath ?? "(stored)",
+				...(s.source !== undefined ? { source: s.source } : {}),
+				entries: s.entries,
+			});
+		}
+	}
 	const conversation = buildMultiSessionContext(sessions);
-	const diff = await getDiffContent(`${summary.commitHash}~1`, summary.commitHash, cwd);
+	const diff = await getDiffContent(`${normalized.commitHash}~1`, normalized.commitHash, cwd);
 
 	const [linearIssues, plans, notes] = await Promise.all([
-		rebuildLinearBlock(summary, cwd),
-		rebuildPlansBlock(summary, cwd),
-		rebuildNotesBlock(summary, cwd),
+		rebuildLinearBlock(normalized, cwd),
+		rebuildPlansBlock(normalized, cwd),
+		rebuildNotesBlock(normalized, cwd),
 	]);
 
 	const totalEntries = sessions.reduce((sum, s) => sum + s.entries.length, 0);
@@ -65,12 +106,17 @@ export async function regenerateSummary(
 		conversation,
 		diff,
 		commitInfo: {
-			hash: summary.commitHash,
-			message: summary.commitMessage,
-			author: summary.commitAuthor,
-			date: summary.commitDate,
+			hash: normalized.commitHash,
+			message: normalized.commitMessage,
+			author: normalized.commitAuthor,
+			date: normalized.commitDate,
 		},
-		diffStats: summary.diffStats ?? summary.stats ?? { filesChanged: 0, insertions: 0, deletions: 0 },
+		// Fallback chain: v4 stores `diffStats`; v3 legacy stored `stats`
+		// (resolveDiffStats elsewhere does the same fallback for display).
+		// normalizeToV4 doesn't touch either field, so a freshly-normalized
+		// v3 still has only `stats` populated until the LLM call below
+		// returns a fresh diffStats we overwrite with.
+		diffStats: normalized.diffStats ?? normalized.stats ?? { filesChanged: 0, insertions: 0, deletions: 0 },
 		transcriptEntries: totalEntries,
 		conversationTurns: humanTurns,
 		linearIssues,
@@ -80,9 +126,12 @@ export async function regenerateSummary(
 	});
 
 	const updated: CommitSummary = {
-		...summary,
+		...normalized,
 		topics: result.topics,
-		...(result.recap !== undefined ? { recap: result.recap } : {}),
+		// Always overwrite recap — confirm dialog promises Recap is OVERWRITTEN.
+		// Empty string communicates "no recap this time" when the LLM omits one,
+		// instead of silently preserving the prior recap.
+		recap: result.recap ?? "",
 		llm: result.llm,
 		transcriptEntries: result.transcriptEntries,
 		...(result.conversationTurns !== undefined ? { conversationTurns: result.conversationTurns } : {}),
@@ -102,6 +151,9 @@ export async function regenerateSummary(
 // — sourcePath may be stale or missing. The simplified block preserves the
 // tag shape (`<plans>`, `<notes>`, `<linear-issues>`) so the SUMMARIZE prompt
 // template's placeholders collapse the same way.
+//
+// All three helpers receive a NORMALIZED summary, so root.{plans,notes,
+// linearIssues} are already the authoritative tree-wide union.
 
 async function rebuildLinearBlock(summary: CommitSummary, cwd: string): Promise<string> {
 	const refs = summary.linearIssues ?? [];

--- a/cli/src/core/Regenerator.ts
+++ b/cli/src/core/Regenerator.ts
@@ -1,0 +1,169 @@
+import { createLogger } from "../Logger.js";
+import type { CommitSummary, LlmConfig, SummaryResult } from "../Types.js";
+import { getDiffContent } from "./GitOps.js";
+import { generateSummary } from "./Summarizer.js";
+import { readLinearIssueFromBranch, readNoteFromBranch, readPlanFromBranch, readTranscript } from "./SummaryStore.js";
+import { buildMultiSessionContext, type SessionTranscript } from "./TranscriptReader.js";
+
+const log = createLogger("Regenerator");
+
+export interface RegenerateResult {
+	readonly updated: CommitSummary;
+	readonly result: SummaryResult;
+}
+
+/**
+ * End-to-end re-run of the summary LLM for an already-summarized commit.
+ *
+ * Reads inputs straight from the orphan branch (transcripts, archived plans /
+ * notes / linear issues) and rebuilds the commit diff via `git show`. No
+ * disk-side registries are consulted, no archives are re-written, and no
+ * cursors / locks / queue entries are touched — see the plan's §1.6 isolation
+ * matrix. The single side effect this returns is the updated CommitSummary
+ * that callers pass to `storeSummary(_, _, true)` (force=true).
+ *
+ * Fields replaced:        topics, recap, diffStats, transcriptEntries,
+ *                         conversationTurns, llm, generatedAt
+ * Fields preserved:       ticketId, e2eTestGuide, plans, notes, linearIssues,
+ *                         children, commitType, commitSource, jolliDocUrl,
+ *                         jolliDocId, orphanedDocIds, everything else.
+ *
+ * Preservation of ticketId and e2eTestGuide is deliberate (see plan §1.2):
+ *   - ticketId is a stable identifier; the LLM may not see the original ticket
+ *     ID in this re-run and would otherwise drop or change it.
+ *   - e2eTestGuide is a user-initiated secondary artifact; the user can
+ *     regenerate it independently if they want.
+ */
+export async function regenerateSummary(
+	summary: CommitSummary,
+	cwd: string,
+	config: LlmConfig,
+): Promise<RegenerateResult> {
+	log.info("Regenerating summary for %s", summary.commitHash.substring(0, 8));
+
+	const stored = await readTranscript(summary.commitHash, cwd);
+
+	const sessions: SessionTranscript[] = (stored?.sessions ?? []).map((s) => ({
+		sessionId: s.sessionId,
+		transcriptPath: s.transcriptPath ?? "(stored)",
+		...(s.source !== undefined ? { source: s.source } : {}),
+		entries: s.entries,
+	}));
+	const conversation = buildMultiSessionContext(sessions);
+	const diff = await getDiffContent(`${summary.commitHash}~1`, summary.commitHash, cwd);
+
+	const [linearIssues, plans, notes] = await Promise.all([
+		rebuildLinearBlock(summary, cwd),
+		rebuildPlansBlock(summary, cwd),
+		rebuildNotesBlock(summary, cwd),
+	]);
+
+	const totalEntries = sessions.reduce((sum, s) => sum + s.entries.length, 0);
+	const humanTurns = sessions.reduce((sum, s) => sum + s.entries.filter((e) => e.role === "human").length, 0);
+
+	const result = await generateSummary({
+		conversation,
+		diff,
+		commitInfo: {
+			hash: summary.commitHash,
+			message: summary.commitMessage,
+			author: summary.commitAuthor,
+			date: summary.commitDate,
+		},
+		diffStats: summary.diffStats ?? summary.stats ?? { filesChanged: 0, insertions: 0, deletions: 0 },
+		transcriptEntries: totalEntries,
+		conversationTurns: humanTurns,
+		linearIssues,
+		plans,
+		notes,
+		config,
+	});
+
+	const updated: CommitSummary = {
+		...summary,
+		topics: result.topics,
+		...(result.recap !== undefined ? { recap: result.recap } : {}),
+		llm: result.llm,
+		transcriptEntries: result.transcriptEntries,
+		...(result.conversationTurns !== undefined ? { conversationTurns: result.conversationTurns } : {}),
+		diffStats: result.stats,
+		generatedAt: new Date().toISOString(),
+	};
+
+	return { updated, result };
+}
+
+// ─── Prompt-block reconstruction from orphan-branch archives ────────────────
+//
+// These helpers intentionally build a SIMPLIFIED XML block rather than reusing
+// `formatPlansBlock` / `formatNotesBlock` / `formatLinearIssuesBlock`. The
+// existing formatters read content via `entry.sourcePath` (disk file paths),
+// but on regenerate we want the orphan-branch archive as the system of record
+// — sourcePath may be stale or missing. The simplified block preserves the
+// tag shape (`<plans>`, `<notes>`, `<linear-issues>`) so the SUMMARIZE prompt
+// template's placeholders collapse the same way.
+
+async function rebuildLinearBlock(summary: CommitSummary, cwd: string): Promise<string> {
+	const refs = summary.linearIssues ?? [];
+	if (refs.length === 0) return "";
+	const rendered: string[] = [];
+	for (const ref of refs) {
+		const md = await readLinearIssueFromBranch(ref.archivedKey, cwd);
+		if (md === null) continue;
+		rendered.push(
+			[
+				`<issue id="${escapeAttr(ref.ticketId)}">`,
+				`  <title>${escapeText(ref.title)}</title>`,
+				`  <url>${escapeText(ref.url)}</url>`,
+				"  <archived-markdown>",
+				escapeText(md),
+				"  </archived-markdown>",
+				"</issue>",
+			].join("\n"),
+		);
+	}
+	if (rendered.length === 0) return "";
+	return `<linear-issues>\n${rendered.join("\n")}\n</linear-issues>`;
+}
+
+async function rebuildPlansBlock(summary: CommitSummary, cwd: string): Promise<string> {
+	const refs = summary.plans ?? [];
+	if (refs.length === 0) return "";
+	const rendered: string[] = [];
+	for (const ref of refs) {
+		const md = await readPlanFromBranch(ref.slug, cwd);
+		if (md === null) continue;
+		rendered.push(
+			[`<plan slug="${escapeAttr(ref.slug)}" title="${escapeAttr(ref.title)}">`, escapeText(md), "</plan>"].join(
+				"\n",
+			),
+		);
+	}
+	if (rendered.length === 0) return "";
+	return `<plans>\n${rendered.join("\n")}\n</plans>`;
+}
+
+async function rebuildNotesBlock(summary: CommitSummary, cwd: string): Promise<string> {
+	const refs = summary.notes ?? [];
+	if (refs.length === 0) return "";
+	const rendered: string[] = [];
+	for (const ref of refs) {
+		const md = await readNoteFromBranch(ref.id, cwd);
+		if (md === null) continue;
+		rendered.push(
+			[`<note id="${escapeAttr(ref.id)}" title="${escapeAttr(ref.title)}">`, escapeText(md), "</note>"].join(
+				"\n",
+			),
+		);
+	}
+	if (rendered.length === 0) return "";
+	return `<notes>\n${rendered.join("\n")}\n</notes>`;
+}
+
+function escapeAttr(s: string): string {
+	return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/"/g, "&quot;");
+}
+
+function escapeText(s: string): string {
+	return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}

--- a/cli/src/core/SummaryStore.test.ts
+++ b/cli/src/core/SummaryStore.test.ts
@@ -1947,6 +1947,44 @@ describe("SummaryStore", () => {
 			expect(result.has("hash3")).toBe(true);
 		});
 
+		it("threads an explicit StorageProvider to readTranscript instead of the orphan-branch fallback", async () => {
+			// Folder-only Memory Bank correctness: when the caller (e.g.
+			// JolliMemoryBridge.loadRegenerateContext) passes a storage
+			// argument, the read MUST go through that provider, not the
+			// resolveStorage fallback that always returns OrphanBranchStorage.
+			const fakeStorage = {
+				readFile: vi.fn().mockResolvedValue(
+					JSON.stringify({
+						sessions: [{ sessionId: "from-folder", entries: [] }],
+					}),
+				),
+			} as unknown as Parameters<typeof readTranscript>[2];
+
+			const result = await readTranscript("abc123", undefined, fakeStorage);
+
+			expect(fakeStorage?.readFile).toHaveBeenCalledWith("transcripts/abc123.json");
+			expect(result?.sessions[0]?.sessionId).toBe("from-folder");
+		});
+
+		it("threads StorageProvider through readTranscriptsForCommits to each read", async () => {
+			// The batch wrapper must forward storage to every underlying
+			// readTranscript so folder-only users get the same backend on
+			// every hash.
+			const fakeStorage = {
+				readFile: vi
+					.fn()
+					.mockResolvedValueOnce(JSON.stringify({ sessions: [{ sessionId: "a", entries: [] }] }))
+					.mockResolvedValueOnce(JSON.stringify({ sessions: [{ sessionId: "b", entries: [] }] })),
+			} as unknown as Parameters<typeof readTranscriptsForCommits>[2];
+
+			const result = await readTranscriptsForCommits(["h1", "h2"], undefined, fakeStorage);
+
+			expect(fakeStorage?.readFile).toHaveBeenCalledTimes(2);
+			expect(fakeStorage?.readFile).toHaveBeenNthCalledWith(1, "transcripts/h1.json");
+			expect(fakeStorage?.readFile).toHaveBeenNthCalledWith(2, "transcripts/h2.json");
+			expect(result.size).toBe(2);
+		});
+
 		it("should write and delete transcript files in a single batch", async () => {
 			await saveTranscriptsBatch(
 				[{ hash: "hash1", data: { sessions: [{ sessionId: "s1", entries: [] }] } }],

--- a/cli/src/core/SummaryStore.ts
+++ b/cli/src/core/SummaryStore.ts
@@ -349,7 +349,7 @@ async function migrateOneToOneLocked(
 }
 
 /** Recursively collects all E2E test scenarios from a list of summaries. */
-function collectChildE2eScenarios(nodes: ReadonlyArray<CommitSummary>): ReadonlyArray<E2eTestScenario> {
+export function collectChildE2eScenarios(nodes: ReadonlyArray<CommitSummary>): ReadonlyArray<E2eTestScenario> {
 	const scenarios: E2eTestScenario[] = [];
 	for (const node of nodes) {
 		if (node.e2eTestGuide) scenarios.push(...node.e2eTestGuide);
@@ -366,7 +366,7 @@ function stripE2eTestGuide(node: CommitSummary): CommitSummary {
 }
 
 /** Recursively collects all PlanReferences from a list of summaries, deduped by slug. */
-function collectChildPlans(nodes: ReadonlyArray<CommitSummary>): ReadonlyArray<PlanReference> {
+export function collectChildPlans(nodes: ReadonlyArray<CommitSummary>): ReadonlyArray<PlanReference> {
 	const planMap = new Map<string, PlanReference>();
 	for (const node of nodes) {
 		if (node.plans) {
@@ -398,7 +398,7 @@ function stripPlans(node: CommitSummary): CommitSummary {
 }
 
 /** Recursively collects all NoteReferences from a list of summaries, deduped by id. */
-function collectChildNotes(nodes: ReadonlyArray<CommitSummary>): ReadonlyArray<NoteReference> {
+export function collectChildNotes(nodes: ReadonlyArray<CommitSummary>): ReadonlyArray<NoteReference> {
 	const noteMap = new Map<string, NoteReference>();
 	for (const node of nodes) {
 		if (node.notes) {
@@ -441,7 +441,7 @@ function stripLinearIssues(node: CommitSummary): CommitSummary {
  * on squash / rebase-pick the root must inherit referenced Linear issues from
  * every source commit, otherwise stripLinearIssues (called below) drops them.
  */
-function collectChildLinearIssues(nodes: ReadonlyArray<CommitSummary>): ReadonlyArray<LinearIssueCommitRef> {
+export function collectChildLinearIssues(nodes: ReadonlyArray<CommitSummary>): ReadonlyArray<LinearIssueCommitRef> {
 	const refMap = new Map<string, LinearIssueCommitRef>();
 	for (const node of nodes) {
 		if (node.linearIssues) {
@@ -475,7 +475,7 @@ function stripJolliMetadata(node: CommitSummary): CommitSummary {
 }
 
 /** Hoist result for Jolli memory article metadata from children. */
-interface JolliMetaHoistResult {
+export interface JolliMetaHoistResult {
 	/**
 	 * The most recent descendant's Jolli metadata (to hoist to merged root), or null if no
 	 * candidates were found. Carries the winner's own commitDate/generatedAt so that when a
@@ -493,7 +493,7 @@ interface JolliMetaHoistResult {
 }
 
 /** Recursively collects jolliDocId/jolliDocUrl from children, picks newest as winner. */
-function collectChildJolliMeta(nodes: ReadonlyArray<CommitSummary>): JolliMetaHoistResult {
+export function collectChildJolliMeta(nodes: ReadonlyArray<CommitSummary>): JolliMetaHoistResult {
 	const candidates: Array<{ jolliDocId: number; jolliDocUrl: string; commitDate: string; generatedAt: string }> = [];
 	for (const node of nodes) {
 		const url = node.jolliDocUrl;
@@ -522,6 +522,81 @@ function collectChildJolliMeta(nodes: ReadonlyArray<CommitSummary>): JolliMetaHo
 	const winner = candidates[0];
 	const orphanedDocIds = candidates.slice(1).map((c) => c.jolliDocId);
 	return { winner, orphanedDocIds };
+}
+
+/**
+ * Recursively walks descendants and collects every node's orphanedDocIds.
+ * Companion to collectChildJolliMeta: that helper only surfaces orphans
+ * created by the current merge, but legacy children may already carry their
+ * own pending-cleanup queue. Used by normalizeToV4 so a v3 → v4 migration
+ * doesn't lose previously-orphaned doc IDs at the strip step.
+ */
+function collectDescendantOrphanedDocIds(children: ReadonlyArray<CommitSummary> | undefined): number[] {
+	const ids: number[] = [];
+	for (const child of children ?? []) {
+		if (child.orphanedDocIds) ids.push(...child.orphanedDocIds);
+		ids.push(...collectDescendantOrphanedDocIds(child.children));
+	}
+	return ids;
+}
+
+/**
+ * Pure in-memory v3 → v4 (unified Hoist) normalization. No I/O — caller
+ * persists the result via storeSummary if it wants the migration to stick.
+ *
+ * Establishes the same invariant first-run amend / squash already enforce via
+ * `buildHoistedAmendRoot` / `mergeManyToOne`:
+ *   - version: 4
+ *   - root holds the authoritative Copy-Hoist fields (plans / notes /
+ *     linearIssues / e2eTestGuide / jolliDocId / jolliDocUrl /
+ *     orphanedDocIds), unioned across the whole tree via the same
+ *     `collectChild*` helpers
+ *   - every descendant is stripped of own-hoist fields
+ *
+ * Deliberately leaves `topics`, `recap`, `ticketId` on the root untouched.
+ * Regenerate (the primary caller) overwrites topics + recap from a fresh
+ * LLM call afterwards; ticketId is preserved per the same rule that lives
+ * in Regenerator.ts. A no-op for v4 input (returns the same reference).
+ *
+ * Used by Regenerator and RegenerateContext to collapse all v3-special-
+ * casing in their hot paths — once normalized, downstream code can assume
+ * a clean v4 tree.
+ */
+export function normalizeToV4(summary: CommitSummary): CommitSummary {
+	if (summary.version >= 4) return summary;
+
+	const hoistedE2e = collectChildE2eScenarios([summary]);
+	const hoistedPlans = collectChildPlans([summary]);
+	const hoistedNotes = collectChildNotes([summary]);
+	const hoistedLinear = collectChildLinearIssues([summary]);
+	const jolliMeta = collectChildJolliMeta([summary]);
+	// Dedup orphanedDocIds across the tree: jolliMeta surfaces orphans from
+	// this normalize step's loser candidates; root + descendants may already
+	// have their own pending cleanup queue.
+	const allOrphanedDocIds = Array.from(
+		new Set<number>([
+			...jolliMeta.orphanedDocIds,
+			...(summary.orphanedDocIds ?? []),
+			...collectDescendantOrphanedDocIds(summary.children),
+		]),
+	);
+
+	return {
+		...summary,
+		version: 4,
+		...(hoistedE2e.length > 0 ? { e2eTestGuide: hoistedE2e } : {}),
+		...(hoistedPlans.length > 0 ? { plans: hoistedPlans } : {}),
+		...(hoistedNotes.length > 0 ? { notes: hoistedNotes } : {}),
+		...(hoistedLinear.length > 0 ? { linearIssues: hoistedLinear } : {}),
+		...(jolliMeta.winner
+			? {
+					jolliDocId: jolliMeta.winner.jolliDocId,
+					jolliDocUrl: jolliMeta.winner.jolliDocUrl,
+				}
+			: {}),
+		...(allOrphanedDocIds.length > 0 ? { orphanedDocIds: allOrphanedDocIds } : {}),
+		...(summary.children !== undefined ? { children: summary.children.map(stripFunctionalMetadata) } : {}),
+	};
 }
 
 /** Returns a deep copy of the summary tree with topics stripped from all nodes. */

--- a/cli/src/core/SummaryStore.ts
+++ b/cli/src/core/SummaryStore.ts
@@ -931,8 +931,12 @@ export async function removeFromIndex(commitHash: string, cwd?: string): Promise
  * Reads a transcript for a specific commit from the orphan branch.
  * Returns null if no transcript file exists for the given commit hash.
  */
-export async function readTranscript(commitHash: string, cwd?: string): Promise<StoredTranscript | null> {
-	const store = resolveStorage(undefined, cwd);
+export async function readTranscript(
+	commitHash: string,
+	cwd?: string,
+	storage?: StorageProvider,
+): Promise<StoredTranscript | null> {
+	const store = resolveStorage(storage, cwd);
 	const raw = await store.readFile(`transcripts/${commitHash}.json`);
 	if (!raw) return null;
 	try {
@@ -950,10 +954,11 @@ export async function readTranscript(commitHash: string, cwd?: string): Promise<
 export async function readTranscriptsForCommits(
 	commitHashes: ReadonlyArray<string>,
 	cwd?: string,
+	storage?: StorageProvider,
 ): Promise<Map<string, StoredTranscript>> {
 	const result = new Map<string, StoredTranscript>();
 	for (const hash of commitHashes) {
-		const transcript = await readTranscript(hash, cwd);
+		const transcript = await readTranscript(hash, cwd, storage);
 		if (transcript) {
 			result.set(hash, transcript);
 		}

--- a/cli/src/core/TranscriptSourceLabel.test.ts
+++ b/cli/src/core/TranscriptSourceLabel.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { transcriptSourceLabel } from "./TranscriptSourceLabel.js";
+
+describe("transcriptSourceLabel", () => {
+	it("returns the friendly label for each known source (matches the current webview behavior)", () => {
+		expect(transcriptSourceLabel("claude")).toBe("Claude");
+		expect(transcriptSourceLabel("codex")).toBe("Codex");
+		expect(transcriptSourceLabel("cursor")).toBe("Cursor");
+		// Note: 'Copilot' not 'Copilot CLI' — matches the pre-existing
+		// TranscriptEntryRenderer.ts getSourceLabel behavior.
+		expect(transcriptSourceLabel("copilot")).toBe("Copilot");
+		expect(transcriptSourceLabel("copilot-chat")).toBe("Copilot Chat");
+		expect(transcriptSourceLabel("gemini")).toBe("Gemini");
+		expect(transcriptSourceLabel("opencode")).toBe("OpenCode");
+	});
+
+	it("falls back to 'Claude' for unknown sources (matches the current webview behavior)", () => {
+		expect(transcriptSourceLabel("unknown" as never)).toBe("Claude");
+	});
+
+	it("falls back to 'Claude' when source is undefined (matches the current webview behavior)", () => {
+		expect(transcriptSourceLabel(undefined)).toBe("Claude");
+	});
+});

--- a/cli/src/core/TranscriptSourceLabel.ts
+++ b/cli/src/core/TranscriptSourceLabel.ts
@@ -1,0 +1,29 @@
+import type { TranscriptSource } from "../Types.js";
+
+/**
+ * Single source of truth for transcript source → friendly label.
+ *
+ * Consumers:
+ *   - Extension host (confirm-dialog detail strings) — import this map / helper directly.
+ *   - Webview JS — `TranscriptEntryRenderer.buildTranscriptEntriesScript()` emits an
+ *     equivalent `getSourceLabel()` function string from this map, so the in-iframe
+ *     behavior stays byte-equivalent.
+ *
+ * Default fallback is "Claude": pre-existing webview behavior treated unknown /
+ * undefined sources as Claude (Claude was the first integration). Keeping the
+ * fallback aligned avoids a silent UI change in conversation-stats rendering.
+ */
+export const TRANSCRIPT_SOURCE_LABELS: Readonly<Record<TranscriptSource, string>> = {
+	claude: "Claude",
+	codex: "Codex",
+	cursor: "Cursor",
+	copilot: "Copilot",
+	"copilot-chat": "Copilot Chat",
+	gemini: "Gemini",
+	opencode: "OpenCode",
+};
+
+export function transcriptSourceLabel(source: TranscriptSource | undefined): string {
+	if (source === undefined) return "Claude";
+	return TRANSCRIPT_SOURCE_LABELS[source] ?? "Claude";
+}

--- a/cli/src/core/normalizeToV4.test.ts
+++ b/cli/src/core/normalizeToV4.test.ts
@@ -1,0 +1,248 @@
+import { describe, expect, it } from "vitest";
+import type { CommitSummary } from "../Types.js";
+import { normalizeToV4 } from "./SummaryStore.js";
+
+const baseNode = {
+	commitHash: "abc1234567890",
+	commitMessage: "x",
+	commitAuthor: "tester",
+	commitDate: "2026-05-21T00:00:00Z",
+	branch: "main",
+	generatedAt: "2026-05-21T00:01:00Z",
+} as const;
+
+describe("normalizeToV4", () => {
+	it("returns the same reference for v4 input (no-op fast path)", () => {
+		const v4: CommitSummary = { ...baseNode, version: 4 } as CommitSummary;
+		expect(normalizeToV4(v4)).toBe(v4);
+	});
+
+	it("treats any version >= 4 as no-op (future-proofs the fast path against v5)", () => {
+		// The implementation gate is `version >= 4`, not `=== 4`. A future v5
+		// would still be a unified-Hoist superset; pre-normalize would be
+		// wrong because v5 might add semantics this helper doesn't know
+		// about. Pin the >= behavior so a future refactor doesn't tighten
+		// to === and silently double-normalize newer summaries.
+		const v5: CommitSummary = { ...baseNode, version: 5 } as CommitSummary;
+		expect(normalizeToV4(v5)).toBe(v5);
+		expect(normalizeToV4(v5).version).toBe(5);
+	});
+
+	it("returns a NEW object reference (not the input) when normalize actually ran on v3", () => {
+		// Counterpart to the v4 fast-path identity assertion above. Without
+		// this, a future refactor that accidentally mutated the input in
+		// place would still pass all the other tests (they assert outcomes,
+		// not non-mutation). Important because callers may hold the v3
+		// reference and expect it unchanged until they explicitly persist.
+		const v3Leaf: CommitSummary = { ...baseNode, version: 3 } as CommitSummary;
+		const normalized = normalizeToV4(v3Leaf);
+		expect(normalized).not.toBe(v3Leaf);
+		// And the input still reports version 3 — we didn't mutate it.
+		expect(v3Leaf.version).toBe(3);
+	});
+
+	it("bumps version to 4 on a v3 leaf with no children", () => {
+		const v3Leaf: CommitSummary = { ...baseNode, version: 3 } as CommitSummary;
+		const normalized = normalizeToV4(v3Leaf);
+		expect(normalized.version).toBe(4);
+		expect(normalized.children).toBeUndefined();
+	});
+
+	it("hoists child-only plans / notes / linearIssues / e2eTestGuide / jolliDoc to root", () => {
+		const v3WithChildMeta: CommitSummary = {
+			...baseNode,
+			version: 3,
+			children: [
+				{
+					...baseNode,
+					commitHash: "child-hash",
+					version: 3,
+					plans: [
+						{
+							slug: "feature-x",
+							title: "Feature X",
+							editCount: 1,
+							addedAt: "2026-05-20T00:00:00Z",
+							updatedAt: "2026-05-20T00:00:00Z",
+						},
+					],
+					notes: [
+						{
+							id: "note-1",
+							title: "N1",
+							format: "snippet",
+							addedAt: "2026-05-20T00:00:00Z",
+							updatedAt: "2026-05-20T00:00:00Z",
+						},
+					],
+					linearIssues: [
+						{
+							archivedKey: "PROJ-1-abc",
+							ticketId: "PROJ-1",
+							title: "T",
+							url: "https://linear.app/x",
+							referencedAt: "2026-05-20T00:00:00Z",
+							sourceToolName: "mcp__linear__get_issue",
+						},
+					],
+					e2eTestGuide: [
+						{
+							title: "Scenario 1",
+							preconditions: "",
+							steps: ["step"],
+							expectedResults: ["ok"],
+						} as never,
+					],
+					jolliDocId: 42,
+					jolliDocUrl: "https://jolli.ai/d/42",
+				},
+			],
+		} as CommitSummary;
+
+		const normalized = normalizeToV4(v3WithChildMeta);
+
+		expect(normalized.version).toBe(4);
+		expect(normalized.plans?.[0]?.slug).toBe("feature-x");
+		expect(normalized.notes?.[0]?.id).toBe("note-1");
+		expect(normalized.linearIssues?.[0]?.archivedKey).toBe("PROJ-1-abc");
+		expect(normalized.e2eTestGuide?.[0]?.title).toBe("Scenario 1");
+		expect(normalized.jolliDocId).toBe(42);
+		expect(normalized.jolliDocUrl).toBe("https://jolli.ai/d/42");
+		// Child stripped.
+		expect(normalized.children?.[0]?.plans).toBeUndefined();
+		expect(normalized.children?.[0]?.notes).toBeUndefined();
+		expect(normalized.children?.[0]?.jolliDocId).toBeUndefined();
+	});
+
+	it("strips descendants recursively through grandchildren", () => {
+		const v3Nested: CommitSummary = {
+			...baseNode,
+			version: 3,
+			children: [
+				{
+					...baseNode,
+					commitHash: "child-hash",
+					version: 3,
+					plans: [
+						{
+							slug: "p-c",
+							title: "child plan",
+							editCount: 1,
+							addedAt: "2026-05-20T00:00:00Z",
+							updatedAt: "2026-05-20T00:00:00Z",
+						},
+					],
+					children: [
+						{
+							...baseNode,
+							commitHash: "grandchild-hash",
+							version: 3,
+							plans: [
+								{
+									slug: "p-g",
+									title: "grandchild plan",
+									editCount: 1,
+									addedAt: "2026-05-20T00:00:00Z",
+									updatedAt: "2026-05-20T00:00:00Z",
+								},
+							],
+						},
+					],
+				},
+			],
+		} as CommitSummary;
+
+		const normalized = normalizeToV4(v3Nested);
+		// Both plans hoisted to root (dedup-by-slug union).
+		const slugs = (normalized.plans ?? []).map((p) => p.slug).sort();
+		expect(slugs).toEqual(["p-c", "p-g"]);
+		// Grandchild stripped too.
+		expect(normalized.children?.[0]?.children?.[0]?.plans).toBeUndefined();
+	});
+
+	it("preserves topics, recap, ticketId on root (regenerate decides whether to overwrite)", () => {
+		const v3WithRootContent: CommitSummary = {
+			...baseNode,
+			version: 3,
+			topics: [{ title: "kept", trigger: "t", response: "r", decisions: "d" }],
+			recap: "kept recap",
+			ticketId: "PROJ-9",
+		} as CommitSummary;
+		const normalized = normalizeToV4(v3WithRootContent);
+		expect(normalized.topics?.[0]?.title).toBe("kept");
+		expect(normalized.recap).toBe("kept recap");
+		expect(normalized.ticketId).toBe("PROJ-9");
+	});
+
+	it("recursively collects orphanedDocIds from every descendant and dedups", () => {
+		const v3WithChildOrphans: CommitSummary = {
+			...baseNode,
+			version: 3,
+			orphanedDocIds: [1, 2],
+			children: [
+				{
+					...baseNode,
+					commitHash: "c1",
+					version: 3,
+					orphanedDocIds: [2, 3],
+					children: [
+						{
+							...baseNode,
+							commitHash: "g1",
+							version: 3,
+							orphanedDocIds: [4],
+						},
+					],
+				},
+			],
+		} as CommitSummary;
+		const normalized = normalizeToV4(v3WithChildOrphans);
+		expect(new Set(normalized.orphanedDocIds ?? [])).toEqual(new Set([1, 2, 3, 4]));
+	});
+
+	it("dedups duplicated plans (by slug) by picking the newest updatedAt", () => {
+		const v3WithDuplicatePlans: CommitSummary = {
+			...baseNode,
+			version: 3,
+			plans: [
+				{
+					slug: "shared",
+					title: "Old (root)",
+					editCount: 1,
+					addedAt: "2026-05-20T00:00:00Z",
+					updatedAt: "2026-05-20T00:00:00Z",
+				},
+			],
+			children: [
+				{
+					...baseNode,
+					commitHash: "c1",
+					version: 3,
+					plans: [
+						{
+							slug: "shared",
+							title: "New (child)",
+							editCount: 2,
+							addedAt: "2026-05-20T00:00:00Z",
+							updatedAt: "2026-05-21T00:00:00Z",
+						},
+					],
+				},
+			],
+		} as CommitSummary;
+		const normalized = normalizeToV4(v3WithDuplicatePlans);
+		expect(normalized.plans).toHaveLength(1);
+		expect(normalized.plans?.[0]?.title).toBe("New (child)");
+	});
+
+	it("omits Copy-Hoist field keys entirely when no node in the tree carried them", () => {
+		const v3Bare: CommitSummary = { ...baseNode, version: 3 } as CommitSummary;
+		const normalized = normalizeToV4(v3Bare);
+		expect(normalized.plans).toBeUndefined();
+		expect(normalized.notes).toBeUndefined();
+		expect(normalized.linearIssues).toBeUndefined();
+		expect(normalized.e2eTestGuide).toBeUndefined();
+		expect(normalized.jolliDocId).toBeUndefined();
+		expect(normalized.orphanedDocIds).toBeUndefined();
+	});
+});

--- a/vscode/src/JolliMemoryBridge.ts
+++ b/vscode/src/JolliMemoryBridge.ts
@@ -1682,6 +1682,39 @@ export class JolliMemoryBridge {
 		await storeSummary(summary, this.cwd, force, artifacts, storage);
 	}
 
+	/**
+	 * Loads regenerate-context (confirm-dialog counts) through the Bridge's
+	 * StorageProvider so folder-only Memory Bank users read transcripts from
+	 * FolderStorage instead of the OrphanBranchStorage fallback baked into
+	 * the underlying SummaryStore helpers. Without this wrapper the dialog
+	 * reports 0 transcripts on every regenerate in folder-only mode.
+	 */
+	async loadRegenerateContext(
+		summary: CommitSummary,
+	): Promise<import("../../cli/src/core/RegenerateContext.js").RegenerateContext> {
+		const storage = await this.getStorage();
+		const { loadRegenerateContext } = await import(
+			"../../cli/src/core/RegenerateContext.js"
+		);
+		return loadRegenerateContext(summary, this.cwd, storage);
+	}
+
+	/**
+	 * Runs the regenerate-summary LLM call through the Bridge's
+	 * StorageProvider — same folder-only correctness rationale as
+	 * `loadRegenerateContext`. Transcripts, archived plans/notes/linear
+	 * issues all read from the active backend (FolderStorage in folder
+	 * mode, OrphanBranchStorage in legacy mode, DualWriteStorage by default).
+	 */
+	async regenerateSummary(
+		summary: CommitSummary,
+		config: import("../../cli/src/Types.js").LlmConfig,
+	): Promise<import("../../cli/src/core/Regenerator.js").RegenerateResult> {
+		const storage = await this.getStorage();
+		const { regenerateSummary } = await import("../../cli/src/core/Regenerator.js");
+		return regenerateSummary(summary, this.cwd, config, storage);
+	}
+
 	/** Writes plan files (orphan-branch + Memory Bank visible MD). */
 	async storePlans(
 		planFiles: ReadonlyArray<{ slug: string; content: string }>,

--- a/vscode/src/views/SummaryCssBuilder.ts
+++ b/vscode/src/views/SummaryCssBuilder.ts
@@ -262,6 +262,23 @@ export function buildCss(): string {
     cursor: wait;
     animation: spin 1s linear infinite;
   }
+  /* Regenerate-summary in-flight: dim topics + recap so the user reads them
+     as stale-pending. pointer-events is redundant w/ button[disabled]
+     (Task 5 freezes every focusable control), but it's a cheap belt-and-
+     suspenders against any non-disabled clickable that slipped through. */
+  .section.regenerating {
+    opacity: 0.5;
+    pointer-events: none;
+    transition: opacity 0.2s;
+  }
+  .section.regenerating button[disabled],
+  .section.regenerating textarea[disabled],
+  .section.regenerating input[disabled] {
+    cursor: not-allowed;
+  }
+  #regenerateSummaryBtn.generating {
+    animation: spin 1.2s linear infinite;
+  }
   .plan-title-link {
     color: var(--vscode-foreground);
     text-decoration: none;

--- a/vscode/src/views/SummaryCssBuilder.ts
+++ b/vscode/src/views/SummaryCssBuilder.ts
@@ -263,17 +263,22 @@ export function buildCss(): string {
     animation: spin 1s linear infinite;
   }
   /* Regenerate-summary in-flight: dim topics + recap so the user reads them
-     as stale-pending. pointer-events is redundant w/ button[disabled]
-     (Task 5 freezes every focusable control), but it's a cheap belt-and-
-     suspenders against any non-disabled clickable that slipped through. */
+     as stale-pending. pointer-events: none on the section is redundant with
+     button[disabled] (the host freezes every focusable control), but it's a
+     cheap belt-and-suspenders against any non-disabled clickable that
+     slipped through. */
   .section.regenerating {
     opacity: 0.5;
     pointer-events: none;
     transition: opacity 0.2s;
   }
+  /* Re-enable pointer-events on the disabled controls themselves so the
+     browser still computes hover state and renders the not-allowed cursor;
+     the disabled attribute still blocks click, so this is purely visual. */
   .section.regenerating button[disabled],
   .section.regenerating textarea[disabled],
   .section.regenerating input[disabled] {
+    pointer-events: auto;
     cursor: not-allowed;
   }
   #regenerateSummaryBtn.generating {

--- a/vscode/src/views/SummaryCssBuilder.ts
+++ b/vscode/src/views/SummaryCssBuilder.ts
@@ -262,27 +262,14 @@ export function buildCss(): string {
     cursor: wait;
     animation: spin 1s linear infinite;
   }
-  /* Regenerate-summary in-flight: dim topics + recap so the user reads them
-     as stale-pending. pointer-events: none on the section is redundant with
-     button[disabled] (the host freezes every focusable control), but it's a
-     cheap belt-and-suspenders against any non-disabled clickable that
-     slipped through. */
-  .section.regenerating {
+  /* Regenerate-summary in-flight: dim topics + recap as "stale, about to be
+     replaced". The page-level .regenerating-readonly class already hides
+     every action button via the foreign-safe whitelist (see further below),
+     so this rule is purely visual — no disabled / pointer-events games. */
+  .page.regenerating-readonly #topicsSection,
+  .page.regenerating-readonly #recapSection {
     opacity: 0.5;
-    pointer-events: none;
     transition: opacity 0.2s;
-  }
-  /* Re-enable pointer-events on the disabled controls themselves so the
-     browser still computes hover state and renders the not-allowed cursor;
-     the disabled attribute still blocks click, so this is purely visual. */
-  .section.regenerating button[disabled],
-  .section.regenerating textarea[disabled],
-  .section.regenerating input[disabled] {
-    pointer-events: auto;
-    cursor: not-allowed;
-  }
-  #regenerateSummaryBtn.generating {
-    animation: spin 1.2s linear infinite;
   }
   .plan-title-link {
     color: var(--vscode-foreground);
@@ -1256,6 +1243,47 @@ export function buildCss(): string {
   .page.foreign-readonly button:not([data-foreign-safe]) {
     display: none !important;
   }
+
+  /* Regenerating-readonly mode.
+     Active for the 20-40s window while the regenerate-summary LLM call is
+     in flight. Same selector + whitelist as foreign-readonly / stale-readonly
+     so it inherits the same allow-list of data-foreign-safe controls (Copy /
+     Save Markdown / Toggle / Hash copy). Host-side dispatchWebviewMessage
+     guard short-circuits any unsafe command that slips through anyway.
+
+     Unlike the other two readonly modes this one is BOUNDED: the
+     summaryRegenerated / summaryRegenerateError message removes the
+     class and the corresponding banner, returning the page to its normal
+     interactive state. */
+  .page.regenerating-readonly button:not([data-foreign-safe]) {
+    display: none !important;
+  }
+
+  /* Regenerating banner - same chrome as .stale-banner but with a spinner
+     and a transient (not persistent) lifetime. Inserted at the top of
+     div.page by the webview's summaryRegenerating handler. */
+  .regenerating-banner {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin: 0 0 16px 0;
+    padding: 12px 16px;
+    background: var(--vscode-inputValidation-infoBackground, #2a4a5a);
+    color: var(--vscode-inputValidation-infoForeground, #cfe2ff);
+    border: 1px solid var(--vscode-inputValidation-infoBorder, #4a8ab5);
+    border-radius: 6px;
+    font-size: 0.9em;
+  }
+  /* Spinning icon reinforces the in-progress state for users who don't
+     see the lower-right system-progress notification (e.g. focus on the
+     panel). Uses the same spin keyframes as other in-flight indicators
+     (.topic-action-btn.generating). */
+  .regenerating-banner-spinner {
+    display: inline-block;
+    animation: spin 1.2s linear infinite;
+    font-size: 1.1em;
+  }
+  .regenerating-banner-text { flex: 1; }
 
   /* Stale-readonly mode.
      Triggered when the panel's commit has been rewritten by amend / squash /

--- a/vscode/src/views/SummaryHtmlBuilder.test.ts
+++ b/vscode/src/views/SummaryHtmlBuilder.test.ts
@@ -122,6 +122,7 @@ import {
 	buildE2eTestSection,
 	buildHtml,
 	buildRecapSection,
+	buildTopicsSection,
 	renderTopic,
 } from "./SummaryHtmlBuilder.js";
 import type { TopicWithDate } from "./SummaryUtils.js";
@@ -1312,5 +1313,49 @@ describe("SummaryHtmlBuilder", () => {
 				expect(html).toContain(expectedClass);
 			}
 		});
+	});
+});
+
+describe("buildTopicsSection", () => {
+	it("wraps topics in a section element with id='topicsSection'", () => {
+		const summary = makeSummary({
+			topics: [makeTopic({ title: "Sample topic" })],
+		});
+		const html = buildTopicsSection(summary);
+		expect(html).toMatch(/<div class="section" id="topicsSection"/);
+	});
+
+	it("produces output that is byte-equal to the corresponding region inside buildHtml", () => {
+		const summary = makeSummary({
+			topics: [makeTopic({ title: "Sample topic" })],
+		});
+		const pageHtml = buildHtml(summary);
+		const sectionHtml = buildTopicsSection(summary);
+		expect(pageHtml).toContain(sectionHtml.trim());
+	});
+
+	it("renders the empty-state placeholder when topics is empty", () => {
+		const html = buildTopicsSection(makeSummary({ topics: [] }));
+		expect(html).toContain('id="topicsSection"');
+		expect(html).toContain("No topics available for this commit.");
+	});
+});
+
+describe("buildAllConversationsSection — Regenerate button", () => {
+	it("renders an enabled Regenerate button when transcripts exist", () => {
+		const summary = makeSummary();
+		const html = buildHtml(summary, {
+			transcriptHashSet: new Set([summary.commitHash]),
+		});
+		expect(html).toContain('id="regenerateSummaryBtn"');
+		expect(html).not.toMatch(/id="regenerateSummaryBtn"[^>]*disabled/);
+	});
+
+	it("renders exactly one Regenerate button even in the empty-transcript branch", () => {
+		const summary = makeSummary();
+		const html = buildHtml(summary); // no transcriptHashSet → empty branch
+		const matches = html.match(/id="regenerateSummaryBtn"/g) ?? [];
+		expect(matches.length).toBe(1);
+		expect(html).not.toMatch(/id="regenerateSummaryBtn"[^>]*disabled/);
 	});
 });

--- a/vscode/src/views/SummaryHtmlBuilder.ts
+++ b/vscode/src/views/SummaryHtmlBuilder.ts
@@ -303,6 +303,14 @@ function buildHeader(
  * Paragraph splitting on `\n\n` is defensive: the LLM may emit one or several
  * paragraphs depending on how many topics it weaves in, and HTML collapses
  * whitespace by default so a textual blank line would otherwise disappear.
+ *
+ * CONTRACT (do not break): the returned HTML is shaped
+ *   `<div class="section recap-section" id="recapSection">…</div><hr class="separator"/>`
+ * — two top-level sibling elements. The webview's `replaceSection('recapSection', …)`
+ * in SummaryScriptBuilder.ts depends on this shape to strip the trailing <hr>
+ * before splicing in the regenerated recap (otherwise stacked or missing
+ * separators result). If you change the wrapping to a single self-contained
+ * <div> (or any other shape), update replaceSection in the same change.
  */
 export function buildRecapSection(recap: string | undefined): string {
 	const trimmed = recap?.trim();

--- a/vscode/src/views/SummaryHtmlBuilder.ts
+++ b/vscode/src/views/SummaryHtmlBuilder.ts
@@ -92,18 +92,11 @@ export function buildHtml(
 	if (opts.foreignRepoName) pageClasses.push("foreign-readonly");
 	if (opts.staleRewrittenInto) pageClasses.push("stale-readonly");
 	const pageClass = pageClasses.join(" ");
-	const { topics: allTopics, sourceNodes } = collectSortedTopics(summary);
+	const { sourceNodes } = collectSortedTopics(summary);
 	const stats = resolveDiffStats(summary);
 	const totalInsertions = stats.insertions;
 	const totalDeletions = stats.deletions;
 	const totalFiles = stats.filesChanged;
-
-	const topicsHtml =
-		allTopics.length === 0
-			? '<p class="empty">No topics available for this commit.</p>'
-			: allTopics.map((t, i) => renderTopic(t, i)).join("\n");
-
-	const topicsLabel = `${allTopics.length} topic${allTopics.length !== 1 ? "s" : ""} extracted from this commit`;
 
 	const csp = nonce
 		? `<meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'nonce-${nonce}'; script-src 'nonce-${nonce}'; img-src data:;" />`
@@ -144,13 +137,7 @@ ${buildPrSectionHtml()}
 ${buildPlansAndNotesSection(summary.plans, summary.notes, summary.linearIssues, planTranslateSet, noteTranslateSet)}
 ${buildE2eTestSection(summary)}
 ${buildSourceCommits(sourceNodes)}
-<div class="section">
-  <div class="section-header">
-    <div class="section-title" title="${topicsLabel}">&#x1F4DD; ${allTopics.length === 1 ? "Topic" : "Topics"} <span class="section-count">${allTopics.length}</span></div>
-    <button class="toggle-all-btn" id="toggleAllBtn" title="Expand / Collapse all topics" data-foreign-safe>Collapse All</button>
-  </div>
-  ${topicsHtml}
-</div>
+${buildTopicsSection(summary)}
 ${buildFooter(summary)}
 </div>
 <script${nonceAttr}>${buildScript()}</script>
@@ -352,6 +339,33 @@ export function buildRecapSection(recap: string | undefined): string {
   <div class="recap-body">${bodyHtml}</div>
 </div>
 <hr class="separator" />`;
+}
+
+// ─── Topics Section ──────────────────────────────────────────────────────────
+
+/**
+ * Renders the topic grid as a self-contained section.
+ *
+ * Exported so the regenerate-summary handler can rebuild this region in
+ * isolation after a successful re-run (the webview's replaceSection picks the
+ * node up by `id="topicsSection"`). The output is byte-equal to the topics
+ * region inside `buildHtml`, so embedding `${buildTopicsSection(summary)}`
+ * there is the canonical way to keep the two render paths in sync.
+ */
+export function buildTopicsSection(summary: CommitSummary): string {
+	const { topics: allTopics } = collectSortedTopics(summary);
+	const topicsHtml =
+		allTopics.length === 0
+			? '<p class="empty">No topics available for this commit.</p>'
+			: allTopics.map((t, i) => renderTopic(t, i)).join("\n");
+	const topicsLabel = `${allTopics.length} topic${allTopics.length !== 1 ? "s" : ""} extracted from this commit`;
+	return `<div class="section" id="topicsSection">
+  <div class="section-header">
+    <div class="section-title" title="${topicsLabel}">&#x1F4DD; ${allTopics.length === 1 ? "Topic" : "Topics"} <span class="section-count">${allTopics.length}</span></div>
+    <button class="toggle-all-btn" id="toggleAllBtn" title="Expand / Collapse all topics" data-foreign-safe>Collapse All</button>
+  </div>
+  ${topicsHtml}
+</div>`;
 }
 
 // ─── Plans & Notes Section ───────────────────────────────────────────────────
@@ -599,6 +613,9 @@ function buildAllConversationsSection(
   <div class="private-zone-watermark">PRIVATE</div>
   <div class="section-header">
     <div class="section-title">&#x1F4AC; All Conversations</div>
+    <span class="conversations-actions">
+      <button class="action-btn" id="regenerateSummaryBtn" title="Re-run the LLM end-to-end">&#x21BB; Regenerate</button>
+    </span>
   </div>
   <p class="empty">No conversation transcripts saved for this commit.</p>
 </div>`;
@@ -609,7 +626,10 @@ function buildAllConversationsSection(
   <div class="private-zone-watermark">PRIVATE</div>
   <div class="section-header">
     <div class="section-title">&#x1F4AC; All Conversations</div>
-    <button class="action-btn" id="openTranscriptsBtn">Manage</button>
+    <span class="conversations-actions">
+      <button class="action-btn" id="regenerateSummaryBtn" title="Re-run the LLM end-to-end">&#x21BB; Regenerate</button>
+      <button class="action-btn" id="openTranscriptsBtn">Manage</button>
+    </span>
   </div>
   <p class="conversations-description">Raw AI conversation transcripts captured during development.</p>
   <p class="conversations-stats" id="conversationsStats">

--- a/vscode/src/views/SummaryScriptBuilder.test.ts
+++ b/vscode/src/views/SummaryScriptBuilder.test.ts
@@ -160,6 +160,46 @@ describe("SummaryScriptBuilder", () => {
 		expect(script).toMatch(/'copilot',\s*'copilot-chat'/);
 	});
 
+	describe("Regenerate summary re-render wiring", () => {
+		// The emitted JS runs in the webview iframe and is not unit-testable
+		// at runtime in vitest. These string-contain assertions pin the
+		// regenerate handlers in place so a refactor that drops them breaks
+		// the build instead of silently regressing webview behavior. Each
+		// matches a load-bearing line from SummaryScriptBuilder's
+		// summaryRegenerated branch.
+
+		it("emits the named handler so success-path re-binds the new #toggleAllBtn", () => {
+			// Function defined and called once at page-load init.
+			expect(script).toContain("function attachToggleAllBtnHandler");
+			// Re-invoked from the summaryRegenerated message branch because
+			// replaceSection swaps in a brand-new #toggleAllBtn element whose
+			// click listener doesn't carry over from the old DOM.
+			expect(script).toMatch(/summaryRegenerated[\s\S]*attachToggleAllBtnHandler\(\)/);
+		});
+
+		it("resets allCollapsed to false before re-binding so button text matches the freshly-uncollapsed topics", () => {
+			expect(script).toMatch(
+				/summaryRegenerated[\s\S]*allCollapsed\s*=\s*false[\s\S]*attachToggleAllBtnHandler/,
+			);
+		});
+
+		it("re-attaches toggle-header handlers on the new topics root (collapse on click still works)", () => {
+			expect(script).toMatch(
+				/summaryRegenerated[\s\S]*\.toggle-header[\s\S]*attachToggleHeader/,
+			);
+		});
+
+		it("does NOT re-attach attachRegenerateSummaryHandler in the success path (button lives outside topicsSection / recapSection)", () => {
+			// The regenerate button is in the Conversations card, which
+			// replaceSection never touches; re-attaching would double-bind
+			// the listener and post N messages on the Nth click after N
+			// regenerates.
+			const summaryRegeneratedBranch = script.split("summaryRegenerated")[1] ?? "";
+			const cancelBranch = summaryRegeneratedBranch.split("summaryRegenerateError")[0] ?? "";
+			expect(cancelBranch).not.toContain("attachRegenerateSummaryHandler(");
+		});
+	});
+
 	describe("Linear issue actions", () => {
 		it("routes the 3 Linear actions through their own data-action cases", () => {
 			// Each case must read the data-linear-key attribute and post a

--- a/vscode/src/views/SummaryScriptBuilder.test.ts
+++ b/vscode/src/views/SummaryScriptBuilder.test.ts
@@ -198,6 +198,44 @@ describe("SummaryScriptBuilder", () => {
 			const cancelBranch = summaryRegeneratedBranch.split("summaryRegenerateError")[0] ?? "";
 			expect(cancelBranch).not.toContain("attachRegenerateSummaryHandler(");
 		});
+
+		it("enters regenerating-readonly mode on summaryRegenerating (banner + page class)", () => {
+			// CSS for .page.regenerating-readonly hides every action button via
+			// the foreign-safe whitelist, and the banner explains why. The
+			// previous freezeSummarySections / thawSummarySections approach
+			// has been removed in favor of this single class toggle — pin
+			// it so a refactor doesn't silently revert.
+			expect(script).toContain("function enterRegeneratingReadonly");
+			expect(script).toContain("function leaveRegeneratingReadonly");
+			expect(script).toContain("regenerating-readonly");
+			expect(script).toMatch(
+				/summaryRegenerating[\s\S]*enterRegeneratingReadonly\(\)/,
+			);
+		});
+
+		it("leaves regenerating-readonly on BOTH success and error/cancel paths", () => {
+			// Either summaryRegenerated OR summaryRegenerateError must
+			// restore the page chrome — otherwise the user is stuck with
+			// every action button hidden until they reload.
+			expect(script).toMatch(
+				/summaryRegenerated[\s\S]*leaveRegeneratingReadonly\(\)/,
+			);
+			expect(script).toMatch(
+				/summaryRegenerateError[\s\S]*leaveRegeneratingReadonly\(\)/,
+			);
+		});
+
+		it("inserts a banner with the regenerating-banner-spinner element so users see a spinner", () => {
+			expect(script).toContain("regenerating-banner-spinner");
+			expect(script).toContain("regenerating-banner-text");
+			expect(script).toContain("Regenerating summary");
+		});
+
+		it("does NOT contain the removed freeze/thaw helpers (deprecated by regenerating-readonly)", () => {
+			expect(script).not.toContain("function freezeSummarySections");
+			expect(script).not.toContain("function thawSummarySections");
+			expect(script).not.toContain("function resetRegenerateButton");
+		});
 	});
 
 	describe("Linear issue actions", () => {

--- a/vscode/src/views/SummaryScriptBuilder.ts
+++ b/vscode/src/views/SummaryScriptBuilder.ts
@@ -207,6 +207,51 @@ ${buildPrMessageScript()}
         regenBtn2.disabled = false;
       }
     }
+
+    // ── Regenerate summary status ──
+    if (msg.command === 'summaryRegenerating') {
+      var rBtn = document.getElementById('regenerateSummaryBtn');
+      if (rBtn) {
+        rBtn.classList.add('generating');
+        rBtn.disabled = true;
+        rBtn.innerHTML = '\\u21BB Regenerating\\u2026';
+      }
+      freezeSummarySections();
+      return;
+    }
+    if (msg.command === 'summaryRegenerated') {
+      // Success: replaceSection drops the old DOM (including dataset markers
+      // set by freezeSummarySections), so we do NOT call thawSummarySections.
+      if (msg.topicsHtml) replaceSection('topicsSection', msg.topicsHtml);
+      if (msg.recapHtml) replaceSection('recapSection', msg.recapHtml);
+      resetRegenerateButton();
+      // Re-attach handlers on the NEW DOM nodes inside topics + recap.
+      // NOTE: do NOT re-attach attachRegenerateSummaryHandler — the Regenerate
+      // button lives in the Conversations card, OUTSIDE topicsSection /
+      // recapSection, so replaceSection never touched it and its original
+      // listener is still bound. Re-attaching would add a duplicate listener
+      // each regenerate, making the Nth click post N messages.
+      attachEditRecapHandler();
+      attachGenerateRecapHandler();
+      var newTopicsRoot = document.getElementById('topicsSection');
+      if (newTopicsRoot) {
+        attachTopicHandlers(newTopicsRoot);
+        // attachTopicHandlers wires the edit/delete buttons inside .toggle,
+        // but NOT the toggle-header expand/collapse click — that's a
+        // separate handler set up once at page load. Re-attach it on the
+        // new headers so topics still expand. The function is idempotent
+        // (skips headers it has already wired via the _toggleAttached flag).
+        newTopicsRoot.querySelectorAll('.toggle-header').forEach(attachToggleHeader);
+      }
+      return;
+    }
+    if (msg.command === 'summaryRegenerateError') {
+      // Error / cancel: sections were NOT replaced — restore the original
+      // disabled state instead of leaving everything inert.
+      thawSummarySections();
+      resetRegenerateButton();
+      return;
+    }
   });
 
   // Toggle All: expand / collapse all topic toggles and timeline groups.
@@ -582,6 +627,89 @@ ${buildPrMessageScript()}
     });
   }
   attachGenerateRecapHandler();
+
+  // ── Regenerate-summary click handler + DOM helpers ─────────────────────
+  // Drives the end-to-end re-run from the Conversations card. The actual
+  // confirm dialog + LLM call lives on the extension host; this side only
+  // gates the click and renders progress state.
+  function attachRegenerateSummaryHandler() {
+    var btn = document.getElementById('regenerateSummaryBtn');
+    if (!btn) return;
+    btn.addEventListener('click', function(e) {
+      e.stopPropagation();
+      if (btn.disabled) return;
+      // Block when user has unsaved edits in topics or recap — otherwise a
+      // 30-second LLM call would silently overwrite in-progress work.
+      if (document.querySelector('#topicsSection .toggle.editing, #recapSection.recap-editing')) {
+        alert('You have unsaved edits in topics or recap. Save or cancel them before regenerating.');
+        return;
+      }
+      // Block when another LLM action is already in flight.
+      if (document.querySelector('.generating')) {
+        alert('Another action is in progress. Please wait for it to finish.');
+        return;
+      }
+      vscode.postMessage({ command: 'regenerateSummary' });
+    });
+  }
+  attachRegenerateSummaryHandler();
+
+  // Disable every focusable control inside topics + recap during regenerate.
+  // Each touched control is tagged data-was-disabled so the error path can
+  // restore the pre-regenerate state without flipping legitimately-disabled
+  // buttons back on.
+  function freezeSummarySections() {
+    var sections = [document.getElementById('topicsSection'), document.getElementById('recapSection')];
+    sections.forEach(function(sec) {
+      if (!sec) return;
+      sec.classList.add('regenerating');
+      var ctrls = sec.querySelectorAll('button, textarea, input');
+      ctrls.forEach(function(c) {
+        if (c.disabled) {
+          c.dataset.wasDisabled = '1';
+        } else {
+          c.dataset.wasDisabled = '0';
+          c.disabled = true;
+        }
+      });
+    });
+  }
+
+  function thawSummarySections() {
+    var sections = [document.getElementById('topicsSection'), document.getElementById('recapSection')];
+    sections.forEach(function(sec) {
+      if (!sec) return;
+      sec.classList.remove('regenerating');
+      var ctrls = sec.querySelectorAll('button, textarea, input');
+      ctrls.forEach(function(c) {
+        if (c.dataset.wasDisabled === '0') c.disabled = false;
+        delete c.dataset.wasDisabled;
+      });
+    });
+  }
+
+  function replaceSection(id, html) {
+    var old = document.getElementById(id);
+    if (!old) return;
+    var wrap = document.createElement('div');
+    wrap.innerHTML = html;
+    var nodes = Array.prototype.slice.call(wrap.childNodes).filter(function(n) { return n.nodeType === 1; });
+    if (nodes.length === 0) return;
+    // Recap section emits "<div>...</div><hr/>"; topics emits a single <div>.
+    // Drop the trailing <hr> that belongs to the OLD recap before splicing,
+    // so we don't end up with two separators stacked.
+    var sep = old.nextElementSibling;
+    if (sep && sep.tagName === 'HR' && id === 'recapSection') sep.remove();
+    old.replaceWith.apply(old, nodes);
+  }
+
+  function resetRegenerateButton() {
+    var rBtn = document.getElementById('regenerateSummaryBtn');
+    if (!rBtn) return;
+    rBtn.classList.remove('generating');
+    rBtn.disabled = false;
+    rBtn.innerHTML = '\\u21BB Regenerate';
+  }
 
   // Recap status messages — generation flow only. The 'recapUpdated' /
   // 'recapUpdateError' messages are handled in the top-level message

--- a/vscode/src/views/SummaryScriptBuilder.ts
+++ b/vscode/src/views/SummaryScriptBuilder.ts
@@ -209,52 +209,47 @@ ${buildPrMessageScript()}
     }
 
     // ── Regenerate summary status ──
+    // Lifecycle:
+    //   summaryRegenerating  → enter regenerating-readonly mode (CSS hides
+    //                          every action button via the foreign-safe
+    //                          allow-list), insert the top-of-page banner
+    //   summaryRegenerated   → swap in new topics/recap HTML, leave
+    //                          regenerating-readonly mode, remove banner
+    //   summaryRegenerateError → leave regenerating-readonly mode, remove
+    //                          banner; topics/recap DOM untouched
     if (msg.command === 'summaryRegenerating') {
-      var rBtn = document.getElementById('regenerateSummaryBtn');
-      if (rBtn) {
-        rBtn.classList.add('generating');
-        rBtn.disabled = true;
-        rBtn.innerHTML = '\\u21BB Regenerating\\u2026';
-      }
-      freezeSummarySections();
+      enterRegeneratingReadonly();
       return;
     }
     if (msg.command === 'summaryRegenerated') {
-      // Success: replaceSection drops the old DOM (including dataset markers
-      // set by freezeSummarySections), so we do NOT call thawSummarySections.
       if (msg.topicsHtml) replaceSection('topicsSection', msg.topicsHtml);
       if (msg.recapHtml) replaceSection('recapSection', msg.recapHtml);
-      resetRegenerateButton();
+      leaveRegeneratingReadonly();
       // Re-attach handlers on the NEW DOM nodes inside topics + recap.
-      // NOTE: do NOT re-attach attachRegenerateSummaryHandler — the Regenerate
-      // button lives in the Conversations card, OUTSIDE topicsSection /
-      // recapSection, so replaceSection never touched it and its original
-      // listener is still bound. Re-attaching would add a duplicate listener
-      // each regenerate, making the Nth click post N messages.
+      // NOTE: do NOT re-attach attachRegenerateSummaryHandler — the
+      // Regenerate button lives in the Conversations card, OUTSIDE
+      // topicsSection / recapSection, so replaceSection never touched it
+      // and its original listener is still bound. Re-attaching would add
+      // a duplicate listener each regenerate.
       attachEditRecapHandler();
       attachGenerateRecapHandler();
       var newTopicsRoot = document.getElementById('topicsSection');
       if (newTopicsRoot) {
         attachTopicHandlers(newTopicsRoot);
-        // attachTopicHandlers wires the edit/delete buttons inside .toggle,
-        // but NOT the toggle-header expand/collapse click — that's a
-        // separate handler set up once at page load. Re-attach it on the
-        // new headers so topics still expand. The function is idempotent
-        // (skips headers it has already wired via the _toggleAttached flag).
+        // attachTopicHandlers wires edit/delete inside .toggle but NOT the
+        // toggle-header expand/collapse click — re-attach explicitly on
+        // the new headers. The function is idempotent (_toggleAttached).
         newTopicsRoot.querySelectorAll('.toggle-header').forEach(attachToggleHeader);
       }
-      // The fresh topicsSection brings a NEW #toggleAllBtn whose click
-      // listener doesn't carry over from the old DOM. Reset allCollapsed
-      // because the new topics are always rendered uncollapsed, then re-bind.
+      // Fresh topicsSection brings a NEW #toggleAllBtn whose click listener
+      // doesn't carry over from the old DOM. Reset allCollapsed because the
+      // new topics are always rendered uncollapsed, then re-bind.
       allCollapsed = false;
       attachToggleAllBtnHandler();
       return;
     }
     if (msg.command === 'summaryRegenerateError') {
-      // Error / cancel: sections were NOT replaced — restore the original
-      // disabled state instead of leaving everything inert.
-      thawSummarySections();
-      resetRegenerateButton();
+      leaveRegeneratingReadonly();
       return;
     }
   });
@@ -670,40 +665,48 @@ ${buildPrMessageScript()}
   }
   attachRegenerateSummaryHandler();
 
-  // Disable every focusable control inside topics + recap during regenerate.
-  // Each touched control is tagged data-was-disabled so the error path can
-  // restore the pre-regenerate state without flipping legitimately-disabled
-  // buttons back on.
-  function freezeSummarySections() {
-    var sections = [document.getElementById('topicsSection'), document.getElementById('recapSection')];
-    sections.forEach(function(sec) {
-      if (!sec) return;
-      sec.classList.add('regenerating');
-      var ctrls = sec.querySelectorAll('button, textarea, input');
-      ctrls.forEach(function(c) {
-        if (c.disabled) {
-          c.dataset.wasDisabled = '1';
-        } else {
-          c.dataset.wasDisabled = '0';
-          c.disabled = true;
-        }
-      });
-    });
+  // Toggle the page into / out of regenerating-readonly mode. CSS
+  // (.page.regenerating-readonly button:not([data-foreign-safe])) takes
+  // care of hiding every action button; the banner explains why. The
+  // host's dispatchWebviewMessage adds a second-layer guard against any
+  // postMessage that slips through (e.g. from a tab still on the old
+  // pre-readonly DOM).
+  function enterRegeneratingReadonly() {
+    var page = document.querySelector('.page');
+    if (page) page.classList.add('regenerating-readonly');
+    insertRegeneratingBanner();
   }
 
-  function thawSummarySections() {
-    var sections = [document.getElementById('topicsSection'), document.getElementById('recapSection')];
-    sections.forEach(function(sec) {
-      if (!sec) return;
-      sec.classList.remove('regenerating');
-      var ctrls = sec.querySelectorAll('button, textarea, input');
-      ctrls.forEach(function(c) {
-        if (c.dataset.wasDisabled === '0') c.disabled = false;
-        delete c.dataset.wasDisabled;
-      });
-    });
+  function leaveRegeneratingReadonly() {
+    var page = document.querySelector('.page');
+    if (page) page.classList.remove('regenerating-readonly');
+    removeRegeneratingBanner();
   }
 
+  function insertRegeneratingBanner() {
+    if (document.getElementById('regeneratingBanner')) return;
+    var page = document.querySelector('.page');
+    if (!page) return;
+    var banner = document.createElement('div');
+    banner.id = 'regeneratingBanner';
+    banner.className = 'regenerating-banner';
+    banner.setAttribute('role', 'status');
+    banner.innerHTML =
+      '<span class="regenerating-banner-spinner" aria-hidden="true">\\u21BB</span>' +
+      '<span class="regenerating-banner-text">Regenerating summary\\u2026 Other actions are temporarily disabled.</span>';
+    page.insertBefore(banner, page.firstChild);
+  }
+
+  function removeRegeneratingBanner() {
+    var banner = document.getElementById('regeneratingBanner');
+    if (banner) banner.remove();
+  }
+
+  // CONTRACT: this function depends on buildRecapSection in
+  // SummaryHtmlBuilder.ts emitting "<div id='recapSection'>...</div><hr/>"
+  // (two siblings) and buildTopicsSection emitting a single <div>. If either
+  // shape changes, update this function in the same commit — otherwise the
+  // regenerate success path leaves stacked or missing <hr class="separator">.
   function replaceSection(id, html) {
     var old = document.getElementById(id);
     if (!old) return;
@@ -711,20 +714,11 @@ ${buildPrMessageScript()}
     wrap.innerHTML = html;
     var nodes = Array.prototype.slice.call(wrap.childNodes).filter(function(n) { return n.nodeType === 1; });
     if (nodes.length === 0) return;
-    // Recap section emits "<div>...</div><hr/>"; topics emits a single <div>.
-    // Drop the trailing <hr> that belongs to the OLD recap before splicing,
+    // Drop the OLD recap's trailing <hr> before splicing in the new node(s),
     // so we don't end up with two separators stacked.
     var sep = old.nextElementSibling;
     if (sep && sep.tagName === 'HR' && id === 'recapSection') sep.remove();
     old.replaceWith.apply(old, nodes);
-  }
-
-  function resetRegenerateButton() {
-    var rBtn = document.getElementById('regenerateSummaryBtn');
-    if (!rBtn) return;
-    rBtn.classList.remove('generating');
-    rBtn.disabled = false;
-    rBtn.innerHTML = '\\u21BB Regenerate';
   }
 
   // Recap status messages — generation flow only. The 'recapUpdated' /

--- a/vscode/src/views/SummaryScriptBuilder.ts
+++ b/vscode/src/views/SummaryScriptBuilder.ts
@@ -243,6 +243,11 @@ ${buildPrMessageScript()}
         // (skips headers it has already wired via the _toggleAttached flag).
         newTopicsRoot.querySelectorAll('.toggle-header').forEach(attachToggleHeader);
       }
+      // The fresh topicsSection brings a NEW #toggleAllBtn whose click
+      // listener doesn't carry over from the old DOM. Reset allCollapsed
+      // because the new topics are always rendered uncollapsed, then re-bind.
+      allCollapsed = false;
+      attachToggleAllBtnHandler();
       return;
     }
     if (msg.command === 'summaryRegenerateError') {
@@ -257,9 +262,19 @@ ${buildPrMessageScript()}
   // Toggle All: expand / collapse all topic toggles and timeline groups.
   // Scoped to topics — explicitly excludes .e2e-scenario so the E2E section
   // has its own independent #toggleAllE2eBtn.
+  //
+  // allCollapsed lives in the buildScript closure so the state survives a
+  // regenerate re-render. The handler is only called twice in the lifecycle:
+  // once at page load, and once after summaryRegenerated swaps in a brand-new
+  // #toggleAllBtn element (the old element is gone, so the new one needs its
+  // own listener — not a re-bind on the same node).
   var allCollapsed = false;
-  var toggleAllBtn = document.getElementById('toggleAllBtn');
-  if (toggleAllBtn) {
+  function attachToggleAllBtnHandler() {
+    var toggleAllBtn = document.getElementById('toggleAllBtn');
+    if (!toggleAllBtn) return;
+    // Sync the button label with allCollapsed so a regenerate's freshly-
+    // rendered topics (always uncollapsed) and the button text agree.
+    toggleAllBtn.textContent = allCollapsed ? 'Expand All' : 'Collapse All';
     toggleAllBtn.addEventListener('click', function() {
       var items = document.querySelectorAll('.toggle:not(.e2e-scenario), .timeline-group');
       allCollapsed = !allCollapsed;
@@ -273,6 +288,7 @@ ${buildPrMessageScript()}
       toggleAllBtn.textContent = allCollapsed ? 'Expand All' : 'Collapse All';
     });
   }
+  attachToggleAllBtnHandler();
 
   // ── Attach collapsible callout toggle handlers inside a root element ──
   function attachCollapsibleHandlers(root) {

--- a/vscode/src/views/SummaryUtils.test.ts
+++ b/vscode/src/views/SummaryUtils.test.ts
@@ -29,6 +29,7 @@ import {
 	collectSortedTopics,
 	escAttr,
 	escHtml,
+	formatActiveProviderLabel,
 	formatDate,
 	formatFullDate,
 	formatProviderLabel,
@@ -779,6 +780,57 @@ describe("SummaryUtils", () => {
 			// print "via undefined" or "via unknown" on every legacy summary.
 			expect(collectLlmSources(nodeWithSource(undefined))).toEqual([]);
 			expect(formatProviderLabel(nodeWithSource(undefined))).toBeUndefined();
+		});
+	});
+
+	describe("formatActiveProviderLabel — current-config attribution for previews", () => {
+		const origEnv = process.env.ANTHROPIC_API_KEY;
+		afterEach(() => {
+			if (origEnv === undefined) delete process.env.ANTHROPIC_API_KEY;
+			else process.env.ANTHROPIC_API_KEY = origEnv;
+		});
+
+		it("returns 'Jolli proxy' when aiProvider is jolli AND jolliApiKey is set", () => {
+			expect(
+				formatActiveProviderLabel({ aiProvider: "jolli", jolliApiKey: "jk" } as never),
+			).toBe("Jolli proxy");
+		});
+
+		it("returns undefined when aiProvider is jolli but jolliApiKey is missing", () => {
+			expect(formatActiveProviderLabel({ aiProvider: "jolli" } as never)).toBeUndefined();
+		});
+
+		it("returns 'Anthropic' when aiProvider is anthropic with config apiKey", () => {
+			expect(
+				formatActiveProviderLabel({ aiProvider: "anthropic", apiKey: "k" } as never),
+			).toBe("Anthropic");
+		});
+
+		it("returns 'Anthropic (env)' when aiProvider is anthropic with only env apiKey", () => {
+			delete process.env.ANTHROPIC_API_KEY;
+			process.env.ANTHROPIC_API_KEY = "envkey";
+			expect(formatActiveProviderLabel({ aiProvider: "anthropic" } as never)).toBe(
+				"Anthropic (env)",
+			);
+		});
+
+		it("returns undefined when aiProvider is anthropic but no apiKey anywhere", () => {
+			delete process.env.ANTHROPIC_API_KEY;
+			expect(formatActiveProviderLabel({ aiProvider: "anthropic" } as never)).toBeUndefined();
+		});
+
+		it("falls back via legacy precedence when aiProvider is unset", () => {
+			delete process.env.ANTHROPIC_API_KEY;
+			expect(formatActiveProviderLabel({ apiKey: "k" } as never)).toBe("Anthropic");
+			process.env.ANTHROPIC_API_KEY = "envkey";
+			expect(formatActiveProviderLabel({} as never)).toBe("Anthropic (env)");
+			delete process.env.ANTHROPIC_API_KEY;
+			expect(formatActiveProviderLabel({ jolliApiKey: "jk" } as never)).toBe("Jolli proxy");
+		});
+
+		it("returns undefined when nothing is configured", () => {
+			delete process.env.ANTHROPIC_API_KEY;
+			expect(formatActiveProviderLabel({} as never)).toBeUndefined();
 		});
 	});
 });

--- a/vscode/src/views/SummaryUtils.ts
+++ b/vscode/src/views/SummaryUtils.ts
@@ -25,6 +25,7 @@ export {
 	type TopicWithDate,
 } from "../../../cli/src/core/SummaryFormat.js";
 
+import { resolveLlmCredentialSource } from "../../../cli/src/core/LlmClient.js";
 import { formatDate as coreFormatDate } from "../../../cli/src/core/SummaryFormat.js";
 import type {
 	CommitSummary,
@@ -97,27 +98,18 @@ export function formatProviderLabel(
  * historically generated an existing summary. Use this one when previewing
  * what a NEW call is about to do (e.g. the Regenerate confirm dialog).
  *
- * Mirrors the same precedence as `resolveLlmCredentialSource` in
- * cli/src/core/LlmClient.ts and returns `undefined` whenever that resolver
- * would also fail — so callers omit "via …" instead of promising a provider
- * that will throw at call time.
+ * Delegates the precedence ladder to `resolveLlmCredentialSource` so the
+ * "would this provider actually work" decision lives in one place; null
+ * back from the resolver becomes `undefined` here so callers can omit
+ * "via …" instead of promising a provider that will throw at call time.
+ * Label strings come from the same PROVIDER_LABELS map `formatProviderLabel`
+ * uses — there's no separate inline string table to drift.
  */
 export function formatActiveProviderLabel(
 	config: LlmConfig,
 ): string | undefined {
-	if (config.aiProvider === "jolli") {
-		return config.jolliApiKey ? "Jolli proxy" : undefined;
-	}
-	if (config.aiProvider === "anthropic") {
-		if (config.apiKey) return "Anthropic";
-		if (process.env.ANTHROPIC_API_KEY) return "Anthropic (env)";
-		return undefined;
-	}
-	// Legacy precedence when aiProvider is unset: apiKey → $ANTHROPIC_API_KEY → jolliApiKey
-	if (config.apiKey) return "Anthropic";
-	if (process.env.ANTHROPIC_API_KEY) return "Anthropic (env)";
-	if (config.jolliApiKey) return "Jolli proxy";
-	return undefined;
+	const source = resolveLlmCredentialSource(config);
+	return source === null ? undefined : PROVIDER_LABELS[source];
 }
 
 // ─── Push contract: relativePath construction ───────────────────────────────

--- a/vscode/src/views/SummaryUtils.ts
+++ b/vscode/src/views/SummaryUtils.ts
@@ -28,6 +28,7 @@ export {
 import { formatDate as coreFormatDate } from "../../../cli/src/core/SummaryFormat.js";
 import type {
 	CommitSummary,
+	LlmConfig,
 	LlmCredentialSource,
 } from "../../../cli/src/Types.js";
 import { sanitizeBranchSlug } from "../util/GitRemoteUtils.js";
@@ -86,6 +87,37 @@ export function formatProviderLabel(
 	if (sources.length === 0) return undefined;
 	if (sources.length === 1) return PROVIDER_LABELS[sources[0]];
 	return `mixed: ${sources.map((s) => PROVIDER_LABELS[s]).join(", ")}`;
+}
+
+/**
+ * Returns a footer-ready provider attribution string for the CURRENT LlmConfig
+ * — i.e. the provider that an LLM call started right now would use.
+ *
+ * Pairs with `formatProviderLabel(summary)` which reflects which provider
+ * historically generated an existing summary. Use this one when previewing
+ * what a NEW call is about to do (e.g. the Regenerate confirm dialog).
+ *
+ * Mirrors the same precedence as `resolveLlmCredentialSource` in
+ * cli/src/core/LlmClient.ts and returns `undefined` whenever that resolver
+ * would also fail — so callers omit "via …" instead of promising a provider
+ * that will throw at call time.
+ */
+export function formatActiveProviderLabel(
+	config: LlmConfig,
+): string | undefined {
+	if (config.aiProvider === "jolli") {
+		return config.jolliApiKey ? "Jolli proxy" : undefined;
+	}
+	if (config.aiProvider === "anthropic") {
+		if (config.apiKey) return "Anthropic";
+		if (process.env.ANTHROPIC_API_KEY) return "Anthropic (env)";
+		return undefined;
+	}
+	// Legacy precedence when aiProvider is unset: apiKey → $ANTHROPIC_API_KEY → jolliApiKey
+	if (config.apiKey) return "Anthropic";
+	if (process.env.ANTHROPIC_API_KEY) return "Anthropic (env)";
+	if (config.jolliApiKey) return "Jolli proxy";
+	return undefined;
 }
 
 // ─── Push contract: relativePath construction ───────────────────────────────

--- a/vscode/src/views/SummaryWebviewPanel.test.ts
+++ b/vscode/src/views/SummaryWebviewPanel.test.ts
@@ -596,6 +596,16 @@ const stubBridge = {
 	// Default to "empty index" so existing tests are unaffected; the
 	// stale-commit describe block overrides per test.
 	getSummaryIndexEntryMap: vi.fn().mockResolvedValue(new Map()),
+	// Regenerate flow now routes through bridge wrappers so the storage
+	// provider is threaded (folder-only Memory Bank correctness). Bridge
+	// wrappers delegate to mockLoadRegenerateContext / mockRegenerateSummary
+	// — same shape as the rest of this stub bridge's mocks.
+	loadRegenerateContext: vi.fn((summary: unknown) =>
+		mockLoadRegenerateContext(summary, workspaceRoot),
+	),
+	regenerateSummary: vi.fn((summary: unknown, config: unknown) =>
+		mockRegenerateSummary(summary, workspaceRoot, config),
+	),
 } as unknown as import("../JolliMemoryBridge.js").JolliMemoryBridge;
 const mainBranch = "main";
 
@@ -2103,18 +2113,24 @@ describe("SummaryWebviewPanel", () => {
 				// token before returning the task's result, so the Promise.race
 				// inside the handler resolves to "cancelled".
 				withProgress.mockImplementationOnce(
-					(_opts: unknown, task: (p: unknown, t: unknown) => Promise<unknown>) => {
+					(
+						_opts: unknown,
+						task: (
+							progress: { report: (v: unknown) => void },
+							token: { onCancellationRequested: (cb: () => void) => void },
+						) => unknown,
+					): unknown => {
 						let cancelCb: (() => void) | null = null;
 						const token = {
 							onCancellationRequested: (cb: () => void) => {
 								cancelCb = cb;
 							},
 						};
-						const taskPromise = task({ report: vi.fn() }, token);
+						const taskResult = task({ report: vi.fn() }, token);
 						// Fire cancel on the next microtask so the handler's
 						// Promise.race sees a "cancelled" winner.
 						queueMicrotask(() => cancelCb?.());
-						return taskPromise;
+						return taskResult;
 					},
 				);
 				const dispatch = await setupPanel();
@@ -2268,6 +2284,82 @@ describe("SummaryWebviewPanel", () => {
 				await flushPromises();
 
 				expect(mockRegenerateSummary).toHaveBeenCalledTimes(1);
+			});
+
+			it("rejects regenerate when a push is already in flight (race against push's writeback)", async () => {
+				// Push completion writes back jolliDocId / jolliDocUrl. If
+				// regenerate captures the pre-push summary snapshot and writes
+				// at the end of its 30 s LLM call, push's writeback gets
+				// silently clobbered — next push creates a duplicate article.
+				mockLoadRegenerateContext.mockResolvedValue(stubCtx());
+				const dispatch = await setupPanel();
+
+				// Reach into the panel instance and flip pushInProgress on
+				// — same pattern as the currentSummary-null tests above.
+				const panel = firstCommitPanel<{ pushInProgress: boolean }>();
+				panel.pushInProgress = true;
+
+				dispatch({ command: "regenerateSummary" });
+				await flushPromises();
+
+				// Regenerate must have early-returned with a toast — no
+				// confirm dialog, no LLM call, no storeSummary.
+				expect(mockRegenerateSummary).not.toHaveBeenCalled();
+				expect(mockStoreSummary).not.toHaveBeenCalled();
+				expect(showInformationMessage).toHaveBeenCalledWith(
+					expect.stringContaining("push to Jolli is in progress"),
+				);
+			});
+
+			it("denies mutating commands while regenerate is in flight (host-side guard)", async () => {
+				// Set up a never-resolving regenerate so the in-flight flag
+				// stays set; then dispatch a representative set of mutating
+				// commands and confirm the storeSummary mock is never called
+				// (the guard short-circuits before the handler runs).
+				mockLoadRegenerateContext.mockResolvedValue(stubCtx());
+				showWarningMessage.mockResolvedValueOnce("Regenerate");
+				mockRegenerateSummary.mockReturnValue(new Promise(() => {}));
+				const dispatch = await setupPanel();
+
+				dispatch({ command: "regenerateSummary" });
+				await flushPromises();
+				// Sanity: we're now in flight; storeSummary has not been called yet.
+				expect(mockStoreSummary).not.toHaveBeenCalled();
+
+				// All of these would normally write to the orphan branch — under
+				// the guard they must be silently dropped.
+				dispatch({ command: "push" });
+				dispatch({ command: "generateRecap" });
+				dispatch({ command: "generateE2eTest" });
+				dispatch({
+					command: "editTopic",
+					topicIndex: 0,
+					updates: { title: "x" },
+				});
+				dispatch({ command: "deleteTopic", topicIndex: 0 });
+				dispatch({ command: "editRecap", recap: "hi" });
+				await flushPromises();
+
+				expect(mockStoreSummary).not.toHaveBeenCalled();
+				expect(mockGenerateRecap).not.toHaveBeenCalled();
+				expect(mockGenerateE2eTest).not.toHaveBeenCalled();
+			});
+
+			it("allows read-only commands (copyMarkdown) while regenerate is in flight", async () => {
+				mockLoadRegenerateContext.mockResolvedValue(stubCtx());
+				showWarningMessage.mockResolvedValueOnce("Regenerate");
+				mockRegenerateSummary.mockReturnValue(new Promise(() => {}));
+				mockBuildMarkdown.mockReturnValue("# md");
+				const dispatch = await setupPanel();
+
+				dispatch({ command: "regenerateSummary" });
+				await flushPromises();
+
+				dispatch({ command: "copyMarkdown" });
+				await flushPromises();
+
+				// copyMarkdown went through — clipboard was written.
+				expect(clipboardWriteText).toHaveBeenCalledWith("# md");
 			});
 		});
 

--- a/vscode/src/views/SummaryWebviewPanel.test.ts
+++ b/vscode/src/views/SummaryWebviewPanel.test.ts
@@ -65,6 +65,23 @@ const { createWebviewPanel } = vi.hoisted(() => ({
 	})),
 }));
 
+const { withProgress } = vi.hoisted(() => ({
+	// Default: pass-through the task with a non-cancelled token. Individual
+	// tests can override via withProgress.mockImplementationOnce(...).
+	// NOTE: NOT async — we want to forward the task's promise directly so
+	// caller's `await withProgress(...)` resolves on the same microtask
+	// chain as the task body's internal awaits.
+	withProgress: vi.fn(
+		(
+			_opts: unknown,
+			task: (
+				progress: { report: (v: unknown) => void },
+				token: { onCancellationRequested: (cb: () => void) => void },
+			) => unknown,
+		) => task({ report: vi.fn() }, { onCancellationRequested: vi.fn() }),
+	),
+}));
+
 vi.mock("vscode", () => ({
 	window: {
 		createWebviewPanel,
@@ -75,7 +92,9 @@ vi.mock("vscode", () => ({
 		showOpenDialog,
 		showSaveDialog,
 		showTextDocument,
+		withProgress,
 	},
+	ProgressLocation: { Notification: 15, Window: 10, SourceControl: 1 },
 	env: {
 		clipboard: { writeText: clipboardWriteText },
 		openExternal,
@@ -136,6 +155,19 @@ vi.mock("../../../cli/src/core/Summarizer.js", () => ({
 	generateE2eTest: mockGenerateE2eTest,
 	generateRecap: mockGenerateRecap,
 	translateToEnglish: mockTranslateToEnglish,
+}));
+
+const { mockRegenerateSummary, mockLoadRegenerateContext } = vi.hoisted(() => ({
+	mockRegenerateSummary: vi.fn(),
+	mockLoadRegenerateContext: vi.fn(),
+}));
+
+vi.mock("../../../cli/src/core/Regenerator.js", () => ({
+	regenerateSummary: mockRegenerateSummary,
+}));
+
+vi.mock("../../../cli/src/core/RegenerateContext.js", () => ({
+	loadRegenerateContext: mockLoadRegenerateContext,
 }));
 
 const {
@@ -377,12 +409,14 @@ const {
 	mockBuildHtml,
 	mockBuildE2eTestSection,
 	mockBuildRecapSection,
+	mockBuildTopicsSection,
 	mockRenderTopic,
 	mockRenderE2eScenario,
 } = vi.hoisted(() => ({
 	mockBuildHtml: vi.fn().mockReturnValue("<html>mock</html>"),
 	mockBuildE2eTestSection: vi.fn().mockReturnValue("<div>e2e</div>"),
 	mockBuildRecapSection: vi.fn().mockReturnValue("<div>recap</div>"),
+	mockBuildTopicsSection: vi.fn().mockReturnValue("<div>topics</div>"),
 	mockRenderTopic: vi.fn().mockReturnValue("<div>topic</div>"),
 	mockRenderE2eScenario: vi.fn().mockReturnValue("<div>scenario</div>"),
 }));
@@ -391,6 +425,7 @@ vi.mock("./SummaryHtmlBuilder.js", () => ({
 	buildHtml: mockBuildHtml,
 	buildE2eTestSection: mockBuildE2eTestSection,
 	buildRecapSection: mockBuildRecapSection,
+	buildTopicsSection: mockBuildTopicsSection,
 	renderTopic: mockRenderTopic,
 	renderE2eScenario: mockRenderE2eScenario,
 }));
@@ -428,6 +463,10 @@ const {
 	mockBuildBranchRelativePath: vi.fn().mockReturnValue("main"),
 }));
 
+const { mockFormatActiveProviderLabel } = vi.hoisted(() => ({
+	mockFormatActiveProviderLabel: vi.fn().mockReturnValue("Anthropic"),
+}));
+
 vi.mock("./SummaryUtils.js", () => ({
 	buildPanelTitle: mockBuildPanelTitle,
 	buildPushTitle: mockBuildPushTitle,
@@ -436,6 +475,7 @@ vi.mock("./SummaryUtils.js", () => ({
 	collectSortedTopics: mockCollectSortedTopics,
 	collectAllPlans: mockCollectAllPlans,
 	buildBranchRelativePath: mockBuildBranchRelativePath,
+	formatActiveProviderLabel: mockFormatActiveProviderLabel,
 }));
 
 const { mockExecSync } = vi.hoisted(() => ({
@@ -1916,6 +1956,318 @@ describe("SummaryWebviewPanel", () => {
 				expect(postMessage).toHaveBeenCalledWith(
 					expect.objectContaining({ command: "recapUpdateError" }),
 				);
+			});
+		});
+
+		// ── regenerateSummary ───────────────────────────────────────────────
+
+		describe("regenerateSummary", () => {
+			const stubCtx = () => ({
+				entryCount: 7,
+				sessionCount: 1,
+				sources: ["Claude"],
+				humanTurns: 3,
+				plansCount: 0,
+				notesCount: 0,
+				linearCount: 0,
+			});
+			const stubUpdated = () =>
+				makeSummary({
+					topics: [],
+					recap: "regenerated",
+					commitMessage: "after regen",
+				});
+
+			beforeEach(() => {
+				mockLoadRegenerateContext.mockReset();
+				mockRegenerateSummary.mockReset();
+				withProgress.mockClear();
+				mockBuildTopicsSection.mockReturnValue('<div id="topicsSection">t</div>');
+				mockBuildRecapSection.mockReturnValue('<div id="recapSection">r</div>');
+			});
+
+			it("no-ops when the user cancels the confirm dialog", async () => {
+				mockLoadRegenerateContext.mockResolvedValue(stubCtx());
+				showWarningMessage.mockResolvedValueOnce(undefined);
+				const dispatch = await setupPanel();
+
+				dispatch({ command: "regenerateSummary" });
+				await flushPromises();
+
+				expect(mockRegenerateSummary).not.toHaveBeenCalled();
+				expect(mockStoreSummary).not.toHaveBeenCalled();
+			});
+
+			it("persists the updated summary and posts re-render on success", async () => {
+				mockLoadRegenerateContext.mockResolvedValue(stubCtx());
+				showWarningMessage.mockResolvedValueOnce("Regenerate");
+				mockRegenerateSummary.mockResolvedValue({
+					updated: stubUpdated(),
+					result: {} as never,
+				});
+				const dispatch = await setupPanel();
+
+				dispatch({ command: "regenerateSummary" });
+				await flushPromises();
+
+				expect(mockStoreSummary).toHaveBeenCalledWith(
+					expect.objectContaining({ recap: "regenerated" }),
+					workspaceRoot,
+					true,
+				);
+				expect(postMessage).toHaveBeenCalledWith(
+					expect.objectContaining({
+						command: "summaryRegenerated",
+						topicsHtml: '<div id="topicsSection">t</div>',
+						recapHtml: '<div id="recapSection">r</div>',
+					}),
+				);
+			});
+
+			it("does NOT pass artifacts to bridge.storeSummary on success", async () => {
+				// Regression guard: artifacts must stay undefined or the orphan-
+				// branch transcripts / plan-progress written at first-run time
+				// would be overwritten on every regenerate.
+				mockLoadRegenerateContext.mockResolvedValue(stubCtx());
+				showWarningMessage.mockResolvedValueOnce("Regenerate");
+				mockRegenerateSummary.mockResolvedValue({
+					updated: stubUpdated(),
+					result: {} as never,
+				});
+				const dispatch = await setupPanel();
+
+				dispatch({ command: "regenerateSummary" });
+				await flushPromises();
+
+				// bridge.storeSummary signature is (summary, force, artifacts?);
+				// stubBridge forwards positional args without the trailing
+				// undefined, so the recorded call should be (summary, root, true).
+				const lastCall = mockStoreSummary.mock.calls[mockStoreSummary.mock.calls.length - 1];
+				expect(lastCall.length).toBe(3);
+			});
+
+			it("includes entry/session counts and the active provider in the confirm dialog detail", async () => {
+				mockLoadRegenerateContext.mockResolvedValue({
+					entryCount: 7,
+					sessionCount: 1,
+					sources: ["Claude"],
+					humanTurns: 3,
+					plansCount: 0,
+					notesCount: 0,
+					linearCount: 0,
+				});
+				mockLoadConfig.mockResolvedValueOnce({ apiKey: "k", model: "haiku" });
+				showWarningMessage.mockResolvedValueOnce(undefined);
+				const dispatch = await setupPanel();
+
+				dispatch({ command: "regenerateSummary" });
+				await flushPromises();
+
+				const [, opts] = showWarningMessage.mock.calls[0];
+				expect(opts.detail).toContain(
+					"7 transcript entries from 1 session (Claude)",
+				);
+				expect(opts.detail).toContain("OVERWRITTEN");
+				expect(opts.detail).toContain("via Anthropic");
+				expect(opts.detail).not.toContain("PRESERVED");
+			});
+
+			it("uses the zero-transcript copy when no AI sessions were saved", async () => {
+				mockLoadRegenerateContext.mockResolvedValue({
+					entryCount: 0,
+					sessionCount: 0,
+					sources: [],
+					humanTurns: 0,
+					plansCount: 0,
+					notesCount: 0,
+					linearCount: 0,
+				});
+				mockLoadConfig.mockResolvedValueOnce({ apiKey: "k", model: "haiku" });
+				showWarningMessage.mockResolvedValueOnce(undefined);
+				const dispatch = await setupPanel();
+
+				dispatch({ command: "regenerateSummary" });
+				await flushPromises();
+
+				const [, opts] = showWarningMessage.mock.calls[0];
+				expect(opts.detail).toContain("No saved AI conversations");
+				expect(showErrorMessage).not.toHaveBeenCalled();
+			});
+
+			it("posts summaryRegenerateError when the user cancels via the progress notification", async () => {
+				mockLoadRegenerateContext.mockResolvedValue(stubCtx());
+				showWarningMessage.mockResolvedValueOnce("Regenerate");
+				// regenerateSummary never resolves; we trigger the cancel token instead.
+				mockRegenerateSummary.mockReturnValue(new Promise(() => {}));
+				// Override withProgress for this test only: fire the cancellation
+				// token before returning the task's result, so the Promise.race
+				// inside the handler resolves to "cancelled".
+				withProgress.mockImplementationOnce(
+					(_opts: unknown, task: (p: unknown, t: unknown) => Promise<unknown>) => {
+						let cancelCb: (() => void) | null = null;
+						const token = {
+							onCancellationRequested: (cb: () => void) => {
+								cancelCb = cb;
+							},
+						};
+						const taskPromise = task({ report: vi.fn() }, token);
+						// Fire cancel on the next microtask so the handler's
+						// Promise.race sees a "cancelled" winner.
+						queueMicrotask(() => cancelCb?.());
+						return taskPromise;
+					},
+				);
+				const dispatch = await setupPanel();
+
+				dispatch({ command: "regenerateSummary" });
+				await flushPromises();
+
+				expect(mockStoreSummary).not.toHaveBeenCalled();
+				expect(postMessage).toHaveBeenCalledWith(
+					expect.objectContaining({ command: "summaryRegenerateError" }),
+				);
+			});
+
+			it("uses singular 'entry'/'session' copy when count is 1", async () => {
+				mockLoadRegenerateContext.mockResolvedValue({
+					entryCount: 1,
+					sessionCount: 1,
+					sources: ["Claude"],
+					humanTurns: 1,
+					plansCount: 0,
+					notesCount: 0,
+					linearCount: 0,
+				});
+				showWarningMessage.mockResolvedValueOnce(undefined);
+				const dispatch = await setupPanel();
+
+				dispatch({ command: "regenerateSummary" });
+				await flushPromises();
+
+				const [, opts] = showWarningMessage.mock.calls[0];
+				// "1 transcript entry from 1 session" — no plural "s".
+				expect(opts.detail).toContain("1 transcript entry from 1 session");
+				expect(opts.detail).not.toContain("entries");
+				expect(opts.detail).not.toContain("sessions");
+			});
+
+			it("includes only the plans line when plans is the sole attached artifact", async () => {
+				// Covers the false branches of the notesCount / linearCount
+				// conditionals inside buildRegenerateConfirmDetail.
+				mockLoadRegenerateContext.mockResolvedValue({
+					entryCount: 5,
+					sessionCount: 1,
+					sources: ["Claude"],
+					humanTurns: 2,
+					plansCount: 1,
+					notesCount: 0,
+					linearCount: 0,
+				});
+				showWarningMessage.mockResolvedValueOnce(undefined);
+				const dispatch = await setupPanel();
+
+				dispatch({ command: "regenerateSummary" });
+				await flushPromises();
+
+				const [, opts] = showWarningMessage.mock.calls[0];
+				expect(opts.detail).toContain("Archived 1 plan attached");
+				expect(opts.detail).not.toContain("note");
+				expect(opts.detail).not.toContain("Linear");
+			});
+
+			it("includes attached plans/notes/linear lines when any are present", async () => {
+				mockLoadRegenerateContext.mockResolvedValue({
+					entryCount: 5,
+					sessionCount: 2,
+					sources: ["Claude"],
+					humanTurns: 2,
+					plansCount: 2,
+					notesCount: 1,
+					linearCount: 3,
+				});
+				showWarningMessage.mockResolvedValueOnce(undefined);
+				const dispatch = await setupPanel();
+
+				dispatch({ command: "regenerateSummary" });
+				await flushPromises();
+
+				const [, opts] = showWarningMessage.mock.calls[0];
+				expect(opts.detail).toContain("2 plans");
+				expect(opts.detail).toContain("1 note");
+				expect(opts.detail).toContain("3 Linear issues");
+			});
+
+			it("omits the 'via {provider}' suffix when no credentials are configured", async () => {
+				mockLoadRegenerateContext.mockResolvedValue(stubCtx());
+				mockFormatActiveProviderLabel.mockReturnValueOnce(undefined);
+				showWarningMessage.mockResolvedValueOnce(undefined);
+				const dispatch = await setupPanel();
+
+				dispatch({ command: "regenerateSummary" });
+				await flushPromises();
+
+				const [, opts] = showWarningMessage.mock.calls[0];
+				// Bare period ends the line; no provider attribution appended.
+				expect(opts.detail).toMatch(/This typically takes 20–40 seconds\.\s*$/);
+				expect(opts.detail).not.toMatch(/seconds\s+·\s+via\s/);
+			});
+
+			it("posts summaryRegenerateError when storeSummary throws (catchAndShow error path)", async () => {
+				mockLoadRegenerateContext.mockResolvedValue(stubCtx());
+				showWarningMessage.mockResolvedValueOnce("Regenerate");
+				mockRegenerateSummary.mockResolvedValue({
+					updated: stubUpdated(),
+					result: {} as never,
+				});
+				mockStoreSummary.mockRejectedValueOnce(new Error("disk full"));
+				const dispatch = await setupPanel();
+
+				dispatch({ command: "regenerateSummary" });
+				await flushPromises();
+
+				expect(showErrorMessage).toHaveBeenCalledWith(
+					expect.stringContaining("Regenerate failed"),
+				);
+				expect(postMessage).toHaveBeenCalledWith(
+					expect.objectContaining({ command: "summaryRegenerateError" }),
+				);
+			});
+
+			it("shows 'Unknown' source label when ctx.sources is empty but entryCount > 0", async () => {
+				mockLoadRegenerateContext.mockResolvedValue({
+					entryCount: 2,
+					sessionCount: 1,
+					sources: [],
+					humanTurns: 1,
+					plansCount: 0,
+					notesCount: 0,
+					linearCount: 0,
+				});
+				showWarningMessage.mockResolvedValueOnce(undefined);
+				const dispatch = await setupPanel();
+
+				dispatch({ command: "regenerateSummary" });
+				await flushPromises();
+
+				const [, opts] = showWarningMessage.mock.calls[0];
+				expect(opts.detail).toContain("(Unknown)");
+			});
+
+			it("does nothing when a regenerate is already in flight (double-click guard)", async () => {
+				mockLoadRegenerateContext.mockResolvedValue(stubCtx());
+				// Only ONE mockResolvedValueOnce — the second dispatch must
+				// short-circuit BEFORE reaching showWarningMessage. Two onces
+				// would leave a stale "Regenerate" in the queue for later tests.
+				showWarningMessage.mockResolvedValueOnce("Regenerate");
+				// Never-resolving promise → first call locks the in-flight flag.
+				mockRegenerateSummary.mockReturnValue(new Promise(() => {}));
+				const dispatch = await setupPanel();
+
+				dispatch({ command: "regenerateSummary" });
+				dispatch({ command: "regenerateSummary" });
+				await flushPromises();
+
+				expect(mockRegenerateSummary).toHaveBeenCalledTimes(1);
 			});
 		});
 
@@ -7770,6 +8122,101 @@ describe("SummaryWebviewPanel", () => {
 			await flushPromises();
 
 			expectStaleModalShown("generate recap");
+			expect(mockStoreSummary).not.toHaveBeenCalled();
+		});
+
+		it("blocks regenerate summary BEFORE the confirm dialog", async () => {
+			(
+				stubBridge.getSummaryIndexEntryMap as ReturnType<typeof vi.fn>
+			).mockResolvedValue(
+				buildChainEntryMap([
+					{ hash: "abc123", parent: "rootnew0" },
+					{ hash: "rootnew0", parent: null },
+				]),
+			);
+			const dispatch = await setupCommit("abc123");
+
+			dispatch({ command: "regenerateSummary" });
+			await flushPromises();
+
+			expectStaleModalShown("regenerate summary");
+			// Confirm dialog ("Regenerate this summary?") never shown.
+			const confirmCalls = showWarningMessage.mock.calls.filter((c) =>
+				typeof c[0] === "string" ? c[0] === "Regenerate this summary?" : false,
+			);
+			expect(confirmCalls).toHaveLength(0);
+			expect(mockStoreSummary).not.toHaveBeenCalled();
+		});
+
+		it("blocks regenerate summary when commit goes stale DURING the LLM call", async () => {
+			// First two guards (entry + post-modal) → not stale; the third
+			// re-check (after the LLM returns) sees a stale chain and aborts
+			// before storeSummary. summaryRegenerateError is posted.
+			(stubBridge.getSummaryIndexEntryMap as ReturnType<typeof vi.fn>)
+				.mockResolvedValueOnce(new Map())
+				.mockResolvedValueOnce(new Map())
+				.mockResolvedValueOnce(
+					buildChainEntryMap([
+						{ hash: "abc123", parent: "rootnew0" },
+						{ hash: "rootnew0", parent: null },
+					]),
+				);
+			mockLoadRegenerateContext.mockResolvedValue({
+				entryCount: 1,
+				sessionCount: 1,
+				sources: ["Claude"],
+				humanTurns: 1,
+				plansCount: 0,
+				notesCount: 0,
+				linearCount: 0,
+			});
+			showWarningMessage.mockResolvedValueOnce("Regenerate");
+			mockRegenerateSummary.mockResolvedValue({
+				updated: makeSummary({ commitHash: "abc123", recap: "fresh" }),
+				result: {} as never,
+			});
+			const dispatch = await setupCommit("abc123");
+
+			dispatch({ command: "regenerateSummary" });
+			await flushPromises();
+
+			expectStaleModalShown("regenerate summary");
+			expect(mockRegenerateSummary).toHaveBeenCalled();
+			expect(mockStoreSummary).not.toHaveBeenCalled();
+			expect(postMessage).toHaveBeenCalledWith(
+				expect.objectContaining({ command: "summaryRegenerateError" }),
+			);
+		});
+
+		it("blocks regenerate summary when commit goes stale BETWEEN entry guard and confirm acceptance", async () => {
+			// First entry-guard call → not stale. Modal-accept guard → stale.
+			// Confirms the post-modal race-window re-check fires; storeSummary
+			// never runs because the LLM step is short-circuited.
+			(stubBridge.getSummaryIndexEntryMap as ReturnType<typeof vi.fn>)
+				.mockResolvedValueOnce(new Map())
+				.mockResolvedValueOnce(
+					buildChainEntryMap([
+						{ hash: "abc123", parent: "rootnew0" },
+						{ hash: "rootnew0", parent: null },
+					]),
+				);
+			mockLoadRegenerateContext.mockResolvedValue({
+				entryCount: 1,
+				sessionCount: 1,
+				sources: ["Claude"],
+				humanTurns: 1,
+				plansCount: 0,
+				notesCount: 0,
+				linearCount: 0,
+			});
+			showWarningMessage.mockResolvedValueOnce("Regenerate");
+			const dispatch = await setupCommit("abc123");
+
+			dispatch({ command: "regenerateSummary" });
+			await flushPromises();
+
+			expectStaleModalShown("regenerate summary");
+			expect(mockRegenerateSummary).not.toHaveBeenCalled();
 			expect(mockStoreSummary).not.toHaveBeenCalled();
 		});
 

--- a/vscode/src/views/SummaryWebviewPanel.ts
+++ b/vscode/src/views/SummaryWebviewPanel.ts
@@ -100,11 +100,7 @@ import {
 	collectSortedTopics,
 	formatActiveProviderLabel,
 } from "./SummaryUtils.js";
-import {
-	loadRegenerateContext,
-	type RegenerateContext,
-} from "../../../cli/src/core/RegenerateContext.js";
-import { regenerateSummary } from "../../../cli/src/core/Regenerator.js";
+import type { RegenerateContext } from "../../../cli/src/core/RegenerateContext.js";
 import type { LlmConfig } from "../../../cli/src/Types.js";
 
 /** Memory field updates sent from the webview edit form. */
@@ -210,6 +206,40 @@ const FOREIGN_SAFE_COMMANDS: ReadonlySet<WebviewMessage["command"]> = new Set([
 
 function isForeignSafeCommand(command: WebviewMessage["command"]): boolean {
 	return FOREIGN_SAFE_COMMANDS.has(command);
+}
+
+/**
+ * Read-only whitelist used by the regenerate-in-flight dispatch guard. While
+ * regenerateSummary is awaiting the LLM, any other write to the orphan
+ * branch (push, edit*, plan/note saves, generateRecap, generateE2eTest…)
+ * would race with the eventual `storeSummary(outcome.updated, true)` at the
+ * end of regenerate — whichever finished last would overwrite the other.
+ *
+ * Default-deny: only commands that don't touch the summary (read-only
+ * stats, navigation, clipboard) are allowed through. The webview-side
+ * `.regenerating-readonly` CSS already hides the affordances for everything
+ * else; this is the second-layer guard against any postMessage that slips
+ * past (e.g. from a queued event before the readonly mode took effect).
+ */
+const REGENERATE_SAFE_COMMANDS: ReadonlySet<WebviewMessage["command"]> = new Set([
+	"copyMarkdown",
+	"downloadMarkdown",
+	"checkPrStatus",
+	"openRewrittenCommit",
+	"loadTranscriptStats",
+	"loadAllTranscripts",
+	"loadPlanContent",
+	"loadNoteContent",
+	"previewPlan",
+	"previewNote",
+	"openLinearIssue",
+	"openLinearIssueMarkdown",
+	// regenerateSummary itself is denied while one is in flight; the
+	// handler's own `regenerateInProgress` guard short-circuits a re-entry.
+]);
+
+function isRegenerateSafeCommand(command: WebviewMessage["command"]): boolean {
+	return REGENERATE_SAFE_COMMANDS.has(command);
 }
 
 // Single source of truth for Create/Update PR body assembly. Branch-first
@@ -419,6 +449,21 @@ export class SummaryWebviewPanel {
 		if (this.foreignRepoName) {
 			if (!isForeignSafeCommand(message.command)) {
 				this.notifyForeignDenied(message.command);
+				return;
+			}
+		}
+		// Regenerate-in-flight guard. The webview's regenerating-readonly
+		// mode already hides the affordances for every command outside this
+		// allow-list; this is the second layer protecting against any
+		// postMessage that slipped past (queued / late / programmatic). A
+		// write while regenerate's LLM call is awaiting would be silently
+		// clobbered by the final `storeSummary(outcome.updated, true)` at
+		// the end of the regenerate path.
+		if (this.regenerateInProgress) {
+			if (!isRegenerateSafeCommand(message.command)) {
+				// Silent drop — the webview's regenerating-readonly chrome
+				// already hides the affordance; an in-flight late postMessage
+				// from a queued event isn't worth a user-visible notification.
 				return;
 			}
 		}
@@ -1712,6 +1757,26 @@ export class SummaryWebviewPanel {
 		const summary = this.currentSummary;
 		if (!summary) return;
 		if (this.regenerateInProgress) return;
+		// Reject if a Push to Jolli is already mid-flight. Push writes back
+		// jolliDocId / jolliDocUrl on completion (handlePush:1428); regenerate
+		// captures the summary snapshot NOW and writes back at the end of its
+		// LLM call. If push completes between the two writes, regenerate's
+		// final storeSummary clobbers the jolliDocId — the next push would
+		// then create a duplicate article instead of updating in place.
+		// (The reverse direction — push during regenerate — is already
+		// blocked by the regenerate-in-flight dispatchWebviewMessage guard.)
+		//
+		// INVARIANT: this panel-local check assumes pushes always originate
+		// from a webview panel (via handlePush) — the only producer of
+		// pushInProgress today. If JolliPushService is ever exposed to the
+		// CLI or a scheduled task, this check becomes blind to those callers;
+		// replace with a bridge-level write lock at that point.
+		if (this.pushInProgress) {
+			vscode.window.showInformationMessage(
+				"A push to Jolli is in progress. Wait for it to finish before regenerating.",
+			);
+			return;
+		}
 		// Set the flag SYNCHRONOUSLY (before any await) so a double-click can't
 		// race past the guard while the first invocation is suspended awaiting
 		// ensureCommitNotRewritten. The flag stays set across the confirm
@@ -1722,7 +1787,11 @@ export class SummaryWebviewPanel {
 
 			// loadRegenerateContext always resolves; zero-valued ctx for legacy
 			// summaries with no stored transcript, the confirm dialog adjusts copy.
-			const ctx = await loadRegenerateContext(summary, this.workspaceRoot);
+			// Route through the Bridge so folder-only Memory Bank users hit
+			// FolderStorage rather than the OrphanBranchStorage fallback in
+			// resolveStorage. The bare CLI helper does not know about the
+			// extension's active storage backend.
+			const ctx = await this.bridge.loadRegenerateContext(summary);
 
 			// Load config BEFORE the confirm dialog so the dialog can show the
 			// provider label the next call will actually use. Same config feeds
@@ -1752,12 +1821,23 @@ export class SummaryWebviewPanel {
 					cancellable: true,
 				},
 				async (_progress, token) => {
-					// AbortController wiring: if Summarizer.callLlm doesn't accept
-					// a signal, we still honor cancel by dropping the LLM result.
+					// AbortController wiring: Summarizer.callLlm / LlmClient don't
+					// accept an AbortSignal today, so user-cancel only drops the
+					// LLM result locally — the in-flight HTTP request keeps running
+					// to completion in the background and we pay for those tokens.
+					// TODO: when Summarizer.SummarizeParams gains a `signal?:
+					// AbortSignal` field and forwards it to the Anthropic SDK's
+					// `messages.create({ signal })` (and combines with the proxy
+					// fetch's existing timeout signal), thread `token` through
+					// `this.bridge.regenerateSummary(summary, config, signal)` so
+					// cancel actually aborts the request.
 					const cancelled = new Promise<"cancelled">((resolve) => {
 						token.onCancellationRequested(() => resolve("cancelled"));
 					});
-					const work = regenerateSummary(summary, this.workspaceRoot, config);
+					// Route through the Bridge so the read path (transcripts,
+					// archived plans/notes/linear) hits the active storage
+					// backend rather than the OrphanBranchStorage fallback.
+					const work = this.bridge.regenerateSummary(summary, config);
 					const outcome = await Promise.race([work, cancelled]);
 					if (outcome === "cancelled") {
 						this.panel.webview.postMessage({

--- a/vscode/src/views/SummaryWebviewPanel.ts
+++ b/vscode/src/views/SummaryWebviewPanel.ts
@@ -84,6 +84,7 @@ import {
 	buildE2eTestSection,
 	buildHtml,
 	buildRecapSection,
+	buildTopicsSection,
 	renderE2eScenario,
 	renderTopic,
 } from "./SummaryHtmlBuilder.js";
@@ -97,7 +98,14 @@ import {
 	buildPlanPushTitle,
 	buildPushTitle,
 	collectSortedTopics,
+	formatActiveProviderLabel,
 } from "./SummaryUtils.js";
+import {
+	loadRegenerateContext,
+	type RegenerateContext,
+} from "../../../cli/src/core/RegenerateContext.js";
+import { regenerateSummary } from "../../../cli/src/core/Regenerator.js";
+import type { LlmConfig } from "../../../cli/src/Types.js";
 
 /** Memory field updates sent from the webview edit form. */
 interface TopicUpdates {
@@ -160,6 +168,7 @@ type WebviewMessage =
 	| { command: "deleteAllTranscripts" }
 	| { command: "editRecap"; recap: string }
 	| { command: "generateRecap" }
+	| { command: "regenerateSummary" }
 	| { command: "openRewrittenCommit"; hash: string };
 
 /** Entry data sent back from the webview on Save All. */
@@ -457,6 +466,15 @@ export class SummaryWebviewPanel {
 					"Recap generation failed",
 					{
 						command: "recapUpdateError",
+					},
+				);
+				break;
+			case "regenerateSummary":
+				this.catchAndShow(
+					this.handleRegenerateSummary(),
+					"Regenerate failed",
+					{
+						command: "summaryRegenerateError",
 					},
 				);
 				break;
@@ -1678,6 +1696,141 @@ export class SummaryWebviewPanel {
 			command: "recapUpdated",
 			html: buildRecapSection(updated.recap),
 		});
+	}
+
+	private regenerateInProgress = false;
+
+	/**
+	 * End-to-end re-run of the summary LLM. Replaces topics + recap (plus
+	 * supporting fields like diffStats, transcriptEntries, llm); preserves
+	 * ticketId, e2eTestGuide, plans, notes, linearIssues, children, and all
+	 * push metadata. See cli/src/core/Regenerator.ts for the isolation
+	 * contract (no cursor advance, no archive re-write, no queue side
+	 * effects).
+	 */
+	private async handleRegenerateSummary(): Promise<void> {
+		const summary = this.currentSummary;
+		if (!summary) return;
+		if (this.regenerateInProgress) return;
+		// Set the flag SYNCHRONOUSLY (before any await) so a double-click can't
+		// race past the guard while the first invocation is suspended awaiting
+		// ensureCommitNotRewritten. The flag stays set across the confirm
+		// dialog too — if the user cancels, finally clears it.
+		this.regenerateInProgress = true;
+		try {
+			if (!(await this.ensureCommitNotRewritten("regenerate summary"))) return;
+
+			// loadRegenerateContext always resolves; zero-valued ctx for legacy
+			// summaries with no stored transcript, the confirm dialog adjusts copy.
+			const ctx = await loadRegenerateContext(summary, this.workspaceRoot);
+
+			// Load config BEFORE the confirm dialog so the dialog can show the
+			// provider label the next call will actually use. Same config feeds
+			// the regenerate call below.
+			const config = await loadGlobalConfig();
+
+			const detail = this.buildRegenerateConfirmDetail(
+				ctx,
+				config,
+				summary.commitHash,
+			);
+			const choice = await vscode.window.showWarningMessage(
+				"Regenerate this summary?",
+				{ modal: true, detail },
+				"Regenerate",
+			);
+			if (choice !== "Regenerate") return;
+
+			if (!(await this.ensureCommitNotRewritten("regenerate summary"))) return;
+
+			this.panel.webview.postMessage({ command: "summaryRegenerating" });
+
+			await vscode.window.withProgress(
+				{
+					location: vscode.ProgressLocation.Notification,
+					title: "Regenerating summary…",
+					cancellable: true,
+				},
+				async (_progress, token) => {
+					// AbortController wiring: if Summarizer.callLlm doesn't accept
+					// a signal, we still honor cancel by dropping the LLM result.
+					const cancelled = new Promise<"cancelled">((resolve) => {
+						token.onCancellationRequested(() => resolve("cancelled"));
+					});
+					const work = regenerateSummary(summary, this.workspaceRoot, config);
+					const outcome = await Promise.race([work, cancelled]);
+					if (outcome === "cancelled") {
+						this.panel.webview.postMessage({
+							command: "summaryRegenerateError",
+						});
+						return;
+					}
+
+					// Race-window re-check: amend can land during the 30 s LLM call.
+					if (!(await this.ensureCommitNotRewritten("regenerate summary"))) {
+						this.panel.webview.postMessage({
+							command: "summaryRegenerateError",
+						});
+						return;
+					}
+
+					await this.bridge.storeSummary(outcome.updated, true);
+					this.currentSummary = outcome.updated;
+					this.panel.webview.postMessage({
+						command: "summaryRegenerated",
+						topicsHtml: buildTopicsSection(outcome.updated),
+						recapHtml: buildRecapSection(outcome.updated.recap),
+					});
+					vscode.window.showInformationMessage("Summary regenerated.");
+				},
+			);
+		} finally {
+			this.regenerateInProgress = false;
+		}
+	}
+
+	private buildRegenerateConfirmDetail(
+		ctx: RegenerateContext,
+		config: LlmConfig,
+		commitHash: string,
+	): string {
+		const s = (n: number): string => (n === 1 ? "" : "s");
+		const sources = ctx.sources.length > 0 ? ctx.sources.join(", ") : "Unknown";
+		const shortHash = commitHash.substring(0, 8);
+		const provider = formatActiveProviderLabel(config);
+
+		const lines: string[] = [];
+		lines.push("The LLM will be re-run using:");
+		if (ctx.entryCount === 0) {
+			lines.push(
+				"  • No saved AI conversations for this commit — regenerating from the diff and attached metadata alone",
+			);
+		} else {
+			lines.push(
+				`  • ${ctx.entryCount} transcript ${ctx.entryCount === 1 ? "entry" : "entries"} from ${ctx.sessionCount} session${s(ctx.sessionCount)} (${sources})`,
+			);
+		}
+		lines.push(`  • The commit diff (reconstructed via \`git show ${shortHash}\`)`);
+		if (ctx.plansCount + ctx.notesCount + ctx.linearCount > 0) {
+			const parts: string[] = [];
+			if (ctx.plansCount > 0) parts.push(`${ctx.plansCount} plan${s(ctx.plansCount)}`);
+			if (ctx.notesCount > 0) parts.push(`${ctx.notesCount} note${s(ctx.notesCount)}`);
+			if (ctx.linearCount > 0) {
+				parts.push(`${ctx.linearCount} Linear issue${s(ctx.linearCount)}`);
+			}
+			lines.push(`  • Archived ${parts.join(", ")} attached to this commit`);
+		}
+		lines.push("");
+		lines.push("These fields will be OVERWRITTEN:");
+		lines.push("  • Topics — including any you have edited");
+		lines.push("  • Recap — including any you have edited");
+		lines.push("");
+		lines.push(
+			provider
+				? `This typically takes 20–40 seconds · via ${provider}`
+				: "This typically takes 20–40 seconds.",
+		);
+		return lines.join("\n");
 	}
 
 	/** Handles deleting a memory at the given global index (with confirmation). */

--- a/vscode/src/views/TranscriptEntryRenderer.ts
+++ b/vscode/src/views/TranscriptEntryRenderer.ts
@@ -1,3 +1,5 @@
+import { TRANSCRIPT_SOURCE_LABELS } from "../../../cli/src/core/TranscriptSourceLabel.js";
+
 /**
  * Shared client-side renderer for transcript entries.
  *
@@ -14,6 +16,10 @@
  * fields that originate from extension-host data are passed through
  * 'esc()' before interpolation, exactly as before.
  *
+ * getSourceLabel BODY is generated from the TS-side TRANSCRIPT_SOURCE_LABELS
+ * map so the extension host and the webview always agree on labels (the
+ * extension uses the TS helper directly; this file emits the equivalent JS).
+ *
  * RUNTIME CONTRACT: the surrounding script must provide these symbols in
  * the enclosing scope (they are NOT params, to keep the call-site
  * signature unchanged):
@@ -28,14 +34,14 @@
  * in a comment) would prematurely terminate that literal.
  */
 export function buildTranscriptEntriesScript(): string {
+	// Generate the `if (source === 'X') return 'Y';` lines for every non-Claude
+	// entry from the shared TS map. Claude is the fallback (return at the end).
+	const labelBranches = Object.entries(TRANSCRIPT_SOURCE_LABELS)
+		.filter(([key]) => key !== "claude")
+		.map(([key, label]) => `    if (source === '${key}') return '${label}';`);
 	return [
 		"  function getSourceLabel(source) {",
-		"    if (source === 'codex') return 'Codex';",
-		"    if (source === 'gemini') return 'Gemini';",
-		"    if (source === 'opencode') return 'OpenCode';",
-		"    if (source === 'cursor') return 'Cursor';",
-		"    if (source === 'copilot') return 'Copilot';",
-		"    if (source === 'copilot-chat') return 'Copilot Chat';",
+		...labelBranches,
 		"    return 'Claude';",
 		"  }",
 		"",


### PR DESCRIPTION
<!-- jollimemory-summary-start -->
## Commits in this PR (3)

1. Add regenerate-summary feature with UI, handler, and tests (`5bbc4a9`)
2. Harden regenerate with v4 normalization, full tree context, and fixes (`3581baf`)
3. Fix regenerate reliability, prompt safety, and code hygiene (`b0ed222`)

## Quick recap (3)

### Commit 1 of 3: Add regenerate-summary feature with UI, handler, and tests (`5bbc4a9`)

Users can now regenerate an existing commit summary directly from the summary panel. A new Regenerate button appears in the Conversations card — present whether or not any conversation transcripts have been saved for that commit — and clicking it opens a modal confirmation dialog that shows exactly how many transcript entries and sessions will be used, which fields will be overwritten, and which AI provider will handle the call. After confirming, a cancellable progress notification appears while the AI reruns, and the topics and recap sections update in place once the call completes. Stable user data — the linked ticket identifier and any end-to-end test guides — is carried forward unchanged into the regenerated result, and the original transcripts, plans, notes, and Linear issues attached to the commit are left untouched.

The regeneration path was built with strict isolation: a new core function reassembles all original inputs entirely from the orphan branch and produces a single updated summary object, leaving all other stored state for the caller to persist. Prompt blocks for attached plans, notes, and Linear issues are rebuilt directly from orphan-branch archive content, and commits from older summary versions are handled transparently. The confirmation dialog is populated by a dedicated context loader that counts transcript entries, sessions, and unique AI sources, returning zero-valued counts when no transcript exists so the dialog can adjust its copy without any special-case branching.

Two bugs discovered during integration were also fixed. After a summary was regenerated, the Regenerate button was accumulating extra listeners on each cycle, causing multiple firings per click. Separately, the collapsible topic headers stopped responding to clicks entirely after a refresh, because the new DOM nodes created during the update were never wired up with their toggle listeners. Both are now resolved: the button's listener is preserved across refreshes, and topic headers correctly expand and collapse again after every regeneration.

The friendly display names for AI sources — Claude, Codex, Cursor, and others — were extracted into a single shared location that both the extension host and the in-page transcript renderer now draw from. Adding support for a new AI source in the future requires a change in exactly one place, and both surfaces update together automatically.

### Commit 2 of 3: Harden regenerate with v4 normalization, full tree context, and fixes (`3581baf`)

The regenerate feature received a substantial correctness overhaul. Previously, legacy summary data was handled through a series of piecemeal steps spread across multiple files, each with its own gaps. A single normalization step now runs at the very start of the regenerate flow, collapsing the entire summary tree into the current unified layout before any other work begins. Attachments from all descendants — plans, notes, linked tickets, test scenarios, and article publish identifiers — are unioned to the root, orphaned document IDs are collected and deduplicated across the full tree, and descendants are stripped of their own copies. The language model, the prompt builder, and the confirm dialog all operate on this clean structure. The migration persists to disk only when the user confirms regeneration, leaving cancelled sessions without side effects.

The AI conversation history fed to the language model during regeneration now reflects the complete history across every commit in a summary tree. For summaries covering squashed, amended, or rebased commits, conversations were previously spread across multiple commits but only the root was consulted. The confirm dialog could report zero conversations even when the user had a full history visible in the All Conversations panel. Both the conversation count shown to the user and the actual input to the AI now reflect the complete history.

Two additional correctness fixes were made to the regenerate path. The confirmation dialog told users their recap would be replaced, but the old recap survived unchanged whenever the language model returned no content; regenerated summaries now always overwrite the recap field, writing an empty result explicitly rather than leaving the previous value in place. After a successful regenerate, the Collapse All button in the topics panel stopped responding to clicks; the button is now re-wired each time the topics section is replaced, its label is synchronized with the actual expanded state of the new topics, and a guard prevents the regenerate button itself from accumulating duplicate listeners across repeated regenerations.

The test suite was substantially hardened alongside these fixes. The core stripping logic is now exercised through the real production function rather than a hand-written stub, a three-level fixture proves that stale data is removed all the way down to grandchild nodes, and dedicated tests verify that the normalization helper is a pure function that never mutates its input and safely passes through any format version beyond the current one.

### Commit 3 of 3: Fix regenerate reliability, prompt safety, and code hygiene (`b0ed222`)

Several reliability gaps in the regenerate-summary feature were closed in this batch of work. The most visible change is that the entire panel now locks into a read-only state while regeneration is running: every action button disappears and a banner with a spinning icon appears at the top of the page, making it clear that other actions are temporarily unavailable. This replaced an earlier approach that only disabled buttons in two specific sections, leaving push, end-to-end test generation, and other write actions still reachable during the 20–40 second window.

Two race conditions that could silently corrupt saved data were also fixed. If a push to the cloud was already in progress when the user started a regeneration, the regeneration would finish later and erase the cloud document identifier the push had just written — causing a duplicate article on the next push. That scenario is now blocked at the point where regeneration starts. The reverse direction, a push arriving while regeneration is active, was already covered by the new page-wide lock.

Users who store their memory bank in a local folder rather than the default git-based storage were seeing zero conversations in the regeneration confirmation dialog, and the regenerated summary was produced without any of their archived context. All data reads during regeneration now go through whichever storage backend the user has configured, so folder-mode users get the same experience as everyone else.

Finally, the regenerate prompt now applies the same per-item and total size limits that the first-run summarization path has always used. Previously, a single large plan or linked issue could be embedded in full, inflating the prompt to an extreme size. Items are now capped individually and selected newest-first, so the most recently updated context fits within the budget and the oldest items are dropped when space runs out.

## Topics (22)
<details>
<summary><strong>01 · [5bbc4a9] Fix duplicate Regenerate button listeners and broken topic header toggles after refresh</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

After a summary was regenerated in the panel, clicking the Regenerate button a second time would fire the action multiple times per click, and the collapsible topic headers stopped responding to clicks entirely.

**💡 Decisions Behind the Code**

- **Scope re-attachment strictly to replaced DOM**: The regeneration flow replaces only the topics and recap sections. Limiting re-attachment to those nodes eliminates the duplicate-listener problem without requiring any listener-deduplication logic, keeping the code simpler and the behavior predictable.
- **Idempotent toggle-header attach over restructured initialization**: Rather than restructuring the page-load initialization flow, re-running the attach call on new header nodes after each replacement was the minimal safe fix. The idempotency flag prevents any risk of double-binding on nodes that were not replaced.

**✅ What Was Implemented**

- Removed the redundant re-attachment call for the Regenerate button handler from the post-regeneration re-bind block in `vscode/src/views/SummaryScriptBuilder.ts`. The button lives outside the DOM sections replaced during a refresh, so its original listener remained intact; re-attaching it on every cycle was stacking duplicate handlers.
- Added a `querySelectorAll('.toggle-header').forEach(attachToggleHeader)` call after the topics section is replaced in `vscode/src/views/SummaryScriptBuilder.ts`. The `attachToggleHeader` function is idempotent via an internal flag, so calling it on new nodes is safe and will not double-bind headers that survived the replacement.

**📁 FILES**
- `vscode/src/views/SummaryScriptBuilder.ts`

</blockquote>
</details>
<details>
<summary><strong>02 · [5bbc4a9] Regenerate Summary command with confirm dialog, progress notification, and full handler</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Users needed a way to re-run the AI summarization on an existing commit — for example after editing transcripts or when the original summary was unsatisfactory — without leaving the summary panel.

**💡 Decisions Behind the Code**

- **Synchronous double-click guard before first await**: Setting the in-flight flag before the first `await` rather than after the confirm dialog resolves closes the window where a second click could pass the guard while the first invocation was suspended. The trade-off is that the flag also blocks a second click during the confirm dialog itself, which is acceptable — showing two simultaneous confirm dialogs would be confusing.
- **Artifacts excluded from the store call**: Passing artifacts to the store would overwrite orphan-branch transcripts and plan-progress files written at first-run time on every regenerate, destroying data the user may want to keep. The regenerate path is intentionally scoped to LLM-derived fields only.
- **Provider label resolved from live config, not from the existing summary**: The confirm dialog shows the provider the next call will use (from the current config) rather than the provider recorded in the existing summary. This gives the user accurate information about what is about to happen, especially when they have changed their API key or switched providers since the original summary was generated.

**✅ What Was Implemented**

- Added `handleRegenerateSummary` in `vscode/src/views/SummaryWebviewPanel.ts`, a full end-to-end handler that loads the regeneration context, presents a modal confirmation dialog with entry/session counts and active provider attribution, runs the LLM call under a cancellable progress notification, persists the updated summary, and posts a partial re-render message back to the webview. A synchronous double-click guard (`regenerateInProgress` flag set before the first `await`) prevents concurrent invocations.
- Added `buildRegenerateConfirmDetail` in `vscode/src/views/SummaryWebviewPanel.ts` to compose the multi-line confirmation dialog body. It surfaces transcript entry and session counts, the reconstructed diff reference, any attached plans/notes/Linear issues, the fields that will be overwritten, and the active provider label — with a zero-transcript fallback copy when no AI sessions were saved.
- Added `formatActiveProviderLabel` in `vscode/src/views/SummaryUtils.ts`, a helper that maps the current LLM configuration to a human-readable provider string ("Anthropic", "Anthropic (env)", "Jolli proxy"), returning `undefined` when no credentials are configured so callers can omit the "via …" clause rather than promise a provider that would fail.
- The regenerated summary is persisted without passing artifacts to `storeSummary`, keeping the regeneration path scoped to LLM-derived fields only and leaving orphan-branch transcripts and plan-progress files untouched.

**📁 FILES**
- `vscode/src/views/SummaryWebviewPanel.ts`
- `vscode/src/views/SummaryUtils.ts`

</blockquote>
</details>
<details>
<summary><strong>03 · [5bbc4a9] Regenerate button wired to freeze, re-render, and restore webview state</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The Regenerate Summary button existed in the UI but had no click handler or response logic — clicking it did nothing, and there was no way to show progress or update the displayed summary after a regeneration completed.

**💡 Decisions Behind the Code**

- **Freeze-and-tag over a blanket disable**: Disabling all controls during regeneration without tracking prior state would have re-enabled legitimately-disabled buttons on error recovery. Tagging each control with its pre-freeze state keeps the error path safe and avoids a secondary bug where controls flip to an incorrect enabled state.
- **Re-attach handlers after DOM replacement, scoped to replaced nodes only**: Replacing section HTML destroys old event listeners along with old nodes. Rather than delegating all events to a stable ancestor, the success path explicitly re-calls each attach function on the new nodes — consistent with the existing handler pattern and keeping the change self-contained.
- **Guard against concurrent actions and unsaved edits at click time**: Blocking the click when another action is generating or when edits are in progress prevents a race where a long LLM call silently overwrites work the user has not yet saved. The check is placed client-side for immediate feedback, with the extension host as the authoritative gate.

**✅ What Was Implemented**

- Added `attachRegenerateSummaryHandler()` in `vscode/src/views/SummaryScriptBuilder.ts`, which listens for clicks on the Regenerate button, guards against unsaved edits and concurrent in-flight actions, and posts a `regenerateSummary` message to the extension host.
- Added three message-listener branches (`summaryRegenerating`, `summaryRegenerated`, `summaryRegenerateError`) that drive the button's spinning/disabled state and call `freezeSummarySections()` / `thawSummarySections()` / `replaceSection()` helpers to swap in fresh HTML or restore the previous state on error.
- Added `freezeSummarySections()` and `thawSummarySections()` helpers that tag each control with a `data-was-disabled` marker before disabling it, so the error path can restore only the controls that were originally enabled rather than blindly re-enabling everything.
- On successful regeneration, handlers for elements inside the replaced sections (edit/generate recap, topic edit/delete) are re-bound; the Regenerate button's handler is not re-attached since its section is never replaced.

**📁 FILES**
- `vscode/src/views/SummaryScriptBuilder.ts`
- `vscode/src/views/SummaryCssBuilder.ts`

</blockquote>
</details>
<details>
<summary><strong>04 · [5bbc4a9] Extract topics section into standalone builder and add Regenerate button to Conversations card</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The topics region inside the full summary page had no way to be regenerated independently, and the Conversations card had no action to trigger a fresh end-to-end summary run from within the panel.

**💡 Decisions Behind the Code**

- **Byte-equality as the correctness contract**: A test asserts the standalone function's output is literally contained within the full-page output, guaranteeing the two render paths can never silently diverge. Any future edit to one that doesn't update the other immediately fails the test suite.
- **ID on the section wrapper for targeted replacement**: Adding a stable identifier to the outermost element of the extracted section was chosen as the mechanism for targeted DOM replacement in the webview, avoiding the need for a more complex selector or data attribute scheme and matching the pattern already used by other replaceable regions.
- **Button in both branches, not just the populated one**: Placing the Regenerate button in the empty-transcript branch as well ensures users who have no saved transcripts can still trigger a re-run. Restricting it to the populated branch would have silently blocked re-generation for those users with no clear explanation.
- **Wrapper span for multiple actions**: The existing "Manage" button was wrapped together with the new Regenerate button in a `conversations-actions` span rather than adding the new button as a sibling at the same level, keeping the header layout stable and providing a single styling hook for the action group.

**✅ What Was Implemented**

- Extracted the topics rendering logic from the full page builder in `vscode/src/views/SummaryHtmlBuilder.ts` into a new exported function `buildTopicsSection`. The wrapping element now carries `id="topicsSection"` so the webview's region-replacement logic can target it by ID. The full page builder delegates to this function, keeping the two render paths byte-equal by construction.
- Added three new tests covering: presence of the section ID, byte-equality between the standalone function's output and the corresponding region inside the full page, and correct empty-state rendering when no topics exist.
- Added a "Regenerate" button (`id="regenerateSummaryBtn"`) to both branches of `buildAllConversationsSection` in `vscode/src/views/SummaryHtmlBuilder.ts`. In the populated branch it sits alongside the existing "Manage" button inside a new `conversations-actions` wrapper span; in the empty branch it is the sole action. Tests verify the button is present in both branches without a `disabled` attribute.

**📁 FILES**
- `vscode/src/views/SummaryHtmlBuilder.ts`

</blockquote>
</details>
<details>
<summary><strong>05 · [5bbc4a9] Add full summary regeneration core function with field preservation and isolation</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The team needed a way to re-run the AI summarization pipeline against a commit that had already been summarized, without touching any queues, locks, or stored artifacts beyond the final summary itself.

**💡 Decisions Behind the Code**

- **Bypass existing prompt-block formatters**: The existing formatters read content via disk file paths that may be stale or absent during a regenerate run. Writing simplified XML builders that read directly from the orphan-branch archive keeps the regeneration path self-contained and avoids a fragile dependency on the local working tree. The tag shape is preserved so the summarization prompt template collapses the blocks identically.
- **Preserve ticketId and e2eTestGuide unconditionally**: Both fields are stable user-initiated artifacts. The LLM re-run may not have visibility into the original ticket identifier and could silently drop or alter it; the end-to-end test guide is a secondary artifact the user can regenerate independently. Locking these fields in the merge step prevents silent data loss without requiring any special LLM instruction.
- **Zero side effects beyond the returned summary object**: The function deliberately avoids touching cursors, locks, queue entries, or any registry. All persistence is left to the caller. This isolation keeps the regeneration path safe to call from any context and makes unit tests straightforward — no filesystem or git state needs to be set up beyond the mocked helpers.

**✅ What Was Implemented**

- Created `cli/src/core/Regenerator.ts` with a `regenerateSummary` function that orchestrates the full re-run: reads the stored transcript from the orphan branch, reconstructs the git diff, rebuilds prompt blocks for any attached plans, notes, and Linear issues from their orphan-branch archives, then calls `generateSummary` with all inputs assembled. The result is merged back onto the original summary, replacing topics, recap, LLM metadata, and timestamps while preserving `ticketId`, `e2eTestGuide`, and all other stable fields.
- Three private helpers (`rebuildLinearBlock`, `rebuildPlansBlock`, `rebuildNotesBlock`) build simplified XML prompt blocks directly from orphan-branch archive content rather than reusing the existing disk-path-dependent formatters. Each helper skips refs whose archive content is missing and returns an empty string when no refs are attached.
- `cli/src/core/Regenerator.test.ts` covers the full surface: missing transcripts, field preservation rules, plan/note/linear-issue block assembly, graceful handling of missing archive entries, legacy `stats` fallback for v3 summaries that lack `diffStats`, and preservation of optional fields (`conversationTurns`, `recap`) when the regeneration result omits them.

**📁 FILES**
- `cli/src/core/Regenerator.ts`

</blockquote>
</details>
<details>
<summary><strong>06 · [5bbc4a9] Add helper to load conversation counts for regenerate confirmation dialog</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Before showing the regenerate-summary confirmation dialog, the app needed a way to tell users how much conversation data would be used — number of messages, sessions, sources, and attached artifacts — so they could make an informed decision about whether to proceed.

**💡 Decisions Behind the Code**

- **Zero counts instead of null when transcript is absent**: The regenerate flow still runs even with no stored conversation, returning a zero-valued struct keeps the interface uniform and lets the dialog adjust its copy on `entryCount === 0` without branching on type.
- **Set for deduplication with insertion-order preservation**: A `Set` in JavaScript iterates in insertion order, so the first occurrence of each source naturally wins without any extra sorting or index-tracking logic. This keeps the implementation minimal while guaranteeing a stable, predictable display order in the dialog.

**✅ What Was Implemented**

- Created `cli/src/core/RegenerateContext.ts` with the `loadRegenerateContext` function and `RegenerateContext` interface. The function reads the persisted transcript for a given commit, iterates over all sessions and entries to count total messages, human turns, and unique sources (deduplicated in insertion order via a `Set`), and also reads plan, note, and Linear issue counts directly from the summary object. When no transcript exists, it returns zero-valued counts rather than null.
- `cli/src/core/RegenerateContext.test.ts` covers four cases: normal counts from a multi-session transcript, zero counts when the transcript is missing, source deduplication, and source ordering (first-occurrence wins).

**📁 FILES**
- `cli/src/core/RegenerateContext.ts`

</blockquote>
</details>
<details>
<summary><strong>07 · [5bbc4a9] Centralize transcript source display names into a single shared location</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The friendly display names for AI sources (Claude, Codex, Cursor, etc.) were duplicated: one copy lived in the webview rendering code and another was needed in the extension host for dialog strings, with no compile-time guarantee they stayed in sync.

**💡 Decisions Behind the Code**

- **Single source of truth over duplication**: Centralizing into one TypeScript map lets the extension host import it directly while the webview renderer generates equivalent JavaScript from the same data, so both surfaces are always consistent. Adding support for a new AI source in the future requires a change in exactly one place.
- **Preserve "Claude" as the fallback**: The original webview code defaulted to "Claude" for unrecognized sources. Keeping that fallback in the shared helper avoids a silent UI regression in conversation-stats rendering for any source value that doesn't match a known key.

**✅ What Was Implemented**

- Created `cli/src/core/TranscriptSourceLabel.ts` with a `TRANSCRIPT_SOURCE_LABELS` map and a `transcriptSourceLabel()` helper function. The map covers all known sources; the helper returns "Claude" as the fallback for unknown or undefined inputs, preserving the pre-existing webview behavior.
- Updated `vscode/src/views/TranscriptEntryRenderer.ts` to import the shared map and generate the webview-side `getSourceLabel` JavaScript function body dynamically from it, replacing the previously hardcoded if-chain strings. The generated JS remains byte-equivalent to the old output.

**📁 FILES**
- `cli/src/core/TranscriptSourceLabel.ts`
- `vscode/src/views/TranscriptEntryRenderer.ts`

</blockquote>
</details>
<details>
<summary><strong>08 · [5bbc4a9] Detailed implementation plan document for commit summary regeneration feature</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The team wanted a structured, ready-to-execute plan for the regenerate-summary feature before writing any code, covering UX, architecture, and task breakdown.

**💡 Decisions Behind the Code**

- **Single LLM call, not two**: A proposed two-call approach (separate summary and recap calls) was corrected after reviewing the actual code — `generateSummary` already returns topics, recap, and ticket ID together in one response, making a second call unnecessary and wasteful.
- **Preserve ticket ID and E2E test guide**: Both fields were initially listed as fields that would be overwritten. After discussion they were moved to the preserved set — ticket IDs are stable identifiers where re-extraction risk outweighs benefit, and the E2E guide is a user-initiated secondary artifact that should survive a topics regeneration.
- **Always-enabled button regardless of transcript availability**: An earlier design disabled the Regenerate button when no transcript was stored. This was reversed: the button stays enabled and the confirmation dialog adjusts its copy to explain that regeneration will proceed from diff and metadata alone, keeping the interaction model consistent.

**✅ What Was Implemented**

Added `docs/2026-05-21-regenerate-summary.md` with a comprehensive implementation plan covering UX design, architecture, file structure, and 8 TDD tasks. The plan specifies a single `generateSummary` call matching the original post-commit pipeline, a modal confirmation dialog populated with live counts from persisted data, dual-layer loading indicators, strict isolation from first-run side effects, and a freeze/thaw pattern to disable all interactive buttons inside affected panels during the LLM call.

**📋 Future Enhancements**

- Verify the exact formatter input field names, whether the LLM call function accepts an abort signal, and whether the topics section builder needs to be newly extracted — three soft alignment points noted in the plan for confirmation at implementation time.

**📁 FILES**
- `docs/2026-05-21-regenerate-summary.md`

</blockquote>
</details>
<details>
<summary><strong>09 · [5bbc4a9] Comprehensive test coverage for regenerate handler, provider label, and core</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The new regenerate handler, provider-label helper, and core regeneration function needed test coverage to guard against regressions in confirm-dialog copy, the double-click guard, artifact exclusion, credential-precedence logic, cancellation races, and missing archive entries.

**💡 Decisions Behind the Code**

- **Cancellation via microtask injection**: The progress-notification cancellation test fires the cancel callback via `queueMicrotask` rather than synchronously. Firing it synchronously would resolve the race before the handler's internal `Promise.race` is set up, making the test unreliable. The microtask boundary gives the handler one tick to register its cancellation listener before the token fires.
- **Sequential mock return values for stale-chain timing**: Each stale-chain race test uses a different number of `mockResolvedValueOnce` calls to position the stale response at exactly the guard check being exercised. This keeps each test self-contained and makes the guard ordering explicit in the test code.
- **Synchronous pass-through for the progress mock**: The `withProgress` mock was implemented as a synchronous pass-through rather than an async wrapper. An async wrapper would introduce an extra microtask tick, causing promise-flush helpers to resolve before the task body's internal awaits completed and making assertions on side effects unreliable.

**✅ What Was Implemented**

- Added a `regenerateSummary` describe block in `vscode/src/views/SummaryWebviewPanel.test.ts` covering: user cancels the dialog (no LLM call), success path (summary persisted and re-render posted), artifact exclusion regression guard, confirm-dialog detail content (entry counts, provider label, "OVERWRITTEN" copy), zero-transcript fallback copy, the double-click guard, progress-notification cancellation posting a regenerate-error message, singular "entry"/"session" copy when counts equal one, detail lines appearing only for the artifact types present, the provider-label suffix being omitted when no credentials exist, and the store-summary error path posting a regenerate-error message.
- Added three stale-chain guard tests covering: the pre-dialog guard suppressing the confirm dialog entirely, the post-modal race-window guard firing after the user accepts but before the LLM is called, and the post-LLM guard firing after the model returns and skipping the store step.
- Added a `formatActiveProviderLabel` describe block in `vscode/src/views/SummaryUtils.test.ts` with seven cases covering all credential-precedence branches.
- Added four new test cases in `cli/src/core/Regenerator.test.ts` covering missing note and linear issue archive entries (skip-and-empty-string), and preservation of optional fields when the regeneration result omits them.

**📁 FILES**
- `vscode/src/views/SummaryWebviewPanel.test.ts`
- `vscode/src/views/SummaryUtils.test.ts`
- `cli/src/core/Regenerator.test.ts`

</blockquote>
</details>
<details>
<summary><strong>10 · [3581baf] Single upfront normalization step unifies all v3-to-v4 migration in regenerate</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The regenerate feature had accumulated several bugs that all traced back to the same structural cause: code handling legacy summary data was scattered across multiple steps, each with its own gaps, so child-only attachments, orphaned document IDs, and inflated session counts all slipped through in different ways.

**💡 Decisions Behind the Code**

- **Single normalization point over scattered per-bug patches**: The alternative was to fix each of the three reported bugs (child attachments missing from LLM prompt, orphaned doc IDs dropped on strip, session count inflated) as independent patches at their respective call sites. All three bugs shared the same structural cause — v3 data living on children while downstream code assumed v4 root-authoritative layout — so patching each site would leave the code fragile against future v3 edge cases. Consolidating into one upfront normalize step gives every downstream path a clean invariant for free, and future callers get the same guarantee without needing to know about v3 history.
- **Pure function with no automatic persistence**: The normalization helper performs no file I/O and does not write the migrated result to disk unless the caller explicitly saves it. A user who opens the regenerate dialog but cancels does not trigger a silent structural change to their stored summary; the migration becomes permanent only when the user confirms regeneration.
- **Session deduplication matches webview logic; entry count does not**: The same AI session can appear in multiple commit transcript files when a squash or amend operation slices a single conversation across several commits. The webview's All Conversations card already collapses these by a composite session identity key, and the confirm dialog now uses the same approach for session count. Entry counts are intentionally left as a cumulative sum rather than deduplicated, because each commit transcript holds a different chronological slice and the union represents the full conversation.
- **Reuse existing collector helpers rather than new field-removal logic**: The five collection helpers already contained the correct deduplication rules (newest-wins by slug, id, or archived key). Exporting and reusing them avoids reimplementing the same logic in a second place, keeping the definition of "what a stripped child looks like" in one place so any future changes automatically apply to the regenerate path.

**✅ What Was Implemented**

- Added `normalizeToV4` as a pure, exported helper in `SummaryStore.ts`. It walks the entire summary tree, hoists all attachment fields (plans, notes, linear issues, end-to-end test guide, document metadata) from descendants to the root using the existing collector helpers, unions orphaned document IDs across all descendants with deduplication via a `Set`, strips descendants of their own copies, and bumps the version to 4. A private companion helper `collectDescendantOrphanedDocIds` performs the recursive orphan ID walk. The function is a no-op (returns the same reference) for v4 input.
- Refactored `Regenerator.ts` to call `normalizeToV4` as its very first step and then operate entirely on the normalized result. The six separate hoist/strip/collect calls that previously ran after the LLM call were deleted; `rebuildLinearBlock`, `rebuildPlansBlock`, and `rebuildNotesBlock` now receive the normalized summary and see the full tree-wide union of attachments before the LLM is invoked.
- Refactored `RegenerateContext.ts` similarly: `normalizeToV4` runs first, attachment counts read from the normalized root, and session counting was fixed to deduplicate by a composite session identity key using a `Set`, matching the webview's All Conversations deduplication logic.
- The migration persists to disk only when the user confirms regeneration, leaving cancelled sessions without side effects.

**📁 FILES**
- `cli/src/core/SummaryStore.ts`
- `cli/src/core/Regenerator.ts`
- `cli/src/core/RegenerateContext.ts`

</blockquote>
</details>
<details>
<summary><strong>11 · [3581baf] Regenerate reads AI conversation history from entire commit tree, not just root</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

When a summary covers multiple commits from squash, amend, or rebase operations, the AI conversation history is spread across several commits. The regenerate feature was only reading the top commit's conversation, so the confirm dialog could report zero conversations even when the user had a full history visible in the All Conversations panel, and the AI would regenerate with far less context than available.

**💡 Decisions Behind the Code**

- **Match what the user already sees**: The All Conversations panel in the webview already collects transcripts from every commit in the tree. Using only the root hash would create a silent mismatch where the user approves a regenerate believing the AI has full context, but it does not. The regenerate path now uses the same collection strategy so the confirm dialog's reported counts and the AI's actual input both reflect the same data the user is looking at.
- **Batch fetch over sequential reads**: Rather than reading transcripts one hash at a time, the existing batch helper is used to fetch all hashes in a single call. This avoids repeated round-trips to the orphan branch and keeps the implementation consistent with how the webview already loads transcript data.

**✅ What Was Implemented**

- `RegenerateContext.ts` was updated to collect all commit hashes across the full summary tree and fetch transcripts for every hash in one batch call, replacing the single-hash read. The aggregated sessions are counted and their sources deduplicated for the confirm dialog display.
- `Regenerator.ts` was updated with the same tree-wide hash collection before building the conversation context passed to the language model. All sessions from every commit in the tree are flattened into a single list fed to `buildMultiSessionContext`.
- `RegenerateContext.test.ts` gained a multi-commit tree test asserting that entry counts, session counts, and sources are correctly aggregated across root, child, and grandchild commits, and that the batch fetch is called with the full hash set.
- Note: the session-count deduplication logic was subsequently unified into the `normalizeToV4` refactor described in the normalization topic above.

**📁 FILES**
- `cli/src/core/RegenerateContext.ts`
- `cli/src/core/Regenerator.ts`

</blockquote>
</details>
<details>
<summary><strong>12 · [3581baf] Child attachment and publish metadata hoisted to root before stripping on regenerate</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

In older summaries created before the current metadata model, attachments such as plans, notes, linked tickets, test scenarios, and article publish identifiers were sometimes stored on child commits rather than the root. The regenerate path was stripping children before rescuing this data, permanently deleting the only copy — users could lose attached plans, notes, and the link to a previously published article, causing the next publish to create a duplicate.

**💡 Decisions Behind the Code**

- **Hoist before strip, matching the existing first-run pattern**: The squash and amend paths already follow a collect-then-strip order. Aligning regenerate to the same sequence enforces the invariant consistently across all paths that produce a root-authoritative summary tree, rather than having regenerate as a special case with weaker guarantees.
- **Export existing helpers rather than duplicating logic**: The five collection helpers already contained the correct deduplication rules. Exporting them avoids reimplementing the same logic in a second place, which would risk the two implementations diverging over time.
- **Include root fields in the collection pass**: The collectors traverse the entire tree including the root node itself, so for already-correct v4 summaries the hoist is a no-op write — the collected value equals what root already holds. This means the same code path handles both the legacy rescue case and the normal case without branching.

**✅ What Was Implemented**

- Five internal helper functions in `SummaryStore.ts` that collect and deduplicate plans, notes, linear issues, e2e scenarios, and article metadata across a tree were exported so they can be called from outside the store.
- `Regenerator.ts` was updated to call all five collectors across the full summary tree before stripping children, then write the merged results onto the root summary. The strip step now runs after the hoist, matching the order used by the first-run squash and amend paths. This logic was subsequently absorbed into the `normalizeToV4` helper.
- New tests in `Regenerator.test.ts` cover the child-only metadata rescue scenario (plans, notes, linear issues, e2e guide, and article doc ID all present only on a child), and a deduplication scenario where root and child both reference the same plan slug and the newer version wins.

**📁 FILES**
- `cli/src/core/SummaryStore.ts`
- `cli/src/core/Regenerator.ts`

</blockquote>
</details>
<details>
<summary><strong>13 · [3581baf] Recap always overwritten on regenerate, even when the model returns no content</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The confirmation dialog shown before regenerating told users their recap would be replaced, but the code silently preserved the old recap whenever the language model returned no recap content, making the dialog's promise false in a common edge case.

**💡 Decisions Behind the Code**

Explicit clearing was chosen over either preserving the old value or treating a missing recap as a hard failure. Preserving the old value contradicts the confirmation dialog's stated behavior and could mislead users into thinking the recap was freshly generated. Failing the entire regenerate when the model omits a recap would be overly strict, since the first-run path already accepts empty recaps. An empty string communicates "no recap this time" unambiguously and keeps the regenerate path consistent with first-run behavior.

**✅ What Was Implemented**

`Regenerator.ts` changed the recap assignment from a conditional spread (only written when the new result included a recap) to an unconditional assignment that defaults to an empty string when the model produces no recap. The corresponding test in `Regenerator.test.ts` was inverted: the case previously titled "preserves recap when generateSummary omits it" now asserts the opposite — that the old recap is cleared.

**📁 FILES**
- `cli/src/core/Regenerator.ts`

</blockquote>
</details>
<details>
<summary><strong>14 · [3581baf] Collapse All button re-bound and state-synced after topics section replaced on regenerate</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

After a successful regenerate, the Collapse All button in the topics section stopped responding to clicks because replacing the topics section with new HTML discarded the old button element along with its event listener.

**💡 Decisions Behind the Code**

- **Reset collapse state on regenerate**: After regeneration the new topic nodes are always rendered in the expanded state, so keeping a stale collapsed state would leave the button labeled "Expand All" while the topics were visually open. Resetting to uncollapsed and syncing the label inside the attach function keeps the button text and DOM state consistent without requiring the caller to manage label text separately.
- **Named function over inline re-bind**: Extracting a named function rather than duplicating the listener setup inline makes it clear that the same logical operation runs at page load and after regenerate. It also avoids the risk of the two copies drifting apart if the toggle behavior changes later.
- **String-contain assertions over runtime tests**: The webview script is emitted as a string and injected into an iframe; there is no practical way to execute it in the unit test environment. String assertions are a deliberate second-best that at least prevent the relevant lines from being silently deleted or renamed during a refactor. The trade-off is that they test presence of text rather than behavior, but that is strictly better than no coverage at all.
- **Negative assertion for the regenerate button re-attach**: Double-binding is a subtle bug that only manifests after the second regenerate. An explicit negative assertion makes the constraint visible in the test file so future contributors know the omission is intentional, not an oversight.

**✅ What Was Implemented**

- `SummaryScriptBuilder.ts` extracts the toggle-all wiring into a named `attachToggleAllBtnHandler` function. The function reads the current collapsed state from the enclosing closure and syncs the button label to match before attaching the click listener, so the label and state agree even after a re-render.
- The `summaryRegenerated` message handler now calls `attachToggleAllBtnHandler` after replacing the topics section, and resets the collapsed state to `false` first — matching the fact that newly rendered topics always start uncollapsed.
- `SummaryScriptBuilder.test.ts` gained a new describe block with four string-level assertions confirming that the named toggle handler is defined, that it is called from within the regeneration success branch, that the collapsed state is reset before re-binding, and that the toggle-header listeners are re-attached on the new topics root. A negative assertion verifies that the regenerate button's own listener is NOT re-attached in the success path, catching a double-bind bug that would cause the button to fire multiple messages after repeated regenerations.

**📁 FILES**
- `vscode/src/views/SummaryScriptBuilder.ts`
- `vscode/src/views/SummaryScriptBuilder.test.ts`

</blockquote>
</details>
<details>
<summary><strong>15 · [3581baf] Regenerate test suite hardened with real strip implementation and multi-level fixtures</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The test suite for the regenerate feature was using a hand-written stub instead of the actual stripping logic, meaning a bug in the recursive strip path would pass all tests undetected. Reviewers also flagged gaps: no coverage for grandchild-depth orphaned document IDs, no immutability guarantee for the normalization helper, and no guard against the version gate being accidentally tightened to reject future format versions.

**💡 Decisions Behind the Code**

- **Real function over a more faithful stub**: A hand-written stub, no matter how carefully written, is a second implementation of the same logic. Any future divergence between the two would be invisible to the test suite. Pulling in the actual function means the test exercises the exact code path that runs in production, so a regression in the recursive strip immediately breaks the test rather than silently passing.
- **Three-level fixture as the minimum meaningful regression depth**: A two-level test would pass even with a non-recursive implementation. The three-level fixture is the smallest tree that distinguishes recursive from non-recursive traversal and matches the realistic worst case of squash-over-squash histories without adding noise.
- **Separate leaf test rather than extending the grandchild fixture**: The version-bump concern is logically independent of the recursion concern. Merging them into one fixture would obscure which invariant a failure points to; keeping them separate makes each test's failure message self-explanatory.
- **Explicit immutability assertion rather than relying on outcome tests**: All other tests assert what the normalized output contains, but none would catch a mutation of the input. A dedicated reference-inequality check machine-verifies the "pure helper" contract rather than assuming it.
- **Pinning the version gate as "≥ 4" rather than "= 4"**: The implementation was written to be forward-compatible with hypothetical future versions, but that intent was invisible to future maintainers. A test with a version-5 fixture makes the design decision explicit and self-enforcing, preventing a well-intentioned simplification from breaking the forward-compatibility guarantee.

**✅ What Was Implemented**

- In `Regenerator.test.ts`, replaced the hand-written `stripFunctionalMetadata` stub with a call to `vi.importActual` that pulls in the real function from `SummaryStore.js`. A comment explains why the real implementation is required.
- Added a grandchild regression test constructing a three-level v3 tree (root → child → grandchild), each node carrying stale topics and recap, asserting that after regeneration all three levels are stripped and identity fields are preserved at every level.
- Added a v3 leaf test (no children) asserting the version is bumped to 4 even when there is no child subtree to recurse into, guarding against a future mistake that conditions the version bump on the presence of children.
- Added a three-level squash-over-squash test covering orphaned document IDs at grandchild depth: constructs a tree with no orphans at depth 1 and two orphan IDs at depth 2, then asserts all three IDs (root's own plus both grandchild IDs) surface on the root after regeneration and that the grandchild node's own field is cleared.
- Added a `version: 5` fast-path test in `normalizeToV4.test.ts` pinning that the helper's gate is "greater than or equal to 4" rather than "exactly 4", asserting both that the returned object is the same reference and that the version number is preserved unchanged.
- Added an immutability assertion in `normalizeToV4.test.ts` confirming that when normalization runs on a version-3 input it returns a new object and leaves the original's version field untouched.

**📁 FILES**
- `cli/src/core/Regenerator.test.ts`
- `cli/src/core/normalizeToV4.test.ts`

</blockquote>
</details>
<details>
<summary><strong>16 · [3581baf] Disabled buttons show not-allowed cursor while regenerate is in progress</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

While a regenerate was running, controls were disabled and the section was dimmed, but hovering over a disabled button did not show the expected "not allowed" cursor because the section-level style that blocked all mouse interaction also prevented the browser from computing hover state on child elements.

**💡 Decisions Behind the Code**

Re-enabling pointer events only on explicitly disabled controls, rather than removing the section-level block entirely, preserves belt-and-suspenders protection against any non-disabled interactive element that might exist inside the section. The disabled attribute is the true click guard; the cursor rule is purely visual, so restoring pointer events on those elements carries no functional risk.

**✅ What Was Implemented**

`SummaryCssBuilder.ts` adds `pointer-events: auto` to the rule targeting disabled buttons, textareas, and inputs inside a regenerating section. The parent section still blocks pointer events for any non-disabled elements, while the disabled controls themselves regain hover computation so the cursor renders correctly. The `disabled` attribute on each control continues to block actual clicks.

**📁 FILES**
- `vscode/src/views/SummaryCssBuilder.ts`

</blockquote>
</details>
<details>
<summary><strong>17 · [3581baf] Comment documents legacy stats field fallback in regeneration pipeline</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

A reviewer flagged that the fallback chain reading from two different field names for diff statistics looked like dead code or an accidental duplication, with no explanation of why both fields exist or which format uses which.

**💡 Decisions Behind the Code**

The comment was added rather than removing the fallback or restructuring the code, because the fallback is genuinely needed for the window between normalization and the completed language model call. Removing it would silently drop diff statistics for any version-3 summary on its first regeneration. Leaving it uncommented risked a future maintainer treating it as dead code and deleting it.

**✅ What Was Implemented**

Added a five-line comment block in `Regenerator.ts` directly above the fallback expression, explaining that version-4 summaries store diff statistics under one field name while version-3 legacy summaries stored them under a different alias, that the normalization step does not touch either field, and that a freshly normalized version-3 summary will therefore still carry only the legacy field until the language model call returns a fresh value that overwrites it.

**📁 FILES**
- `cli/src/core/Regenerator.ts`

</blockquote>
</details>
<details>
<summary><strong>18 · [b0ed222] Fix type error from wrong import location for summary result type</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

A reviewer flagged that the build would fail type-checking: a type used in the regenerate module was being imported from the wrong file, causing a compile error that the regular build process silently masked.

**💡 Decisions Behind the Code**

- **Reuse over duplication**: The local `escapeAttr` / `escapeText` helpers in the regenerate module had subtle drift from the canonical versions — the local one did not escape single quotes in attribute values. Replacing them with the shared utilities eliminates the divergence and ensures the regenerate prompt's XML is escaped identically to every other prompt-building path.
- **Export shared truncation logic**: Rather than keeping a second copy of the truncation function, the existing one in the linear-issue extractor was exported and reused. This guarantees the truncation marker text is byte-identical across first-run and regenerate paths, which matters for consistent LLM behavior.

**✅ What Was Implemented**

- Fixed the import in `cli/src/core/Regenerator.ts` to pull `SummaryResult` from `cli/src/core/Summarizer.ts` where it is actually defined, rather than from the shared types file where it does not exist. Also replaced two local XML-escaping helper functions with calls to the canonical shared utilities in `cli/src/core/PromptXmlEscape.ts`, and exported the `truncate` helper from `cli/src/core/LinearIssueExtractor.ts` so the regenerate path can reuse it instead of duplicating it.
- Updated `vscode/src/views/SummaryWebviewPanel.test.ts` to fix a mock signature type mismatch in the cancellation test that was also caught by the type checker.

**📁 FILES**
- `cli/src/core/Regenerator.ts`
- `cli/src/core/LinearIssueExtractor.ts`

</blockquote>
</details>
<details>
<summary><strong>19 · [b0ed222] Block all actions during regeneration using a page-wide read-only mode</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The original fix for concurrent writes during regeneration only disabled specific buttons in the topics and recap sections. Reviewers pointed out that other actions — like pushing to the cloud, generating end-to-end tests, and editing plans — remained active and could overwrite each other's results.

**💡 Decisions Behind the Code**

- **Page-wide lock over per-button disabling**: The user suggested reusing the existing read-only mode infrastructure rather than patching individual buttons. This approach is simpler, visually consistent with how the panel already behaves when a commit is rewritten, and automatically covers any new buttons added in the future without requiring additional changes.
- **Two-layer defense (CSS hide + host guard)**: The CSS layer gives immediate visible feedback and prevents accidental clicks. The host-side guard catches any message that arrives through a non-UI path. Either layer alone would leave a gap; together they cover both the visible UI and programmatic access.
- **No cancel button in the banner**: The existing system-level progress notification already provides a cancel action. Adding a second cancel button in the banner would create two entry points for the same action, which could confuse users about which one to use.

**✅ What Was Implemented**

- Added a new `regenerating-readonly` CSS class in `vscode/src/views/SummaryCssBuilder.ts` that hides every action button on the page (reusing the same allow-list mechanism already used by the foreign-readonly and stale-readonly modes). A banner with a spinning icon is inserted at the top of the page while regeneration is in flight, explaining that all actions are temporarily disabled.
- Replaced the old `freezeSummarySections` / `thawSummarySections` / `resetRegenerateButton` JavaScript helpers in `vscode/src/views/SummaryScriptBuilder.ts` with two new functions — `enterRegeneratingReadonly` and `leaveRegeneratingReadonly` — that toggle the page class and manage the banner. The topics and recap sections are dimmed visually to signal they are about to be replaced.
- Added a host-side guard in `vscode/src/views/SummaryWebviewPanel.ts` that drops any unsafe incoming command while regeneration is in progress, providing a second layer of protection against commands that bypass the UI (e.g. programmatic messages). A fixed allow-list of safe read-only commands (copy, save markdown, open links) continues to work normally.

**📁 FILES**
- `vscode/src/views/SummaryCssBuilder.ts`
- `vscode/src/views/SummaryScriptBuilder.ts`
- `vscode/src/views/SummaryWebviewPanel.ts`

</blockquote>
</details>
<details>
<summary><strong>20 · [b0ed222] Add per-item and total size limits to regenerate prompt blocks</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Reviewers found that the regenerate path embedded plans, notes, and linked issues into the prompt without any size limits, unlike the first-run summarization path which caps each item and the total block. A single large document could inflate the prompt to an extreme size, increasing cost and risking hitting the model's token limit.

**💡 Decisions Behind the Code**

- **Mirror first-run constants exactly**: Keeping the regenerate path's budgets byte-identical to the first-run formatters ensures the LLM sees the same input shape on both paths. Diverging budgets would make quality comparisons between first-run and regenerated summaries unreliable, and the 2× drift in the linear-issue per-item cap (8 000 vs. the correct 4 000) was caught and corrected in a follow-up.
- **Newest-first greedy selection over uniform truncation**: Dropping the oldest items entirely is simpler to reason about than mid-truncating a merged block, and it matches the behavior of the first-run formatters. Users are more likely to want the most recently updated context in the prompt.

**✅ What Was Implemented**

- Added six budget constants in `cli/src/core/Regenerator.ts` mirroring the defaults from the first-run formatters: 20 000 / 60 000 chars for plans, 4 000 / 12 000 for notes, and 4 000 / 30 000 for linear issues. Each rebuild helper now truncates individual items at the per-item cap and stops adding items once the total cap is reached.
- Items are sorted newest-first before selection so that when the budget is exhausted, the oldest (least recently updated) items are the ones dropped rather than arbitrary ones.
- Added tests in `cli/src/core/Regenerator.test.ts` covering an oversized single plan being truncated and four plans where the oldest is dropped when the total budget is exceeded.

**📁 FILES**
- `cli/src/core/Regenerator.ts`
- `cli/src/core/LinearIssueExtractor.ts`

</blockquote>
</details>
<details>
<summary><strong>21 · [b0ed222] Prevent a concurrent push from losing its cloud document link during regeneration</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

A reviewer identified a race condition: if a push to the cloud was already in progress when the user started a regeneration, the regeneration would finish later and overwrite the summary — erasing the cloud document identifier that the push had just written back. The next push would then create a duplicate article instead of updating the existing one.

**💡 Decisions Behind the Code**

A unified "any write in flight" lock was considered but rejected in favor of two targeted checks. The targeted approach is simpler, easier to test, and avoids introducing a shared mutable lock that every write path would need to acquire and release correctly. The two directions of the race are handled symmetrically: regeneration checks for an active push at entry, and the host guard blocks a new push while regeneration is running.

**✅ What Was Implemented**

Added an early-exit check at the start of `handleRegenerateSummary` in `vscode/src/views/SummaryWebviewPanel.ts` that detects whether a push is already in flight and, if so, shows an informational message and returns without starting the LLM call. The reverse direction (a push arriving while regeneration is active) was already covered by the host-side command guard added in the read-only mode work.

**📁 FILES**
- `vscode/src/views/SummaryWebviewPanel.ts`

</blockquote>
</details>
<details>
<summary><strong>22 · [b0ed222] Route regeneration data reads through the active storage backend</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Users who store their memory bank in a local folder rather than the default git-based backend would see zero conversations in the regeneration confirmation dialog, and the regenerated summary would be produced without any of their archived context. The regeneration code was reading directly from the git backend regardless of which backend the user had configured.

**💡 Decisions Behind the Code**

- **Bridge wrapper over parameter threading at the call site**: Exposing the storage injection through the bridge keeps the panel code free of storage-backend concerns. The bridge already owns the active storage instance, so it is the natural place to perform the injection. Direct parameter threading at the panel level would have leaked storage-backend knowledge into view code.
- **Optional parameter with fallback**: Making the storage parameter optional preserves backward compatibility for callers (such as tests and CLI usage) that do not have a storage instance. Those callers continue to use the existing fallback behavior, which reads from the git backend.

**✅ What Was Implemented**

- Added an optional `storage` parameter to `readTranscript` and `readTranscriptsForCommits` in `cli/src/core/SummaryStore.ts`, and threaded it through `loadRegenerateContext` in `cli/src/core/RegenerateContext.ts` and `regenerateSummary` in `cli/src/core/Regenerator.ts`. The three prompt-block rebuild helpers (plans, notes, linear issues) also receive and forward the storage parameter.
- Added `loadRegenerateContext` and `regenerateSummary` wrapper methods to `vscode/src/JolliMemoryBridge.ts` that retrieve the currently active storage backend and inject it into the CLI helpers, so the panel never needs to know which backend is in use.
- Updated the panel to call these bridge wrappers instead of importing the CLI helpers directly, ensuring all reads during regeneration go through the correct backend.

**📁 FILES**
- `cli/src/core/SummaryStore.ts`
- `cli/src/core/Regenerator.ts`
- `cli/src/core/RegenerateContext.ts`
- `vscode/src/JolliMemoryBridge.ts`

</blockquote>
</details>

---

*Generated by Jolli Memory · May 21, 2026 at 5:59 PM*
<!-- jollimemory-summary-end -->