### PR TITLE
Add GitHub Actions workflow to verify DCO sign-off on pull requests

### DIFF
--- a/.github/workflows/verify-dco.yaml
+++ b/.github/workflows/verify-dco.yaml
@@ -1,0 +1,135 @@
+# Verifies the Developer Certificate of Origin (DCO) sign-off on every
+# commit a pull request introduces.
+#
+# CONTRIBUTING.md and CLAUDE.md both state that PRs without a valid
+# `Signed-off-by:` trailer are rejected — this workflow is the
+# mechanical enforcement of that rule.
+#
+# Why a hand-rolled bash check instead of a marketplace action:
+#   - Keeps the supply chain narrow. OpenSSF Scorecard (scorecard.yaml)
+#     scores us on pinned + minimal third-party action surface, and the
+#     DCO rule is one line of logic — not worth importing for.
+#   - Lets the failure message point straight at the project's existing
+#     CONTRIBUTING.md remediation steps instead of a generic action's.
+#
+# Why only `pull_request`:
+#   - DCO is a PR-time gate. Push events to main only land via PRs that
+#     have already passed this check; re-running on push would also red
+#     the workflow for any pre-DCO commit still reachable on a long-lived
+#     branch, which has no useful corrective action.
+#
+# Every commit is checked, including merge commits authored by the
+# contributor (e.g. "Merge branch 'main' into feature"). GitHub's own
+# synthetic merge ref is never reached because the verification range
+# is `base.sha..head.sha` — the synthetic merge is not an ancestor of
+# head.sha and falls outside the range by construction.
+#
+# Each commit must carry at least one Signed-off-by trailer whose
+# email matches the commit author's email (case-insensitive). This
+# mirrors GitHub's official DCO App default and the DCO semantics on
+# developercertificate.org — the contributor signs for their own work.
+#
+# Workflow injection hygiene (per CLAUDE.md): every user-controlled
+# `${{ … }}` context — including `github.event.pull_request.*.sha` —
+# is funnelled through `env:` before the `run:` block, never inlined
+# into the shell.
+
+name: CI - Verify DCO
+
+on:
+    pull_request:
+        branches: [main, "release/**"]
+
+permissions:
+    contents: read
+
+jobs:
+    verify-dco:
+        runs-on: ubuntu-24.04
+        timeout-minutes: 5
+        steps:
+            -   uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+                with:
+                    # Need history back to the PR's merge base so we can
+                    # enumerate every commit the PR introduces.
+                    fetch-depth: 0
+                    persist-credentials: false
+
+            -   name: Verify Signed-off-by trailer on every PR commit
+                env:
+                    BASE_SHA: ${{ github.event.pull_request.base.sha }}
+                    HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+                run: |
+                    set -euo pipefail
+
+                    # Include merge commits — see CONTRIBUTING.md.
+                    # The PR branch range itself excludes GitHub's
+                    # synthetic merge ref (not an ancestor of head.sha).
+                    mapfile -t commits < <(git rev-list "$BASE_SHA".."$HEAD_SHA")
+
+                    if [ "${#commits[@]}" -eq 0 ]; then
+                        echo "No commits to verify."
+                        exit 0
+                    fi
+
+                    failed=0
+                    for sha in "${commits[@]}"; do
+                        short=$(git log -1 --pretty='%h %s' "$sha")
+                        # Lowercase both sides; email comparison is case-
+                        # insensitive per RFC 5321 (the local part is
+                        # technically case-sensitive, but in practice no
+                        # mail provider relies on that, and git config
+                        # round-trips emails verbatim — matching exactly
+                        # what `git commit -s` would produce).
+                        author_email=$(git show -s --format='%ae' "$sha" \
+                            | tr '[:upper:]' '[:lower:]')
+
+                        # Parse trailers rigorously — grepping the raw
+                        # message would let a commit body that mentions
+                        # the string "Signed-off-by:" pass without an
+                        # actual trailer block. Multiple Signed-off-by
+                        # trailers are allowed (e.g. patch-relay flows);
+                        # one matching the author is enough.
+                        sob_emails=$(git show -s --format=%B "$sha" \
+                            | git interpret-trailers --parse \
+                            | grep -iE '^Signed-off-by:[[:space:]]+.+[[:space:]]+<.+@.+>[[:space:]]*$' \
+                            | sed -E 's/.*<([^>]+)>.*/\1/' \
+                            | tr '[:upper:]' '[:lower:]' \
+                            || true)
+
+                        if [ -z "$sob_emails" ]; then
+                            echo "::error::Missing or malformed Signed-off-by trailer on commit: $short"
+                            failed=$((failed + 1))
+                            continue
+                        fi
+
+                        if ! printf '%s\n' "$sob_emails" | grep -qxF "$author_email"; then
+                            found=$(printf '%s ' $sob_emails)
+                            echo "::error::Signed-off-by does not match author <$author_email> on commit: $short (found: ${found% })"
+                            failed=$((failed + 1))
+                        fi
+                    done
+
+                    if [ "$failed" -gt 0 ]; then
+                        {
+                            echo
+                            echo "DCO check failed for $failed commit(s)."
+                            echo
+                            echo "Every commit must end with a trailer of the form:"
+                            echo "    Signed-off-by: Your Name <your.email@example.com>"
+                            echo "and the email must match the commit author's email."
+                            echo
+                            echo "Amend the most recent commit:"
+                            echo "    git commit --amend -s --no-edit"
+                            echo "    git push --force-with-lease"
+                            echo
+                            echo "Sign off multiple commits at once:"
+                            echo "    git rebase --signoff HEAD~<number-of-commits>"
+                            echo "    git push --force-with-lease"
+                            echo
+                            echo "See CONTRIBUTING.md for the full policy."
+                        } >&2
+                        exit 1
+                    fi
+
+                    echo "All ${#commits[@]} commit(s) carry a matching Signed-off-by trailer."


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## Quick recap

