### PR TITLE
Add unified LLM error marker with summaryError field and webview banner

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,6 +141,9 @@ URL/HTML escaping is consolidated in `cli/src/site/Sanitize.ts` — every layout
 ## Project conventions worth knowing
 
 - **Biome** is the formatter and linter (config: [`cli/biome.json`](cli/biome.json)). Tabs, 4-wide, 120 column limit. Rules of note: `noExplicitAny: error`, `noUnusedImports/Variables: error`, `useImportType: warn`. CI runs `biome check --error-on-warnings` — warnings fail.
+
+- **Use `toForwardSlash` for `\` → `/` path normalization** ([`cli/src/core/PathUtils.ts`](cli/src/core/PathUtils.ts)); never inline `path.replace(/\\/g, "/")` or `path.split(sep).join("/")`. Forward-slash form is the [`StorageProvider.listFiles`](cli/src/core/StorageProvider.ts) contract and the input every downstream regex / prefix consumer expects — one forgotten inline normalization on Windows silently broke webview transcripts in production. The helper does **only** `\` → `/`: if you also need lowercasing or trailing-slash strip, use `normalizePathForCompare` instead. Biome cannot lint this pattern, so the rule is enforced socially — inline reintroduction is a review-blocker. Exempt: code already inside a domain helper that wraps the conversion (`normalizePathForCompare`, `normalizePathForMatch`, `toFileUrl`, `validateRelPath`); tests asserting on a specific separator; regexes whose `\\/g` is matching a literal backslash for non-path reasons.
+
 - **Never include AI/Claude co-author information in commit messages.** No `Co-Authored-By: Claude …` trailers, no "🤖 Generated with …" footers — for either commits or PR descriptions. The repo is going open-source and history should read as human-authored work; only `Signed-off-by:` is required.
 
 (The DCO sign-off, `npm run all` gate, CLI coverage floor, and worktree-aware requirement are stated as critical rules at the top of this file; they are not repeated here to keep this file as a single source of truth.)

--- a/cli/DEVELOPMENT.md
+++ b/cli/DEVELOPMENT.md
@@ -338,8 +338,8 @@ If an existing hook file exists, Jolli Memory's section is appended. On uninstal
 | No active session | Skip summary, infer topics from diff alone if possible |
 | Transcript file missing | Log error, skip that session |
 | No new transcript entries + no file changes | Skip summary generation |
-| API key missing | Throw with setup instructions |
-| API call fails | Retry once (2s delay), then save minimal record (empty topics, `stopReason: "error"`) |
+| LLM call fails (any cause: network, 5xx, credential, quota) | Retry once (2s), then persist a placeholder summary with `summaryError: "llm-failed"`. Amend and squash paths preserve their existing fallback content (Copy-Hoist or mechanical merge); normal commit lands empty `topics`. Webview surfaces a Regenerate banner; Push to Jolli refuses summaries with this marker. |
+| LLM consolidate has nothing to merge (no sources / all empty / LLM self-reported empty) | Mechanical fallback **without** `summaryError` — healthy "nothing to consolidate" case. |
 | API returns non-JSON | Attempt JSON extraction from markdown fences, fallback to raw text |
 | Orphan branch doesn't exist | Auto-create (idempotent) |
 | Existing git hook | Append Jolli Memory section with markers |

--- a/cli/src/Types.ts
+++ b/cli/src/Types.ts
@@ -238,6 +238,21 @@ export type CommitType = "commit" | "amend" | "squash" | "rebase" | "cherry-pick
 export type CommitSource = "cli" | "plugin";
 
 /**
+ * Closed enumeration of summary-error markers. Extend by adding a new
+ * literal here and updating `isSummaryError` in `core/SummaryErrorMarker.ts`.
+ *
+ * Values:
+ *   - "llm-failed": the SUMMARIZE / CONSOLIDATE LLM call failed after one
+ *     retry (network error, 5xx, credential failure, quota, etc.). The
+ *     summary still landed (with empty topics for fresh commits,
+ *     Copy-Hoisted topics for amend short-circuit, or mechanically-merged
+ *     topics for amend step-2 / squash fallback) so downstream pipelines
+ *     never face missing source summaries, but the user is prompted to
+ *     regenerate via the webview banner.
+ */
+export type SummaryErrorKind = "llm-failed";
+
+/**
  * Complete summary for a single git commit (v3 tree format).
  *
  * Tree structure: each node may have its own topics/stats/llm data, plus optional
@@ -314,6 +329,19 @@ export interface CommitSummary {
 	 * authoritative consolidated value).
 	 */
 	readonly recap?: string;
+	/**
+	 * Marker indicating the summary was produced under a degraded LLM path.
+	 * Set by all four LLM-call sites in QueueWorker (normal commit, amend
+	 * step-1, amend step-2 consolidate, squash consolidate) when the LLM
+	 * call fails after one retry. Absent on healthy summaries. Cleared
+	 * explicitly by Regenerator on a successful re-run.
+	 *
+	 * Legacy summaries written before this field existed signal the same
+	 * condition via `llm?.stopReason === "error"`; readers MUST consult both
+	 * fields via the shared `isSummaryError` helper in
+	 * `core/SummaryErrorMarker.ts`.
+	 */
+	readonly summaryError?: SummaryErrorKind;
 	/**
 	 * Child summaries forming a tree. Ordered by commitDate descending (newest first).
 	 * - Amend: children = [original summary before amend]

--- a/cli/src/core/Regenerator.test.ts
+++ b/cli/src/core/Regenerator.test.ts
@@ -125,6 +125,34 @@ describe("regenerateSummary", () => {
 		);
 	});
 
+	it("clears summaryError marker on successful regenerate", async () => {
+		const stale: CommitSummary = {
+			...baseSummary,
+			summaryError: "llm-failed",
+			topics: [],
+		};
+		const { updated } = await regenerateSummary(stale, "/repo", config);
+		expect(updated.summaryError).toBeUndefined();
+		expect(updated.topics).toEqual(successResult.topics);
+	});
+
+	it("also clears summaryError when the regenerate input had legacy stopReason='error' but no marker", async () => {
+		// Legacy summaries written before the summaryError field existed
+		// still surface in the banner via isSummaryError(stopReason==="error").
+		// Regenerate replaces `llm` wholesale with the new successResult,
+		// which has stopReason=null, so isSummaryError naturally returns
+		// false on the updated summary even though summaryError was never
+		// set on the input. This test pins that observable behavior.
+		const legacy: CommitSummary = {
+			...baseSummary,
+			llm: { model: "x", inputTokens: 0, outputTokens: 0, apiLatencyMs: 0, stopReason: "error" },
+			topics: [],
+		};
+		const { updated } = await regenerateSummary(legacy, "/repo", config);
+		expect(updated.summaryError).toBeUndefined();
+		expect(updated.llm?.stopReason).not.toBe("error");
+	});
+
 	it("replaces topics + recap; preserves ticketId, e2eTestGuide, and other fields", async () => {
 		const baseWithTicket: CommitSummary = {
 			...baseSummary,

--- a/cli/src/core/Regenerator.ts
+++ b/cli/src/core/Regenerator.ts
@@ -144,6 +144,11 @@ export async function regenerateSummary(
 		...(result.conversationTurns !== undefined ? { conversationTurns: result.conversationTurns } : {}),
 		diffStats: result.stats,
 		generatedAt: new Date().toISOString(),
+		// Successful regenerate clears any stale failure marker so the
+		// webview banner disappears on the next render. Explicit undefined
+		// instead of leaving the spread-in value alone: JSON.stringify
+		// drops undefined keys, so storeSummary persists a healthy summary.
+		summaryError: undefined,
 	};
 
 	return { updated, result };

--- a/cli/src/core/Summarizer.test.ts
+++ b/cli/src/core/Summarizer.test.ts
@@ -27,6 +27,7 @@ import {
 	parseSummaryResponse,
 	parseTopLevelFields,
 	resolveModelId,
+	type SquashConsolidationResult,
 	type SquashConsolidationSource,
 	TOP_LEVEL_MARKERS,
 	translateToEnglish,
@@ -2088,13 +2089,23 @@ Test reordering
 			config: mockConfig,
 		});
 
-		it("returns null when there are no sources", async () => {
+		// Type narrowing helper: lets the rest of the test body access the
+		// success-payload fields without `as` casts everywhere.
+		function assertOk(
+			outcome: Awaited<ReturnType<typeof generateSquashConsolidation>>,
+		): asserts outcome is { status: "ok" } & SquashConsolidationResult {
+			if (outcome.status !== "ok") {
+				throw new Error(`expected status="ok", got status="${outcome.status}"`);
+			}
+		}
+
+		it("returns no-content when there are no sources", async () => {
 			const result = await generateSquashConsolidation(params([]));
-			expect(result).toBeNull();
+			expect(result).toEqual({ status: "no-content" });
 			expect(mockCallLlm).not.toHaveBeenCalled();
 		});
 
-		it("returns null when every source has empty topics and no recap", async () => {
+		it("returns no-content when every source has empty topics and no recap", async () => {
 			const empty: SquashConsolidationSource = {
 				commitHash: "a",
 				commitDate: "2026-03-10T00:00:00Z",
@@ -2102,7 +2113,7 @@ Test reordering
 				topics: [],
 			};
 			const result = await generateSquashConsolidation(params([empty]));
-			expect(result).toBeNull();
+			expect(result).toEqual({ status: "no-content" });
 			expect(mockCallLlm).not.toHaveBeenCalled();
 		});
 
@@ -2113,10 +2124,10 @@ Test reordering
 				),
 			);
 			const result = await generateSquashConsolidation(params([sourceWithTopic("a", "2026-03-10T00:00:00Z")]));
-			expect(result).not.toBeNull();
-			expect(result?.topics[0].title).toBe("Merged topic");
-			expect(result?.recap).toBe("A recap.");
-			expect(result?.ticketId).toBe("PROJ-1");
+			assertOk(result);
+			expect(result.topics[0].title).toBe("Merged topic");
+			expect(result.recap).toBe("A recap.");
+			expect(result.ticketId).toBe("PROJ-1");
 			expect(mockCallLlm).toHaveBeenCalledWith(
 				expect.objectContaining({
 					action: "squash-consolidate",
@@ -2167,12 +2178,12 @@ Test reordering
 
 			const result = await generateSquashConsolidation(params([sourceWithTopic("a", "2026-03-10T00:00:00Z")]));
 
-			expect(result).not.toBeNull();
-			expect(result?.topics).toHaveLength(2);
-			expect(result?.recap).toBe("Consolidated recap that arrived after the last topic.");
+			assertOk(result);
+			expect(result.topics).toHaveLength(2);
+			expect(result.recap).toBe("Consolidated recap that arrived after the last topic.");
 			// Last topic's importance survived intact (no recap content glued onto it).
-			expect(result?.topics[1].title).toBe("Last merged topic");
-			expect(result?.topics[1].importance).toBe("minor");
+			expect(result.topics[1].title).toBe("Last merged topic");
+			expect(result.topics[1].importance).toBe("minor");
 		});
 
 		it("prefers the outer ticketId over the LLM-extracted one (priority chain)", async () => {
@@ -2184,7 +2195,8 @@ Test reordering
 			const result = await generateSquashConsolidation(
 				params([sourceWithTopic("a", "2026-03-10T00:00:00Z", "PER-A")], "OUTER-99"),
 			);
-			expect(result?.ticketId).toBe("OUTER-99");
+			assertOk(result);
+			expect(result.ticketId).toBe("OUTER-99");
 		});
 
 		it("falls back to the earliest source's ticketId when no outer ticketId and the LLM omits one", async () => {
@@ -2199,13 +2211,14 @@ Test reordering
 					sourceWithTopic("b", "2026-03-20T00:00:00Z", "FROM-B"),
 				]),
 			);
-			expect(result?.ticketId).toBe("FROM-A");
+			assertOk(result);
+			expect(result.ticketId).toBe("FROM-A");
 		});
 
-		it("returns null when the LLM produces no topics and no recap", async () => {
+		it("returns no-content when the LLM produces no topics and no recap", async () => {
 			mockCallLlm.mockResolvedValueOnce(summaryLlmResult(""));
 			const result = await generateSquashConsolidation(params([sourceWithTopic("a", "2026-03-10T00:00:00Z")]));
-			expect(result).toBeNull();
+			expect(result).toEqual({ status: "no-content" });
 		});
 
 		it("retries once on transient API failure and returns the second attempt's result", async () => {
@@ -2216,14 +2229,15 @@ Test reordering
 				),
 			);
 			const result = await generateSquashConsolidation(params([sourceWithTopic("a", "2026-03-10T00:00:00Z")]));
-			expect(result?.topics[0].title).toBe("Retried");
+			assertOk(result);
+			expect(result.topics[0].title).toBe("Retried");
 			expect(mockCallLlm).toHaveBeenCalledTimes(2);
 		});
 
-		it("returns null when both attempts fail", async () => {
+		it("returns llm-error when both attempts fail", async () => {
 			mockCallLlm.mockRejectedValueOnce(new Error("first")).mockRejectedValueOnce(new Error("second"));
 			const result = await generateSquashConsolidation(params([sourceWithTopic("a", "2026-03-10T00:00:00Z")]));
-			expect(result).toBeNull();
+			expect(result).toEqual({ status: "llm-error" });
 			expect(mockCallLlm).toHaveBeenCalledTimes(2);
 		});
 
@@ -2249,7 +2263,8 @@ Test reordering
 				expect(calls[0][0].action).toBe("squash-consolidate");
 				expect(calls[1][0].action).toBe("squash-consolidate-strict");
 				expect(calls[1][0].params.previousResponse).toContain("## Consolidated Summary");
-				expect(result?.topics[0].title).toBe("Recovered");
+				assertOk(result);
+				expect(result.topics[0].title).toBe("Recovered");
 			});
 
 			it("sums LLM tokens across the two calls when squash strict-retry succeeds", async () => {
@@ -2270,9 +2285,10 @@ Test reordering
 				const result = await generateSquashConsolidation(
 					params([sourceWithTopic("a", "2026-03-10T00:00:00Z")]),
 				);
-				expect(result?.llm?.inputTokens).toBe(250);
-				expect(result?.llm?.outputTokens).toBe(180);
-				expect(result?.llm?.apiLatencyMs).toBe(2700);
+				assertOk(result);
+				expect(result.llm.inputTokens).toBe(250);
+				expect(result.llm.outputTokens).toBe(180);
+				expect(result.llm.apiLatencyMs).toBe(2700);
 			});
 
 			it("propagates source from the strict-retry result onto squash llm metadata", async () => {
@@ -2287,10 +2303,11 @@ Test reordering
 				const result = await generateSquashConsolidation(
 					params([sourceWithTopic("a", "2026-03-10T00:00:00Z")]),
 				);
-				expect(result?.llm?.source).toBe("jolli-proxy");
+				assertOk(result);
+				expect(result.llm.source).toBe("jolli-proxy");
 			});
 
-			it("falls through to null when both squash-consolidate and squash-consolidate-strict fail format check", async () => {
+			it("returns no-content when both squash-consolidate and squash-consolidate-strict fail format check", async () => {
 				mockCallLlm
 					.mockResolvedValueOnce(summaryLlmResult(malformedMarkdown))
 					.mockResolvedValueOnce(summaryLlmResult("more markdown ## still no delimiters"));
@@ -2298,18 +2315,18 @@ Test reordering
 					params([sourceWithTopic("a", "2026-03-10T00:00:00Z")]),
 				);
 				expect(mockCallLlm).toHaveBeenCalledTimes(2);
-				expect(result).toBeNull();
+				expect(result).toEqual({ status: "no-content" });
 			});
 
 			it("does NOT retry strict when first response is empty (format-compliant but no consolidation)", async () => {
 				// Empty response is format-compliant. Squash needs SOMETHING to consolidate, so
-				// we fall through to null (caller does mechanicalConsolidate) without burning a retry.
+				// we fall through to no-content (caller does mechanicalConsolidate) without burning a retry.
 				mockCallLlm.mockResolvedValueOnce(summaryLlmResult(""));
 				const result = await generateSquashConsolidation(
 					params([sourceWithTopic("a", "2026-03-10T00:00:00Z")]),
 				);
 				expect(mockCallLlm).toHaveBeenCalledTimes(1);
-				expect(result).toBeNull();
+				expect(result).toEqual({ status: "no-content" });
 			});
 
 			it("DOES retry strict on short non-compliant first response (length is no longer the gate)", async () => {
@@ -2324,10 +2341,11 @@ Test reordering
 					params([sourceWithTopic("a", "2026-03-10T00:00:00Z")]),
 				);
 				expect(mockCallLlm).toHaveBeenCalledTimes(2);
-				expect(result?.topics[0].title).toBe("Recovered");
+				assertOk(result);
+				expect(result.topics[0].title).toBe("Recovered");
 			});
 
-			it("falls through to null when squash-consolidate-strict throws", async () => {
+			it("returns llm-error when squash-consolidate-strict throws", async () => {
 				mockCallLlm
 					.mockResolvedValueOnce(summaryLlmResult(malformedMarkdown))
 					.mockRejectedValueOnce(new Error("strict retry transient error"));
@@ -2335,7 +2353,7 @@ Test reordering
 					params([sourceWithTopic("a", "2026-03-10T00:00:00Z")]),
 				);
 				expect(mockCallLlm).toHaveBeenCalledTimes(2);
-				expect(result).toBeNull();
+				expect(result).toEqual({ status: "llm-error" });
 			});
 
 			it("formats non-Error strict-retry throws via String(err) on the warn line", async () => {
@@ -2349,7 +2367,7 @@ Test reordering
 					params([sourceWithTopic("a", "2026-03-10T00:00:00Z")]),
 				);
 				expect(mockCallLlm).toHaveBeenCalledTimes(2);
-				expect(result).toBeNull();
+				expect(result).toEqual({ status: "llm-error" });
 			});
 
 			it("accepts strict-retry result with recap-only (zero topics)", async () => {
@@ -2367,8 +2385,9 @@ Test reordering
 					params([sourceWithTopic("a", "2026-03-10T00:00:00Z")]),
 				);
 				expect(mockCallLlm).toHaveBeenCalledTimes(2);
-				expect(result?.topics).toHaveLength(0);
-				expect(result?.recap).toContain("Recovered consolidation recap");
+				assertOk(result);
+				expect(result.topics).toHaveLength(0);
+				expect(result.recap).toContain("Recovered consolidation recap");
 			});
 
 			it('treats a null `text` field as empty string in the strict-retry assembly site (covers `?? ""`)', async () => {
@@ -2379,8 +2398,8 @@ Test reordering
 				const result = await generateSquashConsolidation(
 					params([sourceWithTopic("a", "2026-03-10T00:00:00Z")]),
 				);
-				// Empty text → format-compliant + no topics + no recap → fall through to null
-				expect(result).toBeNull();
+				// Empty text → format-compliant + no topics + no recap → fall through to no-content
+				expect(result).toEqual({ status: "no-content" });
 			});
 
 			it("falls back to resolveModelId when the LLM result omits model (covers `?? resolveModelId`)", async () => {
@@ -2397,7 +2416,8 @@ Test reordering
 				const result = await generateSquashConsolidation(
 					params([sourceWithTopic("a", "2026-03-10T00:00:00Z")]),
 				);
-				expect(result?.llm?.model).toBeTruthy();
+				assertOk(result);
+				expect(result.llm.model).toBeTruthy();
 			});
 
 			it("uses null stopReason when the LLM result omits it (covers `?? null` fallback)", async () => {
@@ -2413,7 +2433,8 @@ Test reordering
 				const result = await generateSquashConsolidation(
 					params([sourceWithTopic("a", "2026-03-10T00:00:00Z")]),
 				);
-				expect(result?.llm?.stopReason).toBeNull();
+				assertOk(result);
+				expect(result.llm.stopReason).toBeNull();
 			});
 		});
 	});

--- a/cli/src/core/Summarizer.ts
+++ b/cli/src/core/Summarizer.ts
@@ -1200,6 +1200,32 @@ export interface SquashConsolidationResult {
 }
 
 /**
+ * Tagged outcome from generateSquashConsolidation. Distinguishes the three
+ * reasons the caller might end up running `mechanicalConsolidate`:
+ *
+ *   - "ok": LLM produced usable topics / recap; caller should use the
+ *     embedded SquashConsolidationResult fields directly (no mechanical
+ *     fallback needed).
+ *   - "no-content": no sources / all-empty sources / LLM returned
+ *     format-compliant empty content / strict-retry also produced no
+ *     content. The mechanical fallback is still the right answer here, but
+ *     this is NOT a failure — no `summaryError` marker should be set on
+ *     the merged root.
+ *   - "llm-error": both LLM call attempts (including the strict retry)
+ *     threw. Mechanical fallback runs, AND the merged root carries
+ *     `summaryError: "llm-failed"` so the webview surfaces the
+ *     Regenerate banner.
+ *
+ * Replaces the prior `Promise<SquashConsolidationResult | null>` shape —
+ * the old `null` had five distinct origins that callers couldn't tell
+ * apart.
+ */
+export type SquashConsolidationOutcome =
+	| ({ readonly status: "ok" } & SquashConsolidationResult)
+	| { readonly status: "no-content" }
+	| { readonly status: "llm-error" };
+
+/**
  * Sorts sources by commitDate ascending (oldest first). Internal contract of
  * generateSquashConsolidation and mechanicalConsolidate -- callers MAY pass
  * any order, the prompt always renders oldest-first per "Source Commits
@@ -1290,31 +1316,34 @@ export function mechanicalConsolidate(
  * source commits. Caller MAY pass sources in any order; the function sorts
  * internally and emits an oldest-first {{sourceCommitsBlock}} into the prompt.
  *
- * Returns null when:
- *   - There are no sources at all.
- *   - All sources have empty topics AND empty recap (nothing to consolidate).
- *   - Both LLM call attempts (1 retry) fail.
- *
- * On null, the caller (runSquashPipeline / handleAmendPipeline) falls back to
- * mechanicalConsolidate so the Hoist invariant always completes.
+ * Returns a discriminated union (`SquashConsolidationOutcome`):
+ *   - { status: "ok", topics, recap?, ticketId?, llm }: LLM produced usable
+ *     output. Caller uses these fields directly.
+ *   - { status: "no-content" }: no sources / all-empty sources / LLM
+ *     returned format-compliant empty content / strict-retry also empty.
+ *     Caller falls back to mechanicalConsolidate; **no failure marker**
+ *     should be set — these are healthy "nothing-to-merge" cases.
+ *   - { status: "llm-error" }: both call attempts (including the strict
+ *     retry) threw. Caller falls back to mechanicalConsolidate AND sets
+ *     `summaryError: "llm-failed"` on the merged root.
  *
  * ticketId resolution priority on success: params.ticketId (squash message)
  *   > earliest source's ticketId > LLM-extracted ticketId from response.
  */
 export async function generateSquashConsolidation(
 	params: SquashConsolidationParams,
-): Promise<SquashConsolidationResult | null> {
+): Promise<SquashConsolidationOutcome> {
 	const { sources, squashCommitMessage, ticketId: outerTicketId, config } = params;
 
 	if (sources.length === 0) {
-		log.info("generateSquashConsolidation: no sources -- returning null");
-		return null;
+		log.info("generateSquashConsolidation: no sources -- returning no-content");
+		return { status: "no-content" };
 	}
 
 	const allEmpty = sources.every((s) => s.topics.length === 0 && !s.recap);
 	if (allEmpty) {
-		log.info("generateSquashConsolidation: all sources have no topics or recap -- returning null");
-		return null;
+		log.info("generateSquashConsolidation: all sources have no topics or recap -- returning no-content");
+		return { status: "no-content" };
 	}
 
 	const sourceCommitsBlock = formatSourceCommitsForSquash(sources);
@@ -1387,12 +1416,12 @@ export async function generateSquashConsolidation(
 			first = await callOnce("squash-consolidate");
 		} catch (err2) {
 			log.error("generateSquashConsolidation retry failed: %s", (err2 as Error).message);
-			return null;
+			return { status: "llm-error" };
 		}
 	}
 
 	if (first.parsed.topics.length > 0 || first.parsed.recap) {
-		return buildResult(first.parsed, first.llm);
+		return { status: "ok", ...buildResult(first.parsed, first.llm) };
 	}
 
 	// First call extracted no usable content (no topics, no recap). Two cases:
@@ -1425,7 +1454,7 @@ export async function generateSquashConsolidation(
 					// equal to first.llm.source by construction (callOnce → callLlm).
 					source: strict.llm.source,
 				};
-				return buildResult(strict.parsed, mergedLlm);
+				return { status: "ok", ...buildResult(strict.parsed, mergedLlm) };
 			}
 			log.warn(
 				"squash-consolidate-strict also produced no usable output -- falling through to mechanical fallback",
@@ -1435,11 +1464,12 @@ export async function generateSquashConsolidation(
 				"squash-consolidate-strict call failed: %s -- falling through to mechanical fallback",
 				err instanceof Error ? err.message : String(err),
 			);
+			return { status: "llm-error" };
 		}
 	} else {
 		log.warn(
 			"generateSquashConsolidation: LLM produced format-compliant but empty consolidation -- falling through to mechanical fallback",
 		);
 	}
-	return null;
+	return { status: "no-content" };
 }

--- a/cli/src/core/SummaryErrorMarker.test.ts
+++ b/cli/src/core/SummaryErrorMarker.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+import type { CommitSummary } from "../Types.js";
+import { isSummaryError, LLM_FAILED, withSummaryError } from "./SummaryErrorMarker.js";
+
+const baseSummary: CommitSummary = {
+	version: 4,
+	commitHash: "a".repeat(40),
+	commitMessage: "msg",
+	commitAuthor: "x",
+	commitDate: "2026-01-01T00:00:00.000Z",
+	branch: "main",
+	generatedAt: "2026-01-01T00:00:00.000Z",
+	transcriptEntries: 0,
+	stats: { filesChanged: 0, insertions: 0, deletions: 0 },
+	topics: [],
+};
+
+describe("SummaryErrorMarker", () => {
+	it("isSummaryError returns true when summaryError is set", () => {
+		expect(isSummaryError({ ...baseSummary, summaryError: LLM_FAILED })).toBe(true);
+	});
+
+	it("isSummaryError returns true on legacy stopReason='error' summaries", () => {
+		const legacy: CommitSummary = {
+			...baseSummary,
+			llm: {
+				model: "claude-x",
+				inputTokens: 0,
+				outputTokens: 0,
+				apiLatencyMs: 0,
+				stopReason: "error",
+			},
+		};
+		expect(isSummaryError(legacy)).toBe(true);
+	});
+
+	it("isSummaryError returns false on healthy summaries", () => {
+		expect(isSummaryError(baseSummary)).toBe(false);
+	});
+
+	it("isSummaryError returns false when stopReason is 'end_turn'", () => {
+		const healthy: CommitSummary = {
+			...baseSummary,
+			llm: {
+				model: "claude-x",
+				inputTokens: 0,
+				outputTokens: 0,
+				apiLatencyMs: 0,
+				stopReason: "end_turn",
+			},
+		};
+		expect(isSummaryError(healthy)).toBe(false);
+	});
+
+	it("isSummaryError returns false when stopReason is 'max_tokens' (truncation, not failure)", () => {
+		const truncated: CommitSummary = {
+			...baseSummary,
+			llm: {
+				model: "claude-x",
+				inputTokens: 0,
+				outputTokens: 0,
+				apiLatencyMs: 0,
+				stopReason: "max_tokens",
+			},
+		};
+		expect(isSummaryError(truncated)).toBe(false);
+	});
+
+	it("isSummaryError returns false when stopReason is null", () => {
+		const nullStop: CommitSummary = {
+			...baseSummary,
+			llm: {
+				model: "claude-x",
+				inputTokens: 0,
+				outputTokens: 0,
+				apiLatencyMs: 0,
+				stopReason: null,
+			},
+		};
+		expect(isSummaryError(nullStop)).toBe(false);
+	});
+
+	it("withSummaryError attaches the marker", () => {
+		const marked = withSummaryError(baseSummary);
+		expect(marked.summaryError).toBe(LLM_FAILED);
+	});
+
+	it("withSummaryError is idempotent on already-marked summaries", () => {
+		const marked = withSummaryError({ ...baseSummary, summaryError: LLM_FAILED });
+		expect(marked.summaryError).toBe(LLM_FAILED);
+	});
+
+	it("withSummaryError does not mutate the input summary", () => {
+		const input = { ...baseSummary };
+		withSummaryError(input);
+		expect(input.summaryError).toBeUndefined();
+	});
+});

--- a/cli/src/core/SummaryErrorMarker.ts
+++ b/cli/src/core/SummaryErrorMarker.ts
@@ -1,0 +1,32 @@
+import type { CommitSummary, SummaryErrorKind } from "../Types.js";
+
+/**
+ * Single source of truth for the summary-error marker constant. Importing
+ * this rather than the literal "llm-failed" keeps grep-ability across
+ * QueueWorker / Regenerator / Webview consumers.
+ */
+export const LLM_FAILED: SummaryErrorKind = "llm-failed";
+
+/**
+ * Whether the given summary should surface the "regenerate me" affordance.
+ * Reads two fields:
+ *   - `summaryError` (new field, set explicitly by all failure paths)
+ *   - `llm?.stopReason === "error"` (legacy fallback for summaries written
+ *     before `summaryError` existed; the normal-commit path has been
+ *     setting this since at least 0.98.x)
+ *
+ * Only `stopReason === "error"` triggers the legacy fallback. Other
+ * non-"end_turn" reasons like "max_tokens" indicate truncation, NOT
+ * failure — the summary may be partial but is still authoritative for its
+ * topics. Don't conflate.
+ */
+export function isSummaryError(summary: CommitSummary): boolean {
+	if (summary.summaryError !== undefined) return true;
+	if (summary.llm?.stopReason === "error") return true;
+	return false;
+}
+
+/** Returns a shallow clone of `summary` with the LLM_FAILED marker attached. */
+export function withSummaryError(summary: CommitSummary): CommitSummary {
+	return { ...summary, summaryError: LLM_FAILED };
+}

--- a/cli/src/core/SummaryStore.test.ts
+++ b/cli/src/core/SummaryStore.test.ts
@@ -1017,6 +1017,56 @@ describe("SummaryStore", () => {
 			const migrated = JSON.parse(files[0].content) as CommitSummary;
 			expect(migrated.diffStats).toEqual({ filesChanged: 0, insertions: 0, deletions: 0 });
 		});
+
+		it("Copy-Hoists summaryError from old summary onto the rebased root", async () => {
+			// Rebase-pick doesn't run the LLM, so a degraded old summary stays
+			// degraded on the new hash. Without this propagation the webview
+			// banner would silently disappear after rebase even though the
+			// underlying LLM failure was never resolved.
+			vi.mocked(readFileFromBranch).mockResolvedValueOnce(null);
+			const oldSummary: CommitSummary = {
+				...createMockSummary("oldhash"),
+				summaryError: "llm-failed",
+			};
+
+			await migrateOneToOne(oldSummary, createMockCommitInfo("newhash"));
+
+			const files = vi.mocked(writeMultipleFilesToBranch).mock.calls[0][1] as ReadonlyArray<FileWrite>;
+			const migrated = JSON.parse(files[0].content) as CommitSummary;
+			expect(migrated.summaryError).toBe("llm-failed");
+		});
+
+		it("upgrades legacy stopReason='error' on old summary to summaryError on the rebased root", async () => {
+			// Legacy summaries (pre-summaryError field) signal failure via
+			// llm.stopReason === "error". isSummaryError() honors both so the
+			// new field gets set on migration; without this, post-rebase
+			// banners would only fire for summaries written by the new code.
+			vi.mocked(readFileFromBranch).mockResolvedValueOnce(null);
+			const oldSummary: CommitSummary = {
+				...createMockSummary("oldhash"),
+				llm: { model: "x", inputTokens: 0, outputTokens: 0, apiLatencyMs: 0, stopReason: "error" },
+			};
+
+			await migrateOneToOne(oldSummary, createMockCommitInfo("newhash"));
+
+			const files = vi.mocked(writeMultipleFilesToBranch).mock.calls[0][1] as ReadonlyArray<FileWrite>;
+			const migrated = JSON.parse(files[0].content) as CommitSummary;
+			expect(migrated.summaryError).toBe("llm-failed");
+		});
+
+		it("does NOT set summaryError on the rebased root when the old summary is healthy", async () => {
+			vi.mocked(readFileFromBranch).mockResolvedValueOnce(null);
+			const oldSummary: CommitSummary = {
+				...createMockSummary("oldhash"),
+				llm: { model: "x", inputTokens: 1, outputTokens: 1, apiLatencyMs: 1, stopReason: "end_turn" },
+			};
+
+			await migrateOneToOne(oldSummary, createMockCommitInfo("newhash"));
+
+			const files = vi.mocked(writeMultipleFilesToBranch).mock.calls[0][1] as ReadonlyArray<FileWrite>;
+			const migrated = JSON.parse(files[0].content) as CommitSummary;
+			expect(migrated.summaryError).toBeUndefined();
+		});
 	});
 
 	describe("mergeManyToOne", () => {
@@ -1777,6 +1827,40 @@ describe("SummaryStore", () => {
 			const files = vi.mocked(writeMultipleFilesToBranch).mock.calls[0][1] as ReadonlyArray<FileWrite>;
 			const merged = JSON.parse(files[0].content) as CommitSummary;
 			expect(merged.diffStats).toEqual({ filesChanged: 0, insertions: 0, deletions: 0 });
+		});
+
+		it("propagates summaryError from ConsolidatedTopics onto the merged root", async () => {
+			vi.mocked(readFileFromBranch).mockResolvedValueOnce(null);
+			const newHash = "newhash0000000000000099";
+
+			await mergeManyToOne(
+				[createMockSummary("old1"), createMockSummary("old2")],
+				createMockCommitInfo(newHash),
+				undefined,
+				undefined,
+				{
+					topics: [{ title: "Merged", trigger: "t", response: "r", decisions: "d" }],
+					summaryError: "llm-failed",
+				},
+			);
+
+			const files = vi.mocked(writeMultipleFilesToBranch).mock.calls[0][1] as ReadonlyArray<FileWrite>;
+			const merged = JSON.parse(files[0].content) as CommitSummary;
+			expect(merged.summaryError).toBe("llm-failed");
+			expect(merged.topics).toEqual([{ title: "Merged", trigger: "t", response: "r", decisions: "d" }]);
+		});
+
+		it("does NOT set summaryError on the merged root when ConsolidatedTopics omits it", async () => {
+			vi.mocked(readFileFromBranch).mockResolvedValueOnce(null);
+			const newHash = "newhash0000000000000098";
+
+			await mergeManyToOne([createMockSummary("old1")], createMockCommitInfo(newHash), undefined, undefined, {
+				topics: [{ title: "Merged", trigger: "t", response: "r", decisions: "d" }],
+			});
+
+			const files = vi.mocked(writeMultipleFilesToBranch).mock.calls[0][1] as ReadonlyArray<FileWrite>;
+			const merged = JSON.parse(files[0].content) as CommitSummary;
+			expect(merged.summaryError).toBeUndefined();
 		});
 	});
 

--- a/cli/src/core/SummaryStore.ts
+++ b/cli/src/core/SummaryStore.ts
@@ -42,6 +42,7 @@ import { acquireOrphanWriteLock, releaseOrphanWriteLock } from "./Locks.js";
 import { OrphanBranchStorage } from "./OrphanBranchStorage.js";
 import type { StorageProvider } from "./StorageProvider.js";
 import type { SquashConsolidationSource } from "./Summarizer.js";
+import { isSummaryError, LLM_FAILED } from "./SummaryErrorMarker.js";
 import { getDisplayDate } from "./SummaryFormat.js";
 import { collectAllTopics, collectDisplayTopics, countTopics, isUnifiedHoistFormat } from "./SummaryTree.js";
 
@@ -410,6 +411,12 @@ async function migrateOneToOneLocked(
 		// PR markdown stopped showing the Linear issue associations.
 		...(oldSummary.linearIssues && { linearIssues: oldSummary.linearIssues }),
 		...(oldSummary.e2eTestGuide && { e2eTestGuide: oldSummary.e2eTestGuide }),
+		// summaryError marker — rebase-pick doesn't run the LLM, so a degraded
+		// old summary stays degraded on the new hash. Use isSummaryError() so
+		// legacy summaries (only `llm.stopReason: "error"`, no summaryError
+		// field) get upgraded to the new marker on migration. Without this,
+		// the rebased commit's webview would lose its Regenerate banner.
+		...(isSummaryError(oldSummary) && { summaryError: LLM_FAILED }),
 		topics: hoistedTopics,
 		...(oldSummary.recap && { recap: oldSummary.recap }),
 		diffStats: migratedDiffStats,
@@ -830,6 +837,15 @@ export interface ConsolidatedTopics {
 	readonly recap?: string;
 	readonly ticketId?: string;
 	readonly llm?: import("../Types.js").LlmCallMetadata;
+	/**
+	 * Set when the consolidation outcome was `"llm-error"` (real failure
+	 * after retry exhaustion) or when a runtime error tripped the caller's
+	 * defensive catch. Distinguishes it from `"no-content"` which also
+	 * lands in mechanical fallback but is healthy (no marker).
+	 * mergeManyToOne mirrors this onto the merged root so isSummaryError
+	 * catches it on read.
+	 */
+	readonly summaryError?: import("../Types.js").SummaryErrorKind;
 }
 
 /**
@@ -904,6 +920,7 @@ async function mergeManyToOneLocked(
 	const consolidatedRecap = consolidated?.recap;
 	const consolidatedTicketId = consolidated?.ticketId;
 	const consolidatedLlm = consolidated?.llm;
+	const consolidatedSummaryError = consolidated?.summaryError;
 
 	const mergedSummary: CommitSummary = {
 		version: 4,
@@ -917,6 +934,7 @@ async function mergeManyToOneLocked(
 		...(metadata?.commitSource && { commitSource: metadata.commitSource }),
 		...(consolidatedTicketId && { ticketId: consolidatedTicketId }),
 		...(consolidatedLlm && { llm: consolidatedLlm }),
+		...(consolidatedSummaryError && { summaryError: consolidatedSummaryError }),
 		...(hoistedE2e.length > 0 && { e2eTestGuide: hoistedE2e }),
 		...(hoistedPlans.length > 0 && { plans: hoistedPlans }),
 		...(hoistedNotes.length > 0 && { notes: hoistedNotes }),

--- a/cli/src/hooks/PostCommitHook.helpers.test.ts
+++ b/cli/src/hooks/PostCommitHook.helpers.test.ts
@@ -1298,6 +1298,7 @@ describe("PostCommitHook helpers", () => {
 			// Step 1 default (from beforeEach) returns a topic → bypasses post-LLM short-circuit.
 			// Step 2 returns consolidated content with LLM metadata.
 			mockGenerateSquashConsolidation.mockResolvedValueOnce({
+				status: "ok",
 				topics: [{ title: "Consolidated", trigger: "T", response: "R", decisions: "D" }],
 				recap: "consolidated recap",
 				llm: { model: "test", inputTokens: 10, outputTokens: 10, apiLatencyMs: 50, stopReason: "end_turn" },
@@ -1322,6 +1323,320 @@ describe("PostCommitHook helpers", () => {
 			expect(root.topics).toEqual([{ title: "Consolidated", trigger: "T", response: "R", decisions: "D" }]);
 			expect(root.recap).toBe("consolidated recap");
 			expect(root.llm).toBeDefined();
+		});
+
+		it("step-1 LLM failure with oldSummary Copy-Hoists topics and marks summaryError", async () => {
+			mockGetSummary.mockResolvedValue({
+				version: 3,
+				commitHash: "oldhash",
+				commitMessage: "Old commit",
+				commitAuthor: "Test",
+				commitDate: "2026-02-18T00:00:00Z",
+				branch: "main",
+				generatedAt: "2026-02-18T00:00:00Z",
+				transcriptEntries: 1,
+				stats: { filesChanged: 1, insertions: 1, deletions: 0 },
+				topics: [{ title: "Old kept", trigger: "T", response: "R", decisions: "D" }],
+				recap: "old recap",
+			});
+			mockLoadAllSessions.mockResolvedValue([]);
+			mockLoadConfig.mockResolvedValue({});
+			// Non-trivial delta so the pre-LLM short-circuit doesn't fire.
+			mockGetDiffStats.mockResolvedValue({ filesChanged: 1, insertions: 100, deletions: 0 });
+			mockGetDiffContent.mockResolvedValue("diff");
+			mockGenerateSummary
+				.mockRejectedValueOnce(new Error("403 boom"))
+				.mockRejectedValueOnce(new Error("403 boom again"));
+
+			await __test__.handleAmendPipeline(
+				{ hash: "newhash", message: "New commit", author: "Test", date: "2026-02-19T00:00:00Z" },
+				"oldhash",
+				"/repo",
+				0,
+			);
+
+			expect(mockGenerateSummary).toHaveBeenCalledTimes(2);
+			expect(mockStoreSummary).toHaveBeenCalledTimes(1);
+			const stored = mockStoreSummary.mock.calls[0][0] as {
+				topics: ReadonlyArray<{ title: string }>;
+				summaryError?: string;
+			};
+			expect(stored.topics).toEqual([{ title: "Old kept", trigger: "T", response: "R", decisions: "D" }]);
+			expect(stored.summaryError).toBe("llm-failed");
+		});
+
+		it("step-1 LLM failure without oldSummary stores fresh leaf with empty topics + summaryError", async () => {
+			mockGetSummary.mockResolvedValue(null);
+			mockLoadAllSessions.mockResolvedValue([]);
+			mockLoadConfig.mockResolvedValue({});
+			mockGetDiffStats.mockResolvedValue({ filesChanged: 1, insertions: 100, deletions: 0 });
+			mockGetDiffContent.mockResolvedValue("diff");
+			mockGenerateSummary
+				.mockRejectedValueOnce(new Error("network boom"))
+				.mockRejectedValueOnce(new Error("network boom again"));
+
+			await __test__.handleAmendPipeline(
+				{ hash: "freshhash", message: "First amend", author: "Test", date: "2026-02-19T00:00:00Z" },
+				"oldhash",
+				"/repo",
+				0,
+			);
+
+			expect(mockGenerateSummary).toHaveBeenCalledTimes(2);
+			expect(mockStoreSummary).toHaveBeenCalledTimes(1);
+			const stored = mockStoreSummary.mock.calls[0][0] as {
+				topics: ReadonlyArray<unknown>;
+				summaryError?: string;
+			};
+			expect(stored.topics).toEqual([]);
+			expect(stored.summaryError).toBe("llm-failed");
+		});
+
+		it("step-2 (consolidate) llm-error marks the amend root with summaryError", async () => {
+			mockGetSummary.mockResolvedValue({
+				version: 3,
+				commitHash: "oldhash",
+				commitMessage: "Old commit",
+				commitAuthor: "Test",
+				commitDate: "2026-02-18T00:00:00Z",
+				branch: "main",
+				generatedAt: "2026-02-18T00:00:00Z",
+				transcriptEntries: 1,
+				stats: { filesChanged: 1, insertions: 1, deletions: 0 },
+				topics: [{ title: "Old", trigger: "T", response: "R", decisions: "D" }],
+			});
+			mockLoadAllSessions.mockResolvedValue([]);
+			mockLoadConfig.mockResolvedValue({});
+			mockGetDiffStats.mockResolvedValue({ filesChanged: 1, insertions: 100, deletions: 0 });
+			mockGetDiffContent.mockResolvedValue("diff");
+			// Step 1 default (from beforeEach) returns a topic → bypasses post-LLM short-circuit.
+			// Step 2 returns llm-error → mechanical fallback + summaryError marker.
+			mockGenerateSquashConsolidation.mockResolvedValueOnce({ status: "llm-error" });
+
+			await __test__.handleAmendPipeline(
+				{ hash: "newhash", message: "New commit", author: "Test", date: "2026-02-19T00:00:00Z" },
+				"oldhash",
+				"/repo",
+				0,
+			);
+
+			expect(mockGenerateSquashConsolidation).toHaveBeenCalledTimes(1);
+			expect(mockStoreSummary).toHaveBeenCalledTimes(1);
+			const stored = mockStoreSummary.mock.calls[0][0] as {
+				topics: ReadonlyArray<unknown>;
+				summaryError?: string;
+			};
+			expect(stored.topics.length).toBeGreaterThan(0); // mechanical preserved content
+			expect(stored.summaryError).toBe("llm-failed");
+		});
+
+		it("step-2 (consolidate) no-content falls back to mechanical WITHOUT summaryError marker", async () => {
+			mockGetSummary.mockResolvedValue({
+				version: 3,
+				commitHash: "oldhash",
+				commitMessage: "Old commit",
+				commitAuthor: "Test",
+				commitDate: "2026-02-18T00:00:00Z",
+				branch: "main",
+				generatedAt: "2026-02-18T00:00:00Z",
+				transcriptEntries: 1,
+				stats: { filesChanged: 1, insertions: 1, deletions: 0 },
+				topics: [{ title: "Old", trigger: "T", response: "R", decisions: "D" }],
+			});
+			mockLoadAllSessions.mockResolvedValue([]);
+			mockLoadConfig.mockResolvedValue({});
+			mockGetDiffStats.mockResolvedValue({ filesChanged: 1, insertions: 100, deletions: 0 });
+			mockGetDiffContent.mockResolvedValue("diff");
+			mockGenerateSquashConsolidation.mockResolvedValueOnce({ status: "no-content" });
+
+			await __test__.handleAmendPipeline(
+				{ hash: "newhash", message: "New commit", author: "Test", date: "2026-02-19T00:00:00Z" },
+				"oldhash",
+				"/repo",
+				0,
+			);
+
+			expect(mockStoreSummary).toHaveBeenCalledTimes(1);
+			const stored = mockStoreSummary.mock.calls[0][0] as {
+				summaryError?: string;
+			};
+			expect(stored.summaryError).toBeUndefined();
+		});
+
+		it("full-path consolidate success inherits summaryError when oldSummary was degraded", async () => {
+			// Source-state inheritance: step-2 consolidate merges existing topic
+			// structures, it does NOT re-derive from raw diff + transcript like
+			// Regenerator does. If oldSummary was a placeholder / Copy-Hoist /
+			// mechanical merge from a prior failure, the consolidated output is
+			// "delta + degraded old", not "regenerated". Only Regenerator should
+			// clear the marker.
+			mockGetSummary.mockResolvedValue({
+				version: 3,
+				commitHash: "oldhash",
+				commitMessage: "Old commit (previously failed)",
+				commitAuthor: "Test",
+				commitDate: "2026-02-18T00:00:00Z",
+				branch: "main",
+				generatedAt: "2026-02-18T00:00:00Z",
+				transcriptEntries: 1,
+				stats: { filesChanged: 1, insertions: 1, deletions: 0 },
+				topics: [{ title: "Placeholder", trigger: "T", response: "R", decisions: "D" }],
+				summaryError: "llm-failed",
+			});
+			mockLoadAllSessions.mockResolvedValue([]);
+			mockLoadConfig.mockResolvedValue({});
+			mockGetDiffStats.mockResolvedValue({ filesChanged: 1, insertions: 100, deletions: 0 });
+			mockGetDiffContent.mockResolvedValue("diff");
+			// step-2 succeeds → would clear marker WITHOUT the inheritance fix.
+			mockGenerateSquashConsolidation.mockResolvedValueOnce({
+				status: "ok",
+				topics: [{ title: "Consolidated", trigger: "T", response: "R", decisions: "D" }],
+				recap: "consolidated recap",
+				llm: { model: "x", inputTokens: 1, outputTokens: 1, apiLatencyMs: 1, stopReason: "end_turn" },
+			});
+
+			await __test__.handleAmendPipeline(
+				{ hash: "newhash", message: "New commit", author: "Test", date: "2026-02-19T00:00:00Z" },
+				"oldhash",
+				"/repo",
+				0,
+			);
+
+			expect(mockStoreSummary).toHaveBeenCalledTimes(1);
+			const stored = mockStoreSummary.mock.calls[0][0] as {
+				topics: ReadonlyArray<{ title: string }>;
+				summaryError?: string;
+			};
+			expect(stored.topics).toEqual([{ title: "Consolidated", trigger: "T", response: "R", decisions: "D" }]);
+			expect(stored.summaryError).toBe("llm-failed");
+		});
+
+		it("full-path consolidate success leaves no marker when oldSummary was healthy", async () => {
+			// Regression guard for the inherited-marker fix above — a clean
+			// amend on a clean parent must stay clean.
+			mockGetSummary.mockResolvedValue({
+				version: 3,
+				commitHash: "oldhash",
+				commitMessage: "Healthy old",
+				commitAuthor: "Test",
+				commitDate: "2026-02-18T00:00:00Z",
+				branch: "main",
+				generatedAt: "2026-02-18T00:00:00Z",
+				transcriptEntries: 1,
+				stats: { filesChanged: 1, insertions: 1, deletions: 0 },
+				topics: [{ title: "Old", trigger: "T", response: "R", decisions: "D" }],
+			});
+			mockLoadAllSessions.mockResolvedValue([]);
+			mockLoadConfig.mockResolvedValue({});
+			mockGetDiffStats.mockResolvedValue({ filesChanged: 1, insertions: 100, deletions: 0 });
+			mockGetDiffContent.mockResolvedValue("diff");
+			mockGenerateSquashConsolidation.mockResolvedValueOnce({
+				status: "ok",
+				topics: [{ title: "Consolidated", trigger: "T", response: "R", decisions: "D" }],
+				llm: { model: "x", inputTokens: 1, outputTokens: 1, apiLatencyMs: 1, stopReason: "end_turn" },
+			});
+
+			await __test__.handleAmendPipeline(
+				{ hash: "newhash", message: "New commit", author: "Test", date: "2026-02-19T00:00:00Z" },
+				"oldhash",
+				"/repo",
+				0,
+			);
+
+			expect(mockStoreSummary).toHaveBeenCalledTimes(1);
+			const stored = mockStoreSummary.mock.calls[0][0] as {
+				summaryError?: string;
+			};
+			expect(stored.summaryError).toBeUndefined();
+		});
+
+		it("pre-LLM trivial delta inherits summaryError from oldSummary (no Regenerate yet)", async () => {
+			// A previously-failed amend wrote summaryError="llm-failed". A subsequent
+			// trivial-delta amend (≤ TRIVIAL_AMEND_DELTA_LINES) short-circuits without
+			// calling the LLM — the marker must persist so the banner stays visible.
+			// Only a successful Regenerate should clear it.
+			mockGetSummary.mockResolvedValue({
+				version: 4,
+				commitHash: "oldhash",
+				commitMessage: "Old commit (previously failed)",
+				commitAuthor: "Test",
+				commitDate: "2026-02-18T00:00:00Z",
+				branch: "main",
+				generatedAt: "2026-02-18T00:00:00Z",
+				transcriptEntries: 0,
+				diffStats: { filesChanged: 1, insertions: 1, deletions: 0 },
+				topics: [{ title: "Old", trigger: "T", response: "R", decisions: "D" }],
+				summaryError: "llm-failed",
+			});
+			mockLoadAllSessions.mockResolvedValue([]);
+			mockLoadConfig.mockResolvedValue({});
+			// Trivial delta (1 line) triggers the pre-LLM short-circuit.
+			mockGetDiffStats.mockResolvedValue({ filesChanged: 1, insertions: 1, deletions: 0 });
+			mockGetDiffContent.mockResolvedValue("trivial diff");
+
+			await __test__.handleAmendPipeline(
+				{ hash: "newhash", message: "Typo fix", author: "Test", date: "2026-02-19T00:00:00Z" },
+				"oldhash",
+				"/repo",
+				0,
+			);
+
+			// LLM must NOT have been called (pre-LLM short-circuit).
+			expect(mockGenerateSummary).not.toHaveBeenCalled();
+			expect(mockStoreSummary).toHaveBeenCalledTimes(1);
+			const stored = mockStoreSummary.mock.calls[0][0] as {
+				summaryError?: string;
+			};
+			expect(stored.summaryError).toBe("llm-failed");
+		});
+
+		it("post-LLM empty-topics short-circuit inherits summaryError from oldSummary", async () => {
+			// step-1 LLM succeeded but returned no topics (genuine "nothing new" case);
+			// step-2 is skipped. If oldSummary carried a marker from an earlier failure,
+			// the new root must keep it — step-2 was not run, so the failure is still
+			// unresolved.
+			mockGetSummary.mockResolvedValue({
+				version: 4,
+				commitHash: "oldhash",
+				commitMessage: "Old commit (previously failed)",
+				commitAuthor: "Test",
+				commitDate: "2026-02-18T00:00:00Z",
+				branch: "main",
+				generatedAt: "2026-02-18T00:00:00Z",
+				transcriptEntries: 0,
+				diffStats: { filesChanged: 1, insertions: 1, deletions: 0 },
+				topics: [{ title: "Old", trigger: "T", response: "R", decisions: "D" }],
+				summaryError: "llm-failed",
+			});
+			mockLoadAllSessions.mockResolvedValue([]);
+			mockLoadConfig.mockResolvedValue({});
+			// Non-trivial delta so pre-LLM short-circuit doesn't fire.
+			mockGetDiffStats.mockResolvedValue({ filesChanged: 1, insertions: 100, deletions: 0 });
+			mockGetDiffContent.mockResolvedValue("diff");
+			// step-1 succeeds with empty topics → post-LLM short-circuit, deltaLlmFailed=false.
+			mockGenerateSummary.mockResolvedValueOnce({
+				transcriptEntries: 0,
+				conversationTurns: 0,
+				llm: { model: "test", inputTokens: 1, outputTokens: 1, apiLatencyMs: 1, stopReason: "end_turn" },
+				stats: { filesChanged: 1, insertions: 100, deletions: 0 },
+				topics: [],
+			});
+
+			await __test__.handleAmendPipeline(
+				{ hash: "newhash", message: "Refactor", author: "Test", date: "2026-02-19T00:00:00Z" },
+				"oldhash",
+				"/repo",
+				0,
+			);
+
+			expect(mockGenerateSummary).toHaveBeenCalledTimes(1);
+			// step-2 (generateSquashConsolidation) NOT called — short-circuit fired.
+			expect(mockGenerateSquashConsolidation).not.toHaveBeenCalled();
+			expect(mockStoreSummary).toHaveBeenCalledTimes(1);
+			const stored = mockStoreSummary.mock.calls[0][0] as {
+				summaryError?: string;
+			};
+			expect(stored.summaryError).toBe("llm-failed");
 		});
 	});
 

--- a/cli/src/hooks/PostCommitHook.test.ts
+++ b/cli/src/hooks/PostCommitHook.test.ts
@@ -672,12 +672,14 @@ describe("PostCommitHook", () => {
 
 		expect(generateSummary).toHaveBeenCalledTimes(2);
 		// After double failure, a metadata-only summary is stored so squash/rebase
-		// merges never hit missing source summaries. Topics are empty and
-		// stopReason is "error" to distinguish from a genuine LLM response.
+		// merges never hit missing source summaries. Topics are empty,
+		// stopReason is "error" (legacy marker for pre-summaryError readers),
+		// and summaryError = "llm-failed" drives the webview banner.
 		expect(storeSummary).toHaveBeenCalledTimes(1);
 		const storedSummary = vi.mocked(storeSummary).mock.calls[0][0] as CommitSummary;
 		expect(storedSummary.topics).toEqual([]);
 		expect(storedSummary.llm?.stopReason).toBe("error");
+		expect(storedSummary.summaryError).toBe("llm-failed");
 	});
 
 	it("should handle first commit (diff failure fallback)", async () => {
@@ -1893,7 +1895,7 @@ describe("queue-driven Worker", () => {
 			vi.mocked(isCodexInstalled).mockResolvedValue(true);
 		}
 
-		it("skips amend summary on double API failure", async () => {
+		it("persists amend summary with summaryError marker on double API failure", async () => {
 			setupAmendWithLLM();
 			vi.mocked(generateSummary)
 				.mockRejectedValueOnce(new Error("API error 1"))
@@ -1904,8 +1906,13 @@ describe("queue-driven Worker", () => {
 			await workerPromise;
 
 			expect(generateSummary).toHaveBeenCalledTimes(2);
-			// On double failure in amend, storeSummary should NOT be called (early return)
-			expect(storeSummary).not.toHaveBeenCalled();
+			// New behavior: amend no longer skips silently on double failure.
+			// Either Copy-Hoist via short-circuit (oldSummary present) or
+			// fresh-leaf (no oldSummary); both paths land a summary with
+			// summaryError = "llm-failed" so the webview banner surfaces.
+			expect(storeSummary).toHaveBeenCalledTimes(1);
+			const stored = vi.mocked(storeSummary).mock.calls[0][0];
+			expect(stored.summaryError).toBe("llm-failed");
 		});
 
 		it("logs todo field when amend topic includes a todo item", async () => {

--- a/cli/src/hooks/QueueWorker.test.ts
+++ b/cli/src/hooks/QueueWorker.test.ts
@@ -101,9 +101,11 @@ vi.mock("../core/Summarizer.js", async (importOriginal) => {
 			stats: { filesChanged: 1, insertions: 5, deletions: 2 },
 			topics: [{ title: "Test topic", trigger: "test", response: "done", decisions: "none" }],
 		}),
-		// Mock the LLM-touching path; default behaviour returns null so the
-		// caller falls through to the (real) mechanicalConsolidate.
-		generateSquashConsolidation: vi.fn().mockResolvedValue(null),
+		// Mock the LLM-touching path; default behaviour returns "no-content"
+		// so the caller falls through to the (real) mechanicalConsolidate
+		// WITHOUT setting a summaryError marker — healthy "nothing to merge"
+		// path is what most tests exercise by default.
+		generateSquashConsolidation: vi.fn().mockResolvedValue({ status: "no-content" }),
 		// Real implementations for the pure helpers -- runSquashPipeline /
 		// handleAmendPipeline rely on their actual behaviour.
 		mechanicalConsolidate: actual.mechanicalConsolidate,
@@ -564,27 +566,36 @@ describe("QueueWorker", () => {
 			expect(releaseWorkerLock).toHaveBeenCalled();
 		});
 
-		// The dispatcher's "fail loudly" promise (PR #93) is undermined if the
-		// queue swallows the credential error into an empty-topic placeholder
-		// summary — the user would see no toast, no Status row change, and
-		// orphan-branch junk would accumulate. Pin both attempts: first call
-		// throws → no retry, no placeholder; retry-path same.
-		it("rethrows credential errors on first attempt without retry or placeholder write", async () => {
+		// As of the summaryError-marker unification, credential errors flow
+		// through the same retry-then-placeholder path as any other LLM
+		// failure. The "loud" signal is the webview banner driven by
+		// `summaryError: "llm-failed"` — visible on every affected commit
+		// until the user fixes credentials and clicks Regenerate. These two
+		// tests pin BOTH retry slots (first-attempt and retry-attempt
+		// credential failures) to the placeholder path.
+		it("writes a placeholder + summaryError marker when first attempt throws LlmCredentialError", async () => {
 			const op = makeCommitOp();
 			vi.mocked(dequeueAllGitOperations)
 				.mockResolvedValueOnce([{ op, filePath: "/tmp/queue/cred.json" }])
 				.mockResolvedValueOnce([])
 				.mockResolvedValueOnce([]);
 			setupPipelineMocks();
-			vi.mocked(generateSummary).mockRejectedValueOnce(new LlmCredentialError());
+			vi.mocked(generateSummary)
+				.mockRejectedValueOnce(new LlmCredentialError())
+				.mockRejectedValueOnce(new LlmCredentialError());
 
 			await runWorker("/test/cwd");
 
-			expect(generateSummary).toHaveBeenCalledTimes(1);
-			expect(storeSummary).not.toHaveBeenCalled();
+			// Retry attempt happens; both fail; placeholder lands.
+			expect(generateSummary).toHaveBeenCalledTimes(2);
+			expect(storeSummary).toHaveBeenCalledTimes(1);
+			const stored = vi.mocked(storeSummary).mock.calls[0][0];
+			expect(stored.topics).toEqual([]);
+			expect(stored.llm?.stopReason).toBe("error");
+			expect(stored.summaryError).toBe("llm-failed");
 		});
 
-		it("rethrows credential errors that surface only on the retry attempt", async () => {
+		it("writes a placeholder + summaryError marker when only the retry throws LlmCredentialError", async () => {
 			const op = makeCommitOp();
 			vi.mocked(dequeueAllGitOperations)
 				.mockResolvedValueOnce([{ op, filePath: "/tmp/queue/cred-retry.json" }])
@@ -598,7 +609,9 @@ describe("QueueWorker", () => {
 			await runWorker("/test/cwd");
 
 			expect(generateSummary).toHaveBeenCalledTimes(2);
-			expect(storeSummary).not.toHaveBeenCalled();
+			expect(storeSummary).toHaveBeenCalledTimes(1);
+			const stored = vi.mocked(storeSummary).mock.calls[0][0];
+			expect(stored.summaryError).toBe("llm-failed");
 		});
 	});
 
@@ -1244,6 +1257,180 @@ describe("QueueWorker", () => {
 				expect.objectContaining({ commitSource: "cli", commitType: "squash" }),
 				expect.objectContaining({ topics: expect.any(Array) }),
 			);
+		});
+
+		it("squash llm-error: passes summaryError marker on the consolidated arg into mergeManyToOne", async () => {
+			const { getSummary, mergeManyToOne } = await import("../core/SummaryStore.js");
+			const { generateSquashConsolidation } = await import("../core/Summarizer.js");
+			vi.mocked(getSummary).mockResolvedValue({
+				version: 3,
+				commitHash: "src1",
+				commitMessage: "Src",
+				commitAuthor: "Jane",
+				commitDate: "2026-04-01T10:00:00.000Z",
+				branch: "feature/test",
+				generatedAt: "2026-04-01T10:00:00.000Z",
+				topics: [{ title: "Src topic", trigger: "t", response: "r", decisions: "d" }],
+			} as Awaited<ReturnType<typeof getSummary>>);
+			vi.mocked(generateSquashConsolidation).mockResolvedValueOnce({ status: "llm-error" });
+			setupPipelineMocks("sq-new");
+
+			await __test__.handleSquashFromQueue(
+				makeCommitOp({ commitHash: "sq-new", sourceHashes: ["src1"] }),
+				"/test/cwd",
+			);
+
+			expect(mergeManyToOne).toHaveBeenCalledTimes(1);
+			const consolidatedArg = vi.mocked(mergeManyToOne).mock.calls[0][4];
+			expect(consolidatedArg?.summaryError).toBe("llm-failed");
+			expect((consolidatedArg?.topics ?? []).length).toBeGreaterThan(0); // mechanical preserved content
+		});
+
+		it("squash no-content: mechanical fallback WITHOUT summaryError marker", async () => {
+			const { getSummary, mergeManyToOne } = await import("../core/SummaryStore.js");
+			const { generateSquashConsolidation } = await import("../core/Summarizer.js");
+			vi.mocked(getSummary).mockResolvedValue({
+				version: 3,
+				commitHash: "src2",
+				commitMessage: "Src2",
+				commitAuthor: "Jane",
+				commitDate: "2026-04-01T10:00:00.000Z",
+				branch: "feature/test",
+				generatedAt: "2026-04-01T10:00:00.000Z",
+				topics: [{ title: "Src topic", trigger: "t", response: "r", decisions: "d" }],
+			} as Awaited<ReturnType<typeof getSummary>>);
+			vi.mocked(generateSquashConsolidation).mockResolvedValueOnce({ status: "no-content" });
+			setupPipelineMocks("sq-nc");
+
+			await __test__.handleSquashFromQueue(
+				makeCommitOp({ commitHash: "sq-nc", sourceHashes: ["src2"] }),
+				"/test/cwd",
+			);
+
+			expect(mergeManyToOne).toHaveBeenCalledTimes(1);
+			const consolidatedArg = vi.mocked(mergeManyToOne).mock.calls[0][4];
+			expect(consolidatedArg?.summaryError).toBeUndefined();
+		});
+
+		it("squash ok: inherits summaryError when any source was already degraded", async () => {
+			// Source-state inheritance: even if THIS squash succeeded, if any
+			// source was a prior placeholder / mechanical / Copy-Hoist result
+			// (signalled by summaryError or legacy stopReason="error"), the
+			// merged root is "consolidated from compromised inputs" and must
+			// carry the marker forward. Otherwise handlePush would let the
+			// degraded content land on Jolli unannounced.
+			const { getSummary, mergeManyToOne } = await import("../core/SummaryStore.js");
+			const { generateSquashConsolidation } = await import("../core/Summarizer.js");
+			vi.mocked(getSummary)
+				.mockResolvedValueOnce({
+					version: 3,
+					commitHash: "src-bad",
+					commitMessage: "Previously failed",
+					commitAuthor: "Jane",
+					commitDate: "2026-04-01T10:00:00.000Z",
+					branch: "feature/test",
+					generatedAt: "2026-04-01T10:00:00.000Z",
+					topics: [{ title: "Placeholder", trigger: "t", response: "r", decisions: "d" }],
+					summaryError: "llm-failed",
+				} as Awaited<ReturnType<typeof getSummary>>)
+				.mockResolvedValueOnce({
+					version: 3,
+					commitHash: "src-good",
+					commitMessage: "Healthy",
+					commitAuthor: "Jane",
+					commitDate: "2026-04-02T10:00:00.000Z",
+					branch: "feature/test",
+					generatedAt: "2026-04-02T10:00:00.000Z",
+					topics: [{ title: "Good", trigger: "t", response: "r", decisions: "d" }],
+				} as Awaited<ReturnType<typeof getSummary>>);
+			vi.mocked(generateSquashConsolidation).mockResolvedValueOnce({
+				status: "ok",
+				topics: [{ title: "Merged", trigger: "t", response: "r", decisions: "d" }],
+				llm: { model: "x", inputTokens: 1, outputTokens: 1, apiLatencyMs: 1, stopReason: "end_turn" },
+			});
+			setupPipelineMocks("sq-inh");
+
+			await __test__.handleSquashFromQueue(
+				makeCommitOp({ commitHash: "sq-inh", sourceHashes: ["src-bad", "src-good"] }),
+				"/test/cwd",
+			);
+
+			expect(mergeManyToOne).toHaveBeenCalledTimes(1);
+			const consolidatedArg = vi.mocked(mergeManyToOne).mock.calls[0][4];
+			expect(consolidatedArg?.summaryError).toBe("llm-failed");
+		});
+
+		it("squash ok: does NOT set summaryError when all sources are healthy", async () => {
+			// Regression guard for the inherited-marker fix above — healthy
+			// squash must stay healthy.
+			const { getSummary, mergeManyToOne } = await import("../core/SummaryStore.js");
+			const { generateSquashConsolidation } = await import("../core/Summarizer.js");
+			vi.mocked(getSummary)
+				.mockResolvedValueOnce({
+					version: 3,
+					commitHash: "src-a",
+					commitMessage: "A",
+					commitAuthor: "Jane",
+					commitDate: "2026-04-01T10:00:00.000Z",
+					branch: "feature/test",
+					generatedAt: "2026-04-01T10:00:00.000Z",
+					topics: [{ title: "A", trigger: "t", response: "r", decisions: "d" }],
+				} as Awaited<ReturnType<typeof getSummary>>)
+				.mockResolvedValueOnce({
+					version: 3,
+					commitHash: "src-b",
+					commitMessage: "B",
+					commitAuthor: "Jane",
+					commitDate: "2026-04-02T10:00:00.000Z",
+					branch: "feature/test",
+					generatedAt: "2026-04-02T10:00:00.000Z",
+					topics: [{ title: "B", trigger: "t", response: "r", decisions: "d" }],
+				} as Awaited<ReturnType<typeof getSummary>>);
+			vi.mocked(generateSquashConsolidation).mockResolvedValueOnce({
+				status: "ok",
+				topics: [{ title: "Merged", trigger: "t", response: "r", decisions: "d" }],
+				llm: { model: "x", inputTokens: 1, outputTokens: 1, apiLatencyMs: 1, stopReason: "end_turn" },
+			});
+			setupPipelineMocks("sq-ok");
+
+			await __test__.handleSquashFromQueue(
+				makeCommitOp({ commitHash: "sq-ok", sourceHashes: ["src-a", "src-b"] }),
+				"/test/cwd",
+			);
+
+			expect(mergeManyToOne).toHaveBeenCalledTimes(1);
+			const consolidatedArg = vi.mocked(mergeManyToOne).mock.calls[0][4];
+			expect(consolidatedArg?.summaryError).toBeUndefined();
+		});
+
+		it("squash no-content with degraded source: inherits summaryError", async () => {
+			// no-content is "nothing meaningful to merge" — normally healthy.
+			// But if a source was already degraded, the mechanical-fallback
+			// merge is built on compromised input, so the marker must carry.
+			const { getSummary, mergeManyToOne } = await import("../core/SummaryStore.js");
+			const { generateSquashConsolidation } = await import("../core/Summarizer.js");
+			vi.mocked(getSummary).mockResolvedValueOnce({
+				version: 3,
+				commitHash: "src-bad",
+				commitMessage: "Previously failed",
+				commitAuthor: "Jane",
+				commitDate: "2026-04-01T10:00:00.000Z",
+				branch: "feature/test",
+				generatedAt: "2026-04-01T10:00:00.000Z",
+				topics: [{ title: "Placeholder", trigger: "t", response: "r", decisions: "d" }],
+				summaryError: "llm-failed",
+			} as Awaited<ReturnType<typeof getSummary>>);
+			vi.mocked(generateSquashConsolidation).mockResolvedValueOnce({ status: "no-content" });
+			setupPipelineMocks("sq-nc-inh");
+
+			await __test__.handleSquashFromQueue(
+				makeCommitOp({ commitHash: "sq-nc-inh", sourceHashes: ["src-bad"] }),
+				"/test/cwd",
+			);
+
+			expect(mergeManyToOne).toHaveBeenCalledTimes(1);
+			const consolidatedArg = vi.mocked(mergeManyToOne).mock.calls[0][4];
+			expect(consolidatedArg?.summaryError).toBe("llm-failed");
 		});
 	});
 

--- a/cli/src/hooks/QueueWorker.ts
+++ b/cli/src/hooks/QueueWorker.ts
@@ -41,7 +41,6 @@ import {
 	readLinearIssueMarkdown,
 	renameLinearIssueMarkdown,
 } from "../core/LinearIssueStore.js";
-import { isLlmCredentialError } from "../core/LlmClient.js";
 import { acquireWorkerLock, refreshWorkerLockMtime, releaseWorkerLock } from "../core/Locks.js";
 import { formatNotesBlock } from "../core/NotePromptFormatter.js";
 import { discoverOpenCodeSessions, isOpenCodeInstalled } from "../core/OpenCodeSessionDiscoverer.js";
@@ -76,6 +75,7 @@ import {
 	mechanicalConsolidate,
 	type SquashConsolidationSource,
 } from "../core/Summarizer.js";
+import { isSummaryError, LLM_FAILED } from "../core/SummaryErrorMarker.js";
 import {
 	type ConsolidatedTopics,
 	expandSourcesForConsolidation,
@@ -1127,36 +1127,32 @@ async function executePipeline(cwd: string, op: GitOperation, force = false): Pr
 	try {
 		summaryResult = await generateSummary(summaryParams);
 	} catch (error: unknown) {
-		// Credential-config errors (no provider, missing key for the chosen
-		// provider) won't recover on retry, and writing an empty-topic
-		// placeholder would mask the user's loud-failure expectation set by
-		// the Settings dispatcher fix. Rethrow so the worker logs the
-		// offending commit hash and skips placeholder writes — no junk
-		// summary lands on the orphan branch, debug.log carries the cause.
-		if (isLlmCredentialError(error)) {
-			throw error;
-		}
+		// All LLM failures (network, 5xx, credential, quota) flow through the
+		// same retry-then-placeholder path. The webview banner driven by
+		// `summaryError: "llm-failed"` is the loud-failure signal — visible on
+		// every affected commit until the user fixes the underlying issue and
+		// clicks Regenerate. See cli/DEVELOPMENT.md for the unified contract.
 		log.warn("First API attempt failed: %s. Retrying in %dms...", (error as Error).message, RETRY_DELAY_MS);
 		await delay(RETRY_DELAY_MS);
 
 		try {
 			summaryResult = await generateSummary(summaryParams);
 		} catch (retryError: unknown) {
-			if (isLlmCredentialError(retryError)) {
-				throw retryError;
-			}
 			// LLM completely unavailable — save a summary with empty topics so the commit
 			// still has a record (metadata, diff stats, transcript). This prevents missing
 			// source summaries during squash/rebase merges. Topics can be back-filled later
-			// via a re-summarize command.
+			// via Regenerate.
 			//
 			// Marker fields to distinguish LLM failure from genuinely empty LLM response:
+			//   - `summaryError: "llm-failed"` written onto the root by the assembler below
+			//   - `llm.stopReason: "error"` kept for backward compat with pre-summaryError readers
 			//   - model: config.model → the model we tried to call (not "none")
-			//   - stopReason: "error" → topics are empty due to API failure, not because
-			//                           the LLM returned no topics
 			// A genuine empty response would have stopReason: "end_turn" and a real model ID.
 			log.error("API call failed after retry: %s", (retryError as Error).message);
-			log.warn("Saving summary with empty topics for commit %s", commitInfo.hash.substring(0, 8));
+			log.warn(
+				"Saving summary with empty topics + summaryError marker for commit %s",
+				commitInfo.hash.substring(0, 8),
+			);
 			summaryResult = {
 				transcriptEntries: totalEntries,
 				conversationTurns: humanEntries,
@@ -1237,6 +1233,13 @@ async function executePipeline(cwd: string, op: GitOperation, force = false): Pr
 	// so root is always authoritative. Leaves are the source-of-truth for v4
 	// children; later squash/amend operations strip the Hoist fields off this
 	// node when it becomes a child of a v4 root.
+	// LLM failure marker: if generateSummary fell through to the retry-fail
+	// catch block above, `summaryResult.llm.stopReason === "error"` is the
+	// trip-wire — surface it explicitly on the root via summaryError so
+	// isSummaryError catches it without relying on the legacy stopReason
+	// fallback alone.
+	const llmFailed = summaryResult.llm?.stopReason === "error";
+
 	const summary: CommitSummary = {
 		version: 4,
 		commitHash: commitInfo.hash,
@@ -1249,6 +1252,7 @@ async function executePipeline(cwd: string, op: GitOperation, force = false): Pr
 		commitSource,
 		...summaryResult,
 		diffStats,
+		...(llmFailed ? { summaryError: LLM_FAILED } : {}),
 		...(planRefs.length > 0 ? { plans: planRefs } : {}),
 		...(noteRefs.length > 0 ? { notes: noteRefs } : {}),
 		...(linearIssueRefs.length > 0 ? { linearIssues: linearIssueRefs } : {}),
@@ -1348,28 +1352,64 @@ async function runSquashPipeline(
 	// (earliest source -> LLM-extracted) to fill in.
 	const outerTicketId = extractTicketIdFromMessage(commitInfo.message);
 
+	// Source-state inheritance: if any source summary is already in a degraded
+	// state, the squash result is "merged from compromised inputs" — consolidate
+	// only mergers existing topic structures, it does NOT re-derive from raw
+	// diff + transcript like Regenerator does. expandSourcesForConsolidation
+	// drops summaryError from the source contract (only carries topics/recap/
+	// ticketId/commitMessage), so the LLM never sees the failure history; we
+	// have to OR it in at the caller level.
+	const anySourceFailed = oldSummaries.some(isSummaryError);
+
 	let consolidated: ConsolidatedTopics & { status: "llm" | "mechanical" };
 
 	try {
 		const config = await loadConfig();
-		const result = await generateSquashConsolidation({
+		const outcome = await generateSquashConsolidation({
 			squashCommitMessage: commitInfo.message,
 			/* v8 ignore next */
 			...(outerTicketId !== undefined && { ticketId: outerTicketId }),
 			sources,
 			config,
 		});
-		/* v8 ignore start -- LLM "no content" + LLM-throws fallback: covered at integration level by Summarizer's own tests; each arm just re-routes to mechanicalConsolidate. */
-		if (result) {
-			consolidated = { ...result, status: "llm" };
+		/* v8 ignore start -- mechanical fallback arms: "no-content" and "llm-error" both re-route to mechanicalConsolidate; covered at integration level by Summarizer's own tests. */
+		if (outcome.status === "ok") {
+			consolidated = {
+				topics: outcome.topics,
+				...(outcome.recap !== undefined && { recap: outcome.recap }),
+				...(outcome.ticketId !== undefined && { ticketId: outcome.ticketId }),
+				llm: outcome.llm,
+				status: "llm",
+				...(anySourceFailed && { summaryError: LLM_FAILED }),
+			};
+		} else if (outcome.status === "llm-error") {
+			// Real LLM failure (both attempts threw). Mechanical fallback preserves
+			// source content; mark the root with summaryError so the webview
+			// banner fires.
+			consolidated = {
+				...mechanicalConsolidate(sources, outerTicketId),
+				status: "mechanical",
+				summaryError: LLM_FAILED,
+			};
 		} else {
-			// No content / repeated LLM failure: mechanical fallback preserves source
-			// content so the Hoist root is never hollow.
-			consolidated = { ...mechanicalConsolidate(sources, outerTicketId), status: "mechanical" };
+			// "no-content": no sources / all-empty sources / LLM self-reported
+			// nothing to merge. Healthy case — mechanical fallback. Marker only
+			// if a source was already degraded (input-contamination inheritance).
+			consolidated = {
+				...mechanicalConsolidate(sources, outerTicketId),
+				status: "mechanical",
+				...(anySourceFailed && { summaryError: LLM_FAILED }),
+			};
 		}
 	} catch (err) {
-		log.warn("Squash consolidation LLM failed, using mechanical merge: %s", errMsg(err));
-		consolidated = { ...mechanicalConsolidate(sources, outerTicketId), status: "mechanical" };
+		// Defensive: unexpected runtime error outside generateSquashConsolidation
+		// (e.g. loadConfig throws). Treat as llm-error so the user sees a banner.
+		log.warn("Squash consolidation failed (runtime), using mechanical merge: %s", errMsg(err));
+		consolidated = {
+			...mechanicalConsolidate(sources, outerTicketId),
+			status: "mechanical",
+			summaryError: LLM_FAILED,
+		};
 	}
 	/* v8 ignore stop */
 
@@ -1566,6 +1606,12 @@ interface AmendHoistedFields {
 	readonly recap?: string;
 	readonly ticketId?: string;
 	readonly llm?: import("../Types.js").LlmCallMetadata;
+	/**
+	 * Set when the amend pipeline took a degraded path (step 1 LLM failure
+	 * → Copy-Hoist with marker, or step 2 consolidate llm-error → mechanical
+	 * with marker). Surfaces the webview banner on the new amend root.
+	 */
+	readonly summaryError?: import("../Types.js").SummaryErrorKind;
 }
 
 /**
@@ -1609,6 +1655,7 @@ function buildHoistedAmendRoot(
 		...(hoisted.llm && { llm: hoisted.llm }),
 		...(stats?.transcriptEntries !== undefined && { transcriptEntries: stats.transcriptEntries }),
 		...(stats?.conversationTurns !== undefined && { conversationTurns: stats.conversationTurns }),
+		...(hoisted.summaryError && { summaryError: hoisted.summaryError }),
 		/* v8 ignore stop */
 		...hoistMetadataFromOldSummary(oldSummary),
 		topics: hoisted.topics,
@@ -1646,6 +1693,7 @@ async function applyAmendShortCircuit(
 	pipelineStart: number,
 	oldHash: string,
 	label: string,
+	markError: boolean,
 ): Promise<void> {
 	const storedTranscript = buildStoredTranscript(sessionTranscripts);
 	const transcriptArtifact = storedTranscript.sessions.length > 0 ? storedTranscript : undefined;
@@ -1659,6 +1707,7 @@ async function applyAmendShortCircuit(
 			...(oldSummary.recap !== undefined && { recap: oldSummary.recap }),
 			...(oldSummary.ticketId !== undefined && { ticketId: oldSummary.ticketId }),
 			/* v8 ignore stop */
+			...(markError && { summaryError: LLM_FAILED }),
 		},
 		metadata ?? {},
 		amendFullDiffStats,
@@ -1770,6 +1819,10 @@ async function handleAmendPipeline(
 			"Amend short-circuit (pre-LLM): trivial delta ≤ %d -- skipping both LLM calls",
 			TRIVIAL_AMEND_DELTA_LINES,
 		);
+		// Inherit oldSummary's marker so a trivial amend on top of a previously-
+		// failed commit doesn't silently heal the banner: this short-circuit
+		// didn't run the LLM at all, so any prior failure is still unresolved.
+		// A successful Regenerate is the only legitimate way to clear the marker.
 		await applyAmendShortCircuit(
 			oldSummary,
 			commitInfo,
@@ -1782,6 +1835,7 @@ async function handleAmendPipeline(
 			pipelineStart,
 			oldHash,
 			"pre-LLM trivial delta",
+			isSummaryError(oldSummary),
 		);
 		return;
 	}
@@ -1844,6 +1898,11 @@ async function handleAmendPipeline(
 	};
 
 	let delta: Awaited<ReturnType<typeof generateSummary>>;
+	// `deltaLlmFailed` flips to true when both step-1 attempts threw. The pipeline
+	// continues with an empty-delta placeholder so the commit gets a summary on
+	// the orphan branch (Copy-Hoist via short-circuit when an old summary exists,
+	// fresh leaf otherwise); the marker drives the webview banner.
+	let deltaLlmFailed = false;
 	try {
 		delta = await generateSummary(summaryParams);
 	} catch (error: unknown) {
@@ -1853,12 +1912,24 @@ async function handleAmendPipeline(
 			delta = await generateSummary(summaryParams);
 		} catch (retryError: unknown) {
 			log.error("API call failed after retry: %s", (retryError as Error).message);
-			log.error(
-				"Amend summary generation skipped for commit %s. A new commit will trigger summary generation automatically.",
+			log.warn(
+				"Persisting amend summary for %s with summaryError marker so the commit is not silently dropped",
 				commitInfo.hash.substring(0, 8),
-				commitInfo.hash,
 			);
-			return;
+			deltaLlmFailed = true;
+			delta = {
+				transcriptEntries: totalEntries,
+				conversationTurns: humanEntries,
+				llm: {
+					model: amendConfig.model ?? "unknown",
+					inputTokens: 0,
+					outputTokens: 0,
+					apiLatencyMs: 0,
+					stopReason: "error",
+				},
+				stats: deltaDiffStats,
+				topics: [],
+			};
 		}
 	}
 	log.info("Amend step 1 (delta summary) generated (%s)", formatElapsed(stepStart));
@@ -1872,8 +1943,17 @@ async function handleAmendPipeline(
 	// ── Post-LLM short-circuit: step1 returned empty topics → skip step2 ──────
 	// delta.recap is discarded even if present: a recap without topics is just a
 	// restatement of the diff, and the diff is the source of truth.
+	// Also taken when step-1 LLM failed (deltaLlmFailed=true) so the failure
+	// surfaces with Copy-Hoisted topics + marker, never as a missing summary.
 	if (oldSummary && (delta.topics?.length ?? 0) === 0) {
-		log.info("Amend short-circuit (post-LLM): step1 returned empty topics -- skipping step2 consolidate");
+		log.info(
+			"Amend short-circuit (post-LLM): step1 %s -- skipping step2 consolidate",
+			deltaLlmFailed ? "LLM failed" : "returned empty topics",
+		);
+		// Inherit oldSummary's marker when step-1 succeeded but produced no topics:
+		// we Copy-Hoist the old root and step-2 never ran, so a previously-
+		// unresolved failure is still unresolved. `deltaLlmFailed` covers the
+		// other case (step-1 itself failed) explicitly.
 		await applyAmendShortCircuit(
 			oldSummary,
 			commitInfo,
@@ -1885,7 +1965,8 @@ async function handleAmendPipeline(
 			cwd,
 			pipelineStart,
 			oldHash,
-			"post-LLM empty topics",
+			deltaLlmFailed ? "post-LLM error fallback" : "post-LLM empty topics",
+			deltaLlmFailed || isSummaryError(oldSummary),
 		);
 		return;
 	}
@@ -1913,18 +1994,38 @@ async function handleAmendPipeline(
 
 		stepStart = now();
 		let consolidated: ConsolidatedTopics | null;
+		let consolidateLlmFailed = false;
 		try {
-			consolidated = await generateSquashConsolidation({
+			const outcome = await generateSquashConsolidation({
 				squashCommitMessage: commitInfo.message,
 				/* v8 ignore next */
 				...(outerTicketId !== undefined && { ticketId: outerTicketId }),
 				sources,
 				config: amendConfig,
 			});
-			/* v8 ignore start -- LLM-failure fallback: covered at integration level by Summarizer's own tests; the catch here is a thin re-route to mechanical merge. */
+			if (outcome.status === "ok") {
+				consolidated = {
+					topics: outcome.topics,
+					/* v8 ignore start -- optional-field spreads */
+					...(outcome.recap !== undefined && { recap: outcome.recap }),
+					...(outcome.ticketId !== undefined && { ticketId: outcome.ticketId }),
+					/* v8 ignore stop */
+					llm: outcome.llm,
+				};
+			} else {
+				consolidated = null;
+				/* v8 ignore start -- "no-content" leaves marker unset; "llm-error" trips it. */
+				if (outcome.status === "llm-error") consolidateLlmFailed = true;
+				/* v8 ignore stop */
+			}
+			/* v8 ignore start -- defensive: generateSquashConsolidation handles its own LLM throws internally, so this catch only fires on unexpected runtime errors (e.g. loadConfig threw before the call). Treat as llm-error so banner surfaces. */
 		} catch (err) {
-			log.warn("Amend step 2 (consolidate) LLM failed: %s -- falling back to mechanical merge", errMsg(err));
+			log.warn(
+				"Amend step 2 (consolidate) failed (runtime): %s -- falling back to mechanical merge",
+				errMsg(err),
+			);
 			consolidated = null;
+			consolidateLlmFailed = true;
 		}
 		/* v8 ignore stop */
 		const finalConsolidated: ConsolidatedTopics = consolidated ?? mechanicalConsolidate(sources, outerTicketId);
@@ -1946,6 +2047,13 @@ async function handleAmendPipeline(
 				...(finalConsolidated.ticketId !== undefined && { ticketId: finalConsolidated.ticketId }),
 				// Only include llm metadata when consolidation actually called the LLM.
 				...(consolidated?.llm && { llm: consolidated.llm }),
+				// Inherit oldSummary's degraded state even when step-2 consolidate
+				// succeeded: consolidate merges existing topic structures, it does
+				// NOT re-derive from raw diff + transcript like Regenerator does.
+				// If oldSummary was a placeholder / Copy-Hoist / mechanical merge
+				// from a prior failure, the consolidated output is "delta + degraded
+				// old", not "regenerated". Only a true Regenerate clears the marker.
+				...((consolidateLlmFailed || isSummaryError(oldSummary)) && { summaryError: LLM_FAILED }),
 				/* v8 ignore stop */
 			},
 			metadata ?? {},
@@ -2007,6 +2115,7 @@ async function handleAmendPipeline(
 		...(metadata?.commitSource && { commitSource: metadata.commitSource }),
 		...delta,
 		diffStats: amendFullDiffStats,
+		...(deltaLlmFailed && { summaryError: LLM_FAILED }),
 		...(freshLeafPlanRefs.length > 0 ? { plans: freshLeafPlanRefs } : {}),
 		...(freshLeafNoteRefs.length > 0 ? { notes: freshLeafNoteRefs } : {}),
 		...(freshLeafLinearRefs.length > 0 ? { linearIssues: freshLeafLinearRefs } : {}),

--- a/vscode/src/views/SummaryCssBuilder.ts
+++ b/vscode/src/views/SummaryCssBuilder.ts
@@ -1353,6 +1353,53 @@ export function buildCss(): string {
     background: var(--vscode-button-hoverBackground);
   }
 
+  /* Summary-error banner — shown at the top of the page when the last
+     LLM call failed (network, 5xx, credential, quota). Same chrome family
+     as .stale-banner but with a distinct visual weight so users with both
+     conditions active can tell them apart. Click delegate in
+     SummaryScriptBuilder routes #summaryErrorRegenerateBtn through the
+     shared requestRegenerateSummary() with the same unsaved-edits +
+     in-flight guards as #regenerateSummaryBtn. */
+  .summary-error-banner {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin: 0 0 16px 0;
+    padding: 12px 16px;
+    background: var(--vscode-inputValidation-warningBackground, #5a4a1a);
+    border: 1px solid var(--vscode-inputValidation-warningBorder, #cca700);
+    border-radius: 6px;
+    color: var(--vscode-foreground);
+  }
+  .summary-error-banner-icon {
+    font-size: 18px;
+    line-height: 1;
+  }
+  .summary-error-banner-text {
+    flex: 1;
+    line-height: 1.5;
+  }
+  .summary-error-banner-action {
+    background: var(--vscode-button-background);
+    color: var(--vscode-button-foreground);
+    border: none;
+    padding: 6px 14px;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 13px;
+    white-space: nowrap;
+  }
+  .summary-error-banner-action:hover {
+    background: var(--vscode-button-hoverBackground);
+  }
+  /* Read-only modes (foreign / stale-rewritten) hide the regenerate
+     affordance — same rationale as #regenerateSummaryBtn in the topics
+     section. The banner text still renders so the user knows why. */
+  .foreign-readonly .summary-error-banner-action,
+  .stale-readonly .summary-error-banner-action {
+    display: none;
+  }
+
 ${buildPrSectionCss()}
 `;
 }

