### PR TITLE
Overhaul API reference rendering with TryIt context, nav badges, and server variables

### DIFF
--- a/cli/src/commands/StartCommand.ts
+++ b/cli/src/commands/StartCommand.ts
@@ -23,6 +23,7 @@ import { buildPipeline } from "../site/openapi/OpenApiPipeline.js";
 import { deriveSpecName } from "../site/openapi/SpecName.js";
 import { runPagefind } from "../site/PagefindRunner.js";
 import { resolveRenderer, type SiteRenderer } from "../site/renderer/index.js";
+import { buildApiSidebarOverrides } from "../site/renderer/nextra/index.js";
 import type { OpenApiSpecInput } from "../site/renderer/SiteRenderer.js";
 import { escapeHtml, sanitizeUrl } from "../site/Sanitize.js";
 import { readSiteJson } from "../site/SiteJsonReader.js";
@@ -253,6 +254,12 @@ async function syncContent(
 		await writeRootRedirectIndex(contentDir, redirectHref);
 	}
 
+	// API endpoint folders get summary labels from their OpenAPI operations.
+	// Merged into whichever sidebar overrides the navigation mode supplies —
+	// `/api-{spec}/{tag}` path keys never collide with doc paths, so API wins
+	// for its own folders and doc overrides are untouched.
+	const apiSidebar = specInputs ? buildApiSidebarOverrides(specInputs) : {};
+
 	if (parsedNavigation) {
 		if (parsedNavigation.rootPages?.length) {
 			rootInjection.structurePages = parsedNavigation.rootPages;
@@ -263,10 +270,10 @@ async function syncContent(
 		if (parsedNavigation.defaultPageHref) {
 			rootInjection.defaultPageHref = parsedNavigation.defaultPageHref;
 		}
-		await renderer.generateNavigation(contentDir, parsedNavigation.sidebar, rootInjection);
-	} else if (sidebar && Object.keys(sidebar).length > 0) {
-		// Legacy sidebar overrides
-		await renderer.generateNavigation(contentDir, sidebar, rootInjection);
+		await renderer.generateNavigation(contentDir, { ...parsedNavigation.sidebar, ...apiSidebar }, rootInjection);
+	} else if ((sidebar && Object.keys(sidebar).length > 0) || Object.keys(apiSidebar).length > 0) {
+		// Legacy sidebar overrides and/or API endpoint labels
+		await renderer.generateNavigation(contentDir, { ...sidebar, ...apiSidebar }, rootInjection);
 	} else {
 		// No navigation, no sidebar — empty sidebar (no filesystem auto-discovery)
 		rootInjection.simpleMode = true;

--- a/cli/src/site/NextraProjectWriter.ts
+++ b/cli/src/site/NextraProjectWriter.ts
@@ -210,6 +210,7 @@ export async function writeScopedNextraLayoutComponent(buildDir: string): Promis
 import { Layout } from "nextra-theme-docs";
 import { useEffect, useMemo, type ComponentProps, type ReactNode } from "react";
 import { usePathname } from "next/navigation";
+import { API_NAV_METHODS } from "./apiNavMethods";
 
 // Pure pageMap-filtering logic — pasted verbatim from
 // SCOPE_PAGE_MAP_RUNTIME_SOURCE in ScopePageMap.ts (a hand-maintained string
@@ -237,6 +238,33 @@ export default function ScopedNextraLayout({ pageMap, children, ...layoutProps }
   useEffect(() => {
     document.documentElement.dataset.jolliMultiSpec = isMultiSpec ? "true" : "false";
   }, [isMultiSpec]);
+
+  // Stamp \`data-api-method\` onto each API endpoint's sidebar link so the theme
+  // can render an HTTP-method chip (Nextra v4 has no sidebar titleComponent and
+  // page-map titles are plain strings, so the badge can't ride the nav data).
+  // Re-runs on navigation and on sidebar DOM changes (collapse/expand). Setting
+  // an attribute doesn't emit childList records, so the observer can't loop.
+  useEffect(() => {
+    if (Object.keys(API_NAV_METHODS).length === 0) return;
+    const stamp = () => {
+      document.querySelectorAll("nav a[href], aside a[href]").forEach((a) => {
+        let path;
+        try {
+          path = new URL(a.href, window.location.origin).pathname.replace(/\\/$/, "");
+        } catch {
+          return;
+        }
+        const method = API_NAV_METHODS[path];
+        if (method && a.getAttribute("data-api-method") !== method) {
+          a.setAttribute("data-api-method", method);
+        }
+      });
+    };
+    stamp();
+    const observer = new MutationObserver(stamp);
+    observer.observe(document.body, { childList: true, subtree: true });
+    return () => observer.disconnect();
+  }, [pathname]);
 
   return (
     <Layout pageMap={scopedPageMap as PageMap} {...layoutProps}>

--- a/cli/src/site/openapi/SpecParser.test.ts
+++ b/cli/src/site/openapi/SpecParser.test.ts
@@ -439,6 +439,87 @@ describe("parseFullSpec — top-level extraction", () => {
 		expect(spec.operations[0].servers).toBeUndefined();
 	});
 
+	it("carries server variables (default/enum/description) through on root servers", () => {
+		const doc = makeDoc({
+			servers: [
+				{
+					url: "https://{defaultHost}",
+					description: "default",
+					variables: {
+						defaultHost: {
+							default: "discourse.example.com",
+							enum: ["discourse.example.com", "try.discourse.org"],
+							description: "the host",
+						},
+					},
+				},
+			],
+		});
+		const spec = parseFullSpec(doc);
+		expect(spec.servers).toEqual([
+			{
+				url: "https://{defaultHost}",
+				description: "default",
+				variables: {
+					defaultHost: {
+						default: "discourse.example.com",
+						enum: ["discourse.example.com", "try.discourse.org"],
+						description: "the host",
+					},
+				},
+			},
+		]);
+	});
+
+	it("drops malformed server-variable fields and an empty variables map", () => {
+		const doc = makeDoc({
+			servers: [
+				{
+					url: "https://{host}",
+					variables: {
+						host: { default: 42, enum: [1, "ok"], description: 7 },
+						bogus: "not-an-object",
+					},
+				},
+			],
+		});
+		const spec = parseFullSpec(doc);
+		// `host.default`/`description` are non-strings (dropped); enum keeps only
+		// the string member; `bogus` is not an object (dropped) — leaving just a
+		// single-key enum.
+		expect(spec.servers).toEqual([{ url: "https://{host}", variables: { host: { enum: ["ok"] } } }]);
+	});
+
+	it("omits variables entirely when none survive filtering", () => {
+		const doc = makeDoc({
+			servers: [{ url: "https://x", variables: { a: "nope" } }],
+		});
+		const spec = parseFullSpec(doc);
+		expect(spec.servers).toEqual([{ url: "https://x" }]);
+	});
+
+	it("drops an enum that contains no string members", () => {
+		const doc = makeDoc({
+			servers: [{ url: "https://{host}", variables: { host: { default: "h", enum: [1, 2, true] } } }],
+		});
+		const spec = parseFullSpec(doc);
+		expect(spec.servers).toEqual([{ url: "https://{host}", variables: { host: { default: "h" } } }]);
+	});
+
+	it("carries server variables through on an operation-level override", () => {
+		const doc = makeDoc({
+			paths: {
+				"/x": {
+					get: { servers: [{ url: "https://{region}", variables: { region: { default: "us" } } }] },
+				},
+			},
+		});
+		const spec = parseFullSpec(doc);
+		expect(spec.operations[0].servers).toEqual([
+			{ url: "https://{region}", variables: { region: { default: "us" } } },
+		]);
+	});
+
 	it("extracts security schemes verbatim, dropping schemes without a type", () => {
 		const doc = makeDoc({
 			components: {

--- a/cli/src/site/openapi/SpecParser.ts
+++ b/cli/src/site/openapi/SpecParser.ts
@@ -20,6 +20,7 @@ import type {
 	OpenApiResponse,
 	OpenApiSecurityScheme,
 	OpenApiServerEntry,
+	OpenApiServerVariable,
 	OpenApiTagEntry,
 	ParsedSpec,
 } from "./Types.js";
@@ -256,6 +257,49 @@ function resolveParameters(root: Record<string, unknown>, raw: unknown): OpenApi
 
 // ─── Top-level extractors ────────────────────────────────────────────────────
 
+/**
+ * Reads a server's `variables` map, keeping only the fields the renderer-side
+ * try-it widget consumes (`default` / `enum` / `description`). Returns
+ * undefined when absent or malformed so it can be spread conditionally.
+ */
+function extractServerVariables(raw: unknown): Record<string, OpenApiServerVariable> | undefined {
+	if (!raw || typeof raw !== "object") {
+		return undefined;
+	}
+	const out: Record<string, OpenApiServerVariable> = {};
+	for (const [name, value] of Object.entries(raw as Record<string, unknown>)) {
+		if (!value || typeof value !== "object") {
+			continue;
+		}
+		const v = value as { default?: unknown; enum?: unknown; description?: unknown };
+		const variable: OpenApiServerVariable = {};
+		if (typeof v.default === "string") {
+			variable.default = v.default;
+		}
+		if (Array.isArray(v.enum)) {
+			const values = v.enum.filter((e): e is string => typeof e === "string");
+			if (values.length > 0) {
+				variable.enum = values;
+			}
+		}
+		if (typeof v.description === "string") {
+			variable.description = v.description;
+		}
+		out[name] = variable;
+	}
+	return Object.keys(out).length > 0 ? out : undefined;
+}
+
+/** Normalizes one raw `servers[]` entry, carrying `description` + `variables` when present. */
+function toServerEntry(s: OpenApiServerEntry & { variables?: unknown }): OpenApiServerEntry {
+	const variables = extractServerVariables(s.variables);
+	return {
+		url: s.url,
+		...(s.description !== undefined ? { description: s.description } : {}),
+		...(variables ? { variables } : {}),
+	};
+}
+
 /** Reads the spec's top-level `servers` array, dropping malformed entries. */
 function extractServers(spec: OpenApiDocument): OpenApiServerEntry[] {
 	const raw = spec.servers;
@@ -264,10 +308,7 @@ function extractServers(spec: OpenApiDocument): OpenApiServerEntry[] {
 	}
 	return raw
 		.filter((s): s is OpenApiServerEntry => typeof (s as OpenApiServerEntry)?.url === "string")
-		.map((s) => ({
-			url: s.url,
-			...(s.description !== undefined ? { description: s.description } : {}),
-		}));
+		.map(toServerEntry);
 }
 
 /**
@@ -314,12 +355,9 @@ function extractOperationServers(operation: Record<string, unknown>): OpenApiSer
 	if (!Array.isArray(operation.servers)) {
 		return;
 	}
-	const result = (operation.servers as OpenApiServerEntry[])
+	const result = (operation.servers as Array<OpenApiServerEntry & { variables?: unknown }>)
 		.filter((s) => typeof s?.url === "string")
-		.map((s) => ({
-			url: s.url,
-			...(s.description !== undefined ? { description: s.description } : {}),
-		}));
+		.map(toServerEntry);
 	return result.length > 0 ? result : undefined;
 }
 

--- a/cli/src/site/openapi/Types.ts
+++ b/cli/src/site/openapi/Types.ts
@@ -38,10 +38,23 @@ export interface OpenApiDocument {
 /** HTTP methods we walk. Lowercase to match OpenAPI keys. */
 export type OpenApiHttpMethod = "get" | "post" | "put" | "patch" | "delete" | "head" | "options";
 
+/**
+ * A single `server.variables` entry. A server `url` may contain `{name}`
+ * templated segments whose allowed/default values come from here — the
+ * renderer-side try-it widget renders an input (or a `<select>` when `enum`
+ * is present) per variable and substitutes them into the request URL.
+ */
+export interface OpenApiServerVariable {
+	default?: string;
+	enum?: string[];
+	description?: string;
+}
+
 /** A `servers[]` entry, on either the spec root or a single operation. */
 export interface OpenApiServerEntry {
 	url: string;
 	description?: string;
+	variables?: Record<string, OpenApiServerVariable>;
 }
 
 /**

--- a/cli/src/site/renderer/NextraRenderer.test.ts
+++ b/cli/src/site/renderer/NextraRenderer.test.ts
@@ -93,6 +93,8 @@ describe("NextraRenderer", () => {
 				expect(existsSync(join(buildDir, "components", "api", file))).toBe(true);
 			}
 			expect(existsSync(join(buildDir, "styles", "api.css"))).toBe(true);
+			// The empty route→method map is scaffolded so the layout import resolves.
+			expect(existsSync(join(buildDir, "components", "apiNavMethods.ts"))).toBe(true);
 		} finally {
 			await rm(buildDir, { recursive: true, force: true });
 		}
@@ -314,20 +316,19 @@ describe("NextraRenderer.renderOpenApiSpecs", () => {
 		expect(existsSync(join(contentDir, "api-petstore", "_data", "listpets.json"))).toBe(true);
 	});
 
-	it("writes the spec-folder _meta.ts and one _meta.ts per tag folder", async () => {
+	it("writes the route→method nav map keyed by endpoint route", async () => {
 		await new NextraRenderer().renderOpenApiSpecs(contentDir, publicDir, [makeSpecInput()]);
 
-		const topMeta = await readFile(join(contentDir, "api-petstore", "_meta.ts"), "utf-8");
-		expect(topMeta).toContain("index: 'Overview'");
-		expect(topMeta).toContain("'pets': 'pets'");
-
-		const tagMeta = await readFile(join(contentDir, "api-petstore", "pets", "_meta.ts"), "utf-8");
-		expect(tagMeta).toContain("'listpets':");
+		const navMap = await readFile(join(buildDir, "components", "apiNavMethods.ts"), "utf-8");
+		expect(navMap).toContain('"/api-petstore/pets/listpets": "GET"');
 	});
 
-	it("does not write components/api/ — those are scaffold written by initProject", async () => {
+	it("does not write components/api/ scaffold — only the nav-methods map", async () => {
 		await new NextraRenderer().renderOpenApiSpecs(contentDir, publicDir, [makeSpecInput()]);
-		expect(existsSync(join(buildDir, "components"))).toBe(false);
+		// The scaffold components are written by initProject, not by rendering.
+		expect(existsSync(join(buildDir, "components", "api"))).toBe(false);
+		// …but the render does refresh the route→method map.
+		expect(existsSync(join(buildDir, "components", "apiNavMethods.ts"))).toBe(true);
 	});
 
 	it("writes per-spec output for each input when given multiple specs", async () => {

--- a/cli/src/site/renderer/NextraRenderer.ts
+++ b/cli/src/site/renderer/NextraRenderer.ts
@@ -18,7 +18,7 @@ import type { OutputFilter } from "../OutputFilter.js";
 import { createOutputFilter as createFilter } from "../OutputFilter.js";
 import type { NpmRunResult, SidebarOverrides, SiteJson } from "../Types.js";
 import { generateApiCss } from "./nextra/ApiCss.js";
-import { emitNextraOpenApiFiles, generateApiComponents } from "./nextra/index.js";
+import { EMPTY_API_NAV_METHODS, emitNextraOpenApiFiles, generateApiComponents } from "./nextra/index.js";
 import type { TemplateFile } from "./nextra/Types.js";
 import type { ContentRules, OpenApiSpecInput, SiteRenderer } from "./SiteRenderer.js";
 
@@ -71,7 +71,15 @@ export class NextraRenderer implements SiteRenderer {
 		// (228) so the API surface inherits the pack's identity instead of
 		// the unrelated `generateApiCss` fallback (220).
 		const accentHue = resolveApiAccentHue(config);
-		await this.writeFiles(buildDir, [...generateApiComponents(), generateApiCss({ accentHue })]);
+		// `EMPTY_API_NAV_METHODS` is the route→method map the layout imports for
+		// the sidebar method badges. Written empty here so the import always
+		// resolves; `renderOpenApiSpecs` overwrites it with the populated map
+		// when the site has specs.
+		await this.writeFiles(buildDir, [
+			...generateApiComponents(),
+			generateApiCss({ accentHue }),
+			EMPTY_API_NAV_METHODS,
+		]);
 
 		return result;
 	}

--- a/cli/src/site/renderer/nextra/ApiNavMethods.ts
+++ b/cli/src/site/renderer/nextra/ApiNavMethods.ts
@@ -1,0 +1,43 @@
+/**
+ * Emits `components/apiNavMethods.ts` — a static route → HTTP-method lookup
+ * the sidebar badge client component (`ApiNavMethodBadges.tsx`) reads to stamp
+ * a `data-api-method` attribute onto each API endpoint's sidebar link. The
+ * theme's CSS turns that attribute into the visible method chip.
+ *
+ * Nextra v4 has no sidebar `titleComponent` hook and its page-map titles are
+ * plain strings, so a method badge can't be injected through the navigation
+ * data itself — hence the client-side stamping driven by this map.
+ *
+ * `initProject` writes `EMPTY_API_NAV_METHODS` once so the layout's import
+ * always resolves (even for a site with no specs); a build with specs then
+ * overwrites it with the populated map.
+ */
+
+import type { OpenApiSpecInput } from "../SiteRenderer.js";
+import { endpointRoutePath } from "./Paths.js";
+import type { TemplateFile } from "./Types.js";
+
+const MAP_PATH = "components/apiNavMethods.ts";
+
+/** Empty map module — written at init so the layout import always resolves. */
+export const EMPTY_API_NAV_METHODS: TemplateFile = {
+	path: MAP_PATH,
+	content: "export const API_NAV_METHODS: Record<string, string> = {};\n",
+};
+
+/**
+ * Builds the route → uppercase-method map for every operation across the
+ * supplied specs and serialises it as a typed ES module.
+ */
+export function emitApiNavMethods(specs: ReadonlyArray<OpenApiSpecInput>): TemplateFile {
+	const map: Record<string, string> = {};
+	for (const { specName, pipeline } of specs) {
+		for (const op of pipeline.spec.operations) {
+			map[endpointRoutePath(specName, op)] = op.method.toUpperCase();
+		}
+	}
+	return {
+		path: MAP_PATH,
+		content: `export const API_NAV_METHODS: Record<string, string> = ${JSON.stringify(map, null, 2)};\n`,
+	};
+}

--- a/cli/src/site/renderer/nextra/Components.test.ts
+++ b/cli/src/site/renderer/nextra/Components.test.ts
@@ -11,34 +11,56 @@ describe("generateApiComponents", () => {
 	const files = generateApiComponents();
 	const byPath = new Map(files.map((f) => [f.path, f.content]));
 
-	it("emits exactly nine files under components/api/", () => {
-		expect(files).toHaveLength(9);
+	it("emits exactly twenty files under components/api/", () => {
+		expect(files).toHaveLength(20);
 		for (const f of files) {
 			expect(f.path.startsWith("components/api/")).toBe(true);
 		}
 	});
 
-	it("emits the describeType utility, the eight components, in expected paths", () => {
+	it("emits the utilities and components in expected paths", () => {
 		const paths = new Set(files.map((f) => f.path));
 		for (const file of [
+			// Shared utility + plain (.ts) modules
 			"components/api/describeType.ts",
+			"components/api/requestSnippets.ts",
+			"components/api/tryItHistory.ts",
+			"components/api/jsonHighlight.ts",
+			"components/api/serverVars.ts",
+			"components/api/paramSchema.ts",
+			// React components
 			"components/api/EndpointMeta.tsx",
 			"components/api/ParamTable.tsx",
 			"components/api/SchemaBlock.tsx",
 			"components/api/ResponseBlock.tsx",
+			"components/api/ResponseTabs.tsx",
 			"components/api/AuthRequirements.tsx",
 			"components/api/TryIt.tsx",
+			"components/api/TryItContext.tsx",
 			"components/api/CodeSwitcher.tsx",
+			"components/api/CodeEditor.tsx",
+			"components/api/TypedInput.tsx",
+			"components/api/RequestSample.tsx",
+			"components/api/HistoryItem.tsx",
 			"components/api/Endpoint.tsx",
 		]) {
 			expect(paths.has(file)).toBe(true);
 		}
 	});
 
-	it('emits all components as client components ("use client" pragma)', () => {
-		// The describeType utility is the only one that is a plain module.
+	it('emits all React components as client components ("use client" pragma)', () => {
+		// The plain (.ts) utility modules are the only ones without the pragma.
+		const plainModules = new Set([
+			"components/api/describeType.ts",
+			"components/api/requestSnippets.ts",
+			"components/api/tryItHistory.ts",
+			"components/api/jsonHighlight.ts",
+			"components/api/serverVars.ts",
+			"components/api/paramSchema.ts",
+		]);
 		for (const file of files) {
-			if (file.path === "components/api/describeType.ts") {
+			if (plainModules.has(file.path)) {
+				expect(file.content.startsWith('"use client";')).toBe(false);
 				continue;
 			}
 			expect(file.content.startsWith('"use client";')).toBe(true);
@@ -61,10 +83,28 @@ describe("generateApiComponents", () => {
 		expect(schemaBlock).toContain("(circular)");
 	});
 
-	it("TryIt.tsx persists auth values via sessionStorage (per-spec scoped)", () => {
-		const tryIt = byPath.get("components/api/TryIt.tsx") ?? "";
-		expect(tryIt).toContain("sessionStorage");
-		expect(tryIt).toContain("jolli-tryit:");
+	it("TryItContext.tsx persists auth values via sessionStorage (per-spec scoped)", () => {
+		const ctx = byPath.get("components/api/TryItContext.tsx") ?? "";
+		expect(ctx).toContain("sessionStorage");
+		expect(ctx).toContain("jolli-tryit:");
+	});
+
+	it("tryItHistory.ts logs sent requests to localStorage", () => {
+		const hist = byPath.get("components/api/tryItHistory.ts") ?? "";
+		expect(hist).toContain("localStorage");
+		expect(hist).toContain("jolli-tryit-history:");
+	});
+
+	it("serverVars.ts resolves templated server URLs", () => {
+		const sv = byPath.get("components/api/serverVars.ts") ?? "";
+		expect(sv).toContain("export function resolveServerUrl");
+		expect(sv).toContain("export function serverVariablesFor");
+	});
+
+	it("paramSchema.ts derives the input control from a schema", () => {
+		const ps = byPath.get("components/api/paramSchema.ts") ?? "";
+		expect(ps).toContain("export function inputKind");
+		expect(ps).toContain("export function primaryType");
 	});
 
 	it("describeType handles array items and $ref shorthand", () => {
@@ -80,11 +120,15 @@ describe("generateApiComponents", () => {
 			'import EndpointMeta from "./EndpointMeta"',
 			'import ParamTable from "./ParamTable"',
 			'import SchemaBlock from "./SchemaBlock"',
-			'import ResponseBlock from "./ResponseBlock"',
+			'import ResponseTabs from "./ResponseTabs"',
 			'import AuthRequirements from "./AuthRequirements"',
 			'import TryIt from "./TryIt"',
+			'import RequestSample from "./RequestSample"',
+			'import { TryItProvider } from "./TryItContext"',
 		]) {
 			expect(endpoint).toContain(importLine);
 		}
+		// The vertical ResponseBlock stack was replaced by the tabbed ResponseTabs.
+		expect(endpoint).not.toContain('import ResponseBlock from "./ResponseBlock"');
 	});
 });

--- a/cli/src/site/renderer/nextra/Components.ts
+++ b/cli/src/site/renderer/nextra/Components.ts
@@ -1,34 +1,20 @@
 import type { TemplateFile } from "./Types.js";
 
 /**
- * Emits the React components (and one shared utility) the per-endpoint MDX
- * pages import:
+ * Emits the React components (and shared utilities) the per-endpoint MDX pages
+ * import. Each component is stored as a template-literal string and scaffolded
+ * verbatim into the generated site under `components/api/`. They are emitted
+ * as `"use client"` (except the plain `.ts` utility modules) to avoid Next.js
+ * 15 server-component hydration issues when used inside MDX pages.
  *
- * - describeType (utility) — schema → human-readable type string, shared by
- *   ParamTable and SchemaBlock to keep the rendering rules in one place
- * - EndpointMeta — pill row with METHOD + path + tags + deprecation badge
- * - ParamTable — table for path/query/header/cookie parameters
- * - SchemaBlock — collapsible OpenAPI schema renderer (for request bodies)
- * - ResponseBlock — wraps SchemaBlock with status-code header
- * - AuthRequirements — list of which security schemes apply
- * - TryIt — interactive request builder with response panel
- * - CodeSwitcher — header bar (dropdown + copy) wrapping fenced code blocks,
- *   replaces Nextra's `<Tabs>` for the request samples / response examples
- *   so the picker is inline with the code panel rather than floating above
- * - Endpoint — top-level wrapper composing the above into the two-column
- *   layout the MDX shim renders into; sub-exports `EndpointDescription`
- *   and `EndpointSamples` for the shim's left/right slots
+ * The endpoint page is a single-line identity header (METHOD + path + copy +
+ * "Try it" toggle) that expands an accordion holding the interactive TryIt
+ * form. A shared `TryItContext` feeds the live `RequestSample` in the aside,
+ * which regenerates per-language snippets as the form is filled in. Sent
+ * requests are logged to `localStorage` and rendered by `HistoryItem`.
  *
- * The fenced MDX code blocks inside `<CodeSwitcher>` are still processed by
- * Nextra's MDX → Shiki pipeline, so syntax highlighting is preserved even
- * though the switcher hides/shows panes via React state.
- *
- * Components consume the theme pack's CSS variables (--primary-hue, --api-*)
- * so Forge and Atlas inherit theming automatically. The TryIt widget is the
- * only component with significant state — others are pure presentational.
- *
- * All components are emitted as `"use client"` to avoid Next.js 15 server-
- * component hydration issues when used inside MDX pages.
+ * Styling for every `.api-*` class name is supplied by the active theme — the
+ * components only emit the markup contract.
  */
 export function generateApiComponents(): Array<TemplateFile> {
 	return [
@@ -37,19 +23,24 @@ export function generateApiComponents(): Array<TemplateFile> {
 		{ path: "components/api/ParamTable.tsx", content: PARAM_TABLE },
 		{ path: "components/api/SchemaBlock.tsx", content: SCHEMA_BLOCK },
 		{ path: "components/api/ResponseBlock.tsx", content: RESPONSE_BLOCK },
+		{ path: "components/api/ResponseTabs.tsx", content: RESPONSE_TABS },
 		{ path: "components/api/AuthRequirements.tsx", content: AUTH_REQUIREMENTS },
 		{ path: "components/api/TryIt.tsx", content: TRY_IT },
+		{ path: "components/api/TryItContext.tsx", content: TRY_IT_CONTEXT },
 		{ path: "components/api/CodeSwitcher.tsx", content: CODE_SWITCHER },
+		{ path: "components/api/CodeEditor.tsx", content: CODE_EDITOR },
+		{ path: "components/api/TypedInput.tsx", content: TYPED_INPUT },
+		{ path: "components/api/RequestSample.tsx", content: REQUEST_SAMPLE },
+		{ path: "components/api/HistoryItem.tsx", content: HISTORY_ITEM },
 		{ path: "components/api/Endpoint.tsx", content: ENDPOINT },
+		{ path: "components/api/requestSnippets.ts", content: REQUEST_SNIPPETS },
+		{ path: "components/api/tryItHistory.ts", content: TRY_IT_HISTORY },
+		{ path: "components/api/jsonHighlight.ts", content: JSON_HIGHLIGHT },
+		{ path: "components/api/serverVars.ts", content: SERVER_VARS },
+		{ path: "components/api/paramSchema.ts", content: PARAM_SCHEMA },
 	];
 }
 
-/**
- * describeType — shared by ParamTable and SchemaBlock. Both components used
- * to inline near-identical copies; this version is the SchemaBlock superset
- * (handles array `items.$ref` and falls back to "array" when item type is
- * unknown), which is also correct behavior for ParamTable.
- */
 const DESCRIBE_TYPE = `export function describeType(schema: unknown): string {
   if (!schema || typeof schema !== "object") return "—";
   const s = schema as { type?: string; format?: string; $ref?: string; items?: { type?: string; $ref?: string } };
@@ -64,62 +55,28 @@ const DESCRIBE_TYPE = `export function describeType(schema: unknown): string {
 }
 `;
 
-/**
- * CodeSwitcher — drop-in replacement for `<Tabs>` on endpoint code panels.
- * Expects each child to be a `<div data-pane="<value>">` containing a
- * fenced markdown code block. The component renders one pane at a time
- * (the rest carry `hidden`) and a header bar with a label, a `<select>`
- * picker, and a copy button. The copy button reads `textContent` from the
- * active pane, so it captures the source of the fenced block whether or
- * not Shiki has already replaced it with highlighted spans.
- */
-const CODE_SWITCHER = `"use client";
+const ENDPOINT_META = `"use client";
 
-import { Children, isValidElement, useEffect, useRef, useState, type ReactElement, type ReactNode } from "react";
+import { useEffect, useRef, useState } from "react";
+import { useTryItInputs } from "./TryItContext";
 
-interface Option {
-  value: string;
-  label: string;
+interface EndpointMetaProps {
+  method: string;
+  path: string;
+  deprecated?: boolean;
+  /** First (default) server URL; prepended to the path for the copy action. */
+  server?: string;
+  /** Whether the TryIt accordion below this line is currently open. */
+  tryItOpen?: boolean;
+  /** Toggle handler for the "Try it" button. When omitted, no button renders. */
+  onToggleTryIt?: () => void;
 }
 
-interface CodeSwitcherProps {
-  /** Picker options in display order. The first option is the initial selection. */
-  options: Array<Option>;
-  /** "Request" / "Response" or any short heading for the panel. */
-  label: string;
-  /**
-   * Children whose top-level wrapper is \`<div data-pane="<value>">\` for
-   * each option in \`options\`. Markdown fenced code blocks inside those
-   * wrappers are processed by Nextra so Shiki highlighting is preserved.
-   */
-  children: ReactNode;
-}
-
-interface PaneProps {
-  "data-pane"?: string;
-}
-
-function getPaneValue(child: ReactNode): string | undefined {
-  if (!isValidElement(child)) return undefined;
-  const props = (child as ReactElement<PaneProps>).props;
-  return props["data-pane"];
-}
-
-export default function CodeSwitcher({ options, label, children }: CodeSwitcherProps) {
-  const initial = options[0]?.value ?? "";
-  const [active, setActive] = useState<string>(initial);
+export default function EndpointMeta({ method, path, deprecated, server, tryItOpen, onToggleTryIt }: EndpointMetaProps) {
+  const methodClass = \`api-method api-method-\${method.toLowerCase()}\`;
+  const { resolvedServerUrl } = useTryItInputs();
   const [copied, setCopied] = useState(false);
-  const bodyRef = useRef<HTMLDivElement | null>(null);
   const copyTimer = useRef<number | null>(null);
-
-  // Reset selection if the parent rerenders with a new option set (e.g.,
-  // navigating between endpoints with different status codes).
-  useEffect(() => {
-    if (!options.some(o => o.value === active)) {
-      setActive(initial);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- intentional: only resync when the option list shape changes
-  }, [options.map(o => o.value).join("|")]);
 
   useEffect(
     () => () => {
@@ -129,84 +86,44 @@ export default function CodeSwitcher({ options, label, children }: CodeSwitcherP
   );
 
   function handleCopy() {
-    const body = bodyRef.current;
-    if (!body) return;
-    const pane = body.querySelector<HTMLElement>(\`[data-pane="\${CSS.escape(active)}"]\`);
-    const code = pane?.querySelector("code")?.textContent ?? pane?.textContent ?? "";
-    if (!code) return;
-    void navigator.clipboard.writeText(code).then(() => {
+    // Copy the full URL: resolved server (variables substituted, trailing slash
+    // trimmed) + path. Falls back to the raw \`server\` prop if context is absent.
+    const base = resolvedServerUrl || server || "";
+    const fullUrl = base.replace(/\\/+$/, "") + path;
+    void navigator.clipboard.writeText(fullUrl).then(() => {
       setCopied(true);
+      if (copyTimer.current) window.clearTimeout(copyTimer.current);
       copyTimer.current = window.setTimeout(() => setCopied(false), 1500);
     });
   }
 
-  const childArray = Children.toArray(children);
-
   return (
-    <div className="api-code-switcher">
-      <div className="api-code-switcher-toolbar">
-        <span className="api-code-switcher-label">{label}</span>
-        <select
-          className="api-code-switcher-select"
-          value={active}
-          onChange={e => setActive(e.target.value)}
-          aria-label={\`Select \${label.toLowerCase()}\`}
-        >
-          {options.map(o => (
-            <option key={o.value} value={o.value}>
-              {o.label}
-            </option>
-          ))}
-        </select>
+    <div className="api-endpoint-meta">
+      <div className="api-endpoint-target">
+        <span className={methodClass}>{method.toUpperCase()}</span>
+        <code className="api-endpoint-path">{path}</code>
+        {deprecated && <span className="api-endpoint-deprecated">Deprecated</span>}
         <button
           type="button"
-          className="api-code-switcher-copy"
+          className="api-endpoint-path-copy"
           data-copied={copied ? "true" : "false"}
           onClick={handleCopy}
+          aria-label="Copy path"
         >
           {copied ? "Copied" : "Copy"}
         </button>
       </div>
-      <div className="api-code-switcher-body" ref={bodyRef}>
-        {childArray.map((child, i) => {
-          const value = getPaneValue(child);
-          if (!value) return null;
-          return (
-            <div
-              key={value || i}
-              className="api-code-switcher-pane"
-              data-pane={value}
-              hidden={value !== active}
-            >
-              {child}
-            </div>
-          );
-        })}
-      </div>
-    </div>
-  );
-}
-`;
-
-const ENDPOINT_META = `"use client";
-
-interface EndpointMetaProps {
-  method: string;
-  path: string;
-  tags: Array<string>;
-  deprecated?: boolean;
-}
-
-export default function EndpointMeta({ method, path, tags, deprecated }: EndpointMetaProps) {
-  const methodClass = \`api-method api-method-\${method.toLowerCase()}\`;
-  return (
-    <div className="api-endpoint-meta">
-      <span className={methodClass}>{method.toUpperCase()}</span>
-      <code className="api-endpoint-path">{path}</code>
-      {tags.map(t => (
-        <span key={t} className="api-endpoint-tag">{t}</span>
-      ))}
-      {deprecated && <span className="api-endpoint-deprecated">Deprecated</span>}
+      {onToggleTryIt && (
+        <button
+          type="button"
+          className="api-endpoint-tryit-toggle"
+          aria-expanded={tryItOpen ? "true" : "false"}
+          onClick={onToggleTryIt}
+        >
+          Try it
+          <span className="api-endpoint-tryit-toggle-arrow" aria-hidden="true">▶</span>
+        </button>
+      )}
     </div>
   );
 }
@@ -401,6 +318,64 @@ export default function ResponseBlock({ status, description, contentType, schema
 }
 `;
 
+const RESPONSE_TABS = `"use client";
+
+import { useState } from "react";
+import SchemaBlock from "./SchemaBlock";
+
+interface OperationResponse {
+  status: string;
+  description?: string;
+  contentType?: string;
+  schema?: unknown;
+}
+
+interface ResponseTabsProps {
+  responses: Array<OperationResponse>;
+  refs?: Record<string, unknown>;
+}
+
+/**
+ * Content-side Response section as a tabbed panel — the same visual treatment as
+ * the aside Response switcher (reusing the .api-code-switcher classes), but the
+ * body holds the response **schema** tree rather than an example body. Status
+ * codes are the tabs; the selected response's description becomes the sub-header.
+ */
+export default function ResponseTabs({ responses, refs }: ResponseTabsProps) {
+  const [active, setActive] = useState(responses[0]?.status ?? "");
+  const current = responses.find(r => r.status === active) ?? responses[0];
+  if (!current) return null;
+
+  return (
+    <div className="api-code-switcher api-response-tabs">
+      <div className="api-code-switcher-toolbar">
+        <div className="api-code-switcher-tabs">
+          {responses.map(r => (
+            <button
+              key={r.status}
+              type="button"
+              aria-pressed={r.status === active ? "true" : "false"}
+              className="api-code-switcher-tab"
+              data-active={r.status === active ? "true" : "false"}
+              onClick={() => setActive(r.status)}
+            >
+              {r.status}
+            </button>
+          ))}
+        </div>
+        {current.contentType && <code className="api-response-contenttype">{current.contentType}</code>}
+      </div>
+      {current.description && <div className="api-code-switcher-desc">{current.description}</div>}
+      {current.schema !== undefined && (
+        <div className="api-code-switcher-body">
+          <SchemaBlock schema={current.schema} refs={refs ?? {}} />
+        </div>
+      )}
+    </div>
+  );
+}
+`;
+
 const AUTH_REQUIREMENTS = `"use client";
 
 interface SecurityScheme {
@@ -415,13 +390,25 @@ interface AuthRequirementsProps {
   schemes: Array<{ name: string; scheme: SecurityScheme; scopes: Array<string> }>;
 }
 
-function describeScheme(scheme: SecurityScheme): string {
+function typeLabel(scheme: SecurityScheme): string {
   if (scheme.type === "http" && scheme.scheme === "bearer") return "Bearer token";
   if (scheme.type === "http" && scheme.scheme === "basic") return "Basic auth";
-  if (scheme.type === "apiKey" && scheme.in && scheme.name) return \`API key in \${scheme.in} (\${scheme.name})\`;
+  if (scheme.type === "apiKey") return "API key";
   if (scheme.type === "oauth2") return "OAuth 2.0";
   if (scheme.type === "openIdConnect") return "OpenID Connect";
   return scheme.type;
+}
+
+function detail(scheme: SecurityScheme, scopes: Array<string>): string {
+  const parts: Array<string> = [];
+  if (scheme.type === "apiKey" && scheme.in) {
+    parts.push(scheme.name ? \`\${scheme.in}: \${scheme.name}\` : \`in \${scheme.in}\`);
+  } else if (scheme.type === "http" && (scheme.scheme === "bearer" || scheme.scheme === "basic")) {
+    parts.push("Authorization header");
+  }
+  if (scheme.description) parts.push(scheme.description);
+  if (scopes.length > 0) parts.push(\`scopes: \${scopes.join(", ")}\`);
+  return parts.length > 0 ? parts.join(" · ") : "—";
 }
 
 export default function AuthRequirements({ schemes }: AuthRequirementsProps) {
@@ -429,30 +416,48 @@ export default function AuthRequirements({ schemes }: AuthRequirementsProps) {
     return <p className="api-auth-none">No authentication required.</p>;
   }
   return (
-    <ul className="api-auth-list">
-      {schemes.map(s => (
-        <li key={s.name} className="api-auth-item">
-          <code className="api-auth-name">{s.name}</code>
-          <span className="api-auth-description">{describeScheme(s.scheme)}</span>
-          {s.scopes.length > 0 && (
-            <span className="api-auth-scopes">scopes: {s.scopes.join(", ")}</span>
-          )}
-        </li>
-      ))}
-    </ul>
+    <table className="api-auth-table">
+      <thead>
+        <tr>
+          <th>Scheme</th>
+          <th>Type</th>
+          <th>Details</th>
+        </tr>
+      </thead>
+      <tbody>
+        {schemes.map(s => (
+          <tr key={s.name}>
+            <td>
+              <code>{s.name}</code>
+            </td>
+            <td>{typeLabel(s.scheme)}</td>
+            <td>{detail(s.scheme, s.scopes)}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
   );
 }
 `;
 
 const TRY_IT = `"use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
+import { useTryItInputs } from "./TryItContext";
+import { serverVariablesFor } from "./serverVars";
+import TypedInput from "./TypedInput";
+import CodeEditor from "./CodeEditor";
+import { defaultString, typeLabel, type ParamSchema } from "./paramSchema";
+import HistoryItem from "./HistoryItem";
+import { HISTORY_LIMIT, historyKey, loadHistory, saveHistory, type HistoryEntry } from "./tryItHistory";
 
 interface Param {
   name: string;
   in: "path" | "query" | "header" | "cookie";
   required: boolean;
   description?: string;
+  /** OpenAPI schema for the value — drives the input control + default. */
+  schema?: ParamSchema;
 }
 
 interface SecurityScheme {
@@ -466,71 +471,14 @@ interface TryItProps {
   specName: string;
   method: string;
   path: string;
-  servers: Array<{ url: string; description?: string }>;
+  servers: Array<{
+    url: string;
+    description?: string;
+    variables?: Record<string, { default?: string; enum?: Array<string>; description?: string }>;
+  }>;
   parameters: Array<Param>;
   requestBody?: { contentType: string; example?: unknown; required: boolean };
   authSchemes: Array<{ name: string; scheme: SecurityScheme }>;
-}
-
-interface ResponseState {
-  status: number;
-  statusText: string;
-  headers: Record<string, string>;
-  body: string;
-  /** True when the response body parsed as JSON — drives syntax highlighting. */
-  bodyIsJson: boolean;
-}
-
-/**
- * Escape characters that would break out of an HTML text node. Used before
- * tokenizing JSON so the highlighter's \`<span>\` wrappers are the only HTML
- * the browser sees.
- */
-function escapeHtml(input: string): string {
-  return input
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;");
-}
-
-/**
- * Tokenize a pretty-printed JSON string into HTML with class-tagged spans.
- * Single regex covers strings (including object keys, identified by a
- * trailing colon), \`true\`/\`false\`/\`null\`, and numbers. Other characters
- * (braces, commas, whitespace) pass through as plain text. Input must be
- * HTML-escaped first.
- */
-function highlightJson(json: string): string {
-  const escaped = escapeHtml(json);
-  return escaped.replace(
-    /("(?:\\\\.|[^"\\\\])*")(\\s*:)?|\\b(true|false|null)\\b|(-?\\d+(?:\\.\\d+)?(?:[eE][+-]?\\d+)?)/g,
-    (_, str, colon, bool, num) => {
-      if (str !== undefined) {
-        const cls = colon ? "json-key" : "json-string";
-        return \`<span class="\${cls}">\${str}</span>\${colon ?? ""}\`;
-      }
-      if (bool !== undefined) {
-        const cls = bool === "null" ? "json-null" : "json-boolean";
-        return \`<span class="\${cls}">\${bool}</span>\`;
-      }
-      return \`<span class="json-number">\${num}</span>\`;
-    },
-  );
-}
-
-function storageKey(specName: string, key: string): string {
-  return \`jolli-tryit:\${specName}:\${key}\`;
-}
-
-function loadStored(key: string): string {
-  if (typeof window === "undefined") return "";
-  return window.sessionStorage.getItem(key) ?? "";
-}
-
-function saveStored(key: string, value: string): void {
-  if (typeof window === "undefined") return;
-  if (value) window.sessionStorage.setItem(key, value);
-  else window.sessionStorage.removeItem(key);
 }
 
 function buildAuthHeaders(
@@ -585,50 +533,65 @@ export default function TryIt({
   requestBody,
   authSchemes,
 }: TryItProps) {
-  const defaultServer = servers[0]?.url ?? "";
-  const [serverUrl, setServerUrl] = useState(defaultServer);
-  const [paramValues, setParamValues] = useState<Record<string, string>>({});
-  const [authValues, setAuthValues] = useState<Record<string, string>>({});
-  const [bodyValue, setBodyValue] = useState(
-    requestBody?.example !== undefined ? JSON.stringify(requestBody.example, null, 2) : "",
-  );
-  const [response, setResponse] = useState<ResponseState | undefined>(undefined);
+  const {
+    serverUrl,
+    setServerUrl,
+    serverVarValues,
+    setServerVarValue,
+    resolvedServerUrl,
+    paramValues,
+    setParamValue,
+    authValues,
+    setAuthValue,
+    bodyValue,
+    setBodyValue,
+  } = useTryItInputs();
+  // Variables (e.g. {defaultHost}) declared by the currently selected server.
+  const selectedServer = servers.find(s => s.url === serverUrl) ?? servers[0];
+  const serverVars = serverVariablesFor(selectedServer);
   const [error, setError] = useState<string | undefined>(undefined);
   const [loading, setLoading] = useState(false);
-  const [responseCopied, setResponseCopied] = useState(false);
-  const responseCopyTimer = useRef<number | null>(null);
+  const [history, setHistory] = useState<Array<HistoryEntry>>([]);
+  const [openHistory, setOpenHistory] = useState<Set<number>>(new Set());
 
-  useEffect(
-    () => () => {
-      if (responseCopyTimer.current) window.clearTimeout(responseCopyTimer.current);
-    },
-    [],
-  );
+  const histKey = historyKey(specName, method, path);
 
-  function handleResponseCopy() {
-    if (!response) return;
-    void navigator.clipboard.writeText(response.body).then(() => {
-      setResponseCopied(true);
-      if (responseCopyTimer.current) window.clearTimeout(responseCopyTimer.current);
-      responseCopyTimer.current = window.setTimeout(() => setResponseCopied(false), 1500);
+  // Hydrate the saved history for this operation (client-only).
+  useEffect(() => {
+    setHistory(loadHistory(histKey));
+  }, [histKey]);
+
+  // Seed each parameter from its schema default once per operation, so the live
+  // sample reflects the spec defaults before the user touches anything. Empty
+  // values are left empty (they show a \`<name>\` placeholder in the sample).
+  useEffect(() => {
+    for (const p of parameters) {
+      const key = \`\${p.in}:\${p.name}\`;
+      const def = defaultString(p.schema);
+      if (def && !paramValues[key]) setParamValue(key, def);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- seed once per operation
+  }, [histKey]);
+
+  function clearHistory() {
+    setHistory([]);
+    saveHistory(histKey, []);
+    setOpenHistory(new Set());
+  }
+  function toggleHistory(ts: number) {
+    setOpenHistory(prev => {
+      const next = new Set(prev);
+      if (next.has(ts)) next.delete(ts);
+      else next.add(ts);
+      return next;
     });
   }
-
-  useEffect(() => {
-    const next: Record<string, string> = {};
-    for (const { name } of authSchemes) {
-      next[name] = loadStored(storageKey(specName, \`auth:\${name}\`));
-    }
-    setAuthValues(next);
-  }, [specName, authSchemes]);
-
-  function updateAuth(name: string, value: string) {
-    setAuthValues(prev => ({ ...prev, [name]: value }));
-    saveStored(storageKey(specName, \`auth:\${name}\`), value);
-  }
-
-  function updateParam(name: string, value: string) {
-    setParamValues(prev => ({ ...prev, [name]: value }));
+  function updateHistoryEntry(ts: number, patch: Partial<HistoryEntry>) {
+    setHistory(prev => {
+      const next = prev.map(h => (h.ts === ts ? { ...h, ...patch } : h));
+      saveHistory(histKey, next);
+      return next;
+    });
   }
 
   async function send() {
@@ -636,9 +599,13 @@ export default function TryIt({
       setError("No server URL is configured for this spec.");
       return;
     }
+    const unresolved = resolvedServerUrl.match(/\\{([^}]+)\\}/);
+    if (unresolved) {
+      setError(\`Set a value for the server variable "\${unresolved[1]}" before sending.\`);
+      return;
+    }
     setLoading(true);
     setError(undefined);
-    setResponse(undefined);
 
     const pathValues: Record<string, string> = {};
     const queryValues: Record<string, string> = {};
@@ -652,13 +619,31 @@ export default function TryIt({
     }
 
     const auth = buildAuthHeaders(authSchemes, authValues);
-    const url = buildUrl(serverUrl, path, pathValues, queryValues, auth.query);
+    const url = buildUrl(resolvedServerUrl, path, pathValues, queryValues, auth.query);
     const headers: Record<string, string> = { ...headerValues, ...auth.headers };
     let body: string | undefined;
     if (requestBody && bodyValue.trim().length > 0) {
       headers["Content-Type"] = headers["Content-Type"] ?? requestBody.contentType;
       body = bodyValue;
     }
+
+    // Record the dispatched request in the local history log; the response is
+    // patched onto this same entry (by ts) once the fetch resolves.
+    const ts = Date.now();
+    const entry: HistoryEntry = {
+      ts,
+      method,
+      url,
+      headers,
+      ...(body !== undefined ? { body } : {}),
+    };
+    setHistory(prev => {
+      const next = [entry, ...prev].slice(0, HISTORY_LIMIT);
+      saveHistory(histKey, next);
+      return next;
+    });
+    // Auto-expand the just-sent request, collapsing the rest.
+    setOpenHistory(new Set([ts]));
 
     try {
       const init: RequestInit = { method, headers };
@@ -677,10 +662,18 @@ export default function TryIt({
       } catch {
         pretty = text;
       }
-      setResponse({ status: res.status, statusText: res.statusText, headers: respHeaders, body: pretty, bodyIsJson });
+      updateHistoryEntry(ts, {
+        status: res.status,
+        statusText: res.statusText,
+        responseHeaders: respHeaders,
+        responseBody: pretty,
+        responseBodyIsJson: bodyIsJson,
+      });
     } catch (e) {
       const msg = e instanceof Error ? e.message : String(e);
-      setError(\`Request failed: \${msg}. If the server is on a different origin, the response may have been blocked by CORS.\`);
+      updateHistoryEntry(ts, {
+        error: \`Request failed: \${msg}. If the server is on a different origin, the response may have been blocked by CORS.\`,
+      });
     } finally {
       setLoading(false);
     }
@@ -688,11 +681,6 @@ export default function TryIt({
 
   return (
     <div className="api-tryit">
-      <div className="api-tryit-header">
-        <span className={\`api-method api-method-\${method.toLowerCase()}\`}>{method.toUpperCase()}</span>
-        <code className="api-tryit-path">{path}</code>
-      </div>
-
       {servers.length > 1 && (
         <div className="api-tryit-field">
           <label className="api-tryit-label">Server</label>
@@ -710,6 +698,41 @@ export default function TryIt({
         </div>
       )}
 
+      {serverVars.length > 0 && (
+        <fieldset className="api-tryit-section">
+          <legend>Server variables</legend>
+          {serverVars.map(({ name, variable }) => (
+            <div key={name} className="api-tryit-field">
+              <label className="api-tryit-label">
+                {name}
+                {variable.description && <span className="api-tryit-hint"> — {variable.description}</span>}
+              </label>
+              {variable.enum && variable.enum.length > 0 ? (
+                <select
+                  className="api-tryit-input"
+                  value={serverVarValues[name] ?? variable.default ?? ""}
+                  onChange={e => setServerVarValue(name, e.target.value)}
+                >
+                  {variable.enum.map(opt => (
+                    <option key={opt} value={opt}>
+                      {opt}
+                    </option>
+                  ))}
+                </select>
+              ) : (
+                <input
+                  type="text"
+                  className="api-tryit-input"
+                  value={serverVarValues[name] ?? ""}
+                  onChange={e => setServerVarValue(name, e.target.value)}
+                  placeholder={variable.default ?? name}
+                />
+              )}
+            </div>
+          ))}
+        </fieldset>
+      )}
+
       {authSchemes.length > 0 && (
         <fieldset className="api-tryit-section">
           <legend>Authentication</legend>
@@ -722,7 +745,7 @@ export default function TryIt({
                 type="password"
                 className="api-tryit-input"
                 value={authValues[name] ?? ""}
-                onChange={e => updateAuth(name, e.target.value)}
+                onChange={e => setAuthValue(name, e.target.value)}
                 placeholder={scheme.scheme === "basic" ? "base64(user:password)" : "your token or key"}
               />
             </div>
@@ -738,14 +761,17 @@ export default function TryIt({
             return (
               <div key={key} className="api-tryit-field">
                 <label className="api-tryit-label">
-                  {p.name} <span className="api-tryit-hint">({p.in}{p.required ? ", required" : ""})</span>
+                  {p.name}{" "}
+                  <span className="api-tryit-hint">
+                    ({p.in}, {typeLabel(p.schema)}{p.required ? ", required" : ""})
+                  </span>
                 </label>
-                <input
-                  type="text"
-                  className="api-tryit-input"
+                <TypedInput
+                  schema={p.schema}
                   value={paramValues[key] ?? ""}
-                  onChange={e => updateParam(key, e.target.value)}
-                  placeholder={p.description ?? ""}
+                  onChange={v => setParamValue(key, v)}
+                  required={p.required}
+                  {...(p.description ? { placeholder: p.description } : {})}
                 />
               </div>
             );
@@ -756,11 +782,12 @@ export default function TryIt({
       {requestBody && (
         <fieldset className="api-tryit-section">
           <legend>Request body ({requestBody.contentType})</legend>
-          <textarea
-            className="api-tryit-textarea"
+          <CodeEditor
             value={bodyValue}
-            onChange={e => setBodyValue(e.target.value)}
+            onChange={setBodyValue}
+            language={requestBody.contentType.includes("json") ? "json" : "text"}
             rows={8}
+            ariaLabel="Request body"
           />
         </fieldset>
       )}
@@ -771,46 +798,29 @@ export default function TryIt({
         onClick={send}
         disabled={loading}
       >
-        {loading ? "Sending..." : "Send request"}
+        {loading ? "Sending..." : "Send"}
       </button>
 
       {error && <div className="api-tryit-error">{error}</div>}
 
-      {response && (
-        <div className="api-tryit-response">
-          <div className="api-tryit-response-status">
-            <strong>{response.status}</strong> {response.statusText}
+      {history.length > 0 && (
+        <div className="api-tryit-history">
+          <div className="api-tryit-history-head">
+            <span className="api-tryit-history-title">Request history</span>
+            <button type="button" className="api-tryit-history-clear" onClick={clearHistory}>
+              Clear
+            </button>
           </div>
-          <details className="api-tryit-response-headers">
-            <summary>Response headers</summary>
-            <pre><code>{Object.entries(response.headers).map(([k, v]) => \`\${k}: \${v}\`).join("\\n")}</code></pre>
-          </details>
-          <div className="api-tryit-response-body-wrap">
-            <div className="api-tryit-response-toolbar">
-              <span className="api-tryit-response-label">Response body</span>
-              <button
-                type="button"
-                className="api-code-switcher-copy"
-                data-copied={responseCopied ? "true" : "false"}
-                onClick={handleResponseCopy}
-              >
-                {responseCopied ? "Copied" : "Copy"}
-              </button>
-            </div>
-            {response.bodyIsJson ? (
-              <pre className="api-tryit-response-body">
-                <code
-                  className="language-json"
-                  // eslint-disable-next-line react/no-danger -- input is escaped via escapeHtml before tokenization; only our own <span class="json-*"> wrappers are unescaped
-                  dangerouslySetInnerHTML={{ __html: highlightJson(response.body) }}
-                />
-              </pre>
-            ) : (
-              <pre className="api-tryit-response-body">
-                <code>{response.body}</code>
-              </pre>
-            )}
-          </div>
+          <ul className="api-tryit-history-list">
+            {history.map(h => (
+              <HistoryItem
+                key={h.ts}
+                entry={h}
+                open={openHistory.has(h.ts)}
+                onToggle={() => toggleHistory(h.ts)}
+              />
+            ))}
+          </ul>
         </div>
       )}
     </div>
@@ -818,41 +828,860 @@ export default function TryIt({
 }
 `;
 
+const TRY_IT_CONTEXT = `"use client";
+
+import { createContext, useContext, useEffect, useMemo, useState, type ReactNode } from "react";
+import { resolveServerUrl, seedServerVarValues, type ServerInfo } from "./serverVars";
+
+interface SecurityScheme {
+  type: string;
+  scheme?: string;
+  in?: string;
+  name?: string;
+}
+
+interface AuthScheme {
+  name: string;
+  scheme: SecurityScheme;
+}
+
 /**
- * `<Endpoint>` is the per-page wrapper that renders the entire left column
- * (title, meta, Try It, auth, parameters, schemas, response docs) from the
- * operation's JSON sidecar — and slots two MDX-authored chunks in:
- *
- *   • `<EndpointDescription>` lives between the Try It widget and the auth
- *     section. It exists as a slot (rather than a `description` prop) so
- *     spec authors can use rich MDX (markdown, links, code fences, callouts)
- *     and Nextra's MDX → Shiki pipeline still highlights any embedded code.
- *   • `<EndpointSamples>` populates the right column. The MDX shim drops
- *     `<CodeSwitcher>` blocks (request samples + response examples) inside
- *     it; keeping those as MDX-fenced code blocks is what lets Nextra's
- *     existing Shiki pipeline highlight them — moving them into the JSON
- *     would require a generator-side highlighter (extra dep) or lose
- *     syntax highlighting outright.
- *
- * The slots are detected via `Children.toArray` + a string `displayName`
- * sentinel so the runtime check survives bundler renaming. Unrecognised
- * children render in document order between description and the auth
- * section, which is harmless — typical shims have just the two slots.
- *
- * Why a slot pattern instead of `description` / `samples` props: MDX makes
- * it awkward to pass nested MDX as JSX expression-form props (`<Endpoint
- * description={<>…</>} />`); children + named markers reads naturally in
- * the generated `.mdx` and keeps the shim ~5–10 lines per endpoint.
+ * Shared Try-it input state. The TryIt form (left column, inside the accordion)
+ * writes to it; the live RequestSample (right column) reads from it, so the
+ * code sample updates as the user fills in the form. Response/loading state is
+ * NOT here — that stays local to TryIt.
  */
+export interface TryItInputs {
+  /** All servers for the operation, incl. any \`{var}\` templates + variables. */
+  servers: Array<ServerInfo>;
+  /** Selected server origin (the raw URL template, possibly with \`{var}\`s). */
+  serverUrl: string;
+  setServerUrl: (v: string) => void;
+  /** Server-variable values keyed by variable name (seeded from spec defaults). */
+  serverVarValues: Record<string, string>;
+  setServerVarValue: (name: string, v: string) => void;
+  /**
+   * The selected server URL with its \`{var}\` tokens substituted (entered value →
+   * spec default → \`{var}\` left intact). This is what requests/samples build on.
+   */
+  resolvedServerUrl: string;
+  /** Param values keyed \`\${in}:\${name}\` (path/query/header/cookie). */
+  paramValues: Record<string, string>;
+  setParamValue: (key: string, v: string) => void;
+  /** Auth values keyed by security-scheme name. */
+  authValues: Record<string, string>;
+  setAuthValue: (name: string, v: string) => void;
+  /** Raw request body text. */
+  bodyValue: string;
+  setBodyValue: (v: string) => void;
+}
+
+const TryItContext = createContext<TryItInputs | null>(null);
+
+export function useTryItInputs(): TryItInputs {
+  const ctx = useContext(TryItContext);
+  if (!ctx) throw new Error("useTryItInputs must be used inside <TryItProvider>");
+  return ctx;
+}
+
+function storageKey(specName: string, key: string): string {
+  return \`jolli-tryit:\${specName}:\${key}\`;
+}
+function loadStored(key: string): string {
+  if (typeof window === "undefined") return "";
+  return window.sessionStorage.getItem(key) ?? "";
+}
+function saveStored(key: string, value: string): void {
+  if (typeof window === "undefined") return;
+  if (value) window.sessionStorage.setItem(key, value);
+  else window.sessionStorage.removeItem(key);
+}
+
+export function TryItProvider({
+  specName,
+  servers,
+  defaultServer,
+  defaultBody,
+  authSchemes,
+  children,
+}: {
+  specName: string;
+  servers: Array<ServerInfo>;
+  defaultServer: string;
+  defaultBody: string;
+  authSchemes: Array<AuthScheme>;
+  children: ReactNode;
+}) {
+  const [serverUrl, setServerUrl] = useState(defaultServer);
+  const [serverVarValues, setServerVarValues] = useState<Record<string, string>>(() =>
+    seedServerVarValues(servers),
+  );
+  const [paramValues, setParamValues] = useState<Record<string, string>>({});
+  const [authValues, setAuthValues] = useState<Record<string, string>>({});
+  const [bodyValue, setBodyValue] = useState(defaultBody);
+
+  const resolvedServerUrl = useMemo(() => {
+    const selected = servers.find(s => s.url === serverUrl);
+    return resolveServerUrl(serverUrl, serverVarValues, selected?.variables);
+  }, [servers, serverUrl, serverVarValues]);
+
+  // Hydrate persisted auth values (sessionStorage) once per spec.
+  useEffect(() => {
+    const next: Record<string, string> = {};
+    for (const { name } of authSchemes) {
+      next[name] = loadStored(storageKey(specName, \`auth:\${name}\`));
+    }
+    setAuthValues(next);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- resync only when the spec changes
+  }, [specName]);
+
+  function setParamValue(key: string, v: string) {
+    setParamValues(prev => ({ ...prev, [key]: v }));
+  }
+  function setServerVarValue(name: string, v: string) {
+    setServerVarValues(prev => ({ ...prev, [name]: v }));
+  }
+  function setAuthValue(name: string, v: string) {
+    setAuthValues(prev => ({ ...prev, [name]: v }));
+    saveStored(storageKey(specName, \`auth:\${name}\`), v);
+  }
+
+  return (
+    <TryItContext.Provider
+      value={{ servers, serverUrl, setServerUrl, serverVarValues, setServerVarValue, resolvedServerUrl, paramValues, setParamValue, authValues, setAuthValue, bodyValue, setBodyValue }}
+    >
+      {children}
+    </TryItContext.Provider>
+  );
+}
+`;
+
+const CODE_SWITCHER = `"use client";
+
+import { Children, isValidElement, useEffect, useRef, useState, type ReactElement, type ReactNode } from "react";
+
+interface Option {
+  value: string;
+  label: string;
+}
+
+interface CodeSwitcherProps {
+  /** Picker options in display order. The first option is the initial selection. */
+  options: Array<Option>;
+  /** "Request" / "Response" or any short heading for the panel. */
+  label: string;
+  /**
+   * Children whose top-level wrapper is \`<div data-pane="<value>">\` for
+   * each option in \`options\`. Markdown fenced code blocks inside those
+   * wrappers are processed by Nextra so Shiki highlighting is preserved.
+   */
+  children: ReactNode;
+}
+
+interface PaneProps {
+  "data-pane"?: string;
+}
+
+function getPaneValue(child: ReactNode): string | undefined {
+  if (!isValidElement(child)) return undefined;
+  const props = (child as ReactElement<PaneProps>).props;
+  return props["data-pane"];
+}
+
+/**
+ * Split a switcher option label into a short tab label + an optional
+ * description. Response options arrive combined, e.g.
+ * "401 — Authentication is missing or invalid." — the status code becomes the
+ * tab and the prose renders on its own line between the header and the code.
+ * Labels with no separator (e.g. a language name) keep the whole label as the
+ * tab and carry no description.
+ */
+function splitLabel(label: string): { tab: string; description: string } {
+  const m = label.match(/^(.*?)\\s+[—–-]\\s+(.*)$/);
+  if (m) return { tab: m[1].trim(), description: m[2].trim() };
+  return { tab: label.trim(), description: "" };
+}
+
+export default function CodeSwitcher({ options, label, children }: CodeSwitcherProps) {
+  const initial = options[0]?.value ?? "";
+  const [active, setActive] = useState<string>(initial);
+  const [copied, setCopied] = useState(false);
+  const [wrap, setWrap] = useState(false);
+  const bodyRef = useRef<HTMLDivElement | null>(null);
+  const copyTimer = useRef<number | null>(null);
+
+  // Reset selection if the parent rerenders with a new option set (e.g.,
+  // navigating between endpoints with different status codes).
+  useEffect(() => {
+    if (!options.some(o => o.value === active)) {
+      setActive(initial);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- intentional: only resync when the option list shape changes
+  }, [options.map(o => o.value).join("|")]);
+
+  useEffect(
+    () => () => {
+      if (copyTimer.current) window.clearTimeout(copyTimer.current);
+    },
+    [],
+  );
+
+  function handleCopy() {
+    const body = bodyRef.current;
+    if (!body) return;
+    const pane = body.querySelector<HTMLElement>(\`[data-pane="\${CSS.escape(active)}"]\`);
+    const code = pane?.querySelector("code")?.textContent ?? pane?.textContent ?? "";
+    if (!code) return;
+    void navigator.clipboard.writeText(code).then(() => {
+      setCopied(true);
+      copyTimer.current = window.setTimeout(() => setCopied(false), 1500);
+    });
+  }
+
+  const childArray = Children.toArray(children);
+  const parsed = options.map(o => ({ ...o, ...splitLabel(o.label) }));
+  const activeDescription = parsed.find(o => o.value === active)?.description ?? "";
+
+  return (
+    <div className="api-code-switcher">
+      <div className="api-code-switcher-toolbar">
+        <span className="api-code-switcher-label">{label}</span>
+        {/* Plain toggle buttons — intentionally NOT role="tab"/"tablist", which
+            would inherit the theme's global Nextra-Tabs styling (boxed header
+            bar, accent active pill, top margin). aria-pressed carries the
+            selected state instead. */}
+        <div className="api-code-switcher-tabs">
+          {parsed.map(o => (
+            <button
+              key={o.value}
+              type="button"
+              aria-pressed={o.value === active ? "true" : "false"}
+              className="api-code-switcher-tab"
+              data-active={o.value === active ? "true" : "false"}
+              onClick={() => setActive(o.value)}
+            >
+              {o.tab}
+            </button>
+          ))}
+        </div>
+        <button
+          type="button"
+          className="api-code-switcher-copy"
+          data-copied={copied ? "true" : "false"}
+          onClick={handleCopy}
+        >
+          {copied ? "Copied" : "Copy"}
+        </button>
+      </div>
+      {activeDescription && <div className="api-code-switcher-desc">{activeDescription}</div>}
+      <div className="api-code-switcher-body api-cb-host" ref={bodyRef} data-wrap={wrap ? "true" : "false"}>
+        {childArray.map((child, i) => {
+          const value = getPaneValue(child);
+          if (!value) return null;
+          return (
+            <div
+              key={value || i}
+              className="api-code-switcher-pane"
+              data-pane={value}
+              hidden={value !== active}
+            >
+              {child}
+            </div>
+          );
+        })}
+        <button
+          type="button"
+          className="api-cb-wrap"
+          data-active={wrap ? "true" : "false"}
+          aria-pressed={wrap ? "true" : "false"}
+          aria-label="Toggle word wrap"
+          title="Toggle word wrap"
+          onClick={() => setWrap(w => !w)}
+        >
+          <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+            <path d="M3 6h18M3 12h15a3 3 0 0 1 0 6h-4m0 0 2-2m-2 2 2 2M3 18h6" />
+          </svg>
+        </button>
+      </div>
+    </div>
+  );
+}
+`;
+
+const CODE_EDITOR = `"use client";
+
+import { useRef, type KeyboardEvent } from "react";
+import { escapeHtml, highlightJson } from "./jsonHighlight";
+
+interface CodeEditorProps {
+  value: string;
+  onChange: (v: string) => void;
+  /** Highlight language; only "json" is tokenized, others render as plain text. */
+  language?: string;
+  /** Minimum visible lines (drives the editor's min-height). */
+  rows?: number;
+  ariaLabel?: string;
+}
+
+/**
+ * A dependency-free code editor: a transparent <textarea> layered over a
+ * highlighted <pre> mirror of the same text. The two share identical font,
+ * padding, line-height and wrapping, so the colored tokens sit exactly under
+ * the (invisible) typed characters while the textarea owns editing, caret and
+ * selection. Tab inserts two spaces instead of moving focus.
+ *
+ * This avoids pulling CodeMirror/Monaco into the scaffold (a heavier, build-
+ * managed dependency). If the dev team later wants a full editor, swap this one
+ * component — its props (value/onChange/language) are editor-agnostic.
+ */
+export default function CodeEditor({ value, onChange, language = "json", rows = 8, ariaLabel }: CodeEditorProps) {
+  const preRef = useRef<HTMLPreElement | null>(null);
+
+  const html = (language === "json" ? highlightJson(value) : escapeHtml(value)) + "\\n";
+
+  // Keep the highlighted layer scrolled in lockstep with the textarea.
+  function syncScroll(e: React.UIEvent<HTMLTextAreaElement>) {
+    const pre = preRef.current;
+    if (!pre) return;
+    pre.scrollTop = e.currentTarget.scrollTop;
+    pre.scrollLeft = e.currentTarget.scrollLeft;
+  }
+
+  function handleKeyDown(e: KeyboardEvent<HTMLTextAreaElement>) {
+    if (e.key !== "Tab") return;
+    e.preventDefault();
+    const ta = e.currentTarget;
+    const { selectionStart, selectionEnd } = ta;
+    const next = value.slice(0, selectionStart) + "  " + value.slice(selectionEnd);
+    onChange(next);
+    // Restore the caret after the inserted indent on the next tick.
+    requestAnimationFrame(() => {
+      ta.selectionStart = ta.selectionEnd = selectionStart + 2;
+    });
+  }
+
+  return (
+    <div className="api-tryit-code-editor" style={{ minHeight: \`\${rows * 1.55 + 1.25}em\` }}>
+      <pre className="api-tryit-code-editor-pre" aria-hidden="true" ref={preRef}>
+        <code
+          className={\`language-\${language}\`}
+          // eslint-disable-next-line react/no-danger -- escaped via escapeHtml before tokenization; only our own <span class="json-*"> wrappers are unescaped
+          dangerouslySetInnerHTML={{ __html: html }}
+        />
+      </pre>
+      <textarea
+        className="api-tryit-code-editor-textarea"
+        spellCheck={false}
+        autoCapitalize="off"
+        autoCorrect="off"
+        value={value}
+        rows={rows}
+        aria-label={ariaLabel ?? "Code editor"}
+        onChange={e => onChange(e.target.value)}
+        onScroll={syncScroll}
+        onKeyDown={handleKeyDown}
+      />
+    </div>
+  );
+}
+`;
+
+const TYPED_INPUT = `"use client";
+
+import CodeEditor from "./CodeEditor";
+import { inputKind, type ParamSchema } from "./paramSchema";
+
+interface TypedInputProps {
+  schema: ParamSchema | undefined;
+  value: string;
+  onChange: (v: string) => void;
+  required: boolean;
+  /** Description/hint, used as a text-input placeholder. */
+  placeholder?: string;
+}
+
+/**
+ * Render the input control that matches an OpenAPI parameter/property schema:
+ * a select for enums and booleans, a number spinner for integer/number (with
+ * min/max/step from the schema), native date pickers for date/date-time
+ * formats, a password field for \`format: password\`, a multi-select for arrays
+ * of enums, and a JSON code editor for objects — falling back to a plain text
+ * input. The stored value is always a string (the form/sample layer keeps a
+ * single \`Record<string,string>\`); coercion to the wire type happens at send.
+ */
+export default function TypedInput({ schema, value, onChange, required, placeholder }: TypedInputProps) {
+  const s = schema ?? {};
+  const kind = inputKind(s);
+  const ph = placeholder || (s.example !== undefined ? String(s.example) : "");
+
+  switch (kind) {
+    case "enum":
+      return (
+        <select className="api-tryit-input" value={value} onChange={e => onChange(e.target.value)}>
+          {!required && <option value="">—</option>}
+          {(s.enum ?? []).map(o => (
+            <option key={String(o)} value={String(o)}>
+              {String(o)}
+            </option>
+          ))}
+        </select>
+      );
+
+    case "boolean":
+      return (
+        <select className="api-tryit-input" value={value} onChange={e => onChange(e.target.value)}>
+          <option value="">—</option>
+          <option value="true">true</option>
+          <option value="false">false</option>
+        </select>
+      );
+
+    case "integer":
+    case "number":
+      return (
+        <input
+          type="number"
+          className="api-tryit-input"
+          value={value}
+          step={kind === "integer" ? 1 : "any"}
+          {...(s.minimum !== undefined ? { min: s.minimum } : {})}
+          {...(s.maximum !== undefined ? { max: s.maximum } : {})}
+          onChange={e => onChange(e.target.value)}
+          placeholder={ph}
+        />
+      );
+
+    case "date":
+      return (
+        <input type="date" className="api-tryit-input" value={value} onChange={e => onChange(e.target.value)} />
+      );
+
+    case "datetime":
+      return (
+        <input
+          type="datetime-local"
+          className="api-tryit-input"
+          value={value}
+          onChange={e => onChange(e.target.value)}
+        />
+      );
+
+    case "password":
+      return (
+        <input
+          type="password"
+          className="api-tryit-input"
+          value={value}
+          onChange={e => onChange(e.target.value)}
+          placeholder={ph}
+        />
+      );
+
+    case "array-enum": {
+      const selected = value ? value.split(",") : [];
+      return (
+        <select
+          multiple
+          className="api-tryit-input api-tryit-input-multi"
+          value={selected}
+          onChange={e => onChange(Array.from(e.target.selectedOptions, o => o.value).join(","))}
+        >
+          {(s.items?.enum ?? []).map(o => (
+            <option key={String(o)} value={String(o)}>
+              {String(o)}
+            </option>
+          ))}
+        </select>
+      );
+    }
+
+    case "array":
+      return (
+        <input
+          type="text"
+          className="api-tryit-input"
+          value={value}
+          onChange={e => onChange(e.target.value)}
+          placeholder={ph || "comma-separated values"}
+        />
+      );
+
+    case "object":
+      return <CodeEditor value={value} onChange={onChange} language="json" rows={4} ariaLabel="JSON value" />;
+
+    default:
+      return (
+        <input
+          type="text"
+          className="api-tryit-input"
+          value={value}
+          onChange={e => onChange(e.target.value)}
+          placeholder={ph}
+        />
+      );
+  }
+}
+`;
+
+const REQUEST_SAMPLE = `"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { useTryItInputs } from "./TryItContext";
+import { generateSnippets, type SnippetAuth, type SnippetParam } from "./requestSnippets";
+
+interface RequestSampleProps {
+  method: string;
+  path: string;
+  /** Flat param list (data.tryItParameters). */
+  parameters: Array<SnippetParam>;
+  /** Auth schemes (data.tryItAuthSchemes). */
+  authSchemes: Array<SnippetAuth>;
+  requestBody?: { contentType: string };
+}
+
+/**
+ * Live "Request" sample for the aside column. Reads the current Try-it inputs
+ * from context and regenerates the per-language snippet on every change, so the
+ * sample always reflects what the form would send (all available params/attrs
+ * are shown, with \`<name>\` placeholders until filled). Mirrors CodeSwitcher's
+ * markup/classes so it inherits the theme's code-switcher styling; the only
+ * difference is the body is generated text, not a build-time highlighted block.
+ */
+export default function RequestSample({ method, path, parameters, authSchemes, requestBody }: RequestSampleProps) {
+  const { resolvedServerUrl, paramValues, authValues, bodyValue } = useTryItInputs();
+  const options = generateSnippets({
+    method,
+    path,
+    serverUrl: resolvedServerUrl,
+    parameters,
+    authSchemes,
+    bodyValue,
+    paramValues,
+    authValues,
+    ...(requestBody ? { requestBody } : {}),
+  });
+
+  const [active, setActive] = useState(options[0]?.value ?? "curl");
+  const [copied, setCopied] = useState(false);
+  const [wrap, setWrap] = useState(false);
+  const copyTimer = useRef<number | null>(null);
+
+  useEffect(
+    () => () => {
+      if (copyTimer.current) window.clearTimeout(copyTimer.current);
+    },
+    [],
+  );
+
+  const current = options.find(o => o.value === active) ?? options[0];
+
+  function handleCopy() {
+    if (!current) return;
+    void navigator.clipboard.writeText(current.code).then(() => {
+      setCopied(true);
+      if (copyTimer.current) window.clearTimeout(copyTimer.current);
+      copyTimer.current = window.setTimeout(() => setCopied(false), 1500);
+    });
+  }
+
+  return (
+    <div className="api-code-switcher">
+      <div className="api-code-switcher-toolbar">
+        <span className="api-code-switcher-label">Request</span>
+        <select
+          className="api-code-switcher-select"
+          value={active}
+          onChange={e => setActive(e.target.value)}
+          aria-label="Select language"
+        >
+          {options.map(o => (
+            <option key={o.value} value={o.value}>
+              {o.label}
+            </option>
+          ))}
+        </select>
+        <button
+          type="button"
+          className="api-code-switcher-copy"
+          data-copied={copied ? "true" : "false"}
+          onClick={handleCopy}
+        >
+          {copied ? "Copied" : "Copy"}
+        </button>
+      </div>
+      <div className="api-code-switcher-body api-cb-host">
+        <pre className="api-request-sample-pre" data-wrap={wrap ? "true" : "false"}>
+          <code className={\`language-\${current?.lang ?? "bash"}\`}>{current?.code ?? ""}</code>
+        </pre>
+        <button
+          type="button"
+          className="api-cb-wrap"
+          data-active={wrap ? "true" : "false"}
+          aria-pressed={wrap ? "true" : "false"}
+          aria-label="Toggle word wrap"
+          title="Toggle word wrap"
+          onClick={() => setWrap(w => !w)}
+        >
+          <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+            <path d="M3 6h18M3 12h15a3 3 0 0 1 0 6h-4m0 0 2-2m-2 2 2 2M3 18h6" />
+          </svg>
+        </button>
+      </div>
+    </div>
+  );
+}
+`;
+
+const HISTORY_ITEM = `"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { snippetsForRequest } from "./requestSnippets";
+import { statusFamily, type HistoryEntry } from "./tryItHistory";
+import { highlightJson } from "./jsonHighlight";
+
+interface HistoryItemProps {
+  entry: HistoryEntry;
+  open: boolean;
+  onToggle: () => void;
+}
+
+/** "x minutes/hours/days ago", switching to a plain date after 9 days. */
+function relativeTime(ts: number): string {
+  const sec = Math.floor((Date.now() - ts) / 1000);
+  const min = Math.floor(sec / 60);
+  const hr = Math.floor(min / 60);
+  const day = Math.floor(hr / 24);
+  if (day > 9) return new Date(ts).toLocaleDateString();
+  if (day >= 1) return \`\${day} day\${day === 1 ? "" : "s"} ago\`;
+  if (hr >= 1) return \`\${hr} hour\${hr === 1 ? "" : "s"} ago\`;
+  if (min >= 1) return \`\${min} minute\${min === 1 ? "" : "s"} ago\`;
+  return "just now";
+}
+
+/** Full timestamp for the hover title: "Month Day, Year Time". */
+function fullTimestamp(ts: number): string {
+  return new Date(ts).toLocaleString(undefined, {
+    month: "long",
+    day: "numeric",
+    year: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
+const WrapIcon = () => (
+  <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+    <path d="M3 6h18M3 12h15a3 3 0 0 1 0 6h-4m0 0 2-2m-2 2 2 2M3 18h6" />
+  </svg>
+);
+
+/**
+ * One request-history entry. The row (method + url + status + time) toggles an
+ * expanded view that shows the sent Request as a language-switchable code sample
+ * (same treatment as the right-column RequestSample) and the Response as a
+ * Body/Headers tab switcher — both reusing the .api-code-switcher styling.
+ */
+export default function HistoryItem({ entry, open, onToggle }: HistoryItemProps) {
+  const reqSnippets = snippetsForRequest({
+    method: entry.method,
+    url: entry.url,
+    headers: entry.headers,
+    ...(entry.body !== undefined ? { body: entry.body } : {}),
+  });
+  const [reqLang, setReqLang] = useState(reqSnippets[0]?.value ?? "curl");
+  const [respTab, setRespTab] = useState<"body" | "headers">("body");
+  const [reqWrap, setReqWrap] = useState(false);
+  const [respWrap, setRespWrap] = useState(false);
+  const [reqCopied, setReqCopied] = useState(false);
+  const [respCopied, setRespCopied] = useState(false);
+  const reqTimer = useRef<number | null>(null);
+  const respTimer = useRef<number | null>(null);
+
+  useEffect(
+    () => () => {
+      if (reqTimer.current) window.clearTimeout(reqTimer.current);
+      if (respTimer.current) window.clearTimeout(respTimer.current);
+    },
+    [],
+  );
+
+  const reqCurrent = reqSnippets.find(s => s.value === reqLang) ?? reqSnippets[0];
+  const headerLines = entry.responseHeaders
+    ? Object.entries(entry.responseHeaders).map(([k, v]) => \`\${k}: \${v}\`).join("\\n")
+    : "";
+  const respText = respTab === "headers" ? headerLines : entry.responseBody ?? "";
+
+  function handleReqCopy() {
+    if (!reqCurrent) return;
+    void navigator.clipboard.writeText(reqCurrent.code).then(() => {
+      setReqCopied(true);
+      if (reqTimer.current) window.clearTimeout(reqTimer.current);
+      reqTimer.current = window.setTimeout(() => setReqCopied(false), 1500);
+    });
+  }
+  function handleRespCopy() {
+    void navigator.clipboard.writeText(respText).then(() => {
+      setRespCopied(true);
+      if (respTimer.current) window.clearTimeout(respTimer.current);
+      respTimer.current = window.setTimeout(() => setRespCopied(false), 1500);
+    });
+  }
+
+  return (
+    <li className="api-tryit-history-item" data-open={open ? "true" : "false"}>
+      <button
+        type="button"
+        className="api-tryit-history-row"
+        aria-expanded={open ? "true" : "false"}
+        onClick={onToggle}
+      >
+        <span className={\`api-method api-method-\${entry.method.toLowerCase()}\`}>{entry.method}</span>
+        <code className="api-tryit-history-url">{entry.url}</code>
+        <time className="api-tryit-history-time" title={fullTimestamp(entry.ts)}>
+          {relativeTime(entry.ts)}
+        </time>
+        {entry.status !== undefined ? (
+          <span className={\`api-tryit-history-status api-status-\${statusFamily(entry.status)}\`}>{entry.status}</span>
+        ) : entry.error ? (
+          <span className="api-tryit-history-status api-status-err">ERR</span>
+        ) : null}
+      </button>
+
+      <div className="api-tryit-history-accordion">
+        <div className="api-tryit-history-accordion-inner">
+          <div className="api-tryit-history-detail">
+          {/* Request — code sample with a language switcher */}
+          <div className="api-code-switcher">
+            <div className="api-code-switcher-toolbar">
+              <span className="api-code-switcher-label">Request</span>
+              <select
+                className="api-code-switcher-select"
+                value={reqLang}
+                onChange={e => setReqLang(e.target.value)}
+                aria-label="Select language"
+              >
+                {reqSnippets.map(o => (
+                  <option key={o.value} value={o.value}>
+                    {o.label}
+                  </option>
+                ))}
+              </select>
+              <button
+                type="button"
+                className="api-code-switcher-copy"
+                data-copied={reqCopied ? "true" : "false"}
+                onClick={handleReqCopy}
+              >
+                {reqCopied ? "Copied" : "Copy"}
+              </button>
+            </div>
+            <div className="api-code-switcher-body api-cb-host">
+              <pre className="api-request-sample-pre" data-wrap={reqWrap ? "true" : "false"}>
+                <code className={\`language-\${reqCurrent?.lang ?? "bash"}\`}>{reqCurrent?.code ?? ""}</code>
+              </pre>
+              <button
+                type="button"
+                className="api-cb-wrap"
+                data-active={reqWrap ? "true" : "false"}
+                aria-pressed={reqWrap ? "true" : "false"}
+                aria-label="Toggle word wrap"
+                title="Toggle word wrap"
+                onClick={() => setReqWrap(w => !w)}
+              >
+                <WrapIcon />
+              </button>
+            </div>
+          </div>
+
+          {/* Response — Body/Headers tabs, or the error */}
+          {entry.error ? (
+            <div className="api-tryit-error">{entry.error}</div>
+          ) : entry.status !== undefined ? (
+            <div className="api-code-switcher">
+              <div className="api-code-switcher-toolbar">
+                <span className={\`api-tryit-history-status api-status-\${statusFamily(entry.status)}\`}>
+                  {entry.status}
+                </span>
+                {entry.statusText && (
+                  <span className="api-code-switcher-label">{entry.statusText}</span>
+                )}
+                <div className="api-code-switcher-tabs">
+                  <button
+                    type="button"
+                    className="api-code-switcher-tab"
+                    data-active={respTab === "body" ? "true" : "false"}
+                    aria-pressed={respTab === "body" ? "true" : "false"}
+                    onClick={() => setRespTab("body")}
+                  >
+                    Body
+                  </button>
+                  <button
+                    type="button"
+                    className="api-code-switcher-tab"
+                    data-active={respTab === "headers" ? "true" : "false"}
+                    aria-pressed={respTab === "headers" ? "true" : "false"}
+                    onClick={() => setRespTab("headers")}
+                  >
+                    Headers
+                  </button>
+                </div>
+                <button
+                  type="button"
+                  className="api-code-switcher-copy"
+                  data-copied={respCopied ? "true" : "false"}
+                  onClick={handleRespCopy}
+                >
+                  {respCopied ? "Copied" : "Copy"}
+                </button>
+              </div>
+              <div className="api-code-switcher-body api-cb-host" data-wrap={respWrap ? "true" : "false"}>
+                <pre className="api-tryit-response-body">
+                  {respTab === "body" && entry.responseBodyIsJson ? (
+                    <code
+                      className="language-json"
+                      // eslint-disable-next-line react/no-danger -- escaped via escapeHtml before tokenization; only our own <span class="json-*"> wrappers are unescaped
+                      dangerouslySetInnerHTML={{ __html: highlightJson(entry.responseBody ?? "") }}
+                    />
+                  ) : (
+                    <code>{respText}</code>
+                  )}
+                </pre>
+                <button
+                  type="button"
+                  className="api-cb-wrap"
+                  data-active={respWrap ? "true" : "false"}
+                  aria-pressed={respWrap ? "true" : "false"}
+                  aria-label="Toggle word wrap"
+                  title="Toggle word wrap"
+                  onClick={() => setRespWrap(w => !w)}
+                >
+                  <WrapIcon />
+                </button>
+              </div>
+            </div>
+          ) : (
+            <div className="api-tryit-history-pending">Waiting for response…</div>
+          )}
+          </div>
+        </div>
+      </div>
+    </li>
+  );
+}
+`;
+
 const ENDPOINT = `"use client";
 
-import { Children, isValidElement, type ReactElement, type ReactNode } from "react";
+import { Children, isValidElement, useState, type ReactElement, type ReactNode } from "react";
 import EndpointMeta from "./EndpointMeta";
 import ParamTable from "./ParamTable";
 import SchemaBlock from "./SchemaBlock";
-import ResponseBlock from "./ResponseBlock";
+import ResponseTabs from "./ResponseTabs";
 import AuthRequirements from "./AuthRequirements";
 import TryIt from "./TryIt";
+import RequestSample from "./RequestSample";
+import { TryItProvider } from "./TryItContext";
+import type { ParamSchema } from "./paramSchema";
 
 interface SecurityScheme {
   type: string;
@@ -874,6 +1703,8 @@ interface TryItParameter {
   in: "path" | "query" | "header" | "cookie";
   required: boolean;
   description?: string;
+  /** Value schema (type/format/enum/default) — drives the Try-it input control. */
+  schema?: ParamSchema;
 }
 
 interface OperationResponse {
@@ -891,7 +1722,11 @@ interface OperationData {
   title: string;
   tags: Array<string>;
   deprecated: boolean;
-  servers: Array<{ url: string; description?: string }>;
+  servers: Array<{
+    url: string;
+    description?: string;
+    variables?: Record<string, { default?: string; enum?: Array<string>; description?: string }>;
+  }>;
   tryItParameters: Array<TryItParameter>;
   parameters: {
     path: Array<OperationParameter>;
@@ -960,39 +1795,82 @@ function hasAnyParameters(p: OperationData["parameters"]): boolean {
 export default function Endpoint({ data, refs, children }: EndpointProps) {
   const description = findSlot(children, "description");
   const samples = findSlot(children, "samples");
-  const tagsForMeta = data.tags.filter(t => t !== "default");
   const refsMap = refs ?? {};
+  // Default request body shown in the live sample and the Try it form.
+  const defaultBody =
+    data.requestBody?.example !== undefined ? JSON.stringify(data.requestBody.example, null, 2) : "";
+  // The static "Request" CodeSwitcher from the MDX samples slot is replaced by
+  // the live <RequestSample>; keep the rest of the slot (the Response block).
+  const responseSamples = isValidElement(samples)
+    ? Children.toArray((samples as ReactElement<{ children?: ReactNode }>).props.children).filter(child => {
+        if (!isValidElement(child)) return true;
+        const label = (child as ReactElement<{ label?: string }>).props.label;
+        return typeof label !== "string" || label.toLowerCase() !== "request";
+      })
+    : samples;
+  // The flat tryItParameters drop the value schema; re-attach it from the typed
+  // \`parameters.{in}\` lists (matched by name) so the Try-it form can render a
+  // type-appropriate input. (Build-team handoff: emit \`schema\` directly on
+  // tryItParameters so this bridge isn't needed.)
+  const schemaByKey = new Map<string, ParamSchema | undefined>();
+  for (const kind of ["path", "query", "header", "cookie"] as const) {
+    for (const op of data.parameters[kind]) {
+      schemaByKey.set(\`\${kind}:\${op.name}\`, op.schema as ParamSchema | undefined);
+    }
+  }
+  const tryItParameters: Array<TryItParameter> = data.tryItParameters.map(p => {
+    const schema = p.schema ?? schemaByKey.get(\`\${p.in}:\${p.name}\`);
+    return schema ? { ...p, schema } : p;
+  });
+  // The endpoint meta line carries a "Try it" toggle that expands the TryIt
+  // widget below it as an accordion. State lives here because the toggle
+  // button (in EndpointMeta) and the collapsible panel are siblings.
+  const [tryItOpen, setTryItOpen] = useState(false);
 
   return (
+    <TryItProvider
+      specName={data.specName}
+      servers={data.servers}
+      defaultServer={data.servers[0]?.url ?? ""}
+      defaultBody={defaultBody}
+      authSchemes={data.tryItAuthSchemes}
+    >
     <div className="api-endpoint-grid">
       <div className="api-endpoint-main">
         <h1>{data.title}</h1>
 
-        <EndpointMeta
-          method={data.method}
-          path={data.path}
-          tags={tagsForMeta}
-          deprecated={data.deprecated}
-        />
+        <div className="api-tryit-shell" data-open={tryItOpen ? "true" : "false"}>
+          <EndpointMeta
+            method={data.method}
+            path={data.path}
+            deprecated={data.deprecated}
+            server={data.servers[0]?.url}
+            tryItOpen={tryItOpen}
+            onToggleTryIt={() => setTryItOpen(o => !o)}
+          />
 
-        <h2>Try it</h2>
-        <TryIt
-          specName={data.specName}
-          method={data.method.toUpperCase()}
-          path={data.path}
-          servers={data.servers}
-          parameters={data.tryItParameters}
-          authSchemes={data.tryItAuthSchemes}
-          {...(data.requestBody
-            ? {
-                requestBody: {
-                  contentType: data.requestBody.contentType,
-                  required: data.requestBody.required,
-                  ...(data.requestBody.example !== undefined ? { example: data.requestBody.example } : {}),
-                },
-              }
-            : {})}
-        />
+          <div className="api-tryit-accordion">
+            <div className="api-tryit-accordion-inner">
+              <TryIt
+                specName={data.specName}
+                method={data.method.toUpperCase()}
+                path={data.path}
+                servers={data.servers}
+                parameters={tryItParameters}
+                authSchemes={data.tryItAuthSchemes}
+                {...(data.requestBody
+                  ? {
+                      requestBody: {
+                        contentType: data.requestBody.contentType,
+                        required: data.requestBody.required,
+                        ...(data.requestBody.example !== undefined ? { example: data.requestBody.example } : {}),
+                      },
+                    }
+                  : {})}
+              />
+            </div>
+          </div>
+        </div>
 
         {description}
 
@@ -1024,22 +1902,558 @@ export default function Endpoint({ data, refs, children }: EndpointProps) {
         {data.responses.length > 0 && (
           <>
             <h2>Response</h2>
-            {data.responses.map(r => (
-              <ResponseBlock
-                key={r.status}
-                status={r.status}
-                {...(r.description !== undefined ? { description: r.description } : {})}
-                {...(r.contentType !== undefined ? { contentType: r.contentType } : {})}
-                {...(r.schema !== undefined ? { schema: r.schema } : {})}
-                refs={refsMap}
-              />
-            ))}
+            <ResponseTabs responses={data.responses} refs={refsMap} />
           </>
         )}
       </div>
 
-      <div className="api-endpoint-aside">{samples}</div>
+      <div className="api-endpoint-aside">
+        <RequestSample
+          method={data.method}
+          path={data.path}
+          parameters={data.tryItParameters}
+          authSchemes={data.tryItAuthSchemes}
+          {...(data.requestBody ? { requestBody: { contentType: data.requestBody.contentType } } : {})}
+        />
+        {responseSamples}
+      </div>
     </div>
+    </TryItProvider>
   );
+}
+`;
+
+const REQUEST_SNIPPETS = `// Pure request-snippet generator for the live "Request" sample. Given the
+// operation's spec data plus the values currently entered in the Try it box,
+// it resolves a single concrete request (URL incl. query, headers, body) and
+// renders it as a code string in each supported language. All available
+// parameters/attributes are surfaced: anything not yet filled in shows a
+// \`<name>\`-style placeholder, so the sample is complete from first paint and
+// updates as the user types.
+
+export interface SnippetParam {
+  name: string;
+  in: "path" | "query" | "header" | "cookie";
+  required: boolean;
+}
+
+export interface SnippetScheme {
+  type: string;
+  scheme?: string;
+  in?: string;
+  name?: string;
+}
+
+export interface SnippetAuth {
+  name: string;
+  scheme: SnippetScheme;
+}
+
+export interface SnippetSource {
+  method: string;
+  path: string;
+  serverUrl: string;
+  parameters: Array<SnippetParam>;
+  authSchemes: Array<SnippetAuth>;
+  requestBody?: { contentType: string };
+  /** Raw request body text (the edited/example JSON). */
+  bodyValue: string;
+  /** Entered param values, keyed \`\${in}:\${name}\`. */
+  paramValues: Record<string, string>;
+  /** Entered auth values, keyed by scheme name. */
+  authValues: Record<string, string>;
+}
+
+interface ResolvedRequest {
+  method: string;
+  url: string;
+  headers: Array<[string, string]>;
+  body: string;
+  hasBody: boolean;
+}
+
+function placeholder(name: string): string {
+  return \`<\${name}>\`;
+}
+
+/**
+ * Collapse a request body for embedding in a snippet. The Try-it code editor
+ * holds pretty-printed JSON whose newlines + indentation would otherwise spill
+ * across multiple lines inside a \`curl -d '...'\` argument (or a JS/Python/Go
+ * literal), making the generated request look broken. Valid JSON is
+ * re-serialized compact (single line); anything else is returned trimmed but
+ * otherwise unchanged, since its whitespace may be significant (raw text, a
+ * form-encoded or XML body, …).
+ */
+function compactBody(body: string): string {
+  const trimmed = body.trim();
+  if (!trimmed) return trimmed;
+  try {
+    return JSON.stringify(JSON.parse(trimmed));
+  } catch {
+    return trimmed;
+  }
+}
+
+/** Auth → header/query entries, falling back to readable placeholders. */
+function resolveAuth(
+  authSchemes: Array<SnippetAuth>,
+  authValues: Record<string, string>,
+): { headers: Record<string, string>; query: Record<string, string> } {
+  const headers: Record<string, string> = {};
+  const query: Record<string, string> = {};
+  for (const { name, scheme } of authSchemes) {
+    const v = authValues[name] || "";
+    if (scheme.type === "http" && scheme.scheme === "bearer") {
+      headers["Authorization"] = \`Bearer \${v || "YOUR_TOKEN"}\`;
+    } else if (scheme.type === "http" && scheme.scheme === "basic") {
+      headers["Authorization"] = \`Basic \${v || "BASE64(USER:PASSWORD)"}\`;
+    } else if (scheme.type === "apiKey" && scheme.name) {
+      const val = v || "YOUR_API_KEY";
+      if (scheme.in === "header") headers[scheme.name] = val;
+      else if (scheme.in === "query") query[scheme.name] = val;
+    } else if (scheme.type === "oauth2" || scheme.type === "openIdConnect") {
+      headers["Authorization"] = \`Bearer \${v || "YOUR_TOKEN"}\`;
+    }
+  }
+  return { headers, query };
+}
+
+export function resolveRequest(src: SnippetSource): ResolvedRequest {
+  const pathParams = src.parameters.filter(p => p.in === "path");
+  const queryParams = src.parameters.filter(p => p.in === "query");
+  const headerParams = src.parameters.filter(p => p.in === "header");
+
+  // Path: substitute entered values; keep \`{name}\` where still unfilled.
+  let resolvedPath = src.path;
+  for (const p of pathParams) {
+    const v = src.paramValues[\`path:\${p.name}\`];
+    if (v) resolvedPath = resolvedPath.replace(\`{\${p.name}}\`, encodeURIComponent(v));
+  }
+
+  const auth = resolveAuth(src.authSchemes, src.authValues);
+
+  // Query: every available query param is shown (entered value or placeholder),
+  // plus any auth keys that live in the query string.
+  const queryPairs: Array<[string, string]> = [];
+  for (const p of queryParams) {
+    const v = src.paramValues[\`query:\${p.name}\`];
+    queryPairs.push([p.name, v || placeholder(p.name)]);
+  }
+  for (const [k, v] of Object.entries(auth.query)) queryPairs.push([k, v]);
+
+  const cleanServer = (src.serverUrl || "").replace(/\\/+$/, "");
+  const qs = queryPairs
+    .map(([k, v]) => \`\${encodeURIComponent(k)}=\${encodeURIComponent(v)}\`)
+    .join("&");
+  const url = \`\${cleanServer}\${resolvedPath}\${qs ? \`?\${qs}\` : ""}\`;
+
+  // Headers: explicit header params, then auth headers, then Content-Type.
+  const headers: Array<[string, string]> = [];
+  for (const p of headerParams) {
+    const v = src.paramValues[\`header:\${p.name}\`];
+    headers.push([p.name, v || placeholder(p.name)]);
+  }
+  for (const [k, v] of Object.entries(auth.headers)) headers.push([k, v]);
+  const hasBody = Boolean(src.requestBody) && src.bodyValue.trim().length > 0;
+  if (hasBody) headers.push(["Content-Type", src.requestBody!.contentType]);
+
+  return { method: src.method.toUpperCase(), url, headers, body: compactBody(src.bodyValue), hasBody };
+}
+
+// ── Per-language renderers ───────────────────────────────────────────────────
+
+function indentBody(body: string, indent: string): string {
+  return body
+    .split("\\n")
+    .map((line, i) => (i === 0 ? line : indent + line))
+    .join("\\n");
+}
+
+function toCurl(r: ResolvedRequest): string {
+  const lines = [\`curl -X \${r.method} '\${r.url}'\`];
+  for (const [k, v] of r.headers) lines.push(\`  -H '\${k}: \${v}'\`);
+  if (r.hasBody) lines.push(\`  -d '\${r.body}'\`);
+  return lines.join(" \\\\\\n");
+}
+
+function headerObjectLiteral(r: ResolvedRequest, indent: string): string {
+  if (r.headers.length === 0) return "{}";
+  const inner = r.headers.map(([k, v]) => \`\${indent}  '\${k}': '\${v}'\`).join(",\\n");
+  return \`{\\n\${inner}\\n\${indent}}\`;
+}
+
+function toJavaScript(r: ResolvedRequest): string {
+  const parts = [\`  method: '\${r.method}'\`, \`  headers: \${headerObjectLiteral(r, "  ")}\`];
+  if (r.hasBody) parts.push(\`  body: JSON.stringify(\${indentBody(r.body, "  ")})\`);
+  return \`const response = await fetch('\${r.url}', {
+\${parts.join(",\\n")}
+});
+
+const data = await response.json();
+console.log(data);\`;
+}
+
+function toTypeScript(r: ResolvedRequest): string {
+  const parts = [\`  method: '\${r.method}'\`, \`  headers: \${headerObjectLiteral(r, "  ")}\`];
+  if (r.hasBody) parts.push(\`  body: JSON.stringify(\${indentBody(r.body, "  ")})\`);
+  return \`interface ApiResponse {
+  // shape your response here
+}
+
+const response: Response = await fetch('\${r.url}', {
+\${parts.join(",\\n")}
+});
+
+const data = (await response.json()) as ApiResponse;
+console.log(data);\`;
+}
+
+function toPython(r: ResolvedRequest): string {
+  const headerLines = r.headers.map(([k, v]) => \`    "\${k}": "\${v}"\`).join(",\\n");
+  const lines = [
+    "import requests",
+    "",
+    \`url = "\${r.url}"\`,
+    \`headers = {\\n\${headerLines}\\n}\`,
+  ];
+  if (r.hasBody) {
+    lines.push(\`payload = \${indentBody(r.body, "")}\`);
+    lines.push("");
+    lines.push(\`response = requests.request("\${r.method.toLowerCase()}", url, headers=headers, json=payload)\`);
+  } else {
+    lines.push("");
+    lines.push(\`response = requests.request("\${r.method.toLowerCase()}", url, headers=headers)\`);
+  }
+  lines.push("print(response.json())");
+  return lines.join("\\n");
+}
+
+function toGo(r: ResolvedRequest): string {
+  const headerSets = r.headers.map(([k, v]) => \`\\treq.Header.Set("\${k}", "\${v}")\`).join("\\n");
+  const bodyDecl = r.hasBody ? \`\\tbody := strings.NewReader(\\\`\${r.body}\\\`)\\n\` : "";
+  const bodyArg = r.hasBody ? "body" : "nil";
+  const imports = r.hasBody
+    ? \`\\t"fmt"\\n\\t"io"\\n\\t"net/http"\\n\\t"strings"\`
+    : \`\\t"fmt"\\n\\t"io"\\n\\t"net/http"\`;
+  return \`package main
+
+import (
+\${imports}
+)
+
+func main() {
+\${bodyDecl}\\treq, err := http.NewRequest("\${r.method}", "\${r.url}", \${bodyArg})
+\\tif err != nil {
+\\t\\tpanic(err)
+\\t}
+\${headerSets}
+
+\\tresp, err := http.DefaultClient.Do(req)
+\\tif err != nil {
+\\t\\tpanic(err)
+\\t}
+\\tdefer resp.Body.Close()
+
+\\tout, _ := io.ReadAll(resp.Body)
+\\tfmt.Println(string(out))
+}\`;
+}
+
+export interface SnippetOption {
+  value: string;
+  label: string;
+  lang: string;
+  code: string;
+}
+
+function renderAll(r: ResolvedRequest): Array<SnippetOption> {
+  return [
+    { value: "curl", label: "cURL", lang: "bash", code: toCurl(r) },
+    { value: "javascript", label: "JavaScript", lang: "js", code: toJavaScript(r) },
+    { value: "typescript", label: "TypeScript", lang: "ts", code: toTypeScript(r) },
+    { value: "python", label: "Python", lang: "python", code: toPython(r) },
+    { value: "go", label: "Go", lang: "go", code: toGo(r) },
+  ];
+}
+
+/** Build the language options + rendered code for the current request state. */
+export function generateSnippets(src: SnippetSource): Array<SnippetOption> {
+  return renderAll(resolveRequest(src));
+}
+
+/** Build the language snippets for an already-resolved (e.g. history) request. */
+export function snippetsForRequest(req: {
+  method: string;
+  url: string;
+  headers: Record<string, string>;
+  body?: string;
+}): Array<SnippetOption> {
+  return renderAll({
+    method: req.method.toUpperCase(),
+    url: req.url,
+    headers: Object.entries(req.headers),
+    body: compactBody(req.body ?? ""),
+    hasBody: typeof req.body === "string" && req.body.trim().length > 0,
+  });
+}
+`;
+
+const TRY_IT_HISTORY = `// Shared types + helpers for the Try-it request history. Kept out of TryIt.tsx
+// so both TryIt and HistoryItem can import them without a circular dependency.
+
+/** One sent request plus its response, persisted to localStorage. */
+export interface HistoryEntry {
+  ts: number;
+  method: string;
+  url: string;
+  headers: Record<string, string>;
+  body?: string;
+  // Response — filled in once the fetch resolves.
+  status?: number;
+  statusText?: string;
+  responseHeaders?: Record<string, string>;
+  responseBody?: string;
+  responseBodyIsJson?: boolean;
+  error?: string;
+}
+
+export const HISTORY_LIMIT = 10;
+
+/** 2xx/3xx/4xx/5xx family for status-color styling. */
+export function statusFamily(status: number): string {
+  if (status >= 200 && status < 300) return "2xx";
+  if (status >= 300 && status < 400) return "3xx";
+  if (status >= 400 && status < 500) return "4xx";
+  if (status >= 500) return "5xx";
+  return "default";
+}
+
+export function historyKey(specName: string, method: string, path: string): string {
+  return \`jolli-tryit-history:\${specName}:\${method}:\${path}\`;
+}
+
+export function loadHistory(key: string): Array<HistoryEntry> {
+  if (typeof window === "undefined") return [];
+  try {
+    const raw = window.localStorage.getItem(key);
+    return raw ? (JSON.parse(raw) as Array<HistoryEntry>) : [];
+  } catch {
+    return [];
+  }
+}
+
+export function saveHistory(key: string, entries: Array<HistoryEntry>): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(key, JSON.stringify(entries));
+  } catch {
+    /* ignore quota / serialization errors */
+  }
+}
+`;
+
+const JSON_HIGHLIGHT = `// Lightweight JSON syntax highlighter for the Try-it response bodies. Tokenizes
+// a pretty-printed JSON string into class-tagged <span>s; the input is
+// HTML-escaped first so only our own <span class="json-*"> wrappers are markup.
+// The \`.json-*\` colors live in the built site's styles/api.css, scoped to
+// \`.api-tryit-response-body\`.
+
+export function escapeHtml(input: string): string {
+  return input.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+export function highlightJson(json: string): string {
+  const escaped = escapeHtml(json);
+  return escaped.replace(
+    /("(?:\\\\.|[^"\\\\])*")(\\s*:)?|\\b(true|false|null)\\b|(-?\\d+(?:\\.\\d+)?(?:[eE][+-]?\\d+)?)/g,
+    (_, str, colon, bool, num) => {
+      if (str !== undefined) {
+        const cls = colon ? "json-key" : "json-string";
+        return \`<span class="\${cls}">\${str}</span>\${colon ?? ""}\`;
+      }
+      if (bool !== undefined) {
+        const cls = bool === "null" ? "json-null" : "json-boolean";
+        return \`<span class="\${cls}">\${bool}</span>\`;
+      }
+      return \`<span class="json-number">\${num}</span>\`;
+    },
+  );
+}
+`;
+
+const SERVER_VARS = `// Server-variable handling for OpenAPI server URLs. A server \`url\` may contain
+// \`{name}\` templated segments (host, port, basePath, …) whose values come from
+// the spec's \`server.variables\` map: each variable carries a \`default\` and an
+// optional \`enum\` of allowed values. The Try-it form renders an input (or a
+// select, when an enum is present) per variable, and the resolved URL is what
+// every request/sample is built against.
+//
+// NOTE (build-team handoff): the generated operation \`_data/*.json\` currently
+// drops \`server.variables\`, so only the variable *names* survive (parsed from
+// the URL template here). Until the data layer emits \`variables\`, fields render
+// without a default/enum and the user must type the value. Once \`variables\` is
+// included, the same UI pre-fills defaults and shows enum dropdowns with no
+// component changes.
+
+export interface ServerVariable {
+  default?: string;
+  enum?: Array<string>;
+  description?: string;
+}
+
+export interface ServerInfo {
+  url: string;
+  description?: string;
+  variables?: Record<string, ServerVariable>;
+}
+
+const TOKEN_RE = /\\{([^}]+)\\}/g;
+
+/** Variable names referenced in a server URL template, in order, de-duplicated. */
+export function serverVariableNames(url: string): Array<string> {
+  const out: Array<string> = [];
+  let m: RegExpExecArray | null;
+  TOKEN_RE.lastIndex = 0;
+  while ((m = TOKEN_RE.exec(url)) !== null) {
+    if (!out.includes(m[1])) out.push(m[1]);
+  }
+  return out;
+}
+
+/**
+ * Resolve \`{var}\` tokens in a server URL template. Per-variable precedence:
+ * entered value → spec default → \`{var}\` left intact (so an unfilled,
+ * default-less variable stays visible rather than collapsing to an empty
+ * segment and producing a broken URL).
+ */
+export function resolveServerUrl(
+  url: string,
+  values: Record<string, string>,
+  variables?: Record<string, ServerVariable>,
+): string {
+  return url.replace(TOKEN_RE, (_full, name: string) => {
+    const entered = values[name];
+    if (entered) return entered;
+    const def = variables?.[name]?.default;
+    if (def) return def;
+    return \`{\${name}}\`;
+  });
+}
+
+/** Seed variable values from spec defaults across every server (first default wins). */
+export function seedServerVarValues(servers: Array<ServerInfo>): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const s of servers) {
+    for (const name of serverVariableNames(s.url)) {
+      const def = s.variables?.[name]?.default;
+      if (def && out[name] === undefined) out[name] = def;
+    }
+  }
+  return out;
+}
+
+/**
+ * The variables a given server exposes, in URL order. Names are always derived
+ * from the URL template; metadata (default/enum/description) is attached when
+ * present, falling back to an empty descriptor so the field still renders.
+ */
+export function serverVariablesFor(
+  server: ServerInfo | undefined,
+): Array<{ name: string; variable: ServerVariable }> {
+  if (!server) return [];
+  return serverVariableNames(server.url).map(name => ({
+    name,
+    variable: server.variables?.[name] ?? {},
+  }));
+}
+`;
+
+const PARAM_SCHEMA = `// The subset of an OpenAPI parameter/property schema the Try-it form reads to
+// pick an appropriate input control. Kept deliberately permissive (everything
+// optional) so it tolerates whatever the spec provides, and falls back to a
+// plain text input when nothing useful is present.
+
+export interface ParamSchema {
+  /**
+   * May be a single type or, in OpenAPI 3.1 / JSON Schema, an array such as
+   * \`["boolean", "null"]\` for a nullable value. Read it via \`primaryType()\`,
+   * never directly, so the array form is handled.
+   */
+  type?: string | Array<string>;
+  format?: string;
+  enum?: Array<string | number | boolean>;
+  default?: unknown;
+  example?: unknown;
+  items?: ParamSchema;
+  minimum?: number;
+  maximum?: number;
+  nullable?: boolean;
+}
+
+/**
+ * The schema's effective type, tolerating the 3.1 array form: \`["boolean",
+ * "null"]\` → \`"boolean"\`. Returns the first non-\`"null"\` entry of an array, the
+ * string as-is, or undefined when no type is declared.
+ */
+export function primaryType(schema: ParamSchema | undefined): string | undefined {
+  const t = schema?.type;
+  if (Array.isArray(t)) return t.find(x => x !== "null");
+  return t;
+}
+
+/** The concrete control the form should render for a schema. */
+export type InputKind =
+  | "enum" // <select> of allowed values
+  | "boolean" // true / false select
+  | "integer"
+  | "number"
+  | "date"
+  | "datetime"
+  | "password"
+  | "array-enum" // multi-select of allowed item values
+  | "array" // comma-separated scalars
+  | "object" // JSON code editor
+  | "text";
+
+/** Decide which control fits a schema, honoring enum → format → type, in that order. */
+export function inputKind(schema: ParamSchema | undefined): InputKind {
+  const s = schema ?? {};
+  if (s.enum && s.enum.length > 0) return "enum";
+  const type = primaryType(s);
+  if (type === "boolean") return "boolean";
+  if (type === "integer") return "integer";
+  if (type === "number") return "number";
+  if (type === "array") {
+    return s.items?.enum && s.items.enum.length > 0 ? "array-enum" : "array";
+  }
+  if (type === "object") return "object";
+  if (type === "string" || type === undefined) {
+    if (s.format === "password") return "password";
+    if (s.format === "date") return "date";
+    if (s.format === "date-time") return "datetime";
+  }
+  return "text";
+}
+
+/** A short human label for the field hint, e.g. "integer", "boolean", "array<string>". */
+export function typeLabel(schema: ParamSchema | undefined): string {
+  const s = schema ?? {};
+  const type = primaryType(s);
+  if (type === "array") {
+    const item = primaryType(s.items) ?? "string";
+    return \`array<\${item}>\`;
+  }
+  const base = type ?? "string";
+  return s.format ? \`\${base}<\${s.format}>\` : base;
+}
+
+/** Stringify a schema default/example for seeding an input value. */
+export function defaultString(schema: ParamSchema | undefined): string {
+  const s = schema ?? {};
+  const v = s.default !== undefined ? s.default : undefined;
+  if (v === undefined || v === null) return "";
+  if (typeof v === "object") return JSON.stringify(v, null, 2);
+  return String(v);
 }
 `;

--- a/cli/src/site/renderer/nextra/EndpointDataEmitter.test.ts
+++ b/cli/src/site/renderer/nextra/EndpointDataEmitter.test.ts
@@ -85,6 +85,22 @@ describe("emitEndpointData", () => {
 		expect(data.tryItParameters).toEqual([{ name: "id", in: "path", required: true, description: "ID" }]);
 	});
 
+	it("carries the value schema onto each tryItParameters entry when present", () => {
+		const op = makeOp({
+			parameters: [
+				{ name: "status", in: "query", required: false, schema: { type: "string", enum: ["open", "closed"] } },
+				{ name: "id", in: "path", required: true },
+			],
+		});
+		const data = decode(emitEndpointData("petstore", op, makeSpec()).content) as {
+			tryItParameters: Array<Record<string, unknown>>;
+		};
+		expect(data.tryItParameters).toEqual([
+			{ name: "status", in: "query", required: false, schema: { type: "string", enum: ["open", "closed"] } },
+			{ name: "id", in: "path", required: true },
+		]);
+	});
+
 	it("inlines the request body's example when present", () => {
 		const op = makeOp({
 			requestBody: { required: true, contentType: "application/json", example: { name: "Rex" } },
@@ -158,6 +174,26 @@ describe("emitEndpointData", () => {
 			servers: Array<{ url: string }>;
 		};
 		expect(data.servers).toEqual([{ url: "https://override.example.com" }]);
+	});
+
+	it("carries server variables through into the data sidecar", () => {
+		const spec = makeSpec({
+			servers: [
+				{
+					url: "https://{defaultHost}",
+					variables: { defaultHost: { default: "discourse.example.com", enum: ["a", "b"] } },
+				},
+			],
+		});
+		const data = decode(emitEndpointData("petstore", makeOp(), spec).content) as {
+			servers: Array<{ url: string; variables?: Record<string, unknown> }>;
+		};
+		expect(data.servers).toEqual([
+			{
+				url: "https://{defaultHost}",
+				variables: { defaultHost: { default: "discourse.example.com", enum: ["a", "b"] } },
+			},
+		]);
 	});
 
 	it("preserves apiKey scheme `in` / `name` / `description` when resolving auth schemes", () => {

--- a/cli/src/site/renderer/nextra/EndpointDataEmitter.ts
+++ b/cli/src/site/renderer/nextra/EndpointDataEmitter.ts
@@ -49,7 +49,13 @@ interface OperationData {
 	tags: string[];
 	deprecated: boolean;
 	servers: ParsedSpec["servers"];
-	tryItParameters: Array<{ name: string; in: OpenApiParameterLocation; required: boolean; description?: string }>;
+	tryItParameters: Array<{
+		name: string;
+		in: OpenApiParameterLocation;
+		required: boolean;
+		description?: string;
+		schema?: unknown;
+	}>;
 	parameters: {
 		path: OperationParameter[];
 		query: OperationParameter[];
@@ -85,6 +91,12 @@ function buildOperationData(specName: string, operation: OpenApiOperation, parse
 		};
 		if (p.description !== undefined) {
 			entry.description = p.description;
+		}
+		// Carry the value schema so the Try-it form can render a type-appropriate
+		// input (enum select, number spinner, date picker, …) without having to
+		// reconstruct it from the grouped `parameters.{in}` lists at render time.
+		if (p.schema !== undefined) {
+			entry.schema = p.schema;
 		}
 		return entry;
 	});

--- a/cli/src/site/renderer/nextra/SidebarMetaEmitter.test.ts
+++ b/cli/src/site/renderer/nextra/SidebarMetaEmitter.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
-import type { OpenApiOperation, ParsedSpec } from "../../openapi/Types.js";
-import { emitSidebarMetas } from "./SidebarMetaEmitter.js";
+import type { OpenApiOperation, OpenApiPipelineResult, ParsedSpec } from "../../openapi/Types.js";
+import { buildApiSidebarOverrides } from "./SidebarMetaEmitter.js";
 
 function makeSpec(overrides: Partial<ParsedSpec> = {}): ParsedSpec {
 	return {
@@ -21,7 +21,7 @@ function makeOp(overrides: Partial<OpenApiOperation> = {}): OpenApiOperation {
 		method: "get",
 		path: "/pets",
 		tag: "pets",
-		summary: "",
+		summary: "List pets",
 		description: "",
 		deprecated: false,
 		parameters: [],
@@ -31,53 +31,73 @@ function makeOp(overrides: Partial<OpenApiOperation> = {}): OpenApiOperation {
 	};
 }
 
-describe("emitSidebarMetas", () => {
-	it("emits the spec-folder _meta.ts plus one per tag", () => {
+function makeInput(specName: string, spec: ParsedSpec): { specName: string; pipeline: OpenApiPipelineResult } {
+	return { specName, pipeline: { spec, dossiers: [] } };
+}
+
+describe("buildApiSidebarOverrides", () => {
+	it("keys overrides by per-tag folder path and labels each operation by summary", () => {
 		const spec = makeSpec({
 			tags: [{ name: "pets" }, { name: "users" }],
+			operations: [
+				makeOp({ tag: "pets", operationId: "listpets", summary: "List pets" }),
+				makeOp({ tag: "users", operationId: "listusers", path: "/users", summary: "List users" }),
+			],
+		});
+		const overrides = buildApiSidebarOverrides([makeInput("petstore", spec)]);
+		expect(overrides["/api-petstore/pets"]).toEqual({ listpets: "List pets" });
+		expect(overrides["/api-petstore/users"]).toEqual({ listusers: "List users" });
+	});
+
+	it("emits a top-level /api-{spec} override listing tag groups in spec declaration order", () => {
+		const spec = makeSpec({
+			// Declared order is users, then pets — the reverse of alphabetical.
+			tags: [{ name: "users" }, { name: "pets" }],
 			operations: [
 				makeOp({ tag: "pets", operationId: "listpets" }),
 				makeOp({ tag: "users", operationId: "listusers", path: "/users" }),
 			],
 		});
-		const files = emitSidebarMetas("petstore", spec);
-		const paths = files.map((f) => f.path);
-		expect(paths).toContain("content/api-petstore/_meta.ts");
-		expect(paths).toContain("content/api-petstore/pets/_meta.ts");
-		expect(paths).toContain("content/api-petstore/users/_meta.ts");
+		const overrides = buildApiSidebarOverrides([makeInput("petstore", spec)]);
+		// Spec order (users, pets), not alphabetical (pets, users).
+		expect(Object.keys(overrides["/api-petstore"])).toEqual(["users", "pets"]);
 	});
 
-	it("places `index: 'Overview'` first in the spec-folder _meta.ts", () => {
+	it("title-cases tag-group labels so only the order changes, not the displayed label", () => {
 		const spec = makeSpec({
-			tags: [{ name: "pets" }],
-			operations: [makeOp({ tag: "pets" })],
+			tags: [{ name: "user management" }],
+			operations: [makeOp({ tag: "user management" })],
 		});
-		const files = emitSidebarMetas("petstore", spec);
-		const top = files.find((f) => f.path === "content/api-petstore/_meta.ts");
-		expect(top).toBeDefined();
-		const idxOverview = top?.content.indexOf("index: 'Overview'") ?? -1;
-		const idxPets = top?.content.indexOf("'pets': 'pets'") ?? -1;
-		expect(idxOverview).toBeGreaterThan(-1);
-		expect(idxPets).toBeGreaterThan(idxOverview);
+		const overrides = buildApiSidebarOverrides([makeInput("petstore", spec)]);
+		expect(overrides["/api-petstore"]).toEqual({ "user-management": "User Management" });
 	});
 
-	it("emits per-tag entries labelled `METHOD path` in operation declaration order", () => {
+	it("omits `index` from the top-level override (Overview stays MetaGenerator-managed)", () => {
+		const spec = makeSpec({ tags: [{ name: "pets" }], operations: [makeOp({ tag: "pets" })] });
+		const overrides = buildApiSidebarOverrides([makeInput("petstore", spec)]);
+		expect(overrides["/api-petstore"].index).toBeUndefined();
+	});
+
+	it("preserves operation declaration order within a tag", () => {
 		const spec = makeSpec({
 			tags: [{ name: "pets" }],
 			operations: [
-				makeOp({ tag: "pets", operationId: "listpets", method: "get", path: "/pets" }),
-				makeOp({ tag: "pets", operationId: "createpet", method: "post", path: "/pets" }),
+				makeOp({ tag: "pets", operationId: "listpets", summary: "List pets" }),
+				makeOp({ tag: "pets", operationId: "createpet", method: "post", summary: "Create a pet" }),
 			],
 		});
-		const files = emitSidebarMetas("petstore", spec);
-		const tag = files.find((f) => f.path === "content/api-petstore/pets/_meta.ts");
-		expect(tag).toBeDefined();
-		expect(tag?.content).toContain("'listpets': 'GET /pets'");
-		expect(tag?.content).toContain("'createpet': 'POST /pets'");
-		const idxList = tag?.content.indexOf("'listpets'") ?? -1;
-		const idxCreate = tag?.content.indexOf("'createpet'") ?? -1;
-		expect(idxList).toBeGreaterThan(-1);
-		expect(idxCreate).toBeGreaterThan(idxList);
+		const overrides = buildApiSidebarOverrides([makeInput("petstore", spec)]);
+		expect(Object.keys(overrides["/api-petstore/pets"])).toEqual(["listpets", "createpet"]);
+	});
+
+	it("uses the synthesised METHOD-path summary when the spec omits a summary", () => {
+		// SpecParser sets `summary` to `METHOD /path` when the spec has none.
+		const spec = makeSpec({
+			tags: [{ name: "pets" }],
+			operations: [makeOp({ tag: "pets", operationId: "createpet", method: "post", summary: "POST /pets" })],
+		});
+		const overrides = buildApiSidebarOverrides([makeInput("petstore", spec)]);
+		expect(overrides["/api-petstore/pets"].createpet).toBe("POST /pets");
 	});
 
 	it("skips a tag whose operations array is empty", () => {
@@ -85,38 +105,28 @@ describe("emitSidebarMetas", () => {
 			tags: [{ name: "lonely" }, { name: "pets" }],
 			operations: [makeOp({ tag: "pets" })],
 		});
-		const files = emitSidebarMetas("petstore", spec);
-		const paths = files.map((f) => f.path);
-		expect(paths).toContain("content/api-petstore/pets/_meta.ts");
-		expect(paths).not.toContain("content/api-petstore/lonely/_meta.ts");
-		// Top-level _meta.ts also omits the empty tag.
-		const top = files.find((f) => f.path === "content/api-petstore/_meta.ts");
-		expect(top?.content).not.toContain("lonely");
+		const overrides = buildApiSidebarOverrides([makeInput("petstore", spec)]);
+		expect(overrides["/api-petstore/pets"]).toBeDefined();
+		expect(overrides["/api-petstore/lonely"]).toBeUndefined();
 	});
 
-	it("appends an untagged operation under a synthetic group when no matching tag is declared", () => {
-		// `default` is a JS reserved word, so its slug becomes `default-doc`.
-		// The label keeps the original tag string for sidebar display.
-		const spec = makeSpec({
-			tags: [],
-			operations: [makeOp({ tag: "default", operationId: "ping" })],
-		});
-		const files = emitSidebarMetas("petstore", spec);
-		const top = files.find((f) => f.path === "content/api-petstore/_meta.ts");
-		expect(top?.content).toContain("'default-doc': 'default'");
-		expect(files.some((f) => f.path === "content/api-petstore/default-doc/_meta.ts")).toBe(true);
+	it("slugifies the tag in the path key (e.g. reserved 'default' → 'default-doc')", () => {
+		const spec = makeSpec({ tags: [], operations: [makeOp({ tag: "default", operationId: "ping" })] });
+		const overrides = buildApiSidebarOverrides([makeInput("petstore", spec)]);
+		expect(overrides["/api-petstore/default-doc"]).toEqual({ ping: "List pets" });
 	});
 
-	it("escapes JS-significant characters in tag and operationId labels", () => {
-		const spec = makeSpec({
-			tags: [{ name: "tag's" }],
-			operations: [makeOp({ tag: "tag's", operationId: "op'name" })],
+	it("merges multiple specs under their own folder slugs", () => {
+		const a = makeSpec({
+			tags: [{ name: "pets" }],
+			operations: [makeOp({ tag: "pets", operationId: "listpets" })],
 		});
-		const files = emitSidebarMetas("petstore", spec);
-		const top = files.find((f) => f.path === "content/api-petstore/_meta.ts");
-		// The slug doesn't keep the apostrophe (slugify strips it), but the
-		// label literal does — and that label MUST round-trip through single
-		// quotes safely.
-		expect(top?.content).toContain("'tag\\'s'");
+		const b = makeSpec({
+			tags: [{ name: "cars" }],
+			operations: [makeOp({ tag: "cars", operationId: "listcars" })],
+		});
+		const overrides = buildApiSidebarOverrides([makeInput("petstore", a), makeInput("garage", b)]);
+		expect(overrides["/api-petstore/pets"]).toBeDefined();
+		expect(overrides["/api-garage/cars"]).toBeDefined();
 	});
 });

--- a/cli/src/site/renderer/nextra/SidebarMetaEmitter.ts
+++ b/cli/src/site/renderer/nextra/SidebarMetaEmitter.ts
@@ -1,49 +1,81 @@
 /**
- * Emits the `_meta.ts` files that form one spec's sidebar tree:
+ * Builds the `SidebarOverrides` that name one spec's API endpoints in the
+ * Nextra sidebar.
  *
- *   - `content/api-{specName}/_meta.ts` — top-level: `index` first, then one
- *     entry per tag (order = parsed.tags order).
- *   - `content/api-{specName}/{tagSlug}/_meta.ts` — per tag: ordered
- *     operations in spec order, labelled `METHOD path`.
+ * The sidebar `_meta.js` for every folder is written by `MetaGenerator`, which
+ * (absent an override) labels each entry by title-casing the filename — so an
+ * endpoint page `createbackup.mdx` would show as "Createbackup". To label them
+ * with the operation's friendly summary instead, we hand `generateMetaFiles`
+ * an override keyed by the per-tag folder path:
  *
- * Each spec lives in its own top-level folder so Nextra binds it as a
- * folder-scoped page-tab — when the user is on `/api-{spec}/...` the
- * sidebar shows ONLY that spec's tree.
+ *   - `/{api-spec}/{tag-slug}` → ordered `{ operationId: summary }` (spec
+ *     order). `operation.summary` is the spec's summary, or a synthesised
+ *     `METHOD /path` when the spec omits one (see `SpecParser`).
+ *
+ * The top-level `/{api-spec}` folder (Overview + tag folders) is intentionally
+ * left to `MetaGenerator`'s defaults — tag folder names already title-case
+ * cleanly and the Overview index stays hidden, matching prior behaviour.
  */
 
-import { escapeJsString } from "../../openapi/Escape.js";
-import type { OpenApiOperation, ParsedSpec } from "../../openapi/Types.js";
+import type { OpenApiOperation, OpenApiPipelineResult, ParsedSpec } from "../../openapi/Types.js";
+import type { SidebarItemValue, SidebarOverrides } from "../../Types.js";
 import { apiSpecFolderSlug, tagSlug } from "./Paths.js";
-import type { TemplateFile } from "./Types.js";
 
-export function emitSidebarMetas(specName: string, parsed: ParsedSpec): TemplateFile[] {
-	const files: TemplateFile[] = [];
-	const operationsByTag = groupOperationsByTag(parsed);
-	const folder = apiSpecFolderSlug(specName);
+/**
+ * Title-cases a slug for a tag-group label — mirrors `MetaGenerator.toTitleCase`
+ * so switching the tag order (via this override) doesn't also change the label
+ * `MetaGenerator` would otherwise produce. Inlined rather than imported to keep
+ * this module free of a `MetaGenerator` dependency (callers mock that module).
+ */
+function titleCaseSlug(slug: string): string {
+	return slug.replace(/[-_]/g, " ").replace(/\b\w/g, (ch) => ch.toUpperCase());
+}
 
-	// `groupOperationsByTag` already filters out groups with no operations,
-	// so each iteration here is guaranteed to produce a sidebar entry.
-	const topLevelEntries: string[] = [`  index: 'Overview'`];
-	for (const { tag } of operationsByTag) {
-		topLevelEntries.push(`  '${escapeJsString(tagSlug(tag))}': '${escapeJsString(tag)}'`);
+/** Minimal shape of the per-spec render input this builder needs. */
+export interface ApiSpecNavInput {
+	specName: string;
+	pipeline: OpenApiPipelineResult;
+}
+
+/**
+ * Produces `SidebarOverrides` for the supplied specs so the sidebar follows the
+ * OpenAPI spec's declared order (not alphabetical) and labels each endpoint
+ * with its operation summary. Two layers, both keyed by folder path so they
+ * merge cleanly with the caller's doc overrides (API path keys never collide):
+ *
+ *   - `/{api-spec}` → tag groups in `parsed.tags` declaration order. Labels are
+ *     title-cased to match `MetaGenerator`'s default, so only the *order*
+ *     changes. `index` is intentionally omitted so `MetaGenerator`'s
+ *     auto-hidden-index logic keeps the Overview page hidden (and tolerates an
+ *     `asIndexPage` overview).
+ *   - `/{api-spec}/{tag-slug}` → operations in spec order, labelled by summary.
+ */
+export function buildApiSidebarOverrides(specs: ReadonlyArray<ApiSpecNavInput>): SidebarOverrides {
+	const overrides: SidebarOverrides = {};
+	for (const { specName, pipeline } of specs) {
+		const folder = apiSpecFolderSlug(specName);
+		const groups = groupOperationsByTag(pipeline.spec);
+
+		// Top-level: tag groups in declaration order.
+		const tagEntries: Record<string, SidebarItemValue> = {};
+		for (const { tag } of groups) {
+			const slug = tagSlug(tag);
+			tagEntries[slug] = titleCaseSlug(slug);
+		}
+		if (Object.keys(tagEntries).length > 0) {
+			overrides[`/${folder}`] = tagEntries;
+		}
+
+		// Per tag: operations in spec order, labelled by summary.
+		for (const { tag, operations } of groups) {
+			const entries: Record<string, SidebarItemValue> = {};
+			for (const op of operations) {
+				entries[op.operationId] = op.summary;
+			}
+			overrides[`/${folder}/${tagSlug(tag)}`] = entries;
+		}
 	}
-	files.push({
-		path: `content/${folder}/_meta.ts`,
-		content: `export default {\n${topLevelEntries.join(",\n")}\n}\n`,
-	});
-
-	for (const { tag, operations } of operationsByTag) {
-		const folderEntries = operations.map((op) => {
-			const label = `${op.method.toUpperCase()} ${op.path}`;
-			return `  '${escapeJsString(op.operationId)}': '${escapeJsString(label)}'`;
-		});
-		files.push({
-			path: `content/${folder}/${tagSlug(tag)}/_meta.ts`,
-			content: `export default {\n${folderEntries.join(",\n")}\n}\n`,
-		});
-	}
-
-	return files;
+	return overrides;
 }
 
 interface TagGroup {

--- a/cli/src/site/renderer/nextra/index.test.ts
+++ b/cli/src/site/renderer/nextra/index.test.ts
@@ -51,16 +51,18 @@ function makeInput(overrides: Partial<OpenApiSpecInput> = {}): OpenApiSpecInput 
 // ─── emitNextraOpenApiForSpec ──────────────────────────────────────────────
 
 describe("emitNextraOpenApiForSpec", () => {
-	it("emits overview, _refs, per-operation MDX + JSON, and sidebar metas", () => {
+	it("emits overview, _refs, per-operation MDX + JSON (sidebar labels now come from overrides)", () => {
 		const input = makeInput();
 		const files = emitNextraOpenApiForSpec(input.specName, input.pipeline);
 		const paths = new Set(files.map((f) => f.path));
 		expect(paths.has("content/api-petstore/index.mdx")).toBe(true);
 		expect(paths.has("content/api-petstore/_refs.ts")).toBe(true);
-		expect(paths.has("content/api-petstore/_meta.ts")).toBe(true);
-		expect(paths.has("content/api-petstore/pets/_meta.ts")).toBe(true);
 		expect(paths.has("content/api-petstore/pets/listpets.mdx")).toBe(true);
 		expect(paths.has("content/api-petstore/_data/listpets.json")).toBe(true);
+		// `_meta.ts` is no longer emitted here — sidebar labels are supplied to
+		// MetaGenerator via `buildApiSidebarOverrides` instead.
+		expect(paths.has("content/api-petstore/_meta.ts")).toBe(false);
+		expect(paths.has("content/api-petstore/pets/_meta.ts")).toBe(false);
 	});
 
 	it("synthesises per-operation code samples when the pipeline has no dossiers", () => {
@@ -107,7 +109,7 @@ describe("emitNextraOpenApiForSpec", () => {
 		expect(mdx?.content).toContain("https://api.example.com");
 	});
 
-	it("returns an empty array if the spec has no operations (just overview, refs, top-level _meta)", () => {
+	it("returns only overview + refs when the spec has no operations", () => {
 		const input = makeInput({
 			pipeline: { spec: makeSpec({ operations: [], tags: [] }), dossiers: [] },
 		});
@@ -135,7 +137,14 @@ describe("emitNextraOpenApiFiles", () => {
 		expect(files.some((f) => f.path === "content/api-users/index.mdx")).toBe(true);
 	});
 
-	it("returns an empty array when no specs are provided", () => {
+	it("emits the route→method nav map keyed by endpoint route", () => {
+		const files = emitNextraOpenApiFiles([makeInput()]);
+		const navMap = files.find((f) => f.path === "components/apiNavMethods.ts");
+		expect(navMap).toBeDefined();
+		expect(navMap?.content).toContain('"/api-petstore/pets/listpets": "GET"');
+	});
+
+	it("returns an empty array when no specs are provided (empty map comes from initProject)", () => {
 		expect(emitNextraOpenApiFiles([])).toEqual([]);
 	});
 });

--- a/cli/src/site/renderer/nextra/index.ts
+++ b/cli/src/site/renderer/nextra/index.ts
@@ -14,17 +14,18 @@
 import { generateCodeSamples } from "../../openapi/CodeSampleGenerator.js";
 import type { OpenApiPipelineResult } from "../../openapi/Types.js";
 import type { OpenApiSpecInput } from "../SiteRenderer.js";
+import { emitApiNavMethods } from "./ApiNavMethods.js";
 import { emitEndpointData } from "./EndpointDataEmitter.js";
 import { emitEndpointPage, emitRefsFile } from "./EndpointPageEmitter.js";
 import { emitOverviewPage } from "./OverviewPageEmitter.js";
-import { emitSidebarMetas } from "./SidebarMetaEmitter.js";
 import type { TemplateFile } from "./Types.js";
 
+export { EMPTY_API_NAV_METHODS, emitApiNavMethods } from "./ApiNavMethods.js";
 export { generateApiComponents } from "./Components.js";
 export { emitEndpointData } from "./EndpointDataEmitter.js";
 export { emitEndpointPage, emitRefsFile } from "./EndpointPageEmitter.js";
 export { emitOverviewPage } from "./OverviewPageEmitter.js";
-export { emitSidebarMetas } from "./SidebarMetaEmitter.js";
+export { buildApiSidebarOverrides } from "./SidebarMetaEmitter.js";
 export type { TemplateFile } from "./Types.js";
 
 // ─── Per-spec emission ───────────────────────────────────────────────────────
@@ -68,7 +69,6 @@ export function emitNextraOpenApiForSpec(specName: string, pipeline: OpenApiPipe
 		files.push(emitEndpointPage(specName, operation, samples));
 	}
 
-	files.push(...emitSidebarMetas(specName, pipeline.spec));
 	return files;
 }
 
@@ -83,6 +83,12 @@ export function emitNextraOpenApiFiles(specs: OpenApiSpecInput[]): TemplateFile[
 	const files: TemplateFile[] = [];
 	for (const spec of specs) {
 		files.push(...emitNextraOpenApiForSpec(spec.specName, spec.pipeline));
+	}
+	// Route → HTTP-method lookup consumed by the sidebar badge client component.
+	// Only when there are specs — `initProject` writes the empty map otherwise,
+	// so the layout import always resolves.
+	if (specs.length > 0) {
+		files.push(emitApiNavMethods(specs));
 	}
 	return files;
 }

--- a/cli/src/sync/GitClient.test.ts
+++ b/cli/src/sync/GitClient.test.ts
@@ -9,7 +9,7 @@
  */
 
 import { execFileSync } from "node:child_process";
-import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, stat, utimes, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
@@ -669,9 +669,13 @@ describe("GitClient", () => {
 			await client.clone(bareRepoUrl);
 			const indexLock = join(memoryBankRoot, ".git", "index.lock");
 			await writeFile(indexLock, "");
-			// Backdate the lock so it's clearly older than the 30 s TTL the
-			// engine uses in production (TTL=0 here makes the assertion
-			// timing-independent regardless of FS clock resolution).
+			// Backdate the lock a minute so its mtime is unambiguously older
+			// than the sweep cutoff. `Date.now()` floors to integer ms while
+			// `mtimeMs` carries sub-ms precision, so a just-written lock can
+			// read as *newer* than a TTL=0 cutoff — backdating removes that
+			// race and makes the assertion truly clock-resolution-independent.
+			const past = new Date(Date.now() - 60_000);
+			await utimes(indexLock, past, past);
 			const result = await client.sweepStaleLockFiles(0);
 			expect(result.removed).toContain(indexLock);
 			// Sanity: lock actually gone from disk.
@@ -686,6 +690,11 @@ describe("GitClient", () => {
 			// `refs/heads/main` already exists (set by clone); the .lock
 			// sibling is the artifact a killed `git update-ref` leaves.
 			await writeFile(branchLock, "");
+			// Backdate so the mtime is unambiguously older than the cutoff —
+			// see the index.lock case above for why a TTL=0 sweep otherwise
+			// races sub-ms `mtimeMs` against floored `Date.now()`.
+			const past = new Date(Date.now() - 60_000);
+			await utimes(branchLock, past, past);
 			const result = await client.sweepStaleLockFiles(0);
 			expect(result.removed).toContain(branchLock);
 		});


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## Quick recap

This commit overhauled how API reference pages are generated and displayed across the Jolli site builder. The most visible change was replacing the previous static endpoint layout with a new interactive design: a single-line identity header showing the HTTP method and path, with a collapsible "Try it" accordion that expands an interactive request builder. A shared context layer now feeds a live request sample panel in the sidebar, regenerating per-language code snippets as the user fills in parameters. Sent requests are logged to browser storage and rendered as history items. Alongside the component work, the data pipeline was extended to carry server URL template variables and per-parameter schema information through to the generated page data, enabling typed input controls and server variable dropdowns in the try-it form. The commit also fixed API endpoint navigation: sidebar entries now show the operation's friendly summary name instead of a title-cased slug, follow the declaration order from the OpenAPI spec rather than alphabetical order, and receive HTTP method badges stamped onto their sidebar links by a client-side effect driven by a generated route-to-method lookup table.

---

## E2E Test (3)
<details>
<summary><strong>1. Interactive &quot;Try it&quot; accordion on API endpoint pages</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a site with at least one API spec loaded and navigate to any API endpoint page.

**Steps:**
1. Open the site and go to an API reference page for any endpoint.
2. Look for a "Try it" button near the top of the page, next to the HTTP method and path.
3. Click the "Try it" button.
4. Check that a form expands below the header row with input fields for any parameters the endpoint accepts.
5. Fill in a parameter value and check that the code snippet shown on the page updates to reflect what you typed.
6. Submit the request and check that a response appears, and that the request shows up in a history list.

**Expected Results:**
- Clicking "Try it" opens a collapsible form without reloading the page.
- The code snippet updates live as you type into the parameter fields.
- After sending, a response is displayed and the sent request appears in the history section below the form.

</blockquote>
</details>
<details>
<summary><strong>2. Server variable dropdowns in the Try it form</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a site whose API spec defines a server URL with template variables (for example, a URL like "https://{region}.example.com" with a list of allowed region values).

**Steps:**
1. Open an API endpoint page that uses a server with template variables.
2. Click the "Try it" button to open the interactive form.
3. Look for a dropdown or input field labeled with the variable name (for example, "region").
4. If it is a dropdown, open it and select a different option. If it is a text field, clear it and type a new value.
5. Check that the server URL shown in the code snippet or request preview updates to reflect the value you chose.

**Expected Results:**
- A dropdown (when the spec lists allowed values) or a text input (when no fixed list is given) appears for each server variable.
- Changing the value immediately updates the full request URL shown in the code snippet.

</blockquote>
</details>
<details>
<summary><strong>3. API endpoint sidebar labels show human-readable names and HTTP method badges</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a site with an API spec that includes operation summaries (for example, "List pets" or "Create backup").

**Steps:**
1. Open the site and look at the left-hand navigation sidebar.
2. Find the section for your API spec and expand any tag group (for example, "pets").
3. Check the labels shown for individual endpoint links.
4. Look at each endpoint link and check whether a small colored badge (such as "GET", "POST", or "DELETE") appears next to the label.

**Expected Results:**
- Endpoint links in the sidebar display the human-readable summary from the spec (for example, "List pets") instead of a run-together slug like "Listpets".
- Each endpoint link shows a colored HTTP method chip (GET, POST, DELETE, etc.) that matches the operation's method.

</blockquote>
</details>

---

## Topics (4)
<details>
<summary><strong>01 · Interactive try-it accordion and live request sample on API endpoint pages</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The API reference pages needed a more interactive layout: a collapsible try-it form with live code snippet generation, request history, typed parameter inputs, and server variable controls, replacing the previous static two-column layout.

**💡 Decisions Behind the Code**

- **Escaped template literals vs. real source files**: The components are stored as escaped JavaScript template-literal strings inside a single TypeScript source file, matching the existing pattern in the codebase. An alternative — storing them as real source files read at emit time — would be easier to maintain and review, but would require changes to the CLI's build and packaging pipeline. The team chose to stay with the established pattern for now and flagged the architectural change as a potential follow-up.
- **CSS left entirely to the theme layer**: The component templates emit only semantic class names following the existing markup contract; no styles are written by the CLI. This keeps the component and styling concerns cleanly separated so Forge, Atlas, and any future theme can control the visual appearance of the new accordion, history panel, and typed inputs purely through CSS, without touching generated markup.
- **Generator script for escaping**: Rather than hand-escaping sixteen files worth of template literals (a process that is both tedious and error-prone for content containing regex backslashes, backticks, and interpolation syntax), a one-off script was used to produce the escaped constants and a round-trip verification confirmed correctness before the scratch files were deleted. This trades a small upfront investment for high confidence that the generated components match the intended source exactly.

**✅ What Was Implemented**

- The component set scaffolded into generated sites grew from 9 to 20 files. Five existing components were reworked (the endpoint wrapper, the meta header line, the code switcher, the auth requirements block, and the try-it widget itself), and eleven new files were added: six React client components covering tabbed responses, the request sample panel, history items, a shared try-it context provider, a typed input control, and a code editor; plus five plain TypeScript modules for request snippet generation, history persistence, JSON highlighting, server variable resolution, and parameter schema introspection.
- To avoid hand-escaping errors in the large embedded template-literal strings (which contain regular expressions, SVG markup, Go code with backticks, and Unicode characters), each final file was first written as plain source, then escaped mechanically by a generator script, and all twenty were verified to round-trip byte-for-byte back to the plain source before being committed.
- The component generation function in the renderer and its associated tests were updated to reflect the new file count and structure, including revised assertions about which files carry the client-component pragma and which are plain utility modules.

**📋 Future Enhancements**

The "store sources as escaped strings" pattern is acknowledged as increasingly painful at this scale — the 20 components now represent roughly 86 KB of escaped literals in one file. Moving them to real template source files read at emit time is the cleaner long-term path and was explicitly flagged for a future architectural change.

**📁 FILES**
- `cli/src/site/renderer/nextra/Components.ts`
- `cli/src/site/renderer/nextra/Components.test.ts`

</blockquote>
</details>
<details>
<summary><strong>02 · Server URL template variables and parameter schema carried through to page data</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The try-it form needed to render typed input controls and server variable dropdowns, but the data pipeline was discarding the variable definitions attached to server entries and the schema information attached to individual parameters.

**💡 Decisions Behind the Code**

- **Silent field-level filtering over hard rejection**: When server variable fields contain unexpected types (for example, a numeric default or an enum array containing non-string members), the parser drops only the invalid fields rather than rejecting the entire server entry. This makes the CLI resilient to loosely-typed or hand-authored specs without surfacing confusing build errors for what are ultimately cosmetic data issues.

**✅ What Was Implemented**

- A new interface was added to the OpenAPI type definitions to represent a server variable entry, capturing its default value, allowed enumeration, and description. The spec parser was updated to carry these fields through on both root-level and per-operation server entries, validating that each field is the correct type and silently dropping malformed values rather than failing.
- The endpoint data emitter was extended to include the parameter schema on each try-it parameter entry, making it available to the typed input component at render time without requiring any changes to the dev, build, or start commands (which re-scaffold and re-emit automatically).

**📁 FILES**
- `cli/src/site/openapi/Types.ts`
- `cli/src/site/openapi/SpecParser.ts`
- `cli/src/site/renderer/nextra/EndpointDataEmitter.ts`

</blockquote>
</details>
<details>
<summary><strong>03 · API endpoint sidebar entries show friendly names instead of slugified identifiers</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The left-hand navigation was displaying auto-generated labels like "Createbackup" and "Downloadbackup" for API endpoints instead of the human-readable operation summaries defined in the OpenAPI spec.

**💡 Decisions Behind the Code**

- **Client-side attribute stamping for method badges**: Nextra version 4's sidebar has no component customization hook and its page-map titles are plain strings, so a styled method chip cannot be injected through the navigation data. Stamping a data attribute onto sidebar links via a DOM effect after render was the only viable approach that keeps the badge purely CSS-driven on the theme side and requires no changes to Nextra internals. A MutationObserver re-runs the stamp on collapse and expand events; because setting an attribute does not emit the mutation record types being observed, the observer cannot trigger itself in a loop.
- **Override mechanism over file replacement**: Rather than generating a separate metadata file per tag folder (which the metadata generator would then overwrite), the fix feeds API labels directly into the override map that the generator already consults before falling back to filename-based labels. This is a smaller, safer change that works with the existing system rather than fighting it, and it means API path keys can never collide with documentation path keys.

**✅ What Was Implemented**

- The root cause was that a metadata generation pass walks the entire content tree and rewrites navigation labels from title-cased filenames, overwriting the labels the API sidebar emitter had previously written. The fix routes API endpoint labels through the override mechanism that the metadata generator already honors, so the operation's summary string is used as the label (falling back to the method and path when no summary is present). The now-redundant per-folder metadata files that the old emitter wrote were removed.
- A new emitter was added to produce a route-to-method lookup table as a generated TypeScript module. The scoped layout component was updated to read this map and stamp a data attribute onto each API endpoint's sidebar link on the client side, giving the theme a hook to render HTTP method chips via CSS without requiring any changes to Nextra's navigation data structures.

**📁 FILES**
- `cli/src/site/renderer/nextra/SidebarMetaEmitter.ts`
- `cli/src/site/renderer/nextra/ApiNavMethods.ts`
- `cli/src/site/NextraProjectWriter.ts`
- `cli/src/commands/StartCommand.ts`

</blockquote>
</details>
<details>
<summary><strong>04 · API sidebar tag groups and operations follow OpenAPI declaration order</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The API reference navigation was rendering tag groups and their operations in alphabetical order rather than the order they appear in the OpenAPI specification, which disrupted the intended information hierarchy.

**💡 Decisions Behind the Code**

- **Explicit override at both hierarchy levels**: The metadata generator's default behavior sorts entries alphabetically at every folder level. Supplying an explicit override for the top-level spec folder (in addition to the per-tag overrides already added for friendly names) is the minimal change needed to control tag group order, and it reuses the same mechanism already proven to work for operation ordering within tags.

**✅ What Was Implemented**

The sidebar override builder was extended to also emit a top-level override for the API spec folder, listing tag groups in the order they appear in the parsed specification's tags array. Since the operation grouping logic already preserves declaration order within each tag, this change brings both levels of the hierarchy into alignment with the spec. A small title-case helper was inlined into the emitter to avoid importing it from the metadata generator module, which would have complicated test mocking.

**📁 FILES**
- `cli/src/site/renderer/nextra/SidebarMetaEmitter.ts`

</blockquote>
</details>

---

*Generated by Jolli Memory · May 27, 2026 at 7:59 PM · via Jolli proxy*
<!-- jollimemory-summary-end -->