### PR TITLE
Fix hook routing, LLM proxy, and squash filtering for IntelliJ plugin

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,10 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Ignored default folder with query files
+/queries/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/jollimemory.iml
+++ b/.idea/jollimemory.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectRootManager" version="2">
+    <output url="file://$PROJECT_DIR$/out" />
+  </component>
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/jollimemory.iml" filepath="$PROJECT_DIR$/.idea/jollimemory.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/README.md
+++ b/README.md
@@ -1,14 +1,22 @@
 # Jolli Memory
 
+<!-- Seventh test comment -->
+<!-- Sixth test comment -->
+<!-- Fifth test comment -->
+
 > *Every commit deserves a Memory. Every memory deserves a Recall.*
 
 **Jolli Memory** automatically turns your AI coding sessions into structured development documentation attached to every commit, without any extra effort.
-
-When you work with AI agents like Claude Code, Codex, or Gemini CLI, the reasoning behind every decision lives in the conversation — *why this approach was chosen, what alternatives were considered, what problems came up along the way*. The moment you commit, that context is gone. Jolli Memory captures it automatically.
-
+hello there
+When you work with AI agents like Claude Code, Codex, or Gemini CLI, the reasoning behind every decision lives in the conversation — *why this approach was chosen, what alternatives were considered, what problems came up along the way*. The moment you commit, that context is gone. Jolli Memory captures it automatically. 
+hello there hello there hello therea sdfa sdf asdfasdf  asdfasdf
+as dfasdf asdfasdf
 ---
+whats poppin boy
 
 ## This Repository
+
+<!-- Fourth test comment -->a sfasdf
 
 This repo contains the **Jolli Memory IntelliJ plugin** — a pure-Kotlin implementation for JetBrains IDEs.
 
@@ -18,11 +26,42 @@ This repo contains the **Jolli Memory IntelliJ plugin** — a pure-Kotlin implem
 
 ## Quick Links
 
