### PR TITLE
Unify Plans, Notes, and References panel row interactions to preview-on-click with edit/remove via context menu

### DIFF
--- a/vscode/src/Extension.test.ts
+++ b/vscode/src/Extension.test.ts
@@ -302,6 +302,7 @@ const {
 		listReferences: vi.fn().mockResolvedValue([]),
 		openReferenceInBrowser: vi.fn().mockResolvedValue(undefined),
 		openReferenceMarkdown: vi.fn().mockResolvedValue(undefined),
+		previewReferenceMarkdown: vi.fn().mockResolvedValue(undefined),
 		removeReference: vi.fn().mockResolvedValue(undefined),
 	};
 
@@ -2009,6 +2010,7 @@ describe("Extension", () => {
 				mockBridge.listReferences.mockReset().mockResolvedValue([]);
 				mockBridge.openReferenceInBrowser.mockClear();
 				mockBridge.openReferenceMarkdown.mockClear();
+				mockBridge.previewReferenceMarkdown.mockClear();
 				mockBridge.removeReference.mockClear();
 				showWarningMessage.mockClear();
 			});
@@ -2107,6 +2109,33 @@ describe("Extension", () => {
 					expect.stringContaining("linear:ENG-missing"),
 				);
 				expect(mockBridge.openReferenceMarkdown).not.toHaveBeenCalled();
+			});
+
+			it("openReferenceForPreview: dispatches to bridge.previewReferenceMarkdown when mapKey resolves", async () => {
+				const info = {
+					mapKey: "github:owner/repo#42",
+					source: "github",
+				};
+				mockBridge.listReferences.mockResolvedValueOnce([info as never]);
+
+				const handler = getRegisteredCommand(
+					"jollimemory.openReferenceForPreview",
+				);
+				await handler("github:owner/repo#42");
+
+				expect(mockBridge.previewReferenceMarkdown).toHaveBeenCalledWith(info);
+			});
+
+			it("openReferenceForPreview: warns on miss without dispatching", async () => {
+				const handler = getRegisteredCommand(
+					"jollimemory.openReferenceForPreview",
+				);
+				await handler("linear:ENG-missing");
+
+				expect(showWarningMessage).toHaveBeenCalledWith(
+					expect.stringContaining("linear:ENG-missing"),
+				);
+				expect(mockBridge.previewReferenceMarkdown).not.toHaveBeenCalled();
 			});
 
 			it("ignoreReference: marks the entity ignored and refreshes plans", async () => {
@@ -7089,9 +7118,11 @@ describe("Extension", () => {
 		});
 
 		it("falls back to the orphan-branch snapshot when the plan has no filePath (I16)", async () => {
-			// Plan is in the snapshot but `filePath` is empty (committed-plan case
-			// where the source file path is intentionally blanked). The preview
-			// command must fall through to showPlanPreview rather than firing
+			// Plan is in the snapshot but `filePath` is empty. PlanService no
+			// longer blanks filePath for committed guard rows (they keep the
+			// on-disk path so Edit / Preview open the modified file), so this is
+			// a defensive registry-out-of-sync case. The preview command must
+			// fall through to showPlanPreview rather than firing
 			// markdown.showPreview against a missing local path. The signal is
 			// readPlanFromBranch being invoked, which only happens in the
 			// orphan-branch fallback.

--- a/vscode/src/Extension.ts
+++ b/vscode/src/Extension.ts
@@ -2452,6 +2452,23 @@ export function activate(context: vscode.ExtensionContext): void {
 			},
 		),
 
+		// Sidebar row-click preview for references — same click-equals-preview
+		// contract as openPlanForPreview / openNoteForPreview. Editing the
+		// markdown goes through the context menu (openReferenceMarkdown).
+		vscode.commands.registerCommand(
+			"jollimemory.openReferenceForPreview",
+			async (itemOrKey: ReferenceItem | string) => {
+				const mapKey =
+					typeof itemOrKey === "string" ? itemOrKey : itemOrKey.reference.mapKey;
+				log.info("cmd", `openReferenceForPreview: ${mapKey}`);
+				const info = await resolveReferenceForCommand(
+					mapKey,
+					"openReferenceForPreview",
+				);
+				if (info) await bridge.previewReferenceMarkdown(info);
+			},
+		),
+
 		vscode.commands.registerCommand(
 			"jollimemory.ignoreReference",
 			async (itemOrKey: ReferenceItem | string) => {

--- a/vscode/src/JolliMemoryBridge.test.ts
+++ b/vscode/src/JolliMemoryBridge.test.ts
@@ -352,6 +352,7 @@ vi.mock("./core/ReferenceService.js", () => ({
 	removeReference: vi.fn().mockResolvedValue(undefined),
 	openReferenceInBrowser: vi.fn().mockResolvedValue(true),
 	openReferenceMarkdown: vi.fn().mockResolvedValue(undefined),
+	previewReferenceMarkdown: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock("./util/CommitMessageUtils.js", () => ({
@@ -3463,6 +3464,25 @@ describe("JolliMemoryBridge", () => {
 			await bridge.openReferenceMarkdown(info);
 
 			expect(openReferenceMarkdown).toHaveBeenCalledWith(info);
+		});
+
+		it("previewReferenceMarkdown() delegates to previewReferenceMarkdown impl", async () => {
+			const { previewReferenceMarkdown } = await import(
+				"./core/ReferenceService.js"
+			);
+			(previewReferenceMarkdown as ReturnType<typeof vi.fn>).mockResolvedValue(
+				undefined,
+			);
+			const info = {
+				kind: "reference",
+				source: "notion",
+				sourcePath: "/x.md",
+			} as unknown as Parameters<typeof bridge.previewReferenceMarkdown>[0];
+			const bridge = makeBridge();
+
+			await bridge.previewReferenceMarkdown(info);
+
+			expect(previewReferenceMarkdown).toHaveBeenCalledWith(info);
 		});
 	});
 

--- a/vscode/src/JolliMemoryBridge.ts
+++ b/vscode/src/JolliMemoryBridge.ts
@@ -87,6 +87,7 @@ import {
 	detectReferences,
 	openReferenceInBrowser as openReferenceInBrowserImpl,
 	openReferenceMarkdown as openReferenceMarkdownImpl,
+	previewReferenceMarkdown as previewReferenceMarkdownImpl,
 	removeReference,
 } from "./core/ReferenceService.js";
 import {
@@ -2368,6 +2369,11 @@ export class JolliMemoryBridge {
 	/** Opens the per-reference markdown file in a VS Code editor tab. */
 	openReferenceMarkdown(info: ReferenceInfo): Promise<void> {
 		return openReferenceMarkdownImpl(info);
+	}
+
+	/** Opens the per-reference markdown file in the rendered markdown preview. */
+	previewReferenceMarkdown(info: ReferenceInfo): Promise<void> {
+		return previewReferenceMarkdownImpl(info);
 	}
 }
 

--- a/vscode/src/core/PlanService.test.ts
+++ b/vscode/src/core/PlanService.test.ts
@@ -1075,9 +1075,12 @@ describe("PlanService", () => {
 
 			expect(plans).toHaveLength(1);
 			expect(plans[0].slug).toBe("modified-plan");
-			// Committed plan: filePath is empty, stat/title extraction skipped
-			expect(plans[0].filePath).toBe("");
-			expect(plans[0].lastModified).toBe("2025-06-01T00:00:00.000Z");
+			// Committed-then-modified guard: filePath keeps the on-disk path and
+			// title and lastModified reflect the file, so Edit / Preview open the
+			// same local content shown in the row — same contract as NoteService guards.
+			expect(plans[0].title).toBe("Modified Plan");
+			expect(plans[0].filePath).toBe(`${PLANS_DIR}/modified-plan.md`);
+			expect(plans[0].lastModified).toBe("2025-07-01T00:00:00.000Z");
 		});
 
 		it("filters out uncommitted plans whose source file has been deleted", async () => {

--- a/vscode/src/core/PlanService.ts
+++ b/vscode/src/core/PlanService.ts
@@ -145,15 +145,19 @@ function toPlanInfo(entry: PlanEntry): PlanInfo | null {
 		return null;
 	}
 
-	const filePath = entry.commitHash === null ? entry.sourcePath : "";
+	// Keep the on-disk path for committed-then-modified guard rows too: the row
+	// is only visible because the source file changed after the commit, so Edit
+	// and Preview must open that local file — mirrors NoteService.toNoteInfo,
+	// which never blanks filePath for guard rows.
+	const filePath = entry.sourcePath;
 
 	let title = entry.title;
-	if (entry.commitHash === null && existsSync(entry.sourcePath)) {
+	if (existsSync(entry.sourcePath)) {
 		title = extractTitle(entry.sourcePath);
 	}
 
 	let lastModified = entry.updatedAt;
-	if (entry.commitHash === null && existsSync(entry.sourcePath)) {
+	if (existsSync(entry.sourcePath)) {
 		try {
 			lastModified = statSync(entry.sourcePath).mtime.toISOString();
 		} catch {

--- a/vscode/src/core/ReferenceService.test.ts
+++ b/vscode/src/core/ReferenceService.test.ts
@@ -10,6 +10,7 @@ const {
 	mockOpenExternal,
 	mockShowWarningMessage,
 	mockDeleteReferenceMarkdown,
+	mockExecuteCommand,
 } = vi.hoisted(() => ({
 	mockLoadPlansRegistry: vi.fn(),
 	mockLoadPlansRegistryWithStatus: vi.fn(),
@@ -20,6 +21,7 @@ const {
 	mockOpenExternal: vi.fn(),
 	mockShowWarningMessage: vi.fn(),
 	mockDeleteReferenceMarkdown: vi.fn(),
+	mockExecuteCommand: vi.fn(),
 }));
 
 // plans.lock passthrough — run the RMW body inline (no real lock file I/O on the
@@ -58,6 +60,7 @@ vi.mock("vscode", () => ({
 		file: vi.fn((p: string) => ({ toString: () => p })),
 	},
 	env: { openExternal: mockOpenExternal },
+	commands: { executeCommand: mockExecuteCommand },
 	window: {
 		showTextDocument: mockShowTextDocument,
 		showWarningMessage: mockShowWarningMessage,
@@ -76,6 +79,7 @@ import {
 	detectReferences,
 	openReferenceInBrowser,
 	openReferenceMarkdown,
+	previewReferenceMarkdown,
 	removeReference,
 } from "./ReferenceService.js";
 
@@ -621,5 +625,39 @@ describe("openReferenceMarkdown", () => {
 			sourceToolName: "y",
 		});
 		expect(mockShowTextDocument).toHaveBeenCalledOnce();
+	});
+});
+
+describe("previewReferenceMarkdown", () => {
+	it("opens the rendered markdown preview instead of a text editor", async () => {
+		mockExecuteCommand.mockResolvedValue(undefined);
+		mockShowTextDocument.mockClear();
+		await previewReferenceMarkdown({
+			kind: "reference",
+			source: "jira",
+			nativeId: "KAN-5",
+			mapKey: "jira:KAN-5",
+			title: "t",
+			url: "https://example.atlassian.net/browse/KAN-5",
+			sourcePath: "/repo/.jolli/jollimemory/references/jira/KAN-5.md",
+			branch: "main",
+			addedAt: "x",
+			updatedAt: "x",
+			lastModified: "x",
+			commitHash: null,
+			ignored: false,
+			sourceToolName: "y",
+		});
+		// Assert the preview targets the reference's own sourcePath, not just
+		// "some URI" — catches a regression that previews the wrong file. The
+		// mocked vscode.Uri.file stringifies back to the path it was given.
+		const previewCall = mockExecuteCommand.mock.calls.find(
+			(c) => c[0] === "markdown.showPreview",
+		);
+		expect(previewCall).toBeDefined();
+		expect((previewCall?.[1] as { toString(): string }).toString()).toBe(
+			"/repo/.jolli/jollimemory/references/jira/KAN-5.md",
+		);
+		expect(mockShowTextDocument).not.toHaveBeenCalled();
 	});
 });

--- a/vscode/src/core/ReferenceService.ts
+++ b/vscode/src/core/ReferenceService.ts
@@ -156,10 +156,21 @@ export async function openReferenceInBrowser(info: ReferenceInfo): Promise<boole
 	return vscode.env.openExternal(uri);
 }
 
-/** Opens the per-reference markdown file in VS Code. */
+/** Opens the per-reference markdown file in a VS Code text editor (editable). */
 export async function openReferenceMarkdown(info: ReferenceInfo): Promise<void> {
 	const uri = vscode.Uri.file(info.sourcePath);
 	await vscode.window.showTextDocument(uri);
+}
+
+/**
+ * Opens the per-reference markdown file in the rendered markdown preview.
+ * Sidebar row-click path — mirrors openPlanForPreview / openNoteForPreview so
+ * every Plans & Notes row previews on click; editing goes through the
+ * context menu's "Edit Markdown" (openReferenceMarkdown).
+ */
+export async function previewReferenceMarkdown(info: ReferenceInfo): Promise<void> {
+	const uri = vscode.Uri.file(info.sourcePath);
+	await vscode.commands.executeCommand("markdown.showPreview", uri);
 }
 
 // ─── Internal helpers ────────────────────────────────────────────────────────

--- a/vscode/src/views/SidebarCssBuilder.test.ts
+++ b/vscode/src/views/SidebarCssBuilder.test.ts
@@ -51,6 +51,21 @@ describe("SidebarCssBuilder", () => {
 		expect(css).not.toContain(".kb-tag-memory");
 	});
 
+	it("declares the small iconbtn variant used by Plans & Notes inline actions", () => {
+		// Plans & Notes rows carry two trailing buttons (edit + remove); the
+		// --sm variant keeps them lighter than the default 24x22/14px iconbtn
+		// (the Memories rows' View Memory eye keeps the default size).
+		const css = buildSidebarCss();
+		expect(css).toMatch(/\.iconbtn--sm\s*{[^}]*width:\s*20px/);
+		expect(css).toMatch(/\.iconbtn--sm\s*{[^}]*height:\s*18px/);
+		expect(css).toMatch(/\.iconbtn--sm\s*{[^}]*font-size:\s*12px/);
+		// The glyph override is the part that actually shrinks the icon:
+		// codicon.css pins font: 16px on .codicon[class*='codicon-'] with
+		// higher specificity, so the button-level font-size alone never
+		// reaches the glyph.
+		expect(css).toMatch(/\.iconbtn--sm\s+\.codicon\s*{[^}]*font-size:\s*12px/);
+	});
+
 	it("bolds repo nodes (no longer has the dead repo-root banner styling)", () => {
 		// There's no Memory Bank header / banner row — repos sit at the top of
 		// the tree directly. The only surviving repo-level cue is

--- a/vscode/src/views/SidebarCssBuilder.ts
+++ b/vscode/src/views/SidebarCssBuilder.ts
@@ -349,6 +349,22 @@ export function buildSidebarCss(): string {
     color: var(--vscode-inputOption-activeForeground, var(--vscode-foreground));
     border-color: var(--vscode-inputOption-activeBorder, transparent);
   }
+  /* Small inline-row variant — Plans & Notes rows carry two trailing buttons
+     (✎ + 🗑), so the default 24x22/14px footprint reads heavier than the
+     single View Memory eye on Memories rows. 20x18/12px keeps both icons
+     visually subordinate to the row label while staying a comfortable click
+     target. The .codicon override is required: codicon.css pins font: 16px
+     directly on .codicon[class*='codicon-'] with (0,2,0) specificity, so a
+     font-size on the button alone never reaches the glyph (same reason
+     .tree-node .icon .codicon overrides it explicitly above). */
+  .iconbtn--sm {
+    width: 20px;
+    height: 18px;
+    font-size: 12px;
+  }
+  .iconbtn--sm .codicon {
+    font-size: 12px;
+  }
 
   .tab-content {
     flex: 1;

--- a/vscode/src/views/SidebarMessages.ts
+++ b/vscode/src/views/SidebarMessages.ts
@@ -428,6 +428,7 @@ export type SidebarOutboundMsg =
 	| { readonly type: "branch:openNote"; readonly noteId: string }
 	| { readonly type: "branch:openReference"; readonly mapKey: string }
 	| { readonly type: "branch:openReferenceMarkdown"; readonly mapKey: string }
+	| { readonly type: "branch:openReferencePreview"; readonly mapKey: string }
 	| { readonly type: "branch:ignoreReference"; readonly mapKey: string }
 	| {
 			readonly type: "branch:openChange";

--- a/vscode/src/views/SidebarScriptBuilder.test.ts
+++ b/vscode/src/views/SidebarScriptBuilder.test.ts
@@ -1118,18 +1118,45 @@ describe("SidebarScriptBuilder", () => {
 	describe("Plans & Notes / Changes context menus", () => {
 		it("Plans & Notes rows show 'Edit Plan' / 'Edit Note' depending on contextValue", () => {
 			const js = buildSidebarScript();
-			// ctx === 'note' picks editNote + 'Edit Note'; plan/plansItem fall through
-			// to editPlan + 'Edit Plan'. Both labels must appear in the bundled script.
+			// ctx === 'note' picks editNote + 'Edit Note'; plan picks
+			// editPlan + 'Edit Plan'. Both labels must appear in the bundled script.
 			expect(js).toContain("'Edit Plan'");
 			expect(js).toContain("'Edit Note'");
-			expect(js).toContain("'jollimemory.editPlan'");
 			expect(js).toContain("'jollimemory.editNote'");
+			expect(js).toContain("'jollimemory.editPlan'");
 		});
 
-		it("Plans & Notes context menu handler matches plan / plansItem / note contextValues", () => {
+		it("Plans & Notes context menu handler matches plan / note contextValues", () => {
+			const js = buildSidebarScript();
+			expect(js).toContain("ctx === 'plan' || ctx === 'note'");
+		});
+
+		it("plan / note context menus carry the unified Preview / Edit / Remove entries", () => {
+			const js = buildSidebarScript();
+			// Preview re-posts the row-click message (rawMessage), Edit and
+			// Remove go through the generic command bridge. The same 'Preview'
+			// and 'Remove' labels are shared with the reference menu.
+			expect(js).toContain("'Preview'");
+			expect(js).toContain("'jollimemory.removePlan'");
+			expect(js).toContain("'jollimemory.removeNote'");
+			expect(js).toMatch(
+				/\{ type: 'branch:openNote', noteId: id \}\s*:\s*\{ type: 'branch:openPlan', planId: id \}/,
+			);
+		});
+
+		it("reference context menu shows Preview / Edit Markdown / Open in Browser / Remove", () => {
+			const js = buildSidebarScript();
+			expect(js).toContain("'Edit Markdown'");
+			expect(js).toContain("'Open in Browser'");
+			expect(js).toMatch(/\{ type: 'branch:openReferencePreview',\s+mapKey: id \}/);
+			expect(js).toMatch(/\{ type: 'branch:openReferenceMarkdown',\s+mapKey: id \}/);
+			expect(js).toMatch(/\{ type: 'branch:ignoreReference',\s+mapKey: id \}/);
+		});
+
+		it("reference row click posts branch:openReferencePreview (click = preview, edit via menu)", () => {
 			const js = buildSidebarScript();
 			expect(js).toContain(
-				"ctx === 'plan' || ctx === 'plansItem' || ctx === 'note'",
+				"vscode.postMessage({ type: 'branch:openReferencePreview', mapKey: id });",
 			);
 		});
 
@@ -1902,6 +1929,37 @@ describe("SidebarScriptBuilder", () => {
 			expect(js).toMatch(
 				/ctx\s*===\s*'note'[\s\S]{0,150}ctx\s*===\s*'reference'/,
 			);
+		});
+
+		it("edit button (data-inline='edit') renders left of the trash button with the small variant", () => {
+			const js = buildSidebarScript();
+			const fnStart = js.indexOf("function renderPlanRow");
+			const fnEnd = js.indexOf("function renderConversationRow", fnStart);
+			const body = js.slice(fnStart, fnEnd);
+			// ✎ before 🗑 inside the row's inline-actions.
+			const editIdx = body.indexOf("'data-inline': 'edit'");
+			const removeIdx = body.indexOf("'data-inline': 'remove'");
+			expect(editIdx).toBeGreaterThan(-1);
+			expect(removeIdx).toBeGreaterThan(editIdx);
+			expect(body).toContain("codicon-edit");
+			// BOTH trailing buttons use the small variant so they stay visually
+			// subordinate to the Memories rows' View Memory eye — a single
+			// occurrence would mean one of the two silently lost it.
+			const smCount = body.split("iconbtn iconbtn--sm").length - 1;
+			expect(smCount).toBe(2);
+			// Tooltip mirrors the context menu's per-type edit labels.
+			expect(body).toContain("'Edit Markdown'");
+			expect(body).toContain("'Edit Note'");
+			expect(body).toContain("'Edit Plan'");
+		});
+
+		it("edit button click routes by row contextValue, mirroring the context menu's edit entry", () => {
+			const js = buildSidebarScript();
+			// Pin the ctx → target PAIRING, not just co-occurrence — a swapped
+			// ternary (note → editPlan) must fail these, so each regex requires
+			// the ctx check immediately before its own target.
+			expect(js).toMatch(/action\s*===\s*'edit'[\s\S]{0,400}ctx\s*===\s*'reference'[\s\S]{0,120}branch:openReferenceMarkdown/);
+			expect(js).toMatch(/action\s*===\s*'edit'[\s\S]{0,400}ctx\s*===\s*'note'\s*\?\s*'jollimemory\.editNote'\s*:\s*'jollimemory\.editPlan'/);
 		});
 	});
 

--- a/vscode/src/views/SidebarScriptBuilder.ts
+++ b/vscode/src/views/SidebarScriptBuilder.ts
@@ -2030,12 +2030,12 @@ export function buildSidebarScript(): string {
     // Description preview is intentionally not surfaced — see PlansTreeProvider
     // ReferenceItem comment for the rationale.
     kids.push(el('hr'));
-    // Single action row: Open in <Source>. The trash / open-markdown actions
-    // already live as inline buttons on the row itself (see renderPlanRow),
-    // so the card stays focused on jumping to the upstream record.
+    // Single action row: Open in <Source>. Remove lives as the row's inline
+    // 🗑 button and Preview / Edit Markdown in the context menu, so the card
+    // stays focused on jumping to the upstream record.
     const openLabel = SOURCE_TITLES[h.source]
       ? 'Open in ' + SOURCE_TITLES[h.source]
-      : 'Open in browser';
+      : 'Open in Browser';
     const openLink = attachTextTip(
       el('span', {
         className: 'hc-link',
@@ -2821,16 +2821,28 @@ export function buildSidebarScript(): string {
     if (item.description) {
       kids.push(el('span', { className: 'desc', text: item.description }));
     }
-    // Inline-actions: only the trash (remove) button. The edit button was
-    // dropped because the row click already opens the .md file for editing
-    // (see click delegation: ctx 'plan' → editPlan, ctx 'note' → editNote),
-    // so a separate edit affordance was redundant.
+    // Inline-actions: ✎ (edit) then 🗑 (remove). Row click stays preview-only;
+    // the inline ✎ mirrors the context menu's edit entry ('Edit Plan' /
+    // 'Edit Note' / 'Edit Markdown') as a faster affordance. Both buttons use
+    // the small iconbtn variant so the trailing icons read lighter than the
+    // Memories rows' View Memory eye instead of dominating the row.
+    const editLabel = isReference ? 'Edit Markdown' : isNote ? 'Edit Note' : 'Edit Plan';
     kids.push(
       el('span', { className: 'inline-actions' }, [
         attachTextTip(
           el('button', {
             type: 'button',
-            className: 'iconbtn',
+            className: 'iconbtn iconbtn--sm',
+            'data-inline': 'edit',
+            'data-id': item.id,
+            'aria-label': editLabel,
+          }, [el('i', { className: 'codicon codicon-edit' })]),
+          editLabel,
+        ),
+        attachTextTip(
+          el('button', {
+            type: 'button',
+            className: 'iconbtn iconbtn--sm',
             'data-inline': 'remove',
             'data-id': item.id,
             'aria-label': 'Remove',
@@ -3241,34 +3253,11 @@ export function buildSidebarScript(): string {
     }, kids), item.tooltip || '');
   }
 
-  function renderInlineButtons(item) {
-    const ctx = item.contextValue || '';
-    // Match contextValue strings emitted by PlansTreeProvider — common values are 'plan', 'note', 'plansItem'.
-    // Match contextValue strings emitted by FilesTreeProvider — common values are 'file', 'fileChange'.
-    // If real contextValue differs, this just returns null and falls through to plain row.
-    const isPlanLike = ctx === 'plan' || ctx === 'note' || ctx === 'plansItem';
-    const isFile = ctx === 'file' || ctx === 'fileChange';
-    const isReference = ctx === 'reference';
-    if (isPlanLike) {
-      return el('span', { className: 'inline-actions' }, [
-        attachTextTip(el('button', { type: 'button', className: 'iconbtn', 'data-inline': 'edit', 'data-id': item.id, text: '✎' }), 'Edit'),
-        attachTextTip(el('button', { type: 'button', className: 'iconbtn', 'data-inline': 'remove', 'data-id': item.id, text: '🗑' }), 'Remove'),
-      ]);
-    }
-    if (isReference) {
-      return el('span', { className: 'inline-actions' }, [
-        attachTextTip(el('button', { type: 'button', className: 'iconbtn', 'data-inline': 'open-reference', 'data-id': item.id, text: '↗' }), 'Open in browser'),
-        attachTextTip(el('button', { type: 'button', className: 'iconbtn', 'data-inline': 'ignore-reference', 'data-id': item.id, text: '🗑' }), 'Remove'),
-      ]);
-    }
-    if (isFile) {
-      return el('span', { className: 'inline-actions' }, [
-        attachTextTip(el('button', { type: 'button', className: 'iconbtn', 'data-inline': 'discard', 'data-id': item.id, text: '↻' }), 'Discard'),
-      ]);
-    }
-    return null;
-  }
-
+  // Fallback renderer for sections without a dedicated row function. Every
+  // Branch-tab section has one (renderConversationRow / renderPlanRow /
+  // renderChangeRow / renderCommitRow), so this renders a plain row with no
+  // inline actions — the per-row buttons (🗑 remove, ↻ discard, …) all live
+  // in the dedicated renderers.
   function renderTreeItem(item, depth) {
     const kids = [
       el('span', { className: 'twirl' }),
@@ -3278,8 +3267,6 @@ export function buildSidebarScript(): string {
     if (item.description) {
       kids.push(el('span', { className: 'desc', text: item.description }));
     }
-    const inline = renderInlineButtons(item);
-    if (inline) kids.push(inline);
     return attachTextTip(el('div', {
       className: 'tree-node',
       'data-indent': String(depth),
@@ -3422,7 +3409,8 @@ export function buildSidebarScript(): string {
       return;
     }
 
-    // Inline buttons on tree nodes (edit, remove, discard).
+    // Inline buttons on tree nodes (edit, remove, discard, viewSummary,
+    // copy-recall).
     const inline = e.target.closest('[data-inline]');
     if (inline) {
       const action = inline.getAttribute('data-inline');
@@ -3430,8 +3418,15 @@ export function buildSidebarScript(): string {
       const row = inline.closest('.tree-node');
       const ctx = row ? row.getAttribute('data-context') : '';
       if (action === 'edit') {
-        const cmd = ctx === 'note' ? 'jollimemory.editNote' : 'jollimemory.editPlan';
-        vscode.postMessage({ type: 'command', command: cmd, args: [id] });
+        // Same three-way routing as the context menu's edit entry: reference
+        // markdown is host-resolved by mapKey (branch:openReferenceMarkdown),
+        // plan / note go through their editor commands.
+        if (ctx === 'reference') {
+          vscode.postMessage({ type: 'branch:openReferenceMarkdown', mapKey: id });
+        } else {
+          const cmd = ctx === 'note' ? 'jollimemory.editNote' : 'jollimemory.editPlan';
+          vscode.postMessage({ type: 'command', command: cmd, args: [id] });
+        }
       }
       if (action === 'remove') {
         // Plan / Note / Reference rows all share the trash button rendered by
@@ -3479,12 +3474,6 @@ export function buildSidebarScript(): string {
         // for both workspace and foreign hashes.
         vscode.postMessage({ type: 'command', command: 'jollimemory.copyRecallPrompt', args: [id] });
       }
-      if (action === 'open-reference') {
-        vscode.postMessage({ type: 'branch:openReference', mapKey: id });
-      }
-      if (action === 'ignore-reference') {
-        vscode.postMessage({ type: 'branch:ignoreReference', mapKey: id });
-      }
       e.stopPropagation();
       return;
     }
@@ -3500,18 +3489,21 @@ export function buildSidebarScript(): string {
     if (row) {
       const ctx = row.getAttribute('data-context');
       const id = row.getAttribute('data-id');
-      // Plan vs note dispatch: each TreeItem command differs in the
-      // extension (editPlan / editNote), and routing them through the
-      // wrong command treats the id as the wrong kind of identifier
-      // (note id ≠ plan slug → editPlan would 404 on noteId.md).
-      if (ctx === 'plan' || ctx === 'plansItem') {
+      // Plan vs note dispatch: the host preview commands differ
+      // (openPlanForPreview / openNoteForPreview), and routing them through
+      // the wrong message treats the id as the wrong kind of identifier
+      // (note id ≠ plan slug → the plan path would 404 on noteId.md).
+      if (ctx === 'plan') {
         vscode.postMessage({ type: 'branch:openPlan', planId: id });
       }
       if (ctx === 'note') {
         vscode.postMessage({ type: 'branch:openNote', noteId: id });
       }
       if (ctx === 'reference') {
-        vscode.postMessage({ type: 'branch:openReferenceMarkdown', mapKey: id });
+        // Row click previews the reference markdown — same click-equals-preview
+        // contract as plan / note rows. The editor path (openReferenceMarkdown)
+        // moved to the context menu's 'Edit Markdown'.
+        vscode.postMessage({ type: 'branch:openReferencePreview', mapKey: id });
       }
       if (ctx === 'file' || ctx === 'fileChange') {
         // Forward all three fields the openFileChange command needs.
@@ -3666,9 +3658,11 @@ export function buildSidebarScript(): string {
   // it everywhere and only show a custom menu when a recognised row is hit.
   // Empty area / unhandled rows (e.g. commitFile children) get nothing.
   //
-  //   - Plans & Notes rows ('plan' / 'plansItem' / 'note'):
-  //       single 'Edit Plan' or 'Edit Note' item — mirrors the inline ✎
-  //       button which dispatches editPlan / editNote based on contextValue.
+  //   - Plans & Notes rows ('plan' / 'note' / 'reference'):
+  //       unified Preview / Edit … / ─ / Remove menu. Preview re-posts the
+  //       same message the row click sends; Edit opens the source file in a
+  //       text editor; Remove mirrors the inline 🗑 button. Reference rows
+  //       additionally expose 'Open in Browser' for the upstream record.
   //   - Changes rows ('file' / 'fileChange'):
   //       single 'Discard Changes' item — routed through the same
   //       'branch:discardFile' message the inline discard button uses, so
@@ -3711,18 +3705,26 @@ export function buildSidebarScript(): string {
       showContextMenu(e.clientX, e.clientY, items);
       return;
     }
-    if (ctx === 'plan' || ctx === 'plansItem' || ctx === 'note') {
-      const cmd   = ctx === 'note' ? 'jollimemory.editNote' : 'jollimemory.editPlan';
-      const label = ctx === 'note' ? 'Edit Note' : 'Edit Plan';
+    if (ctx === 'plan' || ctx === 'note') {
+      const isNote = ctx === 'note';
       showContextMenu(e.clientX, e.clientY, [
-        { label: label, command: cmd, args: [id] },
+        { label: 'Preview',
+          rawMessage: isNote
+            ? { type: 'branch:openNote', noteId: id }
+            : { type: 'branch:openPlan', planId: id } },
+        { label: isNote ? 'Edit Note' : 'Edit Plan',
+          command: isNote ? 'jollimemory.editNote' : 'jollimemory.editPlan', args: [id] },
+        { separator: true },
+        { label: 'Remove',
+          command: isNote ? 'jollimemory.removeNote' : 'jollimemory.removePlan', args: [id] },
       ]);
       return;
     }
     if (ctx === 'reference') {
       showContextMenu(e.clientX, e.clientY, [
-        { label: 'Open in browser', rawMessage: { type: 'branch:openReference',         mapKey: id } },
-        { label: 'Open Markdown',   rawMessage: { type: 'branch:openReferenceMarkdown', mapKey: id } },
+        { label: 'Preview',         rawMessage: { type: 'branch:openReferencePreview',  mapKey: id } },
+        { label: 'Edit Markdown',   rawMessage: { type: 'branch:openReferenceMarkdown', mapKey: id } },
+        { label: 'Open in Browser', rawMessage: { type: 'branch:openReference',         mapKey: id } },
         { separator: true },
         { label: 'Remove',          rawMessage: { type: 'branch:ignoreReference',       mapKey: id } },
       ]);

--- a/vscode/src/views/SidebarWebviewProvider.test.ts
+++ b/vscode/src/views/SidebarWebviewProvider.test.ts
@@ -803,8 +803,8 @@ describe("SidebarWebviewProvider", () => {
 	});
 
 	it("forwards branch:openReferenceMarkdown via jollimemory.openReferenceMarkdown", () => {
-		// Context-menu "Open Markdown" path — opens the on-disk markdown copy
-		// rather than the browser URL.
+		// Context-menu "Edit Markdown" path — opens the on-disk markdown copy
+		// in a text editor rather than the browser URL.
 		const view = makeMockView();
 		const exec = vi.fn();
 		const provider = new SidebarWebviewProvider({
@@ -827,6 +827,34 @@ describe("SidebarWebviewProvider", () => {
 		expect(exec).toHaveBeenCalledWith(
 			"jollimemory.openReferenceMarkdown",
 			"jira:KAN-5",
+		);
+	});
+
+	it("forwards branch:openReferencePreview via jollimemory.openReferenceForPreview", () => {
+		// Sidebar row-click path — reference rows preview on click like
+		// plan/note rows; the editor path stays on branch:openReferenceMarkdown.
+		const view = makeMockView();
+		const exec = vi.fn();
+		const provider = new SidebarWebviewProvider({
+			executeCommand: exec,
+			getInitialState: () => ({
+				enabled: true,
+				authenticated: false,
+				activeTab: "branch",
+				kbMode: "folders",
+				branchName: "main",
+				detached: false,
+			}),
+			extensionUri: { fsPath: "/mock", with: () => ({}) } as never,
+		});
+		provider.resolveWebviewView(view as unknown as never);
+		view.webview.triggerMessage({
+			type: "branch:openReferencePreview",
+			mapKey: "linear:PROJ-1528",
+		});
+		expect(exec).toHaveBeenCalledWith(
+			"jollimemory.openReferenceForPreview",
+			"linear:PROJ-1528",
 		);
 	});
 

--- a/vscode/src/views/SidebarWebviewProvider.ts
+++ b/vscode/src/views/SidebarWebviewProvider.ts
@@ -471,16 +471,16 @@ export class SidebarWebviewProvider
 				);
 				return;
 			case "branch:openPlan":
-				// Sidebar row-click → markdown preview, not editor. The ✎ inline
-				// button still goes through editPlan for actual editing.
+				// Sidebar row-click → markdown preview, not editor. Editing goes
+				// through the context menu's "Edit Plan" (editPlan).
 				void this.deps.executeCommand(
 					"jollimemory.openPlanForPreview",
 					msg.planId,
 				);
 				return;
 			case "branch:openNote":
-				// Sidebar row-click → markdown preview, not editor. The ✎ inline
-				// button still goes through editNote for actual editing. Differs
+				// Sidebar row-click → markdown preview, not editor. Editing goes
+				// through the context menu's "Edit Note" (editNote). Differs
 				// from `previewNote` (used by Summary) which is orphan-only.
 				void this.deps.executeCommand(
 					"jollimemory.openNoteForPreview",
@@ -496,6 +496,15 @@ export class SidebarWebviewProvider
 			case "branch:openReferenceMarkdown":
 				void this.deps.executeCommand(
 					"jollimemory.openReferenceMarkdown",
+					msg.mapKey,
+				);
+				return;
+			case "branch:openReferencePreview":
+				// Sidebar row-click → rendered markdown preview, matching the
+				// plan/note rows. "Edit Markdown" in the context menu keeps the
+				// editor path (branch:openReferenceMarkdown).
+				void this.deps.executeCommand(
+					"jollimemory.openReferenceForPreview",
 					msg.mapKey,
 				);
 				return;


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## Quick recap

The Plans & Notes sidebar panel now has a single consistent interaction model across all three row types — plans, notes, and references. Clicking any row opens a read-only preview of its content. Editing is available through a right-click context menu and a new inline edit button that appears on every row, both of which open the file for editing. The context menus were restructured to follow the same order and wording for all three types, with references additionally offering an "Open in Browser" option for jumping to the upstream record.

A long-standing bug with plan rows that had been committed and later modified was also fixed. Previously, attempting to edit such a row would either fail silently or open a stale snapshot from the time of the commit. These rows now open the locally modified file on disk, matching the behavior that note rows had always exhibited. The Summary panel's ability to view the exact committed snapshot remains unchanged, as that feature uses a separate path.

---

## Topics (2)
<details>
<summary><strong>01 · Unify Plans, Notes, and References panel to preview-on-click with edit via context menu</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The Plans & Notes sidebar panel had inconsistent click and right-click behavior across its three row types: plan and note rows previewed on click, while reference rows opened directly in an editable text editor. Right-click menus were also structurally different between the types, with references having more options and different wording than plans and notes.

**💡 Decisions Behind the Code**

- **Reference rows keep an "Edit Markdown" option despite auto-refresh risk**: Reference markdown files are periodically overwritten by upstream polling, meaning manual edits can be silently lost. The decision was to keep the edit path available rather than making references fully read-only, placing the responsibility on the user. Removing it entirely would have been safer but would reduce flexibility for users who want to annotate reference files.
- **Click always previews, edit always goes through menu or inline button**: Rather than toggling between preview and edit on click, the interaction model was simplified so clicking a row always opens a read-only preview. This makes all three row types behave identically on click and gives the edit action a consistent, deliberate home in the context menu and inline button — reducing accidental edits.
- **Dead code removed rather than left in place**: The `renderInlineButtons` function and `plansItem` contextValue handling had never been reachable in the live webview. Removing them eliminated a source of confusion that had already caused one incorrect analysis of the codebase during this session, and the removal was verified with a full-repository grep to confirm zero remaining references.

**✅ What Was Implemented**

- Added a new `previewReferenceMarkdown` function in `ReferenceService.ts` and a corresponding `openReferenceForPreview` command in `Extension.ts`, wired through `JolliMemoryBridge.ts`. Reference row clicks now post a `branch:openReferencePreview` message (added to `SidebarMessages.ts`) routed in `SidebarWebviewProvider.ts` to the new preview command, matching the plan/note click behavior.
- Unified all three right-click context menus in `SidebarScriptBuilder.ts`: plan and note rows now show Preview / Edit Plan or Edit Note / separator / Remove; reference rows show Preview / Edit Markdown / Open in Browser / separator / Remove. Removed the dead `plansItem` contextValue branch and the never-rendered `renderInlineButtons` function (which contained ✎/↗ buttons that were never actually displayed). Standardized all menu label casing to Title Case ("Open in Browser" replacing "Open in browser").
- Added an inline ✎ edit button alongside the existing 🗑 remove button on all three row types in `SidebarScriptBuilder.ts`, using a new smaller `iconbtn--sm` CSS variant defined in `SidebarCssBuilder.ts`. The edit button routes reference rows to `branch:openReferenceMarkdown` and plan/note rows to their respective edit commands, mirroring the context menu's edit entry.

**📁 FILES**
- `vscode/src/views/SidebarScriptBuilder.ts`
- `vscode/src/core/ReferenceService.ts`
- `vscode/src/views/SidebarWebviewProvider.ts`
- `vscode/src/Extension.ts`
- `vscode/src/JolliMemoryBridge.ts`

</blockquote>
</details>
<details>
<summary><strong>02 · Fix committed-then-modified plan rows to open local file instead of old snapshot</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

When a plan file had been committed and then modified again afterward, clicking Edit Plan would fail silently or open a stale read-only snapshot from the commit history. The equivalent behavior for notes already correctly opened the locally modified file, so the two were inconsistent.

**💡 Decisions Behind the Code**

The Summary panel's ability to view the committed snapshot was explicitly preserved. That panel passes an explicit "committed" flag when opening a plan, which takes a separate code path reading from the orphan branch. Only the sidebar Plans panel row — which represents the current state of the file — was changed to open the local version. This kept the two use cases (view what was committed vs. edit what exists now) cleanly separated without conflating them.

**✅ What Was Implemented**

- In `PlanService.ts`, the `toPlanInfo` function previously blanked the `filePath` field for any plan entry that had a recorded commit hash, causing the edit and preview commands to fall back to the orphan-branch snapshot. The condition was removed so committed-then-modified guard rows retain their on-disk path, matching how `NoteService` handles the same case.
- The `lastModified` timestamp for these rows was also corrected: it previously showed the registry's stale `updatedAt` value rather than the file's actual modification time on disk. The `existsSync` guard on the mtime read was widened to cover committed guard rows as well.

**📁 FILES**
- `vscode/src/core/PlanService.ts`

</blockquote>
</details>

---

*Generated by Jolli Memory · June 12, 2026 at 4:29 PM · via Anthropic*
<!-- jollimemory-summary-end -->