--- a/vscode/src/views/SummaryErrorBanner.test.ts
+++ b/vscode/src/views/SummaryErrorBanner.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import type { CommitSummary } from "../../../cli/src/Types.js";
+import { buildSummaryErrorBanner } from "./SummaryErrorBanner.js";
+
+const baseSummary: CommitSummary = {
+	version: 4,
+	commitHash: "a".repeat(40),
+	commitMessage: "msg",
+	commitAuthor: "x",
+	commitDate: "2026-01-01T00:00:00.000Z",
+	branch: "main",
+	generatedAt: "2026-01-01T00:00:00.000Z",
+	transcriptEntries: 0,
+	stats: { filesChanged: 0, insertions: 0, deletions: 0 },
+	topics: [],
+};
+
+describe("buildSummaryErrorBanner", () => {
+	it("returns empty string for a healthy summary", () => {
+		expect(buildSummaryErrorBanner(baseSummary)).toBe("");
+	});
+
+	it("renders banner with #summaryErrorRegenerateBtn when summaryError is set", () => {
+		const html = buildSummaryErrorBanner({ ...baseSummary, summaryError: "llm-failed" });
+		expect(html).toContain('class="summary-error-banner"');
+		expect(html).toContain('id="summaryErrorRegenerateBtn"');
+		expect(html).toContain("Summary generation failed");
+		expect(html).toContain('role="status"');
+	});
+
+	it("renders banner for legacy summaries with llm.stopReason === 'error'", () => {
+		const legacy: CommitSummary = {
+			...baseSummary,
+			llm: { model: "claude", inputTokens: 0, outputTokens: 0, apiLatencyMs: 0, stopReason: "error" },
+		};
+		expect(buildSummaryErrorBanner(legacy)).toContain('class="summary-error-banner"');
+	});
+
+	it("does NOT render banner when stopReason is 'max_tokens' (truncation, not failure)", () => {
+		const truncated: CommitSummary = {
+			...baseSummary,
+			llm: { model: "claude", inputTokens: 0, outputTokens: 0, apiLatencyMs: 0, stopReason: "max_tokens" },
+		};
+		expect(buildSummaryErrorBanner(truncated)).toBe("");
+	});
+
+	it("does NOT render banner when stopReason is 'end_turn' (healthy)", () => {
+		const healthy: CommitSummary = {
+			...baseSummary,
+			llm: { model: "claude", inputTokens: 0, outputTokens: 0, apiLatencyMs: 0, stopReason: "end_turn" },
+		};
+		expect(buildSummaryErrorBanner(healthy)).toBe("");
+	});
+
+	it("readOnly mode omits the Regenerate button and CTA text", () => {
+		// Foreign-readonly / stale-readonly hide the Regenerate button via CSS.
+		// Emitting a "Click Regenerate" CTA in those modes would be a dead
+		// instruction. The banner still renders so the user knows the summary
+		// is degraded, but without the button or the misleading instruction.
+		const html = buildSummaryErrorBanner({ ...baseSummary, summaryError: "llm-failed" }, { readOnly: true });
+		expect(html).toContain('class="summary-error-banner"');
+		expect(html).not.toContain('id="summaryErrorRegenerateBtn"');
+		expect(html).not.toContain("Click Regenerate");
+		expect(html).toContain("incomplete");
+	});
+
+	it("readOnly mode still renders banner for legacy stopReason='error'", () => {
+		const legacy: CommitSummary = {
+			...baseSummary,
+			llm: { model: "claude", inputTokens: 0, outputTokens: 0, apiLatencyMs: 0, stopReason: "error" },
+		};
+		const html = buildSummaryErrorBanner(legacy, { readOnly: true });
+		expect(html).toContain('class="summary-error-banner"');
+		expect(html).not.toContain('id="summaryErrorRegenerateBtn"');
+	});
+});

