### PR TITLE
Archive debug.log on rotation and reduce Cursor scan log noise

### DIFF
--- a/cli/src/Logger.test.ts
+++ b/cli/src/Logger.test.ts
@@ -3,13 +3,17 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 const fsMocks = vi.hoisted(() => ({
 	appendFile: vi.fn(),
 	stat: vi.fn(),
-	writeFile: vi.fn(),
+	rename: vi.fn(),
+	readdir: vi.fn(),
+	unlink: vi.fn(),
 }));
 
 vi.mock("node:fs/promises", () => ({
 	appendFile: fsMocks.appendFile,
 	stat: fsMocks.stat,
-	writeFile: fsMocks.writeFile,
+	rename: fsMocks.rename,
+	readdir: fsMocks.readdir,
+	unlink: fsMocks.unlink,
 }));
 
 import {
@@ -35,7 +39,9 @@ describe("Logger", () => {
 		vi.restoreAllMocks();
 		fsMocks.stat.mockReset();
 		fsMocks.appendFile.mockReset();
-		fsMocks.writeFile.mockReset();
+		fsMocks.rename.mockReset();
+		fsMocks.readdir.mockReset();
+		fsMocks.unlink.mockReset();
 		resetLogDir();
 		setSilentConsole(true);
 	});
@@ -178,34 +184,168 @@ describe("Logger", () => {
 
 			await new Promise((resolve) => setTimeout(resolve, 0));
 
-			// stat is called twice: once for the directory check, once for log rotation
+			// stat is called twice: once for the directory check, once for the rotation size check
 			expect(fsMocks.stat).toHaveBeenCalledTimes(2);
 			expect(fsMocks.appendFile).toHaveBeenCalledOnce();
 			expect(fsMocks.appendFile.mock.calls[0]?.[0]).toMatch(/debug\.log$/);
 			expect(fsMocks.appendFile.mock.calls[0]?.[1]).toContain("persist me");
 		});
 
-		it("should rotate log file when it exceeds size limit", async () => {
+		it("rotates: archives debug.log to debug_<timestamp>.log and keeps appending to a fresh file", async () => {
 			const envSpy = vi.spyOn(process, "env", "get");
-			// First stat call: directory exists; second stat call: file exceeds max size (512KB)
 			fsMocks.stat
 				.mockResolvedValueOnce({}) // directory check
-				.mockResolvedValueOnce({ size: 600_000 }); // file size > 512 * 1024
-			fsMocks.writeFile.mockResolvedValue(undefined);
+				.mockResolvedValueOnce({ size: 3 * 1024 * 1024 }) // logPath size > 2 MB → rotate
+				.mockRejectedValueOnce(new Error("ENOENT")); // archive name not taken
+			fsMocks.rename.mockResolvedValue(undefined);
+			fsMocks.readdir.mockResolvedValue(["debug_2026-06-15_09-24-32.log"]);
 			fsMocks.appendFile.mockResolvedValue(undefined);
 			envSpy.mockReturnValue({ ...process.env, VITEST: "" });
 			setLogDir("/tmp/project");
 
-			const logger = createLogger("TestMod");
-			logger.info("after rotation");
-
+			createLogger("TestMod").info("after rotation");
 			await new Promise((resolve) => setTimeout(resolve, 0));
 
-			// writeFile should be called for log rotation
-			expect(fsMocks.writeFile).toHaveBeenCalledOnce();
-			expect(fsMocks.writeFile.mock.calls[0]?.[0]).toMatch(/debug\.log$/);
-			expect(fsMocks.writeFile.mock.calls[0]?.[1]).toContain("[log rotated at");
-			// appendFile should also be called to write the new log line
+			// Renamed debug.log → debug_<UTC timestamp>.log (seconds precision, Windows-safe).
+			expect(fsMocks.rename).toHaveBeenCalledOnce();
+			const [from, to] = fsMocks.rename.mock.calls[0];
+			expect(from).toMatch(/debug\.log$/);
+			expect(to).toMatch(/debug_\d{4}-\d{2}-\d{2}_\d{2}-\d{2}-\d{2}\.log$/);
+			// Fresh debug.log is recreated by the append.
+			expect(fsMocks.appendFile).toHaveBeenCalledOnce();
+			expect(fsMocks.appendFile.mock.calls[0]?.[0]).toMatch(/debug\.log$/);
+			// Only one archive present → nothing pruned.
+			expect(fsMocks.unlink).not.toHaveBeenCalled();
+		});
+
+		it("does NOT rotate (no rename) when under the size limit", async () => {
+			const envSpy = vi.spyOn(process, "env", "get");
+			fsMocks.stat
+				.mockResolvedValueOnce({}) // directory check
+				.mockResolvedValueOnce({ size: 600_000 }); // < 2 MB
+			fsMocks.appendFile.mockResolvedValue(undefined);
+			envSpy.mockReturnValue({ ...process.env, VITEST: "" });
+			setLogDir("/tmp/project");
+
+			createLogger("TestMod").info("no rotation");
+			await new Promise((resolve) => setTimeout(resolve, 0));
+
+			expect(fsMocks.rename).not.toHaveBeenCalled();
+			// Under the limit, the prune path is never entered either.
+			expect(fsMocks.readdir).not.toHaveBeenCalled();
+			expect(fsMocks.unlink).not.toHaveBeenCalled();
+			expect(fsMocks.appendFile).toHaveBeenCalledOnce();
+		});
+
+		it("prunes the oldest archives, keeping only the 10 most recent", async () => {
+			const envSpy = vi.spyOn(process, "env", "get");
+			fsMocks.stat
+				.mockResolvedValueOnce({}) // directory check
+				.mockResolvedValueOnce({ size: 3 * 1024 * 1024 }) // rotate
+				.mockRejectedValueOnce(new Error("ENOENT")); // archive name free
+			fsMocks.rename.mockResolvedValue(undefined);
+			// 12 archives in unsorted order; lexical sort = chronological.
+			const archives = [
+				"debug_2026-06-15_09-00-05.log",
+				"debug_2026-06-15_09-00-01.log", // oldest
+				"debug_2026-06-15_09-00-12.log",
+				"debug_2026-06-15_09-00-02.log", // 2nd oldest
+				"debug_2026-06-15_09-00-11.log",
+				"debug_2026-06-15_09-00-06.log",
+				"debug_2026-06-15_09-00-07.log",
+				"debug_2026-06-15_09-00-08.log",
+				"debug_2026-06-15_09-00-09.log",
+				"debug_2026-06-15_09-00-10.log",
+				"debug_2026-06-15_09-00-03.log",
+				"debug_2026-06-15_09-00-04.log",
+				"debug.log", // live file — must be ignored by the archive filter
+				"unrelated.txt",
+			];
+			fsMocks.readdir.mockResolvedValue(archives);
+			// First unlink rejects (another process already deleted it) — must be swallowed
+			// and not abort the remaining prune; second resolves.
+			fsMocks.unlink.mockRejectedValueOnce(new Error("ENOENT")).mockResolvedValue(undefined);
+			fsMocks.appendFile.mockResolvedValue(undefined);
+			envSpy.mockReturnValue({ ...process.env, VITEST: "" });
+			setLogDir("/tmp/project");
+
+			createLogger("TestMod").info("after rotation");
+			await new Promise((resolve) => setTimeout(resolve, 0));
+
+			// 12 archives − keep 10 → delete the 2 oldest (by sorted name); a rejecting
+			// unlink is swallowed, so both deletions are still attempted.
+			expect(fsMocks.unlink).toHaveBeenCalledTimes(2);
+			const deleted = fsMocks.unlink.mock.calls.map((c) => c[0] as string);
+			expect(deleted[0]).toMatch(/debug_2026-06-15_09-00-01\.log$/);
+			expect(deleted[1]).toMatch(/debug_2026-06-15_09-00-02\.log$/);
+			// Never deletes the live log or unrelated files.
+			expect(deleted.some((p) => /[/\\]debug\.log$/.test(p))).toBe(false);
+			expect(deleted.some((p) => /unrelated\.txt$/.test(p))).toBe(false);
+		});
+
+		it("appends a _N suffix (sorting after the base) when an archive name is already taken", async () => {
+			const envSpy = vi.spyOn(process, "env", "get");
+			fsMocks.stat
+				.mockResolvedValueOnce({}) // directory check
+				.mockResolvedValueOnce({ size: 3 * 1024 * 1024 }) // rotate
+				.mockResolvedValueOnce({}) // base archive name EXISTS
+				.mockRejectedValueOnce(new Error("ENOENT")); // _1 variant is free
+			fsMocks.rename.mockResolvedValue(undefined);
+			fsMocks.readdir.mockResolvedValue([]);
+			fsMocks.appendFile.mockResolvedValue(undefined);
+			envSpy.mockReturnValue({ ...process.env, VITEST: "" });
+			setLogDir("/tmp/project");
+
+			createLogger("TestMod").info("after rotation");
+			await new Promise((resolve) => setTimeout(resolve, 0));
+
+			const [, to] = fsMocks.rename.mock.calls[0];
+			// `_` (0x5F) > `.` (0x2E), so `..._09-24-32_1.log` sorts AFTER `..._09-24-32.log`.
+			expect(to).toMatch(/debug_\d{4}-\d{2}-\d{2}_\d{2}-\d{2}-\d{2}_1\.log$/);
+			// Pin the ordering invariant using the SAME comparator as the prune step (Array.sort).
+			const base = "debug_2026-06-15_09-24-32.log";
+			const collision = "debug_2026-06-15_09-24-32_1.log";
+			expect([collision, base].sort()).toEqual([base, collision]);
+		});
+
+		it("tolerates a rename failure (already rotated by another process) without throwing", async () => {
+			const envSpy = vi.spyOn(process, "env", "get");
+			fsMocks.stat
+				.mockResolvedValueOnce({}) // directory check
+				.mockResolvedValueOnce({ size: 3 * 1024 * 1024 }) // rotate
+				.mockRejectedValueOnce(new Error("ENOENT")); // archive name free
+			fsMocks.rename.mockRejectedValue(new Error("ENOENT")); // source already moved
+			fsMocks.appendFile.mockResolvedValue(undefined);
+			envSpy.mockReturnValue({ ...process.env, VITEST: "" });
+			setLogDir("/tmp/project");
+
+			createLogger("TestMod").info("after rotation");
+			await new Promise((resolve) => setTimeout(resolve, 0));
+
+			// Rename attempted, failed, swallowed — prune skipped, append still recreates debug.log.
+			expect(fsMocks.rename).toHaveBeenCalledOnce();
+			expect(fsMocks.readdir).not.toHaveBeenCalled();
+			expect(fsMocks.appendFile).toHaveBeenCalledOnce();
+		});
+
+		it("tolerates a readdir failure during prune without throwing", async () => {
+			const envSpy = vi.spyOn(process, "env", "get");
+			fsMocks.stat
+				.mockResolvedValueOnce({}) // directory check
+				.mockResolvedValueOnce({ size: 3 * 1024 * 1024 }) // rotate
+				.mockRejectedValueOnce(new Error("ENOENT")); // archive name free
+			fsMocks.rename.mockResolvedValue(undefined); // archive succeeds
+			fsMocks.readdir.mockRejectedValue(new Error("EIO")); // prune listing fails
+			fsMocks.appendFile.mockResolvedValue(undefined);
+			envSpy.mockReturnValue({ ...process.env, VITEST: "" });
+			setLogDir("/tmp/project");
+
+			createLogger("TestMod").info("after rotation");
+			await new Promise((resolve) => setTimeout(resolve, 0));
+
+			// Archive happened; prune listing failed but was swallowed; nothing deleted; append still ran.
+			expect(fsMocks.rename).toHaveBeenCalledOnce();
+			expect(fsMocks.unlink).not.toHaveBeenCalled();
 			expect(fsMocks.appendFile).toHaveBeenCalledOnce();
 		});
 

--- a/cli/src/Logger.ts
+++ b/cli/src/Logger.ts
@@ -6,7 +6,7 @@
  * Uses a sequential write queue to guarantee log ordering in the file.
  */
 
-import { appendFile, stat, writeFile } from "node:fs/promises";
+import { appendFile, readdir, rename, stat, unlink } from "node:fs/promises";
 import { join } from "node:path";
 import type { LogLevel } from "./Types.js";
 
@@ -162,8 +162,80 @@ let writeQueue: Promise<void> = Promise.resolve();
  * does not exist (plugin not yet enabled), log writes are silently skipped.
  * The directory is created by `ensureJolliMemoryDir()` when enabling the plugin.
  */
-/** Maximum log file size in bytes before rotation (500KB). */
-const MAX_LOG_SIZE = 512 * 1024;
+/** Maximum log file size in bytes before rotation (2 MB). */
+const MAX_LOG_SIZE = 2 * 1024 * 1024;
+
+/** Most recent `debug_<timestamp>.log` archives to keep; older ones are pruned. */
+const MAX_LOG_BACKUPS = 10;
+
+/** Matches rotated archives `debug_<timestamp>.log` (NOT the live `debug.log`). */
+const LOG_ARCHIVE_RE = /^debug_.*\.log$/;
+
+/** Two-digit zero-pad for date/time components. */
+function pad2(n: number): string {
+	return String(n).padStart(2, "0");
+}
+
+/**
+ * Rotates the log by archiving the current file to `debug_<UTC timestamp>.log`
+ * and letting the caller's `appendFile` recreate a fresh `debug.log`. Full
+ * history is preserved across up to `MAX_LOG_BACKUPS` archives; older archives
+ * are pruned. Replaces the previous truncate-in-place scheme so no live content
+ * is ever discarded mid-file.
+ *
+ * Naming: `debug_YYYY-MM-DD_HH-mm-ss.log` (UTC, matching the log line timestamps;
+ * `:`/`.` avoided so the name is valid on Windows; fixed-width so a plain lexical
+ * sort is chronological). On the rare same-second collision a `_N` suffix is
+ * appended (e.g. `..._09-24-32_1.log`); `_` (0x5F) sorts after the `.` of `.log`,
+ * so a suffixed archive always sorts AFTER its un-suffixed base, preserving the
+ * lexical-sort-is-chronological property used by the prune step.
+ *
+ * Best-effort throughout: a failed `rename`, or a failed prune, is swallowed —
+ * `appendFile` still (re)creates `debug.log`, and pruning retries on the next
+ * rotation. There is no cross-process lock: two processes rotating within the
+ * same second could in principle pick the same name and have one `rename`
+ * overwrite the other's archive. That race is accepted (logging is best-effort);
+ * losing one rotated archive never affects correctness of the live log.
+ */
+async function rotateLog(dir: string, logPath: string): Promise<void> {
+	const now = new Date();
+	const stamp =
+		`${now.getUTCFullYear()}-${pad2(now.getUTCMonth() + 1)}-${pad2(now.getUTCDate())}` +
+		`_${pad2(now.getUTCHours())}-${pad2(now.getUTCMinutes())}-${pad2(now.getUTCSeconds())}`;
+
+	try {
+		let archive = join(dir, `debug_${stamp}.log`);
+		for (let suffix = 1; await pathExists(archive); suffix++) {
+			archive = join(dir, `debug_${stamp}_${suffix}.log`);
+		}
+		await rename(logPath, archive);
+	} catch {
+		// Source already rotated by another process, or rename failed — skip; the
+		// caller's appendFile will (re)create debug.log regardless.
+		return;
+	}
+
+	// Prune: keep only the `MAX_LOG_BACKUPS` most recent archives. Archive names
+	// sort lexicographically in chronological order, so the oldest are at the front.
+	try {
+		const archives = (await readdir(dir)).filter((f) => LOG_ARCHIVE_RE.test(f)).sort();
+		for (let i = 0; i < archives.length - MAX_LOG_BACKUPS; i++) {
+			await unlink(join(dir, archives[i])).catch(() => {});
+		}
+	} catch {
+		// readdir failed — non-fatal; the next rotation will prune again.
+	}
+}
+
+/** True if `p` exists (any stat-able entry); false on ENOENT or any stat error. */
+async function pathExists(p: string): Promise<boolean> {
+	try {
+		await stat(p);
+		return true;
+	} catch {
+		return false;
+	}
+}
 
 /**
  * Stable contract for callers that want to use Logger without producing
@@ -187,11 +259,14 @@ function enqueueLogWrite(line: string): void {
 			// This prevents creating .jolli/ in repos where Jolli Memory is not enabled.
 			await stat(dir);
 
-			// Rotate: truncate old content when file exceeds size limit
+			// Rotate: when the file exceeds the size limit, archive it to
+			// `debug_<timestamp>.log` and let the appendFile below recreate a fresh
+			// debug.log. Full history is preserved across up to MAX_LOG_BACKUPS
+			// archives (older ones pruned) — no live content is truncated.
 			try {
 				const fileStat = await stat(logPath);
 				if (fileStat.size > MAX_LOG_SIZE) {
-					await writeFile(logPath, `[log rotated at ${new Date().toISOString()}]\n`, "utf-8");
+					await rotateLog(dir, logPath);
 				}
 			} catch {
 				// File doesn't exist yet — that's fine, appendFile will create it

--- a/cli/src/core/CursorSessionDiscoverer.ts
+++ b/cli/src/core/CursorSessionDiscoverer.ts
@@ -117,6 +117,8 @@ export async function scanCursorSessions(projectDir: string): Promise<CursorScan
 				try {
 					parsed = JSON.parse(row.value);
 				} catch {
+					// Unexpected/anomalous (Cursor writes valid JSON) — kept at warn as a corruption
+					// signal. It's rare, so it won't spam the way the routine placeholder rows below do.
 					log.warn("Skipping Cursor composer row %s: invalid JSON", row.key);
 					continue;
 				}
@@ -127,26 +129,29 @@ export async function scanCursorSessions(projectDir: string): Promise<CursorScan
 				// catch above never fires. Without this guard the `parsed.composerId` access below
 				// throws `Cannot read properties of null`, which escapes the loop and fails the
 				// entire scan (surfacing as "Some sources unavailable (cursor)" in the UI).
+				// Logged at debug, not warn: Cursor ships these placeholder/sentinel rows in every
+				// install, so skipping them is routine — surfacing it per-scan only spams the log.
 				if (parsed === null || typeof parsed !== "object") {
-					log.warn("Skipping Cursor composer row %s: value is not a JSON object", row.key);
+					log.debug("Skipping Cursor composer row %s: value is not a JSON object", row.key);
 					continue;
 				}
 				const composer = parsed as Record<string, unknown>;
 
 				const composerId = typeof composer.composerId === "string" ? composer.composerId : null;
 				if (composerId === null) {
+					// A composerData object without a string composerId is unexpected (schema drift),
+					// not a routine placeholder — kept at warn. Rare, so it won't spam.
 					log.warn("Skipping Cursor composer row %s: missing composerId", row.key);
 					continue;
 				}
 
 				const lastUpdatedAt = composer.lastUpdatedAt;
 
-				// Guard against schema drift: non-numeric timestamps.
+				// Guard against schema drift: non-numeric timestamps. An empty/never-used draft
+				// composer (e.g. a workspace anchor that was never run) has no lastUpdatedAt — that
+				// is routine, so it's logged at debug rather than warn to keep the log quiet.
 				if (typeof lastUpdatedAt !== "number" || !Number.isFinite(lastUpdatedAt)) {
-					// Only warn if this composer is an anchor — otherwise silently skip.
-					if (anchorSet.has(composerId)) {
-						log.warn("Skipping Cursor composer %s: non-finite lastUpdatedAt", composerId);
-					}
+					log.debug("Skipping Cursor composer %s: non-finite lastUpdatedAt", composerId);
 					continue;
 				}
 


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## Quick recap

The debug log rotation mechanism was replaced entirely. Previously, when the log grew too large, most of its content was discarded in place, leaving little history for diagnosing problems. Now, when the active log file reaches two megabytes, it is renamed to a timestamped archive and a fresh log begins automatically. Up to ten archived files are kept on disk, giving a maximum footprint of around twenty megabytes and preserving complete logs across the full archive window.

A subtle ordering bug in the archive naming scheme was also corrected. When two rotations happened within the same second, the collision-avoidance suffix used a character that sorted before the dot in file extensions, causing newer archives to appear earlier than older ones in an alphabetical listing and potentially deleting the wrong files during cleanup. The suffix separator was changed to a character that sorts after a dot, restoring the guarantee that alphabetical and chronological order are identical across all archive filenames. The rotation function's documentation was updated to accurately describe this ordering property and to honestly acknowledge the narrow window in which two processes rotating at the exact same moment could overwrite each other's archive.

Two categories of log entries that had been appearing every sixty seconds in Cursor-enabled projects were also silenced. These entries were generated by placeholder rows that Cursor itself writes into its database on every installation — they were never actionable and repeated on every background scan. Log entries that indicate genuine data problems, such as a corrupted or unreadable row, continue to appear as warnings, preserving diagnostic signal for real anomalies while eliminating the routine noise.

---

## Topics (4)
<details>
<summary><strong>01 · Archive file naming fixed so log files always sort in chronological order</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

When two log rotations happened within the same second, the collision-avoidance suffix used a character that sorts before the dot in file extensions, causing newer collision archives to appear before older base archives in an alphabetical sort and breaking the cleanup step that depends on that ordering.

**💡 Decisions Behind the Code**

- **Underscore over other separator characters**: The separator had to sort strictly after `.` (0x2E) so that a suffixed archive follows its base in a plain array sort. Underscore (0x5F) satisfies this with no ambiguity, requires no escaping on any operating system, and keeps filenames readable. Alternatives such as `+` or `~` would also work numerically but are less conventional in log filenames.
- **No cross-process lock added**: Two processes rotating in the same second could still overwrite each other's archive. Adding a file lock would introduce complexity and a potential deadlock surface for a failure mode that loses at most one rotated archive — an acceptable loss for a best-effort logging system. The docstring now honestly documents this accepted race rather than claiming it cannot happen.

**✅ What Was Implemented**

- In `Logger.ts`, the collision suffix separator was changed from `-` to `_` (e.g. `debug_2026-06-15_09-24-32_1.log`). The underscore character has a higher code point than the dot used in `.log`, so a suffixed archive always sorts after its un-suffixed base, restoring the invariant that alphabetical order equals chronological order.
- The `rotateLog` docstring was rewritten to accurately describe the naming scheme, the sort-order guarantee, and the accepted cross-process race condition. The previous docstring overclaimed that archives are never clobbered and did not explain the sort-order property that the prune step relies on.

**📁 FILES**
- `cli/src/Logger.ts`

</blockquote>
</details>
<details>
<summary><strong>02 · Log rotation replaced with archive-and-prune scheme preserving full history</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

When the debug log grew too large, the previous rotation mechanism discarded most of the file's content in place, leaving almost no useful history for diagnosing problems. A new approach was needed that preserved complete logs across a rolling archive window.

**💡 Decisions Behind the Code**

- **Archive-and-prune over truncate-in-place**: The previous scheme discarded roughly two-thirds of the file on every rotation, meaning a burst of noisy entries could immediately consume the fresh file and leave no useful trail. Renaming the full file preserves complete history up to the archive limit. The trade-off is higher peak disk use — up to roughly 20 MB across ten 2 MB archives — which was judged acceptable given that retaining a meaningful diagnostic window is the primary reason the log exists.
- **Raise the threshold to 2 MB**: The original 512 KB limit was low enough that normal background activity triggered rotation frequently, compounding the data-loss problem. A 2 MB ceiling gives substantially more headroom for a real debugging session while keeping individual files small enough to remain manageable on disk.
- **Timestamp format without ISO separators**: Colons, dots, and the `T`/`Z` characters from ISO 8601 were excluded to keep filenames valid on Windows and improve readability. The fixed-width, zero-padded format was chosen so that lexicographic sort equals chronological sort, making the prune step trivially correct without parsing dates.
- **No cross-process lock**: Multiple processes share the same log file. Adding a file lock was considered but rejected as disproportionate for a logging subsystem — the complexity and latency cost outweighs the risk of an occasional spurious extra archive file. The rename operation is atomic on the same volume, and all failure paths are swallowed, so the worst outcome is a near-empty extra archive rather than data loss or a crash.
- **Ten-archive retention limit**: Keeping ten archives at 2 MB each caps disk use at roughly 20 MB. Fewer archives would risk losing history during an extended debugging session; more would let disk use grow unbounded for a developer tool. Ten was judged a reasonable midpoint given the expected usage pattern.

**✅ What Was Implemented**

- In `cli/src/Logger.ts`, the entire rotation mechanism was rewritten. The size threshold was raised from 512 KB to 2 MB. When the active log file exceeds that limit, it is renamed to a timestamped archive file (`debug_YYYY-MM-DD_HH-mm-ss.log`, UTC, no colons or dots) and the next write automatically creates a fresh `debug.log`. A `pathExists()` helper detects same-second name collisions and appends a `_N` counter when needed. All previous tail-read and in-place truncation logic, along with the associated imports, was removed entirely.
- Pruning runs immediately after each successful rename: the archive directory is scanned for files matching `debug_*.log`, sorted lexicographically (which equals chronological order given the fixed-width timestamp), and the oldest entries are deleted until at most ten archives remain. Both the rename and prune steps swallow failures so a concurrent rotation by another process never breaks the write queue.
- `Logger.test.ts` was overhauled to match: mocks for the old write and open operations were replaced with rename, directory-listing, and delete mocks; the old tail-read and UTF-8 boundary tests were removed; new tests cover the archive rename, the under-threshold no-op, the keep-10 prune, same-second collision suffix, and rename-failure tolerance.

**📁 FILES**
- `cli/src/Logger.ts`

</blockquote>
</details>
<details>
<summary><strong>03 · Routine Cursor placeholder log entries downgraded from warning to silent</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Two log entries were appearing on every background scan of Cursor's data — one for a permanent null sentinel row and one for an empty draft composer with no timestamp — flooding the debug log with noise that repeated every 60 seconds and was never actionable.

**💡 Decisions Behind the Code**

Routine versus anomalous behavior was used as the criterion for log level rather than universally downgrading all skipped rows. The two high-frequency entries fire on every scan against rows Cursor ships in every installation and are never actionable; the two low-frequency entries would only appear if Cursor's database were corrupted or its schema changed. This distinction keeps the log quiet under normal conditions while preserving signal for real problems.

**✅ What Was Implemented**

- In `cli/src/core/CursorSessionDiscoverer.ts`, the branch triggered by Cursor's permanent `empty-state-draft: null` sentinel ("value is not a JSON object") was downgraded from `warn` to `debug`. The branch triggered by an empty draft composer that was never used ("non-finite lastUpdatedAt") was similarly downgraded to `debug` and a previous anchor-set gate was removed, making the behavior unconditional.
- The "invalid JSON" and "missing composerId" branches were kept at `warn`: these indicate genuine data anomalies such as corruption or schema drift, are rare enough not to spam, and carry diagnostic signal worth surfacing.
- Inline comments were added to each branch explaining the rationale for its log level, so future maintainers understand the distinction between routine placeholder rows and genuinely unexpected data.

**📁 FILES**
- `cli/src/core/CursorSessionDiscoverer.ts`

</blockquote>
</details>
<details>
<summary><strong>04 · Log rotation test coverage expanded for error-handling branches</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

A code review identified that several error-handling branches in the log rotation logic had no test coverage: the case where listing the log directory fails, and the case where deleting an old archive fails mid-prune, leaving the "swallow and continue" behavior unverified.

**💡 Decisions Behind the Code**

- **Rejection on first unlink only**: Making only the first of two unlink calls reject — rather than all of them — lets the test verify both that the error is swallowed and that the loop continues to the next file. A blanket rejection would only confirm the swallow, not the continuation behavior.
- **Sort-order invariant pinned with the production comparator**: Using the same sort call in the test as in production ensures the test would catch a regression if the comparator were ever changed, rather than comparing character code points manually and potentially diverging from the real behavior.

**✅ What Was Implemented**

- Added a new test in `Logger.test.ts` that makes the directory-listing step reject with an I/O error. The test confirms that the archive rename still completes and the subsequent log write still succeeds — the prune failure is silently swallowed as intended.
- Updated the existing prune test so the first archive deletion rejects, simulating another process having already removed the file. The test confirms that the second deletion is still attempted, verifying that a single failed deletion does not abort the rest of the prune loop.
- Tightened the "does not rotate under the size limit" assertion to also confirm that neither the directory-listing nor the deletion APIs are called, and updated a stale comment that described the stat call count incorrectly.
- The collision-suffix test now asserts ordering using the same plain `Array.sort` call that the prune step uses in production, ensuring the test would catch a regression if the production sort were ever changed to a different comparator.

**📁 FILES**
- `cli/src/Logger.test.ts`

</blockquote>
</details>

---

*Generated by Jolli Memory · June 15, 2026 at 6:36 PM · via Anthropic*
<!-- jollimemory-summary-end -->