### PR TITLE
Add tie-break preference order to pickBestDistPath and resolve-dist-path

### DIFF
--- a/cli/src/core/references/ClaudeEnvelopeParser.ts
+++ b/cli/src/core/references/ClaudeEnvelopeParser.ts
@@ -17,7 +17,7 @@
  */
 
 import { createLogger } from "../../Logger.js";
-import { CLAUDE_TOOL_PREFIXES, claudeBindingForToolName } from "./bindings/claude/index.js";
+import { CLAUDE_SHELL_TOOL_NAMES, CLAUDE_TOOL_PREFIXES, resolveClaudeTool } from "./bindings/claude/index.js";
 import type { SourceAdapter } from "./sources/SourceAdapter.js";
 import type {
 	EnvelopeParseResult,
@@ -35,14 +35,21 @@ interface PendingEntry {
 	readonly timestamp?: string;
 	readonly adapter: SourceAdapter;
 	readonly normalize: (business: unknown) => unknown;
+	/** CLI (shell) entries require a successful command — drop the result if
+	 *  `is_error: true`. MCP entries set this false to keep prior behaviour. */
+	readonly requireSuccess: boolean;
 }
 
 class ClaudeEnvelopeParser implements TranscriptEnvelopeParser {
 	parse(lines: string[], opts: ExtractOptions, adapters: readonly SourceAdapter[]): EnvelopeParseResult {
 		// Pre-compute the per-line substring needles so we don't rebuild them per line.
 		// Recognition (which tool → which source) lives in the Claude binding now,
-		// not on the adapter; the needles use the binding's tool-name prefixes.
-		const nameNeedles = CLAUDE_TOOL_PREFIXES.map((p) => `"name":"${p}`);
+		// not on the adapter; the needles use the binding's tool-name prefixes plus
+		// the shell tool names (exact-quoted to avoid matching e.g. `BashOutput`).
+		const nameNeedles = [
+			...CLAUDE_TOOL_PREFIXES.map((p) => `"name":"${p}`),
+			...[...CLAUDE_SHELL_TOOL_NAMES].map((n) => `"name":"${n}"`),
+		];
 		const adapterFor = (id: SourceAdapter["id"]): SourceAdapter | undefined => adapters.find((a) => a.id === id);
 
 		const fromLine = opts.fromLineNumber ?? 0;
@@ -129,20 +136,27 @@ function collectToolUses(
 	for (const block of blocks) {
 		/* v8 ignore start -- defensive guards (non-object block, wrong type, missing id/name) are unreachable in valid Claude Code JSONL once the substring pre-filter passed; pinned for total-function semantics. */
 		if (!isObject(block)) continue;
-		const b = block as { type?: unknown; id?: unknown; name?: unknown };
+		const b = block as { type?: unknown; id?: unknown; name?: unknown; input?: unknown };
 		if (b.type !== "tool_use") continue;
 		if (typeof b.id !== "string" || typeof b.name !== "string") continue;
 		/* v8 ignore stop */
 		const name = b.name;
-		// Recognition + tool-level business scope (e.g. Notion only `notion-fetch`)
-		// live in the Claude binding; a non-matching tool is dropped here.
-		const binding = claudeBindingForToolName(name);
-		if (binding === null) continue;
-		const adapter = adapterFor(binding.sourceId);
+		// Recognition + tool-level business scope (e.g. Notion only `notion-fetch`,
+		// or a `Bash` shell command matching the CLI registry) live in the Claude
+		// binding; a non-matching tool is dropped here.
+		const resolved = resolveClaudeTool(name, b.input);
+		if (resolved === null) continue;
+		const adapter = adapterFor(resolved.sourceId);
 		/* v8 ignore start -- adapters always include all four sources; guarded for totality. */
 		if (adapter === undefined) continue;
 		/* v8 ignore stop */
-		pending.set(b.id, { toolName: name, timestamp, adapter, normalize: binding.normalize });
+		pending.set(b.id, {
+			toolName: resolved.toolName,
+			timestamp,
+			adapter,
+			normalize: resolved.normalize,
+			requireSuccess: resolved.kind === "cli",
+		});
 	}
 }
 
@@ -158,11 +172,19 @@ function collectToolResults(
 	for (const block of blocks) {
 		/* v8 ignore start -- defensive guards: non-object block / non-tool_result type / non-string tool_use_id all unreachable in valid Claude Code JSONL once the substring pre-filter ran. */
 		if (!isObject(block)) continue;
-		const b = block as { type?: unknown; tool_use_id?: unknown; content?: unknown };
+		const b = block as { type?: unknown; tool_use_id?: unknown; content?: unknown; is_error?: unknown };
 		if (b.type !== "tool_result" || typeof b.tool_use_id !== "string") continue;
 		/* v8 ignore stop */
 		const pendingEntry = pending.get(b.tool_use_id);
 		if (!pendingEntry) continue;
+		// CLI (shell) results require success: a failed command whose stdout is
+		// valid issue JSON must not be ingested. Scoped to CLI entries via
+		// `requireSuccess` so MCP results stay byte-identical (an errored MCP
+		// result is still parsed exactly as before).
+		if (pendingEntry.requireSuccess && b.is_error === true) {
+			pending.delete(b.tool_use_id);
+			continue;
+		}
 		const payloadText = extractResultPayloadText(b.content);
 		/* v8 ignore start -- defensive against malformed payload (no text content); live transcripts always include payload text. */
 		if (payloadText === undefined) {

--- a/cli/src/core/references/CodexEnvelopeParser.test.ts
+++ b/cli/src/core/references/CodexEnvelopeParser.test.ts
@@ -548,3 +548,155 @@ describe("CodexEnvelopeParser end-to-end — Jira malformed-output recovery", ()
 		expect(jira?.url).toBe("https://acme.atlassian.net/browse/KAN-7");
 	});
 });
+
+// ─── shell CLI (`gh issue view … --json`) ────────────────────────────────────
+
+/** shell_command request row: NO namespace; the command is inside the JSON-string `arguments`. */
+function shellCall(command: string, callId: string): string {
+	return jsonl({
+		type: "response_item",
+		timestamp: TS,
+		payload: {
+			type: "function_call",
+			name: "shell_command",
+			arguments: JSON.stringify({ command, workdir: "e:\\jollimemory-3", timeout_ms: 20000 }),
+			call_id: callId,
+		},
+	});
+}
+
+/** shell function_call_output: real prefix `Exit code: N\nWall time: …\nOutput:\n<json>`. */
+function shellOutput(callId: string, inner: unknown, exitCode = 0): string {
+	const output = `Exit code: ${exitCode}\nWall time: 2.1 seconds\nOutput:\n${JSON.stringify(inner)}`;
+	return jsonl({
+		type: "response_item",
+		timestamp: TS,
+		payload: { type: "function_call_output", call_id: callId, output },
+	});
+}
+
+/** Real `gh issue view 959 --json …` payload (single issue, uppercase state). */
+const GH_CLI = {
+	number: 959,
+	title: "Support multi-source external entity auto-discovery",
+	state: "CLOSED",
+	url: "https://github.com/jolliai/jolli/issues/959",
+	body: "Body text",
+	labels: [{ name: "enhancement" }],
+	assignees: [{ login: "sanshizhang-jolli" }],
+};
+const GH_VIEW_CMD = "gh issue view 959 --repo jolliai/jolli --json number,title,state,labels,assignees,body,url";
+
+describe("CodexEnvelopeParser.parse — shell CLI (gh issue view)", () => {
+	it("emits a github ref from a shell gh issue view pair (canonical toolName, exit 0)", () => {
+		const lines = [shellCall(GH_VIEW_CMD, "c_sh"), shellOutput("c_sh", GH_CLI, 0)];
+		const { results } = codexEnvelopeParser.parse(lines, {}, ALL_ADAPTERS);
+		expect(results).toHaveLength(1);
+		expect(results[0].adapter.id).toBe("github");
+		expect(results[0].toolName).toBe("mcp__github__issue_read");
+	});
+
+	it("drops a failed command (non-zero exit) even when stdout is valid issue JSON", () => {
+		const lines = [shellCall(GH_VIEW_CMD, "c_fail"), shellOutput("c_fail", GH_CLI, 1)];
+		const { results } = codexEnvelopeParser.parse(lines, {}, ALL_ADAPTERS);
+		expect(results).toHaveLength(0);
+	});
+
+	it("ignores a non-gh shell command", () => {
+		const lines = [shellCall("npm test", "c_npm"), shellOutput("c_npm", GH_CLI, 0)];
+		const { results } = codexEnvelopeParser.parse(lines, {}, ALL_ADAPTERS);
+		expect(results).toHaveLength(0);
+	});
+
+	it("ignores a shell call whose `arguments` are not parseable JSON (no command extracted)", () => {
+		const badCall = jsonl({
+			type: "response_item",
+			timestamp: TS,
+			payload: { type: "function_call", name: "shell_command", arguments: "{not json", call_id: "c_bad" },
+		});
+		const { results } = codexEnvelopeParser.parse([badCall, shellOutput("c_bad", GH_CLI, 0)], {}, ALL_ADAPTERS);
+		expect(results).toHaveLength(0);
+	});
+
+	it("drops a gh shell pair whose exit-0 stdout is not JSON", () => {
+		const out = jsonl({
+			type: "response_item",
+			timestamp: TS,
+			payload: {
+				type: "function_call_output",
+				call_id: "c_txt",
+				output: "Exit code: 0\nWall time: 1s\nOutput:\nnot json",
+			},
+		});
+		const { results } = codexEnvelopeParser.parse([shellCall(GH_VIEW_CMD, "c_txt"), out], {}, ALL_ADAPTERS);
+		expect(results).toHaveLength(0);
+	});
+
+	it("drops a gh shell pair whose output lacks the `Exit code:` prefix (treated as not-success)", () => {
+		const out = jsonl({
+			type: "response_item",
+			timestamp: TS,
+			payload: { type: "function_call_output", call_id: "c_nopfx", output: JSON.stringify(GH_CLI) },
+		});
+		const { results } = codexEnvelopeParser.parse([shellCall(GH_VIEW_CMD, "c_nopfx"), out], {}, ALL_ADAPTERS);
+		expect(results).toHaveLength(0);
+	});
+
+	it("holds the cursor before an in-flight shell gh request (output not yet written)", () => {
+		const lines = ["{}", shellCall(GH_VIEW_CMD, "c_inflight")];
+		const { results, lastLineNumberScanned } = codexEnvelopeParser.parse(lines, {}, ALL_ADAPTERS);
+		expect(results).toHaveLength(0);
+		// safeCursor pinned to the request's 0-based line index (1), not EOF (2).
+		expect(lastLineNumberScanned).toBe(1);
+	});
+
+	it("advances the cursor once the in-flight shell output lands on the next poll", () => {
+		const lines = ["{}", shellCall(GH_VIEW_CMD, "c_inflight"), shellOutput("c_inflight", GH_CLI, 0)];
+		const { results, lastLineNumberScanned } = codexEnvelopeParser.parse(lines, {}, ALL_ADAPTERS);
+		expect(results).toHaveLength(1);
+		expect(lastLineNumberScanned).toBe(3);
+	});
+
+	it("holds the cursor at the EARLIEST of multiple in-flight shell requests", () => {
+		const lines = ["{}", shellCall(GH_VIEW_CMD, "c1"), shellCall(GH_VIEW_CMD, "c2")];
+		const { lastLineNumberScanned } = codexEnvelopeParser.parse(lines, {}, ALL_ADAPTERS);
+		expect(lastLineNumberScanned).toBe(1); // pinned to c1's line, not lowered again by c2
+	});
+
+	it("ignores a shell call whose `arguments` is not a string", () => {
+		const badCall = jsonl({
+			type: "response_item",
+			timestamp: TS,
+			payload: { type: "function_call", name: "shell_command", arguments: 42, call_id: "c_numargs" },
+		});
+		const { results } = codexEnvelopeParser.parse([badCall, shellOutput("c_numargs", GH_CLI, 0)], {}, ALL_ADAPTERS);
+		expect(results).toHaveLength(0);
+	});
+});
+
+describe("CodexEnvelopeParser end-to-end — shell gh issue view (state lowercased, dedupe with MCP search)", () => {
+	let dir: string;
+	let file: string;
+	beforeAll(() => {
+		dir = mkdtempSync(join(tmpdir(), "codex-ghcli-"));
+		file = join(dir, "rollout.jsonl");
+		// The connector searched first (sparse hit), then ran gh to backfill — gh
+		// appears LATER, so it wins the same-mapKey dedupe in the realistic flow.
+		const lines = [
+			fnCall("mcp__codex_apps__github", "_search_issues", "c_search"),
+			fnOutput("c_search", GITHUB_SEARCH, { wrap: "bare", prefix: true }),
+			shellCall(GH_VIEW_CMD, "c_sh"),
+			shellOutput("c_sh", GH_CLI, 0),
+		];
+		writeFileSync(file, `${lines.join("\n")}\n`, "utf-8");
+	});
+	afterAll(() => rmSync(dir, { recursive: true, force: true }));
+
+	it("dedupes gh + MCP search to one rich ref with lowercased state", async () => {
+		const { references } = await extractReferencesFromTranscript(file, ALL_ADAPTERS, { source: "codex" });
+		const gh = references.filter((r) => r.mapKey === "github:jolliai/jolli#959");
+		expect(gh).toHaveLength(1);
+		expect(gh[0].fields?.find((f) => f.key === "status")?.value).toBe("closed");
+		expect(gh[0].fields?.some((f) => f.key === "labels")).toBe(true);
+	});
+});

--- a/cli/src/core/references/CodexEnvelopeParser.ts
+++ b/cli/src/core/references/CodexEnvelopeParser.ts
@@ -22,12 +22,22 @@
  * parser only correlates lines and delegates identity + normalisation to that
  * registry.
  *
- * Robustness: the `Wall time:` prefix is stripped only when present; every parse
- * is wrapped and a non-JSON output (e.g. `execution error: Io(...)`) is skipped.
+ * Shell CLI fallback: Codex also resolves entities via plain shell, e.g.
+ * `gh issue view <n> --json …` (a `function_call` named `shell_command`, no
+ * namespace, paired with a `function_call_output` whose body is prefixed
+ * `Exit code: N\nWall time: …\nOutput:\n`). The command string is matched against
+ * the agent-neutral `./bindings/cli` registry; a recognised, exit-0 result is
+ * normalised and emitted just like an MCP pair. Recognition + normalisation live
+ * in that registry, not here.
+ *
+ * Robustness: the `Wall time:`/`Exit code:` prefix is stripped only when present;
+ * every parse is wrapped and a non-JSON output (e.g. `execution error: Io(...)`)
+ * is skipped.
  */
 
 import { createLogger } from "../../Logger.js";
 import type { SourceId } from "../../Types.js";
+import { type CliBinding, matchCliCommand } from "./bindings/cli/index.js";
 import { codexBindingFromFunctionCall, codexBindingFromInvocationTool } from "./bindings/codex/index.js";
 import type { SourceAdapter } from "./sources/SourceAdapter.js";
 import type {
@@ -60,6 +70,12 @@ interface ToolCallEndRow {
 	readonly lineNumber: number;
 	readonly referencedAt: string;
 }
+interface ShellCallRow {
+	readonly binding: CliBinding;
+	/** 0-based line index of the request — holds the cursor before an in-flight
+	 *  (output-not-yet-written) shell call, exactly like an MCP fetch. */
+	readonly lineIndex: number;
+}
 
 class CodexEnvelopeParser implements TranscriptEnvelopeParser {
 	parse(lines: string[], opts: ExtractOptions, adapters: readonly SourceAdapter[]): EnvelopeParseResult {
@@ -67,6 +83,7 @@ class CodexEnvelopeParser implements TranscriptEnvelopeParser {
 		const adapterFor = (id: SourceId): SourceAdapter | undefined => adapters.find((a) => a.id === id);
 
 		const calls = new Map<string, FunctionCallRow>();
+		const shellCalls = new Map<string, ShellCallRow>();
 		const outputs = new Map<string, FunctionOutputRow>();
 		const events: ToolCallEndRow[] = [];
 		// call_ids whose result row (a function_call_output OR an mcp_tool_call_end)
@@ -92,7 +109,12 @@ class CodexEnvelopeParser implements TranscriptEnvelopeParser {
 			if (
 				!line.includes("mcp__codex_apps__") &&
 				!line.includes("mcp_tool_call_end") &&
-				!line.includes("function_call_output")
+				!line.includes("function_call_output") &&
+				// A `gh` shell request is a `function_call` with name `shell_command`
+				// and NO `mcp__codex_apps__` namespace — it would be dropped by the
+				// three needles above, losing the command string. Its paired output is
+				// a `function_call_output` (already covered).
+				!line.includes("shell_command")
 			) {
 				continue;
 			}
@@ -119,6 +141,18 @@ class CodexEnvelopeParser implements TranscriptEnvelopeParser {
 				case "function_call": {
 					const namespace = readString(payload.namespace);
 					const name = readString(payload.name);
+					// Shell CLI fallback (e.g. `gh issue view … --json`): a shell request
+					// is a `function_call` named `shell_command` with NO namespace. The
+					// command lives in the JSON-string `arguments`. Recognised commands
+					// go to a SEPARATE map (the namespace-keyed `calls` map can't hold them).
+					if (callId !== undefined && name === "shell_command") {
+						const command = readShellCommand(payload.arguments);
+						if (command !== undefined) {
+							const binding = matchCliCommand(command);
+							if (binding !== null) shellCalls.set(callId, { binding, lineIndex: i });
+						}
+						break;
+					}
 					if (callId !== undefined && namespace !== undefined && name !== undefined) {
 						calls.set(callId, { namespace, name, lineIndex: i });
 					}
@@ -175,6 +209,28 @@ class CodexEnvelopeParser implements TranscriptEnvelopeParser {
 				referencedAt: out.referencedAt,
 			});
 			emitted.add(callId);
+		}
+
+		// PRIMARY (CLI): shell_command + function_call_output pairs. Gated on
+		// `Exit code: 0` — a failed command whose stdout happens to be valid issue
+		// JSON must NOT be ingested. shell call_ids never overlap MCP ones and there
+		// is no mcp_tool_call_end fallback for shell, so no `emitted` tracking.
+		for (const [callId, shell] of shellCalls) {
+			const out = outputs.get(callId);
+			if (out === undefined) continue;
+			if (readExitCode(out.output) !== 0) continue;
+			const business = parseFunctionCallOutput(out.output);
+			if (business === null) continue;
+			const adapter = adapterFor(shell.binding.id);
+			/* v8 ignore next -- adapters always include all four sources; guarded for totality. */
+			if (adapter === undefined) continue;
+			results.push({
+				adapter,
+				toolName: shell.binding.canonicalToolName,
+				payload: shell.binding.normalize(business),
+				lineNumber: out.lineNumber,
+				referencedAt: out.referencedAt,
+			});
 		}
 
 		// FALLBACK: mcp_tool_call_end events for call_ids without a paired output.
@@ -241,6 +297,13 @@ class CodexEnvelopeParser implements TranscriptEnvelopeParser {
 			if (codexBindingFromFunctionCall(call.namespace, call.name) === null) continue;
 			if (call.lineIndex < safeCursor) safeCursor = call.lineIndex;
 		}
+		// Same hold for an in-flight shell CLI request (already a CLI match by
+		// construction): its function_call_output marks `resultSeen` when it lands,
+		// so an unanswered one pins the cursor on its request line.
+		for (const [callId, shell] of shellCalls) {
+			if (satisfied.has(callId)) continue;
+			if (shell.lineIndex < safeCursor) safeCursor = shell.lineIndex;
+		}
 		return { results, lastLineNumberScanned: safeCursor };
 	}
 }
@@ -262,13 +325,33 @@ export const codexEnvelopeParser: TranscriptEnvelopeParser = new CodexEnvelopePa
  */
 function parseFunctionCallOutput(output: string): unknown {
 	let text = output;
-	if (text.startsWith("Wall time:")) {
+	// MCP outputs are prefixed `Wall time: …\nOutput:\n`; shell outputs add a
+	// leading `Exit code: …\n` before it. Strip from either marker.
+	if (text.startsWith("Wall time:") || text.startsWith("Exit code:")) {
 		const idx = text.indexOf(OUTPUT_MARKER);
 		if (idx >= 0) text = text.slice(idx + OUTPUT_MARKER.length);
 	}
 	const parsed = tryParse(text);
 	if (parsed === null) return null;
 	return unwrapTextArray(parsed);
+}
+
+/** Parse the `command` field from a shell `function_call`'s JSON-string `arguments`. */
+function readShellCommand(args: unknown): string | undefined {
+	if (typeof args !== "string") return undefined;
+	const parsed = tryParse(args);
+	if (!isObject(parsed)) return undefined;
+	return readString(parsed.command);
+}
+
+/**
+ * Exit code from a shell `function_call_output`'s `Exit code: N\n…` prefix.
+ * Returns undefined when absent (format drift) — the caller treats that as
+ * "not 0" and skips, the conservative choice for a false-positive guard.
+ */
+function readExitCode(output: string): number | undefined {
+	const m = /^Exit code:\s*(-?\d+)/.exec(output);
+	return m ? Number(m[1]) : undefined;
 }
 
 /** Try JSON.parse; return null (not throw) on failure. */

--- a/cli/src/core/references/ReferenceExtractor.test.ts
+++ b/cli/src/core/references/ReferenceExtractor.test.ts
@@ -11,6 +11,7 @@ vi.mock("node:fs/promises", async (importOriginal) => {
 
 import type { Reference } from "../../Types.js";
 import { extractReferencesFromTranscript } from "./ReferenceExtractor.js";
+import { GitHubAdapter } from "./sources/GitHubAdapter.js";
 import { LinearAdapter } from "./sources/LinearAdapter.js";
 import type { SourceAdapter } from "./sources/SourceAdapter.js";
 
@@ -1112,5 +1113,140 @@ describe("formatReferencesBlock", () => {
 		expect(out).not.toContain("priority=");
 		expect(out).not.toContain("labels=");
 		expect(out).not.toContain("<description>");
+	});
+});
+
+// ─── Claude `Bash` gh issue view CLI fallback ────────────────────────────────
+
+/** Claude tool_use for the `Bash` tool: the command lives in `input.command`. */
+function bashUseLine(opts: { toolUseId: string; command: string; timestamp: string }): string {
+	return JSON.stringify({
+		message: {
+			role: "assistant",
+			content: [
+				{
+					type: "tool_use",
+					id: opts.toolUseId,
+					name: "Bash",
+					input: { command: opts.command, description: "x" },
+				},
+			],
+		},
+		timestamp: opts.timestamp,
+	});
+}
+
+/** Claude Bash tool_result: stdout is a PLAIN STRING (not a text-block array), with `is_error`. */
+function bashResultLine(opts: { toolUseId: string; stdout: string; timestamp: string; isError?: boolean }): string {
+	return JSON.stringify({
+		type: "user",
+		message: {
+			role: "user",
+			content: [
+				{
+					tool_use_id: opts.toolUseId,
+					type: "tool_result",
+					content: opts.stdout,
+					is_error: opts.isError ?? false,
+				},
+			],
+		},
+		timestamp: opts.timestamp,
+	});
+}
+
+const GH_CLI_STDOUT = JSON.stringify({
+	number: 959,
+	title: "Support multi-source external entity auto-discovery",
+	state: "CLOSED",
+	url: "https://github.com/jolliai/jolli/issues/959",
+	body: "Body text",
+	labels: [{ name: "enhancement" }],
+	assignees: [{ login: "sanshizhang-jolli" }],
+});
+const GH_VIEW_CMD = "gh issue view 959 --repo jolliai/jolli --json number,title,state,labels,assignees,body,url";
+
+describe("extractReferencesFromTranscript — Claude Bash gh issue view CLI fallback", () => {
+	it("extracts a github ref from a Bash `gh issue view --json` call (canonical toolName, lowercased state)", async () => {
+		const jsonl = makeJsonl(
+			bashUseLine({ toolUseId: "tu_gh", command: GH_VIEW_CMD, timestamp: "2026-06-09T10:00:00.000Z" }),
+			bashResultLine({ toolUseId: "tu_gh", stdout: GH_CLI_STDOUT, timestamp: "2026-06-09T10:00:01.000Z" }),
+		);
+		mockReadFile.mockResolvedValue(jsonl);
+
+		const { references } = await extractReferencesFromTranscript("/fake.jsonl", [GitHubAdapter]);
+		expect(references).toHaveLength(1);
+		expect(references[0]).toMatchObject({
+			mapKey: "github:jolliai/jolli#959",
+			url: "https://github.com/jolliai/jolli/issues/959",
+			toolName: "mcp__github__issue_read",
+		});
+		expect(fieldVal(references[0], "status")).toBe("closed");
+	});
+
+	it("drops a failed Bash gh command (is_error true) even when stdout is valid issue JSON", async () => {
+		const jsonl = makeJsonl(
+			bashUseLine({ toolUseId: "tu_err", command: GH_VIEW_CMD, timestamp: "2026-06-09T10:00:00.000Z" }),
+			bashResultLine({
+				toolUseId: "tu_err",
+				stdout: GH_CLI_STDOUT,
+				timestamp: "2026-06-09T10:00:01.000Z",
+				isError: true,
+			}),
+		);
+		mockReadFile.mockResolvedValue(jsonl);
+
+		const { references } = await extractReferencesFromTranscript("/fake.jsonl", [GitHubAdapter]);
+		expect(references).toHaveLength(0);
+	});
+
+	it("does not extract from a Bash command that is not gh issue view", async () => {
+		const jsonl = makeJsonl(
+			bashUseLine({ toolUseId: "tu_x", command: "npm test", timestamp: "2026-06-09T10:00:00.000Z" }),
+			bashResultLine({ toolUseId: "tu_x", stdout: GH_CLI_STDOUT, timestamp: "2026-06-09T10:00:01.000Z" }),
+		);
+		mockReadFile.mockResolvedValue(jsonl);
+
+		const { references } = await extractReferencesFromTranscript("/fake.jsonl", [GitHubAdapter]);
+		expect(references).toHaveLength(0);
+	});
+
+	it("byte-equivalence: an MCP github result with is_error true is STILL extracted (gate is CLI-only)", async () => {
+		// The is_error gate must NOT fire for MCP entries — an errored-but-valid MCP
+		// tool_result was ingested before this change and must still be. MCP github
+		// payloads are already in adapter shape (html_url, not the gh `url`).
+		const mcpPayload = JSON.stringify({
+			number: 959,
+			title: "Support multi-source external entity auto-discovery",
+			html_url: "https://github.com/jolliai/jolli/issues/959",
+		});
+		const jsonl = makeJsonl(
+			toolUseLine({
+				toolUseId: "tu_mcp",
+				toolName: "mcp__github__issue_read",
+				timestamp: "2026-06-09T10:00:00.000Z",
+				inputJson: '{"owner":"o","repo":"r","issue_number":959}',
+			}),
+			JSON.stringify({
+				type: "user",
+				message: {
+					role: "user",
+					content: [
+						{
+							tool_use_id: "tu_mcp",
+							type: "tool_result",
+							content: [{ type: "text", text: mcpPayload }],
+							is_error: true,
+						},
+					],
+				},
+				timestamp: "2026-06-09T10:00:01.000Z",
+			}),
+		);
+		mockReadFile.mockResolvedValue(jsonl);
+
+		const { references } = await extractReferencesFromTranscript("/fake.jsonl", [GitHubAdapter]);
+		expect(references).toHaveLength(1);
+		expect(references[0].mapKey).toBe("github:jolliai/jolli#959");
 	});
 });

--- a/cli/src/core/references/bindings/claude/index.test.ts
+++ b/cli/src/core/references/bindings/claude/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { CLAUDE_TOOL_PREFIXES, claudeBindingForToolName } from "./index.js";
+import { CLAUDE_SHELL_TOOL_NAMES, CLAUDE_TOOL_PREFIXES, claudeBindingForToolName, resolveClaudeTool } from "./index.js";
 
 describe("Claude producer binding", () => {
 	describe("claudeBindingForToolName — source recognition", () => {
@@ -54,6 +54,52 @@ describe("Claude producer binding", () => {
 				"mcp__linear__",
 				"mcp__claude_ai_Notion__",
 			]);
+		});
+	});
+
+	describe("resolveClaudeTool", () => {
+		it("resolves an MCP tool by name (kind mcp, toolName = real name, identity normalize)", () => {
+			const r = resolveClaudeTool("mcp__github__issue_read", undefined);
+			expect(r).toEqual({
+				sourceId: "github",
+				kind: "mcp",
+				toolName: "mcp__github__issue_read",
+				normalize: expect.any(Function),
+			});
+			const payload = { number: 1 };
+			expect(r?.normalize(payload)).toBe(payload); // identity for MCP
+		});
+
+		it("resolves a Bash `gh issue view --json` command to the github CLI binding (kind cli, canonical toolName)", () => {
+			const r = resolveClaudeTool("Bash", { command: "gh issue view 959 --repo o/r --json number,title" });
+			expect(r?.sourceId).toBe("github");
+			expect(r?.kind).toBe("cli");
+			expect(r?.toolName).toBe("mcp__github__issue_read");
+		});
+
+		it("returns null for Bash running a non-gh command", () => {
+			expect(resolveClaudeTool("Bash", { command: "npm test" })).toBeNull();
+		});
+
+		it("returns null for Bash with no command input", () => {
+			expect(resolveClaudeTool("Bash", {})).toBeNull();
+			expect(resolveClaudeTool("Bash", undefined)).toBeNull();
+			expect(resolveClaudeTool("Bash", { command: 42 })).toBeNull();
+		});
+
+		it("returns null for BashOutput (not a shell tool, no command)", () => {
+			expect(resolveClaudeTool("BashOutput", { bash_id: "x" })).toBeNull();
+		});
+
+		it("returns null for an unrecognised non-shell tool", () => {
+			expect(resolveClaudeTool("Read", { file_path: "/x" })).toBeNull();
+		});
+	});
+
+	describe("CLAUDE_SHELL_TOOL_NAMES", () => {
+		it("contains Bash and not BashOutput", () => {
+			expect(CLAUDE_SHELL_TOOL_NAMES.has("Bash")).toBe(true);
+			expect(CLAUDE_SHELL_TOOL_NAMES.has("BashOutput")).toBe(false);
 		});
 	});
 });

--- a/cli/src/core/references/bindings/claude/index.ts
+++ b/cli/src/core/references/bindings/claude/index.ts
@@ -14,10 +14,28 @@
  */
 
 import type { SourceId } from "../../../../Types.js";
+import { matchCliCommand } from "../cli/index.js";
 
 export interface ClaudeBinding {
 	readonly sourceId: SourceId;
 	normalize(business: unknown): unknown;
+}
+
+/**
+ * Tool whose `input.command` carries a shell command line. Claude runs CLI
+ * fallbacks (e.g. `gh issue view … --json`) through `Bash`; its stdout is fed to
+ * the agent-neutral CLI registry. `BashOutput` (the background-shell poller) is
+ * deliberately NOT here — it has no `command` input.
+ */
+export const CLAUDE_SHELL_TOOL_NAMES: ReadonlySet<string> = new Set(["Bash"]);
+
+export interface ClaudeResolved {
+	readonly sourceId: SourceId;
+	/** "cli" results require command success (the is_error gate); "mcp" keeps prior behaviour. */
+	readonly kind: "mcp" | "cli";
+	/** Persisted as `sourceToolName`: the real MCP tool name, or the CLI canonical name. */
+	readonly toolName: string;
+	readonly normalize: (business: unknown) => unknown;
 }
 
 interface Rule {
@@ -53,6 +71,33 @@ export function claudeBindingForToolName(name: string): ClaudeBinding | null {
 		// continuing) is safe. If an overlapping prefix is ever added, revisit this.
 		if (rule.accept !== undefined && !rule.accept(name)) return null;
 		return { sourceId: rule.sourceId, normalize: identity };
+	}
+	return null;
+}
+
+function readCommand(input: unknown): string | undefined {
+	if (typeof input !== "object" || input === null) return undefined;
+	const cmd = (input as { command?: unknown }).command;
+	return typeof cmd === "string" ? cmd : undefined;
+}
+
+/**
+ * Resolve a Claude tool_use to its reference source: an MCP tool by name prefix,
+ * OR a shell CLI by the command in its `input` (e.g. `Bash` running `gh issue
+ * view … --json`). Returns null if neither matches. The MCP branch is unchanged
+ * (`toolName` = the real name, `kind: "mcp"`), preserving byte-identical output.
+ */
+export function resolveClaudeTool(name: string, input: unknown): ClaudeResolved | null {
+	const mcp = claudeBindingForToolName(name);
+	if (mcp !== null) return { sourceId: mcp.sourceId, kind: "mcp", toolName: name, normalize: mcp.normalize };
+	if (CLAUDE_SHELL_TOOL_NAMES.has(name)) {
+		const command = readCommand(input);
+		if (command !== undefined) {
+			const cli = matchCliCommand(command);
+			if (cli !== null) {
+				return { sourceId: cli.id, kind: "cli", toolName: cli.canonicalToolName, normalize: cli.normalize };
+			}
+		}
 	}
 	return null;
 }

--- a/cli/src/core/references/bindings/cli/CliBinding.ts
+++ b/cli/src/core/references/bindings/cli/CliBinding.ts
@@ -1,0 +1,27 @@
+/**
+ * CliBinding — one declaration per shell-CLI command that yields a reference.
+ *
+ * This is the agent-neutral CLI **producer** binding, the third producer kind
+ * alongside `bindings/claude` (MCP tool name) and `bindings/codex` (MCP
+ * namespace+name). An LLM commonly falls back from a connector to a shell CLI
+ * (e.g. `gh issue view … --json`) when the MCP payload is incomplete; that
+ * output is invisible to the MCP path. Both the Claude (`Bash`) and Codex
+ * (`shell_command`) envelopes extract the command string and consult this
+ * registry — recognition lives here, the prefix/exit-code handling stays in each
+ * envelope (Codex's `Exit code:`/`Wall time:` vs Claude's bare stdout).
+ *
+ * The binding receives the already-parsed business JSON (envelope-stripped); it
+ * never touches the transcript shape.
+ */
+
+import type { SourceId } from "../../../../Types.js";
+
+export interface CliBinding {
+	readonly id: SourceId;
+	/** Recognise this CLI invocation from the command string alone (no output parse). */
+	matches(command: string): boolean;
+	/** Stable synthetic tool name persisted as `Reference.toolName`/`sourceToolName`. */
+	readonly canonicalToolName: string;
+	/** Normalize the already-parsed business JSON into the shape the adapter reads. */
+	normalize(business: unknown): unknown;
+}

--- a/cli/src/core/references/bindings/cli/GhIssueCliBinding.test.ts
+++ b/cli/src/core/references/bindings/cli/GhIssueCliBinding.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import { ghIssueCliBinding } from "./GhIssueCliBinding.js";
+
+const matches = (cmd: string) => ghIssueCliBinding.matches(cmd);
+const normalize = (b: unknown) => ghIssueCliBinding.normalize(b) as Record<string, unknown>;
+
+describe("ghIssueCliBinding", () => {
+	it("has the github identity + canonical tool name", () => {
+		expect(ghIssueCliBinding.id).toBe("github");
+		expect(ghIssueCliBinding.canonicalToolName).toBe("mcp__github__issue_read");
+	});
+
+	describe("matches — positives", () => {
+		it.each([
+			"gh issue view 959 --repo jolliai/jolli --json number,title",
+			"GH_TOKEN=x gh issue view 1 --json f",
+			"FOO=bar BAZ=qux gh issue view 1 --json f",
+			"cd /x && gh issue view 1 --json f",
+			"false || gh issue view 1 --json f",
+			"gh issue view 1 --json number | jq .",
+			"gh issue view 1 --json number 2>/dev/null",
+			"/usr/bin/gh issue view 1 --json f",
+			"gh.exe issue view 1 --json f",
+			"gh issue view --json f", // gh defaults to current-branch context; number not required
+			"cd /repo\ngh issue view 1 --json f", // gh on its own line after a prior statement
+			"# fetch the issue\ngh issue view 1 --json f", // comment line above the command
+			"gh --repo cli/cli issue view 1 --json title", // global --repo BEFORE subcommand (valid on gh 2.85.0)
+			"gh -R cli/cli issue view 1 --json title", // global -R BEFORE subcommand (valid on gh 2.85.0)
+		])("matches %j", (cmd) => {
+			expect(matches(cmd)).toBe(true);
+		});
+	});
+
+	describe("matches — negatives", () => {
+		it.each([
+			"gh pr view 1 --json", // different subcommand
+			"gh issue list --json", // not `view`
+			"gh issue viewer --json", // not exactly `view`
+			"gh issue view 1", // no --json
+			"gh issue view 1 --jsonfoo", // --json not a standalone flag
+			"gh issue --json view", // a flag splits the `issue view` pair (not consecutive)
+			'echo "gh issue view 1 --json"', // quoted mention, echo is the executable
+			"# gh issue view 1 --json", // whole line is a comment
+			"gh foo # gh issue view 1 --json", // the real gh is `gh foo`; the rest is a comment
+			"mygh issue view 1 --json", // executable is not gh
+			"github issue view 1 --json", // executable is not gh
+			"sudo gh issue view 1 --json", // gh not at command position (wrapper command)
+			"",
+		])("does not match %j", (cmd) => {
+			expect(matches(cmd)).toBe(false);
+		});
+	});
+
+	describe("normalize", () => {
+		it("reshapes a real `gh issue view --json` payload and lowercases state", () => {
+			const out = normalize({
+				number: 959,
+				title: "Support multi-source external entity auto-discovery",
+				state: "CLOSED",
+				url: "https://github.com/jolliai/jolli/issues/959",
+				body: "Body text",
+				labels: [{ name: "enhancement" }, { name: "JolliMemory" }],
+				assignees: [{ login: "sanshizhang-jolli" }],
+				author: { login: "sanshizhang-jolli" },
+			});
+			expect(out.number).toBe(959);
+			expect(out.html_url).toBe("https://github.com/jolliai/jolli/issues/959");
+			expect(out.state).toBe("closed"); // CLOSED → closed (gh-only normalization)
+			expect(out.labels).toEqual(["enhancement", "JolliMemory"]);
+			expect(out.assignees).toEqual(["sanshizhang-jolli"]);
+		});
+
+		it("leaves a non-string state untouched", () => {
+			const out = normalize({ number: 1, title: "t", url: "https://github.com/o/r/issues/1", state: null });
+			expect(out.state).toBeUndefined(); // reshape only copies string state
+		});
+
+		it("passes through a non-object business value", () => {
+			expect(ghIssueCliBinding.normalize(42)).toBe(42);
+		});
+	});
+});

--- a/cli/src/core/references/bindings/cli/GhIssueCliBinding.test.ts
+++ b/cli/src/core/references/bindings/cli/GhIssueCliBinding.test.ts
@@ -26,6 +26,10 @@ describe("ghIssueCliBinding", () => {
 			"# fetch the issue\ngh issue view 1 --json f", // comment line above the command
 			"gh --repo cli/cli issue view 1 --json title", // global --repo BEFORE subcommand (valid on gh 2.85.0)
 			"gh -R cli/cli issue view 1 --json title", // global -R BEFORE subcommand (valid on gh 2.85.0)
+			"gh issue view 1 --repo cli/cli --json=number,title", // --json=fields equals form (valid on gh 2.85.0)
+			"cd /repo; gh issue view 1 --json number", // `;` glued to the previous token
+			"cd /x&&gh issue view 1 --json f", // `&&` glued with no surrounding spaces
+			"cd C:\\repo; gh issue view 1 --json number", // PowerShell-style `;` separator
 		])("matches %j", (cmd) => {
 			expect(matches(cmd)).toBe(true);
 		});

--- a/cli/src/core/references/bindings/cli/GhIssueCliBinding.ts
+++ b/cli/src/core/references/bindings/cli/GhIssueCliBinding.ts
@@ -1,0 +1,83 @@
+/**
+ * GhIssueCliBinding — `gh issue view … --json` → GitHub issue reference.
+ *
+ * Recognition is a minimal tokenization (split on whitespace — good enough for
+ * gh invocations; perfect shell quote/escape handling is out of scope, the
+ * envelope's exit-code/is_error gate is the second line of defense). It requires
+ * a `gh`/`gh.exe` executable at a COMMAND POSITION (so `echo "gh issue view
+ * --json"`, a `#` comment, or a quoted mention don't match), the exact
+ * `issue view` subcommand, and a standalone `--json` flag (rejects `--jsonfoo`).
+ *
+ * Normalization reuses the shared `reshapeGitHubIssue` (gh's `--json` output maps
+ * onto it verbatim) plus a gh-only `state` lowercasing — gh emits `"CLOSED"`
+ * while the MCP path emits `"closed"`; lowercasing is confined here so the shared
+ * reshape (and the Codex MCP path that also uses it) stays byte-identical.
+ */
+
+import { reshapeGitHubIssue } from "../../sources/GitHubNormalize.js";
+import type { CliBinding } from "./CliBinding.js";
+
+/** Shell operators after which a `gh` token is a fresh command (the executable). */
+const COMMAND_BOUNDARIES = new Set(["&&", "||", "|", ";", "&", "(", "{"]);
+const ENV_ASSIGN = /^[A-Za-z_][A-Za-z0-9_]*=/;
+const GH_EXECUTABLE = /(^|[/\\])gh(\.exe)?$/i;
+
+function isObject(v: unknown): v is Record<string, unknown> {
+	return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+/** A `gh` token at index `i` is at a command position: line start, after a shell
+ *  operator, or preceded only by `VAR=val` env assignments. */
+function atCommandPosition(tokens: readonly string[], i: number): boolean {
+	let j = i - 1;
+	while (j >= 0 && ENV_ASSIGN.test(tokens[j])) j--;
+	return j < 0 || COMMAND_BOUNDARIES.has(tokens[j]);
+}
+
+function lineHasGhIssueView(line: string): boolean {
+	const all = line.split(/\s+/).filter((t) => t.length > 0);
+	// Drop a trailing `#` comment up front so neither the executable scan nor the
+	// `issue view` pair search reaches into commented-out text (e.g. the second
+	// `gh …` in `gh foo # gh issue view 1 --json`).
+	const hash = all.indexOf("#");
+	const tokens = hash === -1 ? all : all.slice(0, hash);
+	for (let i = 0; i < tokens.length; i++) {
+		if (!GH_EXECUTABLE.test(tokens[i]) || !atCommandPosition(tokens, i)) continue;
+		const rest = tokens.slice(i + 1);
+		// gh accepts global flags (e.g. `--repo o/r`, `-R o/r`) BEFORE the subcommand
+		// — verified on gh 2.85.0 — so require `issue view` as a CONSECUTIVE token
+		// pair anywhere in the args, not merely adjacent to `gh`. A standalone
+		// `--json` flag is still required.
+		//   - `gh issue --json view` is correctly missed (pair not consecutive).
+		//   - `gh --json issue view` matches here, but gh rejects it with a non-zero
+		//     exit (`unknown command "view"`), so the exit-code/is_error gate drops it.
+		const hasIssueViewPair = rest.some((t, k) => t === "issue" && rest[k + 1] === "view");
+		if (!hasIssueViewPair) continue;
+		if (rest.some((t) => t === "--json")) return true;
+	}
+	return false;
+}
+
+/**
+ * Match each newline-separated statement independently: a `gh …` on its own line
+ * is then at a command position (not glued to the previous statement's tail), and
+ * a `#` comment scopes to just its line.
+ */
+function matchesGhIssueView(command: string): boolean {
+	return command.split(/[\r\n]+/).some(lineHasGhIssueView);
+}
+
+/** Lowercase `state` only (gh "CLOSED" → "closed"); leave everything else as reshaped. */
+function lowercaseState(reshaped: unknown): unknown {
+	if (isObject(reshaped) && typeof reshaped.state === "string") {
+		return { ...reshaped, state: reshaped.state.toLowerCase() };
+	}
+	return reshaped;
+}
+
+export const ghIssueCliBinding: CliBinding = {
+	id: "github",
+	matches: matchesGhIssueView,
+	canonicalToolName: "mcp__github__issue_read",
+	normalize: (business) => lowercaseState(reshapeGitHubIssue(business)),
+};

--- a/cli/src/core/references/bindings/cli/GhIssueCliBinding.ts
+++ b/cli/src/core/references/bindings/cli/GhIssueCliBinding.ts
@@ -1,12 +1,14 @@
 /**
  * GhIssueCliBinding — `gh issue view … --json` → GitHub issue reference.
  *
- * Recognition is a minimal tokenization (split on whitespace — good enough for
- * gh invocations; perfect shell quote/escape handling is out of scope, the
- * envelope's exit-code/is_error gate is the second line of defense). It requires
- * a `gh`/`gh.exe` executable at a COMMAND POSITION (so `echo "gh issue view
- * --json"`, a `#` comment, or a quoted mention don't match), the exact
- * `issue view` subcommand, and a standalone `--json` flag (rejects `--jsonfoo`).
+ * Recognition is a minimal tokenization (pad shell metacharacters, then split on
+ * whitespace — good enough for gh invocations; perfect shell quote/escape handling
+ * is out of scope, the envelope's exit-code/is_error gate is the second line of
+ * defense). It requires a `gh`/`gh.exe` executable at a COMMAND POSITION (so
+ * `echo "gh issue view --json"`, a `#` comment, or a quoted mention don't match),
+ * the `issue view` subcommand as a consecutive token pair (tolerating global
+ * flags like `--repo o/r` before it), and a standalone `--json` / `--json=<fields>`
+ * flag (rejects `--jsonfoo`).
  *
  * Normalization reuses the shared `reshapeGitHubIssue` (gh's `--json` output maps
  * onto it verbatim) plus a gh-only `state` lowercasing — gh emits `"CLOSED"`
@@ -34,8 +36,19 @@ function atCommandPosition(tokens: readonly string[], i: number): boolean {
 	return j < 0 || COMMAND_BOUNDARIES.has(tokens[j]);
 }
 
+/** A standalone `--json` flag (`--json` or `--json=<fields>`); rejects `--jsonfoo`. */
+function isJsonFlag(token: string): boolean {
+	return token === "--json" || token.startsWith("--json=");
+}
+
 function lineHasGhIssueView(line: string): boolean {
-	const all = line.split(/\s+/).filter((t) => t.length > 0);
+	// Pad shell metacharacters so operators glued to a neighbour become their own
+	// tokens (e.g. `cd /repo; gh …` → `… /repo ; gh …`, `x&&gh` → `x & & gh`).
+	// Without this, atCommandPosition can't see the boundary before `gh`.
+	const all = line
+		.replace(/([;|&(){}])/g, " $1 ")
+		.split(/\s+/)
+		.filter((t) => t.length > 0);
 	// Drop a trailing `#` comment up front so neither the executable scan nor the
 	// `issue view` pair search reaches into commented-out text (e.g. the second
 	// `gh …` in `gh foo # gh issue view 1 --json`).
@@ -47,13 +60,13 @@ function lineHasGhIssueView(line: string): boolean {
 		// gh accepts global flags (e.g. `--repo o/r`, `-R o/r`) BEFORE the subcommand
 		// — verified on gh 2.85.0 — so require `issue view` as a CONSECUTIVE token
 		// pair anywhere in the args, not merely adjacent to `gh`. A standalone
-		// `--json` flag is still required.
+		// `--json` flag (`--json` or `--json=<fields>`) is still required.
 		//   - `gh issue --json view` is correctly missed (pair not consecutive).
 		//   - `gh --json issue view` matches here, but gh rejects it with a non-zero
 		//     exit (`unknown command "view"`), so the exit-code/is_error gate drops it.
 		const hasIssueViewPair = rest.some((t, k) => t === "issue" && rest[k + 1] === "view");
 		if (!hasIssueViewPair) continue;
-		if (rest.some((t) => t === "--json")) return true;
+		if (rest.some(isJsonFlag)) return true;
 	}
 	return false;
 }

--- a/cli/src/core/references/bindings/cli/index.test.ts
+++ b/cli/src/core/references/bindings/cli/index.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { matchCliCommand } from "./index.js";
+
+describe("matchCliCommand", () => {
+	it("resolves a gh issue view --json command to the github CLI binding", () => {
+		const binding = matchCliCommand("gh issue view 959 --repo o/r --json number,title");
+		expect(binding?.id).toBe("github");
+		expect(binding?.canonicalToolName).toBe("mcp__github__issue_read");
+	});
+
+	it("returns null for a non-matching command", () => {
+		expect(matchCliCommand("gh pr view 1 --json")).toBeNull();
+		expect(matchCliCommand("npm test")).toBeNull();
+	});
+
+	it("returns null for an empty command", () => {
+		expect(matchCliCommand("")).toBeNull();
+	});
+});

--- a/cli/src/core/references/bindings/cli/index.ts
+++ b/cli/src/core/references/bindings/cli/index.ts
@@ -1,0 +1,21 @@
+/**
+ * CLI producer binding registry — resolves a shell command string to its
+ * {@link CliBinding}, or null. Agent-neutral: both the Claude (`Bash`) and Codex
+ * (`shell_command`) envelopes feed their extracted command here. Adding a CLI
+ * source = one entry plus its binding file.
+ */
+
+import type { CliBinding } from "./CliBinding.js";
+import { ghIssueCliBinding } from "./GhIssueCliBinding.js";
+
+const CLI_BINDINGS: readonly CliBinding[] = [ghIssueCliBinding];
+
+/** First CLI binding whose `matches(command)` is true, or null. */
+export function matchCliCommand(command: string): CliBinding | null {
+	for (const binding of CLI_BINDINGS) {
+		if (binding.matches(command)) return binding;
+	}
+	return null;
+}
+
+export type { CliBinding } from "./CliBinding.js";

--- a/cli/src/install/DispatchScripts.test.ts
+++ b/cli/src/install/DispatchScripts.test.ts
@@ -34,6 +34,8 @@ describe("installHookScripts", () => {
 		const resolveDistPath = await readFile(join(globalDir, "resolve-dist-path"), "utf-8");
 		expect(resolveDistPath).toContain("#!/bin/bash");
 		expect(resolveDistPath).toContain("dist-paths");
+		// Tie-break pass: strict-greater selection + preference order baked in.
+		expect(resolveDistPath).toContain("for pref in cli vscode cursor");
 
 		const runHook = await readFile(join(globalDir, "run-hook"), "utf-8");
 		expect(runHook).toContain("HOOK_TYPE");

--- a/cli/src/install/DispatchScripts.ts
+++ b/cli/src/install/DispatchScripts.ts
@@ -14,6 +14,7 @@ import { chmod, mkdir, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { createLogger } from "../Logger.js";
+import { SOURCE_PREFERENCE_ORDER } from "./DistPathResolver.js";
 
 const log = createLogger("DispatchScripts");
 
@@ -46,8 +47,11 @@ const log = createLogger("DispatchScripts");
  */
 const RESOLVE_DIST_PATH_CONTENT = `#!/bin/bash
 # JolliMemory dist-path resolver.
-# Outputs the absolute path to the current winning dist directory (highest
-# version across all registered sources whose path exists).
+# Outputs the absolute path to the current winning dist directory: the highest
+# core version across all registered sources whose path exists. Ties (same core
+# version) are broken by a preference list (cli > vscode > cursor > …) because
+# the bundled @jolli.ai/cli core is identical at equal versions — the tie-break
+# only makes the winner deterministic and favours the canonical CLI build.
 #
 # Stable public API: run-hook, run-cli, legacy hooks still on disk, and
 # third-party tools all rely on this script's "output a path, exit 0/1"
@@ -57,13 +61,12 @@ DIR="$HOME/.jolli/jollimemory"
 BEST_PATH=""
 BEST_VER="0.0.0"
 
-# Version selection uses 'sort -V'. It agrees with the in-process compareSemver
-# (cli/src/install/DistPathResolver.ts) on every non-prerelease comparison.
-# Known divergence: sort -V ranks a prerelease (e.g. 1.0.0-rc.1) ABOVE its
-# release (1.0.0), whereas compareSemver follows semver and ranks it below.
-# Matching semver here would mean hand-rolling prerelease rules in POSIX sh;
-# the case (a release and its own prerelease both registered) is too rare to
-# justify the risk. compareSemver is the authority for in-process selection.
+# Pass 1 — highest core version wins. Selection uses 'sort -V', which agrees with
+# the in-process compareSemver (cli/src/install/DistPathResolver.ts) on every
+# non-prerelease comparison. The comparison is STRICT greater-than: an equal
+# version does NOT overwrite, so enumeration (alphabetical) order never decides a
+# tie. (Known sort -V divergence: it ranks 1.0.0-rc.1 ABOVE 1.0.0; compareSemver
+# follows semver and ranks it below. Too rare to hand-roll in POSIX sh.)
 if [ -d "$DIR/dist-paths" ]; then
   for f in "$DIR/dist-paths"/*; do
     [ -f "$f" ] || continue
@@ -75,10 +78,32 @@ if [ -d "$DIR/dist-paths" ]; then
       dev|unknown) VER_CMP="0.0.0" ;;
       *)           VER_CMP="$VER" ;;
     esac
-    if [ -z "$BEST_PATH" ] || \\
-       printf '%s\\n%s' "$BEST_VER" "$VER_CMP" | sort -V | tail -1 | grep -qx "$VER_CMP"; then
+    if [ -z "$BEST_PATH" ]; then
       BEST_PATH="$CANDIDATE"
       BEST_VER="$VER_CMP"
+    elif [ "$VER_CMP" != "$BEST_VER" ] && \\
+         printf '%s\\n%s' "$BEST_VER" "$VER_CMP" | sort -V | tail -1 | grep -qx "$VER_CMP"; then
+      BEST_PATH="$CANDIDATE"
+      BEST_VER="$VER_CMP"
+    fi
+  done
+fi
+
+# Pass 2 — among sources tied at BEST_VER, prefer the order below (kept in lockstep
+# with SOURCE_PREFERENCE_ORDER in DistPathResolver.ts). Only overrides when the
+# preferred source carries the same top version, so a strictly-higher non-preferred
+# source still wins.
+if [ -n "$BEST_PATH" ]; then
+  for pref in ${SOURCE_PREFERENCE_ORDER.join(" ")}; do
+    pf="$DIR/dist-paths/$pref"
+    [ -f "$pf" ] || continue
+    PVER=$(sed -n '1p' "$pf")
+    PPATH=$(sed -n '2p' "$pf")
+    [ -d "$PPATH" ] || continue
+    case "$PVER" in dev|unknown) PVER="0.0.0" ;; esac
+    if [ "$PVER" = "$BEST_VER" ]; then
+      BEST_PATH="$PPATH"
+      break
     fi
   done
 fi

--- a/cli/src/install/DistPathResolver.test.ts
+++ b/cli/src/install/DistPathResolver.test.ts
@@ -319,6 +319,38 @@ describe("DistPathResolver", () => {
 			]);
 			expect(best?.source).toBe("cli");
 		});
+
+		it("prefers cli on a version tie (even when iterated after another source)", () => {
+			const best = pickBestDistPath([
+				{ source: "vscode", version: "0.99.3", distDir: "/v", available: true },
+				{ source: "cli", version: "0.99.3", distDir: "/c", available: true },
+			]);
+			expect(best?.source).toBe("cli");
+		});
+
+		it("prefers vscode over cursor on a tie when cli is absent", () => {
+			const best = pickBestDistPath([
+				{ source: "cursor", version: "0.99.3", distDir: "/cur", available: true },
+				{ source: "vscode", version: "0.99.3", distDir: "/v", available: true },
+			]);
+			expect(best?.source).toBe("vscode");
+		});
+
+		it("does NOT let the tie-break override a strictly-higher non-preferred source", () => {
+			const best = pickBestDistPath([
+				{ source: "cli", version: "0.99.3", distDir: "/c", available: true },
+				{ source: "windsurf", version: "0.99.4", distDir: "/w", available: true },
+			]);
+			expect(best?.source).toBe("windsurf");
+		});
+
+		it("falls back to the first-seen highest when no preferred source is in the tie", () => {
+			const best = pickBestDistPath([
+				{ source: "windsurf", version: "0.99.3", distDir: "/w", available: true },
+				{ source: "antigravity", version: "0.99.3", distDir: "/a", available: true },
+			]);
+			expect(best?.source).toBe("windsurf"); // first-seen highest; order among non-preferred is undefined
+		});
 	});
 
 	// ── resolveDistPath (simplified shim) ────────────────────────────────

--- a/cli/src/install/DistPathResolver.ts
+++ b/cli/src/install/DistPathResolver.ts
@@ -221,7 +221,23 @@ export function compareSemver(a: string, b: string): number {
 }
 
 /**
- * Picks the best (highest version, available) entry from a dist-paths list.
+ * Tie-break preference when multiple sources carry the SAME highest core version.
+ * The bundled `@jolli.ai/cli` core is byte-for-byte the same logic at equal
+ * versions, so this list only makes the winner DETERMINISTIC and favours the
+ * canonical CLI build over an IDE-embedded copy. Sources not listed have no
+ * defined order among themselves (the first-seen highest is kept).
+ *
+ * MUST stay in lockstep with the `for pref in …` list baked into the
+ * `resolve-dist-path` shell script — DispatchScripts.ts imports this constant so
+ * there is a single source of truth.
+ */
+export const SOURCE_PREFERENCE_ORDER: ReadonlyArray<string> = ["cli", "vscode", "cursor"];
+
+/**
+ * Picks the best entry from a dist-paths list:
+ *   1. highest core version, **strict** greater-than (a tie never overwrites, so
+ *      enumeration order can't decide a tie), then
+ *   2. among sources tied at that version, the first in {@link SOURCE_PREFERENCE_ORDER}.
  * Returns undefined if the list is empty or no entries are available.
  */
 export function pickBestDistPath(entries: ReadonlyArray<DistPathInfo>): DistPathInfo | undefined {
@@ -232,6 +248,13 @@ export function pickBestDistPath(entries: ReadonlyArray<DistPathInfo>): DistPath
 		if (compareSemver(available[i].version, best.version) > 0) {
 			best = available[i];
 		}
+	}
+	// Tie-break: among the sources sharing the highest version, prefer cli > vscode
+	// > cursor. Falls through to the first-seen highest when none are preferred.
+	const tied = available.filter((e) => compareSemver(e.version, best.version) === 0);
+	for (const pref of SOURCE_PREFERENCE_ORDER) {
+		const match = tied.find((e) => e.source === pref);
+		if (match) return match;
 	}
 	return best;
 }


### PR DESCRIPTION
<!-- jollimemory-summary-start -->
## Commits in this PR (2)

1. Add CLI binding registry and gh issue view support for Claude/Codex (`c557be0`)
2. Add tie-break preference order to pickBestDistPath and resolve-dist-path (`7791a53`)


## Quick recap (2)

### Commit 1 of 2: Add CLI binding registry and gh issue view support for Claude/Codex (`c557be0`)

The reference extraction pipeline gained support for GitHub issues fetched via the `gh` command-line tool in a shell, covering both the Claude and Codex agents. Previously, when an agent ran `gh issue view` directly in a shell instead of going through the MCP connector, the resulting issue data was invisible to the system entirely. Now both agents' shell-based GitHub lookups are recognized, normalized, and deduplicated against any MCP-sourced data for the same issue.

A new agent-neutral registry sits between the two agent-specific parsers and the GitHub normalization layer. Both agents feed their extracted shell command into the same registry, which handles recognition and normalization once. The Codex path requires an explicit success exit code before ingesting any output; the Claude path requires the command to have completed without error. Either gate independently prevents a failed command whose output happens to look like valid issue data from being recorded as a reference.

Two correctness bugs in the command matcher were caught and fixed during an adversarial review pass. Commands that place global repository flags before the subcommand — a valid and common pattern on current versions of the `gh` tool — were previously dropped silently. A second bug allowed shell comments following a real command on the same line to be scanned for subcommand tokens, producing false matches. Both were corrected before the implementation was finalized.

### Commit 2 of 2: Add tie-break preference order to pickBestDistPath and resolve-dist-path (`7791a53`)

When multiple installed sources carried the same version of the core library, the selection winner was determined by alphabetical directory traversal order — a side effect of the comparison logic treating equal versions the same as newer ones. The standalone CLI installation was losing to IDE-embedded copies purely by accident of naming. The dist-path resolver now uses a strict greater-than comparison as its primary rule, so equal versions no longer overwrite the current best candidate. A second pass then applies an explicit preference order — standalone CLI first, then the VS Code extension, then Cursor — to pick deterministically among any sources that tied at the highest version. Sources outside the preference list retain a stable fallback: whichever was encountered first. The preference list is defined once in the TypeScript source and interpolated directly into the generated shell script, so the two runtimes are guaranteed to apply identical policy.

## Topics (3)
<details>
<summary><strong>01 · [c557be0] Agent-neutral CLI registry for shell-based GitHub issue discovery</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

When an AI agent runs `gh issue view` in a shell instead of using the MCP connector, the resulting GitHub issue data was invisible to the reference extraction pipeline. Both Claude and Codex agents needed to have this shell-based path recognized and normalized alongside the existing MCP path.

**💡 Decisions Behind the Code**

- **Separate CLI binding layer rather than extending existing MCP bindings**: Placing the new registry in `bindings/cli/` as a third producer kind (alongside `bindings/claude` and `bindings/codex`) keeps it agent-neutral — both envelopes feed the same `matchCliCommand` function without duplicating recognition logic. The alternative of embedding shell recognition directly in each envelope would have required maintaining two copies of the same matching rules and made future CLI sources harder to add.
- **State lowercasing confined to the gh binding, not the shared normalizer**: The shared `reshapeGitHubIssue` function is used by the Codex MCP path, which already receives lowercase state from the MCP connector. Modifying the shared function would have required re-verifying byte-equivalence across all existing MCP outputs. Isolating the lowercasing to the gh-specific binding means the shared code and all its existing test snapshots are untouched.
- **CLI-only `is_error` gate via a `requireSuccess` flag rather than a blanket check**: Applying the error gate unconditionally to all tool results in the Claude envelope would have changed behavior for MCP entries — an errored-but-valid MCP result that was previously ingested would silently stop being ingested. The `requireSuccess` flag scopes the gate exclusively to CLI entries, preserving the prior MCP behavior as a hard guarantee rather than an assumption.

**✅ What Was Implemented**

- Created `cli/src/core/references/bindings/cli/` as a new agent-neutral producer binding layer with three files: `CliBinding.ts` (interface), `GhIssueCliBinding.ts` (matcher + normalizer), and `index.ts` (`matchCliCommand` entry point). The matcher uses line-by-line tokenization to identify `gh`/`gh.exe` at a command position, a consecutive `issue view` subcommand pair anywhere in the arguments (tolerating global flags like `--repo`/`-R` before the subcommand), and a standalone `--json` flag. Normalization reuses the shared `reshapeGitHubIssue` function and adds a gh-only `state` lowercasing pass (`"CLOSED"` → `"closed"`).
- Wired the Codex envelope (`CodexEnvelopeParser.ts`) to recognize `shell_command` function calls, extract the command from the JSON-string `arguments` field, match it against the CLI registry, and emit a reference only when the paired output carries `Exit code: 0`. A separate `shellCalls` map tracks in-flight shell requests and extends the existing cursor-hold logic so unresolved shell calls pin the scan cursor exactly like unresolved MCP calls.
- Wired the Claude envelope (`ClaudeEnvelopeParser.ts` and `bindings/claude/index.ts`) by adding a `resolveClaudeTool` function that first checks MCP tool-name prefixes (unchanged path) and then, for `Bash` tool uses, reads `input.command` and consults the CLI registry. A `requireSuccess` flag on each pending entry gates the `is_error` check to CLI entries only, leaving MCP result handling byte-identical to before.

**📋 Future Enhancements**

- Dedupe strategy currently uses latest-timestamp wins, not richest-data wins. If a sparse MCP reference appears after a rich shell reference for the same issue, the sparse one overwrites the rich one. A separate change to implement information-richness-aware deduplication was explicitly deferred and needs its own work item with reverse-order fixture tests.
- The matcher does not handle `sudo gh …`, `time gh …`, or command-substitution forms like `$(gh …)`. These are fail-safe omissions (they produce missed references, never false positives), but could be addressed in a follow-up if agents are observed using those patterns.

**📁 FILES**
- `cli/src/core/references/bindings/cli/GhIssueCliBinding.ts`
- `cli/src/core/references/bindings/cli/index.ts`
- `cli/src/core/references/CodexEnvelopeParser.ts`
- `cli/src/core/references/ClaudeEnvelopeParser.ts`
- `cli/src/core/references/bindings/claude/index.ts`

</blockquote>
</details>
<details>
<summary><strong>02 · [c557be0] Adversarial review cycle caught and fixed two matcher correctness bugs</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

After the initial implementation, three independent review agents were run to find bugs. Two correctness issues were found in the command matcher: one caused valid commands with global flags to be missed, and another caused the comment-truncation logic to leak across the pair-search boundary.

**💡 Decisions Behind the Code**

The line-by-line matching approach (splitting the command on newlines and processing each line independently) was retained rather than switching to a full shell tokenizer. This keeps the matcher simple and auditable while the exit-code and `is_error` gates serve as a second line of defense against any edge cases the tokenizer misses. A full shell parser would handle quoted strings and escape sequences correctly but would add significant complexity for a marginal gain given the double-gate safety net.

**✅ What Was Implemented**

- The original matcher required `issue view` to appear as the first two tokens immediately after `gh`, which caused commands like `gh --repo owner/repo issue view 1 --json` to be silently dropped. The fix changed the pair search to scan for `issue view` as a consecutive token pair anywhere in the argument list, verified against gh 2.85.0 locally.
- A separate bug caused `gh foo # gh issue view 1 --json` to incorrectly match: the `#` comment truncation was applied to the executable scan but the `issue view` pair search still scanned past the `#` token into the comment. The fix moves comment truncation to a single up-front slice before both the executable scan and the pair search run.

**📁 FILES**
- `cli/src/core/references/bindings/cli/GhIssueCliBinding.ts`

</blockquote>
</details>
<details>
<summary><strong>03 · [7791a53] Deterministic dist-path winner with preference order for tied versions</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

A user reported that when two installed sources carried the same version of the core library, the wrong one was winning. The selection was decided by alphabetical directory order, causing the IDE-embedded copy to beat the standalone command-line installation. The user wanted the standalone CLI to be preferred in ties, and asked for a configurable preference list rather than a hard-coded single winner.

**💡 Decisions Behind the Code**

- **Single source of truth for the preference list**: The shell script imports `SOURCE_PREFERENCE_ORDER` from the TypeScript module at code-generation time rather than duplicating the list as a string literal. This prevents the two implementations from drifting silently — any future change to the order only needs to happen in one place, and the generated shell content is verified by a test assertion.
- **Preference list over a single hard-coded winner**: The user explicitly asked for an ordered list (`cli > vscode > cursor`, rest undefined) rather than a binary "prefer CLI" flag. This design accommodates future sources without requiring a policy decision about every possible pairing, and sources outside the list retain deterministic behavior (first-seen highest) without needing an explicit rank.
- **Strict greater-than as the primary fix, preference list as secondary**: Changing the comparison from "greater-than-or-equal" to "strict greater-than" in pass 1 is what actually removes alphabetical-order influence on ties. The preference list in pass 2 then adds a positive, intentional policy on top. Keeping them as two separate passes makes each concern independently readable and testable.

**✅ What Was Implemented**

- `DistPathResolver.ts` gained a new exported constant `SOURCE_PREFERENCE_ORDER` (`["cli", "vscode", "cursor"]`) and `pickBestDistPath` was updated with a two-pass algorithm: pass 1 uses strict greater-than comparison so an equal version never overwrites the current best (eliminating alphabetical-order influence on ties), and pass 2 scans the tied-at-highest-version entries against the preference list, returning the first match or falling back to the first-seen highest if no preferred source is present.
- `DispatchScripts.ts` rewrote the `resolve-dist-path` shell script with the same two-pass structure. Pass 1 now uses a strict inequality guard (`VER_CMP != BEST_VER` before the `sort -V` check) so equal versions are skipped. Pass 2 iterates `for pref in cli vscode cursor` — the list is interpolated directly from `SOURCE_PREFERENCE_ORDER` at build time, making the shell script and the TypeScript logic share a single source of truth.
- Four new unit tests cover the tie-break cases: CLI wins a tie even when iterated after vscode; vscode beats cursor when CLI is absent; a strictly-higher non-preferred source still wins; and non-listed sources fall back to first-seen order.

**📁 FILES**
- `cli/src/install/DistPathResolver.ts`
- `cli/src/install/DispatchScripts.ts`

</blockquote>
</details>

---

*Generated by Jolli Memory · June 10, 2026 at 4:24 PM*
<!-- jollimemory-summary-end -->