### PR TITLE
Fix Windows plugin discovery via self-install node_modules root

### DIFF
--- a/cli/src/PluginLoader.test.ts
+++ b/cli/src/PluginLoader.test.ts
@@ -19,7 +19,7 @@ import { getHelpGroup } from "./commands/HelpGroups.js";
 import type { KnownPlugin } from "./KnownPlugins.js";
 import { KNOWN_PLUGINS } from "./KnownPlugins.js";
 import { setSilentConsole } from "./Logger.js";
-import { getNpmRootGlobal, inspectPlugins, loadPlugins } from "./PluginLoader.js";
+import { findNodeModulesRoot, getNpmRootGlobal, inspectPlugins, loadPlugins } from "./PluginLoader.js";
 
 const FIXTURE_NAME = "@test-fixtures/example-plugin";
 const FIXTURE_SCOPE = "@test-fixtures";
@@ -780,6 +780,79 @@ describe("loadPlugins", () => {
 				getGlobalRoot: async () => null,
 			});
 			expect(program.commands).toHaveLength(0);
+		} finally {
+			process.chdir(origCwd);
+			await rm(cleanCwd, { recursive: true, force: true });
+		}
+	});
+
+	it("discovers a plugin via the self-install root when getGlobalRoot returns null", async () => {
+		// The Windows-regression case (JOLLI-1694): `npm root -g` is unavailable
+		// (subprocess timeout / stripped PATH), so the global resolver yields
+		// null. The running CLI's own node_modules — the sibling-of-the-host
+		// layout a global `npm install -g` produces — must still surface the
+		// plugin. Here `getSelfInstallRoot` stands in for the import.meta.url
+		// walk and points at the fixture's node_modules root.
+		const root = await writeFixture(tempDir, {
+			pluginSource:
+				"export const register = (ctx) => { ctx.program.command('plugin-via-self').action(() => {}); };",
+		});
+		const cleanCwd = await mkdtemp(join(tmpdir(), "clean-cwd-"));
+		const origCwd = process.cwd();
+		process.chdir(cleanCwd);
+		try {
+			const program = new Command();
+			await loadPlugins(program, "0.100.0", {
+				allowlistOverride: [FIXTURE_ID],
+				scopesOverride: [FIXTURE_SCOPE],
+				getGlobalRoot: async () => null,
+				getSelfInstallRoot: () => root,
+			});
+			expect(program.commands.find((c) => c.name() === "plugin-via-self")).toBeDefined();
+		} finally {
+			process.chdir(origCwd);
+			await rm(cleanCwd, { recursive: true, force: true });
+		}
+	});
+
+	it("does not crash when getSelfInstallRoot returns null", async () => {
+		const cleanCwd = await mkdtemp(join(tmpdir(), "clean-cwd-"));
+		const origCwd = process.cwd();
+		process.chdir(cleanCwd);
+		try {
+			const program = new Command();
+			await loadPlugins(program, "0.100.0", {
+				allowlistOverride: [FIXTURE_ID],
+				scopesOverride: [FIXTURE_SCOPE],
+				getGlobalRoot: async () => null,
+				getSelfInstallRoot: () => null,
+			});
+			expect(program.commands).toHaveLength(0);
+		} finally {
+			process.chdir(origCwd);
+			await rm(cleanCwd, { recursive: true, force: true });
+		}
+	});
+
+	it("deduplicates when the self-install root and global root point at the same location", async () => {
+		// A standard global install: both resolvers return the same node_modules.
+		// The plugin must register exactly once, not twice.
+		const root = await writeFixture(tempDir, {
+			pluginSource:
+				"export const register = (ctx) => { ctx.program.command('plugin-self-dedup').action(() => {}); };",
+		});
+		const cleanCwd = await mkdtemp(join(tmpdir(), "clean-cwd-"));
+		const origCwd = process.cwd();
+		process.chdir(cleanCwd);
+		try {
+			const program = new Command();
+			await loadPlugins(program, "0.100.0", {
+				allowlistOverride: [FIXTURE_ID],
+				scopesOverride: [FIXTURE_SCOPE],
+				getSelfInstallRoot: () => root,
+				getGlobalRoot: async () => root,
+			});
+			expect(program.commands.filter((c) => c.name() === "plugin-self-dedup")).toHaveLength(1);
 		} finally {
 			process.chdir(origCwd);
 			await rm(cleanCwd, { recursive: true, force: true });
@@ -1570,5 +1643,36 @@ describe("loadPlugins diagnostics", () => {
 		expect(loaded.size).toBe(0);
 		expect(diagnostics).toHaveLength(KNOWN_PLUGINS.length);
 		expect(diagnostics.every((d) => d.state === "absent")).toBe(true);
+	});
+});
+
+describe("findNodeModulesRoot", () => {
+	// Pure walk used by the self-install discovery root (JOLLI-1694). Inputs use
+	// forward slashes, which both `path.posix` (CI runners) and `path.win32`
+	// (Windows) accept as separators, so the assertions hold on either host.
+
+	it("returns the directory itself when it is named node_modules", () => {
+		expect(findNodeModulesRoot("/usr/lib/node_modules")).toBe("/usr/lib/node_modules");
+	});
+
+	it("returns the nearest node_modules ancestor of a globally-installed CLI path", () => {
+		// The shape a global `npm install -g @jolli.ai/cli` produces.
+		expect(findNodeModulesRoot("/usr/local/lib/node_modules/@jolli.ai/cli/dist")).toBe(
+			"/usr/local/lib/node_modules",
+		);
+	});
+
+	it("returns the closest node_modules when several are nested", () => {
+		expect(findNodeModulesRoot("/a/node_modules/x/node_modules/@jolli.ai/cli/dist")).toBe(
+			"/a/node_modules/x/node_modules",
+		);
+	});
+
+	it("returns null when no node_modules ancestor exists (tsx dev run)", () => {
+		expect(findNodeModulesRoot("/Users/dev/workspace/jolliai/cli/src")).toBeNull();
+	});
+
+	it("returns null at the filesystem root", () => {
+		expect(findNodeModulesRoot("/")).toBeNull();
 	});
 });

--- a/cli/src/PluginLoader.ts
+++ b/cli/src/PluginLoader.ts
@@ -38,8 +38,8 @@
 import { existsSync } from "node:fs";
 import { mkdir, readdir, readFile, realpath, stat, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
-import { dirname, isAbsolute, join, parse as parsePath, relative, resolve } from "node:path";
-import { pathToFileURL } from "node:url";
+import { basename, dirname, isAbsolute, join, parse as parsePath, relative, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { Command } from "commander";
 import { satisfies } from "semver";
 import type { PluginContext, PluginRegister } from "./Api.js";
@@ -87,6 +87,14 @@ export interface LoadPluginsOptions {
 	scopesOverride?: ReadonlyArray<string>;
 	/** Custom resolver for the global npm root. Returning `null` means "not available". */
 	getGlobalRoot?: () => Promise<string | null>;
+	/**
+	 * Custom resolver for the `node_modules` root the running CLI is installed
+	 * under (the sibling-of-`@jolli.ai/cli` discovery root). Returning `null`
+	 * means "could not self-locate" (tsx dev run / bundled host). Test-only
+	 * injection point — production callers leave this unset and the loader uses
+	 * {@link defaultSelfInstallRoot}.
+	 */
+	getSelfInstallRoot?: () => string | null;
 	/**
 	 * Override for the user's home directory, used as the fallback upper bound
 	 * of the upward `node_modules` walk when no `.git` ancestor is found.
@@ -428,6 +436,23 @@ async function resolveRoots(opts?: LoadPluginsOptions): Promise<ReadonlyArray<st
 		dir = parent;
 	}
 
+	// Self-install root: the `node_modules` the running CLI itself lives under.
+	// A globally-installed `jolli` runs from `…/node_modules/@jolli.ai/cli/…`, so
+	// a co-installed plugin like `@jolli.ai/space-cli` is necessarily its sibling
+	// under the same `node_modules`. Adding this root makes global-plugin
+	// discovery independent of `npm root -g` — which on Windows routinely fails
+	// (5s subprocess timeout on cold `cmd.exe → npm.cmd → node`, a PATH stripped
+	// by the launching GUI/IDE, or a version-manager pointing the cache at a
+	// different Node's global root). The cwd walk above can never reach the
+	// global dir, so before this the global plugin was only reachable via that
+	// fragile subprocess. Cheap and deterministic; ordered before the global
+	// root so the sibling layout wins when both resolve to a directory.
+	const selfRootResolver = opts?.getSelfInstallRoot ?? defaultSelfInstallRoot;
+	const selfRoot = selfRootResolver();
+	if (selfRoot && existsSync(selfRoot) && !result.includes(selfRoot)) {
+		result.push(selfRoot);
+	}
+
 	const globalRootResolver = opts?.getGlobalRoot ?? (() => getNpmRootGlobal());
 	const globalRoot = await globalRootResolver();
 	if (globalRoot && existsSync(globalRoot) && !result.includes(globalRoot)) {
@@ -436,6 +461,53 @@ async function resolveRoots(opts?: LoadPluginsOptions): Promise<ReadonlyArray<st
 
 	return result;
 }
+
+/**
+ * Walk up from `startDir` to the nearest ancestor directory named
+ * `node_modules`, returning its absolute path, or `null` when none is found
+ * before reaching the filesystem root.
+ *
+ * Pure and synchronous so the walk logic is unit-testable with both POSIX and
+ * Windows-style inputs without spawning anything or mocking `import.meta.url`.
+ * Uses the platform `node:path` semantics (`basename` / `dirname` / `parse`),
+ * so on a real Windows runtime it walks `\`-separated paths correctly; the
+ * production self-locator ({@link defaultSelfInstallRoot}) feeds it the running
+ * module's own directory.
+ */
+export function findNodeModulesRoot(startDir: string): string | null {
+	const fsRoot = parsePath(startDir).root;
+	let dir = startDir;
+	while (dir !== fsRoot) {
+		if (basename(dir) === "node_modules") return dir;
+		const parent = dirname(dir);
+		if (parent === dir) break;
+		dir = parent;
+	}
+	return null;
+}
+
+/**
+ * Production resolver for the self-install `node_modules` root: walk up from
+ * this module's own on-disk location to the enclosing `node_modules`.
+ *
+ * Coverage-ignored: the result depends on where this module physically resides
+ * (`import.meta.url`), which can't be exercised deterministically in unit tests
+ * — the same rationale as {@link runNpmRootGlobal}. The walk itself is fully
+ * tested via {@link findNodeModulesRoot}; the loader's use of the resolved root
+ * is tested via the `getSelfInstallRoot` injection point. `fileURLToPath` is
+ * the same self-location pattern used in `Installer.ts` / `DistPathWriter.ts`,
+ * and esbuild rewrites `import.meta.url` to a real path in the VS Code bundle
+ * (where the walk simply finds no `@jolli.ai` scope and the root is skipped).
+ */
+/* v8 ignore start */
+function defaultSelfInstallRoot(): string | null {
+	try {
+		return findNodeModulesRoot(dirname(fileURLToPath(import.meta.url)));
+	} catch {
+		return null;
+	}
+}
+/* v8 ignore stop */
 
 /**
  * Walk the given roots, scan each known scope directory, and return the first


### PR DESCRIPTION
## Summary

On Windows, the OSS CLI failed to discover globally-installed plugins (e.g. `@jolli.ai/space-cli`) and silently fell back to the install-hint stub, while the same setup worked on macOS. This adds a self-locating discovery root so global-plugin discovery no longer depends on the Windows-fragile `npm root -g`.

## Motivation

Global plugin discovery's only route to a globally-installed plugin was `npm root -g`. The cwd-walk in `resolveRoots` can never reach the global install dir (it's bounded by the git-root/home boundary and the global dir isn't an ancestor of a project cwd), so the appended global root was the sole route. On Windows that subprocess is fragile:

- **5s timeout** — cold `cmd.exe → npm.cmd → node` startup plus AV scanning routinely exceeds it → `null`.
- **PATH** — launched from a GUI/IDE/integrated terminal with a stripped PATH, `npm` may not resolve → `null`.
- **Version managers** — nvm-windows / fnm / volta plus the 6h cache (`~/.jolli/jollimemory/global-root`) can point at a different Node's global root.

Any of these left `globalRoot` null/wrong, `discoverPlugins` never saw the plugin, and the host registered the stub instead. Refs JOLLI-1694.

## Changes

- `resolveRoots` now adds a **self-install root**: the running `jolli` lives at `…/node_modules/@jolli.ai/cli/…`, so a co-installed plugin is necessarily its sibling. Self-locate via `fileURLToPath(import.meta.url)` (the pattern already used in `Installer.ts` / `DistPathWriter.ts`), walk up to the nearest `node_modules` ancestor, and add it as a root — ordered before the global root. Instant, no subprocess, no PATH dependency, identical across platforms.
- `npm root -g` is kept as a fallback for non-sibling layouts.
- New pure helper `findNodeModulesRoot(startDir)` (exported for test) plus a `getSelfInstallRoot` injection point on `LoadPluginsOptions`.
- Adds the previously-missing real-path coverage for `resolveRoots`: all branches of the pure walk, plus injection-based `loadPlugins` cases for self-root discovery, null safety, and dedup.

## Testing

- [x] Added/updated unit tests (5 `findNodeModulesRoot` branch cases + 3 `loadPlugins` self-root cases)
- [x] Ran `npm run all` locally (clean → build → lint → test); coverage holds: CLI 98.56% stmts / 97.25% branches
- [x] Republished `@jolli.ai/cli@0.99.2` to a local registry and confirmed the self-install logic compiled into the minified bundle
- [x] End-to-end verified on a real Windows box (pending)

## Notes for reviewers

- **Behavioral note (intended):** only adds a root, never removes one. Precedence is cwd-walk › self-root › global. When the self-root and `npm root -g` resolve to *different* dirs that each contain the same plugin id, the self-install version wins — which is exactly the divergence this fix targets.
- **Known limitation:** pnpm's isolated global layout puts the running module under `.pnpm/.../node_modules`, where the plugin isn't a sibling, so self-location won't help there (not a regression — `npm root -g` doesn't work for pnpm either). The reported scenario is npm-style global install.

The template's IntelliJ items (`./gradlew`, Plugin Verifier) don't apply — this is a change under `cli/`.