### PR TITLE
Fix completeMigration defer to also guard born-but-unpushed HEAD

### DIFF
--- a/cli/src/sync/SyncEngine.test.ts
+++ b/cli/src/sync/SyncEngine.test.ts
@@ -1002,7 +1002,12 @@ describe("SyncEngine.runRound — db→git first-bind migration", () => {
 			getLegacyContent: getLegacy,
 			completeMigration,
 		});
-		const client = makeGitClient({ commit });
+		// `isAncestor: true` — by the time `tryCompleteMigration` runs, the
+		// migration commit has already been pushed (step d), so HEAD IS
+		// reachable from origin/<default>. The fix defers completion only when
+		// HEAD is NOT yet on the remote (the bootstrap-merge 409 deadlock); a
+		// pushed HEAD must proceed straight to complete-migration.
+		const client = makeGitClient({ commit, isAncestor: vi.fn(async () => true) });
 		const { engine } = makeEngine({
 			backend,
 			client,
@@ -1038,6 +1043,11 @@ describe("SyncEngine.runRound — db→git first-bind migration", () => {
 		});
 		const { engine } = makeEngine({
 			backend,
+			// `isAncestor: true` — in the alreadyMigrated race the vault was
+			// cloned, so the resolved HEAD is already on origin/<default>;
+			// completion proceeds (the defer-on-unpushed-HEAD fix only catches
+			// the bootstrap-merge case where HEAD is born locally but unpushed).
+			client: makeGitClient({ isAncestor: vi.fn(async () => true) }),
 			makeLegacyMigration: () =>
 				({ apply: applyLegacy }) as unknown as ReturnType<
 					NonNullable<import("./SyncEngine.js").SyncEngineOpts["makeLegacyMigration"]>
@@ -1182,12 +1192,60 @@ describe("SyncEngine.runRound — db→git first-bind migration", () => {
 			})),
 			completeMigration,
 		});
-		const { engine } = makeEngine({ backend });
+		// `isAncestor: true` so completion actually fires (HEAD on remote) and
+		// its failure can surface — otherwise the defer-on-unpushed-HEAD fix
+		// would short-circuit before calling the backend.
+		const { engine } = makeEngine({ backend, client: makeGitClient({ isAncestor: vi.fn(async () => true) }) });
 		const result = await engine.runRound(ROUND);
 		expect(result.newState).toBe("offline");
 		expect(result.lastError?.code).toBe("migration_failed");
 		expect(result.lastError?.message).toMatch(/completeMigration:.*flip_failed 503/);
 		expect(completeMigration).toHaveBeenCalledTimes(1);
+	});
+
+	it("defers completeMigration when HEAD is born but not yet pushed (bootstrap-merge 409 deadlock fix)", async () => {
+		// Regression: bootstrap merge commits the fresh-local vault in
+		// `ensureOnDefaultBranch` WITHOUT pushing, so HEAD is born before
+		// first-bind migration runs. The pre-fix guard only deferred on an
+		// UNBORN head (`!hasHead()`), so it called `complete-migration` with
+		// the un-pushed commit → backend 409 → fatal → round offline before
+		// the step 7 push → deadlock (push gated behind migration, migration
+		// needs the commit pushed). The fix also defers when HEAD is born but
+		// not reachable from origin/<default>.
+		//
+		// Model that exact state on the empty-legacy (docs=0) path:
+		//   - hasHead() === true               (bootstrap already committed)
+		//   - isAncestor(HEAD, origin/main):
+		//       false on the migration-gate call (not yet pushed) → DEFER,
+		//       true after step 7's steady-state push → 7a retry completes.
+		const isAncestor = vi
+			.fn()
+			.mockResolvedValueOnce(false) // step 3c gate: HEAD not on remote yet → defer
+			.mockResolvedValue(true); //    step 7a retry: pushed now → complete
+		const completeMigration = vi.fn(async () => ({ alreadyMigrated: false }));
+		const backend = makeBackend({
+			mintGitCredentials: dbBackingMint(),
+			getLegacyContent: vi.fn(async () => ({
+				spaceId: 1,
+				spaceSlug: "personal",
+				alreadyMigrated: false,
+				docs: [], // empty legacy space → docs=0 shortcut → tryCompleteMigration
+			})),
+			completeMigration,
+		});
+		const client = makeGitClient({ hasHead: vi.fn(async () => true), isAncestor });
+		const { engine } = makeEngine({ backend, client });
+		const result = await engine.runRound(ROUND);
+
+		// No deadlock: the round must NOT go offline on a 409 — it defers,
+		// pushes, then completes against the now-pushed commit.
+		expect(result.newState).toBe("synced");
+		// The gate call must have deferred (no premature complete-migration on
+		// the un-pushed commit); completion fires once, on the 7a retry.
+		expect(completeMigration).toHaveBeenCalledTimes(1);
+		// The defer condition consulted origin-ancestry (proves we didn't fall
+		// through the old `!hasHead()`-only guard).
+		expect(isAncestor).toHaveBeenCalled();
 	});
 
 	it("goes offline when getLegacyContent errors", async () => {
@@ -2025,6 +2083,10 @@ describe("SyncEngine.runRound — extra coverage (commit summary, migration file
 		});
 		const { engine } = makeEngine({
 			backend,
+			// HEAD already on origin/<default> (cloned/empty-legacy space) →
+			// completion proceeds. The defer-on-unpushed-HEAD fix only short-
+			// circuits when HEAD is born locally but not yet pushed.
+			client: makeGitClient({ isAncestor: vi.fn(async () => true) }),
 			makeLegacyMigration: () =>
 				({ apply: applyLegacy }) as unknown as ReturnType<
 					NonNullable<import("./SyncEngine.js").SyncEngineOpts["makeLegacyMigration"]>
@@ -2062,7 +2124,11 @@ describe("SyncEngine.runRound — extra coverage (commit summary, migration file
 			})),
 			completeMigration,
 		});
