### PR TITLE
Add full-text search index and MCP server for knowledge base

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,9 @@ Thumbs.db
 .gemini/
 .codex/
 .opencode/
+# Claude MCP server config — written per-worktree with an absolute local path
+# (jolli install → registerMcpInClaude), so it must never be committed.
+.mcp.json
 .DS_Store
 .idea/
 *.iml

--- a/cli/DEVELOPMENT.md
+++ b/cli/DEVELOPMENT.md
@@ -428,6 +428,31 @@ Api.registerCli(program, version)
 
 The `exports` field in `cli/package.json` is what enforces this: `@jolli.ai/cli` and `@jolli.ai/cli/api` are the only resolvable specifiers. Deep imports like `@jolli.ai/cli/dist/core/Foo.js` no longer resolve — plugins that relied on them must move to the public API.
 
+## Search Index & MCP Server
+
+Starting in JOLLI-1226, the CLI ships a local full-text search index plus an stdio MCP server that exposes JolliMemory's history to AI agents.
+
+### Local search index
+
+The index lives at `.jolli/jollimemory/search-index.json` (with a sidecar `search-index.manifest.json`) under the per-project `.jolli/jollimemory/` dir. It is a **disposable cache** — never written to the orphan branch — rebuilt from source (the topic KB + commit catalog) via [SearchIndex.ts](src/core/SearchIndex.ts) on top of an Orama BM25 index. The manifest records a schema version and a **staleness signature** (`computeSourceSignature` in [SearchIndexSource.ts](src/core/SearchIndexSource.ts)); `SearchIndex.open()` restores from disk only when both match the current source, otherwise it rebuilds and re-persists. Because source data (orphan branch / folder) is always authoritative, the index can be deleted at any time and is regenerated on next open.
+
+The index is also refreshed **incrementally at the end of `jolli compile`** (per-repo), so agents querying right after a compile see fresh results without a manual reindex.
+
+### `jolli mcp`
+
+`jolli mcp` ([McpCommand.ts](src/commands/McpCommand.ts)) starts an stdio MCP server ([McpServer.ts](src/mcp/McpServer.ts)) that AI agents connect to. `jolli mcp --reindex` forces a full rebuild of the local search index from source and exits (no server).
+
+The server exposes four tools, all pure handlers in [McpTools.ts](src/mcp/McpTools.ts):
+
+| Tool | Purpose |
+|------|---------|
+| `search` | Full-text search over the repo's historical decisions and implementations (topics + commits). |
+| `recall` | Recall a branch's development context from **RAW commit summaries** — the same data path as the `jolli-recall` skill, NOT the topic KB. Defaults to the current branch. |
+| `get_decision_timeline` | Chronological evolution of a topic — its source events ordered oldest-first. |
+| `list_branches` | All branches with JolliMemory records and their topic titles. |
+
+`McpServer.ts` is pure glue: tool schemas (`TOOL_DEFINITIONS`) plus a `dispatchTool` table over the `McpTools` handlers, adapted into SDK request handlers (`ListTools` / `CallTool`). Errors from a handler are returned as an `isError` tool response rather than crashing the server.
+
 ## Memory Bank Cloud Sync
 
 `cli/src/sync/` holds the engine that keeps the user's Memory Bank folder mirrored to a private Jolli vault. The engine is shipped in `dist/Cli.js` and inlined into the VS Code extension, but `@jolli.ai/cli` itself does **not** auto-trigger sync rounds today — the long-lived plugin process (currently VS Code only) is what drives the cadence. The CLI side exposes config (`syncEnabled`, `syncTranscripts`, `syncPollIntervalSec`) and the `configure --sync-enable / --sync-disable` shortcuts.

--- a/cli/package.json
+++ b/cli/package.json
@@ -67,6 +67,9 @@
 	},
 	"dependencies": {
 		"@anthropic-ai/sdk": "^0.39.0",
+		"@modelcontextprotocol/sdk": "^1.0.0",
+		"@orama/orama": "^3.0.0",
+		"@orama/plugin-data-persistence": "^3.0.0",
 		"commander": "^13.1.0",
 		"open": "^11.0.0",
 		"semver": "^7.8.1"

--- a/cli/src/Api.test.ts
+++ b/cli/src/Api.test.ts
@@ -167,6 +167,7 @@ vi.mock("./core/SummaryStore.js", () => ({
 	getIndex: vi.fn().mockResolvedValue(null),
 	// Used by compile command to register the configured storage
 	setActiveStorage: vi.fn(),
+	getActiveStorage: vi.fn(() => null),
 }));
 
 vi.mock("./core/SummaryMigration.js", () => ({

--- a/cli/src/Api.ts
+++ b/cli/src/Api.ts
@@ -18,6 +18,7 @@ import { registerDisableCommand, registerEnableCommand } from "./commands/Enable
 import { registerExportCommand, registerExportPromptCommand } from "./commands/ExportCommand.js";
 import { registerHealFolderCommand } from "./commands/HealFolderCommand.js";
 import { getHelpGroup } from "./commands/HelpGroups.js";
+import { registerMcpCommand } from "./commands/McpCommand.js";
 import { registerMigrateCommand } from "./commands/MigrateCommand.js";
 import { registerRecallCommand } from "./commands/RecallCommand.js";
 import { registerSearchCommand } from "./commands/SearchCommand.js";
@@ -157,6 +158,7 @@ const MEMORY_COMMAND_NAMES = new Set([
 	"auth",
 	"heal-folder",
 	"sync-memory-bank",
+	"mcp",
 ]);
 
 const MEMORY_DESCRIPTION = `Auto-documents your AI-assisted development. Lightweight git and AI-agent
@@ -331,6 +333,7 @@ export async function main(args?: ReadonlyArray<string>): Promise<void> {
 	registerExportCommand(program);
 	registerAuthCommands(program);
 	registerSyncCommand(program);
+	registerMcpCommand(program);
 
 	// Plugin-provided command surface. `loadPlugins` discovers and registers
 	// installed plugins (returning the set of IDs it loaded); whatever's left

--- a/cli/src/commands/CompileCommand.test.ts
+++ b/cli/src/commands/CompileCommand.test.ts
@@ -9,6 +9,7 @@ vi.mock("../core/StorageFactory.js", () => ({
 }));
 vi.mock("../core/SummaryStore.js", () => ({
 	setActiveStorage: vi.fn(),
+	getActiveStorage: vi.fn(() => null),
 }));
 vi.mock("../core/IngestPipeline.js", () => ({
 	drainIngest: vi.fn(async () => ({ batches: 1, ingested: 3, outcome: "OK", topicFailures: [] })),
@@ -62,7 +63,8 @@ import { appendCredentialMissingRun } from "../core/IngestRunStore.js";
 import { compileAllRepos } from "../core/MultiRepoCompile.js";
 import { saveProcessedSet } from "../core/ProcessedSourceStore.js";
 import { loadConfig } from "../core/SessionTracker.js";
-import { saveTopicIndex } from "../core/TopicIndexStore.js";
+import { readTopicIndex, saveTopicIndex } from "../core/TopicIndexStore.js";
+import { purgeTopicPagesExcept } from "../core/TopicPageStore.js";
 import { renderTopicKBWiki } from "../core/TopicWikiRenderer.js";
 import { withVaultWriteLock } from "../sync/VaultWriteLock.js";
 import { registerCompileCommand } from "./CompileCommand.js";
@@ -239,6 +241,23 @@ describe("registerCompileCommand", () => {
 		expect(process.exitCode).toBe(1);
 		expect(mockDrainIngest).not.toHaveBeenCalled();
 		expect(vi.mocked(appendCredentialMissingRun)).toHaveBeenCalledWith("/repo", "manual");
+	});
+
+	it("--cwd: passes the index's stable slugs to the topic-page purge", async () => {
+		// The slug-mapping callback in the `purgeTopicPagesExcept(index.topics.map(...))`
+		// call only executes when the index is non-empty. The default mock returns an
+		// empty `topics` array, leaving that arrow uncovered; a populated index exercises
+		// it and pins the convergence contract (keep exactly the indexed slugs).
+		vi.mocked(readTopicIndex).mockResolvedValueOnce({
+			schemaVersion: 1,
+			topics: [{ stableSlug: "auth-flow" }, { stableSlug: "storage-layer" }],
+		} as never);
+		await runCompile(["--cwd", "/repo"]);
+		expect(vi.mocked(purgeTopicPagesExcept)).toHaveBeenCalledWith(
+			["auth-flow", "storage-layer"],
+			"/repo",
+			expect.anything(),
+		);
 	});
 
 	it("--cwd: prints the outcome code and held topics in the summary", async () => {

--- a/cli/src/commands/CompileCommand.ts
+++ b/cli/src/commands/CompileCommand.ts
@@ -17,13 +17,15 @@ import { compileAllRepos } from "../core/MultiRepoCompile.js";
 import { emptyProcessedSet, saveProcessedSet } from "../core/ProcessedSourceStore.js";
 import { loadConfig } from "../core/SessionTracker.js";
 import { createStorage } from "../core/StorageFactory.js";
-import { setActiveStorage } from "../core/SummaryStore.js";
+import { getActiveStorage, setActiveStorage } from "../core/SummaryStore.js";
 import { emptyTopicIndex, readTopicIndex, saveTopicIndex } from "../core/TopicIndexStore.js";
 import { purgeTopicPagesExcept } from "../core/TopicPageStore.js";
 import { renderTopicKBWiki } from "../core/TopicWikiRenderer.js";
-import { setLogDir } from "../Logger.js";
+import { createLogger, setLogDir } from "../Logger.js";
 import { deriveMemoryBankRoot } from "../sync/SyncBootstrap.js";
 import { DEFAULT_VAULT_WRITE_WAIT_MS, withVaultWriteLock } from "../sync/VaultWriteLock.js";
+
+const log = createLogger("CompileCommand");
 
 export type CompileOptions = { rebuild?: boolean; cwd?: string };
 
@@ -38,51 +40,73 @@ async function compileSingleRepo(cwd: string, rebuild: boolean): Promise<void> {
 		return;
 	}
 	const storage = await createStorage(cwd, cwd);
+	// Capture + restore the process-global override so a single-repo compile
+	// doesn't leak it into a long-lived host (mirrors compileAllRepos). Benign in
+	// the one-shot CLI, but executeCompile is an exported entry point.
+	const previousStorage = getActiveStorage();
 	setActiveStorage(storage);
+	try {
+		// Serialise on the same `vault-write.lock` the background QueueWorker holds for
+		// its ingest drain. Without it, a manual compile racing a post-commit worker
+		// lost-updates `topics/index.json` and the `drainIngest → readTopicIndex →
+		// purgeTopicPagesExcept` window can delete a topic page the worker just wrote.
+		// Wait mode (not fail-fast): the user explicitly asked to compile, so yield to
+		// a busy worker/sync rather than skip outright.
+		const vaultRoot = deriveMemoryBankRoot(config.localFolder);
+		const result = await withVaultWriteLock(vaultRoot, { wait: DEFAULT_VAULT_WRITE_WAIT_MS }, async () => {
+			if (rebuild) {
+				// Reset the watermark + index only. An empty index makes route treat every
+				// topic as new, so reconcile gets current=null (clean rebuild).
+				console.log("\n  Rebuilding knowledge base from scratch...");
+				await saveProcessedSet(emptyProcessedSet(), cwd);
+				await saveTopicIndex(emptyTopicIndex(), cwd);
+			} else {
+				console.log("\n  Ingesting pending sources into the knowledge base...");
+			}
 
-	// Serialise on the same `vault-write.lock` the background QueueWorker holds for
-	// its ingest drain. Without it, a manual compile racing a post-commit worker
-	// lost-updates `topics/index.json` and the `drainIngest → readTopicIndex →
-	// purgeTopicPagesExcept` window can delete a topic page the worker just wrote.
-	// Wait mode (not fail-fast): the user explicitly asked to compile, so yield to
-	// a busy worker/sync rather than skip outright.
-	const vaultRoot = deriveMemoryBankRoot(config.localFolder);
-	const result = await withVaultWriteLock(vaultRoot, { wait: DEFAULT_VAULT_WRITE_WAIT_MS }, async () => {
-		if (rebuild) {
-			// Reset the watermark + index only. An empty index makes route treat every
-			// topic as new, so reconcile gets current=null (clean rebuild).
-			console.log("\n  Rebuilding knowledge base from scratch...");
-			await saveProcessedSet(emptyProcessedSet(), cwd);
-			await saveTopicIndex(emptyTopicIndex(), cwd);
-		} else {
-			console.log("\n  Ingesting pending sources into the knowledge base...");
+			const drainResult = await drainIngest(cwd, config, { triggeredBy: "manual" });
+			// Converge the canonical layer to the index: drop topic pages no longer
+			// referenced (e.g. left behind when --rebuild replays into fewer topics).
+			const index = await readTopicIndex(cwd, storage);
+			await purgeTopicPagesExcept(
+				index.topics.map((t) => t.stableSlug),
+				cwd,
+				storage,
+			);
+			await renderTopicKBWiki(cwd, storage);
+			// Keep the local search index warm so the next query (MCP server / `jolli
+			// search`) rarely pays a lazy rebuild. Disposable cache: a failure here must
+			// never fail the compile. SearchIndex (→ @orama/*) is lazy-imported INSIDE
+			// this try so a load failure is contained (mirrors compileAllRepos).
+			try {
+				const { SearchIndex } = await import("../core/SearchIndex.js");
+				await SearchIndex.rebuild(cwd, storage);
+			} catch (idxErr) {
+				log.warn(
+					"Search index update failed (non-fatal): %s",
+					idxErr instanceof Error ? idxErr.message : String(idxErr),
+				);
+			}
+			return drainResult;
+		});
+
+		if (!result.ran) {
+			console.error(
+				"\n  Error: another vault writer (a background worker or sync) is busy — try again shortly.\n",
+			);
+			process.exitCode = 1;
+			return;
 		}
 
-		const drainResult = await drainIngest(cwd, config, { triggeredBy: "manual" });
-		// Converge the canonical layer to the index: drop topic pages no longer
-		// referenced (e.g. left behind when --rebuild replays into fewer topics).
-		const index = await readTopicIndex(cwd, storage);
-		await purgeTopicPagesExcept(
-			index.topics.map((t) => t.stableSlug),
-			cwd,
-			storage,
-		);
-		await renderTopicKBWiki(cwd, storage);
-		return drainResult;
-	});
-
-	if (!result.ran) {
-		console.error("\n  Error: another vault writer (a background worker or sync) is busy — try again shortly.\n");
-		process.exitCode = 1;
-		return;
+		const { batches, ingested, outcome, topicFailures } = result.value;
+		let summary = `\n  Done: ${ingested} source(s) folded in ${batches} batch(es). Wiki rebuilt. [${outcome}]`;
+		if (topicFailures.length > 0) {
+			summary += `\n  ${topicFailures.length} topic(s) held: ${topicFailures.map((f) => `${f.slug} (${f.code})`).join(", ")}`;
+		}
+		console.log(`${summary}\n`);
+	} finally {
+		setActiveStorage(previousStorage);
 	}
-
-	const { batches, ingested, outcome, topicFailures } = result.value;
-	let summary = `\n  Done: ${ingested} source(s) folded in ${batches} batch(es). Wiki rebuilt. [${outcome}]`;
-	if (topicFailures.length > 0) {
-		summary += `\n  ${topicFailures.length} topic(s) held: ${topicFailures.map((f) => `${f.slug} (${f.code})`).join(", ")}`;
-	}
-	console.log(`${summary}\n`);
 }
 
 /** Sweep every repo under the Memory Bank folder. */

--- a/cli/src/commands/McpCommand.test.ts
+++ b/cli/src/commands/McpCommand.test.ts
@@ -1,0 +1,52 @@
+import { Command } from "commander";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../mcp/McpServer.js", () => ({ startMcpServer: vi.fn().mockResolvedValue(undefined) }));
+vi.mock("../core/SearchIndex.js", () => ({ SearchIndex: { rebuild: vi.fn() } }));
+vi.mock("../core/StorageFactory.js", () => ({ createStorage: vi.fn().mockResolvedValue({ kind: "mock" }) }));
+vi.mock("../core/SummaryStore.js", () => ({ setActiveStorage: vi.fn() }));
+
+import { SearchIndex } from "../core/SearchIndex.js";
+import { createStorage } from "../core/StorageFactory.js";
+import { setActiveStorage } from "../core/SummaryStore.js";
+import { startMcpServer } from "../mcp/McpServer.js";
+import { registerMcpCommand } from "./McpCommand.js";
+
+describe("jolli mcp", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("starts the stdio server by default", async () => {
+		const program = new Command();
+		registerMcpCommand(program);
+		await program.parseAsync(["node", "jolli", "mcp"]);
+		expect(startMcpServer).toHaveBeenCalledTimes(1);
+	});
+
+	it("--reindex rebuilds and does not start the server", async () => {
+		vi.mocked(SearchIndex.rebuild).mockResolvedValue({ index: {} as never, docCount: 3 });
+		const program = new Command();
+		registerMcpCommand(program);
+		await program.parseAsync(["node", "jolli", "mcp", "--reindex"]);
+		expect(SearchIndex.rebuild).toHaveBeenCalledTimes(1);
+		expect(startMcpServer).not.toHaveBeenCalled();
+	});
+
+	it("--reindex establishes the configured storage before rebuilding (folder-mode users)", async () => {
+		vi.mocked(SearchIndex.rebuild).mockResolvedValue({ index: {} as never, docCount: 3 });
+		const program = new Command();
+		registerMcpCommand(program);
+		await program.parseAsync(["node", "jolli", "mcp", "--reindex"]);
+		// Without this, rebuild reads through the orphan-branch fallback and a
+		// folder-mode user reindexes from the wrong (empty) store.
+		expect(createStorage).toHaveBeenCalledTimes(1);
+		expect(setActiveStorage).toHaveBeenCalledWith({ kind: "mock" });
+		expect(vi.mocked(setActiveStorage).mock.invocationCallOrder[0]).toBeLessThan(
+			vi.mocked(SearchIndex.rebuild).mock.invocationCallOrder[0],
+		);
+		// And the SAME storage is passed to rebuild so the index file lands in the
+		// folder's kbRoot dir (matching where the MCP server reads it), not cwd.
+		expect(SearchIndex.rebuild).toHaveBeenCalledWith(expect.any(String), { kind: "mock" });
+	});
+});

--- a/cli/src/commands/McpCommand.ts
+++ b/cli/src/commands/McpCommand.ts
@@ -1,0 +1,36 @@
+/**
+ * `jolli mcp` — starts the stdio MCP server for AI agents (JOLLI-1226 P0).
+ * `jolli mcp --reindex` forces a full rebuild of the local search index and exits.
+ */
+
+import type { Command } from "commander";
+import { SearchIndex } from "../core/SearchIndex.js";
+import { createStorage } from "../core/StorageFactory.js";
+import { setActiveStorage } from "../core/SummaryStore.js";
+import { startMcpServer } from "../mcp/McpServer.js";
+
+export function registerMcpCommand(program: Command): void {
+	program
+		.command("mcp")
+		.description("Start the JolliMemory MCP server (stdio) for AI agents")
+		.option("--reindex", "Rebuild the local search index from source and exit")
+		.action(async (options: { reindex?: boolean }) => {
+			const cwd = process.cwd();
+			if (options.reindex) {
+				// Establish the configured backend before reading sources — mirrors
+				// startMcpServer. Without it, rebuild's reads fall through to the
+				// orphan-branch fallback, so a folder-mode user would reindex from the
+				// wrong (possibly empty) store and see a misleading "0 document(s)".
+				const storage = await createStorage(cwd, cwd);
+				setActiveStorage(storage);
+				// Pass `storage` so the index file lands in the SAME dir the MCP server
+				// reads from (`<kbRoot>/.jolli/jollimemory/` in folder/dual-write mode).
+				// Without it resolveIndexDir falls back to cwd and `--reindex` writes to
+				// the checkout instead of the Memory Bank folder.
+				const { docCount } = await SearchIndex.rebuild(cwd, storage);
+				process.stdout.write(`Reindexed ${docCount} document(s).\n`);
+				return;
+			}
+			await startMcpServer(cwd);
+		});
+}

--- a/cli/src/core/ContextCompiler.test.ts
+++ b/cli/src/core/ContextCompiler.test.ts
@@ -639,6 +639,107 @@ describe("renderContextMarkdown", () => {
 		expect(md).toContain("### Inbox [global: Inbox.md]");
 	});
 
+	it("a large user-knowledge file is truncated to its own budget, not allowed to evict the commit history", () => {
+		const ctx = {
+			branch: "feature/test",
+			period: { start: "2026-03-28T10:00:00.000Z", end: "2026-03-28T10:00:00.000Z" },
+			commitCount: 1,
+			totalFilesChanged: 1,
+			totalInsertions: 10,
+			totalDeletions: 0,
+			summaries: [makeSummary()],
+			plans: [],
+			notes: [],
+			keyDecisions: [],
+			userKnowledgeTopics: [
+				{ title: "Huge", content: "U ".repeat(6000), source: "huge.md", scope: "global" as const },
+			],
+			stats: {
+				topicCount: 1,
+				planCount: 0,
+				noteCount: 0,
+				decisionCount: 0,
+				topicTokens: 10,
+				planTokens: 0,
+				noteTokens: 0,
+				decisionTokens: 0,
+				transcriptTokens: 0,
+				totalTokens: 10,
+			},
+		};
+
+		// Before the fix the user file lived in the never-truncated decisions
+		// bucket, blew past the budget, and the function returned early WITHOUT
+		// the commit history. The commit history must survive.
+		const md = renderContextMarkdown(ctx, 500);
+		expect(md).toContain("## Commit History (chronological)");
+		expect(md).toContain("[... truncated due to token budget]");
+	});
+
+	it("a small user-knowledge file does not shrink the commit-summary budget (reclaims its unused share)", () => {
+		// Large commit body so summary truncation is observable, no plans/notes/
+		// decisions. The user-knowledge bucket is capped at 50% of the body, but a
+		// SMALL file must consume only what it needs — the unused remainder has to
+		// stay available to summaries, not be stranded (the old 50/50 split clipped
+		// summaries even when user knowledge barely used its half).
+		const big = "Implemented feature X with a new module. ".repeat(120);
+		const baseCtx = {
+			branch: "feature/test",
+			period: { start: "2026-03-28T10:00:00.000Z", end: "2026-03-28T10:00:00.000Z" },
+			commitCount: 1,
+			totalFilesChanged: 1,
+			totalInsertions: 10,
+			totalDeletions: 0,
+			summaries: [
+				makeSummary({
+					topics: [
+						{
+							title: "Feature X",
+							trigger: "Need feature X",
+							response: big,
+							decisions: "",
+							category: "feature",
+							importance: "major",
+							filesAffected: [],
+						},
+					],
+				}),
+			],
+			plans: [],
+			notes: [],
+			keyDecisions: [],
+			stats: {
+				topicCount: 1,
+				planCount: 0,
+				noteCount: 0,
+				decisionCount: 0,
+				topicTokens: 100,
+				planTokens: 0,
+				noteTokens: 0,
+				decisionTokens: 0,
+				transcriptTokens: 0,
+				totalTokens: 100,
+			},
+		};
+
+		// A budget that fits the whole context (no user knowledge) untruncated.
+		const budget = estimateTokens(renderContextMarkdown(baseCtx, 1_000_000));
+		expect(renderContextMarkdown(baseCtx, budget)).not.toContain("[... truncated due to token budget]");
+
+		// Add a tiny Memory Bank file and give the budget just its extra tokens.
+		const md = renderContextMarkdown(
+			{
+				...baseCtx,
+				userKnowledgeTopics: [
+					{ title: "Tip", content: "small note", source: "t.md", scope: "global" as const },
+				],
+			},
+			budget + 50,
+		);
+		expect(md).toContain("small note");
+		expect(md).not.toContain("[... truncated due to token budget]");
+	});
+
 	it("should omit decisions section when no decisions", () => {
 		const ctx = {
 			branch: "feature/test",
@@ -1327,6 +1428,42 @@ describe("buildRecallPayload", () => {
 		);
 		expect(payload.plans[0]).toEqual({ slug: "p1", title: "P1", content: "plan body" });
 		expect(payload.notes[0]).toEqual({ id: "n1", title: "N1", content: "note body" });
+	});
+
+	it("ships userKnowledge top-level so the JSON/MCP recall path sees Memory Bank files (was dropped)", () => {
+		const payload = buildRecallPayload(
+			makeCtx({
+				userKnowledgeTopics: [
+					{ title: "Auth", content: "Use PKCE", source: "auth.md", scope: "branch" as const },
+				],
+			}),
+			100_000,
+		);
+		expect(payload.userKnowledge).toEqual([
+			{ title: "Auth", source: "auth.md", scope: "branch", content: "Use PKCE" },
+		]);
+	});
+
+	it("omits userKnowledge when the context has none", () => {
+		expect(buildRecallPayload(makeCtx(), 100_000).userKnowledge).toBeUndefined();
+	});
+
+	it("drops userKnowledge content under budget pressure before evicting commits (keeps title+source)", () => {
+		const payload = buildRecallPayload(
+			makeCtx({
+				userKnowledgeTopics: [
+					{ title: "Big", content: "U".repeat(8000), source: "big.md", scope: "global" as const },
+				],
+			}),
+			1000,
+		);
+		expect(payload.truncated).toBe(true);
+		// A large user file must not evict the commit (with its decisions) ...
+		expect(payload.commits).toHaveLength(1);
+		expect(payload.commits[0].topics[0].decisions).toBeDefined();
+		// ... its body is dropped first, leaving title+source as a citation anchor.
+		expect(payload.userKnowledge).toBeDefined();
+		expect(payload.userKnowledge?.[0]).toEqual({ title: "Big", source: "big.md", scope: "global" });
 	});
 
 	it("under tight budget drops topic.response first (preserves trigger and decisions)", () => {

--- a/cli/src/core/ContextCompiler.ts
+++ b/cli/src/core/ContextCompiler.ts
@@ -110,6 +110,20 @@ export interface RecallPayloadNote {
 }
 
 /**
+ * User-written Memory Bank file shipped in {@link RecallPayload}.
+ *
+ * `content` may be omitted when budget enforcement strips bodies (same
+ * discipline as plans/notes); `title` + `source` remain as a citation anchor.
+ */
+export interface RecallPayloadUserKnowledge {
+	readonly title: string;
+	/** Path relative to the Memory Bank parent (`localFolder`). */
+	readonly source: string;
+	readonly scope: "global" | "repo" | "branch";
+	readonly content?: string;
+}
+
+/**
  * Structured output of `jolli recall --format json`.
  *
  * Replaces the prior `ContextOutput` (which shipped a single pre-rendered
@@ -131,6 +145,13 @@ export interface RecallPayload {
 	readonly plans: ReadonlyArray<RecallPayloadPlan>;
 	/** Branch-scoped, deduplicated note bodies. Id is the canonical key. */
 	readonly notes: ReadonlyArray<RecallPayloadNote>;
+	/**
+	 * User-written Memory Bank files surfaced for this branch (spec 108
+	 * Correction 1). Present in the structured payload so the MCP `recall`
+	 * tool / `--format json` consumer sees the same knowledge the `--full`
+	 * markdown renderer shows. Omitted when there is no user knowledge.
+	 */
+	readonly userKnowledge?: ReadonlyArray<RecallPayloadUserKnowledge>;
 	readonly stats: ContextStats;
 	readonly estimatedTokens: number;
 	/** Set when budget enforcement removed at least one field (or commit). */
@@ -613,7 +634,8 @@ function deriveUserKnowledgeTitle(path: string, content: string): string {
  *   2. drop `topic.trigger`
  *   3. drop `plans[].content` (keep slug + title as a citation anchor)
  *   4. drop `notes[].content`
- *   5. drop the entire oldest commit from `commits[]` (with its decisions)
+ *   5. drop `userKnowledge[].content` (keep title + source as an anchor)
+ *   6. drop the entire oldest commit from `commits[]` (with its decisions)
  *
  * Type contract: every {@link SearchHit} that survives in `commits[]` carries
  * `decisions` on every topic and full identity fields. When the budget is so
@@ -626,6 +648,12 @@ export function buildRecallPayload(ctx: CompiledContext, tokenBudget?: number): 
 
 	let plans: RecallPayloadPlan[] = ctx.plans.map((p) => ({ slug: p.slug, title: p.title, content: p.content }));
 	let notes: RecallPayloadNote[] = ctx.notes.map((n) => ({ id: n.id, title: n.title, content: n.content }));
+	let userKnowledge: RecallPayloadUserKnowledge[] = (ctx.userKnowledgeTopics ?? []).map((u) => ({
+		title: u.title,
+		source: u.source,
+		scope: u.scope,
+		content: u.content,
+	}));
 
 	// Resolved-key sets — a stub on a commit is considered "live" only if its
 	// slug/id has a matching entry at the payload top level. This guards the
@@ -709,7 +737,7 @@ export function buildRecallPayload(ctx: CompiledContext, tokenBudget?: number): 
 		stats: ctx.stats,
 	};
 
-	const measure = (): number => estimateTokens(JSON.stringify({ ...envelope, commits, plans, notes }));
+	const measure = (): number => estimateTokens(JSON.stringify({ ...envelope, commits, plans, notes, userKnowledge }));
 
 	// Step 1: drop topic.response from oldest commits.
 	// Skip when pre-pass 2 already stripped response from every commit —
@@ -755,7 +783,19 @@ export function buildRecallPayload(ctx: CompiledContext, tokenBudget?: number): 
 		});
 	}
 
-	// Step 5: drop the oldest commit wholesale (with its decisions) until we fit.
+	// Step 5: drop userKnowledge[].content (title + source remain as citation
+	// anchors). User knowledge competes with summaries for budget but its body
+	// is dropped before whole commits, so a large user-written file can never
+	// evict commit decisions — the regression this guards against.
+	if (measure() > budget && userKnowledge.some((u) => u.content !== undefined)) {
+		userKnowledge = userKnowledge.map((u) => {
+			if (u.content === undefined) return u;
+			truncated = true;
+			return { title: u.title, source: u.source, scope: u.scope };
+		});
+	}
+
+	// Step 6: drop the oldest commit wholesale (with its decisions) until we fit.
 	// Always keep at least one commit — otherwise `commits=[]` would
 	// ambiguously mean "no records found" OR "budget evicted everything",
 	// forcing the skill template to teach the LLM a 3-way state machine
@@ -780,6 +820,7 @@ export function buildRecallPayload(ctx: CompiledContext, tokenBudget?: number): 
 		commits,
 		plans,
 		notes,
+		...(userKnowledge.length > 0 && { userKnowledge }),
 		stats: ctx.stats,
 		estimatedTokens,
 		...(truncated && { truncated: true }),
@@ -817,9 +858,10 @@ function filterStubs(hit: SearchHit, resolvedPlanSlugs: Set<string>, resolvedNot
 /**
  * Renders a compiled context into Markdown, applying token budget truncation.
  *
- * Priority (high to low): decisions → plans → summaries → transcripts.
- * When over budget: drop transcripts → fold older topics → truncate plans.
- * Decisions are never truncated.
+ * Only `decisions` are never truncated. Everything else — user knowledge,
+ * plans, notes, summaries — shares the remaining budget and is truncated to
+ * fit, so no single oversized section (e.g. a large user-written Memory Bank
+ * file) can evict the others.
  */
 export function renderContextMarkdown(ctx: CompiledContext, tokenBudget?: number): string {
 	const budget = tokenBudget ?? DEFAULT_TOKEN_BUDGET;
@@ -850,18 +892,22 @@ export function renderContextMarkdown(ctx: CompiledContext, tokenBudget?: number
 		lines.push("");
 	}
 
-	// User Memory Bank knowledge (spec 108 Correction 1)
+	// User Memory Bank knowledge (spec 108 Correction 1).
+	// Rendered into its own section (NOT the never-truncated decisions bucket)
+	// so a large user-written file is bounded by its own budget share below and
+	// can't evict plans/notes/summaries — the regression this guards against.
+	const userKnowledgeSection: string[] = [];
 	if (ctx.userKnowledgeTopics && ctx.userKnowledgeTopics.length > 0) {
-		lines.push("## Memory Bank Knowledge");
-		lines.push("");
+		userKnowledgeSection.push("## Memory Bank Knowledge");
+		userKnowledgeSection.push("");
 		for (const it of ctx.userKnowledgeTopics) {
-			lines.push(`### ${it.title} [${it.scope}: ${it.source}]`);
-			lines.push("");
-			lines.push(it.content);
-			lines.push("");
+			userKnowledgeSection.push(`### ${it.title} [${it.scope}: ${it.source}]`);
+			userKnowledgeSection.push("");
+			userKnowledgeSection.push(it.content);
+			userKnowledgeSection.push("");
 		}
-		lines.push("---");
-		lines.push("");
+		userKnowledgeSection.push("---");
+		userKnowledgeSection.push("");
 	}
 
 	// Plans section
@@ -905,8 +951,9 @@ export function renderContextMarkdown(ctx: CompiledContext, tokenBudget?: number
 		summarySection.push("");
 	}
 
-	// Apply budget: decisions + plans + notes + summaries
+	// Apply budget: decisions (never truncated) + userKnowledge + plans + notes + summaries
 	const decisionsText = lines.join("\n");
+	const userKnowledgeText = userKnowledgeSection.join("\n");
 	const plansText = planSection.join("\n");
 	const notesText = noteSection.join("\n");
 	const summariesText = summarySection.join("\n");
@@ -914,16 +961,31 @@ export function renderContextMarkdown(ctx: CompiledContext, tokenBudget?: number
 	const currentTokens = estimateTokens(decisionsText);
 	const remaining = budget - currentTokens;
 
-	// When decisions alone exceed the budget, drop plans, notes, and summaries entirely
+	// When decisions alone exceed the budget, drop everything else entirely
 	if (remaining <= 0) {
 		const footer = `\n*Generated by Jolli Memory · ${ctx.commitCount} commits · ~${currentTokens} tokens (decisions exceeded budget)*`;
 		return decisionsText + footer;
 	}
 
-	// Budget allocation: plans+notes share 25%, summaries get the rest
+	// Budget allocation across the truncatable region (everything but decisions):
+	//   plans+notes share 25% of `remaining`; the rest ("body") is split between
+	//   user knowledge and commit summaries. User knowledge is CAPPED at half the
+	//   body so a large user-written file can't evict summaries — but it only ever
+	//   consumes what it actually needs, so a small file leaves the unused share to
+	//   summaries instead of stranding it. Empty/small buckets return their share.
 	const hasPlansOrNotes = ctx.plans.length > 0 || ctx.notes.length > 0;
 	const plansNotesBudget = hasPlansOrNotes ? Math.floor(remaining * 0.25) : 0;
-	const summaryBudget = remaining - plansNotesBudget;
+	const bodyBudget = remaining - plansNotesBudget;
+	const hasUserKnowledge = userKnowledgeText.length > 0;
+	const userKnowledgeCap = hasUserKnowledge ? Math.floor(bodyBudget * 0.5) : 0;
+	const userKnowledgeTokens = estimateTokens(userKnowledgeText);
+	const userKnowledgeBudget = Math.min(userKnowledgeTokens, userKnowledgeCap);
+	const summaryBudget = bodyBudget - userKnowledgeBudget;
+
+	let finalUserKnowledge = userKnowledgeText;
+	if (userKnowledgeTokens > userKnowledgeBudget) {
+		finalUserKnowledge = truncateToTokenBudget(userKnowledgeText, userKnowledgeBudget);
+	}
 
 	let finalPlans = plansText;
 	let finalNotes = notesText;
@@ -940,7 +1002,7 @@ export function renderContextMarkdown(ctx: CompiledContext, tokenBudget?: number
 		finalSummaries = truncateToTokenBudget(summariesText, summaryBudget);
 	}
 
-	const allContent = decisionsText + finalPlans + finalNotes + finalSummaries;
+	const allContent = decisionsText + finalUserKnowledge + finalPlans + finalNotes + finalSummaries;
 	const footer = `\n*Generated by Jolli Memory · ${ctx.commitCount} commits · ~${estimateTokens(allContent)} tokens*`;
 
 	return allContent + footer;

--- a/cli/src/core/DualWriteStorage.ts
+++ b/cli/src/core/DualWriteStorage.ts
@@ -19,6 +19,11 @@ export class DualWriteStorage implements StorageProvider {
 		private readonly shadow: StorageProvider,
 	) {}
 
+	/** Folder root for the disposable search index — the shadow (folder) backend's. */
+	get kbRoot(): string | undefined {
+		return this.shadow.kbRoot;
+	}
+
 	async readFile(path: string): Promise<string | null> {
 		return this.primary.readFile(path);
 	}
@@ -32,14 +37,6 @@ export class DualWriteStorage implements StorageProvider {
 		const result = new Map<string, string | null>();
 		for (const path of paths) result.set(path, await this.primary.readFile(path));
 		return result;
-	}
-
-	async statFile(path: string): Promise<{ mtimeMs: number } | null> {
-		// spec 110 — forward stat to primary (matches readFile routing).
-		// Optional method: undefined on primary → undefined drift here (e.g.
-		// orphan primary lacks real mtime).
-		if (!this.primary.statFile) return null;
-		return this.primary.statFile(path);
 	}
 
 	// Primary writes first because it's the source of truth (orphan branch).

--- a/cli/src/core/FolderStorage.test.ts
+++ b/cli/src/core/FolderStorage.test.ts
@@ -2357,29 +2357,6 @@ describe("FolderStorage", () => {
 		});
 	});
 
-	describe("statFile", () => {
-		beforeEach(async () => {
-			await storage.ensure();
-		});
-
-		it("returns mtimeMs for an existing hidden file", async () => {
-			await storage.writeFiles([{ path: "index.json", content: '{"version":3}' }], "seed");
-			const st = await storage.statFile("index.json");
-			expect(st).not.toBeNull();
-			expect(typeof st?.mtimeMs).toBe("number");
-			expect(st?.mtimeMs).toBeGreaterThan(0);
-		});
-
-		it("returns null for a nonexistent file", async () => {
-			expect(await storage.statFile("ghost.json")).toBeNull();
-		});
-
-		it("returns null when the path is a directory (not a file)", async () => {
-			mkdirSync(join(rootPath, ".jolli", "summaries"), { recursive: true });
-			expect(await storage.statFile("summaries")).toBeNull();
-		});
-	});
-
 	describe("markDirty suppressed-write path", () => {
 		beforeEach(async () => {
 			await storage.ensure();

--- a/cli/src/core/FolderStorage.ts
+++ b/cli/src/core/FolderStorage.ts
@@ -12,7 +12,7 @@
  * 4. Updates manifest to track the AI-generated file
  */
 
-import { existsSync, mkdirSync, readdirSync, readFileSync, statSync, unlinkSync } from "node:fs";
+import { existsSync, mkdirSync, readdirSync, readFileSync, unlinkSync } from "node:fs";
 import { rmdir } from "node:fs/promises";
 import { dirname, join, relative } from "node:path";
 import { createLogger, errMsg } from "../Logger.js";
@@ -73,17 +73,6 @@ export class FolderStorage implements StorageProvider {
 		if (!existsSync(file)) return null;
 		try {
 			return readFileSync(file, "utf-8");
-		} catch {
-			return null;
-		}
-	}
-
-	async statFile(path: string): Promise<{ mtimeMs: number } | null> {
-		const file = join(this.rootPath, ".jolli", path);
-		try {
-			const st = statSync(file);
-			if (!st.isFile()) return null;
-			return { mtimeMs: st.mtimeMs };
 		} catch {
 			return null;
 		}

--- a/cli/src/core/IngestPipeline.test.ts
+++ b/cli/src/core/IngestPipeline.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("./LlmClient.js", () => ({ callLlm: vi.fn(), STREAMING_THRESHOLD_TOKENS: 16_384 }));
+vi.mock("./LlmClient.js", () => ({ callLlm: vi.fn() }));
 vi.mock("./SourceTimeline.js", async (orig) => ({
 	...(await orig<typeof import("./SourceTimeline.js")>()),
 	listPendingSources: vi.fn(),
@@ -23,7 +23,7 @@ vi.mock("./IngestRunStore.js", () => ({ appendIngestRun: vi.fn() }));
 
 import { drainIngest, ingestPendingBatch } from "./IngestPipeline.js";
 import { appendIngestRun } from "./IngestRunStore.js";
-import { callLlm, STREAMING_THRESHOLD_TOKENS } from "./LlmClient.js";
+import { callLlm } from "./LlmClient.js";
 import { emptyProcessedSet, readProcessedSet, saveProcessedSet } from "./ProcessedSourceStore.js";
 import { loadSourceContent } from "./SourceContent.js";
 import { listPendingSources } from "./SourceTimeline.js";
@@ -75,16 +75,16 @@ describe("ingestPendingBatch", () => {
 		expect(vi.mocked(callLlm)).not.toHaveBeenCalled();
 	});
 
-	it("issues the route call with maxTokens above the streaming threshold (forces the streaming path)", async () => {
-		// The route call must take LlmClient's streaming path; if its maxTokens
-		// ever drifted to <= the threshold it would silently fall onto the 180s
-		// direct-call timeout. This pins the invariant against either constant moving.
+	it("issues the route call with forceStreaming so it takes LlmClient's streaming path", async () => {
+		// The route call can run long; it must take the streaming path (no fixed
+		// 180s direct-call cap) via an explicit flag, not by padding maxTokens
+		// above a threshold that could later be retuned out from under it.
 		vi.mocked(listPendingSources).mockResolvedValue([s("c0", "2026-01-01T00:00:00Z")]);
 		vi.mocked(callLlm).mockResolvedValueOnce(llmText("route", JSON.stringify({ updates: [], newTopics: [] })));
 		await ingestPendingBatch("/tmp/x", cfg);
 		const routeCall = vi.mocked(callLlm).mock.calls[0]?.[0];
 		expect(routeCall?.action).toBe("route");
-		expect(routeCall?.maxTokens).toBeGreaterThan(STREAMING_THRESHOLD_TOKENS);
+		expect(routeCall?.forceStreaming).toBe(true);
 	});
 
 	it("feeds reconcile source bodies in chronological order (old -> new)", async () => {

--- a/cli/src/core/IngestPipeline.ts
+++ b/cli/src/core/IngestPipeline.ts
@@ -10,7 +10,7 @@ import type { IngestOperation, LlmConfig } from "../Types.js";
 import { mapWithConcurrency } from "./Concurrency.js";
 import { INGEST_CODES, type IngestCode } from "./IngestErrors.js";
 import { appendIngestRun } from "./IngestRunStore.js";
-import { callLlm, STREAMING_THRESHOLD_TOKENS } from "./LlmClient.js";
+import { callLlm } from "./LlmClient.js";
 import { addProcessed, readProcessedSet, saveProcessedSet } from "./ProcessedSourceStore.js";
 import { createReadStorage } from "./ReadStorageResolver.js";
 import { parseReconciledPage } from "./ReconciledPage.js";
@@ -26,14 +26,12 @@ import { readTopicPage, saveTopicPage } from "./TopicPageStore.js";
 const log = createLogger("IngestPipeline");
 
 const DEFAULT_BATCH_SIZE = 50;
-// Sits just above the streaming threshold *on purpose* so the route call always
-// takes LlmClient's streaming path. That path has no per-call AbortSignal (it may
-// legitimately run long), so it relies on the SDK's own ~10-min ceiling rather
-// than the 180s direct-call timeout. Deriving it from the shared constant keeps
-// that intent intact: if the threshold ever rises past this, the route call would
-// silently fall back onto the 180s path and could clip a large response. The +116
-// is an arbitrary margin — any positive offset preserves the "always streams" rule.
-const ROUTE_MAX_TOKENS = STREAMING_THRESHOLD_TOKENS + 116;
+// The route call can run long, so it takes LlmClient's streaming path (no fixed
+// 180s direct-call cap, just the idle + wall-clock watchdogs). We request it
+// explicitly via `forceStreaming` rather than coercing it by padding maxTokens
+// above the streaming threshold — an explicit flag can't be silently undone by
+// retuning the threshold or this token count.
+const ROUTE_MAX_TOKENS = 16_384;
 const RECONCILE_MAX_TOKENS = 64_000;
 const RECONCILE_CONCURRENCY = 4; // fan out reconcile LLM calls; writes stay serial
 
@@ -90,6 +88,7 @@ export async function ingestPendingBatch(cwd: string, config: LlmConfig, opts?: 
 		params: { topicIndex: formatIndexForRoute(index), sources: sourcesBlock },
 		model: resolveModelId(config.model),
 		maxTokens: ROUTE_MAX_TOKENS,
+		forceStreaming: true,
 		apiKey: config.apiKey,
 		jolliApiKey: config.jolliApiKey,
 	});

--- a/cli/src/core/LlmClient.test.ts
+++ b/cli/src/core/LlmClient.test.ts
@@ -8,6 +8,7 @@ import {
 	PROXY_FETCH_TIMEOUT_MS,
 	resolveLlmCredentialSource,
 	STREAM_IDLE_TIMEOUT_MS,
+	STREAM_MAX_WALL_CLOCK_MS,
 } from "./LlmClient.js";
 
 const { mockCreate, mockStream, mockLogInfo, mockLogWarn, mockLogError } = vi.hoisted(() => ({
@@ -359,6 +360,22 @@ describe("LlmClient", () => {
 			expect(mockStream).not.toHaveBeenCalled();
 		});
 
+		it("uses streaming when forceStreaming is set, even below the token threshold", async () => {
+			// The ingest route call sets forceStreaming explicitly instead of padding
+			// maxTokens above the threshold to coerce the streaming path.
+			await callLlm({
+				action: "translate",
+				params: { content: "x" },
+				apiKey: "sk-ant-test",
+				model: "claude-sonnet-4-6",
+				maxTokens: 8192,
+				forceStreaming: true,
+			});
+
+			expect(mockStream).toHaveBeenCalledTimes(1);
+			expect(mockCreate).not.toHaveBeenCalled();
+		});
+
 		it("aborts a streaming call when no stream events arrive within the idle window", async () => {
 			vi.useFakeTimers();
 			try {
@@ -390,6 +407,49 @@ describe("LlmClient", () => {
 				await vi.advanceTimersByTimeAsync(STREAM_IDLE_TIMEOUT_MS + 10);
 
 				expect(abort).toHaveBeenCalledTimes(1);
+				const err = await settled;
+				expect(String(err)).toContain("aborted");
+			} finally {
+				vi.useRealTimers();
+			}
+		});
+
+		it("aborts a streaming call at the wall-clock cap even while stream events keep arriving", async () => {
+			vi.useFakeTimers();
+			try {
+				let rejectFinal: (err: Error) => void = () => {};
+				const finalMessage = vi.fn(
+					() =>
+						new Promise((_resolve, reject) => {
+							rejectFinal = reject;
+						}),
+				);
+				const abort = vi.fn(() => rejectFinal(new Error("Request was aborted.")));
+				let onStreamEvent: (() => void) | undefined;
+				const on = vi.fn((event: string, cb: () => void) => {
+					if (event === "streamEvent") onStreamEvent = cb;
+				});
+				mockStream.mockReturnValue({ finalMessage, on, abort });
+
+				const promise = callLlm({
+					action: "reconcile",
+					params: { topicTitle: "Auth", currentPage: "", sources: "src" },
+					apiKey: "sk-ant-test",
+					model: "claude-sonnet-4-6",
+					maxTokens: 64_000,
+				});
+				const settled = promise.catch((e: unknown) => e);
+
+				// A stream that pings forever keeps resetting the idle watchdog. Each
+				// step is below the idle window so the idle watchdog never fires; the
+				// independent wall-clock cap must still abort once it elapses.
+				const step = STREAM_IDLE_TIMEOUT_MS - 20_000;
+				for (let elapsed = 0; elapsed <= STREAM_MAX_WALL_CLOCK_MS; elapsed += step) {
+					await vi.advanceTimersByTimeAsync(step);
+					onStreamEvent?.();
+				}
+
+				expect(abort).toHaveBeenCalled();
 				const err = await settled;
 				expect(String(err)).toContain("aborted");
 			} finally {

--- a/cli/src/core/LlmClient.ts
+++ b/cli/src/core/LlmClient.ts
@@ -120,6 +120,20 @@ export const STREAMING_THRESHOLD_TOKENS = 16_384;
  */
 export const STREAM_IDLE_TIMEOUT_MS = 120_000;
 
+/**
+ * Absolute wall-clock cap for the streaming direct path, on TOP of the idle
+ * watchdog above. The idle watchdog alone cannot bound a stream that keeps
+ * emitting `ping` events but never completes (a server-side stall, a relay that
+ * trickles keep-alives, a pathological retry loop) — it would reset the idle
+ * timer forever and hold the QueueWorker / SyncEngine lock indefinitely. This
+ * hard cap fires regardless of activity. Sized well above the largest legitimate
+ * response (a 64K merge regenerate runs a few minutes) so it never clips valid
+ * work, while still failing in bounded time. The QueueWorker refreshes its lock
+ * every 60s, so a call running this long never loses the lock. Exported so a
+ * regression test can pin it.
+ */
+export const STREAM_MAX_WALL_CLOCK_MS = 15 * 60 * 1000;
+
 // `x-jolli-client` header value lives in `./ClientHeader.ts` so both this
 // module and `cli/src/sync/BackendClient.ts` share one source of truth.
 // Build-time `__JOLLI_CLIENT_KIND__` + `__PKG_VERSION__` resolution happens
@@ -196,6 +210,16 @@ export interface LlmCallOptions extends LlmCredentials {
 	readonly params: Record<string, string>;
 	/** Max output tokens (direct mode only, default 8192) */
 	readonly maxTokens?: number;
+	/**
+	 * Force the direct path onto `messages.stream` regardless of `maxTokens`.
+	 * Use when a call may run long enough to trip the SDK's non-streaming "10
+	 * minute" refusal even below {@link STREAMING_THRESHOLD_TOKENS} (e.g. the
+	 * ingest route call). Replaces the old trick of padding `maxTokens` just
+	 * above the threshold to coerce the streaming path — an explicit flag can't
+	 * be silently undone by retuning the threshold or the token count. No effect
+	 * in proxy mode.
+	 */
+	readonly forceStreaming?: boolean;
 	/** Optional prompt revision to pin (proxy mode only) */
 	readonly version?: number;
 }
@@ -319,7 +343,9 @@ async function callDirect(
 	// (the merge path raised this to 64k) keeps working without a per-call
 	// switch. `finalMessage()` resolves to the same `Anthropic.Message` shape
 	// `messages.create` returns, so the downstream code is unchanged.
-	const useStreaming = maxTokens > STREAMING_THRESHOLD_TOKENS;
+	// `forceStreaming` lets a caller pick streaming explicitly even below the
+	// token threshold (the ingest route call) instead of padding maxTokens.
+	const useStreaming = options.forceStreaming === true || maxTokens > STREAMING_THRESHOLD_TOKENS;
 
 	let response: Anthropic.Message;
 	try {
@@ -348,10 +374,15 @@ async function callDirect(
 			};
 			armIdleWatchdog();
 			stream.on("streamEvent", armIdleWatchdog);
+			// Absolute cap, NOT reset by stream events — bounds a stream that keeps
+			// pinging but never completes, which the idle watchdog alone can't catch.
+			const hardTimer = setTimeout(() => stream.abort(), STREAM_MAX_WALL_CLOCK_MS);
+			hardTimer.unref?.();
 			try {
 				response = await stream.finalMessage();
 			} finally {
 				clearTimeout(idleTimer);
+				clearTimeout(hardTimer);
 			}
 		} else {
 			// Hard cap on the in-flight HTTP request — see `DIRECT_FETCH_TIMEOUT_MS`.

--- a/cli/src/core/Locks.ts
+++ b/cli/src/core/Locks.ts
@@ -88,6 +88,17 @@ function gitRevParseCommonDir(cwd: string): Promise<{ stdout: string; stderr: st
 }
 
 export const WORKER_LOCK_FILE = "worker.lock";
+
+/**
+ * Cosmetic, best-effort marker the QueueWorker writes while running a phase the
+ * UI should label specially (currently only `ingest`). Lives next to
+ * `worker.lock` in `<cwd>/.jolli/jollimemory/`. It is NOT a lock and carries no
+ * mutual-exclusion role — the extension reads it only to pick a toolbar label.
+ * Its lifetime is bound to `worker.lock` on the reader side: when the lock
+ * disappears the phase is forced to null, so a stale marker left by a crashed
+ * worker cannot mislead beyond the lock's own staleness window.
+ */
+export const WORKER_PHASE_FILE = "worker-phase";
 export const ORPHAN_WRITE_LOCK_FILE = "orphan-write.lock";
 export const SYNC_LOCK_FILE = "sync.lock";
 export const PLANS_LOCK_FILE = "plans.lock";

--- a/cli/src/core/MemoryBankScanner.test.ts
+++ b/cli/src/core/MemoryBankScanner.test.ts
@@ -23,7 +23,7 @@ vi.mock("./KBPathResolver.js", () => ({
 }));
 
 import { extractRepoName, getRemoteUrl, resolveKBPath } from "./KBPathResolver.js";
-import { listAllUserKnowledgeFromRoot, listUserKnowledge } from "./MemoryBankScanner.js";
+import { listAllUserKnowledge, listAllUserKnowledgeFromRoot, listUserKnowledge } from "./MemoryBankScanner.js";
 import { loadConfig } from "./SessionTracker.js";
 
 const mockLoadConfig = vi.mocked(loadConfig);
@@ -311,6 +311,23 @@ describe("MemoryBankScanner.listUserKnowledge", () => {
 
 	it("listAllUserKnowledgeFromRoot returns [] when kbRoot does not exist", async () => {
 		expect(await listAllUserKnowledgeFromRoot(join(localFolderRoot, "nope"))).toEqual([]);
+	});
+
+	it("listAllUserKnowledge resolves the kbRoot from cwd and scans every branch folder", async () => {
+		// cwd-resolving wrapper: the beforeEach mocks already point the resolver at
+		// kbRoot, so this exercises the resolve → scan handoff end to end.
+		await writeManifest([]);
+		await mkdir(join(kbRoot, "untracked-branch"));
+		await writeFile(join(kbRoot, "Repo.md"), "r", "utf-8");
+		await writeFile(join(kbRoot, "untracked-branch", "scratch.md"), "b", "utf-8");
+
+		const result = await listAllUserKnowledge(cwd);
+		expect(result.map((f) => f.path).sort()).toEqual(["jolliai/Repo.md", "jolliai/untracked-branch/scratch.md"]);
+	});
+
+	it("listAllUserKnowledge returns [] when the Memory Bank root cannot be resolved", async () => {
+		mockLoadConfig.mockRejectedValue(new Error("config gone"));
+		expect(await listAllUserKnowledge(cwd)).toEqual([]);
 	});
 
 	it("returns global + repo + branch in one pass without duplication", async () => {

--- a/cli/src/core/MemoryBankScanner.ts
+++ b/cli/src/core/MemoryBankScanner.ts
@@ -19,7 +19,6 @@
  *   - per-file read failure                       → skip + WARN
  */
 
-import { createHash } from "node:crypto";
 import { type Dirent, existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import { dirname, join, relative } from "node:path";
 import { createLogger } from "../Logger.js";
@@ -280,7 +279,9 @@ function collectMarkdown(args: CollectArgs): void {
 		}
 		/* v8 ignore stop */
 
-		const fingerprint = createHash("sha256").update(content, "utf-8").digest("hex");
+		// Shared helper (NOT an inline createHash) so this fingerprint stays in
+		// lockstep with the manifest fingerprint and SourceContent's verify hash.
+		const fingerprint = MetadataManager.sha256(content);
 		const localRelPath = toForwardSlash(relative(localFolderRoot, absolutePath));
 
 		out.push({

--- a/cli/src/core/MetadataManager.test.ts
+++ b/cli/src/core/MetadataManager.test.ts
@@ -159,6 +159,36 @@ describe("MetadataManager", () => {
 			expect(manager.findById("a")?.path).toBe("main/a-renamed.md");
 			expect(manager.findById("b")?.path).toBe("main/b.md");
 		});
+
+		it("unregisterFilesByType removes only entries of the given type and returns the count", () => {
+			manager.updateManifest(makeEntry({ fileId: "c1", type: "commit" }));
+			manager.updateManifest(makeEntry({ fileId: "w1", type: "wiki" }));
+			manager.updateManifest(makeEntry({ fileId: "w2", type: "wiki" }));
+
+			expect(manager.unregisterFilesByType("wiki")).toBe(2);
+			const remaining = manager.readManifest().files;
+			expect(remaining).toHaveLength(1);
+			expect(remaining[0].fileId).toBe("c1");
+		});
+
+		it("unregisterFilesByType returns 0 and leaves the manifest untouched when no entry matches", () => {
+			manager.updateManifest(makeEntry({ fileId: "c1", type: "commit" }));
+			expect(manager.unregisterFilesByType("wiki")).toBe(0);
+			expect(manager.readManifest().files).toHaveLength(1);
+		});
+
+		it("replaceFiles swaps the entire files array in one write", () => {
+			manager.updateManifest(makeEntry({ fileId: "old" }));
+			const next = [makeEntry({ fileId: "x", path: "main/x.md" }), makeEntry({ fileId: "y", path: "main/y.md" })];
+
+			manager.replaceFiles(next);
+			expect(
+				manager
+					.readManifest()
+					.files.map((f) => f.fileId)
+					.sort(),
+			).toEqual(["x", "y"]);
+		});
 	});
 
 	describe("branch mapping", () => {
@@ -196,6 +226,20 @@ describe("MetadataManager", () => {
 			expect(removed).toBe(1);
 			expect(manager.readManifest().files).toHaveLength(1);
 			expect(manager.findById("b")).toBeDefined();
+		});
+
+		it("removeBranchMapping drops the mapping and returns true", () => {
+			manager.resolveFolderForBranch("feature/gone");
+			expect(manager.listBranchMappings()).toHaveLength(1);
+
+			expect(manager.removeBranchMapping("feature/gone")).toBe(true);
+			expect(manager.listBranchMappings()).toHaveLength(0);
+		});
+
+		it("removeBranchMapping is a no-op returning false when the branch is not mapped", () => {
+			manager.resolveFolderForBranch("feature/kept");
+			expect(manager.removeBranchMapping("feature/never-mapped")).toBe(false);
+			expect(manager.listBranchMappings().map((m) => m.branch)).toEqual(["feature/kept"]);
 		});
 
 		it("renameBranchFolder leaves unrelated manifest entries untouched and returns 0 when nothing matches", () => {

--- a/cli/src/core/MultiRepoCompile.test.ts
+++ b/cli/src/core/MultiRepoCompile.test.ts
@@ -32,11 +32,13 @@ vi.mock("./MemoryBankRepoDiscovery.js", () => ({
 		return all.filter((t) => !exclude.includes(t.folder));
 	}),
 }));
+vi.mock("./SearchIndex.js", () => ({ SearchIndex: { rebuild: vi.fn() } }));
 
 import { withVaultWriteLock } from "../sync/VaultWriteLock.js";
 import { drainIngest } from "./IngestPipeline.js";
 import { discoverRepos } from "./MemoryBankRepoDiscovery.js";
 import { compileAllRepos } from "./MultiRepoCompile.js";
+import { SearchIndex } from "./SearchIndex.js";
 import { getActiveStorage, setActiveStorage } from "./SummaryStore.js";
 import { readTopicIndex } from "./TopicIndexStore.js";
 import { purgeTopicPagesExcept } from "./TopicPageStore.js";
@@ -109,5 +111,31 @@ describe("compileAllRepos", () => {
 		expect(res.failed).toBe(1);
 		expect(res.repos.find((r) => r.folder === "jolli")?.error).toBe("plain string failure");
 		expect(res.repos.find((r) => r.folder === "jolli")?.ingested).toBe(0);
+	});
+
+	it("reindexes each repo after wiki render", async () => {
+		vi.mocked(SearchIndex.rebuild).mockResolvedValue({ index: {} as never, docCount: 5 });
+		// Restrict to a single repo so the assertions are unambiguous.
+		const res = await compileAllRepos("/mb", { compileExcludeFolders: ["jolliai", "boom"] } as never);
+		expect(res.totalIngested).toBe(2);
+		expect(SearchIndex.rebuild).toHaveBeenCalledWith("/mb/jolli", { kbRoot: "/mb/jolli" });
+		expect(SearchIndex.rebuild).toHaveBeenCalledTimes(1);
+	});
+
+	it("swallows a reindex failure without failing the repo", async () => {
+		vi.mocked(SearchIndex.rebuild).mockRejectedValue(new Error("orama boom"));
+		const res = await compileAllRepos("/mb", { compileExcludeFolders: ["jolliai", "boom"] } as never);
+		expect(res.failed).toBe(0); // index failure is non-fatal
+		expect(res.totalIngested).toBe(2);
+	});
+
+	it("swallows a non-Error reindex rejection without failing the repo", async () => {
+		// The reindex catch stringifies a bare-value rejection via String(idxErr)
+		// rather than reading `.message`; it must stay non-fatal like the Error path.
+		// biome-ignore lint/suspicious/noExplicitAny: rejecting with a non-Error value is the point
+		vi.mocked(SearchIndex.rebuild).mockRejectedValue("orama string boom" as any);
+		const res = await compileAllRepos("/mb", { compileExcludeFolders: ["jolliai", "boom"] } as never);
+		expect(res.failed).toBe(0);
+		expect(res.totalIngested).toBe(2);
 	});
 });

--- a/cli/src/core/MultiRepoCompile.ts
+++ b/cli/src/core/MultiRepoCompile.ts
@@ -77,6 +77,22 @@ export async function compileAllRepos(
 						storage,
 					);
 					await renderTopicKBWiki(t.kbRoot, storage);
+					// Keep the local search index warm so query-time rebuilds are rare.
+					// Disposable cache: a failure here must never fail the compile.
+					// SearchIndex (→ @orama/*) is lazy-imported INSIDE this try so a
+					// load failure is contained the same way the node:sqlite readers
+					// are — a missing/incompatible orama degrades to "index not warmed",
+					// it never crashes module load or the whole sweep.
+					try {
+						const { SearchIndex } = await import("./SearchIndex.js");
+						await SearchIndex.rebuild(t.kbRoot, storage);
+					} catch (idxErr) {
+						log.warn(
+							"Search index update failed for %s (non-fatal): %s",
+							t.folder,
+							idxErr instanceof Error ? idxErr.message : String(idxErr),
+						);
+					}
 					totalIngested += ingested;
 					repos.push({ folder: t.folder, repoIdentity: t.repoIdentity, ingested, batches });
 					log.info("Compiled %s: %d source(s) in %d batch(es)", t.folder, ingested, batches);

--- a/cli/src/core/SearchIndex.test.ts
+++ b/cli/src/core/SearchIndex.test.ts
@@ -1,0 +1,305 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { SearchDoc } from "./SearchIndexTypes.js";
+
+vi.mock("./SearchIndexSource.js", () => ({
+	collectSearchDocs: vi.fn(),
+	computeSourceSignature: vi.fn(),
+}));
+
+import { SearchIndex } from "./SearchIndex.js";
+import { collectSearchDocs, computeSourceSignature } from "./SearchIndexSource.js";
+
+const docs: SearchDoc[] = [
+	{
+		id: "topic:auth-timeout",
+		type: "topic",
+		title: "Auth Timeout",
+		content: "Auth Timeout\nThe auth session has a 30-minute hard timeout.",
+		decisions: "",
+		branch: ["feature/auth", "main"],
+		category: "summary",
+		commitDate: "2026-01-03T00:00:00Z",
+		slug: "auth-timeout",
+		hash: "",
+	},
+	{
+		id: "commit:abc123",
+		type: "commit",
+		title: "add auth timeout",
+		content: "add auth timeout\nChose a 30-min hard cap.",
+		decisions: "Chose a 30-min hard cap.",
+		branch: ["feature/auth"],
+		category: "commit",
+		commitDate: "2026-01-02T00:00:00Z",
+		slug: "",
+		hash: "abc123",
+	},
+	{
+		// Sibling feature/* branch sharing the "feature" token with feature/auth —
+		// guards the branch filter against Orama's token-union `where` semantics.
+		id: "topic:billing-cache",
+		type: "topic",
+		title: "Billing Cache",
+		content: "Billing Cache\nThe billing cache also has a 30-minute timeout window.",
+		decisions: "",
+		branch: ["feature/billing"],
+		category: "summary",
+		commitDate: "2026-01-04T00:00:00Z",
+		slug: "billing-cache",
+		hash: "",
+	},
+];
+
+let dir: string;
+beforeEach(async () => {
+	dir = await mkdtemp(join(tmpdir(), "jolli-idx-"));
+	vi.mocked(collectSearchDocs).mockResolvedValue(docs);
+	vi.mocked(computeSourceSignature).mockResolvedValue("sig-v1");
+});
+afterEach(async () => {
+	SearchIndex.clearCache();
+	await rm(dir, { recursive: true, force: true });
+});
+
+describe("SearchIndex", () => {
+	it("builds from sources and finds a full-text match", async () => {
+		const idx = await SearchIndex.open(dir);
+		const res = await idx.search({ query: "auth timeout" });
+		expect(res.length).toBeGreaterThan(0);
+		expect(res.map((r) => r.id)).toContain("topic:auth-timeout");
+	});
+
+	it("filters by type", async () => {
+		const idx = await SearchIndex.open(dir);
+		const commitsOnly = await idx.search({ query: "auth", type: "commit" });
+		expect(commitsOnly.every((r) => r.type === "commit")).toBe(true);
+	});
+
+	it("clamps an oversized limit so a hostile MCP arg can't trigger Orama's Array.from RangeError", async () => {
+		const idx = await SearchIndex.open(dir);
+		// `limit` is unbounded MCP tool input. Orama preallocates
+		// `Array.from({length: limit})`, which throws RangeError above 2^32-1.
+		// The clamp must cap it before it reaches Orama.
+		const res = await idx.search({ query: "timeout", limit: 1e10 });
+		expect(res.length).toBeGreaterThan(0);
+		expect(res.length).toBeLessThanOrEqual(100);
+	});
+
+	it("falls back to the default limit when a non-conforming client sends a non-numeric `limit`", async () => {
+		const idx = await SearchIndex.open(dir);
+		// The MCP SDK validates the request envelope but NOT per-tool arg types, so
+		// `limit` can arrive as a string. Without the Number.isFinite guard,
+		// Math.trunc("abc") → NaN poisons the clamp and Orama returns 0 hits
+		// silently; it must instead fall back to the default and still match.
+		const res = await idx.search({ query: "timeout", limit: "abc" as unknown as number });
+		expect(res.length).toBeGreaterThan(0);
+	});
+
+	it("filters by exact branch membership (multi-branch topic, space-joined)", async () => {
+		const idx = await SearchIndex.open(dir);
+		// Only topic:auth-timeout lists "main" among its related branches.
+		const onMain = await idx.search({ query: "timeout", branch: "main" });
+		const ids = onMain.map((r) => r.id);
+		expect(ids).toContain("topic:auth-timeout"); // branch "feature/auth main"
+		expect(ids).not.toContain("commit:abc123"); // branch "feature/auth" only
+		expect(ids).not.toContain("topic:billing-cache"); // branch "feature/billing"
+	});
+
+	it("does not leak across slash branches that share a token", async () => {
+		const idx = await SearchIndex.open(dir);
+		// "feature/auth" shares the "feature" token with "feature/billing"; the
+		// exact-membership post-filter must NOT surface the billing topic (Orama's
+		// token-union `where` would have).
+		const res = await idx.search({ query: "timeout", branch: "feature/auth" });
+		const ids = res.map((r) => r.id);
+		expect(ids).toContain("topic:auth-timeout");
+		expect(ids).toContain("commit:abc123");
+		expect(ids).not.toContain("topic:billing-cache");
+	});
+
+	it("persists and restores without rebuilding when the signature matches", async () => {
+		await SearchIndex.open(dir); // builds + persists
+		vi.mocked(collectSearchDocs).mockClear();
+
+		const reopened = await SearchIndex.open(dir); // signature unchanged → restore
+		const res = await reopened.search({ query: "timeout" });
+		expect(res.length).toBeGreaterThan(0);
+		expect(collectSearchDocs).not.toHaveBeenCalled(); // restored, not rebuilt
+	});
+
+	it("rebuilds when the source signature changed", async () => {
+		await SearchIndex.open(dir); // persists with sig-v1
+		vi.mocked(computeSourceSignature).mockResolvedValue("sig-v2");
+		vi.mocked(collectSearchDocs).mockClear();
+
+		await SearchIndex.open(dir);
+		expect(collectSearchDocs).toHaveBeenCalledTimes(1); // stale → rebuilt
+	});
+
+	it("rebuild rebuilds from source and returns the doc count", async () => {
+		const { docCount } = await SearchIndex.rebuild(dir);
+		expect(docCount).toBe(docs.length);
+	});
+
+	it("computes the source signature only once on a cold open (no redundant recompute when it builds)", async () => {
+		vi.mocked(computeSourceSignature).mockClear();
+		// Cold: empty cache + no persisted manifest → open must build. open should
+		// reuse the signature it already computed rather than recomputing it inside
+		// the build path (each recompute re-reads index + catalog + topic index).
+		await SearchIndex.open(dir);
+		expect(computeSourceSignature).toHaveBeenCalledTimes(1);
+	});
+
+	it("openCached returns the same instance while the signature is unchanged", async () => {
+		const a = await SearchIndex.openCached(dir);
+		vi.mocked(collectSearchDocs).mockClear();
+		const b = await SearchIndex.openCached(dir);
+		expect(b).toBe(a); // memoized — no re-restore/rebuild
+		expect(collectSearchDocs).not.toHaveBeenCalled();
+	});
+
+	it("openCached reopens when the source signature changes", async () => {
+		const a = await SearchIndex.openCached(dir);
+		vi.mocked(computeSourceSignature).mockResolvedValue("sig-v2");
+		const b = await SearchIndex.openCached(dir);
+		expect(b).not.toBe(a); // stale → new index
+	});
+
+	it("openCached restores from disk (no rebuild) on a cold cache when the persisted signature matches", async () => {
+		// First call builds + persists and memoizes. Dropping the in-memory cache
+		// forces the next openCached to miss the memo but find the matching persisted
+		// manifest, so it restores from disk rather than recollecting source docs.
+		await SearchIndex.openCached(dir);
+		SearchIndex.clearCache();
+		vi.mocked(collectSearchDocs).mockClear();
+
+		const reopened = await SearchIndex.openCached(dir);
+		const res = await reopened.search({ query: "timeout" });
+		expect(res.length).toBeGreaterThan(0);
+		expect(collectSearchDocs).not.toHaveBeenCalled(); // restored from disk, not rebuilt
+	});
+
+	it("rebuilds when the persisted manifest has a stale schema version", async () => {
+		const { writeFile } = await import("node:fs/promises");
+		const { getJolliMemoryDir } = await import("../Logger.js");
+		await SearchIndex.open(dir); // build + persist a current-schema manifest
+		// Rewrite the manifest with an outdated schemaVersion (valid JSON, wrong
+		// version) so tryRestore rejects it on the version guard, not the JSON parse.
+		await writeFile(
+			join(getJolliMemoryDir(dir), "search-index.manifest.json"),
+			JSON.stringify({ schemaVersion: -1, sourceSignature: "sig-v1", savedAt: "2026-01-01T00:00:00Z" }),
+			"utf-8",
+		);
+		SearchIndex.clearCache();
+		vi.mocked(collectSearchDocs).mockClear();
+
+		await SearchIndex.open(dir);
+		expect(collectSearchDocs).toHaveBeenCalledTimes(1); // stale schema → rebuilt
+	});
+
+	it("returns a rare-branch hit even when other branches flood the top-N (no over-fetch truncation)", async () => {
+		// Regression guard (N1): a high-frequency term ("auth") matches many docs on
+		// a popular branch and exactly one doc on a rare branch. A branch filter must
+		// surface the rare-branch hit regardless of how many higher-scoring docs on
+		// OTHER branches exist — i.e. filtering happens in the index, not by post-
+		// filtering a globally-ranked top-N window that the rare hit can fall outside.
+		const flood: SearchDoc[] = Array.from({ length: 130 }, (_, i) => ({
+			id: `commit:flood${i}`,
+			type: "commit" as const,
+			title: "auth auth auth",
+			content: "auth auth auth auth auth", // high TF → outranks the rare doc
+			decisions: "",
+			branch: ["main"],
+			category: "commit",
+			commitDate: "2026-01-01T00:00:00Z",
+			slug: "",
+			hash: `flood${i}`,
+		}));
+		const rare: SearchDoc = {
+			id: "commit:rarehit",
+			type: "commit",
+			title: "auth",
+			content: "auth", // low TF → ranks below the flood
+			decisions: "",
+			branch: ["feature/rare"],
+			category: "commit",
+			commitDate: "2026-01-01T00:00:00Z",
+			slug: "",
+			hash: "rarehit",
+		};
+		vi.mocked(collectSearchDocs).mockResolvedValue([...flood, rare]);
+		const idx = await SearchIndex.open(dir);
+		const res = await idx.search({ query: "auth", branch: "feature/rare" });
+		expect(res.map((r) => r.id)).toContain("commit:rarehit");
+	});
+
+	const cjkDoc: SearchDoc = {
+		id: "commit:cjk",
+		type: "commit",
+		title: "认证超时",
+		content: "用户认证会话有三十分钟的硬性超时限制",
+		decisions: "",
+		branch: ["main"],
+		category: "commit",
+		commitDate: "2026-01-05T00:00:00Z",
+		slug: "",
+		hash: "cjk",
+	};
+
+	it("finds CJK (Chinese) content by a Chinese query", async () => {
+		// The default Orama tokenizer treats CJK characters as separators, so a
+		// Chinese body produces zero tokens and is unsearchable. A CJK-aware
+		// tokenizer must index n-grams so a Chinese query matches.
+		vi.mocked(collectSearchDocs).mockResolvedValue([cjkDoc]);
+		const idx = await SearchIndex.open(dir);
+		const res = await idx.search({ query: "认证超时" });
+		expect(res.map((r) => r.id)).toContain("commit:cjk");
+	});
+
+	it("finds CJK content after restoring the persisted index (tokenizer survives restore)", async () => {
+		// restore() rebuilds the Orama db with default components — the CJK-aware
+		// tokenizer must be re-applied to the restored db, else the query term is
+		// tokenized with the default rule and a Chinese query matches nothing even
+		// though the index holds the n-grams.
+		vi.mocked(collectSearchDocs).mockResolvedValue([cjkDoc]);
+		await SearchIndex.open(dir); // build + persist
+		SearchIndex.clearCache();
+		vi.mocked(collectSearchDocs).mockClear();
+		const reopened = await SearchIndex.open(dir); // restore from disk
+		expect(collectSearchDocs).not.toHaveBeenCalled(); // confirm it restored, not rebuilt
+		const res = await reopened.search({ query: "认证" });
+		expect(res.map((r) => r.id)).toContain("commit:cjk");
+	});
+
+	it("persists the index under the storage's kbRoot, not cwd, when folder-backed", async () => {
+		// P4: the compile sweep warms the index with folder storage rooted at the
+		// Memory Bank folder, while the MCP server runs in the git checkout. Keying
+		// the index off the storage's kbRoot (not cwd) makes both resolve the same
+		// file, so the warm-up isn't wasted.
+		const { existsSync } = await import("node:fs");
+		const { getJolliMemoryDir } = await import("../Logger.js");
+		const kbDir = await mkdtemp(join(tmpdir(), "jolli-kb-"));
+		try {
+			const storage = { kbRoot: kbDir } as unknown as import("./StorageProvider.js").StorageProvider;
+			await SearchIndex.open(dir, storage);
+			expect(existsSync(join(getJolliMemoryDir(kbDir), "search-index.json"))).toBe(true);
+			expect(existsSync(join(getJolliMemoryDir(dir), "search-index.json"))).toBe(false);
+		} finally {
+			await rm(kbDir, { recursive: true, force: true });
+		}
+	});
+
+	it("rebuilds when the persisted manifest is missing/corrupt", async () => {
+		const { writeFile } = await import("node:fs/promises");
+		const { getJolliMemoryDir } = await import("../Logger.js");
+		await SearchIndex.open(dir);
+		// Corrupt the manifest so tryRestore throws → open must rebuild.
+		await writeFile(join(getJolliMemoryDir(dir), "search-index.manifest.json"), "{ not json", "utf-8");
+		vi.mocked(collectSearchDocs).mockClear();
+		await SearchIndex.open(dir);
+		expect(collectSearchDocs).toHaveBeenCalledTimes(1);
+	});
+});

--- a/cli/src/core/SearchIndex.ts
+++ b/cli/src/core/SearchIndex.ts
@@ -1,0 +1,227 @@
+/**
+ * SearchIndex — thin Orama wrapper for JolliMemory's local full-text search
+ * (JOLLI-1226 P0). Builds an in-memory BM25 index from SearchIndexSource,
+ * persists it to .jolli/jollimemory/search-index.json, and rebuilds whenever
+ * the source signature changes (or the persisted file is missing/corrupt).
+ * The index is a disposable cache — source data (orphan branch / folder) is
+ * always authoritative.
+ *
+ * Orama 3.1.18 API notes (verified against the installed package):
+ * - `create({ schema })` is SYNCHRONOUS — returns the db object directly, no Promise.
+ * - `insertMultiple` and `search` are async — both awaited here.
+ * - `where: { … }` on a plain `"string"` field filters by TOKEN match: Orama
+ *   tokenizes the filter value and UNIONs the per-token matches. Safe for the
+ *   `type` filter (`topic`/`commit` are single, exact tokens) but WRONG for a
+ *   branch name — `where.branch === "feature/auth"` tokenizes to `feature`+`auth`
+ *   and would also match `feature/billing` (shared `feature` token). So `branch`
+ *   is an `enum[]` field (one element per related branch), filtered by exact set
+ *   membership: `where.branch === { containsAll: [want] }`. This runs in the index
+ *   alongside the BM25 term query, so the returned `limit` is already filtered —
+ *   no over-fetch-then-post-filter window that a rare-branch hit could fall out of.
+ * - `persist(db, "json")` returns a `string` (async); `restore("json", data)`
+ *   is async with format-first arg order.
+ */
+
+import { mkdir, readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { create, insertMultiple, type Orama, search } from "@orama/orama";
+import { persist, restore } from "@orama/plugin-data-persistence";
+import { createLogger, getJolliMemoryDir } from "../Logger.js";
+import { atomicWriteFile } from "./AtomicWrite.js";
+import { collectSearchDocs, computeSourceSignature } from "./SearchIndexSource.js";
+import { type IndexManifest, SEARCH_SCHEMA, SEARCH_SCHEMA_VERSION, type SearchDoc } from "./SearchIndexTypes.js";
+import { createSearchTokenizer } from "./SearchTokenizer.js";
+import type { StorageProvider } from "./StorageProvider.js";
+
+const log = createLogger("SearchIndex");
+
+const INDEX_FILE = "search-index.json";
+const MANIFEST_FILE = "search-index.manifest.json";
+
+/** The concrete Orama db type for our schema — lets `insertMultiple`/`search` stay type-clean. */
+type SearchDb = Orama<typeof SEARCH_SCHEMA>;
+
+export interface SearchQuery {
+	readonly query: string;
+	readonly branch?: string;
+	readonly type?: "topic" | "commit";
+	readonly limit?: number;
+}
+
+export interface SearchHitResult {
+	readonly id: string;
+	readonly type: "topic" | "commit";
+	readonly title: string;
+	readonly snippet: string;
+	readonly branch: string;
+	readonly commitDate: string;
+	readonly slug: string;
+	readonly hash: string;
+	readonly score: number;
+}
+
+export class SearchIndex {
+	private readonly db: SearchDb;
+
+	/**
+	 * Per-index-dir memo for {@link openCached}. Keyed by the resolved index
+	 * directory (not raw cwd) so two cwds that resolve to the same folder-backed
+	 * `kbRoot` share one entry. Holds the source signature the cached index was
+	 * built against so a stale entry is detected on the next call.
+	 */
+	private static readonly cache = new Map<string, { sig: string; index: SearchIndex }>();
+
+	private constructor(db: SearchDb) {
+		this.db = db;
+	}
+
+	/** Open the index: restore from disk if fresh, else rebuild and persist. */
+	static async open(cwd: string, storage?: StorageProvider): Promise<SearchIndex> {
+		const sig = await computeSourceSignature(cwd, storage);
+		const restored = await tryRestore(resolveIndexDir(cwd, storage), sig);
+		if (restored) return new SearchIndex(restored);
+
+		// Build with the signature we already computed — don't recompute it (each
+		// recompute re-reads index + catalog + topic index off disk).
+		const { index } = await SearchIndex.build(cwd, storage, sig);
+		return index;
+	}
+
+	/**
+	 * Like {@link open} but memoizes the opened index per cwd — for a long-lived
+	 * process (the MCP server) that searches repeatedly. The cheap source
+	 * signature is still recomputed on every call so a stale cache is detected;
+	 * only the expensive restore/rebuild (re-deserializing the whole Orama db
+	 * from disk) is skipped on a hit. A signature change transparently reopens.
+	 */
+	static async openCached(cwd: string, storage?: StorageProvider): Promise<SearchIndex> {
+		const sig = await computeSourceSignature(cwd, storage);
+		const dir = resolveIndexDir(cwd, storage);
+		const hit = SearchIndex.cache.get(dir);
+		if (hit && hit.sig === sig) return hit.index;
+
+		const restored = await tryRestore(dir, sig);
+		const index = restored ? new SearchIndex(restored) : (await SearchIndex.build(cwd, storage, sig)).index;
+		SearchIndex.cache.set(dir, { sig, index });
+		return index;
+	}
+
+	/** Clears the {@link openCached} memo. Test seam + safety hatch. */
+	static clearCache(): void {
+		SearchIndex.cache.clear();
+	}
+
+	/** Force a full rebuild from source, persist, and return the index + count.
+	 * Use this for explicit reindex / post-compile warm-up — it skips the
+	 * restore-if-fresh path of open(), so callers that always want a fresh
+	 * index don't pay for a wasted restore-or-build first. */
+	static async rebuild(cwd: string, storage?: StorageProvider): Promise<{ index: SearchIndex; docCount: number }> {
+		const sig = await computeSourceSignature(cwd, storage);
+		return SearchIndex.build(cwd, storage, sig);
+	}
+
+	/**
+	 * Collect docs, build the Orama db, and persist it against a KNOWN signature.
+	 * Private so callers go through {@link open} / {@link rebuild}; both pass the
+	 * signature they already computed so it isn't recomputed (and the sources
+	 * re-read) inside the build.
+	 */
+	private static async build(
+		cwd: string,
+		storage: StorageProvider | undefined,
+		sig: string,
+	): Promise<{ index: SearchIndex; docCount: number }> {
+		const docs = await collectSearchDocs(cwd, storage);
+		const db: SearchDb = create({ schema: SEARCH_SCHEMA, components: { tokenizer: createSearchTokenizer() } });
+		await insertMultiple(db, docs);
+		await persistTo(resolveIndexDir(cwd, storage), db, sig);
+		log.info("Built search index: %d docs", docs.length);
+		return { index: new SearchIndex(db), docCount: docs.length };
+	}
+
+	async search(q: SearchQuery): Promise<SearchHitResult[]> {
+		// `limit` is unbounded MCP tool input. The MCP SDK validates the request
+		// envelope but NOT per-tool arg types, so a non-conforming client can send a
+		// non-numeric `limit` (e.g. "abc"); `Math.trunc("abc")` is NaN and would
+		// poison the clamp below (Math.max/min(NaN,…) === NaN), reaching Orama as
+		// `Array.from({length: NaN})` → 0 hits silently. So coerce first and fall
+		// back to the default when not finite. Orama also preallocates that array,
+		// which RangeErrors above 2^32-1 and DoS-allocates huge arrays well before
+		// that, so clamp to a sane [1, 100] window (integer-truncated) afterward.
+		const requested = q.limit == null ? 20 : Number(q.limit);
+		const limit = Math.min(Math.max(1, Math.trunc(Number.isFinite(requested) ? requested : 20)), 100);
+		// Both filters run natively inside Orama's index so the returned `limit` is
+		// already post-filter — no over-fetch, no truncation. `type` is a tokenized
+		// `string` field but its values are single exact tokens, so a plain match is
+		// safe; `branch` is an `enum[]` field, matched by exact set membership with
+		// `containsAll: [want]` (one-element ⇒ "the branch set contains `want`").
+		const where: Record<string, unknown> = {};
+		if (q.type) where.type = q.type;
+		if (q.branch) where.branch = { containsAll: [q.branch] };
+		const result = await search(this.db, {
+			term: q.query,
+			limit,
+			...(Object.keys(where).length ? { where } : {}),
+		});
+		return result.hits.map((h) => {
+			const doc = h.document as unknown as SearchDoc;
+			return {
+				id: doc.id,
+				type: doc.type,
+				title: doc.title,
+				snippet: doc.content.slice(0, 280),
+				branch: doc.branch.join(" "),
+				commitDate: doc.commitDate,
+				slug: doc.slug,
+				hash: doc.hash,
+				score: h.score,
+			};
+		});
+	}
+}
+
+/**
+ * Where the disposable index + manifest live. Folder-backed storage roots it at
+ * the Memory Bank folder (`<kbRoot>/.jolli/jollimemory/`) so the `jolli compile`
+ * warm-up and the MCP server resolve the SAME file; orphan-only / no-storage
+ * falls back to the checkout's `.jolli/jollimemory/`. See StorageProvider.kbRoot.
+ */
+function resolveIndexDir(cwd: string, storage?: StorageProvider): string {
+	return getJolliMemoryDir(storage?.kbRoot ?? cwd);
+}
+
+async function persistTo(dir: string, db: SearchDb, sig: string): Promise<void> {
+	const indexPath = join(dir, INDEX_FILE);
+	await mkdir(dirname(indexPath), { recursive: true });
+	const serialized = await persist(db, "json");
+	// Atomic writes (tmpfile + rename) so a crash mid-write never leaves a
+	// half-written file. Index FIRST, then the manifest — the manifest is the
+	// "index is ready" marker, so a torn pair (index written, manifest not) just
+	// fails the signature check on next restore and triggers a rebuild.
+	await atomicWriteFile(indexPath, serialized as string);
+	const manifest: IndexManifest = {
+		schemaVersion: SEARCH_SCHEMA_VERSION,
+		sourceSignature: sig,
+		savedAt: new Date().toISOString(),
+	};
+	await atomicWriteFile(join(dir, MANIFEST_FILE), JSON.stringify(manifest));
+}
+
+async function tryRestore(dir: string, currentSig: string): Promise<SearchDb | null> {
+	try {
+		const manifestRaw = await readFile(join(dir, MANIFEST_FILE), "utf-8");
+		const manifest = JSON.parse(manifestRaw) as IndexManifest;
+		if (manifest.schemaVersion !== SEARCH_SCHEMA_VERSION) return null;
+		if (manifest.sourceSignature !== currentSig) return null;
+		const indexRaw = await readFile(join(dir, INDEX_FILE), "utf-8");
+		const db = (await restore("json", indexRaw)) as SearchDb;
+		// restore() rebuilds the db with DEFAULT components, dropping our CJK-aware
+		// tokenizer — search reads `db.tokenizer` at query time, so re-apply it or a
+		// CJK query against a restored index tokenizes with the default rule and
+		// matches nothing despite the n-grams being present in the loaded index.
+		db.tokenizer = createSearchTokenizer();
+		return db;
+	} catch {
+		return null;
+	}
+}

--- a/cli/src/core/SearchIndexSource.test.ts
+++ b/cli/src/core/SearchIndexSource.test.ts
@@ -1,0 +1,276 @@
+import { describe, expect, it, vi } from "vitest";
+import type { StorageProvider } from "./StorageProvider.js";
+
+// Mock the four stores this module reads.
+vi.mock("./SummaryStore.js", () => ({
+	getIndex: vi.fn(),
+	getCatalogWithLazyBuild: vi.fn(),
+}));
+vi.mock("./TopicIndexStore.js", () => ({ readTopicIndex: vi.fn() }));
+vi.mock("./TopicPageStore.js", () => ({ readTopicPage: vi.fn() }));
+
+import { collectSearchDocs, computeSourceSignature } from "./SearchIndexSource.js";
+import { getCatalogWithLazyBuild, getIndex } from "./SummaryStore.js";
+import { readTopicIndex } from "./TopicIndexStore.js";
+import { readTopicPage } from "./TopicPageStore.js";
+
+const storage = {} as StorageProvider;
+
+function wireSources() {
+	vi.mocked(getIndex).mockResolvedValue({
+		version: 3,
+		entries: [
+			{
+				commitHash: "abc123def456",
+				parentCommitHash: null,
+				commitMessage: "add auth timeout",
+				commitDate: "2026-01-02T00:00:00Z",
+				branch: "feature/auth",
+				generatedAt: "2026-01-02T01:00:00Z",
+			},
+		],
+	} as never);
+	vi.mocked(getCatalogWithLazyBuild).mockResolvedValue({
+		version: 1,
+		entries: [
+			{
+				commitHash: "abc123def456",
+				recap: "Added a configurable auth session timeout.",
+				ticketId: "JOLLI-1",
+				topics: [{ title: "Auth timeout", decisions: "Chose a 30-min hard cap." }],
+			},
+		],
+	} as never);
+	vi.mocked(readTopicIndex).mockResolvedValue({
+		schemaVersion: 1,
+		topics: [
+			{
+				stableSlug: "auth-timeout",
+				title: "Auth Timeout",
+				summary: "How session timeout works",
+				relatedBranches: ["feature/auth", "main"],
+				sourceRefs: [
+					{ type: "summary", id: "abc123def456", timestamp: "2026-01-02T00:00:00Z", branch: "feature/auth" },
+				],
+				lastUpdatedAt: "2026-01-03T00:00:00Z",
+			},
+		],
+	} as never);
+	vi.mocked(readTopicPage).mockResolvedValue({
+		schemaVersion: 1,
+		stableSlug: "auth-timeout",
+		title: "Auth Timeout",
+		content: "The auth session has a 30-minute hard timeout.",
+		relatedBranches: ["feature/auth", "main"],
+		sourceRefs: [
+			{ type: "summary", id: "abc123def456", timestamp: "2026-01-02T00:00:00Z", branch: "feature/auth" },
+		],
+		lastUpdatedAt: "2026-01-03T00:00:00Z",
+	} as never);
+}
+
+describe("collectSearchDocs", () => {
+	it("emits one topic doc and one commit doc with joined fields", async () => {
+		wireSources();
+		const docs = await collectSearchDocs("/repo", storage);
+
+		const topic = docs.find((d) => d.id === "topic:auth-timeout");
+		expect(topic).toBeDefined();
+		expect(topic?.type).toBe("topic");
+		expect(topic?.content).toContain("30-minute hard timeout");
+		expect(topic?.branch).toEqual(["feature/auth", "main"]);
+		expect(topic?.slug).toBe("auth-timeout");
+		expect(topic?.commitDate).toBe("2026-01-03T00:00:00Z");
+
+		const commit = docs.find((d) => d.id === "commit:abc123def456");
+		expect(commit).toBeDefined();
+		expect(commit?.type).toBe("commit");
+		expect(commit?.branch).toEqual(["feature/auth"]);
+		expect(commit?.hash).toBe("abc123def456");
+		expect(commit?.decisions).toContain("30-min hard cap");
+		expect(commit?.content).toContain("Auth timeout"); // topic title folded into body
+		expect(commit?.content).toContain("configurable auth session timeout"); // recap folded in
+	});
+
+	it("returns [] when there is no data", async () => {
+		vi.mocked(getIndex).mockResolvedValue(null);
+		vi.mocked(getCatalogWithLazyBuild).mockResolvedValue({ version: 1, entries: [] } as never);
+		vi.mocked(readTopicIndex).mockResolvedValue({ schemaVersion: 1, topics: [] } as never);
+		const docs = await collectSearchDocs("/repo", storage);
+		expect(docs).toEqual([]);
+	});
+
+	it("falls back to the index-entry fields when no topic page exists, and to 'topic' category when refs are empty", async () => {
+		// No page on disk → content/branches/sourceRefs/lastUpdatedAt come from the
+		// topic index entry, and an empty sourceRefs list defaults the category to
+		// "topic" (the dominantSourceType empty-input branch).
+		wireSources();
+		vi.mocked(readTopicPage).mockResolvedValue(null);
+		vi.mocked(readTopicIndex).mockResolvedValue({
+			schemaVersion: 1,
+			topics: [
+				{
+					stableSlug: "auth-timeout",
+					title: "Auth Timeout",
+					summary: "index-entry summary fallback",
+					relatedBranches: ["main"],
+					sourceRefs: [],
+					lastUpdatedAt: "2026-02-02T00:00:00Z",
+				},
+			],
+		} as never);
+
+		const docs = await collectSearchDocs("/repo", storage);
+		const topic = docs.find((d) => d.id === "topic:auth-timeout");
+		expect(topic?.content).toContain("index-entry summary fallback");
+		expect(topic?.branch).toEqual(["main"]);
+		expect(topic?.commitDate).toBe("2026-02-02T00:00:00Z");
+		expect(topic?.category).toBe("topic"); // empty sourceRefs → default
+	});
+
+	it("picks the most frequent source-ref type as the topic category (sort comparator runs)", async () => {
+		// Mixed sourceRefs (2× plan, 1× summary) force the dominantSourceType sort
+		// comparator to actually compare counts and pick the plurality winner.
+		wireSources();
+		vi.mocked(readTopicPage).mockResolvedValue({
+			schemaVersion: 1,
+			stableSlug: "auth-timeout",
+			title: "Auth Timeout",
+			content: "body",
+			relatedBranches: ["main"],
+			sourceRefs: [
+				{ type: "summary", id: "s1", timestamp: "2026-01-01T00:00:00Z", branch: "main" },
+				{ type: "plan", id: "p1", timestamp: "2026-01-01T00:00:00Z", branch: "main" },
+				{ type: "plan", id: "p2", timestamp: "2026-01-01T00:00:00Z", branch: "main" },
+			],
+			lastUpdatedAt: "2026-01-03T00:00:00Z",
+		} as never);
+
+		const docs = await collectSearchDocs("/repo", storage);
+		expect(docs.find((d) => d.id === "topic:auth-timeout")?.category).toBe("plan");
+	});
+
+	it("skips a catalog entry that has no matching index head, and tolerates missing topics/recap/decisions", async () => {
+		wireSources();
+		vi.mocked(getCatalogWithLazyBuild).mockResolvedValue({
+			version: 1,
+			entries: [
+				// Has an index head (abc123def456) but no topics array and no recap →
+				// body is the commit message only; decisions stays "".
+				{ commitHash: "abc123def456" },
+				// No index head → must be skipped (the `!meta` continue branch).
+				{ commitHash: "orphan-no-index", recap: "dangling" },
+				// Index head present, a topic whose decisions is undefined → filtered out.
+				{ commitHash: "abc123def456", topics: [{ title: "T", decisions: undefined }] },
+			],
+		} as never);
+
+		const docs = await collectSearchDocs("/repo", storage);
+		const commits = docs.filter((d) => d.type === "commit");
+		expect(commits.map((c) => c.hash)).not.toContain("orphan-no-index");
+		const bare = commits[0];
+		expect(bare.content).toBe("add auth timeout"); // commitMessage only
+		expect(bare.decisions).toBe("");
+	});
+});
+
+describe("computeSourceSignature", () => {
+	it("changes when source counts or timestamps change", async () => {
+		wireSources();
+		const sig1 = await computeSourceSignature("/repo", storage);
+
+		vi.mocked(readTopicIndex).mockResolvedValue({
+			schemaVersion: 1,
+			topics: [
+				{
+					stableSlug: "auth-timeout",
+					title: "Auth Timeout",
+					summary: "x",
+					relatedBranches: [],
+					sourceRefs: [],
+					lastUpdatedAt: "2026-09-09T00:00:00Z", // newer
+				},
+			],
+		} as never);
+		const sig2 = await computeSourceSignature("/repo", storage);
+		expect(sig2).not.toBe(sig1);
+	});
+
+	it("changes when catalog content is edited in place (same counts, same timestamps)", async () => {
+		// Regression guard (P3): a WebView recap edit rewrites the catalog entry's
+		// recap but preserves the index entry's generatedAt and every count — the
+		// count+timestamp signature would miss it and serve a stale search index.
+		wireSources();
+		const sig1 = await computeSourceSignature("/repo", storage);
+
+		vi.mocked(getCatalogWithLazyBuild).mockResolvedValue({
+			version: 1,
+			entries: [
+				{
+					commitHash: "abc123def456",
+					recap: "EDITED: a different recap entirely.",
+					ticketId: "JOLLI-1",
+					topics: [{ title: "Auth timeout", decisions: "Chose a 30-min hard cap." }],
+				},
+			],
+		} as never);
+		const sig2 = await computeSourceSignature("/repo", storage);
+		expect(sig2).not.toBe(sig1);
+	});
+
+	it("keeps the newest timestamp when a later entry is older (reducer retains max)", async () => {
+		// Two index entries and two topics where the SECOND is older than the first.
+		// The reducer's `max > e` retain branch only fires when a non-first element
+		// fails the `>` comparison.
+		wireSources();
+		vi.mocked(getIndex).mockResolvedValue({
+			version: 3,
+			entries: [
+				{ commitHash: "a", branch: "main", parentCommitHash: null, generatedAt: "2026-05-05T00:00:00Z" },
+				{ commitHash: "b", branch: "main", parentCommitHash: null, generatedAt: "2026-01-01T00:00:00Z" },
+			],
+		} as never);
+		vi.mocked(readTopicIndex).mockResolvedValue({
+			schemaVersion: 1,
+			topics: [
+				{
+					stableSlug: "t1",
+					title: "T1",
+					summary: "",
+					relatedBranches: [],
+					sourceRefs: [],
+					lastUpdatedAt: "2026-05-05T00:00:00Z",
+				},
+				{
+					stableSlug: "t2",
+					title: "T2",
+					summary: "",
+					relatedBranches: [],
+					sourceRefs: [],
+					lastUpdatedAt: "2026-01-01T00:00:00Z",
+				},
+			],
+		} as never);
+
+		const sig = await computeSourceSignature("/repo", storage);
+		// newestGeneratedAt + topicNewest both pin the May timestamp, not the Jan one.
+		expect(sig).toContain("2026-05-05T00:00:00Z");
+		expect(sig).not.toContain("2026-01-01T00:00:00Z");
+	});
+
+	it("handles a null index and catalog entries missing recap/topics/decisions without throwing", async () => {
+		// index null → indexCount 0 and newestGeneratedAt "" (the `?? 0` / `?? []`
+		// branches); catalog entries with absent recap/topics and undefined
+		// decisions exercise the `?? ""` folds inside the content digest.
+		vi.mocked(getIndex).mockResolvedValue(null);
+		vi.mocked(getCatalogWithLazyBuild).mockResolvedValue({
+			version: 1,
+			entries: [{ commitHash: "h1" }, { commitHash: "h2", topics: [{ title: "T", decisions: undefined }] }],
+		} as never);
+		vi.mocked(readTopicIndex).mockResolvedValue({ schemaVersion: 1, topics: [] } as never);
+
+		const sig = await computeSourceSignature("/repo", storage);
+		expect(typeof sig).toBe("string");
+		expect(sig.split("|")[1]).toBe("0"); // indexCount === 0 from the null index
+	});
+});

--- a/cli/src/core/SearchIndexSource.ts
+++ b/cli/src/core/SearchIndexSource.ts
@@ -1,0 +1,139 @@
+/**
+ * Projects JolliMemory's two on-disk sources — the topic KB (topics/index.json
+ * + topic pages) and the raw commit catalog (catalog.json, joined with
+ * index.json for branch/date) — into the flat SearchDoc shape the Orama index
+ * consumes. The ONLY module that knows these source layouts; SearchIndex stays
+ * source-agnostic.
+ */
+
+import { createHash } from "node:crypto";
+import type { SearchDoc } from "./SearchIndexTypes.js";
+import { SEARCH_SCHEMA_VERSION } from "./SearchIndexTypes.js";
+import type { StorageProvider } from "./StorageProvider.js";
+import { getCatalogWithLazyBuild, getIndex } from "./SummaryStore.js";
+import { readTopicIndex } from "./TopicIndexStore.js";
+import { readTopicPage } from "./TopicPageStore.js";
+
+/** Build every SearchDoc from current source data. */
+export async function collectSearchDocs(cwd: string, storage?: StorageProvider): Promise<SearchDoc[]> {
+	const [topicDocs, commitDocs] = await Promise.all([
+		collectTopicDocs(cwd, storage),
+		collectCommitDocs(cwd, storage),
+	]);
+	return [...topicDocs, ...commitDocs];
+}
+
+async function collectTopicDocs(cwd: string, storage?: StorageProvider): Promise<SearchDoc[]> {
+	const index = await readTopicIndex(cwd, storage);
+	const docs = await Promise.all(
+		index.topics.map(async (entry) => {
+			const page = await readTopicPage(entry.stableSlug, cwd, storage);
+			const content = page?.content ?? entry.summary;
+			const branches = [...(page?.relatedBranches ?? entry.relatedBranches)];
+			const category = dominantSourceType(page?.sourceRefs ?? entry.sourceRefs);
+			const doc: SearchDoc = {
+				id: `topic:${entry.stableSlug}`,
+				type: "topic",
+				title: entry.title,
+				content: `${entry.title}\n${content}`,
+				decisions: "",
+				branch: branches,
+				category,
+				commitDate: page?.lastUpdatedAt ?? entry.lastUpdatedAt,
+				slug: entry.stableSlug,
+				hash: "",
+			};
+			return doc;
+		}),
+	);
+	return docs;
+}
+
+async function collectCommitDocs(cwd: string, storage?: StorageProvider): Promise<SearchDoc[]> {
+	const [index, catalog] = await Promise.all([getIndex(cwd, storage), getCatalogWithLazyBuild(cwd, storage)]);
+	if (!index) return [];
+
+	// Join: catalog has recap/topics/decisions; index has branch/date. Key = commitHash.
+	const metaByHash = new Map(index.entries.map((e) => [e.commitHash, e]));
+
+	const docs: SearchDoc[] = [];
+	for (const entry of catalog.entries) {
+		const meta = metaByHash.get(entry.commitHash);
+		if (!meta) continue; // catalog entry without an index head — skip (not browsable)
+
+		const topicTitles = (entry.topics ?? []).map((t) => t.title).join("\n");
+		const decisions = (entry.topics ?? [])
+			.map((t) => t.decisions)
+			.filter((d): d is string => Boolean(d))
+			.join("\n");
+		const bodyParts = [meta.commitMessage, entry.recap, topicTitles, decisions].filter(Boolean);
+
+		docs.push({
+			id: `commit:${entry.commitHash}`,
+			type: "commit",
+			title: meta.commitMessage,
+			content: bodyParts.join("\n"),
+			decisions,
+			branch: [meta.branch],
+			category: "commit",
+			commitDate: meta.commitDate,
+			slug: "",
+			hash: entry.commitHash,
+		});
+	}
+	return docs;
+}
+
+function dominantSourceType(refs: ReadonlyArray<{ type: string }>): string {
+	if (refs.length === 0) return "topic";
+	const counts = new Map<string, number>();
+	for (const r of refs) counts.set(r.type, (counts.get(r.type) ?? 0) + 1);
+	return [...counts.entries()].sort((a, b) => b[1] - a[1])[0][0];
+}
+
+/**
+ * Cheap signature of source state. Changes whenever a source count or its
+ * newest timestamp changes — enough to detect "data moved since last persist"
+ * without rebuilding to compare. Used by SearchIndex's staleness check.
+ */
+export async function computeSourceSignature(cwd: string, storage?: StorageProvider): Promise<string> {
+	const [index, catalog, topicIndex] = await Promise.all([
+		getIndex(cwd, storage),
+		getCatalogWithLazyBuild(cwd, storage),
+		readTopicIndex(cwd, storage),
+	]);
+	const indexCount = index?.entries.length ?? 0;
+	const newestGeneratedAt = (index?.entries ?? []).reduce(
+		(max, e) => (e.generatedAt > max ? e.generatedAt : max),
+		"",
+	);
+	const topicNewest = topicIndex.topics.reduce((max, t) => (t.lastUpdatedAt > max ? t.lastUpdatedAt : max), "");
+	// Counts + newest timestamps catch adds/removes/re-summarizes, but NOT an
+	// in-place content edit that preserves them — e.g. a WebView recap edit
+	// rewrites `recap` while keeping the index entry's `generatedAt` and every
+	// count. So fold a digest of the searchable catalog content (recap + per-topic
+	// title/decisions) into the signature; any in-place edit changes it and the
+	// stale index is rebuilt. The catalog is already loaded here, so this is CPU
+	// only — no extra I/O.
+	const contentDigest = createHash("sha1")
+		.update(
+			catalog.entries
+				.map(
+					(e) =>
+						`${e.commitHash}\x00${e.recap ?? ""}\x00${(e.topics ?? [])
+							.map((t) => `${t.title}${t.decisions ?? ""}`)
+							.join("")}`,
+				)
+				.join(""),
+		)
+		.digest("hex");
+	return [
+		SEARCH_SCHEMA_VERSION,
+		indexCount,
+		catalog.entries.length,
+		topicIndex.topics.length,
+		newestGeneratedAt,
+		topicNewest,
+		contentDigest,
+	].join("|");
+}

--- a/cli/src/core/SearchIndexTypes.ts
+++ b/cli/src/core/SearchIndexTypes.ts
@@ -1,0 +1,63 @@
+/**
+ * Shared types + constants for the local full-text search index (JOLLI-1226 P0).
+ * Pure module: no runtime behavior, no I/O.
+ */
+
+/** Bump when the document shape or Orama schema changes — forces a rebuild. */
+export const SEARCH_SCHEMA_VERSION = 2 as const;
+
+/** A single indexed document. Topics and commits share one flat shape. */
+export interface SearchDoc {
+	/** "topic:<stableSlug>" | "commit:<fullHash>" — also the Orama document id. */
+	readonly id: string;
+	readonly type: "topic" | "commit";
+	readonly title: string;
+	/** Full searchable body. */
+	readonly content: string;
+	/** Joined decision text; "" when none. */
+	readonly decisions: string;
+	/**
+	 * commit: `[branch]`; topic: relatedBranches. An `enum[]` field so a branch
+	 * filter is an EXACT-membership match in the index (`containsAll: [want]`),
+	 * not a tokenized `where` over a joined string — the latter both leaks across
+	 * slash-siblings (shared `feature` token) and, when post-filtered against an
+	 * over-fetched top-N, silently drops rare-branch hits that fall outside it.
+	 * Mutable element type (not `readonly string[]`) to satisfy Orama's insert
+	 * signature for an `enum[]` field.
+	 */
+	readonly branch: string[];
+	/** commit: source kind ("commit"); topic: dominant sourceRef type. */
+	readonly category: string;
+	/** ISO 8601. commit: commitDate; topic: lastUpdatedAt. */
+	readonly commitDate: string;
+	/** Topic stableSlug, else "". */
+	readonly slug: string;
+	/** Commit fullHash, else "". */
+	readonly hash: string;
+}
+
+/**
+ * Orama schema literal. Full-text fields are `"string"` (tokenized + BM25);
+ * `branch` is `"enum[]"` so it filters by exact set membership rather than token
+ * match (see {@link SearchDoc.branch}).
+ */
+export const SEARCH_SCHEMA = {
+	id: "string",
+	type: "string",
+	title: "string",
+	content: "string",
+	decisions: "string",
+	branch: "enum[]",
+	category: "string",
+	commitDate: "string",
+	slug: "string",
+	hash: "string",
+} as const;
+
+/** Sidecar manifest persisted next to the index file. */
+export interface IndexManifest {
+	readonly schemaVersion: number;
+	/** Output of computeSourceSignature() at persist time. */
+	readonly sourceSignature: string;
+	readonly savedAt: string;
+}

--- a/cli/src/core/SearchTokenizer.test.ts
+++ b/cli/src/core/SearchTokenizer.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { createSearchTokenizer } from "./SearchTokenizer.js";
+
+describe("createSearchTokenizer", () => {
+	const tok = createSearchTokenizer();
+
+	it("emits CJK unigrams and adjacent bigrams", () => {
+		const tokens = tok.tokenize("认证超时");
+		// unigrams + bigrams for the single run "认证超时"
+		expect(tokens).toEqual(expect.arrayContaining(["认", "证", "超", "时", "认证", "证超", "超时"]));
+	});
+
+	it("still tokenizes Latin text (lowercased) and folds CJK into the same stream", () => {
+		const tokens = tok.tokenize("Auth 认证");
+		expect(tokens).toContain("auth"); // default tokenizer lowercases
+		expect(tokens).toContain("认证"); // CJK bigram appended
+	});
+
+	it("returns base tokens unchanged for Latin-only input (no CJK additions)", () => {
+		const tokens = tok.tokenize("hello world");
+		expect(tokens).toContain("hello");
+		expect(tokens.some((t) => /[一-鿿]/.test(t))).toBe(false);
+	});
+
+	it("does not throw on a non-string value (defensive guard)", () => {
+		// Orama's own tokenizer tolerates non-string field values; mirror that.
+		expect(() => tok.tokenize(42 as unknown as string)).not.toThrow();
+	});
+});

--- a/cli/src/core/SearchTokenizer.ts
+++ b/cli/src/core/SearchTokenizer.ts
@@ -1,0 +1,58 @@
+/**
+ * CJK-aware Orama tokenizer for the local search index.
+ *
+ * Orama's default tokenizer splits on the English rule
+ * `/[^A-Za-zàèéìòóù0-9_'-]+/`, which treats every CJK character as a separator —
+ * so a Chinese/Japanese/Korean body yields ZERO tokens and is unsearchable. We
+ * wrap the default tokenizer (keeping its Latin lowercasing + English stemming)
+ * and additionally emit n-grams for each maximal CJK run: every character as a
+ * unigram (so single-character queries match) plus every adjacent pair as a
+ * bigram (so multi-character queries score on contiguity). The same tokenizer is
+ * applied at index AND query time, so the n-gram sets line up for BM25 matching.
+ *
+ * No dictionary segmentation (no extra dependency, no Node-version constraints) —
+ * n-grams trade some precision for guaranteed recall, which is the right default
+ * for a small local memory index.
+ */
+
+import type { Tokenizer } from "@orama/orama";
+import { tokenizer as oramaTokenizer } from "@orama/orama/components";
+
+/**
+ * Maximal runs of CJK script: Unified Ideographs + Ext A, Compatibility
+ * Ideographs, Hiragana, Katakana, and Hangul syllables. Latin/digits are left to
+ * the default tokenizer.
+ */
+const CJK_RUN = /[㐀-䶿一-鿿豈-﫿぀-ヿ가-힯]+/g;
+
+/** Unigrams + adjacent bigrams for one CJK run (e.g. "认证超" → 认,证,超,认证,证超). */
+function cjkNGrams(text: string): string[] {
+	const grams: string[] = [];
+	for (const match of text.matchAll(CJK_RUN)) {
+		const run = match[0];
+		for (let i = 0; i < run.length; i++) {
+			grams.push(run[i]);
+			if (i + 1 < run.length) grams.push(run.slice(i, i + 2));
+		}
+	}
+	return grams;
+}
+
+/**
+ * A {@link Tokenizer} that tokenizes Latin text via Orama's default and augments
+ * each CJK run with unigram + bigram tokens. Must be applied to BOTH a freshly
+ * built db (via `create({ components: { tokenizer } })`) and a restored db (whose
+ * tokenizer reverts to default — reassign `db.tokenizer`), so index-time and
+ * query-time tokenization agree.
+ */
+export function createSearchTokenizer(): Tokenizer {
+	const base = oramaTokenizer.createTokenizer();
+	const baseTokenize = base.tokenize.bind(base);
+	base.tokenize = (raw, language, prop, withCache) => {
+		const latin = baseTokenize(raw, language, prop, withCache);
+		if (typeof raw !== "string") return latin;
+		const grams = cjkNGrams(raw.toLowerCase());
+		return grams.length ? Array.from(new Set([...latin, ...grams])) : latin;
+	};
+	return base;
+}

--- a/cli/src/core/SessionTracker.test.ts
+++ b/cli/src/core/SessionTracker.test.ts
@@ -1530,6 +1530,16 @@ describe("SessionTracker", () => {
 			expect(entries).toEqual([]);
 		});
 
+		it("names queue files with a process-unique nonce segment (guards cross-process same-ms collisions)", async () => {
+			const { readdir } = await import("node:fs/promises");
+			await enqueueGitOperation(makeOp("aaa111ff"), tempDir);
+			const queueDir = join(tempDir, ".jolli", "jollimemory", "git-op-queue");
+			const [name] = await readdir(queueDir);
+			// {timestamp}-{8-digit seq}-{8-hex nonce}-{tag}.json — the nonce is what
+			// makes two processes enqueuing in the same ms with the same tag unique.
+			expect(name).toMatch(/^\d+-\d{8}-[0-9a-f]{8}-aaa111ff\.json$/);
+		});
+
 		it("should delete a queue entry by file path", async () => {
 			await enqueueGitOperation(makeOp("ccc333"), tempDir);
 			const entries = await dequeueAllGitOperations(tempDir);

--- a/cli/src/core/SessionTracker.ts
+++ b/cli/src/core/SessionTracker.ts
@@ -12,6 +12,7 @@
  * Lock primitives (`worker.lock` / `orphan-write.lock`) live in `Locks.ts`.
  */
 
+import { randomBytes } from "node:crypto";
 import { mkdir, readdir, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
@@ -559,18 +560,29 @@ const GIT_OP_QUEUE_DIR = "git-op-queue";
 const GIT_OP_QUEUE_STALE_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
 
 /**
- * Process-local monotonic sequence so two enqueues within the same
- * millisecond cannot collide on filename. Old on-disk entries without the
- * sequence segment still sort correctly because they were written under
- * lower wall-clock ms; this segment only disambiguates within a single ms.
+ * Process-local monotonic sequence — disambiguates two enqueues within the same
+ * millisecond *in the same process*. It does NOT disambiguate across processes
+ * (each fresh node process starts at 0), which is why the filename also carries
+ * {@link PROCESS_NONCE}.
  */
 let enqueueSeq = 0;
 
 /**
+ * Per-process random nonce. The git hooks run as separate node processes
+ * (post-commit, post-merge, the QueueWorker re-enqueue) that can each enqueue
+ * in the same millisecond with the same tag — `{ms}-00000001-ingest` from two
+ * processes would collide and one atomicWrite would overwrite the other, losing
+ * a queue entry. Adding a process-unique segment makes the filename unique
+ * across processes without disturbing the timestamp-first sort order.
+ */
+const PROCESS_NONCE = randomBytes(4).toString("hex");
+
+/**
  * Enqueues a git operation for Worker processing.
  * Each entry is written as a separate file to avoid concurrent-write conflicts.
- * Filename format: `{timestamp}-{seq}-{tag}.json` ensures correct processing
- * order even when multiple enqueues land in the same millisecond.
+ * Filename format: `{timestamp}-{seq}-{nonce}-{tag}.json`. The `{timestamp}`
+ * prefix drives the chronological drain sort; `{seq}` + `{nonce}` only guarantee
+ * uniqueness (within and across processes) for same-millisecond enqueues.
  *
  * Tag is `hash8` for commit operations and `ingest` for ingest operations —
  * both fit the existing chronological-sort drain logic.
@@ -584,7 +596,7 @@ export async function enqueueGitOperation(op: GitOperation, cwd?: string): Promi
 
 		const timestamp = Date.now();
 		const seq = (++enqueueSeq).toString().padStart(8, "0");
-		const fileName = `${timestamp}-${seq}-${tag}.json`;
+		const fileName = `${timestamp}-${seq}-${PROCESS_NONCE}-${tag}.json`;
 		await atomicWrite(join(queueDir, fileName), JSON.stringify(op, null, "\t"));
 		log.info("Enqueued queue operation: type=%s tag=%s file=%s", op.type, tag, fileName);
 		return true;

--- a/cli/src/core/SourceContent.ts
+++ b/cli/src/core/SourceContent.ts
@@ -6,7 +6,6 @@
  * which is passed the same read-side `storage` so it reads the folder view too.
  */
 
-import { createHash } from "node:crypto";
 import { readFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { createLogger } from "../Logger.js";
@@ -14,6 +13,7 @@ import { loadFolderPlanNoteContent, loadFolderPlanNoteHeadline } from "./FolderP
 import { FolderStorage } from "./FolderStorage.js";
 import { formatSummaryForCompile } from "./KnowledgeCompiler.js";
 import { listAllUserKnowledge } from "./MemoryBankScanner.js";
+import { MetadataManager } from "./MetadataManager.js";
 import { loadPlansRegistry } from "./SessionTracker.js";
 import { formatSourceHeadline } from "./SourceHeadline.js";
 import type { StorageProvider } from "./StorageProvider.js";
@@ -69,8 +69,17 @@ export async function loadSourceContent(
 				// fingerprint check → null → it resurfaces as a fresh pending source.
 				const content = await readTextOrNull(join(dirname(kbRoot), path));
 				if (content === null) return null;
-				const fp = createHash("sha256").update(content, "utf-8").digest("hex");
-				return fp === fingerprint ? content : null;
+				// Shared helper (NOT an inline createHash) so this verify hash can't
+				// drift from the one MemoryBankScanner stamped into the ref id.
+				const fp = MetadataManager.sha256(content);
+				if (fp !== fingerprint) {
+					// Not silent: surface the changed-since-scan case so a file that
+					// keeps re-ingesting is diagnosable. It resurfaces as a fresh
+					// pending source next batch under its new fingerprint.
+					log.warn("Userfile %s changed since scan (fingerprint mismatch) — skipped this batch", path);
+					return null;
+				}
+				return content;
 			}
 			// Orphan-only fallback: no kbRoot, so resolve via the cwd-based scan.
 			const files = await listAllUserKnowledge(cwd);

--- a/cli/src/core/StorageProvider.ts
+++ b/cli/src/core/StorageProvider.ts
@@ -61,18 +61,6 @@ export interface StorageProvider {
 	isDirty?(): boolean;
 
 	/**
-	 * Optional: return mtime for a stored file, for callers that need recency
-	 * ordering of stored artifacts.
-	 *
-	 * Only meaningful for backends with a real filesystem layer
-	 * (FolderStorage). OrphanBranchStorage does not implement this — its
-	 * callers fall back to JSON-embedded timestamps.
-	 *
-	 * Returns `null` when the file does not exist or stat fails.
-	 */
-	statFile?(path: string): Promise<{ readonly mtimeMs: number } | null>;
-
-	/**
 	 * Remove the user-visible Markdown copy for a single summary entry.
 	 * Does NOT touch .jolli/summaries/<hash>.json, .jolli/index.json, or any
 	 * orphan-branch state. Idempotent: a missing file is not an error.
@@ -180,6 +168,19 @@ export interface StorageProvider {
 	 * leaves it undefined (no visible layer to recover).
 	 */
 	isTopicWikiPresent?(): boolean;
+
+	/**
+	 * Absolute path to this provider's per-repo Memory Bank root (`<localFolder>/
+	 * <repo>`), when folder-backed. The disposable search index is keyed off this
+	 * so it lives ALONGSIDE the data it indexes: the `jolli compile` sweep (which
+	 * runs with folder storage rooted here) and the MCP server (which runs in the
+	 * git checkout but resolves the SAME folder root in dual-write/folder mode)
+	 * then agree on the index location, instead of the sweep warming an index the
+	 * MCP server can't find. Folder-backed providers implement it; DualWriteStorage
+	 * delegates to its folder backend; orphan-only leaves it undefined (the index
+	 * falls back to the checkout's `.jolli/jollimemory/`).
+	 */
+	readonly kbRoot?: string;
 }
 
 /** Options for a heal-missing-markdown pass. */

--- a/cli/src/hooks/PostMergeHook.test.ts
+++ b/cli/src/hooks/PostMergeHook.test.ts
@@ -112,7 +112,7 @@ describe("handlePostMerge", () => {
 
 		// SP3: one ingest op total, not one compile op per branch
 		expect(mockEnqueueIngest).toHaveBeenCalledOnce();
-		expect(mockEnqueueIngest).toHaveBeenCalledWith("/test", "post-merge");
+		expect(mockEnqueueIngest).toHaveBeenCalledWith("/test", "post-merge", { force: true });
 		// Worker is launched once for the entire pull range
 		expect(mockLaunchWorker).toHaveBeenCalledOnce();
 	});
@@ -146,7 +146,7 @@ describe("handlePostMerge", () => {
 		await handlePostMerge("/test");
 
 		expect(mockEnqueueIngest).toHaveBeenCalledOnce();
-		expect(mockEnqueueIngest).toHaveBeenCalledWith("/test", "post-merge");
+		expect(mockEnqueueIngest).toHaveBeenCalledWith("/test", "post-merge", { force: true });
 		expect(mockLaunchWorker).toHaveBeenCalledOnce();
 	});
 
@@ -170,7 +170,7 @@ describe("handlePostMerge", () => {
 		await handlePostMerge("/test");
 
 		expect(mockEnqueueIngest).toHaveBeenCalledOnce();
-		expect(mockEnqueueIngest).toHaveBeenCalledWith("/test", "post-merge");
+		expect(mockEnqueueIngest).toHaveBeenCalledWith("/test", "post-merge", { force: true });
 		expect(mockLaunchWorker).toHaveBeenCalledOnce();
 	});
 
@@ -188,7 +188,26 @@ describe("handlePostMerge", () => {
 		expect(mockEnqueueIngest).not.toHaveBeenCalled();
 	});
 
-	it("does not launch the worker when the ingest enqueue is refused", async () => {
+	it("skips when the reflog is unavailable, HEAD is a merge, but the subject fetch fails", async () => {
+		// Fallback path: HEAD@{1} fatals, %P confirms a merge (≥2 parents), but the
+		// %s subject lookup itself errors. detectMergeAtHead returns "" rather than a
+		// bogus subject, so the hook treats it as "no merge" and skips cleanly.
+		mockExecGit.mockImplementation(async (args: readonly string[]) => {
+			const cmd = args.join(" ");
+			if (cmd.includes("HEAD@{1}..HEAD")) return { stdout: "", stderr: "fatal", exitCode: 128 };
+			if (cmd.includes("%P")) return { stdout: "parent1 parent2", stderr: "", exitCode: 0 };
+			if (cmd.includes("%s")) return { stdout: "", stderr: "fatal", exitCode: 1 };
+			return { stdout: "", stderr: "", exitCode: 0 };
+		});
+
+		await handlePostMerge("/test");
+
+		expect(mockLoadConfig).not.toHaveBeenCalled();
+		expect(mockEnqueueIngest).not.toHaveBeenCalled();
+		expect(mockLaunchWorker).not.toHaveBeenCalled();
+	});
+
+	it("does not launch the worker when the ingest enqueue fails", async () => {
 		mockExecGit.mockResolvedValue({
 			stdout: "Merge branch 'feature/x' into main",
 			stderr: "",

--- a/cli/src/hooks/PostMergeHook.ts
+++ b/cli/src/hooks/PostMergeHook.ts
@@ -8,8 +8,11 @@
  * under the same lock as commit summaries.
  *
  * SP3 — collapses N per-branch compile enqueues to ONE repo-wide ingest op.
- * A single `git pull` with N merge commits enqueues a single ingest operation;
- * IngestTrigger's cooldown dedupes rapid pull clusters to one drain.
+ * A single `git pull` with N merge commits enqueues a single ingest operation.
+ * The enqueue is `force`d past IngestTrigger's per-cwd cooldown: a merge brings
+ * in genuinely new content (commits authored elsewhere), so it must not be
+ * suppressed by a cooldown a local commit just set. The repo-wide ingest op is
+ * idempotent, so the occasional duplicate drain is benign.
  */
 
 import { execGit } from "../core/GitOps.js";
@@ -114,10 +117,12 @@ export async function handlePostMerge(cwd: string): Promise<void> {
 	}
 
 	// SP3: collapse N per-branch compile enqueues to ONE repo-wide ingest op.
-	// IngestTrigger's per-cwd cooldown dedupes rapid pull clusters to one drain.
-	const enqueued = await enqueueIngestOperation(cwd, "post-merge");
+	// `force` past the cooldown — a merge brings in new commits that a recent
+	// local-commit cooldown must not suppress (the merged content would stay
+	// un-ingested until the window expired and some later trigger fired).
+	const enqueued = await enqueueIngestOperation(cwd, "post-merge", { force: true });
 	if (!enqueued) {
-		log.info("Ingest enqueue refused (within cooldown or failed) — worker not started");
+		log.info("Ingest enqueue failed — worker not started");
 		return;
 	}
 

--- a/cli/src/hooks/QueueWorker.test.ts
+++ b/cli/src/hooks/QueueWorker.test.ts
@@ -65,6 +65,7 @@ vi.mock("../core/Locks.js", () => ({
 	// Passthrough: run the RMW body without touching the real lock file. The
 	// per-worktree lock contract itself is covered in Locks.test.ts.
 	withPlansLock: (_cwd: string | undefined, fn: () => Promise<unknown>) => fn(),
+	WORKER_PHASE_FILE: "worker-phase",
 }));
 
 // `vault-write.lock` integration: the Standalone Hotfix now wraps the worker
@@ -335,7 +336,9 @@ vi.spyOn(console, "warn").mockImplementation(() => {});
 vi.spyOn(console, "error").mockImplementation(() => {});
 
 import { spawn } from "node:child_process";
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { isCodexInstalled } from "../core/CodexSessionDiscoverer.js";
 import { isCopilotChatInstalled } from "../core/CopilotChatDetector.js";
 import { discoverCopilotChatSessions } from "../core/CopilotChatSessionDiscoverer.js";
@@ -2160,6 +2163,40 @@ describe("QueueWorker", () => {
 		});
 	});
 
+	describe("runWorker — stale phase cleanup on lock acquisition", () => {
+		it("removes a worker-phase file left by a crashed worker when it acquires the lock", async () => {
+			const tmp = mkdtempSync(join(tmpdir(), "jolli-stalephase-"));
+			mkdirSync(join(tmp, ".jolli", "jollimemory"), { recursive: true });
+			const phaseFile = join(tmp, ".jolli", "jollimemory", "worker-phase");
+			// Simulate crash residue: a previous worker was SIGKILL'd mid-ingest, so
+			// its `finally` cleanup never ran and the 'ingest' marker persists.
+			writeFileSync(phaseFile, "ingest");
+
+			const { existsSync: realExistsSync } = await vi.importActual<typeof import("node:fs")>("node:fs");
+			expect(realExistsSync(phaseFile)).toBe(true);
+
+			// Minimal storage so setActiveStorage() has something to hold; empty
+			// queue so the worker just acquires the lock and drains nothing.
+			vi.mocked(createStorage).mockResolvedValue({
+				readFile: vi.fn().mockResolvedValue(null),
+				writeFiles: vi.fn().mockResolvedValue(undefined),
+				listFiles: vi.fn().mockResolvedValue([]),
+				exists: vi.fn().mockResolvedValue(true),
+				ensure: vi.fn().mockResolvedValue(undefined),
+			} as never);
+			vi.mocked(dequeueAllGitOperations).mockResolvedValue([]);
+
+			await runWorker(tmp);
+
+			// The fresh worker holds the lock, proving the previous one is gone, so
+			// the stale marker is cleared at the source — not left to mislabel the
+			// next genuine summary run as "Updating Memory Bank…".
+			expect(realExistsSync(phaseFile)).toBe(false);
+
+			rmSync(tmp, { recursive: true, force: true });
+		});
+	});
+
 	describe("runWorker — ingest dispatch", () => {
 		function makeIngestOp(triggeredBy: IngestOperation["triggeredBy"] = "post-merge"): IngestOperation {
 			return { type: "ingest", triggeredBy, createdAt: new Date().toISOString() };
@@ -2181,6 +2218,53 @@ describe("QueueWorker", () => {
 		// case. Per-test overrides drive the wiki-missing recovery path.
 		beforeEach(() => {
 			vi.mocked(createStorage).mockResolvedValue(storageWithWiki(true));
+		});
+
+		it("writes worker-phase=ingest during ingest and removes it after", async () => {
+			const tmp = mkdtempSync(join(tmpdir(), "jolli-phase-"));
+			mkdirSync(join(tmp, ".jolli", "jollimemory"), { recursive: true });
+			const phaseFile = join(tmp, ".jolli", "jollimemory", "worker-phase");
+
+			// Use the actual fs functions so we can observe real disk writes from
+			// production code (writeFileSync / rmSync are actual in the mock spread).
+			const { existsSync: realExistsSync, readFileSync: realReadFileSync } =
+				await vi.importActual<typeof import("node:fs")>("node:fs");
+			vi.mocked(existsSync).mockImplementation(realExistsSync);
+			vi.mocked(readFileSync).mockImplementation(realReadFileSync as typeof readFileSync);
+
+			vi.mocked(loadConfig).mockResolvedValue({ apiKey: "sk-test" } as never);
+			let phaseSeenDuringIngest: string | null = null;
+			vi.mocked(drainIngest).mockImplementation(async () => {
+				phaseSeenDuringIngest = existsSync(phaseFile) ? readFileSync(phaseFile, "utf-8") : null;
+				return { batches: 1, ingested: 2, outcome: "OK", topicFailures: [] };
+			});
+
+			await __test__.processQueueEntry(makeIngestOp("post-merge"), tmp, storageWithWiki(true), false);
+
+			expect(phaseSeenDuringIngest).toBe("ingest");
+			expect(existsSync(phaseFile)).toBe(false);
+
+			rmSync(tmp, { recursive: true, force: true });
+		});
+
+		it("removes worker-phase even when ingest throws", async () => {
+			const tmp = mkdtempSync(join(tmpdir(), "jolli-phase-"));
+			mkdirSync(join(tmp, ".jolli", "jollimemory"), { recursive: true });
+			const phaseFile = join(tmp, ".jolli", "jollimemory", "worker-phase");
+
+			const { existsSync: realExistsSync } = await vi.importActual<typeof import("node:fs")>("node:fs");
+			vi.mocked(existsSync).mockImplementation(realExistsSync);
+
+			vi.mocked(loadConfig).mockResolvedValue({ apiKey: "sk-test" } as never);
+			vi.mocked(drainIngest).mockRejectedValue(new Error("boom"));
+
+			await expect(
+				__test__.processQueueEntry(makeIngestOp("post-merge"), tmp, storageWithWiki(true), false),
+			).rejects.toThrow("boom");
+
+			expect(existsSync(phaseFile)).toBe(false);
+
+			rmSync(tmp, { recursive: true, force: true });
 		});
 
 		it("routes an ingest op to drainIngest and renderTopicKBWiki when API key is configured", async () => {

--- a/cli/src/hooks/QueueWorker.ts
+++ b/cli/src/hooks/QueueWorker.ts
@@ -17,7 +17,7 @@
  */
 
 import { createHash } from "node:crypto";
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { basename, dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { discoverCodexSessions, isCodexInstalled } from "../core/CodexSessionDiscoverer.js";
@@ -35,7 +35,13 @@ import { readCursorTranscript } from "../core/CursorTranscriptReader.js";
 import { readGeminiTranscript } from "../core/GeminiTranscriptReader.js";
 import { getCommitInfo, getCurrentBranch, getDiffContent, getDiffStats } from "../core/GitOps.js";
 import { enqueueIngestOperation } from "../core/IngestTrigger.js";
-import { acquireWorkerLock, refreshWorkerLockMtime, releaseWorkerLock, withPlansLock } from "../core/Locks.js";
+import {
+	acquireWorkerLock,
+	refreshWorkerLockMtime,
+	releaseWorkerLock,
+	WORKER_PHASE_FILE,
+	withPlansLock,
+} from "../core/Locks.js";
 import { formatNotesBlock } from "../core/NotePromptFormatter.js";
 import { discoverOpenCodeSessions, isOpenCodeInstalled } from "../core/OpenCodeSessionDiscoverer.js";
 import { readOpenCodeTranscript } from "../core/OpenCodeTranscriptReader.js";
@@ -92,7 +98,7 @@ import { getParserForSource } from "../core/TranscriptParser.js";
 import type { SessionTranscript } from "../core/TranscriptReader.js";
 import { buildMultiSessionContext, readTranscript } from "../core/TranscriptReader.js";
 import { deriveSourceTag } from "../install/DistPathResolver.js";
-import { createLogger, errMsg, setLogDir, setLogLevel } from "../Logger.js";
+import { createLogger, errMsg, getJolliMemoryDir, setLogDir, setLogLevel } from "../Logger.js";
 import { consumePendingWorkers, recordPendingWorker } from "../sync/PendingWorkers.js";
 import { deriveMemoryBankRoot } from "../sync/SyncBootstrap.js";
 import { acquireVaultWriteLock, DEFAULT_VAULT_WRITE_WAIT_MS } from "../sync/VaultWriteLock.js";
@@ -380,6 +386,20 @@ export async function runWorker(cwd: string, force = false): Promise<void> {
 			return;
 		}
 
+		// Clear a stale `worker-phase` marker at the source. Holding worker.lock
+		// proves no other worker for this repo is alive, so any leftover phase file
+		// was orphaned by a crashed/SIGKILL'd predecessor whose `finally` cleanup
+		// (in processQueueEntry) never ran. Removing it here keeps the file's
+		// lifetime genuinely lock-bound — otherwise it survives indefinitely and
+		// mislabels the next plain summary run as "Updating Memory Bank…".
+		try {
+			rmSync(join(getJolliMemoryDir(cwd), WORKER_PHASE_FILE), { force: true });
+		} catch (e) {
+			/* v8 ignore start -- best-effort cleanup; only an EPERM-class error reaches here and is non-fatal */
+			log.debug("stale worker-phase cleanup skipped (non-fatal): %s", errMsg(e));
+			/* v8 ignore stop */
+		}
+
 		// Periodically bump the worker.lock mtime — same rationale as
 		// vault-write.lock above.
 		/* v8 ignore start -- setInterval's lambda only fires on a real timer tick; unit tests finish in milliseconds and never observe the callback. */
@@ -499,7 +519,27 @@ async function processQueueEntry(
 	// No commit-hash or branch field; dispatch and return before commit-only code.
 	if (isIngestOperation(op)) {
 		log.info("Processing queue entry: type=ingest triggeredBy=%s", op.triggeredBy);
-		await runIngestFromQueue(op, cwd, storage);
+		// Cosmetic phase marker so the VS Code toolbar shows "Updating Memory
+		// Bank…" instead of "AI summary in progress…" during the (potentially
+		// ~80s) topic-KB ingest. Best-effort: a write/delete failure must never
+		// break ingest, so both ends are wrapped and logged at debug only.
+		const phaseFile = join(getJolliMemoryDir(cwd), WORKER_PHASE_FILE);
+		try {
+			writeFileSync(phaseFile, "ingest");
+		} catch (e) {
+			/* v8 ignore next -- best-effort cosmetic marker; write failure is non-fatal */
+			log.debug("worker-phase write skipped (non-fatal): %s", errMsg(e));
+		}
+		try {
+			await runIngestFromQueue(op, cwd, storage);
+		} finally {
+			try {
+				rmSync(phaseFile, { force: true });
+			} catch (e) {
+				/* v8 ignore next -- best-effort cosmetic marker; cleanup failure is non-fatal */
+				log.debug("worker-phase cleanup skipped (non-fatal): %s", errMsg(e));
+			}
+		}
 		return;
 	}
 

--- a/cli/src/install/Installer.test.ts
+++ b/cli/src/install/Installer.test.ts
@@ -43,6 +43,20 @@ vi.mock("../core/GeminiSessionDetector.js", () => ({
 	isGeminiInstalled: vi.fn().mockResolvedValue(false),
 }));
 
+// Partial mock of McpRegistration: keep the REAL register/remove implementations
+// (they operate on the temp dir's .mcp.json) but wrap them in vi.fn so a single
+// test can force `removeMcpFromClaude` to reject and assert uninstall still
+// proceeds. `clearMocks: true` only clears call history, so the real impl given
+// to vi.fn() survives across tests.
+vi.mock("./McpRegistration.js", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("./McpRegistration.js")>();
+	return {
+		...actual,
+		registerMcpInClaude: vi.fn(actual.registerMcpInClaude),
+		removeMcpFromClaude: vi.fn(actual.removeMcpFromClaude),
+	};
+});
+
 // Mock OpenCodeSessionDiscoverer for status/install checks
 vi.mock("../core/OpenCodeSessionDiscoverer.js", () => ({
 	isOpenCodeInstalled: vi.fn().mockResolvedValue(false),
@@ -882,6 +896,28 @@ describe("Installer", () => {
 			const content = await readFile(settingsPath, "utf-8");
 			const settings = JSON.parse(content);
 			expect(settings.hooks).toBeUndefined();
+		});
+
+		it("continues removing git hooks when removeMcpFromClaude throws (e.g. read-only .mcp.json)", async () => {
+			await install(tempDir);
+			const postRewritePath = join(tempDir, ".git", "hooks", "post-rewrite");
+			// Sanity: the hook is installed before uninstall.
+			expect(await readFile(postRewritePath, "utf-8")).toContain("JolliMemory");
+
+			// Force the MCP cleanup to fail for this worktree, as it would on an
+			// EPERM / read-only .mcp.json. The install side already treats this as
+			// non-fatal; uninstall must too, or the git hooks leak and post-commit
+			// keeps firing after the user thinks they've uninstalled.
+			const { removeMcpFromClaude } = await import("./McpRegistration.js");
+			vi.mocked(removeMcpFromClaude).mockRejectedValueOnce(new Error("EPERM: read-only .mcp.json"));
+
+			const result = await uninstall(tempDir);
+			expect(result.success).toBe(true);
+
+			// The post-rewrite git hook must still have been removed despite the
+			// MCP failure earlier in the same uninstall run.
+			const { stat } = await import("node:fs/promises");
+			await expect(stat(postRewritePath)).rejects.toThrow();
 		});
 
 		it("should use process.cwd() when uninstall is called without cwd", async () => {

--- a/cli/src/install/Installer.ts
+++ b/cli/src/install/Installer.ts
@@ -81,6 +81,7 @@ import {
 	removePrepareMsgHook,
 } from "./GitHookInstaller.js";
 import type { HookOpResult } from "./HookSettingsHelper.js";
+import { MCP_GIT_EXCLUDE_PATH, registerMcpInClaude, removeMcpFromClaude } from "./McpRegistration.js";
 import { SKILL_GIT_EXCLUDE_PATHS, updateSkillIfNeeded } from "./SkillInstaller.js";
 
 // ─── Re-exports for backward compatibility ──────────────────────────────────
@@ -205,10 +206,12 @@ export async function install(cwd?: string, options?: { source?: "vscode-extensi
 			// We update SKILL.md before the Claude-hook gate below so disabling
 			// Claude doesn't strand the `.agents/` skills target unupdated.
 			await updateSkillIfNeeded(wt, { claudeEnabled: config.claudeEnabled });
-			// Keep the user's `git status` clean by adding Jolli-managed skill
-			// paths to `.git/info/exclude`. Worktree-aware: linked worktrees
-			// may have their own gitdir, so we resolve per-worktree.
-			await updateGitExclude(wt, SKILL_GIT_EXCLUDE_PATHS);
+			// Keep the user's `git status` clean by adding Jolli-managed paths to
+			// `.git/info/exclude`. Worktree-aware: linked worktrees may have their
+			// own gitdir, so we resolve per-worktree. `.mcp.json` is included
+			// because registerMcpInClaude (below) writes it with a machine-local
+			// absolute path that must never be committed.
+			await updateGitExclude(wt, [...SKILL_GIT_EXCLUDE_PATHS, MCP_GIT_EXCLUDE_PATH]);
 
 			if (config.claudeEnabled === false) continue;
 			const result = await installClaudeHook(wt);
@@ -223,6 +226,13 @@ export async function install(cwd?: string, options?: { source?: "vscode-extensi
 			}
 			// Install SessionStart hook for auto-briefing
 			await installSessionStartHook(wt);
+			// Register the MCP server for AI agents (Claude Code project config).
+			// Non-fatal: a failure here must not block hook installation.
+			try {
+				await registerMcpInClaude(wt);
+			} catch (mcpErr) {
+				log.warn("MCP registration failed in %s (non-fatal): %s", wt, (mcpErr as Error).message);
+			}
 		}
 
 		// Git hooks are shared across all worktrees — install once
@@ -498,6 +508,15 @@ export async function uninstall(cwd?: string): Promise<InstallResult> {
 			}
 			/* v8 ignore stop */
 			await removeGeminiHook(wt);
+			// Non-fatal, mirroring the install side: a failure here (e.g. EPERM on a
+			// read-only .mcp.json) must not abort the uninstall, or the shared git
+			// hooks below would leak and post-commit would keep firing after the
+			// user believes they've uninstalled.
+			try {
+				await removeMcpFromClaude(wt);
+			} catch (mcpErr) {
+				log.warn("MCP removal failed in %s (non-fatal): %s", wt, (mcpErr as Error).message);
+			}
 		}
 
 		// Git hooks are shared — remove once from the common hooks directory

--- a/cli/src/install/McpRegistration.test.ts
+++ b/cli/src/install/McpRegistration.test.ts
@@ -1,0 +1,133 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mcpServerEntry, registerMcpInClaude, removeMcpFromClaude, resolveCliJs } from "./McpRegistration.js";
+
+let dir: string;
+beforeEach(async () => {
+	dir = await mkdtemp(join(tmpdir(), "jolli-mcp-reg-"));
+});
+afterEach(async () => {
+	await rm(dir, { recursive: true, force: true });
+});
+
+describe("registerMcpInClaude", () => {
+	it("creates .mcp.json with a jollimemory server entry", async () => {
+		await registerMcpInClaude(dir);
+		const raw = await readFile(join(dir, ".mcp.json"), "utf-8");
+		const json = JSON.parse(raw);
+		expect(json.mcpServers.jollimemory).toBeDefined();
+		expect(Array.isArray(json.mcpServers.jollimemory.args)).toBe(true);
+		expect(json.mcpServers.jollimemory.args).toContain("mcp");
+	});
+
+	it("takes the Windows branch (node command) without throwing", async () => {
+		// Exercises the win32 path of registerMcpInClaude (resolveCliJs + entry
+		// selection). The exact command depends on whether a dist path is resolvable
+		// on the host, so we only assert a well-formed entry — the command logic
+		// itself is asserted by the mcpServerEntry unit tests.
+		const original = process.platform;
+		Object.defineProperty(process, "platform", { value: "win32", configurable: true });
+		try {
+			await registerMcpInClaude(dir);
+			const json = JSON.parse(await readFile(join(dir, ".mcp.json"), "utf-8"));
+			expect(json.mcpServers.jollimemory.args).toContain("mcp");
+		} finally {
+			Object.defineProperty(process, "platform", { value: original, configurable: true });
+		}
+	});
+
+	it("preserves existing servers and is idempotent", async () => {
+		await writeFile(join(dir, ".mcp.json"), JSON.stringify({ mcpServers: { other: { command: "x" } } }), "utf-8");
+		await registerMcpInClaude(dir);
+		await registerMcpInClaude(dir); // second call must not duplicate or corrupt
+		const json = JSON.parse(await readFile(join(dir, ".mcp.json"), "utf-8"));
+		expect(json.mcpServers.other).toBeDefined();
+		expect(json.mcpServers.jollimemory).toBeDefined();
+	});
+
+	it("leaves a malformed-but-non-empty .mcp.json untouched (never clobbers the user's other servers)", async () => {
+		// Regression: a parse failure on an EXISTING file must not be treated like an
+		// absent file. Overwriting it would silently drop every other MCP server the
+		// user had configured. We leave the file byte-for-byte as-is and skip.
+		const malformed = '{ "mcpServers": { "other": { "command": "x" } },\n'; // trailing comma, unterminated
+		await writeFile(join(dir, ".mcp.json"), malformed, "utf-8");
+		await registerMcpInClaude(dir);
+		const raw = await readFile(join(dir, ".mcp.json"), "utf-8");
+		expect(raw).toBe(malformed); // untouched — not overwritten with a jollimemory-only config
+	});
+});
+
+describe("mcpServerEntry", () => {
+	const runCli = "/home/u/.jolli/jollimemory/run-cli";
+	const cliJs = "/abs/dist/Cli.js";
+
+	it("uses the run-cli shell wrapper on POSIX", () => {
+		// run-cli has a shebang + is +x, so a direct spawn honors it on macOS/Linux.
+		expect(mcpServerEntry("darwin", runCli, cliJs)).toEqual({ command: runCli, args: ["mcp"] });
+		expect(mcpServerEntry("linux", runCli, cliJs)).toEqual({ command: runCli, args: ["mcp"] });
+	});
+
+	it("spawns node on the resolved Cli.js on Windows (run-cli is an unexecutable bash script there)", () => {
+		// The MCP host spawns `command` directly (no shell), so a no-extension bash
+		// script is ENOENT on Windows. node.exe is on PATH (hooks already require it).
+		expect(mcpServerEntry("win32", runCli, cliJs)).toEqual({ command: "node", args: [cliJs, "mcp"] });
+	});
+
+	it("falls back to run-cli on Windows when the dist Cli.js can't be resolved", () => {
+		// Best effort: nothing better to point at, and re-registration will fix it
+		// once a dist path is known.
+		expect(mcpServerEntry("win32", runCli, undefined)).toEqual({ command: runCli, args: ["mcp"] });
+	});
+});
+
+describe("resolveCliJs", () => {
+	it("returns the winning dist's Cli.js", async () => {
+		const distDir = await mkdtemp(join(tmpdir(), "jolli-dist-"));
+		const globalDir = await mkdtemp(join(tmpdir(), "jolli-global-"));
+		try {
+			await mkdir(join(globalDir, "dist-paths"), { recursive: true });
+			// dist-path file format: line 1 = version, line 2 = existing dist dir.
+			await writeFile(join(globalDir, "dist-paths", "cli"), `1.2.3\n${distDir}\n`, "utf-8");
+			expect(resolveCliJs(globalDir)).toBe(join(distDir, "Cli.js"));
+		} finally {
+			await rm(distDir, { recursive: true, force: true });
+			await rm(globalDir, { recursive: true, force: true });
+		}
+	});
+
+	it("returns undefined when no dist path is registered", async () => {
+		const globalDir = await mkdtemp(join(tmpdir(), "jolli-global-"));
+		try {
+			expect(resolveCliJs(globalDir)).toBeUndefined();
+		} finally {
+			await rm(globalDir, { recursive: true, force: true });
+		}
+	});
+});
+
+describe("removeMcpFromClaude", () => {
+	it("removes only the jollimemory entry", async () => {
+		await writeFile(
+			join(dir, ".mcp.json"),
+			JSON.stringify({ mcpServers: { other: { command: "x" }, jollimemory: { command: "y" } } }),
+			"utf-8",
+		);
+		await removeMcpFromClaude(dir);
+		const json = JSON.parse(await readFile(join(dir, ".mcp.json"), "utf-8"));
+		expect(json.mcpServers.jollimemory).toBeUndefined();
+		expect(json.mcpServers.other).toBeDefined();
+	});
+
+	it("no-ops when .mcp.json is absent", async () => {
+		await expect(removeMcpFromClaude(dir)).resolves.toBeUndefined();
+	});
+
+	it("no-ops when the file exists but has no jollimemory entry", async () => {
+		await writeFile(join(dir, ".mcp.json"), JSON.stringify({ mcpServers: { other: { command: "x" } } }), "utf-8");
+		await removeMcpFromClaude(dir);
+		const json = JSON.parse(await readFile(join(dir, ".mcp.json"), "utf-8"));
+		expect(json.mcpServers.other).toBeDefined();
+	});
+});

--- a/cli/src/install/McpRegistration.ts
+++ b/cli/src/install/McpRegistration.ts
@@ -1,0 +1,112 @@
+/**
+ * Auto-registration of the JolliMemory MCP server into a worktree's `.mcp.json`
+ * (Claude Code project config), JOLLI-1226 P0. Idempotent; preserves other
+ * servers. Uses the same global `run-cli` entry script as the CLI/skills so
+ * version bumps don't strand the registration.
+ */
+
+import { readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { getGlobalConfigDir } from "../core/SessionTracker.js";
+import { createLogger } from "../Logger.js";
+import { pickBestDistPath, traverseDistPaths } from "./DistPathResolver.js";
+
+const log = createLogger("McpRegistration");
+const SERVER_KEY = "jollimemory";
+
+interface McpServerEntry {
+	command: string;
+	args: string[];
+}
+
+/**
+ * The `command`/`args` an MCP host should spawn to start the server.
+ *
+ * The MCP host spawns `command` DIRECTLY (no shell), so the platform matters:
+ * - POSIX: the `run-cli` dispatch script has a `#!/bin/bash` shebang and is +x,
+ *   so a direct spawn honors it — and we keep the dist-path indirection (a
+ *   version bump that moves the dist still resolves at spawn time).
+ * - Windows: `run-cli` is an extension-less bash script; a direct spawn is
+ *   ENOENT (no shebang support, not on PATHEXT). So we spawn `node` (already a
+ *   hard requirement for the hooks, hence on PATH) on the resolved `Cli.js`.
+ *   This bakes in an absolute path, but `registerMcpInClaude` re-runs on every
+ *   install/activate, so a moved dist is re-resolved then. If the dist can't be
+ *   resolved yet, fall back to `run-cli` rather than write a broken entry.
+ */
+export function mcpServerEntry(platform: NodeJS.Platform, runCli: string, cliJs: string | undefined): McpServerEntry {
+	if (platform === "win32" && cliJs) return { command: "node", args: [cliJs, "mcp"] };
+	return { command: runCli, args: ["mcp"] };
+}
+
+/**
+ * Absolute path to the winning dist's `Cli.js` — the same dist `run-cli` would
+ * resolve at runtime (highest available version across registered sources).
+ * Returns undefined if no dist path is registered/available yet. `globalDir` is
+ * injectable for tests; production passes the machine-global config dir.
+ */
+export function resolveCliJs(globalDir?: string): string | undefined {
+	const best = pickBestDistPath(traverseDistPaths(globalDir));
+	return best ? join(best.distDir, "Cli.js") : undefined;
+}
+
+/**
+ * Git-exclude path for the auto-written `.mcp.json`. It carries a machine-local
+ * ABSOLUTE `run-cli` path, so it must never be committed — Claude Code's
+ * convention of committing `.mcp.json` for team sharing would otherwise ship a
+ * path that's broken on every other machine/CI. Recorded in `.git/info/exclude`
+ * (gitignore syntax: leading `/` anchors to repo root) alongside the skill paths.
+ */
+export const MCP_GIT_EXCLUDE_PATH = "/.mcp.json";
+
+interface McpConfig {
+	mcpServers?: Record<string, { command: string; args?: string[] }>;
+}
+
+/** Add (or refresh) the jollimemory server entry in <worktreeDir>/.mcp.json. */
+export async function registerMcpInClaude(worktreeDir: string): Promise<void> {
+	const mcpPath = join(worktreeDir, ".mcp.json");
+	let config: McpConfig;
+	try {
+		config = JSON.parse(await readFile(mcpPath, "utf-8")) as McpConfig;
+	} catch (err) {
+		if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+			// The file exists but couldn't be read/parsed (mid-edit, trailing comma,
+			// partial write, EACCES). Resetting to `{}` and writing would silently
+			// drop the user's OTHER MCP servers — so refuse to write and leave the
+			// file untouched. Re-registration on the next install/activate recovers
+			// once the file is valid again.
+			log.warn("Skipping MCP registration: %s exists but is unreadable/invalid (%s)", mcpPath, String(err));
+			return;
+		}
+		config = {}; // no file yet — fine to create a fresh one
+	}
+	const servers = config.mcpServers ?? {};
+
+	// run-cli resolves the active dist path and execs `node <dist>/Cli.js "$@"`,
+	// so passing `mcp` starts the server. Indirection survives version bumps —
+	// but only POSIX can spawn the bash script directly (see mcpServerEntry), so
+	// on Windows we resolve the winning dist's Cli.js and spawn node on it.
+	const globalDir = getGlobalConfigDir();
+	const runCli = join(globalDir, "run-cli");
+	const cliJs = process.platform === "win32" ? resolveCliJs(globalDir) : undefined;
+	servers[SERVER_KEY] = mcpServerEntry(process.platform, runCli, cliJs);
+
+	const next: McpConfig = { ...config, mcpServers: servers };
+	await writeFile(mcpPath, `${JSON.stringify(next, null, 2)}\n`, "utf-8");
+	log.info("Registered MCP server in %s", mcpPath);
+}
+
+/** Remove the jollimemory server entry; no-op if file or entry is absent. */
+export async function removeMcpFromClaude(worktreeDir: string): Promise<void> {
+	const mcpPath = join(worktreeDir, ".mcp.json");
+	let config: McpConfig;
+	try {
+		config = JSON.parse(await readFile(mcpPath, "utf-8")) as McpConfig;
+	} catch {
+		return; // absent or unreadable → nothing to remove
+	}
+	if (!config.mcpServers?.[SERVER_KEY]) return;
+	delete config.mcpServers[SERVER_KEY];
+	await writeFile(mcpPath, `${JSON.stringify(config, null, 2)}\n`, "utf-8");
+	log.info("Removed MCP server from %s", mcpPath);
+}

--- a/cli/src/install/SkillInstaller.test.ts
+++ b/cli/src/install/SkillInstaller.test.ts
@@ -543,4 +543,17 @@ describe("version-line compatibility", () => {
 		// And it now carries the new metadata.version form.
 		expect(readRecall()).toMatch(/metadata:\n {2}version:/);
 	});
+
+	it("rewrites when the existing file has no recognizable version line at all", async () => {
+		// No `version:` / `jolli-skill-version:` / `jollimemory-version:` anywhere
+		// → the version-match regex returns null (the `if (versionMatch)` false
+		// branch) and the installer falls through to a fresh write.
+		const fs = await import("node:fs");
+		const planted = `---\nname: jolli-recall\n---\nbody with no version key`;
+		fs.mkdirSync(join(tempDir, ".claude/skills/jolli-recall"), { recursive: true });
+		fs.writeFileSync(join(tempDir, ".claude/skills/jolli-recall/SKILL.md"), planted, "utf-8");
+		await updateSkillsIfNeeded(tempDir);
+		expect(readRecall()).not.toBe(planted);
+		expect(readRecall()).toMatch(/metadata:\n {2}version:/);
+	});
 });

--- a/cli/src/mcp/DepSmoke.test.ts
+++ b/cli/src/mcp/DepSmoke.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+
+describe("dependency smoke test", () => {
+	it("imports @orama/orama core fns", async () => {
+		const orama = await import("@orama/orama");
+		expect(typeof orama.create).toBe("function");
+		expect(typeof orama.search).toBe("function");
+		expect(typeof orama.insertMultiple).toBe("function");
+	});
+
+	it("imports @orama/plugin-data-persistence", async () => {
+		const p = await import("@orama/plugin-data-persistence");
+		expect(typeof p.persist).toBe("function");
+		expect(typeof p.restore).toBe("function");
+	});
+
+	it("imports MCP SDK Server + stdio transport", async () => {
+		const { Server } = await import("@modelcontextprotocol/sdk/server/index.js");
+		const { StdioServerTransport } = await import("@modelcontextprotocol/sdk/server/stdio.js");
+		expect(typeof Server).toBe("function");
+		expect(typeof StdioServerTransport).toBe("function");
+	});
+});

--- a/cli/src/mcp/McpServer.test.ts
+++ b/cli/src/mcp/McpServer.test.ts
@@ -1,0 +1,167 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("./McpTools.js", () => ({
+	runSearch: vi.fn().mockResolvedValue({ hits: [] }),
+	runRecall: vi.fn().mockResolvedValue({ type: "recall" }),
+	runDecisionTimeline: vi.fn().mockResolvedValue({ timeline: [] }),
+	runListBranches: vi.fn().mockResolvedValue({ branches: [] }),
+}));
+
+const { mockStorage } = vi.hoisted(() => ({ mockStorage: { kind: "mock-storage" } }));
+vi.mock("../core/StorageFactory.js", () => ({ createStorage: vi.fn().mockResolvedValue(mockStorage) }));
+vi.mock("../core/SummaryStore.js", () => ({ setActiveStorage: vi.fn() }));
+
+// Capture the request handlers the server registers so the test can invoke them directly.
+type RequestHandler = (req: { params: { name: string; arguments?: Record<string, unknown> } }) => Promise<unknown>;
+const capturedHandlers: RequestHandler[] = [];
+const connectMock = vi.fn().mockResolvedValue(undefined);
+// Capture the Server constructor's first arg so the test can assert name/version.
+let serverInfo: { name: string; version: string } | undefined;
+
+vi.mock("@modelcontextprotocol/sdk/server/index.js", () => ({
+	Server: class {
+		constructor(info: { name: string; version: string }) {
+			serverInfo = info;
+		}
+		setRequestHandler(_schema: unknown, handler: RequestHandler) {
+			capturedHandlers.push(handler);
+		}
+		connect = connectMock;
+	},
+}));
+
+vi.mock("@modelcontextprotocol/sdk/server/stdio.js", () => ({
+	StdioServerTransport: class {},
+}));
+
+// The SDK request schemas are passed by reference to setRequestHandler; stub them as plain markers.
+vi.mock("@modelcontextprotocol/sdk/types.js", () => ({
+	ListToolsRequestSchema: { kind: "list" },
+	CallToolRequestSchema: { kind: "call" },
+}));
+
+import { VERSION } from "../commands/CliUtils.js";
+import { createStorage } from "../core/StorageFactory.js";
+import { setActiveStorage } from "../core/SummaryStore.js";
+import { dispatchTool, startMcpServer, TOOL_DEFINITIONS } from "./McpServer.js";
+import { runDecisionTimeline, runListBranches, runRecall, runSearch } from "./McpTools.js";
+
+describe("MCP tool registry", () => {
+	it("declares exactly the four P0 tools", () => {
+		expect(TOOL_DEFINITIONS.map((t) => t.name).sort()).toEqual(
+			["get_decision_timeline", "list_branches", "recall", "search"].sort(),
+		);
+	});
+
+	it("each tool has an inputSchema object", () => {
+		for (const t of TOOL_DEFINITIONS) {
+			expect(t.inputSchema.type).toBe("object");
+		}
+	});
+});
+
+describe("dispatchTool", () => {
+	it("routes search to runSearch with parsed args", async () => {
+		await dispatchTool("/repo", "search", { query: "auth" });
+		expect(runSearch).toHaveBeenCalledWith("/repo", { query: "auth" });
+	});
+
+	it("routes list_branches (no args) to runListBranches", async () => {
+		await dispatchTool("/repo", "list_branches", {});
+		expect(runListBranches).toHaveBeenCalledWith("/repo");
+	});
+
+	it("routes recall to runRecall with parsed args", async () => {
+		await dispatchTool("/repo", "recall", { branch: "feat/x" });
+		expect(runRecall).toHaveBeenCalledWith("/repo", { branch: "feat/x" });
+	});
+
+	it("routes get_decision_timeline to runDecisionTimeline with parsed args", async () => {
+		await dispatchTool("/repo", "get_decision_timeline", { slug: "auth-flow" });
+		expect(runDecisionTimeline).toHaveBeenCalledWith("/repo", { slug: "auth-flow" });
+	});
+
+	it("throws on an unknown tool", async () => {
+		await expect(dispatchTool("/repo", "nope", {})).rejects.toThrow(/unknown tool/i);
+	});
+});
+
+describe("startMcpServer", () => {
+	beforeEach(() => {
+		capturedHandlers.length = 0;
+		connectMock.mockClear();
+	});
+
+	it("connects the stdio transport and registers two request handlers", async () => {
+		await startMcpServer("/repo");
+		expect(connectMock).toHaveBeenCalledTimes(1);
+		expect(capturedHandlers).toHaveLength(2);
+	});
+
+	it("ListTools handler returns the tool definitions", async () => {
+		await startMcpServer("/repo");
+		const listHandler = capturedHandlers[0];
+		const result = (await listHandler({ params: { name: "" } })) as { tools: unknown[] };
+		expect(result.tools).toBe(TOOL_DEFINITIONS);
+	});
+
+	it("CallTool handler dispatches a successful tool call to a text response", async () => {
+		await startMcpServer("/repo");
+		const callHandler = capturedHandlers[1];
+		const result = (await callHandler({ params: { name: "search", arguments: { query: "x" } } })) as {
+			content: { type: string; text: string }[];
+			isError?: boolean;
+		};
+		expect(runSearch).toHaveBeenCalledWith("/repo", { query: "x" });
+		expect(result.isError).toBeUndefined();
+		expect(JSON.parse(result.content[0].text)).toEqual({ hits: [] });
+	});
+
+	it("CallTool handler returns an isError response when the handler throws", async () => {
+		vi.mocked(runSearch).mockRejectedValueOnce(new Error("boom"));
+		await startMcpServer("/repo");
+		const callHandler = capturedHandlers[1];
+		const result = (await callHandler({ params: { name: "search", arguments: { query: "x" } } })) as {
+			content: { type: string; text: string }[];
+			isError?: boolean;
+		};
+		expect(result.isError).toBe(true);
+		expect(JSON.parse(result.content[0].text)).toEqual({ error: "boom" });
+	});
+
+	it("CallTool handler stringifies a non-Error throw into the error response", async () => {
+		// A tool that rejects with a bare value (string / object) rather than an
+		// Error — the `String(err)` fallback must still surface a message.
+		// biome-ignore lint/suspicious/noExplicitAny: rejecting with a non-Error value is the point
+		vi.mocked(runSearch).mockRejectedValueOnce("plain string failure" as any);
+		await startMcpServer("/repo");
+		const callHandler = capturedHandlers[1];
+		const result = (await callHandler({ params: { name: "search", arguments: { query: "x" } } })) as {
+			content: { type: string; text: string }[];
+			isError?: boolean;
+		};
+		expect(result.isError).toBe(true);
+		expect(JSON.parse(result.content[0].text)).toEqual({ error: "plain string failure" });
+	});
+
+	it("CallTool handler tolerates a missing arguments field", async () => {
+		await startMcpServer("/repo");
+		const callHandler = capturedHandlers[1];
+		await callHandler({ params: { name: "list_branches" } });
+		expect(runListBranches).toHaveBeenCalledWith("/repo");
+	});
+
+	it("establishes the configured storage backend before serving (so reads don't fall back to orphan)", async () => {
+		// The long-lived server never set active storage, so every store read fell
+		// through resolveStorage to the orphan branch — wrong for folder-mode users
+		// and a per-call WARN in production. Wire the configured backend at startup.
+		await startMcpServer("/repo");
+		expect(createStorage).toHaveBeenCalledWith("/repo", "/repo");
+		expect(setActiveStorage).toHaveBeenCalledWith(mockStorage);
+	});
+
+	it("names the server with the package version, not a hardcoded string", async () => {
+		await startMcpServer("/repo");
+		expect(serverInfo).toMatchObject({ name: "jollimemory", version: VERSION });
+	});
+});

--- a/cli/src/mcp/McpServer.ts
+++ b/cli/src/mcp/McpServer.ts
@@ -1,0 +1,111 @@
+/**
+ * McpServer — exposes JolliMemory's search + context tools to AI agents over an
+ * stdio MCP transport (JOLLI-1226 P0). Pure glue: tool schemas + a dispatch
+ * table over the McpTools handlers. `startMcpServer` is invoked by `jolli mcp`.
+ */
+
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
+import { VERSION } from "../commands/CliUtils.js";
+import { createStorage } from "../core/StorageFactory.js";
+import { setActiveStorage } from "../core/SummaryStore.js";
+import { createLogger } from "../Logger.js";
+import { runDecisionTimeline, runListBranches, runRecall, runSearch } from "./McpTools.js";
+
+const log = createLogger("McpServer");
+
+export interface ToolDefinition {
+	name: string;
+	description: string;
+	inputSchema: { type: "object"; properties: Record<string, unknown>; required?: string[] };
+}
+
+export const TOOL_DEFINITIONS: ToolDefinition[] = [
+	{
+		name: "search",
+		description:
+			"Full-text search over this repo's historical decisions and implementations (topics + commits). Use to check how a topic was handled before.",
+		inputSchema: {
+			type: "object",
+			properties: {
+				query: { type: "string", description: "Natural-language or keyword query." },
+				branch: { type: "string", description: "Optional: restrict to one branch." },
+				type: { type: "string", enum: ["topic", "commit"], description: "Optional: restrict result kind." },
+				limit: { type: "number", description: "Max hits (default 20)." },
+			},
+			required: ["query"],
+		},
+	},
+	{
+		name: "recall",
+		description:
+			"Recall the development context for a branch from raw commit summaries (decisions, plans, notes, commits) — the same data the jolli-recall skill uses, NOT the topic KB. Omit `branch` to recall the current branch.",
+		inputSchema: {
+			type: "object",
+			properties: { branch: { type: "string", description: "Branch to recall; defaults to current." } },
+		},
+	},
+	{
+		name: "get_decision_timeline",
+		description: "Chronological evolution of a topic — its source events ordered oldest-first.",
+		inputSchema: {
+			type: "object",
+			properties: { slug: { type: "string", description: "Topic stableSlug." } },
+			required: ["slug"],
+		},
+	},
+	{
+		name: "list_branches",
+		description: "List all branches that have JolliMemory records, with their topic titles.",
+		inputSchema: { type: "object", properties: {} },
+	},
+];
+
+/** Route a validated tool call to its handler. Throws on unknown tool. */
+export async function dispatchTool(cwd: string, name: string, args: Record<string, unknown>): Promise<unknown> {
+	switch (name) {
+		case "search":
+			return runSearch(
+				cwd,
+				args as { query: string; branch?: string; type?: "topic" | "commit"; limit?: number },
+			);
+		case "recall":
+			return runRecall(cwd, args as { branch?: string });
+		case "get_decision_timeline":
+			return runDecisionTimeline(cwd, args as { slug: string });
+		case "list_branches":
+			return runListBranches(cwd);
+		default:
+			throw new Error(`Unknown tool: ${name}`);
+	}
+}
+
+/** Start the stdio MCP server. Resolves when the transport closes. */
+export async function startMcpServer(cwd: string): Promise<void> {
+	// Establish the configured storage backend up front. The tool handlers read
+	// through the store APIs without threading `storage`, so without this they'd
+	// fall through resolveStorage to the orphan branch — wrong for folder-mode
+	// users and a per-read WARN in this long-lived process.
+	setActiveStorage(await createStorage(cwd, cwd));
+
+	const server = new Server({ name: "jollimemory", version: VERSION }, { capabilities: { tools: {} } });
+
+	server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: TOOL_DEFINITIONS }));
+
+	server.setRequestHandler(CallToolRequestSchema, async (req) => {
+		const { name, arguments: args } = req.params;
+		try {
+			const result = await dispatchTool(cwd, name, args ?? {});
+			return { content: [{ type: "text", text: JSON.stringify(result) }] };
+		} catch (err) {
+			const message = err instanceof Error ? err.message : String(err);
+			log.warn("Tool %s failed: %s", name, message);
+			return { content: [{ type: "text", text: JSON.stringify({ error: message }) }], isError: true };
+		}
+	});
+
+	const transport = new StdioServerTransport();
+	await server.connect(transport);
+	log.info("MCP server connected over stdio (cwd=%s)", cwd);
+}

--- a/cli/src/mcp/McpTools.test.ts
+++ b/cli/src/mcp/McpTools.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../core/SearchIndex.js", () => ({
+	SearchIndex: { openCached: vi.fn() },
+}));
+vi.mock("../core/ContextCompiler.js", () => ({
+	compileTaskContext: vi.fn(),
+	buildRecallPayload: vi.fn(),
+	listBranchCatalog: vi.fn(),
+}));
+vi.mock("../core/TopicPageStore.js", () => ({ readTopicPage: vi.fn() }));
+vi.mock("../core/GitOps.js", () => ({ getCurrentBranch: vi.fn() }));
+vi.mock("../core/SummaryStore.js", () => ({ getActiveStorage: vi.fn() }));
+
+import { buildRecallPayload, compileTaskContext, listBranchCatalog } from "../core/ContextCompiler.js";
+import { getCurrentBranch } from "../core/GitOps.js";
+import { SearchIndex } from "../core/SearchIndex.js";
+import { getActiveStorage } from "../core/SummaryStore.js";
+import { readTopicPage } from "../core/TopicPageStore.js";
+import { runDecisionTimeline, runListBranches, runRecall, runSearch } from "./McpTools.js";
+
+describe("runSearch", () => {
+	it("delegates to SearchIndex.search and returns hits", async () => {
+		const search = vi.fn().mockResolvedValue([{ id: "topic:x", type: "topic", title: "X", score: 1 }]);
+		vi.mocked(SearchIndex.openCached).mockResolvedValue({ search } as never);
+		const out = await runSearch("/repo", { query: "auth", limit: 5 });
+		expect(search).toHaveBeenCalledWith({ query: "auth", limit: 5, branch: undefined, type: undefined });
+		expect(out.hits).toHaveLength(1);
+	});
+
+	it("rejects an empty query with a structured error", async () => {
+		await expect(runSearch("/repo", { query: "" })).rejects.toThrow(/query/i);
+	});
+
+	it("threads the active storage into openCached so the index dir matches the compile warm-up", async () => {
+		// Folder/dual-write users: the index lives at `<kbRoot>/.jolli/jollimemory/`,
+		// resolved from storage.kbRoot. Without passing storage, openCached falls back
+		// to cwd and never sees the warm index. Pin that storage is forwarded.
+		const storage = { kbRoot: "/vault/repo" } as never;
+		vi.mocked(getActiveStorage).mockReturnValue(storage);
+		const search = vi.fn().mockResolvedValue([]);
+		vi.mocked(SearchIndex.openCached).mockResolvedValue({ search } as never);
+		await runSearch("/repo", { query: "auth" });
+		expect(SearchIndex.openCached).toHaveBeenCalledWith("/repo", storage);
+	});
+});
+
+describe("runRecall", () => {
+	it("defaults to the current branch when none given", async () => {
+		vi.mocked(getCurrentBranch).mockResolvedValue("feature/auth");
+		vi.mocked(compileTaskContext).mockResolvedValue({ branch: "feature/auth" } as never);
+		vi.mocked(buildRecallPayload).mockReturnValue({ type: "recall", branch: "feature/auth" } as never);
+		const out = await runRecall("/repo", {});
+		expect(compileTaskContext).toHaveBeenCalledWith({ branch: "feature/auth" }, "/repo");
+		expect(out.branch).toBe("feature/auth");
+	});
+
+	it("uses the explicit branch when provided", async () => {
+		vi.mocked(compileTaskContext).mockResolvedValue({ branch: "main" } as never);
+		vi.mocked(buildRecallPayload).mockReturnValue({ type: "recall", branch: "main" } as never);
+		await runRecall("/repo", { branch: "main" });
+		expect(compileTaskContext).toHaveBeenCalledWith({ branch: "main" }, "/repo");
+	});
+});
+
+describe("runDecisionTimeline", () => {
+	it("sorts a topic's sourceRefs chronologically", async () => {
+		vi.mocked(readTopicPage).mockResolvedValue({
+			title: "Auth",
+			sourceRefs: [
+				{ type: "summary", id: "b", timestamp: "2026-02-01T00:00:00Z", branch: "x" },
+				{ type: "summary", id: "a", timestamp: "2026-01-01T00:00:00Z", branch: "x" },
+			],
+		} as never);
+		const out = await runDecisionTimeline("/repo", { slug: "auth" });
+		expect(out.timeline.map((t) => t.sourceId)).toEqual(["a", "b"]);
+	});
+
+	it("orders mixed-timezone timestamps by instant, not lexically", async () => {
+		// '…+09:00' is the SAME instant as '…Z' minus 9h; a string localeCompare
+		// would order them by suffix and get this wrong. The first ref is the
+		// later instant despite sorting earlier as a raw string.
+		vi.mocked(readTopicPage).mockResolvedValue({
+			title: "Auth",
+			sourceRefs: [
+				{ type: "summary", id: "late", timestamp: "2026-01-01T10:00:00+09:00", branch: "x" },
+				{ type: "summary", id: "early", timestamp: "2026-01-01T00:30:00Z", branch: "x" },
+			],
+		} as never);
+		const out = await runDecisionTimeline("/repo", { slug: "auth" });
+		// 00:30Z (=09:30+09:00) is earlier than 10:00+09:00, so "early" comes first.
+		expect(out.timeline.map((t) => t.sourceId)).toEqual(["early", "late"]);
+	});
+
+	it("throws when the topic does not exist", async () => {
+		vi.mocked(readTopicPage).mockResolvedValue(null);
+		await expect(runDecisionTimeline("/repo", { slug: "missing" })).rejects.toThrow(/not found/i);
+	});
+
+	it("rejects an empty slug", async () => {
+		await expect(runDecisionTimeline("/repo", { slug: "  " })).rejects.toThrow(/slug` is required/i);
+	});
+
+	it("defaults a missing ref branch to an empty string", async () => {
+		vi.mocked(readTopicPage).mockResolvedValue({
+			title: "Auth",
+			sourceRefs: [{ type: "summary", id: "a", timestamp: "2026-01-01T00:00:00Z" }],
+		} as never);
+		const out = await runDecisionTimeline("/repo", { slug: "auth" });
+		expect(out.timeline[0].branch).toBe("");
+	});
+});
+
+describe("runListBranches", () => {
+	it("returns the branch catalog", async () => {
+		vi.mocked(listBranchCatalog).mockResolvedValue({ type: "catalog", branches: [{ branch: "main" }] } as never);
+		const out = await runListBranches("/repo");
+		expect(out.branches).toHaveLength(1);
+	});
+});

--- a/cli/src/mcp/McpTools.ts
+++ b/cli/src/mcp/McpTools.ts
@@ -1,0 +1,79 @@
+/**
+ * Pure MCP tool handlers (JOLLI-1226 P0). Each returns a plain
+ * JSON-serializable object and throws a plain Error on bad input. No MCP SDK
+ * coupling here so the handlers are unit-testable in isolation; McpServer.ts
+ * adapts these into SDK tool responses.
+ */
+
+import type { BranchCatalog, RecallPayload } from "../core/ContextCompiler.js";
+import { buildRecallPayload, compileTaskContext, listBranchCatalog } from "../core/ContextCompiler.js";
+import { getCurrentBranch } from "../core/GitOps.js";
+import type { SearchHitResult } from "../core/SearchIndex.js";
+import { SearchIndex } from "../core/SearchIndex.js";
+import { compareSourceRefs } from "../core/SourceTimeline.js";
+import { getActiveStorage } from "../core/SummaryStore.js";
+import { readTopicPage } from "../core/TopicPageStore.js";
+
+export interface SearchArgs {
+	query: string;
+	branch?: string;
+	type?: "topic" | "commit";
+	limit?: number;
+}
+
+export async function runSearch(cwd: string, args: SearchArgs): Promise<{ hits: SearchHitResult[] }> {
+	if (!args.query || !args.query.trim()) {
+		throw new Error("`query` is required and must be non-empty");
+	}
+	// Pass the active storage so the index dir resolves to the SAME location the
+	// compile warm-up wrote to — `<kbRoot>/.jolli/jollimemory/` in folder/dual-write
+	// mode, the checkout's `.jolli/jollimemory/` in orphan-only. Without it,
+	// resolveIndexDir falls back to cwd and a folder-mode server never sees the
+	// warm index (see SearchIndex.resolveIndexDir).
+	const index = await SearchIndex.openCached(cwd, getActiveStorage());
+	const hits = await index.search({
+		query: args.query,
+		branch: args.branch,
+		type: args.type,
+		limit: args.limit,
+	});
+	return { hits };
+}
+
+export async function runRecall(cwd: string, args: { branch?: string }): Promise<RecallPayload> {
+	const branch = args.branch ?? (await getCurrentBranch(cwd));
+	const ctx = await compileTaskContext({ branch }, cwd);
+	return buildRecallPayload(ctx);
+}
+
+export interface TimelineEntry {
+	timestamp: string;
+	branch: string;
+	sourceType: string;
+	sourceId: string;
+}
+
+export async function runDecisionTimeline(
+	cwd: string,
+	args: { slug: string },
+): Promise<{ slug: string; title: string; timeline: TimelineEntry[] }> {
+	if (!args.slug || !args.slug.trim()) {
+		throw new Error("`slug` is required");
+	}
+	const page = await readTopicPage(args.slug, cwd);
+	if (!page) {
+		throw new Error(`Topic not found: ${args.slug}`);
+	}
+	// Order via the canonical comparator (epoch-parsed, with type/id tie-break)
+	// so a topic whose sources carry mixed-timezone timestamps reads in the same
+	// chronological order the ingest fold actually applied — a plain string
+	// localeCompare would sort '…+09:00' vs '…Z' by their suffix, not by instant.
+	const timeline = [...page.sourceRefs]
+		.sort(compareSourceRefs)
+		.map((r) => ({ timestamp: r.timestamp, branch: r.branch ?? "", sourceType: r.type, sourceId: r.id }));
+	return { slug: args.slug, title: page.title, timeline };
+}
+
+export async function runListBranches(cwd: string): Promise<BranchCatalog> {
+	return listBranchCatalog(cwd);
+}

--- a/cli/src/sync/GitClient.test.ts
+++ b/cli/src/sync/GitClient.test.ts
@@ -13,7 +13,13 @@ import { mkdir, mkdtemp, readFile, rm, stat, utimes, writeFile } from "node:fs/p
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { GitClient, injectGithubAppUsername, isNetworkErrorMessage, isRepoMissingMessage } from "./GitClient.js";
+import {
+	GitClient,
+	injectGithubAppUsername,
+	isNetworkErrorMessage,
+	isRepoMissingMessage,
+	isServerRejectionMessage,
+} from "./GitClient.js";
 import type { GitCredentials } from "./SyncTypes.js";
 
 // Isolate every `git` subprocess in this file from the developer's ~/.gitconfig
@@ -122,6 +128,16 @@ describe("GitClient", () => {
 			});
 			const r = await c.checkGitInstalled();
 			expect(r.ok).toBe(false);
+		});
+
+		it("falls back to the default askpass / maxBuffer when only the required opts are given", async () => {
+			// Covers the constructor's `?? prepareAskpass` and `?? MAX_BUFFER`
+			// default sides. `git --version` runs directly via execFileImpl and
+			// never enters `run()`, so the real `prepareAskpass` default is wired
+			// up but never invoked — no askpass artifacts are written to disk.
+			const c = new GitClient({ memoryBankRoot: rootTempDir, credentials: FAKE_CREDS });
+			const r = await c.checkGitInstalled();
+			expect(r.ok).toBe(true);
 		});
 	});
 
@@ -1662,6 +1678,304 @@ describe("GitClient", () => {
 			expect(remoteMain).toBe(sideSha);
 		});
 	});
+
+	describe("removePath (Tier 2.7 propagate-delete)", () => {
+		it("stages a deletion of a tracked file via `git rm -f`", async () => {
+			// ConflictResolver calls this to propagate a delete rather than
+			// undelete by accepting the modified side. `-f` is required because
+			// the path may be in a conflicted (stage-:3 present) state.
+			const c = makeClient();
+			await c.clone(bareRepoUrl);
+			// README.md was seeded in beforeAll, so it is HEAD-tracked.
+			await c.removePath("README.md");
+			// `git rm` stages the deletion AND removes the working-tree copy.
+			const staged = gitSync(["status", "--porcelain"], memoryBankRoot);
+			expect(staged).toMatch(/^D\s+README\.md/m);
+			await expect(stat(join(memoryBankRoot, "README.md"))).rejects.toThrow();
+		});
+	});
+
+	describe("hasUncommittedChanges — includeIgnored widens the check (§0.13)", () => {
+		it("surfaces ignored working-tree files only when includeIgnored is set", async () => {
+			// The deny-all `.gitignore` template (`*` + `!.gitignore`) makes every
+			// FolderStorage-written file ignored by default. A plain `--porcelain`
+			// check cannot see them, but the auto-reconcile path needs them flagged
+			// before deciding whether a `git checkout` is safe.
+			const c = makeClient();
+			await c.clone(bareRepoUrl);
+			// Commit a deny-all .gitignore so the next file is ignored-by-default.
+			await writeFile(join(memoryBankRoot, ".gitignore"), "*\n!.gitignore\n");
+			await c.addPath(".gitignore");
+			await c.commit("[jolli-mb] add gitignore", { name: "T", email: "t@x" });
+			// This file matches `*` → ignored. The tree is otherwise clean.
+			await writeFile(join(memoryBankRoot, "owned-summary.md"), "summary\n");
+
+			// Plain check is blind to the ignored file.
+			expect(await c.hasUncommittedChanges()).toBe(false);
+			// Opt-in widens to `--ignored=matching` and surfaces it.
+			expect(await c.hasUncommittedChanges({ includeIgnored: true })).toBe(true);
+		});
+	});
+
+	describe("explicit-path staging methods + chunkByBudget batching", () => {
+		it("stageAddPaths force-adds an ignored path (overrides the deny-all template)", async () => {
+			// `-f` is required: the post-allowlist `.gitignore` denies everything
+			// by default, so without it `git add` reports "paths are ignored".
+			const c = makeClient();
+			await c.clone(bareRepoUrl);
+			await writeFile(join(memoryBankRoot, ".gitignore"), "*\n!.gitignore\n");
+			await c.addPath(".gitignore");
+			await c.commit("[jolli-mb] add gitignore", { name: "T", email: "t@x" });
+			await writeFile(join(memoryBankRoot, "a.md"), "a\n");
+			await writeFile(join(memoryBankRoot, "b.md"), "b\n");
+
+			await c.stageAddPaths(["a.md", "b.md"]);
+			const staged = gitSync(["diff", "--name-only", "--cached"], memoryBankRoot).split("\n");
+			expect(staged).toContain("a.md");
+			expect(staged).toContain("b.md");
+		});
+
+		it("stageAddPaths splits into multiple batches when the joined path length exceeds ARG_BUDGET_CHARS", async () => {
+			// chunkByBudget yields more than one batch once the running argv length
+			// crosses 16 KB. Capture the exec calls and assert the path list was
+			// flushed across >1 `git add` invocation rather than one oversized one.
+			const addCalls: ReadonlyArray<string>[] = [];
+			const fakeExec = async (_cmd: string, args: ReadonlyArray<string>) => {
+				if (args.includes("add")) addCalls.push(args);
+				return { stdout: "", stderr: "" };
+			};
+			const c = new GitClient({
+				memoryBankRoot,
+				credentials: FAKE_CREDS,
+				askpass: NOOP_ASKPASS,
+				execFileImpl: fakeExec as never,
+			});
+			// 200 paths of ~200 chars each ≈ 40 KB total → at least 3 batches at 16 KB.
+			const longPaths = Array.from({ length: 200 }, (_, i) => `dir/${"x".repeat(190)}/${i}.json`);
+			await c.stageAddPaths(longPaths);
+			expect(addCalls.length).toBeGreaterThan(1);
+			// Every input path landed in exactly one batch (none dropped).
+			const flushed = addCalls.flatMap((args) => args.slice(args.indexOf("--") + 1));
+			expect(flushed.length).toBe(longPaths.length);
+		});
+
+		it("chunkByBudget ships a single over-budget path as its own batch (no silent drop)", async () => {
+			// A lone path longer than the whole budget still gets emitted — the OS
+			// rejects it with a clearer error than us dropping the entry. Verify the
+			// path reaches a `git add` invocation.
+			const addCalls: ReadonlyArray<string>[] = [];
+			const fakeExec = async (_cmd: string, args: ReadonlyArray<string>) => {
+				if (args.includes("add")) addCalls.push(args);
+				return { stdout: "", stderr: "" };
+			};
+			const c = new GitClient({
+				memoryBankRoot,
+				credentials: FAKE_CREDS,
+				askpass: NOOP_ASKPASS,
+				execFileImpl: fakeExec as never,
+			});
+			const oversized = "z".repeat(20_000);
+			await c.stageAddPaths([oversized]);
+			expect(addCalls.length).toBe(1);
+			expect(addCalls[0]?.includes(oversized)).toBe(true);
+		});
+
+		it("stageAddPaths is a no-op on an empty list (chunkByBudget yields nothing)", async () => {
+			// Empty input must not spawn `git add` at all — the final
+			// `if (batch.length > 0)` guard in chunkByBudget skips the trailing yield.
+			const addCalls: ReadonlyArray<string>[] = [];
+			const fakeExec = async (_cmd: string, args: ReadonlyArray<string>) => {
+				if (args.includes("add")) addCalls.push(args);
+				return { stdout: "", stderr: "" };
+			};
+			const c = new GitClient({
+				memoryBankRoot,
+				credentials: FAKE_CREDS,
+				askpass: NOOP_ASKPASS,
+				execFileImpl: fakeExec as never,
+			});
+			await c.stageAddPaths([]);
+			expect(addCalls.length).toBe(0);
+		});
+
+		it("stageRemovePaths removes index entries tolerantly (`--ignore-unmatch`)", async () => {
+			// Tolerant rm: a path already gone from the index (race between status
+			// snapshot and the rm) must not error.
+			const c = makeClient();
+			await c.clone(bareRepoUrl);
+			await writeFile(join(memoryBankRoot, "doomed.md"), "x\n");
+			await c.addPath("doomed.md");
+			await c.commit("[jolli-mb] add doomed", { name: "T", email: "t@x" });
+
+			// Mix a tracked path with one that was never in the index — both tolerated.
+			await c.stageRemovePaths(["doomed.md", "never-existed.md"]);
+			const staged = gitSync(["status", "--porcelain"], memoryBankRoot);
+			expect(staged).toMatch(/^D\s+doomed\.md/m);
+		});
+
+		it("unstagePaths drops a staged-only add via `git rm --cached` (no HEAD blob → safe)", async () => {
+			// For a path with NO HEAD blob this simply drops the index entry; the
+			// working-tree file survives and no peer-visible deletion is staged.
+			const c = makeClient();
+			await c.clone(bareRepoUrl);
+			await writeFile(join(memoryBankRoot, "staged-only.md"), "draft\n");
+			await c.addPath("staged-only.md");
+			// Currently `A` (staged add). unstagePaths drops it from the index.
+			await c.unstagePaths(["staged-only.md"]);
+			const staged = gitSync(["status", "--porcelain"], memoryBankRoot);
+			// Back to untracked (`??`), not a staged deletion — and still on disk.
+			expect(staged).toMatch(/^\?\?\s+staged-only\.md/m);
+			expect((await readFile(join(memoryBankRoot, "staged-only.md"), "utf-8")).trim()).toBe("draft");
+		});
+
+		it("resetPathsToHead restores a HEAD-tracked path's index entry without staging a deletion", async () => {
+			// Unlike `git rm --cached`, `git reset HEAD --` is non-destructive:
+			// for a HEAD-tracked file it restores the original blob (no diff to
+			// commit) rather than staging a deletion that peers would pull.
+			const c = makeClient();
+			await c.clone(bareRepoUrl);
+			// README.md is HEAD-tracked. Stage a modification to it.
+			await writeFile(join(memoryBankRoot, "README.md"), "locally edited\n");
+			await c.addPath("README.md");
+			expect(gitSync(["diff", "--name-only", "--cached"], memoryBankRoot)).toContain("README.md");
+
+			await c.resetPathsToHead(["README.md"]);
+			// Index entry restored to HEAD blob → nothing staged. The working-tree
+			// edit survives (reset does not touch the working copy).
+			expect(gitSync(["diff", "--name-only", "--cached"], memoryBankRoot)).toBe("");
+			expect((await readFile(join(memoryBankRoot, "README.md"), "utf-8")).trim()).toBe("locally edited");
+		});
+	});
+
+	describe("listLocalBranches — non-zero exit returns []", () => {
+		it("returns [] when the for-each-ref invocation itself fails", async () => {
+			// A corrupted refs store makes `git for-each-ref` exit non-zero. The
+			// bootstrap-merge guard treats that as "no local branches" so a failed
+			// probe never falsely unlocks the destructive fresh-local path... but
+			// here the safe default is simply [].
+			const fakeExec = async () => {
+				const err = new Error("for-each-ref failed") as Error & {
+					stdout?: string;
+					stderr?: string;
+					code?: number;
+				};
+				err.stdout = "";
+				err.stderr = "fatal: refs store corrupt";
+				err.code = 128;
+				throw err;
+			};
+			const c = new GitClient({
+				memoryBankRoot,
+				credentials: FAKE_CREDS,
+				askpass: NOOP_ASKPASS,
+				execFileImpl: fakeExec as never,
+			});
+			expect(await c.listLocalBranches()).toEqual([]);
+		});
+	});
+
+	describe("defensive branch coverage (rare/impossible-with-real-git paths)", () => {
+		it("isRebaseInProgress ignores a non-directory `.git/rebase-merge` entry", async () => {
+			// The state dirs are normally directories; if a stray FILE sits at
+			// `.git/rebase-merge`, `s.isDirectory()` is false and we must NOT report
+			// a rebase in progress (fall through to the `return false`).
+			const c = makeClient();
+			await c.clone(bareRepoUrl);
+			// Plant a regular file where git would place the rebase-state dir.
+			await writeFile(join(memoryBankRoot, ".git", "rebase-merge"), "not a dir\n");
+			expect(await c.isRebaseInProgress()).toBe(false);
+		});
+
+		it("revParse returns null when rev-parse exits 0 but emits empty output", async () => {
+			// Defensive `oid.length === 0 ? null : oid` null side: a 0-exit with no
+			// OID on stdout must surface as `null`, not an empty string the caller
+			// would mistake for a real ref.
+			const fakeExec = async () => ({ stdout: "\n", stderr: "" });
+			const c = new GitClient({
+				memoryBankRoot,
+				credentials: FAKE_CREDS,
+				askpass: NOOP_ASKPASS,
+				execFileImpl: fakeExec as never,
+			});
+			expect(await c.revParse("HEAD")).toBeNull();
+		});
+
+		it("commit error message falls back to stdout when stderr is empty", async () => {
+			// `git commit failed: ${result.stderr || result.stdout}` — the `||`
+			// fallback side. A real failure that prints to stdout (not stderr) must
+			// still be surfaced in the thrown message.
+			const fakeExec = ((_cmd: string, args: ReadonlyArray<string>) => {
+				if (args.includes("commit")) {
+					// Empty message + empty stderr so `run()`'s `err.stderr || err.message`
+					// fallback yields "" — forcing `commit`'s `stderr || stdout` onto stdout.
+					const err = new Error("") as Error & { stdout?: string; stderr?: string; code?: number };
+					err.stdout = "error: pathspec exploded";
+					err.stderr = "";
+					err.code = 1;
+					return Promise.reject(err);
+				}
+				return Promise.resolve({ stdout: "", stderr: "" });
+			}) as unknown as typeof execFileSync;
+			const c = new GitClient({
+				memoryBankRoot: "/tmp/fake",
+				credentials: FAKE_CREDS,
+				askpass: NOOP_ASKPASS,
+				execFileImpl: fakeExec as never,
+			});
+			await expect(c.commit("[jolli-mb] x", { name: "X", email: "x@x" })).rejects.toThrow(
+				/git commit failed: error: pathspec exploded/,
+			);
+		});
+
+		it("untrackPathGlob throw omits the stderr suffix when stderr is empty", async () => {
+			// The `result.stderr ? \` stderr=...\` : ""` ternary's empty side: a
+			// non-zero exit with no stderr still throws, but without a dangling
+			// `stderr=` fragment in the message.
+			const fakeExec = async () => {
+				// Empty message so `run()` cannot backfill stderr from `err.message`;
+				// the resulting `result.stderr === ""` exercises the ternary's empty side.
+				const err = new Error("") as Error & { stdout?: string; stderr?: string; code?: number };
+				err.stdout = "";
+				err.stderr = "";
+				err.code = 1;
+				throw err;
+			};
+			const c = new GitClient({
+				memoryBankRoot,
+				credentials: FAKE_CREDS,
+				askpass: NOOP_ASKPASS,
+				execFileImpl: fakeExec as never,
+			});
+			await expect(c.untrackPathGlob("anything")).rejects.toThrow(/git rm --cached failed for anything: exit=1$/);
+		});
+	});
+
+	describe("pullRebase — committer identity injection (CI runners with no global git config)", () => {
+		it("passes `-c user.name/email` so rebased commits get the caller's author", async () => {
+			// Without identity args `git pull --rebase` derives the committer from
+			// the host config; on CI with none, replaying commits fails with
+			// `empty ident name`. Assert the `-c user.*` flags are threaded through.
+			const captured: ReadonlyArray<string>[] = [];
+			const fakeExec = async (_cmd: string, args: ReadonlyArray<string>) => {
+				captured.push(args);
+				// Exit 0, no "Fast-forward" marker → clean non-FF rebase, conflicted: [].
+				return { stdout: "", stderr: "" };
+			};
+			const c = new GitClient({
+				memoryBankRoot,
+				credentials: FAKE_CREDS,
+				askpass: NOOP_ASKPASS,
+				execFileImpl: fakeExec as never,
+			});
+			const result = await c.pullRebase({ name: "Author Name", email: "author@example.com" });
+			expect(result.conflicted).toEqual([]);
+			const pullCall = captured.find((args) => args.includes("pull"));
+			expect(pullCall).toBeDefined();
+			expect(pullCall).toEqual(
+				expect.arrayContaining(["-c", "user.name=Author Name", "-c", "user.email=author@example.com"]),
+			);
+		});
+	});
 });
 
 describe("injectGithubAppUsername", () => {
@@ -1683,6 +1997,29 @@ describe("injectGithubAppUsername", () => {
 	it("passes through non-https URLs unchanged (file://, ssh, http)", () => {
 		expect(injectGithubAppUsername("file:///tmp/repo.git")).toBe("file:///tmp/repo.git");
 		expect(injectGithubAppUsername("git@github.com:foo/bar.git")).toBe("git@github.com:foo/bar.git");
+	});
+});
+
+describe("isServerRejectionMessage (§0.11 — server decline must outrank network classification)", () => {
+	it.each([
+		// Pre-receive / post-receive hook declines — the canonical case the
+		// classifier exists to keep OUT of the transient `network` bucket.
+		["remote: error: GH006: Protected branch update failed", true],
+		["pre-receive hook declined", true],
+		["pre receive hook declined", true],
+		["post-receive hook declined", true],
+		["error: failed to push some refs: protected branch hook declined", true],
+		["! [remote rejected] main -> main (refusing to update checked out branch)", true],
+		["remote: error: File big.bin is 120 MB; this exceeds GitHub's file size limit of 100 MB", true],
+		["remote: Permission to foo/bar.git denied to deploy-key.", true],
+		// Pure network / unrelated messages must NOT match — they belong to the
+		// retryable `network` bucket or other classifiers.
+		["fatal: the remote end hung up unexpectedly", false],
+		["fatal: early EOF", false],
+		["fatal: Authentication failed", false],
+		["", false],
+	])("classifies %j -> %s", (input, expected) => {
+		expect(isServerRejectionMessage(input)).toBe(expected);
 	});
 });
 

--- a/cli/src/sync/LocalGitExclude.test.ts
+++ b/cli/src/sync/LocalGitExclude.test.ts
@@ -85,4 +85,14 @@ describe("appendLocalExclude", () => {
 		const content = await readFile(join(vault, ".git", "info", "exclude"), "utf-8");
 		expect(content).toBe(".jolli-quarantine-corrupt/\n");
 	});
+
+	it("returns false (non-fatal) when the read fails for a non-ENOENT reason", async () => {
+		// Plant a DIRECTORY where `exclude` should be a file: readFile throws
+		// EISDIR (not ENOENT), exercising the non-ENOENT warn branch, and the
+		// subsequent writeFile also fails — the helper degrades to false rather
+		// than throwing (its contract is "best-effort, never propagate").
+		await mkdir(join(vault, ".git", "info", "exclude"), { recursive: true });
+		const ok = await appendLocalExclude(vault, ".jolli-quarantine-corrupt/");
+		expect(ok).toBe(false);
+	});
 });

--- a/cli/src/sync/MemoryBankBootstrap.test.ts
+++ b/cli/src/sync/MemoryBankBootstrap.test.ts
@@ -12,7 +12,7 @@ import { platform, tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { GitClient } from "./GitClient.js";
-import { buildGitignore, MemoryBankBootstrap } from "./MemoryBankBootstrap.js";
+import { buildGitignore, isPerDeviceJsonPath, MemoryBankBootstrap } from "./MemoryBankBootstrap.js";
 
 let tempDir: string;
 let memoryBankRoot: string;
@@ -62,6 +62,27 @@ describe("buildGitignore (Phase 1 — minimal engine-managed template)", () => {
 
 	it("produces stable output across calls (idempotency)", () => {
 		expect(buildGitignore()).toBe(buildGitignore());
+	});
+});
+
+describe("isPerDeviceJsonPath", () => {
+	it("matches a per-repo shadow-status.json (the realistic <repo>/.jolli/ shape)", () => {
+		expect(isPerDeviceJsonPath("jolliai/.jolli/shadow-status.json")).toBe(true);
+		expect(isPerDeviceJsonPath("some/deep/repo/.jolli/shadow-status.json")).toBe(true);
+	});
+
+	it("does NOT match the bare suffix with nothing before it (length must exceed the suffix)", () => {
+		// The suffix carries a leading slash, so a root-level ".jolli/shadow-status.json"
+		// (no `<repo>/` prefix) is shorter-or-equal and must not match — the engine
+		// never writes per-device JSON at the vault root.
+		expect(isPerDeviceJsonPath(".jolli/shadow-status.json")).toBe(false);
+		expect(isPerDeviceJsonPath("/.jolli/shadow-status.json")).toBe(false);
+	});
+
+	it("does NOT match unrelated paths", () => {
+		expect(isPerDeviceJsonPath("jolliai/.jolli/index.json")).toBe(false);
+		expect(isPerDeviceJsonPath("jolliai/main/notes.md")).toBe(false);
+		expect(isPerDeviceJsonPath("")).toBe(false);
 	});
 });
 

--- a/cli/src/sync/SyncEngine.lockbusy.test.ts
+++ b/cli/src/sync/SyncEngine.lockbusy.test.ts
@@ -1,0 +1,194 @@
+/**
+ * Isolated coverage for SyncEngine's `VaultLockBusyError` path.
+ *
+ * `withPullLock` acquires `vault-write.lock` with a 10 s poll budget
+ * (`DEFAULT_PULL_LOCK_WAIT_MS`). Forcing the "lock unavailable" branch by
+ * actually holding the lock would make the suite poll for the full 10 s,
+ * so this file mocks `./VaultWriteLock.js` to return `null` from
+ * `acquireVaultWriteLock`. That mock is incompatible with the main
+ * SyncEngine.test.ts (whose lock-refresh test needs the real lock), so it
+ * lives here per the "isolate heavy mocks" rule.
+ *
+ * Covered regions in SyncEngine.ts:
+ *   - `VaultLockBusyError` class constructor (the `name = …` line).
+ *   - `withPullLock` `lock === null → throw VaultLockBusyError`.
+ *   - `runRound`'s outer catch routing `VaultLockBusyError → network`.
+ *   - the pull-step inner catch re-throwing `VaultLockBusyError`.
+ *   - `pushWithRetry`'s non-FF catch mapping `VaultLockBusyError → network`.
+ */
+
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockHomeDir, lockState } = vi.hoisted(() => ({
+	mockHomeDir: { value: "" },
+	// `available` toggles whether `acquireVaultWriteLock` hands back a handle
+	// or signals "busy" (null). Hoisted so the module factory can read it.
+	lockState: { available: false },
+}));
+
+vi.mock("node:os", async () => {
+	const actual = await vi.importActual<typeof import("node:os")>("node:os");
+	return { ...actual, homedir: () => mockHomeDir.value };
+});
+
+// Mock the lock module: `acquireVaultWriteLock` returns null (busy) by
+// default so `withPullLock` throws `VaultLockBusyError` synchronously
+// rather than polling for 10 s. Keep `DEFAULT_PULL_LOCK_WAIT_MS` real.
+vi.mock("./VaultWriteLock.js", async () => {
+	const actual = await vi.importActual<typeof import("./VaultWriteLock.js")>("./VaultWriteLock.js");
+	return {
+		...actual,
+		acquireVaultWriteLock: vi.fn(async () =>
+			lockState.available ? { release: async () => undefined, refresh: async () => undefined } : null,
+		),
+	};
+});
+
+import type { BackendClient } from "./BackendClient.js";
+import type { GitClient } from "./GitClient.js";
+import type { RoundContext } from "./SyncEngine.js";
+import { SyncEngine } from "./SyncEngine.js";
+
+let tempDir: string;
+
+beforeEach(async () => {
+	tempDir = await mkdtemp(join(tmpdir(), "syncengine-lockbusy-"));
+	mockHomeDir.value = tempDir;
+	lockState.available = false;
+	await mkdir(join(tempDir, "vault", ".git"), { recursive: true });
+});
+
+afterEach(async () => {
+	await rm(tempDir, { recursive: true, force: true });
+});
+
+function makeGitClient(overrides: Partial<Record<string, ReturnType<typeof vi.fn>>> = {}): GitClient {
+	return {
+		checkGitInstalled: async () => ({ ok: true, version: "git version 2.50" }),
+		clone: vi.fn(async () => undefined),
+		fetch: vi.fn(async () => undefined),
+		initRemote: vi.fn(async () => undefined),
+		untrackPathGlob: vi.fn(async () => undefined),
+		pullRebase: overrides.pullRebase ?? vi.fn(async () => ({ fastForwarded: false, conflicted: [] })),
+		stageAll: vi.fn(async () => undefined),
+		statusPorcelainZ: vi.fn(async () => []),
+		stageAddPaths: vi.fn(async () => undefined),
+		stageRemovePaths: vi.fn(async () => undefined),
+		unstagePaths: vi.fn(async () => undefined),
+		resetPathsToHead: vi.fn(async () => undefined),
+		commit: vi.fn(async () => "deadbeef"),
+		push: overrides.push ?? vi.fn(async () => ({ ok: true as const, transmitted: true })),
+		currentHead: vi.fn(async () => "deadbeef"),
+		hasHead: vi.fn(async () => true),
+		getOriginUrl: vi.fn(async () => "https://github.com/jolli-vaults/test.git"),
+		currentBranch: vi.fn(async () => "main"),
+		checkoutBranch: vi.fn(async () => undefined),
+		checkoutTrackingBranch: vi.fn(async () => undefined),
+		recreateBranchAt: vi.fn(async () => undefined),
+		refExists: vi.fn(async () => true),
+		revParse: vi.fn(async () => "remoteoid"),
+		isAncestor: vi.fn(async () => false),
+		hasUncommittedChanges: vi.fn(async () => false),
+		listDirtyPaths: vi.fn(async () => []),
+		readIndexStage: async () => null,
+		checkoutOurs: async () => undefined,
+		checkoutTheirs: async () => undefined,
+		rebaseContinue: async () => undefined,
+		rebaseAbort: overrides.rebaseAbort ?? vi.fn(async () => undefined),
+		isRebaseInProgress: vi.fn(async () => false),
+		sweepStaleLockFiles: vi.fn(async () => ({ removed: [] })),
+		hasUnmergedPaths: async () => [],
+		addPath: async () => undefined,
+	} as unknown as GitClient;
+}
+
+function makeBackend(): BackendClient {
+	return {
+		mintGitCredentials: vi.fn(async () => ({
+			gitUrl: "https://github.com/jolli-vaults/test.git",
+			token: "ghs_test",
+			expiresAt: Date.now() + 3600_000,
+			repoFullName: "jolli-vaults/test",
+			defaultBranch: "main",
+			githubRepoCreated: false,
+			alreadyVaultBound: true as const,
+			lockOwnerToken: "test-lock-owner-token" as const,
+		})),
+		notifyPush: vi.fn(async () => undefined),
+		getLegacyContent: vi.fn(async () => ({ spaceId: 1, spaceSlug: "personal", alreadyMigrated: true, docs: [] })),
+		completeMigration: vi.fn(async () => ({ alreadyMigrated: false })),
+		releaseLock: vi.fn(async () => undefined),
+		getJolliApiKey: vi.fn(async () => "sk-jol-test-fixture"),
+	} as unknown as BackendClient;
+}
+
+function defaultContext(): RoundContext {
+	return {
+		memoryBankRoot: join(tempDir, "vault"),
+		repoFolderName: "test",
+		repoIdentity: "https://github.com/test-owner/test",
+		author: { name: "Tester", email: "t@x" },
+	};
+}
+
+function makeEngine(client: GitClient) {
+	const bootstrap = { ensureBootstrap: vi.fn(async () => undefined) };
+	const legacy = { apply: vi.fn(async () => ({ filesWritten: 0 })) };
+	return new SyncEngine({
+		backend: makeBackend(),
+		resolveContext: async () => defaultContext(),
+		makeGitClient: () => client,
+		makeBootstrap: () => bootstrap as unknown as never,
+		makeLegacyMigration: () => legacy as unknown as never,
+		ai: async () => null,
+		ui: { promptBinaryPick: async () => "skip" },
+	});
+}
+
+const ROUND = { cwd: "/cwd", reason: "manual" as const, transcripts: false };
+
+describe("SyncEngine — VaultLockBusyError (vault-write.lock held by a concurrent worker)", () => {
+	it("routes the main-round pull-lock miss to a transient network outcome", async () => {
+		// `lockState.available = false` → `withPullLock` (driving the main
+		// step-4 pullRebase) gets `null`, throws `VaultLockBusyError`. The
+		// pull-step inner catch re-throws it (rather than mislabelling it
+		// pull_failed), and runRound's outer catch maps it to the transient
+		// `network` code so the next poll retries instead of a red "Sync
+		// failed".
+		const engine = makeEngine(makeGitClient());
+		const result = await engine.runRound(ROUND);
+		expect(result.newState).toBe("offline");
+		expect(result.lastError?.code).toBe("network");
+		expect(result.lastError?.message).toContain("vault-write.lock");
+	});
+
+	it("maps a busy pull-lock inside the non-FF push retry to network (not sync_failed)", async () => {
+		// Sequence the lock so the FIRST acquire (main step-4 pull) succeeds
+		// but the SECOND (the non-FF push retry's pullRebaseLocked) misses.
+		// That exercises `pushWithRetry`'s catch arm that maps
+		// `VaultLockBusyError → network`, distinct from the main-round
+		// catch covered above.
+		const { acquireVaultWriteLock } = await import("./VaultWriteLock.js");
+		const mocked = acquireVaultWriteLock as unknown as ReturnType<typeof vi.fn>;
+		mocked.mockReset();
+		// First call: real-ish handle. Subsequent calls: busy (null).
+		mocked
+			.mockResolvedValueOnce({ release: async () => undefined, refresh: async () => undefined })
+			.mockResolvedValue(null);
+		const push = vi.fn(async () => ({
+			ok: false as const,
+			nonFastForward: true,
+			unauthorized: false,
+			message: "non-fast-forward",
+		}));
+		const engine = makeEngine(makeGitClient({ push }));
+		const result = await engine.runRound(ROUND);
+		expect(result.newState).toBe("offline");
+		// The non-FF retry's pullRebaseLocked hit a busy lock → mapped to
+		// transient network rather than terminal sync_failed_after_retries.
+		expect(result.lastError?.code).toBe("network");
+	});
+});

--- a/cli/src/sync/SyncEngine.test.ts
+++ b/cli/src/sync/SyncEngine.test.ts
@@ -688,6 +688,35 @@ describe("SyncEngine.runRound — conflicts surface", () => {
 		expect(result.newState).toBe("synced");
 		expect(client.push).toHaveBeenCalled();
 	});
+
+	it("passes a working resolveVaultPath into makeResolver (vault-relative → absolute)", async () => {
+		// `buildResolver` constructs `resolveVaultPath: (rel) =>
+		// `${memoryBankRoot}/${rel}`` and hands it to `makeResolver`. The
+		// existing resolver stubs ignore that arg, so the arrow was never
+		// invoked. Here the stub calls it to prove it joins the vault root
+		// to the relative path — covering the arrow function body.
+		let resolved: string | undefined;
+		const client = makeGitClient({
+			pullRebase: vi.fn(async () => ({ fastForwarded: false, conflicted: ["notes/foo.md"] })),
+		});
+		const { engine } = makeEngine({
+			client,
+			makeResolver: (_client, extra) => {
+				resolved = extra.resolveVaultPath?.("notes/foo.md");
+				return {
+					resolveAll: vi.fn(async () => ({
+						resolved: ["notes/foo.md"],
+						skipped: [],
+						aiMerged: [],
+						binaryPicked: [],
+						rebaseAdvanced: true,
+					})),
+				} as unknown as import("./ConflictResolver.js").ConflictResolver;
+			},
+		});
+		await engine.runRound(ROUND);
+		expect(resolved).toBe(`${join(tempDir, "vault")}/notes/foo.md`);
+	});
 });
 
 describe("SyncEngine.runRound — onRoundComplete (P2 #1 chain-spawn hook)", () => {
@@ -2283,7 +2312,7 @@ describe("SyncEngine.runRound — auto-reconcile dirty vault (§0.9)", () => {
 		]);
 		const listDirtyPaths = vi.fn(async () => [corruptRel, cleanRel] as ReadonlyArray<string>);
 		const stageAll = vi.fn(async () => undefined);
-		const commit = vi.fn(async () => "deadbeef");
+		const commit = vi.fn(async (_message?: string) => "deadbeef");
 		const pullRebase = vi.fn(async () => ({ fastForwarded: false, conflicted: [] }));
 		const client = makeGitClient({
 			statusPorcelainZ,
@@ -3354,5 +3383,737 @@ describe("SyncEngine.runRound — JOLLI-1577 release-lock matrix", () => {
 		// off. Pre-fix this assertion failed: finally released the
 		// recovery token, contradicting the user's defer choice.
 		expect(releaseLock).not.toHaveBeenCalled();
+	});
+});
+
+// ──────────────────────────────────────────────────────────────────────
+// Coverage top-up: small scattered error/edge branches that the main
+// suites above don't exercise. Each test pins a SPECIFIC uncovered line
+// region in SyncEngine.ts and documents why that branch matters.
+// ──────────────────────────────────────────────────────────────────────
+
+describe("SyncEngine.runRound — auto-reconcile failure is non-fatal (catch at the dirty-vault gate)", () => {
+	it("swallows a reconcile commit throw and lets pullRebase be the real gate", async () => {
+		// The §0.9 auto-reconcile block is wrapped in its own try/catch:
+		// staging/committing the dirty vault before pullRebase is
+		// best-effort, because pullRebase will hit the same dirty state and
+		// surface a clear error if it actually matters. The gate is
+		// `hasOwnedDirtyPaths` (porcelain + classifier), NOT
+		// `hasUncommittedChanges` — so to reach the catch we must drive an
+		// OWNED dirty path through porcelain and then make the reconcile
+		// commit throw. Without this test the catch (and its warn log) was
+		// never hit because every existing dirty-vault test used a commit
+		// stub that resolves.
+		const summaryPath = `myrepo/.jolli/summaries/${"e".repeat(40)}.json`;
+		const statusPorcelainZ = vi.fn(async () => [
+			{ path: summaryPath, indexStatus: "!", worktreeStatus: "!", oldPath: undefined },
+		]);
+		let commitCalls = 0;
+		const commit = vi.fn(async (_msg: string) => {
+			commitCalls++;
+			// First call is the reconcile commit — make it throw so the
+			// §0.9 catch fires. Later calls (steady-state commit) succeed.
+			if (commitCalls === 1) throw new Error("reconcile commit failed: index lock");
+			return "deadbeef";
+		});
+		const pullRebase = vi.fn(async () => ({ fastForwarded: false, conflicted: [] }));
+		const client = makeGitClient({ statusPorcelainZ, commit, pullRebase });
+		const { engine } = makeEngine({ client });
+		const result = await engine.runRound(ROUND);
+		// pullRebase succeeded, so despite the reconcile commit throwing,
+		// the round still ends synced — proving the failure was non-fatal.
+		expect(result.newState).toBe("synced");
+		expect(pullRebase).toHaveBeenCalled();
+	});
+});
+
+describe("SyncEngine.runRound — hasOwnedDirtyPaths classifier branches", () => {
+	it("treats an owned transcript path as NOT dirty when syncTranscripts is off", async () => {
+		// `hasOwnedDirtyPaths` mirrors `stageVault`: a transcript path is
+		// owned, but with `syncTranscripts: false` it must NOT trip the
+		// reconcile gate (the transcript is gated out of the commit).
+		// Exercising this with `transcripts: false` covers the
+		// `kind === "transcript" && !syncTranscripts → return false` arm.
+		const transcriptPath = `myrepo/.jolli/transcripts/${"f".repeat(40)}.json`;
+		const statusPorcelainZ = vi.fn(async () => [
+			{ path: transcriptPath, indexStatus: "!", worktreeStatus: "!", oldPath: undefined },
+		]);
+		const commit = vi.fn(async (_message?: string) => "deadbeef");
+		const client = makeGitClient({ statusPorcelainZ, commit });
+		const { engine } = makeEngine({ client });
+		const result = await engine.runRound({ ...ROUND, transcripts: false });
+		expect(result.newState).toBe("synced");
+		// Only the steady-state commit runs — the transcript-only dirtiness
+		// did NOT trigger a reconcile pre-commit.
+		expect(commit).toHaveBeenCalledTimes(1);
+		const firstMsg = commit.mock.calls[0]?.[0];
+		expect(typeof firstMsg === "string" && firstMsg).not.toMatch(/reconcile/);
+	});
+
+	it("treats a rename whose OLD side is owned as dirty (both sides classified)", async () => {
+		// A rename entry carries `path = newSide`, `oldPath = oldSide`.
+		// `stageVault.decomposeOps` classifies both halves, so a rename
+		// FROM an owned path TO an unowned path must still count as dirty
+		// — otherwise the `git rm --cached` for the owned old side never
+		// reaches a commit. This pins the `oldPath !== undefined &&
+		// isOwnedDirty(oldPath)` arm: the NEW side classifies to null
+		// (root-level non-owned) while the OLD side is owned.
+		const ownedOld = `myrepo/.jolli/summaries/${"a".repeat(40)}.json`;
+		const statusPorcelainZ = vi.fn(async () => [
+			// New side `.DS_Store` classifies null, so `isOwnedDirty(path)` is
+			// false and the gate MUST fall through to the oldPath check; old
+			// side is owned, which is what trips the round dirty.
+			{ path: ".DS_Store", indexStatus: "R", worktreeStatus: " ", oldPath: ownedOld },
+		]);
+		const commit = vi.fn(async (_message?: string) => "deadbeef");
+		const client = makeGitClient({ statusPorcelainZ, commit });
+		const { engine } = makeEngine({ client });
+		const result = await engine.runRound(ROUND);
+		expect(result.newState).toBe("synced");
+		// Reconcile commit fired because the owned OLD side made the round dirty.
+		expect(commit.mock.calls[0]?.[0]).toMatch(/reconcile/);
+	});
+
+	it("treats a staged deletion of a per-device JSON path as dirty (engine cleanup target)", async () => {
+		// P2#2: `ensureBootstrap` runs `git rm --cached` against
+		// per-device JSON (e.g. `**/.jolli/shadow-status.json`) so legacy
+		// committed copies get untracked, producing a staged `D`. The
+		// classifier returns null for that path, so without the explicit
+		// `indexStatus === "D" && isPerDeviceJsonPath` arm the round would
+		// idle-skip and the deletion would re-stage forever.
+		const statusPorcelainZ = vi.fn(async () => [
+			{ path: "myrepo/.jolli/shadow-status.json", indexStatus: "D", worktreeStatus: " ", oldPath: undefined },
+		]);
+		const commit = vi.fn(async (_message?: string) => "deadbeef");
+		const client = makeGitClient({ statusPorcelainZ, commit });
+		const { engine } = makeEngine({ client });
+		const result = await engine.runRound(ROUND);
+		expect(result.newState).toBe("synced");
+		expect(commit.mock.calls[0]?.[0]).toMatch(/reconcile/);
+	});
+
+	it("treats an unmerged (U) porcelain entry as dirty", async () => {
+		// An `U` (unmerged) index/worktree status short-circuits to dirty
+		// regardless of classification — the conflict resolver should have
+		// handled it earlier, but if one slipped through we must not
+		// idle-skip. Covers the `e.indexStatus === "U" || e.worktreeStatus
+		// === "U"` arm.
+		const statusPorcelainZ = vi.fn(async () => [
+			{ path: "anything.txt", indexStatus: "U", worktreeStatus: "U", oldPath: undefined },
+		]);
+		const commit = vi.fn(async (_message?: string) => "deadbeef");
+		const client = makeGitClient({ statusPorcelainZ, commit });
+		const { engine } = makeEngine({ client });
+		const result = await engine.runRound(ROUND);
+		expect(result.newState).toBe("synced");
+		expect(commit.mock.calls[0]?.[0]).toMatch(/reconcile/);
+	});
+});
+
+describe("SyncEngine.runRound — stageVault canary unowned bucket", () => {
+	it("folds unowned paths reported by stageVault into the round canary", async () => {
+		// `stageVaultTracked` accumulates `report.unowned` into
+		// `this.canary.unowned` (capped). The only direct test of stageVault
+		// drives the `symlinked` bucket; this pins the `unowned` arm. We
+		// plant an unclassified file in the working tree and report it as a
+		// brand-new (`?`) untracked entry via porcelain so `stageVault`
+		// classifies it as unowned and routes it to the canary.
+		const vault = join(tempDir, "vault");
+		// `.DS_Store` classifies as null (unowned) — OS junk in the vault.
+		await writeFile(join(vault, ".DS_Store"), "junk");
+		const statusPorcelainZ = vi.fn(async () => [
+			{ path: ".DS_Store", indexStatus: "?", worktreeStatus: "?", oldPath: undefined },
+		]);
+		const client = makeGitClient({ statusPorcelainZ });
+		const { engine } = makeEngine({ client });
+		const result = await engine.runRound(ROUND);
+		expect(result.newState).toBe("synced");
+		// The unowned stray file surfaces on the canary so the status bar
+		// can warn the user that something foreign lives in their vault.
+		expect(result.canary?.unowned).toContain(".DS_Store");
+	});
+
+	it("caps the canary unowned bucket at CANARY_PATH_CAP across multiple stage calls", async () => {
+		// `stageVaultTracked` runs TWICE in a reconcile round (once at the
+		// §0.9 pre-pull reconcile, once at step 7). The unowned accumulator
+		// persists across both. With >CANARY_PATH_CAP (10) unowned paths,
+		// the FIRST call fills the bucket to 10 and the SECOND finds
+		// `room <= 0` — exercising the `if (room > 0)` false arm (the cap
+		// guard) that a single-call test can't reach.
+		const vault = join(tempDir, "vault");
+		// 12 OS-junk files (classify null → unowned) + one owned summary so
+		// the reconcile gate fires and stageVaultTracked runs at step 4 too.
+		const junk = Array.from({ length: 12 }, (_, i) => `.DS_Store_${i}`);
+		for (const j of junk) await writeFile(join(vault, j), "junk");
+		const ownedPath = `myrepo/.jolli/summaries/${"c".repeat(40)}.json`;
+		await mkdir(join(vault, "myrepo", ".jolli", "summaries"), { recursive: true });
+		await writeFile(join(vault, ownedPath), JSON.stringify({ ok: true }));
+		const statusPorcelainZ = vi.fn(async () => [
+			...junk.map((p) => ({ path: p, indexStatus: "?", worktreeStatus: "?", oldPath: undefined })),
+			{ path: ownedPath, indexStatus: "!", worktreeStatus: "!", oldPath: undefined },
+		]);
+		const client = makeGitClient({ statusPorcelainZ });
+		const { engine } = makeEngine({ client });
+		const result = await engine.runRound(ROUND);
+		expect(result.newState).toBe("synced");
+		// Bucket is capped at 10 even though 12 unowned paths were reported
+		// across the two stage passes.
+		expect(result.canary?.unowned).toHaveLength(10);
+	});
+
+	it("caps the canary symlinked bucket at CANARY_PATH_CAP across multiple stage calls", async () => {
+		// Mirror of the unowned-cap test for the SYMLINKED bucket: real
+		// symlinks at classifier-OWNED locations are refused by stageVault's
+		// symlink guard and routed to `this.canary.symlinked`. With >10 such
+		// paths reported across the reconcile + step-7 stage passes, the
+		// second pass hits `room <= 0` — the `if (room > 0)` false arm for
+		// the symlinked bucket. Plus one plain owned file so the reconcile
+		// gate fires (a symlink alone wouldn't, since the guard short-circuits
+		// before classification influences the dirty gate).
+		const { symlink } = await import("node:fs/promises");
+		const vault = join(tempDir, "vault");
+		await mkdir(join(vault, "myrepo", ".jolli", "summaries"), { recursive: true });
+		const symPaths: string[] = [];
+		for (let i = 0; i < 12; i++) {
+			const rel = `myrepo/.jolli/summaries/${String(i).padStart(2, "0")}${"d".repeat(38)}.json`;
+			// Symlink the owned-location leaf at a foreign target — hostile
+			// placement the guard must refuse.
+			await symlink("/etc/hostname", join(vault, rel));
+			symPaths.push(rel);
+		}
+		// A plain owned file to trip the reconcile gate (statusPorcelainZ
+		// entry that classifies owned + is non-symlink).
+		const plainOwned = `myrepo/.jolli/summaries/${"e".repeat(40)}.json`;
+		await writeFile(join(vault, plainOwned), JSON.stringify({ ok: true }));
+		const statusPorcelainZ = vi.fn(async () => [
+			{ path: plainOwned, indexStatus: "!", worktreeStatus: "!", oldPath: undefined },
+			...symPaths.map((p) => ({ path: p, indexStatus: "!", worktreeStatus: "!", oldPath: undefined })),
+		]);
+		const client = makeGitClient({ statusPorcelainZ });
+		const { engine } = makeEngine({ client });
+		const result = await engine.runRound(ROUND);
+		expect(result.newState).toBe("synced");
+		// Symlinked bucket capped at 10 despite 12 hostile symlinks reported
+		// across both stage passes.
+		expect(result.canary?.symlinked).toHaveLength(10);
+	});
+});
+
+describe("SyncEngine.runRound — vault marker rewrite (needsRewrite branch)", () => {
+	it("rewrites a legacy-form marker in canonical form and still syncs", async () => {
+		// `verifyVaultMarker` returns `{ ok: true, needsRewrite: true }`
+		// when the stored marker URL matches creds only after
+		// re-normalization (e.g. a pre-541d00e marker that kept the
+		// trailing `.git`). The engine must rewrite the marker once so
+		// subsequent rounds take the byte-equality fast path. We seed a raw
+		// marker with the non-canonical `.git` suffix to trip this arm.
+		const markerPath = join(tempDir, "vault", ".git", "jolli-vault-identity.json");
+		await writeFile(
+			markerPath,
+			`${JSON.stringify({
+				kind: "jolli-memory-bank",
+				version: 1,
+				createdAt: "2025-01-01T00:00:00Z",
+				// Non-canonical: trailing `.git` survives in the raw bytes but
+				// normalizes to the same URL the creds carry.
+				gitUrl: "https://github.com/jolli-vaults/test.git",
+				repoFullName: "jolli-vaults/test",
+				defaultBranch: "main",
+			})}\n`,
+			"utf-8",
+		);
+		const { engine } = makeEngine();
+		const result = await engine.runRound(ROUND);
+		expect(result.newState).toBe("synced");
+		// After the round the marker is rewritten in canonical (no `.git`) form.
+		const rewritten = JSON.parse(await (await import("node:fs/promises")).readFile(markerPath, "utf-8")) as {
+			gitUrl: string;
+		};
+		expect(rewritten.gitUrl).toBe("https://github.com/jolli-vaults/test");
+	});
+});
+
+describe("SyncEngine.runRound — repos.json folder collision surfacing (P2#3)", () => {
+	it("invokes onRepoMappingConflict when two identities claim the same folder", async () => {
+		// After pullRebase integrates a peer's mapping, the engine scans for
+		// cross-device folder collisions and surfaces them so the user can
+		// rename one side. We seed a `repos.json` with two identities
+		// pointing at the same folder to make `findRepoMappingConflicts`
+		// return a non-empty list, exercising the warn-loop + callback.
+		const vault = join(tempDir, "vault");
+		await mkdir(join(vault, ".jolli"), { recursive: true });
+		await writeFile(
+			join(vault, ".jolli", "repos.json"),
+			`${JSON.stringify({
+				version: 1,
+				mappings: [
+					{ repoIdentity: "https://github.com/a/a", folder: "shared" },
+					{ repoIdentity: "https://github.com/b/b", folder: "shared" },
+				],
+			})}\n`,
+			"utf-8",
+		);
+		const onRepoMappingConflict = vi.fn();
+		const { engine } = makeEngine();
+		(
+			engine as unknown as { opts: { onRepoMappingConflict: typeof onRepoMappingConflict } }
+		).opts.onRepoMappingConflict = onRepoMappingConflict;
+		const result = await engine.runRound(ROUND);
+		expect(result.newState).toBe("synced");
+		expect(onRepoMappingConflict).toHaveBeenCalledTimes(1);
+		const conflicts = onRepoMappingConflict.mock.calls[0]?.[0] as ReadonlyArray<{ folder: string }>;
+		expect(conflicts[0]?.folder).toBe("shared");
+	});
+
+	it("swallows a throwing onRepoMappingConflict callback without down-stating the round", async () => {
+		// The collision callback is wired to UI; a buggy handler must not
+		// poison the round. Covers the callback's own try/catch swallow.
+		const vault = join(tempDir, "vault");
+		await mkdir(join(vault, ".jolli"), { recursive: true });
+		await writeFile(
+			join(vault, ".jolli", "repos.json"),
+			`${JSON.stringify({
+				version: 1,
+				mappings: [
+					{ repoIdentity: "https://github.com/a/a", folder: "shared" },
+					{ repoIdentity: "https://github.com/b/b", folder: "shared" },
+				],
+			})}\n`,
+			"utf-8",
+		);
+		const { engine } = makeEngine();
+		(engine as unknown as { opts: { onRepoMappingConflict: () => void } }).opts.onRepoMappingConflict = () => {
+			throw new Error("notification UI exploded");
+		};
+		const result = await engine.runRound(ROUND);
+		expect(result.newState).toBe("synced");
+	});
+});
+
+describe("SyncEngine.runRound — push hard-failure classification", () => {
+	it("classifies a server-rejection push message as push_rejected (terminal)", async () => {
+		// A non-FF / non-auth / non-repoMissing push failure whose message
+		// matches a server-rejection pattern (pre-receive hook declined,
+		// protected branch, …) must route to `push_rejected` BEFORE the
+		// network classifier — otherwise a pre-receive decline that presents
+		// as "remote end hung up" gets misrouted to silent transient retry.
+		const client = makeGitClient({
+			push: vi.fn(async () => ({
+				ok: false as const,
+				nonFastForward: false,
+				unauthorized: false,
+				repoMissing: false,
+				message: "remote: pre-receive hook declined",
+			})),
+		});
+		const { engine } = makeEngine({ client });
+		const result = await engine.runRound(ROUND);
+		expect(result.newState).toBe("offline");
+		expect(result.lastError?.code).toBe("push_rejected");
+	});
+});
+
+describe("SyncEngine.runRound — 503 pending_flush_failed exhaustion", () => {
+	it("gives up with code=network when every 503 retry is consumed", async () => {
+		// The 503 path retries within the same mint budget but, unlike 423,
+		// it does NOT honor `vaultLockedRetrySchedule` for the wait — it
+		// uses `Math.max(1000, retryAfterSeconds*1000)`. With a single-entry
+		// schedule (totalAttempts = 2) we burn one ~1s sleep then hit the
+		// final-attempt give-up arm: code=network. Pins the
+		// "final attempt → return network" branch.
+		const { WebFlushPendingError } = await import("./BackendClient.js");
+		const mintFn = vi.fn(async () => {
+			throw new WebFlushPendingError('{"error":"pending_flush_failed"}', 0);
+		});
+		const backend = makeBackend({ mintGitCredentials: mintFn });
+		// One retry entry → 2 total attempts → 1 wait then terminal.
+		const { engine } = makeEngine({ backend, vaultLockedRetrySchedule: [0] });
+		const result = await engine.runRound(ROUND);
+		expect(result.newState).toBe("offline");
+		expect(result.lastError?.code).toBe("network");
+		expect(mintFn).toHaveBeenCalledTimes(2);
+	});
+
+	it("swallows a throwing onLockedWait during a 503 retry (does not abort the loop)", async () => {
+		// The 503 retry fires `onLockedWait` right before its sleep, wrapped
+		// in its own try/catch. A buggy UI handler must not abort the
+		// cooperative back-off. Pins the 503-path onLockedWait swallow
+		// (distinct from the 423-path swallow already covered).
+		const { WebFlushPendingError } = await import("./BackendClient.js");
+		const mintFn = vi
+			.fn()
+			.mockRejectedValueOnce(new WebFlushPendingError('{"error":"pending_flush_failed"}', 0))
+			.mockResolvedValueOnce({
+				gitUrl: "https://github.com/jolli-vaults/test.git",
+				token: "ghs_test",
+				expiresAt: Date.now() + 3600_000,
+				repoFullName: "jolli-vaults/test",
+				defaultBranch: "main",
+				githubRepoCreated: false,
+				alreadyVaultBound: true as const,
+				lockOwnerToken: "test-lock-owner-token" as const,
+			});
+		const backend = makeBackend({ mintGitCredentials: mintFn });
+		const { engine } = makeEngine({
+			backend,
+			vaultLockedRetrySchedule: [0],
+			onLockedWait: () => {
+				throw new Error("503 UI handler exploded");
+			},
+		});
+		const result = await engine.runRound(ROUND);
+		// First attempt 503 → onLockedWait throws (swallowed) → sleep →
+		// second attempt succeeds.
+		expect(result.newState).toBe("synced");
+		expect(mintFn).toHaveBeenCalledTimes(2);
+	});
+});
+
+describe("SyncEngine.runRound — persistMintedLock with no api key", () => {
+	it("skips persisting the lock token when getJolliApiKey returns undefined (signed-out)", async () => {
+		// `persistMintedLock` early-returns when there is no api key — a
+		// signed-out / key-less install can still mint (the backend may
+		// allow it) but has nowhere to scope the pending-lock entry. Covers
+		// the `if (!apiKey) return;` guard. We assert the round still
+		// completes and no pending-lock file was written for any key.
+		const backend = makeBackend({ getJolliApiKey: vi.fn(async () => undefined) });
+		const { engine } = makeEngine({ backend });
+		const result = await engine.runRound(ROUND);
+		expect(result.newState).toBe("synced");
+		// readSelfLockState also early-returns on no key, so nothing is
+		// persisted; reading back any key yields null.
+		const { readPendingLock } = await import("./PendingLockStore.js");
+		expect(await readPendingLock("sk-jol-test-fixture")).toBeNull();
+	});
+});
+
+describe("SyncEngine — emitPhase / report robustness (direct unit hits)", () => {
+	it("emitPhase swallows a throwing onPhase callback", async () => {
+		// `emitPhase` is best-effort UI signalling; a throwing handler must
+		// not propagate. We invoke the private method directly so we hit the
+		// catch deterministically without depending on which phases a round
+		// happens to emit.
+		const { engine } = makeEngine();
+		(engine as unknown as { opts: { onPhase: () => void } }).opts.onPhase = () => {
+			throw new Error("onPhase exploded");
+		};
+		expect(() => (engine as unknown as { emitPhase: (p: string) => void }).emitPhase("merging")).not.toThrow();
+	});
+
+	it("report honors a caller-supplied canary in the partial (the rare hand-built path)", async () => {
+		// `report` prefers an explicit `canary` in the partial over the
+		// per-round accumulator. No production caller passes one today, so
+		// this defensive branch is only reachable by calling `report`
+		// directly — which we do here to lock the contract: a hand-built
+		// partial's canary wins and is NOT overwritten by `takeCanary()`.
+		const { engine } = makeEngine();
+		const explicit = { symlinked: ["x"], unowned: [] as string[] };
+		const result = (
+			engine as unknown as {
+				report: (
+					state: string,
+					partial: {
+						fetched: boolean;
+						pulled: boolean;
+						pushed: boolean;
+						conflicts: never[];
+						canary: typeof explicit;
+					},
+				) => { canary?: typeof explicit };
+			}
+		).report("synced", { fetched: false, pulled: false, pushed: false, conflicts: [], canary: explicit });
+		expect(result.canary).toBe(explicit);
+	});
+});
+
+describe("SyncEngine — safeRebaseAbort swallows abort failure", () => {
+	it("logs and continues when rebaseAbort throws during recovery", async () => {
+		// `safeRebaseAbort` must never let an abort failure shadow the
+		// upstream error that triggered the cleanup. We drive a non-FF push
+		// retry whose pullRebase throws (forcing `safeRebaseAbort`) AND make
+		// `rebaseAbort` itself throw — the round still reports a classified
+		// terminal failure rather than crashing.
+		let pushes = 0;
+		const client = makeGitClient({
+			push: vi.fn(async () => {
+				pushes++;
+				// Always non-FF so the retry path runs and calls pullRebaseLocked.
+				return { ok: false as const, nonFastForward: true, unauthorized: false, message: "non-fast-forward" };
+			}),
+			// pullRebase throws (no unmerged paths) → safeRebaseAbort fires.
+			pullRebase: vi.fn(async () => {
+				if (pushes >= 1) throw new Error("pull --rebase exploded after non-FF");
+				return { fastForwarded: false, conflicted: [] };
+			}),
+			rebaseAbort: vi.fn(async () => {
+				throw new Error("rebase --abort also failed");
+			}),
+		});
+		const { engine } = makeEngine({ client });
+		const result = await engine.runRound(ROUND);
+		// Despite both pullRebase and rebaseAbort throwing, the round
+		// resolves to a classified offline outcome (no unhandled crash).
+		expect(result.newState).toBe("offline");
+	});
+});
+
+describe("logFirstBindAudit — non-file entries are skipped", () => {
+	it("first-bind init counts only top-level files, skipping subdirectories", async () => {
+		// The forensic audit run on the first-bind branch (`memoryBankExists
+		// && !hasGit`) iterates top-level entries and `continue`s on any
+		// non-file (directory / symlink). We trigger first-bind by removing
+		// `.git`, leave a real directory next to a real file, and assert the
+		// round still inits + syncs — the `if (!entry.isFile()) continue`
+		// arm runs for the directory.
+		const vault = join(tempDir, "vault");
+		await rm(join(vault, ".git"), { recursive: true, force: true });
+		// `vault` itself exists (memoryBankExists) but has no `.git` → init.
+		await mkdir(join(vault, "a-subdir"), { recursive: true });
+		await writeFile(join(vault, "a-file.txt"), "data");
+		const initRemote = vi.fn(async () => {
+			// Emulate `git init` creating `.git` so the marker write lands.
+			await mkdir(join(vault, ".git"), { recursive: true });
+		});
+		const client = makeGitClient({ initRemote });
+		const { engine } = makeEngine({ client });
+		const result = await engine.runRound(ROUND);
+		expect(result.newState).toBe("synced");
+		expect(initRemote).toHaveBeenCalled();
+	});
+});
+
+describe("SyncEngine.runRound — migration completion failure surfaces (docs>0 path)", () => {
+	it("returns the migration_failed result when completeMigration throws after a pushed HEAD", async () => {
+		// db→git migration with docs>0 + filesWritten>0 pushes the migration
+		// commit, then calls `tryCompleteMigration`. With `isAncestor: true`
+		// HEAD is on the remote so completion is NOT deferred — it calls the
+		// backend `completeMigration`, which throws here. That makes
+		// `tryCompleteMigration` return `{ ok: false, code: "migration_failed" }`
+		// and `runFirstBindMigration` bubbles it up via the
+		// `if (!completion.ok) return completion` guard in the docs>0 branch.
+		const mintFn = vi.fn(async () => ({
+			gitUrl: "https://github.com/jolli-vaults/test.git",
+			token: "ghs_test",
+			expiresAt: Date.now() + 3600_000,
+			repoFullName: "jolli-vaults/test",
+			defaultBranch: "main",
+			githubRepoCreated: true,
+			alreadyVaultBound: false as const, // drives the migration branch
+			lockOwnerToken: "test-lock-owner-token" as const,
+		}));
+		const completeMigration = vi.fn(async () => {
+			throw new Error("backend 500 during complete-migration");
+		});
+		const backend = makeBackend({
+			mintGitCredentials: mintFn,
+			completeMigration,
+			getLegacyContent: vi.fn(async () => ({
+				spaceId: 1,
+				spaceSlug: "personal",
+				alreadyMigrated: false,
+				docs: [
+					{
+						id: 1,
+						jrn: "doc:1",
+						slug: "x",
+						path: "/",
+						docType: "document",
+						parentId: null,
+						content: "y",
+						contentType: "text/markdown",
+						sortOrder: 0,
+						createdAt: "2026-05-01T00:00:00Z",
+						updatedAt: "2026-05-01T00:00:00Z",
+					},
+				],
+			})),
+		});
+		// `isAncestor: true` → HEAD already on origin/<default>, so completion
+		// proceeds to the backend call (not the defer branch).
+		const client = makeGitClient({ isAncestor: vi.fn(async () => true) });
+		const applyLegacy = vi.fn(async () => ({ filesWritten: 3 }));
+		const { engine } = makeEngine({
+			backend,
+			client,
+			makeLegacyMigration: () =>
+				({ apply: applyLegacy }) as unknown as ReturnType<
+					NonNullable<import("./SyncEngine.js").SyncEngineOpts["makeLegacyMigration"]>
+				>,
+		});
+		const result = await engine.runRound(ROUND);
+		expect(result.newState).toBe("offline");
+		expect(result.lastError?.code).toBe("migration_failed");
+		expect(result.lastError?.message).toContain("completeMigration");
+	});
+});
+
+describe("SyncEngine.runRound — migration push idempotent (transmitted=false)", () => {
+	it("skips the migration notify-push when the migration push transmitted nothing", async () => {
+		// When the migration `pushWithRetry` reports `transmitted: false`
+		// (the push was idempotent — "Everything up-to-date"), the migration
+		// notify-push is skipped. Covers the `if (pushed.transmitted)` false
+		// arm in `runFirstBindMigration`. The round still completes synced.
+		const mintFn = vi.fn(async () => ({
+			gitUrl: "https://github.com/jolli-vaults/test.git",
+			token: "ghs_test",
+			expiresAt: Date.now() + 3600_000,
+			repoFullName: "jolli-vaults/test",
+			defaultBranch: "main",
+			githubRepoCreated: true,
+			alreadyVaultBound: false as const,
+			lockOwnerToken: "test-lock-owner-token" as const,
+		}));
+		const notifyPush = vi.fn(async () => undefined);
+		const backend = makeBackend({
+			mintGitCredentials: mintFn,
+			notifyPush,
+			completeMigration: vi.fn(async () => ({ alreadyMigrated: false })),
+			getLegacyContent: vi.fn(async () => ({
+				spaceId: 1,
+				spaceSlug: "personal",
+				alreadyMigrated: false,
+				docs: [
+					{
+						id: 1,
+						jrn: "doc:1",
+						slug: "x",
+						path: "/",
+						docType: "document",
+						parentId: null,
+						content: "y",
+						contentType: "text/markdown",
+						sortOrder: 0,
+						createdAt: "2026-05-01T00:00:00Z",
+						updatedAt: "2026-05-01T00:00:00Z",
+					},
+				],
+			})),
+		});
+		// Push is always idempotent (transmitted: false) — both the migration
+		// push and the steady-state push report nothing transmitted.
+		const push = vi.fn(async () => ({ ok: true as const, transmitted: false }));
+		const client = makeGitClient({ push, isAncestor: vi.fn(async () => true) });
+		const applyLegacy = vi.fn(async () => ({ filesWritten: 2 }));
+		const { engine } = makeEngine({
+			backend,
+			client,
+			makeLegacyMigration: () =>
+				({ apply: applyLegacy }) as unknown as ReturnType<
+					NonNullable<import("./SyncEngine.js").SyncEngineOpts["makeLegacyMigration"]>
+				>,
+		});
+		const result = await engine.runRound(ROUND);
+		expect(result.newState).toBe("synced");
+		// Neither the migration notify (transmitted=false) nor the
+		// steady-state notify (transmitted=false) fired.
+		expect(notifyPush).not.toHaveBeenCalled();
+	});
+});
+
+describe("SyncEngine.runRound — tryRemint propagates a failing re-mint", () => {
+	it("returns the re-mint failure code when the recovery mint itself fails", async () => {
+		// A push 401 triggers `tryRemint`, whose `mintFresh` call fails
+		// (network). `tryRemint` must propagate that classified failure
+		// wrapped with the cause prefix — covering the `if (!fresh.ok)
+		// return …` arm. The first mint succeeds (so the round gets going);
+		// the SECOND mint (the recovery) throws a network error.
+		let mintCalls = 0;
+		const mintFn = vi.fn(async () => {
+			mintCalls++;
+			if (mintCalls >= 2) throw new SyncBackendNetworkError(new Error("ECONNRESET on re-mint"));
+			return {
+				gitUrl: "https://github.com/jolli-vaults/test.git",
+				token: "ghs_test",
+				expiresAt: Date.now() + 3600_000,
+				repoFullName: "jolli-vaults/test",
+				defaultBranch: "main",
+				githubRepoCreated: false,
+				alreadyVaultBound: true as const,
+				lockOwnerToken: "test-lock-owner-token" as const,
+			};
+		});
+		const backend = makeBackend({ mintGitCredentials: mintFn });
+		// Push returns unauthorized once → triggers the recovery re-mint.
+		const push = vi.fn(async () => ({
+			ok: false as const,
+			nonFastForward: false,
+			unauthorized: true,
+			repoMissing: false,
+			message: "fatal: authentication failed",
+		}));
+		const client = makeGitClient({ push });
+		const { engine } = makeEngine({ backend, client });
+		const result = await engine.runRound(ROUND);
+		expect(result.newState).toBe("offline");
+		// The re-mint network failure propagates with the cause-prefixed
+		// message ("re-mint after unauthorized: …").
+		expect(result.lastError?.code).toBe("network");
+		expect(result.lastError?.message).toContain("re-mint after unauthorized");
+		expect(mintCalls).toBe(2);
+	});
+});
+
+describe("SyncEngine.runRound — non-FF retry pullRebase throw classification", () => {
+	it("classifies a network-flavored pullRebase throw during non-FF retry as network", async () => {
+		// In `pushWithRetry`, a non-FF push pulls --rebase to integrate. If
+		// that pullRebase THROWS (not VaultLockBusyError) the catch
+		// classifies the message: a network-flavored message routes to
+		// `network`. Pins the `isNetworkErrorMessage(msg) ? "network"` arm.
+		const push = vi.fn(async () => ({
+			ok: false as const,
+			nonFastForward: true,
+			unauthorized: false,
+			message: "non-fast-forward",
+		}));
+		const pullRebase = vi
+			.fn<() => Promise<{ fastForwarded: boolean; conflicted: string[] }>>()
+			// First (main step-4) pull succeeds; the non-FF retry's pull throws.
+			.mockResolvedValueOnce({ fastForwarded: false, conflicted: [] })
+			.mockRejectedValue(new Error("fatal: unable to access — Could not resolve host: github.com"));
+		const client = makeGitClient({ push, pullRebase });
+		const { engine } = makeEngine({ client });
+		const result = await engine.runRound(ROUND);
+		expect(result.newState).toBe("offline");
+		expect(result.lastError?.code).toBe("network");
+	});
+
+	it("classifies a server-rejection pullRebase throw during non-FF retry as push_rejected", async () => {
+		// Same path, but the rethrown message matches a server-rejection
+		// pattern → `push_rejected` (checked BEFORE the network classifier).
+		const push = vi.fn(async () => ({
+			ok: false as const,
+			nonFastForward: true,
+			unauthorized: false,
+			message: "non-fast-forward",
+		}));
+		const pullRebase = vi
+			.fn<() => Promise<{ fastForwarded: boolean; conflicted: string[] }>>()
+			.mockResolvedValueOnce({ fastForwarded: false, conflicted: [] })
+			.mockRejectedValue(new Error("remote: error: GH006: Protected branch update failed"));
+		const client = makeGitClient({ push, pullRebase });
+		const { engine } = makeEngine({ client });
+		const result = await engine.runRound(ROUND);
+		expect(result.newState).toBe("offline");
+		expect(result.lastError?.code).toBe("push_rejected");
+	});
+});
+
+describe("SyncEngine.runRound — mint throws a non-Error value (generic fallback)", () => {
+	it("falls back to String(e) / '(none)' when the thrown value has no message/body", async () => {
+		// The generic mint catch reads `errAny.message ?? String(e)` and
+		// `errAny.body ?? "(none)"`. Throwing a bare object (no `message`,
+		// no `body`, not one of the typed backend errors) exercises BOTH
+		// nullish-fallback arms and the terminal `mint_failed` return.
+		const backend = makeBackend({
+			mintGitCredentials: vi.fn(async () => {
+				// Deliberately throw a non-Error, message-less, body-less value
+				// to drive both `?? String(e)` and `?? "(none)"` fallbacks.
+				throw {} as unknown;
+			}),
+		});
+		const { engine } = makeEngine({ backend });
+		const result = await engine.runRound(ROUND);
+		expect(result.newState).toBe("offline");
+		expect(result.lastError?.code).toBe("mint_failed");
 	});
 });

--- a/cli/src/sync/VaultLockPath.fsmock.test.ts
+++ b/cli/src/sync/VaultLockPath.fsmock.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Mock-isolated tests for the two defensive fallbacks in
+ * `canonicaliseLocalFolder` that a real filesystem can't reach:
+ *
+ *   - The trailing-separator trim (only fires if an upstream step yields a
+ *     trailing `sep`; `path.resolve` strips it, so we force it via a mocked
+ *     `realpathSync.native` that returns a trailing slash).
+ *   - The fs-root fallback in `resolvePartialRealpath` (only fires if even
+ *     `/` can't be statted, which never happens on a healthy system).
+ *
+ * Kept in its own file because it mocks `node:fs` wholesale, whereas the
+ * sibling `VaultLockPath.test.ts` deliberately exercises the real filesystem.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { mockStatSync, mockRealpathNative } = vi.hoisted(() => ({
+	mockStatSync: vi.fn(),
+	mockRealpathNative: vi.fn(),
+}));
+
+vi.mock("node:fs", () => {
+	const realpathSync = Object.assign(vi.fn(), { native: mockRealpathNative });
+	return { statSync: mockStatSync, realpathSync };
+});
+
+import { canonicaliseLocalFolder } from "./VaultLockPath.js";
+
+describe("canonicaliseLocalFolder defensive fallbacks", () => {
+	it("trims a trailing separator that survives into the canonical string (step 5)", () => {
+		// An existing ancestor that realpaths to a path WITH a trailing slash —
+		// the regex collapse preserves the trailing sep, so the explicit trim runs.
+		mockStatSync.mockReturnValue(undefined); // input segment "exists"
+		mockRealpathNative.mockReturnValue("/var/data/vault/");
+
+		const out = canonicaliseLocalFolder("/var/data/vault");
+		expect(out).toBe("/var/data/vault"); // trailing slash stripped
+		expect(out.endsWith("/")).toBe(false);
+	});
+
+	it("returns the lexical path when no ancestor — not even root — can be statted", () => {
+		// statSync throws for every segment → resolvePartialRealpath walks to the
+		// filesystem root, hits parent === cur, and returns the resolved input.
+		mockStatSync.mockImplementation(() => {
+			throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+		});
+
+		const out = canonicaliseLocalFolder("/totally/nonexistent/tree");
+		expect(out).toBe("/totally/nonexistent/tree");
+		expect(mockRealpathNative).not.toHaveBeenCalled(); // never found an ancestor to realpath
+	});
+});
+
+describe("canonicaliseLocalFolder case-folding by platform (step 4)", () => {
+	const realPlatform = process.platform;
+
+	afterEach(() => {
+		Object.defineProperty(process, "platform", { value: realPlatform, configurable: true });
+	});
+
+	function stubPlatform(p: NodeJS.Platform): void {
+		Object.defineProperty(process, "platform", { value: p, configurable: true });
+		mockStatSync.mockReturnValue(undefined); // segment "exists"
+		mockRealpathNative.mockImplementation((s: string) => s); // identity realpath
+	}
+
+	it("preserves case on a case-sensitive filesystem (linux — neither branch of the platform check)", () => {
+		stubPlatform("linux");
+		expect(canonicaliseLocalFolder("/Var/Data/Vault")).toBe("/Var/Data/Vault");
+	});
+
+	it("lower-cases on win32 (the first operand of the platform check)", () => {
+		stubPlatform("win32");
+		expect(canonicaliseLocalFolder("/Var/Data/Vault")).toBe("/var/data/vault");
+	});
+});

--- a/cli/src/sync/VaultLockPath.test.ts
+++ b/cli/src/sync/VaultLockPath.test.ts
@@ -91,6 +91,22 @@ describe("canonicaliseLocalFolder", () => {
 		expect(out).not.toMatch(/[/\\]{2,}/);
 	});
 
+	it("expands a bare `~` to the home directory (step 1)", () => {
+		const { homedir } = require("node:os");
+		// `~` alone → exactly the home dir (after the realpath/case-fold steps,
+		// which are idempotent for an existing dir like $HOME).
+		const out = canonicaliseLocalFolder("~");
+		const expected = canonicaliseLocalFolder(homedir());
+		expect(out).toBe(expected);
+	});
+
+	it("expands a leading `~/` prefix to the home directory (step 1)", () => {
+		const { homedir } = require("node:os");
+		const out = canonicaliseLocalFolder("~/some-vault-dir");
+		const expected = canonicaliseLocalFolder(join(homedir(), "some-vault-dir"));
+		expect(out).toBe(expected);
+	});
+
 	it("__vaultLockCanonicalForTesting is a thin re-export of canonicaliseLocalFolder (test seam stability)", () => {
 		// If someone refactors and breaks the test-seam alias, dependent
 		// tests would silently start using stale logic. Pin the alias.

--- a/cli/src/sync/VaultSymlinkGuard.fsmock.test.ts
+++ b/cli/src/sync/VaultSymlinkGuard.fsmock.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Mock-isolated tests for the non-ENOENT lstat-error rethrow in both
+ * `assertNoSymlinksInPath` (async) and `assertNoSymlinksInPathSync`. A real
+ * filesystem can't reliably produce a non-ENOENT lstat failure (EACCES needs
+ * a 0-perm parent dir, which CI-as-root bypasses), so we mock the lstat calls
+ * to throw EACCES and assert the guard surfaces it rather than swallowing it.
+ *
+ * Separate from `VaultSymlinkGuard.test.ts`, which exercises the real fs.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+
+const { mockLstat, mockLstatSync } = vi.hoisted(() => ({
+	mockLstat: vi.fn(),
+	mockLstatSync: vi.fn(),
+}));
+
+vi.mock("node:fs/promises", async (importActual) => {
+	const actual = await importActual<typeof import("node:fs/promises")>();
+	return { ...actual, lstat: mockLstat };
+});
+
+vi.mock("node:fs", async (importActual) => {
+	const actual = await importActual<typeof import("node:fs")>();
+	return { ...actual, lstatSync: mockLstatSync };
+});
+
+import { assertNoSymlinksInPath, assertNoSymlinksInPathSync } from "./VaultSymlinkGuard.js";
+
+const eacces = () => Object.assign(new Error("EACCES: permission denied"), { code: "EACCES" });
+
+describe("VaultSymlinkGuard rethrows non-ENOENT lstat errors", () => {
+	it("async: surfaces a non-ENOENT lstat error instead of treating it as a clean chain", async () => {
+		mockLstat.mockRejectedValue(eacces());
+		await expect(assertNoSymlinksInPath("/vault", "/vault/repo/.jolli/x.json")).rejects.toThrow(/EACCES/);
+	});
+
+	it("sync: surfaces a non-ENOENT lstatSync error instead of treating it as a clean chain", () => {
+		mockLstatSync.mockImplementation(() => {
+			throw eacces();
+		});
+		expect(() => assertNoSymlinksInPathSync("/vault", "/vault/repo/.jolli/x.json")).toThrow(/EACCES/);
+	});
+});

--- a/cli/src/sync/VaultSymlinkGuard.test.ts
+++ b/cli/src/sync/VaultSymlinkGuard.test.ts
@@ -1,8 +1,8 @@
-import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { lstatSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { assertNoSymlinksInPath } from "./VaultSymlinkGuard.js";
+import { assertNoSymlinksInPath, assertNoSymlinksInPathSync, safeAtomicWriteSync } from "./VaultSymlinkGuard.js";
 
 describe("assertNoSymlinksInPath", () => {
 	let vault: string;
@@ -95,5 +95,93 @@ describe("assertNoSymlinksInPath", () => {
 		await expect(assertNoSymlinksInPath("relative-vault", join(vault, "x.json"))).rejects.toThrow(
 			/must be absolute/,
 		);
+	});
+});
+
+// The sync twin shares the exact contract of the async function; these mirror
+// the async cases so FolderStorage's sync atomicWrite path is equally guarded.
+describe("assertNoSymlinksInPathSync", () => {
+	let vault: string;
+
+	beforeEach(() => {
+		vault = mkdtempSync(join(tmpdir(), "vault-symlink-sync-"));
+	});
+
+	afterEach(() => {
+		rmSync(vault, { recursive: true, force: true });
+	});
+
+	it("accepts a clean target and tolerates not-yet-existing segments", () => {
+		mkdirSync(join(vault, "myrepo", ".jolli"), { recursive: true });
+		expect(() =>
+			assertNoSymlinksInPathSync(vault, join(vault, "myrepo", ".jolli", "summaries", "abc.json")),
+		).not.toThrow();
+		// ENOENT tail (nothing under <vault>/cold/ exists) must not throw.
+		expect(() => assertNoSymlinksInPathSync(vault, join(vault, "cold", "x", "y.json"))).not.toThrow();
+	});
+
+	it("rejects a symlink in the path chain", () => {
+		mkdirSync(join(vault, "myrepo"), { recursive: true });
+		const escapeTarget = mkdtempSync(join(tmpdir(), "escape-"));
+		try {
+			symlinkSync(escapeTarget, join(vault, "myrepo", ".jolli"), "dir");
+			expect(() =>
+				assertNoSymlinksInPathSync(vault, join(vault, "myrepo", ".jolli", "summaries", "abc.json")),
+			).toThrow(/path segment is a symlink/);
+		} finally {
+			rmSync(escapeTarget, { recursive: true, force: true });
+		}
+	});
+
+	it("rejects a regular file where a directory is expected", () => {
+		writeFileSync(join(vault, "myrepo"), "not a dir");
+		expect(() => assertNoSymlinksInPathSync(vault, join(vault, "myrepo", ".jolli", "index.json"))).toThrow(
+			/not a directory/,
+		);
+	});
+
+	it("rejects a target outside the vault and non-absolute args", () => {
+		expect(() => assertNoSymlinksInPathSync(vault, "/etc/passwd")).toThrow(/not inside vault/);
+		expect(() => assertNoSymlinksInPathSync(vault, "myrepo/x.json")).toThrow(/must be absolute/);
+		expect(() => assertNoSymlinksInPathSync("rel-vault", join(vault, "x.json"))).toThrow(/must be absolute/);
+	});
+});
+
+describe("safeAtomicWriteSync", () => {
+	let vault: string;
+
+	beforeEach(() => {
+		vault = mkdtempSync(join(tmpdir(), "vault-safewrite-"));
+	});
+
+	afterEach(() => {
+		rmSync(vault, { recursive: true, force: true });
+	});
+
+	it("writes string content atomically, creating parent dirs, and leaves no .tmp behind", () => {
+		const target = join(vault, "myrepo", ".jolli", "index.json");
+		safeAtomicWriteSync(vault, target, '{"k":1}');
+		expect(readFileSync(target, "utf-8")).toBe('{"k":1}');
+		expect(() => lstatSync(`${target}.tmp`)).toThrow(); // tmp renamed away
+	});
+
+	it("writes Buffer content (the binary branch)", () => {
+		const target = join(vault, "myrepo", "blob.bin");
+		const buf = Buffer.from([0x00, 0x01, 0x02, 0xff]);
+		safeAtomicWriteSync(vault, target, buf);
+		expect(readFileSync(target).equals(buf)).toBe(true);
+	});
+
+	it("refuses to write through a symlinked path segment", () => {
+		mkdirSync(join(vault, "myrepo"), { recursive: true });
+		const escapeTarget = mkdtempSync(join(tmpdir(), "escape-"));
+		try {
+			symlinkSync(escapeTarget, join(vault, "myrepo", ".jolli"), "dir");
+			expect(() => safeAtomicWriteSync(vault, join(vault, "myrepo", ".jolli", "x.json"), "leak")).toThrow(
+				/symlink/,
+			);
+		} finally {
+			rmSync(escapeTarget, { recursive: true, force: true });
+		}
 	});
 });

--- a/cli/src/sync/VaultSymlinkGuard.ts
+++ b/cli/src/sync/VaultSymlinkGuard.ts
@@ -94,7 +94,9 @@ export async function assertNoSymlinksInPath(vaultRoot: string, absTargetPath: s
 	let cur = vaultRoot;
 	for (let i = 0; i < segments.length - 1; i++) {
 		const seg = segments[i];
+		/* v8 ignore start -- defensive: `relative()` normalises away empty/duplicate segments, so an empty `seg` is unreachable here; the guard stays in case a future caller bypasses normalisation */
 		if (seg === undefined || seg.length === 0) continue;
+		/* v8 ignore stop */
 		cur = `${cur}${sep}${seg}`;
 		let stat: Awaited<ReturnType<typeof lstat>>;
 		try {
@@ -153,7 +155,9 @@ export function assertNoSymlinksInPathSync(vaultRoot: string, absTargetPath: str
 	let cur = vaultRoot;
 	for (let i = 0; i < segments.length - 1; i++) {
 		const seg = segments[i];
+		/* v8 ignore start -- defensive: `relative()` normalises away empty/duplicate segments, so an empty `seg` is unreachable here; the guard stays in case a future caller bypasses normalisation */
 		if (seg === undefined || seg.length === 0) continue;
+		/* v8 ignore stop */
 		cur = `${cur}${sep}${seg}`;
 		let stat: ReturnType<typeof lstatSync>;
 		try {

--- a/docs/superpowers/plans/2026-06-08-knowledge-index-and-search-p0.md
+++ b/docs/superpowers/plans/2026-06-08-knowledge-index-and-search-p0.md
@@ -1,0 +1,1530 @@
+# Knowledge Index & Search (P0) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a local full-text search index (Orama) over JolliMemory's topic KB + commit catalog, and an stdio MCP server exposing `search`, `recall`, `get_decision_timeline`, `list_branches` to AI agents, auto-registered into Claude Code's `.mcp.json`.
+
+**Architecture:** A pure projection module (`SearchIndexSource`) turns the two on-disk sources into a flat `SearchDoc[]`. A thin Orama wrapper (`SearchIndex`) builds/searches/persists the index at `.jolli/jollimemory/search-index.json`, with a cheap staleness fingerprint that triggers a full rebuild when source data changed. An MCP server (`McpServer`) declares four tools and dispatches to `SearchIndex` and the existing `ContextCompiler`. `jolli mcp` launches the server (a subcommand of the already-bundled `Cli.js`, so no new bundle entry). The Installer writes a `.mcp.json` entry via the existing `resolve-dist-path` indirection.
+
+**Tech Stack:** TypeScript (ESM), `@orama/orama` (in-memory BM25 full-text), `@orama/plugin-data-persistence` (JSON serialize/restore), `@modelcontextprotocol/sdk` (MCP stdio server), `commander` (CLI), Vitest (tests, 97% coverage floor).
+
+**Standing preferences honored in this plan (per project memory):**
+- Each implementation task contains **only tests + implementation**, plus a focused single-file `vitest` run for red/green. **No per-task `git commit`, no per-task `npm run all`.**
+- The **final task** runs `npm run all` once and creates **one commit**.
+- DCO sign-off (`git commit -s`), **no** `Co-Authored-By: Claude` / `🤖 Generated with` trailers.
+- `toForwardSlash` for any `\`→`/` normalization; never inline `replace(/\\/g,"/")`.
+
+---
+
+## File structure
+
+| File | Responsibility |
+|---|---|
+| `cli/src/core/SearchIndexTypes.ts` (create) | `SearchDoc` interface, the Orama schema literal, `SCHEMA_VERSION`, `IndexManifest` interface. Pure types + constants. |
+| `cli/src/core/SearchIndexSource.ts` (create) | `collectSearchDocs(cwd, storage)` → `SearchDoc[]` and `computeSourceSignature(cwd, storage)` → `string`. The only module that knows the on-disk source layouts. |
+| `cli/src/core/SearchIndex.ts` (create) | `SearchIndex` class wrapping Orama: build/search/persist/restore + staleness check. Reads/writes the local index file. |
+| `cli/src/mcp/McpTools.ts` (create) | Pure tool handlers (`runSearch`, `runRecall`, `runDecisionTimeline`, `runListBranches`) returning plain JSON-serializable objects. No SDK coupling — unit-testable. |
+| `cli/src/mcp/McpServer.ts` (create) | Wires `McpTools` handlers into an `@modelcontextprotocol/sdk` `Server` over stdio. Tool schemas + dispatch only. |
+| `cli/src/commands/McpCommand.ts` (create) | `registerMcpCommand(program)` → `jolli mcp [--reindex]`. |
+| `cli/src/install/McpRegistration.ts` (create) | `registerMcpInClaude(worktreeDir)` / `removeMcpFromClaude(worktreeDir)` — edit `.mcp.json`. |
+| `cli/src/Api.ts` (modify) | Register the new command. |
+| `cli/src/core/MultiRepoCompile.ts` (modify) | Incremental index upsert after each repo's wiki render. |
+| `cli/src/install/Installer.ts` (modify) | Call `registerMcpInClaude` in the per-worktree loop; `removeMcpFromClaude` on uninstall. |
+| `cli/package.json` (modify) | Add the three runtime deps. |
+| Test files | Co-located `*.test.ts` next to each new module. |
+
+---
+
+## Task 0: Add dependencies and prove they bundle
+
+**Why first:** All three deps are ESM-first. The headline risk is that `@modelcontextprotocol/sdk` (or an Orama subpath export) fails to resolve when esbuild bundles `Cli.js` into the VS Code extension's CJS bundle. De-risk before building features.
+
+**Files:**
+- Modify: `cli/package.json`
+- Create: `cli/src/mcp/DepSmoke.test.ts`
+
+- [ ] **Step 1: Add the runtime dependencies**
+
+Edit `cli/package.json` `dependencies` (keep alphabetical order):
+
+```json
+	"dependencies": {
+		"@anthropic-ai/sdk": "^0.39.0",
+		"@modelcontextprotocol/sdk": "^1.0.0",
+		"@orama/orama": "^3.0.0",
+		"@orama/plugin-data-persistence": "^3.0.0",
+		"commander": "^13.1.0",
+		"open": "^11.0.0",
+		"semver": "^7.8.1"
+	},
+```
+
+- [ ] **Step 2: Install**
+
+Run: `npm install`
+Expected: lockfile updates, all three packages added. Re-`git add package-lock.json` (root) since a later `npm install` would otherwise desync it.
+
+- [ ] **Step 3: Write an import smoke test**
+
+`cli/src/mcp/DepSmoke.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+
+describe("dependency smoke test", () => {
+	it("imports @orama/orama core fns", async () => {
+		const orama = await import("@orama/orama");
+		expect(typeof orama.create).toBe("function");
+		expect(typeof orama.search).toBe("function");
+		expect(typeof orama.insertMultiple).toBe("function");
+	});
+
+	it("imports @orama/plugin-data-persistence", async () => {
+		const p = await import("@orama/plugin-data-persistence");
+		expect(typeof p.persist).toBe("function");
+		expect(typeof p.restore).toBe("function");
+	});
+
+	it("imports MCP SDK Server + stdio transport", async () => {
+		const { Server } = await import("@modelcontextprotocol/sdk/server/index.js");
+		const { StdioServerTransport } = await import("@modelcontextprotocol/sdk/server/stdio.js");
+		expect(typeof Server).toBe("function");
+		expect(typeof StdioServerTransport).toBe("function");
+	});
+});
+```
+
+- [ ] **Step 4: Run the smoke test (red→green)**
+
+Run: `npm run test -w @jolli.ai/cli -- src/mcp/DepSmoke.test.ts`
+Expected: PASS. If any import resolves to a wrong subpath, fix the import path here (e.g. some Orama versions export persistence from `@orama/plugin-data-persistence`'s root — adjust to the actual exported entry the installed version provides) before continuing.
+
+- [ ] **Step 5: Prove the VS Code CJS bundle still builds with the new imports**
+
+This is the real risk gate. Build the CLI then the VS Code bundle:
+
+Run: `cd cli && npm run build && cd ../vscode && npm run build 2>&1 | tail -20`
+Expected: esbuild completes with no "Could not resolve" errors. If esbuild errors on an ESM-only subpath, resolve by adding the package to esbuild's bundling (it bundles `node_modules` by default) — the failure mode to watch is a dynamic `require` inside the SDK. If unresolvable, STOP and report; do not work around silently.
+
+> No commit in this task (per standing preference). Verification + commit happen in the final task.
+
+---
+
+## Task 1: SearchDoc types and Orama schema
+
+**Files:**
+- Create: `cli/src/core/SearchIndexTypes.ts`
+
+- [ ] **Step 1: Write the types module**
+
+`cli/src/core/SearchIndexTypes.ts`:
+
+```ts
+/**
+ * Shared types + constants for the local full-text search index (JOLLI-1226 P0).
+ * Pure module: no runtime behavior, no I/O.
+ */
+
+/** Bump when the document shape or Orama schema changes — forces a rebuild. */
+export const SEARCH_SCHEMA_VERSION = 1 as const;
+
+/** A single indexed document. Topics and commits share one flat shape. */
+export interface SearchDoc {
+	/** "topic:<stableSlug>" | "commit:<fullHash>" — also the Orama document id. */
+	readonly id: string;
+	readonly type: "topic" | "commit";
+	readonly title: string;
+	/** Full searchable body. */
+	readonly content: string;
+	/** Joined decision text; "" when none. */
+	readonly decisions: string;
+	/** commit: branch; topic: relatedBranches joined by space. */
+	readonly branch: string;
+	/** commit: source kind ("commit"); topic: dominant sourceRef type. */
+	readonly category: string;
+	/** ISO 8601. commit: commitDate; topic: lastUpdatedAt. */
+	readonly commitDate: string;
+	/** Topic stableSlug, else "". */
+	readonly slug: string;
+	/** Commit fullHash, else "". */
+	readonly hash: string;
+}
+
+/** Orama schema literal. Every field is a filterable/searchable string for P0. */
+export const SEARCH_SCHEMA = {
+	id: "string",
+	type: "string",
+	title: "string",
+	content: "string",
+	decisions: "string",
+	branch: "string",
+	category: "string",
+	commitDate: "string",
+	slug: "string",
+	hash: "string",
+} as const;
+
+/** Sidecar manifest persisted next to the index file. */
+export interface IndexManifest {
+	readonly schemaVersion: number;
+	/** Output of computeSourceSignature() at persist time. */
+	readonly sourceSignature: string;
+	readonly savedAt: string;
+}
+```
+
+> No test for a pure types/constants module. No commit.
+
+---
+
+## Task 2: SearchIndexSource — project sources into SearchDocs
+
+**Files:**
+- Create: `cli/src/core/SearchIndexSource.ts`
+- Create: `cli/src/core/SearchIndexSource.test.ts`
+
+Reused APIs (already exist):
+- `getIndex(cwd?, storage?): Promise<SummaryIndex | null>` — `entries[]` carry `commitHash`, `branch`, `commitDate`, `generatedAt`.
+- `getCatalogWithLazyBuild(cwd?, storage?): Promise<CommitCatalog>` — `entries[]` carry `commitHash`, `recap?`, `ticketId?`, `topics?: CatalogTopic[]` (`{title, decisions?, category?, importance?, filesAffected?}`).
+- `readTopicIndex(cwd?, storage?): Promise<TopicIndex>` — `topics: TopicIndexEntry[]`.
+- `readTopicPage(slug, cwd?, storage?): Promise<TopicPage | null>` — `{content, relatedBranches, sourceRefs, lastUpdatedAt, title}`.
+
+- [ ] **Step 1: Write the failing test**
+
+`cli/src/core/SearchIndexSource.test.ts`:
+
+```ts
+import { describe, expect, it, vi } from "vitest";
+import type { StorageProvider } from "./StorageProvider.js";
+
+// Mock the four stores this module reads.
+vi.mock("./SummaryStore.js", () => ({
+	getIndex: vi.fn(),
+	getCatalogWithLazyBuild: vi.fn(),
+}));
+vi.mock("./TopicIndexStore.js", () => ({ readTopicIndex: vi.fn() }));
+vi.mock("./TopicPageStore.js", () => ({ readTopicPage: vi.fn() }));
+
+import { collectSearchDocs, computeSourceSignature } from "./SearchIndexSource.js";
+import { getCatalogWithLazyBuild, getIndex } from "./SummaryStore.js";
+import { readTopicIndex } from "./TopicIndexStore.js";
+import { readTopicPage } from "./TopicPageStore.js";
+
+const storage = {} as StorageProvider;
+
+function wireSources() {
+	vi.mocked(getIndex).mockResolvedValue({
+		version: 3,
+		entries: [
+			{
+				commitHash: "abc123def456",
+				parentCommitHash: null,
+				commitMessage: "add auth timeout",
+				commitDate: "2026-01-02T00:00:00Z",
+				branch: "feature/auth",
+				generatedAt: "2026-01-02T01:00:00Z",
+			},
+		],
+	} as never);
+	vi.mocked(getCatalogWithLazyBuild).mockResolvedValue({
+		version: 1,
+		entries: [
+			{
+				commitHash: "abc123def456",
+				recap: "Added a configurable auth session timeout.",
+				ticketId: "JOLLI-1",
+				topics: [{ title: "Auth timeout", decisions: "Chose a 30-min hard cap." }],
+			},
+		],
+	} as never);
+	vi.mocked(readTopicIndex).mockResolvedValue({
+		schemaVersion: 1,
+		topics: [
+			{
+				stableSlug: "auth-timeout",
+				title: "Auth Timeout",
+				summary: "How session timeout works",
+				relatedBranches: ["feature/auth", "main"],
+				sourceRefs: [
+					{ type: "summary", id: "abc123def456", timestamp: "2026-01-02T00:00:00Z", branch: "feature/auth" },
+				],
+				lastUpdatedAt: "2026-01-03T00:00:00Z",
+			},
+		],
+	} as never);
+	vi.mocked(readTopicPage).mockResolvedValue({
+		schemaVersion: 1,
+		stableSlug: "auth-timeout",
+		title: "Auth Timeout",
+		content: "The auth session has a 30-minute hard timeout.",
+		relatedBranches: ["feature/auth", "main"],
+		sourceRefs: [
+			{ type: "summary", id: "abc123def456", timestamp: "2026-01-02T00:00:00Z", branch: "feature/auth" },
+		],
+		lastUpdatedAt: "2026-01-03T00:00:00Z",
+	} as never);
+}
+
+describe("collectSearchDocs", () => {
+	it("emits one topic doc and one commit doc with joined fields", async () => {
+		wireSources();
+		const docs = await collectSearchDocs("/repo", storage);
+
+		const topic = docs.find((d) => d.id === "topic:auth-timeout");
+		expect(topic).toBeDefined();
+		expect(topic?.type).toBe("topic");
+		expect(topic?.content).toContain("30-minute hard timeout");
+		expect(topic?.branch).toBe("feature/auth main");
+		expect(topic?.slug).toBe("auth-timeout");
+		expect(topic?.commitDate).toBe("2026-01-03T00:00:00Z");
+
+		const commit = docs.find((d) => d.id === "commit:abc123def456");
+		expect(commit).toBeDefined();
+		expect(commit?.type).toBe("commit");
+		expect(commit?.branch).toBe("feature/auth");
+		expect(commit?.hash).toBe("abc123def456");
+		expect(commit?.decisions).toContain("30-min hard cap");
+		expect(commit?.content).toContain("Auth timeout"); // topic title folded into body
+		expect(commit?.content).toContain("configurable auth session timeout"); // recap folded in
+	});
+
+	it("returns [] when there is no data", async () => {
+		vi.mocked(getIndex).mockResolvedValue(null);
+		vi.mocked(getCatalogWithLazyBuild).mockResolvedValue({ version: 1, entries: [] } as never);
+		vi.mocked(readTopicIndex).mockResolvedValue({ schemaVersion: 1, topics: [] } as never);
+		const docs = await collectSearchDocs("/repo", storage);
+		expect(docs).toEqual([]);
+	});
+});
+
+describe("computeSourceSignature", () => {
+	it("changes when source counts or timestamps change", async () => {
+		wireSources();
+		const sig1 = await computeSourceSignature("/repo", storage);
+
+		vi.mocked(readTopicIndex).mockResolvedValue({
+			schemaVersion: 1,
+			topics: [
+				{
+					stableSlug: "auth-timeout",
+					title: "Auth Timeout",
+					summary: "x",
+					relatedBranches: [],
+					sourceRefs: [],
+					lastUpdatedAt: "2026-09-09T00:00:00Z", // newer
+				},
+			],
+		} as never);
+		const sig2 = await computeSourceSignature("/repo", storage);
+		expect(sig2).not.toBe(sig1);
+	});
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `npm run test -w @jolli.ai/cli -- src/core/SearchIndexSource.test.ts`
+Expected: FAIL — `collectSearchDocs is not a function` (module doesn't exist).
+
+- [ ] **Step 3: Implement the module**
+
+`cli/src/core/SearchIndexSource.ts`:
+
+```ts
+/**
+ * Projects JolliMemory's two on-disk sources — the topic KB (topics/index.json
+ * + topic pages) and the raw commit catalog (catalog.json, joined with
+ * index.json for branch/date) — into the flat SearchDoc shape the Orama index
+ * consumes. The ONLY module that knows these source layouts; SearchIndex stays
+ * source-agnostic.
+ */
+
+import type { StorageProvider } from "./StorageProvider.js";
+import { getCatalogWithLazyBuild, getIndex } from "./SummaryStore.js";
+import type { SearchDoc } from "./SearchIndexTypes.js";
+import { SEARCH_SCHEMA_VERSION } from "./SearchIndexTypes.js";
+import { readTopicIndex } from "./TopicIndexStore.js";
+import { readTopicPage } from "./TopicPageStore.js";
+
+/** Build every SearchDoc from current source data. */
+export async function collectSearchDocs(cwd: string, storage?: StorageProvider): Promise<SearchDoc[]> {
+	const [topicDocs, commitDocs] = await Promise.all([
+		collectTopicDocs(cwd, storage),
+		collectCommitDocs(cwd, storage),
+	]);
+	return [...topicDocs, ...commitDocs];
+}
+
+async function collectTopicDocs(cwd: string, storage?: StorageProvider): Promise<SearchDoc[]> {
+	const index = await readTopicIndex(cwd, storage);
+	const docs = await Promise.all(
+		index.topics.map(async (entry) => {
+			const page = await readTopicPage(entry.stableSlug, cwd, storage);
+			const content = page?.content ?? entry.summary;
+			const branches = (page?.relatedBranches ?? entry.relatedBranches).join(" ");
+			const category = dominantSourceType(page?.sourceRefs ?? entry.sourceRefs);
+			const doc: SearchDoc = {
+				id: `topic:${entry.stableSlug}`,
+				type: "topic",
+				title: entry.title,
+				content: `${entry.title}\n${content}`,
+				decisions: "",
+				branch: branches,
+				category,
+				commitDate: page?.lastUpdatedAt ?? entry.lastUpdatedAt,
+				slug: entry.stableSlug,
+				hash: "",
+			};
+			return doc;
+		}),
+	);
+	return docs;
+}
+
+async function collectCommitDocs(cwd: string, storage?: StorageProvider): Promise<SearchDoc[]> {
+	const [index, catalog] = await Promise.all([
+		getIndex(cwd, storage),
+		getCatalogWithLazyBuild(cwd, storage),
+	]);
+	if (!index) return [];
+
+	// Join: catalog has recap/topics/decisions; index has branch/date. Key = commitHash.
+	const metaByHash = new Map(index.entries.map((e) => [e.commitHash, e]));
+
+	const docs: SearchDoc[] = [];
+	for (const entry of catalog.entries) {
+		const meta = metaByHash.get(entry.commitHash);
+		if (!meta) continue; // catalog entry without an index head — skip (not browsable)
+
+		const topicTitles = (entry.topics ?? []).map((t) => t.title).join("\n");
+		const decisions = (entry.topics ?? [])
+			.map((t) => t.decisions)
+			.filter((d): d is string => Boolean(d))
+			.join("\n");
+		const bodyParts = [meta.commitMessage, entry.recap, topicTitles, decisions].filter(Boolean);
+
+		docs.push({
+			id: `commit:${entry.commitHash}`,
+			type: "commit",
+			title: meta.commitMessage,
+			content: bodyParts.join("\n"),
+			decisions,
+			branch: meta.branch,
+			category: "commit",
+			commitDate: meta.commitDate,
+			slug: "",
+			hash: entry.commitHash,
+		});
+	}
+	return docs;
+}
+
+function dominantSourceType(refs: ReadonlyArray<{ type: string }>): string {
+	if (refs.length === 0) return "topic";
+	const counts = new Map<string, number>();
+	for (const r of refs) counts.set(r.type, (counts.get(r.type) ?? 0) + 1);
+	return [...counts.entries()].sort((a, b) => b[1] - a[1])[0][0];
+}
+
+/**
+ * Cheap signature of source state. Changes whenever a source count or its
+ * newest timestamp changes — enough to detect "data moved since last persist"
+ * without rebuilding to compare. Used by SearchIndex's staleness check.
+ */
+export async function computeSourceSignature(cwd: string, storage?: StorageProvider): Promise<string> {
+	const [index, catalog, topicIndex] = await Promise.all([
+		getIndex(cwd, storage),
+		getCatalogWithLazyBuild(cwd, storage),
+		readTopicIndex(cwd, storage),
+	]);
+	const indexCount = index?.entries.length ?? 0;
+	const newestGeneratedAt = (index?.entries ?? []).reduce((max, e) => (e.generatedAt > max ? e.generatedAt : max), "");
+	const topicNewest = topicIndex.topics.reduce((max, t) => (t.lastUpdatedAt > max ? t.lastUpdatedAt : max), "");
+	return [
+		SEARCH_SCHEMA_VERSION,
+		indexCount,
+		catalog.entries.length,
+		topicIndex.topics.length,
+		newestGeneratedAt,
+		topicNewest,
+	].join("|");
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `npm run test -w @jolli.ai/cli -- src/core/SearchIndexSource.test.ts`
+Expected: PASS.
+
+> No commit (per standing preference).
+
+---
+
+## Task 3: SearchIndex — Orama wrapper with persistence + staleness
+
+**Files:**
+- Create: `cli/src/core/SearchIndex.ts`
+- Create: `cli/src/core/SearchIndex.test.ts`
+
+`SearchHitResult` is the search return shape consumed by the MCP `search` tool and by `jolli mcp` output.
+
+- [ ] **Step 1: Write the failing test**
+
+`cli/src/core/SearchIndex.test.ts`:
+
+```ts
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { SearchDoc } from "./SearchIndexTypes.js";
+
+vi.mock("./SearchIndexSource.js", () => ({
+	collectSearchDocs: vi.fn(),
+	computeSourceSignature: vi.fn(),
+}));
+
+import { SearchIndex } from "./SearchIndex.js";
+import { collectSearchDocs, computeSourceSignature } from "./SearchIndexSource.js";
+
+const docs: SearchDoc[] = [
+	{
+		id: "topic:auth-timeout",
+		type: "topic",
+		title: "Auth Timeout",
+		content: "Auth Timeout\nThe auth session has a 30-minute hard timeout.",
+		decisions: "",
+		branch: "feature/auth main",
+		category: "summary",
+		commitDate: "2026-01-03T00:00:00Z",
+		slug: "auth-timeout",
+		hash: "",
+	},
+	{
+		id: "commit:abc123",
+		type: "commit",
+		title: "add auth timeout",
+		content: "add auth timeout\nChose a 30-min hard cap.",
+		decisions: "Chose a 30-min hard cap.",
+		branch: "feature/auth",
+		category: "commit",
+		commitDate: "2026-01-02T00:00:00Z",
+		slug: "",
+		hash: "abc123",
+	},
+];
+
+let dir: string;
+beforeEach(async () => {
+	dir = await mkdtemp(join(tmpdir(), "jolli-idx-"));
+	vi.mocked(collectSearchDocs).mockResolvedValue(docs);
+	vi.mocked(computeSourceSignature).mockResolvedValue("sig-v1");
+});
+afterEach(async () => {
+	await rm(dir, { recursive: true, force: true });
+});
+
+describe("SearchIndex", () => {
+	it("builds from sources and finds a full-text match", async () => {
+		const idx = await SearchIndex.open(dir);
+		const res = await idx.search({ query: "auth timeout" });
+		expect(res.length).toBeGreaterThan(0);
+		expect(res.map((r) => r.id)).toContain("topic:auth-timeout");
+	});
+
+	it("filters by type and branch", async () => {
+		const idx = await SearchIndex.open(dir);
+		const commitsOnly = await idx.search({ query: "auth", type: "commit" });
+		expect(commitsOnly.every((r) => r.type === "commit")).toBe(true);
+	});
+
+	it("persists and restores without rebuilding when the signature matches", async () => {
+		const idx = await SearchIndex.open(dir); // builds + persists
+		vi.mocked(collectSearchDocs).mockClear();
+
+		const reopened = await SearchIndex.open(dir); // signature unchanged → restore
+		const res = await reopened.search({ query: "timeout" });
+		expect(res.length).toBeGreaterThan(0);
+		expect(collectSearchDocs).not.toHaveBeenCalled(); // restored, not rebuilt
+	});
+
+	it("rebuilds when the source signature changed", async () => {
+		await SearchIndex.open(dir); // persists with sig-v1
+		vi.mocked(computeSourceSignature).mockResolvedValue("sig-v2");
+		vi.mocked(collectSearchDocs).mockClear();
+
+		await SearchIndex.open(dir);
+		expect(collectSearchDocs).toHaveBeenCalledTimes(1); // stale → rebuilt
+	});
+
+	it("rebuilds when the persisted file is corrupt", async () => {
+		const { writeFile } = await import("node:fs/promises");
+		await SearchIndex.open(dir);
+		await writeFile(join(dir, ".jolli", "jollimemory", "search-index.json"), "{ not json", "utf-8").catch(
+			async () => {
+				// directory layout differs in test cwd; write to the resolved path instead
+			},
+		);
+		// Force-reindex path always rebuilds regardless of file state:
+		const idx = await SearchIndex.open(dir);
+		const res = await idx.reindex();
+		expect(res.docCount).toBe(docs.length);
+	});
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `npm run test -w @jolli.ai/cli -- src/core/SearchIndex.test.ts`
+Expected: FAIL — `SearchIndex is not defined`.
+
+- [ ] **Step 3: Implement the module**
+
+`cli/src/core/SearchIndex.ts`:
+
+```ts
+/**
+ * SearchIndex — thin Orama wrapper for JolliMemory's local full-text search
+ * (JOLLI-1226 P0). Builds an in-memory BM25 index from SearchIndexSource,
+ * persists it to .jolli/jollimemory/search-index.json, and rebuilds whenever
+ * the source signature changes (or the persisted file is missing/corrupt).
+ * The index is a disposable cache — source data (orphan branch / folder) is
+ * always authoritative.
+ */
+
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { type AnyOrama, create, insertMultiple, search } from "@orama/orama";
+import { persist, restore } from "@orama/plugin-data-persistence";
+import { createLogger } from "../Logger.js";
+import { getJolliMemoryDir } from "../Logger.js";
+import { collectSearchDocs, computeSourceSignature } from "./SearchIndexSource.js";
+import { type IndexManifest, SEARCH_SCHEMA, SEARCH_SCHEMA_VERSION, type SearchDoc } from "./SearchIndexTypes.js";
+import type { StorageProvider } from "./StorageProvider.js";
+
+const log = createLogger("SearchIndex");
+
+const INDEX_FILE = "search-index.json";
+const MANIFEST_FILE = "search-index.manifest.json";
+
+export interface SearchQuery {
+	readonly query: string;
+	readonly branch?: string;
+	readonly type?: "topic" | "commit";
+	readonly limit?: number;
+}
+
+export interface SearchHitResult {
+	readonly id: string;
+	readonly type: "topic" | "commit";
+	readonly title: string;
+	readonly snippet: string;
+	readonly branch: string;
+	readonly commitDate: string;
+	readonly slug: string;
+	readonly hash: string;
+	readonly score: number;
+}
+
+export class SearchIndex {
+	private constructor(
+		private readonly db: AnyOrama,
+		private readonly cwd: string,
+		private readonly storage: StorageProvider | undefined,
+	) {}
+
+	/** Open the index: restore from disk if fresh, else rebuild and persist. */
+	static async open(cwd: string, storage?: StorageProvider): Promise<SearchIndex> {
+		const sig = await computeSourceSignature(cwd, storage);
+		const restored = await tryRestore(cwd, sig);
+		if (restored) return new SearchIndex(restored, cwd, storage);
+
+		const db = await build(cwd, storage);
+		await SearchIndex.persistTo(cwd, db, sig);
+		return new SearchIndex(db, cwd, storage);
+	}
+
+	/** Force a full rebuild from source, persist, and return the new count. */
+	async reindex(): Promise<{ docCount: number }> {
+		const sig = await computeSourceSignature(this.cwd, this.storage);
+		const docs = await collectSearchDocs(this.cwd, this.storage);
+		const fresh = create({ schema: SEARCH_SCHEMA });
+		await insertMultiple(fresh, docs as never[]);
+		await SearchIndex.persistTo(this.cwd, fresh, sig);
+		// Swap the live db by re-opening would lose `this` immutability; callers of
+		// reindex re-open. For the in-process case, mutate via a fresh search target:
+		(this as { db: AnyOrama }).db = fresh;
+		return { docCount: docs.length };
+	}
+
+	async search(q: SearchQuery): Promise<SearchHitResult[]> {
+		const where: Record<string, string> = {};
+		if (q.type) where.type = q.type;
+		if (q.branch) where.branch = q.branch;
+		const result = await search(this.db, {
+			term: q.query,
+			limit: q.limit ?? 20,
+			...(Object.keys(where).length ? { where } : {}),
+		});
+		return result.hits.map((h) => {
+			const doc = h.document as unknown as SearchDoc;
+			return {
+				id: doc.id,
+				type: doc.type,
+				title: doc.title,
+				snippet: doc.content.slice(0, 280),
+				branch: doc.branch,
+				commitDate: doc.commitDate,
+				slug: doc.slug,
+				hash: doc.hash,
+				score: h.score,
+			};
+		});
+	}
+
+	private static async persistTo(cwd: string, db: AnyOrama, sig: string): Promise<void> {
+		const indexPath = join(getJolliMemoryDir(cwd), INDEX_FILE);
+		await mkdir(dirname(indexPath), { recursive: true });
+		const serialized = await persist(db, "json");
+		await writeFile(indexPath, serialized as string, "utf-8");
+		const manifest: IndexManifest = {
+			schemaVersion: SEARCH_SCHEMA_VERSION,
+			sourceSignature: sig,
+			savedAt: new Date().toISOString(),
+		};
+		await writeFile(join(getJolliMemoryDir(cwd), MANIFEST_FILE), JSON.stringify(manifest), "utf-8");
+	}
+}
+
+async function build(cwd: string, storage?: StorageProvider): Promise<AnyOrama> {
+	const docs = await collectSearchDocs(cwd, storage);
+	const db = create({ schema: SEARCH_SCHEMA });
+	await insertMultiple(db, docs as never[]);
+	log.info("Built search index: %d docs", docs.length);
+	return db;
+}
+
+async function tryRestore(cwd: string, currentSig: string): Promise<AnyOrama | null> {
+	try {
+		const manifestRaw = await readFile(join(getJolliMemoryDir(cwd), MANIFEST_FILE), "utf-8");
+		const manifest = JSON.parse(manifestRaw) as IndexManifest;
+		if (manifest.schemaVersion !== SEARCH_SCHEMA_VERSION) return null;
+		if (manifest.sourceSignature !== currentSig) return null;
+		const indexRaw = await readFile(join(getJolliMemoryDir(cwd), INDEX_FILE), "utf-8");
+		return (await restore("json", indexRaw)) as AnyOrama;
+	} catch {
+		// Missing or corrupt → caller rebuilds.
+		return null;
+	}
+}
+```
+
+> NOTE on the Orama API: `create` is synchronous in Orama v3 and returns the db; `insertMultiple`/`search` are async. If the installed version differs (e.g. `create` returns a promise), adjust the `await` placement here — the Task 0 smoke test and these unit tests will catch a mismatch. Keep `as never[]` only if the strict schema-typed `insertMultiple` rejects the generic `SearchDoc[]`; prefer a typed Orama schema if it compiles cleanly under `noExplicitAny`.
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `npm run test -w @jolli.ai/cli -- src/core/SearchIndex.test.ts`
+Expected: PASS. If the corrupt-file test's path write is flaky, simplify it to delete the manifest file and assert `reindex()` still returns `docCount === docs.length`.
+
+> No commit.
+
+---
+
+## Task 4: MCP tool handlers (pure, SDK-free)
+
+**Files:**
+- Create: `cli/src/mcp/McpTools.ts`
+- Create: `cli/src/mcp/McpTools.test.ts`
+
+Reused APIs:
+- `compileTaskContext({ branch }, cwd): Promise<CompiledContext>` and `buildRecallPayload(ctx): RecallPayload`. **Note:** despite the name, `compileTaskContext` reads **raw `CommitSummary` records** from `index.json` (`CompiledContext.summaries` = "Raw, from orphan branch") — it does NOT read the topic KB. `runRecall` is therefore the exact same path the jolli-recall skill / `RecallCommand` use. "compile" here means "assemble raw summaries into context", unrelated to the topic-KB LLM-compiled artifacts.
+- `listBranchCatalog(cwd): Promise<BranchCatalog>`.
+- `readTopicPage(slug, cwd, storage): Promise<TopicPage | null>`.
+- Current branch resolution: reuse the existing git helper. Find it with `grep -rn "getCurrentBranch\|currentBranch" cli/src/core/GitClient.ts` and import that; the test mocks it.
+
+- [ ] **Step 1: Write the failing test**
+
+`cli/src/mcp/McpTools.test.ts`:
+
+```ts
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../core/SearchIndex.js", () => ({
+	SearchIndex: { open: vi.fn() },
+}));
+vi.mock("../core/ContextCompiler.js", () => ({
+	compileTaskContext: vi.fn(),
+	buildRecallPayload: vi.fn(),
+	listBranchCatalog: vi.fn(),
+}));
+vi.mock("../core/TopicPageStore.js", () => ({ readTopicPage: vi.fn() }));
+vi.mock("../core/GitClient.js", () => ({ getCurrentBranch: vi.fn() }));
+
+import { buildRecallPayload, compileTaskContext, listBranchCatalog } from "../core/ContextCompiler.js";
+import { getCurrentBranch } from "../core/GitClient.js";
+import { SearchIndex } from "../core/SearchIndex.js";
+import { readTopicPage } from "../core/TopicPageStore.js";
+import { runDecisionTimeline, runListBranches, runRecall, runSearch } from "./McpTools.js";
+
+describe("runSearch", () => {
+	it("delegates to SearchIndex.search and returns hits", async () => {
+		const search = vi.fn().mockResolvedValue([{ id: "topic:x", type: "topic", title: "X", score: 1 }]);
+		vi.mocked(SearchIndex.open).mockResolvedValue({ search } as never);
+		const out = await runSearch("/repo", { query: "auth", limit: 5 });
+		expect(search).toHaveBeenCalledWith({ query: "auth", limit: 5, branch: undefined, type: undefined });
+		expect(out.hits).toHaveLength(1);
+	});
+
+	it("rejects an empty query with a structured error", async () => {
+		await expect(runSearch("/repo", { query: "" })).rejects.toThrow(/query/i);
+	});
+});
+
+describe("runRecall", () => {
+	it("defaults to the current branch when none given", async () => {
+		vi.mocked(getCurrentBranch).mockResolvedValue("feature/auth");
+		vi.mocked(compileTaskContext).mockResolvedValue({ branch: "feature/auth" } as never);
+		vi.mocked(buildRecallPayload).mockReturnValue({ type: "recall", branch: "feature/auth" } as never);
+		const out = await runRecall("/repo", {});
+		expect(compileTaskContext).toHaveBeenCalledWith({ branch: "feature/auth" }, "/repo");
+		expect(out.branch).toBe("feature/auth");
+	});
+
+	it("uses the explicit branch when provided", async () => {
+		vi.mocked(compileTaskContext).mockResolvedValue({ branch: "main" } as never);
+		vi.mocked(buildRecallPayload).mockReturnValue({ type: "recall", branch: "main" } as never);
+		await runRecall("/repo", { branch: "main" });
+		expect(compileTaskContext).toHaveBeenCalledWith({ branch: "main" }, "/repo");
+	});
+});
+
+describe("runDecisionTimeline", () => {
+	it("sorts a topic's sourceRefs chronologically", async () => {
+		vi.mocked(readTopicPage).mockResolvedValue({
+			title: "Auth",
+			sourceRefs: [
+				{ type: "summary", id: "b", timestamp: "2026-02-01T00:00:00Z", branch: "x" },
+				{ type: "summary", id: "a", timestamp: "2026-01-01T00:00:00Z", branch: "x" },
+			],
+		} as never);
+		const out = await runDecisionTimeline("/repo", { slug: "auth" });
+		expect(out.timeline.map((t) => t.sourceId)).toEqual(["a", "b"]);
+	});
+
+	it("throws when the topic does not exist", async () => {
+		vi.mocked(readTopicPage).mockResolvedValue(null);
+		await expect(runDecisionTimeline("/repo", { slug: "missing" })).rejects.toThrow(/not found/i);
+	});
+});
+
+describe("runListBranches", () => {
+	it("returns the branch catalog", async () => {
+		vi.mocked(listBranchCatalog).mockResolvedValue({ type: "catalog", branches: [{ branch: "main" }] } as never);
+		const out = await runListBranches("/repo");
+		expect(out.branches).toHaveLength(1);
+	});
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `npm run test -w @jolli.ai/cli -- src/mcp/McpTools.test.ts`
+Expected: FAIL — handlers not defined.
+
+- [ ] **Step 3: Implement the handlers**
+
+First confirm the git helper name:
+
+Run: `grep -rn "export.*getCurrentBranch\|export.*currentBranch" cli/src/core/GitClient.ts`
+If the export is named differently, use that name in the import below and update the test mock to match.
+
+`cli/src/mcp/McpTools.ts`:
+
+```ts
+/**
+ * Pure MCP tool handlers (JOLLI-1226 P0). Each returns a plain
+ * JSON-serializable object and throws a plain Error on bad input. No MCP SDK
+ * coupling here so the handlers are unit-testable in isolation; McpServer.ts
+ * adapts these into SDK tool responses.
+ */
+
+import { buildRecallPayload, compileTaskContext, listBranchCatalog } from "../core/ContextCompiler.js";
+import type { BranchCatalog, RecallPayload } from "../core/ContextCompiler.js";
+import { getCurrentBranch } from "../core/GitClient.js";
+import { SearchIndex } from "../core/SearchIndex.js";
+import type { SearchHitResult } from "../core/SearchIndex.js";
+import { readTopicPage } from "../core/TopicPageStore.js";
+
+export interface SearchArgs {
+	query: string;
+	branch?: string;
+	type?: "topic" | "commit";
+	limit?: number;
+}
+
+export async function runSearch(cwd: string, args: SearchArgs): Promise<{ hits: SearchHitResult[] }> {
+	if (!args.query || !args.query.trim()) {
+		throw new Error("`query` is required and must be non-empty");
+	}
+	const index = await SearchIndex.open(cwd);
+	const hits = await index.search({
+		query: args.query,
+		branch: args.branch,
+		type: args.type,
+		limit: args.limit,
+	});
+	return { hits };
+}
+
+export async function runRecall(cwd: string, args: { branch?: string }): Promise<RecallPayload> {
+	const branch = args.branch ?? (await getCurrentBranch(cwd));
+	const ctx = await compileTaskContext({ branch }, cwd);
+	return buildRecallPayload(ctx);
+}
+
+export interface TimelineEntry {
+	timestamp: string;
+	branch: string;
+	sourceType: string;
+	sourceId: string;
+}
+
+export async function runDecisionTimeline(
+	cwd: string,
+	args: { slug: string },
+): Promise<{ slug: string; title: string; timeline: TimelineEntry[] }> {
+	if (!args.slug || !args.slug.trim()) {
+		throw new Error("`slug` is required");
+	}
+	const page = await readTopicPage(args.slug, cwd);
+	if (!page) {
+		throw new Error(`Topic not found: ${args.slug}`);
+	}
+	const timeline = [...page.sourceRefs]
+		.sort((a, b) => a.timestamp.localeCompare(b.timestamp))
+		.map((r) => ({ timestamp: r.timestamp, branch: r.branch ?? "", sourceType: r.type, sourceId: r.id }));
+	return { slug: args.slug, title: page.title, timeline };
+}
+
+export async function runListBranches(cwd: string): Promise<BranchCatalog> {
+	return listBranchCatalog(cwd);
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `npm run test -w @jolli.ai/cli -- src/mcp/McpTools.test.ts`
+Expected: PASS.
+
+> No commit.
+
+---
+
+## Task 5: McpServer — wire handlers into the SDK over stdio
+
+**Files:**
+- Create: `cli/src/mcp/McpServer.ts`
+- Create: `cli/src/mcp/McpServer.test.ts`
+
+The server itself is thin glue; the heavy logic is tested in Task 4. The test verifies the tool registry (names + that a call routes to the right handler) without spawning a real transport.
+
+- [ ] **Step 1: Write the failing test**
+
+`cli/src/mcp/McpServer.test.ts`:
+
+```ts
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("./McpTools.js", () => ({
+	runSearch: vi.fn().mockResolvedValue({ hits: [] }),
+	runRecall: vi.fn().mockResolvedValue({ type: "recall" }),
+	runDecisionTimeline: vi.fn().mockResolvedValue({ timeline: [] }),
+	runListBranches: vi.fn().mockResolvedValue({ branches: [] }),
+}));
+
+import { TOOL_DEFINITIONS, dispatchTool } from "./McpServer.js";
+import { runListBranches, runSearch } from "./McpTools.js";
+
+describe("MCP tool registry", () => {
+	it("declares exactly the four P0 tools", () => {
+		expect(TOOL_DEFINITIONS.map((t) => t.name).sort()).toEqual(
+			["get_decision_timeline", "list_branches", "recall", "search"].sort(),
+		);
+	});
+
+	it("each tool has an inputSchema object", () => {
+		for (const t of TOOL_DEFINITIONS) {
+			expect(t.inputSchema.type).toBe("object");
+		}
+	});
+});
+
+describe("dispatchTool", () => {
+	it("routes search to runSearch with parsed args", async () => {
+		await dispatchTool("/repo", "search", { query: "auth" });
+		expect(runSearch).toHaveBeenCalledWith("/repo", { query: "auth" });
+	});
+
+	it("routes list_branches (no args) to runListBranches", async () => {
+		await dispatchTool("/repo", "list_branches", {});
+		expect(runListBranches).toHaveBeenCalledWith("/repo");
+	});
+
+	it("throws on an unknown tool", async () => {
+		await expect(dispatchTool("/repo", "nope", {})).rejects.toThrow(/unknown tool/i);
+	});
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `npm run test -w @jolli.ai/cli -- src/mcp/McpServer.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the server**
+
+`cli/src/mcp/McpServer.ts`:
+
+```ts
+/**
+ * McpServer — exposes JolliMemory's search + context tools to AI agents over an
+ * stdio MCP transport (JOLLI-1226 P0). Pure glue: tool schemas + a dispatch
+ * table over the McpTools handlers. `startMcpServer` is invoked by `jolli mcp`.
+ */
+
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
+import { createLogger } from "../Logger.js";
+import { runDecisionTimeline, runListBranches, runRecall, runSearch } from "./McpTools.js";
+
+const log = createLogger("McpServer");
+
+export interface ToolDefinition {
+	name: string;
+	description: string;
+	inputSchema: { type: "object"; properties: Record<string, unknown>; required?: string[] };
+}
+
+export const TOOL_DEFINITIONS: ToolDefinition[] = [
+	{
+		name: "search",
+		description:
+			"Full-text search over this repo's historical decisions and implementations (topics + commits). Use to check how a topic was handled before.",
+		inputSchema: {
+			type: "object",
+			properties: {
+				query: { type: "string", description: "Natural-language or keyword query." },
+				branch: { type: "string", description: "Optional: restrict to one branch." },
+				type: { type: "string", enum: ["topic", "commit"], description: "Optional: restrict result kind." },
+				limit: { type: "number", description: "Max hits (default 20)." },
+			},
+			required: ["query"],
+		},
+	},
+	{
+		name: "recall",
+		description:
+			"Recall the development context for a branch from raw commit summaries (decisions, plans, notes, commits) — the same data the jolli-recall skill uses, NOT the topic KB. Omit `branch` to recall the current branch.",
+		inputSchema: {
+			type: "object",
+			properties: { branch: { type: "string", description: "Branch to recall; defaults to current." } },
+		},
+	},
+	{
+		name: "get_decision_timeline",
+		description: "Chronological evolution of a topic — its source events ordered oldest-first.",
+		inputSchema: {
+			type: "object",
+			properties: { slug: { type: "string", description: "Topic stableSlug." } },
+			required: ["slug"],
+		},
+	},
+	{
+		name: "list_branches",
+		description: "List all branches that have JolliMemory records, with their topic titles.",
+		inputSchema: { type: "object", properties: {} },
+	},
+];
+
+/** Route a validated tool call to its handler. Throws on unknown tool. */
+export async function dispatchTool(cwd: string, name: string, args: Record<string, unknown>): Promise<unknown> {
+	switch (name) {
+		case "search":
+			return runSearch(cwd, args as { query: string; branch?: string; type?: "topic" | "commit"; limit?: number });
+		case "recall":
+			return runRecall(cwd, args as { branch?: string });
+		case "get_decision_timeline":
+			return runDecisionTimeline(cwd, args as { slug: string });
+		case "list_branches":
+			return runListBranches(cwd);
+		default:
+			throw new Error(`Unknown tool: ${name}`);
+	}
+}
+
+/** Start the stdio MCP server. Resolves when the transport closes. */
+export async function startMcpServer(cwd: string): Promise<void> {
+	const server = new Server(
+		{ name: "jollimemory", version: "1.0.0" },
+		{ capabilities: { tools: {} } },
+	);
+
+	server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: TOOL_DEFINITIONS }));
+
+	server.setRequestHandler(CallToolRequestSchema, async (req) => {
+		const { name, arguments: args } = req.params;
+		try {
+			const result = await dispatchTool(cwd, name, args ?? {});
+			return { content: [{ type: "text", text: JSON.stringify(result) }] };
+		} catch (err) {
+			const message = err instanceof Error ? err.message : String(err);
+			log.warn("Tool %s failed: %s", name, message);
+			return { content: [{ type: "text", text: JSON.stringify({ error: message }) }], isError: true };
+		}
+	});
+
+	const transport = new StdioServerTransport();
+	await server.connect(transport);
+	log.info("MCP server connected over stdio (cwd=%s)", cwd);
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `npm run test -w @jolli.ai/cli -- src/mcp/McpServer.test.ts`
+Expected: PASS. If the SDK's request-schema import path differs in the installed version, fix the import (the Task 0 smoke test established the SDK resolves; adjust the subpath to the actual `types.js` export).
+
+> No commit.
+
+---
+
+## Task 6: `jolli mcp` command
+
+**Files:**
+- Create: `cli/src/commands/McpCommand.ts`
+- Create: `cli/src/commands/McpCommand.test.ts`
+- Modify: `cli/src/Api.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+`cli/src/commands/McpCommand.test.ts`:
+
+```ts
+import { Command } from "commander";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../mcp/McpServer.js", () => ({ startMcpServer: vi.fn().mockResolvedValue(undefined) }));
+vi.mock("../core/SearchIndex.js", () => ({ SearchIndex: { open: vi.fn() } }));
+
+import { SearchIndex } from "../core/SearchIndex.js";
+import { startMcpServer } from "../mcp/McpServer.js";
+import { registerMcpCommand } from "./McpCommand.js";
+
+describe("jolli mcp", () => {
+	it("starts the stdio server by default", async () => {
+		const program = new Command();
+		registerMcpCommand(program);
+		await program.parseAsync(["node", "jolli", "mcp"]);
+		expect(startMcpServer).toHaveBeenCalledTimes(1);
+	});
+
+	it("--reindex rebuilds and does not start the server", async () => {
+		const reindex = vi.fn().mockResolvedValue({ docCount: 3 });
+		vi.mocked(SearchIndex.open).mockResolvedValue({ reindex } as never);
+		const program = new Command();
+		registerMcpCommand(program);
+		await program.parseAsync(["node", "jolli", "mcp", "--reindex"]);
+		expect(reindex).toHaveBeenCalledTimes(1);
+		expect(startMcpServer).not.toHaveBeenCalled();
+	});
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `npm run test -w @jolli.ai/cli -- src/commands/McpCommand.test.ts`
+Expected: FAIL — `registerMcpCommand` not defined.
+
+- [ ] **Step 3: Implement the command**
+
+`cli/src/commands/McpCommand.ts`:
+
+```ts
+/**
+ * `jolli mcp` — starts the stdio MCP server for AI agents (JOLLI-1226 P0).
+ * `jolli mcp --reindex` forces a full rebuild of the local search index and exits.
+ */
+
+import type { Command } from "commander";
+import { SearchIndex } from "../core/SearchIndex.js";
+import { startMcpServer } from "../mcp/McpServer.js";
+
+export function registerMcpCommand(program: Command): void {
+	program
+		.command("mcp")
+		.description("Start the JolliMemory MCP server (stdio) for AI agents")
+		.option("--reindex", "Rebuild the local search index from source and exit")
+		.action(async (options: { reindex?: boolean }) => {
+			const cwd = process.cwd();
+			if (options.reindex) {
+				const index = await SearchIndex.open(cwd);
+				const { docCount } = await index.reindex();
+				process.stdout.write(`Reindexed ${docCount} document(s).\n`);
+				return;
+			}
+			await startMcpServer(cwd);
+		});
+}
+```
+
+- [ ] **Step 4: Register in Api.ts**
+
+In `cli/src/Api.ts`, add the import near the other command imports (alphabetical, after `registerMigrateCommand` import is fine):
+
+```ts
+import { registerMcpCommand } from "./commands/McpCommand.js";
+```
+
+And add the registration call alongside the others (near `registerSyncCommand(program);`):
+
+```ts
+	registerMcpCommand(program);
+```
+
+- [ ] **Step 5: Run to verify it passes**
+
+Run: `npm run test -w @jolli.ai/cli -- src/commands/McpCommand.test.ts`
+Expected: PASS.
+
+> No commit.
+
+---
+
+## Task 7: Incremental upsert in compileAllRepos
+
+**Files:**
+- Modify: `cli/src/core/MultiRepoCompile.ts`
+- Modify (extend existing test): `cli/src/core/MultiRepoCompile.test.ts` (create if absent)
+
+The hook: after each repo's `renderTopicKBWiki`, open + reindex that repo's search index so the common path keeps the index warm. Failures are logged and swallowed (matches the file's per-repo isolation and the index's disposable nature).
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `cli/src/core/MultiRepoCompile.test.ts` (mirror the existing mock setup in that file; if the file does not exist, create it mocking `discoverRepos`, `drainIngest`, `readTopicIndex`, `purgeTopicPagesExcept`, `renderTopicKBWiki`, `withVaultWriteLock`, `createFolderStorageAtRoot`, `getActiveStorage`/`setActiveStorage`, `deriveMemoryBankRoot`):
+
+```ts
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../sync/VaultWriteLock.js", () => ({
+	withVaultWriteLock: vi.fn(async (_root, _mode, fn) => ({ ran: true, value: await fn() })),
+}));
+vi.mock("../sync/SyncBootstrap.js", () => ({ deriveMemoryBankRoot: vi.fn(() => "/vault") }));
+vi.mock("./MemoryBankRepoDiscovery.js", () => ({
+	discoverRepos: vi.fn(async () => [{ folder: "r1", repoIdentity: "id1", kbRoot: "/vault/r1" }]),
+}));
+vi.mock("./StorageFactory.js", () => ({ createFolderStorageAtRoot: vi.fn(() => ({})) }));
+vi.mock("./SummaryStore.js", () => ({ getActiveStorage: vi.fn(() => undefined), setActiveStorage: vi.fn() }));
+vi.mock("./IngestPipeline.js", () => ({ drainIngest: vi.fn(async () => ({ batches: 1, ingested: 2 })) }));
+vi.mock("./TopicIndexStore.js", () => ({ readTopicIndex: vi.fn(async () => ({ schemaVersion: 1, topics: [] })) }));
+vi.mock("./TopicPageStore.js", () => ({ purgeTopicPagesExcept: vi.fn(async () => undefined) }));
+vi.mock("./TopicWikiRenderer.js", () => ({ renderTopicKBWiki: vi.fn(async () => undefined) }));
+vi.mock("./SearchIndex.js", () => ({ SearchIndex: { open: vi.fn() } }));
+
+import { compileAllRepos } from "./MultiRepoCompile.js";
+import { SearchIndex } from "./SearchIndex.js";
+
+describe("compileAllRepos search index hook", () => {
+	it("reindexes each repo after wiki render", async () => {
+		const reindex = vi.fn().mockResolvedValue({ docCount: 5 });
+		vi.mocked(SearchIndex.open).mockResolvedValue({ reindex } as never);
+		const res = await compileAllRepos("/vault", {} as never);
+		expect(res.totalIngested).toBe(2);
+		expect(SearchIndex.open).toHaveBeenCalledWith("/vault/r1", expect.anything());
+		expect(reindex).toHaveBeenCalledTimes(1);
+	});
+
+	it("swallows a reindex failure without failing the repo", async () => {
+		vi.mocked(SearchIndex.open).mockRejectedValue(new Error("orama boom"));
+		const res = await compileAllRepos("/vault", {} as never);
+		expect(res.failed).toBe(0); // index failure is non-fatal
+		expect(res.totalIngested).toBe(2);
+	});
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `npm run test -w @jolli.ai/cli -- src/core/MultiRepoCompile.test.ts`
+Expected: FAIL — `SearchIndex.open` never called.
+
+- [ ] **Step 3: Add the hook**
+
+In `cli/src/core/MultiRepoCompile.ts`, add the import:
+
+```ts
+import { SearchIndex } from "./SearchIndex.js";
+```
+
+Then inside the per-repo `try` block, immediately after `await renderTopicKBWiki(t.kbRoot, storage);`, add:
+
+```ts
+				// Keep the local search index warm so query-time rebuilds are rare.
+				// Disposable cache: a failure here must never fail the compile.
+				try {
+					const idx = await SearchIndex.open(t.kbRoot, storage);
+					await idx.reindex();
+				} catch (idxErr) {
+					log.warn(
+						"Search index update failed for %s (non-fatal): %s",
+						t.folder,
+						idxErr instanceof Error ? idxErr.message : String(idxErr),
+					);
+				}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `npm run test -w @jolli.ai/cli -- src/core/MultiRepoCompile.test.ts`
+Expected: PASS.
+
+> No commit.
+
+---
+
+## Task 8: MCP auto-registration in `.mcp.json`
+
+**Files:**
+- Create: `cli/src/install/McpRegistration.ts`
+- Create: `cli/src/install/McpRegistration.test.ts`
+- Modify: `cli/src/install/Installer.ts`
+
+The `.mcp.json` server entry must invoke the same dist-path-resolved `Cli.js` the hooks use, so version bumps don't break it. Find the resolve-dist-path helper the hooks already use:
+
+Run: `grep -rn "resolve-dist-path\|resolveDistPath\|run-cli\|run-hook" cli/src/install/DispatchScripts.ts | head`
+
+Use the existing global script (the `run-cli` entry script, or the `resolve-dist-path` indirection) as the command. The `.mcp.json` schema for Claude Code is `{ "mcpServers": { "<name>": { "command": "<cmd>", "args": ["..."] } } }`.
+
+- [ ] **Step 1: Write the failing test**
+
+`cli/src/install/McpRegistration.test.ts`:
+
+```ts
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { registerMcpInClaude, removeMcpFromClaude } from "./McpRegistration.js";
+
+let dir: string;
+beforeEach(async () => {
+	dir = await mkdtemp(join(tmpdir(), "jolli-mcp-reg-"));
+});
+afterEach(async () => {
+	await rm(dir, { recursive: true, force: true });
+});
+
+describe("registerMcpInClaude", () => {
+	it("creates .mcp.json with a jollimemory server entry", async () => {
+		await registerMcpInClaude(dir);
+		const raw = await readFile(join(dir, ".mcp.json"), "utf-8");
+		const json = JSON.parse(raw);
+		expect(json.mcpServers.jollimemory).toBeDefined();
+		expect(Array.isArray(json.mcpServers.jollimemory.args)).toBe(true);
+		expect(json.mcpServers.jollimemory.args).toContain("mcp");
+	});
+
+	it("preserves existing servers and is idempotent", async () => {
+		await writeFile(
+			join(dir, ".mcp.json"),
+			JSON.stringify({ mcpServers: { other: { command: "x" } } }),
+			"utf-8",
+		);
+		await registerMcpInClaude(dir);
+		await registerMcpInClaude(dir); // second call must not duplicate or corrupt
+		const json = JSON.parse(await readFile(join(dir, ".mcp.json"), "utf-8"));
+		expect(json.mcpServers.other).toBeDefined();
+		expect(json.mcpServers.jollimemory).toBeDefined();
+	});
+});
+
+describe("removeMcpFromClaude", () => {
+	it("removes only the jollimemory entry", async () => {
+		await writeFile(
+			join(dir, ".mcp.json"),
+			JSON.stringify({ mcpServers: { other: { command: "x" }, jollimemory: { command: "y" } } }),
+			"utf-8",
+		);
+		await removeMcpFromClaude(dir);
+		const json = JSON.parse(await readFile(join(dir, ".mcp.json"), "utf-8"));
+		expect(json.mcpServers.jollimemory).toBeUndefined();
+		expect(json.mcpServers.other).toBeDefined();
+	});
+
+	it("no-ops when .mcp.json is absent", async () => {
+		await expect(removeMcpFromClaude(dir)).resolves.toBeUndefined();
+	});
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `npm run test -w @jolli.ai/cli -- src/install/McpRegistration.test.ts`
+Expected: FAIL — module not defined.
+
+- [ ] **Step 3: Implement the registration**
+
+`cli/src/install/McpRegistration.ts`. Use the same global entry-script path the hooks resolve through. Replace `getRunCliScriptPath()` below with the actual helper found in Step 0's grep (e.g. the function that returns `~/.jolli/jollimemory/run-cli`); if hooks invoke `node "$(resolve-dist-path)/Cli.js"`, mirror that exact command form here.
+
+```ts
+/**
+ * Auto-registration of the JolliMemory MCP server into a worktree's `.mcp.json`
+ * (Claude Code project config), JOLLI-1226 P0. Idempotent; preserves other
+ * servers. Uses the same global entry-script indirection as the git/agent hooks
+ * so version bumps don't strand the registration.
+ */
+
+import { readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { createLogger } from "../Logger.js";
+import { getGlobalConfigDir } from "../Logger.js";
+
+const log = createLogger("McpRegistration");
+const SERVER_KEY = "jollimemory";
+
+interface McpConfig {
+	mcpServers?: Record<string, { command: string; args?: string[] }>;
+}
+
+async function readMcpConfig(mcpPath: string): Promise<McpConfig> {
+	try {
+		return JSON.parse(await readFile(mcpPath, "utf-8")) as McpConfig;
+	} catch {
+		return {};
+	}
+}
+
+/** Add (or refresh) the jollimemory server entry in <worktreeDir>/.mcp.json. */
+export async function registerMcpInClaude(worktreeDir: string): Promise<void> {
+	const mcpPath = join(worktreeDir, ".mcp.json");
+	const config = await readMcpConfig(mcpPath);
+	const servers = config.mcpServers ?? {};
+
+	// `run-cli` is the global entry script that resolves the active dist path and
+	// execs `node <dist>/Cli.js "$@"`. Passing `mcp` makes it start the server.
+	const runCli = join(getGlobalConfigDir(), "run-cli");
+	servers[SERVER_KEY] = { command: "sh", args: [runCli, "mcp"] };
+
+	const next: McpConfig = { ...config, mcpServers: servers };
+	await writeFile(mcpPath, `${JSON.stringify(next, null, 2)}\n`, "utf-8");
+	log.info("Registered MCP server in %s", mcpPath);
+}
+
+/** Remove the jollimemory server entry; no-op if file or entry is absent. */
+export async function removeMcpFromClaude(worktreeDir: string): Promise<void> {
+	const mcpPath = join(worktreeDir, ".mcp.json");
+	let config: McpConfig;
+	try {
+		config = JSON.parse(await readFile(mcpPath, "utf-8")) as McpConfig;
+	} catch {
+		return; // absent or unreadable → nothing to remove
+	}
+	if (!config.mcpServers?.[SERVER_KEY]) return;
+	delete config.mcpServers[SERVER_KEY];
+	await writeFile(mcpPath, `${JSON.stringify(config, null, 2)}\n`, "utf-8");
+	log.info("Removed MCP server from %s", mcpPath);
+}
+```
+
+> Confirm `getGlobalConfigDir` is exported from `../Logger.js` (Step 0 grep earlier showed it referenced there). If it lives elsewhere, import from the correct module. Also confirm the global `run-cli` script exists and accepts a passthrough arg — if hooks instead call `run-hook`/`resolve-dist-path`, build the command to match (`{ command: "node", args: ["<resolved>/Cli.js", "mcp"] }` is an acceptable alternative if there is no `run-cli`).
+
+- [ ] **Step 4: Wire into the Installer**
+
+In `cli/src/install/Installer.ts`, add the import:
+
+```ts
+import { registerMcpInClaude, removeMcpFromClaude } from "./McpRegistration.js";
+```
+
+In the per-worktree install loop, immediately after `await installSessionStartHook(wt);` (inside the `if (config.claudeEnabled === false) continue;` gate, so it only runs when Claude is enabled), add:
+
+```ts
+				// Register the MCP server for AI agents (Claude Code project config).
+				// Non-fatal: a failure here must not block hook installation.
+				try {
+					await registerMcpInClaude(wt);
+				} catch (mcpErr) {
+					log.warn("MCP registration failed in %s (non-fatal): %s", wt, (mcpErr as Error).message);
+				}
+```
+
+In the uninstall path (the loop around line 494 that calls `removeClaudeHook(wt)`), add after that call:
+
+```ts
+			await removeMcpFromClaude(wt);
+```
+
+- [ ] **Step 5: Run to verify it passes**
+
+Run: `npm run test -w @jolli.ai/cli -- src/install/McpRegistration.test.ts`
+Expected: PASS.
+
+> No commit. (Installer wiring is covered by McpRegistration unit tests + the existing Installer tests; if Installer tests assert on exact call sequences, update those expectations in this task.)
+
+---
+
+## Task 9: Docs, IntelliJ manual-setup note, and final verification + single commit
+
+**Files:**
+- Modify: `cli/DEVELOPMENT.md` (brief note on the index + `jolli mcp`)
+- Modify: `intellij/DEVELOPMENT.md` (manual `.mcp.json` setup snippet, since IntelliJ auto-registration is deferred)
+- All previously created/modified files
+
+- [ ] **Step 1: Add a short DEVELOPMENT.md note (CLI)**
+
+Append a subsection to `cli/DEVELOPMENT.md` describing: the local index at `.jolli/jollimemory/search-index.json` (disposable cache, rebuilt from source via staleness signature), `jolli mcp` (stdio server) and `jolli mcp --reindex`, and the four MCP tools.
+
+- [ ] **Step 2: Add the IntelliJ manual-setup snippet**
+
+In `intellij/DEVELOPMENT.md`, add a short note that IntelliJ does not auto-register the MCP server yet; users add it manually to `.mcp.json`:
+
+```json
+{ "mcpServers": { "jollimemory": { "command": "jolli", "args": ["mcp"] } } }
+```
+
+- [ ] **Step 3: Verify the CLAUDE.md "three implementations in lockstep" rule is untouched**
+
+This change does not modify `parseJolliApiKey` / `assertJolliOriginAllowed`. Confirm with:
+
+Run: `git diff --name-only | grep -i "JolliApiUtils" || echo "API key parser untouched ✓"`
+Expected: `API key parser untouched ✓`
+
+- [ ] **Step 4: Run the full gate once**
+
+Run: `npm run all`
+Expected: clean → build → lint → test all PASS, including the CLI coverage floor (97% statements / 96% branches / 97% functions / 97% lines). If coverage dips below the floor on any new module, add the missing-branch tests (e.g. the `dominantSourceType` empty-refs branch, `tryRestore` schema-version-mismatch branch, `dispatchTool` default branch) until it passes.
+
+If the VS Code bundle is part of `npm run all`, it must also build clean (Task 0 already de-risked this).
+
+- [ ] **Step 5: Stage and commit once (DCO sign-off, no AI co-author trailer)**
+
+```bash
+git add -A
+git commit -s -m "feat: add local search index and MCP server (JOLLI-1226 P0)
+
+Add an Orama full-text index over the topic KB + commit catalog, persisted
+locally and rebuilt from source via a staleness signature. Expose search,
+recall, get_decision_timeline, and list_branches over an stdio MCP server
+(jolli mcp), auto-registered into Claude Code's .mcp.json by the installer."
+```
+
+Expected: commit succeeds with a `Signed-off-by:` trailer and **no** `Co-Authored-By: Claude` / `🤖 Generated with` lines.
+
+---
+
+## Self-review notes (author checklist — already applied)
+
+- **Spec coverage:** SearchIndex (Tasks 1–3) ✓; MCP server + 4 tools (Tasks 4–6) ✓; dual-source indexing (Task 2) ✓; local persistence + staleness "both combined" (Task 3 + Task 7) ✓; auto-registration into `.mcp.json` (Task 8) ✓; dependency/bundle risk gated first (Task 0) ✓. Deferred items (embeddings, hybrid ranking, L0–L3, cross-branch, IntelliJ auto-register, QueueWorker changes) are explicitly out of scope and not tasked.
+- **Type consistency:** `SearchDoc` fields (Task 1) match the projection (Task 2), the Orama hit mapping (Task 3 `SearchHitResult`), and the tool output (Tasks 4–5). `SearchIndex.open(cwd, storage?)` / `.search(SearchQuery)` / `.reindex()` signatures are used identically in Tasks 3, 4, 6, 7.
+- **Placeholder scan:** No TBD/TODO. The only deliberate "confirm the exact name" steps are for pre-existing helpers (`getCurrentBranch`, `run-cli`/`resolve-dist-path`, `getGlobalConfigDir`) where the grep command and the fallback are both given — not placeholders for new code.
+- **Standing preferences:** per-task commits removed; single `npm run all` + commit in Task 9; DCO sign-off, no AI co-author trailer.

--- a/docs/superpowers/plans/2026-06-10-ingest-phase-indicator.md
+++ b/docs/superpowers/plans/2026-06-10-ingest-phase-indicator.md
@@ -1,0 +1,650 @@
+# Ingest Phase Indicator Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Show a distinct `Updating Memory Bank…` label on the sidebar Branch-tab toolbar while the post-commit worker is running a topic-KB ingest, instead of the generic `AI summary in progress…`.
+
+**Architecture:** The detached `QueueWorker` writes a single-purpose marker file `.jolli/jollimemory/worker-phase` (content `ingest`) for the duration of an ingest entry and deletes it in `finally`. The VS Code extension watches that file with a `FileSystemWatcher`, feeds the phase into `StatusStore` (parallel to the existing `workerBusy` boolean, bound to it so a lost lock clears the phase), pushes it to the webview on its own `worker:phase` message (mirroring the existing `sync:phase` channel), and `SidebarScriptBuilder` selects the label from the phase.
+
+**Tech Stack:** TypeScript (cli ESM + vscode esbuild/CJS bundle), Vitest, VS Code FileSystemWatcher, webview postMessage protocol.
+
+**Spec:** [`docs/superpowers/specs/2026-06-10-ingest-phase-indicator-design.md`](../specs/2026-06-10-ingest-phase-indicator-design.md)
+
+> **Execution note (user preference overrides skill default):** Do NOT run `npm run all` or commit per task. Each task writes its test + implementation only. A single consolidated verification + commit happens in the final task.
+
+---
+
+## File structure
+
+| File | Responsibility | Change |
+|------|----------------|--------|
+| [`cli/src/core/Locks.ts`](../../../cli/src/core/Locks.ts) | Worker-status file name constants | Add `WORKER_PHASE_FILE` |
+| [`cli/src/hooks/QueueWorker.ts`](../../../cli/src/hooks/QueueWorker.ts) | Drains queue; writes phase marker around ingest | Wrap ingest branch |
+| [`cli/src/hooks/QueueWorker.test.ts`](../../../cli/src/hooks/QueueWorker.test.ts) | Worker tests | Add phase-marker tests |
+| [`vscode/src/stores/StatusStore.ts`](../../../vscode/src/stores/StatusStore.ts) | Host-side status state | Add `workerPhase` field + setter + invariant |
+| [`vscode/src/stores/StatusStore.test.ts`](../../../vscode/src/stores/StatusStore.test.ts) | StatusStore tests | Add phase tests |
+| [`vscode/src/views/SidebarScriptBuilder.ts`](../../../vscode/src/views/SidebarScriptBuilder.ts) | Webview client JS (label, state, message handler) | Add phase state + handler + label selection |
+| [`vscode/src/views/SidebarScriptBuilder.test.ts`](../../../vscode/src/views/SidebarScriptBuilder.test.ts) | Webview script tests | Assert generated JS |
+| [`vscode/src/views/SidebarWebviewProvider.ts`](../../../vscode/src/views/SidebarWebviewProvider.ts) | Host→webview push | Add `getWorkerPhase` dep + `worker:phase` push |
+| [`vscode/src/Extension.ts`](../../../vscode/src/Extension.ts) | Wires watchers + provider deps | Add phase watcher + dep wiring |
+
+---
+
+## Task 1: cli — phase-marker constant + worker writer
+
+**Files:**
+- Modify: `cli/src/core/Locks.ts` (near `WORKER_LOCK_FILE`, line ~90)
+- Modify: `cli/src/hooks/QueueWorker.ts` (imports lines 20 & 95; ingest branch lines 484-488)
+- Test: `cli/src/hooks/QueueWorker.test.ts` (inside `describe("runWorker — ingest dispatch", ...)`, line ~2130)
+
+- [ ] **Step 1: Add the phase-file constant in `Locks.ts`**
+
+Find (line ~90):
+
+```typescript
+export const WORKER_LOCK_FILE = "worker.lock";
+```
+
+Add immediately after it:
+
+```typescript
+/**
+ * Cosmetic, best-effort marker the QueueWorker writes while running a phase the
+ * UI should label specially (currently only `ingest`). Lives next to
+ * `worker.lock` in `<cwd>/.jolli/jollimemory/`. It is NOT a lock and carries no
+ * mutual-exclusion role — the extension reads it only to pick a toolbar label.
+ * Its lifetime is bound to `worker.lock` on the reader side: when the lock
+ * disappears the phase is forced to null, so a stale marker left by a crashed
+ * worker cannot mislead beyond the lock's own staleness window.
+ */
+export const WORKER_PHASE_FILE = "worker-phase";
+```
+
+- [ ] **Step 2: Extend the fs + Logger imports in `QueueWorker.ts`**
+
+Find (line 20):
+
+```typescript
+import { existsSync, readFileSync } from "node:fs";
+```
+
+Replace with:
+
+```typescript
+import { existsSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+```
+
+Find (line 95):
+
+```typescript
+import { createLogger, errMsg, setLogDir, setLogLevel } from "../Logger.js";
+```
+
+Replace with:
+
+```typescript
+import { createLogger, errMsg, getJolliMemoryDir, setLogDir, setLogLevel } from "../Logger.js";
+```
+
+Extend the existing Locks import (line 38):
+
+```typescript
+import { acquireWorkerLock, refreshWorkerLockMtime, releaseWorkerLock, withPlansLock } from "../core/Locks.js";
+```
+
+Replace with (add `WORKER_PHASE_FILE`):
+
+```typescript
+import { acquireWorkerLock, refreshWorkerLockMtime, releaseWorkerLock, withPlansLock, WORKER_PHASE_FILE } from "../core/Locks.js";
+```
+
+- [ ] **Step 3: Wrap the ingest branch with the phase marker in `QueueWorker.ts`**
+
+Find (lines 484-488):
+
+```typescript
+	if (isIngestOperation(op)) {
+		log.info("Processing queue entry: type=ingest triggeredBy=%s", op.triggeredBy);
+		await runIngestFromQueue(op, cwd, storage);
+		return;
+	}
+```
+
+Replace with:
+
+```typescript
+	if (isIngestOperation(op)) {
+		log.info("Processing queue entry: type=ingest triggeredBy=%s", op.triggeredBy);
+		// Cosmetic phase marker so the VS Code toolbar shows "Updating Memory
+		// Bank…" instead of "AI summary in progress…" during the (potentially
+		// ~80s) topic-KB ingest. Best-effort: a write/delete failure must never
+		// break ingest, so both ends are wrapped and logged at debug only.
+		const phaseFile = join(getJolliMemoryDir(cwd), WORKER_PHASE_FILE);
+		try {
+			writeFileSync(phaseFile, "ingest");
+		} catch (e) {
+			log.debug("worker-phase write skipped (non-fatal): %s", errMsg(e));
+		}
+		try {
+			await runIngestFromQueue(op, cwd, storage);
+		} finally {
+			try {
+				rmSync(phaseFile, { force: true });
+			} catch (e) {
+				log.debug("worker-phase cleanup skipped (non-fatal): %s", errMsg(e));
+			}
+		}
+		return;
+	}
+```
+
+(`join` is already imported from `node:path` at line 21 — no import change needed.)
+
+- [ ] **Step 4: Write the failing tests in `QueueWorker.test.ts`**
+
+Add a `node:fs` + `node:os` + `node:path` import block at the top of the test file if not already present (the file likely already imports some; only add what is missing):
+
+```typescript
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+```
+
+Inside `describe("runWorker — ingest dispatch", () => { ... })` (after the existing `beforeEach` at line ~2149), add:
+
+```typescript
+		it("writes worker-phase=ingest during ingest and removes it after", async () => {
+			const tmp = mkdtempSync(join(tmpdir(), "jolli-phase-"));
+			mkdirSync(join(tmp, ".jolli", "jollimemory"), { recursive: true });
+			const phaseFile = join(tmp, ".jolli", "jollimemory", "worker-phase");
+
+			vi.mocked(loadConfig).mockResolvedValue({ apiKey: "sk-test" } as never);
+			let phaseSeenDuringIngest: string | null = null;
+			vi.mocked(drainIngest).mockImplementation(async () => {
+				phaseSeenDuringIngest = existsSync(phaseFile) ? readFileSync(phaseFile, "utf-8") : null;
+				return { batches: 1, ingested: 2, outcome: "OK", topicFailures: [] };
+			});
+
+			await __test__.processQueueEntry(makeIngestOp("post-merge"), tmp, storageWithWiki(true), false);
+
+			expect(phaseSeenDuringIngest).toBe("ingest");
+			expect(existsSync(phaseFile)).toBe(false);
+
+			rmSync(tmp, { recursive: true, force: true });
+		});
+
+		it("removes worker-phase even when ingest throws", async () => {
+			const tmp = mkdtempSync(join(tmpdir(), "jolli-phase-"));
+			mkdirSync(join(tmp, ".jolli", "jollimemory"), { recursive: true });
+			const phaseFile = join(tmp, ".jolli", "jollimemory", "worker-phase");
+
+			vi.mocked(loadConfig).mockResolvedValue({ apiKey: "sk-test" } as never);
+			vi.mocked(drainIngest).mockRejectedValue(new Error("boom"));
+
+			await expect(
+				__test__.processQueueEntry(makeIngestOp("post-merge"), tmp, storageWithWiki(true), false),
+			).rejects.toThrow("boom");
+
+			expect(existsSync(phaseFile)).toBe(false);
+
+			rmSync(tmp, { recursive: true, force: true });
+		});
+```
+
+Note: `__test__.processQueueEntry`, `makeIngestOp`, and `storageWithWiki` already exist in this test file (see lines ~1983, ~2131, ~2135). `storageWithWiki` returns `never`-typed; passing it as the storage arg matches the existing call sites.
+
+---
+
+## Task 2: vscode — `StatusStore.workerPhase`
+
+**Files:**
+- Modify: `vscode/src/stores/StatusStore.ts`
+- Test: `vscode/src/stores/StatusStore.test.ts`
+
+- [ ] **Step 1: Add the type to the union and snapshot in `StatusStore.ts`**
+
+Find (lines 31-38):
+
+```typescript
+export type StatusChangeReason =
+	| "init"
+	| "refresh"
+	| "setStatus"
+	| "workerBusy"
+	| "syncPhase"
+	| "extensionOutdated"
+	| "migrating";
+```
+
+Replace with (add `"workerPhase"`):
+
+```typescript
+export type StatusChangeReason =
+	| "init"
+	| "refresh"
+	| "setStatus"
+	| "workerBusy"
+	| "workerPhase"
+	| "syncPhase"
+	| "extensionOutdated"
+	| "migrating";
+```
+
+Find the `StatusSnapshot` interface (lines 57-65), the `workerBusy: boolean;` line:
+
+```typescript
+	readonly workerBusy: boolean;
+```
+
+Add directly after it:
+
+```typescript
+	readonly workerBusy: boolean;
+	readonly workerPhase: "ingest" | null;
+```
+
+Find the `EMPTY` snapshot (lines 74-83), the `workerBusy: false,` line, and add after it:
+
+```typescript
+	workerBusy: false,
+	workerPhase: null,
+```
+
+Find the private field block (lines 89-92), the `private workerBusy = false;` line, and add after it:
+
+```typescript
+	private workerBusy = false;
+	private workerPhase: "ingest" | null = null;
+```
+
+- [ ] **Step 2: Bind phase lifetime to busy + add the setter**
+
+Find `setWorkerBusy` (lines 124-130):
+
+```typescript
+	setWorkerBusy(busy: boolean): void {
+		if (this.workerBusy === busy) {
+			return;
+		}
+		this.workerBusy = busy;
+		this.rebuildSnapshot("workerBusy");
+	}
+```
+
+Replace with:
+
+```typescript
+	setWorkerBusy(busy: boolean): void {
+		if (this.workerBusy === busy) {
+			return;
+		}
+		this.workerBusy = busy;
+		// Phase lifetime is bound to the lock: when the worker stops being busy
+		// the phase marker is meaningless, so clear it here. This is the crash-
+		// fallback landing point — a stale `worker-phase` file left by a dead
+		// worker can never outlive the lock's busy state.
+		if (!busy) {
+			this.workerPhase = null;
+		}
+		this.rebuildSnapshot("workerBusy");
+	}
+
+	/**
+	 * Push (or clear) the post-commit worker's phase. Only `"ingest"` is
+	 * surfaced today; any other phase is represented as `null` (default
+	 * "AI summary in progress…" label). Equality-checked so a redundant call
+	 * is a no-op.
+	 */
+	setWorkerPhase(phase: "ingest" | null): void {
+		if (this.workerPhase === phase) {
+			return;
+		}
+		this.workerPhase = phase;
+		this.rebuildSnapshot("workerPhase");
+	}
+```
+
+- [ ] **Step 3: Include the field in `rebuildSnapshot`**
+
+Find `rebuildSnapshot` (lines 161-173), the `workerBusy: this.workerBusy,` line, and add after it:
+
+```typescript
+			workerBusy: this.workerBusy,
+			workerPhase: this.workerPhase,
+```
+
+- [ ] **Step 4: Write the tests in `StatusStore.test.ts`**
+
+Add inside the top-level `describe("StatusStore", () => { ... })`:
+
+```typescript
+	it("setWorkerPhase updates the snapshot and reason", () => {
+		const store = new StatusStore({ getStatus: vi.fn() } as never);
+		store.setWorkerBusy(true);
+		store.setWorkerPhase("ingest");
+		expect(store.getSnapshot().workerPhase).toBe("ingest");
+		expect(store.getSnapshot().changeReason).toBe("workerPhase");
+	});
+
+	it("setWorkerPhase is a no-op when unchanged", () => {
+		const store = new StatusStore({ getStatus: vi.fn() } as never);
+		let emits = 0;
+		store.onChange(() => {
+			emits++;
+		});
+		store.setWorkerPhase(null); // already null → no emit
+		expect(emits).toBe(0);
+	});
+
+	it("setWorkerBusy(false) clears a set workerPhase (lock-bound lifetime)", () => {
+		const store = new StatusStore({ getStatus: vi.fn() } as never);
+		store.setWorkerBusy(true);
+		store.setWorkerPhase("ingest");
+		store.setWorkerBusy(false);
+		expect(store.getSnapshot().workerPhase).toBeNull();
+		expect(store.getSnapshot().workerBusy).toBe(false);
+	});
+```
+
+Note: `onChange` is the `BaseStore` subscription method (used elsewhere in the suite). If the exact subscription method name differs in this file's other tests, mirror that name.
+
+---
+
+## Task 3: vscode — webview state, message handler, and label selection
+
+**Files:**
+- Modify: `vscode/src/views/SidebarScriptBuilder.ts`
+- Test: `vscode/src/views/SidebarScriptBuilder.test.ts`
+
+- [ ] **Step 1: Add `workerPhase` to the initial webview state**
+
+Find (lines 102-106):
+
+```javascript
+    // Live flag pushed by the host whenever the post-commit Worker is holding
+    // the lock. Drives the "AI summary in progress…" indicator on the Branch
+    // toolbar. Not persisted — start from false on every load and let the next
+    // worker:busy or status push correct it.
+    workerBusy: false,
+```
+
+Replace with:
+
+```javascript
+    // Live flag pushed by the host whenever the post-commit Worker is holding
+    // the lock. Drives the "AI summary in progress…" indicator on the Branch
+    // toolbar. Not persisted — start from false on every load and let the next
+    // worker:busy or status push correct it.
+    workerBusy: false,
+    // Live phase of the running worker (currently only 'ingest'), pushed on the
+    // worker:phase channel. Selects "Updating Memory Bank…" over the default
+    // summary label. Not persisted — host re-pushes on reload.
+    workerPhase: null,
+```
+
+- [ ] **Step 2: Reset `workerPhase` on load**
+
+Find (lines 113-116):
+
+```javascript
+  // workerBusy is intentionally reset on load (above), even if persisted state
+  // had it set — the lock is process-bound and cannot survive a reload.
+  state.workerBusy = false;
+  state.syncPhase = null;
+```
+
+Replace with:
+
+```javascript
+  // workerBusy is intentionally reset on load (above), even if persisted state
+  // had it set — the lock is process-bound and cannot survive a reload.
+  state.workerBusy = false;
+  state.workerPhase = null;
+  state.syncPhase = null;
+```
+
+- [ ] **Step 3: Select the label from the phase**
+
+Find (lines 423-427):
+
+```javascript
+      const items = [];
+      const indicator = state.workerBusy
+        ? { label: 'AI summary in progress…', severity: 'info' }
+        : null;
+      items.push(buildToolbarIndicator(indicator));
+```
+
+Replace with:
+
+```javascript
+      const items = [];
+      const indicator = state.workerBusy
+        ? (state.workerPhase === 'ingest'
+            ? { label: 'Updating Memory Bank…', severity: 'info' }
+            : { label: 'AI summary in progress…', severity: 'info' })
+        : null;
+      items.push(buildToolbarIndicator(indicator));
+```
+
+- [ ] **Step 4: Handle the `worker:phase` message**
+
+Find the `worker:busy` case (lines 684-699), ending at its closing `}` and `break;`. Immediately after that case's closing brace (before `case 'sync:phase': {` at line 700), insert:
+
+```javascript
+      case 'worker:phase': {
+        // Per-phase label for the post-commit Worker. Independent of
+        // worker:busy; only 'ingest' is surfaced today, anything else clears to
+        // the default summary label. Only the Branch tab reacts.
+        state.workerPhase = (msg.phase === 'ingest') ? 'ingest' : null;
+        if (state.activeTab === 'branch') {
+          renderToolbar();
+        }
+        break;
+      }
+```
+
+- [ ] **Step 5: Write the tests in `SidebarScriptBuilder.test.ts`**
+
+Add to the `describe("SidebarScriptBuilder", () => { ... })` block:
+
+```typescript
+	it("selects the Updating Memory Bank label for the ingest phase", () => {
+		const js = buildSidebarScript();
+		expect(js).toContain("Updating Memory Bank…");
+		expect(js).toContain("state.workerPhase === 'ingest'");
+	});
+
+	it("keeps the default AI summary label for non-ingest busy state", () => {
+		const js = buildSidebarScript();
+		// Both labels must coexist — the ternary falls back to the summary label.
+		expect(js).toContain("AI summary in progress…");
+	});
+
+	it("handles the worker:phase message channel", () => {
+		const js = buildSidebarScript();
+		expect(js).toContain("case 'worker:phase'");
+	});
+```
+
+---
+
+## Task 4: vscode — host push + watcher wiring
+
+**Files:**
+- Modify: `vscode/src/views/SidebarWebviewProvider.ts` (interface ~56; `pushStatus` ~872-894)
+- Modify: `vscode/src/Extension.ts` (dep object ~830-836; lock watcher block ~1411-1463)
+
+- [ ] **Step 1: Add `getWorkerPhase` to the provider interface**
+
+In `SidebarWebviewProvider.ts`, find the `getSyncPhase?` declaration (lines 56-59):
+
+```typescript
+		getSyncPhase?: () => {
+			readonly label: string;
+			readonly severity: "info" | "error";
+		} | null;
+	};
+```
+
+Replace with:
+
+```typescript
+		getSyncPhase?: () => {
+			readonly label: string;
+			readonly severity: "info" | "error";
+		} | null;
+		/**
+		 * Returns the current post-commit worker phase from StatusStore. Pushed
+		 * to the webview as `worker:phase` so the Branch tab toolbar can show
+		 * "Updating Memory Bank…" during a topic-KB ingest. Optional so existing
+		 * tests that only stub `getWorkerBusy` keep compiling.
+		 */
+		getWorkerPhase?: () => "ingest" | null;
+	};
+```
+
+- [ ] **Step 2: Push `worker:phase` in `pushStatus`**
+
+Find the end of `pushStatus` (lines 885-894):
+
+```typescript
+		// Sync-phase indicator. Optional on the provider interface so existing
+		// tests that don't stub `getSyncPhase` keep working unchanged.
+		const getSyncPhase = this.deps.statusProvider.getSyncPhase;
+		if (getSyncPhase) {
+			this.postMessage({
+				type: "sync:phase",
+				phase: getSyncPhase(),
+			});
+		}
+	}
+```
+
+Replace with:
+
+```typescript
+		// Sync-phase indicator. Optional on the provider interface so existing
+		// tests that don't stub `getSyncPhase` keep working unchanged.
+		const getSyncPhase = this.deps.statusProvider.getSyncPhase;
+		if (getSyncPhase) {
+			this.postMessage({
+				type: "sync:phase",
+				phase: getSyncPhase(),
+			});
+		}
+		// Worker-phase indicator (ingest). Same StatusStore change event as
+		// worker:busy; optional getter so existing stubs keep compiling.
+		const getWorkerPhase = this.deps.statusProvider.getWorkerPhase;
+		if (getWorkerPhase) {
+			this.postMessage({
+				type: "worker:phase",
+				phase: getWorkerPhase(),
+			});
+		}
+	}
+```
+
+- [ ] **Step 3: Wire the dep in `Extension.ts`**
+
+Find (lines 834-835):
+
+```typescript
+			getWorkerBusy: () => statusProvider.getWorkerBusy(),
+			getSyncPhase: () => statusStore.getSnapshot().syncPhase,
+```
+
+Replace with:
+
+```typescript
+			getWorkerBusy: () => statusProvider.getWorkerBusy(),
+			getSyncPhase: () => statusStore.getSnapshot().syncPhase,
+			getWorkerPhase: () => statusStore.getSnapshot().workerPhase,
+```
+
+- [ ] **Step 4: Add the phase FileSystemWatcher in `Extension.ts`**
+
+Find the end of the lock-watcher block (lines 1461-1463):
+
+```typescript
+	context.subscriptions.push(lockWatcher);
+	// Check initial state — lock file might already exist on activation
+	void isWorkerBusy(workspaceRoot).then(setWorkerBusy);
+```
+
+Replace with:
+
+```typescript
+	context.subscriptions.push(lockWatcher);
+	// Check initial state — lock file might already exist on activation
+	void isWorkerBusy(workspaceRoot).then(setWorkerBusy);
+
+	// ── Worker phase file watcher ───────────────────────────────────────
+	// The worker writes `.jolli/jollimemory/worker-phase` (content "ingest")
+	// while running a topic-KB ingest, so the Branch toolbar can show
+	// "Updating Memory Bank…" instead of "AI summary in progress…". The phase
+	// is purely cosmetic; its busy-bound lifetime (StatusStore clears it on
+	// workerBusy=false) means a stale marker left by a crashed worker can't
+	// outlive the lock. Separate from the lock watcher because a phase-file
+	// write does not touch worker.lock, so onDidChange there would not fire.
+	const phaseWatcher = vscode.workspace.createFileSystemWatcher(
+		new vscode.RelativePattern(workspaceRoot, ".jolli/jollimemory/worker-phase"),
+	);
+	const readWorkerPhase = async (): Promise<void> => {
+		try {
+			const uri = vscode.Uri.joinPath(
+				vscode.Uri.file(workspaceRoot),
+				".jolli",
+				"jollimemory",
+				"worker-phase",
+			);
+			const bytes = await vscode.workspace.fs.readFile(uri);
+			const content = Buffer.from(bytes).toString("utf-8").trim();
+			statusStore.setWorkerPhase(content === "ingest" ? "ingest" : null);
+		} catch {
+			// File missing / unreadable → no special phase.
+			statusStore.setWorkerPhase(null);
+		}
+	};
+	phaseWatcher.onDidCreate(() => void readWorkerPhase());
+	phaseWatcher.onDidChange(() => void readWorkerPhase());
+	phaseWatcher.onDidDelete(() => statusStore.setWorkerPhase(null));
+	context.subscriptions.push(phaseWatcher);
+	// Check initial state — phase file might already exist on activation
+	// (extension started while a worker is mid-ingest).
+	void readWorkerPhase();
+```
+
+---
+
+## Task 5: Verify + commit (single consolidated pass)
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the full gate**
+
+Run: `npm run all`
+Expected: clean → build → lint → test all PASS; cli coverage stays ≥ 97% statements / 96% branches / 97% functions / 97% lines.
+
+If coverage dipped on the new `QueueWorker` phase branch, confirm the Task 1 tests exercise both the write-success path and the ingest-throws path (they do); if the `log.debug` catch lines are flagged uncovered, add a `/* v8 ignore next N */` on the two best-effort `catch` blocks (mirrors the existing best-effort catch-ignore style in this file) — do NOT lower the threshold.
+
+- [ ] **Step 2: Commit (DCO sign-off, no AI co-author trailer)**
+
+```bash
+git add cli/src/core/Locks.ts cli/src/hooks/QueueWorker.ts cli/src/hooks/QueueWorker.test.ts \
+        vscode/src/stores/StatusStore.ts vscode/src/stores/StatusStore.test.ts \
+        vscode/src/views/SidebarScriptBuilder.ts vscode/src/views/SidebarScriptBuilder.test.ts \
+        vscode/src/views/SidebarWebviewProvider.ts vscode/src/Extension.ts
+git commit -s -m "feat(vscode): distinct toolbar label for topic-KB ingest phase"
+```
+
+Expected: commit succeeds with a `Signed-off-by:` trailer and no `Co-Authored-By: Claude` / `🤖 Generated with` footer.
+
+---
+
+## Intentionally unchanged
+
+- `worker.lock` format / lock acquisition in `Locks.ts` (IntelliJ-shared format untouched; only a new sibling constant added).
+- The `syncPhase` channel (Memory Bank sync engine — not reused).
+- Labels for rebase-pick / squash / summary phases (only ingest is split out).
+- IntelliJ plugin (no UI parity required for this cosmetic VS Code label).

--- a/docs/superpowers/specs/2026-06-08-knowledge-index-and-search-p0-design.md
+++ b/docs/superpowers/specs/2026-06-08-knowledge-index-and-search-p0-design.md
@@ -1,0 +1,117 @@
+# P0: Knowledge Index & Search — Design
+
+**Date:** 2026-06-08
+**Scope:** Phase 2 **P0 only** — a full-text search index plus an MCP server. P1/P2 explicitly deferred.
+
+## Background & rationale
+
+The Linear issue was written **before** the topic-KB refactor (SP1–SP5). Two of its premises are now stale and the design corrects them:
+
+- It names "Phase 1 compiled artifacts" as the index source via a `CompiledStore`. That module was removed in the SP5 teardown. The current equivalents are the **topic KB** (`topics/index.json` + `topics/<slug>.json`, LLM-reconciled topic pages) and the **raw commit catalog** (`catalog.json`, per-commit topics).
+- Its §2.4 proposes "refactor ContextCompiler into L0–L3 layered loading." `ContextCompiler` is now the recall engine and reads **raw summaries only** — topic-KB shape was deliberately decoupled from recall. L0–L3 conflicts with that architecture and is **out of scope** for P0.
+
+The only genuinely new, no-prior-art capabilities are **(1) a full-text search index** and **(2) an MCP server**. Both are P0 in the issue's own priority table. We start with Orama full-text (the issue's recommended "Approach A"), no embeddings.
+
+## Scope
+
+**In scope (P0):**
+- Orama full-text index over **two sources**: topic KB pages + raw commit catalog, distinguished by a `type` field so search can hit a topic and drill down to commits.
+- Local persistence at `.jolli/jollimemory/search-index.json` (already gitignored via `.gitignore` `.jolli/`). Never on the orphan branch — always rebuildable from source.
+- Index freshness: **incremental upsert** appended to `compileAllRepos`, **plus** a cheap staleness fingerprint checked at query time with full-rebuild fallback. `jolli mcp --reindex` forces a full rebuild.
+- A stdio **MCP server** exposing **4 tools**: `search`, `recall`, `get_decision_timeline`, `list_branches`.
+- **Auto-registration** of the MCP server into Claude Code's project `.mcp.json`, wired into the existing Installer, gated on `claudeEnabled`.
+
+**Out of scope (deferred follow-ups):**
+- Embeddings / vector search (issue "Approach B", P2).
+- Hybrid re-ranking — time decay, branch affinity, importance weight (P2). P0 uses Orama default BM25 ranking.
+- L0–L3 progressive context loading (P1; conflicts with current recall architecture).
+- Cross-branch association discovery / `get_related_work` / `RelatedBranchFinder` (P1).
+- IntelliJ-side MCP auto-registration (CLI + VS Code only; IntelliJ documents manual setup).
+- Any change to `QueueWorker` / the git-hook pipeline.
+
+## Module structure
+
+All new code under `cli/src/` (bundled into the VS Code extension by esbuild as usual).
+
+| Module | Responsibility |
+|---|---|
+| `core/SearchIndex.ts` | Orama wrapper: schema, `buildFromSources`, incremental `upsert`, `save`/`load` (via `@orama/plugin-data-persistence`), `search`, staleness-fingerprint check + rebuild. |
+| `core/SearchIndexSource.ts` | Projects the two sources (topic KB `index.json` + pages; raw `catalog.json`) into the unified Orama document shape. The only module that knows source layouts. |
+| `mcp/McpServer.ts` | MCP stdio server: declares the 4 tools, validates inputs, dispatches to `SearchIndex` + `ContextCompiler`. No business logic of its own. |
+| `commands/McpCommand.ts` | `registerMcpCommand(program)` → `jolli mcp` starts the stdio server; `jolli mcp --reindex` forces a full rebuild and exits. Registered in `Api.ts` alongside the other `register*` calls. |
+| `install/McpRegistration.ts` | Writes/removes the MCP server entry in `.mcp.json`, invoked from the Installer. Uses the same `resolve-dist-path` indirection as hooks so the entry survives version bumps. Gated on `claudeEnabled`. |
+
+## Index document schema & data flow
+
+Unified Orama document (no embedding field in P0; pure BM25 full-text):
+
+```ts
+interface SearchDoc {
+  id: string;          // "topic:<slug>" | "commit:<fullHash>"
+  type: "topic" | "commit";
+  title: string;
+  content: string;     // searchable body
+  decisions: string;   // joined decision text (empty if none)
+  branch: string;      // commit: branch; topic: relatedBranches joined
+  category: string;    // commit: source kind; topic: source type
+  commitDate: string;  // ISO 8601
+  slug: string;        // topic slug, else ""
+  hash: string;        // commit fullHash, else ""
+}
+```
+
+Orama schema declares every field as `"string"` (filterable/searchable). `commitDate` kept as string for P0 (time-decay ranking is P2).
+
+**Projection (`SearchIndexSource`):**
+- **topic doc:** `id = "topic:<stableSlug>"`, `content` = topic page body, `branch` = `relatedBranches.join(" ")`, `category` = dominant `sourceRefs[].type`, `commitDate` = `lastUpdatedAt`.
+- **commit doc:** `id = "commit:<fullHash>"`, `content` = the commit's topics' `trigger`/`response` concatenated, `decisions` = joined decision texts, `hash` = `fullHash`, `branch` = entry branch, `commitDate` = entry date.
+
+**Persistence:** `@orama/plugin-data-persistence` `persist`/`restore` → `.jolli/jollimemory/search-index.json` (resolved via `getJolliMemoryDir(cwd)`). A sidecar manifest stores `{ schemaVersion, catalogSig, topicIndexSig, savedAt }`.
+
+**Freshness (the "both combined" strategy):**
+- At query time `SearchIndex` computes a cheap signature: `catalog` entry count + `index.json` head hash + max `lastUpdatedAt` across `topics/index.json`. If it differs from the persisted manifest (or the file is missing/corrupt/version-mismatched), it **rebuilds from scratch** and re-persists.
+- `compileAllRepos`, after its existing `drainIngest` + `renderTopicKBWiki` per repo, calls an **incremental upsert** so the common path stays warm and the query-time rebuild is rarely triggered.
+- Commits created by `summarize` (via `QueueWorker`) are **not** hooked directly; the query-time staleness check is what picks them up. This keeps the hook pipeline untouched (a hard scope boundary).
+
+## MCP tools
+
+The server starts with its launch `cwd` as the project root, resolves config + storage through the existing `StorageFactory` / `setActiveStorage`, reads from the orphan branch (system of record), and uses the local index for search. All four tools reuse existing engines — zero new business logic.
+
+| Tool | Input | Implementation |
+|---|---|---|
+| `search` | `{ query, branch?, type?, limit? }` | `SearchIndex.search`; returns hits `{ title, snippet, type, branch, commitDate, hash?, slug? }`. `type`/`branch` map to Orama `where` filters. |
+| `recall` | `{ branch? }` | Defaults to current git branch when omitted. `compileTaskContext(branch)` → `buildRecallPayload`. **Reads raw `CommitSummary` records from `index.json` (NOT the topic KB)** — the exact same path the jolli-recall skill uses; "compile" in the function name means "assemble raw summaries", unrelated to topic-KB compiled artifacts. Covers both "resume my branch" (no arg) and "look at branch X" (arg) — merged from the originally-proposed `get_branch_context`. |
+| `get_decision_timeline` | `{ slug }` | Loads the topic page, sorts `sourceRefs` by `timestamp`, returns a chronological list of `{ timestamp, branch, sourceType, sourceId }` plus the page title. |
+| `list_branches` | `{}` | `listBranchCatalog()`. |
+
+Invalid input → a structured tool error (never crashes the process). Storage miss / empty corpus → empty result, not a throw.
+
+## Dependencies & cross-surface
+
+New `cli/package.json` runtime deps (inlined into the VS Code bundle by esbuild):
+- `@orama/orama`
+- `@orama/plugin-data-persistence`
+- `@modelcontextprotocol/sdk`
+
+**Risk to validate first:** all three must bundle to CJS cleanly inside `vscode/esbuild.config.mjs`. The implementation plan's first step is a packaging smoke test (build the VS Code bundle, confirm no unresolved ESM/CJS issues) before building features on top.
+
+**Auto-registration:** `McpRegistration.ts` writes a server entry to the project `.mcp.json` whose command invokes the dist-path-resolved `Cli.js mcp` (same indirection as hooks, so version bumps don't break it). Hooked into the Installer's per-worktree pass, gated on `claudeEnabled`, and removed on uninstall. IntelliJ auto-registration is deferred; IntelliJ users get documented manual setup.
+
+## Error handling
+
+- **Index corrupt / schema-version mismatch / unreadable:** delete and rebuild from source. The index is never authoritative — source data (orphan branch / folder) always is.
+- **MCP tool bad input:** return a structured MCP error; the server stays up.
+- **Storage unavailable / empty corpus:** return empty results rather than throwing.
+- **`compileAllRepos` upsert failure:** logged and swallowed (matches the existing shadow-write tolerance); next query-time staleness check rebuilds.
+
+## Testing
+
+Must hold the CLAUDE.md CLI coverage floor (97% statements / 96% branches / 97% functions / 97% lines).
+
+- `SearchIndex`: build-from-sources, search (term + filters), staleness detection (sig match → no rebuild; mismatch → rebuild), save/load round-trip, corrupt-file recovery.
+- `SearchIndexSource`: topic and commit projection from fixture `index.json` / `catalog.json` / topic pages.
+- `McpServer`: each tool's dispatch with mocked `SearchIndex` + `ContextCompiler`; bad-input → structured error; `recall` default-branch resolution.
+- `McpRegistration`: writes a correct `.mcp.json` entry; idempotent re-write; removal on uninstall; `claudeEnabled === false` → no-op.
+- `compileAllRepos` incremental-upsert hook covered by extending its existing test.
+
+Per repo convention: write tests + implementation per task, run `npm run all` and commit **once at the end**, not per task.

--- a/docs/superpowers/specs/2026-06-10-ingest-phase-indicator-design.md
+++ b/docs/superpowers/specs/2026-06-10-ingest-phase-indicator-design.md
@@ -1,0 +1,150 @@
+# Ingest phase indicator — design
+
+**Date:** 2026-06-10
+**Status:** Approved (pending spec review)
+
+## Problem
+
+The VS Code sidebar shows a single status string — `AI summary in progress…` —
+whenever the post-commit `QueueWorker` holds `worker.lock`. The worker drains
+several kinds of operations under that lock:
+
+- **summary generation** — real LLM call (~20–40s)
+- **rebase-pick migration** — 1:1 hash migration, no LLM, sub-second
+- **topic-KB ingest** — re-aggregates cross-commit topics and regenerates the
+  `_wiki` (observed ~84s in the wild)
+
+Because the busy signal is a single boolean fed by the lock file, all three
+render the same `AI summary in progress…` label. During an ingest the user sees
+"AI summary in progress" even though no summary is being generated. This was
+hit directly after a `git rebase`: the rebase-pick migrated 1:1 (no LLM), then
+a chain-spawned worker ran the ingest for ~84s under the same label.
+
+### Root cause
+
+The worker phase is a binary black box to the extension:
+
+- `QueueWorker` holds one `worker.lock` for the whole drain
+  ([`cli/src/core/Locks.ts`](../../../cli/src/core/Locks.ts)).
+- The extension watches `worker.lock` via a `FileSystemWatcher`; present →
+  `setWorkerBusy(true)`, deleted → `false`
+  ([`vscode/src/Extension.ts`](../../../vscode/src/Extension.ts) ~1411–1463).
+- `workerBusy` is a single boolean
+  ([`vscode/src/stores/StatusStore.ts`](../../../vscode/src/stores/StatusStore.ts)),
+  and `SidebarScriptBuilder` hard-codes `AI summary in progress…` when it is
+  true ([`vscode/src/views/SidebarScriptBuilder.ts`](../../../vscode/src/views/SidebarScriptBuilder.ts) ~425).
+
+The lock's create/delete only brackets the *entire* drain, so the lock alone
+cannot distinguish phases. The worker must emit a phase signal that the
+extension reads.
+
+## Scope
+
+**Only the ingest phase is split out.** Summary generation and rebase-pick
+migration keep showing `AI summary in progress…`. This is a deliberate YAGNI
+boundary — the signaling channel is built so future phases can be added by one
+enum value, but we do not enumerate them now.
+
+- **Label:** `Updating Memory Bank…` (English, to match the existing
+  English-only sidebar UI; the Chinese gloss is "正在更新记忆库").
+
+## Approach
+
+Three options were considered for the worker → extension signal (the worker is
+a detached process, so only file IPC is available):
+
+- **A — dedicated phase marker file + new watcher (chosen).** Clean single
+  purpose, mirrors the existing lock-watcher pattern, extensible by one enum
+  value, does not touch the IntelliJ-shared lock format.
+- **B — write phase into `worker.lock` content, reuse the lock watcher.**
+  Rejected: overloads the mutual-exclusion lock with status data; `worker.lock`
+  format is owned by `Locks.ts` and shared with IntelliJ, so the format change
+  ripples cross-surface.
+- **C — reuse the `syncPhase` channel.** Rejected: `syncPhase` is the in-process
+  Memory Bank *sync* engine channel (download/merge/upload); the detached worker
+  cannot reach it without a file bridge anyway, and reusing it muddies its
+  meaning.
+
+## Design
+
+### 1. Worker side (`cli/`)
+
+In [`QueueWorker.ts`](../../../cli/src/hooks/QueueWorker.ts), wrap the ingest
+branch (`isIngestOperation(op)` → `runIngestFromQueue`, ~484–486):
+
+- Before ingest starts: write `<projectDir>/.jolli/jollimemory/worker-phase`
+  with content `ingest`.
+- `try / finally`: delete the file on both success and failure.
+- All other operations (summary, rebase-pick) do **not** write it — absent file
+  = default `AI summary in progress…`, matching the "only ingest" scope.
+- Resolve the path via `getJolliMemoryDir(cwd)` (same dir as sessions/cursors;
+  worktree-aware).
+
+**Crash fallback:** a stale `worker-phase` left by a crashed worker does not
+mislead for long because the extension binds the phase lifetime to the lock —
+when `worker.lock` disappears (release or 5-min stale), the phase is forced to
+null. So the phase file needs no independent staleness logic.
+
+### 2. Extension side (`vscode/`)
+
+**a. `StatusStore` — new phase field** (parallel to `workerBusy`, mirroring the
+existing `syncPhase` shape):
+
+- `private workerPhase: "ingest" | null = null`, added to `StatusSnapshot`.
+- `setWorkerPhase(phase)` with equality short-circuit (like `setSyncPhase`).
+- `changeReason` union gains `"workerPhase"`.
+- **Invariant:** `setWorkerBusy(false)` also forces `workerPhase = null` — this
+  is the crash-fallback landing point.
+
+**b. `Extension.ts` — phase watcher** (next to the existing lock watcher,
+~1411–1463):
+
+- `createFileSystemWatcher` on `worker-phase`.
+- `onDidCreate / onDidChange`: read content; `=== "ingest"` →
+  `statusStore.setWorkerPhase("ingest")`.
+- `onDidDelete`: `setWorkerPhase(null)`.
+- The existing `lockWatcher.onDidDelete` path keeps clearing phase via the
+  StatusStore busy→false invariant; no extra disk read there.
+- Beside the startup `isWorkerBusy(...).then(setWorkerBusy)`, add a one-shot
+  initial read of the phase file (covers "extension started while worker is
+  already ingesting").
+
+**c. `SidebarScriptBuilder` — label selection** (replace the hard-coded line at
+~425):
+
+```
+workerBusy && phase === 'ingest'
+  ? { label: 'Updating Memory Bank…', severity: 'info' }
+  : { label: 'AI summary in progress…', severity: 'info' }   // unchanged
+```
+
+The phase rides the existing snapshot → webview push path (same channel as
+`workerBusy`); no new webview protocol message.
+
+### Data flow
+
+```
+QueueWorker(ingest entry) ──write worker-phase=ingest──> disk
+        │                                                 │
+        └─ finally: delete file                  FileSystemWatcher (ext)
+                                                          │
+                                             StatusStore.setWorkerPhase
+                                                          │
+                                       snapshot ──push──> webview ──> toolbar label
+        worker.lock gone ──> workerBusy=false ──(invariant)──> workerPhase=null
+```
+
+## Testing
+
+- **cli (97% threshold):** `QueueWorker` ingest branch writes the phase file and
+  deletes it in `finally`; non-ingest operations do not write it.
+- **vscode:** `StatusStore` — `setWorkerPhase` equality short-circuit; the
+  `setWorkerBusy(false)` → clears phase invariant. `SidebarScriptBuilder` —
+  busy + ingest → `Updating Memory Bank…`; busy + no phase → still
+  `AI summary in progress…`.
+
+## Intentionally unchanged
+
+- `worker.lock` format / `Locks.ts` (so the IntelliJ-shared format is untouched).
+- The `syncPhase` channel (Memory Bank sync engine; not reused).
+- Labels for rebase-pick / squash / summary phases (only ingest is split out).

--- a/intellij/DEVELOPMENT.md
+++ b/intellij/DEVELOPMENT.md
@@ -240,3 +240,15 @@ ideaVersion {
     untilBuild = "262.*"   // Up to IntelliJ 2026.2.x
 }
 ```
+
+---
+
+## MCP Server (manual setup)
+
+The CLI ships a `jolli mcp` stdio MCP server that exposes JolliMemory's search + recall tools to AI agents. The CLI and VS Code extension auto-register it; **the IntelliJ plugin does not register it yet**. IntelliJ users add it manually to their project's `.mcp.json`:
+
+```json
+{ "mcpServers": { "jollimemory": { "command": "jolli", "args": ["mcp"] } } }
+```
+
+This requires the `jolli` CLI to be on `PATH` (`npm install -g @jolli.ai/cli`).

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,11 +15,14 @@
 		},
 		"cli": {
 			"name": "@jolli.ai/cli",
-			"version": "0.99.2",
+			"version": "0.99.3",
 			"hasInstallScript": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@anthropic-ai/sdk": "^0.39.0",
+				"@modelcontextprotocol/sdk": "^1.0.0",
+				"@orama/orama": "^3.0.0",
+				"@orama/plugin-data-persistence": "^3.0.0",
 				"commander": "^13.1.0",
 				"open": "^11.0.0",
 				"semver": "^7.8.1"
@@ -990,6 +993,18 @@
 				"node": ">=18"
 			}
 		},
+		"node_modules/@hono/node-server": {
+			"version": "1.19.14",
+			"resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+			"integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18.14.1"
+			},
+			"peerDependencies": {
+				"hono": "^4"
+			}
+		},
 		"node_modules/@isaacs/cliui": {
 			"version": "9.0.0",
 			"resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-9.0.0.tgz",
@@ -1032,6 +1047,55 @@
 				"@jridgewell/sourcemap-codec": "^1.4.14"
 			}
 		},
+		"node_modules/@modelcontextprotocol/sdk": {
+			"version": "1.29.0",
+			"resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+			"integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@hono/node-server": "^1.19.9",
+				"ajv": "^8.17.1",
+				"ajv-formats": "^3.0.1",
+				"content-type": "^1.0.5",
+				"cors": "^2.8.5",
+				"cross-spawn": "^7.0.5",
+				"eventsource": "^3.0.2",
+				"eventsource-parser": "^3.0.0",
+				"express": "^5.2.1",
+				"express-rate-limit": "^8.2.1",
+				"hono": "^4.11.4",
+				"jose": "^6.1.3",
+				"json-schema-typed": "^8.0.2",
+				"pkce-challenge": "^5.0.0",
+				"raw-body": "^3.0.0",
+				"zod": "^3.25 || ^4.0",
+				"zod-to-json-schema": "^3.25.1"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@cfworker/json-schema": "^4.1.1",
+				"zod": "^3.25 || ^4.0"
+			},
+			"peerDependenciesMeta": {
+				"@cfworker/json-schema": {
+					"optional": true
+				},
+				"zod": {
+					"optional": false
+				}
+			}
+		},
+		"node_modules/@msgpack/msgpack": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/@msgpack/msgpack/-/msgpack-3.1.3.tgz",
+			"integrity": "sha512-47XIizs9XZXvuJgoaJUIE2lFoID8ugvc0jzSHP+Ptfk8nTbnR8g788wv48N03Kx0UkAv559HWRQ3yzOgzlRNUA==",
+			"license": "ISC",
+			"engines": {
+				"node": ">= 18"
+			}
+		},
 		"node_modules/@nodelib/fs.scandir": {
 			"version": "2.1.5",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1068,6 +1132,27 @@
 			},
 			"engines": {
 				"node": ">= 8"
+			}
+		},
+		"node_modules/@orama/orama": {
+			"version": "3.1.18",
+			"resolved": "https://registry.npmjs.org/@orama/orama/-/orama-3.1.18.tgz",
+			"integrity": "sha512-a61ljmRVVyG5MC/698C8/FfFDw5a8LOIvyOLW5fztgUXqUpc1jOfQzOitSCbge657OgXXThmY3Tk8fpiDb4UcA==",
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">= 20.0.0"
+			}
+		},
+		"node_modules/@orama/plugin-data-persistence": {
+			"version": "3.1.18",
+			"resolved": "https://registry.npmjs.org/@orama/plugin-data-persistence/-/plugin-data-persistence-3.1.18.tgz",
+			"integrity": "sha512-pfBbpK96VRW/7IkdMHn2HaW3/+4k2C9Uwyup0IONNuz5bG3L1orCNFZPBmu+zcokOU2YH+IAVuQz6MlvqOe3iw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@msgpack/msgpack": "^3.1.2",
+				"@orama/orama": "3.1.18",
+				"dpack": "^0.6.22",
+				"seqproto": "^0.2.3"
 			}
 		},
 		"node_modules/@rollup/rollup-android-arm-eabi": {
@@ -2180,6 +2265,44 @@
 				"node": ">=6.5"
 			}
 		},
+		"node_modules/accepts": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+			"integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+			"license": "MIT",
+			"dependencies": {
+				"mime-types": "^3.0.0",
+				"negotiator": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/accepts/node_modules/mime-db": {
+			"version": "1.54.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+			"integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/accepts/node_modules/mime-types": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+			"integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+			"license": "MIT",
+			"dependencies": {
+				"mime-db": "^1.54.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
 		"node_modules/agent-base": {
 			"version": "7.1.4",
 			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
@@ -2206,7 +2329,6 @@
 			"version": "8.18.0",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
 			"integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"fast-deep-equal": "^3.1.3",
@@ -2217,6 +2339,23 @@
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/epoberezkin"
+			}
+		},
+		"node_modules/ajv-formats": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+			"integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+			"license": "MIT",
+			"dependencies": {
+				"ajv": "^8.0.0"
+			},
+			"peerDependencies": {
+				"ajv": "^8.0.0"
+			},
+			"peerDependenciesMeta": {
+				"ajv": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/ansi-escapes": {
@@ -2380,6 +2519,46 @@
 				"readable-stream": "^3.4.0"
 			}
 		},
+		"node_modules/body-parser": {
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+			"integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+			"license": "MIT",
+			"dependencies": {
+				"bytes": "^3.1.2",
+				"content-type": "^1.0.5",
+				"debug": "^4.4.3",
+				"http-errors": "^2.0.0",
+				"iconv-lite": "^0.7.0",
+				"on-finished": "^2.4.1",
+				"qs": "^6.14.1",
+				"raw-body": "^3.0.1",
+				"type-is": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/body-parser/node_modules/iconv-lite": {
+			"version": "0.7.2",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+			"integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+			"license": "MIT",
+			"dependencies": {
+				"safer-buffer": ">= 2.1.2 < 3.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
 		"node_modules/boolbase": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
@@ -2477,6 +2656,15 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/bytes": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+			"integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
 		"node_modules/call-bind-apply-helpers": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
@@ -2494,7 +2682,6 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
 			"integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"call-bind-apply-helpers": "^1.0.2",
@@ -2644,6 +2831,28 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/content-disposition": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+			"integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/content-type": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+			"integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
 		"node_modules/convert-source-map": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -2651,11 +2860,45 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/cookie": {
+			"version": "0.7.2",
+			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+			"integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/cookie-signature": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+			"integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.6.0"
+			}
+		},
+		"node_modules/cors": {
+			"version": "2.8.6",
+			"resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+			"integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+			"license": "MIT",
+			"dependencies": {
+				"object-assign": "^4",
+				"vary": "^1"
+			},
+			"engines": {
+				"node": ">= 0.10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
 		"node_modules/cross-spawn": {
 			"version": "7.0.6",
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
 			"integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"path-key": "^3.1.0",
@@ -2700,7 +2943,6 @@
 			"version": "4.4.3",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
 			"integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"ms": "^2.1.3"
@@ -2791,6 +3033,15 @@
 				"node": ">=0.4.0"
 			}
 		},
+		"node_modules/depd": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+			"integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
 		"node_modules/detect-libc": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -2861,6 +3112,12 @@
 				"url": "https://github.com/fb55/domutils?sponsor=1"
 			}
 		},
+		"node_modules/dpack": {
+			"version": "0.6.22",
+			"resolved": "https://registry.npmjs.org/dpack/-/dpack-0.6.22.tgz",
+			"integrity": "sha512-WGPNlW2OAE7Bj0eODMpAHUcEqxrlg01e9OFZDxQodminIgC194/cRHT7K04Z1j7AUEWTeeplYGrIv/xRdwU9Hg==",
+			"license": "MIT"
+		},
 		"node_modules/dunder-proto": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -2902,12 +3159,27 @@
 				"url": "https://bevry.me/fund"
 			}
 		},
+		"node_modules/ee-first": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+			"integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+			"license": "MIT"
+		},
 		"node_modules/emoji-regex": {
 			"version": "8.0.0",
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
 			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/encodeurl": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+			"integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
 		},
 		"node_modules/encoding-sniffer": {
 			"version": "0.2.1",
@@ -3054,6 +3326,12 @@
 				"@esbuild/win32-x64": "0.27.7"
 			}
 		},
+		"node_modules/escape-html": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+			"integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+			"license": "MIT"
+		},
 		"node_modules/estree-walker": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
@@ -3064,6 +3342,15 @@
 				"@types/estree": "^1.0.0"
 			}
 		},
+		"node_modules/etag": {
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+			"integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
 		"node_modules/event-target-shim": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
@@ -3071,6 +3358,27 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=6"
+			}
+		},
+		"node_modules/eventsource": {
+			"version": "3.0.7",
+			"resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+			"integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+			"license": "MIT",
+			"dependencies": {
+				"eventsource-parser": "^3.0.1"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/eventsource-parser": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+			"integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18.0.0"
 			}
 		},
 		"node_modules/expand-template": {
@@ -3092,6 +3400,92 @@
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=12.0.0"
+			}
+		},
+		"node_modules/express": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+			"integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+			"license": "MIT",
+			"dependencies": {
+				"accepts": "^2.0.0",
+				"body-parser": "^2.2.1",
+				"content-disposition": "^1.0.0",
+				"content-type": "^1.0.5",
+				"cookie": "^0.7.1",
+				"cookie-signature": "^1.2.1",
+				"debug": "^4.4.0",
+				"depd": "^2.0.0",
+				"encodeurl": "^2.0.0",
+				"escape-html": "^1.0.3",
+				"etag": "^1.8.1",
+				"finalhandler": "^2.1.0",
+				"fresh": "^2.0.0",
+				"http-errors": "^2.0.0",
+				"merge-descriptors": "^2.0.0",
+				"mime-types": "^3.0.0",
+				"on-finished": "^2.4.1",
+				"once": "^1.4.0",
+				"parseurl": "^1.3.3",
+				"proxy-addr": "^2.0.7",
+				"qs": "^6.14.0",
+				"range-parser": "^1.2.1",
+				"router": "^2.2.0",
+				"send": "^1.1.0",
+				"serve-static": "^2.2.0",
+				"statuses": "^2.0.1",
+				"type-is": "^2.0.1",
+				"vary": "^1.1.2"
+			},
+			"engines": {
+				"node": ">= 18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/express-rate-limit": {
+			"version": "8.5.2",
+			"resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+			"integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+			"license": "MIT",
+			"dependencies": {
+				"ip-address": "^10.2.0"
+			},
+			"engines": {
+				"node": ">= 16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/express-rate-limit"
+			},
+			"peerDependencies": {
+				"express": ">= 4.11"
+			}
+		},
+		"node_modules/express/node_modules/mime-db": {
+			"version": "1.54.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+			"integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/express/node_modules/mime-types": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+			"integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+			"license": "MIT",
+			"dependencies": {
+				"mime-db": "^1.54.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
 			}
 		},
 		"node_modules/fast-check": {
@@ -3121,7 +3515,6 @@
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
 			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/fast-glob": {
@@ -3145,7 +3538,6 @@
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
 			"integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
-			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -3179,6 +3571,27 @@
 			},
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/finalhandler": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+			"integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+			"license": "MIT",
+			"dependencies": {
+				"debug": "^4.4.0",
+				"encodeurl": "^2.0.0",
+				"escape-html": "^1.0.3",
+				"on-finished": "^2.4.1",
+				"parseurl": "^1.3.3",
+				"statuses": "^2.0.1"
+			},
+			"engines": {
+				"node": ">= 18.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
 			}
 		},
 		"node_modules/foreground-child": {
@@ -3231,6 +3644,24 @@
 			},
 			"engines": {
 				"node": ">= 12.20"
+			}
+		},
+		"node_modules/forwarded": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+			"integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/fresh": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+			"integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
 			}
 		},
 		"node_modules/fs-constants": {
@@ -3465,6 +3896,15 @@
 				"node": ">= 0.4"
 			}
 		},
+		"node_modules/hono": {
+			"version": "4.12.24",
+			"resolved": "https://registry.npmjs.org/hono/-/hono-4.12.24.tgz",
+			"integrity": "sha512-I36D1s+HgQc55KbhEr4iybfxv/9o1zdpw+XEM6dJa91LqQD0HCoSGdxpRJCZE+aavs87j4V3Ls2OJzq8C/U4iw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=16.9.0"
+			}
+		},
 		"node_modules/hosted-git-info": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
@@ -3516,6 +3956,26 @@
 			},
 			"funding": {
 				"url": "https://github.com/fb55/entities?sponsor=1"
+			}
+		},
+		"node_modules/http-errors": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+			"integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+			"license": "MIT",
+			"dependencies": {
+				"depd": "~2.0.0",
+				"inherits": "~2.0.4",
+				"setprototypeof": "~1.2.0",
+				"statuses": "~2.0.2",
+				"toidentifier": "~1.0.1"
+			},
+			"engines": {
+				"node": ">= 0.8"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
 			}
 		},
 		"node_modules/http-proxy-agent": {
@@ -3617,9 +4077,7 @@
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
 			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-			"dev": true,
-			"license": "ISC",
-			"optional": true
+			"license": "ISC"
 		},
 		"node_modules/ini": {
 			"version": "1.3.8",
@@ -3628,6 +4086,24 @@
 			"dev": true,
 			"license": "ISC",
 			"optional": true
+		},
+		"node_modules/ip-address": {
+			"version": "10.2.0",
+			"resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+			"integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 12"
+			}
+		},
+		"node_modules/ipaddr.js": {
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+			"integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.10"
+			}
 		},
 		"node_modules/is-docker": {
 			"version": "3.0.0",
@@ -3717,6 +4193,12 @@
 				"node": ">=0.12.0"
 			}
 		},
+		"node_modules/is-promise": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+			"integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+			"license": "MIT"
+		},
 		"node_modules/is-wsl": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
@@ -3736,7 +4218,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
 			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-			"dev": true,
 			"license": "ISC"
 		},
 		"node_modules/istanbul-lib-coverage": {
@@ -3816,6 +4297,15 @@
 			"resolved": "vscode",
 			"link": true
 		},
+		"node_modules/jose": {
+			"version": "6.2.3",
+			"resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+			"integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/panva"
+			}
+		},
 		"node_modules/js-tokens": {
 			"version": "10.0.0",
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
@@ -3840,8 +4330,13 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
 			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/json-schema-typed": {
+			"version": "8.0.2",
+			"resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+			"integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+			"license": "BSD-2-Clause"
 		},
 		"node_modules/json5": {
 			"version": "2.2.3",
@@ -4103,6 +4598,27 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/media-typer": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+			"integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/merge-descriptors": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+			"integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/merge2": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -4259,6 +4775,15 @@
 			"license": "MIT",
 			"optional": true
 		},
+		"node_modules/negotiator": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+			"integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
 		"node_modules/node-abi": {
 			"version": "3.89.0",
 			"resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.89.0.tgz",
@@ -4383,11 +4908,19 @@
 				"url": "https://github.com/fb55/nth-check?sponsor=1"
 			}
 		},
+		"node_modules/object-assign": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+			"integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/object-inspect": {
 			"version": "1.13.4",
 			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
 			"integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.4"
@@ -4407,13 +4940,23 @@
 			],
 			"license": "MIT"
 		},
+		"node_modules/on-finished": {
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+			"integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+			"license": "MIT",
+			"dependencies": {
+				"ee-first": "1.1.1"
+			},
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
 		"node_modules/once": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 			"integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-			"dev": true,
 			"license": "ISC",
-			"optional": true,
 			"dependencies": {
 				"wrappy": "1"
 			}
@@ -4549,11 +5092,19 @@
 				"url": "https://github.com/fb55/entities?sponsor=1"
 			}
 		},
+		"node_modules/parseurl": {
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+			"integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
 		"node_modules/path-key": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
 			"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -4584,6 +5135,16 @@
 			"license": "BlueOak-1.0.0",
 			"engines": {
 				"node": "20 || >=22"
+			}
+		},
+		"node_modules/path-to-regexp": {
+			"version": "8.4.2",
+			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+			"integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+			"license": "MIT",
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
 			}
 		},
 		"node_modules/path-type": {
@@ -4631,6 +5192,15 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/pkce-challenge": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+			"integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=16.20.0"
 			}
 		},
 		"node_modules/pluralize": {
@@ -4713,6 +5283,19 @@
 				"node": ">=10"
 			}
 		},
+		"node_modules/proxy-addr": {
+			"version": "2.0.7",
+			"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+			"integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+			"license": "MIT",
+			"dependencies": {
+				"forwarded": "0.2.0",
+				"ipaddr.js": "1.9.1"
+			},
+			"engines": {
+				"node": ">= 0.10"
+			}
+		},
 		"node_modules/pump": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
@@ -4756,7 +5339,6 @@
 			"version": "6.15.2",
 			"resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
 			"integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
-			"dev": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {
 				"side-channel": "^1.1.0"
@@ -4788,6 +5370,46 @@
 				}
 			],
 			"license": "MIT"
+		},
+		"node_modules/range-parser": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+			"integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/raw-body": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+			"integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+			"license": "MIT",
+			"dependencies": {
+				"bytes": "~3.1.2",
+				"http-errors": "~2.0.1",
+				"iconv-lite": "~0.7.0",
+				"unpipe": "~1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.10"
+			}
+		},
+		"node_modules/raw-body/node_modules/iconv-lite": {
+			"version": "0.7.2",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+			"integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+			"license": "MIT",
+			"dependencies": {
+				"safer-buffer": ">= 2.1.2 < 3.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
 		},
 		"node_modules/rc": {
 			"version": "1.2.8",
@@ -4885,7 +5507,6 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
 			"integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
@@ -4995,6 +5616,22 @@
 				"fsevents": "~2.3.2"
 			}
 		},
+		"node_modules/router": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+			"integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+			"license": "MIT",
+			"dependencies": {
+				"debug": "^4.4.0",
+				"depd": "^2.0.0",
+				"is-promise": "^4.0.0",
+				"parseurl": "^1.3.3",
+				"path-to-regexp": "^8.0.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
 		"node_modules/run-applescript": {
 			"version": "7.1.0",
 			"resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
@@ -5056,7 +5693,6 @@
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
 			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/sax": {
@@ -5103,11 +5739,95 @@
 				"node": ">=10"
 			}
 		},
+		"node_modules/send": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+			"integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+			"license": "MIT",
+			"dependencies": {
+				"debug": "^4.4.3",
+				"encodeurl": "^2.0.0",
+				"escape-html": "^1.0.3",
+				"etag": "^1.8.1",
+				"fresh": "^2.0.0",
+				"http-errors": "^2.0.1",
+				"mime-types": "^3.0.2",
+				"ms": "^2.1.3",
+				"on-finished": "^2.4.1",
+				"range-parser": "^1.2.1",
+				"statuses": "^2.0.2"
+			},
+			"engines": {
+				"node": ">= 18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/send/node_modules/mime-db": {
+			"version": "1.54.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+			"integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/send/node_modules/mime-types": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+			"integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+			"license": "MIT",
+			"dependencies": {
+				"mime-db": "^1.54.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/seqproto": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/seqproto/-/seqproto-0.2.3.tgz",
+			"integrity": "sha512-HpNyPYl7DJa2a6XQJ+MJAc6ft6Y9ZU+zRiuvTHFpLPeqvapcTAGFJyhMEIN7Y7VXhWT6NEdNVhbXFHwtaCOfCw==",
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">= 20.0.0"
+			}
+		},
+		"node_modules/serve-static": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+			"integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+			"license": "MIT",
+			"dependencies": {
+				"encodeurl": "^2.0.0",
+				"escape-html": "^1.0.3",
+				"parseurl": "^1.3.3",
+				"send": "^1.2.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/setprototypeof": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+			"integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+			"license": "ISC"
+		},
 		"node_modules/shebang-command": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
 			"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"shebang-regex": "^3.0.0"
@@ -5120,7 +5840,6 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
 			"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -5130,7 +5849,6 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
 			"integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"es-errors": "^1.3.0",
@@ -5150,7 +5868,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
 			"integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"es-errors": "^1.3.0",
@@ -5167,7 +5884,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
 			"integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"call-bound": "^1.0.2",
@@ -5186,7 +5902,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
 			"integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"call-bound": "^1.0.2",
@@ -5354,6 +6069,15 @@
 			"integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/statuses": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+			"integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
 		},
 		"node_modules/std-env": {
 			"version": "4.1.0",
@@ -5688,6 +6412,15 @@
 				"node": ">=8.0"
 			}
 		},
+		"node_modules/toidentifier": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+			"integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.6"
+			}
+		},
 		"node_modules/tr46": {
 			"version": "0.0.3",
 			"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
@@ -5756,6 +6489,62 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/type-is": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+			"integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+			"license": "MIT",
+			"dependencies": {
+				"content-type": "^2.0.0",
+				"media-typer": "^1.1.0",
+				"mime-types": "^3.0.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/type-is/node_modules/content-type": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+			"integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/type-is/node_modules/mime-db": {
+			"version": "1.54.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+			"integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/type-is/node_modules/mime-types": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+			"integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+			"license": "MIT",
+			"dependencies": {
+				"mime-db": "^1.54.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
 			}
 		},
 		"node_modules/typed-rest-client": {
@@ -5837,6 +6626,15 @@
 				"node": ">= 10.0.0"
 			}
 		},
+		"node_modules/unpipe": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+			"integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
 		"node_modules/url-join": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
@@ -5861,6 +6659,15 @@
 			"dependencies": {
 				"spdx-correct": "^3.0.0",
 				"spdx-expression-parse": "^3.0.0"
+			}
+		},
+		"node_modules/vary": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+			"integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
 			}
 		},
 		"node_modules/version-range": {
@@ -6622,7 +7429,6 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
 			"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"isexe": "^2.0.0"
@@ -6655,9 +7461,7 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
 			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-			"dev": true,
-			"license": "ISC",
-			"optional": true
+			"license": "ISC"
 		},
 		"node_modules/wsl-utils": {
 			"version": "0.3.1",
@@ -6730,6 +7534,24 @@
 				"buffer-crc32": "~0.2.3"
 			}
 		},
+		"node_modules/zod": {
+			"version": "4.4.3",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+			"integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/colinhacks"
+			}
+		},
+		"node_modules/zod-to-json-schema": {
+			"version": "3.25.2",
+			"resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+			"integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+			"license": "ISC",
+			"peerDependencies": {
+				"zod": "^3.25.28 || ^4"
+			}
+		},
 		"site-core": {
 			"name": "@jolli.ai/site-core",
 			"version": "0.1.0",
@@ -6751,7 +7573,7 @@
 		},
 		"vscode": {
 			"name": "jollimemory-vscode",
-			"version": "0.99.2",
+			"version": "0.99.3",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@vscode/codicons": "^0.0.45",

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -2,7 +2,7 @@
 	"name": "jollimemory-vscode",
 	"displayName": "Jolli Memory",
 	"description": "VS Code sidebar for Jolli Memory — AI-powered commit summaries and smart git operations",
-	"version": "0.99.2",
+	"version": "0.99.3",
 	"publisher": "jolli",
 	"license": "Apache-2.0",
 	"icon": "assets/icon.png",

--- a/vscode/src/CompileCommand.test.ts
+++ b/vscode/src/CompileCommand.test.ts
@@ -127,6 +127,17 @@ describe("registerCompileCommand", () => {
 		expect(showInformationMessage).toHaveBeenCalledWith(expect.stringContaining("5 source(s) across 2 repo(s)"));
 	});
 
+	it("shows a skipped notice (not a 0-source success) when the sweep was lock-contended", async () => {
+		mockLoadConfig.mockResolvedValue({ apiKey: "sk-test", localFolder: "/mb" });
+		mockCompileAllRepos.mockResolvedValue({ repos: [], totalIngested: 0, failed: 0, skipped: true });
+		registerCompileCommand(makeOpts());
+
+		await registeredHandlers.get("jollimemory.compileNow")?.();
+
+		expect(showInformationMessage).toHaveBeenCalledWith(expect.stringContaining("already running"));
+		expect(showInformationMessage).not.toHaveBeenCalledWith(expect.stringContaining("0 source(s)"));
+	});
+
 	it("surfaces failed count in the success toast", async () => {
 		mockLoadConfig.mockResolvedValue({ apiKey: "sk-test", localFolder: "/mb" });
 		mockCompileAllRepos.mockResolvedValue({

--- a/vscode/src/CompileCommand.ts
+++ b/vscode/src/CompileCommand.ts
@@ -64,10 +64,18 @@ export function registerCompileCommand(opts: CompileCommandOpts): vscode.Disposa
 				},
 				async () => compileAllRepos(config.localFolder as string, config),
 			);
-			const failedNote = result.failed ? ` (${result.failed} failed)` : "";
-			await vscode.window.showInformationMessage(
-				`Knowledge wiki updated: ${result.totalIngested} source(s) across ${result.repos.length} repo(s)${failedNote}.`,
-			);
+			if (result.skipped) {
+				// Lock contended: a background worker / sync / another compile holds the
+				// vault-write lock. Nothing ran — don't report a "0 source(s)" success.
+				await vscode.window.showInformationMessage(
+					"Another knowledge wiki build is already running for this Memory Bank folder — skipped.",
+				);
+			} else {
+				const failedNote = result.failed ? ` (${result.failed} failed)` : "";
+				await vscode.window.showInformationMessage(
+					`Knowledge wiki updated: ${result.totalIngested} source(s) across ${result.repos.length} repo(s)${failedNote}.`,
+				);
+			}
 		} catch (err) {
 			await vscode.window.showErrorMessage(
 				`Knowledge wiki build failed: ${err instanceof Error ? err.message : String(err)}`,

--- a/vscode/src/Extension.test.ts
+++ b/vscode/src/Extension.test.ts
@@ -791,6 +791,7 @@ const {
 			setEnabled: vi.fn(),
 			setMigrating: vi.fn(),
 			setWorkerBusy: vi.fn(),
+			setWorkerPhase: vi.fn(),
 			setExtensionOutdated: vi.fn(),
 			setStatus: vi.fn(),
 			setMainBranch: vi.fn(),

--- a/vscode/src/Extension.ts
+++ b/vscode/src/Extension.ts
@@ -833,6 +833,7 @@ export function activate(context: vscode.ExtensionContext): void {
 				statusProvider.onDidChangeTreeData.bind(statusProvider),
 			getWorkerBusy: () => statusProvider.getWorkerBusy(),
 			getSyncPhase: () => statusStore.getSnapshot().syncPhase,
+			getWorkerPhase: () => statusStore.getSnapshot().workerPhase,
 		},
 		memoriesProvider: {
 			serialize: () => memoriesProvider.serialize(),
@@ -1461,6 +1462,41 @@ export function activate(context: vscode.ExtensionContext): void {
 	context.subscriptions.push(lockWatcher);
 	// Check initial state — lock file might already exist on activation
 	void isWorkerBusy(workspaceRoot).then(setWorkerBusy);
+
+	// ── Worker phase file watcher ───────────────────────────────────────
+	// The worker writes `.jolli/jollimemory/worker-phase` (content "ingest")
+	// while running a topic-KB ingest, so the Branch toolbar can show
+	// "Updating Memory Bank…" instead of "AI summary in progress…". The phase
+	// is purely cosmetic; its busy-bound lifetime (StatusStore clears it on
+	// workerBusy=false) means a stale marker left by a crashed worker can't
+	// outlive the lock. Separate from the lock watcher because a phase-file
+	// write does not touch worker.lock, so onDidChange there would not fire.
+	const phaseWatcher = vscode.workspace.createFileSystemWatcher(
+		new vscode.RelativePattern(workspaceRoot, ".jolli/jollimemory/worker-phase"),
+	);
+	const readWorkerPhase = async (): Promise<void> => {
+		try {
+			const uri = vscode.Uri.joinPath(
+				vscode.Uri.file(workspaceRoot),
+				".jolli",
+				"jollimemory",
+				"worker-phase",
+			);
+			const bytes = await vscode.workspace.fs.readFile(uri);
+			const content = Buffer.from(bytes).toString("utf-8").trim();
+			statusStore.setWorkerPhase(content === "ingest" ? "ingest" : null);
+		} catch {
+			// File missing / unreadable → no special phase.
+			statusStore.setWorkerPhase(null);
+		}
+	};
+	phaseWatcher.onDidCreate(() => void readWorkerPhase());
+	phaseWatcher.onDidChange(() => void readWorkerPhase());
+	phaseWatcher.onDidDelete(() => statusStore.setWorkerPhase(null));
+	context.subscriptions.push(phaseWatcher);
+	// Check initial state — phase file might already exist on activation
+	// (extension started while a worker is mid-ingest).
+	void readWorkerPhase();
 
 	// COMMITS title updates are handled by the commitsStore.onChange subscription
 	// the sidebar webview wires up — no provider hook needed.

--- a/vscode/src/stores/StatusStore.test.ts
+++ b/vscode/src/stores/StatusStore.test.ts
@@ -166,4 +166,48 @@ describe("StatusStore", () => {
 			expect(store.getSnapshot().syncPhase).not.toBeNull();
 		});
 	});
+
+	it("setWorkerPhase updates the snapshot and reason", () => {
+		const store = new StatusStore({ getStatus: vi.fn() } as never);
+		store.setWorkerBusy(true);
+		store.setWorkerPhase("ingest");
+		expect(store.getSnapshot().workerPhase).toBe("ingest");
+		expect(store.getSnapshot().changeReason).toBe("workerPhase");
+	});
+
+	it("setWorkerPhase is a no-op when unchanged", () => {
+		const store = new StatusStore({ getStatus: vi.fn() } as never);
+		let emits = 0;
+		store.onChange(() => {
+			emits++;
+		});
+		store.setWorkerPhase(null);
+		expect(emits).toBe(0);
+	});
+
+	it("setWorkerBusy(false) clears a set workerPhase (lock-bound lifetime)", () => {
+		const store = new StatusStore({ getStatus: vi.fn() } as never);
+		store.setWorkerBusy(true);
+		store.setWorkerPhase("ingest");
+		store.setWorkerBusy(false);
+		expect(store.getSnapshot().workerPhase).toBeNull();
+		expect(store.getSnapshot().workerBusy).toBe(false);
+	});
+
+	it("setWorkerBusy(false) clears a stale workerPhase even when already not busy (crash-residue activation path)", () => {
+		// Activation order is unspecified: readWorkerPhase() may read a stale
+		// 'ingest' marker (left by a SIGKILL'd worker) BEFORE
+		// isWorkerBusy().then(setWorkerBusy) resolves false. Because workerBusy
+		// starts false, setWorkerBusy(false) would hit the equality early-return
+		// and skip the phase clear — leaving a stale phase that mislabels the
+		// next genuine summary run as "Updating Memory Bank…". The busy-bound
+		// invariant must hold here too.
+		const store = new StatusStore({ getStatus: vi.fn() } as never);
+		store.setWorkerPhase("ingest"); // stale marker read while workerBusy is still false
+		const listener = vi.fn();
+		store.onChange(listener);
+		store.setWorkerBusy(false); // isWorkerBusy() resolved false — no busy transition
+		expect(store.getSnapshot().workerPhase).toBeNull();
+		expect(listener).toHaveBeenCalled(); // snapshot changed (phase cleared), so subscribers must re-render
+	});
 });

--- a/vscode/src/stores/StatusStore.ts
+++ b/vscode/src/stores/StatusStore.ts
@@ -33,6 +33,7 @@ export type StatusChangeReason =
 	| "refresh"
 	| "setStatus"
 	| "workerBusy"
+	| "workerPhase"
 	| "syncPhase"
 	| "extensionOutdated"
 	| "migrating";
@@ -59,6 +60,7 @@ export interface StatusSnapshot extends Snapshot<StatusChangeReason> {
 	readonly config: JolliMemoryConfig | null;
 	readonly derived: StatusDerived;
 	readonly workerBusy: boolean;
+	readonly workerPhase: "ingest" | null;
 	readonly syncPhase: SyncPhaseState | null;
 	readonly extensionOutdated: boolean;
 	readonly migrating: boolean;
@@ -76,6 +78,7 @@ const EMPTY: StatusSnapshot = {
 	config: null,
 	derived: INITIAL_DERIVED,
 	workerBusy: false,
+	workerPhase: null,
 	syncPhase: null,
 	extensionOutdated: false,
 	migrating: false,
@@ -87,6 +90,7 @@ export class StatusStore extends BaseStore<StatusChangeReason, StatusSnapshot> {
 	private status: StatusInfo | null = null;
 	private config: JolliMemoryConfig | null = null;
 	private workerBusy = false;
+	private workerPhase: "ingest" | null = null;
 	private syncPhase: SyncPhaseState | null = null;
 	private extensionOutdated = false;
 	private migrating = false;
@@ -122,11 +126,35 @@ export class StatusStore extends BaseStore<StatusChangeReason, StatusSnapshot> {
 	}
 
 	setWorkerBusy(busy: boolean): void {
-		if (this.workerBusy === busy) {
+		// Phase lifetime is bound to the lock: whenever the worker is not busy the
+		// phase marker is meaningless, so a (possibly stale, crash-left) phase must
+		// be cleared even when `workerBusy` is already false. Otherwise the equality
+		// early-return below would skip the clear, and a stale 'ingest' marker read
+		// at activation — before `isWorkerBusy()` resolves false — would survive into
+		// the next genuine summary run and mislabel it "Updating Memory Bank…".
+		const staleClear = !busy && this.workerPhase !== null;
+		if (this.workerBusy === busy && !staleClear) {
 			return;
 		}
 		this.workerBusy = busy;
+		if (!busy) {
+			this.workerPhase = null;
+		}
 		this.rebuildSnapshot("workerBusy");
+	}
+
+	/**
+	 * Push (or clear) the post-commit worker's phase. Only `"ingest"` is
+	 * surfaced today; any other phase is represented as `null` (default
+	 * "AI summary in progress…" label). Equality-checked so a redundant call
+	 * is a no-op.
+	 */
+	setWorkerPhase(phase: "ingest" | null): void {
+		if (this.workerPhase === phase) {
+			return;
+		}
+		this.workerPhase = phase;
+		this.rebuildSnapshot("workerPhase");
 	}
 
 	/**
@@ -164,6 +192,7 @@ export class StatusStore extends BaseStore<StatusChangeReason, StatusSnapshot> {
 			config: this.config,
 			derived: StatusDataService.derive(this.status, this.config),
 			workerBusy: this.workerBusy,
+			workerPhase: this.workerPhase,
 			syncPhase: this.syncPhase,
 			extensionOutdated: this.extensionOutdated,
 			migrating: this.migrating,

--- a/vscode/src/views/SidebarMessages.ts
+++ b/vscode/src/views/SidebarMessages.ts
@@ -629,6 +629,18 @@ export type SidebarInboundMsg =
 	| { readonly type: "worker:busy"; readonly busy: boolean }
 	| {
 			/**
+			 * Worker-phase indicator for the Branch-tab toolbar. Selects a
+			 * distinct label for specific worker phases — currently only
+			 * `"ingest"` (topic-KB ingest), which renders "Updating Memory
+			 * Bank…" instead of the default "AI summary in progress…". `null`
+			 * falls back to the default label. Lifetime is bound to
+			 * `worker:busy` on the reader side.
+			 */
+			readonly type: "worker:phase";
+			readonly phase: "ingest" | null;
+	  }
+	| {
+			/**
 			 * Sync-phase indicator for the Branch-tab toolbar. `phase: null`
 			 * → idle (sidebar hides the indicator). Non-null → render the
 			 * label with a spinning loading icon (`severity: "info"`) or a

--- a/vscode/src/views/SidebarScriptBuilder.test.ts
+++ b/vscode/src/views/SidebarScriptBuilder.test.ts
@@ -2074,4 +2074,20 @@ describe("SidebarScriptBuilder", () => {
 			expect(js).toContain("getAttribute('data-session')");
 		});
 	});
+
+	it("selects the Updating Memory Bank label for the ingest phase", () => {
+		const js = buildSidebarScript();
+		expect(js).toContain("Updating Memory Bank…");
+		expect(js).toContain("state.workerPhase === 'ingest'");
+	});
+
+	it("keeps the default AI summary label for non-ingest busy state", () => {
+		const js = buildSidebarScript();
+		expect(js).toContain("AI summary in progress…");
+	});
+
+	it("handles the worker:phase message channel", () => {
+		const js = buildSidebarScript();
+		expect(js).toContain("case 'worker:phase'");
+	});
 });

--- a/vscode/src/views/SidebarScriptBuilder.ts
+++ b/vscode/src/views/SidebarScriptBuilder.ts
@@ -104,6 +104,10 @@ export function buildSidebarScript(): string {
     // toolbar. Not persisted — start from false on every load and let the next
     // worker:busy or status push correct it.
     workerBusy: false,
+    // Live phase of the running worker (currently only 'ingest'), pushed on the
+    // worker:phase channel. Selects "Updating Memory Bank..." over the default
+    // summary label. Not persisted -- host re-pushes on reload.
+    workerPhase: null,
     // Live sync-phase indicator pushed by the host as the sync engine
     // advances through phases (downloading / merging / uploading) or ends
     // in a sticky terminal failure. Shape: { label, severity } | null. Not
@@ -113,6 +117,7 @@ export function buildSidebarScript(): string {
   // workerBusy is intentionally reset on load (above), even if persisted state
   // had it set — the lock is process-bound and cannot survive a reload.
   state.workerBusy = false;
+  state.workerPhase = null;
   state.syncPhase = null;
   function persist() { vscode.setState(state); }
 
@@ -422,7 +427,9 @@ export function buildSidebarScript(): string {
       // about the working-tree branch.
       const items = [];
       const indicator = state.workerBusy
-        ? { label: 'AI summary in progress…', severity: 'info' }
+        ? (state.workerPhase === 'ingest'
+            ? { label: 'Updating Memory Bank…', severity: 'info' }
+            : { label: 'AI summary in progress…', severity: 'info' })
         : null;
       items.push(buildToolbarIndicator(indicator));
       items.push(iconButton('refresh', 'Refresh', 'refresh'));
@@ -694,6 +701,16 @@ export function buildSidebarScript(): string {
         if (state.activeTab === 'branch') {
           renderToolbar();
           renderBranch();
+        }
+        break;
+      }
+      case 'worker:phase': {
+        // Per-phase label for the post-commit Worker. Independent of
+        // worker:busy; only 'ingest' is surfaced today, anything else clears to
+        // the default summary label. Only the Branch tab reacts.
+        state.workerPhase = (msg.phase === 'ingest') ? 'ingest' : null;
+        if (state.activeTab === 'branch') {
+          renderToolbar();
         }
         break;
       }

--- a/vscode/src/views/SidebarWebviewProvider.ts
+++ b/vscode/src/views/SidebarWebviewProvider.ts
@@ -57,6 +57,13 @@ export interface SidebarWebviewDeps {
 			readonly label: string;
 			readonly severity: "info" | "error";
 		} | null;
+		/**
+		 * Returns the current post-commit worker phase from StatusStore. Pushed
+		 * to the webview as `worker:phase` so the Branch tab toolbar can show
+		 * "Updating Memory Bank…" during a topic-KB ingest. Optional so existing
+		 * tests that only stub `getWorkerBusy` keep compiling.
+		 */
+		getWorkerPhase?: () => "ingest" | null;
 	};
 	kbFolders?: {
 		listChildren(relPath: string): Promise<FolderNode>;
@@ -889,6 +896,15 @@ export class SidebarWebviewProvider
 			this.postMessage({
 				type: "sync:phase",
 				phase: getSyncPhase(),
+			});
+		}
+		// Worker-phase indicator (ingest). Same StatusStore change event as
+		// worker:busy; optional getter so existing stubs keep compiling.
+		const getWorkerPhase = this.deps.statusProvider.getWorkerPhase;
+		if (getWorkerPhase) {
+			this.postMessage({
+				type: "worker:phase",
+				phase: getWorkerPhase(),
 			});
 		}
 	}


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## Plans & Notes (4)

- Ingest Phase Indicator Implementation Plan
- Ingest phase indicator — design
- P0: Knowledge Index & Search — Design
- Knowledge Index & Search (P0) Implementation Plan

## Quick recap

The developer added a full-text search capability that lets users and AI agents query the knowledge base efficiently without rebuilding the index on every operation. The search index persists locally and automatically detects when it has become stale by checking for new commits, updated timestamps, and edits to existing content. After each repository compilation, the index is warmed proactively to keep queries fast, and the warming process fails gracefully without blocking the compilation itself.

An MCP server now exposes the search, recall, timeline, and branch tools to external AI agents over the Model Context Protocol, allowing Claude and other AI systems to access JolliMemory's knowledge base directly. The server starts via a new command-line interface and can be manually triggered to rebuild the search index. On installation, the MCP server is automatically registered in the Claude Code project configuration so developers do not need to set it up manually.

The recall tool now includes user-written Memory Bank files in its JSON output, fixing a gap where agents calling the JSON interface received incomplete context while the markdown path worked correctly. User knowledge is now budget-bounded and truncatable alongside other context sections, ensuring large files do not monopolize the output. The ingest phase UI now displays a distinct label in the VS Code toolbar during the topic knowledge-base update operation, giving users a clearer signal that the memory bank is being refreshed rather than showing a generic progress message.

---

## E2E Test (10)
<details>
<summary><strong>1. Search the knowledge base using full-text search</strong></summary>
<br>
<blockquote>

**Steps:**
1. Open a terminal and navigate to a project with JolliMemory installed
2. Run `jolli mcp --reindex` and wait for it to complete (should print "Reindexed X document(s)")
3. Run `jolli mcp` to start the MCP server (it should print a startup message and wait for connections)
4. In a separate terminal, use a tool that speaks the Model Context Protocol (or manually test via the Claude Code extension if available) to call the `search` tool with a query like "authentication" or "database"
5. Verify that the search returns relevant results from your project's commit history and knowledge base topics
6. Try a search with a branch filter (e.g. search for "feature" on branch "main") and verify only results from that branch appear

**Expected Results:**
- The reindex command should complete without errors and report a document count greater than 0
- The MCP server should start and remain running
- Search results should include commit summaries and topic titles that match the query
- Results should be ranked by relevance (most relevant first)
- Branch filtering should exclude results from other branches

</blockquote>
</details>
<details>
<summary><strong>2. Recall branch context via MCP for AI agents</strong></summary>
<br>
<blockquote>

**Steps:**
1. Open a terminal in a project with JolliMemory installed
2. Run `jolli mcp` to start the server
3. In another terminal, use an MCP client to call the `recall` tool with a branch name (e.g. "feature/auth")
4. Verify the response includes commit summaries, decisions, plans, notes, and Memory Bank files for that branch
5. Call `recall` without specifying a branch and verify it defaults to the current branch

**Expected Results:**
- The recall response should include a JSON object with commits, decisions, plans, notes, and userKnowledge fields
- Memory Bank files (from the local folder) should appear in the userKnowledge section
- The response should be complete and not truncated (unless the context is very large)

</blockquote>
</details>
<details>
<summary><strong>3. View decision timeline for a topic</strong></summary>
<br>
<blockquote>

**Steps:**
1. Open a terminal in a project with JolliMemory installed
2. Run `jolli mcp` to start the server
3. In another terminal, use an MCP client to call the `get_decision_timeline` tool with a topic name (e.g. "authentication-flow")
4. Verify the returned events are sorted chronologically from oldest to newest
5. Check that each event includes a timestamp and source reference

**Expected Results:**
- The timeline should display events in chronological order (earliest first)
- Each event should have a clear timestamp and description
- If the topic has no events, an empty list should be returned (not an error)

</blockquote>
</details>
<details>
<summary><strong>4. List all branches with memory records</strong></summary>
<br>
<blockquote>

**Steps:**
1. Open a terminal in a project with JolliMemory installed
2. Run `jolli mcp` to start the server
3. In another terminal, use an MCP client to call the `list_branches` tool
4. Verify the response includes all branches that have JolliMemory records
5. Check that each branch entry includes its name and associated topic titles

**Expected Results:**
- The list should include at least the current branch
- Each branch should show its topic titles (if any)
- Branches without any memory records should not appear in the list

</blockquote>
</details>
<details>
<summary><strong>5. MCP server auto-registers in Claude Code configuration</strong></summary>
<br>
<blockquote>

**Steps:**
1. Open a terminal in a project directory
2. Run `jolli install` to install JolliMemory
3. After installation completes, check if a `.mcp.json` file was created in the project root
4. Open the `.mcp.json` file and verify it contains an entry for "jollimemory" server
5. Verify the server entry includes a command to start the MCP server

**Expected Results:**
- The `.mcp.json` file should exist after installation
- It should contain a "jollimemory" server entry with a valid command
- The command should reference the `jolli mcp` command or equivalent
- On Windows, the command should use `node` directly; on Mac/Linux, it should use a shell script

</blockquote>
</details>
<details>
<summary><strong>6. Search index is automatically refreshed after compilation</strong></summary>
<br>
<blockquote>

**Steps:**
1. Open a terminal in a project with JolliMemory installed
2. Make a small change to a file and commit it with a message like "test: update feature"
3. Run `jolli compile` to compile the knowledge base
4. Wait for compilation to complete
5. Run `jolli mcp` and search for a keyword from your recent commit message
6. Verify the search returns your new commit in the results

**Expected Results:**
- The compilation should complete without errors
- The search should include the newly compiled commit
- The search results should be fresh (not stale from before the compile)

</blockquote>
</details>
<details>
<summary><strong>7. Memory Bank files appear in recall output (not silently omitted)</strong></summary>
<br>
<blockquote>

**Steps:**
1. Create a Memory Bank file in your project (e.g. `.jolli/memory/notes.md` with content "Important: use HTTPS for all APIs")
2. Run `jolli recall --format json` on a branch
3. Check the JSON output for a `userKnowledge` field
4. Verify your Memory Bank file appears in that field with its title, source path, and content
5. Run `jolli recall --full` (markdown output) and verify the same file appears in the "Memory Bank Knowledge" section

**Expected Results:**
- The JSON output should include a `userKnowledge` array
- Your Memory Bank file should appear in both JSON and markdown outputs
- The file should show its title, source path, and full content (unless truncated due to size)

</blockquote>
</details>
<details>
<summary><strong>8. Large Memory Bank files do not evict commit history under budget pressure</strong></summary>
<br>
<blockquote>

**Steps:**
1. Create a very large Memory Bank file (e.g. 5000+ words) in your project
2. Make a commit with a meaningful message
3. Run `jolli recall --format json` with a tight token budget (e.g. 1000 tokens)
4. Check the JSON output for both `commits` and `userKnowledge` fields
5. Verify that commits are still present (not evicted) even though the user file is large
6. Verify that the user file's content is truncated (marked with `content` omitted) but the title and source remain as a citation

**Expected Results:**
- The commits array should contain at least one commit (not empty)
- The userKnowledge array should be present with title and source, but content may be omitted
- The output should include a `truncated: true` flag indicating budget enforcement occurred
- Commit decisions should be preserved (not dropped to make room for the user file)

</blockquote>
</details>
<details>
<summary><strong>9. Post-merge ingest is forced past the cooldown</strong></summary>
<br>
<blockquote>

**Steps:**
1. Open a terminal in a project with JolliMemory installed
2. Make a local commit with message "local: test feature"
3. Immediately run `git pull` (or `git merge`) to merge remote changes
4. Wait a few seconds for the post-merge hook to run
5. Run `jolli recall` and verify your local commit appears in the output

**Expected Results:**
- The local commit should appear in the recall output even though it was made shortly before the merge
- The commit should not be skipped due to a cooldown timer
- The merge should complete without errors

</blockquote>
</details>
<details>
<summary><strong>10. Ingest phase indicator shows &quot;Updating Memory Bank&quot; in VS Code</strong></summary>
<br>
<blockquote>

**Steps:**
1. Open the project in VS Code with the JolliMemory extension installed
2. Make a commit that triggers the post-commit hook
3. Watch the VS Code sidebar (or status bar) for the worker status message
4. Verify that during the ingest phase, the message shows "Updating Memory Bank…" (not the generic "AI summary in progress…")
5. Wait for ingest to complete and verify the message returns to idle or clears

**Expected Results:**
- During ingest, the sidebar should display "Updating Memory Bank…" as a distinct label
- After ingest completes, the label should clear or return to idle state
- The label should only appear during the ingest phase, not during other background operations

</blockquote>
</details>

---

## Topics (16)
<details>
<summary><strong>01 · Full-text search index with local persistence and staleness detection</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Users and AI agents needed a way to query the knowledge base efficiently without rebuilding the search index on every operation.

**💡 Decisions Behind the Code**

- **Flat unified schema over separate doc types**: Both topics and commits are projected into a single SearchDoc interface rather than maintaining separate schemas. This simplifies the Orama consumer and allows a single full-text query to span both sources without requiring separate faceted queries.
- **Signature-based staleness with content digest**: The staleness check computes a hash of source counts, newest timestamps, AND catalog content (recap, decisions, topic titles). This is fast enough to call on every operation and detects both structural changes (new/deleted entries) and in-place edits (text modifications) without persisting large metadata.
- **Memoization over full rebuild for long-lived processes**: The expensive operation is deserializing the Orama database from disk; the cheap operation is recomputing the source signature. Caching the deserialized index while always recomputing the signature detects staleness without the overhead of a full rebuild on every call, critical for the MCP server's long-lived process model.
- **Native enum-array filtering over post-filter**: Orama's token-based union matching is correct for full-text search but wrong for identity filters like branch names. Moving branch to a native enum-array field with containsAll filtering ensures the returned limit is already branch-filtered, eliminating truncation risk entirely.

**✅ What Was Implemented**

- Implemented a persistent full-text search index using Orama that unifies commit summaries and topic knowledge into a single searchable format, persisted locally at `.jolli/jollimemory/search-index.json` and automatically rebuilt when source data changes. The index projects commits and topics from four on-disk sources (summary index, commit catalog, topic index, and topic pages) into a flat SearchDoc format.
- Created staleness detection via source signature that includes both structural changes (hash of source counts and newest timestamps) and content changes (digest of recap, decision, and topic title text). The `SearchIndex.openCached` method memoizes the deserialized index per working directory while recomputing the cheap source signature on every call, enabling long-lived processes like the MCP server to cache the index while always detecting when it needs refresh.
- Fixed branch filtering to use native Orama enum-array filtering with exact-membership matching instead of post-filtering on a globally-ranked window, eliminating truncation of rare-branch hits. Added CJK (Chinese, Japanese, Korean) tokenization support via a custom tokenizer that generates character and bigram tokens, making the index searchable for non-English content.

**📁 FILES**
- `cli/src/core/SearchIndexTypes.ts`
- `cli/src/core/SearchIndexSource.ts`
- `cli/src/core/SearchIndex.ts`
- `cli/src/core/SearchTokenizer.ts`

</blockquote>
</details>
<details>
<summary><strong>02 · MCP server exposing search, recall, timeline, and branch tools</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

JolliMemory needed to expose its search and knowledge capabilities to external AI agents over the Model Context Protocol using stdio transport.

**💡 Decisions Behind the Code**

- **Pure tool handlers decoupled from MCP SDK**: The four tool implementations are written as plain functions returning JSON-serializable objects, with no SDK coupling. The MCP server adapts these into SDK tool responses. This separation makes the handlers unit-testable in isolation and allows the tools to be reused by other transports (CLI, webhooks, etc.) in the future without SDK dependencies.
- **Canonical timestamp comparator for timeline ordering**: The ingest pipeline uses `compareSourceRefs` to order sources during fold, so the MCP timeline must use the same comparator to reflect the actual chronological order that ingest applied. String lexical comparison is fragile and produces wrong results for mixed-timezone data.
- **Storage initialization at server startup**: The storage is initialized once at server startup rather than per-tool-call. This matches the pattern used by other read-only commands and eliminates per-call overhead and logging noise for a long-lived process.

**✅ What Was Implemented**

- Created McpTools.ts with four pure, unit-testable handler functions: `runSearch` (queries the search index with optional branch and type filters), `runRecall` (compiles task context for a branch), `runDecisionTimeline` (retrieves and chronologically sorts a topic's source references), and `runListBranches` (returns the branch catalog). Each handler accepts a working directory path and typed arguments, returns a plain JSON-serializable object, and throws a plain Error on validation failure.
- Implemented McpServer.ts as a stdio-based MCP server that declares four tool definitions and routes incoming tool calls to their corresponding handlers. The server uses the MCP SDK's Server, StdioServerTransport, and request schema handlers to manage the protocol lifecycle. Tool definitions include detailed descriptions and input schemas so agents understand what each tool does.
- Fixed the `get_decision_timeline` tool to use the canonical `compareSourceRefs` timestamp comparator (parsing timestamps to epoch milliseconds) instead of lexical string comparison, ensuring correct chronological order. Wired the configured storage backend into the long-lived MCP server at startup via `setActiveStorage(await createStorage(cwd, cwd))`, ensuring all four tools read from the correct storage backend.

**📁 FILES**
- `cli/src/mcp/McpTools.ts`
- `cli/src/mcp/McpServer.ts`

</blockquote>
</details>
<details>
<summary><strong>03 · Auto-register MCP server in Claude Code project configuration</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

When developers install Jolli, the MCP server needs to be automatically registered in the Claude Code project's `.mcp.json` configuration file so that Claude can discover and communicate with the memory service without manual setup steps.

**💡 Decisions Behind the Code**

- **Platform-specific command selection**: On POSIX, the `run-cli` script indirection survives version bumps without requiring re-registration. On Windows, spawning `node` directly on the resolved `Cli.js` path is necessary because the MCP host does not use a shell; the dist path is resolved at registration time (which runs on every install/activate), so baking in an absolute path is safe and survives version bumps through re-registration on activation.
- **Make MCP registration non-fatal during install**: Registration failures should not block the core installation of hooks and skills. Wrapping the call in a try-catch with a warning log allows the install to succeed even if `.mcp.json` cannot be written, preserving the principle that hook installation is the critical path.
- **Preserve existing server entries and make the operation idempotent**: The functions read the entire `.mcp.json`, update only the jollimemory entry, and write the full config back. This allows other MCP servers to coexist, and calling register twice produces the same result without duplication or corruption.

**✅ What Was Implemented**

- Created McpRegistration.ts with two idempotent functions: `registerMcpInClaude()` adds or refreshes the jollimemory server entry in `.mcp.json`, and `removeMcpFromClaude()` removes it during uninstall. Both functions preserve other server entries and handle missing files gracefully.
- Integrated registration into the Installer.ts install flow: after the SessionStart hook is installed, `registerMcpInClaude()` is called with non-fatal error handling so that MCP registration failures do not block the overall installation. Uninstall calls `removeMcpFromClaude()` after removing the Gemini hook.
- On POSIX systems, the server entry uses the global `run-cli` script as the command, which resolves the active distribution path and execs the CLI with the `mcp` argument. On Windows, the entry spawns `node` directly on the resolved `Cli.js` path, since the MCP host spawns commands without a shell and cannot execute bash scripts.

**📁 FILES**
- `cli/src/install/McpRegistration.ts`
- `cli/src/install/Installer.ts`

</blockquote>
</details>
<details>
<summary><strong>04 · CLI command to start MCP server and rebuild search index</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The team needed a command-line interface for starting the MCP server that AI agents connect to, and a way to manually rebuild the local search index when needed.

**💡 Decisions Behind the Code**

The `--reindex` flag was designed to be mutually exclusive with server startup rather than running both sequentially. This keeps the command's behavior predictable and prevents users from accidentally starting a server while a potentially long-running index rebuild is in progress, which could lead to stale data being served. The command uses the existing SearchIndex.rebuild API rather than creating new abstractions, minimizing surface area and leveraging already-tested index logic.

**✅ What Was Implemented**

- Created McpCommand.ts with a new `jolli mcp` command that starts the stdio MCP server by default. The command accepts a `--reindex` flag that rebuilds the search index from source and exits without starting the server, reporting the document count on completion.
- The reindex path establishes the configured storage backend before rebuilding via `setActiveStorage(await createStorage(cwd, cwd))`, ensuring folder-mode users read from the correct backend instead of falling back to an empty orphan-branch store.
- Registered the new command in Api.ts by importing registerMcpCommand and calling it during program initialization, placing it alongside other core commands like sync and auth. Added the command to the MEMORY_COMMAND_NAMES set so it is accessible as a memory-related command.

**📁 FILES**
- `cli/src/commands/McpCommand.ts`
- `cli/src/Api.ts`

</blockquote>
</details>
<details>
<summary><strong>05 · Warm search index after each repository compilation</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Search index rebuilds at query time are expensive and slow down user interactions. The system needed to proactively refresh the index after each repository is compiled so that queries run against a warm, up-to-date index.

**💡 Decisions Behind the Code**

- **Index warming failures must be non-fatal**: The index is treated as a disposable cache that improves query performance but is not required for correctness; a failure to warm it is logged as a warning but does not prevent the repository from being marked as successfully compiled. This keeps the critical path (ingest and wiki rendering) separate from the optional optimization path (index warming).
- **Lazy import for graceful degradation**: Lazy import ensures that Orama load failures degrade gracefully to "index not warmed" rather than crashing the entire compile. This mirrors the pattern already used for optional system libraries.
- **Unified index location via storage provider root**: The index is a disposable artifact that should live alongside the data it indexes (in the Memory Bank folder), not in the git checkout. By keying the index location off the storage provider's `kbRoot` when available, both the compile sweep and the MCP server converge on the same file without introducing a new index location.

**✅ What Was Implemented**

- Modified MultiRepoCompile.ts to call `SearchIndex.rebuild()` after each repository's wiki rendering completes. The reindex operation runs inside a try-catch block so that index failures do not block or fail the overall compilation.
- Lazy-imported SearchIndex inside the try-catch block to isolate Orama load failures, preventing a missing or incompatible Orama dependency from crashing the entire compile sweep. This mirrors the pattern already used for node:sqlite readers, which are also lazily imported to avoid hard dependencies on optional system libraries.
- Aligned the index location resolution between compile warm-up and MCP server by adding an optional `kbRoot` property to the StorageProvider interface. Both the compile sweep (which uses folder storage) and the MCP server (which resolves the same folder root in dual-write mode) now converge on the same physical file.

**📁 FILES**
- `cli/src/core/MultiRepoCompile.ts`
- `cli/src/core/SearchIndex.ts`
- `cli/src/core/StorageProvider.ts`

</blockquote>
</details>
<details>
<summary><strong>06 · Fix recall to include user Memory Bank knowledge in JSON output</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The MCP `recall` tool and `--format json` output were silently omitting user-written Memory Bank files, while the markdown `--full` path correctly included them. Agents calling the JSON path saw incomplete context.

**💡 Decisions Behind the Code**

- **User knowledge in structured JSON payload**: User knowledge must be included in the structured JSON payload so that both the markdown and JSON recall paths expose the same information to downstream consumers (agents, CLI tools, MCP clients). The JSON path is the primary interface for programmatic access, so omitting it there was a silent correctness bug despite the markdown path working correctly.
- **Truncatable and budget-bounded user knowledge**: User knowledge should be truncatable and budget-bounded like other context sections, not privileged as "never truncate" like decisions. This ensures a large user-written file is capped at its own budget share and competes fairly with summaries instead of monopolizing the output.
- **Reclaim unused budget from small files**: The budget allocation uses `min(actual_tokens, 50%_cap)` rather than a fixed 50/50 split. This preserves the safety guarantee that a large user-written file cannot evict summaries (capped at half), while allowing small files to leave their unused share available for summaries.

**✅ What Was Implemented**

- Added `userKnowledge` field to the `RecallPayload` interface and populated it in `buildRecallPayload`, so the JSON/MCP recall path now ships the same Memory Bank files the markdown renderer shows.
- Moved user knowledge from the never-truncated decisions bucket into its own budgeted section that competes fairly with plans, notes, and summaries, preventing a single large user-written file from consuming the entire token budget and evicting commit summaries and decisions.
- Implemented a truncation step that drops user knowledge body content before dropping entire commits, preserving the citation anchor (title and source path) so the user knows what was omitted. Modified the budget allocation logic to cap user knowledge at 50% of the body budget but only consume what it actually needs, allowing small Memory Bank files to leave their unused share available for summaries.

**📁 FILES**
- `cli/src/core/ContextCompiler.ts`

</blockquote>
</details>
<details>
<summary><strong>07 · Force post-merge ingest past the commit cooldown</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

When a user ran `git pull` shortly after making a local commit, the post-merge hook's ingest operation was suppressed by the per-repository cooldown that the post-commit hook had just set, leaving merged commits un-ingested until the cooldown window expired.

**💡 Decisions Behind the Code**

A merge brings in genuinely new content authored elsewhere, so it must not be suppressed by a cooldown that a local commit just set. The cooldown's purpose is to dedupe rapid local commits within a single process; it should not block a separate process (post-merge hook) that is responding to external content. The ingest operation is idempotent, so forcing it past the cooldown is safe.

**✅ What Was Implemented**

Modified `PostMergeHook` to call `enqueueIngestOperation` with `{ force: true }`, bypassing the shared cooldown that normally dedupes rapid local commits. Updated tests and log messages to reflect that post-merge ingest is now forced and the occasional duplicate drain is benign (ingest is idempotent).

**📁 FILES**
- `cli/src/hooks/PostMergeHook.ts`

</blockquote>
</details>
<details>
<summary><strong>08 · Add wall-clock timeout to streaming LLM calls</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The streaming path for large LLM calls relied only on an idle watchdog (120 seconds of no events), which could be reset indefinitely by a server that keeps sending ping events but never completes, holding the QueueWorker lock indefinitely.

**💡 Decisions Behind the Code**

- **Explicit flag over implicit threshold coercion**: The old approach of padding `maxTokens` above `STREAMING_THRESHOLD_TOKENS` to force streaming was fragile — retuning the threshold could silently undo the intent. An explicit `forceStreaming` flag cannot be accidentally undone by constant changes and makes the intent clear at the call site.
- **Dual watchdogs for streaming**: The idle watchdog alone cannot bound a stream that keeps pinging but never completes. A hard wall-clock cap (15 minutes, well above legitimate response times) ensures the QueueWorker never holds a lock indefinitely, while the idle watchdog still catches stalled streams that stop emitting events.

**✅ What Was Implemented**

- Added `STREAM_MAX_WALL_CLOCK_MS` constant (15 minutes) as an absolute cap independent of stream activity, with a separate hard timer that fires regardless of event arrivals.
- Added `forceStreaming` option to `LlmCallOptions` so callers can explicitly request the streaming path without padding `maxTokens` above a threshold that could be retuned.
- Updated `IngestPipeline` to pass `forceStreaming: true` instead of relying on a magic `+116` token offset to coerce streaming behavior.

**📁 FILES**
- `cli/src/core/LlmClient.ts`
- `cli/src/core/IngestPipeline.ts`

</blockquote>
</details>
<details>
<summary><strong>09 · Distinct toolbar label for topic knowledge-base ingest phase</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

During the topic-KB ingest operation, which can take up to 80 seconds, the VS Code toolbar shows a generic "AI summary in progress…" label. Users need a more specific indicator that the system is updating the memory bank, not just running a routine post-commit analysis.

**💡 Decisions Behind the Code**

- **Separate file from the lock**: The phase marker is a distinct file rather than a field in the lock file itself, because writing the lock file would trigger the existing lock watcher and create redundant updates. A separate file allows the phase write to be independent and avoids coupling to the lock's internal structure.
- **Best-effort, non-fatal writes**: Both the phase-file write and cleanup are wrapped in try-catch blocks with debug-level logging. This design prevents a file-system failure (permissions, disk full, etc.) from breaking the ingest operation, which is the user's primary goal. The phase is purely cosmetic — a missing or stale marker degrades the UX label but does not affect functionality.
- **Lifetime bound to lock's busy state**: When the worker stops being busy, the phase is cleared in StatusStore. This ensures a stale phase file left by a crashed worker cannot outlive the lock's own staleness window, providing a crash-safe fallback without requiring the extension to actively clean up the file.

**✅ What Was Implemented**

- Added a cosmetic phase-marker file (`worker-phase`) that the CLI worker writes during ingest and removes afterward. The file lives in `.jolli/jollimemory/` alongside the worker lock and contains the string "ingest". Both write and cleanup are wrapped in try-catch blocks with debug logging, ensuring a file-system failure never breaks the ingest operation itself.
- Extended the VS Code extension to watch the phase-marker file and push its state to the sidebar via a new `worker:phase` message channel. The watcher handles file creation, modification, and deletion events, with a fallback read on extension activation to catch in-progress ingests. The phase state is cleared whenever the worker stops being busy, binding its lifetime to the lock's busy state.
- Updated the sidebar script to render "Updating Memory Bank…" when `workerPhase === 'ingest'` and the worker is busy, falling back to the default "AI summary in progress…" label for other busy states. The phase state is reset on page reload and persisted in the sidebar's local state object.

**📁 FILES**
- `cli/src/core/Locks.ts`
- `cli/src/hooks/QueueWorker.ts`
- `vscode/src/Extension.ts`
- `vscode/src/stores/StatusStore.ts`
- `vscode/src/views/SidebarScriptBuilder.ts`

</blockquote>
</details>
<details>
<summary><strong>10 · Comprehensive test coverage expansion across 15 production files to 98%+ metrics</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The developer needed to increase test coverage across multiple core modules (search indexing, sync engine, git operations, vault management, and skill installation) from their current baseline to 98% or higher on all metrics (statements, branches, functions, lines).

**💡 Decisions Behind the Code**

- **Isolate heavy mocks in separate test files**: SyncEngine.lockbusy.test.ts and VaultLockPath.fsmock.test.ts were created to hold tests that require wholesale mocking of node:fs or VaultWriteLock. This prevents mock pollution from affecting the main test suites, which need real filesystem or lock behavior. The trade-off is a small increase in test file count, but it preserves test isolation and prevents subtle failures when mocks conflict with real implementations.
- **Use v8 ignore start/stop blocks for unreachable defensive code**: The repo's `/* v8 ignore next */` single-line form does not suppress coverage reports, but the `/* v8 ignore start/stop */` block form does. Empty-segment guards in path normalization are provably unreachable because path.relative() normalizes away empty segments, so they were marked with block-form directives rather than adding tests that cannot realistically trigger them.

**✅ What Was Implemented**

- Added 17 new tests to SearchIndexSource, SearchIndex, MetadataManager, and MultiRepoCompile covering defensive branches: null page fallbacks, empty source references, missing metadata fields, schema version mismatches, and non-Error exception handling. These tests exercise the "unhappy path" branches that happy-path tests never reach.
- Expanded GitClient test suite by 15 tests covering removePath staging, hasUncommittedChanges with ignored files, explicit-path staging methods (stageAddPaths, stageRemovePaths, unstagePaths, resetPathsToHead), chunkByBudget batching logic, listLocalBranches error handling, and defensive branches like empty rev-parse output and stderr fallbacks.
- Added 22 tests to SyncEngine covering lock-busy errors, auto-reconcile failures, hasOwnedDirtyPaths classifier branches (transcript gating, rename old-side classification, per-device JSON deletion), canary bucket capping, vault marker rewriting, repo mapping conflict detection, push failure classification, 503 retry exhaustion, and migration edge cases. Isolated lock-busy tests in a separate file to avoid mocking conflicts with the main suite.

**📁 FILES**
- `cli/src/core/SearchIndexSource.test.ts`
- `cli/src/core/SearchIndex.test.ts`
- `cli/src/sync/GitClient.test.ts`
- `cli/src/sync/SyncEngine.test.ts`

</blockquote>
</details>
<details>
<summary><strong>11 · Handle lock contention in VS Code compile command</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

When the VS Code compile button was clicked while a background worker or sync was already running, the command would report "0 source(s) across 0 repo(s)" as a success, misleading the user into thinking the compile completed.

**💡 Decisions Behind the Code**

Lock contention is not a success — it means nothing ran. The UI should clearly distinguish between "compile completed with 0 sources" (rare but valid) and "compile was skipped due to lock contention" (user should wait and retry). The CLI path already handled this correctly; the VS Code path was missing the check.

**✅ What Was Implemented**

Updated `CompileCommand` in VS Code to check the `skipped` flag returned by `compileAllRepos` and show a different message ("another build is already running") instead of the success toast. Added test coverage verifying the correct message is shown on lock contention.

**📁 FILES**
- `vscode/src/CompileCommand.ts`

</blockquote>
</details>
<details>
<summary><strong>12 · Restore storage override in CLI compile command</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The `compileSingleRepo` function set a process-global storage override but never restored it, which could leak into a long-lived host process and cause subsequent operations to read from the wrong storage backend.

**💡 Decisions Behind the Code**

The one-shot CLI process is unaffected, but `executeCompile` is an exported entry point that could be called by a long-lived host. Restoring the previous override ensures the function is a good citizen and does not leak state into the caller's process.

**✅ What Was Implemented**

Added `getActiveStorage()` call to capture the previous override before setting a new one, and wrapped the compile logic in a try-finally block to restore it. Updated the mock in `CompileCommand.test.ts` to include `getActiveStorage` so the test does not fail.

**📁 FILES**
- `cli/src/commands/CompileCommand.ts`

</blockquote>
</details>
<details>
<summary><strong>13 · Unify SHA256 fingerprinting across MemoryBankScanner and SourceContent</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

SHA256 hashing was implemented inline in two places (MemoryBankScanner and SourceContent), creating a risk that the two fingerprints would drift if one implementation was updated without the other, causing files to be silently re-ingested.

**💡 Decisions Behind the Code**

Fingerprints are a round-trip contract: one place produces them (MemoryBankScanner), another verifies them (SourceContent). Using a shared helper ensures they stay in lockstep. The warning log makes the "file changed between scan and load" case diagnosable instead of silent.

**✅ What Was Implemented**

Replaced inline `createHash("sha256")` calls in both `MemoryBankScanner.ts` and `SourceContent.ts` with calls to the shared `MetadataManager.sha256` helper. Added a warning log when a userfile's fingerprint mismatches during load, surfacing the "changed since scan" case instead of silently skipping the file.

**📁 FILES**
- `cli/src/core/MemoryBankScanner.ts`
- `cli/src/core/SourceContent.ts`

</blockquote>
</details>
<details>
<summary><strong>14 · Add process-unique nonce to queue file names</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Git hooks run as separate node processes (post-commit, post-merge, QueueWorker re-enqueue) that could each enqueue an operation in the same millisecond with the same tag, causing file name collisions and lost queue entries.

**💡 Decisions Behind the Code**

The in-process sequence counter (`enqueueSeq`) only disambiguates within a single process. Cross-process collisions require a process-unique identifier. A random nonce is simpler and more robust than trying to coordinate process IDs or other system identifiers, and it does not disturb the timestamp-first sort order that drives the chronological drain.

**✅ What Was Implemented**

Added a process-unique random nonce (4 bytes, hex-encoded) to the queue file name format: `{timestamp}-{seq}-{nonce}-{tag}.json`. The nonce is generated once per process at module load time and included in every enqueued file name. Added a test verifying the nonce segment appears in the file name.

**📁 FILES**
- `cli/src/core/SessionTracker.ts`

</blockquote>
</details>
<details>
<summary><strong>15 · Remove dead statFile interface from storage providers</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The `StorageProvider.statFile` method was added but never called in production code, only in its own unit tests. It was also incorrectly routed in `DualWriteStorage` (forwarded to primary instead of shadow), making it unreliable.

**💡 Decisions Behind the Code**

Dead code that is never called in production should be removed rather than maintained. The method was added speculatively but never integrated into any real call path, and the incorrect routing in `DualWriteStorage` suggests it was not well-integrated. Removing it reduces surface area and eliminates a source of confusion.

**✅ What Was Implemented**

Deleted the `statFile` method from `StorageProvider`, `DualWriteStorage`, and `FolderStorage` interfaces and implementations. Removed the corresponding unit tests from `FolderStorage.test.ts`.

**📁 FILES**
- `cli/src/core/StorageProvider.ts`

</blockquote>
</details>
<details>
<summary><strong>16 · Add Orama and MCP SDK dependencies with smoke test</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The knowledge search feature requires two new runtime dependencies: Orama for full-text search indexing and the Model Context Protocol SDK for server communication. These need to be added to the CLI package and verified to import correctly.

**💡 Decisions Behind the Code**

The smoke test validates imports at the module level rather than attempting to instantiate or run the libraries. This approach catches missing or broken dependencies early without requiring a full integration test, reducing feedback latency during development. The test runs as part of the standard test suite but does not require external services or complex setup, keeping the barrier to running tests low.

**✅ What Was Implemented**

Added three npm dependencies to cli/package.json: `@modelcontextprotocol/sdk` (^1.0.0), `@orama/orama` (^3.0.0), and `@orama/plugin-data-persistence` (^3.0.0). Created a smoke test file cli/src/mcp/DepSmoke.test.ts that verifies all three dependencies can be imported and expose their expected public APIs: Orama's `create`, `search`, and `insertMultiple` functions; the persistence plugin's `persist` and `restore` functions; and the MCP SDK's `Server` and `StdioServerTransport` classes.

**📁 FILES**
- `cli/package.json`

</blockquote>
</details>

---

*Generated by Jolli Memory · June 10, 2026 at 5:43 PM · via Anthropic*
<!-- jollimemory-summary-end -->