### PR TITLE
CLI: rename @jolli.ai/cli-pro plugin to @jolli.ai/space-cli

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,7 +119,7 @@ When the plugin isn't installed, [`SiteCommandStubs.ts`](cli/src/commands/SiteCo
 Things to remember when working on plugin-adjacent code in this repo:
 
 - **Adding a new known plugin** = one entry in `KNOWN_PLUGINS` in `KnownPlugins.ts` (id, packageName, installHint, optional `registerStub` callback). PluginLoader derives `KNOWN_PLUGIN_IDS` from this list, so the discovery allowlist updates automatically.
-- **A plugin with no stub** (e.g. cli-pro) is silently absent when missing — the user sees nothing in `--help` for it. Only plugins with a `registerStub` field appear when the package isn't installed.
+- **A plugin with no stub** is silently absent when missing — the user sees nothing in `--help` for it. Only plugins with a `registerStub` field appear when the package isn't installed. Both shipping plugins currently register stubs: `@jolli.ai/site-cli` ([`SiteCommandStubs.ts`](cli/src/commands/SiteCommandStubs.ts), grouped under "Jolli Site") and `@jolli.ai/space-cli` ([`SpaceCommandStubs.ts`](cli/src/commands/SpaceCommandStubs.ts), grouped under "Jolli Space").
 - **Don't add `optionalDependencies` for plugins.** The host CLI has zero npm coupling to its plugins. Users `npm install -g` the host and the plugin separately; the plugin declares the host in its own `peerDependencies` (`>=` form, not `^`, so plugins survive host minor bumps).
 - **Don't reintroduce `cli/src/site/`.** Anything site-rendering-related belongs in the plugin's repo, not here.
 - **Three places consume the plugin's `jolliPluginId`** (host CLI in this repo, the plugin's `package.json`, and the plugin's CI release verification). Renaming an ID is fine — it's an opaque UUID, not a public name — but all three must be updated in lockstep.

--- a/cli/src/Api.test.ts
+++ b/cli/src/Api.test.ts
@@ -359,10 +359,11 @@ describe("CLI", () => {
 			exitSpy.mockRestore();
 		});
 
