### PR TITLE
vscode: refresh summary webview per-block instead of full-page rebuild

### DIFF
--- a/vscode/src/views/SummaryHtmlBuilder.test.ts
+++ b/vscode/src/views/SummaryHtmlBuilder.test.ts
@@ -119,8 +119,11 @@ import type {
 	PlanReference,
 } from "../../../cli/src/Types.js";
 import {
+	buildAllConversationsSection,
 	buildE2eTestSection,
 	buildHtml,
+	buildJolliRow,
+	buildPlansAndNotesSection,
 	buildRecapSection,
 	buildTopicsSection,
 	renderTopic,
@@ -1613,5 +1616,49 @@ describe("buildAllConversationsSection — Regenerate button", () => {
 		const matches = html.match(/id="regenerateSummaryBtn"/g) ?? [];
 		expect(matches.length).toBe(1);
 		expect(html).not.toMatch(/id="regenerateSummaryBtn"[^>]*disabled/);
+	});
+
+	// ── Partial-refresh support (Option B): exported section builders + the
+	//    stable #allConversationsSection wrapper the webview replaces in place. ──
+	describe("partial-refresh section builders", () => {
+		it("buildPlansAndNotesSection is exported and renders the #plansAndNotesSection container", () => {
+			const html = buildPlansAndNotesSection(
+				undefined,
+				undefined,
+				[],
+				new Set(),
+				new Set(),
+				new Set(),
+			);
+			expect(html).toContain('id="plansAndNotesSection"');
+		});
+
+		it("buildJolliRow is exported: returns '' without a url, renders #jolliRow with one", () => {
+			expect(buildJolliRow(undefined, "msg", undefined, undefined)).toBe("");
+			const withUrl = buildJolliRow(
+				"https://jolli.ai/x",
+				"msg",
+				undefined,
+				undefined,
+			);
+			expect(withUrl).toContain('id="jolliRow"');
+		});
+
+		it("buildAllConversationsSection wraps both branches in #allConversationsSection", () => {
+			// count === 0 (empty) branch
+			const empty = buildAllConversationsSection(new Set(), false);
+			expect(empty).toContain('id="allConversationsSection"');
+			expect(empty).toContain("No conversation transcripts saved");
+			// count > 0 branch (includes the modal)
+			const withData = buildAllConversationsSection(new Set(["h1"]), false);
+			expect(withData).toContain('id="allConversationsSection"');
+			expect(withData).toContain('id="transcriptModal"');
+		});
+
+		it("buildHtml embeds the #allConversationsSection wrapper", () => {
+			expect(buildHtml(makeSummary())).toContain(
+				'id="allConversationsSection"',
+			);
+		});
 	});
 });

