### PR TITLE
Add explicit QueueWorker entry to CLI build and guard worker spawn

### DIFF
--- a/cli/src/hooks/PostCommitHook.test.ts
+++ b/cli/src/hooks/PostCommitHook.test.ts
@@ -2196,6 +2196,10 @@ describe("queue-driven Worker", () => {
 				date: "2026-02-19",
 			});
 			vi.mocked(generateSummary).mockResolvedValue(createMockResult());
+			// launchWorker refuses to spawn when the worker bundle is missing;
+			// satisfy its existence probe (and only that one) so the chain
+			// spawn goes through.
+			vi.mocked(existsSync).mockImplementation((path) => String(path).endsWith("QueueWorker.js"));
 
 			await runWorker("/test/project");
 

--- a/cli/src/hooks/QueueWorker.bundle.test.ts
+++ b/cli/src/hooks/QueueWorker.bundle.test.ts
@@ -1,0 +1,84 @@
+/// <reference types="node" />
+/**
+ * Build contract guard for `dist/QueueWorker.js` (regression for 0.99.2).
+ *
+ * {@link QueueWorker.ts launchWorker} locates the worker by file name at
+ * runtime (`node <dist>/QueueWorker.js --worker`), and the installed
+ * `run-hook` script execs every git/agent hook bundle the same way
+ * (`node $DIST/<Name>.js`). Each of those file names is therefore a contract
+ * the build must keep via an explicit vite entry.
+ *
+ * QueueWorker had no entry of its own until 0.99.3: its code rode along in
+ * whatever shared chunk rollup picked, which happened to be named
+ * `QueueWorker.js` in every release up to 0.99.1. A circular import between
+ * SyncBootstrap and QueueWorker then moved the code into the SyncBootstrap
+ * chunk, and 0.99.2 shipped with no `dist/QueueWorker.js` at all — the
+ * detached worker died on MODULE_NOT_FOUND with stdio ignored, and pure-CLI
+ * installs silently stopped generating summaries.
+ *
+ * vite.config.ts lives outside the tsc rootDir, so the entry list is
+ * asserted on the config text rather than by importing it (same approach as
+ * vscode/src/BuildEntryContract.test.ts). The dist-level checks are skipped
+ * automatically when `dist/` is absent (e.g. during `vitest --watch` before
+ * a build has run), but fail loudly when a build exists and the worker
+ * bundle is missing or hollow.
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+/** Bundles referenced by file name at runtime (run-hook + launchWorker). */
+const RUNTIME_NAMED_BUNDLES = [
+	"StopHook",
+	"PostCommitHook",
+	"PostRewriteHook",
+	"PrepareMsgHook",
+	"GeminiAfterAgentHook",
+	"SessionStartHook",
+	"PostMergeHook",
+	"QueueWorker",
+];
+
+// Test file is at cli/src/hooks/; the vite config and dist are at cli/.
+const cliRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const viteConfigText = readFileSync(resolve(cliRoot, "vite.config.ts"), "utf-8");
+
+// `Cli.js` doubles as the "a build has run" probe — if it exists,
+// QueueWorker.js must too.
+const distDir = resolve(cliRoot, "dist");
+const distBuilt = existsSync(resolve(distDir, "Cli.js"));
+
+describe("vite entry contract for runtime-named bundles", () => {
+	for (const name of RUNTIME_NAMED_BUNDLES) {
+		it(`keeps the ${name} entry`, () => {
+			expect(viteConfigText).toMatch(
+				new RegExp(`${name}:\\s*resolve\\(__dirname,\\s*"src/hooks/${name}\\.ts"\\)`, "u"),
+			);
+		});
+	}
+});
+
+describe("dist artifacts for runtime-named bundles", () => {
+	// The text assertions above can be satisfied by a commented-out entry
+	// line; this is the artifact-level backstop. Covers every bundle that
+	// run-hook or launchWorker references by file name, not just QueueWorker.
+	for (const name of RUNTIME_NAMED_BUNDLES) {
+		it.skipIf(!distBuilt)(`dist contains ${name}.js`, () => {
+			expect(existsSync(resolve(distDir, `${name}.js`))).toBe(true);
+		});
+	}
+});
+
+describe("QueueWorker.js bundle", () => {
+	it.skipIf(!distBuilt)("contains the worker main, not a re-export facade", () => {
+		// If rollup ever emits the entry as a thin facade (real code left in a
+		// shared chunk), the file would exist but the direct-run check inside
+		// it would never fire. The startup banner string and the --worker argv
+		// flag both live in the worker main and survive minification.
+		const content = readFileSync(resolve(distDir, "QueueWorker.js"), "utf-8");
+		expect(content).toContain("--worker");
+		expect(content).toContain("Queue worker started");
+	});
+});

