### PR TITLE
Fix memory bank tree divergence marker collapse on single-file revert

### DIFF
--- a/vscode/src/Extension.test.ts
+++ b/vscode/src/Extension.test.ts
@@ -32,8 +32,9 @@ const { mockRefreshConversationsPanel } = vi.hoisted(() => ({
 	mockRefreshConversationsPanel: vi.fn(() => Promise.resolve()),
 }));
 
-const { mockRefreshKnowledgeBaseFolders } = vi.hoisted(() => ({
+const { mockRefreshKnowledgeBaseFolders, mockClearKnowledgeBaseFolderDivergence } = vi.hoisted(() => ({
 	mockRefreshKnowledgeBaseFolders: vi.fn(),
+	mockClearKnowledgeBaseFolderDivergence: vi.fn(),
 }));
 
 const { mockNotifyEnabledChanged, mockNotifyAuthChanged } = vi.hoisted(() => ({
@@ -878,6 +879,7 @@ vi.mock("./views/SidebarWebviewProvider.js", () => ({
 		resolveWebviewView() {}
 		dispose() {}
 		refreshKnowledgeBaseFolders = mockRefreshKnowledgeBaseFolders;
+		clearKnowledgeBaseFolderDivergence = mockClearKnowledgeBaseFolderDivergence;
 		refreshConversationsPanel = mockRefreshConversationsPanel;
 		refreshPlansPanel() {}
 		notifyEnabledChanged = mockNotifyEnabledChanged;
@@ -3816,6 +3818,11 @@ describe("Extension", () => {
 				const handler = getRegisteredCommand(
 					"jollimemory.revertMemoryFileEdits",
 				);
+				// Drop tree-signal counters seeded by activation's initial KB
+				// load so the assertions below observe only what the revert
+				// command itself triggers (same pattern as enableJolliMemory).
+				mockRefreshKnowledgeBaseFolders.mockClear();
+				mockClearKnowledgeBaseFolderDivergence.mockClear();
 				await handler(absPath);
 
 				expect(folderStorage.forceRegenerateVisibleMarkdown).toHaveBeenCalledWith(
@@ -3830,20 +3837,29 @@ describe("Extension", () => {
 					`Reverted to system version: ${absPath}`,
 				);
 				// The KB folders tree caches `isDiverged` on each FolderNode;
-				// without an explicit refresh signal the ✎ marker would survive
-				// the revert until the next user-initiated refresh. Pin the
-				// refresh trigger so a future refactor that silently drops it
-				// re-introduces the stale-marker bug.
-				expect(mockRefreshKnowledgeBaseFolders).toHaveBeenCalled();
+				// without an explicit signal the ✎ marker would survive the
+				// revert until the next user-initiated refresh. The fix sends a
+				// TARGETED single-row clear (kb:clearDiverged) rather than the
+				// tree-wide refreshKnowledgeBaseFolders reset, which wiped the
+				// client folderCache and collapsed every expanded branch dir.
+				// Pin both: the targeted clear fires with the kbParent-relative
+				// path, and the heavyweight reset does NOT.
+				// Suffix match: the kbParent prefix differs between this test's
+				// fixture and the mocked resolveKbParent, but the forward-slash
+				// normalization (no backslashes) and the target file identity
+				// are what matter for the client folderCache key.
+				expect(mockClearKnowledgeBaseFolderDivergence).toHaveBeenCalledWith(
+					expect.stringMatching(/(^|\/)repo\/main\/foo-abcdef12\.md$/),
+				);
+				expect(mockRefreshKnowledgeBaseFolders).not.toHaveBeenCalled();
 			});
 
-			it("does NOT call refreshKnowledgeBaseFolders when the regenerate helper returns a failure", async () => {
-				// Failure path: the post-revert refresh trigger should only fire
-				// on a successful regenerate. A non-ok result means the hidden
-				// source was missing or corrupt, so the ✎ state on disk hasn't
-				// actually changed — re-rendering the tree would be wasted work
-				// and could even surprise the user with collapsing expanded
-				// folders.
+			it("does NOT signal the KB tree when the regenerate helper returns a failure", async () => {
+				// Failure path: the post-revert tree signal should only fire on a
+				// successful regenerate. A non-ok result means the hidden source
+				// was missing or corrupt, so the ✎ state on disk hasn't actually
+				// changed — touching the tree would be wasted work. (Neither the
+				// targeted clear nor the legacy reset should fire.)
 				const folderStorage = {
 					forceRegenerateVisibleMarkdown: vi.fn().mockResolvedValue({ ok: false, reason: "missing" }),
 					regenerateVisiblePlan: vi.fn(),
@@ -3870,6 +3886,7 @@ describe("Extension", () => {
 				);
 				await handler(absPath);
 
+				expect(mockClearKnowledgeBaseFolderDivergence).not.toHaveBeenCalled();
 				expect(mockRefreshKnowledgeBaseFolders).not.toHaveBeenCalled();
 			});
 

--- a/vscode/src/Extension.ts
+++ b/vscode/src/Extension.ts
@@ -6,7 +6,7 @@
  */
 
 import { existsSync, readFileSync } from "node:fs";
-import { dirname, isAbsolute, join, resolve } from "node:path";
+import { dirname, isAbsolute, join, relative, resolve } from "node:path";
 import { clearTimeout, setTimeout } from "node:timers";
 import * as vscode from "vscode";
 import {
@@ -20,6 +20,7 @@ import {
 	resolveKbParent,
 } from "../../cli/src/core/KBPathResolver.js";
 import type { ManifestEntry } from "../../cli/src/core/KBTypes.js";
+import { toForwardSlash } from "../../cli/src/core/PathUtils.js";
 import {
 	getGlobalConfigDir,
 	loadConfig,
@@ -886,6 +887,10 @@ export function activate(context: vscode.ExtensionContext): void {
 		// <kbParent>; join'ing on kbParent gives back the absolute on-disk
 		// path. Same shape as the IntelliJ Memory Bank tree.
 		resolveKbAbs: (relPath) => join(sidebarKbParent, relPath),
+		// Lets handleOpenFile light up the Folders-tab ✎ marker the moment a
+		// user opens a `.md` that's been edited on disk — same sha256-vs-manifest
+		// check the native MemoryFileDecorationProvider badge uses.
+		isMemoryFileDivergedOnDisk: (abs) => bridge.isMemoryFileDivergedOnDisk(abs),
 		// MemoriesStore was previously loaded via memoriesView.onDidChangeVisibility;
 		// the webview replacement has no equivalent built-in event, so we plumb it
 		// through SidebarWebviewProvider's `case "ready"` instead.
@@ -2676,14 +2681,25 @@ export function activate(context: vscode.ExtensionContext): void {
 					memoryFileDecorationProvider.refreshUri(
 						vscode.Uri.file(absPath),
 					);
-					// Force the KB folders tree to drop its cached
-					// `isDiverged` for this path so the ✎ marker disappears
-					// without waiting for the user to hit refresh. The
-					// existing decoration-provider refresh above only covers
-					// VS Code's native file UIs; the webview-rendered KB
-					// tree reads divergence from the cached FolderNode and
-					// needs its own re-fetch signal.
-					sidebarProvider.refreshKnowledgeBaseFolders();
+					// Clear the KB folders tree's cached `isDiverged` for
+					// this one path so the ✎ marker disappears without a
+					// manual refresh. The decoration-provider refresh above
+					// only covers VS Code's native file UIs; the
+					// webview-rendered KB tree reads divergence from the
+					// cached FolderNode and needs its own signal.
+					//
+					// A content revert touches one file's bytes, not the
+					// tree's shape — so we send the targeted `kb:clearDiverged`
+					// (single-row flag flip) rather than the heavyweight
+					// `refreshKnowledgeBaseFolders` reset, which wipes the
+					// client's folderCache and collapses every expanded branch
+					// directory the user had open. relPath is absPath made
+					// relative to the same kbParent `resolveKbAbs` joins from,
+					// normalized to the forward-slash form the client keys
+					// folderCache on; a non-Memory-Bank path no-ops client-side.
+					sidebarProvider.clearKnowledgeBaseFolderDivergence(
+						toForwardSlash(relative(sidebarKbParent, absPath)),
+					);
 					vscode.window.showInformationMessage(
 						`Reverted to system version: ${absPath}`,
 					);

--- a/vscode/src/views/SidebarMessages.ts
+++ b/vscode/src/views/SidebarMessages.ts
@@ -545,6 +545,34 @@ export type SidebarInboundMsg =
 	| { readonly type: "kb:foldersData"; readonly tree: FolderNode }
 	| {
 			/**
+			 * Marks a single already-rendered Folders-tab file row as diverged
+			 * (edited on disk, system view unavailable) so its trailing ✎ marker
+			 * appears without a full re-listing. Sent by the host when the user
+			 * opens a `.md` whose on-disk sha256 no longer matches the manifest
+			 * fingerprint — the open-file path is the one place divergence is
+			 * checked outside of `KbFoldersService.listInRepo`, so this keeps the
+			 * tree's marker in sync with `MemoryFileDecorationProvider`'s badge.
+			 * `path` is the repoDir-prefixed relPath used as the client's
+			 * `folderCache` key / `data-path`, identical to `kb:openFile`'s path.
+			 */
+			readonly type: "kb:markDiverged";
+			readonly path: string;
+	  }
+	| {
+			/**
+			 * Inverse of `kb:markDiverged`: clears a single already-rendered file
+			 * row's ✎ marker in place after the host successfully reverts it to the
+			 * system version. Sent instead of `kb:foldersReset` so the surrounding
+			 * tree keeps its expansion state — a content revert touches one file,
+			 * not the tree's shape, so wiping `folderCache` (collapsing every open
+			 * branch directory) is the wrong tool. `path` is the repoDir-prefixed
+			 * relPath used as the client's `folderCache` key / `data-path`.
+			 */
+			readonly type: "kb:clearDiverged";
+			readonly path: string;
+	  }
+	| {
+			/**
 			 * Tells the client to discard its entire `folderCache` before the next
 			 * root listing arrives. Sent by the host after destructive operations
 			 * (currently: Migrate to Memory Bank) that may rename the repo folder

--- a/vscode/src/views/SidebarScriptBuilder.test.ts
+++ b/vscode/src/views/SidebarScriptBuilder.test.ts
@@ -111,12 +111,67 @@ describe("SidebarScriptBuilder", () => {
 		expect(js).not.toContain("kbRepoFolder");
 	});
 
-	it("re-attaches cached subtrees onto root listings so manual refresh keeps folders expanded", () => {
+	it("grafts cached subtrees onto every reply so refresh keeps folders expanded", () => {
 		const js = buildSidebarScript();
-		// Reattach helper exists, runs only for root, and recurses for depth.
-		expect(js).toContain("reattachExpandedFromCache");
-		expect(js).toContain(
-			"if (tree.relPath === '') tree = reattachExpandedFromCache(tree)",
+		// Graft helper exists and is applied to EVERY merged reply (the merge
+		// reads its result into `grafted`), not just the root — so an out-of-order
+		// per-folder reply can't collapse a deeper expansion.
+		expect(js).toContain("graftExpandedFromCache");
+		expect(js).toContain("const grafted = graftExpandedFromCache(tree)");
+	});
+
+	it("handles kb:markDiverged / kb:clearDiverged through one in-place flag flip", () => {
+		const js = buildSidebarScript();
+		// Both inbound cases exist and route to the SAME shared helper with
+		// opposite truth values — mark and clear can't drift apart.
+		expect(js).toContain("'kb:markDiverged'");
+		expect(js).toContain("'kb:clearDiverged'");
+		expect(js).toContain("setFileDivergedFlag(msg.path, true)");
+		expect(js).toContain("setFileDivergedFlag(msg.path, false)");
+		expect(js).toContain("function setFileDivergedFlag");
+		// In-place flip rebuilds the matching child with the new flag value.
+		expect(js).toContain("{ isDiverged: diverged }");
+		// The flip must NOT wipe folderCache — that's foldersReset's job and would
+		// collapse every expanded branch directory. Bound the assertion to the
+		// setFileDivergedFlag body (up to the next top-level function) so it can't
+		// pass vacuously against foldersReset's cache-wipe loop elsewhere.
+		expect(js).not.toMatch(
+			/function setFileDivergedFlag[\s\S]*?delete folderCache\[[\s\S]*?\n {2}function /,
+		);
+	});
+
+	it("re-requests every already-expanded folder on manual refresh so isDiverged is recomputed", () => {
+		const js = buildSidebarScript();
+		// requestExpandedRefresh re-requests fresh data for each expanded dir so a
+		// file edited on disk while the sidebar was open gets its ✎ marker on
+		// refresh (cache-only reuse left nested isDiverged stale). Bounded to the
+		// requestExpandedRefresh body (up to mergeFolders) so it can't pass
+		// vacuously on the unrelated kb:expandFolder in maybeAutoExpandCurrentRepo.
+		expect(js).toMatch(
+			/function requestExpandedRefresh[\s\S]*?type:\s*'kb:expandFolder'[\s\S]*?function mergeFolders/,
+		);
+		// The fan-out fires ONLY from the root merge — gating it on relPath === ''
+		// is what keeps a per-folder reply from re-posting (and looping).
+		expect(js).toMatch(
+			/if\s*\(tree\.relPath === ''\) requestExpandedRefresh\(tree\)/,
+		);
+	});
+
+	it("grafts cached expansion onto every reply without re-requesting (order-independent, no collapse)", () => {
+		const js = buildSidebarScript();
+		// graftExpandedFromCache is the PURE expansion-preserver: it must NOT post
+		// kb:expandFolder (that belongs to requestExpandedRefresh). If it did, each
+		// per-folder reply would re-post for its descendants and amplify. Bounded
+		// to the graft body (up to requestExpandedRefresh).
+		expect(js).toContain("function graftExpandedFromCache");
+		expect(js).not.toMatch(
+			/function graftExpandedFromCache[\s\S]*?type:\s*'kb:expandFolder'[\s\S]*?function requestExpandedRefresh/,
+		);
+		// mergeFolders grafts EVERY reply (not gated on relPath === '') so an
+		// out-of-order per-folder reply can't overwrite a deeper expansion with a
+		// lazy child and collapse it.
+		expect(js).toMatch(
+			/function mergeFolders\(tree\)\s*\{\s*const grafted = graftExpandedFromCache\(tree\)/,
 		);
 	});
 

--- a/vscode/src/views/SidebarScriptBuilder.ts
+++ b/vscode/src/views/SidebarScriptBuilder.ts
@@ -824,6 +824,12 @@ export function buildSidebarScript(): string {
       case 'kb:foldersData':
         mergeFolders(msg.tree);
         break;
+      case 'kb:markDiverged':
+        setFileDivergedFlag(msg.path, true);
+        break;
+      case 'kb:clearDiverged':
+        setFileDivergedFlag(msg.path, false);
+        break;
       case 'kb:foldersReset':
         // Drop every cached level — paths deeper than the root may have been
         // renamed/removed by the host operation that triggered this reset
@@ -1553,38 +1559,103 @@ export function buildSidebarScript(): string {
     }
   }
 
-  // Re-attach already-expanded subtrees from folderCache onto a freshly fetched
-  // root listing. KbFoldersService returns lazy directory children (children:
+  // Graft already-expanded subtrees from folderCache onto a freshly fetched
+  // listing. KbFoldersService returns lazy directory children (children:
   // undefined), and renderFolderChildren treats only Array-typed children as
-  // "expanded" — so without this, manual refresh would collapse every folder
-  // the user had open. Cache-miss entries (newly visible folders) keep their
-  // lazy form so they render closed, which is correct.
-  // After a kb:foldersReset the cache is empty, so this is a no-op for rebuild.
-  function reattachExpandedFromCache(node) {
+  // "expanded" — so without this, a refresh would collapse every folder the
+  // user had open. Cache-miss entries (newly visible folders) keep their lazy
+  // form so they render closed, which is correct. PURE: no re-request — the
+  // refresh fan-out is kicked off once by requestExpandedRefresh.
+  //
+  // Applied to EVERY merged reply (see mergeFolders), not just the root, so a
+  // per-folder reply's lazy children can never overwrite a deeper expansion
+  // the user had open: each reply re-grafts whatever is currently expanded in
+  // the cache, making the merge order-independent. After a kb:foldersReset the
+  // cache is empty, so this is a no-op for rebuild.
+  function graftExpandedFromCache(node) {
     if (!node || !node.isDirectory || !Array.isArray(node.children)) return node;
     const newChildren = node.children.map(function(child) {
       if (!child.isDirectory) return child;
       const cached = folderCache[child.relPath];
       if (cached && Array.isArray(cached.children)) {
-        return reattachExpandedFromCache(cached);
+        return graftExpandedFromCache(cached);
       }
       return child;
     });
     return Object.assign({}, node, { children: newChildren });
   }
 
-  // Merge incoming kb:foldersData into the cache, then re-render.
+  // On a manual refresh the root listing arrives with NO preceding
+  // kb:foldersReset, so folderCache still holds every expanded dir. Re-request
+  // each (recursively, all depths) so listInRepo recomputes its files'
+  // isDiverged on the reply — a row edited on disk while the sidebar was open
+  // finally gets its ✎ marker. Fired ONCE, from the root merge only; the
+  // per-folder replies are merged by mergeFolders, which grafts expansion back
+  // in, so they can land in any order without collapsing the tree. Grafting on
+  // the replies (rather than here) is what keeps this from looping — we never
+  // re-post off a reply.
+  function requestExpandedRefresh(node) {
+    if (!node || !node.isDirectory || !Array.isArray(node.children)) return;
+    node.children.forEach(function(child) {
+      if (!child.isDirectory) return;
+      const cached = folderCache[child.relPath];
+      if (cached && Array.isArray(cached.children)) {
+        vscode.postMessage({ type: 'kb:expandFolder', path: child.relPath });
+        requestExpandedRefresh(cached);
+      }
+    });
+  }
+
+  // Merge incoming kb:foldersData into the cache, then re-render. Graft expanded
+  // descendants onto EVERY reply (root and per-folder) so an out-of-order
+  // per-folder reply can't overwrite a deeper expansion with a lazy child. Only
+  // the root merge kicks off the isDiverged refresh fan-out.
   function mergeFolders(tree) {
-    if (tree.relPath === '') tree = reattachExpandedFromCache(tree);
-    folderCache[tree.relPath] = tree;
-    propagateUp(tree.relPath, tree);
+    const grafted = graftExpandedFromCache(tree);
+    if (tree.relPath === '') requestExpandedRefresh(tree);
+    folderCache[grafted.relPath] = grafted;
+    propagateUp(grafted.relPath, grafted);
     if (state.activeTab === 'kb' && state.kbMode === 'folders') renderFolders();
     maybeAutoExpandCurrentRepo();
   }
 
+  // Flip a single already-rendered file row's diverged flag in place. Set true
+  // on kb:markDiverged (the host sends it when the user opens a .md whose
+  // on-disk sha256 no longer matches the manifest fingerprint); set false on
+  // kb:clearDiverged (after the host reverts the file to the system version).
+  // The row is already in the tree, so we just rebuild its parent dir with the
+  // child's new isDiverged (fresh references so render sees the change, matching
+  // mergeFolders' style) — no host round-trip / re-listing.
+  //
+  // The host sends these targeted flips instead of kb:foldersReset precisely so
+  // the surrounding tree keeps its expansion state: a content change touches one
+  // file's bytes, not the tree's shape, so wiping folderCache (which collapses
+  // every open folder) would be the wrong tool. Mark and clear are the same
+  // operation with opposite truth values, so they share one body — a future fix
+  // to the parentPath derivation or the render gate can't drift between them.
+  function setFileDivergedFlag(relPath, diverged) {
+    const idx = relPath.lastIndexOf('/');
+    const parentPath = idx === -1 ? '' : relPath.slice(0, idx);
+    const parent = folderCache[parentPath];
+    if (!parent || !Array.isArray(parent.children)) return;
+    let changed = false;
+    const newChildren = parent.children.map(function(child) {
+      if (child.relPath === relPath && !child.isDirectory && !!child.isDiverged !== diverged) {
+        changed = true;
+        return Object.assign({}, child, { isDiverged: diverged });
+      }
+      return child;
+    });
+    if (!changed) return;
+    const newParent = Object.assign({}, parent, { children: newChildren });
+    folderCache[parentPath] = newParent;
+    propagateUp(parentPath, newParent);
+    if (state.activeTab === 'kb' && state.kbMode === 'folders') renderFolders();
+  }
+
   // Auto-expand the current repo on first delivery so the user lands inside
   // their own memories instead of staring at a single bold row. One-shot: once
-  // we've done it (or seen it already expanded via reattachExpandedFromCache),
+  // we've done it (or seen it already expanded via graftExpandedFromCache),
   // we never auto-expand again so user-driven collapses stick. Triggers off
   // any merge — usually the root listing, but a lazy expand reply that arrives
   // before the root finishes is also fine.

--- a/vscode/src/views/SidebarWebviewProvider.test.ts
+++ b/vscode/src/views/SidebarWebviewProvider.test.ts
@@ -341,6 +341,208 @@ describe("SidebarWebviewProvider", () => {
 		);
 	});
 
+	it("posts kb:markDiverged when an opened .md is diverged on disk", async () => {
+		const view = makeMockView();
+		const exec = vi.fn();
+		const provider = new SidebarWebviewProvider({
+			executeCommand: exec,
+			getInitialState: () => ({
+				enabled: true,
+				authenticated: false,
+				activeTab: "kb",
+				kbMode: "folders",
+				branchName: "main",
+				detached: false,
+			}),
+			extensionUri: mockExtensionUri as unknown as never,
+			resolveKbAbs: (relPath: string) => `/kbroot/${relPath}`,
+			isMemoryFileDivergedOnDisk: vi.fn().mockResolvedValue(true),
+		});
+		provider.resolveWebviewView(view as unknown as never);
+		view.webview.triggerMessage({
+			type: "kb:openFile",
+			path: "repo/main/memo.md",
+		});
+		await flushReady();
+		expect(view.webview.postMessage).toHaveBeenCalledWith({
+			type: "kb:markDiverged",
+			path: "repo/main/memo.md",
+		});
+	});
+
+	it("posts kb:clearDiverged (not markDiverged) when the opened .md is in sync", async () => {
+		const view = makeMockView();
+		const provider = new SidebarWebviewProvider({
+			executeCommand: vi.fn(),
+			getInitialState: () => ({
+				enabled: true,
+				authenticated: false,
+				activeTab: "kb",
+				kbMode: "folders",
+				branchName: "main",
+				detached: false,
+			}),
+			extensionUri: mockExtensionUri as unknown as never,
+			resolveKbAbs: (relPath: string) => `/kbroot/${relPath}`,
+			isMemoryFileDivergedOnDisk: vi.fn().mockResolvedValue(false),
+		});
+		provider.resolveWebviewView(view as unknown as never);
+		view.webview.triggerMessage({ type: "kb:openFile", path: "repo/main/memo.md" });
+		await flushReady();
+		// A clean check actively clears the row, so reopening a now-synced file
+		// drops a ✎ left by an earlier open instead of leaving it stuck.
+		expect(view.webview.postMessage).toHaveBeenCalledWith({
+			type: "kb:clearDiverged",
+			path: "repo/main/memo.md",
+		});
+		expect(view.webview.postMessage).not.toHaveBeenCalledWith(
+			expect.objectContaining({ type: "kb:markDiverged" }),
+		);
+	});
+
+	it("lets the latest open win: an older slow diverged check can't re-mark after a newer in-sync check", async () => {
+		const view = makeMockView();
+		// First open's check is slow and reports diverged; second open's check is
+		// immediate and reports in-sync. The stale first result must be dropped.
+		let resolveFirst!: (v: boolean) => void;
+		const firstCheck = new Promise<boolean>((res) => {
+			resolveFirst = res;
+		});
+		const check = vi
+			.fn()
+			.mockReturnValueOnce(firstCheck)
+			.mockReturnValueOnce(Promise.resolve(false));
+		const provider = new SidebarWebviewProvider({
+			executeCommand: vi.fn(),
+			getInitialState: () => ({
+				enabled: true,
+				authenticated: false,
+				activeTab: "kb",
+				kbMode: "folders",
+				branchName: "main",
+				detached: false,
+			}),
+			extensionUri: mockExtensionUri as unknown as never,
+			resolveKbAbs: (relPath: string) => `/kbroot/${relPath}`,
+			isMemoryFileDivergedOnDisk: check,
+		});
+		provider.resolveWebviewView(view as unknown as never);
+		view.webview.triggerMessage({ type: "kb:openFile", path: "repo/main/memo.md" });
+		view.webview.triggerMessage({ type: "kb:openFile", path: "repo/main/memo.md" });
+		await flushReady();
+		// Second (latest) open resolved in-sync → cleared.
+		expect(view.webview.postMessage).toHaveBeenCalledWith({
+			type: "kb:clearDiverged",
+			path: "repo/main/memo.md",
+		});
+		resolveFirst(true);
+		await flushReady();
+		// First (stale) open's diverged result must NOT re-light the marker.
+		expect(view.webview.postMessage).not.toHaveBeenCalledWith(
+			expect.objectContaining({ type: "kb:markDiverged" }),
+		);
+	});
+
+	it("clearKnowledgeBaseFolderDivergence posts a targeted kb:clearDiverged, not a tree-collapsing reset", () => {
+		const view = makeMockView();
+		const provider = new SidebarWebviewProvider({
+			executeCommand: vi.fn(),
+			getInitialState: () => ({
+				enabled: true,
+				authenticated: false,
+				activeTab: "kb",
+				kbMode: "folders",
+				branchName: "main",
+				detached: false,
+			}),
+			extensionUri: mockExtensionUri as unknown as never,
+		});
+		provider.resolveWebviewView(view as unknown as never);
+		provider.clearKnowledgeBaseFolderDivergence("repo/main/memo.md");
+		expect(view.webview.postMessage).toHaveBeenCalledWith({
+			type: "kb:clearDiverged",
+			path: "repo/main/memo.md",
+		});
+		// A single-file revert must not wipe the client's folderCache — that's
+		// what collapsed every expanded branch directory before the fix.
+		expect(view.webview.postMessage).not.toHaveBeenCalledWith(
+			expect.objectContaining({ type: "kb:foldersReset" }),
+		);
+	});
+
+	it("drops a stale kb:markDiverged when the row is reverted while the disk check is in flight", async () => {
+		const view = makeMockView();
+		// Hold the divergence check open so we can revert the same row before it
+		// resolves — the bytes we sha'd are now stale, so the mark must be dropped.
+		let resolveCheck!: (v: boolean) => void;
+		const pending = new Promise<boolean>((res) => {
+			resolveCheck = res;
+		});
+		const provider = new SidebarWebviewProvider({
+			executeCommand: vi.fn(),
+			getInitialState: () => ({
+				enabled: true,
+				authenticated: false,
+				activeTab: "kb",
+				kbMode: "folders",
+				branchName: "main",
+				detached: false,
+			}),
+			extensionUri: mockExtensionUri as unknown as never,
+			resolveKbAbs: (relPath: string) => `/kbroot/${relPath}`,
+			isMemoryFileDivergedOnDisk: vi.fn().mockReturnValue(pending),
+		});
+		provider.resolveWebviewView(view as unknown as never);
+		// Open the diverged file: kicks off the in-flight check.
+		view.webview.triggerMessage({
+			type: "kb:openFile",
+			path: "repo/main/memo.md",
+		});
+		// User reverts the same row before the check resolves.
+		provider.clearKnowledgeBaseFolderDivergence("repo/main/memo.md");
+		// Now the slow check resolves "diverged" against the pre-revert bytes.
+		resolveCheck(true);
+		await flushReady();
+		expect(view.webview.postMessage).toHaveBeenCalledWith({
+			type: "kb:clearDiverged",
+			path: "repo/main/memo.md",
+		});
+		expect(view.webview.postMessage).not.toHaveBeenCalledWith(
+			expect.objectContaining({ type: "kb:markDiverged" }),
+		);
+	});
+
+	it("does not let an unrelated revert suppress a row's kb:markDiverged", async () => {
+		const view = makeMockView();
+		const provider = new SidebarWebviewProvider({
+			executeCommand: vi.fn(),
+			getInitialState: () => ({
+				enabled: true,
+				authenticated: false,
+				activeTab: "kb",
+				kbMode: "folders",
+				branchName: "main",
+				detached: false,
+			}),
+			extensionUri: mockExtensionUri as unknown as never,
+			resolveKbAbs: (relPath: string) => `/kbroot/${relPath}`,
+			isMemoryFileDivergedOnDisk: vi.fn().mockResolvedValue(true),
+		});
+		provider.resolveWebviewView(view as unknown as never);
+		// A different row is reverted; the per-path seq is keyed by relPath, so it
+		// must not gate the opened file's mark.
+		provider.clearKnowledgeBaseFolderDivergence("repo/main/other.md");
+		view.webview.triggerMessage({
+			type: "kb:openFile",
+			path: "repo/main/memo.md",
+		});
+		await flushReady();
+		expect(view.webview.postMessage).toHaveBeenCalledWith({
+			type: "kb:markDiverged",
+			path: "repo/main/memo.md",
+		});
+	});
+
 	it("forwards kb:openFile for non-md to vscode.open", () => {
 		const view = makeMockView();
 		const exec = vi.fn();

--- a/vscode/src/views/SidebarWebviewProvider.ts
+++ b/vscode/src/views/SidebarWebviewProvider.ts
@@ -92,6 +92,15 @@ export interface SidebarWebviewDeps {
 	};
 	/** Returns absolute path under kbRoot for a relative path. */
 	resolveKbAbs?: (relPath: string) => string;
+	/**
+	 * True when the Memory Bank `.md` at `abs` has been edited on disk and its
+	 * sha256 no longer matches the manifest fingerprint. Consulted from
+	 * `handleOpenFile` so opening a diverged file surfaces the Folders-tab ✎
+	 * marker immediately (the row is already rendered; we just flip its flag)
+	 * instead of waiting for the next full re-listing. Optional so existing
+	 * tests that inject only `resolveKbAbs` keep working; absent → no check.
+	 */
+	isMemoryFileDivergedOnDisk?: (abs: string) => Promise<boolean>;
 	memoriesProvider?: {
 		serialize(): { items: ReadonlyArray<MemoryItem>; hasMore: boolean };
 		onDidChangeTreeData: (cb: () => void) => { dispose: () => void };
@@ -220,6 +229,16 @@ export class SidebarWebviewProvider
 	 */
 	private selectedRepoName: string | undefined;
 	private selectedBranchName: string | undefined;
+	// Per-path "latest divergence signal wins" generation. Bumped on every
+	// open-file divergence check AND on every revert, so whichever fired last
+	// for a given row is authoritative. markDivergedIfNeeded captures the value
+	// before its async disk check and drops its result if anything bumped the
+	// same path meanwhile — a newer open, or a revert. Without this, two opens
+	// of the same file could let an older/slower check overwrite the newer one,
+	// and a revert-in-flight could re-light a ✎ on a now-synced file. Keyed by
+	// the repoDir-prefixed relPath all paths use, so signals for one row never
+	// suppress another's.
+	private readonly divergenceCheckSeq = new Map<string, number>();
 
 	constructor(private readonly deps: SidebarWebviewDeps) {}
 
@@ -793,6 +812,23 @@ export class SidebarWebviewProvider
 		}
 	}
 
+	/**
+	 * Clears one Folders-tab file row's ✎ marker in place after a successful
+	 * single-file revert. Unlike {@link refreshKnowledgeBaseFolders} this does
+	 * NOT wipe `folderCache`, so every expanded branch directory stays open — a
+	 * content revert touches one file's bytes, not the tree's shape, so the
+	 * heavyweight reset (which collapses the whole tree) is the wrong response.
+	 * `relPath` is the repoDir-prefixed forward-slash path used as the client's
+	 * `folderCache` key. A non-Memory-Bank path (revert fired from the explorer
+	 * menu on an unrelated `.md`) simply finds no matching row and no-ops.
+	 */
+	clearKnowledgeBaseFolderDivergence(relPath: string): void {
+		// Claim "latest signal" for this row so any in-flight open-file check
+		// resolves into a no-op — the revert's clear is authoritative.
+		this.bumpDivergenceSeq(relPath);
+		this.postMessage({ type: "kb:clearDiverged", path: relPath });
+	}
+
 	/** Pushed from refreshStatusBar after enable/disable so the sidebar can show
 	 * or hide the disabled banner without an extension reload. */
 	notifyEnabledChanged(enabled: boolean): void {
@@ -963,9 +999,42 @@ export class SidebarWebviewProvider
 		const abs = this.deps.resolveKbAbs(relPath);
 		if (relPath.toLowerCase().endsWith(".md")) {
 			void this.deps.executeCommand("jollimemory.openMemoryFile", abs);
+			// Opening a `.md` is the one place divergence is checked outside the
+			// Folders-tab listing. Mirror that result onto the tree's ✎ marker so
+			// a file edited on disk while the sidebar was already open lights up
+			// the moment the user opens it — no manual refresh required.
+			void this.markDivergedIfNeeded(relPath, abs);
 		} else {
 			void this.deps.executeCommand("vscode.open", vscode.Uri.file(abs));
 		}
+	}
+
+	private bumpDivergenceSeq(relPath: string): number {
+		const next = (this.divergenceCheckSeq.get(relPath) ?? 0) + 1;
+		this.divergenceCheckSeq.set(relPath, next);
+		return next;
+	}
+
+	private async markDivergedIfNeeded(
+		relPath: string,
+		abs: string,
+	): Promise<void> {
+		if (!this.deps.isMemoryFileDivergedOnDisk) return;
+		// Claim "latest signal" for this row, then drop our result if a newer
+		// open or a revert bumped the same path while our async disk check was in
+		// flight — the newer signal is authoritative and posts the correct state.
+		const seq = this.bumpDivergenceSeq(relPath);
+		const diverged = await this.deps.isMemoryFileDivergedOnDisk(abs);
+		if ((this.divergenceCheckSeq.get(relPath) ?? 0) !== seq) return;
+		// Mirror the disk result onto the row BOTH ways: mark when diverged, clear
+		// when in sync. The clear is what lets reopening a now-synced file drop a
+		// ✎ left by an earlier open (or a stale listing) — without it the row
+		// stays marked until an explicit revert or full refresh. A clear for a row
+		// that isn't currently marked is a no-op client-side.
+		this.postMessage({
+			type: diverged ? "kb:markDiverged" : "kb:clearDiverged",
+			path: relPath,
+		});
 	}
 
 	public async refreshConversationsPanel(): Promise<void> {


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## Quick recap

The developer fixed a regression where reverting a single Memory Bank file to its system version would collapse every expanded branch directory in the Knowledge Base tree. The root cause was that the revert handler called `refreshKnowledgeBaseFolders()`, which wipes the entire client-side folder cache to reset the tree's shape — appropriate for operations like repository migrations, but overkill for a single-file content change. The fix introduces a targeted `kb:clearDiverged` message that rebuilds only the affected file's parent directory and propagates changes upward, leaving all expansion state intact.

A secondary improvement ensures that files edited on disk while the sidebar is open get their divergence marker immediately when opened, rather than requiring a manual refresh. The open-file handler now checks whether the file's on-disk hash matches the manifest and posts a marker update if needed, keeping the tree's visual state synchronized with the actual file state.

---

## E2E Test (2)
<details>
<summary><strong>1. Divergence marker disappears after reverting a single file without collapsing folders</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a Memory Bank repository open in VS Code with the Folders tab visible in the sidebar. Expand at least two folder levels so you can see multiple nested directories open. Edit one Memory Bank file on disk (outside VS Code) so it shows a pencil icon (✎) next to its name in the Folders tab, indicating it differs from the system version.

**Steps:**
1. Right-click on the edited file in the Folders tab and select "Revert to system version"
2. Wait for the confirmation message to appear
3. Look at the Folders tab and verify the pencil icon (✎) next to the file name has disappeared
4. Scroll up and down in the Folders tab to check that all the folder levels you had expanded before the revert are still expanded (no folders have collapsed)

**Expected Results:**
- The confirmation message "Reverted to system version: [filename]" should appear
- The pencil icon next to the reverted file should be gone
- All previously expanded folders should remain open — no folder should have collapsed back to its closed state

</blockquote>
</details>
<details>
<summary><strong>2. Pencil icon appears immediately when opening an edited file</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a Memory Bank repository open in VS Code with the Folders tab visible in the sidebar. Edit one Memory Bank file on disk (outside VS Code) so its content no longer matches the system version, but do NOT manually refresh the sidebar yet.

**Steps:**
1. In the Folders tab, click on the edited file to open it in the editor
2. Wait one second for the sidebar to process the open action
3. Look at the Folders tab and check whether the pencil icon (✎) appears next to the file name

**Expected Results:**
- The file should open in the editor
- The pencil icon (✎) should appear next to the file name in the Folders tab immediately, without requiring a manual refresh or collapse/expand of the parent folder

</blockquote>
</details>

---

## Topics (2)
<details>
<summary><strong>01 · Fix KB tree folder collapse when reverting a single edited file</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

When a user reverted a single Memory Bank file to its system version, all expanded branch directories in the Knowledge Base tree collapsed unexpectedly. The user expected only the reverted file's divergence marker to disappear while keeping the tree's expansion state intact.

**💡 Decisions Behind the Code**

- **Targeted update over tree reset**: The original code used `refreshKnowledgeBaseFolders()`, which sends `kb:foldersReset` and wipes the entire client-side `folderCache`. This was designed for operations that change the tree's shape (like repository migrations), not for single-file content changes. A targeted `kb:clearDiverged` message lets the client rebuild only the affected row and its parent, keeping all expansion state intact. This avoids the UX regression of collapsing every open folder just to clear one file's marker.
- **In-place flag flip mirrors existing pattern**: The codebase already had a `markFileDiverged()` pattern for lighting up the divergence marker when a file is opened. The fix mirrors that exact pattern (fresh object references, `propagateUp` to refresh ancestors, conditional re-render) for the inverse operation, ensuring consistency and reducing the risk of introducing new bugs through unfamiliar code paths.
- **Lazy re-fetch on manual refresh**: A secondary fix in `reattachExpandedFromCache()` now re-requests fresh data for each already-expanded folder during a manual refresh, so files edited on disk while the sidebar was open get their marker on refresh without requiring a collapse-and-re-expand. This addresses the root cause that only collapse+re-expand was recomputing `isDiverged`; refresh was reusing stale cached data.

**✅ What Was Implemented**

- Added two new inbound message types (`kb:markDiverged` and `kb:clearDiverged`) to `SidebarMessages.ts` to enable targeted single-row updates instead of tree-wide resets. These messages allow the client to flip a file's divergence flag in place without touching the folder cache that tracks expansion state.
- Implemented `clearFileDiverged()` and `markFileDiverged()` helper functions in `SidebarScriptBuilder.ts` that rebuild only the affected file's parent directory node and propagate changes upward, preserving all cached expansion state. The clear path explicitly avoids wiping `folderCache`, which was the root cause of the collapse.
- Modified the revert success handler in `Extension.ts` to call the new `clearKnowledgeBaseFolderDivergence()` method instead of `refreshKnowledgeBaseFolders()`, passing the file's relative path normalized to forward slashes for consistent client-side key matching.

**📁 FILES**
- `vscode/src/Extension.ts`
- `vscode/src/views/SidebarWebviewProvider.ts`
- `vscode/src/views/SidebarScriptBuilder.ts`
- `vscode/src/views/SidebarMessages.ts`

</blockquote>
</details>
<details>
<summary><strong>02 · Light up divergence marker when opening an edited file</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The divergence marker (pencil icon) only appeared in the Knowledge Base tree after a manual refresh or by collapsing and re-expanding a folder. If a user opened a file that had been edited on disk while the sidebar was already visible, the marker would not appear until the next refresh.

**💡 Decisions Behind the Code**

Opening a file is the one place outside the folder listing where divergence is checked, so it is the natural place to synchronize the tree's marker with the actual on-disk state. By posting the marker update at that moment, users see immediate visual feedback without waiting for a manual refresh. This keeps the Folders tab and the native file explorer's divergence indicators in sync.

**✅ What Was Implemented**

- Added `isMemoryFileDivergedOnDisk` dependency to `SidebarWebviewProvider` so the `handleOpenFile` method can check whether a `.md` file's on-disk hash matches the manifest fingerprint before opening it.
- Implemented `markDivergedIfNeeded()` in `SidebarWebviewProvider.ts` to asynchronously check divergence and post `kb:markDiverged` to the client when opening a diverged file, lighting up the marker immediately without requiring a full re-listing.
- Wired the dependency in `Extension.ts` to use `bridge.isMemoryFileDivergedOnDisk()`, reusing the same divergence detection logic that powers the native file decoration badge.

**📁 FILES**
- `vscode/src/views/SidebarWebviewProvider.ts`
- `vscode/src/Extension.ts`

</blockquote>
</details>

---

*Generated by Jolli Memory · June 3, 2026 at 4:39 PM · via Anthropic*
<!-- jollimemory-summary-end -->