--- a/vscode/src/views/SummaryHtmlBuilder.ts
+++ b/vscode/src/views/SummaryHtmlBuilder.ts
@@ -211,8 +211,14 @@ function buildDurationRow(summary: CommitSummary): string {
   </div>`;
 }
 
-/** Builds the optional "Memory" property row with a clickable article link. */
-function buildJolliRow(
+/**
+ * Builds the optional "Memory" property row with a clickable article link.
+ *
+ * Exported so the webview panel can re-render just the `#jolliRow` (which
+ * embeds the published Plans & Notes link list) after a plan/note add/remove,
+ * without a full-page rebuild. See SummaryWebviewPanel.refreshPlansAndNotes.
+ */
+export function buildJolliRow(
 	url?: string,
 	commitMessage?: string,
 	plans?: ReadonlyArray<PlanReference>,
@@ -435,7 +441,17 @@ export function buildTopicsSection(
  * markup mirrors `buildPlanRow` exactly so the CSS classes (`plan-item`,
  * `plan-header`, `plan-edit-area`, …) are shared.
  */
-function buildPlansAndNotesSection(
+/**
+ * Builds the Plans & Notes section (`#plansAndNotesSection`).
+ *
+ * Exported so the webview panel can re-render just this section after a
+ * plan/note/reference add/remove/save/translate, without a full-page rebuild.
+ * Mutations are also paired with a `#jolliRow` refresh (see
+ * SummaryWebviewPanel.refreshPlansAndNotes). Emits a trailing
+ * `<hr class="separator" />` sibling — the webview's `replaceSection` strips
+ * the stale one to avoid stacked separators.
+ */
+export function buildPlansAndNotesSection(
 	plans: ReadonlyArray<PlanReference> | undefined,
 	notes: ReadonlyArray<NoteReference> | undefined,
 	references: ReadonlyArray<ReferenceCommitRef> | undefined,
@@ -770,16 +786,17 @@ export function renderE2eScenario(s: E2eTestScenario, index: number): string {
  *    Save/Delete/Cancel buttons stay hidden by the same CSS rule so
  *    nothing destructive is reachable.
  */
-function buildAllConversationsSection(
+export function buildAllConversationsSection(
 	transcriptHashSet?: ReadonlySet<string>,
 	isForeign: boolean = false,
 ): string {
 	const count = transcriptHashSet?.size ?? 0;
+	let inner: string;
 	if (count === 0) {
 		const emptyActions = isForeign
 			? ""
 			: `      <button class="action-btn" id="regenerateSummaryBtn" title="Re-run the LLM end-to-end">&#x21BB; Regenerate</button>`;
-		return `
+		inner = `
 <div class="private-zone">
   <div class="private-zone-watermark">PRIVATE</div>
   <div class="section-header">
@@ -790,14 +807,13 @@ ${emptyActions}
   </div>
   <p class="empty">No conversation transcripts saved for this commit.</p>
 </div>`;
-	}
-
-	const headerActions = isForeign
-		? `      <button class="action-btn" id="openTranscriptsBtn" data-foreign-safe title="Browse transcripts (read-only)">View</button>`
-		: `      <button class="action-btn" id="regenerateSummaryBtn" title="Re-run the LLM end-to-end">&#x21BB; Regenerate</button>
+	} else {
+		const headerActions = isForeign
+			? `      <button class="action-btn" id="openTranscriptsBtn" data-foreign-safe title="Browse transcripts (read-only)">View</button>`
+			: `      <button class="action-btn" id="regenerateSummaryBtn" title="Re-run the LLM end-to-end">&#x21BB; Regenerate</button>
       <button class="action-btn" id="openTranscriptsBtn">Manage</button>`;
 
-	return `
+		inner = `
 <div class="private-zone">
   <div class="private-zone-watermark">PRIVATE</div>
   <div class="section-header">
@@ -813,6 +829,13 @@ ${headerActions}
   <p class="conversations-privacy">&#x1F512; Your private data — stored on your machine only. Nothing is uploaded unless you choose to.</p>
 </div>
 ${buildTranscriptModal(isForeign)}`;
+	}
+	// Wrap private-zone + modal in a stable #allConversationsSection container so
+	// the webview can replace just this block on transcript save/delete via
+	// replaceSection (no full-page rebuild). See SummaryWebviewPanel.refreshConversations.
+	return `
+<div id="allConversationsSection">${inner}
+</div>`;
 }
 
 /**

--- a/vscode/src/views/SummaryScriptBuilder.test.ts
+++ b/vscode/src/views/SummaryScriptBuilder.test.ts
@@ -306,4 +306,83 @@ describe("SummaryScriptBuilder", () => {
 			expect(script).toContain("'.plan-edit-textarea'");
 		});
 	});
+
+	describe("partial refresh (Option B) message handlers", () => {
+		it("topicsUpdated rebuilds the section: ESC cleanup, replace, re-attach, and PRESERVE per-topic collapse", () => {
+			expect(script).toContain("msg.command === 'topicsUpdated'");
+			expect(script).toContain("replaceSection('topicsSection', msg.html)");
+			// Per-topic collapse is snapshotted by the stable data-topic payload
+			// (the topic-<index> id renumbers on delete) and restored after the
+			// rebuild, so deleting one topic does NOT re-expand the others.
+			expect(script).toContain("collapseByTopic");
+			expect(script).toContain("getAttribute('data-topic')");
+			// allCollapsed is recomputed from the restored DOM (NOT forced false),
+			// so the #toggleAllBtn label stays accurate.
+			expect(script).toContain(
+				"allCollapsed = topicCount > 0 && everyCollapsed",
+			);
+			expect(script).toContain("attachToggleAllBtnHandler()");
+			// ESC cleanup on still-editing topics before the nodes are discarded.
+			expect(script).toContain("classList.contains('editing')");
+		});
+
+		it("topicUpdated preserves collapse via the `collapsed` class (not the no-op `open`)", () => {
+			// Slice the single-topic-edit handler so the assertions are specific
+			// to it (the `open` class is still used elsewhere for dropdown menus).
+			const start = script.indexOf("msg.command === 'topicUpdated'");
+			const end = script.indexOf("topicUpdateError");
+			const block = script.slice(start, end);
+			expect(block).toContain("wasCollapsed");
+			expect(block).toContain("classList.contains('collapsed')");
+			// Regression guard: the old no-op `open` snapshot must be gone here.
+			expect(block).not.toContain("'open'");
+		});
+
+		it("plansAndNotesUpdated replaces the section and re-binds the snippet inputs", () => {
+			expect(script).toContain("msg.command === 'plansAndNotesUpdated'");
+			expect(script).toContain(
+				"replaceSection('plansAndNotesSection', msg.html)",
+			);
+			// Snippet form input listeners are per-element (lost on replace) → re-bound.
+			expect(script).toContain("function bindPlansAndNotesSection()");
+			expect(script).toContain("bindPlansAndNotesSection()");
+		});
+
+		it("jolliRowUpdated targets the header row by id", () => {
+			expect(script).toContain("msg.command === 'jolliRowUpdated'");
+			expect(script).toContain("getElementById('jolliRow')");
+		});
+
+		it("conversationsUpdated replaces the section and re-binds refs + buttons", () => {
+			expect(script).toContain("msg.command === 'conversationsUpdated'");
+			expect(script).toContain(
+				"replaceSection('allConversationsSection', msg.html)",
+			);
+			expect(script).toContain("function bindConversationsSection()");
+		});
+
+		it("transcriptsSaved/Deleted no longer closeModal — close is owned by the conversationsUpdated rebuild", () => {
+			// Guard against regressing to the old `transcriptsSaved') { closeModal() }`
+			// shape; the section rebuild closes the modal instead.
+			expect(script).not.toMatch(
+				/transcriptsSaved'\s*\)\s*\{\s*closeModal\(\)/,
+			);
+		});
+
+		it("the modal ESC keydown is registered once OUTSIDE bindConversationsSection (no per-refresh leak)", () => {
+			const bindStart = script.indexOf("function bindConversationsSection()");
+			const bindEnd = script.indexOf("bindConversationsSection();", bindStart);
+			const bindBody = script.slice(bindStart, bindEnd);
+			expect(bindBody).not.toContain("addEventListener('keydown'");
+			// …but the global keydown handler does exist at top level.
+			expect(script).toContain("addEventListener('keydown'");
+		});
+
+		it("replaceSection strips a stale trailing <hr> only when the new html ends in one (generalized beyond recap)", () => {
+			expect(script).toContain("function replaceSection(id, html)");
+			expect(script).toContain("lastNew.tagName === 'HR'");
+			// The old recap-only special-case (id === 'recapSection') is gone.
+			expect(script).not.toContain("id === 'recapSection'");
+		});
+	});
 });

--- a/vscode/src/views/SummaryScriptBuilder.ts
+++ b/vscode/src/views/SummaryScriptBuilder.ts
@@ -131,16 +131,18 @@ ${buildPrMessageScript()}
         if (oldToggle._escHandler) {
           document.removeEventListener('keydown', oldToggle._escHandler);
         }
-        // Check if old toggle was expanded
-        var wasOpen = oldToggle.classList.contains('open');
+        // Preserve the collapsed state across the re-render. Topics collapse via
+        // the "collapsed" class ("open" is for dropdown menus / the snippet form),
+        // so the prior "open" snapshot here was a no-op that silently dropped the
+        // collapse state on every single-topic edit.
+        var wasCollapsed = oldToggle.classList.contains('collapsed');
         // Replace with server-rendered HTML
         var wrapper = document.createElement('div');
         wrapper.innerHTML = msg.html;
         var newToggle = wrapper.firstElementChild;
         if (newToggle) {
           oldToggle.replaceWith(newToggle);
-          // Preserve open/collapsed state
-          if (wasOpen) { newToggle.classList.add('open'); }
+          if (wasCollapsed) { newToggle.classList.add('collapsed'); }
           // Re-attach edit/delete button handlers on the new element
           attachTopicHandlers(newToggle);
         }
@@ -154,6 +156,47 @@ ${buildPrMessageScript()}
         if (saveBtn) { saveBtn.textContent = 'Save'; saveBtn.disabled = false; }
         if (cancelBtn) { cancelBtn.disabled = false; }
       }
+    }
+
+    // ── Topics whole-section replace (after a topic delete) ──
+    // Topic edit/delete buttons carry positional treeIndex values; deleting one
+    // shifts every later index, so we rebuild the whole #topicsSection rather
+    // than removing a single node. But a blind rebuild would re-expand the
+    // topics the user had collapsed, so we snapshot each surviving topic's
+    // collapsed state — keyed by its data-topic payload, which is stable across
+    // the treeIndex renumbering (the topic-<index> id is NOT) — and restore it
+    // after the replace, then recompute allCollapsed so the #toggleAllBtn label
+    // stays accurate. Editing ESC handlers are also cleaned up before the nodes
+    // are discarded (partial replace keeps the JS context, so a leaked global
+    // keydown would accumulate).
+    if (msg.command === 'topicsUpdated' && typeof msg.html === 'string') {
+      var oldTopicsSec = document.getElementById('topicsSection');
+      var collapseByTopic = {};
+      if (oldTopicsSec) {
+        oldTopicsSec.querySelectorAll('.toggle').forEach(function(t) {
+          var key = t.getAttribute('data-topic');
+          if (key) collapseByTopic[key] = t.classList.contains('collapsed');
+          if (t.classList.contains('editing') && t._escHandler) {
+            document.removeEventListener('keydown', t._escHandler);
+          }
+        });
+      }
+      replaceSection('topicsSection', msg.html);
+      var newTopicsSec = document.getElementById('topicsSection');
+      var topicCount = 0;
+      var everyCollapsed = true;
+      if (newTopicsSec) {
+        attachTopicHandlers(newTopicsSec);
+        newTopicsSec.querySelectorAll('.toggle-header').forEach(attachToggleHeader);
+        newTopicsSec.querySelectorAll('.toggle').forEach(function(t) {
+          topicCount++;
+          var key = t.getAttribute('data-topic');
+          if (key && collapseByTopic[key]) t.classList.add('collapsed');
+          if (!t.classList.contains('collapsed')) everyCollapsed = false;
+        });
+      }
+      allCollapsed = topicCount > 0 && everyCollapsed;
+      attachToggleAllBtnHandler();
     }
 
     // ── Recap edit / generate status ──
@@ -732,11 +775,16 @@ ${buildPrMessageScript()}
     if (banner) banner.remove();
   }
 