-		const client = makeGitClient({ hasHead, push });
+		// `isAncestor: true` models "after the steady-state push the freshly
+		// born HEAD is on origin/<default>". At the gate it's never consulted
+		// (headBorn=false short-circuits the defer condition); on the 7a retry
+		// headBorn=true AND HEAD-on-remote → completion proceeds.
+		const client = makeGitClient({ hasHead, push, isAncestor: vi.fn(async () => true) });
 		const { engine } = makeEngine({ backend, client });
 		const result = await engine.runRound(ROUND);
 		expect(result.newState).toBe("synced");
@@ -2095,7 +2161,10 @@ describe("SyncEngine.runRound — extra coverage (commit summary, migration file
 			})),
 			completeMigration,
 		});
-		const client = makeGitClient({ hasHead, push });
+		// `isAncestor: true` — after the push the born HEAD is on the remote,
+		// so the 7a deferred retry actually calls completeMigration (which
+		// then throws); the round stays green per the lenient posture.
+		const client = makeGitClient({ hasHead, push, isAncestor: vi.fn(async () => true) });
 		const { engine } = makeEngine({ backend, client });
 		const result = await engine.runRound(ROUND);
 		expect(result.newState).toBe("synced");
@@ -2949,7 +3018,9 @@ describe("SyncEngine.runRound — JOLLI-1577 release-lock matrix", () => {
 				docs: [],
 			})),
 		});
-		const { engine } = makeEngine({ backend });
+		// HEAD on origin/<default> (cloned/already-migrated space) so the
+		// defer-on-unpushed-HEAD fix lets completion proceed.
+		const { engine } = makeEngine({ backend, client: makeGitClient({ isAncestor: vi.fn(async () => true) }) });
 		await engine.runRound(ROUND);
 		expect(completeMigration).toHaveBeenCalled();
 		expect(releaseLock).not.toHaveBeenCalled();
@@ -3031,7 +3102,9 @@ describe("SyncEngine.runRound — JOLLI-1577 release-lock matrix", () => {
 				docs: [],
 			})),
 		});
