### PR TITLE
Remove worker-busy gate from PushCommand and drop workspaceRoot dep

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -159,8 +159,7 @@
 				"command": "jollimemory.pushBranch",
 				"title": "Push",
 				"icon": "$(cloud-upload)",
-				"category": "Jolli Memory",
-				"enablement": "!jollimemory.workerBusy"
+				"category": "Jolli Memory"
 			},
 			{
 				"command": "jollimemory.refreshHistory",

--- a/vscode/src/Extension.ts
+++ b/vscode/src/Extension.ts
@@ -1541,7 +1541,6 @@ export function activate(context: vscode.ExtensionContext): void {
 		filesStore,
 		statusStore,
 		statusBar,
-		workspaceRoot,
 	);
 
 	// Shared resolver for the multi-source reference webview commands. The webview

--- a/vscode/src/commands/PushCommand.test.ts
+++ b/vscode/src/commands/PushCommand.test.ts
@@ -91,7 +91,15 @@ describe("PushCommand", () => {
 		error.mockClear();
 	});
 
-	it("blocks while the worker is busy", async () => {
+	it("pushes even while the worker is busy and never consults the worker lock", async () => {
+		// Regression guard: push must NOT be gated on the post-commit Worker
+		// lock — it shares no state with the QueueWorker. The mock is wired to
+		// report a busy worker (`true`); the hoisted vi.mock intercepts the
+		// module for any importer, so if someone reintroduces an `isWorkerBusy`
+		// guard in execute(), that guard would early-return and the assertions
+		// below (push happened, no busy warning) would fail. The
+		// `not.toHaveBeenCalled()` assertion is the direct invariant: push does
+		// not even look at the lock.
 		isWorkerBusy.mockResolvedValue(true);
 		const deps = makeDeps();
 		const command = new PushCommand(
@@ -100,15 +108,18 @@ describe("PushCommand", () => {
 			deps.filesStore as never,
 			deps.statusStore as never,
 			deps.statusBar as never,
-			"/repo",
 		);
 
 		await command.execute();
 
-		expect(showWarningMessage).toHaveBeenCalledWith(
+		expect(isWorkerBusy).not.toHaveBeenCalled();
+		expect(deps.bridge.pushCurrentBranch).toHaveBeenCalled();
+		expect(showInformationMessage).toHaveBeenCalledWith(
+			"Jolli Memory: Successfully pushed the current branch.",
+		);
+		expect(showWarningMessage).not.toHaveBeenCalledWith(
 			"Jolli Memory: AI summary is being generated. Please wait a moment.",
 		);
-		expect(deps.bridge.pushCurrentBranch).not.toHaveBeenCalled();
 	});
 
 	it("pushes successfully when branch has multiple commits (multi-commit support)", async () => {
@@ -121,7 +132,6 @@ describe("PushCommand", () => {
 			deps.filesStore as never,
 			deps.statusStore as never,
 			deps.statusBar as never,
-			"/repo",
 		);
 
 		await command.execute();
@@ -146,7 +156,6 @@ describe("PushCommand", () => {
 			deps.filesStore as never,
 			deps.statusStore as never,
 			deps.statusBar as never,
-			"/repo",
 		);
 
 		await command.execute();
@@ -170,7 +179,6 @@ describe("PushCommand", () => {
 			deps.filesStore as never,
 			deps.statusStore as never,
 			deps.statusBar as never,
-			"/repo",
 		);
 
 		await command.execute();
@@ -191,7 +199,6 @@ describe("PushCommand", () => {
 			deps.filesStore as never,
 			deps.statusStore as never,
 			deps.statusBar as never,
-			"/repo",
 		);
 
 		await command.execute();
@@ -214,7 +221,6 @@ describe("PushCommand", () => {
 			deps.filesStore as never,
 			deps.statusStore as never,
 			deps.statusBar as never,
-			"/repo",
 		);
 		showWarningMessage
 			.mockResolvedValueOnce(undefined)
@@ -242,7 +248,6 @@ describe("PushCommand", () => {
 			deps.filesStore as never,
 			deps.statusStore as never,
 			deps.statusBar as never,
-			"/repo",
 		);
 
 		await command.execute();
@@ -261,7 +266,6 @@ describe("PushCommand", () => {
 			deps.filesStore as never,
 			deps.statusStore as never,
 			deps.statusBar as never,
-			"/repo",
 		);
 
 		await command.execute();
@@ -284,7 +288,6 @@ describe("PushCommand", () => {
 			deps.filesStore as never,
 			deps.statusStore as never,
 			deps.statusBar as never,
-			"/repo",
 		);
 
 		await command.execute();
@@ -304,7 +307,6 @@ describe("PushCommand", () => {
 			deps.filesStore as never,
 			deps.statusStore as never,
 			deps.statusBar as never,
-			"/repo",
 		);
 
 		await command.execute();

--- a/vscode/src/commands/PushCommand.ts
+++ b/vscode/src/commands/PushCommand.ts
@@ -11,6 +11,13 @@
  * 2. If the HEAD commit is already on remote, ask for force-push confirmation.
  * 3. Otherwise try normal push; on non-fast-forward rejection, offer force push.
  * 4. Refresh panels and status bar after success.
+ *
+ * Note: pushing is intentionally NOT gated on the post-commit Worker lock
+ * (`isWorkerBusy`). Push only runs `git push` on the current code branch; it
+ * shares no git ref or file with the QueueWorker, which writes summaries to the
+ * orphan branch + Memory Bank folder and never touches the remote. Commit and
+ * Squash stay gated because they race the worker (LLM provider / local history
+ * rewrite); push does not. Do not reintroduce a worker-busy guard here.
  */
 
 import * as vscode from "vscode";
@@ -19,7 +26,6 @@ import type { CommitsStore } from "../stores/CommitsStore.js";
 import type { FilesStore } from "../stores/FilesStore.js";
 import type { StatusStore } from "../stores/StatusStore.js";
 import type { BranchCommit } from "../Types.js";
-import { isWorkerBusy } from "../util/LockUtils.js";
 import { log } from "../util/Logger.js";
 import type { StatusBarManager } from "../util/StatusBarManager.js";
 
@@ -32,18 +38,9 @@ export class PushCommand {
 		private readonly filesStore: FilesStore,
 		private readonly statusStore: StatusStore,
 		private readonly statusBar: StatusBarManager,
-		private readonly workspaceRoot: string,
 	) {}
 
 	async execute(): Promise<void> {
-		// Guard: block while the post-commit Worker holds the lock
-		if (await isWorkerBusy(this.workspaceRoot)) {
-			vscode.window.showWarningMessage(
-				"Jolli Memory: AI summary is being generated. Please wait a moment.",
-			);
-			return;
-		}
-
 		const commits = this.commitsStore.getSnapshot().commits;
 		if (commits.length === 0) {
 			log.info(

--- a/vscode/src/util/LockUtils.ts
+++ b/vscode/src/util/LockUtils.ts
@@ -4,7 +4,8 @@
  * The post-commit Worker holds `.jolli/jollimemory/worker.lock` while running
  * the LLM summarization pipeline (~20-40s). These helpers let the extension and
  * command classes check the lock state to prevent race conditions
- * (Commit / Squash / Push are gated on it).
+ * (Commit / Squash are gated on it). Push is intentionally NOT gated: it only
+ * runs `git push` on the current branch and shares no state with the worker.
  *
  * Notes on the lock split:
  *   - `worker.lock` is the QueueWorker's "I'm draining the queue" marker; this

--- a/vscode/src/util/StatusBarManager.test.ts
+++ b/vscode/src/util/StatusBarManager.test.ts
@@ -163,6 +163,26 @@ describe("StatusBarManager", () => {
 			);
 		});
 
+		it("offline + failedCode=vault_locked + selfLocked → self-lock headline (dangling own lock)", () => {
+			// selfLocked=true means the lock is almost certainly held by THIS
+			// device's own previous failed round — the headline must say so
+			// rather than blaming an unknown peer. Exercises the
+			// `detail.selfLocked === true` true-branch in terminalCodeVisual.
+			const manager = new StatusBarManager();
+			manager.setSyncState("offline", {
+				failed: true,
+				failedCode: "vault_locked",
+				selfLocked: true,
+			});
+			expect(item.text).toBe("$(error) Personal Space busy");
+			expect((item.backgroundColor as { id: string }).id).toBe(
+				"statusBarItem.warningBackground",
+			);
+			expect(item.tooltip).toContain(
+				"Your previous sync failed and its backend lock is still releasing",
+			);
+		});
+
 		it("offline + failedCode=localfolder_invalid → 'Memory Bank folder invalid'", () => {
 			const manager = new StatusBarManager();
 			manager.setSyncState("offline", { failed: true, failedCode: "localfolder_invalid" });
@@ -185,6 +205,30 @@ describe("StatusBarManager", () => {
 		// a terminal SyncErrorCode, so there's no status-bar visual to
 		// test. Coverage for the defences themselves is in
 		// StageVault.test.ts and VaultSymlinkGuard.test.ts.
+
+		it.each([
+			"vault_mismatch",
+			"mint_failed",
+			"git_missing",
+			"clone_failed",
+			"fetch_failed",
+			"pull_failed",
+			"migration_failed",
+		] as const)(
+			"offline + failedCode=%s → generic 'Sync failed' + errorBackground",
+			(failedCode) => {
+				// These terminal codes all share the generic error visual via the
+				// fall-through case group in terminalCodeVisual. Each label is its
+				// own switch branch, so exercise them all to keep the mapping honest.
+				const manager = new StatusBarManager();
+				manager.setSyncState("offline", { failed: true, failedCode });
+				expect(item.text).toBe("$(error) Sync failed");
+				expect((item.backgroundColor as { id: string }).id).toBe(
+					"statusBarItem.errorBackground",
+				);
+				expect(item.tooltip).toContain("Memory Bank sync failed");
+			},
+		);
 
 		it("offline + an unrecognized failedCode falls back to generic 'Sync failed' (exhaustive-never runtime safety)", () => {
 			// The terminal-code switch has a compile-time `const _exhaustive:


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## Quick recap

Clicking Push Branch during an active AI summary generation now works immediately instead of showing a warning and refusing to proceed. The investigation confirmed that pushing code to a remote server and generating a local commit summary are entirely independent — they touch different parts of the repository and never compete for the same resources. The gate was removed from the push flow, while the equivalent blocks on commit and squash operations were left in place, as those operations do have genuine conflicts with the background summarization process.

To prevent the gate from being quietly reintroduced in the future, the test that previously verified the block was reversed into a regression guard. It still simulates a busy background worker, but now asserts that the push completes successfully and that the lock file is never consulted at all — any future attempt to add the check back would cause this test to fail immediately.

---

## Topics (2)
<details>
<summary><strong>01 · Push Branch no longer blocked during AI summary generation</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

While a commit summary was being generated in the background (a process that can take 30–120 seconds), clicking Push Branch would show a warning and refuse to proceed. The user identified that pushing code to a remote server and generating a local AI summary are completely independent operations with no shared resources, so the block was unnecessary and frustrating.

**💡 Decisions Behind the Code**

- **Keeping Commit and Squash gated, removing only Push**: The investigation confirmed that Commit and Squash have genuine races with the background worker — Squash rewrites local history that the worker is actively processing, and AI-assisted Commit messages share the same LLM provider rate limit. Push only runs a network transfer of the current branch and touches nothing the worker reads or writes. Removing the gate selectively preserves safety where it matters while eliminating a real UX friction point.
- **Regression test instead of deletion**: The original test was deleted and replaced with an inverted version rather than simply removed. If the guard is ever reintroduced, the test fails immediately because the lock would cause an early return and the push assertion would not be satisfied. A plain deletion would leave no safety net against future regressions.
- **Removing the workspace path parameter entirely**: Once the guard was gone, the constructor parameter that held the workspace path became unused. Leaving unused parameters causes lint errors in this codebase and would mislead future readers into thinking the parameter still serves a purpose. Removing it required updating one call site, which was a small, safe change.

**✅ What Was Implemented**

- Removed the worker-busy guard from `vscode/src/commands/PushCommand.ts`: deleted the early-return check that consulted the worker lock file, removed the now-unused `isWorkerBusy` import, and added an explicit English comment in the file header explaining that this gate was intentionally omitted and must not be reintroduced — naming the exact reason (push shares no git ref or file with the background worker).
- Dropped the `workspaceRoot` constructor parameter from `PushCommand` (it was only used by the removed guard) and updated the call site in `vscode/src/Extension.ts` accordingly. Updated `vscode/src/util/LockUtils.ts` header comment to remove Push from the list of gated operations and note the intentional exclusion.
- Reversed the "blocks while worker is busy" test in `vscode/src/commands/PushCommand.test.ts` into a regression guard: the mock still reports a busy worker, but assertions now verify that push proceeds normally, the success toast appears, and — critically — the lock is never consulted at all (`isWorkerBusy` not called). This makes the test fail if anyone reintroduces the guard.

**📁 FILES**
- `vscode/src/commands/PushCommand.ts`
- `vscode/src/Extension.ts`
- `vscode/src/util/LockUtils.ts`

</blockquote>
</details>
<details>
<summary><strong>02 · Test coverage threshold raised to 98% with new status bar tests</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

After the push gate removal, the user asked for overall test coverage to be raised to 98% and locked in at that level. The existing threshold was 97%, and the status bar component was identified as the main file pulling the branch coverage figure down.

**💡 Decisions Behind the Code**

- **Targeting the status bar component specifically**: The status bar had branch coverage around 82%, making it the single largest drag on the global figure. Adding a small number of focused tests there gave the most coverage gain per line of test code written. Two contrived tests suggested during adversarial review were later removed after it was confirmed they tested states the application never actually produces — keeping only tests that reflect real runtime behavior.
- **Locking the threshold at 98% rather than leaving it at 97%**: Raising the threshold makes the CI gate enforce the new baseline permanently. The trade-off acknowledged is that the branch coverage margin is thin (roughly 18 uncovered branches), meaning unrelated future changes in under-tested areas could trip the gate — the user accepted this as the cost of the higher standard.

**✅ What Was Implemented**

- Added two targeted test cases to `vscode/src/util/StatusBarManager.test.ts`: one covering the "self-locked" vault state (where the status bar must show a specific message blaming the current device's own previous failed sync rather than an unknown peer), and a parameterized test covering seven distinct sync-failure codes that all map to the generic "Sync failed" error display — exercising each switch branch individually.
- Raised the coverage thresholds in `vscode/vitest.config.ts` from 97% to 98% across all four metrics (statements, branches, functions, lines). Post-change measurements: statements 99.25%, branches 98.48%, functions 98.58%, lines 99.38%.

**📋 Future Enhancements**

The branch coverage margin is thin (~18 branches). The sync orchestration layer has notably lower branch coverage (~86%) and is the most likely source of future threshold failures if new code is added there without accompanying tests.

**📁 FILES**
- `vscode/src/util/StatusBarManager.test.ts`
- `vscode/vitest.config.ts`

</blockquote>
</details>

---

*Generated by Jolli Memory · June 11, 2026 at 4:50 PM · via Anthropic*
<!-- jollimemory-summary-end -->