-  // CONTRACT: this function depends on buildRecapSection in
-  // SummaryHtmlBuilder.ts emitting "<div id='recapSection'>...</div><hr/>"
-  // (two siblings) and buildTopicsSection emitting a single <div>. If either
-  // shape changes, update this function in the same commit — otherwise the
-  // regenerate success path leaves stacked or missing <hr class="separator">.
+  // CONTRACT: callers pass section HTML from SummaryHtmlBuilder.ts. Two shapes
+  // exist and both are handled by the trailing-<hr> logic below:
+  //   - "<div id='…'>…</div><hr class='separator'/>" (two siblings) —
+  //     buildRecapSection, buildE2eTestSection, buildPlansAndNotesSection.
+  //   - "<div id='…'>…</div>" (single node, no trailing <hr>) —
+  //     buildTopicsSection (last content section before the footer).
+  // Used by summaryRegenerated (recap+topics), topicsUpdated, and
+  // plansAndNotesUpdated. If any of those builders' trailing-separator shape
+  // changes, update the logic below in the same commit — otherwise the partial
+  // refresh leaves stacked or missing <hr class="separator">.
   function replaceSection(id, html) {
     var old = document.getElementById(id);
     if (!old) return;
@@ -744,10 +792,15 @@ ${buildPrMessageScript()}
     wrap.innerHTML = html;
     var nodes = Array.prototype.slice.call(wrap.childNodes).filter(function(n) { return n.nodeType === 1; });
     if (nodes.length === 0) return;
-    // Drop the OLD recap's trailing <hr> before splicing in the new node(s),
-    // so we don't end up with two separators stacked.
+    // If the NEW html ends with its own <hr class="separator"> sibling, drop the
+    // OLD node's trailing <hr> first so we don't stack two separators. The
+    // recap / e2e / plansAndNotes sections all emit a "<div>…</div><hr/>" pair;
+    // topicsSection ends in "</div>" (no trailing <hr>), so the guard is a
+    // no-op there. Generalized from the former recap-only special case so the
+    // same helper serves topicsUpdated / plansAndNotesUpdated too.
+    var lastNew = nodes[nodes.length - 1];
     var sep = old.nextElementSibling;
-    if (sep && sep.tagName === 'HR' && id === 'recapSection') sep.remove();
+    if (lastNew && lastNew.tagName === 'HR' && sep && sep.tagName === 'HR') sep.remove();
     old.replaceWith.apply(old, nodes);
   }
 
@@ -1019,6 +1072,36 @@ ${buildPrMessageScript()}
 
   if (msg.command === 'snippetSaved') {
     hideSnippetForm();
+  }
+
+  // ── Plans & Notes whole-section replace ──
+  // After a plan/note/reference add/remove/save/translate the host re-renders
+  // the whole #plansAndNotesSection (keeps the count badge + empty-state in
+  // sync). data-action buttons are document-delegated so they survive the
+  // replace; the snippet form's per-element input listeners do NOT, so
+  // bindPlansAndNotesSection re-binds them.
+  if (msg.command === 'plansAndNotesUpdated' && typeof msg.html === 'string') {
+    replaceSection('plansAndNotesSection', msg.html);
+    bindPlansAndNotesSection();
+  }
+
+  // ── Header Jolli row (published Plans & Notes link list) ──
+  // Sent alongside plansAndNotesUpdated because #jolliRow embeds that link list.
+  // Replace if present; remove if the new html is empty; ignore if absent
+  // (#jolliRow only exists after the commit is pushed, and push takes the
+  // full-rebuild path).
+  if (msg.command === 'jolliRowUpdated' && typeof msg.html === 'string') {
+    var oldJolliRow = document.getElementById('jolliRow');
+    if (oldJolliRow) {
+      if (msg.html.trim().length === 0) {
+        oldJolliRow.remove();
+      } else {
+        var jolliWrap = document.createElement('div');
+        jolliWrap.innerHTML = msg.html;
+        var newJolliRow = jolliWrap.firstElementChild;
+        if (newJolliRow) oldJolliRow.replaceWith(newJolliRow);
+      }
+    }
   }
 
   // ── Plan translation status ──
@@ -1329,22 +1412,29 @@ ${buildPrMessageScript()}
     var hasContent = sContent && sContent.value.trim();
     if (saveBtn) saveBtn.disabled = !(hasTitle && hasContent);
   }
-  // Enable/disable Save button based on title and content
-  var snippetTitleEl = document.getElementById('snippetTitle');
-  var snippetContentEl = document.getElementById('snippetContent');
-  if (snippetTitleEl) {
-    snippetTitleEl.addEventListener('input', updateSaveSnippetBtn);
+  // Enable/disable Save button based on title and content. The snippet form
+  // lives inside #plansAndNotesSection, so these per-element input listeners are
+  // lost when that section is replaced (plansAndNotesUpdated). bindPlansAndNotesSection
+  // re-grabs + re-binds them; it runs at init AND after each section replace.
+  // (The plan/note/reference data-action buttons are document-delegated, so
+  // they need no re-bind.)
+  function bindPlansAndNotesSection() {
+    var snippetTitleEl = document.getElementById('snippetTitle');
+    var snippetContentEl = document.getElementById('snippetContent');
+    if (snippetTitleEl) {
+      snippetTitleEl.addEventListener('input', updateSaveSnippetBtn);
+    }
+    if (snippetContentEl) {
+      snippetContentEl.addEventListener('input', updateSaveSnippetBtn);
+    }
   }
-  if (snippetContentEl) {
-    snippetContentEl.addEventListener('input', updateSaveSnippetBtn);
-  }
+  bindPlansAndNotesSection();
 
   // ── Transcript Stats (async load for section description) ───────────────
-
+  // Reassigned by bindConversationsSection after a section replace; the
+  // transcriptStatsLoaded handler fills whatever it points at. The initial (and
+  // post-refresh) stats load is kicked off from bindConversationsSection().
   var conversationsStats = document.getElementById('conversationsStats');
-  if (conversationsStats) {
-    vscode.postMessage({ command: 'loadTranscriptStats' });
-  }
 
   // ── Transcript Modal ──────────────────────────────────────────────────────
 
@@ -1657,39 +1747,68 @@ ${buildTranscriptEntriesScript()}
     return text;
   }
 
