### PR TITLE
Fix Windows path-separator drift in storage layer and unblock test suite

### DIFF
--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/core/CursorSupport.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/core/CursorSupport.kt
@@ -55,7 +55,11 @@ object CursorSupport {
 			osName.contains("mac") ->
 				home + File.separator + "Library" + File.separator + "Application Support" + File.separator + "Cursor"
 			osName.contains("win") ->
-				(System.getenv("APPDATA") ?: (home + File.separator + "AppData" + File.separator + "Roaming")) +
+				// `cursor.appdata.override` is a test hook: Java cannot unset env vars, so tests
+				// that need to redirect away from the real %APPDATA% set this system property instead.
+				(System.getProperty("cursor.appdata.override")
+					?: System.getenv("APPDATA")
+					?: (home + File.separator + "AppData" + File.separator + "Roaming")) +
 					File.separator + "Cursor"
 			else ->
 				home + File.separator + ".config" + File.separator + "Cursor"

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/core/FolderStorage.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/core/FolderStorage.kt
@@ -90,7 +90,7 @@ class FolderStorage(
         return Files.walk(dir).use { stream ->
             stream
                 .filter { it.isRegularFile() }
-                .map { jolliDir.relativize(it).toString() }
+                .map { jolliDir.relativize(it).toString().replace('\\', '/') }
                 .sorted()
                 .toList()
         }

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/core/MetadataManager.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/core/MetadataManager.kt
@@ -224,7 +224,7 @@ class MetadataManager(private val jolliDir: Path) {
                         try {
                             val content = java.nio.file.Files.readString(file, java.nio.charset.StandardCharsets.UTF_8)
                             val fp = FolderStorage.sha256(content)
-                            currentFiles[fp] = kbRoot.relativize(file).toString()
+                            currentFiles[fp] = kbRoot.relativize(file).toString().replace('\\', '/')
                         } catch (_: Exception) {}
                     }
             }

--- a/intellij/src/test/kotlin/ai/jolli/jollimemory/core/CursorSupportTest.kt
+++ b/intellij/src/test/kotlin/ai/jolli/jollimemory/core/CursorSupportTest.kt
@@ -19,15 +19,24 @@ import java.time.Instant
 class CursorSupportTest {
 
     private var originalHome: String? = null
+    private var originalCursorOverride: String? = null
 
     @BeforeEach
     fun setup() {
         originalHome = System.getProperty("user.home")
+        originalCursorOverride = System.getProperty("cursor.appdata.override")
     }
 
     @AfterEach
     fun teardown() {
         originalHome?.let { System.setProperty("user.home", it) }
+        // On Windows the production code reads %APPDATA% (env var); we redirect it via the
+        // `cursor.appdata.override` system property in helpers below. Clear it between tests.
+        if (originalCursorOverride != null) {
+            System.setProperty("cursor.appdata.override", originalCursorOverride!!)
+        } else {
+            System.clearProperty("cursor.appdata.override")
+        }
     }
 
     /** Returns the platform-correct Cursor user-data dir under the given home. */
@@ -35,7 +44,12 @@ class CursorSupportTest {
         val osName = System.getProperty("os.name").lowercase()
         return when {
             osName.contains("mac") -> File(home, "Library/Application Support/Cursor")
-            osName.contains("win") -> File(home, "AppData/Roaming/Cursor")
+            osName.contains("win") -> {
+                // On Windows the production code uses %APPDATA% (env var) which we cannot unset
+                // from Java; redirect it via the `cursor.appdata.override` system property hook.
+                System.setProperty("cursor.appdata.override", File(home, "AppData/Roaming").absolutePath)
+                File(home, "AppData/Roaming/Cursor")
+            }
             else -> File(home, ".config/Cursor")
         }
     }
@@ -112,7 +126,12 @@ class CursorSupportTest {
         // Use absolutePath (not canonicalPath) so the URI matches what callers pass to
         // discoverSessions; canonicalPath would resolve macOS's /var → /private/var
         // symlink and mismatch.
-        return "file://" + f.absolutePath
+        //
+        // Build the URI manually (not via File.toURI()) so we control the exact form:
+        // unix → "file:///abs/path", windows → "file:///C:/abs/path". Real Cursor writes
+        // its workspace.json URIs in this same form on every platform.
+        val abs = f.absolutePath.replace('\\', '/')
+        return if (abs.startsWith("/")) "file://$abs" else "file:///$abs"
     }
 
     @Nested
@@ -120,6 +139,10 @@ class CursorSupportTest {
         @Test
         fun `false when global DB does not exist`(@TempDir tempDir: File) {
             System.setProperty("user.home", tempDir.absolutePath)
+            // On Windows the production resolver uses %APPDATA% (which points at a real path
+            // on dev machines that may have Cursor installed). Redirect via the override so
+            // the resolver lands in the empty tempDir.
+            System.setProperty("cursor.appdata.override", File(tempDir, "AppData/Roaming").absolutePath)
             CursorSupport.isCursorInstalled() shouldBe false
         }
 

--- a/intellij/src/test/kotlin/ai/jolli/jollimemory/core/KBPathResolverTest.kt
+++ b/intellij/src/test/kotlin/ai/jolli/jollimemory/core/KBPathResolverTest.kt
@@ -49,7 +49,8 @@ class KBPathResolverTest {
         fun `uses custom path as parent with repoName appended`() {
             val custom = tempDir.resolve("custom-kb").toString()
             val result = KBPathResolver.resolve("myrepo", "https://github.com/user/myrepo.git", custom)
-            result.toString() shouldBe "$custom/myrepo"
+            // Compare via Path so the separator matches the platform (backslash on Windows).
+            result.toString() shouldBe Path.of(custom, "myrepo").toString()
         }
 
         @Test

--- a/intellij/src/test/kotlin/ai/jolli/jollimemory/hooks/GeminiAfterAgentHookTest.kt
+++ b/intellij/src/test/kotlin/ai/jolli/jollimemory/hooks/GeminiAfterAgentHookTest.kt
@@ -42,7 +42,10 @@ class GeminiAfterAgentHookTest {
 
     @Test
     fun `saves gemini session from valid stdin`() {
-        val json = """{"session_id":"gem-456","transcript_path":"/tmp/gemini.json","cwd":"${tempDir.absolutePath}"}"""
+        // Escape backslashes for JSON — tempDir.absolutePath on Windows contains \\ which
+        // would otherwise produce illegal JSON escape sequences (\U, \A, \L, ...).
+        val cwdJson = tempDir.absolutePath.replace("\\", "\\\\")
+        val json = """{"session_id":"gem-456","transcript_path":"/tmp/gemini.json","cwd":"$cwdJson"}"""
         every { readStdin() } returns json
 
         GeminiAfterAgentHook.run()

--- a/intellij/src/test/kotlin/ai/jolli/jollimemory/hooks/StopHookTest.kt
+++ b/intellij/src/test/kotlin/ai/jolli/jollimemory/hooks/StopHookTest.kt
@@ -35,7 +35,10 @@ class StopHookTest {
 
     @Test
     fun `saves session from valid stdin JSON`() {
-        val json = """{"session_id":"sess-123","transcript_path":"/tmp/transcript.jsonl","cwd":"${tempDir.absolutePath}"}"""
+        // Escape backslashes for JSON — tempDir.absolutePath on Windows contains \\ which
+        // would otherwise produce illegal JSON escape sequences (\U, \A, \L, ...).
+        val cwdJson = tempDir.absolutePath.replace("\\", "\\\\")
+        val json = """{"session_id":"sess-123","transcript_path":"/tmp/transcript.jsonl","cwd":"$cwdJson"}"""
         every { readStdin() } returns json
 
         StopHook.run()


### PR DESCRIPTION
## Summary

- **2 real Windows bugs fixed** in `core/FolderStorage.kt` and `core/MetadataManager.kt`: `Path.relativize().toString()` returned `summaries\a.json` on Windows, but the rest of the codebase keys storage by `summaries/a.json`. Result: silent manifest drift and missed lookups (sidebar listings, search, cross-commit memory association, reconcile-after-move). Fix is `.replace('\', '/')` after relativize — no-op on Linux/macOS.
- **1 testability hook added** in `core/CursorSupport.kt`: a `cursor.appdata.override` system property that takes precedence over `%APPDATA%`. Java cannot unset env vars, so the Cursor test suite needed a way to redirect away from a dev machine's real Cursor install. The property is unset in production and falls through to the existing chain, so real-user behavior is unchanged.
- **12 of 14 Windows-only test failures fixed**: 570/572 pass on Windows now, up from 558/572 on `main`. Linux/macOS unaffected.

## What was wrong on Windows (categorized)

| Category | Count | Where |
|---|---|---|
| Real production bugs | 2 | `FolderStorage.listFiles`, `MetadataManager.reconcile` |
| Test-only (Unix assumptions in test code) | 10 | `CursorSupportTest` (URI helper + APPDATA), `Stop/GeminiAfterAgentHookTest` (JSON escaping), `KBPathResolverTest` (hardcoded `/` in assert) |
| Deferred — test infra (`JBUIScale "Must be precomputed"` from `ThreadLeakTracker.afterEach`) | 2 | `HookInstallerTest`, `JolliAuthServiceTest` |

The 2 deferred failures are not test-body bugs — the assertions pass and the test framework's afterEach trips on UI-scale precompute. Fixing them needs a base test class with `JBUIScale.preload()`, which is a separate concern.

## Files changed

**Production (3 files, 4 lines effective):**
- `intellij/src/main/kotlin/.../core/FolderStorage.kt` — normalize separator in `listFiles`
- `intellij/src/main/kotlin/.../core/MetadataManager.kt` — normalize separator in fingerprint map key in `reconcile`
- `intellij/src/main/kotlin/.../core/CursorSupport.kt` — add `cursor.appdata.override` system-property hook on Windows path

**Tests (4 files):**
- `CursorSupportTest.kt` — fix `fileUri` helper to emit standard `file:///C:/...` URIs; wire `cursor.appdata.override` via `cursorUserDataDir` helper and BeforeEach/AfterEach; set override in the one test that doesn't use a helper
- `GeminiAfterAgentHookTest.kt` & `StopHookTest.kt` — JSON-escape backslashes in `tempDir.absolutePath` before embedding in test JSON
- `KBPathResolverTest.kt` — compare via `Path.of(...).toString()` instead of hardcoded `/`

## Test plan

- [x] `gradlew test -x instrumentCode -x instrumentTestCode` on Windows: 570/572 pass (was 558/572 on `main`); the 2 remaining failures are the explicitly deferred `JBUIScale`/`ThreadLeakTracker` test-infra issues
- [ ] CI on Linux: no regressions expected (Linux paths never contain `\`, the new system property is unset)
- [ ] CI on macOS: same as Linux

## Notes

- Independent of `fix/intellij-internal-api` — no file overlap, no conflict, either branch can merge first.
- The `core/CursorSupport.kt` change is a small "testability hook" in production code. The alternative would be `@DisabledOnOs(OS.WINDOWS)` on the affected tests, but that loses Windows coverage entirely; or reflection-based env-var override, which is fragile across JDKs. The property hook is the cleanest of the three.