--- a/cli/src/hooks/QueueWorker.test.ts
+++ b/cli/src/hooks/QueueWorker.test.ts
@@ -508,6 +508,10 @@ describe("QueueWorker", () => {
 			// `launchWorker` invoked.
 			vi.mocked(consumePendingWorkers).mockResolvedValueOnce(["/test/cwd", "/other/cwd"]);
 			vi.mocked(dequeueAllGitOperations).mockResolvedValueOnce([]).mockResolvedValueOnce([]);
+			// launchWorker refuses to spawn when the worker bundle is missing;
+			// satisfy its existence probe (and only that one) so the wake-up
+			// spawn for /other/cwd goes through.
+			vi.mocked(existsSync).mockImplementation((path) => String(path).endsWith("QueueWorker.js"));
 
 			await runWorker("/test/cwd");
 
@@ -2106,6 +2110,7 @@ describe("QueueWorker", () => {
 	describe("launchWorker — argv hygiene (regression for old-Node startup crash)", () => {
 		it("spawns node with NO flags before scriptPath (no --disable-warning*)", () => {
 			vi.mocked(spawn).mockClear();
+			vi.mocked(existsSync).mockReturnValue(true);
 
 			launchWorker("/test/cwd");
 
@@ -2124,6 +2129,34 @@ describe("QueueWorker", () => {
 
 			// The legitimate script args are still present and ordered.
 			expect(args.slice(scriptIdx + 1)).toEqual(["--worker", "--cwd", "/test/cwd"]);
+		});
+	});
+
+	describe("launchWorker — missing worker script guard (regression for 0.99.2 silent spawn crash)", () => {
+		// 0.99.2 shipped a CLI dist without QueueWorker.js (rollup folded it
+		// into the SyncBootstrap chunk after a circular import appeared), and
+		// the detached child died on MODULE_NOT_FOUND with stdio ignored —
+		// zero log lines, summaries silently never generated. The guard must
+		// refuse to spawn and leave an ERROR trace instead.
+		it("does not spawn when QueueWorker.js is absent next to the running bundle", () => {
+			vi.mocked(spawn).mockClear();
+			vi.mocked(existsSync).mockReturnValue(false);
+
+			launchWorker("/test/cwd");
+
+			expect(spawn).not.toHaveBeenCalled();
+			// The guard must have probed for the worker script by its contract name.
+			const probed = vi.mocked(existsSync).mock.calls.map((c) => String(c[0]));
+			expect(probed.some((p) => p.endsWith("QueueWorker.js"))).toBe(true);
+		});
+
+		it("spawns normally when QueueWorker.js exists", () => {
+			vi.mocked(spawn).mockClear();
+			vi.mocked(existsSync).mockReturnValue(true);
+
+			launchWorker("/test/cwd");
+
+			expect(spawn).toHaveBeenCalledTimes(1);
 		});
 	});
 

--- a/cli/src/hooks/QueueWorker.ts
+++ b/cli/src/hooks/QueueWorker.ts
@@ -213,6 +213,22 @@ export function launchWorker(cwd: string): void {
 	const dir = dirname(fileURLToPath(import.meta.url));
 	const scriptPath = join(dir, "QueueWorker.js");
 
+	// Locating the worker by file name makes "dist contains QueueWorker.js"
+	// a build contract — kept by the QueueWorker entry in cli/vite.config.ts
+	// and vscode/esbuild.config.mjs. Without an explicit entry the file's
+	// existence depends on rollup's chunk naming, and 0.99.2 shipped without
+	// it: the detached child died on MODULE_NOT_FOUND with stdio ignored and
+	// no summaries were generated. This guard is the only place that can
+	// leave a trace of that failure mode.
+	if (!existsSync(scriptPath)) {
+		log.error(
+			"Worker script not found: %s — skipping spawn; summaries will NOT be generated. " +
+				"This dist was built without a QueueWorker entry.",
+			scriptPath,
+		);
+		return;
+	}
+
 	// NO Node flags before scriptPath. The git hook is launched as a bare
 	// `exec node <Hook>.js` (no flags), so `process.execPath` here may be a
 	// Node older than the CLI's `engines` floor. A flag the running Node

--- a/cli/src/hooks/StopHook.test.ts
+++ b/cli/src/hooks/StopHook.test.ts
@@ -1171,7 +1171,7 @@ describe("StopHook — plan discovery", () => {
 
 		const saved = vi.mocked(savePlansRegistry).mock.calls[0]?.[0];
 		// `foo` must stay deleted — not revived from our local snapshot.
-		expect(saved?.plans["foo"]).toBeUndefined();
+		expect(saved?.plans.foo).toBeUndefined();
 		expect(Object.keys(saved?.plans ?? {})).toHaveLength(0);
 	});
 

--- a/cli/vite.config.ts
+++ b/cli/vite.config.ts
@@ -23,6 +23,7 @@ export default defineConfig({
 				GeminiAfterAgentHook: resolve(__dirname, "src/hooks/GeminiAfterAgentHook.ts"),
 				SessionStartHook: resolve(__dirname, "src/hooks/SessionStartHook.ts"),
 				PostMergeHook: resolve(__dirname, "src/hooks/PostMergeHook.ts"),
+				QueueWorker: resolve(__dirname, "src/hooks/QueueWorker.ts"),
 			},
 			formats: ["es"],
 		},

--- a/vscode/src/BuildEntryContract.test.ts
+++ b/vscode/src/BuildEntryContract.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Build contract guard for the bundled hook scripts (vscode side of the
+ * 0.99.2 QueueWorker.js regression — see the matching guard in
+ * cli/src/hooks/QueueWorker.bundle.test.ts).
+ *
+ * The installed run-hook script execs every hook bundle by file name
+ * (`node $DIST/<Name>.js`), and launchWorker spawns `<dist>/QueueWorker.js`
+ * the same way. esbuild.config.mjs runs a build at import time, so instead
+ * of importing it this test asserts on its text: every runtime-named bundle
+ * must keep an explicit `out:` entry.
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const RUNTIME_NAMED_BUNDLES = [
+	"StopHook",
+	"PostCommitHook",
+	"PostRewriteHook",
+	"PrepareMsgHook",
+	"GeminiAfterAgentHook",
+	"SessionStartHook",
+	"PostMergeHook",
+	"QueueWorker",
+];
+
+const vscodeRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const configText = readFileSync(resolve(vscodeRoot, "esbuild.config.mjs"), "utf-8");
+
+// `Extension.js` doubles as the "a build has run" probe — if it exists,
+// every runtime-named bundle must too.
+const distDir = resolve(vscodeRoot, "dist");
+const distBuilt = existsSync(resolve(distDir, "Extension.js"));
+
+describe("esbuild entry contract for runtime-named bundles", () => {
+	for (const name of RUNTIME_NAMED_BUNDLES) {
+		it(`keeps the ${name} entry`, () => {
+			expect(configText).toMatch(new RegExp(`out:\\s*"${name}"`, "u"));
+		});
+	}
+});
+
+describe("dist artifacts for runtime-named bundles", () => {
+	// The text assertions above can be satisfied by a commented-out entry
+	// line; this is the artifact-level backstop.
+	for (const name of RUNTIME_NAMED_BUNDLES) {
+		it.skipIf(!distBuilt)(`dist contains ${name}.js`, () => {
+			expect(existsSync(resolve(distDir, `${name}.js`))).toBe(true);
+		});
+	}
+});


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## Quick recap

A long-standing gap in the CLI's build configuration caused the background process that generates commit summaries to silently crash on every commit for users who installed the CLI without the VS Code extension. The process launched successfully and received a valid process ID, but died immediately on a missing-file error with all output suppressed — leaving no log trace and no summaries, with queued tasks accumulating indefinitely. The bug had been present since the first public release but was masked by a coincidence in how the bundler named its output files; an unrelated sync-engine improvement in the 0.99.2 release cycle broke that coincidence, and a separate change to tie-breaking logic in the same release window was the first thing to route an extension-equipped machine down the same broken path, finally making the failure visible.

The fix adds the worker script as an explicit declared output in the CLI build configuration, so its presence is guaranteed regardless of how the bundler reorganizes shared code in the future. A pre-launch existence check was also added so that if the file ever goes missing again, a clear error message appears in the debug log rather than a silent process death. Two new test files — one for the CLI build and one for the VS Code extension build — assert that every script referenced by name at runtime has a corresponding explicit entry in its respective build configuration, turning what was previously an invisible assumption into a failure CI will catch before any release.

---

## Topics (3)
<details>
<summary><strong>01 · Fix missing worker script in CLI build causing silent summary failures</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

After an amend operation, a commit's summary disappeared from the sidebar. Investigation revealed that the background process responsible for generating summaries was silently crashing on launch with no log output, leaving queued tasks unprocessed. The root cause traced back to the CLI's published package missing a required file entirely.

**💡 Decisions Behind the Code**

- **Explicit build entry over relying on bundler behavior**: The bundler's automatic shared-chunk naming had worked by coincidence across four releases — the file happened to be named correctly each time. A circular import introduced by an unrelated sync-engine feature broke that coincidence in 0.99.2. Making the entry explicit converts an invisible assumption into a declared contract that survives future refactors, at the cost of a slightly larger build output.
- **Pre-spawn existence check over post-crash detection**: The background process runs fully detached with all output channels closed, which is the correct design for not blocking git operations. The trade-off is that any crash inside the process is unobservable from the outside. A file-existence check before launch is the only point where a failure can be logged, and it costs nothing at runtime when the file is present.

**✅ What Was Implemented**

- Added `QueueWorker` as an explicit entry in `cli/vite.config.ts`. Previously the worker's code was folded into a shared file named after a different module by the bundler's automatic chunk-naming logic; the new entry guarantees a standalone `dist/QueueWorker.js` is always produced regardless of how module relationships evolve.
- Added a file-existence check in the `launchWorker` function in `cli/src/hooks/QueueWorker.ts` before spawning the background process. When the worker script is absent, an ERROR-level log line is written and the spawn is skipped, replacing the previous behavior of silently launching a process that immediately crashed with all output suppressed.

**📁 FILES**
- `cli/vite.config.ts`
- `cli/src/hooks/QueueWorker.ts`

</blockquote>
</details>
<details>
<summary><strong>02 · Add build contract tests to prevent worker script from going missing again</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The 0.99.2 regression passed all existing tests because no test verified that the built output actually contained the files referenced by name at runtime. The team needed a way for CI to catch this class of breakage automatically.

**💡 Decisions Behind the Code**

- **Assert on config file text rather than importing the config**: Both build configuration files execute side effects or use module formats incompatible with the test runner when imported directly. Reading them as text and matching against expected patterns avoids that problem and keeps the tests fast and dependency-free, at the cost of slightly more fragile string matching.
- **Skip dist-level checks when no build exists**: Developers running tests before building locally would otherwise see spurious failures. The tests detect whether a build is present and skip the file-system assertions automatically, so the contract is enforced in CI (where a build always precedes tests) without breaking the local watch workflow.

**✅ What Was Implemented**

- Created `cli/src/hooks/QueueWorker.bundle.test.ts`, which asserts that every hook bundle referenced by name at runtime appears as an explicit entry in the CLI build configuration. When a built output directory is present, it additionally checks that `dist/QueueWorker.js` exists and contains the worker's startup code rather than a thin forwarding stub — guarding against a subtler variant where the file exists but contains no real logic.
- Created `vscode/src/BuildEntryContract.test.ts` applying the same entry-list assertions to the VS Code extension's build configuration, ensuring both packaging systems are covered by the same contract.

**📁 FILES**
- `cli/src/hooks/QueueWorker.bundle.test.ts`
- `vscode/src/BuildEntryContract.test.ts`

</blockquote>
</details>
<details>
<summary><strong>03 · Write incident retrospective document for the missing worker script bug</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The team wanted a written record of how the 0.99.2 summary-generation failure was discovered, what caused it, and what the impact was — written for colleagues rather than as an execution plan, and in plain language without build-tooling jargon.

**💡 Decisions Behind the Code**

The document was written as a retrospective for colleagues rather than a how-to or execution plan, so it omits code implementation details and instead links to relevant source locations. This keeps it readable for team members who were not involved in the investigation without requiring them to follow code.

**✅ What Was Implemented**

Created a new document in the `docs/` directory covering: background concepts needed to follow the analysis, the discovery timeline from debug logs, the three-layer root cause (a tie-breaking rule change that exposed the bug, the missing build entry, and the suppressed crash output), the full impact assessment including verification against the published npm package, and lessons learned. The document went through several revision passes to replace shorthand terms with plain-language explanations and to add public URLs colleagues can use to independently verify the published package's missing file.

**📁 FILES**
- `docs/2026-06-10-CLI 构建产物缺少 QueueWorker.js，导致 commit 摘要静默丢失（打包入口清单缺口 + 报错被吞）.md`

</blockquote>
</details>

---

*Generated by Jolli Memory · June 10, 2026 at 10:14 PM · via Anthropic*
<!-- jollimemory-summary-end -->