### PR TITLE
Route current-repo summary reads through FolderStorage for sync visibility

### DIFF
--- a/cli/src/core/StorageFactory.ts
+++ b/cli/src/core/StorageFactory.ts
@@ -54,7 +54,14 @@ export async function createStorage(projectPath: string, cwd?: string): Promise<
 	}
 }
 
-function createFolderStorage(projectPath: string, customKBPath?: string): FolderStorage {
+/**
+ * Builds a FolderStorage rooted at `<localFolder>/<repoName>/` for the given
+ * project. Single source of truth for the kbRoot derivation so `createStorage`
+ * (write path) and any caller that needs a read-only FolderStorage instance
+ * (e.g. the VS Code bridge's `getReadStorage`) stay in lockstep — picking the
+ * same `extractRepoName` / `getRemoteUrl` / `resolveKBPath` chain.
+ */
+export function createFolderStorage(projectPath: string, customKBPath?: string): FolderStorage {
 	const repoName = extractRepoName(projectPath);
 	const remoteUrl = getRemoteUrl(projectPath);
 	const kbRoot = resolveKBPath(repoName, remoteUrl, customKBPath);

--- a/cli/src/core/SummaryStore.test.ts
+++ b/cli/src/core/SummaryStore.test.ts
@@ -2272,6 +2272,94 @@ describe("SummaryStore", () => {
 			expect(result).toBe(false);
 			expect(writeMultipleFilesToBranch).not.toHaveBeenCalled();
 		});
+
+		// ── readStorage split (sync-visibility regression) ───────────────────
+		//
+		// The VS Code bridge passes `readStorage = FolderStorage` (sees
+		// sync-pulled peer rows) and `storage = DualWriteStorage` (alias
+		// writes still hit both backends). Pinning the two-storage split here
+		// keeps the function contract honest as the bridge evolves.
+		it("uses readStorage for preflight + lock-held re-read while alias write stays on storage", async () => {
+			const indexJson = JSON.stringify(
+				v3Index(
+					[
+						{
+							...rootEntry("root1", "Root", "2026-02-18T10:00:00Z"),
+							treeHash: "tree-X",
+						},
+					],
+					{},
+				),
+			);
+			const readStorage: StorageProvider = {
+				readFile: vi.fn().mockResolvedValue(indexJson),
+				writeFiles: vi.fn(),
+				listFiles: vi.fn().mockResolvedValue([]),
+				exists: vi.fn().mockResolvedValue(true),
+				ensure: vi.fn(),
+			};
+			const writeStorage: StorageProvider = {
+				readFile: vi.fn(),
+				writeFiles: vi.fn().mockResolvedValue(undefined),
+				listFiles: vi.fn().mockResolvedValue([]),
+				exists: vi.fn().mockResolvedValue(true),
+				ensure: vi.fn(),
+			};
+			vi.mocked(getTreeHash).mockResolvedValueOnce("tree-X");
+
+			const result = await scanTreeHashAliases(["unknown1"], undefined, writeStorage, readStorage);
+
+			expect(result).toBe(true);
+			// Both the preflight and the inside-lock re-read flow through
+			// readStorage (two readFile calls); the write storage never gets
+			// read from so a stale orphan index can't override the folder's
+			// post-sync candidate set.
+			expect(readStorage.readFile).toHaveBeenCalledTimes(2);
+			expect(writeStorage.readFile).not.toHaveBeenCalled();
+			// Alias write must hit the write storage (so dual-write
+			// propagates it to BOTH backends). Routing the write through the
+			// folder side only would lose the alias from the orphan branch.
+			expect(writeStorage.writeFiles).toHaveBeenCalledTimes(1);
+			expect(readStorage.writeFiles).not.toHaveBeenCalled();
+			const [persistedFiles] = vi.mocked(writeStorage.writeFiles).mock.calls[0] as [
+				ReadonlyArray<FileWrite>,
+				string,
+			];
+			const persistedIndex = JSON.parse(persistedFiles[0].content) as SummaryIndex;
+			expect(persistedIndex.commitAliases).toEqual({ unknown1: "root1" });
+		});
+
+		it("falls back to single-storage behavior when readStorage is omitted", async () => {
+			// Existing single-storage callers (`storage` only) must continue
+			// to work unchanged: both preflight and write flow through that
+			// one storage. Without this fallback, CLI surfaces and tests
+			// that have never heard of readStorage would regress.
+			const indexJson = JSON.stringify(
+				v3Index(
+					[
+						{
+							...rootEntry("root1", "Root", "2026-02-18T10:00:00Z"),
+							treeHash: "tree-Y",
+						},
+					],
+					{},
+				),
+			);
+			const storage: StorageProvider = {
+				readFile: vi.fn().mockResolvedValue(indexJson),
+				writeFiles: vi.fn().mockResolvedValue(undefined),
+				listFiles: vi.fn().mockResolvedValue([]),
+				exists: vi.fn().mockResolvedValue(true),
+				ensure: vi.fn(),
+			};
+			vi.mocked(getTreeHash).mockResolvedValueOnce("tree-Y");
+
+			const result = await scanTreeHashAliases(["unknown1"], undefined, storage);
+
+			expect(result).toBe(true);
+			expect(storage.readFile).toHaveBeenCalledTimes(2);
+			expect(storage.writeFiles).toHaveBeenCalledTimes(1);
+		});
 	});
 
 	describe("index migration", () => {

--- a/cli/src/core/SummaryStore.test.ts
+++ b/cli/src/core/SummaryStore.test.ts
@@ -2273,13 +2273,16 @@ describe("SummaryStore", () => {
 			expect(writeMultipleFilesToBranch).not.toHaveBeenCalled();
 		});
 
-		// ── readStorage split (sync-visibility regression) ───────────────────
+		// ── two-storage contract (readStorage for candidates, storage for write) ───
 		//
-		// The VS Code bridge passes `readStorage = FolderStorage` (sees
-		// sync-pulled peer rows) and `storage = DualWriteStorage` (alias
-		// writes still hit both backends). Pinning the two-storage split here
-		// keeps the function contract honest as the bridge evolves.
-		it("uses readStorage for preflight + lock-held re-read while alias write stays on storage", async () => {
+		// Read-side and write-side may legitimately hold different rows (e.g.
+		// a FolderStorage shadow has rows the orphan-branch primary lacks, or
+		// vice versa). Preflight candidate discovery uses readStorage so the
+		// candidate set reflects what the UI is showing; the inside-lock
+		// re-read and the alias write use storage so the persisted entries
+		// array matches what's already on the write storage's primary backend
+		// (otherwise the dual-write would clobber primary rows).
+		it("preflight reads via readStorage; in-lock re-read + write go via storage", async () => {
 			const indexJson = JSON.stringify(
 				v3Index(
 					[
@@ -2299,7 +2302,7 @@ describe("SummaryStore", () => {
 				ensure: vi.fn(),
 			};
 			const writeStorage: StorageProvider = {
-				readFile: vi.fn(),
+				readFile: vi.fn().mockResolvedValue(indexJson),
 				writeFiles: vi.fn().mockResolvedValue(undefined),
 				listFiles: vi.fn().mockResolvedValue([]),
 				exists: vi.fn().mockResolvedValue(true),
@@ -2310,15 +2313,15 @@ describe("SummaryStore", () => {
 			const result = await scanTreeHashAliases(["unknown1"], undefined, writeStorage, readStorage);
 
 			expect(result).toBe(true);
-			// Both the preflight and the inside-lock re-read flow through
-			// readStorage (two readFile calls); the write storage never gets
-			// read from so a stale orphan index can't override the folder's
-			// post-sync candidate set.
+			// Preflight (1) reads readStorage; in-lock re-read reads BOTH:
+			// writeStorage to build the persisted entries, then readStorage
+			// again for the symmetric divergence check that prevents
+			// shadow-clobber. Two reads on readStorage, one on writeStorage.
 			expect(readStorage.readFile).toHaveBeenCalledTimes(2);
-			expect(writeStorage.readFile).not.toHaveBeenCalled();
-			// Alias write must hit the write storage (so dual-write
-			// propagates it to BOTH backends). Routing the write through the
-			// folder side only would lose the alias from the orphan branch.
+			expect(writeStorage.readFile).toHaveBeenCalledTimes(1);
+			// Alias write hits writeStorage so the alias propagates to both
+			// dual-write backends. Routing the write to readStorage would
+			// orphan the alias from the primary backend.
 			expect(writeStorage.writeFiles).toHaveBeenCalledTimes(1);
 			expect(readStorage.writeFiles).not.toHaveBeenCalled();
 			const [persistedFiles] = vi.mocked(writeStorage.writeFiles).mock.calls[0] as [
@@ -2327,6 +2330,107 @@ describe("SummaryStore", () => {
 			];
 			const persistedIndex = JSON.parse(persistedFiles[0].content) as SummaryIndex;
 			expect(persistedIndex.commitAliases).toEqual({ unknown1: "root1" });
+		});
+
+		it("preserves storage's entries when readStorage lacks rows (no orphan-row clobber)", async () => {
+			// C1 regression: read-side (FolderStorage shadow) is one row short
+			// of the write-side (DualWrite primary = orphan branch). A previous
+			// implementation re-read the freshIndex via readStorage and persisted
+			// readStorage.entries to BOTH backends — silently deleting the
+			// orphan-only row on the primary. Pin the fix: write payload's
+			// entries must come from storage so the primary's rows survive.
+			const orphanIndex = JSON.stringify(
+				v3Index(
+					[
+						{ ...rootEntry("root1", "Root", "2026-02-18T10:00:00Z"), treeHash: "tree-X" },
+						{
+							...rootEntry("orphan-only", "Orphan only row", "2026-02-19T10:00:00Z"),
+							treeHash: "tree-O",
+						},
+					],
+					{},
+				),
+			);
+			const folderIndex = JSON.stringify(
+				v3Index([{ ...rootEntry("root1", "Root", "2026-02-18T10:00:00Z"), treeHash: "tree-X" }], {}),
+			);
+			const readStorage: StorageProvider = {
+				readFile: vi.fn().mockResolvedValue(folderIndex),
+				writeFiles: vi.fn(),
+				listFiles: vi.fn().mockResolvedValue([]),
+				exists: vi.fn().mockResolvedValue(true),
+				ensure: vi.fn(),
+			};
+			const writeStorage: StorageProvider = {
+				readFile: vi.fn().mockResolvedValue(orphanIndex),
+				writeFiles: vi.fn().mockResolvedValue(undefined),
+				listFiles: vi.fn().mockResolvedValue([]),
+				exists: vi.fn().mockResolvedValue(true),
+				ensure: vi.fn(),
+			};
+			vi.mocked(getTreeHash).mockResolvedValueOnce("tree-X");
+
+			await scanTreeHashAliases(["unknown1"], undefined, writeStorage, readStorage);
+
+			const [persistedFiles] = vi.mocked(writeStorage.writeFiles).mock.calls[0] as [
+				ReadonlyArray<FileWrite>,
+				string,
+			];
+			const persistedIndex = JSON.parse(persistedFiles[0].content) as SummaryIndex;
+			const persistedHashes = persistedIndex.entries.map((e) => e.commitHash);
+			// Both rows survive — orphan-only row is the load-bearing one.
+			expect(persistedHashes).toContain("root1");
+			expect(persistedHashes).toContain("orphan-only");
+			// And the alias still landed.
+			expect(persistedIndex.commitAliases).toEqual({ unknown1: "root1" });
+		});
+
+		it("defers alias write when readStorage has rows storage lacks (no folder-row clobber)", async () => {
+			// Symmetric counterpart to the orphan-row-clobber regression above.
+			// readStorage (FolderStorage shadow) holds a row that writeStorage
+			// (DualWrite → orphan primary) doesn't — e.g. cross-machine cloud
+			// sync landed `folder-only` in the folder before this machine
+			// pulled the orphan branch. Persisting `freshIndex.entries` from
+			// writeStorage via dual-write would overwrite the folder's
+			// index.json and delete the synced row. The fix: detect the
+			// divergence inside the lock and skip the alias write. Aliases
+			// are cross-branch optimization; deferring is safe.
+			const orphanIndex = JSON.stringify(
+				v3Index([{ ...rootEntry("root1", "Root", "2026-02-18T10:00:00Z"), treeHash: "tree-X" }], {}),
+			);
+			const folderIndex = JSON.stringify(
+				v3Index(
+					[
+						{ ...rootEntry("root1", "Root", "2026-02-18T10:00:00Z"), treeHash: "tree-X" },
+						{
+							...rootEntry("folder-only", "Sync-only row", "2026-02-19T10:00:00Z"),
+							treeHash: "tree-F",
+						},
+					],
+					{},
+				),
+			);
+			const readStorage: StorageProvider = {
+				readFile: vi.fn().mockResolvedValue(folderIndex),
+				writeFiles: vi.fn(),
+				listFiles: vi.fn().mockResolvedValue([]),
+				exists: vi.fn().mockResolvedValue(true),
+				ensure: vi.fn(),
+			};
+			const writeStorage: StorageProvider = {
+				readFile: vi.fn().mockResolvedValue(orphanIndex),
+				writeFiles: vi.fn().mockResolvedValue(undefined),
+				listFiles: vi.fn().mockResolvedValue([]),
+				exists: vi.fn().mockResolvedValue(true),
+				ensure: vi.fn(),
+			};
+			vi.mocked(getTreeHash).mockResolvedValueOnce("tree-X");
+
+			const result = await scanTreeHashAliases(["unknown1"], undefined, writeStorage, readStorage);
+
+			// Deferred — no alias landed, no folder row destroyed.
+			expect(result).toBe(false);
+			expect(writeStorage.writeFiles).not.toHaveBeenCalled();
 		});
 
 		it("falls back to single-storage behavior when readStorage is omitted", async () => {
@@ -2717,6 +2821,287 @@ describe("SummaryStore", () => {
 			// summary.json on disk reflects the same value — single source of truth
 			const summaryContent = JSON.parse(files[0].content) as CommitSummary;
 			expect(summaryContent.diffStats).toEqual({ filesChanged: 7, insertions: 77, deletions: 17 });
+		});
+	});
+
+	describe("storeSummary union protection for dual-write readStorage", () => {
+		afterEach(() => {
+			setActiveStorage(undefined);
+		});
+
+		function makeStorage(indexEntries: SummaryIndexEntry[]): StorageProvider {
+			const index: SummaryIndex = { version: 3, entries: indexEntries };
+			return {
+				readFile: vi.fn(async (path: string) => {
+					if (path === "index.json") return JSON.stringify(index);
+					return null;
+				}),
+				writeFiles: vi.fn(async () => undefined),
+				listFiles: vi.fn(async () => []),
+				exists: vi.fn(async () => true),
+				ensure: vi.fn(async () => undefined),
+			} as unknown as StorageProvider;
+		}
+
+		it("preserves rows that exist only on the readStorage when force-writing through a separate writeStorage", async () => {
+			// Reviewer scenario: another machine peer-synced an entry into the
+			// folder shadow that hasn't reached the orphan branch yet. A
+			// force-write through DualWriteStorage previously read the index
+			// from orphan-only, then wrote the rebuilt index to BOTH backends,
+			// silently dropping the folder-only entry. With readStorage threaded,
+			// the union-base includes both sides and the dual-write preserves
+			// the folder-only row.
+			const writeStorage = makeStorage([rootEntry("orphanonly", "Orphan only")]);
+			const readStorage = makeStorage([
+				rootEntry("orphanonly", "Orphan only"),
+				rootEntry("foldersync", "Folder-only peer sync"),
+			]);
+
+			await storeSummary(createMockSummary("newcommit"), undefined, false, undefined, writeStorage, readStorage);
+
+			const writeFilesMock = writeStorage.writeFiles as ReturnType<typeof vi.fn>;
+			expect(writeFilesMock).toHaveBeenCalledTimes(1);
+			const files = writeFilesMock.mock.calls[0][0] as ReadonlyArray<FileWrite>;
+			const indexFile = files.find((f) => f.path === "index.json");
+			const newIndex = JSON.parse(indexFile?.content ?? "{}") as SummaryIndex;
+			const hashes = newIndex.entries.map((e) => e.commitHash);
+			expect(hashes).toContain("orphanonly");
+			expect(hashes).toContain("foldersync");
+			expect(hashes).toContain("newcommit");
+		});
+
+		it("falls back to writeStorage-only loading when readStorage is omitted (callers that don't dual-write)", async () => {
+			// QueueWorker and the CLI summarize command don't pass readStorage —
+			// they share one storage instance for both paths. The pre-existing
+			// behavior must survive: the index is read from the single storage
+			// and no union is attempted (so no extra readFile happens against
+			// a non-existent shadow).
+			const onlyStorage = makeStorage([rootEntry("existing", "Existing")]);
+
+			await storeSummary(createMockSummary("new"), undefined, false, undefined, onlyStorage);
+
+			const writeFilesMock = onlyStorage.writeFiles as ReturnType<typeof vi.fn>;
+			expect(writeFilesMock).toHaveBeenCalledTimes(1);
+			const files = writeFilesMock.mock.calls[0][0] as ReadonlyArray<FileWrite>;
+			const indexFile = files.find((f) => f.path === "index.json");
+			const newIndex = JSON.parse(indexFile?.content ?? "{}") as SummaryIndex;
+			const hashes = newIndex.entries.map((e) => e.commitHash);
+			expect(hashes).toEqual(expect.arrayContaining(["existing", "new"]));
+		});
+
+		it("merges commitAliases from both backends, with write-side keys winning on overlap", async () => {
+			// Aliases get the same union treatment as entries. Read-side-only
+			// aliases (cross-machine tree-hash matches) must survive the
+			// rewrite. On the rare collision where both sides hold the same
+			// alias key with different target hashes, the write side (orphan,
+			// system of record) wins.
+			const writeStorage: StorageProvider = {
+				readFile: vi.fn(async (path: string) => {
+					if (path === "index.json") {
+						return JSON.stringify({
+							version: 3,
+							entries: [rootEntry("a", "A")],
+							commitAliases: { sharedKey: "writeTarget" },
+						} satisfies SummaryIndex);
+					}
+					return null;
+				}),
+				writeFiles: vi.fn(async () => undefined),
+				listFiles: vi.fn(async () => []),
+				exists: vi.fn(async () => true),
+				ensure: vi.fn(async () => undefined),
+			} as unknown as StorageProvider;
+			const readStorage: StorageProvider = {
+				readFile: vi.fn(async (path: string) => {
+					if (path === "index.json") {
+						return JSON.stringify({
+							version: 3,
+							entries: [rootEntry("a", "A")],
+							commitAliases: {
+								sharedKey: "readTarget",
+								folderOnlyKey: "folderTarget",
+							},
+						} satisfies SummaryIndex);
+					}
+					return null;
+				}),
+				writeFiles: vi.fn(async () => undefined),
+				listFiles: vi.fn(async () => []),
+				exists: vi.fn(async () => true),
+				ensure: vi.fn(async () => undefined),
+			} as unknown as StorageProvider;
+
+			await storeSummary(createMockSummary("new"), undefined, false, undefined, writeStorage, readStorage);
+
+			const files = (writeStorage.writeFiles as ReturnType<typeof vi.fn>).mock
+				.calls[0][0] as ReadonlyArray<FileWrite>;
+			const newIndex = JSON.parse(files.find((f) => f.path === "index.json")?.content ?? "{}") as SummaryIndex;
+			expect(newIndex.commitAliases?.sharedKey).toBe("writeTarget");
+			expect(newIndex.commitAliases?.folderOnlyKey).toBe("folderTarget");
+		});
+
+		// ── payload backfill for folder-only entries ────────────────────────
+		// Union'ing the index alone leaves orphan with index rows that point
+		// at `summaries/<hash>.json` files only the folder side actually has.
+		// Every orphan-only reader (`getSummary` → `readSummaryFile`,
+		// `QueueWorker.loadSourceSummaries`, `SummaryExporter.exportSummaries`)
+		// still resolves payloads through the active storage's primary, so a
+		// folder-only row whose payload never reached orphan surfaces as a
+		// dangling reference. The dual-write must lift those payloads.
+
+		function makeStorageWithFiles(
+			indexEntries: SummaryIndexEntry[],
+			files: Record<string, string>,
+		): StorageProvider {
+			const index: SummaryIndex = { version: 3, entries: indexEntries };
+			return {
+				readFile: vi.fn(async (path: string) => {
+					if (path === "index.json") return JSON.stringify(index);
+					return files[path] ?? null;
+				}),
+				writeFiles: vi.fn(async () => undefined),
+				listFiles: vi.fn(async () => []),
+				exists: vi.fn(async () => true),
+				ensure: vi.fn(async () => undefined),
+			} as unknown as StorageProvider;
+		}
+
+		it("lifts folder-only summary payloads from readStorage into the writeStorage batch", async () => {
+			// readStorage holds a peer-synced root entry plus its backing
+			// `summaries/<hash>.json` payload. writeStorage (orphan) has not
+			// seen this entry yet. After storeSummary, the writeStorage batch
+			// must include both the new commit's summary AND the folder-only
+			// summary file — otherwise the freshly-unioned orphan index
+			// points at a summaries/foldersync.json that doesn't exist on
+			// orphan, and `getSummary` (which goes through DualWriteStorage's
+			// primary-only readFile) returns null on lookup.
+			const folderOnlyPayload = JSON.stringify({
+				...createMockSummary("foldersync", "Folder-only peer sync"),
+			});
+			const writeStorage = makeStorageWithFiles([rootEntry("orphanonly", "Orphan only")], {});
+			const readStorage = makeStorageWithFiles(
+				[rootEntry("orphanonly", "Orphan only"), rootEntry("foldersync", "Folder-only peer sync")],
+				{ "summaries/foldersync.json": folderOnlyPayload },
+			);
+
+			await storeSummary(createMockSummary("newcommit"), undefined, false, undefined, writeStorage, readStorage);
+
+			const writeFilesMock = writeStorage.writeFiles as ReturnType<typeof vi.fn>;
+			expect(writeFilesMock).toHaveBeenCalledTimes(1);
+			const filesWritten = writeFilesMock.mock.calls[0][0] as ReadonlyArray<FileWrite>;
+			const paths = filesWritten.map((f) => f.path);
+			expect(paths).toContain("summaries/newcommit.json");
+			expect(paths).toContain("summaries/foldersync.json");
+			// Backfilled payload is the readStorage content verbatim — orphan
+			// must end up byte-identical to the folder copy so downstream
+			// readers don't diverge based on which backend they hit.
+			const backfilled = filesWritten.find((f) => f.path === "summaries/foldersync.json");
+			expect(backfilled?.content).toBe(folderOnlyPayload);
+		});
+
+		it("lifts folder-only transcripts alongside their summaries", async () => {
+			// Transcripts are keyed by the same commitHash as their summary
+			// (`transcripts/<hash>.json`). Without backfill, a folder-only
+			// entry's transcript is missing on orphan — `readTranscript`
+			// (driven through the active storage's primary) returns null
+			// and the squash pipeline / sidebar transcript view silently
+			// drop data.
+			const folderOnlySummary = JSON.stringify(createMockSummary("foldersync", "Folder-only peer sync"));
+			const folderOnlyTranscript = JSON.stringify({ sessions: [{ id: "s1", events: [] }] });
+			const writeStorage = makeStorageWithFiles([], {});
+			const readStorage = makeStorageWithFiles([rootEntry("foldersync", "Folder-only peer sync")], {
+				"summaries/foldersync.json": folderOnlySummary,
+				"transcripts/foldersync.json": folderOnlyTranscript,
+			});
+
+			await storeSummary(createMockSummary("newcommit"), undefined, false, undefined, writeStorage, readStorage);
+
+			const filesWritten = (writeStorage.writeFiles as ReturnType<typeof vi.fn>).mock
+				.calls[0][0] as ReadonlyArray<FileWrite>;
+			const transcript = filesWritten.find((f) => f.path === "transcripts/foldersync.json");
+			expect(transcript?.content).toBe(folderOnlyTranscript);
+		});
+
+		it("skips backfill silently when readStorage has the index row but no payload (embedded child case)", async () => {
+			// Children of a squash/amend tree live inside the root's
+			// `summaries/<rootHash>.json` blob, so the child's own
+			// `summaries/<childHash>.json` file may not exist as a separate
+			// artifact. The backfill must tolerate a missing payload without
+			// emitting a phantom write (which would land empty/`null` content
+			// on orphan and corrupt every subsequent direct-read attempt).
+			const writeStorage = makeStorageWithFiles([], {});
+			const readStorage = makeStorageWithFiles(
+				[rootEntry("embeddedchild", "Squashed away")],
+				// no summaries/embeddedchild.json, no transcripts/embeddedchild.json
+				{},
+			);
+
+			await storeSummary(createMockSummary("newcommit"), undefined, false, undefined, writeStorage, readStorage);
+
+			const filesWritten = (writeStorage.writeFiles as ReturnType<typeof vi.fn>).mock
+				.calls[0][0] as ReadonlyArray<FileWrite>;
+			const paths = filesWritten.map((f) => f.path);
+			expect(paths).not.toContain("summaries/embeddedchild.json");
+			expect(paths).not.toContain("transcripts/embeddedchild.json");
+			// The index still carries the row (union preservation), even
+			// though the payload is intentionally absent.
+			const newIndex = JSON.parse(
+				filesWritten.find((f) => f.path === "index.json")?.content ?? "{}",
+			) as SummaryIndex;
+			expect(newIndex.entries.map((e) => e.commitHash)).toContain("embeddedchild");
+		});
+
+		it("does not double-write the headline summary's payload when the same hash also lives folder-only", async () => {
+			// Edge case: user force-writes a commit hash that already exists
+			// as a folder-only row (peer-synced). Both the headline write
+			// path and the backfill loop would emit `summaries/<hash>.json`,
+			// producing two batch entries with the same path. The git tree
+			// builder + folder writer would have to pick one and silently
+			// drop the other. Skip the backfill probe for the headline's
+			// own hash so the batch is uniquely keyed.
+			const writeStorage = makeStorageWithFiles([], {});
+			const readStorage = makeStorageWithFiles([rootEntry("dupe", "Older folder copy")], {
+				"summaries/dupe.json": JSON.stringify(createMockSummary("dupe", "Older folder copy")),
+				"transcripts/dupe.json": JSON.stringify({ sessions: [] }),
+			});
+
+			await storeSummary(
+				createMockSummary("dupe", "Force-rewrite via summarize"),
+				undefined,
+				true,
+				undefined,
+				writeStorage,
+				readStorage,
+			);
+
+			const filesWritten = (writeStorage.writeFiles as ReturnType<typeof vi.fn>).mock
+				.calls[0][0] as ReadonlyArray<FileWrite>;
+			const dupeSummaryPayloads = filesWritten.filter((f) => f.path === "summaries/dupe.json");
+			expect(dupeSummaryPayloads).toHaveLength(1);
+			// The single entry that survives is the headline write
+			// (fresh summary content), not the stale folder copy.
+			const survived = JSON.parse(dupeSummaryPayloads[0].content) as CommitSummary;
+			expect(survived.commitMessage).toBe("Force-rewrite via summarize");
+		});
+
+		it("does not read backfill paths when readStorage is omitted", async () => {
+			// The single-storage callers (QueueWorker, CLI summarize) must
+			// not pay extra readFile round-trips for backfill — there's no
+			// secondary backend to lift from, and probing the same storage
+			// would be wasted IO. Asserts the no-union baseline is untouched.
+			const onlyStorage = makeStorageWithFiles([rootEntry("existing", "Existing")], {
+				"summaries/existing.json": JSON.stringify(createMockSummary("existing", "Existing")),
+			});
+
+			await storeSummary(createMockSummary("new"), undefined, false, undefined, onlyStorage);
+
+			const readFileMock = onlyStorage.readFile as ReturnType<typeof vi.fn>;
+			// The only legitimate readFile calls on the single-storage path
+			// are `index.json` + catalog probes; no `summaries/existing.json`
+			// or `transcripts/existing.json` should be probed for backfill.
+			const probedPaths = readFileMock.mock.calls.map((c) => c[0] as string);
+			expect(probedPaths).not.toContain("summaries/existing.json");
+			expect(probedPaths).not.toContain("transcripts/existing.json");
 		});
 	});
 

--- a/cli/src/core/SummaryStore.ts
+++ b/cli/src/core/SummaryStore.ts
@@ -1347,19 +1347,32 @@ export async function getIndexEntryMap(
  *
  * Designed to run as a background fire-and-forget scan from `listBranchCommits`.
  *
+ * @param storage      — write path. Determines where the alias gets
+ *   persisted; callers in dual-write mode pass a `DualWriteStorage` so the
+ *   alias lands on both backends.
+ * @param readStorage  — optional read path for the preflight + lock-held
+ *   re-load. When provided, candidate determination and freshness re-check
+ *   read from this storage instead of `storage`. Used by the VS Code bridge
+ *   to point the preflight at the FolderStorage shadow (which sees
+ *   sync-pulled peer commits) while keeping alias writes flowing through
+ *   `storage` (so orphan-branch readers still get the alias). Falls back to
+ *   `storage` when omitted to preserve the original single-storage callers.
+ *
  * @returns `true` if any new aliases were written, `false` otherwise
  */
 export async function scanTreeHashAliases(
 	commitHashes: string[],
 	cwd?: string,
 	storage?: StorageProvider,
+	readStorage?: StorageProvider,
 ): Promise<boolean> {
+	const effectiveReadStorage = readStorage ?? storage;
 	// ── Phase 1: preflight (no lock) ────────────────────────────────────────
 	// Compute candidate aliases against the current index. Tree-hash lookup is
 	// O(n) git calls — expensive — so we keep it outside the lock to avoid
 	// blocking concurrent worker writes. The lookup result is "tentative":
 	// Phase 2 re-validates against the freshly-loaded index inside the lock.
-	const preflightIndex = await loadIndex(cwd, storage);
+	const preflightIndex = await loadIndex(cwd, effectiveReadStorage);
 	if (!preflightIndex || preflightIndex.version !== 3) return false;
 
 	const preflightAliases = preflightIndex.commitAliases ?? {};
@@ -1407,7 +1420,12 @@ export async function scanTreeHashAliases(
 		return false;
 	}
 	try {
-		const freshIndex = await loadIndex(cwd, storage);
+		// Re-load via the SAME source as the preflight so the candidate
+		// freshness check sees the same dataset. If the bridge passed a
+		// FolderStorage read-side, post-sync rows that arrived since
+		// preflight (rare; e.g. a sync round finishing mid-scan) are
+		// still observable here, keeping the candidate filter coherent.
+		const freshIndex = await loadIndex(cwd, effectiveReadStorage);
 		if (!freshIndex || freshIndex.version !== 3) return false;
 
 		const freshAliases = freshIndex.commitAliases ?? {};

--- a/cli/src/core/SummaryStore.ts
+++ b/cli/src/core/SummaryStore.ts
@@ -135,6 +135,43 @@ function isRootEntry(e: SummaryIndexEntry): boolean {
 	return e.parentCommitHash == null;
 }
 
+/**
+ * Merges two index snapshots into a single base view used by `storeSummary`'s
+ * upcoming dual-write. Used when a write path has both a write-side index
+ * (e.g. orphan branch primary) and a read-side index (e.g. FolderStorage
+ * shadow) that may legitimately diverge — most commonly when peer-synced rows
+ * land in the folder before the orphan branch catches up. Write-side wins on
+ * collision (orphan is system-of-record) and contributes the `commitAliases`
+ * defaults; read-side-only entries and aliases are appended so the rebuilt
+ * index that gets persisted to both backends doesn't drop any rows that the
+ * user can currently see.
+ */
+function unionIndexes(writeIndex: SummaryIndex | null, readIndex: SummaryIndex | null): SummaryIndex | null {
+	if (!writeIndex && !readIndex) return null;
+	if (!readIndex) return writeIndex;
+	if (!writeIndex) return readIndex;
+	const merged = new Map<string, SummaryIndexEntry>();
+	for (const e of readIndex.entries) merged.set(e.commitHash, e);
+	for (const e of writeIndex.entries) merged.set(e.commitHash, e);
+	const aliases = { ...(readIndex.commitAliases ?? {}), ...(writeIndex.commitAliases ?? {}) };
+	return {
+		version: writeIndex.version,
+		entries: [...merged.values()],
+		...(Object.keys(aliases).length > 0 && { commitAliases: aliases }),
+	};
+}
+
+/** Catalog counterpart of {@link unionIndexes}; same write-wins semantics. */
+function unionCatalogs(writeCatalog: CommitCatalog | null, readCatalog: CommitCatalog | null): CommitCatalog | null {
+	if (!writeCatalog && !readCatalog) return null;
+	if (!readCatalog) return writeCatalog;
+	if (!writeCatalog) return readCatalog;
+	const merged = new Map<string, CatalogEntry>();
+	for (const e of readCatalog.entries) merged.set(e.commitHash, e);
+	for (const e of writeCatalog.entries) merged.set(e.commitHash, e);
+	return { version: writeCatalog.version, entries: [...merged.values()] };
+}
+
 // ─── Public write API ─────────────────────────────────────────────────────────
 
 /**
@@ -146,12 +183,24 @@ function isRootEntry(e: SummaryIndexEntry): boolean {
  * the old root entry naturally becomes a child entry when the new amended
  * summary is stored — no separate `removeFromIndex` call needed.
  *
- * @param summary   - The commit summary to store (root of the tree)
- * @param cwd       - Optional working directory (git repo root)
- * @param force     - When true, overwrites an existing summary for the same commit hash
- *                    instead of skipping (used by the manual `summarize` CLI command)
- * @param artifacts - Optional artifacts to store atomically alongside the summary
- *                    (e.g., transcript data saved as `transcripts/{commitHash}.json`)
+ * @param summary     - The commit summary to store (root of the tree)
+ * @param cwd         - Optional working directory (git repo root)
+ * @param force       - When true, overwrites an existing summary for the same commit hash
+ *                      instead of skipping (used by the manual `summarize` CLI command)
+ * @param artifacts   - Optional artifacts to store atomically alongside the summary
+ *                      (e.g., transcript data saved as `transcripts/{commitHash}.json`)
+ * @param storage     - Write storage. Drives the actual writeFiles call.
+ * @param readStorage - Optional secondary read storage whose index/catalog rows
+ *                      must be preserved in the upcoming dual-write. When passed
+ *                      and distinct from `storage`, the existing index/catalog
+ *                      base is union'd across both backends (write-side wins on
+ *                      collision since orphan is system-of-record) so rows that
+ *                      live only on the read side — e.g. peer-synced FolderStorage
+ *                      entries the orphan branch hasn't caught up to yet —
+ *                      survive the dual-write that follows. Without this, the
+ *                      newly built index would replace the shadow's index.json
+ *                      with one derived from primary-only rows and silently
+ *                      drop the read-only-side entries.
  */
 export async function storeSummary(
 	summary: CommitSummary,
@@ -162,12 +211,41 @@ export async function storeSummary(
 		readonly planProgress?: ReadonlyArray<PlanProgressArtifact>;
 	},
 	storage?: StorageProvider,
+	readStorage?: StorageProvider,
 ): Promise<void> {
 	await withRequiredOrphanWriteLock(cwd, "storeSummary", async () => {
-		const existingIndex = await loadIndex(cwd);
-		const existingCatalog = await loadCatalog(cwd);
+		const writeIndex = await loadIndex(cwd, storage);
+		const writeCatalog = await loadCatalog(cwd, storage);
+		// Union the read-side (folder shadow) snapshot into the base so
+		// peer-synced rows survive the dual-write rewrite. See
+		// `unionIndexes` for merge semantics; the matching payload-lift
+		// below uses `folderOnlyHashes` to keep the writeStorage backing
+		// files in sync with the rebuilt index.
+		const hasDistinctReadStorage = readStorage !== undefined && readStorage !== storage;
+		const readIndex = hasDistinctReadStorage ? await loadIndex(cwd, readStorage) : null;
+		const readCatalog = hasDistinctReadStorage ? await loadCatalog(cwd, readStorage) : null;
+		const existingIndex = hasDistinctReadStorage ? unionIndexes(writeIndex, readIndex) : writeIndex;
+		const existingCatalog = hasDistinctReadStorage ? unionCatalogs(writeCatalog, readCatalog) : writeCatalog;
 		const existingEntries = existingIndex?.entries ? [...existingIndex.entries] : [];
 		const entryMap = new Map(existingEntries.map((e) => [e.commitHash, e]));
+
+		// Hashes whose index row was contributed by readStorage but whose
+		// backing `summaries/<hash>.json` payload hasn't reached writeStorage
+		// yet. Without lifting these files into the same write batch, the
+		// orphan branch ends up with index entries that point at payloads
+		// only the folder side actually has — and every orphan-routed
+		// reader (`getSummary`/`readSummaryFile` via the active storage,
+		// `QueueWorker.loadSourceSummaries`, `SummaryExporter`) returns
+		// null on those rows. `DualWriteStorage.readFile` is primary-only,
+		// so even in dual-write mode we cannot lean on the folder for
+		// payload resolution at read time — orphan must be self-complete.
+		const folderOnlyHashes = new Set<string>();
+		if (hasDistinctReadStorage && readIndex) {
+			const writeHashes = new Set(writeIndex?.entries.map((e) => e.commitHash) ?? []);
+			for (const entry of readIndex.entries) {
+				if (!writeHashes.has(entry.commitHash)) folderOnlyHashes.add(entry.commitHash);
+			}
+		}
 
 		// Duplicate guard: skip if root already indexed and force=false
 		if (!force && entryMap.has(summary.commitHash)) {
@@ -212,6 +290,31 @@ export async function storeSummary(
 					path: `plan-progress/${progress.planSlug}.json`,
 					content: JSON.stringify(progress, null, "\t"),
 				});
+			}
+		}
+
+		// Backfill the payloads behind every folder-only index row so the
+		// orphan branch ends this commit with index → file integrity.
+		// Missing files (embedded squash children that never had their
+		// own `summaries/<hash>.json`) are silently skipped — leaving
+		// the index row alone is the right behavior there since the
+		// child resolves through its parent root's blob via
+		// `flattenSummaryTree` / `getSummary`'s prefix scan. The headline
+		// summary's own hash is skipped because its payload is already in
+		// the batch above (avoids a duplicate path inside one `writeFiles`).
+		if (folderOnlyHashes.size > 0 && readStorage) {
+			for (const hash of folderOnlyHashes) {
+				if (hash === summary.commitHash) continue;
+				const summaryPath = `summaries/${hash}.json`;
+				const transcriptPath = `transcripts/${hash}.json`;
+				const summaryPayload = await readStorage.readFile(summaryPath);
+				if (summaryPayload !== null) {
+					files.push({ path: summaryPath, content: summaryPayload });
+				}
+				const transcriptPayload = await readStorage.readFile(transcriptPath);
+				if (transcriptPayload !== null) {
+					files.push({ path: transcriptPath, content: transcriptPayload });
+				}
 			}
 		}
 
@@ -1347,16 +1450,16 @@ export async function getIndexEntryMap(
  *
  * Designed to run as a background fire-and-forget scan from `listBranchCommits`.
  *
- * @param storage      — write path. Determines where the alias gets
- *   persisted; callers in dual-write mode pass a `DualWriteStorage` so the
- *   alias lands on both backends.
- * @param readStorage  — optional read path for the preflight + lock-held
- *   re-load. When provided, candidate determination and freshness re-check
- *   read from this storage instead of `storage`. Used by the VS Code bridge
- *   to point the preflight at the FolderStorage shadow (which sees
- *   sync-pulled peer commits) while keeping alias writes flowing through
- *   `storage` (so orphan-branch readers still get the alias). Falls back to
- *   `storage` when omitted to preserve the original single-storage callers.
+ * @param storage      — write path. Drives the inside-lock re-read AND the
+ *   alias write, so the persisted blob's `entries` matches what's already on
+ *   the write storage's primary backend (no clobbering rows the read storage
+ *   lacks).
+ * @param readStorage  — optional candidate-discovery storage. When the
+ *   caller's write storage doesn't see the same rows as its read storage
+ *   (e.g. a FolderStorage shadow has rows the orphan-branch primary doesn't,
+ *   or vice versa), pass the read side here so preflight candidate
+ *   computation reflects what the UI is showing. Defaults to `storage` when
+ *   omitted (single-storage callers behave identically to before).
  *
  * @returns `true` if any new aliases were written, `false` otherwise
  */
@@ -1420,13 +1523,46 @@ export async function scanTreeHashAliases(
 		return false;
 	}
 	try {
-		// Re-load via the SAME source as the preflight so the candidate
-		// freshness check sees the same dataset. If the bridge passed a
-		// FolderStorage read-side, post-sync rows that arrived since
-		// preflight (rare; e.g. a sync round finishing mid-scan) are
-		// still observable here, keeping the candidate filter coherent.
-		const freshIndex = await loadIndex(cwd, effectiveReadStorage);
+		// Re-anchor the inside-lock re-read on the WRITE storage, not the
+		// read side. The `newIndex` blob below carries `freshIndex.entries`
+		// verbatim and gets persisted via dual-write to BOTH backends — so
+		// the entries array we write must already match what the write
+		// storage's primary holds. Using the read side here would let the
+		// write payload's entries diverge from the primary (e.g. when the
+		// read storage is a FolderStorage shadow that lacks rows the
+		// primary still has), and the dual-write would then clobber those
+		// rows on the primary. Candidate freshness for `freshAliases` and
+		// `freshEntryHashSet` is intentionally a write-storage check.
+		const freshIndex = await loadIndex(cwd, storage);
 		if (!freshIndex || freshIndex.version !== 3) return false;
+
+		// Symmetric protection: anchoring on writeStorage protects the
+		// primary's rows, but the same dual-write that lands the alias
+		// also overwrites the shadow's index.json with freshIndex.entries.
+		// If the read storage (typically the FolderStorage shadow) holds
+		// rows the write storage doesn't (e.g. cross-machine cloud sync
+		// landed rows in the folder before the orphan branch caught up),
+		// that write deletes them on the shadow. Defer the alias scan in
+		// that case — aliases are a cross-branch tree-hash optimization,
+		// not load-bearing, and the next refresh retries once both sides
+		// reconcile (heal, push/pull of orphan, etc.).
+		if (effectiveReadStorage !== storage) {
+			const readSideIndex = await loadIndex(cwd, effectiveReadStorage);
+			if (readSideIndex && readSideIndex.version === 3) {
+				const writeHashes = new Set(freshIndex.entries.map((e) => e.commitHash));
+				const readOnlyCount = readSideIndex.entries.reduce(
+					(n, e) => (writeHashes.has(e.commitHash) ? n : n + 1),
+					0,
+				);
+				if (readOnlyCount > 0) {
+					log.warn(
+						"scanTreeHashAliases: read side has %d row(s) write side lacks — deferring alias write to avoid shadow clobber",
+						readOnlyCount,
+					);
+					return false;
+				}
+			}
+		}
 
 		const freshAliases = freshIndex.commitAliases ?? {};
 		const freshEntryHashSet = new Set(freshIndex.entries.map((e) => e.commitHash));

--- a/vscode/src/Extension.test.ts
+++ b/vscode/src/Extension.test.ts
@@ -268,6 +268,7 @@ const {
 		invalidateEntriesCache: vi.fn(),
 		getCurrentBranch: vi.fn().mockResolvedValue("main"),
 		reloadStorage: vi.fn(),
+		reloadReadStorage: vi.fn(),
 		// Bridge wrappers added when storage threading replaced direct
 		// SummaryStore calls in `migrateIndexIfNeeded`. Delegate to the
 		// hoisted SummaryStore mocks so existing assertions on
@@ -1599,6 +1600,47 @@ describe("Extension", () => {
 			expect(
 				mockMigrationEngineInstance.runStaleChildCleanup,
 			).not.toHaveBeenCalled();
+		});
+
+		it("busts bridge read-storage cache after runMigration completes", async () => {
+			// Without this, the C2 fallback inside createReadStorage (which
+			// returns OrphanBranchStorage when the folder lacks index.json)
+			// can be cached BEFORE migration finishes. The cache survives
+			// migration completion and the session stays stuck on orphan
+			// reads — any folder-only (e.g. cross-machine cloud-synced)
+			// rows stay invisible until window reload.
+			mockOrphanInstance.exists.mockResolvedValue(true);
+			mockMetadataManagerInstance.readMigrationState.mockReturnValue(null);
+
+			activate(makeContext());
+
+			await vi.waitFor(() => {
+				expect(mockMigrationEngineInstance.runMigration).toHaveBeenCalledTimes(
+					1,
+				);
+			});
+			expect(mockBridge.reloadStorage).toHaveBeenCalled();
+		});
+
+		it("busts bridge read-storage cache after runStaleChildCleanup completes", async () => {
+			// Symmetric pin for the staleChildCleanup branch. Cleanup
+			// mutates the folder's index.json; any bridge cache that
+			// snapshotted pre-cleanup state would keep serving stale rows.
+			mockOrphanInstance.exists.mockResolvedValue(true);
+			mockMetadataManagerInstance.readMigrationState.mockReturnValue({
+				status: "completed",
+				totalEntries: 5,
+				migratedEntries: 5,
+			});
+
+			activate(makeContext());
+
+			await vi.waitFor(() => {
+				expect(
+					mockMigrationEngineInstance.runStaleChildCleanup,
+				).toHaveBeenCalledTimes(1);
+			});
+			expect(mockBridge.reloadStorage).toHaveBeenCalled();
 		});
 	});
 
@@ -3060,11 +3102,17 @@ describe("Extension", () => {
 		// ── refreshMemories command ─────────────────────────────────────────
 
 		describe("refreshMemories", () => {
-			it("calls memoriesProvider.refresh", () => {
+			it("calls memoriesProvider.refresh and re-probes both caches so peer-synced folder rows surface", () => {
 				const handler = getRegisteredCommand("jollimemory.refreshMemories");
 				handler();
 
 				expect(mockMemoriesStore.refresh).toHaveBeenCalled();
+				// Both bridge caches must be dropped: the aggregated entries
+				// cache so cross-repo discovery re-runs, and the read-storage
+				// cache so the dual-write folder-empty fallback gets re-probed
+				// after iCloud (or similar) repopulates the folder.
+				expect(mockBridge.invalidateEntriesCache).toHaveBeenCalled();
+				expect(mockBridge.reloadReadStorage).toHaveBeenCalled();
 			});
 		});
 

--- a/vscode/src/Extension.ts
+++ b/vscode/src/Extension.ts
@@ -1057,6 +1057,16 @@ export function activate(context: vscode.ExtensionContext): void {
 						"activate",
 						`KB auto-migration: ${result.status} (${result.migratedEntries}/${result.totalEntries})`,
 					);
+					// Bust the bridge's read-storage cache. initializeKB is
+					// fire-and-forget, so UI surfaces (Memories / Timeline)
+					// can hit `getReadStorage()` BEFORE migration finishes —
+					// at which point the folder lacks index.json and the C2
+					// fallback caches an OrphanBranchStorage promise. Without
+					// this reset, the cached fallback survives migration
+					// completion and the session stays stuck on orphan reads
+					// (cross-machine folder-synced rows stay invisible) until
+					// a window reload or settings change.
+					bridge.reloadStorage();
 					// initializeKB is fire-and-forget (`void initializeKB()` below),
 					// so the sidebar webview can resolve and request kb:expandFolder
 					// before migration writes its first MD. Without an explicit
@@ -1074,6 +1084,10 @@ export function activate(context: vscode.ExtensionContext): void {
 						"activate",
 						`KB v3 stale-child cleanup: completedAt=${result.staleChildCleanup?.completedAt ?? "n/a"}`,
 					);
+					// Same rationale as above — staleChildCleanup mutates the
+					// folder's index.json, and a bridge cache that snapshotted
+					// pre-cleanup state would keep returning stale rows.
+					bridge.reloadStorage();
 					sidebarProvider.refreshKnowledgeBaseFolders();
 				}
 			}
@@ -2510,7 +2524,14 @@ export function activate(context: vscode.ExtensionContext): void {
 			// other IDE windows to neighbour repos under the same Memory Bank
 			// parent (which don't move this workspace's orphan ref and don't
 			// touch its lock file) only show up after a window reload.
+			//
+			// Also re-probe the read-storage fallback: a dual-write session
+			// that initially fell back to OrphanBranchStorage because the
+			// Memory Bank folder lacked `index.json` would otherwise keep
+			// serving that cached instance forever once peer-sync repopulates
+			// the folder.
 			bridge.invalidateEntriesCache();
+			bridge.reloadReadStorage();
 			memoriesStore.refresh().catch(handleError("refreshMemories"));
 		}),
 

--- a/vscode/src/JolliMemoryBridge.test.ts
+++ b/vscode/src/JolliMemoryBridge.test.ts
@@ -3109,7 +3109,9 @@ describe("JolliMemoryBridge", () => {
 			const result = await bridge.getSummaryIndexEntryMap();
 
 			expect(result).toBe(fakeMap);
-			expect(getIndexEntryMap).toHaveBeenCalledWith(TEST_CWD, storageShape);
+			// Read path uses FolderStorage (not DualWriteStorage); storage
+			// identity is pinned in the "current-repo reads" describe below.
+			expect(getIndexEntryMap).toHaveBeenCalledWith(TEST_CWD, expect.any(Object));
 		});
 	});
 
@@ -3602,9 +3604,13 @@ describe("JolliMemoryBridge", () => {
 
 			// Wait for the fire-and-forget promise to resolve
 			await vi.waitFor(() => {
+				// (hashes, cwd, writeStorage, readStorage). The 4-arg shape
+				// is the contract for sync-aware reads — see the dedicated
+				// regression block at the bottom of this file for the why.
 				expect(scanTreeHashAliases).toHaveBeenCalledWith(
 					["commitHash1"],
 					TEST_CWD,
+					expect.anything(),
 					expect.anything(),
 				);
 				expect(info).toHaveBeenCalledWith(
@@ -4980,6 +4986,231 @@ describe("JolliMemoryBridge", () => {
 			);
 
 			expect(result).not.toBeNull();
+		});
+	});
+
+	// ── Current-repo read path (sync-pulled visibility regression) ──────────
+	//
+	// Pre-fix: every read for the workspace repo (Memories, Timeline,
+	// branch-memories, single-summary, branch-history index lookup) went
+	// through `getStorage()` → `DualWriteStorage` → `primary` =
+	// `OrphanBranchStorage`. Memory Bank sync writes peer commits only to
+	// `<localFolder>/<repo>/.jolli/` (the FolderStorage shadow), so the
+	// orphan branch on the workspace repo never sees them; the Memories /
+	// Timeline panel showed empty while the Memory Bank tree (walks the
+	// folder) and other (foreign) repos (already use FolderStorage in
+	// step 2 of listSummaryEntries) both showed the new data.
+	//
+	// Fix contract pinned by these tests: for `dual-write` (default) and
+	// `folder` storageMode, the workspace-repo READ surface is a
+	// FolderStorage rooted at the same `<localFolder>/<repo>/` that the
+	// Memory Bank tree walks. For `orphan` mode (no folder data exists)
+	// the legacy path is preserved.
+	describe("current-repo reads use FolderStorage (sync-visibility regression)", () => {
+		it("listSummaryEntries hands a FolderStorage to getIndexEntryMap in dual-write mode (default)", async () => {
+			getIndexEntryMap.mockResolvedValue(new Map());
+			const bridge = makeBridge();
+
+			await bridge.listSummaryEntries(10);
+
+			expect(getIndexEntryMap).toHaveBeenCalled();
+			// The storage argument is the load-bearing assertion: a
+			// DualWriteStorage / OrphanBranchStorage would silently skip
+			// sync-pulled rows because their reads come from the orphan
+			// branch in the workspace repo, which sync never updates.
+			const [, storageArg] = getIndexEntryMap.mock.calls[0];
+			expect(storageArg).toBeInstanceOf(MockFolderStorage);
+		});
+
+		it("listSummaryEntries falls back to legacy storage in orphan mode (no folder data on disk)", async () => {
+			loadConfig.mockResolvedValue({ storageMode: "orphan" });
+			getIndexEntryMap.mockResolvedValue(new Map());
+			const bridge = makeBridge();
+
+			await bridge.listSummaryEntries(10);
+
+			const [, storageArg] = getIndexEntryMap.mock.calls[0];
+			// Orphan-only users never wrote folder data, so flipping their
+			// reads to FolderStorage would return empty across the board.
+			// Their behavior must stay unchanged.
+			expect(storageArg).not.toBeInstanceOf(MockFolderStorage);
+		});
+
+		it("listSummaryEntries uses FolderStorage in folder-only storage mode", async () => {
+			loadConfig.mockResolvedValue({ storageMode: "folder" });
+			getIndexEntryMap.mockResolvedValue(new Map());
+			const bridge = makeBridge();
+
+			await bridge.listSummaryEntries(10);
+
+			const [, storageArg] = getIndexEntryMap.mock.calls[0];
+			expect(storageArg).toBeInstanceOf(MockFolderStorage);
+		});
+
+		it("getSummary hands a FolderStorage to SummaryStore.getSummary in dual-write mode", async () => {
+			getSummary.mockResolvedValue({ commitHash: "abc", topics: [] });
+			const bridge = makeBridge();
+
+			await bridge.getSummary("abc");
+
+			const [hashArg, , storageArg] = getSummary.mock.calls[0];
+			expect(hashArg).toBe("abc");
+			expect(storageArg).toBeInstanceOf(MockFolderStorage);
+		});
+
+		it("getSummaryIndexEntryMap hands a FolderStorage to getIndexEntryMap in dual-write mode", async () => {
+			getIndexEntryMap.mockResolvedValue(new Map());
+			const bridge = makeBridge();
+
+			await bridge.getSummaryIndexEntryMap();
+
+			const [, storageArg] = getIndexEntryMap.mock.calls[0];
+			expect(storageArg).toBeInstanceOf(MockFolderStorage);
+		});
+
+		it("listBranchCommits hands a FolderStorage to getIndexEntryMap (peer commits become hasSummary=true)", async () => {
+			// Full pipeline so listBranchCommits runs to its index lookup.
+			mockExecFileSuccess("feature/test\n"); // getCurrentBranch
+			mockExecFileSuccess("abc\n"); // resolveHistoryBaseRef
+			mockExecFileSuccess("headhash123\n"); // getHEADHash
+			mockExecFileSuccess("mergebase456\n"); // merge-base
+			const logEntry = `commitHash1\x00fix: test change\x00John Doe\x00john@example.com\x002025-03-15T10:00:00Z\x00\x00\n`;
+			mockExecFileSuccess(logEntry); // git log
+			mockExecFileSuccess("origin/feature/test\n"); // upstream rev-parse
+			mockExecFileSuccess("def\n"); // refExists upstream
+			mockExecFileSuccess("\n"); // rev-list unpushed (empty)
+			getIndexEntryMap.mockResolvedValue(
+				new Map([
+					[
+						"commitHash1",
+						{
+							commitHash: "commitHash1",
+							parentCommitHash: null,
+							commitType: "commit",
+							commitMessage: "fix: test change",
+							commitDate: "2025-03-15T10:00:00Z",
+							branch: "feature/test",
+							generatedAt: "2025-03-15T10:00:00Z",
+							topicCount: 1,
+							diffStats: { filesChanged: 2, insertions: 10, deletions: 3 },
+						},
+					],
+				]),
+			);
+			const bridge = makeBridge();
+
+			const result = await bridge.listBranchCommits("main");
+
+			expect(result.commits[0].hasSummary).toBe(true);
+			const [, storageArg] = getIndexEntryMap.mock.calls[0];
+			expect(storageArg).toBeInstanceOf(MockFolderStorage);
+		});
+
+		it("listBranchCommits routes scanTreeHashAliases with (writeStorage, readStorage) so alias writes still dual-write", async () => {
+			// Background alias scan: reads from the folder (so post-sync
+			// peer commits don't get queued as 'unmatched' merely because
+			// orphan is stale), writes through the bridge's DualWriteStorage
+			// so the alias lands in both backends.
+			mockExecFileSuccess("feature/test\n");
+			mockExecFileSuccess("abc\n");
+			mockExecFileSuccess("headhash123\n");
+			mockExecFileSuccess("mergebase456\n");
+			// Two commits in log; only one is in the index, so the other
+			// becomes an unmatched candidate that triggers the scan.
+			const logEntry =
+				`matched\x00fix\x00A\x00a@x\x002025-03-15T10:00:00Z\x00\x00\n` +
+				`unmatched\x00wip\x00A\x00a@x\x002025-03-15T11:00:00Z\x00\x00\n`;
+			mockExecFileSuccess(logEntry);
+			mockExecFileSuccess("origin/feature/test\n");
+			mockExecFileSuccess("def\n");
+			mockExecFileSuccess("\n");
+			getIndexEntryMap.mockResolvedValue(
+				new Map([
+					[
+						"matched",
+						{
+							commitHash: "matched",
+							parentCommitHash: null,
+							commitType: "commit",
+							commitMessage: "fix",
+							commitDate: "2025-03-15T10:00:00Z",
+							branch: "feature/test",
+							generatedAt: "2025-03-15T10:00:00Z",
+							topicCount: 1,
+							diffStats: { filesChanged: 1, insertions: 1, deletions: 0 },
+						},
+					],
+				]),
+			);
+			// Unmatched falls through to git diff for stats — stub the
+			// fallback so resolveCommitMeta doesn't choke.
+			getDiffStats.mockResolvedValueOnce({
+				filesChanged: 0,
+				insertions: 0,
+				deletions: 0,
+			});
+			scanTreeHashAliases.mockResolvedValue(false);
+			const bridge = makeBridge();
+
+			await bridge.listBranchCommits("main");
+
+			// Wait one microtask flush for the fire-and-forget scan.
+			await new Promise((resolve) => setImmediate(resolve));
+
+			expect(scanTreeHashAliases).toHaveBeenCalledTimes(1);
+			const [hashesArg, cwdArg, writeStorageArg, readStorageArg] =
+				scanTreeHashAliases.mock.calls[0];
+			expect(hashesArg).toEqual(["unmatched"]);
+			expect(cwdArg).toBe(TEST_CWD);
+			// Write path stays on DualWriteStorage so aliases land on both
+			// backends — flipping this to FolderStorage would orphan the
+			// alias from the orphan branch and break orphan-only readers.
+			expect(writeStorageArg).not.toBeInstanceOf(MockFolderStorage);
+			// Read path uses FolderStorage so the candidate set reflects
+			// post-sync index state, not the stale workspace orphan branch.
+			expect(readStorageArg).toBeInstanceOf(MockFolderStorage);
+		});
+
+		it("falls back to the write storage when loadConfig throws (defensive catch)", async () => {
+			// Config corruption / FS error / EACCES on the global config
+			// file: createReadStorage cannot pick a mode, so it routes
+			// through getStorage() rather than crash the panel. The bridge
+			// stays functional — reads just lose the sync-visibility
+			// benefit until the next reload that succeeds.
+			loadConfig.mockRejectedValueOnce(new Error("EACCES: config locked"));
+			getIndexEntryMap.mockResolvedValue(new Map());
+			const bridge = makeBridge();
+
+			await bridge.listSummaryEntries(10);
+
+			const [, storageArg] = getIndexEntryMap.mock.calls[0];
+			// Fallback hits the dual-write composite (write storage), not
+			// a fresh FolderStorage. The negative assertion captures the
+			// contract without naming the exact composite class.
+			expect(storageArg).not.toBeInstanceOf(MockFolderStorage);
+		});
+
+		it("reloadStorage() clears the read-storage cache (next read re-resolves under new config)", async () => {
+			// First read under dual-write picks FolderStorage.
+			getIndexEntryMap.mockResolvedValue(new Map());
+			const bridge = makeBridge();
+			await bridge.listSummaryEntries(10);
+			const [, firstStorageArg] = getIndexEntryMap.mock.calls[0];
+			expect(firstStorageArg).toBeInstanceOf(MockFolderStorage);
+
+			// Settings flips storageMode to orphan and calls reloadStorage().
+			loadConfig.mockResolvedValue({ storageMode: "orphan" });
+			bridge.reloadStorage();
+			bridge.invalidateEntriesCache();
+
+			await bridge.listSummaryEntries(10);
+			const [, secondStorageArg] =
+				getIndexEntryMap.mock.calls[getIndexEntryMap.mock.calls.length - 1];
+			// Without clearing the read-storage cache, the orphan-mode flip
+			// would silently stay on FolderStorage until window reload —
+			// exactly the kind of stale-state surprise reloadStorage exists
+			// to prevent for its write counterpart.
+			expect(secondStorageArg).not.toBeInstanceOf(MockFolderStorage);
 		});
 	});
 });

--- a/vscode/src/JolliMemoryBridge.test.ts
+++ b/vscode/src/JolliMemoryBridge.test.ts
@@ -24,11 +24,22 @@ const {
 	MockMetadataManager,
 	mockIsUserEditedOnDisk,
 	mockFindByPath,
+	mockFolderReadFile,
+	mockFolderIsDirty,
 } = vi.hoisted(() => {
 	const isUserEditedOnDisk = vi.fn();
 	const findByPath = vi.fn();
+	// Shared across every MockFolderStorage instance so a single test
+	// override (`mockFolderReadFile.mockResolvedValueOnce(null)` /
+	// `mockFolderIsDirty.mockReturnValueOnce(true)`) flips the C2
+	// folder-empty fallback or the shadow-dirty fallback for all
+	// instances created during that test.
+	const mockFolderReadFile = vi.fn();
+	const mockFolderIsDirty = vi.fn().mockReturnValue(false);
 	return {
 		MockFolderStorage: class {
+			readonly readFile = mockFolderReadFile;
+			readonly isDirty = mockFolderIsDirty;
 			constructor(
 				public readonly rootPath: string,
 				public readonly mm: unknown,
@@ -48,6 +59,8 @@ const {
 		},
 		mockIsUserEditedOnDisk: isUserEditedOnDisk,
 		mockFindByPath: findByPath,
+		mockFolderReadFile,
+		mockFolderIsDirty,
 	};
 });
 
@@ -94,6 +107,11 @@ const {
 	storeNotes: vi.fn(),
 	storePlans: vi.fn(),
 	storeSummary: vi.fn(),
+}));
+
+const { loadRegenerateContext, regenerateSummary } = vi.hoisted(() => ({
+	loadRegenerateContext: vi.fn(),
+	regenerateSummary: vi.fn(),
 }));
 
 const { getDiffStats } = vi.hoisted(() => ({
@@ -245,6 +263,14 @@ vi.mock("../../cli/src/core/SummaryStore.js", () => ({
 	storeNotes,
 	storePlans,
 	storeSummary,
+}));
+
+vi.mock("../../cli/src/core/RegenerateContext.js", () => ({
+	loadRegenerateContext,
+}));
+
+vi.mock("../../cli/src/core/Regenerator.js", () => ({
+	regenerateSummary,
 }));
 
 vi.mock("../../cli/src/core/GitOps.js", () => ({
@@ -445,6 +471,14 @@ describe("JolliMemoryBridge", () => {
 		mkdir.mockResolvedValue(undefined);
 		writeFile.mockResolvedValue(undefined);
 		scanTreeHashAliases.mockResolvedValue(false);
+		// Default: folder has an index — every test that doesn't care
+		// about the C2 fallback gets a non-null result and createReadStorage
+		// returns FolderStorage. Tests pinning the fallback override with
+		// `mockFolderReadFile.mockResolvedValueOnce(null)`.
+		mockFolderReadFile.mockResolvedValue("{}");
+		// Default: folder shadow is clean. Tests pinning the shadow-dirty
+		// fallback override with `mockFolderIsDirty.mockReturnValueOnce(true)`.
+		mockFolderIsDirty.mockReturnValue(false);
 	});
 
 	// ── Constructor ──────────────────────────────────────────────────────
@@ -2195,6 +2229,60 @@ describe("JolliMemoryBridge", () => {
 
 	// ── listSummaries / getSummary ───────────────────────────────────────
 
+	describe("createReadStorage (mode selection)", () => {
+		// The bridge's read-storage selector picks FolderStorage in
+		// dual-write mode only when the folder is BOTH initialized
+		// (index.json exists) AND clean (`shadow-status.json` absent).
+		// `DualWriteStorage.writeFiles` marks the folder dirty on any
+		// shadow write failure, so a dirty marker indicates the folder
+		// view is stale relative to the orphan branch. Falling back to
+		// orphan in that state mirrors the existing folder-empty fallback
+		// (C2 in {@link createReadStorage}'s doc): trust orphan whenever
+		// the folder isn't a complete, current picture.
+
+		it("returns FolderStorage when folder has index AND is clean (baseline)", async () => {
+			listSummaries.mockResolvedValue([]);
+			const bridge = makeBridge();
+
+			await bridge.listSummaries(10);
+
+			expect(listSummaries).toHaveBeenCalledTimes(1);
+			const storageArg = listSummaries.mock.calls[0][2];
+			expect(storageArg).toBeInstanceOf(MockFolderStorage);
+		});
+
+		it("falls back to OrphanBranchStorage when folder is dirty (shadow write failed)", async () => {
+			// Without this fallback the bridge would still hand FolderStorage
+			// to getSummary / listSummaries / regenerate context after a
+			// shadow write failure — surfacing stale or missing memories
+			// while the orphan branch holds the fresh authoritative copy.
+			mockFolderIsDirty.mockReturnValue(true);
+			listSummaries.mockResolvedValue([]);
+			const bridge = makeBridge();
+
+			await bridge.listSummaries(10);
+
+			const storageArg = listSummaries.mock.calls[0][2];
+			expect(storageArg).not.toBeInstanceOf(MockFolderStorage);
+		});
+
+		it("still falls back to orphan when folder lacks index, regardless of dirty marker", async () => {
+			// The two fallback signals are independent and either is
+			// sufficient. Lock the C2 (no-index) path's existing behavior
+			// in place so future refactors that move the isDirty check
+			// don't accidentally make the no-index path depend on cleanliness.
+			mockFolderReadFile.mockResolvedValueOnce(null);
+			mockFolderIsDirty.mockReturnValue(false);
+			listSummaries.mockResolvedValue([]);
+			const bridge = makeBridge();
+
+			await bridge.listSummaries(10);
+
+			const storageArg = listSummaries.mock.calls[0][2];
+			expect(storageArg).not.toBeInstanceOf(MockFolderStorage);
+		});
+	});
+
 	describe("listSummaries()", () => {
 		it("fetches summary list entries then loads full summaries", async () => {
 			listSummaries.mockResolvedValue([
@@ -3002,7 +3090,13 @@ describe("JolliMemoryBridge", () => {
 	});
 
 	describe("storeSummary()", () => {
-		it("forwards the Bridge's storage to SummaryStore.storeSummary", async () => {
+		it("forwards the Bridge's storage to SummaryStore.storeSummary and threads a FolderStorage readStorage in dual-write mode", async () => {
+			// readStorage is the load-bearing protection against folder-only
+			// peer-synced rows being silently dropped: SummaryStore.storeSummary
+			// uses it to union the existing index/catalog base across both
+			// backends before the dual-write rewrites them. Mock the call to
+			// land both arguments so a regression that drops the 6th param
+			// (or aliases it to the write storage) surfaces here.
 			storeSummary.mockResolvedValue(undefined);
 			const bridge = makeBridge();
 			const summary = {
@@ -3022,7 +3116,72 @@ describe("JolliMemoryBridge", () => {
 				true,
 				undefined,
 				storageShape,
+				expect.any(MockFolderStorage),
 			);
+		});
+
+		it("does not pass a FolderStorage readStorage in orphan-only mode", async () => {
+			// Orphan-only users have no folder shadow to protect — readStorage
+			// must be an OrphanBranchStorage (not a FolderStorage) so the union
+			// path inside SummaryStore.storeSummary is a no-op against the same
+			// backend. Pinning this protects the legacy mode from accidentally
+			// reading the (empty) folder layout.
+			loadConfig.mockResolvedValue({ storageMode: "orphan" });
+			storeSummary.mockResolvedValue(undefined);
+			const bridge = makeBridge();
+
+			await bridge.storeSummary({ commitHash: "abc1" } as never, true);
+
+			const lastCall = storeSummary.mock.calls.at(-1);
+			expect(lastCall?.[5]).toBeDefined();
+			expect(lastCall?.[5]).not.toBeInstanceOf(MockFolderStorage);
+		});
+	});
+
+	describe("regenerate methods route through read storage", () => {
+		it("loadRegenerateContext hands a FolderStorage to RegenerateContext.loadRegenerateContext in dual-write mode", async () => {
+			// `loadRegenerateContext` aggregates transcript / plan / note /
+			// linear-issue counts that drive the confirm dialog. In dual-write
+			// mode it must read via the folder shadow so that peer-synced
+			// artifacts (e.g. transcripts persisted on another machine) surface
+			// in the dialog. The previous wiring used `getStorage()` which is
+			// a `DualWriteStorage` whose `readFile` is pinned to the orphan
+			// primary, masking those rows.
+			loadRegenerateContext.mockResolvedValue({
+				entryCount: 0,
+				sessionCount: 0,
+				sources: [],
+				humanTurns: 0,
+				plansCount: 0,
+				notesCount: 0,
+				linearCount: 0,
+			});
+			const bridge = makeBridge();
+
+			await bridge.loadRegenerateContext({ commitHash: "abc" } as never);
+
+			expect(loadRegenerateContext).toHaveBeenCalledTimes(1);
+			const [, , storageArg] = loadRegenerateContext.mock.calls[0];
+			expect(storageArg).toBeInstanceOf(MockFolderStorage);
+		});
+
+		it("regenerateSummary hands a FolderStorage to Regenerator.regenerateSummary in dual-write mode", async () => {
+			// Same rationale as `loadRegenerateContext`: the LLM input needs
+			// transcripts/plans/notes/linear archives from the folder shadow
+			// when those rows haven't reached the orphan branch yet — pulling
+			// them via `getStorage()` (DualWriteStorage → primary) would feed
+			// the LLM an empty or stale conversation.
+			regenerateSummary.mockResolvedValue({ updated: {}, result: {} });
+			const bridge = makeBridge();
+
+			await bridge.regenerateSummary(
+				{ commitHash: "abc" } as never,
+				{} as never,
+			);
+
+			expect(regenerateSummary).toHaveBeenCalledTimes(1);
+			const [, , , storageArg] = regenerateSummary.mock.calls[0];
+			expect(storageArg).toBeInstanceOf(MockFolderStorage);
 		});
 	});
 
@@ -3604,9 +3763,9 @@ describe("JolliMemoryBridge", () => {
 
 			// Wait for the fire-and-forget promise to resolve
 			await vi.waitFor(() => {
-				// (hashes, cwd, writeStorage, readStorage). The 4-arg shape
-				// is the contract for sync-aware reads — see the dedicated
-				// regression block at the bottom of this file for the why.
+				// (hashes, cwd, writeStorage, readStorage). 4-arg shape:
+				// preflight reads via readStorage, lock-held re-read + alias
+				// write use writeStorage. See JolliMemoryBridge.readStoragePromise.
 				expect(scanTreeHashAliases).toHaveBeenCalledWith(
 					["commitHash1"],
 					TEST_CWD,
@@ -4989,23 +5148,23 @@ describe("JolliMemoryBridge", () => {
 		});
 	});
 
-	// ── Current-repo read path (sync-pulled visibility regression) ──────────
+	// ── Current-repo read path (workspace-repo storage routing) ────────────
 	//
-	// Pre-fix: every read for the workspace repo (Memories, Timeline,
-	// branch-memories, single-summary, branch-history index lookup) went
-	// through `getStorage()` → `DualWriteStorage` → `primary` =
-	// `OrphanBranchStorage`. Memory Bank sync writes peer commits only to
-	// `<localFolder>/<repo>/.jolli/` (the FolderStorage shadow), so the
-	// orphan branch on the workspace repo never sees them; the Memories /
-	// Timeline panel showed empty while the Memory Bank tree (walks the
-	// folder) and other (foreign) repos (already use FolderStorage in
-	// step 2 of listSummaryEntries) both showed the new data.
+	// Invariant: for `dual-write` (default) and `folder` storageMode, every
+	// workspace-repo READ (Memories, Timeline, branch-memories, single-
+	// summary, branch-history index lookup) flows through a FolderStorage
+	// rooted at `<localFolder>/<repo>/`. Reading via `DualWriteStorage`
+	// would silently miss any row written to the folder by anything other
+	// than this device's local commits (Memory Bank sync, external
+	// migration, sibling IDE on the same folder) because its `readFile`
+	// is pinned to the orphan-branch primary.
 	//
-	// Fix contract pinned by these tests: for `dual-write` (default) and
-	// `folder` storageMode, the workspace-repo READ surface is a
-	// FolderStorage rooted at the same `<localFolder>/<repo>/` that the
-	// Memory Bank tree walks. For `orphan` mode (no folder data exists)
-	// the legacy path is preserved.
+	// For `orphan` mode (no folder data on disk) reads stay on the orphan
+	// branch — same path as 0.98 and earlier.
+	//
+	// For `dual-write` mode when folder has no index yet (fresh install
+	// before migration, or folder wiped), reads fall back to orphan so
+	// the panel keeps showing data instead of "no memories yet".
 	describe("current-repo reads use FolderStorage (sync-visibility regression)", () => {
 		it("listSummaryEntries hands a FolderStorage to getIndexEntryMap in dual-write mode (default)", async () => {
 			getIndexEntryMap.mockResolvedValue(new Map());
@@ -5171,26 +5330,126 @@ describe("JolliMemoryBridge", () => {
 			expect(readStorageArg).toBeInstanceOf(MockFolderStorage);
 		});
 
-		it("falls back to the write storage when loadConfig throws (defensive catch)", async () => {
-			// Config corruption / FS error / EACCES on the global config
-			// file: createReadStorage cannot pick a mode, so it routes
-			// through getStorage() rather than crash the panel. The bridge
-			// stays functional — reads just lose the sync-visibility
-			// benefit until the next reload that succeeds.
-			loadConfig.mockRejectedValueOnce(new Error("EACCES: config locked"));
+		it("falls back to OrphanBranchStorage in dual-write mode when folder lacks an index", async () => {
+			// Folder has no index.json on disk: fresh install before
+			// migration ran, or the user wiped the Memory Bank folder.
+			// Routing reads through FolderStorage would render "no
+			// memories" while the orphan branch still holds the user's
+			// data. The fallback keeps the panel showing real data.
+			mockFolderReadFile.mockResolvedValueOnce(null);
 			getIndexEntryMap.mockResolvedValue(new Map());
 			const bridge = makeBridge();
 
 			await bridge.listSummaryEntries(10);
 
 			const [, storageArg] = getIndexEntryMap.mock.calls[0];
-			// Fallback hits the dual-write composite (write storage), not
-			// a fresh FolderStorage. The negative assertion captures the
-			// contract without naming the exact composite class.
 			expect(storageArg).not.toBeInstanceOf(MockFolderStorage);
 		});
 
-		it("reloadStorage() clears the read-storage cache (next read re-resolves under new config)", async () => {
+		it("listSummaries hands a FolderStorage to SummaryStore.listSummaries in dual-write mode", async () => {
+			listSummaries.mockResolvedValue([]);
+			const bridge = makeBridge();
+
+			await bridge.listSummaries(10);
+
+			const [, , storageArg] = listSummaries.mock.calls[0];
+			expect(storageArg).toBeInstanceOf(MockFolderStorage);
+		});
+
+		it("listBranchMemories hands a FolderStorage to getIndexEntryMap for the current repo", async () => {
+			getIndexEntryMap.mockResolvedValue(new Map());
+			const bridge = makeBridge();
+
+			await bridge.listBranchMemories("test-repo", "main");
+
+			const [, storageArg] = getIndexEntryMap.mock.calls[0];
+			expect(storageArg).toBeInstanceOf(MockFolderStorage);
+		});
+
+		it("generateSquashMessageWithLLM reads summaries via FolderStorage in dual-write mode", async () => {
+			// git log for hash1
+			mockExecFileSuccess("fix: x\n");
+			getSummary.mockResolvedValueOnce({ topics: [] });
+			// rev-list --count
+			mockExecFileSuccess("1\n");
+			generateSquashMessage.mockResolvedValue("squashed");
+			const bridge = makeBridge();
+
+			await bridge.generateSquashMessageWithLLM(["hash1"]);
+
+			// Without folder-routed reads, a row only present in the folder
+			// (e.g. peer-synced) would surface here as `null` from getSummary
+			// and silently lose its topics in the merged prompt.
+			const [, , storageArg] = getSummary.mock.calls[0];
+			expect(storageArg).toBeInstanceOf(MockFolderStorage);
+		});
+
+		it("createReadStorage defaults unknown storageMode values to OrphanBranchStorage (matches StorageFactory)", async () => {
+			// A config typo or future-mode value (e.g. `duallwrite`) used to
+			// land write on orphan (StorageFactory.default) but read on folder
+			// (createReadStorage's `if mode==="orphan"` else folder). That
+			// asymmetry made the panel show "no memories" while the orphan
+			// branch silently received writes — a baffling failure mode. The
+			// switch now matches StorageFactory's default → orphan, so both
+			// sides agree on unknown modes.
+			loadConfig.mockResolvedValue({ storageMode: "duallwrite-typo" });
+			getIndexEntryMap.mockResolvedValue(new Map());
+			const bridge = makeBridge();
+
+			await bridge.listSummaryEntries(10);
+
+			const [, storageArg] = getIndexEntryMap.mock.calls[0];
+			expect(storageArg).not.toBeInstanceOf(MockFolderStorage);
+		});
+
+		it("reloadReadStorage() re-probes the dual-write folder-empty fallback so peer-synced rows become visible after refresh", async () => {
+			// First read finds the folder empty (e.g. fresh install before
+			// migration completed) and caches an OrphanBranchStorage fallback.
+			// The user then triggers a peer sync that populates the folder,
+			// and clicks the Memories refresh action — which calls both
+			// `invalidateEntriesCache()` and `reloadReadStorage()`. The next
+			// read must re-probe and switch to FolderStorage instead of
+			// serving the cached fallback forever. The pairing mirrors
+			// Extension.ts's `jollimemory.refreshMemories` handler.
+			mockFolderReadFile.mockResolvedValueOnce(null);
+			getIndexEntryMap.mockResolvedValue(new Map());
+			const bridge = makeBridge();
+
+			await bridge.listSummaryEntries(10);
+			const [, firstStorageArg] = getIndexEntryMap.mock.calls[0];
+			expect(firstStorageArg).not.toBeInstanceOf(MockFolderStorage);
+
+			// Peer sync drops index.json into the folder; refresh button drops
+			// both the aggregated entries cache and the readStorage cache so
+			// the next read re-probes the fallback decision.
+			mockFolderReadFile.mockResolvedValue('{"version":3,"entries":[]}');
+			bridge.invalidateEntriesCache();
+			bridge.reloadReadStorage();
+
+			await bridge.listSummaryEntries(10);
+			const lastCall = getIndexEntryMap.mock.calls.at(-1);
+			expect(lastCall?.[1]).toBeInstanceOf(MockFolderStorage);
+		});
+
+		it("reloadReadStorage() keeps the write-storage cache hot (only readStorage is dropped)", async () => {
+			// Refresh button should not churn the write-storage pipeline — only
+			// the read-storage cache. Verifies the asymmetry between
+			// `reloadStorage()` (drops both) and `reloadReadStorage()` (drops
+			// only the read side) so a future bug that conflates them surfaces.
+			storeSummary.mockResolvedValue(undefined);
+			const bridge = makeBridge();
+
+			await bridge.storeSummary({ commitHash: "a" } as never, true);
+			const firstWriteStorage = storeSummary.mock.calls[0][4];
+
+			bridge.reloadReadStorage();
+
+			await bridge.storeSummary({ commitHash: "b" } as never, true);
+			const secondWriteStorage = storeSummary.mock.calls[1][4];
+			expect(secondWriteStorage).toBe(firstWriteStorage);
+		});
+
+		it("reloadStorage() alone clears the entries cache so the next read re-resolves storage", async () => {
 			// First read under dual-write picks FolderStorage.
 			getIndexEntryMap.mockResolvedValue(new Map());
 			const bridge = makeBridge();
@@ -5198,19 +5457,45 @@ describe("JolliMemoryBridge", () => {
 			const [, firstStorageArg] = getIndexEntryMap.mock.calls[0];
 			expect(firstStorageArg).toBeInstanceOf(MockFolderStorage);
 
-			// Settings flips storageMode to orphan and calls reloadStorage().
+			// Settings flips storageMode to orphan and calls reloadStorage()
+			// only — NO manual invalidateEntriesCache(). That call alone
+			// must be enough to make the next read re-resolve, otherwise
+			// the entries-cache short-circuit silently keeps the old data
+			// alive after a mode flip.
 			loadConfig.mockResolvedValue({ storageMode: "orphan" });
 			bridge.reloadStorage();
-			bridge.invalidateEntriesCache();
 
 			await bridge.listSummaryEntries(10);
 			const [, secondStorageArg] =
 				getIndexEntryMap.mock.calls[getIndexEntryMap.mock.calls.length - 1];
-			// Without clearing the read-storage cache, the orphan-mode flip
-			// would silently stay on FolderStorage until window reload —
-			// exactly the kind of stale-state surprise reloadStorage exists
-			// to prevent for its write counterpart.
 			expect(secondStorageArg).not.toBeInstanceOf(MockFolderStorage);
+		});
+
+		it("rejected createReadStorage promise resets so the next read retries", async () => {
+			// loadConfig itself never rejects in production (SessionTracker
+			// swallows internally) — but the cache-reset guarantee matters
+			// for any future helper that can throw mid-init (e.g. a
+			// migration probe). Pin it now via a transient loadConfig
+			// rejection so a regression in `.catch(() => { ... = null })`
+			// would surface here as "second call also fails".
+			//
+			// Routed through getSummary (no internal catch) so the rejection
+			// surfaces; listSummaryEntries swallows step-1 errors and would
+			// mask whatever the cache state was.
+			loadConfig.mockRejectedValueOnce(new Error("transient"));
+			getSummary.mockResolvedValue({ commitHash: "abc", topics: [] });
+			const bridge = makeBridge();
+
+			await expect(bridge.getSummary("abc")).rejects.toThrow("transient");
+
+			// Without the cache reset, this second call would await the
+			// cached rejected promise and throw "transient" again — the
+			// user would be permanently stuck on the transient error until
+			// reloadStorage().
+			await expect(bridge.getSummary("abc")).resolves.toEqual({
+				commitHash: "abc",
+				topics: [],
+			});
 		});
 	});
 });

--- a/vscode/src/JolliMemoryBridge.ts
+++ b/vscode/src/JolliMemoryBridge.ts
@@ -20,6 +20,7 @@ import { filterToBranchHeads } from "../../cli/src/core/HeadEntryFilter.js";
 import {
 	extractRepoName,
 	getRemoteUrl,
+	resolveKBPath,
 	resolveKbParent,
 } from "../../cli/src/core/KBPathResolver.js";
 import {
@@ -28,6 +29,7 @@ import {
 } from "../../cli/src/core/KBRepoDiscoverer.js";
 import type { ManifestEntry } from "../../cli/src/core/KBTypes.js";
 import { MetadataManager } from "../../cli/src/core/MetadataManager.js";
+import { OrphanBranchStorage } from "../../cli/src/core/OrphanBranchStorage.js";
 import { normalizePathForCompare } from "../../cli/src/core/PathUtils.js";
 import {
 	loadConfig,
@@ -184,20 +186,40 @@ export class JolliMemoryBridge {
 	readonly cwd: string;
 
 	/**
-	 * Storage backend the bridge passes explicitly into every SummaryStore call,
-	 * so reads honour the user's storageMode (orphan / dual-write / folder)
-	 * without relying on the module-level `setActiveStorage` global. The
-	 * QueueWorker still uses that global because it lives in a separate process;
-	 * the extension process owns this instance instead.
+	 * Storage backend used for **writes** (and as the read fallback in
+	 * `orphan` storageMode). In `dual-write` mode this is a
+	 * `DualWriteStorage` whose `primary` is the orphan branch and whose
+	 * `shadow` is the FolderStorage under `<localFolder>/<repo>/.jolli/`.
+	 * Writes go to both so the Memory Bank folder and orphan branch stay
+	 * in lockstep for everything this device commits locally.
 	 *
-	 * Lazy: created on first `getStorage()` call rather than in the constructor,
-	 * so bridge methods that don't touch SummaryStore (git ops, install, etc.)
-	 * don't pay for config reads / FolderStorage init they'll never use.
-	 * `reloadStorage()` clears the cache so the next `getStorage()` rebuilds
-	 * from the latest config (used after a settings-save changes storageMode
-	 * or localFolder).
+	 * Reads use {@link getReadStorage}, NOT this — see that helper for
+	 * the rationale (sync visibility regression).
+	 *
+	 * Lazy: created on first `getStorage()` call rather than in the
+	 * constructor, so bridge methods that don't touch SummaryStore (git
+	 * ops, install, etc.) don't pay for config reads / FolderStorage
+	 * init they'll never use. `reloadStorage()` clears the cache so the
+	 * next `getStorage()` rebuilds from the latest config (used after a
+	 * settings-save changes storageMode or localFolder).
 	 */
 	private storagePromise: Promise<StorageProvider> | null = null;
+
+	/**
+	 * Companion storage for **reads** on the current workspace repo. See
+	 * {@link getReadStorage} for the full rationale; the short version is
+	 * that Memory Bank sync writes peer commits only to
+	 * `<localFolder>/<repo>/.jolli/`, so reads going through
+	 * `DualWriteStorage` (whose `readFile` is hardwired to `primary` =
+	 * orphan branch) silently miss everything sync brought in. Decoupling
+	 * the read path lets the panel match what Memory Bank Tree view and
+	 * the foreign-repo step of {@link listSummaryEntries} already see.
+	 *
+	 * Cleared by `reloadStorage()` alongside `storagePromise` so a
+	 * settings-driven `storageMode` flip takes effect on the next read
+	 * without a window reload.
+	 */
+	private readStoragePromise: Promise<StorageProvider> | null = null;
 
 	constructor(
 		/** Absolute path to the workspace root (git repo) */
@@ -207,8 +229,10 @@ export class JolliMemoryBridge {
 	}
 
 	/**
-	 * Returns the current StorageProvider, awaiting the initial creation or any
-	 * in-flight reload. Internal helper used by every SummaryStore wrapper below.
+	 * Returns the StorageProvider used for **writes** against the
+	 * current workspace repo. Awaits the initial creation or any
+	 * in-flight reload. Internal helper used by every SummaryStore
+	 * wrapper that *mutates* state.
 	 */
 	private getStorage(): Promise<StorageProvider> {
 		if (!this.storagePromise) {
@@ -218,20 +242,83 @@ export class JolliMemoryBridge {
 	}
 
 	/**
-	 * Drops the cached storage backend so the next `getStorage()` rebuilds
-	 * from the latest config. Called by the settings-save callback after the
-	 * user changes `storageMode` or `localFolder` so subsequent reads hit the
-	 * right backend without requiring a window reload.
+	 * Returns the StorageProvider used for **reads** against the current
+	 * workspace repo. In `dual-write` (default) and `folder` modes this
+	 * is a FolderStorage rooted at the same `<localFolder>/<repo>/`
+	 * directory that the Memory Bank tree walks — making the workspace
+	 * repo's read surface identical to every foreign-repo path in
+	 * {@link listSummaryEntries} step 2 ({@link getSummaryAnyRepo}, etc).
+	 *
+	 * Why split read from write: Memory Bank sync pulls peer commits
+	 * into the FolderStorage shadow only — the orphan branch on the
+	 * workspace repo is never updated by a sync round. Reads going
+	 * through `DualWriteStorage.readFile` (hardwired to `primary` =
+	 * orphan) therefore miss every sync-pulled row, which surfaces as
+	 * Memories / Timeline showing pre-sync state while the Memory Bank
+	 * Tree view (walks disk) shows the new commits. Two views, one
+	 * source of truth, used to disagree.
+	 *
+	 * Falls back to {@link getStorage} (orphan-flavoured) for
+	 * `storageMode = "orphan"`, where no folder data exists on disk —
+	 * legacy single-mode users see no behavior change.
+	 *
+	 * Writes intentionally stay on {@link getStorage} so they continue
+	 * to land on both backends; only reads pivot.
+	 */
+	private getReadStorage(): Promise<StorageProvider> {
+		if (!this.readStoragePromise) {
+			this.readStoragePromise = this.createReadStorage();
+		}
+		return this.readStoragePromise;
+	}
+
+	private async createReadStorage(): Promise<StorageProvider> {
+		let config: Record<string, unknown>;
+		try {
+			config = (await loadConfig()) as Record<string, unknown>;
+		} catch (err) {
+			log.warn(
+				"bridge",
+				"createReadStorage: failed to load config (%s) — falling back to write storage",
+				err instanceof Error ? err.message : String(err),
+			);
+			return this.getStorage();
+		}
+		const mode = (config.storageMode as string | undefined) ?? "dual-write";
+		if (mode === "orphan") {
+			return new OrphanBranchStorage(this.cwd);
+		}
+		const customKBPath = config.localFolder as string | undefined;
+		const repoName = extractRepoName(this.cwd);
+		const remoteUrl = getRemoteUrl(this.cwd);
+		const kbRoot = resolveKBPath(repoName, remoteUrl, customKBPath);
+		const mm = new MetadataManager(join(kbRoot, ".jolli"));
+		return new FolderStorage(kbRoot, mm);
+	}
+
+	/**
+	 * Drops the cached storage backends so the next read/write rebuilds
+	 * from the latest config. Called by the settings-save callback after
+	 * the user changes `storageMode` or `localFolder` so subsequent
+	 * reads/writes hit the right backend without requiring a window
+	 * reload.
+	 *
+	 * Clears both `storagePromise` (write path) AND `readStoragePromise`
+	 * (read path) — leaving the read cache in place after an
+	 * `orphan` ↔ `dual-write` flip would keep reads silently parked on
+	 * the previous mode's storage until window reload, which is exactly
+	 * the surprise this method exists to prevent.
 	 *
 	 * Also clears the aggregated cross-repo entries cache: when the user
-	 * changes `localFolder`, the discoverable set of foreign repos under the
-	 * Memory Bank parent changes too, so the cached merged list is stale by
-	 * definition. The old behavior left the cache in place, which is why
-	 * "switch Memory Bank folder then open Memories" used to show entries
-	 * from the previous folder until a window reload.
+	 * changes `localFolder`, the discoverable set of foreign repos under
+	 * the Memory Bank parent changes too, so the cached merged list is
+	 * stale by definition. The old behavior left the cache in place,
+	 * which is why "switch Memory Bank folder then open Memories" used
+	 * to show entries from the previous folder until a window reload.
 	 */
 	reloadStorage(): void {
 		this.storagePromise = null;
+		this.readStoragePromise = null;
 		this.cachedRootEntries = null;
 	}
 
@@ -901,8 +988,14 @@ export class JolliMemoryBridge {
 			.filter((parts) => parts.length >= 5);
 
 		const commitHashes = parsedEntries.map((parts) => parts[0]);
-		const storage = await this.getStorage();
-		const indexEntryMap = await getIndexEntryMap(this.cwd, storage);
+		// Read storage: post-sync data lives in the FolderStorage shadow
+		// when the user is on dual-write/folder mode, not on the orphan
+		// branch. Write storage (for the background alias scan below)
+		// stays on DualWriteStorage so aliases still land on both
+		// backends.
+		const readStorage = await this.getReadStorage();
+		const writeStorage = await this.getStorage();
+		const indexEntryMap = await getIndexEntryMap(this.cwd, readStorage);
 
 		const commits: Array<BranchCommit> = [];
 
@@ -942,16 +1035,19 @@ export class JolliMemoryBridge {
 		// Fire-and-forget — when new aliases are found, callers should refresh the panel.
 		const unmatchedHashes = commitHashes.filter((h) => !indexEntryMap.has(h));
 		if (unmatchedHashes.length > 0) {
-			void scanTreeHashAliases(unmatchedHashes, this.cwd, storage).then(
-				(anyFound) => {
-					if (anyFound) {
-						log.info(
-							"commits",
-							"Tree hash aliases found — panel refresh recommended",
-						);
-					}
-				},
-			);
+			void scanTreeHashAliases(
+				unmatchedHashes,
+				this.cwd,
+				writeStorage,
+				readStorage,
+			).then((anyFound) => {
+				if (anyFound) {
+					log.info(
+						"commits",
+						"Tree hash aliases found — panel refresh recommended",
+					);
+				}
+			});
 		}
 
 		const cachedCount = commits.filter(
@@ -1160,7 +1256,11 @@ export class JolliMemoryBridge {
 		}> = [];
 		let ticketId: string | undefined;
 
-		const storage = await this.getStorage();
+		// Squash-message prompt is a pure read of the summaries that will
+		// be merged — getReadStorage() so a peer-synced commit (only in
+		// the folder shadow on this device) still contributes its topics
+		// instead of being silently skipped as "no summary".
+		const storage = await this.getReadStorage();
 		for (const hash of hashes) {
 			const msg = (
 				await tryExecGit(["log", "-1", "--pretty=format:%s", hash], this.cwd)
@@ -1307,9 +1407,9 @@ export class JolliMemoryBridge {
 
 	// ── Summary access ────────────────────────────────────────────────────
 
-	/** Lists the most recent summaries from the JolliMemory orphan branch. */
+	/** Lists the most recent summaries for the workspace repo. */
 	async listSummaries(count: number): Promise<Array<CommitSummary>> {
-		const storage = await this.getStorage();
+		const storage = await this.getReadStorage();
 		const entries = await listSummaries(count, this.cwd, storage);
 		const summaries: Array<CommitSummary> = [];
 		for (const entry of entries) {
@@ -1357,10 +1457,14 @@ export class JolliMemoryBridge {
 			const merged: SummaryIndexEntry[] = [];
 			const currentRepoName = extractRepoName(this.cwd);
 
-			// 1. Current workspace repo — keep its configured storage path so
-			//    orphan/dual-write modes continue to read from their primary.
+			// 1. Current workspace repo — read through the FolderStorage
+			//    shadow when storageMode has one (dual-write / folder), so
+			//    rows pulled in by Memory Bank sync are visible. orphan-only
+			//    users fall back to the orphan branch via getReadStorage()
+			//    so their behavior is unchanged. See getReadStorage() for
+			//    the full rationale.
 			try {
-				const storage = await this.getStorage();
+				const storage = await this.getReadStorage();
 				const map = await getIndexEntryMap(this.cwd, storage);
 				for (const entry of map.values()) {
 					merged.push({ ...entry, repoName: currentRepoName });
@@ -1472,9 +1576,10 @@ export class JolliMemoryBridge {
 	 * agreement.
 	 *
 	 * Resolves the right storage based on whether `repoName` is the workspace
-	 * repo (uses the active storage configured for the workspace) or a foreign
-	 * one (instantiates {@link FolderStorage} pointed at that repo's kbRoot,
-	 * mirroring how {@link listSummaryEntries} step 2 walks discovered repos).
+	 * repo (routes through {@link getReadStorage} so sync-pulled rows are
+	 * visible) or a foreign one (instantiates {@link FolderStorage} pointed at
+	 * that repo's kbRoot, mirroring how {@link listSummaryEntries} step 2
+	 * walks discovered repos).
 	 */
 	async listBranchMemories(
 		repoName: string,
@@ -1484,7 +1589,7 @@ export class JolliMemoryBridge {
 		let storage: StorageProvider;
 		let cwd: string | undefined;
 		if (repoName === currentRepoName) {
-			storage = await this.getStorage();
+			storage = await this.getReadStorage();
 			cwd = this.cwd;
 		} else {
 			try {
@@ -1555,7 +1660,7 @@ export class JolliMemoryBridge {
 	 * wrap this in try/catch and surface a "use a longer prefix" hint.
 	 */
 	async getSummary(hash: string): Promise<CommitSummary | null> {
-		const storage = await this.getStorage();
+		const storage = await this.getReadStorage();
 		return getSummary(hash, this.cwd, storage);
 	}
 
@@ -1871,7 +1976,7 @@ export class JolliMemoryBridge {
 	async getSummaryIndexEntryMap(): Promise<
 		ReadonlyMap<string, import("../../cli/src/Types.js").SummaryIndexEntry>
 	> {
-		const storage = await this.getStorage();
+		const storage = await this.getReadStorage();
 		return getIndexEntryMap(this.cwd, storage);
 	}
 

--- a/vscode/src/JolliMemoryBridge.ts
+++ b/vscode/src/JolliMemoryBridge.ts
@@ -20,7 +20,6 @@ import { filterToBranchHeads } from "../../cli/src/core/HeadEntryFilter.js";
 import {
 	extractRepoName,
 	getRemoteUrl,
-	resolveKBPath,
 	resolveKbParent,
 } from "../../cli/src/core/KBPathResolver.js";
 import {
@@ -36,7 +35,10 @@ import {
 	savePluginSource,
 	saveSquashPending,
 } from "../../cli/src/core/SessionTracker.js";
-import { createStorage } from "../../cli/src/core/StorageFactory.js";
+import {
+	createFolderStorage,
+	createStorage,
+} from "../../cli/src/core/StorageFactory.js";
 import type { StorageProvider } from "../../cli/src/core/StorageProvider.js";
 import {
 	generateCommitMessage,
@@ -186,38 +188,46 @@ export class JolliMemoryBridge {
 	readonly cwd: string;
 
 	/**
-	 * Storage backend used for **writes** (and as the read fallback in
-	 * `orphan` storageMode). In `dual-write` mode this is a
-	 * `DualWriteStorage` whose `primary` is the orphan branch and whose
-	 * `shadow` is the FolderStorage under `<localFolder>/<repo>/.jolli/`.
-	 * Writes go to both so the Memory Bank folder and orphan branch stay
-	 * in lockstep for everything this device commits locally.
+	 * Storage backend used for **writes** against the current workspace
+	 * repo. Reads use {@link readStoragePromise} instead — see that
+	 * field for the why.
 	 *
-	 * Reads use {@link getReadStorage}, NOT this — see that helper for
-	 * the rationale (sync visibility regression).
-	 *
-	 * Lazy: created on first `getStorage()` call rather than in the
-	 * constructor, so bridge methods that don't touch SummaryStore (git
-	 * ops, install, etc.) don't pay for config reads / FolderStorage
-	 * init they'll never use. `reloadStorage()` clears the cache so the
-	 * next `getStorage()` rebuilds from the latest config (used after a
-	 * settings-save changes storageMode or localFolder).
+	 * Lazy: built on first {@link getStorage} call so bridge methods
+	 * that don't touch SummaryStore (git ops, install, …) don't pay for
+	 * config reads. {@link reloadStorage} clears the cache so the next
+	 * call rebuilds against the latest config.
 	 */
 	private storagePromise: Promise<StorageProvider> | null = null;
 
 	/**
-	 * Companion storage for **reads** on the current workspace repo. See
-	 * {@link getReadStorage} for the full rationale; the short version is
-	 * that Memory Bank sync writes peer commits only to
-	 * `<localFolder>/<repo>/.jolli/`, so reads going through
-	 * `DualWriteStorage` (whose `readFile` is hardwired to `primary` =
-	 * orphan branch) silently miss everything sync brought in. Decoupling
-	 * the read path lets the panel match what Memory Bank Tree view and
-	 * the foreign-repo step of {@link listSummaryEntries} already see.
+	 * Read-side storage for the current workspace repo.
 	 *
-	 * Cleared by `reloadStorage()` alongside `storagePromise` so a
-	 * settings-driven `storageMode` flip takes effect on the next read
-	 * without a window reload.
+	 * Invariant pinned by this field: every workspace-repo READ
+	 * (Memories, Timeline, branch-memories, single-summary, branch-
+	 * history index lookup) sees whatever lives on disk under
+	 * `<localFolder>/<repo>/.jolli/`, matching the surface that the
+	 * Memory Bank tree view walks and that foreign-repo paths
+	 * ({@link listSummaryEntries} step 2, {@link getSummaryAnyRepo})
+	 * already use. Reading via `DualWriteStorage.readFile` would silently
+	 * miss any row written there by anything other than this device's
+	 * local commits (sync, external migration, sibling IDE on the same
+	 * folder) because `DualWriteStorage.readFile` is pinned to the
+	 * orphan-branch primary — see [DualWriteStorage.ts:21](../../cli/src/core/DualWriteStorage.ts).
+	 *
+	 * Mode handling (resolved by {@link createReadStorage}):
+	 * - `dual-write` (default): FolderStorage when the folder both has
+	 *   an index AND is clean (no shadow-dirty marker). OrphanBranchStorage
+	 *   when either signal indicates the folder isn't a complete current
+	 *   picture — a freshly wiped folder doesn't surface as "no memories"
+	 *   while orphan is intact, and a folder whose last shadow write
+	 *   failed doesn't surface stale rows while orphan holds the
+	 *   authoritative update.
+	 * - `folder`: FolderStorage unconditionally (user opted out of
+	 *   orphan).
+	 * - `orphan`: OrphanBranchStorage (legacy single-mode behavior).
+	 *
+	 * Cleared by {@link reloadStorage} so a settings-driven `storageMode`
+	 * or `localFolder` flip takes effect on the next read.
 	 */
 	private readStoragePromise: Promise<StorageProvider> | null = null;
 
@@ -228,98 +238,145 @@ export class JolliMemoryBridge {
 		this.cwd = cwd;
 	}
 
-	/**
-	 * Returns the StorageProvider used for **writes** against the
-	 * current workspace repo. Awaits the initial creation or any
-	 * in-flight reload. Internal helper used by every SummaryStore
-	 * wrapper that *mutates* state.
-	 */
+	/** Lazy-resolved write storage. See {@link storagePromise}. */
 	private getStorage(): Promise<StorageProvider> {
 		if (!this.storagePromise) {
-			this.storagePromise = createStorage(this.cwd, this.cwd);
+			// Reset on rejection so the next caller gets a fresh attempt
+			// instead of awaiting the cached rejected promise forever.
+			this.storagePromise = createStorage(this.cwd, this.cwd).catch((err) => {
+				this.storagePromise = null;
+				throw err;
+			});
 		}
 		return this.storagePromise;
 	}
 
-	/**
-	 * Returns the StorageProvider used for **reads** against the current
-	 * workspace repo. In `dual-write` (default) and `folder` modes this
-	 * is a FolderStorage rooted at the same `<localFolder>/<repo>/`
-	 * directory that the Memory Bank tree walks — making the workspace
-	 * repo's read surface identical to every foreign-repo path in
-	 * {@link listSummaryEntries} step 2 ({@link getSummaryAnyRepo}, etc).
-	 *
-	 * Why split read from write: Memory Bank sync pulls peer commits
-	 * into the FolderStorage shadow only — the orphan branch on the
-	 * workspace repo is never updated by a sync round. Reads going
-	 * through `DualWriteStorage.readFile` (hardwired to `primary` =
-	 * orphan) therefore miss every sync-pulled row, which surfaces as
-	 * Memories / Timeline showing pre-sync state while the Memory Bank
-	 * Tree view (walks disk) shows the new commits. Two views, one
-	 * source of truth, used to disagree.
-	 *
-	 * Falls back to {@link getStorage} (orphan-flavoured) for
-	 * `storageMode = "orphan"`, where no folder data exists on disk —
-	 * legacy single-mode users see no behavior change.
-	 *
-	 * Writes intentionally stay on {@link getStorage} so they continue
-	 * to land on both backends; only reads pivot.
-	 */
+	/** Lazy-resolved read storage. See {@link readStoragePromise}. */
 	private getReadStorage(): Promise<StorageProvider> {
 		if (!this.readStoragePromise) {
-			this.readStoragePromise = this.createReadStorage();
+			this.readStoragePromise = this.createReadStorage().catch((err) => {
+				this.readStoragePromise = null;
+				throw err;
+			});
 		}
 		return this.readStoragePromise;
 	}
 
 	private async createReadStorage(): Promise<StorageProvider> {
-		let config: Record<string, unknown>;
-		try {
-			config = (await loadConfig()) as Record<string, unknown>;
-		} catch (err) {
-			log.warn(
-				"bridge",
-				"createReadStorage: failed to load config (%s) — falling back to write storage",
-				err instanceof Error ? err.message : String(err),
-			);
-			return this.getStorage();
-		}
+		// `loadConfig` (SessionTracker.loadConfigFromDir) swallows all
+		// errors internally and resolves to `{}` on a missing/corrupt
+		// file — it never rejects. So no try/catch here. Surfacing a
+		// corrupt config to the user is a separate concern (would mean
+		// changing SessionTracker to propagate parse errors).
+		const config = (await loadConfig()) as Record<string, unknown>;
 		const mode = (config.storageMode as string | undefined) ?? "dual-write";
-		if (mode === "orphan") {
-			return new OrphanBranchStorage(this.cwd);
+		// Mode dispatch mirrors `StorageFactory.createStorage`'s switch so a
+		// config typo (e.g. `duallwrite`) doesn't land write on orphan and
+		// read on folder — both sides would refuse to read each other's
+		// data and the only signal would be a baffled user. Unknown modes
+		// fall back to orphan on both sides; the legitimate folder-mode
+		// reads still flow through the explicit "folder" case.
+		switch (mode) {
+			case "orphan":
+				return new OrphanBranchStorage(this.cwd);
+			case "folder":
+				return createFolderStorage(this.cwd, config.localFolder as string | undefined);
+			case "dual-write": {
+				const folder = createFolderStorage(this.cwd, config.localFolder as string | undefined);
+				if ((await folder.readFile("index.json")) === null) {
+					// Folder has no index yet. Three legitimate paths land here:
+					//   1. Fresh install before MigrationEngine has finished
+					//      copying orphan → folder.
+					//   2. User wiped `<localFolder>/<repo>/.jolli/` while the
+					//      orphan branch on the workspace repo still holds data.
+					//   3. Truly empty repo (no commits with summaries yet) —
+					//      orphan is empty too, so the fallback returns empty
+					//      as well, indistinguishable from reading folder.
+					// In cases (1) and (2) the orphan branch is the only source
+					// of truth that still has the user's data; reading the folder
+					// would render "no memories" while orphan is intact. Fall
+					// back to orphan so the panel shows real data and the user
+					// gets a chance to notice and re-run migration.
+					//
+					// The fallback is also why `refreshMemories` calls
+					// `reloadReadStorage()`: once the user reruns migration or
+					// the folder is repopulated via iCloud/peer sync, the next
+					// manual refresh must re-probe rather than serve a cached
+					// orphan-only instance forever.
+					log.warn(
+						"bridge",
+						"createReadStorage: folder lacks index.json — falling back to orphan branch (migration incomplete, or folder wiped)",
+					);
+					return new OrphanBranchStorage(this.cwd);
+				}
+				// `DualWriteStorage.writeFiles` marks the folder dirty
+				// whenever a shadow write fails (best-effort shadow path
+				// keeps the orphan-primary write atomic). A dirty folder
+				// means its index.json / payloads have diverged from the
+				// authoritative orphan branch: stale entries, missing new
+				// rows, or both. Routing reads through the folder in that
+				// state surfaces silently-wrong memories while the orphan
+				// copy is intact. Same fallback path as the no-index case
+				// — trust orphan whenever the folder isn't a complete,
+				// current picture. The dirty marker is cleared by the
+				// next successful `DualWriteStorage.writeFiles`, after
+				// which `reloadReadStorage()` (settings-save, refresh)
+				// will re-probe and pick FolderStorage again.
+				if (folder.isDirty?.()) {
+					log.warn(
+						"bridge",
+						"createReadStorage: folder shadow is dirty — falling back to orphan branch (last shadow write failed)",
+					);
+					return new OrphanBranchStorage(this.cwd);
+				}
+				return folder;
+			}
+			default:
+				log.warn(
+					"bridge",
+					`createReadStorage: unknown storageMode=${mode} — defaulting to orphan branch`,
+				);
+				return new OrphanBranchStorage(this.cwd);
 		}
-		const customKBPath = config.localFolder as string | undefined;
-		const repoName = extractRepoName(this.cwd);
-		const remoteUrl = getRemoteUrl(this.cwd);
-		const kbRoot = resolveKBPath(repoName, remoteUrl, customKBPath);
-		const mm = new MetadataManager(join(kbRoot, ".jolli"));
-		return new FolderStorage(kbRoot, mm);
 	}
 
 	/**
-	 * Drops the cached storage backends so the next read/write rebuilds
-	 * from the latest config. Called by the settings-save callback after
-	 * the user changes `storageMode` or `localFolder` so subsequent
-	 * reads/writes hit the right backend without requiring a window
-	 * reload.
+	 * Drops the cached storage backends and the aggregated entries
+	 * cache so the next read/write rebuilds against the latest config.
+	 * Called by the settings-save callback after `storageMode` or
+	 * `localFolder` changes.
 	 *
-	 * Clears both `storagePromise` (write path) AND `readStoragePromise`
-	 * (read path) — leaving the read cache in place after an
-	 * `orphan` ↔ `dual-write` flip would keep reads silently parked on
-	 * the previous mode's storage until window reload, which is exactly
-	 * the surprise this method exists to prevent.
-	 *
-	 * Also clears the aggregated cross-repo entries cache: when the user
-	 * changes `localFolder`, the discoverable set of foreign repos under
-	 * the Memory Bank parent changes too, so the cached merged list is
-	 * stale by definition. The old behavior left the cache in place,
-	 * which is why "switch Memory Bank folder then open Memories" used
-	 * to show entries from the previous folder until a window reload.
+	 * Both `storagePromise` and `readStoragePromise` must be cleared
+	 * together — leaving the read cache after an `orphan` ↔ `dual-write`
+	 * flip would silently keep reads on the previous mode's storage.
+	 * Entries cache is cleared because `localFolder` changes the
+	 * discoverable set of foreign repos under the Memory Bank parent.
 	 */
 	reloadStorage(): void {
 		this.storagePromise = null;
 		this.readStoragePromise = null;
 		this.cachedRootEntries = null;
+	}
+
+	/**
+	 * Drops only the read-storage cache so the next read operation re-runs
+	 * `createReadStorage` and re-probes the folder/orphan fallback decision.
+	 *
+	 * Use case: a user-initiated refresh (`jollimemory.refreshMemories`)
+	 * after a peer-sync repopulates the Memory Bank folder. Without this,
+	 * a dual-write session that fell back to OrphanBranchStorage on first
+	 * read (because `<localFolder>/<repo>/.jolli/index.json` was still
+	 * missing) would keep serving that cached instance forever, so the
+	 * folder-side rows iCloud just dropped in would stay invisible until
+	 * the next window reload or a settings flip.
+	 *
+	 * Separate from `reloadStorage()`: this method intentionally keeps the
+	 * write-storage cache hot so the refresh button doesn't churn the
+	 * (config-load + factory) path in the common case where the user has
+	 * not changed mode/localFolder.
+	 */
+	reloadReadStorage(): void {
+		this.readStoragePromise = null;
 	}
 
 	// ── Enable / Disable ──────────────────────────────────────────────────
@@ -988,11 +1045,9 @@ export class JolliMemoryBridge {
 			.filter((parts) => parts.length >= 5);
 
 		const commitHashes = parsedEntries.map((parts) => parts[0]);
-		// Read storage: post-sync data lives in the FolderStorage shadow
-		// when the user is on dual-write/folder mode, not on the orphan
-		// branch. Write storage (for the background alias scan below)
-		// stays on DualWriteStorage so aliases still land on both
-		// backends.
+		// readStorage drives the index lookup; writeStorage stays on the
+		// dual-write composite so the background alias scan below keeps
+		// landing aliases on both backends. See {@link readStoragePromise}.
 		const readStorage = await this.getReadStorage();
 		const writeStorage = await this.getStorage();
 		const indexEntryMap = await getIndexEntryMap(this.cwd, readStorage);
@@ -1256,10 +1311,9 @@ export class JolliMemoryBridge {
 		}> = [];
 		let ticketId: string | undefined;
 
-		// Squash-message prompt is a pure read of the summaries that will
-		// be merged — getReadStorage() so a peer-synced commit (only in
-		// the folder shadow on this device) still contributes its topics
-		// instead of being silently skipped as "no summary".
+		// Read path — see {@link readStoragePromise}. Without this, a
+		// row that's on disk but absent from the orphan branch would
+		// contribute no topics to the merged squash message.
 		const storage = await this.getReadStorage();
 		for (const hash of hashes) {
 			const msg = (
@@ -1457,12 +1511,9 @@ export class JolliMemoryBridge {
 			const merged: SummaryIndexEntry[] = [];
 			const currentRepoName = extractRepoName(this.cwd);
 
-			// 1. Current workspace repo — read through the FolderStorage
-			//    shadow when storageMode has one (dual-write / folder), so
-			//    rows pulled in by Memory Bank sync are visible. orphan-only
-			//    users fall back to the orphan branch via getReadStorage()
-			//    so their behavior is unchanged. See getReadStorage() for
-			//    the full rationale.
+			// 1. Current workspace repo — read via getReadStorage() so
+			//    the surface matches step 2 below (FolderStorage). See
+			//    {@link readStoragePromise} for mode handling.
 			try {
 				const storage = await this.getReadStorage();
 				const map = await getIndexEntryMap(this.cwd, storage);
@@ -1575,11 +1626,9 @@ export class JolliMemoryBridge {
 	 * the Memory Bank tree count, Memories panel count, and these counts in
 	 * agreement.
 	 *
-	 * Resolves the right storage based on whether `repoName` is the workspace
-	 * repo (routes through {@link getReadStorage} so sync-pulled rows are
-	 * visible) or a foreign one (instantiates {@link FolderStorage} pointed at
-	 * that repo's kbRoot, mirroring how {@link listSummaryEntries} step 2
-	 * walks discovered repos).
+	 * Storage resolution: workspace repo → {@link getReadStorage};
+	 * foreign repo → a fresh `FolderStorage` rooted at that repo's
+	 * kbRoot, mirroring {@link listSummaryEntries} step 2.
 	 */
 	async listBranchMemories(
 		repoName: string,
@@ -1980,7 +2029,16 @@ export class JolliMemoryBridge {
 		return getIndexEntryMap(this.cwd, storage);
 	}
 
-	/** Writes a summary via the Bridge's DualWriteStorage instance. */
+	/**
+	 * Writes a summary via the Bridge's DualWriteStorage instance.
+	 *
+	 * Threads `readStorage` so storeSummary's index/catalog base preserves rows
+	 * that exist only on the read side (FolderStorage in dual-write mode) —
+	 * e.g. peer-synced entries from another machine that the workspace's
+	 * orphan branch hasn't caught up to yet. Without this, a force-write
+	 * rewrites the index from orphan-only rows and the dual-write below
+	 * silently drops those folder-only rows on the shadow.
+	 */
 	async storeSummary(
 		summary: CommitSummary,
 		force = false,
@@ -1990,20 +2048,23 @@ export class JolliMemoryBridge {
 		},
 	): Promise<void> {
 		const storage = await this.getStorage();
-		await storeSummary(summary, this.cwd, force, artifacts, storage);
+		const readStorage = await this.getReadStorage();
+		await storeSummary(summary, this.cwd, force, artifacts, storage, readStorage);
 	}
 
 	/**
 	 * Loads regenerate-context (confirm-dialog counts) through the Bridge's
-	 * StorageProvider so folder-only Memory Bank users read transcripts from
-	 * FolderStorage instead of the OrphanBranchStorage fallback baked into
-	 * the underlying SummaryStore helpers. Without this wrapper the dialog
-	 * reports 0 transcripts on every regenerate in folder-only mode.
+	 * read StorageProvider so peer-synced FolderStorage transcripts/archives
+	 * surface in the dialog and reach the LLM context. The previous version
+	 * used `getStorage()`, which in dual-write mode is a `DualWriteStorage`
+	 * whose `readFile` only ever touches the orphan-branch primary — so any
+	 * artifact synced into the folder shadow from another machine before the
+	 * orphan branch caught up was invisible to regenerate.
 	 */
 	async loadRegenerateContext(
 		summary: CommitSummary,
 	): Promise<import("../../cli/src/core/RegenerateContext.js").RegenerateContext> {
-		const storage = await this.getStorage();
+		const storage = await this.getReadStorage();
 		const { loadRegenerateContext } = await import(
 			"../../cli/src/core/RegenerateContext.js"
 		);
@@ -2011,17 +2072,17 @@ export class JolliMemoryBridge {
 	}
 
 	/**
-	 * Runs the regenerate-summary LLM call through the Bridge's
-	 * StorageProvider — same folder-only correctness rationale as
-	 * `loadRegenerateContext`. Transcripts, archived plans/notes/linear
-	 * issues all read from the active backend (FolderStorage in folder
-	 * mode, OrphanBranchStorage in legacy mode, DualWriteStorage by default).
+	 * Runs the regenerate-summary LLM call through the Bridge's read
+	 * StorageProvider — same folder-sync rationale as
+	 * `loadRegenerateContext`. Result is returned to the caller; the
+	 * subsequent persist happens via `storeSummary`, which threads the
+	 * write storage separately.
 	 */
 	async regenerateSummary(
 		summary: CommitSummary,
 		config: import("../../cli/src/Types.js").LlmConfig,
 	): Promise<import("../../cli/src/core/Regenerator.js").RegenerateResult> {
-		const storage = await this.getStorage();
+		const storage = await this.getReadStorage();
 		const { regenerateSummary } = await import("../../cli/src/core/Regenerator.js");
 		return regenerateSummary(summary, this.cwd, config, storage);
 	}


### PR DESCRIPTION
## Summary

- In dual-write storageMode (the default since 0.99.0) `DualWriteStorage.readFile` is hardwired to the orphan-branch primary, so when Memory Bank sync pulls a peer's commits into `<localFolder>/<repo>/.jolli/` (the FolderStorage shadow), the workspace repo's orphan branch never sees them. The Memories panel and Timeline silently miss those rows while the Memory Bank tree view (walks disk) and the foreign-repo step in `listSummaryEntries` (already on FolderStorage) both surface the new commits. Three views, one source of truth, used to disagree on the current workspace repo only.
- Splits read from write on `JolliMemoryBridge`. `getReadStorage()` resolves a fresh `FolderStorage` rooted at the same `<localFolder>/<repo>/` the tree view walks (dual-write / folder mode); falls back to `OrphanBranchStorage` in orphan-only mode so legacy single-mode users see no change. Writes stay on `getStorage()` → `DualWriteStorage` so local commits still land on both backends.
- `scanTreeHashAliases` gains an optional 4th `readStorage` parameter so the preflight + lock-held re-read can use the folder side without redirecting alias writes off the orphan branch — preserves "alias lands on both backends" for dual-write users.

## Bug it fixes

After a sync round on Device B pulls peer commits from Device A:
- Memory Bank Tree view shows the new `.md` files ✓
- Timeline / Memories panel for the **current workspace repo** show nothing new ✗
- Timeline / Memories for **other** repos under the same `localFolder` show the new commits ✓ (those already used FolderStorage)

The asymmetry between current and foreign repos was the giveaway: foreign repos always read via `FolderStorage(repo.kbRoot, …)`, current repo went through the bridge's `getStorage()` → `DualWriteStorage` → orphan. This PR makes the two paths symmetric.

## Intentionally unchanged

- `DualWriteStorage` read semantics (`readFile`/`listFiles` still go to `primary`). The pivot is at the caller, not the storage layer, so other callers stay simple.
- All write paths — `storeSummary`, `storePlans`, `storeNotes`, `storeLinearIssues`, `saveTranscriptsBatch`, `archivePlanForCommit`, `archiveNoteForCommit`, `cleanupVisiblePlanArtifact`, `cleanupVisibleNoteArtifact` — keep using `getStorage()` so dual-write semantics for *this device's* commits are intact.
- Foreign-repo step 2 in `listSummaryEntries` (already on FolderStorage).
- `orphan` storageMode behavior — preserved for users on the legacy single mode (no folder data exists for them).
- `QueueWorker`'s `setActiveStorage` global (it lives in a separate process; extension owns its own per-process storage instances).
- Refspec / orphan-branch naming, package names, runtime data paths.

## Test plan

- [x] 9 new bridge-level tests in `vscode/src/JolliMemoryBridge.test.ts` pin the read/write split contract: `listSummaryEntries`, `listBranchCommits`, `listBranchMemories`, `getSummary`, `getSummaryIndexEntryMap`, `generateSquashMessageWithLLM`, plus orphan-mode fallback, folder-mode, and `reloadStorage()` cache invalidation.
- [x] 2 new CLI-level tests in `cli/src/core/SummaryStore.test.ts` pin the `scanTreeHashAliases` `(storage, readStorage)` two-storage contract — preflight + lock-held re-read use `readStorage`, alias write stays on `storage`; single-storage fallback preserved for legacy callers.
- [x] All 71 vscode test files green (2511 tests passing); branch coverage 97% — meets project threshold.
- [x] CLI test suite: my new tests pass in isolation. The full cli run trips intermittent timeouts in 2–5 unrelated tests (`Locks.test.ts`, `GitExclude.test.ts`, `KBPathResolver.test.ts`, `Installer.test.ts`) per run — all real-git + temp-dir tests, all flaky on this Darwin sandbox under parallel load, none touched by this PR. Each passes when re-run in isolation.
- [x] Manual: re-derived the bug scope by tracing `DualWriteStorage.readFile` → `primary` → `OrphanBranchStorage`; confirmed sync engine writes only to `<localFolder>/<repo>/.jolli/` and not to the workspace orphan branch.

<!-- jollimemory-summary-start -->
## Commits in this PR (2)

1. Route current-repo summary reads through FolderStorage for sync visibility (`d38b440`)
2. Fix dual-write data loss and sync visibility issues (`2900cdc`)

## Quick recap (2)

### Commit 1 of 2: Route current-repo summary reads through FolderStorage for sync visibility (`d38b440`)

The developer decoupled read and write storage paths for the workspace repository to fix a sync visibility regression. Memory Bank sync was pulling peer commits into the folder storage shadow only, leaving the orphan branch on the workspace repo untouched. This caused the Memories and Timeline panels to show stale pre-sync state while the Memory Bank tree view (which walks the folder directly) showed the new commits, creating a confusing split where the same data appeared inconsistent across different UI surfaces.

The fix routes workspace repo reads through folder storage in dual-write and folder modes, making the panel's view of the workspace repo identical to how foreign repos and the Memory Bank tree already see it. Writes intentionally stay on the dual-write composite so local commits continue landing on both backends, preserving the invariant that orphan-branch readers on other devices still see everything this device commits. Orphan-only users (who never wrote folder data) fall back to the orphan branch, so their behavior is unchanged. The background alias scan now reads candidates from the folder to avoid queuing post-sync commits as unmatched, while still writing aliases through the dual-write path so they persist to both backends.

### Commit 2 of 2: Fix dual-write data loss and sync visibility issues (`2900cdc`)

This batch of commits addresses critical data-loss and visibility regressions in the dual-write architecture that supports peer-synced Memory Bank folders. The core problem: when users read folder-synced summaries and then perform edits or regenerations, the write path was silently deleting folder-only entries because it rebuilt the index from the orphan branch alone. The fix introduces a union-based approach that merges snapshots from both backends during force-writes, with orphan entries winning on collision since it is the system of record. Peer-synced rows that exist only on the folder side are now preserved in the merged index that gets written to both backends, and the orphan branch is backfilled with the corresponding summary payloads and transcripts to maintain index-to-file integrity.

The commits also fix a caching issue where the read-storage fallback decision was cached forever. When a user triggers a peer sync that populates the folder after a fresh install, the system was serving a stale orphan-branch fallback, keeping peer-synced rows invisible until a window reload. A new `reloadReadStorage()` method clears only the read-storage cache on manual refresh, forcing the next read to re-probe the folder and switch to folder storage if the folder is now populated. The bridge now also respects the dirty marker that dual-write storage sets when shadow writes fail, falling back to orphan reads in that state so stale folder data does not surface while the orphan copy is intact.

Regenerate operations (confirm dialog and LLM context) were updated to read through the folder shadow instead of the orphan primary, ensuring peer-synced artifacts surface in the dialog and reach the LLM input. Three critical read paths (Timeline view, branch-memories sidebar, squash-message generation) now have explicit storage-type assertions to catch any future regression that reverts them to the old dual-write path. The sync-visibility rationale, which was duplicated across five locations, was consolidated into a single authoritative field comment with one-line references elsewhere, reducing maintenance burden and preventing drift.

## Topics (14)
<details>
<summary><strong>01 · [d38b440] Route workspace repo summary reads through folder storage for sync visibility</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Memory Bank sync pulls peer commits into the folder storage shadow only, never updating the orphan branch on the workspace repo. This caused the Memories and Timeline panels to show pre-sync state while the Memory Bank tree view (which walks the folder directly) showed new commits, creating a confusing split view where the same source of truth appeared inconsistent across different UI surfaces.

**💡 Decisions Behind the Code**

- **Read-write split only for workspace repo, not foreign repos**: Foreign repos already instantiate `FolderStorage` directly in `listSummaryEntries` step 2, so they see sync-pulled data by default. Splitting the workspace repo's read path makes it consistent with foreign repos without requiring changes to the foreign-repo logic or introducing a new storage mode. Writes stay on the dual-write composite so local commits continue to land on both backends, preserving the invariant that orphan-branch readers (CLI, other devices) still see everything this device commits.
- **Defensive fallback to write storage on config load failure**: If `loadConfig()` throws (file corruption, permission error), `createReadStorage()` catches the exception and returns the write storage instead of crashing the panel. This keeps the bridge functional during transient config issues — reads lose the sync-visibility benefit until the next reload succeeds, but the panel stays usable rather than blocking on a config file problem.
- **Explicit cache clearing for read storage on settings reload**: `reloadStorage()` now clears both `storagePromise` and `readStoragePromise` so a user-initiated `storageMode` flip (orphan ↔ dual-write) takes effect on the next read without a window reload. Leaving the read cache in place would silently keep reads parked on the previous mode's storage, exactly the kind of stale-state surprise the method exists to prevent.

**✅ What Was Implemented**

- Modified `JolliMemoryBridge` to split read and write storage paths: reads for the workspace repo now flow through `getReadStorage()` which returns a `FolderStorage` instance in dual-write and folder modes, while writes continue through `getStorage()` (which may be `DualWriteStorage`) so aliases and mutations still land on both backends. The read path falls back to orphan-branch storage for orphan-only users, preserving backward compatibility.
- Updated `listBranchCommits()` to pass both write and read storage to `scanTreeHashAliases()`, allowing the background alias scan to read candidates from the folder (so post-sync commits don't get queued as unmatched) while still writing aliases through the dual-write path so they persist to both backends.
- Extended `scanTreeHashAliases()` signature to accept an optional `readStorage` parameter; when provided, both the preflight index load and the lock-held re-check read from this storage instead of the write storage, keeping candidate freshness coherent across the scan. Falls back to single-storage behavior when `readStorage` is omitted for existing CLI callers.

**📁 FILES**
- `cli/src/core/SummaryStore.ts`
- `cli/src/core/SummaryStore.test.ts`
- `vscode/src/JolliMemoryBridge.ts`
- `vscode/src/JolliMemoryBridge.test.ts`

</blockquote>
</details>
<details>
<summary><strong>02 · [2900cdc] Prevent data loss when dual-write overwrites folder with orphan index</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

When the alias-scan optimization runs during a dual-write, it can rebuild the index from the orphan branch and overwrite the folder's index, silently deleting rows that exist only on the folder side (such as entries synced from peer machines).

**💡 Decisions Behind the Code**

- **Defer the alias write rather than merge entries**: Deferring preserves the architectural contract that aliases are a cross-branch optimization, not load-bearing. Aliases can safely be skipped without breaking visibility — the next refresh retries once both backends are in sync. Merging divergent index states during a time-sensitive lock would add complexity and risk.
- **Split preflight and lock-held re-read sources**: Preflight reads from the folder to see sync-pulled candidates; the lock-held re-read anchors on the write storage so the persisted payload matches the primary backend. This preserves both sync visibility and data safety.

**✅ What Was Implemented**

- Added a symmetric divergence check inside the alias-write lock that detects when the folder storage holds rows the orphan storage lacks. When this asymmetry is detected, the alias write is deferred and returns false, allowing the next refresh to retry once both backends reconcile.
- Modified the alias-scan write path to re-read the index from the write-side storage (orphan branch) rather than the read-side, so the persisted entries array matches what's already on the primary backend and the dual-write doesn't clobber rows.
- Added regression tests pinning both the folder-row-clobber case and the orphan-only-rows survival case.

**📁 FILES**
- `cli/src/core/SummaryStore.ts`
- `cli/src/core/SummaryStore.test.ts`

</blockquote>
</details>
<details>
<summary><strong>03 · [2900cdc] Backfill folder-only summary payloads into orphan storage during dual-write commits</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

When users read folder-synced summaries and then perform edits or regenerations, the write path rebuilds the index from the orphan branch alone, causing folder-only peer-synced entries to be silently deleted from the folder during the dual-write.

**💡 Decisions Behind the Code**

The fix targets the write path rather than adding fallback logic to the read path. Making orphan self-complete at write time preserves the design principle that orphan is the system of record and avoids creating a dependency on folder availability during reads. Every force-write operation automatically heals the orphan branch by backfilling any folder-only entries, gradually restoring orphan to a superset state without requiring a separate reconciliation step.

**✅ What Was Implemented**

- `SummaryStore.storeSummary` now accepts an optional `readStorage` parameter and computes a set of folder-only commit hashes (entries present in the read index but absent from the write index). For each folder-only hash, the function lifts the corresponding summary payload and transcript files from the read storage into the same write batch, ensuring the orphan branch ends the commit with complete index-to-file integrity.
- `JolliMemoryBridge.storeSummary` now passes the read storage through to the store function, enabling the dual-write path to preserve folder-only rows.
- Five new test cases lock the backfill contract: lifting summary payloads, lifting transcripts, skipping missing payloads, avoiding double-writes of the headline hash, and confirming single-storage callers do not incur extra read probes.

**📁 FILES**
- `cli/src/core/SummaryStore.ts`
- `vscode/src/JolliMemoryBridge.ts`

</blockquote>
</details>
<details>
<summary><strong>04 · [2900cdc] Fall back to orphan storage when folder shadow write fails or is dirty</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The bridge selects folder storage for reads based only on whether the index file exists, but the dual-write storage marks the folder dirty whenever a shadow write fails. In that dirty state, the folder index and payloads are stale relative to the orphan branch, yet the bridge would still route reads through the folder, surfacing missing or outdated memories.

**💡 Decisions Behind the Code**

The dirty marker was already being written by the dual-write storage but had no reader — a classic dead-signal anti-pattern. Rather than deleting the signal, the fix connects it to the read-path selector so the folder's health directly influences whether it is trusted for reads. This keeps the fallback logic centralized in one place and avoids duplicating the health check across every read method. The separation of `reloadReadStorage()` from the write-cache clearing allows refresh operations to re-probe folder health without losing in-flight write state.

**✅ What Was Implemented**

- `JolliMemoryBridge.createReadStorage` now checks the dirty marker in dual-write mode and falls back to orphan storage if the marker is set, mirroring the existing no-index fallback. The dirty marker is cleared by the next successful dual-write, and subsequent calls to `reloadReadStorage()` will re-probe and pick folder storage again.
- A new `reloadReadStorage()` method clears only the read-storage cache, allowing settings-save and refresh operations to re-evaluate the folder's health without clearing the write-storage cache.
- `Extension.refreshMemories` now calls both `invalidateEntriesCache()` and `reloadReadStorage()` so a manual refresh can detect when the folder shadow has recovered and switch back to folder reads.
- Three new test cases verify the three branches: folder clean and initialized (use folder), folder dirty (fall back to orphan), and folder missing index (fall back to orphan).

**📁 FILES**
- `vscode/src/JolliMemoryBridge.ts`
- `vscode/src/Extension.ts`

</blockquote>
</details>
<details>
<summary><strong>05 · [2900cdc] Preserve peer-synced folder entries during dual-write index rebuilds</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

When a user on one machine peer-syncs entries into the Memory Bank folder, and another machine force-writes a summary before the orphan branch catches up, the dual-write was silently dropping the folder-only entries because it rebuilt the index from orphan-only rows.

**💡 Decisions Behind the Code**

- **Union-based preservation over selective merge**: Rather than trying to detect and preserve only "new" folder entries, the implementation unions both backends' full snapshots and lets write-side entries naturally override on collision. This is simpler to reason about (write is always system-of-record) and handles edge cases like alias conflicts without special logic.
- **Separate read-storage parameter over dual-write transparency**: The `readStorage` parameter is optional and only used when distinct from the write storage. This preserves backward compatibility for callers like QueueWorker and the CLI that share a single storage instance, avoiding unnecessary union operations and extra I/O against non-existent shadows.

**✅ What Was Implemented**

- Added `unionIndexes` and `unionCatalogs` helper functions in SummaryStore.ts that merge index and catalog snapshots from both write and read storage backends, with write-side entries winning on collision (orphan is system-of-record). Read-side-only entries and aliases are preserved in the merged result.
- Modified `storeSummary` to accept an optional `readStorage` parameter and thread it through the index and catalog loading logic. When both storages are provided and distinct, the function unions their snapshots before rebuilding the index, ensuring folder-only rows survive the dual-write.
- Updated JolliMemoryBridge.storeSummary to pass the read storage (FolderStorage in dual-write mode) as an argument to SummaryStore.storeSummary, protecting peer-synced rows from being dropped during force-writes.

**📁 FILES**
- `cli/src/core/SummaryStore.ts`
- `vscode/src/JolliMemoryBridge.ts`

</blockquote>
</details>
<details>
<summary><strong>06 · [2900cdc] Fix data-loss risk when folder storage lacks index during dual-write mode</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

When a user's Memory Bank folder is empty, wiped, or hasn't completed migration yet, the new read-path logic silently renders "no memories" while the orphan branch still holds intact data, inverting the original bug.

**💡 Decisions Behind the Code**

- **Fallback to orphan when folder is empty**: Reading from an empty folder would silently hide user data while the orphan branch is intact. The fallback preserves user-visible data and gives the user a chance to notice and re-run migration.
- **Single source of truth for folder-storage construction**: Exporting and reusing `createFolderStorage()` prevents the read and write paths from diverging over time as the kbRoot derivation logic evolves. Inline duplication is a known anti-pattern for API initialization chains.
- **Cache reset on rejection**: If any future helper in the initialization chain throws, a rejected promise cached forever would lock the user on a transient error until reload. Resetting the cache on rejection is a defensive measure that costs nothing and unblocks the user on retry.

**✅ What Was Implemented**

- Added fallback logic in `createReadStorage()` to detect when the folder lacks an index file in dual-write mode and fall back to orphan-branch storage, keeping the panel showing real data instead of "no memories yet".
- Exported `createFolderStorage()` from `StorageFactory.ts` and refactored `createReadStorage()` to call it, eliminating inline duplication of the kbRoot derivation chain and ensuring both read and write paths stay in lockstep.
- Added rejected-promise cache reset in both `getStorage()` and `getReadStorage()` so transient initialization failures don't permanently lock the user until a window reload.

**📁 FILES**
- `cli/src/core/StorageFactory.ts`
- `vscode/src/JolliMemoryBridge.ts`

</blockquote>
</details>
<details>
<summary><strong>07 · [2900cdc] Re-probe folder-empty fallback on manual refresh to surface peer-synced rows</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

When a user triggers a peer sync that populates the Memory Bank folder after a fresh install, the read-storage cache was serving a stale orphan-branch fallback forever, keeping peer-synced rows invisible until a window reload.

**💡 Decisions Behind the Code**

- **Asymmetric cache invalidation**: `reloadReadStorage()` intentionally keeps the write-storage cache hot while dropping only the read-storage cache. This avoids churning the config-load and factory path on every refresh, which is the common case when the user has not changed storage mode or folder location.
- **Fallback re-probing on refresh**: Rather than eagerly probing the folder on every read operation, the fallback decision is cached and only re-probed when the user explicitly clicks refresh. This balances responsiveness (peer-sync + refresh = visible rows) against I/O cost.

**✅ What Was Implemented**

- Added `reloadReadStorage()` method to JolliMemoryBridge that clears only the read-storage cache, forcing the next read operation to re-run `createReadStorage` and re-probe the folder/orphan fallback decision. This is separate from `reloadStorage()`, which clears both caches.
- Updated the `jollimemory.refreshMemories` command handler in Extension.ts to call both `invalidateEntriesCache()` and `reloadReadStorage()`, ensuring the aggregated entries cache and the read-storage fallback decision are both re-probed after a manual refresh.
- Refactored `createReadStorage` in JolliMemoryBridge to use a switch statement that mirrors StorageFactory's mode dispatch, so unknown config values default to orphan storage on both read and write sides, preventing asymmetric behavior.

**📁 FILES**
- `vscode/src/JolliMemoryBridge.ts`
- `vscode/src/Extension.ts`

</blockquote>
</details>
<details>
<summary><strong>08 · [2900cdc] Thread read storage through regenerate operations for peer-synced artifact visibility</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The regenerate confirm dialog and LLM context were reading transcripts and archived plans from the orphan branch primary, making peer-synced artifacts from other machines invisible until the orphan branch caught up.

**💡 Decisions Behind the Code**

Regenerate context loading is a read-only operation, so it should use the same read-storage selector as other query methods. This keeps the read-path logic consistent across all query methods and ensures the LLM always sees the most complete available context, whether that comes from folder or orphan.

**✅ What Was Implemented**

- Modified `loadRegenerateContext` and `regenerateSummary` calls in JolliMemoryBridge to pass the read storage (FolderStorage in dual-write mode) instead of the dual-write storage, ensuring artifact counts and LLM input include peer-synced rows from the folder shadow.
- Updated JSDoc comments in JolliMemoryBridge to clarify that both regenerate methods now read through the read storage so peer-synced artifacts surface in the confirm dialog and reach the LLM context.
- Two new test cases verify that regenerate methods receive FolderStorage in dual-write mode and that the read-storage fallback (dirty or no-index) is respected.

**📁 FILES**
- `vscode/src/JolliMemoryBridge.ts`

</blockquote>
</details>
<details>
<summary><strong>09 · [2900cdc] Clear bridge read-storage cache after folder migration completes</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The orphan fallback inside the bridge's createReadStorage caches an OrphanBranchStorage promise when the folder lacks index.json. If the Memories or Timeline panel touches the bridge before folder migration finishes, that cached fallback survives migration completion, leaving the session stuck on orphan reads even after the folder is later populated with synced rows.

**💡 Decisions Behind the Code**

- **Cache bust before panel refresh, not after**: The cache must be cleared before the panel refresh so any subsequent bridge calls during the refresh use the freshly-populated folder storage rather than the cached orphan fallback. This ordering prevents the UI from displaying stale data even after migration completes.
- **Treat cleanup mutations the same as migration**: Cleanup operations also require cache invalidation because a bridge cache that snapshotted pre-cleanup state would return stale rows. Both branches get the same treatment to keep the pattern consistent and prevent future regressions if cleanup behavior changes.

**✅ What Was Implemented**

- Added bridge.reloadStorage() calls in Extension.ts after both runMigration() and runStaleChildCleanup() complete, before refreshKnowledgeBaseFolders() is called. This ensures the read-storage cache is busted before the UI refresh that may re-fetch through the bridge.
- Added two regression tests that pin both branches: one verifies the cache is cleared after migration, the other after stale-child cleanup (which also mutates the folder's index).

**📁 FILES**
- `vscode/src/Extension.ts`

</blockquote>
</details>
<details>
<summary><strong>10 · [2900cdc] Remove dead catch block and fix test that pins non-existent contract</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The `loadConfig()` helper in SessionTracker swallows all errors internally and always resolves to an empty object. The bridge's `createReadStorage()` has a catch block that tries to handle a rejection that never happens, and the test mocks a rejection that production never produces.

**💡 Decisions Behind the Code**

The dead catch block created a false sense of error handling and the test was pinning a contract that production never honored. Removing both clarifies the actual behavior and prevents future maintainers from relying on a non-existent guarantee.

**✅ What Was Implemented**

- Removed the unreachable catch block from `createReadStorage()` and replaced it with a comment explaining that `loadConfig()` never rejects.
- Deleted the test case that was pinning a contract that doesn't exist in production.
- Added a new test that pins the actual fallback behavior (folder-empty detection).

**📁 FILES**
- `vscode/src/JolliMemoryBridge.ts`

</blockquote>
</details>
<details>
<summary><strong>11 · [2900cdc] Add storage-type assertions for three workspace-repo read paths</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Three critical read paths that were refactored to use folder storage have no test assertions pinning that they actually receive a FolderStorage instance. A regression that reverted any of these back to the old dual-write path would slip through silently.

**💡 Decisions Behind the Code**

The three surfaces (Timeline view, branch-memories sidebar, squash-message generation) are user-visible and were the original regression targets. Pinning them with storage-type assertions at the call site catches any future refactor that accidentally reverts them to the old path.

**✅ What Was Implemented**

- Added test assertions for `listSummaries`, `listBranchMemories` (current-repo path), and `generateSquashMessageWithLLM` to verify they receive a FolderStorage instance in dual-write mode.
- Each assertion uses `instanceof MockFolderStorage` to pin the storage type at the call site, matching the pattern already established for other read paths.

**📁 FILES**
- `vscode/src/JolliMemoryBridge.test.ts`

</blockquote>
</details>
<details>
<summary><strong>12 · [2900cdc] Consolidate duplicated sync-visibility rationale across five comment locations</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The same explanation of why reads need to split from writes (sync-pulled rows only land in the folder, not the orphan branch) is written out in full at five different locations, creating five rot surfaces that will diverge over time.

**💡 Decisions Behind the Code**

Centralizing the rationale in one field JSDoc reduces maintenance burden and prevents the explanation from drifting across the codebase. One-line references are sufficient for readers who want the full context — they can follow the pointer.

**✅ What Was Implemented**

- Consolidated the full rationale into the `readStoragePromise` field JSDoc as the authoritative version.
- Replaced the other four locations with brief one-line references pointing back to `readStoragePromise` for the detailed explanation.
- Updated test comments to focus on the specific contract being pinned rather than re-explaining the root cause.

**📁 FILES**
- `vscode/src/JolliMemoryBridge.ts`
- `cli/src/core/SummaryStore.ts`

</blockquote>
</details>
<details>
<summary><strong>13 · [2900cdc] Clean up test setup and pin reloadStorage cache-clear contract</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The `reloadStorage()` test manually calls `invalidateEntriesCache()` after `reloadStorage()`, which masks whether `reloadStorage()` alone actually clears the entries cache. The test doesn't fully pin the contract it claims to test.

**💡 Decisions Behind the Code**

Removing the manual invalidation makes the test pin the actual contract: that `reloadStorage()` is sufficient to flip storage on a settings change without requiring a separate cache-clear call. The new test for rejected-promise reset is defensive — production doesn't reject today, but a future refactor could introduce a throwing helper, and the cache reset ensures the user isn't permanently stuck on a transient error.

**✅ What Was Implemented**

- Removed the manual `invalidateEntriesCache()` call from the `reloadStorage()` test so the test verifies that `reloadStorage()` alone clears both the read-storage cache and the entries cache.
- Renamed the test to clarify the contract being pinned.
- Added a new test to pin the rejected-promise cache-reset behavior.

**📁 FILES**
- `vscode/src/JolliMemoryBridge.test.ts`

</blockquote>
</details>
<details>
<summary><strong>14 · [2900cdc] Align unknown storage mode fallback between read and write paths</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

`StorageFactory.createStorage` uses a switch statement with a default case that falls back to orphan for unknown modes, but `JolliMemoryBridge.createReadStorage` had different logic that let all non-orphan modes fall through to folder storage. This read-write asymmetry could cause silent data divergence if a configuration typo appeared.

**💡 Decisions Behind the Code**

Consistency between read and write path fallbacks reduces the surface area for subtle bugs caused by configuration errors. By making both paths use the same switch-with-default pattern, a typo or future mode value will cause the same behavior on both sides, making the problem easier to diagnose and less likely to silently corrupt data.

**✅ What Was Implemented**

- `JolliMemoryBridge.createReadStorage` now uses a switch statement with explicit cases for `"dual-write"` and `"folder"`, falling back to `OrphanBranchStorage` for any unknown mode, matching the semantics of `StorageFactory.createStorage`.
- One new test case verifies that an unknown mode defaults to orphan storage on the read path.

**📁 FILES**
- `vscode/src/JolliMemoryBridge.ts`

</blockquote>
</details>

---

*Generated by Jolli Memory · May 22, 2026 at 5:28 PM*
<!-- jollimemory-summary-end -->