### PR TITLE
Fix launchWorker to drop --disable-warning flag for old-Node compat

### DIFF
--- a/cli/src/hooks/QueueWorker.test.ts
+++ b/cli/src/hooks/QueueWorker.test.ts
@@ -350,7 +350,7 @@ import { buildMultiSessionContext } from "../core/TranscriptReader.js";
 import { consumePendingWorkers, recordPendingWorker } from "../sync/PendingWorkers.js";
 import { acquireVaultWriteLock } from "../sync/VaultWriteLock.js";
 import type { GitOperation } from "../Types.js";
-import { __test__, runWorker } from "./QueueWorker.js";
+import { __test__, buildWorkerStartupBanner, launchWorker, runWorker } from "./QueueWorker.js";
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
@@ -2033,6 +2033,72 @@ describe("QueueWorker", () => {
 			);
 
 			expect(cleanupBranchStaleChildMarkdown).not.toHaveBeenCalled();
+		});
+	});
+
+	describe("buildWorkerStartupBanner", () => {
+		it("reports source=cli verbatim for the CLI surface (no path derivation)", () => {
+			expect(
+				buildWorkerStartupBanner({
+					nodeVersion: "24.10.0",
+					kind: "cli",
+					pkgVersion: "1.2.3",
+					cliVersion: "1.2.3",
+					distDir: "/opt/whatever/dist",
+				}),
+			).toBe("node=24.10.0 kind=cli source=cli pkgVer=1.2.3 cliVer=1.2.3 dist=/opt/whatever/dist");
+		});
+
+		it("derives source=cursor from a Cursor extension dist path", () => {
+			expect(
+				buildWorkerStartupBanner({
+					nodeVersion: "22.5.0",
+					kind: "vscode-plugin",
+					pkgVersion: "0.99.1",
+					cliVersion: "1.4.0",
+					distDir: "/Users/luke/.cursor/extensions/jolli.jollimemory-vscode-0.99.1/dist",
+				}),
+			).toBe(
+				"node=22.5.0 kind=vscode-plugin source=cursor pkgVer=0.99.1 cliVer=1.4.0 dist=/Users/luke/.cursor/extensions/jolli.jollimemory-vscode-0.99.1/dist",
+			);
+		});
+
+		it("derives source=vscode from a VS Code extension dist path", () => {
+			expect(
+				buildWorkerStartupBanner({
+					nodeVersion: "20.11.0",
+					kind: "vscode-plugin",
+					pkgVersion: "0.99.1",
+					cliVersion: "1.4.0",
+					distDir: "/home/u/.vscode/extensions/jolli.jollimemory-vscode/dist",
+				}),
+			).toBe(
+				"node=20.11.0 kind=vscode-plugin source=vscode pkgVer=0.99.1 cliVer=1.4.0 dist=/home/u/.vscode/extensions/jolli.jollimemory-vscode/dist",
+			);
+		});
+	});
+
+	describe("launchWorker — argv hygiene (regression for old-Node startup crash)", () => {
+		it("spawns node with NO flags before scriptPath (no --disable-warning*)", () => {
+			vi.mocked(spawn).mockClear();
+
+			launchWorker("/test/cwd");
+
+			expect(spawn).toHaveBeenCalledTimes(1);
+			const args = vi.mocked(spawn).mock.calls[0][1] as string[];
+
+			// scriptPath is the first non-flag arg; everything before it is a
+			// Node flag. The whole point of the fix is that there are NONE.
+			const scriptIdx = args.findIndex((a) => a.endsWith("QueueWorker.js"));
+			expect(scriptIdx).toBe(0);
+			const nodeFlags = args.slice(0, scriptIdx);
+			expect(nodeFlags).toEqual([]);
+
+			// Belt-and-suspenders: the offending flag must not appear anywhere.
+			expect(args.some((a) => a.startsWith("--disable-warning"))).toBe(false);
+
+			// The legitimate script args are still present and ordered.
+			expect(args.slice(scriptIdx + 1)).toEqual(["--worker", "--cwd", "/test/cwd"]);
 		});
 	});
 });

--- a/cli/src/hooks/QueueWorker.ts
+++ b/cli/src/hooks/QueueWorker.ts
@@ -90,6 +90,7 @@ import { generateTranscriptId } from "../core/TranscriptId.js";
 import { getParserForSource } from "../core/TranscriptParser.js";
 import type { SessionTranscript } from "../core/TranscriptReader.js";
 import { buildMultiSessionContext, readTranscript } from "../core/TranscriptReader.js";
