### PR TITLE
Exempt ingest phase from Commit/Squash worker-busy gates

### DIFF
--- a/cli/src/core/Locks.ts
+++ b/cli/src/core/Locks.ts
@@ -90,13 +90,20 @@ function gitRevParseCommonDir(cwd: string): Promise<{ stdout: string; stderr: st
 export const WORKER_LOCK_FILE = "worker.lock";
 
 /**
- * Cosmetic, best-effort marker the QueueWorker writes while running a phase the
- * UI should label specially (currently only `ingest`). Lives next to
- * `worker.lock` in `<cwd>/.jolli/jollimemory/`. It is NOT a lock and carries no
- * mutual-exclusion role — the extension reads it only to pick a toolbar label.
- * Its lifetime is bound to `worker.lock` on the reader side: when the lock
- * disappears the phase is forced to null, so a stale marker left by a crashed
- * worker cannot mislead beyond the lock's own staleness window.
+ * Best-effort marker the QueueWorker writes while running a phase the UI
+ * treats specially (currently only `ingest`). Lives next to `worker.lock` in
+ * `<cwd>/.jolli/jollimemory/`. It is NOT a lock and carries no mutual-exclusion
+ * role, but it is more than cosmetic: the extension's worker-busy gates
+ * (`isWorkerBlockingBusy` in vscode LockUtils) exempt Commit/Squash from
+ * blocking while the marker reads `ingest`, so a wrongly-surviving marker
+ * under-protects. Three mechanisms bound its lifetime:
+ *   - reader side: the phase is ignored whenever `worker.lock` is gone/stale,
+ *     and an `ingest` marker whose own mtime is stale is treated as blocking
+ *     (the worker heartbeats the marker during a genuine ingest);
+ *   - writer side: each commit-typed queue entry clears a leftover marker
+ *     before processing (`clearLeftoverIngestMarker` in QueueWorker);
+ *   - acquisition: a fresh worker removes any crash-orphaned marker right
+ *     after taking `worker.lock`.
  */
 export const WORKER_PHASE_FILE = "worker-phase";
 export const ORPHAN_WRITE_LOCK_FILE = "orphan-write.lock";

--- a/cli/src/hooks/PostCommitHook.helpers.test.ts
+++ b/cli/src/hooks/PostCommitHook.helpers.test.ts
@@ -178,6 +178,7 @@ vi.mock("../core/Locks.js", () => ({
 	refreshWorkerLockMtime: vi.fn(),
 	isWorkerLockHeld: vi.fn(),
 	withPlansLock: (_cwd: string | undefined, fn: () => Promise<unknown>) => fn(),
+	WORKER_PHASE_FILE: "worker-phase",
 }));
 
 vi.mock("../core/SummaryStore.js", async (importOriginal) => {

--- a/cli/src/hooks/PostCommitHook.test.ts
+++ b/cli/src/hooks/PostCommitHook.test.ts
@@ -82,6 +82,7 @@ vi.mock("../core/Locks.js", () => ({
 	refreshWorkerLockMtime: vi.fn(),
 	isWorkerLockHeld: vi.fn(),
 	withPlansLock: (_cwd: string | undefined, fn: () => Promise<unknown>) => fn(),
+	WORKER_PHASE_FILE: "worker-phase",
 }));
 
 vi.mock("../sync/VaultWriteLock.js", () => ({

--- a/cli/src/hooks/QueueWorker.overlay.test.ts
+++ b/cli/src/hooks/QueueWorker.overlay.test.ts
@@ -108,6 +108,7 @@ vi.mock("../core/Locks.js", () => ({
 	refreshWorkerLockMtime: vi.fn(),
 	isWorkerLockHeld: vi.fn(),
 	withPlansLock: (_cwd: string | undefined, fn: () => Promise<unknown>) => fn(),
+	WORKER_PHASE_FILE: "worker-phase",
 }));
 
 // Sqlite-backed and patch-doc readers — each loadSessionTranscripts call

--- a/cli/src/hooks/QueueWorker.selection.test.ts
+++ b/cli/src/hooks/QueueWorker.selection.test.ts
@@ -101,6 +101,7 @@ vi.mock("../core/Locks.js", () => ({
 	refreshWorkerLockMtime: vi.fn(),
 	isWorkerLockHeld: vi.fn(),
 	withPlansLock: (_cwd: string | undefined, fn: () => Promise<unknown>) => fn(),
+	WORKER_PHASE_FILE: "worker-phase",
 }));
 
 vi.mock("../core/TranscriptReader.js", () => ({

--- a/cli/src/hooks/QueueWorker.test.ts
+++ b/cli/src/hooks/QueueWorker.test.ts
@@ -2197,6 +2197,40 @@ describe("QueueWorker", () => {
 		});
 	});
 
+	describe("clearLeftoverIngestMarker", () => {
+		it("removes an ingest marker that a failed cleanup left behind", async () => {
+			const tmp = mkdtempSync(join(tmpdir(), "jolli-leftover-"));
+			mkdirSync(join(tmp, ".jolli", "jollimemory"), { recursive: true });
+			const phaseFile = join(tmp, ".jolli", "jollimemory", "worker-phase");
+			// Simulate the ingest `finally` rmSync having failed (e.g. Windows AV
+			// briefly holding the file): the marker still reads 'ingest' while the
+			// same drain is about to process a blocking summary entry.
+			writeFileSync(phaseFile, "ingest");
+
+			const { existsSync: realExistsSync } = await vi.importActual<typeof import("node:fs")>("node:fs");
+			vi.mocked(existsSync).mockImplementation(realExistsSync);
+
+			__test__.clearLeftoverIngestMarker(tmp);
+
+			// Gate readers must no longer see an exempt phase.
+			expect(realExistsSync(phaseFile)).toBe(false);
+
+			rmSync(tmp, { recursive: true, force: true });
+		});
+
+		it("is a no-op when no marker exists", async () => {
+			const tmp = mkdtempSync(join(tmpdir(), "jolli-leftover-"));
+			mkdirSync(join(tmp, ".jolli", "jollimemory"), { recursive: true });
+
+			const { existsSync: realExistsSync } = await vi.importActual<typeof import("node:fs")>("node:fs");
+			vi.mocked(existsSync).mockImplementation(realExistsSync);
+
+			expect(() => __test__.clearLeftoverIngestMarker(tmp)).not.toThrow();
+
+			rmSync(tmp, { recursive: true, force: true });
+		});
+	});
+
 	describe("runWorker — ingest dispatch", () => {
 		function makeIngestOp(triggeredBy: IngestOperation["triggeredBy"] = "post-merge"): IngestOperation {
 			return { type: "ingest", triggeredBy, createdAt: new Date().toISOString() };

--- a/cli/src/hooks/QueueWorker.ts
+++ b/cli/src/hooks/QueueWorker.ts
@@ -506,6 +506,32 @@ export async function runWorker(cwd: string, force = false): Promise<void> {
 }
 
 /**
+ * Second line of defense for the worker-phase marker. If the ingest `finally`
+ * cleanup failed (e.g. Windows AV briefly holding the file), the marker still
+ * reads `ingest` while this same drain processes blocking summary entries —
+ * and the extension's Commit/Squash gates would stay open during exactly the
+ * runs they must block. Retry the delete here; if the file is still
+ * undeletable, overwrite the content so readers see a blocking phase (any
+ * value other than `ingest` blocks). The reader-side mtime staleness check is
+ * the final backstop when both attempts fail.
+ */
+function clearLeftoverIngestMarker(cwd: string): void {
+	const phaseFile = join(getJolliMemoryDir(cwd), WORKER_PHASE_FILE);
+	if (!existsSync(phaseFile)) return;
+	try {
+		rmSync(phaseFile, { force: true });
+	} catch {
+		/* v8 ignore start -- needs an OS-level rm failure; the inner catch additionally needs a write failure */
+		try {
+			writeFileSync(phaseFile, "summary");
+		} catch (e) {
+			log.warn("leftover worker-phase marker could not be cleared or overwritten: %s", errMsg(e));
+		}
+		/* v8 ignore stop */
+	}
+}
+
+/**
  * Processes a single queue entry based on its type.
  * Called by runWorker() for each entry in the queue.
  */
@@ -519,25 +545,46 @@ async function processQueueEntry(
 	// No commit-hash or branch field; dispatch and return before commit-only code.
 	if (isIngestOperation(op)) {
 		log.info("Processing queue entry: type=ingest triggeredBy=%s", op.triggeredBy);
-		// Cosmetic phase marker so the VS Code toolbar shows "Updating Memory
-		// Bank…" instead of "AI summary in progress…" during the (potentially
-		// ~80s) topic-KB ingest. Best-effort: a write/delete failure must never
-		// break ingest, so both ends are wrapped and logged at debug only.
+		// Phase marker consumed by the extension's worker-busy gates (and the
+		// toolbar label): while it reads `ingest` AND is fresh, Commit/Squash
+		// stay enabled and the toolbar shows "Updating Memory Bank…". The write
+		// is best-effort — a failure only over-blocks (missing marker = blocking
+		// summary phase), never under-blocks.
 		const phaseFile = join(getJolliMemoryDir(cwd), WORKER_PHASE_FILE);
 		try {
 			writeFileSync(phaseFile, "ingest");
 		} catch (e) {
-			/* v8 ignore next -- best-effort cosmetic marker; write failure is non-fatal */
+			/* v8 ignore next -- best-effort marker; a write failure only over-blocks */
 			log.debug("worker-phase write skipped (non-fatal): %s", errMsg(e));
 		}
+		// Heartbeat: keep the marker's mtime fresh for the whole ingest. Readers
+		// treat a stale marker as blocking (fail-safe), so a long ingest needs
+		// this to stay exempt — and conversely an orphaned `ingest` marker (both
+		// the cleanup below and the per-entry guard failed) ages out instead of
+		// holding the gates open during a later summary run.
+		/* v8 ignore start -- timer callback never fires inside fast unit tests */
+		const phaseRefreshTimer = setInterval(() => {
+			try {
+				writeFileSync(phaseFile, "ingest");
+			} catch {
+				// Next tick retries; reader-side staleness covers persistent failure.
+			}
+		}, WORKER_LOCK_REFRESH_INTERVAL_MS);
+		/* v8 ignore stop */
 		try {
 			await runIngestFromQueue(op, cwd, storage);
 		} finally {
+			clearInterval(phaseRefreshTimer);
 			try {
 				rmSync(phaseFile, { force: true });
 			} catch (e) {
-				/* v8 ignore next -- best-effort cosmetic marker; cleanup failure is non-fatal */
-				log.debug("worker-phase cleanup skipped (non-fatal): %s", errMsg(e));
+				/* v8 ignore start -- needs an OS-level rm failure (e.g. Windows AV briefly holding the file) */
+				// A surviving `ingest` marker would keep the extension's gates open
+				// while this same drain moves on to blocking summary entries. Two
+				// backstops cover it: clearLeftoverIngestMarker before each
+				// commit-typed entry, and the reader-side mtime staleness check.
+				log.warn("worker-phase cleanup failed — relying on per-entry guard + staleness: %s", errMsg(e));
+				/* v8 ignore stop */
 			}
 		}
 		return;
@@ -545,6 +592,9 @@ async function processQueueEntry(
 
 	// At this point the only remaining operation is commit-typed (the GitOperation
 	// union is CommitGitOperation | IngestOperation, and ingest returned above).
+	// A summary run must present a blocking phase to the extension's gates, so
+	// clear any `ingest` marker a failed cleanup left behind before starting.
+	clearLeftoverIngestMarker(cwd);
 	const commitOp = op as CommitGitOperation;
 	log.info("Processing queue entry: type=%s hash=%s", commitOp.type, commitOp.commitHash.substring(0, 8));
 
@@ -2711,6 +2761,7 @@ export const __test__ = {
 	detectPlanSlugsFromRegistry,
 	detectUncommittedNoteIds,
 	hoistMetadataFromOldSummary,
+	clearLeftoverIngestMarker,
 	associatePlansWithCommit,
 	finalizeReferenceArchive,
 	executePipeline,

--- a/vscode/src/Extension.test.ts
+++ b/vscode/src/Extension.test.ts
@@ -404,6 +404,7 @@ const {
 	checkboxCallbacks,
 	visibilityCallbacks,
 	openExternal,
+	fsReadFile,
 } = vi.hoisted(() => {
 	/** Stores callbacks keyed by tree view ID so tests can trigger checkbox events */
 	const checkboxCallbacks_ = new Map<
@@ -463,6 +464,10 @@ const {
 		checkboxCallbacks: checkboxCallbacks_,
 		visibilityCallbacks: visibilityCallbacks_,
 		openExternal: vi.fn().mockResolvedValue(true),
+		// Backs `vscode.workspace.fs.readFile` (worker-phase marker reads).
+		// Defaults to rejection = file missing, matching the pre-mock behavior
+		// where the absent `fs` property made readWorkerPhase throw-and-catch.
+		fsReadFile: vi.fn().mockRejectedValue(new Error("ENOENT")),
 	};
 });
 
@@ -503,6 +508,10 @@ vi.mock("vscode", () => ({
 	},
 	Uri: {
 		file: vi.fn((p: string) => ({ fsPath: p, scheme: "file", with: vi.fn() })),
+		joinPath: vi.fn((base: { fsPath: string }, ...segs: Array<string>) => ({
+			fsPath: [base.fsPath, ...segs].join("/"),
+			scheme: "file",
+		})),
 		from: vi.fn((parts: { scheme: string; path: string; query?: string }) => ({
 			scheme: parts.scheme,
 			path: parts.path,
@@ -556,6 +565,9 @@ vi.mock("vscode", () => ({
 			get: vi.fn(),
 			update: vi.fn(),
 		})),
+		fs: {
+			readFile: fsReadFile,
+		},
 	},
 	commands: {
 		executeCommand,
@@ -4819,6 +4831,110 @@ describe("Extension", () => {
 			onChange?.();
 
 			expect(mockStatusStore.setWorkerBusy).toHaveBeenCalledWith(true);
+			expect(executeCommand).toHaveBeenCalledWith(
+				"setContext",
+				"jollimemory.workerBusy",
+				true,
+			);
+		});
+
+		// The workerBusy context key gates the commitAI / squash commands'
+		// `enablement`. The ingest phase (Memory Bank wiki update) must NOT
+		// block them — only summary runs do — so when the worker-phase marker
+		// reads "ingest" the context flips to false even while the lock is held,
+		// and flips back when the marker is deleted (lock still held).
+		it("exempts the ingest phase from the workerBusy context key", async () => {
+			// Watcher indices: 0=sessions, 1=head, 2=orphan-ref, 3=lock, 4=phase.
+			const lockWatcher = createFileSystemWatcher.mock.results[3]?.value;
+			const phaseWatcher = createFileSystemWatcher.mock.results[4]?.value;
+			const onLockCreate = lockWatcher?.onDidCreate.mock.calls[0]?.[0] as
+				| (() => void)
+				| undefined;
+			const onPhaseCreate = phaseWatcher?.onDidCreate.mock.calls[0]?.[0] as
+				| (() => void)
+				| undefined;
+			const onPhaseDelete = phaseWatcher?.onDidDelete.mock.calls[0]?.[0] as
+				| (() => void)
+				| undefined;
+			expect(onPhaseCreate).toBeDefined();
+			expect(onPhaseDelete).toBeDefined();
+
+			onLockCreate?.();
+			executeCommand.mockClear();
+
+			fsReadFile.mockResolvedValueOnce(Buffer.from("ingest"));
+			onPhaseCreate?.();
+
+			await vi.waitFor(() => {
+				expect(mockStatusStore.setWorkerPhase).toHaveBeenCalledWith("ingest");
+				expect(executeCommand).toHaveBeenCalledWith(
+					"setContext",
+					"jollimemory.workerBusy",
+					false,
+				);
+			});
+
+			// Marker removed (ingest finished) while the lock is still held →
+			// back to blocking semantics for the rest of the drain.
+			executeCommand.mockClear();
+			onPhaseDelete?.();
+
+			expect(mockStatusStore.setWorkerPhase).toHaveBeenCalledWith(null);
+			expect(executeCommand).toHaveBeenCalledWith(
+				"setContext",
+				"jollimemory.workerBusy",
+				true,
+			);
+		});
+
+		// Regression: readWorkerPhase awaits a readFile, and the lock-delete path
+		// clears the phase flag synchronously. A phase read that started during
+		// ingest but resolved AFTER the worker finished used to resurrect a stale
+		// "ingest" flag with no worker running; the next summary run's
+		// setWorkerBusy(true) then computed a non-blocking context and left
+		// Commit/Squash enabled mid-summary. The epoch token must discard the
+		// superseded read.
+		it("discards an in-flight phase read superseded by the lock-delete clear", async () => {
+			const lockWatcher = createFileSystemWatcher.mock.results[3]?.value;
+			const phaseWatcher = createFileSystemWatcher.mock.results[4]?.value;
+			const onLockCreate = lockWatcher?.onDidCreate.mock.calls[0]?.[0] as
+				| (() => void)
+				| undefined;
+			const onLockDelete = lockWatcher?.onDidDelete.mock.calls[0]?.[0] as
+				| (() => void)
+				| undefined;
+			const onPhaseChange = phaseWatcher?.onDidChange.mock.calls[0]?.[0] as
+				| (() => void)
+				| undefined;
+			expect(onLockDelete).toBeDefined();
+			expect(onPhaseChange).toBeDefined();
+
+			// Worker running an ingest; a phase read kicks off but its readFile
+			// stays pending until after the worker has finished.
+			onLockCreate?.();
+			let resolveRead: ((bytes: Buffer) => void) | undefined;
+			fsReadFile.mockImplementationOnce(
+				() =>
+					new Promise<Buffer>(resolve => {
+						resolveRead = resolve;
+					}),
+			);
+			onPhaseChange?.();
+
+			// Worker finishes: the lock-delete handler clears the phase flag
+			// synchronously and bumps the read epoch.
+			onLockDelete?.();
+			mockStatusStore.setWorkerPhase.mockClear();
+
+			// The stale read resolves with pre-delete content — must be discarded.
+			resolveRead?.(Buffer.from("ingest"));
+			await new Promise(resolve => setTimeout(resolve, 0));
+			expect(mockStatusStore.setWorkerPhase).not.toHaveBeenCalledWith("ingest");
+
+			// Next (non-ingest) summary run: the context must be blocking, proving
+			// the stale ingest flag did not survive into setWorkerBusy(true).
+			executeCommand.mockClear();
+			onLockCreate?.();
 			expect(executeCommand).toHaveBeenCalledWith(
 				"setContext",
 				"jollimemory.workerBusy",

--- a/vscode/src/Extension.ts
+++ b/vscode/src/Extension.ts
@@ -1411,9 +1411,10 @@ export function activate(context: vscode.ExtensionContext): void {
 
 	// ── Worker lock file watcher ────────────────────────────────────────
 	// When the post-commit Worker is running, it holds
-	// `.jolli/jollimemory/worker.lock`. Disable Commit/Squash/Push buttons during
-	// this time to prevent race conditions (Bug 3: squash commit while previous
-	// Worker holds the lock).
+	// `.jolli/jollimemory/worker.lock`. Disable Commit/Squash buttons during
+	// summary runs to prevent race conditions (Bug 3: squash commit while
+	// previous Worker holds the lock); the ingest phase is exempt — see
+	// updateWorkerBusyContext below. Push is not gated at all.
 	//
 	// We deliberately watch only `worker.lock`, not the sibling
 	// `orphan-write.lock`. The orphan-write mutex is held for milliseconds at a
@@ -1424,13 +1425,44 @@ export function activate(context: vscode.ExtensionContext): void {
 	const lockWatcher = vscode.workspace.createFileSystemWatcher(
 		new vscode.RelativePattern(workspaceRoot, ".jolli/jollimemory/worker.lock"),
 	);
-	const setWorkerBusy = (busy: boolean) => {
-		statusStore.setWorkerBusy(busy);
+	// The `jollimemory.workerBusy` context key drives `enablement` of the
+	// commitAI / squash contributed commands, so it carries BLOCKING semantics:
+	// busy with any phase except ingest. The ingest phase (Memory Bank wiki
+	// update, ~80s+) never touches the commit pipeline or code-branch history,
+	// so commit/squash stay enabled during it — git ops landed mid-ingest are
+	// enqueued and drained by the chain-spawned successor worker. Display
+	// surfaces (StatusStore.workerBusy → toolbar indicator) keep the raw busy
+	// flag so progress still shows during ingest.
+	// Local mirrors of the two watcher-fed inputs. Mirrored here (rather than
+	// read back from StatusStore's snapshot) so the context computation stays a
+	// pure function of what the two watchers below reported.
+	let workerBusyRaw = false;
+	let workerPhaseIsIngest = false;
+	// Invalidation token for in-flight async phase reads. readWorkerPhase awaits
+	// a readFile; if a synchronous phase clear (lock delete / phase-file delete)
+	// runs while that read is in flight, the read's continuation must NOT apply
+	// its result — it would resurrect a stale `workerPhaseIsIngest = true` with
+	// no worker running, and the next summary run's setWorkerBusy(true) would
+	// then compute a non-blocking context and leave Commit/Squash enabled
+	// mid-summary (the exact race the ingest exemption must not reopen).
+	let workerPhaseEpoch = 0;
+	const updateWorkerBusyContext = () => {
 		void vscode.commands.executeCommand(
 			"setContext",
 			"jollimemory.workerBusy",
-			busy,
+			workerBusyRaw && !workerPhaseIsIngest,
 		);
+	};
+	const setWorkerBusy = (busy: boolean) => {
+		workerBusyRaw = busy;
+		// Phase lifetime is bound to the lock (mirrors StatusStore.setWorkerBusy):
+		// a crash-left 'ingest' marker must not leak into the next summary run.
+		if (!busy) {
+			workerPhaseIsIngest = false;
+			workerPhaseEpoch++;
+		}
+		statusStore.setWorkerBusy(busy);
+		updateWorkerBusyContext();
 	};
 	lockWatcher.onDidCreate(() => setWorkerBusy(true));
 	lockWatcher.onDidChange(() => setWorkerBusy(true));
@@ -1475,6 +1507,9 @@ export function activate(context: vscode.ExtensionContext): void {
 		new vscode.RelativePattern(workspaceRoot, ".jolli/jollimemory/worker-phase"),
 	);
 	const readWorkerPhase = async (): Promise<void> => {
+		// Capture the epoch before awaiting; a clear that runs during the await
+		// bumps it, marking this read's result stale (see workerPhaseEpoch).
+		const epoch = workerPhaseEpoch;
 		try {
 			const uri = vscode.Uri.joinPath(
 				vscode.Uri.file(workspaceRoot),
@@ -1483,16 +1518,35 @@ export function activate(context: vscode.ExtensionContext): void {
 				"worker-phase",
 			);
 			const bytes = await vscode.workspace.fs.readFile(uri);
+			if (epoch !== workerPhaseEpoch) {
+				// A synchronous clear superseded this read; its flag/store writes
+				// are already correct, so applying the pre-clear file content here
+				// would resurrect a stale phase.
+				return;
+			}
 			const content = Buffer.from(bytes).toString("utf-8").trim();
-			statusStore.setWorkerPhase(content === "ingest" ? "ingest" : null);
+			workerPhaseIsIngest = content === "ingest";
+			statusStore.setWorkerPhase(workerPhaseIsIngest ? "ingest" : null);
 		} catch {
+			if (epoch !== workerPhaseEpoch) {
+				return;
+			}
 			// File missing / unreadable → no special phase.
+			workerPhaseIsIngest = false;
 			statusStore.setWorkerPhase(null);
 		}
+		// Phase flips change the blocking decision (ingest is exempt), so the
+		// context key must be recomputed alongside the cosmetic label.
+		updateWorkerBusyContext();
 	};
 	phaseWatcher.onDidCreate(() => void readWorkerPhase());
 	phaseWatcher.onDidChange(() => void readWorkerPhase());
-	phaseWatcher.onDidDelete(() => statusStore.setWorkerPhase(null));
+	phaseWatcher.onDidDelete(() => {
+		workerPhaseIsIngest = false;
+		workerPhaseEpoch++;
+		statusStore.setWorkerPhase(null);
+		updateWorkerBusyContext();
+	});
 	context.subscriptions.push(phaseWatcher);
 	// Check initial state — phase file might already exist on activation
 	// (extension started while a worker is mid-ingest).

--- a/vscode/src/Extension.ts
+++ b/vscode/src/Extension.ts
@@ -1430,7 +1430,10 @@ export function activate(context: vscode.ExtensionContext): void {
 	// busy with any phase except ingest. The ingest phase (Memory Bank wiki
 	// update, ~80s+) never touches the commit pipeline or code-branch history,
 	// so commit/squash stay enabled during it — git ops landed mid-ingest are
-	// enqueued and drained by the chain-spawned successor worker. Display
+	// enqueued and drained right after the ingest entry, usually by the SAME
+	// worker in the same lock hold. That worker can move into a blocking
+	// summary run while the user is mid-flow, so the command handlers re-check
+	// the gate right before executing their git operations. Display
 	// surfaces (StatusStore.workerBusy → toolbar indicator) keep the raw busy
 	// flag so progress still shows during ingest.
 	// Local mirrors of the two watcher-fed inputs. Mirrored here (rather than

--- a/vscode/src/commands/CommitCommand.test.ts
+++ b/vscode/src/commands/CommitCommand.test.ts
@@ -206,6 +206,39 @@ describe("CommitCommand", () => {
 		expect(deps.bridge.generateCommitMessage).not.toHaveBeenCalled();
 	});
 
+	it("re-checks the worker gate after the QuickPick and restores the index when it turned busy", async () => {
+		// Click-time check passes (e.g. exempt ingest phase), but the same
+		// drain moves into a blocking summary run during message generation /
+		// QuickPick review — the commit (possibly an Amend rewriting HEAD)
+		// must not execute, and the user's index must be restored.
+		isWorkerBlockingBusy
+			.mockResolvedValueOnce(false)
+			.mockResolvedValueOnce(true);
+		const deps = makeDeps();
+		const command = new CommitCommand(
+			deps.bridge as never,
+			deps.filesStore as never,
+			deps.commitsStore as never,
+			deps.statusStore as never,
+			deps.statusBar as never,
+			"/repo",
+		);
+		vi.spyOn(command as never, "showCommitQuickPick").mockResolvedValue({
+			item: { label: "$(check) Commit" },
+			message: "feat: generated",
+		});
+
+		await command.execute();
+
+		expect(isWorkerBlockingBusy).toHaveBeenCalledTimes(2);
+		expect(deps.bridge.commit).not.toHaveBeenCalled();
+		expect(deps.bridge.amendCommit).not.toHaveBeenCalled();
+		expect(deps.bridge.restoreIndexTree).toHaveBeenCalledWith("tree-sha");
+		expect(showWarningMessage).toHaveBeenCalledWith(
+			"Jolli Memory: AI summary is being generated. Please wait a moment.",
+		);
+	});
+
 	it("warns when nothing is selected", async () => {
 		const deps = makeDeps();
 		deps.filesStore.getSelectedFiles.mockReturnValue([]);

--- a/vscode/src/commands/CommitCommand.test.ts
+++ b/vscode/src/commands/CommitCommand.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { isWorkerBusy } = vi.hoisted(() => ({
-	isWorkerBusy: vi.fn(),
+const { isWorkerBlockingBusy } = vi.hoisted(() => ({
+	isWorkerBlockingBusy: vi.fn(),
 }));
 
 const { info, warn, error, debug } = vi.hoisted(() => ({
@@ -99,7 +99,7 @@ vi.mock("vscode", () => ({
 }));
 
 vi.mock("../util/LockUtils.js", () => ({
-	isWorkerBusy,
+	isWorkerBlockingBusy,
 }));
 
 vi.mock("../util/Logger.js", () => ({
@@ -173,8 +173,8 @@ function makeDeps() {
 
 describe("CommitCommand", () => {
 	beforeEach(() => {
-		isWorkerBusy.mockReset();
-		isWorkerBusy.mockResolvedValue(false);
+		isWorkerBlockingBusy.mockReset();
+		isWorkerBlockingBusy.mockResolvedValue(false);
 		showWarningMessage.mockReset();
 		showErrorMessage.mockReset();
 		showInformationMessage.mockReset();
@@ -187,7 +187,7 @@ describe("CommitCommand", () => {
 	});
 
 	it("stops immediately when the worker lock is held", async () => {
-		isWorkerBusy.mockResolvedValue(true);
+		isWorkerBlockingBusy.mockResolvedValue(true);
 		const deps = makeDeps();
 		const command = new CommitCommand(
 			deps.bridge as never,

--- a/vscode/src/commands/CommitCommand.ts
+++ b/vscode/src/commands/CommitCommand.ts
@@ -25,7 +25,7 @@ import type { JolliMemoryBridge } from "../JolliMemoryBridge.js";
 import type { CommitsStore } from "../stores/CommitsStore.js";
 import type { FilesStore } from "../stores/FilesStore.js";
 import type { StatusStore } from "../stores/StatusStore.js";
-import { isWorkerBusy } from "../util/LockUtils.js";
+import { isWorkerBlockingBusy } from "../util/LockUtils.js";
 import { log } from "../util/Logger.js";
 import type { StatusBarManager } from "../util/StatusBarManager.js";
 
@@ -70,8 +70,10 @@ export class CommitCommand {
 	 * Called when the user clicks [✦] in the Changes panel header.
 	 */
 	async execute(): Promise<void> {
-		// Guard: block while the post-commit Worker holds the lock
-		if (await isWorkerBusy(this.workspaceRoot)) {
+		// Guard: block while the post-commit Worker holds the lock for a summary
+		// run. The ingest phase (Memory Bank wiki update) is exempt — it never
+		// touches the commit pipeline, so committing during it is safe.
+		if (await isWorkerBlockingBusy(this.workspaceRoot)) {
 			vscode.window.showWarningMessage(
 				"Jolli Memory: AI summary is being generated. Please wait a moment.",
 			);

--- a/vscode/src/commands/CommitCommand.ts
+++ b/vscode/src/commands/CommitCommand.ts
@@ -171,6 +171,21 @@ export class CommitCommand {
 			return;
 		}
 
+		// Re-check the worker gate: the click-time check at the top goes stale
+		// during message generation + QuickPick review. A drain that was in the
+		// exempt ingest phase at click time may since have moved on to a blocking
+		// summary entry, and the Amend actions rewrite HEAD under its reads
+		// (same Bug-3 race class as Squash). Restore the index like the cancel
+		// path so the user's staging state survives the abort.
+		if (await isWorkerBlockingBusy(this.workspaceRoot)) {
+			log.warn("commit", "Worker became busy during QuickPick — aborting");
+			vscode.window.showWarningMessage(
+				"Jolli Memory: AI summary is being generated. Please wait a moment.",
+			);
+			await this.restoreIndex(originalIndexTree);
+			return;
+		}
+
 		// Step 5: Re-stage selected files to capture any edits made during message
 		// generation or QuickPick review, then execute the selected action.
 		try {

--- a/vscode/src/commands/SquashCommand.test.ts
+++ b/vscode/src/commands/SquashCommand.test.ts
@@ -186,6 +186,37 @@ describe("SquashCommand", () => {
 		);
 	});
 
+	it("re-checks the worker gate after the QuickPick and aborts when it turned busy", async () => {
+		// Click-time check passes (e.g. the worker was in the exempt ingest
+		// phase), but the same drain moves into a blocking summary run while
+		// the user reviews the QuickPick — the squash must not execute.
+		isWorkerBlockingBusy
+			.mockResolvedValueOnce(false)
+			.mockResolvedValueOnce(true);
+		const deps = makeDeps();
+		const command = new SquashCommand(
+			deps.bridge as never,
+			deps.commitsStore as never,
+			deps.filesStore as never,
+			deps.statusStore as never,
+			deps.statusBar as never,
+			"/repo",
+		);
+		vi.spyOn(command as never, "showSquashQuickPick").mockResolvedValue({
+			item: { label: "$(git-merge) Squash" },
+			message: "feat: squash",
+		});
+
+		await command.execute();
+
+		expect(isWorkerBlockingBusy).toHaveBeenCalledTimes(2);
+		expect(deps.bridge.getStagedFilePaths).not.toHaveBeenCalled();
+		expect(deps.bridge.squashCommits).not.toHaveBeenCalled();
+		expect(showWarningMessage).toHaveBeenCalledWith(
+			"Jolli Memory: AI summary is being generated. Please wait a moment.",
+		);
+	});
+
 	it("warns when fewer than two commits are selected", async () => {
 		const deps = makeDeps([makeCommit("cccc3333")]);
 		const command = new SquashCommand(

--- a/vscode/src/commands/SquashCommand.test.ts
+++ b/vscode/src/commands/SquashCommand.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { isWorkerBusy } = vi.hoisted(() => ({
-	isWorkerBusy: vi.fn(),
+const { isWorkerBlockingBusy } = vi.hoisted(() => ({
+	isWorkerBlockingBusy: vi.fn(),
 }));
 
 const { info, warn, error, debug } = vi.hoisted(() => ({
@@ -89,7 +89,7 @@ vi.mock("vscode", () => ({
 }));
 
 vi.mock("../util/LockUtils.js", () => ({
-	isWorkerBusy,
+	isWorkerBlockingBusy,
 }));
 
 vi.mock("../util/Logger.js", () => ({
@@ -154,8 +154,8 @@ function makeDeps(selected = [makeCommit("cccc3333"), makeCommit("bbbb2222")]) {
 
 describe("SquashCommand", () => {
 	beforeEach(() => {
-		isWorkerBusy.mockReset();
-		isWorkerBusy.mockResolvedValue(false);
+		isWorkerBlockingBusy.mockReset();
+		isWorkerBlockingBusy.mockResolvedValue(false);
 		showWarningMessage.mockReset();
 		showErrorMessage.mockReset();
 		showInformationMessage.mockReset();
@@ -168,7 +168,7 @@ describe("SquashCommand", () => {
 	});
 
 	it("blocks while the worker is busy", async () => {
-		isWorkerBusy.mockResolvedValue(true);
+		isWorkerBlockingBusy.mockResolvedValue(true);
 		const deps = makeDeps();
 		const command = new SquashCommand(
 			deps.bridge as never,

--- a/vscode/src/commands/SquashCommand.ts
+++ b/vscode/src/commands/SquashCommand.ts
@@ -58,8 +58,11 @@ export class SquashCommand {
 		// Guard: block while the post-commit Worker holds the lock for a summary
 		// run (squashing a commit mid-pipeline races the worker's history reads).
 		// The ingest phase (Memory Bank wiki update) is exempt — it never touches
-		// the code branch; a squash landed during it is enqueued and drained by
-		// the chain-spawned successor worker.
+		// the code branch; a squash landed during it is enqueued and drained
+		// right after the ingest entry, usually by the SAME worker in the same
+		// lock hold. That worker can therefore move into a blocking summary run
+		// while the user is still mid-flow here, which is why the gate is
+		// re-checked after the QuickPick below.
 		if (await isWorkerBlockingBusy(this.workspaceRoot)) {
 			vscode.window.showWarningMessage(
 				"Jolli Memory: AI summary is being generated. Please wait a moment.",
@@ -130,6 +133,19 @@ export class SquashCommand {
 		const selectedAction = await this.showSquashQuickPick(squashMessage);
 		if (!selectedAction) {
 			log.info("squash", "QuickPick cancelled by user");
+			return;
+		}
+
+		// Re-check the worker gate: the click-time check at the top goes stale
+		// during LLM message generation + QuickPick review (seconds to minutes).
+		// A drain that was in the exempt ingest phase at click time may since
+		// have moved on to a blocking summary entry — rewriting history under
+		// its reads is exactly the Bug-3 race the gate exists to prevent.
+		if (await isWorkerBlockingBusy(this.workspaceRoot)) {
+			log.warn("squash", "Worker became busy during QuickPick — aborting");
+			vscode.window.showWarningMessage(
+				"Jolli Memory: AI summary is being generated. Please wait a moment.",
+			);
 			return;
 		}
 

--- a/vscode/src/commands/SquashCommand.ts
+++ b/vscode/src/commands/SquashCommand.ts
@@ -20,7 +20,7 @@ import type { CommitsStore } from "../stores/CommitsStore.js";
 import type { FilesStore } from "../stores/FilesStore.js";
 import type { StatusStore } from "../stores/StatusStore.js";
 import type { BranchCommit } from "../Types.js";
-import { isWorkerBusy } from "../util/LockUtils.js";
+import { isWorkerBlockingBusy } from "../util/LockUtils.js";
 import { log } from "../util/Logger.js";
 import type { StatusBarManager } from "../util/StatusBarManager.js";
 
@@ -55,8 +55,12 @@ export class SquashCommand {
 	 * Called when the user clicks [⊞ Squash] in the Branch History panel header.
 	 */
 	async execute(): Promise<void> {
-		// Guard: block while the post-commit Worker holds the lock
-		if (await isWorkerBusy(this.workspaceRoot)) {
+		// Guard: block while the post-commit Worker holds the lock for a summary
+		// run (squashing a commit mid-pipeline races the worker's history reads).
+		// The ingest phase (Memory Bank wiki update) is exempt — it never touches
+		// the code branch; a squash landed during it is enqueued and drained by
+		// the chain-spawned successor worker.
+		if (await isWorkerBlockingBusy(this.workspaceRoot)) {
 			vscode.window.showWarningMessage(
 				"Jolli Memory: AI summary is being generated. Please wait a moment.",
 			);

--- a/vscode/src/util/LockUtils.test.ts
+++ b/vscode/src/util/LockUtils.test.ts
@@ -66,7 +66,7 @@ describe("isWorkerBlockingBusy", () => {
 		await expect(isWorkerBlockingBusy("/repo")).resolves.toBe(true);
 	});
 
-	it("returns false when busy with the ingest phase", async () => {
+	it("returns false when busy with a fresh ingest phase", async () => {
 		readFile.mockResolvedValue("ingest");
 
 		await expect(isWorkerBlockingBusy("/repo")).resolves.toBe(false);
@@ -84,6 +84,37 @@ describe("isWorkerBlockingBusy", () => {
 
 	it("treats an unknown phase as blocking", async () => {
 		readFile.mockResolvedValue("something-else");
+
+		await expect(isWorkerBlockingBusy("/repo")).resolves.toBe(true);
+	});
+
+	it("treats a stale ingest marker as blocking", async () => {
+		// The worker heartbeats an active ingest marker every 60 s; a marker
+		// whose mtime fell past the 5-min window is residue from a failed
+		// cleanup — the run in progress may be a blocking summary.
+		readFile.mockResolvedValue("ingest");
+		stat.mockImplementation((path: string) =>
+			Promise.resolve({
+				mtimeMs: path.includes("worker-phase")
+					? new Date("2026-03-29T23:59:00.000Z").getTime()
+					: new Date("2026-03-30T00:04:00.000Z").getTime(),
+			}),
+		);
+
+		await expect(isWorkerBlockingBusy("/repo")).resolves.toBe(true);
+	});
+
+	it("treats an ingest marker whose stat fails as blocking", async () => {
+		// readFile succeeded but the marker vanished (or is unreadable) before
+		// the freshness stat — fail safe to blocking.
+		readFile.mockResolvedValue("ingest");
+		stat.mockImplementation((path: string) =>
+			path.includes("worker-phase")
+				? Promise.reject(new Error("ENOENT"))
+				: Promise.resolve({
+						mtimeMs: new Date("2026-03-30T00:04:00.000Z").getTime(),
+					}),
+		);
 
 		await expect(isWorkerBlockingBusy("/repo")).resolves.toBe(true);
 	});

--- a/vscode/src/util/LockUtils.test.ts
+++ b/vscode/src/util/LockUtils.test.ts
@@ -1,14 +1,16 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { stat } = vi.hoisted(() => ({
+const { stat, readFile } = vi.hoisted(() => ({
 	stat: vi.fn(),
+	readFile: vi.fn(),
 }));
 
 vi.mock("node:fs/promises", () => ({
 	stat,
+	readFile,
 }));
 
-import { isWorkerBusy } from "./LockUtils.js";
+import { isWorkerBlockingBusy, isWorkerBusy } from "./LockUtils.js";
 
 describe("isWorkerBusy", () => {
 	beforeEach(() => {
@@ -36,5 +38,53 @@ describe("isWorkerBusy", () => {
 
 		await expect(isWorkerBusy("/repo")).resolves.toBe(false);
 		await expect(isWorkerBusy("/repo")).resolves.toBe(false);
+	});
+});
+
+describe("isWorkerBlockingBusy", () => {
+	beforeEach(() => {
+		stat.mockReset();
+		readFile.mockReset();
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date("2026-03-30T00:05:00.000Z"));
+		// Fresh lock by default — individual tests override.
+		stat.mockResolvedValue({
+			mtimeMs: new Date("2026-03-30T00:04:00.000Z").getTime(),
+		});
+	});
+
+	it("returns false when the worker is not busy at all", async () => {
+		stat.mockRejectedValue(new Error("ENOENT"));
+
+		await expect(isWorkerBlockingBusy("/repo")).resolves.toBe(false);
+		expect(readFile).not.toHaveBeenCalled();
+	});
+
+	it("returns true when busy with the default summary phase (no marker)", async () => {
+		readFile.mockRejectedValue(new Error("ENOENT"));
+
+		await expect(isWorkerBlockingBusy("/repo")).resolves.toBe(true);
+	});
+
+	it("returns false when busy with the ingest phase", async () => {
+		readFile.mockResolvedValue("ingest");
+
+		await expect(isWorkerBlockingBusy("/repo")).resolves.toBe(false);
+		expect(readFile).toHaveBeenCalledWith(
+			expect.stringContaining("worker-phase"),
+			"utf-8",
+		);
+	});
+
+	it("trims whitespace around the phase marker content", async () => {
+		readFile.mockResolvedValue("ingest\n");
+
+		await expect(isWorkerBlockingBusy("/repo")).resolves.toBe(false);
+	});
+
+	it("treats an unknown phase as blocking", async () => {
+		readFile.mockResolvedValue("something-else");
+
+		await expect(isWorkerBlockingBusy("/repo")).resolves.toBe(true);
 	});
 });

--- a/vscode/src/util/LockUtils.ts
+++ b/vscode/src/util/LockUtils.ts
@@ -22,7 +22,13 @@
 import { readFile, stat } from "node:fs/promises";
 import { join } from "node:path";
 
-/** Lock timeout matches `LOCK_TIMEOUT_MS` in cli/src/core/Locks.ts (5 minutes). */
+/**
+ * Lock timeout matches `LOCK_TIMEOUT_MS` in cli/src/core/Locks.ts (5 minutes).
+ * Doubles as the freshness window for the `worker-phase` marker: the worker
+ * heartbeats both `worker.lock` and an active `ingest` marker every 60 s
+ * (WORKER_LOCK_REFRESH_INTERVAL_MS in QueueWorker), so the same 5× margin
+ * applies to both files.
+ */
 const LOCK_TIMEOUT_MS = 5 * 60 * 1000;
 
 /**
@@ -46,28 +52,39 @@ export async function isWorkerBusy(cwd: string): Promise<boolean> {
  * git actions (Commit / Squash). The topic-KB ingest phase is exempt: it only
  * reads already-stored summaries and renders the Memory Bank wiki, never the
  * code branch or the commit pipeline, so blocking commit/squash for its
- * ~80s+ duration is pure UX damage. Any git op landed during ingest is simply
- * enqueued and drained by the chain-spawned successor worker.
+ * ~80s+ duration is pure UX damage. Any git op landed during ingest is queued
+ * and drained right after the ingest entry — usually by the SAME worker, in
+ * the same lock hold (the drain loop re-dequeues between entries; a
+ * chain-spawned successor only covers ops that land after the drain exits).
+ * That is why callers with a long user interaction between the gate check and
+ * the actual git op (Commit/Squash: LLM message generation + QuickPick) must
+ * re-check this gate immediately before executing.
  *
- * The phase comes from the cosmetic `worker-phase` marker the QueueWorker
- * writes next to `worker.lock` (see WORKER_PHASE_FILE in cli/src/core/Locks.ts).
- * A missing/unreadable marker means the default summary phase → blocking.
+ * The phase comes from the `worker-phase` marker the QueueWorker writes next
+ * to `worker.lock` (see WORKER_PHASE_FILE in cli/src/core/Locks.ts). A
+ * missing/unreadable marker means the default summary phase → blocking. An
+ * `ingest` marker is honoured only while its mtime is fresh: the worker
+ * heartbeats the marker during a genuine ingest, so a stale one is residue
+ * from a failed cleanup and the run in progress may well be a blocking
+ * summary — treat it as such (fail-safe).
  */
 export async function isWorkerBlockingBusy(cwd: string): Promise<boolean> {
 	if (!(await isWorkerBusy(cwd))) {
 		return false;
 	}
-	return (await readWorkerPhase(cwd)) !== "ingest";
+	return !(await isFreshIngestPhase(cwd));
 }
 
-async function readWorkerPhase(cwd: string): Promise<string | null> {
+async function isFreshIngestPhase(cwd: string): Promise<boolean> {
+	const phasePath = join(cwd, ".jolli", "jollimemory", "worker-phase");
 	try {
-		const content = await readFile(
-			join(cwd, ".jolli", "jollimemory", "worker-phase"),
-			"utf-8",
-		);
-		return content.trim();
+		const content = await readFile(phasePath, "utf-8");
+		if (content.trim() !== "ingest") {
+			return false;
+		}
+		const phaseStat = await stat(phasePath);
+		return Date.now() - phaseStat.mtimeMs < LOCK_TIMEOUT_MS;
 	} catch {
-		return null;
+		return false;
 	}
 }

--- a/vscode/src/util/LockUtils.ts
+++ b/vscode/src/util/LockUtils.ts
@@ -4,8 +4,9 @@
  * The post-commit Worker holds `.jolli/jollimemory/worker.lock` while running
  * the LLM summarization pipeline (~20-40s). These helpers let the extension and
  * command classes check the lock state to prevent race conditions
- * (Commit / Squash are gated on it). Push is intentionally NOT gated: it only
- * runs `git push` on the current branch and shares no state with the worker.
+ * (Commit / Squash are gated on it — via `isWorkerBlockingBusy`, which exempts
+ * the ingest phase). Push is intentionally NOT gated: it only runs `git push`
+ * on the current branch and shares no state with the worker.
  *
  * Notes on the lock split:
  *   - `worker.lock` is the QueueWorker's "I'm draining the queue" marker; this
@@ -18,7 +19,7 @@
  *     module is updated in lockstep with `Locks.ts`.
  */
 
-import { stat } from "node:fs/promises";
+import { readFile, stat } from "node:fs/promises";
 import { join } from "node:path";
 
 /** Lock timeout matches `LOCK_TIMEOUT_MS` in cli/src/core/Locks.ts (5 minutes). */
@@ -37,5 +38,36 @@ export async function isWorkerBusy(cwd: string): Promise<boolean> {
 		return ageMs < LOCK_TIMEOUT_MS;
 	} catch {
 		return false;
+	}
+}
+
+/**
+ * Returns true only when the worker is busy with a phase that must block user
+ * git actions (Commit / Squash). The topic-KB ingest phase is exempt: it only
+ * reads already-stored summaries and renders the Memory Bank wiki, never the
+ * code branch or the commit pipeline, so blocking commit/squash for its
+ * ~80s+ duration is pure UX damage. Any git op landed during ingest is simply
+ * enqueued and drained by the chain-spawned successor worker.
+ *
+ * The phase comes from the cosmetic `worker-phase` marker the QueueWorker
+ * writes next to `worker.lock` (see WORKER_PHASE_FILE in cli/src/core/Locks.ts).
+ * A missing/unreadable marker means the default summary phase → blocking.
+ */
+export async function isWorkerBlockingBusy(cwd: string): Promise<boolean> {
+	if (!(await isWorkerBusy(cwd))) {
+		return false;
+	}
+	return (await readWorkerPhase(cwd)) !== "ingest";
+}
+
+async function readWorkerPhase(cwd: string): Promise<string | null> {
+	try {
+		const content = await readFile(
+			join(cwd, ".jolli", "jollimemory", "worker-phase"),
+			"utf-8",
+		);
+		return content.trim();
+	} catch {
+		return null;
 	}
 }

--- a/vscode/src/views/SidebarScriptBuilder.test.ts
+++ b/vscode/src/views/SidebarScriptBuilder.test.ts
@@ -970,16 +970,48 @@ describe("SidebarScriptBuilder", () => {
 		it("disables changes-commit-ai while a background AI summary is in progress", () => {
 			const js = buildSidebarScript();
 			// Even with selected changes, the Commit-AI button must stay
-			// disabled when state.workerBusy is true — kicking off another
-			// LLM call while the queue worker is mid-flight risks racing
-			// the same provider / hitting rate limits. Discard stays
-			// available because it's purely local (no LLM).
+			// disabled during a summary run — kicking off another LLM call
+			// while the queue worker is mid-summary risks racing the same
+			// provider / hitting rate limits. The check is phase-aware
+			// (isWorkerBlocking), NOT raw state.workerBusy: the ingest phase
+			// (Memory Bank wiki update) must not block committing. Discard
+			// stays available because it's purely local (no LLM).
 			expect(js).toMatch(
-				/iconButton\('changes-commit-ai',[\s\S]*?disabled:\s*noneSelected\s*\|\|\s*state\.workerBusy/,
+				/iconButton\('changes-commit-ai',[\s\S]*?disabled:\s*noneSelected\s*\|\|\s*isWorkerBlocking\(\)/,
 			);
-			// Discard's disabled condition must NOT include workerBusy.
+			// Discard's disabled condition must NOT include the busy check.
 			expect(js).toMatch(
 				/iconButton\('changes-discard',[\s\S]*?disabled:\s*noneSelected\s*\}/,
+			);
+		});
+
+		it("disables commits-squash while a background AI summary is in progress", () => {
+			const js = buildSidebarScript();
+			// The squash button must mirror the SquashCommand handler gate and the
+			// jollimemory.workerBusy command enablement: disabled during a blocking
+			// worker run (ingest exempt via isWorkerBlocking), on top of the
+			// 2+-selected threshold. Without this, the button stays clickable
+			// mid-summary even though the handler refuses — UI/handler mismatch.
+			expect(js).toMatch(
+				/iconButton\('commits-squash',[\s\S]*?disabled:\s*selectedCount < 2\s*\|\|\s*isWorkerBlocking\(\)/,
+			);
+			// Push Branch is not worker-gated at all.
+			expect(js).toMatch(
+				/iconButton\('commits-push-branch', 'Push Branch',\s*'cloud-upload'\),/,
+			);
+		});
+
+		it("exempts the ingest phase from disabling commit actions", () => {
+			const js = buildSidebarScript();
+			// isWorkerBlocking is the single busy predicate for commit actions:
+			// busy in any phase except ingest.
+			expect(js).toContain(
+				"return state.workerBusy && state.workerPhase !== 'ingest';",
+			);
+			// Both commit entry points go through it: the Commit-AI icon button
+			// (asserted above) and the labelled Commit Memory button.
+			expect(js).toMatch(
+				/const disabled = selectedCount === 0 \|\| isWorkerBlocking\(\);/,
 			);
 		});
 	});
@@ -2089,5 +2121,20 @@ describe("SidebarScriptBuilder", () => {
 	it("handles the worker:phase message channel", () => {
 		const js = buildSidebarScript();
 		expect(js).toContain("case 'worker:phase'");
+	});
+
+	it("re-renders toolbar AND branch when worker:phase changes on the Branch tab", () => {
+		const js = buildSidebarScript();
+		// The phase drives the commit buttons' disabled state (ingest is exempt
+		// from blocking — isWorkerBlocking), so renderToolbar alone is not
+		// enough: section actions live in renderBranch.
+		const handlerStart = js.indexOf("case 'worker:phase'");
+		const handlerEnd = js.indexOf("case ", handlerStart + 1);
+		expect(handlerStart).toBeGreaterThan(-1);
+		const body = js.slice(handlerStart, handlerEnd);
+		// Idempotent: skip re-render when the phase did not change.
+		expect(body).toContain("if (state.workerPhase === nextPhase) break;");
+		expect(body).toContain("renderToolbar()");
+		expect(body).toContain("renderBranch()");
 	});
 });

--- a/vscode/src/views/SidebarScriptBuilder.ts
+++ b/vscode/src/views/SidebarScriptBuilder.ts
@@ -707,10 +707,16 @@ export function buildSidebarScript(): string {
       case 'worker:phase': {
         // Per-phase label for the post-commit Worker. Independent of
         // worker:busy; only 'ingest' is surfaced today, anything else clears to
-        // the default summary label. Only the Branch tab reacts.
-        state.workerPhase = (msg.phase === 'ingest') ? 'ingest' : null;
+        // the default summary label. Only the Branch tab reacts. renderBranch
+        // runs too because the commit buttons' disabled state depends on the
+        // phase (ingest is exempt from blocking — see isWorkerBlocking), not
+        // just on worker:busy.
+        const nextPhase = (msg.phase === 'ingest') ? 'ingest' : null;
+        if (state.workerPhase === nextPhase) break;
+        state.workerPhase = nextPhase;
         if (state.activeTab === 'branch') {
           renderToolbar();
+          renderBranch();
         }
         break;
       }
@@ -2647,11 +2653,19 @@ export function buildSidebarScript(): string {
     }, sectionKids);
   }
 
+  function isWorkerBlocking() {
+    // Busy with a phase that must disable commit actions. The ingest phase
+    // (Memory Bank wiki update, ~80s+) is exempt: it never touches the commit
+    // pipeline, so commits landed during it are simply queued for the next
+    // worker. Mirrors isWorkerBlockingBusy in util/LockUtils.ts.
+    return state.workerBusy && state.workerPhase !== 'ingest';
+  }
+
   function renderCommitMemoryButton() {
     const selectedCount = branchData.changes.filter(function(c) {
       return !!c.isSelected;
     }).length;
-    const disabled = selectedCount === 0 || state.workerBusy;
+    const disabled = selectedCount === 0 || isWorkerBlocking();
     const btn = el('button', {
       type: 'button',
       className: 'commit-memory-btn',
@@ -2686,16 +2700,17 @@ export function buildSidebarScript(): string {
       // that threshold. Re-enables itself on the next branch:changesData
       // push (which always follows a checkbox toggle on the host side).
       // Commit-AI is also disabled while a background AI summary is in
-      // progress (state.workerBusy) — kicking off another LLM call while
-      // the queue worker is mid-flight risks racing the same provider /
-      // hitting rate limits. Discard is local-only so it stays available.
+      // progress (isWorkerBlocking) — kicking off another LLM call while
+      // the queue worker is mid-summary risks racing the same provider /
+      // hitting rate limits. The ingest phase is exempt (see isWorkerBlocking).
+      // Discard is local-only so it stays available.
       const selectedCount = branchData.changes.filter(function(c) {
         return !!c.isSelected;
       }).length;
       const noneSelected = selectedCount === 0;
       return [
         iconButton('changes-select-all', 'Select/Deselect All Files', 'check-all'),
-        iconButton('changes-commit-ai',  'Commit (AI message)',       'sparkle',  { disabled: noneSelected || state.workerBusy }),
+        iconButton('changes-commit-ai',  'Commit (AI message)',       'sparkle',  { disabled: noneSelected || isWorkerBlocking() }),
         iconButton('changes-discard',    'Discard Selected Changes',  'discard',  { disabled: noneSelected }),
       ];
     }
@@ -2710,6 +2725,10 @@ export function buildSidebarScript(): string {
         // button below that threshold; it auto-re-enables when the user picks
         // a 2nd commit because branch:commitsData triggers renderBranch which
         // rebuilds these section actions with a fresh selectedCount.
+        // Squash is also disabled while a blocking worker run is in progress
+        // (isWorkerBlocking, ingest exempt) so the button matches the
+        // SquashCommand handler gate and the jollimemory.workerBusy command
+        // enablement — same pairing as changes-commit-ai above.
         // Push Branch is also exposed in multi mode now that PushCommand
         // supports any commit count >= 1 — squashing remains a user choice,
         // not a precondition.
@@ -2718,7 +2737,7 @@ export function buildSidebarScript(): string {
         }).length;
         return [
           iconButton('commits-select-all', 'Select/Deselect All Commits', 'check-all'),
-          iconButton('commits-squash',     'Squash Selected',             'git-merge', { disabled: selectedCount < 2 }),
+          iconButton('commits-squash',     'Squash Selected',             'git-merge', { disabled: selectedCount < 2 || isWorkerBlocking() }),
           iconButton('commits-push-branch', 'Push Branch',                'cloud-upload'),
         ];
       }

--- a/vscode/src/views/SummaryWebviewPanel.test.ts
+++ b/vscode/src/views/SummaryWebviewPanel.test.ts
@@ -387,12 +387,12 @@ vi.mock("../services/PrCommentService.js", () => ({
 	wrapWithMarkers: (s: string) => `[MARKERS]${s}[/MARKERS]`,
 }));
 
-const { mockIsWorkerBusy } = vi.hoisted(() => ({
-	mockIsWorkerBusy: vi.fn().mockResolvedValue(false),
+const { mockIsWorkerBlockingBusy } = vi.hoisted(() => ({
+	mockIsWorkerBlockingBusy: vi.fn().mockResolvedValue(false),
 }));
 
 vi.mock("../util/LockUtils.js", () => ({
-	isWorkerBusy: mockIsWorkerBusy,
+	isWorkerBlockingBusy: mockIsWorkerBlockingBusy,
 }));
 
 const { mockLoadBranchSummaries } = vi.hoisted(() => ({
@@ -3877,7 +3877,7 @@ describe("SummaryWebviewPanel", () => {
 			});
 
 			it("worker-busy: shows warning + re-runs handleCheckPrStatus to reset the button", async () => {
-				mockIsWorkerBusy.mockResolvedValueOnce(true);
+				mockIsWorkerBlockingBusy.mockResolvedValueOnce(true);
 				const dispatch = await setupPanel();
 
 				dispatch({ command: "prepareCreatePr" });
@@ -4055,7 +4055,7 @@ describe("SummaryWebviewPanel", () => {
 			});
 
 			it("worker-busy: shows warning + re-runs handleCheckPrStatus to reset the button", async () => {
-				mockIsWorkerBusy.mockResolvedValueOnce(true);
+				mockIsWorkerBlockingBusy.mockResolvedValueOnce(true);
 				const dispatch = await setupPanel();
 
 				dispatch({ command: "prepareUpdatePr" });

--- a/vscode/src/views/SummaryWebviewPanel.ts
+++ b/vscode/src/views/SummaryWebviewPanel.ts
@@ -77,7 +77,7 @@ import {
 	deriveRepoNameFromUrl,
 	getCanonicalRepoUrl,
 } from "../util/GitRemoteUtils.js";
-import { isWorkerBusy } from "../util/LockUtils.js";
+import { isWorkerBlockingBusy } from "../util/LockUtils.js";
 import { log } from "../util/Logger.js";
 import { loadGlobalConfig } from "../util/WorkspaceUtils.js";
 import { BindingChooserWebviewPanel } from "./BindingChooserWebviewPanel.js";
@@ -1522,12 +1522,15 @@ export class SummaryWebviewPanel {
 		);
 	}
 
-	// Returns true when worker is busy: shows the toast and re-runs the
-	// status check so the click-time "Loading..." button gets rebuilt.
+	// Returns true when worker is busy with a blocking (summary) run: shows the
+	// toast and re-runs the status check so the click-time "Loading..." button
+	// gets rebuilt. The ingest phase is exempt, same as the Commit/Squash gates:
+	// PR creation reads already-stored orphan-branch summaries, which ingest
+	// never writes — blocking it for ingest's ~80s+ duration is pure UX damage.
 	private async handleWorkerBusyOrContinue(
 		postMessage: (msg: Record<string, unknown>) => void,
 	): Promise<boolean> {
-		if (!(await isWorkerBusy(this.workspaceRoot))) {
+		if (!(await isWorkerBlockingBusy(this.workspaceRoot))) {
 			return false;
 		}
 		vscode.window.showWarningMessage(


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## E2E Test (3)
<details>
<summary><strong>1. Commit and Squash remain enabled during Memory Bank wiki update</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a repository with uncommitted changes ready. You will need to trigger a Memory Bank update (the wiki generation step that normally blocks commits for 80+ seconds).

**Steps:**
1. Open the Source Control panel in VS Code and verify you have changes to commit.
2. Trigger a Memory Bank update by running the post-commit worker (or wait for one to start automatically after a commit). Watch the status bar — it should show "Jolli Memory: AI summary in progress" or similar.
3. While the status bar still shows the worker is running, look at the commit button in the Changes panel header. It should be ENABLED (not grayed out).
4. Click the commit button and verify the commit dialog opens normally — you should NOT see a "AI summary is being generated" warning message.
5. Close the dialog without committing. Wait for the worker to finish (status bar clears), then verify the commit button is still enabled.

**Expected Results:**
- The commit button stays clickable throughout the entire worker run, even during the long wiki update phase.
- No warning message appears when you attempt to commit while the worker is active.
- The button does not become disabled until after the worker fully completes.

</blockquote>
</details>
<details>
<summary><strong>2. Squash remains enabled during Memory Bank wiki update</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a repository with at least 2 commits in the branch history that could be squashed together.

**Steps:**
1. Open the Branch History panel and select 2 or more commits to squash.
2. Trigger a Memory Bank update (post-commit worker run). Watch the status bar for the worker progress indicator.
3. While the worker is still running, look at the Squash button in the Branch History panel header. It should be ENABLED (not grayed out).
4. Click the Squash button and verify the squash dialog opens — you should NOT see a "AI summary is being generated" warning message.
5. Close the dialog without squashing. Wait for the worker to finish, then verify the Squash button is still enabled.

**Expected Results:**
- The Squash button stays clickable while the worker is running the wiki update phase.
- No warning message appears when you attempt to squash during the worker run.
- The button does not become disabled until after the worker fully completes.

</blockquote>
</details>
<details>
<summary><strong>3. Commit and Squash are blocked during actual AI summary generation</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a repository with uncommitted changes and at least 2 commits in history.

**Steps:**
1. Open the Source Control panel and verify you have changes to commit.
2. Make a commit to trigger the post-commit worker. The worker will start the AI summary generation phase (not the wiki update).
3. Immediately (while the status bar shows the worker is active), look at the commit button in the Changes panel. It should be DISABLED (grayed out).
4. Try to click the commit button. A warning message should appear saying "Jolli Memory: AI summary is being generated. Please wait a moment."
5. Switch to the Branch History panel and try to click the Squash button. It should also be DISABLED and show the same warning if clicked.
6. Wait for the worker to finish. Both buttons should become ENABLED again.

**Expected Results:**
- Both commit and squash buttons are disabled during the AI summary phase.
- Attempting to click either button shows a "Please wait" warning message.
- Buttons re-enable once the worker completes.

</blockquote>
</details>

---

## Topic (1)
<details>
<summary><strong>01 · Exempt Memory Bank ingest phase from blocking commit and squash operations</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Updating the Memory Bank knowledge wiki (the ingest phase) was blocking users from committing or squashing commits because the worker lock check could not distinguish between the long-running wiki update and the actual commit summarization pipeline. Users had to wait 80+ seconds for the wiki update to finish before they could perform any git operations.

**💡 Decisions Behind the Code**

- **Phase marker as the exemption signal**: Rather than adding a new lock file or changing the worker protocol, the fix leverages the existing `worker-phase` marker that the QueueWorker already writes. This minimizes coupling and keeps the lock-file contract stable. The marker is read on-demand when the lock is detected, avoiding filesystem overhead during normal operation.
- **Mirrored state in Extension.ts**: The phase state is tracked locally in the extension rather than read back from StatusStore on every context-key update. This keeps the blocking decision a pure function of what the two watchers reported, making the logic easier to reason about and test. The phase is cleared when the lock is released, preventing crash-left markers from affecting the next worker run.
- **Dual rendering on phase change**: When the phase marker is created or deleted, both the toolbar (for the status label) and the branch section (for the commit button disabled state) are re-rendered. This ensures the UI stays consistent even though the two pieces of state (cosmetic phase label vs. blocking decision) are logically separate, and it avoids the complexity of trying to predict which tab is active.

**✅ What Was Implemented**

- Added a new `isWorkerBlockingBusy` function in LockUtils.ts that checks both the worker lock AND the worker-phase marker file. When the phase is "ingest", the function returns false even though the lock is held, allowing commit and squash operations to proceed. The ingest phase only reads stored summaries and renders the wiki, never touching the code branch or commit pipeline.
- Updated CommitCommand.ts and SquashCommand.ts to call `isWorkerBlockingBusy` instead of `isWorkerBusy`, with clarifying comments explaining that ingest is exempt because git operations landed during it are simply queued for the next worker.
- Modified Extension.ts to track the worker phase state locally and recompute the `jollimemory.workerBusy` context key (which gates the commit/squash command enablement) whenever the phase changes. The context now reflects "busy AND not ingest" rather than just "busy", and the phase lifetime is bound to the lock so crash-left markers don't leak into subsequent runs.
- Updated SidebarScriptBuilder.ts to add an `isWorkerBlocking()` helper function that mirrors the backend logic, and changed the commit button disabled state to use this function instead of raw `state.workerBusy`. When the phase changes on the Branch tab, both the toolbar and branch section are re-rendered to update button states.

**📁 FILES**
- `vscode/src/util/LockUtils.ts`
- `vscode/src/commands/CommitCommand.ts`
- `vscode/src/commands/SquashCommand.ts`
- `vscode/src/Extension.ts`
- `vscode/src/views/SidebarScriptBuilder.ts`

</blockquote>
</details>

---

*Generated by Jolli Memory · June 12, 2026 at 3:39 PM · via Anthropic*
<!-- jollimemory-summary-end -->