--- a/vscode/src/views/SummaryErrorBanner.ts
+++ b/vscode/src/views/SummaryErrorBanner.ts
@@ -1,0 +1,51 @@
+import { isSummaryError } from "../../../cli/src/core/SummaryErrorMarker.js";
+import type { CommitSummary } from "../../../cli/src/Types.js";
+
+/** Options controlling banner text + button rendering. */
+export interface SummaryErrorBannerOptions {
+	/**
+	 * True when the panel is showing a foreign-repo summary (cross-repo
+	 * Memory Bank lookup) OR a stale-rewritten summary (the commit was
+	 * rewritten by amend/squash/rebase). In both cases the Regenerate
+	 * button is hidden by CSS — emitting a "Click Regenerate" CTA would
+	 * be a dead instruction.
+	 */
+	readonly readOnly?: boolean;
+}
+
+/**
+ * Top-of-page banner shown when the last summarize / consolidate LLM call
+ * failed and the persisted summary either has empty topics (normal commit,
+ * amend fresh-leaf) or was assembled via Copy-Hoist / mechanical merge
+ * (amend short-circuit, amend step-2 fallback, squash fallback).
+ *
+ * Returns empty string for healthy summaries so callers can splice the
+ * return value into `buildHtml` unconditionally.
+ *
+ * The button id `summaryErrorRegenerateBtn` is picked up by the click
+ * delegate installed in SummaryScriptBuilder, which routes through the
+ * shared `requestRegenerateSummary()` — same unsaved-edits + in-flight-LLM
+ * guards as the existing `#regenerateSummaryBtn` in the Conversations card.
+ *
+ * In read-only modes (foreign / stale-rewritten) the CTA text and button
+ * are omitted: the user can't act on Regenerate here (CSS hides the
+ * button), so promising "Click Regenerate" would be a dead instruction.
+ * The banner still renders so the user knows the summary is degraded.
+ */
+export function buildSummaryErrorBanner(
+	summary: CommitSummary,
+	options: SummaryErrorBannerOptions = {},
+): string {
+	if (!isSummaryError(summary)) return "";
+	if (options.readOnly) {
+		return `<div class="summary-error-banner" role="status">
+  <span class="summary-error-banner-icon" aria-hidden="true">&#x26A0;&#xFE0F;</span>
+  <span class="summary-error-banner-text">Summary generation failed during the last attempt. Topics, recap and transcripts may be incomplete.</span>
+</div>`;
+	}
+	return `<div class="summary-error-banner" role="status">
+  <span class="summary-error-banner-icon" aria-hidden="true">&#x26A0;&#xFE0F;</span>
+  <span class="summary-error-banner-text">Summary generation failed during the last attempt. Click Regenerate to try again — your transcripts, plans, and notes are preserved.</span>
+  <button class="summary-error-banner-action" id="summaryErrorRegenerateBtn" title="Re-run the LLM end-to-end">&#x21BB; Regenerate</button>
+</div>`;
+}

