### PR TITLE
Remove periodic polling timer for branch updates in tool window

### DIFF
--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/JolliMemoryToolWindowFactory.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/JolliMemoryToolWindowFactory.kt
@@ -366,13 +366,7 @@ class JolliMemoryToolWindowFactory : ToolWindowFactory, DumbAware {
             VcsListener { updateBreadcrumbBranch() },
         )
 
-        // Path 3: Periodic poll every 2 seconds (catches all edge cases)
-        javax.swing.Timer(2000) { updateBreadcrumbBranch() }.apply {
-            isRepeats = true
-            start()
-        }
-
-        // Path 4: Service status change
+        // Path 3: Service status change
         service.addStatusListener { updateBreadcrumbBranch() }
 
         toolWindow.contentManager.addContent(content)


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## Quick recap

The developer removed a background polling timer from the IntelliJ tool window that was firing every two seconds and resetting the branch breadcrumb to the current git branch. This timer was the root cause of a confusing bug: a user could select a different branch in the breadcrumb to browse its memories, but within two seconds the label would silently snap back to the active git branch — even though the memories panel continued showing the foreign branch's content. The breadcrumb was effectively lying about what was being displayed.

Investigation traced the timer back through two separate authors and commits: it was originally introduced as a generic branch-label updater, then later rewired to target the breadcrumb specifically when the breadcrumb component was introduced, without accounting for the fact that the breadcrumb now supports intentional foreign-branch viewing. Because IntelliJ's built-in git event listeners already handle real branch switches reliably, the timer had no remaining purpose. Removing it entirely restored correct behavior — the breadcrumb now stays on whichever branch the user selected until a genuine git branch change occurs.

---

## Topic (1)
<details>
<summary><strong>01 · Remove polling timer that reset branch breadcrumb every two seconds</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The branch breadcrumb in the IntelliJ tool window kept snapping back to the current git branch even when the user had intentionally selected a different branch to browse its memories. The displayed branch label was lying about what was actually being shown.

**💡 Decisions Behind the Code**

- **Remove rather than guard**: The timer was identified as a redundant safety net — IntelliJ's `GIT_REPO_CHANGE` and `VCS_CONFIGURATION_CHANGED` listeners already cover real branch switches reliably. Removing it entirely was cleaner than adding a foreign-mode guard, since the timer served no purpose the event listeners didn't already cover.
- **Preserve event listeners untouched**: The other three update paths were left as-is because they respond to actual user-initiated git branch changes and do not need modification for this bug.

**✅ What Was Implemented**

- Removed the two-second repeating `javax.swing.Timer` in `JolliMemoryToolWindowFactory.kt` that unconditionally called `updateBreadcrumbBranch()` on every tick, overwriting any foreign branch selection the user had made.
- The remaining three update paths (two git event listeners and the service status listener) are preserved to handle legitimate branch-switch events.

**📁 FILES**
- `intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/JolliMemoryToolWindowFactory.kt`

</blockquote>
</details>

---

*Generated by JolliMemory · June 5, 2026 at 6:16 PM · via Anthropic*
<!-- jollimemory-summary-end -->