### PR TITLE
docs: update CLI, VS Code, and security docs for 0.99.2 release

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,12 +1,18 @@
 # Changelog
 
-<!-- Last synced commit: d53654bc | 2026-05-13 -->
+<!-- Last synced commit: 8ce5671f | 2026-05-28 -->
 
 ## 0.99.2
 
-- **Plugin mode.** The CLI now discovers and loads allow-listed plugin packages from the project's `node_modules` and the global npm root. Plugins register their own subcommands via a small public API (`PluginContext`, `PluginRegister`, re-exported `parseJolliApiKey` / `parseBaseUrl`). Discovery is gated by an opaque plugin ID each plugin declares in its `package.json` (`jolliPluginId`), is restricted to a small set of trusted npm scopes, and is bounded to the current git project or HOME — `jolli` invoked from outside any project doesn't scan ancestor `node_modules`. Set `JOLLI_NO_PLUGINS=1` to disable. See [SECURITY.md](../SECURITY.md#operational-guidance) for the operational guidance.
-- **Public API surface narrowed.** `@jolli.ai/cli` and `@jolli.ai/cli/api` are now the only supported entry points; deep imports via `@jolli.ai/cli/dist/*` no longer resolve (the package added an `exports` field).
-- **`jolli --help` grouping fix.** `search` and `heal-folder` now appear under the **Jolli Memory** section instead of falling through to "Other commands:".
+- **New `jolli heal-folder` command** — Accidentally deleted Memory Bank Markdown files? This rebuilds them from the source of truth. No AI call, no cost.
+- **Cleaner `jolli recall` output** — Long branches no longer get cut off mid-thought. (The unused `--verbose` flag is gone.)
+- **Linear issues in your memories** — When an AI session mentions a Linear issue, it's saved and shown alongside your plans and notes, and follows the commit through squashes and rebases.
+- **Faster, smaller site generator** — Sites build more reliably (config is checked up front, themes are cached, `jolli start` now supports React Server Components), and the install is smaller — the `tar` dependency is gone.
+- **`jolli auth login` names your device** — Sign-in now labels each session with your hostname and OS, so you can tell them apart in the Jolli web UI instead of seeing anonymous entries.
+- **`--arg-stdin` for agent skills** — `jolli recall` / `search` can read long arguments from stdin, so skills can pass multi-line input without quoting headaches.
+- **CLI plugins (experimental)** — `@jolli.ai/cli` can now load trusted plugin packages (from the `@jolli.ai/` npm scope) that add their own commands. Set `JOLLI_NO_PLUGINS=1` to turn it off. See [SECURITY.md](../SECURITY.md#operational-guidance).
+- **Narrower public API** — `@jolli.ai/cli` and `@jolli.ai/cli/api` are the only supported imports now; deep `dist/*` imports no longer resolve.
+- **More reliable cloud sync (behind the editor plugins)** — The bundled sync engine recovers on its own after an interrupted sync, only ever commits recognized Memory Bank files, and won't let a commit-time write collide with a sync in progress. The CLI doesn't run sync itself — see [`vscode/CHANGELOG.md`](../vscode/CHANGELOG.md).
 - Bug fixes
 
 ## 0.99.1

--- a/cli/DEVELOPMENT.md
+++ b/cli/DEVELOPMENT.md
@@ -117,7 +117,9 @@ jolli status
 
 | Module | Build Output | Purpose |
 |--------|-------------|---------|
-| [Cli.ts](src/Cli.ts) | `dist/Cli.js` | CLI commands — Memory: `enable` / `disable` / `status` / `doctor` / `clean` / `view` / `export` / `recall` / `search` / `configure` / `migrate`; Auth: `auth login` / `logout` / `status`; Site: `new` / `convert` / `dev` / `build` / `start` |
+| [Cli.ts](src/Cli.ts) | `dist/Cli.js` | CLI commands — Memory: `enable` / `disable` / `status` / `doctor` / `clean` / `heal-folder` / `view` / `export` / `recall` / `search` / `configure` / `migrate`; Auth: `auth login` / `logout` / `status`; Site: `new` / `convert` / `dev` / `build` / `start`. Delegates command registration to per-command modules under `src/commands/` and to `Api.registerCli` so the same registration pipeline is reusable by plugins and the test harness. |
+| [Api.ts](src/Api.ts) | `dist/Api.js` | Public API entry (`@jolli.ai/cli/api`). Exports `PluginContext`, `PluginRegister`, `parseJolliApiKey`, `parseBaseUrl`; runs `loadPlugins` after built-in command registration so plugins can append subcommands without touching `Cli.ts`. Backed by an `exports` field in `package.json` that explicitly blocks deep `@jolli.ai/cli/dist/*` imports. |
+| [PluginLoader.ts](src/PluginLoader.ts) | inlined in `dist/Api.js` | Plugin discovery — scans the current git project's `node_modules` and the global npm root for entries on the `KNOWN_PLUGINS` allow-list, validates the plugin's `peerDependencies['@jolli.ai/cli']` range against the host's `VERSION`, and invokes the plugin's `register(ctx)` once. Non-throwing — a broken plugin logs and is skipped, never blocks the CLI. Disabled entirely by `JOLLI_NO_PLUGINS=1`. |
 | [StopHook.ts](src/hooks/StopHook.ts) | `dist/StopHook.js` | Claude Code Stop event handler |
 | [SessionStartHook.ts](src/hooks/SessionStartHook.ts) | `dist/SessionStartHook.js` | Claude Code SessionStart hook (injects mini-briefing) |
 | [PostCommitHook.ts](src/hooks/PostCommitHook.ts) | `dist/PostCommitHook.js` | Git post-commit hook (operation detection + queue enqueue + worker spawn) |
@@ -157,6 +159,15 @@ jolli status
 | [SummaryMigration.ts](src/core/SummaryMigration.ts) | v1→v3 migration logic for legacy orphan branch data |
 | [GitOperationDetector.ts](src/hooks/GitOperationDetector.ts) | Detects git operation type (commit, amend, squash, rebase, cherry-pick, revert) |
 | [Installer.ts](src/install/Installer.ts) | Installs/removes hooks in Claude Code, Gemini, and git |
+| [LinearIssueExtractor.ts](src/core/LinearIssueExtractor.ts) / [LinearIssueStore.ts](src/core/LinearIssueStore.ts) | Linear issue extraction (MCP tool-call scanner) + per-commit issue store. Extractor walks transcripts for `mcp__claude_ai_Linear__*` calls and normalises them into `LinearIssue[]`. Store persists issues to the orphan branch with the same hoist-on-rebase / merge-on-squash semantics as Plans and Notes (see `QueueWorker.runSquashPipeline` for the integration). |
+| [ActiveSessionAggregator.ts](src/core/ActiveSessionAggregator.ts) | Aggregates active sessions across every source (Claude / Codex / Gemini / OpenCode / Cursor / Copilot CLI / Copilot Chat) into a single `ActiveSession[]` snapshot. Powers the VS Code **Conversations** sidebar section; safe to poll because every per-source detector + reader is feature-gated and cheap. |
+| [ConversationOverlayStore.ts](src/core/ConversationOverlayStore.ts) | Persists per-session **transcript edit overlays** — the curated turn list a user produced in the Conversation Details panel. Stored locally per-project; consulted by the summarization pipeline so the LLM sees the user's curated version, not the raw transcript. |
+| [CommitSelectionStore.ts](src/core/CommitSelectionStore.ts) | Per-project on-disk store for the **per-item commit selection** state (plans / notes / conversations / files unchecked from the next commit's memory). Selections persist across commits and restarts; the worker consults this store when assembling the LLM context. |
+| [Regenerator.ts](src/core/Regenerator.ts) / [RegenerateContext.ts](src/core/RegenerateContext.ts) | The "Regenerate Summary" backend. `RegenerateContext` rebuilds the full v4 tree context (transcripts + diff + plans/notes + Linear) for a given commit hash; `Regenerator` drives the LLM call with explicit stale-write guards so an amend / squash mid-regenerate cannot clobber the new history. |
+| [TranscriptSourceLabel.ts](src/core/TranscriptSourceLabel.ts) | Maps a transcript's source (`anthropic-config` / `anthropic-env` / `jolli-proxy` / per-agent labels) to the human-readable provider label rendered in the Summary Webview footer. |
+| [HealFolderCommand.ts](src/commands/HealFolderCommand.ts) | `jolli heal-folder` — re-renders missing visible Markdown files under the Memory Bank folder from the canonical hidden JSON. Driven by `FolderStorage.healMissingVisibleMarkdown`; safe to re-run, never touches the orphan branch or the canonical JSON. |
+| [DeviceLabel.ts](src/auth/DeviceLabel.ts) | Computes a server-accepted `device_label` (hostname + OS, length-clamped) for the OAuth login URL so the Jolli web UI can name authorized sessions. Mirrored in IntelliJ's `JolliAuthService`. |
+| [Subprocess.ts](src/util/Subprocess.ts) | The single allowed wrapper around `node:child_process`. Sets `windowsHide` consistently to suppress the brief console-window flicker that bare `spawn`/`execFile` calls produced on Windows. Biome bans direct `child_process` imports across both `cli/` and `vscode/` to keep this from regressing. |
 
 ## Display-Layer Conventions
 
@@ -325,6 +336,7 @@ If an existing hook file exists, Jolli Memory's section is appended. On uninstal
 ## Concurrency and Safety
 
 - **File lock**: `.jolli/jollimemory/lock` prevents concurrent worker runs. Uses `writeFile` with `wx` flag (exclusive create). Stale locks (>5 min) are auto-removed.
+- **Per-vault write lock**: `~/.jolli/jollimemory/locks/vault-<sha256>.lock` (separate from the per-worktree worker lock) serialises Memory Bank writes between a `QueueWorker` drain and a sync round that share one vault. See [Memory Bank Cloud Sync → Vault-write lock](#vault-write-lock-sync--worker).
 - **Operation queue**: Each git operation gets its own queue file — no single-slot overwriting.
 - **Detached worker**: The post-commit hook spawns a detached child process so `git commit` returns instantly.
 - **Chain spawn**: After draining the queue, the worker checks for new entries and spawns a successor if needed.
@@ -358,12 +370,184 @@ All errors are logged to `.jolli/jollimemory/debug.log`. The tool is designed to
 | `config.json` | Configuration (API keys, model, integrations) |
 | `plans.json` | Plans and notes registry (association with commits) |
 | `scope.json` | Installation scope (project or global) |
-| `lock` | Concurrency lock file |
+| `lock` | Per-worktree worker concurrency lock file |
+| `locks/vault-<sha256>.lock` | Global (`~/.jolli/jollimemory/`) per-vault write lock; `locks/vault-<sha256>-pending/` holds the cross-repo `PendingWorkers` wakeup registry |
 | `dist-path` | Global file (`~/.jolli/jollimemory/`) pointing to the active dist/ directory |
 | `resolve-dist-path` | Global shell script (`~/.jolli/jollimemory/`) that reads the global dist-path |
 | `debug.log` | Debug/error log |
 | `git-op-queue/*.json` | Pending git operation queue entries |
 | `squash-pending.json` | Temporary cross-hook file for squash detection |
+
+## Plugin Loader
+
+Starting in 0.99.2, `@jolli.ai/cli` discovers and loads allow-listed plugin packages that register additional subcommands. Discovery and registration live in [PluginLoader.ts](src/PluginLoader.ts); the public API surface they consume lives in [Api.ts](src/Api.ts).
+
+### Discovery shape
+
+```
+Api.registerCli(program, version)
+    │
+    ├── built-in commands registered (Cli.ts route)
+    │
+    └── loadPlugins(program, version)
+            │
+            ├── if process.env.JOLLI_NO_PLUGINS === "1" → return early
+            │
+            ├── boundary = nearest .git ancestor of cwd, else $HOME
+            │   roots     = walk(cwd → boundary).map(d => d/node_modules)
+            │            ++ [npm root -g]
+            │   (Each node_modules between cwd and boundary is included,
+            │    so hoisted packages in pnpm / Yarn-workspaces monorepos
+            │    are discovered. If cwd sits outside any .git project and
+            │    outside $HOME, the local walk is skipped and only the
+            │    global root is scanned.)
+            │
+            ├── for name in KNOWN_PLUGINS:
+            │     for each root that contains node_modules/<name>:
+            │       1. read plugin package.json
+            │       2. verify peerDependencies["@jolli.ai/cli"] semver
+            │          range matches host VERSION
+            │       3. dynamic import + plugin.register(ctx)
+            │
+            └── any plugin error → log + skip (never throws upward)
+```
+
+### Why an allow-list
+
+`KNOWN_PLUGINS` is a fixed array baked into the CLI build, not a config flag. A malicious package on disk cannot register itself by being installed — its name has to also appear on the allow-list, which requires a CLI release. This pairs with the bounded discovery roots: even with a hostile `node_modules`, the worst case is that an allow-listed package is loaded from a path it shouldn't have been installed to, not arbitrary code execution.
+
+### Plugin contract (`Api.ts`)
+
+| Export | Purpose |
+| --- | --- |
+| `PluginContext` | Carried into the plugin's `register(ctx)` — exposes the host's `commander` program, the resolved CLI version, the user config, and a small set of factory helpers. |
+| `PluginRegister` | The `(ctx: PluginContext) => void \| Promise<void>` shape every plugin's default export must satisfy. |
+| `parseJolliApiKey`, `parseBaseUrl` | Canonical key/URL parsers re-exported so plugins don't have to bundle their own copy (they would drift from the CLI's allow-list). |
+
+The `exports` field in `cli/package.json` is what enforces this: `@jolli.ai/cli` and `@jolli.ai/cli/api` are the only resolvable specifiers. Deep imports like `@jolli.ai/cli/dist/core/Foo.js` no longer resolve — plugins that relied on them must move to the public API.
+
+## Memory Bank Cloud Sync
+
+`cli/src/sync/` holds the engine that keeps the user's Memory Bank folder mirrored to a private Jolli vault. The engine is shipped in `dist/Cli.js` and inlined into the VS Code extension, but `@jolli.ai/cli` itself does **not** auto-trigger sync rounds today — the long-lived plugin process (currently VS Code only) is what drives the cadence. The CLI side exposes config (`syncEnabled`, `syncTranscripts`, `syncPollIntervalSec`) and the `configure --sync-enable / --sync-disable` shortcuts.
+
+### Engine shape
+
+```
+SyncBootstrap.runRound()
+    │
+    ├── SyncLock.acquire()                  ← machine-wide `sync.lock`, serialises
+    │                                          sync-vs-sync only (10 s timeout)
+    │
+    ├── BackendClient.mintCredential()      ← short-lived per-round token
+    │
+    ├── GitClient.cloneOrFetch(vaultRepo)   ← first time: clone (binds vault
+    │                                          to space via VaultMarker);
+    │                                          subsequent: fetch
+    │
+    ├── self-heal (idempotent, before pull):
+    │     2b. abort a stale `.git/rebase-merge|apply` left by a killed round
+    │     2c. sweep stale `.git/*.lock` corpses (TTL 5 min)
+    │
+    ├── withPullLock(memoryBankRoot):       ← VaultWriteLock — per-vault writer
+    │     │                                    lock; the ONLY window sync holds it
+    │     ├── GitClient.pullRebase()
+    │     └── ConflictResolver.resolveAll()  ← three-tier:
+    │           1. AggregateMerge: deterministic merge of the four
+    │              .jolli/<aggregate>.json files (manifest / index /
+    │              branches / catalog) — never prompts
+    │           2. LocalAiMergeProvider: AI merge (uses apiKey when set)
+    │              for other-file conflicts
+    │           3. Manual binary pick (last resort, surfaced to UI)
+    │
+    ├── auto-reconcile user edits → stageVault → `[jolli-mb] reconcile: …` commit
+    │
+    ├── MemoryBankBootstrap.mirror()        ← rsync-shaped diff:
+    │                                          fs ←→ vault working tree
+    │
+    ├── stageVault()                        ← ALLOWLIST staging (not `git add --all`):
+    │                                          classifyVaultPath gates every entry;
+    │                                          symlinked / unowned paths refused
+    │
+    ├── GitClient.commit + push → `[jolli-mb] sync: …`
+    │
+    ├── SyncStateStore.recordRound()        ← updates four-state status
+    │                                          (synced / syncing / conflicts /
+    │                                          offline)
+    │
+    └── PendingWorkers.drain()              ← wake cross-repo QueueWorkers that
+                                              timed out on the vault-write lock
+```
+
+### Space binding (the 412 path)
+
+`VaultMarker` writes a small file inside the vault that binds the clone to a specific Jolli space. If the backend returns **412** on a round (the vault was rebound to a different space, or the user signed into a different account), the engine does NOT silently clobber — `SyncEngine` raises a binding-required failure and surfaces a UI dialog that lets the user re-bind explicitly. This is what stopped the prior "two users on one machine quietly overwrite each other" failure mode.
+
+### `GitAskpass` and credentials
+
+`GitAskpass.ts` writes a one-shot helper script that `GitClient` points `GIT_ASKPASS` at, so each `git push` reads the freshly minted credential from a per-round env var instead of either persisting it to `~/.git-credentials` or echoing it onto the command line. Combined with `AllowList.ts` (which restricts the vault to a fixed set of hostnames), this keeps long-lived secrets off disk.
+
+### Allowlist staging (`stageVault`)
+
+Every staging site in the engine goes through `stageVault` instead of `git add --all`. The vault at `<localFolder>/` hosts many source repos as sibling `<repoFolder>/` subtrees, so a blanket `git add` would happily commit anything a foreign tool — or a hostile placement — dropped into the folder. `stageVault` snapshots `git status --porcelain -z` (parsed by the shared `PorcelainParser`, which also decomposes renames into discrete add/delete ops so each classifies independently), runs every path through `classifyVaultPath`, and stages with `git add -f` **only** paths that classify to a non-null `OwnedPathKind`. The `-f` is deliberate: the classifier — not `.gitignore` — is the staging authority.
+
+`OwnedPathKind` is a **closed** tagged union of the FolderStorage / RepoMapping write families (`repo-config`, `summary`, `transcript`, `plan`, `visible-summary`, …). Adding a new FolderStorage write type requires adding a kind here, and a round-trip integration test enforces "every FolderStorage write path classifies to non-null" so a write that bypasses the catalogue is caught immediately. Two kinds are pointedly excluded: `shadow-status.json` (per-device recovery state, meaningless to peers) and the quarantine subtrees (locally gitignored).
+
+`stageVault` returns a `StageReport` whose `unowned` and `symlinked` arrays are the **canary signals**: non-empty means either FolderStorage grew a write site the classifier doesn't recognise (drift) or a foreign writer touched the vault. SyncEngine folds these into a per-round `canary` accumulator and warn-logs them — they are what dogfood watchers grep for. `transcript` entries are dropped (counted as `skipped`) when `syncTranscripts: false`.
+
+### Vault-write lock (sync ↔ worker)
+
+`VaultWriteLock` is a **per-vault** writer lock distinct from the two existing locks: `sync.lock` is machine-wide and serialises sync-vs-sync; `worker.lock` is per-worktree. Neither closes the sync-vs-worker race, where a `QueueWorker` for repo B writes into `<localFolder>/<repoB>/.jolli/…` while a sync round reads `git status` against the same vault — tearing the worker's multi-file write across the status snapshot. The lock file lives **outside** the vault at `~/.jolli/jollimemory/locks/vault-<sha256(canonical)>.lock` (derived by `VaultLockPath`, because the vault's `.git/` may not exist yet when a worker needs the lock before any storage construction).
+
+The two acquirers hold it for **asymmetric** windows by design:
+
+- **QueueWorker** holds it for the entire drain (a summary is N files: canonical JSON + visible Markdown + aggregate index updates) — it can't release between files without re-opening the tear window.
+- **SyncEngine** holds it only across `withPullLock` (pullRebase + conflict resolution). Pre/post-pull phases run unlocked because holding it for the whole 30–90 s round would make a user's `git commit` in the source repo wait the full round before its summary appears. This accepts a benign, eventually-consistent tradeoff (a concurrent worker write may land partially in one git commit and finish in the next round) in exchange for the UX; the race it *definitively* closes is "worker writes land in the paused-rebase window," which is fully inside `withPullLock`.
+
+When repo B's worker times out (60 s) waiting on the lock, it records its cwd in `PendingWorkers` — a per-vault registry sibling to the lock file. Whoever releases the lock (sync round complete, or another worker's drain finishing) drains the registry and re-spawns those workers, so a cross-repo worker that gave up isn't stranded until repo B's next commit.
+
+### Symlink safety
+
+`VaultSymlinkGuard.assertNoSymlinksInPath` checks the **whole directory chain** from `vaultRoot` to a target before any `mkdir`/`write`/`rename`, refusing the write if any segment is a symlink — closing the intermediate-segment escape (`<repoFolder>/.jolli → /etc`) that a leaf-level `O_NOFOLLOW` can't catch. It replaces the deleted `SymlinkSweep` quarantine pass, which tree-walked and *moved* user files every round (the UX complaint that retired it); the guard instead refuses unsafe writes at write time and names the rogue path in a warn log. Paired with `core.symlinks=false` (forced on every `GitClient` invocation), the two layers cover both inbound (hostile mode-120000 tree entries materialise as plain files) and outbound (no traversal through a planted link) directions. `stageVault` also refuses to stage any path with a symlink in its chain, routing it to the `symlinked` canary.
+
+### Self-healing a killed round
+
+A round killed mid-flight (VSIX reinstall SIGTERM, laptop sleep, crash) can leave the vault's git state wedged in a way that makes every subsequent round fail with a sticky, unactionable error. Before pulling, the engine self-heals two such states (both idempotent, both no-ops on the cold-clone path):
+
+- **Stale rebase** (`.git/rebase-merge|apply`) → `rebase --abort`. Safe to abort unconditionally because the vault working tree is exclusively SyncEngine-driven; the user's real edits live in a separate `[jolli-mb] reconcile: …` commit already on the default branch, which survives the abort.
+- **Stale `.git/*.lock` corpses** (`index.lock`, `HEAD.lock`, `refs/**.lock`, …) → swept if older than a 5-minute TTL (engine ops finish in milliseconds, so a 5-min lock is definitively a corpse, while an out-of-band manual `git` op the user ran in the folder isn't ripped out from under them).
+
+### What lives where
+
+| Module | Purpose |
+| --- | --- |
+| [SyncEngine.ts](src/sync/SyncEngine.ts) | High-level round driver — wires every other module together. Test surface is via injectable factories rather than monkey-patching globals. |
+| [SyncBootstrap.ts](src/sync/SyncBootstrap.ts) | Per-round bootstrap (lock acquire → mint credential → clone-or-fetch → mirror → resolve → commit-push → record state). |
+| [SyncLock.ts](src/sync/SyncLock.ts) | Per-machine file lock (`pending` + ttl), `DEFAULT_SYNC_LOCK_TIMEOUT_MS = 10_000`, poll = 100 ms. |
+| [BackendClient.ts](src/sync/BackendClient.ts) | Jolli backend HTTP client — mints credentials, reports state, handles the 412 binding case. |
+| [GitClient.ts](src/sync/GitClient.ts) + [GitAskpass.ts](src/sync/GitAskpass.ts) | Git invocations against the vault; askpass shim so credentials never persist. |
+| [MemoryBankBootstrap.ts](src/sync/MemoryBankBootstrap.ts) | Diffs the local Memory Bank folder against the vault working tree and stages changes. |
+| [StageVault.ts](src/sync/StageVault.ts) | Allowlist staging — replaces `git add --all` at every staging site; classifies each `git status` entry and stages only owned paths, returning the canary `StageReport`. |
+| [VaultPathClassifier.ts](src/sync/VaultPathClassifier.ts) + [OwnedPathKind.ts](src/sync/OwnedPathKind.ts) | Pure `classifyVaultPath(relPath)` → `OwnedPathKind \| null`; the closed catalogue of vault-owned write families. Instance-free on purpose (constructing `FolderStorage` claims a KB path too early). |
+| [PorcelainParser.ts](src/sync/PorcelainParser.ts) | NUL-record-aware `git status --porcelain -z` parser shared by `listDirtyPaths` and `stageVault` (handles rename source-path trailers). |
+| [VaultSymlinkGuard.ts](src/sync/VaultSymlinkGuard.ts) | Refuses any write whose vault→target path chain contains a symlink; replaces the deleted `SymlinkSweep` quarantine pass. |
+| [VaultWriteLock.ts](src/sync/VaultWriteLock.ts) + [VaultLockPath.ts](src/sync/VaultLockPath.ts) | Per-vault writer lock serialising sync-vs-worker (and worker-vs-worker across repos sharing a vault); lock file lives outside the vault, path derived from a canonicalised `localFolder`. |
+| [PendingWorkers.ts](src/sync/PendingWorkers.ts) | Cross-repo wakeup registry — workers that time out on the vault-write lock record their cwd; lock releasers re-spawn them. |
+| [ConflictResolver.ts](src/sync/ConflictResolver.ts) | Three-tier resolution (`AggregateMerge` → `LocalAiMergeProvider` → manual). |
+| [AggregateMerge.ts](src/sync/AggregateMerge.ts) | Deterministic merge for the four `.jolli/<aggregate>.json` files. |
+| [LocalAiMergeProvider.ts](src/sync/LocalAiMergeProvider.ts) | AI-driven merge for content files (gated on `apiKey`). |
+| [LegacyMigration.ts](src/sync/LegacyMigration.ts) | One-shot import of Web-UI-only personal-space content into a `legacy/` subtree on the first sync of an unbacked space. |
+| [VaultMarker.ts](src/sync/VaultMarker.ts) + [AllowList.ts](src/sync/AllowList.ts) | Space binding marker file + hostname allow-list. |
+| [RepoIdentity.ts](src/sync/RepoIdentity.ts) + [RepoMapping.ts](src/sync/RepoMapping.ts) | Stable repo identity (origin URL + bootstrap hash) → vault-subfolder mapping. |
+| [SyncStateStore.ts](src/sync/SyncStateStore.ts) | Persists the four-state status used by the status-bar indicator. |
+| [CorruptJsonQuarantine.ts](src/sync/CorruptJsonQuarantine.ts) | Quarantines unreadable `.jolli/<aggregate>.json` files into a side directory so a single corrupt file never blocks the whole round. |
+| [CliConflictUi.ts](src/sync/CliConflictUi.ts) | CLI-side conflict prompt (kept thin — most conflict UI lives in the editor plugins). |
+
+Architecture rules:
+
+- **No backend coupling outside `BackendClient`.** Other modules only see typed result objects.
+- **Every git invocation goes through `GitClient`.** Never call `git` directly from a sync module — `GitAskpass` + `windowsHide` go missing otherwise.
+- **`AggregateMerge` is the only deterministic merge.** Anything else routes through `LocalAiMergeProvider` first; only after that fails does the UI get a manual prompt.
+- **`classifyVaultPath` is the staging authority, not `.gitignore`.** Never reintroduce `git add --all` in the engine — a new FolderStorage write type means a new `OwnedPathKind`, not a wildcard add. The `unowned` / `symlinked` canary buckets are a feature; don't suppress them.
 
 ## Site Generation: OpenAPI Reference Pipeline
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -259,7 +259,7 @@ jolli configure --set excludePatterns=docs/**,*.log,node_modules
 jolli configure --remove jolliApiKey
 ```
 
-Supported keys: `apiKey`, `aiProvider`, `model`, `maxTokens`, `jolliApiKey`, `authToken`, `claudeEnabled`, `codexEnabled`, `geminiEnabled`, `openCodeEnabled`, `cursorEnabled`, `copilotEnabled`, `localFolder`, `logLevel`, `excludePatterns`, `syncEnabled`, `syncTranscripts`, `syncPollIntervalSec`. `aiProvider` pins the summarization backend (`"anthropic"` or `"jolli"`); when omitted, the dispatcher falls back to the legacy precedence (`apiKey` > `ANTHROPIC_API_KEY` > `jolliApiKey`). `copilotEnabled` controls both GitHub Copilot CLI and VS Code Copilot Chat as a single switch. `localFolder` is the Memory Bank root on disk where every memory is dual-written. `syncEnabled` opts the Memory Bank into cloud sync (VS Code plugin only — the CLI has no auto-sync trigger). Convenience flags: `--sync-enable` / `--sync-disable` toggle `syncEnabled` without writing the long key form. Run `jolli configure --list-keys` for descriptions and types. Unknown keys and malformed values (e.g. `maxTokens=8192abc`, `logLevel=banana`) are rejected with exit code 1.
+Supported keys: `apiKey`, `aiProvider`, `model`, `maxTokens`, `jolliApiKey`, `authToken`, `claudeEnabled`, `codexEnabled`, `geminiEnabled`, `openCodeEnabled`, `cursorEnabled`, `copilotEnabled`, `localFolder`, `logLevel`, `excludePatterns`, `syncEnabled`, `syncTranscripts`, `syncPollIntervalSec`. `aiProvider` pins the summarization backend (`"anthropic"` or `"jolli"`); when omitted, the dispatcher falls back to the legacy precedence (`apiKey` > `ANTHROPIC_API_KEY` > `jolliApiKey`). `copilotEnabled` controls both GitHub Copilot CLI and VS Code Copilot Chat as a single switch. `localFolder` is the Memory Bank root on disk where every memory is dual-written. The `sync*` keys drive cloud sync (plugin-driven — see [Memory Bank cloud sync](#memory-bank-cloud-sync-plugin-driven) below); `--sync-enable` / `--sync-disable` are shortcuts for toggling `syncEnabled` without the long key form. Run `jolli configure --list-keys` for descriptions and types. Unknown keys and malformed values (e.g. `maxTokens=8192abc`, `logLevel=banana`) are rejected with exit code 1.
 
 ### Memory Bank cloud sync (plugin-driven)
 
@@ -304,6 +304,20 @@ jolli clean --yes
 
 **Safety**: in a non-TTY environment (CI, pipes, redirected stdin), `clean` refuses to delete without `--yes` and exits with code 1. This prevents scripts from silently wiping data.
 
+### `jolli heal-folder`
+
+Restores missing Markdown files in the Memory Bank folder by re-rendering them from the canonical hidden JSON (`<localFolder>/<repo>/.jolli/summaries/<hash>.json`). Useful when you (or another tool) accidentally deleted a `.md` file you wanted to keep — the orphan-branch entry and the hidden JSON remain authoritative, so re-rendering brings the visible Markdown back without re-running the LLM.
+
+```bash
+# Heal the current repo's Memory Bank folder
+jolli heal-folder
+
+# Heal a specific project directory
+jolli heal-folder --cwd /path/to/repo
+```
+
+Healing is also exposed by the editor extensions; running the CLI form is equivalent.
+
 ## Session Context Recall
 
 Jolli Memory feeds prior development context back into your AI agent so it can pick up where you (or a teammate) left off.
@@ -337,6 +351,7 @@ Settings are stored globally in `~/.jolli/jollimemory/config.json`. The recommen
 | `copilotEnabled` | boolean | auto-detect | Enable GitHub Copilot CLI **and** VS Code Copilot Chat session discovery (single shared switch) |
 | `localFolder` | string | — | Memory Bank root on disk — every memory is dual-written here as Markdown alongside the orphan-branch copy. Set via the editor extensions' Memory Bank Settings tab. |
 | `excludePatterns` | string[] | — | Glob patterns for file exclusion (set via `jolli configure --set excludePatterns=glob1,glob2`) |
+| `syncTranscripts` | boolean | `false` | When the editor plugin's sync is enabled, also mirror raw conversation transcripts (not just summaries) into the personal vault. Off by default so transcripts stay local unless you opt in. |
 
 **Authentication setup** — three options:
 
@@ -395,6 +410,22 @@ Each summary uses a **v3 tree structure**. A single commit can cover multiple in
 ## VSCode Extension
 
 The [Jolli Memory VS Code Extension](https://marketplace.visualstudio.com/items?itemName=jolli.jollimemory-vscode) adds a sidebar with three tabs (Branch / Memory Bank / Status) and a per-commit Summary Webview, plus a 5-tab Settings page. If you have both the CLI and the extension installed, they share the same data — the extension bundles the CLI inline so it works whether or not a global CLI install is also present.
+
+## Plugins
+
+Starting in 0.99.2, `@jolli.ai/cli` can discover and load allow-listed plugin packages and let them register additional subcommands. Discovery is bounded: the CLI walks `node_modules/` directories upward from the current working directory, stopping at the nearest `.git` ancestor (or your home directory if none is found), and also consults the global npm root. The allow-list is fixed at the CLI level, so a malicious package cannot register itself merely by being on disk.
+
+```bash
+# Install (your existing jolli install is unchanged)
+# Replace <plugin> with an allow-listed package name — see KNOWN_PLUGINS
+# in cli/src/PluginLoader.ts for the current list.
+npm install -g <plugin>
+
+# Disable plugin loading entirely
+JOLLI_NO_PLUGINS=1 jolli <command>
+```
+
+Plugins use a small public API exported from `@jolli.ai/cli/api` (`PluginContext`, `PluginRegister`, `parseJolliApiKey`, `parseBaseUrl`). See [SECURITY.md](https://github.com/jolliai/jolliai/blob/main/SECURITY.md#operational-guidance) for the operational guidance and trust model.
 
 ## Error Handling
 

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -1,11 +1,20 @@
 # Changelog
 
-<!-- Last synced commit: d53654bc | 2026-05-13 -->
+<!-- Last synced commit: 8ce5671f | 2026-05-28 -->
 
 ## 0.99.2
 
-- **Active AI Conversations panel** — a new **CONVERSATIONS** section in the Branch tab lists your recent AI coding sessions across every supported tool, with the title, agent, and message count at a glance. Click a row to open the full transcript and edit or delete messages — the next commit's memory is generated from your curated version, not the raw conversation.
-- **Per-item commit selection** — uncheck any conversation, plan, note, or file in the Branch tab to keep it out of the next commit's memory. Your choice sticks across commits and restarts until you put it back, and each section has a `Select / Deselect All` shortcut at the top.
+- **See your active AI conversations** — A new **Conversations** section in the Branch tab lists your recent AI coding sessions and keeps itself up to date. Open one to read the full transcript and tidy it up — edit or delete individual turns — before it turns into a memory.
+- **Choose what goes into each memory** — Uncheck any conversation, plan, note, or file to leave it out of the next commit's memory. Your choices stick, and each section has a **Select / Deselect All** shortcut.
+- **Regenerate a summary** — Every memory now has a **Regenerate** button that rewrites it from scratch. Amending or squashing the commit while it runs no longer loses your edits.
+- **No more disappearing panels** — If you amend, squash, or rebase a commit while its memory panel is open, the panel stays open with a warning instead of vanishing mid-edit.
+- **Linear issues in your memories** — When a conversation mentions a Linear issue, it shows up as its own section in the memory, in PR descriptions, and in exports.
+- **See which AI wrote each summary** — Every memory shows where it came from: **Anthropic** (your key), **Anthropic (env)**, or **Jolli**.
+- **Open memories from other repos** — Viewing a memory from another repo's folder in the **Memory Bank** tab now works just like a local one.
+- **More reliable cloud sync** — Your Memory Bank stays in sync across devices more dependably: a sync interrupted by a reload or crash recovers on its own, your vault is tied to one account so a different sign-in can't overwrite it, and conflicts resolve automatically when it's safe. The status bar shows synced / syncing / conflicts / offline.
+- **Quick plan previews** — Hover a plan in **Plans & Notes** to see its title, source, last-updated time, and a snippet.
+- **Opt-in DCO sign-off on AI commits** — A new toggle in **Settings → Others** adds a `Signed-off-by` line to AI-generated commit messages so they pass projects that require it. Off by default.
+- Bug fixes
 
 ## 0.99.1
 

--- a/vscode/DEVELOPMENT.md
+++ b/vscode/DEVELOPMENT.md
@@ -110,7 +110,8 @@ src/
 │   └── CommitsStore.ts           # Branch commits + range selection
 │
 ├── services/                     # Stateless services
-│   ├── AuthService.ts            # OAuth callback URI handling (code-exchange flow + CSRF state validation per RFC 6749), sign-in / sign-out, jollimemory.signedIn context key
+│   ├── AuthService.ts            # OAuth callback URI handling (code-exchange flow + CSRF state validation per RFC 6749), sign-in / sign-out, jollimemory.signedIn context key. Carries `device_label` (hostname + OS) and `client_version` into the OAuth URL so the Jolli web UI can name authorized sessions, and preserves the per-flow nonce across the `openExternal=false` Copy URL path so the manual fallback still completes a sign-in.
+│   ├── ActiveSessionsProvider.ts # Background poller over the seven per-source session aggregators. Powers the Branch tab's CONVERSATIONS section — emits `ActiveSession[]` snapshots that the sidebar webview renders without manual refresh.
 │   ├── ManualDisableFlag.ts      # Durable per-repo opt-out for auto-enable (set when user clicks Disable; respected on every activation)
 │   ├── JolliPushService.ts       # HTTP client for pushing summaries to a Jolli Space
 │   ├── PrCommentService.ts       # GitHub PR creation/update via gh CLI; PR section markers
@@ -146,10 +147,15 @@ src/
 │   ├── BranchSummaryLoader.ts            # Walks the branch and loads every commit's stored summary for the aggregate PR builder
 │   ├── SummaryUtils.ts                   # Shared helpers (HTML escaping, date formatting, topic sorting)
 │   │
-│   ├── SettingsWebviewPanel.ts           # Singleton 5-tab settings form (AI Agents / AI Summary / Sync to Jolli / Memory Bank / Others)
+│   ├── SettingsWebviewPanel.ts           # Singleton 5-tab settings form (AI Agents / AI Summary / Sync to Jolli / Memory Bank / Others). Others tab adds the `dcoSignoff` toggle.
 │   ├── SettingsHtmlBuilder.ts
 │   ├── SettingsCssBuilder.ts
 │   ├── SettingsScriptBuilder.ts
+│   │
+│   ├── ConversationDetailsPanel.ts        # Per-session transcript editor opened from the CONVERSATIONS section. Browse, edit, restore, or delete individual turns; on save, writes a `ConversationOverlay` to disk that the summarization pipeline consults at commit time so the LLM sees the curated version, not the raw transcript.
+│   ├── ConversationDetailsHtmlBuilder.ts  # HTML for the transcript editor (turn list, per-turn actions, restore-all)
+│   ├── ConversationDetailsScriptBuilder.ts  # Embedded JS — turn selection, edit/restore/delete actions, message bus to the panel host
+│   ├── TranscriptEntryRenderer.ts         # Shared per-turn renderer used by both the Summary Webview "All Conversations" section and the Conversation Details panel
 │   │
 │   └── NoteEditorWebviewPanel.ts         # Singleton "Add Text Snippet" editor
 │       NoteEditorHtmlBuilder.ts / NoteEditorCssBuilder.ts / NoteEditorScriptBuilder.ts
@@ -268,7 +274,23 @@ Both panels are singletons (one instance at a time, focused if reopened) and use
 
 **Aggregate PR descriptions for multi-commit branches** — `BranchSummaryLoader` walks every commit between the branch's fork point and HEAD and loads each commit's stored summary; `SummaryPrAggregateMarkdownBuilder` then composes a single PR description with one collapsible `<details>` block per topic across all commits, preceded by Plans and the E2E Test Guide. The single-commit code path is unchanged (`SummaryPrMarkdownBuilder`); `PrCommentService` picks the right builder based on commit count.
 
-**Memory Bank folder mode** — Memory Bank is on by default. `StorageFactory.createStorage` defaults to `"dual-write"`, so every commit's hooks write the memory to **both** the orphan branch and the configured Memory Bank folder; no `setActiveStorage()` toggle is involved at runtime. The orphan branch stays the system of record (reads come from there); the folder mirror is derivable from it. The Memory Bank sidebar tab renders a branch-aware folder view via `KnowledgeBaseTreeProvider` (the class name still uses the legacy "KnowledgeBase" identifier; the user-facing label is "Memory Bank").
+**Regenerate Summary + stale-write guards** — Every Summary Webview has a **Regenerate** action backed by the CLI's `Regenerator` + `RegenerateContext` modules. While a regenerate call is in flight, `SummaryWebviewPanel` switches the page into a `regenerating-readonly` state (CSS class on the root element dims topics + recap, disables every write action, and shows an inline banner explaining the wait). Every write path on the panel (push, edit, regenerate, plan/note add-remove, …) re-checks the commit hash inside the race window via `JolliMemoryBridge.assertCommitStillCurrent()` before writing — if the hash has changed on disk between the user's click and the LLM call completing, the write is rejected with a clear "commit has been rewritten" error rather than silently clobbering. The same hash re-check guards the regenerate response handler itself, so an amend / squash that lands mid-regenerate cannot clobber the new history.
+
+**Stale-rewritten-commit read-only mode** — When a commit shown in a Summary Webview is rewritten (amend / squash / rebase / branch-switch) while the panel is open, the panel is **not** disposed. Instead `SummaryWebviewPanel` flips into a persistent stale-read-only mode: the warning banner explains that the commit has been rewritten and that the panel will not accept new writes; the same body content remains readable so the user can copy out anything they were drafting. This replaces the prior "dispose mid-edit" behaviour that caused users to lose in-progress edits during squash. See `SummaryCssBuilder` (`stale-readonly` + `regenerating-readonly` classes) and the corresponding `SummaryScriptBuilder` handlers.
+
+**Linear issues in the Summary Webview** — When the AI conversation calls the Linear MCP server, the issues are extracted at commit time on the CLI side (`LinearIssueExtractor` → `LinearIssueStore`). The extension renders them as their own panel section between Plans & Notes and E2E Test Guide (`SummaryHtmlBuilder.renderLinearIssues`), embeds them into the Markdown export (`SummaryMarkdownBuilder`), and into the PR description (`SummaryPrMarkdownBuilder` / `SummaryPrAggregateMarkdownBuilder`). Linear issues are hoisted onto the consolidated root on squash / rebase by `QueueWorker.runSquashPipeline` exactly the same way Plans and Notes are, so the link follows the commit through history rewrites.
+
+**Active Conversations sidebar + per-turn editing** — `ActiveSessionsProvider` polls every per-source aggregator on a short cadence and emits `ActiveSession[]` to the sidebar webview, which renders the CONVERSATIONS section in the Branch tab. Clicking a session opens `ConversationDetailsPanel` — a dedicated webview that shows every turn with edit / delete / restore actions. Edits are persisted as a `ConversationOverlay` (per-session JSON under the project's `.jolli/jollimemory/`) and the summarization pipeline consults the overlay at commit time, so the next memory is generated from the curated version. `TranscriptEntryRenderer` is shared between the Conversation Details panel and the Summary Webview's "All Conversations" section to keep the per-turn rendering identical.
+
+**Per-item commit selection** — Plans, notes, conversations, and files can each be unchecked from the next commit's memory via per-row checkboxes in the Branch tab. Selections are persisted by the CLI's `CommitSelectionStore` (per-project file) so they survive commits and restarts; `SidebarScriptBuilder` and `SidebarMessages` carry the toggle events to the host. The post-commit pipeline consults the same store when assembling the LLM context — anything the user excluded is omitted from the prompt, not just the UI.
+
+**Rich hover cards on Plans panel** — The Plans & Notes section in the Branch tab uses `vscode.MarkdownString`-backed hover cards built by `FormatUtils` + `PlansTreeProvider`, showing the title, source path, last-updated time, and a snippet of the body. The card is built lazily on first hover; the regression that lost the panel's scroll position on refresh is fixed by reusing the existing TreeItem identity instead of recreating items.
+
+**Opt-in DCO sign-off on AI Commit** — Settings → Others adds the **DCO sign-off** toggle, backed by the new CLI `dcoSignoff` config. When on, `CommitCommand` appends `Signed-off-by: <user.name> <user.email>` to the LLM-generated commit message before the actual `git commit`. Off by default; the toggle is per-machine (global config) so it lights up for every repo on the machine.
+
+**PR lookup uses `gh pr list` with history; fork PRs are excluded** — `PrCommentService.fetchBranchPrs` switched from `gh pr view` (which only returns the single open PR on the branch) to `gh pr list --state all --head <branch>` so historical closed / merged PRs on the same branch can be found. Fork PRs (where the head repo doesn't match the base repo) are filtered out before the panel offers an edit action — the foreign-denial assertion is pinned in `PrCommentService.test.ts` so the filter cannot regress. The `--arg-stdin` bridging that the extension uses to pass long arguments through the CLI also gained length / content guards so a stray block of `--help` output cannot be piped through as input.
+
+**Memory Bank folder mode** — Memory Bank is on by default. `StorageFactory.createStorage` defaults to `"dual-write"`, so every commit's hooks write the memory to **both** the orphan branch and the configured Memory Bank folder; no `setActiveStorage()` toggle is involved at runtime. The orphan branch stays the system of record (reads come from there); the folder mirror is derivable from it. Cross-repo reads from the MEMORY BANK tab go through `FolderStorage` instead of git plumbing so opening a memory from a sibling repo's subfolder never invokes `git show` in the wrong working tree. The Memory Bank sidebar tab renders a branch-aware folder view via `KnowledgeBaseTreeProvider` (the class name still uses the legacy "KnowledgeBase" identifier; the user-facing label is "Memory Bank").
 
 Two migration paths populate the folder:
 

--- a/vscode/README.md
+++ b/vscode/README.md
@@ -44,8 +44,8 @@ After each commit, Jolli Memory reads your selected AI session transcripts and t
 
 | Tab | What it shows |
 | -- | -- |
-| **Branch tab** *(labeled with the current branch name, e.g. `feature/auth`)* | Three collapsible sections for the current branch: **Plans & Notes** (auto-detected Claude Code plans plus your own text/Markdown notes), **Changes** (all changed files with checkboxes to stage/unstage, plus an exclude filter), and **Commits** (every commit on the current branch not yet in main; click the eye icon (`$(eye)`) to open the full AI summary). |
-| **MEMORY BANK tab** | A cross-branch / cross-repo view of every stored memory on disk. Toggle between **Tree** (folder structure by repo / branch) and **Timeline** (chronological by date) modes from the toolbar, and search across everything. The same data is mirrored on the orphan branch — this tab reads from the dual-written Memory Bank folder. |
+| **Branch tab** *(labeled with the current branch name, e.g. `feature/auth`)* | Four collapsible sections for the current branch: **Conversations** (recent AI coding sessions across every supported tool, with title / agent / message count; the list polls in the background so it stays current), **Plans & Notes** (auto-detected Claude Code plans plus your own text/Markdown notes), **Changes** (all changed files with checkboxes to stage/unstage, plus an exclude filter), and **Commits** (every commit on the current branch not yet in main; click the eye icon (`$(eye)`) to open the full AI summary). Every section has a **Select / Deselect All** toggle, and per-item checkboxes — unchecked items are excluded from the next commit's memory and the exclusion sticks across commits and restarts. |
+| **MEMORY BANK tab** | A cross-branch / cross-repo view of every stored memory on disk. Toggle between **Tree** (folder structure by repo / branch) and **Timeline** (chronological by date) modes from the toolbar, and search across everything. The same data is mirrored on the orphan branch — this tab reads from the dual-written Memory Bank folder, and cross-repo browsing routes reads through the folder layer so opening a memory from a sibling repo never invokes git plumbing in the wrong working tree. |
 | **Status tab** *(icon button on the right)* | Whether Jolli Memory is enabled, active AI agent sessions (Claude, Codex, Gemini, OpenCode, Cursor, Copilot CLI, Copilot Chat), the **AI Summary Provider** row showing what the next commit will actually use (Anthropic / Anthropic (env) / Jolli — clicking it opens Settings), the API-key warning when neither provider has credentials, and per-integration "detected but disabled" rows. The toolbar holds **Settings** (`$(gear)`), either **Sign In to Jolli** or **Sign Out of Jolli** (mutually exclusive based on auth state), **Disable Jolli Memory** (`$(circle-slash)`), and **Refresh** (`$(refresh)`). When the extension is currently disabled, the Status tab is replaced by a single **Enable Jolli Memory** (`$(circle-filled)`) button. A small busy indicator appears while a queue worker is running. |
 
 ---
@@ -105,18 +105,23 @@ Click the eye icon (`$(eye)`) on any commit to open a full memory panel. It show
 * **All Conversations** (Private Zone): raw AI conversation transcripts stored locally on your machine. Browse by session tab, edit, delete, or restore entries. Your private data, nothing is uploaded unless you choose to.
 * **Properties**: commit hash, branch, author, date, duration (working days), conversation count, and code change stats
 * **Plans & Notes**: associated plans and notes with edit, remove, and add actions (plans, Markdown files, or inline text snippets)
+* **Linear Issues**: any Linear issues referenced in the AI conversation (via the Linear MCP server) are extracted at commit time and rendered as first-class items — title, status, identifier, and a deep link back to Linear. They follow the commit through squash / rebase the same way Plans and Notes do.
 * **E2E Test Guide**: AI-generated test scenarios with preconditions, steps, and expected results. Click "Generate" to create them on demand.
 * **Source Commits** (for squash/amend): all contributing commits with diff stats and conversation counts
 * **Topics**: each topic structured as:
   * ⚡ **Why This Change**: the trigger from the AI conversation
   * 💡 **Decisions Behind the Code**: key technical trade-offs and choices
   * ✅ **What Was Implemented**: what was actually built
+* **Footer**: shows the **LLM provider** that produced this memory (Anthropic / Anthropic (env) / Jolli), so a glance tells you which credential the call went through.
 
 Action buttons:
 
 * **Copy Markdown**: copies the full summary to clipboard
 * **Push to Jolli**: publishes the summary (and associated plans and notes) to your Jolli Space. The Memory Bank folder on disk already holds a Markdown copy of every memory automatically — Push to Jolli is purely about cloud publishing.
+* **Regenerate**: re-runs the LLM against the current commit's transcripts + diff, normalizes the result to the v4 tree, and replaces the previous summary in place. While the call is in flight, the panel enters a **regenerating-read-only** state (topics + recap dim, write actions disable, an inline banner explains the wait) and a final stale-write guard re-checks the commit hash inside the race window — so an amend / squash that lands mid-regenerate cannot clobber the new history.
 * **Create & Update PR**: manages a GitHub PR for this commit
+
+**Stale-commit read-only mode** — if the commit shown in the webview is rewritten by an amend / squash / rebase / branch switch while the panel is open, the panel stays open in a persistent **stale read-only** mode with an inline warning banner instead of silently disappearing mid-edit. All write paths (push, edit, regenerate, plan / note add-remove, …) re-check the commit hash inside the race window and bail out cleanly if the hash has moved on disk.
 
 ### Push to Jolli Space
 
@@ -151,7 +156,7 @@ From the Summary Webview, you can:
 * **Remove** a plan or note association from a commit
 * **Associate** additional plans or notes with a commit
 
-Text snippets display their content inline in the Summary Webview; Markdown notes show the filename.
+Text snippets display their content inline in the Summary Webview; Markdown notes show the filename. Hovering any plan in the Branch tab's Plans & Notes section shows a card with the title, source path, last-updated time, and a snippet of the plan body, so you can scan plans without opening each one.
 
 ### Memory Bank sync (cross-device)
 
@@ -218,7 +223,7 @@ Click the gear icon (`$(gear)`) in the Status tab toolbar (or any **Open Setting
 | **AI Summary** | **Provider** dropdown (**Anthropic** vs **Jolli**). The Anthropic card holds `apiKey`, `model`, and `maxTokens`. The Jolli card shows your sign-in state — *Signed-in & ready*, *Signed-in but missing key*, or *Signed-out* — and exposes `jolliApiKey` under an **Advanced** disclosure for power users. |
 | **Sync to Jolli** | Sign-in / sign-out for pushing memories to your Jolli Space. |
 | **Memory Bank** | The on-disk Markdown copy of your memories: pick a folder via **Browse…**, then optionally click **Migrate to Memory Bank** to re-migrate the current repo into a fresh `-N`-suffixed folder (the previous folder is left untouched). |
-| **Others** | `excludePatterns` for the Changes section in the Branch tab. |
+| **Others** | `excludePatterns` for the Changes section in the Branch tab, plus the **DCO sign-off** toggle — when on, **AI Commit** appends `Signed-off-by: <user.name> <user.email>` to its generated commit messages so they pass a DCO-gated CI without manual editing. Off by default. |
 
 Changes are validated on save and persisted to `~/.jolli/jollimemory/config.json`. Click **Apply Changes** in the action bar to commit them.
 
@@ -295,6 +300,10 @@ Most settings live behind the gear icon on the **Status tab** toolbar. `authToke
 | `copilotEnabled` | boolean | auto-detect | Enable GitHub Copilot CLI **and** VS Code Copilot Chat session discovery (single shared switch) |
 | `localFolder` | string | — | Memory Bank folder root — every memory is dual-written here as Markdown alongside the orphan-branch copy. Set via Settings → Memory Bank → Browse…. |
 | `excludePatterns` | string[] | — | Glob patterns for hiding files from the Changes section in the Branch tab |
+| `syncEnabled` | boolean | `false` | Opt the Memory Bank into cloud sync to your Jolli Personal Space. Drives the long-lived sync engine and the status-bar indicator. Toggle via Settings → Memory Bank → **Enable Memory Bank cloud sync**. |
+| `syncTranscripts` | boolean | `false` | When sync is enabled, also mirror raw conversation transcripts (not just summaries) into the personal vault. Off by default so transcripts stay local unless you opt in. |
+| `syncPollIntervalSec` | integer | `5400` | Sync engine wake-up cadence in seconds. Floor is 5400 (90 min) — sync is heavy, and the **Sync to Personal Space Now** button covers urgent updates. |
+| `dcoSignoff` | boolean | `false` | Append `Signed-off-by: <user.name> <user.email>` to commits created by **AI Commit**. Off by default; turn on if your project's CI gates merges on a DCO sign-off. Set via Settings → Others. |
 
 ---
 


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## Quick recap

The documentation for version 0.99.2 was updated to reflect new features and architectural changes across the command-line interface and VS Code extension. The changelog entries now distinguish between what each surface actually exposes to users: the VS Code extension surfaces the regenerate feature and automatically triggers sync rounds, while the command-line interface does not. Each changelog entry was condensed to one or two sentences focused on what users can do, removing internal module names, class names, and implementation details that would confuse non-developers.

The developer documentation was kept separate from user-facing guides, with a new architecture reference section added for contributors. This section includes flow diagrams and module tables explaining the plugin loader and sync engine internals, allowing developers to understand how the system works without cluttering the user-focused README. Bug fixes and internal hardening improvements were consolidated into a single bullet point to keep the feature list clean and scannable.

---

## Topic (1)
<details>
<summary><strong>01 · Documentation updates for 0.99.2 release across CLI, VS Code, and security guidance</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The 0.99.2 release introduced 57 commits spanning new features (plugin loader, heal-folder command, Linear issue extraction, regenerate UI, active conversations panel), architectural changes (sync engine hardening, device labeling), and bug fixes. Documentation needed to be updated to reflect these changes while remaining user-friendly and accurate to what each surface (CLI vs VS Code) actually exposes.

**💡 Decisions Behind the Code**

- **Separate changelog entries by surface (CLI vs VS Code)**: The sync engine, plugin loader, and regenerate feature exist in both, but only VS Code auto-triggers sync rounds and only VS Code surfaces the regenerate UI. Listing sync config keys in the CLI changelog would mislead users into thinking the CLI has sync features it doesn't actually expose. Each changelog now lists only what users of that surface can actually do.
- **Compress changelog to 1-2 sentences per item**: User-friendly changelogs are scanned, not read line-by-line. Removing module names, class names, and internal algorithm details makes each item immediately understandable to someone who uses the product but has never read the codebase. Bug fixes and internal hardening are consolidated into one final bullet so they don't clutter the feature list.
- **Keep DEVELOPMENT.md as a reference for contributors, not a user guide**: The new Plugin Loader and Sync Engine sections include ASCII flow diagrams and module tables because contributors need to understand the architecture; these sections are not meant for end users. The README stays focused on what users can do; DEVELOPMENT.md explains how it works internally.

**✅ What Was Implemented**

- Updated `cli/CHANGELOG.md` and `vscode/CHANGELOG.md` to replace sparse 2-3 line entries with user-friendly 8-13 item lists organized by feature vs internal hardening. Removed technical module names and internal implementation details; consolidated bug fixes into a single "Bug fixes & internal hardening" section. Removed Windows flicker and plans/notes squash survival as standalone items since they are internal fixes, not user-facing features.
- Expanded `cli/README.md` with a new `jolli heal-folder` command section, a Plugins section explaining the allow-listed plugin discovery model, and updated the configuration table to remove `syncEnabled` and `syncPollIntervalSec` (which have no meaning in a non-long-lived CLI process) while keeping `syncTranscripts` as a content-control flag for the sync engine.
- Expanded `vscode/README.md` to document new UI features: the Conversations panel, per-item selection, Regenerate button, stale-readonly warning, Linear issues, provider attribution in footers, cross-repo viewing, sync robustness, Plans hover cards, and DCO toggle.
- Rewrote `cli/DEVELOPMENT.md` and `vscode/DEVELOPMENT.md` to document new modules and entry points: added `Api.ts` and `PluginLoader.ts` to the entry points table; added 10 new core modules (Linear, ActiveSession, ConversationOverlay, CommitSelection, Regenerator, TranscriptSourceLabel, HealFolder, DeviceLabel, Subprocess); added two new major sections with ASCII flow diagrams for Plugin Loader discovery and Memory Bank Cloud Sync engine architecture.
- Updated `SECURITY.md` to remove the specific plugin name `@jolli.ai/cli-pro` and replace it with generic language about the allow-list, making the document forward-compatible as the allow-list grows.

**📁 FILES**
- `cli/CHANGELOG.md`
- `vscode/CHANGELOG.md`
- `cli/README.md`
- `vscode/README.md`
- `cli/DEVELOPMENT.md`

</blockquote>
</details>

---

*Generated by Jolli Memory · May 25, 2026 at 6:41 PM · via Anthropic*
<!-- jollimemory-summary-end -->