### PR TITLE
Add GitHub Copilot CLI and Copilot Chat session discovery support

### DIFF
--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/bridge/SummaryReader.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/bridge/SummaryReader.kt
@@ -2,6 +2,8 @@ package ai.jolli.jollimemory.bridge
 
 import ai.jolli.jollimemory.core.CodexSessionDiscoverer
 import ai.jolli.jollimemory.core.CommitSummary
+import ai.jolli.jollimemory.core.CopilotChatSupport
+import ai.jolli.jollimemory.core.CopilotSupport
 import ai.jolli.jollimemory.core.CursorSupport
 import ai.jolli.jollimemory.core.GeminiSupport
 import ai.jolli.jollimemory.core.JmLogger
@@ -40,6 +42,12 @@ class SummaryReader(private val projectDir: String, private val git: GitOps) {
         val cursorError = if (cursorInstalled && config.cursorEnabled != false)
             CursorSupport.checkDbHealth() else null
 
+        val copilotInstalled = CopilotSupport.isCopilotInstalled()
+        val copilotError = if (copilotInstalled && config.copilotEnabled != false)
+            CopilotSupport.checkDbHealth() else null
+
+        val copilotChatInstalled = CopilotChatSupport.isCopilotChatInstalled()
+
         return StatusInfo(
             enabled = hooksInstalled,
             claudeHookInstalled = installer.isClaudeHookInstalled(),
@@ -61,6 +69,11 @@ class SummaryReader(private val projectDir: String, private val git: GitOps) {
             cursorDetected = cursorInstalled,
             cursorEnabled = config.cursorEnabled,
             cursorScanError = cursorError,
+            copilotDetected = copilotInstalled,
+            copilotEnabled = config.copilotEnabled,
+            copilotScanError = copilotError,
+            copilotChatDetected = copilotChatInstalled,
+            copilotChatScanError = null,
         )
     }
 

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/core/CopilotChatSupport.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/core/CopilotChatSupport.kt
@@ -1,0 +1,460 @@
+package ai.jolli.jollimemory.core
+
+import com.google.gson.JsonArray
+import com.google.gson.JsonElement
+import com.google.gson.JsonObject
+import com.google.gson.JsonParser
+import java.io.File
+import java.time.Instant
+
+/**
+ * Copilot Chat Support — session discovery and transcript reading for VS Code's
+ * Copilot Chat panel (separate from the standalone CLI terminal, which lives in
+ * [CopilotSupport]).
+ *
+ * Two on-disk shapes are covered by this single source because they're both
+ * "New Chat" sessions in the VS Code chat panel — the difference is which model
+ * the user picked:
+ *
+ *   Scan A — chat panel with copilotcli-backend models:
+ *     ~/.copilot/session-state/<sid>/events.jsonl
+ *     Gated by `vscode.metadata.json.workspaceFolder.folderPath` == projectDir.
+ *
+ *   Scan B — chat panel with non-copilotcli-backend (other-vendor) models:
+ *     <userDataDir>/User/workspaceStorage/<wsHash>/chatSessions/<sid>.jsonl
+ *     wsHash resolved via VscodeWorkspaceLocator from projectDir.
+ *
+ * Sessions older than 48 h are excluded (matches every other discovery-based
+ * source). The deprecated `.json` snapshot variant of Scan B is explicitly NOT
+ * read — see the spec.
+ *
+ * Kotlin port of `cli/src/core/{CopilotChatDetector,CopilotChatSessionDiscoverer,CopilotChatTranscriptReader}.ts`.
+ */
+object CopilotChatSupport {
+
+	private val log = JmLogger.create("CopilotChatSupport")
+	private const val SESSION_STALE_MS = 48 * 60 * 60 * 1000L
+
+	/** Returns vscode's `globalStorage/github.copilot-chat` directory path. */
+	fun getCopilotChatStorageDir(): String =
+		getVscodeUserDataDir(VscodeFlavor.Code) + File.separator + "User" +
+			File.separator + "globalStorage" + File.separator + "github.copilot-chat"
+
+	/** Returns `~/.copilot/session-state` directory path (Copilot CLI agent backend). */
+	fun getCopilotCliSessionStateDir(): String =
+		System.getProperty("user.home") + File.separator + ".copilot" + File.separator + "session-state"
+
+	/**
+	 * Returns true when either of the two known Copilot Chat data roots exists
+	 * as a directory.
+	 */
+	fun isCopilotChatInstalled(): Boolean =
+		File(getCopilotChatStorageDir()).isDirectory || File(getCopilotCliSessionStateDir()).isDirectory
+
+	/**
+	 * Runs Scan A then Scan B; concatenates sessions; returns the first error
+	 * encountered (subsequent are debug-logged).
+	 */
+	fun discoverSessions(projectDir: String): CopilotChatScanResult {
+		val a = scanSessionState(projectDir)
+		val b = scanChatSessions(projectDir)
+		val sessions = a.sessions + b.sessions
+		val error = a.error ?: b.error
+		if (a.error != null && b.error != null) {
+			log.debug("Both Copilot Chat scans errored; reporting Scan A, dropped Scan B: %s", b.error.message)
+		}
+		if (sessions.isNotEmpty()) {
+			log.info("Discovered %d Copilot Chat session(s) for %s", sessions.size, projectDir)
+		}
+		return CopilotChatScanResult(sessions, error)
+	}
+
+	/**
+	 * Front door for Copilot Chat transcript reading. Dispatches to one of two
+	 * sub-readers based on the trailing path segments of [transcriptPath]:
+	 *
+	 *   ".../session-state/<sid>/events.jsonl"  → [readEventsJsonl]
+	 *   ".../chatSessions/<sid>.jsonl"          → [readPatchLog]
+	 *
+	 * Throws on an unrecognized path — the discoverer should never emit anything
+	 * else, so this is a defense-in-depth invariant.
+	 */
+	fun readTranscript(
+		transcriptPath: String,
+		cursor: TranscriptCursor?,
+		beforeTimestamp: String? = null,
+	): TranscriptReadResult {
+		val norm = transcriptPath.replace('\\', '/')
+		return when {
+			Regex("/\\.copilot/session-state/[^/]+/events\\.jsonl$").containsMatchIn(norm) ->
+				readEventsJsonl(transcriptPath, cursor, beforeTimestamp)
+			Regex("/chatSessions/[^/]+\\.jsonl$").containsMatchIn(norm) ->
+				readPatchLog(transcriptPath, cursor, beforeTimestamp)
+			else -> throw IllegalArgumentException(
+				"Copilot Chat reader: unrecognized transcriptPath pattern: $transcriptPath"
+			)
+		}
+	}
+
+	// ── Scan A: ~/.copilot/session-state/<sid>/events.jsonl ────────────────
+
+	private fun scanSessionState(projectDir: String): CopilotChatScanResult {
+		val root = File(getCopilotCliSessionStateDir())
+		if (!root.isDirectory) return CopilotChatScanResult(emptyList())
+
+		val cutoffMs = System.currentTimeMillis() - SESSION_STALE_MS
+		val target = normalizePathForMatch(projectDir)
+		val sessions = mutableListOf<SessionInfo>()
+
+		val entries = root.listFiles() ?: return CopilotChatScanResult(
+			emptyList(),
+			CopilotChatScanError("fs", "readdir returned null for ${root.path}"),
+		)
+
+		for (sessionDir in entries) {
+			if (!sessionDir.isDirectory) continue
+			val sid = sessionDir.name
+			val metaFile = File(sessionDir, "vscode.metadata.json")
+			val eventsFile = File(sessionDir, "events.jsonl")
+
+			val folderPath = try {
+				JsonParser.parseString(metaFile.readText()).asJsonObject
+					.getAsJsonObject("workspaceFolder")
+					?.get("folderPath")?.takeIf { it.isJsonPrimitive }?.asString
+			} catch (_: Exception) {
+				log.debug("Skipping %s: vscode.metadata.json read/parse failed", sid)
+				continue
+			}
+			if (folderPath.isNullOrEmpty()) continue
+			if (normalizePathForMatch(folderPath) != target) continue
+
+			if (!eventsFile.isFile) continue
+			val mtimeMs = eventsFile.lastModified()
+			if (mtimeMs < cutoffMs) continue
+
+			sessions.add(SessionInfo(
+				sessionId = sid,
+				transcriptPath = eventsFile.absolutePath,
+				updatedAt = Instant.ofEpochMilli(mtimeMs).toString(),
+				source = TranscriptSource.`copilot-chat`,
+			))
+		}
+		return CopilotChatScanResult(sessions)
+	}
+
+	// ── Scan B: <wsHash>/chatSessions/<sid>.jsonl ──────────────────────────
+
+	private fun scanChatSessions(projectDir: String): CopilotChatScanResult {
+		val wsHash = findVscodeWorkspaceHash(VscodeFlavor.Code, projectDir) ?: run {
+			log.debug("No vscode workspace matched %s", projectDir)
+			return CopilotChatScanResult(emptyList())
+		}
+		val dir = File(
+			getVscodeWorkspaceStorageDir(VscodeFlavor.Code) + File.separator + wsHash + File.separator + "chatSessions"
+		)
+		if (!dir.isDirectory) return CopilotChatScanResult(emptyList())
+
+		val cutoffMs = System.currentTimeMillis() - SESSION_STALE_MS
+		val entries = dir.listFiles() ?: return CopilotChatScanResult(
+			emptyList(),
+			CopilotChatScanError("fs", "readdir returned null for ${dir.path}"),
+		)
+
+		val sessions = mutableListOf<SessionInfo>()
+		for (file in entries) {
+			val name = file.name
+			if (!name.endsWith(".jsonl")) continue // skip .json snapshots and other suffixes
+			val mtimeMs = file.lastModified()
+			if (mtimeMs < cutoffMs) continue
+			sessions.add(SessionInfo(
+				sessionId = name.removeSuffix(".jsonl"),
+				transcriptPath = file.absolutePath,
+				updatedAt = Instant.ofEpochMilli(mtimeMs).toString(),
+				source = TranscriptSource.`copilot-chat`,
+			))
+		}
+		return CopilotChatScanResult(sessions)
+	}
+
+	// ── Reader: events.jsonl (line-streamed) ───────────────────────────────
+
+	private fun readEventsJsonl(
+		transcriptPath: String,
+		cursor: TranscriptCursor?,
+		beforeTimestamp: String?,
+	): TranscriptReadResult {
+		val startLine = cursor?.lineNumber ?: 0
+		val entries = mutableListOf<TranscriptEntry>()
+		var currentLine = 0
+
+		// Collect to a list so the loop runs outside the inline `useLines` lambda —
+		// non-local break/continue inside an inline-lambda nested loop requires
+		// Kotlin 2.2+. Event logs are bounded in size, so the memory cost is fine.
+		val allLines = File(transcriptPath).bufferedReader(Charsets.UTF_8).useLines { it.toList() }
+		for (rawLine in allLines) {
+			currentLine++
+			if (currentLine <= startLine) continue
+
+			val evt = try {
+				JsonParser.parseString(rawLine).asJsonObject
+			} catch (_: Exception) {
+				// skip malformed line, cursor still advances
+				continue
+			}
+
+			val timestamp = evt.get("timestamp")?.takeIf { it.isJsonPrimitive }?.asString
+			// beforeTimestamp gate: ISO 8601 timestamps are lex-sortable, so string
+			// comparison is sufficient here. Stop without consuming this line so the
+			// next read picks it up within a wider cutoff window.
+			if (beforeTimestamp != null && timestamp != null && timestamp > beforeTimestamp) {
+				currentLine-- // do not consume this line
+				break
+			}
+
+			val type = evt.get("type")?.takeIf { it.isJsonPrimitive }?.asString ?: continue
+			val content = evt.getAsJsonObject("data")
+				?.get("content")?.takeIf { it.isJsonPrimitive }?.asString
+			if (content.isNullOrEmpty()) continue
+
+			when (type) {
+				"user.message" -> entries.add(TranscriptEntry("human", content, timestamp))
+				"assistant.message" -> entries.add(TranscriptEntry("assistant", content, timestamp))
+			}
+		}
+
+		val mtimeMs = File(transcriptPath).lastModified()
+		val updatedAt = Instant.ofEpochMilli(mtimeMs).toString()
+		return TranscriptReadResult(
+			entries = entries,
+			newCursor = TranscriptCursor(transcriptPath, currentLine, updatedAt),
+			totalLinesRead = (currentLine - startLine).coerceAtLeast(0),
+		)
+	}
+
+	// ── Reader: chatSessions/<sid>.jsonl (patch log) ───────────────────────
+
+	private fun readPatchLog(
+		transcriptPath: String,
+		cursor: TranscriptCursor?,
+		beforeTimestamp: String?,
+	): TranscriptReadResult {
+		val fromIdx = cursor?.lineNumber ?: 0
+		val file = File(transcriptPath)
+		val raw = try {
+			file.readText(Charsets.UTF_8)
+		} catch (e: Exception) {
+			throw RuntimeException("Copilot Chat patch log read failed: ${e.message}", e)
+		}
+
+		val lines = raw.split('\n').filter { it.isNotEmpty() }
+		val updatedAt = Instant.ofEpochMilli(file.lastModified()).toString()
+		if (lines.isEmpty()) {
+			return TranscriptReadResult(
+				entries = emptyList(),
+				newCursor = TranscriptCursor(transcriptPath, 0, updatedAt),
+				totalLinesRead = 0,
+			)
+		}
+
+		val doc = try {
+			replayPatches(lines)
+		} catch (e: Exception) {
+			throw RuntimeException("Copilot Chat patch replay failed (parse): ${e.message}", e)
+		}
+
+		val requests = (doc as? JsonObject)?.getAsJsonArray("requests")
+			?: throw RuntimeException("Copilot Chat patch replay failed (schema): requests is not an array")
+
+		// Patch-log timestamps are numeric ms since epoch; compare in ms. A request
+		// without a numeric timestamp is treated as before-cutoff.
+		val cutoffMs = beforeTimestamp?.let { Instant.parse(it).toEpochMilli() } ?: Long.MAX_VALUE
+		val entries = mutableListOf<TranscriptEntry>()
+		var lastEmittedIdx = fromIdx
+
+		for (i in fromIdx until requests.size()) {
+			val req = requests[i] as? JsonObject
+			if (req == null) {
+				lastEmittedIdx = i + 1
+				continue
+			}
+			val tsMs = req.get("timestamp")?.takeIf {
+				it.isJsonPrimitive && it.asJsonPrimitive.isNumber
+			}?.asLong
+			if (tsMs != null && tsMs > cutoffMs) break
+
+			// Convert numeric ms timestamp to ISO so emitted entries carry a stable
+			// identity dimension — without this, two distinct turns whose user text
+			// happens to match collapse under ConversationOverlayStore.sameIdentity.
+			val tsIso = tsMs?.let { Instant.ofEpochMilli(it).toString() }
+
+			val userText = req.getAsJsonObject("message")
+				?.get("text")?.takeIf { it.isJsonPrimitive }?.asString
+			if (!userText.isNullOrEmpty()) {
+				entries.add(TranscriptEntry("human", userText, tsIso))
+			}
+
+			val responseArr = req.get("response") as? JsonArray
+			val assistantText = if (responseArr != null) {
+				val parts = mutableListOf<String>()
+				for (chunk in responseArr) {
+					val v = (chunk as? JsonObject)
+						?.get("value")?.takeIf { it.isJsonPrimitive }?.asString
+					if (!v.isNullOrEmpty()) parts.add(v)
+				}
+				parts.joinToString("")
+			} else ""
+			if (assistantText.isNotEmpty()) {
+				entries.add(TranscriptEntry("assistant", assistantText, tsIso))
+			}
+			lastEmittedIdx = i + 1
+		}
+
+		return TranscriptReadResult(
+			entries = entries,
+			newCursor = TranscriptCursor(transcriptPath, lastEmittedIdx, updatedAt),
+			totalLinesRead = lines.size,
+		)
+	}
+
+	// ── Patch replay primitives ────────────────────────────────────────────
+
+	/**
+	 * Replays a JSONL patch log into a final document.
+	 *
+	 *   kind 0 → replace entire document with `v`
+	 *   kind 1 → set `v` at path `k`
+	 *   kind 2 → delete value at path `k`
+	 *
+	 * Unknown `kind` is logged and skipped (forward compatibility). JSON parse
+	 * errors are propagated so the caller can distinguish "mid-write" from
+	 * "structurally broken file".
+	 *
+	 * Exposed as `internal` so unit tests can drive the replay directly.
+	 */
+	internal fun replayPatches(lines: List<String>): JsonElement {
+		var doc: JsonElement = JsonObject()
+		for (rawLine in lines) {
+			val evt = JsonParser.parseString(rawLine).asJsonObject
+			when (val kind = evt.get("kind")?.takeIf { it.isJsonPrimitive }?.asInt) {
+				0 -> doc = evt.get("v") ?: JsonObject()
+				1 -> {
+					val path = evt.getAsJsonArray("k") ?: continue
+					val value = evt.get("v") ?: continue
+					setAtPath(doc, path, value)
+				}
+				2 -> {
+					val path = evt.getAsJsonArray("k") ?: continue
+					deleteAtPath(doc, path)
+				}
+				else -> log.warn("Unknown patch kind %s — skipping", kind)
+			}
+		}
+		return doc
+	}
+
+	/**
+	 * Mutates [doc] in place by setting [value] at [path]. Creates intermediate
+	 * objects/arrays as needed; the *next* segment's type decides the container
+	 * shape (numeric segment → array, string segment → object).
+	 */
+	internal fun setAtPath(doc: JsonElement, path: JsonArray, value: JsonElement) {
+		if (path.size() == 0) return // root replacement is replayPatches's job (kind 0)
+		var cur: JsonElement = doc
+		for (i in 0 until path.size() - 1) {
+			val seg = path[i]
+			val next = path[i + 1]
+			cur = stepInto(cur, seg, createIfMissing = true, nextSeg = next) ?: return
+		}
+		assignAt(cur, path[path.size() - 1], value)
+	}
+
+	/**
+	 * Mutates [doc] in place by removing the value at [path]. No-op if the path
+	 * doesn't exist or is empty. For array elements, uses `remove(int)` so the
+	 * array shifts (matching vscode's emitted semantics for pendingRequests cleanup).
+	 */
+	internal fun deleteAtPath(doc: JsonElement, path: JsonArray) {
+		if (path.size() == 0) return
+		var cur: JsonElement = doc
+		for (i in 0 until path.size() - 1) {
+			cur = stepInto(cur, path[i], createIfMissing = false, nextSeg = null) ?: return
+		}
+		val last = path[path.size() - 1]
+		when (cur) {
+			is JsonObject -> if (last.isJsonPrimitive) cur.remove(last.asString)
+			is JsonArray -> if (last.isJsonPrimitive && last.asJsonPrimitive.isNumber) {
+				val idx = last.asInt
+				if (idx in 0 until cur.size()) cur.remove(idx)
+			}
+			else -> { /* unreachable for well-formed paths */ }
+		}
+	}
+
+	/**
+	 * Returns the child at [seg] inside [parent]; creates it on demand when
+	 * [createIfMissing] is true (using [nextSeg]'s type to decide array vs object).
+	 * Returns null when [createIfMissing] is false and the path doesn't exist —
+	 * caller short-circuits via `?: return`.
+	 */
+	private fun stepInto(
+		parent: JsonElement,
+		seg: JsonElement,
+		createIfMissing: Boolean,
+		nextSeg: JsonElement?,
+	): JsonElement? {
+		return when (parent) {
+			is JsonObject -> {
+				val key = seg.asString
+				val existing = parent.get(key)
+				if (existing != null && !existing.isJsonNull) return existing
+				if (!createIfMissing) return null
+				val fresh: JsonElement = if (nextSeg?.isJsonPrimitive == true && nextSeg.asJsonPrimitive.isNumber) {
+					JsonArray()
+				} else JsonObject()
+				parent.add(key, fresh)
+				fresh
+			}
+			is JsonArray -> {
+				val idx = seg.asInt
+				val existing = if (idx in 0 until parent.size()) parent[idx] else null
+				if (existing != null && !existing.isJsonNull) return existing
+				if (!createIfMissing) return null
+				val fresh: JsonElement = if (nextSeg?.isJsonPrimitive == true && nextSeg.asJsonPrimitive.isNumber) {
+					JsonArray()
+				} else JsonObject()
+				while (parent.size() <= idx) parent.add(JsonObject())
+				parent[idx] = fresh
+				fresh
+			}
+			else -> null // path runs into a primitive; nothing we can step into
+		}
+	}
+
+	/** Assigns [value] at the last segment of a path. */
+	private fun assignAt(parent: JsonElement, seg: JsonElement, value: JsonElement) {
+		when (parent) {
+			is JsonObject -> parent.add(seg.asString, value)
+			is JsonArray -> {
+				val idx = seg.asInt
+				while (parent.size() <= idx) parent.add(JsonObject())
+				parent[idx] = value
+			}
+			else -> { /* cannot assign into a primitive; ignore */ }
+		}
+	}
+}
+
+// ── Public scan-error types ────────────────────────────────────────────────
+
+/** Severity classification for Copilot Chat scan failures. */
+data class CopilotChatScanError(
+	/** "parse" | "fs" | "schema" | "unknown" — see CLI spec. */
+	val kind: String,
+	val message: String,
+)
+
+/** Result of a Copilot Chat session-discovery scan. */
+data class CopilotChatScanResult(
+	val sessions: List<SessionInfo>,
+	val error: CopilotChatScanError? = null,
+)

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/core/CopilotSupport.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/core/CopilotSupport.kt
@@ -1,0 +1,200 @@
+package ai.jolli.jollimemory.core
+
+import java.io.File
+import java.time.Instant
+
+/**
+ * Copilot Support — session discovery and transcript reading for the GitHub
+ * Copilot CLI (the standalone terminal binary, separate from the VS Code
+ * Copilot Chat panel — that lives in [CopilotChatSupport]).
+ *
+ * Copilot CLI stores every session in a single SQLite database at:
+ *   ~/.copilot/session-store.db
+ *
+ * Each `sessions` row carries its own `cwd`, so workspace attribution is exact —
+ * no workspace-locator dance is needed here. The `turns` table holds one row
+ * per conversation turn, with `user_message` and `assistant_response` as
+ * separate columns; each row expands into two TranscriptEntry items.
+ *
+ * Synthetic transcript path: "<dbPath>#<sessionId>" (matches OpenCode / Cursor).
+ *
+ * Kotlin port of `cli/src/core/{CopilotDetector,CopilotSessionDiscoverer,CopilotTranscriptReader}.ts`.
+ */
+object CopilotSupport {
+
+	private val log = JmLogger.create("CopilotSupport")
+
+	/** Sessions older than 48 hours are considered stale (matches other sources). */
+	private const val SESSION_STALE_MS = 48 * 60 * 60 * 1000L
+
+	/** Returns the absolute path to Copilot CLI's session-store database. */
+	fun getDbPath(): String =
+		System.getProperty("user.home") + File.separator + ".copilot" + File.separator + "session-store.db"
+
+	/** Returns true when the Copilot CLI session DB is present on disk. */
+	fun isCopilotInstalled(): Boolean = File(getDbPath()).isFile
+
+	/**
+	 * Lightweight DB health check — opens the database and runs a trivial query
+	 * to detect locked/corrupt/permission errors without scanning all rows.
+	 */
+	fun checkDbHealth(): SqliteScanError? {
+		val dbPath = getDbPath()
+		if (!File(dbPath).isFile) return null
+		return try {
+			withReadOnlyDb(dbPath) { conn ->
+				conn.prepareStatement("SELECT 1 FROM sessions LIMIT 1").use { it.executeQuery() }
+			}
+			null
+		} catch (e: Exception) {
+			classifyScanError(e)
+		}
+	}
+
+	/**
+	 * Discovers Copilot CLI sessions relevant to the given project directory.
+	 * Queries `sessions` by `cwd` (case-insensitive on darwin/win32) and applies
+	 * the 48 h staleness cutoff in Kotlin (not SQL) because `updated_at` is TEXT —
+	 * SQL `>` would be lexicographic and only correct if every row used canonical
+	 * UTC ISO-8601. [Instant.parse] tolerates any format Java date parsing accepts.
+	 */
+	fun discoverSessions(projectDir: String): ScanResult {
+		val dbPath = getDbPath()
+		if (!File(dbPath).isFile) return ScanResult(emptyList())
+
+		val cutoffMs = System.currentTimeMillis() - SESSION_STALE_MS
+		val osName = System.getProperty("os.name").lowercase()
+		val caseInsensitive = osName.contains("mac") || osName.contains("win")
+
+		return try {
+			withReadOnlyDb(dbPath) { conn ->
+				val sql = buildString {
+					append("SELECT id, summary, updated_at FROM sessions WHERE ")
+					append(if (caseInsensitive) "LOWER(cwd) = LOWER(?)" else "cwd = ?")
+					append(" ORDER BY updated_at DESC")
+				}
+
+				val sessions = mutableListOf<SessionInfo>()
+				conn.prepareStatement(sql).use { stmt ->
+					stmt.setString(1, projectDir)
+					val rs = stmt.executeQuery()
+					while (rs.next()) {
+						val id = rs.getString("id")
+						val updatedAtRaw = rs.getString("updated_at")
+						val updatedAtMs = try {
+							Instant.parse(updatedAtRaw).toEpochMilli()
+						} catch (_: Exception) {
+							log.warn("Skipping Copilot session %s: unparseable updated_at %s", id, updatedAtRaw)
+							continue
+						}
+						if (updatedAtMs < cutoffMs) continue
+						val title = rs.getString("summary")?.takeIf { it.isNotBlank() }
+						sessions.add(SessionInfo(
+							sessionId = id,
+							transcriptPath = "$dbPath#$id",
+							updatedAt = Instant.ofEpochMilli(updatedAtMs).toString(),
+							source = TranscriptSource.copilot,
+						))
+						if (title != null) log.debug("Copilot session %s title: %s", id.take(8), title)
+					}
+				}
+				log.info("Discovered %d Copilot session(s) for %s", sessions.size, projectDir)
+				ScanResult(sessions)
+			}
+		} catch (e: Exception) {
+			val scanError = classifyScanError(e)
+			log.error("Copilot scan failed (%s): %s", scanError.kind, scanError.message)
+			ScanResult(emptyList(), scanError)
+		}
+	}
+
+	/**
+	 * Reads turns from a Copilot CLI session and returns parsed transcript entries.
+	 *
+	 * Cursor's `lineNumber` tracks the count of fully-consumed turns (zero-based
+	 * index into the ORDER BY turn_index result set). This is equivalent to
+	 * `turn_index` while Copilot's UNIQUE(session_id, turn_index) constraint
+	 * prevents gaps; if turns are ever deleted leaving holes, a value-based resume
+	 * query would be needed instead.
+	 *
+	 * @param transcriptPath synthetic path: "<dbPath>#<sessionId>"
+	 * @param cursor         optional cursor; lineNumber = turns already consumed
+	 * @param beforeTimestamp optional ISO-8601 cutoff for commit attribution
+	 */
+	fun readTranscript(
+		transcriptPath: String,
+		cursor: TranscriptCursor?,
+		beforeTimestamp: String? = null,
+	): TranscriptReadResult {
+		val (dbPath, sessionId) = parseSyntheticPath(transcriptPath)
+		val startIndex = cursor?.lineNumber ?: 0
+		val cutoffMs = beforeTimestamp?.let { Instant.parse(it).toEpochMilli() }
+
+		try {
+			return withReadOnlyDb(dbPath) { conn ->
+				val rows = mutableListOf<TurnRow>()
+				conn.prepareStatement(
+					"SELECT turn_index, user_message, assistant_response, timestamp " +
+						"FROM turns WHERE session_id = ? ORDER BY turn_index ASC"
+				).use { stmt ->
+					stmt.setString(1, sessionId)
+					val rs = stmt.executeQuery()
+					while (rs.next()) {
+						rows.add(TurnRow(
+							turnIndex = rs.getInt("turn_index"),
+							userMessage = rs.getString("user_message"),
+							assistantResponse = rs.getString("assistant_response"),
+							timestamp = rs.getString("timestamp"),
+						))
+					}
+				}
+
+				val totalTurns = rows.size
+				val newRows = if (startIndex < rows.size) rows.subList(startIndex, rows.size) else emptyList()
+
+				val rawEntries = mutableListOf<TranscriptEntry>()
+				var lastConsumedIndex = startIndex
+				for (i in newRows.indices) {
+					val r = newRows[i]
+					if (cutoffMs != null && r.timestamp != null) {
+						val ts = try { Instant.parse(r.timestamp).toEpochMilli() } catch (_: Exception) { null }
+						if (ts != null && ts > cutoffMs) break
+					}
+					val tsIso = r.timestamp?.let {
+						try { Instant.parse(it); it } catch (_: Exception) { null }
+					}
+					if (!r.userMessage.isNullOrBlank()) {
+						rawEntries.add(TranscriptEntry("human", r.userMessage, tsIso))
+					}
+					if (!r.assistantResponse.isNullOrBlank()) {
+						rawEntries.add(TranscriptEntry("assistant", r.assistantResponse, tsIso))
+					}
+					lastConsumedIndex = startIndex + i + 1
+				}
+
+				val entries = TranscriptReader.mergeConsecutiveEntries(rawEntries)
+				val newCursor = TranscriptCursor(
+					transcriptPath = transcriptPath,
+					lineNumber = if (beforeTimestamp != null) lastConsumedIndex else totalTurns,
+					updatedAt = Instant.now().toString(),
+				)
+				val totalLinesRead = lastConsumedIndex - startIndex
+				log.info(
+					"Read Copilot session %s: %d new turns, %d entries (index %d→%d)",
+					sessionId.take(8), totalLinesRead, entries.size, startIndex, newCursor.lineNumber,
+				)
+				TranscriptReadResult(entries, newCursor, totalLinesRead)
+			}
+		} catch (e: Exception) {
+			log.error("Failed to read Copilot session %s: %s", sessionId.take(8), e.message)
+			throw RuntimeException("Cannot read Copilot session: $sessionId")
+		}
+	}
+
+	private data class TurnRow(
+		val turnIndex: Int,
+		val userMessage: String?,
+		val assistantResponse: String?,
+		val timestamp: String?,
+	)
+}

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/core/CursorSupport.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/core/CursorSupport.kt
@@ -2,8 +2,6 @@ package ai.jolli.jollimemory.core
 
 import com.google.gson.JsonParser
 import java.io.File
-import java.net.URI
-import java.nio.file.Paths
 import java.time.Instant
 
 /**
@@ -47,32 +45,10 @@ object CursorSupport {
 	/** Cursor bubble.type → transcript role. Other values (system messages, tool calls) are skipped. */
 	private val BUBBLE_TYPE_TO_ROLE = mapOf(1 to "human", 2 to "assistant")
 
-	/** Returns the user-data root for Cursor on the current platform. */
-	private fun getUserDataDir(): String {
-		val home = System.getProperty("user.home")
-		val osName = System.getProperty("os.name").lowercase()
-		return when {
-			osName.contains("mac") ->
-				home + File.separator + "Library" + File.separator + "Application Support" + File.separator + "Cursor"
-			osName.contains("win") ->
-				// `cursor.appdata.override` is a test hook: Java cannot unset env vars, so tests
-				// that need to redirect away from the real %APPDATA% set this system property instead.
-				(System.getProperty("cursor.appdata.override")
-					?: System.getenv("APPDATA")
-					?: (home + File.separator + "AppData" + File.separator + "Roaming")) +
-					File.separator + "Cursor"
-			else ->
-				home + File.separator + ".config" + File.separator + "Cursor"
-		}
-	}
-
 	/** Returns the path to Cursor's global SQLite database. */
 	fun getGlobalDbPath(): String =
-		getUserDataDir() + File.separator + "User" + File.separator + "globalStorage" + File.separator + "state.vscdb"
-
-	/** Returns the workspaceStorage directory containing per-workspace state.vscdb files. */
-	private fun getWorkspaceStorageDir(): String =
-		getUserDataDir() + File.separator + "User" + File.separator + "workspaceStorage"
+		getVscodeUserDataDir(VscodeFlavor.Cursor) + File.separator + "User" +
+			File.separator + "globalStorage" + File.separator + "state.vscdb"
 
 	/** Checks whether Cursor's global database file exists. */
 	fun isCursorInstalled(): Boolean {
@@ -108,7 +84,7 @@ object CursorSupport {
 		if (!globalDbFile.isFile) return ScanResult(emptyList())
 
 		// Step 1: Workspace lookup
-		val wsHash = findWorkspaceHash(projectDir)
+		val wsHash = findVscodeWorkspaceHash(VscodeFlavor.Cursor, projectDir)
 		if (wsHash == null) {
 			log.debug("No Cursor workspace found matching %s", projectDir)
 			return ScanResult(emptyList())
@@ -314,54 +290,13 @@ object CursorSupport {
 	// ── Internal helpers ─────────────────────────────────────────────────────
 
 	/**
-	 * Scans workspaceStorage for an entry whose `workspace.json` has a `folder`
-	 * URI resolving to projectDir. Returns the workspace hash on match, null otherwise.
-	 * Single-folder workspaces only — multi-root `.code-workspace` files are skipped.
-	 */
-	private fun findWorkspaceHash(projectDir: String): String? {
-		val wsStorageDir = File(getWorkspaceStorageDir())
-		if (!wsStorageDir.isDirectory) {
-			log.debug("Cursor workspaceStorage not readable at %s", wsStorageDir.path)
-			return null
-		}
-
-		val target = normalizePathForMatch(projectDir)
-		val entries = wsStorageDir.listFiles() ?: return null
-
-		for (entry in entries) {
-			val wsJson = File(entry, "workspace.json")
-			if (!wsJson.isFile) continue
-
-			val folderUri = try {
-				JsonParser.parseString(wsJson.readText()).asJsonObject
-					.get("folder")?.takeIf { it.isJsonPrimitive }?.asString
-			} catch (_: Exception) {
-				continue
-			} ?: continue
-
-			if (!folderUri.startsWith("file://")) continue
-
-			val folderPath = try {
-				Paths.get(URI(folderUri)).toString()
-			} catch (_: Exception) {
-				log.warn("Cursor workspace %s has unparseable folder URI: %s", entry.name, folderUri)
-				continue
-			}
-
-			if (normalizePathForMatch(folderPath) == target) {
-				return entry.name
-			}
-		}
-		return null
-	}
-
-	/**
 	 * Reads the per-workspace state.vscdb and extracts anchor composer IDs from the
 	 * `composer.composerData` row in ItemTable. Returns an empty list on any failure —
 	 * workspace-level errors do NOT abort the broader scan.
 	 */
 	private fun readAnchorComposerIds(wsHash: String): List<String> {
-		val wsDbPath = getWorkspaceStorageDir() + File.separator + wsHash + File.separator + "state.vscdb"
+		val wsDbPath = getVscodeWorkspaceStorageDir(VscodeFlavor.Cursor) +
+			File.separator + wsHash + File.separator + "state.vscdb"
 		if (!File(wsDbPath).isFile) {
 			log.debug("Cursor workspace DB not found at %s — skipping anchor extraction", wsDbPath)
 			return emptyList()
@@ -398,16 +333,4 @@ object CursorSupport {
 		}
 	}
 
-	/**
-	 * Normalises a filesystem path for workspace matching:
-	 *   - Backslashes → forward slashes (Windows path comparison)
-	 *   - Strip trailing slashes
-	 *   - Lowercase on macOS and Windows (case-insensitive filesystems)
-	 */
-	private fun normalizePathForMatch(p: String): String {
-		val fwd = p.replace('\\', '/')
-		val trimmed = fwd.trimEnd('/')
-		val osName = System.getProperty("os.name").lowercase()
-		return if (osName.contains("mac") || osName.contains("win")) trimmed.lowercase() else trimmed
-	}
 }

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/core/TranscriptParsers.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/core/TranscriptParsers.kt
@@ -57,5 +57,7 @@ fun getParserForSource(source: TranscriptSource): TranscriptParser {
         TranscriptSource.gemini -> ClaudeTranscriptParser() // Gemini uses dedicated reader
         TranscriptSource.opencode -> ClaudeTranscriptParser() // OpenCode uses dedicated reader
         TranscriptSource.cursor -> ClaudeTranscriptParser() // Cursor uses dedicated reader
+        TranscriptSource.copilot -> ClaudeTranscriptParser() // Copilot CLI uses dedicated reader
+        TranscriptSource.`copilot-chat` -> ClaudeTranscriptParser() // Copilot Chat uses dedicated reader
     }
 }

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/core/Types.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/core/Types.kt
@@ -7,7 +7,7 @@ package ai.jolli.jollimemory.core
  */
 
 /** Which AI coding agent produced the transcript */
-enum class TranscriptSource { claude, codex, gemini, opencode, cursor }
+enum class TranscriptSource { claude, codex, gemini, opencode, cursor, copilot, `copilot-chat` }
 
 /** Metadata about an AI coding session */
 data class SessionInfo(
@@ -293,6 +293,7 @@ data class JolliMemoryConfig(
     val geminiEnabled: Boolean? = null,
     val openCodeEnabled: Boolean? = null,
     val cursorEnabled: Boolean? = null,
+    val copilotEnabled: Boolean? = null,
     /** AI summarization provider: "jolli" (proxy) or "anthropic" (direct). null defers to legacy "Anthropic wins" routing. */
     val aiProvider: String? = null,
     val logLevel: String? = null,
@@ -375,6 +376,11 @@ data class StatusInfo(
     val cursorDetected: Boolean? = null,
     val cursorEnabled: Boolean? = null,
     val cursorScanError: SqliteScanError? = null,
+    val copilotDetected: Boolean? = null,
+    val copilotEnabled: Boolean? = null,
+    val copilotScanError: SqliteScanError? = null,
+    val copilotChatDetected: Boolean? = null,
+    val copilotChatScanError: CopilotChatScanError? = null,
 )
 
 /** Log levels */

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/core/VscodeWorkspaceLocator.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/core/VscodeWorkspaceLocator.kt
@@ -1,0 +1,110 @@
+package ai.jolli.jollimemory.core
+
+import com.google.gson.JsonParser
+import java.io.File
+import java.net.URI
+import java.nio.file.Paths
+
+/**
+ * VscodeWorkspaceLocator — per-platform path resolution and `workspace.json`
+ * scanning for VS Code-family user data directories.
+ *
+ * Used by both Cursor IDE (`flavor: Cursor`) and VS Code Copilot Chat
+ * (`flavor: Code`). Adding a new vscode fork (Insiders, Code-OSS, Windsurf, …)
+ * requires only extending [VscodeFlavor].
+ *
+ * Kotlin port of `cli/src/core/VscodeWorkspaceLocator.ts`.
+ */
+
+private val log = JmLogger.create("VscodeWorkspaceLocator")
+
+enum class VscodeFlavor(val dirName: String) {
+	Cursor("Cursor"),
+	Code("Code"),
+}
+
+/**
+ * Returns the VS Code-family user-data root for the current platform.
+ *
+ *   darwin   ~/Library/Application Support/<flavor>
+ *   linux    ~/.config/<flavor>
+ *   win32    %APPDATA%/<flavor>  (fallback to ~/AppData/Roaming/<flavor>)
+ */
+fun getVscodeUserDataDir(flavor: VscodeFlavor, home: String = System.getProperty("user.home")): String {
+	val osName = System.getProperty("os.name").lowercase()
+	return when {
+		osName.contains("mac") ->
+			home + File.separator + "Library" + File.separator + "Application Support" + File.separator + flavor.dirName
+		osName.contains("win") -> {
+			// `cursor.appdata.override` is a test hook: Java cannot unset env vars, so tests
+			// that need to redirect away from the real %APPDATA% set this system property instead.
+			val appData = if (flavor == VscodeFlavor.Cursor) System.getProperty("cursor.appdata.override") else null
+			(appData ?: System.getenv("APPDATA") ?: (home + File.separator + "AppData" + File.separator + "Roaming")) +
+				File.separator + flavor.dirName
+		}
+		else ->
+			home + File.separator + ".config" + File.separator + flavor.dirName
+	}
+}
+
+/** Returns the workspaceStorage dir for the given flavor. */
+fun getVscodeWorkspaceStorageDir(flavor: VscodeFlavor, home: String = System.getProperty("user.home")): String =
+	getVscodeUserDataDir(flavor, home) + File.separator + "User" + File.separator + "workspaceStorage"
+
+/**
+ * Normalises a filesystem path for workspace matching:
+ *   - Backslashes → forward slashes (Windows path comparison)
+ *   - Strip trailing slashes
+ *   - Lowercase on macOS and Windows (case-insensitive filesystems)
+ */
+fun normalizePathForMatch(p: String): String {
+	val fwd = p.replace('\\', '/')
+	val trimmed = fwd.trimEnd('/')
+	val osName = System.getProperty("os.name").lowercase()
+	return if (osName.contains("mac") || osName.contains("win")) trimmed.lowercase() else trimmed
+}
+
+/**
+ * Scans the workspaceStorage directory for an entry whose `workspace.json` has
+ * a `folder` URI that resolves to projectDir. Returns the entry name (workspace
+ * hash) on match, or null when no match is found.
+ *
+ * Single-folder workspaces only — entries with a `workspace` field instead of
+ * `folder` (multi-root .code-workspace files) are skipped silently.
+ */
+fun findVscodeWorkspaceHash(flavor: VscodeFlavor, projectDir: String): String? {
+	val wsStorageDir = File(getVscodeWorkspaceStorageDir(flavor))
+	if (!wsStorageDir.isDirectory) {
+		log.debug("%s workspaceStorage not readable at %s", flavor, wsStorageDir.path)
+		return null
+	}
+
+	val target = normalizePathForMatch(projectDir)
+	val entries = wsStorageDir.listFiles() ?: return null
+
+	for (entry in entries) {
+		val wsJson = File(entry, "workspace.json")
+		if (!wsJson.isFile) continue
+
+		val folderUri = try {
+			JsonParser.parseString(wsJson.readText()).asJsonObject
+				.get("folder")?.takeIf { it.isJsonPrimitive }?.asString
+		} catch (_: Exception) {
+			continue
+		} ?: continue
+
+		if (!folderUri.startsWith("file://")) continue
+
+		val folderPath = try {
+			Paths.get(URI(folderUri)).toString()
+		} catch (_: Exception) {
+			log.warn("%s workspace %s has unparseable folder URI: %s", flavor, entry.name, folderUri)
+			continue
+		}
+
+		if (normalizePathForMatch(folderPath) == target) {
+			return entry.name
+		}
+	}
+	return null
+}

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/hooks/PostCommitHook.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/hooks/PostCommitHook.kt
@@ -163,6 +163,16 @@ object PostCommitHook {
                 allSessions.addAll(CursorSupport.discoverSessions(cwd).sessions)
             }
 
+            // On-demand discovery: Copilot CLI (SQLite-backed, no hook)
+            if (config.copilotEnabled != false && CopilotSupport.isCopilotInstalled()) {
+                allSessions.addAll(CopilotSupport.discoverSessions(cwd).sessions)
+            }
+
+            // On-demand discovery: Copilot Chat (JSONL-backed, no hook) — shares copilotEnabled with the CLI source
+            if (config.copilotEnabled != false && CopilotChatSupport.isCopilotChatInstalled()) {
+                allSessions.addAll(CopilotChatSupport.discoverSessions(cwd).sessions)
+            }
+
             val sessions = allSessions
             log.info("Discovered %d session(s): %s", sessions.size,
                 sessions.joinToString(", ") { "${it.source ?: "claude"}:${it.sessionId.take(8)}" })
@@ -192,6 +202,12 @@ object PostCommitHook {
                         }
                         TranscriptSource.cursor -> {
                             CursorSupport.readTranscript(session.transcriptPath, cursor, commitInfo.date)
+                        }
+                        TranscriptSource.copilot -> {
+                            CopilotSupport.readTranscript(session.transcriptPath, cursor, commitInfo.date)
+                        }
+                        TranscriptSource.`copilot-chat` -> {
+                            CopilotChatSupport.readTranscript(session.transcriptPath, cursor, commitInfo.date)
                         }
                         else -> {
                             val parser = getParserForSource(source)

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/JolliMemoryToolWindowFactory.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/JolliMemoryToolWindowFactory.kt
@@ -595,6 +595,28 @@ private class StatusIndicatorLabel(
                 sb.append("<p><span style='color:#3FB950'>\u25CF</span> <b>Cursor:</b> detected</p>")
             }
         }
+        if (status.copilotDetected == true) {
+            val scanError = status.copilotScanError
+            if (scanError != null) {
+                val msg = scanError.message.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+                sb.append("<p><span style='color:#F85149'>\u25CF</span> <b>Copilot CLI:</b> unavailable \u2014 ${scanError.kind}<br/><span style='color:gray'>$msg</span></p>")
+            } else if (status.copilotEnabled == false) {
+                sb.append("<p><span style='color:#D29922'>\u25CF</span> <b>Copilot CLI:</b> detected but disabled</p>")
+            } else {
+                sb.append("<p><span style='color:#3FB950'>\u25CF</span> <b>Copilot CLI:</b> detected</p>")
+            }
+        }
+        if (status.copilotChatDetected == true) {
+            val scanError = status.copilotChatScanError
+            if (scanError != null) {
+                val msg = scanError.message.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+                sb.append("<p><span style='color:#F85149'>\u25CF</span> <b>Copilot Chat:</b> unavailable \u2014 ${scanError.kind}<br/><span style='color:gray'>$msg</span></p>")
+            } else if (status.copilotEnabled == false) {
+                sb.append("<p><span style='color:#D29922'>\u25CF</span> <b>Copilot Chat:</b> detected but disabled</p>")
+            } else {
+                sb.append("<p><span style='color:#3FB950'>\u25CF</span> <b>Copilot Chat:</b> detected</p>")
+            }
+        }
 
         // Error
         val err = service.lastError

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/SettingsDialog.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/SettingsDialog.kt
@@ -95,6 +95,7 @@ class SettingsDialog(
     private val geminiEnabledCheckbox = JBCheckBox("Gemini CLI — Session tracking via AfterAgent hook", true)
     private val openCodeEnabledCheckbox = JBCheckBox("OpenCode — Session discovery via SQLite database scan", true)
     private val cursorEnabledCheckbox = JBCheckBox("Cursor IDE — Composer session discovery via SQLite database scan", true)
+    private val copilotEnabledCheckbox = JBCheckBox("GitHub Copilot — CLI session-store scan + VS Code Chat workspace storage", true)
     private val excludePatternsField = JBTextField()
     private val pauseCheckbox = JBCheckBox("Pause Jolli Memory (temporarily disable hooks without losing configuration)")
 
@@ -167,6 +168,7 @@ class SettingsDialog(
             .addComponent(geminiEnabledCheckbox, 4)
             .addComponent(openCodeEnabledCheckbox, 4)
             .addComponent(cursorEnabledCheckbox, 4)
+            .addComponent(copilotEnabledCheckbox, 4)
             .panel))
 
         return wrapTabContent(panel)
@@ -577,7 +579,7 @@ class SettingsDialog(
 
         if (!claudeEnabledCheckbox.isSelected && !codexEnabledCheckbox.isSelected &&
             !geminiEnabledCheckbox.isSelected && !openCodeEnabledCheckbox.isSelected &&
-            !cursorEnabledCheckbox.isSelected
+            !cursorEnabledCheckbox.isSelected && !copilotEnabledCheckbox.isSelected
         ) {
             return ValidationInfo("At least one platform must be enabled", claudeEnabledCheckbox)
         }
@@ -639,6 +641,7 @@ class SettingsDialog(
             geminiEnabled = geminiEnabledCheckbox.isSelected,
             openCodeEnabled = openCodeEnabledCheckbox.isSelected,
             cursorEnabled = cursorEnabledCheckbox.isSelected,
+            copilotEnabled = copilotEnabledCheckbox.isSelected,
             excludePatterns = if (excludePatterns.isNotEmpty()) excludePatterns else null,
             aiProvider = provider,
             knowledgeBasePath = kbPath,
@@ -739,6 +742,7 @@ class SettingsDialog(
         geminiEnabledCheckbox.isSelected = config.geminiEnabled != false
         openCodeEnabledCheckbox.isSelected = config.openCodeEnabled != false
         cursorEnabledCheckbox.isSelected = config.cursorEnabled != false
+        copilotEnabledCheckbox.isSelected = config.copilotEnabled != false
         pauseCheckbox.isSelected = config.paused == true
 
         // Memory Bank

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/StatusPanel.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/StatusPanel.kt
@@ -2,6 +2,8 @@ package ai.jolli.jollimemory.toolwindow
 
 import ai.jolli.jollimemory.JolliMemoryIcons
 import ai.jolli.jollimemory.core.CodexSessionDiscoverer
+import ai.jolli.jollimemory.core.CopilotChatSupport
+import ai.jolli.jollimemory.core.CopilotSupport
 import ai.jolli.jollimemory.core.GeminiSupport
 import ai.jolli.jollimemory.core.CursorSupport
 import ai.jolli.jollimemory.core.OpenCodeSupport
@@ -250,6 +252,41 @@ class StatusPanel(
                     hookMissingTooltip = null,
                 )
             }
+        }
+
+        // 11. Copilot Integration (no hooks needed — covers both CLI and VS Code Chat under one toggle)
+        val copilotCliDetected = status.copilotDetected ?: CopilotSupport.isCopilotInstalled()
+        val copilotChatDetected = status.copilotChatDetected ?: CopilotChatSupport.isCopilotChatInstalled()
+        val copilotScanError = status.copilotScanError
+        val copilotChatScanError = status.copilotChatScanError
+        if (copilotScanError != null) {
+            listModel.addElement(StatusRow(
+                Icon.WARN,
+                "Copilot Integration",
+                "unavailable — ${copilotScanError.kind}",
+                "Copilot CLI DB scan failed (${copilotScanError.kind}): ${copilotScanError.message}",
+            ))
+        }
+        if (copilotChatScanError != null) {
+            listModel.addElement(StatusRow(
+                Icon.WARN,
+                "Copilot Chat",
+                "unavailable — ${copilotChatScanError.kind}",
+                "Copilot Chat scan failed (${copilotChatScanError.kind}): ${copilotChatScanError.message}",
+            ))
+        }
+        if (copilotCliDetected || copilotChatDetected) {
+            val enabled = config.copilotEnabled != false
+            val cliMark = if (copilotCliDetected) "✓" else "✗"
+            val chatMark = if (copilotChatDetected) "✓" else "✗"
+            addIntegrationRow(
+                enabled = enabled,
+                hookInstalled = null,
+                label = "Copilot Integration",
+                enabledTooltip = "GitHub Copilot detected (CLI: $cliMark, Chat: $chatMark) — session discovery is enabled",
+                disabledTooltip = "GitHub Copilot detected (CLI: $cliMark, Chat: $chatMark) but session discovery is disabled in config",
+                hookMissingTooltip = null,
+            )
         }
 
         add(JBScrollPane(statusList), BorderLayout.CENTER)

--- a/intellij/src/test/kotlin/ai/jolli/jollimemory/core/CopilotChatSupportTest.kt
+++ b/intellij/src/test/kotlin/ai/jolli/jollimemory/core/CopilotChatSupportTest.kt
@@ -1,0 +1,322 @@
+package ai.jolli.jollimemory.core
+
+import com.google.gson.JsonArray
+import com.google.gson.JsonObject
+import com.google.gson.JsonParser
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+
+class CopilotChatSupportTest {
+
+	private var originalHome: String? = null
+
+	@BeforeEach
+	fun setup() {
+		originalHome = System.getProperty("user.home")
+	}
+
+	@AfterEach
+	fun teardown() {
+		originalHome?.let { System.setProperty("user.home", it) }
+	}
+
+	/**
+	 * Builds a `file:///...` URI matching what VS Code actually writes in workspace.json.
+	 * [File.toURI] returns `file:/path` (no authority) which fails the `file://` prefix check.
+	 */
+	private fun fileUri(f: File): String {
+		val abs = f.absolutePath.replace('\\', '/')
+		return if (abs.startsWith("/")) "file://$abs" else "file:///$abs"
+	}
+
+	/** Returns the platform-correct VS Code user-data dir under the given home. */
+	private fun codeUserDataDir(home: File): File {
+		val osName = System.getProperty("os.name").lowercase()
+		return when {
+			osName.contains("mac") -> File(home, "Library/Application Support/Code")
+			osName.contains("win") -> File(home, "AppData/Roaming/Code")
+			else -> File(home, ".config/Code")
+		}
+	}
+
+	/** Creates ~/.copilot/session-state/<sid>/ with vscode.metadata.json and events.jsonl. */
+	private fun setupSessionState(
+		home: File,
+		sid: String,
+		folderPath: String,
+		events: List<String>,
+	): File {
+		val sessionDir = File(home, ".copilot/session-state/$sid").also { it.mkdirs() }
+		File(sessionDir, "vscode.metadata.json").writeText(
+			"""{"workspaceFolder": {"folderPath": "${folderPath.replace("\\", "\\\\")}"}}"""
+		)
+		val eventsFile = File(sessionDir, "events.jsonl")
+		eventsFile.writeText(events.joinToString("\n"))
+		return eventsFile
+	}
+
+	/** Creates VS Code's workspaceStorage/<hash>/chatSessions/<sid>.jsonl with patch-log content. */
+	private fun setupChatSessions(
+		home: File,
+		projectDir: File,
+		hash: String,
+		sid: String,
+		patchLines: List<String>,
+	): File {
+		val ws = File(codeUserDataDir(home), "User/workspaceStorage/$hash").also { it.mkdirs() }
+		File(ws, "workspace.json").writeText("""{"folder": "${fileUri(projectDir)}"}""")
+		val chatDir = File(ws, "chatSessions").also { it.mkdirs() }
+		val file = File(chatDir, "$sid.jsonl")
+		file.writeText(patchLines.joinToString("\n"))
+		return file
+	}
+
+	@Nested
+	inner class Detection {
+
+		@Test
+		fun `false when neither root exists`(@TempDir home: File) {
+			System.setProperty("user.home", home.absolutePath)
+			CopilotChatSupport.isCopilotChatInstalled() shouldBe false
+		}
+
+		@Test
+		fun `true when session-state dir exists`(@TempDir home: File) {
+			System.setProperty("user.home", home.absolutePath)
+			File(home, ".copilot/session-state").mkdirs()
+			CopilotChatSupport.isCopilotChatInstalled() shouldBe true
+		}
+
+		@Test
+		fun `true when github_copilot-chat globalStorage exists`(@TempDir home: File) {
+			System.setProperty("user.home", home.absolutePath)
+			File(codeUserDataDir(home), "User/globalStorage/github.copilot-chat").mkdirs()
+			CopilotChatSupport.isCopilotChatInstalled() shouldBe true
+		}
+	}
+
+	@Nested
+	inner class ScanSessionState {
+
+		@Test
+		fun `picks events_jsonl whose metadata folderPath matches`(@TempDir home: File, @TempDir projectDir: File) {
+			System.setProperty("user.home", home.absolutePath)
+			val events = listOf(
+				"""{"type":"user.message","timestamp":"2026-05-01T00:00:00Z","data":{"content":"hi"}}""",
+			)
+			setupSessionState(home, "sid-1", projectDir.absolutePath, events)
+			val sessions = CopilotChatSupport.discoverSessions(projectDir.absolutePath).sessions
+			sessions.shouldHaveSize(1)
+			sessions[0].sessionId shouldBe "sid-1"
+			sessions[0].source shouldBe TranscriptSource.`copilot-chat`
+		}
+
+		@Test
+		fun `skips events_jsonl whose folderPath does not match`(@TempDir home: File, @TempDir projectDir: File, @TempDir otherDir: File) {
+			System.setProperty("user.home", home.absolutePath)
+			setupSessionState(home, "wrong", otherDir.absolutePath, listOf("""{"type":"x"}"""))
+			CopilotChatSupport.discoverSessions(projectDir.absolutePath).sessions.shouldBeEmpty()
+		}
+
+		@Test
+		fun `skips sessions with malformed metadata`(@TempDir home: File, @TempDir projectDir: File) {
+			System.setProperty("user.home", home.absolutePath)
+			val sessionDir = File(home, ".copilot/session-state/bad").also { it.mkdirs() }
+			File(sessionDir, "vscode.metadata.json").writeText("not json")
+			File(sessionDir, "events.jsonl").writeText("")
+			CopilotChatSupport.discoverSessions(projectDir.absolutePath).sessions.shouldBeEmpty()
+		}
+	}
+
+	@Nested
+	inner class ScanChatSessions {
+
+		@Test
+		fun `picks chatSessions_jsonl under matched workspace hash`(@TempDir home: File, @TempDir projectDir: File) {
+			System.setProperty("user.home", home.absolutePath)
+			setupChatSessions(home, projectDir, "hash-A", "sid-2", listOf("""{"kind":0,"v":{}}"""))
+			val sessions = CopilotChatSupport.discoverSessions(projectDir.absolutePath).sessions
+			sessions.shouldHaveSize(1)
+			sessions[0].sessionId shouldBe "sid-2"
+		}
+
+		@Test
+		fun `skips _json snapshot files`(@TempDir home: File, @TempDir projectDir: File) {
+			System.setProperty("user.home", home.absolutePath)
+			val ws = File(codeUserDataDir(home), "User/workspaceStorage/h").also { it.mkdirs() }
+			File(ws, "workspace.json").writeText("""{"folder": "${fileUri(projectDir)}"}""")
+			val chatDir = File(ws, "chatSessions").also { it.mkdirs() }
+			File(chatDir, "snap.json").writeText("{}") // deprecated snapshot — must be ignored
+			CopilotChatSupport.discoverSessions(projectDir.absolutePath).sessions.shouldBeEmpty()
+		}
+	}
+
+	@Nested
+	inner class ReadEventsJsonl {
+
+		@Test
+		fun `picks user_message and assistant_message, skips other types`(@TempDir home: File, @TempDir projectDir: File) {
+			System.setProperty("user.home", home.absolutePath)
+			val events = listOf(
+				"""{"type":"user.message","timestamp":"2026-05-01T00:00:00Z","data":{"content":"q"}}""",
+				"""{"type":"tool.call","timestamp":"2026-05-01T00:00:01Z","data":{"content":"ignored"}}""",
+				"""{"type":"assistant.message","timestamp":"2026-05-01T00:00:02Z","data":{"content":"a"}}""",
+			)
+			val eventsFile = setupSessionState(home, "sid", projectDir.absolutePath, events)
+			val result = CopilotChatSupport.readTranscript(eventsFile.absolutePath, null)
+			result.entries.shouldHaveSize(2)
+			result.entries[0].role shouldBe "human"
+			result.entries[0].content shouldBe "q"
+			result.entries[1].role shouldBe "assistant"
+			result.entries[1].content shouldBe "a"
+		}
+
+		@Test
+		fun `malformed line skipped but cursor advances`(@TempDir home: File, @TempDir projectDir: File) {
+			System.setProperty("user.home", home.absolutePath)
+			val events = listOf(
+				"not json",
+				"""{"type":"user.message","timestamp":"2026-05-01T00:00:00Z","data":{"content":"q"}}""",
+			)
+			val eventsFile = setupSessionState(home, "sid", projectDir.absolutePath, events)
+			val result = CopilotChatSupport.readTranscript(eventsFile.absolutePath, null)
+			result.entries.shouldHaveSize(1)
+			result.newCursor.lineNumber shouldBe 2
+		}
+
+		@Test
+		fun `beforeTimestamp gate defers events past cutoff`(@TempDir home: File, @TempDir projectDir: File) {
+			System.setProperty("user.home", home.absolutePath)
+			val events = listOf(
+				"""{"type":"user.message","timestamp":"2026-05-01T00:00:00Z","data":{"content":"before"}}""",
+				"""{"type":"assistant.message","timestamp":"2026-05-01T01:00:00Z","data":{"content":"after"}}""",
+			)
+			val eventsFile = setupSessionState(home, "sid", projectDir.absolutePath, events)
+			val result = CopilotChatSupport.readTranscript(
+				eventsFile.absolutePath,
+				null,
+				beforeTimestamp = "2026-05-01T00:30:00Z",
+			)
+			result.entries.shouldHaveSize(1)
+			result.entries[0].content shouldBe "before"
+			result.newCursor.lineNumber shouldBe 1
+		}
+	}
+
+	@Nested
+	inner class ReadPatchLog {
+
+		@Test
+		fun `replays requests array into entries`(@TempDir home: File, @TempDir projectDir: File) {
+			System.setProperty("user.home", home.absolutePath)
+			val patch = listOf(
+				"""{"kind":0,"v":{"requests":[{"message":{"text":"q1"},"response":[{"value":"a1"}],"timestamp":1700000000000}]}}""",
+				"""{"kind":1,"k":["requests",1],"v":{"message":{"text":"q2"},"response":[{"value":"a2"}],"timestamp":1700000060000}}""",
+			)
+			val file = setupChatSessions(home, projectDir, "h", "sid", patch)
+			val result = CopilotChatSupport.readTranscript(file.absolutePath, null)
+			result.entries.shouldHaveSize(4)
+			result.entries[0].content shouldBe "q1"
+			result.entries[1].content shouldBe "a1"
+			result.entries[2].content shouldBe "q2"
+			result.entries[3].content shouldBe "a2"
+		}
+
+		@Test
+		fun `cursor resumption skips already-consumed requests`(@TempDir home: File, @TempDir projectDir: File) {
+			System.setProperty("user.home", home.absolutePath)
+			val patch = listOf(
+				"""{"kind":0,"v":{"requests":[{"message":{"text":"q1"},"response":[{"value":"a1"}]},{"message":{"text":"q2"},"response":[{"value":"a2"}]}]}}""",
+			)
+			val file = setupChatSessions(home, projectDir, "h", "sid", patch)
+			val cursor = TranscriptCursor(file.absolutePath, 1, "")
+			val result = CopilotChatSupport.readTranscript(file.absolutePath, cursor)
+			result.entries.shouldHaveSize(2)
+			result.entries[0].content shouldBe "q2"
+		}
+	}
+
+	@Nested
+	inner class PatchReplayPrimitives {
+
+		private fun arr(vararg segs: Any): JsonArray = JsonArray().apply {
+			for (s in segs) when (s) {
+				is String -> add(s)
+				is Int -> add(s)
+				else -> error("bad segment type")
+			}
+		}
+
+		@Test
+		fun `kind 0 replaces root`() {
+			val lines = listOf("""{"kind":0,"v":{"requests":[]}}""")
+			val doc = CopilotChatSupport.replayPatches(lines) as JsonObject
+			doc.getAsJsonArray("requests").size() shouldBe 0
+		}
+
+		@Test
+		fun `kind 1 sets value at nested path, creating intermediates`() {
+			val doc = JsonObject()
+			val v = JsonParser.parseString(""""hello"""")
+			CopilotChatSupport.setAtPath(doc, arr("a", "b", "c"), v)
+			(doc.getAsJsonObject("a").getAsJsonObject("b").get("c").asString) shouldBe "hello"
+		}
+
+		@Test
+		fun `kind 1 creates array when next segment is numeric`() {
+			val doc = JsonObject()
+			val v = JsonParser.parseString("""{"x":1}""")
+			CopilotChatSupport.setAtPath(doc, arr("items", 0, "x"), JsonParser.parseString("42"))
+			doc.getAsJsonArray("items")[0].asJsonObject.get("x").asInt shouldBe 42
+		}
+
+		@Test
+		fun `kind 2 removes object key`() {
+			val doc = JsonParser.parseString("""{"a":{"b":1,"c":2}}""").asJsonObject
+			CopilotChatSupport.deleteAtPath(doc, arr("a", "b"))
+			doc.getAsJsonObject("a").has("b") shouldBe false
+			doc.getAsJsonObject("a").has("c") shouldBe true
+		}
+
+		@Test
+		fun `kind 2 splices array elements`() {
+			val doc = JsonParser.parseString("""{"items":["a","b","c"]}""").asJsonObject
+			CopilotChatSupport.deleteAtPath(doc, arr("items", 1))
+			val items = doc.getAsJsonArray("items")
+			items.size() shouldBe 2
+			items[0].asString shouldBe "a"
+			items[1].asString shouldBe "c"
+		}
+
+		@Test
+		fun `kind 2 is no-op for non-existent path`() {
+			val doc = JsonParser.parseString("""{"a":1}""").asJsonObject
+			CopilotChatSupport.deleteAtPath(doc, arr("missing", "nested"))
+			doc.get("a").asInt shouldBe 1
+		}
+	}
+
+	@Nested
+	inner class Dispatch {
+
+		@Test
+		fun `unrecognized path throws`() {
+			val ex = try {
+				CopilotChatSupport.readTranscript("/random/path.txt", null)
+				null
+			} catch (e: Exception) {
+				e
+			}
+			ex.shouldNotBeNull()
+		}
+	}
+}

--- a/intellij/src/test/kotlin/ai/jolli/jollimemory/core/CopilotSupportTest.kt
+++ b/intellij/src/test/kotlin/ai/jolli/jollimemory/core/CopilotSupportTest.kt
@@ -1,0 +1,267 @@
+package ai.jolli.jollimemory.core
+
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import java.sql.Connection
+import java.sql.DriverManager
+import java.time.Instant
+
+class CopilotSupportTest {
+
+	private var originalHome: String? = null
+
+	@BeforeEach
+	fun setup() {
+		originalHome = System.getProperty("user.home")
+	}
+
+	@AfterEach
+	fun teardown() {
+		originalHome?.let { System.setProperty("user.home", it) }
+	}
+
+	/** Creates the ~/.copilot/session-store.db with Copilot's schema and seeded rows. */
+	private fun createCopilotDb(home: File): File {
+		val dbFile = File(home, ".copilot/session-store.db")
+		dbFile.parentFile.mkdirs()
+		DriverManager.getConnection("jdbc:sqlite:${dbFile.absolutePath}").use { conn ->
+			conn.createStatement().use { st ->
+				st.execute("""
+					CREATE TABLE sessions (
+						id TEXT PRIMARY KEY,
+						cwd TEXT NOT NULL,
+						repository TEXT,
+						branch TEXT,
+						host_type TEXT,
+						summary TEXT,
+						created_at TEXT,
+						updated_at TEXT
+					)
+				""".trimIndent())
+				st.execute("""
+					CREATE TABLE turns (
+						session_id TEXT NOT NULL,
+						turn_index INTEGER NOT NULL,
+						user_message TEXT,
+						assistant_response TEXT,
+						timestamp TEXT,
+						PRIMARY KEY (session_id, turn_index)
+					)
+				""".trimIndent())
+			}
+		}
+		return dbFile
+	}
+
+	private fun insertSession(
+		dbFile: File,
+		id: String,
+		cwd: String,
+		updatedAt: String,
+		summary: String? = null,
+	) {
+		DriverManager.getConnection("jdbc:sqlite:${dbFile.absolutePath}").use { conn ->
+			conn.prepareStatement(
+				"INSERT INTO sessions(id, cwd, updated_at, summary) VALUES (?, ?, ?, ?)"
+			).use { ps ->
+				ps.setString(1, id)
+				ps.setString(2, cwd)
+				ps.setString(3, updatedAt)
+				ps.setString(4, summary)
+				ps.executeUpdate()
+			}
+		}
+	}
+
+	private fun insertTurn(
+		dbFile: File,
+		sessionId: String,
+		turnIndex: Int,
+		userMessage: String?,
+		assistantResponse: String?,
+		timestamp: String? = null,
+	) {
+		DriverManager.getConnection("jdbc:sqlite:${dbFile.absolutePath}").use { conn ->
+			conn.prepareStatement(
+				"INSERT INTO turns(session_id, turn_index, user_message, assistant_response, timestamp) VALUES (?, ?, ?, ?, ?)"
+			).use { ps ->
+				ps.setString(1, sessionId)
+				ps.setInt(2, turnIndex)
+				ps.setString(3, userMessage)
+				ps.setString(4, assistantResponse)
+				ps.setString(5, timestamp)
+				ps.executeUpdate()
+			}
+		}
+	}
+
+	@Nested
+	inner class Detection {
+
+		@Test
+		fun `isCopilotInstalled false when DB missing`(@TempDir home: File) {
+			System.setProperty("user.home", home.absolutePath)
+			CopilotSupport.isCopilotInstalled() shouldBe false
+		}
+
+		@Test
+		fun `isCopilotInstalled true when DB present`(@TempDir home: File) {
+			System.setProperty("user.home", home.absolutePath)
+			createCopilotDb(home)
+			CopilotSupport.isCopilotInstalled() shouldBe true
+		}
+	}
+
+	@Nested
+	inner class DiscoverSessions {
+
+		@Test
+		fun `returns empty when DB missing`(@TempDir home: File, @TempDir projectDir: File) {
+			System.setProperty("user.home", home.absolutePath)
+			val result = CopilotSupport.discoverSessions(projectDir.absolutePath)
+			result.sessions.shouldBeEmpty()
+			result.error shouldBe null
+		}
+
+		@Test
+		fun `finds session matching cwd`(@TempDir home: File, @TempDir projectDir: File) {
+			System.setProperty("user.home", home.absolutePath)
+			val db = createCopilotDb(home)
+			val recent = Instant.now().toString()
+			insertSession(db, "s-1", projectDir.absolutePath, recent)
+
+			val result = CopilotSupport.discoverSessions(projectDir.absolutePath)
+			result.sessions.shouldHaveSize(1)
+			result.sessions[0].sessionId shouldBe "s-1"
+			result.sessions[0].source shouldBe TranscriptSource.copilot
+			result.sessions[0].transcriptPath shouldBe "${db.absolutePath}#s-1"
+		}
+
+		@Test
+		fun `excludes sessions older than 48 hours`(@TempDir home: File, @TempDir projectDir: File) {
+			System.setProperty("user.home", home.absolutePath)
+			val db = createCopilotDb(home)
+			val old = Instant.now().minusSeconds(49 * 60 * 60).toString()
+			insertSession(db, "stale", projectDir.absolutePath, old)
+			CopilotSupport.discoverSessions(projectDir.absolutePath).sessions.shouldBeEmpty()
+		}
+
+		@Test
+		fun `case-insensitive cwd match on darwin and win32`(@TempDir home: File, @TempDir projectDir: File) {
+			System.setProperty("user.home", home.absolutePath)
+			val db = createCopilotDb(home)
+			val recent = Instant.now().toString()
+			val osName = System.getProperty("os.name").lowercase()
+			val storedCwd = if (osName.contains("mac") || osName.contains("win")) {
+				projectDir.absolutePath.uppercase()
+			} else projectDir.absolutePath
+			insertSession(db, "s-1", storedCwd, recent)
+
+			val sessions = CopilotSupport.discoverSessions(projectDir.absolutePath).sessions
+			sessions.shouldHaveSize(1)
+		}
+
+		@Test
+		fun `skips sessions with unparseable updated_at`(@TempDir home: File, @TempDir projectDir: File) {
+			System.setProperty("user.home", home.absolutePath)
+			val db = createCopilotDb(home)
+			insertSession(db, "bad", projectDir.absolutePath, "not-a-date")
+			CopilotSupport.discoverSessions(projectDir.absolutePath).sessions.shouldBeEmpty()
+		}
+	}
+
+	@Nested
+	inner class ReadTranscript {
+
+		@Test
+		fun `expands turn rows into human-assistant pairs`(@TempDir home: File, @TempDir projectDir: File) {
+			System.setProperty("user.home", home.absolutePath)
+			val db = createCopilotDb(home)
+			val recent = Instant.now().toString()
+			insertSession(db, "s-1", projectDir.absolutePath, recent)
+			insertTurn(db, "s-1", 0, "hello", "hi there", recent)
+			insertTurn(db, "s-1", 1, "another q", "another a", recent)
+
+			val result = CopilotSupport.readTranscript("${db.absolutePath}#s-1", null)
+			result.entries.shouldHaveSize(4)
+			result.entries[0].role shouldBe "human"
+			result.entries[0].content shouldBe "hello"
+			result.entries[1].role shouldBe "assistant"
+			result.entries[2].role shouldBe "human"
+			result.entries[3].role shouldBe "assistant"
+		}
+
+		@Test
+		fun `skips empty messages`(@TempDir home: File, @TempDir projectDir: File) {
+			System.setProperty("user.home", home.absolutePath)
+			val db = createCopilotDb(home)
+			val recent = Instant.now().toString()
+			insertSession(db, "s-1", projectDir.absolutePath, recent)
+			insertTurn(db, "s-1", 0, "user only", null, recent)
+			insertTurn(db, "s-1", 1, null, "assistant only", recent)
+			insertTurn(db, "s-1", 2, "", "  ", recent)
+
+			val result = CopilotSupport.readTranscript("${db.absolutePath}#s-1", null)
+			result.entries.shouldHaveSize(2)
+			result.entries[0].role shouldBe "human"
+			result.entries[0].content shouldBe "user only"
+			result.entries[1].role shouldBe "assistant"
+			result.entries[1].content shouldBe "assistant only"
+		}
+
+		@Test
+		fun `cursor resumption skips already-consumed turns`(@TempDir home: File, @TempDir projectDir: File) {
+			System.setProperty("user.home", home.absolutePath)
+			val db = createCopilotDb(home)
+			val recent = Instant.now().toString()
+			insertSession(db, "s-1", projectDir.absolutePath, recent)
+			insertTurn(db, "s-1", 0, "first", "ok", recent)
+			insertTurn(db, "s-1", 1, "second", "yep", recent)
+
+			val transcriptPath = "${db.absolutePath}#s-1"
+			val cursor = TranscriptCursor(transcriptPath, 1, recent) // first turn already consumed
+			val result = CopilotSupport.readTranscript(transcriptPath, cursor)
+			result.entries.shouldHaveSize(2) // second turn → 2 entries
+			result.entries[0].content shouldBe "second"
+		}
+
+		@Test
+		fun `beforeTimestamp stops at first turn past cutoff`(@TempDir home: File, @TempDir projectDir: File) {
+			System.setProperty("user.home", home.absolutePath)
+			val db = createCopilotDb(home)
+			val base = Instant.parse("2026-01-01T00:00:00Z")
+			insertSession(db, "s-1", projectDir.absolutePath, Instant.now().toString())
+			insertTurn(db, "s-1", 0, "before", "ok", base.toString())
+			insertTurn(db, "s-1", 1, "after", "no", base.plusSeconds(3600).toString())
+
+			val result = CopilotSupport.readTranscript(
+				"${db.absolutePath}#s-1",
+				null,
+				beforeTimestamp = base.plusSeconds(1800).toString(),
+			)
+			result.entries.shouldHaveSize(2) // only the "before" turn
+			result.entries[0].content shouldBe "before"
+		}
+
+		@Test
+		fun `throws on missing synthetic separator`(@TempDir home: File) {
+			System.setProperty("user.home", home.absolutePath)
+			createCopilotDb(home)
+			val ex = try {
+				CopilotSupport.readTranscript("no-hash-here", null)
+				null
+			} catch (e: Exception) {
+				e
+			}
+			ex.shouldNotBeNull()
+		}
+	}
+}

--- a/intellij/src/test/kotlin/ai/jolli/jollimemory/core/TypesTest.kt
+++ b/intellij/src/test/kotlin/ai/jolli/jollimemory/core/TypesTest.kt
@@ -10,7 +10,7 @@ class TypesTest {
     inner class Enums {
         @Test
         fun `TranscriptSource has correct values`() {
-            TranscriptSource.entries.map { it.name } shouldBe listOf("claude", "codex", "gemini", "opencode", "cursor")
+            TranscriptSource.entries.map { it.name } shouldBe listOf("claude", "codex", "gemini", "opencode", "cursor", "copilot", "copilot-chat")
         }
 
         @Test

--- a/intellij/src/test/kotlin/ai/jolli/jollimemory/core/VscodeWorkspaceLocatorTest.kt
+++ b/intellij/src/test/kotlin/ai/jolli/jollimemory/core/VscodeWorkspaceLocatorTest.kt
@@ -1,0 +1,165 @@
+package ai.jolli.jollimemory.core
+
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+
+class VscodeWorkspaceLocatorTest {
+
+	private var originalHome: String? = null
+
+	@BeforeEach
+	fun setup() {
+		originalHome = System.getProperty("user.home")
+	}
+
+	@AfterEach
+	fun teardown() {
+		originalHome?.let { System.setProperty("user.home", it) }
+	}
+
+	/** Returns the platform-correct user-data dir for a flavor under the given home. */
+	private fun userDataDir(home: File, dirName: String): File {
+		val osName = System.getProperty("os.name").lowercase()
+		return when {
+			osName.contains("mac") -> File(home, "Library/Application Support/$dirName")
+			osName.contains("win") -> File(home, "AppData/Roaming/$dirName")
+			else -> File(home, ".config/$dirName")
+		}
+	}
+
+	private fun setupWorkspaceStorage(home: File, flavor: VscodeFlavor): File {
+		val wsStorage = File(userDataDir(home, flavor.dirName), "User/workspaceStorage")
+		wsStorage.mkdirs()
+		return wsStorage
+	}
+
+	private fun writeWorkspaceJson(wsHashDir: File, folderUri: String) {
+		wsHashDir.mkdirs()
+		File(wsHashDir, "workspace.json").writeText("""{"folder": "$folderUri"}""")
+	}
+
+	/**
+	 * Builds a `file:///...` URI matching what VS Code/Cursor actually writes in
+	 * workspace.json. [File.toURI] returns `file:/path` (single slash, no authority)
+	 * which doesn't match the `file://` prefix check in production code.
+	 */
+	private fun fileUri(f: File): String {
+		val abs = f.absolutePath.replace('\\', '/')
+		return if (abs.startsWith("/")) "file://$abs" else "file:///$abs"
+	}
+
+	@Nested
+	inner class PathResolution {
+
+		@Test
+		fun `getVscodeUserDataDir returns flavor-specific path`(@TempDir tempHome: File) {
+			System.setProperty("user.home", tempHome.absolutePath)
+			val cursorDir = getVscodeUserDataDir(VscodeFlavor.Cursor)
+			val codeDir = getVscodeUserDataDir(VscodeFlavor.Code)
+			(cursorDir != codeDir) shouldBe true
+			cursorDir.endsWith("Cursor") shouldBe true
+			codeDir.endsWith("Code") shouldBe true
+		}
+
+		@Test
+		fun `getVscodeWorkspaceStorageDir appends User-workspaceStorage`() {
+			val storage = getVscodeWorkspaceStorageDir(VscodeFlavor.Code)
+			storage.endsWith("User${File.separator}workspaceStorage") shouldBe true
+		}
+	}
+
+	@Nested
+	inner class NormalizePathForMatch {
+
+		@Test
+		fun `converts backslashes to forward slashes`() {
+			normalizePathForMatch("C:\\Users\\me\\proj").contains("\\") shouldBe false
+		}
+
+		@Test
+		fun `strips trailing slashes`() {
+			val osName = System.getProperty("os.name").lowercase()
+			val expected = if (osName.contains("mac") || osName.contains("win")) "/foo/bar" else "/foo/bar"
+			normalizePathForMatch("/foo/bar///") shouldBe expected
+		}
+
+		@Test
+		fun `lowercases on case-insensitive platforms`() {
+			val osName = System.getProperty("os.name").lowercase()
+			val result = normalizePathForMatch("/Foo/BAR")
+			if (osName.contains("mac") || osName.contains("win")) {
+				result shouldBe "/foo/bar"
+			} else {
+				result shouldBe "/Foo/BAR"
+			}
+		}
+	}
+
+	@Nested
+	inner class FindVscodeWorkspaceHash {
+
+		@Test
+		fun `returns null when workspaceStorage doesn't exist`(@TempDir tempHome: File) {
+			System.setProperty("user.home", tempHome.absolutePath)
+			findVscodeWorkspaceHash(VscodeFlavor.Code, tempHome.absolutePath).shouldBeNull()
+		}
+
+		@Test
+		fun `returns the hash whose workspace_json folder matches projectDir`(@TempDir tempHome: File, @TempDir projectDir: File) {
+			System.setProperty("user.home", tempHome.absolutePath)
+			val ws = setupWorkspaceStorage(tempHome, VscodeFlavor.Code)
+			val hashDir = File(ws, "abc123")
+			val folderUri = fileUri(projectDir) // file:/...
+			writeWorkspaceJson(hashDir, folderUri)
+
+			val result = findVscodeWorkspaceHash(VscodeFlavor.Code, projectDir.absolutePath)
+			result.shouldNotBeNull()
+			result shouldBe "abc123"
+		}
+
+		@Test
+		fun `skips entries whose folder URI doesn't match`(@TempDir tempHome: File, @TempDir projectDir: File, @TempDir otherDir: File) {
+			System.setProperty("user.home", tempHome.absolutePath)
+			val ws = setupWorkspaceStorage(tempHome, VscodeFlavor.Code)
+			writeWorkspaceJson(File(ws, "wrong"), fileUri(otherDir))
+			writeWorkspaceJson(File(ws, "right"), fileUri(projectDir))
+			findVscodeWorkspaceHash(VscodeFlavor.Code, projectDir.absolutePath) shouldBe "right"
+		}
+
+		@Test
+		fun `skips workspace_json with missing folder field`(@TempDir tempHome: File, @TempDir projectDir: File) {
+			System.setProperty("user.home", tempHome.absolutePath)
+			val ws = setupWorkspaceStorage(tempHome, VscodeFlavor.Code)
+			val badDir = File(ws, "bad").also { it.mkdirs() }
+			File(badDir, "workspace.json").writeText("""{"notFolder": "x"}""")
+			findVscodeWorkspaceHash(VscodeFlavor.Code, projectDir.absolutePath).shouldBeNull()
+		}
+
+		@Test
+		fun `skips workspace_json with non-file URI`(@TempDir tempHome: File, @TempDir projectDir: File) {
+			System.setProperty("user.home", tempHome.absolutePath)
+			val ws = setupWorkspaceStorage(tempHome, VscodeFlavor.Code)
+			writeWorkspaceJson(File(ws, "remote"), "vscode-remote://ssh-host/foo")
+			findVscodeWorkspaceHash(VscodeFlavor.Code, projectDir.absolutePath).shouldBeNull()
+		}
+
+		@Test
+		fun `Cursor and Code flavors search different roots`(@TempDir tempHome: File, @TempDir projectDir: File) {
+			System.setProperty("user.home", tempHome.absolutePath)
+			val cursorWs = setupWorkspaceStorage(tempHome, VscodeFlavor.Cursor)
+			writeWorkspaceJson(File(cursorWs, "cursor-only"), fileUri(projectDir))
+			// VS Code workspaceStorage left empty
+			setupWorkspaceStorage(tempHome, VscodeFlavor.Code)
+
+			findVscodeWorkspaceHash(VscodeFlavor.Cursor, projectDir.absolutePath) shouldBe "cursor-only"
+			findVscodeWorkspaceHash(VscodeFlavor.Code, projectDir.absolutePath).shouldBeNull()
+		}
+	}
+}


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## Quick recap

The plugin gained the ability to read sessions from two new GitHub Copilot sources: the standalone command-line tool and the chat panel built into VS Code. The CLI integration queries a local SQLite database, matches sessions to the current project by directory, and converts each conversation turn into the same human/assistant format used by Cursor and other existing sources. Developers who rely on the Copilot CLI will now see those conversations reflected in their commit summaries.

The Copilot Chat panel integration handles a more complex storage arrangement: VS Code writes chat history to two entirely different locations depending on which AI model the user had selected at the time, and both locations use different file formats. The new code handles both locations transparently, so developers see their full Copilot Chat history in commit summaries regardless of which model they were using.

Status reporting for both new sources was also tightened. The Copilot CLI integration now runs a minimal database health check at status-refresh time rather than scanning every session record, matching the pattern already in place for other database-backed sources. Copilot Chat, which stores data as plain files, performs only a directory check. Both integrations report their availability accurately without the overhead of a full data scan.

A regression affecting Windows test runs was caught and fixed. When path-resolution logic was consolidated into a shared helper during this work, a test hook that redirected path lookups to a temporary directory was not carried over. The shared helper now includes that override, restoring correct test behavior on Windows.

---

## E2E Test (4)
<details>
<summary><strong>1. GitHub Copilot CLI detected and shown in status panel</strong></summary>
<br>
<blockquote>

**Preconditions:** Have the GitHub Copilot CLI installed on the test machine (so the session database exists at the default location under your home folder).

**Steps:**
1. Open your project in the IDE with the Jolli Memory plugin installed.
2. Open the Jolli Memory status panel (look for the Jolli Memory icon or menu entry).
3. Check the list of detected AI sources shown in the panel.
4. Verify that "Copilot" (or "GitHub Copilot CLI") appears as a detected source with a green or active indicator.
5. Now temporarily rename or move the Copilot session database file so it cannot be found, then refresh the status panel.
6. Verify that the Copilot entry now shows as not detected or shows an error indicator.

**Expected Results:**
- When the Copilot CLI database is present, the status panel lists Copilot as detected with no error.
- When the database is absent or inaccessible, the status panel reflects that Copilot is not detected or shows a scan error, matching the behavior of other sources like Cursor.

</blockquote>
</details>
<details>
<summary><strong>2. Copilot Chat detected and shown in status panel</strong></summary>
<br>
<blockquote>

**Preconditions:** Have VS Code with the GitHub Copilot Chat extension installed, so that either the Copilot Chat storage folder or the Copilot CLI session-state folder exists on the test machine.

**Steps:**
1. Open your project in the IDE with the Jolli Memory plugin installed.
2. Open the Jolli Memory status panel.
3. Check the list of detected AI sources.
4. Verify that "Copilot Chat" appears as a detected source with an active indicator and no scan error shown next to it.

**Expected Results:**
- Copilot Chat is listed as detected in the status panel.
- No error or warning is shown alongside the Copilot Chat entry (since detection is directory-based only and does not perform a database scan).

</blockquote>
</details>
<details>
<summary><strong>3. Copilot CLI conversations included in commit summary</strong></summary>
<br>
<blockquote>

**Preconditions:** Have the GitHub Copilot CLI installed and have held at least one conversation in the CLI within the last 48 hours while working in the test project directory.

**Steps:**
1. Make a small code change in the project and stage it for commit.
2. Trigger a commit through the IDE (using the Jolli Memory-assisted commit flow).
3. Wait for the commit summary or context panel to populate.
4. Check whether the summary includes content or context drawn from your recent Copilot CLI conversation.

**Expected Results:**
- The commit summary or context panel includes entries attributed to the Copilot CLI conversation that took place in the project directory.
- Conversations older than 48 hours or from a different project directory do not appear.

</blockquote>
</details>
<details>
<summary><strong>4. Copilot Chat conversations included in commit summary</strong></summary>
<br>
<blockquote>

**Preconditions:** Have VS Code with Copilot Chat installed and have had at least one chat conversation in the VS Code Copilot Chat panel within the last 48 hours while working in the test project.

**Steps:**
1. Make a small code change in the project and stage it for commit.
2. Trigger a commit through the IDE using the Jolli Memory-assisted commit flow.
3. Wait for the commit summary or context panel to populate.
4. Verify that content from your recent Copilot Chat session appears in the summary alongside any other AI source conversations.

**Expected Results:**
- The commit summary includes context from the Copilot Chat panel conversation.
- Both storage formats are covered: if you used a non-default model in Copilot Chat, those conversations also appear (not just the default model's sessions).
- Sessions older than 48 hours do not appear.

</blockquote>
</details>

---

## Topics (5)
<details>
<summary><strong>01 · Add lightweight health checks for Copilot CLI and Chat status reporting</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The Copilot CLI integration was performing a full session scan just to report whether the integration was working, while every other database-backed source used a cheaper check that only verified the database was readable.

**💡 Decisions Behind the Code**

- **Lightweight query over full scan for database-backed sources**: A full session scan reads every row just to report whether the integration is working, which is expensive enough to cause noticeable overhead on every status refresh. A single-row query is fast enough to call repeatedly and still catches the failure modes that matter — locked, corrupt, or inaccessible databases.
- **No health check for file-based sources**: Copilot Chat stores data as plain files rather than a database, so there is no meaningful database health to verify. Scanning all files just to populate a status field is disproportionately expensive; a directory-existence check is sufficient to tell the user whether the integration is present.

**✅ What Was Implemented**

- Added `checkDbHealth()` to `CopilotSupport.kt`, following the identical pattern used by OpenCode and Cursor: opens the session database in read-only mode and runs a minimal single-row query to detect locked, corrupt, or permission-denied errors without reading all rows.
- Updated `SummaryReader.kt` to use `isCopilotInstalled()` + `checkDbHealth()` for Copilot CLI status checks, replacing the previous full `discoverSessions()` call. Variable naming was aligned with the convention used by other sources (`copilotInstalled` / `copilotError`).
- Removed the full session scan for Copilot Chat status checks entirely. Since Copilot Chat is file-based, only a directory-existence check (`isCopilotChatInstalled()`) is performed at status-check time; `copilotChatScanError` is always null.

**📁 FILES**
- `intellij/src/main/kotlin/ai/jolli/jollimemory/core/CopilotSupport.kt`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/bridge/SummaryReader.kt`

</blockquote>
</details>
<details>
<summary><strong>02 · Add GitHub Copilot CLI session discovery and transcript reading</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The plugin needed to surface conversations from the GitHub Copilot CLI terminal tool alongside other AI coding assistants. Without this, commit summaries would miss context from developers who use Copilot's standalone command-line interface.

**💡 Decisions Behind the Code**

- **Staleness cutoff applied in Kotlin, not SQL**: The `updated_at` column is stored as plain text rather than a typed timestamp, so a SQL date comparison would only be correct if every row used canonical UTC ISO-8601. Applying the cutoff in Kotlin after parsing with `Instant.parse` is more robust against format variation and avoids silent data loss from lexicographic mismatch.
- **Synthetic path format reused from existing sources**: Rather than inventing a new session-identity scheme, the `<dbPath>#<sessionId>` convention already used by Cursor and OpenCode was adopted. This keeps the transcript-dispatch logic uniform and avoids a new path-pattern branch in the reader router.

**✅ What Was Implemented**

- `CopilotSupport.kt` was created to handle detection, session discovery, and transcript reading for the Copilot CLI. It queries a SQLite database at `~/.copilot/session-store.db`, filtering sessions by project directory and a 48-hour staleness cutoff. Each database row expands into a human/assistant entry pair, and a synthetic path format (`<dbPath>#<sessionId>`) is used as the transcript identifier.
- `CopilotSupport` was wired into `SummaryReader.kt`, `Types.kt`, `TranscriptParsers.kt`, `PostCommitHook.kt`, `SettingsDialog.kt`, and `StatusPanel.kt` so the new source participates in detection, status display, session scanning, and commit attribution alongside existing sources.

**📁 FILES**
- `intellij/src/main/kotlin/ai/jolli/jollimemory/core/CopilotSupport.kt`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/bridge/SummaryReader.kt`

</blockquote>
</details>
<details>
<summary><strong>03 · Add Copilot Chat panel session discovery covering two backend storage formats</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The VS Code Copilot Chat panel writes session data to two completely different locations depending on which AI model the user selects, and both needed to be discovered and read so no chat history was missed during commit summarization.

**💡 Decisions Behind the Code**

- **Both backends kept under one source name rather than split into two**: From the user's perspective both are "Copilot Chat" — the model dropdown is an implementation detail they don't control or think about. Splitting them into separate sources would surface that internal distinction in the UI and settings, adding confusion without benefit. The two scan helpers and two readers are internal complexity hidden behind a single toggle.
- **Deprecated `.json` snapshot files explicitly excluded**: VS Code's chat storage directory contains both `.jsonl` patch logs and older `.json` full-document snapshots for the same sessions. Reading both would produce duplicate entries. The patch log is the authoritative live format, so `.json` files are skipped by the scanner.
- **`break`/`continue` inside inline lambdas avoided for Kotlin compatibility**: The build target predates the Kotlin version that allows non-local `break`/`continue` inside inline lambdas. Lines were collected to a list before iteration and null-guard patterns were rewritten to stay within the supported language version.

**✅ What Was Implemented**

- `CopilotChatSupport.kt` was created with two independent scan paths: `scanSessionState` reads from `~/.copilot/session-state/<sid>/events.jsonl` (used when the Copilot CLI backend model is active) and `scanChatSessions` reads from VS Code's workspace storage under a hashed folder (used for all other models). `discoverSessions` runs both scans and concatenates results.
- Two distinct transcript readers were implemented: `readEventsJsonl` streams line-by-line events and filters by type (`user.message` / `assistant.message`), while `readPatchLog` replays a sequence of JSON patch operations (kind 0/1/2) to reconstruct the final document before extracting request/response pairs. A `readTranscript` dispatcher routes to the correct reader based on the trailing path pattern.
- Patch replay primitives (`replayPatches`, `setAtPath`, `deleteAtPath`) were implemented to handle VS Code's document-patch JSONL format, including creation of intermediate objects and arrays and array-shift semantics on deletion.

**📁 FILES**
- `intellij/src/main/kotlin/ai/jolli/jollimemory/core/CopilotChatSupport.kt`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/bridge/SummaryReader.kt`

</blockquote>
</details>
<details>
<summary><strong>04 · Restore Windows test path override lost during shared helper extraction</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

During the refactor that moved Cursor's path-resolution logic into a shared helper, a Windows-specific test hook was not carried over. Tests on Windows would have resolved paths against the real user data directory rather than a controlled temporary location.

**💡 Decisions Behind the Code**

A system property override is used rather than an environment variable override because the Java runtime does not allow tests to unset or replace environment variables at runtime. A system property can be set and cleared freely within a test, making it the only practical way to redirect path resolution on Windows without modifying the real environment.

**✅ What Was Implemented**

- Updated `VscodeWorkspaceLocator.kt` to check for the `cursor.appdata.override` system property when resolving the Windows application data path for the Cursor flavor. If the property is set, it takes precedence over the real environment variable, restoring the test-redirection behavior that existed before the refactor.

**📁 FILES**
- `intellij/src/main/kotlin/ai/jolli/jollimemory/core/VscodeWorkspaceLocator.kt`

</blockquote>
</details>
<details>
<summary><strong>05 · Extract shared VS Code workspace hash lookup into reusable locator</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Both Cursor and the new VS Code Copilot Chat integration needed to resolve an opaque hashed folder name from a project directory path, and the logic was duplicated inside Cursor's support file.

**💡 Decisions Behind the Code**

**Flavor parameter instead of subclassing**: Cursor and VS Code share an identical `workspaceStorage/<hash>/workspace.json` layout — the only difference is the user-data root path. A single parameterized function with a flavor enum is simpler and less error-prone than a class hierarchy or two near-identical copies, and it makes the shared structure explicit rather than coincidental.

**✅ What Was Implemented**

- `VscodeWorkspaceLocator.kt` was created with a `VscodeFlavor` enum (`Cursor` / `Code`) and top-level functions `getVscodeUserDataDir`, `getVscodeWorkspaceStorageDir`, `findVscodeWorkspaceHash`, and `normalizePathForMatch`. The locator walks every `<hash>/workspace.json` under the flavor's storage root, parses the `folder` URI, and returns the matching hash or null.
- `CursorSupport.kt` was refactored to delete its four private helper methods and call the shared locator functions instead. The public API and behavior are unchanged.

**📁 FILES**
- `intellij/src/main/kotlin/ai/jolli/jollimemory/core/VscodeWorkspaceLocator.kt`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/core/CursorSupport.kt`

</blockquote>
</details>

---

*Generated by Jolli Memory · May 26, 2026 at 12:05 PM · via Anthropic*
<!-- jollimemory-summary-end -->