### PR TITLE
Normalize article href against inherited root (dedup + leading-slash)

### DIFF
--- a/cli/schemas/site-config.json
+++ b/cli/schemas/site-config.json
@@ -476,7 +476,7 @@
 				},
 				"href": {
 					"type": "string",
-					"description": "Path to the content. Resolved relative to the nearest ancestor root."
+					"description": "Path to the content, relative to the inherited root (page.root + enclosing group.root). Two normalization rules: (1) a leading '/' is equivalent to no leading slash — both mean 'relative to the inherited root', never the OS filesystem root, so '/intro' and 'intro' are the same. (2) If the href starts with segments that duplicate the end of the inherited root (e.g. href: 'guides/intro' inside group{root:'guides'} under page{root:'/docs'}), the duplicated prefix is stripped — preventing a phantom intermediate folder in the sidebar."
 				},
 				"source": {
 					"type": "string",

--- a/cli/src/site/ContentPlanner.ts
+++ b/cli/src/site/ContentPlanner.ts
@@ -4,6 +4,7 @@ import { dirname, join } from "node:path";
 import { hasIncompatibleImports, rewriteRelativeImagePaths, stripIncompatibleContent } from "./ContentMirror.js";
 import { slugify } from "./openapi/Slug.js";
 import type { ContentRules } from "./renderer/SiteRenderer.js";
+import { normalizeHrefSegments } from "./StructureParser.js";
 import type { Navigation, NavigationArticle, NavigationGroup, NavigationPage } from "./Types.js";
 
 export interface PlannedMarkdownPage {
@@ -99,6 +100,7 @@ function addArticlePlan(
 	article: NavigationArticle,
 	sourceDir: string,
 	targetDir: string,
+	inheritedRootSegs: ReadonlyArray<string>,
 	availableMarkdownFiles: string[],
 	pages: PlannedMarkdownPage[],
 ): void {
@@ -106,13 +108,14 @@ function addArticlePlan(
 		return;
 	}
 
-	const href = article.href.replace(/^\/+/, "");
-	const sourceBase = article.source
-		? article.source
-		: article.href.startsWith("/")
-			? href
-			: joinSegments(sourceDir, href);
-	const targetBase = article.href.startsWith("/") ? href : joinSegments(targetDir, href);
+	// Normalize the href against the inherited root: leading-slash is
+	// equivalent to no slash, and any prefix duplicating the end of the
+	// inherited root is stripped. Removes the source/target double-pathing
+	// that occurred when an author repeated the group's root inside `href`.
+	const hrefSegs = normalizeHrefSegments(article.href, inheritedRootSegs);
+	const href = hrefSegs.join("/");
+	const sourceBase = article.source ? article.source : joinSegments(sourceDir, href);
+	const targetBase = joinSegments(targetDir, href);
 
 	// Articles with children but no corresponding source file are folder-only
 	// entries (collapsible sidebar groups). Skip source resolution for these —
@@ -147,7 +150,7 @@ function addArticlePlan(
 	// Per the spec, href resolution walks up to the nearest ancestor `root`.
 	if (article.articles?.length) {
 		for (const child of article.articles) {
-			addArticlePlan(child, sourceDir, targetDir, availableMarkdownFiles, pages);
+			addArticlePlan(child, sourceDir, targetDir, inheritedRootSegs, availableMarkdownFiles, pages);
 		}
 	}
 }
@@ -156,6 +159,7 @@ function addNodesPlan(
 	nodes: Array<NavigationGroup | NavigationArticle>,
 	sourceDir: string,
 	targetDir: string,
+	inheritedRootSegs: ReadonlyArray<string>,
 	availableMarkdownFiles: string[],
 	pages: PlannedMarkdownPage[],
 ): void {
@@ -166,15 +170,30 @@ function addNodesPlan(
 			// path: the schema treats a group as a sidebar separator, and the
 			// generated build tree is flattened so Nextra renders the articles
 			// at the parent level without a stray `<group.root>` folder.
+			//
+			// `node.root` IS however extended onto `inheritedRootSegs` so an
+			// author who repeats it inside an article's `href`
+			// (e.g. `href: "guides/intro"` inside `group{root: "guides"}`)
+			// gets the redundant prefix stripped instead of producing a
+			// double-pathed source lookup.
 			const childSourceDir = node.sourceRoot
 				? node.sourceRoot.replace(/^\/+|\/+$/g, "")
 				: node.root
 					? joinSegments(sourceDir, node.root)
 					: sourceDir;
-			addNodesPlan(node.content, childSourceDir, targetDir, availableMarkdownFiles, pages);
+			const groupRootSegs = (node.root ?? "").split("/").filter(Boolean);
+			const childInheritedRootSegs = [...inheritedRootSegs, ...groupRootSegs];
+			addNodesPlan(
+				node.content,
+				childSourceDir,
+				targetDir,
+				childInheritedRootSegs,
+				availableMarkdownFiles,
+				pages,
+			);
 			continue;
 		}
-		addArticlePlan(node, sourceDir, targetDir, availableMarkdownFiles, pages);
+		addArticlePlan(node, sourceDir, targetDir, inheritedRootSegs, availableMarkdownFiles, pages);
 	}
 }
 
@@ -230,11 +249,12 @@ export function validateNavigationPaths(
 			if (page.type === "menu" || page.openapi) continue;
 			const root = (page.root ?? `/${slugify(page.page)}`).replace(/^\/+/, "");
 			if (page.content) {
-				checkNodes(page.content, root, availableMarkdownFiles, mismatches);
+				const pageRootSegs = root.split("/").filter(Boolean);
+				checkNodes(page.content, root, pageRootSegs, availableMarkdownFiles, mismatches);
 			}
 		}
 	} else {
-		checkNodes(navigation as (NavigationGroup | NavigationArticle)[], "", availableMarkdownFiles, mismatches);
+		checkNodes(navigation as (NavigationGroup | NavigationArticle)[], "", [], availableMarkdownFiles, mismatches);
 	}
 
 	return mismatches;
@@ -243,17 +263,20 @@ export function validateNavigationPaths(
 function checkNodes(
 	nodes: (NavigationGroup | NavigationArticle)[],
 	parentRoot: string,
+	inheritedRootSegs: ReadonlyArray<string>,
 	files: string[],
 	mismatches: NavigationMismatch[],
 ): void {
 	for (const node of nodes) {
 		if ("group" in node) {
 			const groupRoot = node.root ? joinSegments(parentRoot, node.root) : parentRoot;
+			const groupRootSegs = (node.root ?? "").split("/").filter(Boolean);
+			const childInheritedRootSegs = [...inheritedRootSegs, ...groupRootSegs];
 			for (const article of node.content) {
-				checkArticle(article, groupRoot, files, mismatches);
+				checkArticle(article, groupRoot, childInheritedRootSegs, files, mismatches);
 			}
 		} else {
-			checkArticle(node, parentRoot, files, mismatches);
+			checkArticle(node, parentRoot, inheritedRootSegs, files, mismatches);
 		}
 	}
 }
@@ -261,19 +284,21 @@ function checkNodes(
 function checkArticle(
 	article: NavigationArticle,
 	root: string,
+	inheritedRootSegs: ReadonlyArray<string>,
 	files: string[],
 	mismatches: NavigationMismatch[],
 ): void {
 	if (article.type === "external") return;
 
-	const href = article.href.replace(/^\/+/, "");
-	const resolved = article.href.startsWith("/") ? href : joinSegments(root, href);
+	const hrefSegs = normalizeHrefSegments(article.href, inheritedRootSegs);
+	const href = hrefSegs.join("/");
+	const resolved = joinSegments(root, href);
 
 	// Skip if it has children but no file (folder-only entry)
 	if (article.articles?.length && !hasSourceMarkdown(resolved, files)) {
 		// Still check children
 		for (const child of article.articles) {
-			checkArticle(child, root, files, mismatches);
+			checkArticle(child, root, inheritedRootSegs, files, mismatches);
 		}
 		return;
 	}
@@ -282,7 +307,7 @@ function checkArticle(
 	if (hasSourceMarkdown(resolved, files)) {
 		if (article.articles) {
 			for (const child of article.articles) {
-				checkArticle(child, root, files, mismatches);
+				checkArticle(child, root, inheritedRootSegs, files, mismatches);
 			}
 		}
 		return;
@@ -323,7 +348,7 @@ export function buildNavigationContentPlan(
 
 	const isPageMode = "page" in navigation[0];
 	if (!isPageMode) {
-		addNodesPlan(navigation as (NavigationGroup | NavigationArticle)[], "", "", availableMarkdownFiles, pages);
+		addNodesPlan(navigation as (NavigationGroup | NavigationArticle)[], "", "", [], availableMarkdownFiles, pages);
 		validatePlanConflicts(pages);
 		return { pages };
 	}
@@ -334,7 +359,8 @@ export function buildNavigationContentPlan(
 		}
 		const pageRoot = (pg.root ?? `/${slugify(pg.page)}`).replace(/^\/+/, "");
 		const sourceRoot = pg.sourceRoot ? pg.sourceRoot.replace(/^\/+|\/+$/g, "") : pageRoot;
-		addNodesPlan(pg.content, sourceRoot, pageRoot, availableMarkdownFiles, pages);
+		const pageRootSegs = pageRoot.split("/").filter(Boolean);
+		addNodesPlan(pg.content, sourceRoot, pageRoot, pageRootSegs, availableMarkdownFiles, pages);
 	}
 
 	validatePlanConflicts(pages);

--- a/cli/src/site/StructureParser.test.ts
+++ b/cli/src/site/StructureParser.test.ts
@@ -736,3 +736,162 @@ describe("edge cases", () => {
 		expect(result.sidebar["/guides/a"]).toBeUndefined();
 	});
 });
+
+// ─── Href normalization (dedup + leading-slash equivalence) ──────────────────
+
+describe("href normalization", () => {
+	it("dedups article href that duplicates the enclosing group root (page mode)", () => {
+		// The classic "phantom folder" case. Author put `guides/` inside the
+		// href even though the group already declares `root: "guides"`. Without
+		// dedup, this used to emit a `guides` folder entry in /docs/_meta.js
+		// AND a nested sidebar["/docs/guides"] map — producing a visible
+		// phantom collapsible folder next to the group's separator.
+		const nav: NavigationPage[] = [
+			{
+				page: "Get Started",
+				root: "/docs",
+				content: [
+					{
+						group: "Guides",
+						root: "guides",
+						content: [
+							{ article: "Introduction", href: "guides/introduction" } as NavigationArticle,
+							{ article: "Authentication", href: "guides/authentication" } as NavigationArticle,
+						],
+					} as NavigationGroup,
+				],
+			},
+		];
+		const result = parseNavigation(nav);
+		const docs = result.sidebar["/docs"];
+		expect(docs["__group-guides"]).toEqual({ type: "separator", title: "Guides" });
+		expect(docs.introduction).toBe("Introduction");
+		expect(docs.authentication).toBe("Authentication");
+		expect(docs.guides).toBeUndefined();
+		expect(result.sidebar["/docs/guides"]).toBeUndefined();
+	});
+
+	it("treats leading-slash href as equivalent to no leading slash within the inherited root", () => {
+		// `/intro` and `intro` should mean the same thing — both relative to
+		// the inherited root, never the OS filesystem root.
+		const navWithSlash: NavigationPage[] = [
+			{ page: "Docs", root: "/docs", content: [{ article: "Intro", href: "/intro" } as NavigationArticle] },
+		];
+		const navWithoutSlash: NavigationPage[] = [
+			{ page: "Docs", root: "/docs", content: [{ article: "Intro", href: "intro" } as NavigationArticle] },
+		];
+		const a = parseNavigation(navWithSlash);
+		const b = parseNavigation(navWithoutSlash);
+		expect(a.sidebar).toEqual(b.sidebar);
+		expect(a.sidebar["/docs"].intro).toBe("Intro");
+	});
+
+	it("dedups full page+group root from the start of an article href", () => {
+		// Author redundantly spelled out the entire inherited path. Strip the
+		// whole prefix and the article becomes a single-segment entry.
+		const nav: NavigationPage[] = [
+			{
+				page: "Get Started",
+				root: "/docs",
+				content: [
+					{
+						group: "Guides",
+						root: "guides",
+						content: [{ article: "Introduction", href: "docs/guides/introduction" } as NavigationArticle],
+					} as NavigationGroup,
+				],
+			},
+		];
+		const result = parseNavigation(nav);
+		expect(result.sidebar["/docs"].introduction).toBe("Introduction");
+		expect(result.sidebar["/docs"].docs).toBeUndefined();
+		expect(result.sidebar["/docs/guides"]).toBeUndefined();
+		expect(result.sidebar["/docs/docs"]).toBeUndefined();
+	});
+
+	it("does NOT dedup when the href prefix doesn't match the inherited root", () => {
+		// `deployment/docker` inside a group with root "guides" should still
+		// produce a `deployment` intermediate folder — the author genuinely
+		// wants nested structure here, not accidental duplication.
+		const nav: NavigationPage[] = [
+			{
+				page: "Get Started",
+				root: "/docs",
+				content: [
+					{
+						group: "Guides",
+						root: "guides",
+						content: [
+							{ article: "Docker", href: "deployment/docker" } as NavigationArticle,
+							{ article: "Kubernetes", href: "deployment/kubernetes" } as NavigationArticle,
+						],
+					} as NavigationGroup,
+				],
+			},
+		];
+		const result = parseNavigation(nav);
+		expect(result.sidebar["/docs"].deployment).toBe("deployment");
+		expect(result.sidebar["/docs/deployment"].docker).toBe("Docker");
+		expect(result.sidebar["/docs/deployment"].kubernetes).toBe("Kubernetes");
+	});
+
+	it("strips only one dedup pass even when href intentionally repeats a segment", () => {
+		// `guides/guides/intro` inside group{root:"guides"} strips ONE leading
+		// `guides`; the remaining `guides/intro` is treated as authored. The
+		// rule stays conservative: only one duplication is assumed.
+		const nav: NavigationPage[] = [
+			{
+				page: "Docs",
+				root: "/docs",
+				content: [
+					{
+						group: "Guides",
+						root: "guides",
+						content: [{ article: "Intro", href: "guides/guides/intro" } as NavigationArticle],
+					} as NavigationGroup,
+				],
+			},
+		];
+		const result = parseNavigation(nav);
+		expect(result.sidebar["/docs"].guides).toBe("guides");
+		expect(result.sidebar["/docs/guides"].intro).toBe("Intro");
+	});
+});
+
+describe("normalizeHrefSegments", () => {
+	it("returns the href as-is when the inherited root is empty", async () => {
+		const { normalizeHrefSegments } = await import("./StructureParser.js");
+		expect(normalizeHrefSegments("intro", [])).toEqual(["intro"]);
+		expect(normalizeHrefSegments("/intro", [])).toEqual(["intro"]);
+		expect(normalizeHrefSegments("a/b/c", [])).toEqual(["a", "b", "c"]);
+	});
+
+	it("strips a leading slash regardless of inherited root", async () => {
+		const { normalizeHrefSegments } = await import("./StructureParser.js");
+		expect(normalizeHrefSegments("/intro", ["docs"])).toEqual(["intro"]);
+		expect(normalizeHrefSegments("/a/b", ["docs", "guides"])).toEqual(["a", "b"]);
+	});
+
+	it("strips a matching trailing segment of inherited root from the start of href", async () => {
+		const { normalizeHrefSegments } = await import("./StructureParser.js");
+		expect(normalizeHrefSegments("guides/intro", ["docs", "guides"])).toEqual(["intro"]);
+		expect(normalizeHrefSegments("docs/intro", ["docs"])).toEqual(["intro"]);
+	});
+
+	it("strips the full inherited root when the href spells it out completely", async () => {
+		const { normalizeHrefSegments } = await import("./StructureParser.js");
+		expect(normalizeHrefSegments("docs/guides/intro", ["docs", "guides"])).toEqual(["intro"]);
+	});
+
+	it("does not strip when no leading segment of href matches the inherited root tail", async () => {
+		const { normalizeHrefSegments } = await import("./StructureParser.js");
+		expect(normalizeHrefSegments("deployment/docker", ["docs", "guides"])).toEqual(["deployment", "docker"]);
+		expect(normalizeHrefSegments("intro", ["docs", "guides"])).toEqual(["intro"]);
+	});
+
+	it("returns an empty array when href is exactly the inherited root", async () => {
+		const { normalizeHrefSegments } = await import("./StructureParser.js");
+		expect(normalizeHrefSegments("docs/guides", ["docs", "guides"])).toEqual([]);
+		expect(normalizeHrefSegments("/docs", ["docs"])).toEqual([]);
+	});
+});

--- a/cli/src/site/StructureParser.ts
+++ b/cli/src/site/StructureParser.ts
@@ -186,6 +186,7 @@ function parseContent(
 	sidebar: SidebarOverrides,
 ): void {
 	const entries: Record<string, SidebarItemValue> = {};
+	const pathPrefixSegs = pathPrefix.split("/").filter(Boolean);
 
 	for (const node of nodes) {
 		if (isGroup(node)) {
@@ -195,14 +196,22 @@ function parseContent(
 			// the URL path. The schema intent (group = separator) wins; the
 			// generated build tree is flattened so articles inside the group
 			// live at the parent level and Nextra renders them naturally.
+			//
+			// `node.root` IS used here, however, to extend the "inherited
+			// root" passed into href normalization, so an author who repeats
+			// the group's root inside `href` (e.g. `href: "guides/intro"`
+			// inside `group{root: "guides"}`) gets the redundant prefix
+			// stripped instead of producing a phantom intermediate folder.
 			const groupSlug = slugify(node.group);
 			entries[`__group-${groupSlug}`] = { type: "separator" as const, title: node.group };
 
+			const groupRootSegs = (node.root ?? "").split("/").filter(Boolean);
+			const inheritedRootSegs = [...pathPrefixSegs, ...groupRootSegs];
 			for (const article of node.content) {
-				addArticle(article, pathPrefix, entries, sidebar);
+				addArticle(article, pathPrefix, inheritedRootSegs, entries, sidebar);
 			}
 		} else {
-			addArticle(node, pathPrefix, entries, sidebar);
+			addArticle(node, pathPrefix, pathPrefixSegs, entries, sidebar);
 		}
 	}
 
@@ -216,6 +225,7 @@ function parseContent(
 function addArticle(
 	article: NavigationArticle,
 	resolveRoot: string,
+	inheritedRootSegs: string[],
 	entries: Record<string, SidebarItemValue>,
 	sidebar: SidebarOverrides,
 ): void {
@@ -227,7 +237,7 @@ function addArticle(
 		return;
 	}
 
-	const hrefSegments = article.href.split("/").filter(Boolean);
+	const hrefSegments = normalizeHrefSegments(article.href, inheritedRootSegs);
 	// When the article has nested children and `expanded` is set explicitly,
 	// emit the _meta.js entry as an object with `theme.collapsed` so Nextra
 	// honors the customer's open/closed intent regardless of
@@ -241,7 +251,7 @@ function addArticle(
 	if (hrefSegments.length === 1) {
 		// Single segment — goes directly into the current entries
 		entries[hrefSegments[0]] = entryValue;
-	} else {
+	} else if (hrefSegments.length > 1) {
 		// Multi-segment href (e.g. "real-time-apps/part1") — the first segment
 		// is a directory reference in the current _meta.js, and the last segment
 		// goes into that directory's _meta.js.
@@ -267,11 +277,15 @@ function addArticle(
 	// Multi-segment children write directly to sidebar via the multi-segment
 	// logic above, so they bypass subEntries.
 	if (article.articles?.length) {
-		const parentDir = article.href.startsWith("/")
-			? article.href
-			: joinPath(resolveRoot, hrefSegments.length === 1 ? hrefSegments[0] : hrefSegments.slice(0, -1).join("/"));
+		const parentDir =
+			hrefSegments.length === 0
+				? resolveRoot
+				: joinPath(
+						resolveRoot,
+						hrefSegments.length === 1 ? hrefSegments[0] : hrefSegments.slice(0, -1).join("/"),
+					);
 		for (const child of article.articles) {
-			const childSegments = child.href.split("/").filter(Boolean);
+			const childSegments = normalizeHrefSegments(child.href, inheritedRootSegs);
 			if (childSegments.length === 1) {
 				// Single-segment child → goes into the parent's directory _meta.js
 				if (!sidebar[parentDir]) {
@@ -281,18 +295,68 @@ function addArticle(
 				// Recurse for children of children
 				if (child.articles?.length) {
 					for (const grandchild of child.articles) {
-						addArticle(grandchild, resolveRoot, {} as Record<string, SidebarItemValue>, sidebar);
+						addArticle(
+							grandchild,
+							resolveRoot,
+							inheritedRootSegs,
+							{} as Record<string, SidebarItemValue>,
+							sidebar,
+						);
 					}
 				}
 			} else {
 				// Multi-segment child → writes directly to sidebar via addArticle
-				addArticle(child, resolveRoot, entries, sidebar);
+				addArticle(child, resolveRoot, inheritedRootSegs, entries, sidebar);
 			}
 		}
 	}
 }
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
+
+/**
+ * Normalizes an article's `href` into a list of path segments, relative
+ * to the **inherited root** (the path stack built from all ancestor `root`
+ * fields — i.e. the page's `root` plus the enclosing group's `root`).
+ *
+ * Two rules:
+ *
+ * 1. **Leading slash is equivalent to no leading slash.** `/foo` ≡ `foo`.
+ *    Both mean "relative to the inherited root", never the OS filesystem
+ *    root. This falls out of `split("/").filter(Boolean)` automatically.
+ *
+ * 2. **Prefix dedup.** If the start of `href` duplicates the end of the
+ *    inherited root, strip the duplicated segments. For example, inside
+ *    a group with `root: "guides"` under a page with `root: "/docs"`,
+ *    the inherited root is `["docs", "guides"]`. An href of
+ *    `"guides/introduction"` has its leading `guides` segment stripped
+ *    (the trailing `guides` of the inherited root matches the leading
+ *    `guides` of the href), yielding `["introduction"]`. Without this
+ *    rule the duplicated segment would create a phantom intermediate
+ *    folder in the sidebar tree.
+ *
+ * The algorithm: find the largest `k` such that the first `k` segments
+ * of `href` equal the last `k` segments of the inherited root, and slice
+ * those off. Only one matching prefix is stripped — duplicates beyond
+ * the inherited root (e.g. `"guides/guides/intro"`) are left alone.
+ *
+ * Exported for unit testing.
+ */
+export function normalizeHrefSegments(href: string, inheritedRootSegs: ReadonlyArray<string>): string[] {
+	const segs = href.split("/").filter(Boolean);
+	const maxK = Math.min(segs.length, inheritedRootSegs.length);
+	for (let k = maxK; k >= 1; k--) {
+		let match = true;
+		for (let i = 0; i < k; i++) {
+			if (segs[i] !== inheritedRootSegs[inheritedRootSegs.length - k + i]) {
+				match = false;
+				break;
+			}
+		}
+		if (match) return segs.slice(k);
+	}
+	return segs;
+}
 
 function slugify(title: string): string {
 	return title

--- a/cli/src/site/Types.ts
+++ b/cli/src/site/Types.ts
@@ -283,6 +283,22 @@ export interface AnchorItem {
 /**
  * An article is a navigable sidebar item. Can nest child articles as a
  * collapsible dropdown.
+ *
+ * `href` semantics — two normalization rules apply before the path is used
+ * anywhere downstream (sidebar tree, source lookup, target write, validation):
+ *
+ *   1. **Leading slash is equivalent to no leading slash.** `/intro` and
+ *      `intro` mean the same thing — both are interpreted as relative to
+ *      the inherited root, never the OS filesystem root.
+ *   2. **Prefix dedup against the inherited root.** The inherited root at
+ *      any point is the concatenation of all ancestor `root` fields —
+ *      `page.root` plus the enclosing `group.root` if any. If the start of
+ *      `href` duplicates the end of that root (e.g. `href: "guides/intro"`
+ *      inside `group{root:"guides"}` under `page{root:"/docs"}`), the
+ *      duplicated segments are stripped. This stops the duplicated prefix
+ *      from creating a phantom intermediate folder in the sidebar.
+ *
+ * See `normalizeHrefSegments` in `StructureParser.ts` for the exact rule.
  */
 export interface NavigationArticle {
 	article: string;


### PR DESCRIPTION
## Summary

Two normalization rules added to `article.href`, applied once in the navigation parser and reused by sidebar generation, content planning, and the mismatch validator:

- **Leading-slash equivalence** — `/intro` ≡ `intro`. Both mean "relative to the inherited root" (`page.root` + enclosing `group.root`), never the OS filesystem root. The previous `article.href.startsWith("/")` branches in `addArticlePlan` / `checkArticle` are gone.
- **Prefix dedup against the inherited root** — if `href` starts with segments that duplicate the *end* of the inherited root, strip them. So `href: "guides/introduction"` inside `group{root:"guides"}` under `page{root:"/docs"}` normalizes to `["introduction"]` instead of producing a phantom `guides` folder next to the group separator. Only one matching prefix is stripped; `guides/guides/intro` keeps the second `guides/`.

The rule extends the schema-intent principle already established for `group.root` (sidebar marker, not URL prefix): when an author repeats the group's source-location prefix inside `href`, the parser treats it as the same path, not as additional nesting. Multi-segment hrefs that *don't* match the inherited-root tail (e.g. `deployment/docker` inside `group{root:"guides"}`) keep the existing behavior — no dedup, intermediate folder created as authored.

`normalizeHrefSegments` is exported from `StructureParser.ts` so `ContentPlanner.ts` reuses the exact same normalization across source lookup, target write, and validation. `inheritedRootSegs` threads through `addNodesPlan` / `checkNodes` alongside the existing `sourceDir` / `targetDir` — no new state.

## Before / after on a typical phantom-folder site.json

```json
{ "page": "Get Started", "root": "/docs", "content": [
  { "group": "Guides", "root": "guides", "content": [
    { "article": "Introduction", "href": "guides/introduction" },
    { "article": "Authentication", "href": "guides/authentication" }
  ]}
]}
```

**Before:** sidebar shows `━ Guides ━` separator **plus a phantom `guides` folder** containing the articles.

**After:** `Introduction` and `Authentication` render flat under the `━ Guides ━` separator. Source still resolves to `docs/guides/introduction.mdx` (via `group.root` source hint), target written to `content/docs/introduction.mdx`.

## Test plan

- [x] 11 new tests in `StructureParser.test.ts`: 5 integration scenarios (group-root dedup, full-root dedup, no-match passthrough, leading-slash equivalence, single-pass conservatism) + 6 direct unit tests for `normalizeHrefSegments`
- [x] All existing navigation tests (44 → 55 in this file) pass — multi-segment hrefs, external links inside rooted groups, `expanded` folder collapse, etc.
- [x] `npm run all` clean: build → lint → test → coverage (CLI 98.7% stmts, 97.23% branches, 98.62% funcs, 99.05% lines)
- [ ] Validated against a real customer site.json with multi-segment hrefs that duplicate group root