+import { deriveSourceTag } from "../install/DistPathResolver.js";
 import { createLogger, errMsg, setLogDir, setLogLevel } from "../Logger.js";
 import { consumePendingWorkers, recordPendingWorker } from "../sync/PendingWorkers.js";
 import { deriveMemoryBankRoot } from "../sync/SyncBootstrap.js";
@@ -208,22 +209,57 @@ export function launchWorker(cwd: string): void {
 	const dir = dirname(fileURLToPath(import.meta.url));
 	const scriptPath = join(dir, "QueueWorker.js");
 
-	const child = spawnHidden(
-		process.execPath,
-		// --disable-warning silences node:sqlite's ExperimentalWarning during OpenCode
-		// scans; it also suppresses any other experimental warnings in this subprocess.
-		["--disable-warning=ExperimentalWarning", scriptPath, "--worker", "--cwd", cwd],
-		{
-			detached: true,
-			stdio: "ignore",
-			cwd,
-		},
-	);
+	// NO Node flags before scriptPath. The git hook is launched as a bare
+	// `exec node <Hook>.js` (no flags), so `process.execPath` here may be a
+	// Node older than the CLI's `engines` floor. A flag the running Node
+	// doesn't recognise (e.g. `--disable-warning`, added in Node 20.11/21.3)
+	// makes the child exit immediately with `bad option` BEFORE running any
+	// code — and with `stdio: "ignore"` that crash is invisible, so the worker
+	// silently never starts and no summaries are generated. Keep the argv
+	// flag-free; suppressing cosmetic warnings is not worth breaking startup.
+	const child = spawnHidden(process.execPath, [scriptPath, "--worker", "--cwd", cwd], {
+		detached: true,
+		stdio: "ignore",
+		cwd,
+	});
 	child.unref();
 
 	log.info("Background worker spawned (PID: %d)", child.pid ?? -1);
 }
 /* v8 ignore stop */
+
+/**
+ * Builds the worker startup-banner string: which Node runtime and which
+ * JolliMemory surface/version is actually running. Logged at the very top of
+ * `runWorker` so a debug.log shows, per worker run, the Node version (the
+ * field that made the `--disable-warning` old-Node crash so hard to diagnose)
+ * plus whether the active dist is the VS Code plugin, the Cursor plugin, the
+ * CLI, etc., and its version.
+ *
+ * The surface tag (vscode / cursor / windsurf / cli) is reconstructed from the
+ * running dist directory via `deriveSourceTag` — the SAME derivation
+ * `installDistPath` used to name the `dist-paths/<source>` file — so vscode vs
+ * cursor is distinguished purely from where the worker runs, with no file I/O
+ * or reverse lookup. `__JOLLI_CLIENT_KIND__` alone can't do this: the same VSIX
+ * installed into VS Code, Cursor, Windsurf, … all self-identify as
+ * "vscode-plugin". `pkgVersion` is the surface's own release version
+ * (`__PKG_VERSION__`); `cliVersion` is the bundled `@jolli.ai/cli` core version
+ * (`__CLI_PKG_VERSION__`) — kept separate because they diverge under the VSCode
+ * bundle.
+ *
+ * Pure function (all inputs injected) so it is fully unit-testable across every
+ * surface; `runWorker` supplies the live globals.
+ */
+export function buildWorkerStartupBanner(info: {
+	nodeVersion: string;
+	kind: string;
+	pkgVersion: string;
+	cliVersion: string;
+	distDir: string;
+}): string {
+	const source = info.kind === "cli" ? "cli" : deriveSourceTag(info.distDir);
+	return `node=${info.nodeVersion} kind=${info.kind} source=${source} pkgVer=${info.pkgVersion} cliVer=${info.cliVersion} dist=${info.distDir}`;
+}
 
 /**
  * Worker: acquires lock, drains the git operation queue, and processes each entry.
@@ -238,7 +274,21 @@ export function launchWorker(cwd: string): void {
 export async function runWorker(cwd: string, force = false): Promise<void> {
 	setLogDir(cwd);
 
-	log.info("=== Queue worker started ===");
+	/* v8 ignore start -- compile-time global fallbacks: vite (tests) and esbuild (builds) always define these three, so the `: "…"` arms are unreachable from unit tests; mirrors ClientHeader.ts */
+	const kind = typeof __JOLLI_CLIENT_KIND__ !== "undefined" ? __JOLLI_CLIENT_KIND__ : "cli";
+	const pkgVersion = typeof __PKG_VERSION__ !== "undefined" ? __PKG_VERSION__ : "dev";
+	const cliVersion = typeof __CLI_PKG_VERSION__ !== "undefined" ? __CLI_PKG_VERSION__ : "dev";
+	/* v8 ignore stop */
+	log.info(
+		"=== Queue worker started === %s",
+		buildWorkerStartupBanner({
+			nodeVersion: process.versions.node,
+			kind,
+			pkgVersion,
+			cliVersion,
+			distDir: dirname(fileURLToPath(import.meta.url)),
+		}),
+	);
 
 	// Acquire `vault-write.lock` BEFORE constructing storage. Reason:
 	// `createStorage` → `createFolderStorage` → `resolveKBPath` has side


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## Quick recap

