### PR TITLE
Migrate summaries schema to v5 with stable transcript IDs

### DIFF
--- a/cli/src/Types.ts
+++ b/cli/src/Types.ts
@@ -1018,12 +1018,6 @@ export interface StatusInfo {
 	 * run on next opportunity (worker startup or explicit `jolli migrate`).
 	 */
 	readonly schemaV5?: "in-progress" | "completed" | "failed";
-	/**
-	 * True when migration completed but no pre-v5 data was present — i.e. a
-	 * fresh install. Used to choose between "complete (v5)" and "not needed"
-	 * wording in the status display.
-	 */
-	readonly schemaV5Fresh?: boolean;
 }
 
 /**

--- a/cli/src/Types.ts
+++ b/cli/src/Types.ts
@@ -253,6 +253,31 @@ export type CommitSource = "cli" | "plugin";
 export type SummaryErrorKind = "llm-failed";
 
 /**
+ * Schema version stamped on newly written CommitSummary roots.
+ *
+ * Bumped when the schema introduces a breaking change that requires a
+ * migration step (v3→v4 introduced unified-Hoist root topics; v4→v5 introduced
+ * the stable `transcripts: string[]` ID array). Future v6 etc. follow the
+ * same pattern: define a new migration module under `core/SchemaV{N}Migration`,
+ * then bump this constant — every write path automatically stamps the new
+ * version.
+ *
+ * Use this constant when WRITING a new summary root (executePipeline,
+ * buildHoistedAmendRoot, migrateOneToOne, mergeManyToOne, ...).
+ *
+ * Do NOT use this constant for:
+ *   - Migration target versions — e.g. `SchemaV5Migration` always targets 5,
+ *     not "whatever the latest is". The number is part of the migration's
+ *     identity, not a moving target.
+ *   - Read-time format thresholds — e.g. `isUnifiedHoistFormat` returns
+ *     `version >= 4` (the version that introduced unified Hoist), and that
+ *     "4" stays 4 regardless of how high `CURRENT_SCHEMA_VERSION` climbs.
+ *   - Test fixtures — they deliberately pin specific versions to exercise
+ *     v3/v4/v5 read paths.
+ */
+export const CURRENT_SCHEMA_VERSION = 5;
+
+/**
  * Complete summary for a single git commit (v3 tree format).
  *
  * Tree structure: each node may have its own topics/stats/llm data, plus optional
@@ -369,6 +394,23 @@ export interface CommitSummary {
 	readonly notes?: ReadonlyArray<NoteReference>;
 	/** Linear issues referenced via MCP and associated with this commit */
 	readonly linearIssues?: ReadonlyArray<LinearIssueCommitRef>;
+	/**
+	 * v5 schema: stable transcript IDs referenced by this summary. Each ID
+	 * corresponds to a file at `transcripts/{id}.json` on the orphan branch.
+	 *
+	 * Decoupled from commit hash so history rewrites (rebase / amend / squash /
+	 * cherry-pick) move references around without touching transcript files.
+	 *
+	 * For freshly written v5 data: each ID is a UUID v4 (from `generateTranscriptId`).
+	 * For data migrated from v3/v4: legacy IDs reuse the original commit hash
+	 * string verbatim (no file rename during migration) — both ID formats are
+	 * opaque to readers.
+	 *
+	 * Absent on pre-v5 data (the read path falls back to `collectAllTranscriptHashes`
+	 * via the `getTranscriptIds` compatibility helper). Optional in the type so
+	 * Release N keeps reading legacy data; Release N+M will make it required.
+	 */
+	readonly transcripts?: ReadonlyArray<string>;
 }
 
 /** A single E2E test scenario for one feature or bug fix */
@@ -969,6 +1011,19 @@ export interface StatusInfo {
 	readonly copilotChatDetected?: boolean;
 	/** Copilot Chat scan failed with a real (non-ENOENT) error: parse / fs / schema. */
 	readonly copilotChatScanError?: CopilotChatScanError;
+	/**
+	 * v5 schema migration state — surfaced in `jolli status` and the VSCode
+	 * Hooks tooltip so users can see whether their on-disk data has been
+	 * migrated. Absent state is the implicit "pending" — the migration will
+	 * run on next opportunity (worker startup or explicit `jolli migrate`).
+	 */
+	readonly schemaV5?: "in-progress" | "completed" | "failed";
+	/**
+	 * True when migration completed but no pre-v5 data was present — i.e. a
+	 * fresh install. Used to choose between "complete (v5)" and "not needed"
+	 * wording in the status display.
+	 */
+	readonly schemaV5Fresh?: boolean;
 }
 
 /**

--- a/cli/src/commands/CleanCommand.ts
+++ b/cli/src/commands/CleanCommand.ts
@@ -9,14 +9,20 @@
  * 2. Stale queue entries — `.jolli/jollimemory/git-op-queue/*.json` older than 7 days.
  * 3. Stale squash-pending.json — older than 48h.
  *
- * NOTE: orphan `summaries/{childHash}.json` and `transcripts/{childHash}.json`
+ * NOTE: orphan `summaries/{childHash}.json` and `transcripts/{transcriptId}.json`
  * files are intentionally NOT deleted. Under the unified Hoist model (schema
- * v4), `stripFunctionalMetadata` removes topics + recap from embedded children
+ * v4+), `stripFunctionalMetadata` removes topics + recap from embedded children
  * so the independent `summaries/{childHash}.json` file is the ONLY surviving
- * source of the child's original topics/recap. Transcripts have always been
- * by-hash artifacts that the display layer reads via
- * `collectAllTranscriptHashes`. Both files are tiny (KB) so disk savings would
- * be negligible; the audit / read-by-hash benefit of keeping them dominates.
+ * source of the child's original topics/recap.
+ *
+ * Transcripts have stable opaque IDs under v5 — either legacy commit-hash
+ * filenames preserved through migration, or fresh UUIDs from new writes —
+ * referenced from `summary.transcripts: string[]`. Display + edit/delete
+ * paths funnel through `getTranscriptIds(summary)`, so a transcript file is
+ * "live" as long as ANY summary on the orphan branch lists its ID. A future
+ * GC step could prune transcripts not referenced by any summary; today we
+ * keep them all because the files are tiny (KB) and the audit benefit of
+ * keeping them dominates.
  */
 
 import type { Command } from "commander";

--- a/cli/src/commands/MigrateCommand.ts
+++ b/cli/src/commands/MigrateCommand.ts
@@ -1,11 +1,17 @@
 /**
- * MigrateCommand — Migrate summaries to v3 format.
+ * MigrateCommand — Migrate summaries to the latest schema.
  *
- * Provides the `migrate` CLI command that converts orphan branch data
- * from v1 to v3 tree format and upgrades the index to v3 flat format.
+ * Provides the `migrate` CLI command that:
+ *   1. Converts v1 orphan branch data to v3 tree format
+ *   2. Upgrades the index to v3 flat format
+ *   3. Runs the unified v3 → v4 → v5 schema migration
+ *
+ * Steps 1 and 2 are no-ops after the first run; step 3 reads its own
+ * state file on the orphan branch and is idempotent across runs.
  */
 
 import type { Command } from "commander";
+import { migrateSchemaToV5 } from "../core/SchemaV5Migration.js";
 import { hasMigrationMeta, migrateV1toV3, writeMigrationMeta } from "../core/SummaryMigration.js";
 import { indexNeedsMigration, migrateIndexToV3 } from "../core/SummaryStore.js";
 import { createLogger, setLogDir } from "../Logger.js";
@@ -67,6 +73,34 @@ export function registerMigrateCommand(program: Command): void {
 				if (indexMigrated === 0 && indexSkipped === 0) {
 					console.log("  No index entries found.");
 				}
+			}
+
+			// Step 3: unified v3 → v4 → v5 schema migration. Idempotent; reads
+			// its own `schema-v5-migration.json` state file on the orphan branch
+			// to skip on subsequent runs.
+			console.log("\n  Step 3: Migrating schema to v5 (transcripts stable IDs + lossless hoist)...");
+			try {
+				const v5Result = await migrateSchemaToV5(options.cwd);
+				if (v5Result.alreadyDone) {
+					console.log(`  Already migrated (${v5Result.migrated} summaries previously upgraded).`);
+				} else if (v5Result.fresh) {
+					// `migrateSchemaToV5` deliberately does NOT write a state file
+					// when the orphan branch hasn't been created yet — that would
+					// require creating an empty branch as a side effect. So we
+					// can't honestly say "marked as complete"; the first commit
+					// will create the branch and the next startup picks the
+					// migration up automatically.
+					console.log("  No orphan branch yet — migration will run automatically after the first commit.");
+				} else {
+					console.log(`  Migrated: ${v5Result.migrated} summaries upgraded to v5`);
+					if (v5Result.skipped > 0) {
+						console.log(`  Skipped:  ${v5Result.skipped} summaries (already v5 or unparseable)`);
+					}
+				}
+			} catch (err) {
+				console.error(`  v5 migration failed: ${(err as Error).message}`);
+				console.error("  Re-run `jolli migrate` to retry; data is unchanged on failure.");
+				log.error("v5 migration failed: %s", (err as Error).message);
 			}
 
 			console.log("");

--- a/cli/src/commands/StatusCommand.ts
+++ b/cli/src/commands/StatusCommand.ts
@@ -27,14 +27,14 @@ const log = createLogger("StatusCommand");
  * everything that isn't `completed` reduces to "run `jolli migrate` and check
  * the log".
  *
- * The structured `StatusInfo` mirror of this is `schemaV5` + `schemaV5Fresh`
- * (see `Types.ts`). `migratedCount` / `errorMessage` / `startedAt` /
- * `completedAt` live on the persisted `SchemaV5MigrationState` (read by
- * `readSchemaV5State`) but are NOT projected onto `StatusInfo` today — there's
- * no consumer and `errorMessage` is dead per the design choice not to persist
- * `failed` (see `SchemaV5Migration.ts` doc comment). When Release N+M lands
- * the persisted-`failed` + UI-degrade changes, add the diagnostic fields to
- * `StatusInfo` then so `--json` consumers can drive their own UI.
+ * The structured `StatusInfo` mirror of this is the single `schemaV5` field
+ * (see `Types.ts`). The richer `SchemaV5MigrationState` fields (`fresh`,
+ * `migratedCount`, `errorMessage`, `startedAt`, `completedAt`) live only on the
+ * persisted state read by `readSchemaV5State` and are NOT projected onto
+ * `StatusInfo` — there's no consumer, so the binary `schemaV5` is all we
+ * expose. If a future UI needs finer detail (e.g. distinguishing fresh installs
+ * or surfacing a failure reason), add the specific field to `StatusInfo` then,
+ * driven by a real consumer rather than ahead of need.
  */
 export function describeSchemaV5Status(state: StatusInfo["schemaV5"]): string {
 	return state === "completed" ? "Up to date (v5)" : "Not migrated — run jolli migrate";

--- a/cli/src/commands/StatusCommand.ts
+++ b/cli/src/commands/StatusCommand.ts
@@ -15,6 +15,31 @@ import { resolveProjectDir, VERSION } from "./CliUtils.js";
 
 const log = createLogger("StatusCommand");
 
+/**
+ * Maps the v5 migration state to the user-facing one-line description shown
+ * under `Data migration:` in `jolli status`. Mirrors the VSCode Hooks tooltip
+ * line wording so users see the same language across both surfaces.
+ *
+ * Deliberately binary: "Up to date (v5)" vs "Not migrated — run jolli migrate".
+ * Earlier drafts surfaced five sub-states (completed-fresh, completed-not-fresh,
+ * in-progress, failed, pending) but only three are reachable from the current
+ * code path, and the distinction between them isn't actionable for users —
+ * everything that isn't `completed` reduces to "run `jolli migrate` and check
+ * the log".
+ *
+ * The structured `StatusInfo` mirror of this is `schemaV5` + `schemaV5Fresh`
+ * (see `Types.ts`). `migratedCount` / `errorMessage` / `startedAt` /
+ * `completedAt` live on the persisted `SchemaV5MigrationState` (read by
+ * `readSchemaV5State`) but are NOT projected onto `StatusInfo` today — there's
+ * no consumer and `errorMessage` is dead per the design choice not to persist
+ * `failed` (see `SchemaV5Migration.ts` doc comment). When Release N+M lands
+ * the persisted-`failed` + UI-degrade changes, add the diagnostic fields to
+ * `StatusInfo` then so `--json` consumers can drive their own UI.
+ */
+export function describeSchemaV5Status(state: StatusInfo["schemaV5"]): string {
+	return state === "completed" ? "Up to date (v5)" : "Not migrated — run jolli migrate";
+}
+
 /** Inputs to describeIntegrationStatus — one row in the CLI integration block. */
 interface IntegrationStatusInputs {
 	readonly enabled: boolean;
@@ -101,6 +126,7 @@ export function registerStatusCommand(program: Command): void {
 			if (hookRuntime) {
 				console.log(`  Hook runtime:     ${hookRuntime}`);
 			}
+			console.log(`  Data migration:   ${describeSchemaV5Status(status.schemaV5)}`);
 			/* v8 ignore next -- ternary: auth token presence depends on external config/env */
 			console.log(`  Jolli Account:    ${authToken ? "Signed in" : "Not signed in"}`);
 			console.log(`  Jolli API Key:    ${config?.jolliApiKey ? "Configured" : "Not configured"}`);

--- a/cli/src/core/DualWriteStorage.test.ts
+++ b/cli/src/core/DualWriteStorage.test.ts
@@ -170,6 +170,33 @@ describe("DualWriteStorage", () => {
 		expect(shadow.exists).not.toHaveBeenCalled();
 	});
 
+	describe("isDirty", () => {
+		const stub = (over: Partial<StorageProvider> = {}) =>
+			({
+				readFile: vi.fn(),
+				writeFiles: vi.fn(),
+				listFiles: vi.fn(),
+				exists: vi.fn(),
+				ensure: vi.fn(),
+				...over,
+			}) as unknown as StorageProvider;
+
+		it("reflects the shadow's dirty state", () => {
+			const dual = new DualWriteStorage(stub(), stub({ isDirty: vi.fn().mockReturnValue(true) }));
+			expect(dual.isDirty()).toBe(true);
+		});
+
+		it("returns false when the shadow is clean", () => {
+			const dual = new DualWriteStorage(stub(), stub({ isDirty: vi.fn().mockReturnValue(false) }));
+			expect(dual.isDirty()).toBe(false);
+		});
+
+		it("returns false when the shadow does not implement isDirty", () => {
+			const dual = new DualWriteStorage(stub(), stub());
+			expect(dual.isDirty()).toBe(false);
+		});
+	});
+
 	it("ensure runs both backends when shadow succeeds", async () => {
 		const primaryEnsure = vi.fn();
 		const shadowEnsure = vi.fn();
@@ -286,6 +313,68 @@ describe("DualWriteStorage", () => {
 
 		const dual = new DualWriteStorage(primary, shadow);
 		await expect(dual.writeFiles([{ path: "ok.txt", content: "data" }], "write")).resolves.toBeUndefined();
+	});
+
+	describe("batchReadFiles", () => {
+		it("delegates to the primary's batchReadFiles when present", async () => {
+			const map = new Map<string, string | null>([
+				["summaries/a.json", "A"],
+				["summaries/b.json", null],
+			]);
+			const primaryBatch = vi.fn().mockResolvedValue(map);
+			const primary = {
+				readFile: vi.fn(),
+				batchReadFiles: primaryBatch,
+				writeFiles: vi.fn(),
+				listFiles: vi.fn(),
+				exists: vi.fn().mockResolvedValue(true),
+				ensure: vi.fn(),
+			} as unknown as StorageProvider;
+			const shadow = {
+				readFile: vi.fn(),
+				writeFiles: vi.fn(),
+				listFiles: vi.fn(),
+				exists: vi.fn().mockResolvedValue(true),
+				ensure: vi.fn(),
+			} as unknown as StorageProvider;
+
+			const dual = new DualWriteStorage(primary, shadow);
+			const result = await dual.batchReadFiles(["summaries/a.json", "summaries/b.json"]);
+
+			expect(result).toBe(map);
+			expect(primaryBatch).toHaveBeenCalledWith(["summaries/a.json", "summaries/b.json"]);
+		});
+
+		it("falls back to per-file primary.readFile when the primary lacks batchReadFiles", async () => {
+			// InMemoryStorage has no batchReadFiles → the fallback loop runs.
+			const primary = new InMemoryStorage();
+			await primary.writeFiles(
+				[
+					{ path: "summaries/a.json", content: "A" },
+					{ path: "summaries/b.json", content: "B" },
+				],
+				"seed",
+			);
+			const shadow = {
+				readFile: vi.fn(),
+				writeFiles: vi.fn(),
+				listFiles: vi.fn(),
+				exists: vi.fn().mockResolvedValue(true),
+				ensure: vi.fn(),
+			} as unknown as StorageProvider;
+
+			const dual = new DualWriteStorage(primary, shadow);
+			const result = await dual.batchReadFiles([
+				"summaries/a.json",
+				"summaries/b.json",
+				"summaries/missing.json",
+			]);
+
+			expect(result.get("summaries/a.json")).toBe("A");
+			expect(result.get("summaries/b.json")).toBe("B");
+			// Missing file maps to null — same contract as readFile.
+			expect(result.get("summaries/missing.json")).toBeNull();
+		});
 	});
 
 	describe("deleteVisibleMarkdown delegation", () => {

--- a/cli/src/core/DualWriteStorage.ts
+++ b/cli/src/core/DualWriteStorage.ts
@@ -22,6 +22,17 @@ export class DualWriteStorage implements StorageProvider {
 		return this.primary.readFile(path);
 	}
 
+	// Reads come from the primary (orphan branch), so delegate the batch read
+	// there too. Falls back to per-file reads when the primary lacks the
+	// capability — keeps DualWrite honest if its primary is ever a backend
+	// without `batchReadFiles`.
+	async batchReadFiles(paths: ReadonlyArray<string>): Promise<Map<string, string | null>> {
+		if (this.primary.batchReadFiles) return this.primary.batchReadFiles(paths);
+		const result = new Map<string, string | null>();
+		for (const path of paths) result.set(path, await this.primary.readFile(path));
+		return result;
+	}
+
 	// Primary writes first because it's the source of truth (orphan branch).
 	// Shadow (folder KB) is best-effort — failures are swallowed so a flaky
 	// filesystem never blocks the critical git-based write path.
@@ -144,6 +155,14 @@ export class DualWriteStorage implements StorageProvider {
 
 	async exists(): Promise<boolean> {
 		return this.primary.exists();
+	}
+
+	// Reflects the shadow (folder) sync state: true after a swallowed shadow
+	// write failure, until the next successful shadow write clears it. The v5
+	// migration reads this to avoid stamping `completed` when the folder shadow
+	// silently fell behind (see SchemaV5Migration). Primary has no dirty concept.
+	isDirty(): boolean {
+		return this.shadow.isDirty?.() ?? false;
 	}
 
 	async ensure(): Promise<void> {

--- a/cli/src/core/GitOps.test.ts
+++ b/cli/src/core/GitOps.test.ts
@@ -87,8 +87,11 @@ function mockFailure(code: number | string, stderr: string, stdout = ""): void {
 function mockSpawnSuccess(stdout: string): void {
 	mockSpawn.mockImplementationOnce(() => {
 		// stdin is itself an EventEmitter so production code that attaches
-		// `proc.stdin.on('error', ...)` doesn't blow up on these mocks.
-		const stdin = Object.assign(new EventEmitter(), { write: vi.fn(), end: vi.fn() });
+		// `proc.stdin.on('error', ...)` doesn't blow up on these mocks. `write`
+		// returns true (buffer not full) so the backpressure-aware writer in
+		// runFastImport streams straight through without awaiting a `drain`
+		// that these one-shot mocks never emit.
+		const stdin = Object.assign(new EventEmitter(), { write: vi.fn().mockReturnValue(true), end: vi.fn() });
 		const proc = Object.assign(new EventEmitter(), {
 			stdin,
 			stdout: new EventEmitter(),
@@ -110,8 +113,11 @@ function mockSpawnSuccess(stdout: string): void {
 function mockSpawnFailure(exitCode: number, stderr: string): void {
 	mockSpawn.mockImplementationOnce(() => {
 		// stdin is itself an EventEmitter so production code that attaches
-		// `proc.stdin.on('error', ...)` doesn't blow up on these mocks.
-		const stdin = Object.assign(new EventEmitter(), { write: vi.fn(), end: vi.fn() });
+		// `proc.stdin.on('error', ...)` doesn't blow up on these mocks. `write`
+		// returns true (buffer not full) so the backpressure-aware writer in
+		// runFastImport streams straight through without awaiting a `drain`
+		// that these one-shot mocks never emit.
+		const stdin = Object.assign(new EventEmitter(), { write: vi.fn().mockReturnValue(true), end: vi.fn() });
 		const proc = Object.assign(new EventEmitter(), {
 			stdin,
 			stdout: new EventEmitter(),
@@ -134,8 +140,11 @@ function mockSpawnFailure(exitCode: number, stderr: string): void {
 function mockSpawnStreamingSuccess(chunks: ReadonlyArray<Buffer | string>): void {
 	mockSpawn.mockImplementationOnce(() => {
 		// stdin is itself an EventEmitter so production code that attaches
-		// `proc.stdin.on('error', ...)` doesn't blow up on these mocks.
-		const stdin = Object.assign(new EventEmitter(), { write: vi.fn(), end: vi.fn() });
+		// `proc.stdin.on('error', ...)` doesn't blow up on these mocks. `write`
+		// returns true (buffer not full) so the backpressure-aware writer in
+		// runFastImport streams straight through without awaiting a `drain`
+		// that these one-shot mocks never emit.
+		const stdin = Object.assign(new EventEmitter(), { write: vi.fn().mockReturnValue(true), end: vi.fn() });
 		const proc = Object.assign(new EventEmitter(), {
 			stdin,
 			stdout: new EventEmitter(),
@@ -1055,6 +1064,74 @@ describe("GitOps", () => {
 			await expect(
 				writeMultipleFilesToBranch("branch", [{ path: "test.json", content: "{}" }], "msg"),
 			).rejects.toThrow("write EPIPE");
+		});
+
+		it("honors backpressure: waits for 'drain' when stdin.write reports the buffer is full", async () => {
+			// The streaming writer must pause on `write() === false` and resume on
+			// the next `drain` rather than queuing every chunk in memory. Here the
+			// first chunk reports the buffer full; the writer awaits `drain`, then
+			// streams the rest and finishes. If backpressure were mishandled the
+			// promise would hang (write returned false, no further progress).
+			mockHappyPathPreamble("parent_hash");
+			mockSpawn.mockImplementationOnce(() => {
+				const stdin = Object.assign(new EventEmitter(), {
+					// Buffer full on the first chunk, fine for every chunk after.
+					write: vi.fn().mockReturnValueOnce(false).mockReturnValue(true),
+					end: vi.fn(),
+				});
+				const proc = Object.assign(new EventEmitter(), {
+					stdin,
+					stdout: new EventEmitter(),
+					stderr: new EventEmitter(),
+				});
+				queueMicrotask(() => {
+					// Release the awaited `drain`, then let fast-import exit cleanly.
+					stdin.emit("drain");
+					queueMicrotask(() => proc.emit("close", 0));
+				});
+				return proc;
+			});
+
+			await expect(
+				writeMultipleFilesToBranch(
+					"branch",
+					[
+						{ path: "a.json", content: '{"a":1}' },
+						{ path: "b.json", content: '{"b":2}' },
+					],
+					"msg",
+				),
+			).resolves.toBeUndefined();
+
+			// Writing continued past the drain (more than the single full chunk).
+			const proc = mockSpawn.mock.results[0].value;
+			expect(proc.stdin.write.mock.calls.length).toBeGreaterThan(1);
+		});
+
+		it("C-style-quotes an M-directive path containing a double-quote or newline", async () => {
+			// fast-import REQUIRES quoting when a path contains LF or starts with
+			// a quote; an unquoted such path would split the directive / corrupt
+			// the stream. Program-generated paths never hit this, but the writer
+			// must stay correct for arbitrary paths.
+			mockHappyPathPreamble("parent_hash");
+			mockSpawnSuccess("");
+
+			await writeMultipleFilesToBranch("branch", [{ path: 'a"b\nc.json', content: "{}" }], "msg");
+
+			const stream = captureFastImportStdin();
+			// `"` → `\"`, LF → `\n`, wrapped in double-quotes. The directive stays
+			// on one line because the embedded newline is now escaped.
+			expect(stream).toContain('M 100644 :1 "a\\"b\\nc.json"\n');
+		});
+
+		it("leaves an ordinary (quote/newline-free) path unquoted in the M directive", async () => {
+			mockHappyPathPreamble("parent_hash");
+			mockSpawnSuccess("");
+
+			await writeMultipleFilesToBranch("branch", [{ path: "summaries/abc.json", content: "{}" }], "msg");
+
+			const stream = captureFastImportStdin();
+			expect(stream).toContain("M 100644 :1 summaries/abc.json\n");
 		});
 	});
 

--- a/cli/src/core/GitOps.test.ts
+++ b/cli/src/core/GitOps.test.ts
@@ -36,6 +36,7 @@ vi.spyOn(console, "warn").mockImplementation(() => {});
 vi.spyOn(console, "error").mockImplementation(() => {});
 
 import {
+	batchReadFilesFromBranch,
 	ensureOrphanBranch,
 	execGit,
 	getCommitInfo,
@@ -85,8 +86,11 @@ function mockFailure(code: number | string, stderr: string, stdout = ""): void {
  */
 function mockSpawnSuccess(stdout: string): void {
 	mockSpawn.mockImplementationOnce(() => {
+		// stdin is itself an EventEmitter so production code that attaches
+		// `proc.stdin.on('error', ...)` doesn't blow up on these mocks.
+		const stdin = Object.assign(new EventEmitter(), { write: vi.fn(), end: vi.fn() });
 		const proc = Object.assign(new EventEmitter(), {
-			stdin: { write: vi.fn(), end: vi.fn() },
+			stdin,
 			stdout: new EventEmitter(),
 			stderr: new EventEmitter(),
 		});
@@ -105,14 +109,43 @@ function mockSpawnSuccess(stdout: string): void {
  */
 function mockSpawnFailure(exitCode: number, stderr: string): void {
 	mockSpawn.mockImplementationOnce(() => {
+		// stdin is itself an EventEmitter so production code that attaches
+		// `proc.stdin.on('error', ...)` doesn't blow up on these mocks.
+		const stdin = Object.assign(new EventEmitter(), { write: vi.fn(), end: vi.fn() });
 		const proc = Object.assign(new EventEmitter(), {
-			stdin: { write: vi.fn(), end: vi.fn() },
+			stdin,
 			stdout: new EventEmitter(),
 			stderr: new EventEmitter(),
 		});
 		queueMicrotask(() => {
 			proc.stderr.emit("data", Buffer.from(stderr));
 			proc.emit("close", exitCode);
+		});
+		return proc;
+	});
+}
+
+/**
+ * Queue a successful spawn that emits stdout in caller-controlled chunks.
+ * Used by `batchReadFilesFromBranch` tests where the parser's correctness
+ * depends on handling chunk boundaries (header / body split across `data`
+ * events). Chunks are emitted in order on the same tick.
+ */
+function mockSpawnStreamingSuccess(chunks: ReadonlyArray<Buffer | string>): void {
+	mockSpawn.mockImplementationOnce(() => {
+		// stdin is itself an EventEmitter so production code that attaches
+		// `proc.stdin.on('error', ...)` doesn't blow up on these mocks.
+		const stdin = Object.assign(new EventEmitter(), { write: vi.fn(), end: vi.fn() });
+		const proc = Object.assign(new EventEmitter(), {
+			stdin,
+			stdout: new EventEmitter(),
+			stderr: new EventEmitter(),
+		});
+		queueMicrotask(() => {
+			for (const chunk of chunks) {
+				proc.stdout.emit("data", Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+			}
+			proc.emit("close", 0);
 		});
 		return proc;
 	});
@@ -135,13 +168,17 @@ describe("GitOps", () => {
 			expect(result.stdout).toBe("abc123");
 		});
 
-		it("should pass cwd via -C flag", async () => {
+		it("should pass cwd via the spawn options bag (not the git -C flag)", async () => {
+			// Originally `execGit` injected `-C <cwd>` into argv. After PR #149
+			// it routes `cwd` through `child_process`'s options bag instead —
+			// equivalent behavior on disk, but keeps the path string out of
+			// argv and silences CodeQL's `js/shell-command-constructed-from-input`.
 			mockSuccess("main\n");
 			await execGit(["branch"], "/my/project");
 			expect(mockExecFileAsync).toHaveBeenCalledWith(
 				"git",
-				["-C", "/my/project", "branch"],
-				expect.objectContaining({ maxBuffer: expect.any(Number) }),
+				["branch"],
+				expect.objectContaining({ maxBuffer: expect.any(Number), cwd: "/my/project" }),
 			);
 		});
 
@@ -366,11 +403,12 @@ describe("GitOps", () => {
 
 			await ensureOrphanBranch("new-branch", "/my/project");
 
-			// Verify spawn was called with -C flag for cwd
+			// `cwd` now rides the spawn options bag, not argv. The git command
+			// itself (`hash-object -w --stdin`) lives in argv unchanged.
 			expect(mockSpawn).toHaveBeenCalledWith(
 				"git",
-				expect.arrayContaining(["-C", "/my/project"]),
-				expect.any(Object),
+				expect.any(Array),
+				expect.objectContaining({ cwd: "/my/project" }),
 			);
 		});
 
@@ -567,43 +605,253 @@ describe("GitOps", () => {
 		});
 	});
 
-	describe("writeMultipleFilesToBranch", () => {
-		it("should write multiple files in a single commit", async () => {
-			// ensureOrphanBranch: branch already exists (execGit)
-			mockSuccess("abc\n"); // orphanBranchExists → rev-parse
-			// Get branch tip (execGit)
-			mockSuccess("parent_hash\n");
-			// Get current tree (execGit)
-			mockSuccess("root_tree\n");
+	describe("batchReadFilesFromBranch", () => {
+		// The cat-file --batch protocol per response:
+		//     "<sha> blob <byte-len>\n" + <byte-len bytes of body> + "\n"
+		// or for a missing entry:
+		//     "<request> missing\n"   (no body, no trailing LF beyond the header)
+		// These helpers assemble those byte sequences so individual tests stay
+		// focused on the parsing behavior under test instead of protocol
+		// boilerplate.
+		function buildHeader(sha: string, size: number): string {
+			return `${sha} blob ${size}\n`;
+		}
+		function buildResponse(sha: string, body: string): Buffer {
+			const bodyBuf = Buffer.from(body, "utf8");
+			return Buffer.concat([
+				Buffer.from(buildHeader(sha, bodyBuf.length), "utf8"),
+				bodyBuf,
+				Buffer.from("\n", "utf8"),
+			]);
+		}
 
-			// --- File 1: nested path "summaries/abc123.json" ---
-			// writeBlob (spawn)
-			mockSpawnSuccess("blob_summary\n");
-			// updateTreeWithFile → ls-tree root_tree summaries → not found (execGit)
-			mockSuccess("");
-			// writeTree("") → empty subtree (spawn)
-			mockSpawnSuccess("empty_sub\n");
-			// replaceInTree(empty_sub, "abc123.json") → ls-tree -z (execGit)
-			mockSuccess("");
-			// writeTree → new subtree (spawn)
-			mockSpawnSuccess("new_sub\n");
-			// replaceInTree(root_tree, "summaries") → ls-tree -z (execGit)
-			mockSuccess(`100644 blob idx\tindex.json${NUL}`);
-			// writeTree → intermediate root (spawn)
-			mockSpawnSuccess("mid_root\n");
+		function getSpawnStdinWrites(callIndex = 0): ReadonlyArray<string> {
+			const proc = mockSpawn.mock.results[callIndex].value;
+			return (proc.stdin.write.mock.calls as ReadonlyArray<[unknown]>).map((call) => String(call[0]));
+		}
 
-			// --- File 2: flat path "index.json" ---
-			// writeBlob (spawn)
-			mockSpawnSuccess("blob_index\n");
-			// replaceInTree(mid_root, "index.json") → ls-tree -z (execGit)
-			mockSuccess(`100644 blob idx\tindex.json${NUL}040000 tree sub\tsummaries${NUL}`);
-			// writeTree → final root (spawn)
-			mockSpawnSuccess("final_root\n");
+		it("returns an empty map and does not spawn when the path list is empty", async () => {
+			const result = await batchReadFilesFromBranch("branch", []);
+			expect(result.size).toBe(0);
+			expect(mockSpawn).not.toHaveBeenCalled();
+		});
 
-			// commit-tree (execGit)
-			mockSuccess("new_commit\n");
-			// update-ref (execGit)
-			mockSuccess("\n");
+		it("reads a single file via cat-file --batch and returns its content", async () => {
+			mockSpawnStreamingSuccess([buildResponse("aaaaaaaa", "hello world")]);
+
+			const result = await batchReadFilesFromBranch("branch", ["summaries/a.json"]);
+
+			expect(result.get("summaries/a.json")).toBe("hello world");
+			expect(mockSpawn).toHaveBeenCalledWith(
+				"git",
+				expect.arrayContaining(["cat-file", "--batch"]),
+				expect.any(Object),
+			);
+			// Verify that the request was written using the <branch>:<path> form.
+			expect(getSpawnStdinWrites()).toEqual(["branch:summaries/a.json\n"]);
+		});
+
+		it("preserves request ordering across multiple files in one batch", async () => {
+			mockSpawnStreamingSuccess([
+				buildResponse("aaa", "first"),
+				buildResponse("bbb", "second"),
+				buildResponse("ccc", "third"),
+			]);
+
+			const result = await batchReadFilesFromBranch("branch", ["p/1", "p/2", "p/3"]);
+
+			expect(result.get("p/1")).toBe("first");
+			expect(result.get("p/2")).toBe("second");
+			expect(result.get("p/3")).toBe("third");
+		});
+
+		it("maps missing entries to null while keeping found entries in the same call", async () => {
+			mockSpawnStreamingSuccess([
+				buildResponse("aaa", "exists"),
+				Buffer.from("branch:missing/file.json missing\n", "utf8"),
+				buildResponse("ccc", "also exists"),
+			]);
+
+			const result = await batchReadFilesFromBranch("branch", ["found/a", "missing/file.json", "found/b"]);
+
+			expect(result.get("found/a")).toBe("exists");
+			expect(result.get("missing/file.json")).toBeNull();
+			expect(result.get("found/b")).toBe("also exists");
+		});
+
+		it("parses correctly when stdout chunks split header from body", async () => {
+			// The parser's state machine has to ride out a `data` event that ends
+			// mid-record. Split one full response into two arbitrary halves: the
+			// header + first byte of body in chunk 1, the rest of the body and
+			// trailing LF in chunk 2.
+			const full = buildResponse("aaa", "split across chunks");
+			const split = Math.floor(full.length / 3);
+			mockSpawnStreamingSuccess([full.subarray(0, split), full.subarray(split)]);
+
+			const result = await batchReadFilesFromBranch("branch", ["p"]);
+
+			expect(result.get("p")).toBe("split across chunks");
+		});
+
+		it("parses correctly when a chunk ends exactly at the header's terminating LF", async () => {
+			// Edge case: the OS pipe write boundary lands exactly after the
+			// header's LF and before the first body byte. Hits the
+			// `bytesRemaining > 0 && pending.length === 0` early-return inside
+			// the body branch — without that guard the parser would call
+			// `pending.subarray(0, take)` with `take=0` and emit an empty body.
+			const body = "01234567";
+			const header = Buffer.from(`aaa blob ${body.length}\n`, "utf8");
+			mockSpawnStreamingSuccess([header, Buffer.from(`${body}\n`, "utf8")]);
+
+			const result = await batchReadFilesFromBranch("branch", ["p"]);
+
+			expect(result.get("p")).toBe(body);
+		});
+
+		it("parses correctly when the body is split across multiple chunks", async () => {
+			// Header arrives in full, then body comes in two halves. Exercises
+			// the `bytesRemaining > 0; return` early-exit that keeps the parser
+			// waiting for more body bytes without re-entering the header phase.
+			const body = "0123456789ABCDEFGHIJ"; // 20 bytes
+			const header = Buffer.from(`aaa blob ${body.length}\n`, "utf8");
+			const halfPoint = 8;
+			mockSpawnStreamingSuccess([
+				Buffer.concat([header, Buffer.from(body.substring(0, halfPoint), "utf8")]),
+				Buffer.from(body.substring(halfPoint), "utf8"),
+				Buffer.from("\n", "utf8"), // trailing LF alone in its own chunk
+			]);
+
+			const result = await batchReadFilesFromBranch("branch", ["p"]);
+
+			expect(result.get("p")).toBe(body);
+		});
+
+		it("ignores stderr emissions while still resolving on a zero exit code", async () => {
+			// git can print informational messages to stderr (e.g. warnings)
+			// without failing. The accumulator captures them so that a later
+			// non-zero exit can surface them, but a successful close path must
+			// still resolve normally regardless of stderr content.
+			mockSpawn.mockImplementationOnce(() => {
+				const stdin = Object.assign(new EventEmitter(), { write: vi.fn(), end: vi.fn() });
+				const proc = Object.assign(new EventEmitter(), {
+					stdin,
+					stdout: new EventEmitter(),
+					stderr: new EventEmitter(),
+				});
+				queueMicrotask(() => {
+					proc.stderr.emit("data", Buffer.from("warning: harmless\n"));
+					proc.stdout.emit("data", buildResponse("aaa", "ok"));
+					proc.emit("close", 0);
+				});
+				return proc;
+			});
+
+			const result = await batchReadFilesFromBranch("branch", ["p"]);
+			expect(result.get("p")).toBe("ok");
+		});
+
+		it("parses correctly when one stdout chunk packs multiple responses", async () => {
+			// Concatenate three responses into one buffer to simulate the case
+			// where cat-file flushes several entries in a single OS-level pipe write.
+			mockSpawnStreamingSuccess([
+				Buffer.concat([buildResponse("a", "one"), buildResponse("b", "two"), buildResponse("c", "three")]),
+			]);
+
+			const result = await batchReadFilesFromBranch("branch", ["p1", "p2", "p3"]);
+
+			expect(result.get("p1")).toBe("one");
+			expect(result.get("p2")).toBe("two");
+			expect(result.get("p3")).toBe("three");
+		});
+
+		it("uses byte length (not character length) when consuming UTF-8 bodies", async () => {
+			// "é" is two UTF-8 bytes; if the parser used string-length it would
+			// truncate the body or mis-frame the next response.
+			mockSpawnStreamingSuccess([buildResponse("aaa", "café")]);
+
+			const result = await batchReadFilesFromBranch("branch", ["p"]);
+
+			expect(result.get("p")).toBe("café");
+		});
+
+		it("handles zero-byte bodies correctly", async () => {
+			// Empty blob: header says size 0, no body bytes, single trailing LF.
+			mockSpawnStreamingSuccess([Buffer.from("aaa blob 0\n\n", "utf8")]);
+
+			const result = await batchReadFilesFromBranch("branch", ["p"]);
+
+			expect(result.get("p")).toBe("");
+		});
+
+		it("propagates cwd via spawn's options bag (not as `git -C` in argv)", async () => {
+			mockSpawnStreamingSuccess([buildResponse("a", "x")]);
+
+			await batchReadFilesFromBranch("branch", ["p"], "/some/repo");
+
+			expect(mockSpawn).toHaveBeenCalledWith(
+				"git",
+				expect.arrayContaining(["cat-file", "--batch"]),
+				expect.objectContaining({ cwd: "/some/repo" }),
+			);
+		});
+
+		it("rejects (not crash) when stdin emits EPIPE because cat-file exited early", async () => {
+			// Regression guard: without the `proc.stdin.on('error', ...)` handler,
+			// EPIPE from an early subprocess exit becomes an unhandled stream
+			// error and Node 22 terminates the process. We stand up a stdin that
+			// emits "error" instead of accepting writes, and assert the helper's
+			// promise rejects with that exact error.
+			const epipeError = Object.assign(new Error("write EPIPE"), { code: "EPIPE" });
+			mockSpawn.mockImplementationOnce(() => {
+				const stdin = new EventEmitter() as EventEmitter & { write: typeof vi.fn; end: typeof vi.fn };
+				stdin.write = vi.fn();
+				stdin.end = vi.fn();
+				const proc = Object.assign(new EventEmitter(), {
+					stdin,
+					stdout: new EventEmitter(),
+					stderr: new EventEmitter(),
+				});
+				queueMicrotask(() => {
+					stdin.emit("error", epipeError);
+				});
+				return proc;
+			});
+
+			await expect(batchReadFilesFromBranch("branch", ["p"])).rejects.toThrow("write EPIPE");
+		});
+	});
+
+	describe("writeMultipleFilesToBranch (fast-import path)", () => {
+		// The fast-import-based implementation always issues exactly one spawn
+		// (the import itself); the four execFile calls are the branch-existence
+		// probe inside ensureOrphanBranch, the parent rev-parse, and the two
+		// `git var` lookups for author/committer identity. This helper joins all
+		// stdin chunks written to that single spawn so the assertions below can
+		// pattern-match against the actual fast-import protocol text.
+		function captureFastImportStdin(spawnCallIndex = 0): string {
+			const proc = mockSpawn.mock.results[spawnCallIndex].value;
+			const chunks = proc.stdin.write.mock.calls as ReadonlyArray<[unknown]>;
+			const buffers = chunks.map((call) => {
+				const arg = call[0];
+				if (Buffer.isBuffer(arg)) return arg;
+				return Buffer.from(String(arg), "utf8");
+			});
+			return Buffer.concat(buffers).toString("utf8");
+		}
+
+		// Convenience: queue the four execGit responses every successful call
+		// resolves (orphan probe → tip rev-parse → author ident → committer
+		// ident) and queue a successful spawn for fast-import.
+		function mockHappyPathPreamble(parent: string): void {
+			mockSuccess("abc\n"); // ensureOrphanBranch → orphanBranchExists rev-parse
+			mockSuccess(`${parent}\n`); // tip rev-parse
+			mockSuccess("Alice <alice@example.com> 1700000000 +0000\n"); // GIT_AUTHOR_IDENT
+			mockSuccess("Alice <alice@example.com> 1700000000 +0000\n"); // GIT_COMMITTER_IDENT
+		}
+
+		it("streams blob + commit records for multiple writes in a single spawn", async () => {
+			mockHappyPathPreamble("parent_hash");
+			mockSpawnSuccess("");
 
 			await writeMultipleFilesToBranch(
 				"branch",
@@ -614,221 +862,199 @@ describe("GitOps", () => {
 				"Add summary and update index",
 			);
 
-			// Single commit-tree and single update-ref
-			expect(mockExecFileAsync).toHaveBeenCalledTimes(9);
-			expect(mockSpawn).toHaveBeenCalledTimes(6);
+			// fast-import + the four read-only execGit calls listed in
+			// mockHappyPathPreamble. The historical pipeline issued 9 execGits
+			// and 6 spawns for the same input — see commit history of this file.
+			expect(mockSpawn).toHaveBeenCalledTimes(1);
+			expect(mockExecFileAsync).toHaveBeenCalledTimes(4);
+			expect(mockSpawn).toHaveBeenCalledWith(
+				"git",
+				expect.arrayContaining(["fast-import", "--quiet", "--done"]),
+				expect.any(Object),
+			);
+
+			const stream = captureFastImportStdin();
+			// Two blobs, each with its own mark, in declaration order.
+			expect(stream).toContain("blob\nmark :1\ndata 17\n"); // '{"summary": true}'
+			expect(stream).toContain('{"summary": true}');
+			expect(stream).toContain("blob\nmark :2\ndata 14\n"); // '{"version": 1}'
+			expect(stream).toContain('{"version": 1}');
+			// Commit record targets the right ref, chains onto our observed parent,
+			// and references the marks above by index in declaration order.
+			expect(stream).toContain("commit refs/heads/branch\n");
+			expect(stream).toContain("author Alice <alice@example.com> 1700000000 +0000\n");
+			expect(stream).toContain("committer Alice <alice@example.com> 1700000000 +0000\n");
+			expect(stream).toContain("from parent_hash\n");
+			expect(stream).toContain("M 100644 :1 summaries/abc123.json\n");
+			expect(stream).toContain("M 100644 :2 index.json\n");
+			expect(stream).toMatch(/done\n$/);
 		});
 
-		it("should throw on tip failure", async () => {
-			mockSuccess("abc\n"); // orphanBranchExists
-			mockFailure(128, "fatal: bad ref"); // tip rev-parse fails
+		it("emits a single blob and one M directive for the simplest single-file write", async () => {
+			mockHappyPathPreamble("parent_hash");
+			mockSpawnSuccess("");
+
+			await writeMultipleFilesToBranch("branch", [{ path: "test.json", content: "{}" }], "msg");
+
+			const stream = captureFastImportStdin();
+			expect(stream).toContain("blob\nmark :1\ndata 2\n");
+			expect(stream).toContain("M 100644 :1 test.json\n");
+			expect(stream).not.toContain("\nD ");
+		});
+
+		it("emits only D directives (no blob records) when the batch is delete-only", async () => {
+			mockHappyPathPreamble("parent_hash");
+			mockSpawnSuccess("");
+
+			await writeMultipleFilesToBranch(
+				"branch",
+				[
+					{ path: "transcripts/hash.json", content: "", delete: true },
+					{ path: "summaries/old.json", content: "", delete: true },
+				],
+				"Delete two files",
+			);
+
+			const stream = captureFastImportStdin();
+			expect(stream).not.toContain("blob\n");
+			expect(stream).not.toContain("\nM ");
+			expect(stream).toContain("D transcripts/hash.json\n");
+			expect(stream).toContain("D summaries/old.json\n");
+		});
+
+		it("interleaves write and delete entries in a single commit record", async () => {
+			mockHappyPathPreamble("parent_hash");
+			mockSpawnSuccess("");
+
+			await writeMultipleFilesToBranch(
+				"branch",
+				[
+					{ path: "summaries/new.json", content: '{"v": 5}' },
+					{ path: "transcripts/old.json", content: "", delete: true },
+				],
+				"Mixed batch",
+			);
+
+			const stream = captureFastImportStdin();
+			// One blob for the write, no blob for the delete.
+			expect(stream).toContain("blob\nmark :1\n");
+			// Commit body has both M and D directives.
+			expect(stream).toContain("M 100644 :1 summaries/new.json\n");
+			expect(stream).toContain("D transcripts/old.json\n");
+		});
+
+		it("produces an empty-tree commit when the file list is empty", async () => {
+			mockHappyPathPreamble("parent_hash");
+			mockSpawnSuccess("");
+
+			await writeMultipleFilesToBranch("branch", [], "Empty batch");
+
+			const stream = captureFastImportStdin();
+			expect(stream).not.toContain("blob\n");
+			expect(stream).not.toContain("\nM ");
+			expect(stream).not.toContain("\nD ");
+			// Commit + parent are still emitted, so the resulting commit replays
+			// the parent tree unchanged — same as the historical behavior.
+			expect(stream).toContain("commit refs/heads/branch\n");
+			expect(stream).toContain("from parent_hash\n");
+			expect(stream).toMatch(/done\n$/);
+		});
+
+		it("uses Buffer.byteLength when computing data sizes so multi-byte UTF-8 is preserved", async () => {
+			mockHappyPathPreamble("parent_hash");
+			mockSpawnSuccess("");
+
+			// 'é' is two UTF-8 bytes; using string.length would emit `data 1`
+			// and corrupt the blob. We assert on the byte count via the protocol.
+			await writeMultipleFilesToBranch("branch", [{ path: "x.txt", content: "é" }], "utf-8");
+
+			const stream = captureFastImportStdin();
+			expect(stream).toContain("data 2\n");
+		});
+
+		it("propagates cwd via spawn's options bag for both execGit and the fast-import spawn", async () => {
+			mockHappyPathPreamble("parent_hash");
+			mockSpawnSuccess("");
+
+			await writeMultipleFilesToBranch("branch", [{ path: "test.json", content: "{}" }], "msg", "/some/repo");
+
+			expect(mockSpawn).toHaveBeenCalledWith(
+				"git",
+				expect.arrayContaining(["fast-import", "--quiet", "--done"]),
+				expect.objectContaining({ cwd: "/some/repo" }),
+			);
+		});
+
+		it("throws when the parent rev-parse fails before fast-import is spawned", async () => {
+			mockSuccess("abc\n"); // ensureOrphanBranch
+			mockFailure(128, "fatal: bad ref"); // tip rev-parse
 
 			await expect(
 				writeMultipleFilesToBranch("branch", [{ path: "test.json", content: "{}" }], "msg"),
 			).rejects.toThrow("Failed to get branch tip");
-		});
-
-		it("should throw on tree failure", async () => {
-			mockSuccess("abc\n"); // orphanBranchExists
-			mockSuccess("parent\n"); // tip
-			mockFailure(128, "fatal: bad tree"); // tree rev-parse fails
-
-			await expect(
-				writeMultipleFilesToBranch("branch", [{ path: "test.json", content: "{}" }], "msg"),
-			).rejects.toThrow("Failed to get tree");
-		});
-
-		it("should throw on commit-tree failure", async () => {
-			mockSuccess("abc\n"); // orphanBranchExists
-			mockSuccess("parent\n"); // tip
-			mockSuccess("root_tree\n"); // tree
-			mockSpawnSuccess("blob\n"); // writeBlob
-			mockSuccess(""); // ls-tree -z
-			mockSpawnSuccess("new_tree\n"); // writeTree
-			mockFailure(128, "commit-tree error"); // commit-tree fails
-
-			await expect(
-				writeMultipleFilesToBranch("branch", [{ path: "test.json", content: "{}" }], "msg"),
-			).rejects.toThrow("Failed to create commit");
-		});
-
-		it("should throw on update-ref failure", async () => {
-			mockSuccess("abc\n"); // orphanBranchExists
-			mockSuccess("parent\n"); // tip
-			mockSuccess("root_tree\n"); // tree
-			mockSpawnSuccess("blob\n"); // writeBlob
-			mockSuccess(""); // ls-tree -z
-			mockSpawnSuccess("new_tree\n"); // writeTree
-			mockSuccess("new_commit\n"); // commit-tree
-			mockFailure(128, "update-ref error"); // update-ref fails
-
-			await expect(
-				writeMultipleFilesToBranch("branch", [{ path: "test.json", content: "{}" }], "msg"),
-			).rejects.toThrow("Failed to update ref");
-		});
-
-		it("should delete files and collapse empty subdirectories in a single commit", async () => {
-			mockSuccess("abc\n"); // orphanBranchExists
-			mockSuccess("parent\n"); // tip
-			mockSuccess("root_tree\n"); // tree
-			// removeFileFromTree(root_tree, "transcripts/hash.json")
-			mockSuccess(
-				"040000 tree aabbccddeeff00112233445566778899aabbccdd\ttranscripts\n100644 blob a1b2c3d4\tindex.json\n",
-			); // ls-tree root_tree transcripts (no -z, used by removeFileFromTree regex)
-			mockSuccess(`100644 blob 11223344556677889900aabbccddeeff00112233\thash.json${NUL}`); // removeFromTree ls-tree -z sub_tree
-			mockSpawnSuccess("\n"); // writeTree("") => empty tree
-			mockSuccess(""); // ls-tree newSubTree empty (no -z, used by removeFileFromTree)
-			mockSuccess(
-				`040000 tree aabbccddeeff00112233445566778899aabbccdd\ttranscripts${NUL}100644 blob a1b2c3d4\tindex.json${NUL}`,
-			); // removeFromTree(root_tree, "transcripts") ls-tree -z
-			mockSpawnSuccess("pruned_root\n"); // writeTree(pruned root)
-			mockSuccess("new_commit\n"); // commit-tree
-			mockSuccess("\n"); // update-ref
-
-			await writeMultipleFilesToBranch(
-				"branch",
-				[{ path: "transcripts/hash.json", content: "", delete: true }],
-				"Delete transcript",
-			);
-
-			expect(mockExecFileAsync).toHaveBeenCalledWith(
-				"git",
-				expect.arrayContaining(["commit-tree", "pruned_root", "-p", "parent", "-m", "Delete transcript"]),
-				expect.any(Object),
-			);
-			expect(mockSpawn).toHaveBeenCalledTimes(2);
-		});
-
-		it("should ignore deletion when the target subdirectory does not exist", async () => {
-			mockSuccess("abc\n"); // orphanBranchExists
-			mockSuccess("parent\n"); // tip
-			mockSuccess("root_tree\n"); // tree
-			mockSuccess(""); // ls-tree root_tree missingDir
-			mockSuccess("new_commit\n"); // commit-tree
-			mockSuccess("\n"); // update-ref
-
-			await writeMultipleFilesToBranch(
-				"branch",
-				[{ path: "missing/file.json", content: "", delete: true }],
-				"Delete missing file",
-			);
-
 			expect(mockSpawn).not.toHaveBeenCalled();
 		});
 
-		it("should ignore deletion when the subdirectory tree entry is malformed", async () => {
-			mockSuccess("abc\n"); // orphanBranchExists
+		it("throws when GIT_AUTHOR_IDENT cannot be resolved", async () => {
+			mockSuccess("abc\n"); // ensureOrphanBranch
 			mockSuccess("parent\n"); // tip
-			mockSuccess("root_tree\n"); // tree
-			mockSuccess("100644 blob not-a-tree\ttranscripts\n"); // ls-tree root_tree transcripts
-			mockSuccess("new_commit\n"); // commit-tree
-			mockSuccess("\n"); // update-ref
+			mockFailure(128, "fatal: empty ident name"); // git var GIT_AUTHOR_IDENT
 
-			await writeMultipleFilesToBranch(
-				"branch",
-				[{ path: "transcripts/hash.json", content: "", delete: true }],
-				"Delete malformed nested file",
-			);
-
+			await expect(
+				writeMultipleFilesToBranch("branch", [{ path: "test.json", content: "{}" }], "msg"),
+			).rejects.toThrow("Failed to read GIT_AUTHOR_IDENT");
 			expect(mockSpawn).not.toHaveBeenCalled();
-			expect(mockExecFileAsync).toHaveBeenCalledWith(
-				"git",
-				expect.arrayContaining([
-					"commit-tree",
-					"root_tree",
-					"-p",
-					"parent",
-					"-m",
-					"Delete malformed nested file",
-				]),
-				expect.any(Object),
-			);
 		});
 
-		it("should delete a nested file while keeping the parent subtree when entries remain", async () => {
-			mockSuccess("abc\n"); // orphanBranchExists
+		it("throws when GIT_COMMITTER_IDENT cannot be resolved", async () => {
+			mockSuccess("abc\n"); // ensureOrphanBranch
 			mockSuccess("parent\n"); // tip
-			mockSuccess("root_tree\n"); // tree
-			// removeFileFromTree(root_tree, "transcripts/hash.json"):
-			// 1. ls-tree root_tree transcripts (no -z, regex match)
-			mockSuccess(
-				"040000 tree aabbccddeeff00112233445566778899aabbccdd\ttranscripts\n100644 blob rootblob\tindex.json\n",
-			);
-			// 2. removeFromTree(subtree, "hash.json") → ls-tree -z subtree
-			mockSuccess(
-				`100644 blob 1111111111111111111111111111111111111111\thash.json${NUL}100644 blob 2222222222222222222222222222222222222222\tkeep.json${NUL}`,
-			);
-			// 3. writeTree(filtered entries)
-			mockSpawnSuccess("trimmed_subtree\n");
-			// 4. ls-tree trimmed_subtree (no -z, check if empty)
-			mockSuccess("100644 blob 2222222222222222222222222222222222222222\tkeep.json\n");
-			// 5. replaceInTree(root, "transcripts", tree) → ls-tree -z root
-			mockSuccess(
-				`040000 tree aabbccddeeff00112233445566778899aabbccdd\ttranscripts${NUL}100644 blob rootblob\tindex.json${NUL}`,
-			);
-			mockSpawnSuccess("updated_root\n"); // writeTree(updated root)
-			mockSuccess("new_commit\n"); // commit-tree
-			mockSuccess("\n"); // update-ref
+			mockSuccess("Alice <alice@example.com> 1700000000 +0000\n"); // GIT_AUTHOR_IDENT
+			mockFailure(128, "fatal: empty ident email"); // GIT_COMMITTER_IDENT
 
-			await writeMultipleFilesToBranch(
-				"branch",
-				[{ path: "transcripts/hash.json", content: "", delete: true }],
-				"Delete nested transcript only",
-			);
-
-			expect(mockExecFileAsync).toHaveBeenCalledWith(
-				"git",
-				expect.arrayContaining([
-					"commit-tree",
-					"updated_root",
-					"-p",
-					"parent",
-					"-m",
-					"Delete nested transcript only",
-				]),
-				expect.any(Object),
-			);
+			await expect(
+				writeMultipleFilesToBranch("branch", [{ path: "test.json", content: "{}" }], "msg"),
+			).rejects.toThrow("Failed to read GIT_COMMITTER_IDENT");
+			expect(mockSpawn).not.toHaveBeenCalled();
 		});
 
-		it("should ignore deletion when the target file is missing from an existing subdirectory", async () => {
-			mockSuccess("abc\n"); // orphanBranchExists
-			mockSuccess("parent\n"); // tip
-			mockSuccess("root_tree\n"); // tree
-			// removeFileFromTree(root_tree, "transcripts/hash.json"):
-			// 1. ls-tree root_tree transcripts (no -z, regex)
-			mockSuccess(
-				"040000 tree aabbccddeeff00112233445566778899aabbccdd\ttranscripts\n100644 blob rootblob\tindex.json\n",
-			);
-			// 2. removeFromTree(subtree, "hash.json") → ls-tree -z — hash.json not found, no-op
-			mockSuccess(`100644 blob 2222222222222222222222222222222222222222\tkeep.json${NUL}`);
-			// 3. ls-tree newSubTree (no -z, check if empty) — unchanged, still non-empty
-			mockSuccess("100644 blob 2222222222222222222222222222222222222222\tkeep.json\n");
-			// 4. replaceInTree(root, "transcripts") → ls-tree -z root
-			mockSuccess(
-				`040000 tree aabbccddeeff00112233445566778899aabbccdd\ttranscripts${NUL}100644 blob rootblob\tindex.json${NUL}`,
-			);
-			mockSpawnSuccess("updated_root\n"); // writeTree(updated root)
-			mockSuccess("new_commit\n"); // commit-tree
-			mockSuccess("\n"); // update-ref
+		it("surfaces fast-import's exit code and stderr when the subprocess fails", async () => {
+			mockHappyPathPreamble("parent_hash");
+			mockSpawnFailure(128, "fatal: Unsupported command: gibberish");
 
-			await writeMultipleFilesToBranch(
-				"branch",
-				[{ path: "transcripts/hash.json", content: "", delete: true }],
-				"Delete already-missing nested file",
-			);
+			await expect(
+				writeMultipleFilesToBranch("branch", [{ path: "test.json", content: "{}" }], "msg"),
+			).rejects.toThrow(/git fast-import failed.*Unsupported command/);
+		});
 
-			expect(mockExecFileAsync).toHaveBeenCalledWith(
-				"git",
-				expect.arrayContaining([
-					"commit-tree",
-					"updated_root",
-					"-p",
-					"parent",
-					"-m",
-					"Delete already-missing nested file",
-				]),
-				expect.any(Object),
-			);
+		it("rejects (not crash) when stdin emits EPIPE during the streaming writes", async () => {
+			// Same regression guard as `batchReadFilesFromBranch` — the
+			// streaming-write helper must attach `proc.stdin.on('error', ...)`
+			// or async EPIPEs (fast-import OOM / bad `from <parent>` /
+			// signal during the body write) become unhandled stream errors
+			// that crash the Node process. We swap in a stdin that emits
+			// "error" instead of accepting writes and assert the promise
+			// rejects cleanly.
+			mockHappyPathPreamble("parent_hash");
+			const epipeError = Object.assign(new Error("write EPIPE"), { code: "EPIPE" });
+			mockSpawn.mockImplementationOnce(() => {
+				const stdin = new EventEmitter() as EventEmitter & { write: typeof vi.fn; end: typeof vi.fn };
+				stdin.write = vi.fn();
+				stdin.end = vi.fn();
+				const proc = Object.assign(new EventEmitter(), {
+					stdin,
+					stdout: new EventEmitter(),
+					stderr: new EventEmitter(),
+				});
+				queueMicrotask(() => {
+					stdin.emit("error", epipeError);
+				});
+				return proc;
+			});
+
+			await expect(
+				writeMultipleFilesToBranch("branch", [{ path: "test.json", content: "{}" }], "msg"),
+			).rejects.toThrow("write EPIPE");
 		});
 	});
 

--- a/cli/src/core/GitOps.ts
+++ b/cli/src/core/GitOps.ts
@@ -23,14 +23,22 @@ const log = createLogger("GitOps");
 /**
  * Executes a git command and returns the result.
  * Logs the command being executed and its outcome.
+ *
+ * `cwd` is passed via Node's `child_process` `cwd` option (sets the child
+ * process's working directory at spawn time) rather than git's `-C <path>`
+ * flag. The two are functionally equivalent for our use cases but routing
+ * through `spawn`'s option keeps untrusted-looking path strings out of the
+ * argv array, sidestepping CodeQL's `js/shell-command-constructed-from-input`
+ * static-analysis alert (`spawn` with an args array never invokes a shell,
+ * but CodeQL tracks taint conservatively).
  */
 export async function execGit(args: ReadonlyArray<string>, cwd?: string): Promise<GitCommandResult> {
-	const fullArgs = cwd ? ["-C", cwd, ...args] : [...args];
-	log.debug("git %s", fullArgs.join(" "));
+	log.debug("git %s%s", cwd ? `[cwd=${cwd}] ` : "", args.join(" "));
 
 	try {
-		const { stdout, stderr } = await execFileAsyncHidden("git", fullArgs, {
+		const { stdout, stderr } = await execFileAsyncHidden("git", args, {
 			maxBuffer: MAX_GIT_BUFFER_BYTES,
+			...(cwd !== undefined && { cwd }),
 		});
 		const result: GitCommandResult = {
 			stdout: stdout.trimEnd(),
@@ -311,6 +319,194 @@ export async function readFileFromBranch(branch: string, filePath: string, cwd?:
 }
 
 /**
+ * Bulk read of N files from `branch`, all served by a single
+ * `git cat-file --batch` subprocess. Returns a `Map<path, content | null>`
+ * with one entry per input path; `null` means the file was missing on the
+ * branch at lookup time (cat-file printed `<request> missing`).
+ *
+ * Why this exists: the obvious `for (...) await readFileFromBranch()` is
+ * O(n × spawn-cost). On Windows that's ~80 ms per spawn, so 336 summaries
+ * during a v5 migration cost ~27 s of pure subprocess overhead — even after
+ * the write side switched to fast-import. cat-file's `--batch` mode reads
+ * one request per stdin line and emits the response on stdout, all within
+ * one long-running process; the same 336 reads then take a couple of
+ * seconds total.
+ *
+ * Protocol (see `git-cat-file(1)`):
+ *
+ *     <request>\n              -- on stdin, e.g. "<branch>:<path>"
+ *     <sha> <type> <size>\n    -- on stdout (header line)
+ *     <size bytes of body>\n   -- body, exactly `size` bytes + a trailing LF
+ *
+ * Missing entries are signalled by a single `<request> missing\n` line with
+ * no body. Responses arrive in the exact order requests were written, so the
+ * parser pops them off positionally.
+ *
+ * The parser is a small streaming state machine because TCP-style chunking
+ * applies to subprocess pipes too: a single `data` event may span the
+ * boundary between header and body, multiple responses, or a partial body.
+ * We accumulate bytes in a `pending` buffer and consume them in two phases
+ * (header line vs. fixed-size body + trailing LF) until all expected
+ * responses are accounted for.
+ */
+export async function batchReadFilesFromBranch(
+	branch: string,
+	paths: ReadonlyArray<string>,
+	cwd?: string,
+): Promise<Map<string, string | null>> {
+	const result = new Map<string, string | null>();
+	if (paths.length === 0) return result;
+
+	const args = ["cat-file", "--batch"];
+	log.debug(
+		"git (cat-file --batch stream) %s%s for %d paths",
+		cwd ? `[cwd=${cwd}] ` : "",
+		args.join(" "),
+		paths.length,
+	);
+
+	return new Promise<Map<string, string | null>>((resolve, reject) => {
+		// `cwd` flows through `spawn`'s options bag, not `git -C`. See
+		// `execGit` for the CodeQL rationale.
+		const proc = spawnHidden("git", args, {
+			stdio: ["pipe", "pipe", "pipe"],
+			...(cwd !== undefined && { cwd }),
+		});
+		let stderr = "";
+		let pending = Buffer.alloc(0);
+		let inHeader = true;
+		let bytesRemaining = 0;
+		let bodyChunks: Buffer[] = [];
+		let needsTrailingNewline = false;
+		let pathIdx = 0;
+		let settled = false;
+
+		/* v8 ignore start -- idempotency guard: only fires if multiple error paths race (e.g. both `close` and `error` events). Single-event paths are exercised; double-fire isn't reachable without a hostile mock. */
+		const settle = (err: Error | null): void => {
+			if (settled) return;
+			settled = true;
+			if (err) reject(err);
+			else resolve(result);
+		};
+		/* v8 ignore stop */
+
+		proc.stderr.on("data", (chunk: Buffer) => {
+			stderr += chunk.toString();
+		});
+
+		proc.stdout.on("data", (chunk: Buffer) => {
+			// Always `Buffer.concat` (instead of `pending = chunk` on the first
+			// event) so `pending` keeps a `Buffer<ArrayBuffer>` type — `chunk`
+			// from a pipe is `Buffer<ArrayBufferLike>` and direct assignment
+			// would narrow the variable's type through the loop. Allocation
+			// cost is negligible vs. the cat-file pipe overhead we're paying
+			// anyway.
+			pending = Buffer.concat([pending, chunk]);
+
+			while (!settled) {
+				if (inHeader) {
+					const nlIdx = pending.indexOf(0x0a);
+					if (nlIdx < 0) return; // need more bytes
+					const header = pending.subarray(0, nlIdx).toString("utf8");
+					pending = pending.subarray(nlIdx + 1);
+
+					/* v8 ignore start -- defensive: git only emits more responses than requests if our request/response accounting drifts, which would be a bug */
+					if (pathIdx >= paths.length) {
+						settle(new Error(`git cat-file --batch returned extra response: ${header}`));
+						return;
+					}
+					/* v8 ignore stop */
+					const requestPath = paths[pathIdx];
+					pathIdx++;
+
+					if (header.endsWith(" missing")) {
+						result.set(requestPath, null);
+						continue;
+					}
+
+					// Header: "<sha> <type> <size>"
+					const sizeStr = header.substring(header.lastIndexOf(" ") + 1);
+					const size = Number.parseInt(sizeStr, 10);
+					/* v8 ignore start -- defensive: malformed header would indicate a git protocol break, not a recoverable runtime condition */
+					if (!Number.isFinite(size) || size < 0) {
+						settle(new Error(`Unexpected cat-file --batch header for ${requestPath}: ${header}`));
+						return;
+					}
+					/* v8 ignore stop */
+					bytesRemaining = size;
+					bodyChunks = [];
+					inHeader = false;
+					needsTrailingNewline = true;
+					// fall through into the body branch
+				}
+
+				if (bytesRemaining > 0) {
+					if (pending.length === 0) return; // need more bytes
+					const take = Math.min(bytesRemaining, pending.length);
+					bodyChunks.push(pending.subarray(0, take));
+					pending = pending.subarray(take);
+					bytesRemaining -= take;
+					if (bytesRemaining > 0) return; // body not fully drained yet
+				}
+
+				/* v8 ignore next -- false-arm only reachable if state-machine invariants drift: this block always runs after the body branch transitions out of header. The early-return inside is what tests exercise. */
+				if (needsTrailingNewline) {
+					if (pending.length < 1) return; // need the trailing LF
+					pending = pending.subarray(1);
+					needsTrailingNewline = false;
+
+					const requestPath = paths[pathIdx - 1];
+					result.set(requestPath, Buffer.concat(bodyChunks).toString("utf8"));
+					bodyChunks = [];
+					inHeader = true;
+				}
+			}
+		});
+
+		proc.on("close", (code) => {
+			/* v8 ignore start -- spawn error / non-zero exit / under-response are protocol-failure paths exercised via mocks but exact branch ordering varies by platform */
+			if (code !== 0) {
+				settle(new Error(`git cat-file --batch failed (exit ${code}): ${stderr.trim()}`));
+				return;
+			}
+			if (pathIdx < paths.length) {
+				settle(
+					new Error(
+						`git cat-file --batch returned ${pathIdx} of ${paths.length} expected responses; stderr=${stderr.trim()}`,
+					),
+				);
+				return;
+			}
+			/* v8 ignore stop */
+			settle(null);
+		});
+
+		/* v8 ignore start -- spawn error only triggers when git is not on PATH */
+		proc.on("error", (err) => {
+			settle(err);
+		});
+		/* v8 ignore stop */
+
+		// stdin EPIPE handler — mirrors `runFastImport`. If cat-file exits
+		// early (malformed input, OOM, signal), the in-flight write loop
+		// below can throw EPIPE asynchronously; without this listener Node
+		// would terminate the process on the unhandled stream error.
+		proc.stdin.on("error", (err) => {
+			settle(err);
+		});
+
+		// Write every request in one go. cat-file flushes responses as it
+		// resolves each one, so it's safe (and faster) to feed everything
+		// upfront and close stdin; git will continue draining responses to
+		// stdout even though no more requests are coming.
+		for (const path of paths) {
+			proc.stdin.write(`${branch}:${path}\n`);
+		}
+		proc.stdin.end();
+	});
+}
+
+/**
  * Writes a file to a branch using git plumbing commands.
  * Does NOT checkout the branch — works entirely through object database.
  *
@@ -363,9 +559,30 @@ export async function writeFileToBranch(
 }
 
 /**
- * Writes multiple files to a branch in a single atomic commit.
- * More efficient than calling writeFileToBranch multiple times because it
- * only performs ensureOrphanBranch, rev-parse, commit-tree, and update-ref once.
+ * Writes multiple files to a branch in a single atomic commit, streaming the
+ * entire batch through one `git fast-import` subprocess.
+ *
+ * Why fast-import: the older per-file `hash-object` + `mktree` + `ls-tree`
+ * pipeline spawned roughly 4 git subprocesses per file. On Windows that meant
+ * a v5 schema migration touching 337 summaries took ~3 minutes; switching to
+ * fast-import collapses it to two subprocess spawns total (fast-import itself,
+ * plus one `rev-parse` to learn the parent commit) and finishes in seconds.
+ *
+ * Atomicity: fast-import writes the new commit and updates `refs/heads/<branch>`
+ * in a single transaction. Either the whole batch lands or nothing does — same
+ * guarantee the old plumbing path provided. The `from <parent>` directive ties
+ * the new commit to the tip we observed at entry, so a concurrent writer
+ * advancing the ref between our rev-parse and fast-import would cause the
+ * import to abort rather than overwrite their commit. (Concurrent writers are
+ * already serialized via `orphan-write.lock` upstream of this function; the
+ * `from` check is the belt-and-braces backup.)
+ *
+ * Behavior preserved from the prior implementation:
+ *   - Empty `files` array still produces a commit (same tree as parent).
+ *   - Mixed writes and deletes in any order; deletes use the fast-import `D`
+ *     directive.
+ *   - Author/committer identity is whatever `git var` resolves for the caller,
+ *     so the commit looks exactly like one `commit-tree` would have produced.
  */
 export async function writeMultipleFilesToBranch(
 	branch: string,
@@ -373,55 +590,19 @@ export async function writeMultipleFilesToBranch(
 	commitMessage: string,
 	cwd?: string,
 ): Promise<void> {
-	// Ensure branch exists (single check)
 	await ensureOrphanBranch(branch, cwd);
 
-	// Get the current commit hash of the branch
 	const tipResult = await execGit(["rev-parse", `refs/heads/${branch}`], cwd);
 	if (tipResult.exitCode !== 0) {
 		throw new Error(`Failed to get branch tip: ${tipResult.stderr}`);
 	}
 	const parentCommit = tipResult.stdout.trim();
 
-	// Get the current tree
-	const treeResult = await execGit(["rev-parse", `${parentCommit}^{tree}`], cwd);
-	if (treeResult.exitCode !== 0) {
-		throw new Error(`Failed to get tree: ${treeResult.stderr}`);
-	}
-
-	// Accumulate tree updates across all files (writes and deletes)
-	let currentTree = treeResult.stdout.trim();
-	for (const file of files) {
-		if (file.delete) {
-			currentTree = await removeFileFromTree(currentTree, file.path, cwd);
-		} else {
-			const blobHash = await writeBlob(file.content, cwd);
-			currentTree = await updateTreeWithFile(currentTree, file.path, blobHash, cwd);
-		}
-	}
-
-	// Create a single commit for all file changes
-	const commitResult = await execGit(["commit-tree", currentTree, "-p", parentCommit, "-m", commitMessage], cwd);
-	if (commitResult.exitCode !== 0) {
-		throw new Error(`Failed to create commit: ${commitResult.stderr}`);
-	}
-	const newCommit = commitResult.stdout.trim();
-
-	// Update the branch ref once
-	const refResult = await execGit(["update-ref", `refs/heads/${branch}`, newCommit], cwd);
-	if (refResult.exitCode !== 0) {
-		throw new Error(`Failed to update ref: ${refResult.stderr}`);
-	}
+	await runFastImport(branch, parentCommit, commitMessage, files, cwd);
 
 	const writeCount = files.filter((f) => !f.delete).length;
 	const deleteCount = files.filter((f) => f.delete).length;
-	log.info(
-		"Updated branch '%s': %d written, %d deleted (commit: %s)",
-		branch,
-		writeCount,
-		deleteCount,
-		newCommit.substring(0, 8),
-	);
+	log.info("Updated branch '%s': %d written, %d deleted (via fast-import)", branch, writeCount, deleteCount);
 }
 
 /**
@@ -556,11 +737,14 @@ export async function resolveGitHooksDir(projectDir: string): Promise<string> {
  * child process to hang waiting for stdin data that never arrives.
  */
 function execGitWithStdin(args: ReadonlyArray<string>, input: string, cwd?: string): Promise<string> {
-	const fullArgs = cwd ? ["-C", cwd, ...args] : [...args];
-	log.debug("git (stdin) %s", fullArgs.join(" "));
+	log.debug("git (stdin) %s%s", cwd ? `[cwd=${cwd}] ` : "", args.join(" "));
 
 	return new Promise((resolve, reject) => {
-		const proc = spawnHidden("git", fullArgs, { stdio: ["pipe", "pipe", "pipe"] });
+		// `cwd` flows through `spawn`'s options bag, not `git -C`. See `execGit`.
+		const proc = spawnHidden("git", args, {
+			stdio: ["pipe", "pipe", "pipe"],
+			...(cwd !== undefined && { cwd }),
+		});
 		let stdout = "";
 		let stderr = "";
 
@@ -596,6 +780,145 @@ function execGitWithStdin(args: ReadonlyArray<string>, input: string, cwd?: stri
  */
 async function writeBlob(content: string, cwd?: string): Promise<string> {
 	return execGitWithStdin(["hash-object", "-w", "--stdin"], content, cwd);
+}
+
+/**
+ * Reads one of `GIT_AUTHOR_IDENT` / `GIT_COMMITTER_IDENT` via `git var`. The
+ * returned string is already in the raw `Name <email> <epoch> <tz>` form that
+ * fast-import expects in `author` / `committer` directives, so callers can
+ * splice it verbatim.
+ *
+ * Reading via `git var` rather than hard-coding an identity preserves the
+ * behavior of the old `commit-tree`-based pipeline, which inherited author /
+ * committer from git config too — orphan-branch history therefore continues
+ * to attribute commits to the same identity users see on `git log` elsewhere.
+ */
+async function getGitIdent(varName: "GIT_AUTHOR_IDENT" | "GIT_COMMITTER_IDENT", cwd?: string): Promise<string> {
+	const result = await execGit(["var", varName], cwd);
+	if (result.exitCode !== 0) {
+		throw new Error(`Failed to read ${varName}: ${result.stderr}`);
+	}
+	return result.stdout.trim();
+}
+
+/**
+ * Atomically writes N blobs and one commit to `branch` via a single
+ * `git fast-import` subprocess. Replaces the per-file hash-object + tree-
+ * walk pipeline that previously made bulk writes O(n × spawn-cost).
+ *
+ * fast-import stream layout (see git-fast-import(1) for the full grammar):
+ *
+ *     blob
+ *     mark :1
+ *     data <byte-length-of-content>
+ *     <raw bytes>
+ *     ... (more blob records, one per write) ...
+ *     commit refs/heads/<branch>
+ *     author <name> <email> <epoch> <tz>
+ *     committer <name> <email> <epoch> <tz>
+ *     data <byte-length-of-msg>
+ *     <message bytes>
+ *     from <parent-sha>
+ *     M 100644 :<mark> <path>      -- one per write, referencing the mark above
+ *     D <path>                     -- one per delete
+ *     done
+ *
+ * `--done` makes fast-import treat a truncated stream as an error rather than
+ * silently committing a partial batch; we always emit the matching `done`
+ * directive at the end of the stream so a clean shutdown is unambiguous.
+ *
+ * The `from <parent-sha>` directive is the concurrency guard: fast-import
+ * refuses to advance the ref unless its current value matches `<parent-sha>`.
+ * The caller passes the SHA observed at entry, so if another writer slips in
+ * a commit before fast-import runs, this call fails fast instead of silently
+ * clobbering them. (Upstream serialization via `orphan-write.lock` is the
+ * primary defense; this is the secondary one.)
+ */
+async function runFastImport(
+	branch: string,
+	parent: string,
+	commitMessage: string,
+	files: ReadonlyArray<FileWrite>,
+	cwd?: string,
+): Promise<void> {
+	const authorIdent = await getGitIdent("GIT_AUTHOR_IDENT", cwd);
+	const committerIdent = await getGitIdent("GIT_COMMITTER_IDENT", cwd);
+
+	const args = ["fast-import", "--quiet", "--done"];
+	log.debug("git (fast-import stream) %s%s", cwd ? `[cwd=${cwd}] ` : "", args.join(" "));
+
+	const writes = files.filter((f) => !f.delete);
+	const deletes = files.filter((f) => f.delete);
+
+	return new Promise<void>((resolve, reject) => {
+		// `cwd` flows through `spawn`'s options bag, not `git -C`. See `execGit`.
+		const proc = spawnHidden("git", args, {
+			stdio: ["pipe", "pipe", "pipe"],
+			...(cwd !== undefined && { cwd }),
+		});
+		let stderr = "";
+
+		proc.stderr.on("data", (chunk: Buffer) => {
+			stderr += chunk.toString();
+		});
+		proc.on("close", (code) => {
+			if (code !== 0) {
+				reject(new Error(`git fast-import failed (exit ${code}): ${stderr.trim()}`));
+			} else {
+				resolve();
+			}
+		});
+		/* v8 ignore start -- spawn error only triggers when git is not on PATH */
+		proc.on("error", (err) => {
+			reject(err);
+		});
+		/* v8 ignore stop */
+
+		const stdin = proc.stdin;
+
+		// stdin can emit async errors (EPIPE) if fast-import exits early —
+		// e.g. malformed `from <parent>` or OOM. Without this handler the
+		// EPIPE becomes an unhandled stream-error event and Node terminates
+		// the process. The `close` handler's reject is idempotent vs this
+		// one (whichever fires first wins; Promises swallow the second).
+		stdin.on("error", (err) => {
+			reject(err);
+		});
+
+		// Stream every blob first. Marks are sequential integers — only need
+		// to be unique within this stream, so 1..N is the simplest scheme.
+		// Buffer.from(... , "utf8") + buf.length gives the BYTE count fast-
+		// import requires (using string.length would undercount any multi-
+		// byte UTF-8 sequence and produce a malformed `data` directive).
+		writes.forEach((f, idx) => {
+			const mark = idx + 1;
+			const body = Buffer.from(f.content, "utf8");
+			stdin.write(`blob\nmark :${mark}\ndata ${body.length}\n`);
+			stdin.write(body);
+			stdin.write("\n");
+		});
+
+		// Now emit the single commit record that references the marks above.
+		const msg = Buffer.from(commitMessage, "utf8");
+		stdin.write(`commit refs/heads/${branch}\n`);
+		stdin.write(`author ${authorIdent}\n`);
+		stdin.write(`committer ${committerIdent}\n`);
+		stdin.write(`data ${msg.length}\n`);
+		stdin.write(msg);
+		stdin.write("\n");
+		stdin.write(`from ${parent}\n`);
+
+		writes.forEach((f, idx) => {
+			const mark = idx + 1;
+			stdin.write(`M 100644 :${mark} ${f.path}\n`);
+		});
+		for (const f of deletes) {
+			stdin.write(`D ${f.path}\n`);
+		}
+
+		stdin.write("done\n");
+		stdin.end();
+	});
 }
 
 /**
@@ -687,69 +1010,5 @@ async function replaceInTree(
 	// mktree accepts entries in any order and produces a deterministic tree hash,
 	// so no explicit sorting is needed.
 	const treeInput = `${existingEntries.join("\n")}\n`;
-	return await writeTree(treeInput, cwd);
-}
-
-/**
- * Removes a file from a tree at the given path.
- * Handles nested directories (e.g., "transcripts/abc123.json").
- * If a subdirectory becomes empty after removal, it is also removed from its parent.
- * Returns the original tree unchanged if the file does not exist.
- */
-async function removeFileFromTree(currentTree: string, filePath: string, cwd?: string): Promise<string> {
-	const parts = filePath.split("/");
-
-	if (parts.length === 1) {
-		return await removeFromTree(currentTree, parts[0], cwd);
-	}
-
-	// Nested case: recurse into subdirectory
-	const dirName = parts[0];
-	const remainingPath = parts.slice(1).join("/");
-
-	const lsResult = await execGit(["ls-tree", currentTree, dirName], cwd);
-	if (lsResult.exitCode !== 0 || !lsResult.stdout.trim()) {
-		// Directory doesn't exist — nothing to remove
-		return currentTree;
-	}
-
-	const match = lsResult.stdout.match(/^(\d+)\s+tree\s+([a-f0-9]+)\t/);
-	if (!match) return currentTree;
-	const subTreeHash = match[2];
-
-	const newSubTree = await removeFileFromTree(subTreeHash, remainingPath, cwd);
-
-	// If the subtree is now empty, remove the directory entry from the parent
-	const subEntries = await execGit(["ls-tree", newSubTree], cwd);
-	if (subEntries.exitCode === 0 && !subEntries.stdout.trim()) {
-		return await removeFromTree(currentTree, dirName, cwd);
-	}
-
-	return await replaceInTree(currentTree, dirName, "040000", "tree", newSubTree, cwd);
-}
-
-/**
- * Removes an entry from a tree object by name.
- * Returns the original tree unchanged if the entry does not exist.
- */
-async function removeFromTree(treeHash: string, name: string, cwd?: string): Promise<string> {
-	// Use -z so git outputs raw filenames (no quoting/escaping for non-ASCII names)
-	const lsResult = await execGit(["ls-tree", "-z", treeHash], cwd);
-	const entries = lsResult.stdout.split(NUL).filter((line) => line.length > 0);
-
-	const filtered = entries.filter((line) => {
-		const entryName = line.split("\t")[1];
-		return entryName !== name;
-	});
-
-	// Nothing was removed — return original tree
-	if (filtered.length === entries.length) return treeHash;
-
-	if (filtered.length === 0) {
-		// All entries removed — return an empty tree
-		return await writeTree("", cwd);
-	}
-
-	const treeInput = `${filtered.join("\n")}\n`;
 	return await writeTree(treeInput, cwd);
 }

--- a/cli/src/core/GitOps.ts
+++ b/cli/src/core/GitOps.ts
@@ -8,6 +8,7 @@
  * Pattern adapted from: tools/jolliagent/src/tools/tools/git_shared.ts
  */
 
+import { once } from "node:events";
 import { readFile, stat } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
 import { createLogger } from "../Logger.js";
@@ -885,40 +886,94 @@ async function runFastImport(
 			reject(err);
 		});
 
-		// Stream every blob first. Marks are sequential integers — only need
-		// to be unique within this stream, so 1..N is the simplest scheme.
-		// Buffer.from(... , "utf8") + buf.length gives the BYTE count fast-
-		// import requires (using string.length would undercount any multi-
-		// byte UTF-8 sequence and produce a malformed `data` directive).
+		// Build the fast-import stream as one ordered list of chunks, then
+		// write it with backpressure handling (see writeChunksWithBackpressure).
+		// Blobs come first; marks are sequential integers — only need to be
+		// unique within this stream, so 1..N is the simplest scheme.
+		// Buffer.from(..., "utf8") + buf.length gives the BYTE count fast-import
+		// requires (string.length would undercount any multi-byte UTF-8 sequence
+		// and produce a malformed `data` directive).
+		const chunks: Array<string | Buffer> = [];
 		writes.forEach((f, idx) => {
 			const mark = idx + 1;
 			const body = Buffer.from(f.content, "utf8");
-			stdin.write(`blob\nmark :${mark}\ndata ${body.length}\n`);
-			stdin.write(body);
-			stdin.write("\n");
+			chunks.push(`blob\nmark :${mark}\ndata ${body.length}\n`, body, "\n");
 		});
 
-		// Now emit the single commit record that references the marks above.
+		// The single commit record that references the marks above.
 		const msg = Buffer.from(commitMessage, "utf8");
-		stdin.write(`commit refs/heads/${branch}\n`);
-		stdin.write(`author ${authorIdent}\n`);
-		stdin.write(`committer ${committerIdent}\n`);
-		stdin.write(`data ${msg.length}\n`);
-		stdin.write(msg);
-		stdin.write("\n");
-		stdin.write(`from ${parent}\n`);
-
+		chunks.push(
+			`commit refs/heads/${branch}\n`,
+			`author ${authorIdent}\n`,
+			`committer ${committerIdent}\n`,
+			`data ${msg.length}\n`,
+			msg,
+			"\n",
+			`from ${parent}\n`,
+		);
 		writes.forEach((f, idx) => {
-			const mark = idx + 1;
-			stdin.write(`M 100644 :${mark} ${f.path}\n`);
+			chunks.push(`M 100644 :${idx + 1} ${quoteFastImportPath(f.path)}\n`);
 		});
 		for (const f of deletes) {
-			stdin.write(`D ${f.path}\n`);
+			chunks.push(`D ${quoteFastImportPath(f.path)}\n`);
 		}
+		chunks.push("done\n");
 
-		stdin.write("done\n");
-		stdin.end();
+		// Stream the chunks honoring backpressure: when `write()` returns false
+		// the kernel buffer is full, so wait for `drain` before the next chunk
+		// rather than letting every blob body queue in Node's memory at once —
+		// the 336-file migration this path optimizes is exactly where an
+		// ignore-the-return-value loop would balloon. A write failure mid-stream
+		// (EPIPE) rejects via `once`'s error handling, mirroring the persistent
+		// `stdin.on("error")` above; either path's reject is idempotent.
+		writeChunksWithBackpressure(stdin, chunks).then(
+			() => {
+				stdin.end();
+			},
+			(err) => {
+				reject(err);
+			},
+		);
 	});
+}
+
+/**
+ * Writes `chunks` to `stream` in order, pausing on backpressure: when
+ * `stream.write()` returns false (the internal/kernel buffer is full) it awaits
+ * the next `drain` event before continuing, so a large batch can't pile every
+ * chunk into memory at once. Rejects if the stream errors while draining
+ * (`once` rejects on an `error` event), letting the caller surface an EPIPE
+ * from an early fast-import exit instead of hanging.
+ */
+async function writeChunksWithBackpressure(
+	stream: NodeJS.WritableStream,
+	chunks: ReadonlyArray<string | Buffer>,
+): Promise<void> {
+	for (const chunk of chunks) {
+		if (!stream.write(chunk)) {
+			await once(stream, "drain");
+		}
+	}
+}
+
+/**
+ * Renders a path for a fast-import `M`/`D` directive. fast-import accepts a
+ * C-style-quoted path in all cases and REQUIRES it when the path contains a
+ * newline or begins with a double-quote (an unquoted such path corrupts the
+ * stream or splits the directive). Today every orphan-branch path is a
+ * program-generated hash / UUID / fixed name that never needs quoting, so this
+ * is a hardening / no-regression guard versus the byte-safe `mktree` path it
+ * replaced — but it makes the writer correct for arbitrary paths.
+ *
+ * Quotes whenever the path contains a backslash, double-quote, CR, or LF, and
+ * C-escapes those characters. (The `\\` replacement here escapes a literal
+ * backslash for fast-import quoting — it is NOT path separator normalization,
+ * so the `toForwardSlash` rule does not apply.)
+ */
+function quoteFastImportPath(path: string): string {
+	if (!/["\\\n\r]/.test(path)) return path;
+	const escaped = path.replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/\n/g, "\\n").replace(/\r/g, "\\r");
+	return `"${escaped}"`;
 }
 
 /**

--- a/cli/src/core/OrphanBranchStorage.test.ts
+++ b/cli/src/core/OrphanBranchStorage.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // OrphanBranchStorage is a thin wrapper; every method just forwards to GitOps.
 vi.mock("./GitOps.js", () => ({
+	batchReadFilesFromBranch: vi.fn(),
 	ensureOrphanBranch: vi.fn(),
 	listFilesInBranch: vi.fn(),
 	orphanBranchExists: vi.fn(),
@@ -11,6 +12,7 @@ vi.mock("./GitOps.js", () => ({
 
 import { ORPHAN_BRANCH } from "../Logger.js";
 import {
+	batchReadFilesFromBranch,
 	ensureOrphanBranch,
 	listFilesInBranch,
 	orphanBranchExists,
@@ -20,6 +22,7 @@ import {
 import { OrphanBranchStorage } from "./OrphanBranchStorage.js";
 
 const mockedReadFile = vi.mocked(readFileFromBranch);
+const mockedBatchReadFiles = vi.mocked(batchReadFilesFromBranch);
 const mockedWriteFiles = vi.mocked(writeMultipleFilesToBranch);
 const mockedListFiles = vi.mocked(listFilesInBranch);
 const mockedExists = vi.mocked(orphanBranchExists);
@@ -48,6 +51,24 @@ describe("OrphanBranchStorage", () => {
 
 		expect(result).toBeNull();
 		expect(mockedReadFile).toHaveBeenCalledWith(ORPHAN_BRANCH, "missing.json", undefined);
+	});
+
+	it("batchReadFiles forwards ORPHAN_BRANCH, paths and cwd to batchReadFilesFromBranch", async () => {
+		const map = new Map<string, string | null>([
+			["summaries/a.json", "A"],
+			["summaries/b.json", null],
+		]);
+		mockedBatchReadFiles.mockResolvedValueOnce(map);
+		const storage = new OrphanBranchStorage("/tmp/repo");
+
+		const result = await storage.batchReadFiles(["summaries/a.json", "summaries/b.json"]);
+
+		expect(result).toBe(map);
+		expect(mockedBatchReadFiles).toHaveBeenCalledWith(
+			ORPHAN_BRANCH,
+			["summaries/a.json", "summaries/b.json"],
+			"/tmp/repo",
+		);
 	});
 
 	it("writeFiles calls ensure before writing", async () => {

--- a/cli/src/core/OrphanBranchStorage.ts
+++ b/cli/src/core/OrphanBranchStorage.ts
@@ -1,6 +1,7 @@
 import { ORPHAN_BRANCH } from "../Logger.js";
 import type { FileWrite } from "../Types.js";
 import {
+	batchReadFilesFromBranch,
 	ensureOrphanBranch,
 	listFilesInBranch,
 	orphanBranchExists,
@@ -14,6 +15,10 @@ export class OrphanBranchStorage implements StorageProvider {
 
 	async readFile(path: string): Promise<string | null> {
 		return readFileFromBranch(ORPHAN_BRANCH, path, this.cwd);
+	}
+
+	async batchReadFiles(paths: ReadonlyArray<string>): Promise<Map<string, string | null>> {
+		return batchReadFilesFromBranch(ORPHAN_BRANCH, paths, this.cwd);
 	}
 
 	async writeFiles(files: FileWrite[], message: string): Promise<void> {

--- a/cli/src/core/RegenerateContext.ts
+++ b/cli/src/core/RegenerateContext.ts
@@ -1,7 +1,7 @@
 import type { CommitSummary } from "../Types.js";
 import type { StorageProvider } from "./StorageProvider.js";
 import { normalizeToV4, readTranscriptsForCommits } from "./SummaryStore.js";
-import { collectAllTranscriptHashes } from "./SummaryTree.js";
+import { getTranscriptIds } from "./SummaryTree.js";
 import { transcriptSourceLabel } from "./TranscriptSourceLabel.js";
 
 /**
@@ -42,12 +42,14 @@ export async function loadRegenerateContext(
 	storage?: StorageProvider,
 ): Promise<RegenerateContext> {
 	const normalized = normalizeToV4(summary);
-	const treeHashes = collectAllTranscriptHashes(normalized);
+	// v5 schema: getTranscriptIds returns summary.transcripts when present,
+	// else falls back to children-tree walk for v3/v4 legacy data.
+	const transcriptIds = getTranscriptIds(normalized);
 	// `storage` is threaded so folder-only Memory Bank users read transcripts
 	// from FolderStorage instead of the OrphanBranchStorage fallback in
 	// resolveStorage — otherwise the confirm dialog would report 0 transcript
 	// entries even when the user can see them in the All Conversations card.
-	const transcriptMap = await readTranscriptsForCommits(treeHashes, cwd, storage);
+	const transcriptMap = await readTranscriptsForCommits(transcriptIds, cwd, storage);
 
 	let entryCount = 0;
 	let humanTurns = 0;

--- a/cli/src/core/Regenerator.ts
+++ b/cli/src/core/Regenerator.ts
@@ -12,7 +12,7 @@ import {
 	readPlanFromBranch,
 	readTranscriptsForCommits,
 } from "./SummaryStore.js";
-import { collectAllTranscriptHashes } from "./SummaryTree.js";
+import { getTranscriptIds } from "./SummaryTree.js";
 import { buildMultiSessionContext, type SessionTranscript } from "./TranscriptReader.js";
 
 const log = createLogger("Regenerator");
@@ -84,8 +84,12 @@ export async function regenerateSummary(
 	// Bank users read from FolderStorage instead of the OrphanBranchStorage
 	// fallback in resolveStorage — without it the LLM would see an empty
 	// conversation on every regenerate in folder-only mode.
-	const treeHashes = collectAllTranscriptHashes(normalized);
-	const transcriptMap = await readTranscriptsForCommits(treeHashes, cwd, storage);
+	//
+	// v5 schema: `getTranscriptIds` returns `summary.transcripts` (the v5
+	// authoritative ID array) when present, else falls back to walking
+	// children for v3/v4 data — both forms read correctly.
+	const transcriptIds = getTranscriptIds(normalized);
+	const transcriptMap = await readTranscriptsForCommits(transcriptIds, cwd, storage);
 	const sessions: SessionTranscript[] = [];
 	for (const stored of transcriptMap.values()) {
 		for (const s of stored.sessions) {

--- a/cli/src/core/SchemaV5Migration.test.ts
+++ b/cli/src/core/SchemaV5Migration.test.ts
@@ -1,0 +1,458 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("./GitOps.js", () => ({
+	readFileFromBranch: vi.fn(),
+	// Bulk read of summary contents during migration. Tests feed per-path
+	// content via `Map`-shaped return values; the default empty Map is a safe
+	// fallback for tests that mock listFilesInBranch with no summaries.
+	batchReadFilesFromBranch: vi.fn().mockResolvedValue(new Map()),
+	listFilesInBranch: vi.fn(),
+	// Migration entry guard: default to "branch exists" so existing tests
+	// that exercise the happy path don't need to set this. The fresh-install
+	// case (no orphan branch yet) overrides this per-test.
+	orphanBranchExists: vi.fn().mockResolvedValue(true),
+	// Pre-migration SHA capture for debug-log recovery anchor (Feedback 2).
+	// Tests don't assert on this — a benign stub is enough.
+	execGit: vi.fn().mockResolvedValue({ stdout: "deadbeef0000000000000000000000000000beef\n", stderr: "" }),
+}));
+
+// Mock the StorageFactory so migration writes are observed via a single
+// `writeFiles` spy. In production this returns a DualWriteStorage that fans
+// out to both the orphan branch and the Memory Bank folder; here we just
+// capture the call args so tests can assert on what would have been written.
+const { mockStorageWriteFiles } = vi.hoisted(() => ({
+	mockStorageWriteFiles: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("./StorageFactory.js", () => ({
+	createStorage: vi.fn().mockResolvedValue({
+		writeFiles: mockStorageWriteFiles,
+	}),
+}));
+
+vi.mock("./Locks.js", () => ({
+	acquireOrphanWriteLock: vi.fn().mockResolvedValue(true),
+	releaseOrphanWriteLock: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.spyOn(console, "log").mockImplementation(() => {});
+vi.spyOn(console, "warn").mockImplementation(() => {});
+vi.spyOn(console, "error").mockImplementation(() => {});
+
+import type { CommitSummary, FileWrite } from "../Types.js";
+import { batchReadFilesFromBranch, listFilesInBranch, orphanBranchExists, readFileFromBranch } from "./GitOps.js";
+import { __test__, migrateSchemaToV5, readSchemaV5State } from "./SchemaV5Migration.js";
+
+const baseNode = {
+	commitHash: "abc1234567890",
+	commitMessage: "x",
+	commitAuthor: "tester",
+	commitDate: "2026-05-21T00:00:00Z",
+	branch: "main",
+	generatedAt: "2026-05-21T00:01:00Z",
+} as const;
+
+describe("SchemaV5Migration", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	// ─── upgradeOneSummary (pure unit) ────────────────────────────────────────
+	describe("upgradeOneSummary", () => {
+		it("returns the input reference unchanged for v5 input (idempotent)", () => {
+			const v5: CommitSummary = {
+				...baseNode,
+				version: 5,
+				topics: [],
+				transcripts: ["uuid-1"],
+			} as CommitSummary;
+			expect(__test__.upgradeOneSummary(v5, new Set(["uuid-1"]))).toBe(v5);
+		});
+
+		it("upgrades v4 leaf to v5 with transcripts populated when file exists", () => {
+			const v4: CommitSummary = {
+				...baseNode,
+				version: 4,
+				topics: [],
+			} as CommitSummary;
+			const upgraded = __test__.upgradeOneSummary(v4, new Set([baseNode.commitHash]));
+			expect(upgraded.version).toBe(5);
+			expect(upgraded.transcripts).toEqual([baseNode.commitHash]);
+		});
+
+		it("upgrades v4 leaf to v5 with empty transcripts array when no file exists for the hash", () => {
+			// v5 contract: `transcripts` is ALWAYS present on a v5 root, even if
+			// the migration found no matching files. Empty array is the right
+			// signal for "no AI sessions captured" — distinct from "undefined"
+			// which the read path treats as v3/v4 fallback territory.
+			const v4: CommitSummary = {
+				...baseNode,
+				version: 4,
+				topics: [],
+			} as CommitSummary;
+			const upgraded = __test__.upgradeOneSummary(v4, new Set([]));
+			expect(upgraded.version).toBe(5);
+			expect(upgraded.transcripts).toEqual([]);
+		});
+
+		it("idempotently preserves an existing v4 root's transcripts array (v5-aware writer pre-migration)", () => {
+			// Critical data-loss regression guard: post-Step-3, the live write
+			// paths stamp `version: 5 + transcripts: [uuid-1, uuid-2]` on new
+			// roots, but if `migrateSchemaToV5` runs against a project where
+			// a (rare) v4 root still carries a v5-shaped transcripts array
+			// (e.g. a stale file from a partial earlier rollout), the upgrade
+			// must NOT recompute `transcripts` via `collectAllTranscriptHashes`
+			// — that would silently replace the UUID list with children commit
+			// hashes (and the file-existence filter then drops them all,
+			// yielding an empty transcripts array). Preserve verbatim.
+			const v4WithV5Transcripts: CommitSummary = {
+				...baseNode,
+				version: 4,
+				topics: [],
+				transcripts: ["uuid-1", "uuid-2"],
+			} as CommitSummary;
+			const upgraded = __test__.upgradeOneSummary(
+				v4WithV5Transcripts,
+				// Pretend the UUID files don't exist on disk — verifies we don't
+				// run them through the existence filter at all.
+				new Set([baseNode.commitHash]),
+			);
+			expect(upgraded.version).toBe(5);
+			expect(upgraded.transcripts).toEqual(["uuid-1", "uuid-2"]);
+		});
+
+		it("upgrades v3 squash root to v5 with topics preserved and transcripts from children", () => {
+			// Lossless normalize semantics: v3 squash root's topics live on
+			// children, normalizeToV4 hoists them; this migration carries them
+			// through to v5 without an LLM call.
+			const v3Squash: CommitSummary = {
+				...baseNode,
+				version: 3,
+				topics: [],
+				children: [
+					{
+						...baseNode,
+						commitHash: "child-1",
+						version: 3,
+						topics: [{ title: "Topic 1", trigger: "t", response: "r", decisions: "d" }],
+					} as CommitSummary,
+					{
+						...baseNode,
+						commitHash: "child-2",
+						version: 3,
+						topics: [{ title: "Topic 2", trigger: "t", response: "r", decisions: "d" }],
+					} as CommitSummary,
+				],
+			} as CommitSummary;
+			const upgraded = __test__.upgradeOneSummary(v3Squash, new Set([baseNode.commitHash, "child-1", "child-2"]));
+			expect(upgraded.version).toBe(5);
+			expect(upgraded.topics).toHaveLength(2);
+			expect(upgraded.transcripts).toEqual([baseNode.commitHash, "child-1", "child-2"]);
+		});
+
+		it("filters out hashes that have no transcript file on disk", () => {
+			// Common case: a commit had no AI session so no transcript was ever
+			// written for that hash. The migration must NOT list it in transcripts
+			// or the read path will get null and surface "missing transcript".
+			const v4Squash: CommitSummary = {
+				...baseNode,
+				version: 4,
+				topics: [],
+				children: [
+					{ ...baseNode, commitHash: "has-file", version: 4 } as CommitSummary,
+					{ ...baseNode, commitHash: "no-file", version: 4 } as CommitSummary,
+				],
+			} as CommitSummary;
+			const upgraded = __test__.upgradeOneSummary(v4Squash, new Set(["has-file"]));
+			expect(upgraded.transcripts).toEqual(["has-file"]);
+		});
+
+		it("migrates v3 legacy `stats` to `diffStats` via normalizeToV4", () => {
+			const v3WithStats: CommitSummary = {
+				...baseNode,
+				version: 3,
+				stats: { filesChanged: 4, insertions: 8, deletions: 1 },
+			} as CommitSummary;
+			const upgraded = __test__.upgradeOneSummary(v3WithStats, new Set([baseNode.commitHash]));
+			expect(upgraded.diffStats).toEqual({ filesChanged: 4, insertions: 8, deletions: 1 });
+		});
+	});
+
+	// ─── migrateSchemaToV5 (integration with GitOps mocks) ────────────────────
+	describe("migrateSchemaToV5 (integration)", () => {
+		it("returns a no-op fresh result when the orphan branch does not exist yet", async () => {
+			// Fresh install: no jollimemory data, no orphan branch. Migration
+			// must not create the branch as a side effect.
+			vi.mocked(orphanBranchExists).mockResolvedValueOnce(false);
+			vi.mocked(readFileFromBranch).mockResolvedValueOnce(null); // state read
+
+			const result = await migrateSchemaToV5();
+
+			expect(result.fresh).toBe(true);
+			expect(result.alreadyDone).toBe(false);
+			expect(result.migrated).toBe(0);
+			expect(mockStorageWriteFiles).not.toHaveBeenCalled();
+			expect(listFilesInBranch).not.toHaveBeenCalled();
+		});
+
+		it("writes a fresh-install state when the orphan branch has no summaries", async () => {
+			vi.mocked(readFileFromBranch).mockResolvedValue(null); // state, index reads
+			vi.mocked(listFilesInBranch)
+				.mockResolvedValueOnce([]) // summaries/
+				.mockResolvedValueOnce([]); // transcripts/
+
+			const result = await migrateSchemaToV5();
+
+			expect(result.fresh).toBe(true);
+			expect(result.alreadyDone).toBe(false);
+			expect(result.migrated).toBe(0);
+
+			const writeCall = mockStorageWriteFiles.mock.calls[0];
+			expect(writeCall).toBeDefined();
+			const files = writeCall?.[0] as ReadonlyArray<FileWrite>;
+			expect(files).toHaveLength(1);
+			expect(files[0]?.path).toBe(__test__.SCHEMA_V5_STATE_FILE);
+			const state = JSON.parse(files[0]?.content ?? "{}");
+			expect(state.status).toBe("completed");
+			expect(state.fresh).toBe(true);
+		});
+
+		it("skips when state already shows completed", async () => {
+			vi.mocked(readFileFromBranch).mockResolvedValueOnce(
+				JSON.stringify({
+					version: 1,
+					status: "completed",
+					startedAt: "2026-05-22T00:00:00Z",
+					completedAt: "2026-05-22T00:00:05Z",
+					migratedCount: 3,
+					skippedCount: 1,
+					fresh: false,
+				}),
+			);
+
+			const result = await migrateSchemaToV5();
+
+			expect(result.alreadyDone).toBe(true);
+			expect(result.migrated).toBe(3);
+			expect(result.skipped).toBe(1);
+			expect(mockStorageWriteFiles).not.toHaveBeenCalled();
+		});
+
+		it("upgrades v3 and v4 summaries to v5 in one atomic commit", async () => {
+			const v3: CommitSummary = {
+				...baseNode,
+				commitHash: "v3-hash",
+				version: 3,
+				topics: [{ title: "T1", trigger: "t", response: "r", decisions: "d" }],
+			} as CommitSummary;
+			const v4: CommitSummary = {
+				...baseNode,
+				commitHash: "v4-hash",
+				version: 4,
+				topics: [{ title: "T2", trigger: "t", response: "r", decisions: "d" }],
+			} as CommitSummary;
+
+			vi.mocked(readFileFromBranch).mockResolvedValueOnce(null); // state read (readSchemaV5State)
+			vi.mocked(listFilesInBranch)
+				.mockResolvedValueOnce(["summaries/v3-hash.json", "summaries/v4-hash.json"])
+				.mockResolvedValueOnce(["transcripts/v3-hash.json", "transcripts/v4-hash.json"]);
+			// Summary contents now flow through the batched cat-file reader,
+			// not per-file readFileFromBranch. One mock call serves all paths
+			// for the migration's read phase.
+			vi.mocked(batchReadFilesFromBranch).mockResolvedValueOnce(
+				new Map([
+					["summaries/v3-hash.json", JSON.stringify(v3)],
+					["summaries/v4-hash.json", JSON.stringify(v4)],
+				]),
+			);
+
+			const result = await migrateSchemaToV5();
+
+			expect(result.migrated).toBe(2);
+			expect(result.skipped).toBe(0);
+			expect(result.fresh).toBe(false);
+
+			const files = mockStorageWriteFiles.mock.calls[0]?.[0] as ReadonlyArray<FileWrite>;
+			expect(files.length).toBe(3); // 2 summaries + 1 state file
+			// All summaries are written at version=5.
+			const summaryFiles = files.filter((f) => f.path.startsWith("summaries/"));
+			for (const f of summaryFiles) {
+				const parsed = JSON.parse(f.content);
+				expect(parsed.version).toBe(5);
+				expect(parsed.transcripts).toBeDefined();
+			}
+		});
+
+		it("skips v5 summaries already present without rewriting them", async () => {
+			const v5Already: CommitSummary = {
+				...baseNode,
+				commitHash: "v5-hash",
+				version: 5,
+				topics: [],
+				transcripts: ["uuid-existing"],
+			} as CommitSummary;
+
+			vi.mocked(readFileFromBranch).mockResolvedValueOnce(null); // state read
+			vi.mocked(listFilesInBranch)
+				.mockResolvedValueOnce(["summaries/v5-hash.json"])
+				.mockResolvedValueOnce(["transcripts/uuid-existing.json"]);
+			vi.mocked(batchReadFilesFromBranch).mockResolvedValueOnce(
+				new Map([["summaries/v5-hash.json", JSON.stringify(v5Already)]]),
+			);
+
+			const result = await migrateSchemaToV5();
+
+			expect(result.skipped).toBe(1);
+			expect(result.migrated).toBe(0);
+
+			const files = mockStorageWriteFiles.mock.calls[0]?.[0] as ReadonlyArray<FileWrite>;
+			// Only the state file should be written — the v5 summary is untouched.
+			expect(files.length).toBe(1);
+			expect(files[0]?.path).toBe(__test__.SCHEMA_V5_STATE_FILE);
+		});
+
+		it("routes the migration write through createStorage so dual-write fans out to orphan + shadow", async () => {
+			// Regression guard for the v4-stuck-in-shadow bug: the earlier
+			// implementation called `writeMultipleFilesToBranch` directly, so
+			// dual-write users saw the orphan branch upgraded to v5 while the
+			// `<localFolder>/<repo>/.jolli/summaries/*.json` shadow files kept
+			// `"version": 4` until normal post-commit traffic eventually
+			// rewrote each one. Routing through `createStorage()` gives the
+			// active `StorageProvider` (DualWriteStorage in dual-write mode) a
+			// chance to fan the v5 payload out to both backends in one pass.
+			const { createStorage } = await import("./StorageFactory.js");
+
+			const v4: CommitSummary = {
+				...baseNode,
+				commitHash: "shadow-hash",
+				version: 4,
+				topics: [],
+			} as CommitSummary;
+			vi.mocked(readFileFromBranch).mockResolvedValueOnce(null); // state
+			vi.mocked(listFilesInBranch)
+				.mockResolvedValueOnce(["summaries/shadow-hash.json"])
+				.mockResolvedValueOnce([]);
+			vi.mocked(batchReadFilesFromBranch).mockResolvedValueOnce(
+				new Map([["summaries/shadow-hash.json", JSON.stringify(v4)]]),
+			);
+
+			await migrateSchemaToV5();
+
+			expect(createStorage).toHaveBeenCalledTimes(1);
+			expect(mockStorageWriteFiles).toHaveBeenCalledTimes(1);
+			const writtenFiles = mockStorageWriteFiles.mock.calls[0]?.[0] as ReadonlyArray<FileWrite>;
+			// 1 upgraded summary + 1 state file. The summary content is v5 so a
+			// dual-write storage will write `"version": 5` to BOTH backends —
+			// the bug we're guarding against was the shadow being skipped here.
+			expect(writtenFiles).toHaveLength(2);
+			const summaryFile = writtenFiles.find((f) => f.path.startsWith("summaries/"));
+			expect(summaryFile).toBeDefined();
+			const parsed = JSON.parse(summaryFile?.content ?? "{}");
+			expect(parsed.version).toBe(5);
+		});
+
+		it("tolerates unparseable summary files by skipping them", async () => {
+			vi.mocked(readFileFromBranch).mockResolvedValueOnce(null); // state read
+			vi.mocked(listFilesInBranch).mockResolvedValueOnce(["summaries/bad.json"]).mockResolvedValueOnce([]);
+			vi.mocked(batchReadFilesFromBranch).mockResolvedValueOnce(
+				new Map([["summaries/bad.json", "not valid json {"]]),
+			);
+
+			const result = await migrateSchemaToV5();
+
+			expect(result.skipped).toBe(1);
+			expect(result.migrated).toBe(0);
+			// Migration still completes — the state file is written.
+			expect(mockStorageWriteFiles).toHaveBeenCalledOnce();
+		});
+
+		it("throws when the orphan-write lock cannot be acquired within the timeout", async () => {
+			// `withMigrationLock` short-circuits on lock acquisition failure
+			// (covers the defensive throw branch in withMigrationLock). The
+			// caller is expected to log + retry on next startup — see
+			// `Extension.ts activate` and `Installer.install`.
+			const locksMod = await import("./Locks.js");
+			vi.mocked(locksMod.acquireOrphanWriteLock).mockResolvedValueOnce(false);
+			vi.mocked(readFileFromBranch).mockResolvedValueOnce(null); // state read
+
+			await expect(migrateSchemaToV5()).rejects.toThrow(/orphan-write lock/);
+			expect(mockStorageWriteFiles).not.toHaveBeenCalled();
+		});
+
+		it("tolerates execGit rejection when capturing pre-migration SHA (recovery log is best-effort)", async () => {
+			// Pre-migration SHA capture is a debug-log convenience, not a
+			// correctness gate. If the rev-parse call fails (e.g. on a fresh
+			// orphan branch that hasn't been committed to yet, or in a CI
+			// sandbox where git is unavailable), the migration still completes.
+			const gitops = await import("./GitOps.js");
+			vi.mocked(gitops.execGit).mockRejectedValueOnce(new Error("git not found"));
+			vi.mocked(readFileFromBranch).mockResolvedValueOnce(null); // state
+			vi.mocked(listFilesInBranch)
+				.mockResolvedValueOnce([]) // summaries
+				.mockResolvedValueOnce([]); // transcripts
+
+			const result = await migrateSchemaToV5();
+			expect(result.fresh).toBe(true);
+			expect(mockStorageWriteFiles).toHaveBeenCalledOnce();
+		});
+
+		it("skips summary files whose batched read returned null (transient git read failure)", async () => {
+			// Covers the `content === null` early-continue branch — cat-file's
+			// batch reader maps an entry to null when the path resolved to
+			// `missing` at read time (e.g. a concurrent orphan-write committed
+			// a deletion between listFilesInBranch and the batch read).
+			vi.mocked(readFileFromBranch).mockResolvedValueOnce(null); // state
+			vi.mocked(listFilesInBranch).mockResolvedValueOnce(["summaries/vanished.json"]).mockResolvedValueOnce([]);
+			vi.mocked(batchReadFilesFromBranch).mockResolvedValueOnce(new Map([["summaries/vanished.json", null]]));
+
+			const result = await migrateSchemaToV5();
+
+			expect(result.skipped).toBe(1);
+			expect(result.migrated).toBe(0);
+			expect(mockStorageWriteFiles).toHaveBeenCalledOnce();
+		});
+
+		it("throws when the batched read omits a requested path (contract violation, not transient race)", async () => {
+			// `null` and `undefined` look identical to a casual read but have
+			// very different causes: `null` is a benign race (file vanished),
+			// `undefined` is a bug in the batch reader (it must populate one
+			// entry per request). The migration code MUST surface the latter
+			// — without this guard a future regression in
+			// `batchReadFilesFromBranch` that silently drops entries would
+			// be invisible (migrated count would just be lower than expected).
+			vi.mocked(readFileFromBranch).mockResolvedValueOnce(null); // state
+			vi.mocked(listFilesInBranch).mockResolvedValueOnce(["summaries/dropped.json"]).mockResolvedValueOnce([]);
+			// Empty Map → `contents.get("summaries/dropped.json")` returns undefined.
+			vi.mocked(batchReadFilesFromBranch).mockResolvedValueOnce(new Map());
+
+			await expect(migrateSchemaToV5()).rejects.toThrow(/protocol contract violation/);
+			expect(mockStorageWriteFiles).not.toHaveBeenCalled();
+		});
+	});
+
+	// ─── readSchemaV5State ────────────────────────────────────────────────────
+	describe("readSchemaV5State", () => {
+		it("returns null when state file is absent", async () => {
+			vi.mocked(readFileFromBranch).mockResolvedValueOnce(null);
+			expect(await readSchemaV5State()).toBeNull();
+		});
+
+		it("returns the parsed state when file is present", async () => {
+			const state = {
+				version: 1,
+				status: "completed",
+				startedAt: "2026-05-22T00:00:00Z",
+				completedAt: "2026-05-22T00:00:05Z",
+				migratedCount: 0,
+				skippedCount: 0,
+				fresh: true,
+			};
+			vi.mocked(readFileFromBranch).mockResolvedValueOnce(JSON.stringify(state));
+			expect(await readSchemaV5State()).toEqual(state);
+		});
+
+		it("returns null when state file is unparseable", async () => {
+			vi.mocked(readFileFromBranch).mockResolvedValueOnce("not json");
+			expect(await readSchemaV5State()).toBeNull();
+		});
+	});
+});

--- a/cli/src/core/SchemaV5Migration.test.ts
+++ b/cli/src/core/SchemaV5Migration.test.ts
@@ -1,31 +1,44 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("./GitOps.js", () => ({
-	readFileFromBranch: vi.fn(),
-	// Bulk read of summary contents during migration. Tests feed per-path
-	// content via `Map`-shaped return values; the default empty Map is a safe
-	// fallback for tests that mock listFilesInBranch with no summaries.
-	batchReadFilesFromBranch: vi.fn().mockResolvedValue(new Map()),
-	listFilesInBranch: vi.fn(),
-	// Migration entry guard: default to "branch exists" so existing tests
-	// that exercise the happy path don't need to set this. The fresh-install
-	// case (no orphan branch yet) overrides this per-test.
-	orphanBranchExists: vi.fn().mockResolvedValue(true),
-	// Pre-migration SHA capture for debug-log recovery anchor (Feedback 2).
-	// Tests don't assert on this — a benign stub is enough.
+	// Pre-migration SHA capture for debug-log recovery anchor. Tests don't
+	// assert on this — a benign stub is enough. The migration's reads now go
+	// through the StorageProvider (mocked below), not GitOps directly.
 	execGit: vi.fn().mockResolvedValue({ stdout: "deadbeef0000000000000000000000000000beef\n", stderr: "" }),
 }));
 
-// Mock the StorageFactory so migration writes are observed via a single
-// `writeFiles` spy. In production this returns a DualWriteStorage that fans
-// out to both the orphan branch and the Memory Bank folder; here we just
-// capture the call args so tests can assert on what would have been written.
-const { mockStorageWriteFiles } = vi.hoisted(() => ({
+// Mock the StorageFactory so the migration's reads AND writes are observed via
+// a single fake StorageProvider. In production `createStorage` returns the
+// active backend (DualWriteStorage by default); here every primitive is a spy
+// so tests can drive `exists`/`listFiles`/`batchReadFiles`/`readFile` and
+// assert on the captured `writeFiles` args. Defaults are the happy-path
+// values (backend exists, empty listings, null state) so each test only
+// overrides what it exercises.
+const {
+	mockStorageWriteFiles,
+	mockStorageExists,
+	mockStorageListFiles,
+	mockStorageReadFile,
+	mockStorageBatchReadFiles,
+	mockStorageIsDirty,
+} = vi.hoisted(() => ({
 	mockStorageWriteFiles: vi.fn().mockResolvedValue(undefined),
+	mockStorageExists: vi.fn().mockResolvedValue(true),
+	mockStorageListFiles: vi.fn().mockResolvedValue([]),
+	mockStorageReadFile: vi.fn().mockResolvedValue(null),
+	mockStorageBatchReadFiles: vi.fn().mockResolvedValue(new Map()),
+	// Shadow clean by default → migration stamps `completed`. The shadow-failure
+	// test flips this to true to assert the migration stays pending.
+	mockStorageIsDirty: vi.fn().mockReturnValue(false),
 }));
 vi.mock("./StorageFactory.js", () => ({
 	createStorage: vi.fn().mockResolvedValue({
 		writeFiles: mockStorageWriteFiles,
+		exists: mockStorageExists,
+		listFiles: mockStorageListFiles,
+		readFile: mockStorageReadFile,
+		batchReadFiles: mockStorageBatchReadFiles,
+		isDirty: mockStorageIsDirty,
 	}),
 }));
 
@@ -39,7 +52,6 @@ vi.spyOn(console, "warn").mockImplementation(() => {});
 vi.spyOn(console, "error").mockImplementation(() => {});
 
 import type { CommitSummary, FileWrite } from "../Types.js";
-import { batchReadFilesFromBranch, listFilesInBranch, orphanBranchExists, readFileFromBranch } from "./GitOps.js";
 import { __test__, migrateSchemaToV5, readSchemaV5State } from "./SchemaV5Migration.js";
 
 const baseNode = {
@@ -66,6 +78,22 @@ describe("SchemaV5Migration", () => {
 				transcripts: ["uuid-1"],
 			} as CommitSummary;
 			expect(__test__.upgradeOneSummary(v5, new Set(["uuid-1"]))).toBe(v5);
+		});
+
+		it("repairs a version-5 record that is MISSING the transcripts field (not treated as migrated)", () => {
+			// Anomalous record (bug / hand-edit): version 5 but no `transcripts`.
+			// The fast-path must NOT return it as-is — left alone it forces the
+			// read path down the v3/v4 children-walk fallback forever. Falling
+			// through computes the array like any pre-v5 root.
+			const v5NoTranscripts: CommitSummary = {
+				...baseNode,
+				version: 5,
+				topics: [],
+			} as CommitSummary;
+			const upgraded = __test__.upgradeOneSummary(v5NoTranscripts, new Set([baseNode.commitHash]));
+			expect(upgraded).not.toBe(v5NoTranscripts); // repaired, not returned verbatim
+			expect(upgraded.version).toBe(5);
+			expect(upgraded.transcripts).toEqual([baseNode.commitHash]);
 		});
 
 		it("upgrades v4 leaf to v5 with transcripts populated when file exists", () => {
@@ -174,16 +202,44 @@ describe("SchemaV5Migration", () => {
 			} as CommitSummary;
 			const upgraded = __test__.upgradeOneSummary(v3WithStats, new Set([baseNode.commitHash]));
 			expect(upgraded.diffStats).toEqual({ filesChanged: 4, insertions: 8, deletions: 1 });
+			// The legacy `stats` field is STRIPPED, not carried alongside
+			// `diffStats` — otherwise the read-time stats→diffStats fallback could
+			// never be removed (a v5 record carrying both is the anti-pattern).
+			expect(upgraded.stats).toBeUndefined();
+		});
+
+		it("stamps the AGGREGATE diffStats for a v3 container (amend root), not the raw root delta", async () => {
+			// An amend root's own `stats` is just the delta; pre-v5 the display
+			// went through resolveDiffStats → aggregateStats (delta + children).
+			// Migration must stamp that aggregate, else the v5 fast-path returns
+			// the raw delta and the displayed diff silently shrinks.
+			const v3AmendRoot: CommitSummary = {
+				...baseNode,
+				version: 3,
+				// root (amend) delta
+				stats: { filesChanged: 1, insertions: 2, deletions: 0 },
+				children: [
+					{
+						...baseNode,
+						commitHash: "child-pre-amend",
+						version: 3,
+						stats: { filesChanged: 3, insertions: 10, deletions: 4 },
+					} as CommitSummary,
+				],
+			} as CommitSummary;
+			const upgraded = __test__.upgradeOneSummary(v3AmendRoot, new Set([baseNode.commitHash]));
+			// delta (1/2/0) + child (3/10/4) = 4/12/4, NOT the raw 1/2/0.
+			expect(upgraded.diffStats).toEqual({ filesChanged: 4, insertions: 12, deletions: 4 });
+			expect(upgraded.stats).toBeUndefined();
 		});
 	});
 
-	// ─── migrateSchemaToV5 (integration with GitOps mocks) ────────────────────
+	// ─── migrateSchemaToV5 (integration with StorageProvider mocks) ───────────
 	describe("migrateSchemaToV5 (integration)", () => {
-		it("returns a no-op fresh result when the orphan branch does not exist yet", async () => {
-			// Fresh install: no jollimemory data, no orphan branch. Migration
-			// must not create the branch as a side effect.
-			vi.mocked(orphanBranchExists).mockResolvedValueOnce(false);
-			vi.mocked(readFileFromBranch).mockResolvedValueOnce(null); // state read
+		it("returns a no-op fresh result when the storage backend does not exist yet", async () => {
+			// Fresh install: no jollimemory data, no orphan branch / no Memory
+			// Bank folder. Migration must not create the backend as a side effect.
+			mockStorageExists.mockResolvedValueOnce(false);
 
 			const result = await migrateSchemaToV5();
 
@@ -191,12 +247,51 @@ describe("SchemaV5Migration", () => {
 			expect(result.alreadyDone).toBe(false);
 			expect(result.migrated).toBe(0);
 			expect(mockStorageWriteFiles).not.toHaveBeenCalled();
-			expect(listFilesInBranch).not.toHaveBeenCalled();
+			expect(mockStorageListFiles).not.toHaveBeenCalled();
 		});
 
-		it("writes a fresh-install state when the orphan branch has no summaries", async () => {
-			vi.mocked(readFileFromBranch).mockResolvedValue(null); // state, index reads
-			vi.mocked(listFilesInBranch)
+		it("migrates folder-only data: reads via readFile when batchReadFiles is absent", async () => {
+			// folder-only regression guard: FolderStorage exposes no
+			// `batchReadFiles`, so the migration must fall back to per-file
+			// `readFile`. Previously folder-only repos were skipped entirely
+			// (orphan-branch gate) and never reached v5.
+			const v4: CommitSummary = {
+				...baseNode,
+				commitHash: "folder-hash",
+				version: 4,
+				topics: [],
+			} as CommitSummary;
+			const { createStorage } = await import("./StorageFactory.js");
+			// A folder-style provider: exists/listFiles/readFile/writeFiles but
+			// NO batchReadFiles capability.
+			const folderReadFile = vi.fn(async (path: string) =>
+				path === "summaries/folder-hash.json" ? JSON.stringify(v4) : null,
+			);
+			vi.mocked(createStorage).mockResolvedValueOnce({
+				exists: vi.fn().mockResolvedValue(true),
+				listFiles: vi
+					.fn()
+					.mockResolvedValueOnce(["summaries/folder-hash.json"])
+					.mockResolvedValueOnce(["transcripts/folder-hash.json"]),
+				readFile: folderReadFile,
+				writeFiles: mockStorageWriteFiles,
+				// batchReadFiles intentionally omitted.
+			} as never);
+
+			const result = await migrateSchemaToV5();
+
+			expect(result.migrated).toBe(1);
+			expect(result.fresh).toBe(false);
+			// Per-file fallback was used for the summary read (state reads also
+			// go through readFile, so just assert the summary path was read).
+			expect(folderReadFile).toHaveBeenCalledWith("summaries/folder-hash.json");
+			const files = mockStorageWriteFiles.mock.calls[0]?.[0] as ReadonlyArray<FileWrite>;
+			const summaryFile = files.find((f) => f.path.startsWith("summaries/"));
+			expect(JSON.parse(summaryFile?.content ?? "{}").version).toBe(5);
+		});
+
+		it("writes a fresh-install state when the backend has no summaries", async () => {
+			mockStorageListFiles
 				.mockResolvedValueOnce([]) // summaries/
 				.mockResolvedValueOnce([]); // transcripts/
 
@@ -217,7 +312,7 @@ describe("SchemaV5Migration", () => {
 		});
 
 		it("skips when state already shows completed", async () => {
-			vi.mocked(readFileFromBranch).mockResolvedValueOnce(
+			mockStorageReadFile.mockResolvedValueOnce(
 				JSON.stringify({
 					version: 1,
 					status: "completed",
@@ -237,7 +332,37 @@ describe("SchemaV5Migration", () => {
 			expect(mockStorageWriteFiles).not.toHaveBeenCalled();
 		});
 
-		it("upgrades v3 and v4 summaries to v5 in one atomic commit", async () => {
+		it("skips (no rescan) when a concurrent run completed between the outer check and the lock", async () => {
+			// #6 idempotency guard: the state check in migrateSchemaToV5 is
+			// outside the lock. The first readFile (outer check) returns null
+			// (pending), but by the time we hold the lock another process has
+			// written "completed". The in-lock re-check must short-circuit so we
+			// don't rescan and overwrite the state with migratedCount:0.
+			mockStorageReadFile
+				.mockResolvedValueOnce(null) // outer check: still pending
+				.mockResolvedValueOnce(
+					JSON.stringify({
+						version: 1,
+						status: "completed",
+						startedAt: "2026-05-22T00:00:00Z",
+						completedAt: "2026-05-22T00:00:09Z",
+						migratedCount: 7,
+						skippedCount: 2,
+						fresh: false,
+					}),
+				); // in-lock re-check: a concurrent run finished
+
+			const result = await migrateSchemaToV5();
+
+			expect(result.alreadyDone).toBe(true);
+			expect(result.migrated).toBe(7);
+			expect(result.skipped).toBe(2);
+			// No rescan, no overwrite of the completed state.
+			expect(mockStorageListFiles).not.toHaveBeenCalled();
+			expect(mockStorageWriteFiles).not.toHaveBeenCalled();
+		});
+
+		it("upgrades v3 and v4 summaries to v5 in one atomic write", async () => {
 			const v3: CommitSummary = {
 				...baseNode,
 				commitHash: "v3-hash",
@@ -251,14 +376,19 @@ describe("SchemaV5Migration", () => {
 				topics: [{ title: "T2", trigger: "t", response: "r", decisions: "d" }],
 			} as CommitSummary;
 
-			vi.mocked(readFileFromBranch).mockResolvedValueOnce(null); // state read (readSchemaV5State)
-			vi.mocked(listFilesInBranch)
+			mockStorageListFiles
 				.mockResolvedValueOnce(["summaries/v3-hash.json", "summaries/v4-hash.json"])
-				.mockResolvedValueOnce(["transcripts/v3-hash.json", "transcripts/v4-hash.json"]);
-			// Summary contents now flow through the batched cat-file reader,
-			// not per-file readFileFromBranch. One mock call serves all paths
-			// for the migration's read phase.
-			vi.mocked(batchReadFilesFromBranch).mockResolvedValueOnce(
+				// The stray non-`.json` entry exercises the `match?.[1]` falsy
+				// guard — `listFiles("transcripts/")` can surface paths that don't
+				// match the `transcripts/<id>.json` shape; those must be ignored.
+				.mockResolvedValueOnce([
+					"transcripts/v3-hash.json",
+					"transcripts/v4-hash.json",
+					"transcripts/stray.txt",
+				]);
+			// Summary contents flow through the storage batch reader. One mock
+			// call serves all paths for the migration's read phase.
+			mockStorageBatchReadFiles.mockResolvedValueOnce(
 				new Map([
 					["summaries/v3-hash.json", JSON.stringify(v3)],
 					["summaries/v4-hash.json", JSON.stringify(v4)],
@@ -271,18 +401,30 @@ describe("SchemaV5Migration", () => {
 			expect(result.skipped).toBe(0);
 			expect(result.fresh).toBe(false);
 
-			const files = mockStorageWriteFiles.mock.calls[0]?.[0] as ReadonlyArray<FileWrite>;
-			expect(files.length).toBe(3); // 2 summaries + 1 state file
-			// All summaries are written at version=5.
-			const summaryFiles = files.filter((f) => f.path.startsWith("summaries/"));
-			for (const f of summaryFiles) {
+			// Content first (the 2 summaries), then the completed-state marker as
+			// a SEPARATE write — the marker only lands after the content does, and
+			// only when the shadow is clean.
+			const contentFiles = mockStorageWriteFiles.mock.calls[0]?.[0] as ReadonlyArray<FileWrite>;
+			expect(contentFiles.map((f) => f.path).sort()).toEqual([
+				"summaries/v3-hash.json",
+				"summaries/v4-hash.json",
+			]);
+			for (const f of contentFiles) {
 				const parsed = JSON.parse(f.content);
 				expect(parsed.version).toBe(5);
 				expect(parsed.transcripts).toBeDefined();
 			}
+			const stateFiles = mockStorageWriteFiles.mock.calls[1]?.[0] as ReadonlyArray<FileWrite>;
+			expect(stateFiles).toHaveLength(1);
+			expect(stateFiles[0]?.path).toBe(__test__.SCHEMA_V5_STATE_FILE);
 		});
 
-		it("skips v5 summaries already present without rewriting them", async () => {
+		it("recovery: re-pushes already-v5 summaries to heal a lagging shadow, then completes", async () => {
+			// Reaching the locked migration with everything already v5 (migrated=0)
+			// but no completed marker means a prior attempt upgraded the source of
+			// truth but didn't finish (classic dual-write shadow failure). The
+			// skip-unchanged fast-path would write nothing to the folder; instead
+			// we MUST re-push every v5 summary so the lagging shadow catches up.
 			const v5Already: CommitSummary = {
 				...baseNode,
 				commitHash: "v5-hash",
@@ -291,11 +433,10 @@ describe("SchemaV5Migration", () => {
 				transcripts: ["uuid-existing"],
 			} as CommitSummary;
 
-			vi.mocked(readFileFromBranch).mockResolvedValueOnce(null); // state read
-			vi.mocked(listFilesInBranch)
+			mockStorageListFiles
 				.mockResolvedValueOnce(["summaries/v5-hash.json"])
 				.mockResolvedValueOnce(["transcripts/uuid-existing.json"]);
-			vi.mocked(batchReadFilesFromBranch).mockResolvedValueOnce(
+			mockStorageBatchReadFiles.mockResolvedValueOnce(
 				new Map([["summaries/v5-hash.json", JSON.stringify(v5Already)]]),
 			);
 
@@ -304,10 +445,40 @@ describe("SchemaV5Migration", () => {
 			expect(result.skipped).toBe(1);
 			expect(result.migrated).toBe(0);
 
-			const files = mockStorageWriteFiles.mock.calls[0]?.[0] as ReadonlyArray<FileWrite>;
-			// Only the state file should be written — the v5 summary is untouched.
-			expect(files.length).toBe(1);
-			expect(files[0]?.path).toBe(__test__.SCHEMA_V5_STATE_FILE);
+			// Content write re-pushes the already-v5 summary (NOT skipped), then the
+			// state marker is written separately.
+			const contentFiles = mockStorageWriteFiles.mock.calls[0]?.[0] as ReadonlyArray<FileWrite>;
+			expect(contentFiles).toHaveLength(1);
+			expect(contentFiles[0]?.path).toBe("summaries/v5-hash.json");
+			const stateFiles = mockStorageWriteFiles.mock.calls[1]?.[0] as ReadonlyArray<FileWrite>;
+			expect(stateFiles[0]?.path).toBe(__test__.SCHEMA_V5_STATE_FILE);
+		});
+
+		it("leaves state PENDING (no completed marker) when the storage shadow write failed", async () => {
+			// dual-write swallows a folder (shadow) write failure + flags dirty.
+			// The migration must NOT stamp `completed` then — otherwise the folder
+			// is stranded at the old schema and the marker locks out any retry.
+			const v4: CommitSummary = {
+				...baseNode,
+				commitHash: "shadow-hash",
+				version: 4,
+				topics: [],
+			} as CommitSummary;
+			mockStorageListFiles.mockResolvedValueOnce(["summaries/shadow-hash.json"]).mockResolvedValueOnce([]);
+			mockStorageBatchReadFiles.mockResolvedValueOnce(
+				new Map([["summaries/shadow-hash.json", JSON.stringify(v4)]]),
+			);
+			// Shadow reported dirty after the content write.
+			mockStorageIsDirty.mockReturnValueOnce(true);
+
+			const result = await migrateSchemaToV5();
+
+			expect(result.alreadyDone).toBe(false);
+			// Content was written, but the state marker was NOT (only one write).
+			expect(mockStorageWriteFiles).toHaveBeenCalledTimes(1);
+			const written = mockStorageWriteFiles.mock.calls[0]?.[0] as ReadonlyArray<FileWrite>;
+			expect(written.some((f) => f.path === __test__.SCHEMA_V5_STATE_FILE)).toBe(false);
+			expect(written[0]?.path).toBe("summaries/shadow-hash.json");
 		});
 
 		it("routes the migration write through createStorage so dual-write fans out to orphan + shadow", async () => {
@@ -318,7 +489,7 @@ describe("SchemaV5Migration", () => {
 			// `"version": 4` until normal post-commit traffic eventually
 			// rewrote each one. Routing through `createStorage()` gives the
 			// active `StorageProvider` (DualWriteStorage in dual-write mode) a
-			// chance to fan the v5 payload out to both backends in one pass.
+			// chance to fan the v5 payload out to both backends.
 			const { createStorage } = await import("./StorageFactory.js");
 
 			const v4: CommitSummary = {
@@ -327,35 +498,27 @@ describe("SchemaV5Migration", () => {
 				version: 4,
 				topics: [],
 			} as CommitSummary;
-			vi.mocked(readFileFromBranch).mockResolvedValueOnce(null); // state
-			vi.mocked(listFilesInBranch)
-				.mockResolvedValueOnce(["summaries/shadow-hash.json"])
-				.mockResolvedValueOnce([]);
-			vi.mocked(batchReadFilesFromBranch).mockResolvedValueOnce(
+			mockStorageListFiles.mockResolvedValueOnce(["summaries/shadow-hash.json"]).mockResolvedValueOnce([]);
+			mockStorageBatchReadFiles.mockResolvedValueOnce(
 				new Map([["summaries/shadow-hash.json", JSON.stringify(v4)]]),
 			);
 
 			await migrateSchemaToV5();
 
 			expect(createStorage).toHaveBeenCalledTimes(1);
-			expect(mockStorageWriteFiles).toHaveBeenCalledTimes(1);
-			const writtenFiles = mockStorageWriteFiles.mock.calls[0]?.[0] as ReadonlyArray<FileWrite>;
-			// 1 upgraded summary + 1 state file. The summary content is v5 so a
-			// dual-write storage will write `"version": 5` to BOTH backends —
-			// the bug we're guarding against was the shadow being skipped here.
-			expect(writtenFiles).toHaveLength(2);
-			const summaryFile = writtenFiles.find((f) => f.path.startsWith("summaries/"));
+			// Two writes: content (the upgraded summary) then the completed marker.
+			expect(mockStorageWriteFiles).toHaveBeenCalledTimes(2);
+			const contentFiles = mockStorageWriteFiles.mock.calls[0]?.[0] as ReadonlyArray<FileWrite>;
+			const summaryFile = contentFiles.find((f) => f.path.startsWith("summaries/"));
 			expect(summaryFile).toBeDefined();
-			const parsed = JSON.parse(summaryFile?.content ?? "{}");
-			expect(parsed.version).toBe(5);
+			// The summary content is v5 so dual-write fans `"version": 5` to BOTH
+			// backends — the bug we're guarding against was the shadow being skipped.
+			expect(JSON.parse(summaryFile?.content ?? "{}").version).toBe(5);
 		});
 
 		it("tolerates unparseable summary files by skipping them", async () => {
-			vi.mocked(readFileFromBranch).mockResolvedValueOnce(null); // state read
-			vi.mocked(listFilesInBranch).mockResolvedValueOnce(["summaries/bad.json"]).mockResolvedValueOnce([]);
-			vi.mocked(batchReadFilesFromBranch).mockResolvedValueOnce(
-				new Map([["summaries/bad.json", "not valid json {"]]),
-			);
+			mockStorageListFiles.mockResolvedValueOnce(["summaries/bad.json"]).mockResolvedValueOnce([]);
+			mockStorageBatchReadFiles.mockResolvedValueOnce(new Map([["summaries/bad.json", "not valid json {"]]));
 
 			const result = await migrateSchemaToV5();
 
@@ -372,7 +535,6 @@ describe("SchemaV5Migration", () => {
 			// `Extension.ts activate` and `Installer.install`.
 			const locksMod = await import("./Locks.js");
 			vi.mocked(locksMod.acquireOrphanWriteLock).mockResolvedValueOnce(false);
-			vi.mocked(readFileFromBranch).mockResolvedValueOnce(null); // state read
 
 			await expect(migrateSchemaToV5()).rejects.toThrow(/orphan-write lock/);
 			expect(mockStorageWriteFiles).not.toHaveBeenCalled();
@@ -385,8 +547,7 @@ describe("SchemaV5Migration", () => {
 			// sandbox where git is unavailable), the migration still completes.
 			const gitops = await import("./GitOps.js");
 			vi.mocked(gitops.execGit).mockRejectedValueOnce(new Error("git not found"));
-			vi.mocked(readFileFromBranch).mockResolvedValueOnce(null); // state
-			vi.mocked(listFilesInBranch)
+			mockStorageListFiles
 				.mockResolvedValueOnce([]) // summaries
 				.mockResolvedValueOnce([]); // transcripts
 
@@ -395,14 +556,13 @@ describe("SchemaV5Migration", () => {
 			expect(mockStorageWriteFiles).toHaveBeenCalledOnce();
 		});
 
-		it("skips summary files whose batched read returned null (transient git read failure)", async () => {
-			// Covers the `content === null` early-continue branch — cat-file's
-			// batch reader maps an entry to null when the path resolved to
-			// `missing` at read time (e.g. a concurrent orphan-write committed
-			// a deletion between listFilesInBranch and the batch read).
-			vi.mocked(readFileFromBranch).mockResolvedValueOnce(null); // state
-			vi.mocked(listFilesInBranch).mockResolvedValueOnce(["summaries/vanished.json"]).mockResolvedValueOnce([]);
-			vi.mocked(batchReadFilesFromBranch).mockResolvedValueOnce(new Map([["summaries/vanished.json", null]]));
+		it("skips summary files whose batched read returned null (transient read failure)", async () => {
+			// Covers the `content === null` early-continue branch — the batch
+			// reader maps an entry to null when the path resolved to `missing`
+			// at read time (e.g. a concurrent write committed a deletion between
+			// listFiles and the batch read).
+			mockStorageListFiles.mockResolvedValueOnce(["summaries/vanished.json"]).mockResolvedValueOnce([]);
+			mockStorageBatchReadFiles.mockResolvedValueOnce(new Map([["summaries/vanished.json", null]]));
 
 			const result = await migrateSchemaToV5();
 
@@ -415,14 +575,13 @@ describe("SchemaV5Migration", () => {
 			// `null` and `undefined` look identical to a casual read but have
 			// very different causes: `null` is a benign race (file vanished),
 			// `undefined` is a bug in the batch reader (it must populate one
-			// entry per request). The migration code MUST surface the latter
-			// — without this guard a future regression in
-			// `batchReadFilesFromBranch` that silently drops entries would
-			// be invisible (migrated count would just be lower than expected).
-			vi.mocked(readFileFromBranch).mockResolvedValueOnce(null); // state
-			vi.mocked(listFilesInBranch).mockResolvedValueOnce(["summaries/dropped.json"]).mockResolvedValueOnce([]);
+			// entry per request). The migration code MUST surface the latter —
+			// without this guard a future regression in `readSummaries` that
+			// silently drops entries would be invisible (migrated count would
+			// just be lower than expected).
+			mockStorageListFiles.mockResolvedValueOnce(["summaries/dropped.json"]).mockResolvedValueOnce([]);
 			// Empty Map → `contents.get("summaries/dropped.json")` returns undefined.
-			vi.mocked(batchReadFilesFromBranch).mockResolvedValueOnce(new Map());
+			mockStorageBatchReadFiles.mockResolvedValueOnce(new Map());
 
 			await expect(migrateSchemaToV5()).rejects.toThrow(/protocol contract violation/);
 			expect(mockStorageWriteFiles).not.toHaveBeenCalled();
@@ -432,7 +591,7 @@ describe("SchemaV5Migration", () => {
 	// ─── readSchemaV5State ────────────────────────────────────────────────────
 	describe("readSchemaV5State", () => {
 		it("returns null when state file is absent", async () => {
-			vi.mocked(readFileFromBranch).mockResolvedValueOnce(null);
+			mockStorageReadFile.mockResolvedValueOnce(null);
 			expect(await readSchemaV5State()).toBeNull();
 		});
 
@@ -446,13 +605,24 @@ describe("SchemaV5Migration", () => {
 				skippedCount: 0,
 				fresh: true,
 			};
-			vi.mocked(readFileFromBranch).mockResolvedValueOnce(JSON.stringify(state));
+			mockStorageReadFile.mockResolvedValueOnce(JSON.stringify(state));
 			expect(await readSchemaV5State()).toEqual(state);
 		});
 
 		it("returns null when state file is unparseable", async () => {
-			vi.mocked(readFileFromBranch).mockResolvedValueOnce("not json");
+			mockStorageReadFile.mockResolvedValueOnce("not json");
 			expect(await readSchemaV5State()).toBeNull();
+		});
+
+		it("uses a caller-provided storage without constructing a new one", async () => {
+			// The migration threads its already-built provider in to avoid the
+			// extra `createStorage` (loadConfig) I/O. Verify the passed storage's
+			// readFile is used and createStorage is NOT called.
+			const { createStorage } = await import("./StorageFactory.js");
+			const passedReadFile = vi.fn().mockResolvedValue(null);
+			await readSchemaV5State(undefined, { readFile: passedReadFile } as never);
+			expect(passedReadFile).toHaveBeenCalledWith(__test__.SCHEMA_V5_STATE_FILE);
+			expect(createStorage).not.toHaveBeenCalled();
 		});
 	});
 });

--- a/cli/src/core/SchemaV5Migration.ts
+++ b/cli/src/core/SchemaV5Migration.ts
@@ -12,30 +12,43 @@
  * after migration generate fresh UUIDs (see `TranscriptId.generateTranscriptId`)
  * so the two formats coexist harmlessly; readers treat the IDs as opaque.
  *
- * Atomicity: every write goes into a SINGLE orphan-branch commit, so the
- * migration is all-or-nothing from the storage perspective. State on the
- * orphan branch is `schema-v5-migration.json` — present (with `completedAt`)
- * once the commit lands, absent otherwise. Concurrent post-commit writers
+ * Storage-agnostic: both reads and the final write go through the active
+ * `StorageProvider`, so the migration works identically in orphan-only,
+ * dual-write, AND folder-only mode. `storage.exists()` is the data gate,
+ * `storage.listFiles` / `storage.batchReadFiles` enumerate and read the
+ * summaries, and `storage.readFile(SCHEMA_V5_STATE_FILE)` reads the persisted
+ * state. In orphan-backed modes these resolve to the orphan branch; in
+ * folder-only mode they resolve to `<localFolder>/<repo>/.jolli/`. (Earlier
+ * versions read the orphan branch directly, which silently skipped folder-only
+ * users — their data never migrated and `jolli status` reported "Not migrated"
+ * forever.)
+ *
+ * Write ordering: summary content is written FIRST, then the
+ * `schema-v5-migration.json` `completed` marker is written separately — and
+ * only when the storage shadow is clean. In dual-write a folder (shadow) write
+ * failure is swallowed + flagged dirty, so a successful orphan write alone does
+ * NOT mean both backends are current; stamping `completed` then would lie and
+ * permanently strand the folder at the old schema. Gating the marker on
+ * `storage.isDirty()` keeps the migration PENDING after a shadow failure so the
+ * next startup retries; a retry where the source of truth is already all-v5
+ * re-pushes every summary (recovery branch) to heal the lagging shadow. The
+ * state file is present (with `completedAt`) only once both the content and the
+ * marker have landed cleanly, absent otherwise. Concurrent post-commit writers
  * are serialized via the same `orphan-write.lock` the v1→v3 migration uses;
- * this means a single very long migration can starve a worker for up to
- * 30s, after which that worker's queue entry is dropped (same fire-and-
- * forget semantics documented in QueueWorker).
+ * this means a single very long migration can starve a worker for up to 30s,
+ * after which that worker's queue entry is dropped (same fire-and-forget
+ * semantics documented in QueueWorker).
  */
 
 import { createLogger, ORPHAN_BRANCH } from "../Logger.js";
 import type { CommitSummary, FileWrite } from "../Types.js";
-import {
-	batchReadFilesFromBranch,
-	execGit,
-	listFilesInBranch,
-	orphanBranchExists,
-	readFileFromBranch,
-} from "./GitOps.js";
+import { execGit } from "./GitOps.js";
 import { acquireOrphanWriteLock, releaseOrphanWriteLock } from "./Locks.js";
 import { createStorage } from "./StorageFactory.js";
 import type { StorageProvider } from "./StorageProvider.js";
 import { normalizeToV4 } from "./SummaryStore.js";
 import { collectAllTranscriptHashes } from "./SummaryTree.js";
+import { transcriptIdFromPath } from "./TranscriptId.js";
 
 const log = createLogger("SchemaV5Migration");
 
@@ -72,9 +85,18 @@ export interface SchemaV5MigrationResult {
  * Read-only state inspector. Returns null when the state file is absent
  * (the implicit "pending" state). Status panel / `jolli status` reads this
  * to decide whether to surface a "migration needed" or "complete" message.
+ *
+ * Reads through the active `StorageProvider` so folder-only repos (whose state
+ * lives in `.jolli/schema-v5-migration.json`, not on an orphan branch) report
+ * correctly. Callers may pass a pre-built `storage` to avoid the `loadConfig`
+ * I/O `createStorage` does; when omitted it's constructed from `cwd`.
  */
-export async function readSchemaV5State(cwd?: string): Promise<SchemaV5MigrationState | null> {
-	const content = await readFileFromBranch(ORPHAN_BRANCH, SCHEMA_V5_STATE_FILE, cwd);
+export async function readSchemaV5State(
+	cwd?: string,
+	storage?: StorageProvider,
+): Promise<SchemaV5MigrationState | null> {
+	const provider = storage ?? (await createStorage(cwd ?? process.cwd(), cwd));
+	const content = await provider.readFile(SCHEMA_V5_STATE_FILE);
 	if (!content) return null;
 	try {
 		return JSON.parse(content) as SchemaV5MigrationState;
@@ -112,12 +134,22 @@ async function withMigrationLock<T>(cwd: string | undefined, label: string, fn: 
  *     surface it to the user as a hard failure. Both production call sites
  *     (`Installer.install()` and `Extension.ts initializeKB()`) wrap the
  *     call in `try/catch` and log-warn-only; any new caller must do the same.
- *   - `batchReadFilesFromBranch` or `writeMultipleFilesToBranch` throws. The
- *     orphan-write lock release happens via `withMigrationLock`'s `finally`,
- *     so a thrown migration cannot leak the lock.
+ *   - a `storage` read (`listFiles` / `batchReadFiles` / `readFile`) or the
+ *     final `storage.writeFiles` throws. The orphan-write lock release happens
+ *     via `withMigrationLock`'s `finally`, so a thrown migration cannot leak
+ *     the lock.
  */
 export async function migrateSchemaToV5(cwd?: string): Promise<SchemaV5MigrationResult> {
-	const existing = await readSchemaV5State(cwd);
+	// Resolve the storage provider BEFORE acquiring the orphan-write lock.
+	// `createStorage` calls `loadConfig()` which reads `~/.jolli/jollimemory/
+	// config.json`; doing that disk I/O inside the lock would extend the
+	// window during which concurrent post-commit writers wait (up to their
+	// 30 s timeout). The provider itself is stateless WRT the backend until
+	// `writeFiles` is called, so it's safe to construct early. Built up front
+	// so the state read, the data gate, and the migration all share it.
+	const storage = await createStorage(cwd ?? process.cwd(), cwd);
+
+	const existing = await readSchemaV5State(cwd, storage);
 	if (existing?.status === "completed") {
 		log.info("Schema v5 migration already completed at %s — skipping", existing.completedAt);
 		return {
@@ -128,32 +160,61 @@ export async function migrateSchemaToV5(cwd?: string): Promise<SchemaV5Migration
 		};
 	}
 
-	// Skip when no orphan branch exists yet. Calling
-	// writeMultipleFilesToBranch on a non-existent branch would CREATE it
-	// (with just the state file inside), which is a noisy side effect for
-	// fresh projects that have not yet made their first commit. The first
-	// post-commit will create the branch with real data, and the next
-	// activate() / install will pick the migration up.
-	if (!(await orphanBranchExists(ORPHAN_BRANCH, cwd))) {
-		log.info("Orphan branch does not exist yet — skipping schema v5 migration (no data to migrate)");
+	// Skip when the storage backend is not initialized yet. For orphan-backed
+	// modes this means no orphan branch — calling `writeFiles` would CREATE it
+	// (with just the state file inside), a noisy side effect for fresh projects
+	// that have not yet made their first commit. For folder-only mode it means
+	// the Memory Bank folder does not exist yet. In both cases the first
+	// post-commit creates the backend with real data, and the next activate() /
+	// install picks the migration up.
+	if (!(await storage.exists())) {
+		log.info("Storage backend not initialized yet — skipping schema v5 migration (no data to migrate)");
 		return { migrated: 0, skipped: 0, fresh: true, alreadyDone: false };
 	}
 
-	// Resolve the storage provider BEFORE acquiring the orphan-write lock.
-	// `createStorage` calls `loadConfig()` which reads `~/.jolli/jollimemory/
-	// config.json`; doing that disk I/O inside the lock would extend the
-	// window during which concurrent post-commit writers wait (up to their
-	// 30 s timeout). The provider itself is stateless WRT the orphan branch
-	// until `writeFiles` is called, so it's safe to construct early.
-	const storage = await createStorage(cwd ?? process.cwd(), cwd);
-
 	return withMigrationLock(cwd, "migrateSchemaToV5", () => migrateSchemaToV5Locked(cwd, storage));
+}
+
+/**
+ * Reads every summary path via the storage's batch primitive when available
+ * (orphan-backed: one `git cat-file --batch`), else a per-file `readFile` loop
+ * (folder-only: cheap local reads). Returns a Map keyed by path with `null` for
+ * missing files — the same shape both branches produce, so the caller's
+ * undefined-vs-null contract check downstream stays valid.
+ */
+async function readSummaries(
+	storage: StorageProvider,
+	paths: ReadonlyArray<string>,
+): Promise<Map<string, string | null>> {
+	if (paths.length === 0) return new Map();
+	if (storage.batchReadFiles) return storage.batchReadFiles(paths);
+	const result = new Map<string, string | null>();
+	for (const path of paths) result.set(path, await storage.readFile(path));
+	return result;
 }
 
 async function migrateSchemaToV5Locked(
 	cwd: string | undefined,
 	storage: StorageProvider,
 ): Promise<SchemaV5MigrationResult> {
+	// Re-check state now that we hold the lock. The check in `migrateSchemaToV5`
+	// is outside the lock, so two processes (e.g. VS Code activate() + a CLI
+	// `jolli migrate`) can both pass it and queue on the lock. Without this
+	// re-check the second one would rescan every (now-v5) summary, skip them
+	// all, and overwrite the state with `migratedCount: 0` — a wasted full scan
+	// plus a misleading telemetry count. Re-reading under the lock makes the
+	// idempotency the doc comment promises actually hold.
+	const alreadyDone = await readSchemaV5State(cwd, storage);
+	if (alreadyDone?.status === "completed") {
+		log.info("Schema v5 migration completed by a concurrent run at %s — skipping", alreadyDone.completedAt);
+		return {
+			migrated: alreadyDone.migratedCount,
+			skipped: alreadyDone.skippedCount,
+			fresh: alreadyDone.fresh,
+			alreadyDone: true,
+		};
+	}
+
 	const startedAt = new Date().toISOString();
 
 	// Capture the pre-migration HEAD of the orphan branch BEFORE we touch
@@ -168,35 +229,40 @@ async function migrateSchemaToV5Locked(
 		.then((r) => r.stdout.trim())
 		.catch(() => null);
 
-	// Enumerate every summary file currently on the orphan branch. Empty list
-	// = fresh install (or wiped repo); we still write the "completed" state
-	// so subsequent startups skip without scanning.
-	const summaryPaths = await listFilesInBranch(ORPHAN_BRANCH, "summaries/", cwd);
+	// Enumerate every summary file in the active storage. Empty list = fresh
+	// install (or wiped repo); we still write the "completed" state so
+	// subsequent startups skip without scanning. `storage.listFiles` resolves
+	// to the orphan branch (orphan/dual-write) or `.jolli/summaries/`
+	// (folder-only), so this covers all three modes.
+	const summaryPaths = await storage.listFiles("summaries/");
 	log.info("Found %d summary files to inspect", summaryPaths.length);
 
 	// Single scan of transcripts/ so the per-summary "does file exist" check
 	// is O(1) lookup, not O(commits) git calls. Fresh-install path returns [].
-	const transcriptPaths = await listFilesInBranch(ORPHAN_BRANCH, "transcripts/", cwd);
+	const transcriptPaths = await storage.listFiles("transcripts/");
 	const transcriptFileIds = new Set<string>();
 	for (const p of transcriptPaths) {
-		// p looks like "transcripts/{hash}.json" — strip prefix + extension.
-		const match = /^transcripts\/(.+)\.json$/.exec(p);
-		if (match?.[1]) transcriptFileIds.add(match[1]);
+		// p looks like "transcripts/{id}.json". Shared parser keeps this in
+		// lockstep with SummaryStore.getTranscriptHashes (same dropped-UUID fix).
+		const id = transcriptIdFromPath(p);
+		if (id) transcriptFileIds.add(id);
 	}
 
-	// Batch-read every summary in one `git cat-file --batch` subprocess.
-	// The naive per-file `readFileFromBranch` was N × ~80 ms spawn overhead
-	// on Windows — 336 files took ~27 s of pure subprocess churn during the
-	// first observed v5 run, even after the write side switched to fast-
-	// import. Streaming all reads through one cat-file process drops that
-	// to a couple of seconds.
-	log.info("Reading %d summaries via batched cat-file...", summaryPaths.length);
+	// Batch-read every summary. Orphan-backed storage implements
+	// `batchReadFiles` as one `git cat-file --batch` subprocess: the naive
+	// per-file read was N × ~80 ms spawn overhead on Windows — 336 files took
+	// ~27 s of pure subprocess churn during the first observed v5 run. Folder
+	// storage has no batch method (local `readFile` per path is already cheap),
+	// so fall back to a per-file loop there.
+	log.info("Reading %d summaries...", summaryPaths.length);
 	const readStart = Date.now();
-	const contents =
-		summaryPaths.length > 0 ? await batchReadFilesFromBranch(ORPHAN_BRANCH, summaryPaths, cwd) : new Map();
+	const contents = await readSummaries(storage, summaryPaths);
 	log.info("Read %d summaries in %d ms", contents.size, Date.now() - readStart);
 
 	const filesToWrite: FileWrite[] = [];
+	// Every summary's current (post-upgrade) content, used by the recovery path
+	// below to re-push the full set when a prior attempt left the shadow behind.
+	const allSummaryFiles: FileWrite[] = [];
 	let migrated = 0;
 	let skipped = 0;
 
@@ -211,17 +277,16 @@ async function migrateSchemaToV5Locked(
 		const content = contents.get(path);
 		// Distinguish the two "no content" cases — they have very different
 		// causes:
-		//   - `null`:      cat-file reported `<request> missing`. Legitimate
-		//                  race: a concurrent orphan-write deleted the file
-		//                  between `listFilesInBranch` and the batch read.
-		//                  Skip and move on.
-		//   - `undefined`: `batchReadFilesFromBranch` did not emit an entry
-		//                  for this path. Contract violation — the helper
-		//                  populates the map by request order and must have
-		//                  one entry per input. Treat as a bug, not a race.
+		//   - `null`:      the read reported the file missing. Legitimate race:
+		//                  a concurrent write deleted the file between
+		//                  `listFiles` and the batch read. Skip and move on.
+		//   - `undefined`: `readSummaries` did not emit an entry for this path.
+		//                  Contract violation — both the batch and per-file
+		//                  branches must produce one map entry per input. Treat
+		//                  as a bug, not a race.
 		if (content === undefined) {
 			throw new Error(
-				`batchReadFilesFromBranch omitted ${path} — protocol contract violation (expected one entry per request)`,
+				`readSummaries omitted ${path} — protocol contract violation (expected one entry per request)`,
 			);
 		}
 		if (content === null) {
@@ -239,56 +304,91 @@ async function migrateSchemaToV5Locked(
 		}
 
 		const upgraded = upgradeOneSummary(raw, transcriptFileIds);
+		const serialized = JSON.stringify(upgraded, null, "\t");
+		allSummaryFiles.push({ path, content: serialized });
 		if (upgraded === raw) {
-			// Already v5 — leave the on-disk file untouched.
+			// Already v5 — no schema change to write in the normal path.
 			skipped++;
 			continue;
 		}
 
-		filesToWrite.push({
-			path,
-			content: JSON.stringify(upgraded, null, "\t"),
-		});
+		filesToWrite.push({ path, content: serialized });
 		migrated++;
 	}
 
 	const fresh = summaryPaths.length === 0;
-	const completedAt = new Date().toISOString();
+
+	// Recovery re-push: we only reach here when the migration is NOT marked
+	// completed, yet every summary is already v5 (`migrated === 0 && !fresh`).
+	// That means a prior attempt upgraded the source of truth (orphan) but did
+	// NOT finish cleanly — the classic case being a dual-write run whose shadow
+	// (folder) write failed and was swallowed + flagged dirty. The skip-unchanged
+	// fast-path would write nothing, leaving the folder stranded at the old
+	// schema forever (and the completed marker, once written, would lock out any
+	// retry). So re-push EVERY summary's current content to give the shadow
+	// another chance to catch up. Costs a redundant orphan rewrite on this rare
+	// path; the common first-migration writes only the upgraded files.
+	const isRecovery = migrated === 0 && skipped > 0;
+	const contentFiles = isRecovery ? allSummaryFiles : filesToWrite;
+
+	const commitMessage = fresh
+		? "Schema v5 migration: no pre-v5 data found"
+		: isRecovery
+			? `Schema v5 migration: re-pushing ${skipped} v5 summaries to heal storage shadow`
+			: `Schema v5 migration: ${migrated} upgraded, ${skipped} skipped`;
+
+	// `storage` is built upstream of the orphan-write lock (in
+	// `migrateSchemaToV5`) so its `loadConfig()` I/O doesn't hold the lock.
+	// Routing the write through it gives dual-write users the shadow folder
+	// upgrade in the same pass. In orphan-only mode this is equivalent to the
+	// old direct call; in folder-only mode the orphan branch stays untouched.
+	const writeStart = Date.now();
+	if (contentFiles.length > 0) {
+		log.info("Writing %d summary file(s) via active storage...", contentFiles.length);
+		await storage.writeFiles(contentFiles, commitMessage);
+	}
+
+	// Gate the `completed` marker on the shadow actually landing. In dual-write,
+	// a folder (shadow) write failure is swallowed + flagged dirty rather than
+	// thrown — so a successful primary write does NOT mean both backends are
+	// current. If the shadow is dirty we must NOT stamp `completed`: leaving the
+	// state absent (pending) lets the next startup re-run and, via the recovery
+	// branch above, re-push to heal the folder. Without this gate the completed
+	// marker would lie and permanently strand the folder at the old schema.
+	// Orphan-only / folder-only have no swallowing shadow (`isDirty` absent, or a
+	// real write failure throws), so this resolves to false and we complete.
+	const shadowDirty = storage.isDirty?.() ?? false;
+	if (shadowDirty) {
+		log.warn(
+			"Schema v5 migration: storage shadow write failed (folder marked dirty) — leaving state PENDING; next startup will retry and re-push (migrated=%d, skipped=%d, took %d ms)",
+			migrated,
+			skipped,
+			Date.now() - writeStart,
+		);
+		return { migrated, skipped, fresh, alreadyDone: false };
+	}
+
+	// Shadow is clean (or there is no swallowing shadow): persist the completed
+	// marker as a separate write so it only lands after the content above did.
 	const finalState: SchemaV5MigrationState = {
 		version: 1,
 		status: "completed",
 		startedAt,
-		completedAt,
+		completedAt: new Date().toISOString(),
 		migratedCount: migrated,
 		skippedCount: skipped,
 		fresh,
 	};
-	filesToWrite.push({
-		path: SCHEMA_V5_STATE_FILE,
-		content: JSON.stringify(finalState, null, "\t"),
-	});
-
-	const commitMessage = fresh
-		? "Schema v5 migration: no pre-v5 data found"
-		: `Schema v5 migration: ${migrated} upgraded, ${skipped} skipped`;
-
-	log.info("Committing %d file(s) via fast-import...", filesToWrite.length);
-	const writeStart = Date.now();
-	// `storage` is built upstream of the orphan-write lock (in
-	// `migrateSchemaToV5`) so its `loadConfig()` I/O doesn't hold the lock.
-	// Routing the write through it (instead of `writeMultipleFilesToBranch`
-	// directly) gives dual-write users the shadow folder upgrade in the same
-	// pass — pre-fix, the shadow's `.jolli/summaries/<hash>.json` files
-	// stayed at the pre-migration version until normal post-commit traffic
-	// eventually rewrote them. In orphan-only mode this is equivalent to the
-	// old direct call (OrphanBranchStorage.writeFiles → writeMultipleFiles
-	// ToBranch). In folder-only mode the orphan branch stays untouched.
-	await storage.writeFiles(filesToWrite, commitMessage);
+	await storage.writeFiles(
+		[{ path: SCHEMA_V5_STATE_FILE, content: JSON.stringify(finalState, null, "\t") }],
+		commitMessage,
+	);
 	log.info(
-		"Schema v5 migration complete: %d migrated, %d skipped, fresh=%s (commit took %d ms)",
+		"Schema v5 migration complete: %d migrated, %d skipped, fresh=%s, recovery=%s (took %d ms)",
 		migrated,
 		skipped,
 		fresh,
+		isRecovery,
 		Date.now() - writeStart,
 	);
 	if (preMigrationSHA) {
@@ -325,9 +425,15 @@ async function migrateSchemaToV5Locked(
  * would replace the UUID list with children commit hashes (typically dropping
  * the v5 IDs entirely once the file-existence intersection runs). The guard
  * leaves the array untouched and only bumps version.
+ *
+ * The "already v5" fast-path also requires `transcripts` to be present: a
+ * record stamped `version: 5` but MISSING the `transcripts` field is anomalous
+ * (a bug or hand-edit) and must NOT be treated as migrated — left alone it
+ * would force `getTranscriptIds` down the v3/v4 children-walk fallback forever.
+ * Falling through repairs it by computing the array like any pre-v5 root.
  */
 function upgradeOneSummary(raw: CommitSummary, transcriptFileIds: ReadonlySet<string>): CommitSummary {
-	if (raw.version >= 5) return raw;
+	if (raw.version >= 5 && raw.transcripts !== undefined) return raw;
 
 	const v4 = normalizeToV4(raw);
 

--- a/cli/src/core/SchemaV5Migration.ts
+++ b/cli/src/core/SchemaV5Migration.ts
@@ -1,0 +1,359 @@
+/**
+ * Schema v5 Migration — unified v3 → v4 → v5 one-shot migration.
+ *
+ * Reads every summary on the orphan branch, runs the lossless `normalizeToV4`
+ * helper to collapse v3 layouts into the v4 unified-Hoist invariant, then
+ * stamps `version: 5` + a `transcripts: string[]` array on each root.
+ *
+ * The v5 transcripts array uses **the existing on-disk filenames as opaque
+ * IDs** — legacy `transcripts/{commitHash}.json` files are NOT renamed. This
+ * means each `transcripts: [...]` entry on a migrated summary is the same
+ * 40-char hex commit-hash string that was already the file name. New writes
+ * after migration generate fresh UUIDs (see `TranscriptId.generateTranscriptId`)
+ * so the two formats coexist harmlessly; readers treat the IDs as opaque.
+ *
+ * Atomicity: every write goes into a SINGLE orphan-branch commit, so the
+ * migration is all-or-nothing from the storage perspective. State on the
+ * orphan branch is `schema-v5-migration.json` — present (with `completedAt`)
+ * once the commit lands, absent otherwise. Concurrent post-commit writers
+ * are serialized via the same `orphan-write.lock` the v1→v3 migration uses;
+ * this means a single very long migration can starve a worker for up to
+ * 30s, after which that worker's queue entry is dropped (same fire-and-
+ * forget semantics documented in QueueWorker).
+ */
+
+import { createLogger, ORPHAN_BRANCH } from "../Logger.js";
+import type { CommitSummary, FileWrite } from "../Types.js";
+import {
+	batchReadFilesFromBranch,
+	execGit,
+	listFilesInBranch,
+	orphanBranchExists,
+	readFileFromBranch,
+} from "./GitOps.js";
+import { acquireOrphanWriteLock, releaseOrphanWriteLock } from "./Locks.js";
+import { createStorage } from "./StorageFactory.js";
+import type { StorageProvider } from "./StorageProvider.js";
+import { normalizeToV4 } from "./SummaryStore.js";
+import { collectAllTranscriptHashes } from "./SummaryTree.js";
+
+const log = createLogger("SchemaV5Migration");
+
+const SCHEMA_V5_STATE_FILE = "schema-v5-migration.json";
+const MIGRATION_LOCK_TIMEOUT_MS = 30_000;
+
+/**
+ * Persisted state for the v5 migration. Present on the orphan branch only
+ * after a successful (or in-flight failed) migration attempt. Absent state
+ * is the implicit "pending" state — the migration code interprets that as
+ * "needs to run on next startup".
+ */
+export interface SchemaV5MigrationState {
+	readonly version: 1;
+	readonly status: "in-progress" | "completed" | "failed";
+	readonly startedAt: string;
+	readonly completedAt?: string;
+	readonly migratedCount: number;
+	readonly skippedCount: number;
+	/** True when no v3/v4 data existed at migration time (fresh install). */
+	readonly fresh: boolean;
+	readonly errorMessage?: string;
+}
+
+/** Public summary of what `migrateSchemaToV5` did, for caller telemetry. */
+export interface SchemaV5MigrationResult {
+	readonly migrated: number;
+	readonly skipped: number;
+	readonly fresh: boolean;
+	readonly alreadyDone: boolean;
+}
+
+/**
+ * Read-only state inspector. Returns null when the state file is absent
+ * (the implicit "pending" state). Status panel / `jolli status` reads this
+ * to decide whether to surface a "migration needed" or "complete" message.
+ */
+export async function readSchemaV5State(cwd?: string): Promise<SchemaV5MigrationState | null> {
+	const content = await readFileFromBranch(ORPHAN_BRANCH, SCHEMA_V5_STATE_FILE, cwd);
+	if (!content) return null;
+	try {
+		return JSON.parse(content) as SchemaV5MigrationState;
+	} catch (err) {
+		log.warn("Failed to parse v5 migration state — treating as absent: %s", (err as Error).message);
+		return null;
+	}
+}
+
+async function withMigrationLock<T>(cwd: string | undefined, label: string, fn: () => Promise<T>): Promise<T> {
+	const acquired = await acquireOrphanWriteLock(cwd, { timeoutMs: MIGRATION_LOCK_TIMEOUT_MS });
+	if (!acquired) {
+		throw new Error(`${label}: could not acquire orphan-write lock within ${MIGRATION_LOCK_TIMEOUT_MS}ms`);
+	}
+	try {
+		return await fn();
+	} finally {
+		await releaseOrphanWriteLock(cwd);
+	}
+}
+
+/**
+ * Runs the v5 migration end-to-end. Idempotent — a second call after a
+ * successful run is a fast no-op (returns `alreadyDone: true`).
+ *
+ * Failures throw, and the caller is expected to log + retry on next startup.
+ * The state file does NOT get marked "failed" on throw, so the next run
+ * sees "still pending" and tries again. (We could write "failed" eagerly
+ * but that complicates the happy path — pending is the right starting state
+ * after any kind of failure including process crash.)
+ *
+ * Throws when:
+ *   - the orphan-write lock cannot be acquired inside `MIGRATION_LOCK_TIMEOUT_MS`
+ *     (30 s). Callers MUST treat this as "defer to next startup" — do NOT
+ *     surface it to the user as a hard failure. Both production call sites
+ *     (`Installer.install()` and `Extension.ts initializeKB()`) wrap the
+ *     call in `try/catch` and log-warn-only; any new caller must do the same.
+ *   - `batchReadFilesFromBranch` or `writeMultipleFilesToBranch` throws. The
+ *     orphan-write lock release happens via `withMigrationLock`'s `finally`,
+ *     so a thrown migration cannot leak the lock.
+ */
+export async function migrateSchemaToV5(cwd?: string): Promise<SchemaV5MigrationResult> {
+	const existing = await readSchemaV5State(cwd);
+	if (existing?.status === "completed") {
+		log.info("Schema v5 migration already completed at %s — skipping", existing.completedAt);
+		return {
+			migrated: existing.migratedCount,
+			skipped: existing.skippedCount,
+			fresh: existing.fresh,
+			alreadyDone: true,
+		};
+	}
+
+	// Skip when no orphan branch exists yet. Calling
+	// writeMultipleFilesToBranch on a non-existent branch would CREATE it
+	// (with just the state file inside), which is a noisy side effect for
+	// fresh projects that have not yet made their first commit. The first
+	// post-commit will create the branch with real data, and the next
+	// activate() / install will pick the migration up.
+	if (!(await orphanBranchExists(ORPHAN_BRANCH, cwd))) {
+		log.info("Orphan branch does not exist yet — skipping schema v5 migration (no data to migrate)");
+		return { migrated: 0, skipped: 0, fresh: true, alreadyDone: false };
+	}
+
+	// Resolve the storage provider BEFORE acquiring the orphan-write lock.
+	// `createStorage` calls `loadConfig()` which reads `~/.jolli/jollimemory/
+	// config.json`; doing that disk I/O inside the lock would extend the
+	// window during which concurrent post-commit writers wait (up to their
+	// 30 s timeout). The provider itself is stateless WRT the orphan branch
+	// until `writeFiles` is called, so it's safe to construct early.
+	const storage = await createStorage(cwd ?? process.cwd(), cwd);
+
+	return withMigrationLock(cwd, "migrateSchemaToV5", () => migrateSchemaToV5Locked(cwd, storage));
+}
+
+async function migrateSchemaToV5Locked(
+	cwd: string | undefined,
+	storage: StorageProvider,
+): Promise<SchemaV5MigrationResult> {
+	const startedAt = new Date().toISOString();
+
+	// Capture the pre-migration HEAD of the orphan branch BEFORE we touch
+	// anything, so recovery (rare) has a concrete SHA to roll back to via
+	// `git update-ref refs/heads/<orphan-branch> <preMigrationSHA>`.
+	// Surfaced only in debug.log — users don't normally need or want to know
+	// this; it's for support / triage when migration produces unexpected output.
+	// `git reflog refs/heads/<orphan-branch>` provides the same information
+	// (default 90-day retention) but a single logged SHA is much faster to
+	// reference from a bug report than walking the reflog.
+	const preMigrationSHA = await execGit(["rev-parse", `refs/heads/${ORPHAN_BRANCH}`], cwd)
+		.then((r) => r.stdout.trim())
+		.catch(() => null);
+
+	// Enumerate every summary file currently on the orphan branch. Empty list
+	// = fresh install (or wiped repo); we still write the "completed" state
+	// so subsequent startups skip without scanning.
+	const summaryPaths = await listFilesInBranch(ORPHAN_BRANCH, "summaries/", cwd);
+	log.info("Found %d summary files to inspect", summaryPaths.length);
+
+	// Single scan of transcripts/ so the per-summary "does file exist" check
+	// is O(1) lookup, not O(commits) git calls. Fresh-install path returns [].
+	const transcriptPaths = await listFilesInBranch(ORPHAN_BRANCH, "transcripts/", cwd);
+	const transcriptFileIds = new Set<string>();
+	for (const p of transcriptPaths) {
+		// p looks like "transcripts/{hash}.json" — strip prefix + extension.
+		const match = /^transcripts\/(.+)\.json$/.exec(p);
+		if (match?.[1]) transcriptFileIds.add(match[1]);
+	}
+
+	// Batch-read every summary in one `git cat-file --batch` subprocess.
+	// The naive per-file `readFileFromBranch` was N × ~80 ms spawn overhead
+	// on Windows — 336 files took ~27 s of pure subprocess churn during the
+	// first observed v5 run, even after the write side switched to fast-
+	// import. Streaming all reads through one cat-file process drops that
+	// to a couple of seconds.
+	log.info("Reading %d summaries via batched cat-file...", summaryPaths.length);
+	const readStart = Date.now();
+	const contents =
+		summaryPaths.length > 0 ? await batchReadFilesFromBranch(ORPHAN_BRANCH, summaryPaths, cwd) : new Map();
+	log.info("Read %d summaries in %d ms", contents.size, Date.now() - readStart);
+
+	const filesToWrite: FileWrite[] = [];
+	let migrated = 0;
+	let skipped = 0;
+
+	// `index.json` is NOT rewritten by this migration. The upgrade is in-place
+	// (same commit hashes, same tree shape), so existing index entries already
+	// point at the right summaries — leaving the index alone avoids touching
+	// fields like `treeHash` that we'd otherwise have to recompute, and keeps
+	// the migration's blast radius small (only `summaries/*.json` + the state
+	// file change).
+
+	for (const path of summaryPaths) {
+		const content = contents.get(path);
+		// Distinguish the two "no content" cases — they have very different
+		// causes:
+		//   - `null`:      cat-file reported `<request> missing`. Legitimate
+		//                  race: a concurrent orphan-write deleted the file
+		//                  between `listFilesInBranch` and the batch read.
+		//                  Skip and move on.
+		//   - `undefined`: `batchReadFilesFromBranch` did not emit an entry
+		//                  for this path. Contract violation — the helper
+		//                  populates the map by request order and must have
+		//                  one entry per input. Treat as a bug, not a race.
+		if (content === undefined) {
+			throw new Error(
+				`batchReadFilesFromBranch omitted ${path} — protocol contract violation (expected one entry per request)`,
+			);
+		}
+		if (content === null) {
+			skipped++;
+			continue;
+		}
+
+		let raw: CommitSummary;
+		try {
+			raw = JSON.parse(content) as CommitSummary;
+		} catch (err) {
+			log.warn("Skipping unparseable summary %s: %s", path, (err as Error).message);
+			skipped++;
+			continue;
+		}
+
+		const upgraded = upgradeOneSummary(raw, transcriptFileIds);
+		if (upgraded === raw) {
+			// Already v5 — leave the on-disk file untouched.
+			skipped++;
+			continue;
+		}
+
+		filesToWrite.push({
+			path,
+			content: JSON.stringify(upgraded, null, "\t"),
+		});
+		migrated++;
+	}
+
+	const fresh = summaryPaths.length === 0;
+	const completedAt = new Date().toISOString();
+	const finalState: SchemaV5MigrationState = {
+		version: 1,
+		status: "completed",
+		startedAt,
+		completedAt,
+		migratedCount: migrated,
+		skippedCount: skipped,
+		fresh,
+	};
+	filesToWrite.push({
+		path: SCHEMA_V5_STATE_FILE,
+		content: JSON.stringify(finalState, null, "\t"),
+	});
+
+	const commitMessage = fresh
+		? "Schema v5 migration: no pre-v5 data found"
+		: `Schema v5 migration: ${migrated} upgraded, ${skipped} skipped`;
+
+	log.info("Committing %d file(s) via fast-import...", filesToWrite.length);
+	const writeStart = Date.now();
+	// `storage` is built upstream of the orphan-write lock (in
+	// `migrateSchemaToV5`) so its `loadConfig()` I/O doesn't hold the lock.
+	// Routing the write through it (instead of `writeMultipleFilesToBranch`
+	// directly) gives dual-write users the shadow folder upgrade in the same
+	// pass — pre-fix, the shadow's `.jolli/summaries/<hash>.json` files
+	// stayed at the pre-migration version until normal post-commit traffic
+	// eventually rewrote them. In orphan-only mode this is equivalent to the
+	// old direct call (OrphanBranchStorage.writeFiles → writeMultipleFiles
+	// ToBranch). In folder-only mode the orphan branch stays untouched.
+	await storage.writeFiles(filesToWrite, commitMessage);
+	log.info(
+		"Schema v5 migration complete: %d migrated, %d skipped, fresh=%s (commit took %d ms)",
+		migrated,
+		skipped,
+		fresh,
+		Date.now() - writeStart,
+	);
+	if (preMigrationSHA) {
+		// Recovery hint for triage — NOT shown to users. Operators / support
+		// staff reading debug.log can roll back via:
+		//   git update-ref refs/heads/jollimemory/summaries/v3 <preMigrationSHA>
+		// (git reflog provides the same fallback if this log entry has rotated.)
+		log.info("Pre-migration orphan-branch SHA was %s (debug-only recovery anchor)", preMigrationSHA);
+	}
+
+	return { migrated, skipped, fresh, alreadyDone: false };
+}
+
+/**
+ * Upgrades one summary to v5. Returns the input reference unchanged when the
+ * summary is already v5 (idempotent fast-path).
+ *
+ * v3 → v4: delegated to `normalizeToV4`, now lossless (preserves topics,
+ *          recap, plans, notes, linearIssues, e2eTestGuide, jolliDoc fields,
+ *          orphanedDocIds, and migrates legacy `stats` to `diffStats`).
+ *
+ * v4 → v5: stamp `version: 5` and compute the transcripts array. We
+ *          enumerate every commit hash in the (already-v4) tree via
+ *          `collectAllTranscriptHashes` and keep only those that have a
+ *          `transcripts/{hash}.json` file on the orphan branch — those
+ *          hashes become the v5 transcript IDs verbatim, no rename.
+ *
+ * Idempotency guard for "v4 root that already has a v5-shaped `transcripts`
+ * array": this happens when a project writes summaries via the v5-aware
+ * pipeline BEFORE the migration has run (e.g. a fresh post-commit fires
+ * before the next activate() picks the migration up). Those summaries have
+ * version: 4 but an authoritative UUID-based transcripts array — we MUST NOT
+ * recompute `transcripts` via `collectAllTranscriptHashes`, because that
+ * would replace the UUID list with children commit hashes (typically dropping
+ * the v5 IDs entirely once the file-existence intersection runs). The guard
+ * leaves the array untouched and only bumps version.
+ */
+function upgradeOneSummary(raw: CommitSummary, transcriptFileIds: ReadonlySet<string>): CommitSummary {
+	if (raw.version >= 5) return raw;
+
+	const v4 = normalizeToV4(raw);
+
+	// v5-aware writer already populated transcripts on a v4 root — preserve it
+	// verbatim, only bump version. (Distinct from the v3/v4 read-fallback path
+	// where `transcripts` is undefined.)
+	if (v4.transcripts !== undefined) {
+		return { ...v4, version: 5 };
+	}
+
+	const candidateIds = collectAllTranscriptHashes(v4);
+	const transcripts = candidateIds.filter((id) => transcriptFileIds.has(id));
+
+	// v5 contract: always set the `transcripts` field on a v5 root, even if
+	// empty. Omitting it would force the read path back through the v3/v4
+	// children-walk fallback even on already-migrated data (defeating the
+	// fast-path purity that the v5 schema promises).
+	const v5: CommitSummary = {
+		...v4,
+		version: 5,
+		transcripts,
+	};
+	return v5;
+}
+
+export const __test__ = {
+	upgradeOneSummary,
+	SCHEMA_V5_STATE_FILE,
+};

--- a/cli/src/core/StorageProvider.ts
+++ b/cli/src/core/StorageProvider.ts
@@ -5,6 +5,20 @@ export interface StorageProvider {
 	readFile(path: string): Promise<string | null>;
 
 	/**
+	 * Read many files in one logical operation. Returns a Map keyed by the
+	 * requested path; a missing file maps to `null` (same contract as
+	 * `readFile`). The map MUST contain exactly one entry per requested path.
+	 *
+	 * Optional: backends that can batch cheaply implement this to avoid
+	 * per-file overhead (OrphanBranchStorage spawns one `git cat-file --batch`
+	 * instead of N subprocesses — the v5 migration's 336-file read dropped from
+	 * ~27 s to ~2 s on Windows because of this). Callers that need a batch read
+	 * but find the method absent (FolderStorage, where a local `readFile` per
+	 * path is already cheap) must fall back to looping `readFile` themselves.
+	 */
+	batchReadFiles?(paths: ReadonlyArray<string>): Promise<Map<string, string | null>>;
+
+	/**
 	 * Write multiple files in a single logical operation.
 	 *
 	 * Atomicity varies by implementation:

--- a/cli/src/core/SummaryStore.test.ts
+++ b/cli/src/core/SummaryStore.test.ts
@@ -4,7 +4,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 vi.mock("./GitOps.js", () => ({
 	readFileFromBranch: vi.fn(),
 	writeMultipleFilesToBranch: vi.fn(),
-	listFilesInBranch: vi.fn(),
+	// Default to an empty listing so `getTranscriptHashes` (now called by
+	// migrateOneToOne / mergeManyToOne to file-filter legacy transcript IDs)
+	// resolves to an iterable instead of `undefined`. Tests that need specific
+	// transcript files present override per-case.
+	listFilesInBranch: vi.fn().mockResolvedValue([]),
 	getTreeHash: vi.fn(),
 	getDiffStats: vi.fn(),
 	ensureOrphanBranch: vi.fn(),
@@ -129,6 +133,12 @@ describe("SummaryStore", () => {
 		vi.mocked(getDiffStats).mockResolvedValue({ filesChanged: 1, insertions: 5, deletions: 2 });
 		vi.mocked(acquireOrphanWriteLock).mockResolvedValue(true);
 		vi.mocked(releaseOrphanWriteLock).mockResolvedValue(undefined);
+		// Default empty transcript listing so `getTranscriptHashes` (called by
+		// migrateOneToOne / mergeManyToOne to file-filter legacy transcript IDs)
+		// resolves to an iterable. `resetAllMocks` wipes the factory default each
+		// test, so re-establish it here. Tests needing specific transcript files
+		// present override with `mockResolvedValueOnce`.
+		vi.mocked(listFilesInBranch).mockResolvedValue([]);
 	});
 
 	describe("storeSummary", () => {
@@ -760,6 +770,65 @@ describe("SummaryStore", () => {
 	});
 
 	describe("migrateOneToOne", () => {
+		it("hoists recap from a v3 squash root's children (recap not dropped on rebase-pick)", async () => {
+			// A v3 squash root keeps its recap on children, not the root. Reading
+			// oldSummary.recap directly would drop it; resolveEffectiveRecap picks
+			// the newest descendant's recap (mirrors normalizeToV4 + topics).
+			const oldHash = "oldhash0000000000000rec";
+			const newHash = "newhash0000000000000rec";
+			const oldSummary: CommitSummary = {
+				...createMockSummary(oldHash, "Squashed feature"),
+				recap: undefined, // root carries no recap (v3 squash shape)
+				children: [
+					{ ...createMockSummary("child0000000000000001"), recap: "Implemented the dark-mode toggle." },
+				],
+			};
+
+			vi.mocked(readFileFromBranch).mockResolvedValueOnce(JSON.stringify(v3Index([])));
+
+			await migrateOneToOne(oldSummary, createMockCommitInfo(newHash, "Rebased"));
+
+			const files = vi.mocked(writeMultipleFilesToBranch).mock.calls[0][1] as ReadonlyArray<FileWrite>;
+			const newSummary = JSON.parse(files[0].content) as CommitSummary;
+			expect(newSummary.recap).toBe("Implemented the dark-mode toggle.");
+		});
+
+		it("filters legacy-derived transcript IDs to those with a backing file (#4: no dangling IDs)", async () => {
+			// Legacy (v3) input → transcripts derived from the children tree, then
+			// filtered to commit hashes that actually have a transcript file —
+			// mirrors the v5 migration so a rebase-pick doesn't bake a dangling ID
+			// (a session-less commit) into the authoritative v5 array.
+			const oldHash = "oldhash0000000000000abc";
+			const newHash = "newhash0000000000000def";
+			const oldSummary = createMockSummary(oldHash, "Old message"); // v3, no transcripts field
+
+			vi.mocked(readFileFromBranch).mockResolvedValueOnce(JSON.stringify(v3Index([])));
+			// Only the old commit's transcript file exists on disk.
+			vi.mocked(listFilesInBranch).mockResolvedValueOnce([`transcripts/${oldHash}.json`]);
+
+			await migrateOneToOne(oldSummary, createMockCommitInfo(newHash, "New message"));
+
+			const files = vi.mocked(writeMultipleFilesToBranch).mock.calls[0][1] as ReadonlyArray<FileWrite>;
+			const newSummary = JSON.parse(files[0].content) as CommitSummary;
+			expect(newSummary.transcripts).toEqual([oldHash]);
+		});
+
+		it("drops a legacy transcript ID with no backing file from the migrated v5 array (#4)", async () => {
+			const oldHash = "oldhash0000000000000abc";
+			const newHash = "newhash0000000000000def";
+			const oldSummary = createMockSummary(oldHash, "Old message"); // session-less: no file
+
+			vi.mocked(readFileFromBranch).mockResolvedValueOnce(JSON.stringify(v3Index([])));
+			// No transcript files on disk → the dangling hash must not be carried.
+			vi.mocked(listFilesInBranch).mockResolvedValueOnce([]);
+
+			await migrateOneToOne(oldSummary, createMockCommitInfo(newHash, "New message"));
+
+			const files = vi.mocked(writeMultipleFilesToBranch).mock.calls[0][1] as ReadonlyArray<FileWrite>;
+			const newSummary = JSON.parse(files[0].content) as CommitSummary;
+			expect(newSummary.transcripts).toEqual([]);
+		});
+
 		it("should create a rebase container node wrapping the old summary as a child", async () => {
 			const oldHash = "oldhash0000000000000001";
 			const newHash = "newhash0000000000000002";
@@ -1074,6 +1143,25 @@ describe("SummaryStore", () => {
 	});
 
 	describe("mergeManyToOne", () => {
+		it("unions only file-backed legacy transcript IDs into the merged root (#4: no dangling IDs)", async () => {
+			const oldHash1 = "oldhash00000000000000a1";
+			const oldHash2 = "oldhash00000000000000a2";
+			const newHash = "newhash00000000000000a3";
+			// Two legacy (v3) sources; only the first has a transcript file.
+			const summary1 = createMockSummary(oldHash1, "First");
+			const summary2 = createMockSummary(oldHash2, "Second"); // session-less
+
+			vi.mocked(readFileFromBranch).mockResolvedValueOnce(JSON.stringify(v3Index([])));
+			vi.mocked(listFilesInBranch).mockResolvedValueOnce([`transcripts/${oldHash1}.json`]);
+
+			await mergeManyToOne([summary1, summary2], createMockCommitInfo(newHash, "Squashed"));
+
+			const files = vi.mocked(writeMultipleFilesToBranch).mock.calls[0][1] as ReadonlyArray<FileWrite>;
+			const merged = JSON.parse(files[0].content) as CommitSummary;
+			// oldHash2 had no transcript file → excluded; oldHash1 survives.
+			expect(merged.transcripts).toEqual([oldHash1]);
+		});
+
 		it("should place all source summaries as children sorted by commitDate descending", async () => {
 			const oldHash1 = "oldhash0000000000000001";
 			const oldHash2 = "oldhash0000000000000002";

--- a/cli/src/core/SummaryStore.test.ts
+++ b/cli/src/core/SummaryStore.test.ts
@@ -162,26 +162,29 @@ describe("SummaryStore", () => {
 			expect(indexContent.entries[0].topicCount).toBe(1);
 		});
 
-		it("should append a transcript artifact when transcript sessions are present", async () => {
+		it("should append a transcript artifact at the v5 transcript-id path when sessions are present", async () => {
 			vi.mocked(readFileFromBranch).mockResolvedValueOnce(JSON.stringify(v3Index([])));
 
 			const summary = createMockSummary();
 			await storeSummary(summary, undefined, false, {
 				transcript: {
-					sessions: [
-						{
-							sessionId: "claude/session-1",
-							source: "claude",
-							entries: [],
-						},
-					],
+					id: "transcript-uuid-1",
+					data: {
+						sessions: [
+							{
+								sessionId: "claude/session-1",
+								source: "claude",
+								entries: [],
+							},
+						],
+					},
 				},
 			});
 
 			const files = vi.mocked(writeMultipleFilesToBranch).mock.calls[0][1] as ReadonlyArray<FileWrite>;
 			// 3 base (summary + index + catalog) + 1 transcript appended after.
 			expect(files).toHaveLength(4);
-			expect(files[3]).toMatchObject({ path: "transcripts/abc123def456.json" });
+			expect(files[3]).toMatchObject({ path: "transcripts/transcript-uuid-1.json" });
 		});
 
 		it("should append plan progress artifacts when provided", async () => {
@@ -777,8 +780,9 @@ describe("SummaryStore", () => {
 			const newSummaryContent = JSON.parse(files[0].content) as CommitSummary;
 			expect(newSummaryContent.commitHash).toBe(newHash);
 			expect(newSummaryContent.commitMessage).toBe("New message");
-			// v4 root: commitType = "rebase"; topics + recap are now Copy-Hoisted from old.
-			expect(newSummaryContent.version).toBe(4);
+			// v5 root: commitType = "rebase"; topics + recap are Copy-Hoisted from
+			// old; the migrated summary inherits the source's transcripts array.
+			expect(newSummaryContent.version).toBe(5);
 			expect(newSummaryContent.commitType).toBe("rebase");
 			expect(newSummaryContent.topics).toEqual(oldSummary.topics);
 			expect(newSummaryContent.stats).toBeUndefined();
@@ -1107,8 +1111,8 @@ describe("SummaryStore", () => {
 			const mergedContent = JSON.parse(files[0].content) as CommitSummary;
 			expect(mergedContent.commitHash).toBe(newHash);
 			expect(mergedContent.commitMessage).toBe("Squashed commit");
-			// Root is v4 with consolidated topics/recap on root.
-			expect(mergedContent.version).toBe(4);
+			// Root is v5 with consolidated topics/recap on root + unioned transcripts.
+			expect(mergedContent.version).toBe(5);
 
 			// Children: sorted by commitDate desc -> summary2 (Feb 19) first, then summary1 (Feb 18).
 			// Topics are now stripped from children under the unified Hoist contract.
@@ -2156,6 +2160,30 @@ describe("SummaryStore", () => {
 			} finally {
 				rmSync(root, { recursive: true, force: true });
 			}
+		});
+
+		it("should accept v5 UUID filenames (with hyphens) alongside legacy hex hashes", async () => {
+			// The pre-fix regex required `[a-f0-9]+` which silently rejected v5
+			// UUIDs (`8-4-4-4-12` shape). With UUIDs missing from the file-list
+			// intersection, `SummaryWebviewPanel.refreshTranscriptHashes` would
+			// treat them as "not on disk" and drop them from the panel — hiding
+			// every conversation for v5-written summaries. Guard with mixed-
+			// namespace fixture so a future tightening of the pattern reverts.
+			vi.mocked(listFilesInBranch).mockResolvedValueOnce([
+				"transcripts/abc123def456.json", // legacy commit-hash style
+				"transcripts/01234567-89ab-cdef-0123-456789abcdef.json", // v5 UUID
+				"transcripts/AAAAAAAA-1234-5678-9ABC-DEFFFFFFFFFF.json", // upper-case UUID
+				"transcripts/skip-not-json.txt", // wrong extension
+				"other-dir/abc123.json", // wrong prefix
+			]);
+			const hashes = await getTranscriptHashes();
+			expect(hashes).toEqual(
+				new Set([
+					"abc123def456",
+					"01234567-89ab-cdef-0123-456789abcdef",
+					"AAAAAAAA-1234-5678-9ABC-DEFFFFFFFFFF",
+				]),
+			);
 		});
 	});
 

--- a/cli/src/core/SummaryStore.ts
+++ b/cli/src/core/SummaryStore.ts
@@ -49,9 +49,11 @@ import {
 	collectAllTopics,
 	collectDisplayTopics,
 	countTopics,
-	getTranscriptIds,
 	isUnifiedHoistFormat,
+	resolveDiffStats,
+	resolveTranscriptIdsFiltered,
 } from "./SummaryTree.js";
+import { transcriptIdFromPath } from "./TranscriptId.js";
 
 let activeStorageOverride: StorageProvider | undefined;
 
@@ -399,12 +401,19 @@ async function migrateOneToOneLocked(
 	// Legacy-aware Copy-Hoist of topics: v4 returns root.topics; v3 (legacy
 	// squash / legacy amend) flattens via collectAllTopics so no data drops.
 	const hoistedTopics = resolveEffectiveTopics(oldSummary);
+	// Same legacy-aware Copy-Hoist for recap. A v3 squash root keeps its recap on
+	// children (not the root), so reading `oldSummary.recap` directly would drop
+	// it on rebase-pick. `resolveEffectiveRecap` picks the root's recap when set,
+	// else the newest descendant's — matching normalizeToV4's behavior.
+	const hoistedRecap = resolveEffectiveRecap(oldSummary);
 
 	// Carry transcript IDs through 1:1 — rebase-pick doesn't change content,
 	// only commit hash. v5 data has them on root; v3/v4 data falls back to the
-	// children-tree walk via `getTranscriptIds`, keeping the same legacy
-	// commit-hash strings as opaque IDs (the files at those paths still exist).
-	const inheritedTranscriptIds = getTranscriptIds(oldSummary);
+	// children-tree walk, filtered to commit hashes that actually have a
+	// transcript file (mirrors the v5 migration's upgradeOneSummary so we don't
+	// bake dangling IDs for session-less commits into the authoritative array).
+	const existingTranscriptFileIds = await getTranscriptHashes(cwd, storage);
+	const inheritedTranscriptIds = resolveTranscriptIdsFiltered(oldSummary, existingTranscriptFileIds);
 
 	const newSummary: CommitSummary = {
 		version: CURRENT_SCHEMA_VERSION,
@@ -438,7 +447,7 @@ async function migrateOneToOneLocked(
 		// the rebased commit's webview would lose its Regenerate banner.
 		...(isSummaryError(oldSummary) && { summaryError: LLM_FAILED }),
 		topics: hoistedTopics,
-		...(oldSummary.recap && { recap: oldSummary.recap }),
+		...(hoistedRecap !== undefined ? { recap: hoistedRecap } : {}),
 		// v5 contract: always present, even if empty. Length-0 is the right
 		// signal for "no AI sessions captured for this commit" so the read path
 		// hits the fast `summary.transcripts` lookup instead of the v3/v4
@@ -742,14 +751,27 @@ export function normalizeToV4(summary: CommitSummary): CommitSummary {
 	const hoistedRecap = resolveEffectiveRecap(summary);
 
 	// Migrate v3 `stats` → v4 `diffStats` when only the legacy field is set.
-	// Display code's resolveDiffStats already does this fallback at read time,
-	// but normalizing here means persisted v5 data carries the canonical field
-	// and the fallback can eventually go away.
+	// Display code's resolveDiffStats does this fallback at read time, but
+	// normalizing here means persisted v5 data carries the canonical field and
+	// the read-time fallback can eventually go away — which it only can if the
+	// migrated record DROPS the legacy `stats`. So strip `stats` from the spread
+	// below (destructure it out); the value survives as `diffStats`.
+	//
+	// Stamp the AGGREGATE (`resolveDiffStats`), NOT the raw `stats`. For a
+	// container — e.g. an amend root whose own `stats` is just the delta — the
+	// pre-v5 display went through `resolveDiffStats` → `aggregateStats` (delta +
+	// children). Once we stamp `diffStats`, the v5 fast-path returns it directly
+	// and never re-aggregates, so stamping the raw delta would silently SHRINK
+	// the displayed files/insertions/deletions. `resolveDiffStats` returns the
+	// aggregate for containers and the node's own stats for leaves, so it stamps
+	// exactly what the old read path would have shown. (Called before the
+	// destructure so it still sees the original `stats` + children.)
 	const migratedDiffStats =
-		summary.diffStats === undefined && summary.stats !== undefined ? summary.stats : undefined;
+		summary.diffStats === undefined && summary.stats !== undefined ? resolveDiffStats(summary) : undefined;
+	const { stats: _, ...summaryWithoutStats } = summary;
 
 	return {
-		...summary,
+		...summaryWithoutStats,
 		version: 4,
 		topics: hoistedTopics,
 		...(hoistedRecap !== undefined ? { recap: hoistedRecap } : {}),
@@ -1034,10 +1056,15 @@ async function mergeManyToOneLocked(
 	// Squash kills the source commits in git history, so the merged root is
 	// the only "live" referrer to their transcript files — listing every ID
 	// at root is exactly what `getTranscriptIds(mergedRoot)` needs to find
-	// the full conversation set. Dedup via Set in case two sources share an
-	// ID (legitimate when a project has mixed migrated-from-v3 hashes that
-	// happen to collide — vanishingly rare but cheap to guard against).
-	const mergedTranscriptIds = Array.from(new Set<string>(children.flatMap((child) => getTranscriptIds(child))));
+	// the full conversation set. Legacy children walk the tree, filtered to
+	// hashes with a real transcript file (mirrors the v5 migration so no
+	// dangling IDs leak in); v5 children's arrays are authoritative. Dedup via
+	// Set in case two sources share an ID (legitimate when a project has mixed
+	// migrated-from-v3 hashes that happen to collide — rare but cheap to guard).
+	const existingTranscriptFileIds = await getTranscriptHashes(cwd, storage);
+	const mergedTranscriptIds = Array.from(
+		new Set<string>(children.flatMap((child) => resolveTranscriptIdsFiltered(child, existingTranscriptFileIds))),
+	);
 
 	const mergedSummary: CommitSummary = {
 		version: CURRENT_SCHEMA_VERSION,
@@ -1282,10 +1309,11 @@ export async function getTranscriptHashes(cwd?: string, storage?: StorageProvide
 	for (const filePath of files) {
 		// filePath = "transcripts/{id}.json" → extract "{id}". Tolerates any
 		// non-empty opaque-string ID, including legacy hex-only commit hashes
-		// and v5 UUIDs with hyphens.
-		const match = filePath.match(/^transcripts\/(.+)\.json$/);
-		if (match?.[1]) {
-			hashes.add(match[1]);
+		// and v5 UUIDs with hyphens. Shared parser keeps this in lockstep with
+		// the v5 migration's filename parsing.
+		const id = transcriptIdFromPath(filePath);
+		if (id) {
+			hashes.add(id);
 		}
 	}
 	return hashes;

--- a/cli/src/core/SummaryStore.ts
+++ b/cli/src/core/SummaryStore.ts
@@ -37,6 +37,7 @@ import type {
 	SummaryIndexEntry,
 	TopicSummary,
 } from "../Types.js";
+import { CURRENT_SCHEMA_VERSION } from "../Types.js";
 import { getDiffStats, getTreeHash } from "./GitOps.js";
 import { acquireOrphanWriteLock, releaseOrphanWriteLock } from "./Locks.js";
 import { OrphanBranchStorage } from "./OrphanBranchStorage.js";
@@ -44,7 +45,13 @@ import type { StorageProvider } from "./StorageProvider.js";
 import type { SquashConsolidationSource } from "./Summarizer.js";
 import { isSummaryError, LLM_FAILED } from "./SummaryErrorMarker.js";
 import { getDisplayDate } from "./SummaryFormat.js";
-import { collectAllTopics, collectDisplayTopics, countTopics, isUnifiedHoistFormat } from "./SummaryTree.js";
+import {
+	collectAllTopics,
+	collectDisplayTopics,
+	countTopics,
+	getTranscriptIds,
+	isUnifiedHoistFormat,
+} from "./SummaryTree.js";
 
 let activeStorageOverride: StorageProvider | undefined;
 
@@ -188,8 +195,13 @@ function unionCatalogs(writeCatalog: CommitCatalog | null, readCatalog: CommitCa
  * @param cwd         - Optional working directory (git repo root)
  * @param force       - When true, overwrites an existing summary for the same commit hash
  *                      instead of skipping (used by the manual `summarize` CLI command)
- * @param artifacts   - Optional artifacts to store atomically alongside the summary
- *                      (e.g., transcript data saved as `transcripts/{commitHash}.json`)
+ * @param artifacts   - Optional artifacts to store atomically alongside the summary.
+ *                      `transcript.id` is the v5 transcript ID under which the data
+ *                      is persisted (`transcripts/{id}.json`). Callers MUST also set
+ *                      `summary.transcripts` to include this ID — `storeSummary` does
+ *                      not stamp it on automatically. Generate the ID via
+ *                      `generateTranscriptId()` for new content; for migration paths
+ *                      that reuse a legacy commit-hash filename, pass that hash here.
  * @param storage     - Write storage. Drives the actual writeFiles call.
  * @param readStorage - Optional secondary read storage whose index/catalog rows
  *                      must be preserved in the upcoming dual-write. When passed
@@ -208,7 +220,7 @@ export async function storeSummary(
 	cwd?: string,
 	force = false,
 	artifacts?: {
-		readonly transcript?: StoredTranscript;
+		readonly transcript?: { readonly id: string; readonly data: StoredTranscript };
 		readonly planProgress?: ReadonlyArray<PlanProgressArtifact>;
 	},
 	storage?: StorageProvider,
@@ -276,11 +288,13 @@ export async function storeSummary(
 			buildCatalogFileWrite(existingCatalog, entryMap, summary),
 		];
 
-		// Append transcript file if provided
-		if (artifacts?.transcript && artifacts.transcript.sessions.length > 0) {
+		// Append transcript file if provided. Path is keyed by the v5 transcript
+		// ID, not the commit hash — caller is responsible for matching the ID to
+		// the IDs listed in `summary.transcripts`.
+		if (artifacts?.transcript && artifacts.transcript.data.sessions.length > 0) {
 			files.push({
-				path: `transcripts/${summary.commitHash}.json`,
-				content: JSON.stringify(artifacts.transcript, null, "\t"),
+				path: `transcripts/${artifacts.transcript.id}.json`,
+				content: JSON.stringify(artifacts.transcript.data, null, "\t"),
 			});
 		}
 
@@ -386,8 +400,14 @@ async function migrateOneToOneLocked(
 	// squash / legacy amend) flattens via collectAllTopics so no data drops.
 	const hoistedTopics = resolveEffectiveTopics(oldSummary);
 
+	// Carry transcript IDs through 1:1 — rebase-pick doesn't change content,
+	// only commit hash. v5 data has them on root; v3/v4 data falls back to the
+	// children-tree walk via `getTranscriptIds`, keeping the same legacy
+	// commit-hash strings as opaque IDs (the files at those paths still exist).
+	const inheritedTranscriptIds = getTranscriptIds(oldSummary);
+
 	const newSummary: CommitSummary = {
-		version: 4,
+		version: CURRENT_SCHEMA_VERSION,
 		commitHash: newCommitInfo.hash,
 		commitMessage: newCommitInfo.message,
 		commitAuthor: newCommitInfo.author,
@@ -419,6 +439,11 @@ async function migrateOneToOneLocked(
 		...(isSummaryError(oldSummary) && { summaryError: LLM_FAILED }),
 		topics: hoistedTopics,
 		...(oldSummary.recap && { recap: oldSummary.recap }),
+		// v5 contract: always present, even if empty. Length-0 is the right
+		// signal for "no AI sessions captured for this commit" so the read path
+		// hits the fast `summary.transcripts` lookup instead of the v3/v4
+		// children-walk fallback.
+		transcripts: inheritedTranscriptIds,
 		diffStats: migratedDiffStats,
 		children: [strippedOld],
 	};
@@ -663,16 +688,30 @@ function collectDescendantOrphanedDocIds(children: ReadonlyArray<CommitSummary> 
  *     linearIssues / e2eTestGuide / jolliDocId / jolliDocUrl /
  *     orphanedDocIds), unioned across the whole tree via the same
  *     `collectChild*` helpers
+ *   - root holds authoritative `topics` and `recap` collected from the
+ *     entire tree via `resolveEffectiveTopics` / `resolveEffectiveRecap`
+ *     (added 2026-05-22 so v5 migration and any other lossless caller can
+ *     trust the helper without external rescue logic)
+ *   - root holds `diffStats` (migrated from legacy `stats` when needed)
  *   - every descendant is stripped of own-hoist fields
  *
- * Deliberately leaves `topics`, `recap`, `ticketId` on the root untouched.
- * Regenerate (the primary caller) overwrites topics + recap from a fresh
- * LLM call afterwards; ticketId is preserved per the same rule that lives
- * in Regenerator.ts. A no-op for v4 input (returns the same reference).
+ * The earlier draft of this helper left topics/recap on the root untouched
+ * because the only caller (Regenerator) was about to overwrite them with a
+ * fresh LLM call. That made the helper lossy for v3 squash roots (whose
+ * topics live in children, not on root). Now lossless: callers that want
+ * fresh topics/recap (Regenerator) overwrite the returned object explicitly;
+ * callers that want preservation (v5 migration) just use the result as-is.
  *
- * Used by Regenerator and RegenerateContext to collapse all v3-special-
- * casing in their hot paths — once normalized, downstream code can assume
- * a clean v4 tree.
+ * Leaves `ticketId` on the root untouched — for v3 data ticketId already
+ * lives on the root by construction.
+ *
+ * A no-op for v4 input (returns the same reference). The version gate is
+ * `>= 4`, not `=== 4`, so v5+ input is also a no-op — see the test fixture
+ * pinning this behavior in normalizeToV4.test.ts.
+ *
+ * Used by Regenerator, RegenerateContext, and the v5 schema migration to
+ * collapse all v3-special-casing — once normalized, downstream code can
+ * assume a clean v4 tree (topics/recap/diffStats all populated on root).
  */
 export function normalizeToV4(summary: CommitSummary): CommitSummary {
 	if (summary.version >= 4) return summary;
@@ -693,9 +732,28 @@ export function normalizeToV4(summary: CommitSummary): CommitSummary {
 		]),
 	);
 
+	// Hoist topics + recap from anywhere in the tree. Without this, v3 squash
+	// roots (whose topics live in children) would normalize into a root with
+	// empty topics, and stripFunctionalMetadata would then drop the children
+	// topics too — data loss. resolveEffectiveTopics already exists for the
+	// same reason in the rebase/squash migration paths; resolveEffectiveRecap
+	// is its newly-added recap counterpart.
+	const hoistedTopics = resolveEffectiveTopics(summary);
+	const hoistedRecap = resolveEffectiveRecap(summary);
+
+	// Migrate v3 `stats` → v4 `diffStats` when only the legacy field is set.
+	// Display code's resolveDiffStats already does this fallback at read time,
+	// but normalizing here means persisted v5 data carries the canonical field
+	// and the fallback can eventually go away.
+	const migratedDiffStats =
+		summary.diffStats === undefined && summary.stats !== undefined ? summary.stats : undefined;
+
 	return {
 		...summary,
 		version: 4,
+		topics: hoistedTopics,
+		...(hoistedRecap !== undefined ? { recap: hoistedRecap } : {}),
+		...(migratedDiffStats !== undefined ? { diffStats: migratedDiffStats } : {}),
 		...(hoistedE2e.length > 0 ? { e2eTestGuide: hoistedE2e } : {}),
 		...(hoistedPlans.length > 0 ? { plans: hoistedPlans } : {}),
 		...(hoistedNotes.length > 0 ? { notes: hoistedNotes } : {}),
@@ -747,6 +805,56 @@ function stripRecap(node: CommitSummary): CommitSummary {
 export function resolveEffectiveTopics(oldSummary: CommitSummary): ReadonlyArray<TopicSummary> {
 	if (isUnifiedHoistFormat(oldSummary)) return oldSummary.topics ?? [];
 	return collectAllTopics(oldSummary).map(({ commitDate: _cd, generatedAt: _ga, treeIndex: _ti, ...topic }) => topic);
+}
+
+/**
+ * Returns the recap string to use as Copy-Hoist source when normalizing v3
+ * legacy data to v4. Companion to `resolveEffectiveTopics`.
+ *
+ * Priority:
+ *   - v4+ (unified Hoist): root.recap is authoritative — return it directly.
+ *     May legitimately be undefined for topic-only commits.
+ *   - v3 with root.recap set: root wins. Both legacy squash and legacy amend
+ *     pipelines historically wrote recap to root, so this is the common case.
+ *   - v3 with no root.recap but children carry one: pick the newest child's
+ *     recap by display date (commitDate ?? generatedAt). Picks a single
+ *     representative rather than concatenating because recap is semantically
+ *     singular (one paragraph for this commit's work).
+ *
+ * Returns undefined when no node in the tree has a non-empty recap.
+ */
+export function resolveEffectiveRecap(oldSummary: CommitSummary): string | undefined {
+	if (isUnifiedHoistFormat(oldSummary)) return oldSummary.recap;
+	if (oldSummary.recap) return oldSummary.recap;
+	return pickNewestDescendantRecap(oldSummary.children);
+}
+
+/**
+ * Walks descendants depth-first collecting (recap, displayDate) pairs, then
+ * returns the newest one. Stable secondary order falls out of traversal order
+ * when display dates tie.
+ */
+function pickNewestDescendantRecap(children: ReadonlyArray<CommitSummary> | undefined): string | undefined {
+	if (!children || children.length === 0) return undefined;
+	const candidates: Array<{ readonly recap: string; readonly date: string }> = [];
+	collectRecapCandidates(children, candidates);
+	if (candidates.length === 0) return undefined;
+	candidates.sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
+	return candidates[0]?.recap;
+}
+
+function collectRecapCandidates(
+	nodes: ReadonlyArray<CommitSummary>,
+	out: Array<{ readonly recap: string; readonly date: string }>,
+): void {
+	for (const node of nodes) {
+		if (node.recap) {
+			out.push({ recap: node.recap, date: getDisplayDate(node) });
+		}
+		if (node.children) {
+			collectRecapCandidates(node.children, out);
+		}
+	}
 }
 
 /**
@@ -922,8 +1030,17 @@ async function mergeManyToOneLocked(
 	const consolidatedLlm = consolidated?.llm;
 	const consolidatedSummaryError = consolidated?.summaryError;
 
+	// Union the transcript IDs from every source commit into the merged root.
+	// Squash kills the source commits in git history, so the merged root is
+	// the only "live" referrer to their transcript files — listing every ID
+	// at root is exactly what `getTranscriptIds(mergedRoot)` needs to find
+	// the full conversation set. Dedup via Set in case two sources share an
+	// ID (legitimate when a project has mixed migrated-from-v3 hashes that
+	// happen to collide — vanishingly rare but cheap to guard against).
+	const mergedTranscriptIds = Array.from(new Set<string>(children.flatMap((child) => getTranscriptIds(child))));
+
 	const mergedSummary: CommitSummary = {
-		version: 4,
+		version: CURRENT_SCHEMA_VERSION,
 		commitHash: newCommitInfo.hash,
 		commitMessage: newCommitInfo.message,
 		commitAuthor: newCommitInfo.author,
@@ -943,6 +1060,8 @@ async function mergeManyToOneLocked(
 		...(allOrphanedDocIds.length > 0 && { orphanedDocIds: allOrphanedDocIds }),
 		topics: consolidatedTopics,
 		...(consolidatedRecap && { recap: consolidatedRecap }),
+		// v5 contract: always present, even if empty (see migrateOneToOne note).
+		transcripts: mergedTranscriptIds,
 		diffStats: mergedDiffStats,
 		children: strippedChildren,
 	};
@@ -1144,17 +1263,28 @@ export async function deleteTranscript(commitHash: string, cwd?: string, storage
 }
 
 /**
- * Returns the set of commit hashes that have transcript files in the orphan branch.
+ * Returns the set of transcript IDs whose files exist in the orphan branch.
  * Scans the `transcripts/` prefix via the active storage provider.
+ *
+ * Filename grammar: `transcripts/{transcriptId}.json` where `transcriptId` is
+ * an opaque string. Pre-v5 ("legacy") IDs reuse commit-hash text — all lower-
+ * case hex; v5+ IDs are UUID v4 with hyphens (e.g.
+ * `01234567-89ab-cdef-0123-456789abcdef`). The match accepts BOTH by extracting
+ * everything before `.json` without assuming a format — earlier versions of
+ * this helper used `[a-f0-9]+` and silently dropped v5 UUID files from the
+ * intersection in `SummaryWebviewPanel.refreshTranscriptHashes`, hiding all
+ * conversations for v5-written summaries.
  */
 export async function getTranscriptHashes(cwd?: string, storage?: StorageProvider): Promise<Set<string>> {
 	const store = resolveStorage(storage, cwd);
 	const files = await store.listFiles("transcripts/");
 	const hashes = new Set<string>();
 	for (const filePath of files) {
-		// filePath = "transcripts/abc123.json" → extract "abc123"
-		const match = filePath.match(/^transcripts\/([a-f0-9]+)\.json$/);
-		if (match) {
+		// filePath = "transcripts/{id}.json" → extract "{id}". Tolerates any
+		// non-empty opaque-string ID, including legacy hex-only commit hashes
+		// and v5 UUIDs with hyphens.
+		const match = filePath.match(/^transcripts\/(.+)\.json$/);
+		if (match?.[1]) {
 			hashes.add(match[1]);
 		}
 	}

--- a/cli/src/core/SummaryTree.test.ts
+++ b/cli/src/core/SummaryTree.test.ts
@@ -15,6 +15,7 @@ import {
 	isLeafNode,
 	isUnifiedHoistFormat,
 	resolveDiffStats,
+	resolveTranscriptIdsFiltered,
 	updateTopicInTree,
 } from "./SummaryTree.js";
 
@@ -273,6 +274,23 @@ describe("SummaryTree", () => {
 		it("falls back to collectAllTranscriptHashes when transcripts is undefined (v3/v4 schema)", () => {
 			// transcripts field absent → v3/v4 schema → derive from the tree.
 			expect(getTranscriptIds(A)).toEqual(["aaa"]);
+		});
+	});
+
+	describe("resolveTranscriptIdsFiltered", () => {
+		it("returns the v5 transcripts field verbatim, ignoring existingFileIds", () => {
+			// v5 arrays are authoritative — NOT filtered against on-disk files.
+			const v5 = { ...A, version: 5, transcripts: ["uuid-1", "uuid-2"] } as CommitSummary;
+			expect(resolveTranscriptIdsFiltered(v5, new Set())).toEqual(["uuid-1", "uuid-2"]);
+		});
+
+		it("filters legacy tree-walk IDs down to those with a backing file", () => {
+			// D walks to ["ddd","bbb","ccc","aaa"]; only file-backed hashes survive.
+			expect(resolveTranscriptIdsFiltered(D, new Set(["ddd", "aaa"]))).toEqual(["ddd", "aaa"]);
+		});
+
+		it("returns [] for legacy input when no tree hash has a file (no dangling IDs baked in)", () => {
+			expect(resolveTranscriptIdsFiltered(C, new Set())).toEqual([]);
 		});
 	});
 

--- a/cli/src/core/SummaryTree.test.ts
+++ b/cli/src/core/SummaryTree.test.ts
@@ -11,6 +11,7 @@ import {
 	countTopics,
 	deleteTopicInTree,
 	formatDurationLabel,
+	getTranscriptIds,
 	isLeafNode,
 	isUnifiedHoistFormat,
 	resolveDiffStats,
@@ -252,6 +253,26 @@ describe("SummaryTree", () => {
 		it("returns empty array for v4 root with undefined topics (covers `?? []` fallback)", () => {
 			const noTopics: CommitSummary = { ...A, version: 4, topics: undefined };
 			expect(collectDisplayTopics(noTopics)).toEqual([]);
+		});
+	});
+
+	describe("getTranscriptIds", () => {
+		it("returns the v5 transcripts field verbatim when present", () => {
+			const v5 = { ...A, version: 5, transcripts: ["uuid-1", "uuid-2"] } as CommitSummary;
+			expect(getTranscriptIds(v5)).toEqual(["uuid-1", "uuid-2"]);
+		});
+
+		it("returns an empty v5 transcripts array verbatim (not a fallback)", () => {
+			// The empty-array case is meaningfully distinct from the undefined
+			// case: v5 explicitly states "no AI sessions captured", while
+			// undefined means "v3/v4 schema, fall back to children walk".
+			const v5Empty = { ...A, version: 5, transcripts: [] } as CommitSummary;
+			expect(getTranscriptIds(v5Empty)).toEqual([]);
+		});
+
+		it("falls back to collectAllTranscriptHashes when transcripts is undefined (v3/v4 schema)", () => {
+			// transcripts field absent → v3/v4 schema → derive from the tree.
+			expect(getTranscriptIds(A)).toEqual(["aaa"]);
 		});
 	});
 

--- a/cli/src/core/SummaryTree.ts
+++ b/cli/src/core/SummaryTree.ts
@@ -180,8 +180,14 @@ export function collectDisplayTopics(node: CommitSummary): ReadonlyArray<TopicWi
  * files for all commits whose work is embedded in this summary tree.
  *
  * Companion to readTranscript(hash) in SummaryStore — together they implement
- * the "transcripts are by-hash, not Hoisted" model: physical files stay at
- * `transcripts/{originalHash}.json`, display walks the tree to discover hashes.
+ * the legacy "transcripts are by-hash, not Hoisted" model: physical files
+ * stay at `transcripts/{originalHash}.json`, display walks the tree to
+ * discover hashes.
+ *
+ * In v5 this role is taken over by `summary.transcripts` + `getTranscriptIds`.
+ * This function is kept as the fallback path for v3/v4 data during the
+ * deprecation window; once telemetry confirms ≥95% projects have migrated
+ * to v5 it can be removed alongside the other v3/v4 compatibility code.
  */
 export function collectAllTranscriptHashes(node: CommitSummary): ReadonlyArray<string> {
 	const hashes: string[] = [node.commitHash];
@@ -189,6 +195,28 @@ export function collectAllTranscriptHashes(node: CommitSummary): ReadonlyArray<s
 		hashes.push(...collectAllTranscriptHashes(child));
 	}
 	return hashes;
+}
+
+/**
+ * Returns the list of transcript IDs for a summary, tolerating v3/v4/v5 data.
+ *
+ * This is THE Release N compatibility entry point — every caller that needs
+ * "which transcript files does this summary reference" funnels through here:
+ *   - v5 fast path (the common case after migration completes): the summary
+ *     carries an authoritative `transcripts: string[]` field; return it.
+ *   - v3/v4 fallback (legacy data, or v5 migration not yet completed for
+ *     this project): walk the children tree via `collectAllTranscriptHashes`
+ *     and treat each commit hash as an opaque transcript ID — this is how
+ *     transcript files are physically stored on disk in the pre-v5 world,
+ *     and the v5 migration deliberately keeps those filenames so the v5
+ *     `transcripts` array can reuse the same strings as IDs without a rename.
+ *
+ * Release N+M cleanup: drop the fallback branch and reduce to
+ * `return summary.transcripts ?? []` once all read paths can trust v5 schema.
+ */
+export function getTranscriptIds(summary: CommitSummary): ReadonlyArray<string> {
+	if (summary.transcripts !== undefined) return summary.transcripts;
+	return collectAllTranscriptHashes(summary);
 }
 
 /**

--- a/cli/src/core/SummaryTree.ts
+++ b/cli/src/core/SummaryTree.ts
@@ -220,6 +220,28 @@ export function getTranscriptIds(summary: CommitSummary): ReadonlyArray<string> 
 }
 
 /**
+ * Like `getTranscriptIds`, but for the WRITE side: when materializing an
+ * authoritative v5 `transcripts` array from a (possibly legacy) summary, the
+ * legacy tree-walk must be filtered to IDs that actually have a backing
+ * `transcripts/<id>.json` file (`existingFileIds`). v5 input is already
+ * authoritative and passes through unchanged.
+ *
+ * This mirrors the v5 migration's `upgradeOneSummary` filtering, so the live
+ * construction paths (migrateOneToOne / mergeManyToOne / the panel's lazy
+ * upgrade) and the migration agree on which IDs land in the authoritative
+ * array — without it, a squash/rebase/amend of legacy data bakes "dangling"
+ * commit-hash IDs (commits that never had an AI session, so no file) into the
+ * v5 record, violating the "authoritative + file-backed" contract.
+ */
+export function resolveTranscriptIdsFiltered(
+	summary: CommitSummary,
+	existingFileIds: ReadonlySet<string>,
+): ReadonlyArray<string> {
+	if (summary.transcripts !== undefined) return summary.transcripts;
+	return collectAllTranscriptHashes(summary).filter((id) => existingFileIds.has(id));
+}
+
+/**
  * Updates a topic at a global index within the tree, returning a new tree.
  * The global index follows the same chronological order as `collectAllTopics`.
  * Returns null if the index is out of range.

--- a/cli/src/core/TranscriptId.test.ts
+++ b/cli/src/core/TranscriptId.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { generateTranscriptId, transcriptIdFromPath } from "./TranscriptId.js";
+
+describe("TranscriptId", () => {
+	describe("generateTranscriptId", () => {
+		it("returns an RFC 4122 v4 UUID", () => {
+			expect(generateTranscriptId()).toMatch(
+				/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+			);
+		});
+
+		it("returns a fresh value on each call", () => {
+			expect(generateTranscriptId()).not.toBe(generateTranscriptId());
+		});
+	});
+
+	describe("transcriptIdFromPath", () => {
+		it("extracts the opaque ID from a transcripts/<id>.json path", () => {
+			expect(transcriptIdFromPath("transcripts/abc123.json")).toBe("abc123");
+		});
+
+		it("extracts a v5 UUID (with hyphens) — not just hex commit hashes", () => {
+			expect(transcriptIdFromPath("transcripts/01234567-89ab-cdef-0123-456789abcdef.json")).toBe(
+				"01234567-89ab-cdef-0123-456789abcdef",
+			);
+		});
+
+		it("returns null for a path outside transcripts/ or without a .json extension", () => {
+			expect(transcriptIdFromPath("summaries/abc.json")).toBeNull();
+			expect(transcriptIdFromPath("transcripts/stray.txt")).toBeNull();
+			expect(transcriptIdFromPath("transcripts/.json")).toBeNull();
+		});
+	});
+});

--- a/cli/src/core/TranscriptId.ts
+++ b/cli/src/core/TranscriptId.ts
@@ -24,3 +24,21 @@ import { randomUUID } from "node:crypto";
 export function generateTranscriptId(): string {
 	return randomUUID();
 }
+
+/** Matches a transcript file path `transcripts/<id>.json`, capturing the ID. */
+const TRANSCRIPT_FILE_PATH = /^transcripts\/(.+)\.json$/;
+
+/**
+ * Extracts the opaque transcript ID from a `transcripts/<id>.json` storage
+ * path, or returns null when the path is not a transcript file. The ID is
+ * format-agnostic (legacy hex commit hashes AND v5 UUIDs with hyphens both
+ * match) — see `SummaryStore.getTranscriptHashes` for the bug that a stricter
+ * `[a-f0-9]+` pattern caused.
+ *
+ * Single source of truth: both `SummaryStore.getTranscriptHashes` and the v5
+ * migration parse transcript filenames, and they patch the same "dropped UUID"
+ * bug — keeping the regex here stops the two copies from drifting apart.
+ */
+export function transcriptIdFromPath(path: string): string | null {
+	return TRANSCRIPT_FILE_PATH.exec(path)?.[1] ?? null;
+}

--- a/cli/src/core/TranscriptId.ts
+++ b/cli/src/core/TranscriptId.ts
@@ -1,0 +1,26 @@
+/**
+ * Transcript ID utilities (v5 schema).
+ *
+ * Centralizes ID generation so every write path uses the same opaque-UUID
+ * scheme. Keeping this as a single export prevents drift (e.g. one caller
+ * accidentally using the commit hash as the file name) and gives the v5
+ * migration a clear target to lint against.
+ *
+ * The ID is treated as opaque by all consumers: readTranscript / display /
+ * CleanCommand all take it as a string and never assume a particular format.
+ * Legacy migration reuses the commit hash string verbatim as the ID (mixed
+ * namespace with new UUIDs is fine — both are valid opaque IDs).
+ */
+import { randomUUID } from "node:crypto";
+
+/**
+ * Returns a fresh transcript ID for newly written transcripts. Always
+ * produces a RFC 4122 UUID v4 (e.g. `01234567-89ab-cdef-0123-456789abcdef`).
+ *
+ * Do NOT reuse a commit hash here — that path is reserved for the v5 schema
+ * migration's "legacy preservation" mode, where existing commit-hash-named
+ * files become the IDs without a file rename.
+ */
+export function generateTranscriptId(): string {
+	return randomUUID();
+}

--- a/cli/src/core/normalizeToV4.test.ts
+++ b/cli/src/core/normalizeToV4.test.ts
@@ -245,4 +245,147 @@ describe("normalizeToV4", () => {
 		expect(normalized.jolliDocId).toBeUndefined();
 		expect(normalized.orphanedDocIds).toBeUndefined();
 	});
+
+	// ─── Lossless contract (added 2026-05-22 for v5 migration) ────────────────
+	//
+	// These cases pin the contract that callers other than Regenerator can rely
+	// on the normalized result without separately rescuing topics/recap/stats.
+	// The earlier behavior (root spread, no topic/recap collection) silently
+	// dropped data for v3 squash/amend layouts; v5 migration cannot tolerate
+	// that loss because it does not run an LLM call to repopulate.
+
+	it("preserves topics from v3 squash root with topics-in-children layout", () => {
+		// Legacy v3 squash root layout: root has no topics; topics live on the
+		// individual source-commit children. Without lossless hoist, the strip
+		// step would erase them and the migrated v4 root would have topics=[].
+		const v3Squash: CommitSummary = {
+			...baseNode,
+			version: 3,
+			topics: [],
+			children: [
+				{
+					...baseNode,
+					commitHash: "child-1",
+					version: 3,
+					topics: [{ title: "Child topic 1", trigger: "t1", response: "r1", decisions: "d1" }],
+				} as CommitSummary,
+				{
+					...baseNode,
+					commitHash: "child-2",
+					version: 3,
+					topics: [{ title: "Child topic 2", trigger: "t2", response: "r2", decisions: "d2" }],
+				} as CommitSummary,
+			],
+		} as CommitSummary;
+		const normalized = normalizeToV4(v3Squash);
+		expect(normalized.topics).toHaveLength(2);
+		const titles = (normalized.topics ?? []).map((t) => t.title);
+		expect(titles).toContain("Child topic 1");
+		expect(titles).toContain("Child topic 2");
+	});
+
+	it("preserves recap from v3 amend root with recap-in-children layout", () => {
+		// v3 amend root may have its own delta recap on root OR may have none
+		// (older pipelines). Pick newest descendant recap when root has none.
+		// Discriminator is `getDisplayDate` which prefers `generatedAt` over
+		// `commitDate`, so the fixture differentiates generatedAt on children.
+		const v3AmendChildRecap: CommitSummary = {
+			...baseNode,
+			version: 3,
+			children: [
+				{
+					...baseNode,
+					commitHash: "older-amend",
+					commitDate: "2026-05-18T00:00:00Z",
+					generatedAt: "2026-05-18T00:01:00Z",
+					version: 3,
+					recap: "older recap",
+				} as CommitSummary,
+				{
+					...baseNode,
+					commitHash: "newer-amend",
+					commitDate: "2026-05-20T00:00:00Z",
+					generatedAt: "2026-05-20T00:01:00Z",
+					version: 3,
+					recap: "newest recap",
+				} as CommitSummary,
+			],
+		} as CommitSummary;
+		const normalized = normalizeToV4(v3AmendChildRecap);
+		expect(normalized.recap).toBe("newest recap");
+	});
+
+	it("keeps v3 root recap when present (squash/amend pipelines write it there)", () => {
+		const v3WithRootRecap: CommitSummary = {
+			...baseNode,
+			version: 3,
+			recap: "root-level recap",
+			children: [
+				{
+					...baseNode,
+					commitHash: "c1",
+					version: 3,
+					recap: "child recap should not win",
+				} as CommitSummary,
+			],
+		} as CommitSummary;
+		const normalized = normalizeToV4(v3WithRootRecap);
+		expect(normalized.recap).toBe("root-level recap");
+	});
+
+	it("migrates v3 `stats` → v4 `diffStats` when only the legacy field is set", () => {
+		// v3 stored diff info on `stats`; v4 standardized on `diffStats`. After
+		// lossless normalize the v4 root carries the canonical `diffStats` so
+		// downstream code doesn't need the `?? stats` fallback forever.
+		const v3WithStats: CommitSummary = {
+			...baseNode,
+			version: 3,
+			stats: { filesChanged: 5, insertions: 10, deletions: 3 },
+		} as CommitSummary;
+		const normalized = normalizeToV4(v3WithStats);
+		expect(normalized.diffStats).toEqual({ filesChanged: 5, insertions: 10, deletions: 3 });
+	});
+
+	it("does not overwrite v3 `diffStats` when both fields are present (rare but valid)", () => {
+		const v3Both: CommitSummary = {
+			...baseNode,
+			version: 3,
+			stats: { filesChanged: 1, insertions: 1, deletions: 1 },
+			diffStats: { filesChanged: 9, insertions: 9, deletions: 9 },
+		} as CommitSummary;
+		const normalized = normalizeToV4(v3Both);
+		expect(normalized.diffStats).toEqual({ filesChanged: 9, insertions: 9, deletions: 9 });
+	});
+
+	it("Regenerator-style overwrite path: caller can still freely replace topics/recap on the normalized result", () => {
+		// Sanity check that the lossless behavior does not lock topics/recap.
+		// Regenerator wraps normalize with `{ ...normalized, topics: result.topics }`
+		// and that must still work — we only widened what normalize preserves
+		// when the caller chooses to keep it.
+		const v3: CommitSummary = {
+			...baseNode,
+			version: 3,
+			children: [
+				{
+					...baseNode,
+					commitHash: "c1",
+					version: 3,
+					topics: [{ title: "preserved", trigger: "t", response: "r", decisions: "d" }],
+					recap: "preserved recap",
+				} as CommitSummary,
+			],
+		} as CommitSummary;
+		const normalized = normalizeToV4(v3);
+		const overwritten: CommitSummary = {
+			...normalized,
+			topics: [{ title: "fresh", trigger: "T", response: "R", decisions: "D" }],
+			recap: "fresh recap",
+		} as CommitSummary;
+		expect(overwritten.topics?.[0]?.title).toBe("fresh");
+		expect(overwritten.recap).toBe("fresh recap");
+		// And the original normalized object is unmodified — caller's spread is
+		// the only place that swapped values.
+		expect(normalized.topics?.[0]?.title).toBe("preserved");
+		expect(normalized.recap).toBe("preserved recap");
+	});
 });

--- a/cli/src/hooks/PostCommitHook.helpers.test.ts
+++ b/cli/src/hooks/PostCommitHook.helpers.test.ts
@@ -123,6 +123,10 @@ vi.mock("../core/GitOps.js", () => ({
 	getDiffStats: mockGetDiffStats,
 	getCurrentBranch: mockGetCurrentBranch,
 	getLastReflogAction: mockGetLastReflogAction,
+	// handleAmendPipeline now file-filters a legacy oldSummary's transcript IDs
+	// via getTranscriptHashes → OrphanBranchStorage.listFiles. Empty listing is
+	// fine here — these tests don't assert on the resulting transcripts array.
+	listFilesInBranch: vi.fn().mockResolvedValue([]),
 }));
 
 vi.mock("../core/SessionTracker.js", () => ({

--- a/cli/src/hooks/PostCommitHook.helpers.test.ts
+++ b/cli/src/hooks/PostCommitHook.helpers.test.ts
@@ -1147,9 +1147,15 @@ describe("PostCommitHook helpers", () => {
 			// Pin the force flag at position 2 — short-circuit must never overwrite
 			// existing summaries (that's a Full-pipeline force semantic, not amend).
 			expect(storeArgs[2]).toBe(false);
-			const artifacts = storeArgs[3] as { transcript?: { sessions: ReadonlyArray<unknown> } } | undefined;
+			// v5 artifact shape: `{ transcript: { id, data: { sessions: [...] } } }`.
+			// `id` is the new transcript-ID minted by generateTranscriptId() that
+			// also lands in `summary.transcripts`.
+			const artifacts = storeArgs[3] as
+				| { transcript?: { id: string; data: { sessions: ReadonlyArray<unknown> } } }
+				| undefined;
 			expect(artifacts?.transcript).toBeDefined();
-			expect(artifacts?.transcript?.sessions.length).toBeGreaterThanOrEqual(1);
+			expect(typeof artifacts?.transcript?.id).toBe("string");
+			expect(artifacts?.transcript?.data.sessions.length).toBeGreaterThanOrEqual(1);
 		});
 
 		it("Post-LLM short-circuit (1 LLM): non-trivial delta with empty topics skips step 2", async () => {
@@ -1228,9 +1234,13 @@ describe("PostCommitHook helpers", () => {
 			// must not be silently dropped.
 			expect(mockStoreSummary.mock.calls.length).toBeGreaterThanOrEqual(1);
 			const storeArgs = mockStoreSummary.mock.calls[0];
-			const artifacts = storeArgs[3] as { transcript?: { sessions: ReadonlyArray<unknown> } } | undefined;
+			// v5 artifact shape: `{ transcript: { id, data: { sessions: [...] } } }`.
+			const artifacts = storeArgs[3] as
+				| { transcript?: { id: string; data: { sessions: ReadonlyArray<unknown> } } }
+				| undefined;
 			expect(artifacts?.transcript).toBeDefined();
-			expect(artifacts?.transcript?.sessions.length).toBeGreaterThanOrEqual(1);
+			expect(typeof artifacts?.transcript?.id).toBe("string");
+			expect(artifacts?.transcript?.data.sessions.length).toBeGreaterThanOrEqual(1);
 		});
 
 		it("No old summary + diff fetch failure: skips entirely, no LLM call, no garbage summary", async () => {

--- a/cli/src/hooks/PostCommitHook.test.ts
+++ b/cli/src/hooks/PostCommitHook.test.ts
@@ -121,6 +121,9 @@ vi.mock("../core/SummaryStore.js", async (importOriginal) => {
 		storeNotes: vi.fn(),
 		setActiveStorage: vi.fn(),
 		resolveStorage: vi.fn(),
+		// handleAmendPipeline file-filters a legacy oldSummary's transcript IDs
+		// against this set; empty is fine (tests don't assert transcripts).
+		getTranscriptHashes: vi.fn().mockResolvedValue(new Set<string>()),
 		// Keep real implementations for pure tree-transform helpers.
 		stripFunctionalMetadata: actual.stripFunctionalMetadata,
 		resolveEffectiveTopics: actual.resolveEffectiveTopics,

--- a/cli/src/hooks/QueueWorker.ts
+++ b/cli/src/hooks/QueueWorker.ts
@@ -80,6 +80,7 @@ import {
 	type ConsolidatedTopics,
 	expandSourcesForConsolidation,
 	getSummary,
+	getTranscriptHashes,
 	mergeManyToOne,
 	migrateOneToOne,
 	resolveEffectiveTopics,
@@ -90,7 +91,7 @@ import {
 	storeSummary,
 	stripFunctionalMetadata,
 } from "../core/SummaryStore.js";
-import { getTranscriptIds } from "../core/SummaryTree.js";
+import { resolveTranscriptIdsFiltered } from "../core/SummaryTree.js";
 import { generateTranscriptId } from "../core/TranscriptId.js";
 import { getParserForSource } from "../core/TranscriptParser.js";
 import type { SessionTranscript } from "../core/TranscriptReader.js";
@@ -1851,10 +1852,23 @@ async function handleAmendPipeline(
 	const transcriptArtifact =
 		amendDeltaTranscriptId !== undefined ? { id: amendDeltaTranscriptId, data: amendStoredTranscript } : undefined;
 	// IDs that survive into the new amend root: inherited from old + new delta
-	// when one exists. `getTranscriptIds(oldSummary)` returns [] when oldSummary
-	// is undefined (we always check above before reading), so this is just the
-	// delta when there's no prior summary (fresh-leaf branch below).
-	const inheritedAmendIds = oldSummary ? getTranscriptIds(oldSummary) : [];
+	// when one exists. For legacy (v3/v4) `oldSummary`, derive via the
+	// children-tree walk but FILTER to IDs that actually have a transcript file
+	// — mirrors migrateOneToOne/mergeManyToOne (and the v5 migration) so a
+	// session-less child commit doesn't bake a dangling ID into the new v5
+	// root's authoritative `transcripts` array. v5 input passes through. Empty
+	// when oldSummary is undefined (fresh-leaf branch below).
+	// v5 `oldSummary` carries an authoritative `transcripts` array — pass it
+	// through without a file listing. Only legacy (v3/v4) input needs the
+	// children-tree walk filtered against on-disk transcript files, so we fetch
+	// `getTranscriptHashes` lazily in that branch alone.
+	let inheritedAmendIds: ReadonlyArray<string> = [];
+	if (oldSummary) {
+		inheritedAmendIds =
+			oldSummary.transcripts !== undefined
+				? oldSummary.transcripts
+				: resolveTranscriptIdsFiltered(oldSummary, await getTranscriptHashes(cwd));
+	}
 	const amendTranscripts: ReadonlyArray<string> =
 		amendDeltaTranscriptId !== undefined ? [...inheritedAmendIds, amendDeltaTranscriptId] : inheritedAmendIds;
 

--- a/cli/src/hooks/QueueWorker.ts
+++ b/cli/src/hooks/QueueWorker.ts
@@ -90,6 +90,8 @@ import {
 	storeSummary,
 	stripFunctionalMetadata,
 } from "../core/SummaryStore.js";
+import { getTranscriptIds } from "../core/SummaryTree.js";
+import { generateTranscriptId } from "../core/TranscriptId.js";
 import { getParserForSource } from "../core/TranscriptParser.js";
 import type { SessionTranscript } from "../core/TranscriptReader.js";
 import { buildMultiSessionContext, readTranscript } from "../core/TranscriptReader.js";
@@ -117,6 +119,7 @@ import type {
 	TranscriptReadResult,
 	TranscriptSource,
 } from "../Types.js";
+import { CURRENT_SCHEMA_VERSION } from "../Types.js";
 import { spawnHidden } from "../util/Subprocess.js";
 
 const log = createLogger("QueueWorker");
@@ -1227,12 +1230,23 @@ async function executePipeline(cwd: string, op: GitOperation, force = false): Pr
 		log.info("Plan progress: evaluated %d/%d plan(s)", planProgressArtifacts.length, planRefs.length);
 	}
 
+	// Step 8c (early): Build the StoredTranscript so we can allocate a v5
+	// transcript ID for it and stamp it onto the summary in one go. Overlays
+	// are already applied inside loadSessionTranscripts so the summary input,
+	// the empty-transcript guard, and the stored snapshot all see the same view.
+	const storedTranscript = buildStoredTranscript(sessionTranscripts);
+	const hasTranscriptContent = storedTranscript.sessions.length > 0;
+	const transcriptId = hasTranscriptContent ? generateTranscriptId() : undefined;
+
 	// Build the CommitSummary leaf node with top-level fields from the API result.
 	// For a leaf, diffStats === stats (both are `git diff {hash}^..{hash}`).
-	// Schema v4: unified Hoist -- topics + recap are part of the Hoist family
-	// so root is always authoritative. Leaves are the source-of-truth for v4
-	// children; later squash/amend operations strip the Hoist fields off this
-	// node when it becomes a child of a v4 root.
+	// Schema v5: unified Hoist + stable transcript IDs. Topics + recap are
+	// part of the Hoist family so root is always authoritative. Leaves are
+	// the source-of-truth for v5 children; later squash/amend operations strip
+	// the Hoist fields off this node when it becomes a child of a v5 root.
+	// `transcripts: [transcriptId]` (when set below) is the v5 stable-ID
+	// reference into `transcripts/{transcriptId}.json` on the orphan branch.
+	//
 	// LLM failure marker: if generateSummary fell through to the retry-fail
 	// catch block above, `summaryResult.llm.stopReason === "error"` is the
 	// trip-wire — surface it explicitly on the root via summaryError so
@@ -1241,7 +1255,7 @@ async function executePipeline(cwd: string, op: GitOperation, force = false): Pr
 	const llmFailed = summaryResult.llm?.stopReason === "error";
 
 	const summary: CommitSummary = {
-		version: 4,
+		version: CURRENT_SCHEMA_VERSION,
 		commitHash: commitInfo.hash,
 		commitMessage: commitInfo.message,
 		commitAuthor: commitInfo.author,
@@ -1256,6 +1270,12 @@ async function executePipeline(cwd: string, op: GitOperation, force = false): Pr
 		...(planRefs.length > 0 ? { plans: planRefs } : {}),
 		...(noteRefs.length > 0 ? { notes: noteRefs } : {}),
 		...(linearIssueRefs.length > 0 ? { linearIssues: linearIssueRefs } : {}),
+		// v5 contract: `transcripts` is always present on a v5 root (empty array
+		// when no AI sessions were captured). Omitting the field would route the
+		// `getTranscriptIds` fast-path back through `collectAllTranscriptHashes`,
+		// which both costs an extra git read and confuses the "v5 means field
+		// populated" invariant for future maintainers.
+		transcripts: transcriptId !== undefined ? [transcriptId] : [],
 	};
 
 	/* v8 ignore start -- log formatting ternaries (recap/topics/plans/notes presence) — each is a display variant, not a logical branch. */
@@ -1272,16 +1292,15 @@ async function executePipeline(cwd: string, op: GitOperation, force = false): Pr
 	);
 	/* v8 ignore stop */
 
-	// Step 8c: Build the StoredTranscript. Overlays are already applied
-	// inside loadSessionTranscripts so the summary input, the empty-
-	// transcript guard, and the stored snapshot all see the same view.
-	const storedTranscript = buildStoredTranscript(sessionTranscripts);
-
 	// Step 8d: Store summary (+ transcript + plan progress) in orphan branch
 	// Pass `force` so manual re-summarize can overwrite a previously failed entry.
+	// `storedTranscript` and `transcriptId` were built earlier so the ID could be
+	// stamped onto `summary.transcripts`.
 	stepStart = now();
 	await storeSummary(summary, cwd, force, {
-		transcript: storedTranscript,
+		...(transcriptId !== undefined && hasTranscriptContent
+			? { transcript: { id: transcriptId, data: storedTranscript } }
+			: {}),
 		...(planProgressArtifacts.length > 0 ? { planProgress: planProgressArtifacts } : {}),
 	});
 	log.info(
@@ -1600,6 +1619,11 @@ function isTrivialAmendDelta(deltaStats: DiffStats): boolean {
  * `llm` is only set when the topics/recap actually came from this call (i.e.
  * the consolidate step ran). Both short-circuit paths leave it undefined so
  * the field's "produced this node's data" semantics stay accurate.
+ *
+ * `transcripts` is the v5 transcript-ID array for the new amend root. Each
+ * call site computes it as `[...getTranscriptIds(oldSummary), ...maybeDelta]`
+ * — inherited IDs plus the newly written delta's ID if amend captured new
+ * sessions. Short-circuit paths that don't write a delta pass only inherited.
  */
 interface AmendHoistedFields {
 	readonly topics: ReadonlyArray<TopicSummary>;
@@ -1612,6 +1636,7 @@ interface AmendHoistedFields {
 	 * with marker). Surfaces the webview banner on the new amend root.
 	 */
 	readonly summaryError?: import("../Types.js").SummaryErrorKind;
+	readonly transcripts: ReadonlyArray<string>;
 }
 
 /**
@@ -1638,7 +1663,7 @@ function buildHoistedAmendRoot(
 	stats?: { readonly transcriptEntries?: number; readonly conversationTurns?: number },
 ): CommitSummary {
 	return {
-		version: 4,
+		version: CURRENT_SCHEMA_VERSION,
 		commitHash: newInfo.hash,
 		commitMessage: newInfo.message,
 		commitAuthor: newInfo.author,
@@ -1661,6 +1686,8 @@ function buildHoistedAmendRoot(
 		topics: hoisted.topics,
 		/* v8 ignore next */
 		...(hoisted.recap && { recap: hoisted.recap }),
+		// v5 contract: always present, even if empty (see executePipeline note).
+		transcripts: hoisted.transcripts,
 		diffStats: fullDiffStats,
 		children: [stripFunctionalMetadata(oldSummary)],
 	};
@@ -1686,7 +1713,13 @@ async function applyAmendShortCircuit(
 	commitInfo: CommitInfo,
 	metadata: { readonly commitType?: CommitType; readonly commitSource?: CommitSource } | undefined,
 	amendFullDiffStats: DiffStats,
-	sessionTranscripts: ReadonlyArray<SessionTranscript>,
+	// v5: the caller hoists transcript-artifact construction so the same delta
+	// ID can be stamped on both the stored artifact and the new root's
+	// `transcripts` field. `amendTranscripts` already contains the inherited
+	// IDs plus the new delta's ID when one exists — see the call sites where
+	// they're computed once and shared across the short-circuit + full path.
+	transcriptArtifact: { readonly id: string; readonly data: StoredTranscript } | undefined,
+	amendTranscripts: ReadonlyArray<string>,
 	totalEntries: number,
 	humanEntries: number,
 	cwd: string,
@@ -1695,9 +1728,6 @@ async function applyAmendShortCircuit(
 	label: string,
 	markError: boolean,
 ): Promise<void> {
-	const storedTranscript = buildStoredTranscript(sessionTranscripts);
-	const transcriptArtifact = storedTranscript.sessions.length > 0 ? storedTranscript : undefined;
-
 	const root = buildHoistedAmendRoot(
 		oldSummary,
 		commitInfo,
@@ -1707,7 +1737,9 @@ async function applyAmendShortCircuit(
 			...(oldSummary.recap !== undefined && { recap: oldSummary.recap }),
 			...(oldSummary.ticketId !== undefined && { ticketId: oldSummary.ticketId }),
 			/* v8 ignore stop */
+			// llm: undefined -- topics/recap came from old, not from delta
 			...(markError && { summaryError: LLM_FAILED }),
+			transcripts: amendTranscripts,
 		},
 		metadata ?? {},
 		amendFullDiffStats,
@@ -1810,6 +1842,22 @@ async function handleAmendPipeline(
 			)
 		: deltaDiffStats;
 
+	// Persist the conversation regardless of which path we take from here.
+	// Overlays are applied inside loadSessionTranscripts so this just packages
+	// them for storage. Allocate a v5 transcript ID for the delta upfront so
+	// every short-circuit can stamp it onto `summary.transcripts` consistently.
+	const amendStoredTranscript = buildStoredTranscript(sessionTranscripts);
+	const amendDeltaTranscriptId = amendStoredTranscript.sessions.length > 0 ? generateTranscriptId() : undefined;
+	const transcriptArtifact =
+		amendDeltaTranscriptId !== undefined ? { id: amendDeltaTranscriptId, data: amendStoredTranscript } : undefined;
+	// IDs that survive into the new amend root: inherited from old + new delta
+	// when one exists. `getTranscriptIds(oldSummary)` returns [] when oldSummary
+	// is undefined (we always check above before reading), so this is just the
+	// delta when there's no prior summary (fresh-leaf branch below).
+	const inheritedAmendIds = oldSummary ? getTranscriptIds(oldSummary) : [];
+	const amendTranscripts: ReadonlyArray<string> =
+		amendDeltaTranscriptId !== undefined ? [...inheritedAmendIds, amendDeltaTranscriptId] : inheritedAmendIds;
+
 	// ── Pre-LLM short-circuit: delta ≤ TRIVIAL_AMEND_DELTA_LINES (0 LLM) ──────
 	// When diff fetch failed, the fallback `deltaDiffStats = {0, 0, 0}` would
 	// otherwise spuriously trigger the short-circuit and silently drop the
@@ -1828,7 +1876,8 @@ async function handleAmendPipeline(
 			commitInfo,
 			metadata,
 			amendFullDiffStats,
-			sessionTranscripts,
+			transcriptArtifact,
+			amendTranscripts,
 			totalEntries,
 			humanEntries,
 			cwd,
@@ -1934,12 +1983,6 @@ async function handleAmendPipeline(
 	}
 	log.info("Amend step 1 (delta summary) generated (%s)", formatElapsed(stepStart));
 
-	// Persist the conversation regardless of which path we take from here.
-	// Overlays are applied inside loadSessionTranscripts so this just packages
-	// them for storage.
-	const amendStoredTranscript = buildStoredTranscript(sessionTranscripts);
-	const transcriptArtifact = amendStoredTranscript.sessions.length > 0 ? amendStoredTranscript : undefined;
-
 	// ── Post-LLM short-circuit: step1 returned empty topics → skip step2 ──────
 	// delta.recap is discarded even if present: a recap without topics is just a
 	// restatement of the diff, and the diff is the source of truth.
@@ -1959,7 +2002,8 @@ async function handleAmendPipeline(
 			commitInfo,
 			metadata,
 			amendFullDiffStats,
-			sessionTranscripts,
+			transcriptArtifact,
+			amendTranscripts,
 			totalEntries,
 			humanEntries,
 			cwd,
@@ -2055,6 +2099,7 @@ async function handleAmendPipeline(
 				// old", not "regenerated". Only a true Regenerate clears the marker.
 				...((consolidateLlmFailed || isSummaryError(oldSummary)) && { summaryError: LLM_FAILED }),
 				/* v8 ignore stop */
+				transcripts: amendTranscripts,
 			},
 			metadata ?? {},
 			amendFullDiffStats,
@@ -2104,7 +2149,7 @@ async function handleAmendPipeline(
 	);
 
 	const freshLeaf: CommitSummary = {
-		version: 4,
+		version: CURRENT_SCHEMA_VERSION,
 		commitHash: commitInfo.hash,
 		commitMessage: commitInfo.message,
 		commitAuthor: commitInfo.author,
@@ -2119,6 +2164,9 @@ async function handleAmendPipeline(
 		...(freshLeafPlanRefs.length > 0 ? { plans: freshLeafPlanRefs } : {}),
 		...(freshLeafNoteRefs.length > 0 ? { notes: freshLeafNoteRefs } : {}),
 		...(freshLeafLinearRefs.length > 0 ? { linearIssues: freshLeafLinearRefs } : {}),
+		// v5 contract: always present, even if empty. Fresh leaf has no
+		// inherited IDs; only the new delta (if any).
+		transcripts: amendDeltaTranscriptId !== undefined ? [amendDeltaTranscriptId] : [],
 	};
 	await storeSummary(
 		freshLeaf,

--- a/cli/src/install/Installer.test.ts
+++ b/cli/src/install/Installer.test.ts
@@ -1290,6 +1290,34 @@ describe("Installer", () => {
 			expect(status.summaryCount).toBe(42);
 		});
 
+		it("projects the v5 migration state onto StatusInfo (not gated on the orphan branch)", async () => {
+			// Reads go through readSchemaV5State, which resolves via the active
+			// StorageProvider — so a folder-only repo (no orphan branch) still
+			// reports its real migration state instead of permanently "Not
+			// migrated". orphanBranchExists stays false (mock default) here.
+			const { readSchemaV5State } = await import("../core/SchemaV5Migration.js");
+			vi.mocked(readSchemaV5State).mockResolvedValueOnce({
+				version: 1,
+				status: "completed",
+				startedAt: "2026-05-22T00:00:00Z",
+				completedAt: "2026-05-22T00:00:05Z",
+				migratedCount: 4,
+				skippedCount: 1,
+				fresh: false,
+			});
+
+			const status = await getStatus(tempDir);
+			expect(status.schemaV5).toBe("completed");
+		});
+
+		it("leaves the v5 migration state unknown when the state read throws", async () => {
+			const { readSchemaV5State } = await import("../core/SchemaV5Migration.js");
+			vi.mocked(readSchemaV5State).mockRejectedValueOnce(new Error("state read boom"));
+
+			const status = await getStatus(tempDir);
+			expect(status.schemaV5).toBeUndefined();
+		});
+
 		it("should report gitHookInstalled=false when post-rewrite hook is missing", async () => {
 			// Install all hooks, then manually remove the post-rewrite hook
 			await install(tempDir);

--- a/cli/src/install/Installer.test.ts
+++ b/cli/src/install/Installer.test.ts
@@ -84,6 +84,21 @@ vi.mock("../core/CopilotChatSessionDiscoverer.js", () => ({
 	discoverCopilotChatSessions: vi.fn().mockResolvedValue([]),
 }));
 
+// Mock SchemaV5Migration so install() doesn't spawn real git fast-import on
+// every test. `install()` both statically imports `readSchemaV5State` (for
+// status) and dynamically imports `migrateSchemaToV5` (for the auto-upgrade
+// step), so the mock has to export both. The `migrateSchemaToV5` spy is the
+// load-bearing assertion target for the source-discriminator tests below.
+vi.mock("../core/SchemaV5Migration.js", () => ({
+	migrateSchemaToV5: vi.fn().mockResolvedValue({
+		migrated: 0,
+		skipped: 0,
+		fresh: true,
+		alreadyDone: false,
+	}),
+	readSchemaV5State: vi.fn().mockResolvedValue(null),
+}));
+
 // Partially mock DistPathResolver so resolveDistPath doesn't depend on global npm state.
 // By default, resolveDistPath returns the caller's own dist dir with "cli" source.
 vi.mock("./DistPathResolver.js", async (importOriginal) => {
@@ -800,6 +815,57 @@ describe("Installer", () => {
 			const result = await install(tempDir);
 			expect(result.success).toBe(false);
 			expect(result.message).toMatch(/Unexpected .git file content|ENOTDIR|not a directory/i);
+		});
+
+		describe("v5 migration source discriminator", () => {
+			// When VSCode calls install() via bridge.enable(), Extension.ts
+			// separately runs migrateSchemaToV5 wrapped in setMigrating(true/
+			// false) so the sidebar shows progress. If install() also ran it,
+			// the two calls would race for `orphan-write.lock` and one would
+			// time out after 30 s. The discriminator is the `source` option
+			// — only `"vscode-extension"` skips; CLI (or omitted source, the
+			// test-fixture pattern) keeps the auto-upgrade behavior.
+			it("skips the v5 migration call when source is vscode-extension", async () => {
+				const { migrateSchemaToV5 } = await import("../core/SchemaV5Migration.js");
+				vi.mocked(migrateSchemaToV5).mockClear();
+
+				const result = await install(tempDir, { source: "vscode-extension" });
+
+				expect(result.success).toBe(true);
+				expect(vi.mocked(migrateSchemaToV5)).not.toHaveBeenCalled();
+			});
+
+			it("runs the v5 migration call when source is cli", async () => {
+				const { migrateSchemaToV5 } = await import("../core/SchemaV5Migration.js");
+				vi.mocked(migrateSchemaToV5).mockClear();
+
+				const result = await install(tempDir, { source: "cli" });
+
+				expect(result.success).toBe(true);
+				expect(vi.mocked(migrateSchemaToV5)).toHaveBeenCalledTimes(1);
+				expect(vi.mocked(migrateSchemaToV5)).toHaveBeenCalledWith(tempDir);
+			});
+
+			it("runs the v5 migration call when source is omitted (default behavior)", async () => {
+				const { migrateSchemaToV5 } = await import("../core/SchemaV5Migration.js");
+				vi.mocked(migrateSchemaToV5).mockClear();
+
+				const result = await install(tempDir);
+
+				expect(result.success).toBe(true);
+				expect(vi.mocked(migrateSchemaToV5)).toHaveBeenCalledTimes(1);
+			});
+
+			it("treats migrateSchemaToV5 throws as non-fatal", async () => {
+				const { migrateSchemaToV5 } = await import("../core/SchemaV5Migration.js");
+				vi.mocked(migrateSchemaToV5).mockClear();
+				vi.mocked(migrateSchemaToV5).mockRejectedValueOnce(new Error("boom"));
+
+				const result = await install(tempDir, { source: "cli" });
+
+				expect(result.success).toBe(true);
+				expect(vi.mocked(migrateSchemaToV5)).toHaveBeenCalledTimes(1);
+			});
 		});
 	});
 

--- a/cli/src/install/Installer.ts
+++ b/cli/src/install/Installer.ts
@@ -33,6 +33,7 @@ import {
 	type OpenCodeScanError,
 	scanOpenCodeSessions,
 } from "../core/OpenCodeSessionDiscoverer.js";
+import { readSchemaV5State } from "../core/SchemaV5Migration.js";
 import {
 	ensureJolliMemoryDir,
 	filterSessionsByEnabledIntegrations,
@@ -301,6 +302,38 @@ export async function install(cwd?: string, options?: { source?: "vscode-extensi
 		// The worktrees list always includes the main repo root as its first entry.
 		for (const wt of worktrees) {
 			await migrateWorktreeConfig(wt);
+		}
+
+		// v3 → v4 → v5 unified schema migration. Idempotent: `migrateSchemaToV5`
+		// reads its own state file, skips when already completed, and also
+		// skips when no orphan branch exists yet (fresh install with no commits
+		// to migrate). Failure is non-fatal so an LLM-quota-exhausted or
+		// lock-contended install still succeeds; user can re-run via
+		// `jolli migrate`.
+		//
+		// Skipped on the VSCode path because Extension.ts owns the migration
+		// call there — it wraps the work in `setMigrating(true/false)` across
+		// the three sidebar stores so the user sees a "Migrating memories..."
+		// affordance, which we cannot reproduce from inside the CLI. Running
+		// here as well would have both callers race for `orphan-write.lock`
+		// and time one of them out after 30 s (the symptom that originally
+		// surfaced this bug — see git history of this block).
+		if (options?.source === "vscode-extension") {
+			log.info("Skipping v5 migration on vscode-extension source — Extension.ts owns it with UI");
+		} else {
+			try {
+				const { migrateSchemaToV5 } = await import("../core/SchemaV5Migration.js");
+				const v5Result = await migrateSchemaToV5(projectDir);
+				log.info(
+					"Schema v5 migration: alreadyDone=%s fresh=%s migrated=%d skipped=%d",
+					v5Result.alreadyDone,
+					v5Result.fresh,
+					v5Result.migrated,
+					v5Result.skipped,
+				);
+			} catch (err: unknown) {
+				log.warn("Schema v5 migration failed (non-fatal): %s", (err as Error).message);
+			}
 		}
 
 		log.info("Installation complete");
@@ -652,6 +685,24 @@ export async function getStatus(cwd?: string, storage?: StorageProvider): Promis
 		? { source: winning.source, version: winning.version }
 		: undefined;
 
+	// v5 schema migration state — only meaningful when an orphan branch
+	// exists (a project that's never had jollimemory data has no state to
+	// report). Reads the state file on the orphan branch; null = pending.
+	let schemaV5: StatusInfo["schemaV5"];
+	let schemaV5Fresh: StatusInfo["schemaV5Fresh"];
+	if (branchExists) {
+		try {
+			const state = await readSchemaV5State(projectDir);
+			if (state) {
+				schemaV5 = state.status;
+				schemaV5Fresh = state.fresh;
+			}
+		} catch {
+			// Read errors are non-fatal — leave schemaV5 undefined ("unknown") so
+			// the status display can prompt the user to check / re-run migrate.
+		}
+	}
+
 	const status: StatusInfo = {
 		// The extension is "enabled" when the git hook is installed.
 		// Individual integration hooks (Claude, Codex, Gemini) have their own
@@ -689,6 +740,8 @@ export async function getStatus(cwd?: string, storage?: StorageProvider): Promis
 		allSources,
 		sessionsBySource,
 		openCodeScanError,
+		...(schemaV5 !== undefined && { schemaV5 }),
+		...(schemaV5Fresh !== undefined && { schemaV5Fresh }),
 	};
 
 	log.info(

--- a/cli/src/install/Installer.ts
+++ b/cli/src/install/Installer.ts
@@ -685,22 +685,22 @@ export async function getStatus(cwd?: string, storage?: StorageProvider): Promis
 		? { source: winning.source, version: winning.version }
 		: undefined;
 
-	// v5 schema migration state — only meaningful when an orphan branch
-	// exists (a project that's never had jollimemory data has no state to
-	// report). Reads the state file on the orphan branch; null = pending.
+	// v5 schema migration state. `readSchemaV5State` reads through the active
+	// StorageProvider (passed `storage` when the VS Code bridge supplies one,
+	// otherwise constructed from `cwd`), so this reports correctly in
+	// folder-only mode too — NOT gated on `branchExists`, which would leave
+	// folder-only repos (no orphan branch) permanently showing "Not migrated".
+	// `null` = pending → schemaV5 stays undefined, same as a genuinely empty
+	// repo with no data to migrate.
 	let schemaV5: StatusInfo["schemaV5"];
-	let schemaV5Fresh: StatusInfo["schemaV5Fresh"];
-	if (branchExists) {
-		try {
-			const state = await readSchemaV5State(projectDir);
-			if (state) {
-				schemaV5 = state.status;
-				schemaV5Fresh = state.fresh;
-			}
-		} catch {
-			// Read errors are non-fatal — leave schemaV5 undefined ("unknown") so
-			// the status display can prompt the user to check / re-run migrate.
+	try {
+		const state = await readSchemaV5State(projectDir, storage);
+		if (state) {
+			schemaV5 = state.status;
 		}
+	} catch {
+		// Read errors are non-fatal — leave schemaV5 undefined ("unknown") so
+		// the status display can prompt the user to check / re-run migrate.
 	}
 
 	const status: StatusInfo = {
@@ -741,7 +741,6 @@ export async function getStatus(cwd?: string, storage?: StorageProvider): Promis
 		sessionsBySource,
 		openCodeScanError,
 		...(schemaV5 !== undefined && { schemaV5 }),
-		...(schemaV5Fresh !== undefined && { schemaV5Fresh }),
 	};
 
 	log.info(

--- a/vscode/src/Extension.test.ts
+++ b/vscode/src/Extension.test.ts
@@ -1483,6 +1483,31 @@ describe("Extension", () => {
 			expect(mockCommitsStore.setMigrating).toHaveBeenCalledWith(true);
 			expect(mockCommitsStore.setMigrating).toHaveBeenCalledWith(false);
 		});
+
+		it("skips the v5 migration call (no UI flicker) when already completed", async () => {
+			// Needed-check: when readSchemaV5State reports completed, activate must
+			// NOT call migrateSchemaToV5 (and must not toggle the v5 spinner) — the
+			// common already-migrated path should be a silent no-op.
+			const { readSchemaV5State, migrateSchemaToV5 } = await import("../../cli/src/core/SchemaV5Migration.js");
+			vi.mocked(migrateSchemaToV5).mockClear();
+			vi.mocked(readSchemaV5State).mockResolvedValueOnce({
+				version: 1,
+				status: "completed",
+				startedAt: "2026-06-01T00:00:00Z",
+				completedAt: "2026-06-01T00:00:05Z",
+				migratedCount: 3,
+				skippedCount: 0,
+				fresh: false,
+			});
+
+			const ctx = makeContext();
+			activate(ctx);
+
+			await vi.waitFor(() => {
+				expect(readSchemaV5State).toHaveBeenCalled();
+			});
+			expect(migrateSchemaToV5).not.toHaveBeenCalled();
+		});
 	});
 
 	// ── KB folder auto-init / v3 stale-child cleanup on activate ─────────────

--- a/vscode/src/Extension.test.ts
+++ b/vscode/src/Extension.test.ts
@@ -584,6 +584,21 @@ vi.mock("../../cli/src/core/SummaryMigration.js", () => ({
 	writeMigrationMeta,
 }));
 
+// Stub the v5 schema migration so activate's auto-trigger is a fast no-op
+// in tests. Real-git operations inside `migrateSchemaToV5` (listFilesInBranch /
+// orphan-write-lock acquisition with 30s timeout) would otherwise block
+// `initializeKB` past the assertion windows below. Tests that need to
+// exercise the migration directly should mock SchemaV5Migration.test.ts.
+vi.mock("../../cli/src/core/SchemaV5Migration.js", () => ({
+	migrateSchemaToV5: vi.fn(async () => ({
+		migrated: 0,
+		skipped: 0,
+		fresh: true,
+		alreadyDone: false,
+	})),
+	readSchemaV5State: vi.fn(async () => null),
+}));
+
 vi.mock("../../cli/src/core/SummaryStore.js", () => ({
 	indexNeedsMigration,
 	migrateIndexToV3,

--- a/vscode/src/Extension.ts
+++ b/vscode/src/Extension.ts
@@ -1085,21 +1085,33 @@ export function activate(context: vscode.ExtensionContext): void {
 		// hide-children) while v5 work is in flight. Mirrors the v1→v3 and
 		// index-migration patterns above; user gets a unified "data being
 		// upgraded" signal across panels without us inventing a new banner.
-		statusStore.setMigrating(true);
-		commitsStore.setMigrating(true);
-		filesStore.setMigrating(true);
+		const { migrateSchemaToV5, readSchemaV5State } = await import(
+			"../../cli/src/core/SchemaV5Migration.js"
+		);
+		// Needed-check FIRST so the common already-migrated path doesn't flash the
+		// "Migrating memories..." affordance every activate() (mirrors the v1→v3 /
+		// index migrations, which gate their UI toggle on a check). A read error →
+		// treat as unknown and let migrateSchemaToV5 (re-checks + short-circuits) decide.
+		const v5State = await readSchemaV5State(workspaceRoot ?? undefined).catch(() => null);
+		const v5Pending = v5State?.status !== "completed";
+		if (v5Pending) {
+			statusStore.setMigrating(true);
+			commitsStore.setMigrating(true);
+			filesStore.setMigrating(true);
+		}
 		try {
-			const { migrateSchemaToV5 } = await import(
-				"../../cli/src/core/SchemaV5Migration.js"
-			);
 			// `?? undefined` because workspaceRoot is `string | null` here; the
 			// value is non-null (we returned earlier when it was), the coercion
 			// just satisfies tsc.
-			const v5Result = await migrateSchemaToV5(workspaceRoot ?? undefined);
-			log.info(
-				"activate",
-				`Schema v5 migration: alreadyDone=${v5Result.alreadyDone} fresh=${v5Result.fresh} migrated=${v5Result.migrated} skipped=${v5Result.skipped}`,
-			);
+			if (!v5Pending) {
+				log.info("activate", "Schema v5 migration already complete — skipping (no UI toggle)");
+			} else {
+				const v5Result = await migrateSchemaToV5(workspaceRoot ?? undefined);
+				log.info(
+					"activate",
+					`Schema v5 migration: alreadyDone=${v5Result.alreadyDone} fresh=${v5Result.fresh} migrated=${v5Result.migrated} skipped=${v5Result.skipped}`,
+				);
+			}
 		} catch (err) {
 			log.warn(
 				"activate",
@@ -1109,9 +1121,11 @@ export function activate(context: vscode.ExtensionContext): void {
 			// Always clear migration state — including on failure — so the
 			// sidebar comes back to a usable state and the user can read the
 			// "Not migrated" status / re-run via `jolli migrate`.
-			statusStore.setMigrating(false);
-			commitsStore.setMigrating(false);
-			filesStore.setMigrating(false);
+			if (v5Pending) {
+				statusStore.setMigrating(false);
+				commitsStore.setMigrating(false);
+				filesStore.setMigrating(false);
+			}
 		}
 
 		// 3. KB folder auto-initialization + migration

--- a/vscode/src/Extension.ts
+++ b/vscode/src/Extension.ts
@@ -1072,6 +1072,48 @@ export function activate(context: vscode.ExtensionContext): void {
 		// for 48 hours as a safety net. Check if the retention period has expired.
 		await cleanupV1IfExpired(workspaceRoot);
 
+		// 2.5. v3 → v4 → v5 unified schema migration. Idempotent — reads its own
+		// state file on the orphan branch and skips when already completed; also
+		// skips when no orphan branch exists yet (the first post-commit creates
+		// it, and the next activate() picks the migration up). Runs in the
+		// `initializeKB` sequence so the v1 → v3 conversion completes before v5
+		// inspects summaries. Failure is non-fatal: next activate() retries.
+		//
+		// Wrapped in setMigrating(true/false) across all three stores so the
+		// sidebar surfaces the existing "Migrating memories..." affordance
+		// (StatusTreeProvider spinner, FilesTreeProvider / HistoryTreeProvider
+		// hide-children) while v5 work is in flight. Mirrors the v1→v3 and
+		// index-migration patterns above; user gets a unified "data being
+		// upgraded" signal across panels without us inventing a new banner.
+		statusStore.setMigrating(true);
+		commitsStore.setMigrating(true);
+		filesStore.setMigrating(true);
+		try {
+			const { migrateSchemaToV5 } = await import(
+				"../../cli/src/core/SchemaV5Migration.js"
+			);
+			// `?? undefined` because workspaceRoot is `string | null` here; the
+			// value is non-null (we returned earlier when it was), the coercion
+			// just satisfies tsc.
+			const v5Result = await migrateSchemaToV5(workspaceRoot ?? undefined);
+			log.info(
+				"activate",
+				`Schema v5 migration: alreadyDone=${v5Result.alreadyDone} fresh=${v5Result.fresh} migrated=${v5Result.migrated} skipped=${v5Result.skipped}`,
+			);
+		} catch (err) {
+			log.warn(
+				"activate",
+				`Schema v5 migration failed (non-fatal): ${(err as Error).message}`,
+			);
+		} finally {
+			// Always clear migration state — including on failure — so the
+			// sidebar comes back to a usable state and the user can read the
+			// "Not migrated" status / re-run via `jolli migrate`.
+			statusStore.setMigrating(false);
+			commitsStore.setMigrating(false);
+			filesStore.setMigrating(false);
+		}
+
 		// 3. KB folder auto-initialization + migration
 		// Creates the KB folder (~/Documents/jolli/{repoName}/) and auto-migrates
 		// orphan branch data if migration hasn't been completed yet.

--- a/vscode/src/JolliMemoryBridge.ts
+++ b/vscode/src/JolliMemoryBridge.ts
@@ -423,7 +423,15 @@ export class JolliMemoryBridge {
 
 	// ── Enable / Disable ──────────────────────────────────────────────────
 
-	/** Enables JolliMemory hooks by calling Installer.install() directly. */
+	/**
+	 * Enables JolliMemory hooks by calling Installer.install() directly.
+	 *
+	 * `source: "vscode-extension"` is load-bearing: it tells the Installer to
+	 * skip its own v5 schema migration because Extension.ts runs that step
+	 * with `setMigrating(true/false)` to drive the sidebar spinner. Without
+	 * this flag both call sites race for `orphan-write.lock` and one of them
+	 * times out after 30 s. If a future caller is added here, copy the flag.
+	 */
 	async enable(): Promise<{ success: boolean; message: string }> {
 		log.info("bridge", "enable() called");
 		const result = await installerInstall(this.cwd, {
@@ -434,6 +442,9 @@ export class JolliMemoryBridge {
 
 	/**
 	 * Auto-installs hooks for the current worktree when the project is already enabled.
+	 *
+	 * Same `source: "vscode-extension"` contract as `enable()` — see that
+	 * doc-comment for the v5 migration / lock-contention rationale.
 	 */
 	async autoInstallForWorktree(): Promise<void> {
 		log.info("bridge", "Auto-installing hooks for new worktree");
@@ -2080,12 +2091,17 @@ export class JolliMemoryBridge {
 	 * orphan branch hasn't caught up to yet. Without this, a force-write
 	 * rewrites the index from orphan-only rows and the dual-write below
 	 * silently drops those folder-only rows on the shadow.
+	 *
+	 * `artifacts.transcript.id` is the v5 transcript ID under which the data
+	 * lands on the orphan branch (`transcripts/{id}.json`). The caller MUST
+	 * also include that ID in `summary.transcripts` for the migration / read
+	 * paths to find it later — `storeSummary` does not stamp it on automatically.
 	 */
 	async storeSummary(
 		summary: CommitSummary,
 		force = false,
 		artifacts?: {
-			readonly transcript?: StoredTranscript;
+			readonly transcript?: { readonly id: string; readonly data: StoredTranscript };
 			readonly planProgress?: ReadonlyArray<PlanProgressArtifact>;
 		},
 	): Promise<void> {

--- a/vscode/src/providers/StatusTreeProvider.ts
+++ b/vscode/src/providers/StatusTreeProvider.ts
@@ -10,6 +10,7 @@
  */
 
 import * as vscode from "vscode";
+import { describeSchemaV5Status } from "../../../cli/src/commands/StatusCommand.js";
 import { resolveLlmCredentialSource } from "../../../cli/src/core/LlmClient.js";
 import type { JolliMemoryConfig, StatusInfo } from "../../../cli/src/Types.js";
 import { parseJolliApiKey } from "../services/JolliPushService.js";
@@ -140,6 +141,7 @@ function buildFullStatusItems(
 	if (hookRuntime) {
 		hooksTooltipLines.push(`Hook runtime: ${hookRuntime}`);
 	}
+	hooksTooltipLines.push(`Data migration: ${describeSchemaV5Status(s.schemaV5)}`);
 	const hooksTooltip = hooksTooltipLines.join("\n");
 
 	const sessionsTooltip = `${s.activeSessions} active session${s.activeSessions !== 1 ? "s" : ""} across all integrations`;

--- a/vscode/src/views/SummaryCssBuilder.ts
+++ b/vscode/src/views/SummaryCssBuilder.ts
@@ -1010,6 +1010,16 @@ export function buildCss(): string {
     display: flex;
     gap: 8px;
   }
+  /* Failure banner above the modal footer — shown when v5 save/delete posts
+     transcriptsSaveFailed / transcriptsDeleteFailed. Uses VS Code's standard
+     error tokens so the visual matches notifications. */
+  .modal-error-banner {
+    padding: 8px 20px;
+    color: var(--vscode-inputValidation-errorForeground, var(--vscode-errorForeground, #f48771));
+    background-color: var(--vscode-inputValidation-errorBackground, rgba(244,135,113,0.12));
+    border-top: 1px solid var(--vscode-inputValidation-errorBorder, rgba(244,135,113,0.4));
+    font-size: 0.9em;
+  }
 
   /* ── Conversations description, stats & privacy ── */
   .conversations-description {

--- a/vscode/src/views/SummaryHtmlBuilder.ts
+++ b/vscode/src/views/SummaryHtmlBuilder.ts
@@ -728,6 +728,13 @@ function buildTranscriptModal(isForeign: boolean = false): string {
     <div class="modal-body" id="modalBody">
       <div class="modal-loading" id="modalLoading">Loading transcripts...</div>
     </div>
+    <!--
+      Hidden by default. Shown when the backend posts
+      transcriptsSaveFailed / transcriptsDeleteFailed so the user has a
+      visible recovery hint without leaving the modal. See message handlers
+      in SummaryScriptBuilder.ts.
+    -->
+    <div class="modal-error-banner" id="modalErrorBanner" style="display: none;"></div>
     <div class="modal-footer">
       <button class="action-btn danger" id="deleteTranscriptsBtn">Mark All as Deleted</button>
       <div class="modal-footer-right">

--- a/vscode/src/views/SummaryScriptBuilder.ts
+++ b/vscode/src/views/SummaryScriptBuilder.ts
@@ -1278,6 +1278,10 @@ ${buildPrMessageScript()}
     if (!transcriptModal) return;
     transcriptModal.classList.add('visible');
     if (modalLoading) modalLoading.style.display = 'block';
+    // Clear any error banner from a previous failed save/delete attempt so
+    // the new session starts clean.
+    var prevErr = document.getElementById('modalErrorBanner');
+    if (prevErr) prevErr.style.display = 'none';
     modifiedCount = 0;
     deletedCount = 0;
     updateChangeCounter();
@@ -1614,6 +1618,23 @@ ${buildTranscriptEntriesScript()}
     }
     if (msg.command === 'transcriptsDeleted') {
       // Modal already closed by deleteTranscriptsBtn handler
+    }
+    // Failure paths (added 2026-05-22 for v5): backend posts these when summary
+    // update or transcript file batch failed. Without handling them, the Save
+    // button would stay stuck in "Saving..." disabled state forever (the user
+    // would have to reload the webview to continue). Re-enable the button and
+    // surface a non-blocking notification with the backend-provided detail.
+    if (msg.command === 'transcriptsSaveFailed' || msg.command === 'transcriptsDeleteFailed') {
+      if (modalSaveBtn) {
+        modalSaveBtn.disabled = false;
+        modalSaveBtn.textContent = 'Save All';
+      }
+      var errBanner = document.getElementById('modalErrorBanner');
+      if (errBanner) {
+        var defaultMsg = msg.command === 'transcriptsSaveFailed' ? 'Save failed. See logs.' : 'Delete failed. See logs.';
+        errBanner.textContent = msg.message || defaultMsg;
+        errBanner.style.display = 'block';
+      }
     }
     if (msg.command === 'transcriptsLoading') {
       if (modalLoading) modalLoading.style.display = 'block';

--- a/vscode/src/views/SummaryWebviewPanel.test.ts
+++ b/vscode/src/views/SummaryWebviewPanel.test.ts
@@ -209,10 +209,19 @@ const { mockDeleteTopicInTree, mockUpdateTopicInTree } = vi.hoisted(() => ({
 	mockUpdateTopicInTree: vi.fn(),
 }));
 
-vi.mock("../../../cli/src/core/SummaryTree.js", () => ({
-	deleteTopicInTree: mockDeleteTopicInTree,
-	updateTopicInTree: mockUpdateTopicInTree,
-}));
+vi.mock("../../../cli/src/core/SummaryTree.js", async () => {
+	// Pull real impls for everything not explicitly stubbed (notably
+	// `getTranscriptIds`, used by the panel's refreshTranscriptHashes flow
+	// after the v5 schema migration to a stable transcript-ID set).
+	const actual = await vi.importActual<typeof import("../../../cli/src/core/SummaryTree.js")>(
+		"../../../cli/src/core/SummaryTree.js",
+	);
+	return {
+		...actual,
+		deleteTopicInTree: mockDeleteTopicInTree,
+		updateTopicInTree: mockUpdateTopicInTree,
+	};
+});
 
 const { mockCorePushSummaryToLocal } = vi.hoisted(() => ({
 	mockCorePushSummaryToLocal: vi.fn().mockResolvedValue({
@@ -4763,6 +4772,96 @@ describe("SummaryWebviewPanel", () => {
 					workspaceRoot,
 				);
 			});
+
+			// ── Failure paths (v5 summary-first ordering) ─────────────────────
+
+			it("posts transcriptsSaveFailed when storeSummary rejects — files NOT touched", async () => {
+				mockGetTranscriptHashes.mockResolvedValue(new Set(["abc123", "def456"]));
+				const summary = {
+					...makeSummary(),
+					version: 5,
+					transcripts: ["abc123", "def456"],
+				} as ReturnType<typeof makeSummary>;
+				await SummaryWebviewPanel.show(
+					summary,
+					extensionUri,
+					workspaceRoot,
+					stubBridge,
+					mainBranch,
+				);
+				const dispatch = captureMessageHandler();
+				mockStoreSummary.mockClear();
+				mockStoreSummary.mockRejectedValueOnce(new Error("orphan lock contention"));
+				mockSaveTranscriptsBatch.mockClear();
+
+				// Trigger save with one commit having no entries → goes to deletes,
+				// which forces persistTranscriptIdRemoval to run and fail.
+				dispatch({
+					command: "saveAllTranscripts",
+					entries: [
+						{
+							commitHash: "abc123",
+							sessionId: "s1",
+							source: "claude",
+							originalIndex: 0,
+							role: "human",
+							content: "x",
+						},
+					],
+				});
+				await flushPromises();
+
+				// File batch must NOT run after summary failure
+				expect(mockSaveTranscriptsBatch).not.toHaveBeenCalled();
+				expect(postMessage).toHaveBeenCalledWith(
+					expect.objectContaining({ command: "transcriptsSaveFailed" }),
+				);
+				expect(postMessage).not.toHaveBeenCalledWith({ command: "transcriptsSaved" });
+			});
+
+			it("posts transcriptsSaveFailed when file batch rejects after summary updated", async () => {
+				mockGetTranscriptHashes.mockResolvedValue(new Set(["abc123", "def456"]));
+				const summary = {
+					...makeSummary(),
+					version: 5,
+					transcripts: ["abc123", "def456"],
+				} as ReturnType<typeof makeSummary>;
+				await SummaryWebviewPanel.show(
+					summary,
+					extensionUri,
+					workspaceRoot,
+					stubBridge,
+					mainBranch,
+				);
+				const dispatch = captureMessageHandler();
+				mockStoreSummary.mockClear();
+				mockSaveTranscriptsBatch.mockClear();
+				mockSaveTranscriptsBatch.mockRejectedValueOnce(new Error("io error"));
+
+				dispatch({
+					command: "saveAllTranscripts",
+					entries: [
+						{
+							commitHash: "abc123",
+							sessionId: "s1",
+							source: "claude",
+							originalIndex: 0,
+							role: "human",
+							content: "edited",
+						},
+					],
+				});
+				await flushPromises();
+
+				// Summary was updated; file batch was attempted and failed.
+				expect(mockStoreSummary).toHaveBeenCalled();
+				expect(mockSaveTranscriptsBatch).toHaveBeenCalled();
+				// Failed message posted, NOT success
+				expect(postMessage).toHaveBeenCalledWith(
+					expect.objectContaining({ command: "transcriptsSaveFailed" }),
+				);
+				expect(postMessage).not.toHaveBeenCalledWith({ command: "transcriptsSaved" });
+			});
 		});
 
 		// ── deleteAllTranscripts ─────────────────────────────────────────────
@@ -4831,6 +4930,72 @@ describe("SummaryWebviewPanel", () => {
 				expect(postMessage).toHaveBeenCalledWith({
 					command: "transcriptsDeleted",
 				});
+			});
+
+			// ── Failure paths (v5 summary-first ordering) ─────────────────────
+
+			it("posts transcriptsDeleteFailed when storeSummary rejects — files NOT touched", async () => {
+				mockGetTranscriptHashes.mockResolvedValue(new Set(["abc123"]));
+				const summary = {
+					...makeSummary(),
+					version: 5,
+					transcripts: ["abc123"],
+				} as ReturnType<typeof makeSummary>;
+				await SummaryWebviewPanel.show(
+					summary,
+					extensionUri,
+					workspaceRoot,
+					stubBridge,
+					mainBranch,
+				);
+				mockStoreSummary.mockClear();
+				mockStoreSummary.mockRejectedValueOnce(new Error("disk full"));
+				mockSaveTranscriptsBatch.mockClear();
+				const dispatch = captureMessageHandler();
+
+				dispatch({ command: "deleteAllTranscripts" });
+				await flushPromises();
+
+				// File batch must NOT run when summary update failed first.
+				expect(mockSaveTranscriptsBatch).not.toHaveBeenCalled();
+				// Failure message reaches the user; no Success message is sent.
+				expect(postMessage).toHaveBeenCalledWith(
+					expect.objectContaining({ command: "transcriptsDeleteFailed" }),
+				);
+				expect(postMessage).not.toHaveBeenCalledWith({ command: "transcriptsDeleted" });
+			});
+
+			it("posts transcriptsDeleteFailed when saveTranscriptsBatch rejects after summary already updated", async () => {
+				mockGetTranscriptHashes.mockResolvedValue(new Set(["abc123"]));
+				const summary = {
+					...makeSummary(),
+					version: 5,
+					transcripts: ["abc123"],
+				} as ReturnType<typeof makeSummary>;
+				await SummaryWebviewPanel.show(
+					summary,
+					extensionUri,
+					workspaceRoot,
+					stubBridge,
+					mainBranch,
+				);
+				mockStoreSummary.mockClear();
+				mockSaveTranscriptsBatch.mockClear();
+				mockSaveTranscriptsBatch.mockRejectedValueOnce(new Error("git push timeout"));
+				const dispatch = captureMessageHandler();
+
+				dispatch({ command: "deleteAllTranscripts" });
+				await flushPromises();
+
+				// summary write was attempted (summary-first ordering)
+				expect(mockStoreSummary).toHaveBeenCalled();
+				// file delete was attempted and failed
+				expect(mockSaveTranscriptsBatch).toHaveBeenCalled();
+				// FailureMessage is posted instead of success
+				expect(postMessage).toHaveBeenCalledWith(
+					expect.objectContaining({ command: "transcriptsDeleteFailed" }),
+				);
+				expect(postMessage).not.toHaveBeenCalledWith({ command: "transcriptsDeleted" });
 			});
 		});
 

--- a/vscode/src/views/SummaryWebviewPanel.test.ts
+++ b/vscode/src/views/SummaryWebviewPanel.test.ts
@@ -4836,6 +4836,10 @@ describe("SummaryWebviewPanel", () => {
 				const dispatch = captureMessageHandler();
 				mockStoreSummary.mockClear();
 				mockSaveTranscriptsBatch.mockClear();
+				// Clear so we can assert the failure path does NOT re-refresh the
+				// cache (P2: refreshing from the already-updated summary would hide
+				// the still-on-disk files and break retry).
+				mockGetTranscriptHashes.mockClear();
 				mockSaveTranscriptsBatch.mockRejectedValueOnce(new Error("io error"));
 
 				dispatch({
@@ -4861,6 +4865,10 @@ describe("SummaryWebviewPanel", () => {
 					expect.objectContaining({ command: "transcriptsSaveFailed" }),
 				);
 				expect(postMessage).not.toHaveBeenCalledWith({ command: "transcriptsSaved" });
+				// P2: no refresh-from-updated-summary on failure — the pre-operation
+				// `transcriptHashSet` is kept so the affected transcripts stay
+				// visible and the save/delete stays retryable.
+				expect(mockGetTranscriptHashes).not.toHaveBeenCalled();
 			});
 		});
 
@@ -4890,6 +4898,15 @@ describe("SummaryWebviewPanel", () => {
 				expect(postMessage).toHaveBeenCalledWith({
 					command: "transcriptsDeleted",
 				});
+				// #5 + #4: the legacy (v3) summary is lazily upgraded to a REAL v5
+				// record — version bumped to 5 and `transcripts` written from the
+				// file-backed set (emptied here by the delete), not left as a
+				// "version<5 but has transcripts" hybrid.
+				expect(mockStoreSummary).toHaveBeenCalledWith(
+					expect.objectContaining({ version: 5, transcripts: [] }),
+					workspaceRoot,
+					true,
+				);
 			});
 
 			it("does nothing when no transcripts exist", async () => {
@@ -4996,6 +5013,20 @@ describe("SummaryWebviewPanel", () => {
 					expect.objectContaining({ command: "transcriptsDeleteFailed" }),
 				);
 				expect(postMessage).not.toHaveBeenCalledWith({ command: "transcriptsDeleted" });
+
+				// P2: the failed delete stays RETRYABLE. The still-on-disk file is
+				// NOT hidden (we don't refresh from the cleared summary), so a
+				// repeat "Delete all transcripts" re-attempts the file removal and
+				// succeeds this time.
+				mockSaveTranscriptsBatch.mockClear();
+				mockSaveTranscriptsBatch.mockResolvedValueOnce(undefined);
+				postMessage.mockClear();
+
+				dispatch({ command: "deleteAllTranscripts" });
+				await flushPromises();
+
+				expect(mockSaveTranscriptsBatch).toHaveBeenCalledWith([], ["abc123"], workspaceRoot);
+				expect(postMessage).toHaveBeenCalledWith({ command: "transcriptsDeleted" });
 			});
 		});
 

--- a/vscode/src/views/SummaryWebviewPanel.ts
+++ b/vscode/src/views/SummaryWebviewPanel.ts
@@ -46,6 +46,7 @@ import type {
 	PlanReference,
 	StoredTranscript,
 } from "../../../cli/src/Types.js";
+import { CURRENT_SCHEMA_VERSION } from "../../../cli/src/Types.js";
 import { setLinearIssueIgnored } from "../core/LinearIssueService.js";
 import {
 	ignoreNote,
@@ -3248,6 +3249,14 @@ export class SummaryWebviewPanel {
 					"Summary updated but transcript file batch failed: %s",
 					err instanceof Error ? err.message : String(err),
 				);
+				// Deliberately do NOT `refreshTranscriptHashes` here. The summary
+				// was already cleared of the deleted IDs above, so refreshing from
+				// it would empty `transcriptHashSet` and erase the still-on-disk
+				// files from the panel — leaving the user no way to retry the very
+				// delete that just failed. Keeping the pre-operation set (which
+				// still matches what's on disk, since the batch failed) keeps those
+				// files visible and the retry path live. The Failed message unsticks
+				// the modal buttons on its own.
 				this.panel.webview.postMessage({
 					command: "transcriptsSaveFailed",
 					message: "Some transcript files failed to write. See logs.",
@@ -3306,26 +3315,25 @@ export class SummaryWebviewPanel {
 		try {
 			await this.bridge.saveTranscriptsBatch([], hashes);
 		} catch (err) {
-			// Summary already cleared but the orphan files weren't removed.
-			// From `getTranscriptIds(summary)` the user can no longer SEE the
-			// transcripts, but the bytes remain on the orphan branch and could
-			// resurface via direct branch inspection or future `git push`.
-			// For privacy-sensitive "delete my AI conversations" use cases that
-			// is NOT what the user asked for. Surface the partial failure so
-			// the user can retry / inspect logs rather than silently treating
-			// it as success.
+			// Summary already cleared but the orphan files weren't removed — the
+			// bytes remain on the orphan branch and could resurface via direct
+			// branch inspection or a future `git push`. For privacy-sensitive
+			// "delete my AI conversations" use cases that is NOT what the user
+			// asked for, so the delete MUST stay retryable.
 			log.warn(
 				"Summary cleared but transcript file delete failed: %s",
 				err instanceof Error ? err.message : String(err),
 			);
-			// Reset webview UI consistency: summary has been refreshed already,
-			// but the modal still believes the operation is in-flight. The
-			// failure message lets the script-side handler unstick the buttons
-			// and inform the user.
-			if (this.currentSummary) {
-				await this.refreshTranscriptHashes(this.currentSummary);
-				this.update(this.currentSummary);
-			}
+			// Deliberately do NOT `refreshTranscriptHashes` here. `currentSummary`
+			// was cleared above, so refreshing from it would empty
+			// `transcriptHashSet` and erase the still-on-disk files from the panel
+			// — the user would see "delete failed" with an empty list and no way
+			// to retry the orphaned bytes. Keeping the pre-delete set (which still
+			// matches disk, since the delete failed) keeps those conversations
+			// visible so a repeat "Delete all transcripts" re-attempts the file
+			// removal (the already-cleared v5 summary makes that a summary no-op,
+			// so only the file delete is retried). The Failed message unsticks the
+			// modal buttons on its own.
 			this.panel.webview.postMessage({
 				command: "transcriptsDeleteFailed",
 				message: "Some transcript files failed to delete. See logs.",
@@ -3350,26 +3358,34 @@ export class SummaryWebviewPanel {
 	 * leave a half-migration state).
 	 *
 	 * Handles both v5 and pre-v5 (legacy v3/v4) inputs:
-	 *   - v5 (`summary.transcripts !== undefined`): filter the existing array.
-	 *   - Legacy: derive the effective ID list via `getTranscriptIds` (which
-	 *     walks `children` and returns commit-hash IDs). Filter, then write
-	 *     back as a v5-shaped summary — the delete operation **lazily upgrades**
-	 *     the on-disk summary to v5. Without this, a delete that runs before
-	 *     the background v5 migration completes would leave the legacy summary
+	 *   - v5 (`summary.transcripts !== undefined`): filter the existing
+	 *     authoritative array.
+	 *   - Legacy: derive the effective ID list from `transcriptHashSet`, which
+	 *     `refreshTranscriptHashes` already filtered to tree IDs that have a
+	 *     `transcripts/<id>.json` file on disk — so the lazy upgrade writes the
+	 *     SAME file-backed set the v5 migration would (no dangling commit-hash
+	 *     IDs baked in). Filter, then write back as a v5 summary — the delete
+	 *     **lazily upgrades** the on-disk record to v5 (`version: 5` + the
+	 *     `transcripts` field). Without this, a delete that runs before the
+	 *     background v5 migration completes would leave the legacy summary
 	 *     intact; the next amend/squash/rebase would then re-inherit the
-	 *     just-deleted IDs via the `getTranscriptIds` fallback and stamp them
-	 *     onto the new v5 root.
+	 *     just-deleted IDs via the legacy fallback and stamp them onto the new
+	 *     v5 root.
 	 *
 	 * No-op (returns same reference) when nothing references any of the
 	 * removal IDs — both for empty v5 arrays and for legacy summaries whose
-	 * tree walk yielded no matches.
+	 * file-backed set is empty.
 	 */
 	private async persistTranscriptIdRemoval(
 		summary: CommitSummary,
 		idsToRemove: ReadonlySet<string>,
 	): Promise<CommitSummary> {
 		const isLegacy = summary.transcripts === undefined;
-		const current = isLegacy ? getTranscriptIds(summary) : (summary.transcripts ?? []);
+		// Legacy: `transcriptHashSet` is the tree's transcript IDs already
+		// intersected with on-disk files (see refreshTranscriptHashes), so it's
+		// the file-backed set the migration would produce — using it avoids
+		// re-baking dangling IDs. v5: the array is authoritative.
+		const current = isLegacy ? [...this.transcriptHashSet] : (summary.transcripts ?? []);
 		if (current.length === 0) {
 			return summary;
 		}
@@ -3377,14 +3393,18 @@ export class SummaryWebviewPanel {
 		// Fast-path: nothing removed AND already v5-shaped → return as-is.
 		// Legacy summaries still need a write even when `filtered.length ===
 		// current.length` would normally short-circuit, because the legacy
-		// summary itself doesn't have a `transcripts` field — writing it as
-		// `{ ...summary, transcripts: filtered }` is the lazy-upgrade.
+		// summary itself doesn't have a `transcripts` field / `version: 5` —
+		// writing it is the lazy-upgrade.
 		if (!isLegacy && filtered.length === current.length) {
 			return summary;
 		}
-		// v5 contract: always present, even when empty. Filtered down to []
-		// means "this commit no longer references any transcripts".
-		const updated: CommitSummary = { ...summary, transcripts: filtered };
+		// Write back as a real v5 record: stamp `version: 5` AND the
+		// `transcripts` field (v5 contract: always present, even when empty —
+		// `[]` means "this commit no longer references any transcripts"). Bumping
+		// the version keeps the on-disk record from being a "version<5 but has
+		// transcripts" hybrid that a future version-routing read path would
+		// misclassify.
+		const updated: CommitSummary = { ...summary, version: CURRENT_SCHEMA_VERSION, transcripts: filtered };
 		await this.bridge.storeSummary(updated, true);
 		return updated;
 	}

--- a/vscode/src/views/SummaryWebviewPanel.ts
+++ b/vscode/src/views/SummaryWebviewPanel.ts
@@ -104,6 +104,7 @@ import {
 } from "./SummaryUtils.js";
 import type { RegenerateContext } from "../../../cli/src/core/RegenerateContext.js";
 import { isSummaryError } from "../../../cli/src/core/SummaryErrorMarker.js";
+import { getTranscriptIds } from "../../../cli/src/core/SummaryTree.js";
 import type { LlmConfig } from "../../../cli/src/Types.js";
 
 /** Memory field updates sent from the webview edit form. */
@@ -1085,32 +1086,33 @@ export class SummaryWebviewPanel {
 	}
 
 	/**
-	 * Refreshes the cached `transcriptHashSet` by intersecting the summary tree's
-	 * commit hashes with the transcript files that exist in the orphan branch.
+	 * Refreshes the cached `transcriptHashSet` (logically a transcript-ID set
+	 * after v5: the entries may be UUIDs or legacy commit hashes — both are
+	 * opaque IDs to read/write/delete paths). Pulled via `getTranscriptIds`
+	 * which prefers `summary.transcripts` (v5) and falls back to walking
+	 * children for v3/v4 data; intersected with the files actually present
+	 * on the orphan branch so a missing-on-disk ID isn't kept in the set.
 	 */
 	private async refreshTranscriptHashes(summary: CommitSummary): Promise<void> {
 		try {
-			const treeHashes = collectTreeHashes(summary);
+			// `getTranscriptIds` returns the v5 `summary.transcripts` field
+			// verbatim when present and falls back to walking children for
+			// v3/v4 data — see SummaryTree.getTranscriptIds. Then intersect
+			// with the IDs actually on disk so a stale entry (file deleted
+			// out from under us) doesn't render in the panel.
+			const transcriptIds = getTranscriptIds(summary);
 			// Foreign mode: read the transcript file listing from the foreign
 			// repo's `.jolli/transcripts/` via the supplied StorageProvider.
 			// Going through `this.bridge.getTranscriptHashes()` here would hit
 			// `this.cwd`'s storage and return hashes disjoint from the foreign
 			// commit — which is what made "All Conversations" render empty for
 			// every cross-repo summary.
-			const allFileHashes = this.foreignStorage
-				? await coreGetTranscriptHashes(
-						this.workspaceRoot,
-						this.foreignStorage,
-					)
+			const allFileIds = this.foreignStorage
+				? await coreGetTranscriptHashes(this.workspaceRoot, this.foreignStorage)
 				: await this.bridge.getTranscriptHashes();
-			this.transcriptHashSet = new Set(
-				[...treeHashes].filter((h) => allFileHashes.has(h)),
-			);
+			this.transcriptHashSet = new Set(transcriptIds.filter((id) => allFileIds.has(id)));
 		} catch (err: unknown) {
-			log.warn(
-				"Failed to load transcript hashes: %s",
-				err instanceof Error ? err.message : String(err),
-			);
+			log.warn("Failed to load transcript hashes: %s", err instanceof Error ? err.message : String(err));
 			this.transcriptHashSet = new Set();
 		}
 	}
@@ -3202,8 +3204,56 @@ export class SummaryWebviewPanel {
 			writes.push({ hash: commitHash, data: storedTranscript });
 		}
 
+		// Summary-first ordering: if any deletes are in scope, persist the
+		// updated `summary.transcripts` BEFORE touching transcript files.
+		// Earlier code ran the file batch first, then the summary update; a
+		// failure in the second step left the half-migrated state "files
+		// gone but summary still references them", letting future
+		// amend/squash/rebase inherit stale IDs. Now the worst case after a
+		// summary-write failure is "no files touched yet" — clean abort.
+		if (deletes.length > 0 && this.currentSummary) {
+			try {
+				this.currentSummary = await this.persistTranscriptIdRemoval(
+					this.currentSummary,
+					new Set(deletes),
+				);
+			} catch (err) {
+				log.warn(
+					"Save aborted — could not persist summary.transcripts: %s",
+					err instanceof Error ? err.message : String(err),
+				);
+				this.panel.webview.postMessage({
+					command: "transcriptsSaveFailed",
+					message: "Could not update summary. Transcript files were NOT modified.",
+				});
+				return;
+			}
+		}
+
 		if (writes.length > 0 || deletes.length > 0) {
-			await this.bridge.saveTranscriptsBatch(writes, deletes);
+			try {
+				await this.bridge.saveTranscriptsBatch(writes, deletes);
+			} catch (err) {
+				// File batch failed AFTER summary already updated. Outcomes:
+				//   - `writes` items: user's edits never reached disk →
+				//     they'll see old content on next read; this is a real
+				//     data-fidelity miss the user must know about.
+				//   - `deletes` items: files still on disk but no longer
+				//     referenced by summary (orphan); from the summary's view
+				//     it's "deleted" but the bytes are still there.
+				// We post Failed (not Saved) so the modal's save button can
+				// reset out of its disabled "Saving..." state and the user
+				// can retry. Better to over-alert than silently lose edits.
+				log.warn(
+					"Summary updated but transcript file batch failed: %s",
+					err instanceof Error ? err.message : String(err),
+				);
+				this.panel.webview.postMessage({
+					command: "transcriptsSaveFailed",
+					message: "Some transcript files failed to write. See logs.",
+				});
+				return;
+			}
 		}
 
 		// Refresh cache and webview
@@ -3229,7 +3279,59 @@ export class SummaryWebviewPanel {
 			return;
 		}
 
-		await this.bridge.saveTranscriptsBatch([], hashes);
+		// Summary-first: clear `summary.transcripts` BEFORE the file delete.
+		// Earlier code deleted files first, then updated the summary; a
+		// failure in the second step left the half-migrated state "files
+		// gone but summary still references them", letting future
+		// amend/squash/rebase inherit stale IDs.
+		if (this.currentSummary) {
+			try {
+				this.currentSummary = await this.persistTranscriptIdRemoval(
+					this.currentSummary,
+					new Set(hashes),
+				);
+			} catch (err) {
+				log.warn(
+					"Delete aborted — could not persist summary.transcripts: %s",
+					err instanceof Error ? err.message : String(err),
+				);
+				this.panel.webview.postMessage({
+					command: "transcriptsDeleteFailed",
+					message: "Could not update summary. Transcript files were NOT deleted.",
+				});
+				return;
+			}
+		}
+
+		try {
+			await this.bridge.saveTranscriptsBatch([], hashes);
+		} catch (err) {
+			// Summary already cleared but the orphan files weren't removed.
+			// From `getTranscriptIds(summary)` the user can no longer SEE the
+			// transcripts, but the bytes remain on the orphan branch and could
+			// resurface via direct branch inspection or future `git push`.
+			// For privacy-sensitive "delete my AI conversations" use cases that
+			// is NOT what the user asked for. Surface the partial failure so
+			// the user can retry / inspect logs rather than silently treating
+			// it as success.
+			log.warn(
+				"Summary cleared but transcript file delete failed: %s",
+				err instanceof Error ? err.message : String(err),
+			);
+			// Reset webview UI consistency: summary has been refreshed already,
+			// but the modal still believes the operation is in-flight. The
+			// failure message lets the script-side handler unstick the buttons
+			// and inform the user.
+			if (this.currentSummary) {
+				await this.refreshTranscriptHashes(this.currentSummary);
+				this.update(this.currentSummary);
+			}
+			this.panel.webview.postMessage({
+				command: "transcriptsDeleteFailed",
+				message: "Some transcript files failed to delete. See logs.",
+			});
+			return;
+		}
 
 		// Refresh cache and webview
 		if (this.currentSummary) {
@@ -3238,6 +3340,53 @@ export class SummaryWebviewPanel {
 		}
 
 		this.panel.webview.postMessage({ command: "transcriptsDeleted" });
+	}
+
+	/**
+	 * Removes the given transcript IDs from `summary.transcripts` and persists
+	 * the updated summary via `storeSummary(force=true)`. Returns the new
+	 * summary on success; **throws** on `storeSummary` failure so callers can
+	 * surface the abort decision (e.g. skip the file delete that would otherwise
+	 * leave a half-migration state).
+	 *
+	 * Handles both v5 and pre-v5 (legacy v3/v4) inputs:
+	 *   - v5 (`summary.transcripts !== undefined`): filter the existing array.
+	 *   - Legacy: derive the effective ID list via `getTranscriptIds` (which
+	 *     walks `children` and returns commit-hash IDs). Filter, then write
+	 *     back as a v5-shaped summary — the delete operation **lazily upgrades**
+	 *     the on-disk summary to v5. Without this, a delete that runs before
+	 *     the background v5 migration completes would leave the legacy summary
+	 *     intact; the next amend/squash/rebase would then re-inherit the
+	 *     just-deleted IDs via the `getTranscriptIds` fallback and stamp them
+	 *     onto the new v5 root.
+	 *
+	 * No-op (returns same reference) when nothing references any of the
+	 * removal IDs — both for empty v5 arrays and for legacy summaries whose
+	 * tree walk yielded no matches.
+	 */
+	private async persistTranscriptIdRemoval(
+		summary: CommitSummary,
+		idsToRemove: ReadonlySet<string>,
+	): Promise<CommitSummary> {
+		const isLegacy = summary.transcripts === undefined;
+		const current = isLegacy ? getTranscriptIds(summary) : (summary.transcripts ?? []);
+		if (current.length === 0) {
+			return summary;
+		}
+		const filtered = current.filter((id) => !idsToRemove.has(id));
+		// Fast-path: nothing removed AND already v5-shaped → return as-is.
+		// Legacy summaries still need a write even when `filtered.length ===
+		// current.length` would normally short-circuit, because the legacy
+		// summary itself doesn't have a `transcripts` field — writing it as
+		// `{ ...summary, transcripts: filtered }` is the lazy-upgrade.
+		if (!isLegacy && filtered.length === current.length) {
+			return summary;
+		}
+		// v5 contract: always present, even when empty. Filtered down to []
+		// means "this commit no longer references any transcripts".
+		const updated: CommitSummary = { ...summary, transcripts: filtered };
+		await this.bridge.storeSummary(updated, true);
+		return updated;
 	}
 }
 
@@ -3269,21 +3418,6 @@ function setsEqual(a: ReadonlySet<string>, b: ReadonlySet<string>): boolean {
 		}
 	}
 	return true;
-}
-
-/** Recursively collects all commit hashes from a summary tree (root + all children). */
-function collectTreeHashes(summary: CommitSummary): Set<string> {
-	const hashes = new Set<string>();
-	function walk(node: CommitSummary): void {
-		hashes.add(node.commitHash);
-		if (node.children) {
-			for (const child of node.children) {
-				walk(child);
-			}
-		}
-	}
-	walk(summary);
-	return hashes;
 }
 
 /** Merges published plan URLs/docIds into plan references. */


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## Quick recap

Transcript files are no longer tied to commit hashes. Each transcript now carries a stable opaque identifier — a UUID for newly written data, or the original commit-hash string preserved verbatim for migrated data — stored in a new `transcripts` array on every summary. Rebase, amend, squash, and future cherry-pick operations now move these lightweight ID references around without touching any transcript files on disk, eliminating the file-rename churn that previously made history rewrites expensive and error-prone.

A one-shot migration engine upgrades every existing summary from older schema versions to v5 in a single atomic commit. The migration reads all summaries through one batched git subprocess and writes them back through a single fast-import stream, reducing what previously took minutes of per-file subprocess overhead on Windows to a few seconds. The helper that collapses older summary layouts was made fully lossless so the migration preserves topics, recaps, and diff statistics without needing an AI call. Users see the migration status in both the command-line status output and the editor's status panel, with automatic triggers on extension startup and CLI install.

Transcript editing and deletion in the editor panel now update the summary record before touching files, and surface clear error banners when either step fails. The previous flow could silently report success after a file-write failure, leaving stale references that propagated through future operations. The reversed ordering ensures the worst failure mode is harmless orphan files rather than corrupted summary state.

---

## Topics (6)
<details>
<summary><strong>01 · Stable transcript IDs decoupled from commit hashes for history-rewrite resilience</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Transcript files were named after commit hashes, so every rebase, amend, squash, or cherry-pick forced file renames or complex tree walks to locate conversation data. This made history-rewrite operations expensive and fragile, and blocked the planned cherry-pick summary inheritance feature.

**💡 Decisions Behind the Code**

- **Reuse commit-hash strings as legacy transcript IDs instead of renaming files during migration**: Renaming hundreds of transcript files would multiply migration I/O and introduce a multi-file atomicity risk — a crash mid-rename leaves some files at old names and some at new. Keeping the original filenames and treating them as opaque IDs means the migration only rewrites summary JSON files, all in one atomic commit. The mixed namespace (hex hashes alongside UUIDs) is safe because all downstream code treats transcript IDs as opaque strings, and the two formats are syntactically disjoint.
- **Binary user-facing migration status instead of five sub-states**: Earlier drafts surfaced completed-fresh, completed-migrated, in-progress, failed, and pending as separate status lines. Only three were reachable from the actual code path, and the distinction between them gave users no different action to take — everything that isn't "completed" reduces to "run the migrate command." Collapsing to two states ("Up to date" vs "Not migrated") eliminated dead UI branches and made the display self-explanatory without documentation.
- **Summary-first ordering for transcript edit and delete handlers**: The previous flow deleted transcript files first, then tried to update the summary. If the summary write failed, files were already gone but the summary still referenced stale IDs — a half-migrated state that propagated through future amend and squash operations. Reversing the order means a failed summary update leaves files intact (user retries), while a failed file deletion after a successful summary update only leaves harmless orphan files that a future cleanup can collect.

**✅ What Was Implemented**

- Added a `transcripts: string[]` field to `CommitSummary` (v5 schema) that holds opaque transcript IDs. New writes generate UUID v4 IDs via `generateTranscriptId()` in `TranscriptId.ts`; migrated data reuses the original commit-hash string verbatim as the ID, avoiding any file renames. A `CURRENT_SCHEMA_VERSION` constant in `Types.ts` stamps all five write sites consistently.
- Built a one-shot migration engine (`SchemaV5Migration.ts`) that reads every summary via a single `git cat-file --batch` subprocess (`batchReadFilesFromBranch` in `GitOps.ts`), runs the lossless `normalizeToV4` helper, then stamps v5 with the transcript array. The migration writes all upgraded summaries in one atomic orphan-branch commit through the storage provider, so dual-write (orphan + shadow folder) users get both backends upgraded in one pass.
- Replaced the per-file `hash-object` + `mktree` + `ls-tree` write pipeline with a single `git fast-import` subprocess (`runFastImport` in `GitOps.ts`). On Windows this reduced a 337-summary migration from roughly three minutes of subprocess overhead to a few seconds. The `cwd` parameter was also moved from git's `-C` argv flag to Node's spawn options bag, eliminating CodeQL taint-tracking alerts.

**📋 Future Enhancements**

- Cherry-pick summary inheritance (JOLLI-1570) is unblocked by v5 but not yet implemented — transcript physical copy + new UUID generation for the target commit is designed but deferred.
- Failed migration state persistence and Hooks icon degradation to warning are deferred to Release N+M (plan §9.15).
- The v1→v3 legacy migration code (~1000 lines) is dead-leaning and should be retired via a deprecation window in a future release.

**📁 FILES**
- `cli/src/core/SchemaV5Migration.ts`
- `cli/src/core/GitOps.ts`
- `cli/src/hooks/QueueWorker.ts`
- `cli/src/core/SummaryStore.ts`
- `cli/src/core/SummaryTree.ts`

</blockquote>
</details>
<details>
<summary><strong>02 · Lossless normalization of legacy summary data for safe one-shot migration</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The existing helper that collapsed older summary layouts into the current format silently dropped topics and recaps from certain legacy tree shapes. This was acceptable for its original caller (which immediately overwrote those fields with fresh AI-generated content), but the new migration needed to preserve every field without an AI call.

**💡 Decisions Behind the Code**

- **Single lossless helper shared across all callers rather than per-caller rescue logic**: The alternative was to add "rescue topics before normalize, write them back after" wrappers in each caller. That would duplicate the same fragile sequence in the migration, the regenerator, and any future consumer. Making the core helper lossless eliminates the class of bugs where a new caller forgets the rescue step, and the regeneration path is unaffected because it overwrites topics and recap after normalization regardless.

**✅ What Was Implemented**

- Extended `normalizeToV4` in `SummaryStore.ts` to explicitly hoist topics via `resolveEffectiveTopics` and recaps via a new `resolveEffectiveRecap` helper before stripping children. Added `stats` → `diffStats` migration for the legacy field name. This makes the function safe for any caller that needs lossless normalization, not just the regeneration path.
- Added `resolveEffectiveRecap` and its recursive `pickNewestDescendantRecap` helper to mirror the existing topic-collection pattern. For legacy data where the recap lives on children rather than the root, it selects the newest child's recap by display date.
- Added seven new test cases in `normalizeToV4.test.ts` covering legacy squash roots with topics in children, amend roots with recap in children, stats-to-diffStats migration, and a guard confirming the regeneration caller can still freely overwrite topics and recap on the normalized result.

**📁 FILES**
- `cli/src/core/SummaryStore.ts`
- `cli/src/core/normalizeToV4.test.ts`

</blockquote>
</details>
<details>
<summary><strong>03 · Batched git reads and fast-import writes for bulk orphan-branch operations</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The migration needed to read and rewrite hundreds of summary files on the orphan branch. The existing per-file approach spawned a new git subprocess for each read and each write step, costing roughly 80 milliseconds per spawn on Windows — making a 337-file migration take minutes of pure subprocess overhead.

**💡 Decisions Behind the Code**

- **Streaming state-machine parser over line-buffered approach**: The cat-file batch protocol frames responses by byte count, not by line boundaries. A line-buffered reader would need to re-parse partial bodies and handle binary content specially. The state machine consumes bytes positionally (header phase until newline, then exactly N body bytes, then trailing newline) and naturally handles chunk splits at any boundary, including mid-header and mid-body. The complexity cost is contained in one function with clear phase transitions.
- **Fast-import over incremental tree manipulation**: The old pipeline required four to six subprocess spawns per file (hash-object, ls-tree, mktree, replaceInTree, commit-tree, update-ref). Fast-import collapses all of that into one spawn that accepts blob and commit records on stdin. The trade-off is that fast-import's protocol is more complex to generate correctly (mark references, byte-counted data directives, identity lines), but the generation is straightforward and the performance difference on Windows is two orders of magnitude for bulk operations.

**✅ What Was Implemented**

- Implemented `batchReadFilesFromBranch` in `GitOps.ts`, a streaming parser for `git cat-file --batch` that reads all requested files through a single long-running subprocess. The parser is a state machine that handles arbitrary chunk boundaries between header and body, multi-byte UTF-8, zero-byte blobs, and missing entries. Added EPIPE error handling on stdin for early subprocess exit.
- Replaced the per-file `hash-object` + `mktree` + `ls-tree` + `commit-tree` + `update-ref` write pipeline in `writeMultipleFilesToBranch` with a single `git fast-import --quiet --done` subprocess. Author and committer identity are read from `git var` to match the old `commit-tree` behavior. The `from <parent>` directive provides a secondary concurrency guard against ref advancement between the tip read and the import.
- Rewrote the `GitOps.test.ts` suite to match the new protocol: added streaming chunk-boundary tests, EPIPE rejection tests, UTF-8 byte-length tests, and fast-import protocol assertions. Removed the old tree-manipulation test fixtures that no longer apply.

**📁 FILES**
- `cli/src/core/GitOps.ts`
- `cli/src/core/GitOps.test.ts`

</blockquote>
</details>
<details>
<summary><strong>04 · Migration status visibility in CLI and editor status panels</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

After adding the migration, users had no way to see whether their project's data had been upgraded or whether they needed to take action.

**💡 Decisions Behind the Code**

Binary status display was chosen over a five-state model because only two states are actionable for users: either the data is current or they should run the migrate command. The structured state file retains richer internal fields for future diagnostics, but the user-facing surface deliberately collapses them to avoid confusion over states the user cannot distinguish or act on differently.

**✅ What Was Implemented**

- Added a `Data migration:` line to `jolli status` CLI output showing either "Up to date (v5)" or "Not migrated — run jolli migrate". The same text appears in the VS Code Hooks tooltip via `StatusTreeProvider`. Both surfaces share a single `describeSchemaV5Status` helper in `StatusCommand.ts`.
- Extended `StatusInfo` with `schemaV5` and `schemaV5Fresh` fields populated from the migration state file by `Installer.getStatus`. The `--json` output includes these fields for programmatic consumers.
- Wired automatic migration triggers into VS Code extension activation (`Extension.ts`) and CLI install (`Installer.ts`), both as fire-and-forget calls that log warnings on failure without blocking the user.

**📁 FILES**
- `cli/src/commands/StatusCommand.ts`
- `vscode/src/providers/StatusTreeProvider.ts`
- `cli/src/install/Installer.ts`
- `vscode/src/Extension.ts`

</blockquote>
</details>
<details>
<summary><strong>05 · Transcript edit and delete failure handling with user-visible error feedback</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

When saving or deleting transcript edits in the editor panel, file-write failures were silently swallowed and the panel still reported success. This could leave users believing their edits were saved or their conversations were deleted when neither had actually happened.

**💡 Decisions Behind the Code**

- **Summary-first write ordering over file-first**: The worst failure mode of file-first is "files deleted but summary still references them" — a state that silently propagates stale IDs through every subsequent history-rewrite operation. Summary-first means the worst failure mode is "summary updated but orphan files remain on disk," which is harmless (files are tiny, referenced by nothing, and collectible by future cleanup). The trade-off is that a summary-write failure now blocks the entire operation rather than partially completing, but that's the correct behavior — partial completion was the bug.

**✅ What Was Implemented**

- Reversed the operation order in both `handleSaveAllTranscripts` and `handleDeleteAllTranscripts` in `SummaryWebviewPanel.ts` to update the summary first, then write or delete files. Summary failure now aborts before touching files and posts a `transcriptsSaveFailed` or `transcriptsDeleteFailed` message.
- Added frontend handling for the new failure messages in `SummaryScriptBuilder.ts`: the Save button resets from its disabled "Saving..." state, and an error banner appears in the conversation modal. The banner is cleared on the next modal open via `openModal`.
- Added `persistTranscriptIdRemoval` helper that also handles legacy v3/v4 summaries by deriving transcript IDs via `getTranscriptIds` before filtering, preventing stale IDs from propagating through future amend or squash operations on unmigrated data.

**📁 FILES**
- `vscode/src/views/SummaryWebviewPanel.ts`
- `vscode/src/views/SummaryScriptBuilder.ts`
- `vscode/src/views/SummaryHtmlBuilder.ts`

</blockquote>
</details>
<details>
<summary><strong>06 · Design documentation for transcript stable ID migration and cherry-pick inheritance</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The v5 schema change and the planned cherry-pick feature needed comprehensive design documents capturing the motivation, migration strategy, compatibility constraints, and implementation sequence so that future contributors could understand the reasoning behind the architecture.

**💡 Decisions Behind the Code**

- **Dual-release deprecation window over immediate legacy code removal**: Removing v3/v4 compatibility code in the same release as the migration would break any user whose migration failed or hadn't run yet. The plan explicitly separates Release N (migration + compatibility retained) from Release N+M (compatibility removed after telemetry confirms adoption), following the standard deprecation-window pattern used by database migration frameworks.
- **Git reflog as recovery mechanism instead of explicit backup branch**: The v1→v3 migration created a separate backup branch because it wrote to a different orphan branch. The v5 migration is an in-place rewrite of the same branch, so the old commit is automatically preserved in git's reflog for 90 days by default — strictly longer than the 48-hour backup branch the early design proposed. The pre-migration SHA is logged to the debug log as a recovery anchor for support triage.

**✅ What Was Implemented**

- Created `docs/2026-05-22-v5 transcript 稳定 ID 改造与统一迁移计划.md` covering the full migration design: motivation (four pain points), schema changes, migration strategy with dual-release deprecation window, per-git-operation behavior tables, code change inventory, test plan, and phased implementation order with completion status markers.
- Updated `docs/2026-05-22-cherry-pick 摘要继承 实现计划.md` to align with the v5 model: changed the transcript copy algorithm from hash-based file duplication to transcript-ID array iteration with UUID generation, updated the front dependency to point at the v5 plan, and revised test acceptance criteria.

**📁 FILES**
- `docs/2026-05-22-v5 transcript 稳定 ID 改造与统一迁移计划.md`
- `docs/2026-05-22-cherry-pick 摘要继承 实现计划.md`

</blockquote>
</details>

---

*Generated by Jolli Memory · June 1, 2026 at 2:00 PM · via Anthropic*
<!-- jollimemory-summary-end -->