### PR TITLE
Guard npm package theme refs and fix SidebarTabs root redirect

### DIFF
--- a/cli/src/site/NextraProjectWriter.test.ts
+++ b/cli/src/site/NextraProjectWriter.test.ts
@@ -23,7 +23,7 @@ import { mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import * as fc from "fast-check";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -593,6 +593,39 @@ describe("NextraProjectWriter.generateTsConfig", () => {
 describe("NextraProjectWriter.initNextraProject", () => {
 	let tempDir: string;
 
+	// Register a "default" theme pack stub so `discoverPack` step 2 hits the
+	// in-process registry and skips steps 4 (~/.jolli/themes lookup) and 5
+	// (GitHub registry network fetch). Without this, every `initNextraProject`
+	// call here races a real GitHub roundtrip on cold-cache or slow-network
+	// environments, and tests that call it twice (the isNew:false case)
+	// regularly blow vitest's 15s timeout.
+	//
+	// The stub's `generateLayout` delegates to the real `generateDefaultLayout`,
+	// so the bytes written to `app/layout.tsx` match the prior "no pack
+	// registered → fallback" path — existing title/description/nav assertions
+	// keep passing unchanged.
+	//
+	// Scoped to this describe via `beforeAll` (not file-level) so the earlier
+	// `NextraProjectWriter.generateLayout` block's "uses the default layout
+	// when theme.pack is 'default'" assertion — which depends on the registry
+	// NOT having a `default` pack — keeps passing. Vitest runs describes
+	// top-down within a file, so this fires after generateLayout's
+	// expectations have already been verified.
+	beforeAll(async () => {
+		const { registerPack } = await import("./themes/ThemeRegistry.js");
+		const { generateDefaultLayout } = await import("./NextraProjectWriter.js");
+		registerPack({
+			manifest: {
+				name: "default",
+				displayName: "Default (test stub)",
+				tagline: "test stub",
+				defaults: { primaryHue: 220, defaultTheme: "system", fontFamily: "inter" },
+			},
+			buildCss: () => undefined,
+			generateLayout: (config) => generateDefaultLayout(config),
+		});
+	});
+
 	beforeEach(async () => {
 		tempDir = await makeTempDir();
 	});
@@ -776,6 +809,47 @@ describe("NextraProjectWriter.initNextraProject", () => {
 		expect(helperIdx).toBeGreaterThan(-1);
 		expect(exportIdx).toBeGreaterThan(-1);
 		expect(helperIdx).toBeLessThan(exportIdx);
+	});
+
+	it("writeSidebarTabsComponent emits a client-component SidebarTabs.tsx using Nextra's useConfig + usePathname", async () => {
+		// Call writeSidebarTabsComponent directly instead of going through
+		// initNextraProject — the latter calls discoverPack, which hits the
+		// GitHub registry on cold-cache test environments and can time out on
+		// network / tar-parse failures unrelated to this test.
+		const { writeSidebarTabsComponent } = await import("./NextraProjectWriter.js");
+		const buildDir = join(tempDir, ".jolli-site");
+
+		await writeSidebarTabsComponent(buildDir);
+
+		expect(existsSync(join(buildDir, "components", "SidebarTabs.tsx"))).toBe(true);
+		const content = await readFile(join(buildDir, "components", "SidebarTabs.tsx"), "utf-8");
+		expect(content).toContain('"use client"');
+		expect(content).toContain("useConfig");
+		expect(content).toContain("usePathname");
+	});
+
+	it("SidebarTabs.tsx skips the no-active-tab redirect on '/' so a user-authored root index is not jumped away from", async () => {
+		// Why this test exists: when a customer keeps a real root index.md/.mdx,
+		// StartCommand.syncContent skips writeRootRedirectIndex so "/" renders
+		// that user content. If SidebarTabs still force-redirected when no tab
+		// matched the URL, the saved root page would flash and then disappear
+		// — re-introducing the very flicker the redirect-stub removal was
+		// supposed to eliminate.
+		const { writeSidebarTabsComponent } = await import("./NextraProjectWriter.js");
+		const buildDir = join(tempDir, ".jolli-site");
+
+		await writeSidebarTabsComponent(buildDir);
+
+		const content = await readFile(join(buildDir, "components", "SidebarTabs.tsx"), "utf-8");
+		// The redirect branch must be gated on `pathname !== "/"` AND
+		// `!anyActive`. We assert the conjunction is present in the same
+		// `if` statement rather than just substring-matching individual
+		// fragments so a future refactor that splits them apart still fails
+		// this test.
+		const redirectStmtMatch = content.match(/if\s*\([^)]*!anyActive[^)]*\)\s*{[^}]*window\.location\.href/);
+		expect(redirectStmtMatch, "expected an `if (!anyActive ...) { window.location.href }` block").not.toBeNull();
+		const redirectStmt = redirectStmtMatch?.[0] ?? "";
+		expect(redirectStmt).toContain('pathname !== "/"');
 	});
 
 	it("written package.json is valid JSON with required dependencies", async () => {

--- a/cli/src/site/NextraProjectWriter.ts
+++ b/cli/src/site/NextraProjectWriter.ts
@@ -257,7 +257,7 @@ export default function ScopedNextraLayout({ pageMap, children, ...layoutProps }
  *
  * Uses Nextra's own data — no need to hardcode tab lists.
  */
-async function writeSidebarTabsComponent(buildDir: string): Promise<void> {
+export async function writeSidebarTabsComponent(buildDir: string): Promise<void> {
 	await mkdir(join(buildDir, "components"), { recursive: true });
 	const content = `// @ts-nocheck
 "use client";
@@ -277,8 +277,14 @@ export default function SidebarTabs({ className }) {
     pathname === item.route || pathname === item.route + "/" || pathname.startsWith(item.route + "/")
   );
 
-  // If no tab matches the current URL, redirect to the first tab
-  if (!anyActive && routeItems.length > 0 && typeof window !== "undefined") {
+  // If no tab matches the current URL, redirect to the first tab — except on
+  // "/": StartCommand only skips writeRootRedirectIndex when the user has
+  // authored a real root index, so reaching this branch on "/" means the page
+  // content is real and must NOT be replaced by a client-side jump. (When
+  // there is no root index, "/" is a redirect stub whose inline <script>
+  // navigates away before SidebarTabs ever hydrates, so this branch never
+  // runs on "/" in that case.)
+  if (!anyActive && pathname !== "/" && routeItems.length > 0 && typeof window !== "undefined") {
     window.location.href = routeItems[0].route;
     return null;
   }

--- a/cli/src/site/Types.ts
+++ b/cli/src/site/Types.ts
@@ -120,8 +120,12 @@ export type PathMappings = Record<string, string>;
  *   - `"default"` — vanilla `nextra-theme-docs` (no pack CSS)
  *   - `"./my-theme.js"` — local file path (resolved relative to source root)
  *
- * The `(string & {})` intersection keeps TypeScript's autocomplete for
- * well-known names while accepting any arbitrary string.
+ * npm package references (e.g. `"@acme/docs-theme"` or `"acme/docs-theme"`)
+ * were once supported but were removed in commit d55ec46. They are now
+ * rejected at discovery time with a migration error pointing at the three
+ * forms above. The `(string & {})` intersection still accepts arbitrary
+ * strings for TypeScript's autocomplete on well-known names; runtime
+ * resolution is what enforces the supported forms.
  */
 export type ThemePack = "default" | "forge" | "atlas" | (string & {});
 

--- a/cli/src/site/themes/ThemeRegistry.test.ts
+++ b/cli/src/site/themes/ThemeRegistry.test.ts
@@ -1,10 +1,19 @@
 import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { NextraProjectConfig } from "../NextraProjectWriter.js";
 import type { ThemePackProvider } from "./ThemeRegistry.js";
-import { discoverPack, getPack, listPacks, readManifestVersion, registerPack, resolvePack } from "./ThemeRegistry.js";
+import {
+	discoverPack,
+	getPack,
+	listPacks,
+	looksLikeNpmPackage,
+	NPM_PACKAGE_GUARD_TAG,
+	readManifestVersion,
+	registerPack,
+	resolvePack,
+} from "./ThemeRegistry.js";
 
 const MINIMAL_CONFIG: NextraProjectConfig = {
 	title: "Test",
@@ -134,6 +143,93 @@ export default theme;
 			{ themePath: testThemeDir },
 		);
 		expect(pack?.manifest.name).toBe("discover-test");
+	});
+});
+
+// ─── npm-package-reference guard tests ─────────────────────────────────────
+//
+// Why this guard exists: npm package theme resolution was removed in commit
+// d55ec46, but the `ThemePack` type still accepts arbitrary strings via
+// `(string & {})`. Without an explicit guard, a site.json carrying a
+// historical value like `theme.pack: "@acme/docs-theme"` would fall through
+// to the GitHub registry and fail with an opaque "could not load theme"
+// network error. The guard short-circuits with a migration-pointing error
+// before the network call so users see an actionable message.
+
+describe("looksLikeNpmPackage", () => {
+	it("identifies scoped npm package names (start with @)", () => {
+		expect(looksLikeNpmPackage("@acme/docs-theme")).toBe(true);
+		expect(looksLikeNpmPackage("@scope/pkg")).toBe(true);
+	});
+
+	it("identifies unscoped slash-separated names (likely npm or repo refs)", () => {
+		expect(looksLikeNpmPackage("acme/docs-theme")).toBe(true);
+		expect(looksLikeNpmPackage("foo/bar/baz")).toBe(true);
+	});
+
+	it("does not flag single-segment names (GitHub registry style)", () => {
+		expect(looksLikeNpmPackage("forge")).toBe(false);
+		expect(looksLikeNpmPackage("atlas")).toBe(false);
+		expect(looksLikeNpmPackage("default")).toBe(false);
+		expect(looksLikeNpmPackage("jolli-theme-something")).toBe(false);
+	});
+});
+
+describe("discoverPack — npm package reference migration error", () => {
+	let errorSpy: ReturnType<typeof vi.spyOn>;
+
+	beforeEach(() => {
+		errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+	});
+
+	afterEach(() => {
+		errorSpy.mockRestore();
+	});
+
+	it("returns undefined and logs a migration error for scoped npm package names", async () => {
+		const pack = await discoverPack({
+			...MINIMAL_CONFIG,
+			theme: { pack: "@acme/docs-theme" as string },
+		});
+
+		expect(pack).toBeUndefined();
+		expect(errorSpy).toHaveBeenCalledTimes(1);
+		const msg = errorSpy.mock.calls[0]?.[0] as string;
+		// Migration messaging the user can act on. The guard tag is the
+		// stable contract; surrounding wording can change freely.
+		expect(msg).toContain("@acme/docs-theme");
+		expect(msg).toContain(NPM_PACKAGE_GUARD_TAG);
+		expect(msg).toContain("no longer supported");
+		expect(msg).toContain("github.com/jolliai/themes");
+	});
+
+	it("returns undefined and logs a migration error for unscoped slash-separated names", async () => {
+		const pack = await discoverPack({
+			...MINIMAL_CONFIG,
+			theme: { pack: "acme/docs-theme" as string },
+		});
+
+		expect(pack).toBeUndefined();
+		expect(errorSpy).toHaveBeenCalledTimes(1);
+		const msg = errorSpy.mock.calls[0]?.[0] as string;
+		expect(msg).toContain("acme/docs-theme");
+		expect(msg).toContain(NPM_PACKAGE_GUARD_TAG);
+	});
+
+	it("does NOT short-circuit single-segment names (those still go to the GitHub registry)", async () => {
+		// We can't assert what GitHub returns from a unit test, but we *can*
+		// assert that the npm-package guard did not fire — its `console.error`
+		// carries `NPM_PACKAGE_GUARD_TAG` as a stable marker, which the
+		// GitHub-fallback error ("Could not load theme …") does not share.
+		await discoverPack({
+			...MINIMAL_CONFIG,
+			theme: { pack: "does-not-exist-anywhere-12345" as string },
+		});
+
+		const npmGuardCall = errorSpy.mock.calls.find((call: unknown[]) =>
+			typeof call[0] === "string" ? (call[0] as string).includes(NPM_PACKAGE_GUARD_TAG) : false,
+		);
+		expect(npmGuardCall).toBeUndefined();
 	});
 });
 

--- a/cli/src/site/themes/ThemeRegistry.ts
+++ b/cli/src/site/themes/ThemeRegistry.ts
@@ -12,6 +12,12 @@
  *   3. Explicit file path in site.json (starts with `./` or `/`)
  *   4. User theme directory → ~/.jolli/themes/<name>/index.mjs
  *   5. GitHub registry → github.com/jolliai/themes/<name>/
+ *
+ * npm package references (e.g. `@acme/docs-theme`) were once a supported
+ * resolution mode but were removed in commit d55ec46. They are now
+ * intercepted between step 4 and step 5 with a migration error instead of
+ * being passed to the GitHub registry, which only handles single-segment
+ * names.
  */
 
 import { existsSync, statSync } from "node:fs";
@@ -115,12 +121,24 @@ export function resolvePack(config: NextraProjectConfig): ThemePackProvider | un
 const USER_THEMES_DIR = join(homedir(), ".jolli", "themes");
 
 /**
+ * Stable phrase that the npm-package guard emits in its `console.error`.
+ * Exported so tests can assert on it without hard-coding the surrounding
+ * sentence — change the wording around it freely, but keep this tag intact
+ * (or update its tests when intentionally changing the contract).
+ */
+export const NPM_PACKAGE_GUARD_TAG = "looks like an npm package reference";
+
+/**
  * Discovers and loads a theme pack by name, searching in order:
  *   1. `--theme` CLI path (passed as `themePath`) — always wins
  *   2. Registry (packs registered at runtime)
  *   3. Explicit file path in site.json (starts with `./` or `/`)
  *   4. User theme directory (`~/.jolli/themes/<name>/index.mjs`)
  *   5. GitHub registry (`github.com/jolliai/themes/<name>/`)
+ *
+ * Between step 4 and step 5, names that look like npm package references
+ * (start with `@` or contain `/`) short-circuit with a migration error
+ * instead of being handed to the GitHub registry.
  *
  * Returns the provider (now also registered) or `undefined` if not found.
  */
@@ -153,6 +171,32 @@ export async function discoverPack(
 		return loadFromPath(userThemePath);
 	}
 
+	// Guard: npm package references (e.g. `@acme/docs-theme` or
+	// `acme/docs-theme`) used to be a supported resolution mode but were
+	// removed in commit d55ec46. `ThemePack` is still `(string & {})` so
+	// existing site.json values type-check; without this guard they would
+	// fall through to the GitHub registry, which expects single-segment
+	// names like "forge" and would fail with an opaque
+	// "could not load theme" message. Surface the migration path
+	// explicitly and bail before the network call.
+	//
+	// IMPORTANT: this guard MUST stay above the GitHub registry call below.
+	// Moving it down (e.g. when refactoring `downloadTheme` to a static
+	// import) would let npm-style names hit the network and produce the
+	// opaque error this guard was added to prevent.
+	if (looksLikeNpmPackage(name)) {
+		console.error(
+			`  Error: theme.pack "${name}" ${NPM_PACKAGE_GUARD_TAG}, but npm package theme packs ` +
+				`are no longer supported.\n` +
+				`         Migrate to one of:\n` +
+				`           • A theme name published to github.com/jolliai/themes (e.g. "forge", "atlas")\n` +
+				`           • A local file or folder path (starts with "./" or "/")\n` +
+				`           • The built-in "default" theme (vanilla nextra-theme-docs)\n` +
+				`         Falling back to the default Nextra layout.`,
+		);
+		return undefined;
+	}
+
 	// 5) GitHub registry: github.com/jolliai/themes/<name>/
 	//
 	// On any failure here (network unreachable, theme not in repo, …) the
@@ -176,6 +220,26 @@ export async function discoverPack(
 	}
 
 	return undefined;
+}
+
+/**
+ * Returns `true` when `name` looks like an npm package reference rather than
+ * a GitHub theme registry name. By the time `discoverPack` calls this, the
+ * `./` and `/` path forms have already been resolved by step 3, so any
+ * remaining string containing `/` or starting with `@` is a strong signal
+ * of an npm-style reference (scoped or unscoped).
+ *
+ * Path forms in `site.json` are expected to use forward slashes. Windows-
+ * style absolute paths like `C:\\Users\\foo\\theme` are not detected by
+ * step 3 (which checks `./` / `/` prefixes) and will also slip past this
+ * guard (no `/`, no leading `@`), falling through to the GitHub registry.
+ * Users on Windows should write `C:/Users/foo/theme` or use a `./` relative
+ * path instead.
+ *
+ * Exported for unit testing — call site is in `discoverPack`.
+ */
+export function looksLikeNpmPackage(name: string): boolean {
+	return name.startsWith("@") || name.includes("/");
 }
 
 // ─── Cache version check ────────────────────────────────────────────────


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## Quick recap

This commit addressed two review findings against the site-generation pipeline. The first was a behavioral gap: when a user keeps their own root index page, the site's tab navigation component would still redirect the browser away from the root URL after the page loaded, defeating the purpose of preserving that content. A one-line guard was added to the generated component so the redirect is suppressed specifically on the root path. The second finding concerned npm package names used as theme references — after an earlier removal of npm resolution support, such values would silently fall back to the default layout with no guidance. An explicit interception step was added that detects npm-style names and surfaces a clear migration error before any network call is attempted. Both fixes were accompanied by targeted tests, and a pre-existing test timeout caused by real network calls during theme discovery was resolved by registering a local stub in the affected test suite.

---

## Topics (3)
<details>
<summary><strong>01 · Root URL no longer hijacked by tab navigation after user keeps their own homepage</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

When a user authored their own root index page, the site generator was updated to preserve it rather than overwrite it with a redirect stub. However, the generated tab navigation component still contained client-side logic that would redirect the browser away from the root URL whenever no tab matched the current path — meaning the preserved homepage would flash briefly and then disappear after the page hydrated.

**💡 Decisions Behind the Code**

- **Suppressing the redirect only on root rather than removing it entirely**: The redirect behavior is intentional for all other paths where no tab matches — it prevents users from landing on a blank or broken page. Removing it globally would break navigation for sites that rely on it. Scoping the exception to the root path is the minimal change that fixes the regression without altering behavior elsewhere.
- **Testing the generated source text rather than runtime behavior**: The component is written as a string template into the filesystem, so there is no importable module to exercise at runtime in a unit test. Asserting on the generated text with a regex that spans the full conditional expression was chosen over simple substring matching because it catches refactors that might separate the two conditions into different branches, which would silently reintroduce the bug.

**✅ What Was Implemented**

- Modified the redirect condition inside the generated `SidebarTabs.tsx` template in `cli/src/site/NextraProjectWriter.ts` to skip the client-side redirect when the current path is exactly the root. Added an inline comment explaining the invariant: the only way `SidebarTabs` can hydrate on the root path is if a real user page exists there, because the redirect stub (used when no user page exists) navigates away via an inline script before hydration ever runs.
- Exported `writeSidebarTabsComponent` from `NextraProjectWriter.ts` so tests can invoke it directly without going through the full project initialization flow, which triggers network-dependent theme discovery and is unreliable in cold-cache environments.
- Added two regression tests in `NextraProjectWriter.test.ts`: one verifying the generated component includes the expected client-side hooks, and one asserting via regex that the redirect branch contains the root-path guard in the same conditional expression — structured so a future refactor that splits the conditions apart would still fail the test.

**📁 FILES**
- `cli/src/site/NextraProjectWriter.ts`

</blockquote>
</details>
<details>
<summary><strong>02 · npm package theme references now produce a clear migration error instead of silently falling back</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Support for resolving theme packs from npm packages was removed in an earlier commit, but the theme type definition still accepted arbitrary strings. Sites that had previously configured an npm package as their theme would now silently fall back to the default layout with only a generic error in the logs, giving users no indication of what went wrong or how to fix it.

**💡 Decisions Behind the Code**

- **Hard error with migration guidance rather than silent fallback or a deprecation warning**: A silent fallback was already the status quo and had proven confusing — users had no signal that their configuration was being ignored. A deprecation warning that still attempted resolution would require keeping dead code paths alive. A hard error with explicit migration steps gives users the fastest path to a working configuration and makes the removal unambiguous.
- **Placing the guard between the local directory lookup and the GitHub fetch**: Names that look like npm packages would be passed to the GitHub registry, which expects single-segment names like "forge" or "atlas" and would return a generic failure. Intercepting before the network call avoids a slow, misleading failure and ensures the migration message is the first thing the user sees rather than a network timeout or a confusing "theme not found" error.

**✅ What Was Implemented**

- Added a `looksLikeNpmPackage` guard function in `cli/src/site/themes/ThemeRegistry.ts` that identifies names starting with `@` or containing a `/` as npm-style references. This guard runs between the user theme directory lookup and the GitHub registry fetch, short-circuiting with a `console.error` message that names the unsupported value, explains that npm package resolution was removed, and lists the three supported migration paths.
- Updated the `ThemePack` type comment in `cli/src/site/Types.ts` to document that npm package references are now rejected at discovery time, clarifying that the open string intersection type is retained only for TypeScript autocomplete and that runtime enforcement is what restricts the supported forms.
- Added tests in `ThemeRegistry.test.ts` covering `looksLikeNpmPackage` for scoped names, unscoped slash-separated names, and single-segment names; plus integration-style tests on `discoverPack` asserting that scoped and slash-separated names produce the migration error and that single-segment names are not intercepted by the guard.

**📁 FILES**
- `cli/src/site/themes/ThemeRegistry.ts`
- `cli/src/site/Types.ts`

</blockquote>
</details>
<details>
<summary><strong>03 · Test suite timeout fixed by eliminating real network calls during theme discovery</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

A test that ran the full project initialization flow twice was consistently timing out at fifteen seconds. The root cause was that the default theme was not registered in the in-process registry, causing every initialization call to fall through to a live GitHub network fetch for theme assets — unreliable in cold-cache or slow-network environments, and fatal when called twice in a single test.

**💡 Decisions Behind the Code**

- **Scoping the stub registration to the affected test group rather than the whole file**: An earlier test group asserts behavior that depends on the default theme not being registered. Registering the stub at file level would break that group. Vitest runs describe blocks top-to-bottom within a file, so placing the registration in a setup hook inside the later group means the earlier group completes before the stub is installed, preserving both behaviors without any test ordering tricks.

**✅ What Was Implemented**

Registered a "default" theme stub inside a scoped setup hook in `NextraProjectWriter.test.ts` so that theme discovery resolves from the in-process registry without any network or filesystem access. The stub's layout generator delegates to the real default layout function, keeping the bytes written to disk identical to the prior fallback path so all existing content assertions continue to pass. The hook is scoped to only the initialization test group, placed after the group that depends on the default theme being absent from the registry, preserving that group's existing assertions.

**📁 FILES**
- `cli/src/site/NextraProjectWriter.test.ts`

</blockquote>
</details>

---

*Generated by Jolli Memory · May 25, 2026 at 4:26 PM · via Jolli proxy*
<!-- jollimemory-summary-end -->