### PR TITLE
Closes JOLLI-1753: Fix duplicate KB folders, stale sync badges, and flaky tests

### DIFF
--- a/cli/src/PluginLoader.test.ts
+++ b/cli/src/PluginLoader.test.ts
@@ -20,6 +20,11 @@ import type { KnownPlugin } from "./KnownPlugins.js";
 import { KNOWN_PLUGINS } from "./KnownPlugins.js";
 import { setSilentConsole } from "./Logger.js";
 import { findNodeModulesRoot, getNpmRootGlobal, inspectPlugins, loadPlugins } from "./PluginLoader.js";
+import { symlinksSupported } from "./testUtils/symlinkSupport.js";
+
+// The npm-link / symlink-layout case needs a real symlink, which requires
+// SeCreateSymbolicLinkPrivilege on Windows; skip it on an unprivileged account.
+const itIfSymlinks = symlinksSupported ? it : it.skip;
 
 const FIXTURE_NAME = "@test-fixtures/example-plugin";
 const FIXTURE_SCOPE = "@test-fixtures";
@@ -1112,7 +1117,7 @@ describe("loadPlugins", () => {
 		expect(program.commands).toHaveLength(0);
 	});
 
-	it("discovers a plugin installed as a symlink (npm link / workspace layout)", async () => {
+	itIfSymlinks("discovers a plugin installed as a symlink (npm link / workspace layout)", async () => {
 		// Dirent.isDirectory() returns false for a symlink-to-directory under
 		// `withFileTypes: true`, so without the isSymbolicLink() fallback the
 		// loader would silently miss `npm link`, yarn workspaces, and pnpm's

--- a/cli/src/core/CursorSessionDiscoverer.test.ts
+++ b/cli/src/core/CursorSessionDiscoverer.test.ts
@@ -35,7 +35,12 @@ vi.mock("node:os", async (importOriginal) => {
 	return { ...original, homedir: mockHomedir, platform: mockPlatform };
 });
 
+import { symlinksSupported } from "../testUtils/symlinkSupport.js";
 import { discoverCursorSessions, scanCursorSessions } from "./CursorSessionDiscoverer.js";
+
+// The non-ENOENT-stat case is driven by a self-referential symlink (ELOOP).
+// symlink() throws EPERM on a non-elevated Windows account, so skip it there.
+const itIfSymlinks = symlinksSupported ? it : it.skip;
 
 const CURSOR_DDL = [
 	`CREATE TABLE ItemTable (key TEXT UNIQUE ON CONFLICT REPLACE, value BLOB)`,
@@ -466,7 +471,7 @@ describe("discoverCursorSessions", () => {
 	// gives a real `ELOOP` from `stat()` without requiring a filesystem-level
 	// mock — `isEnoent` correctly classifies this as non-ENOENT and we land
 	// in the warn arm.
-	it("warns and continues when workspace state.vscdb stat fails with a non-ENOENT error", async () => {
+	itIfSymlinks("warns and continues when workspace state.vscdb stat fails with a non-ENOENT error", async () => {
 		const fresh = Date.now() - 60 * 1000;
 		const userDir = join(tmpHome, "Library/Application Support/Cursor/User");
 		await mkdir(join(userDir, "globalStorage"), { recursive: true });

--- a/cli/src/core/KBPathResolver.test.ts
+++ b/cli/src/core/KBPathResolver.test.ts
@@ -8,6 +8,7 @@ import {
 	assertValidLocalFolder,
 	extractRepoName,
 	findFreshKBPath,
+	findRepoFolders,
 	foldGitTransportToHttps,
 	getRemoteUrl,
 	InvalidLocalFolderError,
@@ -451,6 +452,81 @@ esac
 
 			const result = resolveKBPath("miss", "https://github.com/u/different.git", tempDir);
 			expect(result).toBe(join(tempDir, "miss-3"));
+		});
+	});
+
+	describe("archived numbering hole (duplicate-folder / Migrate archive-gate fix)", () => {
+		// Archiving a folder MOVES it out of the ladder, leaving a numbering hole
+		// (e.g. `repo-2` gone while `repo-3` remains). The selectors must not stop
+		// at the hole and ignore a higher-numbered folder that still holds the repo,
+		// or normal resolution spawns a fresh duplicate and the Migrate archive gate
+		// (oldKbRoot !== newKbRoot) collapses onto the same hole and never fires.
+
+		function seedHoleScenario(): string {
+			// base `repo` belongs to a different repo; `repo-2` is the hole (absent);
+			// `repo-3` is the canonical folder for our repo.
+			initializeKBFolder(join(tempDir, "repo"), "repo", "https://github.com/u/other.git");
+			const canonical = join(tempDir, "repo-3");
+			initializeKBFolder(canonical, "repo", "https://github.com/u/canonical.git");
+			return canonical;
+		}
+
+		it("resolveKBPath reuses the higher-numbered match instead of claiming the hole", () => {
+			const canonical = seedHoleScenario();
+			expect(resolveKBPath("repo", "https://github.com/u/canonical.git", tempDir)).toBe(canonical);
+			// The hole must NOT have been claimed as a side effect.
+			expect(existsSync(join(tempDir, "repo-2"))).toBe(false);
+		});
+
+		it("peekKBPath returns the real folder, not the hole", () => {
+			const canonical = seedHoleScenario();
+			expect(peekKBPath("repo", "https://github.com/u/canonical.git", tempDir)).toBe(canonical);
+		});
+
+		it("Migrate archive gate fires: peekKBPath (old) differs from findFreshKBPath (new)", () => {
+			seedHoleScenario();
+			const oldKbRoot = peekKBPath("repo", "https://github.com/u/canonical.git", tempDir);
+			const newKbRoot = findFreshKBPath("repo", tempDir);
+			expect(oldKbRoot).toBe(join(tempDir, "repo-3")); // current folder, not the hole
+			expect(newKbRoot).toBe(join(tempDir, "repo-2")); // fresh slot fills the hole
+			expect(oldKbRoot).not.toBe(newKbRoot); // gate fires → archiveKBFolder runs
+		});
+
+		it("findRepoFolders returns every same-repo folder (base + suffixes), skipping holes and other repos", () => {
+			const remote = "https://github.com/u/canonical.git";
+			// base belongs to a DIFFERENT repo → excluded.
+			initializeKBFolder(join(tempDir, "repo"), "repo", "https://github.com/u/other.git");
+			// repo-2 is a hole (absent) → skipped.
+			// repo-3, repo-4 are our repo → included.
+			initializeKBFolder(join(tempDir, "repo-3"), "repo", remote);
+			initializeKBFolder(join(tempDir, "repo-4"), "repo", remote);
+			// repo-5 is yet another repo → excluded.
+			initializeKBFolder(join(tempDir, "repo-5"), "repo", "https://github.com/u/third.git");
+
+			const found = findRepoFolders("repo", remote, tempDir);
+			expect(found.sort()).toEqual([join(tempDir, "repo-3"), join(tempDir, "repo-4")].sort());
+		});
+
+		it("findRepoFolders includes the base folder when it matches the repo", () => {
+			const remote = "https://github.com/u/canonical.git";
+			initializeKBFolder(join(tempDir, "repo"), "repo", remote);
+			initializeKBFolder(join(tempDir, "repo-2"), "repo", remote);
+
+			const found = findRepoFolders("repo", remote, tempDir);
+			expect(found.sort()).toEqual([join(tempDir, "repo"), join(tempDir, "repo-2")].sort());
+		});
+
+		it("prefers a same-repo match over an unclaimed stub at a lower suffix", () => {
+			initializeKBFolder(join(tempDir, "s"), "s", "https://github.com/u/other.git");
+			// s-2 is an unclaimed schema-default stub (no remoteUrl, no repoName).
+			const stub = join(tempDir, "s-2");
+			mkdirSync(join(stub, ".jolli"), { recursive: true });
+			writeFileSync(join(stub, ".jolli", "config.json"), JSON.stringify({ version: 1 }), "utf-8");
+			// s-3 is the real same-repo folder.
+			const canonical = join(tempDir, "s-3");
+			initializeKBFolder(canonical, "s", "https://github.com/u/canonical.git");
+
+			expect(resolveKBPath("s", "https://github.com/u/canonical.git", tempDir)).toBe(canonical);
 		});
 	});
 

--- a/cli/src/core/KBPathResolver.test.ts
+++ b/cli/src/core/KBPathResolver.test.ts
@@ -1,9 +1,10 @@
 import { execFileSync } from "node:child_process";
 import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
-import { join } from "node:path";
+import { basename, join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+	archiveKBFolder,
 	assertValidLocalFolder,
 	extractRepoName,
 	findFreshKBPath,
@@ -680,6 +681,52 @@ esac
 			expect(peeked).toBe(fresh);
 			expect(peeked).toBe(join(tempDir, "brand-new"));
 			expect(existsSync(peeked)).toBe(false);
+		});
+	});
+
+	describe("archiveKBFolder", () => {
+		const url = "https://github.com/user/myrepo.git";
+
+		it("moves the folder under <parent>/.jolli/archive/ and preserves content", () => {
+			const kbRoot = resolveKBPath("myrepo", url, tempDir);
+			writeFileSync(join(kbRoot, "marker.txt"), "hi");
+
+			const dest = archiveKBFolder(kbRoot, tempDir);
+
+			expect(dest).not.toBeNull();
+			expect(existsSync(kbRoot)).toBe(false); // original removed from active area
+			expect((dest as string).startsWith(join(tempDir, ".jolli", "archive"))).toBe(true);
+			expect(readFileSync(join(dest as string, "marker.txt"), "utf-8")).toBe("hi");
+		});
+
+		it("names the archive dir with the repo folder-name prefix", () => {
+			const kbRoot = resolveKBPath("myrepo", url, tempDir);
+			const dest = archiveKBFolder(kbRoot, tempDir) as string;
+			expect(basename(dest).startsWith("myrepo-")).toBe(true);
+		});
+
+		it("returns null when the folder does not exist (nothing to archive)", () => {
+			expect(archiveKBFolder(join(tempDir, "nope"), tempDir)).toBeNull();
+		});
+
+		it("keeps repeated archives of the same repo distinct (collision guard)", () => {
+			const first = resolveKBPath("myrepo", url, tempDir);
+			const destA = archiveKBFolder(first, tempDir) as string;
+			// Base name is free again now → resolve recreates it, then archive again.
+			const second = resolveKBPath("myrepo", url, tempDir);
+			const destB = archiveKBFolder(second, tempDir) as string;
+
+			expect(destA).not.toBe(destB);
+			expect(existsSync(destA)).toBe(true);
+			expect(existsSync(destB)).toBe(true);
+		});
+
+		it("frees the base name so a subsequent resolve reclaims it (no -N ladder)", () => {
+			const kbRoot = resolveKBPath("myrepo", url, tempDir);
+			expect(kbRoot).toBe(join(tempDir, "myrepo"));
+			archiveKBFolder(kbRoot, tempDir);
+			// With the old folder moved aside, the clean base name is available again.
+			expect(resolveKBPath("myrepo", url, tempDir)).toBe(join(tempDir, "myrepo"));
 		});
 	});
 });

--- a/cli/src/core/KBPathResolver.test.ts
+++ b/cli/src/core/KBPathResolver.test.ts
@@ -483,13 +483,13 @@ esac
 			expect(peekKBPath("repo", "https://github.com/u/canonical.git", tempDir)).toBe(canonical);
 		});
 
-		it("Migrate archive gate fires: peekKBPath (old) differs from findFreshKBPath (new)", () => {
+		it("peekKBPath resolves the real folder while findFreshKBPath fills the hole", () => {
 			seedHoleScenario();
-			const oldKbRoot = peekKBPath("repo", "https://github.com/u/canonical.git", tempDir);
-			const newKbRoot = findFreshKBPath("repo", tempDir);
-			expect(oldKbRoot).toBe(join(tempDir, "repo-3")); // current folder, not the hole
-			expect(newKbRoot).toBe(join(tempDir, "repo-2")); // fresh slot fills the hole
-			expect(oldKbRoot).not.toBe(newKbRoot); // gate fires → archiveKBFolder runs
+			const liveKbRoot = peekKBPath("repo", "https://github.com/u/canonical.git", tempDir);
+			const freshKbRoot = findFreshKBPath("repo", tempDir);
+			expect(liveKbRoot).toBe(join(tempDir, "repo-3")); // current folder, not the hole
+			expect(freshKbRoot).toBe(join(tempDir, "repo-2")); // fresh slot fills the hole
+			expect(liveKbRoot).not.toBe(freshKbRoot);
 		});
 
 		it("findRepoFolders returns every same-repo folder (base + suffixes), skipping holes and other repos", () => {
@@ -527,6 +527,38 @@ esac
 			initializeKBFolder(canonical, "s", "https://github.com/u/canonical.git");
 
 			expect(resolveKBPath("s", "https://github.com/u/canonical.git", tempDir)).toBe(canonical);
+		});
+	});
+
+	describe("base slot free but a suffixed folder holds the repo (post-Migrate)", () => {
+		// After a Migrate archives the base `<repo>` and lands the live data in
+		// `<repo>-N`, the base slot is FREE. resolveKBPath / peekKBPath must reuse
+		// the suffixed data folder rather than spawning a fresh empty `<repo>`
+		// base that shadows it — the "empty jolliai reappears after every migrate"
+		// regression.
+		const remote = "https://github.com/u/canonical.git";
+
+		it("resolveKBPath reuses the suffixed data folder instead of claiming a fresh empty base", () => {
+			const data = join(tempDir, "repo-2");
+			initializeKBFolder(data, "repo", remote);
+
+			expect(resolveKBPath("repo", remote, tempDir)).toBe(data);
+			// The empty base must NOT have been claimed as a side effect.
+			expect(existsSync(join(tempDir, "repo"))).toBe(false);
+		});
+
+		it("peekKBPath returns the suffixed data folder, not the absent base", () => {
+			const data = join(tempDir, "repo-2");
+			initializeKBFolder(data, "repo", remote);
+
+			expect(peekKBPath("repo", remote, tempDir)).toBe(data);
+		});
+
+		it("still claims the base fresh when the only suffixed folder is a different repo", () => {
+			initializeKBFolder(join(tempDir, "repo-2"), "repo", "https://github.com/u/other.git");
+
+			expect(resolveKBPath("repo", remote, tempDir)).toBe(join(tempDir, "repo"));
+			expect(peekKBPath("repo", remote, tempDir)).toBe(join(tempDir, "repo"));
 		});
 	});
 

--- a/cli/src/core/KBPathResolver.ts
+++ b/cli/src/core/KBPathResolver.ts
@@ -96,8 +96,15 @@ export function resolveKBPath(repoName: string, remoteUrl: string | null, custom
 	const parent = resolveKbParent(customPath);
 	const basePath = join(parent, repoName);
 
-	// Case A: basePath is unused → claim it fresh.
+	// Case A: basePath is unused. Before claiming it fresh, scan the suffix
+	// ladder for a folder that already holds this repo — a prior Migrate may
+	// have archived the base and left the live data in `<repo>-N`. Reusing it
+	// keeps `resolveKBPath` in lockstep with `peekKBPath` and stops a fresh
+	// empty `<repo>` base from being spawned to shadow the real data folder
+	// (the "empty base reappears after every migrate" regression).
 	if (!existsSync(basePath)) {
+		const match = scanRepoSuffixes(parent, repoName, remoteUrl).match;
+		if (match) return match;
 		writeKBIdentity(basePath, repoName, remoteUrl);
 		return basePath;
 	}
@@ -134,7 +141,13 @@ export function peekKBPath(repoName: string, remoteUrl: string | null, customPat
 	const parent = resolveKbParent(customPath);
 	const basePath = join(parent, repoName);
 
-	if (!existsSync(basePath)) return basePath;
+	if (!existsSync(basePath)) {
+		// Mirror `resolveKBPath` Case A: the base slot is free, but a prior
+		// Migrate may have archived the base and left this repo's data in a
+		// suffixed folder. Resolve to that folder rather than a base path that
+		// doesn't exist yet, so peek and `resolveKBPath` agree.
+		return scanRepoSuffixes(parent, repoName, remoteUrl).match ?? basePath;
+	}
 
 	const existingConfig = readKBConfig(basePath);
 	if (existingConfig && isSameRepo(existingConfig, remoteUrl, repoName)) return basePath;

--- a/cli/src/core/KBPathResolver.ts
+++ b/cli/src/core/KBPathResolver.ts
@@ -140,14 +140,43 @@ export function peekKBPath(repoName: string, remoteUrl: string | null, customPat
 	if (existingConfig && isSameRepo(existingConfig, remoteUrl, repoName)) return basePath;
 	if (existingConfig && isUnclaimedStub(basePath, existingConfig)) return basePath;
 
+	// Mirror findAvailablePathAndClaim's selection without claiming: reuse an
+	// existing same-repo folder anywhere in the ladder before falling back to an
+	// unclaimed stub or the lowest free slot. Never stop at a numbering hole (left
+	// by an archived folder) and skip a higher-numbered folder that holds this
+	// repo — that is what made the Migrate archive gate target a phantom slot and
+	// spawn duplicate <repo>-N folders.
+	const scan = scanRepoSuffixes(parent, repoName, remoteUrl);
+	return scan.match ?? scan.stub ?? scan.firstUnused ?? join(parent, `${repoName}-${Date.now()}`);
+}
+
+/**
+ * Returns every existing KB folder (`<repo>` and `<repo>-2` … `<repo>-99`) under
+ * the Memory Bank parent whose `.jolli/config.json` identity matches this repo.
+ *
+ * Read-only. Used by the Migrate-to-Memory-Bank flow to fold a *pile* of
+ * duplicates in one pass: earlier buggy runs (the archive gate defeated by a
+ * numbering hole) left several `<repo>-N` folders all sharing one identity, and
+ * archiving only the single peeked folder would clear them one-click-at-a-time.
+ * Only true identity matches are returned — unclaimed stubs and folders for
+ * other repos are left untouched, so this is safe to feed straight to
+ * `archiveKBFolder`.
+ */
+export function findRepoFolders(repoName: string, remoteUrl: string | null, customPath?: string): string[] {
+	const parent = resolveKbParent(customPath);
+	const out: string[] = [];
+	const base = join(parent, repoName);
+	if (existsSync(base)) {
+		const baseConfig = readKBConfig(base);
+		if (baseConfig && isSameRepo(baseConfig, remoteUrl, repoName)) out.push(base);
+	}
 	for (let suffix = 2; suffix <= 99; suffix++) {
 		const candidate = join(parent, `${repoName}-${suffix}`);
-		if (!existsSync(candidate)) return candidate;
+		if (!existsSync(candidate)) continue;
 		const config = readKBConfig(candidate);
-		if (config && isSameRepo(config, remoteUrl, repoName)) return candidate;
-		if (config && isUnclaimedStub(candidate, config)) return candidate;
+		if (config && isSameRepo(config, remoteUrl, repoName)) out.push(candidate);
 	}
-	return join(parent, `${repoName}-${Date.now()}`);
+	return out;
 }
 
 /**
@@ -375,23 +404,51 @@ function nonDefaultPortSegment(port: string | undefined, schemeDefault: string):
 	return `:${port}`;
 }
 
-function findAvailablePathAndClaim(parent: string, repoName: string, remoteUrl: string | null): string {
+interface SuffixScan {
+	/** Existing `<repo>-N` folder that already belongs to this repo (reuse, no claim). */
+	match: string | null;
+	/** Lowest existing `<repo>-N` folder that is an unclaimed schema-default stub. */
+	stub: string | null;
+	/** Lowest `<repo>-N` slot that does not exist on disk. */
+	firstUnused: string | null;
+}
+
+/**
+ * Scans `<repo>-2` … `<repo>-99` ONCE and classifies them. The scan runs to
+ * completion (or until a same-repo match is found) precisely so an archived
+ * folder's numbering hole can't shadow a higher-numbered folder that still
+ * holds this repo — the bug behind duplicate `<repo>-N` folders and the
+ * defeated Migrate archive gate. Callers decide whether to reuse/adopt/claim.
+ */
+function scanRepoSuffixes(parent: string, repoName: string, remoteUrl: string | null): SuffixScan {
+	let match: string | null = null;
+	let stub: string | null = null;
+	let firstUnused: string | null = null;
 	for (let suffix = 2; suffix <= 99; suffix++) {
 		const candidate = join(parent, `${repoName}-${suffix}`);
 		if (!existsSync(candidate)) {
-			writeKBIdentity(candidate, repoName, remoteUrl);
-			return candidate;
+			if (firstUnused === null) firstUnused = candidate;
+			continue;
 		}
 		const config = readKBConfig(candidate);
-		if (config && isSameRepo(config, remoteUrl, repoName)) return candidate;
-		if (config && isUnclaimedStub(candidate, config)) {
-			writeKBIdentity(candidate, repoName, remoteUrl);
-			return candidate;
+		if (config && isSameRepo(config, remoteUrl, repoName)) {
+			match = candidate;
+			break;
 		}
+		if (config && stub === null && isUnclaimedStub(candidate, config)) stub = candidate;
 	}
-	const fallback = join(parent, `${repoName}-${Date.now()}`);
-	writeKBIdentity(fallback, repoName, remoteUrl);
-	return fallback;
+	return { match, stub, firstUnused };
+}
+
+function findAvailablePathAndClaim(parent: string, repoName: string, remoteUrl: string | null): string {
+	const scan = scanRepoSuffixes(parent, repoName, remoteUrl);
+	// Reuse an existing folder for this repo as-is — its identity is already correct.
+	if (scan.match) return scan.match;
+	// No same-repo folder: adopt an unclaimed stub if present, else claim the
+	// lowest free slot. A `Date.now()` name is the 99-collision safety net only.
+	const target = scan.stub ?? scan.firstUnused ?? join(parent, `${repoName}-${Date.now()}`);
+	writeKBIdentity(target, repoName, remoteUrl);
+	return target;
 }
 
 /**

--- a/cli/src/core/KBPathResolver.ts
+++ b/cli/src/core/KBPathResolver.ts
@@ -16,7 +16,7 @@
  * that forgot the follow-up wrote a phantom `{repo}-2`.
  */
 
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, renameSync } from "node:fs";
 import { homedir } from "node:os";
 import { basename, dirname, isAbsolute, join } from "node:path";
 import { createLogger } from "../Logger.js";
@@ -179,6 +179,50 @@ export function findFreshKBPath(repoName: string, customPath?: string): string {
 export function initializeKBFolder(kbRoot: string, repoName: string, remoteUrl: string | null): void {
 	writeKBIdentity(kbRoot, repoName, remoteUrl);
 	log.info("KB folder initialized: %s (remote=%s)", kbRoot, remoteUrl ?? "none");
+}
+
+/**
+ * Moves a KB repo folder out of the active Memory Bank area into the hidden,
+ * per-Memory-Bank archive dir `<parent>/.jolli/archive/<name>-<timestamp>/`.
+ *
+ * Replaces the old "archive = rewrite `config.json` identity in place" step,
+ * which left the folder both visible in the IDE folder views AND still tracked
+ * by the vault git (so it kept syncing to the server — verified: 138 tracked
+ * files under a supposedly-archived repo). The archive dir is hidden (leading
+ * dot → filtered by both the VS Code and IntelliJ explorers) and unowned by the
+ * sync classifier (`VaultPathClassifier` rejects leading-dot path segments → the
+ * next sync round `git rm --cached`s it). It stays *inside* the Memory Bank so it
+ * travels with `localFolder`, and the orphan branch remains the system of record
+ * for recovery.
+ *
+ * Returns the destination path, or `null` if `kbRoot` doesn't exist (nothing to
+ * archive) or the move fails — callers log and proceed, since a stale visible
+ * folder is a lesser evil than aborting a rebuild.
+ *
+ * The IntelliJ Kotlin port (`KBPathResolver.kt`) must mirror this — both IDEs
+ * resolve folders in the same Memory Bank and would otherwise disagree on where
+ * archives live.
+ */
+export function archiveKBFolder(kbRoot: string, customPath?: string): string | null {
+	if (!existsSync(kbRoot)) return null;
+	const parent = resolveKbParent(customPath);
+	const archiveDir = join(parent, ".jolli", "archive");
+	const name = basename(kbRoot);
+	// Timestamp keeps repeated archives of the same repo distinct; the counter
+	// guards against same-millisecond collisions (rapid rebuilds, fake clocks).
+	let dest = join(archiveDir, `${name}-${Date.now()}`);
+	for (let n = 2; existsSync(dest) && n <= 99; n++) {
+		dest = join(archiveDir, `${name}-${Date.now()}-${n}`);
+	}
+	try {
+		mkdirSync(archiveDir, { recursive: true });
+		renameSync(kbRoot, dest);
+		log.info("Archived KB folder: %s → %s", kbRoot, dest);
+		return dest;
+	} catch (err) {
+		log.warn("Failed to archive KB folder %s: %s", kbRoot, err instanceof Error ? err.message : String(err));
+		return null;
+	}
 }
 
 /**

--- a/cli/src/core/SourceContent.test.ts
+++ b/cli/src/core/SourceContent.test.ts
@@ -10,6 +10,7 @@ vi.mock("./FolderPlanNoteSource.js", () => ({
 vi.mock("node:fs/promises", () => ({ readFile: vi.fn() }));
 
 import { readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
 import { loadFolderPlanNoteContent, loadFolderPlanNoteHeadline } from "./FolderPlanNoteSource.js";
 import { FolderStorage } from "./FolderStorage.js";
 import { listAllUserKnowledge, listAllUserKnowledgeFromRoot } from "./MemoryBankScanner.js";
@@ -115,7 +116,9 @@ describe("loadSourceContent", () => {
 
 		expect(result).toBe(content);
 		// Reads the one named file at <dirname(kbRoot)>/<path>, not a vault scan.
-		expect(vi.mocked(readFile)).toHaveBeenCalledWith("/mb/notes/a.md", "utf-8");
+		// Built with the same path ops production uses so the expected separator
+		// matches the host (`/mb/notes/a.md` on POSIX, `\mb\notes\a.md` on Windows).
+		expect(vi.mocked(readFile)).toHaveBeenCalledWith(join(dirname("/mb/jolli"), "notes/a.md"), "utf-8");
 		expect(vi.mocked(listAllUserKnowledgeFromRoot)).not.toHaveBeenCalled();
 	});
 

--- a/cli/src/core/StorageFactory.test.ts
+++ b/cli/src/core/StorageFactory.test.ts
@@ -1,3 +1,4 @@
+import { join } from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // Mock dependencies before importing the module under test
@@ -130,7 +131,9 @@ describe("StorageFactory", () => {
 		expect(FolderStorage).toHaveBeenCalledOnce();
 		expect((storage as unknown as Record<string, unknown>).type).toBe("folder");
 		// MetadataManager is constructed against the `<kbRoot>/.jolli` subfolder.
-		expect(MetadataManager).toHaveBeenCalledWith("/explicit/kb/root/.jolli");
+		// Built with `join` so the separator matches the host (production uses
+		// `join(kbRoot, ".jolli")`, which yields `\` on Windows).
+		expect(MetadataManager).toHaveBeenCalledWith(join("/explicit/kb/root", ".jolli"));
 		// No git-derived resolution: the explicit-root path skips the resolver chain.
 		expect(kbResolver.extractRepoName).not.toHaveBeenCalled();
 		expect(kbResolver.getRemoteUrl).not.toHaveBeenCalled();

--- a/cli/src/sync/BootstrapMerge.test.ts
+++ b/cli/src/sync/BootstrapMerge.test.ts
@@ -12,9 +12,14 @@ import { mkdir, mkdtemp, readFile, rm, stat, symlink, writeFile } from "node:fs/
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { symlinksSupported } from "../testUtils/symlinkSupport.js";
 import { BOOTSTRAP_STASH_DIRNAME, runBootstrapMerge, shouldRunBootstrapMerge } from "./BootstrapMerge.js";
 import { GitClient } from "./GitClient.js";
 import type { GitCredentials } from "./SyncTypes.js";
+
+// Creating symlinks needs SeCreateSymbolicLinkPrivilege on Windows; skip the
+// symlink-collection case on a non-elevated account where symlink() throws EPERM.
+const itIfSymlinks = symlinksSupported ? it : it.skip;
 
 // Same global-config isolation rationale as GitClient.test.ts: a developer
 // `commit.gpgsign=true` or husky hook would hang every commit here.
@@ -605,7 +610,7 @@ describe("runBootstrapMerge — per-path dispositions", () => {
 		expect(result.stashedSurvivors).toHaveLength(0);
 	});
 
-	it("symlinks in the local tree are collected and moved like regular files", async () => {
+	itIfSymlinks("symlinks in the local tree are collected and moved like regular files", async () => {
 		const client = await setupFreshLocal();
 		await writeFile(join(memoryBankRoot, "target.md"), "target\n");
 		await symlink("target.md", join(memoryBankRoot, "link.md"));

--- a/cli/src/sync/StageVault.test.ts
+++ b/cli/src/sync/StageVault.test.ts
@@ -2,9 +2,14 @@ import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { symlinksSupported } from "../testUtils/symlinkSupport.js";
 import type { GitClient } from "./GitClient.js";
 import type { PorcelainEntry } from "./PorcelainParser.js";
 import { stageVault } from "./StageVault.js";
+
+// symlinkSync needs SeCreateSymbolicLinkPrivilege on Windows; on a non-elevated
+// account it throws EPERM, so the symlink-defence cases are skipped there.
+const itIfSymlinks = symlinksSupported ? it : it.skip;
 
 /**
  * StageVault tests use a real (temp-dir) vault for the on-disk lstat
@@ -396,7 +401,7 @@ describe("stageVault — symlink defence (R10)", () => {
 		rmSync(vault, { recursive: true, force: true });
 	});
 
-	it("refuses to stage a path whose LEAF is a symlink (hostile placement at owned location)", async () => {
+	itIfSymlinks("refuses to stage a path whose LEAF is a symlink (hostile placement at owned location)", async () => {
 		// Attacker writes a symlink at <vault>/myrepo/.jolli/index.json →
 		// /etc/passwd. Classifier says `repo-index` (owned), so without the
 		// leaf check we'd `git add` it — leaking the target path string
@@ -412,25 +417,28 @@ describe("stageVault — symlink defence (R10)", () => {
 		expect(stageAdd).not.toHaveBeenCalled();
 	});
 
-	it("refuses to stage when an INTERMEDIATE path segment is a symlink (parent-segment traversal)", async () => {
-		// <vault>/myrepo/.jolli → /etc/. The classifier still says
-		// `repo-config` for myrepo/.jolli/config.json BUT staging it
-		// would let `git add` traverse the symlink. assertNoSymlinksInPath
-		// catches this.
-		mkdirSync(join(vault, "myrepo"), { recursive: true });
-		const escapeTarget = mkdtempSync(join(tmpdir(), "escape-"));
-		try {
-			writeFileSync(join(escapeTarget, "config.json"), "{}");
-			symlinkSync(escapeTarget, join(vault, "myrepo", ".jolli"), "dir");
+	itIfSymlinks(
+		"refuses to stage when an INTERMEDIATE path segment is a symlink (parent-segment traversal)",
+		async () => {
+			// <vault>/myrepo/.jolli → /etc/. The classifier still says
+			// `repo-config` for myrepo/.jolli/config.json BUT staging it
+			// would let `git add` traverse the symlink. assertNoSymlinksInPath
+			// catches this.
+			mkdirSync(join(vault, "myrepo"), { recursive: true });
+			const escapeTarget = mkdtempSync(join(tmpdir(), "escape-"));
+			try {
+				writeFileSync(join(escapeTarget, "config.json"), "{}");
+				symlinkSync(escapeTarget, join(vault, "myrepo", ".jolli"), "dir");
 
-			const { client, stageAdd } = makeClient([entry({ path: "myrepo/.jolli/config.json" })]);
-			const report = await stageVault(client as GitClient, vault, { syncTranscripts: true });
-			expect(report.symlinked).toContain("myrepo/.jolli/config.json");
-			expect(stageAdd).not.toHaveBeenCalled();
-		} finally {
-			rmSync(escapeTarget, { recursive: true, force: true });
-		}
-	});
+				const { client, stageAdd } = makeClient([entry({ path: "myrepo/.jolli/config.json" })]);
+				const report = await stageVault(client as GitClient, vault, { syncTranscripts: true });
+				expect(report.symlinked).toContain("myrepo/.jolli/config.json");
+				expect(stageAdd).not.toHaveBeenCalled();
+			} finally {
+				rmSync(escapeTarget, { recursive: true, force: true });
+			}
+		},
+	);
 
 	it("deletion of an owned path with a symlinked leaf still passes through (we're removing, not following)", async () => {
 		// `git rm` doesn't dereference; it just removes the index entry +

--- a/cli/src/sync/SyncEngine.test.ts
+++ b/cli/src/sync/SyncEngine.test.ts
@@ -18,10 +18,15 @@ vi.mock("node:os", async () => {
 	return { ...actual, homedir: () => mockHomeDir.value };
 });
 
+import { symlinksSupported } from "../testUtils/symlinkSupport.js";
 import { type BackendClient, SyncBackendNetworkError } from "./BackendClient.js";
 import type { GitClient } from "./GitClient.js";
 import type { RoundContext } from "./SyncEngine.js";
 import { SyncEngine } from "./SyncEngine.js";
+
+// The symlinked-bucket cap test creates real symlinks, which require
+// SeCreateSymbolicLinkPrivilege on Windows; skip it on an unprivileged account.
+const itIfSymlinks = symlinksSupported ? it : it.skip;
 
 let tempDir: string;
 
@@ -3561,7 +3566,7 @@ describe("SyncEngine.runRound — stageVault canary unowned bucket", () => {
 		expect(result.canary?.unowned).toHaveLength(10);
 	});
 
-	it("caps the canary symlinked bucket at CANARY_PATH_CAP across multiple stage calls", async () => {
+	itIfSymlinks("caps the canary symlinked bucket at CANARY_PATH_CAP across multiple stage calls", async () => {
 		// Mirror of the unowned-cap test for the SYMLINKED bucket: real
 		// symlinks at classifier-OWNED locations are refused by stageVault's
 		// symlink guard and routed to `this.canary.symlinked`. With >10 such

--- a/cli/src/sync/VaultLockPath.fsmock.test.ts
+++ b/cli/src/sync/VaultLockPath.fsmock.test.ts
@@ -14,6 +14,14 @@
 
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+// These assert canonical POSIX path strings, but the function emits the host's
+// native separator and `path.resolve` prepends a drive letter on Windows — the
+// simulated-platform cases can't be faithfully reproduced on a Windows host
+// (real `sep`/`resolve` ignore the `process.platform` stub). They are fully
+// exercised on POSIX CI, so skip on win32 rather than assert a path shape that
+// only holds on POSIX. Mirrors the `skipIfWin32` pattern in other tests.
+const itPosix = process.platform === "win32" ? it.skip : it;
+
 const { mockStatSync, mockRealpathNative } = vi.hoisted(() => ({
 	mockStatSync: vi.fn(),
 	mockRealpathNative: vi.fn(),
@@ -27,7 +35,7 @@ vi.mock("node:fs", () => {
 import { canonicaliseLocalFolder } from "./VaultLockPath.js";
 
 describe("canonicaliseLocalFolder defensive fallbacks", () => {
-	it("trims a trailing separator that survives into the canonical string (step 5)", () => {
+	itPosix("trims a trailing separator that survives into the canonical string (step 5)", () => {
 		// An existing ancestor that realpaths to a path WITH a trailing slash —
 		// the regex collapse preserves the trailing sep, so the explicit trim runs.
 		mockStatSync.mockReturnValue(undefined); // input segment "exists"
@@ -38,7 +46,7 @@ describe("canonicaliseLocalFolder defensive fallbacks", () => {
 		expect(out.endsWith("/")).toBe(false);
 	});
 
-	it("returns the lexical path when no ancestor — not even root — can be statted", () => {
+	itPosix("returns the lexical path when no ancestor — not even root — can be statted", () => {
 		// statSync throws for every segment → resolvePartialRealpath walks to the
 		// filesystem root, hits parent === cur, and returns the resolved input.
 		mockStatSync.mockImplementation(() => {
@@ -64,12 +72,12 @@ describe("canonicaliseLocalFolder case-folding by platform (step 4)", () => {
 		mockRealpathNative.mockImplementation((s: string) => s); // identity realpath
 	}
 
-	it("preserves case on a case-sensitive filesystem (linux — neither branch of the platform check)", () => {
+	itPosix("preserves case on a case-sensitive filesystem (linux — neither branch of the platform check)", () => {
 		stubPlatform("linux");
 		expect(canonicaliseLocalFolder("/Var/Data/Vault")).toBe("/Var/Data/Vault");
 	});
 
-	it("lower-cases on win32 (the first operand of the platform check)", () => {
+	itPosix("lower-cases on win32 (the first operand of the platform check)", () => {
 		stubPlatform("win32");
 		expect(canonicaliseLocalFolder("/Var/Data/Vault")).toBe("/var/data/vault");
 	});

--- a/cli/src/sync/VaultLockPath.test.ts
+++ b/cli/src/sync/VaultLockPath.test.ts
@@ -2,11 +2,16 @@ import { mkdtempSync, rmSync, symlinkSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, sep } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { symlinksSupported } from "../testUtils/symlinkSupport.js";
 import {
 	__vaultLockCanonicalForTesting as canonicalise,
 	canonicaliseLocalFolder,
 	getVaultWriteLockPath,
 } from "./VaultLockPath.js";
+
+// symlinkSync throws EPERM on a non-elevated Windows account (no
+// SeCreateSymbolicLinkPrivilege); skip the symlink-resolution cases there.
+const itIfSymlinks = symlinksSupported ? it : it.skip;
 
 describe("canonicaliseLocalFolder", () => {
 	let tmpRoot: string;
@@ -54,7 +59,7 @@ describe("canonicaliseLocalFolder", () => {
 		expect(out).not.toContain(`..`);
 	});
 
-	it("realpaths symlinked parent segments (step 3 — production caller correctness)", () => {
+	itIfSymlinks("realpaths symlinked parent segments (step 3 — production caller correctness)", () => {
 		// Build: <tmpRoot>/real/data and a symlink <tmpRoot>/link → real.
 		// canonicalise(<tmpRoot>/link/data) must resolve through the symlink
 		// to <tmpRoot>/real/data — otherwise sync and worker would compute
@@ -168,7 +173,7 @@ describe("getVaultWriteLockPath", () => {
 		expect(filename).toMatch(/^vault-[0-9a-f]{64}\.lock$/);
 	});
 
-	it("symlink-equivalent inputs produce the same lock path (canonical-realpath in path)", () => {
+	itIfSymlinks("symlink-equivalent inputs produce the same lock path (canonical-realpath in path)", () => {
 		// Same scenario as the canonicaliseLocalFolder symlink test, but
 		// asserted at the lock-path level. This is the load-bearing property
 		// for the Hotfix: sync and worker must compute the same hash even if

--- a/cli/src/sync/VaultSymlinkGuard.test.ts
+++ b/cli/src/sync/VaultSymlinkGuard.test.ts
@@ -2,7 +2,14 @@ import { lstatSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, w
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { symlinksSupported } from "../testUtils/symlinkSupport.js";
 import { assertNoSymlinksInPath, assertNoSymlinksInPathSync, safeAtomicWriteSync } from "./VaultSymlinkGuard.js";
+
+// Creating symlinks requires SeCreateSymbolicLinkPrivilege on Windows
+// (admin / Developer Mode). On an unprivileged account symlinkSync throws
+// EPERM, so the guard's symlink-rejection paths can't be exercised — skip
+// rather than fail. Mirrors the IntelliJ createSymbolicLinkOrSkip helper.
+const itIfSymlinks = symlinksSupported ? it : it.skip;
 
 describe("assertNoSymlinksInPath", () => {
 	let vault: string;
@@ -31,7 +38,7 @@ describe("assertNoSymlinksInPath", () => {
 		).resolves.toBeUndefined();
 	});
 
-	it("rejects a symlink at the FIRST intermediate segment (repo folder)", async () => {
+	itIfSymlinks("rejects a symlink at the FIRST intermediate segment (repo folder)", async () => {
 		// Build a /tmp dir we control + a symlink at <vault>/evil → /tmp.
 		// Writing to <vault>/evil/anything would escape the vault entirely.
 		const escapeTarget = mkdtempSync(join(tmpdir(), "escape-"));
@@ -45,7 +52,7 @@ describe("assertNoSymlinksInPath", () => {
 		}
 	});
 
-	it("rejects a symlink at an INNER segment (the .jolli case from the threat model)", async () => {
+	itIfSymlinks("rejects a symlink at an INNER segment (the .jolli case from the threat model)", async () => {
 		// <vault>/myrepo/.jolli → some other directory. mkdirSync(...
 		// summaries) on that path would create the dir inside the symlink
 		// target — atomicWrite would then write+rename into the foreign
@@ -71,7 +78,7 @@ describe("assertNoSymlinksInPath", () => {
 		);
 	});
 
-	it("does NOT check the leaf (caller's O_NOFOLLOW handles that)", async () => {
+	itIfSymlinks("does NOT check the leaf (caller's O_NOFOLLOW handles that)", async () => {
 		// The leaf can be a symlink and the guard still passes — leaf
 		// protection is delegated to the caller's openSync(O_NOFOLLOW).
 		// This split exists so the per-write hot path doesn't double-stat.
@@ -120,7 +127,7 @@ describe("assertNoSymlinksInPathSync", () => {
 		expect(() => assertNoSymlinksInPathSync(vault, join(vault, "cold", "x", "y.json"))).not.toThrow();
 	});
 
-	it("rejects a symlink in the path chain", () => {
+	itIfSymlinks("rejects a symlink in the path chain", () => {
 		mkdirSync(join(vault, "myrepo"), { recursive: true });
 		const escapeTarget = mkdtempSync(join(tmpdir(), "escape-"));
 		try {
@@ -172,7 +179,7 @@ describe("safeAtomicWriteSync", () => {
 		expect(readFileSync(target).equals(buf)).toBe(true);
 	});
 
-	it("refuses to write through a symlinked path segment", () => {
+	itIfSymlinks("refuses to write through a symlinked path segment", () => {
 		mkdirSync(join(vault, "myrepo"), { recursive: true });
 		const escapeTarget = mkdtempSync(join(tmpdir(), "escape-"));
 		try {

--- a/cli/src/testUtils/symlinkSupport.test.ts
+++ b/cli/src/testUtils/symlinkSupport.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+describe("canCreateSymlinks", () => {
+	afterEach(() => {
+		vi.doUnmock("node:fs");
+		vi.resetModules();
+	});
+
+	it("returns true when symlinkSync succeeds", async () => {
+		vi.resetModules();
+		vi.doMock("node:fs", () => ({
+			mkdtempSync: () => "/tmp/jolli-symlink-probe-xyz",
+			writeFileSync: () => {},
+			symlinkSync: () => {},
+			rmSync: () => {},
+		}));
+		const { canCreateSymlinks } = await import("./symlinkSupport.js");
+		expect(canCreateSymlinks()).toBe(true);
+	});
+
+	it("returns false when symlinkSync throws (EPERM on a non-elevated Windows account)", async () => {
+		vi.resetModules();
+		vi.doMock("node:fs", () => ({
+			mkdtempSync: () => "/tmp/jolli-symlink-probe-xyz",
+			writeFileSync: () => {},
+			symlinkSync: () => {
+				throw Object.assign(new Error("EPERM: operation not permitted, symlink"), { code: "EPERM" });
+			},
+			rmSync: () => {},
+		}));
+		const { canCreateSymlinks } = await import("./symlinkSupport.js");
+		expect(canCreateSymlinks()).toBe(false);
+	});
+
+	it("exposes a boolean snapshot via symlinksSupported", async () => {
+		const mod = await import("./symlinkSupport.js");
+		expect(typeof mod.symlinksSupported).toBe("boolean");
+	});
+});

--- a/cli/src/testUtils/symlinkSupport.ts
+++ b/cli/src/testUtils/symlinkSupport.ts
@@ -1,0 +1,44 @@
+/**
+ * Detects whether the current process can create symlinks, so symlink-dependent
+ * tests can be skipped (not failed) on machines that forbid them.
+ *
+ * On Windows, `symlinkSync` requires the SeCreateSymbolicLinkPrivilege
+ * (administrator, or a normal account with Developer Mode enabled). A plain
+ * user account throws `EPERM: operation not permitted`. Such a machine simply
+ * cannot exercise the symlink-guard code paths, so the correct outcome is a
+ * skipped test, not a build failure — mirroring the IntelliJ side's
+ * `createSymbolicLinkOrSkip` (which aborts via a JUnit assumption).
+ *
+ * Usage in a test file:
+ *
+ *   import { it } from "vitest";
+ *   import { symlinksSupported } from "../testUtils/symlinkSupport.js";
+ *   const itIfSymlinks = symlinksSupported ? it : it.skip;
+ *   itIfSymlinks("rejects a symlinked path segment", () => { ... });
+ */
+
+import { mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+/**
+ * Probes symlink capability by actually creating one in a throwaway temp dir.
+ * Returns `true` only if the symlink was created without error. Account-level
+ * (not just platform-level), so an elevated/Developer-Mode Windows box returns
+ * `true` and exercises the real symlink tests.
+ */
+export function canCreateSymlinks(): boolean {
+	const dir = mkdtempSync(join(tmpdir(), "jolli-symlink-probe-"));
+	try {
+		writeFileSync(join(dir, "target"), "x");
+		symlinkSync(join(dir, "target"), join(dir, "link"), "file");
+		return true;
+	} catch {
+		return false;
+	} finally {
+		rmSync(dir, { recursive: true, force: true });
+	}
+}
+
+/** Cached single-probe result — symlink capability does not change mid-run. */
+export const symlinksSupported: boolean = canCreateSymlinks();

--- a/intellij/CHANGELOG.md
+++ b/intellij/CHANGELOG.md
@@ -2,7 +2,34 @@
 
 ## 0.99.1
 
-- **"Push to Jolli" is now "Share in Jolli"** — the summary viewer's cloud-publish button is relabeled **Share in Jolli**. Behavior is unchanged; only the label was updated.
+### New Features
+
+- **Active Conversations** — a new panel showing in-progress AI agent sessions live, with inline transcript editing, message counts, and the ability to hide sessions
+- **Knowledge Wiki** — build a browsable topic wiki from your Memory Bank via an LLM ingest pipeline. Trigger it with the **Build Knowledge Wiki** button or let it auto-compile after each commit; supports both Anthropic and Jolli summarization providers
+- **Full-text search & MCP server** — search across all memories, plus an MCP server that exposes your memory to AI tools, with ingest-phase progress UI
+- **Full vault sync pipeline** — sync your Memory Bank to your Jolli space with live UI feedback, a space-binding dialog, and binding-required (412) handling
+- **Quick Recap** — generate, regenerate, and edit a branch recap section
+- **Memory scope filter** — filter the Memories panel by scope; auto-refreshes on branch switch
+- **Discard selected** — discard multiple selected files at once in the Changes panel
+- **"Push to Jolli" is now "Share in Jolli"** — the cloud-publish button is relabeled across all surfaces. Behavior is unchanged; only the label was updated
+
+### UI
+
+- **Tool window redesign** — breadcrumb navigation and foreign-mode support
+- **Summary panel redesign** — realigned to match the VS Code layout
+- **LLM provider attribution** — summary footers now show which provider generated the summary
+
+### Fixes & Improvements
+
+- Fixed Jolli API key clearing not triggering the status indicator, and not saving as `null` when cleared
+- Fixed SSH/HTTPS remote mismatch that split Memory Banks and created duplicate repo entries; repo identity is now canonicalized on merge
+- Fixed Migrate-to-Memory-Bank creating duplicate repo folders; consolidated onto the base folder name
+- Auto-clear stale sync-status badges in the status bar
+- Windows: mark the `.jolli` directory as hidden, fix path-separator drift in the storage layer, and fix the build & test suite
+- Fixed SQLite JDBC driver loading
+- Fixed a stderr deadlock and refined the sync poll interval
+- Fixed OnboardingPanel font rendering and added an API key help tooltip
+- Added `client_version` to OAuth login URLs
 
 ## 0.99.0
 

--- a/intellij/build.gradle.kts
+++ b/intellij/build.gradle.kts
@@ -15,7 +15,7 @@ plugins {
 }
 
 group = "ai.jolli"
-version = "0.99.0"
+version = "0.99.1"
 
 repositories {
     mavenCentral()
@@ -149,6 +149,55 @@ intellijPlatform {
             </p>
         """.trimIndent()
         changeNotes = """
+            <h3>0.99.1</h3>
+
+            <h4>New Features</h4>
+            <ul>
+                <li><b>Active Conversations</b> &mdash; a new panel showing in-progress AI agent
+                    sessions live, with inline transcript editing, message counts, and the ability
+                    to hide sessions</li>
+                <li><b>Knowledge Wiki</b> &mdash; build a browsable topic wiki from your Memory Bank
+                    via an LLM ingest pipeline. Trigger it with the <b>Build Knowledge Wiki</b> button
+                    or let it auto-compile after each commit; supports both Anthropic and Jolli
+                    summarization providers</li>
+                <li><b>Full-text search &amp; MCP server</b> &mdash; search across all memories, plus
+                    an MCP server that exposes your memory to AI tools, with ingest-phase progress UI</li>
+                <li><b>Full vault sync pipeline</b> &mdash; sync your Memory Bank to your Jolli space
+                    with live UI feedback, a space-binding dialog, and binding-required (412) handling</li>
+                <li><b>Quick Recap</b> &mdash; generate, regenerate, and edit a branch recap section</li>
+                <li><b>Memory scope filter</b> &mdash; filter the Memories panel by scope; auto-refreshes
+                    on branch switch</li>
+                <li><b>Discard selected</b> &mdash; discard multiple selected files at once in the
+                    Changes panel</li>
+                <li><b>"Push to Jolli" is now "Share in Jolli"</b> &mdash; the cloud-publish button is
+                    relabeled across all surfaces. Behavior is unchanged; only the label was updated</li>
+            </ul>
+
+            <h4>UI</h4>
+            <ul>
+                <li><b>Tool window redesign</b> &mdash; breadcrumb navigation and foreign-mode support</li>
+                <li><b>Summary panel redesign</b> &mdash; realigned to match the VS Code layout</li>
+                <li><b>LLM provider attribution</b> &mdash; summary footers now show which provider
+                    generated the summary</li>
+            </ul>
+
+            <h4>Fixes &amp; Improvements</h4>
+            <ul>
+                <li>Fixed Jolli API key clearing not triggering the status indicator, and not saving
+                    as <code>null</code> when cleared</li>
+                <li>Fixed SSH/HTTPS remote mismatch that split Memory Banks and created duplicate repo
+                    entries; repo identity is now canonicalized on merge</li>
+                <li>Fixed Migrate-to-Memory-Bank creating duplicate repo folders; consolidated onto the
+                    base folder name</li>
+                <li>Auto-clear stale sync-status badges in the status bar</li>
+                <li>Windows: mark the <code>.jolli</code> directory as hidden, fix path-separator drift
+                    in the storage layer, and fix the build &amp; test suite</li>
+                <li>Fixed SQLite JDBC driver loading</li>
+                <li>Fixed a stderr deadlock and refined the sync poll interval</li>
+                <li>Fixed OnboardingPanel font rendering and added an API key help tooltip</li>
+                <li>Added <code>client_version</code> to OAuth login URLs</li>
+            </ul>
+
             <h3>0.99.0</h3>
 
             <h4>Memory Bank</h4>

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/bridge/HookInstaller.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/bridge/HookInstaller.kt
@@ -469,7 +469,7 @@ class HookInstaller(private val projectDir: String, private val mainRepoRoot: St
             val pluginId = com.intellij.openapi.extensions.PluginId.getId("ai.jolli.jollimemory")
             searchLog.appendLine("pluginId=$pluginId")
 
-            val plugin = com.intellij.ide.plugins.PluginManager.getInstance().findEnabledPlugin(pluginId)
+            val plugin = com.intellij.ide.plugins.PluginManager.getPlugins().firstOrNull { it.pluginId == pluginId }
             searchLog.appendLine("plugin=${plugin?.name} version=${plugin?.version}")
 
             val pluginPath = plugin?.pluginPath

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/bridge/HookInstaller.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/bridge/HookInstaller.kt
@@ -463,16 +463,17 @@ class HookInstaller(private val projectDir: String, private val mainRepoRoot: St
     private fun findPluginLibJar(): File? {
         val searchLog = StringBuilder()
         return try {
-            // Use IntelliJ Plugin API to find our plugin's installation path.
-            // This will throw NoClassDefFoundError when running from the hooks JAR
-            // (outside IntelliJ), which is caught below.
-            val pluginId = com.intellij.openapi.extensions.PluginId.getId("ai.jolli.jollimemory")
-            searchLog.appendLine("pluginId=$pluginId")
+            // Derive the plugin install path from this class's code-source location
+            // instead of the IntelliJ `PluginManager` API (which is `@ApiStatus.Internal`
+            // and tripped the Marketplace Plugin Verifier). In an installed plugin this
+            // class is loaded from `<pluginPath>/lib/<jar>.jar`, so the plugin root is two
+            // levels up. Pure JVM API — also resolves to null cleanly when running from
+            // the hooks JAR outside the IDE, which the null-guards below handle.
+            val codeSource = File(javaClass.protectionDomain.codeSource.location.toURI())
+            searchLog.appendLine("codeSource=$codeSource")
 
-            val plugin = com.intellij.ide.plugins.PluginManager.getPlugins().firstOrNull { it.pluginId == pluginId }
-            searchLog.appendLine("plugin=${plugin?.name} version=${plugin?.version}")
-
-            val pluginPath = plugin?.pluginPath
+            // <pluginPath>/lib/<jar>.jar -> parent (lib/) -> parent (pluginPath)
+            val pluginPath = codeSource.parentFile?.parentFile?.toPath()
             searchLog.appendLine("pluginPath=$pluginPath")
 
             if (pluginPath != null) {

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/bridge/SkillInstaller.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/bridge/SkillInstaller.kt
@@ -98,22 +98,31 @@ class SkillInstaller(private val projectDir: String) {
     }
 
     /**
-     * Resolves the plugin version.
+     * Resolves the plugin version from the classpath resource baked in by
+     * `processResources` (see build.gradle.kts) — the same mechanism
+     * [ai.jolli.jollimemory.services.JolliApiClient] uses. Reading a resource
+     * avoids the IntelliJ `PluginManager` API entirely (it is `@ApiStatus.Internal`
+     * and tripped the Marketplace Plugin Verifier), and works identically in the
+     * IDE, the hooks JAR, and tests.
      *
-     * Tries IntelliJ's PluginManager API first (runtime in IDE), then falls
-     * back to a hardcoded version for non-IDE contexts (tests, hooks JAR).
+     * Falls back to [FALLBACK_VERSION] when the resource is missing or still
+     * carries the un-expanded Gradle token (tests run without `processResources`).
      */
     private fun resolvePluginVersion(): String {
-        return try {
-            val pluginId = com.intellij.openapi.extensions.PluginId.getId("ai.jolli.jollimemory")
-            val plugin = com.intellij.ide.plugins.PluginManager.getPlugins().firstOrNull { it.pluginId == pluginId }
-            plugin?.version ?: FALLBACK_VERSION
+        val raw = try {
+            javaClass.getResourceAsStream(VERSION_RESOURCE_PATH)
+                ?.bufferedReader(Charsets.UTF_8)
+                ?.use { it.readText() }
         } catch (_: Throwable) {
-            // NoClassDefFoundError when running outside IntelliJ (tests, hooks JAR)
-            FALLBACK_VERSION
+            null
         }
+        val trimmed = raw?.trim().orEmpty()
+        return if (trimmed.isEmpty() || trimmed.contains("\${")) FALLBACK_VERSION else trimmed
     }
 }
 
-/** Fallback version when IntelliJ Plugin API is unavailable. */
+/** Classpath resource holding the plugin version, populated by `processResources`. */
+private const val VERSION_RESOURCE_PATH = "/jollimemory-plugin-version.txt"
+
+/** Fallback version when the version resource is unavailable. */
 private const val FALLBACK_VERSION = "dev"

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/bridge/SkillInstaller.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/bridge/SkillInstaller.kt
@@ -106,7 +106,7 @@ class SkillInstaller(private val projectDir: String) {
     private fun resolvePluginVersion(): String {
         return try {
             val pluginId = com.intellij.openapi.extensions.PluginId.getId("ai.jolli.jollimemory")
-            val plugin = com.intellij.ide.plugins.PluginManager.getInstance().findEnabledPlugin(pluginId)
+            val plugin = com.intellij.ide.plugins.PluginManager.getPlugins().firstOrNull { it.pluginId == pluginId }
             plugin?.version ?: FALLBACK_VERSION
         } catch (_: Throwable) {
             // NoClassDefFoundError when running outside IntelliJ (tests, hooks JAR)

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/core/KBPathResolver.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/core/KBPathResolver.kt
@@ -44,9 +44,13 @@ object KBPathResolver {
         val parent = resolveParent(customPath)
         val basePath = parent.resolve(repoName)
 
-        // Folder doesn't exist yet — use it
+        // Folder doesn't exist yet. Before claiming it, scan the suffix ladder
+        // for a folder that already holds this repo — a prior Migrate may have
+        // archived the base and left the live data in `<repo>-N`. Reusing it
+        // stops a fresh empty `<repo>` base from shadowing the real data folder.
+        // Mirrors the canonical TS resolveKBPath Case A.
         if (!Files.isDirectory(basePath)) {
-            return basePath
+            return findSameRepoSuffix(parent, repoName, remoteUrl) ?: basePath
         }
 
         // Folder exists — check if it belongs to the same repo
@@ -280,6 +284,23 @@ object KBPathResolver {
     private fun nonDefaultPortSegment(port: String, schemeDefault: String): String {
         if (port.isEmpty() || port == schemeDefault) return ""
         return ":$port"
+    }
+
+    /**
+     * Scans `<repo>-2` … `<repo>-99` for a folder whose identity matches this
+     * repo, returning the first match or null. Used by [resolve] to reuse a
+     * suffixed data folder when the base slot is free (e.g. after a Migrate
+     * archived the base). Mirrors the same-repo match arm of the canonical TS
+     * `scanRepoSuffixes`.
+     */
+    private fun findSameRepoSuffix(parent: Path, repoName: String, remoteUrl: String?): Path? {
+        for (suffix in 2..99) {
+            val candidate = parent.resolve("$repoName-$suffix")
+            if (!Files.isDirectory(candidate)) continue
+            val config = readKBConfig(candidate)
+            if (config != null && isSameRepo(config, remoteUrl, repoName)) return candidate
+        }
+        return null
     }
 
     private fun findAvailablePath(parent: Path, repoName: String, remoteUrl: String?): Path {

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/core/KBPathResolver.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/core/KBPathResolver.kt
@@ -34,10 +34,14 @@ object KBPathResolver {
      * @param customPath User-configured custom path from JolliMemoryConfig, or null for default
      * @return The resolved KB root path
      */
+    /** Resolves the Memory Bank parent dir from an optional custom path. */
+    private fun resolveParent(customPath: String?): Path =
+        if (!customPath.isNullOrBlank()) Path.of(customPath) else KB_PARENT
+
     fun resolve(repoName: String, remoteUrl: String?, customPath: String? = null): Path {
         // Custom path is treated as parent directory (like ~/Documents/jolli/),
         // repoName is always appended to keep repos separated
-        val parent = if (!customPath.isNullOrBlank()) Path.of(customPath) else KB_PARENT
+        val parent = resolveParent(customPath)
         val basePath = parent.resolve(repoName)
 
         // Folder doesn't exist yet — use it
@@ -52,7 +56,7 @@ object KBPathResolver {
         }
 
         // Collision: different repo with same name — find next available suffix
-        return findAvailablePath(repoName, remoteUrl)
+        return findAvailablePath(parent, repoName, remoteUrl)
     }
 
     /**
@@ -70,6 +74,90 @@ object KBPathResolver {
             repoName = repoName,
         ))
         log.info("KB folder initialized: %s (remote=%s)", kbRoot, remoteUrl ?: "none")
+    }
+
+    /**
+     * Returns every existing KB folder (`<repo>` and `<repo>-2` … `<repo>-99`)
+     * under the Memory Bank parent whose `.jolli/config.json` identity matches
+     * this repo. Read-only.
+     *
+     * Used by the Migrate-to-Memory-Bank flow to fold a *pile* of duplicates in
+     * one pass: earlier buggy runs left several `<repo>-N` folders all sharing one
+     * identity, and archiving only one would clear them one-click-at-a-time. Only
+     * true identity matches are returned, so it is safe to feed to [archiveKBFolder].
+     * Port of the canonical TS `findRepoFolders`.
+     */
+    fun findRepoFolders(repoName: String, remoteUrl: String?, customPath: String? = null): List<Path> {
+        val parent = resolveParent(customPath)
+        val out = mutableListOf<Path>()
+        val base = parent.resolve(repoName)
+        if (Files.isDirectory(base)) {
+            val baseConfig = readKBConfig(base)
+            if (baseConfig != null && isSameRepo(baseConfig, remoteUrl, repoName)) out.add(base)
+        }
+        for (suffix in 2..99) {
+            val candidate = parent.resolve("$repoName-$suffix")
+            if (!Files.isDirectory(candidate)) continue
+            val config = readKBConfig(candidate)
+            if (config != null && isSameRepo(config, remoteUrl, repoName)) out.add(candidate)
+        }
+        return out
+    }
+
+    /**
+     * Returns the next unused `-N` KB path (or the bare `<repo>` when free) so the
+     * Migrate flow can build into a fresh folder and archive the prior ones.
+     * Port of the canonical TS `findFreshKBPath`.
+     */
+    fun findFreshKBPath(repoName: String, customPath: String? = null): Path {
+        val parent = resolveParent(customPath)
+        val basePath = parent.resolve(repoName)
+        if (!Files.isDirectory(basePath)) return basePath
+        for (suffix in 2..99) {
+            val candidate = parent.resolve("$repoName-$suffix")
+            if (!Files.isDirectory(candidate)) return candidate
+        }
+        return parent.resolve("$repoName-${System.currentTimeMillis()}")
+    }
+
+    /**
+     * Moves a KB repo folder out of the active Memory Bank area into the hidden,
+     * per-Memory-Bank archive dir `<parent>/.jolli/archive/<name>-<timestamp>/`.
+     *
+     * Replaces the old "archive = rewrite config.json identity in place" step,
+     * which left the folder visible in the IDE folder views AND still tracked by
+     * the vault git. The archive dir is hidden (leading dot → filtered by the IDE
+     * explorers) and unowned by the sync classifier, while staying inside the
+     * Memory Bank so it travels with `localFolder` and stays recoverable (the
+     * orphan branch remains the system of record).
+     *
+     * Returns the destination path, or null if [kbRoot] doesn't exist (nothing to
+     * archive) or the move fails — callers log and proceed, since a stale visible
+     * folder is a lesser evil than aborting a rebuild. Mirrors the canonical TS
+     * `archiveKBFolder`; both IDEs resolve folders in the same Memory Bank.
+     */
+    fun archiveKBFolder(kbRoot: Path, customPath: String? = null): Path? {
+        if (!Files.isDirectory(kbRoot)) return null
+        val parent = resolveParent(customPath)
+        val archiveDir = parent.resolve(".jolli").resolve("archive")
+        val name = kbRoot.fileName.toString()
+        // Timestamp keeps repeated archives distinct; the counter guards against
+        // same-millisecond collisions (rapid rebuilds).
+        var dest = archiveDir.resolve("$name-${System.currentTimeMillis()}")
+        var n = 2
+        while (Files.exists(dest) && n <= 99) {
+            dest = archiveDir.resolve("$name-${System.currentTimeMillis()}-$n")
+            n++
+        }
+        return try {
+            Files.createDirectories(archiveDir)
+            Files.move(kbRoot, dest)
+            log.info("Archived KB folder: %s → %s", kbRoot, dest)
+            dest
+        } catch (e: Exception) {
+            log.warn("Failed to archive KB folder %s: %s", kbRoot, e.message)
+            null
+        }
     }
 
     /**
@@ -194,20 +282,27 @@ object KBPathResolver {
         return ":$port"
     }
 
-    private fun findAvailablePath(repoName: String, remoteUrl: String?): Path {
+    private fun findAvailablePath(parent: Path, repoName: String, remoteUrl: String?): Path {
+        // Pass 1: reuse an existing folder that already belongs to this repo. Scan
+        // ALL suffixes first — a folder archived out of the ladder leaves a numbering
+        // hole, and stopping at that hole (claiming it fresh) while a higher-numbered
+        // folder already holds this repo is what spawned duplicate <repo>-N folders.
+        // Mirrors the TS findAvailablePathAndClaim two-pass fix.
+        var firstUnused: Path? = null
         for (suffix in 2..99) {
-            val candidate = KB_PARENT.resolve("$repoName-$suffix")
+            val candidate = parent.resolve("$repoName-$suffix")
             if (!Files.isDirectory(candidate)) {
-                return candidate
+                if (firstUnused == null) firstUnused = candidate
+                continue
             }
-            // Check if this suffixed folder belongs to the same repo
             val config = readKBConfig(candidate)
             if (config != null && isSameRepo(config, remoteUrl, repoName)) {
                 return candidate
             }
         }
-        // Extremely unlikely fallback
-        return KB_PARENT.resolve("$repoName-${System.currentTimeMillis()}")
+        // Pass 2: no existing folder for this repo — use the lowest free slot.
+        // The millis-suffixed name is the 99-collision safety net only.
+        return firstUnused ?: parent.resolve("$repoName-${System.currentTimeMillis()}")
     }
 
     private fun readKBConfig(kbRoot: Path): KBConfig? {

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/services/JolliMemoryService.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/services/JolliMemoryService.kt
@@ -12,10 +12,12 @@ import ai.jolli.jollimemory.core.StatusInfo
 import ai.jolli.jollimemory.core.StorageFactory
 import ai.jolli.jollimemory.sync.SyncEngine
 import ai.jolli.jollimemory.sync.SyncOrchestrator
+import ai.jolli.jollimemory.sync.STATUS_AUTO_CLEAR_DELAY_MS
 import ai.jolli.jollimemory.sync.SyncOrchestratorOpts
 import ai.jolli.jollimemory.sync.SyncState
 import ai.jolli.jollimemory.sync.SyncStatusBarWidget
 import ai.jolli.jollimemory.sync.SyncStatusDetail
+import ai.jolli.jollimemory.sync.autoClearableSyncState
 import ai.jolli.jollimemory.toolwindow.PanelRegistry
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.application.ApplicationManager
@@ -23,6 +25,7 @@ import com.intellij.openapi.components.Service
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.wm.WindowManager
+import com.intellij.util.concurrency.AppExecutorUtil
 import git4idea.repo.GitRepository
 import git4idea.repo.GitRepositoryChangeListener
 import java.io.File
@@ -32,6 +35,7 @@ import java.nio.file.Path
 import java.nio.file.StandardWatchEventKinds
 import java.nio.file.WatchService
 import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicLong
 import javax.swing.Timer
 
@@ -70,6 +74,9 @@ class JolliMemoryService(private val project: Project) : Disposable {
     private var syncState: SyncState? = null
     @Volatile
     private var syncDetail: SyncStatusDetail? = null
+    /** Bumped on every sync-state change so a pending auto-clear can detect that
+     *  a newer state arrived and skip clobbering it. */
+    private val syncStateGen = AtomicLong(0)
     /** Listeners notified (on the EDT) whenever the sync state changes. Lets the
      *  KB explorer toolbar mirror the status-bar widget's progress/error feedback. */
     private val syncListeners = CopyOnWriteArrayList<(SyncState, SyncStatusDetail?) -> Unit>()
@@ -740,12 +747,14 @@ val sb = StringBuilder()
             pollIntervalSec = pollIntervalSec,
             lastSuccessAtMs = lastSyncSuccessAtMs,
             onStateChange = { state, detail ->
+                val gen = syncStateGen.incrementAndGet()
                 syncState = state
                 syncDetail = detail
                 ApplicationManager.getApplication().invokeLater {
                     widget?.setSyncState(state, detail)
                     syncListeners.forEach { it(state, detail) }
                 }
+                scheduleStatusAutoClear(state, gen)
             },
         ))
         orchestrator = orch
@@ -755,6 +764,52 @@ val sb = StringBuilder()
     /** Stop the sync polling loop (orchestrator remains usable for manual sync). */
     fun stopSync() {
         orchestrator?.stop()
+        // A terminal failure from the last round is sticky: the status bar only
+        // leaves OFFLINE on a subsequent *successful* round, which never comes
+        // once polling has stopped (sign-out, auto-sync disabled, restart). Reset
+        // it so a stale "✗ Sync failed" badge doesn't linger while no sync runs.
+        // Gated on "was actually a failure" so a healthy ✓ state is preserved
+        // across the stop()/start() restart dance. Widget + cached state +
+        // listeners are reset together, mirroring the onStateChange path.
+        if (syncState == SyncState.OFFLINE && syncDetail?.failed == true) {
+            syncStateGen.incrementAndGet()
+            syncState = SyncState.OFFLINE
+            syncDetail = null
+            val widget = findSyncWidget()
+            ApplicationManager.getApplication().invokeLater {
+                widget?.clearFailureStatus()
+                syncListeners.forEach { it(SyncState.OFFLINE, null) }
+            }
+        }
+    }
+
+    /**
+     * Auto-dismiss a finished sync status after [STATUS_AUTO_CLEAR_DELAY_MS] so
+     * the status bar and KB toolbar return to a neutral resting state instead of
+     * holding a stale badge. A failure is the worst offender — it otherwise
+     * lingers until the next round (up to 90 min away, or never once polling
+     * stops). SYNCING is skipped: it's an in-progress indicator that its own
+     * result replaces.
+     *
+     * The [gen] guard ensures a newer state (a fresh round starting inside the
+     * window, a sign-out clear, etc.) is never clobbered by a stale timer: if
+     * [syncStateGen] has moved on, the scheduled clear is a no-op. Widget +
+     * cached state + listeners are reset together, mirroring the onStateChange
+     * path so getSyncState() and late-registering panels stay consistent.
+     */
+    private fun scheduleStatusAutoClear(state: SyncState, gen: Long) {
+        if (!autoClearableSyncState(state)) return
+        AppExecutorUtil.getAppScheduledExecutorService().schedule({
+            if (syncStateGen.get() != gen) return@schedule
+            syncState = SyncState.OFFLINE
+            syncDetail = null
+            val widget = findSyncWidget()
+            ApplicationManager.getApplication().invokeLater {
+                if (syncStateGen.get() != gen) return@invokeLater
+                widget?.setSyncState(SyncState.OFFLINE, null)
+                syncListeners.forEach { it(SyncState.OFFLINE, null) }
+            }
+        }, STATUS_AUTO_CLEAR_DELAY_MS, TimeUnit.MILLISECONDS)
     }
 
     /** Trigger a manual sync round, coalescing with any in-flight round. */

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/sync/SyncStatusBarWidget.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/sync/SyncStatusBarWidget.kt
@@ -67,6 +67,27 @@ class SyncStatusBarWidget(private val project: Project) : StatusBarWidget, Statu
 		statusBar?.updateWidget(ID)
 	}
 
+	/**
+	 * If the widget is currently showing a terminal sync FAILURE, reset it to
+	 * the neutral "Jolli Memory" display and return true. Healthy states
+	 * (SYNCED / SYNCING / CONFLICTS, or an already-neutral OFFLINE) are left
+	 * untouched and this returns false.
+	 *
+	 * Called when sync stops (sign-out, auto-sync disabled, orchestrator
+	 * restart). A failure is otherwise sticky — [setSyncState] only overwrites
+	 * OFFLINE on a later *successful* round, which never arrives once polling
+	 * has stopped — so a stale "✗ Sync failed" badge would linger on the status
+	 * bar with no sync actually running. Gating on "was a failure" keeps a
+	 * healthy ✓ badge across the stop()/start() restart dance.
+	 */
+	fun clearFailureStatus(): Boolean {
+		if (currentState == SyncState.OFFLINE && currentDetail?.failed == true) {
+			setSyncState(SyncState.OFFLINE, null)
+			return true
+		}
+		return false
+	}
+
 	// ── StatusBarWidget ──────────────────────────────────────────────────
 
 	override fun ID(): String = ID

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/sync/SyncStatusDetail.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/sync/SyncStatusDetail.kt
@@ -24,6 +24,22 @@ const val DEFAULT_POLL_SEC: Int = 90 * 60
 /** Default eager-tick threshold: 30 minutes. */
 const val DEFAULT_EAGER_TICK_MIN_ELAPSED_MS: Long = 30 * 60_000L
 
+/**
+ * How long a finished sync status badge stays on the status bar / toolbar
+ * before it auto-reverts to the neutral resting state. Keeps a stale badge —
+ * especially a failure — from lingering until the next round (up to 90 min
+ * away, or never once polling stops).
+ */
+const val STATUS_AUTO_CLEAR_DELAY_MS: Long = 3_000L
+
+/**
+ * Whether a [SyncState] should auto-dismiss to neutral after
+ * [STATUS_AUTO_CLEAR_DELAY_MS]. SYNCING is an in-progress indicator that its own
+ * result replaces, so it is never auto-cleared; every finished state (SYNCED /
+ * CONFLICTS / OFFLINE, including failures) is.
+ */
+fun autoClearableSyncState(state: SyncState): Boolean = state != SyncState.SYNCING
+
 /** Clamp a user-supplied poll interval to [MIN_POLL_SEC]..[MAX_POLL_SEC]. */
 fun clampPoll(value: Int?): Int {
 	if (value == null || value <= 0) return DEFAULT_POLL_SEC

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/SettingsDialog.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/SettingsDialog.kt
@@ -824,14 +824,24 @@ class SettingsDialog(
                     val repoName = KBPathResolver.extractRepoName(projectPath)
                     val remoteUrl = KBPathResolver.getRemoteUrl(projectPath)
 
-                    // Enumerate every folder that currently holds this repo BEFORE
-                    // creating the fresh one, so a pile of duplicates left by earlier
-                    // buggy runs is folded in a single Migrate. Build into a fresh -N
-                    // folder, then MOVE the prior ones into the hidden .jolli/archive/
+                    // Enumerate every folder that currently holds this repo, then
+                    // archive the whole pile FIRST — the canonical base `<repo>` slot
+                    // included — so migration lands back on the base name instead of
+                    // climbing to an ever-higher `<repo>-N`. Safe to archive up front:
+                    // the migration SOURCE is the orphan branch (system of record), not
+                    // these folders, so a crash mid-migrate self-heals on the next
+                    // activation, which re-migrates into the now-free base slot.
+                    // archiveKBFolder MOVES each folder into the hidden .jolli/archive/
                     // (not an in-place identity rewrite, which left them visible and
                     // still git-tracked). Mirrors the VS Code rebuildKnowledgeBase flow.
                     val staleFolders = KBPathResolver.findRepoFolders(repoName, remoteUrl, config.knowledgeBasePath)
-                    val kbRoot = KBPathResolver.findFreshKBPath(repoName, config.knowledgeBasePath)
+                    for (stale in staleFolders) {
+                        KBPathResolver.archiveKBFolder(stale, config.knowledgeBasePath)
+                    }
+
+                    // With the pile archived, the base slot is free; resolve to it
+                    // (falling back to a fresh -N only if some folder survived archiving).
+                    val kbRoot = KBPathResolver.resolve(repoName, remoteUrl, config.knowledgeBasePath)
                     KBPathResolver.initializeKBFolder(kbRoot, repoName, remoteUrl)
                     val mm = MetadataManager(kbRoot.resolve(".jolli"))
                     val folder = FolderStorage(kbRoot, mm)
@@ -839,12 +849,6 @@ class SettingsDialog(
 
                     val engine = MigrationEngine(orphan, folder, mm)
                     val result = engine.runMigration()
-
-                    // The fresh folder didn't exist when staleFolders was captured, so
-                    // it can't appear in the list; the guard is belt-and-suspenders.
-                    for (stale in staleFolders) {
-                        if (stale != kbRoot) KBPathResolver.archiveKBFolder(stale, config.knowledgeBasePath)
-                    }
 
                     if (result.status == "completed") {
                         Messages.showInfoMessage(project,

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/SettingsDialog.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/SettingsDialog.kt
@@ -823,13 +823,28 @@ class SettingsDialog(
                     val config = SessionTracker.loadConfig()
                     val repoName = KBPathResolver.extractRepoName(projectPath)
                     val remoteUrl = KBPathResolver.getRemoteUrl(projectPath)
-                    val kbRoot = KBPathResolver.resolve(repoName, remoteUrl, config.knowledgeBasePath)
+
+                    // Enumerate every folder that currently holds this repo BEFORE
+                    // creating the fresh one, so a pile of duplicates left by earlier
+                    // buggy runs is folded in a single Migrate. Build into a fresh -N
+                    // folder, then MOVE the prior ones into the hidden .jolli/archive/
+                    // (not an in-place identity rewrite, which left them visible and
+                    // still git-tracked). Mirrors the VS Code rebuildKnowledgeBase flow.
+                    val staleFolders = KBPathResolver.findRepoFolders(repoName, remoteUrl, config.knowledgeBasePath)
+                    val kbRoot = KBPathResolver.findFreshKBPath(repoName, config.knowledgeBasePath)
+                    KBPathResolver.initializeKBFolder(kbRoot, repoName, remoteUrl)
                     val mm = MetadataManager(kbRoot.resolve(".jolli"))
                     val folder = FolderStorage(kbRoot, mm)
                     folder.ensure()
 
                     val engine = MigrationEngine(orphan, folder, mm)
                     val result = engine.runMigration()
+
+                    // The fresh folder didn't exist when staleFolders was captured, so
+                    // it can't appear in the list; the guard is belt-and-suspenders.
+                    for (stale in staleFolders) {
+                        if (stale != kbRoot) KBPathResolver.archiveKBFolder(stale, config.knowledgeBasePath)
+                    }
 
                     if (result.status == "completed") {
                         Messages.showInfoMessage(project,

--- a/intellij/src/test/kotlin/ai/jolli/jollimemory/bridge/SkillInstallerTest.kt
+++ b/intellij/src/test/kotlin/ai/jolli/jollimemory/bridge/SkillInstallerTest.kt
@@ -61,8 +61,15 @@ Old content
 
             val content = skillFile.readText()
             content shouldContain "Every commit deserves a Memory"
-            // Should have the new version (dev in test context), not the old one
-            content shouldContain "jolli-skill-version: dev"
+            // Should have the current version (resolved from the baked-in
+            // /jollimemory-plugin-version.txt resource, the same source
+            // SkillInstaller reads), not the old one. Derive the expected value
+            // the same way so this stays correct across version bumps.
+            val expectedVersion = SkillInstaller::class.java
+                .getResourceAsStream("/jollimemory-plugin-version.txt")
+                ?.bufferedReader(Charsets.UTF_8)?.use { it.readText().trim() }
+                ?.takeUnless { it.isEmpty() || it.contains("\${") } ?: "dev"
+            content shouldContain "jolli-skill-version: $expectedVersion"
         }
 
         @Test

--- a/intellij/src/test/kotlin/ai/jolli/jollimemory/core/ActiveSessionAggregatorTest.kt
+++ b/intellij/src/test/kotlin/ai/jolli/jollimemory/core/ActiveSessionAggregatorTest.kt
@@ -16,6 +16,15 @@ class ActiveSessionAggregatorTest {
 	@TempDir
 	lateinit var tempDir: File
 
+	/**
+	 * Isolated home so source discoverers that scan the user's home directory
+	 * (Codex's `~/.codex/sessions`, Gemini, OpenCode, …) see an empty tree
+	 * instead of the real machine's sessions. Without this, a developer with a
+	 * recent Codex session would have it leak into every aggregator assertion.
+	 */
+	@TempDir
+	lateinit var homeDir: File
+
 	private val cwd get() = tempDir.absolutePath
 
 	private val HOUR = 3_600_000L
@@ -25,7 +34,6 @@ class ActiveSessionAggregatorTest {
 
 	@BeforeEach
 	fun setUp() {
-		File(tempDir, ".jolli/jollimemory").mkdirs()
 		// Hermetic isolation. The aggregator fans out to the Codex / Cursor / OpenCode
 		// discoverers, which scan machine-global session dirs derived from `user.home`
 		// (~/.codex/sessions, ~/Library/Application Support/Cursor, ~/.local/share/opencode)
@@ -36,7 +44,8 @@ class ActiveSessionAggregatorTest {
 		// this test registers. Mirrors CursorSupportTest / VscodeWorkspaceLocatorTest.
 		// (OpenCode also honors XDG_DATA_HOME; this assumes it is unset, as on CI.)
 		originalHome = System.getProperty("user.home")
-		System.setProperty("user.home", File(tempDir, "home").apply { mkdirs() }.absolutePath)
+		System.setProperty("user.home", homeDir.absolutePath)
+		File(tempDir, ".jolli/jollimemory").mkdirs()
 	}
 
 	@AfterEach

--- a/intellij/src/test/kotlin/ai/jolli/jollimemory/core/ActiveSessionAggregatorTest.kt
+++ b/intellij/src/test/kotlin/ai/jolli/jollimemory/core/ActiveSessionAggregatorTest.kt
@@ -3,6 +3,7 @@ package ai.jolli.jollimemory.core
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -20,9 +21,27 @@ class ActiveSessionAggregatorTest {
 	private val HOUR = 3_600_000L
 	private val DAY = 24 * HOUR
 
+	private var originalHome: String? = null
+
 	@BeforeEach
 	fun setUp() {
 		File(tempDir, ".jolli/jollimemory").mkdirs()
+		// Hermetic isolation. The aggregator fans out to the Codex / Cursor / OpenCode
+		// discoverers, which scan machine-global session dirs derived from `user.home`
+		// (~/.codex/sessions, ~/Library/Application Support/Cursor, ~/.local/share/opencode)
+		// — they ignore the `cwd` temp dir. Without this, real sessions on the developer's
+		// machine pollute the assertions (and opening the real SQLite DBs leaks JDBC
+		// threads onto the next test class). Point user.home at an empty temp dir so those
+		// sources find nothing; the assertions then see only the SessionTracker sessions
+		// this test registers. Mirrors CursorSupportTest / VscodeWorkspaceLocatorTest.
+		// (OpenCode also honors XDG_DATA_HOME; this assumes it is unset, as on CI.)
+		originalHome = System.getProperty("user.home")
+		System.setProperty("user.home", File(tempDir, "home").apply { mkdirs() }.absolutePath)
+	}
+
+	@AfterEach
+	fun tearDown() {
+		originalHome?.let { System.setProperty("user.home", it) } ?: System.clearProperty("user.home")
 	}
 
 	private fun iso(offsetMs: Long): String =

--- a/intellij/src/test/kotlin/ai/jolli/jollimemory/core/KBPathResolverTest.kt
+++ b/intellij/src/test/kotlin/ai/jolli/jollimemory/core/KBPathResolverTest.kt
@@ -215,5 +215,96 @@ class KBPathResolverTest {
             config.remoteUrl shouldBe null
             config.repoName shouldBe "localproject"
         }
+
+        @Test
+        fun `reuses a higher-numbered same-repo folder across an archived numbering hole`() {
+            // Archiving a folder leaves a numbering hole. base `repo` is a different
+            // repo, `repo-2` is the hole (absent), `repo-3` still holds our repo.
+            // resolve must reuse repo-3, not claim the repo-2 hole and spawn a duplicate.
+            createKBFolder("repo", "https://github.com/u/other.git")
+            val canonical = tempDir.resolve("repo-3")
+            KBPathResolver.initializeKBFolder(canonical, "repo", "https://github.com/u/canonical.git")
+
+            KBPathResolver.resolve(
+                "repo",
+                "https://github.com/u/canonical.git",
+                tempDir.toString(),
+            ) shouldBe canonical
+            // resolve must not have created the hole as a side effect.
+            Files.isDirectory(tempDir.resolve("repo-2")) shouldBe false
+        }
+
+        @Test
+        fun `claims the lowest free slot in the custom parent, not the global default`() {
+            // findAvailablePath must honor the custom parent (tempDir), not KB_PARENT.
+            createKBFolder("dup", "https://github.com/u/a.git")
+            val resolved = KBPathResolver.resolve(
+                "dup",
+                "https://github.com/u/b.git",
+                tempDir.toString(),
+            )
+            resolved shouldBe tempDir.resolve("dup-2")
+        }
+    }
+
+    // ── fold + archive (Migrate-to-Memory-Bank flow) ───────────────────────
+    @Nested
+    inner class FoldAndArchive {
+        @TempDir
+        lateinit var tempDir: Path
+
+        private fun seed(folderName: String, repoName: String, remoteUrl: String?): Path {
+            val kbRoot = tempDir.resolve(folderName)
+            KBPathResolver.initializeKBFolder(kbRoot, repoName, remoteUrl)
+            return kbRoot
+        }
+
+        @Test
+        fun `findRepoFolders returns all same-repo folders, skipping holes and other repos`() {
+            val remote = "https://github.com/u/canonical.git"
+            seed("repo", "repo", "https://github.com/u/other.git") // different repo → excluded
+            // repo-2 is a hole (absent) → skipped
+            seed("repo-3", "repo", remote)
+            seed("repo-4", "repo", remote)
+            seed("repo-5", "repo", "https://github.com/u/third.git") // different → excluded
+
+            val found = KBPathResolver.findRepoFolders("repo", remote, tempDir.toString())
+            found.toSet() shouldBe setOf(tempDir.resolve("repo-3"), tempDir.resolve("repo-4"))
+        }
+
+        @Test
+        fun `findRepoFolders includes the base folder when it matches`() {
+            val remote = "https://github.com/u/canonical.git"
+            seed("repo", "repo", remote)
+            seed("repo-2", "repo", remote)
+
+            val found = KBPathResolver.findRepoFolders("repo", remote, tempDir.toString())
+            found.toSet() shouldBe setOf(tempDir.resolve("repo"), tempDir.resolve("repo-2"))
+        }
+
+        @Test
+        fun `findFreshKBPath returns base when free, else the lowest hole`() {
+            KBPathResolver.findFreshKBPath("brand", tempDir.toString()) shouldBe tempDir.resolve("brand")
+            seed("brand", "brand", "https://github.com/u/a.git")
+            KBPathResolver.findFreshKBPath("brand", tempDir.toString()) shouldBe tempDir.resolve("brand-2")
+        }
+
+        @Test
+        fun `archiveKBFolder moves the folder into hidden jolli archive and removes the original`() {
+            val kbRoot = seed("repo-3", "repo", "https://github.com/u/a.git")
+
+            val dest = KBPathResolver.archiveKBFolder(kbRoot, tempDir.toString())
+
+            dest shouldNotBe null
+            Files.isDirectory(kbRoot) shouldBe false
+            Files.isDirectory(dest!!) shouldBe true
+            dest.toString() shouldContain tempDir.resolve(".jolli").resolve("archive").toString()
+            dest.fileName.toString().startsWith("repo-3-") shouldBe true
+        }
+
+        @Test
+        fun `archiveKBFolder returns null when the folder does not exist`() {
+            KBPathResolver.archiveKBFolder(tempDir.resolve("nope"), tempDir.toString()) shouldBe null
+        }
     }
 }

--- a/intellij/src/test/kotlin/ai/jolli/jollimemory/core/KBPathResolverTest.kt
+++ b/intellij/src/test/kotlin/ai/jolli/jollimemory/core/KBPathResolverTest.kt
@@ -235,6 +235,28 @@ class KBPathResolverTest {
         }
 
         @Test
+        fun `reuses a suffixed data folder when the base slot is free (post-Migrate)`() {
+            // After a Migrate archives the base `<repo>` and leaves the live data in
+            // `<repo>-2`, the base slot is free. resolve must reuse repo-2 rather than
+            // claiming a fresh empty base that shadows it. Mirrors the canonical TS
+            // resolveKBPath Case A fix.
+            val remote = "https://github.com/u/canonical.git"
+            val data = tempDir.resolve("repo-2")
+            KBPathResolver.initializeKBFolder(data, "repo", remote)
+
+            KBPathResolver.resolve("repo", remote, tempDir.toString()) shouldBe data
+            Files.isDirectory(tempDir.resolve("repo")) shouldBe false
+        }
+
+        @Test
+        fun `still returns the base when a free base slot has only a different-repo suffix`() {
+            val remote = "https://github.com/u/canonical.git"
+            KBPathResolver.initializeKBFolder(tempDir.resolve("repo-2"), "repo", "https://github.com/u/other.git")
+
+            KBPathResolver.resolve("repo", remote, tempDir.toString()) shouldBe tempDir.resolve("repo")
+        }
+
+        @Test
         fun `claims the lowest free slot in the custom parent, not the global default`() {
             // findAvailablePath must honor the custom parent (tempDir), not KB_PARENT.
             createKBFolder("dup", "https://github.com/u/a.git")

--- a/intellij/src/test/kotlin/ai/jolli/jollimemory/sync/StageVaultTest.kt
+++ b/intellij/src/test/kotlin/ai/jolli/jollimemory/sync/StageVaultTest.kt
@@ -160,7 +160,7 @@ class StageVaultTest {
 		Files.writeString(target, "{}")
 		val link = tempDir.resolve("my-repo/.jolli/index.json")
 		Files.createDirectories(link.parent)
-		Files.createSymbolicLink(link, target)
+		createSymbolicLinkOrSkip(link, target)
 
 		val report = stageVault(client, tempDir.toString(), StageVaultOpts(syncTranscripts = true))
 		assertEquals(0, report.added)

--- a/intellij/src/test/kotlin/ai/jolli/jollimemory/sync/SymlinkTestSupport.kt
+++ b/intellij/src/test/kotlin/ai/jolli/jollimemory/sync/SymlinkTestSupport.kt
@@ -1,0 +1,25 @@
+package ai.jolli.jollimemory.sync
+
+import org.junit.jupiter.api.Assumptions
+import java.io.IOException
+import java.nio.file.Files
+import java.nio.file.Path
+
+/**
+ * Creates a symbolic link for tests, aborting (skipping) the test instead of
+ * failing when the platform forbids symlink creation.
+ *
+ * On Windows, `Files.createSymbolicLink` requires the SeCreateSymbolicLinkPrivilege
+ * (administrator or Developer Mode); a normal user account throws
+ * `FileSystemException: A required privilege is not held by the client`. Such a
+ * machine simply cannot exercise the symlink-guard paths, so the correct outcome
+ * is a skipped test, not a failure.
+ */
+fun createSymbolicLinkOrSkip(link: Path, target: Path): Path =
+	try {
+		Files.createSymbolicLink(link, target)
+	} catch (e: IOException) {
+		Assumptions.abort<Path>("Skipping: cannot create symlinks on this platform (${e.message})")
+	} catch (e: UnsupportedOperationException) {
+		Assumptions.abort<Path>("Skipping: symlinks unsupported on this platform (${e.message})")
+	}

--- a/intellij/src/test/kotlin/ai/jolli/jollimemory/sync/SyncStatusBarWidgetTest.kt
+++ b/intellij/src/test/kotlin/ai/jolli/jollimemory/sync/SyncStatusBarWidgetTest.kt
@@ -1,0 +1,88 @@
+package ai.jolli.jollimemory.sync
+
+import com.intellij.openapi.project.Project
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Unit tests for the status-bar widget's render states, focused on
+ * [SyncStatusBarWidget.clearFailureStatus] — the fix for a terminal failure
+ * badge lingering on the status bar after sync stops with no round to clear it.
+ *
+ * The widget's `Project` is only touched by the click consumer, so a mock is
+ * enough to drive the pure state → text mapping. `statusBar` stays null
+ * (install() is never called), so `updateWidget` is a no-op.
+ */
+class SyncStatusBarWidgetTest {
+
+	private fun widget(): SyncStatusBarWidget = SyncStatusBarWidget(mockk<Project>(relaxed = true))
+
+	private fun failureDetail(code: SyncErrorCode = SyncErrorCode.PUSH_REJECTED) =
+		SyncStatusDetail(failed = true, failedCode = code, lastError = "boom")
+
+	@Test
+	fun `clearFailureStatus resets a terminal failure to neutral`() {
+		val w = widget()
+		w.setSyncState(SyncState.OFFLINE, failureDetail())
+		assertEquals("✗ Push rejected", w.getText())
+
+		val cleared = w.clearFailureStatus()
+
+		assertTrue(cleared)
+		assertEquals("Jolli Memory", w.getText())
+		assertEquals("Jolli Memory — click to open sidebar", w.getTooltipText())
+	}
+
+	@Test
+	fun `clearFailureStatus leaves a healthy SYNCED state untouched`() {
+		val w = widget()
+		w.setSyncState(SyncState.SYNCED)
+		assertEquals("✓ Jolli Memory", w.getText())
+
+		val cleared = w.clearFailureStatus()
+
+		assertFalse(cleared)
+		assertEquals("✓ Jolli Memory", w.getText())
+	}
+
+	@Test
+	fun `clearFailureStatus is a no-op for an already-neutral OFFLINE state`() {
+		val w = widget()
+		w.setSyncState(SyncState.OFFLINE, null)
+		assertEquals("Jolli Memory", w.getText())
+
+		val cleared = w.clearFailureStatus()
+
+		assertFalse(cleared)
+		assertEquals("Jolli Memory", w.getText())
+	}
+
+	@Test
+	fun `clearFailureStatus does not disturb CONFLICTS state`() {
+		val w = widget()
+		w.setSyncState(SyncState.CONFLICTS, SyncStatusDetail(conflictCount = 3))
+		assertEquals("⚠ 3 conflicts", w.getText())
+
+		val cleared = w.clearFailureStatus()
+
+		assertFalse(cleared)
+		assertEquals("⚠ 3 conflicts", w.getText())
+	}
+
+	// ── autoClearableSyncState ───────────────────────────────────────────
+
+	@Test
+	fun `finished states are auto-clearable`() {
+		assertTrue(autoClearableSyncState(SyncState.SYNCED))
+		assertTrue(autoClearableSyncState(SyncState.CONFLICTS))
+		assertTrue(autoClearableSyncState(SyncState.OFFLINE))
+	}
+
+	@Test
+	fun `in-progress SYNCING is never auto-cleared`() {
+		assertFalse(autoClearableSyncState(SyncState.SYNCING))
+	}
+}

--- a/intellij/src/test/kotlin/ai/jolli/jollimemory/sync/VaultSymlinkGuardTest.kt
+++ b/intellij/src/test/kotlin/ai/jolli/jollimemory/sync/VaultSymlinkGuardTest.kt
@@ -53,7 +53,7 @@ class VaultSymlinkGuardTest {
 		Files.createDirectories(realTarget)
 		// Create a symlink inside the vault pointing outside.
 		val link = vault.resolve("evil-link")
-		Files.createSymbolicLink(link, realTarget)
+		createSymbolicLinkOrSkip(link, realTarget)
 		assertThrows(IllegalStateException::class.java) {
 			assertNoSymlinksInPath(
 				vault.toString(),

--- a/vscode/src/Extension.test.ts
+++ b/vscode/src/Extension.test.ts
@@ -624,8 +624,9 @@ vi.mock("../../cli/src/core/SummaryStore.js", () => ({
 // and the rebuildKnowledgeBase command run with predictable, side-effect-free
 // stand-ins. Each test that exercises those paths overrides the relevant helper
 // via `vi.mocked(...).mockReturnValueOnce`.
-const { mockArchiveKBFolder } = vi.hoisted(() => ({
+const { mockArchiveKBFolder, mockFindRepoFolders } = vi.hoisted(() => ({
 	mockArchiveKBFolder: vi.fn(() => "/test/kb-parent/.jolli/archive/test-repo-123"),
+	mockFindRepoFolders: vi.fn(() => ["/test/kb"]),
 }));
 
 vi.mock("../../cli/src/core/KBPathResolver.js", () => ({
@@ -633,7 +634,7 @@ vi.mock("../../cli/src/core/KBPathResolver.js", () => ({
 	getRemoteUrl: vi.fn(() => null),
 	resolveKBPath: vi.fn(() => "/test/kb"),
 	resolveKbParent: vi.fn(() => "/test/kb-parent"),
-	peekKBPath: vi.fn(() => "/test/kb"),
+	findRepoFolders: mockFindRepoFolders,
 	findFreshKBPath: vi.fn(() => "/test/kb-2"),
 	initializeKBFolder: vi.fn(),
 	archiveKBFolder: mockArchiveKBFolder,
@@ -7299,6 +7300,8 @@ describe("Extension", () => {
 			mockArchiveKBFolder.mockReturnValue(
 				"/test/kb-parent/.jolli/archive/test-repo-123",
 			);
+			mockFindRepoFolders.mockReset();
+			mockFindRepoFolders.mockReturnValue(["/test/kb"]);
 		});
 
 		it("returns ok when rebuild migration completes", async () => {
@@ -7307,10 +7310,35 @@ describe("Extension", () => {
 			const result = (await handler()) as { ok: boolean; message: string };
 			expect(result.ok).toBe(true);
 			expect(result.message).toContain("memories migrated");
-			// Archive: the old folder (peekKBPath = "/test/kb") differs from the
-			// fresh one (findFreshKBPath = "/test/kb-2"), so it's MOVED into the
-			// hidden .jolli/archive/ rather than having its identity rewritten.
+			// Archive: every prior folder for this repo (findRepoFolders = ["/test/kb"])
+			// differs from the fresh one (findFreshKBPath = "/test/kb-2"), so it's MOVED
+			// into the hidden .jolli/archive/ rather than having its identity rewritten.
 			expect(mockArchiveKBFolder).toHaveBeenCalledWith("/test/kb", undefined);
+		});
+
+		it("folds a pile of duplicate folders in one Migrate (archives all but the fresh one)", async () => {
+			// Earlier buggy runs left several same-repo folders. findRepoFolders
+			// returns the whole pile; every one must be archived in a single click.
+			mockFindRepoFolders.mockReturnValueOnce(["/test/kb-3", "/test/kb-4", "/test/kb-5"]);
+			activate(makeContext());
+			const handler = getRegisteredCommand("jollimemory.rebuildKnowledgeBase");
+			const result = (await handler()) as { ok: boolean; message: string };
+			expect(result.ok).toBe(true);
+			expect(mockArchiveKBFolder).toHaveBeenCalledWith("/test/kb-3", undefined);
+			expect(mockArchiveKBFolder).toHaveBeenCalledWith("/test/kb-4", undefined);
+			expect(mockArchiveKBFolder).toHaveBeenCalledWith("/test/kb-5", undefined);
+			expect(mockArchiveKBFolder).toHaveBeenCalledTimes(3);
+		});
+
+		it("never archives the freshly-created folder even if it appears in the list", async () => {
+			// Defensive: findFreshKBPath = "/test/kb-2"; if it somehow shows up in the
+			// stale list it must be skipped (the `stale !== newKbRoot` guard).
+			mockFindRepoFolders.mockReturnValueOnce(["/test/kb", "/test/kb-2"]);
+			activate(makeContext());
+			const handler = getRegisteredCommand("jollimemory.rebuildKnowledgeBase");
+			await handler();
+			expect(mockArchiveKBFolder).toHaveBeenCalledWith("/test/kb", undefined);
+			expect(mockArchiveKBFolder).not.toHaveBeenCalledWith("/test/kb-2", undefined);
 		});
 
 		// Same successful-rebuild path, but with memoriesStore.hasFirstLoaded

--- a/vscode/src/Extension.test.ts
+++ b/vscode/src/Extension.test.ts
@@ -624,6 +624,10 @@ vi.mock("../../cli/src/core/SummaryStore.js", () => ({
 // and the rebuildKnowledgeBase command run with predictable, side-effect-free
 // stand-ins. Each test that exercises those paths overrides the relevant helper
 // via `vi.mocked(...).mockReturnValueOnce`.
+const { mockArchiveKBFolder } = vi.hoisted(() => ({
+	mockArchiveKBFolder: vi.fn(() => "/test/kb-parent/.jolli/archive/test-repo-123"),
+}));
+
 vi.mock("../../cli/src/core/KBPathResolver.js", () => ({
 	extractRepoName: vi.fn(() => "test-repo"),
 	getRemoteUrl: vi.fn(() => null),
@@ -632,6 +636,7 @@ vi.mock("../../cli/src/core/KBPathResolver.js", () => ({
 	peekKBPath: vi.fn(() => "/test/kb"),
 	findFreshKBPath: vi.fn(() => "/test/kb-2"),
 	initializeKBFolder: vi.fn(),
+	archiveKBFolder: mockArchiveKBFolder,
 }));
 
 const {
@@ -7290,6 +7295,10 @@ describe("Extension", () => {
 			mockMetadataManagerInstance.readConfig.mockReset();
 			mockMetadataManagerInstance.readConfig.mockReturnValue({});
 			mockMetadataManagerInstance.saveConfig.mockClear();
+			mockArchiveKBFolder.mockReset();
+			mockArchiveKBFolder.mockReturnValue(
+				"/test/kb-parent/.jolli/archive/test-repo-123",
+			);
 		});
 
 		it("returns ok when rebuild migration completes", async () => {
@@ -7298,8 +7307,10 @@ describe("Extension", () => {
 			const result = (await handler()) as { ok: boolean; message: string };
 			expect(result.ok).toBe(true);
 			expect(result.message).toContain("memories migrated");
-			// "Repoint": old KB identity is rewritten so resolveKBPath stops reusing it.
-			expect(mockMetadataManagerInstance.saveConfig).toHaveBeenCalled();
+			// Archive: the old folder (peekKBPath = "/test/kb") differs from the
+			// fresh one (findFreshKBPath = "/test/kb-2"), so it's MOVED into the
+			// hidden .jolli/archive/ rather than having its identity rewritten.
+			expect(mockArchiveKBFolder).toHaveBeenCalledWith("/test/kb", undefined);
 		});
 
 		// Same successful-rebuild path, but with memoriesStore.hasFirstLoaded
@@ -7339,10 +7350,10 @@ describe("Extension", () => {
 			expect(result.message).toContain("Rebuild partial");
 		});
 
-		it("warns but still completes when archiving the old KB identity throws", async () => {
-			mockMetadataManagerInstance.readConfig.mockImplementationOnce(() => {
-				throw new Error("read failed");
-			});
+		it("still completes when archiving the old folder fails (archiveKBFolder returns null)", async () => {
+			// archiveKBFolder swallows its own errors and returns null; the rebuild
+			// must still report success rather than aborting on a failed archive.
+			mockArchiveKBFolder.mockReturnValueOnce(null);
 			activate(makeContext());
 			const handler = getRegisteredCommand("jollimemory.rebuildKnowledgeBase");
 			const result = (await handler()) as { ok: boolean; message: string };

--- a/vscode/src/Extension.test.ts
+++ b/vscode/src/Extension.test.ts
@@ -635,7 +635,7 @@ vi.mock("../../cli/src/core/KBPathResolver.js", () => ({
 	resolveKBPath: vi.fn(() => "/test/kb"),
 	resolveKbParent: vi.fn(() => "/test/kb-parent"),
 	findRepoFolders: mockFindRepoFolders,
-	findFreshKBPath: vi.fn(() => "/test/kb-2"),
+	peekKBPath: vi.fn(() => "/test/kb"),
 	initializeKBFolder: vi.fn(),
 	archiveKBFolder: mockArchiveKBFolder,
 }));
@@ -7310,10 +7310,12 @@ describe("Extension", () => {
 			const result = (await handler()) as { ok: boolean; message: string };
 			expect(result.ok).toBe(true);
 			expect(result.message).toContain("memories migrated");
-			// Archive: every prior folder for this repo (findRepoFolders = ["/test/kb"])
-			// differs from the fresh one (findFreshKBPath = "/test/kb-2"), so it's MOVED
-			// into the hidden .jolli/archive/ rather than having its identity rewritten.
+			// Archive-first: every prior folder for this repo (findRepoFolders =
+			// ["/test/kb"]) is MOVED into the hidden .jolli/archive/ BEFORE migrating,
+			// freeing the base slot so migration lands back on the base name
+			// (peekKBPath = "/test/kb") rather than climbing to "/test/kb-N".
 			expect(mockArchiveKBFolder).toHaveBeenCalledWith("/test/kb", undefined);
+			expect(result.message).toContain("/test/kb");
 		});
 
 		it("folds a pile of duplicate folders in one Migrate (archives all but the fresh one)", async () => {
@@ -7330,15 +7332,19 @@ describe("Extension", () => {
 			expect(mockArchiveKBFolder).toHaveBeenCalledTimes(3);
 		});
 
-		it("never archives the freshly-created folder even if it appears in the list", async () => {
-			// Defensive: findFreshKBPath = "/test/kb-2"; if it somehow shows up in the
-			// stale list it must be skipped (the `stale !== newKbRoot` guard).
+		it("archives the whole pile — base slot included — then migrates back into the base name", async () => {
+			// Consolidation: every folder that held this repo, base `/test/kb`
+			// included, is archived FIRST so migration lands back on the canonical
+			// base name (peekKBPath = "/test/kb") instead of climbing to a `-N`.
 			mockFindRepoFolders.mockReturnValueOnce(["/test/kb", "/test/kb-2"]);
 			activate(makeContext());
 			const handler = getRegisteredCommand("jollimemory.rebuildKnowledgeBase");
-			await handler();
+			const result = (await handler()) as { ok: boolean; message: string };
+			expect(result.ok).toBe(true);
 			expect(mockArchiveKBFolder).toHaveBeenCalledWith("/test/kb", undefined);
-			expect(mockArchiveKBFolder).not.toHaveBeenCalledWith("/test/kb-2", undefined);
+			expect(mockArchiveKBFolder).toHaveBeenCalledWith("/test/kb-2", undefined);
+			expect(mockArchiveKBFolder).toHaveBeenCalledTimes(2);
+			expect(result.message).toContain("memories migrated to /test/kb");
 		});
 
 		// Same successful-rebuild path, but with memoriesStore.hasFirstLoaded

--- a/vscode/src/Extension.ts
+++ b/vscode/src/Extension.ts
@@ -1637,6 +1637,7 @@ export function activate(context: vscode.ExtensionContext): void {
 						initializeKBFolder,
 						peekKBPath,
 						findFreshKBPath,
+						archiveKBFolder,
 					} = await import("../../cli/src/core/KBPathResolver.js");
 					const { MetadataManager } = await import(
 						"../../cli/src/core/MetadataManager.js"
@@ -1681,24 +1682,15 @@ export function activate(context: vscode.ExtensionContext): void {
 					const engine = new MigrationEngine(orphan, folder, newMm);
 					const result = await engine.runMigration();
 
-					// "Repoint": rewrite the old folder's identity so resolveKBPath()
-					// no longer reuses it. Content files are untouched.
+					// Archive the old folder by MOVING it into the hidden, per-Memory-
+					// Bank `.jolli/archive/` dir — not by rewriting its identity in
+					// place. The old identity-rewrite left the folder visible in both
+					// IDE folder views and still tracked by the vault git (so it kept
+					// syncing). `archiveKBFolder` relocates it where both explorers
+					// hide it (leading-dot dir) and the sync classifier treats it as
+					// unowned, while keeping it recoverable inside the Memory Bank.
 					if (oldKbRoot !== newKbRoot) {
-						try {
-							const oldMm = new MetadataManager(join(oldKbRoot, ".jolli"));
-							const oldCfg = oldMm.readConfig();
-							oldMm.saveConfig({
-								...oldCfg,
-								remoteUrl: undefined,
-								repoName: `${repoName}-archived-${Date.now()}`,
-							});
-						} catch (err) {
-							log.warn(
-								"rebuildKnowledgeBase",
-								`failed to archive old KB identity at ${oldKbRoot}`,
-								err,
-							);
-						}
+						archiveKBFolder(oldKbRoot, customKBPath);
 					}
 
 					// Rebuild's new folder lives under the SAME Memory Bank parent

--- a/vscode/src/Extension.ts
+++ b/vscode/src/Extension.ts
@@ -1635,7 +1635,7 @@ export function activate(context: vscode.ExtensionContext): void {
 						extractRepoName,
 						getRemoteUrl,
 						initializeKBFolder,
-						peekKBPath,
+						findRepoFolders,
 						findFreshKBPath,
 						archiveKBFolder,
 					} = await import("../../cli/src/core/KBPathResolver.js");
@@ -1667,12 +1667,14 @@ export function activate(context: vscode.ExtensionContext): void {
 						};
 					}
 
-					// Use the read-only `peekKBPath` for the "where would my old
-					// folder be?" lookup — `resolveKBPath` would *claim* basePath
-					// as a side effect on a pristine system, fooling the
-					// `oldKbRoot !== newKbRoot` archive gate into archiving a
-					// folder we just created (and writing data to `-2` instead).
-					const oldKbRoot = peekKBPath(repoName, remoteUrl, customKBPath);
+					// Enumerate EVERY folder that currently holds this repo BEFORE
+					// creating the fresh one. Earlier buggy runs (archive gate defeated
+					// by a numbering hole) could leave a pile of duplicates — `<repo>-3`,
+					// `-4`, `-5`, … all sharing one identity. Capturing them up front
+					// lets one Migrate fold the whole pile, instead of clearing one
+					// folder per click. The fresh folder doesn't exist yet, so it can
+					// never appear in this list.
+					const staleFolders = findRepoFolders(repoName, remoteUrl, customKBPath);
 					const newKbRoot = findFreshKBPath(repoName, customKBPath);
 					initializeKBFolder(newKbRoot, repoName, remoteUrl);
 
@@ -1682,15 +1684,21 @@ export function activate(context: vscode.ExtensionContext): void {
 					const engine = new MigrationEngine(orphan, folder, newMm);
 					const result = await engine.runMigration();
 
-					// Archive the old folder by MOVING it into the hidden, per-Memory-
-					// Bank `.jolli/archive/` dir — not by rewriting its identity in
-					// place. The old identity-rewrite left the folder visible in both
-					// IDE folder views and still tracked by the vault git (so it kept
-					// syncing). `archiveKBFolder` relocates it where both explorers
-					// hide it (leading-dot dir) and the sync classifier treats it as
-					// unowned, while keeping it recoverable inside the Memory Bank.
-					if (oldKbRoot !== newKbRoot) {
-						archiveKBFolder(oldKbRoot, customKBPath);
+					// Archive every prior folder for this repo by MOVING it into the
+					// hidden, per-Memory-Bank `.jolli/archive/` dir — not by rewriting
+					// its identity in place. The old identity-rewrite left folders
+					// visible in both IDE folder views and still tracked by the vault
+					// git (so they kept syncing). `archiveKBFolder` relocates them where
+					// both explorers hide them (leading-dot dir) and the sync classifier
+					// treats them as unowned, while keeping them recoverable inside the
+					// Memory Bank. Folding the whole pile to a single live folder also
+					// lets the sync layer self-heal `repos.json`: with one folder per
+					// identity, `resolveOrAssignFolder` repoints any stale row to the
+					// live folder on the next round (multi-folder identities are skipped
+					// by `reconcileMappingAdditive` precisely to avoid a mapping↔disk
+					// split, so we must NOT write `repos.json` from here).
+					for (const stale of staleFolders) {
+						if (stale !== newKbRoot) archiveKBFolder(stale, customKBPath);
 					}
 
 					// Rebuild's new folder lives under the SAME Memory Bank parent

--- a/vscode/src/Extension.ts
+++ b/vscode/src/Extension.ts
@@ -1636,7 +1636,7 @@ export function activate(context: vscode.ExtensionContext): void {
 						getRemoteUrl,
 						initializeKBFolder,
 						findRepoFolders,
-						findFreshKBPath,
+						peekKBPath,
 						archiveKBFolder,
 					} = await import("../../cli/src/core/KBPathResolver.js");
 					const { MetadataManager } = await import(
@@ -1667,15 +1667,39 @@ export function activate(context: vscode.ExtensionContext): void {
 						};
 					}
 
-					// Enumerate EVERY folder that currently holds this repo BEFORE
-					// creating the fresh one. Earlier buggy runs (archive gate defeated
-					// by a numbering hole) could leave a pile of duplicates — `<repo>-3`,
-					// `-4`, `-5`, … all sharing one identity. Capturing them up front
-					// lets one Migrate fold the whole pile, instead of clearing one
-					// folder per click. The fresh folder doesn't exist yet, so it can
-					// never appear in this list.
+					// Enumerate EVERY folder that currently holds this repo, then
+					// archive the whole pile FIRST — the canonical base `<repo>` slot
+					// included. Earlier buggy runs (archive gate defeated by a numbering
+					// hole) could leave a pile of duplicates — `<repo>`, `-3`, `-4`, … all
+					// sharing one identity. Archiving up front frees the base slot so the
+					// migration below lands back on the canonical base name instead of
+					// climbing to an ever-higher `<repo>-N` (the user-visible "I keep
+					// getting jolliai-2, -3 …" symptom). Safe to archive before migrating:
+					// the migration SOURCE is the orphan branch (the system of record),
+					// not these folders, so a crash mid-migrate self-heals on the next
+					// activation, which re-migrates from the orphan branch into the now
+					// free base slot.
+					//
+					// `archiveKBFolder` MOVES each folder into the hidden, per-Memory-Bank
+					// `.jolli/archive/` dir rather than rewriting its identity in place.
+					// The old identity-rewrite left folders visible in both IDE folder
+					// views and still tracked by the vault git (so they kept syncing);
+					// the archive dir is hidden (leading-dot) and unowned by the sync
+					// classifier. Folding the whole pile to a single live folder also lets
+					// the sync layer self-heal `repos.json`: with one folder per identity,
+					// `resolveOrAssignFolder` repoints any stale row to the live folder on
+					// the next round (multi-folder identities are skipped by
+					// `reconcileMappingAdditive` precisely to avoid a mapping↔disk split,
+					// so we must NOT write `repos.json` from here).
 					const staleFolders = findRepoFolders(repoName, remoteUrl, customKBPath);
-					const newKbRoot = findFreshKBPath(repoName, customKBPath);
+					for (const stale of staleFolders) {
+						archiveKBFolder(stale, customKBPath);
+					}
+
+					// With the pile archived, the base slot is free again; `peekKBPath`
+					// resolves to it (falling back to a fresh `-N` only if some folder
+					// for this repo survived archiving). Claim it and migrate into it.
+					const newKbRoot = peekKBPath(repoName, remoteUrl, customKBPath);
 					initializeKBFolder(newKbRoot, repoName, remoteUrl);
 
 					const newMm = new MetadataManager(join(newKbRoot, ".jolli"));
@@ -1684,32 +1708,16 @@ export function activate(context: vscode.ExtensionContext): void {
 					const engine = new MigrationEngine(orphan, folder, newMm);
 					const result = await engine.runMigration();
 
-					// Archive every prior folder for this repo by MOVING it into the
-					// hidden, per-Memory-Bank `.jolli/archive/` dir — not by rewriting
-					// its identity in place. The old identity-rewrite left folders
-					// visible in both IDE folder views and still tracked by the vault
-					// git (so they kept syncing). `archiveKBFolder` relocates them where
-					// both explorers hide them (leading-dot dir) and the sync classifier
-					// treats them as unowned, while keeping them recoverable inside the
-					// Memory Bank. Folding the whole pile to a single live folder also
-					// lets the sync layer self-heal `repos.json`: with one folder per
-					// identity, `resolveOrAssignFolder` repoints any stale row to the
-					// live folder on the next round (multi-folder identities are skipped
-					// by `reconcileMappingAdditive` precisely to avoid a mapping↔disk
-					// split, so we must NOT write `repos.json` from here).
-					for (const stale of staleFolders) {
-						if (stale !== newKbRoot) archiveKBFolder(stale, customKBPath);
-					}
-
 					// Rebuild's new folder lives under the SAME Memory Bank parent
-					// as the previous one (e.g. <localFolder>/<repo>-2/), so
+					// as the previous one (the canonical <localFolder>/<repo>/ slot,
+					// re-created after the prior pile was archived), so
 					// refreshSidebarKbRoot would return moved=false and the KB tree
 					// would still point at the archived directory until a window
-					// reload. The per-repo kbRoot changed, even though the parent
-					// did not — refresh + cache-invalidate unconditionally after a
-					// successful rebuild so the tree picks up the new folder and
-					// the multi-repo Memories aggregate drops entries discovered
-					// against the now-archived identity.
+					// reload. The folder's contents were replaced even though its
+					// path did not change — refresh + cache-invalidate unconditionally
+					// after a successful rebuild so the tree picks up the rebuilt
+					// folder and the multi-repo Memories aggregate drops entries
+					// discovered against the now-archived identities.
 					await refreshSidebarKbRoot();
 					sidebarProvider.refreshKnowledgeBaseFolders();
 					bridge.invalidateEntriesCache();


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## Quick recap

The IntelliJ plugin's status bar now clears stale sync badges automatically. Any finished sync result — whether a failure, a success, or a conflict warning — fades back to a neutral resting state three seconds after it appears. When sync is explicitly stopped through sign-out or a disabled auto-sync setting, a lingering failure badge clears immediately without waiting for the timer. The status bar widget, the KB explorer toolbar panel, and the plugin's internal sync state all revert together, so every part of the UI stays consistent.

Duplicate Memory Bank folders no longer accumulate after migrations or rebuilds. Previously, each rebuild left the old folder visible in both IDE explorers and continued uploading its contents to the server, while each migration climbed to a higher-numbered folder name rather than settling back on the canonical project name. Old folders are now physically relocated into a hidden archive directory inside the Memory Bank before any new folder is created, freeing the original name for reuse. The archive directory is hidden from both IDE explorers and excluded from server sync, so users will not encounter it in normal use. After running migration once more, users will see a single cleanly named Memory Bank folder with no numbered suffixes or empty duplicates.

The IntelliJ test suite was hardened against two sources of environment-dependent failures. Tests that verify symlink-guard behavior now skip automatically on Windows machines where the operating system denies symlink creation to unprivileged users, rather than reporting a hard failure. The session aggregator tests were also made fully hermetic: each test run now operates against an isolated, empty home directory, preventing AI tool sessions active on a developer's own machine from leaking into test assertions and producing results that varied from one workstation to another.

---

## E2E Test (2)
<details>
<summary><strong>1. Symlink test skips gracefully on restricted Windows machines</strong></summary>
<br>
<blockquote>

**Preconditions:** A Windows machine where the test runner does not have administrator rights and Developer Mode is not enabled (i.e. a standard user account that cannot create symbolic links).

**Steps:**
1. Open the project in IntelliJ IDEA on the restricted Windows machine.
2. Open the test panel and run the full test suite (or run just the sync-related tests).
3. Wait for the test run to finish completely.
4. Look at the results for any tests with "symlink" or "vault" in their name.
5. Check whether those tests are marked as skipped (shown in yellow or with a "skipped" label) rather than failed (shown in red).
6. Confirm that the overall test run does not report a failure count caused by those symlink tests.

**Expected Results:**
- The symlink-related tests should appear as skipped, not failed.
- The test suite should show a green or passing status overall, with the skipped tests listed separately.
- No error message about "privilege not held" or similar should cause the run to be marked broken.

</blockquote>
</details>
<details>
<summary><strong>2. Aggregator test results are not affected by real sessions on the developer's machine</strong></summary>
<br>
<blockquote>

**Preconditions:** A developer machine that has at least one real AI tool session present (for example, a recent Codex or Gemini session stored in the home directory).

**Steps:**
1. Open the project in IntelliJ IDEA on the developer machine.
2. Open the test panel and run the aggregator-related tests (look for tests with "ActiveSession" or "Aggregator" in their name).
3. Wait for the test run to finish.
4. Check whether all aggregator tests pass consistently.
5. Run the same tests a second time without changing anything, and check the results again.

**Expected Results:**
- All aggregator tests should pass on both runs, showing the same results each time.
- No test should fail or produce unexpected counts because of real session files sitting in the home directory.
- The results should be identical regardless of how many real AI tool sessions exist on the machine.

</blockquote>
</details>

---

## Topics (4)
<details>
<summary><strong>01 · Sync failure badge auto-dismisses after three seconds in IntelliJ</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The IntelliJ plugin's status bar would permanently display a "Sync Failed" message even when no sync was actively running, leaving users staring at a stale error badge for up to 90 minutes or indefinitely after signing out.

**💡 Decisions Behind the Code**

- **Service-level timer over widget-level timer**: The auto-clear logic was placed in the service rather than the widget so that the status bar, the KB explorer toolbar panel, and the cached state returned by the sync-state accessor all revert to neutral at the same moment. A widget-only timer would have left the panel and the cache showing stale failure state, creating inconsistencies visible to other parts of the UI.
- **Generation counter guard**: A simple boolean "is a timer pending" flag would have been a race condition — a new sync round starting inside the 3-second window could set a healthy state that the expiring timer then overwrites. The atomic generation counter makes each scheduled clear uniquely tied to the state change that spawned it, so any newer state change invalidates the pending clear as a no-op and preserves the fresh result.
- **Gating the stop-sync clear on "was a failure"**: The start-sync path calls stop-sync first as a restart dance. Clearing unconditionally on every stop would briefly wipe a healthy success badge during that restart. Gating on the failure condition means only stale red badges are removed, and a healthy checkmark survives the restart cycle intact.

**✅ What Was Implemented**

- Added `STATUS_AUTO_CLEAR_DELAY_MS` (3 seconds) and `autoClearableSyncState()` to `SyncStatusDetail.kt`. The helper returns true for every completed state — success, failure, and conflicts — and false only for the in-progress syncing state, which is always replaced by its own result.
- Wired auto-dismissal into `JolliMemoryService.kt` via a new `scheduleStatusAutoClear()` method. On every state change, a generation counter is incremented and a 3-second delayed task is scheduled; if a newer state arrives before the timer fires, the task detects the generation mismatch and skips the reset. The status bar widget, the service's cached state, and all registered panel listeners are reset together so every UI surface stays consistent.
- Added `clearFailureStatus()` to `SyncStatusBarWidget.kt`, which resets the widget to neutral only when it is currently showing a terminal failure, leaving healthy or already-neutral states untouched. This method is also called from `stopSync()` so a stale failure clears immediately when sync is disabled or the user signs out, without waiting for the timer.

**📋 Future Enhancements**

The root cause of the recurring 401 authentication failure (the backend rejecting the saved token) was not fixed. A follow-up was discussed: showing a more specific "Sign-in expired" message with a re-authentication prompt instead of the generic "Sync failed" label for credential mint failures.

**📁 FILES**
- `intellij/src/main/kotlin/ai/jolli/jollimemory/sync/SyncStatusDetail.kt`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/services/JolliMemoryService.kt`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/sync/SyncStatusBarWidget.kt`

</blockquote>
</details>
<details>
<summary><strong>02 · Duplicate Memory Bank folders eliminated after migration and rebuild</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Users running the Memory Bank migration tool repeatedly saw multiple folders for the same project accumulate over time — an empty base folder alongside numbered variants holding the actual data — and each rebuild left behind additional visible duplicates that continued uploading to the server.

**💡 Decisions Behind the Code**

- **Move the folder rather than rewriting its identity**: The previous approach changed only a config file inside the old folder, leaving the directory itself in the active Memory Bank area. This meant both IDE explorers kept showing it and the vault's git tracker kept uploading its contents to the server. A filesystem move simultaneously removes the folder from views, stops it syncing, and frees its name for reuse in one atomic operation.
- **Archive before migrating, not after**: The original flow migrated into a new numbered folder first, then archived the old ones — which meant the base slot was never freed and the active folder kept climbing to higher numbers. Archiving the whole pile first is safe because the migration reads from the git orphan branch (the authoritative data source), not from the folders being archived. A crash mid-migration self-heals on the next activation, with the trade-off of a brief window where no visible folder exists.
- **Place the archive inside the Memory Bank's own hidden dot-directory**: Putting archives at `<Memory Bank root>/.jolli/archive/` keeps them co-located with the data they belong to, so they travel together if the user moves their Memory Bank folder. A leading-dot directory is automatically hidden by both IDE explorers and rejected by the sync classifier, so no additional filtering rules are needed. A machine-level location would mix archives from different Memory Banks and break if the user changes their Memory Bank path.
- **Keep the archive as a safety net rather than deleting outright**: The orphan branch is the authoritative source of truth and can regenerate content, but a physical copy in the archive directory gives a fast, offline fallback if something goes wrong mid-rebuild. Deleting immediately would save disk space but remove the ability to inspect or recover the previous state without a network round-trip.
- **Consolidate to the base name rather than staying on a numbered variant**: Two approaches were considered — fix only the empty-base regeneration bug (leaving the active folder on a numbered name), or also change migration to land back on the plain base name. The second approach was chosen for the user-visible benefit of a single, cleanly named folder, at the cost of a slightly larger change touching both IDEs.

**✅ What Was Implemented**

- Added `archiveKBFolder()` to `cli/src/core/KBPathResolver.ts`, which physically moves an old repo folder into `<Memory Bank root>/.jolli/archive/<name>-<timestamp>/` using a filesystem rename. The function creates the archive directory if needed, guards against same-millisecond collisions with a counter suffix, swallows move failures gracefully (returning null), and logs both success and failure paths.
- Fixed the folder resolution logic in both the VS Code (TypeScript) and IntelliJ (Kotlin) plugins so that when the base folder slot is free, the resolver first scans numbered variants for an existing folder belonging to the same project before claiming a fresh empty base. This prevents the empty base from reappearing on every activation. Changes span `resolveKBPath`, `peekKBPath` in `cli/src/core/KBPathResolver.ts`, and a new `findSameRepoSuffix` helper in `intellij/src/main/kotlin/ai/jolli/jollimemory/core/KBPathResolver.kt`.
- Changed the migration flow in both IDEs to archive the entire pile of stale folders — including the base folder — before migrating, rather than migrating first and archiving afterward. This frees the base slot so the migration always lands back on the canonical base name. Changes in `vscode/src/Extension.ts` and `intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/SettingsDialog.kt`.
- Updated the rebuild command handler in `vscode/src/Extension.ts` to call `archiveKBFolder()` in place of the previous identity-rewrite block, which had only modified config fields while leaving the folder in place, still visible and still syncing.
- Added and updated tests across all three test suites to cover the new resolution and archival behaviors.

**📋 Future Enhancements**

Mirror `archiveKBFolder` in the IntelliJ Kotlin port (`KBPathResolver.kt`) to keep both IDE plugins in lockstep — both resolve folders in the same Memory Bank and must agree on where archives live.

**📁 FILES**
- `cli/src/core/KBPathResolver.ts`
- `vscode/src/Extension.ts`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/core/KBPathResolver.kt`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/SettingsDialog.kt`

</blockquote>
</details>
<details>
<summary><strong>03 · IntelliJ symlink-guard tests skip gracefully on restricted Windows machines</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

On Windows machines without administrator rights or Developer Mode enabled, tests that create symbolic links were throwing hard failures instead of being skipped, making the test suite appear broken on those machines even though the underlying feature was untestable there by design.

**💡 Decisions Behind the Code**

- **Skip over fail for missing privileges**: Marking the test as skipped rather than failed distinguishes "this machine cannot exercise this path" from "the code is broken." A hard failure on a restricted Windows machine produces false negatives in CI and blocks developers who have no way to grant themselves the required privilege, while a skip preserves the signal that the test exists and runs correctly where the platform allows it.
- **Shared utility rather than per-test try/catch**: Centralizing the symlink-creation guard in a single helper keeps the intent visible and consistent across all tests that need it. Duplicating the try/catch in each test would risk divergent error handling and make it harder to update the policy later.

**✅ What Was Implemented**

- Added `SymlinkTestSupport.kt`, a new shared test utility that wraps symbolic link creation and calls JUnit's abort mechanism on either `IOException` or `UnsupportedOperationException`, causing the test to be marked as skipped rather than failed when the platform denies symlink creation.
- Updated `StageVaultTest.kt` and `VaultSymlinkGuardTest.kt` to replace direct symlink creation calls with the new `createSymbolicLinkOrSkip` helper, so both symlink-guard test paths now skip cleanly on restricted Windows environments.

**📁 FILES**
- `intellij/src/test/kotlin/ai/jolli/jollimemory/sync/SymlinkTestSupport.kt`
- `intellij/src/test/kotlin/ai/jolli/jollimemory/sync/StageVaultTest.kt`
- `intellij/src/test/kotlin/ai/jolli/jollimemory/sync/VaultSymlinkGuardTest.kt`

</blockquote>
</details>
<details>
<summary><strong>04 · Active session aggregator tests isolated from real machine session data</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The session aggregator test suite was scanning the actual home directory of whoever ran the tests, meaning a developer with active AI tool sessions on their own machine would have those sessions leak into test assertions, causing flaky or incorrect results depending on the local environment.

**💡 Decisions Behind the Code**

Redirecting the home directory system property at test setup time was chosen over mocking individual discoverers or injecting a home-path parameter into the aggregator. Overriding the property exercises the full real code path — including all discoverers — without requiring any changes to production code, and JUnit's temp directory lifecycle guarantees the isolated home is always empty and cleaned up automatically. Restoring the exact original value in teardown (rather than clearing it entirely) keeps the test self-contained regardless of the surrounding environment, since clearing it would leave the JVM in a different state than it started and could affect other tests running in the same process.

**✅ What Was Implemented**

- In `ActiveSessionAggregatorTest.kt`, added `@BeforeEach` / `@AfterEach` hooks (and a `@TempDir`-annotated `homeDir` field) that redirect the home directory system property to a freshly created empty temp folder before each test and restore the original value afterward. This prevents all three global session discoverers (Codex, Cursor, OpenCode) from finding any real sessions on disk, so each test sees only the sessions it explicitly registers.
- A code comment documents the one remaining gap: the OpenCode discoverer also reads an environment variable that cannot be overridden via system properties, and the fix assumes that variable is unset (which holds on CI and the team's current machines).

**📋 Future Enhancements**

If the OpenCode environment variable (`XDG_DATA_HOME`) is ever set on a developer's machine or CI runner, the isolation will be incomplete. Full protection would require either a JVM test extension that can manipulate environment variables or a product-side injectable root path for the OpenCode discoverer.

**📁 FILES**
- `intellij/src/test/kotlin/ai/jolli/jollimemory/core/ActiveSessionAggregatorTest.kt`

</blockquote>
</details>

---

*Generated by Jolli Memory · June 15, 2026 at 2:20 PM · via Anthropic*
<!-- jollimemory-summary-end -->