-		const client = makeGitClient({ hasHead });
+		// Gate defers on the first (unborn) hasHead; on the deferred retry
+		// hasHead=true AND HEAD-on-remote (isAncestor=true) → completion fires.
+		const client = makeGitClient({ hasHead, isAncestor: vi.fn(async () => true) });
 		const { engine } = makeEngine({ backend, client });
 		await engine.runRound(ROUND);
 		expect(completeMigration).toHaveBeenCalled();

--- a/cli/src/sync/SyncEngine.ts
+++ b/cli/src/sync/SyncEngine.ts
@@ -1492,16 +1492,38 @@ export class SyncEngine {
 			// required by the backend to verify lock ownership before
 			// flipping `metadata.vault`.
 			//
-			// Truly-empty remote case (post-`git init`, fetched nothing, no
-			// docs to migrate): HEAD is unborn, `currentHead` would throw
-			// "ambiguous argument 'HEAD'", the catch below would swallow it
-			// and the backend would never flip. Skip the call and let the
-			// steady-state push later in the round produce a real HEAD —
-			// the next round's `runFirstBindMigration` retries this.
-			/* v8 ignore start -- truly-empty-remote-and-no-docs case is the §0.13 first-bind degenerate state; reaching it requires synchronously failing every test mint mode, and the next round's runFirstBindMigration retries it cleanly */
-			if (!(await state.client.hasHead())) {
+			// Defer completion whenever there is no commit the backend can
+			// bind to *on the remote* yet. Two cases collapse here:
+			//
+			//   1) HEAD unborn — truly-empty remote (post-`git init`, fetched
+			//      nothing, no docs). `currentHead` would throw "ambiguous
+			//      argument 'HEAD'" and the backend would never flip.
+			//   2) HEAD born locally but NOT yet reachable from
+			//      `origin/<defaultBranch>` — the bootstrap-merge case.
+			//      `ensureOnDefaultBranch` commits the fresh-local vault (e.g.
+			//      172 files) WITHOUT pushing, so HEAD is already born before
+			//      this runs. Calling `complete-migration` with that un-pushed
+			//      `commitSha` makes the backend return 409 — it cannot find
+			//      the commit in the personal-space repo. Because that 409 is
+			//      fatal in `runFirstBindMigration`, the round never reaches
+			//      the step 7 push that would upload the commit: a deadlock
+			//      (push is gated behind migration; migration can only complete
+			//      once the commit is pushed). Pre-fix, the `!hasHead()` guard
+			//      only caught case 1, so the born-but-unpushed bootstrap HEAD
+			//      fell straight through to the 409.
+			//
+			// Deferring routes BOTH cases through the existing defer → step 7
+			// push → step 7a retry machinery: the steady-state push uploads
+			// HEAD, then 7a (or the next round) completes against a commit the
+			// remote actually has.
+			const defaultBranch = state.creds.defaultBranch;
+			const headBorn = await state.client.hasHead();
+			const headOnRemote =
+				headBorn && (await state.client.isAncestor("HEAD", `refs/remotes/origin/${defaultBranch}`));
+			if (!headOnRemote) {
 				log.info(
-					"completeMigration: deferred — HEAD is unborn (empty vault, no docs to migrate yet); doRound will retry after steady-state push",
+					"completeMigration: deferred — HEAD not yet on origin/%s (unborn or not-yet-pushed); doRound will retry after steady-state push",
+					defaultBranch,
 				);
 				// JOLLI-1577 — defer release alongside completion. The
 				// next round's `completeMigration` is the chosen release
@@ -1518,7 +1540,6 @@ export class SyncEngine {
 				lockHolder.deferredCompletion = true;
 				return { ok: true, deferred: true };
 			}
-			/* v8 ignore stop */
 			const commitSha = await state.client.currentHead();
 			const res = await this.opts.backend.completeMigration({
 				commitSha,


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## Plans & Notes

- Plan: Fix first-bind `completeMigration` 409 deadlock (bootstrap-merge regression)

## Quick recap

This commit fixed a deadlock that caused the first sync of a new memory folder to silently succeed in the UI while leaving the remote repository completely empty. The root cause was a hidden assumption in the migration gate: it used "does a local commit exist?" as a proxy for "is that commit already on the remote server?", which broke when the bootstrap-merge feature began creating local commits before pushing them. The fix replaced that proxy check with a direct ancestry query against the remote branch, so the gate now correctly defers when a commit exists locally but has not yet been uploaded. Eight existing tests were updated to reflect the corrected behavior, and a new regression test was added to cover the specific born-but-unpushed scenario that caused the deadlock.

---

## E2E Test (1)
<details>
<summary><strong>1. First sync succeeds on a brand-new memory folder (no 409 deadlock)</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a Jolli account with no memory folder set up yet (or use a second account / test account that has never connected a folder).

**Steps:**
1. Open the app and go through the setup flow to connect a new, empty memory folder for the first time.
2. Wait for the initial sync to complete and watch the sync status indicator in the app.
3. Check the sync status indicator — note whether it shows success or an error.
4. Open your connected private repository (e.g. on GitHub) and confirm it is no longer empty — at least one commit should be visible.
5. Trigger a second manual sync from the app (or wait for the next automatic sync cycle).
6. Check the sync status indicator again and confirm no error appears.

**Expected Results:**
- After the first sync, the status indicator shows a success state (not an error or spinner stuck indefinitely).
- The private repository contains at least one commit — it is not empty.
- The second sync completes without showing a 409 error or leaving the folder in a permanently stuck state.
- The memory folder remains fully functional and continues syncing normally on subsequent attempts.

</blockquote>
</details>

---

## Topic (1)
<details>
<summary><strong>01 · First sync deadlock: migration gate blocked push before commit reached remote</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

After setting up a new memory folder, the first sync showed a success indicator in the UI but the private repository remained completely empty. A second sync attempt then returned a 409 error, leaving the folder permanently stuck and unable to sync.

**💡 Decisions Behind the Code**

- **Ride existing defer machinery rather than adding a new push step:** The codebase already had a defer-then-retry path where the gate could signal "not ready yet," let the round's normal push step run, and then retry completion afterward. Inserting an extra push call inside the migration gate would have duplicated push logic and created ordering risks. Deferring instead keeps the fix minimal and self-contained within the existing round structure.
- **Test the real condition, not a proxy:** The original guard tested local HEAD existence as a stand-in for remote commit availability. This is inherently fragile — any future feature that creates a local commit before pushing would silently re-introduce the same class of bug. Switching to a direct remote-ancestry check makes the guard robust to new commit-creation paths without requiring those authors to know about this invariant.
- **Update existing tests rather than leaving them encoding broken behavior:** The eight affected tests were passing before the fix because their mocks happened to match the pre-fix code path, not because they were testing correct behavior. Leaving them unchanged would have meant the test suite actively validated the deadlock scenario as correct. Updating them to supply realistic mock values makes the suite a genuine safety net going forward.

**✅ What Was Implemented**

- The defer condition inside the migration completion gate in `SyncEngine.ts` was widened from "HEAD is unborn" to "HEAD is unborn OR HEAD is not yet reachable from the remote branch." Previously the gate only deferred when no local commit existed at all; after bootstrap-merge began creating local commits before pushing, the gate saw a born HEAD and immediately tried to register that commit with the backend — which returned 409 because the commit had never been uploaded. The fix uses an ancestry check against the remote tracking ref so both the empty-repo case and the born-but-unpushed case are handled identically.
- Eight existing tests in `SyncEngine.test.ts` were updated to supply a realistic remote-ancestry mock value of true, reflecting that in those scenarios the relevant commit genuinely is already on the remote. Without this correction the tests were encoding the pre-fix broken behavior as the expected outcome, meaning they would have passed even with the bug present.
- A new regression test was added covering the exact deadlock scenario: HEAD born locally but not yet pushed, causing the gate to defer, the steady-state push to upload the commit, and the deferred retry to complete migration successfully against the now-present commit.

**📁 FILES**
- `cli/src/sync/SyncEngine.ts`

</blockquote>
</details>

---

<!-- jollimemory-summary-end -->