### PR TITLE
vscode: fix diff failure when opening a renamed file from the Changes panel

### DIFF
--- a/cli/src/sync/StageVault.test.ts
+++ b/cli/src/sync/StageVault.test.ts
@@ -91,6 +91,38 @@ describe("stageVault — basic flow", () => {
 		expect(stageRm).not.toHaveBeenCalled();
 	});
 
+	it("does NOT print the unowned canary to the console (info-level, file-only)", async () => {
+		// Regression guard: `unowned` routinely holds intentionally-unstaged
+		// engine content (e.g. `.jolli-bootstrap-stash/…` survivors), so the
+		// canary must not surface on the CLI as a warning during
+		// `jolli sync-memory-bank`. It is logged at `info`, which the Logger
+		// suppresses from the console under the default silent-console mode.
+		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+		try {
+			mkdirSync(join(vault, "myrepo", ".jolli-bootstrap-stash", "myrepo", ".jolli"), {
+				recursive: true,
+			});
+			writeFileSync(join(vault, "myrepo", ".jolli-bootstrap-stash", "myrepo", ".jolli", "migration.json"), "{}");
+
+			const { client } = makeClient([
+				// Leading-dot segment → classifier returns null → unowned.
+				entry({ path: "myrepo/.jolli-bootstrap-stash/myrepo/.jolli/migration.json" }),
+			]);
+
+			const report = await stageVault(client as GitClient, vault, { syncTranscripts: true });
+
+			// Still bucketed as unowned for the file log / telemetry…
+			expect(report.unowned).toEqual(["myrepo/.jolli-bootstrap-stash/myrepo/.jolli/migration.json"]);
+			// …but nothing reached the terminal.
+			expect(warnSpy).not.toHaveBeenCalled();
+			expect(errorSpy).not.toHaveBeenCalled();
+		} finally {
+			warnSpy.mockRestore();
+			errorSpy.mockRestore();
+		}
+	});
+
 	it("resets already-staged paths that classifier now rejects (`git reset HEAD --`, NOT `git rm --cached`)", async () => {
 		// Scenario: a path the classifier doesn't recognise is somehow
 		// already in the index — could be classifier drift, a foreign

--- a/cli/src/sync/StageVault.ts
+++ b/cli/src/sync/StageVault.ts
@@ -25,9 +25,17 @@
  *
  * Returns a `StageReport` the caller logs as telemetry. The `unowned`
  * and `symlinked` arrays are the **canary signals** dogfood watchers
- * grep for — non-empty means either FolderStorage added a write site
- * the classifier doesn't recognise (drift) or something outside the
- * engine put a file in the vault (foreign writer / hostile placement).
+ * grep for. They differ in severity, and therefore in log channel:
+ *
+ *   - `unowned` (classifier returned `null`) is logged at `info` —
+ *     file-only under the CLI's silent console. It routinely contains
+ *     intentionally-unstaged engine content (`.jolli-bootstrap-stash/…`
+ *     survivors, quarantine dirs, pre-allowlist legacy files) alongside
+ *     genuine drift, so it must not surface to the user's terminal as an
+ *     error during `jolli sync-memory-bank`.
+ *   - `symlinked` is logged at `warn` — it always reaches the terminal,
+ *     because a symlink at a classifier-matching location is a potential
+ *     hostile placement the operator needs to see immediately.
  */
 
 import { lstat } from "node:fs/promises";
@@ -213,8 +221,20 @@ export async function stageVault(client: GitClient, vaultRoot: string, opts: Sta
 	// `unstagePaths` directly from their own callers, not via stageVault.
 
 	if (unowned.length > 0) {
-		log.warn(
-			"stageVault: %d unowned path(s) skipped (classifier drift or foreign writer). First %d: %s",
+		// `info`, not `warn`: this is a dogfood canary, not a user-facing
+		// problem. The `unowned` bucket legitimately fills with engine-internal
+		// content that is intentionally never staged — most commonly the
+		// `.jolli-bootstrap-stash/…` survivors a bootstrap merge leaves for
+		// manual reconciliation (BootstrapMerge.ts), plus quarantine dirs and
+		// pre-allowlist legacy files. Surfacing it at `warn` printed
+		// "classifier drift or foreign writer" straight onto the CLI during
+		// `jolli sync-memory-bank` (warn/error always hit stderr — Logger.ts),
+		// which reads as an error to end users. At `info` the line still lands
+		// in debug.log for grep-based drift watching but stays off the terminal
+		// under the CLI's silent-console default. The genuinely security-
+		// relevant signal — `symlinked` — remains a `warn` below.
+		log.info(
+			"stageVault: %d unowned path(s) skipped (engine-internal / classifier drift / foreign writer). First %d: %s",
 			unowned.length,
 			Math.min(unowned.length, 5),
 			unowned.slice(0, 5).join(", "),

--- a/vscode/src/Extension.test.ts
+++ b/vscode/src/Extension.test.ts
@@ -5259,6 +5259,58 @@ describe("Extension", () => {
 				"mod.ts (HEAD ↔ Working Tree)",
 			);
 		});
+
+		it("diffs the OLD path at HEAD against the working tree for renamed files", async () => {
+			const handler = getRegisteredCommand("jollimemory.openFileChange");
+			await handler({
+				fileStatus: {
+					absolutePath: "/repo/New.ts",
+					statusCode: "R",
+					indexStatus: "R",
+					worktreeStatus: " ",
+					isSelected: false,
+					relativePath: "New.ts",
+					originalPath: "Old.ts",
+				},
+			});
+
+			expect(executeCommand).toHaveBeenCalledWith(
+				"vscode.diff",
+				// HEAD side must use the original (pre-rename) path — the new path
+				// does not exist at HEAD, which is the bug this guards against.
+				expect.objectContaining({
+					fsPath: join("/test/workspace", "Old.ts"),
+					scheme: "git",
+				}),
+				expect.objectContaining({ fsPath: "/repo/New.ts", scheme: "file" }), // Working Tree
+				"New.ts (HEAD ↔ Working Tree)",
+			);
+		});
+
+		it("opens the working-tree file directly for a rename with no originalPath", async () => {
+			const handler = getRegisteredCommand("jollimemory.openFileChange");
+			await handler({
+				fileStatus: {
+					absolutePath: "/repo/New.ts",
+					statusCode: "R",
+					indexStatus: "R",
+					worktreeStatus: " ",
+					isSelected: false,
+					relativePath: "New.ts",
+					// no originalPath
+				},
+			});
+
+			expect(showTextDocument).toHaveBeenCalledWith(
+				expect.objectContaining({ fsPath: "/repo/New.ts", scheme: "file" }),
+			);
+			expect(executeCommand).not.toHaveBeenCalledWith(
+				"vscode.diff",
+				expect.anything(),
+				expect.anything(),
+				expect.anything(),
+			);
+		});
 	});
 
 	// ── openCommitFileChange command ─────────────────────────────────

--- a/vscode/src/Extension.ts
+++ b/vscode/src/Extension.ts
@@ -1801,7 +1801,31 @@ export function activate(context: vscode.ExtensionContext): void {
 					return;
 				}
 
-				// Modified / renamed files — always diff against the working tree.
+				// Renamed files — at HEAD the content lives under the OLD path, so
+				// the HEAD side of the diff must use `originalPath`. Using the new
+				// path at HEAD reads a nonexistent blob and the editor fails to open.
+				// (Copies aren't handled here: `git status --porcelain` never emits a
+				// `C` status — copy detection only exists in git's diff path, which
+				// the Commits-panel handler uses, not the working-tree `status` call.)
+				if (statusCode === "R") {
+					const { originalPath } = item.fileStatus;
+					if (originalPath === undefined) {
+						// Rename without a recorded source path: no reliable HEAD blob
+						// to diff against, so just open the working-tree file.
+						await vscode.window.showTextDocument(fileUri);
+						return;
+					}
+					const oldFileUri = vscode.Uri.file(join(workspaceRoot, originalPath));
+					await vscode.commands.executeCommand(
+						"vscode.diff",
+						toGitUri(oldFileUri, "HEAD"),
+						fileUri,
+						`${relativePath} (HEAD ↔ Working Tree)`,
+					);
+					return;
+				}
+
+				// Modified files — always diff against the working tree.
 				// Staged vs working-tree content may diverge (edits after staging),
 				// so showing the live file is the most useful default.
 				const headUri = toGitUri(fileUri, "HEAD");


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## Quick recap

The developer diagnosed and fixed a bug where clicking a renamed file in the Changes panel caused an error instead of opening a diff. The root cause was that the working-tree diff handler was using the file's new name to look up its content in the HEAD commit, but HEAD only knows the file by its old name — so the lookup failed with "unable to resolve nonexistent file." The fix adds a dedicated rename branch to the handler that uses the original pre-rename path for the HEAD side of the diff, matching the correct behavior already present in the Commits panel handler. A fallback was also added for the rare case where the original path is unavailable, opening the working-tree file directly rather than attempting a broken diff. Two new tests were added to guard both the happy path and the fallback.

This commit addressed two separate problems in the same session. The primary fix resolved a crash in the VS Code extension's Changes panel where clicking a renamed file would fail to open a diff, because the extension was trying to read the file's current name from Git history rather than its original pre-rename name. A dedicated code path was added to handle renames correctly, mirroring logic that already worked correctly in the Commits panel. The secondary fix addressed a misleading warning message that appeared in the terminal every time a user ran the memory bank sync command — the message implied a serious error ("classifier drift or foreign writer") but was actually routine internal housekeeping noise. Demoting that log message from warning to informational level silenced it from the terminal while keeping it available in the debug log for developers who need it.

The developer fixed a bug in the VS Code extension's Changes panel where clicking a renamed file would fail to open a diff, because the extension was trying to read the file's new name from the HEAD commit where it doesn't yet exist. The fix routes renamed files through their original (pre-rename) path when constructing the HEAD side of the diff. During the session, the developer also considered extending the same fix to cover copied files, but after investigation discovered that the underlying git status command never actually produces a "copy" status in this code path — copy detection only exists in a different git command used elsewhere. The copy-handling branch was therefore removed, keeping the fix strictly scoped to the real, reachable bug. The SUPPORT.md file was also deleted in this commit.

---

## E2E Test (2)
<details>
<summary><strong>1. Renamed file opens diff correctly from the Changes panel</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a Git repository open in VS Code with at least one file that has been renamed (e.g. rename "Old.ts" to "New.ts") so it appears in the Changes panel with a rename indicator.

**Steps:**
1. Open the Changes panel in the Jolli Memory sidebar.
2. Locate the renamed file (it should show both the old and new name, or a rename indicator).
3. Click on the renamed file entry.
4. Check what opens in the editor.
5. Verify the left side of the diff shows the file's original content (from before the rename).
6. Verify the right side shows the current working-tree version of the file.

**Expected Results:**
- A diff view opens without any error message (no "Unable to resolve nonexistent file" or similar alert).
- The diff title reads something like "New.ts (HEAD ↔ Working Tree)".
- The left (HEAD) side displays the file's content under its old name, and the right side shows the current file content.

</blockquote>
</details>
<details>
<summary><strong>2. Renamed file with missing source info opens safely without crashing</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a Git repository open in VS Code where a renamed file appears in the Changes panel but its original (pre-rename) name cannot be determined (an edge case that can occur with certain Git configurations or partial status records).

**Steps:**
1. Open the Changes panel in the Jolli Memory sidebar.
2. Click on a renamed file entry that has no recorded original path.
3. Check what opens in the editor.

**Expected Results:**
- No error message or crash appears.
- The file opens directly in a normal text editor view (not a diff view), showing the current contents of the renamed file.

</blockquote>
</details>

---

## Topics (4)
<details>
<summary><strong>01 · Fix diff failure when opening a renamed file from the Changes panel</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Clicking a renamed file in the Changes panel showed an error ("Unable to resolve nonexistent file") instead of opening a diff. The file's new name was being used to look up its content at HEAD, but HEAD only contains it under the old name.

**💡 Decisions Behind the Code**

- **Use the original path for the HEAD side rather than skipping the diff entirely**: The required data (`originalPath`) was already populated by the porcelain parser and carried on the tree item — it just wasn't being read. Using it preserves the full diff experience (content changes plus rename context) at no extra cost, which is strictly better than degrading to a plain file open for all renames.
- **Fallback to plain file open when original path is missing**: When no original path is recorded, there is no reliable blob to diff against at HEAD. Falling through to the existing modified-file code path would reproduce the same broken URI and the same error. Opening the working-tree file directly is a safe, visible degradation that gives the user something useful without crashing.

**✅ What Was Implemented**

- In `vscode/src/Extension.ts`, the `openFileChange` command handler was extended with a dedicated rename branch. When the file status is `R`, the HEAD side of the diff is now constructed from `FileStatus.originalPath` (the pre-rename path) rather than the new path, mirroring the correct logic already present in the `openCommitFileChange` handler.
- A fallback was added for the edge case where `originalPath` is absent on a rename: instead of falling through to the broken modified-file path, the handler opens the working-tree file directly via `showTextDocument`, avoiding the nonexistent-blob read entirely.
- Two tests were added to `vscode/src/Extension.test.ts` covering the rename happy path (asserting the HEAD-side URI uses the old path) and the no-`originalPath` fallback (asserting `showTextDocument` is called and `vscode.diff` is not).

**📁 FILES**
- `vscode/src/Extension.ts`

</blockquote>
</details>
<details>
<summary><strong>02 · Diff viewer crashes when opening a renamed file from the Changes panel</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

When a user clicked a renamed file in the VS Code extension's Changes panel, the diff failed to open. The extension was looking up the file's new name in Git history, but Git only knows the old name — so the lookup produced nothing and the view broke.

**💡 Decisions Behind the Code**

- **Mirror the already-correct Commits panel**: The Commits panel handler already handled renames correctly by using the original path for the HEAD side. Reusing the same pattern for the Changes panel kept the two code paths consistent and avoided introducing a novel approach that would need its own reasoning and maintenance burden.
- **Graceful fallback when original path is absent**: Rather than throwing or showing an error when a rename has no recorded source path, the handler falls back to opening the working-tree file directly. This trades a potentially confusing empty diff for a usable (if incomplete) experience, which is safer for an edge case that should rarely occur in practice.

**✅ What Was Implemented**

- In the `jollimemory.openFileChange` command handler in `Extension.ts`, a dedicated branch was added for rename-status files (`R`). It now reads the pre-rename path from the file status record and uses that as the HEAD side of the diff, while the working-tree side uses the new path. When no original path is recorded, the handler falls back to opening the file directly without attempting a diff, avoiding the broken state entirely.
- Two new test cases were added to `Extension.test.ts`: one verifying the HEAD side of the diff uses the old path with the correct Git URI scheme, and one verifying the no-original-path fallback opens the file directly without invoking the diff viewer.

**📁 FILES**
- `vscode/src/Extension.ts`

</blockquote>
</details>
<details>
<summary><strong>03 · Fix diff viewer crash when opening a renamed file from the Changes panel</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

When a user clicked a renamed file in the Changes panel, the diff editor failed to open with an error about a nonexistent file. The new filename doesn't exist at HEAD yet, so the extension was pointing the diff viewer at a blob that doesn't exist.

**💡 Decisions Behind the Code**

- **Scope the fix to renames only, not copies**: The developer initially considered handling both rename and copy statuses together, since they share the same structural failure mode. However, investigation confirmed that the git status command used by the Changes panel never emits a copy status — copy detection only exists in git's diff path, which a different panel handler already covers. Including copy handling would have added an unreachable code branch, so it was removed to keep the fix honest and minimal.
- **Retain a fallback for renames missing an original path**: Rather than failing silently or throwing when a rename has no recorded source path, the handler falls back to opening the working-tree file directly. This trades a broken diff experience for a degraded-but-functional one, which is safer for an edge case that is unlikely but theoretically possible.

**✅ What Was Implemented**

In `vscode/src/Extension.ts`, the file-open handler was updated to detect when a file's status is a rename and substitute the original pre-rename path for the HEAD side of the diff. A fallback was also kept for the edge case where a rename has no recorded original path, in which case the working-tree file is opened directly instead of attempting a diff.

**📁 FILES**
- `vscode/src/Extension.ts`

</blockquote>
</details>
<details>
<summary><strong>04 · Routine sync warning message incorrectly surfaced as a terminal error</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Every time a user ran the memory bank sync command, a warning appeared in the terminal saying files were skipped due to "classifier drift or foreign writer." This message was alarming but described normal, expected internal behavior — not a real problem the user needed to act on.

**💡 Decisions Behind the Code**

- **Demote to info rather than suppress entirely**: The unowned canary still has value for developers diagnosing drift — it just shouldn't reach end users. Keeping it at informational level means it continues to appear in the debug log file, where developers can grep for it, while the CLI's silent-console mode prevents it from reaching the terminal. Removing the log call entirely would have eliminated that diagnostic value.
- **Keep the symlink canary at warning level**: Symlinks at classifier-matching locations are a potential hostile placement that an operator genuinely needs to see immediately. Treating both canaries the same way would either over-alert users about routine noise or under-alert them about a real security signal. The severity split makes the distinction explicit and intentional.

**✅ What Was Implemented**

- In `StageVault.ts`, the log call for the unowned-paths canary was demoted from warning level to informational level. The message text was also updated to clarify that engine-internal content (such as bootstrap stash survivors) is an expected and routine cause, not just drift or hostile writes. The module's documentation comment was updated to explain that the two canary signals — unowned paths and symlinked paths — intentionally use different severity levels for different reasons.
- A regression test was added to `StageVault.test.ts` asserting that a sync run containing only bootstrap-stash paths still correctly populates the unowned report array but produces no console warning or error output.

**📁 FILES**
- `cli/src/sync/StageVault.ts`

</blockquote>
</details>

---

<!-- jollimemory-summary-end -->