+<!-- Test comment number 3 -->
+
 - [Features](intellij/README.md#features) — AI Commit, Squash, Summary Viewer, Plans & Notes, Push to Jolli Space, PR management
 - [Installation](intellij/README.md#prerequisites) — IntelliJ IDEA 2024.3+, JDK 21+
 - [Configuration](intellij/README.md#configuration) — Anthropic API key, model selection
 - [Changelog](intellij/CHANGELOG.md)
 
+## Whales
+
+Whales are the largest animals ever to have lived on Earth. These marine mammals belong to the order Cetacea and are found in every ocean on the planet.
+
+### Key Facts
+
+- **Blue whales** can reach lengths of up to 100 feet (30 meters) and weigh as much as 200 tons.
+- Whales are divided into two main groups: **baleen whales** (Mysticeti) and **toothed whales** (Odontoceti).
+- The **sperm whale** has the largest brain of any animal, weighing about 17 pounds.
+- Humpback whales are known for their complex songs, which can last up to 20 minutes and be heard over great distances.
+
+### Why Whales Matter
+
+Whales play a critical role in ocean ecosystems. Their nutrient-rich waste fertilizes phytoplankton, which produces a significant portion of the world's oxygen. When whales die, their bodies sink to the ocean floor and sustain deep-sea ecosystems for decades — a phenomenon known as a **whale fall**.
+
+### Notable Species
+asdf asdf
+
+
+| Species | Type | Max Length | Population Estimate |
+|---------|------|------------|---------------------|
+| Blue Whale | Baleen | 100 ft | 10,000–25,000 |
+| Humpback Whale | Baleen | 60 ft | ~80,000 |
+| Sperm Whale | Toothed | 67 ft | ~300,000 |
+| Orca | Toothed | 32 ft | ~50,000 |
+| Narwhal | Toothed | 18 ft | ~80,000 |
+
 ## License
+
+<!-- Another test comment -->
 
 [Apache License 2.0](LICENSE)

--- a/intellij/README.md
+++ b/intellij/README.md
@@ -6,8 +6,8 @@
 
 When you work with AI agents like Claude Code, Codex, or Gemini CLI, the reasoning behind every decision lives in the conversation: *why this approach was chosen, what alternatives were considered, what problems came up along the way*. The moment you commit, that context is gone. Jolli Memory captures it automatically.
 
----
-
+--- asdfljjl; asdfasdf
+ asdfasdf asdfasdf asdfasdf
 ## What it does
 
 After each commit, Jolli Memory reads your selected AI session transcripts and the code diff, calls the LLM to produce a structured summary, and stores it alongside the commit silently in the background. The IntelliJ plugin surfaces everything in a tool window so you can manage plans, stage files, write AI-assisted commit messages, review summaries, and share them, without leaving your IDE.

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/hooks/PostCommitHook.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/hooks/PostCommitHook.kt
@@ -21,6 +21,7 @@ import java.time.Instant
  *   7. Call Anthropic API for structured summary
  *   8. Store summary in orphan branch
  */
+// test comment for commit 2
 object PostCommitHook {
 
     private val log = JmLogger.create("PostCommitHook")


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## Quick recap

The IntelliJ plugin can now route all AI generation requests through the Jolli API proxy. A new shared routing layer selects between a direct Anthropic connection and the proxy based on which credentials the user has configured, covering commit message generation, summarization, end-to-end test generation, translation, squash message generation, and plan progress evaluation. Users authenticated with a Jolli API key no longer need a personal Anthropic key to use any of these features.

Several issues blocking reliable git hook execution on Windows were addressed. The plugin's hook installation check was found to be insufficiently specific: it detected the presence of JolliMemory hooks but not which implementation was installed, causing it to leave CLI shell hooks in place when the plugin was enabled on a repository that had previously used the CLI. Clearing the hook files and triggering a fresh plugin install resolved the immediate failure. Separately, the plugin's process environment on Windows was updated to include Git's bundled Unix utilities directory, derived dynamically from the discovered Git installation path, making all child processes more robust to non-standard Git install locations.

A long-standing deployment issue with the hooks JAR was uncovered: reinstalling the plugin was not reliably updating the JAR file that git hooks execute at commit time, causing new hook code to silently have no effect. A manual rebuild and copy resolved the immediate problem, and a new one-step deploy command was added as a workaround. The underlying auto-copy mechanism remains broken and is flagged for follow-up.

Two diagnostic investigations were completed without code changes. Squashed commits were found to still appear in the Knowledge Base tab after squashing, traced to missing index fields on entries created outside the standard pipeline. The OAuth callback flow was traced to a likely parameter loss during org selection in the web application, which requires a fix in a separate repository.

---

## Topics (6)
<details>
<summary><strong>01 · Route all IntelliJ plugin LLM calls through shared proxy layer</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The IntelliJ plugin was making direct API calls to Anthropic from multiple places, with no way to route through the Jolli API proxy for users who authenticate with a Jolli API key rather than a personal Anthropic key.

**💡 Decisions Behind the Code**

- **Shared routing layer over per-caller duplication**: A single `LlmClient` was introduced rather than duplicating HTTP proxy logic in each caller, mirroring the CLI's pattern where a unified call function returns a consistent result regardless of path. This keeps future credential or routing changes isolated to one place.
- **Proxy omits model and stop-reason fields**: The backend does not return these fields, so the proxy result leaves them absent rather than fabricating values. This matches existing CLI behavior and avoids misleading callers about which model was used.
- **Plan progress defaults to Haiku inside the evaluator**: Rather than requiring every call site to specify a model, the default is applied inside `evaluatePlanProgress`, matching CLI behavior and reducing the surface area for call-site mistakes.

**✅ What Was Implemented**

- Added `JolliApiClient.callLlmProxy()` to handle HTTP calls to the `/api/push/llm/complete` proxy endpoint.
- Created `LlmClient.kt` as a unified routing layer that selects between direct `AnthropicClient` and the proxy based on which credentials are available.
- Updated all five generation functions in `Summarizer.kt` (`generateSummary`, `generateCommitMessage`, `generateE2eTest`, `translateToEnglish`, `generateSquashMessage`) and `PlanProgressEvaluator` to route through `LlmClient`.
- Added `jolliApiKey` parameter to all params data classes and relaxed API key guards to accept either key type. Updated all six call sites: `SummaryPanel`, `PostCommitHook`, `CommitAIAction`, and `SquashAction`.
- Confirmed proxy path working via log output showing `source=JOLLI_PROXY`. The proxy result omits `model` and `stopReason` fields, matching CLI behavior.

**📁 FILES**
- `intellij/src/main/kotlin/ai/jolli/jollimemory/llm/LlmClient.kt`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/api/JolliApiClient.kt`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/summarizer/Summarizer.kt`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/summarizer/PlanProgressEvaluator.kt`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/actions/CommitAIAction.kt`

</blockquote>
</details>
<details>
<summary><strong>02 · IntelliJ plugin git hooks override CLI hooks on shared repositories</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The AI Commit button was failing with a timeout error because the CLI's shell-based git hook was running inside IntelliJ's process environment, where shell utilities like `sed` are unavailable on Windows.

**💡 Decisions Behind the Code**

- **Manual hook clearing as immediate fix**: Fixing the marker-only detection logic was deemed out of scope for this session, so clearing the hook files was used as a targeted workaround to unblock the plugin's install flow.
- **Kotlin JAR hook over Node.js shell hook**: The JAR-based hook uses pure JVM I/O with no dependency on shell utilities, making it immune to IntelliJ's minimal process PATH on Windows where tools like `sed` are not available.

**✅ What Was Implemented**

- Identified that the hook installation check only looks for JolliMemory marker comments, not for which implementation (Node.js shell script vs. Kotlin JAR) is inside them. This caused the plugin to skip reinstallation when CLI hooks were already present.
- Manually cleared all three hook files (`prepare-commit-msg`, `post-commit`, `post-rewrite`) so the plugin's enable flow would trigger a fresh install, copy `jollimemory-hooks.jar`, and write the Kotlin JAR-based hooks.
- Confirmed the fix resolved the commit failure.

**📋 Future Enhancements**

- Fix the hook installation check to distinguish between CLI-installed hooks and plugin-installed hooks by inspecting hook content rather than just marker presence, so installing one product after the other correctly overwrites the previous implementation.
- Determine whether the CLI has an equivalent command that only rewrites hooks without a full reinstall, for users switching back from IntelliJ to the CLI or VS Code.

**📁 FILES**
- `.git/hooks/prepare-commit-msg`
- `.git/hooks/post-commit`
- `.git/hooks/post-rewrite`

</blockquote>
</details>
<details>
<summary><strong>03 · Windows PATH missing Git utilities causes hook failures in IntelliJ process</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

IntelliJ's JVM process inherits a minimal system PATH that excludes Git's bundled Unix utilities directory, so shell hooks invoked during a commit could not find required tools on Windows.

**💡 Decisions Behind the Code**

- **Derive utilities path from git.exe location**: Hardcoding a path was rejected because Git can be installed in non-default locations. Walking up from the discovered `git.exe` location works regardless of install directory.
- **Lazy caching to match existing patterns**: The `by lazy` pattern was used to match the existing caching convention in the same file and avoid spawning a new process on every git operation.
- **Kept as general robustness improvement**: This change was later identified as treating a symptom rather than the root cause (wrong hook implementation being invoked), but was retained as a general improvement for Windows environments where PATH gaps can affect other operations.

**✅ What Was Implemented**

Updated `GitOps.kt` to detect Windows via a system property check, run `where git` to locate the Git installation, derive the utilities path by walking up from `git.exe`, and append it to the PATH passed to all child processes spawned via `ProcessBuilder`. The resolved PATH is cached using a lazy delegate to avoid repeated process spawning.

**📁 FILES**
- `intellij/src/main/kotlin/ai/jolli/jollimemory/git/GitOps.kt`

</blockquote>
</details>
<details>
<summary><strong>04 · Squashed commits without parent hash field not filtered from KB tab</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Commits that had been squashed were still appearing in the Knowledge Base tab despite a filter intended to exclude them, because their stored index entries were missing the field the filter relies on.

**💡 Decisions Behind the Code**

The KB tab and the main Memories panel use different filtering paths: the KB cache relies solely on `parentCommitHash` fields in the index, while the Memories panel has its own squash-aware logic. This asymmetry means squashes performed outside the standard queue worker pipeline (e.g., via IntelliJ's git UI or a manual rebase) will not update the index and will therefore not be filtered from the KB tab.

**✅ What Was Implemented**

- Diagnosed that the KB tab's data cache filters squashed commits by checking for a `parentCommitHash` field in `index.json`, but entries for the affected commits had no such field set.
- Further investigation found that one commit (`e214880c`) had a summary on the orphan branch but was entirely absent from `index.json`, indicating the indexing step failed or was silently skipped.
- No code was changed; this was a diagnostic session establishing root cause.

**📋 Future Enhancements**

- Investigate why the indexing step did not write `e214880c` to `index.json` even though a summary exists on the orphan branch.
- Determine whether squashes performed outside the queue worker pipeline need a repair or backfill path to retroactively set `parentCommitHash` on stale index entries.

**📁 FILES**
- `intellij/src/main/kotlin/ai/jolli/jollimemory/core/KBDataCache.kt`

</blockquote>
</details>
<details>
<summary><strong>05 · Stale hooks JAR not updated on plugin reinstall</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The hooks JAR deployed to the user's local bin directory was weeks out of date despite repeated plugin rebuilds and reinstalls, causing new hook code changes to silently have no effect.

**💡 Decisions Behind the Code**

- **Manual copy as immediate fix**: The auto-copy mechanism inside the hook installer was silently failing throughout the session with no error surfaced, so manual copying was the only reliable path to deploy updated hook code.
- **Minimal slash command over a full deploy pipeline**: The `/deploy-hook` command was kept intentionally narrow (copy only, no build or other side effects) per explicit user instruction, to serve as a focused, memorable shortcut rather than a full automation.

**✅ What Was Implemented**

- Rebuilt the hooks shadow JAR via Gradle and manually copied it to `~/.jolli/bin/jollimemory-hooks.jar`. The JAR size changed from 17 MB to 2.7 MB, confirming the old file was a different build artifact.
- Added a test comment to `PostCommitHook.kt` and committed to verify the updated JAR executes on the next post-commit trigger.
- Created a `/deploy-hook` slash command that copies the built JAR from the plugin's sandbox output directory to `~/.jolli/bin/jollimemory-hooks.jar` in one step, as a workaround for the broken auto-copy.

**📋 Future Enhancements**

- Investigate and fix the auto-copy logic in the hook installer so that reinstalling the plugin reliably redeploys the latest JAR without requiring manual intervention.

**📁 FILES**
- `intellij/src/main/kotlin/ai/jolli/jollimemory/hooks/PostCommitHook.kt`

</blockquote>
</details>
<details>
<summary><strong>06 · Investigate IntelliJ plugin OAuth callback failure during org selection</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The IntelliJ plugin's OAuth sign-in flow fails on the first attempt when connecting to the dev server: after the user logs in and selects an org, the browser never redirects back to the plugin's local callback server. A second attempt succeeds because the user is already authenticated and org selection is skipped.

**💡 Decisions Behind the Code**

Investigation was scoped to the plugin side only because the web app lives in a separate repository that was not accessible in this session. Jordan was advised to open a new session in the web app repo to continue debugging.

**✅ What Was Implemented**

No code was changed. The full callback flow was traced: the plugin starts a local HTTP server, opens the browser to the Jolli login page with a callback URL and API key generation flag, and waits for a redirect back to `localhost:<port>/callback?token=...`. The root cause was identified as the web app likely losing the callback query parameter during the org-selection redirect step, so the final redirect back to the plugin never fires. The fix must be made in the separate web app repository.

**📋 Future Enhancements**

- Investigate the web app repository to confirm whether the callback parameter is preserved through the org-selection redirect step, and fix the server-side flow if it is being dropped.

**📁 FILES**
- `intellij/`

</blockquote>
</details>

---

*Generated by JolliMemory · June 10, 2026 at 4:30 PM · via Anthropic*
<!-- jollimemory-summary-end -->