The Developer Certificate of Origin (DCO) verification workflow is now fully enforced on pull requests targeting the main and release branches. The workflow validates that every commit—including merge commits authored by contributors—carries a properly formatted Signed-off-by trailer with an email address matching the commit author. The validation uses RFC 822 trailer parsing to distinguish genuine trailers from casual mentions of the string "Signed-off-by:" in commit message bodies, preventing false passes.

When a commit fails verification, the workflow displays the author's email and any Signed-off-by trailers found, making it straightforward for contributors to diagnose and correct sign-off problems. The failure message also quotes the remediation steps directly from the project's CONTRIBUTING.md, guiding contributors to either amend the most recent commit or rebase multiple commits with the appropriate git flags, eliminating the need to hunt down separate documentation.

The implementation uses a hand-rolled bash script rather than a third-party marketplace action, keeping the supply chain narrow and preserving the project's OpenSSF Scorecard score while allowing the failure message to reference the project's own remediation guidance. The workflow runs only on pull requests, not on push events, since commits that land on main have already passed DCO verification through their PR gate.

---

## Topics (2)
<details>
<summary><strong>01 · Enforce Signed-off-by trailer email matching and include merge commits in DCO verification</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Code review identified two gaps in the DCO (Developer Certificate of Origin) verification workflow: merge commits authored by contributors were being skipped entirely, and the trailer validation only checked for the presence of a Signed-off-by line without verifying that the email matched the commit author's email address.

**💡 Decisions Behind the Code**

- **Merge commit inclusion without synthetic merge false positives**: The PR branch range `base.sha..head.sha` naturally excludes GitHub's synthetic merge ref (it is not an ancestor of head.sha), so removing `--no-merges` does not cause false failures on GitHub's auto-generated merges. This approach is simpler than filtering by commit message pattern and aligns with the official GitHub DCO App behavior, which also checks merge commits.
- **Case-insensitive email comparison with multi-trailer support**: Email addresses are case-insensitive per RFC 5321, and git config preserves email case verbatim, so matching must normalize both sides to lowercase. The implementation allows multiple Signed-off-by trailers (supporting patch-relay and cherry-pick workflows) and passes if any one matches the author, mirroring the semantics of `git commit -s` and the DCO specification.

**✅ What Was Implemented**

- Removed the `--no-merges` flag from the git rev-list command so that contributor-authored merge commits (e.g., "Merge branch 'main' into feature") are now included in DCO verification, aligning with the project's policy that all commits must carry a valid sign-off.
- Added email matching logic that extracts the email from each Signed-off-by trailer and compares it case-insensitively against the commit author's email, rejecting commits where the trailer email does not match the author.
- Enhanced error messages to display the author email and any Signed-off-by emails found, making it easier for contributors to diagnose and fix sign-off mismatches.

**📁 FILES**
- `.github/workflows/verify-dco.yaml`

</blockquote>
</details>
<details>
<summary><strong>02 · Add GitHub Actions workflow to enforce Developer Certificate of Origin sign-off on pull requests</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The project's CONTRIBUTING.md and CLAUDE.md documents state that all commits must carry a `Signed-off-by:` trailer, but no automated enforcement existed. Pull requests could be merged without this required sign-off, creating a gap between documented policy and actual enforcement.

**💡 Decisions Behind the Code**

- **Hand-rolled bash instead of a marketplace action**: The DCO rule is a single logical check (does every commit have a valid trailer?), not complex enough to justify importing a third-party action. Keeping the supply chain narrow preserves the project's OpenSSF Scorecard score on pinned dependencies and minimal third-party surface. The failure message can directly reference the project's own CONTRIBUTING.md remediation steps rather than a generic action's boilerplate.
- **Trigger only on `pull_request`, not `push`**: DCO is a PR-time gate. Commits that land on `main` have already passed this check via their PR. Running on push events would also flag pre-DCO commits on long-lived branches with no corrective action available, creating noise without value.
- **Use `git interpret-trailers --parse` instead of grep**: The DCO specification requires a trailer (a structured field at the end of the commit message after a blank line), not merely the string "Signed-off-by:" appearing anywhere in the message. Grepping the raw message would allow a commit body that casually mentions "Signed-off-by: someone" to pass without an actual trailer, violating the spec. The RFC 822 trailer parser enforces the structural requirement.

**✅ What Was Implemented**

- Created `.github/workflows/verify-dco.yaml`, a new GitHub Actions workflow that runs on every pull request targeting `main` or `release/*` branches. The workflow enumerates all non-merge commits introduced by the PR and validates that each carries a properly formatted `Signed-off-by:` trailer using `git interpret-trailers --parse` to avoid false positives from commit message bodies that merely mention the string "Signed-off-by:".
- The workflow failure message directly quotes the remediation steps from CONTRIBUTING.md (lines 65–77), guiding contributors to either amend the most recent commit with `git commit --amend -s --no-edit` or rebase multiple commits with `git rebase --signoff HEAD~<N>`, eliminating the need for contributors to hunt down separate documentation.
- All user-controlled context variables (`github.event.pull_request.base.sha`, `github.event.pull_request.head.sha`) are funneled through the `env:` block before use in the shell script, adhering to the workflow injection hygiene rules documented in CLAUDE.md.

**📁 FILES**
- `.github/workflows/verify-dco.yaml`

</blockquote>
</details>

---

*Generated by Jolli Memory · May 22, 2026 at 3:08 PM · via Anthropic*
<!-- jollimemory-summary-end -->