### PR TITLE
Add PR history strip and replace findPrForBranch with sealed PrLookup

### DIFF
--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/services/PrService.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/services/PrService.kt
@@ -20,13 +20,27 @@ object PrService {
 
     private val log = JmLogger.create("PrService")
 
-    /** PR metadata returned by `findPrForBranch`. */
+    /** PR metadata for an open PR. */
     data class PrInfo(
         val number: Int,
         val url: String,
         val title: String,
         val body: String,
     )
+
+    /** A closed or merged PR shown in the history strip. */
+    data class PrHistoryEntry(
+        val number: Int,
+        val url: String,
+        val state: String, // "MERGED" | "CLOSED"
+    )
+
+    /** Discriminated result of [findPrForBranch]. */
+    sealed class PrLookup {
+        data class Found(val pr: PrInfo, val history: List<PrHistoryEntry>) : PrLookup()
+        data class NoPr(val history: List<PrHistoryEntry>) : PrLookup()
+        data class LookupError(val reason: String) : PrLookup()
+    }
 
     private const val MARKER_START = "<!-- jollimemory-summary-start -->"
     private const val MARKER_END = "<!-- jollimemory-summary-end -->"
@@ -215,26 +229,70 @@ object PrService {
     }
 
     /**
-     * Returns PR info for the current branch, or null if none exists.
-     * Uses `gh pr view` to fetch the PR associated with the current branch.
+     * Returns PR info for the given branch.
+     *
+     * Uses `gh pr list --state all --head <branch>` so we get the active PR (if
+     * any) AND closed history in a single round-trip. The webview shows the active
+     * one front-and-center, history as a "Previously: #N (merged) · ..." strip.
+     *
+     * Why list instead of view: `gh pr view <branch>` only returns the most-recent
+     * PR regardless of state, so a force-pushed branch with PR1 merged + PR2 open
+     * showed only PR2; PR1 disappeared from the UI even though the user could
+     * still navigate to it on GitHub. List + state filtering is the right shape.
      */
-    fun findPrForBranch(cwd: String): PrInfo? {
-        val raw = execGh(listOf("pr", "view", "--json", "number,url,title,body"), cwd) ?: return null
+    fun findPrForBranch(cwd: String, branch: String): PrLookup {
+        val raw = execGh(
+            listOf("pr", "list", "--state", "all", "--head", branch, "--json", "number,url,title,body,state,isCrossRepository"),
+            cwd,
+        )
+        if (raw == null) {
+            return PrLookup.LookupError("gh pr list failed")
+        }
 
         return try {
-            @Suppress("UNCHECKED_CAST")
-            val json = com.google.gson.Gson().fromJson(raw, Map::class.java) as Map<String, Any?>
-            val number = (json["number"] as? Double)?.toInt() ?: return null
-            if (number == 0) return null
+            val gson = com.google.gson.Gson()
+            val listType = object : com.google.gson.reflect.TypeToken<List<Map<String, Any?>>>() {}.type
+            val parsed: List<Map<String, Any?>> = gson.fromJson(raw, listType)
 
-            PrInfo(
-                number = number,
-                url = json["url"] as? String ?: "",
-                title = json["title"] as? String ?: "",
-                body = json["body"] as? String ?: "",
-            )
-        } catch (_: Exception) {
-            null
+            // Filter out malformed entries and cross-repository (fork) PRs
+            val valid = parsed.filter { row ->
+                val number = (row["number"] as? Double)?.toInt() ?: 0
+                val state = row["state"] as? String
+                val isCross = row["isCrossRepository"] as? Boolean ?: false
+                number > 0 && state != null && !isCross
+            }
+
+            val openPrs = valid
+                .filter { (it["state"] as? String) == "OPEN" }
+                .sortedByDescending { (it["number"] as? Double)?.toInt() ?: 0 }
+
+            val closedPrs = valid
+                .filter { (it["state"] as? String).let { s -> s == "MERGED" || s == "CLOSED" } }
+                .sortedByDescending { (it["number"] as? Double)?.toInt() ?: 0 }
+
+            val history = closedPrs.map { row ->
+                PrHistoryEntry(
+                    number = (row["number"] as? Double)?.toInt() ?: 0,
+                    url = row["url"] as? String ?: "",
+                    state = row["state"] as? String ?: "CLOSED",
+                )
+            }
+
+            if (openPrs.isEmpty()) {
+                PrLookup.NoPr(history)
+            } else {
+                val open = openPrs[0]
+                val pr = PrInfo(
+                    number = (open["number"] as? Double)?.toInt() ?: 0,
+                    url = open["url"] as? String ?: "",
+                    title = open["title"] as? String ?: "",
+                    body = open["body"] as? String ?: "",
+                )
+                PrLookup.Found(pr, history)
+            }
+        } catch (e: Exception) {
+            log.warn("findPrForBranch: parse error: %s", e.message ?: e.toString())
+            PrLookup.LookupError("Unparseable response from gh: ${e.message}")
         }
     }
 

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/SummaryPanel.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/SummaryPanel.kt
@@ -815,7 +815,8 @@ class SummaryPanel(
     }
 
     private fun handleCheckPrStatus() {
-        jmLog.info("handleCheckPrStatus: start (cwd='%s')", cwd)
+        val targetBranch = currentSummary.branch
+        jmLog.info("handleCheckPrStatus: start (cwd='%s', branch='%s')", cwd, targetBranch)
         ApplicationManager.getApplication().executeOnPooledThread {
             try {
                 val ghAvailable = PrService.isGhAvailable(cwd)
@@ -837,22 +838,35 @@ class SummaryPanel(
                     return@executeOnPooledThread
                 }
 
-                val branch = PrService.getCurrentBranch(cwd) ?: "unknown"
-                val pr = PrService.findPrForBranch(cwd)
-                jmLog.info("handleCheckPrStatus: branch='%s', pr=%s", branch, pr?.number?.toString() ?: "none")
+                val lookup = PrService.findPrForBranch(cwd, targetBranch)
+                jmLog.info("handleCheckPrStatus: lookup=%s", lookup::class.simpleName)
 
-                if (pr == null) {
-                    jmLog.info("handleCheckPrStatus: status=noPr (branch='%s')", branch)
-                    ApplicationManager.getApplication().invokeLater {
-                        postToWebview("prStatus", mapOf("status" to "noPr", "branch" to branch))
+                when (lookup) {
+                    is PrService.PrLookup.LookupError -> {
+                        jmLog.warn("handleCheckPrStatus: status=unavailable (lookupError: %s)", lookup.reason)
+                        ApplicationManager.getApplication().invokeLater {
+                            postToWebview("prStatus", mapOf("status" to "unavailable", "reason" to lookup.reason))
+                        }
                     }
-                } else {
-                    jmLog.info("handleCheckPrStatus: status=ready (pr #%d)", pr.number)
-                    ApplicationManager.getApplication().invokeLater {
-                        postToWebview("prStatus", mapOf(
-                            "status" to "ready",
-                            "pr" to mapOf("number" to pr.number, "url" to pr.url, "title" to pr.title),
-                        ))
+                    is PrService.PrLookup.NoPr -> {
+                        jmLog.info("handleCheckPrStatus: status=noPr (branch='%s', history=%d)", targetBranch, lookup.history.size)
+                        ApplicationManager.getApplication().invokeLater {
+                            postToWebview("prStatus", mapOf(
+                                "status" to "noPr",
+                                "branch" to targetBranch,
+                                "history" to lookup.history.map { mapOf("number" to it.number, "url" to it.url, "state" to it.state) },
+                            ))
+                        }
+                    }
+                    is PrService.PrLookup.Found -> {
+                        jmLog.info("handleCheckPrStatus: status=ready (pr #%d, history=%d)", lookup.pr.number, lookup.history.size)
+                        ApplicationManager.getApplication().invokeLater {
+                            postToWebview("prStatus", mapOf(
+                                "status" to "ready",
+                                "pr" to mapOf("number" to lookup.pr.number, "url" to lookup.pr.url, "title" to lookup.pr.title),
+                                "history" to lookup.history.map { mapOf("number" to it.number, "url" to it.url, "state" to it.state) },
+                            ))
+                        }
                     }
                 }
             } catch (e: Exception) {
@@ -908,11 +922,11 @@ class SummaryPanel(
             try {
                 PrService.pushBranch(cwd)
                 // Check if PR already exists for this branch — update instead of create
-                val existingPr = PrService.findPrForBranch(cwd)
+                val lookup = PrService.findPrForBranch(cwd, currentSummary.branch)
                 val prUrl: String
-                if (existingPr != null) {
-                    PrService.updatePr(existingPr.number, title, body, cwd)
-                    prUrl = existingPr.url
+                if (lookup is PrService.PrLookup.Found) {
+                    PrService.updatePr(lookup.pr.number, title, body, cwd)
+                    prUrl = lookup.pr.url
                 } else {
                     prUrl = PrService.createPr(title, body, cwd)
                 }
@@ -932,11 +946,12 @@ class SummaryPanel(
     private fun handlePrepareUpdatePr() {
         ApplicationManager.getApplication().executeOnPooledThread {
             try {
-                val pr = PrService.findPrForBranch(cwd)
-                if (pr == null) {
+                val lookup = PrService.findPrForBranch(cwd, currentSummary.branch)
+                if (lookup !is PrService.PrLookup.Found) {
                     ApplicationManager.getApplication().invokeLater { postToWebview("prUpdateError", mapOf("message" to "No PR found")) }
                     return@executeOnPooledThread
                 }
+                val pr = lookup.pr
                 val newMarkdown = SummaryPrMarkdownBuilder.buildPrMarkdown(currentSummary)
                 val newBody = PrService.replaceSummaryInBody(pr.body, newMarkdown)
                 ApplicationManager.getApplication().invokeLater {
@@ -952,11 +967,12 @@ class SummaryPanel(
         postToWebview("prUpdating")
         ApplicationManager.getApplication().executeOnPooledThread {
             try {
-                val pr = PrService.findPrForBranch(cwd)
-                if (pr == null) {
+                val lookup = PrService.findPrForBranch(cwd, currentSummary.branch)
+                if (lookup !is PrService.PrLookup.Found) {
                     ApplicationManager.getApplication().invokeLater { postToWebview("prUpdateError", mapOf("message" to "No PR found")) }
                     return@executeOnPooledThread
                 }
+                val pr = lookup.pr
                 PrService.updatePr(pr.number, title, body, cwd)
                 ApplicationManager.getApplication().invokeLater {
                     postToWebview("prUpdated", mapOf("url" to pr.url))

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/views/SummaryCssBuilder.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/views/SummaryCssBuilder.kt
@@ -1156,6 +1156,32 @@ $rootVars
     gap: 6px;
     margin: 8px 0 4px;
   }
+  /* ── PR History strip ── */
+  .pr-history {
+    margin: 6px 0 4px;
+    font-size: 0.88em;
+    color: var(--text-secondary);
+    line-height: 1.5;
+  }
+  .pr-history-label {
+    margin-right: 4px;
+  }
+  .pr-history a {
+    text-decoration: none;
+  }
+  .pr-history a:hover {
+    text-decoration: underline;
+  }
+  .pr-history-merged {
+    color: #8957e5;
+  }
+  .pr-history-closed {
+    color: #cf222e;
+  }
+  .pr-history-sep {
+    margin: 0 6px;
+    color: var(--text-secondary);
+  }
   /* ── PR Content Status ── */
   .pr-content-status {
     margin-top: 10px;

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/views/SummaryHtmlBuilder.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/views/SummaryHtmlBuilder.kt
@@ -480,6 +480,7 @@ $listItems
   <p class="pr-status-text" id="prStatusText">Checking PR status...</p>
   <div class="pr-link-row pr-hidden" id="prLinkRow"></div>$notIncludedHtml
   <div class="pr-actions pr-hidden" id="prActions"></div>
+  <div class="pr-history pr-hidden" id="prHistory"></div>
   <div class="pr-form pr-hidden" id="prForm" data-title="$escapedTitle" data-body="$escapedBody">
     <label class="pr-form-label">Title</label>
     <input type="text" class="pr-form-input" id="prTitleInput" />

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/views/SummaryScriptBuilder.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/views/SummaryScriptBuilder.kt
@@ -1517,7 +1517,9 @@ ${buildPrMessageScript()}
   var prFormCancel = document.getElementById('prFormCancel');
   var prFormSubmit = document.getElementById('prFormSubmit');
 
+  var prHistory = document.getElementById('prHistory');
   var prCurrentState = 'loading';
+  var prLastHistory = [];
 
   /** Toggle visibility via the pr-hidden CSS class (CSP blocks inline style attributes). */
   function prShow(el) { if (el) el.classList.remove('pr-hidden'); }
@@ -1533,6 +1535,38 @@ ${buildPrMessageScript()}
     led.className = 'led';
     prStatusChip.appendChild(led);
     prStatusChip.appendChild(document.createTextNode(label));
+  }
+
+  function renderPrHistory(history) {
+    prLastHistory = Array.isArray(history) ? history : [];
+    if (prLastHistory.length === 0) {
+      prHide(prHistory);
+      return;
+    }
+    prHistory.textContent = '';
+    var label = document.createElement('span');
+    label.className = 'pr-history-label';
+    label.textContent = 'Previously:';
+    prHistory.appendChild(label);
+    var renderedCount = 0;
+    for (var i = 0; i < prLastHistory.length; i++) {
+      var h = prLastHistory[i];
+      if (typeof h.url !== 'string' || h.url.indexOf('https://') !== 0) continue;
+      if (renderedCount > 0) {
+        var sep = document.createElement('span');
+        sep.className = 'pr-history-sep';
+        sep.textContent = '\u00b7';
+        prHistory.appendChild(sep);
+      }
+      var link = document.createElement('a');
+      link.href = h.url;
+      link.title = 'Open PR in browser';
+      link.className = h.state === 'MERGED' ? 'pr-history-merged' : 'pr-history-closed';
+      link.textContent = '#' + h.number + ' (' + (h.state === 'MERGED' ? 'merged' : 'closed') + ')';
+      prHistory.appendChild(link);
+      renderedCount++;
+    }
+    prShow(prHistory);
   }
 
   // Auto-check PR status on load
@@ -1579,12 +1613,22 @@ ${buildPrMessageScript()}
       prCurrentState = s;
       prHide(prForm);
 
-      if (s === 'unavailable') {
-        setPrChip('is-warn', 'Unavailable');
-        prStatusText.textContent = 'GitHub CLI (gh) is not installed or not authenticated.';
+      if (s === 'multipleCommits') {
+        setPrChip('is-warn', 'Multiple commits');
+        prStatusText.textContent = 'Branch has ' + msg.count + ' commits. Please squash into a single commit before creating or updating a PR.';
         prShow(prStatusText);
         prHide(prLinkRow);
         prHide(prActions);
+        prHide(prHistory);
+      } else if (s === 'unavailable') {
+        setPrChip('is-warn', 'Unavailable');
+        prStatusText.textContent = msg.reason
+          ? ('Could not load PR status \u2014 ' + msg.reason + '. Retry, or check the IDE log.')
+          : 'GitHub CLI (gh) is not installed or not authenticated.';
+        prShow(prStatusText);
+        prHide(prLinkRow);
+        prHide(prActions);
+        prHide(prHistory);
       } else if (s === 'noPr') {
         setPrChip('is-warn', 'No PR');
         prStatusText.textContent = 'No pull request found for branch ' + msg.branch + '.';
@@ -1621,6 +1665,7 @@ ${buildPrMessageScript()}
           if (chainBtn) chainBtn.disabled = true;
           jmSend({ command: 'createPrDirect' });
         });
+        renderPrHistory(msg.history);
       } else if (s === 'ready') {
         var pr = msg.pr;
         setPrChip('is-ok', '#' + pr.number + ' open');
@@ -1647,6 +1692,7 @@ ${buildPrMessageScript()}
           editBtn.disabled = true;
           jmSend({ command: 'prepareUpdatePr' });
         });
+        renderPrHistory(msg.history);
       }
     }
 
@@ -1665,6 +1711,7 @@ ${buildPrMessageScript()}
       prHide(prLinkRow);
       prActions.textContent = '';
       prHide(prActions);
+      prHide(prHistory);
       prShow(prForm);
       prForm.dataset.mode = 'create';
       prFormSubmit.textContent = 'Submit PR';
@@ -1680,6 +1727,7 @@ ${buildPrMessageScript()}
       prHide(prStatusText);
       prHide(prLinkRow);
       prHide(prActions);
+      prHide(prHistory);
       prShow(prForm);
       prForm.dataset.mode = 'update';
       prFormSubmit.textContent = 'Update PR';


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## Quick recap

The IntelliJ plugin's pull request panel now correctly reflects the state of the PR associated with each memory, regardless of what branch the user currently has checked out. Previously, the panel always queried the live working branch, so viewing a memory from an older branch would surface the wrong PR entirely. Now every PR lookup is anchored to the branch recorded in the memory itself.

Closed and merged pull requests are also displayed correctly for the first time. The plugin previously only retrieved open PRs, so a manually closed PR would appear as still open. The lookup now fetches all PR states in a single call, separates the active open PR from any closed or merged predecessors, and renders a "Previously: #N (merged) · #M (closed)" history strip below the PR actions area. The strip uses distinct colors for merged and closed entries and disappears while the create or update form is open. Both fixes bring the IntelliJ plugin's PR behavior into full alignment with the VS Code extension.

---

## E2E Test (4)
<details>
<summary><strong>1. Closed PR no longer shows as open</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a Git repository where a branch previously had a pull request that has since been closed or merged. Open that branch's memory in the JolliMemory panel.

**Steps:**
1. Open IntelliJ and navigate to the JolliMemory tool window.
2. Load the memory summary for the branch whose PR was already closed or merged.
3. Wait for the PR status section to finish loading (the "Checking PR status..." message disappears).
4. Check the PR status chip and the text shown in the PR section.

**Expected Results:**
- The PR status chip should show "No PR" (not "open") if there is no currently open pull request for that branch.
- The PR section should not display the old closed or merged PR as if it were still active.

</blockquote>
</details>
<details>
<summary><strong>2. Previously closed or merged PRs appear in the history strip</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a Git repository where a branch has at least one closed or merged pull request. Open that branch's memory in the JolliMemory panel.

**Steps:**
1. Open IntelliJ and navigate to the JolliMemory tool window.
2. Load the memory summary for the branch that has past closed or merged PRs.
3. Wait for the PR status section to finish loading.
4. Look below the PR action buttons for a "Previously:" line.
5. Check that each entry in the strip is a clickable link, and click one to verify it opens the correct PR page in your browser.

**Expected Results:**
- A "Previously:" strip appears below the PR action buttons listing each past PR by number and state (e.g. "#12 (merged)" in purple, "#8 (closed)" in red).
- Clicking a link opens the correct pull request page on GitHub in the browser.

</blockquote>
</details>
<details>
<summary><strong>3. History strip is hidden while the PR form is open</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a Git repository with a branch that has past closed or merged PRs and no currently open PR. Open that branch's memory in the JolliMemory panel.

**Steps:**
1. Open the JolliMemory tool window and load the memory for the branch with PR history.
2. Confirm the "Previously:" history strip is visible below the PR actions area.
3. Click the button to create a new PR (this opens the PR form with title and body fields).
4. Check whether the history strip is still visible while the form is open.
5. Click "Cancel" to close the PR form.
6. Check whether the history strip reappears.

**Expected Results:**
- While the PR creation form is open, the "Previously:" history strip should be hidden.
- After cancelling the form, the "Previously:" history strip should reappear below the PR actions area.

</blockquote>
</details>
<details>
<summary><strong>4. PR status reflects the memory's branch, not the currently checked-out branch</strong></summary>
<br>
<blockquote>

**Preconditions:** Have two branches: Branch A with an open pull request, and Branch B with no pull request. Currently have Branch B checked out in the IDE. Have saved memories for both branches in JolliMemory.

**Steps:**
1. Open IntelliJ with Branch B currently checked out.
2. Open the JolliMemory tool window and load the memory for Branch A (the one with an open PR).
3. Wait for the PR status section to finish loading.
4. Check the PR status chip and the PR details shown.
5. Now switch to viewing the memory for Branch B (the one with no PR) without changing the checked-out branch.
6. Wait for the PR status to reload and check what is displayed.

**Expected Results:**
- When viewing Branch A's memory, the PR status should show the open PR for Branch A (e.g. chip reads "#5 open") even though Branch B is checked out.
- When viewing Branch B's memory, the PR status should show "No PR" for Branch B, not Branch A's PR.

</blockquote>
</details>

---

## Topics (2)
<details>
<summary><strong>01 · Fix closed PR showing as open by fetching all PR states</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The IntelliJ plugin was displaying closed pull requests as if they were still open. The user identified that the VS Code side handled this correctly and asked for the IntelliJ side to match it exactly.

**💡 Decisions Behind the Code**

- **Match VS Code exactly rather than patching the existing approach**: The root cause of multiple PR bugs (wrong state shown, wrong branch queried) was that IntelliJ's PR lookup had diverged from VS Code's. Rather than patching individual symptoms, the entire lookup was rewritten to mirror VS Code's `gh pr list --state all` flow. This eliminates a whole class of future divergence bugs at the cost of a slightly larger change.
- **Sealed class instead of nullable return**: The old `findPrForBranch` returned a nullable value, which collapsed three meaningfully different outcomes (found, not found, error) into two. A sealed class makes each case explicit and forces every call site to handle all outcomes, reducing the chance of silently swallowing errors or misreading a lookup failure as "no PR exists."
- **History hidden during form editing**: When the user opens the create or update PR form, the history strip is hidden to reduce visual noise. It reappears after the form is dismissed. This matches VS Code's behavior and keeps the form focused.

**✅ What Was Implemented**

- Replaced `findPrForBranch` in `PrService.kt` with a new implementation using `gh pr list --state all --head <branch>` (matching VS Code's approach). The method now returns a sealed `PrLookup` type with three variants — `Found` (open PR + history), `NoPr` (no open PR + history), and `LookupError` — instead of a nullable `PrInfo`. A new `PrHistoryEntry` data class carries closed/merged PR metadata. Cross-repository (fork) PRs are filtered out, mirroring VS Code's filter logic.
- Updated `SummaryPanel.kt` to switch on the new `PrLookup` sealed type in `handleCheckPrStatus`, `handleCreatePr`, `handlePrepareUpdatePr`, and `handleUpdatePr`. History arrays are now serialized into every `prStatus` webview message alongside the active PR data.
- Added `renderPrHistory()` in `SummaryScriptBuilder.kt` and a `<div id="prHistory">` in `SummaryHtmlBuilder.kt`. The function renders a "Previously: #N (merged) · #M (closed)" strip below the PR actions area, with purple styling for merged and red for closed entries, matching VS Code's visual treatment. History is hidden when the PR form is open and restored when it closes.

**📁 FILES**
- `intellij/src/main/kotlin/ai/jolli/jollimemory/services/PrService.kt`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/SummaryPanel.kt`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/views/SummaryScriptBuilder.kt`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/views/SummaryHtmlBuilder.kt`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/views/SummaryCssBuilder.kt`

</blockquote>
</details>
<details>
<summary><strong>02 · Fix PR status checking wrong branch when viewing older memories</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The plugin was showing the wrong pull request when the user viewed a memory from a different branch than the one currently checked out. The PR section was always reflecting the live working branch rather than the branch the memory belonged to.

**💡 Decisions Behind the Code**

- **Use the summary's stored branch rather than the live git branch**: The memory panel can display summaries from any branch in history, so tying PR lookups to the currently checked-out branch was always wrong for any memory that wasn't from the active branch. Using the branch recorded in the summary data is the only correct anchor point, and it also makes the behavior consistent regardless of what the user has checked out locally.
- **Remove the multiple-commits guard**: IntelliJ had an early exit that blocked PR lookup when more than one commit existed on the branch. VS Code has no equivalent check, and its absence was intentional — the PR section should work regardless of commit count. Removing it aligns behavior across both clients.

**✅ What Was Implemented**

In `SummaryPanel.kt`, `handleCheckPrStatus` now passes `currentSummary.branch` to `findPrForBranch` instead of calling `PrService.getCurrentBranch(cwd)` at lookup time. The same fix was applied to `handleCreatePr`, `handlePrepareUpdatePr`, and `handleUpdatePr` so all PR operations consistently use the summary's branch. The `multipleCommits` early-exit guard was also removed from `handleCheckPrStatus` to align with VS Code, which does not have this check.

**📁 FILES**
- `intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/SummaryPanel.kt`

</blockquote>
</details>

---

*Generated by JolliMemory · June 10, 2026 at 5:01 PM · via Anthropic*
<!-- jollimemory-summary-end -->