### PR TITLE
Refactor amend dispatch to two-tier pipeline with safeguards

### DIFF
--- a/cli/src/hooks/PostCommitHook.helpers.test.ts
+++ b/cli/src/hooks/PostCommitHook.helpers.test.ts
@@ -25,6 +25,7 @@ const {
 	mockReadTranscript,
 	mockBuildMultiSessionContext,
 	mockGenerateSummary,
+	mockGenerateSquashConsolidation,
 	mockGetHeadCommitInfo,
 	mockGetCurrentBranch,
 	mockGetDiffContent,
@@ -58,6 +59,7 @@ const {
 	mockReadTranscript: vi.fn(),
 	mockBuildMultiSessionContext: vi.fn(),
 	mockGenerateSummary: vi.fn(),
+	mockGenerateSquashConsolidation: vi.fn(),
 	mockGetHeadCommitInfo: vi.fn(),
 	mockGetCurrentBranch: vi.fn(),
 	mockGetDiffContent: vi.fn(),
@@ -193,9 +195,10 @@ vi.mock("../core/Summarizer.js", async (importOriginal) => {
 	const actual = await importOriginal<typeof import("../core/Summarizer.js")>();
 	return {
 		generateSummary: mockGenerateSummary,
-		// Mock LLM-touching squash consolidation; default null forces the
-		// caller into the (real) mechanicalConsolidate fallback.
-		generateSquashConsolidation: vi.fn().mockResolvedValue(null),
+		// Mock LLM-touching squash consolidation; default null (set in beforeEach)
+		// forces the caller into the (real) mechanicalConsolidate fallback. Exposed
+		// as a hoisted mock so tests can assert call counts per amend path.
+		generateSquashConsolidation: mockGenerateSquashConsolidation,
 		mechanicalConsolidate: actual.mechanicalConsolidate,
 		extractTicketIdFromMessage: actual.extractTicketIdFromMessage,
 		formatSourceCommitsForSquash: actual.formatSourceCommitsForSquash,
@@ -290,6 +293,9 @@ describe("PostCommitHook helpers", () => {
 			stats: { filesChanged: 1, insertions: 1, deletions: 0 },
 			topics: [{ title: "Topic", trigger: "Trigger", response: "Response", decisions: "Decision" }],
 		});
+		// Default to null so Full-path tests exercise the mechanicalConsolidate fallback,
+		// matching the previous inline-mock behavior. Individual tests can override.
+		mockGenerateSquashConsolidation.mockResolvedValue(null);
 		mockGetHeadCommitInfo.mockResolvedValue({
 			hash: "deadbeefcafebabe",
 			message: "Test commit",
@@ -951,7 +957,11 @@ describe("PostCommitHook helpers", () => {
 				0,
 			);
 
-			expect(mockStoreSummary).toHaveBeenCalledWith(
+			// Helper now passes (root, cwd, false, transcriptArtifact?) — match prefix only.
+			expect(mockStoreSummary.mock.calls.length).toBeGreaterThanOrEqual(1);
+			const [hoistedRoot, hoistedCwd] = mockStoreSummary.mock.calls[0];
+			expect(hoistedCwd).toBe("/repo");
+			expect(hoistedRoot).toEqual(
 				expect.objectContaining({
 					jolliDocId: 42,
 					jolliDocUrl: "https://jolli.app/articles/42",
@@ -959,7 +969,6 @@ describe("PostCommitHook helpers", () => {
 					plans: [expect.objectContaining({ slug: "plan-1" })],
 					e2eTestGuide: [expect.objectContaining({ title: "Scenario" })],
 				}),
-				"/repo",
 			);
 		});
 
@@ -991,9 +1000,9 @@ describe("PostCommitHook helpers", () => {
 			});
 			mockLoadAllSessions.mockResolvedValue([]);
 			mockLoadConfig.mockResolvedValue({});
-			// Short-circuit A fires when transcript is empty AND diff is small.
-			// To exercise the LLM path here we need a non-trivial delta (>10 lines).
-			mockGetDiffStats.mockResolvedValue({ filesChanged: 1, insertions: 50, deletions: 0 });
+			// Pre-LLM short-circuit fires when diff is small (≤ TRIVIAL_AMEND_DELTA_LINES = 50).
+			// To exercise the LLM path here we need a non-trivial delta (> 50 lines).
+			mockGetDiffStats.mockResolvedValue({ filesChanged: 1, insertions: 100, deletions: 0 });
 			mockGetDiffContent.mockResolvedValue("diff");
 
 			await __test__.handleAmendPipeline(
@@ -1019,6 +1028,300 @@ describe("PostCommitHook helpers", () => {
 					e2eTestGuide: [expect.objectContaining({ title: "Scenario 2" })],
 				}),
 			);
+		});
+
+		// ── Two-tier amend dispatch coverage ──────────────────────────────────────
+		// These tests pin the LLM call count of each branch so a regression that
+		// silently demotes the pre-LLM / post-LLM short-circuit into the Full
+		// path (and burns LLM tokens on a trivial amend) is caught at test time.
+		// The 15/16-line boundary and the "transcript entries still short-circuits"
+		// case are both exercised.
+
+		const oldSummaryFixture = {
+			version: 4 as const,
+			commitHash: "oldhash",
+			commitMessage: "Old commit",
+			commitAuthor: "Test",
+			commitDate: "2026-02-18T00:00:00Z",
+			branch: "main",
+			generatedAt: "2026-02-18T00:00:00Z",
+			topics: [{ title: "Old topic", trigger: "T", response: "R", decisions: "D" }],
+			recap: "old recap",
+		};
+
+		it("Pre-LLM short-circuit (0 LLM): trivial delta with no sessions skips both LLM steps", async () => {
+			mockGetSummary.mockResolvedValue(oldSummaryFixture);
+			mockLoadAllSessions.mockResolvedValue([]);
+			mockGetDiffStats.mockResolvedValue({ filesChanged: 1, insertions: 5, deletions: 3 });
+			mockGetDiffContent.mockResolvedValue("diff");
+
+			await __test__.handleAmendPipeline(
+				{ hash: "newhash", message: "New commit", author: "Test", date: "2026-02-19T00:00:00Z" },
+				"oldhash",
+				"/repo",
+				0,
+			);
+
+			expect(mockGenerateSummary).not.toHaveBeenCalled();
+			expect(mockGenerateSquashConsolidation).not.toHaveBeenCalled();
+
+			expect(mockStoreSummary.mock.calls.length).toBeGreaterThanOrEqual(1);
+			const root = mockStoreSummary.mock.calls[0][0] as {
+				topics: ReadonlyArray<{ title: string }>;
+				recap?: string;
+				llm?: unknown;
+			};
+			expect(root.topics).toEqual([{ title: "Old topic", trigger: "T", response: "R", decisions: "D" }]);
+			expect(root.recap).toBe("old recap");
+			expect(root.llm).toBeUndefined();
+		});
+
+		it("Pre-LLM short-circuit boundary: exactly 50 insertions+deletions still short-circuits", async () => {
+			mockGetSummary.mockResolvedValue(oldSummaryFixture);
+			mockLoadAllSessions.mockResolvedValue([]);
+			mockGetDiffStats.mockResolvedValue({ filesChanged: 1, insertions: 25, deletions: 25 });
+			mockGetDiffContent.mockResolvedValue("diff");
+
+			await __test__.handleAmendPipeline(
+				{ hash: "newhash", message: "New commit", author: "Test", date: "2026-02-19T00:00:00Z" },
+				"oldhash",
+				"/repo",
+				0,
+			);
+
+			expect(mockGenerateSummary).not.toHaveBeenCalled();
+			expect(mockGenerateSquashConsolidation).not.toHaveBeenCalled();
+		});
+
+		it("Pre-LLM escape: 51 insertions+deletions falls through to LLM pipeline", async () => {
+			mockGetSummary.mockResolvedValue(oldSummaryFixture);
+			mockLoadAllSessions.mockResolvedValue([]);
+			mockGetDiffStats.mockResolvedValue({ filesChanged: 1, insertions: 26, deletions: 25 });
+			mockGetDiffContent.mockResolvedValue("diff");
+
+			await __test__.handleAmendPipeline(
+				{ hash: "newhash", message: "New commit", author: "Test", date: "2026-02-19T00:00:00Z" },
+				"oldhash",
+				"/repo",
+				0,
+			);
+
+			expect(mockGenerateSummary).toHaveBeenCalledTimes(1);
+		});
+
+		it("Pre-LLM short-circuit triggers even WITH transcript entries when delta ≤ 50 lines", async () => {
+			mockGetSummary.mockResolvedValue(oldSummaryFixture);
+			// 有 1 个 session 带 2 条 entries —— 旧逻辑会强制走 Full path，新逻辑应仍短路
+			mockLoadAllSessions.mockResolvedValue([
+				{
+					sessionId: "sess-1",
+					transcriptPath: "/tmp/s.jsonl",
+					source: "claude",
+					updatedAt: "2026-02-19T00:00:00Z",
+				},
+			]);
+			mockReadTranscript.mockResolvedValue({
+				entries: [
+					{ role: "human", content: "hi" },
+					{ role: "assistant", content: "hello" },
+				],
+				newCursor: { transcriptPath: "/tmp/s.jsonl", lineNumber: 2, updatedAt: "2026-02-19T00:00:00Z" },
+				totalLinesRead: 2,
+			});
+			mockGetDiffStats.mockResolvedValue({ filesChanged: 1, insertions: 5, deletions: 3 });
+			mockGetDiffContent.mockResolvedValue("diff");
+
+			await __test__.handleAmendPipeline(
+				{ hash: "newhash", message: "New commit", author: "Test", date: "2026-02-19T00:00:00Z" },
+				"oldhash",
+				"/repo",
+				0,
+			);
+
+			expect(mockGenerateSummary).not.toHaveBeenCalled();
+			expect(mockGenerateSquashConsolidation).not.toHaveBeenCalled();
+
+			// 短路路径也必须把 transcript artifact 传给 storeSummary
+			expect(mockStoreSummary.mock.calls.length).toBeGreaterThanOrEqual(1);
+			const storeArgs = mockStoreSummary.mock.calls[0];
+			// Pin the force flag at position 2 — short-circuit must never overwrite
+			// existing summaries (that's a Full-pipeline force semantic, not amend).
+			expect(storeArgs[2]).toBe(false);
+			const artifacts = storeArgs[3] as { transcript?: { sessions: ReadonlyArray<unknown> } } | undefined;
+			expect(artifacts?.transcript).toBeDefined();
+			expect(artifacts?.transcript?.sessions.length).toBeGreaterThanOrEqual(1);
+		});
+
+		it("Post-LLM short-circuit (1 LLM): non-trivial delta with empty topics skips step 2", async () => {
+			mockGetSummary.mockResolvedValue(oldSummaryFixture);
+			mockLoadAllSessions.mockResolvedValue([]);
+			mockGetDiffStats.mockResolvedValue({ filesChanged: 1, insertions: 100, deletions: 0 });
+			mockGetDiffContent.mockResolvedValue("diff");
+			// Step 1 returns no topics → triggers post-LLM short-circuit
+			mockGenerateSummary.mockResolvedValueOnce({
+				transcriptEntries: 0,
+				llm: { model: "test", inputTokens: 1, outputTokens: 1, apiLatencyMs: 1, stopReason: "end_turn" },
+				stats: { filesChanged: 1, insertions: 100, deletions: 0 },
+				topics: [],
+			});
+
+			await __test__.handleAmendPipeline(
+				{ hash: "newhash", message: "New commit", author: "Test", date: "2026-02-19T00:00:00Z" },
+				"oldhash",
+				"/repo",
+				0,
+			);
+
+			expect(mockGenerateSummary).toHaveBeenCalledTimes(1);
+			expect(mockGenerateSquashConsolidation).not.toHaveBeenCalled();
+
+			expect(mockStoreSummary.mock.calls.length).toBeGreaterThanOrEqual(1);
+			const root = mockStoreSummary.mock.calls[0][0] as {
+				topics: ReadonlyArray<{ title: string }>;
+				recap?: string;
+				llm?: unknown;
+			};
+			expect(root.topics).toEqual([{ title: "Old topic", trigger: "T", response: "R", decisions: "D" }]);
+			expect(root.recap).toBe("old recap");
+			expect(root.llm).toBeUndefined();
+		});
+
+		it("No old summary + small diff + transcript entries: still writes fresh leaf with transcript artifact", async () => {
+			// Edge case: user amends a commit that was never summarised (e.g. pre-install
+			// commit, or summary not yet generated by the previous worker) AND has a small
+			// diff (≤50 lines) AND had an active AI conversation during the amend.
+			// The early return at "if (!oldSummary && ...)" must NOT fire when there are
+			// transcript entries — otherwise the conversation bytes are lost. The fix is
+			// to require `totalEntries === 0` in that early-return guard, so this case
+			// falls through to step1 LLM and the fresh-leaf branch (which writes the
+			// transcript artifact).
+			mockGetSummary.mockResolvedValue(null);
+			mockLoadAllSessions.mockResolvedValue([
+				{
+					sessionId: "sess-1",
+					transcriptPath: "/tmp/s.jsonl",
+					source: "claude",
+					updatedAt: "2026-02-19T00:00:00Z",
+				},
+			]);
+			mockReadTranscript.mockResolvedValue({
+				entries: [
+					{ role: "human", content: "explain this code" },
+					{ role: "assistant", content: "here's an explanation" },
+				],
+				newCursor: { transcriptPath: "/tmp/s.jsonl", lineNumber: 2, updatedAt: "2026-02-19T00:00:00Z" },
+				totalLinesRead: 2,
+			});
+			mockGetDiffStats.mockResolvedValue({ filesChanged: 1, insertions: 5, deletions: 3 });
+			mockGetDiffContent.mockResolvedValue("diff");
+
+			await __test__.handleAmendPipeline(
+				{ hash: "newhash", message: "New commit", author: "Test", date: "2026-02-19T00:00:00Z" },
+				"oldhash",
+				"/repo",
+				0,
+			);
+
+			// step1 LLM ran (fresh leaf path needs delta topics/recap)
+			expect(mockGenerateSummary).toHaveBeenCalledTimes(1);
+			// Fresh leaf was written WITH the transcript artifact — the conversation
+			// must not be silently dropped.
+			expect(mockStoreSummary.mock.calls.length).toBeGreaterThanOrEqual(1);
+			const storeArgs = mockStoreSummary.mock.calls[0];
+			const artifacts = storeArgs[3] as { transcript?: { sessions: ReadonlyArray<unknown> } } | undefined;
+			expect(artifacts?.transcript).toBeDefined();
+			expect(artifacts?.transcript?.sessions.length).toBeGreaterThanOrEqual(1);
+		});
+
+		it("No old summary + diff fetch failure: skips entirely, no LLM call, no garbage summary", async () => {
+			// Edge case: getDiffContent / getDiffStats throw (shallow clone where HEAD~1
+			// doesn't resolve, corrupted repo, etc.) AND there's no oldSummary to fall
+			// back on. The previous code would fall through to step1 LLM with the literal
+			// "(Could not compute diff)" string and persist a low-quality fresh leaf.
+			// Better: skip — we have no diff and no parent context, nothing useful to
+			// summarise. The conversation transcript is also not persisted in this case
+			// because there's nowhere meaningful to attach it.
+			mockGetSummary.mockResolvedValue(null);
+			mockLoadAllSessions.mockResolvedValue([]);
+			mockGetDiffStats.mockRejectedValue(new Error("git diff failed"));
+			mockGetDiffContent.mockRejectedValue(new Error("git diff failed"));
+
+			await __test__.handleAmendPipeline(
+				{ hash: "newhash", message: "New commit", author: "Test", date: "2026-02-19T00:00:00Z" },
+				"oldhash",
+				"/repo",
+				0,
+			);
+
+			expect(mockGenerateSummary).not.toHaveBeenCalled();
+			expect(mockGenerateSquashConsolidation).not.toHaveBeenCalled();
+			expect(mockStoreSummary).not.toHaveBeenCalled();
+		});
+
+		it("Post-LLM short-circuit: step1 returns empty topics but non-empty recap → still skip step2", async () => {
+			mockGetSummary.mockResolvedValue(oldSummaryFixture);
+			mockLoadAllSessions.mockResolvedValue([]);
+			mockGetDiffStats.mockResolvedValue({ filesChanged: 1, insertions: 100, deletions: 0 });
+			mockGetDiffContent.mockResolvedValue("diff");
+			// step1: topics 空 但 recap 非空 —— 旧逻辑进 Full path，新逻辑直接短路、丢弃 delta.recap
+			mockGenerateSummary.mockResolvedValueOnce({
+				transcriptEntries: 0,
+				llm: { model: "test", inputTokens: 1, outputTokens: 1, apiLatencyMs: 1, stopReason: "end_turn" },
+				stats: { filesChanged: 1, insertions: 100, deletions: 0 },
+				topics: [],
+				recap: "delta 复述了 diff —— 应被丢弃",
+			});
+
+			await __test__.handleAmendPipeline(
+				{ hash: "newhash", message: "New commit", author: "Test", date: "2026-02-19T00:00:00Z" },
+				"oldhash",
+				"/repo",
+				0,
+			);
+
+			expect(mockGenerateSummary).toHaveBeenCalledTimes(1);
+			expect(mockGenerateSquashConsolidation).not.toHaveBeenCalled();
+
+			const root = mockStoreSummary.mock.calls[0][0] as {
+				topics: ReadonlyArray<{ title: string }>;
+				recap?: string;
+			};
+			// recap 应是 oldSummaryFixture.recap，不是 delta 的 recap
+			expect(root.recap).toBe("old recap");
+		});
+
+		it("Full path (2 LLM): non-trivial delta with substantive content runs step 1 + step 2", async () => {
+			mockGetSummary.mockResolvedValue(oldSummaryFixture);
+			mockLoadAllSessions.mockResolvedValue([]);
+			mockGetDiffStats.mockResolvedValue({ filesChanged: 1, insertions: 100, deletions: 0 });
+			mockGetDiffContent.mockResolvedValue("diff");
+			// Step 1 default (from beforeEach) returns a topic → bypasses post-LLM short-circuit.
+			// Step 2 returns consolidated content with LLM metadata.
+			mockGenerateSquashConsolidation.mockResolvedValueOnce({
+				topics: [{ title: "Consolidated", trigger: "T", response: "R", decisions: "D" }],
+				recap: "consolidated recap",
+				llm: { model: "test", inputTokens: 10, outputTokens: 10, apiLatencyMs: 50, stopReason: "end_turn" },
+			});
+
+			await __test__.handleAmendPipeline(
+				{ hash: "newhash", message: "New commit", author: "Test", date: "2026-02-19T00:00:00Z" },
+				"oldhash",
+				"/repo",
+				0,
+			);
+
+			expect(mockGenerateSummary).toHaveBeenCalledTimes(1);
+			expect(mockGenerateSquashConsolidation).toHaveBeenCalledTimes(1);
+
+			expect(mockStoreSummary.mock.calls.length).toBeGreaterThanOrEqual(1);
+			const root = mockStoreSummary.mock.calls[0][0] as {
+				topics: ReadonlyArray<{ title: string }>;
+				recap?: string;
+				llm?: unknown;
+			};
+			expect(root.topics).toEqual([{ title: "Consolidated", trigger: "T", response: "R", decisions: "D" }]);
+			expect(root.recap).toBe("consolidated recap");
+			expect(root.llm).toBeDefined();
 		});
 	});
 

--- a/cli/src/hooks/PostCommitHook.test.ts
+++ b/cli/src/hooks/PostCommitHook.test.ts
@@ -1444,8 +1444,10 @@ describe("queue-driven Worker", () => {
 			vi.mocked(getCurrentBranch).mockResolvedValue("feature-branch");
 			vi.mocked(getDiffContent).mockResolvedValue(hasDiff ? "diff content" : "");
 			vi.mocked(getDiffStats).mockResolvedValue(
+				// Default diff > TRIVIAL_AMEND_DELTA_LINES (50) so tests that
+				// exercise the LLM pipeline aren't accidentally short-circuited.
 				hasDiff
-					? { filesChanged: 1, insertions: 5, deletions: 2 }
+					? { filesChanged: 1, insertions: 100, deletions: 0 }
 					: { filesChanged: 0, insertions: 0, deletions: 0 },
 			);
 			vi.mocked(discoverCodexSessions).mockResolvedValue([]);
@@ -1508,6 +1510,64 @@ describe("queue-driven Worker", () => {
 			expect(summaryArg.children).toBeUndefined();
 		});
 
+		// Regression: the fresh-leaf path (amend with no oldSummary) must associate
+		// plans/notes/linearIssues on the branch with the new amend commit hash,
+		// matching what a normal commit does. Without this fix the fresh leaf
+		// silently dropped these references, breaking plan-progress aggregation
+		// and search/reverse-lookups for plans authored before this tool was installed.
+		it("fresh leaf path associates active plans/notes with the amend commit", async () => {
+			setupAmendPipeline({ hasOldSummary: false });
+			const planSourcePath = "/test/project/.jolli/jollimemory/plans/freshly-authored-plan.md";
+			const noteSourcePath = "/test/project/.jolli/jollimemory/notes/leaf-note.md";
+
+			vi.mocked(loadPlansRegistry).mockResolvedValue({
+				version: 1,
+				plans: {
+					"freshly-authored-plan": {
+						slug: "freshly-authored-plan",
+						title: "Freshly authored plan",
+						editCount: 1,
+						sourcePath: planSourcePath,
+						addedAt: "2026-02-19T00:00:00.000Z",
+						updatedAt: "2026-02-19T00:00:00.000Z",
+						branch: "feature-branch",
+						commitHash: null,
+					},
+				},
+				notes: {
+					"leaf-note": {
+						id: "leaf-note",
+						title: "Leaf note",
+						format: "markdown" as const,
+						sourcePath: noteSourcePath,
+						addedAt: "2026-02-19T00:00:00.000Z",
+						updatedAt: "2026-02-19T00:00:00.000Z",
+						branch: "feature-branch",
+						commitHash: null,
+					},
+				},
+			});
+
+			vi.mocked(existsSync).mockImplementation((path) => path === planSourcePath || path === noteSourcePath);
+			vi.mocked(readFileSync).mockImplementation(((path: unknown) => {
+				if (path === planSourcePath) return "# Freshly authored plan\n\nbody";
+				if (path === noteSourcePath) return "# Leaf note\n\nbody";
+				return "";
+			}) as typeof readFileSync);
+
+			await runWorker("/test/project");
+
+			const summaryArg = vi.mocked(storeSummary).mock.calls[0][0] as CommitSummary;
+			// Without the fix, plans/notes would be undefined on the fresh leaf even
+			// though the branch has uncommitted entries.
+			expect(summaryArg.plans).toBeDefined();
+			expect(summaryArg.plans).toEqual(
+				expect.arrayContaining([expect.objectContaining({ title: "Freshly authored plan" })]),
+			);
+			expect(summaryArg.notes).toBeDefined();
+			expect(summaryArg.notes).toEqual(expect.arrayContaining([expect.objectContaining({ title: "Leaf note" })]));
+		});
+
 		it("skips LLM but migrates index for message-only amend (no diff, no transcript)", async () => {
 			setupAmendPipeline({ hasOldSummary: true, hasTranscript: false, hasDiff: false });
 			// Second getDiffStats call (for `{newHash}^..{newHash}` integral) returns
@@ -1522,14 +1582,17 @@ describe("queue-driven Worker", () => {
 
 			// LLM should NOT be called for a message-only amend
 			expect(generateSummary).not.toHaveBeenCalled();
-			// storeSummary should still be called for index migration
-			expect(storeSummary).toHaveBeenCalledWith(
+			// storeSummary should still be called for index migration. The helper now
+			// passes (root, cwd, force, artifacts?) — match the prefix.
+			expect(vi.mocked(storeSummary).mock.calls.length).toBeGreaterThanOrEqual(1);
+			const [migratedRoot, migratedCwd] = vi.mocked(storeSummary).mock.calls[0];
+			expect(migratedCwd).toBe("/test/project");
+			expect(migratedRoot).toEqual(
 				expect.objectContaining({
 					commitHash: "newHash",
 					commitType: "amend",
 					children: expect.arrayContaining([expect.objectContaining({ commitHash: "oldHash" })]),
 				}),
-				"/test/project",
 			);
 			// The message-only amend ALSO writes diffStats (the full commit diff) on
 			// the migrated summary, so display code doesn't fall back to recursive
@@ -1541,11 +1604,11 @@ describe("queue-driven Worker", () => {
 			expect(summaryArg.stats).toBeUndefined();
 		});
 
-		// Coverage: short-circuit A with a fully-populated old summary so
+		// Coverage: pre-LLM short-circuit with a fully-populated old summary so
 		// every `oldSummary.X !== undefined && {...}` spread takes the
 		// truthy arm, plus buildHoistedAmendRoot's optional metadata
 		// spreads (recap, ticketId, llm carried via hoistMetadataFromOldSummary).
-		it("short-circuit A copies recap + ticketId + llm from a fully-populated old summary", async () => {
+		it("pre-LLM short-circuit copies recap + ticketId + llm from a fully-populated old summary", async () => {
 			setupAmendPipeline({ hasOldSummary: true, hasTranscript: false, hasDiff: false });
 			vi.mocked(getSummary).mockResolvedValue(createMockSummaryFull("oldHash"));
 			vi.mocked(getDiffStats)
@@ -1557,14 +1620,14 @@ describe("queue-driven Worker", () => {
 			expect(summaryArg.ticketId).toBe("JOLLI-1234");
 		});
 
-		// Coverage: short-circuit B path (1 LLM, delta empty) with the
+		// Coverage: post-LLM short-circuit (1 LLM, delta empty) with the
 		// same fully-populated old summary — exercises lines 1354/1355
 		// truthy arms.
-		it("short-circuit B copies recap + ticketId from a fully-populated old summary", async () => {
+		it("post-LLM short-circuit copies recap + ticketId from a fully-populated old summary", async () => {
 			setupAmendPipeline({ hasOldSummary: true, hasTranscript: true, hasDiff: true });
 			vi.mocked(getSummary).mockResolvedValue(createMockSummaryFull("oldHash"));
-			// Delta runs the LLM but it produces no topics + no recap, so
-			// the short-circuit B path fires.
+			// Delta runs the LLM but it produces no topics, so
+			// the post-LLM short-circuit fires.
 			vi.mocked(generateSummary).mockResolvedValue({
 				transcriptEntries: 1,
 				topics: [],
@@ -1810,7 +1873,9 @@ describe("queue-driven Worker", () => {
 			vi.mocked(buildMultiSessionContext).mockReturnValue("[Human]: Amend");
 			vi.mocked(getCurrentBranch).mockResolvedValue("feature-branch");
 			vi.mocked(getDiffContent).mockResolvedValue("diff content");
-			vi.mocked(getDiffStats).mockResolvedValue({ filesChanged: 1, insertions: 5, deletions: 2 });
+			// Default diff > TRIVIAL_AMEND_DELTA_LINES (50) so tests that
+			// exercise the LLM pipeline aren't accidentally short-circuited.
+			vi.mocked(getDiffStats).mockResolvedValue({ filesChanged: 1, insertions: 100, deletions: 0 });
 			vi.mocked(discoverCodexSessions).mockResolvedValue([]);
 			vi.mocked(isCodexInstalled).mockResolvedValue(true);
 		}
@@ -2000,17 +2065,17 @@ describe("queue-driven Worker", () => {
 			vi.mocked(getCurrentBranch).mockResolvedValue("feature-branch");
 		}
 
-		it("re-associates plans and notes on short-circuit A (trivial delta, 0 LLM)", async () => {
+		it("re-associates plans and notes on pre-LLM short-circuit (trivial delta, 0 LLM)", async () => {
 			setupAmend();
 			vi.mocked(getSummary).mockResolvedValue(oldSummaryWithMetadata());
-			// No sessions + tiny diff -> isTrivialAmendDelta=true -> short-circuit A
+			// No sessions + tiny diff -> isTrivialAmendDelta=true -> pre-LLM short-circuit
 			vi.mocked(loadAllSessions).mockResolvedValue([]);
 			vi.mocked(getDiffContent).mockResolvedValue("");
 			vi.mocked(getDiffStats).mockResolvedValue({ filesChanged: 0, insertions: 0, deletions: 0 });
 
 			await runWorker("/test/project");
 
-			// Short-circuit A must NOT call generateSummary (0 LLM)
+			// Pre-LLM short-circuit must NOT call generateSummary (0 LLM)
 			expect(generateSummary).not.toHaveBeenCalled();
 			expect(storeSummary).toHaveBeenCalled();
 			expect(associatePlanWithCommit).toHaveBeenCalledWith("plan-old", "newHash", "/test/project");
@@ -2022,10 +2087,11 @@ describe("queue-driven Worker", () => {
 			);
 		});
 
-		it("re-associates plans and notes on short-circuit B (1 LLM, empty delta)", async () => {
+		it("re-associates plans and notes on post-LLM short-circuit (1 LLM, empty topics)", async () => {
 			setupAmend();
 			vi.mocked(getSummary).mockResolvedValue(oldSummaryWithMetadata());
-			// Sessions with entries -> not trivial. Delta returns no topics + no recap -> short-circuit B.
+			// Diff > TRIVIAL_AMEND_DELTA_LINES so pre-LLM short-circuit doesn't fire.
+			// Delta returns no topics -> post-LLM short-circuit (1 LLM, step2 skipped).
 			vi.mocked(loadAllSessions).mockResolvedValue([
 				{ sessionId: "sess-1", transcriptPath: "/path/to/transcript.jsonl", updatedAt: "2026-02-19" },
 			]);
@@ -2036,7 +2102,7 @@ describe("queue-driven Worker", () => {
 			});
 			vi.mocked(buildMultiSessionContext).mockReturnValue("[Human]: Amend");
 			vi.mocked(getDiffContent).mockResolvedValue("diff content");
-			vi.mocked(getDiffStats).mockResolvedValue({ filesChanged: 1, insertions: 5, deletions: 2 });
+			vi.mocked(getDiffStats).mockResolvedValue({ filesChanged: 1, insertions: 100, deletions: 0 });
 			vi.mocked(generateSummary).mockResolvedValue({
 				...createMockResult(),
 				topics: [],
@@ -2069,7 +2135,8 @@ describe("queue-driven Worker", () => {
 			});
 			vi.mocked(buildMultiSessionContext).mockReturnValue("[Human]: Amend");
 			vi.mocked(getDiffContent).mockResolvedValue("diff content");
-			vi.mocked(getDiffStats).mockResolvedValue({ filesChanged: 1, insertions: 5, deletions: 2 });
+			// Diff > TRIVIAL_AMEND_DELTA_LINES so pre-LLM short-circuit doesn't fire.
+			vi.mocked(getDiffStats).mockResolvedValue({ filesChanged: 1, insertions: 100, deletions: 0 });
 			// Delta returns substantive topics -> full path (consolidate runs)
 			vi.mocked(generateSummary).mockResolvedValue(createMockResult());
 
@@ -2275,11 +2342,14 @@ describe("queue-driven Worker", () => {
 
 			await runWorker("/test/project");
 
-			expect(storeSummary).toHaveBeenCalledWith(
+			// Helper passes (root, cwd, force, artifacts?) — match the prefix.
+			expect(vi.mocked(storeSummary).mock.calls.length).toBeGreaterThanOrEqual(1);
+			const [e2eRoot, e2eCwd] = vi.mocked(storeSummary).mock.calls[0];
+			expect(e2eCwd).toBe("/test/project");
+			expect(e2eRoot).toEqual(
 				expect.objectContaining({
 					e2eTestGuide: expect.any(Array),
 				}),
-				"/test/project",
 			);
 		});
 	});

--- a/cli/src/hooks/QueueWorker.ts
+++ b/cli/src/hooks/QueueWorker.ts
@@ -1435,38 +1435,49 @@ async function handleRebaseSquashFromQueue(op: GitOperation, cwd: string): Promi
 }
 
 /**
- * Threshold for the trivial-amend short-circuit A (line count of the delta diff).
- * 10 is intentionally conservative -- prefer running the LLM (false negative)
- * over silently skipping a substantive change (false positive).
+ * Threshold for the pre-LLM amend short-circuit (line count of the delta diff,
+ * insertions + deletions).
+ *
+ * 50 is calibrated to cover most "polish" amends — rename a variable across
+ * call sites, fix a typo in several files, add a guard clause, apply a
+ * formatter pass, refactor a small helper. Truly substantive method rewrites
+ * or new features generally exceed 50 lines and still hit the LLM.
+ *
+ * The transcript artifact is preserved either way, so even when the
+ * short-circuit fires during an active AI chat session, the conversation is
+ * aggregated in the "All Conversations" view via recursive child walking —
+ * no information is lost. Topics/recap stay frozen to the parent commit's
+ * values until the next non-amend commit naturally refreshes them.
  */
-const TRIVIAL_AMEND_DELTA_LINES = 10;
+const TRIVIAL_AMEND_DELTA_LINES = 50;
 
 /**
- * Detects "no real conversation, mechanical-only delta" amends so we can skip
- * the LLM entirely. Examples that should match:
+ * Detects "mechanical-only delta" amends so we can skip the LLM entirely.
+ * Examples that should match:
  *   - `git commit --amend --no-edit`
  *   - bumping a version number
  *   - re-signing with GPG
  *   - applying formatter output
  *
- * Conservative by design: any captured conversation, OR any delta beyond the
- * line threshold (regardless of whitespace), forces the full pipeline. False
- * positives here would silently drop new amend information.
+ * Transcript entries no longer block the short-circuit: even if the user
+ * was chatting with an AI assistant during the amend, the transcript artifact
+ * is persisted by the short-circuit path, so the conversation is not lost.
+ * Topics/recap on the new root are Copy-Hoisted from the old summary —
+ * acceptable because the diff itself is the source of truth for tiny changes.
  */
-function isTrivialAmendDelta(deltaStats: DiffStats, transcriptEntries: number): boolean {
-	if (transcriptEntries > 0) return false;
+function isTrivialAmendDelta(deltaStats: DiffStats): boolean {
 	const totalLines = deltaStats.insertions + deltaStats.deletions;
 	return totalLines <= TRIVIAL_AMEND_DELTA_LINES;
 }
 
 /**
  * Hoisted-fields bundle for buildHoistedAmendRoot. The v4 amend root carries
- * topics + recap + ticketId either Copy-Hoisted from the old summary (short
- * circuit A/B) or LLM-consolidated from [old, delta] (full path).
+ * topics + recap + ticketId either Copy-Hoisted from the old summary (pre-LLM
+ * or post-LLM short-circuit) or LLM-consolidated from [old, delta] (full path).
  *
  * `llm` is only set when the topics/recap actually came from this call (i.e.
- * the consolidate step ran). Short-circuit A/B leave it undefined so the
- * field's "produced this node's data" semantics stay accurate.
+ * the consolidate step ran). Both short-circuit paths leave it undefined so
+ * the field's "produced this node's data" semantics stay accurate.
  */
 interface AmendHoistedFields {
 	readonly topics: ReadonlyArray<TopicSummary>;
@@ -1478,9 +1489,9 @@ interface AmendHoistedFields {
 /**
  * Builds the v4 amend root with all 8 Hoist fields populated and the old
  * summary attached as a stripped child. Used by all three amend paths
- * (short-circuit A, short-circuit B, full path); the only differences are
- * which `hoisted` values the caller passes in and whether they pass a
- * transcript artifact to storeSummary.
+ * (pre-LLM short-circuit, post-LLM short-circuit, full path); the only
+ * differences are which `hoisted` values the caller passes in and whether
+ * they pass a transcript artifact to storeSummary.
  *
  * `oldSummary` is undefined when there's no recorded prior summary (rare:
  * the user amended a commit that was never summarised). In that case the
@@ -1527,19 +1538,75 @@ function buildHoistedAmendRoot(
 }
 
 /**
- * Handles amend queue entries via three-tier dispatch:
+ * Short-circuit writer: Copy-Hoists topics/recap/ticketId from oldSummary to a
+ * new amend root, and persists the transcript artifact if any sessions exist.
+ * Shared by both short-circuit callers in handleAmendPipeline:
+ *   - **Pre-LLM**: delta ≤ TRIVIAL_AMEND_DELTA_LINES (no LLM ran)
+ *   - **Post-LLM**: step 1 summarize(delta) returned empty topics (step 2 skipped)
  *
- *   - **Short-circuit A** (0 LLM): trivial delta (empty transcript + small or
- *     mechanical diff) -> Copy-Hoist topics/recap from old, no transcript artifact.
- *   - **Short-circuit B** (1 LLM): summarize(delta) returned no topics + no
- *     recap -> Copy-Hoist topics/recap from old, BUT write the transcript
- *     artifact (the LLM read the conversation -- those bytes are valuable for
- *     audit even though the topics/recap weren't substantive).
+ * `label` is only used for logging — it distinguishes the two call sites in the
+ * debug.log so a triage can tell which short-circuit fired.
+ *
+ * The transcript artifact is written unconditionally when sessions are present:
+ * "All Conversations" view walks children recursively, so even though topics/recap
+ * are Copy-Hoisted (frozen at the old commit's state), the per-commit transcript
+ * file ensures the actual conversation is still aggregated into the view.
+ */
+async function applyAmendShortCircuit(
+	oldSummary: CommitSummary,
+	commitInfo: CommitInfo,
+	metadata: { readonly commitType?: CommitType; readonly commitSource?: CommitSource } | undefined,
+	amendFullDiffStats: DiffStats,
+	sessionTranscripts: ReadonlyArray<SessionTranscript>,
+	totalEntries: number,
+	humanEntries: number,
+	cwd: string,
+	pipelineStart: number,
+	oldHash: string,
+	label: string,
+): Promise<void> {
+	const storedTranscript = buildStoredTranscript(sessionTranscripts);
+	const transcriptArtifact = storedTranscript.sessions.length > 0 ? storedTranscript : undefined;
+
+	const root = buildHoistedAmendRoot(
+		oldSummary,
+		commitInfo,
+		{
+			topics: resolveEffectiveTopics(oldSummary),
+			/* v8 ignore start -- optional-field spreads (see buildHoistedAmendRoot) */
+			...(oldSummary.recap !== undefined && { recap: oldSummary.recap }),
+			...(oldSummary.ticketId !== undefined && { ticketId: oldSummary.ticketId }),
+			/* v8 ignore stop */
+		},
+		metadata ?? {},
+		amendFullDiffStats,
+		{ transcriptEntries: totalEntries, conversationTurns: humanEntries },
+	);
+
+	await storeSummary(root, cwd, false, transcriptArtifact ? { transcript: transcriptArtifact } : undefined);
+	await reassociateMetadata([oldSummary], commitInfo.hash, cwd);
+	log.info(
+		"Amend short-circuit (%s) complete: %s -> %s (%s)",
+		label,
+		oldHash.substring(0, 8),
+		commitInfo.hash.substring(0, 8),
+		formatElapsed(pipelineStart),
+	);
+}
+
+/**
+ * Handles amend queue entries via two-tier dispatch:
+ *
+ *   - **Short-circuit** (0 or 1 LLM): either delta ≤ TRIVIAL_AMEND_DELTA_LINES
+ *     (skip both LLM calls) OR step 1 returned empty topics (skip step 2).
+ *     Topics/recap/ticketId are Copy-Hoisted from oldSummary; the transcript
+ *     artifact is written if any sessions exist. Implemented by
+ *     applyAmendShortCircuit.
  *   - **Full path** (2 LLM): summarize(delta) + consolidate([old, delta]) ->
  *     LLM-produced topics/recap (or mechanicalConsolidate fallback), with
  *     transcript artifact.
  *
- * All three paths converge on buildHoistedAmendRoot + storeSummary, so the
+ * Both paths converge on buildHoistedAmendRoot + storeSummary, so the
  * Hoist invariant always completes regardless of which dispatch tier ran.
  *
  * Called by both scenarios:
@@ -1580,6 +1647,7 @@ async function handleAmendPipeline(
 	let stepStart = now();
 	let deltaDiff: string;
 	let deltaDiffStats: DiffStats;
+	let diffFetchFailed = false;
 	const fromRef = diffOverride?.fromRef ?? "HEAD~1";
 	const toRef = diffOverride?.toRef ?? "HEAD";
 	try {
@@ -1589,6 +1657,7 @@ async function handleAmendPipeline(
 		log.warn("Could not diff %s..%s, using empty diff", fromRef, toRef);
 		deltaDiff = "(Could not compute diff)";
 		deltaDiffStats = { filesChanged: 0, insertions: 0, deletions: 0 };
+		diffFetchFailed = true;
 	}
 	log.info(
 		"Amend delta diff (%s..%s): %d files changed, +%d -%d (%s)",
@@ -1610,40 +1679,50 @@ async function handleAmendPipeline(
 			)
 		: deltaDiffStats;
 
-	// ── Short-circuit A: trivial delta (0 LLM) ────────────────────────────────
-	if (oldSummary && isTrivialAmendDelta(deltaDiffStats, totalEntries)) {
-		log.info("Amend short-circuit A: trivial delta -- 0 LLM, Copy-Hoist topics/recap from old");
-		const root = buildHoistedAmendRoot(
+	// ── Pre-LLM short-circuit: delta ≤ TRIVIAL_AMEND_DELTA_LINES (0 LLM) ──────
+	// When diff fetch failed, the fallback `deltaDiffStats = {0, 0, 0}` would
+	// otherwise spuriously trigger the short-circuit and silently drop the
+	// LLM-via-conversation fallback. Require a successful diff fetch.
+	if (oldSummary && !diffFetchFailed && isTrivialAmendDelta(deltaDiffStats)) {
+		log.info(
+			"Amend short-circuit (pre-LLM): trivial delta ≤ %d -- skipping both LLM calls",
+			TRIVIAL_AMEND_DELTA_LINES,
+		);
+		await applyAmendShortCircuit(
 			oldSummary,
 			commitInfo,
-			{
-				topics: resolveEffectiveTopics(oldSummary),
-				/* v8 ignore start -- optional-field spreads (see buildHoistedAmendRoot) */
-				...(oldSummary.recap !== undefined && { recap: oldSummary.recap }),
-				...(oldSummary.ticketId !== undefined && { ticketId: oldSummary.ticketId }),
-				/* v8 ignore stop */
-			},
-			metadata ?? {},
+			metadata,
 			amendFullDiffStats,
-		);
-		await storeSummary(root, cwd);
-		await reassociateMetadata([oldSummary], commitInfo.hash, cwd);
-		log.info(
-			"Amend short-circuit A complete: %s -> %s (%s)",
-			oldHash.substring(0, 8),
-			commitInfo.hash.substring(0, 8),
-			formatElapsed(pipelineStart),
+			sessionTranscripts,
+			totalEntries,
+			humanEntries,
+			cwd,
+			pipelineStart,
+			oldHash,
+			"pre-LLM trivial delta",
 		);
 		return;
 	}
 
-	// No old summary AND trivial delta -- nothing useful to record.
-	/* v8 ignore start -- defensive: covered indirectly when both inputs are absent */
-	if (!oldSummary && isTrivialAmendDelta(deltaDiffStats, totalEntries)) {
-		log.info("Amend with no old summary AND trivial delta -- skipping");
+	// No old summary AND trivial delta AND no conversation -- nothing useful to record.
+	// The `totalEntries === 0` guard is critical: without it, an amend that has a small
+	// diff but recorded an AI conversation would silently drop the transcript, because
+	// applyAmendShortCircuit requires an oldSummary for Copy-Hoist and isn't reachable
+	// here. When transcript entries exist we fall through to step1 LLM and the
+	// "no old summary -> fresh leaf" branch below, which persists the transcript artifact.
+	if (!oldSummary && !diffFetchFailed && totalEntries === 0 && isTrivialAmendDelta(deltaDiffStats)) {
+		log.info("Amend with no old summary AND no sessions AND trivial delta -- skipping");
 		return;
 	}
-	/* v8 ignore stop */
+
+	// No old summary AND diff fetch failed -- feeding "(Could not compute diff)" to
+	// the LLM produces low-quality topics, and the fresh leaf's diffStats may also
+	// have fallen back to {0,0,0}. No parent context, no real diff: nothing useful
+	// to summarise. Skip rather than persist a misleading summary.
+	if (!oldSummary && diffFetchFailed) {
+		log.info("Amend with no old summary AND diff fetch failed -- skipping (no meaningful summary possible)");
+		return;
+	}
 
 	// ── Step 1 LLM: summarize the delta ───────────────────────────────────────
 	const conversation = buildMultiSessionContext(sessionTranscripts);
@@ -1708,39 +1787,23 @@ async function handleAmendPipeline(
 	const amendStoredTranscript = buildStoredTranscript(sessionTranscripts);
 	const transcriptArtifact = amendStoredTranscript.sessions.length > 0 ? amendStoredTranscript : undefined;
 
-	// ── Short-circuit B: 1 LLM, delta produced no substantive content ─────────
-	if (oldSummary && (delta.topics?.length ?? 0) === 0 && !delta.recap) {
-		log.info("Amend short-circuit B: 1 LLM, delta empty -- Copy-Hoist topics/recap from old, write transcript");
-		const root = buildHoistedAmendRoot(
+	// ── Post-LLM short-circuit: step1 returned empty topics → skip step2 ──────
+	// delta.recap is discarded even if present: a recap without topics is just a
+	// restatement of the diff, and the diff is the source of truth.
+	if (oldSummary && (delta.topics?.length ?? 0) === 0) {
+		log.info("Amend short-circuit (post-LLM): step1 returned empty topics -- skipping step2 consolidate");
+		await applyAmendShortCircuit(
 			oldSummary,
 			commitInfo,
-			{
-				topics: resolveEffectiveTopics(oldSummary),
-				/* v8 ignore start -- optional-field spreads (see buildHoistedAmendRoot) */
-				...(oldSummary.recap !== undefined && { recap: oldSummary.recap }),
-				...(oldSummary.ticketId !== undefined && { ticketId: oldSummary.ticketId }),
-				/* v8 ignore stop */
-				// llm: undefined -- topics/recap came from old, not from delta
-			},
-			/* v8 ignore next -- `metadata ?? {}` defensive default; the queue dispatch always supplies a populated metadata object. */
-			metadata ?? {},
+			metadata,
 			amendFullDiffStats,
-			{ transcriptEntries: totalEntries, conversationTurns: humanEntries },
-		);
-		await storeSummary(
-			root,
+			sessionTranscripts,
+			totalEntries,
+			humanEntries,
 			cwd,
-			false,
-			/* v8 ignore next -- defensive: transcriptArtifact is set when sessions exist; falsy arm only fires when there are no sessions, which the empty-transcript guard upstream already short-circuits. */ transcriptArtifact
-				? { transcript: transcriptArtifact }
-				: undefined,
-		);
-		await reassociateMetadata([oldSummary], commitInfo.hash, cwd);
-		log.info(
-			"Amend short-circuit B complete: %s -> %s (%s)",
-			oldHash.substring(0, 8),
-			commitInfo.hash.substring(0, 8),
-			formatElapsed(pipelineStart),
+			pipelineStart,
+			oldHash,
+			"post-LLM empty topics",
 		);
 		return;
 	}
@@ -1826,6 +1889,30 @@ async function handleAmendPipeline(
 
 	// ── No old summary AND non-trivial delta -> store delta as a fresh leaf ────
 	const branch = await getCurrentBranch(cwd);
+
+	// Associate plans/notes/linearIssues on the branch with this amend commit,
+	// mirroring executePipeline. Without this the fresh leaf silently drops
+	// references for plans/notes authored before the previous (un-summarised)
+	// commit — the user wouldn't see them in plan-progress aggregation or
+	// reverse-lookups. The oldSummary path handles this via reassociateMetadata;
+	// fresh leaves have no oldSummary to migrate from, so we associate fresh.
+	const freshLeafPlanSlugs = await detectPlanSlugsFromRegistry(cwd, branch);
+	for (const excludedSlug of amendExclusions.plans) freshLeafPlanSlugs.delete(excludedSlug);
+	const freshLeafPlanAssoc = await associatePlansWithCommit(freshLeafPlanSlugs, commitInfo.hash, cwd, branch);
+	const freshLeafPlanRefs = freshLeafPlanAssoc.refs;
+
+	const freshLeafNoteIds = await detectUncommittedNoteIds(cwd, branch);
+	for (const excludedId of amendExclusions.notes) freshLeafNoteIds.delete(excludedId);
+	const freshLeafNoteRefs = await associateNotesWithCommit(freshLeafNoteIds, commitInfo.hash, cwd, branch);
+
+	const freshLeafLinearTicketIds = await detectUncommittedLinearIssueIds(cwd, branch);
+	const freshLeafLinearRefs = await associateLinearIssuesWithCommit(
+		freshLeafLinearTicketIds,
+		commitInfo.hash,
+		cwd,
+		branch,
+	);
+
 	const freshLeaf: CommitSummary = {
 		version: 4,
 		commitHash: commitInfo.hash,
@@ -1838,6 +1925,9 @@ async function handleAmendPipeline(
 		...(metadata?.commitSource && { commitSource: metadata.commitSource }),
 		...delta,
 		diffStats: amendFullDiffStats,
+		...(freshLeafPlanRefs.length > 0 ? { plans: freshLeafPlanRefs } : {}),
+		...(freshLeafNoteRefs.length > 0 ? { notes: freshLeafNoteRefs } : {}),
+		...(freshLeafLinearRefs.length > 0 ? { linearIssues: freshLeafLinearRefs } : {}),
 	};
 	await storeSummary(
 		freshLeaf,


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## Quick recap

The amend processing pipeline was restructured from three dispatch paths down to two. Small amendments — typo fixes, formatter passes, routine variable renames touching multiple files — now bypass AI processing entirely when the change falls within a raised threshold of 50 changed lines, up from the previous 15. Conversation transcripts captured during those sessions are still preserved in a per-commit artifact that the "All Conversations" view picks up automatically. When the AI does run for a larger amendment but finds nothing substantive to report, the pipeline stops after the first call and carries the previous commit's summary forward unchanged.

Two data-loss paths were closed. When diff retrieval between two commits previously failed, the system substituted zeroed-out statistics that happened to match the trivial-change condition, causing real code changes to produce no summary with no warning. An explicit flag now tracks whether the diff was successfully fetched, and the short-circuit requires a confirmed successful fetch before it fires. A separate edge case was also fixed where conversations could be silently lost during a specific kind of amend: when a commit had never been summarised before, the code change was small, and the user had an active conversation at the same time. The short-circuit guard now checks for active conversation content and, when any is present, falls through to full summarisation regardless of diff size.

A third fix addressed plan and note associations on amends with no prior summary. Plans, notes, and Linear issue links authored on the branch were previously dropped from the stored record in that scenario, breaking plan-progress tracking and search lookups. The fresh-leaf path now runs the full association sequence, matching the behavior that normal commits have always had.

A comprehensive automated test suite was added to lock down every branch of the new pipeline. The tests cover the short-circuit at a typical small delta, at the exact line-count boundary, with an active conversation session present, the middle path where the AI returns no topics, and the full path where both generation steps run. Any future change that accidentally routes a trivial amendment through the expensive full pipeline will be caught at test time.

---

## Topics (8)
<details>
<summary><strong>01 · Refactor amend dispatch pipeline from three tiers to two tiers</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The amend pipeline had three separate dispatch paths that were difficult to reason about and caused unnecessary AI calls for small, routine amendments like typo fixes, formatter passes, or version bumps.

**💡 Decisions Behind the Code**

- **Transcript preservation via artifact over pipeline forcing**: Previously, any captured conversation session forced the full two-LLM pipeline to avoid losing session data. Decoupling transcript writing from the AI pipeline — by writing the artifact unconditionally on the short-circuit path — made it safe to remove the transcript-entry gate entirely, reducing latency for small amends that happen to have open sessions.
- **Discard delta recap when topics are absent**: When the AI summarizes a delta but returns no topics, any recap it produces is treated as a low-value restatement of the diff rather than genuine semantic content. Dropping it and Copy-Hoisting the old summary's recap keeps the commit record semantically clean; the diff itself is the authoritative record for tiny changes.
- **Single shared helper over duplicated inline logic**: Both short-circuit call sites previously contained identical Copy-Hoist, store, and reassociate sequences written out in full. Extracting a named helper makes the two-tier structure explicit and eliminates the risk of the two paths diverging silently in future edits.
- **Cosmetic rename kept in a standalone pass**: Aligning comment vocabulary with the established two-tier model was kept strictly cosmetic — no logic was touched — to avoid mixing terminology cleanup into a behavioural change and to make future readers' mental model easier to build.

**✅ What Was Implemented**

- Simplified the trivial-delta detection function in `QueueWorker.ts` to accept only diff stats, removing the transcript-entry count parameter. The function no longer suppresses the short-circuit when conversation sessions are present.
- Extracted a new `applyAmendShortCircuit` helper in `QueueWorker.ts` that consolidates the Copy-Hoist, `storeSummary`, and `reassociateMetadata` logic previously duplicated across the old dispatch paths. Both the pre-LLM short-circuit (delta at or below threshold) and the post-LLM short-circuit (first AI call returned empty topics) now delegate to this single helper.
- The post-LLM short-circuit condition was broadened from requiring both empty topics and an empty recap to requiring only empty topics. A delta recap without supporting topics is discarded; topics and recap are Copy-Hoisted from the previous summary instead.
- The short-circuit helper always writes the transcript artifact when sessions exist, so conversation history is preserved in the per-commit transcript file and aggregated in the "All Conversations" view via recursive child walking.
- Updated comments in `QueueWorker.ts` around the `AmendHoistedFields` interface and `buildHoistedAmendRoot` JSDoc to replace "short-circuit A/B" with "pre-LLM short-circuit" and "post-LLM short-circuit" throughout; a stale threshold reference was corrected to match the actual constant.

**📁 FILES**
- `cli/src/hooks/QueueWorker.ts`

</blockquote>
</details>
<details>
<summary><strong>02 · Raise trivial-change threshold from 15 to 50 lines for amend processing</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The threshold controlling when an amended commit bypasses AI processing was too conservative at 15 lines. Common everyday fixes — renaming a variable across call sites, adjusting a function signature, reformatting across multiple files — routinely exceeded 15 lines and were being sent to the AI unnecessarily.

**💡 Decisions Behind the Code**

- **50 over 15 (via 30 as intermediate candidate)**: A threshold of 30 was considered as a safer middle ground, but 50 was chosen to cover the full practical range of minor amendment work — multi-file renames, small helper refactors, formatter-driven churn — without reaching into territory where a diff typically represents a new feature or substantive rewrite. The cost of a miss is low: topics simply refresh on the next full commit.
- **No upper cap at this time**: A more aggressive value like 80 was available but not chosen. Fifty sits just below the point where a diff starts to represent substantive new functionality, keeping the safety margin meaningful without over-engineering the boundary. A rare large-but-mechanical change (e.g. a formatter pass touching 60 lines) will still hit the LLM, but that edge case is considered acceptable given the improved common-case behavior.
- **No information loss on short-circuit**: Even when the threshold fires and the LLM is skipped, the conversation transcript is still preserved and aggregated through recursive child walking in the "All Conversations" view. Topics and recap stay frozen to the parent commit's values until the next non-amend commit refreshes them, making raising the threshold safe.

**✅ What Was Implemented**

- Raised `TRIVIAL_AMEND_DELTA_LINES` in `QueueWorker.ts` from 15 to 50, with the inline documentation comment updated to reflect the new semantic boundary and calibration rationale: the new value covers typical polish amends while still routing genuine feature work through the LLM.
- Updated all test fixtures in `PostCommitHook.test.ts` that set mock diff stats to use 100 insertions instead of 50, ensuring test scenarios that exercise the LLM pipeline remain above the new threshold and are not accidentally short-circuited.
- Boundary tests in `PostCommitHook.helpers.test.ts` were updated: the "exactly at threshold" case moved from 8+7 to 25+25 insertions/deletions, and the "one line over" escape case moved from 9+7 to 26+25.

**📁 FILES**
- `cli/src/hooks/QueueWorker.ts`
- `cli/src/hooks/PostCommitHook.helpers.test.ts`
- `cli/src/hooks/PostCommitHook.test.ts`

</blockquote>
</details>
<details>
<summary><strong>03 · Fix fresh-leaf amend path dropping plan and note associations</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

When an amend had no prior summary to migrate from, plans and notes that had been authored on the branch were silently dropped from the stored commit record, breaking plan-progress aggregation and reverse-lookups for any plans created before the tool was installed on that branch.

**💡 Decisions Behind the Code**

- **Mirror the normal-commit association pattern rather than a lighter approach**: The existing path for amends with an old summary uses `reassociateMetadata` to migrate references forward. Fresh leaves have no old summary to migrate from, so the only correct option was to run the full association sequence from scratch — the same sequence used by normal commits. A lighter approach such as copying refs from the parent commit would have missed plans authored after the parent was created.
- **Early exit on combined no-summary and failed diff fetch**: Without a parent context and without a real diff, persisting a misleading summary was judged worse than persisting nothing. The pipeline returns early in that specific combination, accepting a gap in the record rather than storing noise.

**✅ What Was Implemented**

- Added plan, note, and Linear issue association logic to the fresh-leaf branch of `handleAmendPipeline` in `QueueWorker.ts`. The new code calls `detectPlanSlugsFromRegistry`, `associatePlansWithCommit`, `detectUncommittedNoteIds`, `associateNotesWithCommit`, `detectUncommittedLinearIssueIds`, and `associateLinearIssuesWithCommit` — mirroring what `executePipeline` already does for normal commits — and spreads the resulting refs onto the `freshLeaf` summary object.
- Added a guard that returns early when there is no prior summary and the diff fetch also failed; without a parent context and without a real diff, the LLM would receive only placeholder text, so the pipeline accepts the commit going unsummarized rather than storing low-quality output.
- Added a regression test in `PostCommitHook.test.ts` covering the fresh-leaf path: it seeds the plans and notes registries with uncommitted entries on the branch and asserts that the stored summary includes those references.

**📁 FILES**
- `cli/src/hooks/QueueWorker.ts`

</blockquote>
</details>
<details>
<summary><strong>04 · Preserve AI fallback when diff retrieval fails during amend processing</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

When the system could not retrieve a diff between two commits, it fell back to zeroed-out statistics that silently matched the trivial-change condition, causing real code changes to produce no summary with no warning.

**💡 Decisions Behind the Code**

An explicit fetch-success flag was chosen over using a null or special-object sentinel for the stats type. The zeroed fallback stats are indistinguishable from a genuinely empty diff by value alone, and a plain boolean is narrower in scope, requires no changes to the stats type, and keeps the guard conditions readable at a glance.

**✅ What Was Implemented**

- Added a `diffFetchFailed` boolean flag in `QueueWorker.ts` inside `handleAmendPipeline`, set to `true` in the catch block that handles diff retrieval errors.
- Both trivial-delta short-circuit guards now require `!diffFetchFailed` in addition to the existing line-count condition. A failed diff fetch therefore falls through to the AI pipeline rather than being silently dropped.

**📁 FILES**
- `cli/src/hooks/QueueWorker.ts`

</blockquote>
</details>
<details>
<summary><strong>05 · Fix silent conversation loss when amending a never-summarised commit</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Conversations held during an amend could be silently discarded in a specific edge case: when the commit being amended had never been summarised before, the code change was small, and the user had an active AI conversation during the amend — all three conditions together caused the tool to exit early and discard the conversation entirely.

**💡 Decisions Behind the Code**

- **Fall through to full LLM summarisation rather than writing a minimal stub**: The alternative was to write a bare placeholder entry with the transcript attached but skip the LLM call entirely, saving one API call. The chosen path spends one LLM call to produce a meaningful summary with real topics and a recap, which was judged worth the cost given how rare this edge case is. A stub with empty topics would have been confusing to read later.
- **Guard on zero conversation entries rather than restructuring the code path**: The fix is a single condition added to an existing guard rather than a new branch or helper. This keeps the change minimal and easy to audit; the existing "no old summary → fresh leaf" path below the guard already handles the fall-through correctly, so no new logic was needed beyond letting execution reach it.

**✅ What Was Implemented**

- In `QueueWorker.ts`, the early-return guard that skips processing for trivial amends with no prior summary was tightened to also require that no conversation entries exist. Previously the guard fired on small diff alone; now it only fires when the diff is small AND there are zero conversation entries, allowing sessions with transcript content to fall through to the full summarisation path that persists the conversation artifact.
- A new test case was added to `PostCommitHook.helpers.test.ts` covering the exact failure scenario: no prior summary, small diff, active conversation. The test asserts that the LLM summarisation step runs and that the stored result includes the transcript artifact, confirming the conversation is not dropped.

**📁 FILES**
- `cli/src/hooks/QueueWorker.ts`
- `cli/src/hooks/PostCommitHook.helpers.test.ts`

</blockquote>
</details>
<details>
<summary><strong>06 · Add automated tests covering all two-tier amend dispatch paths</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

There were no automated tests confirming that small amendments correctly bypassed the AI pipeline, that conversation artifacts were preserved on the short-circuit path, or that the middle and full pipeline paths behaved as expected — leaving all dispatch branches unverified.

**💡 Decisions Behind the Code**

- **Hoisted mock over inline mock**: The consolidation function was previously mocked inline inside the module factory, making it impossible for individual tests to spy on call counts or inject per-test return values. Hoisting it into the shared block gives each test full control without changing the default null behavior that existing tests relied on.
- **Topics-only gate for post-AI short-circuit**: The original condition required both empty topics and an empty recap before skipping the consolidation step. The new approach checks only whether topics are empty, discarding any delta recap alongside them — a recap without supporting topics is effectively a restatement of the diff, and the diff itself is the authoritative record.
- **Pin force flag via targeted assertion**: A code review identified that no test verified whether the short-circuit path correctly passed a "do not overwrite" flag when saving summaries. Adding a single targeted assertion closes the regression gap without touching passing tests or changing how other arguments are verified.

**✅ What Was Implemented**

- Exposed `mockGenerateSquashConsolidation` as a hoisted mock in `PostCommitHook.helpers.test.ts`, replacing a previous inline `vi.fn().mockResolvedValue(null)` that was invisible to test assertions. A `beforeEach` default of `null` preserves all existing test behavior while allowing individual tests to override and assert call counts.
- Added tests covering the zero-AI-call pre-LLM short-circuit path at a typical small delta, at the exact 50-line boundary, and confirming the threshold is exclusive at one line over.
- Added a test confirming the pre-LLM short-circuit fires even when an active conversation session is present, and that the transcript artifact is still written to storage in that case.
- Added a test for the one-call post-LLM middle tier where the first AI call returns empty topics: the consolidation step is skipped, the delta recap is discarded, and the previous commit's topics and recap are carried forward unchanged.
- Added a test for the full two-call path where both generation steps run and the consolidated result is stored, including a targeted assertion pinning the third positional argument of the short-circuit `storeSummary` call to `false`, locking the "never force-overwrite" contract. A regression test also covers the scenario where both diff stats and diff content fetches fail and no prior summary exists, asserting that no AI calls are made and nothing is persisted.

**📁 FILES**
- `cli/src/hooks/PostCommitHook.helpers.test.ts`

</blockquote>
</details>
<details>
<summary><strong>07 · Fix existing amend-mode tests broken by two-tier threshold changes</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

After the trivial-delta threshold was raised and the dispatch paths were renamed, several existing tests started failing because their mock data fell below the new threshold or referenced the old path names.

**💡 Decisions Behind the Code**

- **Raise mock values rather than lower the threshold**: Lowering the threshold to accommodate old test data would have weakened the production guard. Raising mock values to a clearly non-trivial number makes the test intent explicit — tests that want the AI pipeline to run now unambiguously exceed the cutoff.
- **Decompose positional assertions into per-argument checks**: The original assertions broke when the function gained optional trailing parameters. Switching to index-based access on the raw call list makes each assertion resilient to future signature extensions without sacrificing specificity.

**✅ What Was Implemented**

- Updated default mock diff stats in `PostCommitHook.test.ts` from 7 total lines changed to 50 insertions, pushing values above the threshold so tests that exercise the AI pipeline are no longer accidentally bypassed.
- Renamed test cases from "short-circuit A" / "short-circuit B" to "pre-LLM short-circuit" / "post-LLM short-circuit" and updated inline comments to clarify which threshold each path exercises.
- Changed mocked diff stats in the second and third reassociation tests to exceed the trivial-delta threshold and reach the post-LLM stage they were designed to cover.
- Rewrote two `storeSummary` call assertions from positional argument matching to index-based access on the raw call list, making them resilient to future signature extensions.

**📁 FILES**
- `cli/src/hooks/PostCommitHook.test.ts`

</blockquote>
</details>
<details>
<summary><strong>08 · Revert accidental VS Code extension version bump</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

An unrelated version bump had slipped into the branch during the amend-dispatch refactor work and needed to be removed.

**💡 Decisions Behind the Code**

Removing the change via an amend kept the branch history clean without introducing a separate revert commit, since the bump was unintentional and entirely unrelated to the refactor in progress.

**✅ What Was Implemented**

Reverted `vscode/package.json` version field from 0.99.3 back to 0.99.2.

**📁 FILES**
- `vscode/package.json`

</blockquote>
</details>

---

*Generated by Jolli Memory · May 22, 2026 at 3:58 PM · via Anthropic*
<!-- jollimemory-summary-end -->