### PR TITLE
feat(vscode): redesign Commit Memory detail panel

### DIFF
--- a/vscode/src/services/PrCommentService.ts
+++ b/vscode/src/services/PrCommentService.ts
@@ -778,6 +778,7 @@ export function buildPrSectionHtml(): string {
 <div class="section" id="prSection">
   <div class="section-header">
     <div class="section-title">${PR_ICON} Pull Request</div>
+    <span class="ship-status is-loading" id="prStatusChip"><span class="led"></span>Checking…</span>
   </div>
   <p class="pr-status-text" id="prStatusText">Checking PR status...</p>
   <div class="pr-link-row pr-hidden" id="prLinkRow"></div>
@@ -829,6 +830,9 @@ export function buildPrSectionCss(): string {
   }
   .pr-actions {
     margin: 8px 0 4px;
+    display: flex;
+    gap: 7px;
+    flex-wrap: wrap;
   }
   /* ── PR History (Previously: …) ── */
   /*
@@ -930,6 +934,20 @@ export function buildPrSectionScript(): string {
   function prShow(el) { if (el) el.classList.remove('pr-hidden'); }
   function prHide(el) { if (el) el.classList.add('pr-hidden'); }
 
+  // Status chip in the PR card header (mirrors the Jolli card chip). Built via
+  // DOM (no innerHTML) so it stays CSP-safe; reuses the shared .ship-status
+  // styles from SummaryCssBuilder. cls is one of is-ok / is-warn / is-loading.
+  var prStatusChip = document.getElementById('prStatusChip');
+  function setPrChip(cls, label) {
+    if (!prStatusChip) return;
+    prStatusChip.className = 'ship-status ' + cls;
+    prStatusChip.textContent = '';
+    var led = document.createElement('span');
+    led.className = 'led';
+    prStatusChip.appendChild(led);
+    prStatusChip.appendChild(document.createTextNode(label));
+  }
+
   /**
    * Renders the "Previously: #N (merged) · #M (closed) · ..." strip.
    * Hides the row when history is empty. Each entry links to the PR URL;
@@ -1023,12 +1041,14 @@ export function buildPrMessageScript(): string {
       prHide(prForm);
 
       if (s === 'notInstalled') {
+        setPrChip('is-warn', 'Unavailable');
         prStatusText.textContent = 'GitHub CLI (gh) is not installed. Install it from https://cli.github.com/ and reload the window.';
         prShow(prStatusText);
         prHide(prLinkRow);
         prHide(prActions);
         prHide(prHistory);
       } else if (s === 'notAuthenticated') {
+        setPrChip('is-warn', 'Auth needed');
         prStatusText.textContent = 'GitHub CLI (gh) is not authenticated. Run "gh auth login" in a terminal, then retry.';
         prShow(prStatusText);
         prHide(prLinkRow);
@@ -1037,6 +1057,7 @@ export function buildPrMessageScript(): string {
         retryAuthBtn.className = 'action-btn';
         retryAuthBtn.textContent = 'Retry';
         retryAuthBtn.addEventListener('click', function() {
+          setPrChip('is-loading', 'Checking…');
           prStatusText.textContent = 'Checking PR status...';
           vscode.postMessage({ command: 'checkPrStatus' });
         });
@@ -1044,6 +1065,7 @@ export function buildPrMessageScript(): string {
         prShow(prActions);
         prHide(prHistory);
       } else if (s === 'unavailable') {
+        setPrChip('is-warn', 'Unavailable');
         prStatusText.textContent = msg.reason
           ? ('Could not load PR status — ' + msg.reason + '. Retry, or check the extension log.')
           : 'Could not reach GitHub CLI (gh). This is often transient — retry, or check the extension log.';
@@ -1054,6 +1076,7 @@ export function buildPrMessageScript(): string {
         retryBtn.className = 'action-btn';
         retryBtn.textContent = 'Retry';
         retryBtn.addEventListener('click', function() {
+          setPrChip('is-loading', 'Checking…');
           prStatusText.textContent = 'Checking PR status...';
           vscode.postMessage({ command: 'checkPrStatus' });
         });
@@ -1061,6 +1084,7 @@ export function buildPrMessageScript(): string {
         prShow(prActions);
         prHide(prHistory);
       } else if (s === 'noPr') {
+        setPrChip('is-warn', 'No PR');
         prHide(prLinkRow);
         prStatusText.textContent = 'No pull request found for branch ' + msg.branch + '.';
         prShow(prStatusText);
@@ -1078,9 +1102,31 @@ export function buildPrMessageScript(): string {
           btn.textContent = 'Loading...';
           vscode.postMessage({ command: 'prepareCreatePr' });
         });
+        // When no E2E tests exist yet, offer a one-click "generate E2E first,
+        // then create the PR" path so the PR body includes a fresh guide. The
+        // empty-state #generateE2eBtn presence is the "no E2E" signal; when E2E
+        // already exists this button is not rendered (and is removed on
+        // e2eTestUpdated). The shared window.prChainE2eThenCreate flag lets the
+        // e2eTestUpdated handler continue to prepareCreatePr once generation
+        // succeeds.
+        if (document.getElementById('generateE2eBtn')) {
+          var e2eThenPrBtn = document.createElement('button');
+          e2eThenPrBtn.className = 'action-btn';
+          e2eThenPrBtn.id = 'createPrWithE2eBtn';
+          e2eThenPrBtn.textContent = 'Generate E2E + Create PR';
+          prActions.appendChild(e2eThenPrBtn);
+          e2eThenPrBtn.addEventListener('click', function() {
+            e2eThenPrBtn.disabled = true;
+            e2eThenPrBtn.textContent = 'Generating E2E…';
+            btn.disabled = true;
+            window.prChainE2eThenCreate = true;
+            vscode.postMessage({ command: 'generateE2eTest' });
+          });
+        }
         renderPrHistory(msg.history);
       } else if (s === 'ready') {
         var pr = msg.pr;
+        setPrChip('is-ok', '#' + pr.number + ' open');
         prHide(prStatusText);
         // Build PR link via DOM
         prLinkRow.textContent = '';
@@ -1161,6 +1207,11 @@ export function buildPrMessageScript(): string {
     if (msg.command === 'prCreateBlockedCrossBranch') {
       var blockedBtn = document.getElementById('createPrBtn');
       if (blockedBtn) { blockedBtn.textContent = 'Create PR'; blockedBtn.disabled = false; }
+      // Also revert the "Generate E2E + Create PR" chain button + flag so a
+      // blocked attempt leaves a clickable state rather than a stuck spinner.
+      window.prChainE2eThenCreate = false;
+      var blockedE2eBtn = document.getElementById('createPrWithE2eBtn');
+      if (blockedE2eBtn) { blockedE2eBtn.textContent = 'Generate E2E + Create PR'; blockedE2eBtn.disabled = false; }
       if (prFormSubmit) {
         prFormSubmit.textContent = 'Submit PR';
         prFormSubmit.disabled = false;

--- a/vscode/src/views/SummaryCssBuilder.ts
+++ b/vscode/src/views/SummaryCssBuilder.ts
@@ -629,9 +629,13 @@ export function buildCss(): string {
   }
 
   /* ── Toggle content with smooth expand/collapse ── */
+  /* max-height is the expand/collapse animation cap, NOT a content limit. It
+     must stay well above the tallest realistic topic (trigger + decisions +
+     all inner callouts expanded) or long topics clip — the narrower reading
+     column makes topics taller, so 800px was no longer enough. */
   .toggle-content {
     overflow: hidden;
-    max-height: 800px;
+    max-height: 6000px;
     opacity: 1;
     transition: max-height 0.25s ease, opacity 0.2s ease, padding 0.25s ease;
     padding: 4px 10px 12px 30px;
@@ -1408,6 +1412,151 @@ export function buildCss(): string {
   .foreign-readonly .summary-error-banner-action,
   .stale-readonly .summary-error-banner-action {
     display: none;
+  }
+
+  /* ── Redesign v2: ship bar, panels, meta strip, attachment cards, private
+     drawer, reading column, responsive. Appended last so these rules win over
+     the legacy header / properties rules above (equal specificity → later
+     wins). Presentation only; every id + handler is unchanged. ── */
+
+  /* themed tokens (merge into the existing theme blocks via the cascade) */
+  body.vscode-light {
+    --panel-bg: rgba(0, 0, 0, 0.015);
+    --panel-inner: rgba(0, 0, 0, 0.035);
+    --ship-ok: #1b8a4f;
+    --ship-warn: #96680e;
+  }
+  body.vscode-dark, body.vscode-high-contrast {
+    --panel-bg: rgba(255, 255, 255, 0.018);
+    --panel-inner: rgba(255, 255, 255, 0.045);
+    --ship-ok: #4ece8d;
+    --ship-warn: #e0ac2b;
+  }
+
+  /* reading column: cap width for readability, tighten padding for narrow tabs */
+  .page { max-width: 820px; padding: 22px 18px 48px; }
+
+  /* ── Meta strip ── */
+  .meta-strip {
+    display: flex; flex-wrap: wrap; align-items: center; gap: 5px 9px;
+    font-size: 0.86em; color: var(--text-secondary); margin-bottom: 6px;
+  }
+  .meta-strip .meta-sep { color: var(--text-tertiary); opacity: 0.55; }
+  .meta-strip .meta-hash { font-family: var(--vscode-editor-font-family); color: var(--vscode-textLink-foreground); }
+  .meta-branch {
+    display: inline-block; max-width: 220px; overflow: hidden; text-overflow: ellipsis;
+    white-space: nowrap; vertical-align: bottom;
+    padding: 1px 8px; border-radius: 5px; background: var(--pill-bg); color: var(--pill-text); font-size: 0.92em;
+  }
+  .details-toggle {
+    background: none; border: none; cursor: pointer; font-family: var(--vscode-font-family);
+    font-size: 0.96em; color: var(--text-tertiary); padding: 1px 4px; border-radius: 4px;
+    text-decoration: underline; text-underline-offset: 2px; text-decoration-style: dotted;
+  }
+  .details-toggle:hover { color: var(--vscode-textLink-foreground); }
+  .details-toggle:focus-visible { outline: 2px solid var(--vscode-focusBorder); outline-offset: 1px; }
+
+  /* properties → collapsible Details disclosure */
+  .properties.collapsed { display: none; }
+  .properties { margin: 8px 0 4px; border: 1px solid var(--border-light); border-radius: 8px; overflow: hidden; }
+  /* Balanced horizontal padding so the value text isn't flush against the
+     tinted label column (the gap was the reported issue). */
+  .properties .prop-label { padding: 6px 16px; background: var(--panel-inner); }
+  .properties .prop-value { padding: 6px 16px; }
+  .header-actions { margin: 14px 0 20px; }
+
+  /* ── Ship bar (hero) ── */
+  .ship-bar {
+    display: grid; grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
+    gap: 12px; margin: 0 0 20px;
+  }
+  .ship-card {
+    border: 1px solid var(--border-light); border-radius: 11px; padding: 13px 15px;
+    background: var(--panel-bg); display: flex; flex-direction: column; gap: 9px;
+  }
+  .ship-card hr.separator { display: none; }
+  .ship-head { display: flex; align-items: center; gap: 8px; }
+  .ship-icon { opacity: 0.9; }
+  .ship-name { font-weight: 650; font-size: 0.92em; }
+  .ship-sub { font-size: 0.86em; color: var(--text-secondary); line-height: 1.45; }
+  .ship-actions { display: flex; gap: 7px; flex-wrap: wrap; }
+  .jolli-status { font-size: 0.9em; }
+  /* PR section reframed as a ship card: drop its standalone section spacing */
+  #prCard #prSection { margin: 0; }
+  #prCard .section-header { margin-bottom: 6px; }
+  #prCard .pr-status-text { margin-top: 0; }
+
+  /* ── Status chip (shared: Jolli synced/not-shared + PR open / loading) ── */
+  .ship-status {
+    margin-left: auto; display: inline-flex; align-items: center; gap: 5px; flex-shrink: 0;
+    font-size: 0.72em; font-weight: 650; letter-spacing: 0.02em; padding: 2px 9px;
+    border-radius: 11px; background: var(--surface-hover); color: var(--text-secondary);
+  }
+  .ship-status .led { width: 7px; height: 7px; border-radius: 50%; background: var(--text-tertiary); flex-shrink: 0; }
+  .ship-status.is-ok { color: var(--ship-ok); } .ship-status.is-ok .led { background: var(--ship-ok); }
+  .ship-status.is-warn { color: var(--ship-warn); } .ship-status.is-warn .led { background: var(--ship-warn); }
+  .ship-status.is-loading .led { animation: pulse 1.1s ease-in-out infinite; }
+  @keyframes pulse { 0%, 100% { opacity: 0.3; } 50% { opacity: 1; } }
+
+  /* ── Panels (grouping primitive: border = boundary, fills inside) ── */
+  .panel {
+    border: 1px solid var(--border-light); border-radius: 12px;
+    background: var(--panel-bg); padding: 16px; margin-bottom: 20px;
+  }
+  .panel hr.separator { display: none; }
+  .panel-header {
+    display: flex; align-items: center; gap: 8px;
+    padding-bottom: 8px; margin-bottom: 12px; border-bottom: 1px solid var(--border-light);
+  }
+  .panel-title { font-size: 0.78em; font-weight: 700; text-transform: uppercase; letter-spacing: 0.09em; color: var(--text-secondary); }
+  /* recap inside the memory panel: borderless accent block (no box-in-box) */
+  #memoryPanel #recapSection {
+    background: var(--panel-inner); border-left: 3px solid var(--vscode-textLink-foreground);
+    border-radius: 0 6px 6px 0; padding: 10px 13px; margin-bottom: 14px;
+  }
+
+  /* ── Attachment cards (collapse wrapper OUTSIDE the refreshed section so
+     collapse state survives plansAndNotesUpdated rebuilds for free) ── */
+  /* No overflow:hidden — the "+ Add" dropdown opens upward (bottom:100%) and
+     must escape the card bounds; clipping it cut off the first menu item.
+     Collapse uses display:none, so no overflow is needed for it. */
+  .attach-card { border-radius: 8px; background: var(--panel-inner); margin-bottom: 10px; }
+  .attach-card:last-child { margin-bottom: 0; }
+  .attach-card-head {
+    display: flex; align-items: center; gap: 8px; padding: 9px 12px;
+    cursor: pointer; user-select: none; font-size: 0.84em; font-weight: 600;
+  }
+  .attach-card-head:hover { background: var(--surface-hover); }
+  .attach-card-head:focus-visible { outline: 2px solid var(--vscode-focusBorder); outline-offset: -2px; }
+  .attach-arrow { margin-left: auto; font-size: 0.7em; color: var(--text-secondary); transition: transform 0.18s ease; }
+  .attach-card.collapsed .attach-arrow { transform: rotate(-90deg); }
+  .attach-card.collapsed .attach-card-body { display: none; }
+  .attach-card-body { padding: 4px 12px 12px; }
+  /* inner section titles replaced by the card head */
+  .attach-card-body .section-header { display: none; }
+  .attach-card-body .section-title { display: none; }
+
+  /* ── Private drawer (demoted to bottom, collapsible) ── */
+  .private-drawer {
+    border: 1px dashed var(--private-zone-border); border-radius: 10px;
+    background: var(--private-zone-bg); margin-top: 8px; overflow: hidden;
+  }
+  .private-head { display: flex; align-items: center; gap: 9px; padding: 11px 14px; cursor: pointer; user-select: none; }
+  .private-head:focus-visible { outline: 2px solid var(--vscode-focusBorder); outline-offset: -2px; }
+  .private-lock { font-size: 0.92em; }
+  .private-title { font-weight: 650; font-size: 0.8em; text-transform: uppercase; letter-spacing: 0.05em; }
+  .private-badge { font-size: 0.62em; font-weight: 700; letter-spacing: 0.1em; padding: 1px 6px; border-radius: 4px; background: var(--private-zone-border); color: var(--vscode-editor-background); }
+  .private-count { color: var(--text-secondary); font-size: 0.82em; }
+  .private-head .attach-arrow { color: var(--text-secondary); }
+  .private-drawer.collapsed .attach-arrow { transform: rotate(-90deg); }
+  .private-drawer.collapsed .private-body { display: none; }
+  /* the drawer head replaces the inner private-zone chrome; keep Manage/View */
+  .private-body .private-zone { border: none; background: none; padding: 0 14px 12px; margin: 0; }
+  .private-body .private-zone .section-title { display: none; }
+  .private-body .private-zone-watermark { display: none; }
+
+  @media (prefers-reduced-motion: reduce) {
+    .attach-arrow, .ship-status.is-loading .led { transition: none; animation: none; }
   }
 
 ${buildPrSectionCss()}

--- a/vscode/src/views/SummaryHtmlBuilder.test.ts
+++ b/vscode/src/views/SummaryHtmlBuilder.test.ts
@@ -271,6 +271,50 @@ describe("SummaryHtmlBuilder", () => {
 			expect(buildScript).toHaveBeenCalled();
 		});
 
+		// Guards the redesign's load-bearing invariant: the presentation re-skin
+		// must preserve every element id the client script + replaceSection
+		// refresh handlers bind to. A future refactor that drops or renames one
+		// of these would silently break push / regenerate / section refreshes.
+		it("preserves the structural ids the refresh handlers + redesign depend on", () => {
+			buildPrSectionHtml.mockReturnValue(
+				'<div id="prSection"></div><hr class="separator" />',
+			);
+			const html = buildHtml(makeSummary({ recap: "A recap." }), {
+				transcriptHashSet: new Set(["t1"]),
+			});
+			// New presentation wrappers
+			for (const id of [
+				"prCard",
+				"jolliCard",
+				"propTable",
+				"detailsToggle",
+				"memoryPanel",
+				"e2ePanel",
+				"attachmentsPanel",
+				"plansCard",
+				"privateDrawer",
+			]) {
+				expect(html).toContain(`id="${id}"`);
+			}
+			expect(html).toContain('class="ship-bar"');
+			expect(html).toContain('class="meta-strip"');
+			// Refresh-target sections must keep their ids (replaceSection contract)
+			for (const id of [
+				"recapSection",
+				"topicsSection",
+				"e2eTestSection",
+				"allConversationsSection",
+			]) {
+				expect(html).toContain(`id="${id}"`);
+			}
+			// Relocated controls keep their ids (handlers bind by id, not position)
+			expect(html).toContain('id="pushJolliBtn"');
+			expect(html).toContain('id="regenerateSummaryBtn"');
+			// Sections still emit the trailing <hr class="separator"> that
+			// replaceSection relies on as nextElementSibling.
+			expect(html).toContain('<hr class="separator"');
+		});
+
 		it("includes CSP meta tag when nonce is provided", () => {
 			const html = buildHtml(makeSummary(), { nonce: "abc123" });
 			expect(html).toContain('http-equiv="Content-Security-Policy"');
@@ -1183,14 +1227,17 @@ describe("SummaryHtmlBuilder", () => {
 	// ─── buildHtml recap ordering ────────────────────────────────────────────
 
 	describe("buildHtml recap ordering", () => {
-		it("renders Quick recap above the Pull Request section", () => {
+		// Redesign v2: the Ship bar (Create PR is the hero outbound action) sits
+		// at the top of the page; the Quick recap now lives inside the Memory
+		// panel below it. Order is intentionally PR-then-recap.
+		it("renders the Pull Request ship card above the Quick recap", () => {
 			buildPrSectionHtml.mockReturnValue('<div class="pr-marker">PR</div>');
 			const html = buildHtml(makeSummary({ recap: "A short recap." }));
-			const recapIdx = html.indexOf("recapSection");
 			const prIdx = html.indexOf("pr-marker");
-			expect(recapIdx).toBeGreaterThan(0);
+			const recapIdx = html.indexOf("recapSection");
 			expect(prIdx).toBeGreaterThan(0);
-			expect(recapIdx).toBeLessThan(prIdx);
+			expect(recapIdx).toBeGreaterThan(0);
+			expect(prIdx).toBeLessThan(recapIdx);
 		});
 
 		it("renders the State 1 placeholder when summary has no recap (so Generate button is reachable)", () => {

--- a/vscode/src/views/SummaryHtmlBuilder.ts
+++ b/vscode/src/views/SummaryHtmlBuilder.ts
@@ -151,15 +151,12 @@ ${csp}
 <div class="${pageClass}">
 ${buildSummaryErrorBanner(summary, { readOnly })}
 ${staleBannerHtml}
-${buildAllConversationsSection(transcriptHashSet, !!opts.foreignRepoName)}
-${buildHeader(summary, totalFiles, totalInsertions, totalDeletions)}
-<hr class="separator" />
-${buildRecapSection(summary.recap)}
-${buildPrSectionHtml()}
-${buildPlansAndNotesSection(summary.plans, summary.notes, summary.references ?? [], planTranslateSet, noteTranslateSet, referenceTranslateSet)}
-${buildE2eTestSection(summary)}
-${buildSourceCommits(sourceNodes)}
-${buildTopicsSection(summary, { readOnly })}
+${buildHeader(summary, totalFiles, totalInsertions, totalDeletions, !!opts.foreignRepoName)}
+${buildShipBar(summary)}
+${buildMemoryPanel(summary, { readOnly })}
+${buildE2ePanel(summary)}
+${buildAttachmentsPanel(summary, sourceNodes, planTranslateSet, noteTranslateSet, referenceTranslateSet)}
+${buildPrivateDrawer(transcriptHashSet, !!opts.foreignRepoName)}
 ${buildFooter(summary)}
 </div>
 <script${nonceAttr}>${buildScript()}</script>
@@ -246,46 +243,69 @@ export function buildJolliRow(
 		allItems.length > 0
 			? `<div class="jolli-plans-block"><span class="jolli-plans-label">Plans &amp; Notes</span>${allItems.join("")}</div>`
 			: "";
+	// Standalone block (not a `.prop-row`): lives inside the Jolli ship card.
+	// `jolliRowUpdated` (SummaryScriptBuilder) replaces this element wholesale
+	// by id, so the refresh stays consistent with this shape. Returns "" when
+	// the memory has not been shared yet (no url).
 	return `
-  <div class="prop-row" id="jolliRow">
-    <div class="prop-label">Jolli Memory</div>
-    <div class="prop-value">
-      <a class="jolli-link" href="${escHtml(url)}" title="${memoryTooltip}">${escHtml(url)}</a>
-      ${plansAndNotesHtml}
-    </div>
+  <div id="jolliRow" class="jolli-status">
+    <a class="jolli-link" href="${escHtml(url)}" title="${memoryTooltip}">${escHtml(url)}</a>
+    ${plansAndNotesHtml}
   </div>`;
 }
 
 // ─── Header ───────────────────────────────────────────────────────────────────
 
-/** Builds the page header: title + Notion-style properties table. */
+/**
+ * Builds the page header: title, a compact meta strip, the collapsible
+ * Details property table, and a secondary-action row (Copy Markdown +
+ * Regenerate). The Jolli "Share/Update" button and the `#jolliRow` link move
+ * to the ship bar (see buildShipBar); Regenerate (`#regenerateSummaryBtn`)
+ * moves here from the All Conversations section so the top-level action lives
+ * near the export controls.
+ *
+ * In `isForeign` (cross-repo Memory Bank) mode the Regenerate button is
+ * OMITTED from the DOM entirely — regenerating would write the orphan branch
+ * of the wrong repo, so we drop the affordance rather than rely on CSS to hide
+ * it (matching the old All-Conversations behavior). In stale / regenerating
+ * modes it stays in the DOM and is hidden by the readonly CSS rule (it is
+ * intentionally not `data-foreign-safe`).
+ */
 function buildHeader(
 	summary: CommitSummary,
 	totalFiles: number,
 	totalInsertions: number,
 	totalDeletions: number,
+	isForeign: boolean = false,
 ): string {
 	const changesHtml = `${totalFiles} file${totalFiles !== 1 ? "s" : ""} changed, <span class="stat-add">${totalInsertions} insertion${totalInsertions !== 1 ? "s" : ""}(+)</span>, <span class="stat-del">${totalDeletions} deletion${totalDeletions !== 1 ? "s" : ""}(-)</span>`;
 	const totalTurns = aggregateTurns(summary);
-	const pushLabel = summary.jolliDocUrl ? "Update on Jolli" : "Share in Jolli";
+	const shortHash = escHtml(summary.commitHash.substring(0, 8));
+	const turnsMeta =
+		totalTurns > 0
+			? `<span class="meta-sep">&middot;</span><span class="stat-turns">\uD83D\uDCAC ${totalTurns}</span>`
+			: "";
 
 	return `
 <h1 class="page-title">${escHtml(summary.commitMessage)}</h1>
-<div class="header-actions">
-  <div class="split-btn-group">
-    <button class="action-btn" id="copyMdBtn" data-foreign-safe>Copy Markdown</button>
-    <button class="action-btn split-toggle" id="copyMdDropdown" title="More export options" data-foreign-safe>&#x25BE;</button>
-    <div class="split-menu" id="copyMdMenu">
-      <button class="split-menu-item" id="downloadMdBtn" data-foreign-safe>Save as Markdown File</button>
-    </div>
-  </div>
-  <button class="action-btn primary" id="pushJolliBtn">${pushLabel}</button>
+<div class="meta-strip">
+  <span class="meta-hash">${shortHash}</span>
+  <span class="meta-sep">&middot;</span>
+  <span class="meta-branch" title="${escAttr(summary.branch)}">${escHtml(summary.branch)}</span>
+  <span class="meta-sep">&middot;</span>
+  <span class="meta-author">${escHtml(summary.commitAuthor)}</span>
+  <span class="meta-sep">&middot;</span>
+  <span class="meta-date">${timeAgo(getDisplayDate(summary))}</span>
+  <span class="meta-sep">&middot;</span>
+  <span class="meta-changes"><span class="stat-add">+${totalInsertions}</span>/<span class="stat-del">\u2212${totalDeletions}</span></span>
+  ${turnsMeta}
+  <button class="details-toggle" id="detailsToggle" data-foreign-safe aria-expanded="false">Details &#x25BE;</button>
 </div>
-<div class="properties">
+<div class="properties collapsed" id="propTable">
   <div class="prop-row">
     <div class="prop-label">Commit</div>
     <div class="prop-value">
-      <span class="hash">${escHtml(summary.commitHash.substring(0, 8))}</span>
+      <span class="hash">${shortHash}</span>
       <button class="hash-copy" data-hash="${escHtml(summary.commitHash)}" title="Copy full hash" data-foreign-safe>\u29C9</button>
     </div>
   </div>
@@ -310,7 +330,160 @@ function buildHeader(
     <div class="prop-value">${changesHtml}</div>
   </div>
   ${buildConversationsRow(totalTurns)}
-  ${buildJolliRow(summary.jolliDocUrl, summary.commitMessage, summary.plans, summary.notes)}
+</div>
+<div class="header-actions">
+  <div class="split-btn-group">
+    <button class="action-btn" id="copyMdBtn" data-foreign-safe>Copy Markdown</button>
+    <button class="action-btn split-toggle" id="copyMdDropdown" title="More export options" data-foreign-safe>&#x25BE;</button>
+    <div class="split-menu" id="copyMdMenu">
+      <button class="split-menu-item" id="downloadMdBtn" data-foreign-safe>Save as Markdown File</button>
+    </div>
+  </div>
+  ${isForeign ? "" : `<button class="action-btn" id="regenerateSummaryBtn" title="Re-run the LLM end-to-end">&#x21BB; Regenerate</button>`}
+</div>`;
+}
+
+// \u2500\u2500\u2500 Ship bar + content panels (presentation wrappers) \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500
+
+/**
+ * Builds the hero "ship bar": the PR card (wraps the existing #prSection) and
+ * the Jolli card (the relocated #pushJolliBtn + reshaped #jolliRow + a
+ * server-derived synced/not-shared status chip). Both outbound actions sit
+ * side-by-side (responsive: stacks to one column on narrow widths via CSS
+ * auto-fit). No behavior change \u2014 #prSection and #pushJolliBtn keep their ids
+ * and handlers; only their placement and framing change.
+ */
+function buildShipBar(summary: CommitSummary): string {
+	const synced = !!summary.jolliDocUrl;
+	const pushLabel = synced ? "Update on Jolli" : "Share in Jolli";
+	const jolliChip = synced
+		? `<span class="ship-status is-ok"><span class="led"></span>Synced</span>`
+		: `<span class="ship-status is-warn"><span class="led"></span>Not shared</span>`;
+	const jolliSub = synced
+		? ""
+		: `<div class="ship-sub">Lives only on your machine. Share to publish this memory to your team's Jolli space.</div>`;
+	return `
+<div class="ship-bar">
+  <div class="ship-card" id="prCard">
+    ${buildPrSectionHtml()}
+  </div>
+  <div class="ship-card" id="jolliCard">
+    <div class="ship-head">
+      <span class="ship-icon">&#x25C6;</span>
+      <span class="ship-name">Jolli Memory</span>
+      ${jolliChip}
+    </div>
+    ${jolliSub}
+    ${buildJolliRow(summary.jolliDocUrl, summary.commitMessage, summary.plans, summary.notes)}
+    <div class="ship-actions">
+      <button class="action-btn primary" id="pushJolliBtn">${pushLabel}</button>
+    </div>
+  </div>
+</div>`;
+}
+
+/**
+ * Wraps the recap + topics sections in a single bounded "Memory" panel so the
+ * primary content reads as one grouped surface. Both inner sections keep their
+ * ids (#recapSection, #topicsSection) and trailing <hr> (hidden by CSS inside
+ * the panel) so replaceSection refreshes are unaffected.
+ */
+function buildMemoryPanel(
+	summary: CommitSummary,
+	options: BuildTopicsSectionOptions = {},
+): string {
+	return `
+<div class="panel" id="memoryPanel">
+  <div class="panel-header"><span class="panel-title">The memory</span></div>
+  ${buildRecapSection(summary.recap)}
+  ${buildTopicsSection(summary, options)}
+</div>`;
+}
+
+/**
+ * Wraps the E2E section in its own panel (above attachments). The inner
+ * #e2eTestSection keeps its section-header (title + Generate/Regenerate/Delete
+ * actions) and id, so generate/regenerate/delete behavior is unchanged.
+ */
+function buildE2ePanel(summary: CommitSummary): string {
+	return `
+<div class="panel" id="e2ePanel">
+  ${buildE2eTestSection(summary)}
+</div>`;
+}
+
+/**
+ * Builds the "Attachments & context" panel containing collapsible cards.
+ *
+ * Each card wrapper (head + chevron) lives OUTSIDE the refreshed section so
+ * collapse state survives `plansAndNotesUpdated` rebuilds for free \u2014 the
+ * refresh only replaces the inner #plansAndNotesSection, never the card
+ * wrapper. As a consequence card boundaries match refresh boundaries:
+ * references render inside the "Plans & Notes" card (they share
+ * #plansAndNotesSection), and source commits get their own card. Inner
+ * section titles are hidden by CSS in favor of the card head.
+ */
+function buildAttachmentsPanel(
+	summary: CommitSummary,
+	sourceNodes: ReadonlyArray<CommitSummary>,
+	planTranslateSet?: ReadonlySet<string>,
+	noteTranslateSet?: ReadonlySet<string>,
+	referenceTranslateSet?: ReadonlySet<string>,
+): string {
+	const plansBody = buildPlansAndNotesSection(
+		summary.plans,
+		summary.notes,
+		summary.references ?? [],
+		planTranslateSet,
+		noteTranslateSet,
+		referenceTranslateSet,
+	);
+	const sourceBody = buildSourceCommits(sourceNodes);
+	const sourceCard = sourceBody
+		? `
+  <div class="attach-card" id="sourceCard">
+    <div class="attach-card-head" data-collapse="sourceCard" role="button" tabindex="0" aria-expanded="true" data-foreign-safe>&#x1F4E6; Source Commits <span class="attach-arrow">&#x25BC;</span></div>
+    <div class="attach-card-body">${sourceBody}</div>
+  </div>`
+		: "";
+	return `
+<div class="panel" id="attachmentsPanel">
+  <div class="panel-header"><span class="panel-title">Attachments &amp; context</span></div>
+  <div class="attach-card" id="plansCard">
+    <div class="attach-card-head" data-collapse="plansCard" role="button" tabindex="0" aria-expanded="true" data-foreign-safe>&#x1F4CB; Plans &amp; Notes <span class="attach-arrow">&#x25BC;</span></div>
+    <div class="attach-card-body">${plansBody}</div>
+  </div>
+  ${sourceCard}
+</div>`;
+}
+
+/**
+ * Demotes the All Conversations (private transcripts) zone to a collapsible
+ * drawer at the bottom of the page. The collapse toggle lives on the drawer
+ * head (outside #allConversationsSection) so refreshConversations rebuilds of
+ * the inner section never reset the drawer's collapse state. The inner
+ * section's own title is hidden by CSS in favor of the drawer head; its
+ * Manage/View transcript button is preserved.
+ */
+function buildPrivateDrawer(
+	transcriptHashSet?: ReadonlySet<string>,
+	isForeign: boolean = false,
+): string {
+	const count = transcriptHashSet?.size ?? 0;
+	const countLabel =
+		count > 0
+			? `<span class="private-count">${count} session${count !== 1 ? "s" : ""}</span>`
+			: "";
+	return `
+<div class="private-drawer" id="privateDrawer">
+  <div class="private-head" data-collapse="privateDrawer" role="button" tabindex="0" aria-expanded="true" data-foreign-safe>
+    <span class="private-lock">&#x1F512;</span>
+    <span class="private-title">All Conversations</span>
+    <span class="private-badge">PRIVATE</span>
+    ${countLabel}
+    <span class="attach-arrow">&#x25BC;</span>
+  </div>
+  <div class="private-body">${buildAllConversationsSection(transcriptHashSet, isForeign)}</div>
 </div>`;
 }
 
@@ -793,9 +966,9 @@ export function buildAllConversationsSection(
 	const count = transcriptHashSet?.size ?? 0;
 	let inner: string;
 	if (count === 0) {
-		const emptyActions = isForeign
-			? ""
-			: `      <button class="action-btn" id="regenerateSummaryBtn" title="Re-run the LLM end-to-end">&#x21BB; Regenerate</button>`;
+		// Regenerate moved to the page header (buildHeader); the conversations
+		// zone no longer renders its own button to avoid a duplicate id.
+		const emptyActions = "";
 		inner = `
 <div class="private-zone">
   <div class="private-zone-watermark">PRIVATE</div>
@@ -810,8 +983,7 @@ ${emptyActions}
 	} else {
 		const headerActions = isForeign
 			? `      <button class="action-btn" id="openTranscriptsBtn" data-foreign-safe title="Browse transcripts (read-only)">View</button>`
-			: `      <button class="action-btn" id="regenerateSummaryBtn" title="Re-run the LLM end-to-end">&#x21BB; Regenerate</button>
-      <button class="action-btn" id="openTranscriptsBtn">Manage</button>`;
+			: `      <button class="action-btn" id="openTranscriptsBtn">Manage</button>`;
 
 		inner = `
 <div class="private-zone">

--- a/vscode/src/views/SummaryScriptBuilder.ts
+++ b/vscode/src/views/SummaryScriptBuilder.ts
@@ -34,6 +34,38 @@ export function buildScript(): string {
   }
   document.querySelectorAll('.toggle-header').forEach(attachToggleHeader);
 
+  // ── Redesign v2: Details disclosure + panel/card/drawer collapse ──
+  // Net-new presentational toggles. The collapse wrappers (.attach-card,
+  // .private-drawer) live OUTSIDE the sections that replaceSection rebuilds, so
+  // their collapsed state survives plansAndNotesUpdated / refreshConversations
+  // refreshes with no state persistence needed. Bound once at load; the heads
+  // are never replaced. Default state is expanded for every collapsible region
+  // except the Details property table (which ships with .collapsed).
+  var detailsToggle = document.getElementById('detailsToggle');
+  if (detailsToggle) {
+    detailsToggle.addEventListener('click', function() {
+      var t = document.getElementById('propTable');
+      if (!t) { return; }
+      var open = t.classList.toggle('collapsed') === false;
+      detailsToggle.setAttribute('aria-expanded', open ? 'true' : 'false');
+      detailsToggle.textContent = open ? 'Details \\u25B4' : 'Details \\u25BE';
+    });
+  }
+  // A head element carrying data-collapse="<targetId>" toggles .collapsed on
+  // that container (attachment cards, private drawer). Keyboard-operable.
+  document.querySelectorAll('[data-collapse]').forEach(function(head) {
+    function toggleCollapse() {
+      var target = document.getElementById(head.getAttribute('data-collapse'));
+      if (!target) { return; }
+      var collapsed = target.classList.toggle('collapsed');
+      head.setAttribute('aria-expanded', collapsed ? 'false' : 'true');
+    }
+    head.addEventListener('click', toggleCollapse);
+    head.addEventListener('keydown', function(e) {
+      if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); toggleCollapse(); }
+    });
+  });
+
   // Hash copy button: copy full commit hash to clipboard inline
   document.querySelectorAll('.hash-copy').forEach(function(btn) {
     btn.addEventListener('click', function() {
@@ -700,7 +732,7 @@ ${buildPrMessageScript()}
 
   // ── Regenerate-summary shared request + delegated click handlers ────────
   // Drives the end-to-end re-run from either entry point:
-  //   - The Conversations card's #regenerateSummaryBtn (in the initial DOM)
+  //   - The page header's #regenerateSummaryBtn (in the initial DOM)
   //   - The top-of-page #summaryErrorRegenerateBtn (banner; may be inserted
   //     dynamically by the summaryRegenerated handler — event delegation
   //     means we don't need to re-bind after DOM replacement)
@@ -989,6 +1021,16 @@ ${buildPrMessageScript()}
           attachE2eHandlers(newSection);
         }
       }
+      // "Generate E2E + Create PR" chain: E2E now exists, so the second PR
+      // button no longer applies — retire it — and if the user launched the
+      // chain, continue to the PR create form (prepareCreatePr now picks up the
+      // freshly generated E2E in the body).
+      var chainE2eBtn = document.getElementById('createPrWithE2eBtn');
+      if (chainE2eBtn) { chainE2eBtn.remove(); }
+      if (window.prChainE2eThenCreate) {
+        window.prChainE2eThenCreate = false;
+        vscode.postMessage({ command: 'prepareCreatePr' });
+      }
     } else if (msg.command === 'e2eScenarioUpdated' && typeof msg.scenarioIndex === 'number' && msg.html) {
       // Surgical per-scenario replacement preserves collapsed state of other scenarios.
       var oldToggle = document.getElementById('e2e-scenario-' + msg.scenarioIndex);
@@ -1025,6 +1067,15 @@ ${buildPrMessageScript()}
           btn.textContent = '\\u2728 Generate';
         }
         btn.disabled = false;
+      }
+      // Abort the "Generate E2E + Create PR" chain and restore its buttons so
+      // the user can retry or fall back to a plain Create PR.
+      if (window.prChainE2eThenCreate) {
+        window.prChainE2eThenCreate = false;
+        var chainErrBtn = document.getElementById('createPrWithE2eBtn');
+        if (chainErrBtn) { chainErrBtn.disabled = false; chainErrBtn.textContent = 'Generate E2E + Create PR'; }
+        var createErrBtn = document.getElementById('createPrBtn');
+        if (createErrBtn) { createErrBtn.disabled = false; }
       }
     }
 


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## Quick recap

The developer redesigned the Commit Memory detail panel in the VS Code extension, addressing longstanding UX complaints about buried content, wasted space, and disjointed controls. The panel was restructured around a "memory-first" information hierarchy: a hero "Ship bar" now sits at the top with the Create PR and Jolli sync controls unified side-by-side, followed by a bounded Memory panel (recap and topics), a dedicated E2E Test panel with a Generate option, and an Attachments panel for plans, notes, and source commits. Private transcripts were demoted to a collapsible drawer at the bottom. A compact meta strip replaced the tall eight-row properties table, with full details available on demand via a disclosure toggle. The layout is responsive, collapsing to a single column at narrow widths via CSS auto-fit. A new "Generate E2E + Create PR" button was added to the no-PR state when no E2E tests exist yet, chaining the two actions. Three parallel code review passes (consistency, security, and OSS-readiness) were run after implementation, resulting in removal of dead CSS, a stale comment fix, and a new invariant test that locks the structural element IDs the refresh handlers depend on.

---

## E2E Test (5)
<details>
<summary><strong>1. Ship bar appears at the top with PR and Jolli cards side by side</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a commit memory panel open in VS Code (any commit with or without an existing Jolli doc URL works).

**Steps:**
1. Open the Commit Memory detail panel for any commit.
2. Look at the area directly below the commit title.
3. Check that two cards appear side by side (or stacked on a narrow panel): one labelled "Pull Request" and one labelled "Jolli Memory".
4. Check that the Jolli card contains a coloured status chip — "Synced" (green) if the memory has already been shared, or "Not shared" (amber) if it has not.
5. Check that the "Share in Jolli" or "Update on Jolli" button lives inside the Jolli card.
6. Check that the PR card shows a status chip (e.g. "Checking…" with a pulsing dot while loading, then a label like "#12 open" or "No PR" once loaded).

**Expected Results:**
- Two cards are visible in the ship bar immediately below the page title.
- The Jolli card chip reads "Synced" in green for a previously shared memory, or "Not shared" in amber for an unshared one.
- The PR card chip updates from the pulsing "Checking…" state to a meaningful label (such as "#12 open", "No PR", or "Auth needed") once the PR status loads.
- The push button ("Share in Jolli" / "Update on Jolli") is inside the Jolli card, not in a separate top action bar.

</blockquote>
</details>
<details>
<summary><strong>2. PR status chip updates correctly through all states</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a commit memory panel open where GitHub CLI is available and authenticated.

**Steps:**
1. Open the Commit Memory detail panel for a commit that has no pull request on its branch.
2. Wait for the PR card to finish loading and note the chip label.
3. Now open a panel for a commit whose branch has an open pull request.
4. Wait for the PR card to finish loading and note the chip label.
5. If a "Retry" button is visible (e.g. after disconnecting from the network or revoking auth), click it and watch the chip while it rechecks.

**Expected Results:**
- For a branch with no PR the chip shows "No PR" in amber.
- For a branch with an open PR the chip shows the PR number and "open" in green (e.g. "#42 open").
- After clicking Retry the chip immediately switches back to the pulsing "Checking…" state before settling on the new result.

</blockquote>
</details>
<details>
<summary><strong>3. Memory-first layout: recap and topics appear before E2E tests and attachments</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a commit memory panel open for a commit that has a recap, at least one topic, an E2E test entry, and at least one plan or note.

**Steps:**
1. Open the Commit Memory detail panel.
2. Scroll down past the ship bar.
3. Verify the first bordered panel is labelled "The memory" and contains the Quick recap and the topics list.
4. Verify the next panel below it is the E2E test panel.
5. Verify the "Attachments & context" panel (with Plans & Notes and Source Commits cards) appears after the E2E panel.
6. Scroll to the very bottom and verify the private "All Conversations" section is there as a collapsible drawer.

**Expected Results:**
- The recap and topics are the first content seen after the ship bar, inside a single bordered "The memory" panel.
- The E2E panel sits between the memory panel and the attachments panel.
- Plans & Notes and Source Commits appear as collapsible cards inside the Attachments panel.
- The All Conversations drawer is at the bottom of the page, not near the top.

</blockquote>
</details>
<details>
<summary><strong>4. Collapsible attachment cards and private drawer retain state across content refreshes</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a commit memory panel open that has at least one plan or note and at least one conversation session.

**Steps:**
1. Open the Commit Memory detail panel and scroll to the "Attachments & context" panel.
2. Click the "Plans & Notes" card header to collapse it; confirm the body disappears.
3. Click the lock icon / "All Conversations" drawer header at the bottom to collapse it; confirm it closes.
4. Add a new plan or note (use the add button inside the Plans & Notes card body — expand it first if needed) and wait for the panel to refresh.
5. Re-check whether the Plans & Notes card and the All Conversations drawer are still in the same collapsed or expanded state you left them in.

**Expected Results:**
- Clicking a card header collapses that card (body hidden, chevron rotates).
- After a plan/note is added and the content refreshes automatically, the collapsed/expanded state of both the Plans & Notes card and the All Conversations drawer is unchanged — they do not snap back to open.

</blockquote>
</details>
<details>
<summary><strong>5. Compact meta strip and collapsible Details table</strong></summary>
<br>
<blockquote>

**Steps:**
1. Open the Commit Memory detail panel.
2. Look directly below the commit title for a single line showing the short commit hash, branch name, author, date, and diff stats (e.g. "+12/−3").
3. Confirm the full eight-row properties table is NOT visible by default.
4. Click the "Details ▾" button in that meta strip.
5. Verify the full properties table expands below the strip.
6. Click "Details ▴" again and verify the table collapses.

**Expected Results:**
- The meta strip is visible immediately below the title with hash, branch pill, author, date, and diff stats on one compact line.
- The properties table is hidden on first load.
- Clicking "Details" toggles the table open and closed; the button label and chevron direction change to match the current state.

</blockquote>
</details>

---

## Topics (5)
<details>
<summary><strong>01 · Redesign memory detail panel with memory-first layout and ship bar</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The existing memory detail panel opened with private transcripts and a tall metadata table, burying the actual memory content. The Jolli link and Update button were split across different parts of the page, Create PR was hidden mid-page, and the overall layout felt cluttered and disjointed.

**💡 Decisions Behind the Code**

- **Preserving all element IDs over reshaping the DOM structure**: Every interactive element kept its existing ID even as its position and container changed. This was the critical constraint that made a zero-functional-change redesign possible — the client script and the section-replacement refresh system both bind by ID, not by position, so reordering and wrapping nodes is safe as long as IDs are stable.
- **Collapse wrappers outside refreshed sections**: The attachment card heads and private drawer toggle were placed as siblings above the sections that get rebuilt on data updates, rather than inside them. This meant collapse state survived rebuilds for free with no persistence code, but it required that card boundaries match refresh boundaries — references ended up grouped inside the Plans and Notes card rather than getting their own card, which was the accepted trade-off for eliminating a new bug vector.
- **CSS auto-fit for the responsive breakpoint**: Rather than picking a hard pixel breakpoint for the two-column ship bar and attachments grid, the layout uses a CSS grid minimum card width so the column count derives from available space automatically. This means the layout is correct at any panel width without a separate media query to maintain.

**✅ What Was Implemented**

- Restructured the HTML builder to place a two-card "Ship bar" at the top of the page, wrapping the existing PR section in one card and relocating the Jolli push button plus a new server-derived synced/not-shared status chip into a second card. Both cards sit side-by-side via CSS auto-fit and collapse to a single column at narrow widths. All existing element IDs and the section-replacement contract (each section followed immediately by a horizontal rule) were preserved so no refresh handlers required changes.
- Split the header into a compact meta strip (hash, branch, author, date, change stats) plus a collapsible Details disclosure that hides the full properties table by default, replacing the always-visible eight-row table. Added bounded panel wrappers around the Memory (recap and topics), E2E Test, and Attachments zones to create clear visual groupings. Private transcripts were moved into a collapsible drawer at the bottom of the page.
- Added net-new presentational toggle handlers for the Details disclosure and all collapsible cards and the private drawer. Collapse wrappers were placed outside the sections that get rebuilt on refresh, so collapse state survives plan additions and conversation refreshes without any state-persistence logic.

**📋 Future Enhancements**

IntelliJ plugin has a full parallel Kotlin implementation of the same panel with the same UX problems — a port of this redesign is needed to keep both surfaces in lockstep, deferred until the VS Code design is stable.

**📁 FILES**
- `vscode/src/views/SummaryHtmlBuilder.ts`
- `vscode/src/views/SummaryCssBuilder.ts`
- `vscode/src/views/SummaryScriptBuilder.ts`

</blockquote>
</details>
<details>
<summary><strong>02 · Add Generate E2E then Create PR chained action button</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

When no E2E tests had been generated yet, the only path to creating a PR omitted the E2E guide from the PR body. The user wanted a single action that would generate the E2E tests first and then open the PR creation form with the guide already included.

**💡 Decisions Behind the Code**

- **Window-scoped flag over a closure variable**: A flag on the window object was used to communicate between the E2E update handler and the PR message handler, since both handlers are registered independently and share no closure scope. This is consistent with how the existing webview script coordinates state across message handlers.
- **DOM presence as the "no E2E" signal**: Rather than passing a server-side boolean into the script, the presence of the empty-state generate button in the DOM was used to decide whether to render the second button. This kept the change additive and avoided touching the HTML builder's data model, and the button is automatically removed from the DOM when E2E is generated, so the second PR button retires itself naturally.

**✅ What Was Implemented**

- Added a second button alongside Create PR in the no-PR state, rendered only when the empty-state E2E generate button is present in the DOM (used as the signal that no E2E tests exist yet). Clicking it disables both buttons, posts a generate command, and sets a shared flag on the window object.
- Wired the E2E update success handler to check the flag: on success it removes the second button (now redundant since E2E exists) and continues to the PR prepare command so the form opens with the fresh guide in the body. On error or cross-branch block, the flag is cleared and both buttons are restored to a clickable state.

**📁 FILES**
- `vscode/src/services/PrCommentService.ts`
- `vscode/src/views/SummaryScriptBuilder.ts`

</blockquote>
</details>
<details>
<summary><strong>03 · Add PR status chip to the pull request card header</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The PR card in the redesigned ship bar had no at-a-glance status indicator. The user needed to be able to see whether a PR existed, was open, or had a problem without reading the status text paragraph.

**💡 Decisions Behind the Code**

- **Additive chip element over restyling existing status text**: The chip was added as a new element in the section header rather than replacing or restyling the existing status text paragraph. This kept all existing PR flow logic and its tests untouched — the chip is purely an additional visual indicator layered on top of the existing state machine, so the PR test suite passed without modification.

**✅ What Was Implemented**

Added a status chip element to the PR section header markup and a CSP-safe DOM setter function in the PR script. The setter is called in each of the five status branches (not installed, not authenticated, unavailable, no PR, ready/open) and on both retry button clicks to reset to the loading state. The chip reuses the shared status chip styles from the CSS redesign, showing colored LED dot plus label text.

**📁 FILES**
- `vscode/src/services/PrCommentService.ts`

</blockquote>
</details>
<details>
<summary><strong>04 · Fix expanded topic content being clipped at bottom</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

After the redesign narrowed the reading column, long expanded topics were being cut off visually. The content appeared to stop mid-way through with no scroll, making some topic details unreachable.

**💡 Decisions Behind the Code**

- **Raise the cap rather than remove it**: The max-height value drives the CSS expand/collapse height animation — removing it entirely would break the smooth open/close transition. Raising it to a value well above any realistic topic length preserves the animation while eliminating clipping, at the cost of a slightly less precise animation duration on very short topics (negligible in practice).

**✅ What Was Implemented**

Raised the animation cap on expanded toggle content from 800px to 6000px and added a comment explaining that this value is an expand/collapse animation ceiling, not a content limit. The narrower reading column made topic text taller, causing content to exceed the old cap and get hidden by the overflow constraint.

**📁 FILES**
- `vscode/src/views/SummaryCssBuilder.ts`

</blockquote>
</details>
<details>
<summary><strong>05 · Add invariant test locking structural element IDs against future regressions</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

A code review pass identified that nothing prevented a future refactor from silently renaming or removing the element IDs that the client script and section-refresh handlers depend on. Breaking one of these IDs would cause push, regenerate, or section refresh to silently stop working.

**💡 Decisions Behind the Code**

- **Explicit ID invariant test over relying on snapshot tests**: Snapshot tests catch any change but require manual review to distinguish intentional from accidental. An explicit list of must-have IDs fails loudly and specifically when a load-bearing ID is dropped, making the failure message self-explanatory to a developer who was not present for the redesign. This was the highest-value suggestion from the OSS review pass.

**✅ What Was Implemented**

Added a test asserting that a fully rendered panel HTML string contains every load-bearing element ID: the new presentation wrapper IDs introduced by the redesign, the section IDs used by the replacement refresh system, the relocated control IDs for push and regenerate, and the presence of the horizontal rule separator that the replacement system uses to locate adjacent siblings. The test also confirms the ship bar and meta strip class names are present.

**📁 FILES**
- `vscode/src/views/SummaryHtmlBuilder.test.ts`

</blockquote>
</details>

---

*Generated by Jolli Memory · June 9, 2026 at 3:21 PM · via Jolli proxy*
<!-- jollimemory-summary-end -->