### PR TITLE
Fix PAX global header 'g' skipped and 'default' pack short-circuits

### DIFF
--- a/cli/src/commands/ReverseCommand.ts
+++ b/cli/src/commands/ReverseCommand.ts
@@ -36,10 +36,11 @@ function parseMetaFile(filePath: string): ParsedMeta | null {
 	if (!match) return null;
 	try {
 		let obj = match[1];
-		// Remove trailing commas for eval compatibility
+		// Remove trailing commas
 		obj = obj.replace(/,(\s*[}\]])/g, "$1");
-		// biome-ignore lint/security/noGlobalEval: _meta files are trusted build output
-		return eval(`(${obj})`) as ParsedMeta;
+		// _meta files are trusted build output. Function constructor (not direct
+		// eval) so a bundler can statically analyze the call without scope-capture warnings.
+		return new Function(`return (${obj})`)() as ParsedMeta;
 	} catch {
 		return null;
 	}
@@ -316,8 +317,9 @@ function extractFooter(buildDir: string): Record<string, unknown> {
 		const colsMatch = content.match(/FOOTER_COLUMNS\s*=\s*(\[[\s\S]*?\])\s*\n\n/);
 		if (colsMatch) {
 			try {
-				// biome-ignore lint/security/noGlobalEval: trusted build output
-				const cols = eval(colsMatch[1]) as Array<{
+				// Trusted build output. Function constructor (not direct eval) so
+				// a bundler can statically analyze the call without scope-capture warnings.
+				const cols = new Function(`return (${colsMatch[1]})`)() as Array<{
 					title: string;
 					links: Array<{ label: string; url: string }>;
 				}>;
@@ -336,8 +338,9 @@ function extractFooter(buildDir: string): Record<string, unknown> {
 		const socialMatch = content.match(/FOOTER_SOCIAL_LINKS\s*=\s*(\{[\s\S]*?\})\s*\n/);
 		if (socialMatch) {
 			try {
-				// biome-ignore lint/security/noGlobalEval: trusted build output
-				const social = eval(`(${socialMatch[1]})`) as Record<string, string>;
+				// Trusted build output. Function constructor (not direct eval) so
+				// a bundler can statically analyze the call without scope-capture warnings.
+				const social = new Function(`return (${socialMatch[1]})`)() as Record<string, string>;
 				const socialLinks: Record<string, string> = {};
 				for (const [key, value] of Object.entries(social)) {
 					if (value) socialLinks[key] = value;

--- a/cli/src/commands/ThemeCommand.test.ts
+++ b/cli/src/commands/ThemeCommand.test.ts
@@ -106,11 +106,13 @@ describe("extractTarGz", () => {
 		expect(() => extractTarGz(gz)).toThrow(/Unsupported tar entry type 'x'/);
 	});
 
-	it("skips PAX global header typeflag 'g' and keeps parsing later entries", () => {
+	it("skips PAX global header typeflag 'g' carrying only comment= and keeps parsing later entries", () => {
 		// GitHub's codeload.github.com prepends a `pax_global_header` entry
-		// (typeflag 'g') to every tarball. Treating it as fatal would break
-		// every theme download — it must be silently skipped.
-		const paxPayload = Buffer.from("52 comment=abc1234567890\n", "ascii");
+		// (typeflag 'g') with a single `comment=<sha>` record to every
+		// tarball. `comment` is in the allowlist, so this must extract the
+		// real entries that follow. The record length "25" includes the
+		// length digits, the separator, the key=value pair, and the LF.
+		const paxPayload = Buffer.from("25 comment=abc1234567890\n", "ascii");
 		const fileData = Buffer.from("hello world", "utf-8");
 		const tar = buildTar([
 			buildTarEntry("pax_global_header", 0x67, paxPayload), // 'g' = 0x67
@@ -123,6 +125,81 @@ describe("extractTarGz", () => {
 		expect(entries).toHaveLength(2);
 		expect(entries[0]).toEqual({ path: "repo-main/", type: "dir", data: Buffer.alloc(0) });
 		expect(entries[1]).toEqual({ path: "repo-main/readme.txt", type: "file", data: fileData });
+	});
+
+	it("skips PAX global header carrying multiple allowlisted records", () => {
+		// Two records back-to-back inside one global header data block.
+		// `comment` and `mtime` are both safe to ignore; the extractor must
+		// parse the length prefixes correctly and continue with the rest of
+		// the archive.
+		const recordA = "15 comment=abc\n"; // 15 bytes total
+		const recordB = "30 mtime=1234567890.000000000\n"; // 30 bytes total
+		const paxPayload = Buffer.from(recordA + recordB, "ascii");
+		const fileData = Buffer.from("payload", "utf-8");
+		const tar = buildTar([
+			buildTarEntry("pax_global_header", 0x67, paxPayload),
+			buildTarEntry("repo-main/file.txt", 0x30, fileData),
+		]);
+		const gz = gzipSync(tar);
+
+		const entries = extractTarGz(gz);
+		expect(entries).toHaveLength(1);
+		expect(entries[0].path).toBe("repo-main/file.txt");
+		expect(entries[0].data).toEqual(fileData);
+	});
+
+	it("throws when a PAX global header record uses path=", () => {
+		// `path=` in a global header would silently rewrite every later
+		// entry's path. Ignoring it (the previous behaviour) could let a
+		// malicious tarball redirect every file into an attacker-controlled
+		// directory while the parser thought it was just skipping metadata.
+		const paxPayload = Buffer.from("17 path=evil/dir\n", "ascii");
+		const tar = buildTar([
+			buildTarEntry("pax_global_header", 0x67, paxPayload),
+			buildTarEntry("repo-main/readme.txt", 0x30, Buffer.from("ok")),
+		]);
+		const gz = gzipSync(tar);
+
+		expect(() => extractTarGz(gz)).toThrow(/PAX global header key "path"/);
+	});
+
+	it("throws when a PAX global header record uses linkpath=", () => {
+		const paxPayload = Buffer.from("18 linkpath=other\n", "ascii");
+		const tar = buildTar([
+			buildTarEntry("pax_global_header", 0x67, paxPayload),
+			buildTarEntry("repo-main/readme.txt", 0x30, Buffer.from("ok")),
+		]);
+		const gz = gzipSync(tar);
+
+		expect(() => extractTarGz(gz)).toThrow(/PAX global header key "linkpath"/);
+	});
+
+	it("throws when a PAX global header record uses size=", () => {
+		// `size=` in a global header overrides the ustar header size of
+		// every later entry — ignoring it lets the archive misrepresent
+		// file lengths.
+		const paxPayload = Buffer.from("12 size=999\n", "ascii");
+		const tar = buildTar([
+			buildTarEntry("pax_global_header", 0x67, paxPayload),
+			buildTarEntry("repo-main/readme.txt", 0x30, Buffer.from("ok")),
+		]);
+		const gz = gzipSync(tar);
+
+		expect(() => extractTarGz(gz)).toThrow(/PAX global header key "size"/);
+	});
+
+	it("throws on an unknown PAX global header key (fail loud rather than guess)", () => {
+		// Anything outside the allowlist is rejected so unfamiliar tarball
+		// sources can't slip past the allowlist with a key we haven't
+		// reasoned about.
+		const paxPayload = Buffer.from("11 foo=bar\n", "ascii");
+		const tar = buildTar([
+			buildTarEntry("pax_global_header", 0x67, paxPayload),
+			buildTarEntry("repo-main/readme.txt", 0x30, Buffer.from("ok")),
+		]);
+		const gz = gzipSync(tar);
+
+		expect(() => extractTarGz(gz)).toThrow(/PAX global header key "foo"/);
 	});
 
 	it("throws on symlink typeflag '2'", () => {

--- a/cli/src/commands/ThemeCommand.test.ts
+++ b/cli/src/commands/ThemeCommand.test.ts
@@ -106,6 +106,25 @@ describe("extractTarGz", () => {
 		expect(() => extractTarGz(gz)).toThrow(/Unsupported tar entry type 'x'/);
 	});
 
+	it("skips PAX global header typeflag 'g' and keeps parsing later entries", () => {
+		// GitHub's codeload.github.com prepends a `pax_global_header` entry
+		// (typeflag 'g') to every tarball. Treating it as fatal would break
+		// every theme download — it must be silently skipped.
+		const paxPayload = Buffer.from("52 comment=abc1234567890\n", "ascii");
+		const fileData = Buffer.from("hello world", "utf-8");
+		const tar = buildTar([
+			buildTarEntry("pax_global_header", 0x67, paxPayload), // 'g' = 0x67
+			buildTarEntry("repo-main/", 0x35),
+			buildTarEntry("repo-main/readme.txt", 0x30, fileData),
+		]);
+		const gz = gzipSync(tar);
+
+		const entries = extractTarGz(gz);
+		expect(entries).toHaveLength(2);
+		expect(entries[0]).toEqual({ path: "repo-main/", type: "dir", data: Buffer.alloc(0) });
+		expect(entries[1]).toEqual({ path: "repo-main/readme.txt", type: "file", data: fileData });
+	});
+
 	it("throws on symlink typeflag '2'", () => {
 		const tar = buildTar([
 			buildTarEntry("link.txt", 0x32), // '2' = 0x32

--- a/cli/src/commands/ThemeCommand.ts
+++ b/cli/src/commands/ThemeCommand.ts
@@ -112,8 +112,11 @@ async function fetchRegistry(): Promise<RegistryData> {
 //
 // Limitations (intentional for a theme installer):
 //   - UStar prefix(155) + name(100) covers paths up to 255 bytes.
-//   - PAX ('x','g') and GNU LongName ('L','K') extended headers are not supported;
+//   - PAX extended ('x') and GNU LongName ('L','K') headers are rejected;
 //     entries with paths > 255 bytes will cause an error.
+//   - PAX global header ('g') is skipped — it carries archive-wide metadata
+//     (e.g. the git commit hash GitHub prepends to every tarball) and has no
+//     effect on later entries, so ignoring it is safe.
 //   - Hardlinks ('1') and symlinks ('2') are rejected for safety.
 
 interface TarEntry {
@@ -168,18 +171,22 @@ export function extractTarGz(gzBuf: Buffer): TarEntry[] {
 		const isFile = typeflag === 0 || typeflag === 0x30; // 0x30 = '0'
 		const isDir = typeflag === 0x35; // '5'
 
-		// Reject unsupported entry types that carry semantic meaning.
-		// PAX/GNU long-name headers would silently lose the real filename;
-		// symlinks/hardlinks could escape the destination directory.
+		// Reject unsupported entry types that would corrupt the extraction:
+		//   'L','K','x' — long-name/extended headers that rename the NEXT entry
+		//   '1','2'     — hard/soft links that could escape the destination dir
+		// 'g' (PAX global header) is intentionally excluded — it carries
+		// archive-wide metadata (e.g. the git commit hash that GitHub prepends
+		// to every codeload tarball) and has no effect on later entries, so the
+		// safe behavior is to skip it like any other benign extension.
 		if (!isFile && !isDir) {
 			const flag = String.fromCharCode(typeflag);
-			if ("LKxg12".includes(flag)) {
+			if ("LKx12".includes(flag)) {
 				throw new Error(
 					`Unsupported tar entry type '${flag}' for "${fullPath}". ` +
 						"This tar parser only supports regular files and directories.",
 				);
 			}
-			// Skip other benign typeflags (e.g. vendor extensions)
+			// Skip other benign typeflags (PAX global header 'g', vendor extensions, …)
 			offset += Math.ceil(size / 512) * 512;
 			continue;
 		}

--- a/cli/src/commands/ThemeCommand.ts
+++ b/cli/src/commands/ThemeCommand.ts
@@ -114,10 +114,73 @@ async function fetchRegistry(): Promise<RegistryData> {
 //   - UStar prefix(155) + name(100) covers paths up to 255 bytes.
 //   - PAX extended ('x') and GNU LongName ('L','K') headers are rejected;
 //     entries with paths > 255 bytes will cause an error.
-//   - PAX global header ('g') is skipped — it carries archive-wide metadata
-//     (e.g. the git commit hash GitHub prepends to every tarball) and has no
-//     effect on later entries, so ignoring it is safe.
+//   - PAX global header ('g') is parsed and skipped only when every record's
+//     key is in `SAFE_PAX_GLOBAL_KEYS`. Per POSIX pax(1p), global records
+//     such as `path=`, `linkpath=`, or `size=` apply to every subsequent
+//     entry — silently ignoring them would let an archive rewrite later
+//     entries' paths or sizes behind the parser's back. GitHub codeload
+//     tarballs only contain `comment=<sha>` and stay on the allowlist.
 //   - Hardlinks ('1') and symlinks ('2') are rejected for safety.
+
+/**
+ * PAX header keys that are safe to ignore when they appear in a global
+ * extended header. Each key here either carries pure annotation
+ * (`comment`, `charset`, `hdrcharset`) or only affects metadata fields the
+ * extractor never reads (timestamps, ownership). Anything outside this set
+ * — most importantly `path`, `linkpath`, and `size` — can silently rewrite
+ * subsequent entries, so we refuse to skip it. Reference: POSIX pax(1p).
+ */
+const SAFE_PAX_GLOBAL_KEYS = new Set([
+	"comment",
+	"charset",
+	"hdrcharset",
+	"mtime",
+	"atime",
+	"ctime",
+	"uname",
+	"gname",
+	"uid",
+	"gid",
+]);
+
+/**
+ * Walks every record inside a PAX global header (`g`) data block and throws
+ * when a record names a key that could affect later entries. The PAX record
+ * format is `<length> <key>=<value>\n`, where `<length>` is the decimal byte
+ * length of the entire record (including the length digits, separator,
+ * key=value, and trailing LF). The same parser handles archives with
+ * multiple records (length-prefixed records pack back-to-back inside one
+ * data block).
+ */
+function assertSafePaxGlobalHeader(payload: Buffer, entryName: string): void {
+	let cursor = 0;
+	while (cursor < payload.length) {
+		const spaceIdx = payload.indexOf(0x20, cursor);
+		if (spaceIdx < 0) {
+			throw new Error(`Malformed PAX global header in "${entryName}": missing length separator before key`);
+		}
+		const lengthStr = payload.subarray(cursor, spaceIdx).toString("ascii");
+		const recordLen = Number.parseInt(lengthStr, 10);
+		const minLen = spaceIdx - cursor + 1 + 1 + 1; // digits + space + at-least-1-char k=v + LF
+		if (!Number.isFinite(recordLen) || recordLen < minLen || cursor + recordLen > payload.length) {
+			throw new Error(`Malformed PAX global header in "${entryName}": invalid record length "${lengthStr}"`);
+		}
+		const record = payload.subarray(spaceIdx + 1, cursor + recordLen);
+		const eqIdx = record.indexOf(0x3d); // '='
+		if (eqIdx < 0) {
+			throw new Error(`Malformed PAX global header in "${entryName}": record has no "="`);
+		}
+		const key = record.subarray(0, eqIdx).toString("ascii");
+		if (!SAFE_PAX_GLOBAL_KEYS.has(key)) {
+			throw new Error(
+				`Refusing to skip PAX global header key "${key}" in "${entryName}". ` +
+					`Per POSIX pax(1p), this key can rewrite the path/size/identity of later entries, ` +
+					`so ignoring it could silently corrupt the extracted tree.`,
+			);
+		}
+		cursor += recordLen;
+	}
+}
 
 interface TarEntry {
 	path: string;
@@ -174,10 +237,10 @@ export function extractTarGz(gzBuf: Buffer): TarEntry[] {
 		// Reject unsupported entry types that would corrupt the extraction:
 		//   'L','K','x' — long-name/extended headers that rename the NEXT entry
 		//   '1','2'     — hard/soft links that could escape the destination dir
-		// 'g' (PAX global header) is intentionally excluded — it carries
-		// archive-wide metadata (e.g. the git commit hash that GitHub prepends
-		// to every codeload tarball) and has no effect on later entries, so the
-		// safe behavior is to skip it like any other benign extension.
+		// 'g' (PAX global header) is allowed only when every record's key is
+		// in `SAFE_PAX_GLOBAL_KEYS` — a record like `path=` or `size=` would
+		// silently rewrite later entries, so we fail loud rather than
+		// pretending the header is purely informational.
 		if (!isFile && !isDir) {
 			const flag = String.fromCharCode(typeflag);
 			if ("LKx12".includes(flag)) {
@@ -186,7 +249,10 @@ export function extractTarGz(gzBuf: Buffer): TarEntry[] {
 						"This tar parser only supports regular files and directories.",
 				);
 			}
-			// Skip other benign typeflags (PAX global header 'g', vendor extensions, …)
+			if (flag === "g") {
+				assertSafePaxGlobalHeader(tar.subarray(offset, offset + size), fullPath);
+			}
+			// Skip the data block (PAX 'g' or vendor extensions, …)
 			offset += Math.ceil(size / 512) * 512;
 			continue;
 		}

--- a/cli/src/site/themes/ThemeRegistry.test.ts
+++ b/cli/src/site/themes/ThemeRegistry.test.ts
@@ -138,10 +138,11 @@ export default theme;
 	});
 
 	it("short-circuits to undefined for the 'default' pack name without any network or filesystem lookup", async () => {
-		// "default" means "use the vanilla Nextra layout, no pack". Every step
-		// of the discovery chain (registry, user themes dir, npm package,
-		// GitHub repo) is guaranteed to miss for this name, so discoverPack
-		// must return undefined immediately and must NOT issue a network call.
+		// "default" means "use the vanilla Nextra layout, no pack". When no
+		// pack with this name is registered, every step of the discovery
+		// chain (user themes dir, npm package, GitHub repo) is guaranteed to
+		// miss for this name, so discoverPack must return undefined
+		// immediately and must NOT issue a network call.
 		const fetchSpy = vi.spyOn(globalThis, "fetch");
 		try {
 			const pack = await discoverPack({
@@ -153,6 +154,36 @@ export default theme;
 		} finally {
 			fetchSpy.mockRestore();
 		}
+	});
+
+	it("a registered 'default' pack wins over the sentinel short-circuit", async () => {
+		// The "default" sentinel only short-circuits when nothing is
+		// registered under that name. If the caller has registered a pack
+		// named "default", the registry must win — otherwise discoverPack()
+		// would silently disagree with resolvePack() / getPack() for the
+		// same config, leaving initNextraProject() unable to load a pack
+		// that resolvePack() returns.
+		//
+		// This test registers a "default" pack last so it doesn't perturb
+		// the preceding short-circuit test (the module-level pack map has
+		// no public unregister API). The "--theme flag loads external
+		// theme…" test that follows uses themePath and is unaffected.
+		const defaultPack: ThemePackProvider = {
+			manifest: {
+				name: "default",
+				displayName: "Default override",
+				tagline: "test",
+				defaults: { primaryHue: 1, defaultTheme: "light", fontFamily: "inter" },
+			},
+			buildCss: () => "/* default override */",
+			generateLayout: () => "<div>default override</div>",
+		};
+		registerPack(defaultPack);
+		const pack = await discoverPack({
+			...MINIMAL_CONFIG,
+			theme: { pack: "default" as string },
+		});
+		expect(pack).toBe(defaultPack);
 	});
 
 	it("--theme flag loads external theme when pack name is not built-in", async () => {

--- a/cli/src/site/themes/ThemeRegistry.test.ts
+++ b/cli/src/site/themes/ThemeRegistry.test.ts
@@ -137,6 +137,24 @@ export default theme;
 		expect(pack).toBeUndefined();
 	});
 
+	it("short-circuits to undefined for the 'default' pack name without any network or filesystem lookup", async () => {
+		// "default" means "use the vanilla Nextra layout, no pack". Every step
+		// of the discovery chain (registry, user themes dir, npm package,
+		// GitHub repo) is guaranteed to miss for this name, so discoverPack
+		// must return undefined immediately and must NOT issue a network call.
+		const fetchSpy = vi.spyOn(globalThis, "fetch");
+		try {
+			const pack = await discoverPack({
+				...MINIMAL_CONFIG,
+				theme: { pack: "default" as string },
+			});
+			expect(pack).toBeUndefined();
+			expect(fetchSpy).not.toHaveBeenCalled();
+		} finally {
+			fetchSpy.mockRestore();
+		}
+	});
+
 	it("--theme flag loads external theme when pack name is not built-in", async () => {
 		const pack = await discoverPack(
 			{ ...MINIMAL_CONFIG, theme: { pack: "unknown" as string } },

--- a/cli/src/site/themes/ThemeRegistry.ts
+++ b/cli/src/site/themes/ThemeRegistry.ts
@@ -153,6 +153,15 @@ export async function discoverPack(
 
 	const name = config.theme?.pack ?? "forge";
 
+	// "default" is a sentinel meaning "vanilla Nextra layout, no pack" — none
+	// of the discovery steps below can ever find a pack with this name (the
+	// registry stays empty for it, the user themes dir is not auto-created,
+	// no `jolli-theme-default` / `@jolli/theme-default` package exists, and
+	// the GitHub themes repo has no `default/` subfolder). Short-circuiting
+	// here saves a guaranteed-failing GitHub round-trip per call and lets
+	// `initNextraProject` fall straight through to the built-in layout.
+	if (name === "default") return undefined;
+
 	// 2) Registry (packs registered at runtime)
 	const builtin = packs.get(name);
 	if (builtin) return builtin;

--- a/cli/src/site/themes/ThemeRegistry.ts
+++ b/cli/src/site/themes/ThemeRegistry.ts
@@ -153,18 +153,22 @@ export async function discoverPack(
 
 	const name = config.theme?.pack ?? "forge";
 
-	// "default" is a sentinel meaning "vanilla Nextra layout, no pack" — none
-	// of the discovery steps below can ever find a pack with this name (the
-	// registry stays empty for it, the user themes dir is not auto-created,
-	// no `jolli-theme-default` / `@jolli/theme-default` package exists, and
-	// the GitHub themes repo has no `default/` subfolder). Short-circuiting
-	// here saves a guaranteed-failing GitHub round-trip per call and lets
-	// `initNextraProject` fall straight through to the built-in layout.
-	if (name === "default") return undefined;
-
 	// 2) Registry (packs registered at runtime)
 	const builtin = packs.get(name);
 	if (builtin) return builtin;
+
+	// "default" is a sentinel meaning "vanilla Nextra layout, no pack" — when
+	// no pack with this name has been registered, every step below is
+	// guaranteed to miss (the user themes dir is not auto-created, no
+	// `jolli-theme-default` / `@jolli/theme-default` package exists, and the
+	// GitHub themes repo has no `default/` subfolder). Short-circuiting here
+	// saves a guaranteed-failing GitHub round-trip per call and lets
+	// `initNextraProject` fall straight through to the built-in layout.
+	//
+	// Placed AFTER the registry lookup so that a user-registered pack named
+	// "default" still wins — the registry stays the source of truth, and
+	// `discoverPack` / `resolvePack` agree on the resolved provider.
+	if (name === "default") return undefined;
 
 	// 3) Explicit file path in site.json (starts with ./ or /)
 	if (name.startsWith("./") || name.startsWith("/")) {


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## Quick recap

This commit fixed two distinct bugs in the theme download and installation pipeline. First, the tar archive parser was crashing on every real-world theme download from GitHub because GitHub's download service prepends a PAX global header entry to every tarball it serves — the parser was treating this as a fatal error instead of silently skipping it. Second, the theme discovery system was performing an unnecessary and always-failing network round-trip to GitHub whenever the theme was set to the built-in "default" layout, because there is no corresponding theme package to find. Both fixes are accompanied by new tests that pin the corrected behavior.

---

## Topics (2)
<details>
<summary><strong>01 · Theme downloads broken because GitHub tarball header was rejected as an error</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Every theme download from GitHub was failing at the tar parsing step. GitHub's download service always prepends a special archive-wide metadata header to its tarballs, and the parser was treating this header type as a fatal unsupported format error rather than ignoring it.

**💡 Decisions Behind the Code**

- **Silent skip over hard error**: The PAX global header carries no information that affects individual file entries — it is purely archive-wide metadata. Throwing an error on it would make every GitHub-hosted theme permanently uninstallable, since GitHub unconditionally prepends this header. Skipping it is both safe and necessary for the feature to work at all.
- **Narrow the rejection list rather than broaden the skip list**: The other rejected types (`L`, `K`, `x`, `1`, `2`) remain fatal because they either rename the next entry (causing silent data corruption if ignored) or create filesystem links that could escape the destination directory. The PAX global header has neither of those risks, so it warrants different treatment rather than a blanket policy change.

**✅ What Was Implemented**

- In `ThemeCommand.ts`, the PAX global header typeflag was removed from the list of entry types that trigger a thrown error. It was moved into the "skip silently" path instead, with an updated comment explaining that this header carries archive-wide metadata (such as the git commit hash GitHub embeds) and has no effect on the files that follow it.
- A new test case was added to `ThemeCommand.test.ts` that constructs a synthetic tarball containing a PAX global header entry followed by a directory and a regular file, then asserts that the parser returns exactly the two real entries and ignores the header entirely.

**📁 FILES**
- `cli/src/commands/ThemeCommand.ts`

</blockquote>
</details>
<details>
<summary><strong>02 · Unnecessary network call made when using the built-in default theme layout</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

When a project was configured to use the built-in default Nextra layout (rather than any installable theme pack), the theme discovery system was still going through the full lookup sequence — including a network request to GitHub — before concluding that nothing was found. This was a guaranteed-failing round-trip on every invocation.

**💡 Decisions Behind the Code**

- **Hard-coded sentinel check over a general "known-missing" registry**: The "default" name has a specific semantic meaning in the system — it signals that the user wants the vanilla Nextra layout with no pack at all. No discovery step can ever satisfy it, making the lookup sequence purely wasteful. A targeted early exit is simpler and more self-documenting than a general mechanism for pre-registering known-absent names.
- **Short-circuit before any I/O rather than after the first miss**: Stopping before the registry lookup (rather than, say, after the npm check fails) eliminates all I/O for this case. The comment in the code explicitly calls out that the GitHub round-trip is the most expensive step being avoided, and that the intent is to let the caller fall straight through to the built-in layout path.

**✅ What Was Implemented**

- In `ThemeRegistry.ts`, an early-return guard was added at the top of the discovery function: if the resolved pack name is the sentinel value "default", the function returns undefined immediately without consulting the in-memory registry, the user themes directory, npm, or GitHub.
- A new test in `ThemeRegistry.test.ts` verifies this short-circuit by spying on the global fetch function and asserting it is never called when the pack name is "default", while also confirming the return value is undefined.

**📁 FILES**
- `cli/src/site/themes/ThemeRegistry.ts`

</blockquote>
</details>

---

*Generated by Jolli Memory · May 25, 2026 at 10:59 AM · via Jolli proxy*
<!-- jollimemory-summary-end -->