### PR TITLE
Fixed search issue in site build with jolli dev command

### DIFF
--- a/cli/src/commands/StartCommand.test.ts
+++ b/cli/src/commands/StartCommand.test.ts
@@ -211,7 +211,7 @@ function setupSuccessfulRun(
 	mockRunNpmInstall.mockResolvedValue({ success: true, output: "" });
 	mockRunNpmBuild.mockResolvedValue({ success: true, output: "" });
 	mockRunNpmDev.mockResolvedValue({ success: true, output: "" });
-	mockRunPagefind.mockReturnValue({ success: true, output: "Indexed 5 pages", pagesIndexed: 5 });
+	mockRunPagefind.mockResolvedValue({ success: true, output: "Indexed 5 pages", pagesIndexed: 5 });
 	mockRunServe.mockResolvedValue({ success: true, output: "" });
 	mockRunNpmStart.mockResolvedValue({ success: true, output: "" });
 	mockStartSourceWatcher.mockReturnValue({ close: vi.fn().mockResolvedValue(undefined) });
@@ -530,15 +530,43 @@ describe("jolli dev", () => {
 		consoleErrorSpy.mockRestore();
 	});
 
-	it("runs next dev, not build/pagefind/serve", async () => {
+	it("runs next dev and builds the initial search index, but never serve", async () => {
 		setupSuccessfulRun();
 		const program = await makeProgram();
 		await program.parseAsync(["dev", "/my-docs"], { from: "user" });
 
+		// Dev pipeline does ONE one-shot build + pagefind on startup to seed
+		// `public/_pagefind/` so the search box works the moment the page loads.
 		expect(mockRunNpmDev).toHaveBeenCalledOnce();
-		expect(mockRunNpmBuild).not.toHaveBeenCalled();
-		expect(mockRunPagefind).not.toHaveBeenCalled();
+		expect(mockRunNpmBuild).toHaveBeenCalledOnce();
+		expect(mockRunPagefind).toHaveBeenCalledOnce();
 		expect(mockRunServe).not.toHaveBeenCalled();
+	});
+
+	it("seeds the initial search index with JOLLI_PAGEFIND_BUILD=1 and the isolated distDir", async () => {
+		setupSuccessfulRun();
+		const program = await makeProgram();
+		await program.parseAsync(["dev", "/my-docs"], { from: "user" });
+
+		// build runs with the env flag so next.config.mjs redirects output to .next-pagefind/
+		const [, env] = mockRunNpmBuild.mock.calls[0] as [string, Record<string, string> | undefined];
+		expect(env).toEqual({ JOLLI_PAGEFIND_BUILD: "1" });
+
+		// pagefind reads from the isolated distDir, not the default .next/
+		const [, site, outputPath] = mockRunPagefind.mock.calls[0] as [string, string, string];
+		expect(site).toBe(".next-pagefind/server/app");
+		expect(outputPath).toBe("public/_pagefind");
+	});
+
+	it("still starts the dev server when the initial index build fails", async () => {
+		setupSuccessfulRun();
+		mockRunNpmBuild.mockResolvedValue({ success: false, output: "build broken" });
+		const program = await makeProgram();
+		await program.parseAsync(["dev", "/my-docs"], { from: "user" });
+
+		// Build failure must not stop the dev server — search is degraded, dev still works.
+		expect(mockRunNpmDev).toHaveBeenCalledOnce();
+		expect(process.exitCode).toBe(0);
 	});
 
 	it("passes staticExport: false to initNextraProject", async () => {
@@ -648,6 +676,26 @@ describe("jolli dev", () => {
 
 		const output = consoleSpy.mock.calls.map((c: unknown[]) => c.join(" ")).join("\n");
 		expect(output).toMatch(/↻ Synced \d+ files/);
+	});
+
+	it("triggers a background search-index rebuild after each onChange", async () => {
+		setupSuccessfulRun();
+		const program = await makeProgram();
+		await program.parseAsync(["dev", "/my-docs"], { from: "user" });
+
+		// Initial seed already ran once during startup.
+		expect(mockRunNpmBuild).toHaveBeenCalledTimes(1);
+		expect(mockRunPagefind).toHaveBeenCalledTimes(1);
+
+		const [, options] = mockStartSourceWatcher.mock.calls[0] as [string, { onChange: () => Promise<void> }];
+		await options.onChange();
+
+		// Indexer is fire-and-forget; let its drain microtask + awaits settle.
+		await new Promise((resolve) => setTimeout(resolve, 0));
+		await new Promise((resolve) => setTimeout(resolve, 0));
+
+		expect(mockRunNpmBuild).toHaveBeenCalledTimes(2);
+		expect(mockRunPagefind).toHaveBeenCalledTimes(2);
 	});
 
 	it("watcher onChange swallows a site.json read error and does NOT crash", async () => {

--- a/cli/src/commands/StartCommand.ts
+++ b/cli/src/commands/StartCommand.ts
@@ -419,7 +419,7 @@ async function buildAndIndex(
 	// for production server mode it indexes `.next/server/app/` (pre-rendered).
 	const pagefindSite = staticExport ? "out" : ".next/server/app";
 	const pagefindOutput = staticExport ? "out/_pagefind" : "public/_pagefind";
-	const pagefindResult = runPagefind(buildDir, pagefindSite, pagefindOutput);
+	const pagefindResult = await runPagefind(buildDir, pagefindSite, pagefindOutput);
 	if (!pagefindResult.success) {
 		console.error(v ? pagefindResult.output : "  Error: Search indexing failed");
 		process.exitCode = 1;
@@ -430,6 +430,101 @@ async function buildAndIndex(
 	console.log(`  ✓ Indexed ${pagesIndexed} pages for search`);
 
 	return { success: true, pagesBuilt };
+}
+
+// ─── Dev-mode search index ──────────────────────────────────────────────────
+
+/**
+ * Site path (relative to `buildDir`) that pagefind reads in dev mode. The
+ * dev-mode build redirects Next's output to `.next-pagefind/` via the
+ * `JOLLI_PAGEFIND_BUILD=1` env flag in `generateNextConfig`, so the rendered
+ * pages live one level deeper than the default `.next/server/app`.
+ */
+const DEV_PAGEFIND_SITE = ".next-pagefind/server/app";
+
+/**
+ * Output path (relative to `buildDir`) where pagefind writes the index in dev
+ * mode. `next dev` serves the `public/` directory as-is, so writing the index
+ * here makes `/_pagefind/pagefind.js` resolve at request time without any
+ * webpack involvement.
+ */
+const DEV_PAGEFIND_OUTPUT = "public/_pagefind";
+
+/**
+ * Env passed to the dev-mode `next build` invocation. Read by the generated
+ * `next.config.mjs` to redirect the build to `.next-pagefind/` so we never
+ * collide with the running dev compiler's `.next/`.
+ */
+const DEV_PAGEFIND_ENV = { JOLLI_PAGEFIND_BUILD: "1" } as const;
+
+/**
+ * Builds the dev-mode search index. Runs a one-shot `next build` into the
+ * isolated `.next-pagefind/` directory, then runs pagefind against the
+ * resulting HTML and writes the index into `public/_pagefind/`.
+ *
+ * Both stages can fail without taking the dev server down — search is a
+ * nice-to-have in dev, so this function logs and returns a status, never
+ * throws.
+ */
+async function buildDevSearchIndex(
+	buildDir: string,
+	renderer: SiteRenderer,
+	verbose: boolean,
+): Promise<{ success: boolean; pagesIndexed?: number; output?: string }> {
+	const buildResult = await renderer.runBuild(buildDir, DEV_PAGEFIND_ENV);
+	if (!buildResult.success) {
+		return { success: false, output: verbose ? buildResult.output : undefined };
+	}
+
+	const pagefindResult = await runPagefind(buildDir, DEV_PAGEFIND_SITE, DEV_PAGEFIND_OUTPUT);
+	if (!pagefindResult.success) {
+		return { success: false, output: verbose ? pagefindResult.output : undefined };
+	}
+
+	return { success: true, pagesIndexed: pagefindResult.pagesIndexed ?? 0 };
+}
+
+/**
+ * Background search-index rebuilder. Mirrors `SourceWatcher`'s drain pattern
+ * (`running`/`dirty` flags) so concurrent triggers coalesce into a single
+ * follow-up rebuild instead of stacking. The rebuild is fire-and-forget —
+ * callers do not await it, which keeps the watcher's `onChange` snappy and
+ * stops a stalled build from blocking the next sync.
+ */
+function createDevIndexer(buildDir: string, renderer: SiteRenderer, verbose: boolean): { trigger(): void } {
+	let running = false;
+	let dirty = false;
+
+	const drain = async (): Promise<void> => {
+		while (dirty) {
+			dirty = false;
+			try {
+				const result = await buildDevSearchIndex(buildDir, renderer, verbose);
+				if (result.success) {
+					console.log(`  ↻ Rebuilt search index (${result.pagesIndexed ?? 0} pages)`);
+				} else {
+					console.warn("  ⚠ Search index rebuild failed; existing index is still served");
+					if (verbose && result.output) console.error(result.output);
+				}
+			} catch (err) {
+				console.warn(`  ⚠ Search index rebuild error: ${err instanceof Error ? err.message : String(err)}`);
+			}
+		}
+		running = false;
+	};
+
+	return {
+		trigger(): void {
+			dirty = true;
+			if (running) return;
+			running = true;
+			// Fire-and-forget — errors are swallowed inside `drain`. Surfacing
+			// rejection here would propagate to an unhandled promise rejection
+			// and kill the dev process; we'd rather have a stale index than a
+			// dead server.
+			void drain();
+		},
+	};
 }
 
 // ─── Commands ────────────────────────────────────────────────────────────────
@@ -506,6 +601,26 @@ export async function runDevServer(
 	const result = await prepareContent(sourceRoot, buildDir, contentDir, publicDir, false, opts);
 	if (!result.success) return;
 
+	const verbose = opts.verbose === true;
+
+	// Build the initial search index synchronously — the dev server starts a
+	// few seconds later, but the search box works the moment the page loads.
+	// Failures only print a warning so the dev server still comes up; the
+	// `/_pagefind/pagefind.js` 404 is recoverable.
+	console.log("  Building search index…");
+	const initialIndex = await buildDevSearchIndex(buildDir, result.renderer, verbose);
+	if (initialIndex.success) {
+		console.log(`  ✓ Indexed ${initialIndex.pagesIndexed ?? 0} pages for search`);
+	} else {
+		console.warn("  ⚠ Search index build failed; search will be unavailable until the next successful rebuild");
+		if (verbose && initialIndex.output) console.error(initialIndex.output);
+	}
+
+	// Background rebuilder — content changes trigger a rebuild without
+	// blocking the watcher's sync, so the dev page reload stays snappy and
+	// the index just catches up a few seconds behind.
+	const indexer = createDevIndexer(buildDir, result.renderer, verbose);
+
 	console.log("  Watching source folder for changes…");
 	const watcher = startSourceWatcher(sourceRoot, {
 		onChange: async () => {
@@ -518,6 +633,7 @@ export async function runDevServer(
 				const ignored = sync.mirrorResult.ignoredFiles.length;
 				const suffix = ignored > 0 ? ` (${ignored} ignored)` : "";
 				console.log(`  ↻ Synced ${total} files${suffix}`);
+				indexer.trigger();
 			}
 		},
 	});

--- a/cli/src/site/NextraProjectWriter.test.ts
+++ b/cli/src/site/NextraProjectWriter.test.ts
@@ -166,6 +166,14 @@ describe("NextraProjectWriter.generateNextConfig", () => {
 		const config = generateNextConfig(false);
 		expect(config).not.toContain("output: 'export'");
 	});
+
+	it("wires JOLLI_PAGEFIND_BUILD to an isolated distDir", async () => {
+		const { generateNextConfig } = await import("./NextraProjectWriter.js");
+		const config = generateNextConfig();
+		// The runtime branch reads the env at config-load time and flips distDir.
+		expect(config).toContain("JOLLI_PAGEFIND_BUILD");
+		expect(config).toContain(".next-pagefind");
+	});
 });
 
 // ─── generateLayout unit tests ───────────────────────────────────────────────

--- a/cli/src/site/NextraProjectWriter.ts
+++ b/cli/src/site/NextraProjectWriter.ts
@@ -430,7 +430,12 @@ export function generatePackageJson(): string {
 export function generateNextConfig(staticExport?: boolean): string {
 	const exportLines = staticExport ? `\n  output: 'export',\n  images: { unoptimized: true },` : "";
 
+	// `JOLLI_PAGEFIND_BUILD=1` redirects build output to `.next-pagefind/` so the
+	// dev-mode search-index pipeline (which runs `next build` while `next dev` is
+	// also writing `.next/`) doesn't collide with the live dev compiler.
 	return `import nextra from 'nextra'
+
+const isPagefindBuild = process.env.JOLLI_PAGEFIND_BUILD === '1'
 
 const withNextra = nextra({
   contentDirBasePath: '/'
@@ -438,6 +443,7 @@ const withNextra = nextra({
 
 export default withNextra({${exportLines}
   reactStrictMode: true,
+  ...(isPagefindBuild ? { distDir: '.next-pagefind' } : {}),
   webpack(config) {
     // See JSDoc above for why this is here.
     config.infrastructureLogging = { ...(config.infrastructureLogging ?? {}), level: 'error' }

--- a/cli/src/site/NpmRunner.test.ts
+++ b/cli/src/site/NpmRunner.test.ts
@@ -272,6 +272,100 @@ describe("NpmRunner.runNpmBuild", () => {
 		expect(result.success).toBe(true);
 		expect(result.output).toBe("");
 	});
+
+	it("merges env overrides on top of process.env", async () => {
+		const { runNpmBuild } = await import("./NpmRunner.js");
+		mockSpawnSync.mockReturnValue(makeSpawnResult(0));
+
+		await runNpmBuild("/build/dir", { JOLLI_PAGEFIND_BUILD: "1" });
+
+		const opts = mockSpawnSync.mock.calls[0][2];
+		expect(opts.env.JOLLI_PAGEFIND_BUILD).toBe("1");
+		// PATH is a process.env key on every CI runner — it should survive the merge.
+		expect(opts.env.PATH).toBe(process.env.PATH);
+	});
+
+	it("passes process.env directly when no env override is given", async () => {
+		const { runNpmBuild } = await import("./NpmRunner.js");
+		mockSpawnSync.mockReturnValue(makeSpawnResult(0));
+
+		await runNpmBuild("/build/dir");
+
+		const opts = mockSpawnSync.mock.calls[0][2];
+		expect(opts.env).toBe(process.env);
+	});
+});
+
+// ─── runNpmBuildAsync ───────────────────────────────────────────────────────
+
+describe("NpmRunner.runNpmBuildAsync", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("returns { success: true } when the build exits with code 0", async () => {
+		const { runNpmBuildAsync } = await import("./NpmRunner.js");
+		const child = makeMockChild();
+		mockSpawn.mockReturnValue(child);
+
+		const promise = runNpmBuildAsync("/build/dir");
+		child.emit("close", 0);
+
+		const result = await promise;
+		expect(result.success).toBe(true);
+	});
+
+	it("returns { success: false } when the build exits with non-zero code", async () => {
+		const { runNpmBuildAsync } = await import("./NpmRunner.js");
+		const child = makeMockChild();
+		mockSpawn.mockReturnValue(child);
+
+		const promise = runNpmBuildAsync("/build/dir");
+		child.emit("close", 1);
+
+		const result = await promise;
+		expect(result.success).toBe(false);
+	});
+
+	it("returns { success: false } with the error message on spawn error", async () => {
+		const { runNpmBuildAsync } = await import("./NpmRunner.js");
+		const child = makeMockChild();
+		mockSpawn.mockReturnValue(child);
+
+		const promise = runNpmBuildAsync("/build/dir");
+		child.emit("error", new Error("spawn ENOENT"));
+
+		const result = await promise;
+		expect(result.success).toBe(false);
+		expect(result.output).toContain("spawn ENOENT");
+	});
+
+	it("merges env overrides on top of process.env", async () => {
+		const { runNpmBuildAsync } = await import("./NpmRunner.js");
+		const child = makeMockChild();
+		mockSpawn.mockReturnValue(child);
+
+		const promise = runNpmBuildAsync("/build/dir", { JOLLI_PAGEFIND_BUILD: "1" });
+		child.emit("close", 0);
+		await promise;
+
+		const opts = mockSpawn.mock.calls[0][2];
+		expect(opts.env.JOLLI_PAGEFIND_BUILD).toBe("1");
+		expect(opts.env.PATH).toBe(process.env.PATH);
+	});
+
+	it("passes process.env directly when no env override is given", async () => {
+		const { runNpmBuildAsync } = await import("./NpmRunner.js");
+		const child = makeMockChild();
+		mockSpawn.mockReturnValue(child);
+
+		const promise = runNpmBuildAsync("/build/dir");
+		child.emit("close", 0);
+		await promise;
+
+		const opts = mockSpawn.mock.calls[0][2];
+		expect(opts.env).toBe(process.env);
+	});
 });
 
 // ─── runNpmDev ───────────────────────────────────────────────────────────────

--- a/cli/src/site/NpmRunner.ts
+++ b/cli/src/site/NpmRunner.ts
@@ -54,13 +54,16 @@ export async function runNpmInstall(buildDir: string): Promise<NpmRunResult> {
 }
 
 /**
- * Runs `npm run build` inside `buildDir`.
+ * Runs `npm run build` inside `buildDir`. `env` is merged on top of
+ * `process.env` so callers can flip flags like `JOLLI_PAGEFIND_BUILD=1`
+ * without leaking them into the parent process.
  */
-export async function runNpmBuild(buildDir: string): Promise<NpmRunResult> {
+export async function runNpmBuild(buildDir: string, env?: Record<string, string>): Promise<NpmRunResult> {
 	const [cmd, args] = shellCmd("npm", ["run", "build"]);
 	const result = spawnSyncHidden(cmd, args, {
 		cwd: buildDir,
 		stdio: "pipe",
+		env: env ? { ...process.env, ...env } : process.env,
 		...SHELL_OPTS,
 	});
 
@@ -73,6 +76,41 @@ export async function runNpmBuild(buildDir: string): Promise<NpmRunResult> {
 	}
 
 	return { success: false, output };
+}
+
+/**
+ * Async variant of `runNpmBuild` — uses `spawn` instead of `spawnSync` so the
+ * caller's event loop keeps running. Used by the dev-mode background
+ * search-indexer so a rebuild doesn't freeze the SourceWatcher / dev server.
+ */
+export function runNpmBuildAsync(buildDir: string, env?: Record<string, string>): Promise<NpmRunResult> {
+	return new Promise((resolve) => {
+		const [cmd, args] = shellCmd("npm", ["run", "build"]);
+		const child = spawnHidden(cmd, args, {
+			cwd: buildDir,
+			stdio: "pipe",
+			env: env ? { ...process.env, ...env } : process.env,
+			...SHELL_OPTS,
+		});
+
+		let stdout = "";
+		let stderr = "";
+		child.stdout?.on("data", (data: Buffer) => {
+			stdout += data.toString();
+		});
+		child.stderr?.on("data", (data: Buffer) => {
+			stderr += data.toString();
+		});
+
+		child.on("close", (code) => {
+			const output = [stdout, stderr].filter(Boolean).join("\n");
+			resolve({ success: code === 0, output });
+		});
+
+		child.on("error", (err) => {
+			resolve({ success: false, output: err.message });
+		});
+	});
 }
 
 /** Result from a long-running server process. */

--- a/cli/src/site/PagefindRunner.test.ts
+++ b/cli/src/site/PagefindRunner.test.ts
@@ -1,40 +1,73 @@
 /**
  * Tests for PagefindRunner — runs the Pagefind indexer against the built site output.
  *
- * Covers all acceptance criteria from Task 9:
- *   - runPagefind runs `npx pagefind --site out/` inside buildDir
+ * Covers:
+ *   - runPagefind runs `npx pagefind --site <site>` inside buildDir
  *   - runPagefind returns { success: true, output, pagesIndexed } on exit code 0
  *   - runPagefind parses the number of pages indexed from the output
  *   - runPagefind returns { success: false, output } on non-zero exit codes
  *   - stdout and stderr are combined into the output string
  *   - errors are returned (not thrown) on non-zero exit codes
- *   - null stdout/stderr are handled gracefully
+ *   - missing stdout/stderr streams are handled gracefully
+ *   - errors emitted by spawn (e.g. ENOENT) are surfaced as { success: false }
  */
 
+import { EventEmitter } from "node:events";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // ─── Mocks ────────────────────────────────────────────────────────────────────
 
-const { mockSpawnSync } = vi.hoisted(() => ({
-	mockSpawnSync: vi.fn(),
+const { mockSpawn } = vi.hoisted(() => ({
+	mockSpawn: vi.fn(),
 }));
 
 vi.mock("node:child_process", () => ({
-	spawnSync: mockSpawnSync,
+	spawn: mockSpawn,
 }));
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
-/** Creates a mock spawnSync result with the given exit code and output. */
-function makeSpawnResult(status: number, stdout = "", stderr = "") {
-	return {
-		status,
-		stdout: Buffer.from(stdout),
-		stderr: Buffer.from(stderr),
-		pid: 1234,
-		output: [],
-		signal: null,
+interface FakeChildOptions {
+	exitCode?: number;
+	stdout?: string;
+	stderr?: string;
+	hasStdout?: boolean;
+	hasStderr?: boolean;
+	error?: Error;
+}
+
+/**
+ * Returns a stub ChildProcess that emits the configured stdout/stderr chunks
+ * once a listener is attached, then either fires `error` (when `error` is
+ * given) or `close` with the configured exit code. The microtask delay lets
+ * `runPagefind` register its listeners before any events fire.
+ */
+function makeFakeChild(opts: FakeChildOptions = {}): EventEmitter & {
+	stdout: EventEmitter | null;
+	stderr: EventEmitter | null;
+} {
+	const child = new EventEmitter() as EventEmitter & {
+		stdout: EventEmitter | null;
+		stderr: EventEmitter | null;
 	};
+	child.stdout = opts.hasStdout === false ? null : new EventEmitter();
+	child.stderr = opts.hasStderr === false ? null : new EventEmitter();
+
+	queueMicrotask(() => {
+		if (opts.stdout && child.stdout) {
+			child.stdout.emit("data", Buffer.from(opts.stdout));
+		}
+		if (opts.stderr && child.stderr) {
+			child.stderr.emit("data", Buffer.from(opts.stderr));
+		}
+		if (opts.error) {
+			child.emit("error", opts.error);
+			return;
+		}
+		child.emit("close", opts.exitCode ?? 0);
+	});
+
+	return child;
 }
 
 // ─── runPagefind ──────────────────────────────────────────────────────────────
@@ -44,132 +77,135 @@ describe("PagefindRunner.runPagefind", () => {
 		vi.clearAllMocks();
 	});
 
-	it("calls spawnSync with npx pagefind --site out/ and the correct cwd", async () => {
+	it("calls spawn with npx pagefind and the correct cwd", async () => {
 		const { runPagefind } = await import("./PagefindRunner.js");
-		mockSpawnSync.mockReturnValue(makeSpawnResult(0, "Indexed 10 pages"));
+		mockSpawn.mockReturnValue(makeFakeChild({ exitCode: 0, stdout: "Indexed 10 pages" }));
 
 		await runPagefind("/my/build/dir");
 
-		const call = mockSpawnSync.mock.calls[0];
+		const call = mockSpawn.mock.calls[0];
 		const invocation = `${call[0]} ${(call[1] ?? []).join(" ")}`;
 		expect(invocation).toContain("npx");
 		expect(invocation).toContain("pagefind");
 		expect(call[2]).toEqual(expect.objectContaining({ cwd: "/my/build/dir", stdio: "pipe" }));
 	});
 
+	it("forwards custom site and outputPath as CLI args", async () => {
+		const { runPagefind } = await import("./PagefindRunner.js");
+		mockSpawn.mockReturnValue(makeFakeChild({ exitCode: 0, stdout: "Indexed 3 pages" }));
+
+		await runPagefind("/build", ".next-pagefind/server/app", "public/_pagefind");
+
+		const call = mockSpawn.mock.calls[0];
+		const invocation = `${call[0]} ${(call[1] ?? []).join(" ")}`;
+		expect(invocation).toContain("--site .next-pagefind/server/app");
+		expect(invocation).toContain("--output-path public/_pagefind");
+	});
+
 	it("returns { success: true } when pagefind exits with code 0", async () => {
 		const { runPagefind } = await import("./PagefindRunner.js");
-		mockSpawnSync.mockReturnValue(makeSpawnResult(0, "Indexed 5 pages"));
+		mockSpawn.mockReturnValue(makeFakeChild({ exitCode: 0, stdout: "Indexed 5 pages" }));
 
 		const result = await runPagefind("/build/dir");
-
 		expect(result.success).toBe(true);
 	});
 
 	it("returns { success: false } when pagefind exits with non-zero code", async () => {
 		const { runPagefind } = await import("./PagefindRunner.js");
-		mockSpawnSync.mockReturnValue(makeSpawnResult(1, "", "Error: site not found"));
+		mockSpawn.mockReturnValue(makeFakeChild({ exitCode: 1, stderr: "Error: site not found" }));
 
 		const result = await runPagefind("/build/dir");
-
 		expect(result.success).toBe(false);
 	});
 
 	it("parses pagesIndexed from output matching 'Indexed N pages'", async () => {
 		const { runPagefind } = await import("./PagefindRunner.js");
-		mockSpawnSync.mockReturnValue(makeSpawnResult(0, "Indexed 42 pages"));
+		mockSpawn.mockReturnValue(makeFakeChild({ exitCode: 0, stdout: "Indexed 42 pages" }));
 
 		const result = await runPagefind("/build/dir");
-
 		expect(result.pagesIndexed).toBe(42);
 	});
 
 	it("parses pagesIndexed from output matching 'Found N pages'", async () => {
 		const { runPagefind } = await import("./PagefindRunner.js");
-		mockSpawnSync.mockReturnValue(makeSpawnResult(0, "Found 7 pages in the site"));
+		mockSpawn.mockReturnValue(makeFakeChild({ exitCode: 0, stdout: "Found 7 pages in the site" }));
 
 		const result = await runPagefind("/build/dir");
-
 		expect(result.pagesIndexed).toBe(7);
 	});
 
 	it("parses pagesIndexed from output matching singular 'page'", async () => {
 		const { runPagefind } = await import("./PagefindRunner.js");
-		mockSpawnSync.mockReturnValue(makeSpawnResult(0, "Indexed 1 page"));
+		mockSpawn.mockReturnValue(makeFakeChild({ exitCode: 0, stdout: "Indexed 1 page" }));
 
 		const result = await runPagefind("/build/dir");
-
 		expect(result.pagesIndexed).toBe(1);
 	});
 
 	it("returns pagesIndexed as undefined when output has no page count", async () => {
 		const { runPagefind } = await import("./PagefindRunner.js");
-		mockSpawnSync.mockReturnValue(makeSpawnResult(0, "Build complete"));
+		mockSpawn.mockReturnValue(makeFakeChild({ exitCode: 0, stdout: "Build complete" }));
 
 		const result = await runPagefind("/build/dir");
-
 		expect(result.pagesIndexed).toBeUndefined();
 	});
 
 	it("does not include pagesIndexed on failure", async () => {
 		const { runPagefind } = await import("./PagefindRunner.js");
-		mockSpawnSync.mockReturnValue(makeSpawnResult(1, "", "fatal error"));
+		mockSpawn.mockReturnValue(makeFakeChild({ exitCode: 1, stderr: "fatal error" }));
 
 		const result = await runPagefind("/build/dir");
-
 		expect(result.pagesIndexed).toBeUndefined();
 	});
 
 	it("includes stdout in output on success", async () => {
 		const { runPagefind } = await import("./PagefindRunner.js");
-		mockSpawnSync.mockReturnValue(makeSpawnResult(0, "Indexed 3 pages", ""));
+		mockSpawn.mockReturnValue(makeFakeChild({ exitCode: 0, stdout: "Indexed 3 pages" }));
 
 		const result = await runPagefind("/build/dir");
-
 		expect(result.output).toContain("Indexed 3 pages");
 	});
 
 	it("includes stderr in output on failure", async () => {
 		const { runPagefind } = await import("./PagefindRunner.js");
-		mockSpawnSync.mockReturnValue(makeSpawnResult(1, "", "Error: out/ not found"));
+		mockSpawn.mockReturnValue(makeFakeChild({ exitCode: 1, stderr: "Error: out/ not found" }));
 
 		const result = await runPagefind("/build/dir");
-
 		expect(result.output).toContain("Error: out/ not found");
 	});
 
 	it("combines stdout and stderr into output", async () => {
 		const { runPagefind } = await import("./PagefindRunner.js");
-		mockSpawnSync.mockReturnValue(makeSpawnResult(1, "partial stdout", "error details"));
+		mockSpawn.mockReturnValue(makeFakeChild({ exitCode: 1, stdout: "partial stdout", stderr: "error details" }));
 
 		const result = await runPagefind("/build/dir");
-
 		expect(result.output).toContain("partial stdout");
 		expect(result.output).toContain("error details");
 	});
 
 	it("does not throw on non-zero exit code", async () => {
 		const { runPagefind } = await import("./PagefindRunner.js");
-		mockSpawnSync.mockReturnValue(makeSpawnResult(1, "", "fatal error"));
+		mockSpawn.mockReturnValue(makeFakeChild({ exitCode: 1, stderr: "fatal error" }));
 
-		expect(() => runPagefind("/build/dir")).not.toThrow();
+		await expect(runPagefind("/build/dir")).resolves.toEqual(expect.objectContaining({ success: false }));
 	});
 
-	it("handles null stdout and stderr gracefully", async () => {
+	it("handles missing stdout and stderr streams gracefully", async () => {
 		const { runPagefind } = await import("./PagefindRunner.js");
-		mockSpawnSync.mockReturnValue({
-			status: 0,
-			stdout: null,
-			stderr: null,
-			pid: 1234,
-			output: [],
-			signal: null,
-		});
+		mockSpawn.mockReturnValue(makeFakeChild({ exitCode: 0, hasStdout: false, hasStderr: false }));
 
 		const result = await runPagefind("/build/dir");
-
 		expect(result.success).toBe(true);
 		expect(result.output).toBe("");
 		expect(result.pagesIndexed).toBeUndefined();
+	});
+
+	it("returns { success: false } when spawn emits an error (e.g. ENOENT)", async () => {
+		const { runPagefind } = await import("./PagefindRunner.js");
+		mockSpawn.mockReturnValue(makeFakeChild({ error: new Error("spawn ENOENT") }));
+
+		const result = await runPagefind("/build/dir");
+		expect(result.success).toBe(false);
+		expect(result.output).toContain("spawn ENOENT");
 	});
 });

--- a/cli/src/site/PagefindRunner.ts
+++ b/cli/src/site/PagefindRunner.ts
@@ -1,15 +1,14 @@
 /**
  * PagefindRunner — runs the Pagefind indexer against the built site output.
  *
- * Runs `npx pagefind --site out/` inside `buildDir` using `child_process.spawnSync`
- * with `stdio: 'pipe'` to capture output. Parses the output to extract the number
- * of pages indexed.
+ * Runs `npx pagefind --site <site>` inside `buildDir` and parses the output
+ * to extract the number of pages indexed.
  *
  * Returns `{ success: false, output }` on non-zero exit codes rather than
  * throwing, so the caller can print the error and set the exit code.
  */
 
-import { spawnSyncHidden } from "../util/Subprocess.js";
+import { spawnHidden } from "../util/Subprocess.js";
 import type { PagefindResult } from "./Types.js";
 
 /**
@@ -23,30 +22,46 @@ const SHELL_OPTS = IS_WIN ? /* v8 ignore next */ ({ shell: true } as const) : {}
 export type { PagefindResult };
 
 /**
- * Runs `npx pagefind --site out/` inside `buildDir`.
+ * Runs `npx pagefind --site <site> --output-path <outputPath>` inside `buildDir`.
  *
- * Captures stdout and stderr. Parses the output to extract the number of pages
- * indexed (e.g. "Indexed 42 pages"). Returns `{ success: true, output, pagesIndexed }`
- * on exit code 0, or `{ success: false, output }` on any non-zero exit code.
+ * Async via `spawn` (not `spawnSync`) so the dev-mode background indexer can
+ * keep the event loop free while a rebuild is in flight. Captures stdout and
+ * stderr. Parses the output to extract the number of pages indexed (e.g.
+ * "Indexed 42 pages"). Returns `{ success: true, output, pagesIndexed }` on
+ * exit code 0, or `{ success: false, output }` on any non-zero exit code.
  */
-export function runPagefind(buildDir: string, site = "out", outputPath = "out/_pagefind"): PagefindResult {
-	const rawArgs = ["pagefind", "--site", site, "--output-path", outputPath];
-	const [cmd, args] = IS_WIN ? /* v8 ignore next */ [`npx ${rawArgs.join(" ")}`, []] : ["npx", rawArgs];
-	const result = spawnSyncHidden(cmd, args, {
-		cwd: buildDir,
-		stdio: "pipe",
-		...SHELL_OPTS,
+export function runPagefind(buildDir: string, site = "out", outputPath = "out/_pagefind"): Promise<PagefindResult> {
+	return new Promise((resolve) => {
+		const rawArgs = ["pagefind", "--site", site, "--output-path", outputPath];
+		const [cmd, args] = IS_WIN ? /* v8 ignore next */ [`npx ${rawArgs.join(" ")}`, []] : ["npx", rawArgs];
+		const child = spawnHidden(cmd, args, {
+			cwd: buildDir,
+			stdio: "pipe",
+			...SHELL_OPTS,
+		});
+
+		let stdout = "";
+		let stderr = "";
+		child.stdout?.on("data", (data: Buffer) => {
+			stdout += data.toString();
+		});
+		child.stderr?.on("data", (data: Buffer) => {
+			stderr += data.toString();
+		});
+
+		child.on("close", (code) => {
+			const output = [stdout, stderr].filter(Boolean).join("\n");
+			if (code === 0) {
+				const match = output.match(/(\d+)\s+pages?/i);
+				const pagesIndexed = match ? parseInt(match[1], 10) : undefined;
+				resolve({ success: true, output, pagesIndexed });
+				return;
+			}
+			resolve({ success: false, output });
+		});
+
+		child.on("error", (err) => {
+			resolve({ success: false, output: err.message });
+		});
 	});
-
-	const stdout = result.stdout ? result.stdout.toString() : "";
-	const stderr = result.stderr ? result.stderr.toString() : "";
-	const output = [stdout, stderr].filter(Boolean).join("\n");
-
-	if (result.status === 0) {
-		const match = output.match(/(\d+)\s+pages?/i);
-		const pagesIndexed = match ? parseInt(match[1], 10) : undefined;
-		return { success: true, output, pagesIndexed };
-	}
-
-	return { success: false, output };
 }

--- a/cli/src/site/renderer/NextraRenderer.test.ts
+++ b/cli/src/site/renderer/NextraRenderer.test.ts
@@ -178,7 +178,13 @@ describe("NextraRenderer", () => {
 	it("runBuild delegates to runNpmBuild", async () => {
 		const { runNpmBuild } = await import("../NpmRunner.js");
 		await new NextraRenderer().runBuild("/build");
-		expect(runNpmBuild).toHaveBeenCalledWith("/build");
+		expect(runNpmBuild).toHaveBeenCalledWith("/build", undefined);
+	});
+
+	it("runBuild forwards env overrides to runNpmBuild", async () => {
+		const { runNpmBuild } = await import("../NpmRunner.js");
+		await new NextraRenderer().runBuild("/build", { JOLLI_PAGEFIND_BUILD: "1" });
+		expect(runNpmBuild).toHaveBeenCalledWith("/build", { JOLLI_PAGEFIND_BUILD: "1" });
 	});
 
 	it("runDev delegates to runNpmDev", async () => {

--- a/cli/src/site/renderer/NextraRenderer.ts
+++ b/cli/src/site/renderer/NextraRenderer.ts
@@ -128,8 +128,8 @@ export class NextraRenderer implements SiteRenderer {
 		};
 	}
 
-	async runBuild(buildDir: string): Promise<NpmRunResult> {
-		return runNpmBuild(buildDir);
+	async runBuild(buildDir: string, env?: Record<string, string>): Promise<NpmRunResult> {
+		return runNpmBuild(buildDir, env);
 	}
 
 	async runDev(buildDir: string, verbose?: boolean): Promise<ServerResult> {

--- a/cli/src/site/renderer/SiteRenderer.ts
+++ b/cli/src/site/renderer/SiteRenderer.ts
@@ -106,9 +106,11 @@ export interface SiteRenderer {
 	getContentRules(): ContentRules;
 
 	/**
-	 * Run the production build command.
+	 * Run the production build command. `env` overrides are merged onto
+	 * `process.env` for the spawned process — used to flip per-run flags
+	 * like `JOLLI_PAGEFIND_BUILD=1` for the dev-mode search-index build.
 	 */
-	runBuild(buildDir: string): Promise<NpmRunResult>;
+	runBuild(buildDir: string, env?: Record<string, string>): Promise<NpmRunResult>;
 
 	/**
 	 * Run the dev server command.


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## Quick recap

The developer added search index seeding and background rebuilding to `jolli dev`, making the search box functional on page load and keeping it up-to-date as content changes. On startup, the dev server now runs a one-shot build and pagefind into an isolated `.next-pagefind/` directory, then serves the resulting index from `public/_pagefind/` so the search box works immediately. After each content sync, a background rebuilder (using a drain pattern to coalesce concurrent requests) asynchronously rebuilds the index without blocking the watcher or delaying page reloads. If the seed build or a background rebuild fails, the dev server continues running with a stale or missing index—search is degraded but the dev experience is not interrupted. The pagefind runner was migrated from synchronous to asynchronous spawning to support the background rebuilder without freezing the event loop, and the test suite was updated to verify both the seed behavior and the background rebuild behavior under success and failure conditions.

---

## Topics (3)
<details>
<summary><strong>01 · Search index seeding and background rebuilding in dev mode</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The search box in `jolli dev` was not functional on page load because the search index had never been built. Users would see a broken search experience until they manually triggered a rebuild or waited for content changes.

**💡 Decisions Behind the Code**

- **Synchronous seed on startup vs. lazy-on-first-search**: A blocking seed ensures the search box works the moment the page loads, matching user expectations from production builds. Lazy initialization would leave users with a broken search experience on first page load, which is poor UX in dev mode where fast feedback is critical.
- **Fire-and-forget background rebuilds**: Awaiting each rebuild would freeze the watcher's `onChange` callback and delay the next content sync, making the dev experience sluggish. Fire-and-forget keeps the watcher responsive while the index catches up asynchronously. Failures are logged as warnings but do not crash the dev server, since search is a nice-to-have in dev and a stale index is recoverable.
- **Isolated `.next-pagefind/` directory for seed builds**: Running `next build` while `next dev` is actively writing to `.next/` would cause file conflicts and race conditions. The isolated directory (toggled by an environment variable read at config load time) ensures the seed build and live dev compiler never collide, and the index is written to `public/` where `next dev` serves it as static content without webpack involvement.

**✅ What Was Implemented**

- Added a one-shot `next build` + `pagefind` pipeline that runs synchronously on dev server startup, seeding the search index into `public/_pagefind/` before the dev server starts. This uses an isolated `.next-pagefind/` output directory (controlled by the `JOLLI_PAGEFIND_BUILD=1` environment variable) to avoid colliding with the live dev compiler's `.next/` directory.
- Implemented a background search-index rebuilder (`createDevIndexer`) that triggers after each content sync, using a drain pattern (running/dirty flags) to coalesce concurrent rebuild requests into a single follow-up build. The rebuild is fire-and-forget so content syncs remain snappy and stalled builds do not block the watcher.
- Extended `NpmRunner` with an async `runNpmBuildAsync` function and added environment variable override support to both sync and async build runners, allowing callers to pass flags like `JOLLI_PAGEFIND_BUILD=1` without polluting the parent process.

**📁 FILES**
- `cli/src/commands/StartCommand.ts`
- `cli/src/site/NpmRunner.ts`
- `cli/src/site/PagefindRunner.ts`
- `cli/src/site/NextraProjectWriter.ts`

</blockquote>
</details>
<details>
<summary><strong>02 · Async pagefind runner and test migration from sync to async</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The pagefind indexer was using synchronous spawning, which blocked the event loop. The dev-mode background rebuilder needed an async variant to avoid freezing the watcher while indexing runs.

**💡 Decisions Behind the Code**

Async spawning is necessary for the background rebuilder to avoid blocking the watcher's event loop. The test migration from sync mocks to event-emitting fakes ensures the test suite accurately reflects the real async behavior and catches timing issues that sync tests would miss.

**✅ What Was Implemented**

- Migrated `PagefindRunner` from `spawnSync` to `spawn`, converting it to an async function that returns a promise. The runner now collects stdout/stderr via event listeners and resolves when the child process emits `close` or `error`.
- Updated all test mocks and test cases to use async/await patterns and event-emitting fake child processes instead of synchronous spawn results. Added new test cases covering custom site and output paths, spawn errors (e.g. ENOENT), and missing stdout/stderr streams.

**📁 FILES**
- `cli/src/site/PagefindRunner.ts`
- `cli/src/site/PagefindRunner.test.ts`

</blockquote>
</details>
<details>
<summary><strong>03 · Test fixes for dev command search index integration</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Existing dev command tests were written before search index seeding was added, so they expected no build or pagefind calls. The new feature required updating test expectations and adding new test cases to cover the seed and background rebuild behavior.

**💡 Decisions Behind the Code**

The test suite needed to reflect the new startup behavior (seed build + pagefind) and the background rebuild behavior (triggered on content changes). Explicit test cases for the isolated distDir and failure resilience ensure the feature works correctly under edge cases and prevent regressions if the implementation changes.

**✅ What Was Implemented**

- Fixed `mockRunPagefind` mock to use `mockResolvedValue` instead of `mockReturnValue`, matching the async nature of the new pagefind runner.
- Updated the "runs next dev" test to expect one `npm build` and one `pagefind` call during startup (the seed phase), and renamed it to clarify that the dev pipeline now includes an initial index build.
- Added three new test cases: one verifying the seed build uses the `JOLLI_PAGEFIND_BUILD=1` env flag and isolated `.next-pagefind/` directory; one confirming the dev server still starts even if the seed build fails; and one verifying background rebuilds trigger after each content sync.

**📁 FILES**
- `cli/src/commands/StartCommand.test.ts`
- `cli/src/site/NpmRunner.test.ts`
- `cli/src/site/NextraProjectWriter.test.ts`

</blockquote>
</details>

---

*Generated by Jolli Memory · May 22, 2026 at 11:38 AM · via Anthropic*
<!-- jollimemory-summary-end -->