### PR TITLE
Fix SSH/HTTPS remote mismatch causing split Memory Banks and duplicate repo entries

### DIFF
--- a/cli/src/core/IngestPipeline.test.ts
+++ b/cli/src/core/IngestPipeline.test.ts
@@ -20,6 +20,13 @@ vi.mock("./SourceContent.js", () => ({
 	loadSourceContent: vi.fn(async (r) => `content ${r.id}`),
 }));
 vi.mock("./IngestRunStore.js", () => ({ appendIngestRun: vi.fn() }));
+// Without this mock, every `ingestPendingBatch("/tmp/x", …)` call that omits
+// `opts.readStorage` runs the REAL createReadStorage → loadConfig reads the
+// developer's actual ~/.jolli config → resolveKBPath claims a stub `x/` folder
+// inside their real Memory Bank (`<localFolder>/x`). Same pattern as
+// SourceTimeline.test.ts. All storage consumers above are mocked, so the
+// dummy provider is never actually read.
+vi.mock("./ReadStorageResolver.js", () => ({ createReadStorage: vi.fn(async () => ({})) }));
 
 import { drainIngest, ingestPendingBatch } from "./IngestPipeline.js";
 import { appendIngestRun } from "./IngestRunStore.js";

--- a/cli/src/core/KBPathResolver.test.ts
+++ b/cli/src/core/KBPathResolver.test.ts
@@ -7,6 +7,7 @@ import {
 	assertValidLocalFolder,
 	extractRepoName,
 	findFreshKBPath,
+	foldGitTransportToHttps,
 	getRemoteUrl,
 	InvalidLocalFolderError,
 	initializeKBFolder,
@@ -234,6 +235,49 @@ esac
 
 			const result = resolveKBPath("localrepo", null, tempDir);
 			expect(result).toBe(kbRoot);
+		});
+
+		it("reuses the folder across clone transports (stored SSH, live https — and vice versa)", () => {
+			// Same repo, different transport. Before folding, switching the
+			// remote from SSH to https split the Memory Bank into
+			// `myrepo` / `myrepo-2`.
+			const kbRoot = join(tempDir, "myrepo");
+			initializeKBFolder(kbRoot, "myrepo", "git@github.com:user/myrepo.git");
+			expect(resolveKBPath("myrepo", "https://github.com/user/myrepo.git", tempDir)).toBe(kbRoot);
+
+			const kbRoot2 = join(tempDir, "other");
+			initializeKBFolder(kbRoot2, "other", "https://github.com/user/other.git");
+			expect(resolveKBPath("other", "ssh://git@github.com:22/user/other.git", tempDir)).toBe(kbRoot2);
+		});
+	});
+
+	describe("foldGitTransportToHttps", () => {
+		it("folds SCP, ssh:// (with user/port), git+ssh:// and git:// into the https form", () => {
+			expect(foldGitTransportToHttps("git@github.com:user/repo.git")).toBe("https://github.com/user/repo.git");
+			expect(foldGitTransportToHttps("ssh://git@github.com:22/user/repo")).toBe("https://github.com/user/repo");
+			expect(foldGitTransportToHttps("git+ssh://git@github.com/user/repo")).toBe("https://github.com/user/repo");
+			expect(foldGitTransportToHttps("git://github.com:9418/user/repo")).toBe("https://github.com/user/repo");
+		});
+
+		it("preserves non-default ssh/git ports (distinct self-hosted forges must not collapse)", () => {
+			expect(foldGitTransportToHttps("ssh://git@host.example:2222/team/repo")).toBe(
+				"https://host.example:2222/team/repo",
+			);
+			expect(foldGitTransportToHttps("git://host.example:9419/team/repo")).toBe(
+				"https://host.example:9419/team/repo",
+			);
+		});
+
+		it("preserves the absolute-path distinction of SCP paths", () => {
+			expect(foldGitTransportToHttps("git@host.example:/srv/repo")).toBe("https://host.example//srv/repo");
+			expect(foldGitTransportToHttps("git@host.example:srv/repo")).toBe("https://host.example/srv/repo");
+		});
+
+		it("passes through https URLs, Windows drive paths, bare names and bare host:path", () => {
+			expect(foldGitTransportToHttps("https://github.com/user/repo")).toBe("https://github.com/user/repo");
+			expect(foldGitTransportToHttps("C:/repos/foo")).toBe("C:/repos/foo");
+			expect(foldGitTransportToHttps("my-notes")).toBe("my-notes");
+			expect(foldGitTransportToHttps("mygit.local:repos/foo")).toBe("mygit.local:repos/foo");
 		});
 	});
 

