### PR TITLE
Add active conversations panel with inline transcript editing

### DIFF
--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/actions/RefreshConversationsAction.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/actions/RefreshConversationsAction.kt
@@ -1,0 +1,14 @@
+package ai.jolli.jollimemory.actions
+
+import ai.jolli.jollimemory.services.JolliMemoryService
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+
+/** Refreshes the Conversations panel by re-querying all session sources. */
+class RefreshConversationsAction : AnAction() {
+	override fun actionPerformed(e: AnActionEvent) {
+		val project = e.project ?: return
+		val service = project.getService(JolliMemoryService::class.java)
+		service.panelRegistry?.activeConversationsPanel?.refresh()
+	}
+}

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/ActiveConversationsPanel.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/ActiveConversationsPanel.kt
@@ -1,0 +1,136 @@
+package ai.jolli.jollimemory.toolwindow
+
+import ai.jolli.jollimemory.core.ActiveConversationItem
+import ai.jolli.jollimemory.core.ActiveConversationsResult
+import ai.jolli.jollimemory.core.ActiveSessionAggregator
+import ai.jolli.jollimemory.core.HiddenConversationsStore
+import ai.jolli.jollimemory.core.TranscriptSource
+import ai.jolli.jollimemory.services.JolliMemoryService
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.fileEditor.FileEditorManager
+import com.intellij.openapi.project.Project
+import com.intellij.ui.JBColor
+import com.intellij.ui.components.JBLabel
+import com.intellij.ui.components.JBScrollPane
+import com.intellij.util.ui.JBUI
+import java.awt.BorderLayout
+import javax.swing.*
+
+/**
+ * CONVERSATIONS accordion panel — lists active AI conversations from all
+ * sources, with 60-second background polling. Clicking a row opens the
+ * transcript as an editor tab for inline editing.
+ */
+class ActiveConversationsPanel(
+	private val project: Project,
+	private val service: JolliMemoryService,
+) : JPanel(BorderLayout()), Disposable {
+
+	private val rowsPanel = JPanel().apply {
+		layout = BoxLayout(this, BoxLayout.Y_AXIS)
+	}
+	private val emptyLabel = JBLabel("No active conversations").apply {
+		horizontalAlignment = SwingConstants.CENTER
+		foreground = JBColor.GRAY
+		border = JBUI.Borders.empty(16)
+	}
+	private val warningBanner = JPanel(BorderLayout()).apply {
+		isVisible = false
+		border = JBUI.Borders.empty(4, 8)
+		background = JBColor(java.awt.Color(255, 243, 205), java.awt.Color(66, 56, 20))
+		add(JBLabel("Some sources failed to load").apply {
+			foreground = JBColor(java.awt.Color(133, 100, 4), java.awt.Color(250, 204, 21))
+		}, BorderLayout.CENTER)
+	}
+
+	private var conversations: List<ActiveConversationItem> = emptyList()
+	private var failedSources: List<TranscriptSource> = emptyList()
+
+	private val statusListener: () -> Unit = { refresh() }
+
+	private val pollTimer = Timer(60_000) {
+		if (isShowing) refresh()
+	}.apply { isRepeats = true }
+
+	init {
+		val scrollPane = JBScrollPane(rowsPanel).apply {
+			border = JBUI.Borders.empty()
+			verticalScrollBarPolicy = ScrollPaneConstants.VERTICAL_SCROLLBAR_AS_NEEDED
+		}
+		add(warningBanner, BorderLayout.NORTH)
+		add(scrollPane, BorderLayout.CENTER)
+
+		service.addStatusListener(statusListener)
+		pollTimer.start()
+
+		// Initial load
+		ApplicationManager.getApplication().executeOnPooledThread { loadData() }
+	}
+
+	fun refresh() {
+		ApplicationManager.getApplication().executeOnPooledThread { loadData() }
+	}
+
+	override fun dispose() {
+		pollTimer.stop()
+		service.removeStatusListener(statusListener)
+	}
+
+	// ── Data loading ────────────────────────────────────────────────────
+
+	private fun loadData() {
+		val cwd = service.mainRepoRoot ?: project.basePath ?: return
+		val result: ActiveConversationsResult = try {
+			ActiveSessionAggregator.listActiveConversationsWithDiagnostics(cwd)
+		} catch (e: Exception) {
+			ActiveConversationsResult(emptyList(), emptyList())
+		}
+		SwingUtilities.invokeLater { updateUI(result) }
+	}
+
+	private fun updateUI(result: ActiveConversationsResult) {
+		conversations = result.items
+		failedSources = result.failedSources
+
+		warningBanner.isVisible = failedSources.isNotEmpty()
+
+		rowsPanel.removeAll()
+		if (conversations.isEmpty()) {
+			rowsPanel.add(emptyLabel)
+		} else {
+			for (item in conversations) {
+				rowsPanel.add(ConversationRowComponent(
+					item = item,
+					onRowClicked = ::onRowClicked,
+					onHide = ::onHide,
+				))
+			}
+		}
+		rowsPanel.add(Box.createVerticalGlue())
+		rowsPanel.revalidate()
+		rowsPanel.repaint()
+	}
+
+	// ── Row actions ─────────────────────────────────────────────────────
+
+	private fun onRowClicked(item: ActiveConversationItem) {
+		val cwd = service.mainRepoRoot ?: project.basePath ?: return
+		val vf = ConversationVirtualFile(item, cwd)
+		val editors = FileEditorManager.getInstance(project).openFile(vf, true)
+		// Wire the save callback so the list refreshes after edits
+		for (editor in editors) {
+			if (editor is ConversationFileEditor) {
+				editor.onSaved = { refresh() }
+			}
+		}
+	}
+
+	private fun onHide(item: ActiveConversationItem) {
+		val cwd = service.mainRepoRoot ?: project.basePath ?: return
+		ApplicationManager.getApplication().executeOnPooledThread {
+			HiddenConversationsStore.hideConversation(cwd, item.source, item.sessionId)
+			SwingUtilities.invokeLater { refresh() }
+		}
+	}
+}

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/CollapsiblePanel.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/CollapsiblePanel.kt
@@ -101,11 +101,13 @@ class CollapsiblePanel(
         add(headerPanel, BorderLayout.NORTH)
 
         // Content: add a thin top border for visual separation
-        contentPanel.border = JBUI.Borders.merge(
-            JBUI.Borders.customLineTop(UIManager.getColor("Separator.separatorColor") ?: java.awt.Color.GRAY),
-            contentPanel.border,
-            true,
-        )
+        val separatorBorder = JBUI.Borders.customLineTop(UIManager.getColor("Separator.separatorColor") ?: java.awt.Color.GRAY)
+        val existingBorder = contentPanel.border
+        contentPanel.border = if (existingBorder != null) {
+            JBUI.Borders.merge(separatorBorder, existingBorder, true)
+        } else {
+            separatorBorder
+        }
 
         if (expanded) {
             add(contentPanel, BorderLayout.CENTER)

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/ConversationEditorProvider.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/ConversationEditorProvider.kt
@@ -1,0 +1,29 @@
+package ai.jolli.jollimemory.toolwindow
+
+import com.intellij.openapi.fileEditor.FileEditor
+import com.intellij.openapi.fileEditor.FileEditorPolicy
+import com.intellij.openapi.fileEditor.FileEditorProvider
+import com.intellij.openapi.project.DumbAware
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VirtualFile
+
+/**
+ * Provides a custom editor for [ConversationVirtualFile] instances.
+ * This allows conversation transcripts to open as tabs in the main editor
+ * area, matching how VS Code embeds its webview panels.
+ */
+class ConversationEditorProvider : FileEditorProvider, DumbAware {
+
+	override fun accept(project: Project, file: VirtualFile): Boolean {
+		return file is ConversationVirtualFile
+	}
+
+	override fun createEditor(project: Project, file: VirtualFile): FileEditor {
+		val convFile = file as ConversationVirtualFile
+		return ConversationFileEditor(project, convFile)
+	}
+
+	override fun getEditorTypeId(): String = "jollimemory-conversation"
+
+	override fun getPolicy(): FileEditorPolicy = FileEditorPolicy.HIDE_DEFAULT_EDITOR
+}

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/ConversationFileEditor.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/ConversationFileEditor.kt
@@ -1,0 +1,441 @@
+package ai.jolli.jollimemory.toolwindow
+
+import ai.jolli.jollimemory.core.*
+import ai.jolli.jollimemory.core.ConversationOverlayStore.EntryIdentity
+import ai.jolli.jollimemory.core.ConversationOverlayStore.OverlayEditRule
+import ai.jolli.jollimemory.core.ConversationOverlayStore.OverlayKey
+import com.intellij.icons.AllIcons
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.fileEditor.FileEditor
+import com.intellij.openapi.fileEditor.FileEditorManager
+import com.intellij.openapi.fileEditor.FileEditorState
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.UserDataHolderBase
+import com.intellij.ui.JBColor
+import com.intellij.ui.components.JBLabel
+import com.intellij.ui.components.JBScrollPane
+import com.intellij.ui.EditorTextField
+import com.intellij.util.ui.JBUI
+import java.awt.*
+import java.awt.event.MouseAdapter
+import java.awt.event.MouseEvent
+import java.beans.PropertyChangeListener
+import javax.swing.*
+
+/**
+ * Editor tab that renders a conversation transcript with inline edit/delete
+ * capability, matching VS Code's ConversationDetailsPanel behavior.
+ *
+ * Opens as a non-modal editor tab — users can keep working, switch tabs,
+ * and have multiple conversations open simultaneously.
+ */
+class ConversationFileEditor(
+	private val project: Project,
+	private val file: ConversationVirtualFile,
+) : UserDataHolderBase(), FileEditor {
+
+	private val item = file.item
+	private val cwd = file.cwd
+
+	/** Raw entries from the source transcript (pre-overlay). Used for identity derivation. */
+	private var rawEntries: List<TranscriptEntry> = emptyList()
+
+	/** Entries after overlay is applied (what the user sees). */
+	private var displayEntries: List<TranscriptEntry> = emptyList()
+
+	/** Pending edits: display-index → new content. */
+	private val editedContent = mutableMapOf<Int, String>()
+
+	/** Pending deletions: set of display-indices marked for removal. */
+	private val deletedIndices = mutableSetOf<Int>()
+
+	private val rootPanel = JPanel(BorderLayout())
+	private val entriesPanel = JPanel().apply {
+		layout = BoxLayout(this, BoxLayout.Y_AXIS)
+	}
+	private lateinit var scrollPane: JBScrollPane
+	private val saveButton = JButton("Save All").apply { isEnabled = false }
+	private val cancelButton = JButton("Cancel").apply { isEnabled = false }
+	private val markAllDeletedButton = JButton("Mark All as Deleted").apply { isEnabled = true }
+	private val statusLabel = JBLabel("").apply { foreground = JBColor.GRAY }
+
+	/** Callback fired after a successful save or hide so the sidebar can refresh. */
+	var onSaved: (() -> Unit)? = null
+
+	init {
+		buildUI()
+		loadTranscript()
+	}
+
+	// ── FileEditor interface ────────────────────────────────────────────
+
+	override fun getComponent(): JComponent = rootPanel
+	override fun getPreferredFocusedComponent(): JComponent = rootPanel
+	override fun getName(): String = "Conversation"
+	override fun setState(state: FileEditorState) {}
+	override fun isModified(): Boolean = editedContent.isNotEmpty() || deletedIndices.isNotEmpty()
+	override fun isValid(): Boolean = true
+	override fun addPropertyChangeListener(listener: PropertyChangeListener) {}
+	override fun removePropertyChangeListener(listener: PropertyChangeListener) {}
+	override fun getFile() = file
+	override fun dispose() {}
+
+	// ── UI construction ─────────────────────────────────────────────────
+
+	private fun buildUI() {
+		// Header
+		val header = JPanel(BorderLayout()).apply {
+			border = JBUI.Borders.empty(12, 16, 8, 16)
+			val titleLabel = JBLabel(item.title).apply {
+				font = font.deriveFont(Font.BOLD, font.size2D + 2f)
+			}
+			val sourceLabel = JBLabel("${item.source.name}  ·  ${item.messageCount} messages").apply {
+				foreground = JBColor.GRAY
+			}
+			val headerLeft = JPanel().apply {
+				layout = BoxLayout(this, BoxLayout.Y_AXIS)
+				isOpaque = false
+				add(titleLabel)
+				add(Box.createVerticalStrut(JBUI.scale(4)))
+				add(sourceLabel)
+			}
+			add(headerLeft, BorderLayout.CENTER)
+		}
+
+		// Scrollable transcript
+		scrollPane = JBScrollPane(entriesPanel).apply {
+			border = JBUI.Borders.empty()
+			verticalScrollBarPolicy = ScrollPaneConstants.VERTICAL_SCROLLBAR_AS_NEEDED
+		}
+
+		// Footer
+		val footer = JPanel(FlowLayout(FlowLayout.RIGHT, JBUI.scale(8), JBUI.scale(4))).apply {
+			border = JBUI.Borders.empty(4, 16, 8, 16)
+		}
+
+		markAllDeletedButton.addActionListener { doMarkAllDeleted() }
+		cancelButton.addActionListener { doCancel() }
+		saveButton.addActionListener { doSave() }
+
+		footer.add(statusLabel)
+		footer.add(Box.createHorizontalGlue())
+		footer.add(markAllDeletedButton)
+		footer.add(cancelButton)
+		footer.add(saveButton)
+
+		rootPanel.add(header, BorderLayout.NORTH)
+		rootPanel.add(scrollPane, BorderLayout.CENTER)
+		rootPanel.add(footer, BorderLayout.SOUTH)
+	}
+
+	// ── Data loading ────────────────────────────────────────────────────
+
+	private fun loadTranscript() {
+		ApplicationManager.getApplication().executeOnPooledThread {
+			val source = item.source
+			val session = SessionInfo(
+				sessionId = item.sessionId,
+				transcriptPath = item.transcriptPath,
+				updatedAt = item.updatedAt,
+				source = source,
+			)
+			val raw = TranscriptMessageCounter.loadUnreadTranscript(source, item.transcriptPath, cwd)
+			val overlay = ConversationOverlayStore.loadOverlay(
+				OverlayKey(cwd, source, item.sessionId),
+			)
+			val displayed = ConversationOverlayStore.applyOverlay(raw, overlay)
+			// For identity derivation: raw entries with deletes applied but edits NOT applied
+			val rawWithDeletesOnly = ConversationOverlayStore.applyDeletes(raw, overlay)
+
+			SwingUtilities.invokeLater {
+				rawEntries = rawWithDeletesOnly
+				displayEntries = displayed
+				editedContent.clear()
+				deletedIndices.clear()
+				renderEntries()
+				updateFooter()
+				scrollPane.verticalScrollBar.value = 0
+			}
+		}
+	}
+
+	// ── Rendering ───────────────────────────────────────────────────────
+
+	private fun renderEntries() {
+		val scrollPos = scrollPane.verticalScrollBar.value
+
+		entriesPanel.removeAll()
+		if (displayEntries.isEmpty()) {
+			entriesPanel.add(JBLabel("No transcript entries.").apply {
+				border = JBUI.Borders.empty(16)
+				foreground = JBColor.GRAY
+			})
+		} else {
+			for ((i, entry) in displayEntries.withIndex()) {
+				entriesPanel.add(createEntryRow(i, entry))
+				entriesPanel.add(JSeparator().apply {
+					maximumSize = Dimension(Int.MAX_VALUE, 1)
+				})
+			}
+		}
+		entriesPanel.add(Box.createVerticalGlue())
+		entriesPanel.revalidate()
+		entriesPanel.repaint()
+
+		// Restore scroll position after rebuild
+		SwingUtilities.invokeLater {
+			scrollPane.verticalScrollBar.value = scrollPos
+		}
+	}
+
+	private fun createEntryRow(index: Int, entry: TranscriptEntry): JPanel {
+		val isDeleted = index in deletedIndices
+		val displayContent = editedContent[index] ?: entry.content
+
+		val row = JPanel(BorderLayout()).apply {
+			border = JBUI.Borders.empty(8, 16)
+			maximumSize = Dimension(Int.MAX_VALUE, Int.MAX_VALUE)
+		}
+
+		// Role label — "human" → "You"
+		val roleName = if (entry.role == "human") "You" else entry.role.replaceFirstChar { it.uppercase() }
+		val roleColor = if (entry.role == "human") {
+			JBColor(Color(37, 99, 235), Color(96, 165, 250))
+		} else {
+			JBColor(Color(5, 150, 105), Color(52, 211, 153))
+		}
+		val roleLabel = JBLabel(roleName).apply {
+			foreground = roleColor
+			font = font.deriveFont(Font.BOLD, font.size2D - 1f)
+		}
+
+		// Content area — click to edit
+		val contentLabel = JTextArea(displayContent).apply {
+			isEditable = false
+			isOpaque = false
+			lineWrap = true
+			wrapStyleWord = true
+			border = JBUI.Borders.emptyTop(4)
+			font = roleLabel.font.deriveFont(Font.PLAIN, roleLabel.font.size2D)
+			if (isDeleted) {
+				foreground = JBColor.GRAY
+			}
+			cursor = if (isDeleted) Cursor.getDefaultCursor() else Cursor.getPredefinedCursor(Cursor.HAND_CURSOR)
+		}
+
+		if (!isDeleted) {
+			contentLabel.addMouseListener(object : MouseAdapter() {
+				override fun mouseClicked(e: MouseEvent) {
+					startEditing(index, entry, row)
+				}
+			})
+		}
+
+		// Delete/restore button
+		val deleteBtn = JLabel(
+			if (isDeleted) AllIcons.Actions.Undo else AllIcons.Actions.GC,
+		).apply {
+			cursor = Cursor.getPredefinedCursor(Cursor.HAND_CURSOR)
+			toolTipText = if (isDeleted) "Restore" else "Delete"
+			border = JBUI.Borders.emptyRight(8)
+		}
+		deleteBtn.addMouseListener(object : MouseAdapter() {
+			override fun mouseClicked(e: MouseEvent) {
+				if (isDeleted) {
+					deletedIndices.remove(index)
+				} else {
+					deletedIndices.add(index)
+				}
+				renderEntries()
+				updateFooter()
+			}
+		})
+
+		// Format timestamp to h:mm a
+		val formattedTime = entry.timestamp?.let { formatTimestamp(it) }
+
+		// Top row: [delete btn] [role label] ... [timestamp]
+		val leftHeader = JPanel(FlowLayout(FlowLayout.LEFT, JBUI.scale(4), 0)).apply {
+			isOpaque = false
+			add(deleteBtn)
+			add(roleLabel)
+		}
+		val topRow = JPanel(BorderLayout()).apply {
+			isOpaque = false
+			add(leftHeader, BorderLayout.WEST)
+			if (formattedTime != null) {
+				add(JBLabel(formattedTime).apply {
+					foreground = JBColor.GRAY
+					font = font.deriveFont(font.size2D - 2f)
+				}, BorderLayout.EAST)
+			}
+		}
+
+		val leftContent = JPanel(BorderLayout()).apply {
+			isOpaque = false
+			add(topRow, BorderLayout.NORTH)
+			add(contentLabel, BorderLayout.CENTER)
+		}
+
+		row.add(leftContent, BorderLayout.CENTER)
+
+		return row
+	}
+
+	/** Parses an ISO-8601 or epoch-millis timestamp into local "h:mm a" format. */
+	private fun formatTimestamp(ts: String): String {
+		return try {
+			val instant = try {
+				java.time.Instant.parse(ts)
+			} catch (_: Exception) {
+				java.time.Instant.ofEpochMilli(ts.toLong())
+			}
+			val local = instant.atZone(java.time.ZoneId.systemDefault())
+			local.format(java.time.format.DateTimeFormatter.ofPattern("h:mm a"))
+		} catch (_: Exception) {
+			ts
+		}
+	}
+
+	private fun startEditing(index: Int, entry: TranscriptEntry, row: JPanel) {
+		val currentContent = editedContent[index] ?: entry.content
+		val editorField = EditorTextField(currentContent, project, null).apply {
+			setOneLineMode(false)
+			border = JBUI.Borders.empty(4)
+		}
+
+		// Replace row content with editor
+		row.removeAll()
+		row.add(editorField, BorderLayout.CENTER)
+		row.revalidate()
+		row.repaint()
+		editorField.requestFocusInWindow()
+
+		// Enable cancel immediately so user can back out
+		cancelButton.isEnabled = true
+
+		editorField.addFocusListener(object : java.awt.event.FocusAdapter() {
+			override fun focusLost(e: java.awt.event.FocusEvent) {
+				val newValue = editorField.text
+				if (newValue != entry.content) {
+					editedContent[index] = newValue
+				} else {
+					editedContent.remove(index)
+				}
+				renderEntries()
+				updateFooter()
+			}
+		})
+	}
+
+	// ── Footer state ────────────────────────────────────────────────────
+
+	private fun updateFooter() {
+		val pendingCount = editedContent.size + deletedIndices.size
+		val hasPending = pendingCount > 0
+		saveButton.isEnabled = hasPending
+		saveButton.text = if (hasPending) "Save All ($pendingCount)" else "Save All"
+		cancelButton.isEnabled = hasPending
+		markAllDeletedButton.isEnabled = deletedIndices.size < displayEntries.size
+
+		val parts = mutableListOf<String>()
+		if (editedContent.isNotEmpty()) parts.add("${editedContent.size} modified")
+		if (deletedIndices.isNotEmpty()) parts.add("${deletedIndices.size} deleted")
+		statusLabel.text = parts.joinToString(", ")
+	}
+
+	// ── Actions ─────────────────────────────────────────────────────────
+
+	private fun doMarkAllDeleted() {
+		for (i in displayEntries.indices) {
+			deletedIndices.add(i)
+		}
+		renderEntries()
+		updateFooter()
+	}
+
+	private fun doCancel() {
+		editedContent.clear()
+		deletedIndices.clear()
+		renderEntries()
+		updateFooter()
+	}
+
+	/**
+	 * Saves pending edits/deletes as an overlay, auto-hides if all entries
+	 * deleted, and refreshes the sidebar.
+	 */
+	fun doSave() {
+		if (editedContent.isEmpty() && deletedIndices.isEmpty()) return
+
+		val source = item.source
+		val key = OverlayKey(cwd, source, item.sessionId)
+
+		// Build identity-based rules from raw entries (pre-edit content)
+		val newDeletes = mutableListOf<EntryIdentity>()
+		val newEdits = mutableListOf<OverlayEditRule>()
+
+		for (idx in deletedIndices) {
+			if (idx < rawEntries.size) {
+				val raw = rawEntries[idx]
+				newDeletes.add(EntryIdentity(raw.role, raw.content, raw.timestamp))
+			}
+		}
+		for ((idx, newContent) in editedContent) {
+			// Delete wins over edit
+			if (idx in deletedIndices) continue
+			if (idx < rawEntries.size) {
+				val raw = rawEntries[idx]
+				newEdits.add(OverlayEditRule(raw.role, raw.content, raw.timestamp, newContent))
+			}
+		}
+
+		saveButton.isEnabled = false
+		saveButton.text = "Saving…"
+
+		ApplicationManager.getApplication().executeOnPooledThread {
+			try {
+				val existing = ConversationOverlayStore.loadOverlay(key)
+				val (mergedDeletes, mergedEdits) = ConversationOverlayStore.mergeOverlay(
+					existing, newDeletes, newEdits,
+				)
+				ConversationOverlayStore.saveOverlay(key, mergedDeletes, mergedEdits)
+
+				// Check if all entries are now deleted (auto-hide)
+				val raw = TranscriptMessageCounter.loadUnreadTranscript(source, item.transcriptPath, cwd)
+				val updatedOverlay = ConversationOverlayStore.loadOverlay(key)
+				val remaining = ConversationOverlayStore.applyOverlay(raw, updatedOverlay)
+
+				SwingUtilities.invokeLater {
+					if (remaining.isEmpty()) {
+						// Auto-hide: dismiss the conversation and close the tab
+						ApplicationManager.getApplication().executeOnPooledThread {
+							HiddenConversationsStore.hideConversation(cwd, source, item.sessionId)
+							SwingUtilities.invokeLater {
+								FileEditorManager.getInstance(project).closeFile(file)
+								onSaved?.invoke()
+							}
+						}
+					} else {
+						// Reload to show updated state
+						loadTranscript()
+						onSaved?.invoke()
+					}
+				}
+			} catch (e: Exception) {
+				SwingUtilities.invokeLater {
+					saveButton.isEnabled = true
+					saveButton.text = "Save All"
+					statusLabel.text = "Save failed: ${e.message}"
+				}
+			}
+		}
+	}
+
+	companion object {
+		private fun escapeHtml(text: String): String = text
+			.replace("&", "&amp;")
+			.replace("<", "&lt;")
+			.replace(">", "&gt;")
+	}
+}

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/ConversationRowComponent.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/ConversationRowComponent.kt
@@ -1,0 +1,135 @@
+package ai.jolli.jollimemory.toolwindow
+
+import ai.jolli.jollimemory.core.ActiveConversationItem
+import ai.jolli.jollimemory.core.TranscriptSource
+import com.intellij.icons.AllIcons
+import com.intellij.ui.JBColor
+import com.intellij.util.ui.JBUI
+import java.awt.*
+import java.awt.event.MouseAdapter
+import java.awt.event.MouseEvent
+import javax.swing.JLabel
+import javax.swing.JPanel
+
+/**
+ * A single row in the [ActiveConversationsPanel]. Displays a color-coded
+ * source badge, the conversation title, an unread message count, and a
+ * hide button that appears on hover.
+ */
+class ConversationRowComponent(
+	val item: ActiveConversationItem,
+	private val onRowClicked: (ActiveConversationItem) -> Unit,
+	private val onHide: (ActiveConversationItem) -> Unit,
+) : JPanel(BorderLayout()) {
+
+	private val hideLabel = JLabel(AllIcons.Actions.GC).apply {
+		cursor = Cursor.getPredefinedCursor(Cursor.HAND_CURSOR)
+		toolTipText = "Hide conversation"
+		isVisible = false
+		border = JBUI.Borders.emptyRight(4)
+	}
+
+	init {
+		border = JBUI.Borders.empty(4, 8)
+		isOpaque = true
+		cursor = Cursor.getPredefinedCursor(Cursor.HAND_CURSOR)
+
+		// Source badge
+		val badge = SourceBadge(item.source)
+		add(badge, BorderLayout.WEST)
+
+		// Title (center, truncates)
+		val titleLabel = JLabel(item.title).apply {
+			border = JBUI.Borders.emptyLeft(8)
+		}
+		add(titleLabel, BorderLayout.CENTER)
+
+		// Right side: message count + hide button
+		val rightPanel = JPanel(FlowLayout(FlowLayout.RIGHT, JBUI.scale(4), 0)).apply {
+			isOpaque = false
+		}
+		if (item.messageCount > 0) {
+			rightPanel.add(JLabel("${item.messageCount}").apply {
+				foreground = JBColor.GRAY
+				font = font.deriveFont(font.size2D - 1f)
+			})
+		}
+		rightPanel.add(hideLabel)
+		add(rightPanel, BorderLayout.EAST)
+
+		// Click handlers
+		hideLabel.addMouseListener(object : MouseAdapter() {
+			override fun mouseClicked(e: MouseEvent) {
+				e.consume()
+				onHide(item)
+			}
+		})
+
+		val hoverListener = object : MouseAdapter() {
+			override fun mouseEntered(e: MouseEvent) {
+				background = JBColor(Color(0, 0, 0, 20), Color(255, 255, 255, 20))
+				hideLabel.isVisible = true
+			}
+
+			override fun mouseExited(e: MouseEvent) {
+				// Only hide if mouse actually left the row bounds
+				val p = e.point
+				val src = e.source as Component
+				val screenPoint = src.locationOnScreen.apply { translate(p.x, p.y) }
+				val rowLoc = this@ConversationRowComponent.locationOnScreen
+				val rowBounds = Rectangle(rowLoc.x, rowLoc.y, width, height)
+				if (!rowBounds.contains(screenPoint)) {
+					background = null
+					hideLabel.isVisible = false
+				}
+			}
+		}
+		val clickListener = object : MouseAdapter() {
+			override fun mouseClicked(e: MouseEvent) {
+				onRowClicked(item)
+			}
+		}
+		addMouseListener(hoverListener)
+		addMouseListener(clickListener)
+		// Forward events from all children
+		for (c in listOf(badge, titleLabel, rightPanel, hideLabel)) {
+			c.addMouseListener(hoverListener)
+			if (c !== hideLabel) c.addMouseListener(clickListener)
+		}
+	}
+
+	override fun getMaximumSize(): Dimension =
+		Dimension(Int.MAX_VALUE, preferredSize.height)
+}
+
+/** Small color-coded label showing the AI source name. */
+private class SourceBadge(source: TranscriptSource) : JLabel(source.name) {
+	private val badgeColor = SOURCE_COLORS[source] ?: JBColor.GRAY
+	private val arcSize = JBUI.scale(8)
+
+	init {
+		foreground = Color.WHITE
+		font = font.deriveFont(Font.BOLD, font.size2D - 2f)
+		isOpaque = false
+		border = JBUI.Borders.empty(1, 6, 1, 6)
+	}
+
+	override fun paintComponent(g: Graphics) {
+		val g2 = g.create() as Graphics2D
+		g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON)
+		g2.color = badgeColor
+		g2.fillRoundRect(0, 0, width, height, arcSize, arcSize)
+		g2.dispose()
+		super.paintComponent(g)
+	}
+
+	companion object {
+		private val SOURCE_COLORS = mapOf(
+			TranscriptSource.claude to JBColor(Color(217, 119, 6), Color(217, 119, 6)),
+			TranscriptSource.gemini to JBColor(Color(5, 150, 105), Color(5, 150, 105)),
+			TranscriptSource.codex to JBColor(Color(124, 58, 237), Color(124, 58, 237)),
+			TranscriptSource.opencode to JBColor(Color(37, 99, 235), Color(37, 99, 235)),
+			TranscriptSource.cursor to JBColor(Color(220, 38, 38), Color(220, 38, 38)),
+		)
+	}
+}

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/ConversationVirtualFile.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/ConversationVirtualFile.kt
@@ -1,0 +1,36 @@
+package ai.jolli.jollimemory.toolwindow
+
+import ai.jolli.jollimemory.core.ActiveConversationItem
+import com.intellij.testFramework.LightVirtualFile
+
+/**
+ * Lightweight virtual file that carries an [ActiveConversationItem].
+ * Used to open conversation transcripts as editor tabs in the main editor area.
+ */
+class ConversationVirtualFile(
+	val item: ActiveConversationItem,
+	val cwd: String,
+) : LightVirtualFile(
+	"${sourceEmoji(item.source.name)} ${item.title}",
+	"",
+) {
+	/** Stable identity so the same conversation always reuses the same tab. */
+	override fun equals(other: Any?): Boolean {
+		if (this === other) return true
+		if (other !is ConversationVirtualFile) return false
+		return item.source == other.item.source && item.sessionId == other.item.sessionId
+	}
+
+	override fun hashCode(): Int = 31 * item.source.hashCode() + item.sessionId.hashCode()
+
+	override fun isWritable(): Boolean = false
+}
+
+private fun sourceEmoji(source: String): String = when (source) {
+	"claude" -> "\uD83D\uDFE0"  // orange circle
+	"gemini" -> "\uD83D\uDFE2"  // green circle
+	"codex" -> "\uD83D\uDFE3"   // purple circle
+	"opencode" -> "\uD83D\uDD35" // blue circle
+	"cursor" -> "\uD83D\uDD34"  // red circle
+	else -> "\u2B1C"             // white square
+}

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/JolliMemoryToolWindowFactory.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/JolliMemoryToolWindowFactory.kt
@@ -151,6 +151,7 @@ class JolliMemoryToolWindowFactory : ToolWindowFactory, DumbAware {
 
         // Create the panels (Memories + Commits are merged into CommitsPanel)
         val statusPanel = StatusPanel(project, service)
+        val conversationsPanel = ActiveConversationsPanel(project, service)
         val plansPanel = PlansPanel(project, service)
         val changesPanel = ChangesPanel(project, service)
         val commitsPanel = CommitsPanel(project, service)
@@ -158,6 +159,7 @@ class JolliMemoryToolWindowFactory : ToolWindowFactory, DumbAware {
         // Register panels for action lookup
         val registry = PanelRegistry().apply {
             this.statusPanel = statusPanel
+            this.activeConversationsPanel = conversationsPanel
             this.plansPanel = plansPanel
             this.changesPanel = changesPanel
             this.commitsPanel = commitsPanel
@@ -170,6 +172,9 @@ class JolliMemoryToolWindowFactory : ToolWindowFactory, DumbAware {
         // STATUS is no longer a collapsible — it takes the full content area as
         // a dedicated card when the breadcrumb status button is toggled on,
         // matching VS Code's full-pane status view.
+        val conversationsCollapsible = CollapsiblePanel(
+            "CONVERSATIONS", "JolliMemory.ConversationsActions", conversationsPanel,
+        )
         val plansCollapsible = CollapsiblePanel("PLANS & NOTES", "JolliMemory.PlansActions", plansPanel)
         val changesCollapsible = CollapsiblePanel("CHANGES", "JolliMemory.ChangesActions", changesPanel)
         val memoriesCollapsible = CollapsiblePanel(
@@ -180,6 +185,8 @@ class JolliMemoryToolWindowFactory : ToolWindowFactory, DumbAware {
         // and expanded panels share the remaining vertical space proportionally.
         // Resize dividers between panels allow users to drag and adjust panel heights.
         val accordionPanel = JPanel(AccordionLayout()).apply {
+            add(conversationsCollapsible)
+            add(ResizeDivider())
             add(plansCollapsible)
             add(ResizeDivider())
             add(changesCollapsible)
@@ -190,6 +197,7 @@ class JolliMemoryToolWindowFactory : ToolWindowFactory, DumbAware {
         // Add gear menu toggle actions to the tool window title bar,
         // allowing users to show/hide individual panels — like VS Code's "..." menu.
         val gearActions = DefaultActionGroup().apply {
+            add(TogglePanelAction(conversationsCollapsible))
             add(TogglePanelAction(memoriesCollapsible))
             add(TogglePanelAction(plansCollapsible))
             add(TogglePanelAction(changesCollapsible))

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/PanelRegistry.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/PanelRegistry.kt
@@ -15,4 +15,5 @@ class PanelRegistry {
 	var plansPanel: PlansPanel? = null
 	var changesPanel: ChangesPanel? = null
 	var commitsPanel: CommitsPanel? = null
+	var activeConversationsPanel: ActiveConversationsPanel? = null
 }

--- a/intellij/src/main/resources/META-INF/plugin.xml
+++ b/intellij/src/main/resources/META-INF/plugin.xml
@@ -36,6 +36,10 @@
         <fileEditorProvider
             implementation="ai.jolli.jollimemory.toolwindow.SummaryEditorProvider"/>
 
+        <!-- Editor tab provider for conversation transcript detail view -->
+        <fileEditorProvider
+            implementation="ai.jolli.jollimemory.toolwindow.ConversationEditorProvider"/>
+
         <!-- Notification group for balloon notifications (e.g., no-Git warning) -->
         <notificationGroup
             id="JolliMemory"
@@ -98,6 +102,15 @@
                     class="ai.jolli.jollimemory.actions.RefreshChangesAction"
                     text="Refresh Changes"
                     description="Refresh changed files"
+                    icon="AllIcons.Actions.Refresh"/>
+        </group>
+
+        <!-- Conversations panel actions -->
+        <group id="JolliMemory.ConversationsActions" text="JolliMemory Conversations">
+            <action id="JolliMemory.RefreshConversations"
+                    class="ai.jolli.jollimemory.actions.RefreshConversationsAction"
+                    text="Refresh Conversations"
+                    description="Refresh active conversations"
                     icon="AllIcons.Actions.Refresh"/>
         </group>
 

--- a/intellij/src/test/kotlin/ai/jolli/jollimemory/toolwindow/ConversationSaveLogicTest.kt
+++ b/intellij/src/test/kotlin/ai/jolli/jollimemory/toolwindow/ConversationSaveLogicTest.kt
@@ -1,0 +1,241 @@
+package ai.jolli.jollimemory.toolwindow
+
+import ai.jolli.jollimemory.core.*
+import ai.jolli.jollimemory.core.ConversationOverlayStore.EntryIdentity
+import ai.jolli.jollimemory.core.ConversationOverlayStore.OverlayEditRule
+import ai.jolli.jollimemory.core.ConversationOverlayStore.OverlayKey
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+
+/**
+ * Tests the save/overlay/hide workflow that ConversationFileEditor.doSave()
+ * implements. These tests exercise the backend directly without requiring
+ * IntelliJ UI fixtures.
+ */
+class ConversationSaveLogicTest {
+
+	@TempDir
+	lateinit var tempDir: File
+
+	private val cwd get() = tempDir.absolutePath
+
+	@BeforeEach
+	fun setUp() {
+		File(tempDir, ".jolli/jollimemory").mkdirs()
+	}
+
+	private fun key(source: TranscriptSource = TranscriptSource.claude, sessionId: String = "s1") =
+		OverlayKey(cwd, source, sessionId)
+
+	private fun entry(role: String, content: String, timestamp: String? = null) =
+		TranscriptEntry(role, content, timestamp)
+
+	private fun identity(role: String, content: String, timestamp: String? = null) =
+		EntryIdentity(role, content, timestamp)
+
+	private fun edit(role: String, content: String, newContent: String, timestamp: String? = null) =
+		OverlayEditRule(role, content, timestamp, newContent)
+
+	// ── Identity derivation anchors to raw entries ──────────────────────
+
+	@Nested
+	inner class IdentityAnchoring {
+		@Test
+		fun `identity is derived from raw entry content, not edited content`() {
+			val k = key()
+			val rawEntries = listOf(
+				entry("human", "original question"),
+				entry("assistant", "original answer"),
+			)
+
+			// Simulate: user edits entry 1 to "better answer"
+			// Identity must anchor to "original answer" (the raw content)
+			val edits = listOf(edit("assistant", "original answer", "better answer"))
+			ConversationOverlayStore.saveOverlay(k, emptyList(), edits)
+
+			val overlay = ConversationOverlayStore.loadOverlay(k)
+			overlay shouldNotBe null
+			overlay!!.edits shouldHaveSize 1
+			overlay.edits[0].content shouldBe "original answer"
+			overlay.edits[0].newContent shouldBe "better answer"
+
+			// Apply overlay to raw entries
+			val displayed = ConversationOverlayStore.applyOverlay(rawEntries, overlay)
+			displayed shouldHaveSize 2
+			displayed[1].content shouldBe "better answer"
+		}
+
+		@Test
+		fun `chained edits preserve identity through raw content`() {
+			val k = key()
+			val rawContent = "original"
+
+			// First save: edit "original" → "version2"
+			ConversationOverlayStore.saveOverlay(k, emptyList(), listOf(edit("human", rawContent, "version2")))
+
+			// Second save: user sees "version2" but identity must still anchor to "original"
+			// (simulating what the editor does: rawEntries has deletes-only applied)
+			val existing = ConversationOverlayStore.loadOverlay(k)
+			val (mergedDeletes, mergedEdits) = ConversationOverlayStore.mergeOverlay(
+				existing,
+				emptyList(),
+				listOf(edit("human", rawContent, "version3")),
+			)
+			ConversationOverlayStore.saveOverlay(k, mergedDeletes, mergedEdits)
+
+			val final_ = ConversationOverlayStore.loadOverlay(k)
+			final_ shouldNotBe null
+			final_!!.edits shouldHaveSize 1
+			final_.edits[0].content shouldBe rawContent
+			final_.edits[0].newContent shouldBe "version3"
+		}
+	}
+
+	// ── Delete wins over edit ───────────────────────────────────────────
+
+	@Nested
+	inner class DeleteWinsOverEdit {
+		@Test
+		fun `delete supersedes existing edit for same identity`() {
+			val k = key()
+			val raw = entry("human", "hello")
+
+			// First: save an edit
+			ConversationOverlayStore.saveOverlay(k, emptyList(), listOf(edit("human", "hello", "goodbye")))
+
+			// Then: delete the same entry
+			val existing = ConversationOverlayStore.loadOverlay(k)
+			val (mergedDeletes, mergedEdits) = ConversationOverlayStore.mergeOverlay(
+				existing,
+				listOf(identity("human", "hello")),
+				emptyList(),
+			)
+			ConversationOverlayStore.saveOverlay(k, mergedDeletes, mergedEdits)
+
+			val final_ = ConversationOverlayStore.loadOverlay(k)
+			final_ shouldNotBe null
+			final_!!.deletes shouldHaveSize 1
+			final_.edits.shouldBeEmpty()
+
+			// Apply: entry should be gone
+			val result = ConversationOverlayStore.applyOverlay(listOf(raw), final_)
+			result.shouldBeEmpty()
+		}
+
+		@Test
+		fun `editor excludes deleted indices from edits`() {
+			// Simulates the editor's doSave logic: if an index is in both
+			// deletedIndices and editedContent, only the delete is sent
+			val rawEntries = listOf(
+				entry("human", "q1"),
+				entry("assistant", "a1"),
+			)
+			val deletedIndices = setOf(0, 1)
+			val editedContent = mapOf(1 to "edited a1")
+
+			val newDeletes = deletedIndices.map { idx ->
+				val raw = rawEntries[idx]
+				identity(raw.role, raw.content, raw.timestamp)
+			}
+			val newEdits = editedContent
+				.filter { (idx, _) -> idx !in deletedIndices }
+				.map { (idx, newContent) ->
+					val raw = rawEntries[idx]
+					edit(raw.role, raw.content, newContent, raw.timestamp)
+				}
+
+			newDeletes shouldHaveSize 2
+			newEdits.shouldBeEmpty() // Both indices deleted, so no edits
+		}
+	}
+
+	// ── Auto-hide on empty ──────────────────────────────────────────────
+
+	@Nested
+	inner class AutoHideOnEmpty {
+		@Test
+		fun `hiding a conversation persists to hidden-conversations json`() {
+			HiddenConversationsStore.hideConversation(cwd, TranscriptSource.claude, "s1")
+
+			val state = HiddenConversationsStore.loadHiddenConversations(cwd)
+			HiddenConversationsStore.isHidden(state, TranscriptSource.claude, "s1") shouldBe true
+			HiddenConversationsStore.isHidden(state, TranscriptSource.claude, "s2") shouldBe false
+		}
+
+		@Test
+		fun `deleting all entries triggers overlay save then hide`() {
+			val k = key()
+			val rawEntries = listOf(
+				entry("human", "q1"),
+				entry("assistant", "a1"),
+			)
+
+			// Delete all entries
+			val deletes = rawEntries.map { identity(it.role, it.content, it.timestamp) }
+			ConversationOverlayStore.saveOverlay(k, deletes, emptyList())
+
+			// Verify all entries are gone after overlay
+			val overlay = ConversationOverlayStore.loadOverlay(k)
+			val remaining = ConversationOverlayStore.applyOverlay(rawEntries, overlay)
+			remaining.shouldBeEmpty()
+
+			// Auto-hide
+			HiddenConversationsStore.hideConversation(cwd, TranscriptSource.claude, "s1")
+			val state = HiddenConversationsStore.loadHiddenConversations(cwd)
+			HiddenConversationsStore.isHidden(state, TranscriptSource.claude, "s1") shouldBe true
+		}
+	}
+
+	// ── Merge with existing overlay ─────────────────────────────────────
+
+	@Nested
+	inner class MergeWithExisting {
+		@Test
+		fun `mergeOverlay preserves existing rules and adds new ones`() {
+			val k = key()
+
+			// Save initial overlay with one edit
+			ConversationOverlayStore.saveOverlay(
+				k, emptyList(), listOf(edit("human", "q1", "edited q1")),
+			)
+
+			// Merge in a new delete for a different entry
+			val existing = ConversationOverlayStore.loadOverlay(k)
+			val (mergedDeletes, mergedEdits) = ConversationOverlayStore.mergeOverlay(
+				existing,
+				listOf(identity("assistant", "a1")),
+				emptyList(),
+			)
+
+			mergedDeletes shouldHaveSize 1
+			mergedDeletes[0].content shouldBe "a1"
+			mergedEdits shouldHaveSize 1
+			mergedEdits[0].content shouldBe "q1"
+		}
+
+		@Test
+		fun `new edit replaces existing edit for same identity`() {
+			val k = key()
+			ConversationOverlayStore.saveOverlay(
+				k, emptyList(), listOf(edit("human", "q1", "v1")),
+			)
+
+			val existing = ConversationOverlayStore.loadOverlay(k)
+			val (_, mergedEdits) = ConversationOverlayStore.mergeOverlay(
+				existing,
+				emptyList(),
+				listOf(edit("human", "q1", "v2")),
+			)
+
+			mergedEdits shouldHaveSize 1
+			mergedEdits[0].newContent shouldBe "v2"
+		}
+	}
+}


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## Quick recap

The IntelliJ plugin gained a full active conversations workflow, bringing it to feature parity with the VS Code extension's conversation review experience. The tool window now shows a live list of all active AI conversations from every connected source, refreshing in the background every minute. Each conversation can be opened as a persistent editor tab, where users can read the transcript, edit individual messages, mark entries for deletion, and save their changes — all without leaving the IDE. Multiple conversations can be open at once, and reopening the same conversation always reuses its existing tab.

The inline editing surface was built to feel native to the IDE: the edit field matches IntelliJ's theme and fonts, transcript text wraps naturally within the panel width, and scroll position is preserved across edits. Saving builds an overlay from the pending changes and merges it with any existing overlay; if every entry in a conversation is deleted, the conversation is auto-hidden and its tab closes automatically.

Two bugs that would have blocked the feature from being usable were also resolved. A startup crash prevented the tool window from loading at all — a null-safety fix in the collapsible panel's border logic addressed this. The trash can button on conversation rows was disappearing the moment the mouse moved toward it, making it impossible to hide a conversation from the list; the row now tracks whether the cursor has genuinely left the row area before hiding the button, and hover state is maintained correctly as the mouse moves across child elements within the row.

---

## E2E Test (3)
<details>
<summary><strong>1. Active conversations panel shows conversations and opens transcript tab</strong></summary>
<br>
<blockquote>

**Preconditions:** Have at least one active AI conversation (e.g. from Claude, Gemini, or another supported source) visible to the plugin.

**Steps:**
1. Open the Jolli Memory tool window panel on the side of the IDE.
2. Look for the "Conversations" section — it should show a list of active AI conversations, each with a colored badge showing the source name (e.g. "claude", "gemini"), a title, and a message count.
3. Click on any conversation row.
4. Check that a new tab opens in the main editor area with the conversation title (including a colored circle emoji) shown on the tab.
5. Verify the tab displays the conversation transcript with each message showing the sender role ("You" or "Assistant"), a timestamp, and the message content.
6. Switch back to the tool window and confirm the conversations list is still visible and unchanged.

**Expected Results:**
- The Conversations panel lists active conversations with color-coded source badges.
- Clicking a row opens a dedicated editor tab for that conversation — not a plain text file.
- The tab shows the full transcript with role labels, timestamps, and message content.
- The same conversation row can be clicked again and reuses the existing tab rather than opening a duplicate.

</blockquote>
</details>
<details>
<summary><strong>2. Hide a conversation from the panel</strong></summary>
<br>
<blockquote>

**Preconditions:** Have at least one active AI conversation visible in the Conversations panel.

**Steps:**
1. Open the Jolli Memory tool window and locate the Conversations panel.
2. Hover your mouse over one of the conversation rows.
3. A small icon (trash/hide button) should appear on the right side of the row — click it.
4. Verify that the conversation disappears from the list immediately.
5. If no conversations remain, check that the panel shows a "No active conversations" message in the center.

**Expected Results:**
- The hide button only appears when hovering over a row, not all the time.
- Clicking the hide button removes that conversation from the list without affecting other rows.
- If the list becomes empty, a "No active conversations" placeholder message is shown.

</blockquote>
</details>
<details>
<summary><strong>3. Inline transcript editing — edit, delete, save, and cancel changes</strong></summary>
<br>
<blockquote>

**Preconditions:** Have at least one active AI conversation with multiple messages. Open it as an editor tab by clicking its row in the Conversations panel.

**Steps:**
1. In the open conversation tab, click on the text content of any message — the text area should become an editable field.
2. Change the text to something different, then click somewhere else outside the field to confirm the edit.
3. Check that the footer at the bottom now shows a count of modified entries and the "Save All" button is enabled (e.g. "Save All (1)").
4. Click the small delete icon on a different message row to mark it for deletion. Verify the footer count increases and the deleted message appears grayed out.
5. Click "Cancel" — confirm all changes are discarded, the transcript returns to its original state, and the "Save All" button becomes disabled.
6. Repeat steps 1–4, then click "Save All" and verify the tab reloads showing the saved edits and the deleted message removed.

**Expected Results:**
- Clicking message content opens an inline editor for that message only.
- The footer accurately tracks the number of modified and deleted entries.
- "Cancel" fully discards all pending changes with no save occurring.
- "Save All" persists the changes; the transcript reloads reflecting the new state.
- If every message is deleted and saved, the tab closes automatically and the conversation is removed from the panel.

</blockquote>
</details>

---

## Topics (4)
<details>
<summary><strong>01 · Fix hover button disappearing before click can register on conversation rows</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The trash can button on conversation rows vanished the moment the mouse moved toward it, making it impossible to actually hide a conversation from the list.

**💡 Decisions Behind the Code**

- **Bounds-check on exit rather than relying on component hierarchy**: Mouse exit events fire whenever the cursor moves between parent and child components, not just when it leaves the visible row area. Checking actual screen coordinates on exit reliably distinguishes "moved to a child" from "left the row entirely," without restructuring the component tree or adding a glass-pane overlay. This keeps the fix local and low-risk.
- **Separate hover and click listeners**: Splitting the two behaviors into distinct listener objects made it straightforward to attach hover tracking to every child — keeping the highlight and button visible — while withholding the row-click action from the hide button specifically. Combining them into one object would have required conditional logic inside a single handler, which is harder to reason about and more fragile to extend.

**✅ What Was Implemented**

In `ConversationRowComponent.kt`, the `mouseExited` handler was updated to check whether the mouse actually left the row's visible area on screen before hiding the hover button. The fix computes the absolute screen position of the exit event and compares it against the row's bounding rectangle, only hiding the button when the cursor has genuinely left the row.

- Hover and click listeners were split into two separate listener objects (`hoverListener` and `clickListener`) and both are now forwarded to all child components, including the right-side panel and the hide button label. Previously only the badge and title label forwarded events, leaving the button panel unmonitored.
- The hide button label is excluded from receiving the row-click listener, so clicking the trash icon triggers only the hide action and not the row selection handler.

**📁 FILES**
- `intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/ConversationRowComponent.kt`

</blockquote>
</details>
<details>
<summary><strong>02 · Active conversations panel with clickable rows opening transcript editor tabs</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The tool window needed a dedicated panel listing all active AI conversations from every connected source, so users could see what conversations were in progress and open them for review or editing.

**💡 Decisions Behind the Code**

- **Editor tab over tool window panel**: Opening transcripts as editor tabs mirrors how VS Code embeds its conversation details view. This lets users keep multiple conversations open simultaneously, switch between them with standard tab controls, and continue working in the editor area without losing their place.
- **Virtual file as the tab identity carrier**: IntelliJ's editor tab system requires a virtual file to identify a tab. A lightweight in-memory virtual file was used rather than a real file on disk, with equality overridden on source and session ID so reopening the same conversation reuses the existing tab rather than opening a duplicate.

**✅ What Was Implemented**

- `ActiveConversationsPanel.kt` was created as the main panel component. It polls for active conversations every 60 seconds while visible, shows a warning banner when any source fails to load, and renders a scrollable list of `ConversationRowComponent` rows. Clicking a row opens the conversation as an editor tab; a hide button on each row dismisses the conversation from the list.
- `ConversationRowComponent.kt` was created to render individual rows with a color-coded source badge (using rounded-rectangle painting), a truncating title label, a message count, and a hide button that appears only on hover and stays visible long enough to be clicked.
- `ConversationVirtualFile.kt` and `ConversationEditorProvider.kt` were created to integrate with IntelliJ's editor tab system. The virtual file carries the conversation item as its payload and uses emoji-prefixed titles; the provider intercepts opens of these files and routes them to `ConversationFileEditor` instead of the default text editor.

**📁 FILES**
- `intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/ActiveConversationsPanel.kt`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/ConversationRowComponent.kt`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/ConversationVirtualFile.kt`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/ConversationEditorProvider.kt`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/JolliMemoryToolWindowFactory.kt`

</blockquote>
</details>
<details>
<summary><strong>03 · Inline transcript editing with delete, restore, and save in editor tab</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Once conversations could be opened as editor tabs, users needed to be able to edit or delete individual transcript entries and save those changes as overlays, matching the editing behavior already present in the VS Code extension.

**💡 Decisions Behind the Code**

- **IntelliJ native editor component over plain text area**: The plain Java text area component has no awareness of IntelliJ's theme, rendering with mismatched colors and fonts. Switching to IntelliJ's native editor component made the editing surface match the IDE's look and feel automatically, with no functional behavior change.
- **Border layout for entry content over box layout**: The transcript text was rendering far to the right of the role label. Box layout applies alignment math across all children, and the HTML-rendered content label and the header row had different alignment values. Switching the entry's content area to a border layout eliminated the alignment math entirely and let the text fill the available width naturally.
- **Word-wrapping text area for read-only display**: A plain label component computes a fixed preferred width and does not reflow, so it was replaced with a text area configured for word-wrap, which handles reflowing natively within the panel width without requiring HTML rendering.

**✅ What Was Implemented**

- `ConversationFileEditor.kt` was created as the full editor tab implementation. It loads raw transcript entries, applies any existing overlay, and renders each entry as a row with a role label, formatted timestamp, and content area. Clicking the content area opens an inline editor for editing; a delete/restore button on each row toggles the entry's deletion state.
- The footer tracks pending edit and deletion counts, enables the Save All button only when changes exist, and wires a Cancel button to discard all pending changes. On save, identity-based overlay rules are built from the raw entries and merged with any existing overlay; if all entries end up deleted the conversation is auto-hidden and the tab is closed.
- Scroll position is preserved across re-renders triggered by edits or deletions, and the transcript always loads scrolled to the top.

**📋 Future Enhancements**

The Save All button only becomes enabled after the user clicks outside the edit field, since focus loss is what triggers change recording. A document listener on the edit field could enable Save as soon as the user starts typing — this was discussed but not implemented.

**📁 FILES**
- `intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/ConversationFileEditor.kt`

</blockquote>
</details>
<details>
<summary><strong>04 · Fix tool window crash on startup caused by null border merge</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The tool window was failing to load at all due to a crash when constructing the conversations collapsible panel, caused by a border-merging call receiving a null value.

**💡 Decisions Behind the Code**

A null check was added at the merge site rather than guaranteeing a non-null border upstream. This handles the general case where any collapsible panel's content might have no border set, rather than requiring every caller to pre-populate a border just to satisfy the merge call. The fix is therefore safer and more broadly applicable.

**✅ What Was Implemented**

In `CollapsiblePanel.kt`, the border merge call was updated to check whether the content panel already has a border before attempting to merge. When no existing border is present, only the separator border is applied directly instead of trying to combine it with null.

**📁 FILES**
- `intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/CollapsiblePanel.kt`

</blockquote>
</details>

---

*Generated by Jolli Memory · May 26, 2026 at 3:39 PM · via Anthropic*
<!-- jollimemory-summary-end -->