### PR TITLE
Fix activation events and add icon to mainView in package.json

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -39,8 +39,7 @@
 	],
 	"activationEvents": [
 		"workspaceContains:.git",
-		"onUri",
-		"onView:jollimemory.mainView"
+		"onUri"
 	],
 	"main": "./dist/Extension.js",
 	"contributes": {
@@ -65,7 +64,8 @@
 				{
 					"id": "jollimemory.mainView",
 					"name": "Jolli Memory",
-					"type": "webview"
+					"type": "webview",
+					"icon": "assets/icon.svg"
 				}
 			]
 		},


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## Topic (1)
<details>
<summary><strong>01 · Remove redundant activation event and add missing view icon</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

VS Code reported two problems in the extension manifest: an activation event that the editor now generates automatically was declared explicitly, and the main view contribution was missing a required icon property.

**💡 Decisions Behind the Code**

- **Reuse existing asset**: The icon path was set to `assets/icon.svg` rather than introducing a new asset, because that SVG was already present and used by the activity bar container — no new file needed.
- **Remove rather than suppress**: The redundant activation event was deleted outright rather than left with a comment, because VS Code's automatic generation makes the explicit declaration actively misleading to future readers.

**✅ What Was Implemented**

- Removed `"onView:jollimemory.mainView"` from the `activationEvents` array in `vscode/package.json`; VS Code 1.74+ auto-generates this entry from view contribution declarations.
- Added `"icon": "assets/icon.svg"` to the `jollimemory.mainView` view contribution object, reusing the SVG already referenced by the activity bar container.

**📁 FILES**
- `vscode/package.json`

</blockquote>
</details>

---

*Generated by Jolli Memory · June 9, 2026 at 5:14 PM · via Anthropic*
<!-- jollimemory-summary-end -->