### PR TITLE
Upgrade fast-uri dependencies to patch vulnerabilities; Fix escape sequence handling in export and view commands

### DIFF
--- a/cli/src/commands/ExportCommand.ts
+++ b/cli/src/commands/ExportCommand.ts
@@ -120,7 +120,10 @@ function formatPromptMarkdown(entry: ManifestEntry): string {
 		entry.placeholders.length > 0
 			? `placeholders:\n${entry.placeholders.map((p) => `  - ${p}`).join("\n")}`
 			: "placeholders: []";
-	const escapedAction = entry.action.replace(/"/g, '\\"');
+	// Escape backslash FIRST so `\` itself round-trips through YAML's quoted-string
+	// decoder (where `\\` → `\` and `\"` → `"`). Reversing the order leaves bare
+	// `\` in the output, which would then be decoded as the start of an escape.
+	const escapedAction = entry.action.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
 	return `---
 action: "${escapedAction}"
 version: ${entry.version}

--- a/cli/src/commands/ViewCommand.ts
+++ b/cli/src/commands/ViewCommand.ts
@@ -91,7 +91,9 @@ function printCompactList(entries: ReadonlyArray<SummaryIndexEntry>, total: numb
 
 /** Escapes a value for safe inclusion in a GFM table cell: `|` must be escaped and newlines collapsed. */
 function escapeCell(value: string): string {
-	return value.replace(/\|/g, "\\|").replace(/\r?\n/g, " ");
+	// Backslash first — GFM decodes `\\` → `\` and `\|` → literal pipe, so without
+	// this step an input `\|` would emerge as `\\|`, decoded as `\` + cell separator.
+	return value.replace(/\\/g, "\\\\").replace(/\|/g, "\\|").replace(/\r?\n/g, " ");
 }
 
 /** Builds a GFM-compatible markdown table from compact-list entries. */

--- a/cli/src/core/ConversationOverlayStore.ts
+++ b/cli/src/core/ConversationOverlayStore.ts
@@ -299,12 +299,22 @@ export async function applyOverlaysToSessions<T extends OverlayableSession>(
 
 /**
  * Garbage-collects overlay rules whose identity matches an entry in the
- * QueueWorker's consumed slice. Called from QueueWorker immediately after
- * `loadSessionTranscripts` returns — by that point, cursor has already
- * advanced inside `readAllTranscripts` past every entry in the slice, so
- * any rule whose identity matches one of those entries can no longer
- * affect future summaries. Such rules are dead state: keep dropping them
- * here so overlay files don't accumulate.
+ * QueueWorker's consumed slice. Called inside `loadSessionTranscripts`
+ * after `applyOverlaysToSessions` has folded the rules into the in-memory
+ * `sessionTranscripts`, just before the function returns — by that point,
+ * `readAllTranscripts` has already `saveCursor`'d past every entry in the
+ * slice, so any rule whose identity matches one of those entries can no
+ * longer affect future summaries. Such rules are dead state: keep
+ * dropping them here so overlay files don't accumulate.
+ *
+ * Trade-off worth flagging: prune (and the cursor advance it tracks) run
+ * unconditionally — they are NOT gated on a successful `storeSummary`
+ * downstream. If the LLM call fails after this, both the cursor and the
+ * overlay file have moved past the consumed entries, so those edits are
+ * effectively lost. A transactional "advance cursor + drop overlays only
+ * on storeSummary success" refactor would fix that, but the prune call
+ * placement is downstream of the same trade-off — moving it alone would
+ * just produce a stale "edited" badge without recovering the data.
  *
  * Per session:
  *   - Drops delete/edit rules whose `(role, content, timestamp)` identity

--- a/cli/src/core/FolderStorage.test.ts
+++ b/cli/src/core/FolderStorage.test.ts
@@ -2126,11 +2126,11 @@ describe("FolderStorage", () => {
 				parentCommitHash: null,
 			});
 
-			expect(result).toBe(true);
+			expect(result).toEqual({ ok: true });
 			expect(readFileSync(visiblePath, "utf-8")).toBe(original);
 		});
 
-		it("returns false when the hidden JSON source is missing", async () => {
+		it("returns reason 'missing' when the hidden JSON source is absent", async () => {
 			const result = await storage.forceRegenerateVisibleMarkdown({
 				commitHash: "9999000011112222",
 				commitMessage: "Phantom",
@@ -2139,7 +2139,65 @@ describe("FolderStorage", () => {
 				generatedAt: "2026-01-15T10:00:00Z",
 				parentCommitHash: null,
 			});
-			expect(result).toBe(false);
+			expect(result).toEqual({ ok: false, reason: "missing" });
+		});
+
+		// Revert path is the user's only copy of their edits. If the hidden
+		// JSON is missing, the visible (potentially user-edited) `.md` must
+		// stay on disk — otherwise revert turns into silent data loss.
+		it("leaves the visible file intact when the hidden JSON source is missing", async () => {
+			const summaryJson = makeSummaryJson({
+				commitHash: "aaaa1111bbbb2222",
+				commitMessage: "Add tests",
+				branch: "main",
+			});
+			await storage.writeFiles([{ path: "summaries/aaaa1111bbbb2222.json", content: summaryJson }], "seed");
+
+			const visiblePath = join(rootPath, "main", "add-tests-aaaa1111.md");
+			writeFileSync(visiblePath, "# User edits", "utf-8");
+
+			// Trash the hidden JSON so the revert prerequisite fails.
+			unlinkSync(join(rootPath, ".jolli", "summaries", "aaaa1111bbbb2222.json"));
+
+			const result = await storage.forceRegenerateVisibleMarkdown({
+				commitHash: "aaaa1111bbbb2222",
+				commitMessage: "Add tests",
+				commitDate: "2026-01-15T10:00:00Z",
+				branch: "main",
+				generatedAt: "2026-01-15T10:00:00Z",
+				parentCommitHash: null,
+			});
+
+			expect(result).toEqual({ ok: false, reason: "missing" });
+			expect(existsSync(visiblePath)).toBe(true);
+			expect(readFileSync(visiblePath, "utf-8")).toBe("# User edits");
+		});
+
+		it("leaves the visible file intact and reports 'malformed' when the hidden JSON is unparseable", async () => {
+			const summaryJson = makeSummaryJson({
+				commitHash: "cccc3333dddd4444",
+				commitMessage: "Add tests",
+				branch: "main",
+			});
+			await storage.writeFiles([{ path: "summaries/cccc3333dddd4444.json", content: summaryJson }], "seed");
+
+			const visiblePath = join(rootPath, "main", "add-tests-cccc3333.md");
+			writeFileSync(visiblePath, "# User edits", "utf-8");
+
+			writeFileSync(join(rootPath, ".jolli", "summaries", "cccc3333dddd4444.json"), "{ not valid json", "utf-8");
+
+			const result = await storage.forceRegenerateVisibleMarkdown({
+				commitHash: "cccc3333dddd4444",
+				commitMessage: "Add tests",
+				commitDate: "2026-01-15T10:00:00Z",
+				branch: "main",
+				generatedAt: "2026-01-15T10:00:00Z",
+				parentCommitHash: null,
+			});
+
+			expect(result).toEqual({ ok: false, reason: "malformed" });
+			expect(existsSync(visiblePath)).toBe(true);
+			expect(readFileSync(visiblePath, "utf-8")).toBe("# User edits");
 		});
 	});
 

--- a/cli/src/core/FolderStorage.ts
+++ b/cli/src/core/FolderStorage.ts
@@ -23,6 +23,14 @@ import { buildMarkdown } from "./SummaryMarkdownBuilder.js";
 
 const log = createLogger("FolderStorage");
 
+/**
+ * Outcome of {@link FolderStorage.forceRegenerateVisibleMarkdown}. The
+ * three failure modes are distinct user-recoverable states — collapsing
+ * them into a boolean costs the UI its ability to point the user at the
+ * right next step.
+ */
+export type ForceRegenerateResult = { ok: true } | { ok: false; reason: "missing" | "malformed" | "unlinkFailed" };
+
 export class FolderStorage implements StorageProvider {
 	constructor(
 		private readonly rootPath: string,
@@ -249,10 +257,41 @@ export class FolderStorage implements StorageProvider {
 	 * unlink the diverged file and let `regenerateVisibleMarkdown` write a
 	 * fresh copy from the hidden JSON.
 	 *
-	 * Returns true when the regenerate succeeded, false when the hidden
-	 * source was missing.
+	 * Validates the hidden source BEFORE unlinking. The revert path is the
+	 * one place where the visible `.md` is the user's only copy of their
+	 * edits — destroying it before we know the hidden JSON can produce a
+	 * replacement turns the safety command into a data-loss path for
+	 * exactly the corrupted-manifest / missing-source cases it should
+	 * handle most defensively.
+	 *
+	 * Returns `{ ok: true }` when the regenerate succeeded. On failure the
+	 * `reason` distinguishes three recoverable states the UI surfaces with
+	 * distinct hints:
+	 *   - `"missing"`: hidden `summaries/<hash>.json` is absent.
+	 *   - `"malformed"`: hidden JSON exists but does not parse.
+	 *   - `"unlinkFailed"`: cannot remove the existing diverged visible file.
+	 * In every failure mode the visible file is left untouched.
 	 */
-	async forceRegenerateVisibleMarkdown(entry: SummaryIndexEntry): Promise<boolean> {
+	async forceRegenerateVisibleMarkdown(entry: SummaryIndexEntry): Promise<ForceRegenerateResult> {
+		const summaryJson = await this.readFile(`summaries/${entry.commitHash}.json`);
+		if (!summaryJson) {
+			log.warn(
+				"forceRegenerateVisibleMarkdown: hidden summaries/%s.json missing — leaving visible file intact",
+				entry.commitHash.substring(0, 8),
+			);
+			return { ok: false, reason: "missing" };
+		}
+		try {
+			JSON.parse(summaryJson);
+		} catch (err) {
+			log.warn(
+				"forceRegenerateVisibleMarkdown: malformed summaries/%s.json (%s) — leaving visible file intact",
+				entry.commitHash.substring(0, 8),
+				errMsg(err),
+			);
+			return { ok: false, reason: "malformed" };
+		}
+
 		const branchFolder = this.metadataManager.resolveFolderForBranch(entry.branch);
 		const slug = FolderStorage.slugify(entry.commitMessage);
 		const hash8 = entry.commitHash.substring(0, 8);
@@ -265,12 +304,18 @@ export class FolderStorage implements StorageProvider {
 				/* v8 ignore start -- defensive: unlinkSync only fails after existsSync if a concurrent process removed the file or the fs throws EACCES mid-flow. */
 			} catch (err) {
 				log.warn("forceRegenerateVisibleMarkdown: cannot unlink %s [%s]", relativePath, String(err));
-				return false;
+				return { ok: false, reason: "unlinkFailed" };
 			}
 			/* v8 ignore stop */
 		}
 
-		return this.regenerateVisibleMarkdown(entry);
+		// The hidden JSON validated successfully above, so a false return
+		// from regenerateVisibleMarkdown here can only mean a TOCTOU race
+		// where the JSON vanished between our checks and the inner read.
+		// Report it as "missing" so the user gets the same recovery hint
+		// they would for the up-front missing case.
+		const ok = await this.regenerateVisibleMarkdown(entry);
+		return ok ? { ok: true } : { ok: false, reason: "missing" };
 	}
 
 	/**

--- a/cli/src/core/SummaryExporter.ts
+++ b/cli/src/core/SummaryExporter.ts
@@ -104,7 +104,8 @@ function getExistingHashes(outputDir: string): Set<string> {
 /** Builds a single markdown table row for the index. */
 function buildIndexRow(summary: CommitSummary, hashPrefix: string, fileName: string): string {
 	const date = getDisplayDate(summary).substring(0, 10);
-	const safeMessage = summary.commitMessage.replace(/\|/g, "\\|");
+	// Backslash first — see escapeCell in ViewCommand.ts for the round-trip rationale.
+	const safeMessage = summary.commitMessage.replace(/\\/g, "\\\\").replace(/\|/g, "\\|");
 	return `| ${date} | \`${hashPrefix}\` | [${safeMessage}](./${fileName}) |`;
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3519,9 +3519,9 @@
 			}
 		},
 		"node_modules/fast-uri": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-			"integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+			"integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
 			"dev": true,
 			"funding": [
 				{

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -248,7 +248,7 @@
 			"explorer/context": [
 				{
 					"command": "jollimemory.revertMemoryFileEdits",
-					"when": "resourceFilename =~ /\\.md$/ && jollimemory.isMemoryBankFile",
+					"when": "resourceFilename =~ /\\.md$/",
 					"group": "jollimemory@1"
 				}
 			]

--- a/vscode/src/Extension.test.ts
+++ b/vscode/src/Extension.test.ts
@@ -531,12 +531,6 @@ vi.mock("vscode", () => ({
 		})),
 		registerFileDecorationProvider: vi.fn(() => ({ dispose: vi.fn() })),
 		registerUriHandler: vi.fn(() => ({ dispose: vi.fn() })),
-		// Memory Bank context-key wiring subscribes to active-editor changes
-		// to set `jollimemory.isMemoryBankFile` for the explorer right-click
-		// menu. Initial-call branch is exercised via `activeTextEditor =
-		// undefined`; tests that need the truthy `(await resolveMemoryFile)
-		// !== null` branch read the callback off `mock.calls[0][0]` and
-		// invoke it with a stub editor.
 		onDidChangeActiveTextEditor,
 		activeTextEditor: undefined,
 		// Pass-through Progress mock — runs the user's callback so commands that
@@ -3704,7 +3698,7 @@ describe("Extension", () => {
 
 			it("calls forceRegenerateVisibleMarkdown for a commit-type file", async () => {
 				const folderStorage = {
-					forceRegenerateVisibleMarkdown: vi.fn().mockResolvedValue(true),
+					forceRegenerateVisibleMarkdown: vi.fn().mockResolvedValue({ ok: true }),
 					regenerateVisiblePlan: vi.fn(),
 					regenerateVisibleNote: vi.fn(),
 				};
@@ -3748,14 +3742,15 @@ describe("Extension", () => {
 				expect(mockRefreshKnowledgeBaseFolders).toHaveBeenCalled();
 			});
 
-			it("does NOT call refreshKnowledgeBaseFolders when the regenerate helper returns false", async () => {
+			it("does NOT call refreshKnowledgeBaseFolders when the regenerate helper returns a failure", async () => {
 				// Failure path: the post-revert refresh trigger should only fire
-				// on a successful regenerate. A false return means the hidden
-				// source was missing, so the ✎ state on disk hasn't actually
-				// changed — re-rendering the tree would be wasted work and
-				// could even surprise the user with collapsing expanded folders.
+				// on a successful regenerate. A non-ok result means the hidden
+				// source was missing or corrupt, so the ✎ state on disk hasn't
+				// actually changed — re-rendering the tree would be wasted work
+				// and could even surprise the user with collapsing expanded
+				// folders.
 				const folderStorage = {
-					forceRegenerateVisibleMarkdown: vi.fn().mockResolvedValue(false),
+					forceRegenerateVisibleMarkdown: vi.fn().mockResolvedValue({ ok: false, reason: "missing" }),
 					regenerateVisiblePlan: vi.fn(),
 					regenerateVisibleNote: vi.fn(),
 				};
@@ -3857,7 +3852,14 @@ describe("Extension", () => {
 				);
 			});
 
-			it("warns when the file is not under any known kbRoot", async () => {
+			it("silently no-ops when the file is not under any known kbRoot", async () => {
+				// The explorer right-click menu is gated only by `.md`
+				// filename (the `jollimemory.isMemoryBankFile` context-key
+				// gate was removed so the menu covers closed-file
+				// right-clicks). The handler must silently no-op on non-
+				// Memory-Bank `.md` invocations rather than toast — every
+				// stray right-click on an unrelated `.md` would otherwise
+				// flash a warning.
 				mockBridge.resolveMemoryFile.mockResolvedValueOnce(null);
 
 				const handler = getRegisteredCommand(
@@ -3865,9 +3867,7 @@ describe("Extension", () => {
 				);
 				await handler("/random/elsewhere.md");
 
-				expect(showWarningMessage).toHaveBeenCalledWith(
-					"Memory Bank: cannot revert — file is not under a known kbRoot.",
-				);
+				expect(showWarningMessage).not.toHaveBeenCalled();
 				expect(showInformationMessage).not.toHaveBeenCalled();
 			});
 
@@ -3884,9 +3884,9 @@ describe("Extension", () => {
 				expect(showWarningMessage).not.toHaveBeenCalled();
 			});
 
-			it("warns when the regenerate helper returns false (hidden source missing)", async () => {
+			it("warns 'hidden source missing' when the regenerate helper reports reason 'missing'", async () => {
 				const folderStorage = {
-					forceRegenerateVisibleMarkdown: vi.fn().mockResolvedValue(false),
+					forceRegenerateVisibleMarkdown: vi.fn().mockResolvedValue({ ok: false, reason: "missing" }),
 					regenerateVisiblePlan: vi.fn(),
 					regenerateVisibleNote: vi.fn(),
 				};
@@ -3917,6 +3917,131 @@ describe("Extension", () => {
 				expect(showInformationMessage).not.toHaveBeenCalled();
 			});
 
+			it("warns 'hidden source is corrupt' when the regenerate helper reports reason 'malformed'", async () => {
+				// Distinct from the 'missing' branch above — pre-fix both
+				// returned a plain `false` and the UI always blamed a missing
+				// hidden source, hiding the JSON-parse failure from the user.
+				const folderStorage = {
+					forceRegenerateVisibleMarkdown: vi.fn().mockResolvedValue({ ok: false, reason: "malformed" }),
+					regenerateVisiblePlan: vi.fn(),
+					regenerateVisibleNote: vi.fn(),
+				};
+				mockBridge.resolveMemoryFile.mockResolvedValueOnce({
+					folderStorage,
+					manifestEntry: {
+						path: "main/foo-abcdef12.md",
+						fileId: "abcdef1234567890abcdef1234567890abcdef12",
+						type: "commit",
+						fingerprint: "old",
+						source: {
+							commitHash: "abcdef1234567890abcdef1234567890abcdef12",
+							branch: "main",
+							generatedAt: "2026-01-15T10:00:00Z",
+						},
+						title: "Add foo",
+					},
+				});
+
+				const handler = getRegisteredCommand(
+					"jollimemory.revertMemoryFileEdits",
+				);
+				await handler(absPath);
+
+				expect(showWarningMessage).toHaveBeenCalledWith(
+					`Memory Bank: revert failed for ${absPath} — hidden source is corrupt (JSON is unparseable).`,
+				);
+				expect(showInformationMessage).not.toHaveBeenCalled();
+			});
+
+			it("warns 'could not overwrite the existing file' when the regenerate helper reports reason 'unlinkFailed'", async () => {
+				const folderStorage = {
+					forceRegenerateVisibleMarkdown: vi.fn().mockResolvedValue({ ok: false, reason: "unlinkFailed" }),
+					regenerateVisiblePlan: vi.fn(),
+					regenerateVisibleNote: vi.fn(),
+				};
+				mockBridge.resolveMemoryFile.mockResolvedValueOnce({
+					folderStorage,
+					manifestEntry: {
+						path: "main/foo-abcdef12.md",
+						fileId: "abcdef1234567890abcdef1234567890abcdef12",
+						type: "commit",
+						fingerprint: "old",
+						source: {
+							commitHash: "abcdef1234567890abcdef1234567890abcdef12",
+							branch: "main",
+							generatedAt: "2026-01-15T10:00:00Z",
+						},
+						title: "Add foo",
+					},
+				});
+
+				const handler = getRegisteredCommand(
+					"jollimemory.revertMemoryFileEdits",
+				);
+				await handler(absPath);
+
+				expect(showWarningMessage).toHaveBeenCalledWith(
+					`Memory Bank: revert failed for ${absPath} — could not overwrite the existing file (it may be locked by another process).`,
+				);
+				expect(showInformationMessage).not.toHaveBeenCalled();
+			});
+
+			it("accepts a vscode.Uri argument and reverts via its fsPath (explorer/context menu path)", async () => {
+				// The explorer right-click menu invokes commands with a
+				// `vscode.Uri`, not a string. Pre-fix the handler short-
+				// circuited on `typeof !== "string"`, so the advertised
+				// "right-click a closed Memory Bank file" path silently no-
+				// op'd. Duck-type acceptance keeps the test mock (a plain
+				// object factory) interoperable with the real class.
+				const uriArg = { fsPath: absPath, scheme: "file" };
+				const folderStorage = {
+					forceRegenerateVisibleMarkdown: vi.fn().mockResolvedValue({ ok: true }),
+					regenerateVisiblePlan: vi.fn(),
+					regenerateVisibleNote: vi.fn(),
+				};
+				mockBridge.resolveMemoryFile.mockResolvedValueOnce({
+					folderStorage,
+					manifestEntry: {
+						path: "main/foo-abcdef12.md",
+						fileId: "abcdef1234567890abcdef1234567890abcdef12",
+						type: "commit",
+						fingerprint: "old",
+						source: {
+							commitHash: "abcdef1234567890abcdef1234567890abcdef12",
+							branch: "main",
+							generatedAt: "2026-01-15T10:00:00Z",
+						},
+						title: "Add foo",
+					},
+				});
+
+				const handler = getRegisteredCommand(
+					"jollimemory.revertMemoryFileEdits",
+				);
+				await handler(uriArg);
+
+				expect(mockBridge.resolveMemoryFile).toHaveBeenCalledWith(absPath);
+				expect(folderStorage.forceRegenerateVisibleMarkdown).toHaveBeenCalled();
+				expect(showInformationMessage).toHaveBeenCalledWith(
+					`Reverted to system version: ${absPath}`,
+				);
+			});
+
+			it("silently no-ops on a vscode.Uri whose scheme is not 'file' (virtual/remote)", async () => {
+				// Defensive: a Memory Bank file always lives on the local
+				// filesystem, so non-file schemes are not Memory Bank files
+				// and must not produce a toast.
+				const handler = getRegisteredCommand(
+					"jollimemory.revertMemoryFileEdits",
+				);
+				await handler({ fsPath: "/whatever", scheme: "untitled" });
+				await handler({ fsPath: "/whatever", scheme: "git" });
+
+				expect(mockBridge.resolveMemoryFile).not.toHaveBeenCalled();
+				expect(showWarningMessage).not.toHaveBeenCalled();
+				expect(showInformationMessage).not.toHaveBeenCalled();
+			});
+
 			it("falls back to path-based reverse lookup when a legacy commit manifestEntry.source.branch is missing", async () => {
 				// Symmetric with the plan/note legacy reverse-lookup tests.
 				// Legacy commit entry has no source.branch but DOES carry
@@ -3926,7 +4051,7 @@ describe("Extension", () => {
 				// branch's hidden JSON when the commit lives on a feature
 				// branch.
 				const folderStorage = {
-					forceRegenerateVisibleMarkdown: vi.fn().mockResolvedValue(true),
+					forceRegenerateVisibleMarkdown: vi.fn().mockResolvedValue({ ok: true }),
 					regenerateVisiblePlan: vi.fn(),
 					regenerateVisibleNote: vi.fn(),
 					resolveBranchForFolder: vi.fn().mockReturnValue("feature/login"),
@@ -4506,40 +4631,6 @@ describe("Extension", () => {
 			await vi.waitFor(() => {
 				expect(mockMemoriesStore.refresh).toHaveBeenCalled();
 			});
-		});
-
-		// updateMemoryBankContext (the active-editor callback) sets the
-		// `jollimemory.isMemoryBankFile` context key to true when the focused
-		// file resolves to a Memory Bank manifest entry. The default flow
-		// (bridge.resolveMemoryFile → null) covers the false branch via the
-		// initial call with `activeTextEditor=undefined`; this test invokes
-		// the captured callback with a stub editor and a non-null
-		// resolveMemoryFile to cover the truthy ternary arm.
-		it("sets the isMemoryBankFile context to true when the active editor resolves to a manifest entry", async () => {
-			mockBridge.resolveMemoryFile.mockResolvedValue({
-				path: "main/feat-abc.md",
-				kind: "memory",
-			});
-			executeCommand.mockClear();
-
-			const lastCall =
-				onDidChangeActiveTextEditor.mock.calls[
-					onDidChangeActiveTextEditor.mock.calls.length - 1
-				];
-			const cb = lastCall?.[0] as
-				| ((editor: { document: { uri: { fsPath: string } } }) => Promise<void>)
-				| undefined;
-			expect(cb).toBeDefined();
-
-			await cb?.({
-				document: { uri: { fsPath: "/test/workspace/main/feat-abc.md" } },
-			});
-
-			expect(executeCommand).toHaveBeenCalledWith(
-				"setContext",
-				"jollimemory.isMemoryBankFile",
-				true,
-			);
 		});
 
 		it("refreshes memories on orphan-ref change when hasFirstLoaded is true", async () => {

--- a/vscode/src/Extension.ts
+++ b/vscode/src/Extension.ts
@@ -13,7 +13,7 @@ import {
 	conversationKey,
 	setExcluded,
 } from "../../cli/src/core/CommitSelectionStore.js";
-import type { FolderStorage } from "../../cli/src/core/FolderStorage.js";
+import type { FolderStorage, ForceRegenerateResult } from "../../cli/src/core/FolderStorage.js";
 import {
 	extractRepoName,
 	getRemoteUrl,
@@ -237,6 +237,25 @@ function resolveBranch(folderStorage: FolderStorage, manifestEntry: ManifestEntr
 	return folderStorage.resolveBranchForFolder(folder);
 }
 
+/**
+ * Human-readable hint for each `ForceRegenerateResult` failure reason —
+ * the visible warning's trailing clause. Distinct strings let the user
+ * tell whether the hidden source vanished, was corrupted, or whether the
+ * edited visible file is held open by another process. Pre-fix the UI
+ * unconditionally claimed "hidden source missing", which was misleading
+ * for malformed-JSON and unlink-failure modes.
+ */
+function revertFailureHint(reason: "missing" | "malformed" | "unlinkFailed"): string {
+	switch (reason) {
+		case "missing":
+			return "hidden source missing";
+		case "malformed":
+			return "hidden source is corrupt (JSON is unparseable)";
+		case "unlinkFailed":
+			return "could not overwrite the existing file (it may be locked by another process)";
+	}
+}
+
 // Tracks Memory Bank summary `.md` files for which the divergence info
 // message has already been shown in this session, so re-opening a
 // known-diverged file does not re-pop the toast. Module-scoped — lifetime
@@ -419,38 +438,16 @@ export function activate(context: vscode.ExtensionContext): void {
 	// immediately after a system write. Today the badge updates on the next
 	// VS Code re-poll of decorations.
 
-	// `jollimemory.isMemoryBankFile` context key — drives the visibility of
-	// the right-click "Revert Edits to System Version" explorer menu
-	// (declared in `package.json` contributes.menus.explorer/context).
-	//
-	// Trade-off: VS Code's `when` clause for the explorer context menu can
-	// only read context keys, not synchronously inspect each row. We update
-	// the key whenever the active editor changes and base its value on
-	// whether the editor's file resolves to a Memory Bank manifest entry.
-	// This makes the menu appear in the most common revert scenario — the
-	// diverged file is open in an editor — at the cost of not appearing for
-	// a pure right-click on a closed file in the explorer tree. The
-	// `revertMemoryFileEdits` command body still works defensively if
-	// invoked by URI directly (e.g. via the divergence info-message button).
-	const updateMemoryBankContext = async (
-		editor: vscode.TextEditor | undefined,
-	): Promise<void> => {
-		const fsPath = editor?.document.uri.fsPath;
-		const isMemoryBankFile = fsPath
-			? (await bridge.resolveMemoryFile(fsPath)) !== null
-			: false;
-		await vscode.commands.executeCommand(
-			"setContext",
-			"jollimemory.isMemoryBankFile",
-			isMemoryBankFile,
-		);
-	};
-	context.subscriptions.push(
-		vscode.window.onDidChangeActiveTextEditor(updateMemoryBankContext),
-	);
-	// Initial set so reopening a window already focused on a Memory Bank
-	// file picks up the right context immediately.
-	void updateMemoryBankContext(vscode.window.activeTextEditor);
+	// The "Revert Edits to System Version" explorer right-click menu
+	// (declared in `package.json` contributes.menus.explorer/context) is
+	// only gated by the `.md` filename. VS Code's `when` clause cannot
+	// run an async per-row "is this in our manifest?" query, so any
+	// context-key based gate ends up tracking `activeTextEditor` instead
+	// of the right-clicked resource — which silently hides the menu when
+	// users right-click a closed Memory Bank file in the explorer (the
+	// main advertised workflow). We accept the inverse trade-off: the
+	// menu may briefly appear on non-Memory-Bank `.md` files; the
+	// `revertMemoryFileEdits` handler silently no-ops in that case.
 
 	// ── Auth service ─────────────────────────────────────────────────────────
 	const authService = new AuthService();
@@ -2491,25 +2488,49 @@ export function activate(context: vscode.ExtensionContext): void {
 		// 1. The "[Revert]" button on the on-disk-divergence info message
 		//    surfaced by `openMemoryFile`.
 		// 2. The right-click "Revert Edits to System Version" explorer menu
-		//    (declared in package.json contributes.menus.explorer/context).
-		// The handler is intentionally tolerant of bad inputs — non-string
-		// / empty / unresolved paths surface a warning toast rather than
-		// throwing, so even if the `jollimemory.isMemoryBankFile` context
-		// key briefly shows the right-click entry on a non-kbRoot path
-		// (e.g. between editor switches), invoking it is harmless.
+		//    (declared in package.json contributes.menus.explorer/context),
+		//    which is gated only on the `.md` filename — the handler has to
+		//    silently no-op when invoked on a non-Memory-Bank `.md` so the
+		//    menu's broader gate doesn't produce noisy toasts on every
+		//    misclick. Real failure modes (no branch / unrecognized entry
+		//    type) still surface a warning.
+		//
+		// First arg is either:
+		//   - a string absolute path (programmatic callers, [Revert] button,
+		//     `jollimemory.revertMemoryFileByRelPath` wrapper);
+		//   - a `vscode.Uri` (explorer/context menus always pass a Uri, not
+		//     a string — see https://code.visualstudio.com/api/references/contribution-points#contributes.menus).
+		// `instanceof vscode.Uri` is not portable across the test mock
+		// (mocked as a plain object factory, not a class), so this duck-
+		// types on `.fsPath` + `.scheme === "file"`. Non-file schemes
+		// (virtual / remote) are rejected — a Memory Bank file always lives
+		// on the local filesystem.
 		vscode.commands.registerCommand(
 			"jollimemory.revertMemoryFileEdits",
-			async (absPath: unknown) => {
-				if (typeof absPath !== "string" || absPath.length === 0) return;
-				const resolved = await bridge.resolveMemoryFile(absPath);
-				if (!resolved) {
-					vscode.window.showWarningMessage(
-						"Memory Bank: cannot revert — file is not under a known kbRoot.",
-					);
-					return;
+			async (arg: unknown) => {
+				let absPath: string | undefined;
+				if (typeof arg === "string") {
+					if (arg.length > 0) absPath = arg;
+				} else if (typeof arg === "object" && arg !== null && "fsPath" in arg && "scheme" in arg) {
+					const uri = arg as { fsPath: unknown; scheme: unknown };
+					if (uri.scheme === "file" && typeof uri.fsPath === "string" && uri.fsPath.length > 0) {
+						absPath = uri.fsPath;
+					}
 				}
+				if (!absPath) return;
+				const resolved = await bridge.resolveMemoryFile(absPath);
+				if (!resolved) return;
 				const { folderStorage, manifestEntry } = resolved;
-				let ok = false;
+				// Outcome is normalised to FolderStorage's discriminated
+				// `ForceRegenerateResult` so the failure branch below can
+				// give the user a recovery hint matched to the actual
+				// failure mode. Plan/note still return a plain boolean (no
+				// equivalent malformed/unlink-failed split yet) so the
+				// wrapper here promotes their false to `reason: "missing"`
+				// — preserving today's user-facing message for those types
+				// without claiming richer information than they actually
+				// report.
+				let result: ForceRegenerateResult;
 				if (manifestEntry.type === "commit") {
 					const branch = resolveBranch(folderStorage, manifestEntry);
 					if (!branch) {
@@ -2532,7 +2553,7 @@ export function activate(context: vscode.ExtensionContext): void {
 						);
 						return;
 					}
-					ok = await folderStorage.forceRegenerateVisibleMarkdown({
+					result = await folderStorage.forceRegenerateVisibleMarkdown({
 						commitHash: manifestEntry.fileId,
 						commitMessage: manifestEntry.title ?? manifestEntry.fileId,
 						commitDate: generatedAt,
@@ -2549,7 +2570,8 @@ export function activate(context: vscode.ExtensionContext): void {
 						);
 						return;
 					}
-					ok = await folderStorage.regenerateVisiblePlan(slug, branch);
+					const ok = await folderStorage.regenerateVisiblePlan(slug, branch);
+					result = ok ? { ok: true } : { ok: false, reason: "missing" };
 				} else if (manifestEntry.type === "note") {
 					const id = manifestEntry.fileId.replace(/^note:/, "");
 					const branch = resolveBranch(folderStorage, manifestEntry);
@@ -2559,7 +2581,8 @@ export function activate(context: vscode.ExtensionContext): void {
 						);
 						return;
 					}
-					ok = await folderStorage.regenerateVisibleNote(id, branch);
+					const ok = await folderStorage.regenerateVisibleNote(id, branch);
+					result = ok ? { ok: true } : { ok: false, reason: "missing" };
 				} else {
 					// Unknown manifest entry type — surface a distinct warning
 					// instead of falling through to the misleading
@@ -2571,7 +2594,7 @@ export function activate(context: vscode.ExtensionContext): void {
 					);
 					return;
 				}
-				if (ok) {
+				if (result.ok) {
 					// Successful revert clears the "we already showed the
 					// divergence info-message for this path" guard so the
 					// next divergence on the same path can re-prompt. Also
@@ -2594,7 +2617,7 @@ export function activate(context: vscode.ExtensionContext): void {
 					);
 				} else {
 					vscode.window.showWarningMessage(
-						`Memory Bank: revert failed for ${absPath} — hidden source missing.`,
+						`Memory Bank: revert failed for ${absPath} — ${revertFailureHint(result.reason)}.`,
 					);
 				}
 			},

--- a/vscode/src/JolliMemoryBridge.test.ts
+++ b/vscode/src/JolliMemoryBridge.test.ts
@@ -2835,6 +2835,28 @@ describe("JolliMemoryBridge", () => {
 
 			expect(result).toBeNull();
 		});
+
+		// orphan-only users have no folder shadow — reading from one would
+		// surface stale leftovers or blanks. The webview must fall back to
+		// the active StorageProvider (orphan branch) so transcripts / plans
+		// / notes stay coherent with the system of record.
+		it("returns null when storageMode is 'orphan' (no folder shadow)", async () => {
+			loadConfig.mockResolvedValueOnce({ storageMode: "orphan" });
+			discoverRepos.mockReturnValue([
+				{
+					kbRoot: "/mock/home/Documents/jolli/cur",
+					repoName: "cur",
+					dirName: "cur",
+					remoteUrl: null,
+					isCurrentRepo: true,
+				},
+			]);
+			const bridge = makeBridge();
+
+			const result = await bridge.createReadStorageForCurrentRepo();
+
+			expect(result).toBeNull();
+		});
 	});
 
 	// ── Git utility methods ──────────────────────────────────────────────

--- a/vscode/src/JolliMemoryBridge.ts
+++ b/vscode/src/JolliMemoryBridge.ts
@@ -231,11 +231,52 @@ export class JolliMemoryBridge {
 	 */
 	private readStoragePromise: Promise<StorageProvider> | null = null;
 
+	/**
+	 * Short-lived cache for the {@link loadConfig} + {@link discoverRepos}
+	 * pair that {@link findRepoForAbsPath} hits per `.md` URI shown by the
+	 * file-decoration provider. Without this, VS Code's per-URI
+	 * `provideFileDecoration` polling fires a config read + filesystem
+	 * scan for every visible markdown file on every explorer scroll —
+	 * O(N) FS hits per redraw on Memory-Bank-heavy workspaces.
+	 *
+	 * The TTL is intentionally short (a few seconds) so users don't
+	 * notice staleness after editing settings; {@link reloadStorage} also
+	 * invalidates the cache explicitly on settings-save.
+	 */
+	private discoveryCache: {
+		cfg: Record<string, unknown>;
+		repos: DiscoveredRepo[];
+		expiresAt: number;
+	} | null = null;
+	private static readonly DISCOVERY_CACHE_TTL_MS = 3000;
+
 	constructor(
 		/** Absolute path to the workspace root (git repo) */
 		cwd: string,
 	) {
 		this.cwd = cwd;
+	}
+
+	private async getDiscoveryCached(): Promise<{
+		cfg: Record<string, unknown>;
+		repos: DiscoveredRepo[];
+	}> {
+		const now = Date.now();
+		if (this.discoveryCache && this.discoveryCache.expiresAt > now) {
+			return { cfg: this.discoveryCache.cfg, repos: this.discoveryCache.repos };
+		}
+		const cfg = (await loadConfig()) as Record<string, unknown>;
+		const customKBPath = cfg.localFolder as string | undefined;
+		const kbParent = resolveKbParent(customKBPath);
+		const currentRepoName = extractRepoName(this.cwd);
+		const currentRemoteUrl = getRemoteUrl(this.cwd);
+		const repos = discoverRepos(currentRepoName, currentRemoteUrl, kbParent);
+		this.discoveryCache = {
+			cfg,
+			repos,
+			expiresAt: now + JolliMemoryBridge.DISCOVERY_CACHE_TTL_MS,
+		};
+		return { cfg, repos };
 	}
 
 	/** Lazy-resolved write storage. See {@link storagePromise}. */
@@ -356,6 +397,7 @@ export class JolliMemoryBridge {
 		this.storagePromise = null;
 		this.readStoragePromise = null;
 		this.cachedRootEntries = null;
+		this.discoveryCache = null;
 	}
 
 	/**
@@ -1828,21 +1870,24 @@ export class JolliMemoryBridge {
 	 * The SummaryWebviewPanel passes the result as `readStorage` for every
 	 * detail panel (local + foreign) so all detail-panel reads
 	 * (transcripts, plans, notes) uniformly hit the Memory Bank folder
-	 * layer instead of the dual-write primary (orphan branch). Returns
-	 * null on fresh repos whose KB folder hasn't been created yet —
-	 * callers should fall back to bridge-default reads in that case.
+	 * layer instead of the dual-write primary (orphan branch).
+	 *
+	 * Returns null when:
+	 *   - `storageMode === "orphan"`: orphan-only users have no folder
+	 *     shadow, so reading from one would surface stale leftovers or
+	 *     blanks. Callers fall back to bridge-default reads (orphan
+	 *     branch via the active StorageProvider), preserving the source-
+	 *     of-truth contract for users who opted out of dual-write.
+	 *   - No matching kbRoot is discoverable yet (fresh repo whose KB
+	 *     folder hasn't been created).
 	 */
 	async createReadStorageForCurrentRepo(): Promise<{
 		storage: StorageProvider;
 		kbRoot: string;
 	} | null> {
 		try {
-			const cfg = (await loadConfig()) as Record<string, unknown>;
-			const customKBPath = cfg.localFolder as string | undefined;
-			const kbParent = resolveKbParent(customKBPath);
-			const currentRepoName = extractRepoName(this.cwd);
-			const currentRemoteUrl = getRemoteUrl(this.cwd);
-			const repos = discoverRepos(currentRepoName, currentRemoteUrl, kbParent);
+			const { cfg, repos } = await this.getDiscoveryCached();
+			if (cfg.storageMode === "orphan") return null;
 			for (const repo of repos) {
 				if (!repo.isCurrentRepo) continue;
 				const mm = new MetadataManager(join(repo.kbRoot, ".jolli"));
@@ -1931,12 +1976,7 @@ export class JolliMemoryBridge {
 		relPath: string;
 	} | null> {
 		try {
-			const cfg = (await loadConfig()) as Record<string, unknown>;
-			const customKBPath = cfg.localFolder as string | undefined;
-			const kbParent = resolveKbParent(customKBPath);
-			const currentRepoName = extractRepoName(this.cwd);
-			const currentRemoteUrl = getRemoteUrl(this.cwd);
-			const repos = discoverRepos(currentRepoName, currentRemoteUrl, kbParent);
+			const { repos } = await this.getDiscoveryCached();
 			const absNormalized = normalizePathForCompare(absPath);
 			const absSlashed = absPath.replace(/\\/g, "/");
 			for (const repo of repos) {


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## Quick recap

The revert workflow now provides users with specific diagnostic feedback when something goes wrong. Instead of always blaming a missing hidden source, the UI now distinguishes between three failure modes: a genuinely missing source, corrupted JSON that cannot be parsed, and file-lock errors preventing the visible file from being overwritten. Each failure displays a tailored message that helps users understand and recover from the actual problem.

The explorer right-click menu for reverting edits now works reliably on closed Memory Bank files. Previously, the menu would disappear based on which editor happened to be active, making the advertised workflow unusable. The menu now gates only on filename pattern and silently handles misclicks to unrelated markdown files, so users can right-click a closed Memory Bank file in the explorer and immediately see the revert option.

Performance on Memory-Bank-heavy workspaces improved significantly. The file-decoration provider was polling the filesystem on every explorer scroll, creating O(N) hits per redraw. A short-lived discovery cache with explicit invalidation on settings changes eliminates this overhead while keeping configuration updates responsive.

Escape sequence handling in export and view commands was corrected. Backslashes in user-provided content (commit messages, action descriptions) now survive round-trips through YAML and Markdown parsers without being misinterpreted. The fix applies a consistent two-step escaping strategy across three files: backslashes are always escaped first, before any other special characters, ensuring the parser's decoding rules do not accidentally reinterpret the escaped output.

---

## E2E Test (7)
<details>
<summary><strong>1. Revert a closed Memory Bank file from the explorer right-click menu</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a Memory Bank workspace open with at least one summary file (`.md`) that you have manually edited and closed (not currently open in an editor).

**Steps:**
1. In the VS Code explorer panel on the left, locate the edited summary file you closed.
2. Right-click on the file name.
3. Look for the menu option "Revert Edits to System Version" in the context menu.
4. Click on it.
5. Wait a moment for the operation to complete.
6. Open the file again and verify that your manual edits are gone and the file has been restored to the system-generated version.

**Expected Results:**
- The right-click context menu should show "Revert Edits to System Version" option.
- After clicking, an information message should appear saying "Reverted to system version: [file path]".
- The file content should match the system-generated version, with all your manual edits removed.

</blockquote>
</details>
<details>
<summary><strong>2. Revert fails with clear error message when hidden source is corrupted</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a Memory Bank workspace with a summary file that has a corrupted hidden JSON source file (this is an edge case; if you cannot manually corrupt the file, skip this scenario).

**Steps:**
1. Open the summary file (`.md`) in the editor.
2. Click the "Revert" button in the information message at the top of the editor, or use the right-click context menu and select "Revert Edits to System Version".
3. Wait for the operation to complete.

**Expected Results:**
- A warning message should appear saying "Memory Bank: revert failed for [file path] — hidden source is corrupt (JSON is unparseable)."
- The visible summary file should remain untouched on disk (not deleted or overwritten).
- The user now knows the problem is a corrupted hidden file, not a missing one.

</blockquote>
</details>
<details>
<summary><strong>3. Revert fails with clear error message when file is locked by another process</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a Memory Bank workspace with a summary file. Have the file open in another application or process that locks it (e.g., open it in a text editor outside VS Code, or use a file lock tool if available).

**Steps:**
1. In VS Code, open the summary file (`.md`) in the editor.
2. Click the "Revert" button in the information message, or use the right-click context menu and select "Revert Edits to System Version".
3. Wait for the operation to complete.

**Expected Results:**
- A warning message should appear saying "Memory Bank: revert failed for [file path] — could not overwrite the existing file (it may be locked by another process)."
- The file should remain on disk unchanged.
- The user now knows the problem is a file lock, not a missing or corrupted source.

</blockquote>
</details>
<details>
<summary><strong>4. Right-click menu silently ignores non-Memory-Bank markdown files</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a VS Code workspace with both Memory Bank files and unrelated markdown files (`.md` files that are not part of Memory Bank).

**Steps:**
1. In the explorer, right-click on an unrelated markdown file (not a Memory Bank summary).
2. Look for "Revert Edits to System Version" in the context menu.
3. If the option appears, click it.
4. Wait a moment.

**Expected Results:**
- The "Revert Edits to System Version" option may appear in the menu (since the menu is gated only on `.md` filename).
- If clicked, no warning or information message should appear — the action should silently do nothing.
- No toast notification should pop up, and the file should not be modified.

</blockquote>
</details>
<details>
<summary><strong>5. Revert command works when invoked from the divergence warning button</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a Memory Bank workspace with a summary file that has been manually edited and diverged from the system version. The file should be open in the editor.

**Steps:**
1. Open a diverged summary file in the editor.
2. Look for an information message at the top of the editor indicating the file has diverged from the system version.
3. Click the "Revert" button in that message.
4. Wait for the operation to complete.
5. Verify the file content has been restored.

**Expected Results:**
- An information message should appear saying "Reverted to system version: [file path]".
- The file should be restored to the system-generated version with all manual edits removed.
- The divergence warning should disappear.

</blockquote>
</details>
<details>
<summary><strong>6. Export command correctly handles backslashes in action text</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a Memory Bank workspace with at least one summary entry that contains a backslash in the action field (e.g., an action like "Fix regex: \d+ pattern").

**Steps:**
1. Run the export command (via CLI or the VS Code command palette, depending on your setup).
2. Open the exported file and locate the entry with the backslash in the action.
3. Verify that the backslash appears correctly in the exported output (not doubled or escaped incorrectly).

**Expected Results:**
- The exported action text should preserve the backslash exactly as it was in the original entry.
- A backslash followed by a quote (e.g., `\"`) should not appear as `\\"` in the output.
- The YAML formatting should be valid and parseable.

</blockquote>
</details>
<details>
<summary><strong>7. View command correctly handles pipes and backslashes in table cells</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a Memory Bank workspace with summary entries that contain pipe characters (`|`) or backslashes (`\`) in commit messages or other fields that appear in table output.

**Steps:**
1. Run the view command to display a compact list or table (via CLI or VS Code command palette).
2. Locate entries with pipes or backslashes in their commit messages.
3. Examine the table output and verify the special characters are displayed correctly.

**Expected Results:**
- Pipe characters should appear as literal pipes in the table cells, not as cell separators.
- Backslashes should appear as single backslashes, not doubled.
- The table should remain properly formatted with correct column alignment.
- A commit message like "Fix \| issue" should display as "Fix \| issue" in the table, not as "Fix \\| issue" or split across cells.

</blockquote>
</details>

---

## Topics (8)
<details>
<summary><strong>01 · Replace boolean return with discriminated union to distinguish revert failure modes</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The revert command returned a plain boolean on failure, collapsing three distinct failure states (missing hidden source, malformed JSON, file-lock errors) into a single false value. The UI always blamed a missing hidden source regardless of the actual problem, hiding JSON corruption and file-lock errors from users.

**💡 Decisions Behind the Code**

- **Discriminated union over boolean**: A boolean loses information about why a failure occurred. The discriminated union separates success/failure from the cause, allowing TypeScript exhaustiveness checking to enforce UI updates when new failure modes are added. This prevents silent misdiagnosis where the UI blames the wrong problem.
- **Duck-typing for Uri detection**: Test mocks cannot use `instanceof vscode.Uri` because they are plain object factories, not classes. Duck-typing on `"fsPath" in arg && "scheme" in arg` works for both production (real Uri class) and test (mock object), making the contract explicit: what makes something Uri-like is the presence of these two properties.

**✅ What Was Implemented**

- Introduced `ForceRegenerateResult` discriminated union type in `cli/src/core/FolderStorage.ts` with three failure reasons: `"missing"`, `"malformed"`, and `"unlinkFailed"`. The method now returns `{ ok: true }` on success or `{ ok: false; reason: ... }` on failure.
- Added `revertFailureHint()` helper in `vscode/src/Extension.ts` that maps each failure reason to a distinct user-facing message: missing source gets the original hint, malformed JSON now says "hidden source is corrupt (JSON is unparseable)", and unlink failure says "could not overwrite the existing file (it may be locked by another process)".
- Updated all call sites and test mocks across `cli/src/core/FolderStorage.test.ts` and `vscode/src/Extension.test.ts` to handle the new discriminated union shape.

**📁 FILES**
- `cli/src/core/FolderStorage.ts`
- `vscode/src/Extension.ts`

</blockquote>
</details>
<details>
<summary><strong>02 · Fix explorer context-menu revert command to accept Uri arguments</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The revert command handler checked `typeof arg !== "string"` and silently returned, rejecting Uri objects. VS Code's explorer context menu always passes a Uri, not a string, so the advertised "right-click a closed Memory Bank file in the explorer" path was a no-op.

**💡 Decisions Behind the Code**

Duck-typing on Uri properties instead of using `instanceof` ensures the test mock (a plain object factory) remains compatible with production code (the real Uri class). This makes the contract explicit: the handler accepts anything with `fsPath` and `scheme` properties, not just the Uri class itself. The approach is more robust than class-based type checking and documents what the code actually depends on.

**✅ What Was Implemented**

- Modified the command handler in `vscode/src/Extension.ts` to accept both string paths (from programmatic callers and the Revert button) and Uri objects (from explorer menus). The handler duck-types on `fsPath` and `scheme` properties, rejecting non-file schemes (virtual/remote) since Memory Bank files always live on the local filesystem.
- Added two new test cases in `vscode/src/Extension.test.ts`: one verifying that a Uri with `scheme: "file"` successfully triggers the revert flow, and another confirming that non-file schemes silently no-op without producing a warning toast.

**📁 FILES**
- `vscode/src/Extension.ts`

</blockquote>
</details>
<details>
<summary><strong>03 · Validate hidden source before unlinking in revert path</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The revert command is the user's only safety mechanism when a visible markdown file diverges from the system version. If the hidden JSON source is missing or corrupted, destroying the visible file before validation turns the safety command into silent data loss.

**💡 Decisions Behind the Code**

Validation must happen before any destructive action. The revert path is unique: it is the only place where the visible markdown is the user's only copy of their edits. Checking the hidden source first ensures that if corruption or loss has occurred, the user's edits remain on disk and recoverable. This defensive ordering prevents the safety command from becoming a data-loss vector for exactly the cases it should handle most carefully.

**✅ What Was Implemented**

- Modified `forceRegenerateVisibleMarkdown` in `cli/src/core/FolderStorage.ts` to read and validate the hidden JSON file before unlinking the visible markdown. If the file is missing or unparseable, the function returns false and leaves the visible file untouched.
- Added two test cases to `cli/src/core/FolderStorage.test.ts` covering the missing-file and malformed-JSON scenarios, ensuring the visible file survives both failure modes.

**📁 FILES**
- `cli/src/core/FolderStorage.ts`

</blockquote>
</details>
<details>
<summary><strong>04 · Route orphan-only users away from folder shadow storage</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Users who opt into orphan-only storage mode have no folder shadow to read from. Attempting to read from a non-existent shadow storage surfaces stale leftovers or blank data, breaking the source-of-truth contract for users who explicitly chose to avoid dual-write.

**💡 Decisions Behind the Code**

Orphan-only users must always read from the orphan branch, not from a folder shadow that does not exist for them. Returning null from the read-storage factory allows the webview and other callers to fall back to the bridge's default storage provider, preserving the source-of-truth contract. This is simpler and safer than attempting to create or read from a non-existent shadow.

**✅ What Was Implemented**

- Modified `createReadStorageForCurrentRepo` in `vscode/src/JolliMemoryBridge.ts` to check the storage mode and return null when `storageMode === "orphan"`, signaling callers to fall back to the active storage provider.
- Added a test case to `vscode/src/JolliMemoryBridge.test.ts` verifying that the method returns null for orphan-only users.

**📁 FILES**
- `vscode/src/JolliMemoryBridge.ts`

</blockquote>
</details>
<details>
<summary><strong>05 · Simplify explorer menu gating to filename only</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The explorer right-click menu for reverting edits was gated by a context key that tracked the active editor, not the right-clicked resource. This silently hid the menu when users right-clicked a closed Memory Bank file in the explorer—the main advertised workflow—because the context key only updated when the editor changed.

**💡 Decisions Behind the Code**

- **Filename-only gating accepts a broader menu surface**: The menu may briefly appear on non-Memory-Bank markdown files, but the handler silently no-ops in those cases. This trade-off is worth accepting because it fixes the main pain point: users can now right-click a closed Memory Bank file in the explorer and see the revert option, without the menu disappearing based on which editor happens to be active.
- **Silent no-op avoids toast spam**: Because the menu gate is now broader, the handler must not toast a warning on every misclick. A silent return is the right behavior—users who accidentally right-click an unrelated markdown file should not see a warning flash across their screen.

**✅ What Was Implemented**

- Removed the `jollimemory.isMemoryBankFile` context key and the `updateMemoryBankContext` callback from `vscode/src/Extension.ts` that tracked active-editor changes.
- Simplified the `when` clause in `vscode/package.json` to gate the menu only on the `.md` filename pattern, removing the context-key condition.
- Modified the `revertMemoryFileEdits` command handler to silently return (no toast) when the file does not resolve to a Memory Bank entry, avoiding noisy warnings on misclicks to unrelated markdown files.
- Updated test assertions in `vscode/src/Extension.test.ts` to reflect the new silent-no-op behavior and removed the test for the deleted context-key wiring.

**📁 FILES**
- `vscode/src/Extension.ts`
- `vscode/package.json`

</blockquote>
</details>
<details>
<summary><strong>06 · Cache discovery results to reduce filesystem polling overhead</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The file-decoration provider polls every visible markdown file on every explorer scroll, triggering a config read and filesystem scan for each URI. On Memory-Bank-heavy workspaces with many markdown files, this creates O(N) filesystem hits per redraw, causing noticeable lag.

**💡 Decisions Behind the Code**

A short-lived cache (3 seconds) balances responsiveness with performance. The TTL is intentionally brief so users do not notice staleness after editing settings; explicit invalidation on settings-save ensures the cache never blocks configuration updates. This approach eliminates the O(N) filesystem overhead during explorer scrolling without introducing stale-data risk.

**✅ What Was Implemented**

- Added a `discoveryCache` field to `JolliMemoryBridge` with a 3-second TTL to cache the result of the `loadConfig` + `discoverRepos` pair.
- Introduced a `getDiscoveryCached` helper method that returns cached results if still valid, or refreshes and caches new results if expired.
- Updated `findRepoForAbsPath` and `createReadStorageForCurrentRepo` to use the cached discovery results instead of calling `loadConfig` and `discoverRepos` directly.
- Modified `reloadStorage` to invalidate the discovery cache when settings change, ensuring users see updated configuration immediately.

**📁 FILES**
- `vscode/src/JolliMemoryBridge.ts`

</blockquote>
</details>
<details>
<summary><strong>07 · Fix escape sequence handling in export and view commands</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Export and view commands were not correctly handling backslashes in user-provided content, causing escape sequences to round-trip incorrectly through YAML and Markdown parsers.

**💡 Decisions Behind the Code**

Backslash escaping must occur first in the replacement chain. If pipes or quotes are escaped first, a literal backslash in the input will not be escaped, causing it to be interpreted as the start of an escape sequence when the output is later decoded by YAML or Markdown parsers. This order ensures that all special characters round-trip correctly through both encoding and decoding steps.

**✅ What Was Implemented**

- **ExportCommand.ts**: Modified `formatPromptMarkdown` to escape backslashes before double-quotes. The function now calls `replace(/\\/g, "\\\\")` first, then `replace(/"/g, '\\"')`, ensuring that a literal backslash in the input survives YAML's quoted-string decoder.
- **ViewCommand.ts**: Updated `escapeCell` to escape backslashes before pipes. The function now calls `replace(/\\/g, "\\\\")` first, then `replace(/\|/g, "\\|")`, preventing input like `\|` from emerging as `\\|` and being decoded as a backslash plus cell separator in GFM tables.
- **SummaryExporter.ts**: Modified `buildIndexRow` to escape backslashes before pipes in commit messages using the same two-step approach, with a comment referencing the rationale in ViewCommand.

**📁 FILES**
- `cli/src/commands/ExportCommand.ts`
- `cli/src/commands/ViewCommand.ts`

</blockquote>
</details>
<details>
<summary><strong>08 · Document cursor-advance trade-off in overlay pruning</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The overlay pruning logic runs unconditionally after cursor advance, but if the downstream LLM call fails, both the cursor and the overlay file have moved past consumed entries. This means user edits are effectively lost, but the trade-off was not documented.

**💡 Decisions Behind the Code**

The trade-off is real but belongs to a larger refactor. Moving prune alone would leave a stale "edited" badge without recovering the data, so the honest approach is to document the current behavior and defer the transactional fix to a future change that also makes cursor advance conditional on success. This prevents future maintainers from attempting a partial fix that would create worse inconsistency.

**✅ What Was Implemented**

- Updated the docstring in `cli/src/core/ConversationOverlayStore.ts` for `pruneConsumedOverlayRules` to clarify the call site (inside `loadSessionTranscripts` after `applyOverlaysToSessions`, not after the function returns) and to explicitly document the cursor-advance trade-off.
- Added a note explaining that prune and cursor advance run unconditionally, not gated on successful `storeSummary` downstream, and that a transactional refactor would require moving both cursor advance and prune together.

**📁 FILES**
- `cli/src/core/ConversationOverlayStore.ts`

</blockquote>
</details>

---

*Generated by Jolli Memory · May 24, 2026 at 12:28 AM · via Anthropic*
<!-- jollimemory-summary-end -->