The background worker responsible for generating commit summaries was silently crashing on machines running an older system Node version. The worker appeared to launch successfully and received a process ID, but exited before running a single line of code, leaving no summaries produced and no trace in any log. Removing the incompatible Node startup flag resolved the crash, restoring summary generation for affected customers.

Every worker run now emits a diagnostic banner at startup recording the Node version, the active surface (VS Code plugin, Cursor plugin, or CLI), and the exact package version in use. Future incidents where a worker starts but behaves unexpectedly will immediately surface which runtime and plugin version was involved, without requiring a customer to run manual diagnostic commands. A regression test locks in the fix by verifying the shape of the spawn call, catching any future attempt to reintroduce a pre-script flag regardless of its name.

---

## Topic (1)
<details>
<summary><strong>01 · Fix background worker crash on older Node versions at startup</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

A customer reported that no commit summaries were being generated. The background worker was launching and receiving a process ID but dying instantly before running any code, with the failure completely invisible in logs.

**💡 Decisions Behind the Code**

- **Deletion over substitution**: The flag was removed entirely rather than replaced with an environment variable or guarded by a runtime version check. The warning it suppressed is written to stderr, which is already discarded, so no user ever sees it. An environment variable would suppress all warnings rather than just one and add maintenance surface for a problem that does not exist; a version check would add a new failure point to preserve a cosmetic no-op.
- **Pure function for the startup banner**: The banner logic was extracted into a standalone exported function with all inputs injected rather than reading globals inline inside the worker entry point. This makes the banner fully unit-testable across all surfaces without needing to mock module-level globals, and the three test cases can exercise the cli/cursor/vscode derivation paths directly.
- **Argv position assertion over string absence**: The regression test asserts that the script path is at index zero in the argv array, meaning the Node-flags segment before it is empty. This is more precise than checking for the absence of a specific flag name, and it will catch any future attempt to add a Node flag before the script path regardless of what that flag is named.

**✅ What Was Implemented**

- Removed `--disable-warning=ExperimentalWarning` from the Node flags passed to the worker process in `cli/src/hooks/QueueWorker.ts`. The flag was introduced to suppress a cosmetic SQLite warning but only exists in Node 20.11+/21.3+; on older system Node versions the runtime rejects it at startup with "bad option" before executing a single line of script. A detailed comment was added explaining why the flag list must remain empty.
- Added a `buildWorkerStartupBanner` pure function that constructs a diagnostic log line emitted at the very top of `runWorker`, capturing Node version, surface kind (VS Code plugin, Cursor plugin, or CLI), derived source tag, package version, CLI core version, and dist directory. The source tag is derived from the worker's own running path via `deriveSourceTag`, distinguishing Cursor from VS Code installs that would otherwise report identically.
- Added regression tests in `QueueWorker.test.ts`: three cases for `buildWorkerStartupBanner` covering cli/cursor/vscode surfaces, and one `launchWorker` argv hygiene test that mocks `spawnHidden` and asserts no flags appear before `scriptPath` and no `--disable-warning*` flag appears anywhere in the argv.

**📋 Future Enhancements**

Capturing worker stderr to a separate log file — so "worker dies before first log line" failures become visible — was discussed and deferred. The current regression test guards against this specific flag being re-added, but a general "startup crash is invisible" gap remains open under JOLLI-1657.

**📁 FILES**
- `cli/src/hooks/QueueWorker.ts`

</blockquote>
</details>

---

*Generated by Jolli Memory · June 4, 2026 at 4:12 PM · via Jolli proxy*
<!-- jollimemory-summary-end -->