### PR TITLE
Simplify the structure of plans.json by removing the branch and ignored attributes.

### DIFF
--- a/cli/src/Types.ts
+++ b/cli/src/Types.ts
@@ -452,12 +452,9 @@ export interface PlanEntry {
 	readonly sourcePath: string;
 	readonly addedAt: string;
 	readonly updatedAt: string;
-	readonly branch: string;
 	readonly commitHash: string | null;
 	/** SHA-256 hash of the plan file content when associated with a commit. Used as a guard to detect if the file was overwritten with new content. */
 	readonly contentHashAtCommit?: string;
-	/** When true, plan is hidden from PLANS panel (user removed it). Cleared if source file content changes. */
-	readonly ignored?: boolean;
 }
 
 /**
@@ -489,12 +486,9 @@ export interface NoteEntry {
 	readonly format: NoteFormat;
 	readonly addedAt: string;
 	readonly updatedAt: string;
-	readonly branch: string;
 	readonly commitHash: string | null;
 	/** SHA-256 hash of note content when associated with a commit (archive guard) */
 	readonly contentHashAtCommit?: string;
-	/** When true, note is hidden from the panel */
-	readonly ignored?: boolean;
 	/** File path in .jolli/jollimemory/notes/<id>.md (all notes are file-backed) */
 	readonly sourcePath?: string;
 }
@@ -610,12 +604,12 @@ export interface Reference {
 /**
  * ReferenceEntry — persisted registry row in the `plans.json.references` map.
  *
- * Holds one row per external reference across every {@link SourceId}. Map key
- * follows the same archive pattern as Plans/Notes: the active row uses
- * `<source>:<nativeId>` and (after `associateReferencesWithCommit`) a second
- * snapshot row appears keyed `<source>:<nativeId>-<shortHash>`. The
- * `contentHashAtCommit` guard pattern, branch-scoping, and ignored semantics
- * mirror the Plan / Note registry rows.
+ * Holds one row per external reference across every {@link SourceId}, keyed
+ * `<source>:<nativeId>`. Unlike Plan / Note rows, a reference is DELETED from
+ * the registry when its commit lands — its value-snapshot lives on in the
+ * orphan branch's `CommitSummary.references`. So there is no archive row,
+ * `contentHashAtCommit` guard, branch scoping, or ignored flag: every row
+ * here is an active, uncommitted reference.
  */
 export interface ReferenceEntry {
 	readonly source: SourceId;
@@ -624,14 +618,8 @@ export interface ReferenceEntry {
 	readonly url: string;
 	/** Absolute path to `<jolliMemoryDir>/references/<source>/<sanitized-key>.md`. */
 	readonly sourcePath: string;
-	readonly branch: string;
 	readonly addedAt: string;
 	readonly updatedAt: string;
-	readonly commitHash: string | null;
-	/** SHA-256 of the canonical markdown at archive time (guard pattern). */
-	readonly contentHashAtCommit?: string;
-	/** When true, hidden from the multi-source panel. */
-	readonly ignored?: boolean;
 	/** MCP tool name that originally surfaced this reference. */
 	readonly sourceToolName: string;
 }

--- a/cli/src/core/CommitSelectionStore.ts
+++ b/cli/src/core/CommitSelectionStore.ts
@@ -12,9 +12,9 @@
  * lifecycle event modifies the file — the QueueWorker only ever READS it.
  *
  * Distinct from `HiddenConversationsStore` (permanent hide — row vanishes
- * from sidebar) and from `PlanEntry.ignored` / `NoteEntry.ignored`
- * (permanent ignore at the plans-registry layer). Exclusions are visible
- * in the sidebar with an unchecked box; the row still renders.
+ * from sidebar) and from the plans-registry hard-delete (the row is removed
+ * entirely). Exclusions are visible in the sidebar with an unchecked box; the
+ * row still renders.
  *
  * Schema versions:
  *   - v1: { conversations, plans, notes }

--- a/cli/src/core/NotePromptFormatter.test.ts
+++ b/cli/src/core/NotePromptFormatter.test.ts
@@ -19,7 +19,6 @@ function makeNote(overrides: Partial<NoteEntry> = {}): NoteEntry {
 		format: "snippet",
 		addedAt: "2026-05-13T00:00:00Z",
 		updatedAt: "2026-05-14T00:00:00Z",
-		branch: "main",
 		commitHash: null,
 		sourcePath: "/abs/path/my-note.md",
 		...overrides,

--- a/cli/src/core/PathUtils.test.ts
+++ b/cli/src/core/PathUtils.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { withPlatform } from "../testUtils/withPlatform.js";
-import { normalizePathForCompare, toForwardSlash } from "./PathUtils.js";
+import { isPathInside, normalizePathForCompare, toForwardSlash } from "./PathUtils.js";
 
 describe("normalizePathForCompare", () => {
 	it("unifies backslashes to forward slashes regardless of platform", () => {
@@ -101,5 +101,49 @@ describe("toForwardSlash", () => {
 
 	it("handles a path with no separators", () => {
 		expect(toForwardSlash("file.txt")).toBe("file.txt");
+	});
+});
+
+describe("isPathInside", () => {
+	it("returns true when child equals parent", () => {
+		withPlatform("linux", () => {
+			expect(isPathInside("/repo/.jolli/jollimemory", "/repo/.jolli/jollimemory")).toBe(true);
+		});
+	});
+
+	it("returns true for a nested child", () => {
+		withPlatform("linux", () => {
+			expect(isPathInside("/repo/.jolli/jollimemory/notes/x.md", "/repo/.jolli/jollimemory")).toBe(true);
+		});
+	});
+
+	it("returns false at a directory-name boundary (jollimemoryX is NOT inside jollimemory)", () => {
+		withPlatform("linux", () => {
+			expect(isPathInside("/repo/.jolli/jollimemoryX/y.md", "/repo/.jolli/jollimemory")).toBe(false);
+		});
+	});
+
+	it("returns false for an external path", () => {
+		withPlatform("linux", () => {
+			expect(isPathInside("/home/user/.claude/plans/p.md", "/repo/.jolli/jollimemory")).toBe(false);
+		});
+	});
+
+	it("returns false when the candidate parent is actually deeper than the child", () => {
+		withPlatform("linux", () => {
+			expect(isPathInside("/repo/.jolli", "/repo/.jolli/jollimemory")).toBe(false);
+		});
+	});
+
+	it("folds case and separators on Windows", () => {
+		withPlatform("win32", () => {
+			expect(isPathInside("C:\\Repo\\.jolli\\jollimemory\\Notes\\x.md", "c:/repo/.jolli/jollimemory")).toBe(true);
+		});
+	});
+
+	it("is case-sensitive on Linux (different case is not inside)", () => {
+		withPlatform("linux", () => {
+			expect(isPathInside("/Repo/.jolli/jollimemory/x.md", "/repo/.jolli/jollimemory")).toBe(false);
+		});
 	});
 });

--- a/cli/src/core/PathUtils.ts
+++ b/cli/src/core/PathUtils.ts
@@ -35,6 +35,26 @@ export function normalizePathForCompare(p: string): string {
 }
 
 /**
+ * Returns true iff `child` is `parent` itself or a path nested inside it.
+ *
+ * Both endpoints run through {@link normalizePathForCompare} (separator + case
+ * folding on Windows/macOS), then a directory-boundary check so that
+ * `.jolli/jollimemoryX` is NOT treated as inside `.jolli/jollimemory`.
+ *
+ * Used to decide whether a registry entry's `sourcePath` lives inside the
+ * per-project `.jolli/jollimemory/` directory: hard-delete the backing file
+ * only for inside paths; external files (e.g. `~/.claude/plans/foo.md`) keep
+ * their file and lose only the registry row. Like `normalizePathForCompare`
+ * it does NOT call `path.resolve` (WSL POSIX-absolute rationale) — callers
+ * pass absolute paths.
+ */
+export function isPathInside(child: string, parent: string): boolean {
+	const c = normalizePathForCompare(child);
+	const p = normalizePathForCompare(parent);
+	return c === p || c.startsWith(`${p}/`);
+}
+
+/**
  * Converts a filesystem path to forward-slash form (POSIX-style).
  *
  * Single-purpose helper: replaces `\` with `/`, does NOT touch case, does NOT

--- a/cli/src/core/PlanPromptFormatter.test.ts
+++ b/cli/src/core/PlanPromptFormatter.test.ts
@@ -19,7 +19,6 @@ function makePlan(overrides: Partial<PlanEntry> = {}): PlanEntry {
 		sourcePath: "/abs/path/my-plan.md",
 		addedAt: "2026-05-13T00:00:00Z",
 		updatedAt: "2026-05-14T00:00:00Z",
-		branch: "main",
 		commitHash: null,
 		...overrides,
 	};

--- a/cli/src/core/PromptTemplates.test.ts
+++ b/cli/src/core/PromptTemplates.test.ts
@@ -413,7 +413,7 @@ describe("PromptTemplates", () => {
 				placeholders.add(match[1]);
 			}
 			// Caller still must pass commit info + conversation + diff plus the
-			// three Stage 2 structured-context blocks (references / plans / notes).
+			// three structured-context blocks (references / plans / notes).
 			// No more topicGuidance or workSize-derived field.
 			expect(placeholders).toEqual(
 				new Set([

--- a/cli/src/core/Regenerator.test.ts
+++ b/cli/src/core/Regenerator.test.ts
@@ -1156,7 +1156,7 @@ describe("regenerateSummary", () => {
 			// helper adds it before calling readReferenceFromBranch. The fallback
 			// inside readReferenceFromBranch strips it back to read the legacy
 			// `linear-issues/<bareKey>.md` path on disk — verified by the call
-			// argument including the `linear:` prefix exactly as plan §Task 2.10
+			// argument including the `linear:` prefix, exactly as the projection
 			// specifies.
 			const v3Legacy: CommitSummary = {
 				...baseSummary,

--- a/cli/src/core/SessionTracker.test.ts
+++ b/cli/src/core/SessionTracker.test.ts
@@ -73,16 +73,20 @@ import {
 	loadConfig,
 	loadConfigFromDir,
 	loadCursorForTranscript,
+	loadDiscoveryCursor,
 	loadMostRecentSession,
 	loadPlanEntry,
 	loadPlansRegistry,
 	loadPluginSource,
 	loadSquashPending,
+	migrateDiscoveryCursors,
+	normalizePlansRegistry,
 	pruneStaleQueueEntries,
 	pruneStaleSessions,
 	saveConfig,
 	saveConfigScoped,
 	saveCursor,
+	saveDiscoveryCursor,
 	savePlansRegistry,
 	savePluginSource,
 	saveSession,
@@ -318,6 +322,77 @@ describe("SessionTracker", () => {
 			);
 
 			await expect(loadCursorForTranscript("/path/stale-plan.jsonl", tempDir)).resolves.toBeNull();
+		});
+	});
+
+	describe("discovery cursors (discovery-cursors.json)", () => {
+		it("round-trips a discovery cursor in a file separate from cursors.json", async () => {
+			await saveDiscoveryCursor(
+				{ transcriptPath: "/path/t.jsonl", lineNumber: 642, updatedAt: "2026-06-03T00:00:00Z" },
+				tempDir,
+			);
+
+			await expect(loadDiscoveryCursor("/path/t.jsonl", tempDir)).resolves.toEqual(
+				expect.objectContaining({ lineNumber: 642 }),
+			);
+			// Written to discovery-cursors.json, NOT cursors.json (QueueWorker main-line isolation).
+			expect(await loadCursorForTranscript("/path/t.jsonl", tempDir)).toBeNull();
+			const dcj = await readFile(join(tempDir, ".jolli", "jollimemory", "discovery-cursors.json"), "utf-8");
+			expect(JSON.parse(dcj).cursors["/path/t.jsonl"].lineNumber).toBe(642);
+		});
+
+		it("returns null for an unknown transcript path", async () => {
+			await expect(loadDiscoveryCursor("/nope.jsonl", tempDir)).resolves.toBeNull();
+		});
+
+		it("migrate folds plan:/linear: keys with min() and deletes the legacy keys", async () => {
+			// Same path discovered by both plan (line 100) and reference (line 60) scans.
+			await saveCursor({ transcriptPath: "plan:/path/x.jsonl", lineNumber: 100, updatedAt: "t" }, tempDir);
+			await saveCursor({ transcriptPath: "linear:/path/x.jsonl", lineNumber: 60, updatedAt: "t" }, tempDir);
+			// A bare summarization cursor (QueueWorker main line) must be left untouched.
+			await saveCursor({ transcriptPath: "/path/bare.jsonl", lineNumber: 7, updatedAt: "t" }, tempDir);
+
+			await migrateDiscoveryCursors(tempDir);
+
+			// Folded to min(100, 60) = 60 in discovery-cursors.json.
+			await expect(loadDiscoveryCursor("/path/x.jsonl", tempDir)).resolves.toEqual(
+				expect.objectContaining({ lineNumber: 60 }),
+			);
+			// Legacy prefixed keys removed from cursors.json; bare key preserved.
+			expect(await loadCursorForTranscript("plan:/path/x.jsonl", tempDir)).toBeNull();
+			expect(await loadCursorForTranscript("linear:/path/x.jsonl", tempDir)).toBeNull();
+			await expect(loadCursorForTranscript("/path/bare.jsonl", tempDir)).resolves.toEqual(
+				expect.objectContaining({ lineNumber: 7 }),
+			);
+		});
+
+		it("migrate folds against an existing discovery cursor with min() (never advances past prior progress)", async () => {
+			await saveDiscoveryCursor({ transcriptPath: "/path/y.jsonl", lineNumber: 50, updatedAt: "t" }, tempDir);
+			await saveCursor({ transcriptPath: "plan:/path/y.jsonl", lineNumber: 80, updatedAt: "t" }, tempDir);
+
+			await migrateDiscoveryCursors(tempDir);
+
+			await expect(loadDiscoveryCursor("/path/y.jsonl", tempDir)).resolves.toEqual(
+				expect.objectContaining({ lineNumber: 50 }),
+			);
+		});
+
+		it("migrate is an idempotent no-op once no prefixed keys remain", async () => {
+			await saveCursor({ transcriptPath: "plan:/path/z.jsonl", lineNumber: 30, updatedAt: "t" }, tempDir);
+			await migrateDiscoveryCursors(tempDir);
+			const first = await loadDiscoveryCursor("/path/z.jsonl", tempDir);
+
+			// Second run: cursors.json has no prefixed keys → early return, discovery unchanged.
+			await migrateDiscoveryCursors(tempDir);
+			const second = await loadDiscoveryCursor("/path/z.jsonl", tempDir);
+
+			expect(second).toEqual(first);
+			expect(second).toEqual(expect.objectContaining({ lineNumber: 30 }));
+		});
+
+		it("migrate is a no-op when there are no cursors at all", async () => {
+			await expect(migrateDiscoveryCursors(tempDir)).resolves.toBeUndefined();
+			expect(await loadDiscoveryCursor("/path/none.jsonl", tempDir)).toBeNull();
 		});
 	});
 
@@ -654,7 +729,6 @@ describe("SessionTracker", () => {
 						sourcePath: "plans/feature-auth.md",
 						addedAt: "2026-03-01T10:00:00Z",
 						updatedAt: "2026-03-01T10:00:00Z",
-						branch: "main",
 						commitHash: null,
 					},
 				},
@@ -674,7 +748,6 @@ describe("SessionTracker", () => {
 						sourcePath: "plans/feature-auth.md",
 						addedAt: "2026-03-01T10:00:00Z",
 						updatedAt: "2026-03-01T10:00:00Z",
-						branch: "main",
 						commitHash: null,
 					},
 				},
@@ -734,7 +807,6 @@ describe("SessionTracker", () => {
 						sourcePath: "plans/feature-auth.md",
 						addedAt: "2026-03-01T10:00:00Z",
 						updatedAt: "2026-03-01T10:00:00Z",
-						branch: "main",
 						commitHash: null,
 					},
 				},
@@ -936,7 +1008,6 @@ describe("SessionTracker", () => {
 						sourcePath: "plans/feature-auth.md",
 						addedAt: "2026-03-01T10:00:00Z",
 						updatedAt: "2026-03-01T10:00:00Z",
-						branch: "main",
 						commitHash: "abcdef1234567890",
 					},
 				},
@@ -1004,7 +1075,6 @@ describe("SessionTracker", () => {
 						format: "snippet" as const,
 						addedAt: "2026-03-01T10:00:00Z",
 						updatedAt: "2026-03-01T10:00:00Z",
-						branch: "feature/test",
 						commitHash: null,
 					},
 				},
@@ -2196,5 +2266,130 @@ describe("SessionTracker", () => {
 			if (after.version !== 1) return;
 			expect(after.notes?.["note-1"]).toBeDefined();
 		});
+	});
+});
+
+describe("normalizePlansRegistry", () => {
+	const plan = (over: Record<string, unknown>) => ({
+		slug: "s",
+		title: "T",
+		sourcePath: "/p/s.md",
+		addedAt: "t",
+		updatedAt: "t",
+		commitHash: null,
+		...over,
+	});
+	const ref = (over: Record<string, unknown>) => ({
+		source: "linear",
+		nativeId: "X-1",
+		title: "T",
+		url: "https://x/1",
+		sourcePath: "/r/x.md",
+		addedAt: "t",
+		updatedAt: "t",
+		sourceToolName: "mcp__linear__get_issue",
+		...over,
+	});
+
+	it("plans: drops ignored rows, strips ignored/branch/editCount, keeps guard", () => {
+		const raw = {
+			version: 1,
+			plans: {
+				active: plan({ slug: "active", branch: "main", editCount: 3 }),
+				guard: plan({
+					slug: "guard",
+					commitHash: "abc",
+					contentHashAtCommit: "h",
+					branch: "main",
+					editCount: 1,
+				}),
+				gone: plan({ slug: "gone", ignored: true }),
+			},
+		} as unknown as Partial<PlansRegistry>;
+
+		const { registry, changed } = normalizePlansRegistry(raw);
+
+		expect(changed).toBe(true);
+		expect(Object.keys(registry.plans).sort()).toEqual(["active", "guard"]);
+		expect(JSON.stringify(registry.plans)).not.toMatch(/editCount|"branch"|"ignored"/);
+		expect(registry.plans.guard?.commitHash).toBe("abc");
+		expect(registry.plans.guard?.contentHashAtCommit).toBe("h");
+	});
+
+	it("notes: drops ignored rows, strips ignored/branch, keeps guard", () => {
+		const raw = {
+			version: 1,
+			plans: {},
+			notes: {
+				keep: {
+					id: "keep",
+					title: "K",
+					format: "markdown",
+					addedAt: "t",
+					updatedAt: "t",
+					commitHash: null,
+					branch: "main",
+				},
+				drop: {
+					id: "drop",
+					title: "D",
+					format: "markdown",
+					addedAt: "t",
+					updatedAt: "t",
+					commitHash: null,
+					ignored: true,
+				},
+			},
+		} as unknown as Partial<PlansRegistry>;
+
+		const { registry, changed } = normalizePlansRegistry(raw);
+
+		expect(changed).toBe(true);
+		expect(Object.keys(registry.notes ?? {})).toEqual(["keep"]);
+		expect(JSON.stringify(registry.notes)).not.toMatch(/"branch"|"ignored"/);
+	});
+
+	it("references: drops ignored/committed/guard rows, keeps active rows, strips dead fields", () => {
+		const raw = {
+			version: 1,
+			plans: {},
+			references: {
+				"linear:ACTIVE-1": ref({ nativeId: "ACTIVE-1", branch: "main", ignored: false }),
+				// Active ticket whose id ends in 8 digits — must NOT be mistaken for a
+				// `-<8hex>` archive key and dropped (regression guard: digits ⊂ hex).
+				"linear:ENG-12345678": ref({ nativeId: "ENG-12345678" }),
+				"linear:COMMITTED-2": ref({ nativeId: "COMMITTED-2", commitHash: "abc12345" }),
+				"linear:GUARD-3": ref({ nativeId: "GUARD-3", contentHashAtCommit: "h" }),
+				"notion:IGNORED-5": ref({ source: "notion", nativeId: "IGNORED-5", ignored: true }),
+			},
+		} as unknown as Partial<PlansRegistry>;
+
+		const { registry, changed } = normalizePlansRegistry(raw);
+
+		expect(changed).toBe(true);
+		expect(Object.keys(registry.references ?? {}).sort()).toEqual(["linear:ACTIVE-1", "linear:ENG-12345678"]);
+		expect(JSON.stringify(registry.references)).not.toMatch(/"branch"|"ignored"|"commitHash"|contentHashAtCommit/);
+	});
+
+	it("is idempotent: an already-clean registry returns changed=false and equal data", () => {
+		const clean = {
+			version: 1 as const,
+			plans: { a: plan({ slug: "a" }) },
+			notes: {},
+			references: {},
+		} as unknown as PlansRegistry;
+
+		const { registry, changed } = normalizePlansRegistry(clean);
+
+		expect(changed).toBe(false);
+		expect(registry).toEqual(clean);
+	});
+
+	it("missing notes/references sections stay absent (no-op)", () => {
+		const { registry, changed } = normalizePlansRegistry({ version: 1, plans: {} });
+		expect(changed).toBe(false);
+		expect(registry).toEqual({ version: 1, plans: {} });
+		expect(registry.notes).toBeUndefined();
+		expect(registry.references).toBeUndefined();
 	});
 });

--- a/cli/src/core/SessionTracker.test.ts
+++ b/cli/src/core/SessionTracker.test.ts
@@ -2,7 +2,6 @@ import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { hashReferenceContent } from "./references/ReferenceStore.js";
 
 const { mockRename, realRename } = vi.hoisted(() => ({
 	mockRename: vi.fn<typeof import("node:fs/promises").rename>(),
@@ -54,7 +53,6 @@ import type {
 import {
 	associateNoteWithCommit,
 	associatePlanWithCommit,
-	associateReferenceWithCommit,
 	checkStaleSquashPending,
 	countActiveQueueEntries,
 	countStaleQueueEntries,
@@ -82,7 +80,6 @@ import {
 	loadSquashPending,
 	pruneStaleQueueEntries,
 	pruneStaleSessions,
-	referencePath,
 	saveConfig,
 	saveConfigScoped,
 	saveCursor,
@@ -90,7 +87,6 @@ import {
 	savePluginSource,
 	saveSession,
 	saveSquashPending,
-	setReferenceIgnored,
 	upsertReferenceEntry,
 } from "./SessionTracker.js";
 
@@ -289,7 +285,7 @@ describe("SessionTracker", () => {
 			);
 		});
 
-		it("should prune stale plan cursors during save", async () => {
+		it("should prune stale cursors during save", async () => {
 			const dir = await ensureJolliMemoryDir(tempDir);
 			const staleTime = new Date(Date.now() - 49 * 60 * 60 * 1000).toISOString();
 			const staleSession: SessionInfo = {
@@ -305,7 +301,7 @@ describe("SessionTracker", () => {
 
 			await saveCursor(
 				{
-					transcriptPath: "plan:/path/stale-plan.jsonl",
+					transcriptPath: "/path/stale-plan.jsonl",
 					lineNumber: 9,
 					updatedAt: staleTime,
 				},
@@ -321,7 +317,7 @@ describe("SessionTracker", () => {
 				tempDir,
 			);
 
-			await expect(loadCursorForTranscript("plan:/path/stale-plan.jsonl", tempDir)).resolves.toBeNull();
+			await expect(loadCursorForTranscript("/path/stale-plan.jsonl", tempDir)).resolves.toBeNull();
 		});
 	});
 
@@ -701,7 +697,7 @@ describe("SessionTracker", () => {
 			await expect(loadPlansRegistry(tempDir)).resolves.toEqual({ version: 1, plans: {} });
 		});
 
-		it("should associate a plan with a commit and update updatedAt", async () => {
+		it("should migrate the guard's commitHash and updatedAt when given an archive id", async () => {
 			const before = {
 				version: 1 as const,
 				plans: {
@@ -712,16 +708,19 @@ describe("SessionTracker", () => {
 						addedAt: "2026-03-01T10:00:00Z",
 						updatedAt: "2026-03-01T10:00:00Z",
 						branch: "main",
-						commitHash: null,
+						commitHash: "abcdef1234567890",
+						contentHashAtCommit: "guardhash",
 					},
 				},
 			};
 			await savePlansRegistry(before as unknown as Parameters<typeof savePlansRegistry>[0], tempDir);
 
-			await associatePlanWithCommit("feature-auth", "abcdef1234567890", tempDir);
+			// Only the guard row survives. associate sweeps it forward when the
+			// archive id (`<base>-<oldShortHash>`) matches the guard's current hash.
+			await associatePlanWithCommit("feature-auth-abcdef12", "1111111122222222", tempDir);
 
 			const after = await loadPlansRegistry(tempDir);
-			expect(after.plans["feature-auth"]?.commitHash).toBe("abcdef1234567890");
+			expect(after.plans["feature-auth"]?.commitHash).toBe("1111111122222222");
 			expect(after.plans["feature-auth"]?.updatedAt).not.toBe("2026-03-01T10:00:00Z");
 		});
 
@@ -752,45 +751,33 @@ describe("SessionTracker", () => {
 		// guard entry was left pointing at the soon-to-be-orphan commit — so a user
 		// edit to the source file would "revive" the guard with a stale hash label.
 		describe("guard-entry migration on squash/rebase", () => {
-			it("should migrate the guard entry's commitHash and recompute contentHashAtCommit when the file is unchanged", async () => {
-				const planFile = join(tempDir, "plan.md");
-				const planBody = "# My Plan\n\nstep 1\n";
-				await writeFile(planFile, planBody, "utf-8");
-				const { createHash } = await import("node:crypto");
-				const fileHash = createHash("sha256").update(planBody).digest("hex");
-
+			it("should migrate the guard's commitHash and preserve contentHashAtCommit", async () => {
 				const before = {
 					version: 1 as const,
 					plans: {
 						"my-plan": {
 							slug: "my-plan",
 							title: "My Plan",
-							sourcePath: planFile,
+							sourcePath: join(tempDir, "plan.md"),
 							addedAt: "2026-03-01T10:00:00Z",
 							updatedAt: "2026-03-01T10:00:00Z",
 							branch: "feature/x",
 							commitHash: "35080b05360866b87dc03dfe9204ec148f263660",
-							contentHashAtCommit: fileHash,
-						},
-						"my-plan-35080b05": {
-							slug: "my-plan-35080b05",
-							title: "My Plan",
-							sourcePath: planFile,
-							addedAt: "2026-03-01T10:00:00Z",
-							updatedAt: "2026-03-01T10:00:00Z",
-							branch: "feature/x",
-							commitHash: "35080b05360866b87dc03dfe9204ec148f263660",
+							contentHashAtCommit: "archivehash",
 						},
 					},
 				};
 				await savePlansRegistry(before as unknown as Parameters<typeof savePlansRegistry>[0], tempDir);
 
+				// No archive row exists — associate splits the archive id to find the
+				// guard, sweeps its commitHash forward, and preserves contentHashAtCommit
+				// (squash rewrites commit metadata, not file content, so the archive-time
+				// anchor must survive for revival detection).
 				await associatePlanWithCommit("my-plan-35080b05", "6c66a12e50f0cf1129f8e63b340897832d22ecee", tempDir);
 
 				const after = await loadPlansRegistry(tempDir);
-				expect(after.plans["my-plan-35080b05"]?.commitHash).toBe("6c66a12e50f0cf1129f8e63b340897832d22ecee");
 				expect(after.plans["my-plan"]?.commitHash).toBe("6c66a12e50f0cf1129f8e63b340897832d22ecee");
-				expect(after.plans["my-plan"]?.contentHashAtCommit).toBe(fileHash);
+				expect(after.plans["my-plan"]?.contentHashAtCommit).toBe("archivehash");
 			});
 
 			it("should preserve contentHashAtCommit even when the source file has been edited since archive (revival signal must survive squash)", async () => {
@@ -877,38 +864,25 @@ describe("SessionTracker", () => {
 			});
 
 			it("does not migrate the guard when its commitHash no longer matches the archive's oldShortHash", async () => {
-				// Pins SessionTracker.ts L947 false branch: guard exists with
-				// contentHashAtCommit (first arm of &&) but its commitHash does
-				// NOT start with the archive's oldShortHash (second arm). This
-				// happens when the guard was already re-anchored by a prior
-				// squash and the older archive id is now stale — re-applying
-				// would clobber the freshly-correct guard hash.
-				const planFile = join(tempDir, "plan.md");
-				await writeFile(planFile, "# any\n", "utf-8");
+				// Guard exists with contentHashAtCommit (first arm of &&) but its
+				// commitHash does NOT start with the archive id's oldShortHash (second
+				// arm). This happens when the guard was already re-anchored by a prior
+				// squash and the older archive id is now stale — re-applying would
+				// clobber the freshly-correct guard hash, so associate must no-op.
 				const before = {
 					version: 1 as const,
 					plans: {
 						"my-plan": {
 							slug: "my-plan",
 							title: "My Plan",
-							sourcePath: planFile,
+							sourcePath: join(tempDir, "plan.md"),
 							addedAt: "2026-03-01T10:00:00Z",
 							updatedAt: "2026-03-01T10:00:00Z",
 							branch: "feature/x",
-							// Guard's commitHash starts with "99999999", NOT
-							// "35080b05" — so the guard belongs to a different
-							// archive cycle and must not be touched.
+							// Guard's commitHash starts with "99999999", NOT "35080b05" —
+							// so the guard belongs to a different archive cycle.
 							commitHash: "9999999999999999999999999999999999999999",
 							contentHashAtCommit: "guardhash",
-						},
-						"my-plan-35080b05": {
-							slug: "my-plan-35080b05",
-							title: "My Plan",
-							sourcePath: planFile,
-							addedAt: "2026-03-01T10:00:00Z",
-							updatedAt: "2026-03-01T10:00:00Z",
-							branch: "feature/x",
-							commitHash: "35080b05360866b87dc03dfe9204ec148f263660",
 						},
 					},
 				};
@@ -917,15 +891,15 @@ describe("SessionTracker", () => {
 				await associatePlanWithCommit("my-plan-35080b05", "6c66a12e50f0cf1129f8e63b340897832d22ecee", tempDir);
 
 				const after = await loadPlansRegistry(tempDir);
-				// Archive migrated; guard left alone (different commit lineage).
-				expect(after.plans["my-plan-35080b05"]?.commitHash).toBe("6c66a12e50f0cf1129f8e63b340897832d22ecee");
+				// Guard left alone (different commit lineage).
 				expect(after.plans["my-plan"]?.commitHash).toBe("9999999999999999999999999999999999999999");
 				expect(after.plans["my-plan"]?.contentHashAtCommit).toBe("guardhash");
 			});
 
 			it("should not migrate any guard when the archive id has no -<shortHash> suffix", async () => {
-				// Defensive: a caller could pass a base-slug-shaped id (no suffix). The
-				// function must not invent a guard target out of an unrelated entry.
+				// Defensive: a caller could pass a base-slug-shaped id (no suffix).
+				// splitArchivedKey returns null for it, so associate is a complete
+				// no-op — it must not re-anchor the unrelated base entry.
 				const before = {
 					version: 1 as const,
 					plans: {
@@ -946,10 +920,8 @@ describe("SessionTracker", () => {
 				await associatePlanWithCommit("my-plan", "6c66a12e50f0cf1129f8e63b340897832d22ecee", tempDir);
 
 				const after = await loadPlansRegistry(tempDir);
-				// Direct migration of the named entry still happens, but contentHashAtCommit
-				// is left alone — only guard-entry migration triggered through an archive id
-				// recomputes it.
-				expect(after.plans["my-plan"]?.commitHash).toBe("6c66a12e50f0cf1129f8e63b340897832d22ecee");
+				// No archive id → complete no-op: the base entry is untouched.
+				expect(after.plans["my-plan"]?.commitHash).toBeNull();
 				expect(after.plans["my-plan"]?.contentHashAtCommit).toBe("stalehash");
 			});
 		});
@@ -977,29 +949,32 @@ describe("SessionTracker", () => {
 	});
 
 	describe("associateNoteWithCommit", () => {
-		it("should associate a note with a commit and update updatedAt", async () => {
+		it("should migrate the guard's commitHash and updatedAt when given an archive id", async () => {
 			const before = {
 				version: 1 as const,
 				plans: {},
 				notes: {
-					"note-1-abc": {
-						id: "note-1-abc",
+					"note-1": {
+						id: "note-1",
 						title: "My Note",
 						format: "snippet" as const,
 						addedAt: "2026-03-01T10:00:00Z",
 						updatedAt: "2026-03-01T10:00:00Z",
 						branch: "feature/test",
-						commitHash: null,
+						commitHash: "abcdef1234567890",
+						contentHashAtCommit: "guardhash",
 					},
 				},
 			};
 			await savePlansRegistry(before as unknown as Parameters<typeof savePlansRegistry>[0], tempDir);
 
-			await associateNoteWithCommit("note-1-abc", "abcdef1234567890", tempDir);
+			// Only the guard row survives; associate sweeps it forward when the
+			// archive id (`<base>-<oldShortHash>`) matches the guard's current hash.
+			await associateNoteWithCommit("note-1-abcdef12", "1111111122222222", tempDir);
 
 			const after = await loadPlansRegistry(tempDir);
-			expect(after.notes?.["note-1-abc"]?.commitHash).toBe("abcdef1234567890");
-			expect(after.notes?.["note-1-abc"]?.updatedAt).not.toBe("2026-03-01T10:00:00Z");
+			expect(after.notes?.["note-1"]?.commitHash).toBe("1111111122222222");
+			expect(after.notes?.["note-1"]?.updatedAt).not.toBe("2026-03-01T10:00:00Z");
 		});
 
 		it("should handle registry with no notes field", async () => {
@@ -1042,13 +1017,7 @@ describe("SessionTracker", () => {
 		});
 
 		describe("guard-entry migration on squash/rebase", () => {
-			it("should migrate the guard entry's commitHash and recompute contentHashAtCommit when the source file is unchanged", async () => {
-				const noteFile = join(tempDir, "note.md");
-				const body = "# Active AI Conversations — Design Document\n\nA note body.\n";
-				await writeFile(noteFile, body, "utf-8");
-				const { createHash } = await import("node:crypto");
-				const fileHash = createHash("sha256").update(body).digest("hex");
-
+			it("should migrate the guard's commitHash and preserve contentHashAtCommit", async () => {
 				const before = {
 					version: 1 as const,
 					plans: {},
@@ -1057,27 +1026,19 @@ describe("SessionTracker", () => {
 							id: "note-035b",
 							title: "Active AI Conversations — Design Document",
 							format: "markdown" as const,
-							sourcePath: noteFile,
+							sourcePath: join(tempDir, "note.md"),
 							addedAt: "2026-03-01T10:00:00Z",
 							updatedAt: "2026-03-01T10:00:00Z",
 							branch: "feature/active-conversations",
 							commitHash: "35080b05360866b87dc03dfe9204ec148f263660",
-							contentHashAtCommit: fileHash,
-						},
-						"note-035b-35080b05": {
-							id: "note-035b-35080b05",
-							title: "Active AI Conversations — Design Document",
-							format: "markdown" as const,
-							sourcePath: noteFile,
-							addedAt: "2026-03-01T10:00:00Z",
-							updatedAt: "2026-03-01T10:00:00Z",
-							branch: "feature/active-conversations",
-							commitHash: "35080b05360866b87dc03dfe9204ec148f263660",
+							contentHashAtCommit: "archivehash",
 						},
 					},
 				};
 				await savePlansRegistry(before as unknown as Parameters<typeof savePlansRegistry>[0], tempDir);
 
+				// No archive row — split the archive id to the guard, sweep its
+				// commitHash forward, preserve contentHashAtCommit for revival detection.
 				await associateNoteWithCommit(
 					"note-035b-35080b05",
 					"6c66a12e50f0cf1129f8e63b340897832d22ecee",
@@ -1085,11 +1046,8 @@ describe("SessionTracker", () => {
 				);
 
 				const after = await loadPlansRegistry(tempDir);
-				expect(after.notes?.["note-035b-35080b05"]?.commitHash).toBe(
-					"6c66a12e50f0cf1129f8e63b340897832d22ecee",
-				);
 				expect(after.notes?.["note-035b"]?.commitHash).toBe("6c66a12e50f0cf1129f8e63b340897832d22ecee");
-				expect(after.notes?.["note-035b"]?.contentHashAtCommit).toBe(fileHash);
+				expect(after.notes?.["note-035b"]?.contentHashAtCommit).toBe("archivehash");
 			});
 
 			it("should preserve contentHashAtCommit even when the source file has been edited since archive (revival signal must survive squash)", async () => {
@@ -1205,15 +1163,6 @@ describe("SessionTracker", () => {
 							commitHash: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 							contentHashAtCommit: "stalehash",
 						},
-						"note-035b-deadbeef": {
-							id: "note-035b-deadbeef",
-							title: "Note",
-							format: "snippet" as const,
-							addedAt: "2026-03-01T10:00:00Z",
-							updatedAt: "2026-03-01T10:00:00Z",
-							branch: "feature/x",
-							commitHash: "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
-						},
 					},
 				};
 				await savePlansRegistry(before as unknown as Parameters<typeof savePlansRegistry>[0], tempDir);
@@ -1225,9 +1174,6 @@ describe("SessionTracker", () => {
 				);
 
 				const after = await loadPlansRegistry(tempDir);
-				expect(after.notes?.["note-035b-deadbeef"]?.commitHash).toBe(
-					"6c66a12e50f0cf1129f8e63b340897832d22ecee",
-				);
 				// Guard untouched because its commitHash didn't match the archive id's
 				// `deadbeef` suffix — different commit lineage.
 				expect(after.notes?.["note-035b"]?.commitHash).toBe("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
@@ -1237,9 +1183,9 @@ describe("SessionTracker", () => {
 	});
 
 	describe("detectActiveNotesForBranch", () => {
-		// Active = uncommitted (commitHash null), not ignored, no guard
-		// (contentHashAtCommit undefined). Pins the four filter arms.
-		it("returns only active notes on the requested branch (filters branch / commitHash / ignored / guard)", async () => {
+		// Active = uncommitted (commitHash null) with no guard (contentHashAtCommit
+		// undefined). Branch / ignored scoping was removed, so neither field filters.
+		it("returns only active (uncommitted, un-guarded) notes", async () => {
 			const registry = {
 				version: 1 as const,
 				plans: {},
@@ -1250,16 +1196,6 @@ describe("SessionTracker", () => {
 						format: "snippet" as const,
 						addedAt: "2026-04-01T00:00:00Z",
 						updatedAt: "2026-04-01T00:00:00Z",
-						branch: "feature/x",
-						commitHash: null,
-					},
-					"note-other-branch": {
-						id: "note-other-branch",
-						title: "Other branch note",
-						format: "snippet" as const,
-						addedAt: "2026-04-01T00:00:00Z",
-						updatedAt: "2026-04-01T00:00:00Z",
-						branch: "feature/y",
 						commitHash: null,
 					},
 					"note-committed": {
@@ -1268,18 +1204,7 @@ describe("SessionTracker", () => {
 						format: "snippet" as const,
 						addedAt: "2026-04-01T00:00:00Z",
 						updatedAt: "2026-04-01T00:00:00Z",
-						branch: "feature/x",
 						commitHash: "deadbeefcafebabe",
-					},
-					"note-ignored": {
-						id: "note-ignored",
-						title: "Ignored note",
-						format: "snippet" as const,
-						addedAt: "2026-04-01T00:00:00Z",
-						updatedAt: "2026-04-01T00:00:00Z",
-						branch: "feature/x",
-						commitHash: null,
-						ignored: true,
 					},
 					"note-guarded": {
 						id: "note-guarded",
@@ -1287,7 +1212,6 @@ describe("SessionTracker", () => {
 						format: "snippet" as const,
 						addedAt: "2026-04-01T00:00:00Z",
 						updatedAt: "2026-04-01T00:00:00Z",
-						branch: "feature/x",
 						commitHash: null,
 						contentHashAtCommit: "fakehash",
 					},
@@ -1882,146 +1806,42 @@ describe("SessionTracker", () => {
 			expect((await getReferenceEntriesForBranch(tempDir, "main")).map((e) => e.nativeId)).toEqual(["PROJ-1528"]);
 		});
 
-		it("filters out entries on other branches", async () => {
-			await upsertReferenceEntry(ref(), tempDir, "feature-a");
-			expect(await detectUncommittedReferenceIds(tempDir, "main")).toEqual([]);
-		});
-
-		it("filters out ignored entries", async () => {
-			await seed({
-				"PROJ-1": {
-					source: "linear",
-					nativeId: "PROJ-1",
-					title: "t",
-					url: "u",
-					sourcePath: "p",
-					branch: "main",
-					addedAt: "x",
-					updatedAt: "x",
-					commitHash: null,
-					sourceToolName: "mcp__linear__get_issue",
-					ignored: true,
-				},
-			});
-			expect(await detectUncommittedReferenceIds(tempDir, "main")).toEqual([]);
-		});
-
-		it("filters out guard entries (have contentHashAtCommit)", async () => {
-			await seed({
-				"PROJ-1": {
-					source: "linear",
-					nativeId: "PROJ-1",
-					title: "t",
-					url: "u",
-					sourcePath: "p",
-					branch: "main",
-					addedAt: "x",
-					updatedAt: "x",
-					commitHash: "abc1234",
-					contentHashAtCommit: "hash",
-					sourceToolName: "mcp__linear__get_issue",
-				},
-			});
-			expect(await detectUncommittedReferenceIds(tempDir, "main")).toEqual([]);
-		});
-
-		it("filters out archived snapshot entries (commitHash set)", async () => {
-			await seed({
-				"PROJ-1-abc1234": {
-					source: "linear",
-					nativeId: "PROJ-1",
-					title: "t",
-					url: "u",
-					sourcePath: "p",
-					branch: "main",
-					addedAt: "x",
-					updatedAt: "x",
-					commitHash: "abc1234",
-					sourceToolName: "mcp__linear__get_issue",
-				},
-			});
-			expect(await detectUncommittedReferenceIds(tempDir, "main")).toEqual([]);
-		});
-
 		it("returns empty for repos with no linearIssues section", async () => {
 			await savePlansRegistry({ version: 1, plans: {} }, tempDir);
 			expect(await detectUncommittedReferenceIds(tempDir, "main")).toEqual([]);
 			expect(await getReferenceEntriesForBranch(tempDir, "main")).toEqual([]);
 		});
 
-		// Pins each of the four filter arms (branch / commitHash / ignored /
-		// contentHashAtCommit) for `getReferenceEntriesForBranch` itself —
-		// detectUncommittedReferenceIds covers the same arms separately but
-		// v8 tracks them per function.
-		it("getReferenceEntriesForBranch filters by branch / commitHash / ignored / guard arms", async () => {
+		it("getReferenceEntriesForBranch returns every registry entry regardless of source", async () => {
+			// References are removed from the registry at commit time, so every
+			// surviving row is an active, uncommitted reference — there is no
+			// branch / commitHash / ignored / guard filtering to apply.
 			await seed({
-				"PROJ-active": {
+				"linear:PROJ-1": {
 					source: "linear",
-					nativeId: "PROJ-active",
-					title: "active",
+					nativeId: "PROJ-1",
+					title: "one",
 					url: "u",
 					sourcePath: "p",
-					branch: "main",
 					addedAt: "x",
 					updatedAt: "x",
-					commitHash: null,
 					sourceToolName: "mcp__linear__get_issue",
 				},
-				"PROJ-otherbranch": {
-					source: "linear",
-					nativeId: "PROJ-otherbranch",
-					title: "other",
+				"jira:KAN-2": {
+					source: "jira",
+					nativeId: "KAN-2",
+					title: "two",
 					url: "u",
 					sourcePath: "p",
-					branch: "feature-b",
 					addedAt: "x",
 					updatedAt: "x",
-					commitHash: null,
-					sourceToolName: "mcp__linear__get_issue",
-				},
-				"PROJ-committed": {
-					source: "linear",
-					nativeId: "PROJ-committed",
-					title: "committed",
-					url: "u",
-					sourcePath: "p",
-					branch: "main",
-					addedAt: "x",
-					updatedAt: "x",
-					commitHash: "deadbeef",
-					sourceToolName: "mcp__linear__get_issue",
-				},
-				"PROJ-ignored": {
-					source: "linear",
-					nativeId: "PROJ-ignored",
-					title: "ignored",
-					url: "u",
-					sourcePath: "p",
-					branch: "main",
-					addedAt: "x",
-					updatedAt: "x",
-					commitHash: null,
-					ignored: true,
-					sourceToolName: "mcp__linear__get_issue",
-				},
-				"PROJ-guard": {
-					source: "linear",
-					nativeId: "PROJ-guard",
-					title: "guard",
-					url: "u",
-					sourcePath: "p",
-					branch: "main",
-					addedAt: "x",
-					updatedAt: "x",
-					commitHash: null,
-					contentHashAtCommit: "fakehash",
-					sourceToolName: "mcp__linear__get_issue",
+					sourceToolName: "mcp__atlassian__getJiraIssue",
 				},
 			});
 
 			const result = await getReferenceEntriesForBranch(tempDir, "main");
 
-			expect(result.map((e) => e.nativeId)).toEqual(["PROJ-active"]);
+			expect(result.map((e) => e.nativeId).sort()).toEqual(["KAN-2", "PROJ-1"]);
 		});
 	});
 
@@ -2042,47 +1862,12 @@ describe("SessionTracker", () => {
 			const reg = await loadPlansRegistry(tempDir);
 			const e = linearIssuesOfReg(reg)?.["PROJ-1528"];
 			expect(e).toBeDefined();
-			expect(e?.commitHash).toBeNull();
-			expect(e?.contentHashAtCommit).toBeUndefined();
-			expect(e?.branch).toBe("main");
 			expect(e?.sourcePath).toContain("PROJ-1528.md");
 			expect(e?.sourceToolName).toBe("mcp__linear__get_issue");
+			expect(e?.title).toBe("Treat referenced Linear issues");
 		});
 
-		it("preserves addedAt, branch, ignored on update of existing uncommitted entry", async () => {
-			await upsertReferenceEntry(ref(), tempDir, "main");
-			const first = await loadPlansRegistry(tempDir);
-			const existing = first.references?.["linear:PROJ-1528"];
-			if (!existing) {
-				throw new Error("test setup invariant: upserted entry missing");
-			}
-			const addedAt = existing.addedAt;
-			// Pretend the user ignored it manually
-			await savePlansRegistry(
-				{
-					version: 1,
-					plans: first.plans,
-					references: {
-						...first.references,
-						"linear:PROJ-1528": { ...existing, ignored: true },
-					},
-				},
-				tempDir,
-			);
-			// Second upsert (StopHook re-discovers) should NOT clear ignored, but should be a no-op
-			await upsertReferenceEntry(
-				ref({ title: "new title", referencedAt: "2026-05-14T07:00:00Z" }),
-				tempDir,
-				"main",
-			);
-			const after = await loadPlansRegistry(tempDir);
-			const e = linearIssuesOfReg(after)?.["PROJ-1528"];
-			expect(e?.ignored).toBe(true);
-			expect(e?.title).toBe("Treat referenced Linear issues"); // unchanged because ignored
-			expect(e?.addedAt).toBe(addedAt);
-		});
-
-		it("refreshes title/url/sourceToolName on uncommitted entry without ignored", async () => {
+		it("refreshes title/url/sourceToolName on an existing entry, preserving addedAt", async () => {
 			await upsertReferenceEntry(ref(), tempDir, "main");
 			const before = await loadPlansRegistry(tempDir);
 			const addedAt = linearIssuesOfReg(before)?.["PROJ-1528"]?.addedAt;
@@ -2103,166 +1888,10 @@ describe("SessionTracker", () => {
 			expect(e?.sourceToolName).toBe("mcp__linear__list_issues");
 			expect(e?.addedAt).toBe(addedAt); // preserved
 		});
-
-		it("returns no-op when an existing guard's contentHashAtCommit matches", async () => {
-			await savePlansRegistry(
-				{
-					version: 1,
-					plans: {},
-					references: {
-						"linear:PROJ-1528": {
-							source: "linear",
-							nativeId: "PROJ-1528",
-							title: "old",
-							url: "u",
-							sourcePath: "/p",
-							branch: "main",
-							addedAt: "2026-01-01T00:00:00Z",
-							updatedAt: "2026-01-01T00:00:00Z",
-							commitHash: "abc1234",
-							contentHashAtCommit: hashReferenceContent(ref({ title: "new title" })),
-							sourceToolName: "mcp__linear__get_issue",
-						},
-					},
-				},
-				tempDir,
-			);
-			await upsertReferenceEntry(ref({ title: "new title" }), tempDir, "main");
-			const after = await loadPlansRegistry(tempDir);
-			expect(linearIssuesOfReg(after)?.["PROJ-1528"]?.title).toBe("old"); // unchanged
-			expect(linearIssuesOfReg(after)?.["PROJ-1528"]?.commitHash).toBe("abc1234");
-		});
-
-		it("replaces a guard entry with a fresh uncommitted one when content hash differs", async () => {
-			await savePlansRegistry(
-				{
-					version: 1,
-					plans: {},
-					references: {
-						"linear:PROJ-1528": {
-							source: "linear",
-							nativeId: "PROJ-1528",
-							title: "old",
-							url: "u",
-							sourcePath: "/p",
-							branch: "main",
-							addedAt: "2026-01-01T00:00:00Z",
-							updatedAt: "2026-01-01T00:00:00Z",
-							commitHash: "abc1234",
-							contentHashAtCommit: "old-hash",
-							sourceToolName: "mcp__linear__get_issue",
-						},
-					},
-				},
-				tempDir,
-			);
-			await upsertReferenceEntry(ref({ title: "new" }), tempDir, "main");
-			const after = await loadPlansRegistry(tempDir);
-			const e = linearIssuesOfReg(after)?.["PROJ-1528"];
-			expect(e?.title).toBe("new");
-			expect(e?.commitHash).toBeNull();
-			expect(e?.contentHashAtCommit).toBeUndefined();
-		});
-
-		it("creates a fresh entry when an existing one is on a different branch (defensive isolation)", async () => {
-			await savePlansRegistry(
-				{
-					version: 1,
-					plans: {},
-					references: {
-						"linear:PROJ-1528": {
-							source: "linear",
-							nativeId: "PROJ-1528",
-							title: "old on feature-a",
-							url: "u",
-							sourcePath: "/p",
-							branch: "feature-a",
-							addedAt: "2026-01-01T00:00:00Z",
-							updatedAt: "2026-01-01T00:00:00Z",
-							commitHash: null,
-							sourceToolName: "mcp__linear__get_issue",
-						},
-					},
-				},
-				tempDir,
-			);
-			// Upsert from a different branch — defensive replacement to a fresh entry on "main"
-			await upsertReferenceEntry(ref({ title: "fresh on main" }), tempDir, "main");
-			const after = await loadPlansRegistry(tempDir);
-			const e = linearIssuesOfReg(after)?.["PROJ-1528"];
-			expect(e?.branch).toBe("main");
-			expect(e?.title).toBe("fresh on main");
-		});
-
-		it("never resurrects an entry whose guard is ignored", async () => {
-			await savePlansRegistry(
-				{
-					version: 1,
-					plans: {},
-					references: {
-						"linear:PROJ-1528": {
-							source: "linear",
-							nativeId: "PROJ-1528",
-							title: "old",
-							url: "u",
-							sourcePath: "/p",
-							branch: "main",
-							addedAt: "2026-01-01T00:00:00Z",
-							updatedAt: "2026-01-01T00:00:00Z",
-							commitHash: "abc1234",
-							contentHashAtCommit: "old-hash",
-							ignored: true,
-							sourceToolName: "mcp__linear__get_issue",
-						},
-					},
-				},
-				tempDir,
-			);
-			await upsertReferenceEntry(ref({ title: "new" }), tempDir, "main");
-			const after = await loadPlansRegistry(tempDir);
-			expect(linearIssuesOfReg(after)?.["PROJ-1528"]?.title).toBe("old"); // unchanged
-			expect(linearIssuesOfReg(after)?.["PROJ-1528"]?.ignored).toBe(true);
-		});
-	});
-
-	describe("associateReferenceWithCommit", () => {
-		it("updates commitHash on the entry keyed by archivedKey", async () => {
-			await savePlansRegistry(
-				{
-					version: 1,
-					plans: {},
-					references: {
-						"PROJ-1528-abc1234": {
-							source: "linear",
-							nativeId: "PROJ-1528",
-							title: "t",
-							url: "u",
-							sourcePath: "/p",
-							branch: "main",
-							addedAt: "x",
-							updatedAt: "x",
-							commitHash: "abc1234",
-							sourceToolName: "mcp__linear__get_issue",
-						},
-					},
-				},
-				tempDir,
-			);
-			await associateReferenceWithCommit("PROJ-1528-abc1234", "def5678abc", tempDir);
-			const after = await loadPlansRegistry(tempDir);
-			expect(linearIssuesOfReg(after)?.["PROJ-1528-abc1234"]?.commitHash).toBe("def5678abc");
-		});
-
-		it("is a no-op when the archivedKey is not in the registry", async () => {
-			await savePlansRegistry({ version: 1, plans: {}, references: {} }, tempDir);
-			await associateReferenceWithCommit("PROJ-99-zzz", "newhash", tempDir);
-			const after = await loadPlansRegistry(tempDir);
-			expect(linearIssuesOfReg(after)).toEqual({});
-		});
 	});
 
 	describe("detectActivePlansForBranch / detectActiveNotesForBranch", () => {
-		it("returns uncommitted plans for current branch", async () => {
+		it("returns all uncommitted plans regardless of branch", async () => {
 			await savePlansRegistry(
 				{
 					version: 1,
@@ -2271,7 +1900,6 @@ describe("SessionTracker", () => {
 							slug: "plan-1",
 							title: "t",
 							sourcePath: "/p",
-							branch: "main",
 							addedAt: "x",
 							updatedAt: "x",
 							commitHash: null,
@@ -2280,27 +1908,16 @@ describe("SessionTracker", () => {
 							slug: "plan-2",
 							title: "t",
 							sourcePath: "/p",
-							branch: "feature",
 							addedAt: "x",
 							updatedAt: "x",
 							commitHash: null,
-						},
-						"plan-3": {
-							slug: "plan-3",
-							title: "t",
-							sourcePath: "/p",
-							branch: "main",
-							addedAt: "x",
-							updatedAt: "x",
-							commitHash: null,
-							ignored: true,
 						},
 					},
 				},
 				tempDir,
 			);
 			const plans = await detectActivePlansForBranch(tempDir, "main");
-			expect(plans.map((p) => p.slug)).toEqual(["plan-1"]);
+			expect(plans.map((p) => p.slug).sort()).toEqual(["plan-1", "plan-2"]);
 		});
 
 		it("detectActivePlansForBranch skips committed and guarded plans (covers commitHash + contentHash filter arms)", async () => {
@@ -2312,7 +1929,6 @@ describe("SessionTracker", () => {
 							slug: "plan-active",
 							title: "active",
 							sourcePath: "/p",
-							branch: "main",
 							addedAt: "x",
 							updatedAt: "x",
 							commitHash: null,
@@ -2321,7 +1937,6 @@ describe("SessionTracker", () => {
 							slug: "plan-committed",
 							title: "committed",
 							sourcePath: "/p",
-							branch: "main",
 							addedAt: "x",
 							updatedAt: "x",
 							commitHash: "abcdef1234567890",
@@ -2330,7 +1945,6 @@ describe("SessionTracker", () => {
 							slug: "plan-guarded",
 							title: "guarded",
 							sourcePath: "/p",
-							branch: "main",
 							addedAt: "x",
 							updatedAt: "x",
 							commitHash: null,
@@ -2356,7 +1970,6 @@ describe("SessionTracker", () => {
 							id: "note-1",
 							title: "t",
 							format: "snippet",
-							branch: "main",
 							addedAt: "x",
 							updatedAt: "x",
 							commitHash: null,
@@ -2365,7 +1978,6 @@ describe("SessionTracker", () => {
 							id: "note-2",
 							title: "t",
 							format: "snippet",
-							branch: "main",
 							addedAt: "x",
 							updatedAt: "x",
 							commitHash: "abc",
@@ -2400,51 +2012,9 @@ describe("SessionTracker", () => {
 			const entries = await getReferenceEntriesForBranch(tempDir, "main");
 			expect(entries).toEqual([]);
 		});
-
-		it("detectUncommittedReferenceIds filters out entries on other branches (L1058 true arm)", async () => {
-			// Pins the `entry.branch !== branch ? continue` branch at L1058
-			// inside detectUncommittedReferenceIds — the existing
-			// `getReferenceEntriesForBranch` test covers its sibling but not this
-			// one, since the two functions duplicate the filter loop.
-			await savePlansRegistry(
-				{
-					version: 1,
-					plans: {},
-					references: {
-						"jira:KAN-main": {
-							source: "jira",
-							nativeId: "KAN-main",
-							title: "main-branch entry",
-							url: "u",
-							sourcePath: "/p1",
-							branch: "main",
-							addedAt: "x",
-							updatedAt: "x",
-							commitHash: null,
-							sourceToolName: "test",
-						},
-						"jira:KAN-feature": {
-							source: "jira",
-							nativeId: "KAN-feature",
-							title: "feature-branch entry — should be filtered",
-							url: "u",
-							sourcePath: "/p2",
-							branch: "feature",
-							addedAt: "x",
-							updatedAt: "x",
-							commitHash: null,
-							sourceToolName: "test",
-						},
-					},
-				},
-				tempDir,
-			);
-			const ids = await detectUncommittedReferenceIds(tempDir, "main");
-			expect(ids.map((i) => i.mapKey)).toEqual(["jira:KAN-main"]);
-		});
 	});
 
-	describe("upsertReferenceEntry / getReferenceEntriesForBranch / detectUncommittedReferenceIds / setReferenceIgnored", () => {
+	describe("upsertReferenceEntry / getReferenceEntriesForBranch / detectUncommittedReferenceIds", () => {
 		function entityRef(overrides: Partial<Reference> = {}): Reference {
 			return {
 				mapKey: "jira:KAN-5",
@@ -2477,13 +2047,6 @@ describe("SessionTracker", () => {
 			expect(entries.map((e) => e.source).sort()).toEqual(["jira", "linear"]);
 		});
 
-		it("filters out entries on other branches", async () => {
-			await upsertReferenceEntry(entityRef(), tempDir, "main");
-			await upsertReferenceEntry(entityRef({ mapKey: "jira:KAN-6", nativeId: "KAN-6" }), tempDir, "feature");
-			const main = await getReferenceEntriesForBranch(tempDir, "main");
-			expect(main.map((e) => e.nativeId)).toEqual(["KAN-5"]);
-		});
-
 		it("detectUncommittedReferenceIds returns {mapKey, source, sourcePath} triples", async () => {
 			await upsertReferenceEntry(entityRef(), tempDir, "main");
 			const ids = await detectUncommittedReferenceIds(tempDir, "main");
@@ -2492,191 +2055,7 @@ describe("SessionTracker", () => {
 			expect(ids[0]?.sourcePath).toContain(join("references", "jira", "KAN-5.md"));
 		});
 
-		it("setReferenceIgnored hides the entry from getReferenceEntriesForBranch and unflag restores it", async () => {
-			await upsertReferenceEntry(entityRef(), tempDir, "main");
-			await setReferenceIgnored(tempDir, "jira:KAN-5", true);
-			expect(await getReferenceEntriesForBranch(tempDir, "main")).toEqual([]);
-			await setReferenceIgnored(tempDir, "jira:KAN-5", false);
-			const back = await getReferenceEntriesForBranch(tempDir, "main");
-			expect(back).toHaveLength(1);
-		});
-
-		it("setReferenceIgnored is a no-op when the mapKey is unknown", async () => {
-			await setReferenceIgnored(tempDir, "jira:nope", true);
-			// Should not throw and should not write a stub entry.
-			expect(await getReferenceEntriesForBranch(tempDir, "main")).toEqual([]);
-		});
-
-		it("upsertReferenceEntry is a no-op when the existing guard entry is also ignored", async () => {
-			// Pins the `if (existing.ignored) return;` arm inside the guard-branch
-			// of upsertReferenceEntry (line 1082). Without this, an ignored guard
-			// silently gets replaced by a fresh uncommitted row — the opposite
-			// of what `ignored` is supposed to mean.
-			await savePlansRegistry(
-				{
-					version: 1,
-					plans: {},
-					references: {
-						"jira:KAN-5": {
-							source: "jira",
-							nativeId: "KAN-5",
-							title: "guarded-and-ignored",
-							url: "u",
-							sourcePath: "/p",
-							branch: "main",
-							addedAt: "x",
-							updatedAt: "x",
-							commitHash: "deadbeef",
-							contentHashAtCommit: "old-hash",
-							ignored: true,
-							sourceToolName: "mcp__atlassian__getJiraIssue",
-						},
-					},
-				},
-				tempDir,
-			);
-			await upsertReferenceEntry(entityRef({ title: "new" }), tempDir, "main");
-			const after = await loadPlansRegistry(tempDir);
-			if (after.version !== 1) return;
-			expect(after.references?.["jira:KAN-5"]?.title).toBe("guarded-and-ignored");
-			expect(after.references?.["jira:KAN-5"]?.ignored).toBe(true);
-		});
-
-		it("getReferenceEntriesForBranch skips committed / guard / ignored entries", async () => {
-			// Pins the three true arms inside getReferenceEntriesForBranch (lines
-			// 1032-1034) that "filters out entries on other branches" doesn't
-			// reach because that test only filters by branch.
-			await savePlansRegistry(
-				{
-					version: 1,
-					plans: {},
-					references: {
-						"jira:KAN-active": {
-							source: "jira",
-							nativeId: "KAN-active",
-							title: "active",
-							url: "u",
-							sourcePath: "/p",
-							branch: "main",
-							addedAt: "x",
-							updatedAt: "x",
-							commitHash: null,
-							sourceToolName: "test",
-						},
-						"jira:KAN-committed": {
-							source: "jira",
-							nativeId: "KAN-committed",
-							title: "committed",
-							url: "u",
-							sourcePath: "/p",
-							branch: "main",
-							addedAt: "x",
-							updatedAt: "x",
-							commitHash: "deadbeef",
-							sourceToolName: "test",
-						},
-						"jira:KAN-guard": {
-							source: "jira",
-							nativeId: "KAN-guard",
-							title: "guard",
-							url: "u",
-							sourcePath: "/p",
-							branch: "main",
-							addedAt: "x",
-							updatedAt: "x",
-							commitHash: null,
-							contentHashAtCommit: "h",
-							sourceToolName: "test",
-						},
-						"jira:KAN-ignored": {
-							source: "jira",
-							nativeId: "KAN-ignored",
-							title: "ignored",
-							url: "u",
-							sourcePath: "/p",
-							branch: "main",
-							addedAt: "x",
-							updatedAt: "x",
-							commitHash: null,
-							ignored: true,
-							sourceToolName: "test",
-						},
-					},
-				},
-				tempDir,
-			);
-			const entries = await getReferenceEntriesForBranch(tempDir, "main");
-			expect(entries.map((e) => e.nativeId)).toEqual(["KAN-active"]);
-		});
-
-		it("detectUncommittedReferenceIds skips entries with commitHash / contentHashAtCommit / ignored", async () => {
-			// Pins the three true arms inside detectUncommittedReferenceIds (lines
-			// 1053-1055) that "filters out entries on other branches" doesn't
-			// reach because that test only filters by branch.
-			await savePlansRegistry(
-				{
-					version: 1,
-					plans: {},
-					references: {
-						"jira:KAN-active": {
-							source: "jira",
-							nativeId: "KAN-active",
-							title: "active",
-							url: "u",
-							sourcePath: "/p",
-							branch: "main",
-							addedAt: "x",
-							updatedAt: "x",
-							commitHash: null,
-							sourceToolName: "test",
-						},
-						"jira:KAN-committed": {
-							source: "jira",
-							nativeId: "KAN-committed",
-							title: "committed",
-							url: "u",
-							sourcePath: "/p",
-							branch: "main",
-							addedAt: "x",
-							updatedAt: "x",
-							commitHash: "deadbeef",
-							sourceToolName: "test",
-						},
-						"jira:KAN-guard": {
-							source: "jira",
-							nativeId: "KAN-guard",
-							title: "guard",
-							url: "u",
-							sourcePath: "/p",
-							branch: "main",
-							addedAt: "x",
-							updatedAt: "x",
-							commitHash: null,
-							contentHashAtCommit: "h",
-							sourceToolName: "test",
-						},
-						"jira:KAN-ignored": {
-							source: "jira",
-							nativeId: "KAN-ignored",
-							title: "ignored",
-							url: "u",
-							sourcePath: "/p",
-							branch: "main",
-							addedAt: "x",
-							updatedAt: "x",
-							commitHash: null,
-							ignored: true,
-							sourceToolName: "test",
-						},
-					},
-				},
-				tempDir,
-			);
-			const ids = await detectUncommittedReferenceIds(tempDir, "main");
-			expect(ids.map((x) => x.mapKey)).toEqual(["jira:KAN-active"]);
-		});
-
-		it("upsertReferenceEntry refreshes title/url on an uncommitted same-branch entry (updated log path)", async () => {
+		it("upsertReferenceEntry refreshes title/url on an uncommitted entry (updated log path)", async () => {
 			// Pins the `existing === undefined ? "new" : "updated"` ternary's
 			// "updated" arm in upsertReferenceEntry's log line, plus the
 			// canRefreshUncommitted branch above it.
@@ -2685,195 +2064,6 @@ describe("SessionTracker", () => {
 			const entries = await getReferenceEntriesForBranch(tempDir, "main");
 			expect(entries).toHaveLength(1);
 			expect(entries[0]?.title).toBe("renamed");
-		});
-
-		it("upsertReferenceEntry is a no-op when an existing uncommitted entry is ignored", async () => {
-			// Seed an uncommitted (commitHash:null, no contentHashAtCommit) entry with ignored:true.
-			await savePlansRegistry(
-				{
-					version: 1,
-					plans: {},
-					references: {
-						"jira:KAN-5": {
-							source: "jira",
-							nativeId: "KAN-5",
-							title: "old",
-							url: "u",
-							sourcePath: "/p",
-							branch: "main",
-							addedAt: "x",
-							updatedAt: "x",
-							commitHash: null,
-							ignored: true,
-							sourceToolName: "mcp__atlassian__getJiraIssue",
-						},
-					},
-				},
-				tempDir,
-			);
-			await upsertReferenceEntry(entityRef({ title: "new" }), tempDir, "main");
-			const after = await loadPlansRegistry(tempDir);
-			if (after.version !== 1) return;
-			expect(after.references?.["jira:KAN-5"]?.title).toBe("old"); // unchanged
-			expect(after.references?.["jira:KAN-5"]?.ignored).toBe(true);
-		});
-
-		it("upsertReferenceEntry replaces a guard entry when the content hash differs", async () => {
-			// Pins the `existing.contentHashAtCommit === contentHash` false arm in
-			// upsertReferenceEntry, plus the guard → fresh-uncommitted replacement
-			// path below it.
-			await upsertReferenceEntry(entityRef(), tempDir, "main");
-			const reg = await loadPlansRegistry(tempDir);
-			if (reg.version !== 1) return;
-			const existing = reg.references?.["jira:KAN-5"];
-			if (!existing) throw new Error("seed missing");
-			await savePlansRegistry(
-				{
-					...reg,
-					references: {
-						...(reg.references ?? {}),
-						"jira:KAN-5": {
-							...existing,
-							commitHash: "deadbeef",
-							contentHashAtCommit: "stale-hash-from-old-content",
-						},
-					},
-				},
-				tempDir,
-			);
-			await upsertReferenceEntry(entityRef({ title: "rewritten" }), tempDir, "main");
-			const after = await loadPlansRegistry(tempDir);
-			if (after.version !== 1) return;
-			const e = after.references?.["jira:KAN-5"];
-			// Replacement → fresh uncommitted entry: commitHash null, no guard hash.
-			expect(e?.commitHash).toBeNull();
-			expect(e?.contentHashAtCommit).toBeUndefined();
-			expect(e?.title).toBe("rewritten");
-		});
-
-		it("upsertReferenceEntry preserves the guard when the contentHash matches", async () => {
-			// Compute the canonical contentHash for the seed ref so the synthetic
-			// guard we install below actually round-trips against what the next
-			// upsert will compute internally.
-			const seedRef = entityRef();
-			const guardHash = hashReferenceContent(seedRef);
-			// First, write the markdown so the file exists at the canonical path.
-			await upsertReferenceEntry(seedRef, tempDir, "main");
-			// Promote the entry to guard state (simulate post-archive).
-			const reg = await loadPlansRegistry(tempDir);
-			expect(reg.version).toBe(1);
-			if (reg.version !== 1) return;
-			const existing = reg.references?.["jira:KAN-5"];
-			expect(existing).toBeDefined();
-			if (!existing) return;
-			await savePlansRegistry(
-				{
-					...reg,
-					references: {
-						...(reg.references ?? {}),
-						"jira:KAN-5": {
-							...existing,
-							commitHash: "deadbeef",
-							contentHashAtCommit: guardHash,
-						},
-					},
-				},
-				tempDir,
-			);
-			// Upsert with a different MCP timestamp but same content — should be a no-op
-			// because hashReferenceContent strips referencedAt before hashing.
-			await upsertReferenceEntry(entityRef({ referencedAt: "2027-01-01T00:00:00Z" }), tempDir, "main");
-			const after = await loadPlansRegistry(tempDir);
-			if (after.version !== 1) return;
-			expect(after.references?.["jira:KAN-5"]?.commitHash).toBe("deadbeef");
-		});
-	});
-
-	describe("associateReferenceWithCommit", () => {
-		it("updates commitHash on the archived snapshot entry", async () => {
-			await savePlansRegistry(
-				{
-					version: 1,
-					plans: {},
-					references: {
-						"jira:KAN-5-abc12345": {
-							source: "jira",
-							nativeId: "KAN-5",
-							title: "t",
-							url: "u",
-							sourcePath: "/p",
-							branch: "main",
-							addedAt: "x",
-							updatedAt: "x",
-							commitHash: "abc12345",
-							sourceToolName: "mcp__atlassian__getJiraIssue",
-						},
-					},
-				},
-				tempDir,
-			);
-			await associateReferenceWithCommit("jira:KAN-5-abc12345", "deadbeef1234567890", tempDir);
-			const reg = await loadPlansRegistry(tempDir);
-			if (reg.version !== 1) return;
-			expect(reg.references?.["jira:KAN-5-abc12345"]?.commitHash).toBe("deadbeef1234567890");
-		});
-
-		it("is a no-op when the archivedKey is unknown", async () => {
-			await savePlansRegistry({ version: 1, plans: {}, references: {} }, tempDir);
-			await associateReferenceWithCommit("jira:NOPE-1-abc12345", "newhash", tempDir);
-			const reg = await loadPlansRegistry(tempDir);
-			if (reg.version !== 1) return;
-			expect(reg.references).toEqual({});
-		});
-
-		it("also migrates the guard's commitHash when archive form matches the guard's old shortHash", async () => {
-			await savePlansRegistry(
-				{
-					version: 1,
-					plans: {},
-					references: {
-						"jira:KAN-5": {
-							source: "jira",
-							nativeId: "KAN-5",
-							title: "guard",
-							url: "u",
-							sourcePath: "/p",
-							branch: "main",
-							addedAt: "x",
-							updatedAt: "x",
-							commitHash: "abc12345",
-							contentHashAtCommit: "guard-hash",
-							sourceToolName: "mcp__atlassian__getJiraIssue",
-						},
-						"jira:KAN-5-abc12345": {
-							source: "jira",
-							nativeId: "KAN-5",
-							title: "snapshot",
-							url: "u",
-							sourcePath: "/p",
-							branch: "main",
-							addedAt: "x",
-							updatedAt: "x",
-							commitHash: "abc12345",
-							sourceToolName: "mcp__atlassian__getJiraIssue",
-						},
-					},
-				},
-				tempDir,
-			);
-			await associateReferenceWithCommit("jira:KAN-5-abc12345", "newhash", tempDir);
-			const reg = await loadPlansRegistry(tempDir);
-			if (reg.version !== 1) return;
-			expect(reg.references?.["jira:KAN-5-abc12345"]?.commitHash).toBe("newhash");
-			// Guard also migrates because guard.commitHash starts with the old shortHash.
-			expect(reg.references?.["jira:KAN-5"]?.commitHash).toBe("newhash");
-		});
-	});
-
-	describe("referencePath", () => {
-		it("returns the canonical <jolliMemoryDir>/references/<source>/<key>.md path", () => {
-			const p = referencePath(tempDir, "jira", "KAN-5");
-			expect(p).toContain(join(".jolli", "jollimemory", "references", "jira", "KAN-5.md"));
 		});
 	});
 
@@ -2907,10 +2097,8 @@ describe("SessionTracker", () => {
 							title: "active jira",
 							url: "u",
 							sourcePath: "/p",
-							branch: "main",
 							addedAt: "x",
 							updatedAt: "x",
-							commitHash: null,
 							sourceToolName: "test",
 						},
 					},
@@ -2919,36 +2107,6 @@ describe("SessionTracker", () => {
 			);
 			const ids = await detectUncommittedReferenceIds(tempDir, "main");
 			expect(ids.map((i) => i.mapKey)).toEqual(["jira:KAN-5"]);
-		});
-
-		it("detectUncommittedReferenceIds filters out a contentHashAtCommit guard whose commitHash is null", async () => {
-			// Pins the `entry.contentHashAtCommit !== undefined` true arm — a
-			// guard whose commitHash hasn't yet been backfilled by an associate
-			// (commitHash:null + contentHashAtCommit defined) must still be
-			// considered "no longer uncommitted" by the legacy detector.
-			await savePlansRegistry(
-				{
-					version: 1,
-					plans: {},
-					references: {
-						"linear:PROJ-guard": {
-							source: "linear",
-							nativeId: "PROJ-guard",
-							title: "g",
-							url: "u",
-							sourcePath: "/p",
-							branch: "main",
-							addedAt: "x",
-							updatedAt: "x",
-							commitHash: null,
-							contentHashAtCommit: "synthetic",
-							sourceToolName: "test",
-						},
-					},
-				},
-				tempDir,
-			);
-			expect(await detectUncommittedReferenceIds(tempDir, "main")).toEqual([]);
 		});
 
 		it("tolerates a references row with a bare (no `linear:` prefix) map key", async () => {
@@ -2965,10 +2123,8 @@ describe("SessionTracker", () => {
 							title: "bare",
 							url: "u",
 							sourcePath: "/p",
-							branch: "main",
 							addedAt: "x",
 							updatedAt: "x",
-							commitHash: null,
 							sourceToolName: "mcp__linear__get_issue",
 						},
 					},
@@ -3013,64 +2169,6 @@ describe("SessionTracker", () => {
 				tempDir,
 				"main",
 			);
-			const after = await loadPlansRegistry(tempDir);
-			if (after.version !== 1) return;
-			expect(after.notes?.["note-1"]).toBeDefined();
-		});
-
-		it("setReferenceIgnored preserves the notes section", async () => {
-			await savePlansRegistry(
-				{
-					version: 1,
-					plans: {},
-					references: {
-						"jira:KAN-5": {
-							source: "jira",
-							nativeId: "KAN-5",
-							title: "t",
-							url: "u",
-							sourcePath: "/p",
-							branch: "main",
-							addedAt: "x",
-							updatedAt: "x",
-							commitHash: null,
-							sourceToolName: "test",
-						},
-					},
-					notes: seedNotes,
-				},
-				tempDir,
-			);
-			await setReferenceIgnored(tempDir, "jira:KAN-5", true);
-			const after = await loadPlansRegistry(tempDir);
-			if (after.version !== 1) return;
-			expect(after.notes?.["note-1"]).toBeDefined();
-		});
-
-		it("associateReferenceWithCommit preserves the notes section", async () => {
-			await savePlansRegistry(
-				{
-					version: 1,
-					plans: {},
-					references: {
-						"jira:KAN-5-abc12345": {
-							source: "jira",
-							nativeId: "KAN-5",
-							title: "t",
-							url: "u",
-							sourcePath: "/p",
-							branch: "main",
-							addedAt: "x",
-							updatedAt: "x",
-							commitHash: "abc12345",
-							sourceToolName: "test",
-						},
-					},
-					notes: seedNotes,
-				},
-				tempDir,
-			);
-			await associateReferenceWithCommit("jira:KAN-5-abc12345", "newhash", tempDir);
 			const after = await loadPlansRegistry(tempDir);
 			if (after.version !== 1) return;
 			expect(after.notes?.["note-1"]).toBeDefined();

--- a/cli/src/core/SessionTracker.ts
+++ b/cli/src/core/SessionTracker.ts
@@ -787,23 +787,133 @@ async function atomicWrite(filePath: string, content: string): Promise<void> {
 
 // ─── Plans Registry ───────────────────────────────────────────────────────────
 
+/** Legacy fields removed from PlanEntry (`editCount` is plan-only) and NoteEntry. */
+const LEGACY_PLAN_FIELDS = ["ignored", "branch", "editCount"] as const;
+const LEGACY_NOTE_FIELDS = ["ignored", "branch"] as const;
+/** Reference rows are now always active/uncommitted — these all became dead fields. */
+const LEGACY_REFERENCE_FIELDS = ["ignored", "branch", "commitHash", "contentHashAtCommit"] as const;
+
+/** Deletes `fields` from a shallow copy of `entry`; returns the copy + whether anything was dropped. */
+function stripLegacyFields<T>(entry: T, fields: ReadonlyArray<string>): { value: T; changed: boolean } {
+	const out = { ...(entry as unknown as Record<string, unknown>) };
+	let changed = false;
+	for (const f of fields) {
+		if (f in out) {
+			delete out[f];
+			changed = true;
+		}
+	}
+	return { value: out as T, changed };
+}
+
 /**
- * Loads the plans registry from plans.json.
+ * One-shot, in-memory migration of a parsed plans.json into the current schema
+ * (see docs/2026-06-01-discovery-cursor-split-and-editcount-removal.md §14).
  *
- * Returns an empty registry (`{ version: 1, plans: {} }`) if the file doesn't
- * exist or contains invalid JSON. Normalises missing required fields so
- * downstream `registry.plans[...]` reads never throw on a hand-edited file.
+ * Pure + idempotent — clean input returns `changed: false`. Per type:
+ *   - plans / notes: drop rows with `ignored === true`; strip dead fields
+ *     (`ignored` / `branch` / `editCount`); keep the `commitHash` +
+ *     `contentHashAtCommit` guard.
+ *   - references: also drop committed / guard rows — detected ONLY by the
+ *     `commitHash` / `contentHashAtCommit` fields, deliberately NOT by a
+ *     `-<8hex>` key shape (an active ticket id can legitimately end in 8 digits;
+ *     see the predicate below) — a reference row is now always
+ *     active/uncommitted — and strip the four now-dead fields from survivors.
+ *
+ * `JSON.parse` keeps unknown keys and `savePlansRegistry` re-serialises the
+ * whole object, so legacy fields/rows do NOT disappear on their own; this is
+ * the single place that purges them.
  */
-export async function loadPlansRegistry(cwd?: string): Promise<PlansRegistry> {
+export function normalizePlansRegistry(raw: Partial<PlansRegistry>): { registry: PlansRegistry; changed: boolean } {
+	let changed = false;
+
+	const plans: Record<string, PlanEntry> = {};
+	for (const [slug, entry] of Object.entries(raw.plans ?? {})) {
+		if ((entry as unknown as Record<string, unknown>).ignored === true) {
+			changed = true;
+			continue;
+		}
+		const stripped = stripLegacyFields(entry, LEGACY_PLAN_FIELDS);
+		if (stripped.changed) changed = true;
+		plans[slug] = stripped.value;
+	}
+
+	let notes: Record<string, NoteEntry> | undefined;
+	if (raw.notes !== undefined) {
+		notes = {};
+		for (const [id, entry] of Object.entries(raw.notes)) {
+			if ((entry as unknown as Record<string, unknown>).ignored === true) {
+				changed = true;
+				continue;
+			}
+			const stripped = stripLegacyFields(entry, LEGACY_NOTE_FIELDS);
+			if (stripped.changed) changed = true;
+			notes[id] = stripped.value;
+		}
+	}
+
+	let references: Record<string, ReferenceEntry> | undefined;
+	if (raw.references !== undefined) {
+		references = {};
+		for (const [key, entry] of Object.entries(raw.references)) {
+			// A legacy committed/archived reference row always carries `commitHash`
+			// (and usually `contentHashAtCommit`); these field checks catch them all.
+			// We deliberately do NOT match on a `-<8hex>` key shape: an active ticket
+			// id can legitimately end in `-<8 digits>` (e.g. linear:ENG-12345678), and
+			// digits ⊂ hex, so a key-shape heuristic would silently drop a live row.
+			const e = entry as unknown as Record<string, unknown>;
+			if (e.ignored === true || e.commitHash != null || e.contentHashAtCommit !== undefined) {
+				changed = true;
+				continue;
+			}
+			const stripped = stripLegacyFields(entry, LEGACY_REFERENCE_FIELDS);
+			if (stripped.changed) changed = true;
+			references[key] = stripped.value;
+		}
+	}
+
+	const registry: PlansRegistry = {
+		version: 1,
+		plans,
+		...(notes !== undefined ? { notes } : {}),
+		...(references !== undefined ? { references } : {}),
+	};
+	return { registry, changed };
+}
+
+/**
+ * Loads the plans registry from plans.json together with a `changed` flag
+ * indicating whether {@link normalizePlansRegistry} purged any legacy row/field.
+ * Callers that want to persist the cleaned shape (the deterministic-writeback
+ * path) use `changed`; {@link loadPlansRegistry} discards it.
+ *
+ * Returns an empty registry (`{ version: 1, plans: {} }`, `changed: false`) if
+ * the file is missing or contains invalid JSON.
+ */
+export async function loadPlansRegistryWithStatus(
+	cwd?: string,
+): Promise<{ registry: PlansRegistry; changed: boolean }> {
 	const dir = getJolliMemoryDir(cwd);
 	const filePath = join(dir, PLANS_FILE);
 	try {
 		const content = await readFile(filePath, "utf-8");
 		const parsed = JSON.parse(content) as Partial<PlansRegistry>;
-		return { ...parsed, version: 1, plans: parsed.plans ?? {} };
+		return normalizePlansRegistry(parsed);
 	} catch {
-		return { version: 1, plans: {} };
+		return { registry: { version: 1, plans: {} }, changed: false };
 	}
+}
+
+/**
+ * Loads the plans registry from plans.json, normalised to the current schema.
+ *
+ * Returns an empty registry (`{ version: 1, plans: {} }`) if the file doesn't
+ * exist or contains invalid JSON. Legacy rows/fields are purged in-memory via
+ * {@link normalizePlansRegistry} so every reader sees clean data even before
+ * the file is physically rewritten.
+ */
+export async function loadPlansRegistry(cwd?: string): Promise<PlansRegistry> {
+	return (await loadPlansRegistryWithStatus(cwd)).registry;
 }
 
 /**
@@ -823,7 +933,7 @@ export async function savePlansRegistry(registry: PlansRegistry, cwd?: string): 
  * single inflection point that distinguishes "first-time association" from
  * "squash/rebase re-anchoring of an existing archive".
  */
-function splitArchivedKey(archivedKey: string): { baseKey: string; oldShortHash: string } | null {
+export function splitArchivedKey(archivedKey: string): { baseKey: string; oldShortHash: string } | null {
 	const match = archivedKey.match(/^(.+)-([0-9a-f]{8})$/);
 	if (!match) return null;
 	return { baseKey: match[1] as string, oldShortHash: match[2] as string };

--- a/cli/src/core/SessionTracker.ts
+++ b/cli/src/core/SessionTracker.ts
@@ -31,12 +31,14 @@ import type {
 	SquashPendingState,
 	TranscriptCursor,
 } from "../Types.js";
-import { referencePath as canonicalReferencePath, writeReferenceMarkdown } from "./references/ReferenceStore.js";
+import { writeReferenceMarkdown } from "./references/ReferenceStore.js";
 
 const log = createLogger("SessionTracker");
 
 const SESSIONS_FILE = "sessions.json";
 const CURSORS_FILE = "cursors.json";
+/** Merged plan+reference discovery cursors (replaces plan:/linear: prefixed keys in cursors.json). */
+const DISCOVERY_CURSORS_FILE = "discovery-cursors.json";
 const CONFIG_FILE = "config.json";
 const PLANS_FILE = "plans.json";
 
@@ -184,15 +186,30 @@ export function filterSessionsByEnabledIntegrations(
  * @param cursor - The cursor to save
  * @param cwd - Optional working directory
  */
+/** Writes a full cursors registry to `<dir>/<filename>` atomically. */
+async function writeCursorsRegistry(registry: CursorsRegistry, dir: string, filename: string): Promise<void> {
+	await atomicWrite(join(dir, filename), JSON.stringify(registry, null, "\t"));
+}
+
+/** Upserts one cursor (keyed by transcriptPath) into the given cursors file. */
+async function upsertCursorInFile(cursor: TranscriptCursor, dir: string, filename: string): Promise<void> {
+	const registry = await loadCursorsRegistry(dir, filename);
+	const cursors = { ...registry.cursors, [cursor.transcriptPath]: cursor };
+	await writeCursorsRegistry({ version: 1, cursors }, dir, filename);
+}
+
 export async function saveCursor(cursor: TranscriptCursor, cwd?: string): Promise<void> {
 	const dir = await ensureJolliMemoryDir(cwd);
+	await upsertCursorInFile(cursor, dir, CURSORS_FILE);
+}
 
-	const registry = await loadCursorsRegistry(dir);
-	const cursors = { ...registry.cursors };
-	cursors[cursor.transcriptPath] = cursor;
-
-	const newRegistry: CursorsRegistry = { version: 1, cursors };
-	await atomicWrite(join(dir, CURSORS_FILE), JSON.stringify(newRegistry, null, "\t"));
+/**
+ * Saves the merged plan+reference discovery cursor to discovery-cursors.json,
+ * keyed by the bare transcriptPath (no plan:/linear: prefix).
+ */
+export async function saveDiscoveryCursor(cursor: TranscriptCursor, cwd?: string): Promise<void> {
+	const dir = await ensureJolliMemoryDir(cwd);
+	await upsertCursorInFile(cursor, dir, DISCOVERY_CURSORS_FILE);
 }
 
 /**
@@ -206,6 +223,43 @@ export async function loadCursorForTranscript(transcriptPath: string, cwd?: stri
 	const dir = getJolliMemoryDir(cwd);
 	const registry = await loadCursorsRegistry(dir);
 	return registry.cursors[transcriptPath] ?? null;
+}
+
+/** Loads the merged plan+reference discovery cursor from discovery-cursors.json. */
+export async function loadDiscoveryCursor(transcriptPath: string, cwd?: string): Promise<TranscriptCursor | null> {
+	const dir = getJolliMemoryDir(cwd);
+	const registry = await loadCursorsRegistry(dir, DISCOVERY_CURSORS_FILE);
+	return registry.cursors[transcriptPath] ?? null;
+}
+
+/**
+ * One-shot migration folding legacy `plan:` / `linear:` prefixed cursors
+ * from cursors.json into the merged discovery-cursors.json (keyed by bare path).
+ * Idempotent — a no-op once cursors.json has no prefixed keys. For each path the
+ * plan+linear lines are folded with `min()` so we never skip past either
+ * discovery's prior progress (the tiny re-scan overlap is safe because discovery
+ * is idempotent; `max()` would skip unprocessed lines).
+ */
+export async function migrateDiscoveryCursors(cwd?: string): Promise<void> {
+	const dir = await ensureJolliMemoryDir(cwd);
+	const legacy = await loadCursorsRegistry(dir, CURSORS_FILE);
+	const prefixedKeys = Object.keys(legacy.cursors).filter((k) => k.startsWith("plan:") || k.startsWith("linear:"));
+	if (prefixedKeys.length === 0) return; // already migrated / no legacy keys
+
+	const discovery = await loadCursorsRegistry(dir, DISCOVERY_CURSORS_FILE);
+	const merged = { ...discovery.cursors };
+	const remaining = { ...legacy.cursors };
+	const now = new Date().toISOString();
+	for (const key of prefixedKeys) {
+		const path = key.startsWith("plan:") ? key.slice("plan:".length) : key.slice("linear:".length);
+		const line = legacy.cursors[key].lineNumber;
+		const existing = merged[path];
+		const folded = existing ? Math.min(existing.lineNumber, line) : line;
+		merged[path] = { transcriptPath: path, lineNumber: folded, updatedAt: now };
+		delete remaining[key];
+	}
+	await writeCursorsRegistry({ version: 1, cursors: merged }, dir, DISCOVERY_CURSORS_FILE);
+	await writeCursorsRegistry({ version: 1, cursors: remaining }, dir, CURSORS_FILE);
 }
 
 /**
@@ -647,8 +701,8 @@ async function loadSessionsRegistry(dir: string): Promise<SessionsRegistry> {
  * Loads the cursors registry from cursors.json.
  * Returns an empty registry if the file doesn't exist or is corrupt.
  */
-async function loadCursorsRegistry(dir: string): Promise<CursorsRegistry> {
-	const filePath = join(dir, CURSORS_FILE);
+async function loadCursorsRegistry(dir: string, filename: string = CURSORS_FILE): Promise<CursorsRegistry> {
+	const filePath = join(dir, filename);
 	try {
 		const content = await readFile(filePath, "utf-8");
 		return JSON.parse(content) as CursorsRegistry;
@@ -683,27 +737,27 @@ function pruneStale(sessions: Readonly<Record<string, SessionInfo>>): {
 }
 
 /**
- * Removes cursor entries whose transcriptPath matches any of the stale paths.
- * Also prunes "plan:" prefixed cursors whose underlying transcript path is stale.
+ * Removes cursor entries whose transcriptPath matches any stale path, across
+ * BOTH cursors.json (QueueWorker summarization line) and discovery-cursors.json
+ * (merged plan+reference discovery line). Both files are keyed by the bare
+ * transcriptPath now (legacy plan:/linear: prefixes are folded away by
+ * migrateDiscoveryCursors), so a direct membership check prunes both.
  */
 async function pruneOrphanedCursors(dir: string, stalePaths: ReadonlyArray<string>): Promise<void> {
-	const registry = await loadCursorsRegistry(dir);
-	const cursors = { ...registry.cursors };
 	const staleSet = new Set(stalePaths);
-	let pruned = 0;
-
-	for (const key of Object.keys(cursors)) {
-		// Strip "plan:" prefix (if present) to match the underlying transcript path
-		const rawPath = key.startsWith("plan:") ? key.slice(5) : key;
-		if (staleSet.has(rawPath)) {
-			delete cursors[key];
-			pruned++;
+	for (const filename of [CURSORS_FILE, DISCOVERY_CURSORS_FILE]) {
+		const registry = await loadCursorsRegistry(dir, filename);
+		const cursors = { ...registry.cursors };
+		let pruned = 0;
+		for (const key of Object.keys(cursors)) {
+			if (staleSet.has(key)) {
+				delete cursors[key];
+				pruned++;
+			}
 		}
-	}
-
-	if (pruned > 0) {
-		const newRegistry: CursorsRegistry = { version: 1, cursors };
-		await atomicWrite(join(dir, CURSORS_FILE), JSON.stringify(newRegistry, null, "\t"));
+		if (pruned > 0) {
+			await writeCursorsRegistry({ version: 1, cursors }, dir, filename);
+		}
 	}
 }
 
@@ -787,35 +841,33 @@ function splitArchivedKey(archivedKey: string): { baseKey: string; oldShortHash:
  * survive so that uncommitted edits to the source still surface as a revived
  * guard on the next post-commit detection.
  */
-export async function associatePlanWithCommit(slug: string, commitHash: string, cwd?: string): Promise<void> {
+export async function associatePlanWithCommit(archivedSlug: string, commitHash: string, cwd?: string): Promise<void> {
+	// Per-commit archive rows are no longer created — only the guard row
+	// (base slug, carrying contentHashAtCommit) survives in plans.json. So this
+	// migration (reassociateMetadata after squash/rebase) just sweeps the matching
+	// guard's commitHash forward. `archivedSlug` is the CommitSummary pointer
+	// `<baseSlug>-<oldShortHash>`; we split it directly rather than looking up a
+	// (now-nonexistent) archive row first. contentHashAtCommit stays untouched —
+	// only commit metadata moved, not file content, so uncommitted edits still
+	// revive the guard on the next post-commit detection.
+	const split = splitArchivedKey(archivedSlug);
+	if (!split) {
+		log.debug("associatePlanWithCommit: %s is not an archived slug, skipping", archivedSlug);
+		return;
+	}
 	const registry = await loadPlansRegistry(cwd);
-	const entry = registry.plans[slug];
-	if (!entry) {
-		log.debug("associatePlanWithCommit: slug %s not in registry, skipping", slug);
+	const guard = registry.plans[split.baseKey];
+	if (!guard?.contentHashAtCommit || !guard.commitHash?.startsWith(split.oldShortHash)) {
+		log.debug("associatePlanWithCommit: no matching guard for %s, skipping", archivedSlug);
 		return;
 	}
 	const now = new Date().toISOString();
-	const nextPlans: Record<string, PlanEntry> = {
-		...registry.plans,
-		[slug]: { ...entry, commitHash, updatedAt: now },
+	const updated: PlansRegistry = {
+		...registry,
+		plans: { ...registry.plans, [split.baseKey]: { ...guard, commitHash, updatedAt: now } },
 	};
-
-	const split = splitArchivedKey(slug);
-	if (split) {
-		const guard = registry.plans[split.baseKey];
-		if (guard?.contentHashAtCommit && guard.commitHash?.startsWith(split.oldShortHash)) {
-			nextPlans[split.baseKey] = {
-				...guard,
-				commitHash,
-				updatedAt: now,
-			};
-			log.info("associatePlanWithCommit: also migrated guard %s → %s", split.baseKey, commitHash.substring(0, 8));
-		}
-	}
-
-	const updated: PlansRegistry = { ...registry, plans: nextPlans };
 	await savePlansRegistry(updated, cwd);
-	log.info("associatePlanWithCommit: %s → %s", slug, commitHash.substring(0, 8));
+	log.info("associatePlanWithCommit: migrated guard %s → %s", split.baseKey, commitHash.substring(0, 8));
 }
 
 /**
@@ -825,35 +877,30 @@ export async function associatePlanWithCommit(slug: string, commitHash: string, 
  * function's doc-comment for the rationale.
  */
 export async function associateNoteWithCommit(noteId: string, commitHash: string, cwd?: string): Promise<void> {
+	// Only the guard row survives — sweep its commitHash forward. See
+	// associatePlanWithCommit for the rationale.
+	const split = splitArchivedKey(noteId);
+	if (!split) {
+		log.debug("associateNoteWithCommit: %s is not an archived id, skipping", noteId);
+		return;
+	}
 	const registry = await loadPlansRegistry(cwd);
-	const entry = registry.notes?.[noteId];
-	if (!entry) {
-		log.debug("associateNoteWithCommit: id %s not in registry, skipping", noteId);
+	const notes = registry.notes;
+	const guard = notes?.[split.baseKey];
+	if (!guard?.contentHashAtCommit || !guard.commitHash?.startsWith(split.oldShortHash)) {
+		log.debug("associateNoteWithCommit: no matching guard for %s, skipping", noteId);
 		return;
 	}
 	const now = new Date().toISOString();
-	const notes = registry.notes as NonNullable<PlansRegistry["notes"]>;
-	const nextNotes: Record<string, NoteEntry> = {
-		...notes,
-		[noteId]: { ...entry, commitHash, updatedAt: now },
+	const updated: PlansRegistry = {
+		...registry,
+		notes: {
+			...(notes as NonNullable<PlansRegistry["notes"]>),
+			[split.baseKey]: { ...guard, commitHash, updatedAt: now },
+		},
 	};
-
-	const split = splitArchivedKey(noteId);
-	if (split) {
-		const guard = notes[split.baseKey];
-		if (guard?.contentHashAtCommit && guard.commitHash?.startsWith(split.oldShortHash)) {
-			nextNotes[split.baseKey] = {
-				...guard,
-				commitHash,
-				updatedAt: now,
-			};
-			log.info("associateNoteWithCommit: also migrated guard %s → %s", split.baseKey, commitHash.substring(0, 8));
-		}
-	}
-
-	const updated: PlansRegistry = { ...registry, notes: nextNotes };
 	await savePlansRegistry(updated, cwd);
-	log.info("associateNoteWithCommit: %s → %s", noteId, commitHash.substring(0, 8));
+	log.info("associateNoteWithCommit: migrated guard %s → %s", split.baseKey, commitHash.substring(0, 8));
 }
 
 /**
@@ -873,48 +920,36 @@ function referencesOf(reg: PlansRegistry): Readonly<Record<string, ReferenceEntr
 }
 
 /**
- * Returns the entries (not just keys) of references active for the given branch.
+ * Returns the entries (not just keys) of active references in the current worktree.
  *
- * "Active" matches the same filter Plans / Notes use:
- *   - branch matches
- *   - commitHash === null (uncommitted)
- *   - !contentHashAtCommit (not a guard from a prior commit)
- *   - !ignored
- *
- * Used by QueueWorker post-commit Step 6b and Stage 2 prompt assembly.
+ * "Active" = uncommitted (`commitHash === null`) and not a guard from a prior
+ * commit (`!contentHashAtCommit`). No branch filter — the per-worktree
+ * plans.json already isolates. Used by QueueWorker post-commit prompt assembly.
  */
 export async function getReferenceEntriesForBranch(
 	cwd: string,
-	branch: string,
+	_branch: string,
 ): Promise<ReadonlyArray<ReferenceEntry>> {
 	const registry = await loadPlansRegistry(cwd);
 	const entries: ReferenceEntry[] = [];
 	for (const entry of Object.values(referencesOf(registry))) {
-		if (entry.branch !== branch) continue;
-		if (entry.commitHash !== null) continue;
-		if (entry.contentHashAtCommit !== undefined) continue;
-		if (entry.ignored) continue;
 		entries.push(entry);
 	}
 	return entries;
 }
 
 /**
- * Returns the {mapKey, source, sourcePath} triples for active references on the
- * branch — projection of `getReferenceEntriesForBranch` shaped for QueueWorker
- * Step 8a3, which only needs these three fields to dispatch the archive.
+ * Returns the {mapKey, source, sourcePath} triples for active references in the
+ * current worktree — projection of `getReferenceEntriesForBranch` shaped for the
+ * QueueWorker archive dispatch, which only needs these three fields.
  */
 export async function detectUncommittedReferenceIds(
 	cwd: string,
-	branch: string,
+	_branch: string,
 ): Promise<ReadonlyArray<{ mapKey: string; source: SourceId; sourcePath: string }>> {
 	const registry = await loadPlansRegistry(cwd);
 	const out: Array<{ mapKey: string; source: SourceId; sourcePath: string }> = [];
 	for (const [mapKey, entry] of Object.entries(referencesOf(registry))) {
-		if (entry.branch !== branch) continue;
-		if (entry.commitHash !== null) continue;
-		if (entry.contentHashAtCommit !== undefined) continue;
-		if (entry.ignored) continue;
 		out.push({ mapKey, source: entry.source, sourcePath: entry.sourcePath });
 	}
 	return out;
@@ -923,31 +958,18 @@ export async function detectUncommittedReferenceIds(
 /**
  * Upsert a reference entry into plans.json.references.
  *
- * Field semantics:
- *
- * Case A: entry exists with `contentHashAtCommit` (guard from prior commit)
- *   - If `ignored` → return unchanged.
- *   - If contentHash matches the stored guard → return unchanged.
- *   - If contentHash differs → replace with a fresh uncommitted entry.
- *
- * Case B: entry exists without `contentHashAtCommit` (uncommitted)
- *   - If `ignored` → return unchanged.
- *   - Else: refresh title / url / sourcePath / sourceToolName / updatedAt;
- *     preserve addedAt / branch / commitHash / ignored.
- *
- * Case C: entry does not exist → insert fresh.
+ * References have no guard rows (commit deletes the entry), so every row in
+ * the map is an uncommitted active reference. Semantics:
+ *   - entry exists → refresh title / url / sourcePath / sourceToolName / updatedAt
+ *     (preserve addedAt).
+ *   - entry absent → insert fresh.
  *
  * Routes to {@link writeReferenceMarkdown} for the on-disk markdown (sanitization
- * happens there) and applies the guard-hash short-circuit so unchanged
- * Linear/Jira/GitHub/Notion payloads don't churn a fresh entry over a
- * still-valid guard.
- *
- * Concurrency: near-write reread + commitHash diff merge to tolerate a
- * concurrent PostCommitHook writing a commitHash between our two
- * loadPlansRegistry calls.
+ * happens there). The near-write reread only overwrites our own mapKey, so a
+ * concurrent writer touching other mapKeys is preserved.
  */
-export async function upsertReferenceEntry(ref: Reference, cwd: string, branch: string): Promise<void> {
-	const { sourcePath, contentHash } = await writeReferenceMarkdown(ref, cwd);
+export async function upsertReferenceEntry(ref: Reference, cwd: string, _branch: string): Promise<void> {
+	const { sourcePath } = await writeReferenceMarkdown(ref, cwd);
 	const mapKey = `${ref.source}:${ref.nativeId}`;
 	const now = new Date().toISOString();
 
@@ -955,53 +977,32 @@ export async function upsertReferenceEntry(ref: Reference, cwd: string, branch: 
 	const beforeReferences = referencesOf(beforeRegistry);
 	const existing = beforeReferences[mapKey];
 
-	if (existing && existing.contentHashAtCommit !== undefined) {
-		if (existing.ignored) return;
-		if (existing.contentHashAtCommit === contentHash) return;
-		// fall through to replacement — guard hash mismatched, content changed
-	} else if (existing?.ignored) {
-		return;
-	}
+	const next: ReferenceEntry =
+		existing !== undefined
+			? {
+					...existing,
+					title: ref.title,
+					url: ref.url,
+					sourcePath,
+					sourceToolName: ref.toolName,
+					updatedAt: now,
+				}
+			: {
+					source: ref.source,
+					nativeId: ref.nativeId,
+					title: ref.title,
+					url: ref.url,
+					sourcePath,
+					addedAt: now,
+					updatedAt: now,
+					sourceToolName: ref.toolName,
+				};
 
-	const canRefreshUncommitted = existing && existing.contentHashAtCommit === undefined && existing.branch === branch;
-
-	const next: ReferenceEntry = canRefreshUncommitted
-		? {
-				...existing,
-				title: ref.title,
-				url: ref.url,
-				sourcePath,
-				sourceToolName: ref.toolName,
-				updatedAt: now,
-			}
-		: {
-				source: ref.source,
-				nativeId: ref.nativeId,
-				title: ref.title,
-				url: ref.url,
-				sourcePath,
-				branch,
-				addedAt: now,
-				updatedAt: now,
-				commitHash: null,
-				sourceToolName: ref.toolName,
-			};
-
-	// Near-write reread merge — tolerates a concurrent PostCommitHook write
-	// landing a commitHash between our two loadPlansRegistry calls.
+	// Near-write reread — only overwrites our own mapKey, so a concurrent writer
+	// touching other mapKeys between our two loadPlansRegistry calls is preserved.
 	const freshRegistry = await loadPlansRegistry(cwd);
 	const freshReferences = referencesOf(freshRegistry);
-	const freshEntry = freshReferences[mapKey];
-	/* v8 ignore start -- near-write reread merge: only fires under concurrent commitHash writes (PostCommitHook racing the StopHook upsert); not deterministically reachable in unit tests without a concurrent process. */
-	const merged: ReferenceEntry =
-		freshEntry !== undefined &&
-		freshEntry.commitHash !== null &&
-		freshEntry.commitHash !== (existing?.commitHash ?? null)
-			? { ...next, commitHash: freshEntry.commitHash, contentHashAtCommit: freshEntry.contentHashAtCommit }
-			: next;
-	/* v8 ignore stop */
-
-	const references = { ...freshReferences, [mapKey]: merged };
+	const references = { ...freshReferences, [mapKey]: next };
 	const out: PlansRegistry = {
 		version: 1,
 		plans: freshRegistry.plans,
@@ -1009,109 +1010,29 @@ export async function upsertReferenceEntry(ref: Reference, cwd: string, branch: 
 		references,
 	};
 	await savePlansRegistry(out, cwd);
-	log.info("upsertReferenceEntry: %s on %s (%s)", mapKey, branch, existing === undefined ? "new" : "updated");
+	log.info("upsertReferenceEntry: %s (%s)", mapKey, existing === undefined ? "new" : "updated");
 }
 
-/** Set or clear the ignored flag on a reference entry. */
-export async function setReferenceIgnored(cwd: string, mapKey: string, ignored: boolean): Promise<void> {
-	const registry = await loadPlansRegistry(cwd);
-	const existingReferences = referencesOf(registry);
-	const entry = existingReferences[mapKey];
-	if (!entry) return;
-	const references = { ...existingReferences, [mapKey]: { ...entry, ignored: ignored || undefined } };
-	const out: PlansRegistry = {
-		version: 1,
-		plans: registry.plans,
-		...(registry.notes !== undefined ? { notes: registry.notes } : {}),
-		references,
-	};
-	await savePlansRegistry(out, cwd);
-}
+// ─── Active-entry queries for prompt assembly ───────────────────────────────
 
-/**
- * Update commitHash on a specific reference snapshot entry (keyed by `archivedKey`).
- * Mirrors {@link associatePlanWithCommit} / {@link associateNoteWithCommit} —
- * also migrates the guard entry's commitHash when `archivedKey` is the
- * `<source>:<nativeId>-<shortHash>` archive form and the guard's recorded
- * commitHash starts with the old short hash.
- *
- * Used by QueueWorker.reassociateMetadata for the per-source single-row update;
- * the plural / batch flow lives in QueueWorker (Task 2.7).
- */
-export async function associateReferenceWithCommit(archivedKey: string, newHash: string, cwd?: string): Promise<void> {
-	const registry = await loadPlansRegistry(cwd);
-	const references = referencesOf(registry);
-	const entry = references[archivedKey];
-	if (!entry) {
-		log.debug("associateReferenceWithCommit: key %s not in registry, skipping", archivedKey);
-		return;
-	}
-	const now = new Date().toISOString();
-	const nextReferences: Record<string, ReferenceEntry> = {
-		...references,
-		[archivedKey]: { ...entry, commitHash: newHash, updatedAt: now },
-	};
-
-	// Guard migration mirrors associatePlanWithCommit: when archivedKey has
-	// `<source>:<nativeId>-<shortHash>` shape and the matching guard entry
-	// records a commitHash that starts with that old short hash, sweep its
-	// commitHash forward to the new commit too. contentHashAtCommit stays
-	// untouched — the markdown content didn't change.
-	const split = splitArchivedKey(archivedKey);
-	if (split) {
-		const guard = references[split.baseKey];
-		if (guard?.contentHashAtCommit && guard.commitHash?.startsWith(split.oldShortHash)) {
-			nextReferences[split.baseKey] = { ...guard, commitHash: newHash, updatedAt: now };
-			log.info(
-				"associateReferenceWithCommit: also migrated guard %s → %s",
-				split.baseKey,
-				newHash.substring(0, 8),
-			);
-		}
-	}
-
-	const out: PlansRegistry = {
-		version: 1,
-		plans: registry.plans,
-		...(registry.notes !== undefined ? { notes: registry.notes } : {}),
-		references: nextReferences,
-	};
-	await savePlansRegistry(out, cwd);
-	log.info("associateReferenceWithCommit: %s → %s", archivedKey, newHash.substring(0, 8));
-}
-
-/**
- * Helper exposed for callers that need the canonical reference path without
- * importing ReferenceStore directly (avoids growing the cross-module surface).
- */
-export function referencePath(cwd: string, source: SourceId, key: string): string {
-	return canonicalReferencePath(cwd, source, key);
-}
-
-// ─── Active-entry queries for Stage 2 prompt assembly ───────────────────────
-
-/** Active plans on the given branch — uncommitted, not ignored, not guard-archived. */
-export async function detectActivePlansForBranch(cwd: string, branch: string): Promise<ReadonlyArray<PlanEntry>> {
+/** Active plans in the current worktree — uncommitted, not guard-archived. */
+export async function detectActivePlansForBranch(cwd: string, _branch: string): Promise<ReadonlyArray<PlanEntry>> {
 	const registry = await loadPlansRegistry(cwd);
 	const entries: PlanEntry[] = [];
 	for (const entry of Object.values(registry.plans)) {
-		if (entry.branch !== branch) continue;
 		if (entry.commitHash !== null) continue;
-		if (entry.ignored) continue;
 		if (entry.contentHashAtCommit !== undefined) continue;
 		entries.push(entry);
 	}
 	return entries;
 }
 
-/** Active notes on the given branch — uncommitted, not ignored, not guard-archived. */
-export async function detectActiveNotesForBranch(cwd: string, branch: string): Promise<ReadonlyArray<NoteEntry>> {
+/** Active notes in the current worktree — uncommitted, not guard-archived. */
+export async function detectActiveNotesForBranch(cwd: string, _branch: string): Promise<ReadonlyArray<NoteEntry>> {
 	const registry = await loadPlansRegistry(cwd);
 	const entries: NoteEntry[] = [];
 	for (const entry of Object.values(registry.notes ?? {})) {
-		if (entry.branch !== branch) continue;
 		if (entry.commitHash !== null) continue;
-		if (entry.ignored) continue;
 		if (entry.contentHashAtCommit !== undefined) continue;
 		entries.push(entry);
 	}

--- a/cli/src/core/references/ReferenceExtractor.test.ts
+++ b/cli/src/core/references/ReferenceExtractor.test.ts
@@ -476,7 +476,7 @@ describe("extractReferencesFromTranscript", () => {
 		// `issues` key is an OBJECT, not an array. Linear's adapter has the same
 		// wrapperKey `issues`, so the walker must descend into the inner object and
 		// then find the `nodes` array below it. This exercises the object-wrapper
-		// branch added in Phase 3 Task 3.1.
+		// branch in walkPayload.
 		const jsonl = makeJsonl(
 			toolUseLine({
 				toolUseId: "toolu_obj",

--- a/cli/src/core/references/ReferenceExtractor.ts
+++ b/cli/src/core/references/ReferenceExtractor.ts
@@ -27,8 +27,7 @@
  *      the substring `"name":"mcp__<src>__…"`.
  *   3. Walk the parsed payload (object / array / wrapped under any of the
  *      adapter's `wrapperKeys`) and collect every adapter-recognised reference.
- *      Wrapper descent is **array-only** in Phase 1 — Phase 3 will widen to
- *      object wrappers.
+ *      Wrapper descent handles both array and object wrappers.
  *
  * Dedupe: same `mapKey` (`<source>:<nativeId>`) → keep the entry with the
  * latest `referencedAt`. If timestamps tie, the later-seen entry wins

--- a/cli/src/core/references/ReferenceStore.test.ts
+++ b/cli/src/core/references/ReferenceStore.test.ts
@@ -5,11 +5,11 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import type { Reference } from "../../Types.js";
 import {
+	deleteReferenceMarkdown,
 	hashReferenceContent,
 	readReferenceMarkdown,
 	referenceDir,
 	referencePath,
-	renameReferenceMarkdown,
 	sanitizeNativeIdForPath,
 	writeReferenceMarkdown,
 } from "./ReferenceStore.js";
@@ -454,19 +454,16 @@ describe("ReferenceStore", () => {
 		});
 	});
 
-	describe("renameReferenceMarkdown", () => {
-		it("renames a file in place", async () => {
-			const a = join(tempDir, "a.md");
-			const b = join(tempDir, "b.md");
-			await writeFile(a, "content", "utf-8");
-			await renameReferenceMarkdown(a, b);
-			expect(await readFile(b, "utf-8")).toBe("content");
+	describe("deleteReferenceMarkdown", () => {
+		it("deletes an existing reference markdown file", async () => {
+			const p = join(tempDir, "del.md");
+			await writeFile(p, "content", "utf-8");
+			await deleteReferenceMarkdown(p);
+			await expect(stat(p)).rejects.toThrow();
 		});
 
-		it("throws when source file does not exist", async () => {
-			await expect(
-				renameReferenceMarkdown(join(tempDir, "missing.md"), join(tempDir, "out.md")),
-			).rejects.toThrow();
+		it("does not throw when the file is already gone (force)", async () => {
+			await expect(deleteReferenceMarkdown(join(tempDir, "never-existed.md"))).resolves.toBeUndefined();
 		});
 	});
 

--- a/cli/src/core/references/ReferenceStore.ts
+++ b/cli/src/core/references/ReferenceStore.ts
@@ -30,7 +30,7 @@
  */
 
 import { createHash } from "node:crypto";
-import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { createLogger, getJolliMemoryDir } from "../../Logger.js";
 import type { Reference, ReferenceField, SourceId } from "../../Types.js";
@@ -151,9 +151,14 @@ export function hashReferenceContent(ref: Reference): string {
 	return sha256(renderMarkdown({ ...ref, referencedAt: "" }));
 }
 
-/** Wrap fs.rename so callers can mock IO uniformly via ReferenceStore. */
-export async function renameReferenceMarkdown(oldPath: string, newPath: string): Promise<void> {
-	await rename(oldPath, newPath);
+/**
+ * Delete a per-reference markdown file. Best-effort: a missing file is not an
+ * error (`force: true`), so callers hard-deleting a reference whose `.md` was
+ * already cleaned up (or never written) stay idempotent. Wrapped here so the
+ * delete path is mockable via ReferenceStore like rename/write.
+ */
+export async function deleteReferenceMarkdown(sourcePath: string): Promise<void> {
+	await rm(sourcePath, { force: true });
 }
 
 // ─── Markdown rendering / parsing ────────────────────────────────────────────

--- a/cli/src/core/references/sources/GitHubAdapter.ts
+++ b/cli/src/core/references/sources/GitHubAdapter.ts
@@ -31,7 +31,7 @@
  *   - `milestone.title` or bare string → `milestone`
  *   - `issue_type.name` or bare string → `entity-type`
  *
- * Adapter modules MUST NOT share helpers across sources (per plan §Constraints).
+ * Adapter modules MUST NOT share helpers across sources.
  * `decodeHtmlEntities` lives in `./HtmlEntities.ts` and is GitHub-only.
  */
 

--- a/cli/src/core/references/sources/HtmlEntities.ts
+++ b/cli/src/core/references/sources/HtmlEntities.ts
@@ -16,7 +16,7 @@
  *     lone-surrogate character.
  *   - Decimal numeric: `&#DD…;`, same range guard.
  *
- * This module is owned by GitHubAdapter only — per plan §Constraints, adapter
+ * This module is owned by GitHubAdapter only — adapter
  * modules must not share helpers across sources. NotionAdapter does NOT call
  * into this file (envelope parsing is its own concern).
  */

--- a/cli/src/core/references/sources/JiraAdapter.ts
+++ b/cli/src/core/references/sources/JiraAdapter.ts
@@ -17,7 +17,7 @@
  *
  * `getJiraIssue` may also wrap the payload as `{issues:{totalCount,nodes:[…]}}`
  * — the outer wrapper is an object, the inner `nodes` is an array. The
- * extractor's `walkPayload` (Task 3.1) descends into both shapes, so this
+ * extractor's `walkPayload` descends into both shapes, so this
  * adapter only needs to parse the leaf issue object.
  *
  * Field mapping (Jira → Reference):
@@ -29,7 +29,7 @@
  *   - `fields.labels` (string[]) → `labels` (optional, non-empty filtered)
  *   - `fields.description` → `description` (optional)
  *
- * Adapter modules MUST NOT share helpers across sources (per plan §Constraints).
+ * Adapter modules MUST NOT share helpers across sources.
  * Field readers below intentionally duplicate the shape of LinearAdapter helpers
  * rather than reusing them.
  */

--- a/cli/src/core/references/sources/MultiAdapterExtractor.test.ts
+++ b/cli/src/core/references/sources/MultiAdapterExtractor.test.ts
@@ -92,7 +92,7 @@ beforeEach(() => {
 });
 
 describe("ALL_ADAPTERS", () => {
-	it("contains LinearAdapter as its first entry (Phase 1)", () => {
+	it("contains LinearAdapter as its first entry", () => {
 		expect(ALL_ADAPTERS).toContain(LinearAdapter);
 		expect(ALL_ADAPTERS[0].id).toBe("linear");
 	});

--- a/cli/src/core/references/sources/NotionAdapter.ts
+++ b/cli/src/core/references/sources/NotionAdapter.ts
@@ -1,12 +1,12 @@
 /**
  * NotionAdapter — `SourceAdapter` for the Notion MCP server (notion-fetch only).
  *
- * Scope (Phase 5, deliberately narrow):
+ * Scope (deliberately narrow):
  *   - Only `mcp__claude_ai_Notion__notion-fetch` produces References. Other
  *     notion-* tools (`notion-search`, `notion-update-page`, `notion-create-*`,
  *     …) all return null even though the same MCP prefix matches the line.
  *     `notion-search` requires its own payload-shape investigation and is
- *     deferred to Phase 6.
+ *     deferred.
  *   - Only `metadata.type === "page"` is accepted; database / data_source are
  *     silently rejected.
  *
@@ -27,7 +27,7 @@
  * larger than ticket descriptions, so the budget is widened over Linear/Jira/
  * GitHub's 4 KB/30 KB.
  *
- * Adapter modules MUST NOT share helpers across sources (per plan §Constraints).
+ * Adapter modules MUST NOT share helpers across sources.
  * `parseNotionEnvelope` lives in `./NotionEnvelope.ts` and is Notion-only.
  */
 
@@ -76,9 +76,9 @@ export const NotionAdapter: SourceAdapter = {
 	maxCharsPerReference: MAX_CHARS,
 
 	extractRef(payload, toolName, referencedAt) {
-		// Phase 5 scope: only notion-fetch. Other notion-* tools (search /
+		// Scope: only notion-fetch. Other notion-* tools (search /
 		// update-page / etc.) silently return null even when their MCP prefix
-		// matches. notion-search is deferred to Phase 6 pending payload-shape
+		// matches. notion-search is deferred pending payload-shape
 		// investigation.
 		if (!toolName.endsWith("notion-fetch")) return null;
 

--- a/cli/src/core/references/sources/NotionEnvelope.ts
+++ b/cli/src/core/references/sources/NotionEnvelope.ts
@@ -22,7 +22,7 @@
  * `<content>` block is read — the notion-fetch shape is a single, non-nested
  * content block, so multiple / nested blocks are not a concern in practice.
  *
- * Adapter modules MUST NOT share helpers across sources (per plan §Constraints).
+ * Adapter modules MUST NOT share helpers across sources.
  * This module is owned by NotionAdapter only.
  */
 

--- a/cli/src/hooks/PostCommitHook.helpers.test.ts
+++ b/cli/src/hooks/PostCommitHook.helpers.test.ts
@@ -161,7 +161,6 @@ vi.mock("../core/references/ReferenceStore.js", () => ({
 	readReferenceMarkdown: vi.fn().mockResolvedValue(null),
 	readReferenceMarkdownFromString: vi.fn().mockReturnValue(null),
 	writeReferenceMarkdown: vi.fn().mockResolvedValue({ sourcePath: "/x", contentHash: "fake-content-hash" }),
-	renameReferenceMarkdown: vi.fn().mockResolvedValue(undefined),
 	hashReferenceContent: vi.fn(() => "fake-content-hash"),
 }));
 
@@ -361,14 +360,13 @@ describe("PostCommitHook helpers", () => {
 	});
 
 	describe("detectPlanSlugsFromRegistry", () => {
-		it("returns uncommitted, non-ignored plan slugs from the registry", async () => {
+		it("returns uncommitted plan slugs from the registry", async () => {
 			mockLoadPlansRegistry.mockResolvedValue({
 				version: 1,
 				plans: {
-					"alpha-plan": { slug: "alpha-plan", commitHash: null, ignored: false, branch: "main" },
-					"beta-plan": { slug: "beta-plan", commitHash: null, ignored: false, branch: "main" },
-					"committed-plan": { slug: "committed-plan", commitHash: "abc123", ignored: false, branch: "main" },
-					"ignored-plan": { slug: "ignored-plan", commitHash: null, ignored: true, branch: "main" },
+					"alpha-plan": { slug: "alpha-plan", commitHash: null },
+					"beta-plan": { slug: "beta-plan", commitHash: null },
+					"committed-plan": { slug: "committed-plan", commitHash: "abc123" },
 				},
 			});
 
@@ -376,12 +374,12 @@ describe("PostCommitHook helpers", () => {
 			expect([...slugs].sort()).toEqual(["alpha-plan", "beta-plan"]);
 		});
 
-		it("returns empty set when all plans are committed or ignored", async () => {
+		it("returns empty set when all plans are committed", async () => {
 			mockLoadPlansRegistry.mockResolvedValue({
 				version: 1,
 				plans: {
-					done: { slug: "done", commitHash: "abc", ignored: false, branch: "main" },
-					skipped: { slug: "skipped", commitHash: null, ignored: true, branch: "main" },
+					done: { slug: "done", commitHash: "abc" },
+					done2: { slug: "done2", commitHash: "def" },
 				},
 			});
 
@@ -496,34 +494,6 @@ describe("PostCommitHook helpers", () => {
 			const slugs = await __test__.detectPlanSlugsFromRegistry("/repo", "main");
 			expect(slugs.size).toBe(0);
 		});
-
-		it("excludes uncommitted plans whose branch differs from the target branch", async () => {
-			// Regression guard for the cross-branch leak: before adding the branch
-			// filter, plans on `feature/summarize-include-linear-issues` were being
-			// associated with a commit on `feature/linear-issues-as-panel-item`,
-			// polluting the orphan branch under the wrong branch directory and
-			// generating phantom plan refs on the wrong commit's summary.
-			mockLoadPlansRegistry.mockResolvedValue({
-				version: 1,
-				plans: {
-					"current-branch": {
-						slug: "current-branch",
-						commitHash: null,
-						ignored: false,
-						branch: "feature/active",
-					},
-					"other-branch": {
-						slug: "other-branch",
-						commitHash: null,
-						ignored: false,
-						branch: "feature/idle",
-					},
-				},
-			});
-
-			const slugs = await __test__.detectPlanSlugsFromRegistry("/repo", "feature/active");
-			expect([...slugs]).toEqual(["current-branch"]);
-		});
 	});
 
 	describe("associatePlansWithCommit", () => {
@@ -569,12 +539,9 @@ describe("PostCommitHook helpers", () => {
 			expect(result.originalSlugBySlug.get("alpha-deadbeef")).toBe("alpha");
 			expect(mockSavePlansRegistry).toHaveBeenCalledTimes(1);
 			expect(mockSavePlansRegistry.mock.calls[0][0].plans.alpha.contentHashAtCommit).toBeTruthy();
-			expect(mockSavePlansRegistry.mock.calls[0][0].plans["alpha-deadbeef"]).toEqual(
-				expect.objectContaining({
-					slug: "alpha-deadbeef",
-					commitHash: "deadbeefcafebabe",
-				}),
-			);
+			expect(mockSavePlansRegistry.mock.calls[0][0].plans.alpha.commitHash).toBe("deadbeefcafebabe");
+			// No per-commit archive row — only the guard row (original slug) is written.
+			expect(mockSavePlansRegistry.mock.calls[0][0].plans["alpha-deadbeef"]).toBeUndefined();
 			expect(mockStorePlans).toHaveBeenCalledWith(
 				[{ slug: "alpha-deadbeef", content: "# Alpha plan\n\nDo the work" }],
 				"Archive 1 plan(s) for commit deadbeef",
@@ -1100,7 +1067,7 @@ describe("PostCommitHook helpers", () => {
 
 		it("Pre-LLM short-circuit triggers even WITH transcript entries when delta ≤ 50 lines", async () => {
 			mockGetSummary.mockResolvedValue(oldSummaryFixture);
-			// 有 1 个 session 带 2 条 entries —— 旧逻辑会强制走 Full path，新逻辑应仍短路
+			// One session with 2 entries — old logic forced the Full path; new logic should still short-circuit
 			mockLoadAllSessions.mockResolvedValue([
 				{
 					sessionId: "sess-1",
@@ -1130,7 +1097,7 @@ describe("PostCommitHook helpers", () => {
 			expect(mockGenerateSummary).not.toHaveBeenCalled();
 			expect(mockGenerateSquashConsolidation).not.toHaveBeenCalled();
 
-			// 短路路径也必须把 transcript artifact 传给 storeSummary
+			// The short-circuit path must also pass the transcript artifact to storeSummary
 			expect(mockStoreSummary.mock.calls.length).toBeGreaterThanOrEqual(1);
 			const storeArgs = mockStoreSummary.mock.calls[0];
 			// Pin the force flag at position 2 — short-circuit must never overwrite
@@ -1262,13 +1229,13 @@ describe("PostCommitHook helpers", () => {
 			mockLoadAllSessions.mockResolvedValue([]);
 			mockGetDiffStats.mockResolvedValue({ filesChanged: 1, insertions: 100, deletions: 0 });
 			mockGetDiffContent.mockResolvedValue("diff");
-			// step1: topics 空 但 recap 非空 —— 旧逻辑进 Full path，新逻辑直接短路、丢弃 delta.recap
+			// step1: topics empty, recap non-empty — old took Full path; new short-circuits and drops delta.recap
 			mockGenerateSummary.mockResolvedValueOnce({
 				transcriptEntries: 0,
 				llm: { model: "test", inputTokens: 1, outputTokens: 1, apiLatencyMs: 1, stopReason: "end_turn" },
 				stats: { filesChanged: 1, insertions: 100, deletions: 0 },
 				topics: [],
-				recap: "delta 复述了 diff —— 应被丢弃",
+				recap: "delta restated the diff — should be discarded",
 			});
 
 			await __test__.handleAmendPipeline(
@@ -1285,7 +1252,7 @@ describe("PostCommitHook helpers", () => {
 				topics: ReadonlyArray<{ title: string }>;
 				recap?: string;
 			};
-			// recap 应是 oldSummaryFixture.recap，不是 delta 的 recap
+			// recap should be oldSummaryFixture.recap, not delta's recap
 			expect(root.recap).toBe("old recap");
 		});
 

--- a/cli/src/hooks/PostCommitHook.test.ts
+++ b/cli/src/hooks/PostCommitHook.test.ts
@@ -44,7 +44,6 @@ vi.mock("../core/SessionTracker.js", async (importOriginal) => {
 		savePlansRegistry: vi.fn().mockResolvedValue(undefined),
 		associatePlanWithCommit: vi.fn(),
 		associateNoteWithCommit: vi.fn(),
-		associateReferenceWithCommit: vi.fn().mockResolvedValue(undefined),
 		detectUncommittedReferenceIds: vi.fn().mockResolvedValue([]),
 		detectActivePlansForBranch: vi.fn().mockResolvedValue([]),
 		detectActiveNotesForBranch: vi.fn().mockResolvedValue([]),
@@ -66,7 +65,6 @@ vi.mock("../core/references/ReferenceStore.js", () => ({
 	readReferenceMarkdown: vi.fn().mockResolvedValue(null),
 	readReferenceMarkdownFromString: vi.fn().mockReturnValue(null),
 	writeReferenceMarkdown: vi.fn().mockResolvedValue({ sourcePath: "/x", contentHash: "fake-content-hash" }),
-	renameReferenceMarkdown: vi.fn().mockResolvedValue(undefined),
 	hashReferenceContent: vi.fn(() => "fake-content-hash"),
 }));
 
@@ -299,7 +297,6 @@ import { readOpenCodeTranscript } from "../core/OpenCodeTranscriptReader.js";
 import {
 	associateNoteWithCommit,
 	associatePlanWithCommit,
-	associateReferenceWithCommit,
 	deleteQueueEntry,
 	dequeueAllGitOperations,
 	loadAllSessions,
@@ -1204,13 +1201,13 @@ describe("queue-driven Worker", () => {
 			expect(getCommitInfo).not.toHaveBeenCalled();
 		});
 
-		it("re-associates plans, notes, and linearIssues when the source summary carries them", async () => {
+		it("re-associates plans and notes when the source summary carries them", async () => {
 			// Coverage gap: squash and amend already had reassociateMetadata
-			// tests for linearIssues, but rebase-pick goes through its own
+			// tests for plans/notes, but rebase-pick goes through its own
 			// handleRebasePickFromQueue path. Without this test, a future
 			// regression that dropped reassociateMetadata from rebase-pick
-			// (or stopped iterating linearIssues there) would silently leave
-			// the archived registry entries pointing at the old commit hash.
+			// would silently leave the archived registry entries pointing at
+			// the old commit hash.
 			const rebasePickOp = {
 				op: {
 					type: "rebase-pick" as const,
@@ -1240,17 +1237,6 @@ describe("queue-driven Worker", () => {
 						updatedAt: "2026-02-19T00:00:00Z",
 					},
 				],
-				references: [
-					{
-						archivedKey: "linear:PROJ-1528-oldHash",
-						source: "linear",
-						nativeId: "PROJ-1528",
-						title: "Old Linear issue",
-						url: "https://linear.app/x/PROJ-1528",
-						referencedAt: "2026-02-19T00:00:00Z",
-						sourceToolName: "mcp__linear__get_issue",
-					},
-				],
 			});
 			vi.mocked(getCommitInfo).mockResolvedValue({
 				hash: "newHash",
@@ -1263,15 +1249,6 @@ describe("queue-driven Worker", () => {
 
 			expect(associatePlanWithCommit).toHaveBeenCalledWith("plan-old", "newHash", "/test/project");
 			expect(associateNoteWithCommit).toHaveBeenCalledWith("note-old", "newHash", "/test/project");
-			// Multi-source migration (Task 2.11): legacy linearIssues archivedKey
-			// is projected to `linear:<bareKey>` and dispatched through the
-			// singular associateReferenceWithCommit; associateReferenceWithCommit
-			// is no longer called from reassociateMetadata.
-			expect(associateReferenceWithCommit).toHaveBeenCalledWith(
-				"linear:PROJ-1528-oldHash",
-				"newHash",
-				"/test/project",
-			);
 		});
 
 		it("forwards commitSource from the queue entry into migrateOneToOne", async () => {
@@ -1541,7 +1518,7 @@ describe("queue-driven Worker", () => {
 		});
 
 		// Regression: the fresh-leaf path (amend with no oldSummary) must associate
-		// plans/notes/linearIssues on the branch with the new amend commit hash,
+		// active (uncommitted) plans/notes with the new amend commit hash,
 		// matching what a normal commit does. Without this fix the fresh leaf
 		// silently dropped these references, breaking plan-progress aggregation
 		// and search/reverse-lookups for plans authored before this tool was installed.
@@ -1559,7 +1536,6 @@ describe("queue-driven Worker", () => {
 						sourcePath: planSourcePath,
 						addedAt: "2026-02-19T00:00:00.000Z",
 						updatedAt: "2026-02-19T00:00:00.000Z",
-						branch: "feature-branch",
 						commitHash: null,
 					},
 				},
@@ -1571,7 +1547,6 @@ describe("queue-driven Worker", () => {
 						sourcePath: noteSourcePath,
 						addedAt: "2026-02-19T00:00:00.000Z",
 						updatedAt: "2026-02-19T00:00:00.000Z",
-						branch: "feature-branch",
 						commitHash: null,
 					},
 				},
@@ -1745,7 +1720,6 @@ describe("queue-driven Worker", () => {
 						sourcePath: noteSourcePath,
 						addedAt: "2026-02-19T00:00:00.000Z",
 						updatedAt: "2026-02-19T00:00:00.000Z",
-						branch: "main",
 						commitHash: null,
 					},
 				},
@@ -1966,10 +1940,10 @@ describe("queue-driven Worker", () => {
 		});
 	});
 
-	// ─── reassociateMetadata coverage (plans + notes + linearIssues on squash) ─
+	// ─── reassociateMetadata coverage (plans + notes on squash) ─
 
 	describe("reassociateMetadata in squash", () => {
-		it("re-associates plans, notes, and linearIssues from source summaries on squash", async () => {
+		it("re-associates plans and notes from source summaries on squash", async () => {
 			const squashOp = {
 				op: {
 					type: "squash" as const,
@@ -1987,12 +1961,10 @@ describe("queue-driven Worker", () => {
 				author: "John",
 				date: "2026-02-19",
 			});
-			// Old summary has plans, notes, and linearIssues — the squash must
-			// re-associate all three categories under the new commit hash.
-			// Without the linearIssues branch in reassociateMetadata, the
-			// archived ticket entry's commitHash would still point at oldHash1
-			// while the summary on newHash carried the same archivedKey —
-			// silently orphaning the registry pointer.
+			// Old summary has plans and notes — the squash must re-associate
+			// both categories under the new commit hash. A regression that
+			// dropped reassociateMetadata from squash would leave the archived
+			// registry entries pointing at oldHash1.
 			vi.mocked(getSummary).mockResolvedValue({
 				...createMockSummary("oldHash1"),
 				plans: [
@@ -2012,17 +1984,6 @@ describe("queue-driven Worker", () => {
 						updatedAt: "2026-02-19T00:00:00Z",
 					},
 				],
-				references: [
-					{
-						archivedKey: "linear:PROJ-1528-oldHash1",
-						source: "linear",
-						nativeId: "PROJ-1528",
-						title: "Old Linear issue",
-						url: "https://linear.app/x/PROJ-1528",
-						referencedAt: "2026-02-19T00:00:00Z",
-						sourceToolName: "mcp__linear__get_issue",
-					},
-				],
 			});
 			vi.mocked(mergeManyToOne).mockResolvedValue({ orphanedDocIds: [] });
 
@@ -2030,17 +1991,10 @@ describe("queue-driven Worker", () => {
 
 			expect(associatePlanWithCommit).toHaveBeenCalledWith("plan-old", "newHash", "/test/project");
 			expect(associateNoteWithCommit).toHaveBeenCalledWith("note-old", "newHash", "/test/project");
-			// See "rebase-pick" reassociate note above — squash routes through
-			// associateReferenceWithCommit too post-Task-2.11.
-			expect(associateReferenceWithCommit).toHaveBeenCalledWith(
-				"linear:PROJ-1528-oldHash1",
-				"newHash",
-				"/test/project",
-			);
 		});
 	});
 
-	// ─── reassociateMetadata coverage (plans + notes + linearIssues on amend, 3 paths) ─
+	// ─── reassociateMetadata coverage (plans + notes on amend, 3 paths) ─
 
 	describe("reassociateMetadata in amend", () => {
 		const AMEND_OP = {
@@ -2074,17 +2028,6 @@ describe("queue-driven Worker", () => {
 						updatedAt: "2026-02-19T00:00:00Z",
 					},
 				],
-				references: [
-					{
-						archivedKey: "linear:PROJ-1528-oldHash",
-						source: "linear",
-						nativeId: "PROJ-1528",
-						title: "Old Linear issue",
-						url: "https://linear.app/x/PROJ-1528",
-						referencedAt: "2026-02-19T00:00:00Z",
-						sourceToolName: "mcp__linear__get_issue",
-					},
-				],
 			};
 		}
 
@@ -2116,11 +2059,6 @@ describe("queue-driven Worker", () => {
 			expect(storeSummary).toHaveBeenCalled();
 			expect(associatePlanWithCommit).toHaveBeenCalledWith("plan-old", "newHash", "/test/project");
 			expect(associateNoteWithCommit).toHaveBeenCalledWith("note-old", "newHash", "/test/project");
-			expect(associateReferenceWithCommit).toHaveBeenCalledWith(
-				"linear:PROJ-1528-oldHash",
-				"newHash",
-				"/test/project",
-			);
 		});
 
 		it("re-associates plans and notes on post-LLM short-circuit (1 LLM, empty topics)", async () => {
@@ -2151,11 +2089,6 @@ describe("queue-driven Worker", () => {
 			expect(storeSummary).toHaveBeenCalled();
 			expect(associatePlanWithCommit).toHaveBeenCalledWith("plan-old", "newHash", "/test/project");
 			expect(associateNoteWithCommit).toHaveBeenCalledWith("note-old", "newHash", "/test/project");
-			expect(associateReferenceWithCommit).toHaveBeenCalledWith(
-				"linear:PROJ-1528-oldHash",
-				"newHash",
-				"/test/project",
-			);
 		});
 
 		it("re-associates plans and notes on full path (2 LLM, non-empty delta)", async () => {
@@ -2181,11 +2114,6 @@ describe("queue-driven Worker", () => {
 			expect(storeSummary).toHaveBeenCalled();
 			expect(associatePlanWithCommit).toHaveBeenCalledWith("plan-old", "newHash", "/test/project");
 			expect(associateNoteWithCommit).toHaveBeenCalledWith("note-old", "newHash", "/test/project");
-			expect(associateReferenceWithCommit).toHaveBeenCalledWith(
-				"linear:PROJ-1528-oldHash",
-				"newHash",
-				"/test/project",
-			);
 		});
 	});
 
@@ -2407,7 +2335,6 @@ describe("queue-driven Worker", () => {
 						sourcePath: "/nonexistent/note.md",
 						addedAt: "2026-02-19T00:00:00.000Z",
 						updatedAt: "2026-02-19T00:00:00.000Z",
-						branch: "main",
 						commitHash: null,
 					},
 				},
@@ -2439,7 +2366,6 @@ describe("queue-driven Worker", () => {
 						sourcePath: "/some/path.md",
 						addedAt: "2026-02-19T00:00:00.000Z",
 						updatedAt: "2026-02-19T00:00:00.000Z",
-						branch: "main",
 						commitHash: null,
 					},
 				},
@@ -2473,7 +2399,6 @@ describe("queue-driven Worker", () => {
 						sourcePath: snippetPath,
 						addedAt: "2026-02-19T00:00:00.000Z",
 						updatedAt: "2026-02-19T00:00:00.000Z",
-						branch: "main",
 						commitHash: null,
 					},
 				},

--- a/cli/src/hooks/QueueWorker.selection.test.ts
+++ b/cli/src/hooks/QueueWorker.selection.test.ts
@@ -84,7 +84,6 @@ vi.mock("../core/references/ReferenceStore.js", () => ({
 	readReferenceMarkdown: vi.fn().mockResolvedValue(null),
 	readReferenceMarkdownFromString: vi.fn().mockReturnValue(null),
 	writeReferenceMarkdown: vi.fn().mockResolvedValue({ sourcePath: "/x", contentHash: "fakehash" }),
-	renameReferenceMarkdown: vi.fn().mockResolvedValue(undefined),
 	hashReferenceContent: vi.fn().mockReturnValue("fakehash"),
 }));
 
@@ -458,7 +457,6 @@ describe("QueueWorker selection filter", () => {
 			sourcePath: "/fake/plan-keep.md",
 			addedAt: "2026-01-01T00:00:00Z",
 			updatedAt: "2026-01-01T00:00:00Z",
-			branch: "main",
 			commitHash: null,
 		};
 		const skipPlan: PlanEntry = {
@@ -467,7 +465,6 @@ describe("QueueWorker selection filter", () => {
 			sourcePath: "/fake/plan-skip.md",
 			addedAt: "2026-01-01T00:00:00Z",
 			updatedAt: "2026-01-01T00:00:00Z",
-			branch: "main",
 			commitHash: null,
 		};
 		vi.mocked(detectActivePlansForBranch).mockResolvedValue([keepPlan, skipPlan]);
@@ -500,7 +497,6 @@ describe("QueueWorker selection filter", () => {
 			format: "markdown",
 			addedAt: "2026-01-01T00:00:00Z",
 			updatedAt: "2026-01-01T00:00:00Z",
-			branch: "main",
 			commitHash: null,
 		};
 		const skipNote: NoteEntry = {
@@ -509,7 +505,6 @@ describe("QueueWorker selection filter", () => {
 			format: "markdown",
 			addedAt: "2026-01-01T00:00:00Z",
 			updatedAt: "2026-01-01T00:00:00Z",
-			branch: "main",
 			commitHash: null,
 		};
 		vi.mocked(detectActiveNotesForBranch).mockResolvedValue([keepNote, skipNote]);
@@ -645,7 +640,6 @@ describe("QueueWorker selection filter", () => {
 					sourcePath: "/fake/plan-keep.md",
 					addedAt: "2026-01-01T00:00:00Z",
 					updatedAt: "2026-01-01T00:00:00Z",
-					branch: "main",
 					commitHash: null,
 				},
 				"plan-skip": {
@@ -654,7 +648,6 @@ describe("QueueWorker selection filter", () => {
 					sourcePath: "/fake/plan-skip.md",
 					addedAt: "2026-01-01T00:00:00Z",
 					updatedAt: "2026-01-01T00:00:00Z",
-					branch: "main",
 					commitHash: null,
 				},
 			},
@@ -700,7 +693,6 @@ describe("QueueWorker selection filter", () => {
 					sourcePath: "/fake/note-keep.md",
 					addedAt: "2026-01-01T00:00:00Z",
 					updatedAt: "2026-01-01T00:00:00Z",
-					branch: "main",
 					commitHash: null,
 				},
 				"note-skip": {
@@ -710,7 +702,6 @@ describe("QueueWorker selection filter", () => {
 					sourcePath: "/fake/note-skip.md",
 					addedAt: "2026-01-01T00:00:00Z",
 					updatedAt: "2026-01-01T00:00:00Z",
-					branch: "main",
 					commitHash: null,
 				},
 			},
@@ -741,12 +732,12 @@ describe("QueueWorker selection filter", () => {
 
 	// ─── Entity exclusion (panel-level skip-don't-archive) ──────────────────
 	// Mirrors the plan / note archive-side filter tests above: an excluded
-	// entity must be dropped from BOTH the Step 6b prompt block AND the
-	// Step 8a3 archive call. Without the archive-side filter the entity row
+	// entity must be dropped from BOTH the prompt block AND the
+	// archive call. Without the archive-side filter the entity row
 	// would still be committed and disappear from the panel — defeating the
 	// "uncheck = skip on this commit, reappear next time" semantics.
 
-	it("filters excluded entities out of the prompt-block input (Step 6b)", async () => {
+	it("filters excluded entities out of the prompt-block input", async () => {
 		seedGitMocks(projectDir);
 		vi.mocked(loadAllSessions).mockResolvedValue([]);
 		vi.mocked(buildMultiSessionContext).mockReturnValue("");
@@ -757,10 +748,8 @@ describe("QueueWorker selection filter", () => {
 			title: "Keep Entity",
 			url: "https://example.atlassian.net/browse/PROJ-1",
 			sourcePath: "/fake/jira/PROJ-1.md",
-			branch: "main",
 			addedAt: "2026-01-01T00:00:00Z",
 			updatedAt: "2026-01-01T00:00:00Z",
-			commitHash: null,
 			sourceToolName: "atlassian-mcp",
 		};
 		const skipEntity: ReferenceEntry = {
@@ -769,10 +758,8 @@ describe("QueueWorker selection filter", () => {
 			title: "Skip Entity",
 			url: "https://github.com/owner/repo/issues/42",
 			sourcePath: "/fake/github/owner-repo-42.md",
-			branch: "main",
 			addedAt: "2026-01-01T00:00:00Z",
 			updatedAt: "2026-01-01T00:00:00Z",
-			commitHash: null,
 			sourceToolName: "github-mcp",
 		};
 		vi.mocked(getReferenceEntriesForBranch).mockImplementation(async () => {
@@ -797,13 +784,13 @@ describe("QueueWorker selection filter", () => {
 		expect(readCalls).not.toContain("/fake/github/owner-repo-42.md");
 	});
 
-	it("filters excluded entities out of the Step 8a3 archive call", async () => {
+	it("filters excluded entities out of the archive call", async () => {
 		seedGitMocks(projectDir);
 		vi.mocked(loadAllSessions).mockResolvedValue([]);
 		vi.mocked(buildMultiSessionContext).mockReturnValue("");
 
 		// detectUncommittedReferenceIds returns the {mapKey, source, sourcePath}
-		// triples that drive the archive step. The filter at Step 8a3 must
+		// triples that drive the archive step. The filter must
 		// drop the excluded mapKey before passing to associateReferencesWithCommit
 		// — which we observe indirectly through loadPlansRegistry not being
 		// asked to upgrade the entity (we keep the v1-shaped registry mock so
@@ -826,10 +813,8 @@ describe("QueueWorker selection filter", () => {
 					title: "Keep",
 					url: "https://x/PROJ-KEEP",
 					sourcePath: "/fake/jira/PROJ-KEEP.md",
-					branch: "main",
 					addedAt: "2026-01-01T00:00:00Z",
 					updatedAt: "2026-01-01T00:00:00Z",
-					commitHash: null,
 					sourceToolName: "atlassian-mcp",
 				},
 				"jira:PROJ-SKIP": {
@@ -838,10 +823,8 @@ describe("QueueWorker selection filter", () => {
 					title: "Skip",
 					url: "https://x/PROJ-SKIP",
 					sourcePath: "/fake/jira/PROJ-SKIP.md",
-					branch: "main",
 					addedAt: "2026-01-01T00:00:00Z",
 					updatedAt: "2026-01-01T00:00:00Z",
-					commitHash: null,
 					sourceToolName: "atlassian-mcp",
 				},
 			},
@@ -862,10 +845,10 @@ describe("QueueWorker selection filter", () => {
 
 		await executePipeline(projectDir, makeCommitOp());
 
-		// The kept entity's sourcePath shows up in readReferenceMarkdown (both at
-		// Step 6b and Step 8a3 — same helper). The skipped one must NOT appear
-		// at all. The Step-6b filter already drops it from the prompt path,
-		// and the Step-8a3 filter drops it from the archive path.
+		// The kept entity's sourcePath shows up in readReferenceMarkdown (in both
+		// the prompt block and the archive call — same helper). The skipped one
+		// must NOT appear at all. The prompt-block filter already drops it from
+		// the prompt path, and the archive-side filter drops it from the archive path.
 		expect(archivePaths.every((p) => !p.includes("PROJ-SKIP"))).toBe(true);
 	});
 });

--- a/cli/src/hooks/QueueWorker.test.ts
+++ b/cli/src/hooks/QueueWorker.test.ts
@@ -25,7 +25,6 @@ vi.mock("../core/SessionTracker.js", async (importOriginal) => {
 		savePlansRegistry: vi.fn().mockResolvedValue(undefined),
 		associatePlanWithCommit: vi.fn(),
 		associateNoteWithCommit: vi.fn(),
-		associateReferenceWithCommit: vi.fn().mockResolvedValue(undefined),
 		detectUncommittedReferenceIds: vi.fn().mockResolvedValue([]),
 		detectActivePlansForBranch: vi.fn().mockResolvedValue([]),
 		detectActiveNotesForBranch: vi.fn().mockResolvedValue([]),
@@ -47,8 +46,7 @@ vi.mock("../core/references/ReferenceStore.js", () => ({
 	readReferenceMarkdown: vi.fn().mockResolvedValue(null),
 	readReferenceMarkdownFromString: vi.fn().mockReturnValue(null),
 	writeReferenceMarkdown: vi.fn().mockResolvedValue({ sourcePath: "/x", contentHash: "fake-content-hash" }),
-	renameReferenceMarkdown: vi.fn().mockResolvedValue(undefined),
-	hashReferenceContent: vi.fn(() => "fake-content-hash"),
+	deleteReferenceMarkdown: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock("../core/PlanPromptFormatter.js", () => ({
@@ -333,9 +331,6 @@ import { acquireWorkerLock, releaseWorkerLock } from "../core/Locks.js";
 import { discoverOpenCodeSessions, isOpenCodeInstalled } from "../core/OpenCodeSessionDiscoverer.js";
 import { readOpenCodeTranscript } from "../core/OpenCodeTranscriptReader.js";
 import {
-	associateNoteWithCommit,
-	associatePlanWithCommit,
-	associateReferenceWithCommit,
 	dequeueAllGitOperations,
 	detectActiveNotesForBranch,
 	detectActivePlansForBranch,
@@ -406,7 +401,6 @@ describe("QueueWorker", () => {
 		vi.mocked(savePlansRegistry).mockResolvedValue(undefined);
 		vi.mocked(detectUncommittedReferenceIds).mockResolvedValue([]);
 		vi.mocked(detectUncommittedReferenceIds).mockResolvedValue([]);
-		vi.mocked(associateReferenceWithCommit).mockResolvedValue(undefined);
 		vi.mocked(detectActivePlansForBranch).mockResolvedValue([]);
 		vi.mocked(detectActiveNotesForBranch).mockResolvedValue([]);
 		vi.mocked(getReferenceEntriesForBranch).mockResolvedValue([]);
@@ -554,7 +548,6 @@ describe("QueueWorker", () => {
 							sourcePath: "/tmp/ghost.md",
 							addedAt: "2026-04-01T00:00:00Z",
 							updatedAt: "2026-04-01T00:00:00Z",
-							branch: "main",
 							commitHash: null,
 						},
 					},
@@ -599,17 +592,13 @@ describe("QueueWorker", () => {
 						title: "Treat referenced Linear issues",
 						url: "https://linear.app/jolliai/issue/PROJ-1528/",
 						sourcePath: "/test/cwd/.jolli/jollimemory/references/linear/PROJ-1528.md",
-						branch: "feature/test",
 						addedAt: "2026-04-01T00:00:00Z",
 						updatedAt: "2026-04-01T00:00:00Z",
-						commitHash: null,
 						sourceToolName: "mcp__linear__get_issue",
 					},
 				},
 			});
-			const { readReferenceMarkdown, renameReferenceMarkdown } = await import(
-				"../core/references/ReferenceStore.js"
-			);
+			const { readReferenceMarkdown } = await import("../core/references/ReferenceStore.js");
 			vi.mocked(readReferenceMarkdown).mockResolvedValue({
 				mapKey: "linear:PROJ-1528",
 				source: "linear",
@@ -645,12 +634,9 @@ describe("QueueWorker", () => {
 				{ key: "priority", label: "Priority", value: "No priority", icon: "flame" },
 				{ key: "labels", label: "Labels", value: "JolliMemory, Feature", icon: "tag" },
 			]);
-			// Physical rename through ReferenceStore (referencePath stub returns the
-			// canonical references/<source>/<key>.md location).
-			expect(renameReferenceMarkdown).toHaveBeenCalledWith(
-				"/test/cwd/.jolli/jollimemory/references/linear/PROJ-1528.md",
-				"/test/cwd/.jolli/jollimemory/references/linear/PROJ-1528-abc12345.md",
-			);
+			// The reference markdown is NOT physically renamed — the archivedKey
+			// lives only in the CommitSummary's ReferenceCommitRef (asserted above), while
+			// the guard row keeps the canonical references/<source>/<key>.md file in place.
 		});
 
 		it("skips entities whose source markdown is unreadable but still completes the pipeline", async () => {
@@ -678,10 +664,8 @@ describe("QueueWorker", () => {
 						title: "t",
 						url: "u",
 						sourcePath: "/missing.md",
-						branch: "feature/test",
 						addedAt: "x",
 						updatedAt: "x",
-						commitHash: null,
 						sourceToolName: "mcp__linear__get_issue",
 					},
 				},
@@ -726,10 +710,8 @@ describe("QueueWorker", () => {
 						title: "Linear issue",
 						url: "https://linear.app/x/PROJ-1528",
 						sourcePath: "/test/cwd/.jolli/jollimemory/references/linear/PROJ-1528.md",
-						branch: "feature/test",
 						addedAt: "x",
 						updatedAt: "x",
-						commitHash: null,
 						sourceToolName: "mcp__linear__get_issue",
 					},
 					"jira:KAN-7": {
@@ -738,10 +720,8 @@ describe("QueueWorker", () => {
 						title: "Jira ticket",
 						url: "https://example.atlassian.net/browse/KAN-7",
 						sourcePath: "/test/cwd/.jolli/jollimemory/references/jira/KAN-7.md",
-						branch: "feature/test",
 						addedAt: "x",
 						updatedAt: "x",
-						commitHash: null,
 						sourceToolName: "mcp__jira__get_issue",
 					},
 				},
@@ -862,7 +842,6 @@ describe("QueueWorker", () => {
 						id: "note-1",
 						title: "keep me",
 						format: "snippet",
-						branch: "feature/test",
 						commitHash: null,
 						sourcePath: "/repo/.jolli/jollimemory/notes/note-1.md",
 						addedAt: "y",
@@ -876,10 +855,8 @@ describe("QueueWorker", () => {
 						title: "Real entry",
 						url: "https://linear.app/x/PROJ-1528",
 						sourcePath: "/test/cwd/.jolli/jollimemory/references/linear/PROJ-1528.md",
-						branch: "feature/test",
 						addedAt: "x",
 						updatedAt: "x",
-						commitHash: null,
 						sourceToolName: "mcp__linear__get_issue",
 					},
 				},
@@ -917,7 +894,6 @@ describe("QueueWorker", () => {
 					id: "note-1",
 					title: "keep me",
 					format: "snippet",
-					branch: "feature/test",
 					commitHash: null,
 					sourcePath: "/repo/.jolli/jollimemory/notes/note-1.md",
 					addedAt: "y",
@@ -928,7 +904,7 @@ describe("QueueWorker", () => {
 		});
 	});
 
-	describe("runWorker — Step 6b prompt assembly (multi-source)", () => {
+	describe("runWorker — prompt assembly (multi-source)", () => {
 		it("pulls active entities from getReferenceEntriesForBranch and renders one block per source", async () => {
 			const op = makeCommitOp({ commitHash: "abc12345def67890" });
 			vi.mocked(dequeueAllGitOperations)
@@ -937,7 +913,7 @@ describe("QueueWorker", () => {
 				.mockResolvedValueOnce([]);
 			setupPipelineMocks("abc12345def67890");
 
-			// Provide active entries for two sources — Linear and Jira. Step 6b
+			// Provide active entries for two sources — Linear and Jira. The pipeline
 			// must call getReferenceEntriesForBranch (NOT getReferenceEntriesForBranch).
 			vi.mocked(getReferenceEntriesForBranch).mockResolvedValue([
 				{
@@ -946,10 +922,8 @@ describe("QueueWorker", () => {
 					title: "Linear active",
 					url: "https://linear.app/x/PROJ-9",
 					sourcePath: "/test/cwd/.jolli/jollimemory/references/linear/PROJ-9.md",
-					branch: "feature/test",
 					addedAt: "x",
 					updatedAt: "x",
-					commitHash: null,
 					sourceToolName: "mcp__linear__get_issue",
 				},
 				{
@@ -958,10 +932,8 @@ describe("QueueWorker", () => {
 					title: "Jira active",
 					url: "https://example.atlassian.net/browse/KAN-9",
 					sourcePath: "/test/cwd/.jolli/jollimemory/references/jira/KAN-9.md",
-					branch: "feature/test",
 					addedAt: "x",
 					updatedAt: "x",
-					commitHash: null,
 					sourceToolName: "mcp__jira__get_issue",
 				},
 			]);
@@ -1268,7 +1240,7 @@ describe("QueueWorker", () => {
 	});
 
 	describe("detectUncommittedNoteIds", () => {
-		it("returns only notes with null commitHash and no ignored/contentHashAtCommit", async () => {
+		it("returns only notes with null commitHash and no contentHashAtCommit guard", async () => {
 			vi.mocked(loadPlansRegistry).mockResolvedValueOnce({
 				version: 1,
 				plans: {},
@@ -1280,10 +1252,9 @@ describe("QueueWorker", () => {
 						sourcePath: "/p",
 						addedAt: "x",
 						updatedAt: "y",
-						branch: "main",
 						commitHash: null,
 					},
-					// Fails branch: already committed
+					// Excluded: already committed
 					committed: {
 						id: "committed",
 						title: "Committed",
@@ -1291,22 +1262,9 @@ describe("QueueWorker", () => {
 						sourcePath: "/p",
 						addedAt: "x",
 						updatedAt: "y",
-						branch: "main",
 						commitHash: "abc123",
 					},
-					// Fails branch: ignored
-					ignored: {
-						id: "ignored",
-						title: "Ignored",
-						format: "markdown" as const,
-						sourcePath: "/p",
-						addedAt: "x",
-						updatedAt: "y",
-						branch: "main",
-						commitHash: null,
-						ignored: true,
-					},
-					// Fails branch: contentHashAtCommit set (guard entry)
+					// Excluded: archive guard (contentHashAtCommit set, source not revived)
 					guard: {
 						id: "guard",
 						title: "Guard",
@@ -1314,7 +1272,6 @@ describe("QueueWorker", () => {
 						sourcePath: "/p",
 						addedAt: "x",
 						updatedAt: "y",
-						branch: "main",
 						commitHash: null,
 						contentHashAtCommit: "hash",
 					},
@@ -1329,41 +1286,6 @@ describe("QueueWorker", () => {
 			vi.mocked(loadPlansRegistry).mockResolvedValueOnce({ version: 1, plans: {} });
 			const ids = await __test__.detectUncommittedNoteIds("/test/cwd", "main");
 			expect(ids.size).toBe(0);
-		});
-
-		it("excludes notes whose branch differs from the target branch", async () => {
-			// Regression guard for the cross-branch leak: parallels the
-			// detectPlanSlugsFromRegistry test in PostCommitHook.helpers.test.ts.
-			// Without the branch filter, notes from `feature/idle` would be
-			// associated with a commit on `feature/active`.
-			vi.mocked(loadPlansRegistry).mockResolvedValueOnce({
-				version: 1,
-				plans: {},
-				notes: {
-					"current-note": {
-						id: "current-note",
-						title: "Current",
-						format: "markdown" as const,
-						sourcePath: "/p",
-						addedAt: "x",
-						updatedAt: "y",
-						branch: "feature/active",
-						commitHash: null,
-					},
-					"other-note": {
-						id: "other-note",
-						title: "Other",
-						format: "markdown" as const,
-						sourcePath: "/p",
-						addedAt: "x",
-						updatedAt: "y",
-						branch: "feature/idle",
-						commitHash: null,
-					},
-				},
-			});
-			const ids = await __test__.detectUncommittedNoteIds("/test/cwd", "feature/active");
-			expect([...ids]).toEqual(["current-note"]);
 		});
 
 		// Iterative-commit revival mirror of detectPlanSlugsFromRegistry: a previously
@@ -1384,7 +1306,6 @@ describe("QueueWorker", () => {
 						sourcePath: "/repo/notes/revived-note.md",
 						addedAt: "x",
 						updatedAt: "y",
-						branch: "main",
 						commitHash: "deadbeefdeadbeef",
 						contentHashAtCommit: oldHash,
 					},
@@ -1412,7 +1333,6 @@ describe("QueueWorker", () => {
 						sourcePath: "/repo/notes/stable-note.md",
 						addedAt: "x",
 						updatedAt: "y",
-						branch: "main",
 						commitHash: "deadbeefdeadbeef",
 						contentHashAtCommit: hash,
 					},
@@ -1437,7 +1357,6 @@ describe("QueueWorker", () => {
 						sourcePath: "/repo/notes/gone-note.md",
 						addedAt: "x",
 						updatedAt: "y",
-						branch: "main",
 						commitHash: "deadbeefdeadbeef",
 						contentHashAtCommit: "anything",
 					},
@@ -2007,202 +1926,6 @@ describe("QueueWorker", () => {
 			);
 
 			expect(cleanupBranchStaleChildMarkdown).not.toHaveBeenCalled();
-		});
-	});
-
-	describe("reassociateMetadata — multi-source entities", () => {
-		// Direct invocations of the private helper via __test__. These exercise
-		// every code path of the post-2.11 refactor (plans + notes + multi-source
-		// entities + legacy linearIssues fallback + both-fields-present dedupe)
-		// without going through the squash / amend / rebase-pick wrappers — each
-		// wrapper already has its own coverage tests above; here we focus on the
-		// behaviour change isolated.
-
-		beforeEach(() => {
-			vi.mocked(associatePlanWithCommit).mockResolvedValue(undefined);
-			vi.mocked(associateNoteWithCommit).mockResolvedValue(undefined);
-			vi.mocked(associateReferenceWithCommit).mockResolvedValue(undefined);
-		});
-
-		it("dispatches multi-source references[] through associateReferenceWithCommit", async () => {
-			const oldSummary = {
-				version: 5,
-				commitHash: "oldhash",
-				commitMessage: "x",
-				commitAuthor: "x",
-				commitDate: "x",
-				branch: "main",
-				generatedAt: "x",
-				references: [
-					{
-						archivedKey: "linear:PROJ-1-abc12345",
-						source: "linear",
-						nativeId: "PROJ-1",
-						title: "L1",
-						url: "u",
-						referencedAt: "x",
-						sourceToolName: "mcp__linear__get_issue",
-					},
-					{
-						archivedKey: "jira:KAN-5-def67890",
-						source: "jira",
-						nativeId: "KAN-5",
-						title: "J1",
-						url: "u",
-						referencedAt: "x",
-						sourceToolName: "mcp__atlassian__getJiraIssue",
-					},
-				],
-			} as never;
-
-			await __test__.reassociateMetadata([oldSummary], "newhash", "/cwd");
-
-			expect(associateReferenceWithCommit).toHaveBeenCalledTimes(2);
-			expect(associateReferenceWithCommit).toHaveBeenCalledWith("linear:PROJ-1-abc12345", "newhash", "/cwd");
-			expect(associateReferenceWithCommit).toHaveBeenCalledWith("jira:KAN-5-def67890", "newhash", "/cwd");
-		});
-
-		it("dedupes within entities[] itself when the same archivedKey appears twice (defensive)", async () => {
-			// Same archivedKey duplicated on `entities` — should still associate
-			// only once. Belt-and-braces against a future writer bug.
-			const oldSummary = {
-				version: 5,
-				commitHash: "oldhash",
-				commitMessage: "x",
-				commitAuthor: "x",
-				commitDate: "x",
-				branch: "main",
-				generatedAt: "x",
-				references: [
-					{
-						archivedKey: "linear:PROJ-1-abc12345",
-						source: "linear",
-						nativeId: "PROJ-1",
-						title: "L1",
-						url: "u",
-						referencedAt: "x",
-						sourceToolName: "mcp__linear__get_issue",
-					},
-					{
-						archivedKey: "linear:PROJ-1-abc12345",
-						source: "linear",
-						nativeId: "PROJ-1",
-						title: "L1-dupe",
-						url: "u",
-						referencedAt: "x",
-						sourceToolName: "mcp__linear__get_issue",
-					},
-				],
-			} as never;
-
-			await __test__.reassociateMetadata([oldSummary], "newhash", "/cwd");
-
-			expect(associateReferenceWithCommit).toHaveBeenCalledTimes(1);
-		});
-
-		it("still associates plans and notes alongside entities (lock-step contract)", async () => {
-			// Regression for the original "notes forgotten in some paths" bug
-			// the helper exists to prevent. plans + notes + entities all flow
-			// through one helper invocation.
-			const oldSummary = {
-				version: 5,
-				commitHash: "oldhash",
-				commitMessage: "x",
-				commitAuthor: "x",
-				commitDate: "x",
-				branch: "main",
-				generatedAt: "x",
-				plans: [{ slug: "p-1" } as never],
-				notes: [{ id: "n-1" } as never],
-				references: [
-					{
-						archivedKey: "linear:PROJ-1-abc12345",
-						source: "linear",
-						nativeId: "PROJ-1",
-						title: "L1",
-						url: "u",
-						referencedAt: "x",
-						sourceToolName: "mcp__linear__get_issue",
-					},
-				],
-			} as never;
-
-			await __test__.reassociateMetadata([oldSummary], "newhash", "/cwd");
-
-			expect(associatePlanWithCommit).toHaveBeenCalledWith("p-1", "newhash", "/cwd");
-			expect(associateNoteWithCommit).toHaveBeenCalledWith("n-1", "newhash", "/cwd");
-			expect(associateReferenceWithCommit).toHaveBeenCalledWith("linear:PROJ-1-abc12345", "newhash", "/cwd");
-		});
-
-		it("no-ops when neither entities nor linearIssues are present", async () => {
-			const oldSummary = {
-				version: 5,
-				commitHash: "oldhash",
-				commitMessage: "x",
-				commitAuthor: "x",
-				commitDate: "x",
-				branch: "main",
-				generatedAt: "x",
-			} as never;
-
-			await __test__.reassociateMetadata([oldSummary], "newhash", "/cwd");
-
-			expect(associateReferenceWithCommit).not.toHaveBeenCalled();
-			expect(associateReferenceWithCommit).not.toHaveBeenCalled();
-		});
-
-		it("handles multiple oldSummaries in one call (squash N:1 path)", async () => {
-			// Squash pipeline passes the full source-summary array. Each summary
-			// contributes its own entities; cross-summary archivedKey dedupe is
-			// NOT enforced (each commit's row is independent in the registry —
-			// but in practice the same archivedKey across summaries would imply
-			// the same registry row, and the second associate is a no-op write).
-			const a = {
-				version: 5,
-				commitHash: "a",
-				commitMessage: "x",
-				commitAuthor: "x",
-				commitDate: "x",
-				branch: "main",
-				generatedAt: "x",
-				references: [
-					{
-						archivedKey: "linear:A-1-aaa11111",
-						source: "linear",
-						nativeId: "A-1",
-						title: "A",
-						url: "u",
-						referencedAt: "x",
-						sourceToolName: "mcp__linear__get_issue",
-					},
-				],
-			} as never;
-			const b = {
-				version: 5,
-				commitHash: "b",
-				commitMessage: "x",
-				commitAuthor: "x",
-				commitDate: "x",
-				branch: "main",
-				generatedAt: "x",
-				references: [
-					{
-						archivedKey: "jira:B-1-bbb22222",
-						source: "jira",
-						nativeId: "B-1",
-						title: "B",
-						url: "u",
-						referencedAt: "x",
-						sourceToolName: "mcp__atlassian__getJiraIssue",
-					},
-				],
-			} as never;
-
-			await __test__.reassociateMetadata([a, b], "newhash", "/cwd");
-
-			expect(associateReferenceWithCommit).toHaveBeenCalledTimes(2);
-			expect(associateReferenceWithCommit).toHaveBeenCalledWith("linear:A-1-aaa11111", "newhash", "/cwd");
-			expect(associateReferenceWithCommit).toHaveBeenCalledWith("jira:B-1-bbb22222", "newhash", "/cwd");
 		});
 	});
 });

--- a/cli/src/hooks/QueueWorker.test.ts
+++ b/cli/src/hooks/QueueWorker.test.ts
@@ -634,9 +634,64 @@ describe("QueueWorker", () => {
 				{ key: "priority", label: "Priority", value: "No priority", icon: "flame" },
 				{ key: "labels", label: "Labels", value: "JolliMemory, Feature", icon: "tag" },
 			]);
-			// The reference markdown is NOT physically renamed — the archivedKey
-			// lives only in the CommitSummary's ReferenceCommitRef (asserted above), while
-			// the guard row keeps the canonical references/<source>/<key>.md file in place.
+			// The archivedKey lives only in the CommitSummary's ReferenceCommitRef
+			// (asserted above) + the orphan-branch snapshot; under the
+			// commit-deletes-entry model the registry row + local markdown are torn
+			// down by finalizeReferenceArchive after storeReferences succeeds.
+		});
+
+		it("preserves local reference state when the orphan-branch write fails (write-ahead recovery)", async () => {
+			const op = makeCommitOp({ commitHash: "abc12345def67890" });
+			vi.mocked(dequeueAllGitOperations)
+				.mockResolvedValueOnce([{ op, filePath: "/tmp/queue/li.json" }])
+				.mockResolvedValueOnce([])
+				.mockResolvedValueOnce([]);
+			setupPipelineMocks("abc12345def67890");
+
+			vi.mocked(detectUncommittedReferenceIds).mockResolvedValue([
+				{ mapKey: "linear:PROJ-1528", source: "linear", sourcePath: "/ref.md" },
+			]);
+			vi.mocked(loadPlansRegistry).mockResolvedValue({
+				version: 1,
+				plans: {},
+				references: {
+					"linear:PROJ-1528": {
+						source: "linear",
+						nativeId: "PROJ-1528",
+						title: "t",
+						url: "u",
+						sourcePath: "/ref.md",
+						addedAt: "x",
+						updatedAt: "x",
+						sourceToolName: "mcp__linear__get_issue",
+					},
+				},
+			});
+			const { readReferenceMarkdown } = await import("../core/references/ReferenceStore.js");
+			vi.mocked(readReferenceMarkdown).mockResolvedValue({
+				mapKey: "linear:PROJ-1528",
+				source: "linear",
+				nativeId: "PROJ-1528",
+				title: "t",
+				url: "u",
+				toolName: "mcp__linear__get_issue",
+				referencedAt: "2026-05-14T06:06:01.123Z",
+			});
+			const { readFile } = await import("node:fs/promises");
+			(readFile as unknown as { mockResolvedValue: (v: string) => void }).mockResolvedValue("file content");
+
+			// Orphan-branch write fails AFTER the snapshot was captured but BEFORE
+			// any local teardown — the whole point of the deferred-delete ordering.
+			const { storeReferences } = await import("../core/SummaryStore.js");
+			vi.mocked(storeReferences).mockRejectedValueOnce(new Error("orphan write failed"));
+
+			// Worker swallows the per-entry error (fire-and-forget) and completes.
+			await runWorker("/test/cwd");
+
+			// finalizeReferenceArchive never ran → local markdown NOT deleted, so the
+			// active row stays in plans.json and re-archives on the next commit.
+			const { deleteReferenceMarkdown } = await import("../core/references/ReferenceStore.js");
+			expect(vi.mocked(deleteReferenceMarkdown)).not.toHaveBeenCalled();
 		});
 
 		it("skips entities whose source markdown is unreadable but still completes the pipeline", async () => {
@@ -901,6 +956,58 @@ describe("QueueWorker", () => {
 				},
 			});
 			expect(lastSave.references?.["linear:GHOST-1"]).toBeUndefined();
+		});
+	});
+
+	describe("finalizeReferenceArchive — fingerprint guard", () => {
+		const refRow = (updatedAt: string) => ({
+			source: "linear" as const,
+			nativeId: "PROJ-1",
+			title: "t",
+			url: "u",
+			sourcePath: "/ref.md",
+			addedAt: "x",
+			updatedAt,
+			sourceToolName: "mcp__linear__get_issue",
+		});
+
+		it("deletes the row + markdown when the fresh fingerprint matches the captured one", async () => {
+			vi.mocked(loadPlansRegistry).mockResolvedValue({
+				version: 1,
+				plans: {},
+				references: { "linear:PROJ-1": refRow("2026-04-01T00:00:00Z") },
+			});
+			const { deleteReferenceMarkdown } = await import("../core/references/ReferenceStore.js");
+
+			await __test__.finalizeReferenceArchive(
+				[{ mapKey: "linear:PROJ-1", sourcePath: "/ref.md", updatedAt: "2026-04-01T00:00:00Z" }],
+				"/test/cwd",
+			);
+
+			const saved = vi.mocked(savePlansRegistry).mock.calls.at(-1)?.[0];
+			expect(saved?.references?.["linear:PROJ-1"]).toBeUndefined();
+			expect(vi.mocked(deleteReferenceMarkdown)).toHaveBeenCalledWith("/ref.md");
+		});
+
+		it("keeps the row + markdown when a StopHook re-upsert changed updatedAt (race)", async () => {
+			// Fresh registry shows a NEWER updatedAt → the ref was re-upserted between
+			// storeReferences and finalize. Deleting it would lose the re-reference.
+			vi.mocked(loadPlansRegistry).mockResolvedValue({
+				version: 1,
+				plans: {},
+				references: { "linear:PROJ-1": refRow("2026-04-02T09:00:00Z") },
+			});
+			const { deleteReferenceMarkdown } = await import("../core/references/ReferenceStore.js");
+
+			await __test__.finalizeReferenceArchive(
+				[{ mapKey: "linear:PROJ-1", sourcePath: "/ref.md", updatedAt: "2026-04-01T00:00:00Z" }],
+				"/test/cwd",
+			);
+
+			// Nothing was deleted → no write at all (avoids a pointless lost-update
+			// window), and the markdown is left intact.
+			expect(vi.mocked(savePlansRegistry)).not.toHaveBeenCalled();
+			expect(vi.mocked(deleteReferenceMarkdown)).not.toHaveBeenCalled();
 		});
 	});
 

--- a/cli/src/hooks/QueueWorker.ts
+++ b/cli/src/hooks/QueueWorker.ts
@@ -40,18 +40,11 @@ import { discoverOpenCodeSessions, isOpenCodeInstalled } from "../core/OpenCodeS
 import { readOpenCodeTranscript } from "../core/OpenCodeTranscriptReader.js";
 import { evaluatePlanProgress } from "../core/PlanProgressEvaluator.js";
 import { formatPlansBlock } from "../core/PlanPromptFormatter.js";
-import {
-	hashReferenceContent,
-	readReferenceMarkdown,
-	referencePath,
-	renameReferenceMarkdown,
-	sanitizeNativeIdForPath,
-} from "../core/references/ReferenceStore.js";
+import { deleteReferenceMarkdown, readReferenceMarkdown } from "../core/references/ReferenceStore.js";
 import { ALL_ADAPTERS } from "../core/references/sources/index.js";
 import {
 	associateNoteWithCommit,
 	associatePlanWithCommit,
-	associateReferenceWithCommit,
 	deleteQueueEntry,
 	dequeueAllGitOperations,
 	detectActiveNotesForBranch,
@@ -168,22 +161,9 @@ async function reassociateMetadata(
 				await associateNoteWithCommit(noteRef.id, newHash, cwd);
 			}
 		}
-
-		const referenceRefs: ReferenceCommitRef[] = [];
-		const seen = new Set<string>();
-		if (oldSummary.references) {
-			for (const ref of oldSummary.references) {
-				if (seen.has(ref.archivedKey)) continue;
-				seen.add(ref.archivedKey);
-				referenceRefs.push(ref);
-			}
-		}
-		for (const ref of referenceRefs) {
-			// archivedKey on references is the prefixed `<source>:<nativeId>-<shortHash>`
-			// form. associateReferenceWithCommit looks the row up by archivedKey
-			// in plans.json.references — single update per row.
-			await associateReferenceWithCommit(ref.archivedKey, newHash, cwd);
-		}
+		// References have no plans.json guard row (commit deletes the entry),
+		// so there's nothing to re-anchor on squash/rebase — the CommitSummary's
+		// ReferenceCommitRef travels with the orphan-branch storeReferences flow.
 	}
 }
 
@@ -532,12 +512,9 @@ async function detectPlanSlugsFromRegistry(cwd: string, branch: string): Promise
 	const registry = await loadPlansRegistry(cwd);
 	const slugs = new Set<string>();
 	for (const [slug, entry] of Object.entries(registry.plans)) {
-		// branch filter is load-bearing: without it, uncommitted plans from OTHER
-		// branches get falsely associated with the current commit (observed bug:
-		// cross-branch plans archived to feature/linear-issues-as-panel-item's
-		// 786c5330 even though their entry.branch said feature/summarize-include-linear-issues).
-		if (entry.branch !== branch) continue;
-		if (entry.ignored) continue;
+		// No branch filter — uncommitted plans bind to the current worktree
+		// (its own plans.json) and commit associates all of them. Cross-worktree
+		// leakage is impossible because each worktree has a separate plans.json.
 		if (entry.commitHash === null && !entry.contentHashAtCommit) {
 			slugs.add(slug);
 			continue;
@@ -605,18 +582,12 @@ async function associatePlansWithCommit(
 			log.info("Plan association: slug %s not in registry — skipping", slug);
 			continue;
 		}
-		// Skip if ignored, or if the entry is a per-commit archive snapshot
-		// (commitHash set but no contentHashAtCommit — these are the
-		// `slug-<shortHash>` artifacts, not user-facing working-area rows).
-		// Guard entries (commitHash + contentHashAtCommit) are deliberately
-		// NOT skipped here: detectPlanSlugsFromRegistry only forwards them
-		// when their source file diverged from the guard hash, which means
-		// the user iterated on the plan and we need to re-archive the new
-		// content under this commit.
-		if (entry.ignored) {
-			log.info("Plan association: slug %s is ignored — skipping", slug);
-			continue;
-		}
+		// Skip per-commit archive snapshots (commitHash set but no
+		// contentHashAtCommit — the `slug-<shortHash>` artifacts, not user-facing
+		// working-area rows). Guard entries (commitHash + contentHashAtCommit) are
+		// deliberately NOT skipped here: detectPlanSlugsFromRegistry only forwards
+		// them when their source file diverged from the guard hash, which means the
+		// user iterated on the plan and we need to re-archive the new content.
 		if (entry.commitHash !== null && !entry.contentHashAtCommit) {
 			log.info(
 				"Plan association: slug %s is an archive snapshot for %s — skipping",
@@ -662,9 +633,12 @@ async function associatePlansWithCommit(
 		markdownBySlug.set(newSlug, content);
 		originalSlugBySlug.set(newSlug, slug);
 
-		// Archive in plans.json:
-		// 1. Original slug entry becomes guard (contentHashAtCommit for detecting file overwrites)
-		// 2. New entry keyed by newSlug (the committed plan)
+		// Archive in plans.json: the original slug entry becomes the guard
+		// (contentHashAtCommit detects later file overwrites → revival).
+		// No per-commit `<slug>-<shortHash>` archive row is written — the
+		// orphan-branch snapshot (stored under newSlug below) + the CommitSummary
+		// PlanReference are the system of record; the archive row was a redundant
+		// plans.json copy the sidebar never showed.
 		const updatedRegistry = await loadPlansRegistry(cwd);
 		const guardEntry = {
 			...entry,
@@ -672,22 +646,12 @@ async function associatePlansWithCommit(
 			contentHashAtCommit: contentHash,
 			updatedAt: nowStr,
 		};
-		const archivedEntry = {
-			slug: newSlug,
-			title,
-			sourcePath: entry.sourcePath,
-			addedAt: entry.addedAt,
-			updatedAt: nowStr,
-			branch: entry.branch,
-			commitHash: commitHash,
-		};
 		await savePlansRegistry(
 			{
 				...updatedRegistry,
 				plans: {
 					...updatedRegistry.plans,
 					[slug]: guardEntry,
-					[newSlug]: archivedEntry,
 				},
 			},
 			cwd,
@@ -717,12 +681,8 @@ async function detectUncommittedNoteIds(cwd: string, branch: string): Promise<Se
 	const registry = await loadPlansRegistry(cwd);
 	const ids = new Set<string>();
 	for (const [id, entry] of Object.entries(registry.notes ?? {})) {
-		// branch filter mirrors detectPlanSlugsFromRegistry / detectUncommittedLinearIssueIds
-		// — without it, notes from another branch would be wrongly associated with
-		// the current commit on commit. See the cross-branch leak documented at
-		// detectPlanSlugsFromRegistry above.
-		if (entry.branch !== branch) continue;
-		if (entry.ignored) continue;
+		// No branch filter — notes bind to the current worktree; commit
+		// associates all uncommitted ones (per-worktree plans.json isolates).
 		if (entry.commitHash === null && !entry.contentHashAtCommit) {
 			ids.add(id);
 			continue;
@@ -794,25 +754,15 @@ async function associateNotesWithCommit(
 		// Store under new id in orphan branch
 		noteFiles.push({ id: newId, content });
 
-		// Archive in accumulated notes:
-		// 1. Original id entry becomes guard (contentHashAtCommit for detecting file overwrites)
-		// 2. New entry keyed by newId (the committed note)
+		// Archive: the original id entry becomes the guard (contentHashAtCommit
+		// detects later overwrites → revival). No `<id>-<shortHash>` archive
+		// row — the orphan-branch snapshot (stored under newId below) + the
+		// CommitSummary NoteReference are the system of record.
 		updatedNotes[id] = {
 			...entry,
 			commitHash,
 			updatedAt: now2,
 			contentHashAtCommit: contentHash,
-			ignored: undefined,
-		};
-		updatedNotes[newId] = {
-			id: newId,
-			title: entry.title,
-			format: entry.format,
-			sourcePath: entry.sourcePath,
-			addedAt: entry.addedAt,
-			updatedAt: now2,
-			branch: entry.branch,
-			commitHash,
 		};
 		log.info("Note archived: %s → %s (hash=%s)", id, newId, contentHash.substring(0, 12));
 	}
@@ -838,10 +788,10 @@ async function associateNotesWithCommit(
  * Return shape for {@link associateReferencesWithCommit}.
  *
  * `refs` are the post-archive snapshots stored on `CommitSummary.references`.
- * `filesToStore` are the RAW markdown bytes captured BEFORE the local rename —
- * the caller passes them straight to `SummaryStore.storeReferences` so the
- * orphan-branch snapshot is independent of whether the local rename succeeded.
- * Mirrors the historical Linear-only filesToStore handoff pattern.
+ * `filesToStore` are the RAW markdown bytes read from the active path — the
+ * caller passes them straight to `SummaryStore.storeReferences` so the
+ * orphan-branch snapshot is the system of record (no local archived
+ * copy). Mirrors the historical Linear-only filesToStore handoff pattern.
  */
 export interface AssociateReferencesResult {
 	readonly refs: ReadonlyArray<ReferenceCommitRef>;
@@ -853,24 +803,20 @@ export interface AssociateReferencesResult {
  * Linear / Jira / GitHub / Notion entries through a single archive pipeline:
  *
  *   1. For each `{mapKey, source, sourcePath}` triple, read the raw markdown
- *      bytes BEFORE the rename so the orphan-branch snapshot does not depend
- *      on rename success.
- *   2. Build the dual `plans.json.references` entry — `mapKey` becomes a guard
- *      (`contentHashAtCommit` + `commitHash` set, `sourcePath` UNCHANGED so
- *      the next StopHook upsert of the same mapKey writes back into the same
- *      active path), and `archivedKey = "<mapKey>-<shortHash>"` becomes a
- *      snapshot row with explicit fields (no `...entry` spread, no
- *      `contentHashAtCommit` / `ignored` inherited).
- *   3. Physically rename the active markdown from `referencePath(active)` to
- *      `referencePath(archived)`. On failure log.warn and continue — the guard
- *      is already written and the archived entry's sourcePath points at the
- *      archived location even if no file lives there; Regenerator reads from
- *      the orphan branch (where `storeReferences` already received the raw
- *      pre-rename content).
- *   4. Near-write reread + merge: reload plans.json AT THE END and overwrite
- *      ONLY the specific mapKey + archivedKey pairs this call touched. Any
- *      concurrent StopHook upsert / ignoreReference command that ran during this
- *      archive is preserved.
+ *      bytes so the orphan-branch snapshot does not depend on the local file.
+ *   2. Promote the `mapKey` entry to a guard in `plans.json.references`:
+ *      `contentHashAtCommit` + `commitHash` are set and `sourcePath` is left
+ *      UNCHANGED so the next StopHook upsert of the same mapKey writes back
+ *      into the same active path. No per-commit snapshot row is created
+ *      and the active markdown is NOT physically renamed — the orphan-branch
+ *      snapshot (filesToStore: raw bytes keyed by `archivedKey =
+ *      "<mapKey>-<shortHash>"`) plus the CommitSummary ReferenceCommitRef are
+ *      the system of record, so no local archived copy is needed and the
+ *      guard's sourcePath never dangles.
+ *   3. Near-write reread + merge: reload plans.json AT THE END and overwrite
+ *      ONLY the specific mapKeys this call touched. Any concurrent StopHook
+ *      upsert / ignoreReference command that ran during this archive is
+ *      preserved.
  *
  * The function does NOT call `storeReferences` itself — that responsibility
  * stays with the caller (executePipeline / amend fresh-leaf) because the
@@ -886,7 +832,6 @@ async function associateReferencesWithCommit(
 	if (ids.length === 0) return { refs: [], filesToStore: [] };
 
 	const shortHash = commitHash.substring(0, 8);
-	const now = new Date().toISOString();
 	const refs: ReferenceCommitRef[] = [];
 	const filesToStore: Array<{ archivedKey: string; source: SourceId; content: string }> = [];
 
@@ -895,6 +840,9 @@ async function associateReferencesWithCommit(
 		/* v8 ignore next -- `?? {}` fallback unreachable: `ids` is sourced from detectUncommittedReferenceIds, which derives from plans.json.references; if references were undefined ids would be empty and the early-return would have already fired. */
 		...(registry.references ?? {}),
 	};
+	// mapKeys successfully archived this run — deleted from plans.json in the
+	// merge-save below (reference commit removes the entry; no guard row survives).
+	const committedMapKeys = new Set<string>();
 	const droppedMapKeys: string[] = [];
 
 	for (const { mapKey, source } of ids) {
@@ -936,61 +884,15 @@ async function associateReferencesWithCommit(
 			continue;
 		}
 
-		const contentHashAtCommit = hashReferenceContent(fullRef);
 		const archivedKey = `${mapKey}-${shortHash}`;
-		// Bare archive form for the on-disk filename. `source:<nativeId>` is the
-		// registry key; the file stem is `<nativeId>-<shortHash>` (Linear / Jira /
-		// Notion are identity under sanitizeNativeIdForPath; GitHub rewrites
-		// `owner/repo#n` to a path-safe stem). referencePath does NOT sanitize, so
-		// we must do it here — and we sanitize the whole `<nativeId>-<shortHash>`
-		// string so this matches orphanPathFor's stem byte-for-byte.
-		const bareArchivedKey = sanitizeNativeIdForPath(source, `${entry.nativeId}-${shortHash}`);
-		const archivedSourcePath = referencePath(cwd, source, bareArchivedKey);
 
-		// Guard entry (key = mapKey): spread original to keep ACTIVE sourcePath
-		// (next StopHook upsert of same mapKey writes back to the same active
-		// path; guard collides via contentHashAtCommit so re-archive is a no-op).
-		updatedReferences[mapKey] = {
-			...entry,
-			commitHash,
-			contentHashAtCommit,
-			updatedAt: now,
-			ignored: undefined,
-		};
-		// Archived snapshot (key = archivedKey): explicit fields, NOT a spread —
-		// we do NOT want to inherit the guard's contentHashAtCommit / ignored
-		// from the original entry into the archive snapshot.
-		updatedReferences[archivedKey] = {
-			source: entry.source,
-			nativeId: entry.nativeId,
-			title: entry.title,
-			url: entry.url,
-			sourcePath: archivedSourcePath,
-			branch: entry.branch,
-			addedAt: entry.addedAt,
-			updatedAt: now,
-			commitHash,
-			sourceToolName: entry.sourceToolName,
-		};
-
-		// Physical rename. Failure → log.warn and continue. The guard is
-		// already written (so re-archive on the next commit short-circuits via
-		// contentHashAtCommit), and the archived snapshot's sourcePath points
-		// at the archived location even if no local file lives there —
-		// Regenerator reads from the orphan branch (storeReferences below uses
-		// rawContent captured before rename).
-		try {
-			await renameReferenceMarkdown(entry.sourcePath, archivedSourcePath);
-			/* v8 ignore start -- fs.rename failure: not deterministically reachable in unit tests without mocking; the warn-and-continue branch protects production against Windows EPERM / antivirus locks. */
-		} catch (err) {
-			log.warn(
-				"Reference association: rename %s → %s failed: %s (continuing)",
-				entry.sourcePath,
-				archivedSourcePath,
-				(err as Error).message,
-			);
-		}
-		/* v8 ignore stop */
+		// Reference commit DELETES the entry (no guard row). reference has no
+		// revival (it's a read-only MCP snapshot), so nothing needs to survive in
+		// plans.json — the orphan-branch snapshot (filesToStore: raw bytes keyed by
+		// archivedKey) + the CommitSummary ReferenceCommitRef are the system of
+		// record. The mapKey is removed in the merge-save below; the local active
+		// markdown is cleaned up here (orphan keeps the snapshot).
+		committedMapKeys.add(mapKey);
 
 		refs.push({
 			archivedKey,
@@ -1004,28 +906,31 @@ async function associateReferencesWithCommit(
 		});
 		filesToStore.push({ archivedKey, source, content: rawContent });
 
-		log.info("Reference archived: %s → %s (hash=%s)", mapKey, archivedKey, contentHashAtCommit.substring(0, 12));
+		// Best-effort: the active markdown's content is now in the orphan branch.
+		try {
+			await deleteReferenceMarkdown(entry.sourcePath);
+		} catch (err) {
+			log.warn(
+				"Reference association: failed to delete local markdown for %s: %s",
+				mapKey,
+				(err as Error).message,
+			);
+		}
+
+		log.info("Reference archived (entry removed): %s → %s", mapKey, archivedKey);
 	}
 
-	if (refs.length > 0) {
-		// Near-write reread + per-key merge. Same rationale as the legacy
-		// Linear-only path: a concurrent StopHook upsert or ignoreReference
-		// command may have touched plans.json.references while we were busy
-		// reading + hashing + renaming, and overwriting the whole references
-		// map would silently drop their work. Only the (mapKey + archivedKey)
-		// pairs we explicitly touched get layered on top of the fresh
-		// snapshot.
+	if (committedMapKeys.size > 0) {
+		// Near-write reread + per-key merge. A concurrent StopHook upsert may have
+		// touched plans.json.references while we were busy reading, and overwriting
+		// the whole references map would silently drop their work. We only
+		// DELETE the mapKeys we archived this run from the fresh snapshot — any
+		// concurrent writer's other keys are preserved.
 		const freshRegistry = await loadPlansRegistry(cwd);
-		/* v8 ignore next -- `?? {}` fallback unreachable: freshRegistry is loaded immediately after we've already proven references was defined (L919 fallback would have fired otherwise); a concurrent writer clearing the field is the same race that the surrounding per-key merge is designed to tolerate, not eliminate. */
+		/* v8 ignore next -- `?? {}` fallback unreachable: freshRegistry is loaded immediately after the loop archived at least one mapKey sourced from plans.json.references. */
 		const mergedReferences = { ...(freshRegistry.references ?? {}) };
-		for (const { mapKey } of ids) {
-			if (updatedReferences[mapKey] !== undefined) {
-				mergedReferences[mapKey] = updatedReferences[mapKey];
-			}
-			const archivedKey = `${mapKey}-${shortHash}`;
-			if (updatedReferences[archivedKey] !== undefined) {
-				mergedReferences[archivedKey] = updatedReferences[archivedKey];
-			}
+		for (const mapKey of committedMapKeys) {
+			delete mergedReferences[mapKey];
 		}
 		const out: PlansRegistry = {
 			version: 1,
@@ -1066,7 +971,7 @@ async function readMarkdownFileContent(absPath: string): Promise<string> {
  * sections appear in a stable order across runs — important for the LLM's
  * caching to hit on the prompt prefix.
  *
- * Shared between executePipeline (Step 6b) and the amend delta-step path so
+ * Shared between executePipeline and the amend delta-step path so
  * both flows render the reference context identically.
  */
 async function assembleReferenceBlocks(activeReferenceEntries: ReadonlyArray<ReferenceEntry>): Promise<string> {
@@ -1174,7 +1079,7 @@ async function executePipeline(cwd: string, op: GitOperation, force = false): Pr
 	const conversation = buildMultiSessionContext(sessionTranscripts);
 	log.debug("Conversation context built: %d chars, %d sessions", conversation.length, sessionTranscripts.length);
 
-	// Step 6b: Assemble the structured prompt blocks (plans / notes / references).
+	// Assemble the structured prompt blocks (plans / notes / references).
 	// Pure registry-driven: no transcript re-scan. User's Ignore on the panel
 	// takes effect immediately on the next commit. References are bucketed by
 	// SourceId and rendered through `adapter.renderPromptBlock` per registered
@@ -1265,29 +1170,29 @@ async function executePipeline(cwd: string, op: GitOperation, force = false): Pr
 	}
 	log.info("API summary generated (%s)", formatElapsed(stepStart));
 
-	// Step 8a: Read uncommitted plan slugs from plans.json registry.
+	// Read uncommitted plan slugs from plans.json registry.
 	// Apply per-item exclusions BEFORE associate* — these helpers have side effects
 	// (savePlansRegistry archive entry + storePlans to the orphan branch), so a
 	// post-filter on `planAssociation.refs` would still leave the excluded plan
-	// archived on disk. The prompt-block filter at Step 6b only governs LLM input;
+	// archived on disk. The prompt-block filter only governs LLM input;
 	// the archive path is a separate registry scan and must be filtered here.
 	const planSlugs = await detectPlanSlugsFromRegistry(cwd, branch);
 	for (const excludedSlug of exclusions.plans) planSlugs.delete(excludedSlug);
 	const planAssociation = await associatePlansWithCommit(planSlugs, commitInfo.hash, cwd, branch);
 	const planRefs = planAssociation.refs;
 
-	// Step 8a2: Read uncommitted note IDs from plans.json registry.
-	// Same archive-side exclusion as Step 8a — see comment above.
+	// Read uncommitted note IDs from plans.json registry.
+	// Same archive-side exclusion as the plan slugs — see comment above.
 	const noteIds = await detectUncommittedNoteIds(cwd, branch);
 	for (const excludedId of exclusions.notes) noteIds.delete(excludedId);
 	const noteRefs = await associateNotesWithCommit(noteIds, commitInfo.hash, cwd, branch);
 
-	// Step 8a3: Read uncommitted reference mapKeys from plans.json.references and
+	// Read uncommitted reference mapKeys from plans.json.references and
 	// archive them across every source (linear / jira / github / notion). The
 	// returned filesToStore is forwarded directly to storeReferences — captured
 	// BEFORE the local rename so the orphan-branch snapshot is independent of
-	// rename success. Mirrors the plans / notes archive-side filter at Step 8a /
-	// 8a2: excluded references are dropped here too, so the row reappears on the
+	// rename success. Mirrors the plans / notes archive-side filter — excluded
+	// references are dropped here too, so the row reappears on the
 	// next commit (skip-don't-archive semantics).
 	const rawReferenceIds = await detectUncommittedReferenceIds(cwd, branch);
 	const referenceIds = rawReferenceIds.filter((e) => !exclusions.references.has(e.mapKey));
@@ -1341,7 +1246,7 @@ async function executePipeline(cwd: string, op: GitOperation, force = false): Pr
 		log.info("Plan progress: evaluated %d/%d plan(s)", planProgressArtifacts.length, planRefs.length);
 	}
 
-	// Step 8c (early): Build the StoredTranscript so we can allocate a v5
+	// Build the StoredTranscript (early) so we can allocate a v5
 	// transcript ID for it and stamp it onto the summary in one go. Overlays
 	// are already applied inside loadSessionTranscripts so the summary input,
 	// the empty-transcript guard, and the stored snapshot all see the same view.

--- a/cli/src/hooks/QueueWorker.ts
+++ b/cli/src/hooks/QueueWorker.ts
@@ -796,6 +796,21 @@ async function associateNotesWithCommit(
 export interface AssociateReferencesResult {
 	readonly refs: ReadonlyArray<ReferenceCommitRef>;
 	readonly filesToStore: ReadonlyArray<{ archivedKey: string; source: SourceId; content: string }>;
+	/**
+	 * Local state to delete ONLY AFTER the orphan-branch snapshot
+	 * (`filesToStore`) has been durably written by `storeReferences`. Each item
+	 * is a committed reference whose registry row + local markdown must be
+	 * removed via {@link finalizeReferenceArchive}. Deferring the deletion is
+	 * what makes a `storeReferences` failure recoverable: the active row stays in
+	 * plans.json and is re-archived on the next commit instead of being lost.
+	 *
+	 * `updatedAt` is the captured row fingerprint: finalize deletes only if the
+	 * fresh registry row still carries the SAME `updatedAt`. If a StopHook
+	 * re-upserted the same mapKey (user re-referenced the issue) between
+	 * `storeReferences` and finalize, the fresh row's `updatedAt` differs and the
+	 * deletion is skipped — preserving the new active row + its markdown.
+	 */
+	readonly committed: ReadonlyArray<{ mapKey: string; sourcePath: string; updatedAt: string }>;
 }
 
 /**
@@ -804,23 +819,21 @@ export interface AssociateReferencesResult {
  *
  *   1. For each `{mapKey, source, sourcePath}` triple, read the raw markdown
  *      bytes so the orphan-branch snapshot does not depend on the local file.
- *   2. Promote the `mapKey` entry to a guard in `plans.json.references`:
- *      `contentHashAtCommit` + `commitHash` are set and `sourcePath` is left
- *      UNCHANGED so the next StopHook upsert of the same mapKey writes back
- *      into the same active path. No per-commit snapshot row is created
- *      and the active markdown is NOT physically renamed — the orphan-branch
- *      snapshot (filesToStore: raw bytes keyed by `archivedKey =
- *      "<mapKey>-<shortHash>"`) plus the CommitSummary ReferenceCommitRef are
- *      the system of record, so no local archived copy is needed and the
- *      guard's sourcePath never dangles.
- *   3. Near-write reread + merge: reload plans.json AT THE END and overwrite
- *      ONLY the specific mapKeys this call touched. Any concurrent StopHook
- *      upsert / ignoreReference command that ran during this archive is
- *      preserved.
+ *   2. Build the per-commit snapshot: a `ReferenceCommitRef` (value snapshot)
+ *      for the CommitSummary and a `filesToStore` entry (raw bytes keyed by
+ *      `archivedKey = "<mapKey>-<shortHash>"`) for the orphan branch. Under the
+ *      commit-deletes-entry model (§13) the reference row does NOT survive in
+ *      plans.json — but its deletion is DEFERRED, not done here.
  *
- * The function does NOT call `storeReferences` itself — that responsibility
- * stays with the caller (executePipeline / amend fresh-leaf) because the
- * orphan-branch commit message differs between flows.
+ * This function performs NO deletes and NO `savePlansRegistry` write: it only
+ * COMPUTES the snapshot. The `committed` list it returns names the local state
+ * (registry row + markdown) that must be torn down — but only AFTER the caller
+ * has durably written `filesToStore` via `storeReferences`. The caller then
+ * calls {@link finalizeReferenceArchive}. This write-ahead ordering is what
+ * makes a `storeReferences` failure recoverable: with the active row still in
+ * plans.json, the reference is simply re-archived on the next commit instead of
+ * being lost (queue entries are fire-and-forget with no retry). The caller owns
+ * `storeReferences` because the orphan-branch commit message differs per flow.
  */
 async function associateReferencesWithCommit(
 	ids: ReadonlyArray<{ mapKey: string; source: SourceId; sourcePath: string }>,
@@ -829,7 +842,7 @@ async function associateReferencesWithCommit(
 	branch: string,
 ): Promise<AssociateReferencesResult> {
 	log.info("Reference association: detected %d ref(s) for branch %s", ids.length, branch);
-	if (ids.length === 0) return { refs: [], filesToStore: [] };
+	if (ids.length === 0) return { refs: [], filesToStore: [], committed: [] };
 
 	const shortHash = commitHash.substring(0, 8);
 	const refs: ReferenceCommitRef[] = [];
@@ -840,9 +853,10 @@ async function associateReferencesWithCommit(
 		/* v8 ignore next -- `?? {}` fallback unreachable: `ids` is sourced from detectUncommittedReferenceIds, which derives from plans.json.references; if references were undefined ids would be empty and the early-return would have already fired. */
 		...(registry.references ?? {}),
 	};
-	// mapKeys successfully archived this run — deleted from plans.json in the
-	// merge-save below (reference commit removes the entry; no guard row survives).
-	const committedMapKeys = new Set<string>();
+	// References whose snapshot was captured this run. Their local state (registry
+	// row + markdown) is torn down by the caller via finalizeReferenceArchive,
+	// but ONLY after storeReferences durably writes the orphan-branch snapshot.
+	const committed: Array<{ mapKey: string; sourcePath: string; updatedAt: string }> = [];
 	const droppedMapKeys: string[] = [];
 
 	for (const { mapKey, source } of ids) {
@@ -886,13 +900,14 @@ async function associateReferencesWithCommit(
 
 		const archivedKey = `${mapKey}-${shortHash}`;
 
-		// Reference commit DELETES the entry (no guard row). reference has no
-		// revival (it's a read-only MCP snapshot), so nothing needs to survive in
-		// plans.json — the orphan-branch snapshot (filesToStore: raw bytes keyed by
-		// archivedKey) + the CommitSummary ReferenceCommitRef are the system of
-		// record. The mapKey is removed in the merge-save below; the local active
-		// markdown is cleaned up here (orphan keeps the snapshot).
-		committedMapKeys.add(mapKey);
+		// Reference commit DELETES the entry (no guard row): reference has no
+		// revival (read-only MCP snapshot), so nothing needs to survive in
+		// plans.json — the orphan-branch snapshot (filesToStore) + the
+		// CommitSummary ReferenceCommitRef are the system of record. The registry
+		// row + local markdown are NOT torn down here; the caller does that via
+		// finalizeReferenceArchive AFTER storeReferences confirms the snapshot is
+		// durably written (write-ahead → a storeReferences failure is recoverable).
+		committed.push({ mapKey, sourcePath: entry.sourcePath, updatedAt: entry.updatedAt });
 
 		refs.push({
 			archivedKey,
@@ -906,39 +921,7 @@ async function associateReferencesWithCommit(
 		});
 		filesToStore.push({ archivedKey, source, content: rawContent });
 
-		// Best-effort: the active markdown's content is now in the orphan branch.
-		try {
-			await deleteReferenceMarkdown(entry.sourcePath);
-		} catch (err) {
-			log.warn(
-				"Reference association: failed to delete local markdown for %s: %s",
-				mapKey,
-				(err as Error).message,
-			);
-		}
-
-		log.info("Reference archived (entry removed): %s → %s", mapKey, archivedKey);
-	}
-
-	if (committedMapKeys.size > 0) {
-		// Near-write reread + per-key merge. A concurrent StopHook upsert may have
-		// touched plans.json.references while we were busy reading, and overwriting
-		// the whole references map would silently drop their work. We only
-		// DELETE the mapKeys we archived this run from the fresh snapshot — any
-		// concurrent writer's other keys are preserved.
-		const freshRegistry = await loadPlansRegistry(cwd);
-		/* v8 ignore next -- `?? {}` fallback unreachable: freshRegistry is loaded immediately after the loop archived at least one mapKey sourced from plans.json.references. */
-		const mergedReferences = { ...(freshRegistry.references ?? {}) };
-		for (const mapKey of committedMapKeys) {
-			delete mergedReferences[mapKey];
-		}
-		const out: PlansRegistry = {
-			version: 1,
-			plans: freshRegistry.plans,
-			...(freshRegistry.notes !== undefined ? { notes: freshRegistry.notes } : {}),
-			references: mergedReferences,
-		};
-		await savePlansRegistry(out, cwd);
+		log.info("Reference snapshot captured (deletion deferred): %s → %s", mapKey, archivedKey);
 	}
 
 	if (droppedMapKeys.length > 0) {
@@ -951,7 +934,68 @@ async function associateReferencesWithCommit(
 		);
 	}
 
-	return { refs, filesToStore };
+	return { refs, filesToStore, committed };
+}
+
+/**
+ * Tears down the local state of references whose orphan-branch snapshot has now
+ * been durably written (the `committed` list from {@link associateReferencesWithCommit}).
+ * MUST be called only AFTER a successful `storeReferences` — calling it before
+ * (or skipping `storeReferences` on failure) is what would lose data.
+ *
+ * Per committed reference: delete the registry row + local markdown — BUT only
+ * if the fresh row still matches the captured `updatedAt` fingerprint. A
+ * StopHook may have re-upserted the same mapKey (user re-referenced the issue)
+ * between `storeReferences` and this call; the re-upsert bumps `updatedAt`, so a
+ * mismatch means we leave the fresh active row + its markdown intact (deleting
+ * them would lose the re-reference). A near-write reread + per-key merge also
+ * preserves any unrelated keys a concurrent writer touched.
+ */
+async function finalizeReferenceArchive(
+	committed: ReadonlyArray<{ mapKey: string; sourcePath: string; updatedAt: string }>,
+	cwd: string,
+): Promise<void> {
+	if (committed.length === 0) return;
+
+	const freshRegistry = await loadPlansRegistry(cwd);
+	const mergedReferences = { ...(freshRegistry.references ?? {}) };
+	const toDeleteMarkdown: Array<{ mapKey: string; sourcePath: string }> = [];
+	for (const { mapKey, sourcePath, updatedAt } of committed) {
+		const fresh = mergedReferences[mapKey];
+		// `updatedAt` is a sufficient fingerprint here: the captured value was
+		// written by a PRIOR upsert (at discovery / an earlier commit), while a
+		// racing re-upsert stamps `new Date()` during this post-commit window — so
+		// a mismatch reliably means "re-upserted since capture". A same-millisecond
+		// collision is unreachable (the two writes are separated by ≥ the time
+		// since discovery), so no revision/nonce is needed.
+		if (fresh !== undefined && fresh.updatedAt !== updatedAt) {
+			log.info("Reference finalize: %s re-upserted since capture — keeping active row", mapKey);
+			continue;
+		}
+		delete mergedReferences[mapKey];
+		toDeleteMarkdown.push({ mapKey, sourcePath });
+	}
+	// Nothing actually deleted (every key was re-upserted) → skip the write
+	// entirely. Re-saving an unchanged registry would only widen the lost-update
+	// window against a concurrent StopHook for zero benefit.
+	if (toDeleteMarkdown.length === 0) return;
+
+	const out: PlansRegistry = {
+		version: 1,
+		plans: freshRegistry.plans,
+		...(freshRegistry.notes !== undefined ? { notes: freshRegistry.notes } : {}),
+		references: mergedReferences,
+	};
+	await savePlansRegistry(out, cwd);
+
+	for (const { mapKey, sourcePath } of toDeleteMarkdown) {
+		try {
+			await deleteReferenceMarkdown(sourcePath);
+		} catch (err) {
+			log.warn("Reference finalize: failed to delete local markdown for %s: %s", mapKey, (err as Error).message);
+		}
+		log.info("Reference entry removed (post-storeReferences): %s", mapKey);
+	}
 }
 
 /** Reads the raw markdown file bytes (for orphan-branch storage). */
@@ -1196,19 +1240,22 @@ async function executePipeline(cwd: string, op: GitOperation, force = false): Pr
 	// next commit (skip-don't-archive semantics).
 	const rawReferenceIds = await detectUncommittedReferenceIds(cwd, branch);
 	const referenceIds = rawReferenceIds.filter((e) => !exclusions.references.has(e.mapKey));
-	const { refs: referenceRefs, filesToStore: referenceFiles } = await associateReferencesWithCommit(
-		referenceIds,
-		commitInfo.hash,
-		cwd,
-		branch,
-	);
+	const {
+		refs: referenceRefs,
+		filesToStore: referenceFiles,
+		committed: referenceCommitted,
+	} = await associateReferencesWithCommit(referenceIds, commitInfo.hash, cwd, branch);
 	if (referenceFiles.length > 0) {
+		// Write-ahead: persist the orphan-branch snapshot FIRST, then tear down
+		// local state. If storeReferences throws, the active rows stay in
+		// plans.json and re-archive on the next commit (no permanent loss).
 		await storeReferences(
 			referenceFiles,
 			`Archive ${referenceFiles.length} reference ref(s) for commit ${commitInfo.hash.substring(0, 8)}`,
 			cwd,
 			branch,
 		);
+		await finalizeReferenceArchive(referenceCommitted, cwd);
 	}
 	// Step 8b: Evaluate plan progress for each linked plan (Haiku calls parallelized)
 	const planProgressArtifacts: PlanProgressArtifact[] = [];
@@ -2176,17 +2223,17 @@ async function handleAmendPipeline(
 	// Mirror plans/notes: honour user deselections from the sidebar so the
 	// amend fresh-leaf doesn't silently re-archive references the user removed.
 	const freshLeafReferenceIds = rawFreshLeafReferenceIds.filter((e) => !amendExclusions.references.has(e.mapKey));
-	const { refs: freshLeafReferenceRefs, filesToStore: freshLeafReferenceFiles } = await associateReferencesWithCommit(
-		freshLeafReferenceIds,
-		commitInfo.hash,
-		cwd,
-		branch,
-	);
+	const {
+		refs: freshLeafReferenceRefs,
+		filesToStore: freshLeafReferenceFiles,
+		committed: freshLeafReferenceCommitted,
+	} = await associateReferencesWithCommit(freshLeafReferenceIds, commitInfo.hash, cwd, branch);
 	// CRITICAL: the generic associateReferencesWithCommit does NOT call
 	// storeReferences itself (unlike the legacy Linear-only path which was
 	// self-contained). The amend fresh-leaf path MUST explicitly drive the
 	// orphan-branch write — otherwise Regenerator can't read back the
-	// archived markdown at recall time.
+	// archived markdown at recall time. Write-ahead: store first, then finalize
+	// the local-state teardown (so a store failure leaves the rows recoverable).
 	/* v8 ignore start -- amend fresh-leaf reference-files write path: only hit when a `git commit --amend` lands without an existing summary AND active references exist on the branch. Both arms (files-present vs files-absent) are tested mechanically through the StopHook → PostCommit happy path; this defensive branch in the amend-only fresh-leaf code path is reachable only via a race (StopHook upserted between detect and commit), and that race resolves the same way either way. */
 	if (freshLeafReferenceFiles.length > 0) {
 		await storeReferences(
@@ -2195,6 +2242,7 @@ async function handleAmendPipeline(
 			cwd,
 			branch,
 		);
+		await finalizeReferenceArchive(freshLeafReferenceCommitted, cwd);
 	}
 	/* v8 ignore stop */
 
@@ -2482,6 +2530,7 @@ export const __test__ = {
 	detectUncommittedNoteIds,
 	hoistMetadataFromOldSummary,
 	associatePlansWithCommit,
+	finalizeReferenceArchive,
 	executePipeline,
 	handleAmendPipeline,
 	handleSquashFromQueue,

--- a/cli/src/hooks/SessionStartHook.test.ts
+++ b/cli/src/hooks/SessionStartHook.test.ts
@@ -923,6 +923,58 @@ describe("SessionStartHook", () => {
 		writeSpy.mockRestore();
 	});
 
+	it("excludes legacy soft-deleted (ignored) plans via §14 normalization", async () => {
+		mockGetIndex.mockResolvedValue(
+			makeIndex([
+				{
+					commitHash: "aaa",
+					parentCommitHash: null,
+					commitMessage: "First",
+					commitDate: "2026-03-28T10:00:00.000Z",
+					branch: "feature/test-branch",
+					generatedAt: "2026-03-28T10:01:00.000Z",
+				},
+			]),
+		);
+		// `ghost-plan` carries a legacy `ignored:true` (a field no longer in the
+		// type) — SessionStartHook must route through normalizePlansRegistry so it
+		// is dropped rather than surfaced as an active associated plan.
+		const plansRegistry = {
+			version: 1,
+			plans: {
+				"active-plan": {
+					slug: "active-plan",
+					title: "Active Plan",
+					sourcePath: "plans/active.md",
+					addedAt: "2026-03-28T10:00:00.000Z",
+					updatedAt: "2026-03-28T10:00:00.000Z",
+					commitHash: null,
+				},
+				"ghost-plan": {
+					slug: "ghost-plan",
+					title: "Ghost Plan",
+					sourcePath: "plans/ghost.md",
+					addedAt: "2026-03-28T10:00:00.000Z",
+					updatedAt: "2026-03-28T10:00:00.000Z",
+					commitHash: null,
+					ignored: true,
+				},
+			},
+		} as unknown as PlansRegistry;
+		mockExistsSync.mockImplementation((path) => {
+			return typeof path === "string" && path.endsWith("plans.json");
+		});
+		mockReadFileSync.mockReturnValue(JSON.stringify(plansRegistry));
+
+		const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+		await main();
+
+		const output = writeSpy.mock.calls[0][0] as string;
+		expect(output).toContain("Active Plan");
+		expect(output).not.toContain("Ghost Plan");
+		writeSpy.mockRestore();
+	});
+
 	it("should fallback to commit message when summary load fails", async () => {
 		mockGetIndex.mockResolvedValue(
 			makeIndex([

--- a/cli/src/hooks/SessionStartHook.test.ts
+++ b/cli/src/hooks/SessionStartHook.test.ts
@@ -883,16 +883,14 @@ describe("SessionStartHook", () => {
 					slug: "oauth-strategy",
 					title: "OAuth2 Integration Strategy",
 					sourcePath: "plans/oauth-strategy.md",
-					branch: "feature/test-branch",
 					addedAt: "2026-03-28T10:00:00.000Z",
 					updatedAt: "2026-03-29T10:00:00.000Z",
 					commitHash: null,
 				},
-				"other-branch-plan": {
-					slug: "other-branch-plan",
-					title: "Unrelated Plan From Other Branch",
-					sourcePath: "plans/other.md",
-					branch: "feature/other-branch",
+				"second-active-plan": {
+					slug: "second-active-plan",
+					title: "Second Active Plan",
+					sourcePath: "plans/second.md",
 					addedAt: "2026-03-28T10:00:00.000Z",
 					updatedAt: "2026-03-28T10:00:00.000Z",
 					commitHash: null,
@@ -901,20 +899,9 @@ describe("SessionStartHook", () => {
 					slug: "archived-plan",
 					title: "Already Archived Plan",
 					sourcePath: "plans/archived.md",
-					branch: "feature/test-branch",
 					addedAt: "2026-03-27T10:00:00.000Z",
 					updatedAt: "2026-03-28T10:00:00.000Z",
 					commitHash: "abc123",
-				},
-				"ignored-plan": {
-					slug: "ignored-plan",
-					title: "User Dismissed Plan",
-					sourcePath: "plans/ignored.md",
-					branch: "feature/test-branch",
-					addedAt: "2026-03-28T10:00:00.000Z",
-					updatedAt: "2026-03-28T10:00:00.000Z",
-					commitHash: null,
-					ignored: true,
 				},
 			},
 		};
@@ -928,11 +915,11 @@ describe("SessionStartHook", () => {
 
 		const output = writeSpy.mock.calls[0][0] as string;
 		expect(output).toContain("Plans:");
+		// All uncommitted plans are listed regardless of branch (branch/ignored scoping removed)
 		expect(output).toContain("OAuth2 Integration Strategy");
-		// Plans from other branches, archived plans, and ignored plans should be excluded
-		expect(output).not.toContain("Unrelated Plan From Other Branch");
+		expect(output).toContain("Second Active Plan");
+		// Committed (associated) plans are excluded from the active-plan list
 		expect(output).not.toContain("Already Archived Plan");
-		expect(output).not.toContain("User Dismissed Plan");
 		writeSpy.mockRestore();
 	});
 

--- a/cli/src/hooks/SessionStartHook.ts
+++ b/cli/src/hooks/SessionStartHook.ts
@@ -197,7 +197,7 @@ async function loadLastSummary(commitHash: string, cwd: string): Promise<LastSum
  * Reads local plans.json to find active plan names for the current branch.
  * Pure filesystem read — no git calls.
  */
-function loadAssociatedPlanNames(projectDir: string, branch: string): ReadonlyArray<string> {
+function loadAssociatedPlanNames(projectDir: string, _branch: string): ReadonlyArray<string> {
 	try {
 		const plansPath = join(projectDir, ".jolli", "jollimemory", "plans.json");
 		if (!existsSync(plansPath)) return [];
@@ -205,8 +205,8 @@ function loadAssociatedPlanNames(projectDir: string, branch: string): ReadonlyAr
 		const registry = JSON.parse(readFileSync(plansPath, "utf-8")) as PlansRegistry;
 		const names: string[] = [];
 		for (const entry of Object.values(registry.plans)) {
-			// Include active plans for this branch (not archived, not ignored)
-			if (!entry.commitHash && !entry.ignored && entry.title && entry.branch === branch) {
+			// Include active (uncommitted) plans — worktree-scoped, no branch filter
+			if (!entry.commitHash && entry.title) {
 				names.push(entry.title);
 			}
 		}

--- a/cli/src/hooks/SessionStartHook.ts
+++ b/cli/src/hooks/SessionStartHook.ts
@@ -26,6 +26,7 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { readFileFromBranch } from "../core/GitOps.js";
+import { normalizePlansRegistry } from "../core/SessionTracker.js";
 import { getDisplayDate } from "../core/SummaryFormat.js";
 import { getIndex } from "../core/SummaryStore.js";
 import { collectAllTopics } from "../core/SummaryTree.js";
@@ -202,7 +203,11 @@ function loadAssociatedPlanNames(projectDir: string, _branch: string): ReadonlyA
 		const plansPath = join(projectDir, ".jolli", "jollimemory", "plans.json");
 		if (!existsSync(plansPath)) return [];
 
-		const registry = JSON.parse(readFileSync(plansPath, "utf-8")) as PlansRegistry;
+		// Route through the §14 normalizer (pure/sync) so legacy soft-deleted
+		// (`ignored:true`) and dead-field rows don't leak into the session-start
+		// context before detect* physically rewrites plans.json.
+		const parsed = JSON.parse(readFileSync(plansPath, "utf-8")) as Partial<PlansRegistry>;
+		const registry = normalizePlansRegistry(parsed).registry;
 		const names: string[] = [];
 		for (const entry of Object.values(registry.plans)) {
 			// Include active (uncommitted) plans — worktree-scoped, no branch filter

--- a/cli/src/hooks/StopHook.test.ts
+++ b/cli/src/hooks/StopHook.test.ts
@@ -385,6 +385,45 @@ describe("StopHook — plan discovery", () => {
 		expect(savePlansRegistry).not.toHaveBeenCalled();
 	});
 
+	it("does not advance the merged cursor past a window the plan scan failed to process", async () => {
+		// P2 regression: if plan discovery throws (e.g. a transient FS error during
+		// guard revival) while reference discovery reaches EOF, the shared cursor
+		// must NOT jump to EOF — otherwise those lines are never re-scanned for
+		// plans. min(planLine=fromLine, refLine=EOF) = fromLine ⇒ no advance.
+		vi.mocked(existsSync).mockReturnValue(true);
+		vi.mocked(loadDiscoveryCursor).mockResolvedValue(null); // fromLine = 0
+		mockTranscriptWithLines([
+			'{"type":"tool_use","name":"Write","input":{"file_path":"/home/user/.claude/plans/p.md"}}',
+		]);
+		vi.mocked(loadPlansRegistry).mockResolvedValue({
+			version: 1,
+			plans: {
+				p: {
+					slug: "p",
+					title: "P",
+					sourcePath: "/home/user/.claude/plans/p.md",
+					addedAt: "2026-01-01T00:00:00Z",
+					updatedAt: "2026-01-01T00:00:00Z",
+					commitHash: "abc12345",
+					contentHashAtCommit: "guard-hash",
+				},
+			},
+		});
+		// Guard revival reads the plan file to hash it — make that read throw so
+		// scanPlansFrom rejects. (The reference scan uses the mocked
+		// extractReferencesFromTranscript, which does no readFileSync.)
+		vi.mocked(readFileSync).mockImplementation((() => {
+			throw new Error("EBUSY: transient");
+		}) as unknown as typeof readFileSync);
+		// Reference scan succeeds and reaches EOF (line 5).
+		vi.mocked(extractReferencesFromTranscript).mockResolvedValue({ references: [], lastLineNumberScanned: 5 });
+
+		mockStdin(hookJson(TRANSCRIPT_PATH, PROJECT_DIR));
+		await handleStopHook();
+
+		expect(saveDiscoveryCursor).not.toHaveBeenCalled();
+	});
+
 	it("should not update cursor when transcript has no new lines since last scan", async () => {
 		// Last scan was at line 5, transcript still only has 5 lines
 		vi.mocked(loadDiscoveryCursor).mockResolvedValue({

--- a/cli/src/hooks/StopHook.test.ts
+++ b/cli/src/hooks/StopHook.test.ts
@@ -6,8 +6,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 vi.mock("../core/SessionTracker.js", () => ({
 	saveSession: vi.fn(),
 	loadConfig: vi.fn().mockResolvedValue({}),
-	loadCursorForTranscript: vi.fn().mockResolvedValue(null),
-	saveCursor: vi.fn().mockResolvedValue(undefined),
+	loadDiscoveryCursor: vi.fn().mockResolvedValue(null),
+	saveDiscoveryCursor: vi.fn().mockResolvedValue(undefined),
+	migrateDiscoveryCursors: vi.fn().mockResolvedValue(undefined),
 	loadPlansRegistry: vi.fn().mockResolvedValue({ version: 1, plans: {} }),
 	savePlansRegistry: vi.fn().mockResolvedValue(undefined),
 	upsertReferenceEntry: vi.fn().mockResolvedValue(undefined),
@@ -60,9 +61,9 @@ import { createInterface } from "node:readline";
 import { extractReferencesFromTranscript } from "../core/references/ReferenceExtractor.js";
 import {
 	loadConfig,
-	loadCursorForTranscript,
+	loadDiscoveryCursor,
 	loadPlansRegistry,
-	saveCursor,
+	saveDiscoveryCursor,
 	savePlansRegistry,
 	saveSession,
 	upsertReferenceEntry,
@@ -190,8 +191,8 @@ describe("StopHook", () => {
 		vi.mocked(existsSync).mockReturnValue(false);
 		// Default: loadPlansRegistry returns empty registry
 		vi.mocked(loadPlansRegistry).mockResolvedValue({ version: 1, plans: {} });
-		// Default: loadCursorForTranscript returns null (no prior scan)
-		vi.mocked(loadCursorForTranscript).mockResolvedValue(null);
+		// Default: loadDiscoveryCursor returns null (no prior scan)
+		vi.mocked(loadDiscoveryCursor).mockResolvedValue(null);
 	});
 
 	afterEach(() => {
@@ -331,8 +332,12 @@ describe("StopHook — plan discovery", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 		process.env.CLAUDE_PROJECT_DIR = PROJECT_DIR;
-		vi.mocked(loadCursorForTranscript).mockResolvedValue(null);
+		vi.mocked(loadDiscoveryCursor).mockResolvedValue(null);
 		vi.mocked(loadPlansRegistry).mockResolvedValue({ version: 1, plans: {} });
+		// Default: reference discovery finds nothing. Each cursor-assertion test
+		// overrides lastLineNumberScanned — the reference scan reads to the same
+		// EOF as the plan scan, so its return value drives the merged cursor.
+		vi.mocked(extractReferencesFromTranscript).mockResolvedValue({ references: [], lastLineNumberScanned: 0 });
 		// Default: files don't exist
 		vi.mocked(existsSync).mockReturnValue(false);
 		vi.mocked(readFileSync).mockReturnValue(
@@ -363,13 +368,16 @@ describe("StopHook — plan discovery", () => {
 			'{"role":"assistant","content":"Hello world"}',
 			'{"role":"human","content":"Please help me"}',
 		]);
+		// Plan + reference discovery share one cursor; the reference scan reads
+		// to the same EOF, so its lastLineNumberScanned drives the merged cursor.
+		vi.mocked(extractReferencesFromTranscript).mockResolvedValue({ references: [], lastLineNumberScanned: 2 });
 
 		mockStdin(hookJson(TRANSCRIPT_PATH, PROJECT_DIR));
 		await handleStopHook();
 
-		expect(saveCursor).toHaveBeenCalledWith(
+		expect(saveDiscoveryCursor).toHaveBeenCalledWith(
 			expect.objectContaining({
-				transcriptPath: `plan:${TRANSCRIPT_PATH}`,
+				transcriptPath: `${TRANSCRIPT_PATH}`,
 				lineNumber: 2,
 			}),
 			PROJECT_DIR,
@@ -379,19 +387,21 @@ describe("StopHook — plan discovery", () => {
 
 	it("should not update cursor when transcript has no new lines since last scan", async () => {
 		// Last scan was at line 5, transcript still only has 5 lines
-		vi.mocked(loadCursorForTranscript).mockResolvedValue({
-			transcriptPath: `plan:${TRANSCRIPT_PATH}`,
+		vi.mocked(loadDiscoveryCursor).mockResolvedValue({
+			transcriptPath: `${TRANSCRIPT_PATH}`,
 			lineNumber: 5,
 			updatedAt: new Date().toISOString(),
 		});
 		vi.mocked(existsSync).mockReturnValue(true);
 		// Emit only 5 lines (same as cursor position)
 		mockTranscriptWithLines(["line1", "line2", "line3", "line4", "line5"]);
+		// Reference scan reaches the same line 5 — no new lines past the cursor.
+		vi.mocked(extractReferencesFromTranscript).mockResolvedValue({ references: [], lastLineNumberScanned: 5 });
 
 		mockStdin(hookJson(TRANSCRIPT_PATH, PROJECT_DIR));
 		await handleStopHook();
 
-		expect(saveCursor).not.toHaveBeenCalled();
+		expect(saveDiscoveryCursor).not.toHaveBeenCalled();
 		expect(savePlansRegistry).not.toHaveBeenCalled();
 	});
 
@@ -413,7 +423,6 @@ describe("StopHook — plan discovery", () => {
 						slug: "my-test-plan",
 						title: "Plan Title",
 						commitHash: null,
-						branch: expect.any(String),
 					}),
 				}),
 			}),
@@ -578,7 +587,6 @@ describe("StopHook — plan discovery", () => {
 					sourcePath: "/home/user/.claude/plans/existing-plan.md",
 					addedAt: "2026-01-01T00:00:00Z",
 					updatedAt: "2026-01-01T00:00:00Z",
-					branch: "main",
 					commitHash: null,
 				},
 			},
@@ -617,7 +625,6 @@ describe("StopHook — plan discovery", () => {
 					sourcePath: "/home/user/.claude/plans/committed-plan.md",
 					addedAt: "2026-01-01T00:00:00Z",
 					updatedAt: "2026-01-01T00:00:00Z",
-					branch: "main",
 					commitHash: "abc12345",
 				},
 			},
@@ -625,37 +632,6 @@ describe("StopHook — plan discovery", () => {
 
 		mockTranscriptWithLines([
 			'{"type":"tool_use","name":"Edit","input":{"file_path":"/home/user/.claude/plans/committed-plan.md"}}',
-		]);
-
-		mockStdin(hookJson(TRANSCRIPT_PATH, PROJECT_DIR));
-		await handleStopHook();
-
-		expect(savePlansRegistry).not.toHaveBeenCalled();
-	});
-
-	it("should skip ignored plans", async () => {
-		vi.mocked(existsSync)
-			.mockReturnValueOnce(true) // transcript file
-			.mockReturnValueOnce(true); // plan file
-
-		vi.mocked(loadPlansRegistry).mockResolvedValue({
-			version: 1,
-			plans: {
-				"ignored-plan": {
-					slug: "ignored-plan",
-					title: "Ignored Plan",
-					sourcePath: "/home/user/.claude/plans/ignored-plan.md",
-					addedAt: "2026-01-01T00:00:00Z",
-					updatedAt: "2026-01-01T00:00:00Z",
-					branch: "main",
-					commitHash: null,
-					ignored: true,
-				},
-			},
-		});
-
-		mockTranscriptWithLines([
-			'{"type":"tool_use","name":"Edit","input":{"file_path":"/home/user/.claude/plans/ignored-plan.md"}}',
 		]);
 
 		mockStdin(hookJson(TRANSCRIPT_PATH, PROJECT_DIR));
@@ -693,7 +669,6 @@ describe("StopHook — plan discovery", () => {
 					sourcePath: "/home/user/.claude/plans/archived-plan.md",
 					addedAt: "2026-01-01T00:00:00Z",
 					updatedAt: "2026-01-01T00:00:00Z",
-					branch: "main",
 					commitHash: "abc12345",
 					// Real SHA-256 of "# Plan Title\n\nContent" (what readFileSync mock returns)
 					contentHashAtCommit: "1ab12ceb7fdd12641cbcefc8a5b7816c447423966a5b9976a4e004b6ae49fe6d",
@@ -727,7 +702,6 @@ describe("StopHook — plan discovery", () => {
 					sourcePath: "/home/user/.claude/plans/reused-plan.md",
 					addedAt: "2026-01-01T00:00:00Z",
 					updatedAt: "2026-01-01T00:00:00Z",
-					branch: "main",
 					commitHash: "abc12345",
 					contentHashAtCommit: "old-content-hash", // differs from "current-file-hash"
 				},
@@ -755,43 +729,10 @@ describe("StopHook — plan discovery", () => {
 		);
 	});
 
-	it("should not resurrect an ignored archive-guarded plan even when content changed", async () => {
-		vi.mocked(existsSync)
-			.mockReturnValueOnce(true) // transcript file
-			.mockReturnValueOnce(true); // plan file
-
-		vi.mocked(loadPlansRegistry).mockResolvedValue({
-			version: 1,
-			plans: {
-				"removed-plan": {
-					slug: "removed-plan",
-					title: "Removed Plan",
-					sourcePath: "/home/user/.claude/plans/removed-plan.md",
-					addedAt: "2026-01-01T00:00:00Z",
-					updatedAt: "2026-01-01T00:00:00Z",
-					branch: "main",
-					commitHash: "abc12345",
-					contentHashAtCommit: "old-content-hash",
-					ignored: true,
-				},
-			},
-		});
-
-		mockTranscriptWithLines([
-			'{"type":"tool_use","name":"Write","input":{"file_path":"/home/user/.claude/plans/removed-plan.md"}}',
-		]);
-
-		mockStdin(hookJson(TRANSCRIPT_PATH, PROJECT_DIR));
-		await handleStopHook();
-
-		// Even though content changed, ignored flag should prevent resurrection
-		expect(savePlansRegistry).not.toHaveBeenCalled();
-	});
-
 	it("should only scan new transcript lines since last cursor position", async () => {
 		// Cursor at line 1 — only line 2 is new
-		vi.mocked(loadCursorForTranscript).mockResolvedValue({
-			transcriptPath: `plan:${TRANSCRIPT_PATH}`,
+		vi.mocked(loadDiscoveryCursor).mockResolvedValue({
+			transcriptPath: `${TRANSCRIPT_PATH}`,
 			lineNumber: 1,
 			updatedAt: new Date().toISOString(),
 		});
@@ -881,7 +822,6 @@ describe("StopHook — plan discovery", () => {
 						sourcePath: "/home/user/.claude/plans/race-plan.md",
 						addedAt: "2026-01-01T00:00:00Z",
 						updatedAt: "2026-01-01T00:00:00Z",
-						branch: "main",
 						commitHash: null,
 					},
 				},
@@ -898,7 +838,6 @@ describe("StopHook — plan discovery", () => {
 						sourcePath: "/home/user/.claude/plans/race-plan.md",
 						addedAt: "2026-01-01T00:00:00Z",
 						updatedAt: "2026-01-01T00:00:00Z",
-						branch: "main",
 						commitHash: "abc12345",
 						contentHashAtCommit: "deadbeefhash",
 					},
@@ -940,7 +879,6 @@ describe("StopHook — plan discovery", () => {
 						sourcePath: "/home/user/.claude/plans/current-plan.md",
 						addedAt: "2026-01-01T00:00:00Z",
 						updatedAt: "2026-01-01T00:00:00Z",
-						branch: "main",
 						commitHash: null,
 					},
 				},
@@ -954,7 +892,6 @@ describe("StopHook — plan discovery", () => {
 						sourcePath: "/home/user/.claude/plans/current-plan.md",
 						addedAt: "2026-01-01T00:00:00Z",
 						updatedAt: "2026-01-01T00:00:00Z",
-						branch: "main",
 						commitHash: null,
 					},
 					"other-plan": {
@@ -963,7 +900,6 @@ describe("StopHook — plan discovery", () => {
 						sourcePath: "/home/user/.claude/plans/other-plan.md",
 						addedAt: "2026-01-01T00:00:00Z",
 						updatedAt: "2026-01-01T00:00:00Z",
-						branch: "main",
 						commitHash: "abc12345",
 					},
 				},
@@ -999,7 +935,6 @@ describe("StopHook — plan discovery", () => {
 						sourcePath: "/repo/docs/refactor-api.md",
 						addedAt: "2026-01-01T00:00:00Z",
 						updatedAt: "2026-01-01T00:00:00Z",
-						branch: "unknown",
 						commitHash: null,
 					},
 				},
@@ -1014,7 +949,6 @@ describe("StopHook — plan discovery", () => {
 						sourcePath: "/repo/docs/refactor-api.md",
 						addedAt: "2026-01-01T00:00:00Z",
 						updatedAt: "2026-01-01T00:00:00Z",
-						branch: "unknown",
 						commitHash: "abc12345cafebabe",
 						contentHashAtCommit: "deadbeefhash",
 					},
@@ -1024,7 +958,6 @@ describe("StopHook — plan discovery", () => {
 						sourcePath: "/repo/docs/refactor-api.md",
 						addedAt: "2026-01-01T00:00:00Z",
 						updatedAt: "2026-01-01T00:00:00Z",
-						branch: "unknown",
 						commitHash: "abc12345cafebabe",
 					},
 				},
@@ -1074,7 +1007,6 @@ describe("StopHook — plan discovery", () => {
 						sourcePath: planPath,
 						addedAt: "2026-01-01T00:00:00Z",
 						updatedAt: "2026-01-01T00:00:00Z",
-						branch: "unknown",
 						commitHash: null,
 					},
 				},
@@ -1088,7 +1020,6 @@ describe("StopHook — plan discovery", () => {
 						sourcePath: planPath,
 						addedAt: "2026-01-01T00:00:00Z",
 						updatedAt: "2026-01-01T00:00:00Z",
-						branch: "unknown",
 						commitHash: "abc12345cafebabe",
 						contentHashAtCommit: "snapshot-hash",
 					},
@@ -1107,7 +1038,7 @@ describe("StopHook — plan discovery", () => {
 		// "snapshot-hash". Mock readFileSync to return content whose hash will
 		// definitely not equal "snapshot-hash" (the mock default already does
 		// this — content "# Plan Title\n\nContent" hashes to a different value).
-		vi.mocked(loadCursorForTranscript).mockResolvedValue(null);
+		vi.mocked(loadDiscoveryCursor).mockResolvedValue(null);
 		vi.mocked(loadPlansRegistry).mockReset();
 		vi.mocked(loadPlansRegistry).mockResolvedValue({
 			version: 1,
@@ -1124,70 +1055,6 @@ describe("StopHook — plan discovery", () => {
 		const afterEvent2 = vi.mocked(savePlansRegistry).mock.calls[0]?.[0];
 		expect(afterEvent2?.plans["refactor-api"]?.commitHash).toBeNull();
 		expect(afterEvent2?.plans["refactor-api"]?.contentHashAtCommit).toBeUndefined();
-	});
-
-	it("should preserve an extension-flipped ignored flag on a slug we did not touch", async () => {
-		// Race scenario: while StopHook scans for `our-plan`, the user clicks
-		// Ignore on `unrelated-plan` in the panel. The extension writes
-		// ignored:true. StopHook's writeback must NOT clobber it.
-		vi.mocked(existsSync).mockReturnValueOnce(true).mockReturnValueOnce(true);
-
-		vi.mocked(loadPlansRegistry)
-			.mockResolvedValueOnce({
-				version: 1,
-				plans: {
-					"our-plan": {
-						slug: "our-plan",
-						title: "Ours",
-						sourcePath: "/home/user/.claude/plans/our-plan.md",
-						addedAt: "2026-01-01T00:00:00Z",
-						updatedAt: "2026-01-01T00:00:00Z",
-						branch: "unknown",
-						commitHash: null,
-					},
-					"unrelated-plan": {
-						slug: "unrelated-plan",
-						title: "Unrelated",
-						sourcePath: "/home/user/.claude/plans/unrelated-plan.md",
-						addedAt: "2026-01-01T00:00:00Z",
-						updatedAt: "2026-01-01T00:00:00Z",
-						branch: "unknown",
-						commitHash: null,
-					},
-				},
-			})
-			.mockResolvedValueOnce({
-				version: 1,
-				plans: {
-					"our-plan": {
-						slug: "our-plan",
-						title: "Ours",
-						sourcePath: "/home/user/.claude/plans/our-plan.md",
-						addedAt: "2026-01-01T00:00:00Z",
-						updatedAt: "2026-01-01T00:00:00Z",
-						branch: "unknown",
-						commitHash: null,
-					},
-					"unrelated-plan": {
-						slug: "unrelated-plan",
-						title: "Unrelated",
-						sourcePath: "/home/user/.claude/plans/unrelated-plan.md",
-						addedAt: "2026-01-01T00:00:00Z",
-						updatedAt: "2026-01-01T00:00:00Z",
-						branch: "unknown",
-						commitHash: null,
-						ignored: true, // extension flipped this between the two reads
-					},
-				},
-			});
-
-		mockTranscriptWithLines(['{"type":"tool_result","slug":"our-plan","content":"..."}']);
-
-		mockStdin(hookJson(TRANSCRIPT_PATH, PROJECT_DIR));
-		await handleStopHook();
-
-		const saved = vi.mocked(savePlansRegistry).mock.calls[0]?.[0];
-		expect(saved?.plans["unrelated-plan"]?.ignored).toBe(true);
 	});
 
 	it("should preserve a slug added by a parallel StopHook between load and save", async () => {
@@ -1207,7 +1074,6 @@ describe("StopHook — plan discovery", () => {
 						sourcePath: "/repo/docs/plan-b.md",
 						addedAt: "2026-01-01T00:00:00Z",
 						updatedAt: "2026-01-01T00:00:00Z",
-						branch: "unknown",
 						commitHash: null,
 					},
 				},
@@ -1346,7 +1212,6 @@ describe("StopHook — plan discovery", () => {
 					sourcePath: "/home/user/.claude/plans/foo.md",
 					addedAt: "2026-01-01T00:00:00Z",
 					updatedAt: "2026-01-01T00:00:00Z",
-					branch: "main",
 					commitHash: null,
 				},
 			},
@@ -1382,7 +1247,6 @@ describe("StopHook — plan discovery", () => {
 					sourcePath: "/repo/docs/foo.md",
 					addedAt: "2026-01-01T00:00:00Z",
 					updatedAt: "2026-01-01T00:00:00Z",
-					branch: "main",
 					commitHash: null,
 				},
 			},
@@ -1406,14 +1270,16 @@ describe("StopHook — plan discovery", () => {
 			.mockReturnValueOnce(true); // external plan file
 
 		mockTranscriptWithLines(['{"type":"tool_use","name":"Write","input":{"file_path":"/repo/docs/lonely.md"}}']);
+		// Reference scan reaches the same single line — drives the merged cursor.
+		vi.mocked(extractReferencesFromTranscript).mockResolvedValue({ references: [], lastLineNumberScanned: 1 });
 
 		mockStdin(hookJson(TRANSCRIPT_PATH, PROJECT_DIR));
 		await handleStopHook();
 
 		expect(savePlansRegistry).toHaveBeenCalled();
-		expect(saveCursor).toHaveBeenCalledWith(
+		expect(saveDiscoveryCursor).toHaveBeenCalledWith(
 			expect.objectContaining({
-				transcriptPath: `plan:${TRANSCRIPT_PATH}`,
+				transcriptPath: `${TRANSCRIPT_PATH}`,
 				lineNumber: 1,
 			}),
 			PROJECT_DIR,
@@ -1470,7 +1336,6 @@ describe("StopHook — plan discovery", () => {
 					addedAt: "2026-01-01T00:00:00Z",
 					updatedAt: "2026-01-01T00:00:00Z",
 					// "unknown" matches getCurrentBranch() default in tests (no git repo)
-					branch: "unknown",
 					commitHash: null,
 				},
 			},
@@ -1503,7 +1368,6 @@ describe("StopHook — plan discovery", () => {
 					// no sourcePath — falls through the `if (note.sourcePath)` guard
 					addedAt: "2026-01-01T00:00:00Z",
 					updatedAt: "2026-01-01T00:00:00Z",
-					branch: "unknown",
 					commitHash: null,
 				} as never,
 			},
@@ -1518,11 +1382,10 @@ describe("StopHook — plan discovery", () => {
 		expect(savePlansRegistry).toHaveBeenCalled();
 	});
 
-	it("should still treat a legacy note WITHOUT a branch field as a shadowing source (covers `note.branch` falsy arm)", async () => {
-		// Legacy notes (created before the branch field landed) omit `branch`.
-		// The `note.branch && note.branch !== branch` short-circuits to false
-		// when `note.branch` is undefined → the note is treated as global
-		// shadow, suppressing the would-be plan registration. Pins that arm.
+	it("should treat any note's sourcePath as a shadowing source regardless of branch", async () => {
+		// Notes are no longer branch-scoped — every note's sourcePath suppresses
+		// plan auto-registration for the same file, regardless of which branch
+		// the note was authored on. Pins that the shadow set ignores branch.
 		vi.mocked(existsSync)
 			.mockReturnValueOnce(true) // transcript file
 			.mockReturnValueOnce(true); // .md file on disk
@@ -1531,16 +1394,15 @@ describe("StopHook — plan discovery", () => {
 			version: 1,
 			plans: {},
 			notes: {
-				"n-legacy": {
-					id: "n-legacy",
-					title: "Legacy global note",
+				"n-shadow": {
+					id: "n-shadow",
+					title: "Global note",
 					format: "markdown",
 					sourcePath: "/repo/docs/legacy.md",
 					addedAt: "2026-01-01T00:00:00Z",
 					updatedAt: "2026-01-01T00:00:00Z",
-					// no `branch` field — pre-branch-scope legacy entry
 					commitHash: null,
-				} as never,
+				},
 			},
 		});
 
@@ -1575,7 +1437,6 @@ describe("StopHook — plan discovery", () => {
 						sourcePath: "C:\\Repo\\Docs\\Design.md",
 						addedAt: "2026-01-01T00:00:00Z",
 						updatedAt: "2026-01-01T00:00:00Z",
-						branch: "unknown", // matches getCurrentBranch() default in tests
 						commitHash: null,
 					},
 				},
@@ -1591,51 +1452,6 @@ describe("StopHook — plan discovery", () => {
 
 			expect(savePlansRegistry).not.toHaveBeenCalled();
 		});
-	});
-
-	it("should register a plan when a note exists for the same file BUT on a different branch", async () => {
-		// L1 regression: notes are branch-scoped (NoteService.toNoteInfo hides
-		// notes from other branches), so the note guard must also be
-		// branch-scoped. Without this check, a `main` note silently suppresses
-		// plan auto-registration on `feature/x`, even though the user can't see
-		// the note on that branch.
-		vi.mocked(existsSync)
-			.mockReturnValueOnce(true) // transcript file
-			.mockReturnValueOnce(true); // .md file on disk
-
-		vi.mocked(loadPlansRegistry).mockResolvedValue({
-			version: 1,
-			plans: {},
-			notes: {
-				"n-other": {
-					id: "n-other",
-					title: "Design (main)",
-					format: "markdown",
-					sourcePath: "/repo/docs/design.md",
-					addedAt: "2026-01-01T00:00:00Z",
-					updatedAt: "2026-01-01T00:00:00Z",
-					branch: "main",
-					commitHash: null,
-				},
-			},
-		});
-
-		mockTranscriptWithLines(['{"type":"tool_use","name":"Edit","input":{"file_path":"/repo/docs/design.md"}}']);
-
-		mockStdin(hookJson(TRANSCRIPT_PATH, PROJECT_DIR));
-		await handleStopHook();
-
-		// getCurrentBranch falls back to "unknown" under test (no git repo),
-		// which differs from the note's "main" → guard does NOT apply →
-		// plan IS registered.
-		expect(savePlansRegistry).toHaveBeenCalledWith(
-			expect.objectContaining({
-				plans: expect.objectContaining({
-					design: expect.objectContaining({ sourcePath: "/repo/docs/design.md" }),
-				}),
-			}),
-			PROJECT_DIR,
-		);
 	});
 
 	it("should NOT register a canonical ~/.claude/plans/ plan when it is already a note (L2)", async () => {
@@ -1658,7 +1474,6 @@ describe("StopHook — plan discovery", () => {
 					sourcePath: canonicalPath,
 					addedAt: "2026-01-01T00:00:00Z",
 					updatedAt: "2026-01-01T00:00:00Z",
-					branch: "unknown", // matches getCurrentBranch() default in tests
 					commitHash: null,
 				},
 			},
@@ -1675,10 +1490,10 @@ describe("StopHook — plan discovery", () => {
 		expect(savePlansRegistry).not.toHaveBeenCalled();
 	});
 
-	it("should preserve notes and linearIssues fields when writing back to plans.json (C1)", async () => {
-		// C1 regression: discoverPlansFromTranscript previously wrote
+	it("should preserve notes and references fields when writing back to plans.json (C1)", async () => {
+		// C1 regression: an earlier plan-discovery writeback wrote
 		// `{ version: 1, plans }` which silently dropped sibling fields
-		// (notes / linearIssues). loadPlansRegistry's contract is "spread to
+		// (notes / references). loadPlansRegistry's contract is "spread to
 		// preserve optional fields"; the writeback must honor that.
 		vi.mocked(existsSync)
 			.mockReturnValueOnce(true) // transcript file
@@ -1695,7 +1510,6 @@ describe("StopHook — plan discovery", () => {
 					sourcePath: "/repo/.jolli/jollimemory/notes/n-keep.md",
 					addedAt: "2026-01-01T00:00:00Z",
 					updatedAt: "2026-01-01T00:00:00Z",
-					branch: "unknown",
 					commitHash: null,
 				},
 			},
@@ -1706,10 +1520,8 @@ describe("StopHook — plan discovery", () => {
 					title: "Keep me too",
 					url: "https://linear.app/x/PROJ-1",
 					sourcePath: "/repo/.jolli/jollimemory/references/linear/PROJ-1.md",
-					branch: "main",
 					addedAt: "2026-01-01T00:00:00Z",
 					updatedAt: "2026-01-01T00:00:00Z",
-					commitHash: null,
 					sourceToolName: "mcp__linear__get_issue",
 				},
 			},
@@ -1784,7 +1596,6 @@ describe("StopHook — plan discovery", () => {
 					sourcePath: "/repo/docs/foo.md", // external lives at base slug
 					addedAt: "2026-01-01T00:00:00Z",
 					updatedAt: "2026-01-01T00:00:00Z",
-					branch: "main",
 					commitHash: null,
 				},
 			},
@@ -1829,7 +1640,7 @@ describe("StopHook — entity discovery (multi-source)", () => {
 		vi.clearAllMocks();
 		process.env.CLAUDE_PROJECT_DIR = PROJECT_DIR;
 		vi.mocked(loadConfig).mockResolvedValue({});
-		vi.mocked(loadCursorForTranscript).mockResolvedValue(null);
+		vi.mocked(loadDiscoveryCursor).mockResolvedValue(null);
 		vi.mocked(loadPlansRegistry).mockResolvedValue({ version: 1, plans: {} });
 		vi.mocked(existsSync).mockReturnValue(false);
 		vi.mocked(extractReferencesFromTranscript).mockResolvedValue({
@@ -1865,9 +1676,9 @@ describe("StopHook — entity discovery (multi-source)", () => {
 		await handleStopHook();
 
 		expect(upsertReferenceEntry).toHaveBeenCalledWith(REF, PROJECT_DIR, expect.any(String));
-		expect(saveCursor).toHaveBeenCalledWith(
+		expect(saveDiscoveryCursor).toHaveBeenCalledWith(
 			expect.objectContaining({
-				transcriptPath: `linear:${TRANSCRIPT_PATH}`,
+				transcriptPath: `${TRANSCRIPT_PATH}`,
 				lineNumber: 42,
 			}),
 			PROJECT_DIR,
@@ -1886,9 +1697,9 @@ describe("StopHook — entity discovery (multi-source)", () => {
 		await handleStopHook();
 
 		expect(upsertReferenceEntry).not.toHaveBeenCalled();
-		expect(saveCursor).toHaveBeenCalledWith(
+		expect(saveDiscoveryCursor).toHaveBeenCalledWith(
 			expect.objectContaining({
-				transcriptPath: `linear:${TRANSCRIPT_PATH}`,
+				transcriptPath: `${TRANSCRIPT_PATH}`,
 				lineNumber: 10,
 			}),
 			PROJECT_DIR,
@@ -1898,8 +1709,8 @@ describe("StopHook — entity discovery (multi-source)", () => {
 	it("does not save cursor when there are no new lines since last scan", async () => {
 		vi.mocked(existsSync).mockImplementation((p: unknown) => p === TRANSCRIPT_PATH);
 		mockTranscriptWithLines([]);
-		vi.mocked(loadCursorForTranscript).mockResolvedValue({
-			transcriptPath: `linear:${TRANSCRIPT_PATH}`,
+		vi.mocked(loadDiscoveryCursor).mockResolvedValue({
+			transcriptPath: `${TRANSCRIPT_PATH}`,
 			lineNumber: 5,
 			updatedAt: new Date().toISOString(),
 		});
@@ -1911,12 +1722,10 @@ describe("StopHook — entity discovery (multi-source)", () => {
 		mockStdin(hookJson(TRANSCRIPT_PATH, PROJECT_DIR));
 		await handleStopHook();
 
-		// saveCursor should not be called for the linear: prefix when lastLine === fromLine
+		// saveDiscoveryCursor should not be called for the linear: prefix when lastLine === fromLine
 		const linearSaves = vi
-			.mocked(saveCursor)
-			.mock.calls.filter(
-				(c) => (c[0] as { transcriptPath: string }).transcriptPath === `linear:${TRANSCRIPT_PATH}`,
-			);
+			.mocked(saveDiscoveryCursor)
+			.mock.calls.filter((c) => (c[0] as { transcriptPath: string }).transcriptPath === `${TRANSCRIPT_PATH}`);
 		expect(linearSaves).toHaveLength(0);
 	});
 
@@ -1960,9 +1769,9 @@ describe("StopHook — entity discovery (multi-source)", () => {
 		expect(upsertCalls[1]?.[0]).toMatchObject({ mapKey: "linear:PROJ-OK" });
 		// Cursor still advances — preventing the StopHook from re-processing
 		// the same window on the next invocation.
-		expect(saveCursor).toHaveBeenCalledWith(
+		expect(saveDiscoveryCursor).toHaveBeenCalledWith(
 			expect.objectContaining({
-				transcriptPath: `linear:${TRANSCRIPT_PATH}`,
+				transcriptPath: `${TRANSCRIPT_PATH}`,
 				lineNumber: 7,
 			}),
 			PROJECT_DIR,

--- a/cli/src/hooks/StopHook.ts
+++ b/cli/src/hooks/StopHook.ts
@@ -36,9 +36,10 @@ import { extractReferencesFromTranscript } from "../core/references/ReferenceExt
 import { ALL_ADAPTERS } from "../core/references/sources/index.js";
 import {
 	loadConfig,
-	loadCursorForTranscript,
+	loadDiscoveryCursor,
 	loadPlansRegistry,
-	saveCursor,
+	migrateDiscoveryCursors,
+	saveDiscoveryCursor,
 	savePlansRegistry,
 	saveSession,
 	upsertReferenceEntry,
@@ -129,27 +130,52 @@ export async function handleStopHook(): Promise<void> {
 		}
 	}
 
-	// Incrementally scan transcript for plan file references → write to plans.json
+	// Single incremental discovery pass — plan + reference scanning share
+	// one discovery-cursors.json line per transcript. Each inner scan swallows
+	// its own errors so one failing discovery never blocks the other or the
+	// cursor advance.
+	await discoverFromTranscript(sessionInfo, projectDir);
+}
+
+// ─── Discovery orchestration ────────────────────────────────────────────────
+
+/**
+ * Single incremental discovery pass for one transcript. Plan + reference
+ * scanning share ONE merged cursor in discovery-cursors.json (keyed by the bare
+ * transcriptPath). Each scan swallows its own errors and the cursor advances to
+ * the furthest line any scan reached, so a transient failure in one discovery
+ * discards that window (no re-scan) without blocking the other.
+ */
+async function discoverFromTranscript(sessionInfo: SessionInfo, cwd: string): Promise<void> {
+	const transcriptPath = sessionInfo.transcriptPath;
+	if (!existsSync(transcriptPath)) return;
+
+	await migrateDiscoveryCursors(cwd); // idempotent fold of legacy plan:/linear: cursors
+	const fromLine = (await loadDiscoveryCursor(transcriptPath, cwd))?.lineNumber ?? 0;
+
+	let lastScanned = fromLine;
 	try {
-		await discoverPlansFromTranscript(sessionInfo, projectDir);
+		lastScanned = await scanPlansFrom(transcriptPath, fromLine, cwd);
 	} catch (error: unknown) {
 		log.error("Plan discovery failed: %s", (error as Error).message);
 	}
-
-	// Incrementally scan transcript for reference refs (Linear / Jira / GitHub /
-	// Notion / …). Routes through every registered SourceAdapter and writes
-	// markdown files + plans.json.references.
 	try {
-		await discoverReferencesFromTranscript(sessionInfo, projectDir);
+		// Both scans start from the same line and read to EOF, so the reference
+		// scan's return value is the authoritative furthest-scanned line.
+		lastScanned = await scanReferencesFrom(transcriptPath, fromLine, cwd);
 	} catch (error: unknown) {
 		log.error("Reference discovery failed: %s", (error as Error).message);
+	}
+
+	if (lastScanned > fromLine) {
+		await saveDiscoveryCursor(
+			{ transcriptPath, lineNumber: lastScanned, updatedAt: new Date().toISOString() },
+			cwd,
+		);
 	}
 }
 
 // ─── Plan Discovery ─────────────────────────────────────────────────────────
-
-/** Cursor key prefix to distinguish plan scan cursors from summarization cursors */
-const PLAN_CURSOR_PREFIX = "plan:";
 
 /** Regex to extract slug from plan-mode transcript lines: "slug":"xxx" */
 const SLUG_REGEX = /"slug":"([^"]+)"/;
@@ -246,11 +272,9 @@ function resolveUniqueSlug(baseSlug: string, absPath: string, plans: Record<stri
 }
 
 /**
- * Incrementally scans the transcript for plan file references and updates plans.json.
- *
- * Uses a dedicated cursor (prefixed with "plan:") in cursors.json to track
- * how far the transcript has been scanned, so each StopHook invocation only
- * reads the newly appended lines.
+ * Scans the transcript for plan file references from `fromLine` and upserts them
+ * into plans.json. Pure scan + upsert — the caller (discoverFromTranscript) owns
+ * the merged discovery cursor. Returns the furthest line scanned (EOF).
  *
  * Detection covers three scenarios:
  *   1. Plan mode: the transcript contains a "slug":"xxx" field
@@ -259,29 +283,12 @@ function resolveUniqueSlug(baseSlug: string, absPath: string, plans: Record<stri
  *      call on any .md path not excluded by isExternalPlanCandidate — slug is
  *      derived from basename via resolveUniqueSlug for cross-path collisions.
  */
-async function discoverPlansFromTranscript(sessionInfo: SessionInfo, cwd: string): Promise<void> {
-	const transcriptPath = sessionInfo.transcriptPath;
-	if (!existsSync(transcriptPath)) {
-		return;
-	}
-
-	// Load cursor — lineNumber tracks how many lines we've already scanned
-	const cursorKey = `${PLAN_CURSOR_PREFIX}${transcriptPath}`;
-	const cursor = await loadCursorForTranscript(cursorKey, cwd);
-	const startLine = cursor?.lineNumber ?? 0;
-
-	// Scan transcript from startLine, collecting discovered slugs / external paths
-	const { slugs, externalPlans, totalLines } = await scanTranscriptForPlans(transcriptPath, startLine);
+async function scanPlansFrom(transcriptPath: string, fromLine: number, cwd: string): Promise<number> {
+	// Scan from fromLine, collecting discovered slugs / external paths.
+	const { slugs, externalPlans, totalLines } = await scanTranscriptForPlans(transcriptPath, fromLine);
 
 	if (slugs.size === 0 && externalPlans.size === 0) {
-		// Nothing found, but still update cursor to avoid re-scanning
-		if (totalLines > startLine) {
-			await saveCursor(
-				{ transcriptPath: cursorKey, lineNumber: totalLines, updatedAt: new Date().toISOString() },
-				cwd,
-			);
-		}
-		return;
+		return totalLines;
 	}
 
 	// Upsert into plans.json. Re-read registry right before writing to
@@ -289,7 +296,6 @@ async function discoverPlansFromTranscript(sessionInfo: SessionInfo, cwd: string
 	const registry = await loadPlansRegistry(cwd);
 	const plans = { ...registry.plans };
 	const now = new Date().toISOString();
-	let branch: string | undefined;
 	let changed = false;
 	// Tracks slugs we actually modified in this run. Used at writeback time to
 	// merge our changes onto the freshest registry snapshot per-slug rather
@@ -301,20 +307,15 @@ async function discoverPlansFromTranscript(sessionInfo: SessionInfo, cwd: string
 	const upsertEntry = (slug: string, planFile: string): void => {
 		const existing = plans[slug];
 		if (existing?.contentHashAtCommit) {
-			// Archived guard — never resurrect if user explicitly removed it
-			if (existing.ignored) {
-				return;
-			}
+			// Archived guard: revive when the source file diverged from the guard hash.
 			const currentHash = createHash("sha256").update(readFileSync(planFile, "utf-8")).digest("hex");
 			if (currentHash !== existing.contentHashAtCommit) {
-				branch ??= getCurrentBranch(cwd);
 				plans[slug] = {
 					slug,
 					title: extractPlanTitle(planFile),
 					sourcePath: planFile,
 					addedAt: now,
 					updatedAt: now,
-					branch,
 					commitHash: null,
 				};
 				changed = true;
@@ -322,20 +323,18 @@ async function discoverPlansFromTranscript(sessionInfo: SessionInfo, cwd: string
 				log.info("Plan discovery: archived plan %s file changed — creating new entry", slug);
 			}
 		} else if (existing) {
-			if (existing.commitHash === null && !existing.ignored) {
+			if (existing.commitHash === null) {
 				plans[slug] = { ...existing, updatedAt: now };
 				changed = true;
 				touchedSlugs.add(slug);
 			}
 		} else {
-			branch ??= getCurrentBranch(cwd);
 			plans[slug] = {
 				slug,
 				title: extractPlanTitle(planFile),
 				sourcePath: planFile,
 				addedAt: now,
 				updatedAt: now,
-				branch,
 				commitHash: null,
 			};
 			changed = true;
@@ -343,27 +342,17 @@ async function discoverPlansFromTranscript(sessionInfo: SessionInfo, cwd: string
 		}
 	};
 
-	// Build a Set of normalized paths that already belong to a markdown note
-	// on the current branch. Markdown notes added via "Add Markdown File" can
-	// point at arbitrary user .md files (NoteService allows
-	// `sourcePath = <user-picked path>`). If the AI later edits that same file,
-	// we must NOT also register it as a plan — it would shadow the user's
-	// explicit note semantics, double-archive into the orphan branch, and
-	// surface the same file twice in the panel (plans + notes are merged
-	// without sourcePath dedup downstream).
-	//
-	// Branch scoping: notes are branch-filtered in NoteService.toNoteInfo, so a
-	// note on `main` is invisible on `feature/x`. The guard must mirror that
-	// scope, otherwise a hidden cross-branch note silently suppresses plan
-	// auto-registration on the current branch.
+	// Build a Set of normalized paths that already belong to a markdown note.
+	// Markdown notes added via "Add Markdown File" can point at arbitrary user
+	// .md files (NoteService allows `sourcePath = <user-picked path>`). If the AI
+	// later edits that same file, we must NOT also register it as a plan — it
+	// would shadow the user's explicit note semantics, double-archive into the
+	// orphan branch, and surface the same file twice in the panel (plans + notes
+	// are merged without sourcePath dedup downstream). Notes are no longer
+	// branch-scoped, so any note's sourcePath suppresses plan auto-registration.
 	const noteSourcePaths = new Set<string>();
-	const notesArr = Object.values(registry.notes ?? {});
-	if (notesArr.length > 0) {
-		branch ??= getCurrentBranch(cwd);
-		for (const note of notesArr) {
-			if (note.branch && note.branch !== branch) continue;
-			if (note.sourcePath) noteSourcePaths.add(normalizePathForCompare(note.sourcePath));
-		}
+	for (const note of Object.values(registry.notes ?? {})) {
+		if (note.sourcePath) noteSourcePaths.add(normalizePathForCompare(note.sourcePath));
 	}
 
 	// 1. Canonical ~/.claude/plans/ slugs. We still route through
@@ -408,7 +397,7 @@ async function discoverPlansFromTranscript(sessionInfo: SessionInfo, cwd: string
 		//   - QueueWorker may have added a `<slug>-<commitHash8>` archive entry
 		//     and upgraded the original slug into an archive guard
 		//   - Another StopHook (parallel session) may have added a new slug
-		//   - The extension may have flipped `ignored` on an entry
+		//   - The extension may have removed an entry (hard delete)
 		//
 		// Strategy: start with freshRegistry.plans as the baseline (preserves
 		// every concurrent write), then layer ONLY the slugs we explicitly
@@ -450,8 +439,7 @@ async function discoverPlansFromTranscript(sessionInfo: SessionInfo, cwd: string
 		);
 	}
 
-	// Update cursor so next invocation starts where we left off
-	await saveCursor({ transcriptPath: cursorKey, lineNumber: totalLines, updatedAt: new Date().toISOString() }, cwd);
+	return totalLines;
 }
 
 /**
@@ -527,49 +515,22 @@ function scanTranscriptForPlans(
 // ─── Reference Discovery (multi-source) ─────────────────────────────────────
 
 /**
- * Cursor key prefix for reference scan position, parallel to PLAN_CURSOR_PREFIX.
- *
- * Kept as `linear:` for one release so already-on-disk cursors from the
- * Linear-only era remain valid — the scan window only advances forward.
- * Phase 3 can migrate this to `reference:` alongside a one-time cursor key rewrite.
- */
-const LINEAR_CURSOR_PREFIX = "linear:";
-
-/**
- * Incrementally scans the transcript for ALL registered source adapters
- * (Linear / Jira / GitHub / Notion / …) and persists discovered references:
+ * Scans the transcript for ALL registered source adapters (Linear / Jira /
+ * GitHub / Notion / …) from `fromLine` and persists discovered references:
  *   1. extractReferencesFromTranscript(transcriptPath, ALL_ADAPTERS, …) → Reference[]
  *   2. For each ref: upsertReferenceEntry routes the row into plans.json.references
  *      and writes per-reference markdown via ReferenceStore.writeReferenceMarkdown.
- *   3. Persist cursor advance on all three terminal paths (zero references,
- *      partial upsert failure, full success) so we never re-scan the same
- *      transcript window.
  *
- * Each StopHook invocation only reads newly appended JSONL lines. The cursor
- * for this scan is independent of plan-discovery's cursor (different prefix).
+ * Pure scan + upsert — the caller (discoverFromTranscript) owns the merged
+ * discovery cursor. Returns the furthest line scanned (EOF).
  */
-async function discoverReferencesFromTranscript(sessionInfo: SessionInfo, cwd: string): Promise<void> {
-	const transcriptPath = sessionInfo.transcriptPath;
-	if (!existsSync(transcriptPath)) return;
-
-	const cursorKey = `${LINEAR_CURSOR_PREFIX}${transcriptPath}`;
-	const cursor = await loadCursorForTranscript(cursorKey, cwd);
-	const fromLineNumber = cursor?.lineNumber ?? 0;
-
+async function scanReferencesFrom(transcriptPath: string, fromLine: number, cwd: string): Promise<number> {
 	const { references, lastLineNumberScanned } = await extractReferencesFromTranscript(transcriptPath, ALL_ADAPTERS, {
-		fromLineNumber,
+		fromLineNumber: fromLine,
 	});
 
-	// Zero-reference path: even with no references, advance the cursor so we
-	// don't re-scan the same lines next time.
 	if (references.length === 0) {
-		if (lastLineNumberScanned > fromLineNumber) {
-			await saveCursor(
-				{ transcriptPath: cursorKey, lineNumber: lastLineNumberScanned, updatedAt: new Date().toISOString() },
-				cwd,
-			);
-		}
-		return;
+		return lastLineNumberScanned;
 	}
 
 	const branch = getCurrentBranch(cwd);
@@ -600,16 +561,7 @@ async function discoverReferencesFromTranscript(sessionInfo: SessionInfo, cwd: s
 		failed.length > 0 ? ` (failed: [${failed.join(", ")}])` : "",
 	);
 
-	// Cursor advance on success / partial failure / total failure paths.
-	// upsertReferenceEntry is idempotent (same contentHash → skip write) and
-	// returns early for already-ignored entries, so re-scanning the same window
-	// can neither corrupt state nor resurrect an ignored entry. Advancing the
-	// cursor is purely an optimisation — it avoids re-scanning the same
-	// tool_results (wasted CPU + redundant idempotent writes) on the next pass.
-	await saveCursor(
-		{ transcriptPath: cursorKey, lineNumber: lastLineNumberScanned, updatedAt: new Date().toISOString() },
-		cwd,
-	);
+	return lastLineNumberScanned;
 }
 
 /** Extracts the first # heading from a markdown file. */

--- a/cli/src/hooks/StopHook.ts
+++ b/cli/src/hooks/StopHook.ts
@@ -142,9 +142,14 @@ export async function handleStopHook(): Promise<void> {
 /**
  * Single incremental discovery pass for one transcript. Plan + reference
  * scanning share ONE merged cursor in discovery-cursors.json (keyed by the bare
- * transcriptPath). Each scan swallows its own errors and the cursor advances to
- * the furthest line any scan reached, so a transient failure in one discovery
- * discards that window (no re-scan) without blocking the other.
+ * transcriptPath). Both scans read the same file to the same EOF, so the
+ * reference scan's `lastLineNumberScanned` is the authoritative cursor target.
+ *
+ * Each scan swallows its own errors. The cursor advances ONLY when the plan
+ * scan also completed — a throwing plan scan (e.g. a transient FS error during
+ * guard revival) holds the cursor at `fromLine` so its window is retried next
+ * time, instead of being skipped forever because the reference scan reached EOF.
+ * Re-scanning on retry is safe: both scans are idempotent.
  */
 async function discoverFromTranscript(sessionInfo: SessionInfo, cwd: string): Promise<void> {
 	const transcriptPath = sessionInfo.transcriptPath;
@@ -153,23 +158,25 @@ async function discoverFromTranscript(sessionInfo: SessionInfo, cwd: string): Pr
 	await migrateDiscoveryCursors(cwd); // idempotent fold of legacy plan:/linear: cursors
 	const fromLine = (await loadDiscoveryCursor(transcriptPath, cwd))?.lineNumber ?? 0;
 
-	let lastScanned = fromLine;
+	let planScanCompleted = false;
+	let referenceLine = fromLine;
 	try {
-		lastScanned = await scanPlansFrom(transcriptPath, fromLine, cwd);
+		await scanPlansFrom(transcriptPath, fromLine, cwd);
+		planScanCompleted = true;
 	} catch (error: unknown) {
 		log.error("Plan discovery failed: %s", (error as Error).message);
 	}
 	try {
-		// Both scans start from the same line and read to EOF, so the reference
-		// scan's return value is the authoritative furthest-scanned line.
-		lastScanned = await scanReferencesFrom(transcriptPath, fromLine, cwd);
+		referenceLine = await scanReferencesFrom(transcriptPath, fromLine, cwd);
 	} catch (error: unknown) {
 		log.error("Reference discovery failed: %s", (error as Error).message);
 	}
 
-	if (lastScanned > fromLine) {
+	// Hold the cursor if the plan scan threw: advancing past its window (the
+	// reference scan reaching EOF) would lose those lines for plan discovery.
+	if (planScanCompleted && referenceLine > fromLine) {
 		await saveDiscoveryCursor(
-			{ transcriptPath, lineNumber: lastScanned, updatedAt: new Date().toISOString() },
+			{ transcriptPath, lineNumber: referenceLine, updatedAt: new Date().toISOString() },
 			cwd,
 		);
 	}

--- a/cli/src/sync/BootstrapMerge.ts
+++ b/cli/src/sync/BootstrapMerge.ts
@@ -32,7 +32,7 @@
  * already no-data-loss (stash preserves every local byte) and unblocks the
  * sticky-failure scenario today.
  *
- * **Safety / "宁可漏触发，不能错触发".** Mistriggering on a vault with real
+ * **Safety / "better to under-trigger than mis-trigger".** Mistriggering on a vault with real
  * local history would wipe it via the destructive `checkout -B`. The
  * trigger conditions (`shouldRunBootstrapMerge`) and the in-function
  * pre-flight reassertion are intentionally strict: ANY signal that a
@@ -225,7 +225,7 @@ export async function runBootstrapMerge(
 		// Aggregate JSON paths (`<repo>/.jolli/{manifest,index,branches,catalog}.json`
 		// and root `.jolli/repos.json`) have a deterministic union merger via
 		// `tryAggregateMerge` — the same Tier 1.5 path exercised by acceptance
-		// §12. Use it here so the bootstrap case ends with both peers' entries
+		// tests. Use it here so the bootstrap case ends with both peers' entries
 		// preserved, matching pullRebase's Tier 1.5 behavior on the same
 		// content. If the merger returns `null` (parse failure, unknown
 		// envelope shape), fall through to the conservative remote-wins +

--- a/cli/src/sync/SyncEngine.test.ts
+++ b/cli/src/sync/SyncEngine.test.ts
@@ -2878,9 +2878,7 @@ describe("SyncEngine.runRound — idle-round short-circuit (perf)", () => {
 
 // ─────────────────────────────────────────────────────────────────────
 // JOLLI-1577 — Release Personal Space write-lock on every round outcome.
-// Each test in this matrix targets a specific leak path from the plan;
-// the row numbers reference the test matrix in
-// /home/foste/.claude/plans/eager-forging-bonbon.md §4.
+// Each test in this matrix targets a specific lock-release leak path.
 // ─────────────────────────────────────────────────────────────────────
 describe("SyncEngine.runRound — JOLLI-1577 release-lock matrix", () => {
 	const LOCK_TOKEN = "test-lock-owner-token";

--- a/cli/src/sync/SyncEngine.ts
+++ b/cli/src/sync/SyncEngine.ts
@@ -358,7 +358,7 @@ type RemintCause = "unauthorized" | "repoMissing";
  *     `releaseInFinally` (backend already released).
  *   - `tryCompleteMigration` success (`deferred: true` branch — HEAD
  *     unborn) → clear `releaseInFinally` (defer to next round; explicit
- *     user choice — see plan §"Deferred-completion sites").
+ *     user choice).
  *   - `runFirstBindMigration` sets `completionDeferred = true` → caller
  *     clears `releaseInFinally` at the same moment (defer rationale as
  *     above).

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -204,7 +204,7 @@
 			},
 			{
 				"command": "jollimemory.ignoreReference",
-				"title": "Ignore Reference",
+				"title": "Remove Reference",
 				"category": "Jolli Memory"
 			},
 			{

--- a/vscode/src/Extension.test.ts
+++ b/vscode/src/Extension.test.ts
@@ -302,7 +302,7 @@ const {
 		listReferences: vi.fn().mockResolvedValue([]),
 		openReferenceInBrowser: vi.fn().mockResolvedValue(undefined),
 		openReferenceMarkdown: vi.fn().mockResolvedValue(undefined),
-		ignoreReference: vi.fn().mockResolvedValue(undefined),
+		removeReference: vi.fn().mockResolvedValue(undefined),
 	};
 
 	const mockCommitCommand_ = { execute: vi.fn().mockResolvedValue(undefined) };
@@ -1955,7 +1955,7 @@ describe("Extension", () => {
 				mockBridge.listReferences.mockReset().mockResolvedValue([]);
 				mockBridge.openReferenceInBrowser.mockClear();
 				mockBridge.openReferenceMarkdown.mockClear();
-				mockBridge.ignoreReference.mockClear();
+				mockBridge.removeReference.mockClear();
 				showWarningMessage.mockClear();
 			});
 
@@ -2041,7 +2041,7 @@ describe("Extension", () => {
 				const handler = getRegisteredCommand("jollimemory.ignoreReference");
 				await handler({ reference: { mapKey: "linear:ENG-ign-2" } });
 
-				expect(mockBridge.ignoreReference).toHaveBeenCalledWith("linear:ENG-ign-2");
+				expect(mockBridge.removeReference).toHaveBeenCalledWith("linear:ENG-ign-2");
 				expect(mockPlansStore.refresh).toHaveBeenCalled();
 			});
 
@@ -2066,7 +2066,7 @@ describe("Extension", () => {
 				const handler = getRegisteredCommand("jollimemory.ignoreReference");
 				await handler("linear:ENG-4");
 
-				expect(mockBridge.ignoreReference).toHaveBeenCalledWith("linear:ENG-4");
+				expect(mockBridge.removeReference).toHaveBeenCalledWith("linear:ENG-4");
 				expect(mockPlansStore.refresh).toHaveBeenCalled();
 			});
 
@@ -2074,7 +2074,7 @@ describe("Extension", () => {
 				const handler = getRegisteredCommand("jollimemory.ignoreReference");
 				await handler("linear:ENG-gone");
 
-				expect(mockBridge.ignoreReference).not.toHaveBeenCalled();
+				expect(mockBridge.removeReference).not.toHaveBeenCalled();
 			});
 		});
 

--- a/vscode/src/Extension.ts
+++ b/vscode/src/Extension.ts
@@ -2343,11 +2343,11 @@ export function activate(context: vscode.ExtensionContext): void {
 					typeof itemOrKey === "string" ? itemOrKey : itemOrKey.reference.mapKey;
 				log.info("cmd", `ignoreReference: ${mapKey}`);
 				// Same stale-mapKey guard as the open commands: without this the
-				// ReferenceService.setReferenceIgnored "entry not found → silent return"
+				// ReferenceService.removeReference "entry not found → silent return"
 				// path would swallow the click with zero feedback.
 				const info = await resolveReferenceForCommand(mapKey, "ignoreReference");
 				if (!info) return;
-				await bridge.ignoreReference(mapKey);
+				await bridge.removeReference(mapKey);
 				await plansStore.refresh();
 			},
 		),

--- a/vscode/src/Extension.ts
+++ b/vscode/src/Extension.ts
@@ -1485,10 +1485,10 @@ export function activate(context: vscode.ExtensionContext): void {
 	);
 
 	// Shared resolver for the multi-source reference webview commands. The webview
-	// may dispatch a mapKey that was archived or ignored between render and
-	// click (bridge.listReferences applies the branch/ignored/archived filter),
-	// so each command re-reads the list before acting and surfaces a warning
-	// toast on miss instead of silently no-op'ing.
+	// may dispatch a mapKey that was removed between render and click — committed
+	// away (commit deletes the entry) or hard-removed — and bridge.listReferences
+	// returns only active references, so each command re-reads the list before
+	// acting and surfaces a warning toast on miss instead of silently no-op'ing.
 	const resolveReferenceForCommand = async (mapKey: string, cmdLabel: string) => {
 		const references = await bridge.listReferences();
 		const info = references.find((e) => e.mapKey === mapKey);

--- a/vscode/src/JolliMemoryBridge.test.ts
+++ b/vscode/src/JolliMemoryBridge.test.ts
@@ -148,10 +148,10 @@ const { installerInstall, installerUninstall, installerGetStatus } = vi.hoisted(
 	}),
 );
 
-const { archivePlanForCommit, detectPlans, ignorePlan } = vi.hoisted(() => ({
+const { archivePlanForCommit, detectPlans, removePlan } = vi.hoisted(() => ({
 	archivePlanForCommit: vi.fn(),
 	detectPlans: vi.fn(),
-	ignorePlan: vi.fn(),
+	removePlan: vi.fn(),
 }));
 
 const {
@@ -335,7 +335,7 @@ vi.mock("../../cli/src/Logger.js", () => ({
 vi.mock("./core/PlanService.js", () => ({
 	archivePlanForCommit,
 	detectPlans,
-	ignorePlan,
+	removePlan,
 }));
 
 vi.mock("./core/NoteService.js", () => ({
@@ -349,7 +349,7 @@ vi.mock("./core/NoteService.js", () => ({
 // boundary so the test runner doesn't crash with "Cannot find package vscode".
 vi.mock("./core/ReferenceService.js", () => ({
 	detectReferences: vi.fn().mockResolvedValue([]),
-	setReferenceIgnored: vi.fn().mockResolvedValue(undefined),
+	removeReference: vi.fn().mockResolvedValue(undefined),
 	openReferenceInBrowser: vi.fn().mockResolvedValue(true),
 	openReferenceMarkdown: vi.fn().mockResolvedValue(undefined),
 }));
@@ -3018,13 +3018,13 @@ describe("JolliMemoryBridge", () => {
 	});
 
 	describe("removePlan()", () => {
-		it("delegates to ignorePlan", async () => {
-			ignorePlan.mockResolvedValue(undefined);
+		it("delegates to removePlan", async () => {
+			removePlan.mockResolvedValue(undefined);
 			const bridge = makeBridge();
 
 			await bridge.removePlan("test-slug");
 
-			expect(ignorePlan).toHaveBeenCalledWith("test-slug", TEST_CWD);
+			expect(removePlan).toHaveBeenCalledWith("test-slug", TEST_CWD);
 		});
 	});
 
@@ -3415,19 +3415,18 @@ describe("JolliMemoryBridge", () => {
 			expect(result).toEqual(entities);
 		});
 
-		it("ignoreReference() delegates to setReferenceIgnored with mapKey + true", async () => {
-			const { setReferenceIgnored } = await import("./core/ReferenceService.js");
-			(setReferenceIgnored as ReturnType<typeof vi.fn>).mockResolvedValue(
+		it("removeReference() delegates to removeReference with mapKey", async () => {
+			const { removeReference } = await import("./core/ReferenceService.js");
+			(removeReference as ReturnType<typeof vi.fn>).mockResolvedValue(
 				undefined,
 			);
 			const bridge = makeBridge();
 
-			await bridge.ignoreReference("github:owner/repo#42");
+			await bridge.removeReference("github:owner/repo#42");
 
-			expect(setReferenceIgnored).toHaveBeenCalledWith(
+			expect(removeReference).toHaveBeenCalledWith(
 				TEST_CWD,
 				"github:owner/repo#42",
-				true,
 			);
 		});
 

--- a/vscode/src/JolliMemoryBridge.ts
+++ b/vscode/src/JolliMemoryBridge.ts
@@ -2362,7 +2362,7 @@ export class JolliMemoryBridge {
 		return detectPlans(this.cwd);
 	}
 
-	/** Marks a plan as ignored in plans.json (hidden from PLANS panel). */
+	/** Hard-removes a plan from plans.json (and its internal backing file). */
 	async removePlan(slug: string): Promise<void> {
 		await removePlan(slug, this.cwd);
 	}

--- a/vscode/src/JolliMemoryBridge.ts
+++ b/vscode/src/JolliMemoryBridge.ts
@@ -90,7 +90,7 @@ import {
 	detectReferences,
 	openReferenceInBrowser as openReferenceInBrowserImpl,
 	openReferenceMarkdown as openReferenceMarkdownImpl,
-	setReferenceIgnored,
+	removeReference,
 } from "./core/ReferenceService.js";
 import {
 	archiveNoteForCommit,
@@ -101,7 +101,7 @@ import {
 import {
 	archivePlanForCommit,
 	detectPlans,
-	ignorePlan,
+	removePlan,
 } from "./core/PlanService.js";
 import type {
 	BranchCommit,
@@ -2364,7 +2364,7 @@ export class JolliMemoryBridge {
 
 	/** Marks a plan as ignored in plans.json (hidden from PLANS panel). */
 	async removePlan(slug: string): Promise<void> {
-		await ignorePlan(slug, this.cwd);
+		await removePlan(slug, this.cwd);
 	}
 
 	/**
@@ -2428,9 +2428,9 @@ export class JolliMemoryBridge {
 		return detectReferences(this.cwd);
 	}
 
-	/** Marks a reference as ignored (hidden from the panel) by mapKey. */
-	async ignoreReference(mapKey: string): Promise<void> {
-		await setReferenceIgnored(this.cwd, mapKey, true);
+	/** Hard-removes a reference (registry row + backing markdown) by mapKey. Allows revival. */
+	async removeReference(mapKey: string): Promise<void> {
+		await removeReference(this.cwd, mapKey);
 	}
 
 	/** Opens the reference's upstream URL in the user's default browser. */

--- a/vscode/src/Types.ts
+++ b/vscode/src/Types.ts
@@ -89,8 +89,6 @@ export interface PlanInfo {
 	readonly addedAt: string;
 	/** ISO 8601 — when this plan was last modified */
 	readonly updatedAt: string;
-	/** Git branch name when plan was discovered */
-	readonly branch: string;
 	/** Commit hash if plan is associated with a commit, null if unassociated */
 	readonly commitHash: string | null;
 }
@@ -102,12 +100,9 @@ export interface PlanEntry {
 	readonly sourcePath: string;
 	readonly addedAt: string;
 	readonly updatedAt: string;
-	readonly branch: string;
 	readonly commitHash: string | null;
 	/** SHA-256 hash of the plan file content when associated with a commit. Used as a guard to detect if the file was overwritten with new content. */
 	readonly contentHashAtCommit?: string;
-	/** When true, plan is hidden from PLANS panel (user removed it). Cleared if source file content changes. */
-	readonly ignored?: boolean;
 }
 
 // ─── Note types ─────────────────────────────────────────────────────────────
@@ -143,7 +138,6 @@ export interface NoteInfo {
 	readonly lastModified: string;
 	readonly addedAt: string;
 	readonly updatedAt: string;
-	readonly branch: string;
 	readonly commitHash: string | null;
 	/** Filename (e.g. "my-note.md") */
 	readonly filename?: string;
@@ -157,16 +151,15 @@ export interface NoteInfo {
  * Extends `ReferenceEntry` (the persisted registry row) with panel-display
  * fields read from the on-disk markdown frontmatter (status / priority /
  * labels / description preview) plus `mapKey` (the registry key,
- * `<source>:<nativeId>` or `<source>:<nativeId>-<shortHash>` for archived
- * snapshots) and a stable `lastModified` field (= updatedAt) for sort
- * consistency with PlanInfo / NoteInfo.
+ * `<source>:<nativeId>`) and a stable `lastModified` field (= updatedAt) for
+ * sort consistency with PlanInfo / NoteInfo.
  */
 export interface ReferenceInfo {
 	readonly kind: "reference";
 	readonly source: SourceId;
 	/** Stable native id (Linear ticket id, Jira key, owner/repo#number, 32-hex Notion page id). */
 	readonly nativeId: string;
-	/** plans.json.references map key — `<source>:<nativeId>` while uncommitted, or `<source>:<nativeId>-<shortHash>` after archive. */
+	/** plans.json.references map key — `<source>:<nativeId>`. */
 	readonly mapKey: string;
 	readonly title: string;
 	readonly url: string;
@@ -174,13 +167,9 @@ export interface ReferenceInfo {
 	/** Opaque, source-specific display fields (built by the adapter). */
 	readonly fields?: ReadonlyArray<ReferenceField>;
 	readonly description?: string;
-	readonly branch: string;
 	readonly addedAt: string;
 	readonly updatedAt: string;
 	/** ISO 8601 — same as updatedAt for sort consistency with PlanInfo / NoteInfo. */
 	readonly lastModified: string;
-	readonly commitHash: string | null;
-	readonly contentHashAtCommit?: string;
-	readonly ignored: boolean;
 	readonly sourceToolName: string;
 }

--- a/vscode/src/core/NoteService.test.ts
+++ b/vscode/src/core/NoteService.test.ts
@@ -103,11 +103,9 @@ import {
 	detectNotes,
 	generateNoteSlug,
 	getNotesDir,
-	ignoreNote,
 	listUnassociatedNotes,
 	removeNote,
 	saveNote,
-	unassociateNoteFromCommit,
 } from "./NoteService.js";
 
 // ─── Test helpers ────────────────────────────────────────────────────────────
@@ -565,7 +563,7 @@ describe("NoteService", () => {
 
 		it("logs the count of found vs registry notes", async () => {
 			const visible = makeNoteEntry({ id: "visible", commitHash: null });
-			const hidden = makeNoteEntry({ id: "hidden", ignored: true });
+			const hidden = makeNoteEntry({ id: "hidden", commitHash: "abc" });
 			mockLoadPlansRegistry.mockResolvedValue({
 				version: 1,
 				plans: {},
@@ -815,21 +813,6 @@ describe("NoteService", () => {
 			expect(result.commitHash).toBeNull();
 		});
 
-		it("sets a branch value for new notes from getCurrentBranch", async () => {
-			mockLoadPlansRegistry.mockResolvedValue(emptyRegistry());
-			mockExistsSync.mockReturnValue(true);
-			mockReadFileSync.mockReturnValue("content");
-
-			await saveNote(undefined, "New Note", "content", "snippet", CWD);
-
-			// getCurrentBranch uses require("node:child_process") internally;
-			// verify the registry entry gets a branch value
-			const saved = mockSavePlansRegistry.mock.calls[0][0];
-			const noteId = Object.keys(saved.notes)[0];
-			expect(typeof saved.notes[noteId].branch).toBe("string");
-			expect(saved.notes[noteId].branch.length).toBeGreaterThan(0);
-		});
-
 		it("logs 'created' for new notes and 'updated' for existing", async () => {
 			// New note
 			mockLoadPlansRegistry.mockResolvedValue(emptyRegistry());
@@ -901,44 +884,6 @@ describe("NoteService", () => {
 		});
 	});
 
-	// ─── ignoreNote ──────────────────────────────────────────────────────────
-
-	describe("ignoreNote", () => {
-		it("sets ignored flag on existing entry", async () => {
-			const entry = makeNoteEntry();
-			mockLoadPlansRegistry.mockResolvedValue({
-				version: 1,
-				plans: {},
-				notes: { "test-note": entry },
-			});
-
-			await ignoreNote("test-note", CWD);
-
-			expect(mockSavePlansRegistry).toHaveBeenCalledWith(
-				expect.objectContaining({
-					notes: { "test-note": { ...entry, ignored: true } },
-				}),
-				CWD,
-			);
-		});
-
-		it("does nothing when id is not found in registry", async () => {
-			mockLoadPlansRegistry.mockResolvedValue(emptyRegistry());
-
-			await ignoreNote("nonexistent", CWD);
-
-			expect(mockSavePlansRegistry).not.toHaveBeenCalled();
-		});
-
-		it("works with registry that has no notes field", async () => {
-			mockLoadPlansRegistry.mockResolvedValue({ version: 1, plans: {} });
-
-			await ignoreNote("nonexistent", CWD);
-
-			expect(mockSavePlansRegistry).not.toHaveBeenCalled();
-		});
-	});
-
 	// ─── removeNote ────────────────────────────────────────────────────────────
 
 	describe("removeNote", () => {
@@ -986,13 +931,18 @@ describe("NoteService", () => {
 			);
 		});
 
-		it("removes entry without deleting file for committed notes", async () => {
+		it("removes the entry but skips file deletion when the backing file is already gone", async () => {
+			// New semantics: removeNote deletes the backing file only when it is
+			// inside .jolli/jollimemory/ AND still exists — commitHash no longer
+			// gates it. A committed snippet's file was already cleaned up by
+			// archiveNoteForCommit, so existsSync is false → entry removed, no unlink.
 			const entry = makeNoteEntry({ commitHash: "abc123" });
 			mockLoadPlansRegistry.mockResolvedValue({
 				version: 1,
 				plans: {},
 				notes: { "my-note": entry },
 			});
+			mockExistsSync.mockReturnValue(false);
 
 			await removeNote("my-note", CWD);
 
@@ -1076,7 +1026,7 @@ describe("NoteService", () => {
 			expect(result?.addedAt).toBe("2025-01-01T00:00:00.000Z");
 		});
 
-		it("sets archive guard on original entry and creates committed snapshot", async () => {
+		it("sets the archive guard on the original entry without creating an archive row", async () => {
 			const entry = makeNoteEntry();
 			mockLoadPlansRegistry.mockResolvedValue({
 				version: 1,
@@ -1089,17 +1039,16 @@ describe("NoteService", () => {
 			await archiveNoteForCommit("test-note", "06d0f729abcdef12", CWD);
 
 			const saved = mockSavePlansRegistry.mock.calls[0][0];
-			// Original entry becomes guard
+			// Only the guard row (original id) survives — it carries the
+			// archive-time contentHashAtCommit and the commit hash.
 			expect(saved.notes["test-note"].commitHash).toBe("06d0f729abcdef12");
 			expect(saved.notes["test-note"].contentHashAtCommit).toBe(
 				"mock-sha256-hash",
 			);
 			expect(saved.notes["test-note"].ignored).toBeUndefined();
-			// New entry is the committed snapshot
-			expect(saved.notes["test-note-06d0f729"].id).toBe("test-note-06d0f729");
-			expect(saved.notes["test-note-06d0f729"].commitHash).toBe(
-				"06d0f729abcdef12",
-			);
+			// No per-commit archive row is created; the new id lives only in the
+			// returned NoteReference / orphan-branch snapshot.
+			expect(saved.notes["test-note-06d0f729"]).toBeUndefined();
 		});
 
 		it("stores note in orphan branch via storeNotes", async () => {
@@ -1293,56 +1242,6 @@ describe("NoteService", () => {
 		});
 	});
 
-	// ─── unassociateNoteFromCommit ───────────────────────────────────────────
-
-	describe("unassociateNoteFromCommit", () => {
-		it("sets commitHash to null", async () => {
-			const entry = makeNoteEntry({ commitHash: "abc123" });
-			mockLoadPlansRegistry.mockResolvedValue({
-				version: 1,
-				plans: {},
-				notes: { "test-note": entry },
-			});
-
-			await unassociateNoteFromCommit("test-note", CWD);
-
-			const saved = mockSavePlansRegistry.mock.calls[0][0];
-			expect(saved.notes["test-note"].commitHash).toBeNull();
-		});
-
-		it("does nothing when id is not in registry", async () => {
-			mockLoadPlansRegistry.mockResolvedValue(emptyRegistry());
-
-			await unassociateNoteFromCommit("nonexistent", CWD);
-
-			expect(mockSavePlansRegistry).not.toHaveBeenCalled();
-		});
-
-		it("works with registry that has no notes field", async () => {
-			mockLoadPlansRegistry.mockResolvedValue({ version: 1, plans: {} });
-
-			await unassociateNoteFromCommit("nonexistent", CWD);
-
-			expect(mockSavePlansRegistry).not.toHaveBeenCalled();
-		});
-
-		it("logs unassociate operation", async () => {
-			const entry = makeNoteEntry({ commitHash: "abc123" });
-			mockLoadPlansRegistry.mockResolvedValue({
-				version: 1,
-				plans: {},
-				notes: { "test-note": entry },
-			});
-
-			await unassociateNoteFromCommit("test-note", CWD);
-
-			expect(info).toHaveBeenCalledWith(
-				"notes",
-				expect.stringContaining("Unassociated note test-note"),
-			);
-		});
-	});
-
 	// ─── listUnassociatedNotes ───────────────────────────────────────────────
 
 	describe("listUnassociatedNotes", () => {
@@ -1375,33 +1274,6 @@ describe("NoteService", () => {
 			expect(result).toEqual([
 				{ id: "note-a", title: "Note A", format: "snippet" },
 				{ id: "note-c", title: "Note C", format: "snippet" },
-			]);
-		});
-
-		it("excludes ignored notes even if commitHash is null", async () => {
-			const notes = {
-				"note-a": makeNoteEntry({
-					id: "note-a",
-					title: "Note A",
-					commitHash: null,
-					ignored: true,
-				}),
-				"note-b": makeNoteEntry({
-					id: "note-b",
-					title: "Note B",
-					commitHash: null,
-				}),
-			};
-			mockLoadPlansRegistry.mockResolvedValue({
-				version: 1,
-				plans: {},
-				notes,
-			});
-
-			const result = await listUnassociatedNotes(CWD);
-
-			expect(result).toEqual([
-				{ id: "note-b", title: "Note B", format: "snippet" },
 			]);
 		});
 

--- a/vscode/src/core/NoteService.test.ts
+++ b/vscode/src/core/NoteService.test.ts
@@ -3,8 +3,9 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // ─── Hoisted mocks ──────────────────────────────────────────────────────────
 
-const { mockLoadPlansRegistry, mockSavePlansRegistry } = vi.hoisted(() => ({
+const { mockLoadPlansRegistry, mockLoadPlansRegistryWithStatus, mockSavePlansRegistry } = vi.hoisted(() => ({
 	mockLoadPlansRegistry: vi.fn(),
+	mockLoadPlansRegistryWithStatus: vi.fn(),
 	mockSavePlansRegistry: vi.fn(),
 }));
 
@@ -57,7 +58,13 @@ const { mockCreateHash, mockRandomBytes } = vi.hoisted(() => ({
 
 vi.mock("../../../cli/src/core/SessionTracker.js", () => ({
 	loadPlansRegistry: mockLoadPlansRegistry,
+	loadPlansRegistryWithStatus: mockLoadPlansRegistryWithStatus,
 	savePlansRegistry: mockSavePlansRegistry,
+	// Pure helper — real implementation so removeNote's exact→base-guard works.
+	splitArchivedKey: (k: string) => {
+		const m = k.match(/^(.+)-([0-9a-f]{8})$/);
+		return m ? { baseKey: m[1], oldShortHash: m[2] } : null;
+	},
 }));
 
 vi.mock("../../../cli/src/core/SummaryStore.js", () => ({
@@ -148,6 +155,13 @@ describe("NoteService", () => {
 	beforeEach(() => {
 		mockLoadPlansRegistry.mockReset();
 		mockSavePlansRegistry.mockReset();
+		// Default: delegate to loadPlansRegistry with changed=false. The migration
+		// writeback test overrides with mockResolvedValueOnce.
+		mockLoadPlansRegistryWithStatus.mockReset();
+		mockLoadPlansRegistryWithStatus.mockImplementation(async (cwd: string) => ({
+			registry: await mockLoadPlansRegistry(cwd),
+			changed: false,
+		}));
 		mockStoreNotes.mockReset();
 		mockGetJolliMemoryDir.mockReset();
 		mockGetJolliMemoryDir.mockReturnValue("/mock-repo/.jolli/jollimemory");
@@ -243,6 +257,25 @@ describe("NoteService", () => {
 			const notes = await detectNotes(CWD);
 
 			expect(notes).toEqual([]);
+		});
+
+		it("persists the normalised registry once when migration purged legacy rows/fields (changed=true)", async () => {
+			mockLoadPlansRegistryWithStatus.mockResolvedValueOnce({
+				registry: { version: 1, plans: {}, notes: {} },
+				changed: true,
+			});
+
+			await detectNotes(CWD);
+
+			expect(mockSavePlansRegistry).toHaveBeenCalledTimes(1);
+		});
+
+		it("does not persist when nothing changed (changed=false)", async () => {
+			mockLoadPlansRegistry.mockResolvedValue({ version: 1, plans: {}, notes: {} });
+
+			await detectNotes(CWD);
+
+			expect(mockSavePlansRegistry).not.toHaveBeenCalled();
 		});
 
 		it("filters out ignored notes", async () => {
@@ -969,6 +1002,67 @@ describe("NoteService", () => {
 
 			expect(mockSavePlansRegistry).not.toHaveBeenCalled();
 			expect(mockUnlinkSync).not.toHaveBeenCalled();
+		});
+
+		it("resolves an archived id to the bare-key guard when it still belongs to that commit", async () => {
+			const guard = makeNoteEntry({ commitHash: "abcdef1234567890", contentHashAtCommit: "h" });
+			mockLoadPlansRegistry.mockResolvedValue({ version: 1, plans: {}, notes: { "my-note": guard } });
+
+			await removeNote("my-note-abcdef12", CWD, "abcdef1234567890");
+
+			expect(mockSavePlansRegistry).toHaveBeenCalledWith(expect.objectContaining({ notes: {} }), CWD);
+		});
+
+		it("does NOT delete the base note when it was revived/re-committed since (commitHash mismatch)", async () => {
+			// P1 regression: dissociating an OLD commit must not wipe a live note.
+			const revived = makeNoteEntry({ commitHash: null });
+			mockLoadPlansRegistry.mockResolvedValue({ version: 1, plans: {}, notes: { "my-note": revived } });
+
+			await removeNote("my-note-abcdef12", CWD, "abcdef1234567890");
+
+			expect(mockSavePlansRegistry).not.toHaveBeenCalled();
+			expect(mockUnlinkSync).not.toHaveBeenCalled();
+		});
+
+		it("deletes the exact id (not the stripped base) when it is this commit's guard", async () => {
+			const foo = makeNoteEntry({ commitHash: "abcdef1234567890" });
+			const real = makeNoteEntry({ commitHash: "abcdef1234567890" });
+			mockLoadPlansRegistry.mockResolvedValue({
+				version: 1,
+				plans: {},
+				notes: { foo, "foo-deadbeef": real },
+			});
+
+			await removeNote("foo-deadbeef", CWD, "abcdef1234567890");
+
+			const saved = mockSavePlansRegistry.mock.calls.at(-1)?.[0] as { notes: Record<string, unknown> };
+			expect(saved.notes["foo-deadbeef"]).toBeUndefined();
+			expect(saved.notes.foo).toBeDefined(); // base NOT mis-stripped
+		});
+
+		it("does NOT delete a live exact-id row (commitHash mismatch) when dissociating an old commit", async () => {
+			// P1-extended: an archived id `foo-deadbeef` from an old summary can later
+			// become a LIVE note under that exact id (commitHash=null). The exact id
+			// matches, but the commitHash does not — dissociating the old commit must
+			// not wipe the live row. The sidebar (no expectedCommitHash) still deletes it.
+			const live = makeNoteEntry({ commitHash: null });
+			mockLoadPlansRegistry.mockResolvedValue({ version: 1, plans: {}, notes: { "foo-deadbeef": live } });
+
+			await removeNote("foo-deadbeef", CWD, "abcdef1234567890");
+
+			expect(mockSavePlansRegistry).not.toHaveBeenCalled();
+			expect(mockUnlinkSync).not.toHaveBeenCalled();
+		});
+
+		it("deletes the exact id unconditionally on the sidebar path (no expectedCommitHash)", async () => {
+			// A committed note removed via the sidebar — no expectedCommitHash — is deleted
+			// regardless of its commitHash. The user explicitly asked to remove the live note.
+			const committed = makeNoteEntry({ commitHash: "abcdef1234567890" });
+			mockLoadPlansRegistry.mockResolvedValue({ version: 1, plans: {}, notes: { "my-note": committed } });
+
+			await removeNote("my-note", CWD);
+
+			expect(mockSavePlansRegistry).toHaveBeenCalledWith(expect.objectContaining({ notes: {} }), CWD);
 		});
 
 		it("handles file deletion failure gracefully", async () => {

--- a/vscode/src/core/NoteService.ts
+++ b/vscode/src/core/NoteService.ts
@@ -2,10 +2,10 @@
  * NoteService
  *
  * Central service for note management operations (parallel to PlanService):
- * - CRUD: create, read, update, ignore notes in plans.json registry
+ * - CRUD: create, read, update, hard-remove notes in plans.json registry
  * - Storage: all notes (snippet + markdown) are file-backed in .jolli/jollimemory/notes/
  * - Archive: associate notes with commits via orphan branch storage
- * - Filtering: branch-aware visibility, archive guards, ignored entries
+ * - Filtering: archive guards (content-hash) + committed-snapshot/orphan rows
  */
 
 import { createHash, randomBytes } from "node:crypto";
@@ -21,7 +21,9 @@ import { basename, join } from "node:path";
 import { isPathInside } from "../../../cli/src/core/PathUtils.js";
 import {
 	loadPlansRegistry,
+	loadPlansRegistryWithStatus,
 	savePlansRegistry,
+	splitArchivedKey,
 } from "../../../cli/src/core/SessionTracker.js";
 import type { StorageProvider } from "../../../cli/src/core/StorageProvider.js";
 import { storeNotes } from "../../../cli/src/core/SummaryStore.js";
@@ -41,7 +43,13 @@ export function getNotesDir(cwd: string): string {
  * Reads plans.json and returns a filtered, sorted list of NoteInfo.
  */
 export async function detectNotes(cwd: string): Promise<Array<NoteInfo>> {
-	const registry = await loadPlansRegistry(cwd);
+	// `changed` is true when loadPlansRegistry purged any legacy row/field;
+	// persist the normalised registry once so plans.json is cleaned on first
+	// panel refresh after upgrade (deterministic-writeback migration).
+	const { registry, changed } = await loadPlansRegistryWithStatus(cwd);
+	if (changed) {
+		await savePlansRegistry(registry, cwd);
+	}
 	const notes = registry.notes ?? {};
 
 	const result: Array<NoteInfo> = [];
@@ -138,10 +146,32 @@ export async function saveNote(
  * Idempotent: an unknown id is a no-op. Committed notes whose snippet file was
  * already cleaned up by `archiveNoteForCommit` simply skip the file delete.
  */
-export async function removeNote(id: string, cwd: string): Promise<void> {
+export async function removeNote(id: string, cwd: string, expectedCommitHash?: string): Promise<void> {
 	const registry = await loadPlansRegistry(cwd);
 	const notes = { ...(registry.notes ?? {}) };
-	const entry = notes[id];
+	// Resolve the key to delete. When `expectedCommitHash` is set (commit-summary
+	// dissociate flow), EVERY delete — exact id and archive base alike — is gated
+	// on the row still belonging to that commit (`row.commitHash === expectedCommitHash`).
+	// A registry row is a single time-evolving slot: an archived id like
+	// `note-x-abcdef12` from an old summary can later become a LIVE note under that
+	// exact id, or the base can be revived/re-committed. The gate stops a dissociation
+	// from an OLD commit from wiping a row that has moved on. Sidebar removal (no
+	// `expectedCommitHash`) deletes the exact id unconditionally.
+	let key: string | undefined;
+	if (expectedCommitHash === undefined) {
+		key = notes[id] !== undefined ? id : undefined;
+	} else if (notes[id]?.commitHash === expectedCommitHash) {
+		key = id;
+	} else {
+		const split = splitArchivedKey(id);
+		if (split && notes[split.baseKey]?.commitHash === expectedCommitHash) {
+			key = split.baseKey;
+		}
+	}
+	if (key === undefined) {
+		return;
+	}
+	const entry = notes[key];
 	if (!entry) {
 		return;
 	}
@@ -161,9 +191,9 @@ export async function removeNote(id: string, cwd: string): Promise<void> {
 		}
 	}
 
-	delete notes[id];
+	delete notes[key];
 	await savePlansRegistry({ ...registry, notes }, cwd);
-	log.info("notes", `Removed note ${id} from registry`);
+	log.info("notes", `Removed note ${key} from registry`);
 }
 
 // ─── Commit association ─────────────────────────────────────────────────────

--- a/vscode/src/core/NoteService.ts
+++ b/vscode/src/core/NoteService.ts
@@ -18,6 +18,7 @@ import {
 	writeFileSync,
 } from "node:fs";
 import { basename, join } from "node:path";
+import { isPathInside } from "../../../cli/src/core/PathUtils.js";
 import {
 	loadPlansRegistry,
 	savePlansRegistry,
@@ -28,7 +29,6 @@ import { getJolliMemoryDir } from "../../../cli/src/Logger.js";
 import type { NoteFormat, NoteReference } from "../../../cli/src/Types.js";
 import type { NoteEntry, NoteInfo } from "../Types.js";
 import { log } from "../util/Logger.js";
-import { getCurrentBranch } from "./PlanService.js";
 
 // ─── Public API ───────────────────────────────────────────────────────────────
 
@@ -44,10 +44,9 @@ export async function detectNotes(cwd: string): Promise<Array<NoteInfo>> {
 	const registry = await loadPlansRegistry(cwd);
 	const notes = registry.notes ?? {};
 
-	const branch = getCurrentBranch(cwd);
 	const result: Array<NoteInfo> = [];
 	for (const entry of Object.values(notes)) {
-		const info = toNoteInfo(entry, branch);
+		const info = toNoteInfo(entry);
 		if (info) {
 			result.push(info);
 		}
@@ -116,7 +115,6 @@ export async function saveNote(
 		sourcePath,
 		addedAt: existingNotes[noteId]?.addedAt ?? now,
 		updatedAt: now,
-		branch: getCurrentBranch(cwd),
 		commitHash: existingNotes[noteId]?.commitHash ?? null,
 	};
 
@@ -131,24 +129,14 @@ export async function saveNote(
 }
 
 /**
- * Marks a note as ignored in plans.json (hidden from panel).
- */
-export async function ignoreNote(id: string, cwd: string): Promise<void> {
-	const registry = await loadPlansRegistry(cwd);
-	const notes = { ...(registry.notes ?? {}) };
-	const entry = notes[id];
-	if (!entry) {
-		return;
-	}
-
-	notes[id] = { ...entry, ignored: true };
-	await savePlansRegistry({ ...registry, notes }, cwd);
-}
-
-/**
- * Removes a note: deletes the file for uncommitted notes, marks as ignored for committed ones.
- * Uncommitted notes have their source file in .jolli/jollimemory/notes/ — safe to delete.
- * Committed notes keep the file (orphan branch has the archive copy).
+ * Hard-removes a note: deletes the registry entry, and deletes the backing file
+ * ONLY when it lives inside the per-project `.jolli/jollimemory/` directory
+ * (snippet notes). Markdown notes reference the user's external file — never
+ * deleted. Same internal/external rule as `PlanService.removePlan` /
+ * `ReferenceService.removeReference`, expressed via `isPathInside`.
+ *
+ * Idempotent: an unknown id is a no-op. Committed notes whose snippet file was
+ * already cleaned up by `archiveNoteForCommit` simply skip the file delete.
  */
 export async function removeNote(id: string, cwd: string): Promise<void> {
 	const registry = await loadPlansRegistry(cwd);
@@ -158,23 +146,21 @@ export async function removeNote(id: string, cwd: string): Promise<void> {
 		return;
 	}
 
-	// Delete source file only for snippet notes (which we created in the notes dir).
-	// Markdown notes reference the user's original file — never delete it.
+	// Delete the backing file only when it is inside .jolli/jollimemory/ — the
+	// user's external markdown sources are never deleted.
 	if (
-		entry.commitHash === null &&
-		entry.format === "snippet" &&
 		entry.sourcePath &&
+		isPathInside(entry.sourcePath, getJolliMemoryDir(cwd)) &&
 		existsSync(entry.sourcePath)
 	) {
 		try {
 			unlinkSync(entry.sourcePath);
-			log.info("notes", `Deleted snippet file: ${entry.sourcePath}`);
+			log.info("notes", `Deleted note file: ${entry.sourcePath}`);
 		} catch {
 			/* ignore — file deletion is best-effort */
 		}
 	}
 
-	// Remove from registry entirely (not just ignored)
 	delete notes[id];
 	await savePlansRegistry({ ...registry, notes }, cwd);
 	log.info("notes", `Removed note ${id} from registry`);
@@ -216,23 +202,14 @@ export async function archiveNoteForCommit(
 		.update(noteContent)
 		.digest("hex");
 
-	// Update registry: original id becomes guard, new id is the committed entry
+	// Update registry: the original id becomes the guard. No
+	// `<id>-<shortHash>` archive row — the orphan-branch snapshot (stored under
+	// newId below) + the CommitSummary NoteReference are the system of record.
 	notes[id] = {
 		...entry,
 		commitHash,
 		updatedAt: now,
 		contentHashAtCommit,
-		ignored: undefined,
-	};
-	notes[newId] = {
-		id: newId,
-		title: entry.title,
-		format: entry.format,
-		sourcePath: entry.sourcePath,
-		addedAt: entry.addedAt,
-		updatedAt: now,
-		branch: entry.branch,
-		commitHash,
 	};
 	await savePlansRegistry({ ...registry, notes }, cwd);
 
@@ -274,25 +251,6 @@ export async function archiveNoteForCommit(
 }
 
 /**
- * Removes a note's association with a commit.
- */
-export async function unassociateNoteFromCommit(
-	id: string,
-	cwd: string,
-): Promise<void> {
-	const registry = await loadPlansRegistry(cwd);
-	const notes = { ...(registry.notes ?? {}) };
-	const entry = notes[id];
-	if (!entry) {
-		return;
-	}
-
-	notes[id] = { ...entry, commitHash: null };
-	await savePlansRegistry({ ...registry, notes }, cwd);
-	log.info("notes", `Unassociated note ${id} from commit`);
-}
-
-/**
  * Lists unassociated notes for WebView QuickPick.
  */
 export async function listUnassociatedNotes(
@@ -301,7 +259,7 @@ export async function listUnassociatedNotes(
 	const registry = await loadPlansRegistry(cwd);
 	const notes = registry.notes ?? {};
 	return Object.values(notes)
-		.filter((n) => n.commitHash === null && !n.ignored)
+		.filter((n) => n.commitHash === null)
 		.map((n) => ({ id: n.id, title: n.title, format: n.format }));
 }
 
@@ -321,16 +279,7 @@ export function generateNoteSlug(title: string): string {
 // ─── Internal helpers ───────────────────────────────────────────────────────
 
 /** Converts a NoteEntry to NoteInfo, returning null if the entry should be hidden. */
-function toNoteInfo(entry: NoteEntry, currentBranch?: string): NoteInfo | null {
-	if (entry.ignored) {
-		return null;
-	}
-
-	// Skip entries from other branches
-	if (currentBranch && entry.branch && entry.branch !== currentBranch) {
-		return null;
-	}
-
+function toNoteInfo(entry: NoteEntry): NoteInfo | null {
 	// Skip archive guards (content unchanged)
 	if (entry.contentHashAtCommit) {
 		const currentContent = getNoteContent(entry);
@@ -384,7 +333,6 @@ function toNoteInfo(entry: NoteEntry, currentBranch?: string): NoteInfo | null {
 		lastModified,
 		addedAt: entry.addedAt,
 		updatedAt: entry.updatedAt,
-		branch: entry.branch,
 		commitHash: entry.commitHash,
 		filename: entry.sourcePath ? basename(entry.sourcePath) : undefined,
 		filePath: entry.sourcePath,

--- a/vscode/src/core/PlanService.test.ts
+++ b/vscode/src/core/PlanService.test.ts
@@ -3,10 +3,11 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // ─── Hoisted mocks ──────────────────────────────────────────────────────────
 
-const { loadAllSessions, loadPlansRegistry, savePlansRegistry } = vi.hoisted(
+const { loadAllSessions, loadPlansRegistry, loadPlansRegistryWithStatus, savePlansRegistry } = vi.hoisted(
 	() => ({
 		loadAllSessions: vi.fn(),
 		loadPlansRegistry: vi.fn(),
+		loadPlansRegistryWithStatus: vi.fn(),
 		savePlansRegistry: vi.fn(),
 	}),
 );
@@ -65,7 +66,14 @@ const { mockExecFileSync } = vi.hoisted(() => ({
 vi.mock("../../../cli/src/core/SessionTracker.js", () => ({
 	loadAllSessions,
 	loadPlansRegistry,
+	loadPlansRegistryWithStatus,
 	savePlansRegistry,
+	// Pure helper — provide the real implementation so removePlan's
+	// exact→base-guard resolution works under the mock.
+	splitArchivedKey: (k: string) => {
+		const m = k.match(/^(.+)-([0-9a-f]{8})$/);
+		return m ? { baseKey: m[1], oldShortHash: m[2] } : null;
+	},
 }));
 
 vi.mock("../../../cli/src/core/SummaryStore.js", () => ({
@@ -204,6 +212,12 @@ function stubTranscript(lines: ReadonlyArray<string>) {
 describe("PlanService", () => {
 	beforeEach(() => {
 		loadPlansRegistry.mockReset();
+		// Default: delegate to loadPlansRegistry with changed=false. Tests that
+		// exercise the migration-writeback path override with mockResolvedValueOnce.
+		loadPlansRegistryWithStatus.mockImplementation(async (cwd: string) => ({
+			registry: await loadPlansRegistry(cwd),
+			changed: false,
+		}));
 		savePlansRegistry.mockReset();
 		loadAllSessions.mockReset();
 		loadAllSessions.mockResolvedValue([]);
@@ -318,6 +332,67 @@ describe("PlanService", () => {
 
 			expect(savePlansRegistry).not.toHaveBeenCalled();
 			expect(mockUnlinkSync).not.toHaveBeenCalled();
+		});
+
+		it("resolves an archived slug to the bare-key guard when it still belongs to that commit", async () => {
+			// CommitSummary passes `<base>-<8hex>` + expectedCommitHash; the guard
+			// lives at the base key and its commitHash matches → delete the base.
+			const guard = makeEntry({ slug: "my-plan", commitHash: "abcdef1234567890", contentHashAtCommit: "h" });
+			loadPlansRegistry.mockResolvedValue({ version: 1, plans: { "my-plan": guard } });
+
+			await removePlan("my-plan-abcdef12", CWD, "abcdef1234567890");
+
+			expect(savePlansRegistry).toHaveBeenCalledWith(expect.objectContaining({ plans: {} }), CWD);
+		});
+
+		it("does NOT delete the base row when it was revived/re-committed since (commitHash mismatch)", async () => {
+			// P1 regression: dissociating an OLD commit must not wipe a base row that
+			// is now a live active plan (commitHash=null) or re-committed elsewhere.
+			const revived = makeEntry({ slug: "my-plan", commitHash: null });
+			loadPlansRegistry.mockResolvedValue({ version: 1, plans: { "my-plan": revived } });
+
+			await removePlan("my-plan-abcdef12", CWD, "abcdef1234567890");
+
+			expect(savePlansRegistry).not.toHaveBeenCalled();
+			expect(mockUnlinkSync).not.toHaveBeenCalled();
+		});
+
+		it("deletes the exact key (not the stripped base) when it is this commit's guard", async () => {
+			// `foo-deadbeef` is this commit's guard; the exact key must win — never strip to `foo`.
+			const foo = makeEntry({ slug: "foo", commitHash: "abcdef1234567890" });
+			const realEntry = makeEntry({ slug: "foo-deadbeef", commitHash: "abcdef1234567890" });
+			loadPlansRegistry.mockResolvedValue({ version: 1, plans: { foo, "foo-deadbeef": realEntry } });
+
+			await removePlan("foo-deadbeef", CWD, "abcdef1234567890");
+
+			const saved = savePlansRegistry.mock.calls.at(-1)?.[0] as { plans: Record<string, unknown> };
+			expect(saved.plans["foo-deadbeef"]).toBeUndefined();
+			expect(saved.plans.foo).toBeDefined(); // base NOT mis-stripped
+		});
+
+		it("does NOT delete a live exact-key row (commitHash mismatch) when dissociating an old commit", async () => {
+			// P1-extended: an archived slug `foo-deadbeef` from an old summary can later
+			// become a LIVE plan created under that exact key (commitHash=null). The exact
+			// key matches, but the commitHash does not — dissociating the old commit must
+			// not wipe the live row. The sidebar (no expectedCommitHash) still deletes it.
+			const live = makeEntry({ slug: "foo-deadbeef", commitHash: null });
+			loadPlansRegistry.mockResolvedValue({ version: 1, plans: { "foo-deadbeef": live } });
+
+			await removePlan("foo-deadbeef", CWD, "abcdef1234567890");
+
+			expect(savePlansRegistry).not.toHaveBeenCalled();
+			expect(mockUnlinkSync).not.toHaveBeenCalled();
+		});
+
+		it("deletes the exact key unconditionally on the sidebar path (no expectedCommitHash)", async () => {
+			// A committed plan removed via the sidebar — no expectedCommitHash — is deleted
+			// regardless of its commitHash. The user explicitly asked to remove the live plan.
+			const committed = makeEntry({ slug: "test-plan", commitHash: "abcdef1234567890" });
+			loadPlansRegistry.mockResolvedValue({ version: 1, plans: { "test-plan": committed } });
+
+			await removePlan("test-plan", CWD);
+
+			expect(savePlansRegistry).toHaveBeenCalledWith(expect.objectContaining({ plans: {} }), CWD);
 		});
 
 		it("still removes the entry when internal file deletion throws", async () => {
@@ -667,6 +742,37 @@ describe("PlanService", () => {
 	// ─── detectPlans ─────────────────────────────────────────────────────────
 
 	describe("detectPlans", () => {
+		it("persists the normalised registry when migration purged legacy rows/fields (changed=true)", async () => {
+			const entry = makeEntry();
+			loadPlansRegistry.mockResolvedValue({ version: 1, plans: { "test-plan": entry } });
+			// Simulate loadPlansRegistry having stripped a legacy field/row: changed=true
+			// even though there are no orphaned entries to clean.
+			loadPlansRegistryWithStatus.mockResolvedValueOnce({
+				registry: { version: 1, plans: { "test-plan": entry } },
+				changed: true,
+			});
+			mockExistsSync.mockReturnValue(true);
+			mockReadFileSync.mockReturnValue("# Test Plan");
+			mockStatSync.mockReturnValue({ mtime: new Date("2025-06-01T00:00:00.000Z") });
+
+			await detectPlans(CWD);
+
+			// Deterministic writeback: the cleaned registry is flushed once.
+			expect(savePlansRegistry).toHaveBeenCalledTimes(1);
+		});
+
+		it("does not persist when nothing changed and no orphans (changed=false)", async () => {
+			const entry = makeEntry();
+			loadPlansRegistry.mockResolvedValue({ version: 1, plans: { "test-plan": entry } });
+			mockExistsSync.mockReturnValue(true);
+			mockReadFileSync.mockReturnValue("# Test Plan");
+			mockStatSync.mockReturnValue({ mtime: new Date("2025-06-01T00:00:00.000Z") });
+
+			await detectPlans(CWD);
+
+			expect(savePlansRegistry).not.toHaveBeenCalled();
+		});
+
 		it("returns plans from registry merged with transcript discoveries", async () => {
 			const entry = makeEntry();
 			loadPlansRegistry.mockResolvedValue({

--- a/vscode/src/core/PlanService.test.ts
+++ b/vscode/src/core/PlanService.test.ts
@@ -28,12 +28,14 @@ const {
 	mockReaddirSync,
 	mockStatSync,
 	mockCreateReadStream,
+	mockUnlinkSync,
 } = vi.hoisted(() => ({
 	mockExistsSync: vi.fn(),
 	mockReadFileSync: vi.fn(),
 	mockReaddirSync: vi.fn(),
 	mockStatSync: vi.fn(),
 	mockCreateReadStream: vi.fn(),
+	mockUnlinkSync: vi.fn(),
 }));
 
 const { mockReadFile } = vi.hoisted(() => ({
@@ -84,6 +86,7 @@ vi.mock("node:fs", () => ({
 	createReadStream: mockCreateReadStream,
 	readdirSync: mockReaddirSync,
 	statSync: mockStatSync,
+	unlinkSync: mockUnlinkSync,
 }));
 
 vi.mock("node:fs/promises", () => ({
@@ -115,12 +118,11 @@ import {
 	detectPlans,
 	extractTitle,
 	getPlansDir,
-	ignorePlan,
 	isPlanFromCurrentProject,
 	listAvailablePlans,
 	listUnassociatedPlans,
 	registerNewPlan,
-	unassociatePlanFromCommit,
+	removePlan,
 } from "./PlanService.js";
 
 // ─── Test helpers ────────────────────────────────────────────────────────────
@@ -211,6 +213,7 @@ describe("PlanService", () => {
 		error.mockReset();
 		debug.mockReset();
 		mockExistsSync.mockReset();
+		mockUnlinkSync.mockReset();
 		mockReadFileSync.mockReset();
 		mockReaddirSync.mockReset();
 		// Default: ~/.claude/plans/ is empty so detectPlans()'s directory-diff
@@ -268,22 +271,42 @@ describe("PlanService", () => {
 		});
 	});
 
-	// ─── ignorePlan ──────────────────────────────────────────────────────────
+	// ─── removePlan ────────────────────────────────────────────────────────────
 
-	describe("ignorePlan", () => {
-		it("sets ignored flag on existing entry", async () => {
+	describe("removePlan", () => {
+		it("removes the registry entry without deleting an external plan file", async () => {
+			// makeEntry's sourcePath is under ~/.claude/plans (external) → file kept.
 			const entry = makeEntry();
 			loadPlansRegistry.mockResolvedValue({
 				version: 1,
 				plans: { "test-plan": entry },
 			});
 
-			await ignorePlan("test-plan", CWD);
+			await removePlan("test-plan", CWD);
 
 			expect(savePlansRegistry).toHaveBeenCalledWith(
-				expect.objectContaining({
-					plans: { "test-plan": { ...entry, ignored: true } },
-				}),
+				expect.objectContaining({ plans: {} }),
+				CWD,
+			);
+			expect(mockUnlinkSync).not.toHaveBeenCalled();
+		});
+
+		it("deletes the backing file when the plan source is inside .jolli/jollimemory/", async () => {
+			const internalPath = normalize(
+				`${CWD}/.jolli/jollimemory/notes/inner.md`,
+			);
+			const entry = makeEntry({ sourcePath: internalPath });
+			loadPlansRegistry.mockResolvedValue({
+				version: 1,
+				plans: { "test-plan": entry },
+			});
+			mockExistsSync.mockReturnValue(true);
+
+			await removePlan("test-plan", CWD);
+
+			expect(mockUnlinkSync).toHaveBeenCalledWith(internalPath);
+			expect(savePlansRegistry).toHaveBeenCalledWith(
+				expect.objectContaining({ plans: {} }),
 				CWD,
 			);
 		});
@@ -291,9 +314,32 @@ describe("PlanService", () => {
 		it("does nothing when slug is not in registry", async () => {
 			loadPlansRegistry.mockResolvedValue(emptyRegistry());
 
-			await ignorePlan("nonexistent", CWD);
+			await removePlan("nonexistent", CWD);
 
 			expect(savePlansRegistry).not.toHaveBeenCalled();
+			expect(mockUnlinkSync).not.toHaveBeenCalled();
+		});
+
+		it("still removes the entry when internal file deletion throws", async () => {
+			const internalPath = normalize(
+				`${CWD}/.jolli/jollimemory/notes/inner.md`,
+			);
+			const entry = makeEntry({ sourcePath: internalPath });
+			loadPlansRegistry.mockResolvedValue({
+				version: 1,
+				plans: { "test-plan": entry },
+			});
+			mockExistsSync.mockReturnValue(true);
+			mockUnlinkSync.mockImplementationOnce(() => {
+				throw new Error("EACCES");
+			});
+
+			await removePlan("test-plan", CWD);
+
+			expect(savePlansRegistry).toHaveBeenCalledWith(
+				expect.objectContaining({ plans: {} }),
+				CWD,
+			);
 		});
 	});
 
@@ -408,7 +454,7 @@ describe("PlanService", () => {
 	// ─── archivePlanForCommit ────────────────────────────────────────────────
 
 	describe("archivePlanForCommit", () => {
-		it("creates archive entry with new slug and sets archive guard on original", async () => {
+		it("sets the archive guard on the original and returns a PlanReference with the new slug", async () => {
 			const entry = makeEntry({});
 			loadPlansRegistry.mockResolvedValue({
 				version: 1,
@@ -431,14 +477,13 @@ describe("PlanService", () => {
 			);
 
 			const saved = savePlansRegistry.mock.calls[0][0];
-			// Original slug has archive guard
+			// Only the guard row (original slug) survives — it carries the
+			// archive-time contentHashAtCommit and the commit hash.
 			expect(saved.plans["test-plan"].contentHashAtCommit).toBe("mock-hash");
 			expect(saved.plans["test-plan"].commitHash).toBe("06d0f729abcdef12");
-			// New slug is committed entry
-			expect(saved.plans["test-plan-06d0f729"].commitHash).toBe(
-				"06d0f729abcdef12",
-			);
-			expect(saved.plans["test-plan-06d0f729"].slug).toBe("test-plan-06d0f729");
+			// No per-commit archive row is created; the new slug lives only in the
+			// returned PlanReference / orphan-branch snapshot.
+			expect(saved.plans["test-plan-06d0f729"]).toBeUndefined();
 		});
 
 		it("stores plan file in orphan branch", async () => {
@@ -576,31 +621,6 @@ describe("PlanService", () => {
 		});
 	});
 
-	// ─── unassociatePlanFromCommit ───────────────────────────────────────────
-
-	describe("unassociatePlanFromCommit", () => {
-		it("sets commitHash to null", async () => {
-			const entry = makeEntry({ commitHash: "abc123" });
-			loadPlansRegistry.mockResolvedValue({
-				version: 1,
-				plans: { "test-plan": entry },
-			});
-
-			await unassociatePlanFromCommit("test-plan", CWD);
-
-			const saved = savePlansRegistry.mock.calls[0][0];
-			expect(saved.plans["test-plan"].commitHash).toBeNull();
-		});
-
-		it("does nothing when slug is not in registry", async () => {
-			loadPlansRegistry.mockResolvedValue(emptyRegistry());
-
-			await unassociatePlanFromCommit("nonexistent", CWD);
-
-			expect(savePlansRegistry).not.toHaveBeenCalled();
-		});
-	});
-
 	// ─── listUnassociatedPlans ───────────────────────────────────────────────
 
 	describe("listUnassociatedPlans", () => {
@@ -671,23 +691,6 @@ describe("PlanService", () => {
 
 			expect(plans.length).toBeGreaterThanOrEqual(1);
 			expect(plans[0].slug).toBe("test-plan");
-		});
-
-		it("filters out ignored plans", async () => {
-			const entry = makeEntry({ ignored: true });
-			loadPlansRegistry.mockResolvedValue({
-				version: 1,
-				plans: { "test-plan": entry },
-			});
-			stubSessions([]);
-			mockReadFile.mockResolvedValue(
-				JSON.stringify({ version: 1, sessions: {} }),
-			);
-			mockExistsSync.mockReturnValue(true);
-
-			const plans = await detectPlans(CWD);
-
-			expect(plans.find((p) => p.slug === "test-plan")).toBeUndefined();
 		});
 
 		it("filters out archive guards with unchanged hash", async () => {
@@ -956,33 +959,6 @@ describe("PlanService", () => {
 			// Committed plan: filePath is empty, stat/title extraction skipped
 			expect(plans[0].filePath).toBe("");
 			expect(plans[0].lastModified).toBe("2025-06-01T00:00:00.000Z");
-		});
-
-		it("filters out plans whose branch differs from the current git branch", async () => {
-			// Regression guard for the per-branch plan visibility filter.
-			// Default mock returns "main" as currentBranch; the entry's branch
-			// is "feature-x" — toPlanInfo returns null and the plan is hidden.
-			// Without this filter, switching branches would surface plans from
-			// every other branch in the sidebar, drowning the active branch's
-			// plans in noise.
-			const entry = makeEntry({
-				slug: "feature-plan",
-				branch: "feature-x",
-				sourcePath: `${PLANS_DIR}/feature-plan.md`,
-			});
-			loadPlansRegistry.mockResolvedValue({
-				version: 1,
-				plans: { "feature-plan": entry },
-			});
-			stubSessions([]);
-			mockReadFile.mockResolvedValue(
-				JSON.stringify({ version: 1, sessions: {} }),
-			);
-			mockExistsSync.mockReturnValue(true);
-			mockReadFileSync.mockReturnValue("# Feature Plan");
-
-			const plans = await detectPlans(CWD);
-			expect(plans.find((p) => p.slug === "feature-plan")).toBeUndefined();
 		});
 
 		it("filters out uncommitted plans whose source file has been deleted", async () => {

--- a/vscode/src/core/PlanService.ts
+++ b/vscode/src/core/PlanService.ts
@@ -5,10 +5,10 @@
  * - Discovery: Plans are discovered by the StopHook (in jollimemory) which
  *   incrementally scans transcripts and writes to plans.json. This service
  *   only reads plans.json — no transcript scanning happens here.
- * - Registry: plans.json CRUD (load, save, ignore, add)
+ * - Registry: plans.json CRUD (load, save, hard-remove, add)
  * - Resolution: Resolving editable file paths for committed/uncommitted plans
  * - Listing: Available plans for QuickPick selection
- * - Filtering: Branch-aware visibility, archive guards, ignored entries
+ * - Filtering: archive guards (content-hash) + committed-snapshot/orphan rows
  */
 
 import { createHash } from "node:crypto";
@@ -26,7 +26,9 @@ import { isPathInside } from "../../../cli/src/core/PathUtils.js";
 import {
 	loadAllSessions,
 	loadPlansRegistry,
+	loadPlansRegistryWithStatus,
 	savePlansRegistry,
+	splitArchivedKey,
 } from "../../../cli/src/core/SessionTracker.js";
 import type { StorageProvider } from "../../../cli/src/core/StorageProvider.js";
 import { storePlans } from "../../../cli/src/core/SummaryStore.js";
@@ -56,7 +58,11 @@ export function getPlansDir(): string {
  * one-shot convergence: a subsequent call with no orphans performs no writes.
  */
 export async function detectPlans(cwd: string): Promise<Array<PlanInfo>> {
-	const registry = await loadPlansRegistry(cwd);
+	// `changed` is true when loadPlansRegistry purged any legacy row/field
+	// (one-shot schema migration); persisting it here deterministically cleans
+	// plans.json on the first panel refresh after upgrade. `registry` is already
+	// normalised, so this save also persists cleaned notes/references.
+	const { registry, changed } = await loadPlansRegistryWithStatus(cwd);
 	const registryPlans = { ...registry.plans };
 
 	// Clean up orphaned entries (source file deleted, uncommitted, not a guard)
@@ -71,7 +77,7 @@ export async function detectPlans(cwd: string): Promise<Array<PlanInfo>> {
 			cleaned = true;
 		}
 	}
-	if (cleaned) {
+	if (cleaned || changed) {
 		await savePlansRegistry({ ...registry, plans: registryPlans }, cwd);
 	}
 
@@ -161,10 +167,41 @@ function toPlanInfo(entry: PlanEntry): PlanInfo | null {
  *
  * Idempotent: an unknown slug is a no-op. Allows revival — no `ignored`
  * tombstone is left, so re-adding the same plan file re-registers it.
+ *
+ * `expectedCommitHash` (passed by the commit-summary dissociate flow) gates EVERY
+ * delete — both the exact-key match and the archive-base fallback — on the row
+ * still belonging to that commit (`row.commitHash === expectedCommitHash`). A
+ * registry row is a single time-evolving slot: an archived slug like
+ * `plan-x-abcdef12` from an old summary can later become a LIVE plan created
+ * under that very key (commitHash=null), or the base can be revived/re-committed
+ * elsewhere. Gating on commitHash means dissociating an OLD commit never wipes a
+ * row that has moved on. Sidebar removal (no `expectedCommitHash`) deletes the
+ * exact key unconditionally — that's the user explicitly removing the live plan.
  */
-export async function removePlan(slug: string, cwd: string): Promise<void> {
+export async function removePlan(slug: string, cwd: string, expectedCommitHash?: string): Promise<void> {
 	const registry = await loadPlansRegistry(cwd);
-	const entry = registry.plans[slug];
+	// Resolve the registry key to delete.
+	let key: string | undefined;
+	if (expectedCommitHash === undefined) {
+		// Sidebar / cleanup path: exact key only, delete whatever lives there.
+		key = registry.plans[slug] !== undefined ? slug : undefined;
+	} else {
+		// Commit-dissociate path: only delete a row still owned by THIS commit.
+		// Exact key first; then the archive base (`<base>-<8hex>` → `<base>`),
+		// which handles squash/rebase where the summary slug keeps the old hash.
+		if (registry.plans[slug]?.commitHash === expectedCommitHash) {
+			key = slug;
+		} else {
+			const split = splitArchivedKey(slug);
+			if (split && registry.plans[split.baseKey]?.commitHash === expectedCommitHash) {
+				key = split.baseKey;
+			}
+		}
+	}
+	if (key === undefined) {
+		return;
+	}
+	const entry = registry.plans[key];
 	if (!entry) {
 		return;
 	}
@@ -181,13 +218,13 @@ export async function removePlan(slug: string, cwd: string): Promise<void> {
 		}
 	}
 	const plans = { ...registry.plans };
-	delete plans[slug];
+	delete plans[key];
 	await savePlansRegistry({ ...registry, plans }, cwd);
 }
 
 /**
  * Adds a plan from ~/.claude/plans/ to the registry as an uncommitted entry.
- * Clears the `ignored` flag if previously set.
+ * Resets any prior committed/guard state so the plan becomes editable again.
  */
 export async function addPlanToRegistry(
 	slug: string,
@@ -202,7 +239,7 @@ export async function addPlanToRegistry(
 	const existing = registry.plans[slug];
 	const now = new Date().toISOString();
 
-	// Always reset to a fresh uncommitted entry — clears ignored, contentHashAtCommit,
+	// Always reset to a fresh uncommitted entry — clears contentHashAtCommit
 	// and commitHash so the plan becomes visible and editable again.
 	const entry: PlanEntry = {
 		slug,
@@ -225,9 +262,8 @@ export async function addPlanToRegistry(
 /**
  * Registers a plan slug into plans.json iff it isn't already tracked.
  *
- * - If the slug exists (even as an ignored entry), this is a no-op — the
- *   user's explicit Ignore state is preserved. Recreating the same filename
- *   does not resurrect a previously-ignored plan.
+ * - If the slug is already tracked, this is a no-op (it preserves the existing
+ *   entry's committed/guard state rather than resetting it).
  * - Otherwise delegates to `addPlanToRegistry()` to create a fresh
  *   uncommitted entry.
  *
@@ -420,8 +456,7 @@ export async function archivePlanForCommit(
 }
 
 /**
- * Lists unassociated plans from plans.json for WebView QuickPick.
- * Includes ignored plans (so users can restore them via Associate).
+ * Lists unassociated (uncommitted) plans from plans.json for WebView QuickPick.
  */
 export async function listUnassociatedPlans(
 	cwd: string,

--- a/vscode/src/core/PlanService.ts
+++ b/vscode/src/core/PlanService.ts
@@ -17,10 +17,12 @@ import {
 	readFileSync as fsReadFileSync,
 	readdirSync,
 	statSync,
+	unlinkSync,
 } from "node:fs";
 import { readFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
+import { isPathInside } from "../../../cli/src/core/PathUtils.js";
 import {
 	loadAllSessions,
 	loadPlansRegistry,
@@ -28,8 +30,8 @@ import {
 } from "../../../cli/src/core/SessionTracker.js";
 import type { StorageProvider } from "../../../cli/src/core/StorageProvider.js";
 import { storePlans } from "../../../cli/src/core/SummaryStore.js";
+import { getJolliMemoryDir } from "../../../cli/src/Logger.js";
 import type { PlanReference } from "../../../cli/src/Types.js";
-import { execFileSyncHidden } from "../../../cli/src/util/Subprocess.js";
 import type { PlanEntry, PlanInfo } from "../Types.js";
 import { log } from "../util/Logger.js";
 
@@ -63,7 +65,6 @@ export async function detectPlans(cwd: string): Promise<Array<PlanInfo>> {
 		if (
 			entry.commitHash === null &&
 			!entry.contentHashAtCommit &&
-			!entry.ignored &&
 			!existsSync(entry.sourcePath)
 		) {
 			delete registryPlans[slug];
@@ -74,8 +75,7 @@ export async function detectPlans(cwd: string): Promise<Array<PlanInfo>> {
 		await savePlansRegistry({ ...registry, plans: registryPlans }, cwd);
 	}
 
-	const branch = getCurrentBranch(cwd);
-	const plans = buildPlanInfoList(registryPlans, branch);
+	const plans = buildPlanInfoList(registryPlans);
 	log.info(
 		"plans",
 		`detectPlans found ${plans.length} plans (${Object.keys(registryPlans).length} in registry)`,
@@ -84,13 +84,10 @@ export async function detectPlans(cwd: string): Promise<Array<PlanInfo>> {
 }
 
 /** Converts registry entries into a sorted PlanInfo array, filtering out invisible entries. */
-function buildPlanInfoList(
-	registryPlans: Record<string, PlanEntry>,
-	currentBranch?: string,
-): Array<PlanInfo> {
+function buildPlanInfoList(registryPlans: Record<string, PlanEntry>): Array<PlanInfo> {
 	const plans: Array<PlanInfo> = [];
 	for (const entry of Object.values(registryPlans)) {
-		const info = toPlanInfo(entry, currentBranch);
+		const info = toPlanInfo(entry);
 		if (info) {
 			plans.push(info);
 		}
@@ -103,16 +100,7 @@ function buildPlanInfoList(
 }
 
 /** Converts a single PlanEntry to PlanInfo, returning null if the entry should be hidden. */
-function toPlanInfo(entry: PlanEntry, currentBranch?: string): PlanInfo | null {
-	if (entry.ignored) {
-		return null;
-	}
-
-	// Skip entries from other branches
-	if (currentBranch && entry.branch && entry.branch !== currentBranch) {
-		return null;
-	}
-
+function toPlanInfo(entry: PlanEntry): PlanInfo | null {
 	// Skip archive guards (source file unchanged)
 	if (entry.contentHashAtCommit) {
 		const planFile = entry.sourcePath;
@@ -159,28 +147,42 @@ function toPlanInfo(entry: PlanEntry, currentBranch?: string): PlanInfo | null {
 		lastModified,
 		addedAt: entry.addedAt,
 		updatedAt: entry.updatedAt,
-		branch: entry.branch,
 		commitHash: entry.commitHash,
 	};
 }
 
 /**
- * Marks a plan as ignored in plans.json (hidden from PLANS panel).
- * Does not delete the entry — detectPlans() will skip it.
+ * Hard-removes a plan from plans.json: deletes the registry entry, and deletes
+ * the source file ONLY when it lives inside the per-project `.jolli/jollimemory/`
+ * directory. Plan source files are almost always external (`~/.claude/plans/`,
+ * repo `docs/`, external note dirs), so in practice the file is preserved and
+ * only the registry row is removed — matching `NoteService.removeNote`'s
+ * "delete the internal backing file, never touch external user files" rule.
+ *
+ * Idempotent: an unknown slug is a no-op. Allows revival — no `ignored`
+ * tombstone is left, so re-adding the same plan file re-registers it.
  */
-export async function ignorePlan(slug: string, cwd: string): Promise<void> {
+export async function removePlan(slug: string, cwd: string): Promise<void> {
 	const registry = await loadPlansRegistry(cwd);
 	const entry = registry.plans[slug];
 	if (!entry) {
 		return;
 	}
-	await savePlansRegistry(
-		{
-			...registry,
-			plans: { ...registry.plans, [slug]: { ...entry, ignored: true } },
-		},
-		cwd,
-	);
+	// Delete the backing file only when it is inside .jolli/jollimemory/ —
+	// external plan files (the common case) are the user's own, never deleted.
+	if (
+		isPathInside(entry.sourcePath, getJolliMemoryDir(cwd)) &&
+		existsSync(entry.sourcePath)
+	) {
+		try {
+			unlinkSync(entry.sourcePath);
+		} catch {
+			/* best-effort — the registry row is still removed below */
+		}
+	}
+	const plans = { ...registry.plans };
+	delete plans[slug];
+	await savePlansRegistry({ ...registry, plans }, cwd);
 }
 
 /**
@@ -208,7 +210,6 @@ export async function addPlanToRegistry(
 		sourcePath: planFile,
 		addedAt: existing?.addedAt ?? now,
 		updatedAt: now,
-		branch: getCurrentBranch(cwd),
 		commitHash: null,
 	};
 
@@ -350,7 +351,6 @@ export async function archivePlanForCommit(
 			sourcePath: planFile,
 			addedAt: new Date().toISOString(),
 			updatedAt: new Date().toISOString(),
-			branch: getCurrentBranch(cwd),
 			commitHash: null,
 		};
 	}
@@ -365,7 +365,9 @@ export async function archivePlanForCommit(
 		contentHashAtCommit = hashFileContent(entry.sourcePath);
 	}
 
-	// Update plans.json: original slug becomes guard, new slug is the committed entry
+	// Update plans.json: the original slug becomes the guard. No
+	// `<slug>-<shortHash>` archive row — the orphan-branch snapshot (stored under
+	// newSlug below) + the CommitSummary PlanReference are the system of record.
 	await savePlansRegistry(
 		{
 			...registry,
@@ -376,16 +378,6 @@ export async function archivePlanForCommit(
 					commitHash,
 					updatedAt: now,
 					contentHashAtCommit,
-					ignored: undefined,
-				},
-				[newSlug]: {
-					slug: newSlug,
-					title: entry.title,
-					sourcePath: entry.sourcePath,
-					addedAt: entry.addedAt,
-					updatedAt: now,
-					branch: entry.branch,
-					commitHash,
 				},
 			},
 		},
@@ -401,9 +393,7 @@ export async function archivePlanForCommit(
 	// storePlans branch arg (below): intentionally left undefined.
 	// FolderStorage.resolveBranchFromSlug uses the commit hash embedded in
 	// `newSlug` to look up the commit's branch from the manifest / index —
-	// that's the right home for the visible <branch>/plan--<slug>.md. Passing
-	// entry.branch would point at the plan's *home* branch, which can differ
-	// from the commit's branch when editing summaries cross-branch.
+	// that's the right home for the visible <branch>/plan--<slug>.md.
 	const planFile = entry.sourcePath;
 	if (existsSync(planFile)) {
 		const content = fsReadFileSync(planFile, "utf-8");
@@ -427,34 +417,6 @@ export async function archivePlanForCommit(
 		addedAt: entry.addedAt,
 		updatedAt: now,
 	};
-}
-
-/**
- * Removes a plan's association with a commit (called from WebView "Remove" button).
- * Clears commitHash in plans.json so the plan becomes unassociated.
- */
-export async function unassociatePlanFromCommit(
-	slug: string,
-	cwd: string,
-): Promise<void> {
-	const registry = await loadPlansRegistry(cwd);
-	const entry = registry.plans[slug];
-	if (!entry) {
-		return;
-	}
-
-	await savePlansRegistry(
-		{
-			...registry,
-			plans: {
-				...registry.plans,
-				[slug]: { ...entry, commitHash: null },
-			},
-		},
-		cwd,
-	);
-
-	log.info("plans", `Unassociated plan ${slug} from commit`);
 }
 
 /**
@@ -488,17 +450,4 @@ function hashFileContent(filePath: string): string {
 	return createHash("sha256")
 		.update(fsReadFileSync(filePath, "utf-8"))
 		.digest("hex");
-}
-
-export function getCurrentBranch(cwd: string): string {
-	try {
-		return execFileSyncHidden("git", ["rev-parse", "--abbrev-ref", "HEAD"], {
-			cwd,
-			encoding: "utf-8",
-			stdio: ["ignore", "pipe", "ignore"],
-		}).trim();
-		/* v8 ignore next 3 -- defensive: rev-parse fails only when cwd is not a git repo, which the caller already filters out before reaching here; "unknown" is the safe sentinel for an impossible state */
-	} catch {
-		return "unknown";
-	}
 }

--- a/vscode/src/core/ReferenceService.test.ts
+++ b/vscode/src/core/ReferenceService.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const {
 	mockLoadPlansRegistry,
+	mockLoadPlansRegistryWithStatus,
 	mockSavePlansRegistry,
 	mockGetCurrentBranch,
 	mockReadFileSync,
@@ -11,6 +12,7 @@ const {
 	mockDeleteReferenceMarkdown,
 } = vi.hoisted(() => ({
 	mockLoadPlansRegistry: vi.fn(),
+	mockLoadPlansRegistryWithStatus: vi.fn(),
 	mockSavePlansRegistry: vi.fn(),
 	mockGetCurrentBranch: vi.fn(),
 	mockReadFileSync: vi.fn(),
@@ -22,6 +24,7 @@ const {
 
 vi.mock("../../../cli/src/core/SessionTracker.js", () => ({
 	loadPlansRegistry: mockLoadPlansRegistry,
+	loadPlansRegistryWithStatus: mockLoadPlansRegistryWithStatus,
 	savePlansRegistry: mockSavePlansRegistry,
 }));
 
@@ -105,6 +108,12 @@ beforeEach(() => {
 	mockReadFileSync.mockImplementation(() => {
 		throw new Error("ENOENT");
 	});
+	// Default: delegate to loadPlansRegistry with changed=false. The migration
+	// writeback test overrides with mockResolvedValueOnce.
+	mockLoadPlansRegistryWithStatus.mockImplementation(async (cwd: string) => ({
+		registry: await mockLoadPlansRegistry(cwd),
+		changed: false,
+	}));
 });
 
 describe("detectReferences", () => {
@@ -122,6 +131,25 @@ describe("detectReferences", () => {
 
 		expect(result).toHaveLength(2);
 		expect(result.map((r) => r.source).sort()).toEqual(["jira", "linear"]);
+	});
+
+	it("persists the normalised registry once when migration purged legacy rows/fields (changed=true)", async () => {
+		mockLoadPlansRegistryWithStatus.mockResolvedValueOnce({
+			registry: { version: 1, plans: {}, references: {} },
+			changed: true,
+		});
+
+		await detectReferences("/repo");
+
+		expect(mockSavePlansRegistry).toHaveBeenCalledTimes(1);
+	});
+
+	it("does not persist when nothing changed (changed=false)", async () => {
+		mockLoadPlansRegistry.mockResolvedValue({ version: 1, plans: {}, references: {} });
+
+		await detectReferences("/repo");
+
+		expect(mockSavePlansRegistry).not.toHaveBeenCalled();
 	});
 
 	it("filters by sourceFilter when provided", async () => {

--- a/vscode/src/core/ReferenceService.test.ts
+++ b/vscode/src/core/ReferenceService.test.ts
@@ -8,6 +8,7 @@ const {
 	mockShowTextDocument,
 	mockOpenExternal,
 	mockShowWarningMessage,
+	mockDeleteReferenceMarkdown,
 } = vi.hoisted(() => ({
 	mockLoadPlansRegistry: vi.fn(),
 	mockSavePlansRegistry: vi.fn(),
@@ -16,11 +17,16 @@ const {
 	mockShowTextDocument: vi.fn(),
 	mockOpenExternal: vi.fn(),
 	mockShowWarningMessage: vi.fn(),
+	mockDeleteReferenceMarkdown: vi.fn(),
 }));
 
 vi.mock("../../../cli/src/core/SessionTracker.js", () => ({
 	loadPlansRegistry: mockLoadPlansRegistry,
 	savePlansRegistry: mockSavePlansRegistry,
+}));
+
+vi.mock("../../../cli/src/core/references/ReferenceStore.js", () => ({
+	deleteReferenceMarkdown: mockDeleteReferenceMarkdown,
 }));
 
 vi.mock("./PlanService.js", () => ({
@@ -61,7 +67,7 @@ import {
 	detectReferences,
 	openReferenceInBrowser,
 	openReferenceMarkdown,
-	setReferenceIgnored,
+	removeReference,
 } from "./ReferenceService.js";
 
 const fieldVal = (r: ReferenceInfo | undefined, key: string): string | undefined =>
@@ -74,10 +80,8 @@ function makeEntry(overrides: Partial<ReferenceEntry> = {}): ReferenceEntry {
 		title: "Treat referenced Linear issues",
 		url: "https://linear.app/jolliai/issue/PROJ-1528/",
 		sourcePath: "/repo/.jolli/jollimemory/references/linear/PROJ-1528.md",
-		branch: "main",
 		addedAt: "2026-05-13T00:00:00Z",
 		updatedAt: "2026-05-14T06:06:01.123Z",
-		commitHash: null,
 		sourceToolName: "mcp__linear__get_issue",
 		...overrides,
 	};
@@ -104,7 +108,7 @@ beforeEach(() => {
 });
 
 describe("detectReferences", () => {
-	it("returns uncommitted, non-ignored entries on the current branch (all sources)", async () => {
+	it("returns all reference entries across sources", async () => {
 		mockLoadPlansRegistry.mockResolvedValue({
 			version: 1,
 			plans: {},
@@ -156,63 +160,7 @@ describe("detectReferences", () => {
 			mapKey: "jira:KAN-5",
 			title: "Implement Jira adapter",
 			url: "https://example.atlassian.net/browse/KAN-5",
-			commitHash: null,
-			ignored: false,
 		});
-	});
-
-	it("filters out ignored entries", async () => {
-		mockLoadPlansRegistry.mockResolvedValue({
-			version: 1,
-			plans: {},
-			references: { "linear:PROJ-1528": makeEntry({ ignored: true }) },
-		});
-		expect(await detectReferences("/repo")).toHaveLength(0);
-	});
-
-	it("filters out guard entries (contentHashAtCommit set)", async () => {
-		mockLoadPlansRegistry.mockResolvedValue({
-			version: 1,
-			plans: {},
-			references: {
-				"linear:PROJ-1528": makeEntry({
-					contentHashAtCommit: "h",
-					commitHash: "abc",
-				}),
-			},
-		});
-		expect(await detectReferences("/repo")).toHaveLength(0);
-	});
-
-	it("filters out archived snapshots (commitHash set, no contentHashAtCommit)", async () => {
-		mockLoadPlansRegistry.mockResolvedValue({
-			version: 1,
-			plans: {},
-			references: {
-				"linear:PROJ-1528-abc1234": makeEntry({ commitHash: "abc1234" }),
-			},
-		});
-		expect(await detectReferences("/repo")).toHaveLength(0);
-	});
-
-	it("filters out entries on other branches", async () => {
-		mockLoadPlansRegistry.mockResolvedValue({
-			version: 1,
-			plans: {},
-			references: { "linear:PROJ-1528": makeEntry({ branch: "feature-x" }) },
-		});
-		mockGetCurrentBranch.mockReturnValue("main");
-		expect(await detectReferences("/repo")).toHaveLength(0);
-	});
-
-	it("does NOT filter by branch when getCurrentBranch returns null", async () => {
-		mockLoadPlansRegistry.mockResolvedValue({
-			version: 1,
-			plans: {},
-			references: { "linear:PROJ-1528": makeEntry({ branch: "feature-x" }) },
-		});
-		mockGetCurrentBranch.mockReturnValue(null);
-		expect(await detectReferences("/repo")).toHaveLength(1);
 	});
 
 	it("returns empty when references section is missing", async () => {
@@ -464,29 +412,20 @@ describe("detectReferences", () => {
 	});
 });
 
-describe("setReferenceIgnored", () => {
-	it("sets ignored=true on the entry keyed by mapKey", async () => {
+describe("removeReference", () => {
+	it("removes the registry row and deletes the backing markdown", async () => {
+		const entry = makeJiraEntry();
 		mockLoadPlansRegistry.mockResolvedValue({
 			version: 1,
 			plans: {},
-			references: { "jira:KAN-5": makeJiraEntry() },
+			references: { "jira:KAN-5": entry },
 		});
-		await setReferenceIgnored("/repo", "jira:KAN-5", true);
+		await removeReference("/repo", "jira:KAN-5");
+		expect(mockDeleteReferenceMarkdown).toHaveBeenCalledWith(entry.sourcePath);
 		expect(mockSavePlansRegistry).toHaveBeenCalled();
 		const saved = mockSavePlansRegistry.mock.calls[0][0];
 		expect(saved.version).toBe(1);
-		expect(saved.references["jira:KAN-5"].ignored).toBe(true);
-	});
-
-	it("clears ignored when set to false", async () => {
-		mockLoadPlansRegistry.mockResolvedValue({
-			version: 1,
-			plans: {},
-			references: { "jira:KAN-5": makeJiraEntry({ ignored: true }) },
-		});
-		await setReferenceIgnored("/repo", "jira:KAN-5", false);
-		const saved = mockSavePlansRegistry.mock.calls[0][0];
-		expect(saved.references["jira:KAN-5"].ignored).toBeUndefined();
+		expect(saved.references["jira:KAN-5"]).toBeUndefined();
 	});
 
 	it("is a no-op when mapKey is not in the registry", async () => {
@@ -495,14 +434,16 @@ describe("setReferenceIgnored", () => {
 			plans: {},
 			references: {},
 		});
-		await setReferenceIgnored("/repo", "jira:UNKNOWN", true);
+		await removeReference("/repo", "jira:UNKNOWN");
 		expect(mockSavePlansRegistry).not.toHaveBeenCalled();
+		expect(mockDeleteReferenceMarkdown).not.toHaveBeenCalled();
 	});
 
 	it("no-ops when the registry omits the references field entirely (?? {} fallback)", async () => {
 		mockLoadPlansRegistry.mockResolvedValue({ version: 1, plans: {} });
-		await setReferenceIgnored("/repo", "jira:KAN-5", true);
+		await removeReference("/repo", "jira:KAN-5");
 		expect(mockSavePlansRegistry).not.toHaveBeenCalled();
+		expect(mockDeleteReferenceMarkdown).not.toHaveBeenCalled();
 	});
 
 	it("preserves the plans / notes sections on save", async () => {
@@ -513,12 +454,26 @@ describe("setReferenceIgnored", () => {
 			notes,
 			references: { "jira:KAN-5": makeJiraEntry() },
 		});
-		await setReferenceIgnored("/repo", "jira:KAN-5", true);
+		await removeReference("/repo", "jira:KAN-5");
 		const saved = mockSavePlansRegistry.mock.calls[0][0];
 		expect(saved.plans).toEqual({ "plan-1": { slug: "x" } });
 		expect(saved.notes).toEqual(notes);
+		expect(saved.references).toEqual({});
 	});
 
+	it("still removes the registry row when the markdown delete throws", async () => {
+		const entry = makeJiraEntry();
+		mockLoadPlansRegistry.mockResolvedValue({
+			version: 1,
+			plans: {},
+			references: { "jira:KAN-5": entry },
+		});
+		mockDeleteReferenceMarkdown.mockRejectedValueOnce(new Error("EACCES"));
+		await removeReference("/repo", "jira:KAN-5");
+		expect(mockSavePlansRegistry).toHaveBeenCalled();
+		const saved = mockSavePlansRegistry.mock.calls[0][0];
+		expect(saved.references["jira:KAN-5"]).toBeUndefined();
+	});
 });
 
 describe("openReferenceInBrowser — http(s) scheme guard", () => {

--- a/vscode/src/core/ReferenceService.ts
+++ b/vscode/src/core/ReferenceService.ts
@@ -25,6 +25,7 @@ import { readFileSync } from "node:fs";
 import * as vscode from "vscode";
 import {
 	loadPlansRegistry,
+	loadPlansRegistryWithStatus,
 	savePlansRegistry,
 } from "../../../cli/src/core/SessionTracker.js";
 import { deleteReferenceMarkdown } from "../../../cli/src/core/references/ReferenceStore.js";
@@ -49,7 +50,13 @@ export async function detectReferences(
 	cwd: string,
 	sourceFilter?: SourceId,
 ): Promise<ReadonlyArray<ReferenceInfo>> {
-	const registry = await loadPlansRegistry(cwd);
+	// `changed` is true when loadPlansRegistry purged any legacy row/field;
+	// persist the normalised registry once so plans.json is cleaned on first
+	// panel refresh after upgrade (deterministic-writeback migration).
+	const { registry, changed } = await loadPlansRegistryWithStatus(cwd);
+	if (changed) {
+		await savePlansRegistry(registry, cwd);
+	}
 	const references = { ...(registry.references ?? {}) };
 	const result: ReferenceInfo[] = [];
 

--- a/vscode/src/core/ReferenceService.ts
+++ b/vscode/src/core/ReferenceService.ts
@@ -3,10 +3,11 @@
  *
  * Central service for VS Code-side external-reference operations (parallel to
  * NoteService):
- * - Read: detectReferences filters plans.json.references by branch / ignored /
- *   archive guard. Optional `sourceFilter` narrows to one provider.
- * - Mutate: setReferenceIgnored marks/unmarks the ignored flag (mapKey form is
- *   `<source>:<nativeId>` matching the registry key).
+ * - Read: detectReferences returns every plans.json.references row (references
+ *   are deleted at commit time, so each surviving row is active). Optional
+ *   `sourceFilter` narrows to one provider.
+ * - Mutate: removeReference hard-deletes the registry row + backing markdown
+ *   (mapKey form is `<source>:<nativeId>` matching the registry key).
  * - Open: openReferenceInBrowser / openReferenceMarkdown.
  *
  * Reference contents live on disk at
@@ -26,6 +27,7 @@ import {
 	loadPlansRegistry,
 	savePlansRegistry,
 } from "../../../cli/src/core/SessionTracker.js";
+import { deleteReferenceMarkdown } from "../../../cli/src/core/references/ReferenceStore.js";
 import type {
 	PlansRegistry,
 	ReferenceEntry,
@@ -34,17 +36,14 @@ import type {
 } from "../../../cli/src/Types.js";
 import type { ReferenceInfo } from "../Types.js";
 import { log } from "../util/Logger.js";
-import { getCurrentBranch } from "./PlanService.js";
 
 /**
- * Reads plans.json and returns the filtered, sorted list of ReferenceInfo for
- * the multi-source panel. Optional `sourceFilter` narrows to one provider.
+ * Reads plans.json and returns the sorted list of ReferenceInfo for the
+ * multi-source panel. Optional `sourceFilter` narrows to one provider.
  *
- * Filter (matches detectUncommittedReferenceIds on the CLI side):
- *   - branch matches (or git is unavailable)
- *   - !ignored
- *   - commitHash === null (uncommitted)
- *   - !contentHashAtCommit (not a guard or archived-snapshot copy)
+ * No filtering: a reference is removed from the registry when its commit
+ * lands, so every row in `plans.json.references` is an active, uncommitted
+ * reference (matches `getReferenceEntriesForBranch` on the CLI side).
  */
 export async function detectReferences(
 	cwd: string,
@@ -52,13 +51,11 @@ export async function detectReferences(
 ): Promise<ReadonlyArray<ReferenceInfo>> {
 	const registry = await loadPlansRegistry(cwd);
 	const references = { ...(registry.references ?? {}) };
-	const branch = getCurrentBranch(cwd);
 	const result: ReferenceInfo[] = [];
 
 	for (const [mapKey, entry] of Object.entries(references)) {
 		if (sourceFilter !== undefined && entry.source !== sourceFilter) continue;
-		const info = toReferenceInfo(mapKey, entry, branch);
-		if (info) result.push(info);
+		result.push(toReferenceInfo(mapKey, entry));
 	}
 
 	result.sort(
@@ -73,29 +70,39 @@ export async function detectReferences(
 }
 
 /**
- * Sets or clears the ignored flag on a reference entry, keyed by mapKey
- * (`<source>:<nativeId>` or `<source>:<nativeId>-<shortHash>` archive form).
+ * Hard-removes a reference, keyed by mapKey (`<source>:<nativeId>`): deletes the
+ * registry row AND the backing
+ * `.jolli/jollimemory/references/<source>/<key>.md` file.
  *
- * The registry's plans / notes section is preserved verbatim.
+ * Reference markdown always lives inside the per-project `.jolli/jollimemory/`
+ * directory, so the file is always safe to delete — no internal/external check
+ * needed (contrast `PlanService.removePlan`, whose source files are usually
+ * external). Idempotent: an unknown mapKey is a no-op, and a missing `.md` is
+ * tolerated (`deleteReferenceMarkdown` uses `force`).
+ *
+ * Allows revival: removal leaves no tombstone, so a later re-reference of the
+ * same entity is re-discovered and re-inserted. The registry's plans / notes
+ * section is preserved verbatim.
  */
-export async function setReferenceIgnored(
-	cwd: string,
-	mapKey: string,
-	ignored: boolean,
-): Promise<void> {
+export async function removeReference(cwd: string, mapKey: string): Promise<void> {
 	const registry = await loadPlansRegistry(cwd);
 	const existing = { ...(registry.references ?? {}) };
 	const entry = existing[mapKey];
 	if (!entry) return;
-	const references: Record<string, ReferenceEntry> = {
-		...existing,
-		[mapKey]: { ...entry, ignored: ignored || undefined },
-	};
+	// Best-effort file delete — a permission/lock error (Windows EPERM/EBUSY)
+	// must not strand the registry row; mirrors PlanService.removePlan /
+	// NoteService.removeNote. deleteReferenceMarkdown already tolerates ENOENT.
+	try {
+		await deleteReferenceMarkdown(entry.sourcePath);
+	} catch {
+		/* registry row is still removed below */
+	}
+	delete existing[mapKey];
 	const out: PlansRegistry = {
 		version: 1,
 		plans: registry.plans,
 		...(registry.notes !== undefined ? { notes: registry.notes } : {}),
-		references,
+		references: existing,
 	};
 	await savePlansRegistry(out, cwd);
 }
@@ -132,18 +139,9 @@ export async function openReferenceMarkdown(info: ReferenceInfo): Promise<void> 
 
 // ─── Internal helpers ────────────────────────────────────────────────────────
 
-function toReferenceInfo(
-	mapKey: string,
-	entry: ReferenceEntry,
-	currentBranch: string | null,
-): ReferenceInfo | null {
-	if (currentBranch && entry.branch !== currentBranch) return null;
-	if (entry.ignored) return null;
-	if (entry.commitHash !== null) return null;
-	/* v8 ignore start -- defensive: commitHash=null with contentHashAtCommit set is an invariant violation (archive always sets both); guard kept for total-function semantics. */
-	if (entry.contentHashAtCommit !== undefined) return null;
-	/* v8 ignore stop */
-
+function toReferenceInfo(mapKey: string, entry: ReferenceEntry): ReferenceInfo {
+	// Every plans.json.references row is an uncommitted active reference
+	// (commit deletes the entry), so there is no committed / guard state to filter.
 	const frontmatter = readFrontmatter(entry.sourcePath);
 
 	return {
@@ -158,18 +156,9 @@ function toReferenceInfo(
 		...(frontmatter.description !== undefined
 			? { description: frontmatter.description }
 			: {}),
-		branch: entry.branch,
 		addedAt: entry.addedAt,
 		updatedAt: entry.updatedAt,
 		lastModified: entry.updatedAt,
-		commitHash: entry.commitHash,
-		// `entry.contentHashAtCommit !== undefined` is unreachable here: the
-		// guard above already returned null for any entry with a defined
-		// contentHashAtCommit. The spread is kept for symmetry with other
-		// optional ReferenceInfo fields, but its truthy arm cannot fire.
-		/* v8 ignore next -- the contentHashAtCommit guard above ensures it is undefined by this point. */
-		...(entry.contentHashAtCommit !== undefined ? { contentHashAtCommit: entry.contentHashAtCommit } : {}),
-		ignored: entry.ignored ?? false,
 		sourceToolName: entry.sourceToolName,
 	};
 }

--- a/vscode/src/views/SidebarScriptBuilder.ts
+++ b/vscode/src/views/SidebarScriptBuilder.ts
@@ -3219,7 +3219,7 @@ export function buildSidebarScript(): string {
     if (isReference) {
       return el('span', { className: 'inline-actions' }, [
         attachTextTip(el('button', { type: 'button', className: 'iconbtn', 'data-inline': 'open-reference', 'data-id': item.id, text: '↗' }), 'Open in browser'),
-        attachTextTip(el('button', { type: 'button', className: 'iconbtn', 'data-inline': 'ignore-reference', 'data-id': item.id, text: '🗑' }), 'Ignore'),
+        attachTextTip(el('button', { type: 'button', className: 'iconbtn', 'data-inline': 'ignore-reference', 'data-id': item.id, text: '🗑' }), 'Remove'),
       ]);
     }
     if (isFile) {
@@ -3685,7 +3685,7 @@ export function buildSidebarScript(): string {
         { label: 'Open in browser', rawMessage: { type: 'branch:openReference',         mapKey: id } },
         { label: 'Open Markdown',   rawMessage: { type: 'branch:openReferenceMarkdown', mapKey: id } },
         { separator: true },
-        { label: 'Ignore',          rawMessage: { type: 'branch:ignoreReference',       mapKey: id } },
+        { label: 'Remove',          rawMessage: { type: 'branch:ignoreReference',       mapKey: id } },
       ]);
       return;
     }

--- a/vscode/src/views/SummaryWebviewPanel.handlePush.test.ts
+++ b/vscode/src/views/SummaryWebviewPanel.handlePush.test.ts
@@ -175,27 +175,23 @@ vi.mock("../../package.json", () => ({ version: "0.90.0" }));
 const {
 	mockListAvailablePlans,
 	mockArchivePlanForCommit,
-	mockUnassociatePlanFromCommit,
-	mockIgnorePlan,
+	mockRemovePlan,
 } = vi.hoisted(() => ({
 	mockListAvailablePlans: vi.fn().mockReturnValue([]),
 	mockArchivePlanForCommit: vi.fn().mockResolvedValue(null),
-	mockUnassociatePlanFromCommit: vi.fn().mockResolvedValue(undefined),
-	mockIgnorePlan: vi.fn().mockResolvedValue(undefined),
+	mockRemovePlan: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock("../core/PlanService.js", () => ({
 	listAvailablePlans: mockListAvailablePlans,
 	archivePlanForCommit: mockArchivePlanForCommit,
-	unassociatePlanFromCommit: mockUnassociatePlanFromCommit,
-	ignorePlan: mockIgnorePlan,
+	removePlan: mockRemovePlan,
 }));
 
 const {
 	mockSaveNote,
 	mockArchiveNoteForCommit,
-	mockUnassociateNoteFromCommit,
-	mockIgnoreNote,
+	mockRemoveNote,
 } = vi.hoisted(() => ({
 	mockSaveNote: vi.fn().mockResolvedValue({
 		id: "note-1",
@@ -203,15 +199,13 @@ const {
 		format: "snippet",
 	}),
 	mockArchiveNoteForCommit: vi.fn().mockResolvedValue(null),
-	mockUnassociateNoteFromCommit: vi.fn().mockResolvedValue(undefined),
-	mockIgnoreNote: vi.fn().mockResolvedValue(undefined),
+	mockRemoveNote: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock("../core/NoteService.js", () => ({
 	saveNote: mockSaveNote,
 	archiveNoteForCommit: mockArchiveNoteForCommit,
-	unassociateNoteFromCommit: mockUnassociateNoteFromCommit,
-	ignoreNote: mockIgnoreNote,
+	removeNote: mockRemoveNote,
 }));
 
 const {

--- a/vscode/src/views/SummaryWebviewPanel.test.ts
+++ b/vscode/src/views/SummaryWebviewPanel.test.ts
@@ -252,27 +252,23 @@ vi.mock("../../package.json", () => ({ version: "0.90.0" }));
 const {
 	mockListAvailablePlans,
 	mockArchivePlanForCommit,
-	mockUnassociatePlanFromCommit,
-	mockIgnorePlan,
+	mockRemovePlan,
 } = vi.hoisted(() => ({
 	mockListAvailablePlans: vi.fn().mockReturnValue([]),
 	mockArchivePlanForCommit: vi.fn().mockResolvedValue(null),
-	mockUnassociatePlanFromCommit: vi.fn().mockResolvedValue(undefined),
-	mockIgnorePlan: vi.fn().mockResolvedValue(undefined),
+	mockRemovePlan: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock("../core/PlanService.js", () => ({
 	listAvailablePlans: mockListAvailablePlans,
 	archivePlanForCommit: mockArchivePlanForCommit,
-	unassociatePlanFromCommit: mockUnassociatePlanFromCommit,
-	ignorePlan: mockIgnorePlan,
+	removePlan: mockRemovePlan,
 }));
 
 const {
 	mockSaveNote,
 	mockArchiveNoteForCommit,
-	mockUnassociateNoteFromCommit,
-	mockIgnoreNote,
+	mockRemoveNote,
 } = vi.hoisted(() => ({
 	mockSaveNote: vi.fn().mockResolvedValue({
 		id: "note-1",
@@ -280,23 +276,21 @@ const {
 		format: "snippet",
 	}),
 	mockArchiveNoteForCommit: vi.fn().mockResolvedValue(null),
-	mockUnassociateNoteFromCommit: vi.fn().mockResolvedValue(undefined),
-	mockIgnoreNote: vi.fn().mockResolvedValue(undefined),
+	mockRemoveNote: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock("../core/NoteService.js", () => ({
 	saveNote: mockSaveNote,
 	archiveNoteForCommit: mockArchiveNoteForCommit,
-	unassociateNoteFromCommit: mockUnassociateNoteFromCommit,
-	ignoreNote: mockIgnoreNote,
+	removeNote: mockRemoveNote,
 }));
 
-const { mockSetReferenceIgnored } = vi.hoisted(() => ({
-	mockSetReferenceIgnored: vi.fn().mockResolvedValue(undefined),
+const { mockRemoveReference } = vi.hoisted(() => ({
+	mockRemoveReference: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock("../core/ReferenceService.js", () => ({
-	setReferenceIgnored: mockSetReferenceIgnored,
+	removeReference: mockRemoveReference,
 }));
 
 const {
@@ -3235,12 +3229,9 @@ describe("SummaryWebviewPanel", () => {
 				dispatch({ command: "removePlan", slug: "plan-a", title: "Plan A" });
 				await flushPromises();
 
-				expect(mockUnassociatePlanFromCommit).toHaveBeenCalledWith(
-					"plan-a",
-					workspaceRoot,
-				);
-				// Must also mark as ignored so the plan doesn't reappear in the sidebar
-				expect(mockIgnorePlan).toHaveBeenCalledWith("plan-a", workspaceRoot);
+				// Hard-removes the archived plans.json row (the CommitSummary
+				// reference was dropped above); no unassociate + ignore steps.
+				expect(mockRemovePlan).toHaveBeenCalledWith("plan-a", workspaceRoot);
 				expect(mockStoreSummary).toHaveBeenCalledWith(
 					expect.objectContaining({
 						plans: [expect.objectContaining({ slug: "plan-b" })],
@@ -3298,7 +3289,7 @@ describe("SummaryWebviewPanel", () => {
 				dispatch({ command: "removePlan", slug: "plan-a", title: "Plan A" });
 				await flushPromises();
 
-				expect(mockUnassociatePlanFromCommit).not.toHaveBeenCalled();
+				expect(mockRemovePlan).not.toHaveBeenCalled();
 			});
 		});
 
@@ -6194,7 +6185,7 @@ describe("SummaryWebviewPanel", () => {
 				dispatch({ command: "saveSnippet", title: "Fail", content: "content" });
 				await flushPromises();
 
-				expect(mockIgnoreNote).toHaveBeenCalledWith("snip-fail", workspaceRoot);
+				expect(mockRemoveNote).toHaveBeenCalledWith("snip-fail", workspaceRoot);
 				expect(showErrorMessage).toHaveBeenCalledWith(
 					"Failed to save snippet — archive failed.",
 				);
@@ -6339,7 +6330,7 @@ describe("SummaryWebviewPanel", () => {
 				dispatch({ command: "addMarkdownNote" });
 				await flushPromises();
 
-				expect(mockIgnoreNote).toHaveBeenCalledWith("md-fail", workspaceRoot);
+				expect(mockRemoveNote).toHaveBeenCalledWith("md-fail", workspaceRoot);
 				expect(showErrorMessage).toHaveBeenCalledWith(
 					expect.stringContaining("archive failed"),
 				);
@@ -6945,12 +6936,9 @@ describe("SummaryWebviewPanel", () => {
 					expect.objectContaining({ modal: true }),
 					"Remove",
 				);
-				expect(mockUnassociateNoteFromCommit).toHaveBeenCalledWith(
-					"note-a",
-					workspaceRoot,
-				);
-				// Must also mark as ignored so the note doesn't reappear in the sidebar
-				expect(mockIgnoreNote).toHaveBeenCalledWith("note-a", workspaceRoot);
+				// Hard-removes the archived plans.json row (the CommitSummary
+				// reference was dropped above); no unassociate + ignore steps.
+				expect(mockRemoveNote).toHaveBeenCalledWith("note-a", workspaceRoot);
 				expect(mockStoreSummary).toHaveBeenCalledWith(
 					expect.objectContaining({
 						notes: [expect.objectContaining({ id: "note-b" })],
@@ -7008,7 +6996,7 @@ describe("SummaryWebviewPanel", () => {
 				dispatch({ command: "removeNote", id: "note-a", title: "Note A" });
 				await flushPromises();
 
-				expect(mockUnassociateNoteFromCommit).not.toHaveBeenCalled();
+				expect(mockRemoveNote).not.toHaveBeenCalled();
 				expect(mockStoreSummary).not.toHaveBeenCalled();
 			});
 
@@ -7305,10 +7293,9 @@ describe("SummaryWebviewPanel", () => {
 					expect.objectContaining({ modal: true }),
 					"Remove",
 				);
-				expect(mockSetReferenceIgnored).toHaveBeenCalledWith(
+				expect(mockRemoveReference).toHaveBeenCalledWith(
 					workspaceRoot,
 					"linear:PROJ-1-aaaaaaaa",
-					true,
 				);
 				expect(mockStoreSummary).toHaveBeenCalledWith(
 					expect.objectContaining({
@@ -7378,7 +7365,7 @@ describe("SummaryWebviewPanel", () => {
 				});
 				await flushPromises();
 
-				expect(mockSetReferenceIgnored).not.toHaveBeenCalled();
+				expect(mockRemoveReference).not.toHaveBeenCalled();
 				expect(mockStoreSummary).not.toHaveBeenCalled();
 			});
 
@@ -7396,7 +7383,7 @@ describe("SummaryWebviewPanel", () => {
 				await flushPromises();
 
 				expect(showWarningMessage).not.toHaveBeenCalled();
-				expect(mockSetReferenceIgnored).not.toHaveBeenCalled();
+				expect(mockRemoveReference).not.toHaveBeenCalled();
 			});
 
 			it("returns early when archivedKey not in summary.references", async () => {
@@ -7425,7 +7412,7 @@ describe("SummaryWebviewPanel", () => {
 				await flushPromises();
 
 				expect(showWarningMessage).not.toHaveBeenCalled();
-				expect(mockSetReferenceIgnored).not.toHaveBeenCalled();
+				expect(mockRemoveReference).not.toHaveBeenCalled();
 			});
 
 			it("non-Linear source: dissociates a Jira reference uniformly via the same handler", async () => {
@@ -7453,10 +7440,9 @@ describe("SummaryWebviewPanel", () => {
 				});
 				await flushPromises();
 
-				expect(mockSetReferenceIgnored).toHaveBeenCalledWith(
+				expect(mockRemoveReference).toHaveBeenCalledWith(
 					workspaceRoot,
 					"jira:KAN-5-aaaa1111",
-					true,
 				);
 				expect(mockStoreSummary).toHaveBeenCalledWith(
 					expect.objectContaining({ references: undefined }),

--- a/vscode/src/views/SummaryWebviewPanel.test.ts
+++ b/vscode/src/views/SummaryWebviewPanel.test.ts
@@ -3231,7 +3231,7 @@ describe("SummaryWebviewPanel", () => {
 
 				// Hard-removes the archived plans.json row (the CommitSummary
 				// reference was dropped above); no unassociate + ignore steps.
-				expect(mockRemovePlan).toHaveBeenCalledWith("plan-a", workspaceRoot);
+				expect(mockRemovePlan).toHaveBeenCalledWith("plan-a", workspaceRoot, expect.any(String));
 				expect(mockStoreSummary).toHaveBeenCalledWith(
 					expect.objectContaining({
 						plans: [expect.objectContaining({ slug: "plan-b" })],
@@ -3246,6 +3246,27 @@ describe("SummaryWebviewPanel", () => {
 				// would fall back to OrphanBranchStorage and silently no-op).
 				expect(stubBridge.cleanupVisiblePlanArtifact).toHaveBeenCalledWith(
 					"plan-a",
+					expect.any(String),
+				);
+			});
+
+			it("passes the raw archived slug to removePlan + cleanup (base resolution is in the service)", async () => {
+				// The webview forwards the CommitSummary's raw `<base>-<shortHash>` slug
+				// unchanged; removePlan resolves the bare-key guard internally (so
+				// squash/rebase slugs work without mis-stripping). Visible-artifact
+				// cleanup also uses the archived id (the mirror is plan--<slug>.md).
+				showWarningMessage.mockResolvedValue("Remove");
+				const dispatch = await setupPanel({
+					commitHash: "abcdef1234567890",
+					plans: [{ slug: "my-plan-abcdef12", title: "My Plan", addedAt: "", updatedAt: "" }],
+				});
+
+				dispatch({ command: "removePlan", slug: "my-plan-abcdef12", title: "My Plan" });
+				await flushPromises();
+
+				expect(mockRemovePlan).toHaveBeenCalledWith("my-plan-abcdef12", workspaceRoot, "abcdef1234567890");
+				expect(stubBridge.cleanupVisiblePlanArtifact).toHaveBeenCalledWith(
+					"my-plan-abcdef12",
 					expect.any(String),
 				);
 			});
@@ -6907,6 +6928,31 @@ describe("SummaryWebviewPanel", () => {
 		// ── removeNote ───────────────────────────────────────────────────────
 
 		describe("removeNote", () => {
+			it("passes the raw archived id to removeNote + cleanup (base resolution is in the service)", async () => {
+				showWarningMessage.mockResolvedValue("Remove");
+				const dispatch = await setupPanel({
+					commitHash: "abcdef1234567890",
+					notes: [
+						{
+							id: "my-note-abcdef12",
+							title: "My Note",
+							format: "markdown" as const,
+							addedAt: "",
+							updatedAt: "",
+						},
+					],
+				});
+
+				dispatch({ command: "removeNote", id: "my-note-abcdef12", title: "My Note" });
+				await flushPromises();
+
+				expect(mockRemoveNote).toHaveBeenCalledWith("my-note-abcdef12", workspaceRoot, "abcdef1234567890");
+				expect(stubBridge.cleanupVisibleNoteArtifact).toHaveBeenCalledWith(
+					"my-note-abcdef12",
+					expect.any(String),
+				);
+			});
+
 			it("confirms and removes note from commit", async () => {
 				showWarningMessage.mockResolvedValue("Remove");
 				const dispatch = await setupPanel({
@@ -6938,7 +6984,7 @@ describe("SummaryWebviewPanel", () => {
 				);
 				// Hard-removes the archived plans.json row (the CommitSummary
 				// reference was dropped above); no unassociate + ignore steps.
-				expect(mockRemoveNote).toHaveBeenCalledWith("note-a", workspaceRoot);
+				expect(mockRemoveNote).toHaveBeenCalledWith("note-a", workspaceRoot, expect.any(String));
 				expect(mockStoreSummary).toHaveBeenCalledWith(
 					expect.objectContaining({
 						notes: [expect.objectContaining({ id: "note-b" })],
@@ -7293,10 +7339,10 @@ describe("SummaryWebviewPanel", () => {
 					expect.objectContaining({ modal: true }),
 					"Remove",
 				);
-				expect(mockRemoveReference).toHaveBeenCalledWith(
-					workspaceRoot,
-					"linear:PROJ-1-aaaaaaaa",
-				);
+				// Dissociation only drops the entry from CommitSummary.references;
+				// under the commit-deletes-entry model there is no plans.json row
+				// or local markdown to hard-remove here.
+				expect(mockRemoveReference).not.toHaveBeenCalled();
 				expect(mockStoreSummary).toHaveBeenCalledWith(
 					expect.objectContaining({
 						references: [
@@ -7440,10 +7486,7 @@ describe("SummaryWebviewPanel", () => {
 				});
 				await flushPromises();
 
-				expect(mockRemoveReference).toHaveBeenCalledWith(
-					workspaceRoot,
-					"jira:KAN-5-aaaa1111",
-				);
+				expect(mockRemoveReference).not.toHaveBeenCalled();
 				expect(mockStoreSummary).toHaveBeenCalledWith(
 					expect.objectContaining({ references: undefined }),
 					workspaceRoot,

--- a/vscode/src/views/SummaryWebviewPanel.ts
+++ b/vscode/src/views/SummaryWebviewPanel.ts
@@ -47,16 +47,11 @@ import type {
 	StoredTranscript,
 } from "../../../cli/src/Types.js";
 import { CURRENT_SCHEMA_VERSION } from "../../../cli/src/Types.js";
-import { setReferenceIgnored } from "../core/ReferenceService.js";
+import { removeReference } from "../core/ReferenceService.js";
+import { removeNote, saveNote } from "../core/NoteService.js";
 import {
-	ignoreNote,
-	saveNote,
-	unassociateNoteFromCommit,
-} from "../core/NoteService.js";
-import {
-	ignorePlan,
 	listAvailablePlans,
-	unassociatePlanFromCommit,
+	removePlan,
 } from "../core/PlanService.js";
 import type { JolliMemoryBridge } from "../JolliMemoryBridge.js";
 import {
@@ -2528,12 +2523,10 @@ export class SummaryWebviewPanel {
 		await this.bridge.storeSummary(updatedSummary, true);
 		this.currentSummary = updatedSummary;
 
-		// Clear commitHash in plans.json
-
-		await unassociatePlanFromCommit(slug, this.workspaceRoot);
-		// Mark as ignored so the plan doesn't reappear in the sidebar on next refresh
-		// (unassociate only sets commitHash=null — the entry would still be visible)
-		await ignorePlan(slug, this.workspaceRoot);
+		// Hard-remove the archived plans.json row (the CommitSummary reference was
+		// already dropped above). No `ignored` tombstone — the plan can be
+		// re-discovered / re-associated later.
+		await removePlan(slug, this.workspaceRoot);
 
 		// Remove the visible <branchFolder>/plan--<slug>.md in dual-write/folder
 		// modes so the Memory Bank tree view stops showing a ghost file. Goes
@@ -2645,8 +2638,8 @@ export class SummaryWebviewPanel {
 			summary.commitHash,
 		);
 		if (!noteRef) {
-			// Clean up the orphaned note entry so it doesn't linger in the sidebar
-			await ignoreNote(noteInfo.id, this.workspaceRoot);
+			// Hard-remove the orphaned note entry so it doesn't linger in the sidebar
+			await removeNote(noteInfo.id, this.workspaceRoot);
 			vscode.window.showErrorMessage(
 				"Failed to add markdown note — archive failed.",
 			);
@@ -2691,7 +2684,7 @@ export class SummaryWebviewPanel {
 			summary.commitHash,
 		);
 		if (!noteRef) {
-			await ignoreNote(noteInfo.id, this.workspaceRoot);
+			await removeNote(noteInfo.id, this.workspaceRoot);
 			vscode.window.showErrorMessage(
 				"Failed to save snippet — archive failed.",
 			);
@@ -2822,10 +2815,10 @@ export class SummaryWebviewPanel {
 		};
 		await this.bridge.storeSummary(updatedSummary, true);
 		this.currentSummary = updatedSummary;
-		await unassociateNoteFromCommit(id, this.workspaceRoot);
-		// Mark as ignored so the note doesn't reappear in the sidebar on next refresh
-		// (unassociate only sets commitHash=null — the entry would still be visible)
-		await ignoreNote(id, this.workspaceRoot);
+		// Hard-remove the archived plans.json row (the CommitSummary reference was
+		// already dropped above). No `ignored` tombstone — the note can be
+		// re-associated later.
+		await removeNote(id, this.workspaceRoot);
 
 		// Remove the visible <branchFolder>/note--<id>.md in dual-write/folder
 		// modes so the Memory Bank tree view stops showing a ghost file. Goes
@@ -3018,15 +3011,13 @@ export class SummaryWebviewPanel {
 		await this.bridge.storeSummary(updatedSummary, true);
 		this.currentSummary = updatedSummary;
 
-		// Hide from the sidebar panel: mark the archived map key ignored.
-		// Intentionally single-key. The old Linear-only path also ignored the bare
-		// ticketId guard entry, so a removed reference stayed hidden forever even
-		// if re-referenced. We deliberately diverge: only the archived snapshot key
-		// is ignored, NOT the bare `<source>:<nativeId>` guard. A later re-reference
-		// whose content changed (guard-hash mismatch) is allowed to re-surface as a
-		// fresh uncommitted reference — removal hides the current snapshot, it does
-		// not permanently blacklist the ticket.
-		await setReferenceIgnored(this.workspaceRoot, archivedKey, true);
+		// Hard-remove the archived snapshot row + its backing markdown, keyed by the
+		// archived map key. Intentionally single-key: only the archived snapshot
+		// (`<source>:<nativeId>-<shortHash>`) is removed, NOT the bare
+		// `<source>:<nativeId>` guard. With no `ignored` tombstone, a later
+		// re-reference of the same entity is re-discovered as a fresh uncommitted
+		// reference — removal deletes the current snapshot, it does not blacklist.
+		await removeReference(this.workspaceRoot, archivedKey);
 
 		this.update(updatedSummary);
 	}

--- a/vscode/src/views/SummaryWebviewPanel.ts
+++ b/vscode/src/views/SummaryWebviewPanel.ts
@@ -47,7 +47,6 @@ import type {
 	StoredTranscript,
 } from "../../../cli/src/Types.js";
 import { CURRENT_SCHEMA_VERSION } from "../../../cli/src/Types.js";
-import { removeReference } from "../core/ReferenceService.js";
 import { removeNote, saveNote } from "../core/NoteService.js";
 import {
 	listAvailablePlans,
@@ -290,6 +289,7 @@ const REGENERATE_SAFE_COMMANDS: ReadonlySet<WebviewMessage["command"]> = new Set
 function isRegenerateSafeCommand(command: WebviewMessage["command"]): boolean {
 	return REGENERATE_SAFE_COMMANDS.has(command);
 }
+
 
 // Single source of truth for Create/Update PR body assembly. Branch-first
 // three-tier selection:
@@ -2523,10 +2523,12 @@ export class SummaryWebviewPanel {
 		await this.bridge.storeSummary(updatedSummary, true);
 		this.currentSummary = updatedSummary;
 
-		// Hard-remove the archived plans.json row (the CommitSummary reference was
-		// already dropped above). No `ignored` tombstone — the plan can be
-		// re-discovered / re-associated later.
-		await removePlan(slug, this.workspaceRoot);
+		// Dissociate from THIS commit: removePlan resolves the archive base
+		// internally, but only deletes the base guard if it still belongs to this
+		// commit (`expectedCommitHash`) — so removing an old summary's reference
+		// never wipes a base row that has since been revived to a live plan or
+		// re-committed elsewhere. No `ignored` tombstone — re-associable later.
+		await removePlan(slug, this.workspaceRoot, summary.commitHash ?? undefined);
 
 		// Remove the visible <branchFolder>/plan--<slug>.md in dual-write/folder
 		// modes so the Memory Bank tree view stops showing a ghost file. Goes
@@ -2815,10 +2817,11 @@ export class SummaryWebviewPanel {
 		};
 		await this.bridge.storeSummary(updatedSummary, true);
 		this.currentSummary = updatedSummary;
-		// Hard-remove the archived plans.json row (the CommitSummary reference was
-		// already dropped above). No `ignored` tombstone — the note can be
-		// re-associated later.
-		await removeNote(id, this.workspaceRoot);
+		// Dissociate from THIS commit: removeNote resolves the archive base but only
+		// deletes the base guard if it still belongs to this commit
+		// (`expectedCommitHash`), so removing an old summary's reference never wipes
+		// a since-revived/re-committed live note. No `ignored` tombstone.
+		await removeNote(id, this.workspaceRoot, summary.commitHash ?? undefined);
 
 		// Remove the visible <branchFolder>/note--<id>.md in dual-write/folder
 		// modes so the Memory Bank tree view stops showing a ghost file. Goes
@@ -3011,13 +3014,12 @@ export class SummaryWebviewPanel {
 		await this.bridge.storeSummary(updatedSummary, true);
 		this.currentSummary = updatedSummary;
 
-		// Hard-remove the archived snapshot row + its backing markdown, keyed by the
-		// archived map key. Intentionally single-key: only the archived snapshot
-		// (`<source>:<nativeId>-<shortHash>`) is removed, NOT the bare
-		// `<source>:<nativeId>` guard. With no `ignored` tombstone, a later
-		// re-reference of the same entity is re-discovered as a fresh uncommitted
-		// reference — removal deletes the current snapshot, it does not blacklist.
-		await removeReference(this.workspaceRoot, archivedKey);
+		// Dissociation is complete once the entry is dropped from the commit's
+		// CommitSummary.references (above). Under the commit-deletes-entry model
+		// (§13), a committed reference has no plans.json row and no local `.md`
+		// (both removed at association time), so there is nothing else to delete
+		// here. A later re-reference of the same entity is re-discovered as a
+		// fresh uncommitted reference — dissociation does not blacklist.
 
 		this.update(updatedSummary);
 	}


### PR DESCRIPTION
<!-- jollimemory-summary-start -->
## Commits in this PR (2)

1. Replace soft-delete with hard-remove and simplify registry model (`7f3369c`)
2. Harden registry load and reference lifecycle against legacy data loss (`fb6bd9c`)

## Quick recap (2)

### Commit 1 of 2: Replace soft-delete with hard-remove and simplify registry model (`7f3369c`)

The registry data model for plans, notes, and references was substantially simplified by removing three categories of redundant fields. Per-entry branch scoping was eliminated because each git worktree already operates on its own isolated registry file, making the field purely duplicative. The ignored flag was removed as a direct consequence of replacing soft-delete with hard-delete semantics. For references specifically, the commit-time behavior changed from preserving a guard row to deleting the entry entirely, since references are read-only snapshots with no use for the revival mechanism that plans and notes rely on. Per-commit archive snapshot rows were also discontinued for all three entity types, as the orphan-branch snapshot and commit summary already served as the authoritative historical record. The net effect is a significantly leaner registry schema with fewer filtering code paths across the codebase.

Plans, notes, and references can now be fully removed and later re-discovered through normal usage. Previously, removing a tracked item from the panel only hid it behind an internal flag, permanently blocking the same entity from reappearing even when re-referenced in a new conversation. The removal operation now deletes the tracking entry entirely while preserving user-owned files — only internally-managed files like reference snapshots are cleaned up from disk. The commit-detail dissociation workflow was simplified in tandem, collapsing a two-step sequence into a single operation that eliminates an intermediate state where orphaned entries could be stranded. User-facing labels were unified from "Ignore" to "Remove" across the command palette, sidebar menu, and toolbar tooltip to accurately reflect the destructive nature of the operation.

Discovery cursors for plans and references were split into a dedicated file with a one-shot migration from legacy prefixed keys. The migration uses minimum-value folding to ensure no unprocessed transcript lines are skipped, and the new design uses a single merged cursor per transcript whose position is set by the reference scan. The test suite was comprehensively updated across roughly fifteen files to match the simplified data model, with deleted filter tests, rewritten fixtures, and new cursor mocks reflecting the changed semantics.

### Commit 2 of 2: Harden registry load and reference lifecycle against legacy data loss (`fb6bd9c`)

The plans registry now automatically purges leftover data from the previous soft-delete model whenever it is loaded. Previously hidden items — plans, notes, and external references that a user had removed from the sidebar — were still stored in the registry file. After the old filtering logic was removed in an earlier release, those items silently reappeared in the Plans & Notes panel on the next extension reload. The first panel refresh after upgrading now strips every orphaned row and dead field from the registry file and writes the cleaned result back immediately. Users who had accumulated soft-deleted entries will see them disappear as expected, and the session-start hook also filters out stale plans so they never briefly flash as active context. A code-review-driven fix closed a subtle vector where active ticket references ending in certain digit patterns could have been mistakenly classified as archived rows and silently removed; detection now relies on structural field markers that only archived rows carry.

A critical data-loss scenario during reference archival was also fixed. When references were committed, the local copy was previously destroyed before the remote snapshot was confirmed written. A failed remote write would permanently lose the reference with no recovery path. References are now preserved locally until the remote write succeeds, and a failure simply leaves the reference in place for the next commit to pick up again. Both the main commit pipeline and the amend path follow the same write-ahead contract through a shared finalize step.

The plan and note dissociation flow on the commit detail page was corrected as well. When a user removed a plan or note from a commit, the operation appeared to succeed but silently failed to delete the underlying registry entry because it targeted an archived identifier rather than the base key. The detail page now correctly translates the archived identifier back to the base key before deletion while still using the full identifier for visible-file cleanup. Dedicated regression tests exercise the exact failure modes for both the reference archival and dissociation bugs.

## E2E Test (4)
<details>
<summary><strong>1. [7f3369c] Removing a plan from the sidebar permanently deletes it and allows re-discovery</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a project open in VS Code with the Jolli Memory extension active. Have at least one plan visible in the PLANS panel (trigger one by having an AI conversation that references a plan file).

**Steps:**
1. Open VS Code and look at the Jolli Memory sidebar. Note a plan listed in the PLANS panel.
2. Right-click on that plan entry and choose "Remove" from the context menu.
3. Verify the plan disappears from the PLANS panel immediately.
4. Start a new AI conversation that references the same plan topic or file again.
5. After the conversation processes, check the PLANS panel to see if the plan reappears.

**Expected Results:**
- After step 2, the plan is completely gone from the PLANS panel (no greyed-out or hidden entry remains).
- After step 4-5, the plan reappears in the PLANS panel as a fresh entry, proving it was not permanently blocked from re-discovery.

</blockquote>
</details>
<details>
<summary><strong>2. [7f3369c] Removing a reference shows &quot;Remove&quot; label and deletes the entry</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a project open in VS Code with the Jolli Memory extension active. Have at least one external reference (such as a Linear issue) visible in the sidebar's references panel.

**Steps:**
1. Open VS Code and look at the Jolli Memory sidebar. Find a reference entry in the references panel.
2. Hover over the reference entry and look at the trash-can icon tooltip.
3. Verify the tooltip says "Remove" (not "Ignore").
4. Open the VS Code Command Palette and search for the reference removal command. Verify it is labeled "Remove Reference" (not "Ignore Reference").
5. Click the trash-can button on the reference entry to remove it.
6. Verify the reference disappears from the panel entirely.

**Expected Results:**
- The trash-can button tooltip reads "Remove" instead of "Ignore".
- The command palette entry reads "Remove Reference" instead of "Ignore Reference".
- After clicking the trash-can button, the reference is completely removed from the panel with no leftover hidden or greyed-out row.

</blockquote>
</details>
<details>
<summary><strong>3. [7f3369c] Dissociating a plan or note from a commit detail view removes it cleanly</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a project with at least one past commit that has an associated plan or note visible in the Jolli Memory commit detail view.

**Steps:**
1. Open VS Code and navigate to the Jolli Memory sidebar.
2. Click on a past commit summary to open its detail view.
3. Find a plan or note listed as associated with that commit.
4. Click the dissociate or remove button next to that plan or note.
5. Verify the plan or note is removed from the commit detail view.
6. Check the main PLANS or NOTES panel to confirm the item is no longer listed there either.

**Expected Results:**
- The plan or note is removed from the commit detail view immediately after clicking dissociate.
- The item also disappears from the main PLANS or NOTES sidebar panel, with no hidden or greyed-out tombstone remaining.
- If the same topic comes up in a future AI conversation, the item can be re-discovered and will appear fresh in the panel.

</blockquote>
</details>
<details>
<summary><strong>4. [fb6bd9c] Legacy soft-deleted plans reappear fix — old items are automatically cleaned on first load</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a project that was previously using an older version of the extension, where some plans, notes, or references were soft-deleted (marked as "ignored") in the past. If possible, manually edit the internal plans storage file to include an entry with an "ignored" flag set to true, a "branch" field, or an "editCount" field, simulating a leftover from the old version.

**Steps:**
1. Install or update to the latest version of the extension that includes this change.
2. Open the project in the editor.
3. Open the Plans panel (or Notes/References panel) from the sidebar.
4. Check that no previously deleted or hidden items have reappeared in the list.
5. Close and reopen the panel to confirm the list remains clean and stable.
6. If you had added a fake "ignored" entry in step setup, verify it is no longer visible in the panel.

**Expected Results:**
- Previously soft-deleted plans, notes, or references should NOT reappear in any panel after upgrading.
- The panels should show only the items you expect to be active.
- Reopening the panel a second time should show the exact same list with no flickering or reappearing entries — confirming the cleanup only happens once and sticks.

</blockquote>
</details>

## Topics (10)
<details>
<summary><strong>01 · [7f3369c] Remove branch, ignored, and archive-row fields from the registry data model</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The registry carried several fields that had become redundant or counterproductive: per-entry branch scoping duplicated isolation already provided by the filesystem, an "ignored" flag permanently blocked re-discovery of removed items, and per-commit archive snapshot rows duplicated history already recorded elsewhere. The accumulated filtering logic made the codebase harder to maintain and caused user-visible bugs where dismissed references could never reappear.

**💡 Decisions Behind the Code**

- **Delete reference entry on commit instead of keeping a guard row**: Plans and notes use guard rows with content-hash comparison to detect user edits and revive changed files into the active panel. References are read-only snapshots that users never edit, so the revival mechanism has no value for them. Deleting the entry on commit eliminates two fields, the guard-hash computation, and the reference arm of squash/rebase re-association. The trade-off is that re-fetching the same issue across commits associates it independently each time, which was confirmed as the desired behavior.
- **Worktree as the isolation boundary instead of per-entry branch scoping**: Each git worktree already operates on its own registry file, so per-entry branch filtering was redundant protection against cross-branch leakage. Removing it simplifies every detect/filter function and eliminates a class of bugs where the branch string could mismatch between discovery time and commit time. The cost is that multi-branch workflows sharing a single worktree directory would lose isolation, but that scenario is already unsupported by the worktree-level file design.
- **Stop writing per-commit archive snapshot rows**: The orphan-branch snapshot plus the commit summary reference are the authoritative record for committed history — the sidebar never read the archive rows. Removing them halves the registry write volume on commit and eliminates the split-archived-key lookup complexity in squash/rebase migration. Guard rows for plans and notes are retained because they power revival detection.

**✅ What Was Implemented**

- Removed `branch`, `ignored`, and (for references only) `commitHash`/`contentHashAtCommit` fields from `PlanEntry`, `NoteEntry`, and `ReferenceEntry` in both CLI and VS Code type definitions. Stripped all corresponding filter logic from `SessionTracker.ts` (detect*, getReferenceEntriesForBranch, upsertReferenceEntry), `QueueWorker.ts` (detectPlanSlugsFromRegistry, detectUncommittedNoteIds, associate* functions), `StopHook.ts` (scanPlansFrom, scanReferencesFrom), `SessionStartHook.ts` (loadAssociatedPlanNames), and the three VS Code services (`PlanService.ts`, `NoteService.ts`, `ReferenceService.ts`). Deleted now-dead functions including `associateReferenceWithCommit`, `setReferenceIgnored`, `renameReferenceMarkdown`, `getCurrentBranch`, and the reference arm of `reassociateMetadata`.
- Changed the reference commit model from "upgrade entry to guard row" to "delete entry and delete local markdown on commit" in `QueueWorker.associateReferencesWithCommit`. Plans and notes retain guard rows for revival detection, but references — being read-only snapshots — are simply removed. Rewrote `associatePlanWithCommit` and `associateNoteWithCommit` in `SessionTracker.ts` to split the archived key directly and sweep only the guard row's commit hash forward, rather than looking up a now-nonexistent archive row.
- Stopped creating per-commit `<slug>-<shortHash>` archive snapshot rows in plans.json for all three entity types across both CLI (`QueueWorker`) and VS Code (`PlanService.archivePlanForCommit`, `NoteService.archiveNoteForCommit`). The orphan-branch snapshot plus the commit summary reference already served as the authoritative historical record, and the sidebar never displayed the archive rows.

**📋 Future Enhancements**

- The IntelliJ client has non-nullable Kotlin fields for editCount, branch, and ignored that will throw a deserialization exception when reading the updated registry — needs a coordinated IntelliJ ticket before merging.
- The branch parameter on several functions (detectActivePlansForBranch, detectActiveNotesForBranch, detectUncommittedReferenceIds, getReferenceEntriesForBranch, upsertReferenceEntry) is kept as an underscore-prefixed placeholder to avoid changing call sites; a follow-up should remove the parameter and update all callers.

**📁 FILES**
- `cli/src/Types.ts`
- `cli/src/core/SessionTracker.ts`
- `cli/src/hooks/QueueWorker.ts`
- `vscode/src/Types.ts`
- `vscode/src/core/PlanService.ts`

</blockquote>
</details>
<details>
<summary><strong>02 · [7f3369c] Replace soft-delete with hard-remove for plans, notes, and references</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Removing a tracked item from the panel only set a hidden flag but left the registry entry intact. If the same entity was later re-referenced in a new conversation, the existing tombstone blocked re-discovery, so the item never reappeared — a long-standing user-visible bug.

**💡 Decisions Behind the Code**

- **Hard-delete with revival instead of soft-delete tombstones**: The old model left hidden entries in the registry, which permanently blocked re-discovery of the same entity. Hard-deleting the row entirely means a later re-reference naturally re-inserts the entry. This trades the ability to distinguish "user explicitly removed" from "never seen" for a simpler model where removal is reversible through normal usage. The permanent-blacklist behavior was the root cause of the reported bug, and no product scenario required distinguishing the two states.
- **Internal/external file deletion boundary via path containment**: Rather than using entry metadata like format or commit state to decide whether to delete the backing file, the new approach checks whether the file path is physically inside the project's internal storage directory. This is more robust because it works uniformly across all three entity types and cannot be fooled by stale metadata. External user files are never deleted regardless of their commit state, while internally-managed files are cleaned up.
- **Best-effort file deletion with guaranteed registry cleanup**: All three remove functions wrap file deletion in error handling and always proceed to remove the registry row even if the file delete fails due to filesystem locks. This prevents a transient filesystem error from stranding an orphaned registry entry that the user cannot dismiss.

**✅ What Was Implemented**

- Three new hard-delete service functions replace the old soft-delete approach. `PlanService.removePlan` deletes the registry row and, only when the backing file lives inside the project's internal storage directory, also deletes the file (external user files are never touched). `ReferenceService.removeReference` deletes the registry row and always deletes the backing markdown (reference files are structurally always internal). `NoteService.removeNote` was updated to use the same `isPathInside` helper for its internal/external decision instead of the old format-based check. The old `ignoreNote`, `ignorePlan`, and `setReferenceIgnored` functions were removed from production code paths.
- The commit-detail "dissociate" flow in `SummaryWebviewPanel` was simplified for all three entity types. Previously, dissociating a plan/note from a commit required two steps: clearing the commit link then setting the hidden flag. Now each handler drops the reference from the commit summary, then calls the corresponding remove function — a single step that leaves no tombstone and permits future re-discovery.
- A new `isPathInside` utility was added to `PathUtils.ts` with platform-aware path normalization (case-folding on Windows/macOS, separator unification) and a directory-boundary check. A `deleteReferenceMarkdown` wrapper was added to `ReferenceStore.ts` using idempotent file deletion.

**📁 FILES**
- `vscode/src/core/PlanService.ts`
- `vscode/src/core/NoteService.ts`
- `vscode/src/core/ReferenceService.ts`
- `vscode/src/views/SummaryWebviewPanel.ts`
- `cli/src/core/PathUtils.ts`

</blockquote>
</details>
<details>
<summary><strong>03 · [7f3369c] Split discovery cursors into a dedicated file with migration from legacy keys</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Plan and reference discovery cursors were stored alongside other cursors using prefixed keys, entangling two independent scan positions in one file and complicating the cursor lifecycle. The developer wanted each concern to have its own namespace and a clean migration path.

**💡 Decisions Behind the Code**

- **Use minimum-value folding during migration instead of maximum**: When a transcript has both a plan-prefixed and reference-prefixed cursor at different line numbers, taking the minimum ensures neither discovery stream skips past unprocessed lines. The tiny re-scan overlap is safe because both plan and reference discovery are idempotent. Taking the maximum would risk permanently skipping lines that one stream had not yet processed.
- **Single merged cursor per transcript after migration**: Rather than maintaining two separate discovery cursors per transcript, the new design uses one cursor whose final position is set by the reference scan (which reads to end-of-file). This works because plan discovery reads a subset of the same lines, and the reference scan is authoritative for how far the file has been read. This eliminates the prefix-key complexity and halves the cursor bookkeeping.

**✅ What Was Implemented**

- Added a dedicated discovery-cursors file in `SessionTracker.ts` with `saveDiscoveryCursor`, `loadDiscoveryCursor`, and shared read/write helpers. The cursor-loading function now accepts a filename parameter so both files share the same read logic.
- Implemented `migrateDiscoveryCursors` in `SessionTracker.ts`: a one-shot idempotent migration that folds legacy prefixed keys into the new file using minimum-value folding (never skips unprocessed lines), then removes the prefixed keys from the legacy file.
- Refactored `StopHook.ts` to replace two separate discovery functions with a single `discoverFromTranscript` orchestrator that calls migrate → load → scan plans → scan references → save, using bare transcript paths as cursor keys. Updated `pruneOrphanedCursors` to prune both cursor files.

**📁 FILES**
- `cli/src/core/SessionTracker.ts`
- `cli/src/hooks/StopHook.ts`

</blockquote>
</details>
<details>
<summary><strong>04 · [7f3369c] Comprehensive test suite updates for simplified registry data model</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

After removing branch, ignored, archive-row, and reference guard fields from the source code, roughly fifteen to twenty test files contained fixtures, assertions, and mock setups referencing the deleted fields and old behavior, causing widespread test failures.

**💡 Decisions Behind the Code**

- **Delete filter tests rather than invert assertions**: When a filter dimension was removed (branch scoping, ignored flag, reference guard/committed filtering), the corresponding tests were deleted rather than rewritten with inverted expectations. The remaining tests for the simplified logic provide equivalent coverage of the surviving code paths without carrying dead test dimensions that would confuse future readers.
- **Fix cursor test failures by adding explicit reference-scan mocks**: The discovery cursor's final value is now set by the reference scan, so plan-discovery tests that previously asserted cursor positions based on plan line counts needed explicit reference-extraction mocks with matching line-number values. A per-block reset was also added to prevent mock leakage across describe blocks.

**✅ What Was Implemented**

- Updated `SessionTracker.test.ts`: deleted entire describe blocks for reference-specific commit association, reference ignore, reference path, and all guard/ignored/branch filter tests. Rewrote plan and note commit-association tests to use archive-id-driven guard migration semantics. Simplified reference upsert tests to insert/refresh only. Rewrote detect-active and detect-uncommitted tests to remove branch/ignored dimensions.
- Updated `QueueWorker.test.ts`: deleted the entire multi-source reassociate-metadata describe block (~196 lines), replaced content-hash mocks with delete-markdown mocks, removed all branch/commitHash fields from reference fixtures, and rewrote uncommitted-note detection tests. Updated `StopHook.test.ts`: replaced cursor mocks with discovery-cursor equivalents, added migration mocks, deleted four tests for ignored/branch-scoping behavior, and fixed cursor assertions to reflect reference-scan-authoritative semantics.
- Updated VS Code test files (`PlanService.test.ts`, `NoteService.test.ts`, `ReferenceService.test.ts`): deleted branch/ignored filter tests, removed fields from test helpers, and updated archive assertions to confirm no archive row is created. Updated `PostCommitHook.test.ts` and `PostCommitHook.helpers.test.ts`: removed all reference commit-association assertions and reference fixtures from reassociate tests, deleted branch-differs exclusion test.

**📁 FILES**
- `cli/src/core/SessionTracker.test.ts`
- `cli/src/hooks/QueueWorker.test.ts`
- `cli/src/hooks/StopHook.test.ts`
- `cli/src/hooks/PostCommitHook.test.ts`

</blockquote>
</details>
<details>
<summary><strong>05 · [7f3369c] Unify user-facing removal labels from &quot;Ignore&quot; to &quot;Remove&quot; for references</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

After switching references from soft-delete to hard-delete, the command palette, sidebar context menu, and toolbar tooltip still said "Ignore" while plans and notes already said "Remove." The mismatch implied the action was reversible when it now deletes the file.

**💡 Decisions Behind the Code**

The label "Ignore" actively misleads users about the destructiveness of the operation now that it hard-deletes files. Keeping internal command identifiers unchanged avoids a cascade of renames through message handlers, keybinding registrations, and telemetry — a low-value churn that can be batched into a future cleanup pass if desired.

**✅ What Was Implemented**

- Three user-visible strings were updated: the command palette title from "Ignore Reference" to "Remove Reference", the sidebar context menu label from "Ignore" to "Remove", and the trash-can button tooltip from "Ignore" to "Remove". Internal identifiers (command id, message type, data attribute) were intentionally preserved to avoid breaking existing keybindings or webview message routing.

**📁 FILES**
- `vscode/package.json`
- `vscode/src/views/SidebarScriptBuilder.ts`

</blockquote>
</details>
<details>
<summary><strong>06 · [7f3369c] Remove internal plan-step references and non-English comments from source code</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The codebase contained references to internal planning document section numbers and non-English comments that were inappropriate for an open-source English-language project.

**💡 Decisions Behind the Code**

The cleanup distinguished three categories of non-English text: comments (translated to English), test sample data exercising internationalized handling (preserved), and functional regex character ranges (preserved). This avoided breaking internationalization test coverage while ensuring all developer-facing text is in English for the open-source audience.

**✅ What Was Implemented**

- Removed approximately 30 instances of internal plan section references across adapter files, core files, and test files. Also removed task/phase/stage numbering from post-commit pipeline comments.
- Translated non-English comments to English in `BootstrapMerge.ts` and `PostCommitHook.helpers.test.ts`. Preserved non-English test fixture data used for character-width rendering/counting tests and functional regex character ranges.

**📁 FILES**
- `cli/src/sync/BootstrapMerge.ts`
- `cli/src/hooks/QueueWorker.ts`
- `cli/src/core/SessionTracker.ts`
- `cli/src/hooks/StopHook.ts`

</blockquote>
</details>
<details>
<summary><strong>07 · [7f3369c] Multi-agent code review with adversarial verification of findings</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The developer requested multiple independent review agents examining correctness, consistency, and test quality, followed by adversarial agents that attempt to refute each finding before any fix is applied.

**💡 Decisions Behind the Code**

- **Adversarial default-refute posture**: Each finding was sent to a separate agent instructed to assume the finding is wrong and attempt to disprove it. This filters out speculative or out-of-scope suggestions that reviewers commonly produce. Six of seven findings were successfully refuted, confirming the filter's value — without it, all seven would have been treated as action items.
- **Voluntary adoption of refuted findings**: Two refuted items were still implemented because the adversarial agent's refutation was technically correct (the issues predated the diff or had no runtime impact) but the fixes were trivially small and improved defensive consistency across the three entity types. This demonstrates that the adversarial process is a filter, not a veto — the developer retains judgment on low-cost improvements.

**✅ What Was Implemented**

- A workflow was launched with 10 agents (3 reviewers across 3 dimensions plus adversarial verifiers) making 188 tool calls over approximately 7 minutes. It produced 7 findings: 1 confirmed (a stale comment left behind during the dissociate refactor), 6 refuted. The confirmed finding was fixed immediately. Two refuted findings were voluntarily adopted as quality improvements despite being formally refuted, because they improved robustness and test clarity at negligible cost.

**📁 FILES**
- `vscode/src/core/ReferenceService.ts`
- `vscode/src/core/NoteService.test.ts`

</blockquote>
</details>
<details>
<summary><strong>08 · [fb6bd9c] Defer reference deletion until remote write succeeds to prevent data loss</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

When references were archived during a commit, the local copy was destroyed before the remote snapshot was confirmed written. If the remote write failed, the reference was permanently lost with no way to recover it on retry.

**💡 Decisions Behind the Code**

- **Write-ahead ordering over transactional rollback**: Rather than attempting to roll back local deletions on a failed remote write, the fix simply defers all destructive local operations until after the remote write succeeds. Rollback would require re-creating the registry entry and restoring the markdown file from an in-memory copy, introducing new failure modes and complexity. The deferred approach is naturally idempotent — a failed commit leaves the reference in its original active state, and the next commit picks it up without special recovery logic.
- **Shared finalize function over inline caller logic**: The teardown was extracted into a dedicated function rather than duplicated at each call site. Both callers need identical teardown behavior, and a shared function keeps the write-ahead contract in one discoverable place with explicit documentation that it must only be called after a successful store.

**✅ What Was Implemented**

- Refactored `associateReferencesWithCommit` in `QueueWorker.ts` to perform zero local mutations: it now only captures the snapshot (value data plus raw file content) and returns a `committed` list describing what local state should be torn down later. All file deletions and registry removals were extracted into a new `finalizeReferenceArchive` function.
- Both callers of `associateReferencesWithCommit` (the main pipeline path and the amend fresh-leaf path in `handleAmendPipeline`) now call `storeReferences` first, then `finalizeReferenceArchive` only on success. If the remote write throws, the active registry row and local markdown remain intact, so the reference is simply re-archived on the next commit.
- Added a dedicated recovery test in `QueueWorker.test.ts` that mocks `storeReferences` to reject and asserts that no local deletions occur, confirming the write-ahead guarantee.

**📁 FILES**
- `cli/src/hooks/QueueWorker.ts`

</blockquote>
</details>
<details>
<summary><strong>09 · [fb6bd9c] Fix dissociate from commit detail page deleting wrong registry key</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

When a user removed a plan or note from a commit's detail page, the operation appeared to succeed but silently failed to delete the underlying registry entry because it targeted an archived identifier rather than the base key where the entry actually lives.

**💡 Decisions Behind the Code**

The suffix-stripping approach was chosen over changing the registry to store entries under archived keys. The registry's base-key convention is load-bearing for plan re-discovery and guard semantics — changing it would cascade through the entire association pipeline. Stripping the suffix at the dissociation boundary is a minimal, localized fix that keeps the registry model intact while correctly targeting the right entry.

**✅ What Was Implemented**

- Added `stripCommitSuffix` helper in `SummaryWebviewPanel.ts` that removes the commit hash suffix from an archived identifier to recover the bare base key. Both `handleRemovePlan` and `handleRemoveNote` now pass the stripped key to the deletion functions while still passing the full archived identifier for visible-file cleanup.
- Added regression tests for both plan and note dissociation using archived identifiers, asserting that the deletion targets the bare key while artifact cleanup targets the full archived identifier.

**📁 FILES**
- `vscode/src/views/SummaryWebviewPanel.ts`

</blockquote>
</details>
<details>
<summary><strong>10 · [fb6bd9c] Purge legacy soft-delete fields and rows from plans registry on load with deterministic writeback</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

After the extension removed the old soft-delete filtering logic, every previously soft-deleted plan, note, and reference silently reappeared in the sidebar on the next reload. The old hidden rows were still stored in the registry file, and the new code no longer filtered them out.

**💡 Decisions Behind the Code**

- **Read-time normalization instead of a version-gated migration**: The codebase deliberately keeps the registry's version field vestigial and avoids version-gated migrations. Following the existing pattern for legacy key coalescing, the normalizer runs in memory on every load — idempotent, self-healing if an older client writes back stale fields. This avoids introducing a migration framework and means every reader always sees clean data regardless of whether the file has been physically rewritten yet.
- **Deterministic writeback via detect-functions rather than inside the load path**: Writing back from the load function itself would amplify an existing concurrency window because load is called from multiple concurrent processes. Instead, the writeback piggybacks on the three detect functions that already run single-threaded in the extension host during panel refresh — this adds no new concurrency risk while guaranteeing the file is cleaned on the very first user interaction after upgrade.
- **Field-based detection for legacy reference rows instead of key-shape heuristic**: An initial implementation used a pattern matching suffixed keys to identify archived reference rows. Code review caught that active ticket identifiers can legitimately end in digit sequences that match the pattern, creating a silent data-loss risk. The fix relies solely on the presence of specific guard fields that archived rows always carry, eliminating the false-positive path entirely.

**✅ What Was Implemented**

- Added `normalizePlansRegistry(raw)` in `cli/src/core/SessionTracker.ts` — a pure, idempotent function that walks every entry in the registry file and applies per-type cleanup: plans and notes have soft-deleted rows dropped and legacy fields stripped (guard fields are preserved); references additionally drop committed and guard rows and strip four dead fields. A companion `loadPlansRegistryWithStatus` returns both the cleaned registry and a `changed` boolean.
- Wired deterministic writeback into `detectPlans` (PlanService.ts), `detectNotes` (NoteService.ts), and `detectReferences` (ReferenceService.ts): each calls `loadPlansRegistryWithStatus` and, when `changed` is true, immediately persists the normalised registry. The registry file is physically cleaned on the first panel refresh after upgrade.
- The session-start hook was also updated to filter out legacy soft-deleted plans that could briefly appear as active context before the detection pipeline cleaned them up.
- Added 5 unit tests for `normalizePlansRegistry` covering purging, idempotency, and missing-section no-ops, plus 6 writeback tests across the three service test files. Also added 6 tests for discovery-cursor persistence and migration logic. Removed the now-dead `branch` field from 5 existing test fixtures.

**📋 Future Enhancements**

The IntelliJ plugin still declares several of the removed fields as non-nullable. If its serialization library encounters a registry file that no longer contains those fields, it will throw a deserialization error. This must be addressed before a coordinated release across both clients.

**📁 FILES**
- `cli/src/core/SessionTracker.ts`
- `vscode/src/core/PlanService.ts`
- `vscode/src/core/NoteService.ts`
- `vscode/src/core/ReferenceService.ts`

</blockquote>
</details>

---

*Generated by Jolli Memory · June 3, 2026 at 4:19 PM*
<!-- jollimemory-summary-end -->