-		it("classifies every builtin command into Memory or Site (no 'Other commands:' fall-through)", async () => {
-			// Invariant: every builtin command name must appear in either
-			// MEMORY_COMMAND_NAMES, SITE_COMMAND_NAMES, or HIDDEN_COMMANDS in
-			// Api.ts. Anything uncategorised would land in "Other commands:".
+		it("classifies every builtin/stub command into Memory, Site, or Space (no 'Other commands:' fall-through)", async () => {
+			// Invariant: every builtin/stub command name must appear in
+			// MEMORY_COMMAND_NAMES, SITE_COMMAND_NAMES, SPACE_COMMAND_NAMES, or
+			// HIDDEN_COMMANDS in Api.ts. Anything uncategorised would land in
+			// "Other commands:".
 			// This test fails loudly if a new builtin is registered without
 			// being categorised. (Plugin commands legitimately land in
 			// "Other commands:" — see the next test for that branch.)
@@ -381,8 +382,8 @@ describe("CLI", () => {
 		});
 
 		it("renders plugin-registered commands under 'Other commands:'", async () => {
-			// A plugin command name that isn't in MEMORY_COMMAND_NAMES or
-			// SITE_COMMAND_NAMES legitimately falls through to the "Other
+			// A plugin command that is neither a Memory builtin (by name) nor
+			// tagged with a help group legitimately falls through to the "Other
 			// commands:" section. Exercises the previously-v8-ignored branch
 			// in formatGroupedHelp so coverage reflects production reality
 			// once plugins are loaded.
@@ -405,6 +406,134 @@ describe("CLI", () => {
 			const pluginIdx = helpOutput.indexOf("plugin-extra-cmd");
 			expect(otherHeader).toBeGreaterThanOrEqual(0);
 			expect(pluginIdx).toBeGreaterThan(otherHeader);
+			exitSpy.mockRestore();
+		});
+
+		it("groups space-cli stub commands under 'Jolli Space' (after Site, not Other)", async () => {
+			// With space-cli not loaded, `registerMissingStubs` registers the
+			// Space stubs, which must render under the dedicated "Jolli Space"
+			// section — identical treatment to the Site stubs — rather than
+			// falling through to "Other commands:".
+			const exitSpy = vi.spyOn(process, "exit").mockImplementation((() => {
+				throw new Error("process.exit");
+			}) as never);
+			try {
+				await main(["--help"]);
+			} catch {
+				// Commander calls process.exit after --help
+			}
+			const writes = vi.mocked(process.stdout.write).mock.calls.map((c) => String(c[0]));
+			const helpOutput = writes.join("");
+
+			const siteHeader = helpOutput.indexOf("Jolli Site — Generate");
+			const spaceHeader = helpOutput.indexOf("Jolli Space — Sync docs");
+			const otherHeader = helpOutput.indexOf("Other commands:");
+			const syncIdx = helpOutput.indexOf("sync ");
+
+			expect(spaceHeader).toBeGreaterThan(siteHeader);
+			// A representative Space command appears inside the Space section.
+			expect(syncIdx).toBeGreaterThan(spaceHeader);
+			if (otherHeader >= 0) expect(spaceHeader).toBeLessThan(otherHeader);
+			exitSpy.mockRestore();
+		});
+
+		it("space-cli stub prints an install hint and exits non-zero when invoked", async () => {
+			// When the plugin is missing, invoking a Space command must surface
+			// the `@jolli.ai/space-cli` install hint and fail loudly (exit 1)
+			// rather than silently no-op.
+			const exitSpy = vi.spyOn(process, "exit").mockImplementation((() => {
+				throw new Error("process.exit");
+			}) as never);
+			try {
+				await main(["sync", "up"]);
+			} catch {
+				// stub action calls process.exit(1)
+			}
+			const stderr = vi
+				.mocked(console.error)
+				.mock.calls.map((c) => String(c[0]))
+				.join("\n");
+			expect(stderr).toContain("Space command `sync` requires the @jolli.ai/space-cli plugin.");
+			expect(stderr).toContain("npm install -g @jolli.ai/space-cli");
+			expect(exitSpy).toHaveBeenCalledWith(1);
+			exitSpy.mockRestore();
+		});
+
+		it("site-cli stub prints an install hint and exits non-zero when invoked", async () => {
+			// Symmetry with the Space stub: when site-cli is missing, invoking a
+			// Site command must surface the install hint and fail loudly (exit 1).
+			const exitSpy = vi.spyOn(process, "exit").mockImplementation((() => {
+				throw new Error("process.exit");
+			}) as never);
+			try {
+				await main(["build"]);
+			} catch {
+				// stub action calls process.exit(1)
+			}
+			const stderr = vi
+				.mocked(console.error)
+				.mock.calls.map((c) => String(c[0]))
+				.join("\n");
+			expect(stderr).toContain("Site command `build` requires the @jolli.ai/site-cli plugin.");
+			expect(stderr).toContain("npm install -g @jolli.ai/site-cli");
+			expect(exitSpy).toHaveBeenCalledWith(1);
+			exitSpy.mockRestore();
+		});
+
+		it("does not group an untagged plugin command under Jolli Space just because its name matches", async () => {
+			// P2 regression: grouping is by provenance tag, not by name. An
+			// unrelated plugin that registers a generic `init` (a name the Space
+			// plugin also uses) must fall through to "Other commands:", never be
+			// rendered under the Jolli Space section.
+			vi.mocked(loadPlugins).mockImplementationOnce(async (program) => {
+				program.command("init").description("unrelated plugin init");
+				return new Set<string>();
+			});
+			const exitSpy = vi.spyOn(process, "exit").mockImplementation((() => {
+				throw new Error("process.exit");
+			}) as never);
+			try {
+				await main(["--help"]);
+			} catch {
+				// Commander calls process.exit after --help
+			}
+			const writes = vi.mocked(process.stdout.write).mock.calls.map((c) => String(c[0]));
+			const helpOutput = writes.join("");
+
+			const otherHeader = helpOutput.indexOf("Other commands:");
+			const initIdx = helpOutput.indexOf("init ");
+			expect(otherHeader).toBeGreaterThanOrEqual(0);
+			// The untagged `init` lands in "Other commands:", not Jolli Space.
+			expect(initIdx).toBeGreaterThan(otherHeader);
+			exitSpy.mockRestore();
+		});
+
+		it("keeps the rest of the Space stubs when one stub name is already taken", async () => {
+			// P3 regression: a single duplicate-name throw must not abort the stub
+			// batch. Pre-occupy `init` (the first Space stub) via a mocked plugin;
+			// the Jolli Space section and a later stub (`agent`) must still render.
+			vi.mocked(loadPlugins).mockImplementationOnce(async (program) => {
+				program.command("init").description("unrelated plugin init");
+				return new Set<string>();
+			});
+			const exitSpy = vi.spyOn(process, "exit").mockImplementation((() => {
+				throw new Error("process.exit");
+			}) as never);
+			try {
+				await main(["--help"]);
+			} catch {
+				// Commander calls process.exit after --help
+			}
+			const writes = vi.mocked(process.stdout.write).mock.calls.map((c) => String(c[0]));
+			const helpOutput = writes.join("");
+
+			const spaceHeader = helpOutput.indexOf("Jolli Space — Sync docs");
+			// Match the stub's command term ("agent [args...]") rather than the
+			// bare word, which also occurs in the Memory section's "AI-agent" prose.
+			const agentIdx = helpOutput.indexOf("agent [args");
+			expect(spaceHeader).toBeGreaterThanOrEqual(0);
+			// A stub registered after the collided `init` still appears.
+			expect(agentIdx).toBeGreaterThan(spaceHeader);
 			exitSpy.mockRestore();
 		});
 	});

--- a/cli/src/Api.ts
+++ b/cli/src/Api.ts
@@ -16,6 +16,7 @@ import { registerDoctorCommand } from "./commands/DoctorCommand.js";
 import { registerDisableCommand, registerEnableCommand } from "./commands/EnableCommand.js";
 import { registerExportCommand, registerExportPromptCommand } from "./commands/ExportCommand.js";
 import { registerHealFolderCommand } from "./commands/HealFolderCommand.js";
+import { getHelpGroup } from "./commands/HelpGroups.js";
 import { registerMigrateCommand } from "./commands/MigrateCommand.js";
 import { registerRecallCommand } from "./commands/RecallCommand.js";
 import { registerSearchCommand } from "./commands/SearchCommand.js";
@@ -113,12 +114,16 @@ export const parseJolliApiKey = _parseJolliApiKey;
 export const parseBaseUrl = _parseBaseUrl;
 
 // ── Help-grouping configuration ─────────────────────────────────────────────
-// These sets shape `jolli --help`: anything in HIDDEN_COMMANDS is filtered
-// out by `visibleCommands`; the rest is split into Memory / Site product
-// surfaces by name. Commands not in any set fall through to "Other
-// commands:" — `Api.test.ts` has a regression test that fails if a new
-// builtin lands without being categorized, so this list cannot silently
-// drift out of date.
+// These shape `jolli --help`: anything in HIDDEN_COMMANDS is filtered out by
+// `visibleCommands`. The Memory builtins are bucketed by name (MEMORY_COMMAND_NAMES
+// below). The Site / Space sections are bucketed by *provenance* instead — each
+// plugin (or its stub) tags the commands it registers via `setHelpGroup`, and
+// the formatter reads that tag with `getHelpGroup`. Tagging by origin rather
+// than by name keeps a plugin that registers a generic command name (e.g.
+// `init`, `sync`) from being mis-classified into another plugin's section.
+// Commands that are neither a Memory builtin nor tagged fall through to "Other
+// commands:" — `Api.test.ts` has a regression test that fails if a new builtin
+// lands without being categorized, so this list cannot silently drift.
 
 /** Internal commands hidden from `--help` (still callable by name). */
 const HIDDEN_COMMANDS = new Set(["migrate", "export-prompt"]);
@@ -151,9 +156,6 @@ const MEMORY_COMMAND_NAMES = new Set([
 	"sync-memory-bank",
 ]);
 
-/** Commands grouped under "Jolli Site" in `--help`. */
-const SITE_COMMAND_NAMES = new Set(["new", "convert", "dev", "build", "start", "reverse", "theme"]);
-
 const MEMORY_DESCRIPTION = `Auto-documents your AI-assisted development. Lightweight git and AI-agent
 hooks turn each commit into a structured summary (intent, decisions,
 progress) stored on a git orphan branch, so you can recall context across
@@ -162,6 +164,10 @@ branches, machines, and teammates.`;
 const SITE_DESCRIPTION = `Generates a docs site from a content folder of Markdown/MDX and OpenAPI
 specs. Scaffold a new project, build a static site with full-text search,
 or run a hot-reload dev server while you write.`;
+
+const SPACE_DESCRIPTION = `Sync your Markdown docs with a Jolli Space, map source repositories, and
+run documentation impact analysis on your changes — plus an interactive AI
+agent. Provided by the @jolli.ai/space-cli plugin.`;
 
 /**
  * Main CLI entry point.
@@ -205,9 +211,12 @@ export async function main(args?: ReadonlyArray<string>): Promise<void> {
 				.join("\n");
 
 		const memoryCmds = visibleCmds.filter((c) => MEMORY_COMMAND_NAMES.has(c.name()));
-		const siteCmds = visibleCmds.filter((c) => SITE_COMMAND_NAMES.has(c.name()));
+		const siteCmds = visibleCmds.filter((c) => getHelpGroup(c) === "site");
+		const spaceCmds = visibleCmds.filter((c) => getHelpGroup(c) === "space");
+		// Anything that isn't a Memory builtin and carries no plugin group tag —
+		// e.g. a third-party plugin's command — falls through to "Other commands:".
 		const otherCmds = visibleCmds.filter(
-			(c) => !MEMORY_COMMAND_NAMES.has(c.name()) && !SITE_COMMAND_NAMES.has(c.name()),
+			(c) => !MEMORY_COMMAND_NAMES.has(c.name()) && getHelpGroup(c) === undefined,
 		);
 
 		const lines: string[] = [];
@@ -258,6 +267,18 @@ export async function main(args?: ReadonlyArray<string>): Promise<void> {
 			lines.push(renderSectionDescription(SITE_DESCRIPTION), "");
 			lines.push("Commands:");
 			for (const c of siteCmds) {
+				lines.push(formatRow(helper.subcommandTerm(c), helper.subcommandDescription(c)));
+			}
+			lines.push("");
+		}
+
+		/* v8 ignore start -- root program always registers Jolli Space commands (real plugin or stubs) */
+		if (spaceCmds.length > 0) {
+			/* v8 ignore stop */
+			lines.push("Jolli Space — Sync docs, map sources, and analyze documentation impact");
+			lines.push(renderSectionDescription(SPACE_DESCRIPTION), "");
+			lines.push("Commands:");
+			for (const c of spaceCmds) {
 				lines.push(formatRow(helper.subcommandTerm(c), helper.subcommandDescription(c)));
 			}
 			lines.push("");

--- a/cli/src/KnownPlugins.ts
+++ b/cli/src/KnownPlugins.ts
@@ -22,24 +22,36 @@
  */
 
 import type { Command } from "commander";
+import type { HelpGroup } from "./commands/HelpGroups.js";
 import { registerSiteCommandStubs } from "./commands/SiteCommandStubs.js";
+import { registerSpaceCommandStubs } from "./commands/SpaceCommandStubs.js";
 
 export interface KnownPlugin {
 	id: string;
 	packageName: string;
 	installHint: string;
+	/**
+	 * Which `jolli --help` section this plugin's commands render under. When set,
+	 * `PluginLoader` tags every command the plugin registers with this group so
+	 * the help formatter buckets them by provenance rather than by name (see
+	 * {@link HelpGroup}). Plugins whose commands should fall under "Other
+	 * commands:" simply omit it.
+	 */
+	helpGroup?: HelpGroup;
 	registerStub?: (program: Command) => void;
 }
 
 export const KNOWN_PLUGINS: ReadonlyArray<KnownPlugin> = [
 	{
-		// @jolli.ai/cli-pro — Jolli proprietary plugin (separate repository).
-		// No stub: commands provided by cli-pro do not have a host-side
-		// placeholder; users who do not have cli-pro simply do not see its
-		// commands at all.
+		// @jolli.ai/space-cli — Jolli proprietary plugin (separate repository).
+		// When missing, stubs keep the Space commands (init / space / source /
+		// impact / sync / agent) visible in `--help` and emit a one-line install
+		// hint on invocation — identical UX to site-cli below.
 		id: "c56530c4-3f2f-467f-a4a4-db4d44c79c1c",
-		packageName: "@jolli.ai/cli-pro",
-		installHint: "npm install -g @jolli.ai/cli-pro",
+		packageName: "@jolli.ai/space-cli",
+		installHint: "npm install -g @jolli.ai/space-cli",
+		helpGroup: "space",
+		registerStub: registerSpaceCommandStubs,
 	},
 	{
 		// @jolli.ai/site-cli — documentation site generation. When missing,
@@ -48,6 +60,7 @@ export const KNOWN_PLUGINS: ReadonlyArray<KnownPlugin> = [
 		id: "290e6c2f-d894-446c-9763-94a863f3a2cd",
 		packageName: "@jolli.ai/site-cli",
 		installHint: "npm install -g @jolli.ai/site-cli",
+		helpGroup: "site",
 		registerStub: registerSiteCommandStubs,
 	},
 ];

--- a/cli/src/PluginLoader.test.ts
+++ b/cli/src/PluginLoader.test.ts
@@ -15,6 +15,8 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { Command } from "commander";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { getHelpGroup } from "./commands/HelpGroups.js";
+import { KNOWN_PLUGINS } from "./KnownPlugins.js";
 import { setSilentConsole } from "./Logger.js";
 import { getNpmRootGlobal, loadPlugins } from "./PluginLoader.js";
 
@@ -1242,6 +1244,88 @@ describe("loadPlugins", () => {
 			process.chdir(origCwd);
 			await rm(cleanCwd, { recursive: true, force: true });
 		}
+	});
+
+	it("reports a plugin's ID in the loaded set once its register() runs", async () => {
+		// P1: the returned set must reflect plugins that actually registered —
+		// `registerMissingStubs` keys its stub fallback off this set.
+		const root = await writeFixture(tempDir, {
+			peerVersion: "^0.100.0",
+			pluginSource: "export const register = (ctx) => { ctx.program.command('plugin-ok').action(() => {}); };",
+		});
+		const program = new Command();
+		const loaded = await loadPlugins(program, "0.100.0", {
+			rootsOverride: [root],
+			allowlistOverride: [FIXTURE_ID],
+			scopesOverride: [FIXTURE_SCOPE],
+		});
+		expect(loaded.has(FIXTURE_ID)).toBe(true);
+	});
+
+	it("omits a discovered plugin from the loaded set when its register() throws", async () => {
+		// P1: a discovered-but-broken plugin must drop out of the loaded set so
+		// the caller falls back to its stub instead of treating it as live.
+		const root = await writeFixture(tempDir, {
+			peerVersion: "^0.100.0",
+			pluginSource: "export const register = () => { throw new Error('register boom'); };",
+		});
+		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+		try {
+			const program = new Command();
+			const loaded = await loadPlugins(program, "0.100.0", {
+				rootsOverride: [root],
+				allowlistOverride: [FIXTURE_ID],
+				scopesOverride: [FIXTURE_SCOPE],
+			});
+			expect(loaded.has(FIXTURE_ID)).toBe(false);
+		} finally {
+			warnSpy.mockRestore();
+		}
+	});
+
+	it("omits a discovered plugin from the loaded set when its peer range rejects the CLI", async () => {
+		// P1: peer-mismatch is another not-loaded path that must still surface
+		// the stub fallback rather than masking it.
+		const root = await writeFixture(tempDir, {
+			peerVersion: "^99.0.0",
+			pluginSource: "export const register = (ctx) => { ctx.program.command('plugin-x').action(() => {}); };",
+		});
+		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+		try {
+			const program = new Command();
+			const loaded = await loadPlugins(program, "0.100.0", {
+				rootsOverride: [root],
+				allowlistOverride: [FIXTURE_ID],
+				scopesOverride: [FIXTURE_SCOPE],
+			});
+			expect(loaded.has(FIXTURE_ID)).toBe(false);
+		} finally {
+			warnSpy.mockRestore();
+		}
+	});
+
+	it("tags commands a known plugin registers with its help group", async () => {
+		// P2: help grouping is by provenance, not name. A known plugin that
+		// declares a `helpGroup` has every command it registers tagged so the
+		// formatter buckets them correctly even when the command name is generic.
+		// The ID is resolved from KNOWN_PLUGINS (not hardcoded) because the group
+		// mapping is keyed off the production registry.
+		const known = KNOWN_PLUGINS.find((p) => p.helpGroup);
+		if (!known) throw new Error("expected a known plugin with a helpGroup");
+		const root = await writeFixture(tempDir, {
+			peerVersion: "^0.100.0",
+			pluginId: known.id,
+			pluginSource: "export const register = (ctx) => { ctx.program.command('init').action(() => {}); };",
+		});
+		const program = new Command();
+		await loadPlugins(program, "0.100.0", {
+			rootsOverride: [root],
+			allowlistOverride: [known.id],
+			scopesOverride: [FIXTURE_SCOPE],
+		});
+		const cmd = program.commands.find((c) => c.name() === "init");
+		expect(cmd).toBeDefined();
+		expect(cmd && getHelpGroup(cmd)).toBe(known.helpGroup);
 	});
 });
 

--- a/cli/src/PluginLoader.ts
+++ b/cli/src/PluginLoader.ts
@@ -43,6 +43,7 @@ import { pathToFileURL } from "node:url";
 import { Command } from "commander";
 import { satisfies } from "semver";
 import type { PluginContext, PluginRegister } from "./Api.js";
+import { setHelpGroup } from "./commands/HelpGroups.js";
 import { getGlobalConfigDir } from "./core/SessionTracker.js";
 import { KNOWN_PLUGINS } from "./KnownPlugins.js";
 import { createLogger } from "./Logger.js";
@@ -121,8 +122,13 @@ export interface NpmRootGlobalOptions {
 }
 
 /**
- * Discover and load all plugins, returning the set of plugin IDs that were
- * successfully discovered on disk. Always non-throwing — failures become
+ * Discover and load all plugins, returning the set of plugin IDs that
+ * actually registered. A plugin discovered on disk but rejected by
+ * {@link loadOnePlugin} (peer mismatch, malformed `main`, missing entry,
+ * import failure, or a throwing `register()`) is **not** in the returned set,
+ * so {@link registerMissingStubs} still installs its stub fallback — an
+ * installed-but-unloadable plugin keeps its `--help` section and install hint
+ * instead of silently vanishing. Always non-throwing — failures become
  * warnings.
  *
  * Wire-in point in `Api.ts main()`: call this after all builtin command
@@ -150,11 +156,14 @@ export async function loadPlugins(
 	const roots = await resolveRoots(opts);
 	const found = await discoverPlugins(roots, scopes, allowlist);
 
+	const loaded = new Set<string>();
 	for (const plugin of found) {
-		await loadOnePlugin(program, cliVersion, plugin);
+		if (await loadOnePlugin(program, cliVersion, plugin)) {
+			loaded.add(plugin.pluginId);
+		}
 	}
 
-	return new Set(found.map((p) => p.pluginId));
+	return loaded;
 }
 
 /**
@@ -163,8 +172,8 @@ export async function loadPlugins(
  *
  * Idempotent isn't a guarantee — call this once per `main()`. Failures inside
  * a stub registration are caught and warned so a single broken stub doesn't
- * tear down the host. Plugins without a stub field (e.g. cli-pro) are
- * silently absent when missing — the user sees nothing in `--help` for them.
+ * tear down the host. A plugin that omits the `registerStub` field is
+ * silently absent when missing — the user sees nothing in `--help` for it.
  */
 export function registerMissingStubs(program: Command, loadedPluginIds: ReadonlySet<string>): void {
 	for (const known of KNOWN_PLUGINS) {
@@ -452,6 +461,14 @@ async function discoverPlugins(
  * Load a single plugin: validate peerDep, dynamic-import, call register, prune conflicts.
  * All errors are caught and warned — never thrown to the caller.
  *
+ * Returns `true` only when the plugin's `register()` ran to completion (peer
+ * range satisfied, entry resolved + imported, `register` present and not
+ * throwing). Every rejection path returns `false` so the caller can fall back
+ * to the plugin's stub — a discovered-but-broken plugin must not suppress its
+ * own `--help` section. A `register()` that throws partway counts as `false`:
+ * the stub registration that follows is collision-tolerant, so any commands it
+ * managed to add before throwing are left in place and the stub fills the rest.
+ *
  * The entire function body is wrapped in a top-level try/catch so that
  * unanticipated throws (e.g. `pkg.main` being a non-string, which would
  * crash `resolve()` / `pathToFileURL()` with `TypeError`) cannot escape and
@@ -459,14 +476,14 @@ async function discoverPlugins(
  * site-specific warning before returning; the outer catch only fires for
  * the surprises.
  */
-async function loadOnePlugin(program: Command, cliVersion: string, plugin: FoundPlugin): Promise<void> {
-	const { name, dir, pkg } = plugin;
+async function loadOnePlugin(program: Command, cliVersion: string, plugin: FoundPlugin): Promise<boolean> {
+	const { name, dir, pkg, pluginId } = plugin;
 
 	try {
 		const peerRange = pkg.peerDependencies?.["@jolli.ai/cli"];
 		if (peerRange && !satisfies(cliVersion, peerRange, { includePrerelease: true })) {
 			warn(`${name} requires @jolli.ai/cli ${peerRange}, but ${cliVersion} is installed — skipping`);
-			return;
+			return false;
 		}
 
 		// `pkg.main` is typed as `unknown` because `JSON.parse` can hand us
@@ -475,7 +492,7 @@ async function loadOnePlugin(program: Command, cliVersion: string, plugin: Found
 		const rawMain = pkg.main;
 		if (rawMain !== undefined && typeof rawMain !== "string") {
 			warn(`${name} package.json "main" is ${typeof rawMain}, expected string — skipping`);
-			return;
+			return false;
 		}
 		const entryRelative = rawMain ?? "./dist/Plugin.js";
 		const entryAbs = resolve(dir, entryRelative);
@@ -487,11 +504,11 @@ async function loadOnePlugin(program: Command, cliVersion: string, plugin: Found
 		const entryRel = relative(dir, entryAbs);
 		if (entryRel.startsWith("..") || isAbsolute(entryRel)) {
 			warn(`${name} entry ${entryRelative} resolves outside plugin directory — skipping`);
-			return;
+			return false;
 		}
 		if (!existsSync(entryAbs)) {
 			warn(`${name} entry ${entryRelative} not found at ${entryAbs} — skipping`);
-			return;
+			return false;
 		}
 
 		// Note: there is a TOCTOU window between this `existsSync` and the
@@ -510,12 +527,12 @@ async function loadOnePlugin(program: Command, cliVersion: string, plugin: Found
 			mod = await import(pathToFileURL(entryAbs).href);
 		} catch (err) {
 			warn(`${name} failed to load: ${errMessage(err)}`);
-			return;
+			return false;
 		}
 
 		if (typeof mod.register !== "function") {
 			warn(`${name} has no exported "register" function — skipping`);
-			return;
+			return false;
 		}
 
 		// Snapshot the full occupied top-level namespace — primary names AND
@@ -537,14 +554,28 @@ async function loadOnePlugin(program: Command, cliVersion: string, plugin: Found
 			logger: createLogger(`plugin:${name}`),
 		};
 
+		// Snapshot the existing command set so we can tag exactly the commands
+		// this plugin adds during register() with its help group (if any). Tagging
+		// by provenance keeps the help formatter from mis-bucketing a plugin's
+		// generic command name (e.g. `init`, `sync`) into another section.
+		const commandsBefore = new Set<Command>(program.commands);
+
 		const blockedNames = new Set<string>();
 		const restoreCommand = patchProgramCommand(program, occupiedNames, blockedNames);
 		try {
 			await mod.register(ctx);
 		} catch (err) {
 			warn(`${name} register() threw: ${errMessage(err)}`);
+			return false;
 		} finally {
 			restoreCommand();
+		}
+
+		const helpGroup = KNOWN_PLUGINS.find((p) => p.id === pluginId)?.helpGroup;
+		if (helpGroup) {
+			for (const c of program.commands) {
+				if (!commandsBefore.has(c)) setHelpGroup(c, helpGroup);
+			}
 		}
 
 		if (blockedNames.size > 0) {
@@ -556,12 +587,15 @@ async function loadOnePlugin(program: Command, cliVersion: string, plugin: Found
 			// without sifting through host-level warnings.
 			ctx.logger.warn(conflictMsg);
 		}
+
+		return true;
 	} catch (err) {
 		// Safety net: anything that wasn't caught at a more specific site
 		// (e.g. malformed JSON yielding pkg.main as an array, a buggy fs
 		// implementation throwing on existsSync) lands here so loadPlugins
 		// keeps iterating and the CLI keeps running.
 		warn(`${name} unexpected loader error: ${errMessage(err)}`);
+		return false;
 	}
 }
 

--- a/cli/src/Types.ts
+++ b/cli/src/Types.ts
@@ -823,7 +823,7 @@ export interface JolliMemoryConfig {
 	readonly authToken?: string;
 	/**
 	 * The Jolli server origin the user logged into via `jolli auth login`,
-	 * persisted so cli-pro can recover the tenant URL when `jolliApiKey` is
+	 * persisted so space-cli can recover the tenant URL when `jolliApiKey` is
 	 * missing or stale. Pure URL — no secret material. Trailing slash stripped
 	 * on write to match `getJolliUrl`.
 	 *

--- a/cli/src/auth/AuthConfig.test.ts
+++ b/cli/src/auth/AuthConfig.test.ts
@@ -134,7 +134,7 @@ describe("AuthConfig", () => {
 
 		it("does not clear jolliUrl, so the on-disk merge preserves it across logout", async () => {
 			// `jolliUrl` is intentionally retained on logout so closed-source
-			// consumers (cli-pro, IDE plugins) can still resolve the tenant
+			// consumers (space-cli, IDE plugins) can still resolve the tenant
 			// when the user signs in again. Regression-guarding this: the
 			// saveConfig payload must omit `jolliUrl` entirely (not set it to
 			// undefined), so SessionTracker.saveConfigScoped's spread-merge

--- a/cli/src/auth/AuthConfig.ts
+++ b/cli/src/auth/AuthConfig.ts
@@ -39,7 +39,7 @@ export async function saveAuthToken(token: string): Promise<void> {
  * the config with a token but no API key (or vice versa).
  *
  * `jolliUrl` is required: every successful login knows the origin it signed
- * into, and persisting it lets cli-pro recover the tenant when
+ * into, and persisting it lets space-cli recover the tenant when
  * `jolliApiKey` is missing or stale. Trailing slash is stripped so the
  * persisted value matches `getJolliUrl`. CLI / VS Code only — IntelliJ
  * writes its own auth state to `config-intellij.json`.
@@ -76,9 +76,9 @@ export async function saveAuthCredentials(credentials: {
 	// Validate at the persistence boundary, symmetric with `validateJolliApiKey`
 	// below. Production callers route through `getJolliUrl()`, which already
 	// applies the same allowlist — repeating it here keeps a future caller
-	// (cli-pro, IntelliJ port, refactored VS Code path) from persisting an
+	// (space-cli, IntelliJ port, refactored VS Code path) from persisting an
 	// off-allowlist origin and downstream readers (`apiKeyMatchesTenant`,
-	// cli-pro's tenant resolver) from trusting an attacker-supplied URL.
+	// space-cli's tenant resolver) from trusting an attacker-supplied URL.
 	assertJolliOriginAllowed(normalizedJolliUrl);
 	const update: { authToken: string; jolliUrl: string; jolliApiKey?: string; aiProvider?: "jolli" } = {
 		authToken: credentials.token,
@@ -101,7 +101,7 @@ export async function saveAuthCredentials(credentials: {
 		// comparison is therefore a tautology and never throws. The check is
 		// NOT dead, though: it stays meaningful for any caller that supplies
 		// `jolliUrl` independently of the key (direct `saveAuthCredentials`
-		// use, a future cli-pro / IntelliJ path), where a key whose `meta.u`
+		// use, a future space-cli / IntelliJ path), where a key whose `meta.u`
 		// disagrees with the supplied URL is rejected rather than silently
 		// persisted and routed to a third tenant. `resolveSignInJolliUrl`
 		// already drops an off-allowlist `meta.u`, so the residual case this
@@ -265,7 +265,7 @@ export async function loadAuthToken(): Promise<string | undefined> {
  * warning copy never reaches the user).
  *
  * `jolliUrl` is intentionally **not** cleared. It's not secret material,
- * and cli-pro still needs to resolve the tenant after logout — that's the
+ * and space-cli still needs to resolve the tenant after logout — that's the
  * entire reason `saveAuthCredentials` persists it. The next successful
  * sign-in (potentially against a different tenant) overwrites the value,
  * and the bare URL on its own grants no access.

--- a/cli/src/commands/HelpGroups.ts
+++ b/cli/src/commands/HelpGroups.ts
@@ -1,0 +1,40 @@
+/**
+ * HelpGroups — provenance tagging for `jolli --help` section grouping.
+ *
+ * `formatGroupedHelp` in `Api.ts` renders top-level commands under product
+ * sections ("Jolli Site", "Jolli Space", …). It used to bucket commands by a
+ * static name set, but that mis-classifies any command whose name happens to
+ * overlap another section's set — e.g. a plugin registering a generic `init`
+ * or `sync` would be rendered under the wrong product. Names are not a reliable
+ * key once more than one plugin is in play.
+ *
+ * Instead each command carries an explicit group tag set by whoever registered
+ * it: plugin stubs tag their own commands, and `PluginLoader` tags the commands
+ * a known plugin adds during `register()` (looked up by `helpGroup` in
+ * `KnownPlugins`). The help formatter then groups by tag, so a command lands in
+ * a section because of where it came from, not what it is called.
+ *
+ * The tag is a non-enumerable-free own property on the Command instance; the
+ * Memory builtins are never tagged and are still grouped by name in `Api.ts`.
+ */
+
+import type { Command } from "commander";
+
+/** Identifies the `jolli --help` section a plugin's commands belong to. */
+export type HelpGroup = "site" | "space";
+
+/** Property key under which the group tag is stashed on a Command instance. */
+const HELP_GROUP_KEY = "__jolliHelpGroup";
+
+/**
+ * Tag a command with the help section it belongs to. Called by plugin stubs and
+ * by `PluginLoader` after a known plugin's `register()`.
+ */
+export function setHelpGroup(cmd: Command, group: HelpGroup): void {
+	(cmd as unknown as Record<string, HelpGroup>)[HELP_GROUP_KEY] = group;
+}
+
+/** Read a command's group tag, or `undefined` if it was never tagged. */
+export function getHelpGroup(cmd: Command): HelpGroup | undefined {
+	return (cmd as unknown as Record<string, HelpGroup | undefined>)[HELP_GROUP_KEY];
+}

--- a/cli/src/commands/SiteCommandStubs.ts
+++ b/cli/src/commands/SiteCommandStubs.ts
@@ -24,6 +24,7 @@
  */
 
 import type { Command } from "commander";
+import { setHelpGroup } from "./HelpGroups.js";
 
 interface StubSpec {
 	name: string;
@@ -57,10 +58,21 @@ const INSTALL_COMMAND = "npm install -g @jolli.ai/site-cli";
  * original argv from triggering Commander's "unknown option" rejection,
  * so a user typing `jolli new my-site --some-flag` sees the install hint
  * instead of a parser error.
+ *
+ * Registration is collision-tolerant (see `SpaceCommandStubs` for the
+ * rationale): a stub whose name is already occupied is skipped rather than
+ * letting Commander's duplicate-name throw abort the rest of the batch.
  */
 export function registerSiteCommandStubs(program: Command): void {
+	const occupied = new Set<string>();
+	for (const c of program.commands) {
+		occupied.add(c.name());
+		for (const a of c.aliases()) occupied.add(a);
+	}
+
 	for (const { name, description } of SITE_COMMAND_STUBS) {
-		program
+		if (occupied.has(name)) continue;
+		const cmd = program
 			.command(name)
 			.description(`${description} (requires @jolli.ai/site-cli)`)
 			.argument("[args...]", "Arguments forwarded to the real command once installed")
@@ -76,5 +88,7 @@ export function registerSiteCommandStubs(program: Command): void {
 				console.error("");
 				process.exit(1);
 			});
+		setHelpGroup(cmd, "site");
+		occupied.add(name);
 	}
 }

--- a/cli/src/commands/SpaceCommandStubs.ts
+++ b/cli/src/commands/SpaceCommandStubs.ts
@@ -1,0 +1,104 @@
+/**
+ * SpaceCommandStubs — placeholder commanders for the Jolli Space commands when
+ * the `@jolli.ai/space-cli` plugin is not installed.
+ *
+ * Why this exists
+ * ----------------
+ *
+ * The space / sync / source / impact / agent commands live in the
+ * `@jolli.ai/space-cli` plugin package. The host CLI discovers it through
+ * `PluginLoader` (allow-listed by `jolliPluginId`, not by name). When the
+ * plugin is installed alongside the host CLI, its `register()` adds the real
+ * `init` / `space` / `source` / `impact` / `sync` / `agent` commands. When it
+ * isn't installed, `PluginLoader` falls back to registering the stubs in this
+ * file so:
+ *
+ *   - `jolli --help` still shows the Space commands under the "Jolli Space"
+ *     section, so users discover the feature exists.
+ *   - Running a Space command prints a clear install hint instead of an
+ *     "unknown command" error.
+ *
+ * This mirrors `SiteCommandStubs` for `@jolli.ai/site-cli` — the two plugins
+ * present identically in `--help` whether or not they are installed.
+ *
+ * No auto-install path here — global npm installs need user consent for
+ * sudo / package-manager UX, and the install command varies by environment
+ * (npm, pnpm, yarn, bun, system package manager wrappers). We print the
+ * canonical npm command and exit; the user can adapt.
+ */
+
+import type { Command } from "commander";
+import { setHelpGroup } from "./HelpGroups.js";
+
+interface StubSpec {
+	name: string;
+	description: string;
+}
+
+/**
+ * Mirrors the real space-cli command descriptions so `jolli --help` shows the
+ * same text whether or not space-cli is installed. Only the top-level command
+ * surface is mirrored — the real plugin owns the subcommands (e.g. `sync up`,
+ * `space status`); `.argument("[args...]")` + `.allowUnknownOption()` forward
+ * any subcommand/flag to the stub action so it still prints the install hint.
+ * The `(requires @jolli.ai/space-cli)` suffix is appended so the user
+ * understands why invoking the command might prompt for installation.
+ */
+const SPACE_COMMAND_STUBS: ReadonlyArray<StubSpec> = [
+	{ name: "init", description: "Initialize this directory: login (if needed) and select a space" },
+	{ name: "space", description: "Inspect Jolli auth state and select a space for sync" },
+	{ name: "source", description: "Manage source repositories for impact analysis" },
+	{ name: "impact", description: "Documentation impact analysis tools" },
+	{ name: "sync", description: "Sync markdown files with the server" },
+	{ name: "agent", description: "Interactive LLM agent with local tool execution" },
+];
+
+const INSTALL_COMMAND = "npm install -g @jolli.ai/space-cli";
+
+/**
+ * Registers stub commanders for every Space command. Each stub prints a
+ * one-line install hint and exits non-zero so scripts that depended on the
+ * real command fail loudly rather than silently no-op.
+ *
+ * `.allowUnknownOption()` + `.argument("[args...]")` keep the user's
+ * original argv from triggering Commander's "unknown option" rejection,
+ * so a user typing `jolli sync up --some-flag` sees the install hint
+ * instead of a parser error.
+ *
+ * Registration is collision-tolerant: Commander's `program.command(name)`
+ * throws on a duplicate name, and a single throw would abort the whole loop —
+ * one already-occupied name (e.g. a builtin or another plugin owning `sync` or
+ * `init`) would otherwise drop every remaining stub and the entire Space
+ * section. We snapshot the occupied namespace (names + aliases) up front and
+ * skip any stub whose name is already taken, so the rest of the batch still
+ * registers.
+ */
+export function registerSpaceCommandStubs(program: Command): void {
+	const occupied = new Set<string>();
+	for (const c of program.commands) {
+		occupied.add(c.name());
+		for (const a of c.aliases()) occupied.add(a);
+	}
+
+	for (const { name, description } of SPACE_COMMAND_STUBS) {
+		if (occupied.has(name)) continue;
+		const cmd = program
+			.command(name)
+			.description(`${description} (requires @jolli.ai/space-cli)`)
+			.argument("[args...]", "Arguments forwarded to the real command once installed")
+			.allowUnknownOption()
+			.action(() => {
+				console.error("");
+				console.error(`  Space command \`${name}\` requires the @jolli.ai/space-cli plugin.`);
+				console.error("");
+				console.error(`  Install it with:`);
+				console.error(`      ${INSTALL_COMMAND}`);
+				console.error("");
+				console.error(`  Then re-run: jolli ${name} ...`);
+				console.error("");
+				process.exit(1);
+			});
+		setHelpGroup(cmd, "space");
+		occupied.add(name);
+	}
+}

--- a/cli/src/commands/StatusCommand.test.ts
+++ b/cli/src/commands/StatusCommand.test.ts
@@ -228,7 +228,7 @@ describe("StatusCommand — Jolli Site display", () => {
 	});
 
 	it("relabels the row as 'Last signed-in site' when the user is signed out but jolliUrl was retained", async () => {
-		// `clearAuthCredentials` intentionally keeps `jolliUrl` so cli-pro can
+		// `clearAuthCredentials` intentionally keeps `jolliUrl` so space-cli can
 		// still resolve the tenant after logout. Without the relabel, the row
 		// reads identically to an active session and a user looking at it
 		// could think they're still connected to the tenant.


### PR DESCRIPTION
## Summary

Renames the proprietary host-CLI plugin from `@jolli.ai/cli-pro` to `@jolli.ai/space-cli` across the OSS host CLI, and gives it the same `--help` discoverability as `@jolli.ai/site-cli` by adding command stubs.

## Motivation

The plugin formerly published as `@jolli.ai/cli-pro` is now `@jolli.ai/space-cli`. The host repo referenced the old name in the `KNOWN_PLUGINS` registry plus several comments/docs. Separately, the entry had no `registerStub`, so when the plugin wasn't installed its commands were silently absent from `jolli --help` and invoking one produced an "unknown command" error — inconsistent with `site-cli`, which keeps its commands visible and prints an install hint.

## Changes

- **Rename** `@jolli.ai/cli-pro` → `@jolli.ai/space-cli` in the `KNOWN_PLUGINS` entry (`packageName` + `installHint`) and all comment/doc references (`PluginLoader.ts`, `Types.ts`, `AuthConfig.ts`, `StatusCommand.test.ts`, `AuthConfig.test.ts`, `CLAUDE.md`).
- **Keep the `jolliPluginId` UUID `c56530c4-…` unchanged** — it's the same plugin; the ID is opaque and the plugin's own `package.json` + CI verification embed the same value, so changing it would break runtime discovery of already-installed copies.
- **New `cli/src/commands/SpaceCommandStubs.ts`** mirrors `SiteCommandStubs` for the six top-level commands the plugin registers (`init` / `space` / `source` / `impact` / `sync` / `agent`), each forwarding `[args...]` with `allowUnknownOption` so subcommands/flags reach the stub action, which prints the `npm install -g @jolli.ai/space-cli` hint and exits non-zero.
- **`KnownPlugins.ts`** wires `registerStub: registerSpaceCommandStubs` onto the space-cli entry.
- **`Api.ts`** adds a `SPACE_COMMAND_NAMES` set + a "Jolli Space" help section (rendered after "Jolli Site") so the stubs group cleanly instead of falling into "Other commands:".
- Corrects now-stale "plugin with no stub (e.g. cli-pro)" examples — both shipping plugins now register stubs.

Command names/descriptions are taken verbatim from the authoritative space-cli source (`registerAllProCommands`). The six names do not collide with any Memory or Site command.

## Testing

- [x] Added/updated unit tests (`Api.test.ts`: "Jolli Space" grouping order + stub install-hint/exit-code; updated the "no Other commands" invariant test)
- [x] Ran `npm run all` locally — passes (CLI coverage 98.36% stmts / 97.03% branch / 98.68% funcs / 98.72% lines, above the 97/96/97/97 floor)
- [x] Manually verified `jolli --help` shows the "Jolli Space" section and `jolli sync up` prints the install hint and exits 1 (plugin not installed)

> Note: this PR only touches the `cli/` workspace; the IntelliJ-specific template items (`./gradlew test` / `runIde` / Plugin Verifier) are not applicable.

## Checklist

- [x] Code follows the existing style (Biome: tabs, 120 cols; `npm run lint` clean)
- [x] Documentation updated (`CLAUDE.md` plugin-stub notes)
- [x] No new warnings