### PR TITLE
Fix null/scalar JSON and unguarded transcript read failures in scan pipeline

### DIFF
--- a/cli/src/core/CursorSessionDiscoverer.test.ts
+++ b/cli/src/core/CursorSessionDiscoverer.test.ts
@@ -269,6 +269,45 @@ describe("discoverCursorSessions", () => {
 		expect(sessions).toEqual([]);
 	});
 
+	it("skips a composerData row whose value is the literal null without failing the whole scan", async () => {
+		// Regression: Cursor stores `composerData:empty-state-draft` with the JSON literal `null`.
+		// `JSON.parse("null")` returns null WITHOUT throwing, so the invalid-JSON catch never fires;
+		// the subsequent `parsed.composerId` access used to throw `Cannot read properties of null`,
+		// abort the scan, and surface as "Some sources unavailable (cursor)" in the UI — while also
+		// dropping every valid session in the same batch.
+		const userDir = join(tmpHome, "Library/Application Support/Cursor/User");
+		await mkdir(join(userDir, "globalStorage"), { recursive: true });
+		await mkdir(join(userDir, "workspaceStorage", "ws-00000000"), { recursive: true });
+		await writeFile(
+			join(userDir, "workspaceStorage", "ws-00000000", "workspace.json"),
+			JSON.stringify({ folder: toFileUri("/Users/flyer/work/proj-a") }),
+		);
+
+		const wsDbPath = join(userDir, "workspaceStorage", "ws-00000000", "state.vscdb");
+		const wsDb = new DatabaseSync(wsDbPath);
+		for (const sql of CURSOR_DDL) wsDb.prepare(sql).run();
+		wsDb.close();
+
+		const globalDbPath = join(userDir, "globalStorage", "state.vscdb");
+		const globalDb = new DatabaseSync(globalDbPath);
+		for (const sql of CURSOR_DDL) globalDb.prepare(sql).run();
+		// The crashing sentinel row: a valid JSON document that is not an object.
+		globalDb
+			.prepare("INSERT INTO cursorDiskKV (key, value) VALUES (?, ?)")
+			.run("composerData:empty-state-draft", "null");
+		// A non-null, non-object scalar — exercises the `typeof parsed !== "object"` arm of the guard.
+		globalDb.prepare("INSERT INTO cursorDiskKV (key, value) VALUES (?, ?)").run("composerData:scalar", "42");
+		// A genuinely-valid composer that must still be returned despite the bad rows above.
+		globalDb
+			.prepare("INSERT INTO cursorDiskKV (key, value) VALUES (?, ?)")
+			.run("composerData:good-1", JSON.stringify({ composerId: "good-1", lastUpdatedAt: Date.now() }));
+		globalDb.close();
+
+		const result = await scanCursorSessions(toNativePath("/Users/flyer/work/proj-a"));
+		expect(result.error).toBeUndefined();
+		expect(result.sessions.map((s) => s.sessionId)).toEqual(["good-1"]);
+	});
+
 	it("skips composerData rows with non-finite lastUpdatedAt (anchor and non-anchor)", async () => {
 		const userDir = join(tmpHome, "Library/Application Support/Cursor/User");
 		await mkdir(join(userDir, "globalStorage"), { recursive: true });

--- a/cli/src/core/CursorSessionDiscoverer.ts
+++ b/cli/src/core/CursorSessionDiscoverer.ts
@@ -113,21 +113,33 @@ export async function scanCursorSessions(projectDir: string): Promise<CursorScan
 				.all() as ReadonlyArray<{ key: string; value: string }>;
 
 			for (const row of rows) {
-				let parsed: Record<string, unknown>;
+				let parsed: unknown;
 				try {
-					parsed = JSON.parse(row.value) as Record<string, unknown>;
+					parsed = JSON.parse(row.value);
 				} catch {
 					log.warn("Skipping Cursor composer row %s: invalid JSON", row.key);
 					continue;
 				}
 
-				const composerId = typeof parsed.composerId === "string" ? parsed.composerId : null;
+				// `JSON.parse` only throws on syntactically invalid input. A row whose value is a
+				// valid JSON scalar — most notably the literal `null` that Cursor stores for the
+				// `composerData:empty-state-draft` sentinel row — parses without error, so the
+				// catch above never fires. Without this guard the `parsed.composerId` access below
+				// throws `Cannot read properties of null`, which escapes the loop and fails the
+				// entire scan (surfacing as "Some sources unavailable (cursor)" in the UI).
+				if (parsed === null || typeof parsed !== "object") {
+					log.warn("Skipping Cursor composer row %s: value is not a JSON object", row.key);
+					continue;
+				}
+				const composer = parsed as Record<string, unknown>;
+
+				const composerId = typeof composer.composerId === "string" ? composer.composerId : null;
 				if (composerId === null) {
 					log.warn("Skipping Cursor composer row %s: missing composerId", row.key);
 					continue;
 				}
 
-				const lastUpdatedAt = parsed.lastUpdatedAt;
+				const lastUpdatedAt = composer.lastUpdatedAt;
 
 				// Guard against schema drift: non-numeric timestamps.
 				if (typeof lastUpdatedAt !== "number" || !Number.isFinite(lastUpdatedAt)) {
@@ -152,7 +164,7 @@ export async function scanCursorSessions(projectDir: string): Promise<CursorScan
 				}
 				seenIds.add(composerId);
 
-				const nameRaw = typeof parsed.name === "string" ? parsed.name.trim() : "";
+				const nameRaw = typeof composer.name === "string" ? composer.name.trim() : "";
 				const title = nameRaw.length > 0 ? nameRaw : undefined;
 
 				out.push({

--- a/cli/src/hooks/QueueWorker.overlay.test.ts
+++ b/cli/src/hooks/QueueWorker.overlay.test.ts
@@ -147,6 +147,7 @@ import { loadOverlay, overlayPath, saveOverlay } from "../core/ConversationOverl
 import { readCopilotChatTranscript } from "../core/CopilotChatTranscriptReader.js";
 import { readCopilotTranscript } from "../core/CopilotTranscriptReader.js";
 import { readCursorTranscript } from "../core/CursorTranscriptReader.js";
+import { readGeminiTranscript } from "../core/GeminiTranscriptReader.js";
 import { readOpenCodeTranscript } from "../core/OpenCodeTranscriptReader.js";
 import { loadAllSessions, loadCursorForTranscript } from "../core/SessionTracker.js";
 import { readTranscript } from "../core/TranscriptReader.js";
@@ -267,13 +268,14 @@ describe("QueueWorker overlay path", () => {
 	// "skip this session, keep going" semantics) need a test where each
 	// reader throws so the surrounding pipeline still completes.
 	const readErrorCases: ReadonlyArray<{
-		readonly source: "opencode" | "cursor" | "copilot" | "copilot-chat";
+		readonly source: "opencode" | "cursor" | "copilot" | "copilot-chat" | "gemini";
 		readonly mock: ReturnType<typeof vi.fn>;
 	}> = [
 		{ source: "opencode", mock: vi.mocked(readOpenCodeTranscript) },
 		{ source: "cursor", mock: vi.mocked(readCursorTranscript) },
 		{ source: "copilot", mock: vi.mocked(readCopilotTranscript) },
 		{ source: "copilot-chat", mock: vi.mocked(readCopilotChatTranscript) },
+		{ source: "gemini", mock: vi.mocked(readGeminiTranscript) },
 	];
 	for (const { source, mock } of readErrorCases) {
 		it(`skips a ${source} session whose transcript reader throws`, async () => {

--- a/cli/src/hooks/QueueWorker.test.ts
+++ b/cli/src/hooks/QueueWorker.test.ts
@@ -374,7 +374,7 @@ import { createStorage } from "../core/StorageFactory.js";
 import { generateSummary } from "../core/Summarizer.js";
 import { storeSummary } from "../core/SummaryStore.js";
 import { renderTopicKBWiki } from "../core/TopicWikiRenderer.js";
-import { buildMultiSessionContext } from "../core/TranscriptReader.js";
+import { buildMultiSessionContext, readTranscript } from "../core/TranscriptReader.js";
 import { consumePendingWorkers, recordPendingWorker } from "../sync/PendingWorkers.js";
 import { acquireVaultWriteLock } from "../sync/VaultWriteLock.js";
 import type { CommitGitOperation, IngestOperation } from "../Types.js";
@@ -1572,6 +1572,66 @@ describe("QueueWorker", () => {
 			expect(discoverOpenCodeSessions).toHaveBeenCalledWith("/test/cwd");
 			// Pipeline completes normally
 			expect(storeSummary).toHaveBeenCalled();
+		});
+	});
+
+	describe("Claude integration — missing transcript file", () => {
+		it("skips a Claude session whose transcript file is unreadable and still summarizes the rest", async () => {
+			// Regression: a Claude session in sessions.json pointing at a transcript that was
+			// deleted/rotated makes readTranscript throw ENOENT. The claude branch in
+			// readAllTranscripts used to be unguarded, so that throw aborted the whole pipeline
+			// and the commit summary was silently dropped. The reader is now wrapped in
+			// try/catch + continue, so one dead transcript only skips its own session.
+			const op = makeCommitOp();
+			const queueEntry = { op, filePath: "/tmp/queue/claude-missing.json" };
+
+			vi.mocked(dequeueAllGitOperations)
+				.mockResolvedValueOnce([queueEntry])
+				.mockResolvedValueOnce([])
+				.mockResolvedValueOnce([]);
+
+			setupPipelineMocks();
+			vi.mocked(loadAllSessions).mockResolvedValue([
+				{
+					sessionId: "dead-1",
+					transcriptPath: "/Users/zf/.claude/projects/proj/dead-1.jsonl",
+					updatedAt: "2026-04-01T12:00:00.000Z",
+					source: "claude",
+				},
+				{
+					sessionId: "live-1",
+					transcriptPath: "/Users/zf/.claude/projects/proj/live-1.jsonl",
+					updatedAt: "2026-04-01T12:00:00.000Z",
+					source: "claude",
+				},
+			]);
+			vi.mocked(readTranscript).mockImplementation(async (transcriptPath: string) => {
+				if (transcriptPath.endsWith("dead-1.jsonl")) {
+					throw new Error(`Cannot read transcript: ${transcriptPath}`);
+				}
+				return {
+					entries: [{ role: "human", content: "Live context", timestamp: "2026-04-01T12:00:00.000Z" }],
+					newCursor: { transcriptPath, lineNumber: 1, updatedAt: "2026-04-01T12:00:00.000Z" },
+					totalLinesRead: 1,
+				};
+			});
+
+			await runWorker("/test/cwd");
+
+			// The throw from the dead transcript must not abort the run — the summary is still produced.
+			expect(storeSummary).toHaveBeenCalledTimes(1);
+			// The live session's cursor advanced; the dead session never produced a cursor write.
+			expect(saveCursor).toHaveBeenCalledWith(
+				expect.objectContaining({
+					transcriptPath: "/Users/zf/.claude/projects/proj/live-1.jsonl",
+					lineNumber: 1,
+				}),
+				"/test/cwd",
+			);
+			expect(saveCursor).not.toHaveBeenCalledWith(
+				expect.objectContaining({ transcriptPath: "/Users/zf/.claude/projects/proj/dead-1.jsonl" }),
+				"/test/cwd",
+			);
 		});
 	});
 

--- a/cli/src/hooks/QueueWorker.ts
+++ b/cli/src/hooks/QueueWorker.ts
@@ -2669,13 +2669,22 @@ async function readAllTranscripts(
 		const source = session.source ?? "claude";
 
 		// Gemini, OpenCode, Cursor, and Copilot use dedicated readers (not JSONL line-based parsing).
-		// SQLite-backed readers (opencode/cursor/copilot) share the same failure modes —
-		// transient lock, corruption, schema drift, DB disappearing between scan and read.
-		// Wrap each in try/catch + `continue` so one bad session never abandons the rest of
-		// the batch. JSONL readers (gemini/claude) handle their per-line failures internally.
+		// Every reader is wrapped in try/catch + `continue` so one bad session never abandons the
+		// rest of the batch. SQLite-backed readers (opencode/cursor/copilot) fail on transient
+		// lock, corruption, schema drift, or DB disappearing between scan and read. The JSONL
+		// readers (gemini/claude) handle per-line corruption internally, but a missing or
+		// unreadable transcript file (ENOENT/EACCES) throws from the reader BEFORE any line is
+		// parsed — a real case when a session in sessions.json points at a transcript that was
+		// rotated or deleted. Left unguarded, that throw aborts the whole pipeline and the commit
+		// summary is silently dropped, so the claude/gemini branches are wrapped too.
 		let result: TranscriptReadResult;
 		if (source === "gemini") {
-			result = await readGeminiTranscript(session.transcriptPath, cursor, beforeTimestamp);
+			try {
+				result = await readGeminiTranscript(session.transcriptPath, cursor, beforeTimestamp);
+			} catch (error: unknown) {
+				log.error("Skipping Gemini session %s: %s", session.sessionId, (error as Error).message);
+				continue;
+			}
 		} else if (source === "opencode") {
 			try {
 				result = await readOpenCodeTranscript(session.transcriptPath, cursor, beforeTimestamp);
@@ -2705,7 +2714,17 @@ async function readAllTranscripts(
 				continue;
 			}
 		} else {
-			result = await readTranscript(session.transcriptPath, cursor, getParserForSource(source), beforeTimestamp);
+			try {
+				result = await readTranscript(
+					session.transcriptPath,
+					cursor,
+					getParserForSource(source),
+					beforeTimestamp,
+				);
+			} catch (error: unknown) {
+				log.error("Skipping %s session %s: %s", source, session.sessionId, (error as Error).message);
+				continue;
+			}
 		}
 		const endLine = result.newCursor.lineNumber;
 


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## Quick recap

Two independent bugs were found and fixed after a colleague's logs showed that commit summaries had stopped generating entirely. The first bug caused a permanent warning banner to appear in the sidebar every time the tool scanned for active Cursor conversations. The banner appeared on every refresh cycle and never cleared, and on machines where Cursor was actually in use, all Cursor sessions were silently dropped from the conversation list. The root cause was a specific placeholder entry that Cursor permanently stores in its database with a null value — a value that is technically valid and causes no parse error, but which the scanning code then tried to use as an object, crashing the entire scan.

The second bug was the direct cause of all commit summaries going missing. When a session record referenced a transcript file that had been deleted or rotated off disk, the resulting error was not caught at the session level — it propagated upward and caused the entire summarization pipeline for that commit to abort. The commit was then permanently removed from the processing queue with no retry, so the summary was lost forever. The fix brings the Claude and Gemini transcript readers in line with how all other readers were already handled: a failure on one session now skips only that session, and the pipeline continues to produce a summary from whatever context remains.

---

## E2E Test (2)
<details>
<summary><strong>1. Cursor &quot;sources unavailable&quot; banner no longer appears</strong></summary>
<br>
<blockquote>

**Preconditions:** Have the app open and connected to a Cursor workspace that has been used at least once (so Cursor session data exists on disk).

**Steps:**
1. Open the app and look at the left sidebar.
2. Wait up to 90 seconds (the sidebar refreshes roughly every 60 seconds).
3. Check whether a yellow warning banner reading "Some sources unavailable (cursor)" appears in the sidebar.
4. If the banner does not appear after two full refresh cycles, the fix is confirmed.
5. As an extra check, open a second Cursor workspace and repeat steps 1–3 to confirm sessions from that workspace are still discovered and listed normally.

**Expected Results:**
- No yellow "Some sources unavailable (cursor)" warning banner appears in the sidebar at any point.
- Any valid Cursor sessions are still listed correctly in the sidebar without being dropped.

</blockquote>
</details>
<details>
<summary><strong>2. Missing Claude transcript file no longer silently kills all commit summaries</strong></summary>
<br>
<blockquote>

**Preconditions:** Have at least two Claude sessions recorded in the app, where one session's transcript file has been deleted or moved from disk (simulate by renaming or removing one transcript file from the Claude projects folder).

**Steps:**
1. Open the app and navigate to the commit history or activity feed where AI-generated commit summaries appear.
2. Trigger a new commit (or wait for the background worker to process the queue — this typically happens within a minute).
3. Watch the commit summary area to see whether a summary is generated.
4. Confirm that a summary appears for the commit, even though one Claude session's transcript was missing.
5. Check that the session whose transcript was missing does not appear in the summary or session list, while the other session's content is still included.

**Expected Results:**
- A commit summary is generated and displayed — the pipeline does not silently fail.
- The session with the missing transcript is quietly skipped and does not appear.
- The session with the valid transcript contributes its content to the summary as normal.

</blockquote>
</details>

---

## Topics (2)
<details>
<summary><strong>01 · Cursor scan crash causing permanent &quot;sources unavailable&quot; banner fixed</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Users saw a persistent yellow warning banner reading "Some sources unavailable (cursor)" in the sidebar, appearing every 60 seconds and never going away. The root cause was traced to a specific entry in Cursor's database that stores a null placeholder value, which the scanning code could not handle safely.

**💡 Decisions Behind the Code**

- **Skip the bad row, not the whole scan**: The crash was happening inside the per-row loop, but the unguarded throw escaped the loop entirely and caused the whole scan to return an error — dropping every valid Cursor session in the process. The fix places the guard inside the loop so only the offending row is skipped via `continue`, leaving all other rows unaffected. An alternative of wrapping the entire scan in a broader try/catch would have hidden the same symptom but still lost all sessions whenever any bad row appeared.
- **Guard placed between parse and property access, not inside the catch**: The existing `catch` block only fires on syntactically invalid JSON. The literal string `"null"` is valid JSON that parses to `null` without throwing, so the catch was never reachable for this case. Inserting a separate `if (parsed === null || typeof parsed !== "object")` check after the parse — rather than expanding the catch — makes the two failure modes explicit and independently logged, which aids future debugging.

**✅ What Was Implemented**

- In `cli/src/core/CursorSessionDiscoverer.ts`, added a type guard after `JSON.parse` to check whether the parsed value is `null` or a non-object scalar before accessing any properties on it. The variable was also renamed from `parsed` to `composer` after the guard to make the narrowed type explicit. Without this guard, Cursor's permanent `composerData:empty-state-draft` sentinel row (which stores the JSON literal `null`) caused a property-access crash that aborted the entire scan and surfaced as the banner.
- In `cli/src/core/CursorSessionDiscoverer.test.ts`, added a regression test that inserts the real-world `composerData:empty-state-draft` row (value `null`) and a numeric scalar row alongside a valid composer row, asserting that the scan returns no error and yields only the valid session.

**📁 FILES**
- `cli/src/core/CursorSessionDiscoverer.ts`

</blockquote>
</details>
<details>
<summary><strong>02 · Missing transcript files silently killing all commit summaries fixed</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

A colleague's log showed that every commit summary was failing to generate. The investigation found that when a session record pointed to a transcript file that no longer existed on disk, the resulting error was not contained — it aborted the entire summary pipeline for that commit, and the commit was then permanently discarded from the queue with no retry.

**💡 Decisions Behind the Code**

- **Contain the error at the per-session level, not the per-commit level**: The existing pattern for database-backed readers (OpenCode, Cursor, Copilot) already used per-session try/catch. The JSONL readers were left unguarded under the assumption that they handled all failures internally — which is true for per-line parse errors but not for file-open failures that throw before any line is read. Aligning all readers to the same pattern eliminates the inconsistency and means the blast radius of any single bad session is bounded to that session alone.
- **No retry logic added**: The queue worker's drain loop permanently discards a commit entry after any unhandled failure, with no retry path. Rather than introduce retry complexity, the fix ensures the pipeline reaches the diff-only summarization fallback that was already present but previously unreachable. This keeps the change minimal and avoids new failure modes from retry storms or duplicate summaries.

**✅ What Was Implemented**

- In `cli/src/hooks/QueueWorker.ts`, the `readAllTranscripts` function's branches for Claude and Gemini transcript reading were each wrapped in `try/catch + continue`, matching the pattern already used for the OpenCode, Cursor, Copilot, and Copilot Chat branches. A missing or unreadable transcript file now causes only that session to be skipped; the pipeline continues with remaining sessions and falls back to diff-only summarization if needed. The misleading comment claiming JSONL readers handle all failures internally was corrected.
- In `cli/src/hooks/QueueWorker.test.ts`, added a regression test that mocks one dead Claude session (transcript throws on read) alongside one live session, asserting that `storeSummary` is still called once and that only the live session's cursor is saved.
- In `cli/src/hooks/QueueWorker.overlay.test.ts`, extended the `readErrorCases` table to include the Gemini reader, closing a coverage gap where the new Gemini catch arm had no test exercising it.

**📁 FILES**
- `cli/src/hooks/QueueWorker.ts`
- `cli/src/hooks/QueueWorker.overlay.test.ts`

</blockquote>
</details>

---

*Generated by Jolli Memory · June 15, 2026 at 5:02 PM · via Anthropic*
<!-- jollimemory-summary-end -->