### PR TITLE
Add site schema verification, theme caching, and navigation fixes

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -56,6 +56,7 @@
 		"chokidar": "^4.0.0",
 		"commander": "^13.1.0",
 		"open": "^11.0.0",
+		"tar": "^7.5.15",
 		"yaml": "^2.6.1"
 	},
 	"devDependencies": {

--- a/cli/src/commands/StartCommand.test.ts
+++ b/cli/src/commands/StartCommand.test.ts
@@ -1110,3 +1110,184 @@ describe("buildRootInjectionInput", () => {
 		expect(result.apiSpecs).toEqual([{ specName: "public-api", title: "Public API" }]);
 	});
 });
+
+// ─── pickRootRedirectHref / writeRootRedirectIndex unit tests ─────────────────
+
+describe("pickRootRedirectHref", () => {
+	it("returns the first navigable page href when no page is rooted at /", async () => {
+		const { pickRootRedirectHref } = await import("./StartCommand.js");
+		const parsed = {
+			sidebar: {},
+			pages: [
+				{ key: "docs", title: "Get Started", href: "/docs" },
+				{ key: "api", title: "API", href: "/api" },
+			],
+			defaultPageHref: "/docs",
+		};
+		expect(pickRootRedirectHref(parsed)).toBe("/docs");
+	});
+
+	it("returns undefined when one of the pages claims the root", async () => {
+		const { pickRootRedirectHref } = await import("./StartCommand.js");
+		const parsed = {
+			sidebar: {},
+			pages: [
+				{ key: "home", title: "Home", href: "/" },
+				{ key: "docs", title: "Docs", href: "/docs" },
+			],
+			defaultPageHref: "/",
+		};
+		expect(pickRootRedirectHref(parsed)).toBeUndefined();
+	});
+
+	it("skips menu pages (href:#) when picking the first navigable target", async () => {
+		const { pickRootRedirectHref } = await import("./StartCommand.js");
+		const parsed = {
+			sidebar: {},
+			pages: [
+				{ key: "community", title: "Community", href: "#", type: "menu" as const },
+				{ key: "docs", title: "Docs", href: "/docs" },
+			],
+			defaultPageHref: "#",
+		};
+		expect(pickRootRedirectHref(parsed)).toBe("/docs");
+	});
+
+	it("returns undefined when parsedNavigation is missing or in simple mode", async () => {
+		const { pickRootRedirectHref } = await import("./StartCommand.js");
+		expect(pickRootRedirectHref(undefined)).toBeUndefined();
+		expect(pickRootRedirectHref({ sidebar: {} })).toBeUndefined();
+	});
+
+	it("returns undefined when the first navigable href has an unsafe scheme", async () => {
+		// Defense in depth: the href reaches `window.location.replace(...)` in
+		// the inline-script stub. A `javascript:`/`data:` URL in `site.json`
+		// must not be propagated — sanitizeUrl clamps it to "#", and the
+		// caller maps that back to "no redirect" so the original index renders.
+		const { pickRootRedirectHref } = await import("./StartCommand.js");
+		const parsed = {
+			sidebar: {},
+			pages: [{ key: "evil", title: "Evil", href: "javascript:alert(1)" }],
+			defaultPageHref: "javascript:alert(1)",
+		};
+		expect(pickRootRedirectHref(parsed)).toBeUndefined();
+	});
+
+	it("returns undefined when the first navigable href is a scheme-relative URL", async () => {
+		const { pickRootRedirectHref } = await import("./StartCommand.js");
+		const parsed = {
+			sidebar: {},
+			pages: [{ key: "evil", title: "Evil", href: "//evil.com/x" }],
+			defaultPageHref: "//evil.com/x",
+		};
+		expect(pickRootRedirectHref(parsed)).toBeUndefined();
+	});
+});
+
+describe("writeRootRedirectIndex", () => {
+	let contentDir: string;
+
+	beforeEach(async () => {
+		const { mkdtemp } = await import("node:fs/promises");
+		const { tmpdir } = await import("node:os");
+		contentDir = await mkdtemp(join(tmpdir(), "jolli-redirect-test-"));
+	});
+
+	afterEach(async () => {
+		const { rm } = await import("node:fs/promises");
+		await rm(contentDir, { recursive: true, force: true });
+	});
+
+	it("replaces index.md with an index.mdx redirect stub", async () => {
+		const { writeFile, readFile, stat } = await import("node:fs/promises");
+		await writeFile(join(contentDir, "index.md"), "# Old home\n", "utf-8");
+
+		const { writeRootRedirectIndex } = await import("./StartCommand.js");
+		await writeRootRedirectIndex(contentDir, "/docs");
+
+		const mdx = await readFile(join(contentDir, "index.mdx"), "utf-8");
+		expect(mdx).toContain(`window.location.replace("/docs")`);
+		expect(mdx).toContain("Redirecting…");
+		expect(mdx).toContain("<noscript>");
+
+		// Old index.md is gone — Nextra picks up index.mdx as the route.
+		await expect(stat(join(contentDir, "index.md"))).rejects.toBeDefined();
+	});
+
+	it("escapes the redirect href to defuse JS-string injection", async () => {
+		const { readFile } = await import("node:fs/promises");
+		const { writeRootRedirectIndex } = await import("./StartCommand.js");
+
+		await writeRootRedirectIndex(contentDir, `/docs"</script><script>alert(1)//`);
+
+		const mdx = await readFile(join(contentDir, "index.mdx"), "utf-8");
+		// The href is round-tripped through JSON.stringify, so the quote and
+		// closing tag are escaped — no raw </script> in the inline JS.
+		expect(mdx).not.toMatch(/<\/script>.*alert/);
+		expect(mdx).toContain('\\"');
+	});
+
+	it("escapes dollar-curly so a hostile href cannot execute via the outer template literal", async () => {
+		// Regression: the inline-script body is built as a template literal
+		// `\`window.location.replace(${jsHref})\``. JSON.stringify does not
+		// escape the `$` + `{` sequence, so a value like `/x` + `${alert(1)}`
+		// would otherwise survive JSON encoding, land inside the template
+		// literal at MDX render time, and run `alert(1)` as a template
+		// substitution. Build the hostile input by concatenation so the
+		// test source itself doesn't trip Biome's no-template-curly rule.
+		const { readFile } = await import("node:fs/promises");
+		const { writeRootRedirectIndex } = await import("./StartCommand.js");
+
+		const hostile = `/x${"$"}{alert(1)}`;
+		await writeRootRedirectIndex(contentDir, hostile);
+
+		const mdx = await readFile(join(contentDir, "index.mdx"), "utf-8");
+		// The dollar-curly sequence must NOT survive into the inline script
+		// body as a literal `$` + `{` substitution head.
+		expect(mdx).not.toContain(`${"$"}{alert`);
+		// And the escaped form must be present so the JSON.stringify output
+		// is actually neutralised.
+		expect(mdx).toContain("\\u0024{alert(1)}");
+	});
+
+	it("escapes backticks so a hostile href cannot close the outer template literal", async () => {
+		// Regression: a backtick in the href closes the template-literal that
+		// wraps `${jsHref}` in the inline-script body. A trailing backtick
+		// causes a syntax error (DoS crash); a well-placed one followed by
+		// `${...}` lets the attacker append arbitrary JS as a template head.
+		const { readFile } = await import("node:fs/promises");
+		const { writeRootRedirectIndex } = await import("./StartCommand.js");
+
+		await writeRootRedirectIndex(contentDir, "/x`alert(1)`");
+
+		const mdx = await readFile(join(contentDir, "index.mdx"), "utf-8");
+		// No raw backtick survives inside the JS-string portion of the redirect.
+		// Extract the inline script line and check it contains no literal `.
+		const scriptLine = mdx.split("\n").find((l) => l.includes("window.location.replace")) ?? "";
+		// The outer template-literal delimiters (the two backticks that wrap
+		// the call expression) are the only acceptable backticks on that line.
+		const backtickCount = (scriptLine.match(/`/g) ?? []).length;
+		expect(backtickCount).toBe(2);
+		expect(scriptLine).toContain("\\u0060alert(1)\\u0060");
+	});
+
+	it("escapes { and } in the noscript text so MDX does not evaluate them as JSX expressions", async () => {
+		// Regression: the noscript fallback splices `htmlHref` into MDX text
+		// content as `Redirecting to <a href="...">${htmlHref}</a>…`. MDX
+		// parses `{...}` in text as a JSX expression, so a href like
+		// `/foo{alert(1)}` would otherwise execute at render time. The shared
+		// `escapeHtml` helper from Sanitize.ts escapes `{` and `}` for exactly
+		// this reason (the previous local copy only handled `& < > "`).
+		const { readFile } = await import("node:fs/promises");
+		const { writeRootRedirectIndex } = await import("./StartCommand.js");
+
+		await writeRootRedirectIndex(contentDir, "/foo{alert(1)}");
+
+		const mdx = await readFile(join(contentDir, "index.mdx"), "utf-8");
+		// The noscript line(s) must not contain a literal `{alert(1)}` JSX
+		// expression — `{` and `}` must be HTML-entity-encoded.
+		const noscriptBlock = mdx.slice(mdx.indexOf("<noscript>"), mdx.indexOf("</noscript>"));
+		expect(noscriptBlock).not.toContain("{alert(1)}");
+		expect(noscriptBlock).toContain("&#123;alert(1)&#125;");
+	});
+});

--- a/cli/src/commands/StartCommand.ts
+++ b/cli/src/commands/StartCommand.ts
@@ -6,6 +6,7 @@
 
 import { createHash } from "node:crypto";
 import { existsSync } from "node:fs";
+import { mkdir, rm, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join, resolve } from "node:path";
 import type { Command } from "commander";
@@ -23,6 +24,7 @@ import { deriveSpecName } from "../site/openapi/SpecName.js";
 import { runPagefind } from "../site/PagefindRunner.js";
 import { resolveRenderer, type SiteRenderer } from "../site/renderer/index.js";
 import type { OpenApiSpecInput } from "../site/renderer/SiteRenderer.js";
+import { escapeHtml, sanitizeUrl } from "../site/Sanitize.js";
 import { readSiteJson } from "../site/SiteJsonReader.js";
 import { startSourceWatcher } from "../site/SourceWatcher.js";
 import { parseNavigation } from "../site/StructureParser.js";
@@ -220,6 +222,19 @@ async function syncContent(
 		specInputs,
 	);
 
+	// When the site is in page mode and no page is rooted at `/`, the auto-
+	// mirrored root `index.md` is dead weight — `SidebarTabs.tsx` ends up
+	// client-side redirecting from `/` to the first tab, which produces a
+	// visible flash of the index page before the JS runs. Replace the root
+	// index with an inline `<script>` redirect so the browser navigates away
+	// before React even hydrates. We do this *before* `generateNavigation` so
+	// the `_meta.js` writer picks up the rewritten file and emits the standard
+	// `{ "index": { display: "hidden" } }` entry to keep it out of the sidebar.
+	const redirectHref = pickRootRedirectHref(parsedNavigation);
+	if (redirectHref) {
+		await writeRootRedirectIndex(contentDir, redirectHref);
+	}
+
 	if (parsedNavigation) {
 		if (parsedNavigation.rootPages?.length) {
 			rootInjection.structurePages = parsedNavigation.rootPages;
@@ -241,6 +256,78 @@ async function syncContent(
 	}
 
 	return { success: true, mirrorResult };
+}
+
+/**
+ * Returns the href to redirect `/` to, or `undefined` when no redirect is
+ * needed. We redirect only when:
+ *   - The site is in page mode (navigation has `pages`)
+ *   - No page is rooted at `/` (the user didn't claim the root)
+ *   - The first navigable (non-`menu`) page resolves to a real href
+ *
+ * The selected href is then routed through `sanitizeUrl` so a hostile
+ * `site.json` entry like `{ root: "javascript:alert(1)" }` cannot reach the
+ * `window.location.replace(...)` call in the inline-script stub. A clamped
+ * value (`"#"`) collapses back to `undefined` so the original index renders.
+ *
+ * Exported for unit testing — call site is in `syncContent`.
+ */
+export function pickRootRedirectHref(
+	parsedNavigation: ReturnType<typeof parseNavigation> | undefined,
+): string | undefined {
+	if (!parsedNavigation?.pages?.length) return undefined;
+	const claimsRoot = parsedNavigation.pages.some((p) => p.href === "/");
+	if (claimsRoot) return undefined;
+	const firstNavigable = parsedNavigation.pages.find((p) => p.type !== "menu" && p.href && p.href !== "#");
+	if (!firstNavigable?.href) return undefined;
+	const safe = sanitizeUrl(firstNavigable.href);
+	return safe === "#" ? undefined : safe;
+}
+
+/**
+ * Overwrites `<contentDir>/index.{md,mdx}` with a tiny stub that redirects
+ * `/` to `href` via an inline `<script>`. The script runs before React
+ * hydration, so the user never sees the original index content flash. The
+ * `<noscript>` fallback covers JS-disabled browsers and crawlers.
+ *
+ * Exported for unit testing — call site is in `syncContent`.
+ */
+export async function writeRootRedirectIndex(contentDir: string, href: string): Promise<void> {
+	// `jsHref` is for the inline JS string. JSON.stringify handles backslash,
+	// quote, and unicode escapes — but three sequences survive that still
+	// matter at MDX/HTML render time:
+	//   - `</script>` inside the JS string terminates the surrounding
+	//     `<script>` tag at HTML parse time.
+	//   - Backtick (`` ` ``) inside the JS string closes the outer template
+	//     literal that the MDX expression `{`window.location.replace(${jsHref})`}`
+	//     uses to splice `jsHref` in. A trailing backtick causes a syntax
+	//     error (DoS); a properly placed one followed by `${...}` lets the
+	//     attacker append arbitrary JS as a template-literal head expression.
+	//   - `${` inside the JS string introduces a template-literal
+	//     substitution that evaluates the contents as JS at render time
+	//     (e.g. `/x${alert(1)}` → `alert(1)` runs on every visit to `/`).
+	const jsHref = JSON.stringify(href).replace(/</g, "\\u003c").replace(/`/g, "\\u0060").replace(/\$\{/g, "\\u0024{");
+	// `htmlHref` is for the noscript `<a>` href attribute and MDX text. The
+	// shared `escapeHtml` helper escapes `& < > " ' { }` — the curly-brace
+	// escape matters here because the noscript fallback splices `htmlHref`
+	// into MDX text content, and MDX parses `{...}` in text as a JSX
+	// expression (so `/foo{alert(1)}` would execute at render time without
+	// the `{` / `}` escape).
+	const htmlHref = escapeHtml(href);
+	const mdx = `---
+title: Redirecting…
+sidebarTitle: ' '
+---
+
+<script dangerouslySetInnerHTML={{ __html: \`window.location.replace(${jsHref})\` }} />
+
+<noscript>
+  Redirecting to <a href="${htmlHref}">${htmlHref}</a>…
+</noscript>
+`;
+	await mkdir(contentDir, { recursive: true });
+	await rm(join(contentDir, "index.md"), { force: true });
+	await writeFile(join(contentDir, "index.mdx"), mdx, "utf-8");
 }
 
 /**

--- a/cli/src/commands/ThemeCommand.ts
+++ b/cli/src/commands/ThemeCommand.ts
@@ -8,10 +8,13 @@
  */
 
 import { existsSync } from "node:fs";
-import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
-import { homedir } from "node:os";
+import { cp, mkdir, mkdtemp, readdir, readFile, rm, writeFile } from "node:fs/promises";
+import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
+import { Readable } from "node:stream";
+import { pipeline } from "node:stream/promises";
 import type { Command } from "commander";
+import { extract } from "tar";
 import { scaffoldProject } from "../site/StarterKit.js";
 
 // ─── Constants ───────────────────────────────────────────────────────────────
@@ -21,10 +24,19 @@ const REGISTRY_URL = `https://raw.githubusercontent.com/${THEMES_REPO}/main/regi
 const USER_THEMES_DIR = join(homedir(), ".jolli", "themes");
 
 /**
- * Fallback local registry path — used during development before the
- * GitHub repo is created, or when offline. Set via JOLLI_THEMES_DIR env.
+ * Returns auth headers for GitHub fetches when `GITHUB_TOKEN` (or `GH_TOKEN`)
+ * is set. Required while `jolliai/themes` is a private repo; once the repo
+ * is public this becomes a no-op for unauthenticated users while still
+ * raising the rate limit when set.
  */
-const LOCAL_THEMES_DIR = process.env.JOLLI_THEMES_DIR ?? join(homedir(), "jolli.ai", "themes");
+export function githubAuthHeaders(): Record<string, string> {
+	const token = process.env.GITHUB_TOKEN ?? process.env.GH_TOKEN;
+	return token ? { Authorization: `Bearer ${token}` } : {};
+}
+
+const AUTH_HINT =
+	"If this is a private repo, set GITHUB_TOKEN (or GH_TOKEN) to a token with read access " +
+	"(e.g. `export GITHUB_TOKEN=$(gh auth token)`).";
 
 interface RegistryTheme {
 	name: string;
@@ -80,82 +92,76 @@ async function writeInstalledMeta(name: string, version: string): Promise<void> 
 }
 
 async function fetchRegistry(): Promise<RegistryData> {
-	// Try GitHub first
+	let res: Response;
 	try {
-		const res = await fetch(REGISTRY_URL);
-		if (res.ok) {
-			return (await res.json()) as RegistryData;
-		}
-	} catch {
-		// Network error — fall through to local
+		res = await fetch(REGISTRY_URL, { headers: githubAuthHeaders() });
+	} catch (err) {
+		const detail = err instanceof Error ? err.message : String(err);
+		throw new Error(`Could not reach ${REGISTRY_URL}: ${detail}`);
 	}
-
-	// Fallback: local registry.json (development / offline)
-	const localRegistry = join(LOCAL_THEMES_DIR, "registry.json");
-	if (existsSync(localRegistry)) {
-		const { readFile } = await import("node:fs/promises");
-		const raw = await readFile(localRegistry, "utf-8");
-		return JSON.parse(raw) as RegistryData;
+	if (!res.ok) {
+		const hint = res.status === 401 || res.status === 403 || res.status === 404 ? ` ${AUTH_HINT}` : "";
+		throw new Error(`Could not fetch theme registry from ${REGISTRY_URL}: ${res.status} ${res.statusText}.${hint}`);
 	}
-
-	throw new Error("Could not fetch theme registry from GitHub or local fallback");
+	return (await res.json()) as RegistryData;
 }
 
 /**
- * Downloads a theme to `~/.jolli/themes/<name>/`.
- * GitHub is the source of truth; local themes directory is the offline fallback.
- * Saves version metadata from registry when available.
+ * Downloads a theme to `~/.jolli/themes/<name>/` from the canonical GitHub
+ * repo (`github.com/jolliai/themes`). Saves version metadata from the
+ * registry when available. Throws on network error or when the theme is
+ * not present in the repo — callers decide whether to fall back to the
+ * already-cached copy under `~/.jolli/themes/<name>/`.
+ *
+ * Uses the public `codeload.github.com` tarball endpoint (one request for
+ * the whole repo, no `api.github.com` rate-limit consumption) and extracts
+ * only the requested `<name>/` directory into the destination.
  */
 export async function downloadTheme(name: string, version?: string): Promise<string> {
 	const destDir = join(USER_THEMES_DIR, name);
+	const tarballUrl = `https://codeload.github.com/${THEMES_REPO}/tar.gz/refs/heads/main`;
 
-	// 1) GitHub Contents API (source of truth)
+	let res: Response;
 	try {
-		const contentsUrl = `https://api.github.com/repos/${THEMES_REPO}/contents/${name}`;
-		const res = await fetch(contentsUrl, {
-			headers: { Accept: "application/vnd.github.v3+json" },
-		});
-		if (res.ok) {
-			const files = (await res.json()) as Array<{
-				name: string;
-				download_url: string | null;
-				type: string;
-			}>;
-			await mkdir(destDir, { recursive: true });
-			for (const file of files) {
-				if (file.type !== "file" || !file.download_url) continue;
-				const fileRes = await fetch(file.download_url);
-				if (!fileRes.ok) {
-					throw new Error(`Failed to download ${file.name}: ${fileRes.status}`);
-				}
-				const content = await fileRes.text();
-				await writeFile(join(destDir, file.name), content, "utf-8");
-			}
-			if (version) await writeInstalledMeta(name, version);
-			return destDir;
-		}
-		if (res.status !== 404) {
-			throw new Error(`GitHub API error: ${res.status} ${res.statusText}`);
-		}
+		res = await fetch(tarballUrl, { headers: githubAuthHeaders() });
 	} catch (err) {
-		// Network error — fall through to local fallback
-		if (err instanceof Error && err.message.startsWith("GitHub API")) throw err;
+		const detail = err instanceof Error ? err.message : String(err);
+		throw new Error(`Could not reach ${tarballUrl}: ${detail}`);
+	}
+	if (!res.ok || !res.body) {
+		const hint = res.status === 401 || res.status === 403 || res.status === 404 ? ` ${AUTH_HINT}` : "";
+		throw new Error(`Could not fetch theme repo from ${tarballUrl}: ${res.status} ${res.statusText}.${hint}`);
 	}
 
-	// 2) Local themes directory (offline fallback)
-	const localThemeDir = join(LOCAL_THEMES_DIR, name);
-	if (existsSync(localThemeDir)) {
-		await mkdir(destDir, { recursive: true });
-		const { readdir, copyFile } = await import("node:fs/promises");
-		const files = await readdir(localThemeDir);
-		for (const file of files) {
-			await copyFile(join(localThemeDir, file), join(destDir, file));
+	const tmpRoot = await mkdtemp(join(tmpdir(), "jolli-themes-"));
+	try {
+		// `tar.extract` auto-detects the gzip layer; pipe the response into it.
+		// fetch returns a web ReadableStream; Readable.fromWeb bridges to a node stream.
+		const nodeStream = Readable.fromWeb(res.body as Parameters<typeof Readable.fromWeb>[0]);
+		await pipeline(nodeStream, extract({ cwd: tmpRoot }));
+
+		// codeload tarballs unpack into a single root directory like
+		// `themes-main/` (repo-ref). Look up that root and resolve the theme.
+		const rootEntries = await readdir(tmpRoot);
+		if (rootEntries.length !== 1) {
+			throw new Error(`Unexpected tarball layout: ${rootEntries.length} entries at root`);
 		}
+		const srcDir = join(tmpRoot, rootEntries[0], name);
+		if (!existsSync(srcDir)) {
+			throw new Error(`Theme "${name}" not found in ${THEMES_REPO}`);
+		}
+
+		// Replace the destination with the extracted copy so a partial older
+		// install can't leave stale files lying around.
+		await rm(destDir, { recursive: true, force: true });
+		await mkdir(destDir, { recursive: true });
+		await cp(srcDir, destDir, { recursive: true });
+
 		if (version) await writeInstalledMeta(name, version);
 		return destDir;
+	} finally {
+		await rm(tmpRoot, { recursive: true, force: true });
 	}
-
-	throw new Error(`Theme "${name}" not found in ${THEMES_REPO} or local themes directory`);
 }
 
 // ─── Subcommands ─────────────────────────────────────────────────────────────

--- a/cli/src/site/ContentPlanner.test.ts
+++ b/cli/src/site/ContentPlanner.test.ts
@@ -168,6 +168,61 @@ describe("buildNavigationContentPlan", () => {
 		]);
 	});
 
+	it("writes parent article as index.<ext> inside its folder when it has nested children", () => {
+		// Regression: when an article has both an `href` matching a source file
+		// AND nested `articles`, the parent must be written as
+		// `<href>/index.<ext>` — not `<href>.<ext>` next to the children's
+		// `<href>/` folder, which Nextra v4 sees as a layout conflict (sidebar
+		// entry collapses to a non-clickable expandable folder; children 404).
+		const plan = buildNavigationContentPlan(
+			[
+				{
+					page: "Get Started",
+					root: "/docs",
+					content: [
+						{
+							group: "Guides",
+							root: "guides",
+							content: [
+								{
+									article: "Deployment",
+									href: "deployment",
+									articles: [
+										{ article: "Docker", href: "deployment/docker" },
+										{ article: "Kubernetes", href: "deployment/kubernetes" },
+									],
+								},
+							],
+						},
+					],
+				},
+			],
+			[
+				"docs/guides/deployment.mdx",
+				"docs/guides/deployment/docker.mdx",
+				"docs/guides/deployment/kubernetes.mdx",
+			],
+		);
+
+		expect(plan.pages).toEqual([
+			{
+				sourceRelPath: "docs/guides/deployment.mdx",
+				targetRelPath: "docs/guides/deployment/index.mdx",
+				title: "Deployment",
+			},
+			{
+				sourceRelPath: "docs/guides/deployment/docker.mdx",
+				targetRelPath: "docs/guides/deployment/docker.mdx",
+				title: "Docker",
+			},
+			{
+				sourceRelPath: "docs/guides/deployment/kubernetes.mdx",
+				targetRelPath: "docs/guides/deployment/kubernetes.mdx",
+				title: "Kubernetes",
+			},
+		]);
+	});
+
 	it("throws when two logical pages claim the same target path", () => {
 		expect(() =>
 			buildNavigationContentPlan(
@@ -235,5 +290,72 @@ describe("applyNavigationContentPlan", () => {
 		expect(existsSync(join(contentDir, "docs", "intro.md"))).toBe(true);
 		const rewritten = await readFile(join(contentDir, "docs", "intro.md"), "utf-8");
 		expect(rewritten).toContain("![Diagram](../assets/arch.png)");
+	});
+
+	it("injects asIndexPage:true frontmatter when a non-index source is re-homed to <folder>/index.<ext>", async () => {
+		// Regression for the parent-article-with-nested-children case: the
+		// planner writes `<href>/index.<ext>` instead of `<href>.<ext>` so the
+		// folder can hold child pages, and the frontmatter flag makes Nextra v4
+		// route the folder header to the index (instead of just expanding) and
+		// suppress the duplicate auto-discovered index entry in the sidebar.
+		sourceRoot = await makeTempDir();
+		contentDir = await makeTempDir();
+
+		// No existing frontmatter → flag block is prepended.
+		await writeFile(join(sourceRoot, "deployment.mdx"), "# Deployment\nBody.\n", "utf-8");
+		// Existing frontmatter → flag is merged in.
+		await writeFile(join(sourceRoot, "operations.mdx"), "---\ntitle: Ops\n---\n# Operations\n", "utf-8");
+		// Real index source (basename === index) → flag NOT injected; we only
+		// touch frontmatter when we renamed a non-index source into an index slot.
+		await writeFile(join(sourceRoot, "home.mdx"), "---\ntitle: Home\n---\n# Home\n", "utf-8");
+
+		await applyNavigationContentPlan(sourceRoot, contentDir, ["deployment.mdx", "operations.mdx", "home.mdx"], {
+			pages: [
+				{ sourceRelPath: "deployment.mdx", targetRelPath: "guides/deployment/index.mdx", title: "Deployment" },
+				{ sourceRelPath: "operations.mdx", targetRelPath: "sql/operations/index.mdx", title: "Operations" },
+				{ sourceRelPath: "home.mdx", targetRelPath: "home.mdx", title: "Home" },
+			],
+		});
+
+		const deployment = await readFile(join(contentDir, "guides/deployment/index.mdx"), "utf-8");
+		expect(deployment).toMatch(/^---\nasIndexPage: true\n---\n/);
+		expect(deployment).toContain("# Deployment");
+
+		const operations = await readFile(join(contentDir, "sql/operations/index.mdx"), "utf-8");
+		expect(operations).toMatch(/^---\ntitle: Ops\nasIndexPage: true\n---\n/);
+		expect(operations).toContain("# Operations");
+
+		// Source was an .mdx that didn't need renaming → frontmatter untouched.
+		const home = await readFile(join(contentDir, "home.mdx"), "utf-8");
+		expect(home).not.toContain("asIndexPage");
+	});
+
+	it("injects a top-level asIndexPage flag even when the frontmatter has a nested asIndexPage key", async () => {
+		// Regression: the "already declared" check used to match
+		// `^\s*asIndexPage\s*:` on any indentation, so a nested YAML key
+		// (e.g. `things:\n  asIndexPage: true`) falsely registered as a
+		// top-level declaration and the function skipped injection — the
+		// resulting file then had no top-level flag, and Nextra v4 fell
+		// back to its layout-conflict behaviour.
+		sourceRoot = await makeTempDir();
+		contentDir = await makeTempDir();
+
+		await writeFile(
+			join(sourceRoot, "deployment.mdx"),
+			"---\ntitle: Deployment\nthings:\n  asIndexPage: true\n---\n# Deployment\n",
+			"utf-8",
+		);
+
+		await applyNavigationContentPlan(sourceRoot, contentDir, ["deployment.mdx"], {
+			pages: [
+				{ sourceRelPath: "deployment.mdx", targetRelPath: "guides/deployment/index.mdx", title: "Deployment" },
+			],
+		});
+
+		const written = await readFile(join(contentDir, "guides/deployment/index.mdx"), "utf-8");
+		// Top-level flag is present.
+		expect(written).toMatch(/^---\n[\s\S]*^asIndexPage: true$/m);
+		// And the original nested key was preserved.
+		expect(written).toContain("things:\n  asIndexPage: true");
 	});
 });

--- a/cli/src/site/ContentPlanner.ts
+++ b/cli/src/site/ContentPlanner.ts
@@ -126,7 +126,15 @@ function addArticlePlan(
 			? resolveExplicitSourceMarkdown(sourceBase, availableMarkdownFiles)
 			: resolveSourceMarkdown(sourceBase, availableMarkdownFiles);
 		const sourceExt = sourceRelPath.endsWith(".mdx") ? ".mdx" : ".md";
-		const targetRelPath = `${targetBase}${sourceExt}`;
+		// When the article has nested children, write the parent page as
+		// `<targetBase>/index.<ext>` so the child files can live under
+		// `<targetBase>/`. Writing `<targetBase>.<ext>` next to a `<targetBase>/`
+		// folder is a Nextra v4 layout conflict: the folder shadows the file,
+		// the sidebar entry collapses to a non-clickable expandable group, and
+		// the child routes become unreachable.
+		const targetRelPath = article.articles?.length
+			? `${targetBase}/index${sourceExt}`
+			: `${targetBase}${sourceExt}`;
 		pages.push({ sourceRelPath, targetRelPath, title: article.article });
 	} else if (!article.articles?.length) {
 		// No source file AND no children — likely an auto-generated route
@@ -387,9 +395,42 @@ async function rewritePlannedPage(
 	}
 
 	const rewritten = rewriteRelativeImagePaths(content, page.sourceRelPath, finalTargetRelPath);
+	// When the planner re-homed a non-index source (e.g. `guides/deployment.mdx`)
+	// to `<folder>/index.<ext>` because the article has nested children, mark the
+	// rewritten file with `asIndexPage: true`. Nextra v4 reads this frontmatter
+	// flag and treats the index as the folder's representative page — the folder
+	// header in the sidebar becomes a clickable link to the index instead of a
+	// non-clickable expand toggle, and Nextra suppresses the duplicate
+	// auto-discovered index entry from the folder's children list.
+	const sourceIsIndex = /(^|\/)index\.(md|mdx)$/i.test(page.sourceRelPath);
+	const targetIsIndex = /(^|\/)index\.(md|mdx)$/i.test(finalTargetRelPath);
+	const finalContent = targetIsIndex && !sourceIsIndex ? injectAsIndexPageFrontmatter(rewritten) : rewritten;
 	await mkdir(dirname(join(contentDir, finalTargetRelPath)), { recursive: true });
-	await writeFile(join(contentDir, finalTargetRelPath), rewritten, "utf-8");
+	await writeFile(join(contentDir, finalTargetRelPath), finalContent, "utf-8");
 	return finalTargetRelPath;
+}
+
+/**
+ * Adds `asIndexPage: true` to the YAML frontmatter of a markdown/MDX file. If
+ * the file has no frontmatter, prepends a new block. If the frontmatter
+ * already declares `asIndexPage` at the top level, leaves it as authored.
+ *
+ * The "already declared" check is anchored to column 0 so a nested YAML key
+ * (e.g. `things:\n  asIndexPage: true`) doesn't falsely register as a
+ * top-level declaration — in that case Nextra would never see the flag and
+ * fall back to its layout-conflict behaviour.
+ */
+function injectAsIndexPageFrontmatter(content: string): string {
+	const fmMatch = content.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n?/);
+	if (!fmMatch) {
+		return `---\nasIndexPage: true\n---\n${content}`;
+	}
+	const body = fmMatch[1];
+	if (/^asIndexPage\s*:/m.test(body)) {
+		return content;
+	}
+	const newFm = `---\n${body}\nasIndexPage: true\n---\n`;
+	return newFm + content.slice(fmMatch[0].length);
 }
 
 export async function applyNavigationContentPlan(

--- a/cli/src/site/MetaGenerator.test.ts
+++ b/cli/src/site/MetaGenerator.test.ts
@@ -246,6 +246,72 @@ describe("MetaGenerator.generateMetaFiles", () => {
 		expect(content).toContain('"guide"');
 	});
 
+	it("omits the index key entirely when the index file declares asIndexPage:true", async () => {
+		// Regression: Nextra v4 errors with "field key 'index' refers to a page
+		// that cannot be found" when the index has `asIndexPage: true` (Nextra
+		// promotes it to the folder's representative page and removes it from
+		// children) AND `_meta.js` still references "index".
+		const { generateMetaFiles } = await import("./MetaGenerator.js");
+		await writeFile(
+			join(contentDir, "index.mdx"),
+			"---\ntitle: Deployment\nasIndexPage: true\n---\n# Deployment",
+			"utf-8",
+		);
+		await writeFile(join(contentDir, "docker.md"), "# Docker", "utf-8");
+
+		await generateMetaFiles(contentDir);
+
+		const content = await readFile(join(contentDir, "_meta.js"), "utf-8");
+		expect(content).not.toContain('"index"');
+		expect(content).toContain('"docker"');
+	});
+
+	it("does NOT promote an index when asIndexPage appears as a nested YAML key", async () => {
+		// Regression: the detector used to match `^\s*asIndexPage\s*: true` on
+		// any indentation, so a nested key (e.g. `things:\n  asIndexPage: true`)
+		// falsely registered as a top-level declaration. With the fix, the
+		// index stays hidden (the standard `display: "hidden"` shape) so Nextra
+		// keeps treating the folder as a regular grouping.
+		const { generateMetaFiles } = await import("./MetaGenerator.js");
+		await writeFile(
+			join(contentDir, "index.md"),
+			"---\ntitle: Home\nthings:\n  asIndexPage: true\n---\n# Home",
+			"utf-8",
+		);
+		await writeFile(join(contentDir, "docker.md"), "# Docker", "utf-8");
+
+		await generateMetaFiles(contentDir);
+
+		const content = await readFile(join(contentDir, "_meta.js"), "utf-8");
+		expect(content).toContain('"index"');
+		expect(content).toContain('"hidden"');
+		expect(content).toContain('"docker"');
+	});
+
+	it("prefers index.mdx over index.md when both are present and asIndexPage is declared on the .mdx", async () => {
+		// Regression: Nextra resolves to `index.mdx` when both files exist, but
+		// the detector used to pick whichever readdir returned first (typically
+		// alphabetical → `index.md` wins). With both files present and only the
+		// `.mdx` declaring `asIndexPage: true`, the detector must agree with
+		// what Nextra actually compiles.
+		const { generateMetaFiles } = await import("./MetaGenerator.js");
+		await writeFile(
+			join(contentDir, "index.mdx"),
+			"---\ntitle: Deployment\nasIndexPage: true\n---\n# Deployment",
+			"utf-8",
+		);
+		// Stale .md from a previous mirror without the flag.
+		await writeFile(join(contentDir, "index.md"), "---\ntitle: Old\n---\n# Old", "utf-8");
+		await writeFile(join(contentDir, "docker.md"), "# Docker", "utf-8");
+
+		await generateMetaFiles(contentDir);
+
+		const content = await readFile(join(contentDir, "_meta.js"), "utf-8");
+		// The `.mdx` flag wins → index key is omitted entirely.
+		expect(content).not.toContain('"index"');
+		expect(content).toContain('"docker"');
+	});
+
 	it("_meta.js entries are sorted alphabetically", async () => {
 		const { generateMetaFiles } = await import("./MetaGenerator.js");
 		await writeFile(join(contentDir, "zebra.md"), "# Zebra", "utf-8");

--- a/cli/src/site/MetaGenerator.ts
+++ b/cli/src/site/MetaGenerator.ts
@@ -13,7 +13,7 @@
  * title-cased labels (backward-compatible default behavior).
  */
 
-import { mkdir, readdir, rm, stat, writeFile } from "node:fs/promises";
+import { mkdir, readdir, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { basename, extname, join, relative, sep } from "node:path";
 import { sanitizeUrl } from "./Sanitize.js";
 import type { HeaderItem, SidebarItemValue, SidebarOverrides } from "./Types.js";
@@ -105,17 +105,21 @@ export function toTitleCase(filename: string): string {
  * their custom values. Remaining filesystem items are NOT included — Nextra
  * will auto-append them alphabetically at runtime.
  */
-export function buildMetaEntries(filenames: string[], override?: Record<string, SidebarItemValue>): MetaEntry[] {
+export function buildMetaEntries(
+	filenames: string[],
+	override?: Record<string, SidebarItemValue>,
+	options?: { indexHasAsIndexPage?: boolean },
+): MetaEntry[] {
 	if (override) {
-		return buildOverriddenEntries(filenames, override);
+		return buildOverriddenEntries(filenames, override, options);
 	}
-	return buildDefaultEntries(filenames);
+	return buildDefaultEntries(filenames, options);
 }
 
 /**
  * Default behavior: all items alphabetically sorted with auto-generated labels.
  */
-function buildDefaultEntries(filenames: string[]): MetaEntry[] {
+function buildDefaultEntries(filenames: string[], options?: { indexHasAsIndexPage?: boolean }): MetaEntry[] {
 	const seen = new Set<string>();
 	const entries: MetaEntry[] = [];
 
@@ -126,8 +130,15 @@ function buildDefaultEntries(filenames: string[]): MetaEntry[] {
 		// Hide index files from sidebar — they serve as the folder's own page.
 		// Using display: "hidden" prevents Nextra from auto-appending them
 		// as visible children while still allowing them to be the folder page.
+		// When the index has `asIndexPage: true` in its frontmatter, Nextra
+		// promotes it to the folder's representative page and removes it from
+		// children entirely — emitting an `"index"` _meta entry in that case
+		// produces "field key 'index' refers to a page that cannot be found"
+		// at build time, so we skip it.
 		if (key === "index") {
-			entries.push({ key, value: { display: "hidden" } });
+			if (!options?.indexHasAsIndexPage) {
+				entries.push({ key, value: { display: "hidden" } });
+			}
 			seen.add(key);
 			continue;
 		}
@@ -147,17 +158,23 @@ function buildDefaultEntries(filenames: string[]): MetaEntry[] {
  * Items declared in the override that don't exist on the filesystem are
  * included (they may be external links or separators).
  */
-function buildOverriddenEntries(filenames: string[], override: Record<string, SidebarItemValue>): MetaEntry[] {
+function buildOverriddenEntries(
+	filenames: string[],
+	override: Record<string, SidebarItemValue>,
+	options?: { indexHasAsIndexPage?: boolean },
+): MetaEntry[] {
 	const entries: MetaEntry[] = [];
 
 	// If the folder has an index file but the override doesn't mention it,
 	// add it as hidden to prevent Nextra from showing it as a duplicate child.
+	// When the index has `asIndexPage: true`, skip — see the matching comment
+	// in `buildDefaultEntries` for why.
 	const hasIndexFile = filenames.some((f) => {
 		const ext = extname(f);
 		const key = ext ? basename(f, ext) : f;
 		return key === "index";
 	});
-	if (hasIndexFile && !override.index) {
+	if (hasIndexFile && !override.index && !options?.indexHasAsIndexPage) {
 		entries.push({ key: "index", value: { display: "hidden" } });
 	}
 
@@ -178,6 +195,39 @@ function buildOverriddenEntries(filenames: string[], override: Record<string, Si
 	}
 
 	return entries;
+}
+
+/**
+ * Reads `index.mdx` / `index.md` if present in `contentItems` and reports
+ * whether its frontmatter sets `asIndexPage: true`. Nextra v4 uses this flag
+ * to promote the index to the folder's representative page; the folder's
+ * `_meta.js` must omit the `"index"` key in that case.
+ *
+ * When both `index.mdx` and `index.md` are present, prefers `.mdx` to match
+ * Nextra's own resolution order — otherwise the detector could disagree with
+ * the file Nextra actually compiles and we'd emit the wrong `_meta.js` shape.
+ *
+ * The truthy match is anchored to column 0 (top-level YAML keys only) so a
+ * nested key like `things:\n  asIndexPage: true` doesn't falsely register;
+ * it also accepts the YAML 1.1 truthy variants Nextra's gray-matter parser
+ * recognises (`true` / `True` / `TRUE` / `yes` / `Yes` / `YES`).
+ */
+async function detectAsIndexPage(dir: string, contentItems: string[]): Promise<boolean> {
+	const indexFile = contentItems.includes("index.mdx")
+		? "index.mdx"
+		: contentItems.includes("index.md")
+			? "index.md"
+			: undefined;
+	if (!indexFile) return false;
+	let raw: string;
+	try {
+		raw = await readFile(join(dir, indexFile), "utf-8");
+	} catch {
+		return false;
+	}
+	const fm = raw.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+	if (!fm) return false;
+	return /^asIndexPage\s*:\s*(true|True|TRUE|yes|Yes|YES)\s*$/m.test(fm[1]);
 }
 
 // ─── generateMetaFiles ────────────────────────────────────────────────────────
@@ -254,7 +304,8 @@ async function processDir(
 	const pathKey = `/${relPath.split(sep).join("/")}`.replace(/\/$/, "") || "/";
 
 	const override = sidebarOverrides?.[pathKey];
-	let metaEntries = buildMetaEntries(contentItems, override);
+	const indexHasAsIndexPage = await detectAsIndexPage(dir, contentItems);
+	let metaEntries = buildMetaEntries(contentItems, override, { indexHasAsIndexPage });
 
 	// Root-only augmentation: auto-inject `Documentation` / `API Reference`
 	// page tabs and materialise `header.items` as Nextra-native tabs.

--- a/cli/src/site/StructureParser.test.ts
+++ b/cli/src/site/StructureParser.test.ts
@@ -83,6 +83,89 @@ describe("parseNavigation (simple mode)", () => {
 		expect(result.sidebar["/sql/operations"].aggregate).toBe("Aggregate");
 		expect(result.sidebar["/sql/operations"].window).toBe("Window");
 	});
+
+	it("emits theme.collapsed:false for nested articles when expanded:true is set", () => {
+		const nav = [
+			{
+				group: "Guides",
+				root: "guides",
+				content: [
+					{
+						article: "Deployment",
+						href: "deployment",
+						expanded: true,
+						articles: [
+							{ article: "Docker", href: "deployment/docker" } as NavigationArticle,
+							{ article: "Kubernetes", href: "deployment/kubernetes" } as NavigationArticle,
+						],
+					} as NavigationArticle,
+				],
+			} as NavigationGroup,
+		];
+		const result = parseNavigation(nav);
+		expect(result.sidebar["/guides"].deployment).toEqual({
+			title: "Deployment",
+			theme: { collapsed: false },
+		});
+	});
+
+	it("keeps plain string entry when expanded is unset or there are no nested articles", () => {
+		const nav = [
+			{
+				group: "Guides",
+				root: "guides",
+				content: [
+					// Has children but expanded omitted → plain string (default-collapsed)
+					{
+						article: "Deployment",
+						href: "deployment",
+						articles: [{ article: "Docker", href: "deployment/docker" } as NavigationArticle],
+					} as NavigationArticle,
+					// expanded:true but no children → still plain string
+					{
+						article: "Quickstart",
+						href: "quickstart",
+						expanded: true,
+					} as NavigationArticle,
+					// expanded:false but no children → still plain string
+					{
+						article: "Reference",
+						href: "reference",
+						expanded: false,
+					} as NavigationArticle,
+				],
+			} as NavigationGroup,
+		];
+		const result = parseNavigation(nav);
+		expect(result.sidebar["/guides"].deployment).toBe("Deployment");
+		expect(result.sidebar["/guides"].quickstart).toBe("Quickstart");
+		expect(result.sidebar["/guides"].reference).toBe("Reference");
+	});
+
+	it("emits theme.collapsed:true for nested articles when expanded:false is set", () => {
+		const nav = [
+			{
+				group: "Guides",
+				root: "guides",
+				content: [
+					{
+						article: "Deployment",
+						href: "deployment",
+						expanded: false,
+						articles: [
+							{ article: "Docker", href: "deployment/docker" } as NavigationArticle,
+							{ article: "Kubernetes", href: "deployment/kubernetes" } as NavigationArticle,
+						],
+					} as NavigationArticle,
+				],
+			} as NavigationGroup,
+		];
+		const result = parseNavigation(nav);
+		expect(result.sidebar["/guides"].deployment).toEqual({
+			title: "Deployment",
+			theme: { collapsed: true },
+		});
+	});
 });
 
 // ─── parseNavigation: page mode ───────────────────────────────────────────────

--- a/cli/src/site/StructureParser.ts
+++ b/cli/src/site/StructureParser.ts
@@ -261,10 +261,19 @@ function addArticle(
 	}
 
 	const hrefSegments = article.href.split("/").filter(Boolean);
+	// When the article has nested children and `expanded` is set explicitly,
+	// emit the _meta.js entry as an object with `theme.collapsed` so Nextra
+	// honors the customer's open/closed intent regardless of
+	// `defaultMenuCollapseLevel`. When `expanded` is omitted, fall through to
+	// the plain string entry so Nextra's per-depth default applies.
+	const entryValue: SidebarItemValue =
+		article.articles?.length && article.expanded !== undefined
+			? { title: article.article, theme: { collapsed: !article.expanded } }
+			: article.article;
 
 	if (hrefSegments.length === 1) {
 		// Single segment — goes directly into the current entries
-		entries[hrefSegments[0]] = article.article;
+		entries[hrefSegments[0]] = entryValue;
 	} else {
 		// Multi-segment href (e.g. "real-time-apps/part1") — the first segment
 		// is a directory reference in the current _meta.js, and the last segment
@@ -278,7 +287,7 @@ function addArticle(
 				sidebar[intermediatePath] = {};
 			}
 			(sidebar[intermediatePath] as Record<string, SidebarItemValue>)[seg] = isLast
-				? article.article
+				? entryValue
 				: ((sidebar[intermediatePath] as Record<string, SidebarItemValue>)[seg] ?? seg);
 			if (!isLast) {
 				intermediatePath = joinPath(intermediatePath, seg);

--- a/cli/src/site/Types.ts
+++ b/cli/src/site/Types.ts
@@ -89,6 +89,14 @@ export type SidebarItemValue =
 			 * icon field.
 			 */
 			icon?: string;
+			/**
+			 * Nextra v4 theme overrides for this sidebar entry. The only field
+			 * we currently emit is `collapsed`, used to honor `expanded: true` /
+			 * `expanded: false` on a navigation article so its folder defaults
+			 * to the customer-specified state instead of Nextra's per-level
+			 * collapse default.
+			 */
+			theme?: { collapsed?: boolean };
 	  };
 
 /**

--- a/cli/src/site/themes/ThemeRegistry.ts
+++ b/cli/src/site/themes/ThemeRegistry.ts
@@ -17,6 +17,7 @@
  */
 
 import { existsSync, statSync } from "node:fs";
+import { stat, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
@@ -171,14 +172,25 @@ export async function discoverPack(
 	}
 
 	// 7) GitHub registry: github.com/jolliai/themes/<name>/
+	//
+	// On any failure here (network unreachable, theme not in repo, …) the
+	// cached copy under ~/.jolli/themes/<name>/ would have been picked up by
+	// step 4 above. So if we got here, neither GitHub nor the cache had the
+	// theme — log a clear error and let the caller (`generateLayout`) fall
+	// back to the vanilla Nextra layout.
 	try {
 		const { downloadTheme } = await import("../../commands/ThemeCommand.js");
 		console.log(`  Downloading theme "${name}" from GitHub...`);
 		const destDir = await downloadTheme(name);
 		console.log(`  ✓ Theme "${name}" installed to ${destDir}`);
 		return loadFromPath(destDir);
-	} catch {
-		// not found on GitHub
+	} catch (err) {
+		const detail = err instanceof Error ? err.message : String(err);
+		console.error(
+			`  Error: Could not load theme "${name}" — ${detail}.\n` +
+				`         No cached copy at ${join(USER_THEMES_DIR, name)} either. ` +
+				`Falling back to the default Nextra layout.`,
+		);
 	}
 
 	return undefined;
@@ -187,13 +199,57 @@ export async function discoverPack(
 // ─── Cache version check ────────────────────────────────────────────────
 
 /**
+ * How long a cached theme is considered "fresh" before we re-check the
+ * registry. 24 h is enough to pick up a published theme update within a day
+ * while reducing GitHub traffic from "every build" to "once per day per
+ * machine per theme".
+ */
+const VERSION_CHECK_TTL_MS = 24 * 60 * 60 * 1000;
+
+/** Sentinel file whose mtime records the last successful version-check attempt. */
+const LAST_CHECKED_FILE = ".last-checked";
+
+/**
+ * Returns `true` when the cached theme has never been version-checked or the
+ * last check was longer ago than the TTL. Missing / unreadable sentinel
+ * counts as "never checked" so a fresh install always probes once.
+ */
+async function isVersionCheckDue(cachedPath: string): Promise<boolean> {
+	try {
+		const info = await stat(join(cachedPath, LAST_CHECKED_FILE));
+		return Date.now() - info.mtimeMs >= VERSION_CHECK_TTL_MS;
+	} catch {
+		return true;
+	}
+}
+
+/**
+ * Marks the cached theme as version-checked at the start of the check so a
+ * transient GitHub outage during the network call doesn't cause every
+ * subsequent build to retry — we wait out the TTL and try again later.
+ */
+async function markVersionChecked(cachedPath: string): Promise<void> {
+	try {
+		await writeFile(join(cachedPath, LAST_CHECKED_FILE), new Date().toISOString(), "utf-8");
+	} catch {
+		// Best-effort; failing to write just means the next build re-checks early.
+	}
+}
+
+/**
  * Checks the cached theme's version against the GitHub registry.
  * If a newer version is available, re-downloads the theme in-place.
  * Fails silently (keeps cached version) on network errors.
+ *
+ * Skips the network call entirely when the previous check was within
+ * `VERSION_CHECK_TTL_MS` — see `isVersionCheckDue`.
  */
 async function checkAndUpdateCachedTheme(name: string, _cachedPath: string): Promise<void> {
+	if (!(await isVersionCheckDue(_cachedPath))) return;
+	await markVersionChecked(_cachedPath);
+
 	try {
-		const { downloadTheme } = await import("../../commands/ThemeCommand.js");
+		const { downloadTheme, githubAuthHeaders } = await import("../../commands/ThemeCommand.js");
 
 		// Read cached version from manifest.mjs
 		const manifestPath = join(_cachedPath, "manifest.mjs");
@@ -210,7 +266,7 @@ async function checkAndUpdateCachedTheme(name: string, _cachedPath: string): Pro
 
 		// Fetch registry to get latest version
 		const registryUrl = `https://raw.githubusercontent.com/jolliai/themes/main/registry.json`;
-		const res = await fetch(registryUrl);
+		const res = await fetch(registryUrl, { headers: githubAuthHeaders() });
 		if (!res.ok) return;
 		const registry = (await res.json()) as { themes: Array<{ name: string; version: string }> };
 		const entry = registry.themes.find((t) => t.name === name);

--- a/cli/vite.config.ts
+++ b/cli/vite.config.ts
@@ -25,7 +25,7 @@ export default defineConfig({
 			formats: ["es"],
 		},
 		rollupOptions: {
-			external: ["@anthropic-ai/sdk", "@mdx-js/mdx", "chokidar", "commander", "open", "yaml", /^node:.*/],
+			external: ["@anthropic-ai/sdk", "@mdx-js/mdx", "chokidar", "commander", "open", "tar", "yaml", /^node:.*/],
 			output: {
 				chunkFileNames: "[name].js",
 			},

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
 				"chokidar": "^4.0.0",
 				"commander": "^13.1.0",
 				"open": "^11.0.0",
+				"tar": "^7.5.15",
 				"yaml": "^2.6.1"
 			},
 			"bin": {
@@ -999,6 +1000,18 @@
 			"license": "BlueOak-1.0.0",
 			"engines": {
 				"node": ">=18"
+			}
+		},
+		"node_modules/@isaacs/fs-minipass": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+			"integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+			"license": "ISC",
+			"dependencies": {
+				"minipass": "^7.0.4"
+			},
+			"engines": {
+				"node": ">=18.0.0"
 			}
 		},
 		"node_modules/@jolli.ai/cli": {
@@ -5491,10 +5504,21 @@
 			"version": "7.1.3",
 			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
 			"integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
-			"dev": true,
 			"license": "BlueOak-1.0.0",
 			"engines": {
 				"node": ">=16 || 14 >=14.17"
+			}
+		},
+		"node_modules/minizlib": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+			"integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+			"license": "MIT",
+			"dependencies": {
+				"minipass": "^7.1.2"
+			},
+			"engines": {
+				"node": ">= 18"
 			}
 		},
 		"node_modules/mkdirp-classic": {
@@ -7033,6 +7057,22 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/tar": {
+			"version": "7.5.15",
+			"resolved": "https://registry.npmjs.org/tar/-/tar-7.5.15.tgz",
+			"integrity": "sha512-dzGK0boVlC4W5QFuQN1EFSl3bIDYsk7Tj40U6eIBnK2k/8ml7TZ5agbI5j5+qnoVcAA+rNtBml8SEiLxZpNqRQ==",
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"@isaacs/fs-minipass": "^4.0.0",
+				"chownr": "^3.0.0",
+				"minipass": "^7.1.2",
+				"minizlib": "^3.1.0",
+				"yallist": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
 		"node_modules/tar-fs": {
 			"version": "2.1.4",
 			"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
@@ -7063,6 +7103,24 @@
 			},
 			"engines": {
 				"node": ">=6"
+			}
+		},
+		"node_modules/tar/node_modules/chownr": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+			"integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/tar/node_modules/yallist": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+			"integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": ">=18"
 			}
 		},
 		"node_modules/terminal-link": {


### PR DESCRIPTION
## Summary
- Add site.json schema validation at startup to catch configuration errors early
- Cache theme version checks for 24 hours and fetch themes via codeload tarball with optional `GITHUB_TOKEN` auth
- Honor `expanded: false` on navigation articles and fix article rendering with nested children and root redirect
- Make `github.com/jolliai/themes` the sole theme source

## Test plan
- [ ] Verify `jolli start` validates site.json and reports schema errors
- [ ] Confirm theme version check is cached (second run within 24h skips fetch)
- [ ] Test theme download works with and without `GITHUB_TOKEN`
- [ ] Verify `expanded: false` collapses articles in sidebar
- [ ] Check nested navigation articles render correctly with root redirect