### PR TITLE
Use ViewColumn.One for all SummaryWebviewPanel sources

### DIFF
--- a/vscode/src/views/SummaryWebviewPanel.handlePush.test.ts
+++ b/vscode/src/views/SummaryWebviewPanel.handlePush.test.ts
@@ -82,7 +82,7 @@ vi.mock("vscode", () => ({
 			toString: () => String(args.join("/")),
 		})),
 	},
-	ViewColumn: { Beside: 2 },
+	ViewColumn: { One: 1 },
 	workspace: { getConfiguration, fs: { writeFile: fsWriteFile } },
 	commands: { executeCommand },
 }));

--- a/vscode/src/views/SummaryWebviewPanel.test.ts
+++ b/vscode/src/views/SummaryWebviewPanel.test.ts
@@ -113,7 +113,7 @@ vi.mock("vscode", () => ({
 			toString: () => String(args.join("/")),
 		})),
 	},
-	ViewColumn: { One: 1, Beside: 2 },
+	ViewColumn: { One: 1 },
 	workspace: {
 		getConfiguration,
 		fs: { writeFile: fsWriteFile },
@@ -735,7 +735,7 @@ describe("SummaryWebviewPanel", () => {
 			expect(createWebviewPanel).toHaveBeenCalledWith(
 				"jollimemory.summary.commit",
 				"Commit Memory",
-				2,
+				1,
 				expect.objectContaining({
 					enableScripts: true,
 					retainContextWhenHidden: true,
@@ -757,7 +757,7 @@ describe("SummaryWebviewPanel", () => {
 			expect(createWebviewPanel).toHaveBeenCalledWith(
 				"jollimemory.summary.memory",
 				"Commit Memory",
-				2,
+				1,
 				expect.objectContaining({
 					enableScripts: true,
 					retainContextWhenHidden: true,
@@ -765,12 +765,12 @@ describe("SummaryWebviewPanel", () => {
 			);
 		});
 
-		// The KB-folder browser opens a summary tab against an explicit ViewColumn
-		// instead of "Beside" so it lands in column One (the main editor area)
-		// rather than floating next to whatever happens to be focused. The
-		// commit-source default uses Beside; switching source to "kb" must flip
-		// the column the panel is created in.
-		it("opens the KB source in ViewColumn.One instead of Beside", async () => {
+		// All sources — memory / commit / kb — open on ViewColumn.One so every
+		// memory/summary panel stacks as tabs in the main editor group (the same
+		// group VS Code's built-in markdown preview uses for the plain-markdown
+		// memory files: wiki / plan / note). kb was already on One; this guards
+		// against any source regressing to a different column.
+		it("opens the KB source in ViewColumn.One, unified with the other sources", async () => {
 			const summary = makeSummary();
 			await SummaryWebviewPanel.show(
 				summary,
@@ -781,7 +781,7 @@ describe("SummaryWebviewPanel", () => {
 				"kb",
 			);
 
-			// Third positional arg is the ViewColumn — 1 for One, 2 for Beside.
+			// Third positional arg is the ViewColumn — 1 for One.
 			expect(createWebviewPanel).toHaveBeenCalledWith(
 				"jollimemory.summary.commit",
 				"Commit Memory",
@@ -1088,7 +1088,8 @@ describe("SummaryWebviewPanel", () => {
 
 			expect(createWebviewPanel).toHaveBeenCalledTimes(1);
 			// reveal() with undefined viewColumn keeps the panel in its current column
-			// (passing ViewColumn.Beside would risk a column-move that blanks the iframe).
+			// (passing an explicit column would risk a column-move that blanks the iframe).
+			// Second arg is preserveFocus: true for commit source (keep focus on the sidebar).
 			expect(reveal).toHaveBeenCalledWith(undefined, true);
 		});
 

--- a/vscode/src/views/SummaryWebviewPanel.ts
+++ b/vscode/src/views/SummaryWebviewPanel.ts
@@ -4,7 +4,12 @@
  * Opens a webview beside the editor showing the full JolliMemory "Commit Memory" for a commit.
  *
  * Features:
- * - Opens in ViewColumn.Beside (doesn't replace the active editor)
+ * - Opens in ViewColumn.One so every memory/summary panel — regardless of
+ *   source (memory / commit / kb) — lands in the main editor group and stacks
+ *   as tabs there, instead of cascading into a new column per click. One is
+ *   also the group VS Code's built-in markdown preview opens into for the
+ *   plain-markdown memory files (wiki / plan / note), so the rich summary
+ *   panels and those previews end up tabbed together in one group.
  * - Notion-like Clean design: generous whitespace, callout blocks, toggle sections
  * - Automatic light/dark theme support via VSCode CSS variables + custom callout palette
  * - Collapsible memory toggles with smooth CSS transitions
@@ -468,7 +473,16 @@ export class SummaryWebviewPanel {
 		this.panel = vscode.window.createWebviewPanel(
 			viewType,
 			"Commit Memory",
-			source === "kb" ? vscode.ViewColumn.One : vscode.ViewColumn.Beside,
+			// Every source opens in the same fixed column (One — the main editor
+			// group) so the panels stack as tabs in one group rather than
+			// cascading into a fresh column on each click (which is what
+			// ViewColumn.Beside did — it recomputes "beside the active group"
+			// every time, so panel N+1 lands beside panel N). One is also the
+			// group VS Code's built-in markdown preview opens into for the
+			// plain-markdown memory files (wiki / plan / note), so the rich
+			// summary panels and those previews tab together. kb was already
+			// special-cased to One; commit/memory now join it instead of Beside.
+			vscode.ViewColumn.One,
 			{
 				enableScripts: true,
 				localResourceRoots: [extensionUri],
@@ -1105,10 +1119,14 @@ export class SummaryWebviewPanel {
 					existing.update(summary);
 				}
 				// reveal() with no args keeps the panel in its current view column.
-				// Passing ViewColumn.Beside can trigger a column-move (VSCode
-				// recomputes "beside" against the active editor at call time),
-				// which destroys and recreates the iframe and leaves it blank.
-				// KB source: switch focus to the tab. Commit source: keep focus on sidebar.
+				// Passing an explicit column here can trigger a column-move (the
+				// panel may have been dragged to another group since creation),
+				// which destroys and recreates the iframe and leaves it blank —
+				// so we always pass undefined and let it stay put.
+				// KB source: switch focus to the tab (folder-tree "open file"
+				// intent). Commit source: keep focus on the sidebar so the user
+				// can keep arrow-keying down the list. This focus distinction is
+				// independent of the (now unified) column.
 				existing.panel.reveal(undefined, source !== "kb");
 				return;
 			}


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## Quick recap

All memory summary panels in the Jolli Memory extension now open as tabs in the main editor group, sharing space with the plain-text previews for wiki, plan, and note memory files. Previously, clicking multiple items in the Memories list caused each panel to open in a fresh side-by-side column, progressively fragmenting the workspace. Now every panel — opened from a commit, a memory entry, or the knowledge-base folder tree — lands in the same group and stacks as a tab alongside the others.

Rich webview summaries and plain-text memory file previews are now co-located in one tab group, making it straightforward to move between different types of memory content without hunting across columns. The folder-tree entry point, which previously used a distinct placement to match a "file open" metaphor, now behaves consistently with all other entry points. Focus-stealing behavior for folder-tree interactions remains unchanged.

---

## Topic (1)
<details>
<summary><strong>01 · All memory summary panels unified into the main editor group as tabs</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Clicking multiple items in the Memories list caused each summary panel to open in a separate side-by-side column, quickly fragmenting the workspace. The user wanted all memory and summary panels — regardless of how they were opened — to stack as tabs in a single, predictable editor group.

**💡 Decisions Behind the Code**

- **Fixed column over dynamic "open beside active" placement**: The "beside active group" mode recomputes its target column relative to whichever editor group is currently focused, so each successive panel click lands in a new column rather than joining the existing group. A fixed column constant ensures every panel — regardless of when or how it is opened — stacks as a tab in the same group. The acknowledged trade-off is that panels now share space with whatever else the user has open in that group, but predictable placement was judged more valuable than visual isolation.
- **Main editor group over a dedicated side group**: Placing panels in the main editor group means rich webview summaries share space with the plain-text memory file previews (wiki, plan, note entries), so all memory-related content lands in one tab group. The earlier iteration used the second editor group to keep memory panels visually separated from source code; after reflection, the user decided that co-locating all memory content — both rich summaries and plain previews — in one place was more useful than the separation. The acknowledged cost is that summary panels now compete for space with open source files in the main group.
- **Unifying the folder-tree entry point with the rest**: The folder-tree entry point previously opened in the main editor area to match a "open a file" mental model, and this was an intentional, documented design choice with a dedicated test guarding it. After discussion, consistent placement across all entry points was considered more valuable than preserving the file-open metaphor for that one path. The focus-stealing behavior specific to folder-tree clicks was kept unchanged, as it is independent of which column is used.

**✅ What Was Implemented**

- `SummaryWebviewPanel.ts`: The column selection logic was updated twice across this squash. First, the conditional that sent folder-tree ("kb") sources to the main editor area and all others to "beside the active group" was replaced with a single fixed value of `ViewColumn.Two`. Then, in a follow-up amendment, the constant was changed again from `ViewColumn.Two` to `ViewColumn.One`, placing all panels in the main editor group. The surrounding comment and file-header feature description were rewritten to explain that `ViewColumn.One` is also where VS Code's built-in markdown preview opens plain-text memory files (wiki, plan, note), so all memory-related content now shares one tab group.
- `SummaryWebviewPanel.test.ts`: The `ViewColumn` mock was updated to reflect the final value (`{ One: 1 }`), all three column assertions (commit, memory, and kb sources) were changed to `1`, and the kb test name and inline comment were rewritten to reflect the unified-on-One rationale.
- `SummaryWebviewPanel.handlePush.test.ts`: The `ViewColumn` mock was updated to `{ One: 1 }` to match the production change.

**📋 Future Enhancements**

If placing panels in the main group alongside source code turns out to be disruptive in practice, revisiting whether to return to a dedicated side group or introduce a more granular grouping strategy was flagged as a possible follow-up.

**📁 FILES**
- `vscode/src/views/SummaryWebviewPanel.ts`

</blockquote>
</details>

---

*Generated by Jolli Memory · June 9, 2026 at 6:45 PM · via Anthropic*
<!-- jollimemory-summary-end -->