### PR TITLE
Fix regenerate reliability, coverage gaps, and code quality

### DIFF
--- a/cli/src/Cli.test.ts
+++ b/cli/src/Cli.test.ts
@@ -262,6 +262,7 @@ describe("CLI", () => {
 			}
 			const writes = vi.mocked(process.stdout.write).mock.calls.map((c) => String(c[0]));
 			const helpOutput = writes.join("");
+			expect(helpOutput).toContain("Usage:");
 			expect(helpOutput).toContain("auth");
 			// Default formatter does NOT render the Memory/Site section headers
 			// that formatGroupedHelp prepends for the root program.
@@ -3014,6 +3015,33 @@ describe("CLI", () => {
 			}
 		});
 
+		it("should error and set exit code when manual Jolli key fails validation", async () => {
+			const { saveConfigScoped } = await import("./core/SessionTracker.js");
+			vi.mocked(saveConfigScoped).mockClear();
+			// Choose "2" (manual), enter a key that parseJolliApiKey will reject (no sk-jol- prefix),
+			// then skip the Anthropic key prompt that follows.
+			mockUserInput("2", "bad-key", "");
+			mockExistsSync.mockReturnValue(false);
+			Object.defineProperty(process.stdin, "isTTY", { value: true, configurable: true });
+			const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+			const origKey = process.env.ANTHROPIC_API_KEY;
+			delete process.env.ANTHROPIC_API_KEY;
+
+			try {
+				await main(["enable"]);
+
+				const errorCalls = errorSpy.mock.calls.map((c) => String(c[0]));
+				expect(errorCalls.some((s) => s.includes("Error:"))).toBe(true);
+				expect(process.exitCode).toBe(1);
+				// validateJolliApiKey threw before saveConfigScoped could persist the key.
+				expect(saveConfigScoped).not.toHaveBeenCalled();
+			} finally {
+				Object.defineProperty(process.stdin, "isTTY", { value: undefined, configurable: true });
+				errorSpy.mockRestore();
+				if (origKey !== undefined) process.env.ANTHROPIC_API_KEY = origKey;
+			}
+		});
+
 		it("should show no-API-keys warning when manual key is skipped and no Anthropic key", async () => {
 			// Choose "2" (manual), skip Jolli API key, skip Anthropic key
 			mockUserInput("2", "", "");
@@ -3935,6 +3963,12 @@ describe("CLI", () => {
 			expect(output).toContain("Would remove 6 items");
 		});
 
+		it("uses singular item wording in dry-run when exactly one stale item exists", async () => {
+			const output = (await runClean(["clean", "--dry-run"], { staleSessions: 1 })).join("\n");
+			expect(output).toContain("Would remove 1 item.");
+			expect(output).not.toContain("Would remove 1 items");
+		});
+
 		it("does not surface orphan summaries in the output", async () => {
 			const childHash = "abc1111111111111111";
 			const rootHash = "def2222222222222222";
@@ -4460,6 +4494,51 @@ describe("CLI", () => {
 				authToken: undefined,
 				jolliApiKey: undefined,
 			});
+		});
+
+		it("omits the Anthropic-key reminder on logout when no Anthropic key is configured", async () => {
+			// No config.apiKey and no ANTHROPIC_API_KEY env var — the reminder
+			// block is suppressed so users without a fallback aren't told a
+			// non-existent key "will continue to work".
+			const { saveConfig, loadConfig } = await import("./core/SessionTracker.js");
+			vi.mocked(loadConfig).mockResolvedValue({});
+			vi.mocked(saveConfig).mockResolvedValue(undefined);
+			const origKey = process.env.ANTHROPIC_API_KEY;
+			delete process.env.ANTHROPIC_API_KEY;
+
+			try {
+				await main(["auth", "logout"]);
+
+				const calls = vi.mocked(console.log).mock.calls.map((c) => String(c[0]));
+				expect(calls.some((s) => s.includes("Logged out"))).toBe(true);
+				expect(calls.some((s) => s.includes("will continue to work"))).toBe(false);
+			} finally {
+				if (origKey !== undefined) process.env.ANTHROPIC_API_KEY = origKey;
+			}
+		});
+
+		it("shows the Anthropic-key reminder on logout when only ANTHROPIC_API_KEY env var is set", async () => {
+			// Env-var-only fallback: config.apiKey is unset but the dispatcher
+			// can still pick up ANTHROPIC_API_KEY from the environment, so the
+			// reminder must fire on that branch too.
+			const { saveConfig, loadConfig } = await import("./core/SessionTracker.js");
+			vi.mocked(loadConfig).mockResolvedValue({});
+			vi.mocked(saveConfig).mockResolvedValue(undefined);
+			const origKey = process.env.ANTHROPIC_API_KEY;
+			process.env.ANTHROPIC_API_KEY = "sk-ant-env";
+
+			try {
+				await main(["auth", "logout"]);
+
+				const calls = vi.mocked(console.log).mock.calls.map((c) => String(c[0]));
+				expect(calls.some((s) => s.includes("will continue to work"))).toBe(true);
+			} finally {
+				if (origKey === undefined) {
+					delete process.env.ANTHROPIC_API_KEY;
+				} else {
+					process.env.ANTHROPIC_API_KEY = origKey;
+				}
+			}
 		});
 
 		it("should call browserLogin on auth login", async () => {

--- a/cli/src/Cli.ts
+++ b/cli/src/Cli.ts
@@ -125,16 +125,12 @@ export async function main(args?: ReadonlyArray<string>): Promise<void> {
 		const lines: string[] = [];
 		lines.push(`Usage: ${helper.commandUsage(cmd)}`, "");
 
-		// All five conditionals below have unreachable empty arms when invoked
-		// on the root program (description is always set, --version/--help are
-		// always present, every registered command falls into Memory or Site).
-		// The empty arms exist for defensive parity with Commander's default
-		// formatter; they are wrapped in v8 ignore blocks so the dead branches
-		// don't drag down the file's branch coverage.
 		const description = helper.commandDescription(cmd);
-		/* v8 ignore start -- defensive empty arms; see comment above */
+		/* v8 ignore start -- root program always has a description (set via .description() above) */
 		if (description) lines.push(description, "");
+		/* v8 ignore stop */
 
+		/* v8 ignore start -- root program always has visible options (--help, --version) */
 		if (visibleOpts.length > 0) {
 			/* v8 ignore stop */
 			lines.push("Options:");
@@ -144,7 +140,7 @@ export async function main(args?: ReadonlyArray<string>): Promise<void> {
 			lines.push("");
 		}
 
-		/* v8 ignore start -- defensive empty arm */
+		/* v8 ignore start -- root program always registers Jolli Memory commands */
 		if (memoryCmds.length > 0) {
 			/* v8 ignore stop */
 			lines.push("Jolli Memory — Auto-document AI development sessions");
@@ -156,7 +152,7 @@ export async function main(args?: ReadonlyArray<string>): Promise<void> {
 			lines.push("");
 		}
 
-		/* v8 ignore start -- defensive empty arm */
+		/* v8 ignore start -- root program always registers Jolli Site commands */
 		if (siteCmds.length > 0) {
 			/* v8 ignore stop */
 			lines.push("Jolli Site — Generate a docs site from your content folder");
@@ -168,7 +164,7 @@ export async function main(args?: ReadonlyArray<string>): Promise<void> {
 			lines.push("");
 		}
 
-		/* v8 ignore start -- defensive empty arm: every registered command is Memory or Site today */
+		/* v8 ignore start -- root program always registers other commands (search, heal-folder, …) */
 		if (otherCmds.length > 0) {
 			/* v8 ignore stop */
 			lines.push("Other commands:");

--- a/cli/src/auth/Login.test.ts
+++ b/cli/src/auth/Login.test.ts
@@ -817,7 +817,7 @@ describe("Login", () => {
 		});
 
 		it("omits device_name when getDeviceLabel returns undefined (sanitized to empty)", async () => {
-			// Hostname like "中文" sanitizes to undefined — we must not send the
+			// A non-Latin hostname sanitizes to undefined — we must not send the
 			// param so the server falls back to its legacy keyName path.
 			mockLoadConfig.mockResolvedValue({});
 			mockGetDeviceLabel.mockReturnValue(undefined);

--- a/cli/src/auth/Login.ts
+++ b/cli/src/auth/Login.ts
@@ -26,8 +26,9 @@ import { getDeviceLabel } from "./DeviceLabel.js";
  * version in the standalone CLI bundle and falls back to `"dev"` under
  * tsx / tests, matching the convention in `core/LlmClient.ts`.
  */
-/* v8 ignore next -- compile-time ternary: always "dev" in tests, always __PKG_VERSION__ in build */
+/* v8 ignore start -- compile-time ternary: __PKG_VERSION__ is always defined in bundled builds */
 const CLIENT_VERSION = typeof __PKG_VERSION__ !== "undefined" ? __PKG_VERSION__ : "dev";
+/* v8 ignore stop */
 
 /**
  * Opens the browser to `${jolliUrl}/login` with a CLI callback URL, waits for

--- a/cli/src/commands/ConvertCommand.renamefail.test.ts
+++ b/cli/src/commands/ConvertCommand.renamefail.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Standalone test file covering two branches that need precise control over
+ * fs behavior to hit:
+ *
+ * 1. The cross-device fallback in `safeCopyOrMove` where `rename` fails and
+ *    we fall back to `copyFile + safeRemove` (ConvertCommand.ts lines 316-321).
+ * 2. The fallback in `processFile` where the normal copy/move stage's
+ *    `readFile` fails and we return after `safeCopyOrMove`
+ *    (the return statement at ConvertCommand.ts lines 276-277).
+ *
+ * Both paths are hard to reproduce against a real filesystem: one needs a
+ * cross-device link, and the other needs `readFile` to fail while `copyFile`
+ * still succeeds (chmod 000 breaks both at once). The most reliable approach
+ * is to mock `node:fs/promises`, injecting failure into specific calls while
+ * leaving the rest as the real implementation so setup keeps working.
+ *
+ * This lives in a separate file because `vi.mock("node:fs/promises")` is a
+ * module-level mock and would contaminate the many fs operations used in the
+ * main test suite.
+ */
+
+import { existsSync, mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import * as realFsPromises from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Command } from "commander";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// ─── mock readline to avoid prompt blocking ─────────────────────────────────
+
+const { mockCreateInterface } = vi.hoisted(() => ({
+	mockCreateInterface: vi.fn(),
+}));
+
+vi.mock("node:readline", () => ({
+	createInterface: mockCreateInterface,
+}));
+
+// ─── mock FrameworkDetector / DocusaurusConverter ───────────────────────────
+
+const { mockDetectFramework, mockPromptMigration } = vi.hoisted(() => ({
+	mockDetectFramework: vi.fn(),
+	mockPromptMigration: vi.fn(),
+}));
+
+vi.mock("../site/FrameworkDetector.js", () => ({
+	detectFramework: mockDetectFramework,
+	promptMigration: mockPromptMigration,
+}));
+
+const { mockConvertSidebar, mockExtractFavicon } = vi.hoisted(() => ({
+	mockConvertSidebar: vi.fn(),
+	mockExtractFavicon: vi.fn(),
+}));
+
+vi.mock("../site/DocusaurusConverter.js", () => ({
+	convertDocusaurusSidebar: mockConvertSidebar,
+	extractFaviconFromConfig: mockExtractFavicon,
+}));
+
+// ─── key mock: the first rename call throws, the rest keep the original impl
+
+vi.mock("node:fs/promises", async (importOriginal) => {
+	const original = await importOriginal<typeof import("node:fs/promises")>();
+	return {
+		...original,
+		rename: vi.fn(original.rename),
+		readFile: vi.fn(original.readFile),
+	};
+});
+
+describe("safeCopyOrMove falls back to copyFile + safeRemove when rename fails", () => {
+	let tempDir: string;
+	const originalIsTTY = process.stdin.isTTY;
+
+	beforeEach(() => {
+		tempDir = mkdtempSync(join(tmpdir(), "jolli-convert-renamefail-"));
+		vi.spyOn(console, "log").mockImplementation(() => {});
+		vi.spyOn(console, "error").mockImplementation(() => {});
+		mockDetectFramework.mockReturnValue({
+			name: "docusaurus",
+			configPath: join(tempDir, "docusaurus.config.ts"),
+			sidebarPath: join(tempDir, "sidebars.js"),
+		});
+		mockPromptMigration.mockResolvedValue(true);
+		// pathMappings remaps sql/ to pipelines/sql/, which triggers a file move
+		mockConvertSidebar.mockResolvedValue({
+			sidebar: {},
+			pathMappings: { sql: "pipelines/sql" },
+		});
+		mockExtractFavicon.mockReturnValue(undefined);
+		mockCreateInterface.mockReturnValue({
+			question: (_p: string, cb: (answer: string) => void) => cb("Site"),
+			close: vi.fn(),
+		});
+		process.stdin.isTTY = true;
+		vi.mocked(realFsPromises.rename).mockClear();
+		vi.mocked(realFsPromises.readFile).mockClear();
+	});
+
+	afterEach(() => {
+		rmSync(tempDir, { recursive: true, force: true });
+		process.stdin.isTTY = originalIsTTY;
+		vi.restoreAllMocks();
+		process.exitCode = undefined;
+	});
+
+	it("uses copyFile + safeRemove to complete the move when rename throws", async () => {
+		const { registerConvertCommand } = await import("./ConvertCommand.js");
+		const sourceDir = join(tempDir, "docs");
+		mkdirSync(join(sourceDir, "sql"), { recursive: true });
+		await realFsPromises.writeFile(join(sourceDir, "index.md"), "# Home\n", "utf-8");
+		// image files go through safeCopyOrMove; pathMappings moves this one to pipelines/sql/
+		const imgSrc = join(sourceDir, "sql", "diagram.png");
+		await realFsPromises.writeFile(imgSrc, "fake-png", "utf-8");
+
+		// Make the first rename fail (simulating a cross-device EXDEV); other calls
+		// use the real implementation — this exercises the fallback branch without
+		// breaking the subsequent backup / index.md rename logic.
+		const renameMock = vi.mocked(realFsPromises.rename);
+		let triggered = false;
+		renameMock.mockImplementation(async (src, dest) => {
+			const srcStr = src.toString();
+			if (!triggered && srcStr.endsWith("diagram.png")) {
+				triggered = true;
+				const err = new Error("EXDEV: cross-device link not permitted") as NodeJS.ErrnoException;
+				err.code = "EXDEV";
+				throw err;
+			}
+			// fall through to the real implementation
+			const original = await vi.importActual<typeof import("node:fs/promises")>("node:fs/promises");
+			return original.rename(src, dest);
+		});
+
+		const program = new Command();
+		registerConvertCommand(program);
+		// only in-place mode (no --output) exercises the rename branch
+		await program.parseAsync(["node", "test", "convert", sourceDir]);
+
+		// rename was triggered and failed, so we fell back to copyFile + safeRemove;
+		// diagram.png should end up in pipelines/sql/ and disappear from its original spot.
+		expect(triggered).toBe(true);
+		expect(existsSync(join(sourceDir, "pipelines", "sql", "diagram.png"))).toBe(true);
+		expect(existsSync(imgSrc)).toBe(false);
+	});
+
+	// ── readFile fails but safeCopyOrMove succeeds (covers the return at lines 276-277)
+
+	it("falls back to safeCopyOrMove and returns when markdown readFile fails in normal copy/move", async () => {
+		const { registerConvertCommand } = await import("./ConvertCommand.js");
+		const sourceDir = join(tempDir, "docs");
+		mkdirSync(join(sourceDir, "sql"), { recursive: true });
+		await realFsPromises.writeFile(join(sourceDir, "index.md"), "# Home\n", "utf-8");
+		// pathMappings remaps this file path to pipelines/sql/query.md
+		const targetMd = join(sourceDir, "sql", "query.md");
+		await realFsPromises.writeFile(targetMd, "# Query\n", "utf-8");
+
+		// Make readFile throw for query.md while keeping copyFile working.
+		const readFileMock = vi.mocked(realFsPromises.readFile);
+		const original = await vi.importActual<typeof import("node:fs/promises")>("node:fs/promises");
+		readFileMock.mockImplementation(async (path, options) => {
+			const pathStr = path.toString();
+			if (pathStr.endsWith("sql/query.md")) {
+				const err = new Error("simulated EACCES") as NodeJS.ErrnoException;
+				err.code = "EACCES";
+				throw err;
+			}
+			return original.readFile(path, options);
+		});
+
+		const outDir = join(tempDir, "output");
+
+		const program = new Command();
+		registerConvertCommand(program);
+		await program.parseAsync(["node", "test", "convert", sourceDir, "--output", outDir]);
+
+		// safeCopyOrMove moved the file via copyFile; no content rewrite but the file exists
+		expect(existsSync(join(outDir, "pipelines", "sql", "query.md"))).toBe(true);
+	});
+});

--- a/cli/src/commands/ConvertCommand.test.ts
+++ b/cli/src/commands/ConvertCommand.test.ts
@@ -50,6 +50,23 @@ vi.mock("../site/DocusaurusConverter.js", () => ({
 	extractFaviconFromConfig: mockExtractFavicon,
 }));
 
+// ─── Partial mock of node:fs/promises to control rename and readFile ────────
+// Default behavior forwards to the real implementation; individual cases use
+// mockRejectedValueOnce / mockImplementationOnce to trigger branches
+// (cross-device link, unreadable file, etc.).
+
+const { mockRename, mockReadFile } = vi.hoisted(() => ({
+	mockRename: vi.fn(),
+	mockReadFile: vi.fn(),
+}));
+
+vi.mock("node:fs/promises", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("node:fs/promises")>();
+	mockRename.mockImplementation((src: string, dest: string) => actual.rename(src, dest));
+	mockReadFile.mockImplementation((...args: Parameters<typeof actual.readFile>) => actual.readFile(...args));
+	return { ...actual, rename: mockRename, readFile: mockReadFile };
+});
+
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
 async function makeTempDir(): Promise<string> {
@@ -66,6 +83,22 @@ describe("ConvertCommand", () => {
 		logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
 		vi.spyOn(console, "error").mockImplementation(() => {});
 		vi.spyOn(console, "warn").mockImplementation(() => {});
+		// Clear call history accumulated by hoisted mocks in the previous case so
+		mockCreateInterface.mockClear();
+		mockDetectFramework.mockReset();
+		mockPromptMigration.mockReset();
+		mockConvertSidebar.mockReset();
+		mockExtractFavicon.mockReset();
+		// mockRename / mockReadFile only have their call history cleared; rebind
+		// to the original implementation to prevent the previous case's
+		// mockImplementation from leaking.
+		mockRename.mockClear();
+		mockReadFile.mockClear();
+		const fspActual = await vi.importActual<typeof import("node:fs/promises")>("node:fs/promises");
+		mockRename.mockImplementation((src: string, dest: string) => fspActual.rename(src, dest));
+		mockReadFile.mockImplementation((...args: Parameters<typeof fspActual.readFile>) =>
+			fspActual.readFile(...args),
+		);
 		mockDetectFramework.mockReturnValue(null);
 		mockPromptMigration.mockResolvedValue(false);
 		mockConvertSidebar.mockResolvedValue({ sidebar: {}, pathMappings: {} });
@@ -601,5 +634,490 @@ describe("ConvertCommand", () => {
 		// Files should still be in place
 		expect(existsSync(join(sourceDir, "index.md"))).toBe(true);
 		expect(existsSync(join(sourceDir, "guides", "intro.md"))).toBe(true);
+	});
+
+	// ── Error capture: sets exitCode=1 when convertFolder throws (covers lines 55-56) ──
+
+	it("captures errors thrown by convertFolder and sets exit code to 1", async () => {
+		const { registerConvertCommand } = await import("./ConvertCommand.js");
+		mockDetectFramework.mockReturnValue({
+			name: "docusaurus",
+			configPath: join(tempDir, "docusaurus.config.ts"),
+			sidebarPath: join(tempDir, "sidebars.js"),
+		});
+		mockPromptMigration.mockResolvedValue(true);
+		// Make sidebar conversion throw to trigger the action's catch branch
+		mockConvertSidebar.mockRejectedValue(new Error("sidebar conversion failed"));
+
+		const sourceDir = join(tempDir, "docs");
+		await mkdir(sourceDir, { recursive: true });
+		await writeFile(join(sourceDir, "index.md"), "# Home\n", "utf-8");
+		const outDir = join(tempDir, "output");
+
+		const program = new Command();
+		registerConvertCommand(program);
+		await program.parseAsync(["node", "test", "convert", sourceDir, "--output", outDir]);
+
+		expect(process.exitCode).toBe(1);
+	});
+
+	// ── slug:/ + sidebar key rewrite (covers lines 130-132) ─────────────────
+
+	it("rewrites the sidebar key when a slug:/ file is renamed to index", async () => {
+		const { registerConvertCommand } = await import("./ConvertCommand.js");
+		mockDetectFramework.mockReturnValue({
+			name: "docusaurus",
+			configPath: join(tempDir, "docusaurus.config.ts"),
+			sidebarPath: join(tempDir, "sidebars.js"),
+		});
+		mockPromptMigration.mockResolvedValue(true);
+		// The sidebar contains the "intro" key that corresponds to the slug:/ file
+		mockConvertSidebar.mockResolvedValue({
+			sidebar: { "/": { intro: "Introduction", guides: "Guides" } },
+			pathMappings: {},
+		});
+
+		const sourceDir = join(tempDir, "docs");
+		await mkdir(sourceDir, { recursive: true });
+		await writeFile(join(sourceDir, "intro.md"), "---\nslug: /\n---\n# Intro\n", "utf-8");
+		const outDir = join(tempDir, "output");
+
+		const program = new Command();
+		registerConvertCommand(program);
+		await program.parseAsync(["node", "test", "convert", sourceDir, "--output", outDir]);
+
+		const siteJson = JSON.parse(await readFile(join(outDir, "site.json"), "utf-8"));
+		// The original "intro" key should be replaced by "index", label still "Introduction"
+		expect(siteJson.sidebar["/"].intro).toBeUndefined();
+		expect(siteJson.sidebar["/"].index).toBe("Introduction");
+	});
+
+	// ── Silent return when readdir fails (covers line 183) ──────────────────
+
+	it("returns quietly without throwing when the source path is not a directory", async () => {
+		const { registerConvertCommand } = await import("./ConvertCommand.js");
+		// Point source at a file rather than a directory: readdir will throw.
+		const sourceFile = join(tempDir, "not-a-dir.md");
+		await writeFile(sourceFile, "# Not a directory\n", "utf-8");
+		const outDir = join(tempDir, "output");
+
+		const program = new Command();
+		registerConvertCommand(program);
+		await program.parseAsync(["node", "test", "convert", sourceFile, "--output", outDir]);
+
+		// Should not throw; site.json is still written to outDir (mkdir already ran)
+		expect(existsSync(join(outDir, "site.json"))).toBe(true);
+	});
+
+	// ── Skip a single entry when stat fails (covers line 194) ───────────────
+
+	it("skips entries whose stat fails (e.g. broken symlinks)", async () => {
+		const { registerConvertCommand } = await import("./ConvertCommand.js");
+		const { symlink } = await import("node:fs/promises");
+		const sourceDir = join(tempDir, "docs");
+		await mkdir(sourceDir, { recursive: true });
+		await writeFile(join(sourceDir, "index.md"), "# Home\n", "utf-8");
+		// Create a symlink to a missing path: stat (not lstat) will fail.
+		await symlink(join(tempDir, "does-not-exist"), join(sourceDir, "broken-link.md"));
+		const outDir = join(tempDir, "output");
+
+		const program = new Command();
+		registerConvertCommand(program);
+		await program.parseAsync(["node", "test", "convert", sourceDir, "--output", outDir]);
+
+		// Normal files should still convert successfully
+		expect(existsSync(join(outDir, "index.md"))).toBe(true);
+	});
+
+	// ── Skip .mdx when readFile fails (covers line 243) ─────────────────────
+
+	it("skips .mdx files that cannot be read", async () => {
+		const { registerConvertCommand } = await import("./ConvertCommand.js");
+		const { chmod } = await import("node:fs/promises");
+		const sourceDir = join(tempDir, "docs");
+		await mkdir(sourceDir, { recursive: true });
+		await writeFile(join(sourceDir, "index.md"), "# Home\n", "utf-8");
+		const mdxPath = join(sourceDir, "page.mdx");
+		await writeFile(mdxPath, "import X from 'whatever'\n# X\n", "utf-8");
+		// Make the mdx file unreadable so readFile fails
+		await chmod(mdxPath, 0o000);
+		const outDir = join(tempDir, "output");
+
+		const program = new Command();
+		registerConvertCommand(program);
+		await program.parseAsync(["node", "test", "convert", sourceDir, "--output", outDir]);
+
+		// Restore permissions so afterEach can clean up
+		await chmod(mdxPath, 0o644);
+		// Normal files should still succeed
+		expect(existsSync(join(outDir, "index.md"))).toBe(true);
+		// readFile failed and returned early, so page.md should not exist
+		expect(existsSync(join(outDir, "page.md"))).toBe(false);
+	});
+
+	// ── promptMigration=true but framework is not docusaurus (covers the else branch at line 76)
+
+	it("does not call sidebar conversion when a non-docusaurus framework is detected", async () => {
+		const { registerConvertCommand } = await import("./ConvertCommand.js");
+		// User agrees to migration, but the framework is not docusaurus
+		mockDetectFramework.mockReturnValue({
+			name: "mkdocs",
+			configPath: join(tempDir, "mkdocs.yml"),
+			// intentionally omit sidebarPath
+		});
+		mockPromptMigration.mockResolvedValue(true);
+
+		const sourceDir = join(tempDir, "docs");
+		await mkdir(sourceDir, { recursive: true });
+		await writeFile(join(sourceDir, "index.md"), "# Home\n", "utf-8");
+		const outDir = join(tempDir, "output");
+
+		const program = new Command();
+		registerConvertCommand(program);
+		await program.parseAsync(["node", "test", "convert", sourceDir, "--output", outDir]);
+
+		// convertDocusaurusSidebar was not called, but conversion still completes
+		expect(mockConvertSidebar).not.toHaveBeenCalled();
+		expect(existsSync(join(outDir, "site.json"))).toBe(true);
+	});
+
+	// ── favicon configured but path does not exist (covers the else branch at line 120)
+
+	it("skips the copy when conversion.favicon points to a missing path", async () => {
+		const { registerConvertCommand } = await import("./ConvertCommand.js");
+		mockDetectFramework.mockReturnValue({
+			name: "docusaurus",
+			configPath: join(tempDir, "docusaurus.config.ts"),
+			sidebarPath: join(tempDir, "sidebars.js"),
+		});
+		mockPromptMigration.mockResolvedValue(true);
+		mockConvertSidebar.mockResolvedValue({ sidebar: {}, pathMappings: {} });
+		// favicon points to a non-existent file
+		mockExtractFavicon.mockReturnValue(join(tempDir, "missing-favicon.ico"));
+
+		const sourceDir = join(tempDir, "docs");
+		await mkdir(sourceDir, { recursive: true });
+		await writeFile(join(sourceDir, "index.md"), "# Home\n", "utf-8");
+		const outDir = join(tempDir, "output");
+
+		const program = new Command();
+		registerConvertCommand(program);
+		await program.parseAsync(["node", "test", "convert", sourceDir, "--output", outDir]);
+
+		// favicon was not copied, but site.json still records the favicon field
+		expect(existsSync(join(outDir, "favicon.ico"))).toBe(false);
+		const siteJson = JSON.parse(await readFile(join(outDir, "site.json"), "utf-8"));
+		expect(siteJson.favicon).toBe("favicon.ico");
+	});
+
+	// ── .mdx where all imports are safe (covers the else branch of hasIncompatibleImports)
+
+	it("copies .mdx as-is without downgrading when every import uses a safe prefix", async () => {
+		const { registerConvertCommand } = await import("./ConvertCommand.js");
+		const sourceDir = join(tempDir, "docs");
+		await mkdir(sourceDir, { recursive: true });
+		await writeFile(join(sourceDir, "index.md"), "# Home\n", "utf-8");
+		// Only references nextra (which is in the safe-prefix allowlist)
+		const mdxContent = "import { Callout } from 'nextra/components'\n\n# Safe\n";
+		await writeFile(join(sourceDir, "safe.mdx"), mdxContent, "utf-8");
+		const outDir = join(tempDir, "output");
+
+		const program = new Command();
+		registerConvertCommand(program);
+		await program.parseAsync(["node", "test", "convert", sourceDir, "--output", outDir]);
+
+		// No downgrade needed, so .mdx stays .mdx
+		expect(existsSync(join(outDir, "safe.mdx"))).toBe(true);
+		expect(existsSync(join(outDir, "safe.md"))).toBe(false);
+	});
+
+	// ── .mdx with both unsafe and safe imports, kept as .mdx after strip (covers downgraded=false)
+
+	it("keeps the .mdx extension when safe JSX remains after stripping", async () => {
+		const { registerConvertCommand } = await import("./ConvertCommand.js");
+		const sourceDir = join(tempDir, "docs");
+		await mkdir(sourceDir, { recursive: true });
+		await writeFile(join(sourceDir, "index.md"), "# Home\n", "utf-8");
+		// Contains both unsafe (@theme/Tabs) and safe (nextra/components) imports —
+		// hasIncompatibleImports=true, but the nextra import survives the strip.
+		const mdxContent =
+			"import Tabs from '@theme/Tabs'\nimport { Callout } from 'nextra/components'\n\n# Mixed\n\n<Callout>safe</Callout>\n";
+		await writeFile(join(sourceDir, "mixed.mdx"), mdxContent, "utf-8");
+		const outDir = join(tempDir, "output");
+
+		const program = new Command();
+		registerConvertCommand(program);
+		await program.parseAsync(["node", "test", "convert", sourceDir, "--output", outDir]);
+
+		// downgraded=false keeps the .mdx extension
+		expect(existsSync(join(outDir, "mixed.mdx"))).toBe(true);
+		expect(existsSync(join(outDir, "mixed.md"))).toBe(false);
+	});
+
+	// ── in-place + pathMappings changes the .md path (covers the if branch at line 281)
+
+	it("removes the original file when pathMappings changes a markdown path during in-place conversion", async () => {
+		const { registerConvertCommand } = await import("./ConvertCommand.js");
+		mockDetectFramework.mockReturnValue({
+			name: "docusaurus",
+			configPath: join(tempDir, "docusaurus.config.ts"),
+			sidebarPath: join(tempDir, "sidebars.js"),
+		});
+		mockPromptMigration.mockResolvedValue(true);
+		mockConvertSidebar.mockResolvedValue({
+			sidebar: {},
+			pathMappings: { sql: "pipelines/sql" },
+		});
+
+		const sourceDir = join(tempDir, "docs");
+		await mkdir(join(sourceDir, "sql"), { recursive: true });
+		await writeFile(join(sourceDir, "index.md"), "# Home\n", "utf-8");
+		await writeFile(join(sourceDir, "sql", "query.md"), "# Query\n", "utf-8");
+
+		const program = new Command();
+		registerConvertCommand(program);
+		// in-place mode (no --output)
+		await program.parseAsync(["node", "test", "convert", sourceDir]);
+
+		// The file is at the new path and the old path is cleaned up
+		expect(existsSync(join(sourceDir, "pipelines", "sql", "query.md"))).toBe(true);
+		expect(existsSync(join(sourceDir, "sql", "query.md"))).toBe(false);
+	});
+
+	// ── in-place + no pathMappings + image: safeCopyOrMove takes the src===dest early return
+
+	it("skips rename when an image file's path is unchanged during in-place conversion", async () => {
+		const { registerConvertCommand } = await import("./ConvertCommand.js");
+		const sourceDir = join(tempDir, "docs");
+		await mkdir(sourceDir, { recursive: true });
+		await writeFile(join(sourceDir, "index.md"), "# Home\n", "utf-8");
+		await writeFile(join(sourceDir, "logo.png"), "fake-png", "utf-8");
+
+		const program = new Command();
+		registerConvertCommand(program);
+		// in-place + default empty pathMappings → src === dest, safeCopyOrMove returns early
+		await program.parseAsync(["node", "test", "convert", sourceDir]);
+
+		// File stays in place
+		expect(existsSync(join(sourceDir, "logo.png"))).toBe(true);
+	});
+
+	// ── Falls back to process.cwd() when no source argument is given (covers ?? right side at line 42)
+
+	it("uses process.cwd() as the source directory when no source argument is provided", async () => {
+		const { registerConvertCommand } = await import("./ConvertCommand.js");
+		const sourceDir = join(tempDir, "docs");
+		await mkdir(sourceDir, { recursive: true });
+		await writeFile(join(sourceDir, "index.md"), "# Home\n", "utf-8");
+		const outDir = join(tempDir, "output");
+		// Temporarily switch cwd to sourceDir to simulate running `jolli convert` from the source dir
+		const originalCwd = process.cwd();
+		process.chdir(sourceDir);
+
+		try {
+			const program = new Command();
+			registerConvertCommand(program);
+			// No source argument; source comes from process.cwd()
+			await program.parseAsync(["node", "test", "convert", "--output", outDir]);
+			expect(existsSync(join(outDir, "site.json"))).toBe(true);
+			expect(existsSync(join(outDir, "index.md"))).toBe(true);
+		} finally {
+			process.chdir(originalCwd);
+		}
+	});
+
+	// ── catch a non-Error throw, convert via String(err) (covers the right side of the ternary at line 55)
+
+	it("uses String(err) to set the exit code when a non-Error value is thrown", async () => {
+		const { registerConvertCommand } = await import("./ConvertCommand.js");
+		mockDetectFramework.mockReturnValue({
+			name: "docusaurus",
+			configPath: join(tempDir, "docusaurus.config.ts"),
+			sidebarPath: join(tempDir, "sidebars.js"),
+		});
+		mockPromptMigration.mockResolvedValue(true);
+		// Throw a non-Error to force the String(err) branch
+		mockConvertSidebar.mockRejectedValue("not-an-error-string");
+
+		const sourceDir = join(tempDir, "docs");
+		await mkdir(sourceDir, { recursive: true });
+		await writeFile(join(sourceDir, "index.md"), "# Home\n", "utf-8");
+		const outDir = join(tempDir, "output");
+
+		const program = new Command();
+		registerConvertCommand(program);
+		await program.parseAsync(["node", "test", "convert", sourceDir, "--output", outDir]);
+
+		expect(process.exitCode).toBe(1);
+	});
+
+	// ── dev command printed without a path when targetRoot === process.cwd() (covers right side of ternary at line 166)
+
+	it("omits the directory suffix from the summary when targetRoot equals process.cwd()", async () => {
+		const { registerConvertCommand } = await import("./ConvertCommand.js");
+		const sourceDir = join(tempDir, "docs");
+		await mkdir(sourceDir, { recursive: true });
+		await writeFile(join(sourceDir, "index.md"), "# Home\n", "utf-8");
+		// Switch cwd to sourceDir so that in-place makes targetRoot === process.cwd()
+		const originalCwd = process.cwd();
+		process.chdir(sourceDir);
+
+		try {
+			const program = new Command();
+			registerConvertCommand(program);
+			// in-place (no --output), source is cwd
+			await program.parseAsync(["node", "test", "convert"]);
+
+			const output = logSpy.mock.calls.map((c: unknown[]) => (c as string[]).join(" ")).join("\n");
+			// The hint reads "Run `jolli dev`" without a directory suffix
+			expect(output).toContain("Run `jolli dev`");
+		} finally {
+			process.chdir(originalCwd);
+		}
+	});
+
+	// ── stat succeeds but is neither dir nor file (covers the false branch of the if at line 199)
+
+	it("skips special entries that are neither directories nor files (FIFO)", async () => {
+		const { registerConvertCommand } = await import("./ConvertCommand.js");
+		const { execFileSync } = await import("node:child_process");
+		const sourceDir = join(tempDir, "docs");
+		await mkdir(sourceDir, { recursive: true });
+		await writeFile(join(sourceDir, "index.md"), "# Home\n", "utf-8");
+		// Use mkfifo to create a named pipe: stat does not throw, but isFile/isDirectory are both false
+		const fifoPath = join(sourceDir, "pipe.fifo");
+		execFileSync("mkfifo", [fifoPath]);
+		const outDir = join(tempDir, "output");
+
+		const program = new Command();
+		registerConvertCommand(program);
+		await program.parseAsync(["node", "test", "convert", sourceDir, "--output", outDir]);
+
+		// Normal files still convert successfully; the FIFO is silently skipped
+		expect(existsSync(join(outDir, "index.md"))).toBe(true);
+		expect(existsSync(join(outDir, "pipe.fifo"))).toBe(false);
+	});
+
+	// ── Falls back to defaultTitle when the user enters an empty string at the prompt (covers || right side at line 307)
+
+	it("uses the default title when the interactive prompt receives an empty string", async () => {
+		const { registerConvertCommand } = await import("./ConvertCommand.js");
+		// Simulate the user just hitting return (empty input)
+		mockPrompt("   ");
+		const sourceDir = join(tempDir, "my-docs");
+		await mkdir(sourceDir, { recursive: true });
+		await writeFile(join(sourceDir, "index.md"), "# Home\n", "utf-8");
+		const outDir = join(tempDir, "output");
+
+		const program = new Command();
+		registerConvertCommand(program);
+		await program.parseAsync(["node", "test", "convert", sourceDir, "--output", outDir]);
+
+		const siteJson = JSON.parse(await readFile(join(outDir, "site.json"), "utf-8"));
+		// Empty after trim → use defaultTitle "My Docs"
+		expect(siteJson.title).toBe("My Docs");
+	});
+
+	// ── in-place + pathMappings + markdown readFile fails (covers lines 276-277)
+
+	it("falls back to safeCopyOrMove when markdown readFile fails in in-place mode", async () => {
+		const { registerConvertCommand } = await import("./ConvertCommand.js");
+		mockDetectFramework.mockReturnValue({
+			name: "docusaurus",
+			configPath: join(tempDir, "docusaurus.config.ts"),
+			sidebarPath: join(tempDir, "sidebars.js"),
+		});
+		mockPromptMigration.mockResolvedValue(true);
+		mockConvertSidebar.mockResolvedValue({
+			sidebar: {},
+			pathMappings: { sql: "pipelines/sql" },
+		});
+
+		const sourceDir = join(tempDir, "docs");
+		await mkdir(join(sourceDir, "sql"), { recursive: true });
+		await writeFile(join(sourceDir, "index.md"), "# Home\n", "utf-8");
+		const targetMd = join(sourceDir, "sql", "query.md");
+		await writeFile(targetMd, "# Query\n", "utf-8");
+		// Throw EACCES only for query.md's readFile; forward other files normally.
+		// chmod would also break the upfront cp backup, so we must intercept precisely with a mock.
+		const fspActual = await vi.importActual<typeof import("node:fs/promises")>("node:fs/promises");
+		mockReadFile.mockImplementation(async (path: unknown, ...rest: unknown[]) => {
+			if (typeof path === "string" && path === targetMd) {
+				throw Object.assign(new Error("EACCES"), { code: "EACCES" });
+			}
+			return fspActual.readFile(path as Parameters<typeof fspActual.readFile>[0], ...(rest as [])) as unknown as
+				| string
+				| Buffer;
+		});
+
+		const program = new Command();
+		registerConvertCommand(program);
+		// in-place mode lets the catch path use safeCopyOrMove
+		await program.parseAsync(["node", "test", "convert", sourceDir]);
+
+		// File ends up at the new path via safeCopyOrMove, original is removed
+		expect(existsSync(join(sourceDir, "pipelines", "sql", "query.md"))).toBe(true);
+		expect(existsSync(targetMd)).toBe(false);
+	});
+
+	// ── in-place + image + pathMappings: rename succeeds (covers the try in the safeCopyOrMove inPlace branch)
+
+	it("uses rename when in-place mode relocates an image via pathMappings", async () => {
+		const { registerConvertCommand } = await import("./ConvertCommand.js");
+		mockDetectFramework.mockReturnValue({
+			name: "docusaurus",
+			configPath: join(tempDir, "docusaurus.config.ts"),
+			sidebarPath: join(tempDir, "sidebars.js"),
+		});
+		mockPromptMigration.mockResolvedValue(true);
+		mockConvertSidebar.mockResolvedValue({
+			sidebar: {},
+			pathMappings: { img: "assets/img" },
+		});
+
+		const sourceDir = join(tempDir, "docs");
+		await mkdir(join(sourceDir, "img"), { recursive: true });
+		await writeFile(join(sourceDir, "index.md"), "# Home\n", "utf-8");
+		await writeFile(join(sourceDir, "img", "logo.png"), "png-data", "utf-8");
+
+		const program = new Command();
+		registerConvertCommand(program);
+		// in-place mode → safeCopyOrMove takes the inPlace=true branch's rename
+		await program.parseAsync(["node", "test", "convert", sourceDir]);
+
+		// rename succeeded: new path exists, old path gone
+		expect(existsSync(join(sourceDir, "assets", "img", "logo.png"))).toBe(true);
+		expect(existsSync(join(sourceDir, "img", "logo.png"))).toBe(false);
+	});
+
+	// ── in-place + image + rename throws: takes the cross-device fallback (covers the catch at 319-321)
+
+	it("falls back to copyFile + safeRemove when rename throws in in-place mode", async () => {
+		const { registerConvertCommand } = await import("./ConvertCommand.js");
+		mockDetectFramework.mockReturnValue({
+			name: "docusaurus",
+			configPath: join(tempDir, "docusaurus.config.ts"),
+			sidebarPath: join(tempDir, "sidebars.js"),
+		});
+		mockPromptMigration.mockResolvedValue(true);
+		mockConvertSidebar.mockResolvedValue({
+			sidebar: {},
+			pathMappings: { img: "assets/img" },
+		});
+		// Make rename throw EXDEV to simulate a cross-device move
+		mockRename.mockRejectedValueOnce(Object.assign(new Error("EXDEV"), { code: "EXDEV" }));
+
+		const sourceDir = join(tempDir, "docs");
+		await mkdir(join(sourceDir, "img"), { recursive: true });
+		await writeFile(join(sourceDir, "index.md"), "# Home\n", "utf-8");
+		await writeFile(join(sourceDir, "img", "logo.png"), "png-data", "utf-8");
+
+		const program = new Command();
+		registerConvertCommand(program);
+		await program.parseAsync(["node", "test", "convert", sourceDir]);
+
+		// fallback: copyFile writes to the new path, safeRemove deletes the old one
+		expect(existsSync(join(sourceDir, "assets", "img", "logo.png"))).toBe(true);
+		expect(existsSync(join(sourceDir, "img", "logo.png"))).toBe(false);
 	});
 });

--- a/cli/src/commands/ExportCommand.test.ts
+++ b/cli/src/commands/ExportCommand.test.ts
@@ -1,6 +1,9 @@
+import { mkdtemp, readdir, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { Command } from "commander";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { registerExportCommand } from "./ExportCommand.js";
+import { registerExportCommand, registerExportPromptCommand } from "./ExportCommand.js";
 
 vi.mock("../core/SummaryExporter.js", () => ({
 	exportSummaries: vi.fn(),
@@ -26,6 +29,13 @@ function makeProgram(): Command {
 	return program;
 }
 
+function makePromptProgram(): Command {
+	const program = new Command();
+	program.exitOverride();
+	registerExportPromptCommand(program);
+	return program;
+}
+
 async function runCommand(args: string[]): Promise<{ stdout: string; stderr: string }> {
 	let stdout = "";
 	let stderr = "";
@@ -46,7 +56,34 @@ async function runCommand(args: string[]): Promise<{ stdout: string; stderr: str
 	return { stdout, stderr };
 }
 
-describe("registerExportCommand — ambiguous --commit handling", () => {
+async function runPromptCommand(args: string[]): Promise<{ stdout: string; stderr: string; written: string }> {
+	let stdout = "";
+	let stderr = "";
+	let written = "";
+	const origLog = console.log;
+	const origErr = console.error;
+	const origWrite = process.stdout.write.bind(process.stdout);
+	console.log = (msg: string) => {
+		stdout += `${msg}\n`;
+	};
+	console.error = (msg: string) => {
+		stderr += `${msg}\n`;
+	};
+	process.stdout.write = ((chunk: string | Uint8Array) => {
+		written += typeof chunk === "string" ? chunk : Buffer.from(chunk).toString();
+		return true;
+	}) as typeof process.stdout.write;
+	try {
+		await makePromptProgram().parseAsync(["node", "jolli", "export-prompt", ...args]);
+	} finally {
+		console.log = origLog;
+		console.error = origErr;
+		process.stdout.write = origWrite;
+	}
+	return { stdout, stderr, written };
+}
+
+describe("registerExportCommand", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 	});
@@ -87,5 +124,287 @@ describe("registerExportCommand — ambiguous --commit handling", () => {
 		await expect(runCommand(["--commit", "abc12345", "--cwd", "/tmp/jolli-export-test"])).rejects.toThrow(
 			"disk full",
 		);
+	});
+
+	it("prints a friendly note and exits cleanly when there are no summaries", async () => {
+		mockExport.mockResolvedValueOnce({
+			outputDir: "/tmp/empty-out",
+			filesWritten: 0,
+			filesSkipped: 0,
+			filesErrored: 0,
+			totalSummaries: 0,
+			indexPath: "/tmp/empty-out/index.md",
+		});
+
+		const { stdout } = await runCommand(["--cwd", "/tmp/jolli-export-test"]);
+
+		expect(stdout).toContain("No summaries found to export.");
+		expect(process.exitCode).toBeUndefined();
+	});
+
+	it("prints success summary on a successful export", async () => {
+		mockExport.mockResolvedValueOnce({
+			outputDir: "/tmp/ok-out",
+			filesWritten: 3,
+			filesSkipped: 1,
+			filesErrored: 0,
+			totalSummaries: 4,
+			indexPath: "/tmp/ok-out/index.md",
+		});
+
+		const { stdout } = await runCommand(["--cwd", "/tmp/jolli-export-test"]);
+
+		expect(stdout).toContain("Exported to /tmp/ok-out");
+		expect(stdout).toContain("New: 3");
+		expect(stdout).toContain("Skipped: 1");
+		expect(stdout).toContain("Total: 4");
+		expect(stdout).toContain("Index: /tmp/ok-out/index.md");
+		expect(stdout).not.toContain("Errored:");
+	});
+
+	it("includes 'Errored: N' segment when some files failed but others wrote", async () => {
+		// Partial-failure path: keeps the success summary but flags the errored count.
+		mockExport.mockResolvedValueOnce({
+			outputDir: "/tmp/partial-out",
+			filesWritten: 2,
+			filesSkipped: 0,
+			filesErrored: 1,
+			totalSummaries: 3,
+			indexPath: "/tmp/partial-out/index.md",
+		});
+
+		const { stdout } = await runCommand(["--cwd", "/tmp/jolli-export-test"]);
+
+		expect(stdout).toContain("Errored: 1");
+		expect(process.exitCode).toBeUndefined();
+	});
+
+	it("exits non-zero with an error message when every file failed", async () => {
+		// Total-failure path: nothing landed on disk so we surface to stderr
+		// with a non-zero exit code that scripts can detect.
+		mockExport.mockResolvedValueOnce({
+			outputDir: "/tmp/fail-out",
+			filesWritten: 0,
+			filesSkipped: 2,
+			filesErrored: 5,
+			totalSummaries: 7,
+			indexPath: "/tmp/fail-out/index.md",
+		});
+
+		const { stdout, stderr } = await runCommand(["--cwd", "/tmp/jolli-export-test"]);
+
+		expect(stderr).toContain("Export failed");
+		expect(stderr).toContain("5 failed");
+		expect(stderr).toContain("2 already on disk");
+		expect(stdout).not.toContain("Exported to");
+		expect(process.exitCode).toBe(1);
+	});
+
+	it("forwards --commit and --project to exportSummaries", async () => {
+		mockExport.mockResolvedValueOnce({
+			outputDir: "/tmp/p-out",
+			filesWritten: 1,
+			filesSkipped: 0,
+			filesErrored: 0,
+			totalSummaries: 1,
+			indexPath: "/tmp/p-out/index.md",
+		});
+
+		await runCommand(["--commit", "deadbeef", "--project", "demo", "--cwd", "/tmp/jolli-export-test"]);
+
+		expect(mockExport).toHaveBeenCalledWith({
+			commit: "deadbeef",
+			project: "demo",
+			cwd: "/tmp/jolli-export-test",
+		});
+	});
+});
+
+describe("registerExportPromptCommand", () => {
+	let tmpDir: string;
+
+	beforeEach(async () => {
+		vi.clearAllMocks();
+		vi.unstubAllGlobals();
+		tmpDir = await mkdtemp(join(tmpdir(), "jolli-export-prompt-"));
+	});
+
+	afterEach(async () => {
+		process.exitCode = undefined;
+		vi.unstubAllGlobals();
+		await rm(tmpDir, { recursive: true, force: true });
+	});
+
+	it("prints usage guidance when no flags are given", async () => {
+		const { stdout } = await runPromptCommand([]);
+
+		expect(stdout).toContain("--action");
+		expect(stdout).toContain("--output");
+		expect(stdout).toContain("Available actions:");
+	});
+
+	it("prints a single template to stdout for a known --action", async () => {
+		const { written } = await runPromptCommand(["--action", "translate"]);
+
+		expect(written).toContain("Translate the following Markdown");
+	});
+
+	it("errors and exits non-zero for unknown --action without --output", async () => {
+		const { stderr } = await runPromptCommand(["--action", "no-such-action"]);
+
+		expect(stderr).toContain('unknown action "no-such-action"');
+		expect(process.exitCode).toBe(1);
+	});
+
+	it("writes manifest.json + per-prompt .md files when --output is given", async () => {
+		const { stdout } = await runPromptCommand(["--output", tmpDir]);
+
+		const files = await readdir(tmpDir);
+		expect(files).toContain("manifest.json");
+		expect(files).toContain("translate.md");
+		expect(files).toContain("summarize.md");
+
+		const manifest = JSON.parse(await readFile(join(tmpDir, "manifest.json"), "utf-8")) as {
+			cliVersion: string;
+			prompts: ReadonlyArray<{ action: string; placeholders: ReadonlyArray<string> }>;
+		};
+		expect(manifest.cliVersion).toMatch(/^\d+\.\d+\.\d+/);
+		expect(manifest.prompts.length).toBeGreaterThan(1);
+		expect(stdout).toContain("Exported");
+		expect(stdout).toContain("Manifest:");
+	});
+
+	it("filters to a single prompt when --action and --output are both provided", async () => {
+		await runPromptCommand(["--action", "translate", "--output", tmpDir]);
+
+		const files = await readdir(tmpDir);
+		expect(files).toContain("translate.md");
+		expect(files).not.toContain("summarize.md");
+
+		const manifest = JSON.parse(await readFile(join(tmpDir, "manifest.json"), "utf-8")) as {
+			prompts: ReadonlyArray<{ action: string }>;
+		};
+		expect(manifest.prompts).toHaveLength(1);
+		expect(manifest.prompts[0].action).toBe("translate");
+	});
+
+	it("errors when --action is unknown even with --output", async () => {
+		const { stderr } = await runPromptCommand(["--action", "missing", "--output", tmpDir]);
+
+		expect(stderr).toContain('unknown action "missing"');
+		expect(process.exitCode).toBe(1);
+	});
+
+	it("falls back to reading cli/package.json when the build-time version is undefined", async () => {
+		// Vite normally inlines __CLI_PKG_VERSION__; stubbing it as undefined
+		// exercises the fs fallback path in readCliVersion.
+		vi.stubGlobal("__CLI_PKG_VERSION__", undefined);
+
+		await runPromptCommand(["--output", tmpDir]);
+
+		const manifest = JSON.parse(await readFile(join(tmpDir, "manifest.json"), "utf-8")) as {
+			cliVersion: string;
+		};
+		// The fallback should pull the real version from cli/package.json, not
+		// the catch-all "unknown".
+		expect(manifest.cliVersion).toMatch(/^\d+\.\d+\.\d+/);
+	});
+
+	it("falls back to 'unknown' when both the global and the package.json read fail", async () => {
+		vi.stubGlobal("__CLI_PKG_VERSION__", undefined);
+		// Forces the readFile path to throw, exercising the catch arm of
+		// readCliVersion. The mock is scoped to a fresh module so the global
+		// readFile elsewhere is untouched after this test ends.
+		vi.resetModules();
+		vi.doMock("node:fs/promises", async () => {
+			const actual = await vi.importActual<typeof import("node:fs/promises")>("node:fs/promises");
+			return {
+				...actual,
+				readFile: vi.fn().mockRejectedValue(new Error("no such file")),
+			};
+		});
+		const { registerExportPromptCommand: register } = await import("./ExportCommand.js");
+		const program = new Command();
+		program.exitOverride();
+		register(program);
+
+		const origLog = console.log;
+		console.log = () => {};
+		try {
+			await program.parseAsync(["node", "jolli", "export-prompt", "--output", tmpDir]);
+		} finally {
+			console.log = origLog;
+		}
+
+		const manifest = JSON.parse(await readFile(join(tmpDir, "manifest.json"), "utf-8")) as {
+			cliVersion: string;
+		};
+		expect(manifest.cliVersion).toBe("unknown");
+
+		vi.doUnmock("node:fs/promises");
+		vi.resetModules();
+	});
+
+	it("falls back to 'unknown' when the package.json has no version field", async () => {
+		// Exercises the `parsed.version ?? "unknown"` nullish branch on a
+		// well-formed JSON file that simply omits `version`.
+		vi.stubGlobal("__CLI_PKG_VERSION__", undefined);
+		vi.resetModules();
+		vi.doMock("node:fs/promises", async () => {
+			const actual = await vi.importActual<typeof import("node:fs/promises")>("node:fs/promises");
+			return {
+				...actual,
+				readFile: vi.fn().mockResolvedValue("{}"),
+			};
+		});
+		const { registerExportPromptCommand: register } = await import("./ExportCommand.js");
+		const program = new Command();
+		program.exitOverride();
+		register(program);
+
+		const origLog = console.log;
+		console.log = () => {};
+		try {
+			await program.parseAsync(["node", "jolli", "export-prompt", "--output", tmpDir]);
+		} finally {
+			console.log = origLog;
+		}
+
+		const manifest = JSON.parse(await readFile(join(tmpDir, "manifest.json"), "utf-8")) as {
+			cliVersion: string;
+		};
+		expect(manifest.cliVersion).toBe("unknown");
+
+		vi.doUnmock("node:fs/promises");
+		vi.resetModules();
+	});
+
+	it("renders `placeholders: []` for templates that have no placeholders", async () => {
+		// All shipped templates carry at least one `{{slot}}`, so the empty-list
+		// branch in formatPromptMarkdown is only reachable by feeding a curated
+		// template map. Mock PromptTemplates so the fresh module sees one entry
+		// with a placeholder-free body.
+		vi.resetModules();
+		vi.doMock("../core/PromptTemplates.js", () => ({
+			TEMPLATES: new Map([["literal", { action: "literal", version: 1, template: "no slots here" }]]),
+		}));
+		const { registerExportPromptCommand: register } = await import("./ExportCommand.js");
+		const program = new Command();
+		program.exitOverride();
+		register(program);
+
+		const origLog = console.log;
+		console.log = () => {};
+		try {
+			await program.parseAsync(["node", "jolli", "export-prompt", "--output", tmpDir]);
+		} finally {
+			console.log = origLog;
+		}
+
+		const md = await readFile(join(tmpDir, "literal.md"), "utf-8");
+		expect(md).toContain("placeholders: []");
+
+		vi.doUnmock("../core/PromptTemplates.js");
+		vi.resetModules();
 	});
 });

--- a/cli/src/commands/HealFolderCommand.test.ts
+++ b/cli/src/commands/HealFolderCommand.test.ts
@@ -250,6 +250,15 @@ describe("registerHealFolderCommand", () => {
 		expect(stdout).not.toContain("Re-run `jolli enable`");
 	});
 
+	// failed > 0 with skipped === 0: covers the "Skipped:" line being omitted
+	// alongside the failed line.
+	it("omits the Skipped line when only failed entries exist", async () => {
+		mockCreateStorage.mockResolvedValue(makeStorageWith({ healed: 0, skipped: 0, failed: 2 }));
+		const { stdout } = await runCommand(["--cwd", "/tmp/jolli-heal-test-only-failed"]);
+		expect(stdout).toContain("Failed:   2");
+		expect(stdout).not.toMatch(/Skipped:\s+\d/);
+	});
+
 	// When the underlying error carries an errno code (EACCES / ENOSPC / ...)
 	// the CLI must surface it so operators see the failure category, not just
 	// a bare message.

--- a/cli/src/commands/StartCommand.test.ts
+++ b/cli/src/commands/StartCommand.test.ts
@@ -1111,7 +1111,43 @@ describe("buildRootInjectionInput", () => {
 	});
 });
 
-// ─── pickRootRedirectHref / writeRootRedirectIndex unit tests ─────────────────
+// ─── hasUserAuthoredRootIndex / pickRootRedirectHref / writeRootRedirectIndex unit tests ────
+
+describe("hasUserAuthoredRootIndex", () => {
+	it("returns true when the mirror has a root index.md", async () => {
+		const { hasUserAuthoredRootIndex } = await import("./StartCommand.js");
+		expect(hasUserAuthoredRootIndex({ markdownFiles: ["index.md", "foo.md"] })).toBe(true);
+	});
+
+	it("returns true when the mirror has a root index.mdx", async () => {
+		// Covers user-authored MDX landing pages.
+		const { hasUserAuthoredRootIndex } = await import("./StartCommand.js");
+		expect(hasUserAuthoredRootIndex({ markdownFiles: ["index.mdx", "foo.md"] })).toBe(true);
+	});
+
+	it("returns false when no index file is present", async () => {
+		const { hasUserAuthoredRootIndex } = await import("./StartCommand.js");
+		expect(hasUserAuthoredRootIndex({ markdownFiles: ["docs/getting-started.md", "api.md"] })).toBe(false);
+	});
+
+	it("returns false when only a nested index exists — only the root index claims `/`", async () => {
+		// Regression guard: `docs/index.md` is the index of the `/docs` folder,
+		// not the site root. Treating it as a user-authored root index would
+		// suppress the page-mode redirect for sites that legitimately need it.
+		const { hasUserAuthoredRootIndex } = await import("./StartCommand.js");
+		expect(hasUserAuthoredRootIndex({ markdownFiles: ["docs/index.md", "api/index.mdx"] })).toBe(false);
+	});
+
+	it("returns true when both a root and a nested index exist", async () => {
+		const { hasUserAuthoredRootIndex } = await import("./StartCommand.js");
+		expect(hasUserAuthoredRootIndex({ markdownFiles: ["index.md", "docs/index.md"] })).toBe(true);
+	});
+
+	it("returns false for an empty markdown list", async () => {
+		const { hasUserAuthoredRootIndex } = await import("./StartCommand.js");
+		expect(hasUserAuthoredRootIndex({ markdownFiles: [] })).toBe(false);
+	});
+});
 
 describe("pickRootRedirectHref", () => {
 	it("returns the first navigable page href when no page is rooted at /", async () => {

--- a/cli/src/commands/StartCommand.ts
+++ b/cli/src/commands/StartCommand.ts
@@ -230,7 +230,10 @@ async function syncContent(
 	// before React even hydrates. We do this *before* `generateNavigation` so
 	// the `_meta.js` writer picks up the rewritten file and emits the standard
 	// `{ "index": { display: "hidden" } }` entry to keep it out of the sidebar.
-	const redirectHref = pickRootRedirectHref(parsedNavigation);
+	//
+	// Skip the rewrite when the user authored a real root index — see
+	// `hasUserAuthoredRootIndex` for the detection rule and rationale.
+	const redirectHref = hasUserAuthoredRootIndex(mirrorResult) ? undefined : pickRootRedirectHref(parsedNavigation);
 	if (redirectHref) {
 		await writeRootRedirectIndex(contentDir, redirectHref);
 	}
@@ -256,6 +259,21 @@ async function syncContent(
 	}
 
 	return { success: true, mirrorResult };
+}
+
+/**
+ * Returns `true` when `mirrorResult` already contains a user-authored root
+ * `index.md`/`index.mdx` — i.e. the source had a literal `index.{md,mdx}`,
+ * or `ContentMirror.ensureIndexPage` promoted a file with `slug: /` to
+ * `index.md` during mirroring. In either case `/` is meant to render that
+ * page, and `writeRootRedirectIndex` must not silently overwrite it with a
+ * redirect stub. Only the *root* index counts — a nested `docs/index.md`
+ * doesn't claim `/`.
+ *
+ * Exported for unit testing — call site is in `syncContent`.
+ */
+export function hasUserAuthoredRootIndex(mirrorResult: { markdownFiles: string[] }): boolean {
+	return mirrorResult.markdownFiles.some((f) => f === "index.md" || f === "index.mdx");
 }
 
 /**

--- a/cli/src/core/CommitSelectionStore.unlinkfail.test.ts
+++ b/cli/src/core/CommitSelectionStore.unlinkfail.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Coverage for the `.catch(() => undefined)` arrow inside `writeExclusions`'
+ * rename-failure cleanup path. The main `CommitSelectionStore.test.ts`
+ * already proves the cleanup *runs* (rename throws → unlink succeeds, .tmp
+ * vanishes), but the catch handler itself is only invoked when unlink also
+ * fails — the "double failure" scenario where the rename error is the
+ * one we want to surface and the cleanup failure must NOT mask it.
+ *
+ * Kept in a separate file because `vi.mock("node:fs/promises")` is module-
+ * scoped — applying it to the main suite would break every test that uses
+ * real `mkdir`/`writeFile`/etc. for fixture setup.
+ */
+
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import * as realFsPromises from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("node:fs/promises", async (importOriginal) => {
+	const original = await importOriginal<typeof import("node:fs/promises")>();
+	return {
+		...original,
+		// Default-behavior pass-through; tests use mockImplementationOnce
+		// to inject a failure for just the unlink call we care about.
+		unlink: vi.fn(original.unlink),
+	};
+});
+
+import { setExcluded } from "./CommitSelectionStore.js";
+
+describe("writeExclusions unlink-also-fails cleanup", () => {
+	let projectDir: string;
+
+	beforeEach(() => {
+		projectDir = mkdtempSync(join(tmpdir(), "commit-sel-unlink-fail-"));
+		vi.mocked(realFsPromises.unlink).mockClear();
+	});
+
+	afterEach(() => {
+		rmSync(projectDir, { recursive: true, force: true });
+	});
+
+	it("swallows a secondary unlink failure and rethrows the original rename error", async () => {
+		// Force the rename to fail by pre-creating the destination as a
+		// directory — same trick the main test suite uses, EISDIR on POSIX.
+		const dir = join(projectDir, ".jolli", "jollimemory");
+		mkdirSync(dir, { recursive: true });
+		const finalPath = join(dir, "commit-selection.json");
+		mkdirSync(finalPath);
+
+		// Make the cleanup unlink also fail. The .catch arrow must turn this
+		// into a silent no-op so the rename error is what bubbles up.
+		const cleanupErr = new Error("simulated EBUSY on cleanup");
+		vi.mocked(realFsPromises.unlink).mockRejectedValueOnce(cleanupErr);
+
+		// Expect the *rename* error (EISDIR / EPERM) to propagate — NOT the
+		// fake cleanup error. The arrow's job is precisely to drop the
+		// cleanup throw on the floor.
+		await expect(setExcluded(projectDir, "plans", "x", true)).rejects.toThrow(/EISDIR|EPERM|is a directory/i);
+
+		// Confirm the failing unlink was actually attempted (otherwise the
+		// arrow path wasn't exercised even if the test passed for unrelated
+		// reasons).
+		expect(realFsPromises.unlink).toHaveBeenCalled();
+	});
+});

--- a/cli/src/core/DualWriteStorage.test.ts
+++ b/cli/src/core/DualWriteStorage.test.ts
@@ -741,6 +741,31 @@ describe("DualWriteStorage", () => {
 			expect(result.healed).toBe(2);
 		});
 
+		// Defensive: a misbehaving provider might resolve to undefined despite
+		// the StorageProvider contract. The nullish-coalesce fallback in
+		// DualWriteStorage must turn that into the standard zero-counts shape
+		// so callers can rely on a non-null HealResult.
+		it("returns zero counts when the folder side resolves to undefined", async () => {
+			const folderHeal = vi.fn().mockResolvedValue(undefined);
+			const orphan = {
+				readFile: vi.fn(),
+				writeFiles: vi.fn(),
+				listFiles: vi.fn(),
+				exists: vi.fn().mockResolvedValue(true),
+				ensure: vi.fn(),
+			} as unknown as StorageProvider;
+			const folder = {
+				readFile: vi.fn(),
+				writeFiles: vi.fn(),
+				listFiles: vi.fn(),
+				exists: vi.fn().mockResolvedValue(true),
+				ensure: vi.fn(),
+				healMissingVisibleMarkdown: folderHeal,
+			} as unknown as StorageProvider;
+			const dual = new DualWriteStorage(orphan, folder);
+			await expect(dual.healMissingVisibleMarkdown()).resolves.toEqual({ healed: 0, skipped: 0, failed: 0 });
+		});
+
 		it("marks dirty and returns error-tagged result when the folder side throws", async () => {
 			const folderHeal = vi.fn().mockRejectedValue(new Error("manifest read failed"));
 			const markDirty = vi.fn();

--- a/cli/src/core/LinearIssueExtractor.test.ts
+++ b/cli/src/core/LinearIssueExtractor.test.ts
@@ -791,6 +791,93 @@ describe("extractLinearIssuesFromTranscript", () => {
 		expect(issues[0].priority).toBeUndefined();
 		expect(issues[0].labels).toBeUndefined();
 	});
+
+	it("skips a Linear-like line whose message.content is not an array", async () => {
+		// readContentBlocks returns undefined when content is not an array → line is skipped.
+		// The top-level `name` key makes the line satisfy the `"name":"mcp__linear__` substring
+		// pre-filter so we exercise the non-array branch inside readContentBlocks.
+		const nonArrayContentLine = JSON.stringify({
+			name: "mcp__linear__get_issue",
+			message: {
+				role: "assistant",
+				content: "stringified content instead of an array",
+			},
+			timestamp: "2026-05-14T06:00:00.000Z",
+		});
+		const jsonl = makeJsonl(
+			nonArrayContentLine,
+			toolUseLine({
+				toolUseId: "toolu_after",
+				toolName: "mcp__linear__get_issue",
+				timestamp: "2026-05-14T06:00:01.000Z",
+			}),
+			toolResultLine({
+				toolUseId: "toolu_after",
+				timestamp: "2026-05-14T06:00:02.000Z",
+				payload: SAMPLE_ISSUE_PAYLOAD,
+			}),
+		);
+		mockReadFile.mockResolvedValue(jsonl);
+
+		const { issues } = await extractLinearIssuesFromTranscript("/fake.jsonl");
+
+		expect(issues).toHaveLength(1);
+		expect(issues[0].ticketId).toBe("PROJ-1528");
+	});
+
+	it("drops a tool_result whose timestamp is after the beforeTimestamp cutoff even though its tool_use was inside the window", async () => {
+		// tool_use inside cutoff → enters pending. tool_result outside cutoff →
+		// collectToolResults' beforeTimestamp guard returns before walkPayload.
+		const jsonl = makeJsonl(
+			toolUseLine({
+				toolUseId: "toolu_split",
+				toolName: "mcp__linear__get_issue",
+				timestamp: "2026-05-14T06:00:00.000Z",
+			}),
+			toolResultLine({
+				toolUseId: "toolu_split",
+				timestamp: "2026-05-14T07:00:01.000Z",
+				payload: SAMPLE_ISSUE_PAYLOAD,
+			}),
+		);
+		mockReadFile.mockResolvedValue(jsonl);
+
+		const { issues } = await extractLinearIssuesFromTranscript("/fake.jsonl", {
+			beforeTimestamp: "2026-05-14T06:30:00.000Z",
+		});
+
+		expect(issues).toHaveLength(0);
+	});
+
+	it("accepts a tool_result without a timestamp field, falling back to empty referencedAt", async () => {
+		// Forces the `timestamp ?? \"\"` fallback when forwarding to walkPayload.
+		const toolUseLineStr = toolUseLine({
+			toolUseId: "toolu_no_res_ts",
+			toolName: "mcp__linear__get_issue",
+			timestamp: "2026-05-14T06:00:00.000Z",
+		});
+		const toolResultNoTs = JSON.stringify({
+			isSidechain: false,
+			type: "user",
+			message: {
+				role: "user",
+				content: [
+					{
+						tool_use_id: "toolu_no_res_ts",
+						type: "tool_result",
+						content: [{ type: "text", text: JSON.stringify(SAMPLE_ISSUE_PAYLOAD) }],
+					},
+				],
+			},
+			// no timestamp field on the tool_result
+		});
+		mockReadFile.mockResolvedValue(makeJsonl(toolUseLineStr, toolResultNoTs));
+
+		const { issues } = await extractLinearIssuesFromTranscript("/fake.jsonl");
+
+		expect(issues).toHaveLength(1);
+		expect(issues[0].referencedAt).toBe("");
+	});
 });
 
 // ─── formatLinearIssuesBlock ─────────────────────────────────────────────────

--- a/cli/src/core/LinearIssueExtractor.ts
+++ b/cli/src/core/LinearIssueExtractor.ts
@@ -130,7 +130,9 @@ export async function extractLinearIssuesFromTranscript(
 
 		if (role === "assistant") {
 			collectToolUses(blocks, timestamp, opts.beforeTimestamp, pending);
+			/* v8 ignore start -- readRole returns only "assistant" | "user" | undefined; undefined is filtered above, so the else-if's false branch is unreachable. */
 		} else if (role === "user") {
+			/* v8 ignore stop */
 			collectToolResults(blocks, timestamp, opts.beforeTimestamp, pending, collected);
 		}
 	}
@@ -265,10 +267,10 @@ function walkPayload(value: unknown, toolName: string, referencedAt: string, out
 	const ref = tryBuildRef(obj, toolName, referencedAt);
 	if (ref !== undefined) {
 		out.push(ref);
-		return; // 不再下钻 — 已识别为 issue
+		return; // identified as an issue — stop descending
 	}
 
-	// 未识别为 issue → 尝试常见 wrapper 字段
+	// not an issue itself → try common wrapper fields
 	for (const key of ["items", "issues", "nodes", "results"]) {
 		const inner = obj[key];
 		if (Array.isArray(inner)) {

--- a/cli/src/core/LinearIssueStore.test.ts
+++ b/cli/src/core/LinearIssueStore.test.ts
@@ -198,6 +198,23 @@ describe("readLinearIssueMarkdown", () => {
 		expect(got).toBeNull();
 	});
 
+	it("returns null when the closing frontmatter delimiter is missing", async () => {
+		// Opens with `---` but never closes — closingIdx stays -1 in parseMarkdown.
+		mockReadFile.mockResolvedValue('---\nticketId: "PROJ-1"\nno closing delimiter\n');
+		const got = await readLinearIssueMarkdown("/x.md");
+		expect(got).toBeNull();
+	});
+
+	it("treats non-string JSON literal field values as missing (parseField undefined branch)", async () => {
+		// ticketId is a JSON number — JSON.parse succeeds but typeof v !== "string",
+		// so parseField returns undefined and the required-field guard returns null.
+		mockReadFile.mockResolvedValue(
+			'---\nticketId: 123\ntitle: "t"\nurl: "https://x/PROJ-1"\nreferencedAt: "2026-01-01T00:00:00Z"\nsourceToolName: "mcp__linear__get_issue"\n---\nbody\n',
+		);
+		const got = await readLinearIssueMarkdown("/x.md");
+		expect(got).toBeNull();
+	});
+
 	it("returns null when the file is missing the required ticketId field", async () => {
 		mockReadFile.mockResolvedValue(
 			'---\ntitle: "x"\nurl: "https://x"\nreferencedAt: "2026-01-01T00:00:00Z"\nsourceToolName: "mcp__linear__get_issue"\n---\nbody\n',

--- a/cli/src/core/Locks.test.ts
+++ b/cli/src/core/Locks.test.ts
@@ -417,5 +417,58 @@ describe("Locks", () => {
 
 			execSpy.mockRestore();
 		});
+
+		// `acquireOrphanWriteLock()` with no `cwd` argument is the production
+		// call shape for callers that don't track the project root explicitly.
+		// Exercises the `cwd ?? process.cwd()` right-hand branch.
+		it("uses process.cwd() when cwd argument is omitted", async () => {
+			__resetSharedLockDirCache();
+			const cwdSpy = vi.spyOn(process, "cwd").mockReturnValue(tempDir);
+
+			expect(await acquireOrphanWriteLock()).toBe(true);
+			const expected = join(tempDir, ".git", "jollimemory", ORPHAN_WRITE_LOCK_FILE);
+			expect((await stat(expected)).isFile()).toBe(true);
+			await releaseOrphanWriteLock();
+
+			cwdSpy.mockRestore();
+			__resetSharedLockDirCache();
+		});
+
+		// `git rev-parse --git-common-dir` returns an absolute path for linked
+		// worktrees. Exercises the `isAbsolute(commonDir) ? commonDir : …`
+		// true branch — local macOS/Linux `git init` returns ".git" so this is
+		// only reachable through a mock.
+		it("uses the absolute common dir directly when git returns one", async () => {
+			__resetSharedLockDirCache();
+			const absoluteCommonDir = join(tempDir, ".git");
+			const Subprocess = await import("../util/Subprocess.js");
+			const execSpy = vi
+				.spyOn(Subprocess, "execFileAsyncHidden")
+				.mockResolvedValue({ stdout: `${absoluteCommonDir}\n`, stderr: "" });
+
+			expect(await acquireOrphanWriteLock(tempDir)).toBe(true);
+			const expected = join(absoluteCommonDir, "jollimemory", ORPHAN_WRITE_LOCK_FILE);
+			expect((await stat(expected)).isFile()).toBe(true);
+			await releaseOrphanWriteLock(tempDir);
+
+			execSpy.mockRestore();
+			__resetSharedLockDirCache();
+		});
+	});
+
+	describe("readLockOwnerPid edge cases", () => {
+		// `pid.length > 0 ? pid : null` — exercises the empty-PID branch where
+		// readLockOwnerPid returns null even though the lock file exists. The
+		// release path then falls through to rm (treating "unowned" as "ours").
+		it("treats an empty lock file as unowned and removes it on release", async () => {
+			const fsPromises = await import("node:fs/promises");
+			await fsPromises.mkdir(join(tempDir, ".jolli", "jollimemory"), { recursive: true });
+			const lockPath = workerLockPath(tempDir);
+			await writeFile(lockPath, "   \n", "utf-8");
+
+			await releaseWorkerLock(tempDir);
+
+			await expect(stat(lockPath)).rejects.toThrow();
+		});
 	});
 });

--- a/cli/src/core/NotePromptFormatter.test.ts
+++ b/cli/src/core/NotePromptFormatter.test.ts
@@ -89,4 +89,10 @@ describe("formatNotesBlock", () => {
 		const out = await formatNotesBlock([makeNote({ format: "markdown" })]);
 		expect(out).toContain('format="markdown"');
 	});
+
+	it("returns empty string when the first note alone already exceeds maxTotalChars", async () => {
+		mockReadFile.mockResolvedValue("body");
+		const out = await formatNotesBlock([makeNote()], { maxTotalChars: 1 });
+		expect(out).toBe("");
+	});
 });

--- a/cli/src/core/OrphanBranchStorage.test.ts
+++ b/cli/src/core/OrphanBranchStorage.test.ts
@@ -1,0 +1,93 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// OrphanBranchStorage is a thin wrapper; every method just forwards to GitOps.
+vi.mock("./GitOps.js", () => ({
+	ensureOrphanBranch: vi.fn(),
+	listFilesInBranch: vi.fn(),
+	orphanBranchExists: vi.fn(),
+	readFileFromBranch: vi.fn(),
+	writeMultipleFilesToBranch: vi.fn(),
+}));
+
+import { ORPHAN_BRANCH } from "../Logger.js";
+import {
+	ensureOrphanBranch,
+	listFilesInBranch,
+	orphanBranchExists,
+	readFileFromBranch,
+	writeMultipleFilesToBranch,
+} from "./GitOps.js";
+import { OrphanBranchStorage } from "./OrphanBranchStorage.js";
+
+const mockedReadFile = vi.mocked(readFileFromBranch);
+const mockedWriteFiles = vi.mocked(writeMultipleFilesToBranch);
+const mockedListFiles = vi.mocked(listFilesInBranch);
+const mockedExists = vi.mocked(orphanBranchExists);
+const mockedEnsure = vi.mocked(ensureOrphanBranch);
+
+describe("OrphanBranchStorage", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("readFile forwards ORPHAN_BRANCH, path and cwd to readFileFromBranch", async () => {
+		mockedReadFile.mockResolvedValueOnce("hello");
+		const storage = new OrphanBranchStorage("/tmp/repo");
+
+		const result = await storage.readFile("summaries/abc.json");
+
+		expect(result).toBe("hello");
+		expect(mockedReadFile).toHaveBeenCalledWith(ORPHAN_BRANCH, "summaries/abc.json", "/tmp/repo");
+	});
+
+	it("readFile passes undefined through when no cwd is provided", async () => {
+		mockedReadFile.mockResolvedValueOnce(null);
+		const storage = new OrphanBranchStorage();
+
+		const result = await storage.readFile("missing.json");
+
+		expect(result).toBeNull();
+		expect(mockedReadFile).toHaveBeenCalledWith(ORPHAN_BRANCH, "missing.json", undefined);
+	});
+
+	it("writeFiles calls ensure before writing", async () => {
+		const storage = new OrphanBranchStorage("/tmp/repo");
+		const files = [{ path: "a.txt", content: "A" }];
+
+		await storage.writeFiles(files, "commit msg");
+
+		expect(mockedEnsure).toHaveBeenCalledWith(ORPHAN_BRANCH, "/tmp/repo");
+		expect(mockedWriteFiles).toHaveBeenCalledWith(ORPHAN_BRANCH, files, "commit msg", "/tmp/repo");
+		// ensure must run before write
+		expect(mockedEnsure.mock.invocationCallOrder[0]).toBeLessThan(mockedWriteFiles.mock.invocationCallOrder[0]);
+	});
+
+	it("listFiles returns a mutable copy of the GitOps list", async () => {
+		const frozen = Object.freeze(["a.json", "b.json"]) as readonly string[];
+		mockedListFiles.mockResolvedValueOnce(frozen);
+		const storage = new OrphanBranchStorage();
+
+		const result = await storage.listFiles("summaries/");
+
+		expect(result).toEqual(["a.json", "b.json"]);
+		// must be a fresh array (not the readonly reference) so push() is safe
+		expect(Object.isFrozen(result)).toBe(false);
+		expect(mockedListFiles).toHaveBeenCalledWith(ORPHAN_BRANCH, "summaries/", undefined);
+	});
+
+	it("exists forwards to orphanBranchExists", async () => {
+		mockedExists.mockResolvedValueOnce(true);
+		const storage = new OrphanBranchStorage("/tmp/repo");
+
+		await expect(storage.exists()).resolves.toBe(true);
+		expect(mockedExists).toHaveBeenCalledWith(ORPHAN_BRANCH, "/tmp/repo");
+	});
+
+	it("ensure forwards to ensureOrphanBranch", async () => {
+		const storage = new OrphanBranchStorage("/tmp/repo");
+
+		await storage.ensure();
+
+		expect(mockedEnsure).toHaveBeenCalledWith(ORPHAN_BRANCH, "/tmp/repo");
+	});
+});

--- a/cli/src/core/SummaryMarkdownBuilder.test.ts
+++ b/cli/src/core/SummaryMarkdownBuilder.test.ts
@@ -341,6 +341,17 @@ describe("buildMarkdown", () => {
 		expect(md).toContain("Day 5 topic");
 	});
 
+	it("renders Quick recap section when recap is present", () => {
+		const md = buildMarkdown(leaf({ recap: "  Shipped feature X with tests.  " }));
+		expect(md).toContain("## Quick recap");
+		expect(md).toContain("Shipped feature X with tests.");
+	});
+
+	it("omits Quick recap section when recap is whitespace-only", () => {
+		const md = buildMarkdown(leaf({ recap: "   " }));
+		expect(md).not.toContain("## Quick recap");
+	});
+
 	it("renders topic without todo or files", () => {
 		const md = buildMarkdown(
 			leaf({

--- a/cli/src/core/SummaryMigration.test.ts
+++ b/cli/src/core/SummaryMigration.test.ts
@@ -10,6 +10,13 @@ vi.mock("./GitOps.js", () => ({
 	execGit: vi.fn(),
 }));
 
+// Mock Locks so we can simulate lock-acquisition failure without touching the
+// real filesystem. Default behavior matches a happy-path acquire.
+vi.mock("./Locks.js", () => ({
+	acquireOrphanWriteLock: vi.fn().mockResolvedValue(true),
+	releaseOrphanWriteLock: vi.fn().mockResolvedValue(undefined),
+}));
+
 // Suppress console output
 vi.spyOn(console, "log").mockImplementation(() => {});
 vi.spyOn(console, "warn").mockImplementation(() => {});
@@ -24,6 +31,7 @@ import {
 	writeFileToBranch,
 	writeMultipleFilesToBranch,
 } from "./GitOps.js";
+import { acquireOrphanWriteLock, releaseOrphanWriteLock } from "./Locks.js";
 import {
 	cleanupV1IfExpired,
 	deleteV1Branch,
@@ -448,6 +456,16 @@ describe("SummaryMigration", () => {
 			expect(migrated.commitSource).toBe("cli");
 			expect(migrated.conversationTurns).toBe(5);
 			expect(migrated.llm?.model).toBe("claude");
+		});
+
+		it("should throw and skip release when the orphan-write lock cannot be acquired", async () => {
+			vi.mocked(orphanBranchExists).mockResolvedValueOnce(true);
+			vi.mocked(acquireOrphanWriteLock).mockResolvedValueOnce(false);
+
+			await expect(migrateV1toV3()).rejects.toThrow(/could not acquire orphan-write lock/);
+			expect(listFilesInBranch).not.toHaveBeenCalled();
+			expect(writeMultipleFilesToBranch).not.toHaveBeenCalled();
+			expect(releaseOrphanWriteLock).not.toHaveBeenCalled();
 		});
 
 		it("should preserve commitType/commitSource and conversationTurns/llm in multi-record migration children", async () => {

--- a/cli/src/core/SummaryTree.test.ts
+++ b/cli/src/core/SummaryTree.test.ts
@@ -248,6 +248,11 @@ describe("SummaryTree", () => {
 			expect(topics[0].commitDate).toBe(v4Root.commitDate);
 			expect(topics[0].generatedAt).toBe(v4Root.generatedAt);
 		});
+
+		it("returns empty array for v4 root with undefined topics (covers `?? []` fallback)", () => {
+			const noTopics: CommitSummary = { ...A, version: 4, topics: undefined };
+			expect(collectDisplayTopics(noTopics)).toEqual([]);
+		});
 	});
 
 	describe("collectAllTranscriptHashes", () => {

--- a/cli/src/site/AssetResolver.test.ts
+++ b/cli/src/site/AssetResolver.test.ts
@@ -268,6 +268,41 @@ describe("AssetResolver", () => {
 			expect(result.isPlaceholder).toBe(true);
 			expect(result.publicPath).toContain("placeholder-");
 		});
+
+		it("handles extensionless asset located outside the projectRoot", async () => {
+			const { resolveExternalImage } = await import("./AssetResolver.js");
+			// projectRoot anchors to projectDir via package.json marker; asset lives
+			// in tempDir (outside projectRoot) and has no file extension. This
+			// exercises generateUniqueName's basename fallback and empty-ext branch.
+			const projectDir = join(tempDir, "project");
+			const docsDir = join(projectDir, "docs");
+			await mkdir(docsDir, { recursive: true });
+			await writeFile(join(projectDir, "package.json"), "{}", "utf-8");
+			await writeFile(join(tempDir, "extless-file"), "binary", "utf-8");
+
+			const result = resolveExternalImage("../../extless-file", docsDir, docsDir);
+
+			expect(result.isPlaceholder).toBe(false);
+			expect(result.publicPath).toBe("images/extless-file");
+		});
+
+		it("breaks the findProjectRoot search loop when the path bottoms out at the filesystem root", async () => {
+			const { resolveExternalImage } = await import("./AssetResolver.js");
+			// A shallow sourceRoot under /tmp/ lets findProjectRoot reach `/`
+			// within its 5-iteration budget, exercising the `parent === dir`
+			// early-break branch. Use a unique, guaranteed-missing image name so
+			// all candidates fail and the result is a placeholder.
+			const shallowRoot = await mkdtemp("/tmp/jolli-assetresolver-shallow-");
+			try {
+				const uniqueName = `nope-${Date.now()}-${Math.random().toString(36).slice(2)}.png`;
+				const result = resolveExternalImage(uniqueName, shallowRoot, shallowRoot);
+
+				expect(result.isPlaceholder).toBe(true);
+				expect(result.publicPath).toContain("placeholder-");
+			} finally {
+				await rm(shallowRoot, { recursive: true, force: true });
+			}
+		});
 	});
 
 	// ── copyExternalAsset — placeholder content ─────────────────────────────

--- a/cli/src/site/ColorUtils.test.ts
+++ b/cli/src/site/ColorUtils.test.ts
@@ -39,6 +39,12 @@ describe("hexToHsl", () => {
 		expect(result).toEqual({ h: 0, s: 0, l: 0 });
 	});
 
+	it("wraps hue past 360 when max is red and green < blue", () => {
+		// #FF0080: r=255 (max), g=0, b=128, g<b → triggers the wraparound branch
+		const result = hexToHsl("#FF0080");
+		expect(result?.h).toBeGreaterThan(300);
+	});
+
 	it("converts indigo (Forge default hue ~228)", () => {
 		// #4F46E5 → roughly h=243, s=75, l=58 (actual values)
 		const result = hexToHsl("#4F46E5");
@@ -110,5 +116,19 @@ describe("resolveAccent", () => {
 	it("colors.primary takes precedence over primaryHue", () => {
 		const result = resolveAccent({ colors: { primary: "#00FF00" }, primaryHue: 300 }, 228, 84, 61);
 		expect(result.hue).toBe(120); // green hue
+	});
+
+	it("uses primaryColor hex when colors.primary is not set", () => {
+		const result = resolveAccent({ primaryColor: "#0000FF" }, 228, 84, 61);
+		expect(result.hue).toBe(240);
+		expect(result.saturation).toBe(100);
+		expect(result.lightness).toBe(50);
+	});
+
+	it("ignores invalid primaryColor and falls through to primaryHue", () => {
+		const result = resolveAccent({ primaryColor: "not-a-color", primaryHue: 200 }, 228, 84, 61);
+		expect(result.hue).toBe(200);
+		expect(result.saturation).toBe(84);
+		expect(result.lightness).toBe(61);
 	});
 });

--- a/cli/src/site/DocusaurusConverter.test.ts
+++ b/cli/src/site/DocusaurusConverter.test.ts
@@ -388,4 +388,160 @@ describe("DocusaurusConverter branch coverage", () => {
 
 		expect(result.sidebar).toEqual({});
 	});
+
+	it("loads sidebar from ESM module without default export", async () => {
+		const { convertDocusaurusSidebar } = await import("./DocusaurusConverter.js");
+		const sidebarPath = join(tempDir, "sidebars.mjs");
+		await writeFile(sidebarPath, `export const docsSidebar = ['intro'];`, "utf-8");
+
+		const result = await convertDocusaurusSidebar(sidebarPath);
+
+		expect(result.sidebar["/"].intro).toBe("Intro");
+	});
+
+	it("records pathMapping when category actual dir differs from logical dir", async () => {
+		const { convertDocusaurusSidebar } = await import("./DocusaurusConverter.js");
+		const sidebarPath = join(tempDir, "sidebars.js");
+		// link.id puts the category's actual dir at use_cases/fraud, but the
+		// catKey becomes "fraud" so logical child dir is /fraud — actualRel != logicalRel.
+		await writeFile(
+			sidebarPath,
+			`module.exports = { docsSidebar: [
+				{ type: 'category', label: 'Fraud', link: { type: 'doc', id: 'use_cases/fraud/index' }, items: [
+					'use_cases/fraud/intro'
+				] }
+			] }`,
+			"utf-8",
+		);
+
+		const result = await convertDocusaurusSidebar(sidebarPath);
+
+		expect(result.pathMappings["use_cases/fraud"]).toBe("fraud");
+	});
+
+	it("iterates path mappings to resolve nested category parent (both match and skip)", async () => {
+		const { convertDocusaurusSidebar } = await import("./DocusaurusConverter.js");
+		const sidebarPath = join(tempDir, "sidebars.js");
+		// First sibling creates pathMapping tools/eth -> eth (target != "fraud" later).
+		// Second sibling creates pathMapping use_cases/fraud -> fraud, then nests a
+		// category whose parentActualDir must come from logicalToActualDir lookup —
+		// the for-loop will skip the "eth" entry (false) and match the "fraud" entry (true).
+		await writeFile(
+			sidebarPath,
+			`module.exports = { docsSidebar: [
+				{ type: 'category', label: 'Ethers', link: { type: 'doc', id: 'tools/eth/index' }, items: [
+					'tools/eth/intro'
+				] },
+				{ type: 'category', label: 'Fraud', link: { type: 'doc', id: 'use_cases/fraud/index' }, items: [
+					{ type: 'category', label: 'Ops', items: ['use_cases/fraud/ops/intro'] }
+				] }
+			] }`,
+			"utf-8",
+		);
+
+		const result = await convertDocusaurusSidebar(sidebarPath);
+
+		expect(result.sidebar["/fraud"].ops).toBe("Ops");
+		expect(result.sidebar["/fraud/ops"]).toBeDefined();
+		expect(result.pathMappings["tools/eth"]).toBe("eth");
+	});
+
+	it("skips sidebar items with unknown type", async () => {
+		const { convertDocusaurusSidebar } = await import("./DocusaurusConverter.js");
+		const sidebarPath = join(tempDir, "sidebars.js");
+		await writeFile(
+			sidebarPath,
+			`module.exports = { docsSidebar: [
+				'intro',
+				{ type: 'html', value: '<hr />' }
+			] }`,
+			"utf-8",
+		);
+
+		const result = await convertDocusaurusSidebar(sidebarPath);
+
+		expect(result.sidebar["/"].intro).toBe("Intro");
+		expect(Object.keys(result.sidebar["/"])).toHaveLength(1);
+	});
+
+	it("falls back to slugified label when actualDir has no segments", async () => {
+		const { convertDocusaurusSidebar } = await import("./DocusaurusConverter.js");
+		const sidebarPath = join(tempDir, "sidebars.js");
+		// link.id has only one segment; first item is a string with no slash;
+		// so resolveCategoryActualDir falls back to /slugify(label).
+		await writeFile(
+			sidebarPath,
+			`module.exports = { docsSidebar: [
+				{ type: 'category', label: 'Quick Start', link: { type: 'doc', id: 'intro' }, items: ['overview'] }
+			] }`,
+			"utf-8",
+		);
+
+		const result = await convertDocusaurusSidebar(sidebarPath);
+
+		expect(result.sidebar["/"]["quick-start"]).toBe("Quick Start");
+	});
+
+	it("falls back to slugified label when first doc item id has no slash", async () => {
+		const { convertDocusaurusSidebar } = await import("./DocusaurusConverter.js");
+		const sidebarPath = join(tempDir, "sidebars.js");
+		await writeFile(
+			sidebarPath,
+			`module.exports = { docsSidebar: [
+				{ type: 'category', label: 'Reference', items: [
+					{ type: 'doc', id: 'overview' }
+				] }
+			] }`,
+			"utf-8",
+		);
+
+		const result = await convertDocusaurusSidebar(sidebarPath);
+
+		expect(result.sidebar["/"].reference).toBe("Reference");
+	});
+
+	it("falls back to slugified label when actualDir resolves to root under a remapped parent", async () => {
+		const { convertDocusaurusSidebar } = await import("./DocusaurusConverter.js");
+		const sidebarPath = join(tempDir, "sidebars.js");
+		// Outer category remaps use_cases/fraud -> /fraud, so the inner
+		// category sits under a non-root parent. The inner category's items
+		// have no slashes and its label slugifies to "", so actualDir is "/"
+		// — different from parentActualDir, which means collectEntries doesn't
+		// flatten and resolveCategoryKey runs with empty segments, exercising
+		// the || slugify(label) fallback branch.
+		await writeFile(
+			sidebarPath,
+			`module.exports = { docsSidebar: [
+				{ type: 'category', label: 'Fraud', link: { type: 'doc', id: 'use_cases/fraud/index' }, items: [
+					{ type: 'category', label: '???', items: ['intro'] }
+				] }
+			] }`,
+			"utf-8",
+		);
+
+		const result = await convertDocusaurusSidebar(sidebarPath);
+
+		expect(result.sidebar["/fraud"]).toBeDefined();
+	});
+
+	it("does not overwrite existing pathMapping when a doc reuses the same actual dir", async () => {
+		const { convertDocusaurusSidebar } = await import("./DocusaurusConverter.js");
+		const sidebarPath = join(tempDir, "sidebars.js");
+		// Outer category creates pathMapping use_cases/fraud -> fraud, then a
+		// doc child whose actualDir is also use_cases/fraud — addDocPathMapping
+		// must short-circuit because pathMappings[actualDir] already exists.
+		await writeFile(
+			sidebarPath,
+			`module.exports = { docsSidebar: [
+				{ type: 'category', label: 'Fraud', link: { type: 'doc', id: 'use_cases/fraud/index' }, items: [
+					{ type: 'doc', id: 'use_cases/fraud/intro', label: 'Intro' }
+				] }
+			] }`,
+			"utf-8",
+		);
+
+		const result = await convertDocusaurusSidebar(sidebarPath);
+
+		expect(result.pathMappings["use_cases/fraud"]).toBe("fraud");
+	});
 });

--- a/cli/src/site/DocusaurusConverter.ts
+++ b/cli/src/site/DocusaurusConverter.ts
@@ -176,7 +176,9 @@ function addSidebarEntry(
 	if (!sidebar.has(dirPath)) {
 		sidebar.set(dirPath, []);
 	}
+	/* v8 ignore start -- defensive: `has` above guarantees `get` returns the array */
 	const entries = sidebar.get(dirPath) ?? [];
+	/* v8 ignore stop */
 	if (!entries.some(([k]) => k === key)) {
 		entries.push([key, value]);
 	}
@@ -268,7 +270,9 @@ function addDocPathMapping(docId: string, logicalDir: string, pathMappings: Path
 	// The doc is in a different directory — add folder mapping
 	if (!pathMappings[actualDir]) {
 		const folderName = parts[parts.length - 2]; // "fraud_detection"
+		/* v8 ignore start -- defensive: `!logicalDirRel` guard above already returned */
 		const logicalTarget = logicalDirRel ? `${logicalDirRel}/${folderName}` : folderName;
+		/* v8 ignore stop */
 		pathMappings[actualDir] = logicalTarget;
 	}
 }

--- a/cli/src/site/EngineManager.test.ts
+++ b/cli/src/site/EngineManager.test.ts
@@ -3,10 +3,18 @@
  */
 
 import { existsSync, lstatSync, readFileSync } from "node:fs";
+import * as fsPromises from "node:fs/promises";
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Re-export node:fs/promises through a mock so individual tests can `vi.spyOn`
+// specific members (ESM exports are not configurable by default).
+vi.mock("node:fs/promises", async (importOriginal) => {
+	const original = await importOriginal<typeof import("node:fs/promises")>();
+	return { ...original };
+});
 
 // ─── Mock homedir to use temp directory ─────────────────────────────────────
 
@@ -317,19 +325,36 @@ describe("EngineManager.ensureEngine lock contention early return", () => {
 	it("returns success when engine becomes ready while waiting for lock", async () => {
 		const { ensureEngine, getEngineDir, computeDepsHash } = await import("./EngineManager.js");
 		const engineDir = getEngineDir();
-		// Create a fresh lock (not stale) to simulate another process installing
+		// Pre-create the engine dir + a fresh lock so acquireLock fails and we
+		// enter the waitForLock branch. engineNeedsInstall is true here.
 		await mkdir(engineDir, { recursive: true });
-		await writeFile(join(engineDir, ".install-lock"), String(Date.now()));
-		// Also create a valid engine so that after "waiting", engineNeedsInstall returns false
-		await mkdir(join(engineDir, "node_modules"), { recursive: true });
-		await writeFile(
-			join(engineDir, "engine.json"),
-			JSON.stringify({ depsHash: computeDepsHash(), installedAt: new Date().toISOString() }),
-		);
+		const lockPath = join(engineDir, ".install-lock");
+		await writeFile(lockPath, String(Date.now()));
 
+		// Spy on readFile: when waitForLock reads the lock contents, simulate
+		// another process having finished the install (write engine.json +
+		// node_modules) and return a stale timestamp so waitForLock releases
+		// the lock and returns true. The second engineNeedsInstall() inside
+		// ensureEngine then sees the engine as ready and hits the early return.
+		const readFileSpy = vi.spyOn(fsPromises, "readFile").mockImplementation((async (path: string) => {
+			if (typeof path === "string" && path.endsWith(".install-lock")) {
+				await mkdir(join(engineDir, "node_modules"), { recursive: true });
+				await writeFile(
+					join(engineDir, "engine.json"),
+					JSON.stringify({ depsHash: computeDepsHash(), installedAt: new Date().toISOString() }),
+				);
+				return "0"; // stale timestamp -> waitForLock releases + returns true
+			}
+			throw new Error(`unexpected readFile path: ${String(path)}`);
+		}) as typeof fsPromises.readFile);
+
+		mockSpawnSync.mockClear();
 		const result = await ensureEngine();
+		readFileSpy.mockRestore();
 
-		// Should detect engine is ready without running npm install
 		expect(result.success).toBe(true);
+		expect(result.output).toBe("");
+		// Should detect engine is ready without running npm install
+		expect(mockSpawnSync).not.toHaveBeenCalled();
 	});
 });

--- a/cli/src/site/EngineManager.ts
+++ b/cli/src/site/EngineManager.ts
@@ -174,7 +174,8 @@ export async function linkEngineModules(buildDir: string): Promise<void> {
 	}
 
 	await mkdir(buildDir, { recursive: true });
-	await symlink(target, linkPath, process.platform === "win32" ? "junction" : "dir");
+	const symlinkType = process.platform === "win32" ? /* v8 ignore next */ "junction" : "dir";
+	await symlink(target, linkPath, symlinkType);
 }
 
 // ─── Lock helpers ───────────────────────────────────────────────────────────

--- a/cli/src/site/NpmRunner.test.ts
+++ b/cli/src/site/NpmRunner.test.ts
@@ -13,7 +13,7 @@
  */
 
 import { join } from "node:path";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // ─── Mocks ────────────────────────────────────────────────────────────────────
 
@@ -279,17 +279,18 @@ describe("NpmRunner.runNpmBuild", () => {
 /** Creates a mock ChildProcess with stdout/stderr streams for pipe mode. */
 function makeMockChild() {
 	const handlers: Record<string, ((...args: unknown[]) => void)[]> = {};
-	const streamHandlers: Record<string, ((...args: unknown[]) => void)[]> = {};
-	const mockStream = {
+	const stdoutHandlers: Record<string, ((...args: unknown[]) => void)[]> = {};
+	const stderrHandlers: Record<string, ((...args: unknown[]) => void)[]> = {};
+	const makeStream = (store: Record<string, ((...args: unknown[]) => void)[]>) => ({
 		on(event: string, handler: (...args: unknown[]) => void) {
-			if (!streamHandlers[event]) streamHandlers[event] = [];
-			streamHandlers[event].push(handler);
+			if (!store[event]) store[event] = [];
+			store[event].push(handler);
 			return this;
 		},
-	};
+	});
 	return {
-		stdout: mockStream,
-		stderr: { on: vi.fn() },
+		stdout: makeStream(stdoutHandlers),
+		stderr: makeStream(stderrHandlers),
 		on(event: string, handler: (...args: unknown[]) => void) {
 			if (!handlers[event]) handlers[event] = [];
 			handlers[event].push(handler);
@@ -297,6 +298,12 @@ function makeMockChild() {
 		},
 		emit(event: string, ...args: unknown[]) {
 			for (const h of handlers[event] ?? []) h(...args);
+		},
+		emitStdout(event: string, ...args: unknown[]) {
+			for (const h of stdoutHandlers[event] ?? []) h(...args);
+		},
+		emitStderr(event: string, ...args: unknown[]) {
+			for (const h of stderrHandlers[event] ?? []) h(...args);
 		},
 	};
 }
@@ -369,5 +376,133 @@ describe("NpmRunner.runNpmDev", () => {
 		expect(invocation).toContain("npm");
 		expect(invocation).toContain("dev");
 		expect(call[2]).toEqual(expect.objectContaining({ cwd: "/my/build/dir", stdio: "pipe" }));
+	});
+
+	// Trigger stdout/stderr data events to cover the child.stdout?.on / child.stderr?.on callback bodies.
+	it("forwards stdout data chunks to the output filter", async () => {
+		const { runNpmDev } = await import("./NpmRunner.js");
+		const child = makeMockChild();
+		mockSpawn.mockReturnValue(child);
+
+		const promise = runNpmDev("/build/dir");
+		child.emitStdout("data", Buffer.from("ready - started server"));
+		child.emit("close", 0);
+
+		const result = await promise;
+		expect(result.url).toBe("http://localhost:3000");
+	});
+
+	it("forwards stderr data chunks to the output filter", async () => {
+		const { runNpmDev } = await import("./NpmRunner.js");
+		const child = makeMockChild();
+		mockSpawn.mockReturnValue(child);
+
+		const promise = runNpmDev("/build/dir");
+		child.emitStderr("data", Buffer.from("warning: something"));
+		child.emit("close", 0);
+
+		const result = await promise;
+		expect(result.success).toBe(true);
+	});
+});
+
+// ─── runServe ─────────────────────────────────────────────────────────────────
+
+describe("NpmRunner.runServe", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("spawns npx serve out inside buildDir", async () => {
+		const { runServe } = await import("./NpmRunner.js");
+		const child = makeMockChild();
+		mockSpawn.mockReturnValue(child);
+
+		const promise = runServe("/my/build/dir");
+		child.emit("close", 0);
+
+		const result = await promise;
+		expect(result.success).toBe(true);
+
+		const call = mockSpawn.mock.calls[0];
+		const invocation = `${call[0]} ${(call[1] ?? []).join(" ")}`;
+		expect(invocation).toContain("npx");
+		expect(invocation).toContain("serve");
+		expect(invocation).toContain("out");
+		expect(call[2]).toEqual(expect.objectContaining({ cwd: "/my/build/dir", stdio: "pipe" }));
+	});
+});
+
+// ─── runNpmStart ──────────────────────────────────────────────────────────────
+
+describe("NpmRunner.runNpmStart", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("spawns npm start inside buildDir", async () => {
+		const { runNpmStart } = await import("./NpmRunner.js");
+		const child = makeMockChild();
+		mockSpawn.mockReturnValue(child);
+
+		const promise = runNpmStart("/my/build/dir");
+		child.emit("close", 0);
+
+		const result = await promise;
+		expect(result.success).toBe(true);
+
+		const call = mockSpawn.mock.calls[0];
+		const invocation = `${call[0]} ${(call[1] ?? []).join(" ")}`;
+		expect(invocation).toContain("npm");
+		expect(invocation).toContain("start");
+		expect(call[2]).toEqual(expect.objectContaining({ cwd: "/my/build/dir", stdio: "pipe" }));
+	});
+});
+
+// ─── Windows platform branch ──────────────────────────────────────────────────
+//
+// The module-level `IS_WIN = process.platform === "win32"` and the ternary in
+// `shellCmd` are constants evaluated once at module load. To cover the
+// IS_WIN === true branch we stub `process.platform` and then force a fresh
+// module load via `vi.resetModules()`.
+describe("NpmRunner on Windows", () => {
+	const originalPlatform = process.platform;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		vi.resetModules();
+		Object.defineProperty(process, "platform", { value: "win32", configurable: true });
+	});
+
+	afterEach(() => {
+		Object.defineProperty(process, "platform", { value: originalPlatform, configurable: true });
+	});
+
+	it("joins cmd and args into a single string with shell: true for runNpmBuild", async () => {
+		const { runNpmBuild } = await import("./NpmRunner.js");
+		mockSpawnSync.mockReturnValue(makeSpawnResult(0));
+
+		await runNpmBuild("/my/build/dir");
+
+		const call = mockSpawnSync.mock.calls[0];
+		// On Windows it should be the single string "npm run build" with empty args.
+		expect(call[0]).toBe("npm run build");
+		expect(call[1]).toEqual([]);
+		expect(call[2]).toEqual(expect.objectContaining({ shell: true }));
+	});
+
+	it("joins cmd and args into a single string with shell: true for runNpmDev", async () => {
+		const { runNpmDev } = await import("./NpmRunner.js");
+		const child = makeMockChild();
+		mockSpawn.mockReturnValue(child);
+
+		const promise = runNpmDev("/build/dir");
+		child.emit("close", 0);
+		await promise;
+
+		const call = mockSpawn.mock.calls[0];
+		expect(call[0]).toBe("npm run dev");
+		expect(call[1]).toEqual([]);
+		expect(call[2]).toEqual(expect.objectContaining({ shell: true }));
 	});
 });

--- a/cli/src/site/ScopePageMap.test.ts
+++ b/cli/src/site/ScopePageMap.test.ts
@@ -241,6 +241,40 @@ describe("scopePageMap — edge cases", () => {
 		const result = scopePageMap(pageMap, "/getting-started");
 		expect(getData(result)["some-page"]).toBe("api-something-in-label");
 	});
+
+	it("passes a non-object active-spec data entry through unhideActiveSpec unchanged", () => {
+		// String / null data values for an api-* key skip the href/display strip
+		// and survive verbatim — exercises the early-return guard.
+		const pageMap = buildPageMap({
+			dataEntries: {
+				"api-petstore": "Petstore Label",
+				"api-nullish": null,
+			},
+			folderNames: ["api-petstore"],
+		});
+		const result = scopePageMap(pageMap, "/api-petstore");
+		const data = getData(result);
+		expect(data["api-petstore"]).toBe("Petstore Label");
+		expect(data["api-nullish"]).toBeUndefined();
+	});
+
+	it("strips href on the active non-api section so Nextra folder-binds it for sidebar scoping", () => {
+		// When the URL is under a non-api section (e.g. /docs/intro) and that
+		// section's data entry is a type:"page" link, the wrapper strips the
+		// href so Nextra binds the folder instead of routing to the link target.
+		const pageMap = buildPageMap({
+			dataEntries: {
+				docs: { title: "Docs", type: "page", href: "/docs" },
+				other: { title: "Other", type: "page", href: "/other" },
+			},
+			folderNames: ["docs", "other"],
+		});
+		const result = scopePageMap(pageMap, "/docs/intro");
+		const data = getData(result);
+		expect(data.docs).toEqual({ title: "Docs", type: "page" });
+		// Non-active sections pass through with href intact.
+		expect(data.other).toEqual({ title: "Other", type: "page", href: "/other" });
+	});
 });
 
 // ─── Parity: SCOPE_PAGE_MAP_RUNTIME_SOURCE matches the typed function ───────

--- a/cli/src/site/SiteJsonReader.test.ts
+++ b/cli/src/site/SiteJsonReader.test.ts
@@ -633,4 +633,97 @@ describe("SiteJsonReader.readSiteJson", () => {
 		expect(result.config.footer?.socialLinks?.twitter).toBe("https://twitter.com/acme");
 		expect(result.config.footer?.socialLinks?.x).toBeUndefined();
 	});
+
+	// ── branding.logo present but all fields undefined ──────────────────────
+
+	it("leaves theme.logo* unchanged when branding.logo has no defined fields", async () => {
+		const { readSiteJson } = await import("./SiteJsonReader.js");
+		const siteJson = {
+			title: "T",
+			description: "D",
+			nav: [],
+			branding: { logo: {} },
+		};
+		await writeFile(join(tempDir, "site.json"), JSON.stringify(siteJson), "utf-8");
+		const result = await readSiteJson(tempDir);
+		expect(result.config.theme?.logoUrl).toBeUndefined();
+		expect(result.config.theme?.logoUrlDark).toBeUndefined();
+		expect(result.config.theme?.logoText).toBeUndefined();
+		expect(result.config.theme?.logoDisplay).toBeUndefined();
+	});
+
+	// ── docusaurus favicon extraction ───────────────────────────────────────
+
+	it("copies favicon from docusaurus config into site.json", async () => {
+		mockPromptSequence("y", "Docs With Favicon");
+		const { readSiteJson } = await import("./SiteJsonReader.js");
+		await writeFile(join(tempDir, "sidebars.js"), `module.exports = { docsSidebar: ['intro'] }`, "utf-8");
+		await writeFile(
+			join(tempDir, "docusaurus.config.js"),
+			`module.exports = { favicon: "img/favicon.ico" }`,
+			"utf-8",
+		);
+
+		const result = await readSiteJson(tempDir);
+
+		expect(result.config.favicon).toBeDefined();
+		expect(result.config.favicon).toContain("favicon.ico");
+	});
+
+	// ── catch block when convertDocusaurusSidebar throws ────────────────────
+
+	it("warns and continues when docusaurus sidebar conversion throws an Error", async () => {
+		mockPromptSequence("y", "Title");
+		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+		const { readSiteJson } = await import("./SiteJsonReader.js");
+		// A "link" item with no label triggers slugify(undefined) → TypeError inside the converter.
+		await writeFile(
+			join(tempDir, "sidebars.js"),
+			`module.exports = { docsSidebar: [{ type: 'link', href: '/x' }] }`,
+			"utf-8",
+		);
+
+		const result = await readSiteJson(tempDir);
+
+		expect(result.usedDefault).toBe(true);
+		expect(result.config.sidebar).toBeUndefined();
+		const output = warnSpy.mock.calls.map((c: unknown[]) => c.join(" ")).join("\n");
+		expect(output).toContain("Failed to convert sidebar");
+	});
+
+	it("warns when docusaurus sidebar conversion throws a non-Error value", async () => {
+		mockPromptSequence("y", "Title");
+		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+		vi.resetModules();
+		vi.doMock("./DocusaurusConverter.js", async () => {
+			const actual = await vi.importActual<typeof import("./DocusaurusConverter.js")>("./DocusaurusConverter.js");
+			return {
+				...actual,
+				convertDocusaurusSidebar: vi.fn(async () => {
+					throw "string-error";
+				}),
+			};
+		});
+		const { readSiteJson } = await import("./SiteJsonReader.js");
+		await writeFile(join(tempDir, "sidebars.js"), `module.exports = { docsSidebar: ['intro'] }`, "utf-8");
+
+		const result = await readSiteJson(tempDir);
+
+		expect(result.usedDefault).toBe(true);
+		const output = warnSpy.mock.calls.map((c: unknown[]) => c.join(" ")).join("\n");
+		expect(output).toContain("string-error");
+		vi.doUnmock("./DocusaurusConverter.js");
+	});
+
+	// ── JSON.parse throws a non-Error value ─────────────────────────────────
+
+	it("formats the parse error when JSON.parse throws a non-Error value", async () => {
+		const { readSiteJson } = await import("./SiteJsonReader.js");
+		await writeFile(join(tempDir, "site.json"), "{}", "utf-8");
+		vi.spyOn(JSON, "parse").mockImplementationOnce(() => {
+			throw "boom";
+		});
+
+		await expect(readSiteJson(tempDir)).rejects.toThrow("boom");
+	});
 });

--- a/cli/src/site/SourceWatcher.test.ts
+++ b/cli/src/site/SourceWatcher.test.ts
@@ -9,6 +9,13 @@ import { EventEmitter } from "node:events";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { startSourceWatcher, type WatchFactory } from "./SourceWatcher.js";
 
+// Mock `chokidar` so the default-factory branch (`opts.watchFactory ?? chokidarWatch`)
+// can be exercised without touching the real filesystem.
+const { mockChokidarWatch } = vi.hoisted(() => ({
+	mockChokidarWatch: vi.fn(),
+}));
+vi.mock("chokidar", () => ({ watch: mockChokidarWatch }));
+
 // ─── Stub factory ──────────────────────────────────────────────────────────
 
 interface StubWatcher extends EventEmitter {
@@ -247,6 +254,21 @@ describe("startSourceWatcher", () => {
 
 		expect(onChange).not.toHaveBeenCalled();
 		expect(stub.closeMock).toHaveBeenCalled();
+	});
+
+	it("falls back to the default chokidar.watch factory when none is supplied", async () => {
+		const { factory, getWatcher } = makeStubFactory();
+		// Route the default `chokidar.watch` through our stub factory so we don't
+		// touch the real filesystem.
+		mockChokidarWatch.mockImplementationOnce(factory);
+
+		const onChange = vi.fn().mockResolvedValue(undefined);
+		const watcher = startSourceWatcher("/src", { onChange });
+
+		expect(mockChokidarWatch).toHaveBeenCalledWith("/src", expect.objectContaining({ ignoreInitial: true }));
+
+		await watcher.close();
+		expect(getWatcher().closeMock).toHaveBeenCalled();
 	});
 
 	it("ignores events that fire after close()", async () => {

--- a/cli/src/site/StarterKit.test.ts
+++ b/cli/src/site/StarterKit.test.ts
@@ -12,7 +12,21 @@ import { existsSync } from "node:fs";
 import { mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Hoisted mock — defaults to the real mkdir, individual tests can override.
+const { mockMkdir } = vi.hoisted(() => ({
+	mockMkdir: vi.fn(),
+}));
+
+vi.mock("node:fs/promises", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("node:fs/promises")>();
+	mockMkdir.mockImplementation(actual.mkdir);
+	return {
+		...actual,
+		mkdir: mockMkdir,
+	};
+});
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -260,5 +274,19 @@ describe("StarterKit.scaffoldProject", () => {
 
 		expect(result.success).toBe(false);
 		expect(result.message).toBeTruthy();
+	});
+
+	it("stringifies non-Error throwables when a filesystem operation rejects with a primitive", async () => {
+		// Force mkdir to reject with a plain string so the catch block walks the
+		// `String(err)` branch instead of `err.message`.
+		mockMkdir.mockRejectedValueOnce("plain-string-failure");
+
+		const { scaffoldProject } = await import("./StarterKit.js");
+		const targetDir = join(tempBase, "non-error-throw");
+
+		const result = await scaffoldProject(targetDir);
+
+		expect(result.success).toBe(false);
+		expect(result.message).toBe("plain-string-failure");
 	});
 });

--- a/cli/src/site/StructureParser.test.ts
+++ b/cli/src/site/StructureParser.test.ts
@@ -518,3 +518,139 @@ describe("multi-segment hrefs", () => {
 		expect(root.intro).toBe("Intro");
 	});
 });
+
+// ─── Edge cases ─────────────────────────────────────────────────────────────
+
+describe("edge cases", () => {
+	it("parsePages returns defaultPageHref '/' for empty pages array", () => {
+		const result = parsePages([]);
+		expect(result.defaultPageHref).toBe("/");
+		expect(result.pages).toEqual([]);
+		expect(result.rootPages).toEqual([]);
+		expect(result.openapiPages).toEqual([]);
+	});
+
+	it("parseNavigation skips validation body for pages without content (menu, openapi)", () => {
+		const pages: NavigationPage[] = [
+			{ page: "Menu", type: "menu", items: [{ label: "Slack", url: "https://slack.example.com" }] },
+			{ page: "API", openapi: "./api.yaml" },
+		];
+		const result = parseNavigation(pages);
+		expect(result.pages).toHaveLength(2);
+		expect(result.openapiPages).toHaveLength(1);
+	});
+
+	it("page.root='/' is preserved as the root href", () => {
+		const pages: NavigationPage[] = [{ page: "Home", root: "/", content: [] }];
+		const result = parsePages(pages);
+		expect(result.pages?.[0].href).toBe("/");
+		expect(result.pages?.[0].key).toBe("/");
+		expect(result.defaultPageHref).toBe("/");
+	});
+
+	it("page.root without leading slash is normalized", () => {
+		const pages: NavigationPage[] = [{ page: "Docs", root: "docs-no-slash", content: [] }];
+		const result = parsePages(pages);
+		expect(result.pages?.[0].href).toBe("/docs-no-slash");
+	});
+
+	it("openapi page with non-'api-' root keeps the full key as specName", () => {
+		const pages: NavigationPage[] = [{ page: "Spec", root: "/openapi-direct", openapi: "./spec.yaml" }];
+		const result = parsePages(pages);
+		expect(result.openapiPages?.[0]).toEqual({
+			key: "openapi-direct",
+			title: "Spec",
+			href: "/openapi-direct",
+			specPath: "./spec.yaml",
+			specName: "openapi-direct",
+		});
+	});
+
+	it("group with root and empty content writes no sidebar entry for the group path", () => {
+		const nav = [{ group: "Empty Group", root: "empty", content: [] } as NavigationGroup];
+		const result = parseNavigation(nav);
+		expect(result.sidebar["/"].empty).toBe("Empty Group");
+		expect(result.sidebar["/empty"]).toBeUndefined();
+	});
+
+	it("group root with leading slash is joined correctly with the path prefix", () => {
+		const nav = [
+			{
+				group: "API",
+				root: "/api",
+				content: [{ article: "Users", href: "users" } as NavigationArticle],
+			} as NavigationGroup,
+		];
+		const result = parseNavigation(nav);
+		expect(result.sidebar["/"].api).toBe("API");
+		expect(result.sidebar["/api"].users).toBe("Users");
+	});
+
+	it("three-segment group root populates intermediate _meta entries", () => {
+		const nav = [
+			{
+				group: "Deep",
+				root: "a/b/c",
+				content: [{ article: "Leaf", href: "leaf" } as NavigationArticle],
+			} as NavigationGroup,
+		];
+		const result = parseNavigation(nav);
+		expect(result.sidebar["/"].a).toBe("a");
+		expect(result.sidebar["/a"].b).toBe("b");
+		expect(result.sidebar["/a/b"].c).toBe("Deep");
+		expect(result.sidebar["/a/b/c"].leaf).toBe("Leaf");
+	});
+
+	it("two groups sharing the same multi-segment root reuse intermediate dirs", () => {
+		const nav = [
+			{
+				group: "First",
+				root: "shared/one",
+				content: [{ article: "A", href: "a" } as NavigationArticle],
+			} as NavigationGroup,
+			{
+				group: "Second",
+				root: "shared/two",
+				content: [{ article: "B", href: "b" } as NavigationArticle],
+			} as NavigationGroup,
+		];
+		const result = parseNavigation(nav);
+		expect(result.sidebar["/shared"].one).toBe("First");
+		expect(result.sidebar["/shared"].two).toBe("Second");
+		expect(result.sidebar["/shared/one"].a).toBe("A");
+		expect(result.sidebar["/shared/two"].b).toBe("B");
+	});
+
+	it("article with absolute href and nested children resolves parentDir from href", () => {
+		const nav = [
+			{
+				article: "Guide",
+				href: "/guide",
+				articles: [{ article: "Step", href: "step" } as NavigationArticle],
+			} as NavigationArticle,
+		];
+		const result = parseNavigation(nav);
+		expect(result.sidebar["/"].guide).toBe("Guide");
+		expect(result.sidebar["/guide"].step).toBe("Step");
+	});
+
+	it("article with multi-segment relative href and nested children resolves parentDir via joinPath", () => {
+		const nav = [
+			{
+				group: "Guides",
+				root: "guides",
+				content: [
+					{
+						article: "Multi",
+						href: "a/b",
+						articles: [{ article: "Child", href: "child" } as NavigationArticle],
+					} as NavigationArticle,
+				],
+			} as NavigationGroup,
+		];
+		const result = parseNavigation(nav);
+		expect(result.sidebar["/guides"].a).toBe("a");
+		expect(result.sidebar["/guides/a"].b).toBe("Multi");
+		expect(result.sidebar["/guides/a"].child).toBe("Child");
+	});
+});

--- a/cli/src/site/Types.ts
+++ b/cli/src/site/Types.ts
@@ -115,11 +115,10 @@ export type SidebarOverrides = Record<string, Record<string, SidebarItemValue>>;
 export type PathMappings = Record<string, string>;
 
 /**
- * A `ThemePack` value is a theme pack name, a path, or a package reference:
- *   - `"forge"` / `"atlas"` — well-known external packs (installed via npm or GitHub)
+ * A `ThemePack` value is a theme pack name or a path:
+ *   - `"forge"` / `"atlas"` — well-known external packs (installed from the GitHub registry)
  *   - `"default"` — vanilla `nextra-theme-docs` (no pack CSS)
  *   - `"./my-theme.js"` — local file path (resolved relative to source root)
- *   - `"@acme/docs-theme"` — npm package name
  *
  * The `(string & {})` intersection keeps TypeScript's autocomplete for
  * well-known names while accepting any arbitrary string.

--- a/cli/src/site/openapi/CodeSampleGenerator.test.ts
+++ b/cli/src/site/openapi/CodeSampleGenerator.test.ts
@@ -70,6 +70,10 @@ describe("toPythonLiteral", () => {
 	it("escapes string special characters via JSON.stringify", () => {
 		expect(toPythonLiteral('quote "inside"')).toBe('"quote \\"inside\\""');
 	});
+
+	it("falls back to JSON.stringify for values not handled by the typed branches (symbol)", () => {
+		expect(toPythonLiteral(Symbol("x") as unknown)).toBe(undefined as unknown as string);
+	});
 });
 
 // ─── goStringLiteral ─────────────────────────────────────────────────────────
@@ -164,6 +168,18 @@ describe("generateCodeSamples — body handling", () => {
 		expect(samples.curl).toContain("https://api.example.com/widgets");
 		expect(samples.curl).not.toContain("//widgets");
 	});
+
+	it("falls back to an empty `{}` body across all languages when requestBody is present but example/schema yield no value", () => {
+		const op = makeOp({
+			requestBody: { required: true, contentType: "application/json", example: null },
+		});
+		const samples = generateCodeSamples(op, "https://api.example.com", NO_SCHEMES);
+		expect(samples.curl).toContain("-d '{}'");
+		expect(samples.js).toContain("JSON.stringify({})");
+		expect(samples.ts).toContain("JSON.stringify({})");
+		expect(samples.python).toContain("payload = {}");
+		expect(samples.go).toContain("strings.NewReader(`{}`)");
+	});
 });
 
 // ─── generateCodeSamples — parameters & auth ─────────────────────────────────
@@ -249,6 +265,24 @@ describe("generateCodeSamples — parameters and auth", () => {
 		const op = makeOp({ method: "get", path: "/me", security: [{ ghost: [] }] });
 		const samples = generateCodeSamples(op, "https://api.example.com", NO_SCHEMES);
 		expect(samples.curl).not.toContain("Authorization");
+	});
+
+	it("emits no auth placeholder for an apiKey scheme whose `in` is neither header nor query", () => {
+		const op = makeOp({ method: "get", path: "/me", security: [{ apiKey: [] }] });
+		const samples = generateCodeSamples(op, "https://api.example.com", {
+			apiKey: { type: "apiKey", name: "session", in: "cookie" } as OpenApiSecurityScheme,
+		});
+		expect(samples.curl).not.toContain("YOUR_API_KEY");
+		expect(samples.curl).not.toContain("session");
+	});
+
+	it("ignores unrecognised security scheme types (e.g. mutualTLS)", () => {
+		const op = makeOp({ method: "get", path: "/me", security: [{ mtls: [] }] });
+		const samples = generateCodeSamples(op, "https://api.example.com", {
+			mtls: { type: "mutualTLS" } as unknown as OpenApiSecurityScheme,
+		});
+		expect(samples.curl).not.toContain("Authorization");
+		expect(samples.curl).not.toContain("YOUR_");
 	});
 });
 

--- a/cli/src/site/openapi/SpecParser.test.ts
+++ b/cli/src/site/openapi/SpecParser.test.ts
@@ -515,3 +515,162 @@ describe("parseFullSpec — robustness", () => {
 		expect(spec.tags.map((t) => t.name)).toEqual(["good"]);
 	});
 });
+
+// ─── Optional field passthrough (schema / example / description) ─────────────
+
+describe("parseFullSpec — optional field passthrough", () => {
+	it("returns undefined when a $ref walks through a non-object segment", () => {
+		// `info.title` is a string, so descending into `info/title/anything`
+		// hits the non-object guard inside resolveRef and bails out.
+		const doc = makeDoc({
+			info: { title: "T", version: "1" },
+			paths: {
+				"/x": { get: { parameters: [{ $ref: "#/info/title/nope" }] } },
+			},
+		});
+		const spec = parseFullSpec(doc);
+		expect(spec.operations[0].parameters).toEqual([]);
+	});
+
+	it("carries schema and example through on parameter entries", () => {
+		const schema = { type: "integer", minimum: 1 };
+		const doc = makeDoc({
+			paths: {
+				"/x": {
+					get: {
+						parameters: [{ name: "limit", in: "query", schema, example: 25 }],
+					},
+				},
+			},
+		});
+		const spec = parseFullSpec(doc);
+		expect(spec.operations[0].parameters[0].schema).toBe(schema);
+		expect(spec.operations[0].parameters[0].example).toBe(25);
+	});
+
+	it("carries description and media-type example through on the request body", () => {
+		const example = { name: "ada" };
+		const doc = makeDoc({
+			paths: {
+				"/x": {
+					post: {
+						requestBody: {
+							description: "the payload",
+							content: { "application/json": { schema: { type: "object" }, example } },
+						},
+					},
+				},
+			},
+		});
+		const spec = parseFullSpec(doc);
+		expect(spec.operations[0].requestBody?.description).toBe("the payload");
+		expect(spec.operations[0].requestBody?.example).toBe(example);
+	});
+
+	it("carries the media-type example through on responses", () => {
+		const example = { ok: true };
+		const doc = makeDoc({
+			paths: {
+				"/x": {
+					get: {
+						responses: {
+							"200": {
+								description: "ok",
+								content: { "application/json": { schema: { type: "object" }, example } },
+							},
+						},
+					},
+				},
+			},
+		});
+		const spec = parseFullSpec(doc);
+		expect(spec.operations[0].responses[0].example).toBe(example);
+	});
+
+	it("skips responses whose $ref can't be resolved", () => {
+		const doc = makeDoc({
+			paths: {
+				"/x": {
+					get: {
+						responses: {
+							"200": { description: "ok" },
+							"404": { $ref: "#/components/responses/Missing" },
+						},
+					},
+				},
+			},
+			components: { responses: {} },
+		});
+		const spec = parseFullSpec(doc);
+		expect(spec.operations[0].responses.map((r) => r.status)).toEqual(["200"]);
+	});
+
+	it("preserves the operation-level summary and description when supplied", () => {
+		const doc = makeDoc({
+			paths: { "/x": { get: { summary: "list things", description: "the long form" } } },
+		});
+		const spec = parseFullSpec(doc);
+		expect(spec.operations[0].summary).toBe("list things");
+		expect(spec.operations[0].description).toBe("the long form");
+	});
+
+	it("preserves the description on an operation-level servers override entry", () => {
+		const doc = makeDoc({
+			paths: {
+				"/x": {
+					get: {
+						servers: [{ url: "https://override.example.com", description: "ovr" }],
+					},
+				},
+			},
+		});
+		const spec = parseFullSpec(doc);
+		expect(spec.operations[0].servers).toEqual([{ url: "https://override.example.com", description: "ovr" }]);
+	});
+
+	it("supplies sensible defaults when the spec has no info object at all", () => {
+		const doc = { openapi: "3.1.0" } as unknown as OpenApiDocument;
+		const spec = parseFullSpec(doc);
+		expect(spec.info).toEqual({ title: "API Reference", version: "1.0.0", description: "" });
+	});
+
+	it("drops parameter entries whose `in` is not a string", () => {
+		const doc = makeDoc({
+			paths: {
+				"/x": { get: { parameters: [{ name: "broken", in: 42 as unknown as string }] } },
+			},
+		});
+		const spec = parseFullSpec(doc);
+		expect(spec.operations[0].parameters).toEqual([]);
+	});
+
+	it("returns a request body with no schema when the media entry omits it", () => {
+		const doc = makeDoc({
+			paths: {
+				"/x": { post: { requestBody: { content: { "application/json": {} } } } },
+			},
+		});
+		const spec = parseFullSpec(doc);
+		expect(spec.operations[0].requestBody?.contentType).toBe("application/json");
+		expect(spec.operations[0].requestBody?.schema).toBeUndefined();
+	});
+
+	it("returns a response with no description and no schema when both are absent", () => {
+		const doc = makeDoc({
+			paths: {
+				"/x": {
+					get: {
+						responses: {
+							"204": { content: { "application/json": {} } },
+						},
+					},
+				},
+			},
+		});
+		const spec = parseFullSpec(doc);
+		expect(spec.operations[0].responses[0].status).toBe("204");
+		expect(spec.operations[0].responses[0].description).toBeUndefined();
+		expect(spec.operations[0].responses[0].schema).toBeUndefined();
+		expect(spec.operations[0].responses[0].contentType).toBe("application/json");
+	});
+});

--- a/cli/src/site/renderer/NextraRenderer.test.ts
+++ b/cli/src/site/renderer/NextraRenderer.test.ts
@@ -115,6 +115,80 @@ describe("NextraRenderer", () => {
 		}
 	});
 
+	// When theme.colors.primary is a valid hex, hue is parsed from it — highest precedence.
+	it("api.css derives accent hue from theme.colors.primary when set (highest precedence)", async () => {
+		const buildDir = await mkdtemp(join(tmpdir(), "jolli-nextra-colors-primary-"));
+		try {
+			// pure red #ff0000 → hue 0; primaryColor and primaryHue should both be overridden
+			const config = {
+				title: "T",
+				description: "D",
+				nav: [],
+				theme: { colors: { primary: "#ff0000" }, primaryColor: "#00ff00", primaryHue: 200 },
+			};
+			await new NextraRenderer().initProject(buildDir, config, { staticExport: true });
+			const css = await readFile(join(buildDir, "styles", "api.css"), "utf-8");
+			expect(css).toContain("hsl(0 84% 50%)");
+		} finally {
+			await rm(buildDir, { recursive: true, force: true });
+		}
+	});
+
+	// When theme.colors.primary is an invalid hex, fall through to the next level (here primaryHue).
+	it("api.css falls through when theme.colors.primary is an invalid hex", async () => {
+		const buildDir = await mkdtemp(join(tmpdir(), "jolli-nextra-colors-invalid-"));
+		try {
+			const config = {
+				title: "T",
+				description: "D",
+				nav: [],
+				theme: { colors: { primary: "not-a-hex" }, primaryHue: 90 },
+			};
+			await new NextraRenderer().initProject(buildDir, config, { staticExport: true });
+			const css = await readFile(join(buildDir, "styles", "api.css"), "utf-8");
+			expect(css).toContain("hsl(90 84% 50%)");
+		} finally {
+			await rm(buildDir, { recursive: true, force: true });
+		}
+	});
+
+	// When theme.primaryColor is a valid hex, hue is parsed from it (used when colors.primary is missing).
+	it("api.css derives accent hue from theme.primaryColor when colors.primary is absent", async () => {
+		const buildDir = await mkdtemp(join(tmpdir(), "jolli-nextra-primarycolor-"));
+		try {
+			// pure blue #0000ff → hue 240
+			const config = {
+				title: "T",
+				description: "D",
+				nav: [],
+				theme: { primaryColor: "#0000ff", primaryHue: 200 },
+			};
+			await new NextraRenderer().initProject(buildDir, config, { staticExport: true });
+			const css = await readFile(join(buildDir, "styles", "api.css"), "utf-8");
+			expect(css).toContain("hsl(240 84% 50%)");
+		} finally {
+			await rm(buildDir, { recursive: true, force: true });
+		}
+	});
+
+	// When theme.primaryColor is an invalid hex, fall through to primaryHue.
+	it("api.css falls through when theme.primaryColor is an invalid hex", async () => {
+		const buildDir = await mkdtemp(join(tmpdir(), "jolli-nextra-primarycolor-invalid-"));
+		try {
+			const config = {
+				title: "T",
+				description: "D",
+				nav: [],
+				theme: { primaryColor: "garbage", primaryHue: 77 },
+			};
+			await new NextraRenderer().initProject(buildDir, config, { staticExport: true });
+			const css = await readFile(join(buildDir, "styles", "api.css"), "utf-8");
+			expect(css).toContain("hsl(77 84% 50%)");
+		} finally {
+			await rm(buildDir, { recursive: true, force: true });
+		}
+	});
+
 	it("api.css uses generateApiCss's internal default (220) when pack has no primaryHue set", async () => {
 		const buildDir = await mkdtemp(join(tmpdir(), "jolli-nextra-nohue-"));
 		try {

--- a/cli/src/site/renderer/nextra/EndpointDataEmitter.test.ts
+++ b/cli/src/site/renderer/nextra/EndpointDataEmitter.test.ts
@@ -224,4 +224,23 @@ describe("emitEndpointData", () => {
 		expect(data.responses[0].schema).toEqual({ type: "object" });
 		expect(data.responses[1].status).toBe("404");
 	});
+
+	it("omits description / contentType / schema on a response that doesn't define them", () => {
+		const op = makeOp({ responses: [{ status: "204" }] });
+		const data = decode(emitEndpointData("petstore", op, makeSpec()).content) as {
+			responses: Array<Record<string, unknown>>;
+		};
+		expect(data.responses[0]).toEqual({ status: "204" });
+	});
+
+	it("omits the request body example when neither a literal example nor a synthesisable schema is supplied", () => {
+		const op = makeOp({
+			requestBody: { required: false, contentType: "application/octet-stream" },
+		});
+		const data = decode(emitEndpointData("petstore", op, makeSpec()).content) as {
+			requestBody: Record<string, unknown>;
+		};
+		expect(data.requestBody).toEqual({ contentType: "application/octet-stream", required: false });
+		expect("example" in data.requestBody).toBe(false);
+	});
 });

--- a/cli/src/site/renderer/nextra/OverviewPageEmitter.test.ts
+++ b/cli/src/site/renderer/nextra/OverviewPageEmitter.test.ts
@@ -77,6 +77,12 @@ describe("emitOverviewPage", () => {
 		expect(file.content).toContain("— Prod");
 	});
 
+	it("omits the description suffix for servers without a description", () => {
+		const file = emitOverviewPage("petstore", makeSpec({ servers: [{ url: "https://api.example.com" }] }));
+		expect(file.content).toContain("- `https://api.example.com`\n");
+		expect(file.content).not.toContain("—");
+	});
+
 	it("groups operations by tag and renders one table per tag (declaration order)", () => {
 		const spec = makeSpec({
 			tags: [{ name: "users", description: "User ops" }, { name: "pets" }],

--- a/cli/src/site/renderer/nextra/OverviewPageEmitter.ts
+++ b/cli/src/site/renderer/nextra/OverviewPageEmitter.ts
@@ -42,9 +42,11 @@ export function emitOverviewPage(specName: string, parsed: ParsedSpec): Template
 	lines.push("## Endpoints");
 	lines.push("");
 	for (const { tag, operations } of operationsByTag) {
+		/* v8 ignore start -- defensive: groupByTag filters out empty groups before returning */
 		if (operations.length === 0) {
 			continue;
 		}
+		/* v8 ignore stop */
 		lines.push(`### ${escapeMdxText(tag.name)}`);
 		lines.push("");
 		if (tag.description) {

--- a/cli/src/site/renderer/nextra/index.test.ts
+++ b/cli/src/site/renderer/nextra/index.test.ts
@@ -98,6 +98,15 @@ describe("emitNextraOpenApiForSpec", () => {
 		expect(mdx?.content).not.toContain("curl -X GET");
 	});
 
+	it("falls back to https://api.example.com when the spec has no servers", () => {
+		// servers: [] forces the `?? "https://api.example.com"` branch.
+		const op = makeOp();
+		const spec = makeSpec({ servers: [], operations: [op] });
+		const files = emitNextraOpenApiForSpec("petstore", { spec, dossiers: [] });
+		const mdx = files.find((f) => f.path === "content/api-petstore/pets/listpets.mdx");
+		expect(mdx?.content).toContain("https://api.example.com");
+	});
+
 	it("returns an empty array if the spec has no operations (just overview, refs, top-level _meta)", () => {
 		const input = makeInput({
 			pipeline: { spec: makeSpec({ operations: [], tags: [] }), dossiers: [] },

--- a/cli/src/site/themes/ThemeRegistry.test.ts
+++ b/cli/src/site/themes/ThemeRegistry.test.ts
@@ -4,7 +4,7 @@ import { join } from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import type { NextraProjectConfig } from "../NextraProjectWriter.js";
 import type { ThemePackProvider } from "./ThemeRegistry.js";
-import { discoverPack, getPack, listPacks, registerPack, resolvePack } from "./ThemeRegistry.js";
+import { discoverPack, getPack, listPacks, readManifestVersion, registerPack, resolvePack } from "./ThemeRegistry.js";
 
 const MINIMAL_CONFIG: NextraProjectConfig = {
 	title: "Test",
@@ -134,5 +134,80 @@ export default theme;
 			{ themePath: testThemeDir },
 		);
 		expect(pack?.manifest.name).toBe("discover-test");
+	});
+});
+
+// ─── readManifestVersion tests ─────────────────────────────────────────────
+//
+// The version check in `checkAndUpdateCachedTheme` deliberately reads
+// manifest.mjs via text scan instead of `await import(...)` — see the long
+// comment in ThemeRegistry.ts for why. These tests pin that behaviour: the
+// extracted version must match what an ESM importer would see for the same
+// file, and the function must never throw for missing / malformed input
+// (callers treat `undefined` as "cached version unknown → fetch fresh").
+
+describe("readManifestVersion", () => {
+	const fixtureDir = join(tmpdir(), "jolli-readmanifest-test");
+
+	beforeAll(() => {
+		mkdirSync(fixtureDir, { recursive: true });
+	});
+
+	afterAll(() => {
+		rmSync(fixtureDir, { recursive: true, force: true });
+	});
+
+	it("extracts the version literal from a typical forge-style manifest", async () => {
+		const path = join(fixtureDir, "forge-style.mjs");
+		writeFileSync(
+			path,
+			`const manifest = {
+	name: "forge",
+	version: "1.2.3",
+	displayName: "Forge",
+	defaults: { primaryHue: 228 },
+};
+export default manifest;
+`,
+		);
+		expect(await readManifestVersion(path)).toBe("1.2.3");
+	});
+
+	it("tolerates single quotes around the version literal", async () => {
+		const path = join(fixtureDir, "single-quote.mjs");
+		writeFileSync(path, `export default { name: 'x', version: '0.9.0' };\n`);
+		expect(await readManifestVersion(path)).toBe("0.9.0");
+	});
+
+	it("tolerates extra whitespace around the colon", async () => {
+		const path = join(fixtureDir, "whitespace.mjs");
+		writeFileSync(path, `export default { version   :    "4.5.6-beta.1" };\n`);
+		expect(await readManifestVersion(path)).toBe("4.5.6-beta.1");
+	});
+
+	it("returns undefined when the file does not exist", async () => {
+		expect(await readManifestVersion(join(fixtureDir, "missing-file.mjs"))).toBeUndefined();
+	});
+
+	it("returns undefined when no version literal is present", async () => {
+		const path = join(fixtureDir, "no-version.mjs");
+		writeFileSync(path, `export default { name: "x", displayName: "X" };\n`);
+		expect(await readManifestVersion(path)).toBeUndefined();
+	});
+
+	it("does not pollute Node's ESM cache (smoke test)", async () => {
+		// Regression: a previous implementation used `await import(fileUrl)` to
+		// read the version, which seeded Node's ESM cache with the file URL.
+		// If `downloadTheme` then overwrote the file, a subsequent re-import of
+		// the same URL would return the stale cached module. The text-scan
+		// implementation must not have that side effect — we verify by reading
+		// once, mutating the file, reading again, and confirming we see the
+		// new version (which an `import()` based reader would *not* see).
+		const path = join(fixtureDir, "mutation.mjs");
+		writeFileSync(path, `export default { version: "1.0.0" };\n`);
+		expect(await readManifestVersion(path)).toBe("1.0.0");
+
+		writeFileSync(path, `export default { version: "2.0.0" };\n`);
+		expect(await readManifestVersion(path)).toBe("2.0.0");
 	});
 });

--- a/cli/src/site/themes/ThemeRegistry.ts
+++ b/cli/src/site/themes/ThemeRegistry.ts
@@ -11,13 +11,11 @@
  *   2. Registry (packs registered at runtime)
  *   3. Explicit file path in site.json (starts with `./` or `/`)
  *   4. User theme directory → ~/.jolli/themes/<name>/index.mjs
- *   5. npm package → jolli-theme-<name>
- *   6. npm scoped package → @jolli/theme-<name>
- *   7. GitHub registry → github.com/jolliai/themes/<name>/
+ *   5. GitHub registry → github.com/jolliai/themes/<name>/
  */
 
 import { existsSync, statSync } from "node:fs";
-import { stat, writeFile } from "node:fs/promises";
+import { readFile, stat, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
@@ -122,9 +120,7 @@ const USER_THEMES_DIR = join(homedir(), ".jolli", "themes");
  *   2. Registry (packs registered at runtime)
  *   3. Explicit file path in site.json (starts with `./` or `/`)
  *   4. User theme directory (`~/.jolli/themes/<name>/index.mjs`)
- *   5. npm package (`jolli-theme-<name>`)
- *   6. npm scoped package (`@jolli/theme-<name>`)
- *   7. GitHub registry (`github.com/jolliai/themes/<name>/`)
+ *   5. GitHub registry (`github.com/jolliai/themes/<name>/`)
  *
  * Returns the provider (now also registered) or `undefined` if not found.
  */
@@ -157,21 +153,7 @@ export async function discoverPack(
 		return loadFromPath(userThemePath);
 	}
 
-	// 5) npm package: jolli-theme-<name>
-	try {
-		return await loadFromModule(`jolli-theme-${name}`);
-	} catch {
-		// not found as npm package
-	}
-
-	// 6) npm scoped package: @jolli/theme-<name>
-	try {
-		return await loadFromModule(`@jolli/theme-${name}`);
-	} catch {
-		// not found
-	}
-
-	// 7) GitHub registry: github.com/jolliai/themes/<name>/
+	// 5) GitHub registry: github.com/jolliai/themes/<name>/
 	//
 	// On any failure here (network unreachable, theme not in repo, …) the
 	// cached copy under ~/.jolli/themes/<name>/ would have been picked up by
@@ -251,18 +233,16 @@ async function checkAndUpdateCachedTheme(name: string, _cachedPath: string): Pro
 	try {
 		const { downloadTheme, githubAuthHeaders } = await import("../../commands/ThemeCommand.js");
 
-		// Read cached version from manifest.mjs
+		// Read cached version from manifest.mjs via text parse — do NOT use
+		// `await import(manifestPath)` here. Node ESM caches modules by URL, and
+		// the relative `import "./manifest.mjs"` inside the theme's index.mjs
+		// resolves to the same file URL. If we imported it now and `downloadTheme`
+		// then overwrote the file, the freshly-loaded index.mjs would still bind
+		// to the cached stale manifest module — leaving the in-process theme
+		// advertising the new buildCss/generateLayout next to old manifest
+		// fields (name, version, supports, defaults).
 		const manifestPath = join(_cachedPath, "manifest.mjs");
-		let cachedVersion: string | undefined;
-		if (existsSync(manifestPath)) {
-			try {
-				const mod = (await import(pathToFileURL(manifestPath).href)) as Record<string, unknown>;
-				const manifest = mod.default as Record<string, unknown> | undefined;
-				cachedVersion = manifest?.version as string | undefined;
-			} catch {
-				// Can't read manifest — treat as outdated
-			}
-		}
+		const cachedVersion = await readManifestVersion(manifestPath);
 
 		// Fetch registry to get latest version
 		const registryUrl = `https://raw.githubusercontent.com/jolliai/themes/main/registry.json`;
@@ -277,8 +257,35 @@ async function checkAndUpdateCachedTheme(name: string, _cachedPath: string): Pro
 		console.log(`  Updating theme "${name}" (${cachedVersion ?? "unknown"} → ${entry.version})...`);
 		await downloadTheme(name, entry.version);
 		console.log(`  ✓ Theme "${name}" updated to ${entry.version}`);
+		// If the theme's index.mjs / css.mjs / layout.mjs were imported earlier
+		// in this process (long-running `jolli dev`), Node's ESM cache keeps
+		// serving the previously-loaded copies — the disk update can't take
+		// effect until the process restarts. Tell the user explicitly so a
+		// successful "Updated to X.Y.Z" message isn't misleading.
+		console.log(`  ↻ Restart the current process to apply the updated theme.`);
 	} catch {
 		// Network error or download failure — keep cached version
+	}
+}
+
+/**
+ * Reads the `version` field from a theme's `manifest.mjs` via a text scan.
+ * Intentionally avoids `import()` so the file URL stays out of Node's ESM
+ * module cache — see the comment in `checkAndUpdateCachedTheme` for why.
+ *
+ * Returns `undefined` when the file is missing, unreadable, or has no
+ * `version: "..."` literal. The caller treats `undefined` as "outdated" and
+ * triggers a fresh download.
+ *
+ * Exported for unit testing — call site is in `checkAndUpdateCachedTheme`.
+ */
+export async function readManifestVersion(manifestPath: string): Promise<string | undefined> {
+	try {
+		const text = await readFile(manifestPath, "utf-8");
+		const match = text.match(/version\s*:\s*["']([^"']+)["']/);
+		return match?.[1];
+	} catch {
+		return undefined;
 	}
 }
 
@@ -306,7 +313,7 @@ async function loadFromPath(themePath: string): Promise<ThemePackProvider> {
 }
 
 /**
- * Dynamically imports a theme module (file URL or npm package name),
+ * Dynamically imports a theme module from a file URL,
  * validates the default export, and registers it.
  */
 async function loadFromModule(moduleSpecifier: string): Promise<ThemePackProvider> {


### PR DESCRIPTION
## Quick recap

Substantial test coverage improvements across the CLI, file-conversion command, and site-generation modules, plus a small number of source-level changes:

- `ConvertCommand` gains a dedicated test file (`ConvertCommand.renamefail.test.ts`) for two hardest-to-reach branches (cross-device rename fallback and unreadable-file early return) using a module-level `node:fs/promises` mock that forwards to the real implementation by default and injects targeted per-call failures only where needed.
- The main `ConvertCommand.test.ts` adds a dozen branch-coverage cases (error capture, sidebar synchronization, framework detection, path-mapping edge cases).
- `Cli.test.ts` adds coverage for the subcommand help formatter, manual API-key validation errors, singular-item wording in `clean --dry-run`, and the two conditional Anthropic-key reminder paths in `logout`.
- Additional coverage and small refactors across `ExportCommand`, `StartCommand`, `LinearIssueExtractor`, `DocusaurusConverter`, `EngineManager`, `OrphanBranchStorage`, `SiteJsonReader`, `StructureParser`, `NpmRunner`, `SpecParser`, `NextraRenderer`, and related modules.
- Source-level changes: paired v8-ignore annotations on always-true guard clauses in `Cli.ts` and a few site-generation modules; removal of the `npm` package fallback from the theme discovery chain in `ThemeRegistry.ts`; translation of remaining Chinese comments and test names to English.

---

## Topics

<details>
<summary><strong>01 · Expand test coverage for file conversion command edge cases</strong></summary>
<br>
<blockquote>

**Why this change**

Two defensive branches in the file-conversion logic were impossible to exercise against a real filesystem: falling back from a fast rename to a copy-then-delete when rename fails across filesystems (EXDEV), and silently skipping files whose contents cannot be read. These required precise, per-call filesystem failures that would break unrelated setup code if applied globally.

**Decisions**

- **Separate file for module-level mocks.** Placing the cross-device and read-failure tests in their own file prevents a module-level `node:fs/promises` mock from contaminating other operations in the main test file (directory creation, file writes used by other tests). Isolating these cases prevents subtle, hard-to-diagnose failures while still achieving full branch coverage.
- **Default-forward mock pattern.** Mocks forward to the real implementation by default and only intercept specific calls. This keeps setup realistic (actual files are created and read) while still allowing precise fault injection on the one call that needs to fail — the only way to reach these defensive branches.

**What was implemented**

A new dedicated file (`ConvertCommand.renamefail.test.ts`) covers the cross-device rename fallback and read-failure branches. It mocks `node:fs/promises` at the module level but forwards all calls to the real implementation by default, then injects targeted per-call failures (an `EXDEV` on the first rename of a specific file, and an `EACCES` on a specific read).

The main `ConvertCommand.test.ts` was updated to partially mock the same module, resetting mock implementations in the shared `beforeEach` so per-case overrides cannot leak between tests. Additional branch-coverage cases cover: error capture setting the exit code, slug-rewrite sidebar key synchronization, non-directory source handling, broken symlink skipping, unreadable MDX skipping, non-Docusaurus framework detection, missing favicon path, safe-import MDX preservation, mixed-import MDX stripping, in-place path-mapping cleanup, same-path early return, missing source argument fallback, and non-Error exception stringification.

**Files**
- `cli/src/commands/ConvertCommand.renamefail.test.ts`
- `cli/src/commands/ConvertCommand.test.ts`

</blockquote>
</details>

<details>
<summary><strong>02 · Add branch coverage tests for CLI help, key validation, and logout paths</strong></summary>
<br>
<blockquote>

**Why this change**

Several branches in the CLI entry point and authentication flow lacked coverage: the subcommand help formatter (different code path from root help), the error path when a manually entered API key fails validation, the singular-item wording in `clean --dry-run`, and the two conditional branches that decide whether to show an Anthropic-key reminder after `logout`.

**Decisions**

Each test that manipulates environment variables saves the original value before the test and restores it in `finally`, regardless of pass/fail. A failing assertion must not leave the environment modified for unrelated tests — especially important for the Anthropic-key tests where the presence or absence of the variable *is* the condition under test.

**What was implemented**

Four new cases in `Cli.test.ts`:
- Subcommand help using Commander's default formatter rather than the custom grouped layout.
- `enable` command setting the exit code and printing an error when a manually entered key is rejected by the validator.
- `clean` command using singular wording when exactly one stale item exists.
- `logout` suppressing the Anthropic-key reminder when no key is configured vs. showing it when only the environment variable is set.

**Files**
- `cli/src/Cli.test.ts`

</blockquote>
</details>

<details>
<summary><strong>03 · Suppress coverage warnings on structurally unreachable guard clauses</strong></summary>
<br>
<blockquote>

**Why this change**

The custom help formatter in `Cli.ts` contains conditional checks that are always true at runtime — the root command always has a description, always has visible options, and always registers commands in each group. The coverage tool was flagging the never-taken false branches as gaps even though they are intentional defensive guards.

**Decisions**

Annotate rather than remove. Removing the guards would make the code slightly more brittle if command registration ever changes; annotating preserves the defensive intent and keeps the coverage report clean without misrepresenting what is actually tested.

**What was implemented**

Paired `/* v8 ignore start */` / `/* v8 ignore stop */` annotations around the four always-true guard conditions in the help formatter. A similar single-line annotation in `Login.ts` was updated to the paired form for consistency. No logic was changed.

**Files**
- `cli/src/Cli.ts`
- `cli/src/auth/Login.ts`

</blockquote>
</details>

<details>
<summary><strong>04 · Translate Chinese comments and test names to English in CLI tests</strong></summary>
<br>
<blockquote>

**Why this change**

The CLI test files contained comments and test descriptions in Chinese, inconsistent with the rest of the codebase and inaccessible to team members who do not read Chinese.

**Decisions**

- **Translation only, no refactoring.** Nothing changed except the language of comments and test names. Mixing translation with behavioral changes would have made the diff harder to review and risked regressing the project's strict coverage thresholds.
- **Full coverage of all comment types.** Inline rationale, section dividers, and file-level header blocks were all translated — not just the most visible `it()` names.

**What was implemented**

All Chinese content across three test files translated to English: inline comments, file-header blocks, section dividers, and every test case name. No test logic, assertions, or mock behavior was altered.

**Files**
- `cli/src/commands/ConvertCommand.test.ts`
- `cli/src/commands/ConvertCommand.renamefail.test.ts`
- `cli/src/auth/Login.test.ts`

</blockquote>
</details>

<details>
<summary><strong>05 · Remove npm package fallback from theme discovery chain</strong></summary>
<br>
<blockquote>

**Why this change**

The theme loader supported resolving theme names as npm packages before falling back to GitHub, but this path was no longer desired. Code and documentation both needed to reflect that GitHub is the only external theme source.

**Decisions**

Keeping npm resolution alongside GitHub created two competing external lookup paths with overlapping intent. Removing npm simplifies the model for both users and maintainers — there is now exactly one external source for named themes, which also eliminates the latency and silent failure modes of npm resolution attempts that would fall through.

**What was implemented**

Removed two npm resolution steps from `discoverPack` in `ThemeRegistry.ts` (`jolli-theme-<name>` and `@jolli/theme-<name>`), collapsing the seven-step chain to five. JSDoc in `ThemeRegistry.ts` and `Types.ts` was updated to remove all mention of npm package resolution; the `loadFromModule` description was narrowed from "file URL or npm package name" to "file URL" only.

**Files**
- `cli/src/site/themes/ThemeRegistry.ts`
- `cli/src/site/Types.ts`

</blockquote>
</details>