--- a/vscode/src/views/SummaryHtmlBuilder.test.ts
+++ b/vscode/src/views/SummaryHtmlBuilder.test.ts
@@ -1407,6 +1407,45 @@ describe("buildTopicsSection", () => {
 		expect(html).toContain('id="topicsSection"');
 		expect(html).toContain("No topics available for this commit.");
 	});
+
+	it("renders failure empty-state when topics are empty due to LLM failure (summaryError)", () => {
+		const html = buildTopicsSection(makeSummary({ topics: [], summaryError: "llm-failed" }));
+		expect(html).toContain("Summary generation failed");
+		expect(html).toContain("Click Regenerate above");
+		expect(html).not.toContain("No topics available for this commit.");
+	});
+
+	it("renders failure empty-state for legacy summaries with stopReason='error'", () => {
+		const html = buildTopicsSection(
+			makeSummary({
+				topics: [],
+				llm: { model: "claude", inputTokens: 0, outputTokens: 0, apiLatencyMs: 0, stopReason: "error" },
+			}),
+		);
+		expect(html).toContain("Summary generation failed");
+	});
+
+	it("keeps the healthy empty-state when topics are empty without a failure marker", () => {
+		const html = buildTopicsSection(makeSummary({ topics: [] }));
+		expect(html).toContain("No topics available for this commit.");
+		expect(html).not.toContain("Summary generation failed");
+	});
+
+	it("readOnly failure empty-state drops the 'Click Regenerate above' CTA", () => {
+		// In foreign-readonly / stale-readonly the Regenerate button is hidden;
+		// the empty-state shouldn't promise a click action it can't deliver.
+		const html = buildTopicsSection(
+			makeSummary({ topics: [], summaryError: "llm-failed" }),
+			{ readOnly: true },
+		);
+		expect(html).toContain("Summary generation failed");
+		expect(html).not.toContain("Click Regenerate above");
+	});
+
+	it("non-readOnly failure empty-state keeps the 'Click Regenerate above' CTA", () => {
+		const html = buildTopicsSection(makeSummary({ topics: [], summaryError: "llm-failed" }), { readOnly: false });
+		expect(html).toContain("Click Regenerate above");
+	});
 });
 
 describe("buildAllConversationsSection — Regenerate button", () => {

--- a/vscode/src/views/SummaryHtmlBuilder.ts
+++ b/vscode/src/views/SummaryHtmlBuilder.ts
@@ -6,6 +6,7 @@
  * source commits, footer, and interactive script into a single HTML string.
  */
 
+import { isSummaryError } from "../../../cli/src/core/SummaryErrorMarker.js";
 import {
 	aggregateTurns,
 	formatDurationLabel,
@@ -22,6 +23,7 @@ import type {
 import { buildPrSectionHtml } from "../services/PrCommentService.js";
 import { buildCss } from "./SummaryCssBuilder.js";
 import { buildScript } from "./SummaryScriptBuilder.js";
+import { buildSummaryErrorBanner } from "./SummaryErrorBanner.js";
 import {
 	collectSortedTopics,
 	escAttr,
@@ -92,6 +94,11 @@ export function buildHtml(
 	if (opts.foreignRepoName) pageClasses.push("foreign-readonly");
 	if (opts.staleRewrittenInto) pageClasses.push("stale-readonly");
 	const pageClass = pageClasses.join(" ");
+	// Either readonly mode hides the per-section Regenerate buttons. Thread
+	// `readOnly` into the failure-banner + topics-section builders so their
+	// CTA text adapts (no "Click Regenerate" promise when the button is
+	// hidden by CSS).
+	const readOnly = !!opts.foreignRepoName || !!opts.staleRewrittenInto;
 	const { sourceNodes } = collectSortedTopics(summary);
 	const stats = resolveDiffStats(summary);
 	const totalInsertions = stats.insertions;
@@ -128,6 +135,7 @@ ${csp}
 </head>
 <body>
 <div class="${pageClass}">
+${buildSummaryErrorBanner(summary, { readOnly })}
 ${staleBannerHtml}
 ${buildAllConversationsSection(transcriptHashSet, !!opts.foreignRepoName)}
 ${buildHeader(summary, totalFiles, totalInsertions, totalDeletions)}
@@ -137,7 +145,7 @@ ${buildPrSectionHtml()}
 ${buildPlansAndNotesSection(summary.plans, summary.notes, summary.linearIssues, planTranslateSet, noteTranslateSet)}
 ${buildE2eTestSection(summary)}
 ${buildSourceCommits(sourceNodes)}
-${buildTopicsSection(summary)}
+${buildTopicsSection(summary, { readOnly })}
 ${buildFooter(summary)}
 </div>
 <script${nonceAttr}>${buildScript()}</script>
@@ -351,6 +359,17 @@ export function buildRecapSection(recap: string | undefined): string {
 
 // ─── Topics Section ──────────────────────────────────────────────────────────
 
+/** Options for buildTopicsSection. */
+export interface BuildTopicsSectionOptions {
+	/**
+	 * True when the panel is showing a foreign-repo or stale-rewritten
+	 * summary. CSS hides the Regenerate button in both cases, so the
+	 * empty-state CTA text drops the "Click Regenerate above" instruction
+	 * to avoid pointing at a hidden affordance.
+	 */
+	readonly readOnly?: boolean;
+}
+
 /**
  * Renders the topic grid as a self-contained section.
  *
@@ -360,12 +379,22 @@ export function buildRecapSection(recap: string | undefined): string {
  * region inside `buildHtml`, so embedding `${buildTopicsSection(summary)}`
  * there is the canonical way to keep the two render paths in sync.
  */
-export function buildTopicsSection(summary: CommitSummary): string {
+export function buildTopicsSection(
+	summary: CommitSummary,
+	options: BuildTopicsSectionOptions = {},
+): string {
 	const { topics: allTopics } = collectSortedTopics(summary);
-	const topicsHtml =
-		allTopics.length === 0
-			? '<p class="empty">No topics available for this commit.</p>'
-			: allTopics.map((t, i) => renderTopic(t, i)).join("\n");
+	// Failure path: empty topics + isSummaryError → point the user at the
+	// banner above. The banner carries the Regenerate button; the empty-
+	// state itself stays text-only to avoid two competing affordances.
+	// In read-only modes the Regenerate button is hidden, so we drop the
+	// "Click Regenerate above" instruction — the banner already explains
+	// the degraded state without promising an unreachable action.
+	const failureEmpty = options.readOnly
+		? '<p class="empty empty-error">Summary generation failed during the last attempt.</p>'
+		: '<p class="empty empty-error">Summary generation failed during the last attempt. Click Regenerate above to try again.</p>';
+	const emptyHtml = isSummaryError(summary) ? failureEmpty : '<p class="empty">No topics available for this commit.</p>';
+	const topicsHtml = allTopics.length === 0 ? emptyHtml : allTopics.map((t, i) => renderTopic(t, i)).join("\n");
 	const topicsLabel = `${allTopics.length} topic${allTopics.length !== 1 ? "s" : ""} extracted from this commit`;
 	return `<div class="section" id="topicsSection">
   <div class="section-header">

--- a/vscode/src/views/SummaryScriptBuilder.test.ts
+++ b/vscode/src/views/SummaryScriptBuilder.test.ts
@@ -189,14 +189,23 @@ describe("SummaryScriptBuilder", () => {
 			);
 		});
 
-		it("does NOT re-attach attachRegenerateSummaryHandler in the success path (button lives outside topicsSection / recapSection)", () => {
-			// The regenerate button is in the Conversations card, which
-			// replaceSection never touches; re-attaching would double-bind
+		it("does NOT re-attach attachRegenerateSummaryDelegate in the success path (delegate bound once on .page survives banner DOM replacement)", () => {
+			// The regenerate buttons (#regenerateSummaryBtn in the Conversations
+			// card, #summaryErrorRegenerateBtn in the top banner) are reached
+			// via an event delegate on .page bound once at script init.
+			// Re-attaching in the regenerate success branch would double-bind
 			// the listener and post N messages on the Nth click after N
 			// regenerates.
 			const summaryRegeneratedBranch = script.split("summaryRegenerated")[1] ?? "";
 			const cancelBranch = summaryRegeneratedBranch.split("summaryRegenerateError")[0] ?? "";
-			expect(cancelBranch).not.toContain("attachRegenerateSummaryHandler(");
+			expect(cancelBranch).not.toContain("attachRegenerateSummaryDelegate(");
+			// Defensive: assert the delegate is wired exactly once across the
+			// whole script (at top-level init). A future regression that adds
+			// a second call anywhere would break this. We count "call sites"
+			// (call expression with trailing `;`), not the function declaration
+			// (which has `() {`).
+			const delegateCallMatches = script.match(/attachRegenerateSummaryDelegate\(\);/g) ?? [];
+			expect(delegateCallMatches.length).toBe(1);
 		});
 
 		it("enters regenerating-readonly mode on summaryRegenerating (banner + page class)", () => {

--- a/vscode/src/views/SummaryScriptBuilder.ts
+++ b/vscode/src/views/SummaryScriptBuilder.ts
@@ -224,13 +224,29 @@ ${buildPrMessageScript()}
     if (msg.command === 'summaryRegenerated') {
       if (msg.topicsHtml) replaceSection('topicsSection', msg.topicsHtml);
       if (msg.recapHtml) replaceSection('recapSection', msg.recapHtml);
+      // Banner replace/remove: empty string → remove existing banner;
+      // non-empty → replace existing (outerHTML) or insert at top of .page.
+      // The click delegate (attachRegenerateSummaryDelegate) is bound on
+      // .page so any newly-inserted #summaryErrorRegenerateBtn is picked
+      // up without re-binding.
+      if (typeof msg.summaryErrorBannerHtml === 'string') {
+        var existingBanner = document.querySelector('.summary-error-banner');
+        if (msg.summaryErrorBannerHtml === '') {
+          if (existingBanner) existingBanner.remove();
+        } else if (existingBanner) {
+          existingBanner.outerHTML = msg.summaryErrorBannerHtml;
+        } else {
+          var pageRoot = document.querySelector('.page');
+          if (pageRoot) pageRoot.insertAdjacentHTML('afterbegin', msg.summaryErrorBannerHtml);
+        }
+      }
       leaveRegeneratingReadonly();
       // Re-attach handlers on the NEW DOM nodes inside topics + recap.
-      // NOTE: do NOT re-attach attachRegenerateSummaryHandler — the
-      // Regenerate button lives in the Conversations card, OUTSIDE
-      // topicsSection / recapSection, so replaceSection never touched it
-      // and its original listener is still bound. Re-attaching would add
-      // a duplicate listener each regenerate.
+      // NOTE: the Regenerate buttons (#regenerateSummaryBtn in the
+      // Conversations card AND #summaryErrorRegenerateBtn in the banner)
+      // are reached via an event delegate on .page (see
+      // attachRegenerateSummaryDelegate), so they keep working through
+      // DOM replacement without any re-binding.
       attachEditRecapHandler();
       attachGenerateRecapHandler();
       var newTopicsRoot = document.getElementById('topicsSection');
@@ -639,31 +655,45 @@ ${buildPrMessageScript()}
   }
   attachGenerateRecapHandler();
 
-  // ── Regenerate-summary click handler + DOM helpers ─────────────────────
-  // Drives the end-to-end re-run from the Conversations card. The actual
-  // confirm dialog + LLM call lives on the extension host; this side only
-  // gates the click and renders progress state.
-  function attachRegenerateSummaryHandler() {
-    var btn = document.getElementById('regenerateSummaryBtn');
-    if (!btn) return;
-    btn.addEventListener('click', function(e) {
+  // ── Regenerate-summary shared request + delegated click handlers ────────
+  // Drives the end-to-end re-run from either entry point:
+  //   - The Conversations card's #regenerateSummaryBtn (in the initial DOM)
+  //   - The top-of-page #summaryErrorRegenerateBtn (banner; may be inserted
+  //     dynamically by the summaryRegenerated handler — event delegation
+  //     means we don't need to re-bind after DOM replacement)
+  // Both go through the same guards (unsaved edits + in-flight LLM) so the
+  // banner button can't bypass them. The actual confirm dialog + LLM call
+  // lives on the extension host; this side only gates the click and
+  // renders progress state.
+  function requestRegenerateSummary(btn) {
+    if (btn && btn.disabled) return;
+    // Block when user has unsaved edits in topics or recap — otherwise a
+    // 30-second LLM call would silently overwrite in-progress work.
+    if (document.querySelector('#topicsSection .toggle.editing, #recapSection.recap-editing')) {
+      alert('You have unsaved edits in topics or recap. Save or cancel them before regenerating.');
+      return;
+    }
+    // Block when another LLM action is already in flight.
+    if (document.querySelector('.generating')) {
+      alert('Another action is in progress. Please wait for it to finish.');
+      return;
+    }
+    vscode.postMessage({ command: 'regenerateSummary' });
+  }
+
+  function attachRegenerateSummaryDelegate() {
+    var page = document.querySelector('.page');
+    if (!page) return;
+    page.addEventListener('click', function(e) {
+      var target = e.target;
+      if (!target || typeof target.closest !== 'function') return;
+      var btn = target.closest('#regenerateSummaryBtn, #summaryErrorRegenerateBtn');
+      if (!btn) return;
       e.stopPropagation();
-      if (btn.disabled) return;
-      // Block when user has unsaved edits in topics or recap — otherwise a
-      // 30-second LLM call would silently overwrite in-progress work.
-      if (document.querySelector('#topicsSection .toggle.editing, #recapSection.recap-editing')) {
-        alert('You have unsaved edits in topics or recap. Save or cancel them before regenerating.');
-        return;
-      }
-      // Block when another LLM action is already in flight.
-      if (document.querySelector('.generating')) {
-        alert('Another action is in progress. Please wait for it to finish.');
-        return;
-      }
-      vscode.postMessage({ command: 'regenerateSummary' });
+      requestRegenerateSummary(btn);
     });
   }
-  attachRegenerateSummaryHandler();
+  attachRegenerateSummaryDelegate();
 
   // Toggle the page into / out of regenerating-readonly mode. CSS
   // (.page.regenerating-readonly button:not([data-foreign-safe])) takes

--- a/vscode/src/views/SummaryWebviewPanel.test.ts
+++ b/vscode/src/views/SummaryWebviewPanel.test.ts
@@ -1602,6 +1602,50 @@ describe("SummaryWebviewPanel", () => {
 				expect(mockPushToJolli).not.toHaveBeenCalled();
 			});
 
+			it("refuses to push a summary with summaryError marker and prompts user to Regenerate", async () => {
+				// A degraded summary (LLM failed → placeholder/Copy-Hoist/mechanical
+				// fallback with summaryError marker) must NOT be published to Jolli:
+				// if the commit already has a jolliDocId from an earlier successful
+				// push, the new push would silently overwrite the cloud article with
+				// placeholder content. The user must Regenerate first.
+				mockLoadConfig.mockResolvedValue({
+					apiKey: "test",
+					jolliApiKey: "jk_valid",
+				});
+				const dispatch = await setupPanel({ summaryError: "llm-failed" });
+
+				dispatch({ command: "push" });
+				await flushPromises();
+
+				expect(showWarningMessage).toHaveBeenCalledWith(
+					"This summary's last LLM generation failed. Click Regenerate above and try again before pushing to Jolli.",
+				);
+				expect(mockPushToJolli).not.toHaveBeenCalled();
+				expect(mockLoadConfig).not.toHaveBeenCalled();
+			});
+
+			it("refuses to push legacy summaries with llm.stopReason === 'error'", async () => {
+				// Pre-`summaryError` summaries (written before this field existed)
+				// signal failure via `llm.stopReason === "error"`. The push gate
+				// uses isSummaryError() which honors both new field and legacy
+				// fallback, so legacy degraded summaries are also refused.
+				mockLoadConfig.mockResolvedValue({
+					apiKey: "test",
+					jolliApiKey: "jk_valid",
+				});
+				const dispatch = await setupPanel({
+					llm: { model: "claude", inputTokens: 0, outputTokens: 0, apiLatencyMs: 0, stopReason: "error" },
+				});
+
+				dispatch({ command: "push" });
+				await flushPromises();
+
+				expect(showWarningMessage).toHaveBeenCalledWith(
+					expect.stringContaining("Regenerate above"),
+				);
+				expect(mockPushToJolli).not.toHaveBeenCalled();
+			});
+
 			it("warns and skips snippet notes missing content (schema-drift guard)", async () => {
 				// Legacy/corrupt entry: snippet without `content` must not silently drop —
 				// it should log.warn and skip the push, while other valid notes still go through.
@@ -2220,8 +2264,36 @@ describe("SummaryWebviewPanel", () => {
 						command: "summaryRegenerated",
 						topicsHtml: '<div id="topicsSection">t</div>',
 						recapHtml: '<div id="recapSection">r</div>',
+						// Healthy regenerate → empty banner so the script removes any
+						// stale .summary-error-banner from the DOM.
+						summaryErrorBannerHtml: "",
 					}),
 				);
+			});
+
+			it("includes a non-empty summaryErrorBannerHtml when regenerate still produces a degraded summary", async () => {
+				// Defensive: if the regenerate result itself somehow carries
+				// summaryError (e.g. user clicks Regenerate while creds are still
+				// broken — though in practice the regenerate path would have
+				// thrown earlier), the post-message should reflect that with a
+				// non-empty banner HTML so the DOM keeps showing it.
+				mockLoadRegenerateContext.mockResolvedValue(stubCtx());
+				showWarningMessage.mockResolvedValueOnce("Regenerate");
+				mockRegenerateSummary.mockResolvedValue({
+					updated: { ...stubUpdated(), summaryError: "llm-failed" } as never,
+					result: {} as never,
+				});
+				const dispatch = await setupPanel();
+
+				dispatch({ command: "regenerateSummary" });
+				await flushPromises();
+
+				const lastCalls = postMessage.mock.calls;
+				const regenMsg = lastCalls.find(
+					(call) => (call[0] as { command?: string }).command === "summaryRegenerated",
+				)?.[0] as { summaryErrorBannerHtml?: string } | undefined;
+				expect(regenMsg).toBeDefined();
+				expect(regenMsg?.summaryErrorBannerHtml).toContain('class="summary-error-banner"');
 			});
 
 			it("does NOT pass artifacts to bridge.storeSummary on success", async () => {

--- a/vscode/src/views/SummaryWebviewPanel.ts
+++ b/vscode/src/views/SummaryWebviewPanel.ts
@@ -81,6 +81,7 @@ import { log } from "../util/Logger.js";
 import { loadGlobalConfig } from "../util/WorkspaceUtils.js";
 import { BindingChooserWebviewPanel } from "./BindingChooserWebviewPanel.js";
 import { loadBranchSummaries } from "./BranchSummaryLoader.js";
+import { buildSummaryErrorBanner } from "./SummaryErrorBanner.js";
 import {
 	buildE2eTestSection,
 	buildHtml,
@@ -102,6 +103,7 @@ import {
 	formatActiveProviderLabel,
 } from "./SummaryUtils.js";
 import type { RegenerateContext } from "../../../cli/src/core/RegenerateContext.js";
+import { isSummaryError } from "../../../cli/src/core/SummaryErrorMarker.js";
 import type { LlmConfig } from "../../../cli/src/Types.js";
 
 /** Memory field updates sent from the webview edit form. */
@@ -1361,6 +1363,19 @@ export class SummaryWebviewPanel {
 		if (this.pushInProgress) {
 			return;
 		}
+		// Refuse to publish a degraded summary (LLM failed, persisted placeholder
+		// or Copy-Hoist / mechanical fallback with summaryError marker). If we let
+		// the push through and this commit already has a jolliDocId from an
+		// earlier successful push, Jolli would silently update the cloud article
+		// in place — overwriting good content with placeholder topics. The user
+		// must Regenerate first; the in-page banner already tells them how.
+		// biome-ignore lint/style/noNonNullAssertion: dispatch guard ensures currentSummary is set
+		if (isSummaryError(this.currentSummary!)) {
+			vscode.window.showWarningMessage(
+				"This summary's last LLM generation failed. Click Regenerate above and try again before pushing to Jolli.",
+			);
+			return;
+		}
 		// Check BEFORE setting pushInProgress so that a stale-commit early exit
 		// doesn't leave the flag stuck (the panel is about to be disposed anyway,
 		// but defensive against future code paths that survive the guard).
@@ -1915,6 +1930,12 @@ export class SummaryWebviewPanel {
 						command: "summaryRegenerated",
 						topicsHtml: buildTopicsSection(outcome.updated),
 						recapHtml: buildRecapSection(outcome.updated.recap),
+						// Empty string on success → script removes any existing
+						// banner from the DOM. Non-empty (unlikely on success
+						// but defensible — e.g. regenerate produced a partial
+						// result that re-tripped the marker) replaces the
+						// banner in place.
+						summaryErrorBannerHtml: buildSummaryErrorBanner(outcome.updated),
 					});
 					vscode.window.showInformationMessage("Summary regenerated.");
 				},


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## Quick recap

Commit summaries now survive LLM failures gracefully. When a network outage, credential problem, or API error prevents the summarizer from running, a placeholder summary is written to the commit's history with a failure marker attached. The next time the user opens that commit in the summary panel, a yellow banner appears prompting them to regenerate — and the banner persists through rebases and small amendments until the user explicitly triggers a successful regeneration. Commits that carry a failure marker are blocked from being published to Jolli Cloud, preventing empty or degraded content from overwriting previously good articles.

The squash consolidation path was also restructured to distinguish between three outcomes that were previously all represented as a missing result: a successful LLM consolidation, a healthy case where there was simply nothing to merge, and an actual LLM failure. Only the third case now sets the failure marker, so users are not shown a spurious warning banner after a squash that had nothing to consolidate. The rebase migration path received a matching fix: when a commit is rebased to a new hash, any failure marker on the old summary is carried forward to the new one, closing a gap where the banner would silently disappear after a rebase even though the underlying failure had never been addressed.

---

## E2E Test (4)
<details>
<summary><strong>1. Yellow warning banner appears on a commit with a failed LLM summary</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a repository where at least one commit has a summary that failed to generate (the LLM call failed during summarization). If you cannot trigger a real failure, ask a developer to manually mark a test commit with the failure flag before you begin.

**Steps:**
1. Open the Jolli Memory webview panel in VS Code.
2. Navigate to the commit list and click on the commit that has a failed summary.
3. Look at the summary view for that commit.
4. Check whether a yellow warning banner is visible near the top of the summary area.
5. Read the banner message to confirm it prompts you to click "Regenerate."
6. Click the Regenerate button and wait for the summary to reload.

**Expected Results:**
- A yellow warning banner should be clearly visible on the commit summary page before regenerating.
- The banner should contain a message directing you to regenerate the summary.
- After clicking Regenerate and waiting, the yellow banner should disappear and the summary should display normally with topics filled in.

</blockquote>
</details>
<details>
<summary><strong>2. Push to Jolli Cloud is blocked when a commit has a failed summary</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a commit whose summary shows the yellow warning banner (LLM failure marker is set, as described in the previous scenario).

**Steps:**
1. Open the Jolli Memory webview panel and navigate to the commit with the failed summary (yellow banner visible).
2. Attempt to publish or push that commit's summary to Jolli Cloud using the Push button.
3. Check what happens — does the push proceed or is it stopped?

**Expected Results:**
- The push should be refused and should NOT complete.
- A message should appear telling you the summary needs to be regenerated before it can be published.
- No summary should be sent to Jolli Cloud until the failure is resolved.

</blockquote>
</details>
<details>
<summary><strong>3. Warning banner disappears after successfully regenerating a failed summary</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a commit whose summary shows the yellow warning banner.

**Steps:**
1. Open the Jolli Memory webview and go to the commit showing the yellow warning banner.
2. Click the Regenerate button and wait for the process to finish.
3. Once the summary reloads, check whether the yellow banner is still visible.
4. Try clicking the Push button to publish the summary to Jolli Cloud.

**Expected Results:**
- After a successful regeneration, the yellow warning banner should be completely gone.
- The summary should display normally with topics populated.
- The Push button should now work without any error or refusal message.

</blockquote>
</details>
<details>
<summary><strong>4. Warning banner reappears after a rebase on a commit that had a failed summary</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a commit with a failed summary (yellow banner visible). Perform a git rebase on the branch containing that commit, then open the webview.

**Steps:**
1. Before rebasing, confirm the yellow warning banner is visible on the target commit in the Jolli Memory webview.
2. Perform a git rebase on the branch (ask a developer to do this if needed).
3. After the rebase completes, open or refresh the Jolli Memory webview.
4. Navigate to the same commit (it will have a new identifier after rebase).
5. Check whether the yellow warning banner is still visible on that commit.

**Expected Results:**
- The yellow warning banner should still be visible on the rebased commit, even though it now has a new commit hash.
- The banner should not silently disappear just because the commit was rebased.
- The summary should still prompt you to regenerate.

</blockquote>
</details>

---

## Topics (5)
<details>
<summary><strong>01 · Unified LLM failure marker with webview banner and push protection</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

When an LLM call failed during commit summarization, the failure was either silently swallowed or caused a loud throw that left no recoverable artifact. The team needed a consistent way to surface failures to users and let them recover without losing their commit history.

**💡 Decisions Behind the Code**

- **Placeholder over throw for all LLM failures**: The prior behavior threw on credential errors, which was effectively silent for command-line users who never see the hook's stderr. Writing a placeholder with a marker means the failure is always visible the next time the user opens the commit in the webview, regardless of how the commit was made. The trade-off is that a degraded summary lands on the orphan branch, but the push gate prevents that degraded content from ever reaching Jolli Cloud.
- **Single shared helper for error detection**: Rather than scattering `summaryError !== undefined || llm?.stopReason === "error"` checks across the codebase, a single `isSummaryError` function covers both the new field and the legacy `stopReason === "error"` format written by older versions. This keeps the banner, the push gate, and the rebase migration all consistent without requiring a data migration for existing summaries.
- **Refuse push rather than confirm**: The push gate was implemented as a hard refusal rather than a modal confirmation. Any user who clicks Push on a failed summary is almost certainly doing so by accident — there is no valid reason to publish an empty placeholder to Jolli Cloud, and a confirmation dialog would only add friction to the wrong path.

**✅ What Was Implemented**

- Added `summaryError: "llm-failed"` field to the `CommitSummary` type in `cli/src/Types.ts`, along with a new `SummaryErrorMarker.ts` module exporting `isSummaryError`, `LLM_FAILED`, and `withSummaryError`. All four LLM call sites in `QueueWorker.ts` (normal commit, amend step-1, amend step-2 consolidate, squash consolidate) now write a placeholder summary with this marker on failure after one retry, rather than throwing or silently dropping the result.
- Added a yellow warning banner in the webview (`SummaryErrorBanner.ts`, wired through `SummaryHtmlBuilder.ts` and `SummaryScriptBuilder.ts`) that appears on any commit whose summary carries the error marker, prompting the user to click Regenerate. `Regenerator.ts` explicitly clears the marker on a successful re-run.
- Added a push gate in `SummaryWebviewPanel.ts` (`handlePush`) that checks `isSummaryError` before allowing a summary to be published to Jolli Cloud, refusing with a message directing the user to regenerate first.

**📋 Future Enhancements**

- IntelliJ side: `gson.fromJson` silently drops unknown fields, so IntelliJ read-modify-write operations (amend, squash) will strip the `summaryError` field. Needs a tracking ticket for the IntelliJ maintainer.
- Consider a "Regenerate all" command for users who accumulate multiple failed summaries during a credential outage.

**📁 FILES**
- `cli/src/Types.ts`
- `cli/src/core/SummaryErrorMarker.ts`
- `cli/src/hooks/QueueWorker.ts`
- `cli/src/core/Regenerator.ts`
- `vscode/src/views/SummaryWebviewPanel.ts`

</blockquote>
</details>
<details>
<summary><strong>02 · Rebase migration now preserves failure marker on rebased commits</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

After a rebase, a commit that had a failed summary lost its error marker on the new hash, causing the warning banner to silently disappear even though the underlying LLM failure had never been resolved.

**💡 Decisions Behind the Code**

The guard uses `isSummaryError(oldSummary)` rather than `oldSummary.summaryError !== undefined` so that old summaries written before the new field existed are automatically upgraded to the canonical format during the rebase migration. This avoids a separate one-time migration pass and ensures the banner appears correctly for any affected commit regardless of when it was originally written.

**✅ What Was Implemented**

- Updated `migrateOneToOne` in `SummaryStore.ts` to copy the `summaryError` field to the rebased root using `isSummaryError(oldSummary)` as the guard. Using the shared helper (rather than reading the raw field directly) ensures legacy summaries that only have `llm.stopReason === "error"` are also upgraded to the new field format during migration.
- Added three tests to `SummaryStore.test.ts` covering: new-field propagation, legacy `stopReason` upgrade, and healthy summaries producing no marker after rebase.

**📁 FILES**
- `cli/src/core/SummaryStore.ts`

</blockquote>
</details>
<details>
<summary><strong>03 · Squash consolidation returns typed outcome instead of nullable result</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The squash consolidation function previously returned `null` for five distinct situations — no sources, all-empty sources, LLM produced nothing, LLM threw, strict retry threw — and callers could not distinguish a healthy "nothing to merge" case from an actual LLM failure. This made it impossible to set the error marker only when the LLM actually failed.

**💡 Decisions Behind the Code**

The three-way union was chosen over a boolean `failed` flag on the existing result type because the "no-content" and "llm-error" cases both result in the caller running the mechanical fallback, but only "llm-error" should set the failure marker. A single nullable return made this distinction impossible without adding out-of-band state. The discriminated union makes the intent explicit and exhaustively checkable by the TypeScript compiler.

**✅ What Was Implemented**

- Replaced the `Promise<SquashConsolidationResult | null>` return type of `generateSquashConsolidation` in `Summarizer.ts` with a discriminated union `SquashConsolidationOutcome` with three statuses: `"ok"` (LLM produced usable output), `"no-content"` (healthy empty case, no marker), and `"llm-error"` (both attempts threw, marker should be set). Updated all call sites in `QueueWorker.ts` to branch on the new status.
- Updated all affected tests in `Summarizer.test.ts` to use the new shape, adding a type-narrowing `assertOk` helper to avoid unsafe casts throughout the test suite.

**📁 FILES**
- `cli/src/core/Summarizer.ts`
- `cli/src/hooks/QueueWorker.ts`

</blockquote>
</details>
<details>
<summary><strong>04 · Amend short-circuit paths inherit failure marker from previous summary</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

When a user made a small amendment to a commit that had previously failed LLM generation, the short-circuit path (used for tiny changes that don't need a full LLM call) would clear the failure marker, making the warning banner disappear even though the failure had never been fixed.

**💡 Decisions Behind the Code**

The fix uses `isSummaryError(oldSummary)` rather than reading the raw field directly, for the same reason as the rebase migration: legacy summaries that predate the new field are covered automatically. The alternative of always re-running the LLM for previously-failed commits was rejected as too expensive — the short-circuit exists precisely to avoid unnecessary LLM calls for trivial amendments.

**✅ What Was Implemented**

Updated the two `applyAmendShortCircuit` call sites in `QueueWorker.ts`: the pre-LLM trivial-delta path now passes `markError: isSummaryError(oldSummary)` and the post-LLM empty-topics path passes `markError: deltaLlmFailed || isSummaryError(oldSummary)`. Added two end-to-end tests in `PostCommitHook.helpers.test.ts` covering both inheritance scenarios.

**📁 FILES**
- `cli/src/hooks/QueueWorker.ts`
- `cli/src/hooks/PostCommitHook.helpers.test.ts`

</blockquote>
</details>
<details>
<summary><strong>05 · Development guide updated with simplified error handling table</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The error handling table in the CLI development guide had grown to list amend step-1 and step-2 as separate rows with fine-grained detail, making it harder to read and maintain as the implementation evolved.

**💡 Decisions Behind the Code**

The table was collapsed to the level of user-observable behavior rather than implementation steps. Listing amend step-1 and step-2 separately was accurate but required readers to understand internal pipeline stages to make sense of the table — the new version describes what the user sees (placeholder summary, Regenerate banner, push refusal) without requiring knowledge of how the pipeline is structured internally.

**✅ What Was Implemented**

Replaced the previous multi-row breakdown in `cli/DEVELOPMENT.md` with two consolidated rows: one covering all LLM call failures regardless of cause (network, credential, quota, 5xx), and one covering the healthy "nothing to consolidate" mechanical fallback case. Also added a convention entry to `CLAUDE.md` requiring use of the shared `toForwardSlash` path normalization helper rather than inline path separator replacements.

**📁 FILES**
- `cli/DEVELOPMENT.md`
- `CLAUDE.md`

</blockquote>
</details>

---

*Generated by Jolli Memory · May 27, 2026 at 11:40 AM · via Anthropic*
<!-- jollimemory-summary-end -->