### PR TITLE
Fix escape sequence handling in export and view commands

### DIFF
--- a/cli/src/commands/ExportCommand.ts
+++ b/cli/src/commands/ExportCommand.ts
@@ -120,7 +120,10 @@ function formatPromptMarkdown(entry: ManifestEntry): string {
 		entry.placeholders.length > 0
 			? `placeholders:\n${entry.placeholders.map((p) => `  - ${p}`).join("\n")}`
 			: "placeholders: []";
-	const escapedAction = entry.action.replace(/"/g, '\\"');
+	// Escape backslash FIRST so `\` itself round-trips through YAML's quoted-string
+	// decoder (where `\\` → `\` and `\"` → `"`). Reversing the order leaves bare
+	// `\` in the output, which would then be decoded as the start of an escape.
+	const escapedAction = entry.action.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
 	return `---
 action: "${escapedAction}"
 version: ${entry.version}

--- a/cli/src/commands/ViewCommand.ts
+++ b/cli/src/commands/ViewCommand.ts
@@ -91,7 +91,9 @@ function printCompactList(entries: ReadonlyArray<SummaryIndexEntry>, total: numb
 
 /** Escapes a value for safe inclusion in a GFM table cell: `|` must be escaped and newlines collapsed. */
 function escapeCell(value: string): string {
-	return value.replace(/\|/g, "\\|").replace(/\r?\n/g, " ");
+	// Backslash first — GFM decodes `\\` → `\` and `\|` → literal pipe, so without
+	// this step an input `\|` would emerge as `\\|`, decoded as `\` + cell separator.
+	return value.replace(/\\/g, "\\\\").replace(/\|/g, "\\|").replace(/\r?\n/g, " ");
 }
 
 /** Builds a GFM-compatible markdown table from compact-list entries. */

--- a/cli/src/core/SummaryExporter.ts
+++ b/cli/src/core/SummaryExporter.ts
@@ -99,7 +99,8 @@ function getExistingHashes(outputDir: string): Set<string> {
 /** Builds a single markdown table row for the index. */
 function buildIndexRow(summary: CommitSummary, hashPrefix: string, fileName: string): string {
 	const date = getDisplayDate(summary).substring(0, 10);
-	const safeMessage = summary.commitMessage.replace(/\|/g, "\\|");
+	// Backslash first — see escapeCell in ViewCommand.ts for the round-trip rationale.
+	const safeMessage = summary.commitMessage.replace(/\\/g, "\\\\").replace(/\|/g, "\\|");
 	return `| ${date} | \`${hashPrefix}\` | [${safeMessage}](./${fileName}) |`;
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2538,9 +2538,9 @@
 			"license": "BSD-2-Clause"
 		},
 		"node_modules/brace-expansion": {
-			"version": "5.0.5",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-			"integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+			"version": "5.0.6",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+			"integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
 			"license": "MIT",
 			"dependencies": {
 				"balanced-match": "^4.0.2"
@@ -3523,9 +3523,9 @@
 			}
 		},
 		"node_modules/fast-uri": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-			"integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+			"integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
 			"dev": true,
 			"funding": [
 				{


### PR DESCRIPTION
<!-- jollimemory-summary-start -->
## Commits in this PR (2)

1. Upgrade brace-expansion and fast-uri dependencies to patch vulnerabilities (`454c46d`)
2. Fix escape sequence handling in export and view commands (`c3cfd45`)

## Quick recap (1)

### Commit 2 of 2: Fix escape sequence handling in export and view commands (`c3cfd45`)

The developer fixed escape sequence handling in three export and view commands where backslash characters were not being escaped before target characters, causing data corruption on round-trip through YAML and Markdown parsers. Each location now escapes backslashes first, then the target character, ensuring that inputs like `\|` survive serialization and deserialization intact.

In parallel, the developer reviewed and triaged ten open code scanning alerts. Five CodeQL and Scorecard findings were dismissed as false positives or acceptable risk: two CodeQL alerts misclassified taint flows that do not represent actual security leaks, one Scorecard rule flagged a gradle wrapper JAR that is standard practice in the ecosystem, and three Dependabot alerts reported vulnerabilities that the lockfile already satisfies. The remaining open alerts (branch protection policy, repository age, and OpenSSF badge self-assessment) require administrative or process changes outside the scope of code fixes.

## Topics (3)
<details>
<summary><strong>01 · [454c46d] Upgrade brace-expansion and fast-uri dependencies to patch vulnerabilities</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Two transitive npm dependencies contained known security vulnerabilities that needed to be addressed.

**💡 Decisions Behind the Code**

Patch-level version bumps were chosen to minimize risk while addressing the security issues. These are maintenance releases from the upstream projects and do not alter the public API or require code changes in the consuming application.

**✅ What Was Implemented**

Updated brace-expansion from 5.0.5 to 5.0.6 and fast-uri from 3.1.0 to 3.1.2 in package-lock.json. Both upgrades are patch-level version bumps that include vulnerability fixes without introducing breaking changes.

**📁 FILES**
- `package-lock.json`

</blockquote>
</details>
<details>
<summary><strong>02 · [c3cfd45] Fix escape sequence handling in YAML and Markdown export formats</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Code scanning detected incomplete sanitization in three export and view commands where backslash characters were not being escaped before target characters, causing round-trip failures when exported data was re-parsed.

**💡 Decisions Behind the Code**

Escape sequences must be processed in a specific order: the escape character itself (`\`) must be escaped first, before escaping the target character. This ensures that an input containing a backslash followed by a special character (e.g., `\|`) does not become a double-escaped sequence that the downstream parser misinterprets. The fix is minimal (one additional `.replace()` call per location) and carries no performance or compatibility risk because it only affects the serialization layer, not the data model or API surface.

**✅ What Was Implemented**

- **ExportCommand.ts:123**: Added backslash escaping before quote escaping in YAML quoted-string output. The `entry.action` field now calls `.replace(/\\/g, "\\\\")` before `.replace(/"/g, '\\"')` to ensure backslashes round-trip correctly through YAML's decoder.
- **ViewCommand.ts:94**: Added backslash escaping in the `escapeCell()` function used for Markdown table cells. The pipe character escape now follows a preceding `.replace(/\\/g, "\\\\")` so that input like `\|` does not emerge as `\\|` and get decoded as a literal backslash plus cell separator.
- **SummaryExporter.ts:102**: Applied the same backslash-first pattern to `buildIndexRow()` when escaping commit messages for Markdown table output.

**📁 FILES**
- `cli/src/commands/ExportCommand.ts`
- `cli/src/commands/ViewCommand.ts`
- `cli/src/core/SummaryExporter.ts`

</blockquote>
</details>
<details>
<summary><strong>03 · [c3cfd45] Dismiss stale and false-positive code scanning alerts</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Security scanning identified several alerts that were either already resolved in the dependency tree, misclassified by the scanner, or acceptable per the project's risk posture.

**💡 Decisions Behind the Code**

False positives and stale alerts were distinguished from genuine issues by examining the actual dependency tree and code context. The CodeQL alerts were dismissed with detailed comments explaining why the taint flow does not represent a real security risk, following the project's established pattern from prior dismissals. Dependabot alerts were closed as inaccurate rather than fixed because the lockfile already satisfies the vulnerability constraints; re-running the Scorecard workflow will automatically close the aggregate finding once Dependabot's own alerts are resolved.

**✅ What Was Implemented**

- Dismissed two CodeQL false positives: `js/clear-text-logging` (StatusCommand.ts) where the logged value is a tenant hostname, not an API key, and `js/shell-command-constructed-from-input` (GitOps.ts) where the spawn call uses an array argument list and does not invoke a shell.
- Dismissed `BinaryArtifactsID` (gradle-wrapper.jar) as a won't-fix because gradle wrapper JARs are industry standard in Java/Gradle projects and the Scorecard rule does not account for wrapper validation.
- Closed three Dependabot vulnerability alerts as inaccurate: two fast-uri alerts where the lockfile already contains the fixed version (3.1.2), and one brace-expansion alert where the vulnerable range (≥5.0.0, <5.0.6) does not include the versions actually present in the lockfile (1.1.14 and 5.0.6).

**📁 FILES**
- `package-lock.json (no changes; alerts dismissed via GitHub UI)`

</blockquote>
</details>

---

*Generated by Jolli Memory · May 22, 2026 at 6:33 PM*
<!-- jollimemory-summary-end -->