### PR TITLE
Add KB toolbar sync button, inline status indicator, and --autostash pull fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,6 @@ vscode/assets/codicons/
 
 # Local pre-PR review state (per-developer scratch)
 .claude/review-findings/
+
+# Personal notes
+notes.md

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/actions/CloudSyncAction.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/actions/CloudSyncAction.kt
@@ -1,10 +1,16 @@
 package ai.jolli.jollimemory.actions
 
 import ai.jolli.jollimemory.JolliMemoryIcons
+import ai.jolli.jollimemory.core.JmLogger
 import ai.jolli.jollimemory.services.JolliAuthService
+import ai.jolli.jollimemory.services.JolliMemoryService
+import ai.jolli.jollimemory.sync.SyncActivation
 import com.intellij.ide.ActivityTracker
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.components.service
+import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.popup.JBPopupFactory
 import com.intellij.ui.components.JBLabel
 import com.intellij.util.ui.JBUI
@@ -28,6 +34,11 @@ import javax.swing.SwingUtilities
  */
 class CloudSyncAction : AnAction() {
 
+	private val log = JmLogger.create("CloudSyncAction")
+
+	/** Captured from the last [actionPerformed] for use in panel builders. */
+	private var lastProject: Project? = null
+
 	init {
 		JolliAuthService.addAuthListener {
 			ActivityTracker.getInstance().inc()
@@ -47,6 +58,7 @@ class CloudSyncAction : AnAction() {
 
 	override fun actionPerformed(e: AnActionEvent) {
 		val component = e.inputEvent?.component ?: return
+		lastProject = e.project
 		val signedIn = JolliAuthService.isSignedIn()
 
 		val panel = if (signedIn) buildSignedInPanel() else buildSignedOutPanel()
@@ -109,6 +121,10 @@ class CloudSyncAction : AnAction() {
 	}
 
 	private fun buildSignedInPanel(): JPanel {
+		val syncNowButton = JButton("Sync Now").apply {
+			alignmentX = Component.LEFT_ALIGNMENT
+			maximumSize = Dimension(Int.MAX_VALUE, preferredSize.height)
+		}
 		val signOutButton = JButton("Sign Out").apply {
 			alignmentX = Component.LEFT_ALIGNMENT
 			maximumSize = Dimension(Int.MAX_VALUE, preferredSize.height)
@@ -125,7 +141,28 @@ class CloudSyncAction : AnAction() {
 				alignmentX = Component.LEFT_ALIGNMENT
 			})
 			add(Box.createVerticalStrut(8))
+			add(syncNowButton)
+			add(Box.createVerticalStrut(4))
 			add(signOutButton)
+		}
+
+		syncNowButton.addActionListener {
+			log.info("Sync Now button clicked")
+			val project = lastProject
+			SwingUtilities.getWindowAncestor(panel)?.dispose()
+			if (project != null) {
+				// Lazy-build the orchestrator if needed (parity with the KB toolbar
+				// "Sync to Personal Space" button) so a Sign-in-then-Sync without a
+				// reconcile in between still actually syncs — and the toolbar/status
+				// bar indicators get state changes to display.
+				ApplicationManager.getApplication().executeOnPooledThread {
+					val svc = project.service<JolliMemoryService>()
+					if (!svc.isSyncBuilt()) {
+						SyncActivation.reconcileSync(project, svc)
+					}
+					svc.requestManualSync()
+				}
+			}
 		}
 
 		signOutButton.addActionListener {

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/auth/JolliAuthUtils.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/auth/JolliAuthUtils.kt
@@ -49,4 +49,54 @@ object JolliAuthUtils {
 			)
 		}
 	}
+
+	/**
+	 * Sign-in helper: returns true when the upcoming login should ask the server
+	 * to mint a fresh Jolli API key. Mirrors the CLI's `shouldRequestFreshApiKey`.
+	 *
+	 * The rule:
+	 *   - No key on disk → request a fresh one (otherwise the user can't push).
+	 *   - Key on disk whose embedded tenant differs from `jolliUrl` → request a
+	 *     fresh one so a cross-tenant switch completes in a single sign-in. Without
+	 *     this, the callback returns no new key, the stale key stays on disk, and
+	 *     sync keeps routing to the old tenant via the key's embedded `meta.u`.
+	 *   - Otherwise (key matches the target tenant, or is undecodable legacy) →
+	 *     don't request a fresh one; a sign-in here is a re-auth, not a provision.
+	 */
+	fun shouldRequestFreshApiKey(existingKey: String?, jolliUrl: String): Boolean {
+		if (existingKey.isNullOrBlank()) return true
+		return !apiKeyMatchesTenant(existingKey, jolliUrl)
+	}
+
+	/**
+	 * True when [existingKey]'s embedded tenant (origin + first path segment)
+	 * matches [jolliUrl]. An undecodable key counts as a match — we can't prove
+	 * it's stale, and dropping a hand-typed key would surprise the user. Mirrors
+	 * the CLI's `apiKeyMatchesTenant`: origin compares case-insensitively (host is
+	 * case-insensitive per RFC 3986 §6.2.2.1) while the tenant slug compares
+	 * case-SENSITIVELY because it flows downstream verbatim as `x-tenant-slug`.
+	 */
+	private fun apiKeyMatchesTenant(existingKey: String, jolliUrl: String): Boolean {
+		val meta = JolliApiClient.parseJolliApiKey(existingKey) ?: return true
+		return try {
+			val fromKey = parseBaseUrl(meta.u)
+			val target = parseBaseUrl(jolliUrl)
+			fromKey.origin == target.origin && fromKey.tenantSlug == target.tenantSlug
+		} catch (_: Exception) {
+			true
+		}
+	}
+
+	private data class BaseUrlParts(val origin: String, val tenantSlug: String?)
+
+	private fun parseBaseUrl(url: String): BaseUrlParts {
+		val uri = URI.create(url)
+		val scheme = uri.scheme?.lowercase().orEmpty()
+		val authority = uri.authority?.lowercase().orEmpty()
+		val tenantSlug = (uri.path ?: "")
+			.trim('/')
+			.split("/")
+			.firstOrNull { it.isNotEmpty() }
+		return BaseUrlParts(origin = "$scheme://$authority", tenantSlug = tenantSlug)
+	}
 }

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/core/Types.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/core/Types.kt
@@ -305,6 +305,14 @@ data class JolliMemoryConfig(
     val storageMode: String? = null,        // "orphan" | "dual-write" | "folder"
     /** When true, hooks are uninstalled and the plugin is paused without losing config. */
     val paused: Boolean? = null,
+    /** Whether auto-sync polling is enabled (default true). */
+    val autoSyncEnabled: Boolean? = null,
+    /** Poll interval in seconds for sync orchestrator. */
+    val syncPollIntervalSec: Int? = null,
+    /** Whether to sync transcripts to the vault. */
+    val syncTranscripts: Boolean? = null,
+    /** Custom local folder path for the memory bank root. */
+    val localFolder: String? = null,
 )
 
 /** Registry of all active sessions */

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/services/JolliAuthService.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/services/JolliAuthService.kt
@@ -93,17 +93,21 @@ object JolliAuthService {
             SecureRandom().nextBytes(stateBytes)
             val state = stateBytes.joinToString("") { "%02x".format(it) }
             val callbackUrl = "http://localhost:$port/callback?state=$state"
-            // Only ask the server to mint a fresh Jolli API key when the user
-            // doesn't already have one — otherwise sign-in would overwrite a
-            // manually configured key (and a subsequent sign-out would then
-            // delete it). Mirrors the conditional in browserLogin() / VS Code
-            // openSignInPage().
+            // Ask the server to mint a fresh Jolli API key when the user has no
+            // key, OR when their existing key's embedded tenant differs from the
+            // tenant we're signing into. The cross-tenant case matters because
+            // the API key carries the tenant URL that sync/LLM routing use — a
+            // re-login against a different tenant must replace the key, else
+            // sync keeps routing to the old host. When the key already matches
+            // the target tenant we leave it untouched, so a plain re-auth never
+            // overwrites a manually configured key. Mirrors the CLI's
+            // shouldRequestFreshApiKey / VS Code openSignInPage().
             val existingApiKey = SessionTracker.loadConfig().jolliApiKey
             val loginUrl = buildLoginUrl(
                 jolliUrl = jolliUrl,
                 callbackUrl = callbackUrl,
                 clientVersion = JolliApiClient.pluginVersion,
-                generateApiKey = existingApiKey.isNullOrBlank(),
+                generateApiKey = JolliAuthUtils.shouldRequestFreshApiKey(existingApiKey, jolliUrl),
             )
             log.info("Login URL: %s", loginUrl)
 
@@ -218,7 +222,12 @@ object JolliAuthService {
     fun signOut() {
         val globalDir = SessionTracker.getGlobalConfigDir()
         val existing = SessionTracker.loadConfigFromDir(globalDir)
-        SessionTracker.saveConfigToDir(existing.copy(authToken = null), globalDir)
+        // Clear BOTH authToken AND jolliApiKey in a single write. The API key
+        // carries the tenant URL that sync/LLM routing extract via
+        // parseJolliApiKey, so leaving it behind would pin a later sign-in
+        // (into a different tenant) to the old tenant — sync would keep hitting
+        // the stale host. Mirrors VS Code's clearAuthCredentials.
+        SessionTracker.saveConfigToDir(existing.copy(authToken = null, jolliApiKey = null), globalDir)
         notifyAuthListeners()
     }
 

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/services/JolliMemoryService.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/services/JolliMemoryService.kt
@@ -10,12 +10,19 @@ import ai.jolli.jollimemory.core.KBPathResolver
 import ai.jolli.jollimemory.core.SessionTracker
 import ai.jolli.jollimemory.core.StatusInfo
 import ai.jolli.jollimemory.core.StorageFactory
+import ai.jolli.jollimemory.sync.SyncEngine
+import ai.jolli.jollimemory.sync.SyncOrchestrator
+import ai.jolli.jollimemory.sync.SyncOrchestratorOpts
+import ai.jolli.jollimemory.sync.SyncState
+import ai.jolli.jollimemory.sync.SyncStatusBarWidget
+import ai.jolli.jollimemory.sync.SyncStatusDetail
 import ai.jolli.jollimemory.toolwindow.PanelRegistry
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.wm.WindowManager
 import git4idea.repo.GitRepository
 import git4idea.repo.GitRepositoryChangeListener
 import java.io.File
@@ -25,6 +32,7 @@ import java.nio.file.Path
 import java.nio.file.StandardWatchEventKinds
 import java.nio.file.WatchService
 import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.atomic.AtomicLong
 import javax.swing.Timer
 
 /**
@@ -55,6 +63,17 @@ class JolliMemoryService(private val project: Project) : Disposable {
     private var nioWatchService: WatchService? = null
     private var nioWatchThread: Thread? = null
 
+    // ── Sync orchestrator ────────────────────────────────────────────────
+    private var orchestrator: SyncOrchestrator? = null
+    private val lastSyncSuccessAtMs = AtomicLong(0)
+    @Volatile
+    private var syncState: SyncState? = null
+    @Volatile
+    private var syncDetail: SyncStatusDetail? = null
+    /** Listeners notified (on the EDT) whenever the sync state changes. Lets the
+     *  KB explorer toolbar mirror the status-bar widget's progress/error feedback. */
+    private val syncListeners = CopyOnWriteArrayList<(SyncState, SyncStatusDetail?) -> Unit>()
+
     /** Registry of panel references for action lookup (set by JolliMemoryToolWindowFactory). */
     var panelRegistry: PanelRegistry? = null
 
@@ -70,6 +89,18 @@ class JolliMemoryService(private val project: Project) : Disposable {
     }
     fun removeStatusListener(listener: () -> Unit) { listeners.remove(listener) }
     private fun notifyListeners() { listeners.forEach { it() } }
+
+    /**
+     * Adds a sync-state listener. If a sync state has already been observed,
+     * the listener is invoked immediately with it so late-registering panels
+     * reflect the current state.
+     */
+    fun addSyncStateListener(listener: (SyncState, SyncStatusDetail?) -> Unit) {
+        syncListeners.add(listener)
+        val s = syncState
+        if (s != null) listener(s, syncDetail)
+    }
+    fun removeSyncStateListener(listener: (SyncState, SyncStatusDetail?) -> Unit) { syncListeners.remove(listener) }
 
     /** Debug log of initialization steps. */
     var initLog: String = ""
@@ -694,11 +725,68 @@ val sb = StringBuilder()
     fun getGitOps(): GitOps? = git
     fun getInstallerDebug(): String = installer?.getDebugInfo() ?: "installer is null"
 
+    // ── Sync orchestrator lifecycle ──────────────────────────────────────
+
+    /**
+     * Start the sync orchestrator with the given engine and poll interval.
+     * Wires the orchestrator's state changes to the status bar widget.
+     */
+    fun startSync(engine: SyncEngine, cwd: String, pollIntervalSec: Int? = null) {
+        stopSync()
+        val widget = findSyncWidget()
+        val orch = SyncOrchestrator(SyncOrchestratorOpts(
+            engine = engine,
+            cwd = cwd,
+            pollIntervalSec = pollIntervalSec,
+            lastSuccessAtMs = lastSyncSuccessAtMs,
+            onStateChange = { state, detail ->
+                syncState = state
+                syncDetail = detail
+                ApplicationManager.getApplication().invokeLater {
+                    widget?.setSyncState(state, detail)
+                    syncListeners.forEach { it(state, detail) }
+                }
+            },
+        ))
+        orchestrator = orch
+        orch.start()
+    }
+
+    /** Stop the sync polling loop (orchestrator remains usable for manual sync). */
+    fun stopSync() {
+        orchestrator?.stop()
+    }
+
+    /** Trigger a manual sync round, coalescing with any in-flight round. */
+    fun requestManualSync() {
+        orchestrator?.requestManualSync()
+    }
+
+    /**
+     * Whether the sync orchestrator has been built yet. Mirrors the
+     * `runtime.ensureBuilt()` gate in `vscode/src/sync/SyncCommands.ts`: a
+     * manual-sync entry point should lazy-build the orchestrator (via
+     * [ai.jolli.jollimemory.sync.SyncActivation.reconcileSync]) when this
+     * returns `false` before calling [requestManualSync].
+     */
+    fun isSyncBuilt(): Boolean = orchestrator != null
+
+    /** Current sync state, or null if sync has never run. */
+    fun getSyncState(): SyncState? = syncState
+
+    private fun findSyncWidget(): SyncStatusBarWidget? {
+        val statusBar = WindowManager.getInstance().getStatusBar(project) ?: return null
+        return statusBar.getWidget(SyncStatusBarWidget.ID) as? SyncStatusBarWidget
+    }
+
     override fun dispose() {
+        orchestrator?.dispose()
+        orchestrator = null
         orphanRefDebounceTimer?.stop()
         nioWatchThread?.interrupt()
         try { nioWatchService?.close() } catch (_: Exception) { }
         listeners.clear()
+        syncListeners.clear()
     }
 }
 

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/services/JolliMemoryStartupActivity.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/services/JolliMemoryStartupActivity.kt
@@ -1,8 +1,8 @@
 package ai.jolli.jollimemory.services
 
+import ai.jolli.jollimemory.core.JmLogger
 import com.intellij.notification.NotificationGroupManager
 import com.intellij.notification.NotificationType
-import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.startup.ProjectActivity
 
@@ -15,10 +15,14 @@ import com.intellij.openapi.startup.ProjectActivity
  */
 class JolliMemoryStartupActivity : ProjectActivity {
 
-    private val log = Logger.getInstance(JolliMemoryStartupActivity::class.java)
+    private val log = JmLogger.create("StartupActivity")
 
     override suspend fun execute(project: Project) {
         val basePath = project.basePath ?: return
+        // Ensure JmLogger can write before any log calls in this class or downstream.
+        JmLogger.setLogDir(basePath)
+        JmLogger.setLogLevel(ai.jolli.jollimemory.core.LogLevel.debug)
+
         // .git is a directory in normal repos, but a file in worktrees
         val gitEntry = java.io.File(basePath, ".git")
         if (!gitEntry.exists()) {
@@ -39,5 +43,9 @@ class JolliMemoryStartupActivity : ProjectActivity {
         log.info("JolliMemory: initializing for project at $basePath")
         val service = project.getService(JolliMemoryService::class.java)
         service.initialize()
+
+        log.info("JolliMemory: activating sync for project at $basePath")
+        ai.jolli.jollimemory.sync.SyncActivation.activateSync(project, service)
+        log.info("JolliMemory: startup complete for project at $basePath")
     }
 }

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/sync/AggregateMerge.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/sync/AggregateMerge.kt
@@ -1,0 +1,118 @@
+package ai.jolli.jollimemory.sync
+
+/**
+ * Deterministic client-side merge for the four `.jolli/<aggregate>.json`
+ * files (JOLLI-1316 §3). Pure functions — order-independent, no I/O, no
+ * randomness — so the same `(local, remote)` pair on two devices produces
+ * byte-identical output regardless of which side ran first.
+ *
+ * Port of `cli/src/sync/AggregateMerge.ts`.
+ *
+ * Sorting uses [String.compareTo] (UTF-16 code-unit ordering, NOT
+ * locale-dependent collation) so cross-device output is stable.
+ */
+
+/**
+ * Manifest merge — dedupe by `fileId`, keep the row with the newer
+ * `source.generatedAt`. Ties on `generatedAt` keep the first occurrence
+ * (i.e. `local` before `remote`).
+ */
+fun mergeManifest(
+	local: List<ManifestEntry>,
+	remote: List<ManifestEntry>,
+): List<ManifestEntry> {
+	val byId = LinkedHashMap<String, ManifestEntry>()
+	for (entry in local) byId[entry.fileId] = entry
+	for (entry in remote) {
+		val existing = byId[entry.fileId]
+		if (existing == null) {
+			byId[entry.fileId] = entry
+			continue
+		}
+		// Strict `>` keeps the earlier-inserted (local) entry on a tie.
+		if (entry.source.generatedAt > existing.source.generatedAt) {
+			byId[entry.fileId] = entry
+		}
+	}
+	return byId.values.sortedBy { it.fileId }
+}
+
+/**
+ * Index merge — dedupe by `commitHash`, with the 2×2 tiebreak:
+ *
+ * | local.parent | remote.parent | winner |
+ * |---|---|---|
+ * | set    | set    | newer `generatedAt` (strict `>`, ties keep local) |
+ * | null   | null   | newer `generatedAt` |
+ * | set    | null   | local |
+ * | null   | set    | remote |
+ *
+ * A non-null `parentCommitHash` outranks a null-parent row.
+ */
+fun mergeIndex(
+	local: List<IndexEntry>,
+	remote: List<IndexEntry>,
+): List<IndexEntry> {
+	val byHash = LinkedHashMap<String, IndexEntry>()
+	for (entry in local) byHash[entry.commitHash] = entry
+	for (entry in remote) {
+		val existing = byHash[entry.commitHash]
+		if (existing == null) {
+			byHash[entry.commitHash] = entry
+			continue
+		}
+		val existingHasParent = existing.parentCommitHash != null
+		val incomingHasParent = entry.parentCommitHash != null
+		if (existingHasParent == incomingHasParent) {
+			if (entry.generatedAt > existing.generatedAt) {
+				byHash[entry.commitHash] = entry
+			}
+		} else if (incomingHasParent) {
+			byHash[entry.commitHash] = entry
+		}
+		// else: existing has parent, incoming is null → keep existing.
+	}
+	return byHash.values.sortedBy { it.commitHash }
+}
+
+/**
+ * Branches merge — dedupe by `branch`. Last-write-wins: `remote` overrides
+ * `local` for any shared key.
+ */
+fun mergeBranches(
+	local: List<BranchEntry>,
+	remote: List<BranchEntry>,
+): List<BranchEntry> {
+	val byBranch = LinkedHashMap<String, BranchEntry>()
+	for (entry in local) byBranch[entry.branch] = entry
+	for (entry in remote) byBranch[entry.branch] = entry
+	return byBranch.values.sortedBy { it.branch }
+}
+
+/**
+ * Catalog merge — dedupe by `commitHash`. Last-write-wins: `remote`
+ * overrides `local`.
+ */
+fun mergeCatalog(
+	local: List<CatalogEntry>,
+	remote: List<CatalogEntry>,
+): List<CatalogEntry> {
+	val byHash = LinkedHashMap<String, CatalogEntry>()
+	for (entry in local) byHash[entry.commitHash] = entry
+	for (entry in remote) byHash[entry.commitHash] = entry
+	return byHash.values.sortedBy { it.commitHash }
+}
+
+/**
+ * Canonical folder name for a branch — NFKD → lowercase → replace
+ * non-`[a-z0-9-]` runs with a single `-` → collapse repeats → trim
+ * leading/trailing `-`. Empty/all-junk input collapses to `"branch"`.
+ */
+fun canonicalBranchFolder(branch: String): String {
+	val normalized = java.text.Normalizer.normalize(branch, java.text.Normalizer.Form.NFKD)
+		.lowercase()
+		.replace(Regex("[^a-z0-9-]+"), "-")
+		.replace(Regex("-+"), "-")
+		.replace(Regex("^-+|-+$"), "")
+	return if (normalized.isEmpty()) "branch" else normalized
+}

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/sync/AggregateTypes.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/sync/AggregateTypes.kt
@@ -1,0 +1,93 @@
+package ai.jolli.jollimemory.sync
+
+/**
+ * Type definitions for the four `.jolli/<aggregate>.json` files and the
+ * content-addressed per-commit summary files (JOLLI-1316 §2 schema).
+ *
+ * Port of `cli/src/sync/AggregateTypes.ts`.
+ *
+ * Pure data — no runtime logic — so every consumer imports from one source.
+ */
+
+// ── manifest.json ──────────────────────────────────────────────────────
+
+data class ManifestSource(
+	val commitHash: String,
+	val branch: String,
+	val generatedAt: String, // ISO8601
+)
+
+data class ManifestEntry(
+	val path: String,
+	val fileId: String,
+	val type: String, // "commit"
+	val fingerprint: String,
+	val title: String,
+	val source: ManifestSource,
+)
+
+data class ManifestEnvelope(
+	val version: Int, // 1
+	val files: List<ManifestEntry>,
+)
+
+// ── index.json ─────────────────────────────────────────────────────────
+
+data class DiffStats(
+	val filesChanged: Int,
+	val insertions: Int,
+	val deletions: Int,
+)
+
+data class IndexEntry(
+	val commitHash: String,
+	val parentCommitHash: String?, // null when no parent
+	val treeHash: String,
+	val commitType: String, // "commit" | "amend"
+	val commitMessage: String,
+	val commitDate: String, // ISO8601
+	val branch: String,
+	val generatedAt: String, // ISO8601
+	val topicCount: Int? = null,
+	val diffStats: DiffStats? = null,
+)
+
+data class IndexEnvelope(
+	val version: Int, // 3
+	val entries: List<IndexEntry>,
+)
+
+// ── branches.json ──────────────────────────────────────────────────────
+
+data class BranchEntry(
+	val folder: String,
+	val branch: String,
+	val createdAt: String, // ISO8601
+)
+
+data class BranchesEnvelope(
+	val version: Int, // 1
+	val mappings: List<BranchEntry>,
+)
+
+// ── catalog.json ───────────────────────────────────────────────────────
+
+data class CatalogTopic(
+	val title: String,
+	val decisions: String,
+	val category: String,
+	val importance: String,
+	val filesAffected: List<String>,
+)
+
+data class CatalogEntry(
+	val commitHash: String,
+	val recap: String,
+	val ticketId: String,
+	val topics: List<CatalogTopic>,
+)
+
+data class CatalogEnvelope(
+	val version: Int, // 1
+	val entries: List<CatalogEntry>,
+)

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/sync/AllowList.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/sync/AllowList.kt
@@ -1,0 +1,97 @@
+package ai.jolli.jollimemory.sync
+
+import java.nio.file.Files
+import java.nio.file.LinkOption
+import java.nio.file.Path
+
+/**
+ * Path-based allow-list for the vault mirror.
+ *
+ * Port of `cli/src/sync/AllowList.ts`.
+ *
+ * Enforces which files may be staged in the vault:
+ *   - Content area: `.md` and `.json` only
+ *   - `.jolli/summaries/<hash>.json`, `.jolli/transcripts/<hash>.json` (opt-in)
+ *   - Aggregate files under `.jolli/`
+ *   - Plans and notes under `.jolli/plans/`, `.jolli/notes/`
+ *   - Rejects symlinks, dot-prefixed dirs (except `.jolli/`)
+ */
+
+/** Extensions allowed in the content area (outside `.jolli/`). */
+val ALLOWED_EXTENSIONS = setOf(".md", ".json")
+
+/** Aggregate JSON files allowed under `.jolli/`. */
+val ALLOWED_AGGREGATE_FILES = setOf(
+	"manifest.json", "index.json", "branches.json",
+	"catalog.json", "repos.json", "config.json",
+)
+
+/** Lowercase-hex commit hash, 7-64 chars. */
+private val SUMMARY_HASH_REGEX = Regex("^[0-9a-f]{7,64}\\.json$")
+
+/** Slug-style filename for plans/notes. */
+private val PLAN_OR_NOTE_REGEX = Regex("^[A-Za-z0-9][A-Za-z0-9._-]{0,254}\\.md$")
+private val PLAN_PROGRESS_REGEX = Regex("^[A-Za-z0-9][A-Za-z0-9._-]{0,254}\\.json$")
+
+data class AllowListOpts(val syncTranscripts: Boolean)
+
+/**
+ * Returns true if a path relative to the vault working tree is allowed by
+ * the allow-list rules. Pure path-shape check — no disk I/O.
+ */
+fun isAllowedPath(relPath: String, opts: AllowListOpts): Boolean {
+	val segments = relPath.split(Regex("[/\\\\]+")).filter { it.isNotEmpty() }
+	if (segments.isEmpty()) return false
+
+	val first = segments[0]
+
+	// `.jolli/` is the only dot-prefixed top-level we accept.
+	if (first == ".jolli") {
+		if (segments.size == 1) return false
+		if (segments.size == 2) {
+			return segments[1] in ALLOWED_AGGREGATE_FILES
+		}
+		if (segments.size == 3 && segments[1] == "summaries") {
+			return SUMMARY_HASH_REGEX.matches(segments[2])
+		}
+		if (segments.size == 3 && segments[1] == "transcripts") {
+			if (!opts.syncTranscripts) return false
+			return SUMMARY_HASH_REGEX.matches(segments[2])
+		}
+		if (segments.size == 3 && segments[1] == "plans") {
+			return PLAN_OR_NOTE_REGEX.matches(segments[2])
+		}
+		if (segments.size == 3 && segments[1] == "plan-progress") {
+			return PLAN_PROGRESS_REGEX.matches(segments[2])
+		}
+		if (segments.size == 3 && segments[1] == "notes") {
+			return PLAN_OR_NOTE_REGEX.matches(segments[2])
+		}
+		return false
+	}
+
+	// Reject any other dot-prefixed segment.
+	if (segments.any { it.startsWith(".") }) return false
+
+	// Content-area extension check.
+	val ext = relPath.substringAfterLast('.', "").let { if (it.isEmpty()) "" else ".$it" }.lowercase()
+	return ext in ALLOWED_EXTENSIONS
+}
+
+/**
+ * Combines [isAllowedPath] with an on-disk symlink check via lstat.
+ * Returns false for symlinks regardless of extension.
+ */
+fun isAllowedPathOnDisk(absPath: String, relPath: String, opts: AllowListOpts): Boolean {
+	if (!isAllowedPath(relPath, opts)) return false
+	return try {
+		val attrs = Files.readAttributes(
+			Path.of(absPath),
+			java.nio.file.attribute.BasicFileAttributes::class.java,
+			LinkOption.NOFOLLOW_LINKS,
+		)
+		!attrs.isSymbolicLink
+	} catch (_: Exception) {
+		false
+	}
+}

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/sync/BootstrapMerge.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/sync/BootstrapMerge.kt
@@ -1,0 +1,246 @@
+package ai.jolli.jollimemory.sync
+
+import ai.jolli.jollimemory.core.JmLogger
+import java.io.IOException
+import java.nio.file.FileVisitResult
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.SimpleFileVisitor
+import java.nio.file.attribute.BasicFileAttributes
+
+/**
+ * Bootstrap merge — handles the "fresh local vault + populated remote" sync
+ * case where `git pull --rebase` would otherwise hard-fail with
+ * "untracked working tree files would be overwritten by checkout".
+ *
+ * Port of `cli/src/sync/BootstrapMerge.ts`.
+ */
+
+private val log = JmLogger.create("BootstrapMerge")
+
+const val BOOTSTRAP_STASH_DIRNAME = ".jolli-bootstrap-stash"
+
+sealed class ShouldRunResult {
+	data object Ok : ShouldRunResult()
+	data class No(val reason: String) : ShouldRunResult()
+}
+
+data class BootstrapPathReport(
+	val path: String,
+	val disposition: String, // "added-from-local" | "no-op" | "remote-wins-local-stashed" | "aggregate-merged"
+)
+
+data class BootstrapMergeResult(
+	val ok: Boolean,
+	val commitSha: String? = null,
+	val reports: List<BootstrapPathReport> = emptyList(),
+	val stashedSurvivors: List<String> = emptyList(),
+	val code: String? = null, // "race-detected" | "checkout-failed" | "commit-failed"
+	val message: String? = null,
+)
+
+/**
+ * Strict trigger check — all of C1-C5 must hold.
+ *
+ *   C1: HEAD is unborn
+ *   C2: Remote default branch exists
+ *   C3: Working tree has files (not empty after `.git`)
+ *   C4: No local branches
+ *   C5: No stash entries
+ */
+fun shouldRunBootstrapMerge(client: SyncGitClient, defaultBranch: String): ShouldRunResult {
+	if (client.hasHead()) return ShouldRunResult.No("HEAD is born (C1 failed)")
+	if (!client.refExists("refs/remotes/origin/$defaultBranch")) {
+		return ShouldRunResult.No("origin/$defaultBranch missing (C2 failed)")
+	}
+	if (!client.hasUncommittedChanges(includeIgnored = true)) {
+		return ShouldRunResult.No("working tree empty (C3 failed)")
+	}
+	val branches = client.listLocalBranches()
+	if (branches.isNotEmpty()) {
+		return ShouldRunResult.No("local branches present: ${branches.joinToString(",")} (C4 failed)")
+	}
+	if (client.refExists("refs/stash")) {
+		return ShouldRunResult.No("git stash present (C5 failed)")
+	}
+	return ShouldRunResult.Ok
+}
+
+/**
+ * Run the bootstrap merge. Caller MUST have verified [shouldRunBootstrapMerge] first.
+ */
+fun runBootstrapMerge(
+	client: SyncGitClient,
+	vaultRoot: String,
+	defaultBranch: String,
+	author: CommitAuthor,
+): BootstrapMergeResult {
+	val vaultPath = Path.of(vaultRoot)
+	val stashRoot = Path.of(vaultRoot, BOOTSTRAP_STASH_DIRNAME)
+
+	// Pre-flight race reassertion (C1 + C4).
+	if (client.hasHead()) {
+		return BootstrapMergeResult(ok = false, code = "race-detected", message = "HEAD appeared between trigger check and stash")
+	}
+	val branchesNow = client.listLocalBranches()
+	if (branchesNow.isNotEmpty()) {
+		return BootstrapMergeResult(ok = false, code = "race-detected", message = "local branch appeared mid-flight: ${branchesNow.joinToString(",")}")
+	}
+
+	// Step 1: stash every local file.
+	val localFiles = collectLocalFiles(vaultPath, stashRoot)
+	log.info("bootstrap-merge: stashing ${localFiles.size} local files into $BOOTSTRAP_STASH_DIRNAME")
+	for (rel in localFiles) {
+		val src = vaultPath.resolve(rel)
+		val dst = stashRoot.resolve(rel)
+		Files.createDirectories(dst.parent)
+		try {
+			Files.move(src, dst)
+		} catch (_: Exception) {
+			Files.copy(src, dst)
+			Files.delete(src)
+		}
+	}
+
+	// Step 2: adopt remote.
+	try {
+		client.checkoutTrackingBranch(defaultBranch)
+	} catch (e: Exception) {
+		val msg = e.message ?: e.toString()
+		log.warn("bootstrap-merge: checkout failed: $msg — rolling back stash")
+		restoreStashedFiles(localFiles, vaultPath, stashRoot)
+		return BootstrapMergeResult(ok = false, code = "checkout-failed", message = msg)
+	}
+
+	// Step 3: walk stash, decide per-path disposition.
+	val reports = mutableListOf<BootstrapPathReport>()
+	val stashedFiles = collectStashFiles(stashRoot)
+	for (rel in stashedFiles) {
+		val stashPath = stashRoot.resolve(rel)
+		val workingPath = vaultPath.resolve(rel)
+		val workingExists = Files.exists(workingPath)
+
+		if (!workingExists) {
+			// Pure local addition — restore.
+			Files.createDirectories(workingPath.parent)
+			Files.move(stashPath, workingPath)
+			reports.add(BootstrapPathReport(rel, "added-from-local"))
+			continue
+		}
+
+		// Both sides have it.
+		val stashBytes = Files.readAllBytes(stashPath)
+		val workingBytes = Files.readAllBytes(workingPath)
+		if (stashBytes.contentEquals(workingBytes)) {
+			Files.delete(stashPath)
+			reports.add(BootstrapPathReport(rel, "no-op"))
+			continue
+		}
+
+		// Conflicting path — try aggregate merge for JSON aggregates.
+		if (isAggregatePath(rel)) {
+			val oursText = String(stashBytes, Charsets.UTF_8)
+			val theirsText = String(workingBytes, Charsets.UTF_8)
+			val merged = tryAggregateMerge(rel, oursText, theirsText)
+			if (merged != null) {
+				Files.writeString(workingPath, merged)
+				Files.delete(stashPath)
+				reports.add(BootstrapPathReport(rel, "aggregate-merged"))
+				continue
+			}
+			log.warn("bootstrap-merge: aggregate merge returned null for $rel — falling back to remote-wins")
+		}
+
+		// Remote wins, local stays in stash.
+		reports.add(BootstrapPathReport(rel, "remote-wins-local-stashed"))
+	}
+
+	// Sweep empty stash dirs.
+	pruneEmptyDirs(stashRoot)
+	val stashedSurvivors = collectStashFiles(stashRoot)
+
+	// Step 4: stage + commit.
+	client.stageAll()
+	val commitSha: String
+	try {
+		commitSha = client.commit(
+			"[jolli-mb] reconcile: bootstrap merge of fresh local into populated remote",
+			author,
+		)
+	} catch (e: Exception) {
+		val msg = e.message ?: ""
+		if (msg.contains("nothing to commit", ignoreCase = true) || msg.contains("no changes added", ignoreCase = true)) {
+			val head = client.revParse("HEAD")
+				?: return BootstrapMergeResult(ok = false, code = "commit-failed", message = "HEAD missing after empty merge")
+			return BootstrapMergeResult(ok = true, commitSha = head, reports = reports, stashedSurvivors = stashedSurvivors)
+		}
+		log.warn("bootstrap-merge: commit failed: $msg")
+		return BootstrapMergeResult(ok = false, code = "commit-failed", message = msg)
+	}
+
+	log.info("bootstrap-merge: done commit=$commitSha reports=${reports.size} stashedSurvivors=${stashedSurvivors.size}")
+	return BootstrapMergeResult(ok = true, commitSha = commitSha, reports = reports, stashedSurvivors = stashedSurvivors)
+}
+
+// ── File collection helpers ─────────────────────────────────────────
+
+private fun collectLocalFiles(root: Path, stashRoot: Path): List<String> {
+	val out = mutableListOf<String>()
+	if (!Files.isDirectory(root)) return out
+	Files.walkFileTree(root, object : SimpleFileVisitor<Path>() {
+		override fun preVisitDirectory(dir: Path, attrs: BasicFileAttributes): FileVisitResult {
+			if (dir.fileName?.toString() == ".git") return FileVisitResult.SKIP_SUBTREE
+			if (dir == stashRoot) return FileVisitResult.SKIP_SUBTREE
+			return FileVisitResult.CONTINUE
+		}
+		override fun visitFile(file: Path, attrs: BasicFileAttributes): FileVisitResult {
+			out.add(root.relativize(file).toString().replace('\\', '/'))
+			return FileVisitResult.CONTINUE
+		}
+	})
+	return out
+}
+
+private fun collectStashFiles(stashRoot: Path): List<String> {
+	val out = mutableListOf<String>()
+	if (!Files.isDirectory(stashRoot)) return out
+	Files.walkFileTree(stashRoot, object : SimpleFileVisitor<Path>() {
+		override fun visitFile(file: Path, attrs: BasicFileAttributes): FileVisitResult {
+			out.add(stashRoot.relativize(file).toString().replace('\\', '/'))
+			return FileVisitResult.CONTINUE
+		}
+	})
+	return out
+}
+
+private fun restoreStashedFiles(rels: List<String>, vaultRoot: Path, stashRoot: Path) {
+	for (rel in rels) {
+		val src = stashRoot.resolve(rel)
+		val dst = vaultRoot.resolve(rel)
+		if (!Files.exists(src)) continue
+		Files.createDirectories(dst.parent)
+		try {
+			Files.move(src, dst)
+		} catch (_: Exception) {
+			Files.copy(src, dst)
+			Files.delete(src)
+		}
+	}
+	pruneEmptyDirs(stashRoot)
+}
+
+private fun pruneEmptyDirs(root: Path) {
+	if (!Files.isDirectory(root)) return
+	Files.walkFileTree(root, object : SimpleFileVisitor<Path>() {
+		override fun postVisitDirectory(dir: Path, exc: IOException?): FileVisitResult {
+			try {
+				Files.newDirectoryStream(dir).use { stream ->
+					if (!stream.iterator().hasNext()) {
+						Files.delete(dir)
+					}
+				}
+			} catch (_: Exception) {}
+			return FileVisitResult.CONTINUE
+		}
+	})
+}

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/sync/ConflictResolver.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/sync/ConflictResolver.kt
@@ -1,0 +1,420 @@
+package ai.jolli.jollimemory.sync
+
+import ai.jolli.jollimemory.core.JmLogger
+import com.google.gson.Gson
+import com.google.gson.GsonBuilder
+import java.io.File
+
+/**
+ * Conflict resolution pyramid: Tier 1.5 → Tier 2.7 → Tier 2 → Tier 3.
+ *
+ * Called by `SyncEngine.runRound` when `SyncGitClient.pullRebase` returns
+ * non-empty `conflicted`. For each conflicting path:
+ *
+ *   - **Tier 1.5**: aggregate JSON auto-merge (deterministic, no AI/user).
+ *   - **Tier 2.7**: safe heuristics (empty-vs-content, normalize, append-only).
+ *   - **Tier 2**: AI semantic merge via [AiMergeProvider].
+ *   - **Tier 3**: policy-driven fallback (mine/theirs/prompt).
+ *
+ * After all paths: `rebaseContinue` if all resolved, `rebaseAbort` if any skipped.
+ *
+ * Port of `cli/src/sync/ConflictResolver.ts`.
+ */
+
+// ── Interfaces & types ─────────────────────────────────────────────────
+
+data class AiMergeRequest(
+	val path: String,
+	val base: String?,
+	val ours: String,
+	val theirs: String,
+	val fileKind: String, // "md" | "json"
+)
+
+data class AiMergeResponse(
+	val merged: String,
+	val confidence: Double, // 0..1
+	val model: String,
+)
+
+fun interface AiMergeProvider {
+	fun merge(req: AiMergeRequest): AiMergeResponse
+}
+
+enum class Tier3Pick { MINE, THEIRS, SKIP, VIEW_DIFF }
+
+interface ConflictUi {
+	fun promptBinaryPick(path: String, oursOid: String?, theirsOid: String?): Tier3Pick
+	fun showDiff(path: String, ours: String, theirs: String) {}
+}
+
+enum class ConflictPolicy { PROMPT, MINE, THEIRS }
+
+data class ConflictResolutionReport(
+	val resolved: List<String>,
+	val skipped: List<String>,
+	val aiMerged: List<AiMergedEntry>,
+	val binaryPicked: List<BinaryPickedEntry>,
+	val aggregateMerged: List<String>,
+	val rebaseAdvanced: Boolean,
+)
+
+data class AiMergedEntry(val path: String, val model: String)
+data class BinaryPickedEntry(val path: String, val pick: String) // "mine" | "theirs"
+
+sealed class SafeHeuristicResult {
+	data class Merged(val merged: String, val via: String) : SafeHeuristicResult()
+	data class Delete(val via: String) : SafeHeuristicResult()
+}
+
+// ── ConflictResolver ───────────────────────────────────────────────────
+
+class ConflictResolver(
+	private val client: SyncGitClient,
+	private val ai: AiMergeProvider?,
+	private val ui: ConflictUi,
+	private val writeFile: (String, String) -> Unit = { path, content -> File(path).writeText(content) },
+	private val resolveVaultPath: (String) -> String = { it },
+	private val minConfidence: Double = DEFAULT_MIN_CONFIDENCE,
+	private val policy: ConflictPolicy = ConflictPolicy.PROMPT,
+	private val author: CommitAuthor? = null,
+) {
+
+	private val log = JmLogger.create("Sync:ConflictResolver")
+
+	fun resolveAll(paths: List<String>): ConflictResolutionReport {
+		val resolved = mutableListOf<String>()
+		val skipped = mutableListOf<String>()
+		val aiMerged = mutableListOf<AiMergedEntry>()
+		val binaryPicked = mutableListOf<BinaryPickedEntry>()
+		val aggregateMerged = mutableListOf<String>()
+
+		for (path in paths) {
+			val ours = client.readIndexStage(path, 2)
+			val theirs = client.readIndexStage(path, 3)
+			val base = client.readIndexStage(path, 1)
+
+			// Tier 1.5 — aggregate file auto-merge.
+			if (isAggregatePath(path)) {
+				val oursForMerge = ours ?: emptyAggregateEnvelope(path)
+				val theirsForMerge = theirs ?: emptyAggregateEnvelope(path)
+				val merged = tryAggregateMerge(path, oursForMerge, theirsForMerge)
+				if (merged != null) {
+					writeFile(resolveVaultPath(path), merged)
+					client.addPath(path)
+					resolved.add(path)
+					aggregateMerged.add(path)
+					continue
+				}
+				// Parse failure → fall through to Tier 2/3.
+			}
+
+			// Tier 2.7 — safe deterministic heuristics.
+			val safeMerge = trySafeHeuristics(path, base, ours, theirs)
+			if (safeMerge != null) {
+				when (safeMerge) {
+					is SafeHeuristicResult.Merged -> {
+						writeFile(resolveVaultPath(path), safeMerge.merged)
+						client.addPath(path)
+					}
+					is SafeHeuristicResult.Delete -> {
+						client.removePath(path)
+					}
+				}
+				resolved.add(path)
+				val via = when (safeMerge) {
+					is SafeHeuristicResult.Merged -> safeMerge.via
+					is SafeHeuristicResult.Delete -> safeMerge.via
+				}
+				log.info("Tier 2.7 resolved %s via %s", path, via)
+				continue
+			}
+
+			// Tier 2 — AI merge.
+			if (ai != null && ours != null && theirs != null) {
+				val aiResult = tryAiMerge(path, base, ours, theirs)
+				if (aiResult != null) {
+					writeFile(resolveVaultPath(path), aiResult.merged)
+					client.addPath(path)
+					resolved.add(path)
+					aiMerged.add(AiMergedEntry(path, aiResult.model))
+					continue
+				}
+			}
+
+			// Tier 3 — policy-driven fallback.
+			val pick = runTier3(path, ours, theirs)
+			if (pick == "skip") {
+				skipped.add(path)
+				continue
+			}
+			if (pick == "mine") client.checkoutOurs(path)
+			else client.checkoutTheirs(path)
+			resolved.add(path)
+			binaryPicked.add(BinaryPickedEntry(path, pick))
+		}
+
+		if (skipped.isNotEmpty()) {
+			client.rebaseAbort()
+			return ConflictResolutionReport(resolved, skipped, aiMerged, binaryPicked, aggregateMerged, rebaseAdvanced = false)
+		}
+
+		client.rebaseContinue(author)
+		return ConflictResolutionReport(resolved, skipped, aiMerged, binaryPicked, aggregateMerged, rebaseAdvanced = true)
+	}
+
+	private fun tryAiMerge(
+		path: String,
+		base: String?,
+		ours: String,
+		theirs: String,
+	): AiMergeResult? {
+		val fileKind = if (path.lowercase().endsWith(".json")) "json" else "md"
+		return try {
+			val response = ai!!.merge(AiMergeRequest(path, base, ours, theirs, fileKind))
+			if (!passesGuards(response, ours, theirs, fileKind)) null
+			else AiMergeResult(response.merged, response.model)
+		} catch (e: Exception) {
+			log.warn("Tier 2 AI merge failed for %s: %s", path, e.message)
+			null
+		}
+	}
+
+	private fun passesGuards(response: AiMergeResponse, ours: String, theirs: String, fileKind: String): Boolean {
+		if (response.confidence < minConfidence) return false
+		if (MARKER_REGEX.containsMatchIn(response.merged)) return false
+		val maxLen = maxOf(ours.length, theirs.length)
+		val len = response.merged.length
+		if (len < maxLen * MIN_LENGTH_RATIO) return false
+		if (len > maxLen * MAX_LENGTH_RATIO) return false
+		if (fileKind == "json") {
+			try {
+				Gson().fromJson(response.merged, Any::class.java)
+			} catch (_: Exception) {
+				return false
+			}
+		}
+		return true
+	}
+
+	/**
+	 * Tier 2.7 — safe deterministic heuristics applied BEFORE Tier 3.
+	 */
+	internal fun trySafeHeuristics(
+		path: String,
+		base: String?,
+		ours: String?,
+		theirs: String?,
+	): SafeHeuristicResult? {
+		// Rule 1: empty/whitespace-only side.
+		if (ours != null && theirs != null) {
+			if (isWhitespaceOnly(ours) && !isWhitespaceOnly(theirs)) {
+				return SafeHeuristicResult.Merged(theirs, "empty-mine")
+			}
+			if (isWhitespaceOnly(theirs) && !isWhitespaceOnly(ours)) {
+				return SafeHeuristicResult.Merged(ours, "empty-theirs")
+			}
+
+			// Rule 2: identical after normalization.
+			if (normalizeForCompare(ours) == normalizeForCompare(theirs)) {
+				return SafeHeuristicResult.Merged(ours, "identical-after-normalize")
+			}
+		}
+
+		// Rule 3: base-aware delete-vs-modify.
+		if (ours == null && theirs != null) {
+			return classifyDeleteVsModify(base, theirs, "mine-deleted")
+		}
+		if (theirs == null && ours != null) {
+			return classifyDeleteVsModify(base, ours, "theirs-deleted")
+		}
+
+		// Rule 4: Memory Bank summary/plan markdown union.
+		if (ours != null && theirs != null && isMemoryBankAppendOnlyPath(path)) {
+			return SafeHeuristicResult.Merged(unionMarkdown(ours, theirs), "memory-bank-summary-union")
+		}
+
+		return null
+	}
+
+	/**
+	 * Tier 3 — policy-driven fallback.
+	 */
+	private fun runTier3(path: String, ours: String?, theirs: String?): String {
+		if (policy == ConflictPolicy.MINE) return "mine"
+		if (policy == ConflictPolicy.THEIRS) return "theirs"
+		// policy == PROMPT
+		while (true) {
+			val pick = ui.promptBinaryPick(path, ours, theirs)
+			if (pick != Tier3Pick.VIEW_DIFF) {
+				return when (pick) {
+					Tier3Pick.MINE -> "mine"
+					Tier3Pick.THEIRS -> "theirs"
+					else -> "skip"
+				}
+			}
+			if (ours != null && theirs != null) {
+				ui.showDiff(path, ours, theirs)
+			}
+		}
+	}
+
+	private data class AiMergeResult(val merged: String, val model: String)
+
+	companion object {
+		private val MARKER_REGEX = Regex("^(<<<<<<<|=======|>>>>>>>)", RegexOption.MULTILINE)
+		private const val DEFAULT_MIN_CONFIDENCE = 0.6
+		private const val MIN_LENGTH_RATIO = 0.5
+		private const val MAX_LENGTH_RATIO = 4.0
+	}
+}
+
+// ── Top-level helpers (visible for testing) ────────────────────────────
+
+private val AGGREGATE_BASENAMES = setOf("manifest.json", "index.json", "branches.json", "catalog.json")
+
+/**
+ * True if `path` is one of the aggregate files governed by deterministic merge.
+ */
+fun isAggregatePath(path: String): Boolean {
+	if (path == REPO_MAPPING_PATH) return true
+	val segments = path.split("/")
+	if (segments.size < 2) return false
+	val basename = segments.last()
+	val parent = segments[segments.size - 2]
+	return parent == ".jolli" && basename in AGGREGATE_BASENAMES
+}
+
+/**
+ * Returns a serialized empty envelope for the given aggregate path.
+ */
+fun emptyAggregateEnvelope(path: String): String {
+	if (path == REPO_MAPPING_PATH) return """{"version":1,"mappings":[]}"""
+	val basename = path.split("/").last()
+	return when (basename) {
+		"manifest.json" -> """{"version":1,"files":[]}"""
+		"index.json" -> """{"version":3,"entries":[]}"""
+		"branches.json" -> """{"version":1,"mappings":[]}"""
+		"catalog.json" -> """{"version":1,"entries":[]}"""
+		else -> "{}"
+	}
+}
+
+/**
+ * Dispatches on basename to the matching deterministic merge function.
+ * Returns null when either side fails to parse.
+ */
+fun tryAggregateMerge(path: String, ours: String, theirs: String): String? {
+	if (path == REPO_MAPPING_PATH) {
+		return mergeRepoMappingDoc(ours, theirs)
+	}
+
+	if (parseJson(ours) == null || parseJson(theirs) == null) return null
+
+	val gson = GsonBuilder().setPrettyPrinting().create()
+	val basename = path.split("/").last()
+
+	return when (basename) {
+		"manifest.json" -> mergeEnvelopeDoc<ManifestEnvelope>(gson, ours, theirs) { o, t ->
+			if (o.files == null || t.files == null) null
+			else ManifestEnvelope(version = 1, files = mergeManifest(o.files, t.files))
+		}
+		"index.json" -> mergeEnvelopeDoc<IndexEnvelope>(gson, ours, theirs) { o, t ->
+			if (o.entries == null || t.entries == null) null
+			else IndexEnvelope(version = 3, entries = mergeIndex(o.entries, t.entries))
+		}
+		"branches.json" -> mergeEnvelopeDoc<BranchesEnvelope>(gson, ours, theirs) { o, t ->
+			if (o.mappings == null || t.mappings == null) null
+			else BranchesEnvelope(version = 1, mappings = mergeBranches(o.mappings, t.mappings))
+		}
+		"catalog.json" -> mergeEnvelopeDoc<CatalogEnvelope>(gson, ours, theirs) { o, t ->
+			if (o.entries == null || t.entries == null) null
+			else CatalogEnvelope(version = 1, entries = mergeCatalog(o.entries, t.entries))
+		}
+		else -> null
+	}
+}
+
+/**
+ * True if path is a Memory Bank append-only markdown file:
+ * `<repo>/<branch>/<file>.md` (3+ segments, not under `.jolli/`).
+ */
+fun isMemoryBankAppendOnlyPath(path: String): Boolean {
+	if (!path.lowercase().endsWith(".md")) return false
+	val segments = path.split("/").filter { it.isNotEmpty() }
+	if (segments.size < 3) return false
+	if (segments.contains(".jolli")) return false
+	return true
+}
+
+/**
+ * Append `theirs` onto `ours` with a visible separator. Idempotent:
+ * if one side already contains the other, returns the containing side.
+ */
+fun unionMarkdown(ours: String, theirs: String): String {
+	val oursTrimmed = ours.replace(Regex("\\s+$"), "")
+	val theirsTrimmed = theirs.replace(Regex("\\s+$"), "")
+	if (oursTrimmed.contains(theirsTrimmed)) return ours
+	if (theirsTrimmed.contains(oursTrimmed)) return theirs
+	return "$oursTrimmed\n\n---\n\n*Synced from another device:*\n\n$theirsTrimmed\n"
+}
+
+/**
+ * Base-aware classifier for delete-vs-modify (Rule 3).
+ */
+fun classifyDeleteVsModify(
+	base: String?,
+	present: String,
+	tag: String,
+): SafeHeuristicResult? {
+	if (base != null && normalizeForCompare(base) == normalizeForCompare(present)) {
+		return SafeHeuristicResult.Delete("respect-$tag")
+	}
+	if (base == null) {
+		return SafeHeuristicResult.Merged(present, "accept-add-when-$tag")
+	}
+	return null
+}
+
+/** Strips trailing whitespace per line + trailing newlines. CRLF → LF. */
+fun normalizeForCompare(s: String): String {
+	return s
+		.replace("\r\n", "\n")
+		.replace(Regex("[ \\t]+$", RegexOption.MULTILINE), "")
+		.replace(Regex("\\n+$"), "")
+}
+
+// ── Private helpers ────────────────────────────────────────────────────
+
+private fun isWhitespaceOnly(s: String): Boolean = s.trim().isEmpty()
+
+private fun parseJson(text: String): Any? {
+	return try {
+		Gson().fromJson(text, Any::class.java)
+	} catch (_: Exception) {
+		null
+	}
+}
+
+private inline fun <reified T> mergeEnvelopeDoc(
+	gson: Gson,
+	ours: String,
+	theirs: String,
+	merge: (T, T) -> T?,
+): String? {
+	return try {
+		val o = gson.fromJson(ours, T::class.java)
+		val t = gson.fromJson(theirs, T::class.java)
+		val merged = merge(o, t) ?: return null
+		"${gson.toJson(merged)}\n"
+	} catch (_: Exception) {
+		null
+	}
+}
+
+private fun mergeRepoMappingDoc(ours: String, theirs: String): String? {
+	val oursDoc = parseRepoMapping(ours) ?: return null
+	val theirsDoc = parseRepoMapping(theirs) ?: return null
+	val (merged, _) = mergeRepoMapping(oursDoc, theirsDoc)
+	return serializeRepoMapping(merged)
+}

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/sync/CorruptJsonQuarantine.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/sync/CorruptJsonQuarantine.kt
@@ -1,0 +1,119 @@
+package ai.jolli.jollimemory.sync
+
+import ai.jolli.jollimemory.core.JmLogger
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardCopyOption
+
+/**
+ * Pre-stage corrupt-JSON quarantine.
+ *
+ * Validates every dirty JSON file under `.jolli/` BEFORE staging. Files that fail
+ * `JSON.parse` are moved to `<memoryBankRoot>/.jolli-quarantine-corrupt/`
+ * so they never enter the orphan history.
+ *
+ * Port of `cli/src/sync/CorruptJsonQuarantine.ts`.
+ */
+
+private val log = JmLogger.create("CorruptJsonQuarantine")
+
+const val QUARANTINE_CORRUPT_DIR = ".jolli-quarantine-corrupt"
+
+data class CorruptJsonReport(
+	val quarantined: Int,
+	val paths: List<String>,
+)
+
+/**
+ * Walks [dirtyPaths] (relative to [memoryBankRoot]), validates each
+ * JSON files under `.jolli/` are parseable, and quarantines the ones that aren't.
+ */
+fun quarantineCorruptJson(
+	memoryBankRoot: String,
+	dirtyPaths: List<String>,
+): CorruptJsonReport {
+	val candidates = dirtyPaths.filter(::isValidatableJson)
+	if (candidates.isEmpty()) return CorruptJsonReport(0, emptyList())
+
+	val found = mutableListOf<String>()
+	for (rel in candidates) {
+		val abs = Path.of(memoryBankRoot, rel)
+		try {
+			if (!Files.isRegularFile(abs)) continue
+		} catch (_: Exception) {
+			continue // missing
+		}
+		val content: String
+		try {
+			content = Files.readString(abs)
+		} catch (_: Exception) {
+			continue
+		}
+		try {
+			com.google.gson.JsonParser.parseString(content)
+		} catch (_: Exception) {
+			found.add(rel)
+		}
+	}
+
+	if (found.isEmpty()) return CorruptJsonReport(0, emptyList())
+
+	val quarantineDir = Path.of(memoryBankRoot, QUARANTINE_CORRUPT_DIR)
+	val dirOk = ensureQuarantineDir(quarantineDir)
+	if (!dirOk) {
+		log.warn("Quarantine dir unusable — ${found.size} corrupt JSON file(s) left in place")
+		return CorruptJsonReport(0, emptyList())
+	}
+
+	var quarantined = 0
+	val moved = mutableListOf<String>()
+	for (rel in found) {
+		val src = Path.of(memoryBankRoot, rel)
+		val safeName = rel.replace(Regex("[/\\\\]"), "-")
+		val dst = quarantineDir.resolve(safeName)
+		// Clean stale destination first.
+		try { Files.deleteIfExists(dst) } catch (_: Exception) {}
+		try {
+			Files.move(src, dst, StandardCopyOption.REPLACE_EXISTING)
+			quarantined++
+			moved.add(rel)
+			log.warn("Quarantined corrupt JSON: $rel → ${Path.of(memoryBankRoot).relativize(dst)}")
+		} catch (e: Exception) {
+			log.warn("Failed to quarantine corrupt JSON $rel (non-fatal): ${e.message}")
+		}
+	}
+	return CorruptJsonReport(quarantined, moved)
+}
+
+/**
+ * Returns true iff this relative path should be validated: ends in `.json`
+ * AND is under the `.jolli/` subtree.
+ */
+internal fun isValidatableJson(rel: String): Boolean {
+	if (!rel.endsWith(".json")) return false
+	val segments = rel.split(Regex("[/\\\\]+"))
+	return segments.contains(".jolli")
+}
+
+private fun ensureQuarantineDir(quarantineDir: Path): Boolean {
+	try {
+		if (Files.isSymbolicLink(quarantineDir)) {
+			log.warn("Quarantine path $quarantineDir is a symlink — unlinking")
+			try { Files.delete(quarantineDir) } catch (_: Exception) { return false }
+		} else if (Files.isDirectory(quarantineDir)) {
+			return true
+		} else if (Files.exists(quarantineDir)) {
+			log.warn("Quarantine path $quarantineDir exists but is not a directory — refusing")
+			return false
+		}
+	} catch (_: Exception) {
+		// stat failed — treat as missing
+	}
+	return try {
+		Files.createDirectory(quarantineDir)
+		true
+	} catch (e: Exception) {
+		log.warn("Failed to create quarantine dir $quarantineDir: ${e.message}")
+		false
+	}
+}

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/sync/GitAskpass.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/sync/GitAskpass.kt
@@ -1,0 +1,166 @@
+package ai.jolli.jollimemory.sync
+
+import java.io.File
+import java.security.MessageDigest
+
+/**
+ * `GIT_ASKPASS` shim for the sync engine.
+ *
+ * Port of `cli/src/sync/GitAskpass.ts`.
+ *
+ * When the sync engine spawns `git clone/fetch/push` against the vault, git
+ * prompts for a password (the Installation Token). We feed the token via a
+ * one-shot askpass script that reads the token from the spawned child's
+ * environment block — NEVER from argv (which `ps -ef` can read on every OS).
+ *
+ * The script is generated on first use into `~/.jolli/jollimemory/askpass/`
+ * and reused across subsequent spawns. Windows gets a separate `.cmd` variant.
+ */
+
+/** Env var name the spawned git child reads to learn the token. */
+const val ASKPASS_ENV_VAR = "JOLLI_SYNC_GIT_TOKEN"
+
+/**
+ * Handle returned by [prepareAskpass] — ready to merge into ProcessBuilder env.
+ *
+ * @property scriptPath Absolute path to the askpass script.
+ * @property env Curated env map: allowlisted vars + GIT_ASKPASS + token.
+ */
+data class AskpassHandle(
+	val scriptPath: String,
+	val env: Map<String, String>,
+)
+
+/** POSIX askpass script — prints the token from env and exits. */
+private const val POSIX_SCRIPT = "#!/usr/bin/env sh\nprintf '%s\\n' \"\$$ASKPASS_ENV_VAR\"\n"
+
+/** Windows askpass script. */
+private const val WINDOWS_SCRIPT = "@echo off\r\necho %$ASKPASS_ENV_VAR%\r\n"
+
+/**
+ * Env vars passed through to spawned git children. Anything not on this list
+ * (and not matching the `GIT_` prefix pass) is dropped — secrets like
+ * `ANTHROPIC_API_KEY` / `JOLLI_API_KEY` / `GITHUB_TOKEN` must not leak
+ * to git or its subprocesses.
+ */
+private val ENV_ALLOWLIST = listOf(
+	"PATH",
+	"HOME",
+	"USERPROFILE",
+	"TMPDIR",
+	"TEMP",
+	"TMP",
+	"LANG",
+	"LC_ALL",
+	"LC_CTYPE",
+	"LC_MESSAGES",
+	"SSH_AUTH_SOCK",
+	"SSH_AGENT_PID",
+	"XDG_CONFIG_HOME",
+	"XDG_RUNTIME_DIR",
+	"SystemRoot",
+	"APPDATA",
+	"LOCALAPPDATA",
+	"PATHEXT",
+	"COMSPEC",
+	"HTTP_PROXY",
+	"HTTPS_PROXY",
+	"NO_PROXY",
+	"ALL_PROXY",
+	"http_proxy",
+	"https_proxy",
+	"no_proxy",
+	"all_proxy",
+	"SSL_CERT_FILE",
+	"SSL_CERT_DIR",
+	"CURL_CA_BUNDLE",
+	"NODE_EXTRA_CA_CERTS",
+	"USER",
+	"LOGNAME",
+	"USERNAME",
+	"USERDOMAIN",
+	"EDITOR",
+	"VISUAL",
+)
+
+/**
+ * `GIT_*` env vars that the prefix pass refuses to forward. These rewrite
+ * which repo git operates on — the vault sync must always use its own cwd.
+ */
+private val GIT_PREFIX_DENYLIST = setOf("GIT_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE")
+
+private val isWindows = System.getProperty("os.name").lowercase().contains("win")
+
+private fun getAskpassDir(): String {
+	val home = System.getProperty("user.home")
+	return File(home, ".jolli${File.separator}jollimemory${File.separator}askpass").absolutePath
+}
+
+private fun getAskpassScriptPath(): String {
+	val name = if (isWindows) "git-askpass.cmd" else "git-askpass.sh"
+	return File(getAskpassDir(), name).absolutePath
+}
+
+private fun getDesiredScriptBody(): String {
+	return if (isWindows) WINDOWS_SCRIPT else POSIX_SCRIPT
+}
+
+private fun sha256(s: String): String {
+	val digest = MessageDigest.getInstance("SHA-256")
+	return digest.digest(s.toByteArray()).joinToString("") { "%02x".format(it) }
+}
+
+/**
+ * Ensures the askpass script exists with the current expected content, then
+ * returns a handle ready to merge into ProcessBuilder environment.
+ *
+ * Idempotent: a matching script on disk is left alone.
+ */
+fun prepareAskpass(token: String): AskpassHandle {
+	val scriptPath = getAskpassScriptPath()
+	val desired = getDesiredScriptBody()
+	val dir = File(getAskpassDir())
+	dir.mkdirs()
+
+	val scriptFile = File(scriptPath)
+	var needsWrite = true
+	if (scriptFile.exists()) {
+		try {
+			val existing = scriptFile.readText()
+			if (sha256(existing) == sha256(desired)) {
+				needsWrite = false
+			}
+		} catch (_: Exception) {
+			// Unreadable — rewrite below.
+		}
+	}
+
+	if (needsWrite) {
+		scriptFile.writeText(desired)
+		if (!isWindows) {
+			scriptFile.setExecutable(true, true) // chmod 0700
+			scriptFile.setReadable(true, true)
+			scriptFile.setWritable(true, true)
+		}
+	}
+
+	// Build curated env from allowlist + GIT_* prefix pass.
+	val inherited = mutableMapOf<String, String>()
+	for (key in ENV_ALLOWLIST) {
+		val value = System.getenv(key)
+		if (value != null) inherited[key] = value
+	}
+	for ((key, value) in System.getenv()) {
+		if (key.startsWith("GIT_") && !inherited.containsKey(key) && key !in GIT_PREFIX_DENYLIST) {
+			inherited[key] = value
+		}
+	}
+
+	val env = inherited.toMutableMap()
+	env["GIT_ASKPASS"] = scriptPath
+	env["GIT_TERMINAL_PROMPT"] = "0"
+	env["GCM_INTERACTIVE"] = "Never"
+	env[ASKPASS_ENV_VAR] = token
+
+	return AskpassHandle(scriptPath = scriptPath, env = env)
+}

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/sync/GitErrorClassifiers.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/sync/GitErrorClassifiers.kt
@@ -1,0 +1,95 @@
+package ai.jolli.jollimemory.sync
+
+/**
+ * Error classifiers for git stderr/stdout messages.
+ *
+ * Port of the three classifier functions from `cli/src/sync/GitClient.ts`.
+ * Used by both [SyncGitClient] and the sync engine to route failures to
+ * the correct recovery path.
+ *
+ * Priority order at the engine call site:
+ *   `unauthorized` > `repoMissing` > `serverRejection` > `network` > `fatal`
+ */
+
+/**
+ * True when git's output indicates the remote GitHub repo doesn't exist
+ * (deleted, never created, or 404). Engine triggers a re-mint so backend
+ * `ensureGithubRepoExists` can recreate it.
+ */
+fun isRepoMissingMessage(message: String): Boolean {
+	val m = message.lowercase()
+	if (Regex("remote: repository not found").containsMatchIn(m)) return true
+	if (Regex("repository '[^']*' not found").containsMatchIn(m)) return true
+	if (Regex("the requested url returned error: 404").containsMatchIn(m)) return true
+	if (Regex("fatal: not found").containsMatchIn(m)) return true
+	return false
+}
+
+private val NETWORK_ERROR_PATTERNS = listOf(
+	Regex("gnutls"),
+	Regex("\\bhandshake failed\\b"),
+	Regex("tls connection.*(terminated|reset|closed|aborted)"),
+	Regex("ssl[\\s_]?error"),
+	Regex("error: ssl"),
+	Regex("could ?n['o]?t resolve host"),
+	Regex("failed to connect to"),
+	Regex("connection (timed out|refused|reset|closed)"),
+	Regex("operation timed out"),
+	Regex("network is unreachable"),
+	Regex("empty reply from server"),
+	Regex("\\bearly eof\\b"),
+	Regex("unexpected disconnect while reading sideband packet"),
+	Regex("the remote end hung up unexpectedly"),
+	Regex("rpc failed"),
+	Regex("curl.*(\\(56\\)|\\(28\\)|\\(35\\))"),
+)
+
+/**
+ * True when git's output indicates a network-layer failure (DNS, TLS,
+ * timeout, dropped socket). Engine routes these to a transient "offline"
+ * state that self-heals on the next poll tick.
+ */
+fun isNetworkErrorMessage(message: String): Boolean {
+	val m = message.lowercase()
+	return NETWORK_ERROR_PATTERNS.any { it.containsMatchIn(m) }
+}
+
+private val SERVER_REJECTION_PATTERNS = listOf(
+	Regex("^remote: error:", RegexOption.MULTILINE),
+	Regex("pre[-\\s]?receive hook declined"),
+	Regex("post[-\\s]?receive hook declined"),
+	Regex("refusing to update checked out branch"),
+	Regex("\\bprotected branch\\b"),
+	Regex("\\b(push|file).{0,40}(too large|exceeds.{0,20}limit)\\b"),
+	Regex("permission to .* denied"),
+)
+
+/**
+ * True when the server actively rejected the push (pre-receive hook,
+ * protected branch policy, size limit). Must be checked BEFORE
+ * [isNetworkErrorMessage] since rejection symptoms overlap with network
+ * error patterns (server closing the socket looks like "remote end hung up").
+ */
+fun isServerRejectionMessage(message: String): Boolean {
+	val m = message.lowercase()
+	return SERVER_REJECTION_PATTERNS.any { it.containsMatchIn(m) }
+}
+
+private val AUTH_ERROR_RE = Regex(
+	"authentication failed|invalid username or password|401 unauthorized|requested url returned error: 401",
+)
+
+/**
+ * Classifies a git stderr/stdout error into a recovery category.
+ *
+ * Priority: `unauthorized` > `repoMissing` > `network` > `fatal`.
+ * Used by [SyncEngine] to decide whether to re-mint credentials,
+ * report transient offline, or surface a terminal error.
+ */
+fun classifyGitError(message: String): String {
+	val m = message.lowercase()
+	if (AUTH_ERROR_RE.containsMatchIn(m)) return "unauthorized"
+	if (isRepoMissingMessage(message)) return "repoMissing"
+	if (isNetworkErrorMessage(message)) return "network"
+	return "fatal"
+}

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/sync/LegacyMigration.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/sync/LegacyMigration.kt
@@ -1,0 +1,88 @@
+package ai.jolli.jollimemory.sync
+
+import ai.jolli.jollimemory.core.JmLogger
+import java.nio.file.Files
+import java.nio.file.Path
+
+/**
+ * db → git first-bind migration writer.
+ *
+ * One-shot — runs only when `/credentials` reports `alreadyVaultBound === false`.
+ * Backend's [LegacyDoc] list gets written into `<memoryBankRoot>/<doc.path>`,
+ * idempotent under re-application (same path + same content = zero diff).
+ *
+ * Port of `cli/src/sync/LegacyMigration.ts`.
+ */
+class LegacyMigration(
+	private val memoryBankRoot: String,
+	private val transcripts: Boolean,
+) {
+
+	private val log = JmLogger.create("LegacyMigration")
+
+	/**
+	 * Writes legacy DB docs into `<memoryBankRoot>/<doc.path>`.
+	 *
+	 * Returns the number of files written (0 if [response] is already migrated
+	 * or has no docs).
+	 */
+	fun apply(response: LegacyContentResponse): Int {
+		if (response.alreadyMigrated || response.docs.isEmpty()) {
+			return 0
+		}
+		var filesWritten = 0
+		for (doc in response.docs) {
+			if (doc.docType == "folder") continue
+			val targetRel = mapLegacyDocToVaultPath(doc)
+			if (!isAllowedPath(targetRel, AllowListOpts(syncTranscripts = transcripts))) {
+				log.warn("apply: rejected by allow-list path=$targetRel id=${doc.id}")
+				continue
+			}
+			val absPath = Path.of(memoryBankRoot, targetRel)
+
+			// Idempotent re-apply: skip if target already has identical content.
+			try {
+				val existing = Files.readString(absPath)
+				if (existing == doc.content) continue
+			} catch (e: java.nio.file.NoSuchFileException) {
+				// Missing — fall through to write.
+			}
+
+			Files.createDirectories(absPath.parent)
+			Files.writeString(absPath, doc.content)
+			filesWritten++
+		}
+		log.info("apply: wrote $filesWritten files from ${response.docs.size} docs")
+		return filesWritten
+	}
+}
+
+/**
+ * Maps a [LegacyDoc] into the vault-relative on-disk path. The backend's
+ * `path` field is the authoritative file path including filename + extension;
+ * this function only sanitizes dot-segments and (when path is missing) falls
+ * back to a slug-derived name.
+ */
+internal fun mapLegacyDocToVaultPath(doc: LegacyDoc): String {
+	val sanitizedPath = sanitizeLegacyPath(doc.path)
+	if (sanitizedPath.isNotEmpty()) return sanitizedPath
+	val extension = pickExtensionForContentType(doc.contentType)
+	return "${doc.slug.ifEmpty { "doc" }}$extension"
+}
+
+private fun pickExtensionForContentType(contentType: String): String {
+	val ct = contentType.lowercase()
+	return when {
+		"markdown" in ct -> ".md"
+		"json" in ct -> ".json"
+		else -> ".md"
+	}
+}
+
+private fun sanitizeLegacyPath(rawPath: String): String {
+	return rawPath
+		.split("/")
+		.map { it.trim() }
+		.filter { it.isNotEmpty() && it != "." && it != ".." }
+		.joinToString("/")
+}

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/sync/LocalAiMergeProvider.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/sync/LocalAiMergeProvider.kt
@@ -1,0 +1,150 @@
+package ai.jolli.jollimemory.sync
+
+import ai.jolli.jollimemory.core.AnthropicClient
+import ai.jolli.jollimemory.core.JmLogger
+import java.security.SecureRandom
+
+/**
+ * Tier 2 AI merge using the user's locally-configured Anthropic API key.
+ *
+ * Tier 2 NEVER routes through a backend proxy — the user either has an
+ * API key set (this provider is used) or has nothing and the
+ * [ConflictResolver] falls straight to Tier 3 with `ai = null`.
+ *
+ * Port of `cli/src/sync/LocalAiMergeProvider.ts`.
+ */
+class LocalAiMergeProvider(
+	private val apiKey: String,
+	private val model: String = DEFAULT_MODEL,
+	private val maxTokens: Int = DEFAULT_MAX_TOKENS,
+	private val clientFactory: (String) -> AnthropicClient = ::AnthropicClient,
+	private val tokenFactory: () -> String = ::defaultToken,
+) : AiMergeProvider {
+
+	private val log = JmLogger.create("Sync:LocalAiMerge")
+	private val client = clientFactory(apiKey)
+
+	override fun merge(req: AiMergeRequest): AiMergeResponse {
+		val token = tokenFactory()
+		val prompt = buildPrompt(req, token)
+		val response = client.createMessage(
+			model = model,
+			maxTokens = maxTokens,
+			temperature = 0.0,
+			messages = listOf(AnthropicClient.Message("user", prompt)),
+		)
+		val textBlock = response.content.firstOrNull { it.type == "text" }
+			?: throw RuntimeException("LocalAiMergeProvider: no text content in LLM response")
+		val text = textBlock.text
+			?: throw RuntimeException("LocalAiMergeProvider: text block has null text")
+		val parsed = parseModelOutput(text, token)
+		log.debug(
+			"Tier 2 merge for %s — confidence=%.2f len=%d model=%s",
+			req.path, parsed.confidence, parsed.merged.length, response.model,
+		)
+		return AiMergeResponse(
+			merged = parsed.merged,
+			confidence = parsed.confidence,
+			model = response.model,
+		)
+	}
+
+	companion object {
+		private const val DEFAULT_MODEL = "claude-sonnet-4-20250514"
+		private const val DEFAULT_MAX_TOKENS = 8192
+
+		private fun defaultToken(): String {
+			val bytes = ByteArray(8)
+			SecureRandom().nextBytes(bytes)
+			return bytes.joinToString("") { "%02x".format(it) }
+		}
+	}
+}
+
+/**
+ * Builds the merge prompt with per-call random markers.
+ *
+ * The `BEGIN_MERGED_<token>` / `END_MERGED_<token>` markers use a random
+ * hex token so peer-pushed content can't pre-craft colliding lines.
+ */
+fun buildPrompt(req: AiMergeRequest, token: String): String {
+	val fileKindHint = if (req.fileKind == "json")
+		"The file is JSON. Preserve key order from `ours` where possible and ensure the result parses as valid JSON."
+	else
+		"The file is Markdown. Preserve heading structure from `ours` where possible."
+
+	val fence = "```"
+	val beginMarker = "BEGIN_MERGED_$token"
+	val endMarker = "END_MERGED_$token"
+	val baseLines = if (req.base == null)
+		listOf("BASE: <no common ancestor — the file did not exist on the merge base>")
+	else
+		listOf("BASE:", fence, req.base, fence)
+
+	return (listOf(
+		"You are merging two divergent versions of a single file into one coherent result.",
+		fileKindHint,
+		"",
+		"OUTPUT FORMAT — required, no exceptions:",
+		"  Line 1: CONFIDENCE=<0.00-1.00>",
+		"  Line 2: $beginMarker",
+		"  Lines 3..N-1: the merged file body, exactly as it should be written to disk",
+		"  Final line: $endMarker",
+		"The marker tokens ($beginMarker, $endMarker) are randomised per request — emit them VERBATIM, do not invent your own.",
+		"Do not include conflict markers (<<<<<<<, =======, >>>>>>>) anywhere.",
+		"Do not include commentary, explanations, or apologies. Body only.",
+		"",
+		"PATH: ${req.path}",
+		"",
+	) + baseLines + listOf(
+		"",
+		"OURS:",
+		fence,
+		req.ours,
+		fence,
+		"",
+		"THEIRS:",
+		fence,
+		req.theirs,
+		fence,
+	)).joinToString("\n")
+}
+
+data class ParsedOutput(
+	val merged: String,
+	val confidence: Double,
+)
+
+/**
+ * Parses the structured LLM response. Scopes marker matches to the
+ * caller-supplied per-call token. Throws when the format is broken.
+ */
+fun parseModelOutput(text: String, token: String): ParsedOutput {
+	val lines = text.split(Regex("\\r?\\n"))
+	if (lines.size < 3) {
+		throw RuntimeException("LocalAiMergeProvider: response too short to parse")
+	}
+
+	val confidenceMatch = Regex("^CONFIDENCE=(-?[0-9]*\\.?[0-9]+)$").find(lines[0].trim())
+		?: throw RuntimeException("LocalAiMergeProvider: missing CONFIDENCE header")
+	val rawConfidence = confidenceMatch.groupValues[1].toDouble()
+	val confidence = rawConfidence.coerceIn(0.0, 1.0)
+
+	val beginMarker = "BEGIN_MERGED_$token"
+	val endMarker = "END_MERGED_$token"
+	val beginIdx = lines.indexOfFirst { it.trim() == beginMarker }
+	var endIdx = -1
+	if (beginIdx != -1) {
+		for (i in (beginIdx + 1) until lines.size) {
+			if (lines[i].trim() == endMarker) {
+				endIdx = i
+				break
+			}
+		}
+	}
+	if (beginIdx == -1 || endIdx == -1) {
+		throw RuntimeException("LocalAiMergeProvider: missing BEGIN_MERGED / END_MERGED bracket")
+	}
+	val body = lines.subList(beginIdx + 1, endIdx).joinToString("\n")
+	return ParsedOutput(merged = body, confidence = confidence)
+}

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/sync/LockPrimitives.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/sync/LockPrimitives.kt
@@ -1,0 +1,143 @@
+package ai.jolli.jollimemory.sync
+
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardOpenOption
+import java.nio.file.attribute.FileTime
+import java.time.Instant
+
+/**
+ * Reusable file-lock primitives shared by all jollimemory file locks.
+ *
+ * Port of `cli/src/core/LockPrimitives.ts`.
+ *
+ * On-disk convention:
+ *   - PID written into the file as ASCII
+ *   - mtime is the freshness signal
+ *   - locks older than [LOCK_TIMEOUT_MS] are reclaimable by the next acquirer
+ *   - releases are PID-checked to prevent the stale-reclaim race
+ */
+object LockPrimitives {
+
+	/** Stale-reclaim threshold — 5 minutes. */
+	const val LOCK_TIMEOUT_MS = 5L * 60 * 1000
+
+	private val myPid: Long = ProcessHandle.current().pid()
+
+	/**
+	 * Returns true iff the OS reports a process with the given PID is alive.
+	 */
+	fun isPidAlive(pid: Long): Boolean {
+		if (pid <= 0) return false
+		if (pid == myPid) return true
+		return ProcessHandle.of(pid).map { it.isAlive }.orElse(false)
+	}
+
+	/**
+	 * Best-effort single attempt at creating [lockPath] exclusively.
+	 * Returns true on success. Stale locks (mtime > [LOCK_TIMEOUT_MS] or
+	 * dead PID) are removed automatically.
+	 */
+	fun tryAcquireOnce(lockPath: Path): Boolean {
+		if (Files.exists(lockPath)) {
+			try {
+				val mtime = Files.getLastModifiedTime(lockPath).toMillis()
+				val age = System.currentTimeMillis() - mtime
+				val ownerPid = readLockOwnerPid(lockPath)
+				val ownerDead = ownerPid != null && !isPidAlive(ownerPid)
+				if (!ownerDead && age < LOCK_TIMEOUT_MS) {
+					return false
+				}
+				Files.deleteIfExists(lockPath)
+			} catch (_: java.nio.file.NoSuchFileException) {
+				// Deleted between exists check and stat — proceed.
+			} catch (_: Exception) {
+				return false
+			}
+		}
+
+		return try {
+			Files.write(
+				lockPath,
+				myPid.toString().toByteArray(),
+				StandardOpenOption.CREATE_NEW,
+				StandardOpenOption.WRITE,
+			)
+			true
+		} catch (_: java.nio.file.FileAlreadyExistsException) {
+			false
+		} catch (_: Exception) {
+			false
+		}
+	}
+
+	/**
+	 * Reads the PID written into [lockPath]. Returns null when the file
+	 * is missing or unreadable.
+	 */
+	fun readLockOwnerPid(lockPath: Path): Long? {
+		return try {
+			val content = Files.readString(lockPath).trim()
+			if (content.isEmpty()) null else content.toLongOrNull()
+		} catch (_: Exception) {
+			null
+		}
+	}
+
+	/**
+	 * Removes [lockPath] only if its written PID matches the current process.
+	 */
+	fun releaseIfOwned(lockPath: Path, @Suppress("UNUSED_PARAMETER") label: String) {
+		val ownerPid = readLockOwnerPid(lockPath)
+		if (ownerPid != null && ownerPid != myPid) {
+			return
+		}
+		try {
+			Files.deleteIfExists(lockPath)
+		} catch (_: Exception) {
+			// Best-effort.
+		}
+	}
+
+	/**
+	 * Polls [tryAcquireOnce] up to [timeoutMs], sleeping [pollMs] between
+	 * attempts. Returns true on success, false on timeout.
+	 */
+	fun acquireWithPoll(lockPath: Path, timeoutMs: Long, pollMs: Long): Boolean {
+		if (timeoutMs <= 0) {
+			return tryAcquireOnce(lockPath)
+		}
+		val deadline = System.currentTimeMillis() + timeoutMs
+		while (true) {
+			if (tryAcquireOnce(lockPath)) return true
+			if (System.currentTimeMillis() >= deadline) return false
+			Thread.sleep(pollMs)
+		}
+	}
+
+	/**
+	 * Bumps [lockPath]'s mtime so the staleness check sees a fresh lock.
+	 * Skipped when the lock is owned by a different PID.
+	 */
+	fun refreshLockMtime(lockPath: Path) {
+		val ownerPid = readLockOwnerPid(lockPath)
+		if (ownerPid != null && ownerPid != myPid) return
+		try {
+			Files.setLastModifiedTime(lockPath, FileTime.from(Instant.now()))
+		} catch (_: Exception) {
+			// Best-effort.
+		}
+	}
+
+	/**
+	 * Returns true when [lockPath] exists and is younger than [LOCK_TIMEOUT_MS].
+	 */
+	fun isLockHeld(lockPath: Path): Boolean {
+		return try {
+			val mtime = Files.getLastModifiedTime(lockPath).toMillis()
+			System.currentTimeMillis() - mtime < LOCK_TIMEOUT_MS
+		} catch (_: Exception) {
+			false
+		}
+	}
+}

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/sync/OwnedPathKind.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/sync/OwnedPathKind.kt
@@ -1,0 +1,38 @@
+package ai.jolli.jollimemory.sync
+
+/**
+ * Tagged enum identifying which vault path family a relative path belongs to.
+ *
+ * Port of `cli/src/sync/OwnedPathKind.ts`.
+ *
+ * Drives sync's allowlist staging: [stageVault] filters `git status` output
+ * through [classifyVaultPath] and stages only entries whose kind is non-null.
+ */
+enum class OwnedPathKind {
+	// Root-level
+	ROOT_GITIGNORE,
+	ROOT_REPOS,
+
+	// Per-repo aggregates (under <repoFolder>/.jolli/)
+	REPO_CONFIG,
+	REPO_INDEX,
+	REPO_MANIFEST,
+	REPO_BRANCHES,
+	REPO_CATALOG,
+	REPO_MIGRATION,
+
+	// Per-repo content
+	SUMMARY,
+	TRANSCRIPT,
+	PLAN,
+	PLAN_PROGRESS,
+	NOTE,
+
+	// Per-repo visible markdown (under <repoFolder>/<branch>/)
+	VISIBLE_SUMMARY,
+	VISIBLE_PLAN,
+	VISIBLE_NOTE,
+
+	// Catch-all for safe paths that don't match a specific catalogue shape
+	USER_CONTENT,
+}

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/sync/PendingLockStore.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/sync/PendingLockStore.kt
@@ -1,0 +1,113 @@
+package ai.jolli.jollimemory.sync
+
+import com.google.gson.Gson
+import com.google.gson.JsonObject
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardCopyOption
+import javax.crypto.SecretKeyFactory
+import javax.crypto.spec.PBEKeySpec
+
+/**
+ * Persists the most recent `lockOwnerToken` returned by
+ * `POST /api/mb-sync/credentials` so the engine can decide, on a later
+ * 423 vault_locked, whether the lock is self-held vs peer-held.
+ *
+ * Port of `cli/src/sync/PendingLockStore.ts`.
+ *
+ * File location: `~/.jolli/jollimemory/pending-lock.json`
+ */
+
+data class ReadPendingLockResult(
+	val lockOwnerToken: String,
+	val mintedAt: Long,
+)
+
+object PendingLockStore {
+
+	private const val STATE_VERSION = 1
+	private const val KEY_HASH_SALT = "jolli:pending-lock:key-hash:v1"
+	private const val KEY_HASH_ITERATIONS = 210_000
+	private const val KEY_HASH_BYTES = 32
+
+	private val gson = Gson()
+
+	/** Per-process memoization of PBKDF2 hash. */
+	private var cachedKey: String? = null
+	private var cachedHash: String? = null
+
+	private fun getPath(): Path {
+		return Path.of(System.getProperty("user.home"), ".jolli", "jollimemory", "pending-lock.json")
+	}
+
+	private fun hashKey(jolliApiKey: String): String {
+		if (jolliApiKey == cachedKey && cachedHash != null) return cachedHash!!
+		val spec = PBEKeySpec(
+			jolliApiKey.toCharArray(),
+			KEY_HASH_SALT.toByteArray(),
+			KEY_HASH_ITERATIONS,
+			KEY_HASH_BYTES * 8,
+		)
+		val factory = SecretKeyFactory.getInstance("PBKDF2WithHmacSHA256")
+		val digest = factory.generateSecret(spec).encoded
+		val hex = digest.joinToString("") { "%02x".format(it) }.take(32)
+		cachedKey = jolliApiKey
+		cachedHash = hex
+		return hex
+	}
+
+	/**
+	 * Returns the persisted entry iff it matches the supplied [jolliApiKey].
+	 * Returns null for missing, corrupt, version mismatch, or wrong key.
+	 */
+	fun read(jolliApiKey: String): ReadPendingLockResult? {
+		val path = getPath()
+		val raw = try {
+			Files.readString(path)
+		} catch (_: Exception) {
+			return null
+		}
+
+		val parsed = try {
+			gson.fromJson(raw, JsonObject::class.java) ?: return null
+		} catch (_: Exception) {
+			return null
+		}
+
+		if (!parsed.has("version") || parsed.get("version").asInt != STATE_VERSION) return null
+		val keyHash = parsed.get("keyHash")?.asString ?: return null
+		val lockOwnerToken = parsed.get("lockOwnerToken")?.asString ?: return null
+		val mintedAt = parsed.get("mintedAt")?.asLong ?: return null
+
+		if (keyHash != hashKey(jolliApiKey)) return null
+		return ReadPendingLockResult(lockOwnerToken = lockOwnerToken, mintedAt = mintedAt)
+	}
+
+	/**
+	 * Atomic write (tmp+rename) of the pending lock entry.
+	 */
+	fun write(jolliApiKey: String, lockOwnerToken: String, mintedAtMs: Long = System.currentTimeMillis()) {
+		val path = getPath()
+		Files.createDirectories(path.parent)
+
+		val entry = JsonObject().apply {
+			addProperty("version", STATE_VERSION)
+			addProperty("keyHash", hashKey(jolliApiKey))
+			addProperty("lockOwnerToken", lockOwnerToken)
+			addProperty("mintedAt", mintedAtMs)
+		}
+
+		val tmp = path.resolveSibling("${path.fileName}.${ProcessHandle.current().pid()}.tmp")
+		Files.writeString(tmp, gson.toJson(entry))
+		Files.move(tmp, path, StandardCopyOption.REPLACE_EXISTING)
+	}
+
+	/** Removes the persisted entry. No-op when already absent. */
+	fun clear() {
+		try {
+			Files.deleteIfExists(getPath())
+		} catch (_: Exception) {
+			// Best-effort.
+		}
+	}
+}

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/sync/PorcelainParser.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/sync/PorcelainParser.kt
@@ -1,0 +1,100 @@
+package ai.jolli.jollimemory.sync
+
+/**
+ * Parses `git status --porcelain -z` output into structured per-entry records.
+ *
+ * Port of `cli/src/sync/PorcelainParser.ts`.
+ */
+
+/**
+ * Status codes from `git status --porcelain`. Maps each character to a
+ * semantic label; unknown characters fall through to [OTHER] so a future
+ * git version doesn't crash the sync round.
+ */
+enum class PorcelainStatus {
+	A, M, D, R, C,
+	UNTRACKED,    // '?'
+	IGNORED,      // '!'
+	UNMERGED,     // 'U'
+	TYPE_CHANGED, // 'T'
+	UNCHANGED,    // ' '
+	OTHER,
+}
+
+/**
+ * One entry from `git status --porcelain -z`.
+ *
+ * @property indexStatus   First status character — staged state vs HEAD.
+ * @property worktreeStatus Second status character — worktree state vs index.
+ * @property path          The file path (destination path for renames).
+ * @property oldPath       Source path for R/C entries; null otherwise.
+ */
+data class PorcelainEntry(
+	val indexStatus: PorcelainStatus,
+	val worktreeStatus: PorcelainStatus,
+	val path: String,
+	val oldPath: String? = null,
+)
+
+/**
+ * Parses raw stdout of `git status --porcelain -z` into structured entries.
+ *
+ * The `-z` flag uses NUL separators. Rename entries (`R  new\0old\0`)
+ * span two records: the first has the status + destination path, the
+ * second is a raw source path with no status prefix.
+ *
+ * Malformed records (length < 3) are silently dropped.
+ */
+fun parsePorcelainZ(stdout: String): List<PorcelainEntry> {
+	if (stdout.isEmpty()) return emptyList()
+
+	val records = stdout.split("\u0000").filter { it.isNotEmpty() }
+	val out = mutableListOf<PorcelainEntry>()
+	var renameSourcePending = false
+
+	for (rec in records) {
+		if (renameSourcePending) {
+			// This whole record is the source path of the most recently
+			// pushed rename/copy entry.
+			val last = out.lastOrNull()
+			if (last != null) {
+				out[out.lastIndex] = last.copy(oldPath = rec)
+			}
+			renameSourcePending = false
+			continue
+		}
+		if (rec.length < 3) continue
+		val indexStatus = coerceStatus(rec[0])
+		val worktreeStatus = coerceStatus(rec[1])
+		val path = rec.substring(3)
+		out.add(PorcelainEntry(indexStatus, worktreeStatus, path))
+		if (indexStatus == PorcelainStatus.R || indexStatus == PorcelainStatus.C ||
+			worktreeStatus == PorcelainStatus.R || worktreeStatus == PorcelainStatus.C
+		) {
+			renameSourcePending = true
+		}
+	}
+	return out
+}
+
+/**
+ * True when the entry represents a deletion from the working tree's
+ * perspective — `stageVault` should map it to `git rm` rather than `git add`.
+ */
+fun isDeletion(entry: PorcelainEntry): Boolean {
+	return entry.indexStatus == PorcelainStatus.D || entry.worktreeStatus == PorcelainStatus.D
+}
+
+private fun coerceStatus(ch: Char): PorcelainStatus = when (ch) {
+	'A' -> PorcelainStatus.A
+	'M' -> PorcelainStatus.M
+	'D' -> PorcelainStatus.D
+	'R' -> PorcelainStatus.R
+	'C' -> PorcelainStatus.C
+	'?' -> PorcelainStatus.UNTRACKED
+	'!' -> PorcelainStatus.IGNORED
+	'U' -> PorcelainStatus.UNMERGED
+	'T' -> PorcelainStatus.TYPE_CHANGED
+	' ' -> PorcelainStatus.UNCHANGED
+	else -> PorcelainStatus.OTHER
+}

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/sync/RepoMapping.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/sync/RepoMapping.kt
@@ -1,5 +1,6 @@
 package ai.jolli.jollimemory.sync
 
+import ai.jolli.jollimemory.core.KBPathResolver
 import com.google.gson.Gson
 import com.google.gson.JsonSyntaxException
 
@@ -48,6 +49,34 @@ fun parseRepoMapping(raw: String): RepoMappingFile? {
 	}
 }
 
+/** Scheme-prefixed remote (`https://…`, `ssh://…`, `git://…`, `file://…`). */
+private val URL_LIKE_RE = Regex("^[A-Za-z][A-Za-z0-9+.-]*://")
+
+/** SCP-style remote (`user@host:path`) — the only scheme-less URL form git accepts. */
+private val SCP_LIKE_RE = Regex("^[^@/:]+@[^/:]+:.+$")
+
+/**
+ * Re-normalizes an already-persisted `repoIdentity` so style-duplicates left
+ * behind by other clients (e.g. the SCP form `git@github.com:owner/repo`) fold
+ * into this client's https-style identity for the same repo.
+ *
+ * Normalization is GATED to identities that are recognizably remote URLs
+ * (scheme-prefixed or SCP-style). Bare fallback identities — folder/repo names
+ * from the no-remote path — never went through transport folding at compute
+ * time, so re-normalizing them would desync the stored row from the live value
+ * (a remote-less repo named `foo.git` would have its `.git` stripped and start
+ * re-adding a duplicate every round, or collapse with a distinct repo `foo`).
+ *
+ * Port of `cli/src/sync/RepoIdentity.ts canonicalizeRepoIdentity` — kept in
+ * lockstep so both IDEs collapse the same SSH/https duplicates.
+ */
+internal fun canonicalizeRepoIdentity(identity: String): String {
+	if (!URL_LIKE_RE.containsMatchIn(identity) && !SCP_LIKE_RE.matches(identity)) return identity
+	// Fold SSH/SCP/git transports to https first, then apply the shared
+	// host/path/.git normalization used everywhere else in the sync layer.
+	return normalizeGitUrl(KBPathResolver.foldGitTransportToHttps(identity.trim()))
+}
+
 /** Serializes to canonical 2-space-indented JSON + trailing newline. */
 fun serializeRepoMapping(mapping: RepoMappingFile): String {
 	val gson = com.google.gson.GsonBuilder().setPrettyPrinting().create()
@@ -59,15 +88,22 @@ fun serializeRepoMapping(mapping: RepoMappingFile): String {
  * resolved last-write-wins favouring remote). Folder collisions across
  * different identities are detected but not renamed — both keep their
  * original claim, and the conflict is reported for UI surfacing.
+ *
+ * Rows from both sides are run through [canonicalizeRepoIdentity] as they
+ * enter the union, so an SSH-style row pushed by an older client folds into
+ * this client's https-style row for the same repo instead of surviving the
+ * merge as a duplicate (split Memory Bank / duplicate repo entries).
  */
 fun mergeRepoMapping(
 	local: RepoMappingFile,
 	remote: RepoMappingFile,
 ): MergeRepoMappingResult {
-	// First pass: union by repoIdentity (remote overrides).
+	// First pass: union by canonical repoIdentity (last-write-wins; remote overrides).
 	val byIdentity = LinkedHashMap<String, RepoMappingEntry>()
-	for (m in local.mappings) byIdentity[m.repoIdentity] = m
-	for (m in remote.mappings) byIdentity[m.repoIdentity] = m
+	for (m in local.mappings + remote.mappings) {
+		val identity = canonicalizeRepoIdentity(m.repoIdentity)
+		byIdentity[identity] = if (identity == m.repoIdentity) m else m.copy(repoIdentity = identity)
+	}
 
 	// Second pass: detect folder collisions across different identities.
 	val byFolder = mutableMapOf<String, MutableList<RepoMappingEntry>>()

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/sync/RepoMapping.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/sync/RepoMapping.kt
@@ -1,0 +1,164 @@
+package ai.jolli.jollimemory.sync
+
+import com.google.gson.Gson
+import com.google.gson.JsonSyntaxException
+
+/**
+ * Vault-side `repoIdentity → folder` directory.
+ *
+ * Lives at `<memoryBankRoot>/.jolli/repos.json`. Merge logic for Tier 1.5
+ * conflict resolution and cross-device folder allocation.
+ *
+ * Port of `cli/src/sync/RepoMapping.ts`.
+ */
+
+/** Vault-relative path to the mapping file. */
+const val REPO_MAPPING_PATH = ".jolli/repos.json"
+
+/** A single `repoIdentity → folder` mapping row. */
+data class RepoMappingEntry(
+	val repoIdentity: String,
+	val folder: String,
+)
+
+/** Shape of `<memoryBankRoot>/.jolli/repos.json`. */
+data class RepoMappingFile(
+	val version: Int, // 1
+	val mappings: List<RepoMappingEntry>,
+)
+
+/** Folder claimed by 2+ different `repoIdentity` values after merge. */
+data class RepoMappingConflict(
+	val folder: String,
+	val identities: List<String>,
+)
+
+/** Parses an in-memory string into a [RepoMappingFile], or null on garbage. */
+fun parseRepoMapping(raw: String): RepoMappingFile? {
+	return try {
+		val doc = Gson().fromJson(raw, RepoMappingFile::class.java) ?: return null
+		if (doc.version != 1) return null
+		if (doc.mappings == null) return null
+		for (m in doc.mappings) {
+			if (m.repoIdentity == null || m.folder == null) return null
+		}
+		doc
+	} catch (_: JsonSyntaxException) {
+		null
+	}
+}
+
+/** Serializes to canonical 2-space-indented JSON + trailing newline. */
+fun serializeRepoMapping(mapping: RepoMappingFile): String {
+	val gson = com.google.gson.GsonBuilder().setPrettyPrinting().create()
+	return "${gson.toJson(mapping)}\n"
+}
+
+/**
+ * Tier 1.5 merge for `repos.json`. Dedupe by `repoIdentity` (union; ties
+ * resolved last-write-wins favouring remote). Folder collisions across
+ * different identities are detected but not renamed — both keep their
+ * original claim, and the conflict is reported for UI surfacing.
+ */
+fun mergeRepoMapping(
+	local: RepoMappingFile,
+	remote: RepoMappingFile,
+): MergeRepoMappingResult {
+	// First pass: union by repoIdentity (remote overrides).
+	val byIdentity = LinkedHashMap<String, RepoMappingEntry>()
+	for (m in local.mappings) byIdentity[m.repoIdentity] = m
+	for (m in remote.mappings) byIdentity[m.repoIdentity] = m
+
+	// Second pass: detect folder collisions across different identities.
+	val byFolder = mutableMapOf<String, MutableList<RepoMappingEntry>>()
+	for (m in byIdentity.values) {
+		byFolder.getOrPut(m.folder) { mutableListOf() }.add(m)
+	}
+	val conflicts = byFolder
+		.filter { it.value.size > 1 }
+		.map { (folder, entries) ->
+			RepoMappingConflict(
+				folder = folder,
+				identities = entries.map { it.repoIdentity }.sorted(),
+			)
+		}
+
+	// Stable output: sort by repoIdentity for byte-stable JSON across devices.
+	val merged = byIdentity.values.sortedBy { it.repoIdentity }
+	return MergeRepoMappingResult(
+		merged = RepoMappingFile(version = 1, mappings = merged),
+		conflicts = conflicts,
+	)
+}
+
+data class MergeRepoMappingResult(
+	val merged: RepoMappingFile,
+	val conflicts: List<RepoMappingConflict>,
+)
+
+/** Reads `<memoryBankRoot>/.jolli/repos.json`, returning an empty mapping on failure. */
+fun loadRepoMapping(memoryBankRoot: String): RepoMappingFile {
+	val path = java.nio.file.Path.of(memoryBankRoot, REPO_MAPPING_PATH)
+	val raw = try {
+		java.nio.file.Files.readString(path)
+	} catch (_: Exception) {
+		return emptyMapping()
+	}
+	return parseRepoMapping(raw) ?: emptyMapping()
+}
+
+/** Writes `<memoryBankRoot>/.jolli/repos.json`. Creates parent dir if needed. */
+fun saveRepoMapping(memoryBankRoot: String, mapping: RepoMappingFile) {
+	val path = java.nio.file.Path.of(memoryBankRoot, REPO_MAPPING_PATH)
+	java.nio.file.Files.createDirectories(path.parent)
+	java.nio.file.Files.writeString(path, serializeRepoMapping(mapping))
+}
+
+/** Scans for folder collisions (2+ identities claiming the same folder). */
+fun findRepoMappingConflicts(mapping: RepoMappingFile): List<RepoMappingConflict> {
+	val byFolder = mutableMapOf<String, MutableList<RepoMappingEntry>>()
+	for (m in mapping.mappings) {
+		byFolder.getOrPut(m.folder) { mutableListOf() }.add(m)
+	}
+	return byFolder
+		.filter { it.value.size > 1 }
+		.map { (folder, entries) ->
+			RepoMappingConflict(folder, entries.map { it.repoIdentity }.sorted())
+		}
+}
+
+/**
+ * Looks up or assigns the vault folder for the given repo identity.
+ * Returns the effective folder and an updated mapping (if changed), or null mapping if no change.
+ */
+fun resolveOrAssignFolder(
+	mapping: RepoMappingFile,
+	repoIdentity: String,
+	authoritativeFolder: String,
+): ResolveOrAssignResult {
+	val existing = mapping.mappings.find { it.repoIdentity == repoIdentity }
+	if (existing != null) {
+		if (existing.folder == authoritativeFolder) {
+			return ResolveOrAssignResult(existing.folder, null)
+		}
+		val updated = RepoMappingFile(
+			version = 1,
+			mappings = mapping.mappings.map {
+				if (it.repoIdentity == repoIdentity) it.copy(folder = authoritativeFolder) else it
+			},
+		)
+		return ResolveOrAssignResult(authoritativeFolder, updated)
+	}
+	val updated = RepoMappingFile(
+		version = 1,
+		mappings = mapping.mappings + RepoMappingEntry(repoIdentity, authoritativeFolder),
+	)
+	return ResolveOrAssignResult(authoritativeFolder, updated)
+}
+
+data class ResolveOrAssignResult(
+	val folder: String,
+	val updatedMapping: RepoMappingFile?,
+)
+
+private fun emptyMapping() = RepoMappingFile(version = 1, mappings = emptyList())

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/sync/StageVault.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/sync/StageVault.kt
@@ -1,0 +1,160 @@
+package ai.jolli.jollimemory.sync
+
+import java.io.File
+import java.nio.file.Files
+import java.nio.file.LinkOption
+import java.nio.file.Path
+
+/**
+ * Allowlist-staging entry point — replaces `git add --all` for vault staging.
+ *
+ * Port of `cli/src/sync/StageVault.ts`.
+ *
+ * Flow:
+ *   1. Snapshot `git status --porcelain -z` via [SyncGitClient.statusPorcelainZ].
+ *   2. Decompose renames into discrete `(add new, del old)` operations.
+ *   3. Classify each path via [classifyVaultPath].
+ *   4. Symlink-check adds via [assertNoSymlinksInPath] + leaf lstat.
+ *   5. Stage survivors via `git add -f` / `git rm` / `git reset HEAD --`.
+ */
+
+data class StageReport(
+	val added: Int,
+	val removed: Int,
+	val skipped: Int,
+	val unowned: List<String>,
+	val symlinked: List<String>,
+	val byKind: Map<String, Int>,
+)
+
+data class StageVaultOpts(val syncTranscripts: Boolean)
+
+/**
+ * Per-op intermediate used by the staging loop.
+ */
+private data class Op(
+	val kind: String, // "add" or "del"
+	val path: String,
+	val staged: Boolean,
+)
+
+/**
+ * Stages the vault's owned-path changes via `git add -f` / `git rm`.
+ */
+fun stageVault(client: SyncGitClient, vaultRoot: String, opts: StageVaultOpts): StageReport {
+	val entries = client.statusPorcelainZ()
+	val ops = decomposeOps(entries)
+
+	val byKind = mutableMapOf<String, Int>()
+	val toAdd = mutableListOf<String>()
+	val toRm = mutableListOf<String>()
+	val toReset = mutableListOf<String>()
+	val unowned = mutableListOf<String>()
+	val symlinked = mutableListOf<String>()
+	var skipped = 0
+
+	for (op in ops) {
+		val kind = classifyVaultPath(op.path)
+		if (kind == null) {
+			unowned.add(op.path)
+			bump(byKind, "unowned")
+			if (op.staged) toReset.add(op.path)
+			continue
+		}
+		if (kind == OwnedPathKind.TRANSCRIPT && !opts.syncTranscripts) {
+			skipped++
+			bump(byKind, "skipped")
+			if (op.staged) toReset.add(op.path)
+			continue
+		}
+		if (op.kind == "del") {
+			toRm.add(op.path)
+			bump(byKind, kind.name)
+			continue
+		}
+		// Add path — verify symlink safety.
+		val absPath = Path.of(vaultRoot, op.path).toString()
+		val isOk = isSymlinkSafeForStaging(vaultRoot, absPath)
+		if (!isOk) {
+			symlinked.add(op.path)
+			bump(byKind, "symlink-blocked")
+			if (op.staged) toReset.add(op.path)
+			continue
+		}
+		toAdd.add(op.path)
+		bump(byKind, kind.name)
+	}
+
+	if (toAdd.isNotEmpty()) client.stageAddPaths(toAdd)
+	if (toRm.isNotEmpty()) client.stageRemovePaths(toRm)
+	if (toReset.isNotEmpty()) client.resetPathsToHead(toReset)
+
+	return StageReport(
+		added = toAdd.size,
+		removed = toRm.size,
+		skipped = skipped,
+		unowned = unowned,
+		symlinked = symlinked,
+		byKind = byKind,
+	)
+}
+
+/**
+ * Flattens [PorcelainEntry] list into per-op stream. Renames become
+ * del(old) + add(new); copies become add(new) only.
+ */
+private fun decomposeOps(entries: List<PorcelainEntry>): List<Op> {
+	val ops = mutableListOf<Op>()
+	for (e in entries) {
+		// Skip unmerged entries.
+		if (e.indexStatus == PorcelainStatus.UNMERGED || e.worktreeStatus == PorcelainStatus.UNMERGED) {
+			continue
+		}
+		val staged = e.indexStatus == PorcelainStatus.A ||
+			e.indexStatus == PorcelainStatus.M ||
+			e.indexStatus == PorcelainStatus.D ||
+			e.indexStatus == PorcelainStatus.R ||
+			e.indexStatus == PorcelainStatus.C
+
+		if (e.oldPath != null) {
+			val isRename = e.indexStatus == PorcelainStatus.R || e.worktreeStatus == PorcelainStatus.R
+			if (isRename) {
+				ops.add(Op(kind = "del", path = e.oldPath, staged = true))
+			}
+			ops.add(Op(kind = "add", path = e.path, staged = staged))
+			continue
+		}
+		if (isDeletion(e)) {
+			ops.add(Op(kind = "del", path = e.path, staged = staged))
+			continue
+		}
+		ops.add(Op(kind = "add", path = e.path, staged = staged))
+	}
+	return ops
+}
+
+/**
+ * Returns true if the path is safe to stage from a symlink standpoint.
+ */
+private fun isSymlinkSafeForStaging(vaultRoot: String, absPath: String): Boolean {
+	return try {
+		// Leaf check.
+		val attrs = Files.readAttributes(
+			Path.of(absPath),
+			java.nio.file.attribute.BasicFileAttributes::class.java,
+			LinkOption.NOFOLLOW_LINKS,
+		)
+		if (attrs.isSymbolicLink) return false
+		// Path-chain check.
+		assertNoSymlinksInPath(vaultRoot, absPath)
+		true
+	} catch (_: java.nio.file.NoSuchFileException) {
+		false
+	} catch (_: Exception) {
+		false
+	}
+}
+
+private fun bump(map: MutableMap<String, Int>, key: String) {
+	map[key] = (map[key] ?: 0) + 1
+}

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/sync/SyncActivation.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/sync/SyncActivation.kt
@@ -1,0 +1,73 @@
+package ai.jolli.jollimemory.sync
+
+import ai.jolli.jollimemory.core.JmLogger
+import ai.jolli.jollimemory.core.SessionTracker
+import ai.jolli.jollimemory.services.JolliAuthService
+import ai.jolli.jollimemory.services.JolliMemoryService
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.project.Project
+
+/**
+ * IntelliJ-specific glue that constructs a [SyncEngine] on sign-in
+ * and tears it down on sign-out.
+ *
+ * Port of `vscode/src/sync/VsCodeSyncBootstrap.ts:activateSync()`.
+ */
+object SyncActivation {
+
+	private val log = JmLogger.create("SyncActivation")
+
+	/**
+	 * Registers an auth listener that calls [reconcileSync] on sign-in/sign-out,
+	 * and runs an initial reconcile for the "already signed in at startup" case.
+	 *
+	 * Returns a [Disposable] that removes the auth listener.
+	 */
+	fun activateSync(project: Project, service: JolliMemoryService): Disposable {
+		log.info("activateSync: registering auth listener for project=${project.name}")
+		val disposable = JolliAuthService.addAuthListener {
+			log.info("activateSync: auth state changed, reconciling")
+			reconcileSync(project, service)
+		}
+		// Initial reconcile for "already signed in" case.
+		log.info("activateSync: running initial reconcile")
+		reconcileSync(project, service)
+		return disposable
+	}
+
+	/**
+	 * Checks config and either starts or stops sync accordingly.
+	 *
+	 * - No API key → stop sync (sign-out path)
+	 * - Engine built → start sync (engine is always built so manual sync works)
+	 * - `autoSyncEnabled == false` → stop polling (but engine remains for manual sync)
+	 */
+	internal fun reconcileSync(project: Project, service: JolliMemoryService) {
+		val cwd = service.mainRepoRoot ?: project.basePath ?: return
+
+		val config = SessionTracker.loadConfig(cwd)
+		if (config.jolliApiKey.isNullOrBlank()) {
+			log.info("reconcileSync: no jolliApiKey — stopping sync")
+			service.stopSync()
+			return
+		}
+
+		val engine = buildSyncEngine(cwd)
+		if (engine == null) {
+			log.info("reconcileSync: engine could not be built — stopping sync")
+			service.stopSync()
+			return
+		}
+
+		val autoSyncEnabled = config.autoSyncEnabled ?: true
+		val pollIntervalSec = config.syncPollIntervalSec
+		log.info("reconcileSync: engine built, autoSync=$autoSyncEnabled pollInterval=$pollIntervalSec")
+
+		service.startSync(engine, cwd, pollIntervalSec)
+
+		if (!autoSyncEnabled) {
+			log.info("reconcileSync: autoSyncEnabled=false — stopping polling (manual sync still available)")
+			service.stopSync()
+		}
+	}
+}

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/sync/SyncBackendClient.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/sync/SyncBackendClient.kt
@@ -1,0 +1,401 @@
+package ai.jolli.jollimemory.sync
+
+import ai.jolli.jollimemory.core.JmLogger
+import ai.jolli.jollimemory.core.SessionTracker
+import ai.jolli.jollimemory.services.JolliApiClient
+import com.google.gson.Gson
+import java.io.IOException
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import java.net.http.HttpTimeoutException
+import java.time.Duration
+
+/**
+ * HTTP client for the Memory Bank sync backend endpoints.
+ *
+ * Five endpoints under `/api/mb-sync/`:
+ *
+ *   - `POST /credentials` — mint a short-lived GitHub Installation Token and
+ *     acquire the personal-space write-lock.
+ *   - `POST /notify-push` — fire-and-forget "I just pushed" notification;
+ *     releases the write-lock on the success path.
+ *   - `POST /release-lock` — explicit write-lock release on failure paths.
+ *   - `GET /legacy-content` — dump legacy DB docs for first-bind migration.
+ *   - `POST /complete-migration` — flip backing from DB to git.
+ *
+ * All calls authenticate with `Authorization: Bearer <jolliApiKey>` and route
+ * via the tenant URL encoded in the API key (same pattern as [JolliApiClient]).
+ *
+ * Constructor parameters are test seams — production callers use the defaults.
+ */
+class SyncBackendClient(
+	private val httpClient: HttpClient = HttpClient.newBuilder()
+		.connectTimeout(Duration.ofSeconds(10))
+		.build(),
+	private val baseUrlOverride: String? = null,
+	private val jolliApiKeyProvider: () -> String? = ::defaultJolliApiKeyProvider,
+	private val timeoutMs: Long = DEFAULT_TIMEOUT_MS,
+) {
+
+	private val log = JmLogger.create("SyncBackendClient")
+	private val gson = Gson()
+
+	/**
+	 * Mints a fresh GitHub Installation Token and reports the personal space's
+	 * current backing. On the user's first call, the backend provisions the
+	 * GitHub repo transparently. Returns [GitCredentials] with the short-lived
+	 * token, vault repo info, and a [GitCredentials.lockOwnerToken] for the
+	 * per-space write-lock.
+	 */
+	fun mintGitCredentials(): GitCredentials {
+		val body = request<Map<String, Any?>>("POST", "/api/mb-sync/credentials", emptyMap<String, Any>())
+
+		val missing = missingMintFields(body)
+		if (missing.isNotEmpty()) {
+			throw SyncBackendError(
+				502,
+				"Sync backend returned an incomplete mint response (missing ${missing.joinToString(", ")})",
+				gson.toJson(body),
+			)
+		}
+
+		val cloneUrl = body["repoCloneUrl"] as String
+		val parsedCloneUrl = try {
+			URI.create(cloneUrl)
+		} catch (_: Exception) {
+			throw SyncBackendError(
+				502,
+				"Sync backend returned an unparseable repoCloneUrl: $cloneUrl",
+				gson.toJson(body),
+			)
+		}
+		if (parsedCloneUrl.scheme != "https") {
+			throw SyncBackendError(
+				502,
+				"Sync backend returned a non-https repoCloneUrl (${parsedCloneUrl.scheme}://…); refusing to attach bearer token over cleartext",
+				gson.toJson(body),
+			)
+		}
+
+		val expiresAtRaw = body["expiresAt"]
+		val expiresAt: Long = when (expiresAtRaw) {
+			is Number -> expiresAtRaw.toLong()
+			is String -> {
+				val parsed = try {
+					java.time.Instant.parse(expiresAtRaw).toEpochMilli()
+				} catch (_: Exception) {
+					throw SyncBackendError(
+						502,
+						"Sync backend returned an invalid expiresAt: $expiresAtRaw",
+						gson.toJson(body),
+					)
+				}
+				parsed
+			}
+			else -> throw SyncBackendError(
+				502,
+				"Sync backend returned an invalid expiresAt: $expiresAtRaw",
+				gson.toJson(body),
+			)
+		}
+
+		return GitCredentials(
+			gitUrl = cloneUrl,
+			token = body["token"] as String,
+			expiresAt = expiresAt,
+			repoFullName = body["repoFullName"] as String,
+			defaultBranch = body["defaultBranch"] as String,
+			githubRepoCreated = body["githubRepoCreated"] as? Boolean ?: false,
+			alreadyVaultBound = body["alreadyVaultBound"] as Boolean,
+			lockOwnerToken = body["lockOwnerToken"] as String,
+		)
+	}
+
+	/**
+	 * Fire-and-forget notification that [commitSha] was just pushed on [branch].
+	 * Releases the personal-space write-lock on the success path.
+	 * Callers should swallow errors — the webhook + reconciler cover lost messages.
+	 */
+	fun notifyPush(commitSha: String, branch: String, lockOwnerToken: String) {
+		request<Any>("POST", "/api/mb-sync/notify-push", mapOf(
+			"commitSha" to commitSha,
+			"branch" to branch,
+			"lockOwnerToken" to lockOwnerToken,
+		))
+	}
+
+	/**
+	 * Explicit write-lock release for failure paths. Called from the round's
+	 * finally block when neither [notifyPush] nor [completeMigration] ran.
+	 * Callers MUST swallow errors — the backend's TTL is the backstop.
+	 */
+	fun releaseLock(lockOwnerToken: String) {
+		request<Any>("POST", "/api/mb-sync/release-lock", mapOf(
+			"lockOwnerToken" to lockOwnerToken,
+		))
+	}
+
+	/**
+	 * Fetches legacy `backing_type=db` content for first-bind migration.
+	 * Idempotent: once the space is git-backed, returns
+	 * `alreadyMigrated = true` with an empty `docs` list.
+	 */
+	fun getLegacyContent(): LegacyContentResponse {
+		val body = request<Map<String, Any?>>("GET", "/api/mb-sync/legacy-content", null)
+
+		@Suppress("UNCHECKED_CAST")
+		val rawDocs = body["docs"] as? List<Map<String, Any?>> ?: emptyList()
+		val docs = rawDocs.map { d ->
+			LegacyDoc(
+				id = (d["id"] as Number).toInt(),
+				jrn = d["jrn"] as String,
+				slug = d["slug"] as String,
+				path = d["path"] as String,
+				docType = d["docType"] as String,
+				parentId = (d["parentId"] as? Number)?.toInt(),
+				content = d["content"] as String,
+				contentType = d["contentType"] as String,
+				sortOrder = (d["sortOrder"] as Number).toInt(),
+				createdAt = d["createdAt"] as String,
+				updatedAt = d["updatedAt"] as String,
+			)
+		}
+
+		return LegacyContentResponse(
+			spaceId = (body["spaceId"] as Number).toInt(),
+			spaceSlug = body["spaceSlug"] as String,
+			alreadyMigrated = body["alreadyMigrated"] as Boolean,
+			docs = docs,
+		)
+	}
+
+	/**
+	 * Tells the backend that first-bind migration is complete: flip the space
+	 * from `backing_type=db` to git. Releases the write-lock. Idempotent.
+	 */
+	fun completeMigration(commitSha: String, lockOwnerToken: String): CompleteMigrationResult {
+		val body = request<Map<String, Any?>>("POST", "/api/mb-sync/complete-migration", mapOf(
+			"commitSha" to commitSha,
+			"lockOwnerToken" to lockOwnerToken,
+		))
+		return CompleteMigrationResult(
+			alreadyMigrated = body["alreadyMigrated"] as? Boolean ?: false,
+		)
+	}
+
+	/**
+	 * Exposes the currently-resolved `jolliApiKey` so the engine can scope
+	 * `pending-lock.json` entries by a hash of the key. Returns `null` when
+	 * the user is signed out.
+	 */
+	fun getJolliApiKey(): String? = jolliApiKeyProvider()
+
+	// ── Internal HTTP plumbing ──────────────────────────────────────────
+
+	private inline fun <reified T> request(method: String, path: String, payload: Any?): T {
+		val apiKey = jolliApiKeyProvider()
+		if (apiKey.isNullOrBlank()) {
+			throw SyncBackendUnauthorizedError("""{"error":"no_jolli_api_key"}""")
+		}
+		val keyMeta = JolliApiClient.parseJolliApiKey(apiKey)
+		if (keyMeta == null) {
+			throw SyncBackendUnauthorizedError("""{"error":"invalid_jolli_api_key"}""")
+		}
+
+		val baseUrl = baseUrlOverride ?: keyMeta.u
+		val parsed = parseBaseUrl(baseUrl)
+		val url = URI.create("${parsed.origin}$path")
+		log.info("request: %s %s", method, url)
+
+		val requestBuilder = HttpRequest.newBuilder()
+			.uri(url)
+			.header("Authorization", "Bearer $apiKey")
+			.header("x-jolli-client", "intellij-plugin/${JolliApiClient.pluginVersion}")
+			.timeout(Duration.ofMillis(timeoutMs))
+
+		if (parsed.tenantSlug != null) {
+			requestBuilder.header("x-tenant-slug", parsed.tenantSlug)
+		}
+		if (keyMeta.o != null) {
+			requestBuilder.header("x-org-slug", keyMeta.o)
+		}
+
+		when (method) {
+			"GET" -> requestBuilder.GET()
+			"POST" -> {
+				requestBuilder.header("Content-Type", "application/json")
+				requestBuilder.POST(HttpRequest.BodyPublishers.ofString(gson.toJson(payload ?: emptyMap<String, Any>())))
+			}
+		}
+
+		val response: HttpResponse<String>
+		try {
+			response = httpClient.send(requestBuilder.build(), HttpResponse.BodyHandlers.ofString())
+		} catch (e: HttpTimeoutException) {
+			throw SyncBackendNetworkError(e)
+		} catch (e: IOException) {
+			throw SyncBackendNetworkError(e)
+		}
+
+		val text = response.body() ?: ""
+		val statusCode = response.statusCode()
+
+		if (statusCode == 401 || statusCode == 403) {
+			throw SyncBackendUnauthorizedError(text)
+		}
+		if (statusCode == 423) {
+			throw VaultLockedError(text)
+		}
+		if (statusCode == 503) {
+			val pendingFlush = tryParsePendingFlush(text)
+			if (pendingFlush != null) {
+				throw WebFlushPendingError(text, pendingFlush.retryAfterSeconds)
+			}
+		}
+		if (statusCode !in 200..299) {
+			throw SyncBackendError(statusCode, "Sync backend returned $statusCode", text)
+		}
+		if (text.isEmpty()) {
+			@Suppress("UNCHECKED_CAST")
+			return emptyMap<String, Any?>() as T
+		}
+		return try {
+			@Suppress("UNCHECKED_CAST")
+			gson.fromJson(text, Map::class.java) as T
+		} catch (_: Exception) {
+			throw SyncBackendError(502, "Sync backend returned non-JSON 2xx body", text.take(1024))
+		}
+	}
+
+	private data class ParsedBaseUrl(val origin: String, val tenantSlug: String?)
+
+	private fun parseBaseUrl(baseUrl: String): ParsedBaseUrl {
+		val uri = URI.create(baseUrl)
+		val pathSegments = (uri.path ?: "")
+			.trim('/')
+			.split("/")
+			.filter { it.isNotEmpty() }
+		val origin = "${uri.scheme}://${uri.authority}"
+		val tenantSlug = pathSegments.firstOrNull()
+		return ParsedBaseUrl(origin = origin, tenantSlug = tenantSlug)
+	}
+
+	private fun missingMintFields(body: Map<String, Any?>): List<String> {
+		val missing = mutableListOf<String>()
+		if (body["token"] == null) missing.add("token")
+		if (body["expiresAt"] == null) missing.add("expiresAt")
+		if (body["repoCloneUrl"] == null) missing.add("repoCloneUrl")
+		if (body["repoFullName"] == null) missing.add("repoFullName")
+		if (body["defaultBranch"] == null) missing.add("defaultBranch")
+		if (body["alreadyVaultBound"] !is Boolean) missing.add("alreadyVaultBound")
+		if (body["lockOwnerToken"] == null) missing.add("lockOwnerToken")
+		return missing
+	}
+
+	private data class PendingFlushInfo(val retryAfterSeconds: Int)
+
+	private fun tryParsePendingFlush(text: String): PendingFlushInfo? {
+		return try {
+			@Suppress("UNCHECKED_CAST")
+			val body = gson.fromJson(text, Map::class.java) as? Map<String, Any?> ?: return null
+			if (body["error"] != "pending_flush_failed") return null
+			val raw = body["retryAfterSeconds"]
+			val retryAfterSeconds = when (raw) {
+				is Number -> if (raw.toInt() > 0) raw.toInt() else 30
+				else -> 30
+			}
+			PendingFlushInfo(retryAfterSeconds)
+		} catch (_: Exception) {
+			null
+		}
+	}
+
+	companion object {
+		private const val DEFAULT_TIMEOUT_MS = 10_000L
+	}
+}
+
+// ── Error hierarchy ─────────────────────────────────────────────────────
+
+/** Generic non-2xx response from the sync backend. */
+open class SyncBackendError(
+	val status: Int,
+	message: String,
+	val body: String,
+) : RuntimeException(message)
+
+/** 401/403 — auth token rejected. Engine maps this to re-mint + retry. */
+class SyncBackendUnauthorizedError(body: String) : SyncBackendError(
+	401, "Sync backend rejected the auth token (401)", body,
+)
+
+/** 423 — vault write-lock held by another device. Engine retries with backoff. */
+class VaultLockedError(body: String) : SyncBackendError(
+	423, "Personal Space is being synced by another device", body,
+)
+
+/**
+ * 503 with `pending_flush_failed` — backend's web-side flusher hasn't pushed
+ * pending edits to GitHub yet. Engine retries after [retryAfterSeconds].
+ */
+class WebFlushPendingError(body: String, val retryAfterSeconds: Int) : SyncBackendError(
+	503, "Waiting for web edits to upload to GitHub", body,
+)
+
+/** Network-layer failure (DNS, refused, timeout). Transient — next round may succeed. */
+class SyncBackendNetworkError(override val cause: Throwable?) : RuntimeException(
+	"Sync backend unreachable", cause,
+)
+
+// ── Data classes ────────────────────────────────────────────────────────
+
+/** Short-lived GitHub Installation Token + vault info from `POST /credentials`. */
+data class GitCredentials(
+	val gitUrl: String,
+	val token: String,
+	/** Epoch milliseconds (UTC). */
+	val expiresAt: Long,
+	val repoFullName: String,
+	val defaultBranch: String,
+	val githubRepoCreated: Boolean,
+	val alreadyVaultBound: Boolean,
+	/** Per-space write-lock owner token. Echo back to notify-push / release-lock. */
+	val lockOwnerToken: String,
+)
+
+/** A single doc from `GET /legacy-content`. */
+data class LegacyDoc(
+	val id: Int,
+	val jrn: String,
+	val slug: String,
+	val path: String,
+	val docType: String,
+	val parentId: Int?,
+	val content: String,
+	val contentType: String,
+	val sortOrder: Int,
+	val createdAt: String,
+	val updatedAt: String,
+)
+
+/** Response from `GET /legacy-content`. */
+data class LegacyContentResponse(
+	val spaceId: Int,
+	val spaceSlug: String,
+	val alreadyMigrated: Boolean,
+	val docs: List<LegacyDoc>,
+)
+
+/** Response from `POST /complete-migration`. */
+data class CompleteMigrationResult(
+	val alreadyMigrated: Boolean,
+)
+
+// ── Default provider ────────────────────────────────────────────────────
+
+private fun defaultJolliApiKeyProvider(): String? {
+	val config = SessionTracker.loadConfigFromDir(SessionTracker.getGlobalConfigDir())
+	return config.jolliApiKey?.takeIf { it.isNotBlank() }
+}

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/sync/SyncBootstrap.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/sync/SyncBootstrap.kt
@@ -1,0 +1,109 @@
+package ai.jolli.jollimemory.sync
+
+import ai.jolli.jollimemory.core.JmLogger
+import ai.jolli.jollimemory.core.KBPathResolver
+import ai.jolli.jollimemory.core.SessionTracker
+
+/**
+ * DI helper that assembles a fully-wired [SyncEngine] from the user's
+ * config + cwd, or returns `null` when sync is dormant (no auth token).
+ *
+ * Port of `cli/src/sync/SyncBootstrap.ts`.
+ */
+
+private val log = JmLogger.create("SyncBootstrap")
+
+/**
+ * Returns a configured [SyncEngine] or `null` when prerequisites are missing.
+ */
+fun buildSyncEngine(cwd: String): SyncEngine? {
+	val config = SessionTracker.loadConfig(cwd)
+	if (config.jolliApiKey.isNullOrBlank()) {
+		log.debug("jolliApiKey missing — engine dormant (user must sign in)")
+		return null
+	}
+
+	log.info("buildSyncEngine: API key present, building engine for cwd=$cwd")
+
+	val backend = SyncBackendClient(
+		baseUrlOverride = System.getProperty("jolli.sync.baseUrl"),
+		jolliApiKeyProvider = { SessionTracker.loadConfig(cwd).jolliApiKey },
+	)
+
+	// Re-read config per round so localFolder/syncTranscripts changes
+	// take effect without restart.
+	val resolveContext: (SyncRoundOptions) -> RoundContext = { round ->
+		val fresh = SessionTracker.loadConfig(cwd)
+		defaultResolveContext(round, fresh.localFolder)
+	}
+
+	val makeGitClient = GitClientFactory { creds, memoryBankRoot ->
+		SyncGitClient(
+			vaultRoot = memoryBankRoot,
+			credentials = creds,
+		)
+	}
+
+	log.info("buildSyncEngine: engine assembled successfully")
+	return SyncEngine(SyncEngineOpts(
+		backend = backend,
+		resolveContext = resolveContext,
+		makeGitClient = makeGitClient,
+	))
+}
+
+/**
+ * Default context resolver. `memoryBankRoot` is the parent folder
+ * (e.g. `~/Documents/jolli/`); `repoFolderName` is the specific repo
+ * subdirectory basename.
+ */
+internal fun defaultResolveContext(
+	round: SyncRoundOptions,
+	localFolder: String?,
+): RoundContext {
+	val repoName = KBPathResolver.extractRepoName(round.cwd)
+	val remoteUrl = KBPathResolver.getRemoteUrl(round.cwd)
+	val repoPath = KBPathResolver.resolve(repoName, remoteUrl, localFolder)
+	val memoryBankRoot = repoPath.parent.toString()
+	val repoFolderName = repoPath.fileName.toString()
+	val identity = computeRepoIdentity(round.cwd)
+	log.debug("resolveContext: repo=$repoName folder=$repoFolderName root=$memoryBankRoot identity=$identity")
+	return RoundContext(
+		memoryBankRoot = memoryBankRoot,
+		repoFolderName = repoFolderName,
+		repoIdentity = identity,
+		author = CommitAuthor(name = "Jolli Memory", email = "memory@jolli.ai"),
+	)
+}
+
+/**
+ * Computes a stable repo identity from the working tree path.
+ * Uses normalized git remote URL, or directory basename as fallback.
+ *
+ * Port of `cli/src/sync/RepoIdentity.ts:computeRepoIdentity`.
+ */
+fun computeRepoIdentity(projectPath: String): String {
+	val remote = KBPathResolver.getRemoteUrl(projectPath)
+	return if (remote != null) normalizeGitUrl(remote) else java.io.File(projectPath).name
+}
+
+
+/**
+ * Default vault subdirectory name — slug derived from repo name.
+ *
+ * Port of `cli/src/sync/RepoIdentity.ts:computeRepoFolderName`.
+ */
+fun defaultRepoFolderName(cwd: String): String {
+	val name = KBPathResolver.extractRepoName(cwd)
+	return slugify(name)
+}
+
+internal fun slugify(name: String): String {
+	val cleaned = java.text.Normalizer.normalize(name, java.text.Normalizer.Form.NFKD)
+		.lowercase()
+		.replace(Regex("[\\u0300-\\u036f]"), "")
+		.replace(Regex("[^a-z0-9-]+"), "-")
+		.replace(Regex("-+"), "-")
+		.replace(Regex("^-|-$"), "")
+	return cleaned.ifEmpty { "repo" }
+}

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/sync/SyncEngine.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/sync/SyncEngine.kt
@@ -1,0 +1,849 @@
+package ai.jolli.jollimemory.sync
+
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.concurrent.Executors
+import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.TimeUnit
+
+/** Factory: builds a [SyncGitClient] for the given credentials + vault root. */
+fun interface GitClientFactory {
+	fun create(creds: GitCredentials, memoryBankRoot: String): SyncGitClient
+}
+
+/** Engine configuration and dependency bundle. */
+data class SyncEngineOpts(
+	val backend: SyncBackendClient,
+	val resolveContext: (SyncRoundOptions) -> RoundContext,
+	val makeGitClient: GitClientFactory,
+	val onStateChange: ((SyncState, SyncRoundResult) -> Unit)? = null,
+	val onLockedWait: ((VaultLockedWaitInfo) -> Unit)? = null,
+	val onPhase: ((SyncPhase) -> Unit)? = null,
+	val onRoundComplete: ((String) -> Unit)? = null,
+	val lockTimeoutMs: Long = 10_000L,
+	val refreshIntervalMs: Long = 60_000L,
+	val maxPushAttempts: Int = 3,
+	val vaultLockedRetrySchedule: List<Long> = listOf(60_000L, 120_000L, 180_000L),
+	val sleepFn: (Long) -> Unit = { Thread.sleep(it) },
+	val conflictPolicy: ConflictPolicy = ConflictPolicy.MINE,
+	val aiProvider: (() -> AiMergeProvider?)? = null,
+	val conflictUi: ConflictUi? = null,
+	val makeResolver: ((SyncGitClient, CommitAuthor?) -> ConflictResolver)? = null,
+)
+
+/**
+ * Core sync-round pipeline.
+ *
+ * Port of `cli/src/sync/SyncEngine.ts` — steady-state path.
+ * First-bind migration and conflict resolution are stubbed for Phase 5.
+ */
+open class SyncEngine(private val opts: SyncEngineOpts) {
+
+	companion object {
+		private const val MAX_REMINTS_PER_PHASE = 1
+		private const val SELF_LOCK_TTL_GRACE_MS = 9 * 60_000L
+		private const val STALE_LOCK_TTL_MS = 300_000L
+		private val log = ai.jolli.jollimemory.core.JmLogger.create("SyncEngine")
+	}
+
+	// ── Public entry point ──────────────────────────────────────────
+
+	open fun runRound(round: SyncRoundOptions): SyncRoundResult {
+		log.info("runRound start reason=${round.reason} cwd=${round.cwd}")
+		if (!SyncLock.acquire(SyncLockOpts(timeoutMs = opts.lockTimeoutMs))) {
+			log.info("runRound skipped — another round already in progress (lock contention)")
+			return report(SyncState.SYNCING, SyncRoundResult(
+				fetched = false, pulled = false, pushed = false,
+				newState = SyncState.SYNCING,
+			))
+		}
+
+		var refresher: ScheduledExecutorService? = null
+		val lockHolder = RoundLockHolder()
+
+		try {
+			refresher = Executors.newSingleThreadScheduledExecutor { r ->
+				Thread(r, "sync-lock-refresh").apply { isDaemon = true }
+			}
+			refresher.scheduleAtFixedRate(
+				{ SyncLock.refreshMtime() },
+				opts.refreshIntervalMs, opts.refreshIntervalMs, TimeUnit.MILLISECONDS,
+			)
+
+			val ctx = opts.resolveContext(round)
+			return doRound(round, ctx, lockHolder)
+		} catch (e: Exception) {
+			log.warn("runRound threw — going offline: ${e.message} ${e.stackTraceToString()}")
+			return reportOffline(
+				fetched = false, pulled = false, pushed = false,
+				code = SyncErrorCode.SYNC_FAILED_AFTER_RETRIES,
+				message = e.message ?: "unexpected error",
+			)
+		} finally {
+			refresher?.shutdownNow()
+			releaseLockHolderIfNeeded(lockHolder)
+			try { opts.onRoundComplete?.invoke(round.cwd) } catch (_: Exception) {}
+			SyncLock.release()
+		}
+	}
+
+	// ── Pipeline ────────────────────────────────────────────────────
+
+	private fun doRound(
+		round: SyncRoundOptions,
+		ctx: RoundContext,
+		lockHolder: RoundLockHolder,
+	): SyncRoundResult {
+		// Step 1: Mint credentials (with 423 retry loop).
+		log.debug("Step 1: minting credentials")
+		val mint = mintFresh(lockHolder)
+		if (mint !is MintResult.Ok) {
+			val failed = mint as MintResult.Failed
+			log.warn("Step 1 failed: mint credentials code=${failed.code} message=${failed.message}")
+			return reportOffline(
+				fetched = false, pulled = false, pushed = false,
+				code = failed.code, message = failed.message, selfLocked = failed.selfLocked,
+			)
+		}
+
+		log.info("Step 1 ok: credentials minted, defaultBranch=${mint.creds.defaultBranch}")
+
+		val state = RoundState(
+			creds = mint.creds,
+			client = opts.makeGitClient.create(mint.creds, ctx.memoryBankRoot),
+			ctx = ctx,
+		)
+
+		// Step 2: Check git is installed.
+		log.debug("Step 2: checking git installation")
+		val gitCheck = state.client.checkGitInstalled()
+		if (gitCheck is GitVersionResult.NotFound) {
+			log.warn("Step 2 failed: git not found on PATH")
+			return reportOffline(
+				fetched = false, pulled = false, pushed = false,
+				code = SyncErrorCode.GIT_MISSING, message = "git binary not found on PATH",
+			)
+		}
+
+		// Step 2b: Self-heal stale rebase state.
+		try {
+			if (state.client.isRebaseInProgress()) {
+				log.info("Step 2b: aborting stale rebase")
+				state.client.rebaseAbort()
+			}
+		} catch (_: Exception) {}
+
+		// Step 2c: Sweep stale .git/*.lock files.
+		try {
+			state.client.sweepStaleLockFiles(STALE_LOCK_TTL_MS)
+		} catch (_: Exception) {}
+
+		// Step 3: Fetch or clone with retry.
+		log.debug("Step 3: fetch/clone memoryBankRoot=${ctx.memoryBankRoot}")
+		emitPhase(SyncPhase.DOWNLOADING)
+		val fetchResult = fetchOrCloneWithRetry(state, lockHolder)
+		if (fetchResult !is FetchStepResult.Ok) {
+			val failed = fetchResult as FetchStepResult.Failed
+			log.warn("Step 3 failed: fetch/clone code=${failed.code} message=${failed.message}")
+			return reportOffline(
+				fetched = false, pulled = false, pushed = false,
+				code = failed.code, message = failed.message,
+			)
+		}
+
+		log.info("Step 3 ok: fetch/clone complete cloned=${(fetchResult as FetchStepResult.Ok).cloned}")
+
+		// Step 3b: Ensure on default branch.
+		log.debug("Step 3b: ensuring on default branch=${state.creds.defaultBranch}")
+		val branchResult = ensureOnDefaultBranch(state)
+		if (branchResult !is BranchStepResult.Ok) {
+			val failed = branchResult as BranchStepResult.Failed
+			log.warn("Step 3b failed: branch setup code=${failed.code} message=${failed.message}")
+			return reportOffline(
+				fetched = true, pulled = false, pushed = false,
+				code = failed.code, message = failed.message,
+			)
+		}
+
+		// Check if remote has the default branch.
+		val remoteRef = "refs/remotes/origin/${state.creds.defaultBranch}"
+		val remoteHasDefault = state.client.refExists(remoteRef)
+
+		// Step 3c: First-bind migration (db → git one-shot).
+		if (!state.creds.alreadyVaultBound) {
+			log.info("Step 3c: running first-bind migration (vault not yet bound)")
+			val migrationResult = runFirstBindMigration(state, round)
+			if (!migrationResult.ok) {
+				log.warn("Step 3c failed: migration error=${migrationResult.message}")
+				return reportOffline(
+					fetched = true, pulled = false, pushed = false,
+					code = SyncErrorCode.MIGRATION_FAILED,
+					message = migrationResult.message ?: "first-bind migration failed",
+				)
+			}
+		}
+
+		// Step 3d: Auto-reconcile owned dirty paths before pull-rebase.
+		log.debug("Step 3d: auto-reconcile dirty paths")
+		autoReconcile(state, round.transcripts)
+
+		// Step 4: Pull-rebase (skip if remote has no default branch).
+		var pulled = false
+		var workingTreeChangedByPull = false
+		if (remoteHasDefault) {
+			log.debug("Step 4: pull-rebase (remote has default branch)")
+			emitPhase(SyncPhase.MERGING)
+			val pullAndResolve = pullRebaseAndResolve(state)
+			if (pullAndResolve == null) {
+				return reportOffline(
+					fetched = true, pulled = false, pushed = false,
+					code = SyncErrorCode.NETWORK,
+					message = "vault-write.lock busy (QueueWorker active)",
+				)
+			}
+			pulled = true
+			if (pullAndResolve.unresolved.isNotEmpty()) {
+				return report(SyncState.CONFLICTS, SyncRoundResult(
+					fetched = true, pulled = true, pushed = false,
+					conflicts = pullAndResolve.unresolved, newState = SyncState.CONFLICTS,
+				))
+			}
+			workingTreeChangedByPull = pullAndResolve.fastForwarded || pullAndResolve.conflictsResolved
+			log.info("Step 4 ok: pulled=true fastForwarded=${pullAndResolve.fastForwarded} conflictsResolved=${pullAndResolve.conflictsResolved}")
+		} else {
+			log.debug("Step 4: skipped (remote has no default branch)")
+		}
+
+		// Step 4b: Repo mapping — resolve vault folder via .jolli/repos.json.
+		val effectiveCtx = try {
+			val mapping = loadRepoMapping(ctx.memoryBankRoot)
+			val conflicts = findRepoMappingConflicts(mapping)
+			if (conflicts.isNotEmpty()) {
+				for (c in conflicts) {
+					log.warn("repos.json folder collision: ${c.folder} claimed by ${c.identities.size} identities (${c.identities.joinToString(", ")})")
+				}
+			}
+			val resolved = resolveOrAssignFolder(mapping, ctx.repoIdentity, ctx.repoFolderName)
+			if (resolved.updatedMapping != null) {
+				saveRepoMapping(ctx.memoryBankRoot, resolved.updatedMapping)
+			}
+			if (resolved.folder != ctx.repoFolderName) {
+				ctx.copy(repoFolderName = resolved.folder)
+			} else ctx
+		} catch (_: Exception) { ctx }
+
+		// Step 5: Idle short-circuit.
+		if (isIdle(state, remoteHasDefault, workingTreeChangedByPull, round.transcripts)) {
+			log.info("Step 5: idle — nothing to push, already synced")
+			return report(SyncState.SYNCED, SyncRoundResult(
+				fetched = true, pulled = pulled, pushed = false,
+				newState = SyncState.SYNCED,
+			))
+		}
+
+		// Step 6: Stage vault.
+		log.debug("Step 6: staging vault files")
+		val stageReport = stageVault(
+			state.client, ctx.memoryBankRoot,
+			StageVaultOpts(syncTranscripts = round.transcripts),
+		)
+		val canary = if (stageReport.symlinked.isNotEmpty() || stageReport.unowned.isNotEmpty()) {
+			CanaryReport(symlinked = stageReport.symlinked, unowned = stageReport.unowned)
+		} else null
+
+		// Step 7: Commit.
+		log.debug("Step 7: committing staged changes")
+		val commitMessage = "[jolli-mb] add: memory bank changes"
+		state.client.commit(commitMessage, ctx.author)
+
+		// Step 8: Push with retry.
+		log.debug("Step 8: pushing to remote")
+		emitPhase(SyncPhase.UPLOADING)
+		val pushResult = pushWithRetry(state, lockHolder)
+		if (pushResult !is PushStepResult.Ok) {
+			val failed = pushResult as PushStepResult.Failed
+			log.warn("Step 8 failed: push code=${failed.code} message=${failed.message}")
+			return reportOffline(
+				fetched = true, pulled = pulled, pushed = false,
+				code = failed.code, message = failed.message, canary = canary,
+			)
+		}
+
+		log.info("Step 8 ok: push complete transmitted=${pushResult.transmitted}")
+
+		// Step 9: Notify push (fire-and-forget).
+		if (pushResult.transmitted) {
+			try {
+				val pushedHead = state.client.currentHead()
+				opts.backend.notifyPush(pushedHead, state.creds.defaultBranch, state.creds.lockOwnerToken)
+				clearPersistedLock()
+				lockHolder.releaseInFinally = false
+			} catch (_: Exception) {}
+		}
+
+		log.info("runRound end state=SYNCED pushed=true pulled=$pulled")
+		return report(SyncState.SYNCED, SyncRoundResult(
+			fetched = true, pulled = pulled, pushed = true,
+			newState = SyncState.SYNCED, canary = canary,
+		))
+	}
+
+	// ── Credential minting ──────────────────────────────────────────
+
+	private sealed class MintResult {
+		data class Ok(val creds: GitCredentials) : MintResult()
+		data class Failed(val code: SyncErrorCode, val message: String, val selfLocked: Boolean? = null) : MintResult()
+	}
+
+	private fun mintFresh(lockHolder: RoundLockHolder): MintResult {
+		val schedule = opts.vaultLockedRetrySchedule
+		val totalAttempts = schedule.size + 1
+
+		// Capture self-lock state once at loop entry.
+		val selfLocked = isSelfLocked()
+
+		var lastMessage = ""
+		for (attempt in 1..totalAttempts) {
+			try {
+				val creds = opts.backend.mintGitCredentials()
+				lockHolder.token = creds.lockOwnerToken
+				lockHolder.releaseInFinally = true
+				persistMintedLock(creds)
+				return MintResult.Ok(creds)
+			} catch (e: VaultLockedError) {
+				lastMessage = e.message ?: "vault locked"
+				log.info("Mint attempt $attempt/$totalAttempts: vault locked, selfLocked=$selfLocked")
+				if (attempt < totalAttempts) {
+					val delayMs = schedule[attempt - 1]
+					try {
+						opts.onLockedWait?.invoke(VaultLockedWaitInfo(
+							attempt = attempt,
+							totalAttempts = totalAttempts,
+							nextRetryInMs = delayMs,
+							message = lastMessage,
+							selfLocked = selfLocked,
+						))
+					} catch (_: Exception) {}
+					emitPhase(SyncPhase.WAITING)
+					opts.sleepFn(delayMs)
+					continue
+				}
+				return MintResult.Failed(SyncErrorCode.VAULT_LOCKED, lastMessage, selfLocked)
+			} catch (e: WebFlushPendingError) {
+				lastMessage = e.message ?: "pending flush"
+				if (attempt < totalAttempts) {
+					val delayMs = maxOf(1000L, e.retryAfterSeconds * 1000L)
+					emitPhase(SyncPhase.WAITING)
+					opts.sleepFn(delayMs)
+					continue
+				}
+				return MintResult.Failed(SyncErrorCode.NETWORK, lastMessage)
+			} catch (e: SyncBackendNetworkError) {
+				return MintResult.Failed(SyncErrorCode.NETWORK, e.message ?: "network error")
+			} catch (e: SyncBackendUnauthorizedError) {
+				return MintResult.Failed(SyncErrorCode.MINT_FAILED, e.message ?: "unauthorized")
+			} catch (e: SyncBackendError) {
+				return MintResult.Failed(SyncErrorCode.MINT_FAILED, e.message ?: "mint error")
+			}
+		}
+		return MintResult.Failed(SyncErrorCode.MINT_FAILED, "unreachable: mint loop exited ($lastMessage)")
+	}
+
+	// ── Re-mint budget ──────────────────────────────────────────────
+
+	private sealed class RemintResult {
+		data object Ok : RemintResult()
+		data class Failed(val code: SyncErrorCode, val message: String) : RemintResult()
+	}
+
+	private fun tryRemint(state: RoundState, cause: String, lockHolder: RoundLockHolder): RemintResult {
+		if (state.remintsUsed >= MAX_REMINTS_PER_PHASE) {
+			return RemintResult.Failed(
+				SyncErrorCode.SYNC_FAILED_AFTER_RETRIES,
+				"remint budget exhausted ($cause)",
+			)
+		}
+		val fresh = mintFresh(lockHolder)
+		if (fresh !is MintResult.Ok) {
+			val failed = fresh as MintResult.Failed
+			return RemintResult.Failed(failed.code, failed.message)
+		}
+		state.creds = fresh.creds
+		state.client = opts.makeGitClient.create(fresh.creds, state.ctx.memoryBankRoot)
+		state.remintsUsed++
+		return RemintResult.Ok
+	}
+
+	// ── Fetch / clone ───────────────────────────────────────────────
+
+	private sealed class FetchStepResult {
+		data class Ok(val cloned: Boolean) : FetchStepResult()
+		data class Failed(val code: SyncErrorCode, val message: String) : FetchStepResult()
+	}
+
+	private fun fetchOrCloneWithRetry(state: RoundState, lockHolder: RoundLockHolder): FetchStepResult {
+		val maxAttempts = opts.maxPushAttempts
+		for (attempt in 1..maxAttempts) {
+			try {
+				val gitDir = Path.of(state.ctx.memoryBankRoot, ".git")
+				val mbDir = Path.of(state.ctx.memoryBankRoot)
+
+				if (Files.isDirectory(gitDir)) {
+					// Steady state: verify marker, then fetch.
+					val guard = guardVaultIdentity(state)
+					if (guard != null) return guard
+					state.client.fetch()
+					return FetchStepResult.Ok(cloned = false)
+				}
+
+				if (Files.isDirectory(mbDir)) {
+					// First-bind: dir exists but no .git.
+					state.client.initRemote(state.creds.gitUrl)
+					state.client.fetch()
+					writeVaultMarker(state.ctx.memoryBankRoot, state.creds)
+					return FetchStepResult.Ok(cloned = true)
+				}
+
+				// Cold start: clone.
+				state.client.clone(state.creds.gitUrl)
+				writeVaultMarker(state.ctx.memoryBankRoot, state.creds)
+				return FetchStepResult.Ok(cloned = true)
+			} catch (e: Exception) {
+				val msg = e.message ?: ""
+				log.warn("Fetch/clone attempt $attempt/${maxAttempts} failed: $msg")
+				val cause = classifyGitError(msg)
+				if (cause == "unauthorized" || cause == "repoMissing") {
+					val remint = tryRemint(state, cause, lockHolder)
+					if (remint is RemintResult.Ok) continue
+					val failed = remint as RemintResult.Failed
+					return FetchStepResult.Failed(failed.code, failed.message)
+				}
+				if (cause == "network") {
+					return FetchStepResult.Failed(SyncErrorCode.NETWORK, msg)
+				}
+				val code = if (Files.isDirectory(Path.of(state.ctx.memoryBankRoot, ".git")))
+					SyncErrorCode.FETCH_FAILED else SyncErrorCode.CLONE_FAILED
+				return FetchStepResult.Failed(code, msg)
+			}
+		}
+		return FetchStepResult.Failed(SyncErrorCode.SYNC_FAILED_AFTER_RETRIES, "fetch exhausted $maxAttempts attempts")
+	}
+
+	/** Returns a [FetchStepResult.Failed] if the vault identity check fails, null if ok. */
+	private fun guardVaultIdentity(state: RoundState): FetchStepResult.Failed? {
+		val originUrl = state.client.getOriginUrl()
+		val verdict = verifyVaultMarker(state.ctx.memoryBankRoot, originUrl, state.creds)
+		return when (verdict) {
+			is VaultVerdict.Ok -> {
+				if (verdict.needsRewrite) {
+					try { writeVaultMarker(state.ctx.memoryBankRoot, state.creds) } catch (_: Exception) {}
+				}
+				null
+			}
+			is VaultVerdict.Failed -> {
+				// Try backfill if marker is missing but origin matches.
+				if (verdict.reason == "missing_marker" && originUrl != null) {
+					val normalizedOrigin = normalizeGitUrl(originUrl)
+					val normalizedCreds = normalizeGitUrl(state.creds.gitUrl)
+					if (normalizedOrigin == normalizedCreds) {
+						try { writeVaultMarker(state.ctx.memoryBankRoot, state.creds) } catch (_: Exception) {}
+						return null
+					}
+				}
+				FetchStepResult.Failed(SyncErrorCode.VAULT_MISMATCH, verdict.message)
+			}
+		}
+	}
+
+	// ── Branch management ───────────────────────────────────────────
+
+	private sealed class BranchStepResult {
+		data object Ok : BranchStepResult()
+		data class Failed(val code: SyncErrorCode, val message: String) : BranchStepResult()
+	}
+
+	private fun ensureOnDefaultBranch(state: RoundState): BranchStepResult {
+		val defaultBranch = state.creds.defaultBranch
+		try {
+			val currentBranch = state.client.currentBranch()
+			if (currentBranch == defaultBranch) {
+				log.debug("Already on default branch $defaultBranch")
+				return BranchStepResult.Ok
+			}
+			log.info("On branch $currentBranch, need $defaultBranch — switching")
+
+			val remoteRef = "refs/remotes/origin/$defaultBranch"
+			val localRef = "refs/heads/$defaultBranch"
+			val hasRemote = state.client.refExists(remoteRef)
+			val hasLocal = state.client.refExists(localRef)
+
+			if (!hasLocal && hasRemote) {
+				// Check if bootstrap merge is needed (fresh local + populated remote).
+				val shouldMerge = shouldRunBootstrapMerge(state.client, defaultBranch)
+				if (shouldMerge is ShouldRunResult.Ok) {
+					val mergeResult = runBootstrapMerge(
+						state.client, state.ctx.memoryBankRoot, defaultBranch, state.ctx.author,
+					)
+					if (mergeResult.ok) {
+						return BranchStepResult.Ok
+					}
+					// Bootstrap merge failed — fall through to normal checkout.
+				}
+				// Missing local ref: create from remote.
+				state.client.checkoutTrackingBranch(defaultBranch)
+				return BranchStepResult.Ok
+			}
+
+			if (!hasLocal && !hasRemote) {
+				// Empty repo, no refs at all.
+				state.client.checkoutBranch(defaultBranch)
+				return BranchStepResult.Ok
+			}
+
+			if (hasLocal) {
+				val headSha = state.client.revParse("HEAD")
+				val defaultSha = state.client.revParse(localRef)
+				if (headSha != null && defaultSha != null) {
+					if (state.client.isAncestor(headSha, defaultSha)) {
+						// HEAD ⊆ default: simple checkout.
+						state.client.checkoutBranch(defaultBranch)
+						return BranchStepResult.Ok
+					}
+					if (state.client.isAncestor(defaultSha, headSha)) {
+						// default ⊆ HEAD: fast-forward default to stranded commits.
+						state.client.recreateBranchAt(defaultBranch, "HEAD")
+						return BranchStepResult.Ok
+					}
+				}
+				// Divergent: refuse.
+				return BranchStepResult.Failed(
+					SyncErrorCode.VAULT_MISMATCH,
+					"HEAD diverged from $defaultBranch; manual resolution required",
+				)
+			}
+
+			return BranchStepResult.Ok
+		} catch (_: Exception) {
+			// Non-fatal: proceed and let pull-rebase surface real errors.
+			return BranchStepResult.Ok
+		}
+	}
+
+	// ── Auto-reconcile ──────────────────────────────────────────────
+
+	private fun autoReconcile(state: RoundState, syncTranscripts: Boolean) {
+		try {
+			if (hasOwnedDirtyPaths(state, syncTranscripts)) {
+				// Quarantine corrupt JSON before staging so truncated files
+				// never reach the orphan history.
+				val dirty = state.client.listDirtyPaths()
+				val corrupt = quarantineCorruptJson(state.ctx.memoryBankRoot, dirty)
+				if (corrupt.quarantined > 0) {
+					log.warn("Auto-reconcile quarantined ${corrupt.quarantined} corrupt JSON file(s): ${corrupt.paths.joinToString(", ")}")
+				}
+				stageVault(
+					state.client, state.ctx.memoryBankRoot,
+					StageVaultOpts(syncTranscripts = syncTranscripts),
+				)
+				state.client.commit("[jolli-mb] reconcile: user-modified", state.ctx.author)
+				log.info("Auto-reconcile: committed dirty owned paths")
+			}
+		} catch (e: Exception) {
+			log.warn("Auto-reconcile failed (non-fatal): ${e.message}")
+		}
+	}
+
+	// ── Pull-rebase + conflict resolution ────────────────────────────
+
+	private data class PullAndResolveResult(
+		val fastForwarded: Boolean,
+		val unresolved: List<String>,
+		val conflictsResolved: Boolean,
+	)
+
+	/**
+	 * Runs pull-rebase inside a vault-write.lock. If conflicts occur,
+	 * runs conflict resolution while still holding the lock.
+	 * Returns null if the lock could not be acquired.
+	 */
+	private fun pullRebaseAndResolve(state: RoundState): PullAndResolveResult? {
+		val handle = VaultWriteLock.acquire(
+			state.ctx.memoryBankRoot,
+			VaultWriteLockMode.Wait(VaultWriteLock.DEFAULT_PULL_LOCK_WAIT_MS),
+		) ?: return null
+
+		return try {
+			val pullResult = state.client.pullRebase(state.ctx.author)
+			if (pullResult.conflicted.isEmpty()) {
+				return PullAndResolveResult(
+					fastForwarded = pullResult.fastForwarded,
+					unresolved = emptyList(),
+					conflictsResolved = false,
+				)
+			}
+
+			// Conflicts detected — resolve while holding the lock.
+			emitPhase(SyncPhase.RESOLVING)
+			val resolver = buildResolver(state)
+			val resolution = resolver.resolveAll(pullResult.conflicted)
+			if (!resolution.rebaseAdvanced) {
+				PullAndResolveResult(
+					fastForwarded = false,
+					unresolved = resolution.skipped,
+					conflictsResolved = false,
+				)
+			} else {
+				PullAndResolveResult(
+					fastForwarded = pullResult.fastForwarded,
+					unresolved = emptyList(),
+					conflictsResolved = true,
+				)
+			}
+		} finally {
+			handle.release()
+		}
+	}
+
+	/**
+	 * Runs pull-rebase inside a vault-write.lock (no conflict resolution).
+	 * Used by push-retry non-FF path where conflicts abort immediately.
+	 */
+	private fun pullRebaseLocked(state: RoundState): PullResult? {
+		val handle = VaultWriteLock.acquire(
+			state.ctx.memoryBankRoot,
+			VaultWriteLockMode.Wait(VaultWriteLock.DEFAULT_PULL_LOCK_WAIT_MS),
+		) ?: return null
+
+		return try {
+			state.client.pullRebase(state.ctx.author)
+		} finally {
+			handle.release()
+		}
+	}
+
+	private fun buildResolver(state: RoundState): ConflictResolver {
+		if (opts.makeResolver != null) {
+			return opts.makeResolver.invoke(state.client, state.ctx.author)
+		}
+		val ui = opts.conflictUi ?: object : ConflictUi {
+			override fun promptBinaryPick(path: String, oursOid: String?, theirsOid: String?) = Tier3Pick.MINE
+		}
+		return ConflictResolver(
+			client = state.client,
+			ai = opts.aiProvider?.invoke(),
+			ui = ui,
+			resolveVaultPath = { path -> Path.of(state.ctx.memoryBankRoot, path).toString() },
+			policy = opts.conflictPolicy,
+			author = state.ctx.author,
+		)
+	}
+
+	// ── Idle short-circuit ──────────────────────────────────────────
+
+	private fun isIdle(
+		state: RoundState,
+		remoteHasDefault: Boolean,
+		workingTreeChangedByPull: Boolean,
+		syncTranscripts: Boolean,
+	): Boolean {
+		if (!remoteHasDefault) return false
+		if (workingTreeChangedByPull) return false
+
+		val remoteRef = "refs/remotes/origin/${state.creds.defaultBranch}"
+		val localHead = state.client.revParse("HEAD")
+		val remoteHead = state.client.revParse(remoteRef)
+		if (localHead == null || remoteHead == null || localHead != remoteHead) return false
+
+		return !hasOwnedDirtyPaths(state, syncTranscripts)
+	}
+
+	private fun hasOwnedDirtyPaths(state: RoundState, syncTranscripts: Boolean): Boolean {
+		val entries = state.client.statusPorcelainZ()
+		if (entries.isEmpty()) return false
+		return entries.any { entry ->
+			val path = entry.path
+			classifyVaultPath(path) != null &&
+				isAllowedPath(path, AllowListOpts(syncTranscripts = syncTranscripts))
+		}
+	}
+
+	// ── Push with retry ─────────────────────────────────────────────
+
+	private sealed class PushStepResult {
+		data class Ok(val transmitted: Boolean) : PushStepResult()
+		data class Failed(val code: SyncErrorCode, val message: String) : PushStepResult()
+	}
+
+	private fun pushWithRetry(state: RoundState, lockHolder: RoundLockHolder): PushStepResult {
+		var lastMessage = ""
+		for (attempt in 1..opts.maxPushAttempts) {
+			log.debug("Push attempt $attempt/${opts.maxPushAttempts}")
+			val result = state.client.push()
+			when (result) {
+				is PushResult.Ok -> {
+					return PushStepResult.Ok(transmitted = result.transmitted)
+				}
+				is PushResult.Failed -> {
+					lastMessage = result.message
+					log.warn("Push attempt $attempt failed: ${result.message} nonFF=${result.nonFastForward} unauth=${result.unauthorized}")
+					if (result.unauthorized || result.repoMissing) {
+						val cause = if (result.unauthorized) "unauthorized" else "repoMissing"
+						val remint = tryRemint(state, cause, lockHolder)
+						if (remint is RemintResult.Ok) continue
+						val failed = remint as RemintResult.Failed
+						return PushStepResult.Failed(failed.code, failed.message)
+					}
+					if (result.nonFastForward) {
+						try {
+							val pull = pullRebaseLocked(state)
+							if (pull == null) {
+								return PushStepResult.Failed(
+									SyncErrorCode.NETWORK,
+									"vault-write.lock busy during non-FF retry",
+								)
+							}
+							if (pull.conflicted.isNotEmpty()) {
+								safeRebaseAbort(state)
+								return PushStepResult.Failed(
+									SyncErrorCode.SYNC_FAILED_AFTER_RETRIES,
+									"non-FF retry hit conflicts",
+								)
+							}
+							continue
+						} catch (e: Exception) {
+							safeRebaseAbort(state)
+							val msg = e.message ?: ""
+							val code = when {
+								isServerRejectionMessage(msg) -> SyncErrorCode.PUSH_REJECTED
+								isNetworkErrorMessage(msg) -> SyncErrorCode.NETWORK
+								else -> SyncErrorCode.SYNC_FAILED_AFTER_RETRIES
+							}
+							return PushStepResult.Failed(code, msg)
+						}
+					}
+					// Terminal failure.
+					val code = when {
+						isServerRejectionMessage(result.message) -> SyncErrorCode.PUSH_REJECTED
+						isNetworkErrorMessage(result.message) -> SyncErrorCode.NETWORK
+						else -> SyncErrorCode.SYNC_FAILED_AFTER_RETRIES
+					}
+					return PushStepResult.Failed(code, result.message)
+				}
+			}
+		}
+		return PushStepResult.Failed(
+			SyncErrorCode.SYNC_FAILED_AFTER_RETRIES,
+			"push exhausted ${opts.maxPushAttempts} attempts: $lastMessage",
+		)
+	}
+
+	// ── Self-lock detection ─────────────────────────────────────────
+
+	private fun isSelfLocked(): Boolean {
+		val apiKey = opts.backend.getJolliApiKey() ?: return false
+		val entry = PendingLockStore.read(apiKey) ?: return false
+		val ageMs = System.currentTimeMillis() - entry.mintedAt
+		return ageMs < SELF_LOCK_TTL_GRACE_MS
+	}
+
+	private fun persistMintedLock(creds: GitCredentials) {
+		val apiKey = opts.backend.getJolliApiKey() ?: return
+		try { PendingLockStore.write(apiKey, creds.lockOwnerToken) } catch (_: Exception) {}
+	}
+
+	private fun clearPersistedLock() {
+		try { PendingLockStore.clear() } catch (_: Exception) {}
+	}
+
+	// ── Lock release ────────────────────────────────────────────────
+
+	private fun releaseLockHolderIfNeeded(lockHolder: RoundLockHolder) {
+		if (lockHolder.token != null && lockHolder.releaseInFinally && !lockHolder.deferredCompletion) {
+			try {
+				opts.backend.releaseLock(lockHolder.token!!)
+				clearPersistedLock()
+			} catch (_: Exception) {}
+		}
+	}
+
+	// ── First-bind migration ────────────────────────────────────────
+
+	private data class MigrationStepResult(val ok: Boolean, val message: String? = null)
+
+	private fun runFirstBindMigration(state: RoundState, round: SyncRoundOptions): MigrationStepResult {
+		return try {
+			val legacyResponse = opts.backend.getLegacyContent()
+			log.debug("First-bind migration: alreadyMigrated=${legacyResponse.alreadyMigrated} docs=${legacyResponse.docs.size}")
+			if (!legacyResponse.alreadyMigrated && legacyResponse.docs.isNotEmpty()) {
+				log.info("First-bind migration: writing ${legacyResponse.docs.size} legacy docs")
+				val migration = LegacyMigration(state.ctx.memoryBankRoot, round.transcripts)
+				migration.apply(legacyResponse)
+				stageVault(
+					state.client, state.ctx.memoryBankRoot,
+					StageVaultOpts(syncTranscripts = round.transcripts),
+				)
+				state.client.commit("[jolli-mb] migrate: legacy db content", state.ctx.author)
+				state.client.push()
+			}
+			// Complete migration (flips backend from db → git backing).
+			val headSha = state.client.currentHead()
+			opts.backend.completeMigration(headSha, state.creds.lockOwnerToken)
+			log.info("First-bind migration: completed successfully")
+			MigrationStepResult(ok = true)
+		} catch (e: Exception) {
+			log.warn("First-bind migration failed: ${e.message} ${e.stackTraceToString()}")
+			MigrationStepResult(ok = false, message = "first-bind migration: ${e.message}")
+		}
+	}
+
+	// ── Rebase safety ───────────────────────────────────────────────
+
+	private fun safeRebaseAbort(state: RoundState) {
+		try { state.client.rebaseAbort() } catch (_: Exception) {}
+	}
+
+	// ── Reporting ───────────────────────────────────────────────────
+
+	private fun report(newState: SyncState, result: SyncRoundResult): SyncRoundResult {
+		try { opts.onStateChange?.invoke(newState, result) } catch (_: Exception) {}
+		return result
+	}
+
+	private fun reportOffline(
+		fetched: Boolean,
+		pulled: Boolean,
+		pushed: Boolean,
+		code: SyncErrorCode,
+		message: String,
+		selfLocked: Boolean? = null,
+		canary: CanaryReport? = null,
+	): SyncRoundResult {
+		return report(SyncState.OFFLINE, SyncRoundResult(
+			fetched = fetched,
+			pulled = pulled,
+			pushed = pushed,
+			newState = SyncState.OFFLINE,
+			lastError = SyncRoundError(code = code, message = message, selfLocked = selfLocked),
+			canary = canary,
+		))
+	}
+
+	private fun emitPhase(phase: SyncPhase) {
+		try { opts.onPhase?.invoke(phase) } catch (_: Exception) {}
+	}
+}
+
+// ── Internal mutable state ──────────────────────────────────────────
+
+private class RoundState(
+	var creds: GitCredentials,
+	var client: SyncGitClient,
+	val ctx: RoundContext,
+	var remintsUsed: Int = 0,
+)
+
+private class RoundLockHolder(
+	var token: String? = null,
+	var releaseInFinally: Boolean = false,
+	var deferredCompletion: Boolean = false,
+)

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/sync/SyncGitClient.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/sync/SyncGitClient.kt
@@ -1,0 +1,651 @@
+package ai.jolli.jollimemory.sync
+
+import ai.jolli.jollimemory.core.JmLogger
+import java.io.File
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.TimeUnit
+
+/**
+ * Thin wrapper around the system `git` binary for vault working-tree
+ * operations (clone, fetch, pull-rebase, commit, push, conflict resolution,
+ * self-healing).
+ *
+ * Port of `cli/src/sync/GitClient.ts`.
+ *
+ * This is a separate working tree from the source repo (`GitOps`). The same
+ * `git` binary is used; only the cwd and env differ. All commands flow
+ * through [run] which injects the askpass env so the Installation Token
+ * never leaks into argv.
+ *
+ * @param vaultRoot        Absolute path to the Memory Bank folder (vault working tree).
+ * @param credentials      Credentials from [SyncBackendClient.mintGitCredentials].
+ * @param askpassProvider  Test seam — defaults to [prepareAskpass].
+ * @param processRunner    Test seam — defaults to real ProcessBuilder execution.
+ */
+class SyncGitClient(
+	private val vaultRoot: String,
+	private val credentials: GitCredentials,
+	private val askpassProvider: (token: String) -> AskpassHandle = ::prepareAskpass,
+	private val processRunner: ProcessRunner = RealProcessRunner(),
+) {
+
+	private val log = JmLogger.create("Sync:Git")
+	private var cachedAskpass: AskpassHandle? = null
+
+	companion object {
+		/**
+		 * Per-batch character budget for [stageAddPaths] / [stageRemovePaths].
+		 * Stays under the Windows `cmd.exe` ARG_MAX floor (~32 KB).
+		 */
+		const val ARG_BUDGET_CHARS = 16_384
+
+		/**
+		 * Hard timeout for local rebase plumbing (ms). 30s is generous — rebase
+		 * continue/abort are pure index/refs operations. The deadline bounds
+		 * the failure mode where a misconfigured git tries to open `$EDITOR`.
+		 */
+		const val REBASE_TIMEOUT_MS = 30_000L
+
+		/**
+		 * Always-injected git config flags for security hardening.
+		 * - `core.symlinks=false` — prevents symlink attacks from malicious peers.
+		 * - `credential.helper=` — clears the inherited credential helper chain.
+		 * - `credential.modalprompt=false` — prevents GCM modal dialogs on Windows.
+		 */
+		val GIT_HARDENING_CONFIG = listOf(
+			"-c", "core.symlinks=false",
+			"-c", "credential.helper=",
+			"-c", "credential.modalprompt=false",
+		)
+
+		/**
+		 * Env block that suppresses every git editor entry point.
+		 * `true` is the POSIX shell built-in that returns 0 immediately.
+		 */
+		val NO_EDITOR_ENV = mapOf(
+			"GIT_EDITOR" to "true",
+			"GIT_SEQUENCE_EDITOR" to "true",
+		)
+	}
+
+	// ── Public API ────────────────────────────────────────────────────
+
+	/** Probes `git --version`. Used at sync engine startup. */
+	fun checkGitInstalled(): GitVersionResult {
+		return try {
+			val result = processRunner.exec(listOf("git", "--version"), null, emptyMap(), null)
+			GitVersionResult.Ok(result.stdout.trim())
+		} catch (_: Exception) {
+			GitVersionResult.NotFound
+		}
+	}
+
+	/**
+	 * `git clone <gitUrl> <vaultRoot>` with `x-access-token@` injected as
+	 * the URL username so GitHub knows we're authenticating as a GitHub App
+	 * Installation Token (the actual token comes via `GIT_ASKPASS`).
+	 */
+	fun clone(gitUrl: String) {
+		val authUrl = injectGithubAppUsername(gitUrl)
+		runExpectOk(listOf("clone", authUrl, vaultRoot), cwdOverride = UseNoWorkDir)
+		persistNoSymlinksConfig()
+	}
+
+	/** `git fetch origin`. */
+	fun fetch() {
+		runExpectOk(listOf("fetch", "origin"))
+	}
+
+	/**
+	 * `git pull --rebase origin <branch>`. Returns the conflicted-paths
+	 * list when rebase pauses; empty list on a clean run.
+	 */
+	fun pullRebase(author: CommitAuthor? = null): PullResult {
+		val branch = credentials.defaultBranch
+		val identityArgs = if (author != null) {
+			listOf("-c", "user.name=${author.name}", "-c", "user.email=${author.email}")
+		} else emptyList()
+
+		// `--autostash`: the Memory Bank vault can hold tracked files that the
+		// sync classifier does not own (e.g. `.jolli/topics/` written by a newer
+		// surface's post-commit pipeline). Auto-reconcile only commits owned
+		// paths, so those leftover modifications keep the working tree dirty and
+		// `git pull --rebase` hard-fails with "cannot pull with rebase: You have
+		// unstaged changes", dropping the whole round to offline. Autostash
+		// shelves any such changes for the rebase and restores them after, so an
+		// unrecognized content type can no longer block sync.
+		val result = run(
+			identityArgs + listOf("-c", "core.editor=true", "pull", "--rebase", "--autostash", "origin", branch),
+			extraEnv = NO_EDITOR_ENV,
+		)
+		if (result.exitCode == 0) {
+			return PullResult(
+				fastForwarded = Regex("Fast-forward", RegexOption.IGNORE_CASE).containsMatchIn(result.stdout),
+				conflicted = emptyList(),
+			)
+		}
+		val unmerged = hasUnmergedPaths()
+		if (unmerged.isEmpty()) {
+			throw RuntimeException("git pull --rebase failed: ${result.stderr.ifEmpty { result.stdout }}")
+		}
+		return PullResult(fastForwarded = false, conflicted = unmerged.map { it.path })
+	}
+
+	/** `git add --all`. Idempotent. */
+	fun stageAll() {
+		runExpectOk(listOf("add", "--all"))
+	}
+
+	/** `git add -f -- <path>`. Force-add past deny-all `.gitignore`. */
+	fun addPath(path: String) {
+		runExpectOk(listOf("add", "-f", "--", path))
+	}
+
+	/** `git rm -f -- <path>`. Force-remove for conflict resolution deletes. */
+	fun removePath(path: String) {
+		runExpectOk(listOf("rm", "-f", "--", path))
+	}
+
+	/**
+	 * `git commit -m <message>`. Returns the new HEAD sha.
+	 * Returns the current HEAD when there is nothing to commit.
+	 */
+	fun commit(message: String, author: CommitAuthor): String {
+		val args = listOf(
+			"-c", "user.name=${author.name}",
+			"-c", "user.email=${author.email}",
+			"commit", "-m", message,
+		)
+		val result = run(args)
+		if (result.exitCode != 0) {
+			if (Regex("nothing to commit", RegexOption.IGNORE_CASE).containsMatchIn(result.stdout)) {
+				return currentHead()
+			}
+			throw RuntimeException("git commit failed: ${result.stderr.ifEmpty { result.stdout }}")
+		}
+		return currentHead()
+	}
+
+	/**
+	 * `git push origin HEAD:refs/heads/<branch>`. Distinguishes non-FF,
+	 * unauthorized, and repo-missing failure modes.
+	 */
+	fun push(): PushResult {
+		val branch = credentials.defaultBranch
+		val result = run(listOf("push", "origin", "HEAD:refs/heads/$branch"))
+		if (result.exitCode == 0) {
+			val combined = "${result.stdout}\n${result.stderr}"
+			val transmitted = !Regex("everything up-to-date", RegexOption.IGNORE_CASE).containsMatchIn(combined)
+			return PushResult.Ok(transmitted)
+		}
+		val merged = "${result.stdout}\n${result.stderr}".lowercase()
+		val unauthorized = Regex(
+			"authentication failed|invalid username or password|401 unauthorized|requested url returned error: 401"
+		).containsMatchIn(merged)
+		val repoMissing = !unauthorized && isRepoMissingMessage(merged)
+		val nonFastForward = !unauthorized && !repoMissing &&
+			Regex("non-fast-forward|rejected").containsMatchIn(merged)
+		return PushResult.Failed(
+			nonFastForward = nonFastForward,
+			unauthorized = unauthorized,
+			repoMissing = repoMissing,
+			message = result.stderr.ifEmpty { result.stdout },
+		)
+	}
+
+	/** `git show :<stage>:<path>`. Returns null when the stage is missing. */
+	fun readIndexStage(path: String, stage: Int): String? {
+		require(stage in 1..3) { "stage must be 1, 2, or 3" }
+		val result = run(listOf("show", ":$stage:$path"))
+		if (result.exitCode != 0) return null
+		return result.stdout
+	}
+
+	/**
+	 * "Use my local edit" — during `pull --rebase`, ours/theirs are inverted:
+	 * `--theirs` = the local commit being replayed (your edit).
+	 */
+	fun checkoutOurs(path: String) {
+		runExpectOk(listOf("checkout", "--theirs", "--", path))
+		runExpectOk(listOf("add", "-f", "--", path))
+	}
+
+	/** "Use the remote's version" — see [checkoutOurs] for rebase gotcha. */
+	fun checkoutTheirs(path: String) {
+		runExpectOk(listOf("checkout", "--ours", "--", path))
+		runExpectOk(listOf("add", "-f", "--", path))
+	}
+
+	/** `git rebase --continue` with editor suppression + timeout. */
+	fun rebaseContinue(author: CommitAuthor? = null) {
+		val identityArgs = if (author != null) {
+			listOf("-c", "user.name=${author.name}", "-c", "user.email=${author.email}")
+		} else emptyList()
+		runExpectOk(
+			identityArgs + listOf("-c", "core.editor=true", "rebase", "--continue"),
+			extraEnv = NO_EDITOR_ENV,
+			timeoutMs = REBASE_TIMEOUT_MS,
+		)
+	}
+
+	/** `git rebase --abort` with editor suppression. */
+	fun rebaseAbort() {
+		runExpectOk(
+			listOf("-c", "core.editor=true", "rebase", "--abort"),
+			extraEnv = NO_EDITOR_ENV,
+			timeoutMs = REBASE_TIMEOUT_MS,
+		)
+	}
+
+	/**
+	 * Returns true when a previous rebase left its state files behind
+	 * (`.git/rebase-merge/` or `.git/rebase-apply/`). Engine uses this
+	 * to self-heal at round start.
+	 */
+	fun isRebaseInProgress(): Boolean {
+		for (dir in listOf("rebase-merge", "rebase-apply")) {
+			val f = File(vaultRoot, ".git${File.separator}$dir")
+			if (f.isDirectory) return true
+		}
+		return false
+	}
+
+	/**
+	 * Sweeps stale `*.lock` files under `.git/` left behind when a
+	 * previous git invocation was killed. Returns removed paths.
+	 *
+	 * @param ttlMs Lock files older than this are considered stale (default 5 min).
+	 */
+	fun sweepStaleLockFiles(ttlMs: Long = 5 * 60_000L): List<String> {
+		val gitDir = File(vaultRoot, ".git")
+		val cutoff = System.currentTimeMillis() - ttlMs
+		val removed = mutableListOf<String>()
+
+		val candidates = mutableListOf(
+			File(gitDir, "index.lock"),
+			File(gitDir, "HEAD.lock"),
+			File(gitDir, "packed-refs.lock"),
+			File(gitDir, "config.lock"),
+		)
+		candidates.addAll(collectLockFiles(File(gitDir, "refs")))
+
+		for (file in candidates) {
+			try {
+				if (file.isFile && file.lastModified() <= cutoff) {
+					if (file.delete()) {
+						removed.add(file.absolutePath)
+					}
+				}
+			} catch (_: Exception) {
+				// Already gone or perm error — ignore.
+			}
+		}
+		return removed
+	}
+
+	/**
+	 * `git ls-files -u` parsed into per-path stage sets. Empty list when
+	 * the index has no unmerged entries.
+	 */
+	fun hasUnmergedPaths(): List<UnmergedEntry> {
+		val result = run(listOf("ls-files", "-u", "-z"))
+		if (result.exitCode != 0) return emptyList()
+		val entries = mutableMapOf<String, MutableSet<Int>>()
+		for (entry in result.stdout.split("\u0000")) {
+			if (entry.isEmpty()) continue
+			val tabIdx = entry.indexOf('\t')
+			if (tabIdx == -1) continue
+			val head = entry.substring(0, tabIdx)
+			val path = entry.substring(tabIdx + 1)
+			val parts = head.split(Regex("\\s+"))
+			val stage = parts.getOrNull(2)?.toIntOrNull() ?: continue
+			if (stage !in 1..3) continue
+			entries.getOrPut(path) { mutableSetOf() }.add(stage)
+		}
+		return entries.map { (path, stages) -> UnmergedEntry(path, stages.toSet()) }
+	}
+
+	/** `git rev-parse HEAD`. */
+	fun currentHead(): String {
+		return runExpectOk(listOf("rev-parse", "HEAD")).stdout.trim()
+	}
+
+	/** True iff `HEAD` resolves to a commit. False on an unborn branch. */
+	fun hasHead(): Boolean {
+		return run(listOf("rev-parse", "--verify", "--quiet", "HEAD")).exitCode == 0
+	}
+
+	/** True iff `git status --porcelain` reports any uncommitted entry. */
+	fun hasUncommittedChanges(includeIgnored: Boolean = false): Boolean {
+		val args = mutableListOf("status", "--porcelain")
+		if (includeIgnored) {
+			args.addAll(listOf("--untracked-files=all", "--ignored=matching"))
+		}
+		val result = runExpectOk(args)
+		return result.stdout.trim().isNotEmpty()
+	}
+
+	/** Returns every dirty path from `git status --porcelain -z`. */
+	fun listDirtyPaths(): List<String> {
+		val entries = statusPorcelainZ()
+		val paths = mutableListOf<String>()
+		for (e in entries) {
+			paths.add(e.path)
+			if (e.oldPath != null) paths.add(e.oldPath)
+		}
+		return paths
+	}
+
+	/** Structured `git status --porcelain -z` output. */
+	fun statusPorcelainZ(): List<PorcelainEntry> {
+		val result = runExpectOk(listOf(
+			"status", "--porcelain", "-z",
+			"--untracked-files=all", "--ignored=matching",
+		))
+		return parsePorcelainZ(result.stdout)
+	}
+
+	/**
+	 * Stages paths via `git add -f`. Chunked at [ARG_BUDGET_CHARS] to stay
+	 * under the Windows ARG_MAX floor.
+	 */
+	fun stageAddPaths(paths: List<String>) {
+		for (batch in chunkByBudget(paths, ARG_BUDGET_CHARS)) {
+			runExpectOk(listOf("add", "-f", "--") + batch)
+		}
+	}
+
+	/** Removes paths from index via `git rm --ignore-unmatch --quiet`. */
+	fun stageRemovePaths(paths: List<String>) {
+		for (batch in chunkByBudget(paths, ARG_BUDGET_CHARS)) {
+			runExpectOk(listOf("rm", "--ignore-unmatch", "--quiet", "--") + batch)
+		}
+	}
+
+	/**
+	 * DANGER: data-loss vector. `git rm --cached -f --ignore-unmatch`.
+	 * For HEAD-tracked paths, stages a DELETION. Only use for explicit
+	 * one-shot eviction logic.
+	 */
+	fun unstagePaths(paths: List<String>) {
+		for (batch in chunkByBudget(paths, ARG_BUDGET_CHARS)) {
+			runExpectOk(listOf("rm", "--cached", "-f", "--ignore-unmatch", "--quiet", "--") + batch)
+		}
+	}
+
+	/**
+	 * Restores index entries to their HEAD blob without touching the
+	 * working tree. Safe alternative to [unstagePaths] for per-round use.
+	 */
+	fun resetPathsToHead(paths: List<String>) {
+		for (batch in chunkByBudget(paths, ARG_BUDGET_CHARS)) {
+			runExpectOk(listOf("reset", "--quiet", "HEAD", "--") + batch)
+		}
+	}
+
+	/**
+	 * `git init` + `git remote add/set-url origin <gitUrl>`. Used for
+	 * first-bind when a Memory Bank folder exists but isn't a git repo yet.
+	 */
+	fun initRemote(gitUrl: String) {
+		val authUrl = injectGithubAppUsername(gitUrl)
+		runExpectOk(listOf("init", "--initial-branch=${credentials.defaultBranch}"))
+		val addRes = run(listOf("remote", "add", "origin", authUrl))
+		if (addRes.exitCode != 0) {
+			runExpectOk(listOf("remote", "set-url", "origin", authUrl))
+		}
+		persistNoSymlinksConfig()
+	}
+
+	/** `git remote get-url origin`. Null when no remote configured. */
+	fun getOriginUrl(): String? {
+		val result = run(listOf("remote", "get-url", "origin"))
+		if (result.exitCode != 0) return null
+		val url = result.stdout.trim()
+		return url.ifEmpty { null }
+	}
+
+	/** `git symbolic-ref --short HEAD`. Falls back to "HEAD" when detached. */
+	fun currentBranch(): String {
+		val result = run(listOf("symbolic-ref", "--short", "HEAD"))
+		if (result.exitCode == 0) return result.stdout.trim()
+		return "HEAD"
+	}
+
+	/** `git checkout <branch>` — switches HEAD to an existing local branch. */
+	fun checkoutBranch(branch: String) {
+		runExpectOk(listOf("checkout", branch))
+	}
+
+	/** `git checkout -B <branch> origin/<branch>` — create/reset tracking branch. */
+	fun checkoutTrackingBranch(branch: String) {
+		runExpectOk(listOf("checkout", "-B", branch, "origin/$branch"))
+	}
+
+	/** `git checkout -B <branch> <sourceRef>` — recreate branch at a ref. */
+	fun recreateBranchAt(branch: String, sourceRef: String) {
+		runExpectOk(listOf("checkout", "-B", branch, sourceRef))
+	}
+
+	/** `git show-ref --verify --quiet <fullRef>` — true iff the ref exists. */
+	fun refExists(fullRef: String): Boolean {
+		return run(listOf("show-ref", "--verify", "--quiet", fullRef)).exitCode == 0
+	}
+
+	/** `git rev-parse --verify --quiet <ref>` — returns OID or null. */
+	fun revParse(ref: String): String? {
+		val result = run(listOf("rev-parse", "--verify", "--quiet", ref))
+		if (result.exitCode != 0) return null
+		val oid = result.stdout.trim()
+		return oid.ifEmpty { null }
+	}
+
+	/** `git merge-base --is-ancestor <a> <b>` — true iff a is ancestor of b. */
+	fun isAncestor(maybeAncestor: String, descendant: String): Boolean {
+		return run(listOf("merge-base", "--is-ancestor", maybeAncestor, descendant)).exitCode == 0
+	}
+
+	/** `git for-each-ref refs/heads/` — returns local branch short names. */
+	fun listLocalBranches(): List<String> {
+		val result = run(listOf("for-each-ref", "--format=%(refname:short)", "refs/heads/"))
+		if (result.exitCode != 0) return emptyList()
+		return result.stdout.split("\n").map { it.trim() }.filter { it.isNotEmpty() }
+	}
+
+	// ── Internals ─────────────────────────────────────────────────────
+
+	private fun getAskpass(): AskpassHandle {
+		if (cachedAskpass == null) {
+			cachedAskpass = askpassProvider(credentials.token)
+		}
+		return cachedAskpass!!
+	}
+
+	private fun persistNoSymlinksConfig() {
+		val res = run(listOf("config", "core.symlinks", "false"))
+		if (res.exitCode != 0) {
+			log.warn("Failed to persist core.symlinks=false (non-fatal): %s", res.stderr)
+		}
+	}
+
+	private fun run(
+		args: List<String>,
+		cwdOverride: CwdOverride = UseVaultRoot,
+		extraEnv: Map<String, String> = emptyMap(),
+		timeoutMs: Long? = null,
+	): ExecResult {
+		val handle = getAskpass()
+		val cwd = when (cwdOverride) {
+			UseVaultRoot -> vaultRoot
+			UseNoWorkDir -> null
+		}
+		val env = if (extraEnv.isNotEmpty()) handle.env + extraEnv else handle.env
+		val finalArgs = listOf("git") + GIT_HARDENING_CONFIG + args
+		log.debug("git %s (cwd=%s)", (GIT_HARDENING_CONFIG + args).joinToString(" "), cwd ?: "<inherited>")
+		return processRunner.exec(finalArgs, cwd, env, timeoutMs)
+	}
+
+	private fun runExpectOk(
+		args: List<String>,
+		cwdOverride: CwdOverride = UseVaultRoot,
+		extraEnv: Map<String, String> = emptyMap(),
+		timeoutMs: Long? = null,
+	): ExecResult {
+		val result = run(args, cwdOverride, extraEnv, timeoutMs)
+		if (result.exitCode != 0) {
+			throw RuntimeException(
+				"git ${args.joinToString(" ")} exit=${result.exitCode}: ${
+					result.stderr.ifEmpty { result.stdout.ifEmpty { "(no output)" } }
+				}"
+			)
+		}
+		return result
+	}
+}
+
+// ── Types ─────────────────────────────────────────────────────────────
+
+/** Raw result from a git process invocation. */
+data class ExecResult(val stdout: String, val stderr: String, val exitCode: Int)
+
+/** Result of `git pull --rebase`. */
+data class PullResult(val fastForwarded: Boolean, val conflicted: List<String>)
+
+/** Result of `git push`. */
+sealed class PushResult {
+	data class Ok(val transmitted: Boolean) : PushResult()
+	data class Failed(
+		val nonFastForward: Boolean,
+		val unauthorized: Boolean,
+		val repoMissing: Boolean,
+		val message: String,
+	) : PushResult()
+}
+
+/** Per-path unmerged-stage map from `git ls-files -u`. */
+data class UnmergedEntry(val path: String, val stages: Set<Int>)
+
+/** Author identity for commits. */
+data class CommitAuthor(val name: String, val email: String)
+
+/** Sealed marker for cwd override in [SyncGitClient.run]. */
+sealed interface CwdOverride
+private data object UseVaultRoot : CwdOverride
+private data object UseNoWorkDir : CwdOverride
+
+/** Result of [SyncGitClient.checkGitInstalled]. */
+sealed class GitVersionResult {
+	data class Ok(val version: String) : GitVersionResult()
+	data object NotFound : GitVersionResult()
+}
+
+/**
+ * Abstraction over process execution for testability. The real implementation
+ * uses ProcessBuilder; tests inject a fake that returns canned responses.
+ */
+interface ProcessRunner {
+	fun exec(
+		command: List<String>,
+		cwd: String?,
+		env: Map<String, String>,
+		timeoutMs: Long?,
+	): ExecResult
+}
+
+/**
+ * Real implementation that spawns a child process via ProcessBuilder.
+ * Reads stdout on a CompletableFuture to avoid pipe deadlock.
+ */
+class RealProcessRunner : ProcessRunner {
+	override fun exec(
+		command: List<String>,
+		cwd: String?,
+		env: Map<String, String>,
+		timeoutMs: Long?,
+	): ExecResult {
+		return try {
+			val pb = ProcessBuilder(command)
+			if (cwd != null) pb.directory(File(cwd))
+			pb.redirectErrorStream(false)
+			pb.environment().clear()
+			pb.environment().putAll(env)
+
+			val process = pb.start()
+
+			// Read stdout on a separate thread to avoid pipe buffer deadlock.
+			val stdoutFuture = CompletableFuture.supplyAsync {
+				process.inputStream.bufferedReader(Charsets.UTF_8).use { it.readText() }
+			}
+
+			val timeout = timeoutMs ?: 600_000L // 10 min default for network ops
+			val completed = process.waitFor(timeout, TimeUnit.MILLISECONDS)
+			if (!completed) {
+				process.destroyForcibly()
+				stdoutFuture.cancel(true)
+				return ExecResult(
+					stdout = "",
+					stderr = "git ${command.drop(1).joinToString(" ")} timed out after ${timeout}ms",
+					exitCode = 1,
+				)
+			}
+
+			val stderr = process.errorStream.bufferedReader(Charsets.UTF_8).use { it.readText() }
+			val stdout = stdoutFuture.get(5, TimeUnit.SECONDS) ?: ""
+
+			ExecResult(stdout = stdout, stderr = stderr, exitCode = process.exitValue())
+		} catch (e: Exception) {
+			ExecResult(stdout = "", stderr = e.message ?: "unknown error", exitCode = 1)
+		}
+	}
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────
+
+/**
+ * Injects `x-access-token@` as the URL username for `https://` URLs so
+ * GitHub's auth flow treats us as a GitHub App. Idempotent.
+ */
+internal fun injectGithubAppUsername(url: String): String {
+	val match = Regex("^(https://)(?:([^@/]+)@)?(.+)$").find(url) ?: return url
+	if (match.groupValues[2].isNotEmpty()) return url // Already has username
+	return "${match.groupValues[1]}x-access-token@${match.groupValues[3]}"
+}
+
+/**
+ * Splits paths into batches whose joined character length stays under budget.
+ * A single path longer than budget ships as its own batch.
+ */
+internal fun chunkByBudget(paths: List<String>, budget: Int): List<List<String>> {
+	val result = mutableListOf<List<String>>()
+	var batch = mutableListOf<String>()
+	var used = 0
+	for (p in paths) {
+		val cost = p.length + 1
+		if (batch.isNotEmpty() && used + cost > budget) {
+			result.add(batch)
+			batch = mutableListOf()
+			used = 0
+		}
+		batch.add(p)
+		used += cost
+	}
+	if (batch.isNotEmpty()) result.add(batch)
+	return result
+}
+
+/**
+ * Recursively collects every `*.lock` file path under [root].
+ * Returns empty list when root doesn't exist.
+ */
+private fun collectLockFiles(root: File): List<File> {
+	val out = mutableListOf<File>()
+	val entries = root.listFiles() ?: return out
+	for (entry in entries) {
+		if (entry.isDirectory) {
+			out.addAll(collectLockFiles(entry))
+		} else if (entry.isFile && entry.name.endsWith(".lock")) {
+			out.add(entry)
+		}
+	}
+	return out
+}

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/sync/SyncGitClient.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/sync/SyncGitClient.kt
@@ -572,9 +572,16 @@ class RealProcessRunner : ProcessRunner {
 
 			val process = pb.start()
 
-			// Read stdout on a separate thread to avoid pipe buffer deadlock.
+			// Drain BOTH stdout and stderr concurrently to avoid a pipe-buffer
+			// deadlock. A git command that fills either pipe (fetch/push/clone
+			// progress, or a large error dump) blocks on its write until the pipe is
+			// drained; reading stderr only after waitFor() could hang the child — and
+			// thus this call — until the (up to 10-minute) timeout fires.
 			val stdoutFuture = CompletableFuture.supplyAsync {
 				process.inputStream.bufferedReader(Charsets.UTF_8).use { it.readText() }
+			}
+			val stderrFuture = CompletableFuture.supplyAsync {
+				process.errorStream.bufferedReader(Charsets.UTF_8).use { it.readText() }
 			}
 
 			val timeout = timeoutMs ?: 600_000L // 10 min default for network ops
@@ -582,6 +589,7 @@ class RealProcessRunner : ProcessRunner {
 			if (!completed) {
 				process.destroyForcibly()
 				stdoutFuture.cancel(true)
+				stderrFuture.cancel(true)
 				return ExecResult(
 					stdout = "",
 					stderr = "git ${command.drop(1).joinToString(" ")} timed out after ${timeout}ms",
@@ -589,8 +597,8 @@ class RealProcessRunner : ProcessRunner {
 				)
 			}
 
-			val stderr = process.errorStream.bufferedReader(Charsets.UTF_8).use { it.readText() }
 			val stdout = stdoutFuture.get(5, TimeUnit.SECONDS) ?: ""
+			val stderr = stderrFuture.get(5, TimeUnit.SECONDS) ?: ""
 
 			ExecResult(stdout = stdout, stderr = stderr, exitCode = process.exitValue())
 		} catch (e: Exception) {

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/sync/SyncLock.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/sync/SyncLock.kt
@@ -1,0 +1,67 @@
+package ai.jolli.jollimemory.sync
+
+import java.nio.file.Files
+import java.nio.file.Path
+
+/**
+ * Global per-user lock for Memory Bank sync rounds.
+ *
+ * Port of `cli/src/sync/SyncLock.ts`.
+ *
+ * Lives at `~/.jolli/jollimemory/sync.lock` and serializes sync rounds
+ * across all worktrees and the long-lived plugin watcher for a single user.
+ * Only one sync round runs at a time, machine-wide.
+ */
+
+data class SyncLockOpts(
+	val timeoutMs: Long = SyncLock.DEFAULT_TIMEOUT_MS,
+	val pollMs: Long = SyncLock.DEFAULT_POLL_MS,
+)
+
+object SyncLock {
+
+	const val DEFAULT_TIMEOUT_MS = 10_000L
+	const val DEFAULT_POLL_MS = 100L
+	private const val SYNC_LOCK_FILE = "sync.lock"
+
+	/**
+	 * Returns the absolute path to `sync.lock`.
+	 * Respects `JOLLI_SYNC_LOCK_DIR` env override for test isolation.
+	 */
+	fun getSyncLockPath(): Path {
+		val override = System.getenv("JOLLI_SYNC_LOCK_DIR")
+		val dir = if (!override.isNullOrEmpty()) {
+			Path.of(override)
+		} else {
+			Path.of(System.getProperty("user.home"), ".jolli", "jollimemory")
+		}
+		return dir.resolve(SYNC_LOCK_FILE)
+	}
+
+	/**
+	 * Acquires `sync.lock`, waiting up to [opts] timeout. Returns true on
+	 * success, false on timeout. Creates parent directory if needed.
+	 */
+	fun acquire(opts: SyncLockOpts = SyncLockOpts()): Boolean {
+		val lockPath = getSyncLockPath()
+		Files.createDirectories(lockPath.parent)
+		return LockPrimitives.acquireWithPoll(lockPath, opts.timeoutMs, opts.pollMs)
+	}
+
+	/**
+	 * Releases `sync.lock` — only if the lock file's PID matches us.
+	 */
+	fun release() {
+		LockPrimitives.releaseIfOwned(getSyncLockPath(), "sync.lock")
+	}
+
+	/** Bumps mtime so a long-running round doesn't get reclaimed. */
+	fun refreshMtime() {
+		LockPrimitives.refreshLockMtime(getSyncLockPath())
+	}
+
+	/** Returns true when `sync.lock` exists and is fresh. */
+	fun isHeld(): Boolean {
+		return LockPrimitives.isLockHeld(getSyncLockPath())
+	}
+}

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/sync/SyncOrchestrator.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/sync/SyncOrchestrator.kt
@@ -78,7 +78,11 @@ class SyncOrchestrator(private val opts: SyncOrchestratorOpts) {
 			val gen = pollGeneration.incrementAndGet()
 
 			if (shouldFireEagerTick()) {
-				opts.timer.submit { tick("poll", null) }
+				// Pass the current generation (not null) so a stop() racing in
+				// between cancels this queued eager tick — matching the TS source.
+				// A null generation would make it an always-proceed manual tick,
+				// reintroducing an unwanted round after auto-sync is toggled off.
+				opts.timer.submit { tick("poll", gen) }
 			}
 
 			pollHandle = opts.timer.scheduleAtFixedRate(

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/sync/SyncOrchestrator.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/sync/SyncOrchestrator.kt
@@ -1,0 +1,273 @@
+package ai.jolli.jollimemory.sync
+
+import ai.jolli.jollimemory.core.JmLogger
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.Executors
+import java.util.concurrent.RejectedExecutionException
+import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.ScheduledFuture
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicLong
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.concurrent.withLock
+
+/**
+ * Constructor options for [SyncOrchestrator].
+ */
+data class SyncOrchestratorOpts(
+	val engine: SyncEngine,
+	val cwd: String,
+	val pollIntervalSec: Int? = null,
+	val onStateChange: (SyncState, SyncStatusDetail?) -> Unit = { _, _ -> },
+	val onRoundFinished: ((SyncState, SyncRoundResult) -> Unit)? = null,
+	val readyGate: CompletableFuture<Unit>? = null,
+	val lastSuccessAtMs: AtomicLong = AtomicLong(0),
+	val eagerTickMinElapsedMs: Long = DEFAULT_EAGER_TICK_MIN_ELAPSED_MS,
+	val timer: ScheduledExecutorService = Executors.newSingleThreadScheduledExecutor { r ->
+		Thread(r, "JolliMemory-SyncOrchestrator").apply { isDaemon = true }
+	},
+	val syncTranscripts: () -> Boolean = { false },
+)
+
+/**
+ * Drives [SyncEngine.runRound] on a timer with coalescing, generation-based
+ * cancellation, and eager-tick-on-startup logic.
+ *
+ * Port of `vscode/src/sync/StatusOrchestrator.ts`.
+ */
+class SyncOrchestrator(private val opts: SyncOrchestratorOpts) {
+
+	private val log = JmLogger.create("SyncOrchestrator")
+	private val pollMs = clampPoll(opts.pollIntervalSec).toLong() * 1000L
+	private val lock = ReentrantLock()
+
+	// ── Generation-based cancellation ────────────────────────────────────
+	private val pollGeneration = AtomicInteger(0)
+
+	// ── Coalescing ───────────────────────────────────────────────────────
+	private var currentRound: CompletableFuture<Unit>? = null
+	private val pendingManualFollowup = AtomicBoolean(false)
+
+	// ── Polling handle ───────────────────────────────────────────────────
+	private var pollHandle: ScheduledFuture<*>? = null
+
+	// ── State tracking ───────────────────────────────────────────────────
+	@Volatile
+	private var lastState: SyncState = SyncState.SYNCED
+	private val disposed = AtomicBoolean(false)
+
+	/** Whether the polling loop is active. */
+	val isPolling: Boolean get() = lock.withLock { pollHandle != null }
+
+	/** Most recent [SyncState] observed after a round. */
+	val lastObservedState: SyncState get() = lastState
+
+	// ── Lifecycle ────────────────────────────────────────────────────────
+
+	/**
+	 * Start the polling loop.  Idempotent — calling while already polling
+	 * is a no-op.
+	 */
+	fun start() {
+		if (disposed.get()) return
+		log.info("start: beginning poll loop, interval=${pollMs}ms")
+		lock.withLock {
+			if (pollHandle != null) return
+			val gen = pollGeneration.incrementAndGet()
+
+			if (shouldFireEagerTick()) {
+				opts.timer.submit { tick("poll", null) }
+			}
+
+			pollHandle = opts.timer.scheduleAtFixedRate(
+				{ tick("poll", gen) },
+				pollMs, pollMs, TimeUnit.MILLISECONDS,
+			)
+		}
+	}
+
+	/**
+	 * Stop polling.  Does **not** dispose — [syncNow] still works after
+	 * stop.  Bumps [pollGeneration] so any queued poll tick will bail.
+	 */
+	fun stop() {
+		lock.withLock {
+			pollHandle?.cancel(false)
+			pollHandle = null
+			pollGeneration.incrementAndGet()
+		}
+	}
+
+	/**
+	 * Manual sync — fires immediately, bypasses generation check.
+	 */
+	fun syncNow() {
+		if (disposed.get()) {
+			log.debug("syncNow: ignored — orchestrator disposed")
+			return
+		}
+		log.info("syncNow: submitting manual tick")
+		try {
+			opts.timer.submit { tick("manual", null) }
+		} catch (_: RejectedExecutionException) {
+			// dispose() raced with this call and shut the timer down — manual
+			// sync becomes a no-op rather than surfacing an executor error.
+		}
+	}
+
+	/**
+	 * Smart manual sync entry point.  If no round is in flight, fires
+	 * immediately.  If a round is running, sets the followup latch so a
+	 * manual tick fires as soon as the current round completes.
+	 */
+	fun requestManualSync(): CompletableFuture<Unit> {
+		log.info("requestManualSync: manual sync requested")
+		val result = CompletableFuture<Unit>()
+		if (disposed.get()) {
+			log.debug("requestManualSync: ignored — orchestrator disposed")
+			result.complete(Unit)
+			return result
+		}
+		try {
+			opts.timer.submit {
+				try {
+					val existing = lock.withLock { currentRound }
+					if (existing == null) {
+						log.debug("requestManualSync: no round in flight, firing immediately")
+						tick("manual", null)
+					} else {
+						log.debug("requestManualSync: round in flight, setting followup latch")
+						pendingManualFollowup.set(true)
+						try { existing.join() } catch (_: Exception) {}
+						// If the followup produced a new round, await that too.
+						val followup = lock.withLock { currentRound }
+						if (followup != null) {
+							try { followup.join() } catch (_: Exception) {}
+						}
+					}
+					result.complete(Unit)
+				} catch (e: Exception) {
+					result.completeExceptionally(e)
+				}
+			}
+		} catch (_: RejectedExecutionException) {
+			// dispose() raced with this call — resolve as a no-op.
+			result.complete(Unit)
+		}
+		return result
+	}
+
+	/** Whether a round is currently executing. */
+	fun isRoundInFlight(): Boolean = lock.withLock { currentRound != null }
+
+	/**
+	 * Permanently shut down this orchestrator.  Stops polling and shuts
+	 * down the timer executor.
+	 */
+	fun dispose() {
+		if (disposed.getAndSet(true)) return
+		stop()
+		opts.timer.shutdownNow()
+	}
+
+	// ── Core tick ────────────────────────────────────────────────────────
+
+	/**
+	 * Execute one sync round.  Handles coalescing, ready-gate, and
+	 * generation-based cancellation.
+	 */
+	private fun tick(reason: String, queuedGeneration: Int?) {
+		if (disposed.get()) return
+		log.debug("tick($reason) starting, generation=$queuedGeneration")
+
+		// Coalescing: if a round is already running, wait for it.
+		val existing = lock.withLock { currentRound }
+		if (existing != null) {
+			log.debug("tick($reason) coalesced — round already in flight")
+			try { existing.join() } catch (_: Exception) {}
+			return
+		}
+
+		val preTickState = lastState
+		setState(SyncState.SYNCING, null)
+
+		val future = CompletableFuture<Unit>()
+		lock.withLock { currentRound = future }
+
+		try {
+			// Await KB init gate.
+			if (opts.readyGate != null) {
+				try {
+					opts.readyGate.join()
+				} catch (e: Exception) {
+					log.warn("readyGate failed: ${e.stackTraceToString()}")
+				}
+			}
+
+			// Generation check: bail if stop() was called since this tick
+			// was queued.  Manual ticks pass null and always proceed.
+			if (queuedGeneration != null && queuedGeneration != pollGeneration.get()) {
+				setState(preTickState, null)
+				return
+			}
+
+			val result = opts.engine.runRound(
+				SyncRoundOptions(
+					cwd = opts.cwd,
+					reason = reason,
+					transcripts = opts.syncTranscripts(),
+				),
+			)
+
+			val detail = buildDetail(result)
+			setState(result.newState, detail)
+
+			if (result.newState == SyncState.SYNCED) {
+				opts.lastSuccessAtMs.set(System.currentTimeMillis())
+			}
+
+			fireRoundFinished(result.newState, result)
+		} catch (e: Exception) {
+			log.error("tick($reason) failed: ${e.stackTraceToString()}")
+			val syntheticResult = SyncRoundResult(
+				fetched = false, pulled = false, pushed = false,
+				newState = SyncState.OFFLINE,
+				lastError = SyncRoundError(
+					code = SyncErrorCode.SYNC_FAILED_AFTER_RETRIES,
+					message = e.message ?: "unknown error",
+				),
+			)
+			val detail = buildDetail(syntheticResult)
+			setState(SyncState.OFFLINE, detail)
+			fireRoundFinished(SyncState.OFFLINE, syntheticResult)
+		} finally {
+			future.complete(Unit)
+			lock.withLock { currentRound = null }
+		}
+
+		// P3-A followup: if someone clicked manual sync while the round
+		// was running, fire another tick now.
+		if (pendingManualFollowup.getAndSet(false) && !disposed.get()) {
+			tick("manual", null)
+		}
+	}
+
+	// ── Helpers ──────────────────────────────────────────────────────────
+
+	private fun shouldFireEagerTick(): Boolean {
+		val last = opts.lastSuccessAtMs.get()
+		if (last == 0L) return true
+		return System.currentTimeMillis() - last >= opts.eagerTickMinElapsedMs
+	}
+
+	private fun setState(state: SyncState, detail: SyncStatusDetail?) {
+		lastState = state
+		try { opts.onStateChange(state, detail) } catch (_: Exception) {}
+	}
+
+	private fun fireRoundFinished(state: SyncState, result: SyncRoundResult) {
+		try { opts.onRoundFinished?.invoke(state, result) } catch (_: Exception) {}
+	}
+}

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/sync/SyncStatusBarWidget.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/sync/SyncStatusBarWidget.kt
@@ -1,0 +1,120 @@
+package ai.jolli.jollimemory.sync
+
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.wm.StatusBar
+import com.intellij.openapi.wm.StatusBarWidget
+import com.intellij.openapi.wm.ToolWindowManager
+import com.intellij.util.Consumer
+import java.awt.event.MouseEvent
+
+/**
+ * Status bar widget showing the current Memory Bank sync state.
+ *
+ * Four-state machine driven by [setSyncState]:
+ * - **SYNCED** — "✓ Jolli Memory"
+ * - **SYNCING** — "⟳ Syncing…"
+ * - **CONFLICTS** — "⚠ N conflicts"
+ * - **OFFLINE** — terminal error text or neutral fallback
+ *
+ * Port of the sync state machine from `vscode/src/util/StatusBarManager.ts`.
+ */
+class SyncStatusBarWidget(private val project: Project) : StatusBarWidget, StatusBarWidget.TextPresentation {
+
+	companion object {
+		const val ID = "JolliSyncStatus"
+	}
+
+	private var statusBar: StatusBar? = null
+	@Volatile
+	private var currentState: SyncState = SyncState.SYNCED
+	@Volatile
+	private var currentDetail: SyncStatusDetail? = null
+	@Volatile
+	private var displayText: String = "Jolli Memory"
+	@Volatile
+	private var tooltipText: String = "Jolli Memory — click to open sidebar"
+
+	fun setSyncState(state: SyncState, detail: SyncStatusDetail? = null) {
+		currentState = state
+		currentDetail = detail
+
+		when (state) {
+			SyncState.SYNCED -> {
+				displayText = "✓ Jolli Memory"
+				tooltipText = "Memory Bank in sync"
+			}
+			SyncState.SYNCING -> {
+				displayText = "⟳ Syncing…"
+				tooltipText = "Memory Bank sync in progress"
+			}
+			SyncState.CONFLICTS -> {
+				val count = detail?.conflictCount
+				displayText = if (count != null) "⚠ $count conflicts" else "⚠ Conflicts"
+				tooltipText = if (count != null) "$count items need your attention" else "Conflicts need your attention"
+			}
+			SyncState.OFFLINE -> {
+				if (detail?.failed == true && detail.failedCode != null) {
+					val visual = terminalCodeVisual(detail.failedCode, detail)
+					displayText = visual.text
+					tooltipText = visual.headline
+				} else {
+					displayText = "Jolli Memory"
+					tooltipText = "Jolli Memory — click to open sidebar"
+				}
+			}
+		}
+
+		statusBar?.updateWidget(ID)
+	}
+
+	// ── StatusBarWidget ──────────────────────────────────────────────────
+
+	override fun ID(): String = ID
+
+	override fun install(statusBar: StatusBar) {
+		this.statusBar = statusBar
+	}
+
+	override fun dispose() {
+		statusBar = null
+	}
+
+	// ── StatusBarWidget.TextPresentation ─────────────────────────────────
+
+	override fun getText(): String = displayText
+
+	override fun getTooltipText(): String = tooltipText
+
+	override fun getAlignment(): Float = java.awt.Component.LEFT_ALIGNMENT
+
+	override fun getClickConsumer(): Consumer<MouseEvent> = Consumer {
+		val tw = ToolWindowManager.getInstance(project).getToolWindow("JOLLI")
+		tw?.show()
+	}
+
+	// ── Terminal error visuals ───────────────────────────────────────────
+
+	private data class TerminalVisual(val text: String, val headline: String)
+
+	private fun terminalCodeVisual(code: SyncErrorCode, detail: SyncStatusDetail): TerminalVisual {
+		return when (code) {
+			SyncErrorCode.VAULT_LOCKED -> {
+				val headline = if (detail.selfLocked) {
+					"Your previous sync failed — waiting for lock to expire"
+				} else {
+					"Personal Space is being synced by another device"
+				}
+				TerminalVisual("⚠ Personal Space busy", headline)
+			}
+			SyncErrorCode.LOCALFOLDER_INVALID -> {
+				TerminalVisual("✗ Memory Bank folder invalid", "Update the Memory Bank folder in Settings")
+			}
+			SyncErrorCode.PUSH_REJECTED -> {
+				TerminalVisual("✗ Push rejected", "Memory Bank sync failed")
+			}
+			else -> {
+				TerminalVisual("✗ Sync failed", "Memory Bank sync failed")
+			}
+		}
+	}
+}

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/sync/SyncStatusBarWidgetFactory.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/sync/SyncStatusBarWidgetFactory.kt
@@ -1,0 +1,23 @@
+package ai.jolli.jollimemory.sync
+
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.wm.StatusBar
+import com.intellij.openapi.wm.StatusBarWidget
+import com.intellij.openapi.wm.StatusBarWidgetFactory
+
+/**
+ * Factory that registers [SyncStatusBarWidget] with IntelliJ's status bar.
+ *
+ * Declared in `plugin.xml` as a `<statusBarWidgetFactory>` extension.
+ */
+class SyncStatusBarWidgetFactory : StatusBarWidgetFactory {
+
+	override fun getId(): String = SyncStatusBarWidget.ID
+
+	override fun getDisplayName(): String = "Jolli Memory Sync"
+
+	override fun createWidget(project: Project): StatusBarWidget =
+		SyncStatusBarWidget(project)
+
+	override fun isAvailable(project: Project): Boolean = true
+}

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/sync/SyncStatusDetail.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/sync/SyncStatusDetail.kt
@@ -1,0 +1,69 @@
+package ai.jolli.jollimemory.sync
+
+import kotlin.math.max
+import kotlin.math.min
+
+/** Status bar detail accompanying a [SyncState] update. */
+data class SyncStatusDetail(
+	val conflictCount: Int? = null,
+	val lastError: String? = null,
+	val failed: Boolean = false,
+	val failedCode: SyncErrorCode? = null,
+	val selfLocked: Boolean = false,
+)
+
+/** Minimum poll interval: 90 minutes. */
+const val MIN_POLL_SEC: Int = 90 * 60
+
+/** Maximum poll interval: 24 hours. */
+const val MAX_POLL_SEC: Int = 86_400
+
+/** Default poll interval: 90 minutes. */
+const val DEFAULT_POLL_SEC: Int = 90 * 60
+
+/** Default eager-tick threshold: 30 minutes. */
+const val DEFAULT_EAGER_TICK_MIN_ELAPSED_MS: Long = 30 * 60_000L
+
+/** Clamp a user-supplied poll interval to [MIN_POLL_SEC]..[MAX_POLL_SEC]. */
+fun clampPoll(value: Int?): Int {
+	if (value == null || value <= 0) return DEFAULT_POLL_SEC
+	return max(MIN_POLL_SEC, min(MAX_POLL_SEC, value))
+}
+
+/**
+ * Build a [SyncStatusDetail] from a [SyncRoundResult], or null if there is
+ * nothing interesting to surface.
+ */
+fun buildDetail(result: SyncRoundResult): SyncStatusDetail? {
+	var conflictCount: Int? = null
+	var lastError: String? = null
+	var failed = false
+	var failedCode: SyncErrorCode? = null
+	var selfLocked = false
+
+	if (result.conflicts.isNotEmpty()) {
+		conflictCount = result.conflicts.size
+	}
+
+	val err = result.lastError
+	if (err != null && !err.code.isTransient) {
+		lastError = err.message
+		failed = true
+		failedCode = err.code
+	}
+
+	if (err?.selfLocked == true) {
+		selfLocked = true
+	}
+
+	// Nothing interesting — return null so the status bar can use defaults.
+	if (conflictCount == null && lastError == null && !selfLocked) return null
+
+	return SyncStatusDetail(
+		conflictCount = conflictCount,
+		lastError = lastError,
+		failed = failed,
+		failedCode = failedCode,
+		selfLocked = selfLocked,
+	)
+}

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/sync/SyncTypes.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/sync/SyncTypes.kt
@@ -1,0 +1,70 @@
+package ai.jolli.jollimemory.sync
+
+/** UI-facing sync state persisted between rounds. */
+enum class SyncState { SYNCED, SYNCING, CONFLICTS, OFFLINE }
+
+/** Stable error codes. NETWORK is transient; all others are terminal. */
+enum class SyncErrorCode {
+	NETWORK,
+	MINT_FAILED,
+	VAULT_LOCKED,
+	VAULT_MISMATCH,
+	LOCALFOLDER_INVALID,
+	PUSH_REJECTED,
+	GIT_MISSING,
+	CLONE_FAILED,
+	FETCH_FAILED,
+	PULL_FAILED,
+	MIGRATION_FAILED,
+	SYNC_FAILED_AFTER_RETRIES;
+
+	val isTransient: Boolean get() = this == NETWORK
+}
+
+/** Granular progress phase within a running round. */
+enum class SyncPhase { DOWNLOADING, MERGING, RESOLVING, UPLOADING, WAITING }
+
+/** Caller-supplied options for [SyncEngine.runRound]. */
+data class SyncRoundOptions(
+	val cwd: String,
+	val reason: String,
+	val transcripts: Boolean,
+)
+
+/** Immutable per-round context resolved from [SyncRoundOptions]. */
+data class RoundContext(
+	val memoryBankRoot: String,
+	val repoFolderName: String,
+	val repoIdentity: String,
+	val author: CommitAuthor,
+)
+
+data class SyncRoundError(
+	val code: SyncErrorCode,
+	val message: String,
+	val selfLocked: Boolean? = null,
+)
+
+data class CanaryReport(
+	val symlinked: List<String>,
+	val unowned: List<String>,
+)
+
+data class SyncRoundResult(
+	val fetched: Boolean,
+	val pulled: Boolean,
+	val pushed: Boolean,
+	val conflicts: List<String> = emptyList(),
+	val newState: SyncState,
+	val lastError: SyncRoundError? = null,
+	val canary: CanaryReport? = null,
+)
+
+/** Emitted by [SyncEngine] when a 423 vault_locked retry backoff begins. */
+data class VaultLockedWaitInfo(
+	val attempt: Int,
+	val totalAttempts: Int,
+	val nextRetryInMs: Long,
+	val message: String,
+	val selfLocked: Boolean,
+)

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/sync/VaultLockPath.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/sync/VaultLockPath.kt
@@ -1,0 +1,106 @@
+package ai.jolli.jollimemory.sync
+
+import java.io.File
+import java.nio.file.Files
+import java.nio.file.Path
+import java.security.MessageDigest
+
+/**
+ * Path derivation for `vault-write.lock` — the per-vault writer lock.
+ *
+ * Port of `cli/src/sync/VaultLockPath.ts`.
+ *
+ * Lock location: `~/.jolli/jollimemory/locks/vault-<sha256(canonical)>.lock`.
+ */
+
+private val isWindows = System.getProperty("os.name").lowercase().contains("win")
+private val isMac = System.getProperty("os.name").lowercase().contains("mac")
+private val isCaseInsensitive = isWindows || isMac
+
+/**
+ * Canonicalises a local folder path into a stable identifier suitable for
+ * hashing into the lock filename.
+ *
+ * Steps:
+ *   1. Expand leading `~` to the user's home directory.
+ *   2. Resolve to a lexical absolute path.
+ *   3. Walk up to the nearest existing ancestor and realpath it, then
+ *      re-append the non-existent tail segments.
+ *   4. Case-fold on case-insensitive filesystems (Windows, macOS).
+ *   5. Normalize separators to platform native, collapse duplicates,
+ *      trim trailing separator.
+ */
+fun canonicaliseLocalFolder(s: String): String {
+	require(s.isNotEmpty()) { "canonicaliseLocalFolder: empty input" }
+
+	// Step 1 — tilde expansion.
+	var p = s
+	val home = System.getProperty("user.home")
+	if (p == "~") {
+		p = home
+	} else if (p.startsWith("~/") || p.startsWith("~\\")) {
+		p = home + p.substring(1)
+	}
+
+	// Step 2 — resolve to absolute.
+	p = Path.of(p).toAbsolutePath().normalize().toString()
+
+	// Step 3 — realpath nearest existing ancestor.
+	p = resolvePartialRealpath(p)
+
+	// Step 4 — case-fold on case-insensitive filesystems.
+	if (isCaseInsensitive) {
+		p = p.lowercase()
+	}
+
+	// Step 5 — collapse duplicate separators, trim trailing.
+	p = p.replace(Regex("[/\\\\]+"), File.separator)
+	if (p.length > 1 && p.endsWith(File.separator)) {
+		p = p.dropLast(1)
+	}
+
+	return p
+}
+
+/**
+ * Walks up [p] to the nearest existing ancestor, realpaths it (resolving
+ * symlinks), and re-appends the non-existent tail segments.
+ */
+private fun resolvePartialRealpath(p: String): String {
+	val tail = mutableListOf<String>()
+	var cur = Path.of(p)
+	while (true) {
+		if (Files.exists(cur)) {
+			val real = cur.toRealPath().toString()
+			return if (tail.isEmpty()) real else {
+				var result = real
+				for (seg in tail) {
+					result = result + File.separator + seg
+				}
+				result
+			}
+		}
+		val parent = cur.parent ?: return p
+		if (parent == cur) return p
+		tail.add(0, cur.fileName.toString())
+		cur = parent
+	}
+}
+
+/**
+ * Returns the absolute path to the vault-write lock file for the given
+ * [vaultRoot]. Respects `JOLLI_VAULT_LOCK_DIR` env override.
+ */
+fun getVaultWriteLockPath(vaultRoot: String): Path {
+	val override = System.getenv("JOLLI_VAULT_LOCK_DIR")
+	val dir = if (!override.isNullOrEmpty()) {
+		Path.of(override)
+	} else {
+		Path.of(System.getProperty("user.home"), ".jolli", "jollimemory", "locks")
+	}
+	val canonical = canonicaliseLocalFolder(vaultRoot)
+	val hash = MessageDigest.getInstance("SHA-256")
+		.digest(canonical.toByteArray())
+		.joinToString("") { "%02x".format(it) }
+	return dir.resolve("vault-$hash.lock")
+}

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/sync/VaultMarker.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/sync/VaultMarker.kt
@@ -1,0 +1,142 @@
+package ai.jolli.jollimemory.sync
+
+import com.google.gson.Gson
+import com.google.gson.JsonObject
+import java.io.File
+import java.nio.file.Files
+import java.nio.file.Path
+import java.time.Instant
+
+/**
+ * Vault identity marker — proves that `<memoryBankRoot>/.git/` belongs to the
+ * Jolli sync engine and points at the expected personal-space repo.
+ *
+ * Port of `cli/src/sync/VaultMarker.ts`.
+ */
+
+/** Path of the marker relative to `<memoryBankRoot>`. Inside `.git/` on purpose. */
+val VAULT_MARKER_REL_PATH: String = ".git${File.separator}jolli-vault-identity.json"
+
+data class VaultMarkerData(
+	val kind: String,
+	val version: Int,
+	val createdAt: String,
+	val gitUrl: String,
+	val repoFullName: String,
+	val defaultBranch: String,
+)
+
+sealed class VaultVerdict {
+	data class Ok(val needsRewrite: Boolean = false) : VaultVerdict()
+	data class Failed(val reason: String, val message: String) : VaultVerdict()
+}
+
+/**
+ * Hosts whose owner/repo path is case-insensitive (GitHub, GitLab, Bitbucket).
+ */
+private val CASE_INSENSITIVE_PATH_HOSTS = setOf("github.com", "gitlab.com", "bitbucket.org")
+
+private val GIT_URL_REGEX = Regex("^(https://)(?:[^@/]+@)?([^/]+)(/.+?)/?$", RegexOption.IGNORE_CASE)
+
+/**
+ * Normalizes a git URL for safe comparison. Strips auth, trailing `.git`,
+ * trailing slash. Lowercases host always; lowercases path only for
+ * case-insensitive forges.
+ */
+fun normalizeGitUrl(url: String): String {
+	val trimmed = url.trim()
+	val match = GIT_URL_REGEX.find(trimmed) ?: return trimmed
+	val scheme = match.groupValues[1].lowercase()
+	val host = match.groupValues[2].lowercase()
+	var path = match.groupValues[3]
+	if (path.lowercase().endsWith(".git")) {
+		path = path.dropLast(4)
+	}
+	if (host in CASE_INSENSITIVE_PATH_HOSTS) {
+		path = path.lowercase()
+	}
+	return "$scheme$host$path"
+}
+
+private val gson = Gson()
+
+/**
+ * Writes (or rewrites) the marker for [memoryBankRoot]. Idempotent.
+ */
+fun writeVaultMarker(memoryBankRoot: String, creds: GitCredentials) {
+	val path = Path.of(memoryBankRoot, VAULT_MARKER_REL_PATH)
+	Files.createDirectories(path.parent)
+	val marker = JsonObject().apply {
+		addProperty("kind", "jolli-memory-bank")
+		addProperty("version", 1)
+		addProperty("createdAt", Instant.now().toString())
+		addProperty("gitUrl", normalizeGitUrl(creds.gitUrl))
+		addProperty("repoFullName", creds.repoFullName)
+		addProperty("defaultBranch", creds.defaultBranch)
+	}
+	Files.writeString(path, gson.toJson(marker) + "\n")
+}
+
+/**
+ * Reads the marker if present and well-formed. Returns null for any error.
+ */
+fun readVaultMarker(memoryBankRoot: String): VaultMarkerData? {
+	return try {
+		val raw = Files.readString(Path.of(memoryBankRoot, VAULT_MARKER_REL_PATH))
+		val parsed = gson.fromJson(raw, JsonObject::class.java) ?: return null
+		val kind = parsed.get("kind")?.asString ?: return null
+		val version = parsed.get("version")?.asInt ?: return null
+		if (kind != "jolli-memory-bank" || version != 1) return null
+		val gitUrl = parsed.get("gitUrl")?.asString
+		if (gitUrl.isNullOrEmpty()) return null
+		VaultMarkerData(
+			kind = kind,
+			version = version,
+			createdAt = parsed.get("createdAt")?.asString ?: "",
+			gitUrl = gitUrl,
+			repoFullName = parsed.get("repoFullName")?.asString ?: "",
+			defaultBranch = parsed.get("defaultBranch")?.asString ?: "",
+		)
+	} catch (_: Exception) {
+		null
+	}
+}
+
+/**
+ * Verifies that [memoryBankRoot] carries a marker that matches the freshly-
+ * minted credentials. Both marker URL and live origin URL must match.
+ */
+fun verifyVaultMarker(memoryBankRoot: String, originUrl: String?, creds: GitCredentials): VaultVerdict {
+	val marker = readVaultMarker(memoryBankRoot) ?: return VaultVerdict.Failed(
+		reason = "missing_marker",
+		message = "$memoryBankRoot already contains a .git directory but no Jolli vault marker. Refusing to write — pick a different Memory Bank folder.",
+	)
+
+	val expected = normalizeGitUrl(creds.gitUrl)
+	val storedNormalized = normalizeGitUrl(marker.gitUrl)
+	if (storedNormalized != expected) {
+		return VaultVerdict.Failed(
+			reason = "url_mismatch",
+			message = "Vault marker remembers ${marker.gitUrl} but credentials point at $expected. Refusing to write.",
+		)
+	}
+
+	val needsRewrite = storedNormalized != marker.gitUrl
+
+	if (originUrl == null) {
+		return VaultVerdict.Failed(
+			reason = "url_mismatch",
+			message = "Vault at $memoryBankRoot has no origin remote configured. Refusing to write.",
+		)
+	}
+
+	val actual = normalizeGitUrl(originUrl)
+	if (actual != expected) {
+		return VaultVerdict.Failed(
+			reason = "url_mismatch",
+			message = "Vault origin remote is $actual but credentials point at $expected. Refusing to write.",
+		)
+	}
+
+	return if (needsRewrite) VaultVerdict.Ok(needsRewrite = true) else VaultVerdict.Ok()
+}

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/sync/VaultPathClassifier.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/sync/VaultPathClassifier.kt
@@ -1,0 +1,166 @@
+package ai.jolli.jollimemory.sync
+
+/**
+ * Pure path classifier for vault staging.
+ *
+ * Port of `cli/src/sync/VaultPathClassifier.ts`.
+ *
+ * [classifyVaultPath] returns the kind of vault-owned content the path
+ * represents, or null if the path is not a FolderStorage / RepoMapping output.
+ *
+ * Caller contract:
+ *   - Forward slashes only (git status --porcelain -z emits POSIX on every platform).
+ *   - No leading `./` or `/`.
+ *   - No `..` segments.
+ */
+
+/** SHA-1 partial hash, 7-64 lowercase hex chars. */
+val HASH_PARTIAL_RE = Regex("^[0-9a-f]{7,64}$")
+
+/** 8-char hex prefix used in visible-summary basenames. */
+val HASH8_RE = Regex("^[0-9a-f]{8}$")
+
+/** FolderStorage.slugify output: lowercase a-z0-9 and dashes, or "untitled". */
+val SUMMARY_SLUG_RE = Regex("^(?:[a-z0-9]+(?:-[a-z0-9]+)*|untitled)$")
+
+/**
+ * Plan / note ID grammar: `[A-Za-z0-9._-]`, no leading dot or dash,
+ * no `..` substring, length cap 200.
+ */
+val PLAN_NOTE_ID_RE = Regex("^(?!\\.)(?!.*\\.\\.)[A-Za-z0-9._-]{1,200}$")
+
+/**
+ * Safe segment regex for repo folder and branch names. Rejects:
+ *   - Path separators, control chars (0x00-0x1F, 0x7F), backslash
+ *   - Leading `.`, `-`, or whitespace
+ *   - `..` substring
+ *   - Trailing `.`, `-`, or whitespace
+ *   - Length > 200
+ */
+private val SAFE_SEGMENT_RE = Regex(
+	"^(?![.\\-\\s])(?!.*\\.\\.)[^\\x00-\\x1f\\x7f/\\\\]{1,200}(?<![.\\-\\s])$"
+)
+
+val REPO_FOLDER_RE = SAFE_SEGMENT_RE
+val BRANCH_FOLDER_RE = SAFE_SEGMENT_RE
+
+/**
+ * Classify a POSIX-style forward-slash-separated relative path from the
+ * vault root. Returns the [OwnedPathKind] or null if unrecognized.
+ */
+fun classifyVaultPath(relPath: String): OwnedPathKind? {
+	val strict = classifyStrict(relPath)
+	if (strict != null) return strict
+	return classifyFallthrough(relPath)
+}
+
+private fun classifyStrict(relPath: String): OwnedPathKind? {
+	if (relPath.isEmpty()) return null
+	if (relPath.startsWith("/") || relPath.startsWith("./")) return null
+	if (relPath.contains("..")) return null
+	if (relPath.contains("\\")) return null
+
+	// Root-level files.
+	if (relPath == ".gitignore") return OwnedPathKind.ROOT_GITIGNORE
+	if (relPath == ".jolli/repos.json") return OwnedPathKind.ROOT_REPOS
+
+	val segments = relPath.split("/")
+	if (segments.size < 2) return null
+
+	val repoFolder = segments[0]
+	if (!REPO_FOLDER_RE.matches(repoFolder)) return null
+
+	// <repoFolder>/.jolli/...
+	if (segments[1] == ".jolli") {
+		if (segments.size == 3) {
+			return when (segments[2]) {
+				"config.json" -> OwnedPathKind.REPO_CONFIG
+				"index.json" -> OwnedPathKind.REPO_INDEX
+				"manifest.json" -> OwnedPathKind.REPO_MANIFEST
+				"branches.json" -> OwnedPathKind.REPO_BRANCHES
+				"catalog.json" -> OwnedPathKind.REPO_CATALOG
+				"migration.json" -> OwnedPathKind.REPO_MIGRATION
+				"shadow-status.json" -> null // per-device, never synced
+				else -> null
+			}
+		}
+		if (segments.size == 4) {
+			val dir = segments[2]
+			val file = segments[3]
+			return when (dir) {
+				"summaries" -> {
+					val base = stripExt(file, ".json") ?: return null
+					if (HASH_PARTIAL_RE.matches(base)) OwnedPathKind.SUMMARY else null
+				}
+				"transcripts" -> {
+					val base = stripExt(file, ".json") ?: return null
+					if (HASH_PARTIAL_RE.matches(base)) OwnedPathKind.TRANSCRIPT else null
+				}
+				"plans" -> {
+					val base = stripExt(file, ".md") ?: return null
+					if (PLAN_NOTE_ID_RE.matches(base)) OwnedPathKind.PLAN else null
+				}
+				"plan-progress" -> {
+					val base = stripExt(file, ".json") ?: return null
+					if (PLAN_NOTE_ID_RE.matches(base)) OwnedPathKind.PLAN_PROGRESS else null
+				}
+				"notes" -> {
+					val base = stripExt(file, ".md") ?: return null
+					if (PLAN_NOTE_ID_RE.matches(base)) OwnedPathKind.NOTE else null
+				}
+				else -> null
+			}
+		}
+		return null
+	}
+
+	// <repoFolder>/<branch>/<file> — visible markdown.
+	if (segments.size == 3) {
+		val branch = segments[1]
+		val file = segments[2]
+		if (!BRANCH_FOLDER_RE.matches(branch)) return null
+
+		// plan--<slug>.md
+		if (file.startsWith("plan--") && file.endsWith(".md")) {
+			val slug = file.removePrefix("plan--").removeSuffix(".md")
+			return if (PLAN_NOTE_ID_RE.matches(slug)) OwnedPathKind.VISIBLE_PLAN else null
+		}
+		// note--<id>.md
+		if (file.startsWith("note--") && file.endsWith(".md")) {
+			val id = file.removePrefix("note--").removeSuffix(".md")
+			return if (PLAN_NOTE_ID_RE.matches(id)) OwnedPathKind.VISIBLE_NOTE else null
+		}
+		// <slug>-<hex8>.md
+		if (file.endsWith(".md")) {
+			val stem = file.removeSuffix(".md")
+			val dashIdx = stem.lastIndexOf('-')
+			if (dashIdx <= 0 || dashIdx >= stem.length - 1) return null
+			val slug = stem.substring(0, dashIdx)
+			val hex8 = stem.substring(dashIdx + 1)
+			if (!HASH8_RE.matches(hex8)) return null
+			if (!SUMMARY_SLUG_RE.matches(slug)) return null
+			return OwnedPathKind.VISIBLE_SUMMARY
+		}
+		return null
+	}
+
+	return null
+}
+
+private fun classifyFallthrough(relPath: String): OwnedPathKind? {
+	if (relPath.isEmpty()) return null
+	if (relPath.startsWith("/") || relPath.startsWith("./")) return null
+	if (relPath.contains("..")) return null
+	if (relPath.contains("\\")) return null
+	val segments = relPath.split("/")
+	for (seg in segments) {
+		if (!SAFE_SEGMENT_RE.matches(seg)) return null
+	}
+	val leaf = segments.last()
+	if (leaf == "shadow-status.json") return null
+	return OwnedPathKind.USER_CONTENT
+}
+
+private fun stripExt(name: String, ext: String): String? {
+	return if (name.endsWith(ext)) name.dropLast(ext.length) else null
+}

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/sync/VaultSymlinkGuard.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/sync/VaultSymlinkGuard.kt
@@ -1,0 +1,62 @@
+package ai.jolli.jollimemory.sync
+
+import java.io.File
+import java.nio.file.Files
+import java.nio.file.LinkOption
+import java.nio.file.Path
+
+/**
+ * Symlink-safety guard for vault writes.
+ *
+ * Port of `cli/src/sync/VaultSymlinkGuard.ts`.
+ *
+ * Walks the path chain from [vaultRoot] to [absTargetPath] (exclusive of the
+ * final basename) and verifies every existing segment is a real directory,
+ * not a symlink.
+ *
+ * Throws if any intermediate segment is a symlink or if [absTargetPath] is
+ * not inside [vaultRoot].
+ */
+fun assertNoSymlinksInPath(vaultRoot: String, absTargetPath: String) {
+	val vaultPath = Path.of(vaultRoot).toAbsolutePath()
+	val targetPath = Path.of(absTargetPath).toAbsolutePath()
+
+	require(targetPath.isAbsolute) { "assertNoSymlinksInPath: absTargetPath must be absolute, got $absTargetPath" }
+	require(vaultPath.isAbsolute) { "assertNoSymlinksInPath: vaultRoot must be absolute, got $vaultRoot" }
+
+	val rel = vaultPath.relativize(targetPath)
+	val relStr = rel.toString()
+	if (relStr.isEmpty() || relStr.startsWith("..") || rel.isAbsolute) {
+		throw IllegalArgumentException(
+			"assertNoSymlinksInPath: target $absTargetPath is not inside vault $vaultRoot"
+		)
+	}
+
+	// Walk down the path one segment at a time, excluding the final segment.
+	val segments = relStr.split(File.separator)
+	var cur = vaultPath
+	for (i in 0 until segments.size - 1) {
+		val seg = segments[i]
+		if (seg.isEmpty()) continue
+		cur = cur.resolve(seg)
+
+		val attrs = try {
+			Files.readAttributes(cur, java.nio.file.attribute.BasicFileAttributes::class.java, LinkOption.NOFOLLOW_LINKS)
+		} catch (_: java.nio.file.NoSuchFileException) {
+			// Segment doesn't exist yet — fine, mkdir will create it.
+			// Deeper segments are guaranteed non-existent too.
+			return
+		}
+
+		if (attrs.isSymbolicLink) {
+			throw IllegalStateException(
+				"Refused vault write: path segment is a symlink at $cur (target $absTargetPath). Inspect and unlink before retrying."
+			)
+		}
+		if (!attrs.isDirectory) {
+			throw IllegalStateException(
+				"Refused vault write: path segment is not a directory at $cur (target $absTargetPath)."
+			)
+		}
+	}
+}

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/sync/VaultWriteLock.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/sync/VaultWriteLock.kt
@@ -1,0 +1,66 @@
+package ai.jolli.jollimemory.sync
+
+import java.nio.file.Files
+import java.nio.file.Path
+
+/**
+ * Per-vault writer lock — coordinates sync vs QueueWorker.
+ *
+ * Port of `cli/src/sync/VaultWriteLock.ts`.
+ *
+ * Held by callers that mutate the vault working tree, with asymmetric scope:
+ *   - QueueWorker holds for the entire drain
+ *   - SyncEngine holds only during pullRebase + conflict resolution
+ */
+
+sealed class VaultWriteLockMode {
+	object FailFast : VaultWriteLockMode()
+	data class Wait(val ms: Long) : VaultWriteLockMode()
+}
+
+interface VaultWriteLockHandle {
+	fun release()
+	fun refresh()
+}
+
+object VaultWriteLock {
+
+	const val DEFAULT_WAIT_MS = 60_000L
+	const val DEFAULT_PULL_LOCK_WAIT_MS = 10_000L
+	const val DEFAULT_POLL_MS = 100L
+
+	/**
+	 * Acquires `vault-write.lock` for the vault rooted at [vaultRoot].
+	 * Returns a handle on success, or null on miss/timeout.
+	 */
+	fun acquire(vaultRoot: String, mode: VaultWriteLockMode): VaultWriteLockHandle? {
+		val lockPath = getVaultWriteLockPath(vaultRoot)
+		Files.createDirectories(lockPath.parent)
+
+		val acquired = when (mode) {
+			is VaultWriteLockMode.FailFast -> LockPrimitives.tryAcquireOnce(lockPath)
+			is VaultWriteLockMode.Wait -> LockPrimitives.acquireWithPoll(
+				lockPath, mode.ms, DEFAULT_POLL_MS
+			)
+		}
+
+		if (!acquired) return null
+
+		return object : VaultWriteLockHandle {
+			override fun release() {
+				LockPrimitives.releaseIfOwned(lockPath, "vault-write.lock")
+			}
+
+			override fun refresh() {
+				LockPrimitives.refreshLockMtime(lockPath)
+			}
+		}
+	}
+
+	/**
+	 * Returns true when `vault-write.lock` exists and is fresh. Diagnostic only.
+	 */
+	fun isHeld(vaultRoot: String): Boolean {
+		return LockPrimitives.isLockHeld(getVaultWriteLockPath(vaultRoot))
+	}
+}

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/KBExplorerPanel.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/KBExplorerPanel.kt
@@ -10,8 +10,14 @@ import ai.jolli.jollimemory.core.MigrationState
 import ai.jolli.jollimemory.core.FolderStorage
 import ai.jolli.jollimemory.core.OrphanBranchStorage
 import ai.jolli.jollimemory.core.SessionTracker
+import ai.jolli.jollimemory.JolliMemoryIcons
 import ai.jolli.jollimemory.bridge.GitOps
+import ai.jolli.jollimemory.services.JolliAuthService
 import ai.jolli.jollimemory.services.JolliMemoryService
+import ai.jolli.jollimemory.sync.SyncActivation
+import ai.jolli.jollimemory.sync.SyncErrorCode
+import ai.jolli.jollimemory.sync.SyncState
+import ai.jolli.jollimemory.sync.SyncStatusDetail
 import com.google.gson.Gson
 import com.google.gson.GsonBuilder
 import com.intellij.icons.AllIcons
@@ -41,6 +47,7 @@ import com.intellij.openapi.vfs.newvfs.events.VFileMoveEvent
 import git4idea.repo.GitRepository
 import git4idea.repo.GitRepositoryChangeListener
 import com.intellij.ui.ColoredTreeCellRenderer
+import com.intellij.ui.JBColor
 import com.intellij.ui.SimpleTextAttributes
 import com.intellij.ui.components.JBScrollPane
 import com.intellij.ui.treeStructure.Tree
@@ -65,6 +72,7 @@ import javax.swing.JToggleButton
 import javax.swing.JTree
 import javax.swing.SwingConstants
 import javax.swing.SwingUtilities
+import javax.swing.Timer
 import javax.swing.event.DocumentEvent
 import javax.swing.event.DocumentListener
 import java.awt.CardLayout
@@ -107,7 +115,15 @@ class KBExplorerPanel(
     private var searchQuery: String = ""
 
     private val statusListener: () -> Unit
+    private val syncStateListener: (SyncState, SyncStatusDetail?) -> Unit
     private val busConnection: MessageBusConnection
+
+    /** Inline sync progress/result indicator, shown in the toolbar row next to the
+     *  view-toggle buttons. Mirrors the IDE status-bar widget so the user gets
+     *  immediate feedback after clicking "Sync to Personal Space". */
+    private val syncStatusLabel = JLabel().apply { isVisible = false }
+    /** Auto-clears the transient "Synced" message after a short delay. */
+    private var syncClearTimer: Timer? = null
 
     data class KBNodeData(
         val path: Path,
@@ -174,6 +190,30 @@ class KBExplorerPanel(
         }
         toolbar.add(btnReset)
         toolbar.add(javax.swing.Box.createHorizontalStrut(JBUI.scale(4)))
+
+        // Sync to Personal Space — mirrors the cloud-upload button on VS Code's
+        // Memory Bank toolbar (vscode/src/views/SidebarScriptBuilder.ts), which
+        // fires the same `jollimemory.syncNow` flow. The button is deliberately
+        // independent of the auto-sync toggle: it is always shown, and the
+        // handler only points the user to sign-in when sync is dormant.
+        val btnSync = JButton(JolliMemoryIcons.CloudUpload).apply {
+            toolTipText = "Sync to Personal Space"
+            isBorderPainted = false
+            isFocusPainted = false
+            isContentAreaFilled = false
+            preferredSize = Dimension(JBUI.scale(22), JBUI.scale(22))
+            maximumSize = Dimension(JBUI.scale(22), JBUI.scale(22))
+            margin = JBUI.emptyInsets()
+            addActionListener {
+                ApplicationManager.getApplication().executeOnPooledThread { syncToPersonalSpace() }
+            }
+        }
+        toolbar.add(btnSync)
+        toolbar.add(javax.swing.Box.createHorizontalStrut(JBUI.scale(4)))
+        // Inline sync status — same row as the Tree/Timeline toggle and the sync
+        // button. Hidden until the first sync state arrives.
+        toolbar.add(syncStatusLabel)
+        toolbar.add(javax.swing.Box.createHorizontalStrut(JBUI.scale(4)))
         toolbar.add(searchField)
 
         contentPanel.add(treePanel, ViewMode.TREE.name)
@@ -186,6 +226,12 @@ class KBExplorerPanel(
 
         statusListener = { ApplicationManager.getApplication().executeOnPooledThread { refresh() } }
         service.addStatusListener(statusListener)
+
+        // Mirror sync state into the toolbar indicator (progress + result).
+        syncStateListener = { state, detail ->
+            SwingUtilities.invokeLater { updateSyncStatus(state, detail) }
+        }
+        service.addSyncStateListener(syncStateListener)
 
         // Watch KB parent directory for file changes across all repos
         busConnection = ApplicationManager.getApplication().messageBus.connect()
@@ -899,6 +945,110 @@ class KBExplorerPanel(
         }
     }
 
+    /**
+     * Manual "Sync to Personal Space" — IntelliJ port of the
+     * `jollimemory.syncNow` command (vscode/src/sync/SyncCommands.ts).
+     *
+     * Parity with VS Code's `runtime.ensureBuilt()` gate:
+     *   - Not signed in → the orchestrator can never be built, so point the
+     *     user at sign-in instead of silently doing nothing.
+     *   - Signed in but orchestrator not yet built (e.g. enabled after the
+     *     last reconcile) → lazy-build it via [SyncActivation.reconcileSync].
+     *   - Then route through [JolliMemoryService.requestManualSync], which
+     *     coalesces with any in-flight round.
+     */
+    private fun syncToPersonalSpace() {
+        JM.info("syncToPersonalSpace: button clicked")
+        if (!JolliAuthService.isSignedIn()) {
+            JM.info("syncToPersonalSpace: not signed in — prompting sign-in, aborting")
+            com.intellij.notification.Notifications.Bus.notify(
+                com.intellij.notification.Notification(
+                    "JolliMemory",
+                    "Sync to Personal Space",
+                    "Memory Bank sync needs a Jolli sign-in. Open Settings → Memory Bank and sign in to Jolli, then try again.",
+                    com.intellij.notification.NotificationType.INFORMATION,
+                ),
+                project,
+            )
+            return
+        }
+        JM.info("syncToPersonalSpace: signed in; isSyncBuilt=${service.isSyncBuilt()}")
+        if (!service.isSyncBuilt()) {
+            JM.info("syncToPersonalSpace: orchestrator not built — running reconcileSync to lazy-build")
+            SyncActivation.reconcileSync(project, service)
+            JM.info("syncToPersonalSpace: after reconcileSync, isSyncBuilt=${service.isSyncBuilt()}")
+        }
+        JM.info("syncToPersonalSpace: calling requestManualSync (orchestrator built=${service.isSyncBuilt()})")
+        service.requestManualSync()
+        JM.info("syncToPersonalSpace: requestManualSync returned")
+    }
+
+    /**
+     * Reflects a sync state change in the toolbar indicator. Runs on the EDT.
+     *
+     * Mirrors the IDE status-bar widget ([ai.jolli.jollimemory.sync.SyncStatusBarWidget]),
+     * which remains the canonical place for terminal errors. This inline copy gives
+     * immediate, in-panel feedback so the user does not have to hunt for the status bar:
+     * - SYNCING  → "⟳ Syncing…"
+     * - SYNCED   → "✓ Synced" (auto-clears after a few seconds)
+     * - CONFLICTS→ "⚠ N conflicts"
+     * - OFFLINE  → "✗ Sync failed" when a terminal error is present, otherwise hidden
+     */
+    private fun updateSyncStatus(state: SyncState, detail: SyncStatusDetail?) {
+        syncClearTimer?.stop()
+        syncClearTimer = null
+
+        when (state) {
+            SyncState.SYNCING -> {
+                syncStatusLabel.text = "⟳ Syncing…"
+                syncStatusLabel.foreground = JBColor.foreground()
+                syncStatusLabel.toolTipText = "Memory Bank sync in progress"
+                syncStatusLabel.isVisible = true
+            }
+            SyncState.SYNCED -> {
+                syncStatusLabel.text = "✓ Synced"
+                syncStatusLabel.foreground = JBColor(Color(0x59, 0xA8, 0x69), Color(0x5F, 0xB8, 0x65))
+                syncStatusLabel.toolTipText = "Memory Bank in sync"
+                syncStatusLabel.isVisible = true
+                // Transient success — fade out so the toolbar returns to its resting state.
+                syncClearTimer = Timer(4000) {
+                    syncStatusLabel.isVisible = false
+                    syncStatusLabel.text = ""
+                }.apply { isRepeats = false; start() }
+            }
+            SyncState.CONFLICTS -> {
+                val count = detail?.conflictCount
+                syncStatusLabel.text = if (count != null) "⚠ $count conflicts" else "⚠ Conflicts"
+                syncStatusLabel.foreground = JBColor(Color(0xC2, 0x8A, 0x00), Color(0xD6, 0xA0, 0x2E))
+                syncStatusLabel.toolTipText =
+                    if (count != null) "$count items need your attention" else "Conflicts need your attention"
+                syncStatusLabel.isVisible = true
+            }
+            SyncState.OFFLINE -> {
+                if (detail?.failed == true && detail.failedCode != null) {
+                    syncStatusLabel.text = failedText(detail.failedCode)
+                    syncStatusLabel.foreground = JBColor(Color(0xC7, 0x42, 0x2E), Color(0xD9, 0x5A, 0x4A))
+                    // The full error lives in the IDE status bar; tooltip carries the detail here too.
+                    syncStatusLabel.toolTipText = detail.lastError ?: "Memory Bank sync failed"
+                    syncStatusLabel.isVisible = true
+                } else {
+                    syncStatusLabel.isVisible = false
+                    syncStatusLabel.text = ""
+                }
+            }
+        }
+        syncStatusLabel.parent?.revalidate()
+        syncStatusLabel.parent?.repaint()
+    }
+
+    /** Short toolbar label for a terminal sync error; mirrors the status-bar widget. */
+    private fun failedText(code: SyncErrorCode): String = when (code) {
+        SyncErrorCode.VAULT_LOCKED -> "⚠ Personal Space busy"
+        SyncErrorCode.LOCALFOLDER_INVALID -> "✗ Folder invalid"
+        SyncErrorCode.PUSH_REJECTED -> "✗ Push rejected"
+        else -> "✗ Sync failed"
+    }
+
     // ── Timeline view ──────────────────────────────────────────────────────
 
     private fun buildTimeline() {
@@ -994,10 +1144,16 @@ class KBExplorerPanel(
     override fun dispose() {
         busConnection.disconnect()
         service.removeStatusListener(statusListener)
+        service.removeSyncStateListener(syncStateListener)
+        syncClearTimer?.stop()
+        syncClearTimer = null
     }
 
     companion object {
         private val LOG = Logger.getInstance(KBExplorerPanel::class.java)
+        // Lands in the shared <projectDir>/.jolli/jollimemory/debug.log so the
+        // manual-sync click path is observable alongside the sync-layer logs.
+        private val JM = ai.jolli.jollimemory.core.JmLogger.create("KBExplorerPanel")
     }
 
     // ── Tree cell renderer ─────────────────────────────────────────────────

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/SettingsDialog.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/SettingsDialog.kt
@@ -74,6 +74,9 @@ class SettingsDialog(
     private val syncCardLayout = CardLayout()
     private val syncCardPanel = JPanel(syncCardLayout)
     private lateinit var signInForSyncButton: JButton
+    private val autoSyncCheckbox = JBCheckBox("Auto-sync to Personal Space", true)
+    private val syncTranscriptsCheckbox = JBCheckBox("Sync transcripts", false)
+    private val pollIntervalField = JBTextField()
 
     // ── Tab 3: Memory Bank ─────────────────────────────────────────────────
     private val kbPathField = TextFieldWithBrowseButton().apply {
@@ -410,6 +413,27 @@ class SettingsDialog(
         syncCardPanel.alignmentX = JComponent.LEFT_ALIGNMENT
         panel.add(syncCardPanel)
 
+        panel.add(Box.createVerticalStrut(12))
+        panel.add(javax.swing.JSeparator().apply { alignmentX = JComponent.LEFT_ALIGNMENT; maximumSize = Dimension(Int.MAX_VALUE, 1) })
+        panel.add(Box.createVerticalStrut(8))
+
+        autoSyncCheckbox.alignmentX = JComponent.LEFT_ALIGNMENT
+        panel.add(autoSyncCheckbox)
+        panel.add(Box.createVerticalStrut(4))
+
+        syncTranscriptsCheckbox.alignmentX = JComponent.LEFT_ALIGNMENT
+        panel.add(syncTranscriptsCheckbox)
+        panel.add(Box.createVerticalStrut(8))
+
+        pollIntervalField.apply {
+            alignmentX = JComponent.LEFT_ALIGNMENT
+            maximumSize = Dimension(Int.MAX_VALUE, preferredSize.height)
+        }
+        panel.add(createStretchedFormPanel(FormBuilder.createFormBuilder()
+            .addLabeledComponent(JBLabel("Poll interval (seconds):"), pollIntervalField, 1, false)
+            .addTooltip("How often to sync automatically. Leave blank for default (5 minutes).")
+            .panel))
+
         return wrapTabContent(panel)
     }
 
@@ -647,6 +671,9 @@ class SettingsDialog(
             knowledgeBasePath = kbPath,
             knowledgeBaseSort = kbSort,
             paused = if (pauseCheckbox.isSelected) true else null,
+            autoSyncEnabled = if (autoSyncCheckbox.isSelected) null else false,
+            syncTranscripts = if (syncTranscriptsCheckbox.isSelected) true else null,
+            syncPollIntervalSec = pollIntervalField.text.trim().toIntOrNull(),
         )
         SessionTracker.saveConfigToDir(config, configDir)
 
@@ -754,6 +781,11 @@ class SettingsDialog(
         }
         kbPathField.text = config.knowledgeBasePath ?: KBPathResolver.KB_PARENT.toString()
         kbSortCombo.selectedItem = config.knowledgeBaseSort ?: "date"
+
+        // Sync settings
+        autoSyncCheckbox.isSelected = config.autoSyncEnabled != false
+        syncTranscriptsCheckbox.isSelected = config.syncTranscripts == true
+        pollIntervalField.text = config.syncPollIntervalSec?.toString() ?: ""
 
         // Sync card states after all fields are populated
         syncProviderCard()

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/SettingsDialog.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/SettingsDialog.kt
@@ -431,7 +431,7 @@ class SettingsDialog(
         }
         panel.add(createStretchedFormPanel(FormBuilder.createFormBuilder()
             .addLabeledComponent(JBLabel("Poll interval (seconds):"), pollIntervalField, 1, false)
-            .addTooltip("How often to sync automatically. Leave blank for default (5 minutes).")
+            .addTooltip("How often to sync automatically. Leave blank for the default (90 minutes); shorter values are raised to the 90-minute minimum.")
             .panel))
 
         return wrapTabContent(panel)

--- a/intellij/src/main/resources/META-INF/plugin.xml
+++ b/intellij/src/main/resources/META-INF/plugin.xml
@@ -45,6 +45,11 @@
             id="JolliMemory"
             displayType="BALLOON"/>
 
+        <!-- Sync status bar widget -->
+        <statusBarWidgetFactory
+            id="JolliSyncStatus"
+            implementation="ai.jolli.jollimemory.sync.SyncStatusBarWidgetFactory"/>
+
         <!-- Settings page -->
         <projectConfigurable
             instance="ai.jolli.jollimemory.settings.JolliMemoryConfigurable"

--- a/intellij/src/test/kotlin/ai/jolli/jollimemory/auth/JolliAuthUtilsTest.kt
+++ b/intellij/src/test/kotlin/ai/jolli/jollimemory/auth/JolliAuthUtilsTest.kt
@@ -1,5 +1,6 @@
 package ai.jolli.jollimemory.auth
 
+import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
@@ -119,5 +120,68 @@ class JolliAuthUtilsTest {
             JolliAuthUtils.validateJolliApiKey("sk-other-abc123")
         }
         ex.message shouldContain "cannot be decoded"
+    }
+
+    // --- shouldRequestFreshApiKey tests ---
+
+    @Test
+    fun `shouldRequestFreshApiKey true when no existing key`() {
+        JolliAuthUtils.shouldRequestFreshApiKey(null, "https://jolli.ai") shouldBe true
+        JolliAuthUtils.shouldRequestFreshApiKey("", "https://jolli.ai") shouldBe true
+        JolliAuthUtils.shouldRequestFreshApiKey("   ", "https://jolli.ai") shouldBe true
+    }
+
+    @Test
+    fun `shouldRequestFreshApiKey false when key tenant matches target`() {
+        JolliAuthUtils.shouldRequestFreshApiKey(fakeKey("https://jolli.ai"), "https://jolli.ai") shouldBe false
+    }
+
+    @Test
+    fun `shouldRequestFreshApiKey true on cross-tenant switch`() {
+        // The bug this fixes: stale jolli.ai key, signing into jolli-local.me.
+        JolliAuthUtils.shouldRequestFreshApiKey(
+            fakeKey("https://jolli.ai"),
+            "https://jolli-local.me",
+        ) shouldBe true
+    }
+
+    @Test
+    fun `shouldRequestFreshApiKey origin compares case-insensitively`() {
+        JolliAuthUtils.shouldRequestFreshApiKey(
+            fakeKey("https://Jolli.AI"),
+            "https://jolli.ai",
+        ) shouldBe false
+    }
+
+    @Test
+    fun `shouldRequestFreshApiKey true when tenant slug differs`() {
+        JolliAuthUtils.shouldRequestFreshApiKey(
+            fakeKey("https://jolli-local.me/dev"),
+            "https://jolli-local.me/prod",
+        ) shouldBe true
+    }
+
+    @Test
+    fun `shouldRequestFreshApiKey false when tenant slug matches`() {
+        JolliAuthUtils.shouldRequestFreshApiKey(
+            fakeKey("https://jolli-local.me/prod"),
+            "https://jolli-local.me/prod",
+        ) shouldBe false
+    }
+
+    @Test
+    fun `shouldRequestFreshApiKey tenant slug compares case-sensitively`() {
+        // Slug flows downstream verbatim as x-tenant-slug, so a case variant is
+        // a different tenant — fail safe by requesting a fresh key.
+        JolliAuthUtils.shouldRequestFreshApiKey(
+            fakeKey("https://jolli-local.me/Acme"),
+            "https://jolli-local.me/acme",
+        ) shouldBe true
+    }
+
+    @Test
+    fun `shouldRequestFreshApiKey false for undecodable legacy key`() {
+        // Can't prove it's stale; don't surprise-drop a hand-typed key.
+        JolliAuthUtils.shouldRequestFreshApiKey("sk-jol-notbase64", "https://jolli.ai") shouldBe false
     }
 }

--- a/intellij/src/test/kotlin/ai/jolli/jollimemory/services/JolliAuthServiceTest.kt
+++ b/intellij/src/test/kotlin/ai/jolli/jollimemory/services/JolliAuthServiceTest.kt
@@ -145,12 +145,16 @@ class JolliAuthServiceTest {
     }
 
     @Test
-    fun `signOut clears authToken but preserves jolliApiKey`() {
+    fun `signOut clears both authToken and jolliApiKey`() {
+        // The API key carries the tenant URL that sync/LLM routing extract via
+        // parseJolliApiKey. Leaving it behind pins a later sign-in (into a
+        // different tenant) to the old host. Clear both in one write — mirrors
+        // VS Code's clearAuthCredentials.
         mockkObject(SessionTracker)
         every { SessionTracker.getGlobalConfigDir() } returns "/fake/global"
         every { SessionTracker.loadConfigFromDir("/fake/global") } returns JolliMemoryConfig(
             authToken = "old-token",
-            jolliApiKey = "sk-jol-keep-me",
+            jolliApiKey = "sk-jol-stale-tenant",
         )
         val savedConfig = slot<JolliMemoryConfig>()
         every { SessionTracker.saveConfigToDir(capture(savedConfig), "/fake/global") } returns Unit
@@ -158,7 +162,27 @@ class JolliAuthServiceTest {
         JolliAuthService.signOut()
 
         savedConfig.captured.authToken shouldBe null
-        savedConfig.captured.jolliApiKey shouldBe "sk-jol-keep-me"
+        savedConfig.captured.jolliApiKey shouldBe null
+    }
+
+    @Test
+    fun `signOut preserves unrelated config fields`() {
+        // Only the auth credentials are cleared — model, provider, etc. survive.
+        mockkObject(SessionTracker)
+        every { SessionTracker.getGlobalConfigDir() } returns "/fake/global"
+        every { SessionTracker.loadConfigFromDir("/fake/global") } returns JolliMemoryConfig(
+            authToken = "old-token",
+            jolliApiKey = "sk-jol-stale",
+            aiProvider = "jolli",
+            storageMode = "dual-write",
+        )
+        val savedConfig = slot<JolliMemoryConfig>()
+        every { SessionTracker.saveConfigToDir(capture(savedConfig), "/fake/global") } returns Unit
+
+        JolliAuthService.signOut()
+
+        savedConfig.captured.aiProvider shouldBe "jolli"
+        savedConfig.captured.storageMode shouldBe "dual-write"
     }
 
     @Test

--- a/intellij/src/test/kotlin/ai/jolli/jollimemory/sync/AggregateMergeTest.kt
+++ b/intellij/src/test/kotlin/ai/jolli/jollimemory/sync/AggregateMergeTest.kt
@@ -1,0 +1,204 @@
+package ai.jolli.jollimemory.sync
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+
+class AggregateMergeTest {
+
+	// ── mergeManifest ──────────────────────────────────────────────────
+
+	@Test
+	fun `mergeManifest unions by fileId`() {
+		val local = listOf(
+			ManifestEntry("a.json", "f1", "commit", "fp1", "title1",
+				ManifestSource("c1", "main", "2024-01-01T00:00:00Z")),
+		)
+		val remote = listOf(
+			ManifestEntry("b.json", "f2", "commit", "fp2", "title2",
+				ManifestSource("c2", "main", "2024-01-02T00:00:00Z")),
+		)
+		val merged = mergeManifest(local, remote)
+		assertEquals(2, merged.size)
+		assertEquals("f1", merged[0].fileId)
+		assertEquals("f2", merged[1].fileId)
+	}
+
+	@Test
+	fun `mergeManifest newer generatedAt wins on same fileId`() {
+		val local = listOf(
+			ManifestEntry("a.json", "f1", "commit", "fp1", "old",
+				ManifestSource("c1", "main", "2024-01-01T00:00:00Z")),
+		)
+		val remote = listOf(
+			ManifestEntry("a.json", "f1", "commit", "fp1", "new",
+				ManifestSource("c1", "main", "2024-01-02T00:00:00Z")),
+		)
+		val merged = mergeManifest(local, remote)
+		assertEquals(1, merged.size)
+		assertEquals("new", merged[0].title)
+	}
+
+	@Test
+	fun `mergeManifest ties keep local`() {
+		val local = listOf(
+			ManifestEntry("a.json", "f1", "commit", "fp1", "local",
+				ManifestSource("c1", "main", "2024-01-01T00:00:00Z")),
+		)
+		val remote = listOf(
+			ManifestEntry("a.json", "f1", "commit", "fp1", "remote",
+				ManifestSource("c1", "main", "2024-01-01T00:00:00Z")),
+		)
+		val merged = mergeManifest(local, remote)
+		assertEquals("local", merged[0].title)
+	}
+
+	@Test
+	fun `mergeManifest output sorted by fileId`() {
+		val local = listOf(
+			ManifestEntry("z.json", "z1", "commit", "fp", "z",
+				ManifestSource("c1", "main", "2024-01-01T00:00:00Z")),
+		)
+		val remote = listOf(
+			ManifestEntry("a.json", "a1", "commit", "fp", "a",
+				ManifestSource("c1", "main", "2024-01-01T00:00:00Z")),
+		)
+		val merged = mergeManifest(local, remote)
+		assertEquals("a1", merged[0].fileId)
+		assertEquals("z1", merged[1].fileId)
+	}
+
+	// ── mergeIndex ─────────────────────────────────────────────────────
+
+	@Test
+	fun `mergeIndex unions by commitHash`() {
+		val local = listOf(indexEntry("aaa", parent = null, generatedAt = "2024-01-01T00:00:00Z"))
+		val remote = listOf(indexEntry("bbb", parent = null, generatedAt = "2024-01-01T00:00:00Z"))
+		val merged = mergeIndex(local, remote)
+		assertEquals(2, merged.size)
+	}
+
+	@Test
+	fun `mergeIndex parent trumps no-parent`() {
+		val local = listOf(indexEntry("aaa", parent = null, generatedAt = "2024-01-02T00:00:00Z"))
+		val remote = listOf(indexEntry("aaa", parent = "ppp", generatedAt = "2024-01-01T00:00:00Z"))
+		val merged = mergeIndex(local, remote)
+		assertEquals(1, merged.size)
+		assertEquals("ppp", merged[0].parentCommitHash)
+	}
+
+	@Test
+	fun `mergeIndex both have parent newer wins`() {
+		val local = listOf(indexEntry("aaa", parent = "p1", generatedAt = "2024-01-01T00:00:00Z"))
+		val remote = listOf(indexEntry("aaa", parent = "p2", generatedAt = "2024-01-02T00:00:00Z"))
+		val merged = mergeIndex(local, remote)
+		assertEquals("p2", merged[0].parentCommitHash)
+	}
+
+	@Test
+	fun `mergeIndex sorted by commitHash`() {
+		val local = listOf(indexEntry("zzz", parent = null, generatedAt = "2024-01-01T00:00:00Z"))
+		val remote = listOf(indexEntry("aaa", parent = null, generatedAt = "2024-01-01T00:00:00Z"))
+		val merged = mergeIndex(local, remote)
+		assertEquals("aaa", merged[0].commitHash)
+		assertEquals("zzz", merged[1].commitHash)
+	}
+
+	// ── mergeBranches ──────────────────────────────────────────────────
+
+	@Test
+	fun `mergeBranches unions and remote overrides`() {
+		val local = listOf(
+			BranchEntry("main-folder", "main", "2024-01-01T00:00:00Z"),
+			BranchEntry("dev-folder", "dev", "2024-01-01T00:00:00Z"),
+		)
+		val remote = listOf(
+			BranchEntry("main-updated", "main", "2024-01-02T00:00:00Z"),
+			BranchEntry("feat-folder", "feat", "2024-01-01T00:00:00Z"),
+		)
+		val merged = mergeBranches(local, remote)
+		assertEquals(3, merged.size)
+		// Remote overrides local for "main"
+		val mainEntry = merged.first { it.branch == "main" }
+		assertEquals("main-updated", mainEntry.folder)
+	}
+
+	@Test
+	fun `mergeBranches sorted by branch`() {
+		val local = listOf(BranchEntry("z", "z-branch", "2024-01-01T00:00:00Z"))
+		val remote = listOf(BranchEntry("a", "a-branch", "2024-01-01T00:00:00Z"))
+		val merged = mergeBranches(local, remote)
+		assertEquals("a-branch", merged[0].branch)
+		assertEquals("z-branch", merged[1].branch)
+	}
+
+	// ── mergeCatalog ───────────────────────────────────────────────────
+
+	@Test
+	fun `mergeCatalog unions and remote overrides`() {
+		val local = listOf(CatalogEntry("aaa", "local recap", "", emptyList()))
+		val remote = listOf(
+			CatalogEntry("aaa", "remote recap", "", emptyList()),
+			CatalogEntry("bbb", "new recap", "", emptyList()),
+		)
+		val merged = mergeCatalog(local, remote)
+		assertEquals(2, merged.size)
+		assertEquals("remote recap", merged.first { it.commitHash == "aaa" }.recap)
+	}
+
+	// ── canonicalBranchFolder ──────────────────────────────────────────
+
+	@Test
+	fun `canonicalBranchFolder slugifies`() {
+		assertEquals("feature-foo", canonicalBranchFolder("feature/foo"))
+		assertEquals("main", canonicalBranchFolder("main"))
+		assertEquals("branch", canonicalBranchFolder("///"))
+		assertEquals("branch", canonicalBranchFolder(""))
+	}
+
+	// ── tryAggregateMerge ──────────────────────────────────────────────
+
+	@Test
+	fun `tryAggregateMerge merges manifest json`() {
+		val ours = """{"version":1,"files":[{"path":"a.json","fileId":"f1","type":"commit","fingerprint":"fp","title":"t","source":{"commitHash":"c1","branch":"main","generatedAt":"2024-01-01T00:00:00Z"}}]}"""
+		val theirs = """{"version":1,"files":[{"path":"b.json","fileId":"f2","type":"commit","fingerprint":"fp","title":"t","source":{"commitHash":"c2","branch":"main","generatedAt":"2024-01-02T00:00:00Z"}}]}"""
+		val result = tryAggregateMerge("repo/.jolli/manifest.json", ours, theirs)
+		assertNotNull(result)
+		assertTrue(result!!.contains("f1"))
+		assertTrue(result.contains("f2"))
+	}
+
+	@Test
+	fun `tryAggregateMerge returns null on invalid json`() {
+		val result = tryAggregateMerge("repo/.jolli/manifest.json", "not json", "{}")
+		assertNull(result)
+	}
+
+	// ── isAggregatePath ────────────────────────────────────────────────
+
+	@Test
+	fun `isAggregatePath recognizes aggregate files`() {
+		assertTrue(isAggregatePath("repo/.jolli/manifest.json"))
+		assertTrue(isAggregatePath("repo/.jolli/index.json"))
+		assertTrue(isAggregatePath("repo/.jolli/branches.json"))
+		assertTrue(isAggregatePath("repo/.jolli/catalog.json"))
+		assertTrue(isAggregatePath(".jolli/repos.json"))
+		assertFalse(isAggregatePath("repo/.jolli/summaries/abc.json"))
+		assertFalse(isAggregatePath("manifest.json"))
+	}
+
+	// ── emptyAggregateEnvelope ─────────────────────────────────────────
+
+	@Test
+	fun `emptyAggregateEnvelope returns valid empty envelopes`() {
+		assertTrue(emptyAggregateEnvelope(".jolli/repos.json").contains("mappings"))
+		assertTrue(emptyAggregateEnvelope("repo/.jolli/manifest.json").contains("files"))
+		assertTrue(emptyAggregateEnvelope("repo/.jolli/index.json").contains("entries"))
+		assertTrue(emptyAggregateEnvelope("repo/.jolli/branches.json").contains("mappings"))
+		assertTrue(emptyAggregateEnvelope("repo/.jolli/catalog.json").contains("entries"))
+	}
+
+	// ── helpers ────────────────────────────────────────────────────────
+
+	private fun indexEntry(hash: String, parent: String?, generatedAt: String) =
+		IndexEntry(hash, parent, "tree", "commit", "msg", "2024-01-01T00:00:00Z", "main", generatedAt)
+}

--- a/intellij/src/test/kotlin/ai/jolli/jollimemory/sync/AllowListTest.kt
+++ b/intellij/src/test/kotlin/ai/jolli/jollimemory/sync/AllowListTest.kt
@@ -1,0 +1,117 @@
+package ai.jolli.jollimemory.sync
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+
+class AllowListTest {
+
+	private val optsOn = AllowListOpts(syncTranscripts = true)
+	private val optsOff = AllowListOpts(syncTranscripts = false)
+
+	// ── Content area ─────────────────────────────────────────────────
+
+	@Test
+	fun `allows md files`() {
+		assertTrue(isAllowedPath("repo/main/summary.md", optsOn))
+	}
+
+	@Test
+	fun `allows json files`() {
+		assertTrue(isAllowedPath("repo/data.json", optsOn))
+	}
+
+	@Test
+	fun `rejects txt files`() {
+		assertFalse(isAllowedPath("repo/readme.txt", optsOn))
+	}
+
+	@Test
+	fun `rejects files with no extension`() {
+		assertFalse(isAllowedPath("repo/Makefile", optsOn))
+	}
+
+	// ── .jolli/ subtree ──────────────────────────────────────────────
+
+	@Test
+	fun `allows aggregate files`() {
+		assertTrue(isAllowedPath(".jolli/index.json", optsOn))
+		assertTrue(isAllowedPath(".jolli/manifest.json", optsOn))
+		assertTrue(isAllowedPath(".jolli/branches.json", optsOn))
+		assertTrue(isAllowedPath(".jolli/catalog.json", optsOn))
+		assertTrue(isAllowedPath(".jolli/repos.json", optsOn))
+		assertTrue(isAllowedPath(".jolli/config.json", optsOn))
+	}
+
+	@Test
+	fun `rejects unknown files under jolli root`() {
+		assertFalse(isAllowedPath(".jolli/unknown.json", optsOn))
+	}
+
+	@Test
+	fun `allows summaries with valid hash`() {
+		assertTrue(isAllowedPath(".jolli/summaries/abc1234.json", optsOn))
+	}
+
+	@Test
+	fun `rejects summaries with short hash`() {
+		assertFalse(isAllowedPath(".jolli/summaries/abc.json", optsOn))
+	}
+
+	@Test
+	fun `allows transcripts when enabled`() {
+		assertTrue(isAllowedPath(".jolli/transcripts/abc1234.json", optsOn))
+	}
+
+	@Test
+	fun `rejects transcripts when disabled`() {
+		assertFalse(isAllowedPath(".jolli/transcripts/abc1234.json", optsOff))
+	}
+
+	@Test
+	fun `allows plans`() {
+		assertTrue(isAllowedPath(".jolli/plans/MyPlan.md", optsOn))
+	}
+
+	@Test
+	fun `allows plan-progress`() {
+		assertTrue(isAllowedPath(".jolli/plan-progress/MyPlan.json", optsOn))
+	}
+
+	@Test
+	fun `allows notes`() {
+		assertTrue(isAllowedPath(".jolli/notes/my-note.md", optsOn))
+	}
+
+	// ── Dot-prefixed rejection ───────────────────────────────────────
+
+	@Test
+	fun `rejects dot-prefixed directories`() {
+		assertFalse(isAllowedPath(".git/config", optsOn))
+		assertFalse(isAllowedPath(".vscode/settings.json", optsOn))
+	}
+
+	@Test
+	fun `rejects dot-prefixed files`() {
+		assertFalse(isAllowedPath(".DS_Store", optsOn))
+		assertFalse(isAllowedPath(".gitignore", optsOn)) // AllowList doesn't know about root gitignore
+	}
+
+	// ── Empty / bare ─────────────────────────────────────────────────
+
+	@Test
+	fun `rejects empty path`() {
+		assertFalse(isAllowedPath("", optsOn))
+	}
+
+	@Test
+	fun `rejects bare jolli directory`() {
+		assertFalse(isAllowedPath(".jolli", optsOn))
+	}
+
+	// ── Backslash separator ──────────────────────────────────────────
+
+	@Test
+	fun `handles backslash separators`() {
+		assertTrue(isAllowedPath(".jolli\\summaries\\abc1234.json", optsOn))
+	}
+}

--- a/intellij/src/test/kotlin/ai/jolli/jollimemory/sync/ConflictResolverTest.kt
+++ b/intellij/src/test/kotlin/ai/jolli/jollimemory/sync/ConflictResolverTest.kt
@@ -1,0 +1,349 @@
+package ai.jolli.jollimemory.sync
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Path
+
+class ConflictResolverTest {
+
+	@TempDir
+	lateinit var tempDir: Path
+
+	// ── isAggregatePath ────────────────────────────────────────────────
+
+	@Test
+	fun `isAggregatePath matches repo-prefixed aggregate files`() {
+		assertTrue(isAggregatePath("myrepo/.jolli/manifest.json"))
+		assertTrue(isAggregatePath("myrepo/.jolli/index.json"))
+		assertTrue(isAggregatePath("myrepo/.jolli/branches.json"))
+		assertTrue(isAggregatePath("myrepo/.jolli/catalog.json"))
+	}
+
+	@Test
+	fun `isAggregatePath matches repos json`() {
+		assertTrue(isAggregatePath(".jolli/repos.json"))
+	}
+
+	@Test
+	fun `isAggregatePath rejects non-aggregate files`() {
+		assertFalse(isAggregatePath("myrepo/.jolli/summaries/abc.json"))
+		assertFalse(isAggregatePath("manifest.json"))
+		assertFalse(isAggregatePath("myrepo/manifest.json"))
+	}
+
+	// ── isMemoryBankAppendOnlyPath ─────────────────────────────────────
+
+	@Test
+	fun `isMemoryBankAppendOnlyPath accepts 3-segment md paths`() {
+		assertTrue(isMemoryBankAppendOnlyPath("repo/main/summary-abc123.md"))
+		assertTrue(isMemoryBankAppendOnlyPath("repo/feature-x/plan--task.md"))
+	}
+
+	@Test
+	fun `isMemoryBankAppendOnlyPath rejects short paths`() {
+		assertFalse(isMemoryBankAppendOnlyPath("notes.md"))
+		assertFalse(isMemoryBankAppendOnlyPath("repo/notes.md"))
+	}
+
+	@Test
+	fun `isMemoryBankAppendOnlyPath rejects jolli paths`() {
+		assertFalse(isMemoryBankAppendOnlyPath("repo/.jolli/something/file.md"))
+	}
+
+	@Test
+	fun `isMemoryBankAppendOnlyPath rejects non-md`() {
+		assertFalse(isMemoryBankAppendOnlyPath("repo/main/data.json"))
+	}
+
+	// ── unionMarkdown ──────────────────────────────────────────────────
+
+	@Test
+	fun `unionMarkdown appends with separator`() {
+		val result = unionMarkdown("# Ours\nContent A", "# Theirs\nContent B")
+		assertTrue(result.contains("Content A"))
+		assertTrue(result.contains("Content B"))
+		assertTrue(result.contains("---"))
+		assertTrue(result.contains("Synced from another device"))
+	}
+
+	@Test
+	fun `unionMarkdown idempotent when ours contains theirs`() {
+		val ours = "# Title\nPart A\nPart B"
+		val theirs = "Part A"
+		assertEquals(ours, unionMarkdown(ours, theirs))
+	}
+
+	@Test
+	fun `unionMarkdown idempotent when theirs contains ours`() {
+		val ours = "Part A"
+		val theirs = "# Title\nPart A\nPart B"
+		assertEquals(theirs, unionMarkdown(ours, theirs))
+	}
+
+	// ── normalizeForCompare ────────────────────────────────────────────
+
+	@Test
+	fun `normalizeForCompare strips CRLF trailing whitespace trailing newlines`() {
+		assertEquals(
+			normalizeForCompare("hello  \r\nworld\t \n\n"),
+			normalizeForCompare("hello\nworld\n"),
+		)
+	}
+
+	@Test
+	fun `normalizeForCompare makes identical content match`() {
+		val a = "line1  \nline2\n\n"
+		val b = "line1\r\nline2"
+		assertEquals(normalizeForCompare(a), normalizeForCompare(b))
+	}
+
+	// ── classifyDeleteVsModify ─────────────────────────────────────────
+
+	@Test
+	fun `classifyDeleteVsModify respects delete when base matches present`() {
+		val result = classifyDeleteVsModify("unchanged content", "unchanged content", "mine-deleted")
+		assertTrue(result is SafeHeuristicResult.Delete)
+		assertEquals("respect-mine-deleted", (result as SafeHeuristicResult.Delete).via)
+	}
+
+	@Test
+	fun `classifyDeleteVsModify accepts add when base is null`() {
+		val result = classifyDeleteVsModify(null, "new content", "theirs-deleted")
+		assertTrue(result is SafeHeuristicResult.Merged)
+		assertEquals("new content", (result as SafeHeuristicResult.Merged).merged)
+	}
+
+	@Test
+	fun `classifyDeleteVsModify returns null on genuine conflict`() {
+		val result = classifyDeleteVsModify("base version", "modified version", "mine-deleted")
+		assertNull(result)
+	}
+
+	// ── Tier 2.7 heuristics (via ConflictResolver.trySafeHeuristics) ──
+
+	@Nested
+	inner class SafeHeuristics {
+
+		private fun makeResolver(): ConflictResolver {
+			val runner = ScriptedRunner()
+			val client = SyncGitClient(
+				vaultRoot = tempDir.toString(),
+				credentials = fakeCreds(),
+				processRunner = runner,
+			)
+			return ConflictResolver(
+				client = client,
+				ai = null,
+				ui = object : ConflictUi {
+					override fun promptBinaryPick(path: String, oursOid: String?, theirsOid: String?) = Tier3Pick.MINE
+				},
+			)
+		}
+
+		@Test
+		fun `empty ours picks theirs via trySafeHeuristics`() {
+			val resolver = makeResolver()
+			val result = resolver.trySafeHeuristics("file.md", null, "  \n  ", "real content")
+			assertTrue(result is SafeHeuristicResult.Merged)
+			assertEquals("real content", (result as SafeHeuristicResult.Merged).merged)
+			assertEquals("empty-mine", result.via)
+		}
+
+		@Test
+		fun `empty theirs picks ours`() {
+			val resolver = makeResolver()
+			val result = resolver.trySafeHeuristics("file.md", null, "real content", "  ")
+			assertTrue(result is SafeHeuristicResult.Merged)
+			assertEquals("real content", (result as SafeHeuristicResult.Merged).merged)
+			assertEquals("empty-theirs", result.via)
+		}
+
+		@Test
+		fun `identical after normalize picks ours`() {
+			val resolver = makeResolver()
+			val result = resolver.trySafeHeuristics("file.md", null, "hello  \n", "hello\r\n")
+			assertTrue(result is SafeHeuristicResult.Merged)
+			assertEquals("hello  \n", (result as SafeHeuristicResult.Merged).merged)
+			assertEquals("identical-after-normalize", result.via)
+		}
+
+		@Test
+		fun `append-only md path unions`() {
+			val resolver = makeResolver()
+			val result = resolver.trySafeHeuristics("repo/main/summary.md", null, "A content", "B content")
+			assertTrue(result is SafeHeuristicResult.Merged)
+			val merged = (result as SafeHeuristicResult.Merged).merged
+			assertTrue(merged.contains("A content"))
+			assertTrue(merged.contains("B content"))
+			assertEquals("memory-bank-summary-union", result.via)
+		}
+
+		@Test
+		fun `genuinely different non-md content returns null`() {
+			val resolver = makeResolver()
+			val result = resolver.trySafeHeuristics("file.txt", null, "version A", "version B")
+			assertNull(result)
+		}
+	}
+
+	// ── Full resolveAll with scripted ProcessRunner ────────────────────
+
+	@Test
+	fun `policy MINE resolves without UI via checkoutOurs`() {
+		val gitCmds = mutableListOf<List<String>>()
+		val runner = ScriptedRunner { args ->
+			gitCmds.add(args)
+			conflictingStages(args)
+		}
+		val client = SyncGitClient(
+			vaultRoot = tempDir.toString(),
+			credentials = fakeCreds(),
+			processRunner = runner,
+		)
+		val resolver = ConflictResolver(
+			client = client,
+			ai = null,
+			ui = object : ConflictUi {
+				override fun promptBinaryPick(path: String, oursOid: String?, theirsOid: String?): Tier3Pick {
+					throw AssertionError("UI should not be called with MINE policy")
+				}
+			},
+			writeFile = { _, _ -> },
+			policy = ConflictPolicy.MINE,
+		)
+
+		val report = resolver.resolveAll(listOf("file.md"))
+		assertTrue(report.rebaseAdvanced)
+		assertEquals(1, report.binaryPicked.size)
+		assertEquals("mine", report.binaryPicked[0].pick)
+		// checkoutOurs calls `git checkout --theirs` (rebase swap)
+		assertTrue(gitCmds.any { it.contains("--theirs") })
+	}
+
+	@Test
+	fun `skip causes rebaseAbort`() {
+		val gitCmds = mutableListOf<List<String>>()
+		val runner = ScriptedRunner { args ->
+			gitCmds.add(args)
+			conflictingStages(args)
+		}
+		val client = SyncGitClient(
+			vaultRoot = tempDir.toString(),
+			credentials = fakeCreds(),
+			processRunner = runner,
+		)
+		val resolver = ConflictResolver(
+			client = client,
+			ai = null,
+			ui = object : ConflictUi {
+				override fun promptBinaryPick(path: String, oursOid: String?, theirsOid: String?) = Tier3Pick.SKIP
+			},
+			writeFile = { _, _ -> },
+			policy = ConflictPolicy.PROMPT,
+		)
+
+		val report = resolver.resolveAll(listOf("file.md"))
+		assertFalse(report.rebaseAdvanced)
+		assertEquals(1, report.skipped.size)
+		assertTrue(gitCmds.any { it.contains("--abort") })
+	}
+
+	@Test
+	fun `aggregate paths resolve via tier 1-5`() {
+		val writes = mutableMapOf<String, String>()
+		val gitCmds = mutableListOf<List<String>>()
+		val manifestOurs = """{"version":1,"files":[{"path":"a.json","fileId":"f1","type":"commit","fingerprint":"fp","title":"t","source":{"commitHash":"c1","branch":"main","generatedAt":"2024-01-01T00:00:00Z"}}]}"""
+		val manifestTheirs = """{"version":1,"files":[{"path":"b.json","fileId":"f2","type":"commit","fingerprint":"fp","title":"t","source":{"commitHash":"c2","branch":"main","generatedAt":"2024-01-02T00:00:00Z"}}]}"""
+
+		val runner = ScriptedRunner { args ->
+			// Respond to `git show :<stage>:<path>`
+			val showArg = args.find { it.startsWith(":") }
+			if (args.contains("show") && showArg != null) {
+				if (showArg == ":2:repo/.jolli/manifest.json") {
+					return@ScriptedRunner ExecResult(manifestOurs, "", 0)
+				}
+				if (showArg == ":3:repo/.jolli/manifest.json") {
+					return@ScriptedRunner ExecResult(manifestTheirs, "", 0)
+				}
+				// Stage 1 (base) — not found
+				return@ScriptedRunner ExecResult("", "not found", 1)
+			}
+			gitCmds.add(args)
+			ExecResult("", "", 0)
+		}
+		val client = SyncGitClient(
+			vaultRoot = tempDir.toString(),
+			credentials = fakeCreds(),
+			processRunner = runner,
+		)
+		val resolver = ConflictResolver(
+			client = client,
+			ai = null,
+			ui = object : ConflictUi {
+				override fun promptBinaryPick(path: String, oursOid: String?, theirsOid: String?): Tier3Pick {
+					throw AssertionError("UI should not be called for aggregate paths")
+				}
+			},
+			writeFile = { path, content -> writes[path] = content },
+			policy = ConflictPolicy.PROMPT,
+		)
+
+		val report = resolver.resolveAll(listOf("repo/.jolli/manifest.json"))
+		assertTrue(report.rebaseAdvanced)
+		assertEquals(1, report.aggregateMerged.size)
+		val mergedContent = writes.values.first()
+		assertTrue(mergedContent.contains("f1"))
+		assertTrue(mergedContent.contains("f2"))
+	}
+
+	// ── Helpers ────────────────────────────────────────────────────────
+
+	companion object {
+		fun fakeCreds() = GitCredentials(
+			gitUrl = "https://example.com/repo.git",
+			token = "ghs_test",
+			expiresAt = System.currentTimeMillis() + 3_600_000L,
+			repoFullName = "test/vault",
+			defaultBranch = "main",
+			githubRepoCreated = false,
+			alreadyVaultBound = true,
+			lockOwnerToken = "lock-123",
+		)
+	}
+
+	/**
+	 * A [ProcessRunner] that delegates to a handler function.
+	 */
+	/**
+	 * Scripts `git show :2:<path>` / `:3:<path>` to return distinct, non-empty
+	 * index-stage content so a path is a genuine conflict that reaches Tier 3.
+	 * Returning empty stdout (the bare default) makes ours == theirs == "", which
+	 * Tier 2.7's "identical-after-normalize" rule resolves before Tier 3 runs.
+	 * All other git commands succeed with empty output.
+	 */
+	private fun conflictingStages(args: List<String>): ExecResult {
+		// `git show :<stage>:<path>` — scan for the stage token rather than a
+		// fixed index: run() prepends git-hardening `-c` flags before the args.
+		if (args.contains("show")) {
+			if (args.any { it.startsWith(":2:") }) return ExecResult("ours content\n", "", 0)
+			if (args.any { it.startsWith(":3:") }) return ExecResult("theirs content\n", "", 0)
+		}
+		return ExecResult("", "", 0)
+	}
+
+	private class ScriptedRunner(
+		private val handler: (List<String>) -> ExecResult = { ExecResult("", "", 0) },
+	) : ProcessRunner {
+		override fun exec(
+			command: List<String>,
+			cwd: String?,
+			env: Map<String, String>,
+			timeoutMs: Long?,
+		): ExecResult {
+			val gitArgs = command.drop(1) // drop "git"
+			return handler(gitArgs)
+		}
+	}
+}

--- a/intellij/src/test/kotlin/ai/jolli/jollimemory/sync/GitErrorClassifiersTest.kt
+++ b/intellij/src/test/kotlin/ai/jolli/jollimemory/sync/GitErrorClassifiersTest.kt
@@ -1,0 +1,123 @@
+package ai.jolli.jollimemory.sync
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+
+class GitErrorClassifiersTest {
+
+	// ── isRepoMissingMessage ──────────────────────────────────────────
+
+	@Test
+	fun `detects remote repository not found`() {
+		assertTrue(isRepoMissingMessage("remote: Repository not found.\nfatal: ..."))
+	}
+
+	@Test
+	fun `detects repository URL not found`() {
+		assertTrue(isRepoMissingMessage("fatal: repository 'https://github.com/x/y.git' not found"))
+	}
+
+	@Test
+	fun `detects 404 error`() {
+		assertTrue(isRepoMissingMessage("The requested URL returned error: 404"))
+	}
+
+	@Test
+	fun `detects fatal not found`() {
+		assertTrue(isRepoMissingMessage("fatal: not found"))
+	}
+
+	@Test
+	fun `does not match unrelated message for repo missing`() {
+		assertFalse(isRepoMissingMessage("everything up-to-date"))
+	}
+
+	// ── isNetworkErrorMessage ─────────────────────────────────────────
+
+	@Test
+	fun `detects DNS failure`() {
+		assertTrue(isNetworkErrorMessage("fatal: unable to access: Could not resolve host: github.com"))
+	}
+
+	@Test
+	fun `detects connection timeout`() {
+		assertTrue(isNetworkErrorMessage("fatal: unable to access: Connection timed out"))
+	}
+
+	@Test
+	fun `detects connection refused`() {
+		assertTrue(isNetworkErrorMessage("fatal: unable to access: Connection refused"))
+	}
+
+	@Test
+	fun `detects TLS handshake failure`() {
+		assertTrue(isNetworkErrorMessage("GnuTLS recv error (-110): The TLS connection was non-properly terminated"))
+	}
+
+	@Test
+	fun `detects SSL error`() {
+		assertTrue(isNetworkErrorMessage("error: SSL certificate problem"))
+	}
+
+	@Test
+	fun `detects early EOF`() {
+		assertTrue(isNetworkErrorMessage("error: early EOF"))
+	}
+
+	@Test
+	fun `detects remote hung up`() {
+		assertTrue(isNetworkErrorMessage("fatal: the remote end hung up unexpectedly"))
+	}
+
+	@Test
+	fun `detects RPC failure`() {
+		assertTrue(isNetworkErrorMessage("error: RPC failed; curl 56"))
+	}
+
+	@Test
+	fun `detects network unreachable`() {
+		assertTrue(isNetworkErrorMessage("fatal: unable to access: Network is unreachable"))
+	}
+
+	@Test
+	fun `does not match unrelated message for network`() {
+		assertFalse(isNetworkErrorMessage("non-fast-forward"))
+	}
+
+	// ── isServerRejectionMessage ──────────────────────────────────────
+
+	@Test
+	fun `detects pre-receive hook declined`() {
+		assertTrue(isServerRejectionMessage("remote: error: pre-receive hook declined"))
+	}
+
+	@Test
+	fun `detects protected branch`() {
+		assertTrue(isServerRejectionMessage("remote: error: GH006: Protected branch update failed"))
+	}
+
+	@Test
+	fun `detects push too large`() {
+		assertTrue(isServerRejectionMessage("remote: error: push file too large"))
+	}
+
+	@Test
+	fun `detects file exceeds limit`() {
+		assertTrue(isServerRejectionMessage("remote: error: File exceeds 100MB limit"))
+	}
+
+	@Test
+	fun `detects permission denied`() {
+		assertTrue(isServerRejectionMessage("remote: Permission to user/repo.git denied to bot"))
+	}
+
+	@Test
+	fun `detects refusing to update checked out branch`() {
+		assertTrue(isServerRejectionMessage("remote: error: refusing to update checked out branch"))
+	}
+
+	@Test
+	fun `does not match unrelated message for server rejection`() {
+		assertFalse(isServerRejectionMessage("everything up-to-date"))
+	}
+}

--- a/intellij/src/test/kotlin/ai/jolli/jollimemory/sync/LocalAiMergeProviderTest.kt
+++ b/intellij/src/test/kotlin/ai/jolli/jollimemory/sync/LocalAiMergeProviderTest.kt
@@ -1,0 +1,100 @@
+package ai.jolli.jollimemory.sync
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class LocalAiMergeProviderTest {
+
+	// ── buildPrompt ────────────────────────────────────────────────────
+
+	@Test
+	fun `buildPrompt includes markers with token`() {
+		val req = AiMergeRequest("file.md", "base", "ours", "theirs", "md")
+		val prompt = buildPrompt(req, "abc123")
+		assertTrue(prompt.contains("BEGIN_MERGED_abc123"))
+		assertTrue(prompt.contains("END_MERGED_abc123"))
+		assertTrue(prompt.contains("CONFIDENCE="))
+		assertTrue(prompt.contains("file.md"))
+	}
+
+	@Test
+	fun `buildPrompt handles null base`() {
+		val req = AiMergeRequest("file.json", null, "ours", "theirs", "json")
+		val prompt = buildPrompt(req, "token")
+		assertTrue(prompt.contains("no common ancestor"))
+		assertTrue(prompt.contains("valid JSON"))
+	}
+
+	@Test
+	fun `buildPrompt includes base when present`() {
+		val req = AiMergeRequest("file.md", "base content", "ours", "theirs", "md")
+		val prompt = buildPrompt(req, "token")
+		assertTrue(prompt.contains("base content"))
+		assertTrue(prompt.contains("BASE:"))
+	}
+
+	// ── parseModelOutput ───────────────────────────────────────────────
+
+	@Test
+	fun `parseModelOutput extracts body and confidence`() {
+		val text = """
+CONFIDENCE=0.85
+BEGIN_MERGED_token123
+merged content here
+line two
+END_MERGED_token123
+""".trimIndent()
+		val result = parseModelOutput(text, "token123")
+		assertEquals(0.85, result.confidence, 0.001)
+		assertEquals("merged content here\nline two", result.merged)
+	}
+
+	@Test
+	fun `parseModelOutput clamps confidence to 0-1`() {
+		val text = "CONFIDENCE=1.50\nBEGIN_MERGED_t\nbody\nEND_MERGED_t"
+		val result = parseModelOutput(text, "t")
+		assertEquals(1.0, result.confidence, 0.001)
+
+		val text2 = "CONFIDENCE=-0.5\nBEGIN_MERGED_t\nbody\nEND_MERGED_t"
+		val result2 = parseModelOutput(text2, "t")
+		assertEquals(0.0, result2.confidence, 0.001)
+	}
+
+	@Test
+	fun `parseModelOutput tolerates trimmed marker lines`() {
+		val text = "CONFIDENCE=0.90\n  BEGIN_MERGED_tok  \nthe body\n  END_MERGED_tok  "
+		val result = parseModelOutput(text, "tok")
+		assertEquals("the body", result.merged)
+	}
+
+	@Test
+	fun `parseModelOutput throws on missing confidence`() {
+		val text = "NO_CONFIDENCE\nBEGIN_MERGED_t\nbody\nEND_MERGED_t"
+		assertThrows<RuntimeException> { parseModelOutput(text, "t") }
+	}
+
+	@Test
+	fun `parseModelOutput throws on missing markers`() {
+		val text = "CONFIDENCE=0.5\nno markers here"
+		assertThrows<RuntimeException> { parseModelOutput(text, "t") }
+	}
+
+	@Test
+	fun `parseModelOutput throws on too-short response`() {
+		assertThrows<RuntimeException> { parseModelOutput("short", "t") }
+	}
+
+	@Test
+	fun `parseModelOutput uses first end marker`() {
+		val text = "CONFIDENCE=0.9\nBEGIN_MERGED_t\nreal body\nEND_MERGED_t\nextra\nEND_MERGED_t"
+		val result = parseModelOutput(text, "t")
+		assertEquals("real body", result.merged)
+	}
+
+	@Test
+	fun `parseModelOutput rejects wrong token`() {
+		val text = "CONFIDENCE=0.9\nBEGIN_MERGED_wrong\nbody\nEND_MERGED_wrong"
+		assertThrows<RuntimeException> { parseModelOutput(text, "correct") }
+	}
+}

--- a/intellij/src/test/kotlin/ai/jolli/jollimemory/sync/LockPrimitivesTest.kt
+++ b/intellij/src/test/kotlin/ai/jolli/jollimemory/sync/LockPrimitivesTest.kt
@@ -1,0 +1,173 @@
+package ai.jolli.jollimemory.sync
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.attribute.FileTime
+import java.time.Instant
+
+class LockPrimitivesTest {
+
+	@TempDir
+	lateinit var tempDir: Path
+
+	// ── tryAcquireOnce ───────────────────────────────────────────────
+
+	@Test
+	fun `acquires lock on empty directory`() {
+		val lockPath = tempDir.resolve("test.lock")
+		assertTrue(LockPrimitives.tryAcquireOnce(lockPath))
+		assertTrue(Files.exists(lockPath))
+		val content = Files.readString(lockPath).trim()
+		assertEquals(ProcessHandle.current().pid().toString(), content)
+	}
+
+	@Test
+	fun `fails when lock is fresh and held by current process`() {
+		val lockPath = tempDir.resolve("test.lock")
+		assertTrue(LockPrimitives.tryAcquireOnce(lockPath))
+		// Second attempt should fail — lock is fresh and PID is alive.
+		assertFalse(LockPrimitives.tryAcquireOnce(lockPath))
+	}
+
+	@Test
+	fun `reclaims stale lock`() {
+		val lockPath = tempDir.resolve("test.lock")
+		Files.writeString(lockPath, "99999999") // fake PID
+		// Set mtime to 10 minutes ago.
+		val oldTime = Instant.now().minusMillis(10 * 60 * 1000)
+		Files.setLastModifiedTime(lockPath, FileTime.from(oldTime))
+		assertTrue(LockPrimitives.tryAcquireOnce(lockPath))
+	}
+
+	@Test
+	fun `reclaims lock with dead PID even if mtime is fresh`() {
+		val lockPath = tempDir.resolve("test.lock")
+		// PID 99999999 is almost certainly not running.
+		Files.writeString(lockPath, "99999999")
+		assertTrue(LockPrimitives.tryAcquireOnce(lockPath))
+	}
+
+	// ── releaseIfOwned ───────────────────────────────────────────────
+
+	@Test
+	fun `releases own lock`() {
+		val lockPath = tempDir.resolve("test.lock")
+		LockPrimitives.tryAcquireOnce(lockPath)
+		assertTrue(Files.exists(lockPath))
+		LockPrimitives.releaseIfOwned(lockPath, "test")
+		assertFalse(Files.exists(lockPath))
+	}
+
+	@Test
+	fun `does not release lock held by another PID`() {
+		val lockPath = tempDir.resolve("test.lock")
+		Files.writeString(lockPath, "99999999")
+		LockPrimitives.releaseIfOwned(lockPath, "test")
+		// File should still exist — we didn't own it.
+		assertTrue(Files.exists(lockPath))
+	}
+
+	@Test
+	fun `release is no-op on missing file`() {
+		val lockPath = tempDir.resolve("nonexistent.lock")
+		// Should not throw.
+		LockPrimitives.releaseIfOwned(lockPath, "test")
+	}
+
+	// ── acquireWithPoll ──────────────────────────────────────────────
+
+	@Test
+	fun `acquireWithPoll succeeds immediately when no contention`() {
+		val lockPath = tempDir.resolve("test.lock")
+		assertTrue(LockPrimitives.acquireWithPoll(lockPath, 1000, 50))
+	}
+
+	@Test
+	fun `acquireWithPoll times out on held lock`() {
+		val lockPath = tempDir.resolve("test.lock")
+		// Write a "held by another alive process" lock — use PID 1 which is
+		// always alive on most OSes.
+		Files.writeString(lockPath, "1")
+		assertFalse(LockPrimitives.acquireWithPoll(lockPath, 200, 50))
+	}
+
+	@Test
+	fun `acquireWithPoll with zero timeout is fail-fast`() {
+		val lockPath = tempDir.resolve("test.lock")
+		assertTrue(LockPrimitives.acquireWithPoll(lockPath, 0, 50))
+	}
+
+	// ── refreshLockMtime ─────────────────────────────────────────────
+
+	@Test
+	fun `refreshes mtime of own lock`() {
+		val lockPath = tempDir.resolve("test.lock")
+		LockPrimitives.tryAcquireOnce(lockPath)
+		val oldTime = Instant.now().minusMillis(60_000)
+		Files.setLastModifiedTime(lockPath, FileTime.from(oldTime))
+		LockPrimitives.refreshLockMtime(lockPath)
+		val newMtime = Files.getLastModifiedTime(lockPath).toMillis()
+		assertTrue(System.currentTimeMillis() - newMtime < 5000)
+	}
+
+	@Test
+	fun `does not refresh lock held by another PID`() {
+		val lockPath = tempDir.resolve("test.lock")
+		Files.writeString(lockPath, "99999999")
+		val oldTime = Instant.now().minusMillis(60_000)
+		Files.setLastModifiedTime(lockPath, FileTime.from(oldTime))
+		LockPrimitives.refreshLockMtime(lockPath)
+		val mtime = Files.getLastModifiedTime(lockPath).toMillis()
+		// Should still be old — we didn't own it.
+		assertTrue(System.currentTimeMillis() - mtime > 30_000)
+	}
+
+	// ── isLockHeld ───────────────────────────────────────────────────
+
+	@Test
+	fun `isLockHeld returns true for fresh lock`() {
+		val lockPath = tempDir.resolve("test.lock")
+		LockPrimitives.tryAcquireOnce(lockPath)
+		assertTrue(LockPrimitives.isLockHeld(lockPath))
+	}
+
+	@Test
+	fun `isLockHeld returns false for stale lock`() {
+		val lockPath = tempDir.resolve("test.lock")
+		Files.writeString(lockPath, "12345")
+		val oldTime = Instant.now().minusMillis(10 * 60 * 1000)
+		Files.setLastModifiedTime(lockPath, FileTime.from(oldTime))
+		assertFalse(LockPrimitives.isLockHeld(lockPath))
+	}
+
+	@Test
+	fun `isLockHeld returns false for missing lock`() {
+		val lockPath = tempDir.resolve("nonexistent.lock")
+		assertFalse(LockPrimitives.isLockHeld(lockPath))
+	}
+
+	// ── isPidAlive ───────────────────────────────────────────────────
+
+	@Test
+	fun `current process is alive`() {
+		assertTrue(LockPrimitives.isPidAlive(ProcessHandle.current().pid()))
+	}
+
+	@Test
+	fun `bogus PID is not alive`() {
+		assertFalse(LockPrimitives.isPidAlive(99999999))
+	}
+
+	@Test
+	fun `negative PID is not alive`() {
+		assertFalse(LockPrimitives.isPidAlive(-1))
+	}
+
+	@Test
+	fun `zero PID is not alive`() {
+		assertFalse(LockPrimitives.isPidAlive(0))
+	}
+}

--- a/intellij/src/test/kotlin/ai/jolli/jollimemory/sync/PendingLockStoreTest.kt
+++ b/intellij/src/test/kotlin/ai/jolli/jollimemory/sync/PendingLockStoreTest.kt
@@ -1,0 +1,68 @@
+package ai.jolli.jollimemory.sync
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Files
+import java.nio.file.Path
+
+class PendingLockStoreTest {
+
+	// NOTE: PendingLockStore uses a hardcoded path under ~/.jolli/jollimemory/.
+	// These tests exercise the read/write/clear logic by writing directly to
+	// that location. In a real test environment, we'd use a temp override.
+	// For now, we test the data structures and hash consistency.
+
+	@Test
+	fun `ReadPendingLockResult holds correct values`() {
+		val result = ReadPendingLockResult(
+			lockOwnerToken = "token-123",
+			mintedAt = 1000L,
+		)
+		assertEquals("token-123", result.lockOwnerToken)
+		assertEquals(1000L, result.mintedAt)
+	}
+
+	@Test
+	fun `read returns null for missing file`() {
+		// Before any write, read should return null for any key.
+		// This may read from the real path but that's fine — it's a read-only check.
+		val result = PendingLockStore.read("sk-jol-nonexistent-key-for-testing-only")
+		assertNull(result)
+	}
+
+	@Test
+	fun `write and read round-trip`() {
+		val testKey = "sk-jol-test-key-pending-lock-roundtrip-${System.nanoTime()}"
+		try {
+			PendingLockStore.write(testKey, "lock-token-abc", 42_000L)
+			val result = PendingLockStore.read(testKey)
+			assertNotNull(result)
+			assertEquals("lock-token-abc", result!!.lockOwnerToken)
+			assertEquals(42_000L, result.mintedAt)
+		} finally {
+			PendingLockStore.clear()
+		}
+	}
+
+	@Test
+	fun `read returns null for wrong API key`() {
+		val testKey = "sk-jol-test-key-pending-lock-wrongkey-${System.nanoTime()}"
+		try {
+			PendingLockStore.write(testKey, "lock-token-xyz", 100_000L)
+			val result = PendingLockStore.read("sk-jol-different-key")
+			assertNull(result)
+		} finally {
+			PendingLockStore.clear()
+		}
+	}
+
+	@Test
+	fun `clear removes the file`() {
+		val testKey = "sk-jol-test-key-pending-lock-clear-${System.nanoTime()}"
+		PendingLockStore.write(testKey, "lock-token-clear", 200_000L)
+		PendingLockStore.clear()
+		val result = PendingLockStore.read(testKey)
+		assertNull(result)
+	}
+}

--- a/intellij/src/test/kotlin/ai/jolli/jollimemory/sync/PorcelainParserTest.kt
+++ b/intellij/src/test/kotlin/ai/jolli/jollimemory/sync/PorcelainParserTest.kt
@@ -1,0 +1,129 @@
+package ai.jolli.jollimemory.sync
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+
+class PorcelainParserTest {
+
+	@Test
+	fun `empty input returns empty list`() {
+		assertEquals(emptyList<PorcelainEntry>(), parsePorcelainZ(""))
+	}
+
+	@Test
+	fun `parses simple modified entry`() {
+		// " M src/foo.kt" — worktree modified, not staged
+		val entries = parsePorcelainZ(" M src/foo.kt\u0000")
+		assertEquals(1, entries.size)
+		val e = entries[0]
+		assertEquals(PorcelainStatus.UNCHANGED, e.indexStatus)
+		assertEquals(PorcelainStatus.M, e.worktreeStatus)
+		assertEquals("src/foo.kt", e.path)
+		assertNull(e.oldPath)
+	}
+
+	@Test
+	fun `parses added entry`() {
+		val entries = parsePorcelainZ("A  src/new.kt\u0000")
+		assertEquals(1, entries.size)
+		assertEquals(PorcelainStatus.A, entries[0].indexStatus)
+		assertEquals(PorcelainStatus.UNCHANGED, entries[0].worktreeStatus)
+		assertEquals("src/new.kt", entries[0].path)
+	}
+
+	@Test
+	fun `parses deleted entry`() {
+		val entries = parsePorcelainZ("D  old.kt\u0000")
+		assertEquals(1, entries.size)
+		assertEquals(PorcelainStatus.D, entries[0].indexStatus)
+		assertTrue(isDeletion(entries[0]))
+	}
+
+	@Test
+	fun `parses worktree deletion`() {
+		val entries = parsePorcelainZ(" D old.kt\u0000")
+		assertEquals(1, entries.size)
+		assertEquals(PorcelainStatus.D, entries[0].worktreeStatus)
+		assertTrue(isDeletion(entries[0]))
+	}
+
+	@Test
+	fun `non-deletion entry returns false for isDeletion`() {
+		val entries = parsePorcelainZ("M  src/foo.kt\u0000")
+		assertFalse(isDeletion(entries[0]))
+	}
+
+	@Test
+	fun `parses rename with oldPath pairing`() {
+		// "R  new-name.kt\0old-name.kt\0"
+		val entries = parsePorcelainZ("R  new-name.kt\u0000old-name.kt\u0000")
+		assertEquals(1, entries.size)
+		assertEquals(PorcelainStatus.R, entries[0].indexStatus)
+		assertEquals("new-name.kt", entries[0].path)
+		assertEquals("old-name.kt", entries[0].oldPath)
+	}
+
+	@Test
+	fun `parses copy entry with oldPath`() {
+		val entries = parsePorcelainZ("C  copy.kt\u0000original.kt\u0000")
+		assertEquals(1, entries.size)
+		assertEquals(PorcelainStatus.C, entries[0].indexStatus)
+		assertEquals("copy.kt", entries[0].path)
+		assertEquals("original.kt", entries[0].oldPath)
+	}
+
+	@Test
+	fun `parses untracked entry`() {
+		val entries = parsePorcelainZ("?? untracked.txt\u0000")
+		assertEquals(1, entries.size)
+		assertEquals(PorcelainStatus.UNTRACKED, entries[0].indexStatus)
+		assertEquals(PorcelainStatus.UNTRACKED, entries[0].worktreeStatus)
+	}
+
+	@Test
+	fun `parses ignored entry`() {
+		val entries = parsePorcelainZ("!! ignored.txt\u0000")
+		assertEquals(1, entries.size)
+		assertEquals(PorcelainStatus.IGNORED, entries[0].indexStatus)
+		assertEquals(PorcelainStatus.IGNORED, entries[0].worktreeStatus)
+	}
+
+	@Test
+	fun `records shorter than 3 chars are silently dropped`() {
+		val entries = parsePorcelainZ("AB\u0000M  valid.kt\u0000")
+		assertEquals(1, entries.size)
+		assertEquals("valid.kt", entries[0].path)
+	}
+
+	@Test
+	fun `multiple entries parsed correctly`() {
+		val input = "M  a.kt\u0000 D b.kt\u0000A  c.kt\u0000"
+		val entries = parsePorcelainZ(input)
+		assertEquals(3, entries.size)
+		assertEquals("a.kt", entries[0].path)
+		assertEquals("b.kt", entries[1].path)
+		assertEquals("c.kt", entries[2].path)
+	}
+
+	@Test
+	fun `unknown status character maps to OTHER`() {
+		val entries = parsePorcelainZ("X  weird.kt\u0000")
+		assertEquals(1, entries.size)
+		assertEquals(PorcelainStatus.OTHER, entries[0].indexStatus)
+	}
+
+	@Test
+	fun `type changed entry`() {
+		val entries = parsePorcelainZ("T  changed.kt\u0000")
+		assertEquals(1, entries.size)
+		assertEquals(PorcelainStatus.TYPE_CHANGED, entries[0].indexStatus)
+	}
+
+	@Test
+	fun `unmerged entry`() {
+		val entries = parsePorcelainZ("UU conflict.kt\u0000")
+		assertEquals(1, entries.size)
+		assertEquals(PorcelainStatus.UNMERGED, entries[0].indexStatus)
+		assertEquals(PorcelainStatus.UNMERGED, entries[0].worktreeStatus)
+	}
+}

--- a/intellij/src/test/kotlin/ai/jolli/jollimemory/sync/RepoMappingTest.kt
+++ b/intellij/src/test/kotlin/ai/jolli/jollimemory/sync/RepoMappingTest.kt
@@ -1,0 +1,78 @@
+package ai.jolli.jollimemory.sync
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+
+class RepoMappingTest {
+
+	@Test
+	fun `parseRepoMapping parses valid mapping`() {
+		val raw = """{"version":1,"mappings":[{"repoIdentity":"id1","folder":"folder1"}]}"""
+		val result = parseRepoMapping(raw)
+		assertNotNull(result)
+		assertEquals(1, result!!.mappings.size)
+		assertEquals("id1", result.mappings[0].repoIdentity)
+		assertEquals("folder1", result.mappings[0].folder)
+	}
+
+	@Test
+	fun `parseRepoMapping returns null on bad version`() {
+		assertNull(parseRepoMapping("""{"version":2,"mappings":[]}"""))
+	}
+
+	@Test
+	fun `parseRepoMapping returns null on invalid json`() {
+		assertNull(parseRepoMapping("not json"))
+	}
+
+	@Test
+	fun `parseRepoMapping returns null on missing mappings`() {
+		assertNull(parseRepoMapping("""{"version":1}"""))
+	}
+
+	@Test
+	fun `serializeRepoMapping produces canonical json with trailing newline`() {
+		val mapping = RepoMappingFile(1, listOf(RepoMappingEntry("id1", "f1")))
+		val serialized = serializeRepoMapping(mapping)
+		assertTrue(serialized.endsWith("\n"))
+		assertTrue(serialized.contains("\"repoIdentity\""))
+	}
+
+	@Test
+	fun `mergeRepoMapping unions by repoIdentity`() {
+		val local = RepoMappingFile(1, listOf(RepoMappingEntry("id1", "f1")))
+		val remote = RepoMappingFile(1, listOf(RepoMappingEntry("id2", "f2")))
+		val (merged, conflicts) = mergeRepoMapping(local, remote)
+		assertEquals(2, merged.mappings.size)
+		assertTrue(conflicts.isEmpty())
+	}
+
+	@Test
+	fun `mergeRepoMapping remote overrides local on same identity`() {
+		val local = RepoMappingFile(1, listOf(RepoMappingEntry("id1", "old-folder")))
+		val remote = RepoMappingFile(1, listOf(RepoMappingEntry("id1", "new-folder")))
+		val (merged, _) = mergeRepoMapping(local, remote)
+		assertEquals(1, merged.mappings.size)
+		assertEquals("new-folder", merged.mappings[0].folder)
+	}
+
+	@Test
+	fun `mergeRepoMapping detects folder collisions`() {
+		val local = RepoMappingFile(1, listOf(RepoMappingEntry("id1", "shared-folder")))
+		val remote = RepoMappingFile(1, listOf(RepoMappingEntry("id2", "shared-folder")))
+		val (merged, conflicts) = mergeRepoMapping(local, remote)
+		assertEquals(2, merged.mappings.size)
+		assertEquals(1, conflicts.size)
+		assertEquals("shared-folder", conflicts[0].folder)
+		assertEquals(listOf("id1", "id2"), conflicts[0].identities)
+	}
+
+	@Test
+	fun `mergeRepoMapping output sorted by repoIdentity`() {
+		val local = RepoMappingFile(1, listOf(RepoMappingEntry("zzz", "f1")))
+		val remote = RepoMappingFile(1, listOf(RepoMappingEntry("aaa", "f2")))
+		val (merged, _) = mergeRepoMapping(local, remote)
+		assertEquals("aaa", merged.mappings[0].repoIdentity)
+		assertEquals("zzz", merged.mappings[1].repoIdentity)
+	}
+}

--- a/intellij/src/test/kotlin/ai/jolli/jollimemory/sync/RepoMappingTest.kt
+++ b/intellij/src/test/kotlin/ai/jolli/jollimemory/sync/RepoMappingTest.kt
@@ -75,4 +75,40 @@ class RepoMappingTest {
 		assertEquals("aaa", merged.mappings[0].repoIdentity)
 		assertEquals("zzz", merged.mappings[1].repoIdentity)
 	}
+
+	@Test
+	fun `mergeRepoMapping folds an SSH-style remote row into the https row for the same repo`() {
+		// Local stored its identity via https; another client pushed the SCP/SSH
+		// form. They are the same repo and must collapse to one row, not survive
+		// as a duplicate (split Memory Bank).
+		val local = RepoMappingFile(1, listOf(RepoMappingEntry("https://github.com/jolliai/jolli", "jolli")))
+		val remote = RepoMappingFile(1, listOf(RepoMappingEntry("git@github.com:jolliai/jolli", "jolli")))
+		val (merged, conflicts) = mergeRepoMapping(local, remote)
+		assertEquals(1, merged.mappings.size)
+		assertEquals("https://github.com/jolliai/jolli", merged.mappings[0].repoIdentity)
+		assertEquals("jolli", merged.mappings[0].folder)
+		assertTrue(conflicts.isEmpty())
+	}
+
+	@Test
+	fun `mergeRepoMapping leaves bare non-URL identities untouched`() {
+		// A remote-less fallback identity (folder/repo name) never went through
+		// transport folding at compute time, so it must NOT be re-normalized
+		// (e.g. `foo.git` must not have its suffix stripped into `foo`).
+		val local = RepoMappingFile(1, listOf(RepoMappingEntry("foo.git", "foo-git")))
+		val remote = RepoMappingFile(1, listOf(RepoMappingEntry("foo", "foo")))
+		val (merged, _) = mergeRepoMapping(local, remote)
+		assertEquals(2, merged.mappings.size)
+		assertEquals(setOf("foo", "foo.git"), merged.mappings.map { it.repoIdentity }.toSet())
+	}
+
+	@Test
+	fun `canonicalizeRepoIdentity folds SSH and SCP forms but preserves bare names`() {
+		assertEquals("https://github.com/jolliai/jolli", canonicalizeRepoIdentity("git@github.com:jolliai/jolli"))
+		assertEquals("https://github.com/jolliai/jolli", canonicalizeRepoIdentity("git@github.com:jolliai/jolli.git"))
+		assertEquals("https://github.com/jolliai/jolli", canonicalizeRepoIdentity("https://github.com/jolliai/jolli"))
+		// Bare identities are passed through verbatim (gating).
+		assertEquals("foo.git", canonicalizeRepoIdentity("foo.git"))
+		assertEquals("my-repo", canonicalizeRepoIdentity("my-repo"))
+	}
 }

--- a/intellij/src/test/kotlin/ai/jolli/jollimemory/sync/StageVaultTest.kt
+++ b/intellij/src/test/kotlin/ai/jolli/jollimemory/sync/StageVaultTest.kt
@@ -1,0 +1,188 @@
+package ai.jolli.jollimemory.sync
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Files
+import java.nio.file.Path
+
+class StageVaultTest {
+
+	@TempDir
+	lateinit var tempDir: Path
+
+	private fun staticRunner(result: ExecResult): ProcessRunner {
+		return object : ProcessRunner {
+			override fun exec(command: List<String>, cwd: String?, env: Map<String, String>, timeoutMs: Long?): ExecResult {
+				return result
+			}
+		}
+	}
+
+	private class RecordingRunner(private val responses: ArrayDeque<ExecResult>) : ProcessRunner {
+		val calls = mutableListOf<List<String>>()
+		override fun exec(command: List<String>, cwd: String?, env: Map<String, String>, timeoutMs: Long?): ExecResult {
+			calls.add(command)
+			return if (responses.isNotEmpty()) responses.removeFirst() else ExecResult("", "", 0)
+		}
+	}
+
+	private val defaultCredentials = GitCredentials(
+		token = "ghs_test",
+		gitUrl = "https://github.com/test/vault.git",
+		expiresAt = System.currentTimeMillis() + 3_600_000L,
+		repoFullName = "test/vault",
+		defaultBranch = "main",
+		githubRepoCreated = false,
+		alreadyVaultBound = false,
+		lockOwnerToken = "lock-123",
+	)
+
+	private val fakeAskpass: (String) -> AskpassHandle = { _ ->
+		AskpassHandle(
+			scriptPath = "/fake/askpass.sh",
+			env = mapOf("GIT_ASKPASS" to "/fake/askpass.sh"),
+		)
+	}
+
+	/**
+	 * Creates a SyncGitClient backed by a [RecordingRunner] that returns
+	 * canned responses. The runner records all commands for assertion.
+	 */
+	private fun clientWithRunner(runner: ProcessRunner): SyncGitClient {
+		return SyncGitClient(
+			vaultRoot = tempDir.toString(),
+			credentials = defaultCredentials,
+			askpassProvider = fakeAskpass,
+			processRunner = runner,
+		)
+	}
+
+	// ── Empty status ─────────────────────────────────────────────────
+
+	@Test
+	fun `empty status produces empty report`() {
+		val runner = staticRunner(ExecResult(stdout = "", stderr = "", exitCode = 0))
+		val client = clientWithRunner(runner)
+		val report = stageVault(client, tempDir.toString(), StageVaultOpts(syncTranscripts = true))
+		assertEquals(0, report.added)
+		assertEquals(0, report.removed)
+		assertEquals(0, report.skipped)
+		assertTrue(report.unowned.isEmpty())
+		assertTrue(report.symlinked.isEmpty())
+	}
+
+	// ── Classify and stage ───────────────────────────────────────────
+
+	@Test
+	fun `stages owned add and tracks kind`() {
+		// Simulate: new file my-repo/.jolli/config.json (added, untracked)
+		val statusOutput = "?? my-repo/.jolli/config.json\u0000"
+		val recording = RecordingRunner(
+			ArrayDeque(
+				listOf(
+					// statusPorcelainZ
+					ExecResult(stdout = statusOutput, stderr = "", exitCode = 0),
+					// stageAddPaths
+					ExecResult(stdout = "", stderr = "", exitCode = 0),
+				)
+			)
+		)
+		val client = clientWithRunner(recording)
+
+		// Create the file on disk so symlink check passes.
+		val filePath = tempDir.resolve("my-repo/.jolli/config.json")
+		Files.createDirectories(filePath.parent)
+		Files.writeString(filePath, "{}")
+
+		val report = stageVault(client, tempDir.toString(), StageVaultOpts(syncTranscripts = true))
+		assertEquals(1, report.added)
+		assertEquals(0, report.removed)
+		assertTrue(report.unowned.isEmpty())
+	}
+
+	// ── Unowned paths ────────────────────────────────────────────────
+
+	@Test
+	fun `unowned paths are not staged`() {
+		val statusOutput = "?? .DS_Store\u0000"
+		val runner = staticRunner(ExecResult(stdout = statusOutput, stderr = "", exitCode = 0))
+		val client = clientWithRunner(runner)
+		val report = stageVault(client, tempDir.toString(), StageVaultOpts(syncTranscripts = true))
+		assertEquals(0, report.added)
+		assertEquals(1, report.unowned.size)
+		assertEquals(".DS_Store", report.unowned[0])
+	}
+
+	// ── Transcript filtering ─────────────────────────────────────────
+
+	@Test
+	fun `transcripts skipped when syncTranscripts is false`() {
+		val statusOutput = "?? my-repo/.jolli/transcripts/abc1234.json\u0000"
+		val runner = staticRunner(ExecResult(stdout = statusOutput, stderr = "", exitCode = 0))
+		val client = clientWithRunner(runner)
+		val report = stageVault(client, tempDir.toString(), StageVaultOpts(syncTranscripts = false))
+		assertEquals(0, report.added)
+		assertEquals(1, report.skipped)
+	}
+
+	// ── Deletion handling ────────────────────────────────────────────
+
+	@Test
+	fun `deletion of owned path is staged as removal`() {
+		val statusOutput = " D my-repo/.jolli/config.json\u0000"
+		val recording = RecordingRunner(
+			ArrayDeque(
+				listOf(
+					// statusPorcelainZ
+					ExecResult(stdout = statusOutput, stderr = "", exitCode = 0),
+					// stageRemovePaths
+					ExecResult(stdout = "", stderr = "", exitCode = 0),
+				)
+			)
+		)
+		val client = clientWithRunner(recording)
+		val report = stageVault(client, tempDir.toString(), StageVaultOpts(syncTranscripts = true))
+		assertEquals(0, report.added)
+		assertEquals(1, report.removed)
+	}
+
+	// ── Symlink blocking ─────────────────────────────────────────────
+
+	@Test
+	fun `symlink at leaf is blocked`() {
+		val statusOutput = "?? my-repo/.jolli/index.json\u0000"
+		val runner = staticRunner(ExecResult(stdout = statusOutput, stderr = "", exitCode = 0))
+		val client = clientWithRunner(runner)
+
+		// Create a symlink instead of a real file.
+		val target = tempDir.resolve("real-target.json")
+		Files.writeString(target, "{}")
+		val link = tempDir.resolve("my-repo/.jolli/index.json")
+		Files.createDirectories(link.parent)
+		Files.createSymbolicLink(link, target)
+
+		val report = stageVault(client, tempDir.toString(), StageVaultOpts(syncTranscripts = true))
+		assertEquals(0, report.added)
+		assertEquals(1, report.symlinked.size)
+	}
+
+	// ── StageReport data class ───────────────────────────────────────
+
+	@Test
+	fun `StageReport holds correct values`() {
+		val report = StageReport(
+			added = 5,
+			removed = 2,
+			skipped = 1,
+			unowned = listOf("a", "b"),
+			symlinked = listOf("c"),
+			byKind = mapOf("SUMMARY" to 3, "REPO_CONFIG" to 2),
+		)
+		assertEquals(5, report.added)
+		assertEquals(2, report.removed)
+		assertEquals(1, report.skipped)
+		assertEquals(2, report.unowned.size)
+		assertEquals(1, report.symlinked.size)
+	}
+}

--- a/intellij/src/test/kotlin/ai/jolli/jollimemory/sync/SyncBackendClientTest.kt
+++ b/intellij/src/test/kotlin/ai/jolli/jollimemory/sync/SyncBackendClientTest.kt
@@ -1,0 +1,416 @@
+package ai.jolli.jollimemory.sync
+
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.string.shouldContain
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.io.IOException
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpHeaders
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import java.net.http.HttpResponse.BodyHandler
+import java.util.Base64
+import java.util.Optional
+import javax.net.ssl.SSLSession
+
+/**
+ * Unit tests for [SyncBackendClient]. Uses a fake [HttpClient] injected via
+ * the constructor to avoid real network calls.
+ */
+class SyncBackendClientTest {
+
+	// ── Test helpers ────────────────────────────────────────────────────
+
+	private val testApiKey = buildApiKey(
+		"""{"t":"test-tenant","u":"https://test-tenant.jolli.ai"}""",
+	)
+
+	private fun buildApiKey(meta: String): String {
+		val encoded = Base64.getUrlEncoder().withoutPadding().encodeToString(meta.toByteArray())
+		val secret = Base64.getUrlEncoder().withoutPadding().encodeToString(ByteArray(32))
+		return "sk-jol-$encoded.$secret"
+	}
+
+	/**
+	 * Builds a [SyncBackendClient] whose HTTP layer returns [responseBody]
+	 * at [statusCode] for every request. Captures the last [HttpRequest]
+	 * sent so tests can assert on URL, headers, etc.
+	 */
+	private class FakeHttpSetup(
+		private val statusCode: Int,
+		private val responseBody: String,
+		apiKey: String,
+	) {
+		var lastRequest: HttpRequest? = null
+
+		val client = SyncBackendClient(
+			httpClient = fakeHttpClient { req ->
+				lastRequest = req
+				fakeResponse(statusCode, responseBody, req.uri())
+			},
+			baseUrlOverride = "https://test-tenant.jolli.ai",
+			jolliApiKeyProvider = { apiKey },
+		)
+	}
+
+	private fun setup(statusCode: Int, responseBody: String) =
+		FakeHttpSetup(statusCode, responseBody, testApiKey)
+
+	// ── mintGitCredentials ──────────────────────────────────────────────
+
+	@Nested
+	inner class MintGitCredentials {
+		private val validMintResponse = """
+			{
+				"token": "ghs_abc123",
+				"expiresAt": 1700000000000,
+				"repoCloneUrl": "https://github.com/jolli-vaults/test.git",
+				"repoFullName": "jolli-vaults/test",
+				"defaultBranch": "main",
+				"githubRepoCreated": true,
+				"alreadyVaultBound": false,
+				"lockOwnerToken": "abc123def456abc123def456abc123de"
+			}
+		""".trimIndent()
+
+		@Test
+		fun `parses successful mint response`() {
+			val s = setup(200, validMintResponse)
+			val creds = s.client.mintGitCredentials()
+
+			creds.gitUrl shouldBe "https://github.com/jolli-vaults/test.git"
+			creds.token shouldBe "ghs_abc123"
+			creds.expiresAt shouldBe 1700000000000L
+			creds.repoFullName shouldBe "jolli-vaults/test"
+			creds.defaultBranch shouldBe "main"
+			creds.githubRepoCreated shouldBe true
+			creds.alreadyVaultBound shouldBe false
+			creds.lockOwnerToken shouldBe "abc123def456abc123def456abc123de"
+		}
+
+		@Test
+		fun `parses ISO 8601 expiresAt string`() {
+			val body = validMintResponse.replace("1700000000000", "\"2023-11-14T22:13:20Z\"")
+			val s = setup(200, body)
+			val creds = s.client.mintGitCredentials()
+			creds.expiresAt shouldBe 1700000000000L
+		}
+
+		@Test
+		fun `sends POST to correct endpoint`() {
+			val s = setup(200, validMintResponse)
+			s.client.mintGitCredentials()
+
+			s.lastRequest shouldNotBe null
+			s.lastRequest!!.uri().path shouldBe "/api/mb-sync/credentials"
+			s.lastRequest!!.method() shouldBe "POST"
+		}
+
+		@Test
+		fun `sends auth and client headers`() {
+			val s = setup(200, validMintResponse)
+			s.client.mintGitCredentials()
+
+			val headers = s.lastRequest!!.headers()
+			headers.firstValue("Authorization").get() shouldContain "Bearer sk-jol-"
+			headers.firstValue("x-jolli-client").get() shouldContain "intellij-plugin/"
+		}
+
+		@Test
+		fun `throws on missing required fields`() {
+			val s = setup(200, """{"token": "ghs_abc"}""")
+			val ex = assertThrows<SyncBackendError> { s.client.mintGitCredentials() }
+			ex.status shouldBe 502
+			ex.message!! shouldContain "incomplete mint response"
+		}
+
+		@Test
+		fun `throws on non-https clone URL`() {
+			val body = validMintResponse.replace("https://github.com", "http://github.com")
+			val s = setup(200, body)
+			val ex = assertThrows<SyncBackendError> { s.client.mintGitCredentials() }
+			ex.status shouldBe 502
+			ex.message!! shouldContain "non-https"
+		}
+
+		@Test
+		fun `throws on unparseable clone URL`() {
+			val body = validMintResponse.replace(
+				"https://github.com/jolli-vaults/test.git",
+				"not a url at all",
+			)
+			val s = setup(200, body)
+			// URI.create may or may not throw on "not a url at all" — either
+			// the parse fails (unparseable) or the scheme check fails (non-https).
+			assertThrows<SyncBackendError> { s.client.mintGitCredentials() }
+		}
+
+		@Test
+		fun `throws on invalid expiresAt`() {
+			val body = validMintResponse.replace("1700000000000", "\"not-a-date\"")
+			val s = setup(200, body)
+			val ex = assertThrows<SyncBackendError> { s.client.mintGitCredentials() }
+			ex.status shouldBe 502
+			ex.message!! shouldContain "invalid expiresAt"
+		}
+	}
+
+	// ── notifyPush ──────────────────────────────────────────────────────
+
+	@Nested
+	inner class NotifyPush {
+		@Test
+		fun `sends POST to correct endpoint`() {
+			val s = setup(200, "{}")
+			s.client.notifyPush("abc1234", "main", "lock-token-123")
+
+			s.lastRequest!!.uri().path shouldBe "/api/mb-sync/notify-push"
+			s.lastRequest!!.method() shouldBe "POST"
+		}
+	}
+
+	// ── releaseLock ─────────────────────────────────────────────────────
+
+	@Nested
+	inner class ReleaseLock {
+		@Test
+		fun `sends POST to correct endpoint`() {
+			val s = setup(200, "{}")
+			s.client.releaseLock("lock-token-123")
+
+			s.lastRequest!!.uri().path shouldBe "/api/mb-sync/release-lock"
+			s.lastRequest!!.method() shouldBe "POST"
+		}
+	}
+
+	// ── getLegacyContent ────────────────────────────────────────────────
+
+	@Nested
+	inner class GetLegacyContent {
+		@Test
+		fun `parses response with docs`() {
+			val body = """
+				{
+					"spaceId": 1,
+					"spaceSlug": "my-space",
+					"alreadyMigrated": false,
+					"docs": [{
+						"id": 10,
+						"jrn": "jrn:doc:10",
+						"slug": "test-doc",
+						"path": "/test",
+						"docType": "summary",
+						"parentId": null,
+						"content": "# Hello",
+						"contentType": "markdown",
+						"sortOrder": 0,
+						"createdAt": "2024-01-01T00:00:00Z",
+						"updatedAt": "2024-01-02T00:00:00Z"
+					}]
+				}
+			""".trimIndent()
+			val s = setup(200, body)
+			val result = s.client.getLegacyContent()
+
+			result.spaceId shouldBe 1
+			result.spaceSlug shouldBe "my-space"
+			result.alreadyMigrated shouldBe false
+			result.docs.size shouldBe 1
+			result.docs[0].id shouldBe 10
+			result.docs[0].content shouldBe "# Hello"
+			result.docs[0].parentId shouldBe null
+		}
+
+		@Test
+		fun `parses already-migrated response`() {
+			val body = """{"spaceId":1,"spaceSlug":"s","alreadyMigrated":true,"docs":[]}"""
+			val s = setup(200, body)
+			val result = s.client.getLegacyContent()
+			result.alreadyMigrated shouldBe true
+			result.docs shouldBe emptyList()
+		}
+
+		@Test
+		fun `sends GET to correct endpoint`() {
+			val body = """{"spaceId":1,"spaceSlug":"s","alreadyMigrated":true,"docs":[]}"""
+			val s = setup(200, body)
+			s.client.getLegacyContent()
+			s.lastRequest!!.method() shouldBe "GET"
+			s.lastRequest!!.uri().path shouldBe "/api/mb-sync/legacy-content"
+		}
+	}
+
+	// ── completeMigration ───────────────────────────────────────────────
+
+	@Nested
+	inner class CompleteMigration {
+		@Test
+		fun `parses response`() {
+			val s = setup(200, """{"alreadyMigrated": false}""")
+			val result = s.client.completeMigration("abc1234", "lock-token")
+			result.alreadyMigrated shouldBe false
+		}
+
+		@Test
+		fun `handles already-migrated`() {
+			val s = setup(200, """{"alreadyMigrated": true}""")
+			val result = s.client.completeMigration("abc1234", "lock-token")
+			result.alreadyMigrated shouldBe true
+		}
+	}
+
+	// ── Error dispatch ──────────────────────────────────────────────────
+
+	@Nested
+	inner class ErrorDispatch {
+		@Test
+		fun `401 throws SyncBackendUnauthorizedError`() {
+			val s = setup(401, """{"error":"unauthorized"}""")
+			assertThrows<SyncBackendUnauthorizedError> { s.client.mintGitCredentials() }
+		}
+
+		@Test
+		fun `403 throws SyncBackendUnauthorizedError`() {
+			val s = setup(403, """{"error":"forbidden"}""")
+			assertThrows<SyncBackendUnauthorizedError> { s.client.mintGitCredentials() }
+		}
+
+		@Test
+		fun `423 throws VaultLockedError`() {
+			val s = setup(423, """{"error":"vault_locked"}""")
+			assertThrows<VaultLockedError> { s.client.mintGitCredentials() }
+		}
+
+		@Test
+		fun `503 pending_flush_failed throws WebFlushPendingError`() {
+			val body = """{"error":"pending_flush_failed","retryAfterSeconds":45}"""
+			val s = setup(503, body)
+			val ex = assertThrows<WebFlushPendingError> { s.client.mintGitCredentials() }
+			ex.retryAfterSeconds shouldBe 45
+		}
+
+		@Test
+		fun `503 pending_flush_failed defaults retryAfterSeconds to 30`() {
+			val body = """{"error":"pending_flush_failed"}"""
+			val s = setup(503, body)
+			val ex = assertThrows<WebFlushPendingError> { s.client.mintGitCredentials() }
+			ex.retryAfterSeconds shouldBe 30
+		}
+
+		@Test
+		fun `503 non-pending_flush throws generic SyncBackendError`() {
+			val s = setup(503, """{"error":"service_unavailable"}""")
+			val ex = assertThrows<SyncBackendError> { s.client.mintGitCredentials() }
+			ex.status shouldBe 503
+			(ex is WebFlushPendingError) shouldBe false
+		}
+
+		@Test
+		fun `other non-2xx throws generic SyncBackendError`() {
+			val s = setup(500, """{"error":"internal"}""")
+			val ex = assertThrows<SyncBackendError> { s.client.mintGitCredentials() }
+			ex.status shouldBe 500
+		}
+
+		@Test
+		fun `no API key throws SyncBackendUnauthorizedError`() {
+			val client = SyncBackendClient(
+				jolliApiKeyProvider = { null },
+				baseUrlOverride = "https://test.jolli.ai",
+			)
+			assertThrows<SyncBackendUnauthorizedError> { client.mintGitCredentials() }
+		}
+
+		@Test
+		fun `invalid API key throws SyncBackendUnauthorizedError`() {
+			val client = SyncBackendClient(
+				jolliApiKeyProvider = { "not-a-valid-key" },
+				baseUrlOverride = "https://test.jolli.ai",
+			)
+			assertThrows<SyncBackendUnauthorizedError> { client.mintGitCredentials() }
+		}
+
+		@Test
+		fun `network failure throws SyncBackendNetworkError`() {
+			val client = SyncBackendClient(
+				httpClient = fakeHttpClient { throw IOException("Connection refused") },
+				jolliApiKeyProvider = { testApiKey },
+				baseUrlOverride = "https://test.jolli.ai",
+			)
+			assertThrows<SyncBackendNetworkError> { client.mintGitCredentials() }
+		}
+	}
+
+	// ── getJolliApiKey ──────────────────────────────────────────────────
+
+	@Nested
+	inner class GetJolliApiKey {
+		@Test
+		fun `returns key from provider`() {
+			val client = SyncBackendClient(jolliApiKeyProvider = { "sk-jol-test" })
+			client.getJolliApiKey() shouldBe "sk-jol-test"
+		}
+
+		@Test
+		fun `returns null when signed out`() {
+			val client = SyncBackendClient(jolliApiKeyProvider = { null })
+			client.getJolliApiKey() shouldBe null
+		}
+	}
+}
+
+// ── Fake HttpClient infrastructure ──────────────────────────────────────
+
+/**
+ * Creates a minimal [HttpClient] that delegates every `send()` call to
+ * [handler]. Good enough for unit-testing request/response contracts without
+ * a real server or a mocking library dependency.
+ */
+private fun fakeHttpClient(handler: (HttpRequest) -> HttpResponse<String>): HttpClient {
+	return object : HttpClient() {
+		override fun cookieHandler() = Optional.empty<java.net.CookieHandler>()
+		override fun connectTimeout() = Optional.empty<java.time.Duration>()
+		override fun followRedirects() = Redirect.NEVER
+		override fun proxy() = Optional.empty<java.net.ProxySelector>()
+		override fun sslContext(): javax.net.ssl.SSLContext = javax.net.ssl.SSLContext.getDefault()
+		override fun sslParameters(): javax.net.ssl.SSLParameters = javax.net.ssl.SSLParameters()
+		override fun authenticator() = Optional.empty<java.net.Authenticator>()
+		override fun version() = Version.HTTP_2
+		override fun executor() = Optional.empty<java.util.concurrent.Executor>()
+		override fun newWebSocketBuilder(): java.net.http.WebSocket.Builder = throw UnsupportedOperationException()
+
+		@Suppress("UNCHECKED_CAST")
+		override fun <T : Any?> send(request: HttpRequest, responseBodyHandler: BodyHandler<T>): HttpResponse<T> {
+			return handler(request) as HttpResponse<T>
+		}
+
+		override fun <T : Any?> sendAsync(
+			request: HttpRequest,
+			responseBodyHandler: BodyHandler<T>,
+		) = throw UnsupportedOperationException()
+
+		override fun <T : Any?> sendAsync(
+			request: HttpRequest,
+			responseBodyHandler: BodyHandler<T>,
+			pushPromiseHandler: HttpResponse.PushPromiseHandler<T>?,
+		) = throw UnsupportedOperationException()
+	}
+}
+
+/** Creates a minimal [HttpResponse] with the given status and body. */
+private fun fakeResponse(statusCode: Int, body: String, uri: URI): HttpResponse<String> {
+	return object : HttpResponse<String> {
+		override fun statusCode() = statusCode
+		override fun body() = body
+		override fun headers(): HttpHeaders = HttpHeaders.of(emptyMap()) { _, _ -> true }
+		override fun request(): HttpRequest = HttpRequest.newBuilder(uri).build()
+		override fun previousResponse() = Optional.empty<HttpResponse<String>>()
+		override fun sslSession() = Optional.empty<SSLSession>()
+		override fun uri() = uri
+		override fun version() = HttpClient.Version.HTTP_2
+	}
+}

--- a/intellij/src/test/kotlin/ai/jolli/jollimemory/sync/SyncEngineTest.kt
+++ b/intellij/src/test/kotlin/ai/jolli/jollimemory/sync/SyncEngineTest.kt
@@ -1,0 +1,593 @@
+package ai.jolli.jollimemory.sync
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.IOException
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpHeaders
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import java.net.http.HttpResponse.BodyHandler
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.Base64
+import java.util.Optional
+import java.util.concurrent.atomic.AtomicInteger
+import javax.net.ssl.SSLSession
+
+/**
+ * End-to-end tests for [SyncEngine.runRound].
+ *
+ * Uses a fake [HttpClient] for backend calls and a scripted [ProcessRunner]
+ * for git commands to verify the full pipeline without network or git.
+ */
+class SyncEngineTest {
+
+	@TempDir
+	lateinit var tempDir: Path
+
+	// ── Helpers ─────────────────────────────────────────────────────
+
+	private val testApiKey = buildApiKey(
+		"""{"t":"test-tenant","u":"https://test-tenant.jolli.ai"}""",
+	)
+
+	private fun buildApiKey(meta: String): String {
+		val encoded = Base64.getUrlEncoder().withoutPadding().encodeToString(meta.toByteArray())
+		val secret = Base64.getUrlEncoder().withoutPadding().encodeToString(ByteArray(32))
+		return "sk-jol-$encoded.$secret"
+	}
+
+	private val defaultCreds = GitCredentials(
+		token = "ghs_test",
+		gitUrl = "https://github.com/test/vault.git",
+		expiresAt = System.currentTimeMillis() + 3_600_000L,
+		repoFullName = "test/vault",
+		defaultBranch = "main",
+		githubRepoCreated = false,
+		alreadyVaultBound = true,
+		lockOwnerToken = "lock-123",
+	)
+
+	private val defaultContext = RoundContext(
+		memoryBankRoot = "", // overridden per test
+		repoFolderName = "test-repo",
+		repoIdentity = "https://github.com/test/vault",
+		author = CommitAuthor(name = "Test", email = "test@test.com"),
+	)
+
+	private val defaultRound = SyncRoundOptions(
+		cwd = "/tmp/project",
+		reason = "manual",
+		transcripts = true,
+	)
+
+	// Mint response JSON matching what SyncBackendClient expects.
+	private val mintResponseJson = """
+		{
+			"token": "ghs_test",
+			"expiresAt": ${System.currentTimeMillis() + 3_600_000L},
+			"repoCloneUrl": "https://github.com/test/vault.git",
+			"repoFullName": "test/vault",
+			"defaultBranch": "main",
+			"githubRepoCreated": false,
+			"alreadyVaultBound": true,
+			"lockOwnerToken": "lock-123"
+		}
+	""".trimIndent()
+
+	/**
+	 * A [ProcessRunner] that returns scripted responses in order.
+	 * Falls back to an empty success result when the script is exhausted.
+	 */
+	private class ScriptedRunner(private val responses: ArrayDeque<ExecResult> = ArrayDeque()) : ProcessRunner {
+		val calls = mutableListOf<List<String>>()
+		override fun exec(command: List<String>, cwd: String?, env: Map<String, String>, timeoutMs: Long?): ExecResult {
+			calls.add(command)
+			return if (responses.isNotEmpty()) responses.removeFirst() else ExecResult("", "", 0)
+		}
+	}
+
+	/**
+	 * A [ProcessRunner] that decides responses based on git command patterns.
+	 * More flexible than [ScriptedRunner] for complex pipelines.
+	 */
+	private class SmartRunner(
+		private val gitVersion: String = "git version 2.43.0",
+		private val fetchOk: Boolean = true,
+		private val pullOk: Boolean = true,
+		private val pushOk: Boolean = true,
+		private val pushTransmitted: Boolean = true,
+		private val statusOutput: String = "",
+		private val currentBranch: String = "main",
+		private val headSha: String = "abc1234",
+		private val remoteHeadSha: String = "abc1234",
+		private val refExistsResult: Boolean = true,
+		private val isRebaseInProgress: Boolean = false,
+		private val originUrl: String = "https://github.com/test/vault.git",
+	) : ProcessRunner {
+		val calls = mutableListOf<List<String>>()
+
+		override fun exec(command: List<String>, cwd: String?, env: Map<String, String>, timeoutMs: Long?): ExecResult {
+			calls.add(command)
+			val joined = command.joinToString(" ")
+
+			// git --version
+			if (joined.contains("--version")) {
+				return ExecResult(gitVersion, "", 0)
+			}
+
+			// git remote get-url origin — the vault identity guard reads this to
+			// verify the configured origin matches the minted credentials. Without
+			// a stub the round fails verifyVaultMarker and degrades to OFFLINE.
+			if (joined.contains("remote") && joined.contains("get-url")) {
+				return ExecResult(originUrl, "", 0)
+			}
+
+			// git status --porcelain -z
+			if (joined.contains("status") && joined.contains("--porcelain")) {
+				return ExecResult(statusOutput, "", 0)
+			}
+
+			// git symbolic-ref --short HEAD
+			if (joined.contains("symbolic-ref")) {
+				return ExecResult(currentBranch, "", 0)
+			}
+
+			// git rev-parse
+			if (joined.contains("rev-parse")) {
+				val sha = if (joined.contains("remotes/origin")) remoteHeadSha else headSha
+				return ExecResult(sha, "", 0)
+			}
+
+			// git show-ref --verify
+			if (joined.contains("show-ref")) {
+				return if (refExistsResult) ExecResult("abc1234 refs/remotes/origin/main", "", 0)
+				else ExecResult("", "", 1)
+			}
+
+			// git fetch
+			if (joined.contains("fetch")) {
+				return if (fetchOk) ExecResult("", "", 0)
+				else ExecResult("", "fatal: authentication failed", 128)
+			}
+
+			// git pull --rebase
+			if (joined.contains("pull") && joined.contains("--rebase")) {
+				return if (pullOk) ExecResult("Already up to date.", "", 0)
+				else ExecResult("", "CONFLICT (content)", 1)
+			}
+
+			// git push
+			if (joined.contains("push")) {
+				return if (pushOk) {
+					if (pushTransmitted) ExecResult("", "To https://github.com/test/vault.git\n   abc..def  HEAD -> main", 0)
+					else ExecResult("Everything up-to-date", "", 0)
+				} else {
+					ExecResult("", "! [rejected] HEAD -> main (non-fast-forward)", 1)
+				}
+			}
+
+			// git commit
+			if (joined.contains("commit")) {
+				return ExecResult("[main abc1234] commit message", "", 0)
+			}
+
+			// Rebase in progress check (ls .git/rebase-merge)
+			if (joined.contains("rebase-merge") || joined.contains("rebase-apply")) {
+				return if (isRebaseInProgress) ExecResult("", "", 0) else ExecResult("", "", 1)
+			}
+
+			// Default: success
+			return ExecResult("", "", 0)
+		}
+	}
+
+	/**
+	 * Builds a [SyncBackendClient] with a fake HTTP layer that responds
+	 * differently based on path and call count.
+	 */
+	private class FakeBackend(
+		apiKey: String,
+		private val mintHandler: (Int) -> HttpResponse<String>,
+	) {
+		var notifyPushCalled = false
+		var releaseLockCalled = false
+		var releaseLockToken: String? = null
+
+		val client = SyncBackendClient(
+			httpClient = object : HttpClient() {
+				val mintCount = AtomicInteger(0)
+
+				override fun cookieHandler() = Optional.empty<java.net.CookieHandler>()
+				override fun connectTimeout() = Optional.empty<java.time.Duration>()
+				override fun followRedirects() = Redirect.NEVER
+				override fun proxy() = Optional.empty<java.net.ProxySelector>()
+				override fun sslContext(): javax.net.ssl.SSLContext = javax.net.ssl.SSLContext.getDefault()
+				override fun sslParameters(): javax.net.ssl.SSLParameters = javax.net.ssl.SSLParameters()
+				override fun authenticator() = Optional.empty<java.net.Authenticator>()
+				override fun version() = Version.HTTP_2
+				override fun executor() = Optional.empty<java.util.concurrent.Executor>()
+				override fun newWebSocketBuilder(): java.net.http.WebSocket.Builder = throw UnsupportedOperationException()
+
+				@Suppress("UNCHECKED_CAST")
+				override fun <T : Any?> send(request: HttpRequest, handler: BodyHandler<T>): HttpResponse<T> {
+					val path = request.uri().path
+					if (path.endsWith("/credentials")) {
+						val resp = mintHandler(mintCount.incrementAndGet())
+						return resp as HttpResponse<T>
+					}
+					if (path.endsWith("/notify-push")) {
+						notifyPushCalled = true
+						return fakeResp(200, """{"ok":true}""", request.uri()) as HttpResponse<T>
+					}
+					if (path.endsWith("/release-lock")) {
+						releaseLockCalled = true
+						return fakeResp(200, """{"ok":true}""", request.uri()) as HttpResponse<T>
+					}
+					return fakeResp(200, """{}""", request.uri()) as HttpResponse<T>
+				}
+
+				override fun <T : Any?> sendAsync(r: HttpRequest, h: BodyHandler<T>) = throw UnsupportedOperationException()
+				override fun <T : Any?> sendAsync(r: HttpRequest, h: BodyHandler<T>, p: HttpResponse.PushPromiseHandler<T>?) = throw UnsupportedOperationException()
+			},
+			baseUrlOverride = "https://test-tenant.jolli.ai",
+			jolliApiKeyProvider = { apiKey },
+		)
+	}
+
+	companion object {
+		fun fakeResp(status: Int, body: String, uri: URI): HttpResponse<String> {
+			return object : HttpResponse<String> {
+				override fun statusCode() = status
+				override fun body() = body
+				override fun headers(): HttpHeaders = HttpHeaders.of(emptyMap()) { _, _ -> true }
+				override fun request(): HttpRequest = HttpRequest.newBuilder(uri).build()
+				override fun previousResponse() = Optional.empty<HttpResponse<String>>()
+				override fun sslSession() = Optional.empty<SSLSession>()
+				override fun uri() = uri
+				override fun version() = HttpClient.Version.HTTP_2
+			}
+		}
+	}
+
+	private fun mintOkResponse(uri: URI = URI.create("https://test-tenant.jolli.ai/api/mb-sync/credentials")): HttpResponse<String> {
+		return fakeResp(200, mintResponseJson, uri)
+	}
+
+	/** Sets up a vault directory with .git/ and a vault marker so the steady-state path runs. */
+	private fun setupVault(): Path {
+		val vault = tempDir.resolve("vault")
+		Files.createDirectories(vault.resolve(".git"))
+		// Write a vault marker.
+		val markerPath = vault.resolve(".git/jolli-vault-identity.json")
+		Files.writeString(markerPath, """
+			{
+				"kind": "jolli-memory-bank",
+				"version": 1,
+				"createdAt": "2024-01-01T00:00:00Z",
+				"gitUrl": "https://github.com/test/vault",
+				"repoFullName": "test/vault",
+				"defaultBranch": "main"
+			}
+		""".trimIndent())
+		return vault
+	}
+
+	private fun buildEngine(
+		backend: FakeBackend,
+		runner: ProcessRunner,
+		vaultRoot: String,
+	): SyncEngine {
+		return SyncEngine(SyncEngineOpts(
+			backend = backend.client,
+			resolveContext = { round ->
+				defaultContext.copy(memoryBankRoot = vaultRoot)
+			},
+			makeGitClient = GitClientFactory { creds, mbRoot ->
+				SyncGitClient(
+					vaultRoot = mbRoot,
+					credentials = creds,
+					askpassProvider = { _ ->
+						AskpassHandle(scriptPath = "/fake/askpass", env = mapOf("GIT_ASKPASS" to "/fake/askpass"))
+					},
+					processRunner = runner,
+				)
+			},
+			lockTimeoutMs = 5_000L,
+			refreshIntervalMs = 60_000L,
+			sleepFn = { /* no-op for tests */ },
+			vaultLockedRetrySchedule = listOf(10L, 10L, 10L), // fast retries
+		))
+	}
+
+	// ── Tests ───────────────────────────────────────────────────────
+
+	@Test
+	fun `clean round with idle short-circuit returns SYNCED pushed=false`() {
+		val vault = setupVault()
+		val runner = SmartRunner(
+			headSha = "abc1234",
+			remoteHeadSha = "abc1234",
+			statusOutput = "", // no dirty paths
+		)
+		val backend = FakeBackend(testApiKey) { mintOkResponse() }
+		val engine = buildEngine(backend, runner, vault.toString())
+
+		val result = engine.runRound(defaultRound)
+
+		assertEquals(SyncState.SYNCED, result.newState)
+		assertFalse(result.pushed)
+		assertTrue(result.fetched)
+		assertNull(result.lastError)
+	}
+
+	@Test
+	fun `clean round with local changes returns SYNCED pushed=true`() {
+		val vault = setupVault()
+		// Report dirty owned path, then clean status for the idle check.
+		val runner = SmartRunner(
+			headSha = "abc1234",
+			remoteHeadSha = "def5678", // different = not idle
+			statusOutput = "", // stage vault will see nothing, but idle check fails
+		)
+		val backend = FakeBackend(testApiKey) { mintOkResponse() }
+		val engine = buildEngine(backend, runner, vault.toString())
+
+		val result = engine.runRound(defaultRound)
+
+		assertEquals(SyncState.SYNCED, result.newState)
+		assertTrue(result.pushed)
+		assertTrue(result.fetched)
+	}
+
+	@Test
+	fun `mint 423 retry succeeds on second attempt`() {
+		val vault = setupVault()
+		val runner = SmartRunner()
+		var lockedWaitCalled = false
+
+		val backend = FakeBackend(testApiKey) { callNum ->
+			if (callNum == 1) fakeResp(423, """{"error":"vault_locked"}""", URI.create("https://test-tenant.jolli.ai/api/mb-sync/credentials"))
+			else mintOkResponse()
+		}
+
+		val engine = SyncEngine(SyncEngineOpts(
+			backend = backend.client,
+			resolveContext = { defaultContext.copy(memoryBankRoot = vault.toString()) },
+			makeGitClient = GitClientFactory { creds, mbRoot ->
+				SyncGitClient(mbRoot, creds, { AskpassHandle("/fake", mapOf()) }, runner)
+			},
+			lockTimeoutMs = 5_000L,
+			sleepFn = {},
+			vaultLockedRetrySchedule = listOf(10L, 10L, 10L),
+			onLockedWait = { lockedWaitCalled = true },
+		))
+
+		val result = engine.runRound(defaultRound)
+
+		assertEquals(SyncState.SYNCED, result.newState)
+		assertTrue(lockedWaitCalled)
+	}
+
+	@Test
+	fun `mint 423 exhausted returns OFFLINE VAULT_LOCKED`() {
+		val vault = setupVault()
+		val runner = SmartRunner()
+
+		val backend = FakeBackend(testApiKey) { _ ->
+			fakeResp(423, """{"error":"vault_locked"}""", URI.create("https://test-tenant.jolli.ai/api/mb-sync/credentials"))
+		}
+		val engine = buildEngine(backend, runner, vault.toString())
+
+		val result = engine.runRound(defaultRound)
+
+		assertEquals(SyncState.OFFLINE, result.newState)
+		assertEquals(SyncErrorCode.VAULT_LOCKED, result.lastError?.code)
+	}
+
+	@Test
+	fun `mint network error returns OFFLINE NETWORK`() {
+		val vault = setupVault()
+		val runner = SmartRunner()
+
+		val backend = FakeBackend(testApiKey) { _ ->
+			throw IOException("Connection refused")
+		}
+
+		// Need a backend that actually throws network errors.
+		val backendClient = SyncBackendClient(
+			httpClient = object : HttpClient() {
+				override fun cookieHandler() = Optional.empty<java.net.CookieHandler>()
+				override fun connectTimeout() = Optional.empty<java.time.Duration>()
+				override fun followRedirects() = Redirect.NEVER
+				override fun proxy() = Optional.empty<java.net.ProxySelector>()
+				override fun sslContext(): javax.net.ssl.SSLContext = javax.net.ssl.SSLContext.getDefault()
+				override fun sslParameters(): javax.net.ssl.SSLParameters = javax.net.ssl.SSLParameters()
+				override fun authenticator() = Optional.empty<java.net.Authenticator>()
+				override fun version() = Version.HTTP_2
+				override fun executor() = Optional.empty<java.util.concurrent.Executor>()
+				override fun newWebSocketBuilder(): java.net.http.WebSocket.Builder = throw UnsupportedOperationException()
+				@Suppress("UNCHECKED_CAST")
+				override fun <T : Any?> send(r: HttpRequest, h: BodyHandler<T>): HttpResponse<T> = throw IOException("Connection refused")
+				override fun <T : Any?> sendAsync(r: HttpRequest, h: BodyHandler<T>) = throw UnsupportedOperationException()
+				override fun <T : Any?> sendAsync(r: HttpRequest, h: BodyHandler<T>, p: HttpResponse.PushPromiseHandler<T>?) = throw UnsupportedOperationException()
+			},
+			baseUrlOverride = "https://test-tenant.jolli.ai",
+			jolliApiKeyProvider = { testApiKey },
+		)
+
+		val engine = SyncEngine(SyncEngineOpts(
+			backend = backendClient,
+			resolveContext = { defaultContext.copy(memoryBankRoot = vault.toString()) },
+			makeGitClient = GitClientFactory { creds, mbRoot ->
+				SyncGitClient(mbRoot, creds, { AskpassHandle("/fake", mapOf()) }, runner)
+			},
+			lockTimeoutMs = 5_000L,
+			sleepFn = {},
+			vaultLockedRetrySchedule = listOf(10L),
+		))
+
+		val result = engine.runRound(defaultRound)
+
+		assertEquals(SyncState.OFFLINE, result.newState)
+		assertEquals(SyncErrorCode.NETWORK, result.lastError?.code)
+	}
+
+	@Test
+	fun `mint unauthorized returns OFFLINE MINT_FAILED`() {
+		val vault = setupVault()
+		val runner = SmartRunner()
+
+		val backend = FakeBackend(testApiKey) { _ ->
+			fakeResp(401, """{"error":"unauthorized"}""", URI.create("https://test-tenant.jolli.ai/api/mb-sync/credentials"))
+		}
+		val engine = buildEngine(backend, runner, vault.toString())
+
+		val result = engine.runRound(defaultRound)
+
+		assertEquals(SyncState.OFFLINE, result.newState)
+		assertEquals(SyncErrorCode.MINT_FAILED, result.lastError?.code)
+	}
+
+	@Test
+	fun `git missing returns OFFLINE GIT_MISSING`() {
+		val vault = setupVault()
+		// SmartRunner with empty git version to trigger NotFound.
+		val runner = SmartRunner(gitVersion = "")
+		val backend = FakeBackend(testApiKey) { mintOkResponse() }
+
+		// Need a runner where checkGitInstalled returns NotFound.
+		// The SmartRunner always returns a version string which parses as Ok.
+		// Use a scripted runner: first call is git --version with exit code 1.
+		val scriptedRunner = object : ProcessRunner {
+			override fun exec(command: List<String>, cwd: String?, env: Map<String, String>, timeoutMs: Long?): ExecResult {
+				if (command.any { it == "--version" }) {
+					throw RuntimeException("git not found")
+				}
+				return ExecResult("", "", 0)
+			}
+		}
+
+		val engine = buildEngine(backend, scriptedRunner, vault.toString())
+		val result = engine.runRound(defaultRound)
+
+		assertEquals(SyncState.OFFLINE, result.newState)
+		assertEquals(SyncErrorCode.GIT_MISSING, result.lastError?.code)
+	}
+
+	@Test
+	fun `vault marker mismatch returns OFFLINE VAULT_MISMATCH`() {
+		val vault = tempDir.resolve("vault-mismatch")
+		Files.createDirectories(vault.resolve(".git"))
+		// Write marker with different git URL.
+		val markerPath = vault.resolve(".git/jolli-vault-identity.json")
+		Files.writeString(markerPath, """
+			{
+				"kind": "jolli-memory-bank",
+				"version": 1,
+				"createdAt": "2024-01-01T00:00:00Z",
+				"gitUrl": "https://github.com/other-org/other-repo",
+				"repoFullName": "other-org/other-repo",
+				"defaultBranch": "main"
+			}
+		""".trimIndent())
+
+		// SmartRunner that returns a different origin URL.
+		val runner = object : ProcessRunner {
+			override fun exec(command: List<String>, cwd: String?, env: Map<String, String>, timeoutMs: Long?): ExecResult {
+				val joined = command.joinToString(" ")
+				if (joined.contains("--version")) return ExecResult("git version 2.43.0", "", 0)
+				if (joined.contains("rebase-merge") || joined.contains("rebase-apply"))
+					return ExecResult("", "", 1) // not in progress
+				// git remote get-url origin
+				if (joined.contains("remote") && joined.contains("get-url")) {
+					return ExecResult("https://github.com/other-org/other-repo.git", "", 0)
+				}
+				return ExecResult("", "", 0)
+			}
+		}
+
+		val backend = FakeBackend(testApiKey) { mintOkResponse() }
+		val engine = buildEngine(backend, runner, vault.toString())
+
+		val result = engine.runRound(defaultRound)
+
+		assertEquals(SyncState.OFFLINE, result.newState)
+		assertEquals(SyncErrorCode.VAULT_MISMATCH, result.lastError?.code)
+	}
+
+	@Test
+	fun `lock release called in finally on mid-round error`() {
+		val vault = setupVault()
+		val backend = FakeBackend(testApiKey) { mintOkResponse() }
+
+		// Runner that throws on fetch to cause a mid-round failure.
+		val runner = object : ProcessRunner {
+			override fun exec(command: List<String>, cwd: String?, env: Map<String, String>, timeoutMs: Long?): ExecResult {
+				val joined = command.joinToString(" ")
+				if (joined.contains("--version")) return ExecResult("git version 2.43.0", "", 0)
+				if (joined.contains("rebase-merge") || joined.contains("rebase-apply"))
+					return ExecResult("", "", 1)
+				if (joined.contains("fetch")) return ExecResult("", "fatal: something went wrong", 128)
+				return ExecResult("", "", 0)
+			}
+		}
+
+		val engine = buildEngine(backend, runner, vault.toString())
+		val result = engine.runRound(defaultRound)
+
+		assertEquals(SyncState.OFFLINE, result.newState)
+		// The backend's releaseLock should have been called in finally.
+		assertTrue(backend.releaseLockCalled)
+	}
+
+	@Test
+	fun `notify push clears releaseInFinally`() {
+		val vault = setupVault()
+		val runner = SmartRunner(
+			headSha = "abc1234",
+			remoteHeadSha = "def5678", // not idle
+			pushTransmitted = true,
+		)
+		val backend = FakeBackend(testApiKey) { mintOkResponse() }
+		val engine = buildEngine(backend, runner, vault.toString())
+
+		val result = engine.runRound(defaultRound)
+
+		assertEquals(SyncState.SYNCED, result.newState)
+		assertTrue(backend.notifyPushCalled)
+		// releaseLock should NOT be called because notifyPush succeeded.
+		assertFalse(backend.releaseLockCalled)
+	}
+
+	@Test
+	fun `SyncRoundResult data class holds correct values`() {
+		val result = SyncRoundResult(
+			fetched = true,
+			pulled = true,
+			pushed = false,
+			conflicts = listOf("a.json"),
+			newState = SyncState.CONFLICTS,
+			lastError = null,
+			canary = CanaryReport(symlinked = listOf("s"), unowned = listOf("u")),
+		)
+		assertTrue(result.fetched)
+		assertTrue(result.pulled)
+		assertFalse(result.pushed)
+		assertEquals(1, result.conflicts.size)
+		assertEquals(SyncState.CONFLICTS, result.newState)
+		assertEquals(1, result.canary?.symlinked?.size)
+		assertEquals(1, result.canary?.unowned?.size)
+	}
+
+	@Test
+	fun `SyncErrorCode transient classification`() {
+		assertTrue(SyncErrorCode.NETWORK.isTransient)
+		assertFalse(SyncErrorCode.MINT_FAILED.isTransient)
+		assertFalse(SyncErrorCode.VAULT_LOCKED.isTransient)
+		assertFalse(SyncErrorCode.GIT_MISSING.isTransient)
+	}
+}

--- a/intellij/src/test/kotlin/ai/jolli/jollimemory/sync/SyncGitClientTest.kt
+++ b/intellij/src/test/kotlin/ai/jolli/jollimemory/sync/SyncGitClientTest.kt
@@ -1,0 +1,620 @@
+package ai.jolli.jollimemory.sync
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import java.nio.file.Path
+
+class SyncGitClientTest {
+
+	private val defaultCredentials = GitCredentials(
+		token = "ghs_test_token_123",
+		gitUrl = "https://github.com/test-user/vault.git",
+		expiresAt = System.currentTimeMillis() + 3_600_000L,
+		repoFullName = "test-user/vault",
+		defaultBranch = "main",
+		githubRepoCreated = false,
+		alreadyVaultBound = false,
+		lockOwnerToken = "lock-token-123",
+	)
+
+	private val fakeAskpass: (String) -> AskpassHandle = { token ->
+		AskpassHandle(
+			scriptPath = "/fake/askpass.sh",
+			env = mapOf(
+				"GIT_ASKPASS" to "/fake/askpass.sh",
+				"GIT_TERMINAL_PROMPT" to "0",
+				"JOLLI_SYNC_GIT_TOKEN" to token,
+			),
+		)
+	}
+
+	private fun client(
+		runner: ProcessRunner,
+		vaultRoot: String = "/fake/vault",
+		credentials: GitCredentials = defaultCredentials,
+	): SyncGitClient {
+		return SyncGitClient(
+			vaultRoot = vaultRoot,
+			credentials = credentials,
+			askpassProvider = fakeAskpass,
+			processRunner = runner,
+		)
+	}
+
+	/** Builds a fake runner that returns the given result for any command. */
+	private fun staticRunner(
+		stdout: String = "",
+		stderr: String = "",
+		exitCode: Int = 0,
+	): ProcessRunner {
+		return object : ProcessRunner {
+			override fun exec(command: List<String>, cwd: String?, env: Map<String, String>, timeoutMs: Long?): ExecResult {
+				return ExecResult(stdout, stderr, exitCode)
+			}
+		}
+	}
+
+	/** Builds a fake runner that captures calls and returns from a queue. */
+	private class RecordingRunner(private val responses: MutableList<ExecResult>) : ProcessRunner {
+		val calls = mutableListOf<CapturedCall>()
+
+		data class CapturedCall(
+			val command: List<String>,
+			val cwd: String?,
+			val env: Map<String, String>,
+			val timeoutMs: Long?,
+		)
+
+		override fun exec(command: List<String>, cwd: String?, env: Map<String, String>, timeoutMs: Long?): ExecResult {
+			calls.add(CapturedCall(command, cwd, env, timeoutMs))
+			return if (responses.isNotEmpty()) responses.removeAt(0) else ExecResult("", "", 0)
+		}
+	}
+
+	// ── clone ─────────────────────────────────────────────────────────
+
+	@Test
+	fun `clone injects x-access-token username`() {
+		val runner = RecordingRunner(mutableListOf(
+			ExecResult("", "", 0), // clone
+			ExecResult("", "", 0), // config core.symlinks
+		))
+		val c = client(runner)
+		c.clone("https://github.com/user/repo.git")
+		val cloneCall = runner.calls[0]
+		assertTrue(cloneCall.command.any { it.contains("x-access-token@") })
+	}
+
+	@Test
+	fun `clone runs with no cwd`() {
+		val runner = RecordingRunner(mutableListOf(
+			ExecResult("", "", 0),
+			ExecResult("", "", 0),
+		))
+		val c = client(runner)
+		c.clone("https://github.com/user/repo.git")
+		assertNull(runner.calls[0].cwd)
+	}
+
+	@Test
+	fun `clone persists no-symlinks config`() {
+		val runner = RecordingRunner(mutableListOf(
+			ExecResult("", "", 0),
+			ExecResult("", "", 0),
+		))
+		val c = client(runner)
+		c.clone("https://github.com/user/repo.git")
+		assertEquals(2, runner.calls.size)
+		assertTrue(runner.calls[1].command.any { it == "core.symlinks" })
+	}
+
+	// ── fetch ─────────────────────────────────────────────────────────
+
+	@Test
+	fun `fetch runs git fetch origin`() {
+		val runner = RecordingRunner(mutableListOf(ExecResult("", "", 0)))
+		val c = client(runner)
+		c.fetch()
+		val cmd = runner.calls[0].command
+		assertTrue(cmd.contains("fetch"))
+		assertTrue(cmd.contains("origin"))
+	}
+
+	@Test
+	fun `fetch injects askpass env`() {
+		val runner = RecordingRunner(mutableListOf(ExecResult("", "", 0)))
+		val c = client(runner)
+		c.fetch()
+		val env = runner.calls[0].env
+		assertEquals("/fake/askpass.sh", env["GIT_ASKPASS"])
+		assertEquals("ghs_test_token_123", env["JOLLI_SYNC_GIT_TOKEN"])
+	}
+
+	// ── pullRebase ────────────────────────────────────────────────────
+
+	@Test
+	fun `pullRebase detects fast-forward`() {
+		val runner = staticRunner(stdout = "Updating abc..def\nFast-forward\n src/foo.kt | 2 +-")
+		val result = client(runner).pullRebase()
+		assertTrue(result.fastForwarded)
+		assertTrue(result.conflicted.isEmpty())
+	}
+
+	@Test
+	fun `pullRebase detects conflicts via unmerged paths`() {
+		val runner = RecordingRunner(mutableListOf(
+			// pullRebase itself fails
+			ExecResult("", "CONFLICT (content): Merge conflict in foo.kt", 1),
+			// hasUnmergedPaths — ls-files -u -z
+			ExecResult("100644 abc123 2\tfoo.kt\u0000100644 def456 3\tfoo.kt\u0000", "", 0),
+		))
+		val result = client(runner).pullRebase()
+		assertFalse(result.fastForwarded)
+		assertEquals(listOf("foo.kt"), result.conflicted)
+	}
+
+	@Test
+	fun `pullRebase throws on non-conflict failure`() {
+		val runner = RecordingRunner(mutableListOf(
+			ExecResult("", "fatal: some error", 1),
+			// hasUnmergedPaths returns empty
+			ExecResult("", "", 0),
+		))
+		assertThrows(RuntimeException::class.java) {
+			client(runner).pullRebase()
+		}
+	}
+
+	@Test
+	fun `pullRebase suppresses editor`() {
+		val runner = RecordingRunner(mutableListOf(ExecResult("", "", 0)))
+		client(runner).pullRebase()
+		val env = runner.calls[0].env
+		assertEquals("true", env["GIT_EDITOR"])
+		assertEquals("true", env["GIT_SEQUENCE_EDITOR"])
+	}
+
+	@Test
+	fun `pullRebase uses autostash so unowned dirty files do not block the rebase`() {
+		// A dirty working tree (e.g. unrecognized .jolli/topics/ files left by a
+		// newer surface's hook) would otherwise hard-fail the rebase and drop
+		// the whole sync round to offline. --autostash shelves and restores them.
+		val runner = RecordingRunner(mutableListOf(ExecResult("", "", 0)))
+		client(runner).pullRebase()
+		assertTrue(runner.calls[0].command.contains("--autostash"))
+	}
+
+	// ── commit ────────────────────────────────────────────────────────
+
+	@Test
+	fun `commit returns HEAD sha on success`() {
+		val runner = RecordingRunner(mutableListOf(
+			ExecResult("", "", 0), // commit
+			ExecResult("abc123def456", "", 0), // rev-parse HEAD
+		))
+		val sha = client(runner).commit("test commit", CommitAuthor("Test", "test@test.com"))
+		assertEquals("abc123def456", sha)
+	}
+
+	@Test
+	fun `commit returns current HEAD when nothing to commit`() {
+		val runner = RecordingRunner(mutableListOf(
+			ExecResult("nothing to commit, working tree clean", "", 1),
+			ExecResult("existingsha", "", 0),
+		))
+		val sha = client(runner).commit("test", CommitAuthor("Test", "test@test.com"))
+		assertEquals("existingsha", sha)
+	}
+
+	@Test
+	fun `commit throws on real failure`() {
+		val runner = staticRunner(stderr = "fatal: some error", exitCode = 1)
+		assertThrows(RuntimeException::class.java) {
+			client(runner).commit("test", CommitAuthor("Test", "test@test.com"))
+		}
+	}
+
+	// ── push ──────────────────────────────────────────────────────────
+
+	@Test
+	fun `push ok with transmitted`() {
+		val runner = staticRunner(stderr = "To https://github.com/...\n   abc..def  HEAD -> main")
+		val result = client(runner).push()
+		assertTrue(result is PushResult.Ok)
+		assertTrue((result as PushResult.Ok).transmitted)
+	}
+
+	@Test
+	fun `push ok up-to-date`() {
+		val runner = staticRunner(stderr = "Everything up-to-date")
+		val result = client(runner).push()
+		assertTrue(result is PushResult.Ok)
+		assertFalse((result as PushResult.Ok).transmitted)
+	}
+
+	@Test
+	fun `push detects non-fast-forward`() {
+		val runner = staticRunner(stderr = "! [rejected] ... (non-fast-forward)", exitCode = 1)
+		val result = client(runner).push()
+		assertTrue(result is PushResult.Failed)
+		assertTrue((result as PushResult.Failed).nonFastForward)
+		assertFalse(result.unauthorized)
+		assertFalse(result.repoMissing)
+	}
+
+	@Test
+	fun `push detects unauthorized`() {
+		val runner = staticRunner(stderr = "fatal: Authentication failed for ...", exitCode = 128)
+		val result = client(runner).push()
+		assertTrue(result is PushResult.Failed)
+		assertTrue((result as PushResult.Failed).unauthorized)
+	}
+
+	@Test
+	fun `push detects repo missing`() {
+		val runner = staticRunner(stderr = "remote: Repository not found.\nfatal: ...", exitCode = 128)
+		val result = client(runner).push()
+		assertTrue(result is PushResult.Failed)
+		assertTrue((result as PushResult.Failed).repoMissing)
+		assertFalse(result.unauthorized)
+	}
+
+	@Test
+	fun `push unauthorized takes priority over repo missing`() {
+		val runner = staticRunner(
+			stderr = "Authentication failed\nremote: Repository not found.",
+			exitCode = 128,
+		)
+		val result = client(runner).push()
+		assertTrue(result is PushResult.Failed)
+		assertTrue((result as PushResult.Failed).unauthorized)
+		assertFalse(result.repoMissing)
+	}
+
+	// ── conflict resolution ───────────────────────────────────────────
+
+	@Test
+	fun `readIndexStage returns content on success`() {
+		val runner = staticRunner(stdout = "{\"key\":\"value\"}")
+		val content = client(runner).readIndexStage("foo.json", 2)
+		assertEquals("{\"key\":\"value\"}", content)
+	}
+
+	@Test
+	fun `readIndexStage returns null on failure`() {
+		val runner = staticRunner(exitCode = 1)
+		assertNull(client(runner).readIndexStage("missing.json", 1))
+	}
+
+	@Test
+	fun `readIndexStage rejects invalid stage`() {
+		assertThrows(IllegalArgumentException::class.java) {
+			client(staticRunner()).readIndexStage("foo.json", 0)
+		}
+	}
+
+	@Test
+	fun `checkoutOurs uses --theirs flag due to rebase inversion`() {
+		val runner = RecordingRunner(mutableListOf(
+			ExecResult("", "", 0), // checkout
+			ExecResult("", "", 0), // add
+		))
+		client(runner).checkoutOurs("foo.kt")
+		assertTrue(runner.calls[0].command.contains("--theirs"))
+	}
+
+	@Test
+	fun `checkoutTheirs uses --ours flag due to rebase inversion`() {
+		val runner = RecordingRunner(mutableListOf(
+			ExecResult("", "", 0),
+			ExecResult("", "", 0),
+		))
+		client(runner).checkoutTheirs("foo.kt")
+		assertTrue(runner.calls[0].command.contains("--ours"))
+	}
+
+	@Test
+	fun `rebaseContinue applies timeout`() {
+		val runner = RecordingRunner(mutableListOf(ExecResult("", "", 0)))
+		client(runner).rebaseContinue()
+		assertEquals(SyncGitClient.REBASE_TIMEOUT_MS, runner.calls[0].timeoutMs)
+	}
+
+	@Test
+	fun `rebaseAbort applies timeout`() {
+		val runner = RecordingRunner(mutableListOf(ExecResult("", "", 0)))
+		client(runner).rebaseAbort()
+		assertEquals(SyncGitClient.REBASE_TIMEOUT_MS, runner.calls[0].timeoutMs)
+	}
+
+	// ── self-healing ──────────────────────────────────────────────────
+
+	@Test
+	fun `isRebaseInProgress detects rebase-merge dir`(@TempDir tempDir: Path) {
+		val vault = tempDir.toFile()
+		File(vault, ".git/rebase-merge").mkdirs()
+		val c = client(staticRunner(), vaultRoot = vault.absolutePath)
+		assertTrue(c.isRebaseInProgress())
+	}
+
+	@Test
+	fun `isRebaseInProgress detects rebase-apply dir`(@TempDir tempDir: Path) {
+		val vault = tempDir.toFile()
+		File(vault, ".git/rebase-apply").mkdirs()
+		val c = client(staticRunner(), vaultRoot = vault.absolutePath)
+		assertTrue(c.isRebaseInProgress())
+	}
+
+	@Test
+	fun `isRebaseInProgress returns false when no rebase state`(@TempDir tempDir: Path) {
+		val vault = tempDir.toFile()
+		File(vault, ".git").mkdirs()
+		val c = client(staticRunner(), vaultRoot = vault.absolutePath)
+		assertFalse(c.isRebaseInProgress())
+	}
+
+	@Test
+	fun `sweepStaleLockFiles removes old lock files`(@TempDir tempDir: Path) {
+		val vault = tempDir.toFile()
+		val gitDir = File(vault, ".git")
+		gitDir.mkdirs()
+		val lockFile = File(gitDir, "index.lock")
+		lockFile.createNewFile()
+		// Set modification time to 10 minutes ago
+		lockFile.setLastModified(System.currentTimeMillis() - 10 * 60_000L)
+
+		val c = client(staticRunner(), vaultRoot = vault.absolutePath)
+		val removed = c.sweepStaleLockFiles()
+		assertEquals(1, removed.size)
+		assertFalse(lockFile.exists())
+	}
+
+	@Test
+	fun `sweepStaleLockFiles keeps fresh lock files`(@TempDir tempDir: Path) {
+		val vault = tempDir.toFile()
+		val gitDir = File(vault, ".git")
+		gitDir.mkdirs()
+		val lockFile = File(gitDir, "index.lock")
+		lockFile.createNewFile()
+		// Fresh file — should not be removed
+
+		val c = client(staticRunner(), vaultRoot = vault.absolutePath)
+		val removed = c.sweepStaleLockFiles()
+		assertTrue(removed.isEmpty())
+		assertTrue(lockFile.exists())
+	}
+
+	// ── branch management ─────────────────────────────────────────────
+
+	@Test
+	fun `currentBranch returns branch name on success`() {
+		val runner = staticRunner(stdout = "main\n")
+		assertEquals("main", client(runner).currentBranch())
+	}
+
+	@Test
+	fun `currentBranch falls back to HEAD when detached`() {
+		val runner = staticRunner(exitCode = 1)
+		assertEquals("HEAD", client(runner).currentBranch())
+	}
+
+	@Test
+	fun `refExists returns true when ref exists`() {
+		val runner = staticRunner(exitCode = 0)
+		assertTrue(client(runner).refExists("refs/heads/main"))
+	}
+
+	@Test
+	fun `refExists returns false when ref missing`() {
+		val runner = staticRunner(exitCode = 1)
+		assertFalse(client(runner).refExists("refs/heads/missing"))
+	}
+
+	@Test
+	fun `isAncestor returns true on exit 0`() {
+		assertTrue(client(staticRunner(exitCode = 0)).isAncestor("abc", "def"))
+	}
+
+	@Test
+	fun `isAncestor returns false on non-zero exit`() {
+		assertFalse(client(staticRunner(exitCode = 1)).isAncestor("abc", "def"))
+	}
+
+	@Test
+	fun `listLocalBranches parses output`() {
+		val runner = staticRunner(stdout = "main\nfeature/foo\ndev\n")
+		val branches = client(runner).listLocalBranches()
+		assertEquals(listOf("main", "feature/foo", "dev"), branches)
+	}
+
+	@Test
+	fun `listLocalBranches returns empty on failure`() {
+		val runner = staticRunner(exitCode = 1)
+		assertTrue(client(runner).listLocalBranches().isEmpty())
+	}
+
+	// ── staging ───────────────────────────────────────────────────────
+
+	@Test
+	fun `stageAddPaths chunks large path lists`() {
+		val paths = (1..100).map { "very/long/path/to/file_$it.kt" }
+		val runner = RecordingRunner(mutableListOf<ExecResult>().apply {
+			repeat(10) { add(ExecResult("", "", 0)) }
+		})
+		// Use a tiny budget to force multiple batches
+		val c = SyncGitClient(
+			vaultRoot = "/fake/vault",
+			credentials = defaultCredentials,
+			askpassProvider = fakeAskpass,
+			processRunner = runner,
+		)
+		// Call with real budget — should fit in one call for this size
+		c.stageAddPaths(paths)
+		assertTrue(runner.calls.isNotEmpty())
+		// All calls should contain "add" and "-f"
+		for (call in runner.calls) {
+			assertTrue(call.command.any { it == "add" })
+			assertTrue(call.command.any { it == "-f" })
+		}
+	}
+
+	// ── status ────────────────────────────────────────────────────────
+
+	@Test
+	fun `hasUncommittedChanges returns true when dirty`() {
+		val runner = staticRunner(stdout = " M foo.kt\n")
+		assertTrue(client(runner).hasUncommittedChanges())
+	}
+
+	@Test
+	fun `hasUncommittedChanges returns false when clean`() {
+		val runner = staticRunner(stdout = "")
+		assertFalse(client(runner).hasUncommittedChanges())
+	}
+
+	@Test
+	fun `statusPorcelainZ delegates to parser`() {
+		val runner = staticRunner(stdout = "M  foo.kt\u0000A  bar.kt\u0000")
+		val entries = client(runner).statusPorcelainZ()
+		assertEquals(2, entries.size)
+		assertEquals("foo.kt", entries[0].path)
+		assertEquals("bar.kt", entries[1].path)
+	}
+
+	// ── hasUnmergedPaths ──────────────────────────────────────────────
+
+	@Test
+	fun `hasUnmergedPaths parses ls-files output`() {
+		val output = "100644 abc 1\tconflict.kt\u0000100644 def 2\tconflict.kt\u0000100644 ghi 3\tconflict.kt\u0000"
+		val runner = staticRunner(stdout = output)
+		val entries = client(runner).hasUnmergedPaths()
+		assertEquals(1, entries.size)
+		assertEquals("conflict.kt", entries[0].path)
+		assertEquals(setOf(1, 2, 3), entries[0].stages)
+	}
+
+	@Test
+	fun `hasUnmergedPaths returns empty on clean index`() {
+		val runner = staticRunner(stdout = "")
+		assertTrue(client(runner).hasUnmergedPaths().isEmpty())
+	}
+
+	// ── initRemote ────────────────────────────────────────────────────
+
+	@Test
+	fun `initRemote uses defaultBranch`() {
+		val runner = RecordingRunner(mutableListOf(
+			ExecResult("", "", 0), // init
+			ExecResult("", "", 0), // remote add
+			ExecResult("", "", 0), // config
+		))
+		client(runner).initRemote("https://github.com/user/repo.git")
+		val initCmd = runner.calls[0].command
+		assertTrue(initCmd.any { it.contains("--initial-branch=main") })
+	}
+
+	@Test
+	fun `initRemote falls back to set-url when remote exists`() {
+		val runner = RecordingRunner(mutableListOf(
+			ExecResult("", "", 0),  // init
+			ExecResult("", "fatal: remote origin already exists", 1), // remote add fails
+			ExecResult("", "", 0),  // remote set-url
+			ExecResult("", "", 0),  // config
+		))
+		client(runner).initRemote("https://github.com/user/repo.git")
+		val setUrlCmd = runner.calls[2].command
+		assertTrue(setUrlCmd.contains("set-url"))
+	}
+
+	// ── hardening ─────────────────────────────────────────────────────
+
+	@Test
+	fun `all commands include hardening config`() {
+		val runner = RecordingRunner(mutableListOf(ExecResult("", "", 0)))
+		client(runner).fetch()
+		val cmd = runner.calls[0].command
+		assertTrue(cmd.contains("core.symlinks=false"))
+		assertTrue(cmd.contains("credential.helper="))
+		assertTrue(cmd.contains("credential.modalprompt=false"))
+	}
+
+	// ── checkGitInstalled ─────────────────────────────────────────────
+
+	@Test
+	fun `checkGitInstalled returns version on success`() {
+		val runner = staticRunner(stdout = "git version 2.43.0\n")
+		val result = client(runner).checkGitInstalled()
+		assertTrue(result is GitVersionResult.Ok)
+		assertEquals("git version 2.43.0", (result as GitVersionResult.Ok).version)
+	}
+
+	@Test
+	fun `checkGitInstalled returns NotFound on failure`() {
+		val runner = object : ProcessRunner {
+			override fun exec(command: List<String>, cwd: String?, env: Map<String, String>, timeoutMs: Long?): ExecResult {
+				throw RuntimeException("No git found")
+			}
+		}
+		val result = client(runner).checkGitInstalled()
+		assertTrue(result is GitVersionResult.NotFound)
+	}
+}
+
+// ── Helper function tests ─────────────────────────────────────────────
+
+class InjectGithubAppUsernameTest {
+
+	@Test
+	fun `injects x-access-token for plain https URL`() {
+		assertEquals(
+			"https://x-access-token@github.com/user/repo.git",
+			injectGithubAppUsername("https://github.com/user/repo.git"),
+		)
+	}
+
+	@Test
+	fun `preserves existing username`() {
+		val url = "https://existing-user@github.com/user/repo.git"
+		assertEquals(url, injectGithubAppUsername(url))
+	}
+
+	@Test
+	fun `passes through non-https URLs`() {
+		val url = "git@github.com:user/repo.git"
+		assertEquals(url, injectGithubAppUsername(url))
+	}
+}
+
+class ChunkByBudgetTest {
+
+	@Test
+	fun `single batch when under budget`() {
+		val paths = listOf("a.kt", "b.kt", "c.kt")
+		val batches = chunkByBudget(paths, 100)
+		assertEquals(1, batches.size)
+		assertEquals(paths, batches[0])
+	}
+
+	@Test
+	fun `splits into multiple batches`() {
+		val paths = listOf("aaaa", "bbbb", "cccc")
+		// budget = 6 → each path costs 5 chars, only one fits per batch
+		val batches = chunkByBudget(paths, 6)
+		assertEquals(3, batches.size)
+	}
+
+	@Test
+	fun `empty input returns empty`() {
+		assertTrue(chunkByBudget(emptyList(), 100).isEmpty())
+	}
+
+	@Test
+	fun `single path exceeding budget still ships as its own batch`() {
+		val paths = listOf("very-long-path-name")
+		val batches = chunkByBudget(paths, 5)
+		assertEquals(1, batches.size)
+		assertEquals(paths, batches[0])
+	}
+}

--- a/intellij/src/test/kotlin/ai/jolli/jollimemory/sync/SyncLockTest.kt
+++ b/intellij/src/test/kotlin/ai/jolli/jollimemory/sync/SyncLockTest.kt
@@ -1,0 +1,35 @@
+package ai.jolli.jollimemory.sync
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Path
+
+class SyncLockTest {
+
+	@TempDir
+	lateinit var tempDir: Path
+
+	@Test
+	fun `acquire and release round-trip`() {
+		try {
+			System.setProperty("JOLLI_SYNC_LOCK_DIR_TEST", tempDir.toString())
+			// Use the real SyncLock but with a tempdir-based path.
+			// Since we can't easily override env vars in JVM, test the
+			// underlying primitives directly.
+			val lockPath = tempDir.resolve("sync.lock")
+			assertTrue(LockPrimitives.tryAcquireOnce(lockPath))
+			assertTrue(LockPrimitives.isLockHeld(lockPath))
+			LockPrimitives.releaseIfOwned(lockPath, "sync.lock")
+			assertFalse(LockPrimitives.isLockHeld(lockPath))
+		} finally {
+			System.clearProperty("JOLLI_SYNC_LOCK_DIR_TEST")
+		}
+	}
+
+	@Test
+	fun `getSyncLockPath returns expected shape`() {
+		val path = SyncLock.getSyncLockPath()
+		assertTrue(path.toString().endsWith("sync.lock"))
+	}
+}

--- a/intellij/src/test/kotlin/ai/jolli/jollimemory/sync/SyncOrchestratorTest.kt
+++ b/intellij/src/test/kotlin/ai/jolli/jollimemory/sync/SyncOrchestratorTest.kt
@@ -1,0 +1,360 @@
+package ai.jolli.jollimemory.sync
+
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicLong
+
+class SyncOrchestratorTest {
+
+	private val orchestrators = mutableListOf<SyncOrchestrator>()
+
+	@AfterEach
+	fun tearDown() {
+		orchestrators.forEach { it.dispose() }
+	}
+
+	private fun track(orch: SyncOrchestrator): SyncOrchestrator {
+		orchestrators.add(orch)
+		return orch
+	}
+
+	// ── clampPoll ────────────────────────────────────────────────────────
+
+	@Test
+	fun `clampPoll returns default for null`() {
+		assertEquals(DEFAULT_POLL_SEC, clampPoll(null))
+	}
+
+	@Test
+	fun `clampPoll returns default for zero`() {
+		assertEquals(DEFAULT_POLL_SEC, clampPoll(0))
+	}
+
+	@Test
+	fun `clampPoll returns default for negative`() {
+		assertEquals(DEFAULT_POLL_SEC, clampPoll(-10))
+	}
+
+	@Test
+	fun `clampPoll clamps below minimum`() {
+		assertEquals(MIN_POLL_SEC, clampPoll(60))
+	}
+
+	@Test
+	fun `clampPoll clamps above maximum`() {
+		assertEquals(MAX_POLL_SEC, clampPoll(100_000))
+	}
+
+	@Test
+	fun `clampPoll passes through valid value`() {
+		val twoHours = 2 * 60 * 60
+		assertEquals(twoHours, clampPoll(twoHours))
+	}
+
+	// ── buildDetail ──────────────────────────────────────────────────────
+
+	@Test
+	fun `buildDetail returns null for clean synced result`() {
+		val result = SyncRoundResult(
+			fetched = true, pulled = true, pushed = true,
+			newState = SyncState.SYNCED,
+		)
+		assertEquals(null, buildDetail(result))
+	}
+
+	@Test
+	fun `buildDetail returns conflict count`() {
+		val result = SyncRoundResult(
+			fetched = true, pulled = true, pushed = false,
+			conflicts = listOf("a.json", "b.json"),
+			newState = SyncState.CONFLICTS,
+		)
+		val detail = buildDetail(result)!!
+		assertEquals(2, detail.conflictCount)
+	}
+
+	@Test
+	fun `buildDetail returns terminal error info`() {
+		val result = SyncRoundResult(
+			fetched = true, pulled = false, pushed = false,
+			newState = SyncState.OFFLINE,
+			lastError = SyncRoundError(
+				code = SyncErrorCode.VAULT_LOCKED,
+				message = "locked by other device",
+				selfLocked = true,
+			),
+		)
+		val detail = buildDetail(result)!!
+		assertTrue(detail.failed)
+		assertEquals(SyncErrorCode.VAULT_LOCKED, detail.failedCode)
+		assertTrue(detail.selfLocked)
+	}
+
+	@Test
+	fun `buildDetail ignores transient network error`() {
+		val result = SyncRoundResult(
+			fetched = false, pulled = false, pushed = false,
+			newState = SyncState.OFFLINE,
+			lastError = SyncRoundError(
+				code = SyncErrorCode.NETWORK,
+				message = "timeout",
+			),
+		)
+		assertEquals(null, buildDetail(result))
+	}
+
+	// ── SyncOrchestrator lifecycle ───────────────────────────────────────
+
+	private fun makeShimEngine(
+		roundFn: (SyncRoundOptions) -> SyncRoundResult,
+	): SyncEngine {
+		return ShimSyncEngine(roundFn)
+	}
+
+	private fun makeOrch(
+		roundFn: (SyncRoundOptions) -> SyncRoundResult = {
+			SyncRoundResult(
+				fetched = true, pulled = true, pushed = true,
+				newState = SyncState.SYNCED,
+			)
+		},
+		lastSuccessAtMs: AtomicLong = AtomicLong(0),
+		eagerTickMinElapsedMs: Long = DEFAULT_EAGER_TICK_MIN_ELAPSED_MS,
+		readyGate: CompletableFuture<Unit>? = null,
+		onStateChange: (SyncState, SyncStatusDetail?) -> Unit = { _, _ -> },
+		onRoundFinished: ((SyncState, SyncRoundResult) -> Unit)? = null,
+	): SyncOrchestrator {
+		return track(SyncOrchestrator(SyncOrchestratorOpts(
+			engine = makeShimEngine(roundFn),
+			cwd = "/test",
+			pollIntervalSec = MIN_POLL_SEC,
+			onStateChange = onStateChange,
+			onRoundFinished = onRoundFinished,
+			readyGate = readyGate,
+			lastSuccessAtMs = lastSuccessAtMs,
+			eagerTickMinElapsedMs = eagerTickMinElapsedMs,
+		)))
+	}
+
+	@Test
+	fun `start is idempotent`() {
+		val orch = makeOrch(lastSuccessAtMs = AtomicLong(System.currentTimeMillis()))
+		orch.start()
+		assertTrue(orch.isPolling)
+		orch.start()
+		assertTrue(orch.isPolling)
+	}
+
+	@Test
+	fun `stop cancels polling`() {
+		val orch = makeOrch(lastSuccessAtMs = AtomicLong(System.currentTimeMillis()))
+		orch.start()
+		assertTrue(orch.isPolling)
+		orch.stop()
+		assertFalse(orch.isPolling)
+	}
+
+	@Test
+	fun `syncNow fires a round`() {
+		val latch = CountDownLatch(1)
+		val roundCount = AtomicInteger(0)
+		val orch = makeOrch(
+			roundFn = {
+				roundCount.incrementAndGet()
+				SyncRoundResult(
+					fetched = true, pulled = true, pushed = true,
+					newState = SyncState.SYNCED,
+				)
+			},
+			onRoundFinished = { _, _ -> latch.countDown() },
+		)
+		orch.syncNow()
+		assertTrue(latch.await(5, TimeUnit.SECONDS))
+		assertEquals(1, roundCount.get())
+	}
+
+	@Test
+	fun `syncNow updates lastObservedState`() {
+		val latch = CountDownLatch(1)
+		val orch = makeOrch(
+			onRoundFinished = { _, _ -> latch.countDown() },
+		)
+		orch.syncNow()
+		assertTrue(latch.await(5, TimeUnit.SECONDS))
+		assertEquals(SyncState.SYNCED, orch.lastObservedState)
+	}
+
+	@Test
+	fun `syncNow records lastSuccessAtMs on success`() {
+		val lastSuccess = AtomicLong(0)
+		val latch = CountDownLatch(1)
+		val orch = makeOrch(
+			lastSuccessAtMs = lastSuccess,
+			onRoundFinished = { _, _ -> latch.countDown() },
+		)
+		orch.syncNow()
+		assertTrue(latch.await(5, TimeUnit.SECONDS))
+		assertTrue(lastSuccess.get() > 0)
+	}
+
+	@Test
+	fun `engine failure produces OFFLINE state`() {
+		val latch = CountDownLatch(1)
+		val orch = makeOrch(
+			roundFn = { throw RuntimeException("boom") },
+			onRoundFinished = { _, _ -> latch.countDown() },
+		)
+		orch.syncNow()
+		assertTrue(latch.await(5, TimeUnit.SECONDS))
+		assertEquals(SyncState.OFFLINE, orch.lastObservedState)
+	}
+
+	@Test
+	fun `onStateChange receives SYNCING then final state`() {
+		val states = CopyOnWriteArrayList<SyncState>()
+		val latch = CountDownLatch(1)
+		val orch = makeOrch(
+			onStateChange = { state, _ -> states.add(state) },
+			onRoundFinished = { _, _ -> latch.countDown() },
+		)
+		orch.syncNow()
+		assertTrue(latch.await(5, TimeUnit.SECONDS))
+		assertTrue(states.size >= 2)
+		assertEquals(SyncState.SYNCING, states[0])
+		assertEquals(SyncState.SYNCED, states.last())
+	}
+
+	@Test
+	fun `eager tick fires when lastSuccessAtMs is zero`() {
+		val latch = CountDownLatch(1)
+		val roundCount = AtomicInteger(0)
+		val orch = makeOrch(
+			lastSuccessAtMs = AtomicLong(0),
+			roundFn = {
+				roundCount.incrementAndGet()
+				SyncRoundResult(
+					fetched = true, pulled = true, pushed = true,
+					newState = SyncState.SYNCED,
+				)
+			},
+			onRoundFinished = { _, _ -> latch.countDown() },
+		)
+		orch.start()
+		assertTrue(latch.await(5, TimeUnit.SECONDS))
+		assertTrue(roundCount.get() >= 1)
+	}
+
+	@Test
+	fun `eager tick does not fire when last success is recent`() {
+		val roundCount = AtomicInteger(0)
+		val orch = makeOrch(
+			lastSuccessAtMs = AtomicLong(System.currentTimeMillis()),
+			roundFn = {
+				roundCount.incrementAndGet()
+				SyncRoundResult(
+					fetched = true, pulled = true, pushed = true,
+					newState = SyncState.SYNCED,
+				)
+			},
+		)
+		orch.start()
+		Thread.sleep(500)
+		assertEquals(0, roundCount.get())
+	}
+
+	@Test
+	fun `dispose prevents further ticks`() {
+		val roundCount = AtomicInteger(0)
+		val orch = makeOrch(
+			lastSuccessAtMs = AtomicLong(System.currentTimeMillis()),
+			roundFn = {
+				roundCount.incrementAndGet()
+				SyncRoundResult(
+					fetched = true, pulled = true, pushed = true,
+					newState = SyncState.SYNCED,
+				)
+			},
+		)
+		orch.dispose()
+		orch.syncNow()
+		Thread.sleep(500)
+		assertEquals(0, roundCount.get())
+	}
+
+	@Test
+	fun `generation check cancels stale poll tick`() {
+		val blockLatch = CountDownLatch(1)
+		val roundCount = AtomicInteger(0)
+		val orch = makeOrch(
+			lastSuccessAtMs = AtomicLong(System.currentTimeMillis()),
+			roundFn = {
+				roundCount.incrementAndGet()
+				blockLatch.await(5, TimeUnit.SECONDS)
+				SyncRoundResult(
+					fetched = true, pulled = true, pushed = true,
+					newState = SyncState.SYNCED,
+				)
+			},
+		)
+		orch.start()
+		orch.stop()
+		blockLatch.countDown()
+		Thread.sleep(500)
+		assertEquals(0, roundCount.get())
+	}
+
+	@Test
+	fun `requestManualSync fires followup after in-flight round`() {
+		val blockLatch = CountDownLatch(1)
+		val roundCount = AtomicInteger(0)
+		val orch = makeOrch(
+			lastSuccessAtMs = AtomicLong(System.currentTimeMillis()),
+			roundFn = {
+				val n = roundCount.incrementAndGet()
+				if (n == 1) {
+					blockLatch.await(5, TimeUnit.SECONDS)
+				}
+				SyncRoundResult(
+					fetched = true, pulled = true, pushed = true,
+					newState = SyncState.SYNCED,
+				)
+			},
+		)
+		// Start a manual round that blocks.
+		orch.syncNow()
+		Thread.sleep(200)
+
+		// Request another manual sync while the first is in flight.
+		val followupFuture = orch.requestManualSync()
+
+		// Release the first round.
+		blockLatch.countDown()
+
+		// The followup should complete and have triggered a second round.
+		followupFuture.get(5, TimeUnit.SECONDS)
+		assertEquals(2, roundCount.get())
+	}
+}
+
+/**
+ * Minimal [SyncEngine] subclass for testing.  Overrides [runRound] to
+ * delegate to a lambda, avoiding the full dependency tree.
+ */
+private class ShimSyncEngine(
+	private val roundFn: (SyncRoundOptions) -> SyncRoundResult,
+) : SyncEngine(SyncEngineOpts(
+	backend = SyncBackendClient(),
+	resolveContext = { throw UnsupportedOperationException() },
+	makeGitClient = GitClientFactory { _, _ -> throw UnsupportedOperationException() },
+)) {
+	override fun runRound(round: SyncRoundOptions): SyncRoundResult = roundFn(round)
+}

--- a/intellij/src/test/kotlin/ai/jolli/jollimemory/sync/VaultLockPathTest.kt
+++ b/intellij/src/test/kotlin/ai/jolli/jollimemory/sync/VaultLockPathTest.kt
@@ -1,0 +1,57 @@
+package ai.jolli.jollimemory.sync
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Path
+
+class VaultLockPathTest {
+
+	@TempDir
+	lateinit var tempDir: Path
+
+	@Test
+	fun `canonicalisation is stable across calls`() {
+		val a = canonicaliseLocalFolder(tempDir.toString())
+		val b = canonicaliseLocalFolder(tempDir.toString())
+		assertEquals(a, b)
+	}
+
+	@Test
+	fun `canonicalisation resolves trailing separator`() {
+		val withSlash = canonicaliseLocalFolder(tempDir.toString() + "/")
+		val without = canonicaliseLocalFolder(tempDir.toString())
+		assertEquals(withSlash, without)
+	}
+
+	@Test
+	fun `empty input throws`() {
+		assertThrows(IllegalArgumentException::class.java) {
+			canonicaliseLocalFolder("")
+		}
+	}
+
+	@Test
+	fun `getVaultWriteLockPath returns deterministic hash`() {
+		val path1 = getVaultWriteLockPath(tempDir.toString())
+		val path2 = getVaultWriteLockPath(tempDir.toString())
+		assertEquals(path1, path2)
+		assertTrue(path1.fileName.toString().startsWith("vault-"))
+		assertTrue(path1.fileName.toString().endsWith(".lock"))
+	}
+
+	@Test
+	fun `different paths produce different lock files`() {
+		val path1 = getVaultWriteLockPath(tempDir.resolve("a").toString())
+		val path2 = getVaultWriteLockPath(tempDir.resolve("b").toString())
+		assertNotEquals(path1, path2)
+	}
+
+	@Test
+	fun `tilde expansion works`() {
+		val home = System.getProperty("user.home")
+		val fromTilde = canonicaliseLocalFolder("~/test-folder")
+		val fromFull = canonicaliseLocalFolder("$home/test-folder")
+		assertEquals(fromTilde, fromFull)
+	}
+}

--- a/intellij/src/test/kotlin/ai/jolli/jollimemory/sync/VaultMarkerTest.kt
+++ b/intellij/src/test/kotlin/ai/jolli/jollimemory/sync/VaultMarkerTest.kt
@@ -1,0 +1,185 @@
+package ai.jolli.jollimemory.sync
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Files
+import java.nio.file.Path
+
+class VaultMarkerTest {
+
+	@TempDir
+	lateinit var tempDir: Path
+
+	private fun makeCreds(
+		gitUrl: String = "https://github.com/jolli-vaults/test-user.git",
+	) = GitCredentials(
+		token = "ghs_test",
+		gitUrl = gitUrl,
+		expiresAt = System.currentTimeMillis() + 3_600_000L,
+		repoFullName = "jolli-vaults/test-user",
+		defaultBranch = "main",
+		githubRepoCreated = false,
+		alreadyVaultBound = false,
+		lockOwnerToken = "lock-123",
+	)
+
+	// ── normalizeGitUrl ──────────────────────────────────────────────
+
+	@Test
+	fun `strips trailing dot-git`() {
+		assertEquals(
+			"https://github.com/jolli-vaults/test",
+			normalizeGitUrl("https://github.com/jolli-vaults/test.git"),
+		)
+	}
+
+	@Test
+	fun `strips auth segment`() {
+		assertEquals(
+			"https://github.com/jolli-vaults/test",
+			normalizeGitUrl("https://x-access-token:ghs_abc@github.com/jolli-vaults/test.git"),
+		)
+	}
+
+	@Test
+	fun `lowercases host always`() {
+		assertEquals(
+			"https://github.com/jolli-vaults/test",
+			normalizeGitUrl("https://GitHub.COM/jolli-vaults/test"),
+		)
+	}
+
+	@Test
+	fun `lowercases path for GitHub`() {
+		assertEquals(
+			"https://github.com/jolli-vaults/test",
+			normalizeGitUrl("https://github.com/Jolli-Vaults/TEST"),
+		)
+	}
+
+	@Test
+	fun `preserves path case for non-GitHub hosts`() {
+		assertEquals(
+			"https://git.example.com/MyOrg/MyRepo",
+			normalizeGitUrl("https://git.example.com/MyOrg/MyRepo"),
+		)
+	}
+
+	@Test
+	fun `strips trailing slash`() {
+		assertEquals(
+			"https://github.com/jolli-vaults/test",
+			normalizeGitUrl("https://github.com/jolli-vaults/test/"),
+		)
+	}
+
+	@Test
+	fun `returns non-https URLs unchanged`() {
+		val url = "git@github.com:user/repo.git"
+		assertEquals(url, normalizeGitUrl(url))
+	}
+
+	// ── writeVaultMarker + readVaultMarker ────────────────────────────
+
+	@Test
+	fun `write and read round-trip`() {
+		val root = tempDir.toString()
+		Files.createDirectories(Path.of(root, ".git"))
+		val creds = makeCreds()
+		writeVaultMarker(root, creds)
+		val marker = readVaultMarker(root)
+		assertNotNull(marker)
+		assertEquals("jolli-memory-bank", marker!!.kind)
+		assertEquals(1, marker.version)
+		assertEquals(normalizeGitUrl(creds.gitUrl), marker.gitUrl)
+		assertEquals("jolli-vaults/test-user", marker.repoFullName)
+		assertEquals("main", marker.defaultBranch)
+	}
+
+	@Test
+	fun `readVaultMarker returns null for missing marker`() {
+		val root = tempDir.resolve("empty").toString()
+		Files.createDirectories(Path.of(root, ".git"))
+		assertNull(readVaultMarker(root))
+	}
+
+	@Test
+	fun `readVaultMarker returns null for corrupt JSON`() {
+		val root = tempDir.toString()
+		val markerPath = Path.of(root, ".git", "jolli-vault-identity.json")
+		Files.createDirectories(markerPath.parent)
+		Files.writeString(markerPath, "not json")
+		assertNull(readVaultMarker(root))
+	}
+
+	@Test
+	fun `readVaultMarker returns null for wrong kind`() {
+		val root = tempDir.toString()
+		val markerPath = Path.of(root, ".git", "jolli-vault-identity.json")
+		Files.createDirectories(markerPath.parent)
+		Files.writeString(markerPath, """{"kind":"wrong","version":1,"gitUrl":"https://x.com/a/b"}""")
+		assertNull(readVaultMarker(root))
+	}
+
+	// ── verifyVaultMarker ────────────────────────────────────────────
+
+	@Test
+	fun `verify succeeds with matching URLs`() {
+		val root = tempDir.toString()
+		Files.createDirectories(Path.of(root, ".git"))
+		val creds = makeCreds()
+		writeVaultMarker(root, creds)
+		val verdict = verifyVaultMarker(root, creds.gitUrl, creds)
+		assertTrue(verdict is VaultVerdict.Ok)
+	}
+
+	@Test
+	fun `verify fails with missing marker`() {
+		val root = tempDir.resolve("empty2").toString()
+		Files.createDirectories(Path.of(root, ".git"))
+		val creds = makeCreds()
+		val verdict = verifyVaultMarker(root, creds.gitUrl, creds)
+		assertTrue(verdict is VaultVerdict.Failed)
+		assertEquals("missing_marker", (verdict as VaultVerdict.Failed).reason)
+	}
+
+	@Test
+	fun `verify fails with URL mismatch`() {
+		val root = tempDir.toString()
+		Files.createDirectories(Path.of(root, ".git"))
+		val creds = makeCreds()
+		writeVaultMarker(root, creds)
+		val otherCreds = makeCreds(gitUrl = "https://github.com/other-org/other-repo.git")
+		val verdict = verifyVaultMarker(root, creds.gitUrl, otherCreds)
+		assertTrue(verdict is VaultVerdict.Failed)
+		assertEquals("url_mismatch", (verdict as VaultVerdict.Failed).reason)
+	}
+
+	@Test
+	fun `verify fails with null origin URL`() {
+		val root = tempDir.toString()
+		Files.createDirectories(Path.of(root, ".git"))
+		val creds = makeCreds()
+		writeVaultMarker(root, creds)
+		val verdict = verifyVaultMarker(root, null, creds)
+		assertTrue(verdict is VaultVerdict.Failed)
+		assertEquals("url_mismatch", (verdict as VaultVerdict.Failed).reason)
+	}
+
+	@Test
+	fun `verify flags needsRewrite when stored URL differs in case`() {
+		val root = tempDir.toString()
+		Files.createDirectories(Path.of(root, ".git"))
+		// Write marker with uppercase path (simulating old client).
+		val markerPath = Path.of(root, ".git", "jolli-vault-identity.json")
+		Files.writeString(
+			markerPath,
+			"""{"kind":"jolli-memory-bank","version":1,"createdAt":"","gitUrl":"https://github.com/Jolli-Vaults/Test-User","repoFullName":"jolli-vaults/test-user","defaultBranch":"main"}""",
+		)
+		val creds = makeCreds(gitUrl = "https://github.com/jolli-vaults/test-user")
+		val verdict = verifyVaultMarker(root, creds.gitUrl, creds)
+		assertTrue(verdict is VaultVerdict.Ok)
+		assertTrue((verdict as VaultVerdict.Ok).needsRewrite)
+	}
+}

--- a/intellij/src/test/kotlin/ai/jolli/jollimemory/sync/VaultPathClassifierTest.kt
+++ b/intellij/src/test/kotlin/ai/jolli/jollimemory/sync/VaultPathClassifierTest.kt
@@ -1,0 +1,193 @@
+package ai.jolli.jollimemory.sync
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+
+class VaultPathClassifierTest {
+
+	// ── Root-level ───────────────────────────────────────────────────
+
+	@Test
+	fun `classifies root gitignore`() {
+		assertEquals(OwnedPathKind.ROOT_GITIGNORE, classifyVaultPath(".gitignore"))
+	}
+
+	@Test
+	fun `classifies root repos json`() {
+		assertEquals(OwnedPathKind.ROOT_REPOS, classifyVaultPath(".jolli/repos.json"))
+	}
+
+	// ── Per-repo aggregates ──────────────────────────────────────────
+
+	@Test
+	fun `classifies repo config`() {
+		assertEquals(OwnedPathKind.REPO_CONFIG, classifyVaultPath("my-repo/.jolli/config.json"))
+	}
+
+	@Test
+	fun `classifies repo index`() {
+		assertEquals(OwnedPathKind.REPO_INDEX, classifyVaultPath("my-repo/.jolli/index.json"))
+	}
+
+	@Test
+	fun `classifies repo manifest`() {
+		assertEquals(OwnedPathKind.REPO_MANIFEST, classifyVaultPath("my-repo/.jolli/manifest.json"))
+	}
+
+	@Test
+	fun `classifies repo branches`() {
+		assertEquals(OwnedPathKind.REPO_BRANCHES, classifyVaultPath("my-repo/.jolli/branches.json"))
+	}
+
+	@Test
+	fun `classifies repo catalog`() {
+		assertEquals(OwnedPathKind.REPO_CATALOG, classifyVaultPath("my-repo/.jolli/catalog.json"))
+	}
+
+	@Test
+	fun `classifies repo migration`() {
+		assertEquals(OwnedPathKind.REPO_MIGRATION, classifyVaultPath("my-repo/.jolli/migration.json"))
+	}
+
+	@Test
+	fun `rejects shadow-status json`() {
+		assertNull(classifyVaultPath("my-repo/.jolli/shadow-status.json"))
+	}
+
+	// ── Per-repo content ─────────────────────────────────────────────
+
+	@Test
+	fun `classifies summary`() {
+		assertEquals(OwnedPathKind.SUMMARY, classifyVaultPath("my-repo/.jolli/summaries/abc1234.json"))
+	}
+
+	@Test
+	fun `classifies summary with full SHA-1`() {
+		val hash = "a".repeat(40)
+		assertEquals(OwnedPathKind.SUMMARY, classifyVaultPath("my-repo/.jolli/summaries/$hash.json"))
+	}
+
+	@Test
+	fun `rejects summary with too-short hash`() {
+		assertNull(classifyVaultPath("my-repo/.jolli/summaries/abc12.json"))
+	}
+
+	@Test
+	fun `classifies transcript`() {
+		assertEquals(OwnedPathKind.TRANSCRIPT, classifyVaultPath("my-repo/.jolli/transcripts/abc1234.json"))
+	}
+
+	@Test
+	fun `classifies plan`() {
+		assertEquals(OwnedPathKind.PLAN, classifyVaultPath("my-repo/.jolli/plans/MyPlan.md"))
+	}
+
+	@Test
+	fun `classifies plan-progress`() {
+		assertEquals(OwnedPathKind.PLAN_PROGRESS, classifyVaultPath("my-repo/.jolli/plan-progress/MyPlan.json"))
+	}
+
+	@Test
+	fun `classifies note`() {
+		assertEquals(OwnedPathKind.NOTE, classifyVaultPath("my-repo/.jolli/notes/my-note.md"))
+	}
+
+	// ── Visible markdown ─────────────────────────────────────────────
+
+	@Test
+	fun `classifies visible summary`() {
+		assertEquals(
+			OwnedPathKind.VISIBLE_SUMMARY,
+			classifyVaultPath("my-repo/main/fix-bug-a1b2c3d4.md"),
+		)
+	}
+
+	@Test
+	fun `classifies visible plan`() {
+		assertEquals(
+			OwnedPathKind.VISIBLE_PLAN,
+			classifyVaultPath("my-repo/main/plan--MyPlan.md"),
+		)
+	}
+
+	@Test
+	fun `classifies visible note`() {
+		assertEquals(
+			OwnedPathKind.VISIBLE_NOTE,
+			classifyVaultPath("my-repo/main/note--my-note.md"),
+		)
+	}
+
+	@Test
+	fun `visible summary with wrong hex length falls through to user-content`() {
+		// The hex part must be exactly 8 chars to be a VISIBLE_SUMMARY, so this
+		// fails the strict catalogue check. But the vault is a general working
+		// tree, not just a FolderStorage drop, so a safe-segmented .md path
+		// rides the user-content fallthrough rather than being rejected.
+		// Matches the CLI source of truth (`short-1a2b.md` -> "user-content").
+		assertEquals(
+			OwnedPathKind.USER_CONTENT,
+			classifyVaultPath("my-repo/main/fix-bug-a1b2c3.md"),
+		)
+	}
+
+	// ── Fallthrough (user-content) ───────────────────────────────────
+
+	@Test
+	fun `safe path falls through to user-content`() {
+		assertEquals(OwnedPathKind.USER_CONTENT, classifyVaultPath("my-repo/hello.md"))
+	}
+
+	@Test
+	fun `multi-segment safe path is user-content`() {
+		assertEquals(OwnedPathKind.USER_CONTENT, classifyVaultPath("my-repo/notes/a.md"))
+	}
+
+	// ── Rejections (null) ────────────────────────────────────────────
+
+	@Test
+	fun `rejects empty string`() {
+		assertNull(classifyVaultPath(""))
+	}
+
+	@Test
+	fun `rejects leading slash`() {
+		assertNull(classifyVaultPath("/foo/bar.md"))
+	}
+
+	@Test
+	fun `rejects dot-slash prefix`() {
+		assertNull(classifyVaultPath("./foo/bar.md"))
+	}
+
+	@Test
+	fun `rejects double-dot traversal`() {
+		assertNull(classifyVaultPath("my-repo/../etc/passwd"))
+	}
+
+	@Test
+	fun `rejects backslash`() {
+		assertNull(classifyVaultPath("my-repo\\.jolli\\config.json"))
+	}
+
+	@Test
+	fun `rejects dot-prefixed segment`() {
+		assertNull(classifyVaultPath(".hidden/file.md"))
+	}
+
+	@Test
+	fun `rejects DS_Store`() {
+		assertNull(classifyVaultPath(".DS_Store"))
+	}
+
+	@Test
+	fun `rejects dot-vscode dir`() {
+		assertNull(classifyVaultPath(".vscode/settings.json"))
+	}
+
+	@Test
+	fun `rejects shadow-status in fallthrough`() {
+		// Even as a safe-segmented leaf, shadow-status.json is blocked.
+		assertNull(classifyVaultPath("my-repo/shadow-status.json"))
+	}
+}

--- a/intellij/src/test/kotlin/ai/jolli/jollimemory/sync/VaultSymlinkGuardTest.kt
+++ b/intellij/src/test/kotlin/ai/jolli/jollimemory/sync/VaultSymlinkGuardTest.kt
@@ -1,0 +1,86 @@
+package ai.jolli.jollimemory.sync
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Files
+import java.nio.file.Path
+
+class VaultSymlinkGuardTest {
+
+	@TempDir
+	lateinit var tempDir: Path
+
+	@Test
+	fun `passes with real directories`() {
+		val vault = tempDir.resolve("vault")
+		Files.createDirectories(vault.resolve("repo/.jolli/summaries"))
+		// Should not throw.
+		assertNoSymlinksInPath(
+			vault.toString(),
+			vault.resolve("repo/.jolli/summaries/abc.json").toString(),
+		)
+	}
+
+	@Test
+	fun `passes when intermediate dirs do not exist`() {
+		val vault = tempDir.resolve("vault2")
+		Files.createDirectories(vault)
+		// Deeper dirs don't exist yet — should not throw (ENOENT is tolerated).
+		assertNoSymlinksInPath(
+			vault.toString(),
+			vault.resolve("new-repo/.jolli/summaries/abc.json").toString(),
+		)
+	}
+
+	@Test
+	fun `throws when target escapes vault`() {
+		val vault = tempDir.resolve("vault3")
+		Files.createDirectories(vault)
+		assertThrows(IllegalArgumentException::class.java) {
+			assertNoSymlinksInPath(
+				vault.toString(),
+				tempDir.resolve("outside/file.json").toString(),
+			)
+		}
+	}
+
+	@Test
+	fun `throws when intermediate segment is a symlink`() {
+		val vault = tempDir.resolve("vault4")
+		Files.createDirectories(vault)
+		val realTarget = tempDir.resolve("real-target")
+		Files.createDirectories(realTarget)
+		// Create a symlink inside the vault pointing outside.
+		val link = vault.resolve("evil-link")
+		Files.createSymbolicLink(link, realTarget)
+		assertThrows(IllegalStateException::class.java) {
+			assertNoSymlinksInPath(
+				vault.toString(),
+				vault.resolve("evil-link/file.json").toString(),
+			)
+		}
+	}
+
+	@Test
+	fun `throws when segment is a regular file instead of directory`() {
+		val vault = tempDir.resolve("vault5")
+		Files.createDirectories(vault)
+		Files.writeString(vault.resolve("not-a-dir"), "content")
+		assertThrows(IllegalStateException::class.java) {
+			assertNoSymlinksInPath(
+				vault.toString(),
+				vault.resolve("not-a-dir/file.json").toString(),
+			)
+		}
+	}
+
+	@Test
+	fun `throws when target equals vault root`() {
+		val vault = tempDir.resolve("vault6")
+		Files.createDirectories(vault)
+		assertThrows(IllegalArgumentException::class.java) {
+			assertNoSymlinksInPath(vault.toString(), vault.toString())
+		}
+	}
+}

--- a/intellij/src/test/kotlin/ai/jolli/jollimemory/sync/VaultWriteLockTest.kt
+++ b/intellij/src/test/kotlin/ai/jolli/jollimemory/sync/VaultWriteLockTest.kt
@@ -1,0 +1,49 @@
+package ai.jolli.jollimemory.sync
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Path
+
+class VaultWriteLockTest {
+
+	@TempDir
+	lateinit var tempDir: Path
+
+	@Test
+	fun `fail-fast acquire succeeds when no contention`() {
+		// Use LockPrimitives directly with a known path to avoid env issues.
+		val lockPath = tempDir.resolve("vault-test.lock")
+		assertTrue(LockPrimitives.tryAcquireOnce(lockPath))
+		LockPrimitives.releaseIfOwned(lockPath, "test")
+	}
+
+	@Test
+	fun `handle release deletes lock file`() {
+		val lockPath = tempDir.resolve("vault-test.lock")
+		assertTrue(LockPrimitives.tryAcquireOnce(lockPath))
+		assertTrue(java.nio.file.Files.exists(lockPath))
+		LockPrimitives.releaseIfOwned(lockPath, "test")
+		assertFalse(java.nio.file.Files.exists(lockPath))
+	}
+
+	@Test
+	fun `handle refresh bumps mtime`() {
+		val lockPath = tempDir.resolve("vault-test.lock")
+		LockPrimitives.tryAcquireOnce(lockPath)
+		val oldMtime = java.nio.file.Files.getLastModifiedTime(lockPath).toMillis()
+		Thread.sleep(50)
+		LockPrimitives.refreshLockMtime(lockPath)
+		val newMtime = java.nio.file.Files.getLastModifiedTime(lockPath).toMillis()
+		assertTrue(newMtime >= oldMtime)
+	}
+
+	@Test
+	fun `VaultWriteLockMode sealed class variants`() {
+		val failFast: VaultWriteLockMode = VaultWriteLockMode.FailFast
+		val wait: VaultWriteLockMode = VaultWriteLockMode.Wait(10_000)
+		assertNotEquals(failFast, wait)
+		assertTrue(wait is VaultWriteLockMode.Wait)
+		assertEquals(10_000, (wait as VaultWriteLockMode.Wait).ms)
+	}
+}


### PR DESCRIPTION
<!-- jollimemory-summary-start -->
## Commits in this PR (3 of 13)

1. Fix IntelliJ sign-out/sign-in to clear and refresh jolliApiKey on tenant switch (`ccdd359`)
2. Make manual sync a no-op after dispose and fix stale sync tests (`449282a`)
3. Add KB toolbar sync button, inline status indicator, and --autostash pull fix (`5f1225b`)

## Quick recap (3)

### Commit 1 of 3: Fix IntelliJ sign-out/sign-in to clear and refresh jolliApiKey on tenant switch (`ccdd359`)

The IntelliJ plugin's sign-in and sign-out flow now correctly handles switching between Jolli tenants. Previously, signing out only cleared the session token, leaving behind a stored key that encodes the previous tenant's address. Any subsequent sign-in into a different tenant would appear to succeed in the browser but leave sync traffic still routing to the old tenant, producing silent failures on every sync attempt. After this fix, sign-out clears both credentials together, and sign-in detects when the stored key belongs to a different tenant and requests a replacement automatically. Users who sign out of one Jolli environment and sign into another will now have their memory bank sync correctly reach the new environment without any manual intervention or IDE restart.

### Commit 2 of 3: Make manual sync a no-op after dispose and fix stale sync tests (`449282a`)

Manual sync calls made after the sync engine shuts down now resolve quietly as no-ops. Previously, a sync request arriving at the moment of shutdown could surface an unhandled executor error; the fix adds a two-layer guard so both the fire-and-forget and the awaitable sync variants complete cleanly regardless of shutdown timing. Callers waiting on the awaitable variant receive an orderly success result rather than an exception to handle.

A set of sync tests that were passing for the wrong reasons were also corrected. The tests were using overly permissive fake git responses that caused conflict resolution and vault identity checks to short-circuit before reaching the code paths the tests were meant to cover. Updating the fakes to return realistic git output means the tests now exercise the intended logic and will catch genuine regressions going forward.

### Commit 3 of 3: Add KB toolbar sync button, inline status indicator, and --autostash pull fix (`5f1225b`)

The IntelliJ plugin's personal-space sync now provides visible feedback at every stage. A status label appears directly in the Knowledge Base toolbar — the same row as the view-toggle buttons — showing progress while a sync round runs, a brief green confirmation on success, and a red error label with detail on failure. Previously, both sync buttons gave no in-panel response at all, and the only signal was a small status-bar widget at the bottom of the IDE that was easy to miss.

The title-bar sync button was also fixed. It previously did nothing in certain situations — most notably right after signing in — and even when it did trigger a sync, it produced no feedback in the toolbar. Both sync entry points now go through the same code path and both drive the new toolbar indicator as well as the existing status-bar widget.

End-to-end sync was verified working against a local environment after these changes. A separate issue was discovered and fixed during that verification: a newer version of the background commit-processing hook writes a category of files into the Memory Bank vault that the IntelliJ sync engine does not recognize. Those files were sitting in a permanently modified state and causing every sync round to abort at the git rebase step. Adding a single flag to the rebase command causes git to automatically set those files aside during the rebase and restore them after, so an unrecognized file category can no longer bring down an entire sync round.

## E2E Test (4)
<details>
<summary><strong>1. [5f1225b] Toolbar sync button shows inline progress and result</strong></summary>
<br>
<blockquote>

**Preconditions:** Have the IntelliJ plugin installed and signed in to Jolli. Open a project that has a Memory Bank set up.

**Steps:**
1. Open the Memory Bank panel (the Jolli Memory tool window) in IntelliJ.
2. Look at the toolbar row at the top of the panel — find the cloud upload button (the sync icon next to the view-toggle buttons).
3. Click the cloud upload button.
4. Watch the toolbar row immediately to the right of the sync button.
5. Wait a few seconds for the sync to complete.
6. After the sync finishes, wait about four seconds without clicking anything.

**Expected Results:**
- As soon as you click the button, a spinning "⟳ Syncing…" label appears in the toolbar row.
- When the sync completes successfully, the label changes to a green "✓ Synced".
- About four seconds after showing "✓ Synced", the label disappears on its own and the toolbar returns to its normal state.
- At no point do you need to look at the bottom status bar to know whether sync is running or finished.

</blockquote>
</details>
<details>
<summary><strong>2. [5f1225b] Toolbar sync indicator shows error details on failure</strong></summary>
<br>
<blockquote>

**Preconditions:** Have the IntelliJ plugin installed and signed in to Jolli. Arrange for a sync failure (for example, disconnect from the internet or revoke credentials so the next sync will fail).

**Steps:**
1. Open the Memory Bank panel in IntelliJ.
2. Click the cloud upload button in the toolbar row.
3. Wait for the sync attempt to finish.
4. Look at the inline label that appears in the toolbar row.
5. Hover your mouse over the red error label.

**Expected Results:**
- The label turns red and shows a short message such as "✗ Sync failed" (or a more specific message like "✗ Push rejected" depending on the error type).
- Hovering over the label shows a tooltip with a fuller description of what went wrong.
- The red label stays visible and does not auto-clear (unlike the green "✓ Synced" message).

</blockquote>
</details>
<details>
<summary><strong>3. [5f1225b] Title-bar &quot;Sync Now&quot; button works immediately after signing in</strong></summary>
<br>
<blockquote>

**Preconditions:** Have the IntelliJ plugin installed. Start from a signed-out state so you can sign in fresh during the test.

**Steps:**
1. Open the Memory Bank tool window in IntelliJ.
2. Sign in to Jolli using the Settings panel (open Settings → Memory Bank and complete sign-in).
3. Without restarting IntelliJ or doing anything else, click the "Sync Now" button in the tool window title bar (the cloud icon at the very top of the tool window, not inside the panel).
4. Watch the inline toolbar label inside the Memory Bank panel.

**Expected Results:**
- Clicking "Sync Now" immediately after signing in does not silently do nothing.
- The "⟳ Syncing…" label appears in the panel toolbar, confirming that a sync round actually started.
- The label eventually updates to "✓ Synced" (or an error label if something goes wrong), showing that the title-bar button and the toolbar indicator are connected.

</blockquote>
</details>
<details>
<summary><strong>4. [5f1225b] Sync completes successfully when unrecognized vault files are present</strong></summary>
<br>
<blockquote>

**Preconditions:** Have the IntelliJ plugin installed and signed in. The Memory Bank vault should contain files that the plugin does not manage — for example, files written by a newer version of the post-commit hook (such as extra files inside the `.jolli/topics/` folder). These files should be in a modified state (edited but not committed).

**Steps:**
1. Open the Memory Bank panel in IntelliJ.
2. Click the cloud upload button in the toolbar to start a sync.
3. Watch the inline toolbar label and wait for the sync to finish.

**Expected Results:**
- The label progresses from "⟳ Syncing…" to "✓ Synced" without showing any error.
- The sync does not get stuck or drop to an offline/failed state because of the unrecognized modified files.
- The unrecognized files are still present in the vault after sync completes (they are not deleted or committed by the sync).

</blockquote>
</details>

## Topics (6)
<details>
<summary><strong>01 · [ccdd359] Sign-out and sign-in now fully reset the stored authentication key on tenant switch</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

After signing out of one Jolli tenant and signing into a different one, the memory sync kept routing to the original tenant and failing. Restarting the IDE did not help. The root cause was traced through debug logs: the stored authentication key encodes the target tenant, and sign-out was leaving the old key on disk while sign-in was not replacing it when switching tenants.

**💡 Decisions Behind the Code**

- **Clearing both credentials together on sign-out**: Leaving the API key behind after sign-out was the direct cause of the routing bug — the key's embedded tenant URL is what the sync engine uses to decide where to send requests, so a stale key from a previous tenant would keep misdirecting traffic even after a fresh sign-in. The VS Code and CLI implementations already clear both in one atomic write, so this brings the IntelliJ plugin to parity with the established contract.
- **Tenant-mismatch check on sign-in, not just absence check**: Checking only for a missing key meant that a user who had ever signed in would never get a fresh key on a tenant switch — the old key would silently survive. Comparing the key's embedded tenant against the sign-in target catches the cross-tenant case while leaving re-authentication against the same tenant untouched, so manually configured keys are not disrupted by routine re-logins.
- **Treating undecodable legacy keys as a match**: Keys that cannot be decoded could be hand-typed or from an older format. Treating them as mismatched would silently drop them on the next sign-in, which would surprise users who configured them deliberately. Failing safe by treating them as a match means the worst outcome is that a legacy key is not replaced when it arguably should be — a much less disruptive failure mode than unexpectedly deleting a working key.

**✅ What Was Implemented**

- `JolliAuthService.signOut()` was updated to clear both the session token and the API key in a single write. Previously only the session token was cleared, leaving the tenant-encoded key behind to misdirect all subsequent sync traffic.
- `JolliAuthService.login()` was updated to request a fresh API key whenever the existing key's embedded tenant differs from the tenant being signed into, not only when no key exists at all. This mirrors the equivalent logic already present in the CLI and VS Code extensions.
- A new helper, `shouldRequestFreshApiKey`, was added to the auth utilities module. It decodes the stored key's tenant origin and slug and compares them against the sign-in target, treating undecodable legacy keys as a safe match to avoid silently dropping hand-configured keys.

**📁 FILES**
- `intellij/src/main/kotlin/ai/jolli/jollimemory/auth/JolliAuthUtils.kt`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/services/JolliAuthService.kt`
- `intellij/src/test/kotlin/ai/jolli/jollimemory/auth/JolliAuthUtilsTest.kt`
- `intellij/src/test/kotlin/ai/jolli/jollimemory/services/JolliAuthServiceTest.kt`

</blockquote>
</details>
<details>
<summary><strong>02 · [449282a] Prevent errors when syncing after the sync engine is shut down</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Calling a manual sync right as the sync engine was shutting down could cause an unhandled executor error to surface, rather than silently doing nothing. The same race condition affected both the fire-and-forget sync and the awaitable sync variant.

**💡 Decisions Behind the Code**

- **Two-layer defense over a single lock**: A single disposed-flag check cannot fully close the race window between checking and submitting — the executor can be shut down in that gap. Catching `RejectedExecutionException` as a second layer handles this narrow window without requiring heavier synchronization, keeping the shutdown path simple and lock-free.
- **Resolve the awaitable future as success on disposal**: When the sync engine is already gone, completing the returned future with a success value (rather than an exception) treats disposal as a clean terminal state. Callers waiting on the future get an orderly resolution rather than an error they would need to filter out, which simplifies every call site.

**✅ What Was Implemented**

- In `SyncOrchestrator.syncNow()`, added an early-exit guard that checks whether the orchestrator has already been disposed before attempting to submit work. A `RejectedExecutionException` catch block handles the narrow race where disposal completes between the guard check and the actual submission.
- In `SyncOrchestrator.requestManualSync()`, applied the same two-layer defense: a disposed-state early return that immediately resolves the returned future as a no-op, plus a `RejectedExecutionException` catch on the submission call that also resolves the future cleanly rather than leaving it hanging.

**📁 FILES**
- `intellij/src/main/kotlin/ai/jolli/jollimemory/sync/SyncOrchestrator.kt`

</blockquote>
</details>
<details>
<summary><strong>03 · [449282a] Fix stale sync tests that passed for the wrong reason</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Several sync tests were passing not because the code under test was working correctly, but because the fake git responses they used returned empty output, which caused the conflict resolution logic to short-circuit before reaching the code path the tests were meant to exercise.

**💡 Decisions Behind the Code**

- **Fix root causes rather than adjust assertions**: Each failing or misleading test was tracing back to an incomplete fake environment — missing git command stubs or overly permissive empty responses. Fixing the stubs to reflect realistic git behavior makes the tests meaningful and prevents them from masking future regressions in the paths they claim to cover.

**✅ What Was Implemented**

- In `ConflictResolverTest`, replaced the bare empty-output stub with a `conflictingStages()` helper that returns distinct non-empty content for the two sides of a conflict. This ensures the conflict resolver actually reaches the deeper resolution tier the tests are validating, rather than being short-circuited by an "identical content" fast path.
- In `SyncEngineTest`, added a stub response for the `git remote get-url` command. Without it, the vault identity guard was failing its origin-URL check and degrading the sync round to an offline state, meaning the test assertions were running against a degraded path rather than the intended one.
- In `VaultPathClassifierTest`, corrected a test that expected a path with a slightly malformed identifier to be outright rejected; the correct behavior (and the behavior matching the CLI reference implementation) is to fall through and classify it as general user content instead.

**📋 Future Enhancements**

Review other tests that use the bare empty-output git stub to check whether any are similarly short-circuiting logic they intend to exercise.

**📁 FILES**
- `intellij/src/test/kotlin/ai/jolli/jollimemory/sync/ConflictResolverTest.kt`
- `intellij/src/test/kotlin/ai/jolli/jollimemory/sync/SyncEngineTest.kt`
- `intellij/src/test/kotlin/ai/jolli/jollimemory/sync/VaultPathClassifierTest.kt`

</blockquote>
</details>
<details>
<summary><strong>04 · [5f1225b] Inline sync progress indicator added to Knowledge Base toolbar</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Clicking either sync button in the IntelliJ plugin gave no visual feedback — there was no way to tell whether a sync was in progress, succeeded, or failed without hunting for the IDE status bar at the bottom of the screen.

**💡 Decisions Behind the Code**

- **Inline indicator alongside the existing status-bar widget**: The IDE status bar already showed errors, mirroring VS Code's behavior, but it is easy to miss. Adding a second, in-panel indicator in the same toolbar row as the sync button gives immediate, contextual feedback without removing the status-bar signal. The two surfaces are intentionally redundant: the toolbar label is transient and auto-clears on success, while the status bar persists for errors.
- **Listener-based fan-out rather than polling**: The panel registers a callback with the service rather than polling sync state on a timer. This keeps the indicator latency-free and avoids any coupling between the panel's lifecycle and the orchestrator's internal scheduling. Late-registration replay (delivering the current state on subscribe) ensures panels opened after a sync round has already started still reflect the correct state.

**✅ What Was Implemented**

- `KBExplorerPanel.kt` gained a `syncStatusLabel` placed in the toolbar row alongside the view-toggle buttons. It shows a spinning "Syncing…" label while a round is active, a green "Synced" confirmation that auto-clears after four seconds on success, a yellow conflict count, and a red error label with a tooltip carrying the full error message on failure. A `syncClearTimer` drives the auto-clear behavior and is stopped on panel disposal.
- `JolliMemoryService.kt` was extended with a `syncListeners` list and `addSyncStateListener` / `removeSyncStateListener` methods. The orchestrator's existing state-change callback now fans out to these listeners on the UI thread in addition to updating the status-bar widget. Late-registering panels receive the current state immediately on registration, and all listeners are cleared on service disposal.

**📁 FILES**
- `intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/KBExplorerPanel.kt`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/services/JolliMemoryService.kt`

</blockquote>
</details>
<details>
<summary><strong>05 · [5f1225b] Title-bar sync button fixed to reliably trigger sync and show feedback</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The sync button in the tool window title bar sometimes did nothing when clicked — particularly right after signing in — and never produced the toolbar progress indicator even when it did work.

**💡 Decisions Behind the Code**

The title-bar button previously called the sync request directly, which is a silent no-op when the orchestrator does not exist yet. Rather than making the orchestrator always pre-built at startup (which would consume resources even when sync is disabled), the fix mirrors the approach already used by the toolbar button: check whether the orchestrator exists and build it on demand in the background before requesting the sync. This keeps startup cost low while making both entry points equally reliable.

**✅ What Was Implemented**

`CloudSyncAction.kt` was updated so the title-bar "Sync Now" button follows the same lazy-build path as the toolbar button: if the sync orchestrator has not been constructed yet, it is built first on a background thread before the manual sync request is issued. A new `isSyncBuilt()` method was added to `JolliMemoryService` to expose this gate. Both sync entry points now route through the orchestrator's state-change callbacks, so both produce toolbar indicator updates and status-bar feedback.

**📁 FILES**
- `intellij/src/main/kotlin/ai/jolli/jollimemory/actions/CloudSyncAction.kt`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/services/JolliMemoryService.kt`

</blockquote>
</details>
<details>
<summary><strong>06 · [5f1225b] Unrecognized vault files no longer block personal-space sync</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

After the authentication fix landed, sync still failed every round with a git error about uncommitted changes. Three files written by a newer version of the post-commit hook were sitting in a modified state that the sync engine did not know how to handle, permanently jamming the rebase step.

**💡 Decisions Behind the Code**

- **Autostash over teaching the classifier about the new content type**: The files causing the failure belong to a knowledge-base feature that exists in a newer version of the hook pipeline but has not yet been ported to the IntelliJ sync engine. Fully supporting that content type would require porting a non-trivial feature across multiple surfaces in lockstep. Autostash is a one-line change that unblocks sync immediately and also defends against any future unrecognized content type, not just this one. The deferred work of properly classifying and syncing that content type remains open.
- **Not discarding the unrecognized files**: An alternative was to simply discard the modified files before rebasing. That would have been destructive — the files are valid data written by another part of the system. Autostash preserves them locally while keeping the sync round unblocked.

**✅ What Was Implemented**

- `SyncGitClient.kt`: the pull-rebase command gained the `--autostash` flag. Git now automatically shelves any modified tracked files that the sync engine does not own before rebasing and restores them afterward. A code comment explains the specific scenario (newer hook surfaces writing content types the classifier does not recognize).
- `SyncGitClientTest.kt`: a new test asserts that the pull command includes the autostash flag, with a comment describing the failure mode it prevents.

**📋 Future Enhancements**

The `.jolli/topics/` content type (a cross-branch knowledge-base index written by the post-commit hook in newer surface versions) is not classified or synced by the IntelliJ engine. It should be added as a recognized, syncable content type in lockstep with the CLI classifier once the topics feature is formally ported.

**📁 FILES**
- `intellij/src/main/kotlin/ai/jolli/jollimemory/sync/SyncGitClient.kt`

</blockquote>
</details>

> Note: 10 commit(s) without summary were skipped.

---

*Generated by Jolli Memory · June 12, 2026 at 9:53 AM*
<!-- jollimemory-summary-end -->