### PR TITLE
Fix Windows path separators via shared toForwardSlash helper

### DIFF
--- a/cli/src/core/CopilotChatTranscriptReader.ts
+++ b/cli/src/core/CopilotChatTranscriptReader.ts
@@ -16,6 +16,7 @@ import { readFile, stat } from "node:fs/promises";
 import { createInterface } from "node:readline";
 import { createLogger } from "../Logger.js";
 import type { TranscriptCursor, TranscriptEntry, TranscriptReadResult } from "../Types.js";
+import { toForwardSlash } from "./PathUtils.js";
 
 type PathSegment = string | number;
 
@@ -324,7 +325,7 @@ export async function readCopilotChatTranscript(
 	cursor?: TranscriptCursor,
 	beforeTimestamp?: string,
 ): Promise<TranscriptReadResult> {
-	const norm = transcriptPath.replace(/\\/g, "/");
+	const norm = toForwardSlash(transcriptPath);
 	if (/\/\.copilot\/session-state\/[^/]+\/events\.jsonl$/.test(norm)) {
 		return readEventsJsonl(transcriptPath, cursor, beforeTimestamp);
 	}

--- a/cli/src/core/FolderStorage.test.ts
+++ b/cli/src/core/FolderStorage.test.ts
@@ -1527,6 +1527,28 @@ describe("FolderStorage", () => {
 			expect(result.some((p) => p.includes("sub-a"))).toBe(true);
 			expect(result.some((p) => p.includes("sub-b"))).toBe(true);
 		});
+
+		// Regression test for the 2026-05-26 Windows path bug — listFiles must
+		// emit forward-slash paths regardless of host OS so downstream regex
+		// consumers (SummaryStore.getTranscriptHashes etc.) match uniformly.
+		// On non-Windows runners the assertion is trivially true; on Windows
+		// it would fail before the toForwardSlash fix.
+		it("listFiles emits forward-slash separators on all platforms", async () => {
+			await storage.writeFiles(
+				[
+					{ path: "summaries/a.json", content: makeSummaryJson({ commitHash: "aaaaaaaaaaaaaaaa" }) },
+					{ path: "transcripts/aaaaaaaaaaaaaaaa.json", content: "{}" },
+					{ path: "summaries/sub/b.json", content: makeSummaryJson({ commitHash: "bbbbbbbbbbbbbbbb" }) },
+				],
+				"slash-form",
+			);
+			const summaries = await storage.listFiles("summaries");
+			const transcripts = await storage.listFiles("transcripts");
+			const all = [...summaries, ...transcripts];
+			expect(all.length).toBeGreaterThan(0);
+			expect(all.every((p) => !p.includes("\\"))).toBe(true);
+			expect(summaries.some((p) => p.startsWith("summaries/sub/"))).toBe(true);
+		});
 	});
 
 	describe("frontmatter commitType", () => {

--- a/cli/src/core/FolderStorage.ts
+++ b/cli/src/core/FolderStorage.ts
@@ -18,6 +18,7 @@ import { dirname, join, relative } from "node:path";
 import { createLogger, errMsg } from "../Logger.js";
 import type { CommitSummary, FileWrite, SummaryIndex, SummaryIndexEntry } from "../Types.js";
 import { MetadataManager } from "./MetadataManager.js";
+import { toForwardSlash } from "./PathUtils.js";
 import type { HealOptions, HealResult, StorageProvider } from "./StorageProvider.js";
 import { buildMarkdown } from "./SummaryMarkdownBuilder.js";
 
@@ -951,7 +952,13 @@ export class FolderStorage implements StorageProvider {
 			if (entry.isDirectory()) {
 				this.walkDir(fullPath, baseDir, result);
 			} else {
-				result.push(relative(baseDir, fullPath));
+				// Forward-slash form — matches OrphanBranchStorage.listFiles (git
+				// emits POSIX paths regardless of host) so downstream regex /
+				// prefix consumers (e.g. SummaryStore.getTranscriptHashes) work
+				// uniformly across both storage backends. Without this, Windows
+				// produced `transcripts\<hash>.json` and every consumer regex that
+				// hard-coded `transcripts/` silently returned an empty set.
+				result.push(toForwardSlash(relative(baseDir, fullPath)));
 			}
 		}
 	}

--- a/cli/src/core/MetadataManager.test.ts
+++ b/cli/src/core/MetadataManager.test.ts
@@ -377,10 +377,7 @@ describe("MetadataManager", () => {
 
 			const fixed = manager.reconcile(kbRoot);
 			expect(fixed).toBe(1);
-			// Normalize path separators — reconcile uses platform-native separators
-			// (backslash on Windows, slash on POSIX). The stored value is the
-			// platform-correct one; tests run on both.
-			expect(manager.findById("abc")?.path.replace(/\\/g, "/")).toBe("other/test.md");
+			expect(manager.findById("abc")?.path).toBe("other/test.md");
 		});
 
 		it("no changes when files are in place", () => {
@@ -415,8 +412,8 @@ describe("MetadataManager", () => {
 			const fixed = manager.reconcile(kbRoot);
 			// No fingerprint match for B; A stays unchanged.
 			expect(fixed).toBe(0);
-			expect(manager.findById("A")?.path.replace(/\\/g, "/")).toBe("main/present.md");
-			expect(manager.findById("B")?.path.replace(/\\/g, "/")).toBe("main/gone.md");
+			expect(manager.findById("A")?.path).toBe("main/present.md");
+			expect(manager.findById("B")?.path).toBe("main/gone.md");
 		});
 
 		it("walkDir skips dot-prefixed dirs and non-md files while scanning fingerprints", () => {
@@ -434,8 +431,7 @@ describe("MetadataManager", () => {
 
 			const fixed = manager.reconcile(kbRoot);
 			expect(fixed).toBe(1);
-			// Normalize path separators — same rationale as the move-by-fingerprint test above.
-			expect(manager.findById("abc")?.path.replace(/\\/g, "/")).toBe("main/moved.md");
+			expect(manager.findById("abc")?.path).toBe("main/moved.md");
 		});
 	});
 

--- a/cli/src/core/MetadataManager.ts
+++ b/cli/src/core/MetadataManager.ts
@@ -14,6 +14,7 @@ import { dirname, join, relative } from "node:path";
 import { createLogger } from "../Logger.js";
 import { tryMarkHiddenOnWindows } from "../util/WindowsHidden.js";
 import type { BranchesJson, BranchMapping, KBConfig, Manifest, ManifestEntry, MigrationState } from "./KBTypes.js";
+import { toForwardSlash } from "./PathUtils.js";
 
 const log = createLogger("MetadataManager");
 
@@ -322,7 +323,7 @@ export class MetadataManager {
 				try {
 					const content = readFileSync(fullPath, "utf-8");
 					const fp = MetadataManager.sha256(content);
-					map.set(fp, relative(kbRoot, fullPath).replace(/\\/g, "/"));
+					map.set(fp, toForwardSlash(relative(kbRoot, fullPath)));
 				} catch {
 					/* ignore */
 				}

--- a/cli/src/core/PathUtils.test.ts
+++ b/cli/src/core/PathUtils.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { withPlatform } from "../testUtils/withPlatform.js";
-import { normalizePathForCompare } from "./PathUtils.js";
+import { normalizePathForCompare, toForwardSlash } from "./PathUtils.js";
 
 describe("normalizePathForCompare", () => {
 	it("unifies backslashes to forward slashes regardless of platform", () => {
@@ -59,5 +59,47 @@ describe("normalizePathForCompare", () => {
 			// Single root slash gets stripped — fine because all production callers pass absolute file paths
 			expect(normalizePathForCompare("/")).toBe("");
 		});
+	});
+});
+
+// Platform-agnostic tests for toForwardSlash. The FolderStorage and
+// SummaryStore integration tests that exercise this helper through walkDir
+// are no-ops on Linux CI (node:path emits forward slashes there natively),
+// so the regression net for the 2026-05-26 Windows path bug needs at least
+// one host-OS-independent assertion. These tests are it.
+describe("toForwardSlash", () => {
+	it("returns an empty string unchanged", () => {
+		expect(toForwardSlash("")).toBe("");
+	});
+
+	it("returns a forward-slash path unchanged (idempotent on POSIX form)", () => {
+		expect(toForwardSlash("transcripts/abc.json")).toBe("transcripts/abc.json");
+		expect(toForwardSlash("a/b/c/d.txt")).toBe("a/b/c/d.txt");
+	});
+
+	it("converts a Windows-style backslash path to forward slashes", () => {
+		expect(toForwardSlash("transcripts\\abc.json")).toBe("transcripts/abc.json");
+		expect(toForwardSlash("a\\b\\c\\d.txt")).toBe("a/b/c/d.txt");
+	});
+
+	it("converts mixed separators to forward slashes", () => {
+		expect(toForwardSlash("a\\b/c\\d")).toBe("a/b/c/d");
+	});
+
+	it("does not strip trailing or leading separators (unlike normalizePathForCompare)", () => {
+		expect(toForwardSlash("\\a\\b\\")).toBe("/a/b/");
+		expect(toForwardSlash("/a/b/")).toBe("/a/b/");
+	});
+
+	it("does not change case (unlike normalizePathForCompare)", () => {
+		expect(toForwardSlash("C:\\Users\\Sanshi\\AppData")).toBe("C:/Users/Sanshi/AppData");
+	});
+
+	it("handles a single backslash", () => {
+		expect(toForwardSlash("\\")).toBe("/");
+	});
+
+	it("handles a path with no separators", () => {
+		expect(toForwardSlash("file.txt")).toBe("file.txt");
 	});
 });

--- a/cli/src/core/PathUtils.ts
+++ b/cli/src/core/PathUtils.ts
@@ -33,3 +33,29 @@ export function normalizePathForCompare(p: string): string {
 	if (end !== unified.length) unified = unified.slice(0, end);
 	return process.platform === "win32" || process.platform === "darwin" ? unified.toLowerCase() : unified;
 }
+
+/**
+ * Converts a filesystem path to forward-slash form (POSIX-style).
+ *
+ * Single-purpose helper: replaces `\` with `/`, does NOT touch case, does NOT
+ * strip trailing slashes, does NOT resolve `..`. Use this when the path will
+ * be matched against a forward-slash literal (regex, string prefix, sidebar
+ * key, manifest entry), so the matcher does not have to know the host OS.
+ *
+ * Why a dedicated helper instead of inlining `.replace(/\\/g, "/")`:
+ *   - The repo accumulated 15+ private copies of that one-liner; a shared
+ *     name makes the intent ("normalize for forward-slash matching") explicit
+ *     and gives a single grep target if the contract ever needs to change.
+ *   - {@link normalizePathForCompare} also strips trailing slashes AND lower-
+ *     cases on case-insensitive platforms, so it must NOT be used here — both
+ *     side-effects would corrupt the path before downstream consumers (e.g.
+ *     `getTranscriptHashes`, manifest map values) see it.
+ *
+ * Real-world bug this prevents: `FolderStorage.walkDir` once returned
+ * `transcripts\<hash>.json` on Windows, which broke every downstream regex
+ * that hard-coded `transcripts/`. Forcing all path emitters through this
+ * helper turns the contract into a single grep + a single function body.
+ */
+export function toForwardSlash(p: string): string {
+	return p.replace(/\\/g, "/");
+}

--- a/cli/src/core/StorageProvider.ts
+++ b/cli/src/core/StorageProvider.ts
@@ -14,7 +14,20 @@ export interface StorageProvider {
 	 */
 	writeFiles(files: FileWrite[], message: string): Promise<void>;
 
-	/** List files under a prefix path. */
+	/**
+	 * List files under a prefix path.
+	 *
+	 * Returned paths use forward-slash separators (`/`) regardless of host OS.
+	 * This mirrors `git ls-tree`'s output (the format the orphan-branch backend
+	 * inherits) and lets downstream consumers (e.g. `SummaryStore.getTranscriptHashes`'s
+	 * `transcripts/<hash>.json` regex) match without per-platform branching.
+	 *
+	 * Implementations that walk a filesystem (FolderStorage) MUST normalize via
+	 * `toForwardSlash` before returning — `node:path.relative` emits backslashes
+	 * on Windows, and an un-normalized return value silently fails every
+	 * forward-slash regex on the consumer side. See the FolderStorage Windows
+	 * path bug (2026-05-26) for the cautionary tale.
+	 */
 	listFiles(prefix: string): Promise<string[]>;
 
 	/** Check if the storage backend is initialized. */

--- a/cli/src/core/SummaryStore.test.ts
+++ b/cli/src/core/SummaryStore.test.ts
@@ -21,6 +21,9 @@ vi.spyOn(console, "log").mockImplementation(() => {});
 vi.spyOn(console, "warn").mockImplementation(() => {});
 vi.spyOn(console, "error").mockImplementation(() => {});
 
+import { mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join as joinPath } from "node:path";
 import type {
 	CommitInfo,
 	CommitSummary,
@@ -29,6 +32,7 @@ import type {
 	SummaryIndex,
 	SummaryIndexEntry,
 } from "../Types.js";
+import { FolderStorage } from "./FolderStorage.js";
 import {
 	getDiffStats,
 	getTreeHash,
@@ -37,6 +41,7 @@ import {
 	writeMultipleFilesToBranch,
 } from "./GitOps.js";
 import { acquireOrphanWriteLock, releaseOrphanWriteLock } from "./Locks.js";
+import { MetadataManager } from "./MetadataManager.js";
 import type { StorageProvider } from "./StorageProvider.js";
 import {
 	AmbiguousHashError,
@@ -2029,6 +2034,44 @@ describe("SummaryStore", () => {
 
 			const hashes = await getTranscriptHashes();
 			expect(hashes).toEqual(new Set(["abc123", "def456"]));
+		});
+
+		// End-to-end integration test for the 2026-05-26 Windows path bug:
+		// drive a REAL FolderStorage (not a mock) and verify getTranscriptHashes
+		// finds the hash. Before the toForwardSlash fix, FolderStorage.walkDir
+		// on Windows returned `transcripts\<hash>.json`, the regex never
+		// matched, and the set came back empty.
+		it("extracts hashes from a real FolderStorage backend (Windows regression)", async () => {
+			const root = joinPath(
+				tmpdir(),
+				`getTranscriptHashes-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+			);
+			mkdirSync(root, { recursive: true });
+			try {
+				const mm = new MetadataManager(joinPath(root, ".jolli"));
+				const storage: StorageProvider = new FolderStorage(root, mm);
+				await storage.ensure();
+				await storage.writeFiles(
+					[
+						{
+							path: "transcripts/8af39d0716602b52396ae1cc7ee08420d6dddfc3.json",
+							content: '{"sessions":[]}',
+						},
+						{
+							path: "transcripts/0123456789abcdef0123456789abcdef01234567.json",
+							content: '{"sessions":[]}',
+						},
+					],
+					"seed",
+				);
+
+				const hashes = await getTranscriptHashes(undefined, storage);
+				expect(hashes.has("8af39d0716602b52396ae1cc7ee08420d6dddfc3")).toBe(true);
+				expect(hashes.has("0123456789abcdef0123456789abcdef01234567")).toBe(true);
+				expect(hashes.size).toBe(2);
+			} finally {
+				rmSync(root, { recursive: true, force: true });
+			}
 		});
 	});
 

--- a/cli/src/site/MetaGenerator.ts
+++ b/cli/src/site/MetaGenerator.ts
@@ -14,7 +14,8 @@
  */
 
 import { mkdir, readdir, readFile, rm, stat, writeFile } from "node:fs/promises";
-import { basename, extname, join, relative, sep } from "node:path";
+import { basename, extname, join, relative } from "node:path";
+import { toForwardSlash } from "../core/PathUtils.js";
 import { sanitizeUrl } from "./Sanitize.js";
 import type { HeaderItem, SidebarItemValue, SidebarOverrides } from "./Types.js";
 
@@ -301,7 +302,7 @@ async function processDir(
 
 	// Compute the path key for sidebar override lookup (e.g. "/", "/get-started")
 	const relPath = relative(contentDir, dir);
-	const pathKey = `/${relPath.split(sep).join("/")}`.replace(/\/$/, "") || "/";
+	const pathKey = `/${toForwardSlash(relPath)}`.replace(/\/$/, "") || "/";
 
 	const override = sidebarOverrides?.[pathKey];
 	const indexHasAsIndexPage = await detectAsIndexPage(dir, contentItems);

--- a/vscode/src/JolliMemoryBridge.ts
+++ b/vscode/src/JolliMemoryBridge.ts
@@ -29,7 +29,7 @@ import {
 import type { ManifestEntry } from "../../cli/src/core/KBTypes.js";
 import { MetadataManager } from "../../cli/src/core/MetadataManager.js";
 import { OrphanBranchStorage } from "../../cli/src/core/OrphanBranchStorage.js";
-import { normalizePathForCompare } from "../../cli/src/core/PathUtils.js";
+import { normalizePathForCompare, toForwardSlash } from "../../cli/src/core/PathUtils.js";
 import {
 	loadConfig,
 	savePluginSource,
@@ -1978,9 +1978,9 @@ export class JolliMemoryBridge {
 		try {
 			const { repos } = await this.getDiscoveryCached();
 			const absNormalized = normalizePathForCompare(absPath);
-			const absSlashed = absPath.replace(/\\/g, "/");
+			const absSlashed = toForwardSlash(absPath);
 			for (const repo of repos) {
-				const kbRootSlashed = repo.kbRoot.replace(/\\/g, "/");
+				const kbRootSlashed = toForwardSlash(repo.kbRoot);
 				const prefixSlashed = kbRootSlashed.endsWith("/")
 					? kbRootSlashed
 					: `${kbRootSlashed}/`;


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## Quick recap

Windows users with local storage enabled were unable to see any conversation transcripts in the "All Conversations" panel, even when those transcripts were confirmed to exist on disk. The panel consistently showed a "no transcripts" message, directly contradicting the banner text that told users their transcripts were preserved. The root cause was a mismatch between how the local file storage layer listed files on Windows — using backslash separators — and how the transcript-extraction logic expected them — using forward slashes. The orphan-branch storage backend, which uses git's output, always produces forward slashes regardless of platform, so the same extraction logic worked correctly there and the bug had gone undetected since the local storage layer was introduced.

The fix normalized the file listing output to always use forward slashes, matching the established convention of the other storage backend. To prevent the same class of mistake from recurring, a named shared helper replaced the scattered inline normalization one-liners that had accumulated across the codebase. Five structurally similar call sites were updated at the same time. The storage interface now carries explicit documentation stating that all implementations must return forward-slash paths regardless of the host operating system, giving future contributors a clear contract to follow.

---

## Topics (3)
<details>
<summary><strong>01 · Fix Windows path separator bug breaking conversation transcript display</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

On Windows, the local file storage layer returned backslash-separated paths when listing files, but the code that extracts transcript identifiers used a forward-slash pattern. This caused the "All Conversations" panel in the webview to always show "No conversation transcripts saved for this commit" — even when transcripts were confirmed to exist on disk — for all Windows users with local storage enabled.

**💡 Decisions Behind the Code**

- **Shared helper over inline normalization**: The codebase already had fifteen scattered copies of the same one-liner normalization. Rather than adding a sixteenth, a named helper was introduced in the existing path utilities file. A shared name makes the intent explicit, gives a single grep target if the contract ever changes, and makes the correct approach the shortest path for future contributors.
- **Scope of replacement — high-risk sites only**: The team audited all fifteen existing inline normalizations and found none were actually buggy — every one had remembered to normalize. Only the five sites structurally identical to the bug (path fed directly into a regex or string prefix comparison) were migrated in this commit. The remaining lower-risk sites were left as-is to keep the diff focused and avoid noise in an unrelated area.
- **Independent hotfix branch over bundling into the feature branch**: The bug predated the feature branch under development and affected other parallel branches as well. Isolating it in its own branch made it straightforward to apply to any release branch that needed it, and kept the feature branch's review scope clean.

**✅ What Was Implemented**

- The root fix landed in `cli/src/core/FolderStorage.ts`: the `walkDir` method now wraps its `relative()` call with `toForwardSlash()` before pushing to the result list. A detailed comment explains the Windows-specific failure mode and the contract it must satisfy to match the orphan-branch storage backend's output format.
- `cli/src/core/StorageProvider.ts` received an expanded JSDoc on `listFiles` that formally declares the forward-slash contract, names the Windows failure as a cautionary example, and instructs future implementors to normalize before returning.
- Five additional call sites across `cli/src/core/MetadataManager.ts`, `cli/src/core/CopilotChatTranscriptReader.ts`, `cli/src/site/MetaGenerator.ts`, and `vscode/src/JolliMemoryBridge.ts` were migrated from inline one-liners to the shared helper, closing the same structural risk in sibling code paths that had remembered to normalize but had no shared abstraction to enforce it.

**📋 Future Enhancements**

- A pre-existing Windows image-path rewrite bug was spotted in the convert command during review (the directory-extraction helper only recognizes forward slashes, so it silently returns an empty string on Windows). Flagged for a separate issue.
- A lint-time script to detect inline backslash-replacement one-liners being re-introduced was discussed but deferred.
- Adding Windows runners to the CI matrix was raised as an architectural follow-up.

**📁 FILES**
- `cli/src/core/FolderStorage.ts`
- `cli/src/core/PathUtils.ts`
- `cli/src/core/StorageProvider.ts`
- `cli/src/core/MetadataManager.ts`
- `vscode/src/JolliMemoryBridge.ts`

</blockquote>
</details>
<details>
<summary><strong>02 · Add shared forward-slash helper with platform-agnostic unit tests</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The fix for the Windows path bug required a normalization function, but the existing path utility only offered a function that also lowercased paths and stripped trailing slashes — side effects that would corrupt the values being normalized. A purpose-built, single-responsibility helper was needed.

**💡 Decisions Behind the Code**

- **`toForwardSlash` over `toPosixPath` or `toUnixPath`**: The name was chosen for immediate readability by anyone unfamiliar with POSIX terminology. The test: a contributor who has never encountered the Node `path.posix` API should understand the function's effect from its name alone without needing to read the body.
- **Dedicated helper rather than reusing the existing comparison utility**: The existing utility intentionally lowercases on case-insensitive platforms and strips trailing slashes, both of which are correct for its "compare two paths" use case but would silently corrupt hash values and manifest keys if applied here. Keeping them separate prevents a future contributor from reaching for the wrong tool.

**✅ What Was Implemented**

- `toForwardSlash` was added to `cli/src/core/PathUtils.ts` with a JSDoc that explicitly distinguishes it from the existing comparison-oriented utility, explains why the two must not be conflated, and references the real-world bug it prevents.
- Eight platform-agnostic unit tests were added to `cli/src/core/PathUtils.test.ts` covering empty strings, already-normalized paths, pure backslash paths, mixed separators, leading/trailing separator preservation, and case preservation — all properties that distinguish this helper from the existing one.

**📁 FILES**
- `cli/src/core/PathUtils.ts`
- `cli/src/core/PathUtils.test.ts`

</blockquote>
</details>
<details>
<summary><strong>03 · Add regression tests locking in the transcript-listing fix end-to-end</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The integration tests for transcript hash extraction used a mock storage backend, meaning the Windows path bug could silently regress without any test catching it. On Linux CI, the filesystem naturally produces forward slashes, so a test using real file I/O would also pass on Linux even if the normalization were removed — leaving a blind spot.

**💡 Decisions Behind the Code**

- **Platform-agnostic unit tests in addition to integration tests**: The integration tests are no-ops on Linux CI because the OS never produces backslashes. The unit tests for the helper function use hardcoded backslash strings, so they exercise the conversion logic on every platform regardless of what the OS's path separator happens to be. Both layers are needed: the unit tests catch regressions in the helper itself; the integration tests catch regressions in the call sites.
- **Real filesystem in the integration test rather than a mock**: The existing mock-based test already passed before the fix, which is precisely why the bug went undetected. Using a real temporary directory ensures the test exercises the actual `walkDir` code path that was broken, not a stub that bypasses it.

**✅ What Was Implemented**

- A new integration test in `cli/src/core/SummaryStore.test.ts` drives a real `FolderStorage` instance against a temporary directory, writes two transcript files, calls the hash-extraction function, and asserts both hashes are returned. This test would have failed on Windows before the fix and documents the exact failure scenario from the bug report.
- A regression test in `cli/src/core/FolderStorage.test.ts` calls `listFiles` on a real nested directory structure and asserts that every returned path contains no backslash characters, covering both flat and nested cases.
- Four now-redundant backslash-normalization calls were removed from `cli/src/core/MetadataManager.test.ts` along with their accompanying comments, which had become factually incorrect after the underlying storage method was fixed.

**📁 FILES**
- `cli/src/core/SummaryStore.test.ts`
- `cli/src/core/FolderStorage.test.ts`
- `cli/src/core/MetadataManager.test.ts`

</blockquote>
</details>

---

*Generated by Jolli Memory · May 26, 2026 at 6:22 PM · via Anthropic*
<!-- jollimemory-summary-end -->