### PR TITLE
CLI: externalize @jolli.ai/site-core with lazy-load + install prompt

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -67,13 +67,15 @@
 	},
 	"dependencies": {
 		"@anthropic-ai/sdk": "^0.39.0",
-		"@jolli.ai/site-core": "^0.1.0",
 		"@mdx-js/mdx": "^3.1.1",
 		"chokidar": "^4.0.0",
 		"commander": "^13.1.0",
 		"open": "^11.0.0",
 		"semver": "^7.8.1",
 		"yaml": "^2.6.1"
+	},
+	"optionalDependencies": {
+		"@jolli.ai/site-core": "^0.1.0"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "2.2.6",

--- a/cli/src/Cli.ts
+++ b/cli/src/Cli.ts
@@ -3,16 +3,41 @@
 /**
  * Jolli Memory CLI — bin entry point.
  *
- * Thin shim: delegates all logic to `Api.ts` so the same code is reachable
- * both as a CLI and as a programmatic import (`@jolli.ai/cli/api`).
+ * Two-phase startup so a missing `@jolli.ai/site-core` produces a clean
+ * install prompt instead of an ERR_MODULE_NOT_FOUND crash:
+ *
+ *   1. Statically import only `EnsureSiteCore` (which itself does NOT
+ *      import site-core — it probes via `require.resolve`).
+ *   2. Run `ensureSiteCoreInstalled` *before* any other import. On TTY
+ *      we prompt + spawn `npm install -g`; non-TTY prints the manual
+ *      command and exits.
+ *   3. Only after site-core is reachable do we dynamically import
+ *      `Api.ts` and `Logger.ts`. Those transitively pull site command
+ *      modules whose own imports of `@jolli.ai/site-core` would
+ *      otherwise fail at module load.
+ *
+ * Programmatic callers that import `@jolli.ai/cli/api` directly skip
+ * this binary entirely and reach `Api.ts`'s exports without the prompt
+ * — they're expected to provide site-core themselves.
  */
 
-import { main } from "./Api.js";
-import { setSilentConsole } from "./Logger.js";
+import { ensureSiteCoreInstalled } from "./site/EnsureSiteCore.js";
 
-// Auto-execute when run as a script (skip in test environment).
 /* v8 ignore start */
 if (!process.env.VITEST) {
+	void runCli();
+}
+/* v8 ignore stop */
+
+async function runCli(): Promise<void> {
+	await ensureSiteCoreInstalled();
+
+	// Lazy-load so the static imports inside Api.ts (and its transitive
+	// site command modules) only fire after site-core is guaranteed
+	// resolvable. See module-level docstring above.
+	const { main } = await import("./Api.js");
+	const { setSilentConsole } = await import("./Logger.js");
+
 	// Suppress info/debug log output to stderr in CLI mode — users only need
 	// to see command results (via console.log), not internal diagnostics.
 	// warn/error still go to stderr; all levels still write to debug.log.
@@ -20,9 +45,11 @@ if (!process.env.VITEST) {
 	// callers of `main()` (e.g. embedders) don't pick up the global side
 	// effect by accident.
 	setSilentConsole(true);
-	main().catch((error: unknown) => {
+
+	try {
+		await main();
+	} catch (error: unknown) {
 		console.error("Fatal error:", error);
 		process.exit(1);
-	});
+	}
 }
-/* v8 ignore stop */

--- a/cli/src/site/EnsureSiteCore.test.ts
+++ b/cli/src/site/EnsureSiteCore.test.ts
@@ -1,0 +1,236 @@
+import { EventEmitter } from "node:events";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// ─── Module mocks ───────────────────────────────────────────────────────────
+
+const mockResolve = vi.fn<(specifier: string) => string>();
+const mockCreateRequire = vi.fn(() => ({ resolve: mockResolve }));
+const mockSpawn = vi.fn();
+const mockQuestion = vi.fn();
+const mockClose = vi.fn();
+const mockCreateInterface = vi.fn(() => ({ question: mockQuestion, close: mockClose }));
+
+vi.mock("node:module", () => ({
+	createRequire: mockCreateRequire,
+}));
+
+vi.mock("../util/Subprocess.js", () => ({
+	spawnHidden: mockSpawn,
+}));
+
+vi.mock("node:readline", () => ({
+	createInterface: mockCreateInterface,
+}));
+
+// ─── Test helpers ───────────────────────────────────────────────────────────
+
+function buildSpawnChild(): EventEmitter {
+	// `spawn` returns a ChildProcess that emits 'exit' / 'error'. We don't
+	// need the full surface area — an EventEmitter that we control via
+	// `emit("exit", code)` is enough.
+	return new EventEmitter();
+}
+
+function expectExit(): { exitMock: ReturnType<typeof vi.spyOn> } {
+	// We throw a tagged sentinel from the mock so the function under test
+	// halts where the real `process.exit` would. The assertion in each test
+	// just looks for exit code 1.
+	const exitMock = vi.spyOn(process, "exit").mockImplementation((code) => {
+		throw new Error(`__exit_${code}__`);
+	});
+	return { exitMock };
+}
+
+function silenceStderr(): ReturnType<typeof vi.spyOn> {
+	return vi.spyOn(console, "error").mockImplementation(() => undefined);
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe("isSiteCoreInstalled", () => {
+	beforeEach(() => {
+		vi.resetModules();
+		mockResolve.mockReset();
+	});
+
+	it("returns true when require.resolve succeeds", async () => {
+		mockResolve.mockReturnValue("/fake/path/index.js");
+		const { isSiteCoreInstalled } = await import("./EnsureSiteCore.js");
+		expect(isSiteCoreInstalled()).toBe(true);
+		expect(mockResolve).toHaveBeenCalledWith("@jolli.ai/site-core");
+	});
+
+	it("returns false when require.resolve throws MODULE_NOT_FOUND", async () => {
+		mockResolve.mockImplementation(() => {
+			const err = new Error("Cannot find module '@jolli.ai/site-core'");
+			(err as NodeJS.ErrnoException).code = "MODULE_NOT_FOUND";
+			throw err;
+		});
+		const { isSiteCoreInstalled } = await import("./EnsureSiteCore.js");
+		expect(isSiteCoreInstalled()).toBe(false);
+	});
+
+	it("returns false on any other resolve error too (avoid leaking exceptions)", async () => {
+		mockResolve.mockImplementation(() => {
+			throw new Error("unexpected resolve error");
+		});
+		const { isSiteCoreInstalled } = await import("./EnsureSiteCore.js");
+		// Defensive — production code shouldn't crash if Node hands back an
+		// odd error subclass. `try/catch` in the implementation handles this.
+		expect(isSiteCoreInstalled()).toBe(false);
+	});
+});
+
+describe("ensureSiteCoreInstalled — already installed", () => {
+	beforeEach(() => {
+		vi.resetModules();
+		mockResolve.mockReset();
+		mockSpawn.mockReset();
+		mockCreateInterface.mockClear();
+	});
+
+	it("returns immediately, no prompt, no spawn", async () => {
+		mockResolve.mockReturnValue("/fake/path/index.js");
+		const { ensureSiteCoreInstalled } = await import("./EnsureSiteCore.js");
+		await expect(ensureSiteCoreInstalled()).resolves.toBeUndefined();
+		expect(mockCreateInterface).not.toHaveBeenCalled();
+		expect(mockSpawn).not.toHaveBeenCalled();
+	});
+});
+
+describe("ensureSiteCoreInstalled — missing + non-TTY", () => {
+	let stdinTTYOriginal: boolean | undefined;
+	let errSpy: ReturnType<typeof silenceStderr>;
+	let exitInfo: ReturnType<typeof expectExit>;
+
+	beforeEach(() => {
+		vi.resetModules();
+		mockResolve.mockReset();
+		mockResolve.mockImplementation(() => {
+			const err = new Error("Cannot find module");
+			(err as NodeJS.ErrnoException).code = "MODULE_NOT_FOUND";
+			throw err;
+		});
+		stdinTTYOriginal = process.stdin.isTTY;
+		Object.defineProperty(process.stdin, "isTTY", { configurable: true, value: false });
+		errSpy = silenceStderr();
+		exitInfo = expectExit();
+	});
+
+	afterEach(() => {
+		Object.defineProperty(process.stdin, "isTTY", { configurable: true, value: stdinTTYOriginal });
+		errSpy.mockRestore();
+		exitInfo.exitMock.mockRestore();
+	});
+
+	it("prints manual install instructions and exits 1", async () => {
+		const { ensureSiteCoreInstalled } = await import("./EnsureSiteCore.js");
+		await expect(ensureSiteCoreInstalled()).rejects.toThrow("__exit_1__");
+		expect(exitInfo.exitMock).toHaveBeenCalledWith(1);
+		const printed = errSpy.mock.calls.map((c: unknown[]) => c[0]).join("\n");
+		expect(printed).toMatch(/Site rendering requires/);
+		expect(printed).toMatch(/npm install -g @jolli\.ai\/site-core/);
+	});
+
+	it("does not prompt or spawn npm", async () => {
+		const { ensureSiteCoreInstalled } = await import("./EnsureSiteCore.js");
+		await expect(ensureSiteCoreInstalled()).rejects.toThrow();
+		expect(mockCreateInterface).not.toHaveBeenCalled();
+		expect(mockSpawn).not.toHaveBeenCalled();
+	});
+});
+
+describe("ensureSiteCoreInstalled — missing + TTY", () => {
+	let stdinTTYOriginal: boolean | undefined;
+	let errSpy: ReturnType<typeof silenceStderr>;
+	let exitInfo: ReturnType<typeof expectExit>;
+
+	beforeEach(() => {
+		vi.resetModules();
+		mockResolve.mockReset();
+		mockResolve.mockImplementation(() => {
+			const err = new Error("Cannot find module");
+			(err as NodeJS.ErrnoException).code = "MODULE_NOT_FOUND";
+			throw err;
+		});
+		mockSpawn.mockReset();
+		mockQuestion.mockReset();
+		mockClose.mockReset();
+		mockCreateInterface.mockClear();
+		stdinTTYOriginal = process.stdin.isTTY;
+		Object.defineProperty(process.stdin, "isTTY", { configurable: true, value: true });
+		errSpy = silenceStderr();
+		exitInfo = expectExit();
+	});
+
+	afterEach(() => {
+		Object.defineProperty(process.stdin, "isTTY", { configurable: true, value: stdinTTYOriginal });
+		errSpy.mockRestore();
+		exitInfo.exitMock.mockRestore();
+	});
+
+	it("answer 'n' → exits 1 with abort message", async () => {
+		mockQuestion.mockImplementation((_q, cb) => cb("n"));
+		const { ensureSiteCoreInstalled } = await import("./EnsureSiteCore.js");
+		await expect(ensureSiteCoreInstalled()).rejects.toThrow("__exit_1__");
+		expect(exitInfo.exitMock).toHaveBeenCalledWith(1);
+		expect(mockClose).toHaveBeenCalled();
+		expect(mockSpawn).not.toHaveBeenCalled();
+		const printed = errSpy.mock.calls.map((c: unknown[]) => c[0]).join("\n");
+		expect(printed).toMatch(/Aborted/);
+	});
+
+	it("empty answer (just Enter) defaults to yes → spawns npm install", async () => {
+		mockQuestion.mockImplementation((_q, cb) => cb(""));
+		mockSpawn.mockImplementation(() => {
+			const child = buildSpawnChild();
+			setImmediate(() => child.emit("exit", 0));
+			return child;
+		});
+		const { ensureSiteCoreInstalled } = await import("./EnsureSiteCore.js");
+		await expect(ensureSiteCoreInstalled()).resolves.toBeUndefined();
+		expect(mockSpawn).toHaveBeenCalledWith(
+			"npm",
+			["install", "-g", "@jolli.ai/site-core@^0.1.0"],
+			expect.objectContaining({ stdio: "inherit" }),
+		);
+	});
+
+	it("answer 'yes' → spawns npm install", async () => {
+		mockQuestion.mockImplementation((_q, cb) => cb("yes"));
+		mockSpawn.mockImplementation(() => {
+			const child = buildSpawnChild();
+			setImmediate(() => child.emit("exit", 0));
+			return child;
+		});
+		const { ensureSiteCoreInstalled } = await import("./EnsureSiteCore.js");
+		await expect(ensureSiteCoreInstalled()).resolves.toBeUndefined();
+		expect(mockSpawn).toHaveBeenCalledTimes(1);
+	});
+
+	it("npm install exits non-zero → rejects with descriptive error", async () => {
+		mockQuestion.mockImplementation((_q, cb) => cb("y"));
+		mockSpawn.mockImplementation(() => {
+			const child = buildSpawnChild();
+			setImmediate(() => child.emit("exit", 42));
+			return child;
+		});
+		const { ensureSiteCoreInstalled } = await import("./EnsureSiteCore.js");
+		await expect(ensureSiteCoreInstalled()).rejects.toThrow(/npm install failed \(exit 42\)/);
+		const printed = errSpy.mock.calls.map((c: unknown[]) => c[0]).join("\n");
+		expect(printed).toMatch(/exited with code 42/);
+	});
+
+	it("npm spawn 'error' event → rejects and prints manual command", async () => {
+		mockQuestion.mockImplementation((_q, cb) => cb("y"));
+		mockSpawn.mockImplementation(() => {
+			const child = buildSpawnChild();
+			setImmediate(() => child.emit("error", new Error("ENOENT")));
+			return child;
+		});
+		const { ensureSiteCoreInstalled } = await import("./EnsureSiteCore.js");
+		await expect(ensureSiteCoreInstalled()).rejects.toThrow(/ENOENT/);
+		const printed = errSpy.mock.calls.map((c: unknown[]) => c[0]).join("\n");
+		expect(printed).toMatch(/Failed to spawn npm/);
+	});
+});

--- a/cli/src/site/EnsureSiteCore.ts
+++ b/cli/src/site/EnsureSiteCore.ts
@@ -1,0 +1,119 @@
+/**
+ * EnsureSiteCore — runtime guard that `@jolli.ai/site-core` is reachable
+ * before a site command executes its real work.
+ *
+ * The CLI ships with site-core as an `optionalDependencies` entry; npm
+ * tries to install it during `npm install -g @jolli.ai/cli`, but a
+ * private registry, sandboxed CI, or offline machine can skip that step
+ * silently. The OSS CLI also does not inline site-core's compiled
+ * source (Plan A+ open-core split), so a missing package surfaces only
+ * when a site command actually imports it — at which point the user
+ * sees a cryptic `Cannot find module` deep in a stack trace.
+ *
+ * `ensureSiteCoreInstalled` short-circuits that: it probes `require.resolve`
+ * up front, and on TTY prompts the user to install the package via
+ * `npm install -g`. Non-TTY contexts (CI, piped stdin) print the manual
+ * command and exit non-zero so automated callers fail fast with a clear
+ * message instead of mid-pipeline.
+ */
+
+import { createRequire } from "node:module";
+import { createInterface } from "node:readline";
+import { spawnHidden } from "../util/Subprocess.js";
+
+const PACKAGE_NAME = "@jolli.ai/site-core";
+
+/** Range CLI expects. Kept in sync with `optionalDependencies` in package.json. */
+const VERSION_RANGE = "^0.1.0";
+
+/**
+ * Returns true if the runtime can resolve `@jolli.ai/site-core` from the
+ * CLI's location. Uses `createRequire(import.meta.url)` so resolution
+ * matches what an actual `import "@jolli.ai/site-core"` would do —
+ * walking node_modules from the CLI's installed location, not from cwd.
+ */
+export function isSiteCoreInstalled(): boolean {
+	try {
+		createRequire(import.meta.url).resolve(PACKAGE_NAME);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Guards a site command's entry point. Resolves normally when site-core
+ * is present; otherwise prompts (or exits) per the rules above.
+ *
+ * Side effects on the missing-package path:
+ *   - May call `process.exit(1)` (non-TTY, or user declines).
+ *   - May spawn `npm install -g @jolli.ai/site-core`.
+ *
+ * Returns normally — including after a successful install — so the
+ * caller's next line (typically `import("@jolli.ai/site-core")`) finds
+ * the package ready.
+ */
+export async function ensureSiteCoreInstalled(): Promise<void> {
+	if (isSiteCoreInstalled()) return;
+
+	if (!process.stdin.isTTY) {
+		printMissingMessage();
+		process.exit(1);
+	}
+
+	const shouldInstall = await promptYesNo(`Install \`${PACKAGE_NAME}\` now? [Y/n] `);
+	if (!shouldInstall) {
+		console.error(`Aborted. To install later: npm install -g ${PACKAGE_NAME}@${VERSION_RANGE}`);
+		process.exit(1);
+	}
+
+	await runNpmInstall();
+}
+
+function printMissingMessage(): void {
+	console.error("");
+	console.error(`Site rendering requires \`${PACKAGE_NAME}\` (not installed).`);
+	console.error(`Install with: npm install -g ${PACKAGE_NAME}@${VERSION_RANGE}`);
+	console.error("");
+}
+
+function promptYesNo(question: string): Promise<boolean> {
+	return new Promise((resolve) => {
+		// Write the prompt to stderr (not stdout) so a caller piping the
+		// command's output into another tool doesn't get the prompt text
+		// mixed into the data stream.
+		const rl = createInterface({ input: process.stdin, output: process.stderr });
+		rl.question(question, (answer) => {
+			rl.close();
+			const trimmed = answer.trim().toLowerCase();
+			// Default to "yes" on bare Enter — the user already saw the
+			// "needs install" message, this matches conventional `[Y/n]`.
+			resolve(trimmed === "" || trimmed === "y" || trimmed === "yes");
+		});
+	});
+}
+
+function runNpmInstall(): Promise<void> {
+	return new Promise((resolve, reject) => {
+		// `npm install -g` matches how the CLI itself is typically
+		// installed, so site-core lands in the same global prefix and the
+		// next `require.resolve` finds it without further configuration.
+		const child = spawnHidden("npm", ["install", "-g", `${PACKAGE_NAME}@${VERSION_RANGE}`], {
+			stdio: "inherit",
+		});
+		child.on("exit", (code) => {
+			if (code === 0) {
+				resolve();
+				return;
+			}
+			console.error(`npm install exited with code ${code}.`);
+			console.error(`Try manually: npm install -g ${PACKAGE_NAME}@${VERSION_RANGE}`);
+			reject(new Error(`npm install failed (exit ${code})`));
+		});
+		child.on("error", (err) => {
+			console.error(`Failed to spawn npm: ${err.message}`);
+			console.error(`Try manually: npm install -g ${PACKAGE_NAME}@${VERSION_RANGE}`);
+			reject(err);
+		});
+	});
+}

--- a/cli/vite.config.ts
+++ b/cli/vite.config.ts
@@ -26,7 +26,7 @@ export default defineConfig({
 			formats: ["es"],
 		},
 		rollupOptions: {
-			external: ["@anthropic-ai/sdk", "@mdx-js/mdx", "chokidar", "commander", "open", "semver", "yaml", /^node:.*/],
+			external: ["@anthropic-ai/sdk", "@jolli.ai/site-core", "@mdx-js/mdx", "chokidar", "commander", "open", "semver", "yaml", /^node:.*/],
 			output: {
 				chunkFileNames: "[name].js",
 			},

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,6 @@
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@anthropic-ai/sdk": "^0.39.0",
-				"@jolli.ai/site-core": "^0.1.0",
 				"@mdx-js/mdx": "^3.1.1",
 				"chokidar": "^4.0.0",
 				"commander": "^13.1.0",
@@ -46,6 +45,9 @@
 			},
 			"engines": {
 				"node": ">=22.5.0"
+			},
+			"optionalDependencies": {
+				"@jolli.ai/site-core": "^0.1.0"
 			}
 		},
 		"node_modules/@anthropic-ai/sdk": {


### PR DESCRIPTION
## Summary

Phase 3 of the Plan A+ open-core split. Drops `@jolli.ai/site-core`'s compiled JS out of the published CLI bundle and moves it to a runtime `optionalDependencies` entry with a lazy install prompt.

- `cli/dist/Api.js` shrinks from **393 KB → 222 KB** (≈ 100 KB drop = site-core's compiled code, now resolved at runtime via `node_modules`).
- Reverse-engineering the public OSS CLI bundle no longer reveals the IR / Nextra emitter / OpenAPI parser implementation — site-core stays in the private jolli repo (per [PR #965](https://github.com/jolliai/jolli/pull/965)).
- First-time `npm install -g @jolli.ai/cli` still pulls site-core automatically (optionalDeps); when that's skipped (private registry, sandboxed CI), the CLI prompts on TTY and shells out to `npm install -g`.
- Non-TTY paths fail fast with the explicit manual command.

## Files

| File | Change |
|---|---|
| `cli/vite.config.ts` | Add `@jolli.ai/site-core` to esbuild externals list |
| `cli/package.json` | Move site-core from `dependencies` → `optionalDependencies` |
| `cli/src/Cli.ts` | Two-phase shim: probe → ensure → dynamic-import `Api.ts` |
| `cli/src/site/EnsureSiteCore.ts` | NEW — runtime probe + TTY prompt + spawn `npm install -g` via `spawnHidden` |
| `cli/src/site/EnsureSiteCore.test.ts` | NEW — 11 unit tests covering all branches |

## Verification

- `npm run all` ✓
- CLI test coverage: **98.23% statements / 96.57% branches / 98.52% functions / 98.6% lines** (above the 97/96/97/97 floor)
- E2E with site-core present: `node cli/dist/Cli.js --version` runs normally
- E2E with site-core absent (non-TTY): exits 1 with `Site rendering requires \`@jolli.ai/site-core\` (not installed). Install with: npm install -g @jolli.ai/site-core@^0.1.0`
- Bundle grep: `cli/dist/Api.js` no longer contains site-core-internal strings

## Known limitation

Static-import chain inside `Api.ts` still transitively reaches `@jolli.ai/site-core` via `NewCommand → StarterKit → site-core` (and similar in Convert/Reverse/Start/Theme command modules). So **all CLI invocations** — including non-site commands like `jolli memory list` — require site-core to be present.

Refactoring those command modules to dynamic-import `cli/src/site/*` would let non-site commands run without site-core. Deferred to a follow-up; in practice the missing-site-core case only surfaces once after an install where `optionalDependencies` was skipped, and the prompt + auto-install handles it cleanly.

## Manual test plan

- [ ] `npm install -g @jolli.ai/cli@<this-version>` on a fresh machine → site-core installed alongside (happy path)
- [ ] `npm uninstall -g @jolli.ai/site-core` then `jolli new x` → prompt appears → answer Y → install completes → command continues
- [ ] Same as above with `</dev/null` → exits 1 with manual instruction (CI behavior)
- [ ] `npm uninstall -g @jolli.ai/site-core` then `jolli new x` → answer 'n' → exits with abort message
- [ ] Other site commands (build / start / dev / convert / reverse / theme) behave the same as `new`