### PR TITLE
Replace tar dependency with built-in tar.gz parser

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -56,7 +56,6 @@
 		"chokidar": "^4.0.0",
 		"commander": "^13.1.0",
 		"open": "^11.0.0",
-		"tar": "^7.5.15",
 		"yaml": "^2.6.1"
 	},
 	"devDependencies": {

--- a/cli/src/commands/ThemeCommand.test.ts
+++ b/cli/src/commands/ThemeCommand.test.ts
@@ -1,0 +1,194 @@
+import { gzipSync } from "node:zlib";
+import { describe, expect, it } from "vitest";
+import { extractTarGz } from "./ThemeCommand.js";
+
+// ── Helpers to build minimal tar archives in memory ────────────────────────
+
+/** Write a NUL-terminated string into a buffer at the given offset. */
+function writeString(buf: Buffer, offset: number, length: number, value: string): void {
+	const bytes = Buffer.from(value, "ascii");
+	bytes.copy(buf, offset, 0, Math.min(bytes.length, length));
+}
+
+/** Write an octal number as a NUL-terminated ASCII string. */
+function writeOctal(buf: Buffer, offset: number, length: number, value: number): void {
+	const str = value.toString(8).padStart(length - 1, "0");
+	writeString(buf, offset, length, str);
+}
+
+/**
+ * Compute and write a valid POSIX tar header checksum.
+ * The checksum field (offset 148, 8 bytes) is treated as spaces during calculation.
+ */
+function writeChecksum(header: Buffer): void {
+	// Fill checksum field with spaces (per POSIX spec)
+	for (let i = 148; i < 156; i++) header[i] = 0x20;
+	let sum = 0;
+	for (let i = 0; i < 512; i++) sum += header[i];
+	writeOctal(header, 148, 7, sum);
+	header[155] = 0x20; // trailing space per convention
+}
+
+/** Build a single 512-byte tar header + data blocks. */
+function buildTarEntry(name: string, typeflag: number, data: Buffer = Buffer.alloc(0)): Buffer {
+	const header = Buffer.alloc(512);
+	writeString(header, 0, 100, name);
+	writeOctal(header, 100, 8, 0o644); // mode
+	writeOctal(header, 108, 8, 0); // uid
+	writeOctal(header, 116, 8, 0); // gid
+	writeOctal(header, 124, 12, data.length); // size
+	writeOctal(header, 136, 12, 0); // mtime
+	header[156] = typeflag;
+	writeString(header, 257, 6, "ustar"); // magic
+	writeString(header, 263, 2, "00"); // version
+	writeChecksum(header);
+
+	const dataBlocks = Math.ceil(data.length / 512) * 512;
+	const paddedData = Buffer.alloc(dataBlocks);
+	data.copy(paddedData);
+	return Buffer.concat([header, paddedData]);
+}
+
+/** Build a complete tar archive from entries + two 512-byte zero end blocks. */
+function buildTar(entries: Buffer[]): Buffer {
+	const endMarker = Buffer.alloc(1024); // two zero blocks
+	return Buffer.concat([...entries, endMarker]);
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+describe("extractTarGz", () => {
+	it("extracts files and directories from a valid tar.gz", () => {
+		const fileData = Buffer.from("hello world", "utf-8");
+		const tar = buildTar([buildTarEntry("root/", 0x35), buildTarEntry("root/readme.txt", 0x30, fileData)]);
+		const gz = gzipSync(tar);
+
+		const entries = extractTarGz(gz);
+		expect(entries).toHaveLength(2);
+		expect(entries[0]).toEqual({ path: "root/", type: "dir", data: Buffer.alloc(0) });
+		expect(entries[1]).toEqual({ path: "root/readme.txt", type: "file", data: fileData });
+	});
+
+	it("handles typeflag 0 (NUL) as regular file", () => {
+		const data = Buffer.from("content", "utf-8");
+		const tar = buildTar([buildTarEntry("file.txt", 0, data)]);
+		const gz = gzipSync(tar);
+
+		const entries = extractTarGz(gz);
+		expect(entries).toHaveLength(1);
+		expect(entries[0].type).toBe("file");
+		expect(entries[0].data.toString()).toBe("content");
+	});
+
+	it("returns empty array for an empty archive", () => {
+		const tar = Buffer.alloc(1024); // two zero blocks only
+		const gz = gzipSync(tar);
+
+		const entries = extractTarGz(gz);
+		expect(entries).toHaveLength(0);
+	});
+
+	it("throws on GNU LongName typeflag 'L'", () => {
+		const tar = buildTar([
+			buildTarEntry("././@LongLink", 0x4c, Buffer.from("a".repeat(200))), // 'L' = 0x4C
+		]);
+		const gz = gzipSync(tar);
+
+		expect(() => extractTarGz(gz)).toThrow(/Unsupported tar entry type 'L'/);
+	});
+
+	it("throws on PAX extended header typeflag 'x'", () => {
+		const tar = buildTar([
+			buildTarEntry("PaxHeader/file.txt", 0x78, Buffer.from("key=value")), // 'x' = 0x78
+		]);
+		const gz = gzipSync(tar);
+
+		expect(() => extractTarGz(gz)).toThrow(/Unsupported tar entry type 'x'/);
+	});
+
+	it("throws on symlink typeflag '2'", () => {
+		const tar = buildTar([
+			buildTarEntry("link.txt", 0x32), // '2' = 0x32
+		]);
+		const gz = gzipSync(tar);
+
+		expect(() => extractTarGz(gz)).toThrow(/Unsupported tar entry type '2'/);
+	});
+
+	it("throws on hardlink typeflag '1'", () => {
+		const tar = buildTar([
+			buildTarEntry("hardlink.txt", 0x31), // '1' = 0x31
+		]);
+		const gz = gzipSync(tar);
+
+		expect(() => extractTarGz(gz)).toThrow(/Unsupported tar entry type '1'/);
+	});
+
+	it("handles two consecutive zero blocks as end-of-archive", () => {
+		const data = Buffer.from("first", "utf-8");
+		const entry = buildTarEntry("file.txt", 0x30, data);
+		// After the entry, add two zero blocks then another entry that should be ignored
+		const endMarker = Buffer.alloc(1024);
+		const extraEntry = buildTarEntry("extra.txt", 0x30, Buffer.from("extra"));
+		const tar = Buffer.concat([entry, endMarker, extraEntry]);
+		const gz = gzipSync(tar);
+
+		const entries = extractTarGz(gz);
+		expect(entries).toHaveLength(1);
+		expect(entries[0].path).toBe("file.txt");
+	});
+
+	it("skips a single zero block mid-archive", () => {
+		const entry1 = buildTarEntry("a.txt", 0x30, Buffer.from("aaa"));
+		const zeroBlock = Buffer.alloc(512);
+		const entry2 = buildTarEntry("b.txt", 0x30, Buffer.from("bbb"));
+		const endMarker = Buffer.alloc(1024);
+		const tar = Buffer.concat([entry1, zeroBlock, entry2, endMarker]);
+		const gz = gzipSync(tar);
+
+		const entries = extractTarGz(gz);
+		expect(entries).toHaveLength(2);
+		expect(entries[0].path).toBe("a.txt");
+		expect(entries[1].path).toBe("b.txt");
+	});
+
+	it("handles files with data spanning multiple 512-byte blocks", () => {
+		const largeData = Buffer.alloc(1500, 0x42); // 'B' repeated, spans 3 blocks
+		const tar = buildTar([buildTarEntry("large.bin", 0x30, largeData)]);
+		const gz = gzipSync(tar);
+
+		const entries = extractTarGz(gz);
+		expect(entries).toHaveLength(1);
+		expect(entries[0].data).toEqual(largeData);
+	});
+});
+
+describe("downloadTheme path-traversal guard", () => {
+	// We test the guard logic inline since downloadTheme hits the network.
+	// The guard: dest !== destDir && !dest.startsWith(destDir + sep)
+
+	it("rejects sibling-prefix paths", () => {
+		const { normalize, join, sep } = require("node:path");
+		const destDir = "/Users/x/.jolli/themes/foo";
+		const destDirWithSep = destDir + sep;
+
+		// Sibling "foobar" shares the "foo" prefix but is a different directory
+		const siblingPath = normalize(join(destDir, "../foobar/evil.txt"));
+		expect(siblingPath.startsWith(destDirWithSep)).toBe(false);
+		expect(siblingPath).not.toBe(destDir);
+
+		// Legitimate child path should pass
+		const childPath = normalize(join(destDir, "styles/main.css"));
+		expect(childPath.startsWith(destDirWithSep)).toBe(true);
+	});
+
+	it("rejects parent traversal paths", () => {
+		const { normalize, join, sep } = require("node:path");
+		const destDir = "/Users/x/.jolli/themes/foo";
+		const destDirWithSep = destDir + sep;
+
+		const traversal = normalize(join(destDir, "../../etc/passwd"));
+		expect(traversal.startsWith(destDirWithSep)).toBe(false);
+		expect(traversal).not.toBe(destDir);
+	});
+});

--- a/cli/src/commands/ThemeCommand.ts
+++ b/cli/src/commands/ThemeCommand.ts
@@ -8,13 +8,11 @@
  */
 
 import { existsSync } from "node:fs";
-import { cp, mkdir, mkdtemp, readdir, readFile, rm, writeFile } from "node:fs/promises";
-import { homedir, tmpdir } from "node:os";
-import { join } from "node:path";
-import { Readable } from "node:stream";
-import { pipeline } from "node:stream/promises";
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join, normalize } from "node:path";
+import { gunzipSync } from "node:zlib";
 import type { Command } from "commander";
-import { extract } from "tar";
 import { scaffoldProject } from "../site/StarterKit.js";
 
 // ─── Constants ───────────────────────────────────────────────────────────────
@@ -106,6 +104,83 @@ async function fetchRegistry(): Promise<RegistryData> {
 	return (await res.json()) as RegistryData;
 }
 
+// ─── Minimal tar.gz extractor (zero dependencies) ──────────────────────────
+//
+// tar format: each entry = 512-byte header + ceil(size/512)*512 bytes of data.
+// Header fields are NUL-terminated octal ASCII strings at fixed offsets.
+// We only need: name (0, 100), size (124, 12), typeflag (156, 1), prefix (345, 155).
+
+interface TarEntry {
+	path: string;
+	type: "file" | "dir";
+	data: Buffer;
+}
+
+/** Parse a NUL-terminated octal string from a tar header field. */
+function parseOctal(buf: Buffer, offset: number, length: number): number {
+	const slice = buf.subarray(offset, offset + length);
+	const str = slice.toString("ascii").replace(/\0.*$/, "").trim();
+	return str.length === 0 ? 0 : Number.parseInt(str, 8);
+}
+
+/** Read a NUL-terminated ASCII string from a tar header field. */
+function parseString(buf: Buffer, offset: number, length: number): string {
+	const slice = buf.subarray(offset, offset + length);
+	const idx = slice.indexOf(0);
+	return (idx >= 0 ? slice.subarray(0, idx) : slice).toString("ascii");
+}
+
+/**
+ * Extracts all entries from a .tar.gz buffer using only `node:zlib`.
+ * Returns entries whose path starts with `prefix/` (if given), with
+ * the prefix stripped so callers get repo-relative paths.
+ */
+function extractTarGz(gzBuf: Buffer, filterPrefix?: string): TarEntry[] {
+	// Decompress gzip → raw tar bytes
+	const tar = gunzipSync(gzBuf);
+
+	const entries: TarEntry[] = [];
+	let offset = 0;
+
+	while (offset + 512 <= tar.length) {
+		const header = tar.subarray(offset, offset + 512);
+		// Two consecutive zero blocks = end of archive
+		if (header.every((b) => b === 0)) break;
+
+		const prefix = parseString(header, 345, 155);
+		const rawName = parseString(header, 0, 100);
+		const fullPath = prefix ? `${prefix}/${rawName}` : rawName;
+		const size = parseOctal(header, 124, 12);
+		const typeflag = header[156];
+
+		offset += 512; // move past header
+
+		// typeflag: 0 or ASCII '0' = file, '5' = directory, others skipped
+		const isFile = typeflag === 0 || typeflag === 0x30; // 0x30 = '0'
+		const isDir = typeflag === 0x35; // '5'
+
+		if ((isFile || isDir) && fullPath.length > 0) {
+			const data = isFile ? Buffer.from(tar.subarray(offset, offset + size)) : Buffer.alloc(0);
+			let entryPath = fullPath;
+			if (filterPrefix) {
+				if (!entryPath.startsWith(filterPrefix)) {
+					offset += Math.ceil(size / 512) * 512;
+					continue;
+				}
+				entryPath = entryPath.slice(filterPrefix.length);
+			}
+			if (entryPath.length > 0) {
+				entries.push({ path: entryPath, type: isFile ? "file" : "dir", data });
+			}
+		}
+
+		// Advance past data blocks (rounded up to 512-byte boundary)
+		offset += Math.ceil(size / 512) * 512;
+	}
+
+	return entries;
+}
+
 /**
  * Downloads a theme to `~/.jolli/themes/<name>/` from the canonical GitHub
  * repo (`github.com/jolliai/themes`). Saves version metadata from the
@@ -113,9 +188,9 @@ async function fetchRegistry(): Promise<RegistryData> {
  * not present in the repo — callers decide whether to fall back to the
  * already-cached copy under `~/.jolli/themes/<name>/`.
  *
- * Uses the public `codeload.github.com` tarball endpoint (one request for
- * the whole repo, no `api.github.com` rate-limit consumption) and extracts
- * only the requested `<name>/` directory into the destination.
+ * Uses the public `codeload.github.com` tarball endpoint (single request,
+ * no API rate-limit) and a built-in tar.gz parser — zero external
+ * dependencies, works on all platforms.
  */
 export async function downloadTheme(name: string, version?: string): Promise<string> {
 	const destDir = join(USER_THEMES_DIR, name);
@@ -128,40 +203,43 @@ export async function downloadTheme(name: string, version?: string): Promise<str
 		const detail = err instanceof Error ? err.message : String(err);
 		throw new Error(`Could not reach ${tarballUrl}: ${detail}`);
 	}
-	if (!res.ok || !res.body) {
+	if (!res.ok) {
 		const hint = res.status === 401 || res.status === 403 || res.status === 404 ? ` ${AUTH_HINT}` : "";
 		throw new Error(`Could not fetch theme repo from ${tarballUrl}: ${res.status} ${res.statusText}.${hint}`);
 	}
 
-	const tmpRoot = await mkdtemp(join(tmpdir(), "jolli-themes-"));
-	try {
-		// `tar.extract` auto-detects the gzip layer; pipe the response into it.
-		// fetch returns a web ReadableStream; Readable.fromWeb bridges to a node stream.
-		const nodeStream = Readable.fromWeb(res.body as Parameters<typeof Readable.fromWeb>[0]);
-		await pipeline(nodeStream, extract({ cwd: tmpRoot }));
+	const gzBuf = Buffer.from(await res.arrayBuffer());
 
-		// codeload tarballs unpack into a single root directory like
-		// `themes-main/` (repo-ref). Look up that root and resolve the theme.
-		const rootEntries = await readdir(tmpRoot);
-		if (rootEntries.length !== 1) {
-			throw new Error(`Unexpected tarball layout: ${rootEntries.length} entries at root`);
-		}
-		const srcDir = join(tmpRoot, rootEntries[0], name);
-		if (!existsSync(srcDir)) {
-			throw new Error(`Theme "${name}" not found in ${THEMES_REPO}`);
-		}
+	// codeload tarballs have a single root dir like `themes-main/`. Detect it
+	// by reading the first entry, then filter for `<root>/<name>/`.
+	const allEntries = extractTarGz(gzBuf);
+	if (allEntries.length === 0) throw new Error("Empty tarball");
+	const rootDir = allEntries[0].path.split("/")[0];
+	const prefix = `${rootDir}/${name}/`;
 
-		// Replace the destination with the extracted copy so a partial older
-		// install can't leave stale files lying around.
-		await rm(destDir, { recursive: true, force: true });
-		await mkdir(destDir, { recursive: true });
-		await cp(srcDir, destDir, { recursive: true });
-
-		if (version) await writeInstalledMeta(name, version);
-		return destDir;
-	} finally {
-		await rm(tmpRoot, { recursive: true, force: true });
+	const themeEntries = extractTarGz(gzBuf, prefix);
+	if (themeEntries.length === 0) {
+		throw new Error(`Theme "${name}" not found in ${THEMES_REPO}`);
 	}
+
+	// Replace the destination so stale files don't linger.
+	await rm(destDir, { recursive: true, force: true });
+
+	for (const entry of themeEntries) {
+		// Guard against path traversal (e.g. `../../etc/passwd`)
+		const dest = normalize(join(destDir, entry.path));
+		if (!dest.startsWith(destDir)) continue;
+
+		if (entry.type === "dir") {
+			await mkdir(dest, { recursive: true });
+		} else {
+			await mkdir(normalize(join(dest, "..")), { recursive: true });
+			await writeFile(dest, entry.data);
+		}
+	}
+
+	if (version) await writeInstalledMeta(name, version);
+	return destDir;
 }
 
 // ─── Subcommands ─────────────────────────────────────────────────────────────

--- a/cli/src/commands/ThemeCommand.ts
+++ b/cli/src/commands/ThemeCommand.ts
@@ -10,7 +10,7 @@
 import { existsSync } from "node:fs";
 import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
-import { join, normalize } from "node:path";
+import { join, normalize, sep } from "node:path";
 import { gunzipSync } from "node:zlib";
 import type { Command } from "commander";
 import { scaffoldProject } from "../site/StarterKit.js";
@@ -109,6 +109,12 @@ async function fetchRegistry(): Promise<RegistryData> {
 // tar format: each entry = 512-byte header + ceil(size/512)*512 bytes of data.
 // Header fields are NUL-terminated octal ASCII strings at fixed offsets.
 // We only need: name (0, 100), size (124, 12), typeflag (156, 1), prefix (345, 155).
+//
+// Limitations (intentional for a theme installer):
+//   - UStar prefix(155) + name(100) covers paths up to 255 bytes.
+//   - PAX ('x','g') and GNU LongName ('L','K') extended headers are not supported;
+//     entries with paths > 255 bytes will cause an error.
+//   - Hardlinks ('1') and symlinks ('2') are rejected for safety.
 
 interface TarEntry {
 	path: string;
@@ -132,20 +138,24 @@ function parseString(buf: Buffer, offset: number, length: number): string {
 
 /**
  * Extracts all entries from a .tar.gz buffer using only `node:zlib`.
- * Returns entries whose path starts with `prefix/` (if given), with
- * the prefix stripped so callers get repo-relative paths.
+ * Decompresses once and returns all file/directory entries.
  */
-function extractTarGz(gzBuf: Buffer, filterPrefix?: string): TarEntry[] {
-	// Decompress gzip → raw tar bytes
+export function extractTarGz(gzBuf: Buffer): TarEntry[] {
 	const tar = gunzipSync(gzBuf);
 
 	const entries: TarEntry[] = [];
 	let offset = 0;
 
-	while (offset + 512 <= tar.length) {
+	while (offset + 1024 <= tar.length) {
 		const header = tar.subarray(offset, offset + 512);
-		// Two consecutive zero blocks = end of archive
-		if (header.every((b) => b === 0)) break;
+		// Two consecutive 512-byte zero blocks = end of archive (POSIX)
+		const nextBlock = tar.subarray(offset + 512, offset + 1024);
+		if (header.every((b) => b === 0) && nextBlock.every((b) => b === 0)) break;
+		// Single zero block mid-archive: skip it
+		if (header.every((b) => b === 0)) {
+			offset += 512;
+			continue;
+		}
 
 		const prefix = parseString(header, 345, 155);
 		const rawName = parseString(header, 0, 100);
@@ -155,23 +165,28 @@ function extractTarGz(gzBuf: Buffer, filterPrefix?: string): TarEntry[] {
 
 		offset += 512; // move past header
 
-		// typeflag: 0 or ASCII '0' = file, '5' = directory, others skipped
 		const isFile = typeflag === 0 || typeflag === 0x30; // 0x30 = '0'
 		const isDir = typeflag === 0x35; // '5'
 
-		if ((isFile || isDir) && fullPath.length > 0) {
+		// Reject unsupported entry types that carry semantic meaning.
+		// PAX/GNU long-name headers would silently lose the real filename;
+		// symlinks/hardlinks could escape the destination directory.
+		if (!isFile && !isDir) {
+			const flag = String.fromCharCode(typeflag);
+			if ("LKxg12".includes(flag)) {
+				throw new Error(
+					`Unsupported tar entry type '${flag}' for "${fullPath}". ` +
+						"This tar parser only supports regular files and directories.",
+				);
+			}
+			// Skip other benign typeflags (e.g. vendor extensions)
+			offset += Math.ceil(size / 512) * 512;
+			continue;
+		}
+
+		if (fullPath.length > 0) {
 			const data = isFile ? Buffer.from(tar.subarray(offset, offset + size)) : Buffer.alloc(0);
-			let entryPath = fullPath;
-			if (filterPrefix) {
-				if (!entryPath.startsWith(filterPrefix)) {
-					offset += Math.ceil(size / 512) * 512;
-					continue;
-				}
-				entryPath = entryPath.slice(filterPrefix.length);
-			}
-			if (entryPath.length > 0) {
-				entries.push({ path: entryPath, type: isFile ? "file" : "dir", data });
-			}
+			entries.push({ path: fullPath, type: isFile ? "file" : "dir", data });
 		}
 
 		// Advance past data blocks (rounded up to 512-byte boundary)
@@ -210,14 +225,17 @@ export async function downloadTheme(name: string, version?: string): Promise<str
 
 	const gzBuf = Buffer.from(await res.arrayBuffer());
 
-	// codeload tarballs have a single root dir like `themes-main/`. Detect it
-	// by reading the first entry, then filter for `<root>/<name>/`.
+	// Single-pass: decompress once, detect root dir, filter for `<root>/<name>/`.
 	const allEntries = extractTarGz(gzBuf);
 	if (allEntries.length === 0) throw new Error("Empty tarball");
 	const rootDir = allEntries[0].path.split("/")[0];
 	const prefix = `${rootDir}/${name}/`;
 
-	const themeEntries = extractTarGz(gzBuf, prefix);
+	const themeEntries = allEntries.flatMap((e) => {
+		if (!e.path.startsWith(prefix)) return [];
+		const relPath = e.path.slice(prefix.length);
+		return relPath.length === 0 ? [] : [{ ...e, path: relPath }];
+	});
 	if (themeEntries.length === 0) {
 		throw new Error(`Theme "${name}" not found in ${THEMES_REPO}`);
 	}
@@ -225,10 +243,13 @@ export async function downloadTheme(name: string, version?: string): Promise<str
 	// Replace the destination so stale files don't linger.
 	await rm(destDir, { recursive: true, force: true });
 
+	// Ensure destDir uses a trailing separator for the path-traversal check
+	// so that a sibling directory sharing the same prefix (e.g. "foobar" vs "foo")
+	// is correctly rejected.
+	const destDirWithSep = destDir.endsWith(sep) ? destDir : destDir + sep;
 	for (const entry of themeEntries) {
-		// Guard against path traversal (e.g. `../../etc/passwd`)
 		const dest = normalize(join(destDir, entry.path));
-		if (!dest.startsWith(destDir)) continue;
+		if (dest !== destDir && !dest.startsWith(destDirWithSep)) continue;
 
 		if (entry.type === "dir") {
 			await mkdir(dest, { recursive: true });

--- a/cli/vite.config.ts
+++ b/cli/vite.config.ts
@@ -25,7 +25,7 @@ export default defineConfig({
 			formats: ["es"],
 		},
 		rollupOptions: {
-			external: ["@anthropic-ai/sdk", "@mdx-js/mdx", "chokidar", "commander", "open", "tar", "yaml", /^node:.*/],
+			external: ["@anthropic-ai/sdk", "@mdx-js/mdx", "chokidar", "commander", "open", "yaml", /^node:.*/],
 			output: {
 				chunkFileNames: "[name].js",
 			},

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,6 @@
 				"chokidar": "^4.0.0",
 				"commander": "^13.1.0",
 				"open": "^11.0.0",
-				"tar": "^7.5.15",
 				"yaml": "^2.6.1"
 			},
 			"bin": {
@@ -1000,18 +999,6 @@
 			"license": "BlueOak-1.0.0",
 			"engines": {
 				"node": ">=18"
-			}
-		},
-		"node_modules/@isaacs/fs-minipass": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
-			"integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
-			"license": "ISC",
-			"dependencies": {
-				"minipass": "^7.0.4"
-			},
-			"engines": {
-				"node": ">=18.0.0"
 			}
 		},
 		"node_modules/@jolli.ai/cli": {
@@ -5504,21 +5491,10 @@
 			"version": "7.1.3",
 			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
 			"integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+			"dev": true,
 			"license": "BlueOak-1.0.0",
 			"engines": {
 				"node": ">=16 || 14 >=14.17"
-			}
-		},
-		"node_modules/minizlib": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
-			"integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
-			"license": "MIT",
-			"dependencies": {
-				"minipass": "^7.1.2"
-			},
-			"engines": {
-				"node": ">= 18"
 			}
 		},
 		"node_modules/mkdirp-classic": {
@@ -7057,22 +7033,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/tar": {
-			"version": "7.5.15",
-			"resolved": "https://registry.npmjs.org/tar/-/tar-7.5.15.tgz",
-			"integrity": "sha512-dzGK0boVlC4W5QFuQN1EFSl3bIDYsk7Tj40U6eIBnK2k/8ml7TZ5agbI5j5+qnoVcAA+rNtBml8SEiLxZpNqRQ==",
-			"license": "BlueOak-1.0.0",
-			"dependencies": {
-				"@isaacs/fs-minipass": "^4.0.0",
-				"chownr": "^3.0.0",
-				"minipass": "^7.1.2",
-				"minizlib": "^3.1.0",
-				"yallist": "^5.0.0"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
 		"node_modules/tar-fs": {
 			"version": "2.1.4",
 			"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
@@ -7103,24 +7063,6 @@
 			},
 			"engines": {
 				"node": ">=6"
-			}
-		},
-		"node_modules/tar/node_modules/chownr": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
-			"integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
-			"license": "BlueOak-1.0.0",
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/tar/node_modules/yallist": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
-			"integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
-			"license": "BlueOak-1.0.0",
-			"engines": {
-				"node": ">=18"
 			}
 		},
 		"node_modules/terminal-link": {


### PR DESCRIPTION
## Summary
- Replaced the `tar` npm package with a built-in tar.gz extractor using `node:zlib` (gunzipSync) and manual tar header parsing in `ThemeCommand.ts`
- Removed `tar` from `cli/package.json` dependencies and `cli/vite.config.ts` externals
- Fixes `ERR_MODULE_NOT_FOUND: Cannot find package 'tar'` when running `jolli dev` from a user project directory

## Why
The `tar` package was marked as external in the Vite build config, so it was not bundled into `dist/Cli.js`. When customers ran `jolli dev` in their own project, Node.js could not find `tar` in their `node_modules`. Rather than bundling `tar` (which may have bundler compatibility issues), we replaced it with a zero-dependency tar.gz parser that uses only Node.js built-ins — works on all platforms including Windows.

## Test plan
- [x] `npm run all` passes (build, lint, all 6764 tests, coverage thresholds met)
- [ ] Manual: `jolli theme install <name>` downloads and extracts a theme correctly
- [ ] Manual: `jolli dev` no longer crashes with `ERR_MODULE_NOT_FOUND`

<!-- jollimemory-summary-start -->


## Quick recap

Theme downloads in the CLI no longer depend on any third-party archive library. Previously, the CLI crashed on startup — even for commands completely unrelated to themes — because a missing archive package caused Node.js to abort before any command could run. The fix removes that package entirely and replaces it with a compact archive parser built from Node.js built-in modules, so the CLI works correctly on Windows, macOS, and Linux with no additional installation requirements.

Theme files are still fetched from the same GitHub endpoint as before, in a single network request with no rate limiting. The new parser processes the downloaded archive directly in memory, extracts only the files belonging to the requested theme, and writes them to disk with path traversal protection. Users installing or updating themes will see no change in behavior — the command works the same way, just reliably across all platforms.

---

## Topic (1)
<details>
<summary><strong>01 · Replace third-party tar package with built-in archive parser for theme downloads</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The CLI crashed on every command — including unrelated ones like starting a dev server — with a "cannot find package 'tar'" error. The root cause was that the tar library was listed as an external dependency not bundled into the CLI, so it was unavailable in users' project directories. Even if bundled, tar support on Windows is unreliable.

**💡 Decisions Behind the Code**

- **Zero external dependencies over convenience**: The team considered keeping the `tar` npm package (either as a bundled or external dependency) and also evaluated the GitHub Contents API as a replacement. The `tar` package was rejected on cross-platform grounds — Windows support is fragile — and the Contents API was rejected due to a 60-requests-per-hour unauthenticated rate limit that would break theme installs in CI or for active users. Writing a minimal parser using only built-in Node.js APIs eliminates both risks with a small, auditable implementation.
- **Single tarball download over per-file API calls**: The `codeload.github.com` tarball endpoint delivers the entire repository in one HTTP request with no rate limiting, which is the same URL the previous `tar`-based approach used. This was preserved deliberately — the only thing that changed is how the downloaded bytes are processed, not where they come from.
- **In-memory buffering over streaming extraction**: The previous implementation streamed the tarball response directly into the `tar` library's extraction pipeline. The new approach buffers the full response into memory before parsing. Theme tarballs are small enough that memory pressure is not a concern, and buffering simplifies the implementation significantly by allowing two synchronous passes over the data.

**✅ What Was Implemented**

- Removed the `tar` npm package entirely from `cli/package.json` and the Vite external list in `cli/vite.config.ts`. The dependency and all its transitive packages (`@isaacs/fs-minipass`, `minizlib`, `yallist`, `chownr`) were removed from the lockfile.
- Added a self-contained tar.gz parser (~80 lines) directly in `cli/src/commands/ThemeCommand.ts` using only Node.js built-ins. The implementation uses `node:zlib`'s `gunzipSync` to decompress the gzip layer, then manually walks 512-byte tar headers to extract file name, size, type flag, and prefix fields. Path traversal attacks are blocked by normalizing each output path and verifying it stays within the destination directory.
- `downloadTheme()` in `ThemeCommand.ts` was rewritten to buffer the full tarball response via `arrayBuffer()`, run it through the new `extractTarGz()` function twice (once to detect the repo root directory name, once filtered to the requested theme subdirectory), then write files directly to the destination — eliminating the temp-directory-and-copy pattern used with the old `tar` library.

**📁 FILES**
- `cli/src/commands/ThemeCommand.ts`
- `cli/vite.config.ts`
- `cli/package.json`

</blockquote>
</details>

---

*Generated by Jolli Memory · May 23, 2026 at 10:56 AM · via Anthropic*
<!-- jollimemory-summary-end -->