### PR TITLE
Add version detection and plugin diagnostics for update checks

### DIFF
--- a/cli/src/Api.test.ts
+++ b/cli/src/Api.test.ts
@@ -76,8 +76,29 @@ vi.mock("./core/Locks.js", () => ({
 vi.mock("./PluginLoader.js", async () => {
 	const actual = await vi.importActual<typeof import("./PluginLoader.js")>("./PluginLoader.js");
 	return {
-		loadPlugins: vi.fn().mockResolvedValue(new Set<string>()),
+		loadPlugins: vi.fn().mockResolvedValue({ loaded: new Set<string>(), diagnostics: [] }),
 		registerMissingStubs: actual.registerMissingStubs,
+		// Default: no plugins installed. The `doctor` command calls this; tests
+		// that exercise plugin rows override the resolved value per-test.
+		inspectPlugins: vi.fn().mockResolvedValue([]),
+	};
+});
+
+// Mock only the registry-querying refresh so the hidden `__refresh-update-cache`
+// command never spawns a real `npm view`. The pure cache/notice logic is covered
+// by UpdateCheck.test.ts; here we only assert the command wires through to it.
+vi.mock("./core/UpdateCheck.js", async () => {
+	const actual = await vi.importActual<typeof import("./core/UpdateCheck.js")>("./core/UpdateCheck.js");
+	return {
+		...actual,
+		refreshUpdateCache: vi.fn().mockResolvedValue({ checkedAt: "", ttlHours: 24, packages: {} }),
+		// Keep the registry/cache I/O out of the test process: no real npm-view
+		// cache on disk, no real detached refresh spawn. The local-surface
+		// comparison (the part these tests exercise) is unaffected.
+		readUpdateCache: vi.fn().mockResolvedValue(null),
+		spawnDetachedRefresh: vi.fn(),
+		// Keep the debounce sentinel off disk; always allow the (mocked) spawn.
+		claimRefreshSpawn: vi.fn().mockResolvedValue(true),
 	};
 });
 
@@ -244,6 +265,7 @@ import { loadConfigFromDir } from "./core/SessionTracker.js";
 import { exportSummaries } from "./core/SummaryExporter.js";
 import { hasMigrationMeta, migrateV1toV3 } from "./core/SummaryMigration.js";
 import { getIndex, getSummary, indexNeedsMigration, listSummaries, migrateIndexToV3 } from "./core/SummaryStore.js";
+import { CLI_PACKAGE_NAME, REFRESH_COMMAND, refreshUpdateCache } from "./core/UpdateCheck.js";
 import { getStatus, install, uninstall } from "./install/Installer.js";
 import { loadPlugins } from "./PluginLoader.js";
 
@@ -341,7 +363,7 @@ describe("CLI", () => {
 			vi.mocked(loadPlugins).mockImplementationOnce(async (program) => {
 				program.command("plugin-hidden-secret", { hidden: true }).description("hidden by plugin");
 				program.command("plugin-visible-cmd").description("visible plugin cmd");
-				return new Set<string>();
+				return { loaded: new Set<string>(), diagnostics: [] };
 			});
 
 			const exitSpy = vi.spyOn(process, "exit").mockImplementation((() => {
@@ -389,7 +411,7 @@ describe("CLI", () => {
 			// once plugins are loaded.
 			vi.mocked(loadPlugins).mockImplementationOnce(async (program) => {
 				program.command("plugin-extra-cmd").description("third-party plugin command");
-				return new Set<string>();
+				return { loaded: new Set<string>(), diagnostics: [] };
 			});
 
 			const exitSpy = vi.spyOn(process, "exit").mockImplementation((() => {
@@ -487,7 +509,7 @@ describe("CLI", () => {
 			// rendered under the Jolli Space section.
 			vi.mocked(loadPlugins).mockImplementationOnce(async (program) => {
 				program.command("init").description("unrelated plugin init");
-				return new Set<string>();
+				return { loaded: new Set<string>(), diagnostics: [] };
 			});
 			const exitSpy = vi.spyOn(process, "exit").mockImplementation((() => {
 				throw new Error("process.exit");
@@ -514,7 +536,7 @@ describe("CLI", () => {
 			// the Jolli Space section and a later stub (`agent`) must still render.
 			vi.mocked(loadPlugins).mockImplementationOnce(async (program) => {
 				program.command("init").description("unrelated plugin init");
-				return new Set<string>();
+				return { loaded: new Set<string>(), diagnostics: [] };
 			});
 			const exitSpy = vi.spyOn(process, "exit").mockImplementation((() => {
 				throw new Error("process.exit");
@@ -2989,48 +3011,44 @@ describe("CLI", () => {
 		 * checkVersionMismatch runs at the top of main(), before commander parses.
 		 * Since __PKG_VERSION__ is undefined in tests (VERSION = "dev"), we need
 		 * vi.resetModules() + vi.stubGlobal() to re-import Cli with a real version.
+		 *
+		 * The notice is driven solely by the npm registry `latest` cached in
+		 * update-check.json (mocked via readUpdateCache); local dist-paths/<surface>
+		 * versions are intentionally not consulted.
 		 */
-		async function runWithVersion(cliVersion: string, distPathContent: string | null): Promise<void> {
+		async function runWithVersion(cliVersion: string, registryLatest: string | null): Promise<void> {
 			vi.resetModules();
 			vi.stubGlobal("__PKG_VERSION__", cliVersion);
 
-			// Parse the legacy-style `source=tag@ver\npath` test fixture into the
-			// new per-source registry mock. checkVersionMismatch only reads
-			// traverseDistPaths() now — legacy single-file fallback was removed
-			// once migrateLegacyDistPath started deleting the old file.
-			const { traverseDistPaths } = await import("./install/DistPathResolver.js");
-			vi.mocked(traverseDistPaths).mockReset();
-
-			if (distPathContent) {
-				const m = distPathContent.match(/^source=([^@\n]+)(?:@([^\n]+))?\n(.+)$/);
-				if (m?.[2]) {
-					vi.mocked(traverseDistPaths).mockReturnValue([
-						{ source: m[1], version: m[2], distDir: m[3], available: true },
-					]);
-				} else {
-					vi.mocked(traverseDistPaths).mockReturnValue([]);
-				}
-			} else {
-				vi.mocked(traverseDistPaths).mockReturnValue([]);
-			}
+			const { readUpdateCache } = await import("./core/UpdateCheck.js");
+			vi.mocked(readUpdateCache).mockReset();
+			vi.mocked(readUpdateCache).mockResolvedValue(
+				registryLatest
+					? {
+							checkedAt: new Date().toISOString(),
+							ttlHours: 24,
+							packages: { [CLI_PACKAGE_NAME]: { latest: registryLatest } },
+						}
+					: null,
+			);
 
 			const { main: freshMain } = await import("./Api.js");
 			await freshMain(["status"]);
 		}
 
-		it("should warn when dist-paths version is higher than CLI version", async () => {
-			await runWithVersion("0.1.0", "source=vscode-extension@0.2.0\n/ext/dist");
+		it("should warn when the registry latest is higher than the CLI version", async () => {
+			await runWithVersion("0.1.0", "0.2.0");
 
 			const output = vi
 				.mocked(process.stderr.write)
 				.mock.calls.map((c) => String(c[0]))
 				.join("");
-			expect(output).toContain("A newer version of jolli is available");
+			expect(output).toContain("A newer version of @jolli.ai/cli is available");
 			expect(output).toContain("npm update -g @jolli.ai/cli");
 		});
 
 		it("should not warn when versions match", async () => {
-			await runWithVersion("1.0.0", "source=cli@1.0.0\n/global/dist");
+			await runWithVersion("1.0.0", "1.0.0");
 
 			const calls = vi.mocked(process.stderr.write).mock.calls;
 			const hasWarning = calls.some((c) => String(c[0]).includes("newer version"));
@@ -3038,23 +3056,15 @@ describe("CLI", () => {
 		});
 
 		it("should not warn when CLI version is higher", async () => {
-			await runWithVersion("2.0.0", "source=vscode-extension@1.5.0\n/ext/dist");
+			await runWithVersion("2.0.0", "1.5.0");
 
 			const calls = vi.mocked(process.stderr.write).mock.calls;
 			const hasWarning = calls.some((c) => String(c[0]).includes("newer version"));
 			expect(hasWarning).toBe(false);
 		});
 
-		it("should not warn when no sources are registered", async () => {
+		it("should not warn when there is no cached registry data", async () => {
 			await runWithVersion("1.0.0", null);
-
-			const calls = vi.mocked(process.stderr.write).mock.calls;
-			const hasWarning = calls.some((c) => String(c[0]).includes("newer version"));
-			expect(hasWarning).toBe(false);
-		});
-
-		it("should not warn for source entry with no version (legacy content ignored)", async () => {
-			await runWithVersion("1.0.0", "source=cli\n/global/dist");
 
 			const calls = vi.mocked(process.stderr.write).mock.calls;
 			const hasWarning = calls.some((c) => String(c[0]).includes("newer version"));
@@ -3438,67 +3448,6 @@ describe("CLI", () => {
 
 	// ── checkVersionMismatch: additional branches ─────────────────────────
 
-	describe("checkVersionMismatch — additional branches", () => {
-		async function runWithVersion(cliVersion: string, distPathContent: string | null): Promise<void> {
-			vi.resetModules();
-			vi.stubGlobal("__PKG_VERSION__", cliVersion);
-
-			// Parse the legacy-style `source=tag@ver\npath` test fixture into the
-			// new per-source registry mock. No readDistPathInfo mock is needed:
-			// checkVersionMismatch no longer reads the legacy single file.
-			const { traverseDistPaths } = await import("./install/DistPathResolver.js");
-			vi.mocked(traverseDistPaths).mockReset();
-
-			if (distPathContent) {
-				const m = distPathContent.match(/^source=([^@\n]+)(?:@([^\n]+))?\n(.+)$/);
-				if (m?.[2]) {
-					vi.mocked(traverseDistPaths).mockReturnValue([
-						{ source: m[1], version: m[2], distDir: m[3], available: true },
-					]);
-				} else {
-					vi.mocked(traverseDistPaths).mockReturnValue([]);
-				}
-			} else {
-				vi.mocked(traverseDistPaths).mockReturnValue([]);
-			}
-
-			const { main: freshMain } = await import("./Api.js");
-			await freshMain(["status"]);
-		}
-
-		it("should not warn when dist-paths entry has no source= prefix", async () => {
-			await runWithVersion("1.0.0", "some-random-content\n/path/to/dist");
-
-			const calls = vi.mocked(process.stderr.write).mock.calls;
-			const hasWarning = calls.some((c) => String(c[0]).includes("newer version"));
-			expect(hasWarning).toBe(false);
-		});
-
-		it("should pick highest version across multiple registered sources", async () => {
-			vi.resetModules();
-			vi.stubGlobal("__PKG_VERSION__", "1.0.0");
-			const { traverseDistPaths } = await import("./install/DistPathResolver.js");
-			vi.mocked(traverseDistPaths).mockReset();
-			// Mix of available + unavailable + sorted out-of-order; highest available is 2.5.0
-			vi.mocked(traverseDistPaths).mockReturnValue([
-				{ source: "cli", version: "1.0.0", distDir: "/cli", available: true },
-				{ source: "cursor", version: "3.0.0", distDir: "/cursor", available: false },
-				{ source: "vscode", version: "2.5.0", distDir: "/vscode", available: true },
-				{ source: "windsurf", version: "0.5.0", distDir: "/ws", available: true },
-			]);
-
-			vi.mocked(process.stderr.write).mockClear();
-			const { main: freshMain } = await import("./Api.js");
-			await freshMain(["status"]);
-
-			const stderrOutput = vi
-				.mocked(process.stderr.write)
-				.mock.calls.map((c) => String(c[0]))
-				.join("");
-			expect(stderrOutput).toContain("A newer version of jolli is available");
-		});
-	});
-
 	// ── configure command ───────────────────────────────────────────────
 	describe("configure command", () => {
 		it("should display empty config when nothing is set", async () => {
@@ -3868,6 +3817,21 @@ describe("CLI", () => {
 		});
 	});
 
+	// ── hidden update-check refresh command ─────────────────────────────
+	describe("__refresh-update-cache command", () => {
+		it("refreshes the given package list via refreshUpdateCache", async () => {
+			vi.mocked(refreshUpdateCache).mockClear();
+			await main([REFRESH_COMMAND, "@jolli.ai/cli", "@jolli.ai/site-cli"]);
+			expect(refreshUpdateCache).toHaveBeenCalledWith(["@jolli.ai/cli", "@jolli.ai/site-cli"]);
+		});
+
+		it("defaults to the CLI package when no packages are passed", async () => {
+			vi.mocked(refreshUpdateCache).mockClear();
+			await main([REFRESH_COMMAND]);
+			expect(refreshUpdateCache).toHaveBeenCalledWith([CLI_PACKAGE_NAME]);
+		});
+	});
+
 	// ── doctor command ──────────────────────────────────────────────────
 	describe("doctor command", () => {
 		async function runDoctor(
@@ -3882,6 +3846,15 @@ describe("CLI", () => {
 				orphanBranch?: boolean;
 				/** Per-source registry entries. Empty array = no sources registered. */
 				distPaths?: Array<{ source: string; version: string; distDir: string; available: boolean }>;
+				/** Plugin diagnostics returned by inspectPlugins. Empty = no plugins installed. */
+				plugins?: Array<{
+					id: string;
+					packageName: string;
+					installHint: string;
+					state: "absent" | "incompatible" | "ok";
+					installedVersion?: string;
+					peerRange?: string;
+				}>;
 			} = {},
 		): Promise<string[]> {
 			const { getStatus } = await import("./install/Installer.js");
@@ -3889,6 +3862,7 @@ describe("CLI", () => {
 			const { isWorkerLockStale } = await import("./core/Locks.js");
 			const { orphanBranchExists } = await import("./core/GitOps.js");
 			const { traverseDistPaths } = await import("./install/DistPathResolver.js");
+			const { inspectPlugins } = await import("./PluginLoader.js");
 
 			// Reset (prevent bleed-over from prior tests' mockResolvedValueOnce)
 			vi.mocked(getStatus).mockReset();
@@ -3898,6 +3872,7 @@ describe("CLI", () => {
 			vi.mocked(loadAllSessions).mockReset();
 			vi.mocked(orphanBranchExists).mockReset();
 			vi.mocked(traverseDistPaths).mockReset();
+			vi.mocked(inspectPlugins).mockReset();
 
 			vi.mocked(getStatus).mockResolvedValue({
 				enabled: true,
@@ -3918,6 +3893,7 @@ describe("CLI", () => {
 			vi.mocked(traverseDistPaths).mockReturnValue(
 				overrides.distPaths ?? [{ source: "cli", version: "0.97.12", distDir: "/mock/dist", available: true }],
 			);
+			vi.mocked(inspectPlugins).mockResolvedValue(overrides.plugins ?? []);
 
 			vi.mocked(console.log).mockClear();
 			await main(args);
@@ -4005,6 +3981,83 @@ describe("CLI", () => {
 			expect(output).toContain("✓ dist-paths/cli");
 			expect(output).toContain("⚠ dist-paths/cursor");
 			expect(output).toContain("MISSING");
+		});
+
+		it("should report a compatible installed plugin as ok", async () => {
+			const output = (
+				await runDoctor(["doctor"], {
+					apiKey: "sk-ant-test",
+					plugins: [
+						{
+							id: "fixture-id",
+							packageName: "@jolli.ai/site-cli",
+							installHint: "npm install -g @jolli.ai/site-cli",
+							state: "ok",
+							installedVersion: "0.4.2",
+							peerRange: ">=0.99.0",
+						},
+					],
+				})
+			).join("\n");
+			expect(output).toContain("✓ plugin @jolli.ai/site-cli");
+			expect(output).toContain("0.4.2");
+		});
+
+		it("should flag an incompatible installed plugin as warn with an upgrade hint", async () => {
+			const output = (
+				await runDoctor(["doctor"], {
+					apiKey: "sk-ant-test",
+					plugins: [
+						{
+							id: "fixture-id",
+							packageName: "@jolli.ai/space-cli",
+							installHint: "npm install -g @jolli.ai/space-cli",
+							state: "incompatible",
+							installedVersion: "0.2.0",
+							peerRange: ">=2.0.0",
+						},
+					],
+				})
+			).join("\n");
+			expect(output).toContain("⚠ plugin @jolli.ai/space-cli");
+			expect(output).toContain(">=2.0.0");
+			expect(output).toContain("npm install -g @jolli.ai/space-cli");
+		});
+
+		it("should render 'unknown' when an installed plugin has no version field", async () => {
+			const output = (
+				await runDoctor(["doctor"], {
+					apiKey: "sk-ant-test",
+					plugins: [
+						{
+							id: "fixture-id",
+							packageName: "@jolli.ai/site-cli",
+							installHint: "npm install -g @jolli.ai/site-cli",
+							state: "ok",
+							// installedVersion omitted — package.json lacked a version field
+						},
+					],
+				})
+			).join("\n");
+			expect(output).toContain("✓ plugin @jolli.ai/site-cli");
+			expect(output).toContain("vunknown");
+		});
+
+		it("should omit absent plugins from the doctor report", async () => {
+			const output = (
+				await runDoctor(["doctor"], {
+					apiKey: "sk-ant-test",
+					plugins: [
+						{
+							id: "fixture-id",
+							packageName: "@jolli.ai/site-cli",
+							installHint: "npm install -g @jolli.ai/site-cli",
+							state: "absent",
+						},
+					],
+				})
+			).join("\n");
+			expect(output).not.toContain("plugin @jolli.ai/site-cli");
 		});
 
 		it("should auto-fix stale dist-paths entry when --fix is passed", async () => {

--- a/cli/src/Api.ts
+++ b/cli/src/Api.ts
@@ -28,6 +28,7 @@ import { registerViewCommand } from "./commands/ViewCommand.js";
 // pure re-exports from the entry bundle when nothing inside the entry
 // consumes them).
 import { parseBaseUrl as _parseBaseUrl, parseJolliApiKey as _parseJolliApiKey } from "./core/JolliApiUtils.js";
+import { CLI_PACKAGE_NAME, REFRESH_COMMAND, refreshUpdateCache } from "./core/UpdateCheck.js";
 import type { Logger } from "./Logger.js";
 import { loadPlugins, registerMissingStubs } from "./PluginLoader.js";
 
@@ -334,10 +335,22 @@ export async function main(args?: ReadonlyArray<string>): Promise<void> {
 	// registered by `registerMissingStubs` so the commands stay visible in
 	// `--help` and emit an install hint when invoked. Both calls are
 	// non-throwing — a broken plugin / stub never blocks the CLI.
-	const loadedPluginIds = await loadPlugins(program, VERSION);
+	const { loaded: loadedPluginIds, diagnostics: pluginDiagnostics } = await loadPlugins(program, VERSION);
 	registerMissingStubs(program, loadedPluginIds);
 
-	checkVersionMismatch();
+	// Hidden subcommand spawned by checkVersionMismatch's detached refresh:
+	// queries npm for the latest version of the CLI + the given plugins and
+	// rewrites update-check.json. Never user-invoked directly.
+	program
+		.command(REFRESH_COMMAND, { hidden: true })
+		.argument("[packages...]", "package names to refresh")
+		.action(async (packages: string[]) => {
+			await refreshUpdateCache(packages.length > 0 ? packages : [CLI_PACKAGE_NAME]);
+		});
+
+	// Reuse the plugin diagnostics loadPlugins already computed, so the version
+	// check doesn't trigger a second discovery walk on the startup hot path.
+	await checkVersionMismatch({ pluginDiagnostics });
 
 	/* v8 ignore start - process.argv branch only used when running as script, not in tests */
 	await program.parseAsync(args ? ["node", "jolli", ...args] : process.argv);

--- a/cli/src/PluginLoader.test.ts
+++ b/cli/src/PluginLoader.test.ts
@@ -16,9 +16,10 @@ import { dirname, join } from "node:path";
 import { Command } from "commander";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { getHelpGroup } from "./commands/HelpGroups.js";
+import type { KnownPlugin } from "./KnownPlugins.js";
 import { KNOWN_PLUGINS } from "./KnownPlugins.js";
 import { setSilentConsole } from "./Logger.js";
-import { getNpmRootGlobal, loadPlugins } from "./PluginLoader.js";
+import { getNpmRootGlobal, inspectPlugins, loadPlugins } from "./PluginLoader.js";
 
 const FIXTURE_NAME = "@test-fixtures/example-plugin";
 const FIXTURE_SCOPE = "@test-fixtures";
@@ -38,6 +39,7 @@ async function writeFixture(
 	tempDir: string,
 	opts: {
 		name?: string;
+		version?: string;
 		peerVersion?: string;
 		pluginSource?: string;
 		mainPath?: string;
@@ -54,7 +56,7 @@ async function writeFixture(
 	} else {
 		const pkg: Record<string, unknown> = {
 			name,
-			version: "0.1.0",
+			version: opts.version ?? "0.1.0",
 			// Critical: dynamic import of `.js` requires ESM resolution, which the
 			// nearest package.json's `"type": "module"` provides.
 			type: "module",
@@ -632,13 +634,12 @@ describe("loadPlugins", () => {
 		await mkdir(pkgDir, { recursive: true });
 		await writeFile(join(pkgDir, "package.json"), "[]", "utf-8");
 		const program = new Command();
-		await expect(
-			loadPlugins(program, "0.100.0", {
-				rootsOverride: [join(tempDir, "node_modules")],
-				allowlistOverride: [FIXTURE_ID],
-				scopesOverride: [FIXTURE_SCOPE],
-			}),
-		).resolves.toBeInstanceOf(Set);
+		const { loaded } = await loadPlugins(program, "0.100.0", {
+			rootsOverride: [join(tempDir, "node_modules")],
+			allowlistOverride: [FIXTURE_ID],
+			scopesOverride: [FIXTURE_SCOPE],
+		});
+		expect(loaded).toBeInstanceOf(Set);
 		expect(program.commands).toHaveLength(0);
 	});
 
@@ -673,13 +674,12 @@ describe("loadPlugins", () => {
 			"utf-8",
 		);
 		const program = new Command();
-		await expect(
-			loadPlugins(program, "0.100.0", {
-				rootsOverride: [join(tempDir, "node_modules")],
-				allowlistOverride: [FIXTURE_ID],
-				scopesOverride: [FIXTURE_SCOPE],
-			}),
-		).resolves.toBeInstanceOf(Set);
+		const { loaded } = await loadPlugins(program, "0.100.0", {
+			rootsOverride: [join(tempDir, "node_modules")],
+			allowlistOverride: [FIXTURE_ID],
+			scopesOverride: [FIXTURE_SCOPE],
+		});
+		expect(loaded).toBeInstanceOf(Set);
 		expect(program.commands).toHaveLength(0);
 	});
 
@@ -1254,7 +1254,7 @@ describe("loadPlugins", () => {
 			pluginSource: "export const register = (ctx) => { ctx.program.command('plugin-ok').action(() => {}); };",
 		});
 		const program = new Command();
-		const loaded = await loadPlugins(program, "0.100.0", {
+		const { loaded } = await loadPlugins(program, "0.100.0", {
 			rootsOverride: [root],
 			allowlistOverride: [FIXTURE_ID],
 			scopesOverride: [FIXTURE_SCOPE],
@@ -1272,7 +1272,7 @@ describe("loadPlugins", () => {
 		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 		try {
 			const program = new Command();
-			const loaded = await loadPlugins(program, "0.100.0", {
+			const { loaded } = await loadPlugins(program, "0.100.0", {
 				rootsOverride: [root],
 				allowlistOverride: [FIXTURE_ID],
 				scopesOverride: [FIXTURE_SCOPE],
@@ -1293,7 +1293,7 @@ describe("loadPlugins", () => {
 		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 		try {
 			const program = new Command();
-			const loaded = await loadPlugins(program, "0.100.0", {
+			const { loaded } = await loadPlugins(program, "0.100.0", {
 				rootsOverride: [root],
 				allowlistOverride: [FIXTURE_ID],
 				scopesOverride: [FIXTURE_SCOPE],
@@ -1412,5 +1412,163 @@ describe("getNpmRootGlobal", () => {
 		});
 		// Still returns the runtime path even if cache write fails
 		expect(result).toBe("/runtime/path");
+	});
+});
+
+describe("inspectPlugins", () => {
+	// inspectPlugins maps each KNOWN_PLUGINS entry to a three-state diagnostic
+	// (absent / incompatible / ok), reusing the same discovery + peer-range
+	// logic as loadPlugins so the visibility layer never disagrees with what
+	// the loader actually does.
+	let tempDir: string;
+
+	const KNOWN: ReadonlyArray<KnownPlugin> = [
+		{
+			id: FIXTURE_ID,
+			packageName: FIXTURE_NAME,
+			installHint: "npm install -g @test-fixtures/example-plugin",
+		},
+	];
+
+	beforeEach(async () => {
+		tempDir = await mkdtemp(join(tmpdir(), "plugin-inspect-test-"));
+		delete process.env.JOLLI_NO_PLUGINS;
+		delete process.env.JOLLI_NO_PLUGIN_WARNINGS;
+	});
+
+	afterEach(async () => {
+		await rm(tempDir, { recursive: true, force: true });
+	});
+
+	it("reports absent for a known plugin not installed on disk", async () => {
+		const diagnostics = await inspectPlugins("1.0.0", {
+			rootsOverride: [join(tempDir, "node_modules")],
+			scopesOverride: [FIXTURE_SCOPE],
+			knownPluginsOverride: KNOWN,
+		});
+		expect(diagnostics).toHaveLength(1);
+		expect(diagnostics[0]).toMatchObject({
+			id: FIXTURE_ID,
+			packageName: FIXTURE_NAME,
+			state: "absent",
+		});
+		expect(diagnostics[0].installedVersion).toBeUndefined();
+	});
+
+	it("reports ok with the installed version for a compatible plugin", async () => {
+		const root = await writeFixture(tempDir, { version: "0.4.2", peerVersion: ">=1.0.0" });
+		const diagnostics = await inspectPlugins("1.5.0", {
+			rootsOverride: [root],
+			scopesOverride: [FIXTURE_SCOPE],
+			knownPluginsOverride: KNOWN,
+		});
+		expect(diagnostics[0]).toMatchObject({
+			state: "ok",
+			installedVersion: "0.4.2",
+			peerRange: ">=1.0.0",
+		});
+	});
+
+	it("reports incompatible when the peer range excludes the cli version", async () => {
+		const root = await writeFixture(tempDir, { version: "0.4.2", peerVersion: ">=2.0.0" });
+		const diagnostics = await inspectPlugins("1.0.0", {
+			rootsOverride: [root],
+			scopesOverride: [FIXTURE_SCOPE],
+			knownPluginsOverride: KNOWN,
+		});
+		expect(diagnostics[0]).toMatchObject({
+			state: "incompatible",
+			installedVersion: "0.4.2",
+			peerRange: ">=2.0.0",
+		});
+	});
+
+	it("treats a plugin with no peerDependencies as ok", async () => {
+		const root = await writeFixture(tempDir, { version: "1.2.3" });
+		const diagnostics = await inspectPlugins("0.0.1", {
+			rootsOverride: [root],
+			scopesOverride: [FIXTURE_SCOPE],
+			knownPluginsOverride: KNOWN,
+		});
+		expect(diagnostics[0]).toMatchObject({ state: "ok", installedVersion: "1.2.3" });
+		expect(diagnostics[0].peerRange).toBeUndefined();
+	});
+
+	it("defaults to the production KNOWN_PLUGINS list when none is injected", async () => {
+		// With an empty root and the real allow-list, every known plugin is absent.
+		const diagnostics = await inspectPlugins("1.0.0", {
+			rootsOverride: [join(tempDir, "node_modules")],
+		});
+		expect(diagnostics).toHaveLength(KNOWN_PLUGINS.length);
+		expect(diagnostics.every((d) => d.state === "absent")).toBe(true);
+		expect(diagnostics.map((d) => d.packageName)).toEqual(KNOWN_PLUGINS.map((p) => p.packageName));
+	});
+
+	it("reports every known plugin absent when JOLLI_NO_PLUGINS=1, even if installed", async () => {
+		// The loader short-circuits discovery under the kill-switch, so nothing is
+		// loadable; the diagnostic must agree (never claim an on-disk plugin ok)
+		// or doctor/version-check would disagree with what loadPlugins does.
+		const root = await writeFixture(tempDir, { version: "0.4.2", peerVersion: ">=1.0.0" });
+		process.env.JOLLI_NO_PLUGINS = "1";
+		const diagnostics = await inspectPlugins("1.5.0", {
+			rootsOverride: [root],
+			scopesOverride: [FIXTURE_SCOPE],
+			knownPluginsOverride: KNOWN,
+		});
+		expect(diagnostics).toHaveLength(1);
+		expect(diagnostics[0]).toMatchObject({ id: FIXTURE_ID, state: "absent" });
+		expect(diagnostics[0].installedVersion).toBeUndefined();
+	});
+});
+
+describe("loadPlugins diagnostics", () => {
+	// loadPlugins computes its PluginDiagnostic snapshot from the same single
+	// discovery walk it uses to load, so the hot path (checkVersionMismatch) can
+	// reuse it instead of re-scanning the filesystem.
+	let tempDir: string;
+
+	const KNOWN: ReadonlyArray<KnownPlugin> = [
+		{
+			id: FIXTURE_ID,
+			packageName: FIXTURE_NAME,
+			installHint: "npm install -g @test-fixtures/example-plugin",
+		},
+	];
+
+	beforeEach(async () => {
+		tempDir = await mkdtemp(join(tmpdir(), "plugin-load-diag-test-"));
+		delete process.env.JOLLI_NO_PLUGINS;
+	});
+
+	afterEach(async () => {
+		await rm(tempDir, { recursive: true, force: true });
+	});
+
+	it("returns diagnostics alongside the loaded set from one discovery", async () => {
+		const root = await writeFixture(tempDir, {
+			version: "0.4.2",
+			peerVersion: "^0.100.0",
+			pluginSource: "export const register = (ctx) => { ctx.program.command('diag-ok').action(() => {}); };",
+		});
+		const program = new Command();
+		const { loaded, diagnostics } = await loadPlugins(program, "0.100.0", {
+			rootsOverride: [root],
+			scopesOverride: [FIXTURE_SCOPE],
+			knownPluginsOverride: KNOWN,
+		});
+		expect(loaded.has(FIXTURE_ID)).toBe(true);
+		const entry = diagnostics.find((d) => d.id === FIXTURE_ID);
+		expect(entry).toMatchObject({ state: "ok", installedVersion: "0.4.2", peerRange: "^0.100.0" });
+	});
+
+	it("returns an all-absent diagnostic snapshot when JOLLI_NO_PLUGINS=1", async () => {
+		process.env.JOLLI_NO_PLUGINS = "1";
+		const program = new Command();
+		const { loaded, diagnostics } = await loadPlugins(program, "0.100.0", {
+			rootsOverride: [join(tempDir, "node_modules")],
+		});
+		expect(loaded.size).toBe(0);
+		expect(diagnostics).toHaveLength(KNOWN_PLUGINS.length);
+		expect(diagnostics.every((d) => d.state === "absent")).toBe(true);
 	});
 });

--- a/cli/src/PluginLoader.ts
+++ b/cli/src/PluginLoader.ts
@@ -5,8 +5,8 @@
  * A plugin is an npm package that declares a stable, opaque random string in
  * its `package.json` under `jolliPluginId`. The loader scans well-known scope
  * directories ({@link PLUGIN_SCOPES}) inside each `node_modules` root and only
- * loads packages whose declared ID is in {@link KNOWN_PLUGIN_IDS}. Package
- * names are intentionally **not** used for gating — names can change as the
+ * loads packages whose declared ID is in the {@link KnownPlugins} registry.
+ * Package names are intentionally **not** used for gating — names can change as the
  * plugin ecosystem evolves, and binding the host CLI to a specific name would
  * also leak that name (and any commercial-product hint it carries) into the
  * open-source codebase.
@@ -45,27 +45,11 @@ import { satisfies } from "semver";
 import type { PluginContext, PluginRegister } from "./Api.js";
 import { setHelpGroup } from "./commands/HelpGroups.js";
 import { getGlobalConfigDir } from "./core/SessionTracker.js";
-import { KNOWN_PLUGINS } from "./KnownPlugins.js";
+import { KNOWN_PLUGINS, type KnownPlugin } from "./KnownPlugins.js";
 import { createLogger } from "./Logger.js";
-import { execFileAsyncHidden } from "./util/Subprocess.js";
+import { runNpmCommand } from "./util/Subprocess.js";
 
 const log = createLogger("PluginLoader");
-
-/**
- * Allow-list of plugin IDs derived from the registry in {@link KnownPlugins}.
- *
- * Each entry is an opaque random string that the matching plugin embeds in
- * its own `package.json` as `jolliPluginId`. IDs are stable for the lifetime
- * of a plugin: a plugin author can rename, re-scope, or re-publish their
- * package without touching this list.
- *
- * IDs are not secrets — they are bundled in the plugin's package.json and
- * visible to anyone who installs it. The security boundary is still the scope
- * restriction in {@link PLUGIN_SCOPES} plus npm's own ownership controls on
- * the scopes we trust. Random IDs just make the allow-list flexible across
- * package renames.
- */
-const KNOWN_PLUGIN_IDS: ReadonlyArray<string> = KNOWN_PLUGINS.map((p) => p.id);
 
 /**
  * Scope directories the loader scans under each `node_modules` root. Bounding
@@ -94,7 +78,10 @@ const NPM_ROOT_TIMEOUT_MS = 5000;
 export interface LoadPluginsOptions {
 	/** Replace the discovered roots with these. Used by tests to point at fixtures. */
 	rootsOverride?: ReadonlyArray<string>;
-	/** Replace the {@link KNOWN_PLUGIN_IDS} allow-list. Used by tests with fake IDs. */
+	/**
+	 * Replace the default allow-list (the IDs from {@link KnownPlugins}). Used by
+	 * tests with fake IDs. When unset it is derived from {@link knownPluginsOverride}.
+	 */
 	allowlistOverride?: ReadonlyArray<string>;
 	/** Replace the {@link PLUGIN_SCOPES} scan set. Used by tests that fixture under a different scope. */
 	scopesOverride?: ReadonlyArray<string>;
@@ -107,6 +94,12 @@ export interface LoadPluginsOptions {
 	 * loader uses `os.homedir()`.
 	 */
 	homedirOverride?: string;
+	/**
+	 * Replace the {@link KNOWN_PLUGINS} registry. Defaults to the production
+	 * list. When set without {@link allowlistOverride}, the allow-list is derived
+	 * from it so discovery and the diagnostic snapshot stay in lockstep.
+	 */
+	knownPluginsOverride?: ReadonlyArray<KnownPlugin>;
 }
 
 /**
@@ -140,21 +133,62 @@ export interface NpmRootGlobalOptions {
  * to do nothing still gets the stub registration through the second call —
  * the stubs are part of `jolli --help`'s output contract, not a side-effect
  * of plugin discovery.
+ *
+ * Returns both the loaded-ID set **and** a {@link PluginDiagnostic} snapshot of
+ * every known plugin, computed from the one discovery walk this function
+ * already performs. The hot path (`checkVersionMismatch`) consumes the
+ * diagnostics directly instead of calling {@link inspectPlugins} again, so a
+ * single `jolli` invocation discovers plugins exactly once.
  */
+export interface LoadPluginsResult {
+	/** Plugin IDs that registered successfully — pass to {@link registerMissingStubs}. */
+	loaded: ReadonlySet<string>;
+	/** Three-state diagnostic for every {@link KnownPlugin}, in registry order. */
+	diagnostics: PluginDiagnostic[];
+}
+
+/** Outcome of the shared discovery walk consumed by {@link loadPlugins} and {@link inspectPlugins}. */
+interface DiscoveryResult {
+	/** The known-plugin registry in effect (override or {@link KNOWN_PLUGINS}). */
+	known: ReadonlyArray<KnownPlugin>;
+	/** Allow-listed plugins found on disk. Empty when discovery was skipped. */
+	found: ReadonlyArray<FoundPlugin>;
+	/** True when `JOLLI_NO_PLUGINS=1` short-circuited the walk (nothing is loadable). */
+	skipped: boolean;
+}
+
+/**
+ * Resolve the known registry, honor the `JOLLI_NO_PLUGINS` kill-switch, then run
+ * the discovery walk (allow-list / scopes / roots → {@link discoverPlugins}).
+ *
+ * The single source of truth for "which plugins exist", shared verbatim by
+ * {@link loadPlugins} (the load gate) and {@link inspectPlugins} (the diagnostic
+ * view) so a change to discovery defaults (a new scope, kill-switch, or roots
+ * tweak) can never land in one path but not the other — the divergence the
+ * diagnostic view is meant to be immune to.
+ */
+async function discoverKnownPlugins(opts?: LoadPluginsOptions): Promise<DiscoveryResult> {
+	const known = opts?.knownPluginsOverride ?? KNOWN_PLUGINS;
+	if (process.env.JOLLI_NO_PLUGINS === "1") {
+		return { known, found: [], skipped: true };
+	}
+	const allowlist = opts?.allowlistOverride ?? known.map((p) => p.id);
+	const scopes = opts?.scopesOverride ?? PLUGIN_SCOPES;
+	const roots = await resolveRoots(opts);
+	const found = await discoverPlugins(roots, scopes, allowlist);
+	return { known, found, skipped: false };
+}
+
 export async function loadPlugins(
 	program: Command,
 	cliVersion: string,
 	opts?: LoadPluginsOptions,
-): Promise<ReadonlySet<string>> {
-	if (process.env.JOLLI_NO_PLUGINS === "1") {
+): Promise<LoadPluginsResult> {
+	const { known, found, skipped } = await discoverKnownPlugins(opts);
+	if (skipped) {
 		log.debug("JOLLI_NO_PLUGINS=1 — skipping plugin discovery");
-		return new Set();
+		return { loaded: new Set(), diagnostics: allAbsentDiagnostics(known) };
 	}
-
-	const allowlist = opts?.allowlistOverride ?? KNOWN_PLUGIN_IDS;
-	const scopes = opts?.scopesOverride ?? PLUGIN_SCOPES;
-	const roots = await resolveRoots(opts);
-	const found = await discoverPlugins(roots, scopes, allowlist);
 
 	const loaded = new Set<string>();
 	for (const plugin of found) {
@@ -163,7 +197,7 @@ export async function loadPlugins(
 		}
 	}
 
-	return loaded;
+	return { loaded, diagnostics: diagnoseFound(found, known, cliVersion) };
 }
 
 /**
@@ -189,6 +223,130 @@ export function registerMissingStubs(program: Command, loadedPluginIds: Readonly
 }
 
 /**
+ * Whether the host CLI version satisfies a plugin's declared peer range.
+ *
+ * A plugin with no `peerDependencies["@jolli.ai/cli"]` declaration is always
+ * compatible. Otherwise the npm `semver` range grammar applies, with
+ * `includePrerelease` so a host running a prerelease build (e.g. `1.1.0-rc.1`)
+ * is not spuriously rejected by a `^1.1.0` range. An unparseable host version
+ * (`dev`/`unknown`/corrupt) fails the range and is treated as incompatible —
+ * a conservative default: we don't load a peer-constrained plugin against a
+ * host whose version we can't verify.
+ *
+ * Single source of truth shared by {@link loadOnePlugin} (the load gate) and
+ * {@link inspectPlugins} (the diagnostic view) so the two can never disagree on
+ * whether a given plugin is loadable.
+ */
+function isPeerCompatible(cliVersion: string, peerRange: string | undefined): boolean {
+	return !peerRange || satisfies(cliVersion, peerRange, { includePrerelease: true });
+}
+
+/**
+ * Three-state condition of a known plugin, as reported by {@link inspectPlugins}.
+ *
+ * - `ok` — discovered on disk **and** peer-compatible. This is NOT a guarantee
+ *   the plugin's code loaded: a broken `main`, a failed import, or a throwing
+ *   `register()` is still `ok` here because discovery + the peer check both
+ *   pass; the loader rejects such a plugin separately (and warns) at load time.
+ *   These diagnostics are a no-load probe — callers must not present `ok` as
+ *   "working".
+ * - `incompatible` — discovered but the declared peer range excludes this CLI.
+ * - `absent` — not discovered (or discovery was skipped via `JOLLI_NO_PLUGINS`).
+ */
+export type PluginState = "absent" | "incompatible" | "ok";
+
+/**
+ * Diagnostic view of one {@link KnownPlugin}: installed-and-compatible,
+ * installed-but-incompatible, or absent. Carries the data callers (doctor,
+ * update-check) need to render a row and an explicit upgrade exit —
+ * deliberately replacing the old "incompatible → warn → skip" dead signal.
+ * See {@link PluginState} for the `ok`-≠-loaded caveat.
+ */
+export interface PluginDiagnostic {
+	/** The plugin's stable `jolliPluginId`. */
+	id: string;
+	/** npm package name, for display and the install/upgrade hint. */
+	packageName: string;
+	/** Shell command to install/add the plugin (from {@link KnownPlugin}). */
+	installHint: string;
+	state: PluginState;
+	/** Version from the installed plugin's `package.json`. Undefined when absent or unreadable. */
+	installedVersion?: string;
+	/** Declared `peerDependencies["@jolli.ai/cli"]` range, if any. Undefined when absent or unconstrained. */
+	peerRange?: string;
+}
+
+/**
+ * Options for {@link inspectPlugins}. All overrides are test-injection points.
+ * Identical to {@link LoadPluginsOptions} (which now carries
+ * `knownPluginsOverride`); kept as a named alias for call-site readability.
+ */
+export type InspectPluginsOptions = LoadPluginsOptions;
+
+/** Diagnostic snapshot reporting every known plugin as `absent` (in registry order). */
+function allAbsentDiagnostics(known: ReadonlyArray<KnownPlugin>): PluginDiagnostic[] {
+	return known.map((kp) => ({
+		id: kp.id,
+		packageName: kp.packageName,
+		installHint: kp.installHint,
+		state: "absent",
+	}));
+}
+
+/**
+ * Pure mapping from a discovery result to one {@link PluginDiagnostic} per known
+ * plugin (registry order), with no I/O. Shared by {@link inspectPlugins} and
+ * {@link loadPlugins} so the load gate and the diagnostic view are computed from
+ * the exact same `found` set and {@link isPeerCompatible} check — they can never
+ * disagree on whether a plugin is loadable.
+ */
+function diagnoseFound(
+	found: ReadonlyArray<FoundPlugin>,
+	known: ReadonlyArray<KnownPlugin>,
+	cliVersion: string,
+): PluginDiagnostic[] {
+	const foundById = new Map(found.map((f) => [f.pluginId, f]));
+	return known.map((kp) => {
+		const hit = foundById.get(kp.id);
+		if (!hit) {
+			return { id: kp.id, packageName: kp.packageName, installHint: kp.installHint, state: "absent" };
+		}
+		const installedVersion = typeof hit.pkg.version === "string" ? hit.pkg.version : undefined;
+		const peerRange = hit.pkg.peerDependencies?.["@jolli.ai/cli"];
+		return {
+			id: kp.id,
+			packageName: kp.packageName,
+			installHint: kp.installHint,
+			state: isPeerCompatible(cliVersion, peerRange) ? "ok" : "incompatible",
+			installedVersion,
+			peerRange,
+		};
+	});
+}
+
+/**
+ * Inspect every known plugin and report its three-state {@link PluginDiagnostic}
+ * without loading any plugin code. Reuses the same discovery walk and
+ * peer-range check as {@link loadPlugins}, so the diagnostic can never claim a
+ * plugin is loadable when the loader would skip it (or vice versa).
+ *
+ * Honors `JOLLI_NO_PLUGINS=1` exactly as {@link loadPlugins} does: when the
+ * loader short-circuits discovery, nothing is loadable, so every known plugin
+ * is reported `absent` (no on-disk plugin is claimed `ok`). This keeps the
+ * diagnostic from disagreeing with the loader under the kill-switch.
+ *
+ * Returns one entry per {@link KnownPlugin} in registry order — including
+ * `absent` ones — so callers can render a stable, complete view. Always
+ * non-throwing on discovery errors (they surface as `absent`), matching the
+ * loader's "a broken plugin never breaks the host" contract.
+ */
+export async function inspectPlugins(cliVersion: string, opts?: InspectPluginsOptions): Promise<PluginDiagnostic[]> {
+	const { known, found, skipped } = await discoverKnownPlugins(opts);
+	if (skipped) return allAbsentDiagnostics(known);
+	return diagnoseFound(found, known, cliVersion);
+}
+
+/**
  * Subset of a plugin's `package.json` that the loader consumes after discovery.
  * Typed loosely (`main` as `unknown`) because `JSON.parse` will hand us
  * whatever the file contained — `loadOnePlugin` does its own runtime check
@@ -196,6 +354,7 @@ export function registerMissingStubs(program: Command, loadedPluginIds: Readonly
  */
 interface PluginPackageJson {
 	main?: unknown;
+	version?: unknown;
 	peerDependencies?: Record<string, string>;
 }
 
@@ -481,7 +640,7 @@ async function loadOnePlugin(program: Command, cliVersion: string, plugin: Found
 
 	try {
 		const peerRange = pkg.peerDependencies?.["@jolli.ai/cli"];
-		if (peerRange && !satisfies(cliVersion, peerRange, { includePrerelease: true })) {
+		if (!isPeerCompatible(cliVersion, peerRange)) {
 			warn(`${name} requires @jolli.ai/cli ${peerRange}, but ${cliVersion} is installed — skipping`);
 			return false;
 		}
@@ -856,6 +1015,9 @@ export async function getNpmRootGlobal(opts?: NpmRootGlobalOptions): Promise<str
 
 /**
  * Run `npm root -g` with a hard timeout. Returns null on any failure.
+ * Delegates to {@link runNpmCommand} so the cross-platform (win32 shell) npm
+ * invocation lives in one place — a bare `execFile("npm")` silently no-ops on
+ * Windows.
  *
  * Coverage-ignored: the only side-effect is spawning a subprocess, which is
  * impractical to unit-test deterministically without injecting a fake npm
@@ -863,12 +1025,6 @@ export async function getNpmRootGlobal(opts?: NpmRootGlobalOptions): Promise<str
  */
 /* v8 ignore start */
 async function runNpmRootGlobal(): Promise<string | null> {
-	try {
-		const { stdout } = await execFileAsyncHidden("npm", ["root", "-g"], { timeout: NPM_ROOT_TIMEOUT_MS });
-		const trimmed = stdout.trim();
-		return trimmed.length > 0 ? trimmed : null;
-	} catch {
-		return null;
-	}
+	return runNpmCommand(["root", "-g"], { timeout: NPM_ROOT_TIMEOUT_MS });
 }
 /* v8 ignore stop */

--- a/cli/src/commands/CliUtils.test.ts
+++ b/cli/src/commands/CliUtils.test.ts
@@ -37,6 +37,27 @@ vi.mock("../install/DistPathResolver.js", () => ({
 	traverseDistPaths: vi.fn().mockReturnValue([]),
 }));
 
+// checkVersionMismatch inspects plugins and reads the update-check cache. Stub
+// both out so these tests drive the notice from the cached registry `latest`
+// and never spawn a real npm/detached process. The DistPathResolver mock stays
+// because the real UpdateCheck module (loaded via importActual below) imports
+// `compareSemver` from it. The pure freshness logic is covered by
+// UpdateCheck.test.ts.
+vi.mock("../PluginLoader.js", () => ({
+	inspectPlugins: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock("../core/UpdateCheck.js", async () => {
+	const actual = await vi.importActual<typeof import("../core/UpdateCheck.js")>("../core/UpdateCheck.js");
+	return {
+		...actual,
+		readUpdateCache: vi.fn().mockResolvedValue(null),
+		spawnDetachedRefresh: vi.fn(),
+		// Keep the debounce sentinel off disk; always allow the (mocked) spawn.
+		claimRefreshSpawn: vi.fn().mockResolvedValue(true),
+	};
+});
+
 // Suppress stderr output during tests
 vi.spyOn(process.stderr, "write").mockImplementation(() => true);
 
@@ -90,95 +111,79 @@ describe("CliUtils", () => {
 			const { checkVersionMismatch } = await import("./CliUtils.js");
 			vi.mocked(process.stderr.write).mockClear();
 
-			checkVersionMismatch();
+			await checkVersionMismatch();
 
 			const stderrCalls = vi.mocked(process.stderr.write).mock.calls;
 			const hasWarning = stderrCalls.some((c) => String(c[0]).includes("newer version"));
 			expect(hasWarning).toBe(false);
 		});
 
-		it("should warn when a registered source has a higher version", async () => {
+		it("should warn when the registry cache reports a newer CLI", async () => {
 			vi.resetModules();
 			vi.stubGlobal("__PKG_VERSION__", "1.0.0");
-			const { traverseDistPaths } = await import("../install/DistPathResolver.js");
-			vi.mocked(traverseDistPaths).mockReturnValue([
-				{ source: "vscode", version: "2.0.0", distDir: "/vscode/dist", available: true },
-			]);
+			const { readUpdateCache } = await import("../core/UpdateCheck.js");
+			vi.mocked(readUpdateCache).mockResolvedValue({
+				checkedAt: new Date().toISOString(),
+				ttlHours: 24,
+				packages: { "@jolli.ai/cli": { latest: "2.0.0" } },
+			});
 
 			vi.mocked(process.stderr.write).mockClear();
 			const { checkVersionMismatch } = await import("./CliUtils.js");
-			checkVersionMismatch();
+			await checkVersionMismatch();
 
 			const stderrOutput = vi
 				.mocked(process.stderr.write)
 				.mock.calls.map((c) => String(c[0]))
 				.join("");
-			expect(stderrOutput).toContain("A newer version of jolli is available");
+			expect(stderrOutput).toContain("A newer version of @jolli.ai/cli is available");
 		});
 
-		it("should not warn when all sources have equal or lower versions", async () => {
+		it("should not warn when the registry cache matches the running version", async () => {
 			vi.resetModules();
 			vi.stubGlobal("__PKG_VERSION__", "2.0.0");
-			const { traverseDistPaths } = await import("../install/DistPathResolver.js");
-			vi.mocked(traverseDistPaths).mockReturnValue([
-				{ source: "cli", version: "1.5.0", distDir: "/cli/dist", available: true },
-				{ source: "vscode", version: "2.0.0", distDir: "/vscode/dist", available: true },
-			]);
-
-			vi.mocked(process.stderr.write).mockClear();
-			const { checkVersionMismatch } = await import("./CliUtils.js");
-			checkVersionMismatch();
-
-			const stderrCalls = vi.mocked(process.stderr.write).mock.calls;
-			const hasWarning = stderrCalls.some((c) => String(c[0]).includes("newer version"));
-			expect(hasWarning).toBe(false);
-		});
-
-		it("should not warn when no sources are registered", async () => {
-			vi.resetModules();
-			vi.stubGlobal("__PKG_VERSION__", "1.0.0");
-			const { traverseDistPaths } = await import("../install/DistPathResolver.js");
-			vi.mocked(traverseDistPaths).mockReturnValue([]);
-
-			vi.mocked(process.stderr.write).mockClear();
-			const { checkVersionMismatch } = await import("./CliUtils.js");
-			checkVersionMismatch();
-
-			const stderrCalls = vi.mocked(process.stderr.write).mock.calls;
-			const hasWarning = stderrCalls.some((c) => String(c[0]).includes("newer version"));
-			expect(hasWarning).toBe(false);
-		});
-
-		it("should skip unavailable entries when finding highest version", async () => {
-			vi.resetModules();
-			vi.stubGlobal("__PKG_VERSION__", "1.0.0");
-			const { traverseDistPaths } = await import("../install/DistPathResolver.js");
-			// The only higher-version entry is unavailable — should NOT warn
-			vi.mocked(traverseDistPaths).mockReturnValue([
-				{ source: "cli", version: "1.0.0", distDir: "/cli/dist", available: true },
-				{ source: "stale", version: "9.9.9", distDir: "/missing/dist", available: false },
-			]);
-
-			vi.mocked(process.stderr.write).mockClear();
-			const { checkVersionMismatch } = await import("./CliUtils.js");
-			checkVersionMismatch();
-
-			const stderrCalls = vi.mocked(process.stderr.write).mock.calls;
-			const hasWarning = stderrCalls.some((c) => String(c[0]).includes("newer version"));
-			expect(hasWarning).toBe(false);
-		});
-
-		it("should not throw when traverseDistPaths throws", async () => {
-			vi.resetModules();
-			vi.stubGlobal("__PKG_VERSION__", "1.0.0");
-			const { traverseDistPaths } = await import("../install/DistPathResolver.js");
-			vi.mocked(traverseDistPaths).mockImplementation(() => {
-				throw new Error("EACCES");
+			const { readUpdateCache } = await import("../core/UpdateCheck.js");
+			vi.mocked(readUpdateCache).mockResolvedValue({
+				checkedAt: new Date().toISOString(),
+				ttlHours: 24,
+				packages: { "@jolli.ai/cli": { latest: "2.0.0" } },
 			});
 
+			vi.mocked(process.stderr.write).mockClear();
 			const { checkVersionMismatch } = await import("./CliUtils.js");
-			// Should not throw — error is silently caught
-			expect(() => checkVersionMismatch()).not.toThrow();
+			await checkVersionMismatch();
+
+			const stderrCalls = vi.mocked(process.stderr.write).mock.calls;
+			const hasWarning = stderrCalls.some((c) => String(c[0]).includes("newer version"));
+			expect(hasWarning).toBe(false);
+		});
+
+		it("should not warn when there is no cached registry data", async () => {
+			vi.resetModules();
+			vi.stubGlobal("__PKG_VERSION__", "1.0.0");
+			// Set null explicitly: a mock implementation from a prior test survives
+			// vi.resetModules(). With no registry data, a higher version in any
+			// dist-paths/<surface> must NOT produce a CLI notice.
+			const { readUpdateCache } = await import("../core/UpdateCheck.js");
+			vi.mocked(readUpdateCache).mockResolvedValue(null);
+			vi.mocked(process.stderr.write).mockClear();
+			const { checkVersionMismatch } = await import("./CliUtils.js");
+			await checkVersionMismatch();
+
+			const stderrCalls = vi.mocked(process.stderr.write).mock.calls;
+			const hasWarning = stderrCalls.some((c) => String(c[0]).includes("newer version"));
+			expect(hasWarning).toBe(false);
+		});
+
+		it("should not throw when readUpdateCache rejects", async () => {
+			vi.resetModules();
+			vi.stubGlobal("__PKG_VERSION__", "1.0.0");
+			const { readUpdateCache } = await import("../core/UpdateCheck.js");
+			vi.mocked(readUpdateCache).mockRejectedValue(new Error("EACCES"));
+
+			const { checkVersionMismatch } = await import("./CliUtils.js");
+			// Should not reject — error is silently caught
+			await expect(checkVersionMismatch()).resolves.not.toThrow();
 		});
 	});
 

--- a/cli/src/commands/CliUtils.ts
+++ b/cli/src/commands/CliUtils.ts
@@ -8,9 +8,18 @@
  */
 
 import { createInterface } from "node:readline";
-import { getGlobalConfigDir } from "../core/SessionTracker.js";
 import type { AmbiguousHashError } from "../core/SummaryStore.js";
-import { compareSemver, traverseDistPaths } from "../install/DistPathResolver.js";
+import {
+	CLI_PACKAGE_NAME,
+	claimRefreshSpawn,
+	computeCliUpdateNotice,
+	computePluginUpdateNotices,
+	isCacheStale,
+	REFRESH_COMMAND,
+	readUpdateCache,
+	spawnDetachedRefresh,
+} from "../core/UpdateCheck.js";
+import { inspectPlugins, type PluginDiagnostic } from "../PluginLoader.js";
 import { execFileSyncHidden } from "../util/Subprocess.js";
 
 /** Package version — injected by Vite at build time, falls back to "dev" when running via tsx. */
@@ -62,39 +71,60 @@ export function isSafeQuery(query: string): boolean {
 }
 
 /**
- * Prints a warning to stderr if any registered source's dist-paths/<source>
- * file references a higher version than this CLI binary. This happens when,
- * for example, a VSCode extension with a newer core has been activated and
- * registered a higher version — hooks would run the newer code, but the
- * standalone `jolli` CLI binary on PATH remains at the old version.
+ * Prints upgrade hints to stderr when a newer version of the CLI — or of an
+ * installed plugin — is published on npm. "Newer" is decided solely from the
+ * cached registry `latest` in `update-check.json`: the cache is read-only here,
+ * and when it is stale a *detached* refresh process is spawned (it re-invokes
+ * this CLI with {@link REFRESH_COMMAND}) and the current invocation continues
+ * without waiting.
  *
- * Reads only `dist-paths/<source>`; the legacy single `dist-path` file is
- * not consulted. Every `install()` migrates and deletes the legacy file, so
- * by the time this CLI runs it's either gone or will be on next
- * `jolli enable`. Never throws — silently returns on any error.
+ * Local `dist-paths/<surface>` versions are intentionally NOT consulted — the
+ * CLI and the IDE extensions are independent release lines, so another surface's
+ * version is not a comparable `@jolli.ai/cli` version (see
+ * {@link computeCliUpdateNotice}).
+ *
+ * The locally-installed versions (CLI = {@link VERSION}, plugins = their
+ * `package.json`) are always read live, never cached. Never throws — every
+ * failure path degrades to "no hint" so the version check cannot block the CLI.
+ *
+ * `pluginDiagnostics` is the snapshot {@link loadPlugins} already produced this
+ * invocation; passing it in avoids a second plugin-discovery walk on the
+ * startup hot path. When omitted (direct callers, tests) it falls back to a
+ * fresh {@link inspectPlugins} scan.
+ *
+ * Skipped entirely in `dev` (tsx) builds and inside the detached refresh process
+ * itself (the {@link REFRESH_COMMAND} re-entrancy guard) to avoid a spawn loop.
  */
-/* v8 ignore start -- VERSION is always "dev" in tests; build-only code path */
-export function checkVersionMismatch(): void {
+/* v8 ignore start -- VERSION is always "dev" in tests; the freshness logic is unit-tested in UpdateCheck.test.ts */
+export async function checkVersionMismatch(opts?: { pluginDiagnostics?: PluginDiagnostic[] }): Promise<void> {
 	try {
 		if (VERSION === "dev") return;
-		const globalDir = getGlobalConfigDir();
+		// Re-entrancy guard: the detached refresh re-invokes this CLI with
+		// REFRESH_COMMAND; it must not trigger yet another refresh spawn.
+		if (process.argv.includes(REFRESH_COMMAND)) return;
 
-		// Find the highest version across all registered sources
-		let highestVersion: string | undefined;
-		const sources = traverseDistPaths(globalDir);
-		for (const entry of sources) {
-			if (!entry.available) continue;
-			if (!highestVersion || compareSemver(entry.version, highestVersion) > 0) {
-				highestVersion = entry.version;
-			}
+		const diagnostics = opts?.pluginDiagnostics ?? (await inspectPlugins(VERSION));
+		const installedPlugins = diagnostics.filter((p) => p.state !== "absent");
+		const cache = await readUpdateCache();
+
+		// Refresh in the background when the cache is stale and no recent refresh
+		// is still within the debounce window; the current command continues
+		// immediately and uses whatever the cache already holds.
+		if (isCacheStale(cache, Date.now()) && (await claimRefreshSpawn())) {
+			spawnDetachedRefresh([CLI_PACKAGE_NAME, ...installedPlugins.map((p) => p.packageName)]);
 		}
 
-		if (!highestVersion || highestVersion === VERSION) return;
-		if (compareSemver(highestVersion, VERSION) <= 0) return;
+		const notices: string[] = [];
+		const cliNotice = computeCliUpdateNotice({
+			currentVersion: VERSION,
+			registryLatest: cache?.packages[CLI_PACKAGE_NAME]?.latest,
+		});
+		if (cliNotice) notices.push(cliNotice);
+		notices.push(...computePluginUpdateNotices(installedPlugins, cache));
 
-		process.stderr.write(
-			"\nWarning:\n" + "  A newer version of jolli is available. Please upgrade: npm update -g @jolli.ai/cli\n\n",
-		);
+		if (notices.length > 0) {
+			process.stderr.write(`\nWarning:\n${notices.map((n) => `  ${n}`).join("\n")}\n\n`);
+		}
 	} catch {
 		// Never block CLI execution
 	}

--- a/cli/src/commands/DoctorCommand.ts
+++ b/cli/src/commands/DoctorCommand.ts
@@ -19,7 +19,8 @@ import { countActiveQueueEntries, getGlobalConfigDir, loadAllSessions, loadConfi
 import { traverseDistPaths } from "../install/DistPathResolver.js";
 import { getStatus, install } from "../install/Installer.js";
 import { createLogger, ORPHAN_BRANCH, setLogDir } from "../Logger.js";
-import { resolveProjectDir } from "./CliUtils.js";
+import { inspectPlugins } from "../PluginLoader.js";
+import { resolveProjectDir, VERSION } from "./CliUtils.js";
 
 const log = createLogger("doctor");
 
@@ -174,6 +175,39 @@ async function runDoctor(cwd: string, fix: boolean): Promise<void> {
 							return "removed stale entry";
 						}
 					: undefined,
+			});
+		}
+	}
+
+	// 8. Known plugins. Only installed plugins are reported — an absent plugin
+	// is the normal state for most users (the commands still surface via stubs
+	// in `jolli --help`), so listing them here would be noise. An `incompatible`
+	// plugin is a warn (not a fail): the CLI keeps working because the stub takes
+	// over, but the user should know to upgrade.
+	//
+	// `inspectPlugins` is a no-load probe: `ok` means "installed and version-
+	// compatible", NOT "loaded successfully". A plugin with a broken `main`,
+	// failed import, or throwing `register()` is still version-compatible and
+	// reads `ok` here — the loader rejects it separately and warns at load time.
+	// The row text says "installed, compatible" (not "working") to avoid
+	// overstating what this check actually verified.
+	for (const p of await inspectPlugins(VERSION)) {
+		if (p.state === "absent") continue;
+		const version = p.installedVersion ?? "unknown";
+		if (p.state === "ok") {
+			checks.push({
+				name: `plugin ${p.packageName}`,
+				status: "ok",
+				message: `v${version} (installed, compatible)`,
+			});
+		} else {
+			// `incompatible` implies a declared peer range — isPeerCompatible only
+			// returns false when peerRange is present and unsatisfied — so peerRange
+			// is always a string here.
+			checks.push({
+				name: `plugin ${p.packageName}`,
+				status: "warn",
+				message: `v${version} requires @jolli.ai/cli ${p.peerRange}, but you have ${VERSION} — upgrade the CLI (npm update -g @jolli.ai/cli) or reinstall a compatible plugin (${p.installHint})`,
 			});
 		}
 	}

--- a/cli/src/core/UpdateCheck.test.ts
+++ b/cli/src/core/UpdateCheck.test.ts
@@ -1,0 +1,358 @@
+/// <reference types="node" />
+/**
+ * Tests for {@link UpdateCheck} — the outward freshness-detection cache.
+ *
+ * The cache file (`update-check.json`) and the `npm view` query are both
+ * injected so these tests never touch the real `~/.jolli/jollimemory/` dir or
+ * spawn npm. The detached refresh spawn and the default `npm view` runner are
+ * v8-ignored in the implementation (subprocess side effects), exactly like
+ * PluginLoader's `runNpmRootGlobal`.
+ */
+
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+	claimRefreshSpawn,
+	computeCliUpdateNotice,
+	computePluginUpdateNotices,
+	isCacheStale,
+	isRefreshDebounced,
+	REFRESH_DEBOUNCE_MS,
+	readUpdateCache,
+	refreshUpdateCache,
+	type UpdateCache,
+} from "./UpdateCheck.js";
+
+describe("UpdateCheck", () => {
+	let tempDir: string;
+	let cacheFile: string;
+
+	beforeEach(async () => {
+		tempDir = await mkdtemp(join(tmpdir(), "update-check-test-"));
+		cacheFile = join(tempDir, "update-check.json");
+	});
+
+	afterEach(async () => {
+		await rm(tempDir, { recursive: true, force: true });
+	});
+
+	describe("readUpdateCache", () => {
+		it("returns null when the cache file does not exist", async () => {
+			expect(await readUpdateCache(cacheFile)).toBeNull();
+		});
+
+		it("returns null when the cache file is corrupt", async () => {
+			await writeFile(cacheFile, "{ not json", "utf-8");
+			expect(await readUpdateCache(cacheFile)).toBeNull();
+		});
+
+		it("returns null when the parsed shape is invalid", async () => {
+			await writeFile(cacheFile, JSON.stringify({ checkedAt: 123, packages: "nope" }), "utf-8");
+			expect(await readUpdateCache(cacheFile)).toBeNull();
+		});
+
+		it("returns null when a package entry has a non-string latest", async () => {
+			// A hand-edited/half-written `{ latest: 110 }` would make compareSemver
+			// throw — treat it as no info (→ refresh) instead.
+			await writeFile(
+				cacheFile,
+				JSON.stringify({
+					checkedAt: "2026-06-04T09:00:00.000Z",
+					ttlHours: 24,
+					packages: { "@jolli.ai/cli": { latest: 110 } },
+				}),
+				"utf-8",
+			);
+			expect(await readUpdateCache(cacheFile)).toBeNull();
+		});
+
+		it("returns null when ttlHours is not positive", async () => {
+			await writeFile(
+				cacheFile,
+				JSON.stringify({ checkedAt: "2026-06-04T09:00:00.000Z", ttlHours: 0, packages: {} }),
+				"utf-8",
+			);
+			expect(await readUpdateCache(cacheFile)).toBeNull();
+		});
+
+		it("parses a well-formed cache", async () => {
+			const cache: UpdateCache = {
+				checkedAt: "2026-06-04T09:00:00.000Z",
+				ttlHours: 24,
+				packages: { "@jolli.ai/cli": { latest: "1.1.0" } },
+			};
+			await writeFile(cacheFile, JSON.stringify(cache), "utf-8");
+			expect(await readUpdateCache(cacheFile)).toEqual(cache);
+		});
+	});
+
+	describe("isCacheStale", () => {
+		const fresh: UpdateCache = { checkedAt: "2026-06-04T09:00:00.000Z", ttlHours: 24, packages: {} };
+
+		it("treats a missing cache as stale", () => {
+			expect(isCacheStale(null, Date.parse("2026-06-04T09:00:00.000Z"))).toBe(true);
+		});
+
+		it("is fresh within the TTL window", () => {
+			const now = Date.parse("2026-06-04T20:00:00.000Z"); // 11h later
+			expect(isCacheStale(fresh, now)).toBe(false);
+		});
+
+		it("is stale once the TTL has elapsed", () => {
+			const now = Date.parse("2026-06-05T10:00:00.000Z"); // 25h later
+			expect(isCacheStale(fresh, now)).toBe(true);
+		});
+
+		it("treats an unparseable checkedAt as stale", () => {
+			expect(isCacheStale({ checkedAt: "not-a-date", ttlHours: 24, packages: {} }, Date.now())).toBe(true);
+		});
+	});
+
+	describe("isRefreshDebounced", () => {
+		const last = Date.parse("2026-06-04T09:00:00.000Z");
+
+		it("is not debounced when there was no prior attempt", () => {
+			expect(isRefreshDebounced(null, last)).toBe(false);
+		});
+
+		it("is debounced within the window", () => {
+			expect(isRefreshDebounced(last, last + 30_000, 60_000)).toBe(true);
+		});
+
+		it("is not debounced once the window has elapsed", () => {
+			expect(isRefreshDebounced(last, last + 60_000, 60_000)).toBe(false);
+		});
+	});
+
+	describe("claimRefreshSpawn", () => {
+		it("claims (returns true) and records the attempt when no sentinel exists", async () => {
+			const file = join(tempDir, "refresh-sentinel");
+			expect(await claimRefreshSpawn({ file })).toBe(true);
+			expect((await readFile(file, "utf-8")).length).toBeGreaterThan(0);
+		});
+
+		it("suppresses a second claim within the debounce window", async () => {
+			const file = join(tempDir, "refresh-sentinel");
+			expect(await claimRefreshSpawn({ file })).toBe(true);
+			expect(await claimRefreshSpawn({ file })).toBe(false);
+		});
+
+		it("collapses concurrent claims on a missing sentinel to a single winner", async () => {
+			// The debounce exists to prevent an npm-view storm when several commands
+			// fire at once. A stat()-then-write() check is not atomic across
+			// processes: every racer sees "no recent attempt" and every racer claims.
+			// An atomic claim must let exactly one of a simultaneous burst through.
+			const file = join(tempDir, "refresh-sentinel");
+			const results = await Promise.all([
+				claimRefreshSpawn({ file }),
+				claimRefreshSpawn({ file }),
+				claimRefreshSpawn({ file }),
+				claimRefreshSpawn({ file }),
+			]);
+			expect(results.filter(Boolean)).toHaveLength(1);
+		});
+
+		it("re-claims once the debounce window has elapsed", async () => {
+			const file = join(tempDir, "refresh-sentinel");
+			expect(await claimRefreshSpawn({ file })).toBe(true);
+			// A `now` far past the window relative to the just-written sentinel mtime.
+			expect(await claimRefreshSpawn({ file, now: Date.now() + REFRESH_DEBOUNCE_MS + 10_000 })).toBe(true);
+		});
+
+		it("allows the spawn (true) when the sentinel cannot be written", async () => {
+			// Parent is a file, so mkdir/writeFile fail — but a broken sentinel must
+			// never permanently suppress refreshing.
+			const blocker = join(tempDir, "blocker");
+			await writeFile(blocker, "x", "utf-8");
+			expect(await claimRefreshSpawn({ file: join(blocker, "nested", "sentinel") })).toBe(true);
+		});
+	});
+
+	describe("refreshUpdateCache", () => {
+		it("queries each package and writes a cache file", async () => {
+			const now = Date.parse("2026-06-04T09:00:00.000Z");
+			const queried: string[] = [];
+			const cache = await refreshUpdateCache(["@jolli.ai/cli", "@jolli.ai/site-cli"], {
+				file: cacheFile,
+				now,
+				runNpmView: async (pkg) => {
+					queried.push(pkg);
+					return pkg === "@jolli.ai/cli" ? "1.2.0" : "0.4.2";
+				},
+			});
+
+			expect(queried).toEqual(["@jolli.ai/cli", "@jolli.ai/site-cli"]);
+			expect(cache.packages).toEqual({
+				"@jolli.ai/cli": { latest: "1.2.0" },
+				"@jolli.ai/site-cli": { latest: "0.4.2" },
+			});
+			expect(cache.checkedAt).toBe(new Date(now).toISOString());
+
+			const onDisk = JSON.parse(await readFile(cacheFile, "utf-8"));
+			expect(onDisk.packages["@jolli.ai/cli"].latest).toBe("1.2.0");
+		});
+
+		it("omits packages whose query returned null", async () => {
+			const cache = await refreshUpdateCache(["@jolli.ai/cli", "@jolli.ai/ghost"], {
+				file: cacheFile,
+				runNpmView: async (pkg) => (pkg === "@jolli.ai/cli" ? "1.0.0" : null),
+			});
+			expect(cache.packages).toEqual({ "@jolli.ai/cli": { latest: "1.0.0" } });
+		});
+
+		it("preserves a previously-cached latest when this round's query fails", async () => {
+			const prior: UpdateCache = {
+				checkedAt: "2026-06-03T09:00:00.000Z",
+				ttlHours: 24,
+				packages: { "@jolli.ai/cli": { latest: "1.0.0" }, "@jolli.ai/site-cli": { latest: "0.9.0" } },
+			};
+			await writeFile(cacheFile, JSON.stringify(prior), "utf-8");
+
+			// cli refreshes to a newer version; site-cli's query fails this round.
+			const cache = await refreshUpdateCache(["@jolli.ai/cli", "@jolli.ai/site-cli"], {
+				file: cacheFile,
+				runNpmView: async (pkg) => (pkg === "@jolli.ai/cli" ? "1.1.0" : null),
+			});
+
+			expect(cache.packages).toEqual({
+				"@jolli.ai/cli": { latest: "1.1.0" }, // refreshed
+				"@jolli.ai/site-cli": { latest: "0.9.0" }, // preserved from the prior cache
+			});
+		});
+
+		it("tolerates a rejected query without dropping the other packages", async () => {
+			// With serial awaits a thrown lookup would reject the whole refresh;
+			// allSettled isolates it so the surviving package is still cached.
+			const cache = await refreshUpdateCache(["@jolli.ai/cli", "@jolli.ai/site-cli"], {
+				file: cacheFile,
+				runNpmView: async (pkg) => {
+					if (pkg === "@jolli.ai/site-cli") throw new Error("registry timeout");
+					return "1.3.0";
+				},
+			});
+			expect(cache.packages).toEqual({ "@jolli.ai/cli": { latest: "1.3.0" } });
+		});
+
+		it("does not record an incomplete refresh as fresh for the full TTL", async () => {
+			// Fresh install / just-installed plugin: the package has no prior-cached
+			// `latest` to fall back on, and its query fails transiently this round.
+			// The cli query succeeds. An incomplete refresh must NOT be recorded as
+			// fully fresh, or the missing package gets no data and no retry for the
+			// full 24h TTL.
+			const now = Date.parse("2026-06-04T09:00:00.000Z");
+			const cache = await refreshUpdateCache(["@jolli.ai/cli", "@jolli.ai/new-plugin"], {
+				file: cacheFile,
+				now,
+				runNpmView: async (pkg) => (pkg === "@jolli.ai/cli" ? "1.0.0" : null),
+			});
+
+			expect(cache.packages["@jolli.ai/new-plugin"]).toBeUndefined();
+			// Retried well within the default TTL (here: stale already 2h later).
+			expect(isCacheStale(cache, now + 2 * 3_600_000)).toBe(true);
+
+			// And the same must hold for the persisted cache the next process reads.
+			const onDisk = await readUpdateCache(cacheFile);
+			expect(isCacheStale(onDisk, now + 2 * 3_600_000)).toBe(true);
+		});
+
+		it("keeps a complete refresh fresh for the full TTL", async () => {
+			// Guard against over-correcting P1: when every requested package resolved,
+			// the cache must stay fresh for the normal window (no needless polling).
+			const now = Date.parse("2026-06-04T09:00:00.000Z");
+			const cache = await refreshUpdateCache(["@jolli.ai/cli"], {
+				file: cacheFile,
+				now,
+				runNpmView: async () => "1.0.0",
+			});
+			expect(isCacheStale(cache, now + 12 * 3_600_000)).toBe(false);
+		});
+
+		it("tolerates a cache-write failure without throwing", async () => {
+			// Point the cache at a path whose parent is a file, so mkdir/writeFile fail.
+			const blocker = join(tempDir, "blocker");
+			await writeFile(blocker, "x", "utf-8");
+			const cache = await refreshUpdateCache(["@jolli.ai/cli"], {
+				file: join(blocker, "nested", "update-check.json"),
+				runNpmView: async () => "1.0.0",
+			});
+			// Still returns the computed cache even when persistence fails.
+			expect(cache.packages["@jolli.ai/cli"].latest).toBe("1.0.0");
+		});
+	});
+
+	describe("computeCliUpdateNotice", () => {
+		it("returns null when the CLI already matches the registry latest", () => {
+			expect(computeCliUpdateNotice({ currentVersion: "1.1.0", registryLatest: "1.1.0" })).toBeNull();
+		});
+
+		it("flags a newer registry version", () => {
+			const notice = computeCliUpdateNotice({ currentVersion: "1.0.0", registryLatest: "1.2.0" });
+			expect(notice).toContain("1.2.0");
+			expect(notice).toContain("1.0.0");
+			expect(notice).toContain("npm update -g @jolli.ai/cli");
+		});
+
+		it("returns null when the registry latest is older than the running version", () => {
+			expect(computeCliUpdateNotice({ currentVersion: "2.0.0", registryLatest: "1.9.0" })).toBeNull();
+		});
+
+		it("returns null when no registry data is known (dist-path surfaces are ignored)", () => {
+			expect(computeCliUpdateNotice({ currentVersion: "1.0.0" })).toBeNull();
+		});
+	});
+
+	describe("computePluginUpdateNotices", () => {
+		const cache: UpdateCache = {
+			checkedAt: "2026-06-04T09:00:00.000Z",
+			ttlHours: 24,
+			packages: { "@jolli.ai/site-cli": { latest: "0.5.0" }, "@jolli.ai/space-cli": { latest: "0.2.0" } },
+		};
+
+		it("flags a plugin whose installed version trails the registry latest", () => {
+			const notices = computePluginUpdateNotices(
+				[
+					{
+						packageName: "@jolli.ai/site-cli",
+						installedVersion: "0.4.0",
+						installHint: "npm install -g @jolli.ai/site-cli",
+					},
+				],
+				cache,
+			);
+			expect(notices).toHaveLength(1);
+			expect(notices[0]).toContain("@jolli.ai/site-cli");
+			expect(notices[0]).toContain("0.5.0");
+			expect(notices[0]).toContain("npm install -g @jolli.ai/site-cli");
+		});
+
+		it("ignores a plugin that is already current", () => {
+			const notices = computePluginUpdateNotices(
+				[{ packageName: "@jolli.ai/space-cli", installedVersion: "0.2.0", installHint: "x" }],
+				cache,
+			);
+			expect(notices).toEqual([]);
+		});
+
+		it("ignores plugins absent from the cache or without an installed version", () => {
+			const notices = computePluginUpdateNotices(
+				[
+					{ packageName: "@jolli.ai/unknown", installedVersion: "0.1.0", installHint: "x" },
+					{ packageName: "@jolli.ai/site-cli", installHint: "x" },
+				],
+				cache,
+			);
+			expect(notices).toEqual([]);
+		});
+
+		it("returns nothing when there is no cache", () => {
+			expect(
+				computePluginUpdateNotices(
+					[{ packageName: "@jolli.ai/site-cli", installedVersion: "0.1.0", installHint: "x" }],
+					null,
+				),
+			).toEqual([]);
+		});
+	});
+});

--- a/cli/src/core/UpdateCheck.ts
+++ b/cli/src/core/UpdateCheck.ts
@@ -1,0 +1,367 @@
+/**
+ * UpdateCheck — outward freshness detection for the host CLI and its plugins.
+ *
+ * The dist-path registry ({@link ../install/DistPathResolver}) only answers
+ * "which locally-installed surface is newest" — it never consults npm. This
+ * module fills that gap: it caches the `latest` published version of the CLI
+ * and each installed plugin in `~/.jolli/jollimemory/update-check.json` and
+ * surfaces an upgrade hint when the running version trails it.
+ *
+ * Design (see "111. DESIGN — Version Detection & Upgrade Management"):
+ *   - **Foreground reads the cache only** — never blocks, never hits the network.
+ *   - When the cache is older than its TTL, the foreground spawns a *detached*
+ *     refresh process (a re-invocation of the CLI with the hidden
+ *     `{@link REFRESH_COMMAND}` subcommand) and returns immediately. This mirrors
+ *     the post-commit → QueueWorker spawn pattern.
+ *   - The cache stores only the registry `latest`. The locally-installed version
+ *     is always read live (CLI = `VERSION`, plugin = its `package.json`) so the
+ *     cache can never drift from what is actually installed.
+ *   - Every failure (missing/corrupt cache, npm query failure, write failure)
+ *     degrades silently — the version check must never block CLI execution.
+ *
+ * VSCode does not use this module: the extension is upgraded by the Marketplace.
+ */
+
+import { mkdir, open, readFile, rename, stat, unlink, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { compareSemver } from "../install/DistPathResolver.js";
+import { createLogger } from "../Logger.js";
+import { runNpmCommand, spawnHidden } from "../util/Subprocess.js";
+import { getGlobalConfigDir } from "./SessionTracker.js";
+
+const log = createLogger("UpdateCheck");
+
+/** npm package name of the host CLI — the always-tracked package. */
+export const CLI_PACKAGE_NAME = "@jolli.ai/cli";
+
+/** Hidden subcommand the detached refresh process is invoked with. */
+export const REFRESH_COMMAND = "__refresh-update-cache";
+
+/** Default freshness window. A day is long enough to never feel like polling. */
+export const DEFAULT_TTL_HOURS = 24;
+
+/**
+ * Freshness window applied when a refresh is *incomplete* — i.e. at least one
+ * requested package ended with no `latest` at all (a transient `npm view`
+ * failure on a fresh install or a just-installed plugin that has no prior-cached
+ * value to fall back on). Such a cache is recorded with this shortened TTL
+ * instead of {@link DEFAULT_TTL_HOURS} so the next command retries soon rather
+ * than being suppressed for a full day. A permanently-unresolvable package
+ * (renamed / unpublished) therefore costs at most one background refresh per
+ * this window, not one per command.
+ */
+export const RETRY_TTL_HOURS = 1;
+
+/** Hard timeout for a single `npm view` query, so a broken registry never hangs the refresh. */
+const NPM_VIEW_TIMEOUT_MS = 10_000;
+
+/**
+ * Debounce window for spawning the detached refresh. The cache's `checkedAt`
+ * only advances when a refresh *finishes*, so several commands run back-to-back
+ * just after the TTL expires would each see a stale cache and each spawn their
+ * own `npm view` process before the first one lands. A short-lived attempt
+ * marker (see {@link claimRefreshSpawn}) collapses that burst to one spawn,
+ * generously longer than {@link NPM_VIEW_TIMEOUT_MS} so an in-flight refresh is
+ * given time to complete and rewrite the cache.
+ */
+export const REFRESH_DEBOUNCE_MS = 60_000;
+
+/**
+ * On-disk shape of `update-check.json`. Only the registry `latest` per package
+ * is cached; installed versions are read live by callers.
+ */
+export interface UpdateCache {
+	/** ISO timestamp of the last successful refresh. */
+	checkedAt: string;
+	/** Freshness window in hours; a refresh is triggered once the cache exceeds it. */
+	ttlHours: number;
+	/** Registry `latest` keyed by npm package name. */
+	packages: Record<string, { latest: string }>;
+}
+
+/** Queries the registry `latest` for one package. Returns null on any failure. */
+export type NpmViewFn = (packageName: string) => Promise<string | null>;
+
+/** Default cache file location: `~/.jolli/jollimemory/update-check.json`. */
+function getCacheFile(): string {
+	return join(getGlobalConfigDir(), "update-check.json");
+}
+
+/** True when `value` is a non-null, non-array object. */
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Read and validate the cache. Returns null when the file is absent, unreadable,
+ * unparseable, or structurally invalid — callers treat null as "no info" and
+ * fall back to local-only comparison.
+ */
+export async function readUpdateCache(file?: string): Promise<UpdateCache | null> {
+	try {
+		const raw = await readFile(file ?? getCacheFile(), "utf-8");
+		const parsed: unknown = JSON.parse(raw);
+		if (!isPlainObject(parsed)) return null;
+		if (typeof parsed.checkedAt !== "string") return null;
+		// `> 0` also rejects 0 / negative / NaN — a non-positive TTL would make
+		// every read look stale and trigger a refresh on (almost) every command.
+		if (typeof parsed.ttlHours !== "number" || !(parsed.ttlHours > 0)) return null;
+		if (!isPlainObject(parsed.packages)) return null;
+		// Validate the leaf shape too, not just the container: `compareSemver`
+		// (the sole consumer of `latest`) calls `.includes("-")`, which throws a
+		// TypeError on a non-string `latest`. A hand-edited or half-written entry
+		// like `{ latest: 110 }` must be treated as "no info" (→ refresh) rather
+		// than crashing any caller that isn't wrapped in a try/catch.
+		for (const entry of Object.values(parsed.packages)) {
+			if (!isPlainObject(entry) || typeof entry.latest !== "string") return null;
+		}
+		return parsed as unknown as UpdateCache;
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * True when the cache is missing, has an unparseable `checkedAt`, or is older
+ * than its own `ttlHours` relative to `now` (ms epoch).
+ */
+export function isCacheStale(cache: UpdateCache | null, now: number): boolean {
+	if (!cache) return true;
+	const checkedAt = Date.parse(cache.checkedAt);
+	if (Number.isNaN(checkedAt)) return true;
+	const ageHours = (now - checkedAt) / 3_600_000;
+	return ageHours >= cache.ttlHours;
+}
+
+/** Marker file recording the last detached-refresh spawn attempt. */
+function getRefreshSentinelFile(): string {
+	return join(getGlobalConfigDir(), "update-check.refresh");
+}
+
+/**
+ * Pure: true when a refresh was attempted within the debounce window and a new
+ * spawn should be suppressed. A null `lastAttemptMs` (no prior attempt) is never
+ * debounced.
+ */
+export function isRefreshDebounced(lastAttemptMs: number | null, now: number, windowMs = REFRESH_DEBOUNCE_MS): boolean {
+	return lastAttemptMs !== null && now - lastAttemptMs < windowMs;
+}
+
+/**
+ * Claim the right to spawn a detached refresh. Returns false (suppress the
+ * spawn) when a prior attempt is still within {@link REFRESH_DEBOUNCE_MS};
+ * otherwise records this attempt via the sentinel mtime and returns true.
+ *
+ * Collapses a burst of near-simultaneous invocations to a single refresh
+ * (see {@link REFRESH_DEBOUNCE_MS}). The claim is made *atomically* so that the
+ * collapse actually holds across concurrent processes — a plain `stat`-then-
+ * `writeFile` is not atomic, and every racer that read "no recent attempt"
+ * would each write and each return true, defeating the debounce:
+ *
+ *   - **Absent sentinel** (the common burst) — an `O_EXCL` create lets exactly
+ *     one of N simultaneous callers win; the rest get `EEXIST` and fall through
+ *     to the freshness check, where the just-written sentinel reads as recent.
+ *   - **Stale sentinel** — taken over via `rename`, which removes the source, so
+ *     exactly one stale racer succeeds and the rest get `ENOENT`. A racer that
+ *     re-creates in the sub-millisecond gap between the rename and the rewrite
+ *     could double-claim; that residual race is accepted — the only cost is one
+ *     extra detached `npm view`, and the burst is still collapsed from N to ~1.
+ *
+ * Best-effort: a non-`EEXIST` I/O failure (read-only / broken dir) resolves to
+ * `true` so a sentinel that can never be written can never permanently suppress
+ * refreshing.
+ */
+export async function claimRefreshSpawn(opts?: { file?: string; now?: number; windowMs?: number }): Promise<boolean> {
+	const file = opts?.file ?? getRefreshSentinelFile();
+	const now = opts?.now ?? Date.now();
+	const stamp = new Date(now).toISOString();
+
+	// Atomic claim for the absent-sentinel burst: only one O_EXCL create wins.
+	try {
+		await mkdir(dirname(file), { recursive: true });
+		const handle = await open(file, "wx");
+		try {
+			await handle.writeFile(stamp, "utf-8");
+		} finally {
+			await handle.close();
+		}
+		return true;
+	} catch (err) {
+		if ((err as NodeJS.ErrnoException).code !== "EEXIST") {
+			// Could not create the sentinel for a reason other than "already there"
+			// (read-only / broken dir). Allow this spawn rather than risk
+			// suppressing refreshes forever on a sentinel we can never write.
+			return true;
+		}
+	}
+
+	// Sentinel already exists — back off if a recent attempt is still recorded.
+	let lastAttemptMs: number;
+	try {
+		lastAttemptMs = (await stat(file)).mtimeMs;
+	} catch {
+		/* v8 ignore next 2 -- sentinel removed concurrently between the EEXIST and the stat; another process is actively managing it, so back off */
+		return false;
+	}
+	if (isRefreshDebounced(lastAttemptMs, now, opts?.windowMs)) return false;
+
+	// Stale sentinel: take it over atomically. Only one rename of the source can
+	// succeed; the losers see ENOENT and back off.
+	const claim = `${file}.claim-${process.pid}-${now}`;
+	try {
+		await rename(file, claim);
+	} catch {
+		/* v8 ignore next -- lost the takeover race (another process renamed the stale sentinel first); back off */
+		return false;
+	}
+	try {
+		await writeFile(file, stamp, "utf-8");
+	} catch {
+		/* v8 ignore next 2 -- won the claim but could not rewrite the stamp; still proceed with the spawn */
+	}
+	await unlink(claim).catch(() => undefined);
+	return true;
+}
+
+/**
+ * Query the registry `latest` for each package and write a fresh cache file.
+ * The new cache is seeded from the existing one, so a package whose query fails
+ * this round keeps its previously-cached `latest` instead of being evicted — a
+ * transient registry failure must not silently suppress a known update notice.
+ * Returns the computed cache even when the write fails, so the detached process
+ * can still log what it found.
+ */
+export async function refreshUpdateCache(
+	packageNames: ReadonlyArray<string>,
+	opts?: { file?: string; runNpmView?: NpmViewFn; now?: number; ttlHours?: number },
+): Promise<UpdateCache> {
+	const runNpmView = opts?.runNpmView ?? defaultNpmView;
+	const file = opts?.file ?? getCacheFile();
+
+	// Seed from the prior cache so a failed query (null) preserves that package's
+	// last-known `latest` rather than dropping it on a wholesale overwrite.
+	const existing = await readUpdateCache(file);
+	const packages: Record<string, { latest: string }> = { ...(existing?.packages ?? {}) };
+	// Query every package concurrently — each lookup is independent and capped by
+	// its own NPM_VIEW_TIMEOUT_MS, so serial `await`s would stack those timeouts
+	// (3 packages × 10s could approach the refresh debounce window). `allSettled`
+	// keeps a single rejected/failed lookup from discarding the rest; a null or
+	// rejected result simply leaves that package's prior-cached `latest` in place.
+	const results = await Promise.allSettled(packageNames.map((name) => runNpmView(name)));
+	results.forEach((result, i) => {
+		const latest = result.status === "fulfilled" ? result.value : null;
+		if (latest) packages[packageNames[i]] = { latest };
+	});
+
+	// A refresh is "complete" only when every *requested* package now resolves to
+	// a `latest` (freshly fetched this round or preserved from the prior cache).
+	// An incomplete refresh must not be recorded as fresh for the full TTL, or a
+	// package left with no data at all (fresh install / just-added plugin whose
+	// query failed) gets no update info and no retry until the window elapses.
+	// `Math.min` keeps the retry window from ever exceeding the configured TTL.
+	const fullTtl = opts?.ttlHours ?? DEFAULT_TTL_HOURS;
+	const complete = packageNames.every((name) => packages[name] !== undefined);
+	const cache: UpdateCache = {
+		checkedAt: new Date(opts?.now ?? Date.now()).toISOString(),
+		ttlHours: complete ? fullTtl : Math.min(RETRY_TTL_HOURS, fullTtl),
+		packages,
+	};
+
+	try {
+		await mkdir(dirname(file), { recursive: true });
+		// Atomic write: a concurrent detached refresh (no cross-process lock here)
+		// could otherwise interleave two `writeFile`s into the same path and leave
+		// a corrupt half-written JSON that the next `readUpdateCache` rejects. A
+		// per-pid temp file plus `rename` makes the swap atomic on POSIX; on a
+		// rename failure we best-effort unlink the temp so it can't accumulate.
+		const tmp = `${file}.tmp-${process.pid}-${Date.now()}`;
+		await writeFile(tmp, JSON.stringify(cache, null, 2), "utf-8");
+		try {
+			await rename(tmp, file);
+		} catch (err) {
+			await unlink(tmp).catch(() => undefined);
+			throw err;
+		}
+	} catch (err) {
+		log.debug("failed to write update-check cache: %s", (err as Error).message);
+	}
+	return cache;
+}
+
+/**
+ * Decide the host-CLI upgrade notice. Pure: compares the running version against
+ * the npm registry `latest` cached in `update-check.json`. Returns the one-line
+ * notice, or null when nothing newer is known.
+ *
+ * Deliberately ignores local `dist-paths/<surface>` versions. The CLI and the
+ * IDE extensions are independent release lines, and a surface's dist-path version
+ * is that surface's *own* release number — not a comparable `@jolli.ai/cli`
+ * version. Feeding it in produced a phantom notice that reported, say, the VSCode
+ * extension's version as a "newer @jolli.ai/cli". The npm registry is the only
+ * authoritative source for whether a newer `@jolli.ai/cli` has been published.
+ */
+export function computeCliUpdateNotice(args: { currentVersion: string; registryLatest?: string }): string | null {
+	const latest = args.registryLatest;
+	if (!latest || compareSemver(latest, args.currentVersion) <= 0) return null;
+	return `A newer version of ${CLI_PACKAGE_NAME} is available (${latest} → you have ${args.currentVersion}). Upgrade: npm update -g ${CLI_PACKAGE_NAME}`;
+}
+
+/**
+ * Decide per-plugin upgrade notices. Pure: for each installed plugin with a
+ * known installed version, compare against the cached registry latest and emit
+ * a notice when it trails. Plugins absent from the cache, missing an installed
+ * version, or already current produce nothing.
+ */
+export function computePluginUpdateNotices(
+	plugins: ReadonlyArray<{ packageName: string; installedVersion?: string; installHint: string }>,
+	cache: UpdateCache | null,
+): string[] {
+	if (!cache) return [];
+	const notices: string[] = [];
+	for (const p of plugins) {
+		const latest = cache.packages[p.packageName]?.latest;
+		if (!latest || !p.installedVersion) continue;
+		if (compareSemver(latest, p.installedVersion) > 0) {
+			notices.push(
+				`A newer version of ${p.packageName} is available (${latest} → you have ${p.installedVersion}). Upgrade: ${p.installHint}`,
+			);
+		}
+	}
+	return notices;
+}
+
+/**
+ * Spawn the detached refresh process: re-invokes this CLI with the hidden
+ * {@link REFRESH_COMMAND} and the package list, then unrefs so the foreground
+ * exits immediately. Best-effort — a spawn failure is swallowed.
+ *
+ * Coverage-ignored: the only effect is launching a child process, which can't
+ * be unit-tested deterministically without a fake node on PATH. Same rationale
+ * as PluginLoader's `runNpmRootGlobal` / QueueWorker's `launchWorker`. The work
+ * it performs ({@link refreshUpdateCache}) is tested directly.
+ */
+/* v8 ignore start */
+export function spawnDetachedRefresh(packageNames: ReadonlyArray<string>, cliEntry?: string): void {
+	try {
+		const entry = cliEntry ?? process.argv[1];
+		if (!entry) return;
+		const child = spawnHidden(process.execPath, [entry, REFRESH_COMMAND, ...packageNames], {
+			detached: true,
+			stdio: "ignore",
+		});
+		child.unref();
+		log.info("Spawned detached update-check refresh (PID: %d)", child.pid ?? -1);
+	} catch (err) {
+		log.debug("failed to spawn update-check refresh: %s", (err as Error).message);
+	}
+}
+
+/**
+ * Default `npm view <pkg> version` runner. Returns null on any failure.
+ * Delegates to {@link runNpmCommand} so the cross-platform (win32 shell) npm
+ * invocation lives in one place.
+ */
+async function defaultNpmView(packageName: string): Promise<string | null> {
+	return runNpmCommand(["view", packageName, "version"], { timeout: NPM_VIEW_TIMEOUT_MS });
+}
+/* v8 ignore stop */

--- a/cli/src/install/DispatchScripts.ts
+++ b/cli/src/install/DispatchScripts.ts
@@ -57,6 +57,13 @@ DIR="$HOME/.jolli/jollimemory"
 BEST_PATH=""
 BEST_VER="0.0.0"
 
+# Version selection uses 'sort -V'. It agrees with the in-process compareSemver
+# (cli/src/install/DistPathResolver.ts) on every non-prerelease comparison.
+# Known divergence: sort -V ranks a prerelease (e.g. 1.0.0-rc.1) ABOVE its
+# release (1.0.0), whereas compareSemver follows semver and ranks it below.
+# Matching semver here would mean hand-rolling prerelease rules in POSIX sh;
+# the case (a release and its own prerelease both registered) is too rare to
+# justify the risk. compareSemver is the authority for in-process selection.
 if [ -d "$DIR/dist-paths" ]; then
   for f in "$DIR/dist-paths"/*; do
     [ -f "$f" ] || continue

--- a/cli/src/install/DistPathResolver.test.ts
+++ b/cli/src/install/DistPathResolver.test.ts
@@ -154,6 +154,62 @@ describe("DistPathResolver", () => {
 			expect(compareSemver("1.0.1", "1.0")).toBeGreaterThan(0);
 			expect(compareSemver("1.0", "1.0.1")).toBeLessThan(0);
 		});
+
+		// Prerelease handling. The historical implementation treated any version
+		// carrying a `-rc.N` suffix as non-numeric → ranked LOWEST, so an RC build
+		// (e.g. `1.0.0-rc.1`) would lose dist-path selection even to an ancient
+		// stable like `0.1.0`. compareSemver now follows semver ordering:
+		// prerelease sorts below its own release, but a newer prerelease still
+		// beats an older stable.
+		//
+		// NOTE on the shell: `resolve-dist-path` uses `sort -V`, which ranks
+		// `1.0.0-rc.1` ABOVE `1.0.0` — the opposite of semver. compareSemver is
+		// the in-process authority; the divergence only affects the rare case of a
+		// stable and its own prerelease both being registered. See the JSDoc.
+		describe("prerelease ordering (semver semantics)", () => {
+			it("ranks a prerelease below its own release", () => {
+				expect(compareSemver("1.0.0-rc.1", "1.0.0")).toBeLessThan(0);
+				expect(compareSemver("1.0.0", "1.0.0-rc.1")).toBeGreaterThan(0);
+			});
+
+			it("ranks a newer prerelease above an older stable release", () => {
+				expect(compareSemver("1.0.0-rc.1", "0.99.0")).toBeGreaterThan(0);
+				expect(compareSemver("0.99.0", "1.0.0-rc.1")).toBeLessThan(0);
+			});
+
+			it("orders prereleases among themselves", () => {
+				expect(compareSemver("1.0.0-rc.2", "1.0.0-rc.1")).toBeGreaterThan(0);
+			});
+
+			it("ranks a prerelease above the dev/unknown sentinels", () => {
+				expect(compareSemver("1.0.0-rc.1", "dev")).toBeGreaterThan(0);
+				expect(compareSemver("unknown", "1.0.0-rc.1")).toBeLessThan(0);
+			});
+
+			it("ignores build metadata", () => {
+				expect(compareSemver("1.0.0+build.5", "1.0.0")).toBe(0);
+			});
+
+			it("ranks a loose two-part release above a tagged prerelease", () => {
+				// A loose `1.0` (coerced to 1.0.0) must beat `1.0.0-rc.1`, not be
+				// mistaken for a non-semver sentinel that loses to any prerelease.
+				expect(compareSemver("1.0", "1.0.0-rc.1")).toBeGreaterThan(0);
+				expect(compareSemver("1.0.0-rc.1", "1.0")).toBeLessThan(0);
+			});
+
+			it("orders a loose two-part version against a higher tagged release", () => {
+				expect(compareSemver("1.0", "2.0.0-rc.1")).toBeLessThan(0);
+				expect(compareSemver("2.0.0-rc.1", "1.0")).toBeGreaterThan(0);
+			});
+
+			it("sorts a full canonical ascending sequence consistently", () => {
+				const ascending = ["dev", "0.99.0", "1.0.0-rc.1", "1.0.0-rc.2", "1.0.0"];
+				for (let i = 0; i + 1 < ascending.length; i++) {
+					expect(compareSemver(ascending[i], ascending[i + 1])).toBeLessThan(0);
+					expect(compareSemver(ascending[i + 1], ascending[i])).toBeGreaterThan(0);
+				}
+			});
+		});
 	});
 
 	// ── deriveSourceTag ──────────────────────────────────────────────────

--- a/cli/src/install/DistPathResolver.ts
+++ b/cli/src/install/DistPathResolver.ts
@@ -24,6 +24,7 @@ import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { unlink } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
+import { coerce as semverCoerce, compare as semverCompare, valid as semverValid } from "semver";
 import { createLogger } from "../Logger.js";
 import type { DistPathInfo } from "../Types.js";
 import { installDistPath } from "./DistPathWriter.js";
@@ -156,17 +157,54 @@ export function traverseDistPaths(globalDir?: string): DistPathInfo[] {
 // ─── Version comparison ──────────────────────────────────────────────────────
 
 /**
- * Compares two semver version strings. Returns:
+ * Compares two version strings for dist-path selection. Returns:
  *   > 0 if a > b
  *   < 0 if a < b
  *   0   if a === b
  *
- * Non-numeric versions ("unknown", "dev", "") are treated as the lowest possible
- * version, so any valid semver string wins over them. Matches the shell-side
- * `run-hook` behavior (which normalizes dev/unknown to 0.0.0 before
- * `sort -V`).
+ * Three tiers, in order:
+ *   1. **Prerelease / build metadata** (`-rc.1`, `+build.5`): when either side
+ *      carries such a tag, defer to the `semver` library for both-valid pairs
+ *      so a prerelease sorts below its own release (`1.0.0-rc.1` < `1.0.0`) yet
+ *      a newer prerelease still beats an older stable (`1.0.0-rc.1` > `0.99.0`)
+ *      and build metadata is ignored. A valid semver string beats a non-semver
+ *      sentinel (`dev`/`unknown`) on that tagged side.
+ *   2. **Plain numeric** (`1.0`, `1.2.3`): loose dotted comparison, filling
+ *      missing parts with 0 so `1.0` === `1.0.0`.
+ *   3. **Non-numeric sentinels** (`dev`, `unknown`, ``): ranked lowest, two
+ *      sentinels compare equal.
+ *
+ * Divergence from the shell side: `resolve-dist-path` selects with `sort -V`,
+ * which ranks `1.0.0-rc.1` ABOVE `1.0.0` (opposite of semver). Matching that in
+ * POSIX sh would mean hand-rolling semver prerelease rules — not worth the risk
+ * for the rare case of a release and its own prerelease both being registered.
+ * This function is the in-process authority; the shell is a best-effort
+ * approximation that agrees on every non-prerelease comparison.
  */
 export function compareSemver(a: string, b: string): number {
+	// Tier 1: prerelease/build metadata needs semver-aware ordering — the loose
+	// numeric path below cannot order a `-rc.N` suffix.
+	if (a.includes("-") || a.includes("+") || b.includes("-") || b.includes("+")) {
+		// Normalize each side to a comparable semver string. A tagged side uses
+		// its exact valid form (keeping the prerelease/build tag); a loose dotted
+		// numeric like `1.0` is coerced to `1.0.0` so it can be ordered *against*
+		// a tagged version (`1.0` > `1.0.0-rc.1`) instead of being mistaken for a
+		// non-semver sentinel. Non-numeric sentinels (`dev`/`unknown`) stay null.
+		const norm = (v: string): string | null => {
+			const exact = semverValid(v);
+			if (exact) return exact;
+			return /^\d+(\.\d+)*$/.test(v) ? (semverCoerce(v)?.version ?? null) : null;
+		};
+		const aSem = norm(a);
+		const bSem = norm(b);
+		if (aSem && bSem) return semverCompare(aSem, bSem);
+		if (aSem) return 1; // valid (pre)release beats a non-semver sentinel
+		if (bSem) return -1;
+		// Neither parses as semver → fall through to the numeric tier, where both
+		// rank lowest and compare equal.
+	}
+
+	// Tier 2 + 3: loose numeric comparison; non-numeric sentinels rank lowest.
 	const aValid = /^\d+(\.\d+)*$/.test(a);
 	const bValid = /^\d+(\.\d+)*$/.test(b);
 	if (!aValid && !bValid) return 0;

--- a/cli/src/install/DistPathWriter.ts
+++ b/cli/src/install/DistPathWriter.ts
@@ -26,22 +26,26 @@ const log = createLogger("DistPathWriter");
  *   <version>
  *   /absolute/path/to/dist
  *
- * The version is the `@jolli.ai/cli` core version (`__PKG_VERSION__`), not the
- * IDE extension's own release version. CLI, VS Code, Cursor, etc. all bundle
- * the same `@jolli.ai/cli` core, so versions are directly comparable.
+ * The version is the `@jolli.ai/cli` core version (`__CLI_PKG_VERSION__`), not
+ * the IDE extension's own release version. CLI, VS Code, Cursor, etc. all bundle
+ * the same `@jolli.ai/cli` core, so versions are directly comparable — runtime
+ * selection picks the surface carrying the newest *core*. `__CLI_PKG_VERSION__`
+ * (rather than `__PKG_VERSION__`) is required because under the VSCode bundle
+ * `__PKG_VERSION__` is the extension's own release number, which diverges from
+ * the bundled core's version (see Globals.d.ts).
  *
  * @param sourceTag - Source identifier ("cli", "vscode", "cursor", ...).
  *   Becomes the filename inside `dist-paths/`.
  * @param distDir - Absolute path to the dist directory. Defaults to the
  *   caller's own dist/.
- * @param version - Core version. Defaults to `__PKG_VERSION__`.
+ * @param version - Core version. Defaults to `__CLI_PKG_VERSION__`.
  *
  * @returns `true` on success, `false` on filesystem failure (logged as warning).
  */
 export async function installDistPath(sourceTag: string, distDir?: string, version?: string): Promise<boolean> {
 	const currentDir = distDir ?? dirname(fileURLToPath(import.meta.url));
-	/* v8 ignore start -- compile-time ternary: __PKG_VERSION__ is always defined in bundled builds */
-	const ver = version ?? (typeof __PKG_VERSION__ !== "undefined" ? __PKG_VERSION__ : "dev");
+	/* v8 ignore start -- compile-time ternary: __CLI_PKG_VERSION__ is always defined in bundled builds */
+	const ver = version ?? (typeof __CLI_PKG_VERSION__ !== "undefined" ? __CLI_PKG_VERSION__ : "dev");
 	/* v8 ignore stop */
 	const distPathsDir = join(homedir(), ".jolli", "jollimemory", "dist-paths");
 	const distPathFile = join(distPathsDir, sourceTag);

--- a/cli/src/sync/BootstrapMerge.test.ts
+++ b/cli/src/sync/BootstrapMerge.test.ts
@@ -10,7 +10,7 @@ import { execFileSync } from "node:child_process";
 import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { BOOTSTRAP_STASH_DIRNAME, runBootstrapMerge, shouldRunBootstrapMerge } from "./BootstrapMerge.js";
 import { GitClient } from "./GitClient.js";
 import type { GitCredentials } from "./SyncTypes.js";
@@ -20,6 +20,11 @@ import type { GitCredentials } from "./SyncTypes.js";
 process.env.GIT_CONFIG_GLOBAL = "/dev/null";
 process.env.GIT_CONFIG_SYSTEM = "/dev/null";
 process.env.GIT_TERMINAL_PROMPT = "0";
+
+// Every test spawns several real `git` subprocesses; under parallel suite load
+// + `--coverage` the global 15s testTimeout / 10s hookTimeout flake. 30s gives
+// this real-git suite headroom without loosening the global pure-unit budget.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
 
 const NOOP_ASKPASS = async (): Promise<{
 	scriptPath: string;

--- a/cli/src/sync/GitClient.test.ts
+++ b/cli/src/sync/GitClient.test.ts
@@ -12,7 +12,7 @@ import { execFileSync } from "node:child_process";
 import { mkdir, mkdtemp, readFile, rm, stat, utimes, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { GitClient, injectGithubAppUsername, isNetworkErrorMessage, isRepoMissingMessage } from "./GitClient.js";
 import type { GitCredentials } from "./SyncTypes.js";
 
@@ -23,6 +23,12 @@ import type { GitCredentials } from "./SyncTypes.js";
 process.env.GIT_CONFIG_GLOBAL = "/dev/null";
 process.env.GIT_CONFIG_SYSTEM = "/dev/null";
 process.env.GIT_TERMINAL_PROMPT = "0";
+
+// Every test here spawns several real `git` subprocesses (clone/commit/push/
+// pullRebase). Under parallel suite load + `--coverage` instrumentation the
+// global 15s testTimeout / 10s hookTimeout flake; 30s gives this real-git
+// suite headroom without loosening the global budget for pure-unit tests.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
 
 const NOOP_ASKPASS = async (): Promise<{
 	scriptPath: string;

--- a/cli/src/util/Subprocess.test.ts
+++ b/cli/src/util/Subprocess.test.ts
@@ -209,4 +209,32 @@ describe("Subprocess", () => {
 			await expect(execFileAsyncHidden("git", ["bogus"])).rejects.toBe(err);
 		});
 	});
+
+	describe("runNpmCommand", () => {
+		it("rejects a shell-unsafe argument before spawning npm", async () => {
+			const { runNpmCommand } = await import("./Subprocess.js");
+			await expect(runNpmCommand(["view", "evil; rm -rf /", "version"])).rejects.toThrow(/shell-unsafe argument/);
+			expect(mockExecFile).not.toHaveBeenCalled();
+		});
+
+		it("allows allow-list-shaped tokens and returns trimmed stdout", async () => {
+			mockExecFile.mockImplementationOnce(
+				(
+					_file: string,
+					_args: ReadonlyArray<string>,
+					_options: unknown,
+					callback: (err: null, result: { stdout: string; stderr: string }) => void,
+				) => {
+					callback(null, { stdout: "1.2.3\n", stderr: "" });
+				},
+			);
+			const { runNpmCommand } = await import("./Subprocess.js");
+			expect(await runNpmCommand(["view", "@jolli.ai/cli", "version"])).toBe("1.2.3");
+		});
+
+		it("returns null on empty stdout", async () => {
+			const { runNpmCommand } = await import("./Subprocess.js");
+			expect(await runNpmCommand(["root", "-g"])).toBeNull();
+		});
+	});
 });

--- a/cli/src/util/Subprocess.ts
+++ b/cli/src/util/Subprocess.ts
@@ -49,6 +49,55 @@ export function execFileAsyncHidden(
 	}>;
 }
 
+/**
+ * Run an `npm` subcommand cross-platform, returning trimmed stdout or null on
+ * any failure (npm missing, non-zero exit, timeout, empty output).
+ *
+ * On Windows the npm launcher is `npm.cmd`, and a bare `npm` cannot be spawned
+ * without a shell: `execFile`/`spawn` don't resolve via `PATHEXT` (→ `ENOENT`),
+ * and since the Node fix for CVE-2024-27980 (18.20.2 / 20.12.2 / 21.7.2 — all
+ * below our `>=22.5` floor) even an explicit `npm.cmd` is rejected without
+ * `shell: true` (→ `EINVAL`). So we opt into a shell on win32 only, where
+ * `cmd.exe` resolves `npm.cmd` through `PATHEXT`. Every caller passes static
+ * tokens plus allow-listed package names — never user-controlled input — and the
+ * `UNSAFE_ARG` guard below enforces that contract in code rather than leaving it
+ * to comment discipline, so the shell carries no injection surface.
+ *
+ * Single source of truth for "how to invoke npm" so a future third call site
+ * can't reintroduce the bare-`execFile("npm")` bug that silently no-ops on
+ * Windows.
+ *
+ * Coverage-ignored: the only effect is spawning npm, which can't be unit-tested
+ * deterministically without a fake npm on PATH — same rationale the two former
+ * inline runners carried.
+ */
+/** A shell-unsafe argument is anything outside the chars npm tokens / package names actually use. */
+const UNSAFE_ARG = /[^\w.@/-]/;
+
+/* v8 ignore start */
+export async function runNpmCommand(args: ReadonlyArray<string>, opts?: { timeout?: number }): Promise<string | null> {
+	// Programmer-error guard, deliberately OUTSIDE the try below: a caller that
+	// passes an arg with shell metacharacters is a bug to surface loudly, not to
+	// swallow into a silent null (which is the very failure mode this helper exists
+	// to prevent). Validated on every platform so the mistake is caught in dev, not
+	// only once it reaches the win32 `shell: true` path.
+	const unsafe = args.find((arg) => UNSAFE_ARG.test(arg));
+	if (unsafe !== undefined) {
+		throw new Error(`runNpmCommand: refusing to invoke npm with shell-unsafe argument: ${JSON.stringify(unsafe)}`);
+	}
+	try {
+		const { stdout } = await execFileAsyncHidden("npm", args, {
+			timeout: opts?.timeout,
+			shell: process.platform === "win32",
+		});
+		const trimmed = stdout.trim();
+		return trimmed.length > 0 ? trimmed : null;
+	} catch {
+		return null;
+	}
+}
+/* v8 ignore stop */
+
 export function execFileSyncHidden(
 	file: string,
 	args: ReadonlyArray<string> | undefined,


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## Plans & Notes

- 111. DESIGN - JolliMemory Version Detection & Upgrade Management Across Four Deliverables

## Quick recap

The developer implemented a three-phase version-detection system across the CLI and plugin ecosystem. Plugin diagnostics now surface in the doctor command with three states—absent, incompatible, or compatible—replacing the old silent-skip behavior and giving users explicit upgrade paths when a plugin is installed but incompatible with the host. The diagnostic output was clarified to indicate that it verifies installation and version compatibility only, not whether the plugin's code actually loaded, preventing users from misinterpreting a passing check as proof the plugin works.

The CLI now performs outward freshness detection by caching the npm registry's latest version for the CLI and installed plugins, spawning a detached background refresh when the cache is stale so the foreground never blocks on network I/O. Users will see upgrade hints when a newer version is available on npm. The cache refresh logic was hardened to preserve previously-cached package versions when a registry query fails transiently, preventing the silent loss of update notices that users rely on to stay current. The system gracefully degrades on any failure—missing cache, npm query timeout, or write failure all fall back to local-only comparison without blocking the CLI.

The dist-path selection logic was also hardened to follow semver semantics for prerelease versions, fixing a bug where RC builds would lose selection to ancient stable versions. The in-process version comparison now correctly ranks a prerelease below its own release but above older stable versions, aligning with semver standards.

---

## E2E Test (3)
<details>
<summary><strong>1. Doctor command displays installed plugins with version and compatibility status</strong></summary>
<br>
<blockquote>

**Steps:**
1. Open a terminal and run `jolli doctor`
2. Scroll down to the "Plugins" section of the output
3. Verify that any installed plugins are listed with a checkmark (✓) or warning (⚠) icon
4. For compatible plugins, confirm the plugin name and version number are displayed (e.g., "✓ plugin @jolli.ai/site-cli 0.4.2")
5. For incompatible plugins, confirm a warning icon appears with the plugin name, required version range, and an npm install command to upgrade it
6. Verify that plugins marked as absent do not appear in the list

**Expected Results:**
- Compatible installed plugins show a checkmark with their package name and installed version
- Incompatible plugins show a warning icon with the package name, required peer version range (e.g., ">=2.0.0"), and an explicit npm install command
- Absent plugins are not listed to reduce clutter
- If a plugin has no version information, it displays "vunknown" instead of a version number

</blockquote>
</details>
<details>
<summary><strong>2. CLI displays upgrade prompt with correct package name when newer version is available</strong></summary>
<br>
<blockquote>

**Steps:**
1. Open a terminal and run any `jolli` command (e.g., `jolli --help`)
2. Check the output for an upgrade notice
3. Verify the notice mentions the full package name "@jolli.ai/cli" (not just "jolli")
4. Confirm the notice includes the exact npm command to upgrade: `npm update -g @jolli.ai/cli`

**Expected Results:**
- The upgrade message reads "A newer version of @jolli.ai/cli is available"
- The suggested command is `npm update -g @jolli.ai/cli`
- The message appears in stderr output

</blockquote>
</details>
<details>
<summary><strong>3. Prerelease versions are ranked correctly in version comparison</strong></summary>
<br>
<blockquote>

**Steps:**
1. Run `jolli doctor` to check the CLI version display
2. If the running CLI is a prerelease version (e.g., 1.0.0-rc.1), verify it is correctly compared against available versions
3. Confirm that a prerelease version is ranked below its final release (e.g., 1.0.0-rc.1 < 1.0.0) but above older stable versions (e.g., 1.0.0-rc.1 > 0.99.0)

**Expected Results:**
- Prerelease versions sort correctly according to semantic versioning rules
- An RC build does not lose to ancient stable versions in version selection
- The version comparison respects semver semantics for prerelease ordering

</blockquote>
</details>

---

## Topics (4)
<details>
<summary><strong>01 · Plugin version visibility and compatibility diagnostics in doctor command</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Plugins had only a binary installed/absent state with no visibility into whether an installed plugin was compatible with the host CLI or whether a newer version existed. When a plugin failed to load due to incompatibility, the loader only printed a warning and silently skipped it, leaving users with no clear upgrade path.

**💡 Decisions Behind the Code**

- **Reuse discovery data instead of re-scanning**: The plugin loader already reads metadata during discovery; returning diagnostics alongside the loaded set avoids a second filesystem walk in the version check, keeping the startup hot path fast while ensuring the diagnostic view and loader use identical data.
- **Shared peer-compatibility check**: A single `isPeerCompatible()` function is used by both the load gate and the diagnostic view so they can never report conflicting states. This eliminates the anti-pattern where incompatibility was detected but only warned, with no upgrade exit.
- **Three-state diagnostic over binary state**: Replacing "installed / not installed" with "absent / incompatible / ok" gives users actionable information. An incompatible plugin now surfaces with the required peer range and an explicit install command, transforming a silent skip into a clear upgrade path.
- **Narrow the diagnostic scope**: The diagnostic is a no-load probe that verifies installation and version compatibility only, not whether the plugin's code actually loaded. Adding load-health detection would defeat the purpose of fast diagnostics without executing plugin code. The three-state model is appropriate for its intended use case.

**✅ What Was Implemented**

- Added a `version` field to the plugin metadata interface and extracted a shared `isPeerCompatible()` function used by both the loader (load gate) and a new `inspectPlugins()` diagnostic function, ensuring the two never disagree on loadability.
- Modified the plugin loader to return both the loaded-ID set and a three-state `PluginDiagnostic` snapshot (absent, incompatible, or ok) computed from the single discovery walk it already performs, eliminating a second filesystem scan on the startup hot path.
- Integrated plugin diagnostics into the doctor command to render installed plugins with their state: compatible plugins show version and status, incompatible plugins display the required peer range and explicit upgrade instructions, and absent plugins are omitted to reduce noise.
- Clarified in documentation that the `ok` state means "discovered and peer-compatible" and is NOT a guarantee the plugin's code loaded successfully. Updated the doctor output message from "(compatible)" to "(installed, compatible)" to avoid implying successful load.

**📁 FILES**
- `cli/src/PluginLoader.ts`
- `cli/src/commands/DoctorCommand.ts`
- `cli/src/Api.ts`

</blockquote>
</details>
<details>
<summary><strong>02 · Outward freshness detection with npm registry cache and detached refresh</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The version check only compared locally-installed surfaces and never queried npm, so a user with only the CLI installed would never receive an upgrade prompt even when a newer version existed on npm. Plugins had no version freshness visibility at all.

**💡 Decisions Behind the Code**

- **Detached refresh over blocking network I/O**: Querying npm in the foreground would add latency to every CLI invocation. Spawning a detached child process keeps the foreground fast while refreshing the cache in the background. A debounce sentinel prevents a retry storm when the TTL expires.
- **Cache only registry latest, read versions live**: Caching installed versions would risk drift between cache and actual install. Only the registry `latest` is cached; the locally-installed version is always read live, so the cache can never become stale relative to what is actually on disk.
- **Graceful degradation on all failures**: Missing or corrupt cache, npm query failure, write failure, or spawn failure all degrade silently. The version check must never block CLI execution, so every error path falls back to "no hint" rather than throwing.
- **Merge strategy for transient failures**: Use a merge approach instead of wholesale overwrite when refreshing the cache. This prevents a single transient failure from erasing all known update information, which could cause users to miss legitimate upgrade opportunities.

**✅ What Was Implemented**

- Created a new `UpdateCheck` module with a TTL-bounded cache storing the registry `latest` for the CLI and each installed plugin. The cache is read-only in the foreground (never blocks); when stale, a detached refresh process is spawned and the current invocation continues immediately.
- Implemented `claimRefreshSpawn()` with a debounce sentinel to collapse a burst of near-simultaneous invocations to a single npm query, preventing a retry storm when the cache TTL expires. Atomic temp+rename writes prevent concurrent refresh processes from corrupting the cache file.
- Upgraded the version check to async, consuming plugin diagnostics and comparing the running version against the highest of local surfaces or registry latest. Generates separate upgrade notices for the CLI and each stale plugin with explicit npm commands.
- Modified the cache refresh logic to seed the new cache from the existing one before querying the registry. When a package query fails, that package now retains its previously-cached latest version instead of being dropped, preventing transient failures from silently suppressing known update notices.
- Registered a hidden refresh subcommand in the API to accept a package list and invoke the cache refresh, completing the detached-spawn pattern.

**📁 FILES**
- `cli/src/core/UpdateCheck.ts`
- `cli/src/commands/CliUtils.ts`
- `cli/src/Api.ts`

</blockquote>
</details>
<details>
<summary><strong>03 · Semver prerelease ordering in dist-path selection</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The in-process version comparison function treated any prerelease version as non-numeric and ranked it lowest, so an RC build would lose dist-path selection even to ancient stable versions. This contradicted semver semantics where a prerelease sorts below its own release but above older stable versions.

**💡 Decisions Behind the Code**

- **Semver as the in-process authority**: The rare case of a release and its own prerelease both being registered does not justify hand-rolling prerelease rules in POSIX shell. The in-process function is the source of truth; the shell divergence is documented and acceptable because non-prerelease comparisons (the common case) agree.

**✅ What Was Implemented**

- Rewrote the version comparison function to use a three-tier approach: when either version carries a prerelease or build tag, defer to the semver library for both-valid pairs so `1.0.0-rc.1` correctly sorts below `1.0.0` yet above `0.99.0`; plain numeric versions use loose dotted comparison; non-numeric sentinels rank lowest.
- Added nine new test cases covering prerelease ordering, loose two-part versions against tagged releases, and a full canonical ascending sequence.
- Added a JSDoc note documenting the known divergence: the shell `sort -V` ranks `1.0.0-rc.1` ABOVE `1.0.0` (opposite of semver), but matching that in POSIX sh would require hand-rolling prerelease rules. The in-process function is the authority; the shell is a best-effort approximation that agrees on every non-prerelease comparison.

**📁 FILES**
- `cli/src/install/DistPathResolver.ts`
- `cli/src/install/DispatchScripts.ts`

</blockquote>
</details>
<details>
<summary><strong>04 · Test timeout hardening for real-git suites</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Under parallel test load with coverage instrumentation, test suites that spawn multiple git subprocesses were timing out at the global 15-second limit, causing flaky failures unrelated to code changes.

**💡 Decisions Behind the Code**

- **Per-suite timeout override over global loosening**: Raising the global timeout would weaken the constraint on pure-unit tests, which should be fast. Targeting only the real-git suites that actually need it preserves the fast-feedback guarantee for the majority of tests while giving integration tests the headroom they require.

**✅ What Was Implemented**

- Added per-suite timeout overrides to the real-git test suites with explanatory comments noting that these suites spawn heavy real-git operations and need headroom under parallel load and coverage instrumentation.

**📁 FILES**
- `cli/src/sync/GitClient.test.ts`
- `cli/src/sync/BootstrapMerge.test.ts`

</blockquote>
</details>

---

*Generated by Jolli Memory · June 5, 2026 at 9:21 AM · via Anthropic*
<!-- jollimemory-summary-end -->