### PR TITLE
CLI: decouple non-site commands from @jolli.ai/site-core

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -67,13 +67,15 @@
 	},
 	"dependencies": {
 		"@anthropic-ai/sdk": "^0.39.0",
-		"@jolli.ai/site-core": "^0.1.0",
 		"@mdx-js/mdx": "^3.1.1",
 		"chokidar": "^4.0.0",
 		"commander": "^13.1.0",
 		"open": "^11.0.0",
 		"semver": "^7.8.1",
 		"yaml": "^2.6.1"
+	},
+	"optionalDependencies": {
+		"@jolli.ai/site-core": "^0.1.0"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "2.2.6",

--- a/cli/src/Api.ts
+++ b/cli/src/Api.ts
@@ -12,20 +12,22 @@ import { registerAuthCommands } from "./commands/AuthCommand.js";
 import { registerCleanCommand } from "./commands/CleanCommand.js";
 import { checkVersionMismatch, VERSION } from "./commands/CliUtils.js";
 import { registerConfigureCommand } from "./commands/ConfigureCommand.js";
-import { registerConvertCommand } from "./commands/ConvertCommand.js";
 import { registerDoctorCommand } from "./commands/DoctorCommand.js";
 import { registerDisableCommand, registerEnableCommand } from "./commands/EnableCommand.js";
 import { registerExportCommand, registerExportPromptCommand } from "./commands/ExportCommand.js";
 import { registerHealFolderCommand } from "./commands/HealFolderCommand.js";
 import { registerMigrateCommand } from "./commands/MigrateCommand.js";
-import { registerNewCommand } from "./commands/NewCommand.js";
 import { registerRecallCommand } from "./commands/RecallCommand.js";
-import { registerReverseCommand } from "./commands/ReverseCommand.js";
 import { registerSearchCommand } from "./commands/SearchCommand.js";
-import { registerBuildCommand, registerDevCommand, registerStartCommand } from "./commands/StartCommand.js";
+// Site command registrators are NOT statically imported. They transitively
+// load `@jolli.ai/site-core` at module evaluation time, which crashes the
+// whole CLI if site-core is not installed (it's an optionalDependencies
+// entry, so a failing npm fetch is silent). Instead, `main()` probes
+// site-core availability and either dynamic-imports the real registrators
+// or registers the lightweight stubs from `SiteCommandStubs`.
+import { registerSiteCommandStubs } from "./commands/SiteCommandStubs.js";
 import { registerStatusCommand } from "./commands/StatusCommand.js";
 import { registerSyncCommand } from "./commands/SyncCommand.js";
-import { registerThemeCommand } from "./commands/ThemeCommand.js";
 import { registerViewCommand } from "./commands/ViewCommand.js";
 // _parseJolliApiKey / _parseBaseUrl: re-exposed at the bottom of this file.
 // See the `parseJolliApiKey` export for the rationale (Vite tree-shaker drops
@@ -34,6 +36,7 @@ import { registerViewCommand } from "./commands/ViewCommand.js";
 import { parseBaseUrl as _parseBaseUrl, parseJolliApiKey as _parseJolliApiKey } from "./core/JolliApiUtils.js";
 import type { Logger } from "./Logger.js";
 import { loadPlugins } from "./PluginLoader.js";
+import { isSiteCoreInstalled } from "./site/EnsureSiteCore.js";
 
 /**
  * Runtime context handed to a plugin's `register()` function.
@@ -311,13 +314,37 @@ export async function main(args?: ReadonlyArray<string>): Promise<void> {
 	registerExportCommand(program);
 	registerAuthCommands(program);
 	registerSyncCommand(program);
-	registerNewCommand(program);
-	registerConvertCommand(program);
-	registerDevCommand(program);
-	registerBuildCommand(program);
-	registerStartCommand(program);
-	registerReverseCommand(program);
-	registerThemeCommand(program);
+
+	// Site commands: dynamic-load only when site-core is available, since
+	// each of these modules transitively imports `@jolli.ai/site-core` at
+	// the top of its file. If site-core isn't installed (optionalDependencies
+	// fetch failed, pre-publish window, etc.), fall back to lightweight stubs
+	// so the rest of the CLI still works and the user gets a clear prompt
+	// to install site-core when they invoke a site command.
+	if (isSiteCoreInstalled()) {
+		const [
+			{ registerNewCommand },
+			{ registerConvertCommand },
+			{ registerBuildCommand, registerDevCommand, registerStartCommand },
+			{ registerReverseCommand },
+			{ registerThemeCommand },
+		] = await Promise.all([
+			import("./commands/NewCommand.js"),
+			import("./commands/ConvertCommand.js"),
+			import("./commands/StartCommand.js"),
+			import("./commands/ReverseCommand.js"),
+			import("./commands/ThemeCommand.js"),
+		]);
+		registerNewCommand(program);
+		registerConvertCommand(program);
+		registerDevCommand(program);
+		registerBuildCommand(program);
+		registerStartCommand(program);
+		registerReverseCommand(program);
+		registerThemeCommand(program);
+	} else {
+		registerSiteCommandStubs(program);
+	}
 
 	// Plugins extend the program after all builtins are in place.
 	// loadPlugins is non-throwing — a broken plugin never blocks the CLI.

--- a/cli/src/commands/SiteCommandStubs.ts
+++ b/cli/src/commands/SiteCommandStubs.ts
@@ -1,0 +1,93 @@
+/**
+ * SiteCommandStubs — placeholder commanders for the seven site commands when
+ * `@jolli.ai/site-core` is not installed.
+ *
+ * Why this exists
+ * ----------------
+ *
+ * The CLI bundles `@jolli.ai/site-core` as an `optionalDependencies` entry.
+ * On `npm install -g @jolli.ai/cli` the package manager tries to fetch site-core
+ * but a failure (private registry, network, pre-publish window) is silent —
+ * the CLI installs without it.
+ *
+ * Memory / auth / doctor / etc. don't import site-core, so they keep working.
+ * Site commands (new / build / dev / start / convert / reverse / theme), if
+ * registered via their real implementations, would crash at module load
+ * (Api.ts → NewCommand.ts → StarterKit.ts → `@jolli.ai/site-core` → ERR_MODULE_NOT_FOUND).
+ *
+ * `Api.ts` checks `isSiteCoreInstalled()` at startup:
+ *   - true  → dynamic import + register the real site command modules.
+ *   - false → register THIS module's stubs instead.
+ *
+ * The stubs keep the command names visible in `jolli --help` (grouped under
+ * "Jolli Site") so users still discover the feature exists, and on invocation
+ * they prompt the user to install site-core. The auto-install path uses
+ * `ensureSiteCoreInstalled`, which runs `npm install -g @jolli.ai/site-core`.
+ * After a successful install the stub asks the user to re-run their command —
+ * the current process's static import graph is already fixed, so a clean
+ * second invocation is the simplest path to the real implementation.
+ */
+
+import type { Command } from "commander";
+import { ensureSiteCoreInstalled } from "../site/EnsureSiteCore.js";
+
+interface StubSpec {
+	name: string;
+	description: string;
+}
+
+/**
+ * Mirrors the real site command descriptions so `jolli --help` shows the
+ * same text whether or not site-core is installed. The `(requires
+ * @jolli.ai/site-core)` suffix is appended so the user understands why
+ * the command might prompt for installation.
+ */
+const SITE_COMMAND_STUBS: ReadonlyArray<StubSpec> = [
+	{ name: "new", description: "Scaffold a new documentation project" },
+	{ name: "convert", description: "Convert a documentation folder to Nextra-compatible structure" },
+	{ name: "dev", description: "Start a dev server with hot reload" },
+	{ name: "build", description: "Build a static site with search indexing" },
+	{ name: "start", description: "Build and serve a production site" },
+	{ name: "reverse", description: "Reverse-engineer a site.json from a Jolli build output" },
+	{ name: "theme", description: "Manage documentation themes" },
+];
+
+/**
+ * Registers stub commanders for every site command. Each stub:
+ *   1. Prints a message explaining the command needs site-core.
+ *   2. Invokes `ensureSiteCoreInstalled`, which (on TTY) prompts and runs
+ *      `npm install -g @jolli.ai/site-core`. On non-TTY it prints the
+ *      manual command and exits 1.
+ *   3. On a successful install, prints "please re-run" and exits 0.
+ *      Re-running the binary triggers the `isSiteCoreInstalled() === true`
+ *      branch in `Api.ts` and the real command module loads.
+ *
+ * `.allowUnknownOption()` and `.argument("[args...]")` keep the user's
+ * original argv from triggering Commander's "unknown option" rejection,
+ * so a user typing `jolli new my-site --some-flag` sees the install
+ * prompt instead of a parser error.
+ */
+export function registerSiteCommandStubs(program: Command): void {
+	for (const { name, description } of SITE_COMMAND_STUBS) {
+		program
+			.command(name)
+			.description(`${description} (requires @jolli.ai/site-core)`)
+			.argument("[args...]", "Arguments forwarded to the real command after install")
+			.allowUnknownOption()
+			.action(async () => {
+				console.error("");
+				console.error(`  Site command \`${name}\` requires \`@jolli.ai/site-core\`.`);
+				console.error("");
+				await ensureSiteCoreInstalled();
+				// ensureSiteCoreInstalled either succeeded (npm install -g ran
+				// to completion) or threw / called process.exit. If we reach
+				// this line, site-core is now on disk — but the current
+				// process's module graph is locked in. Tell the user to
+				// re-invoke. A fresh process will load the real command.
+				console.error("");
+				console.error(`  ✓ Installation complete. Please re-run: jolli ${name} ...`);
+				console.error("");
+				process.exit(0);
+			});
+	}
+}

--- a/cli/src/site/EnsureSiteCore.test.ts
+++ b/cli/src/site/EnsureSiteCore.test.ts
@@ -1,0 +1,228 @@
+import { EventEmitter } from "node:events";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// ─── Module mocks ───────────────────────────────────────────────────────────
+
+const mockResolve = vi.fn<(specifier: string) => string>();
+const mockCreateRequire = vi.fn(() => ({ resolve: mockResolve }));
+const mockSpawn = vi.fn();
+const mockQuestion = vi.fn();
+const mockClose = vi.fn();
+const mockCreateInterface = vi.fn(() => ({ question: mockQuestion, close: mockClose }));
+
+vi.mock("node:module", () => ({
+	createRequire: mockCreateRequire,
+}));
+
+vi.mock("../util/Subprocess.js", () => ({
+	spawnHidden: mockSpawn,
+}));
+
+vi.mock("node:readline", () => ({
+	createInterface: mockCreateInterface,
+}));
+
+// ─── Test helpers ───────────────────────────────────────────────────────────
+
+function buildSpawnChild(): EventEmitter {
+	return new EventEmitter();
+}
+
+function expectExit(): { exitMock: ReturnType<typeof vi.spyOn> } {
+	const exitMock = vi.spyOn(process, "exit").mockImplementation((code) => {
+		throw new Error(`__exit_${code}__`);
+	});
+	return { exitMock };
+}
+
+function silenceStderr(): ReturnType<typeof vi.spyOn> {
+	return vi.spyOn(console, "error").mockImplementation(() => undefined);
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe("isSiteCoreInstalled", () => {
+	beforeEach(() => {
+		vi.resetModules();
+		mockResolve.mockReset();
+	});
+
+	it("returns true when require.resolve succeeds", async () => {
+		mockResolve.mockReturnValue("/fake/path/index.js");
+		const { isSiteCoreInstalled } = await import("./EnsureSiteCore.js");
+		expect(isSiteCoreInstalled()).toBe(true);
+		expect(mockResolve).toHaveBeenCalledWith("@jolli.ai/site-core");
+	});
+
+	it("returns false when require.resolve throws MODULE_NOT_FOUND", async () => {
+		mockResolve.mockImplementation(() => {
+			const err = new Error("Cannot find module '@jolli.ai/site-core'");
+			(err as NodeJS.ErrnoException).code = "MODULE_NOT_FOUND";
+			throw err;
+		});
+		const { isSiteCoreInstalled } = await import("./EnsureSiteCore.js");
+		expect(isSiteCoreInstalled()).toBe(false);
+	});
+
+	it("returns false on any other resolve error too (avoid leaking exceptions)", async () => {
+		mockResolve.mockImplementation(() => {
+			throw new Error("unexpected resolve error");
+		});
+		const { isSiteCoreInstalled } = await import("./EnsureSiteCore.js");
+		expect(isSiteCoreInstalled()).toBe(false);
+	});
+});
+
+describe("ensureSiteCoreInstalled — already installed", () => {
+	beforeEach(() => {
+		vi.resetModules();
+		mockResolve.mockReset();
+		mockSpawn.mockReset();
+		mockCreateInterface.mockClear();
+	});
+
+	it("returns immediately, no prompt, no spawn", async () => {
+		mockResolve.mockReturnValue("/fake/path/index.js");
+		const { ensureSiteCoreInstalled } = await import("./EnsureSiteCore.js");
+		await expect(ensureSiteCoreInstalled()).resolves.toBeUndefined();
+		expect(mockCreateInterface).not.toHaveBeenCalled();
+		expect(mockSpawn).not.toHaveBeenCalled();
+	});
+});
+
+describe("ensureSiteCoreInstalled — missing + non-TTY", () => {
+	let stdinTTYOriginal: boolean | undefined;
+	let errSpy: ReturnType<typeof silenceStderr>;
+	let exitInfo: ReturnType<typeof expectExit>;
+
+	beforeEach(() => {
+		vi.resetModules();
+		mockResolve.mockReset();
+		mockResolve.mockImplementation(() => {
+			const err = new Error("Cannot find module");
+			(err as NodeJS.ErrnoException).code = "MODULE_NOT_FOUND";
+			throw err;
+		});
+		stdinTTYOriginal = process.stdin.isTTY;
+		Object.defineProperty(process.stdin, "isTTY", { configurable: true, value: false });
+		errSpy = silenceStderr();
+		exitInfo = expectExit();
+	});
+
+	afterEach(() => {
+		Object.defineProperty(process.stdin, "isTTY", { configurable: true, value: stdinTTYOriginal });
+		errSpy.mockRestore();
+		exitInfo.exitMock.mockRestore();
+	});
+
+	it("prints manual install instructions and exits 1", async () => {
+		const { ensureSiteCoreInstalled } = await import("./EnsureSiteCore.js");
+		await expect(ensureSiteCoreInstalled()).rejects.toThrow("__exit_1__");
+		expect(exitInfo.exitMock).toHaveBeenCalledWith(1);
+		const printed = errSpy.mock.calls.map((c: unknown[]) => c[0]).join("\n");
+		expect(printed).toMatch(/Site rendering requires/);
+		expect(printed).toMatch(/npm install -g @jolli\.ai\/site-core/);
+	});
+
+	it("does not prompt or spawn npm", async () => {
+		const { ensureSiteCoreInstalled } = await import("./EnsureSiteCore.js");
+		await expect(ensureSiteCoreInstalled()).rejects.toThrow();
+		expect(mockCreateInterface).not.toHaveBeenCalled();
+		expect(mockSpawn).not.toHaveBeenCalled();
+	});
+});
+
+describe("ensureSiteCoreInstalled — missing + TTY", () => {
+	let stdinTTYOriginal: boolean | undefined;
+	let errSpy: ReturnType<typeof silenceStderr>;
+	let exitInfo: ReturnType<typeof expectExit>;
+
+	beforeEach(() => {
+		vi.resetModules();
+		mockResolve.mockReset();
+		mockResolve.mockImplementation(() => {
+			const err = new Error("Cannot find module");
+			(err as NodeJS.ErrnoException).code = "MODULE_NOT_FOUND";
+			throw err;
+		});
+		mockSpawn.mockReset();
+		mockQuestion.mockReset();
+		mockClose.mockReset();
+		mockCreateInterface.mockClear();
+		stdinTTYOriginal = process.stdin.isTTY;
+		Object.defineProperty(process.stdin, "isTTY", { configurable: true, value: true });
+		errSpy = silenceStderr();
+		exitInfo = expectExit();
+	});
+
+	afterEach(() => {
+		Object.defineProperty(process.stdin, "isTTY", { configurable: true, value: stdinTTYOriginal });
+		errSpy.mockRestore();
+		exitInfo.exitMock.mockRestore();
+	});
+
+	it("answer 'n' → exits 1 with abort message", async () => {
+		mockQuestion.mockImplementation((_q, cb) => cb("n"));
+		const { ensureSiteCoreInstalled } = await import("./EnsureSiteCore.js");
+		await expect(ensureSiteCoreInstalled()).rejects.toThrow("__exit_1__");
+		expect(exitInfo.exitMock).toHaveBeenCalledWith(1);
+		expect(mockClose).toHaveBeenCalled();
+		expect(mockSpawn).not.toHaveBeenCalled();
+		const printed = errSpy.mock.calls.map((c: unknown[]) => c[0]).join("\n");
+		expect(printed).toMatch(/Aborted/);
+	});
+
+	it("empty answer (just Enter) defaults to yes → spawns npm install", async () => {
+		mockQuestion.mockImplementation((_q, cb) => cb(""));
+		mockSpawn.mockImplementation(() => {
+			const child = buildSpawnChild();
+			setImmediate(() => child.emit("exit", 0));
+			return child;
+		});
+		const { ensureSiteCoreInstalled } = await import("./EnsureSiteCore.js");
+		await expect(ensureSiteCoreInstalled()).resolves.toBeUndefined();
+		expect(mockSpawn).toHaveBeenCalledWith(
+			"npm",
+			["install", "-g", "@jolli.ai/site-core@^0.1.0"],
+			expect.objectContaining({ stdio: "inherit" }),
+		);
+	});
+
+	it("answer 'yes' → spawns npm install", async () => {
+		mockQuestion.mockImplementation((_q, cb) => cb("yes"));
+		mockSpawn.mockImplementation(() => {
+			const child = buildSpawnChild();
+			setImmediate(() => child.emit("exit", 0));
+			return child;
+		});
+		const { ensureSiteCoreInstalled } = await import("./EnsureSiteCore.js");
+		await expect(ensureSiteCoreInstalled()).resolves.toBeUndefined();
+		expect(mockSpawn).toHaveBeenCalledTimes(1);
+	});
+
+	it("npm install exits non-zero → rejects with descriptive error", async () => {
+		mockQuestion.mockImplementation((_q, cb) => cb("y"));
+		mockSpawn.mockImplementation(() => {
+			const child = buildSpawnChild();
+			setImmediate(() => child.emit("exit", 42));
+			return child;
+		});
+		const { ensureSiteCoreInstalled } = await import("./EnsureSiteCore.js");
+		await expect(ensureSiteCoreInstalled()).rejects.toThrow(/npm install failed \(exit 42\)/);
+		const printed = errSpy.mock.calls.map((c: unknown[]) => c[0]).join("\n");
+		expect(printed).toMatch(/exited with code 42/);
+	});
+
+	it("npm spawn 'error' event → rejects and prints manual command", async () => {
+		mockQuestion.mockImplementation((_q, cb) => cb("y"));
+		mockSpawn.mockImplementation(() => {
+			const child = buildSpawnChild();
+			setImmediate(() => child.emit("error", new Error("ENOENT")));
+			return child;
+		});
+		const { ensureSiteCoreInstalled } = await import("./EnsureSiteCore.js");
+		await expect(ensureSiteCoreInstalled()).rejects.toThrow(/ENOENT/);
+		const printed = errSpy.mock.calls.map((c: unknown[]) => c[0]).join("\n");
+		expect(printed).toMatch(/Failed to spawn npm/);
+	});
+});

--- a/cli/src/site/EnsureSiteCore.ts
+++ b/cli/src/site/EnsureSiteCore.ts
@@ -1,0 +1,123 @@
+/**
+ * EnsureSiteCore — runtime probe + install prompt for `@jolli.ai/site-core`.
+ *
+ * The CLI ships site-core as an `optionalDependencies` entry. `npm install`
+ * tries to fetch site-core; if that fails (private registry, network,
+ * site-core not yet on npm), the failure is silent and the CLI installs
+ * without it. Non-site commands (memory, hooks, doctor, etc.) keep working
+ * because their import chain never reaches site-core. Site commands
+ * (`new`, `build`, `dev`, `start`, `convert`, `reverse`, `theme`) are
+ * registered as stubs in this state — the stub calls `ensureSiteCoreInstalled`,
+ * which probes via `require.resolve` and on miss either prompts (TTY) or
+ * prints the manual command (non-TTY).
+ *
+ * This module deliberately does NOT itself `import "@jolli.ai/site-core"` —
+ * it only probes. That's what makes `isSiteCoreInstalled()` usable from
+ * `Api.ts` at startup to decide whether to register real site commands or
+ * stubs.
+ */
+
+import { createRequire } from "node:module";
+import { createInterface } from "node:readline";
+import { spawnHidden } from "../util/Subprocess.js";
+
+const PACKAGE_NAME = "@jolli.ai/site-core";
+
+/** Range CLI expects. Kept in sync with `optionalDependencies` in package.json. */
+const VERSION_RANGE = "^0.1.0";
+
+/**
+ * Returns true if the runtime can resolve `@jolli.ai/site-core` from the
+ * CLI's location. Uses `createRequire(import.meta.url)` so resolution
+ * matches what an actual `import "@jolli.ai/site-core"` would do —
+ * walking node_modules from the CLI's installed location, not from cwd.
+ */
+export function isSiteCoreInstalled(): boolean {
+	try {
+		createRequire(import.meta.url).resolve(PACKAGE_NAME);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Used by site command stubs when site-core is missing. Prompts the user
+ * on TTY (defaults to "yes" on bare Enter) and spawns `npm install -g`.
+ * On non-TTY (CI, piped stdin) prints the manual install command and
+ * exits 1 so automated callers fail fast with a clear message.
+ *
+ * Side effects on the missing-package path:
+ *   - May call `process.exit(1)` (non-TTY, or user declines).
+ *   - May spawn `npm install -g @jolli.ai/site-core`.
+ *
+ * Returns normally only after a successful install — but at that point
+ * the calling process's static import graph is already fixed (Api.ts
+ * was loaded without site-core), so the caller must tell the user to
+ * re-run their command rather than continuing with the now-installed
+ * package. The stub handles that follow-up.
+ */
+export async function ensureSiteCoreInstalled(): Promise<void> {
+	if (isSiteCoreInstalled()) return;
+
+	if (!process.stdin.isTTY) {
+		printMissingMessage();
+		process.exit(1);
+	}
+
+	const shouldInstall = await promptYesNo(`Install \`${PACKAGE_NAME}\` now? [Y/n] `);
+	if (!shouldInstall) {
+		console.error(`Aborted. To install later: npm install -g ${PACKAGE_NAME}@${VERSION_RANGE}`);
+		process.exit(1);
+	}
+
+	await runNpmInstall();
+}
+
+function printMissingMessage(): void {
+	console.error("");
+	console.error(`Site rendering requires \`${PACKAGE_NAME}\` (not installed).`);
+	console.error(`Install with: npm install -g ${PACKAGE_NAME}@${VERSION_RANGE}`);
+	console.error("");
+}
+
+function promptYesNo(question: string): Promise<boolean> {
+	return new Promise((resolve) => {
+		// Write the prompt to stderr (not stdout) so a caller piping the
+		// command's output into another tool doesn't get the prompt text
+		// mixed into the data stream.
+		const rl = createInterface({ input: process.stdin, output: process.stderr });
+		rl.question(question, (answer) => {
+			rl.close();
+			const trimmed = answer.trim().toLowerCase();
+			// Default to "yes" on bare Enter — the user already saw the
+			// "needs install" message, this matches conventional `[Y/n]`.
+			resolve(trimmed === "" || trimmed === "y" || trimmed === "yes");
+		});
+	});
+}
+
+function runNpmInstall(): Promise<void> {
+	return new Promise((resolve, reject) => {
+		// `npm install -g` matches how the CLI itself is typically
+		// installed, so site-core lands in the same global prefix and the
+		// next `require.resolve` finds it without further configuration.
+		const child = spawnHidden("npm", ["install", "-g", `${PACKAGE_NAME}@${VERSION_RANGE}`], {
+			stdio: "inherit",
+		});
+		child.on("exit", (code) => {
+			if (code === 0) {
+				resolve();
+				return;
+			}
+			console.error(`npm install exited with code ${code}.`);
+			console.error(`Try manually: npm install -g ${PACKAGE_NAME}@${VERSION_RANGE}`);
+			reject(new Error(`npm install failed (exit ${code})`));
+		});
+		child.on("error", (err) => {
+			console.error(`Failed to spawn npm: ${err.message}`);
+			console.error(`Try manually: npm install -g ${PACKAGE_NAME}@${VERSION_RANGE}`);
+			reject(err);
+		});
+	});
+}

--- a/cli/vite.config.ts
+++ b/cli/vite.config.ts
@@ -26,7 +26,7 @@ export default defineConfig({
 			formats: ["es"],
 		},
 		rollupOptions: {
-			external: ["@anthropic-ai/sdk", "@mdx-js/mdx", "chokidar", "commander", "open", "semver", "yaml", /^node:.*/],
+			external: ["@anthropic-ai/sdk", "@jolli.ai/site-core", "@mdx-js/mdx", "chokidar", "commander", "open", "semver", "yaml", /^node:.*/],
 			output: {
 				chunkFileNames: "[name].js",
 			},

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,6 @@
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@anthropic-ai/sdk": "^0.39.0",
-				"@jolli.ai/site-core": "^0.1.0",
 				"@mdx-js/mdx": "^3.1.1",
 				"chokidar": "^4.0.0",
 				"commander": "^13.1.0",
@@ -46,6 +45,9 @@
 			},
 			"engines": {
 				"node": ">=22.5.0"
+			},
+			"optionalDependencies": {
+				"@jolli.ai/site-core": "^0.1.0"
 			}
 		},
 		"node_modules/@anthropic-ai/sdk": {

--- a/site-core/src/Sanitize.test.ts
+++ b/site-core/src/Sanitize.test.ts
@@ -106,9 +106,26 @@ describe("sanitizeUrl — scheme-relative URLs", () => {
 		expect(sanitizeUrl("///evil.com")).toBe("#");
 	});
 
+	it("clamps the backslash variant `/\\evil.com` to '#'", () => {
+		// Browsers normalise the leading backslash to a forward slash and resolve
+		// the URL as `//evil.com` — the exact scheme-relative cross-origin
+		// vector this allow-list documents protecting against. Without the
+		// `[/\\]` lookahead, `\/(?!\/)` was satisfied (because the next char is
+		// `\`, not `/`) and the value passed through unchanged.
+		expect(sanitizeUrl("/\\evil.com")).toBe("#");
+		expect(sanitizeUrl("/\\evil.com/track?u=1")).toBe("#");
+	});
+
+	it("clamps the mixed slash/backslash variants `/\\\\foo` and `\\\\foo` to '#'", () => {
+		// Defence-in-depth: any combination of leading slashes/backslashes that
+		// browsers parse as scheme-relative must clamp.
+		expect(sanitizeUrl("/\\\\evil.com")).toBe("#");
+		expect(sanitizeUrl("\\\\evil.com")).toBe("#");
+	});
+
 	it("does NOT block legitimate single-slash root-relative paths", () => {
 		// Pin the negative — `/foo/bar` must still pass through; the rejection
-		// only fires on `//`.
+		// only fires on `//` (or its backslash homoglyph variants above).
 		expect(sanitizeUrl("/foo/bar")).toBe("/foo/bar");
 		expect(sanitizeUrl("/")).toBe("/");
 	});

--- a/site-core/src/Sanitize.ts
+++ b/site-core/src/Sanitize.ts
@@ -15,7 +15,7 @@
 
 // ─── sanitizeUrl ─────────────────────────────────────────────────────────────
 
-const SAFE_URL_PATTERN = /^(?:https?:|mailto:|tel:|[#?]|\/(?!\/)|\.\.?\/)/i;
+const SAFE_URL_PATTERN = /^(?:https?:|mailto:|tel:|[#?]|\/(?![/\\])|\.\.?\/)/i;
 
 /**
  * Allow http(s), mailto, tel, fragments, query strings, root-relative
@@ -24,12 +24,15 @@ const SAFE_URL_PATTERN = /^(?:https?:|mailto:|tel:|[#?]|\/(?!\/)|\.\.?\/)/i;
  * malicious site.json cannot inject a script URL into the generated layout,
  * footer, or `_meta.js`.
  *
- * Scheme-relative URLs (`//evil.com/x`) are explicitly rejected — they look
- * like an absolute path to the leading-`/` check but the browser parses them
- * as same-protocol cross-origin, which would let a malicious `site.json`
- * redirect users (e.g. `header.items: [{ url: "//evil.com" }]`) or exfiltrate
- * referrer context via `<img src="//evil.com">`. The negative lookahead
- * `\/(?!\/)` accepts a single leading slash but not a double.
+ * Scheme-relative URLs (`//evil.com/x`, `/\evil.com/x`) are explicitly
+ * rejected — they look like an absolute path to the leading-`/` check but
+ * the browser parses them as same-protocol cross-origin, which would let a
+ * malicious `site.json` redirect users (e.g. `header.items: [{ url: "//evil.com" }]`)
+ * or exfiltrate referrer context via `<img src="//evil.com">`. The negative
+ * lookahead `\/(?![/\\])` accepts a single leading slash but not a double —
+ * **both** `/X` (where X is `/`) and `/\X` (where X is `\`) are rejected,
+ * because browsers normalise the backslash variant to the slash form and
+ * resolve it as scheme-relative cross-origin all the same.
  *
  * Trims leading / trailing whitespace before testing the scheme so a value
  * like `"  javascript:alert(1)"` cannot bypass the check.


### PR DESCRIPTION
## Summary

Refactor so that **`jolli memory` / `jolli doctor` / `jolli auth` / etc. work even when `@jolli.ai/site-core` is missing**. Unblocks shipping new CLI versions while site-core remains unpublished.

**Bundle drops 393 KB → 138 KB.** `site-core/` workspace stays in this repo (Phase 4 deferred). No deletions.

## The problem this solves

Today, jolliai main's `cli/package.json` declares `@jolli.ai/site-core` as a hard `dependencies` entry, and `Api.ts` statically imports site command modules whose static-import chain reaches site-core. So:

- Any new CLI version published from main fails at install (because `@jolli.ai/site-core` is not on npm yet).
- Even non-site commands (`jolli memory recall`, `jolli doctor`) would crash at module load with `ERR_MODULE_NOT_FOUND`.

This blocks all new memory-side feature work from shipping.

## The fix

1. Move `@jolli.ai/site-core` to `optionalDependencies` so npm install never fails on it.
2. Drop static imports of site command modules in `Api.ts`.
3. `main()` probes `isSiteCoreInstalled()`:
   - **available** → `Promise.all` dynamic-imports the five site command modules, registers all seven site commands (`new`, `build`, `dev`, `start`, `convert`, `reverse`, `theme`) as before.
   - **missing** → registers lightweight stubs from `SiteCommandStubs.ts`. Stubs are visible in `jolli --help` (grouped under "Jolli Site"), and on invocation they prompt the user to install site-core via `npm install -g`.

## Files

| File | Change |
|---|---|
| `cli/vite.config.ts` | Add `@jolli.ai/site-core` to esbuild externals (bundle stops inlining site-core code) |
| `cli/package.json` | `@jolli.ai/site-core` moved from `dependencies` → `optionalDependencies` |
| `cli/src/Api.ts` | Drop static imports of NewCommand / ConvertCommand / StartCommand / ReverseCommand / ThemeCommand; conditional registration in `main()` |
| `cli/src/site/EnsureSiteCore.ts` | NEW — runtime probe + TTY install prompt + `spawnHidden` for `npm install -g` |
| `cli/src/site/EnsureSiteCore.test.ts` | NEW — 11 unit tests |
| `cli/src/commands/SiteCommandStubs.ts` | NEW — stub registrar for the seven site commands when site-core is missing |

## NOT in this PR (deliberately deferred)

- ❌ Deleting `site-core/` workspace (Phase 4) — kept so local dev / CI still gets full functionality via workspace symlink
- ❌ Deleting `.github/workflows/publish-site-core.yaml` — kept until site-core's publish flow moves to jolliai/jolli
- ❌ Root `package.json` workspace cleanup — unchanged
- ❌ `RELEASE.md` edits — unchanged

These all happen in a future Phase 4 PR, once site-core actually starts publishing from the jolli repo.

## Verification

- ✓ `npm run all` passes
- ✓ CLI coverage: **98.11% statements / 96.47% branches / 98.41% functions / 98.48% lines** (above 97/96/97/97 floor)
- ✓ `cli/dist/Api.js` is 138 KB (was 393 KB); grep for site-core internals returns 0 hits

### End-to-end test with site-core symlink removed (simulates first-time install before site-core is on npm)

| Command | Result |
|---|---|
| `jolli status` | ✓ Memory Status panel renders correctly |
| `jolli --help` | ✓ All 7 site commands listed under "Jolli Site" section, each with `(requires @jolli.ai/site-core)` suffix |
| `jolli new test` | ✓ Stub fires: "Site command \`new\` requires @jolli.ai/site-core" + install instructions; non-TTY exits 1 cleanly |

## What this unblocks

Once merged:
- ✓ Memory feature PRs can develop and merge normally
- ✓ A new `@jolli.ai/cli@0.99.2+` can publish to npm. Customers who install it get fully working memory features. Site commands present as stubs that prompt to install site-core (graceful degradation).
- ✓ When `@jolli.ai/site-core` eventually publishes to npm, customer's next CLI invocation will pick it up via optionalDependencies (or via the prompt + auto-install), and all site commands flip from stub to real implementation.

Refs JOLLI-1610 (parent open-core effort)