--- a/cli/src/core/KBPathResolver.ts
+++ b/cli/src/core/KBPathResolver.ts
@@ -260,10 +260,75 @@ function isSameRepo(config: KBConfig, remoteUrl: string | null, repoName: string
 }
 
 function normalizeRemoteUrl(url: string): string {
-	return url
+	return foldGitTransportToHttps(url)
 		.replace(/\/+$/, "")
 		.replace(/\.git$/, "")
 		.toLowerCase();
+}
+
+/**
+ * Folds the SSH transport forms of a git remote URL into the https form so
+ * all transports of the same repo compare equal:
+ *
+ *   - `ssh://[user@]host[:port]/path` (and `git+ssh://`) → `https://host[:port]/path`.
+ *     The scheme's DEFAULT port (22) is dropped — it carries no identity —
+ *     but a non-default port is preserved: two self-hosted forges on
+ *     `host:2222` and `host:2223` are distinct repos and must not collapse.
+ *     Same rule as `vscode/src/util/GitRemoteUtils.ts` (the server binding
+ *     key), so the two canonicalizers agree on self-hosted SSH remotes.
+ *   - `git://host[:port]/path` → `https://host[:port]/path` (default 9418
+ *     dropped, same rule).
+ *   - SCP form `user@host:path` → `https://host/path`. The `user@` part is
+ *     REQUIRED on purpose: a bare `host:path` was never folded by earlier
+ *     releases either, and requiring the `@` keeps non-URL strings that
+ *     happen to contain a `:` (a basename can legally contain one on Linux,
+ *     `C:/repos/foo` is a Windows drive path) from being mangled into fake
+ *     https URLs. Hosted-git SSH remotes universally use `git@`, so the
+ *     constraint costs nothing in practice. The absolute-vs-relative
+ *     distinction of the SCP path is preserved (`host:/srv/repo` →
+ *     `…host//srv/repo` vs `host:srv/repo` → `…host/srv/repo`).
+ *
+ * Anything else (https, file paths, bare names) passes through unchanged.
+ *
+ * Shared by the local folder-reuse predicate (`isSameRepo` above) and the
+ * vault identity normalizer (`sync/RepoIdentity.ts`) so "is this the same
+ * repo?" gets one answer on both sides — they diverged once and the same
+ * repo cloned via SSH on one device and https on another produced duplicate
+ * `repos.json` rows plus a split local folder (`<repo>` / `<repo>-2`).
+ *
+ * The IntelliJ plugin carries a Kotlin port (`KBPathResolver.kt
+ * foldGitTransportToHttps`) that must stay in lockstep — both IDEs resolve
+ * folders in the same Memory Bank, and divergent folding sends them to
+ * different folders for the same repo.
+ */
+/**
+ * Hosts whose owner/repo path is case-insensitive on the wire — clones typed
+ * with different casing all resolve to the same repo, so canonicalizers must
+ * lower-case the path for these hosts (and ONLY these: self-hosted forges may
+ * be case-sensitive). Single shared source of truth for every comparer:
+ * `sync/RepoIdentity.ts` (vault identity), `vscode/src/util/GitRemoteUtils.ts`
+ * (server binding key — imports this set), and the whole-string-lowercasing
+ * comparers (`normalizeRemoteUrl` above, `KBRepoDiscoverer`) which fold case
+ * unconditionally and need no per-host check. Add new entries only after
+ * confirming the host actually treats the path as case-insensitive (assuming
+ * wrong here merges distinct repos).
+ */
+export const CASE_INSENSITIVE_PATH_HOSTS: ReadonlySet<string> = new Set(["github.com", "gitlab.com", "bitbucket.org"]);
+
+export function foldGitTransportToHttps(url: string): string {
+	const ssh = url.match(/^(?:git\+)?ssh:\/\/(?:[^@/]+@)?([^/:]+)(?::(\d+))?\/(.+)$/i);
+	if (ssh) return `https://${ssh[1]}${nonDefaultPortSegment(ssh[2], "22")}/${ssh[3]}`;
+	const git = url.match(/^git:\/\/([^/:]+)(?::(\d+))?\/(.+)$/i);
+	if (git) return `https://${git[1]}${nonDefaultPortSegment(git[2], "9418")}/${git[3]}`;
+	const scp = url.match(/^[^@/:]+@([^/:]+):(.+)$/);
+	if (scp) return `https://${scp[1]}/${scp[2]}`;
+	return url;
+}
+
+/** `:<port>` when present and not the scheme's default, else empty. */
+function nonDefaultPortSegment(port: string | undefined, schemeDefault: string): string {
+	if (port === undefined || port === schemeDefault) return "";
+	return `:${port}`;
 }
 
 function findAvailablePathAndClaim(parent: string, repoName: string, remoteUrl: string | null): string {

--- a/cli/src/core/KBRepoDiscoverer.test.ts
+++ b/cli/src/core/KBRepoDiscoverer.test.ts
@@ -86,6 +86,21 @@ describe("KBRepoDiscoverer.discoverRepos", () => {
 		expect(repos[0]?.isCurrentRepo).toBe(true);
 	});
 
+	it("matches current repo across SSH/https transports of the same remote", () => {
+		// Config persisted from an SSH clone, current checkout uses https
+		// (and vice versa). Without transport folding the discoverer called
+		// the current repo "foreign" even though KBPathResolver.isSameRepo
+		// reuses its folder — breaking current-repo highlighting and
+		// createReadStorageForCurrentRepo.
+		initializeKBFolder(join(parent, "sshstored"), "sshstored", "git@github.com:user/repo.git");
+		const fromHttps = discoverRepos(null, "https://github.com/user/repo.git", parent);
+		expect(fromHttps[0]?.isCurrentRepo).toBe(true);
+
+		initializeKBFolder(join(parent, "httpsstored"), "httpsstored", "https://github.com/other/thing.git");
+		const fromSsh = discoverRepos(null, "ssh://git@github.com:22/other/thing", parent);
+		expect(fromSsh.find((r) => r.repoName === "httpsstored")?.isCurrentRepo).toBe(true);
+	});
+
 	it("falls back to repoName when remote URL is missing on either side", () => {
 		initializeKBFolder(join(parent, "name-match"), "name-match", null);
 		initializeKBFolder(join(parent, "other"), "other", null);

--- a/cli/src/core/KBRepoDiscoverer.ts
+++ b/cli/src/core/KBRepoDiscoverer.ts
@@ -17,7 +17,7 @@
 import { readdirSync, readFileSync, statSync } from "node:fs";
 import { join } from "node:path";
 import { createLogger } from "../Logger.js";
-import { resolveKbParent } from "./KBPathResolver.js";
+import { foldGitTransportToHttps, resolveKbParent } from "./KBPathResolver.js";
 import type { KBConfig } from "./KBTypes.js";
 
 const log = createLogger("KBRepoDiscoverer");
@@ -112,7 +112,13 @@ function isCurrentRepo(
 }
 
 function normalizeUrl(url: string): string {
-	return url
+	// Fold SSH transports first so a config stored from an SSH clone still
+	// matches the https remote of the same repo (and vice versa) — otherwise
+	// `isCurrentRepo` calls the current repo "foreign" while
+	// `KBPathResolver.isSameRepo` (which folds) happily reuses its folder,
+	// breaking current-repo highlighting and `createReadStorageForCurrentRepo`.
+	// The whole-string lowercase below already covers path-case differences.
+	return foldGitTransportToHttps(url)
 		.replace(/\/+$/, "")
 		.replace(/\.git$/, "")
 		.toLowerCase();

--- a/cli/src/sync/RepoIdentity.test.ts
+++ b/cli/src/sync/RepoIdentity.test.ts
@@ -11,10 +11,12 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import * as kbResolver from "../core/KBPathResolver.js";
 import {
+	canonicalizeRepoIdentity,
 	computeRepoFolderName,
 	computeRepoIdentity,
 	decodeBranchFolderName,
 	encodeBranchFolderName,
+	repoIdentityFromConfig,
 } from "./RepoIdentity.js";
 
 let tempDir: string;
@@ -39,13 +41,25 @@ describe("computeRepoIdentity", () => {
 		expect(result.slug).toBe("bar");
 	});
 
-	it("falls back to basename(projectPath) when no remote is configured", () => {
+	it("falls back to extractRepoName when no remote is configured", () => {
 		vi.spyOn(kbResolver, "getRemoteUrl").mockReturnValue(null);
 		vi.spyOn(kbResolver, "extractRepoName").mockReturnValue("my-notes");
 
 		const result = computeRepoIdentity("/home/foo/my-notes");
 		expect(result.repoIdentity).toBe("my-notes");
 		expect(result.slug).toBe("my-notes");
+	});
+
+	it("uses extractRepoName (not basename) for remote-less worktrees, matching the persisted repoName", () => {
+		// A worktree's basename is the worktree dir name, but extractRepoName
+		// resolves to the main repo's name via git-common-dir — the same value
+		// `writeKBIdentity` persists, so live and scanned identities agree.
+		vi.spyOn(kbResolver, "getRemoteUrl").mockReturnValue(null);
+		vi.spyOn(kbResolver, "extractRepoName").mockReturnValue("main-repo");
+
+		const result = computeRepoIdentity("/home/foo/wt-feature");
+		expect(result.repoIdentity).toBe("main-repo");
+		expect(result.slug).toBe("main-repo");
 	});
 
 	it("strips https user-info from the remote URL", () => {
@@ -56,22 +70,84 @@ describe("computeRepoIdentity", () => {
 		expect(result.repoIdentity).toBe("https://github.com/foo/bar");
 	});
 
-	it("lowercases scheme and host but preserves path case", () => {
-		vi.spyOn(kbResolver, "getRemoteUrl").mockReturnValue("HTTPS://GITHUB.com/Foo/Bar");
+	it("lowercases scheme and host but preserves path case for self-hosted forges", () => {
+		vi.spyOn(kbResolver, "getRemoteUrl").mockReturnValue("HTTPS://GIT.corp.Example/Foo/Bar");
 		vi.spyOn(kbResolver, "extractRepoName").mockReturnValue("Bar");
 
 		const result = computeRepoIdentity("/x");
-		expect(result.repoIdentity).toBe("https://github.com/Foo/Bar");
+		expect(result.repoIdentity).toBe("https://git.corp.example/Foo/Bar");
 	});
 
-	it("leaves SCP-style URLs as-is (only schemed URLs are case-normalized)", () => {
-		// SCP form: `git@github.com:foo/bar.git`. We strip `.git` and trim,
-		// but `@` is not user-info so we don't touch it.
+	it("folds path case on known case-insensitive hosts (same repo, different typed casing)", () => {
+		// github.com routes owner/repo case-insensitively, so JolliAI/Jolli
+		// and jolliai/jolli are one repo — distinct identities would re-open
+		// the duplicate-row hazard on the casing axis. Same rule + host set
+		// as the server-facing canonicalizer in GitRemoteUtils.
+		vi.spyOn(kbResolver, "extractRepoName").mockReturnValue("Jolli");
+		const getRemoteUrl = vi.spyOn(kbResolver, "getRemoteUrl");
+
+		getRemoteUrl.mockReturnValue("https://github.com/JolliAI/Jolli.git");
+		expect(computeRepoIdentity("/x").repoIdentity).toBe("https://github.com/jolliai/jolli");
+
+		getRemoteUrl.mockReturnValue("git@github.com:JolliAI/Jolli.git");
+		expect(computeRepoIdentity("/x").repoIdentity).toBe("https://github.com/jolliai/jolli");
+	});
+
+	it("folds SCP-style URLs into the https form (same repo via SSH and https → one identity)", () => {
 		vi.spyOn(kbResolver, "getRemoteUrl").mockReturnValue("git@github.com:foo/bar.git");
 		vi.spyOn(kbResolver, "extractRepoName").mockReturnValue("bar");
 
 		const result = computeRepoIdentity("/x");
-		expect(result.repoIdentity).toBe("git@github.com:foo/bar");
+		expect(result.repoIdentity).toBe("https://github.com/foo/bar");
+	});
+
+	it("folds ssh:// URLs (user-info + port dropped) into the https form", () => {
+		vi.spyOn(kbResolver, "getRemoteUrl").mockReturnValue("ssh://git@github.com:22/foo/bar.git");
+		vi.spyOn(kbResolver, "extractRepoName").mockReturnValue("bar");
+
+		const result = computeRepoIdentity("/x");
+		expect(result.repoIdentity).toBe("https://github.com/foo/bar");
+	});
+
+	it("folds git:// and git+ssh:// URLs into the https form", () => {
+		vi.spyOn(kbResolver, "extractRepoName").mockReturnValue("bar");
+		const getRemoteUrl = vi.spyOn(kbResolver, "getRemoteUrl");
+
+		getRemoteUrl.mockReturnValue("git://github.com/foo/bar.git");
+		expect(computeRepoIdentity("/x").repoIdentity).toBe("https://github.com/foo/bar");
+
+		getRemoteUrl.mockReturnValue("git+ssh://git@github.com/foo/bar.git");
+		expect(computeRepoIdentity("/x").repoIdentity).toBe("https://github.com/foo/bar");
+	});
+
+	it("lowercases the host of a folded SCP URL but preserves path case on self-hosted forges", () => {
+		vi.spyOn(kbResolver, "getRemoteUrl").mockReturnValue("git@GIT.corp.Example:Foo/Bar.git");
+		vi.spyOn(kbResolver, "extractRepoName").mockReturnValue("Bar");
+
+		const result = computeRepoIdentity("/x");
+		expect(result.repoIdentity).toBe("https://git.corp.example/Foo/Bar");
+	});
+
+	it("preserves the absolute-path distinction when folding SCP URLs", () => {
+		vi.spyOn(kbResolver, "getRemoteUrl").mockReturnValue("git@host.example:/srv/repo");
+		vi.spyOn(kbResolver, "extractRepoName").mockReturnValue("repo");
+
+		expect(computeRepoIdentity("/x").repoIdentity).toBe("https://host.example//srv/repo");
+	});
+
+	it("does not fold non-SSH remotes that merely contain a colon", () => {
+		vi.spyOn(kbResolver, "extractRepoName").mockReturnValue("foo");
+		const getRemoteUrl = vi.spyOn(kbResolver, "getRemoteUrl");
+
+		// Windows drive path remote — not an SCP URL (no `user@`).
+		getRemoteUrl.mockReturnValue("C:/repos/foo.git");
+		expect(computeRepoIdentity("/x").repoIdentity).toBe("C:/repos/foo");
+
+		// Bare `host:path` without user-info: earlier releases never folded
+		// it either, and folding here but not in stored rows would split
+		// identities. Stays opaque.
+		getRemoteUrl.mockReturnValue("mygit.local:repos/foo");
+		expect(computeRepoIdentity("/x").repoIdentity).toBe("mygit.local:repos/foo");
 	});
 
 	it("slugifies the repo name (NFKD + lowercase + non-[a-z0-9-] → -)", () => {
@@ -88,6 +164,72 @@ describe("computeRepoIdentity", () => {
 
 		const result = computeRepoIdentity("/x");
 		expect(result.slug).toBe("repo");
+	});
+});
+
+describe("repoIdentityFromConfig", () => {
+	it("normalizes remoteUrl to the same key computeRepoIdentity produces", () => {
+		// Same normalization (strip .git, lower host) as the live-checkout path.
+		vi.spyOn(kbResolver, "getRemoteUrl").mockReturnValue("https://GitHub.com/jolliai/jolli.git");
+		vi.spyOn(kbResolver, "extractRepoName").mockReturnValue("jolli");
+		const live = computeRepoIdentity("/x").repoIdentity;
+
+		expect(repoIdentityFromConfig({ remoteUrl: "https://GitHub.com/jolliai/jolli.git" })).toBe(live);
+		expect(repoIdentityFromConfig({ remoteUrl: "https://github.com/jolliai/jolli" })).toBe(live);
+	});
+
+	it("folds scp-style URLs to the same https identity as the live-checkout normalizer", () => {
+		expect(repoIdentityFromConfig({ remoteUrl: "git@github.com:jolliai/jolli.git" })).toBe(
+			"https://github.com/jolliai/jolli",
+		);
+		// SSH-config and https-config of the same repo agree — the exact
+		// duplicate-row trigger in repos.json.
+		expect(repoIdentityFromConfig({ remoteUrl: "git@github.com:jolliai/jolli.git" })).toBe(
+			repoIdentityFromConfig({ remoteUrl: "https://github.com/jolliai/jolli" }),
+		);
+	});
+
+	it("falls back to repoName when there is no remoteUrl", () => {
+		expect(repoIdentityFromConfig({ repoName: "jolli" })).toBe("jolli");
+		expect(repoIdentityFromConfig({ remoteUrl: "   ", repoName: "jolli" })).toBe("jolli");
+	});
+
+	it("returns null when neither remoteUrl nor repoName is derivable", () => {
+		expect(repoIdentityFromConfig({})).toBeNull();
+		expect(repoIdentityFromConfig({ remoteUrl: "  ", repoName: "  " })).toBeNull();
+	});
+});
+
+describe("canonicalizeRepoIdentity", () => {
+	it("folds a persisted SCP-style identity to the https form", () => {
+		expect(canonicalizeRepoIdentity("git@github.com:jolliai/jolli")).toBe("https://github.com/jolliai/jolli");
+	});
+
+	it("leaves an already-canonical https identity unchanged", () => {
+		expect(canonicalizeRepoIdentity("https://github.com/jolliai/jolli")).toBe("https://github.com/jolliai/jolli");
+	});
+
+	it("passes bare fallback identities through, even ones containing a colon", () => {
+		// Name-fallback identities never went through URL normalization at
+		// compute time, so re-normalizing a stored row must not invent a
+		// fake https URL out of a folder name.
+		expect(canonicalizeRepoIdentity("my-notes")).toBe("my-notes");
+		expect(canonicalizeRepoIdentity("notes:personal")).toBe("notes:personal");
+	});
+
+	it("does not strip .git from a bare fallback identity (only URL/SCP forms are normalized)", () => {
+		// A remote-less repo whose directory is literally named `foo.git`
+		// computes identity `foo.git`. An un-gated normalizer would rewrite
+		// the stored row to `foo`, desyncing it from the live value AND
+		// colliding it with a genuinely distinct repo named `foo`.
+		expect(canonicalizeRepoIdentity("foo.git")).toBe("foo.git");
+		// URL forms still normalize as before.
+		expect(canonicalizeRepoIdentity("https://github.com/a/foo.git")).toBe("https://github.com/a/foo");
+	});
+
+	it("preserves a non-default ssh port (self-hosted forges stay distinct)", () => {
+		expect(canonicalizeRepoIdentity("ssh://git@host.example:2222/a/b.git")).toBe("https://host.example:2222/a/b");
+		expect(canonicalizeRepoIdentity("ssh://git@host.example:22/a/b.git")).toBe("https://host.example/a/b");
 	});
 });
 

--- a/cli/src/sync/RepoIdentity.ts
+++ b/cli/src/sync/RepoIdentity.ts
@@ -18,23 +18,57 @@
  */
 
 import { createHash } from "node:crypto";
-import { basename } from "node:path";
-import { extractRepoName, getRemoteUrl } from "../core/KBPathResolver.js";
+import {
+	CASE_INSENSITIVE_PATH_HOSTS,
+	extractRepoName,
+	foldGitTransportToHttps,
+	getRemoteUrl,
+} from "../core/KBPathResolver.js";
 import type { RepoIdentity } from "./SyncTypes.js";
 
 /**
  * Computes a source-repo's identity from its working tree path.
  *
- * Fallback chain per source plan §2.2:
+ * Fallback chain:
  *
  *   1. `git remote get-url origin` → normalized URL
- *   2. `basename(projectPath)` — only when no remote is configured
+ *   2. `extractRepoName(projectPath)` — only when no remote is configured.
+ *      NOT `basename(projectPath)` (the original §2.2 wording): for a git
+ *      worktree of a remote-less repo, basename is the worktree dir name
+ *      while `extractRepoName` resolves to the MAIN repo's name via
+ *      git-common-dir — which is also what `writeKBIdentity` persists as
+ *      `repoName` in the folder config. Using basename made the live round
+ *      and `repoIdentityFromConfig` derive two different identities for the
+ *      same repo, so reconcile added a second row and the same folder got a
+ *      persistent bogus collision warning. For a normal (non-worktree)
+ *      checkout the two agree, so this is worktree-only behavior.
  */
 export function computeRepoIdentity(projectPath: string): RepoIdentity {
 	const remote = getRemoteUrl(projectPath);
-	const repoIdentity = remote ? normalizeGitUrl(remote) : basename(projectPath);
 	const name = extractRepoName(projectPath);
+	const repoIdentity = remote ? normalizeGitUrl(remote) : name;
 	return { repoIdentity, slug: slugify(name) };
+}
+
+/**
+ * Derives the same `repoIdentity` that `computeRepoIdentity` would produce, but
+ * from an already-persisted `<folder>/.jolli/config.json` identity instead of a
+ * live git checkout. Used by the `repos.json` reconcile pass to map an on-disk
+ * Memory Bank folder back to its repo identity without re-running git.
+ *
+ * Mirrors `computeRepoIdentity`'s fallback chain: a `remoteUrl` normalizes to
+ * the canonical key; otherwise `repoName` stands in for the live
+ * `extractRepoName(projectPath)` value — both come from the same helper
+ * (`writeKBIdentity` persists `extractRepoName`'s result), so the two agree
+ * even for git worktrees. Returns `null` when the config carries neither —
+ * the caller skips such folders rather than inventing a key.
+ */
+export function repoIdentityFromConfig(config: { remoteUrl?: string; repoName?: string }): string | null {
+	const remote = config.remoteUrl?.trim();
+	if (remote) return normalizeGitUrl(remote);
+	const name = config.repoName?.trim();
+	if (name) return name;
+	return null;
 }
 
 /**
@@ -88,27 +122,73 @@ export function decodeBranchFolderName(folder: string): string {
 	return folder.replace(/\^/g, "/");
 }
 
+/** Scheme-prefixed remote (`https://…`, `ssh://…`, `git://…`, `file://…`). */
+const URL_LIKE_RE = /^[A-Za-z][A-Za-z0-9+.-]*:\/\//;
+/** SCP-style remote (`user@host:path`) — the only scheme-less URL form git accepts. */
+const SCP_LIKE_RE = /^[^@/:]+@[^/:]+:.+$/;
+
 /**
- * Normalizes a git remote URL so trivial variations (trailing slash, `.git`
- * suffix, https user-info, host case) collapse to the same identity. Path
- * case is preserved because case-sensitive filesystems do exist on Linux
- * and a path-rename should produce a new vault subdirectory, not silently
- * reuse the old one.
+ * Re-normalizes an already-persisted `repoIdentity` string through the same
+ * normalizer `computeRepoIdentity` uses. Rows written by clients that
+ * predate SSH→https transport folding carry the SCP form
+ * (`git@github.com:owner/repo`); folding them lets `RepoMapping` collapse
+ * the style-duplicates those clients left behind.
+ *
+ * Normalization is GATED to identities that are recognizably remote URLs
+ * (scheme-prefixed or SCP-style). Bare fallback identities — folder/repo
+ * names from the no-remote path — never went through `normalizeGitUrl` at
+ * compute time, so re-normalizing them here would desynchronize the stored
+ * row from the live value: a remote-less repo named `foo.git` computes
+ * identity `foo.git`, but the un-gated normalizer would strip the suffix
+ * and rewrite the row to `foo` (re-adding a duplicate every round, and
+ * collapsing it with a genuinely distinct repo named `foo`).
+ */
+export function canonicalizeRepoIdentity(identity: string): string {
+	if (!URL_LIKE_RE.test(identity) && !SCP_LIKE_RE.test(identity)) return identity;
+	return normalizeGitUrl(identity);
+}
+
+/**
+ * Normalizes a git remote URL so variations that don't change which repo is
+ * meant collapse to the same identity: trailing slash, `.git` suffix, https
+ * user-info, host case, and — critically — the SSH transport forms
+ * (`git@host:path`, `ssh://…`, `git://…`), which fold into the equivalent
+ * https form. The same repo reached via SSH on one device and https on
+ * another MUST produce one identity: distinct strings mean duplicate
+ * `repos.json` rows that the identity-keyed dedupe in
+ * `resolveOrAssignFolder` / `mergeRepoMapping` / `reconcileMappingAdditive`
+ * cannot see through, and the duplicates then claim the same folder and
+ * trip `findRepoMappingConflicts`' cross-repo collision warning.
+ *
+ * Path case is folded ONLY for hosts known to route owner/repo
+ * case-insensitively (`CASE_INSENSITIVE_PATH_HOSTS` — github.com etc., the
+ * same set and rule as the server-facing canonicalizer in
+ * `vscode/src/util/GitRemoteUtils.ts`): `JolliAI/Jolli` and `jolliai/jolli`
+ * are one repo there, and distinct identities re-open the duplicate-row
+ * hazard on the casing axis. For every other host path case is preserved —
+ * self-hosted forges may be case-sensitive, and a path-rename should
+ * produce a new vault subdirectory, not silently reuse the old one.
  */
 function normalizeGitUrl(url: string): string {
-	let trimmed = url.trim();
+	// Transport folding is shared with `KBPathResolver.isSameRepo` so the
+	// vault identity and the local folder-reuse predicate agree on "same
+	// repo" across SSH/https clones.
+	let trimmed = foldGitTransportToHttps(url.trim());
 	// Strip user-info from https URLs: `https://user:pass@host/...` → `https://host/...`
 	trimmed = trimmed.replace(/^(https?:\/\/)[^@/]+@/i, "$1");
 	// Strip trailing `.git` and any trailing slashes.
 	trimmed = trimmed.replace(/\.git\/*$/i, "");
 	trimmed = trimmed.replace(/\/+$/, "");
-	// Lowercase scheme + host. SCP-style `git@host:owner/repo` URLs aren't
-	// rewritten — the `@` is a valid separator, not user-info, and rewriting
-	// would lose info.
+	// Lowercase scheme + host (also covers the host of a just-folded SSH form).
 	trimmed = trimmed.replace(
 		/^([A-Za-z+]+:\/\/)([^/]+)/,
 		(_, scheme: string, host: string) => `${scheme.toLowerCase()}${host.toLowerCase()}`,
 	);
+	// Lowercase the path too — but only for known case-insensitive hosts.
+	const parts = trimmed.match(/^(https?:\/\/)([^/]+)(\/.*)$/);
+	if (parts && CASE_INSENSITIVE_PATH_HOSTS.has((parts[2] ?? "").split(":")[0] ?? "")) {
+		trimmed = `${parts[1]}${parts[2]}${(parts[3] ?? "").toLowerCase()}`;
+	}
 	return trimmed;
 }
 

--- a/cli/src/sync/RepoMapping.test.ts
+++ b/cli/src/sync/RepoMapping.test.ts
@@ -7,6 +7,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
+	canonicalizeRepoMapping,
 	emptyMapping,
 	findRepoMappingConflicts,
 	loadRepoMapping,
@@ -14,8 +15,10 @@ import {
 	parseRepoMapping,
 	REPO_MAPPING_PATH,
 	type RepoMappingFile,
+	reconcileMappingAdditive,
 	resolveOrAssignFolder,
 	saveRepoMapping,
+	scanFolderIdentities,
 	serializeRepoMapping,
 } from "./RepoMapping.js";
 
@@ -177,6 +180,80 @@ describe("resolveOrAssignFolder", () => {
 	});
 });
 
+describe("canonicalizeRepoMapping", () => {
+	it("returns the same object with changed=false when every row is already canonical", () => {
+		const mapping: RepoMappingFile = {
+			version: 1,
+			mappings: [
+				{ repoIdentity: "https://github.com/jolliai/jolli", folder: "jolli" },
+				{ repoIdentity: "my-notes", folder: "my-notes" },
+				// Bare fallback identity ending in `.git` — must NOT be
+				// rewritten to `foo` (it never went through the URL
+				// normalizer at compute time).
+				{ repoIdentity: "foo.git", folder: "foo.git" },
+			],
+		};
+		const result = canonicalizeRepoMapping(mapping);
+		expect(result.changed).toBe(false);
+		expect(result.merged).toBe(mapping);
+	});
+
+	it("collapses SSH- and https-style rows of the same repo into one canonical row", () => {
+		// The exact duplicate observed in the field: one device's remote was
+		// SSH, another's https, both rounds appended their own row for the
+		// same repo + folder.
+		const mapping: RepoMappingFile = {
+			version: 1,
+			mappings: [
+				{ repoIdentity: "git@github.com:jolliai/jolli", folder: "jolli" },
+				{ repoIdentity: "https://github.com/jolliai/jolli", folder: "jolli" },
+			],
+		};
+		const result = canonicalizeRepoMapping(mapping);
+		expect(result.changed).toBe(true);
+		expect(result.merged.mappings).toEqual([{ repoIdentity: "https://github.com/jolliai/jolli", folder: "jolli" }]);
+		// The collapse also removes the bogus folder-collision warning.
+		expect(findRepoMappingConflicts(result.merged)).toHaveLength(0);
+	});
+
+	it("rewrites a lone legacy SSH row in place (changed=true)", () => {
+		const mapping: RepoMappingFile = {
+			version: 1,
+			mappings: [{ repoIdentity: "git@github.com:foo/bar", folder: "bar" }],
+		};
+		const result = canonicalizeRepoMapping(mapping);
+		expect(result.changed).toBe(true);
+		expect(result.merged.mappings).toEqual([{ repoIdentity: "https://github.com/foo/bar", folder: "bar" }]);
+	});
+
+	it("lets the later row win when collapsing rows that disagree on folder", () => {
+		const mapping: RepoMappingFile = {
+			version: 1,
+			mappings: [
+				{ repoIdentity: "git@github.com:foo/bar", folder: "bar" },
+				{ repoIdentity: "https://github.com/foo/bar", folder: "bar-2" },
+			],
+		};
+		const result = canonicalizeRepoMapping(mapping);
+		expect(result.merged.mappings).toEqual([{ repoIdentity: "https://github.com/foo/bar", folder: "bar-2" }]);
+	});
+
+	it("emits stable order (sorted by canonical repoIdentity)", () => {
+		const mapping: RepoMappingFile = {
+			version: 1,
+			mappings: [
+				{ repoIdentity: "https://github.com/z/z", folder: "z" },
+				{ repoIdentity: "git@github.com:a/a", folder: "a" },
+			],
+		};
+		const result = canonicalizeRepoMapping(mapping);
+		expect(result.merged.mappings.map((m) => m.repoIdentity)).toEqual([
+			"https://github.com/a/a",
+			"https://github.com/z/z",
+		]);
+	});
+});
+
 describe("mergeRepoMapping", () => {
 	it("returns the union when repoIdentities are disjoint", () => {
 		const local: RepoMappingFile = {
@@ -248,6 +325,20 @@ describe("mergeRepoMapping", () => {
 		expect(merged.mappings.map((m) => m.repoIdentity)).toEqual(["a", "b", "c"]);
 	});
 
+	it("folds an SSH-style row from an older client into this client's https row for the same repo", () => {
+		const local: RepoMappingFile = {
+			version: 1,
+			mappings: [{ repoIdentity: "https://github.com/jolliai/jolli", folder: "jolli" }],
+		};
+		const remote: RepoMappingFile = {
+			version: 1,
+			mappings: [{ repoIdentity: "git@github.com:jolliai/jolli", folder: "jolli" }],
+		};
+		const { merged, conflicts } = mergeRepoMapping(local, remote);
+		expect(merged.mappings).toEqual([{ repoIdentity: "https://github.com/jolliai/jolli", folder: "jolli" }]);
+		expect(conflicts).toHaveLength(0);
+	});
+
 	it("is idempotent — merging identical inputs returns the same shape and no conflicts", () => {
 		const m: RepoMappingFile = {
 			version: 1,
@@ -288,5 +379,122 @@ describe("findRepoMappingConflicts", () => {
 			folder: "shared",
 			identities: ["alpha", "beta"],
 		});
+	});
+});
+
+describe("scanFolderIdentities", () => {
+	async function writeFolder(name: string, config: Record<string, unknown> | null): Promise<void> {
+		const dir = join(tempDir, name, ".jolli");
+		await mkdir(dir, { recursive: true });
+		if (config !== null) {
+			await writeFile(join(dir, "config.json"), JSON.stringify(config));
+		}
+	}
+
+	it("derives identity per folder from its config, skipping dot dirs and config-less folders", async () => {
+		await writeFolder("jolliai", { remoteUrl: "https://github.com/jolliai/jolliai.git", repoName: "jolliai" });
+		await writeFolder("jolli", { remoteUrl: "git@github.com:jolliai/jolli.git", repoName: "jolli" });
+		// `.jolli` (vault metadata) and a bootstrap stash must be ignored.
+		await mkdir(join(tempDir, ".jolli"), { recursive: true });
+		await mkdir(join(tempDir, ".jolli-bootstrap-stash", ".jolli"), { recursive: true });
+		// A folder with no config.json is not a managed repo folder.
+		await mkdir(join(tempDir, "loose", ".jolli"), { recursive: true });
+		// A plain file at the root must be ignored (not a directory).
+		await writeFile(join(tempDir, "README.md"), "# vault");
+
+		const scanned = await scanFolderIdentities(tempDir);
+		expect(scanned.sort((a, b) => a.folder.localeCompare(b.folder))).toEqual([
+			// SCP-style config remoteUrl folds to the same https identity the
+			// live round computes, so the reconcile can't re-add style duplicates.
+			{ identity: "https://github.com/jolliai/jolli", folder: "jolli" },
+			{ identity: "https://github.com/jolliai/jolliai", folder: "jolliai" },
+		]);
+	});
+
+	it("falls back to repoName, and skips identity-less / unparseable configs", async () => {
+		await writeFolder("local-only", { repoName: "local-only" });
+		await writeFolder("stripped", { version: 1, sortOrder: "date" });
+		await writeFolder("broken", null);
+		await mkdir(join(tempDir, "broken", ".jolli"), { recursive: true });
+		await writeFile(join(tempDir, "broken", ".jolli", "config.json"), "{ not json");
+
+		const scanned = await scanFolderIdentities(tempDir);
+		expect(scanned).toEqual([{ identity: "local-only", folder: "local-only" }]);
+	});
+
+	it("returns [] when the root cannot be read", async () => {
+		expect(await scanFolderIdentities(join(tempDir, "does-not-exist"))).toEqual([]);
+	});
+});
+
+describe("reconcileMappingAdditive", () => {
+	it("adds a missing on-disk folder while preserving existing rows", () => {
+		// mb_test shape: repos.json has only jolliai, but jolli exists on disk.
+		const loaded: RepoMappingFile = {
+			version: 1,
+			mappings: [{ repoIdentity: "https://github.com/jolliai/jolliai", folder: "jolliai" }],
+		};
+		const { merged, changed } = reconcileMappingAdditive(loaded, [
+			{ identity: "https://github.com/jolliai/jolliai", folder: "jolliai" },
+			{ identity: "git@github.com:jolliai/jolli", folder: "jolli" },
+		]);
+		expect(changed).toBe(true);
+		expect(merged.mappings).toEqual([
+			{ repoIdentity: "git@github.com:jolliai/jolli", folder: "jolli" },
+			{ repoIdentity: "https://github.com/jolliai/jolliai", folder: "jolliai" },
+		]);
+	});
+
+	it("is idempotent — a second pass over the same disk is a no-op", () => {
+		const loaded: RepoMappingFile = {
+			version: 1,
+			mappings: [
+				{ repoIdentity: "git@github.com:jolliai/jolli", folder: "jolli" },
+				{ repoIdentity: "https://github.com/jolliai/jolliai", folder: "jolliai" },
+			],
+		};
+		const result = reconcileMappingAdditive(loaded, [
+			{ identity: "https://github.com/jolliai/jolliai", folder: "jolliai" },
+			{ identity: "git@github.com:jolliai/jolli", folder: "jolli" },
+		]);
+		expect(result.changed).toBe(false);
+		expect(result.merged).toBe(loaded);
+	});
+
+	it("never deletes a row whose folder is absent on this device", () => {
+		// repos.json carries a peer's repo; this device has only jolliai locally.
+		const loaded: RepoMappingFile = {
+			version: 1,
+			mappings: [
+				{ repoIdentity: "https://github.com/jolliai/jolliai", folder: "jolliai" },
+				{ repoIdentity: "https://github.com/peer/only", folder: "peer-only" },
+			],
+		};
+		const { merged, changed } = reconcileMappingAdditive(loaded, [
+			{ identity: "https://github.com/jolliai/jolliai", folder: "jolliai" },
+		]);
+		expect(changed).toBe(false);
+		expect(merged.mappings.map((m) => m.repoIdentity)).toContain("https://github.com/peer/only");
+	});
+
+	it("skips an identity backed by more than one local folder (migrate-to-fresh case)", () => {
+		// Old + new folders share one remoteUrl → one identity. Guessing a row
+		// could point repos.json at the stale folder; defer to the per-repo path.
+		const { merged, changed } = reconcileMappingAdditive(emptyMapping(), [
+			{ identity: "https://github.com/jolliai/jolli", folder: "jolli" },
+			{ identity: "https://github.com/jolliai/jolli", folder: "jolli-2" },
+		]);
+		expect(changed).toBe(false);
+		expect(merged.mappings).toEqual([]);
+	});
+
+	it("adds a single-folder identity even when another identity is ambiguous", () => {
+		const { merged, changed } = reconcileMappingAdditive(emptyMapping(), [
+			{ identity: "dup", folder: "a" },
+			{ identity: "dup", folder: "a-2" },
+			{ identity: "unique", folder: "u" },
+		]);
+		expect(changed).toBe(true);
+		expect(merged.mappings).toEqual([{ repoIdentity: "unique", folder: "u" }]);
 	});
 });

--- a/cli/src/sync/RepoMapping.ts
+++ b/cli/src/sync/RepoMapping.ts
@@ -28,8 +28,10 @@
  *      notification in VS Code) for manual disambiguation (P2#3).
  */
 
-import { mkdir, readFile, writeFile } from "node:fs/promises";
+import type { Dirent } from "node:fs";
+import { mkdir, readdir, readFile, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
+import { canonicalizeRepoIdentity, repoIdentityFromConfig } from "./RepoIdentity.js";
 
 /** A single `repoIdentity → folder` mapping row. */
 export interface RepoMappingEntry {
@@ -89,6 +91,42 @@ export function parseRepoMapping(raw: string): RepoMappingFile | null {
 /** Serializes to the canonical 2-space-indented JSON + trailing newline. */
 export function serializeRepoMapping(mapping: RepoMappingFile): string {
 	return `${JSON.stringify(mapping, null, 2)}\n`;
+}
+
+/**
+ * Re-normalizes every row's `repoIdentity` through `canonicalizeRepoIdentity`
+ * and collapses rows that fold to the same identity. Heals files written
+ * before SSH→https transport folding: the same repo reached via
+ * `git@github.com:owner/repo` on one device and `https://github.com/owner/repo`
+ * on another got two rows, typically both claiming the same folder — which
+ * `findRepoMappingConflicts` then mis-reported as a cross-repo folder
+ * collision. When collapsing rows disagree on `folder`, the later row in
+ * file order wins — arbitrary but deterministic, and the affected repo's
+ * own sync round rewrites the row to the authoritative `KBPathResolver`
+ * pick on its next pass anyway (`resolveOrAssignFolder` case 3).
+ *
+ * Returns the original `mapping` object with `changed: false` when every
+ * row was already canonical, so callers can skip the persist (and the
+ * commit/push) on steady-state rounds.
+ */
+export function canonicalizeRepoMapping(mapping: RepoMappingFile): {
+	readonly merged: RepoMappingFile;
+	readonly changed: boolean;
+} {
+	const byIdentity = new Map<string, RepoMappingEntry>();
+	let changed = false;
+	for (const m of mapping.mappings) {
+		const identity = canonicalizeRepoIdentity(m.repoIdentity);
+		if (identity !== m.repoIdentity || byIdentity.has(identity)) changed = true;
+		byIdentity.set(identity, identity === m.repoIdentity ? m : { repoIdentity: identity, folder: m.folder });
+	}
+	if (!changed) return { merged: mapping, changed: false };
+	/* v8 ignore start -- comparator equal-branch (`: 0`) is unreachable: `byIdentity` keys are unique canonical identities */
+	const mappings = [...byIdentity.values()].sort((a, b) =>
+		a.repoIdentity < b.repoIdentity ? -1 : a.repoIdentity > b.repoIdentity ? 1 : 0,
+	);
+	/* v8 ignore stop */
+	return { merged: { version: 1, mappings }, changed: true };
 }
 
 /**
@@ -186,15 +224,22 @@ export interface RepoMappingConflict {
  * Cross-device first-bind races on the same `<slug>` (e.g. `alice/foo`
  * vs `bob/foo` on different hosts) are the typical trigger; rare in
  * practice and the warning + manual fix is acceptable.
+ *
+ * Rows from both sides are canonicalized (`canonicalizeRepoIdentity`) as
+ * they enter the union, so an SSH-style row pushed by an older client
+ * folds into this client's https-style row for the same repo instead of
+ * surviving the merge as a duplicate.
  */
 export function mergeRepoMapping(
 	local: RepoMappingFile,
 	remote: RepoMappingFile,
 ): { readonly merged: RepoMappingFile; readonly conflicts: ReadonlyArray<RepoMappingConflict> } {
-	// First pass: union by repoIdentity (last-write-wins; remote overrides).
+	// First pass: union by canonical repoIdentity (last-write-wins; remote overrides).
 	const byIdentity = new Map<string, RepoMappingEntry>();
-	for (const m of local.mappings) byIdentity.set(m.repoIdentity, m);
-	for (const m of remote.mappings) byIdentity.set(m.repoIdentity, m);
+	for (const m of [...local.mappings, ...remote.mappings]) {
+		const identity = canonicalizeRepoIdentity(m.repoIdentity);
+		byIdentity.set(identity, identity === m.repoIdentity ? m : { repoIdentity: identity, folder: m.folder });
+	}
 
 	// Second pass: detect folder collisions across different identities.
 	// Report each colliding folder once; entries themselves are left
@@ -258,4 +303,114 @@ export async function saveRepoMapping(memoryBankRoot: string, mapping: RepoMappi
 	const path = join(memoryBankRoot, REPO_MAPPING_PATH);
 	await mkdir(dirname(path), { recursive: true });
 	await writeFile(path, serializeRepoMapping(mapping));
+}
+
+/** One on-disk Memory Bank repo folder paired with the identity its config carries. */
+export interface ScannedFolderIdentity {
+	readonly identity: string;
+	readonly folder: string;
+}
+
+/**
+ * Scans `<memoryBankRoot>` for repo folders and derives each one's
+ * `repoIdentity` from its persisted `<folder>/.jolli/config.json`.
+ *
+ * Used by the reconcile pass (`reconcileMappingAdditive`) so `repos.json` can
+ * be brought in line with the folders that actually exist on disk — the live
+ * sync round only ever writes the row for the repo it is syncing, so a folder
+ * whose own first-bind round never reached the mapping-write step stays absent
+ * from `repos.json` indefinitely.
+ *
+ * Skips:
+ *   - non-directories
+ *   - dot-prefixed entries (`.jolli`, `.git`, `.jolli-bootstrap-stash`, …)
+ *   - folders with no readable / parseable `config.json`
+ *   - folders whose config carries no derivable identity (neither `remoteUrl`
+ *     nor `repoName` — e.g. an identity-stripped archive stub)
+ *
+ * Returns an empty list (never throws) when `memoryBankRoot` can't be read.
+ */
+export async function scanFolderIdentities(memoryBankRoot: string): Promise<ScannedFolderIdentity[]> {
+	let entries: Dirent[];
+	try {
+		entries = await readdir(memoryBankRoot, { withFileTypes: true });
+	} catch {
+		return [];
+	}
+	const out: ScannedFolderIdentity[] = [];
+	for (const entry of entries) {
+		if (!entry.isDirectory()) continue;
+		if (entry.name.startsWith(".")) continue;
+		const configPath = join(memoryBankRoot, entry.name, ".jolli", "config.json");
+		let raw: string;
+		try {
+			raw = await readFile(configPath, "utf-8");
+		} catch {
+			continue;
+		}
+		let parsed: { remoteUrl?: unknown; repoName?: unknown };
+		try {
+			parsed = JSON.parse(raw);
+		} catch {
+			continue;
+		}
+		const identity = repoIdentityFromConfig({
+			remoteUrl: typeof parsed.remoteUrl === "string" ? parsed.remoteUrl : undefined,
+			repoName: typeof parsed.repoName === "string" ? parsed.repoName : undefined,
+		});
+		if (identity === null) continue;
+		out.push({ identity, folder: entry.name });
+	}
+	return out;
+}
+
+/**
+ * Brings `mapping` in line with the on-disk folders reported by
+ * `scanFolderIdentities` — **additively**:
+ *
+ *   - Adds a row for every scanned identity that isn't already mapped.
+ *   - **Never removes** an existing row. `repos.json` is shared across devices
+ *     and clones via git, so a row pointing at a folder absent on THIS device
+ *     may belong to a peer — dropping it would corrupt the shared index.
+ *   - **Skips identities backed by more than one local folder.** The
+ *     migrate-to-fresh-folder flow leaves the old and new `<repo>` /
+ *     `<repo>-N` folders sharing one `remoteUrl` (hence one identity); guessing
+ *     a row here could point `repos.json` at the stale folder while
+ *     FolderStorage writes the new one — the exact mapping↔disk split that
+ *     `resolveOrAssignFolder` (with the authoritative `KBPathResolver` pick)
+ *     avoids. Those repos are left to their own round's authoritative path.
+ *
+ * Returns `{ merged, changed: false }` with the original mapping object when
+ * nothing was added, so callers can skip the write (and the commit/push) on the
+ * steady-state no-op rounds.
+ */
+export function reconcileMappingAdditive(
+	mapping: RepoMappingFile,
+	scanned: ReadonlyArray<ScannedFolderIdentity>,
+): { readonly merged: RepoMappingFile; readonly changed: boolean } {
+	const folderCountByIdentity = new Map<string, number>();
+	for (const s of scanned) {
+		folderCountByIdentity.set(s.identity, (folderCountByIdentity.get(s.identity) ?? 0) + 1);
+	}
+	const ambiguous = new Set<string>();
+	for (const [identity, count] of folderCountByIdentity) {
+		if (count > 1) ambiguous.add(identity);
+	}
+	const present = new Set(mapping.mappings.map((m) => m.repoIdentity));
+	const additions: RepoMappingEntry[] = [];
+	for (const s of scanned) {
+		if (present.has(s.identity)) continue;
+		if (ambiguous.has(s.identity)) continue;
+		additions.push({ repoIdentity: s.identity, folder: s.folder });
+		// Treat as present so a duplicate scan entry (same identity, ruled in
+		// above) can't add the row twice.
+		present.add(s.identity);
+	}
+	if (additions.length === 0) return { merged: mapping, changed: false };
+	/* v8 ignore start -- comparator equal-branch (`: 0`) is unreachable: rows are deduped by repoIdentity above */
+	const mappings = [...mapping.mappings, ...additions].sort((a, b) =>
+		a.repoIdentity < b.repoIdentity ? -1 : a.repoIdentity > b.repoIdentity ? 1 : 0,
+	);
+	/* v8 ignore stop */
+	return { merged: { version: 1, mappings }, changed: true };
 }

--- a/cli/src/sync/SyncEngine.ts
+++ b/cli/src/sync/SyncEngine.ts
@@ -69,11 +69,14 @@ import { LegacyMigration } from "./LegacyMigration.js";
 import { isPerDeviceJsonPath, MemoryBankBootstrap } from "./MemoryBankBootstrap.js";
 import { clearPendingLock, readPendingLock, writePendingLock } from "./PendingLockStore.js";
 import {
+	canonicalizeRepoMapping,
 	findRepoMappingConflicts,
 	loadRepoMapping,
 	type RepoMappingConflict,
+	reconcileMappingAdditive,
 	resolveOrAssignFolder,
 	saveRepoMapping,
+	scanFolderIdentities,
 } from "./RepoMapping.js";
 import { stageVault } from "./StageVault.js";
 import { acquireSyncLock, refreshSyncLockMtime, releaseSyncLock } from "./SyncLock.js";
@@ -1072,7 +1075,23 @@ export class SyncEngine {
 		// merge step (`mergeRepoMappingDoc`) does the detection, this
 		// path catches both the freshly-merged file AND any stale
 		// collisions left over from before P2#3 landed.
-		const mapping = await loadRepoMapping(ctx.memoryBankRoot);
+		// Reconcile `repos.json` with the repo folders actually on disk BEFORE
+		// resolving this round's repo. Each round otherwise only writes its own
+		// repo's row, so a folder whose first-bind round never reached this step
+		// (e.g. an older client whose migration deadlocked before the mapping
+		// write) stays missing from `repos.json` forever — and no other repo's
+		// round will ever add it back. The reconcile is additive only (never
+		// deletes a cross-device/-clone row) and skips identities backed by >1
+		// local folder (deferred to the authoritative per-repo path below).
+		//
+		// Canonicalize first: rows written before SSH→https transport folding
+		// carry the SCP-style identity, and the live identity (already
+		// canonical) would not match them — the same repo would get a second
+		// row and a bogus folder-collision warning below.
+		const loadedMapping = await loadRepoMapping(ctx.memoryBankRoot);
+		const canon = canonicalizeRepoMapping(loadedMapping);
+		const reconcile = reconcileMappingAdditive(canon.merged, await scanFolderIdentities(ctx.memoryBankRoot));
+		const mapping = reconcile.merged;
 		const mappingConflicts = findRepoMappingConflicts(mapping);
 		if (mappingConflicts.length > 0) {
 			for (const c of mappingConflicts) {
@@ -1094,16 +1113,24 @@ export class SyncEngine {
 			authoritativeFolder: ctx.repoFolderName,
 		});
 		const effectiveCtx: RoundContext = { ...ctx, repoFolderName: resolved.folder };
-		if (resolved.updatedMapping !== null) {
-			await saveRepoMapping(effectiveCtx.memoryBankRoot, resolved.updatedMapping);
-			// One log line covers both "new mapping" and "rewrote diverged
-			// mapping" — the engine doesn't care which one happened, only
-			// that `repos.json` is now consistent with disk.
+		// Persist when the canonicalize pass collapsed legacy rows, the
+		// reconcile added on-disk folders, OR `resolveOrAssignFolder` changed
+		// this round's repo. `resolved` already carries the
+		// canonicalized+reconciled mapping (it was fed `mapping`), so its
+		// `updatedMapping` supersedes the earlier results when non-null.
+		if (canon.changed || reconcile.changed || resolved.updatedMapping !== null) {
+			await saveRepoMapping(effectiveCtx.memoryBankRoot, resolved.updatedMapping ?? mapping);
+			// One log line covers "new mapping", "rewrote diverged mapping",
+			// "collapsed legacy duplicate rows", and "reconciled missing
+			// on-disk folders" — the engine doesn't care which one happened,
+			// only that `repos.json` is now consistent with disk.
 			log.info(
-				"repos.json: persisted folder=%s for repoIdentity=%s (authoritative=%s)",
+				"repos.json: persisted folder=%s for repoIdentity=%s (authoritative=%s, canonicalized=%s, reconciled=%s)",
 				resolved.folder,
 				ctx.repoIdentity,
 				ctx.repoFolderName,
+				canon.changed,
+				reconcile.changed,
 			);
 		}
 

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/core/KBPathResolver.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/core/KBPathResolver.kt
@@ -144,9 +144,54 @@ object KBPathResolver {
         return false
     }
 
-    /** Normalizes a git remote URL for comparison (strips .git suffix, trailing slash). */
+    /**
+     * Normalizes a git remote URL for comparison: folds SSH transports into
+     * the https form, then strips trailing slashes + `.git` and lowercases.
+     */
     private fun normalizeRemoteUrl(url: String): String {
-        return url.trimEnd('/').removeSuffix(".git").lowercase()
+        return foldGitTransportToHttps(url).trimEnd('/').removeSuffix(".git").lowercase()
+    }
+
+    private val SSH_URL_REGEX = Regex("^(?:git\\+)?ssh://(?:[^@/]+@)?([^/:]+)(?::(\\d+))?/(.+)$", RegexOption.IGNORE_CASE)
+    private val GIT_URL_REGEX = Regex("^git://([^/:]+)(?::(\\d+))?/(.+)$", RegexOption.IGNORE_CASE)
+    private val SCP_URL_REGEX = Regex("^[^@/:]+@([^/:]+):(.+)$")
+
+    /**
+     * Folds the SSH transport forms of a git remote URL into the https form so
+     * all transports of the same repo compare equal — `git@host:owner/repo`,
+     * `ssh://[user@]host[:port]/owner/repo`, `git://host/owner/repo` and
+     * `https://host/owner/repo` are the same repo, and treating them as
+     * different splits the Memory Bank into `<repo>` / `<repo>-2` folders when
+     * the user switches clone transport.
+     *
+     * The SCP form requires the `user@` prefix on purpose: a bare `host:path`
+     * was never folded by earlier releases either, and requiring the `@` keeps
+     * non-URL strings that merely contain a `:` (Windows drive paths like
+     * `C:/repos/foo`) from being mangled into fake https URLs.
+     *
+     * Port of the canonical TypeScript implementation in
+     * `cli/src/core/KBPathResolver.ts foldGitTransportToHttps` — the two MUST
+     * stay in lockstep, since both IDEs resolve folders in the same Memory
+     * Bank and divergent folding sends them to different folders.
+     */
+    internal fun foldGitTransportToHttps(url: String): String {
+        // The scheme's DEFAULT port (ssh 22 / git 9418) is dropped — it carries
+        // no identity — but a non-default port is preserved so two self-hosted
+        // forges on `host:2222` and `host:2223` stay distinct repos.
+        SSH_URL_REGEX.find(url)?.let {
+            return "https://${it.groupValues[1]}${nonDefaultPortSegment(it.groupValues[2], "22")}/${it.groupValues[3]}"
+        }
+        GIT_URL_REGEX.find(url)?.let {
+            return "https://${it.groupValues[1]}${nonDefaultPortSegment(it.groupValues[2], "9418")}/${it.groupValues[3]}"
+        }
+        SCP_URL_REGEX.find(url)?.let { return "https://${it.groupValues[1]}/${it.groupValues[2]}" }
+        return url
+    }
+
+    /** `:<port>` when present and not the scheme's default, else empty. */
+    private fun nonDefaultPortSegment(port: String, schemeDefault: String): String {
+        if (port.isEmpty() || port == schemeDefault) return ""
+        return ":$port"
     }
 
     private fun findAvailablePath(repoName: String, remoteUrl: String?): Path {

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/core/KBRepoDiscoverer.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/core/KBRepoDiscoverer.kt
@@ -69,6 +69,11 @@ object KBRepoDiscoverer {
     }
 
     private fun normalizeUrl(url: String): String {
-        return url.removeSuffix("/").removeSuffix(".git").lowercase()
+        // Fold SSH transports first (shared rule with KBPathResolver) so a
+        // config stored from an SSH clone still matches the https remote of
+        // the same repo — otherwise isCurrentRepo calls the current repo
+        // "foreign" while the resolver happily reuses its folder. The
+        // whole-string lowercase below already covers path-case differences.
+        return KBPathResolver.foldGitTransportToHttps(url).removeSuffix("/").removeSuffix(".git").lowercase()
     }
 }

--- a/intellij/src/test/kotlin/ai/jolli/jollimemory/core/KBPathResolverTest.kt
+++ b/intellij/src/test/kotlin/ai/jolli/jollimemory/core/KBPathResolverTest.kt
@@ -158,6 +158,52 @@ class KBPathResolverTest {
         }
 
         @Test
+        fun `reuses folder when stored SSH remote matches the https clone of the same repo`() {
+            // Same repo, different clone transport. Before transport folding the
+            // SSH and https forms compared unequal and the resolver split the
+            // Memory Bank into myrepo / myrepo-2.
+            createKBFolder("myrepo", "git@github.com:user/myrepo.git")
+
+            val resolved = KBPathResolver.resolve(
+                "myrepo",
+                "https://github.com/user/myrepo.git",
+                tempDir.toString(),
+            )
+            resolved shouldBe tempDir.resolve("myrepo")
+        }
+
+        @Test
+        fun `reuses folder when stored https remote matches the ssh clone of the same repo`() {
+            createKBFolder("myrepo", "https://github.com/user/myrepo.git")
+
+            val resolved = KBPathResolver.resolve(
+                "myrepo",
+                "ssh://git@github.com:22/user/myrepo.git",
+                tempDir.toString(),
+            )
+            resolved shouldBe tempDir.resolve("myrepo")
+        }
+
+        @Test
+        fun `treats default ssh port as identical but a non-default port as a different repo`() {
+            createKBFolder("myrepo", "ssh://git@host.example:2222/user/myrepo.git")
+
+            // Same non-default port → same repo, folder reused.
+            KBPathResolver.resolve(
+                "myrepo",
+                "ssh://git@host.example:2222/user/myrepo",
+                tempDir.toString(),
+            ) shouldBe tempDir.resolve("myrepo")
+
+            // Different port → distinct self-hosted forge, must NOT reuse.
+            KBPathResolver.resolve(
+                "myrepo",
+                "ssh://git@host.example:2223/user/myrepo",
+                tempDir.toString(),
+            ) shouldNotBe tempDir.resolve("myrepo")
+        }
+
+        @Test
         fun `local repos match by name when both have no remote`() {
             createKBFolder("localproject", null)
 

--- a/intellij/src/test/kotlin/ai/jolli/jollimemory/core/KBRepoDiscovererTest.kt
+++ b/intellij/src/test/kotlin/ai/jolli/jollimemory/core/KBRepoDiscovererTest.kt
@@ -1,0 +1,52 @@
+package ai.jolli.jollimemory.core
+
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Path
+
+class KBRepoDiscovererTest {
+
+    @TempDir
+    lateinit var tempDir: Path
+
+    @Test
+    fun `matches current repo across SSH and https transports of the same remote`() {
+        // Config persisted from an SSH clone, current checkout uses https.
+        // Without transport folding the discoverer called the current repo
+        // "foreign" even though KBPathResolver.isSameRepo reuses its folder —
+        // breaking current-repo highlighting in the Memory Bank UI.
+        KBPathResolver.initializeKBFolder(
+            tempDir.resolve("sshstored"),
+            "sshstored",
+            "git@github.com:user/repo.git",
+        )
+
+        val repos = KBRepoDiscoverer.discover(null, "https://github.com/user/repo.git", tempDir.toString())
+        repos.first { it.repoName == "sshstored" }.isCurrentRepo shouldBe true
+    }
+
+    @Test
+    fun `matches current repo when the stored config is https and the live remote is ssh`() {
+        KBPathResolver.initializeKBFolder(
+            tempDir.resolve("httpsstored"),
+            "httpsstored",
+            "https://github.com/other/thing.git",
+        )
+
+        val repos = KBRepoDiscoverer.discover(null, "ssh://git@github.com:22/other/thing", tempDir.toString())
+        repos.first { it.repoName == "httpsstored" }.isCurrentRepo shouldBe true
+    }
+
+    @Test
+    fun `does not match a genuinely different repo`() {
+        KBPathResolver.initializeKBFolder(
+            tempDir.resolve("unrelated"),
+            "unrelated",
+            "git@github.com:someone/else.git",
+        )
+
+        val repos = KBRepoDiscoverer.discover(null, "https://github.com/user/repo.git", tempDir.toString())
+        repos.first { it.repoName == "unrelated" }.isCurrentRepo shouldBe false
+    }
+}

--- a/vscode/src/util/GitRemoteUtils.ts
+++ b/vscode/src/util/GitRemoteUtils.ts
@@ -39,19 +39,11 @@
  */
 
 import { execGit } from "../../../cli/src/core/GitOps.js";
-
-/**
- * Hosts whose owner/repo path is case-insensitive on the wire — clones with
- * different casing all resolve to the same repo. Lower-casing the path on
- * these hosts is required to make the canonical URL a stable identity key.
- * Add new entries only after confirming the host actually treats the path
- * as case-insensitive (assuming wrong here merges distinct repos).
- */
-const CASE_INSENSITIVE_PATH_HOSTS: ReadonlySet<string> = new Set([
-	"github.com",
-	"gitlab.com",
-	"bitbucket.org",
-]);
+// Shared with the vault identity / folder-reuse canonicalizers in
+// cli/src/core/KBPathResolver.ts — one host list, so the server binding key
+// and the local identity comparers can never drift on which hosts get their
+// path case folded.
+import { CASE_INSENSITIVE_PATH_HOSTS } from "../../../cli/src/core/KBPathResolver.js";
 
 /** Returns the canonical, server-facing repo URL for the given workspace root. */
 export async function getCanonicalRepoUrl(

--- a/vscode/src/views/SettingsHtmlBuilder.ts
+++ b/vscode/src/views/SettingsHtmlBuilder.ts
@@ -195,7 +195,10 @@ export function buildSettingsHtml(nonce: string): string {
         <span class="hint">Push this Memory Bank to your <strong>private</strong> Personal Space. Requires Jolli sign-in.</span>
       </div>
 
-      <div class="settings-row column" id="syncAutoGroup">
+      <!-- Hidden for now: auto-sync stays functional for repos that already
+           enabled it (the script round-trips the saved value), but the toggle
+           is not user-facing until the feature is ready to surface. -->
+      <div class="settings-row column hidden" id="syncAutoGroup">
         <label class="settings-toggle">
           <input type="checkbox" id="autoSyncEnabled" />
           Auto-sync to Personal Space


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## Quick recap

Three related bugs were fixed that caused the Memory Bank to misidentify repositories when the same repo was accessed through different URL forms. The most visible symptom was the Memory Bank panel treating the current workspace as a foreign repository when a developer's saved configuration had been written from an SSH clone but the active checkout used an HTTPS remote, or vice versa. With the fix, the current-repo highlight, sort order, and cross-repo memory reads all behave correctly regardless of which transport style was used at clone time. Both the VS Code and IntelliJ plugins now apply the same normalization at every point where two remote addresses are compared.

A second problem affected the shared repository index: the same repository could accumulate two separate entries — one SSH-style, one HTTPS-style — causing false folder-conflict warnings and, in some cases, prompting the plugin to create a second Memory Bank folder rather than reusing the existing one. Each sync round now runs a healing pass that rewrites any legacy SSH-style rows into their canonical form and adds back any repository folders present on disk but missing from the index. The healing pass never removes rows, preserving entries that may belong to other devices sharing the same index. Git worktrees, which previously produced spurious collision warnings, now resolve to a stable identity that matches what was already written to disk.

A third, related fix addressed the case where two developers clone the same GitHub repository with different owner/repo casing. Previously this produced two separate registry entries both claiming the same local folder. Path-case folding is now applied for GitHub, GitLab, and Bitbucket — platforms confirmed to treat repository paths case-insensitively — while self-hosted forges continue to preserve path casing to avoid incorrectly merging genuinely distinct repositories.

---

## E2E Test (3)
<details>
<summary><strong>1. SSH-stored config matches HTTPS remote (no split Memory Bank folders)</strong></summary>
<br>
<blockquote>

**Preconditions:** Have two devices (or two user accounts) where one cloned a repository using an SSH address (e.g. git@github.com:yourname/yourrepo.git) and the other cloned the same repository using an HTTPS address (e.g. https://github.com/yourname/yourrepo.git). Both should have the Jolli Memory Bank set up and synced at least once.

**Steps:**
1. On the device that originally connected via SSH, open the Jolli Memory Bank panel in your editor.
2. Check that your repository appears highlighted as the "current repo" in the panel (it should be visually distinguished from other repos in the list).
3. On the second device (or after switching the remote to HTTPS), open the same Jolli Memory Bank panel.
4. Check that the same repository still appears highlighted as the "current repo" — not listed as an unrecognized or foreign repository.
5. Open the Memory Bank folder on disk and confirm there is only one folder for this repository (for example, "yourrepo"), not a duplicate like "yourrepo-2".

**Expected Results:**
- The repository is highlighted as the current repo on both devices regardless of whether SSH or HTTPS was used to clone it.
- Only one Memory Bank folder exists for the repository — no duplicate folders with a numbered suffix appear.

</blockquote>
</details>
<details>
<summary><strong>2. No duplicate repo entries in the index when switching between SSH and HTTPS remotes</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a repository that was previously synced using an SSH remote address. The shared repository index (repos.json) should have at least one entry for this repo stored under its SSH address.

**Steps:**
1. Open the Jolli Memory Bank panel in your editor on a machine where the same repository is cloned via HTTPS.
2. Trigger a sync (for example, by saving a note or using the sync button in the panel).
3. After sync completes, open the Memory Bank panel and look at the list of repositories shown.
4. Confirm the repository appears only once in the list — not as two separate entries (one for SSH, one for HTTPS).
5. Check that no "folder conflict" warning or collision alert is shown for this repository.

**Expected Results:**
- The repository appears exactly once in the Memory Bank panel's repo list.
- No duplicate entries, conflict warnings, or collision alerts are shown for the repository.
- The existing Memory Bank folder is reused — no second folder is created for the same repo.

</blockquote>
</details>
<details>
<summary><strong>3. Same GitHub repo cloned with different owner/repo casing produces one identity, not two</strong></summary>
<br>
<blockquote>

**Preconditions:** Have two team members (or two machines) where one cloned a GitHub repository typing the owner name in uppercase (e.g. github.com/JolliAI/Jolli) and another typed it in lowercase (e.g. github.com/jolliai/jolli). Both should have synced their Memory Bank at least once.

**Steps:**
1. On the first machine (uppercase clone), open the Jolli Memory Bank panel and note the repository name shown in the list.
2. On the second machine (lowercase clone), open the Jolli Memory Bank panel and note the repository name shown.
3. Trigger a sync on both machines.
4. After sync, check the Memory Bank panel on either machine and confirm the repository appears only once in the shared list.
5. Confirm no conflict warning or "collision" alert appears for this repository.

**Expected Results:**
- The repository appears as a single entry in the Memory Bank panel regardless of how the owner/repo name was typed during cloning.
- No duplicate entries or conflict warnings appear.
- Both machines read from and write to the same Memory Bank folder for this repository.

</blockquote>
</details>

---

## Topics (4)
<details>
<summary><strong>01 · Fix Memory Bank panel misidentifying current repo when SSH and HTTPS remotes differ</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

When a developer had saved their repository configuration from an SSH clone but the active workspace used an HTTPS remote (or vice versa), the Memory Bank panel treated the current workspace as a foreign repository, hiding the current-repo highlight and causing cross-repo memory reads to skip the workspace's own memories entirely.

**💡 Decisions Behind the Code**

- **Reuse the existing transport-folding function rather than duplicating logic**: The project already had a well-tested transport-folding utility that the folder-reuse predicate and the vault identity normalizer both call. Wiring the discoverer to the same function guarantees all three comparison sites give the same answer for any given pair of URLs, eliminating the class of bugs where one layer says "same repo" and another says "foreign repo". Duplicating the regex would have kept the risk of future drift alive.
- **Whole-string lowercasing in the discoverer rather than a per-host allowlist**: The discoverer's comparison is purely local and never written to disk, so aggressively lowercasing the entire URL — including the path — is safe and simpler than the per-host set used by the vault identity normalizer. The vault identity must be conservative about path case to avoid merging distinct self-hosted repos; the discoverer only needs to answer "is this the current repo?" and can afford to be more permissive.

**✅ What Was Implemented**

- `KBRepoDiscoverer.ts` and `KBRepoDiscoverer.kt`: the internal URL comparison function in both the TypeScript CLI and the Kotlin IntelliJ plugin now runs SSH-to-HTTPS transport folding before stripping suffixes and lowercasing. Previously the function only stripped `.git` and lowercased the whole string, so `git@github.com:user/repo.git` and `https://github.com/user/repo.git` compared as unequal. The shared `foldGitTransportToHttps` function from `KBPathResolver.ts` is now reused, and `KBPathResolver.kt`'s equivalent was widened from `private` to `internal` so `KBRepoDiscoverer.kt` can call it.
- A new Kotlin test file `KBRepoDiscovererTest.kt` was added covering SSH-stored-config vs. HTTPS-current-remote, HTTPS-stored vs. SSH-current, and a negative case confirming genuinely different repos are not conflated.

**📁 FILES**
- `cli/src/core/KBRepoDiscoverer.ts`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/core/KBRepoDiscoverer.kt`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/core/KBPathResolver.kt`

</blockquote>
</details>
<details>
<summary><strong>02 · Fix duplicate repo index entries when SSH and HTTPS remotes point to same repository</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The shared repository index file was accumulating duplicate entries for the same repository — one using an SSH-style address and another using a standard web address — causing false "folder conflict" warnings and preventing sync from correctly recognizing that both entries referred to the same repo. In some cases the plugin would create a second Memory Bank folder rather than reusing the existing one, splitting notes across two locations.

**💡 Decisions Behind the Code**

- **Single canonical HTTPS form over transport-agnostic stripping**: Rather than reducing all URLs to a bare `host/owner/repo` string, SSH forms are folded into the HTTPS form. This preserves the largest share of already-stored entries unchanged (most users clone via HTTPS), minimizing the number of rows that need rewriting on upgrade and keeping stored values human-readable and round-trippable.
- **Preserve non-default ports rather than always dropping them**: Dropping all ports was the original simplification for hosted-git services like GitHub, where SSH port 22 is interchangeable with HTTPS. For self-hosted forges, the port is part of the server's identity — two services on the same hostname but different ports are genuinely different repositories. Preserving non-default ports keeps canonicalization safe for self-hosted setups without changing behavior for the common GitHub/GitLab case.
- **Shared normalization placed in the core layer, not the sync layer**: Both the local folder resolver and the vault identity system needed the same folding logic, but the sync layer already imports from core — not the reverse. Putting the function in core lets both consumers import it without creating a circular dependency, and makes the "one answer" guarantee enforceable at the type level rather than by convention.
- **Additive-only reconcile with ambiguity skip**: The reconcile pass never removes rows, because the index is shared across devices via git and a row absent on this machine may belong to a peer. Identities backed by more than one local folder are skipped entirely rather than guessed at, deferring to the per-repo sync round that has authoritative path information — a wrong guess would split the Memory Bank in exactly the way the fix is trying to prevent.
- **IntelliJ port required alongside the TypeScript change**: Both the VS Code and IntelliJ plugins resolve local folders against the same on-disk Memory Bank. If only one plugin folded SSH to HTTPS, a user with both installed could still end up with split folders depending on which IDE ran first. The Kotlin implementation was added in the same commit with an explicit lockstep comment to make the coupling visible to future maintainers.

**✅ What Was Implemented**

- Introduced `foldGitTransportToHttps` in `cli/src/core/KBPathResolver.ts` as the single shared normalization function: SSH shorthand (`git@host:path`), `ssh://`, `git+ssh://`, and `git://` URLs all fold into their `https://` equivalent. The function requires a `user@` prefix on the shorthand form to avoid misidentifying Windows drive paths or colon-containing folder names as SSH addresses. Non-default SSH ports (anything other than 22) and non-default git protocol ports (anything other than 9418) are preserved in the canonical form; a `nonDefaultPortSegment` helper encapsulates the default-port-drop logic in both languages.
- Wired the shared function into both the vault identity normalizer (`cli/src/sync/RepoIdentity.ts`) and the local folder-reuse predicate (`KBPathResolver.normalizeRemoteUrl`), so "is this the same repo?" now has one consistent answer across both subsystems. `canonicalizeRepoIdentity` and `repoIdentityFromConfig` were added as exports to support healing already-persisted legacy rows.
- `canonicalizeRepoIdentity` in `cli/src/sync/RepoIdentity.ts` was gated behind a URL/SCP pattern check (`URL_LIKE_RE` / `SCP_LIKE_RE`). Bare fallback identities — names used when a repo has no remote — now pass through unchanged instead of being run through the URL normalizer, which previously stripped `.git` suffixes and could corrupt or collapse distinct entries.
- `computeRepoIdentity` in `cli/src/sync/RepoIdentity.ts` was changed to use `extractRepoName` (worktree-aware) instead of `basename` for the no-remote fallback, aligning the live-round identity with the value persisted in each folder's config file and eliminating spurious collision warnings for git worktrees.
- Added `canonicalizeRepoMapping` and `reconcileMappingAdditive` to `cli/src/sync/RepoMapping.ts`, and wired them into `SyncEngine.ts` so each sync round automatically collapses legacy SSH-style rows into their canonical HTTPS form and adds any on-disk repo folders missing from the index — without ever deleting rows that belong to other devices. The same local folder-reuse fix was ported to the IntelliJ plugin's Kotlin implementation with matching regex patterns and a lockstep comment.

**📋 Future Enhancements**

- The local folder-reuse predicate and the vault identity normalizer still differ on path case sensitivity: the local predicate lowercases the entire URL while the vault identity preserves path case. A repository whose remote URL changes only in path casing would be treated as the same repo locally but as a different repo in the shared index. This known inconsistency was deferred for a separate decision.
- Users who already have a split primary and secondary Memory Bank folder from a previous transport switch will have new writes routed back to the original folder, but the secondary folder's contents are left in place. Automatically merging them would risk data loss and requires a separate migration strategy.

**📁 FILES**
- `cli/src/core/KBPathResolver.ts`
- `cli/src/sync/RepoIdentity.ts`
- `cli/src/sync/RepoMapping.ts`
- `cli/src/sync/SyncEngine.ts`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/core/KBPathResolver.kt`

</blockquote>
</details>
<details>
<summary><strong>03 · Prevent duplicate registry entries when GitHub repository path casing differs between clones</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Two developers cloning the same GitHub repository with different owner/repo casing (for example, one types the owner name in uppercase and another in lowercase) would end up with two separate identity entries in the shared repository registry, both pointing at the same local folder, triggering a false collision warning and unpredictable sync behavior.

**💡 Decisions Behind the Code**

- **Apply path-case folding only to a known allowlist of hosts, not universally**: GitHub, GitLab, and Bitbucket are confirmed to treat owner/repo paths case-insensitively at the server level, so folding is safe and necessary there. Self-hosted instances of Gitea, GitLab, or other forges may be case-sensitive, and silently merging two differently-cased paths on such a host would incorrectly collapse two distinct repositories into one vault folder. The conservative per-host approach matches the rule already established in the server-facing canonicalizer.
- **Move the host list to the CLI layer and import it into the VS Code layer**: The dependency direction in this codebase flows from VS Code to CLI, never the reverse. Defining the authoritative list in the CLI package and importing it into the VS Code utility keeps that direction intact while guaranteeing both canonicalizers always agree on which hosts are in scope. A duplicated local constant in each layer would be simpler to write but would inevitably drift as new hosts are added.

**✅ What Was Implemented**

- `RepoIdentity.ts` (`normalizeGitUrl`): after lowercasing the scheme and host, the function now also lowercases the URL path — but only for hosts confirmed to route owner/repo names case-insensitively (GitHub, GitLab, Bitbucket). For all other hosts the path case is preserved as before. The host set is read from the new shared constant rather than being defined locally.
- `KBPathResolver.ts`: a new exported constant `CASE_INSENSITIVE_PATH_HOSTS` is defined here as the single source of truth for which hosts get path-case folding. `GitRemoteUtils.ts` (the server-facing canonicalizer) was updated to import this constant instead of maintaining its own identical local copy, eliminating the risk of the two lists drifting apart.
- Two existing tests that asserted GitHub path case was preserved were updated to use a self-hosted forge URL instead, keeping the self-hosted-preserve behavior pinned. New tests assert that GitHub URLs with mixed-case owner/repo fold to the same identity regardless of transport.

**📁 FILES**
- `cli/src/sync/RepoIdentity.ts`
- `cli/src/core/KBPathResolver.ts`
- `vscode/src/util/GitRemoteUtils.ts`

</blockquote>
</details>
<details>
<summary><strong>04 · Hide auto-sync toggle in Settings panel until feature is ready</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The auto-sync toggle and polling interval input were visible in the Settings panel but the feature was not ready to be surfaced to users.

**💡 Decisions Behind the Code**

Hiding rather than removing the DOM element was chosen to protect users who had already saved an enabled state. The settings save script reads the checkbox value directly from the DOM; removing the element would cause it to write `false` on the next save, quietly disabling auto-sync for anyone who had previously turned it on.

**✅ What Was Implemented**

Added the `hidden` CSS class to the auto-sync settings group in `vscode/src/views/SettingsHtmlBuilder.ts`. The elements remain in the DOM so the settings save logic continues to round-trip the stored value correctly.

**📁 FILES**
- `vscode/src/views/SettingsHtmlBuilder.ts`

</blockquote>
</details>

---

*Generated by Jolli Memory · June 11, 2026 at 6:00 PM · via Anthropic*
<!-- jollimemory-summary-end -->