-  // Wire up buttons
-  if (openTranscriptsBtn) openTranscriptsBtn.addEventListener('click', openModal);
-  if (modalCloseBtn) modalCloseBtn.addEventListener('click', function() { closeModal(); });
-  if (modalCancelBtn) modalCancelBtn.addEventListener('click', function() { closeModal(); });
-  if (transcriptModal) {
-    transcriptModal.addEventListener('click', function(e) {
-      if (e.target === transcriptModal) closeModal();
-    });
+  // ── Conversations section binding (init + after conversationsUpdated) ────
+  // After conversationsUpdated replaces #allConversationsSection the old modal +
+  // button nodes are discarded, so we re-grab every ref (reassigning the closure
+  // vars that openModal/closeModal/renderTranscriptEntries/the message listener
+  // all read) and re-wire the per-element button listeners. The GLOBAL keydown +
+  // message listeners are registered ONCE, below, outside this function — they
+  // read the reassignable refs, so they keep working against the new modal
+  // without piling up duplicate registrations on every refresh.
+  function bindConversationsSection() {
+    transcriptModal = document.getElementById('transcriptModal');
+    modalTabs = document.getElementById('modalTabs');
+    modalBody = document.getElementById('modalBody');
+    modalLoading = document.getElementById('modalLoading');
+    modalSubtitle = document.getElementById('modalSubtitle');
+    modalSaveBtn = document.getElementById('modalSaveBtn');
+    modalCancelBtn = document.getElementById('modalCancelBtn');
+    modalCloseBtn = document.getElementById('modalCloseBtn');
+    deleteTranscriptsBtn = document.getElementById('deleteTranscriptsBtn');
+    openTranscriptsBtn = document.getElementById('openTranscriptsBtn');
+    conversationsStats = document.getElementById('conversationsStats');
+
+    if (openTranscriptsBtn) openTranscriptsBtn.addEventListener('click', openModal);
+    if (modalCloseBtn) modalCloseBtn.addEventListener('click', function() { closeModal(); });
+    if (modalCancelBtn) modalCancelBtn.addEventListener('click', function() { closeModal(); });
+    if (transcriptModal) {
+      transcriptModal.addEventListener('click', function(e) {
+        if (e.target === transcriptModal) closeModal();
+      });
+    }
+    if (modalSaveBtn) {
+      modalSaveBtn.addEventListener('click', function() {
+        var data = collectSaveData();
+        vscode.postMessage({ command: 'saveAllTranscripts', entries: data });
+        modalSaveBtn.disabled = true;
+        modalSaveBtn.textContent = 'Saving...';
+      });
+    }
+    if (deleteTranscriptsBtn) {
+      deleteTranscriptsBtn.addEventListener('click', function() {
+        // Mark all entries as deleted across all sessions (same as clicking each tab's delete)
+        if (!modalTabs || !modalBody) return;
+        var allTabs = modalTabs.querySelectorAll('.modal-tab:not(.session-deleted)');
+        for (var t = 0; t < allTabs.length; t++) {
+          var tabDeleteBtn = allTabs[t].querySelector('.session-delete-btn');
+          if (tabDeleteBtn) tabDeleteBtn.click();
+        }
+      });
+    }
+
+    // Kick off / refresh the async stats line for the (possibly new) element.
+    if (conversationsStats) vscode.postMessage({ command: 'loadTranscriptStats' });
   }
+  bindConversationsSection();
+
+  // GLOBAL listener — registered ONCE (NOT inside bindConversationsSection, or
+  // every refresh would stack another). Reads the reassignable transcriptModal
+  // ref + closure closeModal fn, so it stays valid across section rebuilds.
   document.addEventListener('keydown', function(e) {
     if (e.key === 'Escape' && transcriptModal && transcriptModal.classList.contains('visible')) {
       closeModal();
     }
   });
-  if (modalSaveBtn) {
-    modalSaveBtn.addEventListener('click', function() {
-      var data = collectSaveData();
-      vscode.postMessage({ command: 'saveAllTranscripts', entries: data });
-      modalSaveBtn.disabled = true;
-      modalSaveBtn.textContent = 'Saving...';
-    });
-  }
-  if (deleteTranscriptsBtn) {
-    deleteTranscriptsBtn.addEventListener('click', function() {
-      // Mark all entries as deleted across all sessions (same as clicking each tab's delete)
-      if (!modalTabs || !modalBody) return;
-      var allTabs = modalTabs.querySelectorAll('.modal-tab:not(.session-deleted)');
-      for (var t = 0; t < allTabs.length; t++) {
-        var tabDeleteBtn = allTabs[t].querySelector('.session-delete-btn');
-        if (tabDeleteBtn) tabDeleteBtn.click();
-      }
-    });
-  }
 
   // Handle transcript messages from extension
   window.addEventListener('message', function(event) {
@@ -1706,12 +1825,17 @@ ${buildTranscriptEntriesScript()}
       baseSubtitle = totalEntries + ' entries, ' + sessionCount + ' session' + (sessionCount !== 1 ? 's' : '');
       if (modalSubtitle) modalSubtitle.textContent = baseSubtitle;
     }
-    if (msg.command === 'transcriptsSaved') {
-      closeModal();
+    // Success: the host re-renders the whole #allConversationsSection, which
+    // discards the open modal (closing it) and refreshes the stats / empty
+    // state. bindConversationsSection re-grabs refs + re-wires the new buttons.
+    if (msg.command === 'conversationsUpdated' && typeof msg.html === 'string') {
+      replaceSection('allConversationsSection', msg.html);
+      bindConversationsSection();
     }
-    if (msg.command === 'transcriptsDeleted') {
-      // Modal already closed by deleteTranscriptsBtn handler
-    }
+    // transcriptsSaved / transcriptsDeleted are still posted by the host (kept
+    // for existing assertions), but intentionally do NO DOM work here: closing +
+    // refresh is owned by conversationsUpdated above. The former closeModal()
+    // was removed so it doesn't double-handle / race the rebuild.
     // Failure paths (added 2026-05-22 for v5): backend posts these when summary
     // update or transcript file batch failed. Without handling them, the Save
     // button would stay stuck in "Saving..." disabled state forever (the user

--- a/vscode/src/views/SummaryWebviewPanel.test.ts
+++ b/vscode/src/views/SummaryWebviewPanel.test.ts
@@ -419,6 +419,9 @@ const {
 	mockBuildTopicsSection,
 	mockRenderTopic,
 	mockRenderE2eScenario,
+	mockBuildPlansAndNotesSection,
+	mockBuildJolliRow,
+	mockBuildAllConversationsSection,
 } = vi.hoisted(() => ({
 	mockBuildHtml: vi.fn().mockReturnValue("<html>mock</html>"),
 	mockBuildE2eTestSection: vi.fn().mockReturnValue("<div>e2e</div>"),
@@ -426,6 +429,13 @@ const {
 	mockBuildTopicsSection: vi.fn().mockReturnValue("<div>topics</div>"),
 	mockRenderTopic: vi.fn().mockReturnValue("<div>topic</div>"),
 	mockRenderE2eScenario: vi.fn().mockReturnValue("<div>scenario</div>"),
+	mockBuildPlansAndNotesSection: vi
+		.fn()
+		.mockReturnValue("<div>plansAndNotes</div>"),
+	mockBuildJolliRow: vi.fn().mockReturnValue("<div>jolliRow</div>"),
+	mockBuildAllConversationsSection: vi
+		.fn()
+		.mockReturnValue("<div>conversations</div>"),
 }));
 
 vi.mock("./SummaryHtmlBuilder.js", () => ({
@@ -435,6 +445,9 @@ vi.mock("./SummaryHtmlBuilder.js", () => ({
 	buildTopicsSection: mockBuildTopicsSection,
 	renderTopic: mockRenderTopic,
 	renderE2eScenario: mockRenderE2eScenario,
+	buildPlansAndNotesSection: mockBuildPlansAndNotesSection,
+	buildJolliRow: mockBuildJolliRow,
+	buildAllConversationsSection: mockBuildAllConversationsSection,
 }));
 
 const { mockBuildMarkdown, mockBuildPrMarkdown } = vi.hoisted(() => ({
@@ -1246,6 +1259,166 @@ describe("SummaryWebviewPanel", () => {
 
 			// webview.html must not have been overwritten — update() short-circuited.
 			expect(firstPanel.webview.html).toBe("<sentinel>");
+		});
+
+		it("refresh* partial helpers are no-ops on a disposed instance (post-await race)", async () => {
+			const summary = makeSummary({ commitHash: "aaa" });
+			await SummaryWebviewPanel.show(
+				summary,
+				extensionUri,
+				workspaceRoot,
+				stubBridge,
+				mainBranch,
+				"memory",
+			);
+			const instance = (
+				SummaryWebviewPanel as unknown as {
+					currentMemoryPanel: {
+						disposed: boolean;
+						refreshPlansAndNotes: (s: unknown) => void;
+						refreshTopicsSection: (s: unknown) => void;
+						refreshConversations: (s: unknown) => void;
+					};
+				}
+			).currentMemoryPanel;
+			instance.disposed = true;
+			postMessage.mockClear();
+
+			// All three helpers must bail before touching the (disposed) webview,
+			// mirroring update()'s disposed guard.
+			instance.refreshPlansAndNotes(summary);
+			instance.refreshTopicsSection(summary);
+			instance.refreshConversations(summary);
+
+			expect(postMessage).not.toHaveBeenCalled();
+		});
+
+		// Direct unit tests on the private partial-refresh helpers. They exercise
+		// branches (readOnly / foreign / references-present) that are unreachable
+		// through the normal handler flow — e.g. deleteTopic can't run on a
+		// readonly panel (stale → ensureCommitNotRewritten bails; foreign →
+		// dispatch denied), yet refreshTopicsSection still threads the real
+		// readOnly so a future caller renders correctly.
+		type RefreshCallable = {
+			disposed: boolean;
+			foreignRepoName: string | null;
+			staleRewrittenInto: string | null;
+			transcriptHashSet: Set<string>;
+			refreshPlansAndNotes: (s: CommitSummary) => void;
+			refreshTopicsSection: (s: CommitSummary) => void;
+			refreshConversations: (s: CommitSummary) => void;
+		};
+		async function getPanelInstance(
+			summary: CommitSummary,
+		): Promise<RefreshCallable> {
+			await SummaryWebviewPanel.show(
+				summary,
+				extensionUri,
+				workspaceRoot,
+				stubBridge,
+				mainBranch,
+				"memory",
+			);
+			return (
+				SummaryWebviewPanel as unknown as {
+					currentMemoryPanel: RefreshCallable;
+				}
+			).currentMemoryPanel;
+		}
+
+		it("refreshPlansAndNotes posts plansAndNotesUpdated + jolliRowUpdated and forwards references", async () => {
+			const reference = {
+				source: "linear" as const,
+				archivedKey: "linear:ENG-1",
+				nativeId: "ENG-1",
+				title: "Ref",
+				url: "https://linear.app/x/ENG-1",
+				referencedAt: "2025-01-01T00:00:00Z",
+				sourceToolName: "Linear",
+			};
+			const summary = makeSummary({ commitHash: "aaa", references: [reference] });
+			const instance = await getPanelInstance(summary);
+			postMessage.mockClear();
+			mockBuildPlansAndNotesSection.mockClear();
+
+			instance.refreshPlansAndNotes(summary);
+
+			const commands = postMessage.mock.calls.map((c) => c[0].command);
+			expect(commands).toContain("plansAndNotesUpdated");
+			expect(commands).toContain("jolliRowUpdated");
+			// references (3rd positional arg) forwarded, not dropped.
+			expect(mockBuildPlansAndNotesSection.mock.calls[0][2]).toEqual([reference]);
+		});
+
+		it("refreshTopicsSection threads readOnly=true on a foreign panel", async () => {
+			const summary = makeSummary({ commitHash: "aaa" });
+			const instance = await getPanelInstance(summary);
+			instance.foreignRepoName = "other-repo";
+			mockBuildTopicsSection.mockClear();
+			postMessage.mockClear();
+
+			instance.refreshTopicsSection(summary);
+
+			expect(mockBuildTopicsSection).toHaveBeenCalledWith(summary, {
+				readOnly: true,
+			});
+			expect(postMessage.mock.calls.map((c) => c[0].command)).toContain(
+				"topicsUpdated",
+			);
+		});
+
+		it("refreshTopicsSection threads readOnly=true on a stale-rewritten panel", async () => {
+			const summary = makeSummary({ commitHash: "aaa" });
+			const instance = await getPanelInstance(summary);
+			instance.foreignRepoName = null;
+			instance.staleRewrittenInto = "bbbbbbbb";
+			mockBuildTopicsSection.mockClear();
+
+			instance.refreshTopicsSection(summary);
+
+			expect(mockBuildTopicsSection).toHaveBeenCalledWith(summary, {
+				readOnly: true,
+			});
+		});
+
+		it("refreshConversations passes isForeign=true on a foreign panel", async () => {
+			const summary = makeSummary({ commitHash: "aaa" });
+			const instance = await getPanelInstance(summary);
+			instance.foreignRepoName = "other-repo";
+			instance.transcriptHashSet = new Set(["h1"]);
+			mockBuildAllConversationsSection.mockClear();
+			postMessage.mockClear();
+
+			instance.refreshConversations(summary);
+
+			expect(mockBuildAllConversationsSection).toHaveBeenCalledWith(
+				instance.transcriptHashSet,
+				true,
+			);
+			expect(postMessage.mock.calls.map((c) => c[0].command)).toContain(
+				"conversationsUpdated",
+			);
+		});
+
+		it("refresh helpers still post their partial update during regenerate (in-flight async write must clear its block's loading state)", async () => {
+			// Regression guard for the removed regenerateInProgress skip: a translate
+			// dispatched before regenerate can land mid-regenerate. Its block
+			// (plans/notes) is disjoint from what regenerate re-renders
+			// (topics/recap/banner), and the section rebuild is the ONLY thing that
+			// clears the translate button's loading state (no *Translated DOM
+			// handler). Skipping it would strand the button on "translating".
+			const summary = makeSummary({ commitHash: "aaa" });
+			const instance = (await getPanelInstance(summary)) as RefreshCallable & {
+				regenerateInProgress: boolean;
+			};
+			instance.regenerateInProgress = true;
+			postMessage.mockClear();
+
+			instance.refreshPlansAndNotes(summary);
+
+			expect(postMessage.mock.calls.map((c) => c[0].command)).toContain(
+				"plansAndNotesUpdated",
+			);
 		});
 
 		it("collects transcript hashes from nested children via collectTreeHashes", async () => {
@@ -2671,6 +2844,18 @@ describe("SummaryWebviewPanel", () => {
 					updatedSummary,
 					workspaceRoot,
 					true,
+				);
+				// Partial refresh: whole topics section re-rendered (indices shift on
+				// delete), NOT a full webview.html rebuild, and the legacy
+				// (webview-ignored) topicDeleted message is gone.
+				const cmds = postMessage.mock.calls.map((c) => c[0].command);
+				expect(cmds).toContain("topicsUpdated");
+				expect(cmds).not.toContain("topicDeleted");
+				// Guards the #1 footgun: the rebuilt topics section must be built from
+				// the POST-delete summary (result.result), not the stale currentSummary.
+				expect(mockBuildTopicsSection).toHaveBeenCalledWith(
+					updatedSummary,
+					expect.anything(),
 				);
 			});
 
@@ -4345,6 +4530,34 @@ describe("SummaryWebviewPanel", () => {
 				);
 			});
 
+			it("refreshes Plans & Notes exactly once, after the slug leaves planTranslateSet", async () => {
+				// Regression: syncPlanTitle({refresh:false}) must NOT render; the single
+				// refresh happens after planTranslateSet.delete, so the 🌐 button is gone.
+				mockReadPlanFromBranch.mockResolvedValue("# 中文标题\n\n内容");
+				mockTranslateToEnglish.mockResolvedValue("# Translated\n\nContent");
+				mockLoadPlansRegistry.mockResolvedValue({
+					plans: { "cn-plan": { slug: "cn-plan", title: "中文标题" } },
+				});
+				const dispatch = await setupPanel({
+					plans: [
+						{ slug: "cn-plan", title: "中文标题", addedAt: "", updatedAt: "" },
+					],
+				});
+				mockBuildPlansAndNotesSection.mockClear();
+
+				dispatch({ command: "translatePlan", slug: "cn-plan" });
+				await flushPromises();
+
+				// Single refresh (not the old double-update from syncPlanTitle + tail).
+				expect(mockBuildPlansAndNotesSection).toHaveBeenCalledTimes(1);
+				const planTranslateSetArg =
+					mockBuildPlansAndNotesSection.mock.calls[0][3];
+				expect(planTranslateSetArg).toBeInstanceOf(Set);
+				expect((planTranslateSetArg as Set<string>).has("cn-plan")).toBe(false);
+				const cmds = postMessage.mock.calls.map((c) => c[0].command);
+				expect(cmds.filter((c) => c === "plansAndNotesUpdated")).toHaveLength(1);
+			});
+
 			it("shows info when plan is already in English", async () => {
 				mockReadPlanFromBranch.mockResolvedValue(
 					"# English Plan\n\nAll ASCII content",
@@ -4655,6 +4868,12 @@ describe("SummaryWebviewPanel", () => {
 				expect(postMessage).toHaveBeenCalledWith({
 					command: "transcriptsSaved",
 				});
+				// Partial refresh: the All Conversations section is re-rendered
+				// (closing the modal + refreshing stats), AND the legacy
+				// transcriptsSaved message is still posted (existing assertion above).
+				expect(postMessage.mock.calls.map((c) => c[0].command)).toContain(
+					"conversationsUpdated",
+				);
 			});
 		});
 
@@ -4918,6 +5137,11 @@ describe("SummaryWebviewPanel", () => {
 				expect(postMessage).toHaveBeenCalledWith({
 					command: "transcriptsDeleted",
 				});
+				// Partial refresh: All Conversations section re-rendered (flips to the
+				// count===0 empty state), alongside the retained transcriptsDeleted message.
+				expect(postMessage.mock.calls.map((c) => c[0].command)).toContain(
+					"conversationsUpdated",
+				);
 				// #5 + #4: the legacy (v3) summary is lazily upgraded to a REAL v5
 				// record — version bumped to 5 and `transcripts` written from the
 				// file-backed set (emptied here by the delete), not left as a
@@ -6185,13 +6409,12 @@ describe("SummaryWebviewPanel", () => {
 				});
 				await flushPromises();
 
-				// buildHtml should be called with noteTranslateSet containing the new CJK note
-				expect(mockBuildHtml).toHaveBeenCalledWith(
-					expect.anything(),
-					expect.objectContaining({
-						noteTranslateSet: new Set(["cn-snip"]),
-					}),
-				);
+				// The Plans & Notes partial re-render must receive the noteTranslateSet
+				// (5th positional arg) already containing the new CJK note, proving
+				// refreshNoteTranslateSet ran before the render.
+				expect(mockBuildPlansAndNotesSection).toHaveBeenCalled();
+				const snippetArgs = mockBuildPlansAndNotesSection.mock.calls[0];
+				expect(snippetArgs[4]).toEqual(new Set(["cn-snip"]));
 			});
 
 			it("shows error when archiveNoteForCommit returns null", async () => {
@@ -6310,12 +6533,11 @@ describe("SummaryWebviewPanel", () => {
 				dispatch({ command: "addMarkdownNote" });
 				await flushPromises();
 
-				expect(mockBuildHtml).toHaveBeenCalledWith(
-					expect.anything(),
-					expect.objectContaining({
-						noteTranslateSet: new Set(["cn-md"]),
-					}),
-				);
+				// The Plans & Notes partial re-render must receive the noteTranslateSet
+				// (5th positional arg) already containing the new CJK note.
+				expect(mockBuildPlansAndNotesSection).toHaveBeenCalled();
+				const mdArgs = mockBuildPlansAndNotesSection.mock.calls[0];
+				expect(mdArgs[4]).toEqual(new Set(["cn-md"]));
 			});
 
 			it("does nothing when user cancels file dialog", async () => {

--- a/vscode/src/views/SummaryWebviewPanel.ts
+++ b/vscode/src/views/SummaryWebviewPanel.ts
@@ -79,8 +79,11 @@ import { loadBranchSummaries } from "./BranchSummaryLoader.js";
 import { SOURCE_TITLES } from "./SourceLabels.js";
 import { buildSummaryErrorBanner } from "./SummaryErrorBanner.js";
 import {
+	buildAllConversationsSection,
 	buildE2eTestSection,
 	buildHtml,
+	buildJolliRow,
+	buildPlansAndNotesSection,
 	buildRecapSection,
 	buildTopicsSection,
 	renderE2eScenario,
@@ -1169,6 +1172,105 @@ export class SummaryWebviewPanel {
 	}
 
 	/**
+	 * Partial-refresh helpers — used by mutation handlers instead of `update()`
+	 * to re-render just the affected block via `postMessage` (no full-page
+	 * `webview.html` rebuild, so expand/collapse + scroll state survive).
+	 *
+	 * Each helper mirrors `update()`'s two preconditions: bail if the panel was
+	 * disposed mid-await, then adopt the new summary as `currentSummary` so a
+	 * subsequent block render reads fresh data. Render inputs reuse the same
+	 * cached translate/transcript sets as `update()` so partial and full renders
+	 * stay in sync.
+	 *
+	 * They deliberately do NOT skip while `regenerateInProgress`: these blocks
+	 * (plans/notes, topics, conversations) are disjoint from what the regenerate
+	 * completion re-renders (topics+recap+banner only re-render via
+	 * `summaryRegenerated`; plans/notes + conversations do not). An in-flight
+	 * async write (e.g. a translate dispatched before regenerate started, landing
+	 * mid-regenerate) MUST still post its partial refresh — it is the only path
+	 * that clears the block's loading state (there is no `*Translated` /
+	 * `transcriptsSaved` DOM-restore in the webview; the section rebuild is the
+	 * restore). Skipping it would strand the translate button on "translating" or
+	 * the transcript modal on "Saving…". The regenerating-readonly CSS still hides
+	 * the freshly-rendered block's buttons, so no readonly affordance leaks.
+	 */
+	private get isReadOnlyPanel(): boolean {
+		return !!this.foreignRepoName || !!this.staleRewrittenInto;
+	}
+
+	/**
+	 * Re-renders the Plans & Notes block AND the header `#jolliRow`. The two are
+	 * sent together because `#jolliRow` embeds the published Plans & Notes link
+	 * list (see buildJolliRow); refreshing only the section would leave the
+	 * header's link list stale after a published plan/note add/remove.
+	 */
+	private refreshPlansAndNotes(summary: CommitSummary): void {
+		if (this.disposed) {
+			return;
+		}
+		this.currentSummary = summary;
+		this.panel.webview.postMessage({
+			command: "plansAndNotesUpdated",
+			html: buildPlansAndNotesSection(
+				summary.plans,
+				summary.notes,
+				summary.references ?? [],
+				this.planTranslateSet,
+				this.noteTranslateSet,
+				this.referenceTranslateSet,
+			),
+		});
+		this.panel.webview.postMessage({
+			command: "jolliRowUpdated",
+			html: buildJolliRow(
+				summary.jolliDocUrl,
+				summary.commitMessage,
+				summary.plans,
+				summary.notes,
+			),
+		});
+	}
+
+	/**
+	 * Re-renders the whole `#topicsSection`. Topic edit/delete buttons carry a
+	 * positional `treeIndex`; deleting a topic shifts every later index, so the
+	 * whole section is rebuilt (rather than removing one node) to keep indices
+	 * consistent. Nothing outside the topics block depends on topic data, so no
+	 * companion refresh is needed.
+	 */
+	private refreshTopicsSection(summary: CommitSummary): void {
+		if (this.disposed) {
+			return;
+		}
+		this.currentSummary = summary;
+		this.panel.webview.postMessage({
+			command: "topicsUpdated",
+			html: buildTopicsSection(summary, { readOnly: this.isReadOnlyPanel }),
+		});
+	}
+
+	/**
+	 * Re-renders the whole `#allConversationsSection` (private-zone + modal).
+	 * Caller must refresh `this.transcriptHashSet` first (transcript save/delete
+	 * already does). The header "Conversations N turns" row reads the stored
+	 * `conversationTurns` field, not the transcript files, so it is unaffected
+	 * and needs no companion refresh.
+	 */
+	private refreshConversations(summary: CommitSummary): void {
+		if (this.disposed) {
+			return;
+		}
+		this.currentSummary = summary;
+		this.panel.webview.postMessage({
+			command: "conversationsUpdated",
+			html: buildAllConversationsSection(
+				this.transcriptHashSet,
+				!!this.foreignRepoName,
+			),
+		});
+	}
+
+	/**
 	 * Refreshes the cached `transcriptHashSet` (logically a transcript-ID set
 	 * after v5: the entries may be UUIDs or legacy commit hashes — both are
 	 * opaque IDs to read/write/delete paths). Pulled via `getTranscriptIds`
@@ -2159,8 +2261,10 @@ export class SummaryWebviewPanel {
 		}
 
 		await this.bridge.storeSummary(result.result, true);
-		this.update(result.result);
-		this.panel.webview.postMessage({ command: "topicDeleted", topicIndex });
+		// Re-render the whole topics section (not a single-node removal): topic
+		// edit/delete buttons carry positional treeIndex values, and deleting one
+		// shifts every later index, so a full section rebuild keeps them correct.
+		this.refreshTopicsSection(result.result);
 	}
 
 	/** Generates E2E test scenarios from the current summary via AI. */
@@ -2455,7 +2559,12 @@ export class SummaryWebviewPanel {
 	 * Extracts the title from plan markdown content and syncs it to
 	 * CommitSummary.plans, plans.json registry, and the current webview.
 	 */
-	private async syncPlanTitle(slug: string, content: string): Promise<void> {
+	private async syncPlanTitle(
+		slug: string,
+		content: string,
+		opts: { refresh?: boolean } = {},
+	): Promise<void> {
+		const { refresh = true } = opts;
 		const titleMatch = /^#\s+(.+)/m.exec(content);
 		const newTitle = titleMatch?.[1]?.trim();
 		if (!newTitle || !this.currentSummary?.plans) {
@@ -2471,7 +2580,12 @@ export class SummaryWebviewPanel {
 		};
 		await this.bridge.storeSummary(updatedSummary, true);
 		this.currentSummary = updatedSummary;
-		this.update(updatedSummary);
+		// `refresh: false` lets the translate path batch a single refresh after it
+		// finishes its own state mutation (planTranslateSet.delete), avoiding a
+		// double render where the first one still shows the 🌐 button.
+		if (refresh) {
+			this.refreshPlansAndNotes(updatedSummary);
+		}
 
 		const registry = await loadPlansRegistry(this.workspaceRoot);
 		const entry = registry.plans[slug];
@@ -2538,7 +2652,7 @@ export class SummaryWebviewPanel {
 		// does not install setActiveStorage; only QueueWorker does).
 		await this.bridge.cleanupVisiblePlanArtifact(slug, summary.branch);
 
-		this.update(updatedSummary);
+		this.refreshPlansAndNotes(updatedSummary);
 	}
 
 	private async handleAddPlan(): Promise<void> {
@@ -2598,7 +2712,7 @@ export class SummaryWebviewPanel {
 		};
 		await this.bridge.storeSummary(updatedSummary, true);
 		this.currentSummary = updatedSummary;
-		this.update(updatedSummary);
+		this.refreshPlansAndNotes(updatedSummary);
 	}
 
 	private async handleAddMarkdownNote(): Promise<void> {
@@ -2656,7 +2770,7 @@ export class SummaryWebviewPanel {
 		await this.bridge.storeSummary(updatedSummary, true);
 		this.currentSummary = updatedSummary;
 		await this.refreshNoteTranslateSet(updatedSummary);
-		this.update(updatedSummary);
+		this.refreshPlansAndNotes(updatedSummary);
 	}
 
 	private async handleSaveSnippet(
@@ -2701,7 +2815,7 @@ export class SummaryWebviewPanel {
 		await this.bridge.storeSummary(updatedSummary, true);
 		this.currentSummary = updatedSummary;
 		await this.refreshNoteTranslateSet(updatedSummary);
-		this.update(updatedSummary);
+		this.refreshPlansAndNotes(updatedSummary);
 		this.panel.webview.postMessage({ command: "snippetSaved" });
 	}
 
@@ -2775,7 +2889,10 @@ export class SummaryWebviewPanel {
 			};
 			await this.bridge.storeSummary(updatedSummary, true);
 			this.currentSummary = updatedSummary;
-			this.update(updatedSummary);
+			// Stays inside the `if (this.currentSummary?.notes)` block: when there
+			// are no notes there is nothing to re-render, but `noteSaved` below is
+			// still posted so the webview exits inline-edit mode.
+			this.refreshPlansAndNotes(updatedSummary);
 		}
 
 		this.panel.webview.postMessage({ command: "noteSaved", id });
@@ -2829,7 +2946,7 @@ export class SummaryWebviewPanel {
 		// instance (see handleRemovePlan for the rationale).
 		await this.bridge.cleanupVisibleNoteArtifact(id, summary.branch);
 
-		this.update(updatedSummary);
+		this.refreshPlansAndNotes(updatedSummary);
 	}
 
 	// ── Reference actions (multi-source: Linear / Jira / GitHub / Notion) ───
@@ -3021,7 +3138,7 @@ export class SummaryWebviewPanel {
 		// here. A later re-reference of the same entity is re-discovered as a
 		// fresh uncommitted reference — dissociation does not blacklist.
 
-		this.update(updatedSummary);
+		this.refreshPlansAndNotes(updatedSummary);
 	}
 
 	/**
@@ -3088,7 +3205,7 @@ export class SummaryWebviewPanel {
 		// Drop from translate set immediately — user explicitly translated.
 		this.referenceTranslateSet.delete(archivedKey);
 		if (this.currentSummary) {
-			this.update(this.currentSummary);
+			this.refreshPlansAndNotes(this.currentSummary);
 		}
 
 		this.panel.webview.postMessage({
@@ -3162,12 +3279,14 @@ export class SummaryWebviewPanel {
 			[{ slug, content: translated }],
 			`Translate plan ${slug} to English`,
 		);
-		await this.syncPlanTitle(slug, translated);
+		// `refresh: false`: syncPlanTitle must not render before the translate set
+		// is updated below, or the first render would still show the 🌐 button.
+		await this.syncPlanTitle(slug, translated, { refresh: false });
 
 		// Remove from translate set immediately — user explicitly requested translation
 		this.planTranslateSet.delete(slug);
 		if (this.currentSummary) {
-			this.update(this.currentSummary);
+			this.refreshPlansAndNotes(this.currentSummary);
 		}
 
 		this.panel.webview.postMessage({ command: "planTranslated", slug });
@@ -3256,7 +3375,7 @@ export class SummaryWebviewPanel {
 		// Remove from translate set immediately — user explicitly requested translation
 		this.noteTranslateSet.delete(id);
 		if (this.currentSummary) {
-			this.update(this.currentSummary);
+			this.refreshPlansAndNotes(this.currentSummary);
 		}
 
 		const translatedTitle =
@@ -3552,7 +3671,7 @@ export class SummaryWebviewPanel {
 		// Refresh cache and webview
 		if (this.currentSummary) {
 			await this.refreshTranscriptHashes(this.currentSummary);
-			this.update(this.currentSummary);
+			this.refreshConversations(this.currentSummary);
 		}
 
 		this.panel.webview.postMessage({ command: "transcriptsSaved" });
@@ -3628,7 +3747,7 @@ export class SummaryWebviewPanel {
 		// Refresh cache and webview
 		if (this.currentSummary) {
 			await this.refreshTranscriptHashes(this.currentSummary);
-			this.update(this.currentSummary);
+			this.refreshConversations(this.currentSummary);
 		}
 
 		this.panel.webview.postMessage({ command: "transcriptsDeleted" });


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## Quick recap

The summary panel now updates individual sections in place rather than rebuilding the entire page whenever the user makes a change. Deleting a plan, translating a note, saving transcripts, or removing a topic each replaces only the relevant portion of the panel, preserving scroll position and the expand/collapse state of every other section. The header's published-plan link list stays synchronized with the Plans and Notes section on every mutation.

Topic deletions rebuild the full topics list rather than removing a single entry, keeping the action buttons on every remaining topic correctly targeted. The transcript modal's close behavior and the translate buttons' loading states are now driven entirely by the section rebuild messages, and a regression test guards against a previous attempt to suppress these refreshes during summary regeneration that would have left buttons permanently stuck in a loading state.

---

## E2E Test (3)
<details>
<summary><strong>1. No flicker or scroll-position loss when deleting a plan or note</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a commit open in the summary panel that has at least two plans or notes listed, and scroll the panel down so the Plans & Notes section is not at the very top of the view.

**Steps:**
1. Open the VS Code extension and navigate to the summary panel for a commit that has multiple plans or notes.
2. Scroll down so the Plans & Notes section is visible but not at the top of the panel — note your scroll position.
3. Delete one of the plans or notes by clicking its delete button and confirming.
4. Watch the panel as the deletion completes.
5. Check whether the panel scrolled back to the top or stayed near where you were.
6. Check whether the page visibly flashed or went blank during the update.

**Expected Results:**
- The deleted plan or note disappears from the list immediately.
- The panel does NOT flash, go white, or reload the entire page.
- The scroll position stays roughly where it was before the deletion — the panel does not jump back to the top.

</blockquote>
</details>
<details>
<summary><strong>2. No flicker or scroll-position loss when saving or deleting conversation transcripts</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a commit open in the summary panel that has at least one saved conversation transcript. The Conversations section should be visible.

**Steps:**
1. Open the summary panel for a commit that has saved transcripts.
2. Scroll down so the Conversations section is visible and note your scroll position.
3. Click the "Manage" button to open the transcript modal.
4. Click "Save" (or delete a transcript) and wait for the modal to close.
5. Watch the panel as the operation completes.
6. Check whether the page flashed or jumped to the top.

**Expected Results:**
- The transcript modal closes after saving or deleting.
- The Conversations section updates to reflect the change (for example, the empty-state message appears if all transcripts were deleted).
- The rest of the page does NOT flash, go white, or reload — only the Conversations section refreshes.
- The scroll position outside the Conversations section is preserved.

</blockquote>
</details>
<details>
<summary><strong>3. No flicker or scroll-position loss when deleting a topic</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a commit open in the summary panel that has at least two topics listed, and expand one or more topics so their content is visible.

**Steps:**
1. Open the summary panel for a commit with multiple topics.
2. Expand at least one topic by clicking its header, and scroll the panel so the topics list is in view — note which topics are expanded.
3. Delete one of the topics using its delete button and confirm the action.
4. Watch the panel as the deletion completes.
5. Check whether the remaining topics kept their expanded or collapsed state.
6. Check whether the page flashed or scrolled back to the top.

**Expected Results:**
- The deleted topic is removed from the list.
- The page does NOT flash or go entirely blank during the update.
- The scroll position is preserved — the panel does not jump back to the top.
- Previously expanded topics remain expanded (collapse state is not reset by the deletion).

</blockquote>
</details>

---

## Topic (1)
<details>
<summary><strong>01 · Add partial refresh helpers to avoid full webview rebuilds on mutations</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Every user action in the summary panel — deleting a plan, translating a note, saving transcripts — triggered a full HTML page rebuild, causing visible flicker and losing the user's scroll position and expand/collapse state. The developer investigated which operations still used the full-rebuild path and designed targeted replacements.

**💡 Decisions Behind the Code**

- **Whole-section rebuild for topic deletions instead of single-node removal**: Topic edit and delete buttons carry positional index values computed at render time. Removing one topic shifts every later index, so removing a single DOM node would leave sibling buttons pointing at wrong targets. The chosen fix rebuilds the entire topics section on each structural change, keeping indices consistent without requiring a stable identifier on each topic object. Adding stable identifiers was explicitly considered and deferred as a separate future task.
- **Plans and Notes refresh always paired with a header row refresh**: The header area embeds a list of published plan and note links, creating a cross-block data dependency. Rather than having each handler decide whether its specific change affects the header, a single helper always sends both messages together, concentrating the coupling in one place and eliminating the risk of individual handlers leaving the header stale.
- **Translate-during-regenerate must not be skipped**: An earlier implementation added a guard that suppressed partial refreshes while a summary regeneration was in progress. This was identified as a real bug: the plans/notes and conversations sections are not touched by regeneration completion, and the section rebuild is the only mechanism that clears translate-button loading states and closes the transcript modal. The guard was removed, with a regression test added to prevent reintroduction.

**✅ What Was Implemented**

- Three private helper methods (`refreshPlansAndNotes`, `refreshTopicsSection`, `refreshConversations`) were added to `SummaryWebviewPanel.ts`. Each mirrors the disposed-panel guard and `currentSummary` adoption from the existing full-rebuild method, then posts a targeted `postMessage` to replace only the affected DOM section. Fourteen handler methods that previously called the full rebuild were switched to the appropriate helper, with null guards preserved on handlers that read `this.currentSummary` directly.
- `SummaryHtmlBuilder.ts` exported three previously private builder functions (`buildPlansAndNotesSection`, `buildJolliRow`, `buildAllConversationsSection`) and wrapped the All Conversations block in a stable `#allConversationsSection` container so the webview can replace it in place. The `buildJolliRow` export is needed because the header's published-plan link list must stay in sync with the Plans & Notes section on every mutation.
- `SummaryScriptBuilder.ts` added four new inbound message handlers (`topicsUpdated`, `plansAndNotesUpdated`, `jolliRowUpdated`, `conversationsUpdated`), generalized `replaceSection` to strip trailing separator elements for any section (not just the recap), extracted `bindPlansAndNotesSection` to re-attach per-element snippet form listeners after a section replace, and refactored the transcript modal initialization into `bindConversationsSection` — called at init and after each conversations rebuild — while keeping the global ESC keydown registered exactly once outside that function to prevent listener accumulation.

**📋 Future Enhancements**

- Adding stable identifiers to topic and E2E scenario objects (to enable true single-node DOM updates instead of whole-section rebuilds) was explicitly deferred as a follow-up task.
- The `handlePush` operation was intentionally left on the full-rebuild path; it touches the widest set of cross-block fields and was scoped out of this change.
- An existing data race where regeneration completion can overwrite concurrent translate writes to the summary store was noted as a pre-existing issue outside this change's scope.

**📁 FILES**
- `vscode/src/views/SummaryWebviewPanel.ts`
- `vscode/src/views/SummaryScriptBuilder.ts`
- `vscode/src/views/SummaryHtmlBuilder.ts`

</blockquote>
</details>

---

*Generated by Jolli Memory · June 4, 2026 at 6:07 PM · via Jolli proxy*
<!-- jollimemory-summary-end -->