### PR TITLE
Stop materialising header.items into the root _meta.js

### DIFF
--- a/cli/src/site/MetaGenerator.test.ts
+++ b/cli/src/site/MetaGenerator.test.ts
@@ -471,9 +471,8 @@ describe("MetaGenerator.generateMetaFiles with rootInjection", () => {
 		});
 		const meta = await readRootMeta();
 		expect(meta).not.toContain("__documentation");
-		// User entry survives, slug-keyed.
-		expect(meta).toContain('"nav-documentation":');
-		expect(meta).toContain('"href":"/docs"');
+		// Header items are not emitted into _meta.js — themes render them inline.
+		expect(meta).not.toContain('"nav-documentation":');
 	});
 
 	it("skips __api-reference when the user declares an 'API Reference' header item", async () => {
@@ -486,8 +485,8 @@ describe("MetaGenerator.generateMetaFiles with rootInjection", () => {
 		expect(meta).not.toContain('"__api-reference":');
 		// Per-spec hidden entries are still emitted (they're folder-bindings).
 		expect(meta).toContain('"api-petstore":');
-		// User entry survives.
-		expect(meta).toContain('"nav-api-reference":');
+		// Header items are not emitted into _meta.js.
+		expect(meta).not.toContain('"nav-api-reference":');
 	});
 
 	it("matches override labels case-insensitively", async () => {
@@ -512,20 +511,24 @@ describe("MetaGenerator.generateMetaFiles with rootInjection", () => {
 		expect(meta).not.toContain('"title":"API Reference"');
 	});
 
-	// ── header.items materialisation ─────────────────────────────────────────
+	// ── header.items are NOT materialised into _meta.js ──────────────────────
+	//
+	// Themes render header items inline via their own <Navbar> JSX. Emitting
+	// them into _meta.js too would produce duplicate links (theme row +
+	// Nextra's auto page-tabs strip). The CLI only uses `header.items` for
+	// override detection — see the override-wins tests above.
 
-	it("materialises a flat header item as type:'page' with the configured href", async () => {
+	it("does not emit a flat header item into _meta.js", async () => {
 		const { generateMetaFiles } = await import("./MetaGenerator.js");
 		await generateMetaFiles(tempDir, undefined, {
 			headerItems: [{ label: "Pricing", url: "/pricing" }],
 		});
 		const meta = await readRootMeta();
-		expect(meta).toContain('"nav-pricing":');
-		expect(meta).toContain('"type":"page"');
-		expect(meta).toContain('"href":"/pricing"');
+		expect(meta).not.toContain('"nav-pricing":');
+		expect(meta).not.toContain('"href":"/pricing"');
 	});
 
-	it("materialises a header item with sub-items as type:'menu' with sub-entries", async () => {
+	it("does not emit a header item with sub-items into _meta.js", async () => {
 		const { generateMetaFiles } = await import("./MetaGenerator.js");
 		await generateMetaFiles(tempDir, undefined, {
 			headerItems: [
@@ -539,70 +542,9 @@ describe("MetaGenerator.generateMetaFiles with rootInjection", () => {
 			],
 		});
 		const meta = await readRootMeta();
-		expect(meta).toContain('"nav-resources":');
-		expect(meta).toContain('"type":"menu"');
-		expect(meta).toContain('"blog":{"title":"Blog","href":"/blog"}');
-		expect(meta).toContain('"changelog":{"title":"Changelog","href":"/changelog"}');
-	});
-
-	// ── Security: URL sanitisation ───────────────────────────────────────────
-
-	it("sanitises javascript: URLs in flat header.items[].url to '#'", async () => {
-		const { generateMetaFiles } = await import("./MetaGenerator.js");
-		await generateMetaFiles(tempDir, undefined, {
-			headerItems: [{ label: "Bad", url: "javascript:alert(1)" }],
-		});
-		const meta = await readRootMeta();
-		expect(meta).not.toMatch(/javascript:alert/i);
-		expect(meta).toContain('"href":"#"');
-	});
-
-	it("sanitises javascript: URLs in dropdown sub-items to '#'", async () => {
-		const { generateMetaFiles } = await import("./MetaGenerator.js");
-		await generateMetaFiles(tempDir, undefined, {
-			headerItems: [
-				{
-					label: "Menu",
-					items: [{ label: "Bad", url: "JAVASCRIPT:alert(1)" }],
-				},
-			],
-		});
-		const meta = await readRootMeta();
-		expect(meta).not.toMatch(/javascript:alert/i);
-		expect(meta).toContain('"href":"#"');
-	});
-
-	it("sanitises data: and vbscript: URLs to '#'", async () => {
-		const { generateMetaFiles } = await import("./MetaGenerator.js");
-		await generateMetaFiles(tempDir, undefined, {
-			headerItems: [
-				{ label: "DataUrl", url: "data:text/html,<script>alert(1)</script>" },
-				{ label: "VbsUrl", url: "vbscript:msgbox(1)" },
-			],
-		});
-		const meta = await readRootMeta();
-		expect(meta).not.toContain("data:text/html");
-		expect(meta).not.toContain("vbscript:");
-		expect(meta).not.toContain("<script>");
-	});
-
-	it("preserves http(s), mailto, tel, fragment, and relative hrefs unchanged", async () => {
-		const { generateMetaFiles } = await import("./MetaGenerator.js");
-		await generateMetaFiles(tempDir, undefined, {
-			headerItems: [
-				{ label: "Site", url: "https://example.com/path" },
-				{ label: "Email", url: "mailto:hi@example.com" },
-				{ label: "Phone", url: "tel:+15551234567" },
-				{ label: "Fragment", url: "#section" },
-				{ label: "Relative", url: "/path/to/page" },
-			],
-		});
-		const meta = await readRootMeta();
-		expect(meta).toContain("https://example.com/path");
-		expect(meta).toContain("mailto:hi@example.com");
-		expect(meta).toContain("tel:+15551234567");
-		expect(meta).toContain("#section");
-		expect(meta).toContain("/path/to/page");
+		expect(meta).not.toContain('"nav-resources":');
+		expect(meta).not.toContain("/blog");
+		expect(meta).not.toContain("/changelog");
 	});
 
 	// ── Key collision handling ───────────────────────────────────────────────
@@ -623,89 +565,26 @@ describe("MetaGenerator.generateMetaFiles with rootInjection", () => {
 		expect(occurrences.length).toBe(1);
 	});
 
-	it("disambiguates two header.items with identical labels by appending an index", async () => {
-		const { generateMetaFiles } = await import("./MetaGenerator.js");
-		await generateMetaFiles(tempDir, undefined, {
-			headerItems: [
-				{ label: "Docs", url: "/a" },
-				{ label: "Docs", url: "/b" },
-			],
-		});
-		const meta = await readRootMeta();
-		// First gets `nav-docs`, second gets a suffixed key so both survive.
-		expect(meta).toContain('"nav-docs":');
-		expect(meta).toMatch(/"nav-docs-1":/);
-		expect(meta).toContain("/a");
-		expect(meta).toContain("/b");
-	});
-
-	it("disambiguates dropdown sub-items with identical labels so neither is silently overwritten", async () => {
-		const { generateMetaFiles } = await import("./MetaGenerator.js");
-		await generateMetaFiles(tempDir, undefined, {
-			headerItems: [
-				{
-					label: "Resources",
-					items: [
-						{ label: "Blog", url: "/a" },
-						{ label: "Blog", url: "/b" },
-					],
-				},
-			],
-		});
-		const meta = await readRootMeta();
-		// Both sub-items survive — first as `blog`, second with an index suffix.
-		expect(meta).toContain('"blog":{"title":"Blog","href":"/a"}');
-		expect(meta).toMatch(/"blog-1":\{"title":"Blog","href":"\/b"\}/);
-	});
-
-	it("falls back to nav-{idx} for header items whose label slugs to empty", async () => {
-		const { generateMetaFiles } = await import("./MetaGenerator.js");
-		await generateMetaFiles(tempDir, undefined, {
-			headerItems: [{ label: "!!!", url: "/symbol" }],
-		});
-		const meta = await readRootMeta();
-		expect(meta).toContain('"nav-0":');
-		expect(meta).toContain('"href":"/symbol"');
-	});
-
 	// ── Defensive: malformed header items ────────────────────────────────────
+	//
+	// site.json is parsed without shape validation, so malformed entries can
+	// reach injectRootNavEntries. They must not crash the build, even though
+	// header items no longer flow into _meta.js (the label-based override
+	// detection still iterates them).
 
-	it("skips malformed header items missing 'label' instead of crashing the build", async () => {
+	it("skips malformed header items missing 'label' without crashing the build", async () => {
 		const { generateMetaFiles } = await import("./MetaGenerator.js");
 		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-		// Cast to bypass type check — site.json is parsed without shape validation
-		// in production, so missing-label objects can reach injectRootNavEntries.
 		await generateMetaFiles(tempDir, undefined, {
+			apiSpecs: [{ specName: "petstore" }],
 			headerItems: [
 				{ url: "/no-label" } as unknown as { label: string; url: string },
-				{ label: "Valid", url: "/ok" },
+				{ label: "Documentation", url: "/docs" },
 			],
 		});
 		const meta = await readRootMeta();
-		expect(meta).toContain('"nav-valid":');
-		expect(meta).toContain("/ok");
-		expect(meta).not.toContain("/no-label");
-		expect(warnSpy).toHaveBeenCalled();
-		warnSpy.mockRestore();
-	});
-
-	it("skips malformed dropdown sub-items missing 'label' instead of crashing", async () => {
-		const { generateMetaFiles } = await import("./MetaGenerator.js");
-		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-		await generateMetaFiles(tempDir, undefined, {
-			headerItems: [
-				{
-					label: "Resources",
-					items: [
-						{ url: "/no-label" } as unknown as { label: string; url: string },
-						{ label: "Blog", url: "/blog" },
-					],
-				},
-			],
-		});
-		const meta = await readRootMeta();
-		expect(meta).toContain('"nav-resources":');
-		expect(meta).toContain('"blog":{"title":"Blog","href":"/blog"}');
+		// Valid override still suppresses __documentation.
+		expect(meta).not.toContain("__documentation");
 		expect(meta).not.toContain("/no-label");
 		expect(warnSpy).toHaveBeenCalled();
 		warnSpy.mockRestore();
@@ -715,13 +594,14 @@ describe("MetaGenerator.generateMetaFiles with rootInjection", () => {
 		const { generateMetaFiles } = await import("./MetaGenerator.js");
 		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 		await generateMetaFiles(tempDir, undefined, {
+			apiSpecs: [{ specName: "petstore" }],
 			headerItems: [
 				{ label: "   ", url: "/whitespace" },
-				{ label: "Real", url: "/real" },
+				{ label: "Documentation", url: "/docs" },
 			],
 		});
 		const meta = await readRootMeta();
-		expect(meta).toContain('"nav-real":');
+		expect(meta).not.toContain("__documentation");
 		expect(meta).not.toContain("/whitespace");
 		expect(warnSpy).toHaveBeenCalled();
 		warnSpy.mockRestore();

--- a/site-core/src/MetaGenerator.test.ts
+++ b/site-core/src/MetaGenerator.test.ts
@@ -6,7 +6,7 @@
  */
 
 import * as fc from "fast-check";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 // ─── toTitleCase unit tests ───────────────────────────────────────────────────
 
@@ -382,7 +382,7 @@ describe("injectRootNavEntries", () => {
 		expect(result.find((e) => e.key === DOC_HOME_NAV_KEY)).toBeUndefined();
 	});
 
-	it("materializes header.items as nav-{slug} keyed page-tab entries with sanitized urls", async () => {
+	it("does not materialize header.items into _meta.js (themes render them inline)", async () => {
 		const { injectRootNavEntries } = await import("./MetaGenerator.js");
 		const result = injectRootNavEntries([], {
 			headerItems: [
@@ -390,25 +390,28 @@ describe("injectRootNavEntries", () => {
 				{ label: "Blog", url: "javascript:alert(1)" },
 			],
 		});
-		const changelog = result.find((e) => e.key === "nav-changelog");
-		expect(changelog?.value).toEqual({ title: "Changelog", type: "page", href: "/changelog" });
-		const blog = result.find((e) => e.key === "nav-blog");
-		// javascript: URLs collapse to "#" via sanitizeUrl
-		expect((blog?.value as { href: string }).href).toBe("#");
+		// No nav-* entries should appear — themes own header presentation.
+		expect(result.find((e) => e.key.startsWith("nav-"))).toBeUndefined();
+		expect(result.find((e) => e.key === "nav-changelog")).toBeUndefined();
+		expect(result.find((e) => e.key === "nav-blog")).toBeUndefined();
 	});
 
-	it("skips header.items entries with missing or empty label", async () => {
-		const { injectRootNavEntries } = await import("./MetaGenerator.js");
+	it("warns on malformed header.items but does not crash override detection", async () => {
+		const { DOC_HOME_NAV_KEY, injectRootNavEntries } = await import("./MetaGenerator.js");
+		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 		const result = injectRootNavEntries([], {
+			apiSpecs: [{ specName: "petstore" }],
 			headerItems: [
 				{ label: "", url: "/empty" },
 				// biome-ignore lint/suspicious/noExplicitAny: forcing the malformed shape on purpose
 				{ url: "/missing" } as any,
-				{ label: "Real", url: "/real" },
+				{ label: "Documentation", url: "/docs" },
 			],
 		});
-		expect(result.find((e) => e.key === "nav-real")).toBeDefined();
-		expect(result.find((e) => e.key === "nav-empty")).toBeUndefined();
+		// Valid override entry still suppresses the auto-injected Documentation tab.
+		expect(result.find((e) => e.key === DOC_HOME_NAV_KEY)).toBeUndefined();
+		expect(warnSpy).toHaveBeenCalled();
+		warnSpy.mockRestore();
 	});
 });
 
@@ -465,7 +468,7 @@ describe("hasVisibleEntries", () => {
 // ─── injectRootNavEntries — header.items dropdowns and structurePages ──────────
 
 describe("injectRootNavEntries (dropdown + structure pages)", () => {
-	it("materializes a header.items entry with subitems as a type:menu dropdown", async () => {
+	it("does not materialize a header.items dropdown into _meta.js (themes render it inline)", async () => {
 		const { injectRootNavEntries } = await import("./MetaGenerator.js");
 		const result = injectRootNavEntries([], {
 			headerItems: [
@@ -478,32 +481,8 @@ describe("injectRootNavEntries (dropdown + structure pages)", () => {
 				},
 			],
 		});
-		const community = result.find((e) => e.key === "nav-community");
-		expect((community?.value as { type: string }).type).toBe("menu");
-		expect((community?.value as { items: Record<string, unknown> }).items).toEqual({
-			discord: { title: "Discord", href: "https://discord.example" },
-			github: { title: "GitHub", href: "https://github.example" },
-		});
-	});
-
-	it("skips dropdown sub-items with missing/empty label", async () => {
-		const { injectRootNavEntries } = await import("./MetaGenerator.js");
-		const result = injectRootNavEntries([], {
-			headerItems: [
-				{
-					label: "Community",
-					items: [
-						// biome-ignore lint/suspicious/noExplicitAny: forcing the malformed shape on purpose
-						{ url: "/missing-label" } as any,
-						{ label: "", url: "/empty-label" },
-						{ label: "Slack", url: "/slack" },
-					],
-				},
-			],
-		});
-		const community = result.find((e) => e.key === "nav-community");
-		const items = (community?.value as { items: Record<string, unknown> }).items;
-		expect(Object.keys(items)).toEqual(["slack"]);
+		expect(result.find((e) => e.key === "nav-community")).toBeUndefined();
+		expect(result.find((e) => e.key.startsWith("nav-"))).toBeUndefined();
 	});
 
 	it("emits structurePages as type:page entries when not labelled like a reserved injection", async () => {

--- a/site-core/src/MetaGenerator.ts
+++ b/site-core/src/MetaGenerator.ts
@@ -17,7 +17,6 @@
  * entry lists produced here.
  */
 
-import { sanitizeUrl } from "./Sanitize.js";
 import type { HeaderItem, SidebarItemValue } from "./Types.js";
 
 // ─── Root-injection types ────────────────────────────────────────────────────
@@ -41,9 +40,12 @@ export interface RootInjectionInput {
 	/** Detected OpenAPI specs — drives the auto-injected `Documentation` + `API Reference` entries. */
 	apiSpecs?: RootApiSpec[];
 	/**
-	 * `site.json`'s `header.items`. Each entry is materialised as a root
-	 * `_meta.js` key so Nextra renders it as a native page-tab (with chevron
-	 * for `items`-bearing dropdowns) instead of custom JSX.
+	 * `site.json`'s `header.items`. Used **only** for override detection —
+	 * a customer-declared "Documentation" / "API Reference" label suppresses
+	 * the matching auto-injection. Items are **not** materialised into
+	 * `_meta.js`; themes render header items inline in their own `<Navbar>`
+	 * JSX, and emitting them here as well would surface every link twice
+	 * (theme row + Nextra's auto page-tabs strip).
 	 */
 	headerItems?: HeaderItem[];
 	/**
@@ -219,32 +221,8 @@ const DOCUMENTATION_LABELS = new Set(["documentation"]);
 const API_REFERENCE_LABELS = new Set(["api reference", "api"]);
 
 /**
- * Slugifies a header-item label into a stable `_meta.js` key. Uses a
- * `nav-` prefix to namespace customer-supplied entries so they cannot
- * collide with auto-injected `__documentation` / `__api-reference` /
- * `api-{slug}` keys, even via crafted labels.
- *
- * Falls back to `nav-${idx}` when slugification yields an empty string —
- * e.g. a label that was all punctuation.
- */
-function navKeyFromLabel(label: string, idx: number): string {
-	// The third replace collapses any run of hyphens to a single `-`, so the
-	// final trim can use `/^-|-$/g` (single char) rather than `/^-+|-+$/g`.
-	// Dropping the `+` quantifier defuses CodeQL's `js/polynomial-redos`
-	// finding: the previous pattern paired greedy `-+` against arbitrary
-	// label input, which scaled quadratically on adversarial repetition.
-	const slug = label
-		.toLowerCase()
-		.replace(/[^\w\s-]/g, "")
-		.replace(/\s+/g, "-")
-		.replace(/-+/g, "-")
-		.replace(/^-|-$/g, "");
-	return slug ? `nav-${slug}` : `nav-${idx}`;
-}
-
-/**
  * Returns a new entry list with auto-injected `Documentation` / `API Reference`
- * tabs and materialised `header.items` entries:
+ * tabs:
  *
  *   - `__documentation` page-tab linking to `/` whenever the customer has any
  *     specs and hasn't already declared a header item labelled "Documentation".
@@ -257,17 +235,17 @@ function navKeyFromLabel(label: string, idx: number): string {
  *     each spec is recorded as a hidden page-tab + a visible
  *     `__api-reference` dropdown (`type: "menu"`) whose `items` map is one
  *     sub-entry per spec.
- *   - User-supplied `header.items` are appended after the auto entries with
- *     `nav-{slug}` keys derived from the label so customer reordering is a
- *     no-op on the generated keys. URLs flow through `sanitizeUrl` —
- *     `javascript:` / `data:` URLs are clamped to `"#"`.
- *     A header item with a clashing label (Documentation / API / API
- *     Reference, case-insensitive) suppresses the matching auto injection —
- *     customer overrides win.
+ *
+ * Customer `header.items` are **not** materialised into `_meta.js` — each
+ * theme renders them inline in its own `<Navbar>` JSX. If both surfaces
+ * emitted them, every header link would appear twice (once in the theme
+ * navbar row, once in Nextra's auto page-links strip). Themes own header
+ * presentation end-to-end; `injectRootNavEntries` only consults
+ * `header.items` here for override detection (a customer-declared
+ * "Documentation" suppresses `__documentation`, etc.).
  *
  * Order matters: Nextra renders root tabs in `_meta.js` declaration order,
- * and we want `Documentation` first (primary anchor), `API Reference` next,
- * then user-supplied pages.
+ * and we want `Documentation` first (primary anchor), `API Reference` next.
  */
 export function injectRootNavEntries(existing: MetaEntry[], input: RootInjectionInput): MetaEntry[] {
 	const apiSpecs = input.apiSpecs ?? [];
@@ -351,84 +329,26 @@ export function injectRootNavEntries(existing: MetaEntry[], input: RootInjection
 		}
 	}
 
-	// User-supplied header items — coerced into Nextra page-tab shape with
-	// sanitised URLs and slug-derived keys (stable across reordering).
-	const usedNavKeys = new Set<string>();
-	headerItems.forEach((item, idx) => {
-		let key = navKeyFromLabel(item.label, idx);
-		// Defuse two `header.items` entries with the same label collapsing onto
-		// one key (Nextra reads the last definition wins; we'd rather keep all
-		// entries by appending an index suffix on collision).
-		if (usedNavKeys.has(key)) {
-			key = `${key}-${idx}`;
-		}
-		usedNavKeys.add(key);
-
-		if (item.items && item.items.length > 0) {
-			const items: Record<string, { title: string; href?: string }> = {};
-			const usedSubKeys = new Set<string>();
-			// Same defensive filter as the outer loop — `ExternalLink.label: string`
-			// is required at the type level but site.json shape isn't validated.
-			const validSubItems = item.items.filter((sub) => {
-				if (typeof sub?.label !== "string" || sub.label.trim() === "") {
-					console.warn(
-						`[jolli] Skipping header.items[].items entry with missing/empty 'label': ${JSON.stringify(sub)}`,
-					);
-					return false;
-				}
-				return true;
-			});
-			validSubItems.forEach((sub, subIdx) => {
-				// `navKeyFromLabel` always returns `nav-{slug}` or `nav-{idx}`, so
-				// after stripping the prefix we always have at least one character.
-				let subKey = navKeyFromLabel(sub.label, subIdx).replace(/^nav-/, "");
-				// Same dedup discipline as the outer header-items loop: two sub-items
-				// with the same label otherwise collapse to one entry (last wins).
-				if (usedSubKeys.has(subKey)) {
-					subKey = `${subKey}-${subIdx}`;
-				}
-				usedSubKeys.add(subKey);
-				// Mirror the outer-item url-defensive pattern: `ExternalLink.url` is
-				// required at the type level but site.json shape isn't validated, so a
-				// sub-item with a missing `url` would otherwise crash `sanitizeUrl`'s
-				// `url.trim()` call. Emit the entry without href when url is missing
-				// so the build doesn't blow up on a malformed config.
-				const subValue: { title: string; href?: string } = { title: sub.label };
-				if (sub.url) {
-					subValue.href = sanitizeUrl(sub.url);
-				}
-				items[subKey] = subValue;
-			});
-			injected.push({ key, value: { title: item.label, type: "menu", items } });
-		} else {
-			const value: Record<string, unknown> = { title: item.label, type: "page" };
-			if (item.url) {
-				value.href = sanitizeUrl(item.url);
-			}
-			injected.push({ key, value });
-		}
-	});
-
 	// Navigation pages — `type: "page"` for Nextra sidebar scoping, or
 	// `type: "menu"` for navbar dropdown pages.
 	// Nextra renders these as navbar links; pack CSS repositions them
 	// as a second-row tab bar with active underline via aria-current.
 	if (input.structurePages) {
+		const usedKeys = new Set<string>();
 		for (const sp of input.structurePages) {
-			if (!usedNavKeys.has(sp.key)) {
-				if (sp.type === "menu" && sp.menuItems) {
-					injected.push({
-						key: sp.key,
-						value: { title: sp.title, type: "menu", items: sp.menuItems },
-					});
-				} else {
-					injected.push({
-						key: sp.key,
-						value: { title: sp.title, type: "page", href: sp.href },
-					});
-				}
-				usedNavKeys.add(sp.key);
+			if (usedKeys.has(sp.key)) continue;
+			if (sp.type === "menu" && sp.menuItems) {
+				injected.push({
+					key: sp.key,
+					value: { title: sp.title, type: "menu", items: sp.menuItems },
+				});
+			} else {
+				injected.push({
+					key: sp.key,
+					value: { title: sp.title, type: "page", href: sp.href },
+				});
 			}
+			usedKeys.add(sp.key);
 		}
 	}
 
@@ -453,8 +373,8 @@ export function injectRootNavEntries(existing: MetaEntry[], input: RootInjection
 		return true;
 	});
 
-	// Non-structure injected entries (API specs, header items) should not
-	// duplicate existing keys.
+	// Non-structure injected entries (API specs, auto-Documentation) should
+	// not duplicate existing keys.
 	const existingKeys = new Set(filteredExisting.map((e) => e.key));
 	const filtered = injected.filter((e) => structureKeys.has(e.key) || !existingKeys.has(e.key));
 	return [...filtered, ...filteredExisting];


### PR DESCRIPTION
## Summary

- Themes already render `header.items` inline in their own `<Navbar>` JSX (`forge-nav-link` / `jolli-nav-link`), and the generator was simultaneously emitting the same entries into the root `_meta.js`. Nextra then surfaced them in its auto page-tabs strip, producing two copies of every header link on desktop. The forge theme papered over this with a CSS hide that only worked for `target="_blank"` links — relative hrefs leaked through, and menu dropdowns weren't covered by the rule at all.
- Drop the materialisation in `injectRootNavEntries` ([site-core/src/MetaGenerator.ts](site-core/src/MetaGenerator.ts) — the canonical implementation the CLI re-exports). The `header.items` collection still flows in so label-based override detection (a customer-declared "Documentation" / "API" / "API Reference" suppresses the matching auto-injection) keeps working, but nothing reaches `_meta.js`.
- Removed the now-unused `navKeyFromLabel` helper, the `sanitizeUrl` import (URL sanitisation now lives only in the themes' `layout.mjs`), and the `usedNavKeys` cross-tracking. Replaced with a local `usedKeys` set inside the `structurePages` block to preserve within-`structurePages` dedup.

## Why this approach over `display: "hidden"`

`display: "hidden"` would have been viable if it only filtered the navbar render. It doesn't — Nextra's `normalize-pages.js:175,191` applies `if (isHidden) continue;` **before** both `topLevelNavbarItems.push` and `directories.push`. `MobileNav`, `Sidebar`, and breadcrumbs all consume `directories`, so the two options are functionally identical on every downstream surface. The cleaner option wins.

## Known follow-ups (theme repo, not in this PR)

- The redundant CSS hide at `themes/forge/css.mjs:502-506` (`nav > div > a[target="_blank"]:not(.forge-nav-link)`) can be deleted — there are no page-strip duplicates to hide anymore.
- Themes hide their inline `.forge-nav-link` / `.jolli-nav-link` at BP1 (≤1099px) and previously relied on Nextra's mobile drawer to surface header items. With this change, the drawer no longer carries them. Themes need to either render `header.items` inside their own mobile drawer or stop hiding the inline links at narrow widths.

## ReverseCommand note

`ReverseCommand.extractHeaderItems` reads `type: "menu"` entries out of any `_meta.js` and emits them as `header.items` for a reconstructed `site.json`. With this change, a Jolli-built site → `jolli reverse` round-trip will no longer recover header items (the source `site.json` is still authoritative, so this only matters if you intentionally round-trip Jolli's own output). Third-party site migrations are unaffected — their `_meta.js` still contains native `type: "menu"` entries that get extracted as before. No existing tests cover this path; flagging in case round-trip fidelity matters.

## Test plan

- [x] `npm run all` at repo root: 77 VS Code test files / 2883 tests passed, 8 skipped. Lint clean. Coverage thresholds met (98.68% statements / 97.58% branches / 98.02% functions / 98.85% lines).
- [x] [site-core/src/MetaGenerator.test.ts](site-core/src/MetaGenerator.test.ts): `injectRootNavEntries` tests now assert no `nav-*` entries are emitted; malformed-`header.items` test rewritten to verify "warns but doesn't crash, and override detection still suppresses the auto-injected Documentation tab".
- [x] [cli/src/site/MetaGenerator.test.ts](cli/src/site/MetaGenerator.test.ts): override-wins tests now assert `.not.toContain('"nav-documentation":')`; negative-assertion tests confirm flat items and dropdowns are absent from `_meta.js`; URL-sanitisation / dedup / fallback-key tests removed (those code paths are gone); defensive malformed-input tests rewritten to verify "doesn't crash + override detection still works".
- [ ] After merge: pair with a themes-repo PR removing the CSS hide and adding mobile-drawer rendering of `header.items`.
