### PR TITLE
Isolate IntelliJ tests from machine-local sessions and symlink privilege

### DIFF
--- a/intellij/src/test/kotlin/ai/jolli/jollimemory/core/ActiveSessionAggregatorTest.kt
+++ b/intellij/src/test/kotlin/ai/jolli/jollimemory/core/ActiveSessionAggregatorTest.kt
@@ -3,6 +3,7 @@ package ai.jolli.jollimemory.core
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -15,14 +16,32 @@ class ActiveSessionAggregatorTest {
 	@TempDir
 	lateinit var tempDir: File
 
+	/**
+	 * Isolated home so source discoverers that scan the user's home directory
+	 * (Codex's `~/.codex/sessions`, Gemini, OpenCode, …) see an empty tree
+	 * instead of the real machine's sessions. Without this, a developer with a
+	 * recent Codex session would have it leak into every aggregator assertion.
+	 */
+	@TempDir
+	lateinit var homeDir: File
+
 	private val cwd get() = tempDir.absolutePath
 
 	private val HOUR = 3_600_000L
 	private val DAY = 24 * HOUR
 
+	private var originalHome: String? = null
+
 	@BeforeEach
 	fun setUp() {
+		originalHome = System.getProperty("user.home")
+		System.setProperty("user.home", homeDir.absolutePath)
 		File(tempDir, ".jolli/jollimemory").mkdirs()
+	}
+
+	@AfterEach
+	fun tearDown() {
+		originalHome?.let { System.setProperty("user.home", it) }
 	}
 
 	private fun iso(offsetMs: Long): String =

--- a/intellij/src/test/kotlin/ai/jolli/jollimemory/sync/StageVaultTest.kt
+++ b/intellij/src/test/kotlin/ai/jolli/jollimemory/sync/StageVaultTest.kt
@@ -160,7 +160,7 @@ class StageVaultTest {
 		Files.writeString(target, "{}")
 		val link = tempDir.resolve("my-repo/.jolli/index.json")
 		Files.createDirectories(link.parent)
-		Files.createSymbolicLink(link, target)
+		createSymbolicLinkOrSkip(link, target)
 
 		val report = stageVault(client, tempDir.toString(), StageVaultOpts(syncTranscripts = true))
 		assertEquals(0, report.added)

--- a/intellij/src/test/kotlin/ai/jolli/jollimemory/sync/SymlinkTestSupport.kt
+++ b/intellij/src/test/kotlin/ai/jolli/jollimemory/sync/SymlinkTestSupport.kt
@@ -1,0 +1,25 @@
+package ai.jolli.jollimemory.sync
+
+import org.junit.jupiter.api.Assumptions
+import java.io.IOException
+import java.nio.file.Files
+import java.nio.file.Path
+
+/**
+ * Creates a symbolic link for tests, aborting (skipping) the test instead of
+ * failing when the platform forbids symlink creation.
+ *
+ * On Windows, `Files.createSymbolicLink` requires the SeCreateSymbolicLinkPrivilege
+ * (administrator or Developer Mode); a normal user account throws
+ * `FileSystemException: A required privilege is not held by the client`. Such a
+ * machine simply cannot exercise the symlink-guard paths, so the correct outcome
+ * is a skipped test, not a failure.
+ */
+fun createSymbolicLinkOrSkip(link: Path, target: Path): Path =
+	try {
+		Files.createSymbolicLink(link, target)
+	} catch (e: IOException) {
+		Assumptions.abort<Path>("Skipping: cannot create symlinks on this platform (${e.message})")
+	} catch (e: UnsupportedOperationException) {
+		Assumptions.abort<Path>("Skipping: symlinks unsupported on this platform (${e.message})")
+	}

--- a/intellij/src/test/kotlin/ai/jolli/jollimemory/sync/VaultSymlinkGuardTest.kt
+++ b/intellij/src/test/kotlin/ai/jolli/jollimemory/sync/VaultSymlinkGuardTest.kt
@@ -53,7 +53,7 @@ class VaultSymlinkGuardTest {
 		Files.createDirectories(realTarget)
 		// Create a symlink inside the vault pointing outside.
 		val link = vault.resolve("evil-link")
-		Files.createSymbolicLink(link, realTarget)
+		createSymbolicLinkOrSkip(link, realTarget)
 		assertThrows(IllegalStateException::class.java) {
 			assertNoSymlinksInPath(
 				vault.toString(),


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## Quick recap

Seven tests that had been failing consistently on the developer's Windows machine were resolved without changing any production code. Five of the failures came from a real Codex session stored in the developer's home directory being discovered and included in test data, causing assertions about controlled, isolated data sets to produce unexpected results. The fix redirects the home directory to a clean temporary folder for the duration of each affected test, matching a pattern already established elsewhere in the test suite.

The remaining two failures involved tests that verify how the application handles symbolic links in security-sensitive paths. On a standard Windows account, creating symbolic links requires a privilege that most developers do not hold, so the tests were throwing a hard error rather than running. A new shared helper was introduced that detects this condition and marks the test as skipped rather than failed, preserving the tests' value on platforms and environments where the privilege is available while giving a clear and honest signal on machines where it is not.

---

## Topics (2)
<details>
<summary><strong>01 · Prevent real user sessions from leaking into aggregator tests</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Several aggregator tests were failing on the developer's machine because a real Codex session stored in the developer's home directory was being picked up and included in test results, causing assertions about empty or controlled data sets to fail.

**💡 Decisions Behind the Code**

Overriding the home directory system property for the duration of each test was chosen over alternatives such as mocking the discoverer or injecting a fake file system. The home directory override is the established convention already used by several other test classes in this codebase, keeping the approach consistent. It is also the narrowest intervention: no production code needed to change, and the session-registration path used by the tests keys off the working directory rather than the home directory, so the override has no side effects on what the tests actually exercise.

**✅ What Was Implemented**

- `ActiveSessionAggregatorTest.kt` was updated to redirect the home directory to an isolated temporary folder before each test and restore the original value afterward. This matches the isolation pattern already used by other support tests in the codebase and ensures that session discoverers scanning the home directory see an empty tree rather than real machine data.

**📁 FILES**
- `intellij/src/test/kotlin/ai/jolli/jollimemory/core/ActiveSessionAggregatorTest.kt`

</blockquote>
</details>
<details>
<summary><strong>02 · Skip symlink tests gracefully when OS privileges are insufficient</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Two tests that verify symlink-related security behavior were failing on Windows with a privilege error rather than running or being skipped cleanly, because creating symbolic links on Windows requires elevated permissions that a normal developer account does not have.

**💡 Decisions Behind the Code**

- **Skip rather than fail**: Marking the test as skipped (via a JUnit assumption) was chosen over catching the error and passing, or removing the tests entirely. A skip accurately communicates that the behavior could not be verified on this machine, preserving the test's value on environments where symlinks are available (CI with elevated rights, Linux, macOS) without producing a misleading green result.
- **Shared helper over per-test try/catch**: Extracting the logic into a single shared function avoids duplicating the same error-handling pattern in every test that needs symlink creation. It also makes the skip reason visible in one place, making it easier to update if the privilege detection logic needs to change.

**✅ What Was Implemented**

- A new shared helper file `SymlinkTestSupport.kt` was added containing a `createSymbolicLinkOrSkip` function. When symlink creation throws an IO or unsupported-operation error, the function aborts the test via a JUnit assumption (marking it skipped) rather than letting it fail.
- `StageVaultTest.kt` and `VaultSymlinkGuardTest.kt` were updated to call the new helper in place of the direct symlink creation call, so both tests now skip cleanly on machines without the required privilege.

**📁 FILES**
- `intellij/src/test/kotlin/ai/jolli/jollimemory/sync/SymlinkTestSupport.kt`
- `intellij/src/test/kotlin/ai/jolli/jollimemory/sync/StageVaultTest.kt`
- `intellij/src/test/kotlin/ai/jolli/jollimemory/sync/VaultSymlinkGuardTest.kt`

</blockquote>
</details>

---

*Generated by Jolli Memory · June 15, 2026 at 1:45 PM · via Anthropic*

> Note: 9 commit(s) without summary were skipped.
<!-- jollimemory-summary-end -->