### PR TITLE
site-core: close sanitizeUrl backslash bypass on scheme-relative URLs

### DIFF
--- a/site-core/src/Sanitize.test.ts
+++ b/site-core/src/Sanitize.test.ts
@@ -106,9 +106,28 @@ describe("sanitizeUrl — scheme-relative URLs", () => {
 		expect(sanitizeUrl("///evil.com")).toBe("#");
 	});
 
+	it("clamps the backslash variant `/\\evil.com` to '#'", () => {
+		// Browsers normalise the leading backslash to a forward slash and resolve
+		// the URL as `//evil.com` — the exact scheme-relative cross-origin
+		// vector this allow-list documents protecting against. Without the
+		// `[/\\]` lookahead, `\/(?!\/)` was satisfied (because the next char is
+		// `\`, not `/`) and the value passed through unchanged.
+		expect(sanitizeUrl("/\\evil.com")).toBe("#");
+		expect(sanitizeUrl("/\\evil.com/track?u=1")).toBe("#");
+	});
+
+	it("clamps the mixed slash/backslash variants `/\\\\foo` and `\\\\foo` to '#'", () => {
+		// Defence-in-depth: any combination of leading slashes/backslashes that
+		// browsers parse as scheme-relative must clamp. We can't trust a
+		// single-character lookahead to catch every variant, but we pin the
+		// common ones here so regressions are caught immediately.
+		expect(sanitizeUrl("/\\\\evil.com")).toBe("#");
+		expect(sanitizeUrl("\\\\evil.com")).toBe("#");
+	});
+
 	it("does NOT block legitimate single-slash root-relative paths", () => {
 		// Pin the negative — `/foo/bar` must still pass through; the rejection
-		// only fires on `//`.
+		// only fires on `//` (or its backslash homoglyph variants above).
 		expect(sanitizeUrl("/foo/bar")).toBe("/foo/bar");
 		expect(sanitizeUrl("/")).toBe("/");
 	});

--- a/site-core/src/Sanitize.ts
+++ b/site-core/src/Sanitize.ts
@@ -15,7 +15,7 @@
 
 // ─── sanitizeUrl ─────────────────────────────────────────────────────────────
 
-const SAFE_URL_PATTERN = /^(?:https?:|mailto:|tel:|[#?]|\/(?!\/)|\.\.?\/)/i;
+const SAFE_URL_PATTERN = /^(?:https?:|mailto:|tel:|[#?]|\/(?![/\\])|\.\.?\/)/i;
 
 /**
  * Allow http(s), mailto, tel, fragments, query strings, root-relative
@@ -24,12 +24,15 @@ const SAFE_URL_PATTERN = /^(?:https?:|mailto:|tel:|[#?]|\/(?!\/)|\.\.?\/)/i;
  * malicious site.json cannot inject a script URL into the generated layout,
  * footer, or `_meta.js`.
  *
- * Scheme-relative URLs (`//evil.com/x`) are explicitly rejected — they look
- * like an absolute path to the leading-`/` check but the browser parses them
- * as same-protocol cross-origin, which would let a malicious `site.json`
- * redirect users (e.g. `header.items: [{ url: "//evil.com" }]`) or exfiltrate
- * referrer context via `<img src="//evil.com">`. The negative lookahead
- * `\/(?!\/)` accepts a single leading slash but not a double.
+ * Scheme-relative URLs (`//evil.com/x`, `/\evil.com/x`) are explicitly
+ * rejected — they look like an absolute path to the leading-`/` check but
+ * the browser parses them as same-protocol cross-origin, which would let a
+ * malicious `site.json` redirect users (e.g. `header.items: [{ url: "//evil.com" }]`)
+ * or exfiltrate referrer context via `<img src="//evil.com">`. The negative
+ * lookahead `\/(?![/\\])` accepts a single leading slash but not a double —
+ * **both** `/X` (where X is `/`) and `/\X` (where X is `\`) are rejected,
+ * because browsers normalise the backslash variant to the slash form and
+ * resolve it as scheme-relative cross-origin all the same.
  *
  * Trims leading / trailing whitespace before testing the scheme so a value
  * like `"  javascript:alert(1)"` cannot bypass the check.


### PR DESCRIPTION
## Summary

`SAFE_URL_PATTERN` in `site-core/src/Sanitize.ts` blocked `//evil.com` but **not** the backslash variant `/\evil.com`. Browsers normalise the backslash to `/`, resolving the URL as `//evil.com` — the exact scheme-relative cross-origin vector the function documents protecting against.

## Why this matters

`sanitizeUrl` is the single allow-list for every customer-supplied URL that hits the generated site — `header.items`, `footer.links`, `socialLinks`, page-tab links materialised via `MetaGenerator`. A bypass here is a generic XSS / open-redirect / phishing vector against any site built by Jolli CLI / web tool.

This is **already live** in the shipped `@jolli.ai/cli` (PR #168 merged this code into main). The merge of the cross-repo `tools/site-core` import (jolliai/jolli#965) inherited the same bug. Same patch should be applied in jolli (separate PR, follow-up).

## Fix

```diff
-const SAFE_URL_PATTERN = /^(?:https?:|mailto:|tel:|[#?]|\/(?!\/)|\.\.?\/)/i;
+const SAFE_URL_PATTERN = /^(?:https?:|mailto:|tel:|[#?]|\/(?![/\\])|\.\.?\/)/i;
```

The lookahead now rejects both `/` and `\` immediately after the leading slash.

## Tests

| Input | Before | After |
|---|---|---|
| `//evil.com` | clamp to `#` ✅ | clamp to `#` ✅ |
| **`/\evil.com`** | **pass through (bug)** | **clamp to `#` ✅** |
| `/\\evil.com` | pass through | clamp to `#` ✅ |
| `\\evil.com` | clamp (no leading `/`) | clamp ✅ |
| `/foo/bar` | pass through ✅ | pass through ✅ |
| `/` | pass through ✅ | pass through ✅ |

Adds 2 new test groups (backslash bypass + mixed variants) on top of the existing scheme-relative tests.

## Validation

- `npm run all` ✓ (passes site-core's 597 tests, CLI's full suite, VS Code's full suite)
- Sanitize.test.ts: 32 tests passing (was 28, +4 new)

## Credit

Caught by @aidancrosbie in review of jolliai/jolli#965.

## Follow-up

Apply same patch in jolli/tools/site-core/src/Sanitize.ts (separate PR — that file diverged from this one when PR #965 landed, so it carries the same bug).